### PR TITLE
Add Tana LiteLLM provider

### DIFF
--- a/tana/firebase_resigner/BUILD.bazel
+++ b/tana/firebase_resigner/BUILD.bazel
@@ -8,6 +8,7 @@ load("//props:oci.bzl", "py_image_entrypoint", "py_image_env")
 py_library(
     name = "resigner",
     srcs = ["resigner.py"],
+    visibility = ["//tana:__subpackages__"],
     deps = [
         "@pypi//httpx",
         "@pypi//kubernetes_asyncio",

--- a/tana/litellm_proxy/BUILD.bazel
+++ b/tana/litellm_proxy/BUILD.bazel
@@ -1,0 +1,37 @@
+load("//devinfra/python:defs.bzl", "py_binary", "py_library", "py_test")
+
+py_library(
+    name = "provider",
+    srcs = [
+        "__init__.py",
+        "provider.py",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//tana/firebase_resigner:resigner",
+        "@pypi//httpx",
+        "@pypi//litellm",
+    ],
+)
+
+py_binary(
+    name = "demo",
+    srcs = ["demo.py"],
+    main_module = "tana.litellm_proxy.demo",
+    tags = ["manual"],
+    deps = [
+        ":provider",
+        "@pypi//litellm",
+    ],
+)
+
+py_test(
+    name = "test_provider",
+    srcs = ["test_provider.py"],
+    deps = [
+        ":provider",
+        "@pypi//httpx",
+        "@pypi//litellm",
+        "@pypi//pytest_bazel",
+    ],
+)

--- a/tana/litellm_proxy/README.md
+++ b/tana/litellm_proxy/README.md
@@ -1,0 +1,118 @@
+# Tana LiteLLM Provider
+
+This package is a small LiteLLM custom provider for Tana's internal
+`llmProxy` endpoint. It is intended as a development/demo integration, not as a
+stable public Tana API.
+
+## Usage
+
+```bash
+bazelisk run //tana/litellm_proxy:demo -- \
+  --model tana/claude-3-5-sonnet-latest \
+  --prompt 'Reply with exactly: tana-litellm-ok'
+```
+
+Tool-call smoke:
+
+```bash
+bazelisk run //tana/litellm_proxy:demo -- \
+  --model tana/claude-3-5-sonnet-latest \
+  --tool-demo
+```
+
+Streaming smoke:
+
+```bash
+bazelisk run //tana/litellm_proxy:demo -- \
+  --model tana/claude-3-5-sonnet-latest \
+  --stream \
+  --prompt 'Reply with exactly: tana-stream-ok'
+```
+
+Streaming tool-call smoke:
+
+```bash
+bazelisk run //tana/litellm_proxy:demo -- \
+  --model tana/claude-3-5-sonnet-latest \
+  --stream \
+  --tool-demo
+```
+
+The model prefix before the first slash is LiteLLM's custom provider name. The
+provider strips `tana/` and sends the remainder as Tana's `options.model`.
+
+## Authentication
+
+The provider exchanges a Firebase refresh token for a Firebase ID token, then
+uses that ID token as `Authorization: Bearer <id-token>` when calling:
+
+```text
+POST https://app.tana.inc/functions/llmProxy
+POST https://app.tana.inc/functions/llmProxyNext
+```
+
+Refresh token lookup order:
+
+1. `TANA_FIREBASE_REFRESH_TOKEN`
+2. `TANA_FIREBASE_REFRESH_TOKEN_FILE`
+3. Kubernetes secret via local `kubectl`
+
+The default secret is `tana-mcp/tana-firebase-refresh-token`, key
+`refresh_token`, matching the in-cluster Tana MCP setup.
+
+The default `userContext` is `Generic AI Query`, one of the labels observed in
+the Tana client. The live endpoint rejects arbitrary labels during request
+validation. Treat it as a Tana action/accounting label, not as LLM prompt
+content; model input goes in `args.messages`.
+
+## LiteLLM Mapping
+
+The provider maps basic OpenAI-style chat fields onto Tana's request shape.
+OpenAI/LiteLLM `messages` are always sent as Tana `args.messages` envelopes;
+the provider does not collapse chat into a single prompt string.
+
+| LiteLLM/OpenAI option | Tana option |
+| --- | --- |
+| `model="tana/<model>"` | `args.options.model="<model>"` |
+| `messages` | `args.messages` |
+| `temperature` | `args.options.temperature` |
+| `top_p` | `args.options.topP` |
+| `max_tokens` / `max_completion_tokens` | `args.options.maxOutputTokens` |
+| `stop` | `args.options.stopStrings` |
+| `frequency_penalty` | `args.options.frequencyPenalty` |
+| `presence_penalty` | `args.options.presencePenalty` |
+| `tools` | `llmProxyNext.dynamicTools` |
+| `stream=True` | `isStreaming: true` |
+
+Message normalization preserves message boundaries and maps common OpenAI/AI SDK
+aliases into the Tana core-message shape:
+
+- message and content-block `provider_options` become `providerOptions`
+- content blocks with `type: "input_text"` become Tana `type: "text"` blocks
+- assistant `tool_calls` become `content` blocks with `type: "tool-call"`
+- OpenAI `tool` messages become `content` blocks with `type: "tool-result"`
+
+When `tools` are present, the provider switches to `llmProxyNext`, sends
+source-observed `userContext: "Ask Tana"`, and maps OpenAI function tools to
+Tana client-runtime dynamic tools:
+
+```json
+{
+  "name": "tool_name",
+  "description": "Tool description",
+  "kind": "mcpTool",
+  "runtime": "client",
+  "schema": {"type": "object", "properties": {}}
+}
+```
+
+Returned Tana `toolCalls` are converted back into OpenAI-style
+`message.tool_calls`. The provider does not execute tools locally; callers
+should execute the returned function calls and continue the chat themselves.
+
+For `stream=True`, the provider returns LiteLLM streaming chunks. Plain text
+streaming parses Tana `data: {"type":"text-delta",...}` and AI SDK-style
+`0:"..."` records. Tool streaming parses `llmProxyNext` tool-input events into
+OpenAI-style `delta.tool_calls`; Tana can emit an initial empty `{}` tool
+argument delta before the full JSON arguments, and the demo merges those deltas
+before printing.

--- a/tana/litellm_proxy/README.md
+++ b/tana/litellm_proxy/README.md
@@ -71,18 +71,18 @@ The provider maps basic OpenAI-style chat fields onto Tana's request shape.
 OpenAI/LiteLLM `messages` are always sent as Tana `args.messages` envelopes;
 the provider does not collapse chat into a single prompt string.
 
-| LiteLLM/OpenAI option | Tana option |
-| --- | --- |
-| `model="tana/<model>"` | `args.options.model="<model>"` |
-| `messages` | `args.messages` |
-| `temperature` | `args.options.temperature` |
-| `top_p` | `args.options.topP` |
-| `max_tokens` / `max_completion_tokens` | `args.options.maxOutputTokens` |
-| `stop` | `args.options.stopStrings` |
-| `frequency_penalty` | `args.options.frequencyPenalty` |
-| `presence_penalty` | `args.options.presencePenalty` |
-| `tools` | `llmProxyNext.dynamicTools` |
-| `stream=True` | `isStreaming: true` |
+| LiteLLM/OpenAI option                  | Tana option                     |
+| -------------------------------------- | ------------------------------- |
+| `model="tana/<model>"`                 | `args.options.model="<model>"`  |
+| `messages`                             | `args.messages`                 |
+| `temperature`                          | `args.options.temperature`      |
+| `top_p`                                | `args.options.topP`             |
+| `max_tokens` / `max_completion_tokens` | `args.options.maxOutputTokens`  |
+| `stop`                                 | `args.options.stopStrings`      |
+| `frequency_penalty`                    | `args.options.frequencyPenalty` |
+| `presence_penalty`                     | `args.options.presencePenalty`  |
+| `tools`                                | `llmProxyNext.dynamicTools`     |
+| `stream=True`                          | `isStreaming: true`             |
 
 Message normalization preserves message boundaries and maps common OpenAI/AI SDK
 aliases into the Tana core-message shape:
@@ -102,7 +102,7 @@ Tana client-runtime dynamic tools:
   "description": "Tool description",
   "kind": "mcpTool",
   "runtime": "client",
-  "schema": {"type": "object", "properties": {}}
+  "schema": { "type": "object", "properties": {} }
 }
 ```
 

--- a/tana/litellm_proxy/__init__.py
+++ b/tana/litellm_proxy/__init__.py
@@ -1,15 +1,5 @@
 """LiteLLM adapter for Tana's internal LLM proxy."""
 
-from tana.litellm_proxy.provider import (
-    TanaLiteLLM,
-    TanaProxyClient,
-    TanaProxyConfig,
-    register_litellm_provider,
-)
+from tana.litellm_proxy.provider import TanaLiteLLM, TanaProxyClient, TanaProxyConfig, register_litellm_provider
 
-__all__ = [
-    "TanaLiteLLM",
-    "TanaProxyClient",
-    "TanaProxyConfig",
-    "register_litellm_provider",
-]
+__all__ = ["TanaLiteLLM", "TanaProxyClient", "TanaProxyConfig", "register_litellm_provider"]

--- a/tana/litellm_proxy/__init__.py
+++ b/tana/litellm_proxy/__init__.py
@@ -1,0 +1,15 @@
+"""LiteLLM adapter for Tana's internal LLM proxy."""
+
+from tana.litellm_proxy.provider import (
+    TanaLiteLLM,
+    TanaProxyClient,
+    TanaProxyConfig,
+    register_litellm_provider,
+)
+
+__all__ = [
+    "TanaLiteLLM",
+    "TanaProxyClient",
+    "TanaProxyConfig",
+    "register_litellm_provider",
+]

--- a/tana/litellm_proxy/demo.py
+++ b/tana/litellm_proxy/demo.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping
+from typing import Any
+
+import litellm
+from litellm.types.utils import Choices
+
+from tana.litellm_proxy.provider import register_litellm_provider
+
+DEMO_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "lookup_demo_fact",
+        "description": "Look up one short demo fact by topic.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "topic": {
+                    "type": "string",
+                    "description": "The exact topic to look up.",
+                }
+            },
+            "required": ["topic"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Call Tana's llmProxy through LiteLLM.")
+    parser.add_argument("--model", default="tana/claude-3-5-sonnet-latest")
+    parser.add_argument("--prompt", default="Reply with exactly: tana-litellm-ok")
+    parser.add_argument("--system", default=None)
+    parser.add_argument("--temperature", type=float, default=0.0)
+    parser.add_argument("--max-tokens", type=int, default=64)
+    parser.add_argument("--tool-demo", action="store_true", help="Ask the model to emit a demo function tool call.")
+    parser.add_argument("--stream", action="store_true", help="Use LiteLLM streaming mode.")
+    args = parser.parse_args()
+
+    register_litellm_provider()
+    messages: list[dict[str, str]] = []
+    if args.system:
+        messages.append({"role": "system", "content": args.system})
+    prompt = args.prompt
+    tools = None
+    if args.tool_demo:
+        tools = [DEMO_TOOL]
+        prompt = (
+            "Call the lookup_demo_fact tool exactly once with topic "
+            "'tana-litellm-tool'. Do not answer directly."
+        )
+    messages.append({"role": "user", "content": prompt})
+
+    completion_kwargs = {
+        "model": args.model,
+        "messages": messages,
+        "temperature": args.temperature,
+        "max_tokens": args.max_tokens,
+        "tools": tools,
+    }
+    if args.stream:
+        stream = litellm.completion(**completion_kwargs, stream=True)
+        streamed_tool_calls: dict[str, dict[str, Any]] = {}
+        printed_text = False
+        for chunk in stream:
+            choice = chunk.choices[0]
+            delta = choice.delta
+            content = _field(delta, "content")
+            if content:
+                print(content, end="", flush=True)
+                printed_text = True
+            tool_calls = _field(delta, "tool_calls")
+            if tool_calls:
+                for tool_call in tool_calls:
+                    _merge_tool_call_delta(streamed_tool_calls, _tool_call_to_dict(tool_call))
+        if streamed_tool_calls:
+            if printed_text:
+                print()
+            print(json.dumps(list(streamed_tool_calls.values()), indent=2))
+        else:
+            print()
+        return 0
+
+    response = litellm.completion(**completion_kwargs)
+    choice = response.choices[0]
+    if not isinstance(choice, Choices):
+        raise TypeError(f"unexpected streaming choice in non-streaming response: {type(choice).__name__}")
+    if choice.message.tool_calls:
+        print(
+            json.dumps(
+                [
+                    {
+                        "id": tool_call.id,
+                        "type": tool_call.type,
+                        "function": {
+                            "name": tool_call.function.name,
+                            "arguments": tool_call.function.arguments,
+                        },
+                    }
+                    for tool_call in choice.message.tool_calls
+                ],
+                indent=2,
+            )
+        )
+    else:
+        print(choice.message.content)
+    return 0
+
+
+def _field(value: Any, name: str) -> Any:
+    if isinstance(value, Mapping):
+        return value.get(name)
+    return getattr(value, name, None)
+
+
+def _tool_call_to_dict(tool_call: Any) -> dict[str, Any]:
+    function = _field(tool_call, "function")
+    return {
+        "id": _field(tool_call, "id"),
+        "type": _field(tool_call, "type"),
+        "function": {
+            "name": _field(function, "name"),
+            "arguments": _field(function, "arguments"),
+        },
+    }
+
+
+def _merge_tool_call_delta(tool_calls: dict[str, dict[str, Any]], delta: dict[str, Any]) -> None:
+    key = str(delta.get("id") or len(tool_calls))
+    existing = tool_calls.setdefault(
+        key,
+        {
+            "id": delta.get("id"),
+            "type": delta.get("type") or "function",
+            "function": {"name": None, "arguments": ""},
+        },
+    )
+    function = delta.get("function") or {}
+    if delta.get("id"):
+        existing["id"] = delta["id"]
+    if delta.get("type"):
+        existing["type"] = delta["type"]
+    if function.get("name"):
+        existing["function"]["name"] = function["name"]
+    arguments = function.get("arguments")
+    if arguments:
+        existing_arguments = existing["function"]["arguments"]
+        if arguments == "{}" and not existing_arguments:
+            return
+        if existing_arguments == "{}" and arguments.startswith("{"):
+            existing["function"]["arguments"] = ""
+        existing["function"]["arguments"] += arguments
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tana/litellm_proxy/demo.py
+++ b/tana/litellm_proxy/demo.py
@@ -17,12 +17,7 @@ DEMO_TOOL = {
         "description": "Look up one short demo fact by topic.",
         "parameters": {
             "type": "object",
-            "properties": {
-                "topic": {
-                    "type": "string",
-                    "description": "The exact topic to look up.",
-                }
-            },
+            "properties": {"topic": {"type": "string", "description": "The exact topic to look up."}},
             "required": ["topic"],
             "additionalProperties": False,
         },
@@ -49,10 +44,7 @@ def main() -> int:
     tools = None
     if args.tool_demo:
         tools = [DEMO_TOOL]
-        prompt = (
-            "Call the lookup_demo_fact tool exactly once with topic "
-            "'tana-litellm-tool'. Do not answer directly."
-        )
+        prompt = "Call the lookup_demo_fact tool exactly once with topic 'tana-litellm-tool'. Do not answer directly."
     messages.append({"role": "user", "content": prompt})
 
     completion_kwargs = {
@@ -96,10 +88,7 @@ def main() -> int:
                     {
                         "id": tool_call.id,
                         "type": tool_call.type,
-                        "function": {
-                            "name": tool_call.function.name,
-                            "arguments": tool_call.function.arguments,
-                        },
+                        "function": {"name": tool_call.function.name, "arguments": tool_call.function.arguments},
                     }
                     for tool_call in choice.message.tool_calls
                 ],
@@ -122,10 +111,7 @@ def _tool_call_to_dict(tool_call: Any) -> dict[str, Any]:
     return {
         "id": _field(tool_call, "id"),
         "type": _field(tool_call, "type"),
-        "function": {
-            "name": _field(function, "name"),
-            "arguments": _field(function, "arguments"),
-        },
+        "function": {"name": _field(function, "name"), "arguments": _field(function, "arguments")},
     }
 
 
@@ -133,11 +119,7 @@ def _merge_tool_call_delta(tool_calls: dict[str, dict[str, Any]], delta: dict[st
     key = str(delta.get("id") or len(tool_calls))
     existing = tool_calls.setdefault(
         key,
-        {
-            "id": delta.get("id"),
-            "type": delta.get("type") or "function",
-            "function": {"name": None, "arguments": ""},
-        },
+        {"id": delta.get("id"), "type": delta.get("type") or "function", "function": {"name": None, "arguments": ""}},
     )
     function = delta.get("function") or {}
     if delta.get("id"):

--- a/tana/litellm_proxy/provider.py
+++ b/tana/litellm_proxy/provider.py
@@ -8,6 +8,7 @@ import subprocess
 import time
 from collections.abc import AsyncIterator, Callable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Protocol, cast
 
 import httpx
@@ -71,28 +72,16 @@ class TanaChatResult:
 
 class _ChatClient(Protocol):
     async def chat_completion(
-        self,
-        model: str,
-        messages: Sequence[Mapping[str, Any]],
-        optional_params: Mapping[str, Any] | None = None,
-    ) -> TanaChatResult:
-        ...
+        self, model: str, messages: Sequence[Mapping[str, Any]], optional_params: Mapping[str, Any] | None = None
+    ) -> TanaChatResult: ...
 
     def stream_completion(
-        self,
-        model: str,
-        messages: Sequence[Mapping[str, Any]],
-        optional_params: Mapping[str, Any] | None = None,
-    ) -> Iterator[GenericStreamingChunk]:
-        ...
+        self, model: str, messages: Sequence[Mapping[str, Any]], optional_params: Mapping[str, Any] | None = None
+    ) -> Iterator[GenericStreamingChunk]: ...
 
     def astream_completion(
-        self,
-        model: str,
-        messages: Sequence[Mapping[str, Any]],
-        optional_params: Mapping[str, Any] | None = None,
-    ) -> AsyncIterator[GenericStreamingChunk]:
-        ...
+        self, model: str, messages: Sequence[Mapping[str, Any]], optional_params: Mapping[str, Any] | None = None
+    ) -> AsyncIterator[GenericStreamingChunk]: ...
 
 
 Runner = Callable[[list[str]], subprocess.CompletedProcess[str]]
@@ -106,19 +95,15 @@ def _env_bool(name: str, default: bool) -> bool:
 
 
 def _run_command(args: list[str]) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(args, check=True, stderr=subprocess.PIPE, stdout=subprocess.PIPE, text=True)
+    return subprocess.run(args, check=True, capture_output=True, text=True)
 
 
 def _secret_ref_parts(secret_ref: str) -> tuple[str, str]:
     if "/" not in secret_ref:
-        raise TanaProxyError(
-            f"TANA_FIREBASE_REFRESH_TOKEN_SECRET must be namespace/name, got {secret_ref!r}"
-        )
+        raise TanaProxyError(f"TANA_FIREBASE_REFRESH_TOKEN_SECRET must be namespace/name, got {secret_ref!r}")
     namespace, name = secret_ref.split("/", 1)
     if not namespace or not name:
-        raise TanaProxyError(
-            f"TANA_FIREBASE_REFRESH_TOKEN_SECRET must be namespace/name, got {secret_ref!r}"
-        )
+        raise TanaProxyError(f"TANA_FIREBASE_REFRESH_TOKEN_SECRET must be namespace/name, got {secret_ref!r}")
     return namespace, name
 
 
@@ -126,7 +111,7 @@ def read_refresh_token_from_config(cfg: TanaProxyConfig, runner: Runner = _run_c
     if cfg.refresh_token:
         return cfg.refresh_token.strip()
     if cfg.refresh_token_file:
-        with open(cfg.refresh_token_file, encoding="utf-8") as token_file:
+        with Path(cfg.refresh_token_file).open(encoding="utf-8") as token_file:
             return token_file.read().strip()
 
     namespace, name = _secret_ref_parts(cfg.refresh_token_secret)
@@ -134,8 +119,7 @@ def read_refresh_token_from_config(cfg: TanaProxyConfig, runner: Runner = _run_c
         completed = runner(["kubectl", "get", "secret", "-n", namespace, name, "-o", "json"])
     except FileNotFoundError as exc:
         raise TanaProxyError(
-            "kubectl is required when TANA_FIREBASE_REFRESH_TOKEN or "
-            "TANA_FIREBASE_REFRESH_TOKEN_FILE is not set"
+            "kubectl is required when TANA_FIREBASE_REFRESH_TOKEN or TANA_FIREBASE_REFRESH_TOKEN_FILE is not set"
         ) from exc
     except subprocess.CalledProcessError as exc:
         stderr = exc.stderr.strip() if exc.stderr else str(exc)
@@ -151,9 +135,7 @@ def read_refresh_token_from_config(cfg: TanaProxyConfig, runner: Runner = _run_c
         ) from exc
 
 
-async def _refresh_id_token_once(
-    http: httpx.AsyncClient, cfg: ResignerConfig, refresh_token: str
-) -> FreshTokens:
+async def _refresh_id_token_once(http: httpx.AsyncClient, cfg: ResignerConfig, refresh_token: str) -> FreshTokens:
     response = await http.post(
         "https://securetoken.googleapis.com/v1/token",
         params={"key": cfg.api_key},
@@ -209,10 +191,7 @@ class TanaProxyClient:
         self._refresh_token: str | None = self._cfg.refresh_token
 
     async def chat_completion(
-        self,
-        model: str,
-        messages: Sequence[Mapping[str, Any]],
-        optional_params: Mapping[str, Any] | None = None,
+        self, model: str, messages: Sequence[Mapping[str, Any]], optional_params: Mapping[str, Any] | None = None
     ) -> TanaChatResult:
         if self._http_client is not None:
             return await self._chat_completion(self._http_client, model, messages, optional_params or {})
@@ -231,17 +210,8 @@ class TanaProxyClient:
         id_token = await self._id_token_for_request(http)
         if _has_tools(optional_params):
             return await self._tool_chat_completion(http, id_token, model, messages, optional_params)
-        args = _basic_chat_args(
-            self._cfg.user_context,
-            _strip_tana_prefix(model),
-            messages,
-            optional_params,
-            self._cfg,
-        )
-        body = {
-            "isStreaming": False,
-            "args": args,
-        }
+        args = _basic_chat_args(self._cfg.user_context, _strip_tana_prefix(model), messages, optional_params, self._cfg)
+        body = {"isStreaming": False, "args": args}
         response = await http.post(
             f"{self._cfg.functions_base_url.rstrip('/')}/llmProxy",
             json=body,
@@ -299,10 +269,7 @@ class TanaProxyClient:
         return fresh.id_token
 
     def stream_completion(
-        self,
-        model: str,
-        messages: Sequence[Mapping[str, Any]],
-        optional_params: Mapping[str, Any] | None = None,
+        self, model: str, messages: Sequence[Mapping[str, Any]], optional_params: Mapping[str, Any] | None = None
     ) -> Iterator[GenericStreamingChunk]:
         if self._sync_http_client is not None:
             yield from self._stream_completion(self._sync_http_client, model, messages, optional_params or {})
@@ -312,11 +279,7 @@ class TanaProxyClient:
             yield from self._stream_completion(http, model, messages, optional_params or {})
 
     def _stream_completion(
-        self,
-        http: httpx.Client,
-        model: str,
-        messages: Sequence[Mapping[str, Any]],
-        optional_params: Mapping[str, Any],
+        self, http: httpx.Client, model: str, messages: Sequence[Mapping[str, Any]], optional_params: Mapping[str, Any]
     ) -> Iterator[GenericStreamingChunk]:
         _reject_unsupported(optional_params)
         id_token = self._id_token_for_request_sync(http)
@@ -336,15 +299,10 @@ class TanaProxyClient:
             yield from _parse_tana_stream_lines(response.iter_lines())
 
     async def astream_completion(
-        self,
-        model: str,
-        messages: Sequence[Mapping[str, Any]],
-        optional_params: Mapping[str, Any] | None = None,
+        self, model: str, messages: Sequence[Mapping[str, Any]], optional_params: Mapping[str, Any] | None = None
     ) -> AsyncIterator[GenericStreamingChunk]:
         if self._http_client is not None:
-            async for chunk in self._astream_completion(
-                self._http_client, model, messages, optional_params or {}
-            ):
+            async for chunk in self._astream_completion(self._http_client, model, messages, optional_params or {}):
                 yield chunk
             return
 
@@ -378,10 +336,7 @@ class TanaProxyClient:
                 yield chunk
 
     def _stream_request(
-        self,
-        model: str,
-        messages: Sequence[Mapping[str, Any]],
-        optional_params: Mapping[str, Any],
+        self, model: str, messages: Sequence[Mapping[str, Any]], optional_params: Mapping[str, Any]
     ) -> tuple[str, dict[str, Any]]:
         if _has_tools(optional_params):
             return (
@@ -451,9 +406,7 @@ class TanaLiteLLM(CustomLLM):
 
 def register_litellm_provider(handler: TanaLiteLLM | None = None) -> TanaLiteLLM:
     custom_handler = handler or TanaLiteLLM()
-    litellm.custom_provider_map = [
-        item for item in litellm.custom_provider_map if item.get("provider") != "tana"
-    ]
+    litellm.custom_provider_map = [item for item in litellm.custom_provider_map if item.get("provider") != "tana"]
     litellm.custom_provider_map.append({"provider": "tana", "custom_handler": custom_handler})
     custom_llm_setup()
     return custom_handler
@@ -560,10 +513,7 @@ def _normalize_messages(messages: Sequence[Mapping[str, Any]]) -> list[dict[str,
             content = _append_content_parts(content, _normalize_tool_call_parts(tool_calls))
         if role == "tool":
             content = _normalize_tool_result_content(message, content)
-        normalized_message = {
-            "role": role,
-            "content": content,
-        }
+        normalized_message = {"role": role, "content": content}
         _copy_first_set(message, normalized_message, ("providerOptions", "provider_options"), "providerOptions")
         normalized.append(normalized_message)
     return normalized
@@ -670,11 +620,7 @@ def _normalize_tool_result_content(message: Mapping[str, Any], content: Any) -> 
             return normalized_parts
     if not isinstance(tool_call_id, str) or not tool_call_id:
         raise TanaProxyError(f"tool message is missing tool_call_id/toolCallId: {message!r}")
-    part: dict[str, Any] = {
-        "type": "tool-result",
-        "toolCallId": tool_call_id,
-        "output": content,
-    }
+    part: dict[str, Any] = {"type": "tool-result", "toolCallId": tool_call_id, "output": content}
     if isinstance(tool_name, str) and tool_name:
         part["toolName"] = tool_name
     return [part]
@@ -717,9 +663,7 @@ def _copy_if_set(source: Mapping[str, Any], dest: dict[str, Any], source_key: st
         dest[dest_key] = value
 
 
-def _copy_first_set(
-    source: Mapping[str, Any], dest: dict[str, Any], source_keys: Sequence[str], dest_key: str
-) -> None:
+def _copy_first_set(source: Mapping[str, Any], dest: dict[str, Any], source_keys: Sequence[str], dest_key: str) -> None:
     for source_key in source_keys:
         value = source.get(source_key)
         if value is not None:
@@ -747,11 +691,7 @@ def _parse_tana_response(response: httpx.Response) -> TanaChatResult:
         tool_results = data.get("toolResults") if isinstance(data.get("toolResults"), list) else None
         if "text" in data:
             return TanaChatResult(
-                text=str(data["text"] or ""),
-                tool_calls=tool_calls,
-                tool_results=tool_results,
-                usage=usage,
-                raw=data,
+                text=str(data["text"] or ""), tool_calls=tool_calls, tool_results=tool_results, usage=usage, raw=data
             )
         result = data.get("result")
         if isinstance(result, Mapping) and "text" in result:
@@ -763,8 +703,7 @@ def _parse_tana_response(response: httpx.Response) -> TanaChatResult:
 
 def _parse_tana_stream_lines(lines: Iterator[str]) -> Iterator[GenericStreamingChunk]:
     for line in lines:
-        for chunk in _parse_tana_stream_line(line):
-            yield chunk
+        yield from _parse_tana_stream_line(line)
 
 
 async def _parse_tana_stream_lines_async(lines: AsyncIterator[str]) -> AsyncIterator[GenericStreamingChunk]:
@@ -892,10 +831,7 @@ def _openai_tool_call_chunk(
         {
             "id": str(normalized["toolCallId"]),
             "type": "function",
-            "function": {
-                "name": str(normalized["toolName"]),
-                "arguments": arguments,
-            },
+            "function": {"name": str(normalized["toolName"]), "arguments": arguments},
             "index": index,
         },
     )
@@ -975,12 +911,7 @@ def _stream_chunk(
     provider_specific_fields: dict[str, Any] | None = None,
 ) -> GenericStreamingChunk:
     chunk = GenericStreamingChunk(
-        text=text,
-        tool_use=tool_use,
-        is_finished=is_finished,
-        finish_reason=finish_reason,
-        usage=usage,
-        index=0,
+        text=text, tool_use=tool_use, is_finished=is_finished, finish_reason=finish_reason, usage=usage, index=0
     )
     if provider_specific_fields:
         chunk["provider_specific_fields"] = provider_specific_fields
@@ -997,10 +928,7 @@ def _normalize_stream_usage(data: Mapping[str, Any]) -> dict[str, int] | None:
 def _list_of_mappings(value: Any) -> list[dict[str, Any]] | None:
     if not isinstance(value, list):
         return None
-    mappings: list[dict[str, Any]] = []
-    for item in value:
-        if isinstance(item, Mapping):
-            mappings.append(dict(item))
+    mappings = [dict(item) for item in value if isinstance(item, Mapping)]
     return mappings or None
 
 
@@ -1053,13 +981,7 @@ def _openai_tool_calls(tool_calls: list[dict[str, Any]] | None) -> list[dict[str
         chunk = _openai_tool_call_chunk(tool_call, index)
         if chunk is None:
             continue
-        converted.append(
-            {
-                "id": chunk["id"] or f"call_{index}",
-                "type": chunk["type"],
-                "function": chunk["function"],
-            }
-        )
+        converted.append({"id": chunk["id"] or f"call_{index}", "type": chunk["type"], "function": chunk["function"]})
     return converted or None
 
 

--- a/tana/litellm_proxy/provider.py
+++ b/tana/litellm_proxy/provider.py
@@ -1,0 +1,1070 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import os
+import subprocess
+import time
+from collections.abc import AsyncIterator, Callable, Iterator, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Protocol, cast
+
+import httpx
+import litellm
+from litellm import CustomLLM
+from litellm.types.llms.openai import ChatCompletionToolCallChunk
+from litellm.types.utils import GenericStreamingChunk, ModelResponse, Usage
+from litellm.utils import custom_llm_setup
+
+from tana.firebase_resigner.resigner import FreshTokens, ResignerConfig
+
+DEFAULT_FIREBASE_API_KEY = "AIzaSyA9LtJM6Ga9VAwCfj9w_mNORdOaq2yLshQ"
+DEFAULT_FUNCTIONS_BASE_URL = "https://app.tana.inc/functions"
+DEFAULT_REFRESH_TOKEN_SECRET = "tana-mcp/tana-firebase-refresh-token"
+DEFAULT_REFRESH_TOKEN_KEY = "refresh_token"
+
+
+class TanaProxyError(RuntimeError):
+    """Raised when a Tana proxy request or token lookup fails."""
+
+
+@dataclass(frozen=True)
+class TanaProxyConfig:
+    firebase_api_key: str = DEFAULT_FIREBASE_API_KEY
+    functions_base_url: str = DEFAULT_FUNCTIONS_BASE_URL
+    user_context: str = "Generic AI Query"
+    tool_user_context: str = "Ask Tana"
+    refresh_token: str | None = None
+    refresh_token_file: str | None = None
+    refresh_token_secret: str = DEFAULT_REFRESH_TOKEN_SECRET
+    refresh_token_secret_key: str = DEFAULT_REFRESH_TOKEN_KEY
+    request_timeout_seconds: float = 60.0
+    ignore_large_context_warning: bool = True
+    ignore_out_of_credits_warning: bool = False
+
+    @classmethod
+    def from_env(cls) -> TanaProxyConfig:
+        return cls(
+            firebase_api_key=os.environ.get("TANA_FIREBASE_API_KEY", DEFAULT_FIREBASE_API_KEY),
+            functions_base_url=os.environ.get("TANA_FUNCTIONS_BASE_URL", DEFAULT_FUNCTIONS_BASE_URL),
+            user_context=os.environ.get("TANA_LLM_USER_CONTEXT", "Generic AI Query"),
+            tool_user_context=os.environ.get("TANA_LLM_TOOL_USER_CONTEXT", "Ask Tana"),
+            refresh_token=os.environ.get("TANA_FIREBASE_REFRESH_TOKEN"),
+            refresh_token_file=os.environ.get("TANA_FIREBASE_REFRESH_TOKEN_FILE"),
+            refresh_token_secret=os.environ.get("TANA_FIREBASE_REFRESH_TOKEN_SECRET", DEFAULT_REFRESH_TOKEN_SECRET),
+            refresh_token_secret_key=os.environ.get("TANA_FIREBASE_REFRESH_TOKEN_KEY", DEFAULT_REFRESH_TOKEN_KEY),
+            request_timeout_seconds=float(os.environ.get("TANA_LLM_TIMEOUT_SECONDS", "60")),
+            ignore_large_context_warning=_env_bool("TANA_IGNORE_LARGE_CONTEXT_WARNING", True),
+            ignore_out_of_credits_warning=_env_bool("TANA_IGNORE_OUT_OF_CREDITS_WARNING", False),
+        )
+
+
+@dataclass(frozen=True)
+class TanaChatResult:
+    text: str
+    tool_calls: list[dict[str, Any]] | None = None
+    tool_results: list[Any] | None = None
+    usage: dict[str, int] | None = None
+    raw: Any | None = None
+
+
+class _ChatClient(Protocol):
+    async def chat_completion(
+        self,
+        model: str,
+        messages: Sequence[Mapping[str, Any]],
+        optional_params: Mapping[str, Any] | None = None,
+    ) -> TanaChatResult:
+        ...
+
+    def stream_completion(
+        self,
+        model: str,
+        messages: Sequence[Mapping[str, Any]],
+        optional_params: Mapping[str, Any] | None = None,
+    ) -> Iterator[GenericStreamingChunk]:
+        ...
+
+    def astream_completion(
+        self,
+        model: str,
+        messages: Sequence[Mapping[str, Any]],
+        optional_params: Mapping[str, Any] | None = None,
+    ) -> AsyncIterator[GenericStreamingChunk]:
+        ...
+
+
+Runner = Callable[[list[str]], subprocess.CompletedProcess[str]]
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.lower() in {"1", "true", "yes", "on"}
+
+
+def _run_command(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, check=True, stderr=subprocess.PIPE, stdout=subprocess.PIPE, text=True)
+
+
+def _secret_ref_parts(secret_ref: str) -> tuple[str, str]:
+    if "/" not in secret_ref:
+        raise TanaProxyError(
+            f"TANA_FIREBASE_REFRESH_TOKEN_SECRET must be namespace/name, got {secret_ref!r}"
+        )
+    namespace, name = secret_ref.split("/", 1)
+    if not namespace or not name:
+        raise TanaProxyError(
+            f"TANA_FIREBASE_REFRESH_TOKEN_SECRET must be namespace/name, got {secret_ref!r}"
+        )
+    return namespace, name
+
+
+def read_refresh_token_from_config(cfg: TanaProxyConfig, runner: Runner = _run_command) -> str:
+    if cfg.refresh_token:
+        return cfg.refresh_token.strip()
+    if cfg.refresh_token_file:
+        with open(cfg.refresh_token_file, encoding="utf-8") as token_file:
+            return token_file.read().strip()
+
+    namespace, name = _secret_ref_parts(cfg.refresh_token_secret)
+    try:
+        completed = runner(["kubectl", "get", "secret", "-n", namespace, name, "-o", "json"])
+    except FileNotFoundError as exc:
+        raise TanaProxyError(
+            "kubectl is required when TANA_FIREBASE_REFRESH_TOKEN or "
+            "TANA_FIREBASE_REFRESH_TOKEN_FILE is not set"
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        stderr = exc.stderr.strip() if exc.stderr else str(exc)
+        raise TanaProxyError(f"failed to read Kubernetes secret {namespace}/{name}: {stderr}") from exc
+
+    try:
+        secret = json.loads(completed.stdout)
+        encoded = secret["data"][cfg.refresh_token_secret_key]
+        return base64.b64decode(encoded).decode("utf-8").strip()
+    except (KeyError, ValueError, json.JSONDecodeError) as exc:
+        raise TanaProxyError(
+            f"Kubernetes secret {namespace}/{name} is missing data key {cfg.refresh_token_secret_key!r}"
+        ) from exc
+
+
+async def _refresh_id_token_once(
+    http: httpx.AsyncClient, cfg: ResignerConfig, refresh_token: str
+) -> FreshTokens:
+    response = await http.post(
+        "https://securetoken.googleapis.com/v1/token",
+        params={"key": cfg.api_key},
+        data={"grant_type": "refresh_token", "refresh_token": refresh_token},
+    )
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        raise TanaProxyError(
+            f"Firebase refresh-token exchange failed with HTTP {response.status_code}: {_body_snippet(response)}"
+        ) from exc
+    data = response.json()
+    return FreshTokens(
+        id_token=data["id_token"], refresh_token=data["refresh_token"], expires_in=int(data["expires_in"])
+    )
+
+
+def _refresh_id_token_once_sync(http: httpx.Client, cfg: ResignerConfig, refresh_token: str) -> FreshTokens:
+    response = http.post(
+        "https://securetoken.googleapis.com/v1/token",
+        params={"key": cfg.api_key},
+        data={"grant_type": "refresh_token", "refresh_token": refresh_token},
+    )
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        raise TanaProxyError(
+            f"Firebase refresh-token exchange failed with HTTP {response.status_code}: {_body_snippet(response)}"
+        ) from exc
+    data = response.json()
+    return FreshTokens(
+        id_token=data["id_token"], refresh_token=data["refresh_token"], expires_in=int(data["expires_in"])
+    )
+
+
+class TanaProxyClient:
+    def __init__(
+        self,
+        cfg: TanaProxyConfig | None = None,
+        *,
+        http_client: httpx.AsyncClient | None = None,
+        sync_http_client: httpx.Client | None = None,
+        refresh_token_reader: Callable[[TanaProxyConfig], str] = read_refresh_token_from_config,
+        now: Callable[[], float] = time.time,
+    ) -> None:
+        self._cfg = cfg or TanaProxyConfig.from_env()
+        self._http_client = http_client
+        self._sync_http_client = sync_http_client
+        self._refresh_token_reader = refresh_token_reader
+        self._now = now
+        self._id_token: str | None = None
+        self._id_token_expires_at = 0.0
+        self._refresh_token: str | None = self._cfg.refresh_token
+
+    async def chat_completion(
+        self,
+        model: str,
+        messages: Sequence[Mapping[str, Any]],
+        optional_params: Mapping[str, Any] | None = None,
+    ) -> TanaChatResult:
+        if self._http_client is not None:
+            return await self._chat_completion(self._http_client, model, messages, optional_params or {})
+
+        async with httpx.AsyncClient(timeout=self._cfg.request_timeout_seconds) as http:
+            return await self._chat_completion(http, model, messages, optional_params or {})
+
+    async def _chat_completion(
+        self,
+        http: httpx.AsyncClient,
+        model: str,
+        messages: Sequence[Mapping[str, Any]],
+        optional_params: Mapping[str, Any],
+    ) -> TanaChatResult:
+        _reject_unsupported(optional_params)
+        id_token = await self._id_token_for_request(http)
+        if _has_tools(optional_params):
+            return await self._tool_chat_completion(http, id_token, model, messages, optional_params)
+        args = _basic_chat_args(
+            self._cfg.user_context,
+            _strip_tana_prefix(model),
+            messages,
+            optional_params,
+            self._cfg,
+        )
+        body = {
+            "isStreaming": False,
+            "args": args,
+        }
+        response = await http.post(
+            f"{self._cfg.functions_base_url.rstrip('/')}/llmProxy",
+            json=body,
+            headers={
+                "Authorization": f"Bearer {id_token}",
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+            },
+        )
+        if response.status_code >= 400:
+            raise TanaProxyError(f"Tana llmProxy failed with HTTP {response.status_code}: {_body_snippet(response)}")
+        return _parse_tana_response(response)
+
+    async def _tool_chat_completion(
+        self,
+        http: httpx.AsyncClient,
+        id_token: str,
+        model: str,
+        messages: Sequence[Mapping[str, Any]],
+        optional_params: Mapping[str, Any],
+    ) -> TanaChatResult:
+        body = {
+            "isStreaming": False,
+            "args": {
+                "userContext": self._cfg.tool_user_context,
+                "messages": _normalize_messages(messages),
+                "options": _tana_options(_strip_tana_prefix(model), optional_params, self._cfg),
+            },
+            "dynamicTools": _dynamic_tools(optional_params),
+        }
+        response = await http.post(
+            f"{self._cfg.functions_base_url.rstrip('/')}/llmProxyNext",
+            json=body,
+            headers={
+                "Authorization": f"Bearer {id_token}",
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+            },
+        )
+        if response.status_code >= 400:
+            raise TanaProxyError(
+                f"Tana llmProxyNext failed with HTTP {response.status_code}: {_body_snippet(response)}"
+            )
+        return _parse_tana_response(response)
+
+    async def _id_token_for_request(self, http: httpx.AsyncClient) -> str:
+        if self._id_token is not None and self._now() < self._id_token_expires_at - 60:
+            return self._id_token
+
+        refresh_token = self._refresh_token or self._refresh_token_reader(self._cfg)
+        fresh = await _refresh_id_token_once(http, ResignerConfig(api_key=self._cfg.firebase_api_key), refresh_token)
+        self._refresh_token = fresh.refresh_token
+        self._id_token = fresh.id_token
+        self._id_token_expires_at = self._now() + fresh.expires_in
+        return fresh.id_token
+
+    def stream_completion(
+        self,
+        model: str,
+        messages: Sequence[Mapping[str, Any]],
+        optional_params: Mapping[str, Any] | None = None,
+    ) -> Iterator[GenericStreamingChunk]:
+        if self._sync_http_client is not None:
+            yield from self._stream_completion(self._sync_http_client, model, messages, optional_params or {})
+            return
+
+        with httpx.Client(timeout=self._cfg.request_timeout_seconds) as http:
+            yield from self._stream_completion(http, model, messages, optional_params or {})
+
+    def _stream_completion(
+        self,
+        http: httpx.Client,
+        model: str,
+        messages: Sequence[Mapping[str, Any]],
+        optional_params: Mapping[str, Any],
+    ) -> Iterator[GenericStreamingChunk]:
+        _reject_unsupported(optional_params)
+        id_token = self._id_token_for_request_sync(http)
+        url, body = self._stream_request(_strip_tana_prefix(model), messages, optional_params)
+        headers = {
+            "Authorization": f"Bearer {id_token}",
+            "Accept": "text/event-stream, application/json",
+            "Content-Type": "application/json",
+        }
+        with http.stream("POST", url, json=body, headers=headers) as response:
+            if response.status_code >= 400:
+                response.read()
+                endpoint = "llmProxyNext" if _has_tools(optional_params) else "llmProxy"
+                raise TanaProxyError(
+                    f"Tana {endpoint} streaming failed with HTTP {response.status_code}: {_body_snippet(response)}"
+                )
+            yield from _parse_tana_stream_lines(response.iter_lines())
+
+    async def astream_completion(
+        self,
+        model: str,
+        messages: Sequence[Mapping[str, Any]],
+        optional_params: Mapping[str, Any] | None = None,
+    ) -> AsyncIterator[GenericStreamingChunk]:
+        if self._http_client is not None:
+            async for chunk in self._astream_completion(
+                self._http_client, model, messages, optional_params or {}
+            ):
+                yield chunk
+            return
+
+        async with httpx.AsyncClient(timeout=self._cfg.request_timeout_seconds) as http:
+            async for chunk in self._astream_completion(http, model, messages, optional_params or {}):
+                yield chunk
+
+    async def _astream_completion(
+        self,
+        http: httpx.AsyncClient,
+        model: str,
+        messages: Sequence[Mapping[str, Any]],
+        optional_params: Mapping[str, Any],
+    ) -> AsyncIterator[GenericStreamingChunk]:
+        _reject_unsupported(optional_params)
+        id_token = await self._id_token_for_request(http)
+        url, body = self._stream_request(_strip_tana_prefix(model), messages, optional_params)
+        headers = {
+            "Authorization": f"Bearer {id_token}",
+            "Accept": "text/event-stream, application/json",
+            "Content-Type": "application/json",
+        }
+        async with http.stream("POST", url, json=body, headers=headers) as response:
+            if response.status_code >= 400:
+                await response.aread()
+                endpoint = "llmProxyNext" if _has_tools(optional_params) else "llmProxy"
+                raise TanaProxyError(
+                    f"Tana {endpoint} streaming failed with HTTP {response.status_code}: {_body_snippet(response)}"
+                )
+            async for chunk in _parse_tana_stream_lines_async(response.aiter_lines()):
+                yield chunk
+
+    def _stream_request(
+        self,
+        model: str,
+        messages: Sequence[Mapping[str, Any]],
+        optional_params: Mapping[str, Any],
+    ) -> tuple[str, dict[str, Any]]:
+        if _has_tools(optional_params):
+            return (
+                f"{self._cfg.functions_base_url.rstrip('/')}/llmProxyNext",
+                {
+                    "isStreaming": True,
+                    "args": {
+                        "userContext": self._cfg.tool_user_context,
+                        "messages": _normalize_messages(messages),
+                        "options": _tana_options(model, optional_params, self._cfg),
+                    },
+                    "dynamicTools": _dynamic_tools(optional_params),
+                },
+            )
+        return (
+            f"{self._cfg.functions_base_url.rstrip('/')}/llmProxy",
+            {
+                "isStreaming": True,
+                "args": _basic_chat_args(self._cfg.user_context, model, messages, optional_params, self._cfg),
+            },
+        )
+
+    def _id_token_for_request_sync(self, http: httpx.Client) -> str:
+        if self._id_token is not None and self._now() < self._id_token_expires_at - 60:
+            return self._id_token
+
+        refresh_token = self._refresh_token or self._refresh_token_reader(self._cfg)
+        fresh = _refresh_id_token_once_sync(http, ResignerConfig(api_key=self._cfg.firebase_api_key), refresh_token)
+        self._refresh_token = fresh.refresh_token
+        self._id_token = fresh.id_token
+        self._id_token_expires_at = self._now() + fresh.expires_in
+        return fresh.id_token
+
+
+class TanaLiteLLM(CustomLLM):
+    def __init__(self, client: _ChatClient | None = None) -> None:
+        super().__init__()
+        self._client = client or TanaProxyClient()
+
+    def completion(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self.acompletion(*args, **kwargs))
+        raise TanaProxyError("Use litellm.acompletion() when calling TanaLiteLLM from an active event loop")
+
+    async def acompletion(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        model = _required_kwarg("model", kwargs)
+        messages = _required_kwarg("messages", kwargs)
+        optional_params = kwargs.get("optional_params") or {}
+        result = await self._client.chat_completion(model, messages, optional_params)
+        return _model_response(model, result)
+
+    def streaming(self, *args: Any, **kwargs: Any) -> Iterator[GenericStreamingChunk]:
+        model = _required_kwarg("model", kwargs)
+        messages = _required_kwarg("messages", kwargs)
+        optional_params = kwargs.get("optional_params") or {}
+        return self._client.stream_completion(model, messages, optional_params)
+
+    async def astreaming(self, *args: Any, **kwargs: Any) -> AsyncIterator[GenericStreamingChunk]:
+        model = _required_kwarg("model", kwargs)
+        messages = _required_kwarg("messages", kwargs)
+        optional_params = kwargs.get("optional_params") or {}
+        async for chunk in self._client.astream_completion(model, messages, optional_params):
+            yield chunk
+
+
+def register_litellm_provider(handler: TanaLiteLLM | None = None) -> TanaLiteLLM:
+    custom_handler = handler or TanaLiteLLM()
+    litellm.custom_provider_map = [
+        item for item in litellm.custom_provider_map if item.get("provider") != "tana"
+    ]
+    litellm.custom_provider_map.append({"provider": "tana", "custom_handler": custom_handler})
+    custom_llm_setup()
+    return custom_handler
+
+
+def _required_kwarg(name: str, kwargs: Mapping[str, Any]) -> Any:
+    if name not in kwargs:
+        raise TanaProxyError(f"LiteLLM did not pass required argument {name!r}")
+    return kwargs[name]
+
+
+def _strip_tana_prefix(model: str) -> str:
+    if model.startswith("tana/"):
+        return model.removeprefix("tana/")
+    return model
+
+
+def _display_model(model: str) -> str:
+    if model.startswith("tana/"):
+        return model
+    return f"tana/{model}"
+
+
+def _reject_unsupported(optional_params: Mapping[str, Any]) -> None:
+    for key in ("function_call",):
+        if optional_params.get(key):
+            raise NotImplementedError(f"Tana LiteLLM provider does not support {key!r} yet")
+
+
+def _has_tools(optional_params: Mapping[str, Any]) -> bool:
+    if optional_params.get("tool_choice") == "none":
+        return False
+    tools = optional_params.get("tools")
+    functions = optional_params.get("functions")
+    return bool(tools or functions)
+
+
+def _basic_chat_args(
+    user_context: str,
+    model: str,
+    messages: Sequence[Mapping[str, Any]],
+    optional_params: Mapping[str, Any],
+    cfg: TanaProxyConfig,
+) -> dict[str, Any]:
+    return {
+        "userContext": user_context,
+        "messages": _normalize_messages(messages),
+        "options": _tana_options(model, optional_params, cfg),
+    }
+
+
+def _dynamic_tools(optional_params: Mapping[str, Any]) -> list[dict[str, Any]]:
+    dynamic_tools: list[dict[str, Any]] = []
+    for tool in optional_params.get("tools") or []:
+        if not isinstance(tool, Mapping):
+            raise TanaProxyError(f"expected tool mapping, got {type(tool).__name__}")
+        if tool.get("type") != "function":
+            raise NotImplementedError("Tana LiteLLM provider only supports OpenAI function tools")
+        function = tool.get("function")
+        if not isinstance(function, Mapping):
+            raise TanaProxyError(f"tool is missing function definition: {tool!r}")
+        dynamic_tools.append(_dynamic_tool_from_function(function))
+    for function in optional_params.get("functions") or []:
+        if not isinstance(function, Mapping):
+            raise TanaProxyError(f"expected function mapping, got {type(function).__name__}")
+        dynamic_tools.append(_dynamic_tool_from_function(function))
+    if not dynamic_tools:
+        raise TanaProxyError("tool request did not include any function tools")
+    return dynamic_tools
+
+
+def _dynamic_tool_from_function(function: Mapping[str, Any]) -> dict[str, Any]:
+    name = function.get("name")
+    if not isinstance(name, str) or not name:
+        raise TanaProxyError(f"function tool is missing a non-empty name: {function!r}")
+    parameters = function.get("parameters")
+    if parameters is None:
+        parameters = {"type": "object", "properties": {}}
+    if not isinstance(parameters, Mapping):
+        raise TanaProxyError(f"function tool {name!r} parameters must be a JSON object")
+    description = function.get("description")
+    return {
+        "name": name,
+        "description": str(description) if description else f"Execute {name}",
+        "kind": "mcpTool",
+        "runtime": "client",
+        "schema": parameters,
+    }
+
+
+def _normalize_messages(messages: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    normalized: list[dict[str, Any]] = []
+    for message in messages:
+        if not isinstance(message, Mapping):
+            raise TanaProxyError(f"expected LiteLLM message mappings, got {type(message).__name__}")
+        role = message.get("role")
+        if role is None:
+            raise TanaProxyError(f"message is missing required role: {message!r}")
+        content = _normalize_content(message.get("content", ""))
+        tool_calls = message.get("tool_calls")
+        if tool_calls is None:
+            tool_calls = message.get("toolCalls")
+        if tool_calls is not None:
+            content = _append_content_parts(content, _normalize_tool_call_parts(tool_calls))
+        if role == "tool":
+            content = _normalize_tool_result_content(message, content)
+        normalized_message = {
+            "role": role,
+            "content": content,
+        }
+        _copy_first_set(message, normalized_message, ("providerOptions", "provider_options"), "providerOptions")
+        normalized.append(normalized_message)
+    return normalized
+
+
+def _normalize_content(content: Any) -> Any:
+    if isinstance(content, Sequence) and not isinstance(content, (bytes, bytearray, str)):
+        return [_normalize_content_part(part) for part in content]
+    return content
+
+
+def _normalize_content_part(part: Any) -> Any:
+    if not isinstance(part, Mapping):
+        return part
+    normalized = dict(part)
+    if normalized.get("type") == "input_text":
+        normalized["type"] = "text"
+    _move_alias(normalized, "provider_options", "providerOptions")
+    _move_alias(normalized, "tool_call_id", "toolCallId")
+    _move_alias(normalized, "tool_name", "toolName")
+    if normalized.get("type") == "tool-call":
+        arguments = normalized.pop("arguments", None)
+        if arguments is not None and normalized.get("input") is None:
+            normalized["input"] = _parse_tool_arguments(arguments)
+    if normalized.get("type") == "tool-result":
+        result_content = normalized.pop("content", None)
+        if result_content is not None and normalized.get("output") is None:
+            normalized["output"] = result_content
+    return normalized
+
+
+def _normalize_tool_call_parts(tool_calls: Any) -> list[dict[str, Any]]:
+    if not isinstance(tool_calls, Sequence) or isinstance(tool_calls, (bytes, bytearray, str)):
+        raise TanaProxyError(f"expected tool_calls sequence, got {type(tool_calls).__name__}")
+    parts: list[dict[str, Any]] = []
+    for tool_call in tool_calls:
+        if not isinstance(tool_call, Mapping):
+            raise TanaProxyError(f"expected tool_call mapping, got {type(tool_call).__name__}")
+        normalized = dict(tool_call)
+        _move_alias(normalized, "tool_call_id", "toolCallId")
+        _move_alias(normalized, "tool_name", "toolName")
+        function = normalized.get("function")
+        if isinstance(function, Mapping):
+            name = function.get("name")
+            arguments = function.get("arguments")
+            if name is not None and normalized.get("toolName") is None:
+                normalized["toolName"] = name
+            if arguments is not None and normalized.get("input") is None:
+                normalized["input"] = _parse_tool_arguments(arguments)
+            normalized.pop("function", None)
+        if normalized.get("id") is not None and normalized.get("toolCallId") is None:
+            normalized["toolCallId"] = normalized["id"]
+        if normalized.get("name") is not None and normalized.get("toolName") is None:
+            normalized["toolName"] = normalized["name"]
+        tool_call_id = normalized.get("toolCallId")
+        tool_name = normalized.get("toolName")
+        if not isinstance(tool_call_id, str) or not tool_call_id:
+            raise TanaProxyError(f"assistant tool call is missing toolCallId/id: {tool_call!r}")
+        if not isinstance(tool_name, str) or not tool_name:
+            raise TanaProxyError(f"assistant tool call is missing toolName/function.name: {tool_call!r}")
+        part = {
+            "type": "tool-call",
+            "toolCallId": tool_call_id,
+            "toolName": tool_name,
+            "input": normalized.get("input", normalized.get("args", {})),
+        }
+        _copy_if_set(normalized, part, "providerOptions", "providerOptions")
+        _copy_if_set(normalized, part, "providerExecuted", "providerExecuted")
+        _copy_if_set(normalized, part, "thoughtSignature", "thoughtSignature")
+        _copy_if_set(normalized, part, "thought", "thought")
+        parts.append(part)
+    return parts
+
+
+def _append_content_parts(content: Any, parts: Sequence[dict[str, Any]]) -> Any:
+    if not parts:
+        return content
+    if content in (None, ""):
+        return list(parts)
+    if isinstance(content, Sequence) and not isinstance(content, (bytes, bytearray, str)):
+        return [*content, *parts]
+    if isinstance(content, str):
+        return [{"type": "text", "text": content}, *parts]
+    return [content, *parts]
+
+
+def _normalize_tool_result_content(message: Mapping[str, Any], content: Any) -> Any:
+    tool_call_id = message.get("toolCallId") or message.get("tool_call_id")
+    tool_name = message.get("toolName") or message.get("name")
+    if isinstance(content, Sequence) and not isinstance(content, (bytes, bytearray, str)):
+        normalized_parts = []
+        has_tool_result = False
+        for part in content:
+            normalized_part = _normalize_content_part(part)
+            if isinstance(normalized_part, Mapping) and normalized_part.get("type") == "tool-result":
+                has_tool_result = True
+                normalized_part = dict(normalized_part)
+                if tool_call_id is not None and normalized_part.get("toolCallId") is None:
+                    normalized_part["toolCallId"] = tool_call_id
+                if tool_name is not None and normalized_part.get("toolName") is None:
+                    normalized_part["toolName"] = tool_name
+            normalized_parts.append(normalized_part)
+        if has_tool_result:
+            return normalized_parts
+    if not isinstance(tool_call_id, str) or not tool_call_id:
+        raise TanaProxyError(f"tool message is missing tool_call_id/toolCallId: {message!r}")
+    part: dict[str, Any] = {
+        "type": "tool-result",
+        "toolCallId": tool_call_id,
+        "output": content,
+    }
+    if isinstance(tool_name, str) and tool_name:
+        part["toolName"] = tool_name
+    return [part]
+
+
+def _parse_tool_arguments(arguments: Any) -> Any:
+    if not isinstance(arguments, str):
+        return arguments
+    try:
+        return json.loads(arguments)
+    except json.JSONDecodeError:
+        return arguments
+
+
+def _tana_options(model: str, optional_params: Mapping[str, Any], cfg: TanaProxyConfig) -> dict[str, Any]:
+    options: dict[str, Any] = {
+        "model": model,
+        "ignoreLargeContextWarning": cfg.ignore_large_context_warning,
+        "ignoreOutOfCreditsWarning": cfg.ignore_out_of_credits_warning,
+    }
+    _copy_if_set(optional_params, options, "temperature", "temperature")
+    _copy_if_set(optional_params, options, "top_p", "topP")
+    _copy_if_set(optional_params, options, "frequency_penalty", "frequencyPenalty")
+    _copy_if_set(optional_params, options, "presence_penalty", "presencePenalty")
+    max_tokens = optional_params.get("max_tokens", optional_params.get("max_completion_tokens"))
+    if max_tokens is not None:
+        options["maxOutputTokens"] = max_tokens
+    stop = optional_params.get("stop")
+    if stop is not None:
+        options["stopStrings"] = [stop] if isinstance(stop, str) else list(stop)
+    provider_options = optional_params.get("provider_options") or optional_params.get("providerOptions")
+    if provider_options is not None:
+        options["providerOptions"] = provider_options
+    return options
+
+
+def _copy_if_set(source: Mapping[str, Any], dest: dict[str, Any], source_key: str, dest_key: str) -> None:
+    value = source.get(source_key)
+    if value is not None:
+        dest[dest_key] = value
+
+
+def _copy_first_set(
+    source: Mapping[str, Any], dest: dict[str, Any], source_keys: Sequence[str], dest_key: str
+) -> None:
+    for source_key in source_keys:
+        value = source.get(source_key)
+        if value is not None:
+            dest[dest_key] = value
+            return
+
+
+def _move_alias(mapping: dict[str, Any], source_key: str, dest_key: str) -> None:
+    value = mapping.pop(source_key, None)
+    if value is not None and mapping.get(dest_key) is None:
+        mapping[dest_key] = value
+
+
+def _parse_tana_response(response: httpx.Response) -> TanaChatResult:
+    content_type = response.headers.get("content-type", "")
+    if "json" not in content_type:
+        return TanaChatResult(text=response.text)
+    data = response.json()
+    usage: dict[str, int] | None = None
+    if isinstance(data, Mapping):
+        raw_usage = data.get("usage")
+        if isinstance(raw_usage, Mapping):
+            usage = _normalize_usage(raw_usage)
+        tool_calls = _list_of_mappings(data.get("toolCalls"))
+        tool_results = data.get("toolResults") if isinstance(data.get("toolResults"), list) else None
+        if "text" in data:
+            return TanaChatResult(
+                text=str(data["text"] or ""),
+                tool_calls=tool_calls,
+                tool_results=tool_results,
+                usage=usage,
+                raw=data,
+            )
+        result = data.get("result")
+        if isinstance(result, Mapping) and "text" in result:
+            return TanaChatResult(text=str(result["text"] or ""), usage=usage, raw=data)
+    if isinstance(data, str):
+        return TanaChatResult(text=data, usage=usage, raw=data)
+    return TanaChatResult(text=json.dumps(data, ensure_ascii=False), usage=usage, raw=data)
+
+
+def _parse_tana_stream_lines(lines: Iterator[str]) -> Iterator[GenericStreamingChunk]:
+    for line in lines:
+        for chunk in _parse_tana_stream_line(line):
+            yield chunk
+
+
+async def _parse_tana_stream_lines_async(lines: AsyncIterator[str]) -> AsyncIterator[GenericStreamingChunk]:
+    async for line in lines:
+        for chunk in _parse_tana_stream_line(line):
+            yield chunk
+
+
+def _parse_tana_stream_line(line: str) -> list[GenericStreamingChunk]:
+    stripped = line.strip()
+    if not stripped:
+        return []
+
+    if stripped.startswith("data:"):
+        payload = stripped.removeprefix("data:").strip()
+        if payload == "[DONE]":
+            return []
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError:
+            return []
+        if isinstance(data, Mapping):
+            return _stream_chunks_from_event(data)
+        return []
+
+    if stripped.startswith(("d:", "e:")):
+        try:
+            data = json.loads(stripped[2:])
+        except json.JSONDecodeError:
+            return []
+        if not isinstance(data, Mapping):
+            return []
+        finish_reason = str(data.get("finishReason") or "stop")
+        return [_stream_chunk(is_finished=True, finish_reason=finish_reason, usage=_normalize_stream_usage(data))]
+
+    if stripped.startswith("0:"):
+        try:
+            text = json.loads(stripped[2:])
+        except json.JSONDecodeError:
+            return []
+        if isinstance(text, str) and text:
+            return [_stream_chunk(text=text)]
+
+    return []
+
+
+def _stream_chunks_from_event(data: Mapping[str, Any]) -> list[GenericStreamingChunk]:
+    event_type = data.get("type")
+    chunks: list[GenericStreamingChunk] = []
+    emitted_tools = False
+
+    if event_type == "text-delta":
+        delta = data.get("delta")
+        if isinstance(delta, str) and delta:
+            chunks.append(_stream_chunk(text=delta))
+
+    if event_type in {"tool-input-available", "tool-input-error"}:
+        chunks.extend(_tool_call_stream_chunks([data]))
+        emitted_tools = True
+
+    if event_type == "error":
+        error_text = data.get("errorText") or data.get("message") or data.get("error")
+        raise TanaProxyError(f"Tana streaming error: {error_text or json.dumps(data, ensure_ascii=False)}")
+
+    if event_type == "finish":
+        message_metadata = data.get("messageMetadata")
+        if isinstance(message_metadata, Mapping):
+            chunks.extend(_tool_call_stream_chunks(message_metadata.get("toolCalls")))
+            provider_fields: dict[str, Any] = {}
+            _copy_if_set(message_metadata, provider_fields, "providerMetadata", "tana_providerMetadata")
+            _copy_if_set(message_metadata, provider_fields, "warnings", "tana_warnings")
+            _copy_if_set(message_metadata, provider_fields, "response", "tana_response")
+            finish_reason = str(data.get("finishReason") or message_metadata.get("finishReason") or "stop")
+            chunks.append(
+                _stream_chunk(
+                    is_finished=True,
+                    finish_reason=finish_reason,
+                    usage=_normalize_stream_usage(message_metadata),
+                    provider_specific_fields=provider_fields or None,
+                )
+            )
+        else:
+            chunks.append(
+                _stream_chunk(
+                    is_finished=True,
+                    finish_reason=str(data.get("finishReason") or "stop"),
+                    usage=_normalize_stream_usage(data),
+                )
+            )
+        return chunks
+
+    if not emitted_tools:
+        chunks.extend(_tool_call_stream_chunks([data]))
+    chunks.extend(_tool_call_stream_chunks(data.get("toolCalls")))
+    return chunks
+
+
+def _tool_call_stream_chunks(value: Any) -> list[GenericStreamingChunk]:
+    if value is None:
+        return []
+    raw_tool_calls = value if isinstance(value, list) else list(value) if isinstance(value, tuple) else [value]
+    chunks: list[GenericStreamingChunk] = []
+    for index, raw_tool_call in enumerate(raw_tool_calls):
+        if not isinstance(raw_tool_call, Mapping):
+            continue
+        tool_call = _openai_tool_call_chunk(raw_tool_call, index, streaming_delta=True)
+        if tool_call is not None:
+            chunks.append(_stream_chunk(tool_use=tool_call))
+    return chunks
+
+
+def _openai_tool_call_chunk(
+    tool_call: Mapping[str, Any], index: int, *, streaming_delta: bool = False
+) -> ChatCompletionToolCallChunk | None:
+    normalized = _normalize_tana_tool_call(tool_call)
+    if normalized is None:
+        return None
+    arguments = normalized["input"]
+    if streaming_delta and _is_empty_json_object(arguments):
+        arguments = ""
+    elif not isinstance(arguments, str):
+        arguments = json.dumps(arguments if arguments is not None else {}, ensure_ascii=False)
+    return cast(
+        ChatCompletionToolCallChunk,
+        {
+            "id": str(normalized["toolCallId"]),
+            "type": "function",
+            "function": {
+                "name": str(normalized["toolName"]),
+                "arguments": arguments,
+            },
+            "index": index,
+        },
+    )
+
+
+def _normalize_tana_tool_call(tool_call: Mapping[str, Any]) -> dict[str, Any] | None:
+    function_call = tool_call.get("functionCall")
+    if not isinstance(function_call, Mapping):
+        function_call = {}
+    provider_metadata = tool_call.get("providerMetadata")
+    if not isinstance(provider_metadata, Mapping):
+        provider_metadata = {}
+    provider_options = tool_call.get("providerOptions")
+    if not isinstance(provider_options, Mapping):
+        provider_options = {}
+    google_metadata = provider_metadata.get("google") if isinstance(provider_metadata.get("google"), Mapping) else {}
+    google_options = provider_options.get("google") if isinstance(provider_options.get("google"), Mapping) else {}
+
+    tool_call_id = _first_non_none(tool_call.get("toolCallId"), tool_call.get("id"), tool_call.get("tool_call_id"))
+    tool_name = _first_non_none(tool_call.get("toolName"), function_call.get("name"), tool_call.get("name"))
+    if not tool_call_id or not tool_name:
+        return None
+    return {
+        "toolCallId": tool_call_id,
+        "toolName": tool_name,
+        "input": _first_non_none(tool_call.get("input"), function_call.get("arguments"), tool_call.get("args")),
+        "providerExecuted": tool_call.get("providerExecuted"),
+        "thoughtSignature": (
+            _first_non_none(
+                tool_call.get("thoughtSignature"),
+                tool_call.get("thought_signature"),
+                function_call.get("thoughtSignature"),
+                google_metadata.get("thoughtSignature"),
+                google_options.get("thoughtSignature"),
+            )
+        ),
+        "thought": (
+            _first_non_none(
+                tool_call.get("thought"),
+                function_call.get("thought"),
+                google_metadata.get("thought"),
+                google_options.get("thought"),
+            )
+        ),
+    }
+
+
+def _first_non_none(*values: Any) -> Any:
+    for value in values:
+        if value is not None:
+            return value
+    return None
+
+
+def _is_empty_json_object(value: Any) -> bool:
+    if value == {}:
+        return True
+    if not isinstance(value, str):
+        return False
+    stripped = value.strip()
+    if stripped == "{}":
+        return True
+    try:
+        decoded = json.loads(stripped)
+    except json.JSONDecodeError:
+        return False
+    return decoded == {} or (isinstance(decoded, str) and decoded.strip() == "{}")
+
+
+def _stream_chunk(
+    *,
+    text: str = "",
+    tool_use: ChatCompletionToolCallChunk | None = None,
+    is_finished: bool = False,
+    finish_reason: str = "",
+    usage: dict[str, int] | None = None,
+    provider_specific_fields: dict[str, Any] | None = None,
+) -> GenericStreamingChunk:
+    chunk = GenericStreamingChunk(
+        text=text,
+        tool_use=tool_use,
+        is_finished=is_finished,
+        finish_reason=finish_reason,
+        usage=usage,
+        index=0,
+    )
+    if provider_specific_fields:
+        chunk["provider_specific_fields"] = provider_specific_fields
+    return chunk
+
+
+def _normalize_stream_usage(data: Mapping[str, Any]) -> dict[str, int] | None:
+    raw_usage = data.get("usage")
+    if isinstance(raw_usage, Mapping):
+        return _normalize_usage(raw_usage)
+    return _normalize_usage(data)
+
+
+def _list_of_mappings(value: Any) -> list[dict[str, Any]] | None:
+    if not isinstance(value, list):
+        return None
+    mappings: list[dict[str, Any]] = []
+    for item in value:
+        if isinstance(item, Mapping):
+            mappings.append(dict(item))
+    return mappings or None
+
+
+def _normalize_usage(usage: Mapping[str, Any]) -> dict[str, int] | None:
+    normalized: dict[str, int] = {}
+    aliases = {
+        "prompt_tokens": ("prompt_tokens", "input_tokens", "inputTokens", "promptTokens"),
+        "completion_tokens": ("completion_tokens", "output_tokens", "outputTokens", "completionTokens"),
+        "total_tokens": ("total_tokens", "totalTokens"),
+    }
+    for dest, keys in aliases.items():
+        for key in keys:
+            if key in usage and usage[key] is not None:
+                normalized[dest] = int(usage[key])
+                break
+    if "total_tokens" not in normalized and {"prompt_tokens", "completion_tokens"} <= normalized.keys():
+        normalized["total_tokens"] = normalized["prompt_tokens"] + normalized["completion_tokens"]
+    return normalized or None
+
+
+def _model_response(model: str, result: TanaChatResult) -> ModelResponse:
+    usage = Usage(**result.usage) if result.usage is not None else None
+    tool_calls = _openai_tool_calls(result.tool_calls)
+    provider_fields: dict[str, Any] = {}
+    if result.tool_results:
+        provider_fields["tana_toolResults"] = result.tool_results
+    return ModelResponse(
+        model=_display_model(model),
+        choices=[
+            {
+                "index": 0,
+                "finish_reason": "tool_calls" if tool_calls else "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": result.text or None,
+                    **({"tool_calls": tool_calls} if tool_calls else {}),
+                    **({"provider_specific_fields": provider_fields} if provider_fields else {}),
+                },
+            }
+        ],
+        usage=usage,
+    )
+
+
+def _openai_tool_calls(tool_calls: list[dict[str, Any]] | None) -> list[dict[str, Any]] | None:
+    if not tool_calls:
+        return None
+    converted: list[dict[str, Any]] = []
+    for index, tool_call in enumerate(tool_calls):
+        chunk = _openai_tool_call_chunk(tool_call, index)
+        if chunk is None:
+            continue
+        converted.append(
+            {
+                "id": chunk["id"] or f"call_{index}",
+                "type": chunk["type"],
+                "function": chunk["function"],
+            }
+        )
+    return converted or None
+
+
+def _body_snippet(response: httpx.Response) -> str:
+    body = response.text.strip().replace("\n", " ")
+    if len(body) > 500:
+        return f"{body[:500]}..."
+    return body

--- a/tana/litellm_proxy/provider.py
+++ b/tana/litellm_proxy/provider.py
@@ -396,12 +396,28 @@ class TanaLiteLLM(CustomLLM):
         optional_params = kwargs.get("optional_params") or {}
         return self._client.stream_completion(model, messages, optional_params)
 
-    async def astreaming(self, *args: Any, **kwargs: Any) -> AsyncIterator[GenericStreamingChunk]:
-        model = _required_kwarg("model", kwargs)
-        messages = _required_kwarg("messages", kwargs)
-        optional_params = kwargs.get("optional_params") or {}
-        async for chunk in self._client.astream_completion(model, messages, optional_params):
-            yield chunk
+    async def astreaming(
+        self,
+        model: str,
+        messages: list[Any],
+        api_base: str,
+        custom_prompt_dict: dict[Any, Any],
+        model_response: ModelResponse,
+        print_verbose: Callable[..., Any],
+        encoding: Any,
+        api_key: Any,
+        logging_obj: Any,
+        optional_params: dict[Any, Any],
+        acompletion: Any = None,
+        litellm_params: Any = None,
+        logger_fn: Any = None,
+        headers: Any = None,
+        timeout: Any = None,  # noqa: ASYNC109 - LiteLLM's override signature includes timeout.
+        client: Any = None,
+    ) -> AsyncIterator[GenericStreamingChunk]:
+        del api_base, custom_prompt_dict, model_response, print_verbose, encoding, api_key
+        del logging_obj, acompletion, litellm_params, logger_fn, headers, timeout, client
+        return self._client.astream_completion(model, cast(Sequence[Mapping[str, Any]], messages), optional_params)
 
 
 def register_litellm_provider(handler: TanaLiteLLM | None = None) -> TanaLiteLLM:
@@ -620,10 +636,10 @@ def _normalize_tool_result_content(message: Mapping[str, Any], content: Any) -> 
             return normalized_parts
     if not isinstance(tool_call_id, str) or not tool_call_id:
         raise TanaProxyError(f"tool message is missing tool_call_id/toolCallId: {message!r}")
-    part: dict[str, Any] = {"type": "tool-result", "toolCallId": tool_call_id, "output": content}
+    result_part: dict[str, Any] = {"type": "tool-result", "toolCallId": tool_call_id, "output": content}
     if isinstance(tool_name, str) and tool_name:
-        part["toolName"] = tool_name
-    return [part]
+        result_part["toolName"] = tool_name
+    return [result_part]
 
 
 def _parse_tool_arguments(arguments: Any) -> Any:
@@ -838,17 +854,16 @@ def _openai_tool_call_chunk(
 
 
 def _normalize_tana_tool_call(tool_call: Mapping[str, Any]) -> dict[str, Any] | None:
-    function_call = tool_call.get("functionCall")
-    if not isinstance(function_call, Mapping):
-        function_call = {}
-    provider_metadata = tool_call.get("providerMetadata")
-    if not isinstance(provider_metadata, Mapping):
-        provider_metadata = {}
-    provider_options = tool_call.get("providerOptions")
-    if not isinstance(provider_options, Mapping):
-        provider_options = {}
-    google_metadata = provider_metadata.get("google") if isinstance(provider_metadata.get("google"), Mapping) else {}
-    google_options = provider_options.get("google") if isinstance(provider_options.get("google"), Mapping) else {}
+    raw_function_call = tool_call.get("functionCall")
+    function_call: Mapping[str, Any] = raw_function_call if isinstance(raw_function_call, Mapping) else {}
+    raw_provider_metadata = tool_call.get("providerMetadata")
+    provider_metadata: Mapping[str, Any] = raw_provider_metadata if isinstance(raw_provider_metadata, Mapping) else {}
+    raw_provider_options = tool_call.get("providerOptions")
+    provider_options: Mapping[str, Any] = raw_provider_options if isinstance(raw_provider_options, Mapping) else {}
+    raw_google_metadata = provider_metadata.get("google")
+    google_metadata: Mapping[str, Any] = raw_google_metadata if isinstance(raw_google_metadata, Mapping) else {}
+    raw_google_options = provider_options.get("google")
+    google_options: Mapping[str, Any] = raw_google_options if isinstance(raw_google_options, Mapping) else {}
 
     tool_call_id = _first_non_none(tool_call.get("toolCallId"), tool_call.get("id"), tool_call.get("tool_call_id"))
     tool_name = _first_non_none(tool_call.get("toolName"), function_call.get("name"), tool_call.get("name"))
@@ -911,7 +926,12 @@ def _stream_chunk(
     provider_specific_fields: dict[str, Any] | None = None,
 ) -> GenericStreamingChunk:
     chunk = GenericStreamingChunk(
-        text=text, tool_use=tool_use, is_finished=is_finished, finish_reason=finish_reason, usage=usage, index=0
+        text=text,
+        tool_use=tool_use,
+        is_finished=is_finished,
+        finish_reason=finish_reason,
+        usage=cast(Any, usage),
+        index=0,
     )
     if provider_specific_fields:
         chunk["provider_specific_fields"] = provider_specific_fields
@@ -950,7 +970,7 @@ def _normalize_usage(usage: Mapping[str, Any]) -> dict[str, int] | None:
 
 
 def _model_response(model: str, result: TanaChatResult) -> ModelResponse:
-    usage = Usage(**result.usage) if result.usage is not None else None
+    usage = Usage(**cast(Any, result.usage)) if result.usage is not None else None
     tool_calls = _openai_tool_calls(result.tool_calls)
     provider_fields: dict[str, Any] = {}
     if result.tool_results:

--- a/tana/litellm_proxy/test_provider.py
+++ b/tana/litellm_proxy/test_provider.py
@@ -28,18 +28,12 @@ class _ModelResponseWithUsage(Protocol):
 
 class _NoStreamingClient:
     def stream_completion(
-        self,
-        model: str,
-        messages: Sequence[Mapping[str, Any]],
-        optional_params: Mapping[str, Any] | None = None,
+        self, model: str, messages: Sequence[Mapping[str, Any]], optional_params: Mapping[str, Any] | None = None
     ) -> Iterator[GenericStreamingChunk]:
         raise AssertionError("non-streaming test should not call stream_completion")
 
     async def astream_completion(
-        self,
-        model: str,
-        messages: Sequence[Mapping[str, Any]],
-        optional_params: Mapping[str, Any] | None = None,
+        self, model: str, messages: Sequence[Mapping[str, Any]], optional_params: Mapping[str, Any] | None = None
     ) -> AsyncIterator[GenericStreamingChunk]:
         raise AssertionError("non-streaming test should not call astream_completion")
         yield GenericStreamingChunk(text="", is_finished=True, finish_reason="stop", usage=None, index=0)
@@ -53,8 +47,7 @@ def test_client_maps_basic_chat_request() -> None:
         seen_requests.append(request)
         if request.url.host == "securetoken.googleapis.com":
             return httpx.Response(
-                200,
-                json={"id_token": "id-token-1", "refresh_token": "refresh-2", "expires_in": "3600"},
+                200, json={"id_token": "id-token-1", "refresh_token": "refresh-2", "expires_in": "3600"}
             )
         assert request.url == "https://app.tana.inc/functions/llmProxy"
         seen_bodies.append(json.loads(request.content.decode("utf-8")))
@@ -62,18 +55,12 @@ def test_client_maps_basic_chat_request() -> None:
         return httpx.Response(
             200,
             headers={"content-type": "application/json"},
-            json={
-                "text": "hello from tana",
-                "usage": {"inputTokens": 2, "outputTokens": 3},
-            },
+            json={"text": "hello from tana", "usage": {"inputTokens": 2, "outputTokens": 3}},
         )
 
     async def run() -> TanaChatResult:
         async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
-            client = TanaProxyClient(
-                TanaProxyConfig(refresh_token="refresh-1"),
-                http_client=http,
-            )
+            client = TanaProxyClient(TanaProxyConfig(refresh_token="refresh-1"), http_client=http)
             return await client.chat_completion(
                 "tana/claude-test",
                 [{"role": "user", "content": "hi"}],
@@ -119,23 +106,15 @@ def test_client_maps_message_envelopes_without_prompt_collapsing() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         if request.url.host == "securetoken.googleapis.com":
             return httpx.Response(
-                200,
-                json={"id_token": "id-token-1", "refresh_token": "refresh-2", "expires_in": "3600"},
+                200, json={"id_token": "id-token-1", "refresh_token": "refresh-2", "expires_in": "3600"}
             )
         assert request.url == "https://app.tana.inc/functions/llmProxy"
         seen_bodies.append(json.loads(request.content.decode("utf-8")))
-        return httpx.Response(
-            200,
-            headers={"content-type": "application/json"},
-            json={"text": "ok"},
-        )
+        return httpx.Response(200, headers={"content-type": "application/json"}, json={"text": "ok"})
 
     async def run() -> TanaChatResult:
         async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
-            client = TanaProxyClient(
-                TanaProxyConfig(refresh_token="refresh-1"),
-                http_client=http,
-            )
+            client = TanaProxyClient(TanaProxyConfig(refresh_token="refresh-1"), http_client=http)
             return await client.chat_completion(
                 "claude-test",
                 [
@@ -162,23 +141,13 @@ def test_client_maps_message_envelopes_without_prompt_collapsing() -> None:
                             {
                                 "id": "call-1",
                                 "type": "function",
-                                "function": {
-                                    "name": "lookup_demo_fact",
-                                    "arguments": "{\"topic\":\"tana-litellm-tool\"}",
-                                },
+                                "function": {"name": "lookup_demo_fact", "arguments": '{"topic":"tana-litellm-tool"}'},
                             }
                         ],
                     },
-                    {
-                        "role": "tool",
-                        "tool_call_id": "call-1",
-                        "name": "lookup_demo_fact",
-                        "content": "{\"ok\":true}",
-                    },
+                    {"role": "tool", "tool_call_id": "call-1", "name": "lookup_demo_fact", "content": '{"ok":true}'},
                 ],
-                {
-                    "provider_options": {"openai": {"promptCacheKey": "conversation-1"}},
-                },
+                {"provider_options": {"openai": {"promptCacheKey": "conversation-1"}}},
             )
 
     result = asyncio.run(run())
@@ -225,7 +194,7 @@ def test_client_maps_message_envelopes_without_prompt_collapsing() -> None:
                             "type": "tool-result",
                             "toolCallId": "call-1",
                             "toolName": "lookup_demo_fact",
-                            "output": "{\"ok\":true}",
+                            "output": '{"ok":true}',
                         }
                     ],
                 },
@@ -246,8 +215,7 @@ def test_client_maps_tool_request_to_llm_proxy_next() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         if request.url.host == "securetoken.googleapis.com":
             return httpx.Response(
-                200,
-                json={"id_token": "id-token-1", "refresh_token": "refresh-2", "expires_in": "3600"},
+                200, json={"id_token": "id-token-1", "refresh_token": "refresh-2", "expires_in": "3600"}
             )
         assert request.url == "https://app.tana.inc/functions/llmProxyNext"
         assert request.headers["authorization"] == "Bearer id-token-1"
@@ -258,11 +226,7 @@ def test_client_maps_tool_request_to_llm_proxy_next() -> None:
             json={
                 "text": "",
                 "toolCalls": [
-                    {
-                        "toolCallId": "call-1",
-                        "toolName": "lookup_demo_fact",
-                        "input": {"topic": "tana-litellm-tool"},
-                    }
+                    {"toolCallId": "call-1", "toolName": "lookup_demo_fact", "input": {"topic": "tana-litellm-tool"}}
                 ],
                 "usage": {"promptTokens": 4, "completionTokens": 5},
             },
@@ -270,10 +234,7 @@ def test_client_maps_tool_request_to_llm_proxy_next() -> None:
 
     async def run() -> TanaChatResult:
         async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
-            client = TanaProxyClient(
-                TanaProxyConfig(refresh_token="refresh-1"),
-                http_client=http,
-            )
+            client = TanaProxyClient(TanaProxyConfig(refresh_token="refresh-1"), http_client=http)
             return await client.chat_completion(
                 "claude-test",
                 [{"role": "user", "content": "call the tool"}],
@@ -321,11 +282,7 @@ def test_client_maps_tool_request_to_llm_proxy_next() -> None:
                     "description": "Look up a demo fact.",
                     "kind": "mcpTool",
                     "runtime": "client",
-                    "schema": {
-                        "type": "object",
-                        "properties": {"topic": {"type": "string"}},
-                        "required": ["topic"],
-                    },
+                    "schema": {"type": "object", "properties": {"topic": {"type": "string"}}, "required": ["topic"]},
                 }
             ],
         }
@@ -338,8 +295,7 @@ def test_client_streams_text_chunks_from_llm_proxy() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         if request.url.host == "securetoken.googleapis.com":
             return httpx.Response(
-                200,
-                json={"id_token": "id-token-1", "refresh_token": "refresh-2", "expires_in": "3600"},
+                200, json={"id_token": "id-token-1", "refresh_token": "refresh-2", "expires_in": "3600"}
             )
         assert request.url == "https://app.tana.inc/functions/llmProxy"
         assert request.headers["authorization"] == "Bearer id-token-1"
@@ -356,15 +312,10 @@ def test_client_streams_text_chunks_from_llm_proxy() -> None:
         )
 
     with httpx.Client(transport=httpx.MockTransport(handler)) as http:
-        client = TanaProxyClient(
-            TanaProxyConfig(refresh_token="refresh-1"),
-            sync_http_client=http,
-        )
+        client = TanaProxyClient(TanaProxyConfig(refresh_token="refresh-1"), sync_http_client=http)
         chunks = list(
             client.stream_completion(
-                "tana/claude-test",
-                [{"role": "user", "content": "hi"}],
-                {"temperature": 0.0, "max_tokens": 16},
+                "tana/claude-test", [{"role": "user", "content": "hi"}], {"temperature": 0.0, "max_tokens": 16}
             )
         )
 
@@ -396,8 +347,7 @@ def test_client_streams_tool_calls_from_llm_proxy_next() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         if request.url.host == "securetoken.googleapis.com":
             return httpx.Response(
-                200,
-                json={"id_token": "id-token-1", "refresh_token": "refresh-2", "expires_in": "3600"},
+                200, json={"id_token": "id-token-1", "refresh_token": "refresh-2", "expires_in": "3600"}
             )
         assert request.url == "https://app.tana.inc/functions/llmProxyNext"
         seen_bodies.append(json.loads(request.content.decode("utf-8")))
@@ -415,10 +365,7 @@ def test_client_streams_tool_calls_from_llm_proxy_next() -> None:
         )
 
     with httpx.Client(transport=httpx.MockTransport(handler)) as http:
-        client = TanaProxyClient(
-            TanaProxyConfig(refresh_token="refresh-1"),
-            sync_http_client=http,
-        )
+        client = TanaProxyClient(TanaProxyConfig(refresh_token="refresh-1"), sync_http_client=http)
         chunks = list(
             client.stream_completion(
                 "claude-test",
@@ -456,10 +403,7 @@ def test_reads_refresh_token_from_kubernetes_secret_json() -> None:
 def test_litellm_handler_returns_model_response() -> None:
     class FakeClient(_NoStreamingClient):
         async def chat_completion(
-            self,
-            model: str,
-            messages: Sequence[Mapping[str, Any]],
-            optional_params: Mapping[str, Any] | None = None,
+            self, model: str, messages: Sequence[Mapping[str, Any]], optional_params: Mapping[str, Any] | None = None
         ) -> TanaChatResult:
             assert model == "claude-test"
             assert messages == [{"role": "user", "content": "hi"}]
@@ -469,9 +413,7 @@ def test_litellm_handler_returns_model_response() -> None:
     handler = TanaLiteLLM(FakeClient())
     response = asyncio.run(
         handler.acompletion(
-            model="claude-test",
-            messages=[{"role": "user", "content": "hi"}],
-            optional_params={"temperature": 0.0},
+            model="claude-test", messages=[{"role": "user", "content": "hi"}], optional_params={"temperature": 0.0}
         )
     )
 
@@ -488,10 +430,7 @@ def test_litellm_handler_returns_model_response() -> None:
 def test_litellm_handler_returns_tool_calls() -> None:
     class FakeClient(_NoStreamingClient):
         async def chat_completion(
-            self,
-            model: str,
-            messages: Sequence[Mapping[str, Any]],
-            optional_params: Mapping[str, Any] | None = None,
+            self, model: str, messages: Sequence[Mapping[str, Any]], optional_params: Mapping[str, Any] | None = None
         ) -> TanaChatResult:
             assert model == "claude-test"
             assert optional_params is not None
@@ -499,11 +438,7 @@ def test_litellm_handler_returns_tool_calls() -> None:
             return TanaChatResult(
                 text="",
                 tool_calls=[
-                    {
-                        "toolCallId": "call-1",
-                        "toolName": "lookup_demo_fact",
-                        "input": {"topic": "tana-litellm-tool"},
-                    }
+                    {"toolCallId": "call-1", "toolName": "lookup_demo_fact", "input": {"topic": "tana-litellm-tool"}}
                 ],
                 usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
             )
@@ -531,18 +466,12 @@ def test_litellm_handler_returns_tool_calls() -> None:
 def test_litellm_routes_streaming_to_custom_provider() -> None:
     class FakeClient:
         async def chat_completion(
-            self,
-            model: str,
-            messages: Sequence[Mapping[str, Any]],
-            optional_params: Mapping[str, Any] | None = None,
+            self, model: str, messages: Sequence[Mapping[str, Any]], optional_params: Mapping[str, Any] | None = None
         ) -> TanaChatResult:
             raise AssertionError("streaming test should not call non-streaming chat_completion")
 
         def stream_completion(
-            self,
-            model: str,
-            messages: Sequence[Mapping[str, Any]],
-            optional_params: Mapping[str, Any] | None = None,
+            self, model: str, messages: Sequence[Mapping[str, Any]], optional_params: Mapping[str, Any] | None = None
         ) -> Iterator[GenericStreamingChunk]:
             assert model == "claude-test"
             assert messages == [{"role": "user", "content": "hi"}]
@@ -551,20 +480,13 @@ def test_litellm_routes_streaming_to_custom_provider() -> None:
             yield GenericStreamingChunk(text="", is_finished=True, finish_reason="stop", usage=None, index=0)
 
         async def astream_completion(
-            self,
-            model: str,
-            messages: Sequence[Mapping[str, Any]],
-            optional_params: Mapping[str, Any] | None = None,
+            self, model: str, messages: Sequence[Mapping[str, Any]], optional_params: Mapping[str, Any] | None = None
         ) -> AsyncIterator[GenericStreamingChunk]:
             raise AssertionError("sync streaming test should not call astream_completion")
             yield GenericStreamingChunk(text="", is_finished=True, finish_reason="stop", usage=None, index=0)
 
     register_litellm_provider(TanaLiteLLM(FakeClient()))
-    stream = litellm.completion(
-        model="tana/claude-test",
-        messages=[{"role": "user", "content": "hi"}],
-        stream=True,
-    )
+    stream = litellm.completion(model="tana/claude-test", messages=[{"role": "user", "content": "hi"}], stream=True)
 
     chunks = list(stream)
 
@@ -575,10 +497,7 @@ def test_litellm_routes_streaming_to_custom_provider() -> None:
 def test_registers_tana_as_litellm_custom_provider() -> None:
     handler = register_litellm_provider(TanaLiteLLM())
 
-    assert any(
-        item["provider"] == "tana" and item["custom_handler"] is handler
-        for item in litellm.custom_provider_map
-    )
+    assert any(item["provider"] == "tana" and item["custom_handler"] is handler for item in litellm.custom_provider_map)
 
 
 if __name__ == "__main__":

--- a/tana/litellm_proxy/test_provider.py
+++ b/tana/litellm_proxy/test_provider.py
@@ -1,0 +1,585 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import subprocess
+from collections.abc import AsyncIterator, Iterator, Mapping, Sequence
+from typing import Any, Protocol, cast
+
+import httpx
+import litellm
+import pytest_bazel
+from litellm.types.utils import Choices, GenericStreamingChunk, Usage
+
+from tana.litellm_proxy.provider import (
+    TanaChatResult,
+    TanaLiteLLM,
+    TanaProxyClient,
+    TanaProxyConfig,
+    read_refresh_token_from_config,
+    register_litellm_provider,
+)
+
+
+class _ModelResponseWithUsage(Protocol):
+    usage: Usage
+
+
+class _NoStreamingClient:
+    def stream_completion(
+        self,
+        model: str,
+        messages: Sequence[Mapping[str, Any]],
+        optional_params: Mapping[str, Any] | None = None,
+    ) -> Iterator[GenericStreamingChunk]:
+        raise AssertionError("non-streaming test should not call stream_completion")
+
+    async def astream_completion(
+        self,
+        model: str,
+        messages: Sequence[Mapping[str, Any]],
+        optional_params: Mapping[str, Any] | None = None,
+    ) -> AsyncIterator[GenericStreamingChunk]:
+        raise AssertionError("non-streaming test should not call astream_completion")
+        yield GenericStreamingChunk(text="", is_finished=True, finish_reason="stop", usage=None, index=0)
+
+
+def test_client_maps_basic_chat_request() -> None:
+    seen_requests: list[httpx.Request] = []
+    seen_bodies: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_requests.append(request)
+        if request.url.host == "securetoken.googleapis.com":
+            return httpx.Response(
+                200,
+                json={"id_token": "id-token-1", "refresh_token": "refresh-2", "expires_in": "3600"},
+            )
+        assert request.url == "https://app.tana.inc/functions/llmProxy"
+        seen_bodies.append(json.loads(request.content.decode("utf-8")))
+        assert request.headers["authorization"] == "Bearer id-token-1"
+        return httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            json={
+                "text": "hello from tana",
+                "usage": {"inputTokens": 2, "outputTokens": 3},
+            },
+        )
+
+    async def run() -> TanaChatResult:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+            client = TanaProxyClient(
+                TanaProxyConfig(refresh_token="refresh-1"),
+                http_client=http,
+            )
+            return await client.chat_completion(
+                "tana/claude-test",
+                [{"role": "user", "content": "hi"}],
+                {
+                    "temperature": 0.25,
+                    "top_p": 0.9,
+                    "max_tokens": 12,
+                    "stop": "END",
+                    "frequency_penalty": 0.1,
+                    "presence_penalty": 0.2,
+                },
+            )
+
+    result = asyncio.run(run())
+
+    assert result.text == "hello from tana"
+    assert result.usage == {"prompt_tokens": 2, "completion_tokens": 3, "total_tokens": 5}
+    assert len(seen_requests) == 2
+    body = seen_bodies[0]
+    assert body == {
+        "isStreaming": False,
+        "args": {
+            "userContext": "Generic AI Query",
+            "messages": [{"role": "user", "content": "hi"}],
+            "options": {
+                "model": "claude-test",
+                "ignoreLargeContextWarning": True,
+                "ignoreOutOfCreditsWarning": False,
+                "temperature": 0.25,
+                "topP": 0.9,
+                "frequencyPenalty": 0.1,
+                "presencePenalty": 0.2,
+                "maxOutputTokens": 12,
+                "stopStrings": ["END"],
+            },
+        },
+    }
+
+
+def test_client_maps_message_envelopes_without_prompt_collapsing() -> None:
+    seen_bodies: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "securetoken.googleapis.com":
+            return httpx.Response(
+                200,
+                json={"id_token": "id-token-1", "refresh_token": "refresh-2", "expires_in": "3600"},
+            )
+        assert request.url == "https://app.tana.inc/functions/llmProxy"
+        seen_bodies.append(json.loads(request.content.decode("utf-8")))
+        return httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            json={"text": "ok"},
+        )
+
+    async def run() -> TanaChatResult:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+            client = TanaProxyClient(
+                TanaProxyConfig(refresh_token="refresh-1"),
+                http_client=http,
+            )
+            return await client.chat_completion(
+                "claude-test",
+                [
+                    {
+                        "role": "system",
+                        "content": "You are concise.",
+                        "provider_options": {"anthropic": {"cacheControl": {"type": "ephemeral"}}},
+                    },
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "input_text",
+                                "text": "call the tool later",
+                                "provider_options": {"anthropic": {"cacheControl": {"type": "ephemeral"}}},
+                            },
+                            {"type": "reasoning", "text": "prior scratchpad"},
+                        ],
+                    },
+                    {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "call-1",
+                                "type": "function",
+                                "function": {
+                                    "name": "lookup_demo_fact",
+                                    "arguments": "{\"topic\":\"tana-litellm-tool\"}",
+                                },
+                            }
+                        ],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "call-1",
+                        "name": "lookup_demo_fact",
+                        "content": "{\"ok\":true}",
+                    },
+                ],
+                {
+                    "provider_options": {"openai": {"promptCacheKey": "conversation-1"}},
+                },
+            )
+
+    result = asyncio.run(run())
+
+    assert result.text == "ok"
+    body = seen_bodies[0]
+    assert "prompt" not in body["args"]
+    assert body == {
+        "isStreaming": False,
+        "args": {
+            "userContext": "Generic AI Query",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "You are concise.",
+                    "providerOptions": {"anthropic": {"cacheControl": {"type": "ephemeral"}}},
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "call the tool later",
+                            "providerOptions": {"anthropic": {"cacheControl": {"type": "ephemeral"}}},
+                        },
+                        {"type": "reasoning", "text": "prior scratchpad"},
+                    ],
+                },
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool-call",
+                            "toolCallId": "call-1",
+                            "toolName": "lookup_demo_fact",
+                            "input": {"topic": "tana-litellm-tool"},
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "content": [
+                        {
+                            "type": "tool-result",
+                            "toolCallId": "call-1",
+                            "toolName": "lookup_demo_fact",
+                            "output": "{\"ok\":true}",
+                        }
+                    ],
+                },
+            ],
+            "options": {
+                "model": "claude-test",
+                "ignoreLargeContextWarning": True,
+                "ignoreOutOfCreditsWarning": False,
+                "providerOptions": {"openai": {"promptCacheKey": "conversation-1"}},
+            },
+        },
+    }
+
+
+def test_client_maps_tool_request_to_llm_proxy_next() -> None:
+    seen_bodies: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "securetoken.googleapis.com":
+            return httpx.Response(
+                200,
+                json={"id_token": "id-token-1", "refresh_token": "refresh-2", "expires_in": "3600"},
+            )
+        assert request.url == "https://app.tana.inc/functions/llmProxyNext"
+        assert request.headers["authorization"] == "Bearer id-token-1"
+        seen_bodies.append(json.loads(request.content.decode("utf-8")))
+        return httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            json={
+                "text": "",
+                "toolCalls": [
+                    {
+                        "toolCallId": "call-1",
+                        "toolName": "lookup_demo_fact",
+                        "input": {"topic": "tana-litellm-tool"},
+                    }
+                ],
+                "usage": {"promptTokens": 4, "completionTokens": 5},
+            },
+        )
+
+    async def run() -> TanaChatResult:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+            client = TanaProxyClient(
+                TanaProxyConfig(refresh_token="refresh-1"),
+                http_client=http,
+            )
+            return await client.chat_completion(
+                "claude-test",
+                [{"role": "user", "content": "call the tool"}],
+                {
+                    "tools": [
+                        {
+                            "type": "function",
+                            "function": {
+                                "name": "lookup_demo_fact",
+                                "description": "Look up a demo fact.",
+                                "parameters": {
+                                    "type": "object",
+                                    "properties": {"topic": {"type": "string"}},
+                                    "required": ["topic"],
+                                },
+                            },
+                        }
+                    ],
+                    "max_tokens": 32,
+                },
+            )
+
+    result = asyncio.run(run())
+
+    assert result.text == ""
+    assert result.tool_calls == [
+        {"toolCallId": "call-1", "toolName": "lookup_demo_fact", "input": {"topic": "tana-litellm-tool"}}
+    ]
+    assert seen_bodies == [
+        {
+            "isStreaming": False,
+            "args": {
+                "userContext": "Ask Tana",
+                "messages": [{"role": "user", "content": "call the tool"}],
+                "options": {
+                    "model": "claude-test",
+                    "ignoreLargeContextWarning": True,
+                    "ignoreOutOfCreditsWarning": False,
+                    "maxOutputTokens": 32,
+                },
+            },
+            "dynamicTools": [
+                {
+                    "name": "lookup_demo_fact",
+                    "description": "Look up a demo fact.",
+                    "kind": "mcpTool",
+                    "runtime": "client",
+                    "schema": {
+                        "type": "object",
+                        "properties": {"topic": {"type": "string"}},
+                        "required": ["topic"],
+                    },
+                }
+            ],
+        }
+    ]
+
+
+def test_client_streams_text_chunks_from_llm_proxy() -> None:
+    seen_bodies: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "securetoken.googleapis.com":
+            return httpx.Response(
+                200,
+                json={"id_token": "id-token-1", "refresh_token": "refresh-2", "expires_in": "3600"},
+            )
+        assert request.url == "https://app.tana.inc/functions/llmProxy"
+        assert request.headers["authorization"] == "Bearer id-token-1"
+        seen_bodies.append(json.loads(request.content.decode("utf-8")))
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=(
+                b'data: {"type":"text-delta","delta":"hello"}\n'
+                b'0:" world"\n'
+                b'data: {"type":"finish","finishReason":"stop",'
+                b'"messageMetadata":{"usage":{"promptTokens":2,"completionTokens":3}}}\n'
+            ),
+        )
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as http:
+        client = TanaProxyClient(
+            TanaProxyConfig(refresh_token="refresh-1"),
+            sync_http_client=http,
+        )
+        chunks = list(
+            client.stream_completion(
+                "tana/claude-test",
+                [{"role": "user", "content": "hi"}],
+                {"temperature": 0.0, "max_tokens": 16},
+            )
+        )
+
+    assert [chunk["text"] for chunk in chunks if chunk["text"]] == ["hello", " world"]
+    assert chunks[-1]["is_finished"] is True
+    assert chunks[-1]["finish_reason"] == "stop"
+    assert chunks[-1]["usage"] == {"prompt_tokens": 2, "completion_tokens": 3, "total_tokens": 5}
+    assert seen_bodies == [
+        {
+            "isStreaming": True,
+            "args": {
+                "userContext": "Generic AI Query",
+                "messages": [{"role": "user", "content": "hi"}],
+                "options": {
+                    "model": "claude-test",
+                    "ignoreLargeContextWarning": True,
+                    "ignoreOutOfCreditsWarning": False,
+                    "temperature": 0.0,
+                    "maxOutputTokens": 16,
+                },
+            },
+        }
+    ]
+
+
+def test_client_streams_tool_calls_from_llm_proxy_next() -> None:
+    seen_bodies: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "securetoken.googleapis.com":
+            return httpx.Response(
+                200,
+                json={"id_token": "id-token-1", "refresh_token": "refresh-2", "expires_in": "3600"},
+            )
+        assert request.url == "https://app.tana.inc/functions/llmProxyNext"
+        seen_bodies.append(json.loads(request.content.decode("utf-8")))
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=(
+                b'data: {"type":"tool-input-available","toolCallId":"call-1",'
+                b'"toolName":"lookup_demo_fact","input":"{}"}\n'
+                b'data: {"type":"tool-input-available","toolCallId":"call-1",'
+                b'"toolName":"lookup_demo_fact","input":{"topic":"tana-litellm-tool"}}\n'
+                b'data: {"type":"finish","messageMetadata":{"finishReason":"stop",'
+                b'"usage":{"inputTokens":4,"outputTokens":5}}}\n'
+            ),
+        )
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as http:
+        client = TanaProxyClient(
+            TanaProxyConfig(refresh_token="refresh-1"),
+            sync_http_client=http,
+        )
+        chunks = list(
+            client.stream_completion(
+                "claude-test",
+                [{"role": "user", "content": "call the tool"}],
+                {"tools": [{"type": "function", "function": {"name": "lookup_demo_fact"}}]},
+            )
+        )
+
+    tool_chunks = [chunk for chunk in chunks if chunk.get("tool_use") is not None]
+    assert len(tool_chunks) == 2
+    initial_tool_use = tool_chunks[0]["tool_use"]
+    assert initial_tool_use is not None
+    assert initial_tool_use["function"]["arguments"] == ""
+    tool_use = tool_chunks[1]["tool_use"]
+    assert tool_use is not None
+    assert tool_use["id"] == "call-1"
+    assert tool_use["type"] == "function"
+    assert tool_use["function"]["name"] == "lookup_demo_fact"
+    assert json.loads(tool_use["function"]["arguments"]) == {"topic": "tana-litellm-tool"}
+    assert chunks[-1]["usage"] == {"prompt_tokens": 4, "completion_tokens": 5, "total_tokens": 9}
+    assert seen_bodies[0]["isStreaming"] is True
+    assert seen_bodies[0]["args"]["userContext"] == "Ask Tana"
+    assert seen_bodies[0]["dynamicTools"][0]["runtime"] == "client"
+
+
+def test_reads_refresh_token_from_kubernetes_secret_json() -> None:
+    def runner(args: list[str]) -> subprocess.CompletedProcess[str]:
+        assert args == ["kubectl", "get", "secret", "-n", "tana-mcp", "tana-firebase-refresh-token", "-o", "json"]
+        stdout = json.dumps({"data": {"refresh_token": base64.b64encode(b"refresh-token").decode("ascii")}})
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout=stdout, stderr="")
+
+    assert read_refresh_token_from_config(TanaProxyConfig(), runner=runner) == "refresh-token"
+
+
+def test_litellm_handler_returns_model_response() -> None:
+    class FakeClient(_NoStreamingClient):
+        async def chat_completion(
+            self,
+            model: str,
+            messages: Sequence[Mapping[str, Any]],
+            optional_params: Mapping[str, Any] | None = None,
+        ) -> TanaChatResult:
+            assert model == "claude-test"
+            assert messages == [{"role": "user", "content": "hi"}]
+            assert optional_params == {"temperature": 0.0}
+            return TanaChatResult(text="pong", usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2})
+
+    handler = TanaLiteLLM(FakeClient())
+    response = asyncio.run(
+        handler.acompletion(
+            model="claude-test",
+            messages=[{"role": "user", "content": "hi"}],
+            optional_params={"temperature": 0.0},
+        )
+    )
+
+    choice = response.choices[0]
+    assert isinstance(choice, Choices)
+    assert response.model == "tana/claude-test"
+    assert choice.message.content == "pong"
+
+    response_with_usage = cast(_ModelResponseWithUsage, response)
+    assert isinstance(response_with_usage.usage, Usage)
+    assert response_with_usage.usage.prompt_tokens == 1
+
+
+def test_litellm_handler_returns_tool_calls() -> None:
+    class FakeClient(_NoStreamingClient):
+        async def chat_completion(
+            self,
+            model: str,
+            messages: Sequence[Mapping[str, Any]],
+            optional_params: Mapping[str, Any] | None = None,
+        ) -> TanaChatResult:
+            assert model == "claude-test"
+            assert optional_params is not None
+            assert "tools" in optional_params
+            return TanaChatResult(
+                text="",
+                tool_calls=[
+                    {
+                        "toolCallId": "call-1",
+                        "toolName": "lookup_demo_fact",
+                        "input": {"topic": "tana-litellm-tool"},
+                    }
+                ],
+                usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            )
+
+    handler = TanaLiteLLM(FakeClient())
+    response = asyncio.run(
+        handler.acompletion(
+            model="claude-test",
+            messages=[{"role": "user", "content": "call the tool"}],
+            optional_params={"tools": [{"type": "function", "function": {"name": "lookup_demo_fact"}}]},
+        )
+    )
+
+    choice = response.choices[0]
+    assert isinstance(choice, Choices)
+    assert choice.finish_reason == "tool_calls"
+    assert choice.message.tool_calls is not None
+    tool_call = choice.message.tool_calls[0]
+    assert tool_call.id == "call-1"
+    assert tool_call.type == "function"
+    assert tool_call.function.name == "lookup_demo_fact"
+    assert json.loads(tool_call.function.arguments) == {"topic": "tana-litellm-tool"}
+
+
+def test_litellm_routes_streaming_to_custom_provider() -> None:
+    class FakeClient:
+        async def chat_completion(
+            self,
+            model: str,
+            messages: Sequence[Mapping[str, Any]],
+            optional_params: Mapping[str, Any] | None = None,
+        ) -> TanaChatResult:
+            raise AssertionError("streaming test should not call non-streaming chat_completion")
+
+        def stream_completion(
+            self,
+            model: str,
+            messages: Sequence[Mapping[str, Any]],
+            optional_params: Mapping[str, Any] | None = None,
+        ) -> Iterator[GenericStreamingChunk]:
+            assert model == "claude-test"
+            assert messages == [{"role": "user", "content": "hi"}]
+            assert optional_params == {"stream": True}
+            yield GenericStreamingChunk(text="pong", is_finished=False, finish_reason="", usage=None, index=0)
+            yield GenericStreamingChunk(text="", is_finished=True, finish_reason="stop", usage=None, index=0)
+
+        async def astream_completion(
+            self,
+            model: str,
+            messages: Sequence[Mapping[str, Any]],
+            optional_params: Mapping[str, Any] | None = None,
+        ) -> AsyncIterator[GenericStreamingChunk]:
+            raise AssertionError("sync streaming test should not call astream_completion")
+            yield GenericStreamingChunk(text="", is_finished=True, finish_reason="stop", usage=None, index=0)
+
+    register_litellm_provider(TanaLiteLLM(FakeClient()))
+    stream = litellm.completion(
+        model="tana/claude-test",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=True,
+    )
+
+    chunks = list(stream)
+
+    assert chunks[0].choices[0].delta.content == "pong"
+    assert chunks[-1].choices[0].finish_reason == "stop"
+
+
+def test_registers_tana_as_litellm_custom_provider() -> None:
+    handler = register_litellm_provider(TanaLiteLLM())
+
+    assert any(
+        item["provider"] == "tana" and item["custom_handler"] is handler
+        for item in litellm.custom_provider_map
+    )
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()


### PR DESCRIPTION
## Summary
- add a LiteLLM custom provider for Tana's internal LLM proxy
- always send chat input as Tana `args.messages` envelopes
- normalize OpenAI/AI SDK message aliases, provider options, tool calls, and tool results into Tana message content parts
- include a Bazel demo and provider tests

## Validation
- `nix develop -c pre-commit run --files tana/firebase_resigner/BUILD.bazel tana/litellm_proxy/BUILD.bazel tana/litellm_proxy/README.md tana/litellm_proxy/__init__.py tana/litellm_proxy/demo.py tana/litellm_proxy/provider.py tana/litellm_proxy/test_provider.py`
- `nix develop -c pre-commit run --files tana/litellm_proxy/provider.py`
- GitHub `Pre-commit checks` passed on `23061be8a`
- GitHub `CI / bazel-ci / Test & Build` passed on `23061be8a`
- `bbr build //tana/litellm_proxy:provider`
- `bbr test //tana/litellm_proxy:test_provider`
- live non-streaming demo returned `tana-message-ok`
- live streaming demo returned `tana-message-stream-ok`
- live streamed tool demo returned a `lookup_demo_fact` call with `{"topic": "tana-litellm-tool"}`