### PR TITLE
ci(pre-commit): skip no-commit-to-branch on the protected-branch CI run

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -58,6 +58,11 @@ jobs:
       # ============================================================================
 
       - name: Run pre-commit
+        env:
+          # no-commit-to-branch is a local guard against committing directly to
+          # devel/main. CI deliberately runs pre-commit against the protected
+          # branch's own checkout, where that hook would always fail — skip it here.
+          SKIP: no-commit-to-branch
         run: |
           # Unset NODE_OPTIONS to avoid global-agent requirement in pre-commit's
           # isolated node environments (markdownlint-cli2 hook uses npm)


### PR DESCRIPTION
## Problem

Pre-commit CI has been **red on devel since #1966**, unrelated to any file content.

#1966 added the `no-commit-to-branch` hook (`--branch devel --branch main`) to block direct local commits to the protected branches. But the pre-commit CI job runs `pre-commit run --all-files` against the **devel checkout itself**, so that hook fires by design on every devel run:

```
don't commit to branch...................................................Failed
- hook id: no-commit-to-branch
##[error]Process completed with exit code 1.
```

It's a local commit-time guard, not a CI check — so it's an infra/config issue, not a real failure.

## Fix

`SKIP=no-commit-to-branch` on the CI pre-commit step (pre-commit's documented mechanism for this exact case). Every other hook still runs in CI; the guard still works locally on `git commit`.