### PR TITLE
Profile CI BuildBuddy tool logs

### DIFF
--- a/.github/workflows/bazel-ci.yml
+++ b/.github/workflows/bazel-ci.yml
@@ -59,35 +59,14 @@ jobs:
           script: |
             set -euo pipefail
             RBE_FLAGS="--config=rbe --config=ci --remote_default_exec_properties=container-image=docker://$RBE_IMAGE"
+            export CI_VM_PROBE_DIR="/home/buildbuddy/workspace/.ducktape-ci-vm-probe"
             probe_bb_runner() {
-              local phase="$1"
-              local marker="/home/buildbuddy/workspace/.ducktape-ci-vm-recycle-marker"
-
-              echo "CI_VM_PROBE phase=${phase}"
-              echo "CI_VM_PROBE ts=$(date -Is)"
-              echo "CI_VM_PROBE hostname=$(hostname 2>/dev/null || true)"
-              echo "CI_VM_PROBE boot_id=$(cat /proc/sys/kernel/random/boot_id 2>/dev/null || true)"
-              echo "CI_VM_PROBE uptime=$(cut -d' ' -f1 /proc/uptime 2>/dev/null || true)"
-              echo "CI_VM_PROBE cwd=$(pwd)"
-              echo "CI_VM_PROBE commit=$(git rev-parse HEAD 2>/dev/null || true)"
-              echo "CI_VM_PROBE marker_path=${marker}"
-              if [[ -r "$marker" ]]; then
-                sed 's/^/CI_VM_PROBE previous_marker /' "$marker"
-              else
-                echo "CI_VM_PROBE previous_marker=missing"
-              fi
-              ps -eo pid,ppid,lstart,etime,cmd | awk '/[b]azel|[b]laze/ {print "CI_VM_PROBE bazel_process " $0}'
-
-              if mkdir -p "$(dirname "$marker")"; then
-                {
-                  echo "phase=${phase}"
-                  echo "ts=$(date -Is)"
-                  echo "commit=$(git rev-parse HEAD 2>/dev/null || true)"
-                  echo "boot_id=$(cat /proc/sys/kernel/random/boot_id 2>/dev/null || true)"
-                  echo "uptime=$(cut -d' ' -f1 /proc/uptime 2>/dev/null || true)"
-                } >"$marker" || true
-              fi
+              python3 devinfra/ci/bb_runner_probe.py snapshot "$1" || true
             }
+            finalize_bb_runner_probe() {
+              python3 devinfra/ci/bb_runner_probe.py finalize --upload || true
+            }
+            trap finalize_bb_runner_probe EXIT
             probe_bb_runner before-test
             bazel test --keep_going $RBE_FLAGS //... && \
               probe_bb_runner after-test && \

--- a/.github/workflows/bazel-ci.yml
+++ b/.github/workflows/bazel-ci.yml
@@ -59,5 +59,37 @@ jobs:
           script: |
             set -euo pipefail
             RBE_FLAGS="--config=rbe --config=ci --remote_default_exec_properties=container-image=docker://$RBE_IMAGE"
+            probe_bb_runner() {
+              local phase="$1"
+              local marker="/home/buildbuddy/workspace/.ducktape-ci-vm-recycle-marker"
+
+              echo "CI_VM_PROBE phase=${phase}"
+              echo "CI_VM_PROBE ts=$(date -Is)"
+              echo "CI_VM_PROBE hostname=$(hostname 2>/dev/null || true)"
+              echo "CI_VM_PROBE boot_id=$(cat /proc/sys/kernel/random/boot_id 2>/dev/null || true)"
+              echo "CI_VM_PROBE uptime=$(cut -d' ' -f1 /proc/uptime 2>/dev/null || true)"
+              echo "CI_VM_PROBE cwd=$(pwd)"
+              echo "CI_VM_PROBE commit=$(git rev-parse HEAD 2>/dev/null || true)"
+              echo "CI_VM_PROBE marker_path=${marker}"
+              if [[ -r "$marker" ]]; then
+                sed 's/^/CI_VM_PROBE previous_marker /' "$marker"
+              else
+                echo "CI_VM_PROBE previous_marker=missing"
+              fi
+              ps -eo pid,ppid,lstart,etime,cmd | awk '/[b]azel|[b]laze/ {print "CI_VM_PROBE bazel_process " $0}'
+
+              if mkdir -p "$(dirname "$marker")"; then
+                {
+                  echo "phase=${phase}"
+                  echo "ts=$(date -Is)"
+                  echo "commit=$(git rev-parse HEAD 2>/dev/null || true)"
+                  echo "boot_id=$(cat /proc/sys/kernel/random/boot_id 2>/dev/null || true)"
+                  echo "uptime=$(cut -d' ' -f1 /proc/uptime 2>/dev/null || true)"
+                } >"$marker" || true
+              fi
+            }
+            probe_bb_runner before-test
             bazel test --keep_going $RBE_FLAGS //... && \
-              bazel build --keep_going $RBE_FLAGS //...
+              probe_bb_runner after-test && \
+              bazel build --keep_going $RBE_FLAGS //... && \
+              probe_bb_runner after-build

--- a/debug/ci_firecracker_analysis_cache_profile.md
+++ b/debug/ci_firecracker_analysis_cache_profile.md
@@ -40,6 +40,8 @@ header. It does not independently measure inner Bazel analysis work in CI.
   - `recycle-runner=true`
   - `remote-snapshot-save-policy=always`
   - `snapshot-read-policy=newest`
+- Opened PR #2013 from this branch to run instrumented CI against the real GitHub Actions
+  -> BuildBuddy path.
 
 ## Evidence Tables
 
@@ -155,6 +157,58 @@ the combined load/analyze/execute marker.
 | `27304748140` | build | `835339f9` | build   |     7.3s |             2 |                   21030 |
 | `27305863277` | test  | `32b6919b` | test    |   124.5s |           656 |                   21162 |
 
+### Self-Instrumented PR Run
+
+PR #2013's first CI run used the initial inline runner probe. It produced a more interesting
+case than the earlier samples:
+
+- GitHub run `27310006267`, job `80677575140`, passed in about 2m2s.
+- The runner log still said `Syncing existing repo...`.
+- Before the first Bazel command, the probe saw a pre-existing Bazel server:
+  - PID `11591`
+  - start time `Wed Jun 10 22:10:07 2026`
+  - age about 9m35s at the `before-test` probe
+  - output base `/home/buildbuddy/workspace/output-base`
+  - workspace `/home/buildbuddy/workspace/repo-root`
+- The marker from the previous implementation was missing, because this was the first run
+  with marker instrumentation.
+- `boot_id` was `acc2ffc5-1fbe-443a-b33d-08f76b58c8be`; per the older Firecracker notes,
+  `boot_id` is recorded but is not treated as decisive.
+
+The first Bazel child in that run, `a2d71f3f-1c08-41fe-af1e-dd1a00e7488b`, showed:
+
+- `Elapsed time: 57.345s`, `Critical Path: 48.85s`.
+- `704 processes: 61408 action cache hit, 695 remote cache hit, 1 internal, 8 remote`.
+- Console progress included:
+  - `Analyzing: 3529 targets (1 packages loaded, 0 targets configured)`
+  - `Analyzing: 3529 targets (1 packages loaded, 3437 targets configured)`
+  - `Analyzing: 3529 targets (1 packages loaded, 297270 targets configured)`
+- Profile phase summary:
+  - launch: 0.813s
+  - init: 2.415s
+  - target pattern evaluation: 0.044s
+  - interleaved loading/analysis/execution: 54.072s
+  - finish: 0.021s
+- The critical path was dominated by one remote test action:
+  `Testing //devinfra/claude/claude_hook/container_e2e:test_container_e2e` at 48.85s.
+
+The second Bazel child in the same runner, `9528ade3-d76c-42c4-a60f-2427f3da73dd`, was a
+small `bazel build //...`:
+
+- `Elapsed time: 7.982s`, `Critical Path: 0.97s`.
+- Console progress showed `0 packages loaded, 0 targets configured`.
+- Profile phase summary:
+  - init: 3.414s
+  - interleaved loading/analysis/execution: 4.548s
+  - critical path: `OCI Image //devinfra/firecracker/vm_pod:image` at 968ms.
+
+This is the strongest evidence so far that the old runner-recycle note was too strong:
+we positively observed VM/Bazel-process reuse, while the first Bazel command still emitted
+large configured-target progress. That does not by itself prove a cold analysis cache, because
+Bazel 8/Skymeld interleaves analysis and execution and the profile critical path was remote
+execution. It does mean outer runner reuse and even a pre-existing Bazel JVM are insufficient
+evidence for "no reanalysis".
+
 ### Local Validation Caveat
 
 While validating the new `bbapi tool-log` command locally:
@@ -181,12 +235,15 @@ The prior runner-recycle analysis is right about the outer runner state for the 
 window: the logs show warm runner workspaces (`Syncing existing repo...`). It overreaches if
 it treats that header alone as proof that the inner Bazel analysis cache survived.
 
-For the sampled CI runs, the inner Bazel evidence points mostly toward analysis cache reuse:
+The current evidence is mixed:
 
