### PR TITLE
loki/promtail: add upgrade.disableWait for roaming nodes

### DIFF
--- a/cluster/k8s/monitoring/loki/promtail-helmrelease.yaml
+++ b/cluster/k8s/monitoring/loki/promtail-helmrelease.yaml
@@ -9,6 +9,9 @@ spec:
     remediation:
       retries: 3
   upgrade:
+    # DaemonSet runs on roaming nodes (rugged, iguana) that may be offline.
+    # Without this, Helm waits for all pods including those stuck Pending/Terminating
+    # on offline nodes, causing the HelmRelease to hit RetriesExceeded and stall.
     disableWait: true
   chart:
     spec:

--- a/cluster/k8s/monitoring/loki/promtail-helmrelease.yaml
+++ b/cluster/k8s/monitoring/loki/promtail-helmrelease.yaml
@@ -8,6 +8,8 @@ spec:
   install:
     remediation:
       retries: 3
+  upgrade:
+    disableWait: true
   chart:
     spec:
       chart: promtail


### PR DESCRIPTION
## Summary

- Adds `upgrade.disableWait: true` to the promtail HelmRelease with a comment explaining why
- Unblocks the current `RetriesExceeded` stall (caused by the wyrm2 DaemonSet pod stuck Terminating for 28d while Proxmox is offline)

## Root cause

Helm waits for all DaemonSet pods to become Ready on upgrade. Promtail is a DaemonSet that tolerates all nodes including roaming ones (rugged, iguana, wyrm2). When an offline node has a pod stuck Pending or Terminating, the upgrade waits until timeout → hits retry limit → `Stalled: RetriesExceeded`. Same fix as monitoring-stack already uses.

## Test plan

- [ ] PR merged to devel → Flux reconciles updated HelmRelease spec
- [ ] HelmRelease transitions from Stalled → Ready
- [ ] All running promtail pods stay Running