### PR TITLE
augur evidence scraper: per-source freshness skip + stale-aware exit code

### DIFF
--- a/finance/augur/ingest/BUILD.bazel
+++ b/finance/augur/ingest/BUILD.bazel
@@ -21,6 +21,7 @@ py_library(
     deps = [
         ":http_fetch",
         "//finance/evidence:sources",
+        "@pypi//pydantic",
         "@pypi//pygit2",
     ],
 )

--- a/finance/augur/ingest/fetch.py
+++ b/finance/augur/ingest/fetch.py
@@ -3,9 +3,17 @@
 Clones the evidence repo, GETs each public source (FRED / Yahoo / Zillow) with
 its per-source User-Agent, writes each into the working tree under its
 `output_filename`, then commits-if-changed + pushes. Git provides history,
-change-detection (an unchanged upstream produces the same tree, so Zillow's
-monthly republish doesn't accrue an empty daily commit), and an atomic "latest"
-(HEAD) — no object store, no pointer protocol.
+change-detection (an unchanged upstream produces the same tree), and an atomic
+"latest" (HEAD) — no object store, no pointer protocol.
+
+A small `evidence_meta.json` manifest, committed alongside the data, records each
+source's last successful fetch time. It drives two policies the raw data files
+can't (git history isn't available — the scraper shallow-clones at depth=1):
+  * freshness skip — don't re-GET a source fetched within `max_age` (the daily run
+    still refreshes; closely-spaced re-runs stop re-hammering the upstreams);
+  * stale-aware exit — a source that fails to fetch is only a Job failure once its
+    committed copy is older than `stale_after`, so a transient single-upstream blip
+    doesn't turn the whole Job red while the other sources commit fine.
 
 Clone/commit/push go through pygit2 (libgit2); GIT_USERNAME/GIT_PASSWORD drive a
 UserPass credential callback, so no credentials are embedded in the remote URL.
@@ -20,10 +28,11 @@ import os
 import sys
 import tempfile
 from collections.abc import Iterable
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pygit2
+from pydantic import BaseModel, Field
 
 from finance.augur.ingest.http_fetch import FETCH_ERRORS, HttpGet, http_get as _real_http_get
 from finance.evidence.sources import EVIDENCE_SOURCES, EvidenceSource
@@ -32,31 +41,65 @@ logger = logging.getLogger(__name__)
 
 _AUTHOR = pygit2.Signature("augur evidence scraper", "augur@allegedly.works")
 
+EVIDENCE_META_FILENAME = "evidence_meta.json"
 
-async def write_sources(workdir: Path, sources: Iterable[EvidenceSource], *, http_get: HttpGet) -> int:
+# Skip re-GETting a source fetched within this window: its committed copy is still
+# fresh, so refetching would just re-download unchanged data and burn rate limits.
+# < 24h so the daily CronJob still refreshes every day.
+DEFAULT_MAX_AGE = timedelta(hours=20)
+
+# A source that fails to fetch is tolerated (Job stays green) until its last
+# successful fetch is older than this — long enough to ride out transient upstream
+# outages, short enough that a genuinely stuck source still surfaces.
+DEFAULT_STALE_AFTER = timedelta(days=3)
+
+
+class EvidenceManifest(BaseModel):
+    """Per-source last-successful-fetch times, committed as evidence_meta.json."""
+
+    # provenance_label (e.g. "fred:CPIAUCSL") -> last successful fetch (UTC).
+    last_fetched: dict[str, datetime] = Field(default_factory=dict)
+
+
+def _load_manifest(workdir: Path) -> EvidenceManifest:
+    path = workdir / EVIDENCE_META_FILENAME
+    return EvidenceManifest.model_validate_json(path.read_text()) if path.exists() else EvidenceManifest()
+
+
+def _write_manifest(workdir: Path, manifest: EvidenceManifest) -> None:
+    (workdir / EVIDENCE_META_FILENAME).write_text(manifest.model_dump_json(indent=2) + "\n")
+
+
+def _age_since_fetch(manifest: EvidenceManifest, source: EvidenceSource, now: datetime) -> timedelta | None:
+    """How long since `source` was last successfully fetched, or None if never recorded."""
+    last = manifest.last_fetched.get(source.provenance_label)
+    return None if last is None else now - last
+
+
+async def write_sources(workdir: Path, sources: Iterable[EvidenceSource], *, http_get: HttpGet) -> set[EvidenceSource]:
     """GET every source concurrently and write each into `workdir/<output_filename>`.
 
     Fetches run concurrently (`asyncio.gather`) so the whole set completes in roughly
     the slowest single source's time rather than the sum — the CronJob's 600s
     `activeDeadlineSeconds` can't be blown by serializing a dozen large downloads.
-    Per-source upstream failures are logged + counted, not raised (tenacity already
-    rode out transient blips, and a bounded per-source retry budget keeps any one
-    stalled upstream from eating the whole deadline), so one dead upstream doesn't
-    block committing the rest. Returns the failure count.
+    Per-source upstream failures are logged, not raised (tenacity already rode out
+    transient blips, and a bounded per-source retry budget keeps any one stalled
+    upstream from eating the whole deadline), so one dead upstream doesn't block
+    committing the rest. Returns the set of sources that failed to fetch.
     """
     sources = list(sources)
     bodies = await asyncio.gather(*(http_get(s.upstream_url, s.user_agent) for s in sources), return_exceptions=True)
