### PR TITLE
cluster docs: storage table + OVH-resilience/bootstrap consolidation, generic ops

### DIFF
--- a/cluster/README.md
+++ b/cluster/README.md
@@ -81,18 +81,18 @@ OpenClaw requires a one-time gateway token entry in the UI — the token is incl
 
 All storage is region-local — no cross-site synchronous replication.
 
-| StorageClass         | Provisioner            | Region    | Notes                                                                    |
-| -------------------- | ---------------------- | --------- | ------------------------------------------------------------------------ |
-| `local-path`         | local-path-provisioner | Any       | CNPG (most databases), Gatus                                             |
-| `local-path-proxmox` | local-path-provisioner | `proxmox` | Matrix, ActivityWatch, Scanner, OpenClaw, Google Workspace MCP, Tana MCP |
-| `local-path-ovh`     | local-path-provisioner | `hil-ovh` | SeaweedFS volume servers, attic-db (CNPG OVH-HA)                         |
-| `lvm-proxmox-ssd`    | OpenEBS LVM CSI        | `proxmox` | NVMe thin provisioning: Firecracker                                      |
-| `lvm-proxmox-hdd`    | OpenEBS LVM CSI        | `proxmox` | HDD thin provisioning: Harbor, Docker CI, Grocy                          |
-| `proxmox-csi-retain` | Proxmox CSI            | `proxmox` | Block storage via Proxmox API: Ollama, Devbot (migrating off)            |
-| `longhorn`           | Longhorn               | `hil`     | Legacy — orphaned PVCs only, no active workloads                         |
+| StorageClass         | Provisioner            | Region    | Notes                                                                              |
+| -------------------- | ---------------------- | --------- | ---------------------------------------------------------------------------------- |
+| `local-path-proxmox` | local-path-provisioner | `proxmox` | Proxmox-single CNPG DBs; Matrix, ActivityWatch, Scanner, OpenClaw, Tana MCP        |
+| `local-path-ovh`     | local-path-provisioner | `hil-ovh` | OVH-HA CNPG DBs (authentik, gatus, forgejo, langfuse, …); SeaweedFS volume servers |
+| `seaweedfs-ovh`      | SeaweedFS CSI          | `hil-ovh` | POSIX/S3-backed volumes for apps needing a real filesystem (Forgejo git repos)     |
+| `lvm-proxmox-ssd`    | OpenEBS LVM CSI        | `proxmox` | NVMe thin provisioning: Firecracker                                                |
+| `lvm-proxmox-hdd`    | OpenEBS LVM CSI        | `proxmox` | HDD thin provisioning: Harbor, Docker CI, Grocy                                    |
+| `proxmox-csi-retain` | Proxmox CSI            | `proxmox` | Block storage via Proxmox API: Ollama, Devbot (migrating off)                      |
 
 Proxmox CSI needs VLAN access to Proxmox API. OpenEBS LVM is constrained to nodes
 with the `openebs-proxmox-ssd` / `openebs-proxmox-hdd` volume groups (currently Proxmox nodes only).
+CNPG database placement (OVH-HA vs Proxmox-single) follows <docs/cnpg_conventions.md>.
 
 ## GPU (NVIDIA)
 
@@ -125,14 +125,10 @@ which reads the env var and injects GPU devices/libraries via host CDI specs.
 
 ### OVH-Only Resilience Invariants
 
-The following services **MUST** work/recover with OVH only (without Proxmox):
-
-- **DNS** (AWS Route 53) — all external name resolution depends on this
-- **Website** (`allegedly.works`) — public-facing
-
-These services must not depend on `proxmox-csi-retain` storage or Proxmox-pinned nodes.
-Authentik uses CloudNativePG on `local-path`.
-See <docs/plan.md> for the full invariant definition, compliance tracking, and fix plan.
+DNS (AWS Route 53) and the public website must keep working/recovering with OVH
+only (no Proxmox) — so they must not depend on `proxmox-csi-retain` storage or
+Proxmox-pinned nodes. Full invariant set, compliance tracking, and fix plan:
+<docs/plan.md> § "OVH-Only Resilience Invariants".
 
 ## SSO (Authentik)
 

