### PR TITLE
wayback-cache: shared pull-through cache for the Internet Archive (W1)

### DIFF
--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -288,6 +288,9 @@ resources:
   - proxmox-proxy/flux-kustomization.yaml
   - proxmox-proxy/agent-rbac/flux-kustomization.yaml
 
+  # --- wayback-cache ---
+  - wayback-cache/flux-kustomization.yaml
+
   # --- user-agentydragon ---
   - user-agentydragon/flux-kustomization.yaml
 

--- a/cluster/k8s/wayback-cache/config/nginx.conf
+++ b/cluster/k8s/wayback-cache/config/nginx.conf
@@ -1,0 +1,95 @@
+# Shared pull-through cache for the Internet Archive Wayback Machine.
+# See loom/plans/wayback_proxy.md. Two tiers:
+#   tier 1 (:8080)          — PVC-backed proxy_cache; hits never touch IA.
+#   tier 2 (127.0.0.1:8081) — loopback-only; every request reaching it is by
+#                             construction a cold miss, so a single limit_req
+#                             bucket paces exactly the traffic IA sees.
+# The cache is deliberately dumb: any path forwards verbatim to
+# web.archive.org (CDX queries and /web/<ts>id_/ fetches alike). Date
+# clamping is the per-agent wayback proxy's job (loom/wayback_proxy/).
+# Workers must run as nginx (uid/gid 101): the deployment's fsGroup makes the
+# /cache PVC group-writable for exactly that gid.
+user nginx;
+worker_processes auto;
+error_log /dev/stderr warn;
+
+events {
+    worker_connections 256;
+}
+
+http {
+    access_log /dev/stdout;
+
+    # Snapshot bytes at a fixed 14-digit timestamp are immutable.
+    # use_temp_path=off avoids cross-filesystem renames onto the PVC.
+    proxy_cache_path /cache levels=1:2 keys_zone=wayback:64m max_size=18g
+                     inactive=3650d use_temp_path=off;
+
+    limit_req_zone $server_name zone=ia_upstream:1m rate=30r/m;
+
+    # DNS resolved once at nginx startup; the Recreate deployment strategy
+    # means a pod restart re-resolves if IA rotates IPs.
+    upstream ia {
+        server web.archive.org:443;
+        keepalive 8;
+    }
+
+    server { # tier 1: PVC-backed cache
+        listen 8080;
+
+        proxy_cache wayback;
+        proxy_cache_key $request_uri;
+        proxy_cache_lock on; # collapse concurrent identical misses
+        # Lock timeouts must ride out tier-2 limit_req delays
+        # (burst 60 at 30r/m queues up to ~120s).
+        proxy_cache_lock_timeout 300s;
+        proxy_cache_lock_age 300s;
+        proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+        proxy_read_timeout 300s;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        add_header X-Wayback-Cache $upstream_cache_status always;
+
+        # /web/<ts>id_/<url> snapshot bytes: immutable -> ~forever. Cached
+        # 302s are IA timestamp-canonicalization, equally stable. 404s are
+        # cached briefly so transient IA flakiness doesn't stick.
+        location / {
+            proxy_cache_valid 200 302 3650d;
+            proxy_cache_valid 404 1h;
+            proxy_pass http://127.0.0.1:8081;
+        }
+
+        # CDX index queries are NOT immutable: IA backfills old crawls and
+        # applies takedowns retroactively. A 7d staleness bound keeps repeat
+        # lookups off IA while still tracking the index; the per-run
+        # evidence manifest — not this cache — is the reproducibility record.
+        location /cdx/ {
+            proxy_cache_valid 200 7d;
+            proxy_pass http://127.0.0.1:8081;
+        }
+    }
+
+    server { # tier 2: loopback-only, rate-limited hop to IA
+        listen 127.0.0.1:8081;
+        server_name wayback-upstream;
+
+        location / {
+            limit_req zone=ia_upstream burst=60; # delays up to 60 queued, then 503
+
+            proxy_pass https://ia;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_set_header Host web.archive.org;
+            proxy_set_header User-Agent "ducktape-wayback-cache/1 (+agentydragon@gmail.com)";
+            # Deterministic bytes: no content-encoding variants in the cache,
+            # so per-agent evidence sha256s are stable.
+            proxy_set_header Accept-Encoding "identity";
+            proxy_ssl_server_name on;
+            proxy_ssl_name web.archive.org;
+            proxy_ssl_verify on;
+            proxy_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
+            proxy_connect_timeout 10s;
+            proxy_read_timeout 60s;
+        }
+    }
+}

