### PR TITLE
loom: Manifold dump mirroring — cluster Job + streaming dump readers

### DIFF
--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -336,5 +336,8 @@ resources:
   - seaweedfs/monitoring/flux-kustomization.yaml
   - seaweedfs-csi/flux-kustomization.yaml
 
+  # --- loom forecasting gym (dataset mirror into loom-gym bucket) ---
+  - loom-harvest/flux-kustomization.yaml
+
   # --- VM image publisher (in-cluster builder + S3 uploader) ---
   - vm-images-publisher/flux-kustomization.yaml

--- a/cluster/k8s/loom-harvest/flux-kustomization.yaml
+++ b/cluster/k8s/loom-harvest/flux-kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: loom-harvest
+  namespace: flux-system
+spec:
+  interval: 10m
+  retryInterval: 2m
+  path: ./cluster/k8s/loom-harvest
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  dependsOn:
+    - name: seaweedfs-loom-gym-bucket
+      namespace: flux-system
+    - name: seaweedfs-secrets
+      namespace: flux-system
+  # wait covers Job completion: ~1.2 GB Firebase download on a fresh mirror.
+  wait: true
+  timeout: 15m

--- a/cluster/k8s/loom-harvest/job.yaml
+++ b/cluster/k8s/loom-harvest/job.yaml
@@ -1,0 +1,56 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: manifold-dump-mirror
+  namespace: loom-harvest
+  annotations:
+    # Script changes roll the hashed ConfigMap name into the (immutable) pod
+    # template; force lets Flux recreate the Job so the new script actually runs.
+    kustomize.toolkit.fluxcd.io/force: enabled
+spec:
+  backoffLimit: 4
+  template:
+    metadata:
+      labels:
+        app: manifold-dump-mirror
+    spec:
+      restartPolicy: OnFailure
+      # Run next to the SeaweedFS volume servers (OVH).
+      nodeSelector:
+        topology.kubernetes.io/zone: hil-ovh
+      containers:
+        - name: mirror
+          image: curlimages/curl:8.10.1
+          command: [sh, /config/mirror-manifold.sh]
+          env:
+            - name: S3_ENDPOINT
+              value: http://seaweedfs-s3.seaweedfs.svc:8333
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: s3-identity-loom-harvest
+                  key: accessKey
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: s3-identity-loom-harvest
+                  key: secretKey
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              memory: 512Mi
+          volumeMounts:
+            - name: config
+              mountPath: /config
+              readOnly: true
+            - name: work
+              mountPath: /work
+      volumes:
+        - name: config
+          configMap:
+            name: manifold-dump-mirror-config
+        - name: work
+          emptyDir:
+            sizeLimit: 2Gi

--- a/cluster/k8s/loom-harvest/kustomization.yaml
+++ b/cluster/k8s/loom-harvest/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - job.yaml
+configMapGenerator:
+  - name: manifold-dump-mirror-config
+    namespace: loom-harvest
+    files:
+      - mirror-manifold.sh
+      - manifold-20240706.sha256
+      - manifold-20240706-readme.md

--- a/cluster/k8s/loom-harvest/manifold-20240706-readme.md
+++ b/cluster/k8s/loom-harvest/manifold-20240706-readme.md
@@ -1,0 +1,13 @@
+# Manifold Markets full-site dump mirror (snapshot 2024-07-06)
+
+Source: <https://docs.manifold.markets/data> (Firebase trade-dumps), mirrored 2026-06-09.
+License: personal/academic/non-commercial use only; commercial or
+AI-training-for-commercial use requires a license from <data@manifold.markets>.
+Used here for the loom forecasting gym's market-resolved eval tasks
+(see ducktape `loom/plans/market_harvest.md`).
+
+```text
+63671168210deda1d96ba6c9e3d7fd1bb1bcd2a5a564c561f56ea12f5bceb8b7  manifold-contracts-20240706.json.zip
+cb9d2ecddb9ab23d7f123a7be7875b41d839bbd5142dff7b518c062181ab06f0  manifold-comments-20240706.json.zip
+521d8f4363edfd930bf9e47f66499e2731f51685555064835b204a25c0613da9  manifold-dump-bets-04072024.json.zip
+```

