### PR TITLE
Pin Tana LiteLLM models to custom provider

### DIFF
--- a/cluster/k8s/litellm/tana/generate_tana_litellm.py
+++ b/cluster/k8s/litellm/tana/generate_tana_litellm.py
@@ -21,7 +21,7 @@ _CUSTOM_HANDLER = "custom_handler.tana_handler"
 def _model_entry(model_id: str) -> dict:
     return {
         "model_name": model_id,
-        "litellm_params": {"model": f"tana/{model_id}"},
+        "litellm_params": {"model": f"tana/{model_id}", "custom_llm_provider": "tana"},
         "model_info": {"mode": "chat", "supports_function_calling": True},
     }
 

--- a/cluster/k8s/litellm/tana/proxy-config.yaml
+++ b/cluster/k8s/litellm/tana/proxy-config.yaml
@@ -3,396 +3,462 @@ model_list:
   - model_name: gpt-4o-mini
     litellm_params:
       model: tana/gpt-4o-mini
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: o3-mini
     litellm_params:
       model: tana/o3-mini
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: o1
     litellm_params:
       model: tana/o1
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: o1-2024-12-17
     litellm_params:
       model: tana/o1-2024-12-17
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: o1-preview
     litellm_params:
       model: tana/o1-preview
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: o1-preview-2024-09-12
     litellm_params:
       model: tana/o1-preview-2024-09-12
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: gpt-4.5-preview
     litellm_params:
       model: tana/gpt-4.5-preview
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: gpt-4.5-preview-2025-02-27
     litellm_params:
       model: tana/gpt-4.5-preview-2025-02-27
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: o4-mini
     litellm_params:
       model: tana/o4-mini
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: o4-mini-2025-04-16
     litellm_params:
       model: tana/o4-mini-2025-04-16
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: o3
     litellm_params:
       model: tana/o3
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: o3-2025-04-16
     litellm_params:
       model: tana/o3-2025-04-16
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: o3-pro
     litellm_params:
       model: tana/o3-pro
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: o3-pro-2025-06-10
     litellm_params:
       model: tana/o3-pro-2025-06-10
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: gpt-4.1-mini
     litellm_params:
       model: tana/gpt-4.1-mini
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: gpt-4.1-mini-2025-04-14
     litellm_params:
       model: tana/gpt-4.1-mini-2025-04-14
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: gpt-4.1-nano
     litellm_params:
       model: tana/gpt-4.1-nano
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: gpt-4.1-nano-2025-04-14
     litellm_params:
       model: tana/gpt-4.1-nano-2025-04-14
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: gpt-5
     litellm_params:
       model: tana/gpt-5
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: gpt-5-mini
     litellm_params:
       model: tana/gpt-5-mini
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: gpt-5-nano
     litellm_params:
       model: tana/gpt-5-nano
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: gpt-5.1/none
     litellm_params:
       model: tana/gpt-5.1/none
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: gpt-5.1/low
     litellm_params:
       model: tana/gpt-5.1/low
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: gpt-5.1/medium
     litellm_params:
       model: tana/gpt-5.1/medium
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: gpt-5.1/high
     litellm_params:
       model: tana/gpt-5.1/high
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: gpt-5.1/extended
     litellm_params:
       model: tana/gpt-5.1/extended
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: gpt-5.2/none
     litellm_params:
       model: tana/gpt-5.2/none
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: gpt-5.2/low
     litellm_params:
       model: tana/gpt-5.2/low
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: gpt-5.2/medium
     litellm_params:
       model: tana/gpt-5.2/medium
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: gpt-5.2/high
     litellm_params:
       model: tana/gpt-5.2/high
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: gpt-5.4/none
     litellm_params:
       model: tana/gpt-5.4/none
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: gpt-5.4/low
     litellm_params:
       model: tana/gpt-5.4/low
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: gpt-5.4/medium
     litellm_params:
       model: tana/gpt-5.4/medium
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: gpt-5.4/high
     litellm_params:
       model: tana/gpt-5.4/high
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: claude-3-5-sonnet-latest
     litellm_params:
       model: tana/claude-3-5-sonnet-latest
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: claude-3-7-sonnet-20250219
     litellm_params:
       model: tana/claude-3-7-sonnet-20250219
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: claude-3-7-sonnet-20250219/extended
     litellm_params:
       model: tana/claude-3-7-sonnet-20250219/extended
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: claude-sonnet-4-20250514
     litellm_params:
       model: tana/claude-sonnet-4-20250514
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: claude-sonnet-4-20250514/extended
     litellm_params:
       model: tana/claude-sonnet-4-20250514/extended
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: claude-sonnet-4-5-20250929
     litellm_params:
       model: tana/claude-sonnet-4-5-20250929
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: claude-haiku-4-5-20251001
     litellm_params:
       model: tana/claude-haiku-4-5-20251001
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: claude-opus-4-1-20250805
     litellm_params:
       model: tana/claude-opus-4-1-20250805
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: claude-opus-4-5-20251101/low
     litellm_params:
       model: tana/claude-opus-4-5-20251101/low
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: claude-opus-4-5-20251101/medium
     litellm_params:
       model: tana/claude-opus-4-5-20251101/medium
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: claude-opus-4-5-20251101/high
     litellm_params:
       model: tana/claude-opus-4-5-20251101/high
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: claude-sonnet-4-6/low
     litellm_params:
       model: tana/claude-sonnet-4-6/low
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: claude-sonnet-4-6/medium
     litellm_params:
       model: tana/claude-sonnet-4-6/medium
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: claude-sonnet-4-6/high
     litellm_params:
       model: tana/claude-sonnet-4-6/high
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: claude-opus-4-6/low
     litellm_params:
       model: tana/claude-opus-4-6/low
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: claude-opus-4-6/medium
     litellm_params:
       model: tana/claude-opus-4-6/medium
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: claude-opus-4-6/high
     litellm_params:
       model: tana/claude-opus-4-6/high
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: gemini-2.0-flash
     litellm_params:
       model: tana/gemini-2.0-flash
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: gemini-2.0-flash-lite-preview-02-05
     litellm_params:
       model: tana/gemini-2.0-flash-lite-preview-02-05
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: gemini-2.5-flash-preview-04-17
     litellm_params:
       model: tana/gemini-2.5-flash-preview-04-17
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: gemini-2.5-flash-preview-04-17/reasoning
     litellm_params:
       model: tana/gemini-2.5-flash-preview-04-17/reasoning
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: gemini-2.5-flash
     litellm_params:
       model: tana/gemini-2.5-flash
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: gemini-2.5-flash/reasoning
     litellm_params:
       model: tana/gemini-2.5-flash/reasoning
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: gemini-2.5-pro
     litellm_params:
       model: tana/gemini-2.5-pro
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: gemini-3-pro-preview/low
     litellm_params:
       model: tana/gemini-3-pro-preview/low
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: gemini-3-pro-preview/high
     litellm_params:
       model: tana/gemini-3-pro-preview/high
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: gemini-3-pro-image-preview
     litellm_params:
       model: tana/gemini-3-pro-image-preview
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: gemini-3-flash-preview/low
     litellm_params:
       model: tana/gemini-3-flash-preview/low
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: gemini-3-flash-preview/high
     litellm_params:
       model: tana/gemini-3-flash-preview/high
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: gemini-3.1-pro-preview/low
     litellm_params:
       model: tana/gemini-3.1-pro-preview/low
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: gemini-3.1-pro-preview/medium
     litellm_params:
       model: tana/gemini-3.1-pro-preview/medium
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true
   - model_name: gemini-3.1-pro-preview/high
     litellm_params:
       model: tana/gemini-3.1-pro-preview/high
