### PR TITLE
wayback-cache: move cache storage to seaweedfs-ovh (Proxmox down; PVC never bound)

### DIFF
--- a/cluster/k8s/wayback-cache/deployment.yaml
+++ b/cluster/k8s/wayback-cache/deployment.yaml
@@ -20,7 +20,9 @@ spec:
         app.kubernetes.io/name: wayback-cache
     spec:
       nodeSelector:
-        topology.kubernetes.io/region: proxmox
+        # Same zone pinning as other seaweedfs-ovh consumers (forgejo): the
+        # cache lives on always-on OVH nodes, independent of home Proxmox.
+        topology.kubernetes.io/zone: hil-ovh
       securityContext:
         # nginx:alpine workers run as uid/gid 101; make the PVC writable.
         fsGroup: 101
@@ -62,4 +64,4 @@ spec:
             name: wayback-cache-config
         - name: cache
           persistentVolumeClaim:
-            claimName: wayback-cache-data
+            claimName: wayback-cache-data-ovh

--- a/cluster/k8s/wayback-cache/pvc.yaml
+++ b/cluster/k8s/wayback-cache/pvc.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: wayback-cache-data
+  name: wayback-cache-data-ovh
   namespace: wayback-cache
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: lvm-proxmox-hdd
+  storageClassName: seaweedfs-ovh
   resources:
     requests:
       storage: 20Gi # nginx max_size=18g + metadata headroom


### PR DESCRIPTION
Follow-up to #1975, requested move of the cache store to SeaweedFS.

The `lvm-proxmox-hdd` PVC never bound — Proxmox is down, so the `topology.kubernetes.io/region: proxmox` selector matches no schedulable node (`0/7 nodes are available: 2 node(s) had untolerated taint(s), 5 node(s) didn't match Pod's node affinity/selector`), the `WaitForFirstConsumer` claim sat Pending, and the Flux health check stalled (`Deployment/wayback-cache status: 'Failed'`).

Changes:

- PVC → `storageClassName: seaweedfs-ovh`, renamed `wayback-cache-data` → `wayback-cache-data-ovh` (grocy's `-ovh` precedent) so the immutable `storageClassName` swap is a clean replace; `prune: true` deletes the stuck claim.
- Deployment → `nodeSelector: topology.kubernetes.io/zone: hil-ovh`, same pinning as the other `seaweedfs-ovh` consumers (forgejo). The cache now lives on always-on OVH nodes, independent of home infra — fitting for a service whose whole point is shared availability.

nginx `proxy_cache` on the FUSE mount is safe: `use_temp_path=off` keeps temp files and renames within the one mount, and forgejo already runs a heavier rename/fsync workload on this storage class. `fsGroup: 101` stays for cache-dir writability; if the SeaweedFS CSI turns out not to honor fsGroup (couldn't read the CSIDriver's `fsGroupPolicy` with sandbox RBAC), the symptom will be `mkdir() ... failed (13: Permission denied)` in pod logs and the fast-follow is a one-line root initContainer chown.

Post-merge: `flux get kustomization wayback-cache` → Ready; then two fetches of the same `/web/<ts>id_/…` URL through the service — second must return `X-Wayback-Cache: HIT` (I'll run that from a `claude-sandbox` pod once this lands).

https://claude.ai/code/session_01C92Haj75EreshnVNLaFVMz

---
_Generated by [Claude Code](https://claude.ai/code/session_01C92Haj75EreshnVNLaFVMz)_