### PR TITLE
monitoring: scrape Talos etcd metrics

### DIFF
--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -132,6 +132,7 @@ resources:
   - monitoring/stack/flux-kustomization.yaml
   - monitoring/stack-secrets/flux-kustomization.yaml
   - monitoring/rules/flux-kustomization.yaml
+  - monitoring/etcd/flux-kustomization.yaml
   - monitoring/loki/flux-kustomization.yaml
   - monitoring/alloy/flux-kustomization.yaml
   - monitoring/alloy-otlp-bearer-token-tf/flux-kustomization.yaml

--- a/cluster/k8s/monitoring/etcd/endpoints.yaml
+++ b/cluster/k8s/monitoring/etcd/endpoints.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: talos-etcd-metrics
+  labels:
+    app.kubernetes.io/name: talos-etcd-metrics
+    app.kubernetes.io/part-of: monitoring
+spec:
+  clusterIP: None
+  ports:
+    - name: metrics
+      port: 2381
+      targetPort: 2381
+      protocol: TCP
+---
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: talos-etcd-metrics
+  labels:
+    kubernetes.io/service-name: talos-etcd-metrics
+    endpointslice.kubernetes.io/managed-by: ducktape-static
+addressType: IPv4
+ports:
+  - name: metrics
+    protocol: TCP
+    port: 2381
+endpoints:
+  - addresses: ["10.42.0.13"]
+    hostname: ovh-ns103656
+    nodeName: ovh-ns103656
+    conditions:
+      ready: true
+  - addresses: ["10.42.0.14"]
+    hostname: ovh-ns103711
+    nodeName: ovh-ns103711
+    conditions:
+      ready: true
+  - addresses: ["10.42.0.15"]
+    hostname: ovh-ns102453
+    nodeName: ovh-ns102453
+    conditions:
+      ready: true

--- a/cluster/k8s/monitoring/etcd/flux-kustomization.yaml
+++ b/cluster/k8s/monitoring/etcd/flux-kustomization.yaml
@@ -1,0 +1,25 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: etcd-monitoring
+  namespace: flux-system
+spec:
+  suspend: false
+  interval: 10m
+  retryInterval: 1m
+  timeout: 2m
+  path: ./cluster/k8s/monitoring/etcd
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  dependsOn:
+    # monitoring-stack installs the ServiceMonitor CRD via kube-prometheus-stack.
+    - name: monitoring-stack
+      namespace: flux-system
+  wait: true
+  healthChecks:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: ServiceMonitor
+      name: talos-etcd
+      namespace: monitoring

--- a/cluster/k8s/monitoring/etcd/kustomization.yaml
+++ b/cluster/k8s/monitoring/etcd/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+resources:
+  - endpoints.yaml
+  - servicemonitor.yaml

--- a/cluster/k8s/monitoring/etcd/servicemonitor.yaml
+++ b/cluster/k8s/monitoring/etcd/servicemonitor.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: talos-etcd
+  labels:
+    app.kubernetes.io/name: talos-etcd-metrics
+    app.kubernetes.io/part-of: monitoring
+spec:
+  namespaceSelector:
+    matchNames:
+      - monitoring
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: talos-etcd-metrics
+  endpoints:
+    - port: metrics
+      path: /metrics
+      scheme: http
+      interval: 30s
+      scrapeTimeout: 10s
+      relabelings:
+        - sourceLabels: [__meta_kubernetes_endpointslice_endpoint_hostname]
+          targetLabel: node

--- a/cluster/k8s/monitoring/stack/helmrelease.yaml
+++ b/cluster/k8s/monitoring/stack/helmrelease.yaml
@@ -39,7 +39,9 @@ spec:
       create: true
       rules:
         alertmanager: true
-        etcd: false # Talos doesn't expose etcd metrics
+        # Static Talos etcd endpoints are scraped by monitoring/etcd; keep the
+        # chart's stock etcd rule bundle disabled until the scrape is verified.
+        etcd: false
         configReloaders: true
         general: true
         k8s: true
@@ -284,7 +286,8 @@ spec:
     coreDns:
       enabled: true
     kubeEtcd:
-      enabled: false # Talos doesn't expose etcd metrics
+      # Static Talos etcd endpoints are managed in cluster/k8s/monitoring/etcd.
+      enabled: false
     kubeScheduler:
       enabled: true
     kubeProxy:

--- a/cluster/terraform/main/BUILD.bazel
+++ b/cluster/terraform/main/BUILD.bazel
@@ -1,7 +1,10 @@
 load("@rules_tf//tf:def.bzl", "tf_module", "tf_providers_versions")
 
 exports_files(
-    ["cilium-values.yaml"],
+    [
+        "cilium-values.yaml",
+        "ovh-nodes.tf",
+    ],
     visibility = ["//cluster:__subpackages__"],
 )
 

