### PR TITLE
augur evidence scraper: skip refetch when committed evidence is still fresh

### DIFF
--- a/finance/augur/ingest/fetch.py
+++ b/finance/augur/ingest/fetch.py
@@ -20,7 +20,7 @@ import os
 import sys
 import tempfile
 from collections.abc import Iterable
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pygit2
@@ -31,6 +31,17 @@ from finance.evidence.sources import EVIDENCE_SOURCES, EvidenceSource
 logger = logging.getLogger(__name__)
 
 _AUTHOR = pygit2.Signature("augur evidence scraper", "augur@allegedly.works")
+
+# Default freshness window: skip the whole refresh if HEAD (the last committed refresh) is
+# younger than this. < 24h so the daily CronJob still refreshes every day, but enough to skip
+# closely-spaced re-runs (manual triggers, retries) so they don't re-hammer the upstreams.
+DEFAULT_MAX_AGE = timedelta(hours=20)
+
+
+def _head_committed_at(repo: pygit2.Repository) -> datetime:
+    """UTC time of the tip commit — i.e. when the evidence was last refreshed."""
+    commit = repo[repo.head.target].peel(pygit2.Commit)
+    return datetime.fromtimestamp(commit.commit_time, UTC)
 
 
 async def write_sources(workdir: Path, sources: Iterable[EvidenceSource], *, http_get: HttpGet) -> int:
