### PR TITLE
augur evidence scraper: fix pygit2 cert crash + fetch sources concurrently

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -331,7 +331,16 @@ apt.install(
     lock = "//finance/beancount_export:trixie_budget_exporter.lock.json",
     manifest = "//finance/beancount_export:trixie_budget_exporter.yaml",
 )
-use_repo(apt, "bookworm_cpap_sync", "bookworm_fc_vm_pod", "gnome_shell_test", "trixie_attic_rotation", "trixie_budget_exporter", "trixie_e2e", "trixie_jwt_rotation")
+
+# Augur evidence scraper image: ca-certificates on debian:trixie-slim so
+# `import pygit2` can initialize libgit2's OpenSSL cert locations (it fails the
+# whole process at import without a system CA bundle).
+apt.install(
+    name = "trixie_evidence",
+    lock = "//finance/augur/ingest:trixie_evidence.lock.json",
+    manifest = "//finance/augur/ingest:trixie_evidence.yaml",
+)
+use_repo(apt, "bookworm_cpap_sync", "bookworm_fc_vm_pod", "gnome_shell_test", "trixie_attic_rotation", "trixie_budget_exporter", "trixie_e2e", "trixie_evidence", "trixie_jwt_rotation")
 
 # JavaScript/TypeScript (Node.js frontends)
 bazel_dep(name = "aspect_bazel_lib", version = "2.22.5")

--- a/finance/augur/ingest/BUILD.bazel
+++ b/finance/augur/ingest/BUILD.bazel
@@ -10,6 +10,7 @@ py_library(
     srcs = ["http_fetch.py"],
     deps = [
         "@pypi//certifi",
+        "@pypi//httpx",
         "@pypi//tenacity",
     ],
 )
@@ -36,17 +37,23 @@ py_test(
     deps = [
         ":fetch",
         ":http_fetch",
+        "//:conftest",
         "//finance/evidence:sources",
+        "@pypi//httpx",
         "@pypi//pygit2",
         "@pypi//pytest",
+        "@pypi//pytest_asyncio",
         "@pypi//pytest_bazel",
     ],
 )
 
 # ── OCI image: augur-evidence (git-scrape CronJob) ──────────────────────
-# No apt layer: pygit2's manylinux wheel bundles libgit2 + its TLS backend, the
-# push targets in-cluster Forgejo over plain HTTP, and the upstream HTTPS GETs
-# pin certifi's CA bundle (see http_fetch). So the slim base needs nothing extra.
+# ca-certificates apt layer (@trixie_evidence): pygit2's Settings() eagerly loads
+# libgit2's OpenSSL cert locations from the system trust store at *import* time, so
+# `import pygit2` raises GitError on the bare slim base (no CA bundle) before the
+# scraper does anything. The certs are needed only to satisfy that init — libgit2
+# push targets in-cluster Forgejo over plain HTTP, and the upstream HTTPS GETs use
+# certifi via httpx (see http_fetch).
 aspect_py_binary(
     name = "evidence_image_bin",
     main = "fetch.py",
@@ -69,7 +76,10 @@ oci_image(
         "org.opencontainers.image.source": "https://github.com/agentydragon/ducktape",
         "org.opencontainers.image.title": "augur-evidence",
     },
-    tars = [":layers"],
+    tars = [
+        ":layers",
+        "@trixie_evidence//:flat",
+    ],
     user = "1000:1000",
 )
 

--- a/finance/augur/ingest/fetch.py
+++ b/finance/augur/ingest/fetch.py
@@ -14,6 +14,7 @@ UserPass credential callback, so no credentials are embedded in the remote URL.
 from __future__ import annotations
 
 import argparse
+import asyncio
 import logging
 import os
 import sys
@@ -32,19 +33,25 @@ logger = logging.getLogger(__name__)
 _AUTHOR = pygit2.Signature("augur evidence scraper", "augur@allegedly.works")
 
 
-def write_sources(workdir: Path, sources: Iterable[EvidenceSource], *, http_get: HttpGet) -> int:
-    """GET each source and write it into `workdir/<output_filename>`.
+async def write_sources(workdir: Path, sources: Iterable[EvidenceSource], *, http_get: HttpGet) -> int:
+    """GET every source concurrently and write each into `workdir/<output_filename>`.
 