--- a/cluster/k8s/wayback-cache/deployment.yaml
+++ b/cluster/k8s/wayback-cache/deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wayback-cache
+  namespace: wayback-cache
+  labels:
+    app.kubernetes.io/name: wayback-cache
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: wayback-cache
+  strategy:
+    type: Recreate # RWO PVC; restart also re-resolves web.archive.org DNS
+  template:
+    metadata:
+      annotations:
+        reloader.stakater.com/auto: "true"
+      labels:
+        app.kubernetes.io/name: wayback-cache
+    spec:
+      nodeSelector:
+        topology.kubernetes.io/region: proxmox
+      securityContext:
+        # nginx:alpine workers run as uid/gid 101; make the PVC writable.
+        fsGroup: 101
+      containers:
+        - name: nginx
+          image: docker.io/library/nginx:alpine
+          ports:
+            - containerPort: 8080
+              name: http
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+              readOnly: true
+            - name: cache
+              mountPath: /cache
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          # Probes hit tier 1, which serves cache hits without touching the
+          # IA rate limiter — limit_req delays cannot fail probes.
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 2
+            periodSeconds: 5
+      volumes:
+        - name: config
+          configMap:
+            name: wayback-cache-config
+        - name: cache
+          persistentVolumeClaim:
+            claimName: wayback-cache-data

--- a/cluster/k8s/wayback-cache/flux-kustomization.yaml
+++ b/cluster/k8s/wayback-cache/flux-kustomization.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: wayback-cache
+  namespace: flux-system
+spec:
+  retryInterval: 1m
+  interval: 10m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./cluster/k8s/wayback-cache
+  prune: true
+  wait: true
+  healthChecks:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: wayback-cache
+      namespace: wayback-cache
+  dependsOn:
+    - name: openebs-lvm

--- a/cluster/k8s/wayback-cache/kustomization.yaml
+++ b/cluster/k8s/wayback-cache/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml
+
+configMapGenerator:
+  - name: wayback-cache-config
+    namespace: wayback-cache
+    files:
+      - config/nginx.conf

--- a/cluster/k8s/wayback-cache/namespace.yaml
+++ b/cluster/k8s/wayback-cache/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: wayback-cache
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"
+    goldilocks.fairwinds.com/vpa-update-mode: "auto"

--- a/cluster/k8s/wayback-cache/pvc.yaml
+++ b/cluster/k8s/wayback-cache/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: wayback-cache-data
+  namespace: wayback-cache
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: lvm-proxmox-hdd
+  resources:
+    requests:
+      storage: 20Gi # nginx max_size=18g + metadata headroom

--- a/cluster/k8s/wayback-cache/service.yaml
+++ b/cluster/k8s/wayback-cache/service.yaml
@@ -1,0 +1,16 @@
+# ClusterIP only, deliberately: the gateway only exposes public hostnames,
+# and a publicly reachable pull-through cache would be an open relay to
+# web.archive.org. Dev access: kubectl port-forward.
+apiVersion: v1
+kind: Service
+metadata:
+  name: wayback-cache
+  namespace: wayback-cache
+spec:
+  selector:
+    app.kubernetes.io/name: wayback-cache
+  ports:
+    - port: 8080
+      targetPort: 8080
+      protocol: TCP
+      name: http


### PR DESCRIPTION
W1 of [loom/plans/wayback_proxy.md](https://github.com/agentydragon/ducktape/blob/devel/loom/plans/wayback_proxy.md): the shared pull-through cache for the Internet Archive, cluster manifests only (the per-agent clamping proxy + demo compose live on `claude/gallant-euler-1lv89g` and follow separately).

**What's in here** — `cluster/k8s/wayback-cache/` (+ root kustomization registration):

- Two-tier nginx: tier 1 serves from a PVC-backed `proxy_cache` (immutable `/web/<ts>id_/` snapshot bytes cached 3650d, CDX results 7d, `proxy_cache_lock` collapses concurrent misses); tier 2 is loopback-only, so every request reaching it is by construction a cold miss — its `limit_req` bucket (30r/m, burst 60, delay-then-503) paces exactly the traffic IA sees, while cache hits are never throttled.
- Upstream hop sets a contact `User-Agent`, `Accept-Encoding: identity` (byte-stable evidence sha256s), TLS verification against the system CA bundle.
- `ClusterIP` only, deliberately: the gateway only exposes public hostnames and an open IA relay is undesirable. Dev access via `kubectl port-forward`; in-cluster consumers use `http://wayback-cache.wayback-cache.svc.cluster.local:8080`.
- 20Gi `lvm-proxmox-hdd` PVC (nginx `max_size=18g` + headroom), proxmox-region nodeSelector, `fsGroup: 101` + explicit `user nginx;` so cache writes work on the fresh PVC.
- Flux kustomization `dependsOn: openebs-lvm`, healthCheck on the Deployment.

**Validation:** kustomize render ✓, kubeconform ✓, `nginx -t` inside `nginx:alpine` ✓ (also confirms uid/gid 101 and the CA bundle path in that image). The cache has already been exercised end-to-end by the per-agent proxy's RBE e2e + live-IA tests on the feature branch (proxy → upstream contract).

**Post-merge check:** `flux get kustomization wayback-cache`; then two identical fetches through the service — second response must carry `X-Wayback-Cache: HIT`.

https://claude.ai/code/session_01C92Haj75EreshnVNLaFVMz

---
_Generated by [Claude Code](https://claude.ai/code/session_01C92Haj75EreshnVNLaFVMz)_