### PR TITLE
Fix Tana LiteLLM proxy startup dependency

### DIFF
--- a/tana/litellm_proxy/BUILD.bazel
+++ b/tana/litellm_proxy/BUILD.bazel
@@ -7,6 +7,7 @@ LITELLM_PROXY_RUNTIME_DEPS = [
     "@pypi//aiohttp",
     "@pypi//apscheduler",
     "@pypi//backoff",
+    "@pypi//cryptography",
     "@pypi//fastapi",
     "@pypi//opentelemetry_api",
     "@pypi//opentelemetry_exporter_otlp_proto_http",
@@ -76,8 +77,10 @@ py_test(
 py_test(
     name = "test_proxy_runtime",
     srcs = ["test_proxy_runtime.py"],
+    data = [":server_bin"],
     deps = [
         ":provider",
+        "//util/bazel:runfiles",
         "@pypi//litellm",
     ] + LITELLM_PROXY_RUNTIME_DEPS,
 )

--- a/tana/litellm_proxy/test_proxy_runtime.py
+++ b/tana/litellm_proxy/test_proxy_runtime.py
@@ -1,8 +1,37 @@
 """Runtime smoke tests for the LiteLLM proxy entrypoint closure."""
 
 import importlib
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+from util.bazel.runfiles import get_required_path
 
 
 def test_litellm_proxy_server_imports() -> None:
     importlib.import_module("litellm.proxy.proxy_cli")
     importlib.import_module("litellm.proxy.proxy_server")
+
+
+def test_litellm_proxy_binary_imports_server(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        textwrap.dedent(
+            """
+            model_list: []
+            litellm_settings:
+              drop_params: true
+            """
+        )
+    )
+
+    result = subprocess.run(
+        [get_required_path("ducktape/tana/litellm_proxy/server_bin"), "--config", config_path, "--skip_server_startup"],
+        capture_output=True,
+        check=False,
+        env=os.environ | {"LITELLM_MASTER_KEY": "sk-test"},
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout


### PR DESCRIPTION
## Summary
- Add `cryptography` to the Tana LiteLLM proxy runtime closure.
- Strengthen `//tana/litellm_proxy:test_proxy_runtime` to execute the packaged `server_bin --config ... --skip_server_startup` path, so CI catches LiteLLM proxy import-time dependencies that are only exercised by the real entrypoint.

## Why
The deployed `tana-litellm` pods reached the current image `ghcr.io/agentydragon/tana-litellm-proxy:devel-20260610215952-d149b1c` but CrashLooped while importing LiteLLM proxy auth code:

```text
ModuleNotFoundError: Missing dependency No module named 'cryptography'. Run `pip install 'litellm[proxy]'`
```

A one-off pod with the same image confirmed `websockets` is present and importable after the launcher creates its venv, so the next missing import-time dependency is `cryptography`.

## Validation
- `nix develop -c bazelisk test //tana/litellm_proxy:test_proxy_runtime`
- `nix develop -c bazelisk test //tana/litellm_proxy/... //cluster/k8s/litellm/tana:test_generate_tana_litellm`
- `nix develop -c bazelisk build //tana/litellm_proxy:image`