--- a/cluster/k8s/loom-harvest/manifold-20240706.sha256
+++ b/cluster/k8s/loom-harvest/manifold-20240706.sha256
@@ -1,0 +1,3 @@
+63671168210deda1d96ba6c9e3d7fd1bb1bcd2a5a564c561f56ea12f5bceb8b7  manifold-contracts-20240706.json.zip
+cb9d2ecddb9ab23d7f123a7be7875b41d839bbd5142dff7b518c062181ab06f0  manifold-comments-20240706.json.zip
+521d8f4363edfd930bf9e47f66499e2731f51685555064835b204a25c0613da9  manifold-dump-bets-04072024.json.zip

--- a/cluster/k8s/loom-harvest/mirror-manifold.sh
+++ b/cluster/k8s/loom-harvest/mirror-manifold.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+# Mirror the 2024-07-06 Manifold Markets full-site dump (contracts, comments,
+# bets) from Firebase into s3://loom-gym/harvest/raw/manifold-20240706/.
+#
+# Idempotent: objects already in the bucket (HEAD 200) are skipped, so reruns
+# after the initial mirror are cheap verifications. Downloads are checked
+# against the pinned sha256 manifest before upload — if Firebase ever serves
+# different bytes, the Job fails instead of silently replacing the snapshot.
+set -eu
+
+S3_PREFIX="${S3_ENDPOINT}/loom-gym/harvest/raw/manifold-20240706"
+FIREBASE_BASE="https://firebasestorage.googleapis.com/v0/b/mantic-markets.appspot.com/o/trade-dumps%2F"
+
+s3curl() {
+  curl --fail --silent --show-error --aws-sigv4 "aws:amz:us-east-1:s3" \
+    --user "${AWS_ACCESS_KEY_ID}:${AWS_SECRET_ACCESS_KEY}" "$@"
+}
+
+# A non-HTTP failure (DNS, refused connection) also reports "absent" here; the
+# subsequent upload then fails loudly, so real S3 outages still fail the Job.
+object_exists() {
+  s3curl --head --output /dev/null "${S3_PREFIX}/$1" 2>/dev/null
+}
+
+put_if_absent() {
+  if object_exists "$2"; then
+    echo "=== $2: already mirrored, skipping"
+  else
+    echo "=== $2: uploading"
+    s3curl --upload-file "$1" "${S3_PREFIX}/$2"
+  fi
+}
+
+# Dump files are ~1.2 GB combined; handle one at a time and delete after
+# upload so peak /work usage stays around the largest single file (~1 GB).
+while read -r sha256 name; do
+  if object_exists "${name}"; then
+    echo "=== ${name}: already mirrored, skipping"
+    continue
+  fi
+  echo "=== ${name}: downloading from Firebase"
+  curl --fail --silent --show-error --output "/work/${name}" "${FIREBASE_BASE}${name}?alt=media"
+  echo "${sha256}  /work/${name}" | sha256sum -c -
+  echo "=== ${name}: uploading"
+  s3curl --upload-file "/work/${name}" "${S3_PREFIX}/${name}"
+  rm "/work/${name}"
+done </config/manifold-20240706.sha256
+
+put_if_absent /config/manifold-20240706-readme.md README.md
+put_if_absent /config/manifold-20240706.sha256 checksums.sha256
+echo "=== mirror complete"

--- a/cluster/k8s/loom-harvest/namespace.yaml
+++ b/cluster/k8s/loom-harvest/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: loom-harvest
+  annotations:
+    description: >-
+      Declarative mirror Jobs that copy external forecasting datasets
+      (prediction-market dumps) into the loom-gym S3 bucket.

--- a/cluster/k8s/seaweedfs/loom-gym-bucket/bucket.yaml
+++ b/cluster/k8s/seaweedfs/loom-gym-bucket/bucket.yaml
@@ -12,3 +12,5 @@ spec:
   access:
     - user: claude-reader
       actions: [Read, Write, List, Tagging]
