### PR TITLE
monitoring: alert on control-plane disk contention

### DIFF
--- a/cluster/k8s/flux-monitoring/podmonitor.yaml
+++ b/cluster/k8s/flux-monitoring/podmonitor.yaml
@@ -4,10 +4,10 @@
 # the shared label `app.kubernetes.io/part-of: flux` (per gotk-components.yaml)
 # and exposes /metrics on the `http-prom` named port (8080).
 #
-# Without this PodMonitor the gotk_reconcile_duration_seconds /
-# gotk_reconcile_condition / gotk_suspend_status series are not ingested,
-# which leaves the flux_reconcile_audit skill blind. See
-# <skills/flux_reconcile_audit/SKILL.md>.
+# Without this PodMonitor the gotk_reconcile_duration_seconds series is not
+# ingested, which leaves the flux_reconcile_audit skill partly blind. Flux CR
+# Ready-condition metrics come from kube-state-metrics customResourceState in
+# cluster/k8s/monitoring/stack/helmrelease.yaml.
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:

--- a/cluster/k8s/monitoring/rules/control-plane-io-prometheus-rule.yaml
+++ b/cluster/k8s/monitoring/rules/control-plane-io-prometheus-rule.yaml
@@ -1,0 +1,69 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: control-plane-io-alerts
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: control-plane-io
+      rules:
+        - alert: ControlPlaneSystemDiskBusy
+          expr: |
+            (
+              rate(node_disk_io_time_seconds_total{device="sda"}[10m])
+              * on(namespace, pod) group_left(node)
+                kube_pod_info{namespace="monitoring", pod=~"prometheus-node-exporter-.+"}
+              * on(node) group_left()
+                kube_node_role{role="control-plane"}
+            ) > 0.50
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Control-plane system disk is busy on {{ $labels.node }}"
+            description: "/dev/sda on control-plane node {{ $labels.node }} has been busy for more than 50% of wall time over 15 minutes. This disk also carries Talos EPHEMERAL and etcd."
+        - alert: ControlPlanePodSystemDiskWriterHigh
+          expr: |
+            (
+              sum by (namespace, pod, node) (
+                rate(container_fs_writes_bytes_total{device="/dev/sda", container!="", pod!="", namespace!="kube-system"}[10m])
+              )
+              * on(node) group_left()
+                kube_node_role{role="control-plane"}
+            ) > 1048576
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Pod {{ $labels.namespace }}/{{ $labels.pod }} is writing heavily to control-plane /dev/sda"
+            description: "Pod {{ $labels.namespace }}/{{ $labels.pod }} on {{ $labels.node }} is writing {{ $value | humanize1024 }}B/s to /dev/sda for more than 10 minutes, which can contend with etcd."
+        - alert: ControlPlaneLeasePutLatencyHigh
+          expr: |
+            histogram_quantile(
+              0.99,
+              sum by (instance, le) (
+                rate(apiserver_request_duration_seconds_bucket{resource="leases", verb="PUT", scope="resource"}[10m])
+              )
+            ) > 0.5
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Apiserver lease PUT latency is high on {{ $labels.instance }}"
+            description: "p99 apiserver lease PUT latency on {{ $labels.instance }} has exceeded 500ms for 10 minutes. This is an early signal for leader-election and node-lease write path contention."
+        - alert: ControlPlaneLeasePutLatencyCritical
+          expr: |
+            histogram_quantile(
+              0.99,
+              sum by (instance, le) (
+                rate(apiserver_request_duration_seconds_bucket{resource="leases", verb="PUT", scope="resource"}[10m])
+              )
+            ) > 2
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Apiserver lease PUT latency is critical on {{ $labels.instance }}"
+            description: "p99 apiserver lease PUT latency on {{ $labels.instance }} has exceeded 2s for 5 minutes. Leader election and node heartbeats may time out."

