### PR TITLE
loom/gym: strict structured submit tool, schema+parse from one pydantic model

### DIFF
--- a/loom/gym/baseline_llm.py
+++ b/loom/gym/baseline_llm.py
@@ -66,7 +66,14 @@ def question_schema(question: Question) -> dict[str, object]:
         case BinaryQuestion():
             return {
                 "type": "object",
-                "properties": {"p": {"type": "number", "minimum": 0, "maximum": 1}},
+                "properties": {
+                    "p": {
+                        "type": "number",
+                        "exclusiveMinimum": 0,
+                        "exclusiveMaximum": 1,
+                        "description": "Probability that the question resolves YES, strictly between 0 and 1 (never 0 or 1).",
+                    }
+                },
                 "required": ["p"],
                 "additionalProperties": False,
             }
@@ -76,6 +83,7 @@ def question_schema(question: Question) -> dict[str, object]:
                 "properties": {
                     "quantiles": {
                         "type": "object",
+                        "description": "Your stated value at each quantile level, non-decreasing in level.",
                         "properties": {str(level): {"type": "number"} for level in QUANTILE_LEVELS},
                         "required": [str(level) for level in QUANTILE_LEVELS],
                         "additionalProperties": False,
@@ -90,6 +98,7 @@ def question_schema(question: Question) -> dict[str, object]:
                 "properties": {
                     "probabilities": {
                         "type": "object",
+                        "description": "Your probability for each listed category; the values must sum to 1.",
                         "properties": {category: {"type": "number", "minimum": 0} for category in categories},
                         "required": list(categories),
                         "additionalProperties": False,

--- a/loom/gym/baseline_llm.py
+++ b/loom/gym/baseline_llm.py
@@ -24,9 +24,11 @@ from __future__ import annotations
 import logging
 from collections.abc import Sequence
 from dataclasses import dataclass
+from typing import Any, cast
 
 import httpx
 from more_itertools import one
+from pydantic import BaseModel, ConfigDict, Field, create_model
 from tenacity import before_sleep_log, retry, retry_if_exception, stop_after_attempt, wait_exponential
 
 from loom.gym.scoring import QUANTILE_LEVELS, Answer, BinaryAnswer, CategoricalAnswer, QuantileAnswer
@@ -61,52 +63,77 @@ class ForecastResult:
     output_tokens: int
 
 
-def question_schema(question: Question) -> dict[str, object]:
+# extra="forbid" closes every object (additionalProperties: false in the schema);
+# the per-question required keys (the fixed quantile levels, the question's
+# category set) are real fields, so the Anthropic-shaped API enforces exactly the
+# answer shape. Semantic checks (quantiles non-decreasing, probabilities sum to 1)
+# stay on the scoring Answer models that parse_answer builds from a validated input.
+_FORBID = ConfigDict(extra="forbid")
+
+
+def _model(name: str, **fields: Any) -> type[BaseModel]:
+    # **fields: Any so pydantic's loose create_model overload accepts the
+    # (type, FieldInfo) tuples (it types field_definitions as Any | tuple[str, Any]).
+    return create_model(name, __config__=_FORBID, **fields)
+
+
+def _answer_input_model(question: Question) -> type[BaseModel]:
+    """Per-question model that is the single source for both the submit tool's
+    input schema (`question_schema`) and the shape validation of the model's tool
+    call (`parse_answer`). Nested objects use aliased fields so the JSON keys are
+    the quantile levels / category names."""
     match question:
         case BinaryQuestion():
-            return {
-                "type": "object",
-                "properties": {
-                    "p": {
-                        "type": "number",
-                        "exclusiveMinimum": 0,
-                        "exclusiveMaximum": 1,
-                        "description": "Probability that the question resolves YES, strictly between 0 and 1 (never 0 or 1).",
-                    }
+            p = Field(gt=0, lt=1, description="Probability the question resolves YES, strictly in (0, 1).")
+            return _model("BinaryAnswerInput", p=(float, p))
+        case ScalarQuestion(unit=unit):
+            quantiles = _model(
+                "QuantilesInput",
+                **{
+                    f"q{index}": (float, Field(alias=str(level), description=f"value at the {level} quantile"))
+                    for index, level in enumerate(QUANTILE_LEVELS)
                 },
-                "required": ["p"],
-                "additionalProperties": False,
-            }
-        case ScalarQuestion():
-            return {
-                "type": "object",
-                "properties": {
-                    "quantiles": {
-                        "type": "object",
-                        "description": "Your stated value at each quantile level, non-decreasing in level.",
-                        "properties": {str(level): {"type": "number"} for level in QUANTILE_LEVELS},
-                        "required": [str(level) for level in QUANTILE_LEVELS],
-                        "additionalProperties": False,
-                    }
-                },
-                "required": ["quantiles"],
-                "additionalProperties": False,
-            }
+            )
+            description = f"your value (in {unit}) at each quantile level, non-decreasing in level"
+            return _model("ScalarAnswerInput", quantiles=(quantiles, Field(description=description)))
         case CategoricalQuestion(categories=categories):
-            return {
-                "type": "object",
-                "properties": {
-                    "probabilities": {
-                        "type": "object",
-                        "description": "Your probability for each listed category; the values must sum to 1.",
-                        "properties": {category: {"type": "number", "minimum": 0} for category in categories},
-                        "required": list(categories),
-                        "additionalProperties": False,
-                    }
+            probabilities = _model(
+                "ProbabilitiesInput",
+                **{
+                    f"c{index}": (float, Field(alias=category, ge=0, description=f"probability of {category!r}"))
+                    for index, category in enumerate(categories)
                 },
-                "required": ["probabilities"],
-                "additionalProperties": False,
-            }
+            )
+            description = "probability for each category; values must sum to 1"
+            return _model("CategoricalAnswerInput", probabilities=(probabilities, Field(description=description)))
+
+
+def _inline_refs(schema: dict[str, Any]) -> dict[str, Any]:
+    """Inline Pydantic's `$defs`/`$ref` into one self-contained schema (merging
+    sibling keys like a field description over the referenced def). inspect's
+    JSONSchema and a plain Anthropic `input_schema` don't resolve `$ref`, so a
+    nested model would otherwise lose its structure."""
+    defs = schema.pop("$defs", {})
+
+    def walk(node: Any) -> Any:
+        if isinstance(node, dict):
+            if "$ref" in node:
+                target = defs[node["$ref"].rsplit("/", 1)[-1]]
+                return walk({**target, **{key: value for key, value in node.items() if key != "$ref"}})
+            if "allOf" in node and len(node["allOf"]) == 1:
+                merged = node["allOf"][0] | {key: value for key, value in node.items() if key != "allOf"}
+                return walk(merged)
+            return {key: walk(value) for key, value in node.items()}
+        if isinstance(node, list):
+            return [walk(item) for item in node]
+        return node
+
+    return cast("dict[str, Any]", walk(schema))
+
+
+def question_schema(question: Question) -> dict[str, object]:
+    """JSON schema for the answer to `question`, derived from its input model."""
+    return _inline_refs(_answer_input_model(question).model_json_schema())
 
 
 def answer_instruction(question: Question) -> str:
@@ -121,13 +148,17 @@ def answer_instruction(question: Question) -> str:
 
 
 def parse_answer(task: Task, tool_input: dict[str, object]) -> Answer:
+    # Validate the strict per-question shape via the same model the schema came
+    # from, then build the scoring Answer (which adds the semantic checks).
+    # by_alias dumps back to the wire keys (quantile levels / category names).
+    data = _answer_input_model(task.question).model_validate(tool_input).model_dump(by_alias=True)
     match task.question:
         case BinaryQuestion():
-            return BinaryAnswer.model_validate(tool_input)
+            return BinaryAnswer.model_validate(data)
         case ScalarQuestion():
-            return QuantileAnswer.model_validate(tool_input)
+            return QuantileAnswer.model_validate(data)
         case CategoricalQuestion():
-            return CategoricalAnswer.model_validate(tool_input)
+            return CategoricalAnswer.model_validate(data)
 
 
 def _as_of_header(task: Task, dossier: dict[str, str] | None) -> str:

--- a/loom/gym/inspect_harness.py
+++ b/loom/gym/inspect_harness.py
@@ -26,9 +26,11 @@ from __future__ import annotations
 import json
 import logging
 import tempfile
+from collections import defaultdict
 from collections.abc import Sequence
 from datetime import date
 from pathlib import Path
+from typing import Any
 
 import yaml
 
@@ -38,14 +40,14 @@ from inspect_ai.agent import AgentSubmit, react
 from inspect_ai.dataset import MemoryDataset, Sample
 from inspect_ai.scorer import Score, Target, mean, scorer
 from inspect_ai.solver import TaskState
-from inspect_ai.tool import bash
+from inspect_ai.tool import ToolDef, ToolParams, ToolResult, bash
 from inspect_ai.util import sandbox
 
 from loom.gym import scoring
-from loom.gym.baseline_llm import answer_instruction, parse_answer
+from loom.gym.baseline_llm import answer_instruction, parse_answer, question_schema
 from loom.gym.dossier import series_dossier
 from loom.gym.monthly_series import MonthlySeries
-from loom.gym.task import Task
+from loom.gym.task import Question, Task
 
 logger = logging.getLogger(__name__)
 
@@ -162,7 +164,8 @@ AGENT_PROMPT = (
     "starting points for your research, which you can follow and branch out from. You can browse the "
     "web as it existed at your information cutoff through a preconfigured proxy: ordinary http:// and "
     "https:// URLs both work (curl, urllib, and requests honor the proxy and its CA automatically). "
-    "When confident, call submit with ONLY the JSON answer object, no prose."
+    "When confident, call the submit tool with your forecast — its arguments are the structured "
+    "answer fields, which the tool schema enforces."
 )
 
 # Container path the proxy sidecar writes its served-evidence manifest to;
@@ -202,7 +205,7 @@ def sample_for_task(task: Task, dossier: dict[str, str], compose_path: Path) -> 
         f"knowledge of events on or before {task.as_of}.\n"
         f"Question: {task.question.text}\n"
         f"Resolution date: {task.resolution_date}\n"
-        f"Submit ONLY a JSON object: {answer_instruction(task.question)}."
+        f"When done, call the submit tool with your forecast: {answer_instruction(task.question)}."
     )
     files = {f"/data/{name}": content for name, content in dossier.items()}
     if task.evidence:
@@ -259,6 +262,36 @@ def gym_proper_loss():
     return score_fn
 
 
+def _submit_tool(question: Question) -> ToolDef:
+    """Submit tool whose input_schema is the question's strict answer shape.
+
+    react's default submit takes a free-form `answer` string, which a sloppy
+    model can leave empty or fill with prose — an unparseable non-submission
+    (observed live: glm-4.5 researched a task then submitted an empty payload →
+    `JSONDecodeError`). Carrying `question_schema(question)` as the tool's
+    parameters instead makes the Anthropic-shaped API enforce a well-formed
+    forecast object — the same forced-schema path the bare baseline uses, which
+    z.ai's GLM honors — so the model cannot submit the wrong shape. The
+    structured arguments are returned as JSON for the scorer's parse_answer.
+    (inspect's JSONSchema drops the numeric min/max bounds it doesn't model;
+    the Answer pydantic models re-enforce them on parse.)
+    """
+
+    # Signature must be exactly `**kwargs: Any` — Inspect's tool-arg coercion
+    # special-cases that to pass the model's structured arguments through
+    # unchanged; any other name/annotation makes it bind a VAR_KEYWORD parameter
+    # and inject `inspect.Parameter.empty` (a type, which then fails to serialize).
+    async def submit(**kwargs: Any) -> ToolResult:
+        return json.dumps(kwargs)
+
+    return ToolDef(
+        submit,
+        name="submit",
+        description=f"Submit your final forecast: {answer_instruction(question)}.",
+        parameters=ToolParams.model_validate(question_schema(question)),
+    )
+
+
 def agent_eval_task(
     tasks: Sequence[Task],
     series: Sequence[MonthlySeries],
@@ -267,8 +300,11 @@ def agent_eval_task(
     wayback_upstream_auth: str = "",
     agent_image: str = SANDBOX_IMAGE_TAG,
     compose_dir: Path | None = None,
-) -> InspectTask:
-    """Inspect task over gym tasks; one sandbox compose is generated per distinct as_of."""
+) -> list[InspectTask]:
+    """Inspect tasks over gym tasks: one sandbox compose per distinct as_of, and
+    one Inspect task per distinct answer schema. The react submit tool carries a
+    single question's strict shape (`_submit_tool`), so tasks are grouped by it —
+    a uniform-kind panel (e.g. the binary market set) stays a single task."""
     if compose_dir is None:
         compose_dir = Path(tempfile.mkdtemp(prefix="gym-sandbox-"))
     as_ofs = {task.as_of for task in tasks}
@@ -277,8 +313,21 @@ def agent_eval_task(
         as_of: write_sandbox_compose(compose_dir, as_of, wayback_upstream, agent_image, wayback_upstream_auth)
         for as_of in as_ofs
     }
-    return InspectTask(
-        dataset=MemoryDataset([sample_for_task(task, dossiers[task.as_of], composes[task.as_of]) for task in tasks]),
-        solver=react(prompt=AGENT_PROMPT, tools=[bash(timeout=180)], submit=AgentSubmit(answer_only=True)),
-        scorer=gym_proper_loss(),
-    )
+    by_schema: dict[str, list[Task]] = defaultdict(list)
+    for task in tasks:
+        by_schema[json.dumps(question_schema(task.question), sort_keys=True)].append(task)
+    return [
+        InspectTask(
+            name=f"agent_eval_{group[0].question.kind}_{index}",
+            dataset=MemoryDataset(
+                [sample_for_task(task, dossiers[task.as_of], composes[task.as_of]) for task in group]
+            ),
+            solver=react(
+                prompt=AGENT_PROMPT,
+                tools=[bash(timeout=180)],
+                submit=AgentSubmit(tool=_submit_tool(group[0].question), answer_only=True),
+            ),
+            scorer=gym_proper_loss(),
+        )
+        for index, group in enumerate(by_schema.values())
+    ]

--- a/loom/gym/scoring.py
+++ b/loom/gym/scoring.py
@@ -32,7 +32,11 @@ class BinaryAnswer(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     kind: Literal["binary"] = "binary"
-    p: float = Field(ge=0.0, le=1.0, description="Stated probability that the question resolves YES.")
+    # Strictly in (0, 1): p=0/1 are numerically degenerate (infinite log loss)
+    # and express impossible certainty; a forecaster must state a real probability.
+    p: float = Field(
+        gt=0.0, lt=1.0, description="Stated probability that the question resolves YES, strictly in (0, 1)."
+    )
 
 
 class QuantileAnswer(BaseModel):

--- a/loom/gym/test_inspect_harness.py
+++ b/loom/gym/test_inspect_harness.py
@@ -20,7 +20,13 @@ from inspect_ai.model import ModelOutput, get_model
 from more_itertools import one
 
 from loom.gym.dossier import series_dossier
-from loom.gym.inspect_harness import WAYBACK_PROXY_IMAGE_TAG, agent_eval_task, sample_for_task, write_sandbox_compose
+from loom.gym.inspect_harness import (
+    WAYBACK_PROXY_IMAGE_TAG,
+    _submit_tool,
+    agent_eval_task,
+    sample_for_task,
+    write_sandbox_compose,
+)
 from loom.gym.monthly_series import MonthlySeries, add_months
 from loom.gym.series_tasks import SeriesTaskSpec, tasks_for_spec
 from loom.gym.task import BinaryOutcome, EvidenceItem
@@ -78,9 +84,22 @@ def test_sample_carries_dossier_task_and_sandbox(tmp_path: Path) -> None:
     assert sample.metadata is not None
     assert sample.metadata["gym_task"]["task_id"] == GYM_TASK.task_id
     assert json.loads(str(sample.target))["value"] is True
-    assert "Submit ONLY a JSON object" in str(sample.input)
+    assert "call the submit tool" in str(sample.input)
     assert sample.sandbox is not None
     assert sample.sandbox.config == str(compose_path)
+
+
+def test_submit_tool_enforces_answer_shape() -> None:
+    # The strict submit tool is what stops empty/prose non-submissions: its
+    # parameters require the answer field and forbid anything else, so the
+    # (Anthropic-shaped) API rejects a malformed tool call before it reaches us.
+    tool = _submit_tool(GYM_TASK.question)
+    assert tool.name == "submit"
+    assert tool.parameters.required == ["p"]
+    assert set(tool.parameters.properties) == {"p"}
+    assert tool.parameters.additionalProperties is False
+    # A well-formed call echoes the structured args as JSON for the scorer to parse.
+    assert json.loads(asyncio.run(tool.tool(p=0.8))) == {"p": 0.8}
 
 
 def test_evidence_lands_as_url_file_never_in_prompt(tmp_path: Path) -> None:
@@ -225,7 +244,9 @@ def test_agent_answers_in_sandbox(tmp_path: Path, fake_upstream_port: int) -> No
         custom_outputs=[
             ModelOutput.for_tool_call("mockllm/model", "bash", {"cmd": fetch_cmd}),
             ModelOutput.for_tool_call("mockllm/model", "bash", {"cmd": "head -3 /data/ramp_monthly.csv"}),
-            ModelOutput.for_tool_call("mockllm/model", "submit", {"answer": json.dumps({"p": 0.8})}),
+            # The submit tool now carries the strict answer schema, so its
+            # arguments are the structured fields (p), not a free-form JSON string.
+            ModelOutput.for_tool_call("mockllm/model", "submit", {"p": 0.8}),
         ],
     )
     try:
@@ -254,8 +275,13 @@ def test_agent_answers_in_sandbox(tmp_path: Path, fake_upstream_port: int) -> No
     assert sample.scores is not None
     score = sample.scores["gym_proper_loss"]
     assert score.value == pytest.approx(-math.log(0.8))
-    # W3: the proxy's served-evidence manifest rides along in the score.
     assert score.metadata is not None
+    # The structured submit registered cleanly as the scored answer: the strict
+    # tool's arguments round-trip into the completion and the scorer parses them,
+    # taking the success path (no `submission_error` fallback).
+    assert "submission_error" not in score.metadata
+    assert json.loads(str(score.answer)) == {"p": 0.8}
+    # W3: the proxy's served-evidence manifest rides along in the score.
     served = one(score.metadata["served_evidence"])
     assert served["url"] == fake_ia.EXAMPLE_ORIGINAL
     assert served["capture_ts"] == fake_ia.GOOD_TS

--- a/loom/gym/test_scoring.py
+++ b/loom/gym/test_scoring.py
@@ -37,15 +37,26 @@ BINARY_TASK_YES = _task(BinaryQuestion(text="?"), BinaryOutcome(value=True))
 
 
 def test_binary_scores() -> None:
-    assert score(BINARY_TASK_YES, BinaryAnswer(p=1.0)).metrics == {"log_loss": 0.0, "brier": 0.0}
+    confident = score(BINARY_TASK_YES, BinaryAnswer(p=0.99)).metrics
+    assert confident["log_loss"] == pytest.approx(-math.log(0.99))
+    assert confident["brier"] == pytest.approx(0.0001)
     half = score(BINARY_TASK_YES, BinaryAnswer(p=0.5)).metrics
     assert half["log_loss"] == pytest.approx(math.log(2))
     assert half["brier"] == pytest.approx(0.25)
 
 
-def test_hard_wrong_binary_answer_scores_finite() -> None:
-    # p=0 on a YES outcome must produce a large but finite log loss, not infinity.
-    metrics = score(BINARY_TASK_YES, BinaryAnswer(p=0.0)).metrics
+@pytest.mark.parametrize("p", [0.0, 1.0])
+def test_binary_answer_rejects_degenerate_probability(p: float) -> None:
+    # p=0/1 give infinite log loss and express impossible certainty; the answer
+    # boundary requires a strict probability in (0, 1).
+    with pytest.raises(ValidationError):
+        BinaryAnswer(p=p)
+
+
+def test_near_certain_wrong_binary_answer_scores_finite() -> None:
+    # A near-0 probability on a YES outcome is clamped to a large but finite log
+    # loss, not infinity (p=0 itself is rejected at the answer boundary).
+    metrics = score(BINARY_TASK_YES, BinaryAnswer(p=1e-9)).metrics
     assert math.isfinite(metrics["log_loss"])
     assert metrics["log_loss"] > 10
     assert metrics["brier"] == pytest.approx(1.0)

--- a/loom/plans/program_plan.md
+++ b/loom/plans/program_plan.md
@@ -446,6 +446,34 @@ date, realized outcome)`; a contestant may use any data dated ≤ t.
   currently hand-set priors — get tuned against held-out gym loss instead of
   argued about.
 
+## Roadmap: decouple events from tasks
+
+Today `loom/gym/task.py` fuses question + outcome + as_of into one `Task`. A
+cleaner model separates two concepts:
+
+- **Event**: a thing that resolves at some point in time, optionally carrying a
+  "market probability" trajectory up to resolution. Examples: "S&P 500 close on
+  day X", "will X happen by day Y", "which FOO happens on day BAR". A Manifold
+  market is an event (question text, eventual answer, resolution day); our
+  financial series are another source of events. Events are the durable,
+  reusable unit — independent of any particular forecast prompt.
+- **Task**: an `as_of` date plus a set of **distribution queries** about future
+  events. A query is a joint distribution over one or more event outcomes —
+  a single binary marginal, a scalar's full distribution at a date, the N-way
+  categorical or continuous joint of several events, etc. The `as_of` must
+  strictly precede the resolution date of every event the task references.
+
+Consequences of the split: one event can appear in many tasks (different
+`as_of`s, solo vs. jointly with others); a task can bundle many queries over a
+shared `as_of` (this is what `bundle_tasks.py` approximates today, but keyed by
+task id rather than by event). Scoring stays per-query. This generalizes the
+current binary/scalar/categorical `Question` kinds into "distribution query
+over a set of event outcomes", with the marginal cases as the 1-event
+specializations.
+
+Not built yet — recorded here so the eventual schema refactor (Event store +
+Task = as_of + queries-over-events) is deliberate rather than emergent.
+
 ## What loom is not
 
 - **Not trading or market-making.** "Coherence" means "a joint with these


### PR DESCRIPTION
Two commits. Rebased onto current devel (incl. #2009, which fixes the unrelated tana `bazel-ci` breakage that was blocking this PR).

## 1. Strict structured submit tool (`2b42b14`)

The agent's submit was inspect's default free-form `answer` string → `json.loads`, which a sloppy model leaves empty or fills with prose (observed live: glm-4.5 researched a task then submitted nothing → `JSONDecodeError`, NaN score). Replace it with a submit tool whose `input_schema` is the question's answer shape, so the Anthropic-shaped API (which z.ai's GLM honors) enforces a well-formed forecast object.

- `inspect_harness._submit_tool(question)` builds a strict submit `ToolDef` (signature must be `**kwargs: Any` so inspect passes the structured args through unchanged). Tasks are grouped by answer schema — one Inspect task / react submit tool per shape — so `agent_eval_task` returns `list[InspectTask]`.
- `scoring.BinaryAnswer.p` made strictly `(0, 1)` — `p=0/1` are numerically degenerate (infinite log loss) and express impossible certainty.
- tests: strict-submit schema + arg echo; the mockllm docker e2e asserts the structured answer registers cleanly (no `submission_error`); scoring rejects `p=0/1`.
- roadmap note in `program_plan.md` to decouple **events** from **tasks**.

## 2. Schema + parse from one per-question pydantic model (`330b329`)

`question_schema` and `parse_answer` were two hand-maintained descriptions of the same shape. Collapse them to a single source: `_answer_input_model(question)` builds a per-question model with `create_model` (binary `p`; a nested quantiles object with the fixed levels; a nested probabilities object with the question's categories — aliased so the JSON keys are the levels/category names), `extra="forbid"` closing every object.

- `question_schema` is now that model's `model_json_schema()`, with `$defs` inlined (inspect's `JSONSchema` and a plain Anthropic `input_schema` don't resolve `$ref`; sibling keys like a field description are merged over the referenced def).
- `parse_answer` validates the tool call through the same model, then builds the scoring `Answer` from the alias-dumped data — the semantic validators (quantiles non-decreasing, probabilities sum to 1) stay on those models.

### Live validation

A second smoke (glm-4.5, `new-glenn`, in-cluster authed cache) with this submit tool produced a clean `{"p": 0.26}` — scored, no `submission_error` — vs. the empty NaN submission before. Verified on RBE: `//loom/gym:{test_inspect_harness,test_scoring,test_baseline_llm}` green, mypy/lint clean.

https://claude.ai/code/session_01AXSFxfCXddADoSKTjgF5Nz