### PR TITLE
wayback-cache: agent read-only RBAC (namespace-diagnostics-reader)

### DIFF
--- a/cluster/k8s/agents/claude-rbac/permissions.md
+++ b/cluster/k8s/agents/claude-rbac/permissions.md
@@ -1,7 +1,8 @@
 **Namespace diagnostics** (`namespace-diagnostics-reader` ClusterRole bound per-namespace):
 harbor, gatus, csi-proxmox, openebs, proxmox-proxy, cnpg-system,
 nvidia-device-plugin, node-feature-discovery, local-path-storage, cert-manager, litellm,
-docker-ci, matrix, grocy-sf, grocy-vallejo, study-casino, props, tana-mcp
+docker-ci, matrix, grocy-sf, grocy-vallejo, study-casino, props, tana-mcp,
+wayback-cache
 
 **Extended read**: ollama (`rolebinding-ollama-reader.yaml` in `ollama/agent-rbac/`),
 langfuse (in `langfuse/agent-rbac/`), openclaw (in `openclaw/gateway-agent-rbac/`),

--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -297,6 +297,7 @@ resources:
 
   # --- wayback-cache ---
   - wayback-cache/flux-kustomization.yaml
+  - wayback-cache/agent-rbac/flux-kustomization.yaml
 
   # --- user-agentydragon ---
   - user-agentydragon/flux-kustomization.yaml

--- a/cluster/k8s/wayback-cache/agent-rbac/flux-kustomization.yaml
+++ b/cluster/k8s/wayback-cache/agent-rbac/flux-kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: wayback-cache-agent-rbac
+  namespace: flux-system
+  annotations:
+    description: Agent RBAC for wayback-cache namespace. Lightweight — only RoleBindings. Depends on namespace existing + claude-rbac for ClusterRoles.
+spec:
+  interval: 10m
+  path: ./cluster/k8s/wayback-cache/agent-rbac
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  dependsOn:
+    - name: wayback-cache
+    - name: claude-rbac

--- a/cluster/k8s/wayback-cache/agent-rbac/kustomization.yaml
+++ b/cluster/k8s/wayback-cache/agent-rbac/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - rolebinding-namespace-diagnostics-reader.yaml

--- a/cluster/k8s/wayback-cache/agent-rbac/rolebinding-namespace-diagnostics-reader.yaml
+++ b/cluster/k8s/wayback-cache/agent-rbac/rolebinding-namespace-diagnostics-reader.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: agent-namespace-diagnostics-reader
+  namespace: wayback-cache
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: namespace-diagnostics-reader
+subjects:
+  - kind: Group
+    name: oidc-ksbx-groups:kubectl-sandbox-users
+    apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Grants the agent group read-only access in the `wayback-cache` namespace, by binding the existing `namespace-diagnostics-reader` ClusterRole — same per-service `agent-rbac/` pattern as `docker-ci` et al.

## Why
While confirming the CDX nginx reconcile, `pods/exec` and configmap reads were forbidden in `wayback-cache` (the agent only had cluster-wide read, which covers pod *list* but not configmaps/logs in that ns). This adds the standard namespaced read-only binding so future diagnostics there work without the cluster-admin escape hatch.

## What
`cluster/k8s/wayback-cache/agent-rbac/`:
- `flux-kustomization.yaml` — independent Kustomization, `dependsOn` the `wayback-cache` namespace + `claude-rbac` (for the ClusterRole)
- `rolebinding-namespace-diagnostics-reader.yaml` — binds `namespace-diagnostics-reader` to Group `oidc-ksbx-groups:kubectl-sandbox-users` in `wayback-cache`
- `kustomization.yaml`

Plus the root `cluster/k8s/kustomization.yaml` entry and a `permissions.md` doc update.

The bound ClusterRole grants **get/list/watch only** on pods, pods/log, services, configmaps, PVCs, events, and deployments/replicasets/statefulsets — **no exec/attach, no writes, no secrets**.

Pre-commit clean (kubeconform + cluster validators pass). Takes effect on Flux reconcile after merge.

https://claude.ai/code/session_01AXSFxfCXddADoSKTjgF5Nz

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXSFxfCXddADoSKTjgF5Nz)_