### PR TITLE
gecko: re-pin bootstrap image to readable devel.latest qcow2

### DIFF
--- a/cluster/k8s/gecko/app/datavolume.yaml
+++ b/cluster/k8s/gecko/app/datavolume.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   source:
     s3:
-      url: "https://s3.allegedly.works/vm-images/bootstrap/3b9e37c50911c40c11a51903de961c2db0f50f59.qcow2"
+      url: "https://s3.allegedly.works/vm-images/bootstrap/da37375538eb7da442add719d65dce838df2603b.qcow2"
       secretRef: gecko-vm-images-s3-reader
   pvc:
     accessModes:


### PR DESCRIPTION
## Why

gecko's `gecko-root` DataVolume pinned `bootstrap/3b9e37c5….qcow2`, whose SeaweedFS data chunks were lost in the **2026-06-02 OVH-rename volume wipe** (volumes 0–150 — see `cluster/docs/lessons_learned/2026_06_02_seaweedfs_volume_loss_ovh_rename.md`). Filer metadata survives (HEAD = 1.8 GB) but every GET returns `unexpected EOF`, so CDI import failed with `could not process image header: unexpected EOF`, which is what was paging.

## What

Re-pin to `bootstrap/da37375538….qcow2` — the current `devel.latest.txt` target, published post-incident onto surviving volumes. Verified fully readable: valid qcow2 v3 header (`QFI\xfb`), mid-file (@1.5 GB) and tail reads OK.

## Cutover (out-of-band, alongside merge)

DataVolume specs are immutable, so the live `gecko-root` DV must be deleted and recreated to pick up the new URL. Done manually after merge; VM kept halted during import to avoid a WaitForFirstConsumer bind livelock, then started.

## Follow-up (not in this PR)

For true autoprovision, the publisher could also write a stable `bootstrap/<ref>.latest.qcow2` key that gecko tracks, so re-pins aren't needed per image.