### PR TITLE
finance/beancount_export: sync via pygit2, not a git subprocess

### DIFF
--- a/finance/beancount_export/BUILD.bazel
+++ b/finance/beancount_export/BUILD.bazel
@@ -23,6 +23,7 @@ py_library(
         "//finance/augur/budget:sql_read_model",
         "//finance/plaid/db:schema",
         "@pypi//beancount",
+        "@pypi//pygit2",
         "@pypi//pyyaml",
         "@pypi//structlog",
         "@pypi//typer",

--- a/finance/beancount_export/runner.py
+++ b/finance/beancount_export/runner.py
@@ -14,12 +14,11 @@ from __future__ import annotations
 
 import asyncio
 import os
-import subprocess
 import tempfile
 from datetime import date
 from pathlib import Path
-from urllib.parse import quote, urlsplit, urlunsplit
 
+import pygit2
 import structlog
 import typer
 import yaml
@@ -134,23 +133,6 @@ def _validate(ledger: str) -> None:
         )
 
 
-def _authenticated_url(url: str) -> str:
-    """Inject GIT_USERNAME/GIT_PASSWORD into an https URL, if both are set."""
-    user, password = os.environ.get("GIT_USERNAME"), os.environ.get("GIT_PASSWORD")
-    if not (user and password):
-        return url
-    parts = urlsplit(url)
-    netloc = f"{quote(user, safe='')}:{quote(password, safe='')}@{parts.hostname}"
-    if parts.port:
-        netloc += f":{parts.port}"
-    return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
-
-
-def _git(repo: Path, *args: str) -> str:
-    result = subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True, text=True)
-    return result.stdout
-
-
 @app.command()
 def render(out: Path = _OUT_OPTION, config_path: Path | None = _CONFIG_OPTION, title: str = _TITLE_OPTION) -> None:
     """Render the ledger to a local file (no git)."""
@@ -173,26 +155,25 @@ def sync(
     config = _load_budget_config(config_path)
     ledger = build_ledger(config, _database_url(config), window_end=date.today(), title=title)
 
-    url = _authenticated_url(git_url)
+    # UserPass credential callback — no credentials embedded in the remote URL.
+    user, password = os.environ.get("GIT_USERNAME"), os.environ.get("GIT_PASSWORD")
+    callbacks = pygit2.RemoteCallbacks(credentials=pygit2.UserPass(user, password)) if user and password else None
     with tempfile.TemporaryDirectory() as tmp:
-        repo = Path(tmp) / "repo"
-        _git(Path(tmp), "clone", "--depth", "1", "--branch", branch, url, str(repo))
-        (repo / ledger_name).write_text(ledger)
-        if not _git(repo, "status", "--porcelain").strip():
+        repo_path = Path(tmp) / "repo"
+        repo = pygit2.clone_repository(git_url, str(repo_path), checkout_branch=branch, callbacks=callbacks, depth=1)
+        (repo_path / ledger_name).write_text(ledger)
+        repo.index.add(ledger_name)
+        repo.index.write()
+        tree = repo.index.write_tree()
+        head_commit = repo[repo.head.target].peel(pygit2.Commit)
+        if tree == head_commit.tree_id:
             log.info("ledger unchanged; nothing to commit")
             return
-        _git(repo, "add", ledger_name)
-        _git(
-            repo,
-            "-c",
-            f"user.name={author_name}",
-            "-c",
-            f"user.email={author_email}",
-            "commit",
-            "-m",
-            f"budget ledger: {date.today().isoformat()}",
+        author = pygit2.Signature(author_name, author_email)
+        repo.create_commit(
+            repo.head.name, author, author, f"budget ledger: {date.today().isoformat()}", tree, [head_commit.id]
         )
-        _git(repo, "push", "origin", branch)
+        repo.remotes["origin"].push([f"refs/heads/{branch}"], callbacks=callbacks)
         log.info("pushed ledger", branch=branch, ledger=ledger_name)
 
 


### PR DESCRIPTION
## What

Port the budget-ledger `sync` in `finance/beancount_export/runner.py` from shelling out to the `git` binary to **pygit2**.

## Why

`sync` cloned (`--depth 1 --branch`), staged, committed, and pushed via a `git` subprocess (`_git`), embedding HTTP Basic creds in the remote URL (`_authenticated_url`). pygit2 is already a dependency and (libgit2 ≥1.7) does shallow clone, so the git binary is no longer needed.

## How

Mirrors the established, tested pattern in `finance/scraper/fetch.py`:

- `pygit2.clone_repository(git_url, ..., checkout_branch=branch, depth=1, callbacks=...)`
- a `pygit2.RemoteCallbacks(credentials=pygit2.UserPass(GIT_USERNAME, GIT_PASSWORD))` callback — **credentials are no longer embedded in the remote URL**
- write the ledger, stage it, and commit **only if the tree changed** (compare `index.write_tree()` to the HEAD commit's tree), then `remote.push([refs/heads/<branch>])`

Drops `_authenticated_url`, `_git`, and the `subprocess` / `urllib.parse` imports.

## Verification

`//finance/beancount_export:runner` builds + lints clean (ruff + mypy). The clone/commit/push is the same pygit2 surface `fetch.py` already uses in production; there's no `sync` unit test (the existing test covers `export`/rendering only), so the budget CronJob exercises the live push.

## Note on the broader pygit2 survey

Other git-subprocess sites were left as-is on purpose: `cpap/gitstore.py` needs **partial clone** (`--filter=blob:none` + promisor lazy-fetch), which libgit2/pygit2 do **not** support (verified: pygit2 1.19's `clone_repository` has `depth` but no `filter`, and the package has no promisor surface); `inop/runners/base.py` fetches a **bare commit SHA** and runs git **inside the target container**, neither of which an in-process libgit2 can do.

https://claude.ai/code/session_01AXSFxfCXddADoSKTjgF5Nz

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXSFxfCXddADoSKTjgF5Nz)_