### PR TITLE
debundle: show home-module path in `describe` text output

### DIFF
--- a/devinfra/js/debundle/CLI_DOGFOOD.md
+++ b/devinfra/js/debundle/CLI_DOGFOOD.md
@@ -17,19 +17,6 @@ The actual path now has a `+_repo_rules+` prefix:
 
 **Fix**: update gaffer-private's AGENTS.md.
 
-### 2. `describe` text format missing home-module path
-
-JSON output includes `binding_homes[].path`. Text output shows owners,
-bindings, atom membership, edge counts — but no module path. Either the
-text output should include the path, or the docs should reflect text's
-narrower surface.
-
-### 3. `describe <sym>` text format hangs on repeat invocations
-
-First invocation returned a 5-line summary; second invocation of the
-same command hung indefinitely. `--format json` consistently completes
-in ~30s. May indicate a stale cache or non-idempotent text renderer.
-
 ## Planner CLI follow-ups
 
 Generic usability follow-ups for the top-level planner commands.

--- a/devinfra/js/debundle/cli/mod.rs
+++ b/devinfra/js/debundle/cli/mod.rs
@@ -1331,6 +1331,15 @@ fn render_explain_text(report: &peel::ExplainReport, out: &mut String) {
             .collect::<Vec<_>>()
             .join(", ")
     ));
+    // Home module path per binding (CLI_DOGFOOD #6): the JSON carries
+    // `binding_homes[].path`, but the text view previously dropped it,
+    // leaving no way to see where a binding lives without `--format json`.
+    if !report.binding_homes.is_empty() {
+        out.push_str("  homes:\n");
+        for home in &report.binding_homes {
+            out.push_str(&format!("    {} -> {}\n", home.binding, home.path));
+        }
+    }
     out.push_str(&format!("  atomic_units: {}\n", report.atomic_units.len()));
     out.push_str(&format!(
         "  incoming_edges: {}, outgoing_edges: {}\n",
@@ -1519,6 +1528,46 @@ mod tests {
             parsed.command,
             super::DebundleCommand::Describe(_)
         ));
+    }
+
+    #[test]
+    fn render_explain_text_includes_home_module_paths() {
+        // CLI_DOGFOOD #6: the text view must surface each binding's home
+        // module path (the JSON's `binding_homes[].path`), not only owners
+        // / bindings / atom / edge counts.
+        use peel::plan::{BindingHomeReport, BindingHomeSourceKind, QueryKind, QueryReport};
+        let report = peel::ExplainReport {
+            query: QueryReport {
+                kind: QueryKind::Binding,
+                value: "XOe".to_string(),
+            },
+            owner_ids: vec!["owner:0".to_string()],
+            owners: vec![],
+            neighbor_owners: vec![],
+            bindings: vec![],
+            binding_homes: vec![BindingHomeReport {
+                binding: "XOe".to_string(),
+                name: "PluginSettingsAccessor".to_string(),
+                source_kind: BindingHomeSourceKind::Module,
+                path: "runtime/plugins".to_string(),
+            }],
+            incoming_edges: vec![],
+            outgoing_edges: vec![],
+            atomic_units: vec![],
+            incoming_atomic_edges: vec![],
+            outgoing_atomic_edges: vec![],
+            quotient_edges: vec![],
+            factorize_proposals: None,
+            factorize_diagnostics: None,
+            limits: None,
+        };
+        let mut out = String::new();
+        super::render_explain_text(&report, &mut out);
+        assert!(out.contains("homes:"), "missing homes section:\n{out}");
+        assert!(
+            out.contains("XOe -> runtime/plugins"),
+            "missing binding->path line:\n{out}",
+        );
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #2024, closing out the `describe`-related items in `CLI_DOGFOOD.md`.

## `describe` text output now shows the home-module path (CLI_DOGFOOD #6)

The text view of `describe` listed owners, bindings, atom membership, and edge counts — but not where a binding actually lives. The home module path was only available via `--format json` (`binding_homes[].path`). This adds a `homes:` block to `render_explain_text`:

```
Binding "XOe"
  owners: owner:0
  bindings: XOe
  homes:
    XOe -> ui/plugins
  atomic_units: 0
  incoming_edges: 0, outgoing_edges: 0
```

Covered by a renderer unit test.

## Dropped the "describe text hangs on repeat" item (CLI_DOGFOOD #8) as irreproducible

Investigated and could not reproduce. The direct binary runs `describe` (both text and json) in ~5ms and is idempotent across repeated invocations — it holds no caches, locks, or cross-run state; each run is a fresh process that loads the graph, renders, and exits. The original "~30s / hang on repeat" is consistent with large-graph load plus a `bazel run` server-lock/rebuild between the two invocations, not a debundle code defect. Removed from the backlog (no fix warranted).

`CLI_DOGFOOD.md` now carries only the cross-repo BIN-path note and the planner follow-ups.

## Testing

Pre-commit clean; full `//devinfra/js/debundle/...` subtree green (82/82) on BuildBuddy RBE.

https://claude.ai/code/session_013C7drQKK7n1DMBqwn2BGGv

---
_Generated by [Claude Code](https://claude.ai/code/session_013C7drQKK7n1DMBqwn2BGGv)_