### PR TITLE
loom/wayback_proxy: per-agent date-clamping proxy + demo compose

### DIFF
--- a/loom/plans/wayback_proxy.md
+++ b/loom/plans/wayback_proxy.md
@@ -1,6 +1,15 @@
 # Wayback proxy: date-clamped web access for contestants
 
-Status: **plan** (direction approved 2026-06-10; build pending go-ahead).
+Status: **in progress** (direction approved 2026-06-10). W1 landed:
+`cluster/k8s/wayback-cache/` (ClusterIP-only — the gateway is public-only and
+an open IA relay is undesirable; dev access via `kubectl port-forward`). W2
+partially landed: per-agent proxy + demo compose + e2e at
+<../wayback_proxy/>; Inspect/gym wiring still pending. The proxy is the
+mini-implementation, not a WaybackProxy fork — upstream's selection is
+nearest-capture (can serve post-date content within `DATE_TOLERANCE`), its
+in-band settings page can change the date at runtime from the client side,
+CONNECT is fake-accepted, and the upstream host is hardcoded; hardening all
+that approximated writing the clamped proxy directly.
 
 ## Goal
 
@@ -88,10 +97,11 @@ fetch them — and browse outward from them — rather than only reading titles.
 
 ## Phasing
 
-- **W1**: deploy `wayback-cache` (drafted manifests).
-- **W2**: per-agent proxy image (WaybackProxy fork or mini-implementation) +
-  Inspect compose wiring + `as_of` env plumbing; mockllm e2e test on RBE that
-  fetches a known snapshot through the full chain.
+- **W1** ✅: deploy `wayback-cache` (`cluster/k8s/wayback-cache/`).
+- **W2** (proxy + demo compose ✅; Inspect wiring pending): per-agent proxy
+  image (mini-implementation, `loom/wayback_proxy/`) + Inspect compose wiring
+  - `as_of` env plumbing; mockllm e2e test on RBE that fetches a known
+    snapshot through the full chain.
 - **W3**: served-evidence manifest → run payload → S3.
 - **W4** (optional): HTTPS MITM; text-extraction convenience endpoint for
   dossier-style consumption.

--- a/loom/wayback_proxy/BUILD.bazel
+++ b/loom/wayback_proxy/BUILD.bazel
@@ -1,0 +1,123 @@
+load("@aspect_rules_py//py:defs.bzl", "py_image_layer", aspect_py_binary = "py_binary")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
+load("//devinfra/oci:defs.bzl", "oci_layout_rloc")
+load("//devinfra/python:defs.bzl", "py_binary", "py_library", "py_test")
+load("//props:oci.bzl", "py_image_entrypoint", "py_image_env")
+
+py_library(
+    name = "proxy",
+    srcs = ["proxy.py"],
+    deps = ["@pypi//aiohttp"],
+)
+
+py_binary(
+    name = "wayback_proxy",
+    main_module = "loom.wayback_proxy.proxy",
+    deps = [":proxy"],
+)
+
+py_library(
+    name = "fake_ia",
+    testonly = True,
+    srcs = ["fake_ia.py"],
+    deps = ["@pypi//aiohttp"],
+)
+
+py_test(
+    name = "test_proxy",
+    srcs = ["test_proxy.py"],
+    deps = [
+        ":fake_ia",
+        ":proxy",
+        "//:conftest",
+        "@pypi//aiohttp",
+        "@pypi//pytest",
+        "@pypi//pytest_asyncio",  # runtime dep: conftest sets asyncio_mode="auto"
+        "@pypi//pytest_bazel",
+    ],
+)
+
+# Live smoke against the real Internet Archive; run on demand, never in CI
+# ("manual" keeps it out of wildcard builds, "external" disables caching).
+py_test(
+    name = "test_live_ia",
+    srcs = ["test_live_ia.py"],
+    tags = [
+        "external",
+        "manual",
+    ],
+    deps = [
+        ":proxy",
+        "//:conftest",
+        "@pypi//aiohttp",
+        "@pypi//pytest",
+        "@pypi//pytest_asyncio",  # runtime dep: conftest sets asyncio_mode="auto"
+        "@pypi//pytest_bazel",
+    ],
+)
+
+# ── OCI image (pattern: x/grocy_mcp/BUILD.bazel) ─────────────────────────────
+
+aspect_py_binary(
+    name = "proxy_bin",
+    main = "proxy.py",
+    deps = [":proxy"],
+)
+
+py_image_layer(
+    name = "proxy_layers",
+    binary = ":proxy_bin",
+    group = "1000",
+    owner = "1000",
+)
+
+oci_image(
+    name = "image",
+    base = "@debian_slim_linux_amd64",
+    entrypoint = py_image_entrypoint("proxy_bin"),
+    env = py_image_env(binary_name = "proxy_bin"),
+    labels = {"org.opencontainers.image.source": "https://github.com/agentydragon/ducktape"},
+    tars = [":proxy_layers"],
+    user = "1000:1000",
+)
+
+oci_load(
+    name = "load",
+    image = ":image",
+    repo_tags = ["wayback-proxy:latest"],
+)
+
+oci_layout_rloc(
+    name = "image_info",
+    testonly = True,
+    image = ":image",
+)
+
+filegroup(
+    name = "compose",
+    srcs = ["compose.yaml"],
+)
+
+py_test(
+    name = "test_compose_e2e",
+    size = "large",
+    srcs = ["test_compose_e2e.py"],
+    data = [
+        ":compose",
+        ":image_info",
+        "//third_party/containers:python_3_13_slim",
+    ],
+    requires_docker = True,
+    deps = [
+        ":fake_ia",
+        "//:conftest",
+        "//third_party/containers:rlocations",
+        "//util:oci",
+        "//util/bazel:runfiles",
+        "//util/testing:undeclared_outputs",
+        "@pypi//aiohttp",
+        "@pypi//pytest",
+        "@pypi//pytest_asyncio",  # runtime dep: conftest sets asyncio_mode="auto"
+        "@pypi//pytest_bazel",
+    ],
+)

