### PR TITLE
scraper: agent-proxy TLS support + no manifest-only commits on quiet runs

### DIFF
--- a/finance/scraper/fetch.py
+++ b/finance/scraper/fetch.py
@@ -58,6 +58,13 @@ DEFAULT_MAX_AGE = timedelta(hours=20)
 # outages, short enough that a genuinely stuck source still surfaces.
 DEFAULT_STALE_AFTER = timedelta(days=3)
 
+# A successful sync re-stamps the committed last_fetched only once the stored stamp
+# is this old. Its consumers (freshness skip, stale-aware exit) tolerate day-level
+# accuracy, and skipping the no-op bump keeps an hourly run whose data didn't change
+# from committing a manifest-only diff every time — the mirror's git history stays
+# a record of real data changes (plus one liveness attestation per ~day).
+MANIFEST_REFRESH_FLOOR = DEFAULT_MAX_AGE
+
 
 class EvidenceManifest(BaseModel):
     """Per-source last-successful-fetch times, committed as evidence_meta.json."""
@@ -196,12 +203,12 @@ async def run_scrape(
         due_markets = _due(markets, manifest, now, market_max_age)
         failed_markets = await sync_markets(repo_path, due_markets, http_get=http_get)
 
-        for source in due_sources:
-            if source not in failed_sources:
-                manifest.last_fetched[source.provenance_label] = now
-        for entry in due_markets:
-            if entry not in failed_markets:
-                manifest.last_fetched[entry.provenance_label] = now
+        succeeded: list[_Provenanced] = [source for source in due_sources if source not in failed_sources]
+        succeeded += [entry for entry in due_markets if entry not in failed_markets]
+        for item in succeeded:
+            age = _age_since_fetch(manifest, item.provenance_label, now)
+            if age is None or age >= MANIFEST_REFRESH_FLOOR:
+                manifest.last_fetched[item.provenance_label] = now
         _write_manifest(repo_path, manifest)
         commit_and_push(repo, branch, now=now, callbacks=callbacks)
 

--- a/finance/scraper/http_fetch.py
+++ b/finance/scraper/http_fetch.py
@@ -1,11 +1,16 @@
 """Async HTTPS GET for the public upstreams, with certifi trust + transient retry.
 
-debian-slim ships no CA bundle, so the client is pinned to certifi's bundled
-certs rather than the (absent) system trust store.
+debian-slim ships no CA bundle, so the client defaults to certifi's bundled certs
+rather than the (absent) system trust store. An explicit `SSL_CERT_FILE` wins when
+set: agent sandboxes (Claude Code sessions, the claude-sandbox namespace) force
+egress through a TLS-intercepting proxy and inject its CA via that variable — the
+standard contract curl/requests/node already honor. Production CronJobs set
+neither, so they stay on certifi.
 """
 
 from __future__ import annotations
 
+import os
 import ssl
 from collections.abc import Awaitable, Callable
 
@@ -19,7 +24,12 @@ HttpGet = Callable[[str, str], Awaitable[bytes]]  # (url, user_agent) -> body
 # as per-source skips (a dead upstream shouldn't block refreshing the rest).
 FETCH_ERRORS: tuple[type[BaseException], ...] = (httpx.HTTPError,)
 
-_SSL_CONTEXT = ssl.create_default_context(cafile=certifi.where())
+
+def _ca_file() -> str:
+    return os.environ.get("SSL_CERT_FILE") or certifi.where()
+
+
+_SSL_CONTEXT = ssl.create_default_context(cafile=_ca_file())
 
 
 def _is_transient(exc: BaseException) -> bool:

--- a/finance/scraper/test_fetch.py
+++ b/finance/scraper/test_fetch.py
@@ -6,12 +6,13 @@ from pathlib import Path
 
 import httpx
 import pygit2
+import pytest
 import pytest_bazel
 
 from finance.evidence.markets import MarketEntry, Platform
 from finance.evidence.sources import EvidenceKind, EvidenceSource
 from finance.scraper.fetch import EVIDENCE_META_FILENAME, EvidenceManifest, commit_and_push, run_scrape, write_sources
-from finance.scraper.http_fetch import HttpGet
+from finance.scraper.http_fetch import HttpGet, _ca_file
 from finance.scraper.market_mirror import KALSHI_API, MANIFOLD_API
 
 SOURCE = EvidenceSource(
@@ -74,6 +75,15 @@ def _remote_last_message(remote: Path) -> str:
 def _remote_commit_count(remote: Path) -> int:
     repo = pygit2.Repository(str(remote))
     return sum(1 for _ in repo.walk(repo.revparse_single("main").peel(pygit2.Commit).id))
+
+
+def test_ca_file_honors_ssl_cert_file(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Agent sandboxes inject a TLS-intercepting proxy's CA via SSL_CERT_FILE; the
+    # fetcher must trust it there while staying on certifi when the env is unset.
+    monkeypatch.setenv("SSL_CERT_FILE", "/tmp/proxy-ca.pem")
+    assert _ca_file() == "/tmp/proxy-ca.pem"
+    monkeypatch.delenv("SSL_CERT_FILE")
+    assert _ca_file().endswith("cacert.pem")
 
 
 async def test_write_sources_writes_each_file_by_output_filename(tmp_path: Path) -> None:

--- a/finance/scraper/test_fetch.py
+++ b/finance/scraper/test_fetch.py
@@ -338,7 +338,7 @@ async def test_run_scrape_unchanged_markets_skip_the_commit(tmp_path: Path) -> N
     _seed_remote(remote)
     get, _ = _dispatch_get({SOURCE.upstream_url: b"body", **_MARKET_RESPONSES})
 
-    async def scrape_once() -> int:
+    async def scrape_once(now: datetime) -> int:
         return await run_scrape(
             str(remote),
             "main",
@@ -346,15 +346,31 @@ async def test_run_scrape_unchanged_markets_skip_the_commit(tmp_path: Path) -> N
             username="",
             password="",
             http_get=get,
-            now=NOW,
+            now=now,
             depth=0,
             markets=[MANIFOLD_ENTRY, KALSHI_ENTRY],
         )
 
-    assert await scrape_once() == 0
+    assert await scrape_once(NOW) == 0
     count_after_first = _remote_commit_count(remote)
-    assert await scrape_once() == 0
+    # An hour later (the hourly-cron case): identical payloads and a manifest stamp
+    # young enough to keep — nothing to commit, not even a manifest-only diff.
+    assert await scrape_once(NOW + timedelta(hours=1)) == 0
     assert _remote_commit_count(remote) == count_after_first
+
+
+async def test_run_scrape_restamps_manifest_after_refresh_floor(tmp_path: Path) -> None:
+    # Quiet markets skip the manifest bump (no churn), but the stamp still refreshes
+    # about daily so the stale-after exit stays honest about ongoing successes.
+    remote = tmp_path / "remote.git"
+    _seed_with_last_fetched(remote, {KALSHI_ENTRY.provenance_label: NOW - timedelta(hours=21)})
+    get, _ = _dispatch_get(_MARKET_RESPONSES)
+    code = await run_scrape(
+        str(remote), "main", [], username="", password="", http_get=get, now=NOW, depth=0, markets=[KALSHI_ENTRY]
+    )
+    assert code == 0
+    manifest = EvidenceManifest.model_validate_json(_remote_blob(remote, EVIDENCE_META_FILENAME))
+    assert manifest.last_fetched[KALSHI_ENTRY.provenance_label] == NOW
 
 
 async def test_run_scrape_market_syncs_while_fresh_source_skips(tmp_path: Path) -> None:


### PR DESCRIPTION
Two scraper fixes that fell out of running the live end-to-end smoke of the market mirror (#1984/#1986 follow-up):

- **`http_fetch` honors `SSL_CERT_FILE`**: agent sandboxes (Claude Code session hosts, the `claude-sandbox` namespace) force egress through a TLS-intercepting proxy and hand its CA to workloads via `SSL_CERT_FILE` — the standard contract curl/requests/node already honor. The fetcher's certifi pinning ignored it, so the scraper couldn't run in any agent environment (verified: identical cert failures on the session host and in-cluster, where the `sandbox-force-proxy-egress` CCNP allows no direct egress and the mitmproxy intercepts everything). An explicit `SSL_CERT_FILE` now wins; production CronJobs set neither and stay on certifi.
- **No manifest-only commits on quiet runs**: always-due markets re-stamped `last_fetched` every run, so an hourly cron would push a manifest-only diff 24×/day with byte-identical data — polluting the as-of git history the mirror design depends on. A successful sync now re-stamps the committed timestamp only once it's 20h old (`MANIFEST_REFRESH_FLOOR`); quiet runs leave the tree unchanged while the stamp still refreshes ~daily so the stale-after exit stays honest.

**Live smoke results** (real APIs through the session proxy, scratch `git://` remote, the example roster):
- all 11 FRED/Yahoo/Zillow sources + 3 deep manifold markets synced and pushed;
- bet/comment counts match the harvest survey's verification log exactly (1,092 bets / 10 comments on `a3k1Rg…`);
- `probAfter` of the last bet before 2024-01-15 reproduces the independently verified **0.139** (0.13923…);
- incremental re-sync of the 80,847-bet MC election market: ~4s vs ~5min cold backfill;
- second run: all sources freshness-skipped, markets re-synced, **"evidence unchanged; nothing to commit"**.

https://claude.ai/code/session_01KVxYdZeAd6eWcrPEPLbSZ2

---
_Generated by [Claude Code](https://claude.ai/code/session_01KVxYdZeAd6eWcrPEPLbSZ2)_