--- a/cluster/terraform/main/ovh-nodes.tf
+++ b/cluster/terraform/main/ovh-nodes.tf
@@ -267,6 +267,18 @@ locals {
     allowSchedulingOnControlPlanes = true
   })
 
+  kimsufi_controlplane_cluster_config_by_node = {
+    for k, v in merge(local.kimsufi_servers, local.kimsufi_cp_servers) :
+    k => merge(local.kimsufi_controlplane_cluster_config, {
+      etcd = merge(local.kimsufi_controlplane_cluster_config.etcd, {
+        extraArgs = {
+          "listen-metrics-urls" = "http://${v.nebula_ip}:2381"
+        }
+      })
+    })
+    if v.role == "controlplane"
+  }
+
   # Per-node user-volume patches. KS-5 nodes expose /dev/sdb; KS-GAME nodes
   # expose a second NVMe. Both are mounted at the same path so local-path-ovh
   # can use OVH-local capacity uniformly.
@@ -307,7 +319,7 @@ locals {
           "topology.kubernetes.io/zone"   = v.zone
         }
       })
-      cluster = local.kimsufi_controlplane_cluster_config
+      cluster = local.kimsufi_controlplane_cluster_config_by_node[k]
     })
     if v.role == "controlplane"
   }
@@ -449,7 +461,7 @@ locals {
           "topology.kubernetes.io/zone"   = v.zone
         }
       })
-      cluster = local.kimsufi_controlplane_cluster_config
+      cluster = local.kimsufi_controlplane_cluster_config_by_node[k]
     })
   }
 }