-- no `discarding analysis cache` warnings;
-- `0-3 packages loaded`, `0 targets configured` in CI console progress;
-- actions begin within <1s after the load/analyze marker;
-- the second `bazel build //...` child in the same runner is consistently tiny.
+- sampled recent devel/PR CI runs showed no `discarding analysis cache` warnings and mostly
+  `0-3 packages loaded`, `0 targets configured`;
+- the self-instrumented PR run positively found a pre-existing Bazel server before the first
+  command, but still showed a large configured-target progress counter;
+- the second `bazel build //...` child inside the same runner remains consistently tiny;
+- in the profile, the long wall-clock critical path is still dominated by remote tests/actions,
+  not a separable serial target-pattern or package-loading phase.
 
 The residual time the user noticed is real, but in these samples it is primarily:
 
@@ -194,28 +251,43 @@ The residual time the user noticed is real, but in these samples it is primarily
 - remote action cache checking for thousands of actions in the large PR sample;
 - a small number of long remote executions/tests/mypy actions.
 
-This does not rule out occasional cold runner or analysis-cache-loss cases. It does mean the
-specific recent sampled CI jobs do not support the hypothesis that CI is broadly losing the
-Bazel analysis cache across Firecracker snapshot reuse.
+This does not yet prove that the analysis cache is being dropped between Firecracker snapshots,
+but it does disprove the simpler claim that Firecracker/Bazel-process reuse is enough to infer
+no reanalysis. The next useful data is a structured per-run bundle showing raw procfs state,
+previous local probe logs, Bazel server identity, and BuildBuddy tool profiles for consecutive
+recycled runs.
 
 ## Instrumentation Added On This Branch
 
-`.github/workflows/bazel-ci.yml` now logs `CI_VM_PROBE ...` lines from inside the `bb remote`
-runner script:
+`.github/workflows/bazel-ci.yml` now runs `devinfra/ci/bb_runner_probe.py` from inside the
+`bb remote` runner script:
 
 - before the first Bazel command;
 - after `bazel test`;
 - after `bazel build`.
 
-The probe records timestamp, hostname, `boot_id`, uptime, cwd, commit, previous marker contents,
-and currently-running Bazel/Blaze processes. It writes a marker to
-`/home/buildbuddy/workspace/.ducktape-ci-vm-recycle-marker`, outside the git-cleaned repo.
+The probe writes structured JSONL to
+`/home/buildbuddy/workspace/.ducktape-ci-vm-probe/current/probes.jsonl`, persists the completed
+run under `latest/`, and reads `latest/probes.jsonl` at the next `before-test` probe. On exit it
+creates `current/probe.tgz` and attempts to upload that tarball with `bb upload`; successful
+uploads are printed as `CI_VM_PROBE_CAS digest=...`.
+
+The tarball includes:
+
+- `probes.jsonl`;
+- raw current-run procfs snapshots under `proc/<phase>/...`;
+- previous-run logs under `previous/probes.jsonl`;
+- previous-run procfs snapshots under `previous/proc/...`, if the VM has a local `latest/`
+  directory from an earlier run.
+
+The JSON summary parses `/proc/<pid>/stat` only for compact CI log fields such as Bazel server
+start time and age. The raw `/proc` files in the tarball are the source of truth.
 
 Positive recycle signal to look for on a later CI run:
 
-- `CI_VM_PROBE previous_marker ...` from an earlier run before the first Bazel command; and
-- a pre-existing Bazel/Blaze JVM in `CI_VM_PROBE bazel_process ...` before the first Bazel
-  command.
+- `CI_VM_PROBE_SUMMARY phase=before-test previous_run_log=yes`;
+- a pre-existing Bazel server in `CI_VM_PROBE_SERVER ...` before the first Bazel command;
+- matching current raw procfs state plus previous local probe logs in the uploaded tarball.
 
 `boot_id` is logged but should not be used as the decisive signal; prior Firecracker notes say
 it can change on snapshot restore.

