### PR TITLE
monitoring: raise kube-state-metrics memory

### DIFF
--- a/cluster/k8s/monitoring/stack/helmrelease.yaml
+++ b/cluster/k8s/monitoring/stack/helmrelease.yaml
@@ -269,10 +269,10 @@ spec:
       resources:
         requests:
           cpu: 10m
-          memory: 64Mi
+          memory: 128Mi
         limits:
           cpu: 100m
-          memory: 128Mi
+          memory: 512Mi
 
     # Disable components we don't need
     kubeApiServer:


### PR DESCRIPTION
## Summary
- raise kube-state-metrics memory request/limit from `64Mi`/`128Mi` to `128Mi`/`512Mi`
- fixes the live CrashLoopBackOff after enabling Flux customResourceState metrics; kube-state-metrics starts, then gets OOMKilled under the old 128Mi limit

## Validation
- `kubectl kustomize cluster/k8s/monitoring/stack >/tmp/monitoring-stack-rendered.yaml`
- `kubectl apply --dry-run=server -k cluster/k8s/monitoring/stack`
- pre-commit hooks via `git commit`

Full `bbr build //...` / `bbr test //...` not run; this is a Helm values resource-budget fix.