### PR TITLE
Add Forgejo site admin group via OIDC

### DIFF
--- a/cluster/README.md
+++ b/cluster/README.md
@@ -62,7 +62,7 @@ HTTPRoutes):
 | Service        | URL                                | Purpose                       |
 | -------------- | ---------------------------------- | ----------------------------- |
 | Authentik      | <https://auth.allegedly.works>     | SSO provider                  |
-| Forgejo        | <https://git.allegedly.works>      | Git hosting (suspended)       |
+| Forgejo        | <https://git.allegedly.works>      | Git hosting                   |
 | Harbor         | <https://registry.allegedly.works> | Container registry            |
 | Matrix/Element | <https://chat.allegedly.works>     | Chat                          |
 | Grafana        | <https://grafana.allegedly.works>  | Monitoring                    |

--- a/cluster/k8s/forgejo/app/helmrelease.yaml
+++ b/cluster/k8s/forgejo/app/helmrelease.yaml
@@ -70,6 +70,13 @@ spec:
           autoDiscoverUrl: "https://auth.allegedly.works/application/o/forgejo/.well-known/openid-configuration"
           iconUrl: "https://auth.allegedly.works/static/dist/assets/icons/icon.png"
           scopes: "email profile"
+          # Map the Authentik `groups` claim (emitted by the default `profile`
+          # scope mapping) to Forgejo site-admin: members of the `forgejo-admins`
+          # Authentik group (tf/gitops/sso-providers/main.tf) are promoted to admin
+          # on OIDC login, non-members demoted. The built-in local admin account is
+          # unaffected (not an OAuth2 user). Takes effect on the user's next login.
+          groupClaimName: "groups"
+          adminGroup: "forgejo-admins"
 
       config:
         APP_NAME: "Forgejo: Beyond coding. We forge."

--- a/tf/gitops/sso-providers/main.tf
+++ b/tf/gitops/sso-providers/main.tf
@@ -100,6 +100,15 @@ resource "authentik_group" "grafana_admins" {
   users = [tonumber(authentik_user.agentydragon.id)]
 }
 
+# Forgejo site admins. The Forgejo OIDC source
+# (cluster/k8s/forgejo/app/helmrelease.yaml) maps this group's name -- carried in
+# the `groups` claim emitted by the default `profile` scope mapping -- to Forgejo
+# site-admin on login. Keep the name in sync with `adminGroup` there.
+resource "authentik_group" "forgejo_admins" {
+  name  = "forgejo-admins"
+  users = [tonumber(authentik_user.agentydragon.id)]
+}
+
 resource "authentik_group" "study_casino" {
   name = "study-casino"
   users = [

--- a/tf/gitops/sso-providers/provider_forgejo.tf
+++ b/tf/gitops/sso-providers/provider_forgejo.tf
@@ -1,5 +1,5 @@
 # ============================================================================
-# Forgejo — OIDC login for the git server (suspended)
+# Forgejo — OIDC login for the git server
 # ============================================================================
 
 resource "authentik_provider_oauth2" "forgejo" {


### PR DESCRIPTION
## Summary
Configure Authentik and Forgejo to map an OIDC group claim to Forgejo site admin privileges, allowing centralized admin management through Authentik group membership.

## Changes
- **Authentik**: Created `forgejo_admins` group in SSO provider configuration with `agentydragon` as initial member
- **Forgejo**: Enabled OIDC group claim mapping by configuring `groupClaimName: "groups"` and `adminGroup: "forgejo-admins"` in the Authentik OIDC source

## Implementation Details
- The `forgejo-admins` Authentik group name is synchronized between both configurations (Terraform and Helm values)
- Group membership is carried in the `groups` claim from Authentik's default `profile` scope mapping
- Admin status is applied on user login; non-members are demoted, while the built-in local admin account remains unaffected
- Changes take effect on the user's next OIDC login

https://claude.ai/code/session_01NYzAqrWXJRJwdN1VheUXUH