--- a/debug/ci_firecracker_analysis_cache_profile.md
+++ b/debug/ci_firecracker_analysis_cache_profile.md
@@ -1,0 +1,240 @@
+# CI Firecracker / Bazel Analysis Cache Profile
+
+Date: 2026-06-10
+
+## Question
+
+Recent notes concluded that CI/`bbr` Firecracker runner invocations are reusing snapshots.
+That may be true for the outer runner VM while still not proving that the inner Bazel server's
+analysis cache survives CI runs. This investigation separates:
+
+- outer `bb remote` runner warm/cold state (`Syncing existing repo...` vs `Cloning ...`);
+- inner Bazel package loading / target configuration / analysis timing;
+- action-cache and execution timing from BuildBuddy.
+
+## Prior Claims To Check
+
+- `x/firecracker_workflow/README.md`: warm snapshot recycling should preserve full VM memory,
+  including a running Bazel server and in-memory analysis cache. A fully warm repeat showed
+  `0 packages loaded, 0 targets configured`.
+- `devinfra/x/runner_recycle_stats/README.md`: sampled runner logs showed 100% warm outer
+  runner reuse over a recent window, and the note infers that external-repo fetches and analysis
+  cache are reused.
+
+The main suspected hole: the newer runner-recycle analysis classifies only the outer runner
+header. It does not independently measure inner Bazel analysis work in CI.
+
+## Work Log
+
+- Created worktree `/tmp/ducktape-ci-firecracker-profile` on branch
+  `codex/ci-firecracker-profile` from `origin/devel` at `f6662c850`.
+- Read prior notes:
+  - `x/firecracker_workflow/README.md`
+  - `debug/bazel_ci_analysis_cache.md`
+  - `debug/bb_remote_default_branch_cache_warning.md`
+  - `devinfra/x/runner_recycle_stats/README.md`
+  - `devinfra/x/runner_recycle_stats/runner_recycle_stats.py`
+- Confirmed CI uses `.github/actions/bb-remote/action.yml`, which passes:
+  - `workload-isolation-type=firecracker`
+  - `init-dockerd=true`
+  - `recycle-runner=true`
+  - `remote-snapshot-save-policy=always`
+  - `snapshot-read-policy=newest`
+
+## Evidence Tables
+
+### Recent CI Sample
+
+Sampled recent `bazel-ci / Test & Build` GitHub Actions jobs on 2026-06-10. All four
+outer runner logs contained `Syncing existing repo...`, so the runner workspace/rootfs
+path is warm by the existing `runner_recycle_stats` classifier.
+
+| GH run        | GH job        | result  | commit        | outer runner invocation                | child Bazel invocations                                                                   |
+| ------------- | ------------- | ------- | ------------- | -------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `27302927129` | `80653198772` | success | `6d460847...` | `4c6a40ea-286c-44d1-9d88-d03236e52365` | test `807b8b62-73ee-4b88-a5a9-4deb28c3312a`, build `a319a101-db09-44bf-9dc0-d181b581c150` |
+| `27303834911` | `80656268692` | success | `7daf37a...`  | `20f633a7-6ac6-4131-9b2e-b5d0d98caf2b` | test `b479e30b-5c46-4837-941f-449f1e2bca5c`, build `c1ee99c2-ad30-41e9-ae77-3befbbc60400` |
+| `27304748140` | `80659460268` | success | `7daf37a...`  | `46e65377-9b48-4585-aa72-08781e421abe` | test `8f5235d5-3a5a-433d-883c-62cee7ac3409`, build `835339f9-a89f-461d-9797-8dd18d39791e` |
+| `27305863277` | `80663371184` | failure | PR head       | `77e96787-c5a0-495f-a447-6e74d11ae0ce` | test `32b6919b-3ce3-4737-b9a4-222d3b1f15c1`                                               |
+
+The failure in `27305863277` was a real build failure, not a profiling failure:
+`//tana/litellm_proxy:provider` failed its mypy aspect, and
+`//cluster/k8s/litellm/tana:test_generate_tana_litellm` also failed.
+
+### BuildBuddy Tool Logs
+
+`command.profile.gz` is not a test artifact. It is a BES `BuildToolLogs` entry on the
+invocation, next to inline logs named `elapsed time`, `critical path`, and `process stats`.
+The initial `bbapi artifact` model hid this domain distinction, so this branch adds:
+
+```bash
+bbapi tool-log list <invocation-id>
+bbapi tool-log cat <invocation-id> "critical path"
+bbapi tool-log download <runner-invocation-id> command.profile.gz --all -o profiles/
+```
+
+This command auto-resolves a workflow/runner invocation to child Bazel invocations, matching
+the existing `target`/`artifact` behavior without inventing fake artifact labels.
+
+### Phase Profile From `command.profile.gz`
+
+Wall-clock markers from Bazel's Chrome trace profile. `load/analyze/exec marker span` is the
+Bazel marker named `Load, analyze dependencies and build artifacts` through `Complete build`;
+Bazel 8/Skymeld does not split this cleanly into separate analysis-only and execution-only
+wall spans. `pre-action after load` is the wall time from that marker to the first
+`action processing` event, which is a practical upper bound on non-action work after the
+load/analyze marker for these warm samples.
+
+| run           | role  | child      | console progress | elapsed | setup/diff before target eval | eval to load marker | load/analyze/exec marker span | pre-action after load | action span | action events | critical path | process stats                                                                       |
+| ------------- | ----- | ---------- | ---------------- | ------: | ----------------------------: | ------------------: | ----------------------------: | --------------------: | ----------: | ------------: | ------------: | ----------------------------------------------------------------------------------- |
+| `27302927129` | test  | `807b8b62` | `1 pkg / 0 cfg`  |   66.5s |                        3.830s |              0.035s |                       62.613s |                0.694s |     61.742s |            33 |        55.27s | 33 processes: 4658 action cache hit, 18 remote cache hit, 13 internal, 2 remote     |
+| `27302927129` | build | `a319a101` | `0 pkg / 0 cfg`  |    9.1s |                        4.346s |              0.026s |                        4.669s |                0.753s |      0.140s |             1 |         1.22s | 1 process: 147 action cache hit, 1 internal                                         |
+| `27303834911` | test  | `b479e30b` | `3 pkg / 0 cfg`  |   62.4s |                        2.765s |              0.053s |                       59.478s |                0.597s |     58.748s |           272 |        50.11s | 272 processes: 6739 action cache hit, 157 remote cache hit, 113 internal, 2 remote  |
+| `27303834911` | build | `c1ee99c2` | `0 pkg / 0 cfg`  |    8.8s |                        3.892s |              0.019s |                        4.922s |                0.666s |      0.050s |             1 |         0.12s | 1 process: 147 action cache hit, 1 internal                                         |
+| `27304748140` | test  | `8f5235d5` | `0 pkg / 0 cfg`  |  157.3s |                        3.300s |              0.024s |                      153.960s |                0.253s |    153.527s |         16156 |       118.35s | 16156 processes: 1302 action cache hit, 16276 remote cache hit, 24 remote           |
+| `27304748140` | build | `835339f9` | `0 pkg / 0 cfg`  |    7.3s |                        3.599s |              0.019s |                        3.672s |                0.665s |      2.273s |             2 |         0.07s | 2 processes: 192 action cache hit, 1 remote cache hit, 1 internal                   |
+| `27305863277` | test  | `32b6919b` | `3 pkg / 0 cfg`  |  124.5s |                        3.237s |              0.050s |                      121.082s |                0.625s |    120.302s |           656 |       116.85s | 656 processes: 4781 action cache hit, 53 remote cache hit, 370 internal, 233 remote |
+
+Detailed profile internals:
+
+| run           | role  | child      | `handleDiffs` | `fsvc.getDirtyKeys` | `prepareForExecution` | `skyframeExecutor.evaluateBuildDriverKeys` | `evaluateTargetPatterns` |
+| ------------- | ----- | ---------- | ------------: | ------------------: | --------------------: | -----------------------------------------: | -----------------------: |
+| `27302927129` | test  | `807b8b62` |        3.564s |              3.163s |                0.655s |                                    61.780s |                   0.027s |
+| `27302927129` | build | `a319a101` |        4.168s |              2.803s |                0.692s |                                     3.898s |                   0.019s |
+| `27303834911` | test  | `b479e30b` |        2.448s |              2.421s |                0.558s |                                    58.779s |                   0.034s |
+| `27303834911` | build | `c1ee99c2` |        3.754s |              2.381s |                0.624s |                                     4.235s |                   0.013s |
+| `27304748140` | test  | `8f5235d5` |        3.184s |              2.404s |                0.205s |                                   153.561s |                   0.015s |
+| `27304748140` | build | `835339f9` |        3.480s |              2.304s |                0.621s |                                     2.989s |                   0.013s |
+| `27305863277` | test  | `32b6919b` |        2.892s |              2.852s |                0.583s |                                   120.335s |                   0.038s |
+
+Interval-union view of action categories. These are wall-time coverage of intervals in the
+profile, not summed per-action durations. Categories overlap: for example, remote cache checks
+can run concurrently with remote execution.
+
+| run           | role  | child      | action processing wall | remote cache check wall | remote exec wall | remote process wall |
+| ------------- | ----- | ---------- | ---------------------: | ----------------------: | ---------------: | ------------------: |
+| `27302927129` | test  | `807b8b62` |                58.045s |                  0.966s |          56.067s |             55.421s |
+| `27302927129` | build | `a319a101` |                 0.140s |                  0.000s |           0.000s |              0.000s |
+| `27303834911` | test  | `b479e30b` |                56.103s |                  4.061s |          49.751s |             49.224s |
+| `27303834911` | build | `c1ee99c2` |                 0.050s |                  0.000s |           0.000s |              0.000s |
+| `27304748140` | test  | `8f5235d5` |               153.516s |                 53.929s |         148.640s |            147.152s |
+| `27304748140` | build | `835339f9` |                 0.093s |                  0.041s |           0.000s |              0.000s |
+| `27305863277` | test  | `32b6919b` |               117.647s |                 13.958s |         116.066s |             78.168s |
+
+Top actions by profile duration:
+
+| run           | role | child      | slowest actions                                                                                                                                                                                        |
+| ------------- | ---- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `27302927129` | test | `807b8b62` | 55.16s `Testing //devinfra/claude/claude_hook/container_e2e:test_container_e2e`; 41.98s `Testing //devinfra/claude/claude_hook:test_mailbox_delivery_e2e`                                              |
+| `27303834911` | test | `b479e30b` | 50.04s `Testing //devinfra/claude/claude_hook/container_e2e:test_container_e2e`; 41.83s `Testing //devinfra/claude/claude_hook:test_mailbox_delivery_e2e`                                              |
+| `27304748140` | test | `8f5235d5` | 118.10s `Testing //loom/gym:test_inspect_harness`; 69.96s `mypy //loom/gym:test_compare_runs`; 64.81s `Testing //devinfra/claude/claude_hook:test_mailbox_delivery_e2e`                                |
+| `27305863277` | test | `32b6919b` | 83.79s `Testing //devinfra/js/debundle:pipeline_test`; 56.97s `Compiling Rust bin runtime_tdz_on_imported_class_test`; 53.33s `Testing //devinfra/claude/claude_hook/container_e2e:test_container_e2e` |
+
+### BuildBuddy Invocation Metrics
+
+BuildBuddy `targetConfiguredCount` is high even in apparently warm runs. In this sample it is
+`21030` for the successful `//...` test/build children and `21162` for the failing PR head.
+Interpret this as the configured graph size/result count, not direct evidence that those
+targets were recomputed from scratch. The stronger recomputation indicators are:
+
+- console `discarding analysis cache` warnings;
+- package/target progress lines showing newly loaded/configured targets;
+- profile time before first action;
+- profile spans for target-pattern evaluation / package loading / non-action Skyframe work.
+
+For these CI samples, GitHub logs did not contain `discarding analysis cache`; progress lines
+showed `0-3 packages loaded` and `0 targets configured`; actions began within 0.25-0.75s after
+the combined load/analyze/execute marker.
+
+| run           | role  | child      | command | duration | `actionCount` | `targetConfiguredCount` |
+| ------------- | ----- | ---------- | ------- | -------: | ------------: | ----------------------: |
+| `27302927129` | test  | `807b8b62` | test    |    66.5s |            33 |                   21030 |
+| `27302927129` | build | `a319a101` | build   |     9.1s |             1 |                   21030 |
+| `27303834911` | test  | `b479e30b` | test    |    62.4s |           272 |                   21030 |
+| `27303834911` | build | `c1ee99c2` | build   |     8.8s |             1 |                   21030 |
+| `27304748140` | test  | `8f5235d5` | test    |   157.3s |         16156 |                   21030 |
+| `27304748140` | build | `835339f9` | build   |     7.3s |             2 |                   21030 |
+| `27305863277` | test  | `32b6919b` | test    |   124.5s |           656 |                   21162 |
+
+### Local Validation Caveat
+
+While validating the new `bbapi tool-log` command locally:
+
+- first local `bazelisk build //devinfra/buildbuddy_cli:bbapi --config=rbe` analyzed
+  `1036 packages loaded, 42027 targets configured` and took 340s wall time;
+- the immediate rebuild analyzed `0 packages loaded, 0 targets configured` and took 14s;
+- then `bazelisk test //devinfra/buildbuddy_cli:bbapi_test --config=rbe` printed
+  `WARNING: Build option --test_env has changed, discarding analysis cache` and configured
+  `41904 targets`.
+
+This confirms two things:
+
+- a real analysis-cache invalidation is visibly different in logs;
+- package count alone is not enough; a run can show few packages loaded while still
+  reconfiguring many targets if options invalidate analysis.
+
+That invalidation appeared in the local `bazelisk` sequence, not in the sampled CI `bb remote`
+logs.
+
+## Current Read
+
+The prior runner-recycle analysis is right about the outer runner state for the sampled CI
+window: the logs show warm runner workspaces (`Syncing existing repo...`). It overreaches if
+it treats that header alone as proof that the inner Bazel analysis cache survived.
+
+For the sampled CI runs, the inner Bazel evidence points mostly toward analysis cache reuse:
+
+- no `discarding analysis cache` warnings;
+- `0-3 packages loaded`, `0 targets configured` in CI console progress;
+- actions begin within <1s after the load/analyze marker;
+- the second `bazel build //...` child in the same runner is consistently tiny.
+
+The residual time the user noticed is real, but in these samples it is primarily:
+
+- 2.4-4.2s of file-diff / dirty-key scanning before target-pattern evaluation;
+- remote action cache checking for thousands of actions in the large PR sample;
+- a small number of long remote executions/tests/mypy actions.
+
+This does not rule out occasional cold runner or analysis-cache-loss cases. It does mean the
+specific recent sampled CI jobs do not support the hypothesis that CI is broadly losing the
+Bazel analysis cache across Firecracker snapshot reuse.
+
+## Instrumentation Added On This Branch
+
+`.github/workflows/bazel-ci.yml` now logs `CI_VM_PROBE ...` lines from inside the `bb remote`
+runner script:
+
+- before the first Bazel command;
+- after `bazel test`;
+- after `bazel build`.
+
+The probe records timestamp, hostname, `boot_id`, uptime, cwd, commit, previous marker contents,
+and currently-running Bazel/Blaze processes. It writes a marker to
+`/home/buildbuddy/workspace/.ducktape-ci-vm-recycle-marker`, outside the git-cleaned repo.
+
+Positive recycle signal to look for on a later CI run:
+
+- `CI_VM_PROBE previous_marker ...` from an earlier run before the first Bazel command; and
+- a pre-existing Bazel/Blaze JVM in `CI_VM_PROBE bazel_process ...` before the first Bazel
+  command.
+
+`boot_id` is logged but should not be used as the decisive signal; prior Firecracker notes say
+it can change on snapshot restore.
+
+## Commands / Artifacts
+
+Downloaded profiles live outside the repo at `/tmp/ci-firecracker-profiles`.
+
+Useful commands:
+
+```bash
+bbapi tool-log list 8f5235d5-3a5a-433d-883c-62cee7ac3409
+bbapi tool-log cat 8f5235d5-3a5a-433d-883c-62cee7ac3409 "critical path"
+bbapi tool-log download 46e65377-9b48-4585-aa72-08781e421abe command.profile.gz --all -o /tmp/ci-firecracker-profiles/27304748140
+```
+
+Validation performed:
+
+```bash
+bazelisk build //devinfra/buildbuddy_cli:bbapi --config=rbe --remote_download_outputs=toplevel
+bazelisk test //devinfra/buildbuddy_cli:bbapi_test --config=rbe
+```