-    Per-source upstream failures are logged + counted, not raised (tenacity
-    already rode out transient blips), so one dead upstream doesn't block
-    refreshing the rest. Returns the failure count.
+    Fetches run concurrently (`asyncio.gather`) so the whole set completes in roughly
+    the slowest single source's time rather than the sum — the CronJob's 600s
+    `activeDeadlineSeconds` can't be blown by serializing a dozen large downloads.
+    Per-source upstream failures are logged + counted, not raised (tenacity already
+    rode out transient blips, and a bounded per-source retry budget keeps any one
+    stalled upstream from eating the whole deadline), so one dead upstream doesn't
+    block committing the rest. Returns the failure count.
     """
+    sources = list(sources)
+    bodies = await asyncio.gather(*(http_get(s.upstream_url, s.user_agent) for s in sources), return_exceptions=True)
     failures = 0
-    for source in sources:
-        try:
-            body = http_get(source.upstream_url, source.user_agent)
-        except FETCH_ERRORS:
-            logger.warning("failed to fetch %s", source.provenance_label, exc_info=True)
+    for source, body in zip(sources, bodies, strict=True):
+        if isinstance(body, BaseException):
+            if not isinstance(body, FETCH_ERRORS):
+                raise body  # an unexpected error is a bug, not a recoverable upstream outage
+            logger.warning("failed to fetch %s", source.provenance_label, exc_info=body)
             failures += 1
             continue
         (workdir / source.output_filename).write_bytes(body)
@@ -72,7 +79,7 @@ def commit_and_push(
     return True
 
 
-def run_scrape(
+async def run_scrape(
     git_url: str,
     branch: str,
     sources: Iterable[EvidenceSource],
@@ -102,21 +109,20 @@ def run_scrape(
         repo = pygit2.clone_repository(
             git_url, str(repo_path), checkout_branch=branch, callbacks=callbacks, depth=depth
         )
-        failures = write_sources(repo_path, sources, http_get=http_get)
+        failures = await write_sources(repo_path, sources, http_get=http_get)
         commit_and_push(repo, branch, now=now, callbacks=callbacks)
     return 1 if failures else 0
 
 
-def main(argv: list[str] | None = None) -> int:
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
-    parser = argparse.ArgumentParser(prog="augur-evidence", description=__doc__.splitlines()[0])
+async def async_main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="augur-evidence", description=(__doc__ or "").splitlines()[0])
     parser.add_argument(
         "--git-url", required=True, help="Evidence repo http(s) URL (creds via GIT_USERNAME/GIT_PASSWORD)."
     )
     parser.add_argument("--branch", default="main", help="Branch to clone + push (default: main).")
     args = parser.parse_args(argv)
 
-    return run_scrape(
+    return await run_scrape(
         args.git_url,
         args.branch,
         EVIDENCE_SOURCES,
@@ -125,6 +131,11 @@ def main(argv: list[str] | None = None) -> int:
         http_get=_real_http_get,
         now=datetime.now(UTC),
     )
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+    return asyncio.run(async_main(argv))
 
 
 if __name__ == "__main__":

--- a/finance/augur/ingest/http_fetch.py
+++ b/finance/augur/ingest/http_fetch.py
@@ -1,42 +1,48 @@
-"""HTTPS GET for the public upstreams, with certifi trust + transient retry.
+"""Async HTTPS GET for the public upstreams, with certifi trust + transient retry.
 
-debian-slim ships no CA bundle, so the SSL context is pinned to certifi's
-bundled certs rather than the (absent) system trust store.
+debian-slim ships no CA bundle, so the client is pinned to certifi's bundled
+certs rather than the (absent) system trust store.
 """
 
 from __future__ import annotations
 
 import ssl
-import urllib.error
-import urllib.request
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 
 import certifi
+import httpx
 from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
-HttpGet = Callable[[str, str], bytes]  # (url, user_agent) -> body
+HttpGet = Callable[[str, str], Awaitable[bytes]]  # (url, user_agent) -> body
 
