### PR TITLE
loom/gym: "today is &lt;as_of&gt;" prompt framing + tolerate per-sample errors

### DIFF
--- a/loom/gym/agent_eval.py
+++ b/loom/gym/agent_eval.py
@@ -92,6 +92,9 @@ def main() -> None:
         log_dir=str(args.log_dir),
         display="plain",
         message_limit=args.message_limit,
+        # A transient per-sample failure (e.g. a flaky DNS/connection to the model
+        # endpoint) should drop that sample, not abort the whole run.
+        fail_on_error=False,
     )
     for log in logs:
         print(f"eval status={log.status}" + (f" error={log.error}" if log.error else ""))

--- a/loom/gym/inspect_harness.py
+++ b/loom/gym/inspect_harness.py
@@ -179,12 +179,11 @@ AGENT_PROMPT = (
     "persist between calls, so make every command self-contained. python3 is available; the image "
     "(loom/gym/sandbox/Dockerfile) has pandas, numpy, scipy, statsmodels, python-dateutil, requests, "
     "and curl preinstalled, so run analysis with e.g. `python3 - <<'PY' ... PY` or `python3 -c '...'`. "
-    "If /data/sources.txt exists, it lists URLs that may contain relevant information — possible "
-    "starting points for your research, which you can follow and branch out from. You can browse the "
-    "web as it existed at your information cutoff through a preconfigured proxy: ordinary http:// and "
-    "https:// URLs both work (curl, urllib, and requests honor the proxy and its CA automatically). "
-    "When confident, call the submit tool with your forecast — its arguments are the structured "
-    "answer fields, which the tool schema enforces."
+    "You have access to a snapshotted archive of today's internet through a preconfigured proxy: "
+    "ordinary http:// and https:// URLs both work (curl, urllib, and requests honor the proxy and its "
+    "CA automatically) — use it to gather information. If /data/sources.txt exists, it lists URLs worth "
+    "starting from. When confident, call the submit tool with your forecast — its arguments are the "
+    "structured answer fields, which the tool schema enforces."
 )
 
 AGENT_PROMPT_NO_ARCHIVE = (
@@ -193,8 +192,7 @@ AGENT_PROMPT_NO_ARCHIVE = (
     "persist between calls, so make every command self-contained. python3 is available; the image "
     "(loom/gym/sandbox/Dockerfile) has pandas, numpy, scipy, statsmodels, python-dateutil, requests, "
     "and curl preinstalled, so run analysis with e.g. `python3 - <<'PY' ... PY` or `python3 -c '...'`. "
-    "You have NO network access: forecast from the /data files and your own knowledge of events at or "
-    "before your information cutoff. "
+    "You have NO network access: rely only on the /data files and your own knowledge. "
     "When confident, call the submit tool with your forecast — its arguments are the structured "
     "answer fields, which the tool schema enforces."
 )
@@ -222,9 +220,8 @@ def write_sandbox_compose(
 
 
 _SOURCES_HEADER = (
-    "URLs that may contain information relevant to this question, archived at or before your "
-    "information cutoff. They are possible starting points only — fetch them (http:// or https://) "
-    "through the proxy and branch out as you see fit.\n"
+    "URLs worth checking for this question, from today's archived internet. They are starting points "
+    "only — fetch them (http:// or https://) through the proxy and branch out as you see fit.\n"
 )
 
 
@@ -237,21 +234,22 @@ def _sources_txt(task: Task) -> str:
 
 
 def sample_for_task(task: Task, dossier: dict[str, str], compose_path: Path, *, archive: bool = True) -> Sample:
-    if archive:
-        as_of_line = (
-            f"You are forecasting as of {task.as_of}. The /data files are truncated to what was knowable then, "
-            f"and the web proxy serves pages as archived on or before {task.as_of}; use only those sources and "
-            f"knowledge of events on or before {task.as_of}.\n"
-        )
-    else:
-        as_of_line = (
-            f"You are forecasting as of {task.as_of}. You have no network access: use only the /data files "
-            f"(truncated to what was knowable then) and your own knowledge of events on or before {task.as_of}.\n"
-        )
+    # "Today is <as_of>" frames the as_of as the present, so the contestant
+    # naturally reasons only from then-knowable information; the archive clamp and
+    # truncated /data enforce that physically. With archive, point it at the
+    # snapshotted internet; without, it forecasts from /data + its own knowledge.
+    research_line = (
+        "You can gather information from the snapshotted archive of today's internet through the proxy"
+        " (start from /data/sources.txt if it exists).\n"
+        if archive
+        else ""
+    )
     instructions = (
-        as_of_line + f"Question: {task.question.text}\n"
-        f"Resolution date: {task.resolution_date}\n"
-        f"When done, call the submit tool with your forecast: {answer_instruction(task.question)}."
+        f"Today is {task.as_of}. Answer this question:\n"
+        f"{task.question.text}\n"
+        f"It resolves on {task.resolution_date}.\n"
+        + research_line
+        + f"When you are done, call the submit tool with your forecast: {answer_instruction(task.question)}."
     )
     files = {f"/data/{name}": content for name, content in dossier.items()}
     # No archive means no way to fetch the source URLs, so don't land them.


### PR DESCRIPTION
Two small harness changes from running the first baseline pass (glm-4.5, archive vs no-network, on the 33-market panel).

## 1. "Today is &lt;as_of&gt;" prompt framing

Reframe the contestant prompt to present the `as_of` as the present:
- Per task: **"Today is &lt;as_of&gt;. Answer this question: … It resolves on &lt;resolution_date&gt;."**
- Archive system prompt: **"You have access to a snapshotted archive of today's internet through a proxy … use it to gather information."**

The old framing ("browse the web *as it existed at your information cutoff*") read as a restriction — in the first archive run the agents barely fetched (`fetched=[-]` on every sample). Framing the `as_of` as today, with the archive as "today's internet you can use," is both cleaner and should actually pull the agent onto the archive. The no-archive arm gets the same framing minus any network mention. (The as-of leak-safety is unchanged — it's enforced physically by the proxy clamp + truncated `/data`; the prompt framing just makes the model reason from "today" naturally.)

## 2. `fail_on_error=False`

A single transient per-sample failure — a flaky egress-DNS/connection to the **model endpoint** (`litellm.allegedly.works` momentarily resolving to a private/reserved IP) — was aborting the *entire* 33-task eval at sample 20 (inspect's default `fail_on_error=True`). With `False`, that sample is dropped and the run completes; the analyzer already treats missing/NaN tasks as non-submissions.

Lint-clean on RBE; the docker e2e (`test_inspect_harness`, mockllm) is prompt-agnostic and its assertions still hold. Baseline numbers (with the analysis tooling + a notebook) will follow separately once the re-runs land.

https://claude.ai/code/session_01AXSFxfCXddADoSKTjgF5Nz

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXSFxfCXddADoSKTjgF5Nz)_