### PR TITLE
plan: TODO — autoprovision gecko's bootstrap image via stable latest key

### DIFF
--- a/cluster/docs/plan.md
+++ b/cluster/docs/plan.md
@@ -67,6 +67,22 @@ returns (not independently parked):
       nuked (data loss accepted, forward ingest is fine on v183+). Only the
       6 `augur-assets` landing jpegs still need to be re-uploaded — they
       live in `gaffer-private`, not this repo.
+- [ ] **Wire gecko's bootstrap image to autoprovision (stable `latest` key).**
+      gecko's `gecko-root` DataVolume hardcodes a specific
+      `bootstrap/<sha>.qcow2` URL, so when that object's SeaweedFS chunks were
+      lost on 2026-06-02 it needed a manual re-pin (#1980, to the readable
+      `da37375538…` = current `devel.latest.txt` target). The
+      `vm-images-publisher` already writes a `bootstrap/<ref>.latest.txt`
+      pointer, but a DataVolume can't dereference a pointer file. To make this
+      self-healing: have `publish.sh` also `aws s3 cp` to a stable key
+      (`bootstrap/<ref>.latest.qcow2`, overwritten each publish) and point
+      gecko's DataVolume at that — then refreshing the image is just a publish + DV recreate, no manifest edit. Caveat: the DataVolume `source` is a
+      one-shot seed and is gecko's root disk, so recreating it wipes the disk
+      (re-seed, not in-place upgrade). The dead `bootstrap/3b9e37c50911…qcow2`
+      phantom (+ sidecar) has been deleted, but several orphan
+      `bootstrap/<sha>.qcow2.sha256` sidecars with no surviving qcow2 still
+      linger in the `vm-images` bucket and could be swept too. See
+      <lessons_learned/2026_06_02_seaweedfs_volume_loss_ovh_rename.md>.
 - [ ] **Fix SeaweedFS rack labels.** All three OVH volume servers currently
       advertise `rack=hil-ovh-h109b04`, so the `defaultReplication: "001"`
       policy effectively means "any other DataNode" rather than "another


### PR DESCRIPTION
Records a followup in `cluster/docs/plan.md` Next Actions: wire the `vm-images-publisher` to also write a stable `bootstrap/<ref>.latest.qcow2` key that gecko's DataVolume tracks, so a lost/updated image is a publish + DV-recreate rather than a manual sha re-pin (as #1980 had to do after the 2026-06-02 SeaweedFS volume loss). Also notes the leftover orphan `.qcow2.sha256` sidecars to sweep. Docs-only.