-    failures = 0
+    failed: set[EvidenceSource] = set()
     for source, body in zip(sources, bodies, strict=True):
         if isinstance(body, BaseException):
             if not isinstance(body, FETCH_ERRORS):
                 raise body  # an unexpected error is a bug, not a recoverable upstream outage
             logger.warning("failed to fetch %s", source.provenance_label, exc_info=body)
-            failures += 1
+            failed.add(source)
             continue
         (workdir / source.output_filename).write_bytes(body)
         logger.info("fetched %s -> %s (%d bytes)", source.provenance_label, source.output_filename, len(body))
-    return failures
+    return failed
 
 
 def commit_and_push(
@@ -89,17 +132,22 @@ async def run_scrape(
     http_get: HttpGet,
     now: datetime,
     depth: int = 1,
+    max_age: timedelta | None = None,
+    stale_after: timedelta | None = None,
 ) -> int:
-    """Clone, refresh every source, commit-if-changed + push.
-
-    Returns a process exit code: nonzero if any source failed to fetch, so the
-    CronJob surfaces a partial outage. Sources that did fetch are still committed.
+    """Clone, refresh the due sources, commit-if-changed + push.
 
     `depth` defaults to a shallow (depth=1) clone — the scraper only needs the tip to write
     the refresh and commit on top of it, and the full history stays server-side in Forgejo.
     Tests against a local filesystem remote must pass `depth=0` (libgit2's local transport
     does not support shallow fetch).
+
+    `max_age` (when set) skips re-GETting any source last fetched within it. `stale_after`
+    (when set) decides the exit code: a source that failed to fetch only fails the Job once
+    its last successful fetch is older than `stale_after` (or was never recorded). With
+    `stale_after=None` any failed source fails the Job. Returns the process exit code.
     """
+    sources = list(sources)
     # Empty creds (tests against a local filesystem remote) clone without a credential callback.
     callbacks = (
         pygit2.RemoteCallbacks(credentials=pygit2.UserPass(username, password)) if username and password else None
@@ -109,9 +157,38 @@ async def run_scrape(
         repo = pygit2.clone_repository(
             git_url, str(repo_path), checkout_branch=branch, callbacks=callbacks, depth=depth
         )
-        failures = await write_sources(repo_path, sources, http_get=http_get)
+        manifest = _load_manifest(repo_path)
+
+        if max_age is None:
+            due = sources
+        else:
+            due = []
+            for source in sources:
+                age = _age_since_fetch(manifest, source, now)
+                if age is not None and age < max_age:
+                    logger.info("skipping %s; fetched %s ago (< %s)", source.provenance_label, age, max_age)
+                else:
+                    due.append(source)
+
+        failed = await write_sources(repo_path, due, http_get=http_get)
+        for source in due:
+            if source not in failed:
+                manifest.last_fetched[source.provenance_label] = now
+        _write_manifest(repo_path, manifest)
         commit_and_push(repo, branch, now=now, callbacks=callbacks)
-    return 1 if failures else 0
+
+        stale = {
+            source
+            for source in failed
+            if stale_after is None or (age := _age_since_fetch(manifest, source, now)) is None or age >= stale_after
+        }
+        for source in stale:
+            logger.error(
+                "source %s is stale: last fetched %s ago",
+                source.provenance_label,
+                _age_since_fetch(manifest, source, now),
+            )
+    return 1 if stale else 0
 
 
 async def async_main(argv: list[str] | None = None) -> int:
@@ -120,6 +197,19 @@ async def async_main(argv: list[str] | None = None) -> int:
         "--git-url", required=True, help="Evidence repo http(s) URL (creds via GIT_USERNAME/GIT_PASSWORD)."
     )
     parser.add_argument("--branch", default="main", help="Branch to clone + push (default: main).")
+    parser.add_argument(
+        "--max-age-hours",
+        type=float,
+        default=DEFAULT_MAX_AGE.total_seconds() / 3600,
+        help="Skip re-GETting a source fetched within this many hours (0 to always refetch).",
+    )
+    parser.add_argument(
+        "--stale-after-hours",
+        type=float,
+        default=DEFAULT_STALE_AFTER.total_seconds() / 3600,
+        help="Fail the Job only if a source that couldn't be fetched was last fetched longer ago than this "
+        "(0 to fail on any fetch miss).",
+    )
     args = parser.parse_args(argv)
 
     return await run_scrape(
@@ -130,6 +220,8 @@ async def async_main(argv: list[str] | None = None) -> int:
         password=os.environ["GIT_PASSWORD"],
         http_get=_real_http_get,
         now=datetime.now(UTC),
+        max_age=timedelta(hours=args.max_age_hours) if args.max_age_hours > 0 else None,
+        stale_after=timedelta(hours=args.stale_after_hours) if args.stale_after_hours > 0 else None,
     )
 
 

--- a/finance/augur/ingest/test_ingest.py
+++ b/finance/augur/ingest/test_ingest.py
@@ -1,14 +1,20 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import httpx
 import pygit2
 import pytest_bazel
 
-from finance.augur.ingest.fetch import commit_and_push, run_scrape, write_sources
+from finance.augur.ingest.fetch import (
+    EVIDENCE_META_FILENAME,
+    EvidenceManifest,
+    commit_and_push,
+    run_scrape,
+    write_sources,
+)
 from finance.augur.ingest.http_fetch import HttpGet
 from finance.evidence.sources import EvidenceKind, EvidenceSource
 
@@ -29,6 +35,10 @@ def _constant_get(body: bytes) -> HttpGet:
     return get
 
 
+async def _boom(url: str, user_agent: str) -> bytes:
+    raise httpx.ConnectError("upstream down")
+
+
 def _commit_all(repo: pygit2.Repository, message: str, *, push: bool = False) -> None:
     repo.index.add_all()
     repo.index.write()
@@ -39,14 +49,21 @@ def _commit_all(repo: pygit2.Repository, message: str, *, push: bool = False) ->
         repo.remotes["origin"].push(["refs/heads/main"])
 
 
-def _seed_remote(remote: Path) -> None:
+def _seed_remote(remote: Path, files: dict[str, str] | None = None) -> None:
     """Create a bare remote on `main` with one seed commit, ready for a --branch main clone."""
     pygit2.init_repository(str(remote), bare=True, initial_head="main")
     work = remote.parent / f"{remote.name}-seed"
     repo = pygit2.init_repository(str(work), initial_head="main")
     (work / ".keep").write_text("")
+    for name, content in (files or {}).items():
+        (work / name).write_text(content)
     repo.remotes.create("origin", str(remote))
     _commit_all(repo, "init", push=True)
+
+
+def _seed_with_last_fetched(remote: Path, last_fetched: dict[str, datetime]) -> None:
+    manifest = EvidenceManifest(last_fetched=last_fetched).model_dump_json()
+    _seed_remote(remote, {EVIDENCE_META_FILENAME: manifest})
 
 
 def _remote_blob(remote: Path, path: str) -> bytes:
@@ -58,12 +75,12 @@ def _remote_last_message(remote: Path) -> str:
 
 
 async def test_write_sources_writes_each_file_by_output_filename(tmp_path: Path) -> None:
-    failures = await write_sources(tmp_path, [SOURCE], http_get=_constant_get(b"payload"))
-    assert failures == 0
+    failed = await write_sources(tmp_path, [SOURCE], http_get=_constant_get(b"payload"))
+    assert failed == set()
     assert (tmp_path / "fred_cpi_us.csv").read_bytes() == b"payload"
 
 
-async def test_write_sources_counts_upstream_failures_and_keeps_going(tmp_path: Path) -> None:
+async def test_write_sources_reports_failed_sources_and_keeps_going(tmp_path: Path) -> None:
     other = EvidenceSource(
         kind=EvidenceKind.YAHOO, series_id="SPY", upstream_url="https://example.test/spy", output_filename="spy.json"
     )
@@ -73,8 +90,8 @@ async def test_write_sources_counts_upstream_failures_and_keeps_going(tmp_path: 
             raise httpx.ConnectError("upstream down")
         return b"ok"
 
-    failures = await write_sources(tmp_path, [SOURCE, other], http_get=get)
-    assert failures == 1
+    failed = await write_sources(tmp_path, [SOURCE, other], http_get=get)
+    assert failed == {SOURCE}
     # The failed source wrote no file; the healthy one still did.
     assert not (tmp_path / "fred_cpi_us.csv").exists()
     assert (tmp_path / "spy.json").read_bytes() == b"ok"
@@ -99,8 +116,8 @@ async def test_write_sources_fetches_concurrently(tmp_path: Path) -> None:
             await barrier.wait()
         return b"ok"
 
-    failures = await write_sources(tmp_path, sources, http_get=get)
-    assert failures == 0
+    failed = await write_sources(tmp_path, sources, http_get=get)
+    assert failed == set()
     assert all((tmp_path / s.output_filename).read_bytes() == b"ok" for s in sources)
 
 
@@ -133,20 +150,99 @@ async def test_run_scrape_clones_writes_and_pushes(tmp_path: Path) -> None:
         str(remote), "main", [SOURCE], username="", password="", http_get=_constant_get(b"body"), now=NOW, depth=0
     )
     assert code == 0
-    # The fetched file is now committed on the remote's main.
+    # The fetched file is now committed on the remote's main, with the fetch recorded in the manifest.
+    assert _remote_blob(remote, "fred_cpi_us.csv") == b"body"
+    manifest = EvidenceManifest.model_validate_json(_remote_blob(remote, EVIDENCE_META_FILENAME))
+    assert manifest.last_fetched[SOURCE.provenance_label] == NOW
+
+
+async def test_run_scrape_fails_on_any_miss_without_stale_policy(tmp_path: Path) -> None:
+    remote = tmp_path / "remote.git"
+    _seed_remote(remote)
+    # No stale_after -> any failed source fails the Job.
+    assert (
+        await run_scrape(str(remote), "main", [SOURCE], username="", password="", http_get=_boom, now=NOW, depth=0) == 1
+    )
+
+
+async def test_run_scrape_skips_source_fetched_within_max_age(tmp_path: Path) -> None:
+    remote = tmp_path / "remote.git"
+    _seed_with_last_fetched(remote, {SOURCE.provenance_label: NOW - timedelta(hours=1)})
+    fetched = False
+
+    async def get(url: str, user_agent: str) -> bytes:
+        nonlocal fetched
+        fetched = True
+        return b"new"
+
+    code = await run_scrape(
+        str(remote),
+        "main",
+        [SOURCE],
+        username="",
+        password="",
+        http_get=get,
+        now=NOW,
+        depth=0,
+        max_age=timedelta(hours=20),
+    )
+    assert code == 0
+    assert not fetched  # fetched 1h ago (< 20h) -> skipped
+
+
+async def test_run_scrape_refetches_source_older_than_max_age(tmp_path: Path) -> None:
+    remote = tmp_path / "remote.git"
+    _seed_with_last_fetched(remote, {SOURCE.provenance_label: NOW - timedelta(hours=48)})
+    code = await run_scrape(
+        str(remote),
+        "main",
+        [SOURCE],
+        username="",
+        password="",
+        http_get=_constant_get(b"body"),
+        now=NOW,
+        depth=0,
+        max_age=timedelta(hours=20),
+    )
+    assert code == 0
     assert _remote_blob(remote, "fred_cpi_us.csv") == b"body"
 
 
-async def test_run_scrape_returns_nonzero_when_a_source_fails(tmp_path: Path) -> None:
+async def test_run_scrape_tolerates_failure_when_committed_copy_is_fresh(tmp_path: Path) -> None:
     remote = tmp_path / "remote.git"
-    _seed_remote(remote)
-
-    async def boom(url: str, user_agent: str) -> bytes:
-        raise httpx.ConnectError("upstream down")
-
-    assert (
-        await run_scrape(str(remote), "main", [SOURCE], username="", password="", http_get=boom, now=NOW, depth=0) == 1
+    _seed_with_last_fetched(remote, {SOURCE.provenance_label: NOW - timedelta(hours=1)})
+    # max_age=None forces a fetch attempt (which fails); the 1h-old copy is < stale_after, so green.
+    code = await run_scrape(
+        str(remote),
+        "main",
+        [SOURCE],
+        username="",
+        password="",
+        http_get=_boom,
+        now=NOW,
+        depth=0,
+        max_age=None,
+        stale_after=timedelta(hours=72),
     )
+    assert code == 0
+
+
+async def test_run_scrape_fails_when_failed_source_is_stale(tmp_path: Path) -> None:
+    remote = tmp_path / "remote.git"
+    _seed_with_last_fetched(remote, {SOURCE.provenance_label: NOW - timedelta(hours=100)})
+    code = await run_scrape(
+        str(remote),
+        "main",
+        [SOURCE],
+        username="",
+        password="",
+        http_get=_boom,
+        now=NOW,
+        depth=0,
+        max_age=None,
+        stale_after=timedelta(hours=72),
+    )
+    assert code == 1  # last fetched 100h ago (> 72h) and still failing
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Supersedes #1968 (which used a coarse global HEAD-age gate). Per discussion, switches to a per-source **last-fetch manifest** so both policies are accurate per source.

## What

Adds `evidence_meta.json` (committed alongside the data) recording each source's last successful fetch time, and uses it for:

- **Freshness skip** (`--max-age-hours`, default **20h**): don't re-GET a source fetched within the window. The daily CronJob still refreshes; closely-spaced re-runs (manual triggers, retries) stop re-hammering upstreams and re-downloading the 92 MB Zillow CSV.
- **Stale-aware exit** (`--stale-after-hours`, default **72h**): a source that fails to fetch only fails the Job once its last successful fetch is older than the threshold. A transient single-upstream blip (e.g. the FRED `504`s we observed live) no longer turns the whole Job red while the other ten sources commit fine — but a genuinely stuck source still surfaces once its data goes stale.

## Why a manifest (not git commit age)

The scraper shallow-clones at `depth=1`, so per-file git history isn't available — and commit age tracks last *change*, not last *fetch* (4 sources update daily and would mask a stuck one). The manifest tracks fetch attempts directly. Cost: a small metadata commit on successful runs (the data blobs still only change when their content does).

`write_sources` now returns the **set of failed sources** (was a count) so `run_scrape` can apply the per-source staleness policy.

## Tests

11 pass, including skip-when-fresh, refetch-when-stale, tolerate-failure-when-copy-fresh, fail-when-failed-source-stale, and manifest-records-fetch.

Verified separately end-to-end on the live cluster (repo populated, git-sync serving it). Will re-verify the merged image once this lands.