--- a/cluster/k8s/monitoring/rules/flux-prometheus-rule.yaml
+++ b/cluster/k8s/monitoring/rules/flux-prometheus-rule.yaml
@@ -9,11 +9,35 @@ spec:
   groups:
     - name: flux
       rules:
-        - alert: FluxReconciliationFailure
-          expr: gotk_reconcile_condition{status="False",type="Ready"} == 1
+        - alert: FluxKustomizationNotReady
+          expr: kube_customresource_flux_kustomization_ready{status!="True"} == 1
           for: 15m
           labels:
             severity: warning
           annotations:
-            summary: "Flux resource {{ $labels.kind }}/{{ $labels.name }} failed to reconcile"
-            description: "{{ $labels.kind }} {{ $labels.namespace }}/{{ $labels.name }} has been failing to reconcile for more than 15 minutes."
+            summary: "Flux Kustomization {{ $labels.namespace }}/{{ $labels.name }} is not Ready"
+            description: "Flux Kustomization {{ $labels.namespace }}/{{ $labels.name }} has reported Ready={{ $labels.status }} for more than 15 minutes."
+        - alert: FluxHelmReleaseNotReady
+          expr: kube_customresource_flux_helmrelease_ready{status!="True"} == 1
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Flux HelmRelease {{ $labels.namespace }}/{{ $labels.name }} is not Ready"
+            description: "Flux HelmRelease {{ $labels.namespace }}/{{ $labels.name }} has reported Ready={{ $labels.status }} for more than 15 minutes."
+        - alert: FluxGitRepositoryNotReady
+          expr: kube_customresource_flux_gitrepository_ready{status!="True"} == 1
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Flux GitRepository {{ $labels.namespace }}/{{ $labels.name }} is not Ready"
+            description: "Flux GitRepository {{ $labels.namespace }}/{{ $labels.name }} has reported Ready={{ $labels.status }} for more than 15 minutes."
+        - alert: FluxMainGitRepositoryArtifactLarge
+          expr: kube_customresource_flux_gitrepository_artifact_size_bytes{namespace="flux-system",name="flux-system"} > 16777216
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Flux main GitRepository artifact is large"
+            description: "GitRepository flux-system/flux-system artifact is {{ $value | humanize1024 }}B, increasing source unpack/write pressure for every dependent Kustomization."

--- a/cluster/k8s/monitoring/rules/kustomization.yaml
+++ b/cluster/k8s/monitoring/rules/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - control-plane-io-prometheus-rule.yaml
   - flux-prometheus-rule.yaml