-# urllib raises these for network failures; callers treat them as per-source skips.
-FETCH_ERRORS: tuple[type[BaseException], ...] = (urllib.error.URLError, TimeoutError)
+# httpx raises these for network failures + non-2xx responses; callers treat them
+# as per-source skips (a dead upstream shouldn't block refreshing the rest).
+FETCH_ERRORS: tuple[type[BaseException], ...] = (httpx.HTTPError,)
 
 _SSL_CONTEXT = ssl.create_default_context(cafile=certifi.where())
 
 
 def _is_transient(exc: BaseException) -> bool:
-    """A read worth retrying: a 429/5xx response, or a transport-level timeout/URL error."""
-    if isinstance(exc, urllib.error.HTTPError):  # HTTPError is a URLError subclass — check it first
-        return exc.code == 429 or exc.code >= 500
-    return isinstance(exc, TimeoutError | urllib.error.URLError)
+    """A read worth retrying: a 429/5xx response, or a transport-level error."""
+    if isinstance(exc, httpx.HTTPStatusError):
+        return exc.response.status_code == 429 or exc.response.status_code >= 500
+    return isinstance(exc, httpx.TransportError)
 
 
+# 3 attempts × 120s caps a single stalled upstream at ~6min of retries — under the
+# CronJob's 600s deadline, so one black-holed source can't starve the whole scrape
+# (sources fetch concurrently, so the job waits ~one source's worst case, then commits
+# whatever the healthy upstreams returned).
 @retry(
     retry=retry_if_exception(_is_transient),
     wait=wait_exponential(multiplier=2, max=30),
-    stop=stop_after_attempt(5),
+    stop=stop_after_attempt(3),
     reraise=True,
 )
-def http_get(url: str, user_agent: str) -> bytes:
-    req = urllib.request.Request(url, headers={"User-Agent": user_agent})
-    # timeout is generous: the Zillow national CSVs are tens of MB.
-    with urllib.request.urlopen(req, timeout=120, context=_SSL_CONTEXT) as resp:
-        return bytes(resp.read())
+async def http_get(url: str, user_agent: str) -> bytes:
+    # timeout is per-socket-op (not total), so it bounds a stalled connection without
+    # killing a legitimately slow large transfer (the Zillow national CSVs are tens of MB).
+    async with httpx.AsyncClient(verify=_SSL_CONTEXT, timeout=120, follow_redirects=True) as client:
+        resp = await client.get(url, headers={"User-Agent": user_agent})
+        resp.raise_for_status()
+        return resp.content

--- a/finance/augur/ingest/test_ingest.py
+++ b/finance/augur/ingest/test_ingest.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-import urllib.error
+import asyncio
 from datetime import UTC, datetime
 from pathlib import Path
 
+import httpx
 import pygit2
 import pytest_bazel
 
@@ -22,7 +23,7 @@ _SIG = pygit2.Signature("t", "t@t.test")
 
 
 def _constant_get(body: bytes) -> HttpGet:
-    def get(url: str, user_agent: str) -> bytes:
+    async def get(url: str, user_agent: str) -> bytes:
         return body
 
     return get
@@ -56,27 +57,51 @@ def _remote_last_message(remote: Path) -> str:
     return pygit2.Repository(str(remote)).revparse_single("main").peel(pygit2.Commit).message
 
 
-def test_write_sources_writes_each_file_by_output_filename(tmp_path: Path) -> None:
-    failures = write_sources(tmp_path, [SOURCE], http_get=_constant_get(b"payload"))
+async def test_write_sources_writes_each_file_by_output_filename(tmp_path: Path) -> None:
+    failures = await write_sources(tmp_path, [SOURCE], http_get=_constant_get(b"payload"))
     assert failures == 0
     assert (tmp_path / "fred_cpi_us.csv").read_bytes() == b"payload"
 
 
-def test_write_sources_counts_upstream_failures_and_keeps_going(tmp_path: Path) -> None:
+async def test_write_sources_counts_upstream_failures_and_keeps_going(tmp_path: Path) -> None:
     other = EvidenceSource(
         kind=EvidenceKind.YAHOO, series_id="SPY", upstream_url="https://example.test/spy", output_filename="spy.json"
     )
 
-    def get(url: str, user_agent: str) -> bytes:
+    async def get(url: str, user_agent: str) -> bytes:
         if url == SOURCE.upstream_url:
-            raise urllib.error.URLError("upstream down")
+            raise httpx.ConnectError("upstream down")
         return b"ok"
 
-    failures = write_sources(tmp_path, [SOURCE, other], http_get=get)
+    failures = await write_sources(tmp_path, [SOURCE, other], http_get=get)
     assert failures == 1
     # The failed source wrote no file; the healthy one still did.
     assert not (tmp_path / "fred_cpi_us.csv").exists()
     assert (tmp_path / "spy.json").read_bytes() == b"ok"
+
+
+async def test_write_sources_fetches_concurrently(tmp_path: Path) -> None:
+    # All sources must be in flight at once for the barrier to release; a serial fetch
+    # would block on the first party forever, so the timeout below would trip the test.
+    sources = [
+        EvidenceSource(
+            kind=EvidenceKind.FRED,
+            series_id=f"S{i}",
+            upstream_url=f"https://example.test/{i}",
+            output_filename=f"{i}.csv",
+        )
+        for i in range(4)
+    ]
+    barrier = asyncio.Barrier(len(sources))
+
+    async def get(url: str, user_agent: str) -> bytes:
+        async with asyncio.timeout(10):
+            await barrier.wait()
+        return b"ok"
+
+    failures = await write_sources(tmp_path, sources, http_get=get)
+    assert failures == 0
+    assert all((tmp_path / s.output_filename).read_bytes() == b"ok" for s in sources)
 
 
 def test_commit_and_push_skips_when_nothing_changed(tmp_path: Path) -> None:
@@ -99,12 +124,12 @@ def test_commit_and_push_commits_changed_files(tmp_path: Path) -> None:
     assert "evidence: refresh 2026-06-09" in _remote_last_message(remote)
 
 
-def test_run_scrape_clones_writes_and_pushes(tmp_path: Path) -> None:
+async def test_run_scrape_clones_writes_and_pushes(tmp_path: Path) -> None:
     remote = tmp_path / "remote.git"
     _seed_remote(remote)
 
     # depth=0 (full clone): libgit2's local file transport doesn't support shallow fetch.
