### PR TITLE
Add eager market-cache warmer for prediction markets

### DIFF
--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -74,6 +74,11 @@ jobs:
               test_target: "//finance/augur/frontend:image_build_test",
             }
           - {
+              image: "//finance/augur/calibration:warm_market_cache_image",
+              image_name: augur-market-warmer,
+              test_target: "//finance/augur/calibration/...",
+            }
+          - {
               image: "//homeassistant/proxy:image",
               image_name: homeassistant-proxy,
               test_target: "//homeassistant/proxy/...",

--- a/finance/augur/calibration/BUILD.bazel
+++ b/finance/augur/calibration/BUILD.bazel
@@ -1,4 +1,7 @@
+load("@aspect_rules_py//py:defs.bzl", "py_image_layer", aspect_py_binary = "py_binary")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
 load("//devinfra/python:defs.bzl", "py_binary", "py_library", "py_test")
+load("//props:oci.bzl", "py_image_entrypoint", "py_image_env")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -144,6 +147,19 @@ py_library(
 )
 
 py_library(
+    name = "warm_cache",
+    srcs = ["warm_cache.py"],
+    deps = [
+        ":catalog",
+        ":default_clients",
+        ":platform",
+        ":redis_cache",
+        "@pypi//httpx",
+        "@pypi//polymarket_client",
+    ],
+)
+
+py_library(
     name = "macro_anchors",
     srcs = ["macro_anchors.py"],
     deps = [
@@ -186,6 +202,46 @@ py_binary(
         "//finance/augur/model:series",
         "@pypi//tabulate",
     ],
+)
+
+py_binary(
+    name = "warm_market_cache",
+    main_module = "finance.augur.calibration.warm_cache",
+    deps = [":warm_cache"],
+)
+
+# Lean warmer image for the eager-prefetch CronJob: only the catalog + price clients (httpx /
+# valkey / polymarket SDK), none of the serving image's JAX / simulator / FastAPI stack.
+aspect_py_binary(
+    name = "warm_market_cache_image_bin",
+    main = "warm_cache.py",
+    deps = [":warm_cache"],
+)
+
+py_image_layer(
+    name = "warm_market_cache_layers",
+    binary = ":warm_market_cache_image_bin",
+    group = "1000",
+    owner = "1000",
+)
+
+oci_image(
+    name = "warm_market_cache_image",
+    base = "@debian_trixie_slim_linux_amd64",
+    entrypoint = py_image_entrypoint("warm_market_cache_image_bin"),
+    env = py_image_env(binary_name = "warm_market_cache_image_bin"),
+    labels = {
+        "org.opencontainers.image.source": "https://github.com/agentydragon/ducktape",
+        "org.opencontainers.image.title": "augur-market-warmer",
+    },
+    tars = [":warm_market_cache_layers"],
+    user = "1000:1000",
+)
+
+oci_load(
+    name = "warm_market_cache_image_load",
+    image = ":warm_market_cache_image",
+    repo_tags = ["augur-market-warmer:dev"],
 )
 
 py_test(
@@ -312,6 +368,22 @@ py_test(
         ":testing",
         "//:conftest",
         "//finance/augur/model:private_equity_risk",
+        "@pypi//pytest",
+        "@pypi//pytest_asyncio",
+        "@pypi//pytest_bazel",
+    ],
+)
+
+py_test(
+    name = "test_warm_cache",
+    srcs = ["test_warm_cache.py"],
+    deps = [
+        ":catalog",
+        ":platform",
+        ":quote",
+        ":warm_cache",
+        "//:conftest",
+        "@pypi//httpx",
         "@pypi//pytest",
         "@pypi//pytest_asyncio",
         "@pypi//pytest_bazel",

--- a/finance/augur/calibration/calibration.py
+++ b/finance/augur/calibration/calibration.py
@@ -952,23 +952,7 @@ async def run_calibration(
 
     # Every (platform, market_id) the catalog references, deduped (one market can back several rows),
     # fetched concurrently once; the row builders below read from this resolved map.
-    needed: set[tuple[Platform, str]] = set()
-    needed.update((market.platform, market.market_id) for market in catalog.exact_markets())
-    needed.update((market.platform, market.market_id) for market in catalog.surfaced_markets())
-    needed.update(
-        (family.platform, bucket.market_id) for family in catalog.bucket_families for bucket in family.buckets
-    )
-    needed.update(
-        (family.platform, threshold.market_id)
-        for family in catalog.threshold_ladder_families
-        for threshold in family.thresholds
-    )
-    needed.update(
-        (family.platform, date_member.market_id)
-        for family in catalog.date_ladder_families
-        for date_member in family.dates
-    )
-    keys = list(needed)
+    keys = list(catalog.referenced_markets())
     fetched = await asyncio.gather(*(_live(market_id, platform) for platform, market_id in keys))
     live_markets: dict[tuple[Platform, str], Market | None] = dict(zip(keys, fetched, strict=True))
 

--- a/finance/augur/calibration/catalog.py
+++ b/finance/augur/calibration/catalog.py
@@ -417,6 +417,26 @@ class MarketCatalog(BaseModel):
         """Markets shown with their price + reason but never scored (correlate / unmappable)."""
         return [market for market in self.markets if not isinstance(market, ExactMarket)]
 
+    def referenced_markets(self) -> set[tuple[Platform, str]]:
+        """Every `(platform, market_id)` the catalog references, deduped.
+
+        One platform market can back several catalog rows (an exact market and a correlate of it,
+        a bucket and a ladder rung), so this is the deduped set every consumer fetches exactly
+        once: `run_calibration` to score the live price, the cache warmer to pre-populate the
+        shared snapshot cache out of band.
+        """
+        refs: set[tuple[Platform, str]] = {(market.platform, market.market_id) for market in self.markets}
+        refs.update((family.platform, bucket.market_id) for family in self.bucket_families for bucket in family.buckets)
+        refs.update(
+            (family.platform, threshold.market_id)
+            for family in self.threshold_ladder_families
+            for threshold in family.thresholds
+        )
+        refs.update(
+            (family.platform, member.market_id) for family in self.date_ladder_families for member in family.dates
+        )
+        return refs
+
     def referenced_level_series(self) -> set[str]:
         """Wire ids of every level series any macro market / bucket family scores against."""
         series = {str(family.series) for family in self.bucket_families}

--- a/finance/augur/calibration/test_catalog.py
+++ b/finance/augur/calibration/test_catalog.py
@@ -53,6 +53,58 @@ def test_partitions_dispatch_on_variant(catalog: MarketCatalog) -> None:
     assert exact.mapping == IpoByDateMapping(issuer="openai", by_date=date(2027, 1, 1))
 
 
+def test_referenced_markets_unions_and_dedupes() -> None:
+    """`referenced_markets` collects every (platform, market_id) across markets + all family rungs,
+    deduping an id that backs more than one row (here "AAA" is both an exact and a correlate)."""
+    catalog = MarketCatalog.model_validate(
+        {
+            "metadata": {"as_of": "2026-05-29"},
+            "markets": [
+                {
+                    "manifold_id": "AAA",
+                    "mappability": "exact",
+                    "mapping": {"kind": "ipo_by_date", "issuer": "openai", "by_date": "2027-01-01"},
+                },
+                {"manifold_id": "AAA", "mappability": "correlate", "correlate_of": "ipo_by_date"},
+                {"platform": "polymarket", "polymarket_id": "0xpoly", "mappability": "unmappable", "reason": "n/a"},
+            ],
+            "bucket_families": [
+                {
+                    "family_id": "spx",
+                    "question": "S&P bucket",
+                    "platform": "kalshi",
+                    "series": "sp500",
+                    "at_date": "2027-01-01",
+                    "buckets": [
+                        {"market_id": "K-LO", "label": "lo", "high": 6000},
+                        {"market_id": "K-HI", "label": "hi", "low": 6000},
+                    ],
+                }
+            ],
+            "date_ladder_families": [
+                {
+                    "family_id": "ipo",
+                    "question": "OpenAI IPO timing",
+                    "platform": "manifold",
+                    "issuer": "openai",
+                    "dates": [
+                        {"market_id": "D1", "by_date": "2027-01-01"},
+                        {"market_id": "D2", "by_date": "2027-06-01"},
+                    ],
+                }
+            ],
+        }
+    )
+    assert catalog.referenced_markets() == {
+        (Platform.MANIFOLD, "AAA"),
+        (Platform.POLYMARKET, "0xpoly"),
+        (Platform.KALSHI, "K-LO"),
+        (Platform.KALSHI, "K-HI"),
+        (Platform.MANIFOLD, "D1"),
+        (Platform.MANIFOLD, "D2"),
+    }
+
+
 def test_exact_requires_mapping_fields() -> None:
     """The EXACT variant cannot be constructed without a typed `mapping`."""
     with pytest.raises(ValidationError):

--- a/finance/augur/calibration/test_warm_cache.py
+++ b/finance/augur/calibration/test_warm_cache.py
@@ -1,0 +1,80 @@
+"""Tests for the eager market-cache warmer (`warm_cache`)."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import httpx
+import pytest
+import pytest_bazel
+
+from finance.augur.calibration.catalog import CorrelateMarket, ExactMarket, IpoByDateMapping, ManifoldRef, MarketCatalog
+from finance.augur.calibration.platform import Market, Platform
+from finance.augur.calibration.quote import BookQuote
+from finance.augur.calibration.warm_cache import WarmSummary, _run, warm_market_cache
+
+
+class _RecordingClient:
+    """A `PriceClient` recording every fetched id; chosen ids raise an httpx error to model a flap."""
+
+    def __init__(self, *, fail_ids: frozenset[str] = frozenset()) -> None:
+        self.calls: list[str] = []
+        self._fail_ids = fail_ids
+
+    async def get_market(self, market_id: str) -> Market:
+        self.calls.append(market_id)
+        if market_id in self._fail_ids:
+            raise httpx.ConnectError("boom")
+        return Market(
+            id=market_id,
+            url=f"https://test.example/{market_id}",
+            quote=BookQuote(bid=0.5, ask=0.5, bid_size=None, ask_size=None, last_trade=0.5),
+        )
+
+    async def aclose(self) -> None:
+        pass
+
+
+def _catalog() -> MarketCatalog:
+    """Two distinct Manifold markets, where one id ("AAA") backs both an exact and a correlate row."""
+    return MarketCatalog(
+        metadata={"as_of": "2026-05-29"},
+        markets=[
+            ExactMarket(
+                platform_ref=ManifoldRef(manifold_id="AAA"),
+                mapping=IpoByDateMapping(issuer="openai", by_date=date(2027, 1, 1)),
+            ),
+            CorrelateMarket(platform_ref=ManifoldRef(manifold_id="AAA"), correlate_of="ipo_by_date"),
+            CorrelateMarket(platform_ref=ManifoldRef(manifold_id="BBB"), correlate_of="ipo_by_date"),
+        ],
+    )
+
+
+async def test_warms_each_referenced_market_once() -> None:
+    """A market backing several catalog rows is fetched once; every fetch populates the cache."""
+    client = _RecordingClient()
+    summary = await warm_market_cache(_catalog(), {Platform.MANIFOLD: client})
+    assert sorted(client.calls) == ["AAA", "BBB"]
+    assert summary == WarmSummary(requested=2, succeeded=2, failed=0)
+
+
+async def test_failing_market_is_counted_not_raised() -> None:
+    """A flapping upstream skips just that market — the pass continues and reports it failed."""
+    client = _RecordingClient(fail_ids=frozenset({"BBB"}))
+    summary = await warm_market_cache(_catalog(), {Platform.MANIFOLD: client})
+    assert summary == WarmSummary(requested=2, succeeded=1, failed=1)
+    assert sorted(client.calls) == ["AAA", "BBB"]
+
+
+async def test_run_requires_cache_url(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The CLI refuses to warm a process-local cache (no AUGUR_MARKET_CACHE_URL): those snapshots
+    would die with the pod and serve nobody. The guard fires before any catalog read or network."""
+    monkeypatch.delenv("AUGUR_MARKET_CACHE_URL", raising=False)
+    monkeypatch.delenv("AUGUR_CACHE_URL", raising=False)
+    with pytest.raises(RuntimeError, match="AUGUR_MARKET_CACHE_URL"):
+        await _run(["--catalog", str(tmp_path / "missing.yaml")])
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/finance/augur/calibration/warm_cache.py
+++ b/finance/augur/calibration/warm_cache.py
@@ -1,0 +1,109 @@
+"""Eagerly warm the shared prediction-market snapshot cache.
+
+`run_calibration` fetches every catalog market lazily on each request; the shared Valkey
+read-through cache (`default_clients` + `redis_cache`) then absorbs repeats for the TTL window.
+This module pre-populates that cache out of band so the first calibration request after a
+snapshot goes stale is a cache hit instead of paying the upstream fetch (and its flakiness —
+Kalshi in particular flaps 503s). A CronJob runs `warm-market-cache --catalog <catalog.yaml>`
+more often than the TTL so the cache never goes cold.
+
+It deliberately depends only on the catalog + the price clients — never on `api.config` or any
+model provider — so the warmer image stays free of the JAX / simulator / FastAPI stack the
+serving image carries. The CronJob points it straight at the `prediction_markets.yaml` already
+mounted in the `augur-config` ConfigMap.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+import httpx
+from polymarket.errors import PolymarketError
+
+from finance.augur.calibration.catalog import MarketCatalog
+from finance.augur.calibration.default_clients import default_price_clients
+from finance.augur.calibration.platform import Platform, PriceClient
+from finance.augur.calibration.redis_cache import market_cache_config_from_env
+
+logger = logging.getLogger(__name__)
+
+# Per-market failures we tolerate by skipping that market instead of aborting the whole warm pass:
+# httpx for the manifold + kalshi clients, PolymarketError for the polymarket SDK. Mirrors
+# `calibration._LIVE_FETCH_ERRORS` (a bad id / flapping upstream is expected, not a warmer bug).
+_WARM_FETCH_ERRORS: tuple[type[BaseException], ...] = (httpx.HTTPError, PolymarketError)
+
+# Match `calibration._MAX_CONCURRENT_MARKET_FETCHES`: cap concurrent upstream connections so a
+# large catalog on a cold cache can't open hundreds at once (and trip rate limits).
+_WARM_CONCURRENCY = 16
+
+
+@dataclass(frozen=True)
+class WarmSummary:
+    requested: int
+    succeeded: int
+    failed: int
+
+
+async def warm_market_cache(
+    catalog: MarketCatalog, price_clients: Mapping[Platform, PriceClient], *, concurrency: int = _WARM_CONCURRENCY
+) -> WarmSummary:
+    """Fetch every catalog market through `price_clients`, populating the read-through cache.
+
+    Each `get_market` call writes a fresh snapshot to the shared store as a side effect. Per-market
+    fetch failures are logged and counted, never raised — one broken id or a single flapping upstream
+    must not abort the pass — so the returned counts let the caller log + pick an exit status.
+    """
+    refs = sorted(catalog.referenced_markets())
+    slots = asyncio.Semaphore(concurrency)
+
+    async def _warm_one(platform: Platform, market_id: str) -> bool:
+        async with slots:
+            try:
+                await price_clients[platform].get_market(market_id)
+            except _WARM_FETCH_ERRORS:
+                logger.warning("failed to warm %s market %r", platform.value, market_id, exc_info=True)
+                return False
+        return True
+
+    results = await asyncio.gather(*(_warm_one(platform, market_id) for platform, market_id in refs))
+    succeeded = sum(results)
+    return WarmSummary(requested=len(refs), succeeded=succeeded, failed=len(refs) - succeeded)
+
+
+async def _run(argv: list[str] | None) -> int:
+    parser = argparse.ArgumentParser(description="Eagerly warm the prediction-market snapshot cache.")
+    parser.add_argument("--catalog", type=Path, required=True, help="Path to the prediction-market catalog YAML.")
+    args = parser.parse_args(argv)
+
+    # Warming is pointless without the shared cache: otherwise `default_price_clients` builds
+    # process-local TTL clients whose snapshots die with this CronJob pod. Fail fast instead.
+    if market_cache_config_from_env() is None:
+        raise RuntimeError(
+            "AUGUR_MARKET_CACHE_URL (or AUGUR_CACHE_URL) must be set: warming a process-local cache "
+            "that dies with this process serves nobody."
+        )
+
+    catalog = MarketCatalog.from_yaml(args.catalog)
+    async with default_price_clients() as price_clients:
+        summary = await warm_market_cache(catalog, price_clients)
+    logger.info(
+        "warmed market cache: %d/%d markets succeeded, %d failed", summary.succeeded, summary.requested, summary.failed
+    )
+    # Exit nonzero only when nothing succeeded (cache unreachable / every upstream down) so the
+    # CronJob surfaces a hard outage; a few flapping markets still leave the pass green.
+    return 0 if summary.succeeded > 0 or summary.requested == 0 else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+    return asyncio.run(_run(argv))
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Adds a new cache-warming service that eagerly pre-populates the shared prediction-market snapshot cache out of band, ensuring the first calibration request after a snapshot goes stale is a cache hit rather than paying the upstream fetch cost.

## Key Changes
- **New `warm_cache` module** (`warm_cache.py`): Implements `warm_market_cache()` async function that fetches every catalog market through price clients, populating the read-through cache. Tolerates per-market failures (flapping upstreams, bad IDs) without aborting the entire pass, using a semaphore to cap concurrent connections at 16 to avoid rate limits.

- **CLI entry point**: `_run()` and `main()` functions provide a command-line interface (`warm-market-cache --catalog <catalog.yaml>`) that validates a shared cache is configured (fails fast if only process-local cache available) and reports success/failure counts.

- **Lean warmer image**: New OCI image target (`warm_market_cache_image`) containing only the catalog + price clients (httpx, Valkey, polymarket SDK), deliberately excluding the serving image's JAX/simulator/FastAPI stack to keep the warmer lightweight.

- **Catalog refactoring**: Extracted `referenced_markets()` method in `MarketCatalog` to deduplicate and collect all `(platform, market_id)` tuples across exact markets, surfaced markets, bucket families, threshold ladders, and date ladders. This is now used by both the warmer and `run_calibration`.

- **Test coverage**: Comprehensive tests for the warmer including deduplication of markets backing multiple catalog rows, graceful handling of per-market fetch failures, and validation that a shared cache URL is required.

- **CI integration**: Added warmer image to the push-images workflow for automated builds.

## Implementation Details
- The warmer mirrors `calibration._LIVE_FETCH_ERRORS` and `_MAX_CONCURRENT_MARKET_FETCHES` to handle the same error types and concurrency constraints as the live calibration path.
- Designed to run as a Kubernetes CronJob more frequently than the cache TTL to keep snapshots fresh.
- Returns exit code 0 if any markets succeeded (or catalog is empty), nonzero only when nothing succeeded, allowing the CronJob to surface hard outages while tolerating transient flaps.

https://claude.ai/code/session_014y7uziwRNSBRmzjVcJyobh