### PR TITLE
kyverno: claude-sandbox janitor + props finished-pod reaper

### DIFF
--- a/cluster/k8s/agents/claude-rbac/cleanuppolicy-sandbox-janitor.yaml
+++ b/cluster/k8s/agents/claude-rbac/cleanuppolicy-sandbox-janitor.yaml
@@ -1,0 +1,30 @@
+# The sandbox is ephemeral by contract: agents get full CRUD and a shared
+# quota (8 CPU / 16Gi / 20 pods), and nothing here is GitOps-managed, so
+# forgotten experiments otherwise linger and pin the quota forever. Reap
+# anything older than 7 days. CronJob is included deliberately — an orphaned
+# CronJob is self-renewing litter that keeps spawning fresh Jobs. Owned
+# children (ReplicaSets, Job pods) go via cascade when their parent is
+# reaped. Delete RBAC comes from the two aggregated ClusterRoles in
+# kyverno/policies/ (cleanup-controller-{jobs,workloads}).
+apiVersion: kyverno.io/v2
+kind: CleanupPolicy
+metadata:
+  name: sandbox-janitor
+  namespace: claude-sandbox
+spec:
+  schedule: "20 * * * *"
+  match:
+    any:
+      - resources:
+          kinds:
+            - Pod
+            - Deployment
+            - StatefulSet
+            - Job
+            - CronJob
+            - Service
+  conditions:
+    all:
+      - key: "{{ time_since('', '{{ target.metadata.creationTimestamp }}', '') }}"
+        operator: GreaterThan
+        value: 168h

--- a/cluster/k8s/agents/claude-rbac/kustomization.yaml
+++ b/cluster/k8s/agents/claude-rbac/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - clusterrole-cluster-diagnostics-reader.yaml
   - clusterrole-logs-configmaps-reader.yaml
   - clusterrole-namespace-diagnostics-reader.yaml
+  - cleanuppolicy-sandbox-janitor.yaml

--- a/cluster/k8s/kyverno/policies/clusterrole-cleanup-controller-workloads.yaml
+++ b/cluster/k8s/kyverno/policies/clusterrole-cleanup-controller-workloads.yaml
@@ -1,0 +1,21 @@
+# Aggregates into the kyverno cleanup controller alongside
+# clusterrole-cleanup-controller-jobs.yaml (which covers batch/jobs).
+# Consumers: the claude-sandbox janitor (agents/claude-rbac/) and the props
+# finished-pod reaper (props/app/) — kyverno rejects a CleanupPolicy at
+# admission unless the controller can delete every kind it matches.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno-cleanup-controller-workloads
+  labels:
+    rbac.kyverno.io/aggregate-to-cleanup-controller: "true"
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "services"]
+    verbs: ["get", "list", "watch", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets"]
+    verbs: ["get", "list", "watch", "delete"]
+  - apiGroups: ["batch"]
+    resources: ["cronjobs"]
+    verbs: ["get", "list", "watch", "delete"]

--- a/cluster/k8s/kyverno/policies/kustomization.yaml
+++ b/cluster/k8s/kyverno/policies/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - inject-mitmproxy.yaml
   - restrict-agent-kustomization-patch.yaml
   - clusterrole-cleanup-controller-jobs.yaml
+  - clusterrole-cleanup-controller-workloads.yaml

--- a/cluster/k8s/props/app/cleanuppolicy-finished-pods.yaml
+++ b/cluster/k8s/props/app/cleanuppolicy-finished-pods.yaml
@@ -1,0 +1,25 @@
+# The props backend spawns bare critic/agent pods and does not reap the ones
+# that fail (e.g. critic-dev-opt-* pods sitting in Error for days). Delete
+# Succeeded/Failed pods after 3 days — recent failures stay inspectable, and
+# agent traces live in the database regardless. Running pods never match.
+# Delete RBAC: kyverno/policies/clusterrole-cleanup-controller-workloads.yaml.
+apiVersion: kyverno.io/v2
+kind: CleanupPolicy
+metadata:
+  name: reap-finished-pods
+  namespace: props
+spec:
+  schedule: "10 * * * *"
+  match:
+    any:
+      - resources:
+          kinds:
+            - Pod
+  conditions:
+    all:
+      - key: "{{ target.status.phase }}"
+        operator: AnyIn
+        value: [Succeeded, Failed]
+      - key: "{{ time_since('', '{{ target.metadata.creationTimestamp }}', '') }}"
+        operator: GreaterThan
+        value: 72h

--- a/cluster/k8s/props/app/kustomization.yaml
+++ b/cluster/k8s/props/app/kustomization.yaml
@@ -22,3 +22,4 @@ resources:
   - httproute.yaml
   - registry-httproute.yaml
   - rolebinding-ollama-consumer.yaml
+  - cleanuppolicy-finished-pods.yaml


### PR DESCRIPTION
Follow-up to #1998, adding the two cleanup policies picked from today's cluster cruft scan:

**`claude-sandbox/sandbox-janitor`** — hourly, deletes Pods/Deployments/StatefulSets/Jobs/CronJobs/Services older than **7 days**. The sandbox is ephemeral by contract (agents get full CRUD, nothing there is GitOps-managed), so forgotten experiments otherwise pin the 8 CPU / 16Gi / 20-pod quota forever. CronJob is matched deliberately: an orphaned CronJob is self-renewing litter. Owned children (ReplicaSets, Job pods) cascade with their parent. Namespace is empty today, so first application is a no-op.

**`props/reap-finished-pods`** — hourly, deletes pods in phase **Succeeded/Failed** older than **3 days**. The props backend spawns bare critic/agent pods and doesn't reap failures (current specimen: `critic-dev-opt-bd8c23bd`, in Error for 2d7h — it becomes the first catch). Running pods never match, and recent failures stay inspectable for three days; traces live in the DB regardless.

Plus `kyverno-cleanup-controller-workloads`: the aggregated ClusterRole granting the cleanup controller delete on `pods`, `services`, `deployments`/`statefulsets`, and `cronjobs` (jobs already landed in #1998). Kyverno's admission check requires it for every matched kind. `claude-rbac` already depends on `kyverno-policies`, so ordering is guaranteed there; `props` doesn't, but Flux retries until the role aggregates (~1m) — same convergence story as the gaffer policy, which applied cleanly this way today.

`require-gitops` is not in the way: it's Audit-mode and matches only CREATE/UPDATE on workloads, not deletes.

kustomize render + kubeconform pass on all three kustomizations.

https://claude.ai/code/session_01RufPzcJjy3Zky7A5EannGU

---
_Generated by [Claude Code](https://claude.ai/code/session_01RufPzcJjy3Zky7A5EannGU)_