### PR TITLE
wayback-cache: ignore origin caching headers (IA Set-Cookie defeated the cache)

### DIFF
--- a/cluster/k8s/wayback-cache/config/nginx.conf
+++ b/cluster/k8s/wayback-cache/config/nginx.conf
@@ -50,6 +50,14 @@ http {
         proxy_set_header Connection "";
         add_header X-Wayback-Cache $upstream_cache_status always;
 
+        # IA replies carry load-balancer cookies (wb-p-SERVER) and ad-hoc
+        # cache-control; nginx refuses to cache anything with Set-Cookie by
+        # default. Our cacheability rule is structural — snapshot bytes at a
+        # fixed timestamp are immutable — so ignore origin caching headers
+        # entirely, and never store or propagate cookies.
+        proxy_ignore_headers Set-Cookie Cache-Control Expires Vary X-Accel-Expires;
+        proxy_hide_header Set-Cookie;
+
         # /web/<ts>id_/<url> snapshot bytes: immutable -> ~forever. Cached
         # 302s are IA timestamp-canonicalization, equally stable. 404s are
         # cached briefly so transient IA flakiness doesn't stick.


### PR DESCRIPTION
Found by the post-merge in-cluster smoke test: two identical fetches through the cache both returned `X-Wayback-Cache: MISS`. Full header dump showed why — IA replies carry a load-balancer cookie:

```
set-cookie: wb-p-SERVER=wwwb-app257; path=/
```

and nginx refuses to cache any response with `Set-Cookie` by default (likewise honoring origin `Cache-Control`/`Expires`/`Vary`). Cacheability for this service is structural — snapshot bytes at a fixed 14-digit timestamp are immutable — so tier 1 now ignores origin caching headers entirely (`proxy_ignore_headers Set-Cookie Cache-Control Expires Vary X-Accel-Expires`) and hides `Set-Cookie` so a cached LB cookie is never replayed to clients.

Validated with `nginx -t` in `nginx:alpine`. The `reloader` annotation restarts the deployment on the ConfigMap change; I'll re-run the MISS→HIT smoke after merge.

The 302 leg of the smoke already behaved correctly, for the record: requesting `/web/20200101000000id_/https://example.com/` returned IA's canonicalization redirect to capture `20191231234501` — before the requested timestamp, as the clamp design expects.

https://claude.ai/code/session_01C92Haj75EreshnVNLaFVMz

---
_Generated by [Claude Code](https://claude.ai/code/session_01C92Haj75EreshnVNLaFVMz)_