### PR TITLE
loom: cross-series comparisons, 4 new series, path-shape tasks, floors

### DIFF
--- a/loom/gym/BUILD.bazel
+++ b/loom/gym/BUILD.bazel
@@ -56,11 +56,33 @@ py_library(
 )
 
 py_library(
+    name = "comparison_tasks",
+    srcs = ["comparison_tasks.py"],
+    deps = [
+        ":monthly_series",
+        ":task",
+    ],
+)
+
+py_library(
+    name = "path_tasks",
+    srcs = ["path_tasks.py"],
+    deps = [
+        ":bundle_tasks",
+        ":monthly_series",
+        ":task",
+        "@pypi//more_itertools",
+    ],
+)
+
+py_library(
     name = "series_tasks",
     srcs = ["series_tasks.py"],
     deps = [
         ":bundle_tasks",
+        ":comparison_tasks",
         ":monthly_series",
+        ":path_tasks",
         ":seed_tasks",
         ":task",
     ],
@@ -224,6 +246,30 @@ py_test(
         ":task",
         "//:conftest",
         "@pypi//more_itertools",
+        "@pypi//pytest_bazel",
+    ],
+)
+
+py_test(
+    name = "test_comparison_tasks",
+    srcs = ["test_comparison_tasks.py"],
+    deps = [
+        ":comparison_tasks",
+        ":monthly_series",
+        ":task",
+        "//:conftest",
+        "@pypi//pytest_bazel",
+    ],
+)
+
+py_test(
+    name = "test_path_tasks",
+    srcs = ["test_path_tasks.py"],
+    deps = [
+        ":monthly_series",
+        ":path_tasks",
+        ":task",
+        "//:conftest",
         "@pypi//pytest_bazel",
     ],
 )

--- a/loom/gym/bundle_tasks.py
+++ b/loom/gym/bundle_tasks.py
@@ -38,11 +38,15 @@ class BundleSpec:
     band_fractions: tuple[float, ...]
 
 
+# mortgage30/sfxrsa stay out of bundles: their floor/ceiling questions in the
+# series family already cover the interesting moves at their low volatility.
 def default_bundle_specs(series: Sequence[MonthlySeries]) -> tuple[BundleSpec, ...]:
     by_id = {one_series.series_id: one_series for one_series in series}
     return (
         BundleSpec(series=by_id["sp500"], level_multipliers=(0.95, 1.05, 1.15), band_fractions=(0.05, 0.1, 0.2)),
+        BundleSpec(series=by_id["spy"], level_multipliers=(0.95, 1.05, 1.15), band_fractions=(0.05, 0.1, 0.2)),
         BundleSpec(series=by_id["btcusd"], level_multipliers=(0.8, 1.2, 1.8), band_fractions=(0.2, 0.4, 0.8)),
+        BundleSpec(series=by_id["eth"], level_multipliers=(0.8, 1.2, 1.8), band_fractions=(0.2, 0.4, 0.8)),
         BundleSpec(series=by_id["cpi"], level_multipliers=(1.0, 1.02, 1.04), band_fractions=(0.01, 0.02, 0.04)),
     )
 

