### PR TITLE
wayback-cache: depend on seaweedfs-csi, not openebs-lvm

### DIFF
--- a/cluster/k8s/wayback-cache/flux-kustomization.yaml
+++ b/cluster/k8s/wayback-cache/flux-kustomization.yaml
@@ -19,4 +19,4 @@ spec:
       name: wayback-cache
       namespace: wayback-cache
   dependsOn:
-    - name: openebs-lvm
+    - name: seaweedfs-csi


### PR DESCRIPTION
One-liner unblocking the #1978 rollout: `wayback-cache`'s `dependsOn: openebs-lvm` is a leftover from the `lvm-proxmox-hdd` era. With Proxmox down, `openebs-lvm` is itself unready, so the stale dependency gates the very reconcile that would apply the seaweedfs swap:

```
Ready: False — dependency 'flux-system/openebs-lvm' is not ready
inventory: still the old wayback-cache-data PVC
```

Now depends on `seaweedfs-csi` (provider of the `seaweedfs-ovh` storage class).

https://claude.ai/code/session_01C92Haj75EreshnVNLaFVMz

---
_Generated by [Claude Code](https://claude.ai/code/session_01C92Haj75EreshnVNLaFVMz)_