--- a/cluster/k8s/monitoring/stack-secrets/alertmanager-ntfy-webhook.sops.yaml
+++ b/cluster/k8s/monitoring/stack-secrets/alertmanager-ntfy-webhook.sops.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: alertmanager-ntfy-webhook
+    namespace: monitoring
+stringData:
+    address: ENC[AES256_GCM,data:rXrpBfgtkiGjQnYLg9PAxMPAEIbbEvihxMXez7w+0WUj7IKdKzF97KnsyR2nMg==,iv:gM/TKR0Wv7HldZhIZBu6ehnXweD3k/D/TbdemGUS+rM=,tag:z6pJgqTuOsYIQAxBMdM8/A==,type:str]
+sops:
+    age:
+        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrYlNGOGM4Y3l4aHVUemxT
+            bEpCdEMza0JjNllZUDRGV1ZaT0w4dW56RmxBCjJPZFZ3QS9xL0sycDFKRzJNdTVa
+            NWQxYVlyOVZUNUNQNTE5QVJ3T2I0M3cKLS0tIEl5UWUzTFZKU3F6WHljcm1xR25P
+            NkRUTldoRkkwRGNwWHgyVHZ1K0tseVkKCzl/tzT4EtQCPHtGoCAHhH1deQlsAsGm
+            rK2bcq8J3pp8oRqB5msGhjwInrvomOPmxOdMfltH8ED1dK3Ev8p/ig==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1nywlwepsyfxvyhqwkjquzz02nmus65gf6qewfjju4alym8f7se5qnua8na
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVNUZWR1ZWRlg4MFR3YVh6
+            cjJWZGFhaHFQRG5IVmdnLzRyTGdoOFd0RVdzCm05T3FBV21IeWVDdW50dGlvbTNR
+            TDVkNGR5RVcvMUFiVk1wRWVYVFpWLzgKLS0tIDhlYXJ6TUhCYVZLRUw3WnBDRmY0
+            UENCdlNQSHQwK1Z6WmdscXN4TlEwQ0EKA3KZjewCN5CcVoBpIqPWFXhC7QAG0MFv
+            ud6dnVVS/B27w9OrxQ7X14Kc0HjQwba/om68ilYHvLwFUSUr1LK9WQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-06-10T23:12:01Z"
+    mac: ENC[AES256_GCM,data:lAayNYeAmNnpuFJfFnevLW+HoYi+ykzpS/6Iu8hRyJtFJCLFjVBFmZFudty+W5EeyvAIcVsf61UvMczVBmmq955C9cEpjQyXMlz+ZWUHPqw1ScVKFz3PHiGZkE8C0tdZ/3n+3LXm3Nd1TFui1BPHc0fOE+bdVLsiZi/OZWsQmbM=,iv:AB5AJrOHEl9B2AZ7eM1zwmzC3x6nYpKBaOz07ceZmJ4=,tag:Gel1D90/hbMRUajeYwJKKQ==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.1

--- a/cluster/k8s/monitoring/stack-secrets/kustomization.yaml
+++ b/cluster/k8s/monitoring/stack-secrets/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - alertmanager-ntfy-webhook.sops.yaml
   - grafana-admin-password.sops.yaml

--- a/cluster/k8s/monitoring/stack/helmrelease.yaml
+++ b/cluster/k8s/monitoring/stack/helmrelease.yaml
@@ -65,10 +65,60 @@ spec:
     # Alertmanager configuration
     alertmanager:
       enabled: true
+      config:
+        global:
+          resolve_timeout: 5m
+        inhibit_rules:
+          - source_matchers:
+              - severity = critical
+            target_matchers:
+              - severity =~ warning|info
+            equal:
+              - namespace
+              - alertname
+          - source_matchers:
+              - severity = warning
+            target_matchers:
+              - severity = info
+            equal:
+              - namespace
+              - alertname
+          - source_matchers:
+              - alertname = InfoInhibitor
+            target_matchers:
+              - severity = info
+            equal:
+              - namespace
+          - target_matchers:
+              - alertname = InfoInhibitor
+        route:
+          group_by: ["namespace"]
+          group_wait: 30s
+          group_interval: 5m
+          repeat_interval: 12h
+          receiver: "null"
+          routes:
+            - receiver: "null"
+              matchers:
+                - alertname = "Watchdog"
+            - receiver: ntfy
+              matchers:
+                - alertname =~ "FluxKustomizationNotReady|FluxHelmReleaseNotReady|FluxGitRepositoryNotReady|FluxMainGitRepositoryArtifactLarge|ControlPlaneSystemDiskBusy|ControlPlanePodSystemDiskWriterHigh|ControlPlaneLeasePutLatencyHigh|ControlPlaneLeasePutLatencyCritical"
+              repeat_interval: 2h
+        receivers:
+          - name: "null"
+          - name: ntfy
+            webhook_configs:
+              - send_resolved: true
+                url_file: /etc/alertmanager/secrets/alertmanager-ntfy-webhook/address
+        templates:
+          - /etc/alertmanager/config/*.tmpl
       ingress:
         enabled: false
       alertmanagerSpec:
         replicas: 2
+        secrets:
+          - alertmanager-ntfy-webhook
         storage:
           volumeClaimTemplate:
             metadata:
@@ -141,6 +191,81 @@ spec:
     # Kube-state-metrics configuration
     kube-state-metrics:
       fullnameOverride: kube-state-metrics
+      rbac:
+        extraRules:
+          - apiGroups: ["apiextensions.k8s.io"]
+            resources: ["customresourcedefinitions"]
+            verbs: ["list", "watch"]
+          - apiGroups: ["kustomize.toolkit.fluxcd.io"]
+            resources: ["kustomizations"]
+            verbs: ["list", "watch"]
+          - apiGroups: ["helm.toolkit.fluxcd.io"]
+            resources: ["helmreleases"]
+            verbs: ["list", "watch"]
+          - apiGroups: ["source.toolkit.fluxcd.io"]
+            resources: ["gitrepositories"]
+            verbs: ["list", "watch"]
+      customResourceState:
+        enabled: true
+        config:
+          kind: CustomResourceStateMetrics
+          spec:
+            resources:
+              - groupVersionKind:
+                  group: kustomize.toolkit.fluxcd.io
+                  version: v1
+                  kind: Kustomization
+                labelsFromPath:
+                  namespace: [metadata, namespace]
+                  name: [metadata, name]
+                metrics:
+                  - name: flux_kustomization_ready
+                    help: Flux Kustomization Ready condition status.
+                    each:
+                      type: StateSet
+                      stateSet:
+                        labelName: status
+                        path: [status, conditions, "[type=Ready]", status]
+                        list: ["True", "False", "Unknown"]
+              - groupVersionKind:
+                  group: helm.toolkit.fluxcd.io
+                  version: v2
+                  kind: HelmRelease
+                labelsFromPath:
+                  namespace: [metadata, namespace]
+                  name: [metadata, name]
+                metrics:
+                  - name: flux_helmrelease_ready
+                    help: Flux HelmRelease Ready condition status.
+                    each:
+                      type: StateSet
+                      stateSet:
+                        labelName: status
+                        path: [status, conditions, "[type=Ready]", status]
+                        list: ["True", "False", "Unknown"]
+              - groupVersionKind:
+                  group: source.toolkit.fluxcd.io
+                  version: v1
+                  kind: GitRepository
+                labelsFromPath:
+                  namespace: [metadata, namespace]
+                  name: [metadata, name]
+                metrics:
+                  - name: flux_gitrepository_ready
+                    help: Flux GitRepository Ready condition status.
+                    each:
+                      type: StateSet
+                      stateSet:
+                        labelName: status
+                        path: [status, conditions, "[type=Ready]", status]
+                        list: ["True", "False", "Unknown"]
+                  - name: flux_gitrepository_artifact_size_bytes
+                    help: Flux GitRepository artifact size in bytes.
+                    each:
+                      type: Gauge
+                      gauge:
+                        path: [status, artifact]
+                        valueFrom: [size]
       resources:
         requests:
           cpu: 10m


### PR DESCRIPTION
## Summary
- expose Flux Kustomization, HelmRelease, and GitRepository Ready-condition metrics through kube-state-metrics customResourceState
- replace the broken Flux Ready alert that referenced absent `gotk_reconcile_condition`
- add control-plane `/dev/sda`, high pod write, and lease PUT latency alerts
- route these new Flux/control-plane I/O alerts to the existing ntfy topic through Alertmanager, while leaving unrelated alerts on the existing null receiver

## Validation
- `kubectl kustomize cluster/k8s/monitoring/rules >/tmp/monitoring-rules-rendered.yaml`
- `kubectl kustomize cluster/k8s/monitoring/stack >/tmp/monitoring-stack-rendered.yaml`
- `kubectl kustomize cluster/k8s/monitoring/stack-secrets >/tmp/monitoring-stack-secrets-rendered.yaml`
- `kubectl apply --dry-run=server -k cluster/k8s/monitoring/rules`
- `kubectl apply --dry-run=server -k cluster/k8s/monitoring/stack`
- live Mimir query API parsed the new PromQL alert expressions
- live Alertmanager `amtool check-config` accepted the candidate Alertmanager config
- pre-commit hooks via `git commit --amend --no-edit`