### PR TITLE
wayback-cache: reflect the cache bearer token into claude-sandbox

### DIFF
--- a/cluster/AGENTS.md
+++ b/cluster/AGENTS.md
@@ -113,6 +113,19 @@ See <docs/secrets.md> for SOPS procedures, adding/rotating secrets, age key mana
 **Keep <docs/bootstrap_dependencies.md> up to date** when adding/removing/changing secrets,
 SOPS files, tofu resources, or external credential requirements.
 
+### Annotating a SOPS-encrypted Secret
+
+Adding annotations/labels to a `*.sops.yaml` Secret needs **no manual re-MAC**:
+`sops <file>` re-encrypts and recomputes the MAC on save automatically. The
+catch is what an _agent_ hits — these files set no `mac_only_encrypted`, so the
+document MAC covers metadata too, and a **raw text edit** of the ciphertext
+(without re-running `sops`) fails decryption with a `MAC mismatch` (verified:
+adding one annotation to a real `*.sops.yaml` Secret breaks `sops -d`). Agents
+don't hold the cluster age key and can't `sops`-edit, so to add annotations,
+**patch the metadata in kustomize** instead — it leaves the encrypted file
+untouched. Example: `k8s/wayback-cache/kustomization.yaml` annotates
+`wayback-cache-token` for the emberstack reflector via a `patches:` entry.
+
 ### Description Annotations
 
 Add `metadata.annotations.description` to any resource where name + namespace doesn't

--- a/cluster/k8s/wayback-cache/kustomization.yaml
+++ b/cluster/k8s/wayback-cache/kustomization.yaml
@@ -9,6 +9,27 @@ resources:
   - httproute.yaml
   - token.sops.yaml
 
+# Mirror the cache bearer token into claude-sandbox via the emberstack
+# reflector, so agent sessions (which already read secrets in their own
+# sandbox namespace) can use the authed gateway route without cross-namespace
+# RBAC. Patching metadata here keeps the SOPS-encrypted token.sops.yaml (whose
+# MAC covers all values) untouched. Same mechanism as litellm-master-key.
+patches:
+  - target:
+      kind: Secret
+      name: wayback-cache-token
+    patch: |-
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: wayback-cache-token
+        namespace: wayback-cache
+        annotations:
+          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "claude-sandbox"
+          reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+          reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "claude-sandbox"
+
 configMapGenerator:
   - name: wayback-cache-config
     namespace: wayback-cache


### PR DESCRIPTION
## What

A kustomize patch annotates the `wayback-cache-token` Secret for the emberstack reflector to mirror it into `claude-sandbox`.

## Why

Agent sessions (Claude Code web, `oidc-ksbx-groups:kubectl-sandbox-users`) already read Secrets in their own `claude-sandbox` namespace but cannot read `wayback-cache-token` in the `wayback-cache` namespace. To let an agent's out-of-cluster wayback proxy use the authed gateway route (`https://wayback-cache.allegedly.works`, which needs `Authorization: Bearer <token>`) instead of hitting IA directly, the token needs to be reachable from the sandbox.

This mirrors the exact mechanism that already brings `litellm-master-key` (and other secrets) into the sandbox namespaces via the reflector — no new cross-namespace RBAC, least surprise.

## How

- The reflector annotations go on the **source** Secret, but `token.sops.yaml` is SOPS-encrypted with a MAC over **all** values (no `mac_only_encrypted`), so hand-editing its metadata would break decryption. Instead, a kustomize `patches` entry adds the four `reflector.v1.k8s.emberstack.com/reflection-*` annotations at apply time, leaving the encrypted file untouched.
- Scoped to `claude-sandbox` only.

## Verification

Once merged and reconciled, the mirrored Secret appears as `wayback-cache-token` in `claude-sandbox` (the reflector stamps `reflector.v1.k8s.emberstack.com/reflected-at`), readable by sandbox agent creds — same as the existing `litellm-master-key` mirror.

https://claude.ai/code/session_01AXSFxfCXddADoSKTjgF5Nz

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXSFxfCXddADoSKTjgF5Nz)_