+    - user: loom-harvest
+      actions: [Read, Write, List, Tagging]

--- a/cluster/k8s/seaweedfs/secrets/identities/loom-harvest.sops.yaml
+++ b/cluster/k8s/seaweedfs/secrets/identities/loom-harvest.sops.yaml
@@ -1,0 +1,98 @@
+# SeaweedFS s3 identity for "loom-harvest": the declarative mirror Job in the
+# loom-harvest namespace that copies external forecasting datasets (Manifold
+# dumps) into the loom-gym bucket. Reflected into loom-harvest so the Job can
+# read the keys.
+apiVersion: v1
+kind: Secret
+metadata:
+    name: s3-identity-loom-harvest
+    namespace: seaweedfs
+    labels:
+        seaweedfs.io/role: s3-identity
+    annotations:
+        reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+        reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: loom-harvest
+        reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+        reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: loom-harvest
+type: Opaque
+stringData:
+    name: loom-harvest
+    actions: Read:loom-gym,Write:loom-gym,List:loom-gym,Tagging:loom-gym
+    accessKey: ENC[AES256_GCM,data:Ea6cqYjkCNbei16UL2SzLtOI6U6Vngu7jx7xWRwdXA==,iv:STUx5auMqa5ef0N2vDp+5CEHDOKI85ri42Z2m65nsNQ=,tag:cYQ7ikIh60C4wKsLNdScRQ==,type:str]
+    secretKey: ENC[AES256_GCM,data:NXPxXsFqcly6dYsCpNqaEXYQ/ukmf7TcsM1ryr8vYvmkOQ5TSEmQzbxo21UwjsfPIWWQyITayc4LPMEhbIt5vA==,iv:dfeZXjEjs6K8wAbTb+mRlK+VMG5YDfx/+SG5ofyJbG0=,tag:rhfWj01NkzuP2qtpaX719A==,type:str]
+sops:
+    age:
+        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSMmhJdkJHNXFiUi83dGlH
+            ME9nMHdhYm81eGU4SWRucVo0ME51MlV0Vm1NCi8weXc2a0EydlkxbFBzLzdSQ1FD
+            MVcva09mRTl2OXlGRGg3b2EyLzJRU2MKLS0tIE5CdEUzVkVOeXhVK0o4SDA3VTUx
+            S2llUTVQeG9YUDJ1K1FVbHlERlVjVTgK3Pws8+HQ439ffvQVnl4WdHmmKKAnugb8
+            PYTm7aNj7fRSkwu1f45nOdMu92LvhZFQw6mRe+/Wq0XREe+iSHRjHw==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1nywlwepsyfxvyhqwkjquzz02nmus65gf6qewfjju4alym8f7se5qnua8na
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBINWEwb2RyM0lCazdaamZh
+            ajdINmpWOTBySFJxN283a25UUzR1YmMwN3pVCjkyUGxxNkgzT01iZWJwbEZRNEpD
+            MHc5Q09jM0dJT0lUclBFQVpKZTkvbkkKLS0tIFU4RDIyenY3QUNPTFdwQTdYdDdH
+            Um1seXpPVnN6UUorNjVBL2ZOLzRGU2sKfP/ncXqJ4Q8C3vnGKZisxkANttCpzF8Y
+            znR6m40X/HQDBRXAxuq+rQTPLQZCl9ljrFb5YwxoNj43kCiwf6rf3w==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-06-10T01:06:00Z"
+    mac: ENC[AES256_GCM,data:NQo+7OcGNGSJUrV7NvckPHHzR8kgtu34D/0d6ZQBvYyTNbxmq+4Jnu8NLvGG2ym4zza/+xtpvXdbabyEXS56ul0/4VFvXBV9tTeQnuEc7A/96PE5vtoJWjpAUFVFkpuPnAf2afGVojMwae8X35Q1/hKk9NRbymRckWa3/ZqwDn4=,iv:Vk0qCxlNh1gFgOsgKmlkBVnmusR9e9NMXzacaLx/Czs=,tag:AM1GBaF5t1jAvZsdfFV2Kg==,type:str]
+    encrypted_regex: ^(accessKey|secretKey)$
+    version: 3.12.1
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+    name: s3-identity-loom-harvest-json
+    namespace: seaweedfs
+    labels:
+        seaweedfs.io/role: s3-identity-json
+spec:
+    refreshInterval: 1m
+    secretStoreRef:
+        kind: SecretStore
+        name: seaweedfs-identities
+    target:
+        name: s3-identity-loom-harvest-json
+        template:
+            type: Opaque
+            data:
+                identity: |
+                    {"name":"{{ .name }}",
+                     "credentials":[{"accessKey":"{{ .accessKey }}","secretKey":"{{ .secretKey }}"}],
+                     "actions":[{{- $first := true -}}
+                       {{- range splitList "," .actions -}}
+                       {{- if not $first }},{{ end -}}"{{ . }}"{{- $first = false -}}
+                       {{- end }}]}
+    dataFrom:
+        - extract:
+            key: s3-identity-loom-harvest
+sops:
+    age:
+        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSMmhJdkJHNXFiUi83dGlH
+            ME9nMHdhYm81eGU4SWRucVo0ME51MlV0Vm1NCi8weXc2a0EydlkxbFBzLzdSQ1FD
+            MVcva09mRTl2OXlGRGg3b2EyLzJRU2MKLS0tIE5CdEUzVkVOeXhVK0o4SDA3VTUx
+            S2llUTVQeG9YUDJ1K1FVbHlERlVjVTgK3Pws8+HQ439ffvQVnl4WdHmmKKAnugb8
+            PYTm7aNj7fRSkwu1f45nOdMu92LvhZFQw6mRe+/Wq0XREe+iSHRjHw==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1nywlwepsyfxvyhqwkjquzz02nmus65gf6qewfjju4alym8f7se5qnua8na
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBINWEwb2RyM0lCazdaamZh
+            ajdINmpWOTBySFJxN283a25UUzR1YmMwN3pVCjkyUGxxNkgzT01iZWJwbEZRNEpD
+            MHc5Q09jM0dJT0lUclBFQVpKZTkvbkkKLS0tIFU4RDIyenY3QUNPTFdwQTdYdDdH
+            Um1seXpPVnN6UUorNjVBL2ZOLzRGU2sKfP/ncXqJ4Q8C3vnGKZisxkANttCpzF8Y
+            znR6m40X/HQDBRXAxuq+rQTPLQZCl9ljrFb5YwxoNj43kCiwf6rf3w==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-06-10T01:06:00Z"
+    mac: ENC[AES256_GCM,data:NQo+7OcGNGSJUrV7NvckPHHzR8kgtu34D/0d6ZQBvYyTNbxmq+4Jnu8NLvGG2ym4zza/+xtpvXdbabyEXS56ul0/4VFvXBV9tTeQnuEc7A/96PE5vtoJWjpAUFVFkpuPnAf2afGVojMwae8X35Q1/hKk9NRbymRckWa3/ZqwDn4=,iv:Vk0qCxlNh1gFgOsgKmlkBVnmusR9e9NMXzacaLx/Czs=,tag:AM1GBaF5t1jAvZsdfFV2Kg==,type:str]
+    encrypted_regex: ^(accessKey|secretKey)$
+    version: 3.12.1

