### PR TITLE
kyverno: let the cleanup controller delete Jobs

### DIFF
--- a/cluster/k8s/kyverno/policies/clusterrole-cleanup-controller-jobs.yaml
+++ b/cluster/k8s/kyverno/policies/clusterrole-cleanup-controller-jobs.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno-cleanup-controller-jobs
+  labels:
+    # Aggregates into the kyverno cleanup controller's ClusterRole. Required
+    # before any CleanupPolicy can target Jobs: kyverno validates at policy
+    # admission that the cleanup controller holds delete permission for the
+    # matched kind. First consumer: gaffer-private's wedged-Job reaper in the
+    # thrive-scraper namespace.
+    rbac.kyverno.io/aggregate-to-cleanup-controller: "true"
+rules:
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "delete"]

--- a/cluster/k8s/kyverno/policies/kustomization.yaml
+++ b/cluster/k8s/kyverno/policies/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - require-gitops.yaml
   - inject-mitmproxy.yaml
   - restrict-agent-kustomization-patch.yaml
+  - clusterrole-cleanup-controller-jobs.yaml


### PR DESCRIPTION
Capability half of the GitOps fix for the wedged thrive Job: an aggregated ClusterRole (`rbac.kyverno.io/aggregate-to-cleanup-controller: "true"`, the chart's documented extension point — verified against the live `kyverno-kyverno:cleanup-controller` aggregationRule) granting the Kyverno cleanup controller `get/list/watch/delete` on `batch/Jobs`.

Kyverno validates at CleanupPolicy admission that its controller holds permissions for the matched kind, so this must land for the policy half to apply: agentydragon/gaffer-private#279 (the `thrive-scraper` wedged-Job reaper). Merge this first, or let Flux retry the gaffer side until the role aggregates — both converge.

The role is capability only; the controller acts solely where a (git-reviewed) CleanupPolicy directs it.

kustomize render + kubeconform pass.

https://claude.ai/code/session_01RufPzcJjy3Zky7A5EannGU

---
_Generated by [Claude Code](https://claude.ai/code/session_01RufPzcJjy3Zky7A5EannGU)_