### PR TITLE
Fix Tana LiteLLM proxy runtime deps

### DIFF
--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -91,7 +91,7 @@ jobs:
           - {
               image: "//tana/litellm_proxy:image",
               image_name: tana-litellm-proxy,
-              test_target: "//tana/litellm_proxy:test_provider",
+              test_target: "//tana/litellm_proxy/...",
             }
           - {
               image: "//x/mcp_oauth_facade:image",

--- a/cluster/k8s/litellm/tana/custom_handler.py
+++ b/cluster/k8s/litellm/tana/custom_handler.py
@@ -1,1 +1,5 @@
 from __future__ import annotations
+
+from tana.litellm_proxy.custom_handler import tana_handler
+
+__all__ = ["tana_handler"]

--- a/devinfra/gazelle_python.yaml
+++ b/devinfra/gazelle_python.yaml
@@ -40,6 +40,7 @@ manifest:
     anyio: anyio
     apiclient: google_api_python_client
     appdirs: appdirs
+    apscheduler: apscheduler
     arch: arch
     argon2: argon2_cffi
     arrow: arrow
@@ -545,7 +546,7 @@ manifest:
     sympy: sympy
     syrupy: syrupy
     tabulate: tabulate
-    takethetime: takethetime
+    takethetime: TakeTheTime
     tenacity: tenacity
     terminado: terminado
     testcontainers.arangodb: testcontainers
@@ -616,6 +617,7 @@ manifest:
     typing_extensions: typing_extensions
     typing_inspection: typing_inspection
     tzdata: tzdata
+    tzlocal: tzlocal
     uc_micro: uc_micro_py
     uncalled_for: uncalled_for
     unidiff: unidiff
@@ -652,4 +654,4 @@ manifest:
     zstandard: zstandard
   pip_repository:
     name: pypi
-integrity: 19fb9142f8b4e2a03ee8819690ce3154b14e1ab97674f3ecb6b43e096630176f
+integrity: ac3939c106bacca4bbb962ff3b327225cb158fe4cf0fb35f5fe92cd3886c2d7e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "uvicorn[standard]>=0.30.0",
     "httpx>=0.27.0",
     "websockets>=15.0",
+    "apscheduler>=3.10.0",
     # CRDT for the Study Casino multi-device sync (also indirectly pulled in
     # by datalayer-pycrdt; pinned here as a direct dep so the casino doesn't
     # depend on that transitive edge).

--- a/requirements_bazel.txt
+++ b/requirements_bazel.txt
@@ -285,6 +285,10 @@ appdirs==1.4.4 \
     # via
     #   aw-core
     #   crewai
+apscheduler==3.11.2 \
+    --hash=sha256:2a9966b052ec805f020c8c4c3ae6e6a06e24b1bf19f2e11d91d8cca0473eef41 \
+    --hash=sha256:ce005177f741409db4e4dd40a7431b76feb856b9dd69d57e0da49d6715bfd26d
+    # via ducktape (pyproject.toml)
 arch==8.0.0 \
     --hash=sha256:119766cdb3ac9ebdad4077dcf8238fb2a4554ba3c6503bd4431161f43923357e \
     --hash=sha256:13cbf04d45ecbee7578704a232f897cd02794d845f877158fb2838e6fb637887 \
@@ -7077,6 +7081,10 @@ tzdata==2025.3 \
     --hash=sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1 \
     --hash=sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7
     # via arrow
+tzlocal==5.3.1 \
+    --hash=sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd \
+    --hash=sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d
+    # via apscheduler
 uc-micro-py==2.0.0 \
     --hash=sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c \
     --hash=sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811

--- a/tana/litellm_proxy/BUILD.bazel
+++ b/tana/litellm_proxy/BUILD.bazel
@@ -3,6 +3,23 @@ load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
 load("//devinfra/python:defs.bzl", "py_binary", "py_library", "py_test")
 load("//props:oci.bzl", "py_image_entrypoint", "py_image_env")
 
+LITELLM_PROXY_RUNTIME_DEPS = [
+    "@pypi//aiohttp",
+    "@pypi//apscheduler",
+    "@pypi//backoff",
+    "@pypi//fastapi",
+    "@pypi//opentelemetry_api",
+    "@pypi//opentelemetry_exporter_otlp_proto_http",
+    "@pypi//opentelemetry_sdk",
+    "@pypi//orjson",
+    "@pypi//prometheus_client",
+    "@pypi//pydantic_settings",
+    "@pypi//python_multipart",
+    "@pypi//pyyaml",
+    "@pypi//uvicorn",
+    "@pypi//websockets",
+]
+
 py_library(
     name = "provider",
     srcs = [
@@ -56,6 +73,15 @@ py_test(
     ],
 )
 
+py_test(
+    name = "test_proxy_runtime",
+    srcs = ["test_proxy_runtime.py"],
+    deps = [
+        ":provider",
+        "@pypi//litellm",
+    ] + LITELLM_PROXY_RUNTIME_DEPS,
+)
+
 aspect_py_binary(
     name = "server_bin",
     srcs = ["@@rules_python++pip+pypi_313_litellm//:rules_python_wheel_entry_point_litellm.py"],
@@ -63,7 +89,7 @@ aspect_py_binary(
     deps = [
         ":provider",
         "@pypi//litellm",
-    ],
+    ] + LITELLM_PROXY_RUNTIME_DEPS,
 )
 
 py_image_layer(

--- a/tana/litellm_proxy/provider.py
+++ b/tana/litellm_proxy/provider.py
@@ -420,10 +420,7 @@ class TanaLiteLLM(CustomLLM):
     ) -> AsyncIterator[GenericStreamingChunk]:
         del api_base, custom_prompt_dict, model_response, print_verbose, encoding, api_key
         del logging_obj, acompletion, litellm_params, logger_fn, headers, timeout, client
-        async for chunk in self._client.astream_completion(
-            model, cast(Sequence[Mapping[str, Any]], messages), optional_params
-        ):
-            yield chunk
+        return self._client.astream_completion(model, cast(Sequence[Mapping[str, Any]], messages), optional_params)
 
 
 def register_litellm_provider(handler: TanaLiteLLM | None = None) -> TanaLiteLLM:

--- a/tana/litellm_proxy/test_provider.py
+++ b/tana/litellm_proxy/test_provider.py
@@ -588,21 +588,19 @@ def test_litellm_handler_astreaming_yields_chunks() -> None:
 
     async def collect_chunks() -> list[GenericStreamingChunk]:
         handler = TanaLiteLLM(FakeClient())
-        return [
-            chunk
-            async for chunk in handler.astreaming(
-                model="claude-test",
-                messages=[{"role": "user", "content": "hi"}],
-                api_base="",
-                custom_prompt_dict={},
-                model_response=cast(ModelResponse, None),
-                print_verbose=lambda *args, **kwargs: None,
-                encoding=None,
-                api_key=None,
-                logging_obj=None,
-                optional_params={"stream": True},
-            )
-        ]
+        stream = await handler.astreaming(
+            model="claude-test",
+            messages=[{"role": "user", "content": "hi"}],
+            api_base="",
+            custom_prompt_dict={},
+            model_response=cast(ModelResponse, None),
+            print_verbose=lambda *args, **kwargs: None,
+            encoding=None,
+            api_key=None,
+            logging_obj=None,
+            optional_params={"stream": True},
+        )
+        return [chunk async for chunk in stream]
 
     chunks = asyncio.run(collect_chunks())
 

--- a/tana/litellm_proxy/test_proxy_runtime.py
+++ b/tana/litellm_proxy/test_proxy_runtime.py
@@ -1,0 +1,8 @@
+"""Runtime smoke tests for the LiteLLM proxy entrypoint closure."""
+
+import importlib
+
+
+def test_litellm_proxy_server_imports() -> None:
+    importlib.import_module("litellm.proxy.proxy_cli")
+    importlib.import_module("litellm.proxy.proxy_server")


### PR DESCRIPTION
## Summary
- Add the LiteLLM proxy runtime dependencies to the custom `server_bin` closure.
- Add a runtime smoke test that imports LiteLLM proxy server modules so missing proxy extras fail in CI.
- Restore the Tana LiteLLM custom handler ConfigMap shim so `custom_handler.tana_handler` resolves at runtime.
- Gate the Tana LiteLLM image push on `//tana/litellm_proxy/...`.
- Match LiteLLM's async streaming override shape so the full package target passes mypy aspects.

## Verification
- `nix develop -c bazelisk test //tana/litellm_proxy/... //cluster/k8s/litellm/tana:test_generate_tana_litellm`
- `nix develop -c bazelisk build //tana/litellm_proxy:image`