--- a/cluster/k8s/seaweedfs/secrets/kustomization.yaml
+++ b/cluster/k8s/seaweedfs/secrets/kustomization.yaml
@@ -15,5 +15,6 @@ resources:
   - identities/langfuse.sops.yaml
   - identities/listing-monitor-captures.sops.yaml
   - identities/loki.sops.yaml
+  - identities/loom-harvest.sops.yaml
   - identities/tempo.sops.yaml
   - identities/mimir.sops.yaml

--- a/loom/harvest/BUILD.bazel
+++ b/loom/harvest/BUILD.bazel
@@ -1,0 +1,21 @@
+load("//devinfra/python:defs.bzl", "py_library", "py_test")
+
+py_library(
+    name = "manifold_dump",
+    srcs = ["manifold_dump.py"],
+    deps = [
+        "@pypi//more_itertools",
+        "@pypi//pydantic",
+    ],
+)
+
+py_test(
+    name = "test_manifold_dump",
+    srcs = ["test_manifold_dump.py"],
+    deps = [
+        ":manifold_dump",
+        "//:conftest",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
+    ],
+)

--- a/loom/harvest/manifold_dump.py
+++ b/loom/harvest/manifold_dump.py
@@ -1,0 +1,173 @@
+"""Typed streaming readers for the Manifold Markets full-site dump (2024-07-06 snapshot).
+
+The dump (https://docs.manifold.markets/data) is three zips — contracts,
+comments, bets — each containing a single member that is one large JSON array
+(the bets array is ~6.8 GB uncompressed). Records are decoded incrementally
+straight from the compressed stream; nothing is extracted to disk or held in
+memory beyond one record plus a read buffer.
+
+Models keep only the fields the gym harvest needs and use snake_case names
+aliased to the dump's camelCase keys. Timestamps stay epoch-milliseconds as in
+the dump; convert with `ms_to_datetime`.
+
+License: the dump is personal/academic/non-commercial use only (commercial use
+requires a license from data@manifold.markets); see the mirror's README at
+s3://loom-gym/harvest/raw/manifold-20240706/README.md.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from collections.abc import Iterable, Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import IO
+
+from more_itertools import one
+from pydantic import BaseModel, ConfigDict, Field
+
+_CHUNK_SIZE = 8 << 20
+
+
+def ms_to_datetime(ms: int) -> datetime:
+    """Convert a dump epoch-milliseconds timestamp to an aware UTC datetime."""
+    return datetime.fromtimestamp(ms / 1000, tz=UTC)
+
+
+def tiptap_plain_text(node: object) -> str:
+    """Flatten a TipTap JSON document to plain text (paragraph/heading breaks become newlines)."""
+    if not isinstance(node, dict):
+        return ""
+    parts: list[str] = []
+    if node.get("type") == "text":
+        parts.append(str(node.get("text", "")))
+    content = node.get("content")
+    if isinstance(content, list):
+        parts.extend(tiptap_plain_text(child) for child in content)
+    if node.get("type") in ("paragraph", "heading"):
+        parts.append("\n")
+    return "".join(parts)
+
+
+class ContractRecord(BaseModel):
+    """One market. `resolution`/`resolution_time` are absent for unresolved markets."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: str
+    question: str
+    outcome_type: str = Field(alias="outcomeType")
+    created_time: int = Field(alias="createdTime", description="Epoch ms.")
+    resolution: str | None = Field(default=None, description='For binary markets: "YES"/"NO"/"CANCEL"/"MKT".')
+    resolution_time: int | None = Field(default=None, alias="resolutionTime", description="Epoch ms.")
+    unique_bettor_count: int = Field(alias="uniqueBettorCount")
+    description: str | dict[str, object] = Field(
+        description="Plain string on pre-2022 markets, TipTap JSON document otherwise."
+    )
+
+    def description_text(self) -> str:
+        if isinstance(self.description, str):
+            return self.description
+        return tiptap_plain_text(self.description)
+
+
+class CommentRecord(BaseModel):
+    """One comment; the body is either plain `text` (old) or a TipTap `content` document (new)."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    contract_id: str = Field(alias="contractId")
+    created_time: int = Field(alias="createdTime", description="Epoch ms.")
+    user_name: str = Field(alias="userName")
+    text: str | None = None
+    content: dict[str, object] | None = None
+
+    def body_text(self) -> str:
+        if self.text is not None:
+            return self.text
+        return tiptap_plain_text(self.content)
+
+
+class BetRecord(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    contract_id: str = Field(alias="contractId")
+    created_time: int = Field(alias="createdTime", description="Epoch ms.")
+    prob_after: float = Field(alias="probAfter")
+
+
+def iter_json_array(reader: IO[str], chunk_size: int = _CHUNK_SIZE) -> Iterator[object]:
+    """Incrementally yield elements of a JSON array read from `reader`.
+
+    Raises `json.JSONDecodeError` on malformed input and `ValueError` on
+    truncation (EOF before the closing bracket).
+    """
+    decoder = json.JSONDecoder()
+    buf = reader.read(chunk_size)
+    head = buf.lstrip()
+    if not head.startswith("["):
+        raise ValueError(f"not a JSON array: starts with {head[:20]!r}")
+    pos = len(buf) - len(head) + 1
+    while True:
+        # Skip inter-element whitespace and commas, refilling the buffer at its end.
+        while True:
+            while pos < len(buf) and buf[pos] in " \t\r\n,":
+                pos += 1
+            if pos < len(buf):
+                break
+            buf = reader.read(chunk_size)
+            if not buf:
+                raise ValueError("truncated JSON array: EOF before closing bracket")
+            pos = 0
+        if buf[pos] == "]":
+            return
+        try:
+            element, pos = decoder.raw_decode(buf, pos)
+        except json.JSONDecodeError:
+            # Element may straddle the buffer edge: refill and retry; re-raise at EOF.
+            chunk = reader.read(chunk_size)
+            if not chunk:
+                raise
+            buf = buf[pos:] + chunk
+            pos = 0
+            continue
+        yield element
+        if pos > chunk_size:
+            buf = buf[pos:]
+            pos = 0
+
+
+def _iter_zip_records(zip_path: Path) -> Iterator[object]:
+    """Stream JSON-array records from the single member of a dump zip."""
+    with zipfile.ZipFile(zip_path) as dump_zip, dump_zip.open(one(dump_zip.namelist())) as raw:
+        yield from iter_json_array(io.TextIOWrapper(raw, encoding="utf-8"))
+
+
+def iter_contracts(zip_path: Path) -> Iterator[ContractRecord]:
+    for record in _iter_zip_records(zip_path):
+        yield ContractRecord.model_validate(record)
+
+
+def iter_comments(zip_path: Path) -> Iterator[CommentRecord]:
+    for record in _iter_zip_records(zip_path):
+        yield CommentRecord.model_validate(record)
+
+
+def iter_bets(zip_path: Path) -> Iterator[BetRecord]:
+    for record in _iter_zip_records(zip_path):
+        yield BetRecord.model_validate(record)
+
+
+def prob_at(bets: Iterable[BetRecord], when: datetime) -> float | None:
+    """`probAfter` of the last bet at/before `when`, or None if no bet that early.
+
+    The reconstruction rule verified in loom/plans/market_harvest.md: sort bets
+    by createdTime, take the last bet at/before the cutoff, read its probAfter.
+    """
+    cutoff_ms = when.timestamp() * 1000
+    eligible = [bet for bet in bets if bet.created_time <= cutoff_ms]
+    if not eligible:
+        return None
+    return max(eligible, key=lambda bet: bet.created_time).prob_after

--- a/loom/harvest/test_manifold_dump.py
+++ b/loom/harvest/test_manifold_dump.py
@@ -1,0 +1,168 @@
+"""Hermetic tests for the dump readers, against fixture zips built from real record shapes."""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+import pytest_bazel
+
+from loom.harvest.manifold_dump import (
+    BetRecord,
+    iter_bets,
+    iter_comments,
+    iter_contracts,
+    iter_json_array,
+    ms_to_datetime,
+    prob_at,
+    tiptap_plain_text,
+)
+
+# Field shapes mirror real records from the 2024-07-06 dump (truncated to the relevant fields).
+RESOLVED_CONTRACT = {
+    "id": "a3k1RgxAVYiAU1qeA5Su",
+    "question": "January 2024: Will Bitcoin hit $50,000?",
+    "outcomeType": "BINARY",
+    "createdTime": 1704225194859,
+    "resolution": "NO",
+    "resolutionTime": 1706860865370,
+    "uniqueBettorCount": 277,
+    "isResolved": True,  # extra field: must be ignored
+    "description": {
+        "type": "doc",
+        "content": [
+            {
+                "type": "paragraph",
+                "content": [
+                    {"type": "text", "text": "If in January 2024 at least one 30min "},
+                    {"type": "text", "text": "Coingecko", "marks": [{"type": "link", "attrs": {"href": "x"}}]},
+                    {"type": "text", "text": " candle hits $50,000, this resolves YES."},
+                ],
+            }
+        ],
+    },
+}
+OPEN_CONTRACT = {
+    "id": "will-bitcoin-be-worth-more",
+    "question": "Will Bitcoin be worth more than $60,000?",
+    "outcomeType": "BINARY",
+    "createdTime": 1639779118231,
+    "uniqueBettorCount": 37,
+    "description": "Plain old string description",
+}
+TEXT_COMMENT = {
+    "contractId": "a3k1RgxAVYiAU1qeA5Su",
+    "createdTime": 1641280475468,
+    "userName": "Austin",
+    "text": "What a #meta question!",
+    "betAmount": 10,  # extra field: must be ignored
+}
+TIPTAP_COMMENT = {
+    "contractId": "a3k1RgxAVYiAU1qeA5Su",
+    "createdTime": 1704630000000,
+    "userName": "uair01",
+    "content": {
+        "type": "doc",
+        "content": [
+            {"type": "paragraph", "content": [{"type": "text", "text": "Interesting critique,"}]},
+            {"type": "paragraph", "content": [{"type": "text", "text": "feel free to disagree."}]},
+        ],
+    },
+}
+
+
+def _bet(created_time: int, prob_after: float) -> dict[str, object]:
+    return {
+        "contractId": "a3k1RgxAVYiAU1qeA5Su",
+        "createdTime": created_time,
+        "probAfter": prob_after,
+        "probBefore": 0.5,  # extra field: must be ignored
+        "amount": 100,
+    }
+
+
+def _fixture_zip(tmp_path: Path, member: str, records: list[dict[str, object]]) -> Path:
+    zip_path = tmp_path / f"{member}.zip"
+    with zipfile.ZipFile(zip_path, "w") as fixture:
+        fixture.writestr(member, json.dumps(records, indent=2))
+    return zip_path
+
+
+def test_iter_json_array_streams_across_chunk_boundaries() -> None:
+    records = [{"name": f"record-{n}", "value": n} for n in range(50)]
+    # chunk_size far smaller than one record forces every refill path.
+    assert list(iter_json_array(io.StringIO(json.dumps(records)), chunk_size=7)) == records
+
+
+def test_iter_json_array_empty_and_whitespace() -> None:
+    assert list(iter_json_array(io.StringIO("  [ ]  "), chunk_size=3)) == []
+
+
+def test_iter_json_array_rejects_non_array() -> None:
+    with pytest.raises(ValueError, match="not a JSON array"):
+        list(iter_json_array(io.StringIO('{"a": 1}')))
+
+
+def test_iter_json_array_rejects_truncation() -> None:
+    with pytest.raises(ValueError, match="truncated"):
+        list(iter_json_array(io.StringIO('[{"a": 1}, {"b": 2}'), chunk_size=5))
+    with pytest.raises(json.JSONDecodeError):
+        list(iter_json_array(io.StringIO('[{"a": 1}, {"b":'), chunk_size=5))
+
+
+def test_iter_contracts_parses_resolved_and_open(tmp_path: Path) -> None:
+    zip_path = _fixture_zip(tmp_path, "contracts.json", [RESOLVED_CONTRACT, OPEN_CONTRACT])
+    resolved, opened = iter_contracts(zip_path)
+    assert resolved.id == "a3k1RgxAVYiAU1qeA5Su"
+    assert (resolved.outcome_type, resolved.resolution, resolved.unique_bettor_count) == ("BINARY", "NO", 277)
+    assert ms_to_datetime(resolved.created_time) == datetime(2024, 1, 2, 19, 53, 14, 859000, tzinfo=UTC)
+    assert resolved.resolution_time is not None
+    assert ms_to_datetime(resolved.resolution_time).date() == datetime(2024, 2, 2, tzinfo=UTC).date()
+    assert "Coingecko candle hits $50,000" in resolved.description_text()
+    assert opened.resolution is None
+    assert opened.resolution_time is None
+    assert opened.description_text() == "Plain old string description"
+
+
+def test_iter_comments_handles_text_and_tiptap_bodies(tmp_path: Path) -> None:
+    zip_path = _fixture_zip(tmp_path, "comments.json", [TEXT_COMMENT, TIPTAP_COMMENT])
+    plain, tiptap = iter_comments(zip_path)
+    assert (plain.user_name, plain.body_text()) == ("Austin", "What a #meta question!")
+    assert tiptap.user_name == "uair01"
+    assert tiptap.body_text() == "Interesting critique,\nfeel free to disagree.\n"
+
+
+def test_tiptap_plain_text_of_non_document() -> None:
+    assert tiptap_plain_text(None) == ""
+
+
+def test_iter_bets_and_prob_at(tmp_path: Path) -> None:
+    zip_path = _fixture_zip(tmp_path, "bets.json", [_bet(1000, 0.3), _bet(3000, 0.7), _bet(2000, 0.5)])
+    bets = list(iter_bets(zip_path))
+    assert [bet.prob_after for bet in bets] == [0.3, 0.7, 0.5]
+    assert all(bet.contract_id == "a3k1RgxAVYiAU1qeA5Su" for bet in bets)
+
+    def at(ms: int) -> datetime:
+        return datetime.fromtimestamp(ms / 1000, tz=UTC)
+
+    # Last bet at/before the cutoff wins regardless of input order; an exact-time bet counts.
+    assert prob_at(bets, at(2500)) == 0.5
+    assert prob_at(bets, at(3000)) == 0.7
+    assert prob_at(bets, at(999)) is None
+
+
+def test_prob_at_empty() -> None:
+    assert prob_at([], datetime(2024, 1, 15, tzinfo=UTC)) is None
+
+
+def test_bet_record_round_trip() -> None:
+    bet = BetRecord.model_validate({"contractId": "abc", "createdTime": 1000, "probAfter": 0.42})
+    assert (bet.contract_id, bet.created_time, bet.prob_after) == ("abc", 1000, 0.42)
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()


### PR DESCRIPTION
**On hold (draft)** — parked per program priorities: the dump backfill serves old-model-window task volume, which isn't on the critical path; the live-API mirror (in progress separately) covers current needs.

Everything that exists solely for mirroring/reading the 2024-07-06 Manifold full-site dump (split out of #1971).

- **`cluster/k8s/loom-harvest/`**: new namespace + Job running an idempotent mirror script via `configMapGenerator` — per file: HEAD-check against the bucket (skip if present), download from Firebase, verify against the pinned sha256 manifest (fails loudly if Firebase ever serves different bytes), upload via the internal SeaweedFS gateway, one file at a time so peak scratch stays ~1 GB in a 2 Gi emptyDir. The hashed ConfigMap name flows into the pod template and `kustomize.toolkit.fluxcd.io/force` lets Flux recreate the immutable Job on script changes.
- **`s3-identity-loom-harvest`**: dedicated SeaweedFS identity scoped to `Read/Write/List/Tagging` on `loom-gym` only, reflected into the `loom-harvest` namespace; registered in the secrets kustomization and granted on the Bucket CRD.
- Flux kustomization depends on `seaweedfs-loom-gym-bucket` + `seaweedfs-secrets`, `wait: true` (covers the ~1.2 GB cold download; 15m timeout).
- **`loom/harvest/manifold_dump.py`**: typed streaming readers for the mirrored dump zips (contracts/comments/bets — bets streamed, never extracted) plus `prob_at(bets, when)`; hermetic fixture tests. The archive source for bulk old-model-window task minting later (market_harvest.md H1).

The bucket is already populated from the verified imperative run (`s3://loom-gym/harvest/raw/manifold-20240706/`, checksums match this manifest byte-for-byte), so the Job's first reconcile is a cheap all-skip verification.

https://claude.ai/code/session_01RksV17NqcuP742fWgDU9AW