+      custom_llm_provider: tana
     model_info:
       mode: chat
       supports_function_calling: true

--- a/cluster/k8s/litellm/tana/test_generate_tana_litellm.py
+++ b/cluster/k8s/litellm/tana/test_generate_tana_litellm.py
@@ -24,6 +24,7 @@ def test_tana_litellm_exposes_every_responding_model_once() -> None:
     expected = [model.model_id for model in TANA_LLM_PROXY_RESPONDING_MODELS]
     assert configured == expected
     assert len(configured) == len(set(configured))
+    assert all(entry["litellm_params"]["custom_llm_provider"] == "tana" for entry in config["model_list"])
 
 
 def test_custom_handler_config_uses_adjacent_import_shim() -> None:

--- a/tana/litellm_proxy/test_proxy_runtime.py
+++ b/tana/litellm_proxy/test_proxy_runtime.py
@@ -58,6 +58,7 @@ def test_litellm_proxy_config_registers_custom_provider_before_router_build(tmp_
               - model_name: gpt-4o-mini
                 litellm_params:
                   model: tana/gpt-4o-mini
+                  custom_llm_provider: tana
                 model_info:
                   mode: chat
                   supports_function_calling: true
@@ -120,6 +121,7 @@ def test_litellm_proxy_config_registers_custom_provider_before_router_build(tmp_
             assert deployments is not None
             assert len(deployments) == 1
             assert deployments[0]["litellm_params"]["model"] == "tana/gpt-4o-mini"
+            assert deployments[0]["litellm_params"]["custom_llm_provider"] == "tana"
 
             tana_handler = _get_tana_handler()
             original_client = tana_handler._client


### PR DESCRIPTION
## Summary
- set `custom_llm_provider: tana` on every generated Tana LiteLLM model entry
- keep generated config parity covered by tests
- make the proxy runtime test exercise the explicit provider field

## Validation
- `nix develop -c bazelisk test //tana/litellm_proxy/... //cluster/k8s/litellm/tana:test_generate_tana_litellm`
- `nix develop -c pre-commit run --files cluster/k8s/litellm/tana/generate_tana_litellm.py cluster/k8s/litellm/tana/proxy-config.yaml cluster/k8s/litellm/tana/test_generate_tana_litellm.py tana/litellm_proxy/test_proxy_runtime.py`