### PR TITLE
wayback-cache: inline the reflector annotations on the token Secret (follow-up to #2001)

### DIFF
--- a/cluster/AGENTS.md
+++ b/cluster/AGENTS.md
@@ -115,16 +115,17 @@ SOPS files, tofu resources, or external credential requirements.
 
 ### Annotating a SOPS-encrypted Secret
 
-Adding annotations/labels to a `*.sops.yaml` Secret needs **no manual re-MAC**:
-`sops <file>` re-encrypts and recomputes the MAC on save automatically. The
-catch is what an _agent_ hits — these files set no `mac_only_encrypted`, so the
-document MAC covers metadata too, and a **raw text edit** of the ciphertext
-(without re-running `sops`) fails decryption with a `MAC mismatch` (verified:
-adding one annotation to a real `*.sops.yaml` Secret breaks `sops -d`). Agents
-don't hold the cluster age key and can't `sops`-edit, so to add annotations,
-**patch the metadata in kustomize** instead — it leaves the encrypted file
-untouched. Example: `k8s/wayback-cache/kustomization.yaml` annotates
-`wayback-cache-token` for the emberstack reflector via a `patches:` entry.
+Adding annotations/labels to a `*.sops.yaml` Secret needs **no manual re-MAC** —
+encrypting recomputes the MAC. But these files set no `mac_only_encrypted`, so
+the document MAC covers metadata too: a **raw text edit** of the ciphertext
+(without re-encrypting) fails decryption with a `MAC mismatch` (verified —
+adding one annotation to a real `*.sops.yaml` Secret breaks `sops -d`). Go
+through `sops`: with the cluster age key, `sops <file>` edits and re-MACs in one
+step. An **agent** that lacks the key can still _encrypt_ to a rule's recipients
+(encryption only needs their public keys), so it authors the whole Secret as
+plaintext and `sops -e -i`s it — minting a fresh value for any opaque field it
+can't recover (i.e. rotate). Example: `k8s/wayback-cache/token.sops.yaml` carries
+the emberstack reflector annotations inline and was (re)authored that way.
 
 ### Description Annotations
 

--- a/cluster/k8s/wayback-cache/kustomization.yaml
+++ b/cluster/k8s/wayback-cache/kustomization.yaml
@@ -9,27 +9,6 @@ resources:
   - httproute.yaml
   - token.sops.yaml
 
-# Mirror the cache bearer token into claude-sandbox via the emberstack
-# reflector, so agent sessions (which already read secrets in their own
-# sandbox namespace) can use the authed gateway route without cross-namespace
-# RBAC. Patching metadata here keeps the SOPS-encrypted token.sops.yaml (whose
-# MAC covers all values) untouched. Same mechanism as litellm-master-key.
-patches:
-  - target:
-      kind: Secret
-      name: wayback-cache-token
-    patch: |-
-      apiVersion: v1
-      kind: Secret
-      metadata:
-        name: wayback-cache-token
-        namespace: wayback-cache
-        annotations:
-          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "claude-sandbox"
-          reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-          reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "claude-sandbox"
-
 configMapGenerator:
   - name: wayback-cache-config
     namespace: wayback-cache

--- a/cluster/k8s/wayback-cache/token.sops.yaml
+++ b/cluster/k8s/wayback-cache/token.sops.yaml
@@ -1,35 +1,44 @@
 # Bearer token for the cache's gateway-facing :8090 listener. Consumed by the
 # wayback-cache deployment (envsubst into nginx.conf) and by the per-agent
 # wayback proxy (WAYBACK_UPSTREAM_AUTH) when its upstream is the public route.
+# The emberstack reflector annotations mirror it into claude-sandbox so agent
+# sessions can read it without cross-namespace RBAC. (Authored fresh + rotated
+# rather than edited in place: the SOPS MAC covers metadata, so adding
+# annotations to the ciphertext by hand would fail decryption.)
 apiVersion: v1
 kind: Secret
 metadata:
     name: wayback-cache-token
     namespace: wayback-cache
+    annotations:
+        reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+        reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: claude-sandbox
+        reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+        reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: claude-sandbox
 type: Opaque
 stringData:
-    token: ENC[AES256_GCM,data:RTVgsoLI639MDZ+8QiVjpWqJjDZnF5ZXemTvMS4PqtLgS+7R6tMgDE3jse1GqARRE6XefYNHILyR17V2oSzPRw==,iv:PbR8zS81u9pqXT88jE5A+av6ECpgWqeiKY1knYD8C/Y=,tag:4kUIbsZ1xk9ETVnSt0Jzjg==,type:str]
+    token: ENC[AES256_GCM,data:ssX6wX/7D7pfzTT+4zG7KVGALJPqtC/RNQlnum+Xptq8nRIdi3/QI2Bi03hA9VB5K+taw/zm62jas4LSwNK1BA==,iv:ziJBWWkMUjutwmJ8oeJauuQcpBHwEvWqYF2fBQhCPLo=,tag:/BvFr5clfJ9HA3eo50lbfQ==,type:str]
 sops:
     age:
         - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6NUZvZWQzWE5SOTM5L0lz
-            b25kWExoOFdPU045QVlIRk8wUVJ0anVnNHljCmtIdFIxR0p5OUo2aGkrYVY0czM5
-            N1JLRmdNbnBWQVBWWTdKRHBGTlh6RjAKLS0tIFk2bnVYUjM5VEpMZHl4b3k0Nm5z
-            cVU1YkdrUTUwN3EzY2h5b3YyM1luTVEK60mWe89fn0DOektnI022CEuGrlWEVExV
-            m+Vlw+o8DObeJaPFnfahsJzVIoYG8XrGtQGLLRi4etdcGM/7khvkNg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPNGdzQ2EzaklWVXQ2RlJX
+            aHl1elZkbnoyK3R2QlJCaUJJRWRSdzh2S0hvCnB4Y1hjQnl6RFl4UmtONWRDaWFh
+            bm5Ham40d3dpUjF1WXN6SU5zU0h4M2cKLS0tIGx4WU93T3RlZmJ0UHhBOEFKMkxn
+            Unc3bGhmNnBGK3dSWFh2Rm5DdTJVVWsK2ZU1CwP3CMtB9TgUHLn30da61dKZgEDd
+            +/4AKsQbxDM2HRVcwrm3XU2F9kyZMgSInjiOVzXb17Jpg9fD4aauuw==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1nywlwepsyfxvyhqwkjquzz02nmus65gf6qewfjju4alym8f7se5qnua8na
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmd3NjOXhRZEtGeWlmS0s5
-            bU1OVVV0RDVncktSWnFydklzY2tMdVNiYTE4CitIWE1MQUxtNEw5WDJEM1RMMWF4
-            ajJXUGMyN1JPS09qUVVQU3EvaytPM2sKLS0tIENicmkzMGprNlBqSlpIbE93UUdK
-            ZkNKbWJxTXhSMzFHeG0vMDF6QlJqN1EKESXkyXRKaZ1r3SwReeRm1Ty09R++uzId
-            0Bqaw7Z5WWM47gizCMhkAKJLUTsDRrXlaV3ddVJVoAWErw6L8mlPcg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6RDBvaGxyT3dFRWZvN0xh
+            aXRlaHkwR0xZTkVqUmVEclFDc2FMN0RoeVVNCnR6SFJLT1FwT0JTYnRieXFobUpX
+            c0kwYXJiRDlKUlU5c0tzTEF3T2hqWGcKLS0tIEM3SFBJTXZEdUZqRVBsViszWE5V
+            Ny8wK1pSZW1YS0pLTHppTjRnUU1LSDQKCI8yS0d42eYWKHWWZVFUq1AUFiiFMWQw
+            /0BiERTExG7ZN0Wvq7kPihEFfx77jrfhAzlIFS13bUSMI5EVpr627Q==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-06-10T10:40:59Z"
-    mac: ENC[AES256_GCM,data:z/jvuMxwdokeGxRlZTGA1MwKYSDXNYBE8mgR4T8peVxyiQa/G20pWI1OLB0BzbHXNJJ5W/71q6qdlEt73zdNob7h9tYZdm1l6tMOJEaISJFKhP99gFEPVTaigxTzoQX/84jNAtvLYkPNl2KQaCf+zUwt2/jVetMa45HSB1MrD5g=,iv:fEFxhb72Nd5dGO/NbLyiNKx7iVz9e1/NQ4RhTsbUk60=,tag:CgF0mn1mU1agcuSXKRbMOg==,type:str]
+    lastmodified: "2026-06-10T18:27:57Z"
+    mac: ENC[AES256_GCM,data:ylTaNeyahX59hLlssvEGaZ8H3CIXnAOa5CFGOM1Ho1o+6juStm9wbyWPTTaKpcohitiIbUVPZuGIfW7oNzuUBkEDkSU168/MxADQATgsiV9Qx5bNUPlPW+HKd8mqa+/2FN4rQfexOIiXTn8K63SLGwaxUz4To46JFvgcT1ja7d4=,iv:T+kK43EAqoIE1IjEpn+d2XvoiMa0yFMUnncAOvkjq9A=,tag:Sax9sDLU08A8mKxx0iTahw==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.12.1


### PR DESCRIPTION
## What

Follow-up to #2001. Carry the emberstack reflector annotations **directly on** the `wayback-cache-token` Secret and drop the kustomize `patches:` entry #2001 added.

## Why

#2001 reflected the token into `claude-sandbox` via a kustomize metadata patch — to avoid hand-editing the SOPS-encrypted file (whose MAC covers metadata, so a raw edit breaks decryption). Preference is to keep the annotations inline on the Secret instead.

## How

- The file is **re-authored and re-encrypted** through the `cluster/k8s/*` SOPS creation rule (`sops -e -i`), not hand-edited — so the MAC is recomputed correctly. Encrypting only needs the rule's recipient public keys (admin + cluster-secrets), so this works without holding the decryption key.
- Re-authoring an opaque value you can't decrypt means **rotating** it: the token gets a fresh value. Safe — the cache `deployment.yaml` carries `reloader.stakater.com/auto: "true"`, so the pod restarts onto the new token when this reconciles, and the same (reflected) value reaches any client.
- `cluster/AGENTS.md` updated: documents authoring SOPS-Secret annotations this way (re-author + `sops -e -i`, no manual re-MAC) rather than via a patch.

## Net effect

`cluster/k8s/wayback-cache/kustomization.yaml` returns to no `patches:`; `token.sops.yaml` carries the four `reflector.v1.k8s.emberstack.com/reflection-*` annotations inline (scoped to `claude-sandbox`); same end state as #2001 (token mirrored into `claude-sandbox`), just inline + rotated.

https://claude.ai/code/session_01AXSFxfCXddADoSKTjgF5Nz

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXSFxfCXddADoSKTjgF5Nz)_