### PR TITLE
loom/wayback: retry IA 5xx + capture upstream error bodies

### DIFF
--- a/cluster/k8s/wayback-cache/config/nginx.conf
+++ b/cluster/k8s/wayback-cache/config/nginx.conf
@@ -129,6 +129,16 @@ http {
         proxy_connect_timeout 10s;
         proxy_read_timeout 60s;
 
+        # IA returns sporadic 502/503/504 under load (a bad gateway behind its
+        # own LB, not a real miss). Retry the same upstream a couple more times
+        # before surfacing the failure; with one server in `upstream ia` these
+        # are sequential re-attempts against IA. GET-only (CDX + content fetches
+        # are idempotent), so non_idempotent is intentionally left off. Our own
+        # limit_req 503s are generated before proxy_pass and so are unaffected.
+        proxy_next_upstream error timeout http_502 http_503 http_504;
+        proxy_next_upstream_tries 3;
+        proxy_next_upstream_timeout 60s;
+
         # CDX index lookups are slow at IA (10-25s) and every clamp issues one:
         # give them a more generous bucket and a longer read timeout so a queued
         # query rides out the wait instead of 504-ing, and never competes with

--- a/loom/gym/agent_eval.py
+++ b/loom/gym/agent_eval.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import argparse
 import logging
 import os
+from collections import Counter
 from pathlib import Path
 
 from inspect_ai import eval as inspect_eval
@@ -106,8 +107,12 @@ def main() -> None:
             meta = score.metadata or {}
             served = meta.get("served_evidence", [])
             fetched = " ".join(record["url"] for record in served) or "-"
+            statuses = Counter(record["status"] for record in meta.get("upstream_errors", []))
+            err_note = (
+                " upstream_errors=" + ",".join(f"{s}×{n}" for s, n in sorted(statuses.items())) if statuses else ""
+            )
             note = f" submission_error={meta['submission_error']}" if "submission_error" in meta else ""
-            print(f"{sample.id}: value={score.value} answer={score.answer!r}{note} fetched=[{fetched}]")
+            print(f"{sample.id}: value={score.value} answer={score.answer!r}{note} fetched=[{fetched}]{err_note}")
 
 
 if __name__ == "__main__":

--- a/loom/gym/inspect_harness.py
+++ b/loom/gym/inspect_harness.py
@@ -271,12 +271,12 @@ def headline_metric(metrics: dict[str, float], kind: str) -> str:
     return "mean_pinball_log" if "mean_pinball_log" in metrics else "mean_pinball"
 
 
-async def _served_evidence() -> list[dict[str, object]]:
+async def _read_manifest() -> list[dict[str, object]]:
     try:
         manifest_text = await sandbox("proxy").read_file(MANIFEST_PATH)
     except FileNotFoundError:
-        # The proxy creates the manifest lazily on its first served response;
-        # absence just means this sample fetched nothing.
+        # The proxy creates the manifest lazily on its first emitted record;
+        # absence just means this sample neither fetched nor hit an upstream error.
         return []
     return [json.loads(line) for line in manifest_text.splitlines() if line]
 
@@ -286,7 +286,13 @@ def gym_proper_loss(*, archive: bool = True):
     async def score_fn(state: TaskState, target: Target) -> Score:
         gym_task = Task.model_validate(state.metadata["gym_task"])
         # No-archive runs have no `proxy` service, so sandbox("proxy") would raise.
-        served = await _served_evidence() if archive else []
+        records = await _read_manifest() if archive else []
+        # Records are untyped JSON the proxy emitted; split by `kind` so served
+        # evidence and upstream failures (IA 5xx) are surfaced as distinct
+        # diagnostics rather than one mixed list the consumer must re-sort.
+        served = [r for r in records if r.get("kind") == "served"]
+        upstream_errors = [r for r in records if r.get("kind") == "upstream_error"]
+        evidence = {"served_evidence": served, "upstream_errors": upstream_errors}
         # A contestant that emits no parseable answer (ran out of turns, wrote
         # prose) is a non-submission, not a crash: record it as NaN with the
         # reason so the run can report a submission rate separately from loss.
@@ -296,13 +302,13 @@ def gym_proper_loss(*, archive: bool = True):
             return Score(
                 value=float("nan"),
                 answer=state.output.completion,
-                metadata={"submission_error": f"{type(error).__name__}: {error}", "served_evidence": served},
+                metadata={"submission_error": f"{type(error).__name__}: {error}", **evidence},
             )
         task_score = scoring.score(gym_task, answer)
         return Score(
             value=task_score.metrics[headline_metric(task_score.metrics, gym_task.question.kind)],
             answer=state.output.completion,
-            metadata={**task_score.metrics, "served_evidence": served},
+            metadata={**task_score.metrics, **evidence},
         )
 
     return score_fn

--- a/loom/wayback_proxy/README.md
+++ b/loom/wayback_proxy/README.md
@@ -7,7 +7,10 @@ or before the cutoff → 404. Explicit `web.archive.org/web/<ts>/…` requests a
 clamped (`ts ≤ as_of`), CDX queries get their `to=` bound clamped, and redirect
 hops are re-clamped (IA canonicalizes toward the _closest_ capture, which can
 walk forward in time). Every served response is logged as a JSONL evidence line
-`{url, capture_ts, sha256, size}` on stdout.
+`{kind: "served", url, capture_ts, sha256, size}` on stdout; an unexpected
+upstream failure (IA/cache HTTP ≥400 that isn't an archived error page) is logged
+on the same stream as `{kind: "upstream_error", request_url, status, body}` (body
+truncated) so a degraded run is diagnosable rather than collapsing into an opaque 502.
 
 It runs as an embedded [mitmproxy](https://mitmproxy.org/) (a
 [`WaybackAddon`](addon.py) answers every flow from the archive), so **agents

--- a/loom/wayback_proxy/proxy.py
+++ b/loom/wayback_proxy/proxy.py
@@ -36,6 +36,10 @@ CDX_PATH = "/cdx/search/cdx"
 ARCHIVE_HOST = "web.archive.org"
 MAX_REDIRECT_HOPS = 10
 MAX_BODY_BYTES = 64 * 2**20
+# Upstream error bodies (IA/cache 5xx pages) are captured to the manifest for
+# diagnosis; a few KB of the HTML is enough to tell a bad-gateway page from a
+# rate-limit notice without bloating the per-sample evidence.
+MAX_ERROR_BODY_BYTES = 4096
 
 # "/web/<ts><modifier?>/<url>" — IA replay path. Modifiers are two letters
 # plus underscore (id_, if_, im_, js_, cs_, ...).
@@ -194,6 +198,7 @@ class WaybackResolver:
         async with self._session.get(URL(self._config.upstream + CDX_PATH), params=params) as response:
             body = await response.content.read(MAX_BODY_BYTES)
             if response.status != 200:
+                self._emit_upstream_error(str(response.url), response.status, body)
                 raise UpstreamError(f"CDX query failed with HTTP {response.status}")
             return ProxyResponse(
                 status=200, headers={"Content-Type": response.headers.get("Content-Type", "text/plain")}, body=body
@@ -204,6 +209,9 @@ class WaybackResolver:
         params = {"url": str(target), "to": self._config.as_of_ts, "output": "json", "limit": "-1"}
         async with self._session.get(URL(self._config.upstream + CDX_PATH), params=params) as response:
             if response.status != 200:
+                self._emit_upstream_error(
+                    str(response.url), response.status, await response.content.read(MAX_ERROR_BODY_BYTES)
+                )
                 raise UpstreamError(f"CDX lookup failed with HTTP {response.status}")
             raw = await response.content.read(MAX_BODY_BYTES)
         if not raw.strip():
@@ -267,6 +275,7 @@ class WaybackResolver:
                 # 404s/500s (which are correct as-of content). Error statuses
                 # without it are the archive/cache itself failing.
                 if response.status >= 400 and "Memento-Datetime" not in response.headers:
+                    self._emit_upstream_error(str(response.url), response.status, body)
                     raise UpstreamError(f"archive upstream returned HTTP {response.status} for {current}")
                 content_type = response.headers.get("Content-Type", "application/octet-stream")
                 return Snapshot(ts=final_ts, status=response.status, content_type=content_type, body=body)
@@ -285,10 +294,28 @@ class WaybackResolver:
         """Served-evidence record; the harness attaches these to the run payload (W3)."""
         line = json.dumps(
             {
+                "kind": "served",
                 "url": url,
                 "capture_ts": snapshot.ts,
                 "sha256": hashlib.sha256(snapshot.body).hexdigest(),
                 "size": len(snapshot.body),
+            }
+        )
+        print(line, file=self._manifest, flush=True)
+
+    def _emit_upstream_error(self, request_url: str, status: int, body: bytes) -> None:
+        """Upstream-failure record: archive/cache returned HTTP ≥400 unexpectedly
+        (an IA bad gateway or a rate-limit notice, not an archived error page).
+
+        Shares the manifest with served records, tagged by `kind`, so the harness
+        surfaces a degraded run's failures per sample instead of swallowing the
+        body into an opaque 502."""
+        line = json.dumps(
+            {
+                "kind": "upstream_error",
+                "request_url": request_url,
+                "status": status,
+                "body": body[:MAX_ERROR_BODY_BYTES].decode("utf-8", errors="replace"),
             }
         )
         print(line, file=self._manifest, flush=True)

--- a/loom/wayback_proxy/test_proxy.py
+++ b/loom/wayback_proxy/test_proxy.py
@@ -102,6 +102,7 @@ async def test_manifest_records_served_evidence(fetch: Fetch, manifest: io.Strin
     await fetch(fake_ia.EXAMPLE_URL)
     record = json.loads(manifest.getvalue())
     assert record == {
+        "kind": "served",
         "url": fake_ia.EXAMPLE_URL,
         "capture_ts": fake_ia.GOOD_TS,
         "sha256": hashlib.sha256(fake_ia.EXAMPLE_BODY).hexdigest(),
@@ -148,6 +149,17 @@ async def test_archived_404_is_served_as_of_content(fetch: Fetch) -> None:
 async def test_cdx_failure_maps_to_502(fetch: Fetch) -> None:
     result = await fetch(fake_ia.CDX_BROKEN_URL)
     assert result.status == 502
+
+
+async def test_upstream_error_body_recorded_to_manifest(fetch: Fetch, manifest: io.StringIO) -> None:
+    # A CDX 503 from IA must be captured (status + body) for diagnosis, not
+    # swallowed into an opaque 502 — the body distinguishes a bad gateway from
+    # a rate-limit notice when a degraded archive run is post-mortemed.
+    await fetch(fake_ia.CDX_BROKEN_URL)
+    record = json.loads(manifest.getvalue())
+    assert record["kind"] == "upstream_error"
+    assert record["status"] == 503
+    assert record["body"] == "CDX is having a bad day\n"
 
 
 async def test_explicit_pinned_capture_within_as_of_served(fetch: Fetch) -> None:


### PR DESCRIPTION
## Why

The archive baseline arm (glm-4.5, 33-task burst) hit ~40 Internet-Archive **HTTP 502s** on CDX lookups. The proxy collapsed every such failure into an opaque `502` with the upstream body discarded, and the agent burned its fixed turn budget retrying the failing fetches — producing **13 non-submissions** (vs 1/33 for the no-network arm). That makes the `archive − no-archive` comparison untrustworthy: it's measuring a *degraded* archive, not the archive.

Two reliability fixes so a re-run is trustworthy and diagnosable:

## What

**1. Retry transient IA 5xx on the cache hop** (`cluster/k8s/wayback-cache/config/nginx.conf`)

On the tier-2 (loopback → IA) server, add `proxy_next_upstream error timeout http_502 http_503 http_504` with `proxy_next_upstream_tries 3` / `proxy_next_upstream_timeout 60s`. IA's 5xx under burst load are transient bad gateways behind its own LB, not real misses. Requests are GET-only (CDX + immutable content fetches), so the retries are safe. Our own `limit_req` 503s are generated *before* `proxy_pass`, so they're unaffected — only genuine IA failures are retried.

**2. Capture upstream error bodies** (`loom/wayback_proxy/proxy.py`, `loom/gym/inspect_harness.py`, `loom/gym/agent_eval.py`)

At the three `UpstreamError` sites (CDX query, CDX lookup, capture fetch) the proxy now reads a truncated (~4KB) response body and emits an `{kind: "upstream_error", request_url, status, body}` record to the manifest — alongside the served-evidence lines, which are now tagged `{kind: "served"}`. The gym harness splits the manifest by `kind` and attaches `upstream_errors` to the score metadata; `agent_eval` prints a per-sample status histogram (e.g. `upstream_errors=502×3`) so a degraded run is diagnosable instead of swallowing the failure into an opaque 502.

## Test

- `//loom/wayback_proxy:test_proxy` — updated the served-evidence record assertion for the `kind` tag; added `test_upstream_error_body_recorded_to_manifest` (CDX 503 → manifest captures status + body).
- `//loom/gym:test_inspect_harness` — Docker harness test still green (served evidence rides through unchanged).
- Both pass on RBE; ruff + mypy lint aspects green.

After this lands I'll re-run the archive arm for a trustworthy `archive − no-archive` delta.

https://claude.ai/code/session_01AXSFxfCXddADoSKTjgF5Nz

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXSFxfCXddADoSKTjgF5Nz)_