--- a/loom/wayback_proxy/README.md
+++ b/loom/wayback_proxy/README.md
@@ -1,0 +1,75 @@
+# Wayback proxy — date-clamped web access for sandboxed agents
+
+The per-agent "time machine" from the [wayback proxy plan](../plans/wayback_proxy.md):
+a plain-HTTP forward proxy that answers every URL with the newest Internet
+Archive capture at-or-before `WAYBACK_AS_OF`, served as raw `id_` bytes. No
+capture at or before the cutoff → 404. Explicit `web.archive.org/web/<ts>/…`
+requests are clamped (`ts ≤ as_of`), CDX queries get their `to=` bound
+clamped, redirect hops are re-clamped (IA canonicalizes toward the _closest_
+capture, which can walk forward in time), and CONNECT is refused — agents use
+`http://` URLs (IA serves the same snapshot regardless of the original
+scheme). Every served response is logged as a JSONL evidence line
+`{url, capture_ts, sha256, size}` on stdout.
+
+`compose.yaml` is the demo the gym sandbox builds on: the `agent` container
+sits on an `internal: true` network with **no internet route** — its only
+reachable peer is the proxy sidecar.
+
+## Demo
+
+```bash
+bazelisk run //loom/wayback_proxy:load   # build + docker-load wayback-proxy:latest
+cd loom/wayback_proxy
+docker compose up -d --wait
+
+# Browse the web as of 2020-06-01 (the default WAYBACK_AS_OF):
+docker compose exec agent python -c '
+import urllib.request
+with urllib.request.urlopen("http://example.com/") as r:
+    print(r.status, r.headers["X-Wayback-Timestamp"])
+    print(r.read()[:200])
+'
+
+# https fails fast by design (501 from the proxy; retry as http://):
+docker compose exec agent python -c '
+import urllib.request
+urllib.request.urlopen("https://example.com/")
+'
+
+# Direct egress is physically blocked (no route off the internal network):
+docker compose exec agent python -c '
+import socket
+socket.create_connection(("1.1.1.1", 80), timeout=5)
+'
+
+docker compose down -v
+```
+
+Knobs (compose env interpolation): `WAYBACK_AS_OF` (ISO date, default
+`2020-06-01`), `WAYBACK_UPSTREAM` (default `https://web.archive.org`).
+
+## Using the shared cluster cache
+
+`cluster/k8s/wayback-cache/` runs a two-tier nginx pull-through cache
+(ClusterIP only) so repeated lookups never re-hit IA and the upstream hop is
+rate-limited. Point the proxy at it through a port-forward:
+
+```bash
+# --address 0.0.0.0: host.docker.internal resolves to the docker bridge
+# gateway, so the forward must listen beyond loopback.
+kubectl -n wayback-cache port-forward --address 0.0.0.0 svc/wayback-cache 8080:8080 &
+WAYBACK_UPSTREAM=http://host.docker.internal:8080 docker compose up -d --wait
+```
+
+In-cluster consumers use `http://wayback-cache.wayback-cache.svc.cluster.local:8080`.
+
+## Tests
+
+```bash
+bbr test //loom/wayback_proxy:test_proxy        # proxy semantics vs canned fake IA
+bbr test //loom/wayback_proxy:test_compose_e2e  # the compose demo, end to end (Docker)
+```
+
+`fake_ia.py` pins the IA contract the proxy relies on (CDX header-row JSON,
+empty body on no matches, `Memento-Datetime` on replays, 302 timestamp
+canonicalization, captured live-web redirects).

