### PR TITLE
wayback: lazy proxy connection strategy + separate CDX throttle

### DIFF
--- a/cluster/k8s/wayback-cache/config/nginx.conf
+++ b/cluster/k8s/wayback-cache/config/nginx.conf
@@ -2,8 +2,10 @@
 # See loom/plans/wayback_proxy.md. Two tiers:
 #   tier 1 (:8080)          — PVC-backed proxy_cache; hits never touch IA.
 #   tier 2 (127.0.0.1:8081) — loopback-only; every request reaching it is by
-#                             construction a cold miss, so a single limit_req
-#                             bucket paces exactly the traffic IA sees.
+#                             construction a cold miss, so limit_req buckets pace
+#                             exactly the traffic IA sees — content fetches and
+#                             the slower CDX index queries throttled separately
+#                             so neither starves the other.
 # The cache is deliberately dumb: any path forwards verbatim to
 # web.archive.org (CDX queries and /web/<ts>id_/ fetches alike). Date
 # clamping is the per-agent wayback proxy's job (loom/wayback_proxy/).
@@ -37,7 +39,11 @@ http {
     proxy_cache_path /cache levels=1:2 keys_zone=wayback:64m max_size=18g
                      inactive=3650d use_temp_path=off;
 
+    # Content fetches (immutable snapshot bytes) and CDX index queries are paced
+    # separately: CDX is slow at IA (10-25s/query) but every clamp needs one, so
+    # sharing one bucket made cold bursts queue CDX behind content and 504.
     limit_req_zone $server_name zone=ia_upstream:1m rate=30r/m;
+    limit_req_zone $server_name zone=ia_cdx:1m rate=60r/m;
 
     # DNS resolved once at nginx startup; the Recreate deployment strategy
     # means a pod restart re-resolves if IA rotates IPs.
@@ -106,23 +112,36 @@ http {
         listen 127.0.0.1:8081;
         server_name wayback-upstream;
 
+        # Common IA upstream settings, inherited by both locations below. (A
+        # location that set its own proxy_set_header would inherit none of these,
+        # so neither does — they differ only in rate bucket and read timeout.)
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        proxy_set_header Host web.archive.org;
+        proxy_set_header User-Agent "ducktape-wayback-cache/1 (+agentydragon@gmail.com)";
+        # Deterministic bytes: no content-encoding variants in the cache, so
+        # per-agent evidence sha256s are stable.
+        proxy_set_header Accept-Encoding "identity";
+        proxy_ssl_server_name on;
+        proxy_ssl_name web.archive.org;
+        proxy_ssl_verify on;
+        proxy_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
+        proxy_connect_timeout 10s;
+        proxy_read_timeout 60s;
+
+        # CDX index lookups are slow at IA (10-25s) and every clamp issues one:
+        # give them a more generous bucket and a longer read timeout so a queued
+        # query rides out the wait instead of 504-ing, and never competes with
+        # content fetches for the same tokens.
+        location /cdx/ {
+            limit_req zone=ia_cdx burst=30;
+            proxy_read_timeout 120s;
+            proxy_pass https://ia;
+        }
+
         location / {
             limit_req zone=ia_upstream burst=60; # delays up to 60 queued, then 503
-
             proxy_pass https://ia;
-            proxy_http_version 1.1;
-            proxy_set_header Connection "";
-            proxy_set_header Host web.archive.org;
-            proxy_set_header User-Agent "ducktape-wayback-cache/1 (+agentydragon@gmail.com)";
-            # Deterministic bytes: no content-encoding variants in the cache,
-            # so per-agent evidence sha256s are stable.
-            proxy_set_header Accept-Encoding "identity";
-            proxy_ssl_server_name on;
-            proxy_ssl_name web.archive.org;
-            proxy_ssl_verify on;
-            proxy_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
-            proxy_connect_timeout 10s;
-            proxy_read_timeout 60s;
         }
     }
 }

--- a/loom/wayback_proxy/server.py
+++ b/loom/wayback_proxy/server.py
@@ -48,6 +48,11 @@ async def amain(config: Config, manifest: TextIO) -> None:
         resolver = WaybackResolver(config, session, manifest)
         options = Options(listen_host="0.0.0.0", listen_port=config.port, confdir=str(ca_dir))
         master = DumpMaster(options, with_termlog=False, with_dumper=False)
+        # lazy: the addon answers every flow from the archive (flow.response set in
+        # the request hook), so mitmproxy must never open a connection to the real
+        # upstream. Default "eager" opens one before the addon runs — wasted work
+        # that also fails TLS verification behind a TLS-inspecting egress proxy.
+        master.options.connection_strategy = "lazy"
         master.addons.add(WaybackAddon(resolver))
         await master.run()
 


### PR DESCRIPTION
Two wayback reliability fixes surfaced by the live agent smokes (both documented as follow-ups in `loom/plans/wayback_proxy.md`).

## 1. Proxy: `connection_strategy=lazy` (`loom/wayback_proxy/server.py`)

mitmproxy defaults to **eager**: for every flow it opens an upstream TLS connection to the original host *before* our addon runs. The `WaybackAddon` answers every flow from the archive (sets `flow.response` in the request hook), so that upstream socket is never used — and behind a TLS-inspecting egress proxy it fails cert verification, logging a warning per request. `lazy` skips it.

Verified live: smoke #1 logged one `Unable to establish TLS connection with server` warning **per fetch**; smoke #2 (with this fix) logged **zero**, with identical research behavior.

## 2. Cache: throttle CDX index lookups separately from content (`cluster/k8s/wayback-cache/config/nginx.conf`)

The first smoke 504'd on CDX lookups. Root cause: IA's CDX API is slow (measured **10–25s/query**) and every date clamp issues one, but content fetches and CDX shared a single `30r/m` `limit_req` bucket behind a `60s` read timeout — so under an agent's burst of cold lookups the CDX queries queued behind content and timed out (504), while the snapshot byte path stayed fine.

Fix: give CDX its own, more generous bucket (`ia_cdx`, `60r/m` burst `30`) and a `120s` read timeout, and hoist the common IA upstream settings to the tier-2 `server` level so the content and CDX locations share everything but rate + timeout.

> Note: this is a cluster config change — needs a Flux reconcile of `wayback-cache` after merge. Smoke #2 did not *reproduce* the 504s (lighter IA load + warm CDX cache), so this is hardening against the cold-burst case the diagnosis identified, not a fix for an observed-every-time failure.

Both changes are isolated to the proxy/cache; no gym/eval code touched.

https://claude.ai/code/session_01AXSFxfCXddADoSKTjgF5Nz

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXSFxfCXddADoSKTjgF5Nz)_