### PR TITLE
gecko: stop forcing immediate CDI binding (honor WaitForFirstConsumer)

### DIFF
--- a/cluster/k8s/gecko/app/virtualmachine.yaml
+++ b/cluster/k8s/gecko/app/virtualmachine.yaml
@@ -7,17 +7,21 @@ metadata:
     app.kubernetes.io/name: gecko
 spec:
   runStrategy: Always
-  # Own the root-disk DataVolume so KubeVirt sequences import -> boot (it won't
-  # start virt-launcher until the import Succeeds, so the importer is the sole
-  # consumer during import). immediate.requested:true makes CDI provision the
-  # PVC up front rather than playing the WaitForFirstConsumer consumer-wait,
-  # which deadlocks/races against the scheduler on local-path-ovh (a WFFC
-  # storageclass) — see cluster/docs/lessons_learned and plan.md Next Actions.
+  # Own the root-disk DataVolume so KubeVirt drives the WaitForFirstConsumer
+  # bind: on local-path-ovh (a WFFC storageclass) CDI stays off the PVC, and
+  # KubeVirt schedules a short-lived pod with the VMI's requirements as the
+  # PVC's first consumer to bind it on the target node; CDI imports only after
+  # the PVC is Bound, then the VM boots — one consumer per phase, no race.
+  #
+  # Do NOT add cdi.kubevirt.io/storage.bind.immediate.requested here. CDI's
+  # ImmediateBindingRequested() is PRESENCE-based — ANY value (even "false")
+  # forces immediate binding, so CDI would start its own importer pod that
+  # races KubeVirt's bind pod for the same PVC, producing the "object has been
+  # modified" provisioning livelock. See
+  # https://github.com/kubevirt/containerized-data-importer/blob/main/doc/waitforfirstconsumer-storage-handling.md
   dataVolumeTemplates:
     - metadata:
         name: gecko-root
-        annotations:
-          cdi.kubevirt.io/storage.bind.immediate.requested: "true"
       spec:
         source:
           s3:


### PR DESCRIPTION
## Root cause (found by reading CDI source semantics)

CDI's [`ImmediateBindingRequested()`](https://pkg.go.dev/kubevirt.io/containerized-data-importer/pkg/controller/common#ImmediateBindingRequested) is **presence-based** — *any* value of `cdi.kubevirt.io/storage.bind.immediate.requested`, including `"false"`, counts as "immediate requested."

So:
- The **original** gecko config set the annotation to `"false"` (intending "honor WFFC") — a no-op that **still forced immediate binding**.
- **#1983** changed it to `"true"` — zero behavioral difference, still forced immediate.

With immediate binding forced on a WaitForFirstConsumer storageclass (`local-path-ovh`), CDI schedules its own importer pod that **races KubeVirt's WFFC bind pod** for the same PVC → the `object has been modified` provisioning livelock that needed manual `selected-node` nudging to clear every time.

## Fix

**Remove the annotation entirely.** Per the [CDI WFFC handling doc](https://github.com/kubevirt/containerized-data-importer/blob/main/doc/waitforfirstconsumer-storage-handling.md), CDI then honors WFFC: it stays off the PVC during binding, KubeVirt's short-lived pod is the **sole** consumer that binds it on the target node, and CDI imports only once Bound. One consumer per phase, no race.

(`HonorWaitForFirstConsumer` is enabled on this cluster's CDI, so this is the supported path.)

## Validation

After merge: clean teardown of the live VM + DV, let Flux + KubeVirt rebuild, confirm gecko provisions + imports + boots with **zero** manual intervention. This is the actual turnkey fix the autoprovision TODO (#1982) was after.