-    code = run_scrape(
+    code = await run_scrape(
         str(remote), "main", [SOURCE], username="", password="", http_get=_constant_get(b"body"), now=NOW, depth=0
     )
     assert code == 0
@@ -112,14 +137,16 @@ def test_run_scrape_clones_writes_and_pushes(tmp_path: Path) -> None:
     assert _remote_blob(remote, "fred_cpi_us.csv") == b"body"
 
 
-def test_run_scrape_returns_nonzero_when_a_source_fails(tmp_path: Path) -> None:
+async def test_run_scrape_returns_nonzero_when_a_source_fails(tmp_path: Path) -> None:
     remote = tmp_path / "remote.git"
     _seed_remote(remote)
 
-    def boom(url: str, user_agent: str) -> bytes:
-        raise urllib.error.URLError("upstream down")
+    async def boom(url: str, user_agent: str) -> bytes:
+        raise httpx.ConnectError("upstream down")
 
-    assert run_scrape(str(remote), "main", [SOURCE], username="", password="", http_get=boom, now=NOW, depth=0) == 1
+    assert (
+        await run_scrape(str(remote), "main", [SOURCE], username="", password="", http_get=boom, now=NOW, depth=0) == 1
+    )
 
 
 if __name__ == "__main__":

--- a/finance/augur/ingest/trixie_evidence.lock.json
+++ b/finance/augur/ingest/trixie_evidence.lock.json
@@ -1,0 +1,161 @@
+{
+  "packages": [
+    {
+      "arch": "amd64",
+      "dependencies": [
+        {
+          "key": "debconf_1.5.91_amd64",
+          "name": "debconf",
+          "version": "1.5.91"
+        },
+        {
+          "key": "openssl_3.5.4-1_deb13u2_amd64",
+          "name": "openssl",
+          "version": "3.5.4-1~deb13u2"
+        },
+        {
+          "key": "libssl3t64_3.5.4-1_deb13u2_amd64",
+          "name": "libssl3t64",
+          "version": "3.5.4-1~deb13u2"
+        },
+        {
+          "key": "openssl-provider-legacy_3.5.4-1_deb13u2_amd64",
+          "name": "openssl-provider-legacy",
+          "version": "3.5.4-1~deb13u2"
+        },
+        {
+          "key": "libc6_2.41-12-p-deb13u1_amd64",
+          "name": "libc6",
+          "version": "2.41-12+deb13u1"
+        },
+        {
+          "key": "libgcc-s1_14.2.0-19_amd64",
+          "name": "libgcc-s1",
+          "version": "14.2.0-19"
+        },
+        {
+          "key": "gcc-14-base_14.2.0-19_amd64",
+          "name": "gcc-14-base",
+          "version": "14.2.0-19"
+        },
+        {
+          "key": "zlib1g_1-1.3.dfsg-p-really1.3.1-1-p-b1_amd64",
+          "name": "zlib1g",
+          "version": "1:1.3.dfsg+really1.3.1-1+b1"
+        },
+        {
+          "key": "libzstd1_1.5.7-p-dfsg-1_amd64",
+          "name": "libzstd1",
+          "version": "1.5.7+dfsg-1"
+        }
+      ],
+      "key": "ca-certificates_20250419_amd64",
+      "name": "ca-certificates",
+      "sha256": "ef590f89563aa4b46c8260d49d1cea0fc1b181d19e8df3782694706adf05c184",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/c/ca-certificates/ca-certificates_20250419_all.deb"
+      ],
+      "version": "20250419"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "debconf_1.5.91_amd64",
+      "name": "debconf",
+      "sha256": "1ddc7e6c5925f748eefb7ca811d98e049f18c158bb21fbc7e122262ce6011e49",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/d/debconf/debconf_1.5.91_all.deb"
+      ],
+      "version": "1.5.91"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "openssl_3.5.4-1_deb13u2_amd64",
+      "name": "openssl",
+      "sha256": "583f2881a9ed89e480d46caa3de39a6f0e174d259077a98c8b6cc3d46166e1e5",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian-security/20260301T000000Z/pool/updates/main/o/openssl/openssl_3.5.4-1~deb13u2_amd64.deb"
+      ],
+      "version": "3.5.4-1~deb13u2"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libssl3t64_3.5.4-1_deb13u2_amd64",
+      "name": "libssl3t64",
+      "sha256": "4a832fbdfc6ae292e4846eab6a6bf3687958c37ebcfd970e49169774d66d1231",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian-security/20260301T000000Z/pool/updates/main/o/openssl/libssl3t64_3.5.4-1~deb13u2_amd64.deb"
+      ],
+      "version": "3.5.4-1~deb13u2"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "openssl-provider-legacy_3.5.4-1_deb13u2_amd64",
+      "name": "openssl-provider-legacy",
+      "sha256": "69e406fb6f02261bc6ea3477fc38bab86fd66afc6d58a946e51d7832ae8c89e1",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian-security/20260301T000000Z/pool/updates/main/o/openssl/openssl-provider-legacy_3.5.4-1~deb13u2_amd64.deb"
+      ],
+      "version": "3.5.4-1~deb13u2"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libc6_2.41-12-p-deb13u1_amd64",
+      "name": "libc6",
+      "sha256": "0a51c7ba7c59b3c664b836fe33c5184e6f5a869f57e86613381e954d74282b66",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/g/glibc/libc6_2.41-12+deb13u1_amd64.deb"
+      ],
+      "version": "2.41-12+deb13u1"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libgcc-s1_14.2.0-19_amd64",
+      "name": "libgcc-s1",
+      "sha256": "3c71917b490d1a17aed43196a2787a256ecf060526cdb20216a74bedc061b150",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/g/gcc-14/libgcc-s1_14.2.0-19_amd64.deb"
+      ],
+      "version": "14.2.0-19"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "gcc-14-base_14.2.0-19_amd64",
+      "name": "gcc-14-base",
+      "sha256": "5b6825de4263824b78c4c51f6476414f3b4e89c2ab63e81dc8b9b5501e867cf6",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/g/gcc-14/gcc-14-base_14.2.0-19_amd64.deb"
+      ],
+      "version": "14.2.0-19"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "zlib1g_1-1.3.dfsg-p-really1.3.1-1-p-b1_amd64",
+      "name": "zlib1g",
+      "sha256": "015be740d6236ad114582dea500c1d907f29e16d6db00566ca32fb68d71ac90d",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/z/zlib/zlib1g_1.3.dfsg+really1.3.1-1+b1_amd64.deb"
+      ],
+      "version": "1:1.3.dfsg+really1.3.1-1+b1"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libzstd1_1.5.7-p-dfsg-1_amd64",
+      "name": "libzstd1",
+      "sha256": "2f6a2aeacfc925eba8b00ac9139bc4bfccf8cacb09eb93de067074b26948eef9",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/libz/libzstd/libzstd1_1.5.7+dfsg-1_amd64.deb"
+      ],
+      "version": "1.5.7+dfsg-1"
+    }
+  ],
+  "version": 1
+}

