### PR TITLE
devinfra/x: clarify runner recycle signal

### DIFF
--- a/devinfra/x/ci_build_profile_analysis/README.md
+++ b/devinfra/x/ci_build_profile_analysis/README.md
@@ -24,11 +24,12 @@ analysis cache survives CI runs. This investigation separates:
 The main suspected hole: the newer runner-recycle analysis classifies only the outer runner
 header. It does not independently measure inner Bazel analysis work in CI.
 
-## Outer Runner Snapshot-Reuse Stats
+## Outer Runner Workspace-Reuse Stats
 
-`runner_recycle_stats.py` classifies BuildBuddy Firecracker runner invocations as warm or
-cold from BuildBuddy history. It answers the outer-VM question only: did the `HOSTED_BAZEL`
-`remote ...` runner resume from a snapshot or start from an empty workspace?
+`runner_recycle_stats.py` is a pre-probe historical classifier for BuildBuddy runner
+invocations. It answers a narrower question than its original name suggested: did the
+`HOSTED_BAZEL` `remote ...` runner take the existing-workspace setup path or the fresh-clone
+setup path?
 
 Every `bbr`/CI run dispatches a `ci_runner` Firecracker VM configured in
 `../../bbr.json` with:
@@ -39,21 +40,39 @@ Every `bbr`/CI run dispatches a `ci_runner` Firecracker VM configured in
 "snapshot-read-policy": "newest"
 ```
 
-The runner's first console lines are the empirical signal:
+The runner's first console lines are the empirical signal for that setup path:
 
-| Verdict  | Console header                                                                             | What it proves                                                                                                         |
-| -------- | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
-| **warm** | `Syncing existing repo...` -> shallow `git fetch --depth=1` + `git clean` + `git checkout` | the runner workspace/output-base came from a previous snapshot; external repos and Bazel server state may be available |
-| **cold** | `Cloning ...`                                                                              | a fresh VM/workspace was used, so the runner redoes clone/fetch/setup work before invoking Bazel                       |
+| Verdict            | Console header                                                                             | What it proves                                                                                    |
+| ------------------ | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| **warm workspace** | `Syncing existing repo...` -> shallow `git fetch --depth=1` + `git clean` + `git checkout` | `bb remote` found an existing `repo-root`; the adjacent output-base may also contain useful state |
+| **cold workspace** | `Cloning ...`                                                                              | `bb remote` did not find the existing checkout and had to create one before invoking Bazel        |
 
-Warm outer-runner reuse is not the same claim as "the Bazel analysis cache did no work".
+Why this was originally treated as warm/cold runner evidence: in normal `bb remote` setup,
+`Syncing existing repo...` means the runner sees `/home/buildbuddy/workspace/repo-root` from a
+previous run and refreshes it in place, while `Cloning ...` means the workspace is empty. Since
+the Bazel output base is outside `repo-root`, a warm workspace often correlates with preserved
+external repos and possibly a surviving Bazel server.
+
+That is still only a proxy. It should not be treated as proof of Firecracker process-memory
+resume or proof that Bazel analysis did no work. For post-instrumentation CI runs, prefer the
+stronger probe/linkage signals:
+
+- `CI_VM_PROBE_SUMMARY phase=before-test previous_run_log=yes`, showing the VM-local probe
+  directory from an earlier run survived into this runner;
+- `CI_VM_PROBE_SERVER ...` before the first Bazel command, showing a Bazel server already
+  existed before CI started Bazel;
+- the uploaded probe bundle's `previous/probes.jsonl` and `previous/proc/...` raw files,
+  especially raw `/proc/<pid>/stat` `start_ticks` and `cmdline_sha256`;
+- the GitHub linkage artifact, which ties the GitHub run to the BuildBuddy runner invocation,
+  child Bazel invocations, and probe CAS digest.
+
 Use BES metrics, Bazel profiles, and probe bundles from this investigation to answer the inner
-Bazel question.
+Bazel analysis-cache question.
 
 Usage:
 
 ```bash