--- a/loom/gym/comparison_tasks.py
+++ b/loom/gym/comparison_tasks.py
@@ -1,0 +1,59 @@
+"""Cross-series relative questions — the era factor cancels inside each question.
+
+Each task asks whether series A gains more in percent than series B over the
+same 12-month window. Macro conditions shared by both legs (the era's overall
+direction) cancel out of the comparison, so memorized era priors help less
+than for single-series questions. All pair questions at one anchor share a
+`bundle_id`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import date
+
+from loom.gym.monthly_series import MonthlySeries, add_months, month_end
+from loom.gym.task import BinaryOutcome, BinaryQuestion, Task
+
+HORIZON_MONTHS = 12
+
+# (A, B) series ids per question: "will A out-gain B over the window?"
+PAIRS = (("btcusd", "sp500"), ("eth", "sp500"), ("eth", "btcusd"), ("sp500", "cpi"))
+
+
+def comparison_task(a: MonthlySeries, b: MonthlySeries, anchor: date) -> Task | None:
+    """The one A-vs-B task at `anchor`, or None when any of the four needed months is unobserved."""
+    target = add_months(anchor, HORIZON_MONTHS)
+    a_anchor, a_target = a.values.get(anchor), a.values.get(target)
+    b_anchor, b_target = b.values.get(anchor), b.values.get(target)
+    if a_anchor is None or a_target is None or b_anchor is None or b_target is None:
+        return None
+    return Task(
+        task_id=f"cmp-{a.series_id}-vs-{b.series_id}-{anchor:%Y-%m}-h{HORIZON_MONTHS}",
+        as_of=add_months(anchor, 1),
+        resolution_date=month_end(target),
+        question=BinaryQuestion(
+            text=(
+                f"As of {anchor:%Y-%m} the {a.description} is {a_anchor:,.2f} and the {b.description} is "
+                f"{b_anchor:,.2f}. Will the {a.description} have a greater percentage change than the "
+                f"{b.description} from {anchor:%Y-%m} to {target:%Y-%m}?"
+            )
+        ),
+        outcome=BinaryOutcome(value=a_target / a_anchor > b_target / b_anchor),
+        outcome_source=f"computed from {a.provenance} and {b.provenance}",
+        bundle_id=f"compare-bundle-{anchor:%Y-%m}",
+    )
+
+
+def comparison_tasks(
+    series: Sequence[MonthlySeries], anchor_start: date = date(2016, 3, 1), anchor_step_months: int = 3
+) -> tuple[Task, ...]:
+    by_id = {one_series.series_id: one_series for one_series in series}
+    pairs = tuple((by_id[a_id], by_id[b_id]) for a_id, b_id in PAIRS)
+    last_anchor = max(min(a.last_month(), b.last_month()) for a, b in pairs)
+    tasks: list[Task] = []
+    anchor = anchor_start
+    while anchor <= last_anchor:
+        tasks.extend(task for a, b in pairs if (task := comparison_task(a, b, anchor)) is not None)
+        anchor = add_months(anchor, anchor_step_months)
+    return tuple(tasks)

--- a/loom/gym/monthly_series.py
+++ b/loom/gym/monthly_series.py
@@ -18,7 +18,16 @@ from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 
 from finance.evidence.loading import read_monthly_levels
-from finance.evidence.sources import FRED_CPI, FRED_SP500, YAHOO_BTC, EvidenceSource
+from finance.evidence.sources import (
+    FRED_CPI,
+    FRED_MORTGAGE30,
+    FRED_SFXRSA,
+    FRED_SP500,
+    YAHOO_BTC,
+    YAHOO_ETH,
+    YAHOO_SPY,
+    EvidenceSource,
+)
 
 _HISTORY_START = date(2013, 1, 1)
 
@@ -45,6 +54,11 @@ class MonthlySeries:
         """Max value over observed months in (after, through]; None if no month is observed."""
         window = [value for month, value in self.values.items() if after < month <= through]
         return max(window) if window else None
+
+    def min_observed_between(self, after: date, through: date) -> float | None:
+        """Min value over observed months in (after, through]; None if no month is observed."""
+        window = [value for month, value in self.values.items() if after < month <= through]
+        return min(window) if window else None
 
     def last_month(self) -> date:
         return max(self.values)
@@ -77,6 +91,30 @@ SERIES_SPECS = (
         unit="index points",
         source=FRED_CPI,
     ),
+    SeriesSpec(
+        series_id="spy",
+        description="SPDR S&P 500 ETF dividend-adjusted price (last observation of the month)",
+        unit="USD",
+        source=YAHOO_SPY,
+    ),
+    SeriesSpec(
+        series_id="eth",
+        description="Ethereum price in US dollars (last observation of the month)",
+        unit="USD",
+        source=YAHOO_ETH,
+    ),
+    SeriesSpec(
+        series_id="mortgage30",
+        description="US 30-year fixed mortgage rate (FRED MORTGAGE30US)",
+        unit="percent",
+        source=FRED_MORTGAGE30,
+    ),
+    SeriesSpec(
+        series_id="sfxrsa",
+        description="S&P/Case-Shiller San Francisco home price index, seasonally adjusted",
+        unit="index points",
+        source=FRED_SFXRSA,
+    ),
 )
 
 
@@ -91,10 +129,14 @@ class KnownValue:
 # Famous month-end values; a load failing these is a bad scrape or format
 # drift, not new data. BTC's tolerance is wide because Yahoo may serve weekly
 # or monthly bars under range=max, shifting the "last observation" by days.
+# Gates exist per parser path and per series where we hold a confident
+# reference value; remaining series are covered by the parser-path gates.
 KNOWN_HISTORY = (
     KnownValue(series_id="sp500", month=date(2024, 12, 1), value=5881.63, tolerance=1.0),
     KnownValue(series_id="btcusd", month=date(2024, 12, 1), value=93429.0, tolerance=5000.0),
     KnownValue(series_id="cpi", month=date(2024, 11, 1), value=316.5, tolerance=1.0),
+    KnownValue(series_id="mortgage30", month=date(2024, 12, 1), value=6.85, tolerance=0.5),
+    KnownValue(series_id="eth", month=date(2024, 12, 1), value=3350.0, tolerance=500.0),
 )
 
 

--- a/loom/gym/path_tasks.py
+++ b/loom/gym/path_tasks.py
@@ -1,0 +1,156 @@
+"""Path-statistic questions over one series.
+
+Where the bundle families ask about window endpoints, these ask about the
+shape of the 12-month path: the realized year-over-year change bucket (CPI),
+the maximum peak-to-trough drawdown bucket (equity/crypto), and the first
+window month to cross the series' 12-month ceiling threshold. All tasks per
+(series, anchor) join the existing `{series_id}-bundle-{anchor}` bundle.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import date
+from itertools import pairwise
+
+from more_itertools import first
+
+from loom.gym.bundle_tasks import bucket_for
+from loom.gym.monthly_series import MonthlySeries, add_months, month_end
+from loom.gym.task import CategoricalOutcome, CategoricalQuestion, Task
+
+HORIZON_MONTHS = 12
+
+# Realized CPI year-over-year change bucket edges, in percent.
+_YOY_EDGES = (2.0, 3.0, 4.0)
+# Max peak-to-trough drawdown bucket edges, as fractions of the running peak.
+_DRAWDOWN_EDGES = {
+    "sp500": (0.05, 0.10, 0.20),
+    "spy": (0.05, 0.10, 0.20),
+    "btcusd": (0.15, 0.30, 0.50),
+    "eth": (0.15, 0.30, 0.50),
+}
+# First-cross threshold as a multiple of the anchor level: the series' 12-month
+# ceiling multiplier from the binary threshold family.
+_FIRST_CROSS_MULTIPLIERS = {"sp500": 1.10, "spy": 1.10, "btcusd": 1.50, "eth": 1.50}
+_FIRST_CROSS_CATEGORIES = ("months 1-3", "months 4-6", "months 7-9", "months 10-12", "never")
+
+
+def percent_bucket_labels(edges: tuple[float, ...]) -> tuple[str, ...]:
+    """`bundle_tasks.bucket_labels` for percent-valued edges — "under 5.0%" style."""
+    labels = [f"under {edges[0]:.1f}%"]
+    labels += [f"{low:.1f}% to under {high:.1f}%" for low, high in pairwise(edges)]
+    labels.append(f"at or above {edges[-1]:.1f}%")
+    return tuple(labels)
+
+
+def tasks_for_path(series: MonthlySeries, anchor: date) -> list[Task]:
+    anchor_level = series.values.get(anchor)
+    if anchor_level is None:
+        return []
+    target = add_months(anchor, HORIZON_MONTHS)
+    # Path tasks join the per-(series, anchor) bundle from bundle_tasks: same
+    # dossier, same as_of, so one bundled request elicits all of them together.
+    bundle_id = f"{series.series_id}-bundle-{anchor:%Y-%m}"
+    header = f"As of {anchor:%Y-%m} the {series.description} is {anchor_level:,.2f}."
+    source = f"computed from {series.provenance}"
+    as_of = add_months(anchor, 1)
+    resolution = month_end(target)
+
+    tasks: list[Task] = []
+    # YoY needs only the two months 12 apart; at this horizon the baseline month is the anchor itself.
+    if series.series_id == "cpi" and (target_value := series.values.get(target)) is not None:
+        yoy = (target_value / anchor_level - 1.0) * 100.0
+        labels = percent_bucket_labels(_YOY_EDGES)
+        tasks.append(
+            Task(
+                task_id=f"{bundle_id}-yoy",
+                as_of=as_of,
+                resolution_date=resolution,
+                question=CategoricalQuestion(
+                    text=(
+                        f"{header} Into which range will the year-over-year percentage change of the index "
+                        f"for {target:%Y-%m} vs {anchor:%Y-%m} fall?"
+                    ),
+                    categories=labels,
+                    ordered=True,
+                ),
+                outcome=CategoricalOutcome(category=bucket_for(yoy, _YOY_EDGES, labels)),
+                outcome_source=source,
+                bundle_id=bundle_id,
+            )
+        )
+
+    # Drawdown and first-cross are order-sensitive path statistics: any hole in
+    # the window makes them uncomputable, so those tasks are skipped entirely.
+    window: list[float] = []
+    for offset in range(1, HORIZON_MONTHS + 1):
+        if (value := series.values.get(add_months(anchor, offset))) is None:
+            return tasks
+        window.append(value)
+
+    if (drawdown_fractions := _DRAWDOWN_EDGES.get(series.series_id)) is not None:
+        peak = anchor_level
+        fractions = []
+        for value in window:
+            peak = max(peak, value)
+            fractions.append((peak - value) / peak)
+        edges = tuple(fraction * 100.0 for fraction in drawdown_fractions)
+        labels = percent_bucket_labels(edges)
+        tasks.append(
+            Task(
+                task_id=f"{bundle_id}-drawdown",
+                as_of=as_of,
+                resolution_date=resolution,
+                question=CategoricalQuestion(
+                    text=(
+                        f"{header} Consider the largest peak-to-trough decline over the months after "
+                        f"{anchor:%Y-%m} up to and including {target:%Y-%m}, with the running peak starting "
+                        f"at the {anchor:%Y-%m} value. Into which range, as a percentage of the running peak, "
+                        "will it fall?"
+                    ),
+                    categories=labels,
+                    ordered=True,
+                ),
+                outcome=CategoricalOutcome(category=bucket_for(max(fractions) * 100.0, edges, labels)),
+                outcome_source=source,
+                bundle_id=bundle_id,
+            )
+        )
+
+    if (multiplier := _FIRST_CROSS_MULTIPLIERS.get(series.series_id)) is not None:
+        threshold = round(anchor_level * multiplier, 2)
+        crossed = first((offset for offset, value in enumerate(window, start=1) if value >= threshold), default=None)
+        realized = _FIRST_CROSS_CATEGORIES[-1] if crossed is None else _FIRST_CROSS_CATEGORIES[(crossed - 1) // 3]
+        tasks.append(
+            Task(
+                task_id=f"{bundle_id}-first-cross",
+                as_of=as_of,
+                resolution_date=resolution,
+                question=CategoricalQuestion(
+                    text=(
+                        f"{header} In which window of months after {anchor:%Y-%m} (if any) will its value first "
+                        f"be at or above {threshold:,.2f}? Month 1 is {add_months(anchor, 1):%Y-%m}; the last "
+                        f"counted month, month {HORIZON_MONTHS}, is {target:%Y-%m}."
+                    ),
+                    categories=_FIRST_CROSS_CATEGORIES,
+                    ordered=True,
+                ),
+                outcome=CategoricalOutcome(category=realized),
+                outcome_source=source,
+                bundle_id=bundle_id,
+            )
+        )
+    return tasks
+
+
+def path_tasks(
+    series: Sequence[MonthlySeries], anchor_start: date = date(2016, 3, 1), anchor_step_months: int = 3
+) -> tuple[Task, ...]:
+    tasks: list[Task] = []
+    for one_series in series:
+        anchor = anchor_start
+        while anchor <= one_series.last_month():
+            tasks.extend(tasks_for_path(one_series, anchor))
+            anchor = add_months(anchor, anchor_step_months)
+    return tuple(tasks)

--- a/loom/gym/run_eval.py
+++ b/loom/gym/run_eval.py
@@ -187,6 +187,8 @@ def main() -> None:
     )
     series = list(load_series(ensure_checkout()))
     tasks = admissible_tasks(series, model_id=args.model_id, task_filter=args.task_filter, strict=args.strict)
