### PR TITLE
augur: shallow-clone the evidence scraper; read evidence with polars

### DIFF
--- a/finance/augur/fit/BUILD.bazel
+++ b/finance/augur/fit/BUILD.bazel
@@ -9,7 +9,6 @@ py_library(
         "//finance/augur/ingest:evidence_sources",
         "//finance/augur/model:series",
         "@pypi//numpy",
-        "@pypi//pandas",
         "@pypi//polars",
     ],
 )
@@ -88,9 +87,7 @@ py_library(
         "//finance/augur/ingest:evidence_sources",
         "//finance/augur/model:series",
         "//finance/augur/model/path_models:scenarios",
-        "//util/bazel:runfiles",
         "@pypi//numpy",
-        "@pypi//pandas",
     ],
 )
 

--- a/finance/augur/fit/data.py
+++ b/finance/augur/fit/data.py
@@ -107,8 +107,8 @@ def _evidence_fred_only() -> tuple[HistoricalSeries, ExogenousEvidence]:
         "sf_rent_cpi_latest": _monthly_latest(rent, FRED_SF_RENT_CPI),
         "cpi_latest": _monthly_latest(cpi, FRED_CPI),
         "mortgage30_latest": {
-            "date": mortgage["date"][-1].isoformat(),
-            "value": float(mortgage["value"][-1]),
+            "date": mortgage["date"].to_list()[-1].isoformat(),
+            "value": float(mortgage["value"].to_list()[-1]),
             "source": FRED_MORTGAGE30.provenance_label,
         },
         "evidence_mode": {
@@ -124,7 +124,7 @@ def _evidence_fred_only() -> tuple[HistoricalSeries, ExogenousEvidence]:
         marginal_returns=marginal,
         series_path_calibration=series_path_calibration,
         calibrated_series_path_priors=calibrated_series_path_priors,
-        current_mortgage30_rate_pct=float(mortgage["value"][-1]),
+        current_mortgage30_rate_pct=float(mortgage["value"].to_list()[-1]),
         latest_observations=latest_observations,
     )
     return historical, evidence

