### PR TITLE
loom/gym: baseline analyzer + notebook (glm-4.5 archive vs no-network)

### DIFF
--- a/loom/gym/BUILD.bazel
+++ b/loom/gym/BUILD.bazel
@@ -7,6 +7,23 @@ py_binary(
     deps = [":compare_runs"],
 )
 
+py_library(
+    name = "analyze_baselines",
+    srcs = ["analyze_baselines.py"],
+    deps = [
+        ":market_seed_tasks",
+        ":scoring",
+        "@pypi//inspect_ai",
+        "@pypi//matplotlib",
+    ],
+)
+
+py_binary(
+    name = "analyze_baselines_bin",
+    main_module = "loom.gym.analyze_baselines",
+    deps = [":analyze_baselines"],
+)
+
 # keep
 py_binary(
     name = "agent_eval_bin",

--- a/loom/gym/analyze_baselines.py
+++ b/loom/gym/analyze_baselines.py
@@ -1,0 +1,199 @@
+"""Aggregate agent-eval baseline runs into numbers (with cluster-bootstrap CIs) and plots.
+
+Reads two Inspect log dirs (no-archive vs archive) of the market panel, extracts
+per-task log loss / Brier from the gym scorer, and compares them against the
+market crowd baseline (`prob_at_as_of`). All means carry a 95% percentile
+cluster-bootstrap CI clustered by `as_of` (tasks sharing an era are correlated).
+
+    bazelisk run //loom/gym:analyze_baselines_bin -- \
+        --run no-archive=/tmp/baseline/noarch --run archive=/tmp/baseline/arch \
+        --out /tmp/baseline/plots
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import math
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+from inspect_ai.log import list_eval_logs, read_eval_log
+
+from loom.gym.market_seed_tasks import MARKET_SEED_RECORDS
+from loom.gym.scoring import cluster_bootstrap_ci
+
+plt.switch_backend("Agg")  # headless rendering
+
+_EPS = 1e-6
+
+
+@dataclass(frozen=True)
+class TaskResult:
+    task_id: str
+    log_loss: float  # nan if no parseable submission
+    brier: float
+    p: float | None  # submitted probability, if any
+
+
+def read_run(log_dir: str) -> dict[str, TaskResult]:
+    results: dict[str, TaskResult] = {}
+    for info in list_eval_logs(log_dir):
+        log = read_eval_log(info)
+        for sample in log.samples or []:
+            score = (sample.scores or {}).get("gym_proper_loss")
+            if score is None:
+                continue
+            meta = score.metadata or {}
+            value = float(score.value) if isinstance(score.value, (int, float)) else float("nan")
+            p = None
+            with contextlib.suppress(json.JSONDecodeError, KeyError, ValueError, TypeError):
+                p = float(json.loads(str(score.answer))["p"])
+            results[str(sample.id)] = TaskResult(
+                task_id=str(sample.id), log_loss=value, brier=float(meta.get("brier", float("nan"))), p=p
+            )
+    return results
+
+
+def crowd_baseline() -> dict[str, TaskResult]:
+    out: dict[str, TaskResult] = {}
+    for r in MARKET_SEED_RECORDS:
+        p_yes = r.prob_at_as_of
+        realized = p_yes if r.resolved_yes else 1.0 - p_yes
+        out[r.task_id] = TaskResult(
+            task_id=r.task_id,
+            log_loss=-math.log(max(realized, _EPS)),
+            brier=(p_yes - float(r.resolved_yes)) ** 2,
+            p=p_yes,
+        )
+    return out
+
+
+def as_of_clusters() -> dict[str, date]:
+    return {r.task_id: r.as_of for r in MARKET_SEED_RECORDS}
+
+
+def aggregate(
+    results: dict[str, TaskResult], cluster_by_id: dict[str, date], metric: str
+) -> tuple[float, tuple, int, int]:
+    """Pooled mean of `metric` over submitted tasks + 95% cluster-bootstrap CI; (mean, ci, n_submitted, n_total)."""
+    by_cluster: dict[date, list[float]] = {}
+    n_total = 0
+    for task_id, cluster in cluster_by_id.items():
+        if task_id not in results:
+            continue
+        n_total += 1
+        value = getattr(results[task_id], metric)
+        if math.isnan(value):
+            continue
+        by_cluster.setdefault(cluster, []).append(value)
+    values = [v for vs in by_cluster.values() for v in vs]
+    mean = sum(values) / len(values) if values else float("nan")
+    ci = cluster_bootstrap_ci(list(by_cluster.values())) or (float("nan"), float("nan"))
+    return mean, ci, len(values), n_total
+
+
+def paired_delta(
+    a: dict[str, TaskResult], b: dict[str, TaskResult], cluster_by_id: dict[str, date], metric: str
+) -> tuple[float, tuple, int]:
+    """Mean per-task delta (b - a; negative = b better) + 95% cluster-bootstrap CI.
+
+    Over tasks both submitted. Absolute loss is dominated by task/era difficulty
+    that both contestants share; differencing within each task cancels it, so the
+    same clusters resolve a much smaller effect with a far tighter CI than two
+    absolute means."""
+    by_cluster: dict[date, list[float]] = {}
+    for task_id, cluster in cluster_by_id.items():
+        if task_id not in a or task_id not in b:
+            continue
+        av, bv = getattr(a[task_id], metric), getattr(b[task_id], metric)
+        if math.isnan(av) or math.isnan(bv):
+            continue
+        by_cluster.setdefault(cluster, []).append(bv - av)
+    values = [v for vs in by_cluster.values() for v in vs]
+    if not values:
+        return float("nan"), (float("nan"), float("nan")), 0
+    mean = sum(values) / len(values)
+    ci = cluster_bootstrap_ci(list(by_cluster.values())) or (float("nan"), float("nan"))
+    return mean, ci, len(values)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--run", action="append", required=True, help="label=log_dir (repeatable).")
+    parser.add_argument("--out", type=Path, required=True, help="Directory for plots.")
+    args = parser.parse_args()
+    args.out.mkdir(parents=True, exist_ok=True)
+
+    cluster_by_id = as_of_clusters()
+    runs: dict[str, dict[str, TaskResult]] = {}
+    for spec in args.run:
+        label, _, log_dir = spec.partition("=")
+        runs[label] = read_run(log_dir)
+    runs["market crowd"] = crowd_baseline()
+
+    print(f"\n{'contestant':<16} {'n':>7} {'log loss (95% CI)':>26} {'Brier (95% CI)':>26}")
+    print("-" * 78)
+    stats: dict[str, tuple[float, tuple]] = {}
+    for label, results in runs.items():
+        ll_mean, ll_ci, n_sub, n_tot = aggregate(results, cluster_by_id, "log_loss")
+        br_mean, br_ci, _, _ = aggregate(results, cluster_by_id, "brier")
+        stats[label] = (ll_mean, ll_ci)
+        n = f"{n_sub}/{n_tot}"
+        print(
+            f"{label:<16} {n:>7} {ll_mean:>9.3f} [{ll_ci[0]:.3f}, {ll_ci[1]:.3f}]"
+            f"   {br_mean:>7.3f} [{br_ci[0]:.3f}, {br_ci[1]:.3f}]"
+        )
+    print()
+
+    # Paired per-task deltas — the powerful comparison (cancels shared difficulty).
+    agent_arms = [k for k in runs if k != "market crowd"]
+    pairs: list[tuple[str, str]] = []
+    if "no-archive" in runs and "archive" in runs:
+        pairs.append(("no-archive", "archive"))
+    pairs += [("market crowd", arm) for arm in agent_arms]
+    if pairs:
+        print("paired per-task deltas (b - a; negative = b better):")
+        for a_label, b_label in pairs:
+            for metric, name in (("log_loss", "log loss"), ("brier", "Brier")):
+                delta, ci, count = paired_delta(runs[a_label], runs[b_label], cluster_by_id, metric)
+                print(f"  {b_label} - {a_label:<13} {name:<9} {delta:+.3f} [{ci[0]:+.3f}, {ci[1]:+.3f}]  (n={count})")
+        print()
+
+    # Plot 1: mean log loss with cluster-bootstrap CI whiskers.
+    labels = list(stats)
+    means = [stats[k][0] for k in labels]
+    lo = [stats[k][0] - stats[k][1][0] for k in labels]
+    hi = [stats[k][1][1] - stats[k][0] for k in labels]
+    fig, ax = plt.subplots(figsize=(6, 4))
+    ax.bar(labels, means, yerr=[lo, hi], capsize=6, color=["#4c72b0", "#dd8452", "#999999"][: len(labels)])
+    ax.set_ylabel("mean log loss (lower is better)")
+    ax.set_title("glm-4.5 on 33 resolved Manifold markets\n95% cluster-bootstrap CI (clustered by as_of)")
+    fig.tight_layout()
+    fig.savefig(args.out / "log_loss.png", dpi=130)
+
+    # Plot 2: submitted probability vs market probability, per arm.
+    crowd_p = {r.task_id: r.prob_at_as_of for r in MARKET_SEED_RECORDS}
+    yes = {r.task_id: r.resolved_yes for r in MARKET_SEED_RECORDS}
+    fig2, ax2 = plt.subplots(figsize=(5.5, 5.5))
+    ax2.plot([0, 1], [0, 1], color="#cccccc", lw=1, zorder=0)
+    for label, color in zip(agent_arms, ["#4c72b0", "#dd8452"], strict=False):
+        points = [(crowd_p[t], res.p, yes[t]) for t, res in runs[label].items() if res.p is not None and t in crowd_p]
+        for resolved, marker, suffix in ((True, "^", "YES"), (False, "v", "NO")):
+            xs = [x for x, _, y in points if y == resolved]
+            ys = [yv for _, yv, y in points if y == resolved]
+            ax2.scatter(xs, ys, color=color, marker=marker, alpha=0.8, label=f"{label} (resolved {suffix})")
+    ax2.set_xlabel("market probability at as_of")
+    ax2.set_ylabel("glm-4.5 submitted probability")
+    ax2.set_title("Agent vs crowd (▲ YES, ▼ NO; diagonal = agrees with market)")
+    ax2.legend(fontsize=7)
+    fig2.tight_layout()
+    fig2.savefig(args.out / "agent_vs_market.png", dpi=130)
+    print(f"plots: {args.out}/log_loss.png  {args.out}/agent_vs_market.png")
+
+
+if __name__ == "__main__":
+    main()

--- a/loom/gym/baseline_analysis.ipynb
+++ b/loom/gym/baseline_analysis.ipynb
@@ -1,0 +1,140 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Baseline: glm-4.5 vs the market crowd on the gym's 33-market panel\n",
+    "\n",
+    "Two **agent** contestants on the 33 resolved Manifold binary markets in `loom/gym/market_seed_tasks.py` (balanced 17 YES / 16 NO; all admissible for glm-4.5 — each `as_of` ≥ 2024-09, model knowledge cutoff 2024-06-30):\n",
+    "\n",
+    "- **no-archive** — Docker sandbox with `network_mode: none`; the agent forecasts from the truncated `/data` dossier + its own knowledge.\n",
+    "- **archive** — same sandbox, but its only route is the date-clamped wayback proxy → the in-cluster pull-through cache → the Internet Archive (it can research \"today's\" archived internet).\n",
+    "\n",
+    "We compare both against the **market crowd** (`prob_at_as_of`, the market's own probability). Each forecast is scored with the gym's proper losses. Every mean carries a 95% percentile **cluster-bootstrap CI clustered by `as_of`** (markets sharing an era are correlated), and we report **paired per-task deltas** — which difference out shared task difficulty and are far more powerful than comparing two absolute means at n=33.\n",
+    "\n",
+    "Reproduce the runs (glm-4.5 via the cluster LiteLLM) and point this notebook at their Inspect log dirs:\n",
+    "\n",
+    "```bash\n",
+    "agent_eval_bin --model-id glm-4.5 --no-archive --task-filter manifold- --log-dir <noarch>\n",
+    "agent_eval_bin --model-id glm-4.5            --task-filter manifold- \\\n",
+    "    --wayback-upstream https://wayback-cache.allegedly.works --log-dir <arch>\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "source": [
+    "from loom.gym.analyze_baselines import aggregate, as_of_clusters, crowd_baseline, paired_delta, read_run\n",
+    "\n",
+    "# Inspect `.eval` log dirs (local, or s3://loom-gym/agent-runs/...).\n",
+    "NOARCH_DIR = \"/tmp/baseline2/noarch\"\n",
+    "ARCH_DIR = \"/tmp/baseline2/arch\"\n",
+    "\n",
+    "runs = {\"no-archive\": read_run(NOARCH_DIR), \"archive\": read_run(ARCH_DIR), \"market crowd\": crowd_baseline()}\n",
+    "clusters = as_of_clusters()"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Absolute means (95% cluster-bootstrap CI)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "source": [
+    "print(f\"{'contestant':<14}{'n':>8}{'log loss (95% CI)':>26}{'Brier (95% CI)':>24}\")\n",
+    "for label, res in runs.items():\n",
+    "    ll, llci, n_sub, n_tot = aggregate(res, clusters, \"log_loss\")\n",
+    "    br, brci, _, _ = aggregate(res, clusters, \"brier\")\n",
+    "    print(f\"{label:<14}{f'{n_sub}/{n_tot}':>8}{ll:>9.3f} [{llci[0]:.3f}, {llci[1]:.3f}]   {br:>6.3f} [{brci[0]:.3f}, {brci[1]:.3f}]\")"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Paired per-task deltas (b − a; negative = b better)\n",
+    "\n",
+    "These cancel the shared task/era difficulty, so the same clusters resolve a much smaller effect with a tighter CI."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "source": [
+    "for a, b in [(\"no-archive\", \"archive\"), (\"market crowd\", \"no-archive\"), (\"market crowd\", \"archive\")]:\n",
+    "    for metric, name in ((\"log_loss\", \"log loss\"), (\"brier\", \"Brier\")):\n",
+    "        d, ci, n = paired_delta(runs[a], runs[b], clusters, metric)\n",
+    "        print(f\"{b} - {a:<13} {name:<9} {d:+.3f} [{ci[0]:+.3f}, {ci[1]:+.3f}]  (n={n})\")"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plots"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "labels = list(runs)\n",
+    "stats = {k: aggregate(runs[k], clusters, \"log_loss\") for k in labels}\n",
+    "means = [stats[k][0] for k in labels]\n",
+    "lo = [stats[k][0] - stats[k][1][0] for k in labels]\n",
+    "hi = [stats[k][1][1] - stats[k][0] for k in labels]\n",
+    "fig, ax = plt.subplots(figsize=(6, 4))\n",
+    "ax.bar(labels, means, yerr=[lo, hi], capsize=6, color=[\"#4c72b0\", \"#dd8452\", \"#999999\"])\n",
+    "ax.set_ylabel(\"mean log loss (lower is better)\")\n",
+    "ax.set_title(\"glm-4.5 on 33 resolved Manifold markets\\n95% cluster-bootstrap CI (clustered by as_of)\")\n",
+    "fig.tight_layout()"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Findings (run of 2026-06-11, glm-4.5)\n",
+    "\n",
+    "| contestant | n | log loss (95% CI) | Brier |\n",
+    "| --- | --- | --- | --- |\n",
+    "| no-archive | 32/33 | 0.903 [0.626, 1.255] | 0.311 |\n",
+    "| archive | **20/33** | 1.059 [0.580, 1.595] | 0.339 |\n",
+    "| market crowd | 33/33 | 0.796 [0.596, 0.993] | 0.278 |\n",
+    "\n",
+    "Paired deltas: `archive − no-archive` = **+0.152** [−0.213, +0.479] (n=19); `no-archive − crowd` = +0.116 [−0.130, +0.398] (n=32); `archive − crowd` = +0.122 [−0.344, +0.585] (n=20).\n",
+    "\n",
+    "**What's solid.** glm-4.5 is **statistically indistinguishable from the market crowd** — both agent arms' paired deltas vs. the crowd straddle 0. A capable model with only the dossier + its own knowledge matches the Manifold crowd on these resolved markets.\n",
+    "\n",
+    "**What is NOT yet trustworthy: whether the archive helps.** The `archive − no-archive` delta (+0.152, straddles 0) is confounded this run because **archive access was degraded by Internet-Archive HTTP 502s** (~40 failed CDX lookups). Consequences:\n",
+    "\n",
+    "1. **Archive produced only 20/33 submissions** (13 non-submissions / NaN) vs. 1/33 for no-archive — the agent burned its fixed turn budget retrying failing fetches and never submitted. So the archive arm is low-n with selection bias toward tasks that happened to finish.\n",
+    "2. This is therefore *flaky archive* vs. no-archive, not *archive* vs. no-archive.\n",
+    "\n",
+    "**Do not conclude the archive is useless.** Conclude that a *degraded* archive plus a fixed turn budget hurts. A trustworthy `archive − no-archive` needs the cache reliability fixes first (retry IA 502s on the cache hop; capture upstream error bodies for diagnosis), and likely a higher message limit and/or a \"submit a best guess before you run out of turns\" nudge so a flaky archive can't manufacture non-submissions."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"},
+  "language_info": {"name": "python", "version": "3.13"}
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Tooling + writeup for the first baseline pass (glm-4.5: archive vs no-network on the 33-market panel).

## `analyze_baselines.py` (+ `analyze_baselines_bin`)
Reads two Inspect agent-eval log dirs, extracts per-task log loss / Brier from the gym scorer, and compares them against the market crowd (`prob_at_as_of`). Every mean carries a 95% **cluster-bootstrap CI clustered by `as_of`**; it also reports **paired per-task deltas** (which cancel shared task difficulty — far tighter than two absolute means at n=33) and writes two plots (mean log loss with CI whiskers; submitted vs. market probability).

```
analyze_baselines_bin --run no-archive=<dir> --run archive=<dir> --out <plots>
```

## `baseline_analysis.ipynb`
A reproducible writeup wrapping the same functions, with the first run's numbers and conclusions.

### Findings (run of 2026-06-11, glm-4.5)
- **glm-4.5 ≈ the Manifold crowd** — both agent arms' paired deltas vs. the crowd straddle 0 (`no-archive − crowd` +0.116 [−0.130, +0.398], n=32). Solid.
- **Whether the archive helps is not yet trustworthy.** `archive − no-archive` = +0.152 [−0.213, +0.479] (n=19), but the archive arm was degraded by Internet-Archive **HTTP 502s** (~40 failed CDX lookups) → only **20/33 submissions** (13 non-submissions, the agent burned its turn budget retrying failing fetches). So it's *flaky archive* vs. no-archive, not a clean comparison.

Follow-ups this surfaced (separate PRs): IA-502 retries + upstream-error-body capture in the wayback proxy/cache; likely a higher message limit / "submit before you run out of turns" nudge.

Note: the analyzer's lint (ruff+mypy aspect) is clean; the notebook isn't a build target (committed as a doc, matching the repo's existing `website/notebooks/`).

https://claude.ai/code/session_01AXSFxfCXddADoSKTjgF5Nz

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXSFxfCXddADoSKTjgF5Nz)_