### PR TITLE
loom: wayback-proxy W4 wrap-up + strict structured submit tool

### DIFF
--- a/loom/gym/market_seed_tasks.py
+++ b/loom/gym/market_seed_tasks.py
@@ -1,11 +1,13 @@
 """Hand-curated tasks minted from top resolved binary markets on the live Manifold API.
 
-Thirty-four resolved YES/NO binary markets (each with ≥ 20 unique bettors)
+Thirty-three live YES/NO binary markets (each with ≥ 20 unique bettors)
 chosen from topical sweeps of the Manifold `search-markets` endpoint over
 markets resolved between 2024-08 and 2026-05 — recent enough that every model
 in `loom.gym.model_cutoffs` (including glm-4.5, knowledge cutoff 2024-06-30)
-is admissible at every task's `as_of`. The panel is balanced 17 YES / 17 NO
-(a skewed set would reward base-rate guessing) and spans US and non-US
+is admissible at every task's `as_of`. The curated set was 17 YES / 17 NO; the
+China/Taiwan invasion market (a NO) is commented out below because CN-hosted
+models refuse it at the API (moderation error 1301), leaving 17 YES / 16 NO
+active. The panel spans US and non-US
 politics, geopolitics, economic data, courts, space, public health, sports,
 tech business, and entertainment. Probabilities at `as_of` mix mid-range
 questions with calibration tails, including several markets that were
@@ -106,19 +108,21 @@ MARKET_SEED_RECORDS: tuple[MarketSeedRecord, ...] = (
             ),
         ),
     ),
-    MarketSeedRecord(
-        market_id="k4XTBQLFuDvBljexbalv",
-        task_id="manifold-china-invades-taiwan-2024",
-        as_of=date(2024, 9, 15),
-        resolution_date=date(2025, 1, 1),
-        resolved_yes=False,
-        prob_at_as_of=0.0634,
-        question=(
-            "Will China invade mainland Taiwan by the end of 2024? Only an invasion of Taiwan's main island "
-            "counts; seizing outlying islands such as Kinmen or Matsu does not."
-        ),
-        evidence=(),
-    ),
+    # Disabled: Zhipu/GLM (and likely other CN-hosted models) reject this prompt at the
+    # API with content-moderation error 1301 ("potentially unsafe or sensitive content"),
+    # so the China/Taiwan invasion market is not runnable across the model panel. Kept here
+    # commented (not deleted) as a record of the curated set; re-enable if the panel drops
+    # CN-hosted models or they stop refusing it.
+    #   MarketSeedRecord(
+    #       market_id="k4XTBQLFuDvBljexbalv",
+    #       task_id="manifold-china-invades-taiwan-2024",
+    #       as_of=date(2024, 9, 15),
+    #       resolution_date=date(2025, 1, 1),
+    #       resolved_yes=False,
+    #       prob_at_as_of=0.0634,
+    #       question=(... China invade mainland Taiwan by end of 2024 ...),
+    #       evidence=(),
+    #   ),
     MarketSeedRecord(
         market_id="9ln3uPEbleLkjwQ5HR4b",
         task_id="manifold-biden-pardons-hunter",

--- a/loom/plans/program_plan.md
+++ b/loom/plans/program_plan.md
@@ -381,8 +381,13 @@ date, realized outcome)`; a contestant may use any data dated ≤ t.
   served-evidence manifest is read back per sample into
   `Score.metadata["served_evidence"]`. The mockllm e2e proves the loop on
   RBE: lead discovered in the evidence file → fetched through the clamped
-  proxy → manifest in the score. Pending: pointing real runs at the
-  cluster cache.
+  proxy → manifest in the score. A live agent harness
+  (`loom/gym/agent_eval.py`) drives a real model over the same chain against
+  the **in-cluster authed cache**; the first end-to-end smoke (glm-4.5, an
+  open-ended no-starting-URL market) confirmed genuine open-ended archive
+  research over `https://` with no URL rewriting. Follow-ups it surfaced are
+  tracked in <wayback_proxy.md> (mitmproxy `connection_strategy=lazy`,
+  per-model task refusals, cache 5xx under IA pressure).
 - **Bundle tasks — ✅ landed** (`bundle_tasks.py`): one dossier, one
   submission, **many named sub-questions** — more metrics per sampled
   token, and joint structure becomes scoreable. A bundle is a set of

--- a/loom/plans/wayback_proxy.md
+++ b/loom/plans/wayback_proxy.md
@@ -1,18 +1,27 @@
 # Wayback proxy: date-clamped web access for contestants
 
-Status: **in progress** (direction approved 2026-06-10). W1 landed:
+Status: **W1–W4 all landed** (direction approved 2026-06-10). W1:
 `cluster/k8s/wayback-cache/` (ClusterIP-only — the gateway is public-only and
-an open IA relay is undesirable; dev access via `kubectl port-forward`). W2
-landed: per-agent proxy + demo compose + e2e at <../wayback_proxy/>, and the
-gym's Inspect harness generates a per-`as_of` sandbox compose (agent on an
+an open IA relay is undesirable; dev access via `kubectl port-forward`). W2:
+per-agent proxy + demo compose + e2e at <../wayback_proxy/>, and the gym's
+Inspect harness generates a per-`as_of` sandbox compose (agent on an
 internal-only network whose sole peer is the proxy; `WAYBACK_AS_OF` baked as
-a literal) with a mockllm e2e fetching a clamped page end to end on RBE. The
-proxy is the mini-implementation, not a WaybackProxy fork — upstream's
-selection is nearest-capture (can serve post-date content within
+a literal) with a mockllm e2e fetching a clamped page end to end on RBE. W3:
+served-evidence manifest read back into `Score.metadata`. W4: HTTPS MITM (see
+below). The proxy is the mini-implementation, not a WaybackProxy fork —
+upstream's selection is nearest-capture (can serve post-date content within
 `DATE_TOLERANCE`), its in-band settings page can change the date at runtime
 from the client side, CONNECT is fake-accepted, and the upstream host is
 hardcoded; hardening all that approximated writing the clamped proxy
 directly.
+
+A live agent harness (`loom/gym/agent_eval.py`, `//loom/gym:agent_eval_bin`)
+runs a real model against the full chain: the model client runs host-side
+against the cluster LiteLLM (Anthropic-shaped), the react agent's tools
+execute in the Docker sandbox whose only route is the date-clamped proxy, and
+`--wayback-upstream` points at the in-cluster authed pull-through cache
+(`WAYBACK_UPSTREAM_AUTH` carries the `Bearer` token). See "Live eval findings"
+below for the first end-to-end smoke.
 
 ## Goal
 
@@ -121,3 +130,45 @@ fetch them — and browse outward from them — rather than only reading titles.
   `SSL_CERT_FILE` & friends (the gym sandbox mounts the CA and drops the
   "rewrite to http" instruction). Remaining (optional): text-extraction
   convenience endpoint for dossier-style consumption.
+
+## Live eval findings (first end-to-end smoke, 2026-06-10)
+
+`agent_eval_bin` was run against the in-cluster authed `wayback-cache`
+(`--wayback-upstream https://wayback-cache.allegedly.works`, glm-4.5 via
+cluster LiteLLM) on an open-ended, no-starting-URL market. The full chain
+works: host-side model client → LiteLLM (through the claude-web egress MITM,
+TLS verified via the host CA bundle) → react agent in the Docker sandbox →
+embedded mitmproxy → authed cluster cache. The model does genuine open-ended
+archive research — for "did New Glenn reach orbit on its first launch?" it
+fetched Wikipedia (article + REST summary API), blueorigin.com, SpaceNews,
+Spaceflight Now, NASASpaceflight (its 2024-12-30 launch roundup), Ars Technica,
+and a Google-cache search, all as `https://` through the clamped proxy with no
+URL rewriting, and the served-evidence manifest came back in
+`Score.metadata["served_evidence"]` (the W3 read-back works with a live model).
+Findings to act on:
+
+- **`connection_strategy` should be `lazy`.** mitmproxy defaults to eager: for
+  every flow it opens an upstream TLS connection to the _original_ host before
+  our addon runs. That connection egresses through the claude-web TLS-inspecting
+  proxy and fails cert verification (`self-signed certificate in certificate
+chain`), logging a warning per request. It's harmless — the addon sets
+  `flow.response` from the cache so the eager connection is discarded — but
+  wasteful and noisy. Set `connection_strategy=lazy` in `server.py` so the
+  upstream socket is never opened.
+- **CN-hosted models refuse politically sensitive prompts.** glm-4.5 rejects
+  the China/Taiwan invasion market at the API (`invalid_request_error` code
+  `1301`, "potentially unsafe or sensitive content"). That market is now
+  commented out of `market_seed_tasks.py`; the panel is otherwise unaffected,
+  but cross-model runs must tolerate per-model task refusals rather than
+  aborting the whole eval.
+- **Cache returns 5xx under IA pressure.** Live CDX/content lookups returned a
+  mix of `403/502/503/504` from `wayback-cache` (IA throttling/erroring the
+  cold-miss tier-2 hop), so many of the agent's fetches failed. The clamp and
+  manifest logic are correct; this is an operational tuning matter for the
+  cache's `limit_req` pacing and IA retry/backoff, not a proxy bug.
+- **Submission must tolerate a malformed answer.** glm-4.5 researched the task
+  but its final `submit` carried an empty/non-JSON payload, so scoring raised
+  `JSONDecodeError` and the sample scored `value=nan` (no probability). A
+  well-formed run is the next thing to confirm, but the harness should also
+  degrade gracefully — record the parse failure as a scored miss with the
+  served-evidence manifest intact (already captured), not lose the whole sample.


### PR DESCRIPTION
Two commits, both independent of the (separate) wayback-cache fix.

## 1. W4 wrap-up (`a68ac47`)

W1–W4 of the date-clamped wayback proxy are landed (code shipped in #1999/#2003/#2004); this records the finished state and the first live end-to-end smoke in the plans, and removes a task no model on the panel can run.

- **plans** (`wayback_proxy.md`, `program_plan.md`): mark W1–W4 done; document the live agent harness (`loom/gym/agent_eval.py`) driving a real model over the full chain against the in-cluster authed cache, and the first smoke (glm-4.5, an open-ended no-starting-URL market) — genuine open-ended archive research over `https://`, no URL rewriting.
- **`market_seed_tasks.py`**: comment out the China/Taiwan market — CN-hosted models (glm-4.5) reject it at the API with moderation error `1301`. Panel is now 33 markets, 17 YES / 16 NO.

## 2. Strict structured submit tool (`68e0a37`)

Implements W4 follow-up #4 (submission robustness). The agent's submit was inspect's default free-form `answer` string → `json.loads`, which a sloppy model leaves empty or fills with prose (observed live: glm-4.5 researched a task then submitted nothing → `JSONDecodeError`, NaN score).

- **`inspect_harness.py`**: `_submit_tool(question)` builds a submit `ToolDef` whose `input_schema` is the question's answer shape — reusing `question_schema`, the same forced-schema path the bare baseline uses (which z.ai's GLM honors), so the Anthropic-shaped API enforces a well-formed forecast object. Tasks are grouped by answer schema (one Inspect task / react submit tool per shape; a uniform binary panel stays a single task), so `agent_eval_task` now returns `list[InspectTask]`.
- **`baseline_llm.question_schema`**: per-property descriptions (inspect requires them on tool params); binary `p` made exclusive `(0, 1)`.
- **`scoring.BinaryAnswer`**: `p` strictly in `(0, 1)` — `p=0/1` are numerically degenerate (infinite log loss) and express impossible certainty.
- **tests**: unit-test the strict submit schema + arg echo; the mockllm e2e asserts the structured answer registers cleanly as the scored output (no `submission_error`); scoring rejects `p=0/1` and clamps near-0.
- **`plans/program_plan.md`**: roadmap to decouple **events** (resolvable, with a market-probability trajectory) from **tasks** (an `as_of` + distribution queries over event outcomes).

Verified on RBE: `//loom/gym:{test_inspect_harness,test_scoring,test_baseline_llm}` green, mypy/lint clean.

https://claude.ai/code/session_01AXSFxfCXddADoSKTjgF5Nz