--- a/loom/wayback_proxy/compose.yaml
+++ b/loom/wayback_proxy/compose.yaml
@@ -1,0 +1,45 @@
+# Demo: a container with NO internet route ("agent") that can still browse
+# the archived web as of a fixed date, through the wayback proxy sidecar.
+# loom's gym sandbox builds on this shape. See README.md.
+services:
+  agent:
+    image: python:3.13-slim
+    init: true
+    command: tail -f /dev/null
+    networks: [sandbox]
+    environment:
+      http_proxy: http://proxy:8080
+      HTTP_PROXY: http://proxy:8080
+    depends_on:
+      proxy:
+        condition: service_healthy
+
+  proxy:
+    image: wayback-proxy:latest
+    init: true
+    networks: [sandbox, egress]
+    environment:
+      WAYBACK_AS_OF: ${WAYBACK_AS_OF:-2020-06-01}
+      WAYBACK_UPSTREAM: ${WAYBACK_UPSTREAM:-https://web.archive.org}
+    extra_hosts:
+      # Lets WAYBACK_UPSTREAM point at a port on the host: a kubectl
+      # port-forward of the wayback-cache cluster service, or the e2e test's
+      # in-process fake IA. Maps to the docker bridge gateway IP on Linux.
+      - host.docker.internal:host-gateway
+    healthcheck:
+      # python3 resolves via the image's venv PATH; start_period covers the
+      # launcher materializing the venv on first run.
+      test:
+        - CMD
+        - python3
+        - -c
+        - import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/healthz', timeout=3)
+      interval: 2s
+      timeout: 5s
+      retries: 15
+      start_period: 10s
+
+networks:
+  sandbox:
+    internal: true # no gateway out: the agent's only reachable peer is the proxy
+  egress: {}

--- a/loom/wayback_proxy/fake_ia.py
+++ b/loom/wayback_proxy/fake_ia.py
@@ -1,0 +1,139 @@
+"""Canned Internet Archive stand-in for wayback proxy tests.
+
+Implements just enough of the CDX API (``/cdx/search/cdx`` with ``url``,
+``to``, ``limit=-1``, ``output=json``) and the ``/web/<ts><modifier>/<url>``
+replay endpoint, from a literal capture table. Deliberately independent of
+proxy.py — this module is the test oracle pinning what we believe IA does:
+header-row CDX JSON, empty body when no captures match, ``Memento-Datetime``
+on replayed captures (including archived 404s), 302 timestamp
+canonicalization, and captured live-web redirects.
+
+Runs in the test process: in-process for test_proxy.py, bound on 0.0.0.0 for
+the compose e2e (the proxy container reaches it via host.docker.internal).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from datetime import date
+
+from aiohttp import web
+
+CDX_PATH = "/cdx/search/cdx"
+CDX_HEADER = ["urlkey", "timestamp", "original", "mimetype", "statuscode", "digest", "length"]
+MEMENTO_HEADER = {"Memento-Datetime": "Wed, 15 Jan 2020 10:30:00 GMT"}
+
+_WEB_RE = re.compile(r"^/web/(\d{4,14})([a-z]{2}_)?/(.*)$")
+
+AS_OF = date(2020, 6, 1)
+
+OLD_TS = "20180704120000"
+GOOD_TS = "20200115103000"
+CANON_LISTED_TS = "20200301000000"
+DRIFT_LISTED_TS = "20200401000000"
+TOO_NEW_TS = "20230301000000"
+
+# Plain page with pre- and post-as_of captures; CDX `original` is the https
+# form (exercises fetching by the original column, not the client's URL).
+EXAMPLE_URL = "http://example.com/"
+EXAMPLE_ORIGINAL = "https://example.com/"
+EXAMPLE_BODY = b"<html><body>archived example.com as of 2020-01-15</body></html>\n"
+
+# Only captured after as_of: must 404 through the proxy.
+FUTURE_ONLY_URL = "http://newsite.example/launch"
+
+# Replay of the CDX-listed ts 302s to the canonical capture ts (IA behavior
+# for inexact timestamps); the canonical hop is still within as_of.
+CANON_URL = "http://redirects.example/page"
+CANON_BODY = b"canonical capture body\n"
+
+# Replay 302s forward past as_of: the proxy must refuse the hop.
+DRIFT_URL = "http://drift.example/page"
+
+# Captured live-web redirect: replay responds 302 to an off-archive https
+# URL; the proxy must bounce the client to its http form.
+MOVED_URL = "http://moved.example/old"
+MOVED_TARGET = "https://moved.example/new"
+
+# The newest capture at-or-before as_of is an archived 404 — correct as-of
+# content, served with Memento-Datetime.
+GONE_URL = "http://gone.example/page"
+GONE_BODY = b"not found, as of 2020\n"
+
+# CDX itself fails for this URL (tests 503 -> 502 mapping).
+CDX_BROKEN_URL = "http://cdx-broken.example/"
+
+
+@dataclass(frozen=True)
+class Replay:
+    status: int = 200
+    body: bytes = b""
+    content_type: str = "text/html"
+    redirect_to: str | None = None
+
+
+# CDX index: client-facing URL -> [(timestamp, original), ...] ascending.
+CDX_CAPTURES: dict[str, list[tuple[str, str]]] = {
+    EXAMPLE_URL: [(OLD_TS, EXAMPLE_ORIGINAL), (GOOD_TS, EXAMPLE_ORIGINAL), (TOO_NEW_TS, EXAMPLE_ORIGINAL)],
+    FUTURE_ONLY_URL: [(TOO_NEW_TS, FUTURE_ONLY_URL)],
+    CANON_URL: [(CANON_LISTED_TS, CANON_URL)],
+    DRIFT_URL: [(DRIFT_LISTED_TS, DRIFT_URL)],
+    MOVED_URL: [(GOOD_TS, MOVED_URL)],
+    GONE_URL: [(GOOD_TS, GONE_URL)],
+}
+
+# Replay table: (timestamp, original URL) -> response.
+REPLAYS: dict[tuple[str, str], Replay] = {
+    (GOOD_TS, EXAMPLE_ORIGINAL): Replay(body=EXAMPLE_BODY),
+    (OLD_TS, EXAMPLE_ORIGINAL): Replay(body=b"older capture\n"),
+    (CANON_LISTED_TS, CANON_URL): Replay(redirect_to=f"/web/{GOOD_TS}id_/{CANON_URL}"),
+    (GOOD_TS, CANON_URL): Replay(body=CANON_BODY),
+    (DRIFT_LISTED_TS, DRIFT_URL): Replay(redirect_to=f"/web/{TOO_NEW_TS}id_/{DRIFT_URL}"),
+    (TOO_NEW_TS, DRIFT_URL): Replay(body=b"post-as_of content that must never be served\n"),
+    (GOOD_TS, MOVED_URL): Replay(redirect_to=MOVED_TARGET),
+    (GOOD_TS, GONE_URL): Replay(status=404, body=GONE_BODY),
+}
+
+
+def _cdx_response(request: web.BaseRequest) -> web.Response:
+    url = request.query["url"]
+    if url == CDX_BROKEN_URL:
+        return web.Response(status=503, text="CDX is having a bad day\n")
+    to_ts = request.query.get("to", "99999999999999").ljust(14, "9")
+    matching = [capture for capture in CDX_CAPTURES.get(url, []) if capture[0] <= to_ts]
+    if request.query.get("limit") == "-1":
+        matching = matching[-1:]
+    if not matching:
+        # Real CDX returns an empty body (not an empty JSON array) for no matches.
+        return web.Response(body=b"")
+    rows = [CDX_HEADER] + [
+        [f"fake({url})", ts, original, "text/html", "200", "FAKEDIGEST", "123"] for ts, original in matching
+    ]
+    return web.Response(body=json.dumps(rows).encode(), content_type="application/json")
+
+
+async def handle(request: web.BaseRequest) -> web.StreamResponse:
+    raw_path = request.raw_path
+    if raw_path.startswith(CDX_PATH):
+        return _cdx_response(request)
+    if (match := _WEB_RE.match(raw_path)) is not None:
+        ts, _modifier, inner = match.groups()
+        replay = REPLAYS.get((ts, inner))
+        if replay is None:
+            return web.Response(status=404, text="snapshot not found\n")  # IA-level miss: no Memento header
+        if replay.redirect_to is not None:
+            return web.Response(status=302, headers={"Location": replay.redirect_to})
+        return web.Response(
+            status=replay.status, body=replay.body, headers={"Content-Type": replay.content_type, **MEMENTO_HEADER}
+        )
+    return web.Response(status=404, text="unknown fake-ia path\n")
+
+
+async def start(port: int = 0, host: str = "127.0.0.1") -> web.ServerRunner:
+    """Start the fake; bound port is in runner.addresses."""
+    runner = web.ServerRunner(web.Server(handle))
+    await runner.setup()
+    await web.TCPSite(runner, host, port).start()
+    return runner

--- a/loom/wayback_proxy/proxy.py
+++ b/loom/wayback_proxy/proxy.py
@@ -1,0 +1,323 @@
+"""Date-clamping Wayback Machine forward proxy (the loom "time machine").
+
+Plain-HTTP forward proxy: every absolute-URI request is answered with the
+newest Internet Archive capture at-or-before ``WAYBACK_AS_OF``, served as raw
+``id_`` bytes (no IA banner or rewriting). CONNECT is refused — HTTPS is
+disabled by design; agents use ``http://`` URLs (IA serves the same snapshot
+regardless of the original scheme). Emits a served-evidence JSONL manifest
+line per response on stdout. See loom/plans/wayback_proxy.md.
+
+Configuration (env): ``WAYBACK_AS_OF`` (required ISO date, inclusive),
+``WAYBACK_UPSTREAM`` (default ``https://web.archive.org``; point at the
+wayback-cache cluster service to share a pull-through cache), ``PORT``
+(default 8080).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import re
+import sys
+from dataclasses import dataclass
+from datetime import date
+from typing import TextIO
+
+import aiohttp
+from aiohttp import web
+from yarl import URL
+
+logger = logging.getLogger(__name__)
+
+CDX_PATH = "/cdx/search/cdx"
+ARCHIVE_HOST = "web.archive.org"
+MAX_REDIRECT_HOPS = 10
+MAX_BODY_BYTES = 64 * 2**20
+
+# "/web/<ts><modifier?>/<url>" — IA replay path. Modifiers are two letters
+# plus underscore (id_, if_, im_, js_, cs_, ...).
+_WEB_PATH_RE = re.compile(r"^/web/(\d{4,14})([a-z]{2}_)?/(.*)$")
+
+
+class NoCaptureError(Exception):
+    """No archived capture at or before as_of → HTTP 404."""
+
+
+class ClampViolationError(Exception):
+    """Request or archive redirect points after as_of → HTTP 403."""
+
+
+class UpstreamError(Exception):
+    """Archive/cache failed in an unexpected way → HTTP 502."""
+
+
+def pad_ts(ts: str) -> str:
+    """Right-pad a partial IA timestamp to 14 digits (earliest moment in the period)."""
+    return ts.ljust(14, "0")
+
+
+def ts_allowed(ts: str, as_of_ts: str) -> bool:
+    return pad_ts(ts) <= as_of_ts
+
+
+def parse_web_path(path_qs: str) -> tuple[str, str, str] | None:
+    """Split "/web/<ts><modifier?>/<url>" into (ts, modifier, inner url)."""
+    if (match := _WEB_PATH_RE.match(path_qs)) is None:
+        return None
+    ts, modifier, inner = match.groups()
+    return ts, modifier or "", inner
+
+
+def pick_capture(cdx_rows: list[list[str]]) -> tuple[str, str] | None:
+    """Newest (timestamp, original) from a CDX ``output=json`` payload.
+
+    Row 0 is the column-name header; with ``limit=-1`` the single data row is
+    the newest capture ≤ ``to``. Returns None when no data rows exist.
+    """
+    if len(cdx_rows) < 2:
+        return None
+    header, *rows = cdx_rows
+    ts_index, original_index = header.index("timestamp"), header.index("original")
+    newest = rows[-1]
+    return newest[ts_index], newest[original_index]
+
+
+@dataclass(frozen=True)
+class Config:
+    as_of: date
+    upstream: str  # base URL, no trailing slash
+    port: int
+
+    @classmethod
+    def from_env(cls) -> Config:
+        as_of_raw = os.environ.get("WAYBACK_AS_OF")
+        if as_of_raw is None:
+            raise RuntimeError("WAYBACK_AS_OF must be set to the ISO information-cutoff date")
+        return cls(
+            as_of=date.fromisoformat(as_of_raw),
+            upstream=os.environ.get("WAYBACK_UPSTREAM", f"https://{ARCHIVE_HOST}").rstrip("/"),
+            port=int(os.environ.get("PORT", "8080")),
+        )
+
+    @property
+    def as_of_ts(self) -> str:
+        """Inclusive 14-digit clamp: end of the as_of day (IA timestamps are UTC)."""
+        return f"{self.as_of:%Y%m%d}235959"
+
+    @property
+    def upstream_host(self) -> str:
+        host = URL(self.upstream).host
+        if host is None:
+            raise RuntimeError(f"WAYBACK_UPSTREAM has no host: {self.upstream!r}")
+        return host
+
+
+@dataclass(frozen=True)
+class Snapshot:
+    """One archive response: either a body to serve or an off-archive redirect."""
+
+    ts: str
+    status: int
+    content_type: str
+    body: bytes
+    location: str | None = None
+
+
+class WaybackProxy:
+    def __init__(self, config: Config, session: aiohttp.ClientSession, manifest: TextIO) -> None:
+        self._config = config
+        self._session = session
+        self._manifest = manifest
+
+    async def handle(self, request: web.BaseRequest) -> web.StreamResponse:
+        if request.method == "CONNECT":
+            return web.Response(
+                status=501,
+                text="HTTPS tunneling is disabled; request the http:// form of the URL through this proxy.\n",
+            )
+        # raw_path is the verbatim request-target: "/path" for origin-form
+        # requests, the full absolute URI for proxy (absolute-form) requests.
+        raw_target = request.raw_path
+        if raw_target.startswith("/"):
+            if raw_target == "/healthz":
+                return web.Response(text="ok\n")
+            return web.Response(
+                status=400, text="This is a forward HTTP proxy; set http_proxy and request http:// URLs.\n"
+            )
+        target = URL(raw_target, encoded=True)
+        if target.scheme != "http" or target.host is None:
+            return web.Response(status=400, text=f"Unsupported proxy target {raw_target!r}; use http:// URLs.\n")
+        try:
+            return await self._serve(target)
+        except NoCaptureError as e:
+            return web.Response(status=404, text=f"{e}\n")
+        except ClampViolationError as e:
+            return web.Response(status=403, text=f"{e}\n")
+        except UpstreamError as e:
+            logger.warning("upstream error for %s: %s", target, e)
+            return web.Response(status=502, text=f"{e}\n")
+
+    async def _serve(self, target: URL) -> web.Response:
+        if target.host in (ARCHIVE_HOST, self._config.upstream_host):
+            return await self._serve_archive_url(target)
+        ts, original = await self._resolve_capture(target)
+        snapshot = await self._fetch_capture(ts, "id_", original)
+        return self._respond(str(target), snapshot)
+
+    async def _serve_archive_url(self, target: URL) -> web.Response:
+        """Defense in depth for explicitly archive-addressed requests.
+
+        Pinned ``/web/<ts>/`` URLs (e.g. curated Task.evidence) are served iff
+        ts ≤ as_of; CDX queries are forwarded with ``to`` clamped so the agent
+        cannot even learn that a post-as_of capture exists.
+        """
+        path_qs = target.raw_path_qs
+        if (parsed := parse_web_path(path_qs)) is not None:
+            ts, modifier, inner = parsed
+            if not ts_allowed(ts, self._config.as_of_ts):
+                raise ClampViolationError(f"capture {ts} is after as_of {self._config.as_of}")
+            snapshot = await self._fetch_capture(ts, modifier or "id_", inner)
+            return self._respond(inner, snapshot)
+        if path_qs.startswith(CDX_PATH):
+            return await self._forward_cdx(target)
+        raise ClampViolationError(f"only /web/ and {CDX_PATH} paths are allowed on the archive host")
+
+    async def _forward_cdx(self, target: URL) -> web.Response:
+        params = dict(target.query)
+        # A partial `to` means "through the end of that period" — pad with 9s
+        # before comparing so the clamp never *widens* the requested bound.
+        requested_to = params.get("to")
+        params["to"] = (
+            min(requested_to.ljust(14, "9"), self._config.as_of_ts) if requested_to else self._config.as_of_ts
+        )
+        async with self._session.get(URL(self._config.upstream + CDX_PATH), params=params) as response:
+            body = await response.content.read(MAX_BODY_BYTES)
+            if response.status != 200:
+                raise UpstreamError(f"CDX query failed with HTTP {response.status}")
+            return web.Response(body=body, headers={"Content-Type": response.headers.get("Content-Type", "text/plain")})
+
+    async def _resolve_capture(self, target: URL) -> tuple[str, str]:
+        """Newest (timestamp, original URL) capture of `target` at or before as_of."""
+        params = {"url": str(target), "to": self._config.as_of_ts, "output": "json", "limit": "-1"}
+        async with self._session.get(URL(self._config.upstream + CDX_PATH), params=params) as response:
+            if response.status != 200:
+                raise UpstreamError(f"CDX lookup failed with HTTP {response.status}")
+            raw = await response.content.read(MAX_BODY_BYTES)
+        if not raw.strip():
+            raise NoCaptureError(f"no archived capture of {target} at or before {self._config.as_of}")
+        try:
+            rows = json.loads(raw)
+        except json.JSONDecodeError as e:
+            raise UpstreamError(f"CDX returned invalid JSON: {e}") from e
+        if not isinstance(rows, list):
+            raise UpstreamError(f"CDX returned non-list JSON: {type(rows).__name__}")
+        try:
+            picked = pick_capture(rows)
+        except (ValueError, IndexError) as e:
+            raise UpstreamError(f"CDX rows have unexpected shape: {e}") from e
+        if picked is None:
+            raise NoCaptureError(f"no archived capture of {target} at or before {self._config.as_of}")
+        return picked
+
+    async def _fetch_capture(self, ts: str, modifier: str, url: str) -> Snapshot:
+        """Fetch /web/<ts><modifier>/<url> from upstream, following archive-internal redirects.
+
+        Every hop that stays on the archive is re-clamped (IA canonicalizes
+        partial/inexact timestamps to the *closest* capture, which can walk
+        forward past as_of). Off-archive Locations (captured live-web
+        redirects) are bounced back to the client so the follow-up request
+        re-enters the proxy and is re-resolved under the clamp.
+        """
+        current = URL(f"{self._config.upstream}/web/{ts}{modifier}/{url}", encoded=True)
+        final_ts = ts
+        for _ in range(MAX_REDIRECT_HOPS):
+            async with self._session.get(
+                current, allow_redirects=False, headers={"Accept-Encoding": "identity"}
+            ) as response:
+                if response.status in (301, 302, 303, 307, 308):
+                    location = response.headers.get("Location")
+                    if location is None:
+                        raise UpstreamError(f"redirect without Location from {current}")
+                    next_url = current.join(URL(location, encoded=True))
+                    on_archive = next_url.host in (ARCHIVE_HOST, self._config.upstream_host)
+                    if on_archive and (parsed := parse_web_path(next_url.raw_path_qs)) is not None:
+                        hop_ts, _, _ = parsed
+                        if not ts_allowed(hop_ts, self._config.as_of_ts):
+                            raise ClampViolationError(
+                                f"archive redirected to capture {hop_ts}, after as_of {self._config.as_of}"
+                            )
+                        final_ts = hop_ts
+                        # Re-anchor on the configured upstream so redirect
+                        # targets are also fetched through the shared cache.
+                        current = URL(self._config.upstream + next_url.raw_path_qs, encoded=True)
+                        continue
+                    # Captured live-web redirect: hand it to the client,
+                    # downgraded to http so it can re-enter this proxy.
+                    bounce = next_url.with_scheme("http") if next_url.scheme == "https" else next_url
+                    return Snapshot(
+                        ts=final_ts, status=response.status, content_type="", body=b"", location=str(bounce)
+                    )
+                body = await response.content.read(MAX_BODY_BYTES + 1)
+                if len(body) > MAX_BODY_BYTES:
+                    raise UpstreamError(f"capture body exceeds {MAX_BODY_BYTES} bytes")
+                # Replayed captures carry Memento-Datetime — even archived
+                # 404s/500s (which are correct as-of content). Error statuses
+                # without it are the archive/cache itself failing.
+                if response.status >= 400 and "Memento-Datetime" not in response.headers:
+                    raise UpstreamError(f"archive upstream returned HTTP {response.status} for {current}")
+                content_type = response.headers.get("Content-Type", "application/octet-stream")
+                return Snapshot(ts=final_ts, status=response.status, content_type=content_type, body=body)
+        raise UpstreamError(f"redirect chain exceeded {MAX_REDIRECT_HOPS} hops for {url}")
+
+    def _respond(self, served_url: str, snapshot: Snapshot) -> web.Response:
+        headers = {"X-Wayback-Timestamp": snapshot.ts}
+        if snapshot.location is not None:
+            headers["Location"] = snapshot.location
+            return web.Response(status=snapshot.status, headers=headers)
+        self._emit_manifest(served_url, snapshot)
+        headers["Content-Type"] = snapshot.content_type
+        return web.Response(status=snapshot.status, body=snapshot.body, headers=headers)
+
+    def _emit_manifest(self, url: str, snapshot: Snapshot) -> None:
+        """Served-evidence record; the harness attaches these to the run payload (W3)."""
+        line = json.dumps(
+            {
+                "url": url,
+                "capture_ts": snapshot.ts,
+                "sha256": hashlib.sha256(snapshot.body).hexdigest(),
+                "size": len(snapshot.body),
+            }
+        )
+        print(line, file=self._manifest, flush=True)
+
+
+async def start_proxy(
+    config: Config, session: aiohttp.ClientSession, manifest: TextIO, host: str = "0.0.0.0"
+) -> web.ServerRunner:
+    """Start the proxy; returns the runner (bound port in runner.addresses)."""
+    proxy = WaybackProxy(config, session, manifest)
+    runner = web.ServerRunner(web.Server(proxy.handle))
+    await runner.setup()
+    await web.TCPSite(runner, host, config.port).start()
+    return runner
+
+
+async def amain() -> None:
+    config = Config.from_env()
+    logger.info("wayback proxy: as_of=%s upstream=%s port=%d", config.as_of, config.upstream, config.port)
+    # Total timeout rides out wayback-cache limit_req delays (burst 60 @ 30r/m).
+    async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=300)) as session:
+        await start_proxy(config, session, sys.stdout)
+        await asyncio.Event().wait()
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, stream=sys.stderr, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+    asyncio.run(amain())
+
+
+if __name__ == "__main__":
+    main()