@@ -89,6 +100,7 @@ async def run_scrape(
     http_get: HttpGet,
     now: datetime,
     depth: int = 1,
+    max_age: timedelta | None = None,
 ) -> int:
     """Clone, refresh every source, commit-if-changed + push.
 
@@ -99,6 +111,12 @@ async def run_scrape(
     the refresh and commit on top of it, and the full history stays server-side in Forgejo.
     Tests against a local filesystem remote must pass `depth=0` (libgit2's local transport
     does not support shallow fetch).
+
+    `max_age` (when set) skips the refresh entirely if HEAD — the last committed refresh — is
+    younger than it: the committed evidence is still fresh, so re-GETting the upstreams would
+    just re-download unchanged data (and burn upstream rate limits). Every run commits all
+    sources in one commit, so HEAD's age is each file's last-change age — making this the
+    per-file commit-age check the shallow clone can't otherwise compute (no history at depth 1).
     """
     # Empty creds (tests against a local filesystem remote) clone without a credential callback.
     callbacks = (
@@ -109,6 +127,9 @@ async def run_scrape(
         repo = pygit2.clone_repository(
             git_url, str(repo_path), checkout_branch=branch, callbacks=callbacks, depth=depth
         )
+        if max_age is not None and (age := now - _head_committed_at(repo)) < max_age:
+            logger.info("evidence refreshed %s ago (< %s); skipping refetch", age, max_age)
+            return 0
         failures = await write_sources(repo_path, sources, http_get=http_get)
         commit_and_push(repo, branch, now=now, callbacks=callbacks)
     return 1 if failures else 0
@@ -120,6 +141,12 @@ async def async_main(argv: list[str] | None = None) -> int:
         "--git-url", required=True, help="Evidence repo http(s) URL (creds via GIT_USERNAME/GIT_PASSWORD)."
     )
     parser.add_argument("--branch", default="main", help="Branch to clone + push (default: main).")
+    parser.add_argument(
+        "--max-age-hours",
+        type=float,
+        default=DEFAULT_MAX_AGE.total_seconds() / 3600,
+        help="Skip the refresh if the committed evidence is younger than this many hours (0 to always refetch).",
+    )
     args = parser.parse_args(argv)
 
     return await run_scrape(
@@ -130,6 +157,7 @@ async def async_main(argv: list[str] | None = None) -> int:
         password=os.environ["GIT_PASSWORD"],
         http_get=_real_http_get,
         now=datetime.now(UTC),
+        max_age=timedelta(hours=args.max_age_hours) if args.max_age_hours > 0 else None,
     )
 
 

--- a/finance/augur/ingest/test_ingest.py
+++ b/finance/augur/ingest/test_ingest.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import httpx
@@ -55,6 +55,11 @@ def _remote_blob(remote: Path, path: str) -> bytes:
 
 def _remote_last_message(remote: Path) -> str:
     return pygit2.Repository(str(remote)).revparse_single("main").peel(pygit2.Commit).message
+
+
+def _remote_head_time(remote: Path) -> datetime:
+    commit = pygit2.Repository(str(remote)).revparse_single("main").peel(pygit2.Commit)
+    return datetime.fromtimestamp(commit.commit_time, UTC)
 
 
 async def test_write_sources_writes_each_file_by_output_filename(tmp_path: Path) -> None:
@@ -147,6 +152,55 @@ async def test_run_scrape_returns_nonzero_when_a_source_fails(tmp_path: Path) ->
     assert (
         await run_scrape(str(remote), "main", [SOURCE], username="", password="", http_get=boom, now=NOW, depth=0) == 1
     )
+
+
+async def test_run_scrape_skips_when_evidence_is_fresh(tmp_path: Path) -> None:
+    remote = tmp_path / "remote.git"
+    _seed_remote(remote)
+    fetched = False
+
+    async def get(url: str, user_agent: str) -> bytes:
+        nonlocal fetched
+        fetched = True
+        return b"body"
+
+    # HEAD committed 1h ago, max_age 20h -> still fresh, so no upstream fetch and no new commit.
+    fresh_now = _remote_head_time(remote) + timedelta(hours=1)
+    code = await run_scrape(
+        str(remote),
+        "main",
+        [SOURCE],
+        username="",
+        password="",
+        http_get=get,
+        now=fresh_now,
+        depth=0,
+        max_age=timedelta(hours=20),
+    )
+    assert code == 0
+    assert not fetched
+    assert "evidence: refresh" not in _remote_last_message(remote)
+
+
+async def test_run_scrape_refetches_when_evidence_is_stale(tmp_path: Path) -> None:
+    remote = tmp_path / "remote.git"
+    _seed_remote(remote)
+
+    # HEAD committed 48h ago, max_age 20h -> stale, so it refetches and commits.
+    stale_now = _remote_head_time(remote) + timedelta(hours=48)
+    code = await run_scrape(
+        str(remote),
+        "main",
+        [SOURCE],
+        username="",
+        password="",
+        http_get=_constant_get(b"body"),
+        now=stale_now,
+        depth=0,
+        max_age=timedelta(hours=20),
+    )
+    assert code == 0
+    assert _remote_blob(remote, "fred_cpi_us.csv") == b"body"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Adds a freshness gate to the evidence scraper's `run_scrape`: if `HEAD` (the last committed refresh) is younger than `--max-age-hours` (default **20h**), skip the whole refresh and exit 0.

Rationale: when the committed evidence is still fresh, re-GETting all 11 upstreams just re-downloads unchanged data (the 92 MB Zillow CSV, etc.) and burns upstream rate limits — we've observed FRED `504`s under repeated hits.

## Freshness signal

Per the chosen approach: **git commit age**. Since every run commits all sources in one commit, `HEAD`'s age *is* each file's last-change age — so this is effectively the per-file commit-age check, computed without history (the scraper shallow-clones at `depth=1`, so no per-file history is available).

Behavior:
- daily CronJob (runs >20h apart) → `HEAD` is >20h old → still refreshes every day;
- closely-spaced re-runs (manual triggers, retries within 20h) → skip, stop re-hammering upstreams.

## Tests

`test_run_scrape_skips_when_evidence_is_fresh` (HEAD 1h old → no fetch, no commit) and `test_run_scrape_refetches_when_evidence_is_stale` (HEAD 48h old → fetches + commits). 9/9 pass.

## Related follow-up (not in this PR)

Verified live: the pipeline now works end-to-end (repo fully populated, git-sync serving `/git/evidence`). But a transient single-upstream outage (e.g. a FRED `504`) currently makes the whole Job exit 1 → red + backoff, even though it commits the other 10 sources fine. Worth softening the exit-code contract (fail only when a source that's actually *stale* can't be refreshed) — happy to do that as a separate change.