--- a/cluster/docs/bootstrap.md
+++ b/cluster/docs/bootstrap.md
@@ -70,9 +70,9 @@ kubectl get storageclass               # local-path-ovh, local-path-proxmox, sea
 
 ## Dependency Chain
 
-```text
-Talos OS → Nebula mesh → K8s API → Cilium CNI → Flux (SOPS) → CSI Drivers → Apps
-```
+See <bootstrap_dependencies.md> for the full L0–L7 bootstrap dependency graph
+(external creds → SOPS → persistent auth → infrastructure → networking → Flux →
+services → NixOS workers) plus per-layer recovery procedures.
 
 ## Let's Encrypt Issuer Toggle
 

--- a/cluster/docs/operations.md
+++ b/cluster/docs/operations.md
@@ -34,14 +34,11 @@ tofu apply
 ### Restart Single Node
 
 ```bash
-# Gracefully restart a node (example: controlplane0)
-talosctl \
-  --endpoints 10.2.1.1 \
-  --nodes 10.2.1.1 \
-  reboot
+# Gracefully restart a node via Talos (use the node's Nebula IP or hostname)
+talosctl --endpoints <node> --nodes <node> reboot
 
-# Or force restart via Proxmox
-ssh root@atlas 'qm reboot 10000'
+# Force restart out-of-band: OVH nodes via the OVH manager/IPMI; Proxmox-hosted
+# Talos VMs via `ssh root@atlas 'qm reboot <vmid>'`
 ```
 
 ### Remove Node
@@ -60,9 +57,9 @@ See `~/.claude/skills/proxmox_vm/vm-screenshot.sh`
 ### Direct VM Console Access
 
 ```bash
-# Interactive console access (from Proxmox host)
+# Interactive console for a Proxmox-hosted VM (from the Proxmox host)
 ssh root@atlas
-qm terminal 10000  # talos-pve-cp-0
+qm terminal <vmid>
 ```
 
 ## Switching Let's Encrypt Environment (Staging ↔ Production)


### PR DESCRIPTION
Follow-up cleanup after #1959, knocking out four more items from that PR's checklist.

- **README storage table**: dropped the retired plain `local-path` SC (the provisioner now serves only `-ovh`/`-proxmox`) and the removed `longhorn` SC; added the real `seaweedfs-ovh` class (Forgejo's POSIX-needing volumes); folded the displaced CNPG/Gatus consumers into the `local-path-{ovh,proxmox}` rows and added a pointer to `cnpg_conventions.md` for profile placement. (Verified against live `kubectl get storageclass`.)
- **OVH-Only Resilience**: trimmed the README restatement to a 2-line summary + pointer to `plan.md` (canonical home for the full invariant set + compliance table); dropped the stale "Authentik on `local-path`" line.
- **Bootstrap notation drift**: replaced `bootstrap.md`'s simplified arrow "Dependency Chain" (which had drifted from the layered graph) with a pointer to the canonical L0–L7 graph in `bootstrap_dependencies.md`.
- **operations.md**: genericized the node-restart and VM-console examples (`<node>` / `<vmid>`), dropping the retired `talos-pve-cp-0` / `10.2.1.1` / vmid `10000` Proxmox-CP specifics — the control plane is OVH bare metal now.

Docs-only; passed the full pre-commit suite locally.

Remaining from the original audit checklist (not in this PR — both need a judgment call):
- [ ] `plan.md` "Suspended Kustomizations" list is incomplete (~8 listed vs ~20+ suspended live).
- [ ] `cnpg_conventions.md` compliance table: `harbor-db` single-instance-OVH (not Proxmox-single), `study-casino-db` 3 instances (neither blessed profile), `plaid-mcp-db` missing — needs a profile decision.

https://claude.ai/code/session_01NYzAqrWXJRJwdN1VheUXUH

---
_Generated by [Claude Code](https://claude.ai/code/session_01NYzAqrWXJRJwdN1VheUXUH)_