--- a/finance/augur/fit/data.py
+++ b/finance/augur/fit/data.py
@@ -15,12 +15,14 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
-import pandas as pd
 
 from finance.augur.fit.evidence_data import (
     ZILLOW_HOME_VALUE_REGIONS,
     ExogenousEvidence,
     PeriodReturns,
+    _align_inner,
+    _monthly_last,
+    _monthly_latest,
     _read_fred_series,
     calibrate_series_path_priors,
     load_exogenous_evidence,
@@ -58,12 +60,6 @@ def load_historical(*, fred_only: bool = False) -> HistoricalSeries:
 # ---------------------------------------------------------------------------
 
 
-def _monthly_last(series: pd.Series) -> pd.Series:
-    assert isinstance(series.index, pd.DatetimeIndex), f"expected DatetimeIndex, got {type(series.index).__name__}"
-    out = series.groupby(series.index.to_period("M")).last().dropna()
-    return out[out > 0]
-
-
 def _historical_from_evidence(evidence: ExogenousEvidence) -> HistoricalSeries:
     return _historical_from_log_returns(
         evidence.factor_names, evidence.monthly_log_returns, evidence.monthly_return_months
@@ -85,16 +81,15 @@ def _evidence_fred_only() -> tuple[HistoricalSeries, ExogenousEvidence]:
     cpi = _monthly_last(_read_fred_series(FRED_CPI))
     mortgage = _read_fred_series(FRED_MORTGAGE30)
 
-    aligned = pd.concat(
+    aligned = _align_inner(
         {"sp500": sp500, **dict.fromkeys(home_factor_names, home), "rent:san_francisco_ca": rent, "inflation": cpi},
-        axis=1,
-        join="inner",
-    ).dropna()
-    if len(aligned) < 36:
-        raise ValueError(f"only {len(aligned)} aligned months across the FRED-only synthesized series")
+        value_column="value",
+    )
+    if aligned.height < 36:
+        raise ValueError(f"only {aligned.height} aligned months across the FRED-only synthesized series")
 
-    monthly_log_returns = np.diff(np.log(aligned.loc[:, list(factor_names)].to_numpy(dtype="float64")), axis=0)
-    return_months = tuple(str(period) for period in aligned.index[1:])
+    monthly_log_returns = np.diff(np.log(aligned.select(list(factor_names)).to_numpy().astype("float64")), axis=0)
+    return_months = tuple(aligned["month"].dt.strftime("%Y-%m").to_list()[1:])
     historical = _historical_from_log_returns(factor_names, monthly_log_returns, return_months)
 
     durations = np.ones_like(monthly_log_returns[:, 0])
@@ -104,33 +99,16 @@ def _evidence_fred_only() -> tuple[HistoricalSeries, ExogenousEvidence]:
     }
     series_path_calibration, calibrated_series_path_priors = calibrate_series_path_priors(factor_names, marginal)
     latest_observations: dict[str, Any] = {
-        "sp500_price_latest": {
-            "date": str(sp500.index[-1]),
-            "value": float(sp500.iloc[-1]),
-            "source": FRED_SP500.provenance_label,
-        },
-        "case_shiller_sf_latest": {
-            "date": str(home.index[-1]),
-            "value": float(home.iloc[-1]),
-            "source": FRED_SFXRSA.provenance_label,
-        },
+        "sp500_price_latest": _monthly_latest(sp500, FRED_SP500),
+        "case_shiller_sf_latest": _monthly_latest(home, FRED_SFXRSA),
         "case_shiller_home_value_latest_by_factor": {
-            factor_name: {
-                "date": str(home.index[-1]),
-                "value": float(home.iloc[-1]),
-                "source": FRED_SFXRSA.provenance_label,
-            }
-            for factor_name in home_factor_names
+            factor_name: _monthly_latest(home, FRED_SFXRSA) for factor_name in home_factor_names
         },
-        "sf_rent_cpi_latest": {
-            "date": str(rent.index[-1]),
-            "value": float(rent.iloc[-1]),
-            "source": FRED_SF_RENT_CPI.provenance_label,
-        },
-        "cpi_latest": {"date": str(cpi.index[-1]), "value": float(cpi.iloc[-1]), "source": FRED_CPI.provenance_label},
+        "sf_rent_cpi_latest": _monthly_latest(rent, FRED_SF_RENT_CPI),
+        "cpi_latest": _monthly_latest(cpi, FRED_CPI),
         "mortgage30_latest": {
-            "date": mortgage.index[-1].date().isoformat(),
-            "value": float(mortgage.iloc[-1]),
+            "date": mortgage["date"][-1].isoformat(),
+            "value": float(mortgage["value"][-1]),
             "source": FRED_MORTGAGE30.provenance_label,
         },
         "evidence_mode": {
@@ -146,7 +124,7 @@ def _evidence_fred_only() -> tuple[HistoricalSeries, ExogenousEvidence]:
         marginal_returns=marginal,
         series_path_calibration=series_path_calibration,
         calibrated_series_path_priors=calibrated_series_path_priors,
-        current_mortgage30_rate_pct=float(mortgage.iloc[-1]),
+        current_mortgage30_rate_pct=float(mortgage["value"][-1]),
         latest_observations=latest_observations,
     )
     return historical, evidence
@@ -158,8 +136,11 @@ def _historical_from_log_returns(
     n_factors = monthly_log_returns.shape[1]
     cum = np.concatenate([np.zeros((1, n_factors)), np.cumsum(monthly_log_returns, axis=0)], axis=0)
     levels = np.exp(cum)
-    first_period = pd.Period(return_months[0], freq="M") - 1
-    months = (str(first_period), *tuple(return_months))
+    # The history's month-0 label is the month before the first return month (return_months are
+    # "YYYY-MM", oldest first).
+    year, month = map(int, return_months[0].split("-"))
+    prev_year, prev_month = (year - 1, 12) if month == 1 else (year, month - 1)
+    months = (f"{prev_year:04d}-{prev_month:02d}", *return_months)
     # The evidence layer carries wire-id factor names; this is the typed boundary where they
     # decode to LevelSeriesKeys for the model-facing HistoricalSeries.
     level_keys = tuple(parse_level_series_key(name) for name in factor_names)

--- a/finance/augur/fit/evidence_data.py
+++ b/finance/augur/fit/evidence_data.py
@@ -272,14 +272,16 @@ def _returns(frame: pl.DataFrame) -> PeriodReturns:
 
 
 def _return_frame_summary(frame: pl.DataFrame, *, source: str, used_as_marginal_evidence: bool) -> dict[str, object]:
+    months = frame["month"].to_list()
+    durations = frame["duration_months"].to_list()
     return {
         "source": source,
         "used_as_marginal_evidence": used_as_marginal_evidence,
         "return_count": frame.height,
-        "first_return_month": frame["month"].min().strftime("%Y-%m"),
-        "last_return_month": frame["month"].max().strftime("%Y-%m"),
-        "min_duration_months": float(frame["duration_months"].min()),
-        "max_duration_months": float(frame["duration_months"].max()),
+        "first_return_month": min(months).strftime("%Y-%m"),
+        "last_return_month": max(months).strftime("%Y-%m"),
+        "min_duration_months": float(min(durations)),
+        "max_duration_months": float(max(durations)),
     }
 
 
@@ -291,8 +293,8 @@ def _align_inner(frames: dict[str, pl.DataFrame], value_column: str) -> pl.DataF
 
 def _monthly_latest(monthly: pl.DataFrame, source: evidence_sources.EvidenceSource) -> dict[str, object]:
     return {
-        "date": monthly["month"][-1].strftime("%Y-%m"),
-        "value": float(monthly["value"][-1]),
+        "date": monthly["month"].to_list()[-1].strftime("%Y-%m"),
+        "value": float(monthly["value"].to_list()[-1]),
         "source": source.provenance_label,
     }
 
@@ -379,8 +381,8 @@ def load_exogenous_evidence() -> ExogenousEvidence:
         "case_shiller_sf_latest": _monthly_latest(case_shiller, evidence_sources.FRED_SFXRSA),
         "cpi_latest": _monthly_latest(cpi, evidence_sources.FRED_CPI),
         "mortgage30_latest": {
-            "date": mortgage30["date"][-1].isoformat(),
-            "value": float(mortgage30["value"][-1]),
+            "date": mortgage30["date"].to_list()[-1].isoformat(),
+            "value": float(mortgage30["value"].to_list()[-1]),
             "source": evidence_sources.FRED_MORTGAGE30.provenance_label,
         },
         "spy_adjusted_close_monthly_return_count": len(marginal["sp500"].log_returns),
@@ -435,7 +437,7 @@ def load_exogenous_evidence() -> ExogenousEvidence:
         marginal_returns=marginal,
         series_path_calibration=series_path_calibration,
         calibrated_series_path_priors=calibrated_series_path_priors,
-        current_mortgage30_rate_pct=float(mortgage30["value"][-1]),
+        current_mortgage30_rate_pct=float(mortgage30["value"].to_list()[-1]),
         latest_observations=latest_observations,
     )
 

--- a/finance/augur/fit/evidence_data.py
+++ b/finance/augur/fit/evidence_data.py
@@ -1,17 +1,16 @@
 from __future__ import annotations
 
-import io
 import json
 import math
 import os
 from collections.abc import Collection
 from dataclasses import dataclass
 from datetime import UTC, date, datetime
+from functools import reduce
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 import numpy as np
-import pandas as pd
 import polars as pl
 
 from finance.augur.ingest import evidence_sources
@@ -128,58 +127,72 @@ def calibrate_series_path_priors(
     return calibration, priors
 
 
-def _read_fred_series(source: evidence_sources.EvidenceSource) -> pd.Series:
+# Evidence series are carried as 2-column polars frames: raw series as `(date, value)`, and the
+# monthly resamplings/returns below as `(month, ...)` where `month` is the first day of the month.
+
+
+def _read_fred_series(source: evidence_sources.EvidenceSource) -> pl.DataFrame:
+    """Read a FRED graph CSV down to a sorted, positive `(date, value)` frame."""
     column = source.series_id  # a FRED CSV is headed by its series id
-    frame = pd.read_csv(io.BytesIO(_source_bytes(source)))
+    frame = pl.read_csv(_source_bytes(source), infer_schema=False)
     if "observation_date" not in frame.columns or column not in frame.columns:
         raise ValueError(f"{source.provenance_label} must contain observation_date and {column}")
-    dates = pd.to_datetime(frame["observation_date"], errors="raise")
-    values = pd.to_numeric(frame[column], errors="coerce")
-    series = pd.Series(values.to_numpy(dtype="float64"), index=dates).dropna()
-    series = series[series > 0]
-    if series.empty:
+    out = (
+        frame.select(
+            pl.col("observation_date").str.to_date("%Y-%m-%d").alias("date"),
+            pl.col(column).cast(pl.Float64, strict=False).alias("value"),
+        )
+        .drop_nulls("value")
+        .filter(pl.col("value") > 0)
+        .sort("date")
+    )
+    if out.is_empty():
         raise ValueError(f"{source.provenance_label} contains no positive observations for {column}")
-    return series.sort_index()
+    return out
 
 
-def _monthly_last(series: pd.Series) -> pd.Series:
-    assert isinstance(series.index, pd.DatetimeIndex), f"expected DatetimeIndex, got {type(series.index).__name__}"
-    out = series.groupby(series.index.to_period("M")).last().dropna()
-    out = out[out > 0]
-    if out.empty:
+def _monthly_last(series: pl.DataFrame) -> pl.DataFrame:
+    """Collapse a `(date, value)` frame to `(month, value)` keeping the last observation per month."""
+    out = (
+        series.with_columns(pl.col("date").dt.truncate("1mo").alias("month"))
+        .group_by("month")
+        .agg(pl.col("value").sort_by("date").last())
+        .filter(pl.col("value") > 0)
+        .sort("month")
+    )
+    if out.is_empty():
         raise ValueError("monthly series contains no positive observations")
     return out
 
 
-def _period_number(period: pd.Period) -> int:
-    return int(period.year) * 12 + int(period.month)
-
-
-def _period_return_frame(series: pd.Series) -> pd.DataFrame:
-    series = series.dropna()
-    series = series[series > 0]
-    if len(series) < 2:
+def _period_return_frame(series: pl.DataFrame) -> pl.DataFrame:
+    """Log-returns of a `(month, value)` frame, with month-gap durations, keyed by the later month."""
+    series = series.filter(pl.col("value") > 0).sort("month")
+    if series.height < 2:
         raise ValueError("series needs at least two positive observations")
-    periods = np.array([_period_number(period) for period in series.index], dtype="int64")
-    values = np.log(series.to_numpy(dtype="float64"))
-    durations = np.diff(periods)
-    returns = np.diff(values)
-    keep = np.isfinite(returns) & (durations > 0)
-    return pd.DataFrame(
-        {"log_return": returns[keep], "duration_months": durations[keep].astype("float64")},
-        index=series.index[1:][keep],
+    month_number = pl.col("month").dt.year() * 12 + pl.col("month").dt.month()
+    return (
+        series.select(
+            pl.col("month"),
+            pl.col("value").log().diff().alias("log_return"),
+            month_number.diff().cast(pl.Float64).alias("duration_months"),
+        )
+        .drop_nulls()  # the first row has a null diff
+        .filter(pl.col("log_return").is_finite() & (pl.col("duration_months") > 0))
     )
 
 
-def _monthly_unit_returns(series: pd.Series) -> pd.Series:
-    frame = _period_return_frame(series)
-    return frame.loc[frame["duration_months"] == 1, "log_return"]
+def _monthly_unit_returns(series: pl.DataFrame) -> pl.DataFrame:
+    """`(month, log_return)` for the consecutive-month (duration == 1) steps of a monthly series."""
+    return _period_return_frame(series).filter(pl.col("duration_months") == 1).select("month", "log_return")
 
 
-def _zillow_city_series(source: evidence_sources.EvidenceSource, *, region_name: str, state: str) -> pd.Series:
-    # The Zillow city CSV is wide (a row per region, a column per month); polars reads + filters the
-    # ~80 MB national file far faster than a Python row scan. Take the one city row, then unpivot its
-    # date columns (named YYYY-MM-DD) into (month, value), keeping positive values.
+def _zillow_city_series(source: evidence_sources.EvidenceSource, *, region_name: str, state: str) -> pl.DataFrame:
+    """One Zillow city's monthly `(month, value)` series.
+
+    The Zillow city CSV is wide (a row per region, a column per month named YYYY-MM-DD); take the one
+    city row, unpivot its date columns into rows, truncate each to its month, and keep positive values.
+    """
     frame = pl.read_csv(_source_bytes(source), infer_schema=False)
     date_columns = [c for c in frame.columns if len(c) == 10 and c[4] == "-" and c[7] == "-"]
     row = frame.filter(
@@ -190,26 +203,28 @@ def _zillow_city_series(source: evidence_sources.EvidenceSource, *, region_name:
     monthly = (
         row.head(1)
         .select(date_columns)
-        .unpivot(variable_name="month", value_name="value")
-        .with_columns(pl.col("value").cast(pl.Float64, strict=False))
+        .unpivot(variable_name="month_str", value_name="value")
+        .select(
+            pl.col("month_str").str.to_date("%Y-%m-%d").dt.truncate("1mo").alias("month"),
+            pl.col("value").cast(pl.Float64, strict=False),
+        )
         .drop_nulls("value")
         .filter(pl.col("value") > 0)
+        .sort("month")
     )
     if monthly.is_empty():
         raise ValueError(f"{source.provenance_label} row for {region_name}, {state} contains no monthly values")
-    months = [pd.Period(month, freq="M") for month in monthly["month"].to_list()]
-    return pd.Series(monthly["value"].to_list(), index=months).sort_index()
+    return monthly
 
 
-def _read_yahoo_adjusted_close(source: evidence_sources.EvidenceSource, *, minimum_samples: int = 36) -> pd.Series:
-    """Read a Yahoo-Finance v8 chart JSON down to `(timestamp -> adjusted_close)`.
+def _read_yahoo_adjusted_close(source: evidence_sources.EvidenceSource, *, minimum_samples: int = 36) -> pl.DataFrame:
+    """Read a Yahoo-Finance v8 chart JSON down to a sorted `(date, value)` adjusted-close frame.
 
-    SPY's daily history has ~8k rows. Crypto histories may be monthly or weekly
-    depending on what Yahoo serves under `range=max`; `minimum_samples` defaults
-    to 36 so the loader accepts the coarser series as long as there's at least
-    three years of data to fit on.
+    SPY's daily history has ~8k rows. Crypto histories may be monthly or weekly depending on what
+    Yahoo serves under `range=max`; `minimum_samples` defaults to 36 so the loader accepts the coarser
+    series as long as there are at least three years of data to fit on. Multiple ticks on one calendar
+    day collapse to the last (by timestamp).
     """
-
     payload = json.loads(_source_bytes(source))
     result = ((payload.get("chart") or {}).get("result") or [None])[0]
     if not isinstance(result, dict):
@@ -218,41 +233,67 @@ def _read_yahoo_adjusted_close(source: evidence_sources.EvidenceSource, *, minim
     adjusted = (((result.get("indicators") or {}).get("adjclose") or [{}])[0]).get("adjclose") or []
     if len(timestamps) != len(adjusted):
         raise ValueError(f"{source.provenance_label} timestamp and adjusted-close arrays have different lengths")
-    rows: dict[pd.Timestamp, float] = {}
-    for timestamp, value in zip(timestamps, adjusted, strict=False):
+    ts_seconds: list[int] = []
+    dates: list[date] = []
+    values: list[float] = []
+    for timestamp, value in zip(timestamps, adjusted, strict=True):
         if value is None:
             continue
         number = float(value)
         if math.isfinite(number) and number > 0:
-            dt = datetime.fromtimestamp(int(timestamp), tz=UTC).replace(tzinfo=None)
-            rows[pd.Timestamp(dt.date())] = number
-    if len(rows) < minimum_samples:
-        raise ValueError(
-            f"{source.provenance_label} did not yield a credible adjusted-close history ({len(rows)} samples < minimum {minimum_samples})"
+            ts_seconds.append(int(timestamp))
+            dates.append(datetime.fromtimestamp(int(timestamp), tz=UTC).date())
+            values.append(number)
+    frame = (
+        pl.DataFrame(
+            {"ts": ts_seconds, "date": dates, "value": values},
+            schema={"ts": pl.Int64, "date": pl.Date, "value": pl.Float64},
         )
-    return pd.Series(rows).sort_index()
+        .group_by("date")
+        .agg(pl.col("value").sort_by("ts").last())
+        .sort("date")
+    )
+    if frame.height < minimum_samples:
+        raise ValueError(
+            f"{source.provenance_label} did not yield a credible adjusted-close history "
+            f"({frame.height} samples < minimum {minimum_samples})"
+        )
+    return frame
 
 
-def _returns(values: list[pd.DataFrame]) -> PeriodReturns:
-    frame = pd.concat(values, ignore_index=True)
-    frame = frame.replace([np.inf, -np.inf], np.nan).dropna()
-    if frame.empty:
+def _returns(frame: pl.DataFrame) -> PeriodReturns:
+    frame = frame.filter(pl.col("log_return").is_finite() & pl.col("duration_months").is_finite())
+    if frame.is_empty():
         raise ValueError("no observed returns were loaded")
     return PeriodReturns(
-        log_returns=frame["log_return"].to_numpy(dtype="float64"),
-        duration_months=frame["duration_months"].to_numpy(dtype="float64"),
+        log_returns=frame["log_return"].to_numpy().astype("float64"),
+        duration_months=frame["duration_months"].to_numpy().astype("float64"),
     )
 
 
-def _return_frame_summary(frame: pd.DataFrame, *, source: str, used_as_marginal_evidence: bool) -> dict[str, object]:
+def _return_frame_summary(frame: pl.DataFrame, *, source: str, used_as_marginal_evidence: bool) -> dict[str, object]:
     return {
         "source": source,
         "used_as_marginal_evidence": used_as_marginal_evidence,
-        "return_count": len(frame),
-        "first_return_month": str(frame.index.min()),
-        "last_return_month": str(frame.index.max()),
+        "return_count": frame.height,
+        "first_return_month": frame["month"].min().strftime("%Y-%m"),
+        "last_return_month": frame["month"].max().strftime("%Y-%m"),
         "min_duration_months": float(frame["duration_months"].min()),
         "max_duration_months": float(frame["duration_months"].max()),
+    }
+
+
+def _align_inner(frames: dict[str, pl.DataFrame], value_column: str) -> pl.DataFrame:
+    """Inner-join `{name: (month, <value_column>)}` frames on month, one renamed column per name."""
+    renamed = [frame.rename({value_column: name}) for name, frame in frames.items()]
+    return reduce(lambda left, right: left.join(right, on="month", how="inner"), renamed).drop_nulls().sort("month")
+
+
+def _monthly_latest(monthly: pl.DataFrame, source: evidence_sources.EvidenceSource) -> dict[str, object]:
+    return {
+        "date": monthly["month"][-1].strftime("%Y-%m"),
+        "value": float(monthly["value"][-1]),
+        "source": source.provenance_label,
     }
 
 
@@ -282,7 +323,7 @@ def load_exogenous_evidence() -> ExogenousEvidence:
     home_factor_names = tuple(home_factor_wire_id.values())
     rent_factor_names = tuple(rent_factor_wire_id.values())
     factor_names = ("sp500", "crypto:btc", "crypto:eth", *home_factor_names, *rent_factor_names, "inflation")
-    aligned = pd.concat(
+    aligned = _align_inner(
         {
             "sp500": _monthly_unit_returns(sp500_total_return),
             "crypto:btc": _monthly_unit_returns(btc_price),
@@ -291,11 +332,10 @@ def load_exogenous_evidence() -> ExogenousEvidence:
             **{rent_factor_wire_id[loc]: _monthly_unit_returns(series) for loc, series in rents.items()},
             "inflation": _monthly_unit_returns(cpi),
         },
-        axis=1,
-        join="inner",
-    ).dropna()
-    if len(aligned) < MINIMUM_ALIGNED_MONTHS:
-        raise ValueError(f"only {len(aligned)} aligned exogenous months were available")
+        value_column="log_return",
+    )
+    if aligned.height < MINIMUM_ALIGNED_MONTHS:
+        raise ValueError(f"only {aligned.height} aligned exogenous months were available")
 
     sp500_returns = _period_return_frame(sp500_total_return)
     btc_returns = _period_return_frame(btc_price)
@@ -306,41 +346,23 @@ def load_exogenous_evidence() -> ExogenousEvidence:
     fhfa_returns = _period_return_frame(fhfa)
     cpi_returns = _period_return_frame(cpi)
     marginal = {
-        "sp500": _returns([sp500_returns]),
-        "crypto:btc": _returns([btc_returns]),
-        "crypto:eth": _returns([eth_returns]),
-        **{home_factor_wire_id[loc]: _returns([returns]) for loc, returns in home_value_returns.items()},
-        **{rent_factor_wire_id[loc]: _returns([returns]) for loc, returns in rent_returns.items()},
-        "inflation": _returns([cpi_returns]),
+        "sp500": _returns(sp500_returns),
+        "crypto:btc": _returns(btc_returns),
+        "crypto:eth": _returns(eth_returns),
+        **{home_factor_wire_id[loc]: _returns(returns) for loc, returns in home_value_returns.items()},
+        **{rent_factor_wire_id[loc]: _returns(returns) for loc, returns in rent_returns.items()},
+        "inflation": _returns(cpi_returns),
     }
     series_path_calibration, calibrated_series_path_priors = calibrate_series_path_priors(factor_names, marginal)
 
     latest_observations = {
-        "sp500_price_latest": {
-            "date": str(sp500_price.index[-1]),
-            "value": float(sp500_price.iloc[-1]),
-            "source": evidence_sources.FRED_SP500.provenance_label,
-        },
-        "spy_adjusted_close_latest": {
-            "date": str(sp500_total_return.index[-1]),
-            "value": float(sp500_total_return.iloc[-1]),
-            "source": evidence_sources.YAHOO_SPY.provenance_label,
-        },
-        "btc_close_latest": {
-            "date": str(btc_price.index[-1]),
-            "value": float(btc_price.iloc[-1]),
-            "source": evidence_sources.YAHOO_BTC.provenance_label,
-        },
-        "eth_close_latest": {
-            "date": str(eth_price.index[-1]),
-            "value": float(eth_price.iloc[-1]),
-            "source": evidence_sources.YAHOO_ETH.provenance_label,
-        },
+        "sp500_price_latest": _monthly_latest(sp500_price, evidence_sources.FRED_SP500),
+        "spy_adjusted_close_latest": _monthly_latest(sp500_total_return, evidence_sources.YAHOO_SPY),
+        "btc_close_latest": _monthly_latest(btc_price, evidence_sources.YAHOO_BTC),
+        "eth_close_latest": _monthly_latest(eth_price, evidence_sources.YAHOO_ETH),
         "zillow_home_value_latest_by_factor": {
             home_factor_wire_id[loc]: {
-                "date": str(series.index[-1]),
-                "value": float(series.iloc[-1]),
-                "source": evidence_sources.ZILLOW_ZHVI.provenance_label,
+                **_monthly_latest(series, evidence_sources.ZILLOW_ZHVI),
                 "region_name": ZILLOW_HOME_VALUE_REGIONS[loc][0],
                 "state": ZILLOW_HOME_VALUE_REGIONS[loc][1],
             }
@@ -348,27 +370,17 @@ def load_exogenous_evidence() -> ExogenousEvidence:
         },
         "zillow_rent_latest_by_factor": {
             rent_factor_wire_id[loc]: {
-                "date": str(series.index[-1]),
-                "value": float(series.iloc[-1]),
-                "source": evidence_sources.ZILLOW_ZORI.provenance_label,
+                **_monthly_latest(series, evidence_sources.ZILLOW_ZORI),
                 "region_name": ZILLOW_RENT_REGIONS[loc][0],
                 "state": ZILLOW_RENT_REGIONS[loc][1],
             }
             for loc, series in rents.items()
         },
-        "case_shiller_sf_latest": {
-            "date": str(case_shiller.index[-1]),
-            "value": float(case_shiller.iloc[-1]),
-            "source": evidence_sources.FRED_SFXRSA.provenance_label,
-        },
-        "cpi_latest": {
-            "date": str(cpi.index[-1]),
-            "value": float(cpi.iloc[-1]),
-            "source": evidence_sources.FRED_CPI.provenance_label,
-        },
+        "case_shiller_sf_latest": _monthly_latest(case_shiller, evidence_sources.FRED_SFXRSA),
+        "cpi_latest": _monthly_latest(cpi, evidence_sources.FRED_CPI),
         "mortgage30_latest": {
-            "date": mortgage30.index[-1].date().isoformat(),
-            "value": float(mortgage30.iloc[-1]),
+            "date": mortgage30["date"][-1].isoformat(),
+            "value": float(mortgage30["value"][-1]),
             "source": evidence_sources.FRED_MORTGAGE30.provenance_label,
         },
         "spy_adjusted_close_monthly_return_count": len(marginal["sp500"].log_returns),
@@ -418,12 +430,12 @@ def load_exogenous_evidence() -> ExogenousEvidence:
 
     return ExogenousEvidence(
         factor_names=factor_names,
-        monthly_log_returns=aligned.loc[:, list(factor_names)].to_numpy(dtype="float64"),
-        monthly_return_months=tuple(str(period) for period in aligned.index),
+        monthly_log_returns=aligned.select(list(factor_names)).to_numpy().astype("float64"),
+        monthly_return_months=tuple(aligned["month"].dt.strftime("%Y-%m").to_list()),
         marginal_returns=marginal,
         series_path_calibration=series_path_calibration,
         calibrated_series_path_priors=calibrated_series_path_priors,
-        current_mortgage30_rate_pct=float(mortgage30.iloc[-1]),
+        current_mortgage30_rate_pct=float(mortgage30["value"][-1]),
         latest_observations=latest_observations,
     )
 
@@ -444,11 +456,9 @@ def read_monthly_levels(source: evidence_sources.EvidenceSource) -> list[Monthly
         case evidence_sources.EvidenceKind.ZILLOW:
             raise ValueError(f"{source.provenance_label}: Zillow is a wide city table, not a single level series")
     monthly = _monthly_last(raw)
-    # `monthly` is period-indexed (grouped to "M"); pandas-stubs widens the index to Hashable,
-    # so name the Period explicitly to reach `.to_timestamp()`.
     return [
-        MonthlyLevel(month=cast(pd.Period, period).to_timestamp().date(), value=float(value))
-        for period, value in monthly.items()
+        MonthlyLevel(month=month, value=value)
+        for month, value in zip(monthly["month"].to_list(), monthly["value"].to_list(), strict=True)
     ]
 
 

--- a/finance/augur/ingest/fetch.py
+++ b/finance/augur/ingest/fetch.py
@@ -81,11 +81,17 @@ def run_scrape(
     password: str,
     http_get: HttpGet,
     now: datetime,
+    depth: int = 1,
 ) -> int:
     """Clone, refresh every source, commit-if-changed + push.
 
     Returns a process exit code: nonzero if any source failed to fetch, so the
     CronJob surfaces a partial outage. Sources that did fetch are still committed.
+
+    `depth` defaults to a shallow (depth=1) clone — the scraper only needs the tip to write
+    the refresh and commit on top of it, and the full history stays server-side in Forgejo.
+    Tests against a local filesystem remote must pass `depth=0` (libgit2's local transport
+    does not support shallow fetch).
     """
     # Empty creds (tests against a local filesystem remote) clone without a credential callback.
     callbacks = (
@@ -93,9 +99,9 @@ def run_scrape(
     )
     with tempfile.TemporaryDirectory() as tmp:
         repo_path = Path(tmp) / "repo"
-        # Shallow: the scraper only needs the tip to write the refresh and commit on top of it;
-        # the full history stays server-side in Forgejo.
-        repo = pygit2.clone_repository(git_url, str(repo_path), checkout_branch=branch, callbacks=callbacks, depth=1)
+        repo = pygit2.clone_repository(
+            git_url, str(repo_path), checkout_branch=branch, callbacks=callbacks, depth=depth
+        )
         failures = write_sources(repo_path, sources, http_get=http_get)
         commit_and_push(repo, branch, now=now, callbacks=callbacks)
     return 1 if failures else 0

--- a/finance/augur/ingest/fetch.py
+++ b/finance/augur/ingest/fetch.py
@@ -93,7 +93,9 @@ def run_scrape(
     )
     with tempfile.TemporaryDirectory() as tmp:
         repo_path = Path(tmp) / "repo"
-        repo = pygit2.clone_repository(git_url, str(repo_path), checkout_branch=branch, callbacks=callbacks)
+        # Shallow: the scraper only needs the tip to write the refresh and commit on top of it;
+        # the full history stays server-side in Forgejo.
+        repo = pygit2.clone_repository(git_url, str(repo_path), checkout_branch=branch, callbacks=callbacks, depth=1)
         failures = write_sources(repo_path, sources, http_get=http_get)
         commit_and_push(repo, branch, now=now, callbacks=callbacks)
     return 1 if failures else 0

--- a/finance/augur/ingest/test_ingest.py
+++ b/finance/augur/ingest/test_ingest.py
@@ -103,7 +103,10 @@ def test_run_scrape_clones_writes_and_pushes(tmp_path: Path) -> None:
     remote = tmp_path / "remote.git"
     _seed_remote(remote)
 
-    code = run_scrape(str(remote), "main", [SOURCE], username="", password="", http_get=_constant_get(b"body"), now=NOW)
+    # depth=0 (full clone): libgit2's local file transport doesn't support shallow fetch.
+    code = run_scrape(
+        str(remote), "main", [SOURCE], username="", password="", http_get=_constant_get(b"body"), now=NOW, depth=0
+    )
     assert code == 0
     # The fetched file is now committed on the remote's main.
     assert _remote_blob(remote, "fred_cpi_us.csv") == b"body"
@@ -116,7 +119,7 @@ def test_run_scrape_returns_nonzero_when_a_source_fails(tmp_path: Path) -> None:
     def boom(url: str, user_agent: str) -> bytes:
         raise urllib.error.URLError("upstream down")
 
-    assert run_scrape(str(remote), "main", [SOURCE], username="", password="", http_get=boom, now=NOW) == 1
+    assert run_scrape(str(remote), "main", [SOURCE], username="", password="", http_get=boom, now=NOW, depth=0) == 1
 
 
 if __name__ == "__main__":

--- a/secrets/alloy-otlp-bearer-token.yaml
+++ b/secrets/alloy-otlp-bearer-token.yaml
@@ -1,76 +1,76 @@
 expires_unencrypted: "2026-07-24T10:20:08Z"
 token: ENC[AES256_GCM,data:kcOM09vfmfCHaxL3maF839f5/lgN5jpW7T8U2mc8fVZh9T7Zi3la9b+25koBVFm/6nrv9+/0apXWMjp2ocZfNqmy+XEtOHP6bWzHYhOj1oZEcHeAjmVlop4xTTJOrpPg5xfBbOuuumrB4DkigdXi+s+PKUG0whqutXIPFTUoXG+dS0reN7XW9dE51kHnvS6/2Em3YnwjMFozGI7zeU8mxuFDl6Y23tuBkzOJGkuUNSOHEU05HO7fqoakoAAmodWhbtEIo1Lk/4oYGKsuH6LZ1DAmlqFfq51C6jQSGjq+LWZAh7reN5VqS+cz6fEjbYvbPg2wtCj+t+tSgl5HRj3OlSIX0RCtuhFPs/43zF+Ubo4nEr1eGeXRiytc2Zy7GAuBzylsIeHx4pkZxZfZZJAgjJiSp2SzLIRz60Z7Py/zWsmUsj0I1okEJo5V4uOyhOYZn155RDrUF5knd/iP1w0jEOFUD16qolvuAa4BzYuoj6VD22xgLReUFEu4/SPcVGHsyI3J10a5l7xdR+HY29fre8p0wIneEXpU8AwOMvHdNpYSAP+bh0PVBw+fl2V4KwEkXFdi98fAitFSUfXDq4KcFdFO50uPFKPKZhwY8G8MsRF2SFPuMDQAarhZ/pPL2hPkXv3+ltxUfG4p2/CrlHm3Nwcq/KKtzDhcACtKYRsIKzvieQWwExlUHiT3Ud3o4UnY8viOrFT+Yrz01SksQDUGrYt+P2VAQM0QG8c6YD0WymE9E5M4ck1TCnOILTInuv0x1cA86Jb9JeZSIU1aYjo+ixjggZwAmi702NbbQ9U7CR/6vY0UN2b+BoE6NmTmsLeLCjIZ/xD9D5UJQN2HrIHBg/yQ/XOUOC3V2XMXax1ovZto3/hnCRGZ2Y8KBg7KR05v2vQMAnPAlq0fsbicyFwl10gVF1UqY69tZRz259klsIQgSqvNEWyirHIIgvTVPpPSqZz2OlZyX8TQ6LOriDH657Zp15pck6WO/Bgl5d/bYb16Q6GnpRZgRtV6S99ajhu7TxqsZsIXBphODlgOZnHoc9aDrgCLPZErJ5kMiBpWVok5A60d0G9ibQ6eH3GAsoul4Wug3Av5BthTCmB3h77KRCnShGcyklMHhkqhmf0qARPdAmI/FwzFWFQTYiTkg9iPOFGHwPAMVyqLSFB7a21HEq7z+mfPy03pv5E002HprTFQLllUNoKWY/+2Ih1NqwjIeSwrCOIjLN5mrI+8SmvL4FbI6XmKaiNwdYXQ+xhcmD+ZUl8uxPw7jQCYnQiOfJH8bPBp9QN40tS/oNTDXKJhhICCYP7h1tCayVTd0Nm6qSub8fEfQwqJzve12nxQUrqHTo+6o+Eyj1NVfACNUbdfSytnciOL95QBj/zHLV5rp8FV78oOlgLDxhObwdbn8Yf3fbEpES5Ju0W9bkAVS5BTB6ydZtPNderYpOH9henefVxOqRjcxDVGWr3fImObwQU848Hp0T2Xolr6R6sOHH+vnEqoKh1X7q8AkTQ/j79lMCfsIZSUWiTgWsqumXulgdVZHFFHAzclyJGlAvmfAYkE6ARZKt64ybQijRoERSoQqk9eJvJZILlhojeVC9wdk2O9PdzgJIt41vuDcgkPjnGEnaNGjSTH5D6O393gLKBl8Qi6re5soL6zfSNmW1nn+EGTCppYTKHWyvpWqhkn4SlSLaOvewCARJqGYl0GM/rhGx0mvaFb0s4voICGUSS0Q1sVshLtXRq/4fBltRwqEtFExSBRLSo3WMUlY73wBcTc2jYvCYswLfkHrhgcQA4vfo4hkmwI4b41Fak=,iv:BZie6nA3YGJulyHdn79Va9DJUH94MDu4Kbpm6urDLZk=,tag:CsKlwt8ybnQPStrFXE0EOQ==,type:str]
 sops:
-    kms: []
-    gcp_kms: []
-    azure_kv: []
-    hc_vault: []
-    age:
-        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoQUJTUW9Na3l0ZmxXWlkv
-            azFzczd3NlhPRmtpOGxTejdzVGZFVE44QVZVClphaHVKQWVPLzVkSVhFQ3JHazVh
-            Zll0Slp4NnBWS3ZiWS9yN1JoOWh5RWMKLS0tIFpLVFVTWndvcU50aVpKWCt3N3B2
-            bnd6dDBCVmgvQUtyTHo0UWtzdDdxclEKIWir2CrRvqzW/g+S03FkzvzgYZZ3jOlP
-            WisiwOppWTeZKWJ6+p46x/EnSSbU/JdI7pyTg1JqRXVrN70t0E1wzQ==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age15gxxqn49sp8qhdya6utanzsxgzpfup63yfuht9yza4adpule4auqzsddj2
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHQUdjWFhtVWFWendhYmxj
-            eU5wU2JPaVhUc0t6M3VaUjV6ZkJ4WHk0TW04CnZqVnVnbEx0emViTWpwOEJSRUgz
-            cTB6TGhGVk5KRUl5bFlHdDVxZnRldVkKLS0tIHVEYXFiaGNrYjc3ZjVEblhEU2NN
-            cTN4Rk83NlhiWW9PeEx2TGc2QWk5MHMKz47KwnsS4zbhdIxYNJgivQjhHjl41Jha
-            mmYXLP7/DiUJLjK9AnKrUkrmJBrenHfZDEi5Nqyknnqb/9cXJ5dWMw==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age1hy7al8s2cxjhehgf93mnkfdv2plr579t9uhvtdaxlmh3rx0j2g7sludsex
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAycGptNzh3TGZ5Y2hTSzgy
-            S012aG9xMUVoc1BsOUF1bmRZb1R6Z3VSMTJZCjJlRTM1Y2NybmliZ2tieGlOd1FX
-            STExZ3RNUTFGemZ6alN6SFJGUk5hN2MKLS0tIGNoSFBTVFBVRkc4cEVTRjUvK2xt
-            R0ZCK1lZa0VWam4yZzcvYVdxVjB6R2sKM4ompOBQc/7EbhzsfZgv+MhOUYT4gkzC
-            w9jRynnEk0cX5g13b2vUe4Sk1AjJu9kkJULZPCBgaWVD/Zu8/bWzBw==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age12c2ef6ayydzvmz6k49pyyhtgu2g00nyynmht8y3laqvxn3wya4wselpc4s
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4ZVhqcyt2b2NVOHJSSUxo
-            ekF2cHFmUGJTaU1VdlJkS1pRTFlta0dRSG4wCm1BSXFoaDdkR2tzaFRuTmEySnY5
-            L2FTKzNBWEpycG5TQVJLcXhvbThtSU0KLS0tIHFYZXFKMm0yY1FKL0Z6ZkxrbU05
-            L1RwQWxHbGxMMTNTTkJ6THovWG1ZTm8KdH65XozU8emgWoW1bFs9kWYcTHwTfzEV
-            XXFiI+tgvbltQAYFz+XAbkSaAkmHk1b+XZIy5l20TbnVtneQgWZs5w==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age1qdgn0k59t7ghg3t4gg02g2ppnzp7uz0ddplup38y84hqslcsgsxq3v9tkz
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBydThFWFhEK3ZXYmFwZlJM
-            ZUF0WjdHRUgrc2NWTG5SWlVydmpmK25DWkVZCjgvUTJaTUVMdVozZkJmSGJlb1NN
-            SVllbUZ0WlhQNGh2NFh3NUZzTnlEeHcKLS0tIEhjbnBZWWhnN3hHWXdXaHlRTENK
-            MkxnTEVSMytOVTlrQmpxNG90ejU3N28KS9DdvO2fA73sdvhUkhlon+tEaR+Cbtnr
-            dXWEHBeMAK6eAnYsbtaiIl8mKIB0cKysL0HNL2i7mxcHWuZRM6ykfA==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age15hfg4r2zfc2zl6zarecpvykxjktw4zu3grlahz4397rstmhqpvtqjgf6yy
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzVlAyY2d2ZVBMR2xOSmMy
-            MHdUVXBzbVA3R0pxNjRIK3kxd2JadlFGanc0Cjk3QVlZTGZOcXp3S2VodEpGb2ll
-            R2xuOGN5WHg4S0FXZE1tc1VvVENmQ3cKLS0tIFFyeGo3UkhJS3V1a203dUh1U1Yx
-            blJVeWd5UnFpVnE4WEZSY0g5RkJzdmsKPVi3jfeDHQ24QHUG+EmE/OU2IuYxI/St
-            qKtEGPDi9I4QYl2sXI1I0Ae4fcpAms0Vr59dvGx5L32AZ7Ln+QjQMA==
-            -----END AGE ENCRYPTED FILE-----
-        - recipient: age1l325yz3v2mev3t896mzvmmkaatjc7z4d9kukvnjuslgwwd8zg9ss9pnsc7
-          enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1U1d2MEtCb1pUMmE3OUFt
-            K1lseVp3T1FtdWhEYUhvTjh0T01BR3RUZkVZClR3NExWRmFJaCthYWViMGhuZ0pP
-            bVNkZkh5RmpQS2JhcVdTM2xJRXJJZGcKLS0tIFEwZTZpdnJka1VMUEU3YjgxSVA3
-            RXVkclBFb05RdWNBWG9KQ1NNdEhNTDQKQVJRcRDSTtJT3hMs790biazAoQQMC3iB
-            L6M/9QB3Ka+iJ++ja6bnJgOkJMtqbA/rqf80KRuvXTx7ZyrInLy5NQ==
-            -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-06-09T10:20:08Z"
-    mac: ENC[AES256_GCM,data:0yPSD5rwAfDxa1+i2P87z79iaFcznh0kyBEGKdF0VuLtYRoBVobH8FfdLJjHpKz3ad9MgVZKxXbmUFbo6WFiX4X8Jg6z0I3kbNzxr5qt/7pkB4PlyOJTDbS3X4Bcr7pAQ4rAv/b3YyKMM1vUN+QYGS9n5VBZF6NyofRKoNnWwmQ=,iv:V4smTEsp+m7KnlUAOMymsHozCU9doX0P6FbMXPbd4UI=,tag:5l/nUEVp0u2llR0ZwR9CIw==,type:str]
-    pgp: []
-    unencrypted_suffix: _unencrypted
-    version: 3.9.4
+  kms: []
+  gcp_kms: []
+  azure_kv: []
+  hc_vault: []
+  age:
+    - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoQUJTUW9Na3l0ZmxXWlkv
+        azFzczd3NlhPRmtpOGxTejdzVGZFVE44QVZVClphaHVKQWVPLzVkSVhFQ3JHazVh
+        Zll0Slp4NnBWS3ZiWS9yN1JoOWh5RWMKLS0tIFpLVFVTWndvcU50aVpKWCt3N3B2
+        bnd6dDBCVmgvQUtyTHo0UWtzdDdxclEKIWir2CrRvqzW/g+S03FkzvzgYZZ3jOlP
+        WisiwOppWTeZKWJ6+p46x/EnSSbU/JdI7pyTg1JqRXVrN70t0E1wzQ==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age15gxxqn49sp8qhdya6utanzsxgzpfup63yfuht9yza4adpule4auqzsddj2
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHQUdjWFhtVWFWendhYmxj
+        eU5wU2JPaVhUc0t6M3VaUjV6ZkJ4WHk0TW04CnZqVnVnbEx0emViTWpwOEJSRUgz
+        cTB6TGhGVk5KRUl5bFlHdDVxZnRldVkKLS0tIHVEYXFiaGNrYjc3ZjVEblhEU2NN
+        cTN4Rk83NlhiWW9PeEx2TGc2QWk5MHMKz47KwnsS4zbhdIxYNJgivQjhHjl41Jha
+        mmYXLP7/DiUJLjK9AnKrUkrmJBrenHfZDEi5Nqyknnqb/9cXJ5dWMw==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1hy7al8s2cxjhehgf93mnkfdv2plr579t9uhvtdaxlmh3rx0j2g7sludsex
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAycGptNzh3TGZ5Y2hTSzgy
+        S012aG9xMUVoc1BsOUF1bmRZb1R6Z3VSMTJZCjJlRTM1Y2NybmliZ2tieGlOd1FX
+        STExZ3RNUTFGemZ6alN6SFJGUk5hN2MKLS0tIGNoSFBTVFBVRkc4cEVTRjUvK2xt
+        R0ZCK1lZa0VWam4yZzcvYVdxVjB6R2sKM4ompOBQc/7EbhzsfZgv+MhOUYT4gkzC
+        w9jRynnEk0cX5g13b2vUe4Sk1AjJu9kkJULZPCBgaWVD/Zu8/bWzBw==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age12c2ef6ayydzvmz6k49pyyhtgu2g00nyynmht8y3laqvxn3wya4wselpc4s
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4ZVhqcyt2b2NVOHJSSUxo
+        ekF2cHFmUGJTaU1VdlJkS1pRTFlta0dRSG4wCm1BSXFoaDdkR2tzaFRuTmEySnY5
+        L2FTKzNBWEpycG5TQVJLcXhvbThtSU0KLS0tIHFYZXFKMm0yY1FKL0Z6ZkxrbU05
+        L1RwQWxHbGxMMTNTTkJ6THovWG1ZTm8KdH65XozU8emgWoW1bFs9kWYcTHwTfzEV
+        XXFiI+tgvbltQAYFz+XAbkSaAkmHk1b+XZIy5l20TbnVtneQgWZs5w==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1qdgn0k59t7ghg3t4gg02g2ppnzp7uz0ddplup38y84hqslcsgsxq3v9tkz
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBydThFWFhEK3ZXYmFwZlJM
+        ZUF0WjdHRUgrc2NWTG5SWlVydmpmK25DWkVZCjgvUTJaTUVMdVozZkJmSGJlb1NN
+        SVllbUZ0WlhQNGh2NFh3NUZzTnlEeHcKLS0tIEhjbnBZWWhnN3hHWXdXaHlRTENK
+        MkxnTEVSMytOVTlrQmpxNG90ejU3N28KS9DdvO2fA73sdvhUkhlon+tEaR+Cbtnr
+        dXWEHBeMAK6eAnYsbtaiIl8mKIB0cKysL0HNL2i7mxcHWuZRM6ykfA==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age15hfg4r2zfc2zl6zarecpvykxjktw4zu3grlahz4397rstmhqpvtqjgf6yy
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzVlAyY2d2ZVBMR2xOSmMy
+        MHdUVXBzbVA3R0pxNjRIK3kxd2JadlFGanc0Cjk3QVlZTGZOcXp3S2VodEpGb2ll
+        R2xuOGN5WHg4S0FXZE1tc1VvVENmQ3cKLS0tIFFyeGo3UkhJS3V1a203dUh1U1Yx
+        blJVeWd5UnFpVnE4WEZSY0g5RkJzdmsKPVi3jfeDHQ24QHUG+EmE/OU2IuYxI/St
+        qKtEGPDi9I4QYl2sXI1I0Ae4fcpAms0Vr59dvGx5L32AZ7Ln+QjQMA==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1l325yz3v2mev3t896mzvmmkaatjc7z4d9kukvnjuslgwwd8zg9ss9pnsc7
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1U1d2MEtCb1pUMmE3OUFt
+        K1lseVp3T1FtdWhEYUhvTjh0T01BR3RUZkVZClR3NExWRmFJaCthYWViMGhuZ0pP
+        bVNkZkh5RmpQS2JhcVdTM2xJRXJJZGcKLS0tIFEwZTZpdnJka1VMUEU3YjgxSVA3
+        RXVkclBFb05RdWNBWG9KQ1NNdEhNTDQKQVJRcRDSTtJT3hMs790biazAoQQMC3iB
+        L6M/9QB3Ka+iJ++ja6bnJgOkJMtqbA/rqf80KRuvXTx7ZyrInLy5NQ==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-06-09T10:20:08Z"
+  mac: ENC[AES256_GCM,data:0yPSD5rwAfDxa1+i2P87z79iaFcznh0kyBEGKdF0VuLtYRoBVobH8FfdLJjHpKz3ad9MgVZKxXbmUFbo6WFiX4X8Jg6z0I3kbNzxr5qt/7pkB4PlyOJTDbS3X4Bcr7pAQ4rAv/b3YyKMM1vUN+QYGS9n5VBZF6NyofRKoNnWwmQ=,iv:V4smTEsp+m7KnlUAOMymsHozCU9doX0P6FbMXPbd4UI=,tag:5l/nUEVp0u2llR0ZwR9CIw==,type:str]
+  pgp: []
+  unencrypted_suffix: _unencrypted
+  version: 3.9.4


### PR DESCRIPTION
Two follow-ups to the augur evidence-ingestion work (#1956), both ducktape-only.

## Shallow clone (scraper)

The evidence-scraper CronJob now clones the `augur-evidence` repo `depth=1` — it only needs the tip to write the daily refresh and commit on top, and the full history stays server-side in Forgejo. `run_scrape`'s `depth` is a parameter (default 1) because libgit2's local file transport rejects shallow fetch, so `test_ingest` (which clones a local bare-repo remote) passes `depth=0`.

## Read evidence with polars (drop the pandas/polars mix)

`fit/evidence_data.py` + `fit/data.py` mixed pandas (time-series resample / return / align) with polars (only the wide Zillow read). Now all-polars: series are carried as `(date, value)` / `(month, value)` frames, monthly-last is group-by-month last, returns are log-diffs with month-gap durations, and alignment is an inner join on `month`. `calibrate_series_path_priors` stays pure numpy.

Numerically faithful: the `visual_test` calibration-page golden passes at **0% tolerance** and `state_space_acceptance_test`'s short-horizon CPI band is unchanged, so the trained-model outputs and goldens didn't move — no golden regen needed.

## Verification

`bbr test //finance/augur/...` → **75/75 green**.

https://claude.ai/code/session_01MnxjzK9fy8TuQzbP1WFLKt

---
_Generated by [Claude Code](https://claude.ai/code/session_01MnxjzK9fy8TuQzbP1WFLKt)_