--- a/devinfra/buildbuddy_cli/BUILD.bazel
+++ b/devinfra/buildbuddy_cli/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "cmd_execution.go",
         "cmd_invocation.go",
         "cmd_target.go",
+        "cmd_tool_log.go",
         "cmd_trend.go",
         "cmd_workflow.go",
         "git.go",

--- a/devinfra/buildbuddy_cli/cmd_tool_log.go
+++ b/devinfra/buildbuddy_cli/cmd_tool_log.go
@@ -1,0 +1,344 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	bespb "github.com/buildbuddy-io/buildbuddy/proto/build_event_stream"
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+type toolLog struct {
+	InvocationID string `json:"invocation_id"`
+	Name         string `json:"name"`
+	URI          string `json:"uri"`
+	Source       string `json:"source"`
+	SizeBytes    int    `json:"size_bytes,omitempty"`
+	contents     []byte
+}
+
+func toolLogCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "tool-log <invocation-id>",
+		Short: "Manage invocation-level BES build tool logs",
+		Long: `Manage Build Event Stream build tool logs for an invocation.
+
+Bazel publishes files such as command.profile.gz as build tool logs, not as
+test artifacts. Patterns containing '*' use glob matching; otherwise substring
+match against "invocation-id/name".`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			c, err := newClient()
+			if err != nil {
+				return err
+			}
+			logs, err := listToolLogsResolved(c, args[0])
+			if err != nil {
+				return err
+			}
+			return printToolLogs(logs)
+		},
+	}
+	cmd.AddCommand(toolLogListCmd())
+	cmd.AddCommand(toolLogCatCmd())
+	cmd.AddCommand(toolLogDownloadCmd())
+	return cmd
+}
+
+func toolLogListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "list <invocation-id>",
+		Aliases: []string{"ls"},
+		Short:   "List build tool logs for an invocation",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			c, err := newClient()
+			if err != nil {
+				return err
+			}
+			logs, err := listToolLogsResolved(c, args[0])
+			if err != nil {
+				return err
+			}
+			return printToolLogs(logs)
+		},
+	}
+}
+
+func toolLogCatCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "cat <invocation-id> <name-pattern>",
+		Short: "Stream a build tool log to stdout",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(_ *cobra.Command, args []string) error {
+			c, err := newClient()
+			if err != nil {
+				return err
+			}
+			logs, err := listToolLogsResolved(c, args[0])
+			if err != nil {
+				return err
+			}
+			match, err := resolveToolLog(logs, args[1])
+			if err != nil {
+				return err
+			}
+			data, err := readToolLog(c, match)
+			if err != nil {
+				return err
+			}
+			_, err = os.Stdout.Write(data)
+			return err
+		},
+	}
+}
+
+func toolLogDownloadCmd() *cobra.Command {
+	var output string
+	var all bool
+	cmd := &cobra.Command{
+		Use:   "download <invocation-id> [name-pattern]",
+		Short: "Download build tool log(s)",
+		Long: `Download Build Event Stream build tool logs.
+
+With --all and multiple child invocations, output filenames are prefixed with
+the invocation ID to avoid collisions.
+
+  bbapi tool-log download <id> command.profile.gz
+  bbapi tool-log download <runner-id> command.profile.gz --all -o profiles`,
+		Args: cobra.RangeArgs(1, 2),
+		RunE: func(_ *cobra.Command, args []string) error {
+			c, err := newClient()
+			if err != nil {
+				return err
+			}
+			logs, err := listToolLogsResolved(c, args[0])
+			if err != nil {
+				return err
+			}
+			if all {
+				matches := logs
+				if len(args) == 2 {
+					matches = filterToolLogs(logs, args[1])
+				}
+				if len(matches) == 0 {
+					if len(args) == 2 {
+						return fmt.Errorf("no tool logs matching %q", args[1])
+					}
+					return fmt.Errorf("no tool logs found")
+				}
+				return downloadAllToolLogs(c, matches, output)
+			}
+			if len(args) != 2 {
+				return fmt.Errorf("requires a name-pattern (or use --all with no pattern)")
+			}
+			match, err := resolveToolLog(logs, args[1])
+			if err != nil {
+				return err
+			}
+			if output == "" {
+				output = filepath.Base(match.Name)
+			}
+			return saveToolLog(c, match, output)
+		},
+	}
+	cmd.Flags().StringVarP(&output, "output", "o", "", "output directory for --all, or file path for single download")
+	cmd.Flags().BoolVar(&all, "all", false, "download all matching logs (default: first match only)")
+	return cmd
+}
+
+func printToolLogs(logs []toolLog) error {
+	if jsonOutput {
+		b, err := json.MarshalIndent(logs, "", "  ")
+		if err != nil {
+			return err
+		}
+		os.Stdout.Write(b)
+		fmt.Println()
+		return nil
+	}
+	t := newTable()
+	t.header("INVOCATION", "NAME", "SOURCE", "SIZE")
+	for _, l := range logs {
+		size := ""
+		if l.SizeBytes > 0 {
+			size = fmt.Sprintf("%d", l.SizeBytes)
+		}
+		t.row(l.InvocationID, l.Name, l.Source, size)
+	}
+	t.flush()
+	return nil
+}
+
+func (l toolLog) matchKey() string {
+	return l.InvocationID + "/" + l.Name
+}
+
+func resolveToolLog(logs []toolLog, pattern string) (toolLog, error) {
+	matches := filterToolLogs(logs, pattern)
+	if len(matches) == 0 {
+		fmt.Fprintf(os.Stderr, "No build tool logs matching %q\n", pattern)
+		if len(logs) > 0 {
+			fmt.Fprintf(os.Stderr, "\nAvailable tool logs:\n")
+			for _, l := range logs {
+				fmt.Fprintf(os.Stderr, "  %s  %s\n", l.InvocationID, l.Name)
+			}
+		}
+		return toolLog{}, fmt.Errorf("no build tool logs matching %q", pattern)
+	}
+	if len(matches) > 1 {
+		fmt.Fprintf(os.Stderr, "Multiple build tool logs match %q:\n", pattern)
+		for _, l := range matches {
+			fmt.Fprintf(os.Stderr, "  %s  %s\n", l.InvocationID, l.Name)
+		}
+		fmt.Fprintf(os.Stderr, "Using first match: %s %s\n", matches[0].InvocationID, matches[0].Name)
+	}
+	return matches[0], nil
+}
+
+func filterToolLogs(logs []toolLog, pattern string) []toolLog {
+	var matches []toolLog
+	if strings.Contains(pattern, "*") {
+		for _, l := range logs {
+			if matchGlob(pattern, l.matchKey()) || matchGlob(pattern, l.Name) {
+				matches = append(matches, l)
+			}
+		}
+		return matches
+	}
+	for _, l := range logs {
+		if strings.Contains(l.matchKey(), pattern) || strings.Contains(l.Name, pattern) {
+			matches = append(matches, l)
+		}
+	}
+	return matches
+}
+
+func listToolLogsResolved(c *client, invocationID string) ([]toolLog, error) {
+	ids, err := resolveInvocationIDs(c, invocationID)
+	if err != nil {
+		return nil, err
+	}
+	var all []toolLog
+	for _, id := range ids {
+		logs, err := listToolLogs(c, id)
+		if err != nil {
+			return nil, fmt.Errorf("list tool logs for %s: %w", id, err)
+		}
+		all = append(all, logs...)
+	}
+	return all, nil
+}
+
+func listToolLogs(c *client, invocationID string) ([]toolLog, error) {
+	besURL := fmt.Sprintf("%s/file/download?invocation_id=%s&artifact=raw_json",
+		c.baseURL, url.QueryEscape(invocationID))
+	data, err := c.fetchURL(besURL)
+	if err != nil {
+		return nil, fmt.Errorf("fetch BES event stream: %w", err)
+	}
+	var rawEvents []json.RawMessage
+	if err := json.Unmarshal(data, &rawEvents); err != nil {
+		return nil, fmt.Errorf("parse BES event stream: %w", err)
+	}
+	var result []toolLog
+	for _, raw := range rawEvents {
+		var ev bespb.BuildEvent
+		if err := protojson.Unmarshal(raw, &ev); err != nil {
+			return nil, fmt.Errorf("parse BES event: %w", err)
+		}
+		logs := ev.GetBuildToolLogs()
+		if logs == nil {
+			continue
+		}
+		for _, f := range logs.GetLog() {
+			contents := f.GetContents()
+			source, size := toolLogSourceAndSize(f.GetUri(), contents)
+			result = append(result, toolLog{
+				InvocationID: invocationID,
+				Name:         f.GetName(),
+				URI:          f.GetUri(),
+				Source:       source,
+				SizeBytes:    size,
+				contents:     contents,
+			})
+		}
+	}
+	return result, nil
+}
+
+func downloadAllToolLogs(c *client, logs []toolLog, dir string) error {
+	if dir == "" {
+		dir = "."
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create output directory: %w", err)
+	}
+	var failures []string
+	for _, l := range logs {
+		dest := filepath.Join(dir, l.InvocationID+"-"+filepath.Base(l.Name))
+		if err := saveToolLog(c, l, dest); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to download %s %s: %v\n", l.InvocationID, l.Name, err)
+			failures = append(failures, l.InvocationID+"/"+l.Name)
+		}
+	}
+	if len(failures) > 0 {
+		return fmt.Errorf("failed to download %d build tool log(s): %s", len(failures), strings.Join(failures, ", "))
+	}
+	return nil
+}
+
+func saveToolLog(c *client, l toolLog, dest string) error {
+	data, err := readToolLog(c, l)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(dest, data, 0o644); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "Downloaded to %s (%d bytes)\n", dest, len(data))
+	return nil
+}
+
+func readToolLog(c *client, l toolLog) ([]byte, error) {
+	if l.URI != "" {
+		return fetchBytestream(c, l.URI)
+	}
+	if len(l.contents) > 0 {
+		return l.contents, nil
+	}
+	return nil, fmt.Errorf("build tool log %q has neither URI nor inline contents", l.Name)
+}
+
+func fetchBytestream(c *client, uri string) ([]byte, error) {
+	downloadURL := fmt.Sprintf("%s/file/download?bytestream_url=%s", c.baseURL, url.QueryEscape(uri))
+	return c.fetchURL(downloadURL)
+}
+
+func toolLogSourceAndSize(uri string, contents []byte) (string, int) {
+	if uri != "" {
+		return "bytestream", bytestreamSize(uri)
+	}
+	if len(contents) > 0 {
+		return "inline", len(contents)
+	}
+	return "empty", 0
+}
+
+func bytestreamSize(uri string) int {
+	i := strings.LastIndex(uri, "/")
+	if i == -1 || i == len(uri)-1 {
+		return 0
+	}
+	size, err := strconv.Atoi(uri[i+1:])
+	if err != nil {
+		return 0
+	}
+	return size
+}