--- a/loom/wayback_proxy/test_compose_e2e.py
+++ b/loom/wayback_proxy/test_compose_e2e.py
@@ -1,0 +1,143 @@
+"""End-to-end test of the demo compose file.
+
+Proves the deliverable claim: the agent container has no internet route, yet
+fetches date-clamped historical pages through the proxy sidecar. Runs the
+exact checked-in compose.yaml; the only test affordance is WAYBACK_UPSTREAM
+pointing at an in-process fake IA reachable via host.docker.internal
+(host-gateway), which requires the worker-local Docker daemon.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import uuid
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from textwrap import dedent
+
+import pytest
+import pytest_bazel
+
+from loom.wayback_proxy import fake_ia
+from third_party.containers.rlocations import PYTHON_3_13_SLIM
+from util.bazel.runfiles import get_required_path
+from util.oci import OciImage, load_oci_image
+from util.testing.undeclared_outputs import undeclared_outputs_dir
+
+WAYBACK_PROXY_IMAGE = OciImage("_main/loom/wayback_proxy/image_info.rloc", "wayback-proxy:latest")
+COMPOSE_RLOCATION = "_main/loom/wayback_proxy/compose.yaml"
+
+
+@dataclass(frozen=True)
+class ComposeStack:
+    base_args: tuple[str, ...]
+    env: dict[str, str]
+
+    async def run(self, *args: str) -> str:
+        process = await asyncio.create_subprocess_exec(
+            *self.base_args, *args, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE, env=self.env
+        )
+        stdout, stderr = await process.communicate()
+        if process.returncode != 0:
+            raise RuntimeError(
+                f"{' '.join(self.base_args + args)} failed (exit {process.returncode}):\n{stderr.decode()}"
+            )
+        return stdout.decode()
+
+    async def exec_agent_python(self, script: str) -> str:
+        return await self.run("exec", "-T", "agent", "python", "-c", script)
+
+
+@pytest.fixture
+async def fake_upstream_port() -> AsyncIterator[int]:
+    # 0.0.0.0 so the proxy container can reach it via host.docker.internal.
+    runner = await fake_ia.start(host="0.0.0.0")
+    yield int(runner.addresses[0][1])
+    await runner.cleanup()
+
+
+@pytest.fixture
+async def compose_stack(fake_upstream_port: int) -> AsyncIterator[ComposeStack]:
+    load_oci_image(WAYBACK_PROXY_IMAGE)
+    load_oci_image(PYTHON_3_13_SLIM)
+    compose_file = get_required_path(COMPOSE_RLOCATION)
+    project = f"wayback-e2e-{uuid.uuid4().hex[:8]}"
+    stack = ComposeStack(
+        base_args=("docker", "compose", "-f", str(compose_file), "-p", project),
+        env={
+            **os.environ,
+            "WAYBACK_AS_OF": str(fake_ia.AS_OF),
+            "WAYBACK_UPSTREAM": f"http://host.docker.internal:{fake_upstream_port}",
+        },
+    )
+    try:
+        await stack.run("up", "-d", "--wait")
+        yield stack
+    finally:
+        logs = await stack.run("logs", "--no-color")
+        (undeclared_outputs_dir() / "compose.log").write_text(logs)
+        await stack.run("down", "-v", "--remove-orphans")
+
+
+async def test_agent_browses_only_the_clamped_archive(compose_stack: ComposeStack) -> None:
+    # Historical fetch through the proxy: urllib honors the http_proxy env
+    # baked into the agent service.
+    output = await compose_stack.exec_agent_python(
+        dedent(
+            f"""
+            import urllib.request
+            with urllib.request.urlopen({fake_ia.EXAMPLE_URL!r}, timeout=30) as response:
+                print(response.status, response.headers["X-Wayback-Timestamp"])
+                print(response.read().decode())
+            """
+        )
+    )
+    assert f"200 {fake_ia.GOOD_TS}" in output
+    assert fake_ia.EXAMPLE_BODY.decode() in output
+
+    # A page that only exists after as_of is a 404.
+    output = await compose_stack.exec_agent_python(
+        dedent(
+            f"""
+            import urllib.error, urllib.request
+            try:
+                urllib.request.urlopen({fake_ia.FUTURE_ONLY_URL!r}, timeout=30)
+                print("UNEXPECTED-SUCCESS")
+            except urllib.error.HTTPError as e:
+                print("HTTP-ERROR", e.code)
+            """
+        )
+    )
+    assert "HTTP-ERROR 404" in output
+    assert "UNEXPECTED-SUCCESS" not in output
+
+    # Physical isolation: no route to the internet, no route to the host
+    # (the fake IA's port), no DNS for host.docker.internal on the agent.
+    output = await compose_stack.exec_agent_python(
+        dedent(
+            """
+            import socket
+            for host, port in (("1.1.1.1", 80), ("host.docker.internal", 8081)):
+                try:
+                    socket.create_connection((host, port), timeout=5)
+                    print("CONNECTED", host)
+                except OSError as e:
+                    print("BLOCKED", host, type(e).__name__)
+            """
+        )
+    )
+    assert "CONNECTED" not in output
+    assert output.count("BLOCKED") == 2
+
+    # The proxy logged served-evidence manifest lines to stdout.
+    proxy_logs = await compose_stack.run("logs", "--no-color", "proxy")
+    manifest_lines = [json.loads(line[line.index("{") :]) for line in proxy_logs.splitlines() if '"sha256"' in line]
+    assert any(
+        record["url"] == fake_ia.EXAMPLE_URL and record["capture_ts"] == fake_ia.GOOD_TS for record in manifest_lines
+    )
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/loom/wayback_proxy/test_live_ia.py
+++ b/loom/wayback_proxy/test_live_ia.py
@@ -1,0 +1,72 @@
+"""Live smoke test against the real Internet Archive (manual-only target).
+
+Tagged manual: IA availability/rate limits make this unsuitable for CI. Run
+on demand (RBE workers have open egress):
+
+    bbr test //loom/wayback_proxy:test_live_ia --test_output=streamed
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+from collections.abc import AsyncIterator
+from datetime import date
+
+import aiohttp
+import pytest
+import pytest_bazel
+from aiohttp import web
+
+from loom.wayback_proxy.proxy import Config, start_proxy
+
+logger = logging.getLogger(__name__)
+
+AS_OF = date(2020, 6, 1)
+
+
+def _port(runner: web.ServerRunner) -> int:
+    return int(runner.addresses[0][1])
+
+
+@pytest.fixture
+async def live_proxy() -> AsyncIterator[str]:
+    config = Config(as_of=AS_OF, upstream="https://web.archive.org", port=0)
+    async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=120)) as session:
+        runner = await start_proxy(config, session, io.StringIO(), host="127.0.0.1")
+        yield f"http://127.0.0.1:{_port(runner)}"
+        await runner.cleanup()
+
+
+async def test_live_example_com_is_clamped(live_proxy: str) -> None:
+    async with aiohttp.ClientSession() as client:
+        async with client.get("http://example.com/", proxy=live_proxy) as response:
+            body = await response.read()
+            assert response.status == 200, body.decode(errors="replace")[:500]
+            ts = response.headers["X-Wayback-Timestamp"]
+            logger.info("served capture ts=%s, %d bytes", ts, len(body))
+            assert ts <= "20200601235959"
+            assert b"Example Domain" in body
+
+        # A pinned capture after as_of must be refused outright.
+        async with client.get(
+            "http://web.archive.org/web/20240101000000id_/https://example.com/", proxy=live_proxy
+        ) as response:
+            assert response.status == 403
+
+        # CDX passthrough must not reveal post-as_of captures. Bounded with
+        # limit=-5 (newest five): IA truncates huge unbounded listings
+        # mid-stream (example.com has ~10^5 captures), cutting the JSON off.
+        async with client.get(
+            "http://web.archive.org/cdx/search/cdx?url=example.com/&output=json&limit=-5", proxy=live_proxy
+        ) as response:
+            assert response.status == 200
+            rows = json.loads(await response.read())
+            timestamps = [row[rows[0].index("timestamp")] for row in rows[1:]]
+            assert timestamps, "expected at least one pre-as_of capture"
+            assert max(timestamps) <= "20200601235959"
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/loom/wayback_proxy/test_proxy.py
+++ b/loom/wayback_proxy/test_proxy.py
@@ -1,0 +1,210 @@
+"""Tests for the date-clamping wayback proxy against the canned fake IA."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from datetime import date
+
+import aiohttp
+import pytest
+import pytest_bazel
+from aiohttp import web
+
+from loom.wayback_proxy import fake_ia
+from loom.wayback_proxy.proxy import Config, parse_web_path, pick_capture, start_proxy, ts_allowed
+
+AS_OF_TS = "20200601235959"
+
+
+def _port(runner: web.ServerRunner) -> int:
+    return int(runner.addresses[0][1])
+
+
+@dataclass(frozen=True)
+class RunningProxy:
+    url: str
+    manifest: io.StringIO
+
+
+@dataclass(frozen=True)
+class FetchResult:
+    status: int
+    headers: dict[str, str]
+    body: bytes
+
+
+@pytest.fixture
+async def fake_upstream() -> AsyncIterator[str]:
+    runner = await fake_ia.start()
+    yield f"http://127.0.0.1:{_port(runner)}"
+    await runner.cleanup()
+
+
+@pytest.fixture
+async def running_proxy(fake_upstream: str) -> AsyncIterator[RunningProxy]:
+    config = Config(as_of=fake_ia.AS_OF, upstream=fake_upstream, port=0)
+    manifest = io.StringIO()
+    async with aiohttp.ClientSession() as session:
+        runner = await start_proxy(config, session, manifest, host="127.0.0.1")
+        yield RunningProxy(url=f"http://127.0.0.1:{_port(runner)}", manifest=manifest)
+        await runner.cleanup()
+
+
+@pytest.fixture
+async def fetch(running_proxy: RunningProxy):
+    async with aiohttp.ClientSession() as client:
+
+        async def fetch_via_proxy(url: str) -> FetchResult:
+            async with client.get(url, proxy=running_proxy.url, allow_redirects=False) as response:
+                return FetchResult(status=response.status, headers=dict(response.headers), body=await response.read())
+
+        yield fetch_via_proxy
+
+
+async def test_serves_newest_capture_at_or_before_as_of(fetch) -> None:
+    result = await fetch(fake_ia.EXAMPLE_URL)
+    assert result.status == 200
+    assert result.body == fake_ia.EXAMPLE_BODY
+    assert result.headers["X-Wayback-Timestamp"] == fake_ia.GOOD_TS
+    assert result.headers["Content-Type"] == "text/html"
+
+
+async def test_manifest_records_served_evidence(fetch, running_proxy: RunningProxy) -> None:
+    await fetch(fake_ia.EXAMPLE_URL)
+    record = json.loads(running_proxy.manifest.getvalue())
+    assert record == {
+        "url": fake_ia.EXAMPLE_URL,
+        "capture_ts": fake_ia.GOOD_TS,
+        "sha256": hashlib.sha256(fake_ia.EXAMPLE_BODY).hexdigest(),
+        "size": len(fake_ia.EXAMPLE_BODY),
+    }
+
+
+async def test_no_capture_at_or_before_as_of_is_404(fetch) -> None:
+    result = await fetch(fake_ia.FUTURE_ONLY_URL)
+    assert result.status == 404
+    assert str(fake_ia.AS_OF) in result.body.decode()
+    assert "X-Wayback-Timestamp" not in result.headers
+
+
+async def test_follows_timestamp_canonicalization_redirect(fetch) -> None:
+    result = await fetch(fake_ia.CANON_URL)
+    assert result.status == 200
+    assert result.body == fake_ia.CANON_BODY
+    assert result.headers["X-Wayback-Timestamp"] == fake_ia.GOOD_TS
+
+
+async def test_refuses_redirect_drifting_past_as_of(fetch) -> None:
+    result = await fetch(fake_ia.DRIFT_URL)
+    assert result.status == 403
+    assert fake_ia.TOO_NEW_TS in result.body.decode()
+
+
+async def test_bounces_captured_live_redirect_downgraded_to_http(fetch) -> None:
+    result = await fetch(fake_ia.MOVED_URL)
+    assert result.status == 302
+    # https Location is downgraded so the client's follow-up re-enters the proxy.
+    assert result.headers["Location"] == "http://moved.example/new"
+
+
+async def test_archived_404_is_served_as_of_content(fetch) -> None:
+    result = await fetch(fake_ia.GONE_URL)
+    assert result.status == 404
+    assert result.body == fake_ia.GONE_BODY
+    # Distinguishable from the proxy's own "no capture" 404 by the ts header.
+    assert result.headers["X-Wayback-Timestamp"] == fake_ia.GOOD_TS
+
+
+async def test_cdx_failure_maps_to_502(fetch) -> None:
+    result = await fetch(fake_ia.CDX_BROKEN_URL)
+    assert result.status == 502
+
+
+async def test_explicit_pinned_capture_within_as_of_served(fetch) -> None:
+    result = await fetch(f"http://web.archive.org/web/{fake_ia.GOOD_TS}id_/{fake_ia.EXAMPLE_ORIGINAL}")
+    assert result.status == 200
+    assert result.body == fake_ia.EXAMPLE_BODY
+
+
+async def test_explicit_capture_after_as_of_refused(fetch) -> None:
+    result = await fetch(f"http://web.archive.org/web/{fake_ia.TOO_NEW_TS}id_/{fake_ia.EXAMPLE_ORIGINAL}")
+    assert result.status == 403
+
+
+async def test_cdx_passthrough_clamps_to_param(fetch) -> None:
+    result = await fetch(f"http://web.archive.org{fake_ia.CDX_PATH}?url={fake_ia.EXAMPLE_URL}&output=json")
+    assert result.status == 200
+    listed_timestamps = {row[1] for row in json.loads(result.body)[1:]}
+    assert fake_ia.GOOD_TS in listed_timestamps
+    assert fake_ia.TOO_NEW_TS not in listed_timestamps
+
+
+async def test_other_archive_paths_refused(fetch) -> None:
+    result = await fetch("http://web.archive.org/somewhere-else")
+    assert result.status == 403
+
+
+async def test_connect_for_https_rejected(running_proxy: RunningProxy) -> None:
+    async with aiohttp.ClientSession() as client:
+        with pytest.raises(aiohttp.ClientHttpProxyError) as exc_info:
+            await client.get("https://example.com/", proxy=running_proxy.url)
+    assert exc_info.value.status == 501
+
+
+async def test_healthz_and_origin_form(running_proxy: RunningProxy) -> None:
+    async with aiohttp.ClientSession() as client:
+        async with client.get(f"{running_proxy.url}/healthz") as response:
+            assert response.status == 200
+        async with client.get(f"{running_proxy.url}/not-a-proxy-request") as response:
+            assert response.status == 400
+
+
+def test_ts_allowed_boundaries() -> None:
+    assert ts_allowed(AS_OF_TS, AS_OF_TS)
+    assert ts_allowed("20200601235958", AS_OF_TS)
+    assert not ts_allowed("20200602000000", AS_OF_TS)
+    # Partial timestamps are zero-padded (earliest moment of the period).
+    assert ts_allowed("2020", AS_OF_TS)
+    assert not ts_allowed("202012", AS_OF_TS)
+
+
+def test_parse_web_path() -> None:
+    assert parse_web_path("/web/20200115103000id_/http://example.com/a?q=1") == (
+        "20200115103000",
+        "id_",
+        "http://example.com/a?q=1",
+    )
+    assert parse_web_path("/web/2020/http://example.com/") == ("2020", "", "http://example.com/")
+    assert parse_web_path("/web/20200115103000id_") is None
+    assert parse_web_path("/cdx/search/cdx?url=x") is None
+
+
+def test_pick_capture() -> None:
+    assert pick_capture([]) is None
+    assert pick_capture([["urlkey", "timestamp", "original"]]) is None
+    # Columns are resolved by header name, not position.
+    rows = [
+        ["original", "timestamp", "urlkey"],
+        ["https://a/", "20190101000000", "key"],
+        ["https://b/", "20200101000000", "key"],
+    ]
+    assert pick_capture(rows) == ("20200101000000", "https://b/")
+
+
+def test_config_requires_as_of(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("WAYBACK_AS_OF", raising=False)
+    with pytest.raises(RuntimeError, match="WAYBACK_AS_OF"):
+        Config.from_env()
+
+
+def test_config_as_of_ts() -> None:
+    config = Config(as_of=date(2020, 6, 1), upstream="https://web.archive.org", port=8080)
+    assert config.as_of_ts == AS_OF_TS
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()


### PR DESCRIPTION
The per-agent proxy wiring on top of the merged cluster cache (#1975). Plan: [loom/plans/wayback_proxy.md](https://github.com/agentydragon/ducktape/blob/devel/loom/plans/wayback_proxy.md). (Firecracker docs split out to a separate PR.)

## `loom/wayback_proxy/` — per-agent date-clamping proxy + demo compose (W2, sans gym wiring)

- **`proxy.py`** (~250 lines, aiohttp low-level `web.Server`): plain-HTTP forward proxy answering every URL with the newest IA capture at-or-before `WAYBACK_AS_OF`, served as raw `id_` bytes. No capture ≤ as_of → 404. Explicit `/web/<ts>/` URLs clamped (pinned `Task.evidence` fetches allowed iff ts ≤ as_of), CDX `to=` clamped (no "a newer capture exists" metadata leak), every redirect hop re-clamped (IA canonicalizes toward *closest*, which can walk forward in time), captured live-web redirects bounced back to the client downgraded to `http://` so the follow-up re-enters the proxy, CONNECT refused with 501 (http-only by design). Per-response JSONL evidence manifest `{url, capture_ts, sha256, size}` on stdout (W3 foundation). `WAYBACK_UPSTREAM` points at the cluster cache or directly at IA.
- **`compose.yaml`** — the demo the gym sandbox builds on: `agent` container on an `internal: true` network with no internet route, proxy sidecar as its only peer; `host-gateway` extra_host for port-forwarding the cluster cache.
- **Mini-implementation, not a WaybackProxy fork** (decision recorded in the plan doc): upstream's nearest-capture selection can serve post-date content within `DATE_TOLERANCE`, its in-band settings page can change the date at runtime from the client side, CONNECT is fake-accepted, and the upstream host is hardcoded — hardening all that ≈ writing the clamped proxy directly.

## Tests (all passing on RBE)

- `test_proxy` — 19 cases against a canned in-process fake IA (`fake_ia.py` pins the IA contract: CDX header-row JSON, empty body on no matches, `Memento-Datetime` on replays incl. archived 404s, 302 canonicalization, captured live redirects).
- `test_compose_e2e` (`requires_docker`) — runs the exact checked-in compose file: historical fetch through the proxy succeeds, future-only page 404s, direct egress physically blocked, manifest line in proxy logs.
- `test_live_ia` (`manual`+`external`, never in CI) — real web.archive.org: clamped `example.com` capture served, pinned 2024 capture refused, CDX passthrough leaks nothing post-as_of. Caught one live quirk (IA truncates huge unbounded CDX listings mid-stream), documented in the test.

Test record: `bbr test //loom/wayback_proxy/...` and full `bbr test //... --test_tag_filters=-live_openai_api` (689 pass / 1 pre-existing skip); invocation `045d7fad-5d74-4491-9520-1b6a421dd2e3`.

On the CodeQL "information exposure through an exception" alerts: intentional — see inline reply.

https://claude.ai/code/session_01C92Haj75EreshnVNLaFVMz