-# Full sample over the densest recent window
+# Historical setup-path sample over the densest recent window
 devinfra/x/ci_build_profile_analysis/runner_recycle_stats.py --count 600
 
 # Wider window (API pages by recency; larger N == more hours)

--- a/devinfra/x/ci_build_profile_analysis/runner_recycle_stats.py
+++ b/devinfra/x/ci_build_profile_analysis/runner_recycle_stats.py
@@ -1,23 +1,23 @@
 #!/usr/bin/env python3
-"""Estimate how often bbr/CI Firecracker runners reuse a snapshot vs cold-start.
+"""Estimate how often bbr/CI runners see a warm vs cold workspace.
 
 Each `bbr`/CI run dispatches a ci_runner Firecracker VM (the `HOSTED_BAZEL`
 "remote ..." invocation, configured in devinfra/bbr.json with recycle-runner,
 remote-snapshot-save-policy=always, snapshot-read-policy=newest). The runner's
-first console lines reveal whether the VM resumed from a snapshot:
+first console lines reveal which workspace setup path `bb remote` took:
 
-  warm (snapshot reused):  "Syncing existing repo..." -> shallow git fetch +
-                           git clean + git checkout. repo and Bazel output-base
-                           survive, so external repos and Bazel server state may
-                           be available.
-  cold (fresh VM):         "Cloning ..." -> full clone, re-fetch every external
-                           repo, reload all packages ("redoing repo fetch work").
+  warm workspace: "Syncing existing repo..." -> shallow git fetch + git clean +
+                  git checkout. The existing checkout survived and the adjacent
+                  Bazel output-base may contain useful state.
+  cold workspace: "Cloning ..." -> full clone before invoking Bazel.
 
-This classifies only the outer runner VM. Use BES metrics and Bazel profiles to
-answer whether the inner Bazel analysis cache did any work. There is no clean
-structured field for runner warm/cold state; the console header is authoritative.
+This is a historical proxy, not definitive proof of Firecracker process-memory
+resume. For post-instrumentation CI runs, prefer CI_VM_PROBE_* data and the
+uploaded probe bundles. Use BES metrics and Bazel profiles to answer whether the
+inner Bazel analysis cache did any work.
+
 We list runner invocations via `bbapi`, fetch each runner's console via `bb view`,
-and classify.
+and classify the workspace setup path.
 
 Usage:
   ./runner_recycle_stats.py [--count N] [--workers W] [--gaps-only] [--json]
@@ -71,7 +71,7 @@ def post_gap_candidates(runners: list[dict], gap_min: float) -> set[str]:
 
 
 def classify(invocation_id: str) -> str:
-    """warm | cold | unknown, from the runner's console header."""
+    """warm | cold | unknown workspace setup path, from the runner console header."""
     proc = subprocess.run(["bb", "view", invocation_id], check=False, capture_output=True, text=True)
     header = "\n".join(proc.stdout.splitlines()[:10])
     m = _MARKERS.search(header)
@@ -125,8 +125,8 @@ def main() -> None:
         f"window: {span_h:.1f}h  runner invocations: {len(runners)}  "
         f"classified: {total}{' (post-gap firsts only)' if args.gaps_only else ''}"
     )
-    print(f"  warm (snapshot reused): {counts['warm']}")
-    print(f"  cold (fresh VM):        {counts['cold']}")
+    print(f"  warm workspace: {counts['warm']}")
+    print(f"  cold workspace: {counts['cold']}")
     if counts["unknown"]:
         print(f"  unknown:                {counts['unknown']}")
     print(f"  warm rate: {warm_pct:.1f}%")


### PR DESCRIPTION
## Summary
- clarify that runner_recycle_stats classifies the bb remote workspace setup path, not definitive Firecracker process-memory reuse
- document why the Syncing vs Cloning header was used historically
- point post-instrumentation investigations at stronger CI_VM_PROBE and linkage signals

## Validation
- python3 -m py_compile devinfra/x/ci_build_profile_analysis/runner_recycle_stats.py
- pre-commit run --files devinfra/x/ci_build_profile_analysis/README.md devinfra/x/ci_build_profile_analysis/runner_recycle_stats.py