### PR TITLE
tf/github-branch-protection: drop applied moved block

### DIFF
--- a/plans/branch_protection.md
+++ b/plans/branch_protection.md
@@ -156,10 +156,10 @@ No further migration is needed before enabling protection on `devel`.
 
 The originally-planned evaluate gate turned out to be Enterprise-only (see the
 plan-limitation note above), so the ruleset went straight to
-`enforcement = "active"` covering `devel` + `main`. The `moved` block renames
-`ducktape_main` → `default_branch_protection` as an in-place state move; drop
-it (per its `CLEANUP` marker) once the tf-runner has applied successfully and
-`lastAppliedRevision` advances past the rename.
+`enforcement = "active"` covering `devel` + `main` (applied 2026-06-09). The
+resource was renamed `ducktape_main` → `default_branch_protection` via a
+`moved` block; that state move has since landed and the `moved` block has been
+removed.
 
 Verification that substituted for the evaluate gate:
 

--- a/tf/gitops/github-branch-protection/main.tf
+++ b/tf/gitops/github-branch-protection/main.tf
@@ -54,14 +54,6 @@ locals {
   automation_app_id = 3590331
 }
 
-# CLEANUP(2026-06-09): resource renamed ducktape_main -> default_branch_protection
-# when devel was added to the ruleset. Drop this moved block once the apply
-# (state move) has landed in the tf-runner backend.
-moved {
-  from = github_repository_ruleset.ducktape_main
-  to   = github_repository_ruleset.default_branch_protection
-}
-
 resource "github_repository_ruleset" "default_branch_protection" {
   name        = "default-branch-protection"
   repository  = "ducktape"


### PR DESCRIPTION
Housekeeping follow-up to the devel-protection activation.

The `ducktape_main` → `default_branch_protection` resource rename applied cleanly (tf-runner `lastAppliedRevision` advanced past `42d7b8a68`, `TerraformAppliedSucceed`), so the `moved` block has done its job and is removed. No plan change — pure state-bookkeeping cleanup.

First PR to merge under the now-active devel ruleset, so it exercises the required `bazel-ci / Test & Build` + `Pre-commit checks` gates.