--- a/devinfra/buildbuddy_cli/helpers_test.go
+++ b/devinfra/buildbuddy_cli/helpers_test.go
@@ -60,6 +60,87 @@ func TestFilterArtifacts(t *testing.T) {
 	}
 }
 
+func TestFilterToolLogs(t *testing.T) {
+	logs := []toolLog{
+		{InvocationID: "inv-test", Name: "elapsed time"},
+		{InvocationID: "inv-test", Name: "command.profile.gz"},
+		{InvocationID: "inv-build", Name: "command.profile.gz"},
+	}
+	tests := []struct {
+		pattern string
+		want    int
+	}{
+		{"command.profile.gz", 2},
+		{"inv-test/command.profile.gz", 1},
+		{"inv-*/command.profile.gz", 2},
+		{"elapsed", 1},
+		{"missing", 0},
+	}
+	for _, tt := range tests {
+		matches := filterToolLogs(logs, tt.pattern)
+		if len(matches) != tt.want {
+			t.Errorf("filterToolLogs(%q) = %d matches, want %d", tt.pattern, len(matches), tt.want)
+		}
+	}
+}
+
+func TestReadToolLogInline(t *testing.T) {
+	got, err := readToolLog(nil, toolLog{Name: "elapsed time", contents: []byte("12.300000")})
+	if err != nil {
+		t.Fatalf("readToolLog inline returned error: %v", err)
+	}
+	if string(got) != "12.300000" {
+		t.Fatalf("readToolLog inline = %q, want %q", got, "12.300000")
+	}
+
+	_, err = readToolLog(nil, toolLog{Name: "empty"})
+	if err == nil {
+		t.Fatal("readToolLog empty expected error")
+	}
+}
+
+func TestToolLogSourceAndSize(t *testing.T) {
+	tests := []struct {
+		name       string
+		uri        string
+		contents   []byte
+		wantSource string
+		wantSize   int
+	}{
+		{
+			name:       "inline",
+			contents:   []byte("critical path"),
+			wantSource: "inline",
+			wantSize:   13,
+		},
+		{
+			name:       "bytestream with size",
+			uri:        "bytestream://remote.buildbuddy.io/blobs/abc/3232454",
+			wantSource: "bytestream",
+			wantSize:   3232454,
+		},
+		{
+			name:       "bytestream malformed size",
+			uri:        "bytestream://remote.buildbuddy.io/blobs/abc/not-a-size",
+			wantSource: "bytestream",
+			wantSize:   0,
+		},
+		{
+			name:       "empty",
+			wantSource: "empty",
+			wantSize:   0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotSource, gotSize := toolLogSourceAndSize(tt.uri, tt.contents)
+			if gotSource != tt.wantSource || gotSize != tt.wantSize {
+				t.Fatalf("toolLogSourceAndSize() = (%q, %d), want (%q, %d)", gotSource, gotSize, tt.wantSource, tt.wantSize)
+			}
+		})
+	}
+}
+
 func TestNormalizeGitURL(t *testing.T) {
 	tests := []struct {
 		name string

--- a/devinfra/buildbuddy_cli/main.go
+++ b/devinfra/buildbuddy_cli/main.go
@@ -34,6 +34,7 @@ Full service definition:
 	root.AddCommand(executionCmd())
 	root.AddCommand(cacheCmd())
 	root.AddCommand(artifactCmd())
+	root.AddCommand(toolLogCmd())
 	root.AddCommand(trendCmd())
 	root.AddCommand(workflowCmd())
 	root.AddCommand(askCmd())

--- a/devinfra/ci/BUILD.bazel
+++ b/devinfra/ci/BUILD.bazel
@@ -69,6 +69,12 @@ py_library(
     visibility = ["//:__subpackages__"],
 )
 
+py_library(
+    name = "bb_runner_probe",
+    srcs = ["bb_runner_probe.py"],
+    visibility = ["//:__subpackages__"],
+)
+
 # === Binaries ===
 
 py_binary(
@@ -89,11 +95,26 @@ py_binary(
     deps = [":release_metadata"],
 )
 
+py_binary(
+    name = "bb_runner_probe_bin",
+    main_module = "devinfra.ci.bb_runner_probe",
+    deps = [":bb_runner_probe"],
+)
+
 py_test(
     name = "test_release_metadata",
     srcs = ["test_release_metadata.py"],
     deps = [
         ":release_metadata",
+        "@pypi//pytest_bazel",
+    ],
+)
+
+py_test(
+    name = "test_bb_runner_probe",
+    srcs = ["test_bb_runner_probe.py"],
+    deps = [
+        ":bb_runner_probe",
         "@pypi//pytest_bazel",
     ],
 )

--- a/devinfra/ci/bb_runner_probe.py
+++ b/devinfra/ci/bb_runner_probe.py
@@ -1,0 +1,534 @@
+"""Structured probe for BuildBuddy `bb remote` runner reuse.
+
+This script runs inside the BuildBuddy runner VM. It records explicit,
+non-secret data into a persistent probe directory so a later recycled VM can
+read the previous run's local probe logs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as dt
+import hashlib
+import json
+import os
+import shutil
+import socket
+import subprocess
+import tarfile
+import time
+from pathlib import Path
+from typing import Any
+
+SCHEMA = "ducktape.bb_runner_probe.v1"
+DEFAULT_DIR = Path(os.environ.get("CI_VM_PROBE_DIR", "/home/buildbuddy/workspace/.ducktape-ci-vm-probe"))
+SAFE_ENV_KEYS = ("BUILD_WORKSPACE_DIRECTORY", "GIT_REPO_DEFAULT_BRANCH", "HOME", "PWD", "RBE_IMAGE", "USER")
+PATHS_TO_STAT = (
+    "/home/buildbuddy/workspace",
+    "/home/buildbuddy/workspace/repo-root",
+    "/home/buildbuddy/workspace/output-base",
+    "/home/buildbuddy/workspace/output-base/server",
+)
+PROC_GLOBAL_FILES = (
+    (Path("/proc/sys/kernel/random/boot_id"), "global/boot_id"),
+    (Path("/proc/uptime"), "global/uptime"),
+    (Path("/proc/stat"), "global/stat"),
+    (Path("/proc/meminfo"), "global/meminfo"),
+    (Path("/proc/self/cgroup"), "global/self_cgroup"),
+    (Path("/proc/self/mountinfo"), "global/self_mountinfo"),
+)
+PROC_PROCESS_FILES = ("cmdline", "stat", "status", "statm", "io", "cgroup", "limits", "schedstat")
+
+
+@dataclasses.dataclass(frozen=True)
+class ProbePaths:
+    root: Path
+    current: Path
+    latest: Path
+    probes_jsonl: Path
+    archive: Path
+    latest_jsonl: Path
+
+
+@dataclasses.dataclass(frozen=True)
+class CommandResult:
+    argv: list[str]
+    returncode: int | None
+    stdout: str
+    stderr: str
+    error: str | None = None
+
+
+def probe_paths(root: Path) -> ProbePaths:
+    current = root / "current"
+    latest = root / "latest"
+    return ProbePaths(
+        root=root,
+        current=current,
+        latest=latest,
+        probes_jsonl=current / "probes.jsonl",
+        archive=current / "probe.tgz",
+        latest_jsonl=latest / "probes.jsonl",
+    )
+
+
+def iso_now() -> str:
+    return dt.datetime.now(dt.UTC).isoformat()
+
+
+def read_text(path: Path, *, max_bytes: int = 1_000_000) -> str | None:
+    try:
+        with path.open("rb") as f:
+            return f.read(max_bytes).decode("utf-8", errors="replace").strip()
+    except OSError:
+        return None
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        while chunk := f.read(1024 * 1024):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def parse_float(value: str | None) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value.split()[0])
+    except (IndexError, ValueError):
+        return None
+
+
+def run_command(argv: list[str], *, timeout: float = 2.0) -> CommandResult:
+    try:
+        proc = subprocess.run(argv, check=False, text=True, capture_output=True, timeout=timeout)
+    except Exception as e:
+        return CommandResult(argv=argv, returncode=None, stdout="", stderr="", error=repr(e))
+    return CommandResult(argv=argv, returncode=proc.returncode, stdout=proc.stdout.strip(), stderr=proc.stderr.strip())
+
+
+def command_json(result: CommandResult) -> dict[str, Any]:
+    return dataclasses.asdict(result)
+
+
+def safe_env() -> dict[str, str]:
+    return {k: os.environ[k] for k in SAFE_ENV_KEYS if k in os.environ}
+
+
+def path_stat(path: Path) -> dict[str, Any]:
+    try:
+        st = path.stat()
+    except OSError as e:
+        return {"path": str(path), "exists": False, "error": repr(e)}
+    return {
+        "path": str(path),
+        "exists": True,
+        "mode": oct(st.st_mode),
+        "inode": st.st_ino,
+        "dev": st.st_dev,
+        "size": st.st_size,
+        "mtime": st.st_mtime,
+        "ctime": st.st_ctime,
+        "is_dir": path.is_dir(),
+        "is_file": path.is_file(),
+    }
+
+
+def safe_path_component(value: str) -> str:
+    return "".join(c if c.isalnum() or c in ("-", "_", ".") else "_" for c in value)
+
+
+def parse_proc_stat(text: str) -> dict[str, Any]:
+    # Raw procfs files are archived separately. This parser is only for the
+    # compact log summary fields that make CI output scannable.
+    # /proc/<pid>/stat is: pid (comm with spaces) state ppid ... starttime ...
+    close = text.rfind(")")
+    if close == -1:
+        return {}
+    prefix = text[: close + 1]
+    rest = text[close + 2 :].split()
+    if len(rest) < 20:
+        return {}
+    return {
+        "pid": int(prefix.split(" ", 1)[0]),
+        "comm": prefix.split(" ", 1)[1][1:-1],
+        "state": rest[0],
+        "ppid": int(rest[1]),
+        "start_ticks": int(rest[19]),
+    }
+
+
+def proc_btime() -> int | None:
+    text = read_text(Path("/proc/stat"))
+    if text is None:
+        return None
+    for line in text.splitlines():
+        if line.startswith("btime "):
+            try:
+                return int(line.split()[1])
+            except (IndexError, ValueError):
+                return None
+    return None
+
+
+def is_bazel_server_argv(argv: list[str]) -> bool:
+    joined = "\0".join(argv)
+    return "A-server.jar" in joined or any(arg.startswith("bazel(") for arg in argv)
+
+
+def process_info(pid_dir: Path, *, boot_time: int | None, ticks_per_second: int) -> dict[str, Any] | None:
+    if not pid_dir.name.isdigit():
+        return None
+    cmdline_raw = read_text(pid_dir / "cmdline", max_bytes=256_000)
+    if not cmdline_raw:
+        return None
+    argv = [part for part in cmdline_raw.split("\x00") if part]
+    if not is_bazel_server_argv(argv):
+        return None
+
+    stat = parse_proc_stat(read_text(pid_dir / "stat") or "")
+    start_time = None
+    age_seconds = None
+    if boot_time is not None and stat.get("start_ticks") is not None:
+        start_epoch = boot_time + (stat["start_ticks"] / ticks_per_second)
+        start_time = dt.datetime.fromtimestamp(start_epoch, dt.UTC).isoformat()
+        age_seconds = max(0.0, time.time() - start_epoch)
+
+    try:
+        cwd = str((pid_dir / "cwd").readlink())
+    except OSError:
+        cwd = None
+
+    return {
+        "pid": int(pid_dir.name),
+        "argv": argv,
+        "cmdline_sha256": hashlib.sha256(cmdline_raw.encode()).hexdigest(),
+        "stat": stat,
+        "start_time": start_time,
+        "age_seconds": age_seconds,
+        "cwd": cwd,
+    }
+
+
+def bazel_servers() -> list[dict[str, Any]]:
+    boot_time = proc_btime()
+    ticks = os.sysconf(os.sysconf_names["SC_CLK_TCK"])
+    result = []
+    for pid_dir in Path("/proc").iterdir():
+        try:
+            info = process_info(pid_dir, boot_time=boot_time, ticks_per_second=ticks)
+        except OSError:
+            continue
+        if info is not None:
+            result.append(info)
+    return sorted(result, key=lambda p: p["pid"])
+
+
+def capture_bytes(src: Path, dest: Path, *, max_bytes: int = 2_000_000) -> dict[str, Any]:
+    rel = str(dest)
+    try:
+        with src.open("rb") as f:
+            data = f.read(max_bytes + 1)
+    except OSError as e:
+        return {"source": str(src), "path": rel, "exists": False, "error": repr(e)}
+    truncated = len(data) > max_bytes
+    data = data[:max_bytes]
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(data)
+    return {
+        "source": str(src),
+        "path": rel,
+        "exists": True,
+        "size": len(data),
+        "sha256": sha256_bytes(data),
+        "truncated": truncated,
+    }
+
+
+def capture_symlink(src: Path, dest: Path) -> dict[str, Any]:
+    try:
+        target = str(src.readlink())
+    except OSError as e:
+        return {"source": str(src), "path": str(dest), "exists": False, "error": repr(e)}
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(target + "\n")
+    return {
+        "source": str(src),
+        "path": str(dest),
+        "exists": True,
+        "target": target,
+        "size": dest.stat().st_size,
+        "sha256": sha256_file(dest),
+    }
+
+
+def capture_proc_snapshot(paths: ProbePaths, phase: str, servers: list[dict[str, Any]]) -> dict[str, Any]:
+    root = paths.current / "proc" / safe_path_component(phase)
+    files = []
+    for src, rel in PROC_GLOBAL_FILES:
+        files.append(capture_bytes(src, root / rel))
+    processes = []
+    for server in servers:
+        pid = str(server["pid"])
+        proc_dir = Path("/proc") / pid
+        dest_dir = root / "bazel_servers" / pid
+        proc_files = [capture_bytes(proc_dir / name, dest_dir / name) for name in PROC_PROCESS_FILES]
+        proc_files.append(capture_symlink(proc_dir / "cwd", dest_dir / "cwd.txt"))
+        proc_files.append(capture_symlink(proc_dir / "exe", dest_dir / "exe.txt"))
+        processes.append({"pid": server["pid"], "files": proc_files})
+    return {"root": str(root), "global_files": files, "processes": processes}
+
+
+def summarize_jsonl(path: Path, *, tail: int = 5, max_bytes: int = 5_000_000) -> dict[str, Any]:
+    if not path.exists():
+        return {"exists": False, "path": str(path)}
+    data = path.read_bytes()
+    truncated = False
+    if len(data) > max_bytes:
+        data = data[-max_bytes:]
+        truncated = True
+    entries = []
+    for line in data.decode("utf-8", errors="replace").splitlines():
+        try:
+            entries.append(json.loads(line))
+        except json.JSONDecodeError:
+            entries.append({"raw": line})
+    phases = [entry.get("phase") for entry in entries if isinstance(entry, dict)]
+    last = entries[-1] if entries else None
+    tail_summaries = []
+    for entry in entries[-tail:]:
+        if not isinstance(entry, dict):
+            tail_summaries.append({"raw": entry.get("raw") if isinstance(entry, dict) else str(entry)})
+            continue
+        tail_summaries.append(
+            {
+                "phase": entry.get("phase"),
+                "timestamp": entry.get("timestamp"),
+                "boot_id": entry.get("boot_id"),
+                "uptime_seconds": entry.get("uptime_seconds"),
+                "bazel_servers": [
+                    {
+                        "pid": p.get("pid"),
+                        "start_time": p.get("start_time"),
+                        "age_seconds": p.get("age_seconds"),
+                        "cmdline_sha256": p.get("cmdline_sha256"),
+                    }
+                    for p in entry.get("bazel_servers", [])
+                ],
+                "git_head": entry.get("git", {}).get("head", {}).get("stdout"),
+            }
+        )
+    return {
+        "exists": True,
+        "path": str(path),
+        "size": path.stat().st_size,
+        "sha256": sha256_file(path),
+        "truncated": truncated,
+        "entry_count_in_sample": len(entries),
+        "phases_in_sample": phases,
+        "first_timestamp_in_sample": entries[0].get("timestamp") if entries else None,
+        "last_timestamp_in_sample": last.get("timestamp") if isinstance(last, dict) else None,
+        "last_phase": last.get("phase") if isinstance(last, dict) else None,
+        "last_bazel_servers": [
+            {
+                "pid": p.get("pid"),
+                "start_time": p.get("start_time"),
+                "age_seconds": p.get("age_seconds"),
+                "cmdline_sha256": p.get("cmdline_sha256"),
+            }
+            for p in (last or {}).get("bazel_servers", [])
+        ]
+        if isinstance(last, dict)
+        else [],
+        "tail_summaries": tail_summaries,
+    }
+
+
+def prepare_current(paths: ProbePaths, phase: str) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    previous_run_log = summarize_jsonl(paths.latest_jsonl)
+    stale_current = None
+    if phase == "before-test":
+        current = summarize_jsonl(paths.probes_jsonl)
+        if current.get("exists") and current.get("sha256") != previous_run_log.get("sha256"):
+            stale_current = current
+        shutil.rmtree(paths.current, ignore_errors=True)
+    paths.current.mkdir(parents=True, exist_ok=True)
+    return previous_run_log, stale_current
+
+
+def snapshot(
+    phase: str, paths: ProbePaths, previous_run_log: dict[str, Any], stale_current: dict[str, Any] | None
+) -> dict[str, Any]:
+    uname = os.uname()
+    git = {
+        "head": run_command(["git", "rev-parse", "HEAD"]),
+        "branch": run_command(["git", "branch", "--show-current"]),
+        "status": run_command(["git", "status", "--short", "--branch"], timeout=5.0),
+        "last_commit": run_command(["git", "log", "-1", "--format=%H%x00%P%x00%ct%x00%s"]),
+    }
+    servers = bazel_servers()
+    proc_snapshot = capture_proc_snapshot(paths, phase, servers)
+    return {
+        "schema": SCHEMA,
+        "phase": phase,
+        "timestamp": iso_now(),
+        "hostname": socket.gethostname(),
+        "uname": {
+            "sysname": uname.sysname,
+            "nodename": uname.nodename,
+            "release": uname.release,
+            "version": uname.version,
+            "machine": uname.machine,
+        },
+        "cwd": str(Path.cwd()),
+        "probe_dir": str(paths.root),
+        "env": safe_env(),
+        "boot_id": read_text(Path("/proc/sys/kernel/random/boot_id")),
+        "uptime_seconds": parse_float(read_text(Path("/proc/uptime"))),
+        "previous_run_log": previous_run_log,
+        "stale_current_log": stale_current,
+        "paths": [path_stat(Path(p)) for p in PATHS_TO_STAT]
+        + [
+            path_stat(paths.root),
+            path_stat(paths.current),
+            path_stat(paths.latest),
+            path_stat(paths.probes_jsonl),
+            path_stat(paths.latest_jsonl),
+        ],
+        "git": git,
+        "bazel_servers": servers,
+        "proc_snapshot": proc_snapshot,
+    }
+
+
+def snapshot_for_json(data: dict[str, Any]) -> dict[str, Any]:
+    out = dict(data)
+    out["git"] = {k: command_json(v) for k, v in data["git"].items()}
+    return out
+
+
+def append_snapshot(out: Path, data: dict[str, Any]) -> None:
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with out.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(snapshot_for_json(data), sort_keys=True) + "\n")
+
+
+def print_summary(data: dict[str, Any], out: Path) -> None:
+    previous = data["previous_run_log"].get("exists", False)
+    stale = bool((data.get("stale_current_log") or {}).get("exists"))
+    print(
+        "CI_VM_PROBE_SUMMARY "
+        f"phase={data['phase']} "
+        f"out={out} "
+        f"previous_run_log={'yes' if previous else 'no'} "
+        f"stale_current_log={'yes' if stale else 'no'} "
+        f"bazel_servers={len(data['bazel_servers'])} "
+        f"boot_id={data.get('boot_id')} "
+        f"uptime={data.get('uptime_seconds')}"
+    )
+    for proc in data["bazel_servers"]:
+        print(
+            "CI_VM_PROBE_SERVER "
+            f"pid={proc['pid']} age={proc.get('age_seconds', 0):.1f}s "
+            f"start={proc.get('start_time')} sha256={proc['cmdline_sha256']}"
+        )
+
+
+def cmd_snapshot(args: argparse.Namespace) -> int:
+    paths = probe_paths(Path(args.dir))
+    previous_run_log, stale_current = prepare_current(paths, args.phase)
+    data = snapshot(args.phase, paths, previous_run_log, stale_current)
+    append_snapshot(paths.probes_jsonl, data)
+    print_summary(data, paths.probes_jsonl)
+    return 0
+
+
+def make_archive(paths: ProbePaths) -> dict[str, Any]:
+    paths.current.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "schema": SCHEMA,
+        "timestamp": iso_now(),
+        "probe_dir": str(paths.root),
+        "probes_jsonl": str(paths.probes_jsonl),
+        "probes_jsonl_exists": paths.probes_jsonl.exists(),
+    }
+    manifest_path = paths.current / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, sort_keys=True, indent=2) + "\n")
+    with tarfile.open(paths.archive, "w:gz") as tar:
+        if paths.probes_jsonl.exists():
+            tar.add(paths.probes_jsonl, arcname="probes.jsonl")
+        proc_dir = paths.current / "proc"
+        if proc_dir.exists():
+            tar.add(proc_dir, arcname="proc")
+        if paths.latest_jsonl.exists():
+            tar.add(paths.latest_jsonl, arcname="previous/probes.jsonl")
+        previous_proc_dir = paths.latest / "proc"
+        if previous_proc_dir.exists():
+            tar.add(previous_proc_dir, arcname="previous/proc")
+        tar.add(manifest_path, arcname="manifest.json")
+    return {"path": str(paths.archive), "size": paths.archive.stat().st_size, "sha256": sha256_file(paths.archive)}
+
+
+def persist_latest(paths: ProbePaths) -> None:
+    tmp = paths.root / "latest.tmp"
+    shutil.rmtree(tmp, ignore_errors=True)
+    shutil.copytree(paths.current, tmp)
+    shutil.rmtree(paths.latest, ignore_errors=True)
+    tmp.rename(paths.latest)
+
+
+def upload_archive(archive: Path) -> dict[str, Any]:
+    bb = shutil.which("bb")
+    if bb is None:
+        return {"attempted": False, "reason": "bb not found on PATH"}
+    result = run_command([bb, "upload", str(archive)], timeout=30.0)
+    return {"attempted": True, "result": command_json(result)}
+
+
+def cmd_finalize(args: argparse.Namespace) -> int:
+    paths = probe_paths(Path(args.dir))
+    archive_info = make_archive(paths)
+    persist_latest(paths)
+    print(
+        f"CI_VM_PROBE_ARCHIVE path={archive_info['path']} size={archive_info['size']} sha256={archive_info['sha256']}"
+    )
+    if args.upload:
+        upload = upload_archive(paths.archive)
+        if upload.get("attempted") and upload["result"]["returncode"] == 0:
+            digest = upload["result"]["stdout"].splitlines()[-1] if upload["result"]["stdout"] else ""
+            print(f"CI_VM_PROBE_CAS digest={digest}")
+        else:
+            print(f"CI_VM_PROBE_CAS unavailable={json.dumps(upload, sort_keys=True)}")
+    return 0
+
+
+def parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser()
+    sub = p.add_subparsers(required=True)
+
+    snap = sub.add_parser("snapshot")
+    snap.add_argument("phase")
+    snap.add_argument("--dir", default=str(DEFAULT_DIR))
+    snap.set_defaults(func=cmd_snapshot)
+
+    final = sub.add_parser("finalize")
+    final.add_argument("--dir", default=str(DEFAULT_DIR))
+    final.add_argument("--upload", action="store_true")
+    final.set_defaults(func=cmd_finalize)
+    return p
+
+
+def main() -> None:
+    args = parser().parse_args()
+    raise SystemExit(args.func(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/devinfra/ci/test_bb_runner_probe.py
+++ b/devinfra/ci/test_bb_runner_probe.py
@@ -1,0 +1,97 @@
+import tarfile
+from pathlib import Path
+
+import pytest_bazel
+
+from devinfra.ci import bb_runner_probe
+
+
+def test_is_bazel_server_argv() -> None:
+    assert bb_runner_probe.is_bazel_server_argv(["bazel(repo-root)", "--output_base=/tmp/out"])
+    assert bb_runner_probe.is_bazel_server_argv(["java", "-jar", "/tmp/install/A-server.jar"])
+    assert not bb_runner_probe.is_bazel_server_argv(["bash", "-c", "echo bazel(repo-root)"])
+    assert not bb_runner_probe.is_bazel_server_argv(["awk", "/[b]azel/"])
+
+
+def test_parse_proc_stat_for_summary_only() -> None:
+    parsed = bb_runner_probe.parse_proc_stat(
+        "1234 (bazel(repo-root)) S 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 424242 21"
+    )
+
+    assert parsed["pid"] == 1234
+    assert parsed["comm"] == "bazel(repo-root)"
+    assert parsed["state"] == "S"
+    assert parsed["ppid"] == 1
+    assert parsed["start_ticks"] == 424242
+
+
+def test_summarize_jsonl(tmp_path: Path) -> None:
+    probes = tmp_path / "probes.jsonl"
+
+    assert bb_runner_probe.summarize_jsonl(probes) == {"exists": False, "path": str(probes)}
+
+    probes.write_text(
+        '{"phase": "before-test", "timestamp": "2026-06-10T00:00:00+00:00", "bazel_servers": []}\n'
+        '{"phase": "after-test", "timestamp": "2026-06-10T00:01:00+00:00", '
+        '"bazel_servers": [{"pid": 123, "start_time": "t", "age_seconds": 10, "cmdline_sha256": "abc"}]}\n'
+    )
+    summary = bb_runner_probe.summarize_jsonl(probes)
+
+    assert summary["exists"] is True
+    assert summary["entry_count_in_sample"] == 2
+    assert summary["phases_in_sample"] == ["before-test", "after-test"]
+    assert summary["last_phase"] == "after-test"
+    assert summary["last_bazel_servers"] == [
+        {"pid": 123, "start_time": "t", "age_seconds": 10, "cmdline_sha256": "abc"}
+    ]
+
+
+def test_make_archive(tmp_path: Path) -> None:
+    paths = bb_runner_probe.probe_paths(tmp_path / "probe")
+    paths.current.mkdir(parents=True)
+    paths.probes_jsonl.write_text('{"phase": "before-test"}\n')
+    (paths.current / "proc" / "before-test" / "global").mkdir(parents=True)
+    (paths.current / "proc" / "before-test" / "global" / "boot_id").write_text("current-boot\n")
+    (paths.latest / "proc" / "after-build" / "global").mkdir(parents=True)
+    (paths.latest / "proc" / "after-build" / "global" / "boot_id").write_text("previous-boot\n")
+    paths.latest_jsonl.parent.mkdir(parents=True, exist_ok=True)
+    paths.latest_jsonl.write_text('{"phase": "after-build"}\n')
+
+    info = bb_runner_probe.make_archive(paths)
+
+    assert info["path"] == str(paths.archive)
+    assert info["size"] > 0
+    assert len(info["sha256"]) == 64
+    with tarfile.open(paths.archive) as tar:
+        names = set(tar.getnames())
+    assert "probes.jsonl" in names
+    assert "proc/before-test/global/boot_id" in names
+    assert "previous/probes.jsonl" in names
+    assert "previous/proc/after-build/global/boot_id" in names
+
+
+def test_capture_bytes_records_truncation_without_stat_size(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    dest = tmp_path / "dest"
+    src.write_bytes(b"abcdef")
+
+    info = bb_runner_probe.capture_bytes(src, dest, max_bytes=3)
+
+    assert info["exists"] is True
+    assert info["size"] == 3
+    assert info["truncated"] is True
+    assert dest.read_bytes() == b"abc"
+
+
+def test_persist_latest(tmp_path: Path) -> None:
+    paths = bb_runner_probe.probe_paths(tmp_path / "probe")
+    paths.current.mkdir(parents=True)
+    paths.probes_jsonl.write_text('{"phase": "after-build"}\n')
+
+    bb_runner_probe.persist_latest(paths)
+
+    assert paths.latest_jsonl.read_text() == '{"phase": "after-build"}\n'
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/skills/buildbuddy_api/SKILL.md
+++ b/skills/buildbuddy_api/SKILL.md
@@ -73,6 +73,18 @@ bbapi artifact cat <invocation-id> <name-substring>
 # override with -o/--output)
 bbapi artifact download <invocation-id> <name-substring> [-o PATH]
 
+# List invocation-level build tool logs such as Bazel command profiles
+bbapi tool-log list <invocation-id>
+
+# Stream an inline or bytestream-backed build tool log to stdout
+bbapi tool-log cat <invocation-id> "critical path"
+
+# Download a Bazel JSON profile emitted as a build tool log
+bbapi tool-log download <invocation-id> command.profile.gz [-o PATH]
+
+# Download logs from all child invocations of a workflow/runner invocation
+bbapi tool-log download <runner-invocation-id> command.profile.gz --all -o profiles/
+
 # List remote executions for an invocation
 bbapi execution <invocation-id>
 
@@ -144,6 +156,33 @@ invocation contains the actual `bazel test` results, targets, and artifacts.
 - `"compositor/test_lifecycle"` matches `//mcp_infra/compositor:test_lifecycle/test.log`
 
 When no match is found, the CLI prints available labels as hints.
+
+### Build Tool Logs vs Test Artifacts
+
+Bazel files attached to the invocation itself, such as `command.profile.gz`, are BES
+`BuildToolLogs`, not test artifacts. Use `bbapi tool-log {list,cat,download}` for these
+files. Use `bbapi artifact` only for test outputs like `test.log`, `test.xml`, and files
+under `test.outputs/`. Build tool logs can be inline (`elapsed time`, `critical path`,
+`process stats`) or bytestream-backed (`command.profile.gz`); `bbapi tool-log cat` handles
+both.
+
+For CI phase profiling, start with:
+
+```bash
+bb view <runner-or-child-invocation> --lines=200000
+bbapi invocation <runner-invocation>   # shows child invocations
+bbapi tool-log list <runner-invocation>
+bbapi tool-log cat <child-invocation> "process stats"
+bbapi tool-log download <runner-invocation> command.profile.gz --all -o profiles/
+```
+
+The runner log line `Syncing existing repo...` identifies a warm outer `bb remote` runner
+workspace, but it does not by itself prove the inner Bazel analysis cache survived. Check
+Bazel's package/configuration counts, elapsed time, `targetConfiguredCount`, and
+`command.profile.gz`. Treat `targetConfiguredCount` as the configured graph size/result
+count, not by itself proof that those configured targets were recomputed; profile markers,
+`discarding analysis cache` warnings, and time-to-first-action are better recomputation
+signals.
 
 ## Bisecting Test Failures with Target History
 


### PR DESCRIPTION
## Summary

- add `bbapi tool-log` for BES `BuildToolLogs` (`elapsed time`, `critical path`, `process stats`, `command.profile.gz`), including workflow/runner child auto-resolution
- document the CI Firecracker / Bazel analysis-cache investigation in `debug/ci_firecracker_analysis_cache_profile.md`
- replace inline runner-marker logging with `devinfra/ci/bb_runner_probe.py`, which writes structured JSONL, captures raw procfs snapshots, persists `latest/` across recycled VMs, and uploads a tarball with `bb upload`
- update the BuildBuddy API skill to distinguish BuildBuddy tool logs from test artifacts and to describe profile interpretation caveats

## Current read from sampled CI

Recent sampled CI jobs all showed warm outer runner state (`Syncing existing repo...`). Their BuildBuddy profiles showed visible wall time mostly in dirty-key scanning, remote action-cache checks, and long remote test/mypy actions, with no `discarding analysis cache` warnings.

The self-instrumented PR run complicates the older conclusion: before the first Bazel command it positively found a pre-existing Bazel server, but that same `bazel test //...` still emitted a large configured-target progress counter. So Firecracker/Bazel-process reuse is not enough to infer "no reanalysis". The next useful evidence is consecutive structured probe bundles from recycled CI VMs plus the child Bazel tool profiles.

## Validation

- `bazelisk build //devinfra/buildbuddy_cli:bbapi --config=rbe --remote_download_outputs=toplevel`
- `bazelisk test //devinfra/buildbuddy_cli:bbapi_test --config=rbe`
- `bazelisk test //devinfra/ci:test_bb_runner_probe --config=rbe`
- `nix develop -c pre-commit run --files .github/workflows/bazel-ci.yml devinfra/ci/BUILD.bazel devinfra/ci/bb_runner_probe.py devinfra/ci/test_bb_runner_probe.py devinfra/buildbuddy_cli/BUILD.bazel devinfra/buildbuddy_cli/helpers_test.go devinfra/buildbuddy_cli/main.go devinfra/buildbuddy_cli/cmd_tool_log.go skills/buildbuddy_api/SKILL.md debug/ci_firecracker_analysis_cache_profile.md`
- local probe smoke: two-cycle `snapshot`/`finalize` run confirmed the tarball includes `proc/...`, `previous/probes.jsonl`, and `previous/proc/...`
- smoke: `bbapi tool-log list 8f5235d5-3a5a-433d-883c-62cee7ac3409`