### PR TITLE
wayback-cache: authed gateway route for out-of-cluster cache sharing

### DIFF
--- a/cluster/k8s/wayback-cache/config/nginx.conf
+++ b/cluster/k8s/wayback-cache/config/nginx.conf
@@ -20,6 +20,18 @@ events {
 http {
     access_log /dev/stdout;
 
+    # Bearer token for the gateway-facing listener (:8090). Injected at
+    # container start by nginx:alpine's envsubst from $WAYBACK_CACHE_TOKEN
+    # (NGINX_ENVSUBST_FILTER restricts substitution to this one var so nginx's
+    # own $variables survive). In-cluster consumers use :8080 unauthenticated;
+    # only the public HTTPRoute path is token-gated.
+    # The "Bearer <64-hex>" key is ~71 bytes, over the 64-byte default bucket.
+    map_hash_bucket_size 128;
+    map $http_authorization $wayback_authed {
+        default 0;
+        "Bearer ${WAYBACK_CACHE_TOKEN}" 1;
+    }
+
     # Snapshot bytes at a fixed 14-digit timestamp are immutable.
     # use_temp_path=off avoids cross-filesystem renames onto the PVC.
     proxy_cache_path /cache levels=1:2 keys_zone=wayback:64m max_size=18g
@@ -74,6 +86,19 @@ http {
         location /cdx/ {
             proxy_cache_valid 200 7d;
             proxy_pass http://127.0.0.1:8081;
+        }
+    }
+
+    server { # gateway-facing: bearer-authed wrapper over tier 1
+        listen 8090;
+        location / {
+            if ($wayback_authed = 0) {
+                return 401;
+            }
+            proxy_pass http://127.0.0.1:8080;
+            proxy_read_timeout 300s;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
         }
     }
 

--- a/cluster/k8s/wayback-cache/deployment.yaml
+++ b/cluster/k8s/wayback-cache/deployment.yaml
@@ -32,9 +32,24 @@ spec:
           ports:
             - containerPort: 8080
               name: http
+            - containerPort: 8090
+              name: authed
+          env:
+            # nginx:alpine entrypoint renders templates/*.template with
+            # envsubst, substituting only WAYBACK_CACHE_TOKEN (the filter) so
+            # nginx's own $variables survive. Output overwrites nginx.conf.
+            - name: WAYBACK_CACHE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: wayback-cache-token
+                  key: token
+            - name: NGINX_ENVSUBST_FILTER
+              value: WAYBACK_CACHE_TOKEN
+            - name: NGINX_ENVSUBST_OUTPUT_DIR
+              value: /etc/nginx
           volumeMounts:
             - name: config
-              mountPath: /etc/nginx/nginx.conf
+              mountPath: /etc/nginx/templates/nginx.conf.template
               subPath: nginx.conf
               readOnly: true
             - name: cache

--- a/cluster/k8s/wayback-cache/flux-kustomization.yaml
+++ b/cluster/k8s/wayback-cache/flux-kustomization.yaml
@@ -13,6 +13,10 @@ spec:
   path: ./cluster/k8s/wayback-cache
   prune: true
   wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age-cluster-secrets
   healthChecks:
     - apiVersion: apps/v1
       kind: Deployment

--- a/cluster/k8s/wayback-cache/httproute.yaml
+++ b/cluster/k8s/wayback-cache/httproute.yaml
@@ -1,0 +1,22 @@
+# Public, bearer-authed entry to the cache so an out-of-cluster wayback proxy
+# (e.g. a dev agent run on a local Docker daemon) can use the shared cache
+# instead of hitting IA directly. Routes to the :8090 listener, which requires
+# the wayback-cache-token bearer; the unauthed :8080 stays ClusterIP-only.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: wayback-cache
+  namespace: wayback-cache
+spec:
+  parentRefs:
+    - name: cluster-gateway
+      namespace: gateway-system
+  hostnames:
+    - "wayback-cache.allegedly.works"
+  rules:
+    - timeouts:
+        request: "300s"
+        backendRequest: "300s"
+      backendRefs:
+        - name: wayback-cache
+          port: 8090

--- a/cluster/k8s/wayback-cache/kustomization.yaml
+++ b/cluster/k8s/wayback-cache/kustomization.yaml
@@ -6,6 +6,8 @@ resources:
   - pvc.yaml
   - deployment.yaml
   - service.yaml
+  - httproute.yaml
+  - token.sops.yaml
 
 configMapGenerator:
   - name: wayback-cache-config

--- a/cluster/k8s/wayback-cache/service.yaml
+++ b/cluster/k8s/wayback-cache/service.yaml
@@ -14,3 +14,8 @@ spec:
       targetPort: 8080
       protocol: TCP
       name: http
+    # Bearer-authed listener, target of the public HTTPRoute.
+    - port: 8090
+      targetPort: 8090
+      protocol: TCP
+      name: authed

--- a/cluster/k8s/wayback-cache/token.sops.yaml
+++ b/cluster/k8s/wayback-cache/token.sops.yaml
@@ -1,0 +1,35 @@
+# Bearer token for the cache's gateway-facing :8090 listener. Consumed by the
+# wayback-cache deployment (envsubst into nginx.conf) and by the per-agent
+# wayback proxy (WAYBACK_UPSTREAM_AUTH) when its upstream is the public route.
+apiVersion: v1
+kind: Secret
+metadata:
+    name: wayback-cache-token
+    namespace: wayback-cache
+type: Opaque
+stringData:
+    token: ENC[AES256_GCM,data:RTVgsoLI639MDZ+8QiVjpWqJjDZnF5ZXemTvMS4PqtLgS+7R6tMgDE3jse1GqARRE6XefYNHILyR17V2oSzPRw==,iv:PbR8zS81u9pqXT88jE5A+av6ECpgWqeiKY1knYD8C/Y=,tag:4kUIbsZ1xk9ETVnSt0Jzjg==,type:str]
+sops:
+    age:
+        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6NUZvZWQzWE5SOTM5L0lz
+            b25kWExoOFdPU045QVlIRk8wUVJ0anVnNHljCmtIdFIxR0p5OUo2aGkrYVY0czM5
+            N1JLRmdNbnBWQVBWWTdKRHBGTlh6RjAKLS0tIFk2bnVYUjM5VEpMZHl4b3k0Nm5z
+            cVU1YkdrUTUwN3EzY2h5b3YyM1luTVEK60mWe89fn0DOektnI022CEuGrlWEVExV
+            m+Vlw+o8DObeJaPFnfahsJzVIoYG8XrGtQGLLRi4etdcGM/7khvkNg==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1nywlwepsyfxvyhqwkjquzz02nmus65gf6qewfjju4alym8f7se5qnua8na
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmd3NjOXhRZEtGeWlmS0s5
+            bU1OVVV0RDVncktSWnFydklzY2tMdVNiYTE4CitIWE1MQUxtNEw5WDJEM1RMMWF4
+            ajJXUGMyN1JPS09qUVVQU3EvaytPM2sKLS0tIENicmkzMGprNlBqSlpIbE93UUdK
+            ZkNKbWJxTXhSMzFHeG0vMDF6QlJqN1EKESXkyXRKaZ1r3SwReeRm1Ty09R++uzId
+            0Bqaw7Z5WWM47gizCMhkAKJLUTsDRrXlaV3ddVJVoAWErw6L8mlPcg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-06-10T10:40:59Z"
+    mac: ENC[AES256_GCM,data:z/jvuMxwdokeGxRlZTGA1MwKYSDXNYBE8mgR4T8peVxyiQa/G20pWI1OLB0BzbHXNJJ5W/71q6qdlEt73zdNob7h9tYZdm1l6tMOJEaISJFKhP99gFEPVTaigxTzoQX/84jNAtvLYkPNl2KQaCf+zUwt2/jVetMa45HSB1MrD5g=,iv:fEFxhb72Nd5dGO/NbLyiNKx7iVz9e1/NQ4RhTsbUk60=,tag:CgF0mn1mU1agcuSXKRbMOg==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.1


### PR DESCRIPTION
Lets an out-of-cluster wayback proxy (e.g. a dev agent run on a local Docker daemon) use the shared IA pull-through cache instead of hitting — or being blocked from — the Internet Archive directly. Split out of the loom forecasting-gym branch so it can deploy on its own.

## What

- **`:8090` bearer-authed listener** in the cache nginx, fronting the existing unauthed `:8080` cache tier. The token (`wayback-cache-token`, SOPS-encrypted) is injected via `nginx:alpine`'s envsubst — `NGINX_ENVSUBST_FILTER=WAYBACK_CACHE_TOKEN` restricts substitution to that one var so nginx's own `$variables` survive, and the rendered `nginx.conf` overwrites the stock one.
- **`HTTPRoute`** exposing it at `wayback-cache.allegedly.works` behind the existing `*.allegedly.works` wildcard cert; `300s` timeouts to ride out the cache's IA rate-limit queueing.
- **Service** gains the `authed` port `8090`; the **deployment** mounts the config as an envsubst template and pulls the token from the secret; the **flux-kustomization** gets the SOPS `decryption` block.
- `map_hash_bucket_size` bumped to 128 — the `Bearer <64-hex>` map key (~71 bytes) overflows nginx's 64-byte default and crashed startup.

## Security posture

The unauthed `:8080` ClusterIP is unchanged (in-cluster consumers stay trusted); only the public gateway path is token-gated. The cache still only ever proxies `web.archive.org`, so even a leaked token exposes nothing but a rate-limited IA mirror.

## Verification

Ran the rendered config on a local Docker daemon before deploy: no-token → 401, wrong-token → 401, correct-token → passes the gate to the upstream. `kubectl kustomize` builds clean. The consumer side (the per-agent proxy sending `Authorization: Bearer <token>`, and the gym harness threading it in) lands separately with the loom gym branch.

https://claude.ai/code/session_01RksV17NqcuP742fWgDU9AW

---
_Generated by [Claude Code](https://claude.ai/code/session_01RksV17NqcuP742fWgDU9AW)_