+    if not tasks:
+        raise SystemExit(f"no admissible tasks ({args.model_id=}, {args.strict=}, {args.task_filter=})")
     print(
         f"{len(tasks)} admissible tasks for {args.model_id} "
         f"(strict={args.strict}, with_data={args.with_data}, bundled={args.bundled})"

--- a/loom/gym/series_tasks.py
+++ b/loom/gym/series_tasks.py
@@ -18,7 +18,9 @@ from dataclasses import dataclass
 from datetime import date
 
 from loom.gym.bundle_tasks import bundle_tasks
+from loom.gym.comparison_tasks import comparison_tasks
 from loom.gym.monthly_series import MonthlySeries, add_months, month_end
+from loom.gym.path_tasks import path_tasks
 from loom.gym.seed_tasks import SEED_TASKS
 from loom.gym.task import BinaryOutcome, BinaryQuestion, ScalarOutcome, ScalarQuestion, Task
 
@@ -26,17 +28,45 @@ from loom.gym.task import BinaryOutcome, BinaryQuestion, ScalarOutcome, ScalarQu
 @dataclass(frozen=True)
 class SeriesTaskSpec:
     series: MonthlySeries
-    # (horizon_months, multiplier-of-anchor-level) per binary threshold question.
+    # (horizon_months, multiplier-of-anchor-level) per binary ceiling-threshold question.
     binary_thresholds: tuple[tuple[int, float], ...]
+    # (horizon_months, multiplier-of-anchor-level below 1) per binary floor-threshold question.
+    binary_floor_thresholds: tuple[tuple[int, float], ...] = ()
     scalar_horizons: tuple[int, ...] = (6,)
 
 
 def default_specs(series: Sequence[MonthlySeries]) -> tuple[SeriesTaskSpec, ...]:
     by_id = {one_series.series_id: one_series for one_series in series}
     return (
-        SeriesTaskSpec(series=by_id["sp500"], binary_thresholds=((6, 1.05), (12, 1.10))),
-        SeriesTaskSpec(series=by_id["btcusd"], binary_thresholds=((6, 1.25), (12, 1.50))),
-        SeriesTaskSpec(series=by_id["cpi"], binary_thresholds=((6, 1.02), (12, 1.035))),
+        SeriesTaskSpec(
+            series=by_id["sp500"],
+            binary_thresholds=((3, 1.03), (6, 1.05), (12, 1.10), (24, 1.20)),
+            binary_floor_thresholds=((12, 0.90),),
+            scalar_horizons=(3, 6, 24),
+        ),
+        SeriesTaskSpec(
+            series=by_id["spy"], binary_thresholds=((6, 1.05), (12, 1.10)), binary_floor_thresholds=((12, 0.90),)
+        ),
+        SeriesTaskSpec(
+            series=by_id["btcusd"],
+            binary_thresholds=((3, 1.15), (6, 1.25), (12, 1.50), (24, 2.0)),
+            binary_floor_thresholds=((12, 0.70),),
+            scalar_horizons=(3, 6, 24),
+        ),
+        SeriesTaskSpec(
+            series=by_id["eth"], binary_thresholds=((6, 1.25), (12, 1.50)), binary_floor_thresholds=((12, 0.70),)
+        ),
+        SeriesTaskSpec(
+            series=by_id["cpi"],
+            binary_thresholds=((3, 1.01), (6, 1.02), (12, 1.035), (24, 1.07)),
+            scalar_horizons=(3, 6, 24),
+        ),
+        SeriesTaskSpec(
+            series=by_id["mortgage30"],
+            binary_thresholds=((6, 1.10), (12, 1.20)),
+            binary_floor_thresholds=((6, 0.90), (12, 0.85)),
+        ),
+        SeriesTaskSpec(series=by_id["sfxrsa"], binary_thresholds=((12, 1.05),), binary_floor_thresholds=((12, 0.95),)),
     )
 
 
@@ -90,6 +120,29 @@ def tasks_for_spec(spec: SeriesTaskSpec, anchor_start: date, anchor_step_months:
                     outcome_source=f"computed from {series.provenance}",
                 )
             )
