### PR TITLE
Document class-member selector hole TODO

### DIFF
--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -97,6 +97,14 @@ private corpus details in Ducktape.
   and `EXPR2` to arbitrary expression subtrees while alpha-renaming
   surrounding identifiers. Repeated holes should mean repeated equal
   subtrees. Ambiguous matches must remain hard errors.
+- **Statement-list and class-member holes.** Extend wildcard matching to
+  contiguous statement lists and class element lists so a selector can match
+  stable class/method structure without copying an entire minified body. For
+  example, `class View { render() { STMT_LIST_BODY } close() { ... } }`
+  should be able to match a class whose `render` body drifted, while still
+  requiring the selected class and member names to be unambiguous. Likewise,
+  class element holes should allow "class with these fields/methods, plus any
+  other members" without forcing an exact whole-class source copy.
 - **Cross-module binding groups.** Current `binding_groups` export
   multiple bindings into one logical module. Add or design a form for
   one matched declaration context whose bindings should land in


### PR DESCRIPTION
## Summary

- Add a generic Ducktape TODO for statement-list and class-member wildcard holes in structural selectors.
- Call out the portability goal: match stable class/member structure without copying entire minified method bodies or full class declarations.
- Preserve the ambiguity requirement for selector matches.

## Testing

- Not run; documentation-only change.