--- a/cluster/validation/BUILD.bazel
+++ b/cluster/validation/BUILD.bazel
@@ -266,12 +266,17 @@ py_test(
 py_test(
     name = "test_nebula_mesh",
     srcs = ["test_nebula_mesh.py"],
-    data = ["//:nebula-mesh.json"],
+    data = [
+        "//:nebula-mesh.json",
+        "//cluster/k8s:cluster_all_files",
+        "//cluster/terraform/main:ovh-nodes.tf",
+    ],
     deps = [
         "//cluster/scripts:nebula_mesh",
         "//util/bazel:runfiles",
         "@pypi//pytest",
         "@pypi//pytest_bazel",
+        "@pypi//pyyaml",
     ],
 )
 

--- a/cluster/validation/test_nebula_mesh.py
+++ b/cluster/validation/test_nebula_mesh.py
@@ -3,12 +3,18 @@
 from __future__ import annotations
 
 import ipaddress
+import re
+from pathlib import Path
 
 import pytest
 import pytest_bazel
+import yaml
 
 from cluster.scripts import nebula_mesh
 from util.bazel.runfiles import get_required_path
+
+_TERRAFORM_NODE_RE = re.compile(r"^    (?P<key>[A-Za-z0-9_]+)\s*=\s*\{(?P<body>.*?)^    \}", re.MULTILINE | re.DOTALL)
+_TERRAFORM_STRING_ATTR_RE = re.compile(r'^\s*(?P<name>[A-Za-z0-9_]+)\s*=\s*"(?P<value>[^"]*)"', re.MULTILINE)
 
 
 @pytest.fixture(scope="module")
@@ -63,6 +69,79 @@ def test_at_least_one_control_plane(mesh: nebula_mesh.Mesh) -> None:
     """k8s-worker.nix derives controlPlaneEndpoints from role=control-plane."""
     cps = [h for h in mesh.hosts.values() if h.role == "control-plane"]
     assert cps, "roster must contain at least one role=control-plane host"
+
+
+def _control_plane_nebula_ips(mesh: nebula_mesh.Mesh) -> dict[str, str]:
+    return {name: host.nebula_ip for name, host in mesh.hosts.items() if host.role == "control-plane"}
+
+
+def _string_attrs(terraform_block: str) -> dict[str, str]:
+    return {match.group("name"): match.group("value") for match in _TERRAFORM_STRING_ATTR_RE.finditer(terraform_block)}
+
+
+def _terraform_control_plane_nebula_ips(path: Path) -> dict[str, str]:
+    text = path.read_text()
+    control_planes: dict[str, str] = {}
+    for match in _TERRAFORM_NODE_RE.finditer(text):
+        attrs = _string_attrs(match.group("body"))
+        if attrs.get("role") != "controlplane":
+            continue
+        hostname = attrs.get("hostname")
+        nebula_ip = attrs.get("nebula_ip")
+        assert hostname, f"{match.group('key')}: control-plane node is missing hostname"
+        assert nebula_ip, f"{match.group('key')}: control-plane node is missing nebula_ip"
+        control_planes[hostname] = nebula_ip
+    assert control_planes, f"{path}: expected at least one control-plane node"
+    return control_planes
+
+
+def _static_etcd_endpoint_nebula_ips(path: Path) -> dict[str, str]:
+    docs = [doc for doc in yaml.safe_load_all(path.read_text()) if doc is not None]
+    endpoint_slices = [
+        doc
+        for doc in docs
+        if doc.get("apiVersion") == "discovery.k8s.io/v1"
+        and doc.get("kind") == "EndpointSlice"
+        and doc.get("metadata", {}).get("name") == "talos-etcd-metrics"
+    ]
+    assert len(endpoint_slices) == 1, f"{path}: expected exactly one talos-etcd-metrics EndpointSlice"
+
+    endpoint_slice = endpoint_slices[0]
+    assert endpoint_slice.get("addressType") == "IPv4"
+    assert (
+        endpoint_slice.get("metadata", {}).get("labels", {}).get("kubernetes.io/service-name") == "talos-etcd-metrics"
+    )
+    assert endpoint_slice.get("ports") == [{"name": "metrics", "protocol": "TCP", "port": 2381}]
+
+    endpoints: dict[str, str] = {}
+    for endpoint in endpoint_slice.get("endpoints", []):
+        hostname = endpoint.get("hostname")
+        assert hostname, f"{path}: EndpointSlice endpoint is missing hostname"
+        assert endpoint.get("nodeName") == hostname, f"{hostname}: endpoint nodeName should match hostname"
+        assert endpoint.get("conditions", {}).get("ready") is True, f"{hostname}: endpoint should be marked ready"
+
+        addresses = endpoint.get("addresses")
+        assert isinstance(addresses, list), f"{hostname}: endpoint addresses must be a list"
+        assert len(addresses) == 1, f"{hostname}: expected exactly one endpoint address, got {addresses!r}"
+        assert hostname not in endpoints, f"{path}: duplicate endpoint hostname {hostname}"
+        endpoints[hostname] = addresses[0]
+
+    assert endpoints, f"{path}: expected at least one endpoint"
+    return endpoints
+
+
+def test_etcd_metrics_static_endpoints_match_control_plane_rosters(mesh: nebula_mesh.Mesh) -> None:
+    """The static etcd scrape endpoints must follow the control-plane node inventories."""
+    mesh_control_planes = _control_plane_nebula_ips(mesh)
+    terraform_control_planes = _terraform_control_plane_nebula_ips(
+        get_required_path("_main/cluster/terraform/main/ovh-nodes.tf")
+    )
+    static_etcd_endpoints = _static_etcd_endpoint_nebula_ips(
+        get_required_path("_main/cluster/k8s/monitoring/etcd/endpoints.yaml")
+    )
+
+    assert terraform_control_planes == mesh_control_planes
+    assert static_etcd_endpoints == mesh_control_planes
 
 
 def test_host_names_have_no_dots(mesh: nebula_mesh.Mesh) -> None:


### PR DESCRIPTION
## Summary

- expose Talos etcd metrics on each OVH control-plane node's Nebula IP via `listen-metrics-urls`
- add a static `Service`/`EndpointSlice`/`ServiceMonitor` under `monitoring/etcd` for Alloy -> Mimir scraping
- add a Bazel drift test that checks the static etcd endpoint list matches both `nebula-mesh.json` control-plane hosts and the OVH Terraform control-plane inventory

## Validation

- `bbr test //cluster/validation:test_nebula_mesh`
- `bbr test //cluster/terraform/main:validate //cluster/validation:test_cluster_integration`
- `kubectl kustomize cluster/k8s/monitoring/etcd`
- `kubectl kustomize cluster/k8s/monitoring/etcd | kubectl apply --dry-run=server -f -`
- `kubectl kustomize cluster/k8s`
- `nix develop -c pre-commit run --files cluster/terraform/main/ovh-nodes.tf cluster/terraform/main/BUILD.bazel cluster/k8s/kustomization.yaml cluster/k8s/monitoring/stack/helmrelease.yaml cluster/k8s/monitoring/etcd/kustomization.yaml cluster/k8s/monitoring/etcd/endpoints.yaml cluster/k8s/monitoring/etcd/servicemonitor.yaml cluster/k8s/monitoring/etcd/flux-kustomization.yaml cluster/validation/BUILD.bazel cluster/validation/test_nebula_mesh.py`

## Rollout note

Merging this adds the Flux scrape objects, but samples only appear after the Talos machine config is applied to the control-plane nodes and etcd is listening on `10.42.0.{13,14,15}:2381`. Roll the Talos apply one control-plane node at a time and verify etcd quorum after each node.