+
+        for horizon, multiplier in spec.binary_floor_thresholds:
+            through = add_months(anchor, horizon)
+            if through > last_month:
+                continue
+            threshold = round(anchor_level * multiplier, 2)
+            if (observed_min := series.min_observed_between(after=anchor, through=through)) is None:
+                continue
+            tasks.append(
+                Task(
+                    task_id=f"{series.series_id}-le-{multiplier}x-{anchor:%Y-%m}-h{horizon}",
+                    as_of=as_of,
+                    resolution_date=month_end(through),
+                    question=BinaryQuestion(
+                        text=(
+                            f"{header} Will it be at or below {threshold:,.2f} for any month after "
+                            f"{anchor:%Y-%m}, up to and including {through:%Y-%m}?"
+                        )
+                    ),
+                    outcome=BinaryOutcome(value=observed_min <= threshold),
+                    outcome_source=f"computed from {series.provenance}",
+                )
+            )
         anchor = add_months(anchor, anchor_step_months)
     return tasks
 
@@ -105,4 +158,4 @@ def series_tasks(
 
 
 def all_tasks(series: Sequence[MonthlySeries]) -> tuple[Task, ...]:
-    return SEED_TASKS + series_tasks(series) + bundle_tasks(series)
+    return SEED_TASKS + series_tasks(series) + bundle_tasks(series) + path_tasks(series) + comparison_tasks(series)

--- a/loom/gym/test_comparison_tasks.py
+++ b/loom/gym/test_comparison_tasks.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from datetime import date
+
+import pytest_bazel
+
+from loom.gym.comparison_tasks import comparison_task, comparison_tasks
+from loom.gym.monthly_series import MonthlySeries, add_months
+from loom.gym.task import BinaryOutcome
+
+
+def _series(series_id: str, values: dict[date, float]) -> MonthlySeries:
+    return MonthlySeries(
+        series_id=series_id,
+        description=f"test {series_id}",
+        unit="units",
+        provenance=f"synthetic {series_id}",
+        values=values,
+    )
+
+
+def test_outcome_compares_percentage_changes() -> None:
+    # A gains 10%, B gains 5% → A out-gains B; with the legs swapped the answer flips.
+    a = _series("btcusd", {date(2020, 1, 1): 100.0, date(2021, 1, 1): 110.0})
+    b = _series("sp500", {date(2020, 1, 1): 200.0, date(2021, 1, 1): 210.0})
+    task = comparison_task(a, b, anchor=date(2020, 1, 1))
+    assert task is not None
+    assert task.task_id == "cmp-btcusd-vs-sp500-2020-01-h12"
+    assert task.bundle_id == "compare-bundle-2020-01"
+    assert task.as_of == date(2020, 2, 1)
+    assert task.resolution_date == date(2021, 1, 31)
+    # Both anchor levels are stated in the question.
+    assert "100.00" in task.question.text
+    assert "200.00" in task.question.text
+    assert task.outcome == BinaryOutcome(value=True)
+    assert task.outcome_source == "computed from synthetic btcusd and synthetic sp500"
+
+    swapped = comparison_task(b, a, anchor=date(2020, 1, 1))
+    assert swapped is not None
+    assert swapped.outcome == BinaryOutcome(value=False)
+
+
+def test_missing_month_yields_no_task() -> None:
+    a = _series("btcusd", {date(2020, 1, 1): 100.0})  # +12m target month missing
+    b = _series("sp500", {date(2020, 1, 1): 200.0, date(2021, 1, 1): 210.0})
+    assert comparison_task(a, b, anchor=date(2020, 1, 1)) is None
+
+
+def test_comparison_tasks_grid_and_bundles() -> None:
+    # 16 months of data: anchors 2020-01 and 2020-04 have +12m targets; all four pairs emit at each.
+    months = {add_months(date(2020, 1, 1), n): 100.0 + n for n in range(16)}
+    series = [_series(series_id, months) for series_id in ("btcusd", "sp500", "eth", "cpi")]
+    tasks = comparison_tasks(series, anchor_start=date(2020, 1, 1), anchor_step_months=3)
+    assert len(tasks) == 8
+    assert len({task.task_id for task in tasks}) == 8
+    assert {task.bundle_id for task in tasks} == {"compare-bundle-2020-01", "compare-bundle-2020-04"}
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/loom/gym/test_path_tasks.py
+++ b/loom/gym/test_path_tasks.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import date
+
+import pytest_bazel
+
+from loom.gym.monthly_series import MonthlySeries, add_months
+from loom.gym.path_tasks import path_tasks, tasks_for_path
+from loom.gym.task import CategoricalOutcome, CategoricalQuestion
+
+ANCHOR = date(2020, 1, 1)
+
+
+def _series(series_id: str, levels: Sequence[float | None]) -> MonthlySeries:
+    """Monthly levels from 2020-01; None makes a hole (unobserved month)."""
+    return MonthlySeries(
+        series_id=series_id,
+        description=f"test {series_id}",
+        unit="units",
+        provenance="synthetic",
+        values={add_months(ANCHOR, n): level for n, level in enumerate(levels) if level is not None},
+    )
+
+
+# 14 months 2020-01..2021-02: peak 110 in 2020-03, trough 95 in 2020-04
+# ((110 - 95) / 110 = 13.6% drawdown), then a recovery that stays below the peak.
+DIP = _series(
+    "sp500", [100.0, 105.0, 110.0, 95.0, 100.0, 101.0, 102.0, 103.0, 104.0, 105.0, 106.0, 107.0, 108.0, 109.0]
+)
+
+
+def test_dip_drawdown_and_first_cross_buckets() -> None:
+    tasks = {task.task_id: task for task in tasks_for_path(DIP, anchor=ANCHOR)}
+    assert set(tasks) == {"sp500-bundle-2020-01-drawdown", "sp500-bundle-2020-01-first-cross"}
+    assert all(task.bundle_id == "sp500-bundle-2020-01" for task in tasks.values())
+    assert all(task.as_of == date(2020, 2, 1) for task in tasks.values())
+    assert all(task.resolution_date == date(2021, 1, 31) for task in tasks.values())
+    drawdown = tasks["sp500-bundle-2020-01-drawdown"]
+    assert drawdown.outcome == CategoricalOutcome(category="10.0% to under 20.0%")
+    drawdown_question = drawdown.question
+    assert isinstance(drawdown_question, CategoricalQuestion)
+    assert drawdown_question.ordered
+    assert drawdown_question.categories == (
+        "under 5.0%",
+        "5.0% to under 10.0%",
+        "10.0% to under 20.0%",
+        "at or above 20.0%",
+    )
+    # 2020-03 (window month 2) is the first month at or above the 1.10x threshold (110.00).
+    assert tasks["sp500-bundle-2020-01-first-cross"].outcome == CategoricalOutcome(category="months 1-3")
+
+
+def test_ramp_first_cross_and_never() -> None:
+    # The ramp from 100 by +2/month first reaches the 1.10x threshold (110.00) at window month 5.
+    ramp = _series("sp500", [100.0 + 2 * n for n in range(14)])
+    tasks = {task.task_id: task for task in tasks_for_path(ramp, anchor=ANCHOR)}
+    assert tasks["sp500-bundle-2020-01-first-cross"].outcome == CategoricalOutcome(category="months 4-6")
+    # A monotone ramp never declines from its running peak.
+    assert tasks["sp500-bundle-2020-01-drawdown"].outcome == CategoricalOutcome(category="under 5.0%")
+
+    flat = _series("sp500", [100.0] * 14)
+    flat_tasks = {task.task_id: task for task in tasks_for_path(flat, anchor=ANCHOR)}
+    assert flat_tasks["sp500-bundle-2020-01-first-cross"].outcome == CategoricalOutcome(category="never")
+
+
+def test_yoy_from_12m_apart_values() -> None:
+    # YoY needs only the two months 12 apart: 102.5 / 100.0 → +2.5%, even though
+    # every month in between is missing (so no other path task is emitted).
+    cpi = _series("cpi", [100.0] + [None] * 11 + [102.5])
+    (task,) = tasks_for_path(cpi, anchor=ANCHOR)
+    assert task.task_id == "cpi-bundle-2020-01-yoy"
+    assert task.bundle_id == "cpi-bundle-2020-01"
+    assert task.outcome == CategoricalOutcome(category="2.0% to under 3.0%")
+    question = task.question
+    assert isinstance(question, CategoricalQuestion)
+    assert question.ordered
+    assert question.categories == ("under 2.0%", "2.0% to under 3.0%", "3.0% to under 4.0%", "at or above 4.0%")
+    assert "2021-01 vs 2020-01" in question.text
+
+
+def test_window_hole_skips_drawdown_and_first_cross() -> None:
+    # 2020-07 (window month 6) is missing → the order-sensitive path statistics are uncomputable.
+    holed = _series("sp500", [100.0, 105.0, 110.0, 95.0, 100.0, 101.0, None, 103.0, 104.0, 105.0, 106.0, 107.0, 108.0])
+    assert tasks_for_path(holed, anchor=ANCHOR) == []
+
+
+def test_missing_target_month_skips_yoy() -> None:
+    assert tasks_for_path(_series("cpi", [100.0, 101.0]), anchor=ANCHOR) == []
+
+
+def test_path_tasks_iterates_anchor_grid() -> None:
+    # Only the 2020-01 anchor has a full 12-month window within DIP's 14 months.
+    tasks = path_tasks([DIP], anchor_start=ANCHOR, anchor_step_months=3)
+    assert {task.task_id for task in tasks} == {"sp500-bundle-2020-01-drawdown", "sp500-bundle-2020-01-first-cross"}
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/loom/gym/test_series_tasks.py
+++ b/loom/gym/test_series_tasks.py
@@ -6,7 +6,7 @@ import pytest_bazel
 
 from loom.gym.monthly_series import MonthlySeries, add_months, month_end
 from loom.gym.series_tasks import SeriesTaskSpec, tasks_for_spec
-from loom.gym.task import BinaryOutcome, ScalarOutcome
+from loom.gym.task import BinaryOutcome, ScalarOutcome, Task
 
 # Linear ramp 100, 102, ... over 2020-01..2020-12 with a hole at 2020-05
 # (mimics the BLS Oct-2025 CPI gap).
@@ -18,6 +18,23 @@ RAMP = MonthlySeries(
     values={add_months(date(2020, 1, 1), n): 100.0 + 2 * n for n in range(12) if n != 4},
 )
 
+# Linear decline 100, 98, ... over 2020-01..2020-12.
+DECLINE = MonthlySeries(
+    series_id="decline",
+    description="test decline",
+    unit="units",
+    provenance="synthetic",
+    values={add_months(date(2020, 1, 1), n): 100.0 - 2 * n for n in range(12)},
+)
+
+FLAT = MonthlySeries(
+    series_id="flat",
+    description="test flat",
+    unit="units",
+    provenance="synthetic",
+    values={add_months(date(2020, 1, 1), n): 100.0 for n in range(12)},
+)
+
 
 def test_month_arithmetic() -> None:
     assert add_months(date(2024, 11, 1), 2) == date(2025, 1, 1)
@@ -27,6 +44,34 @@ def test_month_arithmetic() -> None:
 def test_max_observed_skips_holes() -> None:
     # Window (2020-03, 2020-06] contains the 2020-05 hole; max is over observed months only.
     assert RAMP.max_observed_between(after=date(2020, 3, 1), through=date(2020, 6, 1)) == 110.0
+
+
+def test_min_observed_skips_holes() -> None:
+    # Window (2020-03, 2020-06] contains the 2020-05 hole; min is over observed months only.
+    assert RAMP.min_observed_between(after=date(2020, 3, 1), through=date(2020, 6, 1)) == 106.0
+
+
+def test_floor_threshold_outcomes() -> None:
+    # The decline reaches 88 by +6m, at or below the 0.9x floor (90) → YES; the flat series never dips → NO.
+    def floor_task(series: MonthlySeries) -> Task:
+        spec = SeriesTaskSpec(
+            series=series, binary_thresholds=(), binary_floor_thresholds=((6, 0.9),), scalar_horizons=()
+        )
+        (task,) = tasks_for_spec(spec, anchor_start=date(2020, 1, 1), anchor_step_months=12)
+        return task
+
+    decline_task = floor_task(DECLINE)
+    assert decline_task.task_id == "decline-le-0.9x-2020-01-h6"
+    assert "at or below 90.00" in decline_task.question.text
+    assert decline_task.outcome == BinaryOutcome(value=True)
+    assert floor_task(FLAT).outcome == BinaryOutcome(value=False)
+
+
+def test_scalar_horizon_emission() -> None:
+    spec = SeriesTaskSpec(series=RAMP, binary_thresholds=(), scalar_horizons=(3,))
+    (task,) = tasks_for_spec(spec, anchor_start=date(2020, 1, 1), anchor_step_months=12)
+    assert task.task_id == "ramp-level-2020-01-h3"
+    assert task.outcome == ScalarOutcome(value=106.0)
 
 
 def test_generated_outcomes_match_series() -> None:


### PR DESCRIPTION
Gym task-family expansion (trimmed scope — companions: plans merged via #1972; dump mirroring in #1973; the timestamped-evidence schema + curated market panel are parked on `claude/exciting-mendel-mqugwo-market-evidence` for later revival).

- **Cross-series comparison tasks** (`comparison_tasks.py`): h12 return comparisons for (BTC, S&P), (ETH, S&P), (ETH, BTC), (S&P, CPI) — era cancels inside them, highest information per token.
- **4 new evidence series**: SPY (dividend-adjusted), ETH, 30y mortgage rate, Case-Shiller SF — with known-history load gates.
- **Path-shape tasks** (`path_tasks.py`): CPI YoY buckets, drawdown-exceedance (equity 5/10/20%, crypto 15/30/50%), first-cross quarters (ordinal, with "never"); merged into the existing per-(series, anchor) bundles.
- **Floor thresholds + horizon spread** in the series family (h3/h24; `le` floor questions).
- **`run_eval`**: fail early with a clear message when zero tasks are admissible (previously `ZeroDivisionError`).

https://claude.ai/code/session_01RksV17NqcuP742fWgDU9AW