--- a/finance/augur/ingest/trixie_evidence.yaml
+++ b/finance/augur/ingest/trixie_evidence.yaml
@@ -1,0 +1,23 @@
+# Deb packages for the augur-evidence scraper image.
+# Only `ca-certificates` on debian:trixie-slim: pygit2 eagerly initializes
+# libgit2's OpenSSL cert locations at import time from the system trust store, so
+# without a CA bundle `import pygit2` raises GitError and the scraper never starts.
+# (libgit2 push targets in-cluster Forgejo over plain HTTP, and the upstream HTTPS
+# GETs use certifi via httpx, so certs are needed purely to satisfy pygit2's init.)
+# The Python interpreter + app come from the rules_py image layers, not from apt.
+#
+# Regenerate the lock file after any change:
+#   bazel run @trixie_evidence//:lock
+version: 1
+
+sources:
+  - channel: trixie main
+    url: https://snapshot.debian.org/archive/debian/20260301T000000Z
+  - channel: trixie-security main
+    url: https://snapshot.debian.org/archive/debian-security/20260301T000000Z
+
+archs:
+  - "amd64"
+
+packages:
+  - "ca-certificates"


### PR DESCRIPTION
## Problem

The `augur-evidence-ingest` CronJob (gaffer-private #266) has **never** successfully populated the evidence repo. Diagnosed via the live cluster — two bugs:

### 1. Image crashed at `import pygit2`
The deployed image dies on startup:
```
_pygit2.GitError: OpenSSL error: failed to load certificates
```
pygit2's `Settings()` eagerly initializes libgit2's OpenSSL cert locations from the **system trust store at import time**, but `debian-trixie-slim` ships no CA bundle. The old BUILD comment ("slim base needs nothing extra") was wrong. Fixed with a `ca-certificates` apt layer (`@trixie_evidence`), mirroring the sibling `budget-exporter` image. The certs only satisfy pygit2's init — the push targets in-cluster Forgejo over plain HTTP and the upstream GETs use certifi via httpx.

### 2. Sources fetched serially → blew the 600s deadline
11 upstreams, each up to 5×120s of retries; a couple of slow/flaky sources serialized past the Job's `activeDeadlineSeconds: 600`, so nothing ever committed. Now:
- fetch concurrently with `asyncio.gather` over an async `httpx` client;
- per-source retry budget 5→3 so one stalled upstream (~6min worst case) can't starve the deadline alone;
- partial failures still commit (one dead upstream doesn't block refreshing the rest), as requested.

## Verification (live cluster, end-to-end)
Built the image, pushed a throwaway ghcr tag, ran a manual Job in `augur`:
- all 11 sources fetched **in parallel** in **~2m50s** (vs. blowing 600s);
- FRED `SP500`/`MORTGAGE30US` hit `504`s, rode out the retry, recovered;
- 92 MB Zillow ZHVI fetched fine; refreshed evidence **pushed to `main`**.

## Follow-up (separate, not in this PR)
The augur app's **`git-sync` read sidecar is independently broken** (CrashLoopBackOff): `readOnlyRootFilesystem: true` with no writable HOME/tmp →
```
FATAL: can't create gitconfig file ... read-only file system
```
That's a one-line fix in gaffer-private `k8s/augur/deployment.yaml` (add a writable `/tmp` emptyDir + `HOME=/tmp` for the git-sync container). Filing separately.