### PR TITLE
forgejo: model the claude-collaborator ordering with Terraform dependsOn

### DIFF
--- a/cluster/k8s/forgejo/augur-evidence/terraform.yaml
+++ b/cluster/k8s/forgejo/augur-evidence/terraform.yaml
@@ -12,6 +12,11 @@ spec:
     name: flux-system
     namespace: flux-system
 
+  # forgejo_collaborator.claude grants read to the claude agent account, so the
+  # forgejo-claude module (which provisions that user) must apply first.
+  dependsOn:
+    - name: forgejo-claude
+
   serviceAccountName: tf-runner
   approvePlan: "auto"
 

--- a/cluster/k8s/forgejo/budget-ledger/terraform.yaml
+++ b/cluster/k8s/forgejo/budget-ledger/terraform.yaml
@@ -12,6 +12,11 @@ spec:
     name: flux-system
     namespace: flux-system
 
+  # forgejo_collaborator.claude grants read to the claude agent account, so the
+  # forgejo-claude module (which provisions that user) must apply first.
+  dependsOn:
+    - name: forgejo-claude
+
   serviceAccountName: tf-runner
   approvePlan: "auto"
 

--- a/cluster/k8s/forgejo/cpap-data/terraform.yaml
+++ b/cluster/k8s/forgejo/cpap-data/terraform.yaml
@@ -12,6 +12,11 @@ spec:
     name: flux-system
     namespace: flux-system
 
+  # forgejo_collaborator.claude grants read to the claude agent account, so the
+  # forgejo-claude module (which provisions that user) must apply first.
+  dependsOn:
+    - name: forgejo-claude
+
   serviceAccountName: tf-runner
   approvePlan: "auto"
 


### PR DESCRIPTION
Models the claude-collaborator ordering explicitly instead of retry-until-converged. Each repo module's `forgejo_collaborator "claude"` implicitly requires the `claude` user from `tf/gitops/forgejo-claude` — at the account's first bootstrap this morning that edge cost ~10 minutes of red `TerraformAppliedFail` CRs (`user does not exist [name: claude]`) before converging, and would recur on every from-scratch bootstrap.

Adds `spec.dependsOn: [{name: forgejo-claude}]` to the `augur-evidence`, `cpap-data`, and `budget-ledger` Terraform CRs (the deployed v1alpha2 CRD supports Terraform-to-Terraform `dependsOn`; all CRs live in `flux-system`). `forgejo-claude` itself is currently Ready, so rollout is a no-op for steady state.

Companion: agentydragon/gaffer-private#274 does the same for the `thrive-scrape` CR (cross-source, same namespace).

Verified: kustomize renders + kubeconform pass.

https://claude.ai/code/session_01RufPzcJjy3Zky7A5EannGU