### PR TITLE
cluster docs: stale-claim fixes + dedup/consolidation pass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,8 @@ The MCP server uses a client certificate (CN=`claude-code-web`, group
 
 - **claude-sandbox namespace**: full CRUD on pods, pods/log, pods/exec, pods/attach,
   services, configmaps, secrets, PVCs, events, deployments, statefulsets, daemonsets,
-  replicasets, jobs, cronjobs (<role-sandbox.yaml>). Quota: 8 CPU, 16Gi memory, 20 pods.
+  replicasets, jobs, cronjobs (<role-sandbox.yaml>); resource-quota-limited (see
+  <cluster/k8s/agents/claude-rbac/README.md>).
 - **Cluster-wide read** (`cluster-diagnostics-reader` ClusterRole): nodes, pods,
   deployments, Flux kustomizations (+ patch for reconcile triggers), HelmReleases,
   cert-manager, CNPG clusters, metrics, Longhorn, Gateway API, Kyverno, and more.

--- a/cluster/AGENTS.md
+++ b/cluster/AGENTS.md
@@ -124,22 +124,12 @@ See <docs/container-images.md> for build/push/tag guide and Flux image automatio
 
 ## Agent RBAC Architecture
 
-Agent RBAC is split into three independent layers so that missing/suspended service
-namespaces don't block unrelated RBAC from applying.
-
-**`claude-rbac`** (lightweight base): Sandbox namespace + ClusterRoles only. Depends on
-`kyverno-policies`. Must never depend on service or database kustomizations.
-
-**`shared-rbac`**: Cluster-scoped ClusterRoleBindings + `flux-system` RoleBinding only.
-Depends on `claude-rbac`.
-
-**`<service>/agent-rbac/`**: Per-service namespace-scoped RoleBindings. Each is its own
-Flux kustomization depending on `[service namespace kustomization]` + `claude-rbac`.
-Service namespaces have zero coupling to agent infrastructure.
-
 When adding agent read access to a new service namespace, create a new `agent-rbac/`
-directory — don't add RoleBindings to `claude-rbac` or `shared-rbac`. See
-<k8s/agents/claude-rbac/README.md> for the full convention.
+directory — never add RoleBindings to `claude-rbac` or `shared-rbac`. The full
+three-layer split, permission scopes, and the sandbox quota live once in the claude-rbac
+README, transcluded here:
+
+@k8s/agents/claude-rbac/README.md
 
 ## Flux Kustomization Layering
 

--- a/cluster/AGENTS.md
+++ b/cluster/AGENTS.md
@@ -92,7 +92,7 @@ In `terraform/main/`:
 | `proxmox-nodes.tf`         | Proxmox VM definitions                         |
 | `talos-machine-secrets.tf` | Machine secrets (ephemeral)                    |
 | `cilium.tf`                | CNI configuration                              |
-| `main.tf`                  | Providers, firewall, Talos bootstrap           |
+| `infrastructure.tf`        | Firewall, Talos bootstrap, registry mirrors    |
 | `persistent-auth.tf`       | Keypairs, tokens (`prevent_destroy` lifecycle) |
 | `nebula.tf`                | Per-node Nebula config + endpoint drift check  |
 

--- a/cluster/README.md
+++ b/cluster/README.md
@@ -36,14 +36,14 @@ See <docs/bootstrap.md> for full setup.
 
 ### Node Types
 
-| Node                                               | Type             | Region    | Availability     | Hardware            |
-| -------------------------------------------------- | ---------------- | --------- | ---------------- | ------------------- |
-| `talos-kimsufi-cp-0`                               | Talos CP         | `hil`     | Always on        | OVH Kimsufi KS-5    |
-| `talos-kimsufi-worker-0`, `talos-kimsufi-worker-1` | Talos CP         | `hil`     | Always on        | OVH Kimsufi KS-5    |
-| `talos-ks-game-worker-0`, `talos-ks-game-worker-1` | Talos worker     | `hil`     | Always on        | OVH KS-GAME         |
-| `wyrm2`                                            | NixOS GPU worker | `proxmox` | Always on (home) | 2x RTX 5090         |
-| `iguana`                                           | NixOS laptop     | `roaming` | Often offline    | ThinkPad X1 Extreme |
-| `rugged`                                           | NixOS laptop     | `roaming` | Often offline    | Dell Rugged 12      |
+| Node                           | Type             | Region    | Availability     | Hardware            |
+| ------------------------------ | ---------------- | --------- | ---------------- | ------------------- |
+| `ovh-ns102453`                 | Talos CP         | `hil`     | Always on        | OVH Kimsufi KS-5    |
+| `ovh-ns103656`, `ovh-ns103711` | Talos CP         | `hil`     | Always on        | OVH Kimsufi KS-5    |
+| `ovh-ns104952`, `ovh-ns104963` | Talos worker     | `hil`     | Always on        | OVH KS-GAME         |
+| `wyrm2`                        | NixOS GPU worker | `proxmox` | Always on (home) | 2x RTX 5090         |
+| `iguana`                       | NixOS laptop     | `roaming` | Often offline    | ThinkPad X1 Extreme |
+| `rugged`                       | NixOS laptop     | `roaming` | Often offline    | Dell Rugged 12      |
 
 Region labels are `topology.kubernetes.io/region`. Roaming nodes are laptops that
 join/leave the cluster frequently. `rugged` has taint
@@ -87,7 +87,7 @@ All storage is region-local — no cross-site synchronous replication.
 | `local-path-proxmox` | local-path-provisioner | `proxmox` | Matrix, ActivityWatch, Scanner, OpenClaw, Google Workspace MCP, Tana MCP |
 | `local-path-ovh`     | local-path-provisioner | `hil-ovh` | SeaweedFS volume servers, attic-db (CNPG OVH-HA)                         |
 | `lvm-proxmox-ssd`    | OpenEBS LVM CSI        | `proxmox` | NVMe thin provisioning: Firecracker                                      |
-| `lvm-proxmox-hdd`    | OpenEBS LVM CSI        | `proxmox` | HDD thin provisioning: Harbor, Langfuse, Docker CI, Grocy                |
+| `lvm-proxmox-hdd`    | OpenEBS LVM CSI        | `proxmox` | HDD thin provisioning: Harbor, Docker CI, Grocy                          |
 | `proxmox-csi-retain` | Proxmox CSI            | `proxmox` | Block storage via Proxmox API: Ollama, Devbot (migrating off)            |
 | `longhorn`           | Longhorn               | `hil`     | Legacy — orphaned PVCs only, no active workloads                         |
 
@@ -147,7 +147,7 @@ No built-in auth; Nebula mesh membership is the trust boundary.
 
 - **Server**: `aw-server-rust` on Proxmox, SQLite on `local-path-proxmox` (1Gi PVC)
 - **Sidecar**: Nebula container joins the mesh (`10.42.0.40`, cert name `activitywatch`)
-- **Image**: `ghcr.io/agentydragon/aw-server`, pushed via BuildBuddy Workflows (`buildbuddy.yaml`)
+- **Image**: `ghcr.io/agentydragon/aw-server`, built with Bazel (`//third_party/activitywatch:image`) and pushed by the `push-images.yml` GHA matrix
 - **Certs**: SOPS secret (`k8s/activitywatch/nebula-certs.sops.yaml`)
 - **Read-only proxy**: nginx sidecar on port 5601 (Service `activitywatch-readonly`),
   allows GET + POST `/api/0/query` only. `openclaw-sandbox` and `claude-sandbox` namespaces

--- a/cluster/docs/bootstrap.md
+++ b/cluster/docs/bootstrap.md
@@ -65,7 +65,7 @@ The bootstrap script executes a multi-phase deployment against a single TF root
 kubectl get nodes -o wide              # All nodes Ready
 flux get all                           # Flux status
 kubectl get pods -A | grep -v Running  # Non-running pods
-kubectl get storageclass               # longhorn (default), proxmox-csi-retain, etc.
+kubectl get storageclass               # local-path-ovh, local-path-proxmox, seaweedfs-ovh, proxmox-csi-retain (no default class)
 ```
 
 ## Dependency Chain
@@ -80,7 +80,7 @@ Two always-present ClusterIssuers (`letsencrypt-prod`, `letsencrypt-staging`).
 A single ConfigMap controls which is active:
 
 ```yaml
-# k8s/cert-manager-issuer-config/configmap.yaml
+# k8s/cert-manager/issuer-config/configmap.yaml
 data:
   LETSENCRYPT_ISSUER: letsencrypt-prod # or letsencrypt-staging
 ```

--- a/cluster/docs/bootstrap_dependencies.md
+++ b/cluster/docs/bootstrap_dependencies.md
@@ -311,12 +311,9 @@ re-enter from the external service and SOPS-encrypt.
 
 ### Lost cluster age key
 
-1. Generate: `age-keygen -o /dev/stdout`
-2. SOPS-encrypt private key to `secrets/shared/cluster-secrets-age.yaml`
-3. Update `.sops.yaml` with new public key
-4. Re-encrypt all `k8s/**/*.sops.yaml`: `for f in $(find cluster/k8s -name '*.sops.yaml'); do sops updatekeys "$f"; done`
-5. `tofu apply` to deploy new k8s secret
-6. Commit + push; Flux picks up re-encrypted secrets
+Regenerate and redeploy per <secrets.md> § "Rotating the Cluster Age Key". The
+key is also SOPS-backed in `secrets/shared/cluster-secrets-age.yaml`, so it
+survives tofu-state loss.
 
 ### Lost single app credential
 

--- a/cluster/docs/bootstrap_dependencies.md
+++ b/cluster/docs/bootstrap_dependencies.md
@@ -79,14 +79,12 @@ to `secrets/nebula/ca.crt`, encrypt key to `secrets/nebula/ca.sops.key`.
 Then regenerate all node certs (L2) and update all NixOS worker nebula
 files (L7).
 
-**If `secrets/shared/cluster-secrets-age.yaml` is lost**: Generate new age key with
-`age-keygen`, SOPS-encrypt, commit. Update `.sops.yaml` with new public key.
-Re-encrypt all `k8s/**/*.sops.yaml` files with `sops updatekeys`. Redeploy
-the k8s secret via `tofu apply`.
+**If `secrets/shared/cluster-secrets-age.yaml` is lost**: regenerate and redeploy per
+<secrets.md> § "Rotating the Cluster Age Key".
 
 **If `secrets/shared/flux-deploy-key.yaml` is lost**: Generate new ED25519 key with
 `ssh-keygen -t ed25519`, SOPS-encrypt, commit. Register public key in
-GitHub → repo settings �� deploy keys. Redeploy via `tofu apply`.
+GitHub → repo settings → deploy keys. Redeploy via `tofu apply`.
 
 **If `secrets/shared/cluster-tokens.yaml` is lost**: Re-enter the Proxmox token
 (Proxmox UI -> API Tokens), SOPS-encrypt to `secrets/shared/cluster-tokens.yaml`,
@@ -97,7 +95,7 @@ re-entered separately if account archaeology needs it.
 `https://api.us.ovhcloud.com/createToken/` (GET/PUT/POST/DELETE on `/dedicated/server/*`),
 SOPS-encrypt to `secrets/ovh-credentials.sops.yaml`, commit.
 
-**If a `k8s/**/\*.sops.yaml` app credential is lost\*\*: Re-enter the credential
+**If a `k8s/**/\*.sops.yaml` app credential is lost\*\*: re-enter the credential
 from the external service (see [App Credentials](#app-credentials) below),
 SOPS-encrypt, commit, push. Flux picks it up automatically.
 

--- a/cluster/docs/dns_automation.md
+++ b/cluster/docs/dns_automation.md
@@ -37,7 +37,7 @@ or removing gateway nodes.
 ### IAM User: `cluster-dns-manager`
 
 Dedicated user with Route 53 policy. Credentials in SOPS-encrypted secrets
-(see table above). IAM policy documented in <docs/iam-policy-route53.json>.
+(see table above). IAM policy documented in <iam-policy-route53.json>.
 
 ## Verification
 

--- a/cluster/docs/dns_automation.md
+++ b/cluster/docs/dns_automation.md
@@ -29,7 +29,7 @@ or removing gateway nodes.
 
 | File                                                     | Purpose                              |
 | -------------------------------------------------------- | ------------------------------------ |
-| `terraform/gitops/dns-records/main.tf`                   | Route 53 records + domain delegation |
+| `tf/gitops/dns-records/main.tf`                          | Route 53 records + domain delegation |
 | `k8s/dns-automation/dns-records-tf.yaml`                 | tofu-controller Terraform resource   |
 | `k8s/dns-automation/aws-credentials.sops.yaml`           | AWS IAM credentials (SOPS)           |
 | `k8s/cert-manager/config/base/aws-credentials.sops.yaml` | AWS creds for cert-manager (SOPS)    |
@@ -56,5 +56,5 @@ kubectl get certificate -A
 ## Updating Gateway Node IPs
 
 When adding or removing gateway nodes, update the IP locals in
-`terraform/gitops/dns-records/main.tf`. Commit and push; tofu-controller applies
+`tf/gitops/dns-records/main.tf`. Commit and push; tofu-controller applies
 automatically.

--- a/cluster/docs/harbor_pullthrough.md
+++ b/cluster/docs/harbor_pullthrough.md
@@ -5,10 +5,10 @@ avoiding rate limits and speeding up image pulls.
 
 ## How It Works
 
-1. **Talos registry mirrors** in `terraform/main/talos.tf` redirect containerd
+1. **Talos registry mirrors** in `terraform/main/infrastructure.tf` redirect containerd
    image pulls through Harbor proxy cache projects, with upstream as fallback.
 2. **Harbor proxy cache projects** (public, anonymous pull) are created by tofu-controller
-   via `terraform/gitops/harbor-proxy-cache/`. Each project maps to an upstream registry endpoint.
+   via `tf/gitops/harbor-proxy-cache/`. Each project maps to an upstream registry endpoint.
 3. **Fallback ensures turnkey bootstrap** — first boot pulls from upstream (Harbor doesn't exist yet),
    subsequent pulls use cache automatically.
 

--- a/cluster/docs/harbor_sso.md
+++ b/cluster/docs/harbor_sso.md
@@ -16,7 +16,7 @@
 Uses the [goharbor/harbor Terraform provider](https://registry.terraform.io/providers/goharbor/harbor/latest/docs)
 via tofu-controller.
 
-**Location**: `terraform/gitops/sso/harbor/`
+**Location**: `tf/gitops/sso/harbor-config/`
 
 The `harbor_config_auth` resource configures OIDC with Authentik (auto-onboard, group mapping).
 Follows the same pattern as the other SSO providers in `tf/gitops/sso-providers/`.

--- a/cluster/docs/kubevirt_nixos_vm.md
+++ b/cluster/docs/kubevirt_nixos_vm.md
@@ -1,11 +1,11 @@
 # KubeVirt NixOS VM Runbook
 
-KubeVirt and CDI are installed from <k8s/kubevirt/>. The paved end-to-end flow
+KubeVirt and CDI are installed from <../k8s/kubevirt/>. The paved end-to-end flow
 for a new NixOS VM is:
 
 1. Publish the bootstrap qcow2 to SeaweedFS — `cluster/k8s/vm-images-publisher/`.
 2. Define the VM under `cluster/k8s/<name>/` with a CDI `DataVolume` sourcing
-   that qcow2 — see <k8s/gecko/> as the canonical example.
+   that qcow2 — see <../k8s/gecko/> as the canonical example.
 3. Boot, SSH in with a key in `nix/nixos/hosts/bootstrap/default.nix`, then
    `nixos-rebuild switch --flake github:agentydragon/ducktape?ref=devel#<name>`
    to take on a real host config.
@@ -19,13 +19,13 @@ kubectl create job --from=cronjob/vm-images-publisher \
   "publish-$(date +%s)" -n vm-images-publisher
 ```
 
-See <k8s/vm-images-publisher/README.md> for environment overrides (publish a
+See <../k8s/vm-images-publisher/README.md> for environment overrides (publish a
 non-default ref, alternate flake output, etc.). The resulting object key is
 `bootstrap/<commit-sha>.qcow2`.
 
 ## Wiring A VM
 
-Crib from <k8s/gecko/>:
+Crib from <../k8s/gecko/>:
 
 - `namespace/` — dedicated namespace.
 - `app/vm-images-s3-reader.yaml` — `ExternalSecret` pulling `cdiReader*` keys
@@ -62,7 +62,7 @@ Cilium 1.19's Gateway API controller does not implement `TCPRoute`, so a
 `protocol: TCP` listener on `cluster-gateway` never gets a corresponding
 Envoy listener. The workaround is a hand-written `CiliumEnvoyConfig` that
 declares the listener directly on the `cilium-envoy` DaemonSet. See
-<k8s/gecko/app/ciliumenvoyconfig.yaml>: it binds `0.0.0.0:22` on every hil
+<../k8s/gecko/app/ciliumenvoyconfig.yaml>: it binds `0.0.0.0:22` on every hil
 node (hostNetwork) with a `tcp_proxy` filter pointing at the gecko-ssh
 Service. Wildcard `*.allegedly.works` already resolves to those node IPs,
 so `ssh agentydragon@gecko.allegedly.works` works for any key in

--- a/cluster/docs/kubevirt_vm_image_artifacts.md
+++ b/cluster/docs/kubevirt_vm_image_artifacts.md
@@ -44,7 +44,7 @@ kubectl create job --from=cronjob/vm-images-publisher \
   "publish-$(date +%s)" -n vm-images-publisher
 ```
 
-See <k8s/vm-images-publisher/README.md> for the runbook. Object keys are
+See <../k8s/vm-images-publisher/README.md> for the runbook. Object keys are
 commit-addressed (`bootstrap/<sha>.qcow2`); existing VMs do not auto-replace
 their root PVC when a new image is published.
 

--- a/cluster/docs/nix_cache.md
+++ b/cluster/docs/nix_cache.md
@@ -1,13 +1,14 @@
 # Nix Binary Cache (Attic)
 
-Attic server at `cache.allegedly.works`, backed by PostgreSQL (CNPG) and local
-storage on a `local-path-ovh` PVC. Manifests in `k8s/nix-cache/`.
+Attic server at `cache.allegedly.works`, backed by PostgreSQL (CNPG) for
+metadata and a SeaweedFS S3 bucket for NAR chunk storage. Manifests in
+`k8s/nix-cache/`.
 
 ## Architecture
 
 - **Server**: `ghcr.io/zhaofengli/attic:latest` (busybox-based Rust image)
 - **Database**: CNPG cluster `attic-db` (2 instances, OVH-HA, `local-path-ovh`)
-- **Cache storage**: 30Gi `local-path-ovh` PVC at `/cache`
+- **Cache storage**: SeaweedFS S3 bucket `attic` (`seaweedfs-s3.seaweedfs:8333`), replicated `001` across OVH volume servers
 - **Caches** (private, priority 41, server-generated ED25519 keypairs):
   - `main` — ducktape CI's general-purpose cache (flake outputs)
   - `gaffer` — gaffer-private CI's cache (drivefs and friends)

--- a/cluster/docs/nix_cache.md
+++ b/cluster/docs/nix_cache.md
@@ -1,13 +1,13 @@
 # Nix Binary Cache (Attic)
 
 Attic server at `cache.allegedly.works`, backed by PostgreSQL (CNPG) and local
-storage on a `local-path` PVC. Manifests in `k8s/nix-cache/`.
+storage on a `local-path-ovh` PVC. Manifests in `k8s/nix-cache/`.
 
 ## Architecture
 
 - **Server**: `ghcr.io/zhaofengli/attic:latest` (busybox-based Rust image)
-- **Database**: CNPG cluster `attic-db` (1 instance, Proxmox-single, `local-path`)
-- **Cache storage**: 30Gi `local-path` PVC at `/cache`
+- **Database**: CNPG cluster `attic-db` (2 instances, OVH-HA, `local-path-ovh`)
+- **Cache storage**: 30Gi `local-path-ovh` PVC at `/cache`
 - **Caches** (private, priority 41, server-generated ED25519 keypairs):
   - `main` — ducktape CI's general-purpose cache (flake outputs)
   - `gaffer` — gaffer-private CI's cache (drivefs and friends)

--- a/cluster/docs/operations.md
+++ b/cluster/docs/operations.md
@@ -69,7 +69,7 @@ qm terminal 10000  # talos-pve-cp-0
 
 See <bootstrap.md> for the issuer toggle mechanism. To switch:
 
-1. Edit `LETSENCRYPT_ISSUER` in `k8s/cert-manager-issuer-config/configmap.yaml`
+1. Edit `LETSENCRYPT_ISSUER` in `k8s/cert-manager/issuer-config/configmap.yaml`
 2. Commit and push
 3. Flux re-renders all Ingresses and cert-manager re-issues certificates automatically
 

--- a/cluster/docs/plan.md
+++ b/cluster/docs/plan.md
@@ -91,7 +91,7 @@ PowerDNS and Authentik run on CloudNativePG `local-path`.
       and a source going empty only adds a new snapshot, not destroys
       old ones. Overlaps with the off-cluster object-storage decision in
       the items above. See
-      <debug/2026-06-03-ns103711-seaweedfs-data-volume-mount-missing.md>
+      <../debug/2026-06-03-ns103711-seaweedfs-data-volume-mount-missing.md>
       for the close call.
 - [ ] **Decide whether observability storage stays on SeaweedFS**. Loki,
       Mimir, and Tempo all lost data in the rename. If those backends are
@@ -691,7 +691,7 @@ Options, from cheapest to cleanest:
   (`tana-mcp` nginx whitelisting `/mcp` + `/health`, `activitywatch-readonly`
   whitelisting `GET/POST /api/0/query`). Natural allowlist: the
   `namespace-diagnostics-reader` and `logs-configmaps-reader` binding sets in
-  <k8s/agents/claude-rbac/permissions.md>.
+  <../k8s/agents/claude-rbac/permissions.md>.
 - **C. Loki multi-tenancy.** Set `auth_enabled: true`, route per-namespace logs to
   per-namespace tenants via Alloy/Promtail, grant tenant IDs. Touches every log
   producer; almost certainly overkill.
@@ -832,4 +832,4 @@ kimsufi) and Proxmox-single (1 instance). See <cnpg_conventions.md>.
 - <troubleshooting.md>
 - <lessons_learned/2025_11_28_eso_password_generator_desync.md>
 
-**Monthly Cost**: ~EUR64 (4x CPX31, grandfathered at HIL).
+**Monthly Cost**: OVH Kimsufi bare metal (3× KS-5 + 2× KS-GAME, HIL); refresh figure (was ~EUR64/mo on the retired Hetzner CPX31 fleet).

--- a/cluster/docs/secrets.md
+++ b/cluster/docs/secrets.md
@@ -47,7 +47,7 @@ file based on its path. Commit and push — Flux deploys automatically.
 2. Update `secrets/shared/cluster-secrets-age.yaml` with new keypair
 3. Update `.sops.yaml` with new public key
 4. Re-encrypt all cluster secrets: `for f in $(find cluster/k8s -name '*.sops.yaml'); do sops updatekeys "$f"; done`
-5. `tofu apply` to deploy new k8s secret
+5. Redeploy the k8s secret: `cd terraform/main && tofu apply -target=kubernetes_secret.sops_age_cluster_secrets`
 6. Commit + push
 
 ## Common Failure Modes
@@ -59,8 +59,16 @@ file based on its path. Commit and push — Flux deploys automatically.
 **Cause**: Cluster age key in `flux-system/sops-age-cluster-secrets` doesn't
 match the key used to encrypt the file.
 
-**Fix**: Verify the key matches `.sops.yaml`, re-encrypt if needed with
-`sops updatekeys`, redeploy the k8s secret via `tofu apply`.
+**Fix**:
+
+```bash
+# Verify the key exists in-cluster
+kubectl get secret sops-age-cluster-secrets -n flux-system
+# Re-encrypt all cluster SOPS files with the current keys
+for f in $(find cluster/k8s -name '*.sops.yaml'); do sops updatekeys "$f"; done
+# Redeploy the age key from tofu state
+cd terraform/main && tofu apply -target=kubernetes_secret.sops_age_cluster_secrets
+```
 
 ### OpenTofu State Lost
 

--- a/cluster/docs/secrets.md
+++ b/cluster/docs/secrets.md
@@ -68,7 +68,7 @@ match the key used to encrypt the file.
 
 **Prevention**:
 
-- PG backend with backup CronJob (`pg_dump` every 6 hours)
+- PG backend in the `tofu-state-db` CNPG cluster (automated offsite backup is a pending TODO — see <plan.md>)
 - Age keypair also stored in `secrets/shared/cluster-secrets-age.yaml` (SOPS-encrypted
   with admin key) — survives tofu state loss
 

--- a/cluster/docs/sso.md
+++ b/cluster/docs/sso.md
@@ -4,7 +4,7 @@
 
 ### TF-managed providers (preferred for new providers)
 
-`terraform/gitops/sso-providers/` creates `authentik_provider_oauth2` resources directly.
+`tf/gitops/sso-providers/` creates `authentik_provider_oauth2` resources directly.
 TF owns the client_secret lifecycle — no Vault, no ESO, no `!Env` drift.
 
 **Secret flow**: TF creates provider → reads `client_secret` → writes `kubernetes_secret`

--- a/cluster/docs/troubleshooting.md
+++ b/cluster/docs/troubleshooting.md
@@ -201,29 +201,10 @@ Vault is decommissioned. Kept for context only.
 
 ### SOPS Decryption Failure
 
-**Symptoms**: Kustomization shows `sops decryption error`; secrets not created.
-
-**Cause**: Cluster age key in `flux-system/sops-age-cluster-secrets` doesn't
-match the key used to encrypt the `*.sops.yaml` files.
-
-**Fix**:
-
-```bash
-# Verify the key exists
-kubectl get secret sops-age-cluster-secrets -n flux-system
-
-# Re-encrypt all cluster SOPS files with current keys
-for f in $(find cluster/k8s -name '*.sops.yaml'); do sops updatekeys "$f"; done
-
-# Redeploy the age key from tofu state
-cd terraform/main && tofu apply -target=kubernetes_secret.sops_age_cluster_secrets
-```
-
-**Validation** (runs as part of unified pre-commit):
-
-```bash
-pre-commit run --all-files
-```
+`sops decryption error` on a Kustomization means the cluster age key in
+`flux-system/sops-age-cluster-secrets` doesn't match the key that encrypted the
+`*.sops.yaml` files. See <secrets.md> § "SOPS Decryption Failure in Flux" for the
+verify / `sops updatekeys` / redeploy fix (validated by `pre-commit run --all-files`).
 
 ## PVC File Ownership After Restore
 

--- a/cluster/docs/troubleshooting/harbor_proxy_cache_401.md
+++ b/cluster/docs/troubleshooting/harbor_proxy_cache_401.md
@@ -30,7 +30,7 @@ curl -H "Authorization: Bearer $TOKEN" \
 ## Fix
 
 Added `overridePath = true` to each mirror entry in
-`terraform/main/main.tf`. This makes Talos set
+`terraform/main/infrastructure.tf`. This makes Talos set
 `override_path = true` in the generated `hosts.toml`, so the endpoint path
 replaces `/v2/` instead of being prepended.
 

--- a/cluster/k8s/agents/claude-rbac/README.md
+++ b/cluster/k8s/agents/claude-rbac/README.md
@@ -7,8 +7,9 @@ within `claude-sandbox`). It must **never** depend on service or database kustom
 Namespace-scoped RoleBindings targeting other namespaces live in per-service `agent-rbac/`
 directories (see Architecture below).
 
-**Cross-references**: RBAC is referenced from `cluster/AGENTS.md` (Kubernetes MCP Server
-section) and the root `AGENTS.md`. Keep in sync when changing permissions.
+**Cross-references**: this README is `@`-transcluded into `cluster/AGENTS.md`; the root
+`AGENTS.md` (Kubernetes MCP Server section) keeps a brief MCP-usage summary that points
+here. Update this file as the single source when changing permissions or the quota.
 
 ## Architecture
 

--- a/cluster/k8s/agents/kagent/TODO.md
+++ b/cluster/k8s/agents/kagent/TODO.md
@@ -7,7 +7,7 @@ single MCP call (`kubectl get events`, full pod listings) dumps enough text
 into the event history that the next request exceeds z.ai's per-prompt cap
 (error 1261), killing the session. This makes the platform too fragile for
 cluster-ops use. See the "Tool-output robustness" section in
-<../../../docs/self_hosted_coding_agent_platforms.md>.
+<../../../../docs/self_hosted_coding_agent_platforms.md>.
 
 Originally revived on 2026-05-08. Reachable at <https://kagent.allegedly.works>
 behind Authentik OIDC via the chart's bundled `oauth2-proxy` subchart.
@@ -60,7 +60,7 @@ behind Authentik OIDC via the chart's bundled `oauth2-proxy` subchart.
 
 - <namespace/namespace.yaml> — PSS dropped to `baseline` (TODO to retighten
   to `restricted` once upstream agent Deployments set proper securityContext).
-- <../../../docs/z_ai_api.md> — z.ai endpoint shapes, including the coding
+- <../../../../docs/z_ai_api.md> — z.ai endpoint shapes, including the coding
   plan vs general distinction.
-- <../../../docs/self_hosted_coding_agent_platforms.md> — broader survey of
+- <../../../../docs/self_hosted_coding_agent_platforms.md> — broader survey of
   options if kagent's rough edges become disqualifying.

--- a/cluster/skills/cnpg_region_switch/RUNBOOK.md
+++ b/cluster/skills/cnpg_region_switch/RUNBOOK.md
@@ -1,22 +1,24 @@
 # CNPG Cross-Region Migration via Streaming Replication
 
-Migrate a single-instance CNPG PostgreSQL cluster between regions (Proxmox home ↔ Hetzner VPS) with sub-second downtime.
+Migrate a single-instance CNPG PostgreSQL cluster between regions (or region-pinned storage classes) with sub-second downtime.
 
 Uses CNPG's **Standalone Replica Cluster** pattern: target bootstrapped via `pg_basebackup`, runs as streaming replica, then promoted to independent primary. Irreversible — no demotion back to replica.
 
 ## Prerequisites
 
 - CNPG operator installed in cluster
-- Source and target storage classes exist and are region-pinned
+- Source and target storage classes exist and are region-pinned (see <../../docs/cnpg_conventions.md> for the current profiles and region names)
 - Both regions' nodes can reach each other over pod network (Nebula mesh)
 - `kubectl` access to the namespace
 - Same PostgreSQL image version on both clusters (required for physical replication)
 
-## Migration: Proxmox → Hetzner
+## Migration procedure
+
+Set `<SOURCE_STORAGECLASS>` / `<TARGET_STORAGECLASS>` to the region-pinned storage classes for the source and target regions. The procedure is identical in either direction — just swap which region is source vs. target.
 
 ### Step 1: Create source cluster (if not existing)
 
-Source cluster runs on Proxmox with `local-path-proxmox` storage.
+Source cluster runs in the source region with `<SOURCE_STORAGECLASS>` storage.
 
 ```yaml
 apiVersion: postgresql.cnpg.io/v1
@@ -32,7 +34,7 @@ spec:
       isolationCheck:
         enabled: false
   storage:
-    storageClass: local-path-proxmox
+    storageClass: <SOURCE_STORAGECLASS>
     size: <SIZE>
   monitoring:
     enablePodMonitor: false
@@ -50,7 +52,7 @@ kubectl wait cluster/<SOURCE_NAME> -n <NAMESPACE> --for=condition=Ready --timeou
 
 ### Step 2: Create target cluster as streaming replica
 
-Target cluster on Hetzner with `local-path-hetzner` storage, bootstrapped from source via `pg_basebackup`.
+Target cluster in the target region with `<TARGET_STORAGECLASS>` storage, bootstrapped from source via `pg_basebackup`.
 
 ```yaml
 apiVersion: postgresql.cnpg.io/v1
@@ -68,7 +70,7 @@ spec:
       isolationCheck:
         enabled: false
   storage:
-    storageClass: local-path-hetzner
+    storageClass: <TARGET_STORAGECLASS>
     size: <SIZE>
   monitoring:
     enablePodMonitor: false
@@ -170,13 +172,6 @@ kubectl delete cluster <SOURCE_NAME> -n <NAMESPACE>
 ```
 
 CNPG finalizers clean up PVCs automatically.
-
-## Migration: Hetzner → Proxmox
-
-Same procedure with storage classes reversed:
-
-- Source: `local-path-hetzner`
-- Target: `local-path-proxmox`
 
 ## Gotchas
 

--- a/cluster/skills/cnpg_region_switch/SKILL.md
+++ b/cluster/skills/cnpg_region_switch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cnpg_region_switch
-description: Migrate a CNPG PostgreSQL cluster between Proxmox and Hetzner regions via streaming replication with sub-second downtime
+description: Migrate a single-instance CNPG PostgreSQL cluster between regions or region-pinned storage classes via streaming replication with sub-second downtime
 ---
 
 # CNPG Cross-Region Migration
@@ -9,7 +9,7 @@ Migrate a single-instance CNPG PostgreSQL cluster between regions using the Stan
 
 ## When to use
 
-- Migrating a database from Proxmox to Hetzner (or vice versa)
+- Migrating a database from one region to another (either direction)
 - Moving a database to region-appropriate storage
 - No HA replicas exist — single-instance cluster only
 
@@ -32,3 +32,4 @@ Key steps:
 - Both clusters must use the same PostgreSQL image version
 - Promotion is irreversible (standalone replica pattern)
 - Namespace must have quota for ≥6 services during migration (3 per cluster)
+- Region and storage-class names are deployment-specific — see <../../docs/cnpg_conventions.md> for the current CNPG profiles and region-pinning rules


### PR DESCRIPTION
Audited `cluster/` documentation against the committed manifests/Terraform **and** the live cluster, then did a dedup/consolidation pass. Six commits:

### 1. Stale-claim fixes (`c3c7630`)
- Dead paths: `terraform/gitops/...` → `tf/gitops/...`; `terraform/main/{main,talos}.tf` → `infrastructure.tf`; `cert-manager-issuer-config/` → `cert-manager/issuer-config/`.
- Node table: `talos-kimsufi-*` / `talos-ks-game-*` → actual `ovh-ns*` hostnames (nodes were renamed).
- `bootstrap.md`: no `longhorn` StorageClass / no default class. `nix_cache.md`: attic-db is 2-instance OVH-HA. README: Langfuse off `lvm-proxmox-hdd`; `aw-server` built via `oci_image` + `push-images.yml` (no `buildbuddy.yaml`); `secrets.md`: the tofu-state `pg_dump` CronJob was removed.

### 2. `cnpg_region_switch` skill genericized + attic storage fixed (`3802c12`)
- Skill: dropped the retired Proxmox↔**Hetzner** / `local-path-hetzner` specifics for generic `<SOURCE/TARGET_STORAGECLASS>` placeholders + a pointer to `cnpg_conventions.md`. (Hetzner→OVH migration confirmed by owner.)
- `nix_cache.md`: corrected attic NAR-chunk storage to the **SeaweedFS S3 bucket** (`server.toml type=s3`, `bucket=attic`) — both the original doc and my first-pass `local-path-ovh` edit were wrong.

### 3. SOPS dedup (`23cece4`)
`secrets.md` is the single source for age-key rotation + the SOPS-decryption-failure fix (enriched with the precise commands). `troubleshooting.md` and `bootstrap_dependencies.md` reduced to pointers. (`plan.md`'s "re-key admin-only files" is a distinct live TODO, left alone.)

### 4. Agent-RBAC + quota dedup via `@`-transclusion (`d7af767`)
`claude-rbac/README.md` is canonical; `cluster/AGENTS.md` now `@`-transcludes it (dropping 3 restated layer paragraphs); root `AGENTS.md` drops the hardcoded `8 CPU/16Gi/20 pods` quota and references the README.

### 5. Sanitize `bootstrap_dependencies.md` (`b8ee7a3`)
Fixed mojibake (corrupted arrow), prettier-damaged markdown on the app-credential bullet, and reduced an inline age-key recovery note to a pointer.

### 6. Broken relative links + stale OVH cost (`ee520bf`)
`cluster/docs/*.md` links written as if rooted at `cluster/` → fixed to `../`-relative (`plan.md`, `dns_automation.md`, `kubevirt_*.md`); kagent TODO `../../../docs/` → `../../../../docs/` (repo-root). `plan.md` Monthly Cost: dropped the retired Hetzner `4x CPX31` for current OVH Kimsufi (figure flagged for refresh).

---

### Still open (judgment calls / not in scope here)
- [ ] `plan.md` "Suspended Kustomizations" list is incomplete (~8 listed, ~20+ suspended live — many are Proxmox-pinned, suspended while `wyrm2`/Proxmox is down).
- [ ] `cnpg_conventions.md` compliance table: `harbor-db` is single-instance OVH (not Proxmox-single); `study-casino-db` is 3 instances (neither blessed profile); `plaid-mcp-db` missing — needs a profile decision.
- [ ] README storage table: plain `local-path` row (SC retired/split) and `longhorn` row (SC gone, kustomization suspended).
- [ ] README services table: Harbor/Matrix/OpenClaw shown active but currently suspended (transient Proxmox outage — deliberately not relabeled).
- [ ] Remaining consolidations: SeaweedFS rack-label caveat (3×), OVH-resilience restatement (3×), bootstrap dependency-chain notation drift.
- [ ] `operations.md` node-restart examples reference the retired `talos-pve-cp-0` Proxmox CP.

https://claude.ai/code/session_01NYzAqrWXJRJwdN1VheUXUH