### PR TITLE
debundle: multi-hole ordered-subsequence matching + bare-keyword anonymous holes

### DIFF
--- a/devinfra/js/debundle/docs/guide.md
+++ b/devinfra/js/debundle/docs/guide.md
@@ -374,15 +374,22 @@ members:
     name: Counter
 ```
 
-A list takes **at most one** hole — a second `STMT_LIST_*` in the same block,
-or a second `CLASS_REST` in the same class body, is ambiguous and never
-matches. The members or statements you pin around the hole are still matched
-**in order and contiguously**: the elements before the hole must be the
-candidate's leading elements, in that order, and the elements after it the
-candidate's trailing elements, with the hole absorbing only the contiguous
-middle. So `class K { a() { … } b() { … } CLASS_REST; }` matches a class whose
-**first two** members are `a` then `b` (in that order), followed by anything —
-it is _not_ an unordered "class that contains `a` and `b` somewhere" match.
+A list may take **several** holes. Each hole is a gap, and the members or
+statements you pin between the holes are matched as an **ordered subsequence**:
+in source order, each pinned run contiguous, with every hole absorbing an
+arbitrary run (including none) of the candidate's elements. With no leading
+hole the first pinned run is anchored to the candidate's start; with no
+trailing hole the last pinned run is anchored to its end. So
+`class K { a() { … } b() { … } CLASS_REST; }` matches a class whose **first
+two** members are `a` then `b`, followed by anything, while
+`class K { CLASS_REST; open() { … } CLASS_REST; close() { … } CLASS_REST; }`
+matches any class with an `open` method somewhere before a `close` method.
+Either way the match is ordered — it is _not_ an unordered "contains these
+somewhere" match, and pinning `close` before `open` would not match a class
+that defines `open` first. When more than one alignment is possible the
+leftmost is used; that interior choice never changes _which_ declaration
+matched, and a selector that matches more than one top-level declaration is
+still a hard error.
 
 A hole works in **any** position — leading, middle, or trailing. Under
 `alpha_all`, identifiers match by an alpha-correspondence the matcher builds as

--- a/devinfra/js/debundle/docs/guide.md
+++ b/devinfra/js/debundle/docs/guide.md
@@ -337,27 +337,30 @@ anonymous_statements:
         }
 ```
 
-Identifier expressions whose names start with `EXPR_` match one arbitrary
-expression subtree. Bare expression statements whose names start with `STMT_`
-match one arbitrary statement. Reusing the same placeholder name requires the
-same candidate subtree/statement everywhere it appears. When you don't need
-that equality, use the **bare prefix** as an anonymous wildcard — `EXPR_`,
-`STMT_`, `STMT_LIST_`, or `CLASS_REST` with no suffix — and every occurrence
-matches independently, so there's no need to mint a unique name per
-placeholder. These are still structural selectors: surrounding syntax is exact
-after the identifier policy is applied, and ambiguous matches are rejected
-rather than resolved by source order.
+Each hole keyword has two forms. The **bare keyword** is an anonymous
+wildcard: every occurrence matches independently, so there's no need to mint a
+unique name per throwaway placeholder. The **named form** `KEYWORD_name` binds
+for cross-occurrence equality — the same name must match the same
+candidate subtree/statement everywhere it appears. So `EXPR` is the identifier
+expression that matches one arbitrary expression subtree, and `EXPR_left`
+matches one too but forces every `EXPR_left` to be the same subtree; `STMT` and
+`STMT_setup` are the single-statement equivalents. For example, `foo(EXPR)`
+matches both `foo(123)` and `foo(456)`, and `bar(EXPR, EXPR)` matches
+`bar(1, 2)` (the two holes are independent), whereas `bar(EXPR_x, EXPR_x)` only
+matches a call whose two arguments are identical. These are still structural
+selectors: surrounding syntax is exact after the identifier policy is applied,
+and ambiguous matches are rejected rather than resolved by source order.
 
 Two variable-length **list holes** absorb a contiguous run rather than a
 single node — ideal for pinning a class by a stable skeleton without copying
 its whole minified body:
 
-- A bare `STMT_LIST_*;` statement in a block body matches any run of
-  statements (including none) at that position — e.g. a method or function
-  body you do not want to spell out.
-- A bare `CLASS_REST;` class field (no initializer) matches the remaining
-  class members — "this class by these members, ignore the rest".
-  `CLASS_REST` is an exact token (not a prefix).
+- A bare `STMT_LIST;` statement (or named `STMT_LIST_name;`) in a block body
+  matches any run of statements (including none) at that position — e.g. a
+  method or function body you do not want to spell out.
+- A bare `CLASS_REST;` class field (no initializer) matches a run of class
+  members — "this class by these members, ignore the rest". `CLASS_REST` is an
+  exact token (not a prefix).
 
 ```yaml
 members:
@@ -395,7 +398,7 @@ A hole works in **any** position — leading, middle, or trailing. Under
 `alpha_all`, identifiers match by an alpha-correspondence the matcher builds as
 it walks both trees, and a hole never contributes the identifiers it absorbs,
 so the members or statements after a hole still match by their own structure
-rather than by absolute position. (Single-node `EXPR_`/`STMT_` holes share this
+rather than by absolute position. (Single-node `EXPR`/`STMT` holes share this
 property.)
 
 ## Workflow: renaming a binding without moving

--- a/devinfra/js/debundle/e2e/syntactic_holes_test.rs
+++ b/devinfra/js/debundle/e2e/syntactic_holes_test.rs
@@ -1,15 +1,20 @@
 //! End-to-end coverage for `source_match` syntactic holes.
 //!
+//! Each hole keyword has a bare anonymous form (matches independently,
+//! never binds) and a named `KEYWORD_name` form (binds for
+//! cross-occurrence equality).
+//!
 //! Single-node holes:
-//! - Expression holes are selector-local identifier expressions prefixed
-//!   with `EXPR_`; they match one arbitrary expression subtree.
-//! - Statement holes are selector-local bare expression statements
-//!   prefixed with `STMT_`; they match exactly one statement.
+//! - Expression holes (`EXPR` / `EXPR_name`) are selector-local
+//!   identifier expressions; they match one arbitrary expression subtree.
+//! - Statement holes (`STMT` / `STMT_name`) are selector-local bare
+//!   expression statements; they match exactly one statement.
 //!
 //! List holes (variable-length):
-//! - `STMT_LIST_*;` in a block body absorbs a run of statements
-//!   (including an empty run) — e.g. a method body you don't want to pin.
-//! - `CLASS_REST*;` as a class field absorbs a run of class members —
+//! - `STMT_LIST` / `STMT_LIST_name;` in a block body absorbs a run of
+//!   statements (including an empty run) — e.g. a method body you don't
+//!   want to pin.
+//! - `CLASS_REST;` as a class field absorbs a run of class members —
 //!   e.g. "match this class by these members, ignore the rest".
 //!
 //! Several list holes may appear in one block or class body: they split
@@ -401,7 +406,7 @@ export { Counter };
 
 #[test]
 fn anonymous_expr_holes_match_independent_subtrees() {
-    // Bare `EXPR_` (no suffix) is anonymous: the two occurrences match
+    // The bare keyword `EXPR` is anonymous: the two occurrences match
     // *different* expressions. A named hole `EXPR_X` repeated would
     // instead force the two arguments to be equal.
     let fixture = run_fixture(FixtureOpts::new(
@@ -413,7 +418,7 @@ export { actual };
             "calc",
             &[Member::source_alpha_with_syntactic_holes(
                 "calc_value",
-                r#"const readable = Math.max(EXPR_, EXPR_);"#,
+                r#"const readable = Math.max(EXPR, EXPR);"#,
             )],
         )],
     ));
@@ -423,13 +428,48 @@ export { actual };
         &fixture.out_root,
         "static/app/modules/calc.js",
         &["Math.max", "const calc_value"],
-        &["EXPR_"],
+        &["EXPR"],
+    );
+}
+
+#[test]
+fn anonymous_stmt_hole_matches_one_arbitrary_statement() {
+    // The bare keyword `STMT` matches exactly one statement, with no
+    // suffix to mint — the anonymous single-statement form.
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"if (true) {
+  console.log("setup");
+  console.log("done");
+}
+const marker = "ready";
+export { marker };
+"#,
+        vec![logical_module_with_anon_alpha_syntactic_holes(
+            "init",
+            &[Member::new("marker")],
+            r#"if (true) {
+  STMT;
+  console.log("done");
+}"#,
+        )],
+    ));
+
+    assert_entry_output(&fixture, "setup\ndone\n");
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/modules/init.js",
+        &[
+            r#"console.log("setup")"#,
+            r#"console.log("done")"#,
+            "const marker",
+        ],
+        &["STMT"],
     );
 }
 
 #[test]
 fn anonymous_stmt_list_and_class_rest_holes_need_no_minted_names() {
-    // Bare `STMT_LIST_` and bare `CLASS_REST` select the class with no
+    // Bare `STMT_LIST` and bare `CLASS_REST` select the class with no
     // suffixes to invent.
     let fixture = run_fixture(FixtureOpts::new(
         r#"class Counter {
@@ -451,7 +491,7 @@ export { Counter };
                 "Counter",
                 r#"class K {
   constructor() {
-    STMT_LIST_;
+    STMT_LIST;
   }
   CLASS_REST;
 }"#,
@@ -470,7 +510,7 @@ export { Counter };
         &fixture.out_root,
         "static/app/modules/shapes.js",
         &["class", "increment"],
-        &["STMT_LIST_", "CLASS_REST"],
+        &["STMT_LIST", "CLASS_REST"],
     );
 }
 
@@ -726,7 +766,7 @@ export { Counter };
 
 #[test]
 fn single_node_hole_keeps_later_identifiers_aligned() {
-    // The same bijection guard for single-node holes: `EXPR_` absorbs a
+    // The same bijection guard for single-node holes: `EXPR` absorbs a
     // multi-identifier subtree, and the `limit` argument after it still
     // matches by alpha-correspondence rather than by absolute position.
     let fixture = run_fixture(FixtureOpts::new(
@@ -740,7 +780,7 @@ export { total };
             "calc",
             &[Member::source_alpha_with_syntactic_holes(
                 "calc_total",
-                r#"const readable = Math.max(EXPR_, limit);"#,
+                r#"const readable = Math.max(EXPR, limit);"#,
             )],
         )],
     ));
@@ -750,6 +790,6 @@ export { total };
         &fixture.out_root,
         "static/app/modules/calc.js",
         &["Math.max", "const calc_total"],
-        &["EXPR_"],
+        &["EXPR"],
     );
 }

--- a/devinfra/js/debundle/e2e/syntactic_holes_test.rs
+++ b/devinfra/js/debundle/e2e/syntactic_holes_test.rs
@@ -7,11 +7,15 @@
 //!   prefixed with `STMT_`; they match exactly one statement.
 //!
 //! List holes (variable-length):
-//! - `STMT_LIST_*;` in a block body absorbs a contiguous run of
-//!   statements (including an empty run) — e.g. a method body you don't
-//!   want to pin.
-//! - `CLASS_REST*;` as a class field absorbs the remaining class members
-//!   — e.g. "match this class by these members, ignore the rest".
+//! - `STMT_LIST_*;` in a block body absorbs a run of statements
+//!   (including an empty run) — e.g. a method body you don't want to pin.
+//! - `CLASS_REST*;` as a class field absorbs a run of class members —
+//!   e.g. "match this class by these members, ignore the rest".
+//!
+//! Several list holes may appear in one block or class body: they split
+//! the pinned statements/members into an ordered subsequence with gaps,
+//! so a selector can bracket a few stable members with `CLASS_REST;`
+//! holes and match any class that contains them in that order.
 
 use debundle_e2e_support::*;
 
@@ -471,10 +475,13 @@ export { Counter };
 }
 
 #[test]
-fn member_source_match_two_class_rest_holes_never_match() {
-    // At most one CLASS_REST hole per class body; a second one is
-    // ambiguous, so the selector matches nothing.
-    let opts = FixtureOpts::new(
+fn member_source_match_class_rest_holes_bracket_interior_member() {
+    // Two `CLASS_REST;` holes bracket a single pinned member, so the
+    // selector matches a class by an interior member it contains: the
+    // leading hole absorbs `a`, the trailing hole absorbs `c`, and `b`
+    // is pinned in between. (Previously a second `CLASS_REST` was a hard
+    // "ambiguous, never matches"; it is now an ordered-subsequence gap.)
+    let fixture = run_fixture(FixtureOpts::new(
         r#"class Counter {
   a() {
     return 1;
@@ -482,9 +489,126 @@ fn member_source_match_two_class_rest_holes_never_match() {
   b() {
     return 2;
   }
+  c() {
+    return 3;
+  }
 }
-console.log(new Counter().a());
+console.log(new Counter().b());
 export { Counter };
+"#,
+        vec![logical_module(
+            "shapes",
+            &[Member::source_alpha_with_syntactic_holes(
+                "Counter",
+                r#"class K {
+  CLASS_REST;
+  b() {
+    STMT_LIST_B;
+  }
+  CLASS_REST;
+}"#,
+            )],
+        )],
+    ));
+
+    assert_entry_output(&fixture, "2\n");
+    assert_module_exports(
+        &fixture.out_root,
+        "static/app/modules/shapes.js",
+        &["Counter"],
+        &[],
+    );
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/modules/shapes.js",
+        // The whole class moved; the bracketing holes are selector-only.
+        &["class", "a()", "b()", "c()"],
+        &["CLASS_REST", "STMT_LIST_B"],
+    );
+}
+
+#[test]
+fn member_source_match_interleaved_class_rest_holes_match_ordered_members() {
+    // Two pinned members separated by a `CLASS_REST;` hole match a class
+    // that contains them in that order with other members interspersed:
+    // `open` (after `setup`) then `close` (after `tick`). This is the
+    // ordered-subset fingerprint — pin a few stable members, ignore the
+    // rest.
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"class Widget {
+  setup() {
+    return 0;
+  }
+  open() {
+    return 1;
+  }
+  tick() {
+    return 2;
+  }
+  close() {
+    return 3;
+  }
+}
+console.log(new Widget().open() + new Widget().close());
+export { Widget };
+"#,
+        vec![logical_module(
+            "shapes",
+            &[Member::source_alpha_with_syntactic_holes(
+                "Widget",
+                r#"class K {
+  CLASS_REST;
+  open() {
+    STMT_LIST_O;
+  }
+  CLASS_REST;
+  close() {
+    STMT_LIST_C;
+  }
+  CLASS_REST;
+}"#,
+            )],
+        )],
+    ));
+
+    assert_entry_output(&fixture, "4\n");
+    assert_module_exports(
+        &fixture.out_root,
+        "static/app/modules/shapes.js",
+        &["Widget"],
+        &[],
+    );
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/modules/shapes.js",
+        &["setup()", "open()", "tick()", "close()"],
+        &["CLASS_REST"],
+    );
+}
+
+#[test]
+fn member_source_match_interleaved_class_rest_holes_enforce_order() {
+    // The same `Widget`, but the selector pins `close` before `open`.
+    // Ordered-subsequence matching keeps source order, so pinning them
+    // in the wrong order matches nothing — it is not an unordered
+    // "contains both somewhere" match.
+    let opts = FixtureOpts::new(
+        r#"class Widget {
+  setup() {
+    return 0;
+  }
+  open() {
+    return 1;
+  }
+  tick() {
+    return 2;
+  }
+  close() {
+    return 3;
+  }
+}
+console.log(new Widget().open());
+export { Widget };
 "#,
         vec![logical_module(
             "shapes",
@@ -492,8 +616,12 @@ export { Counter };
                 "Selected",
                 r#"class K {
   CLASS_REST;
-  a() {
-    STMT_LIST_A;
+  close() {
+    STMT_LIST_C;
+  }
+  CLASS_REST;
+  open() {
+    STMT_LIST_O;
   }
   CLASS_REST;
 }"#,
@@ -502,6 +630,49 @@ export { Counter };
     );
 
     expect_rejection_containing_all(opts, &["static/app::shapes", "did not match"]);
+}
+
+#[test]
+fn anonymous_source_match_multiple_stmt_list_holes_bracket_pinned_statements() {
+    // Three `STMT_LIST_*;` holes bracket two pinned statements inside a
+    // block: the holes absorb the `a`/`b`/`c` logs, leaving `pinned1`
+    // then `pinned2` matched in order.
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"if (true) {
+  console.log("a");
+  console.log("pinned1");
+  console.log("b");
+  console.log("pinned2");
+  console.log("c");
+}
+const marker = "ready";
+export { marker };
+"#,
+        vec![logical_module_with_anon_alpha_syntactic_holes(
+            "init",
+            &[Member::new("marker")],
+            r#"if (true) {
+  STMT_LIST_HEAD;
+  console.log("pinned1");
+  STMT_LIST_MID;
+  console.log("pinned2");
+  STMT_LIST_TAIL;
+}"#,
+        )],
+    ));
+
+    assert_entry_output(&fixture, "a\npinned1\nb\npinned2\nc\n");
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/modules/init.js",
+        &[
+            r#"console.log("a")"#,
+            r#"console.log("pinned1")"#,
+            r#"console.log("pinned2")"#,
+            "const marker",
+        ],
+        &["STMT_LIST_HEAD", "STMT_LIST_MID", "STMT_LIST_TAIL"],
+    );
 }
 
 #[test]

--- a/devinfra/js/debundle/source_match.rs
+++ b/devinfra/js/debundle/source_match.rs
@@ -13,26 +13,24 @@ use swc_common::{EqIgnoreSpan, SyntaxContext};
 use swc_ecma_ast::*;
 use swc_ecma_visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 
-const EXPR_HOLE_PREFIX: &str = "EXPR_";
-const STMT_HOLE_PREFIX: &str = "STMT_";
-/// A bare `STMT_LIST_*;` expression-statement in a block body is a
-/// statement-**list** hole: it absorbs a run of candidate statements
-/// (including an empty run) at that position. Several may appear in one
-/// block, splitting the pinned statements into an ordered subsequence
-/// with gaps (see [`AstWildcardMatcher::match_list_with_holes`]).
-/// Distinct from the single-statement `STMT_` hole, which matches
-/// exactly one statement. `STMT_LIST_` is checked before `STMT_` since
-/// it is a prefix of it.
-const STMT_LIST_HOLE_PREFIX: &str = "STMT_LIST_";
-/// A bare `CLASS_REST;` class field (no initializer) is a class-member
-/// hole: it absorbs a run of class members at its position. Several may
-/// appear in one class body, bracketing pinned members so a selector can
-/// match a class by an ordered subset of its members and ignore the gaps
-/// (see [`AstWildcardMatcher::match_list_with_holes`]). Matched as an
-/// exact token (not a prefix) so it never collides with a real field
-/// whose name merely starts with `CLASS_REST`, and because it never
-/// reuses, a suffix would be meaningless anyway.
-const CLASS_REST_HOLE_TOKEN: &str = "CLASS_REST";
+/// Syntactic-hole keywords. The **bare keyword** is the anonymous form:
+/// it matches independently at every occurrence and never binds, so
+/// authors don't have to mint a unique name per throwaway placeholder. A
+/// `<keyword>_<name>` identifier is the **named** form, which binds for
+/// cross-occurrence equality — the same name must match the same
+/// subtree/statement everywhere it appears.
+///
+/// `EXPR` matches one arbitrary expression and `STMT` one arbitrary
+/// statement. `STMT_LIST` and `CLASS_REST` are variable-length list holes
+/// (see [`AstWildcardMatcher::match_list_with_holes`]): `STMT_LIST`
+/// absorbs a run of block statements and `CLASS_REST` a run of class
+/// members; several may appear in one list, splitting the pinned
+/// elements into an ordered subsequence with gaps. `STMT_LIST` must be
+/// checked before `STMT`, since `STMT` is a keyword-prefix of it.
+const EXPR_HOLE_KEYWORD: &str = "EXPR";
+const STMT_HOLE_KEYWORD: &str = "STMT";
+const STMT_LIST_HOLE_KEYWORD: &str = "STMT_LIST";
+const CLASS_REST_HOLE_KEYWORD: &str = "CLASS_REST";
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ResolvedMemberBinding {
@@ -698,11 +696,11 @@ impl<'a> AstWildcardMatcher<'a> {
     }
 
     fn bind_expr(&mut self, wildcard: &str, candidate: &Expr) -> bool {
-        // A bare `EXPR_` (the prefix with no suffix) is an anonymous
-        // wildcard: every occurrence matches independently, so authors
-        // don't have to mint a unique name per placeholder. Named holes
-        // (`EXPR_FOO`) keep their cross-occurrence equality.
-        if is_anonymous_hole(wildcard, EXPR_HOLE_PREFIX) {
+        // The bare keyword `EXPR` is an anonymous wildcard: every
+        // occurrence matches independently, so authors don't have to mint
+        // a unique name per placeholder. Named holes (`EXPR_FOO`) keep
+        // their cross-occurrence equality.
+        if hole_is_anonymous(wildcard, EXPR_HOLE_KEYWORD) {
             return true;
         }
         match self.replacements.expressions.get(wildcard) {
@@ -717,8 +715,8 @@ impl<'a> AstWildcardMatcher<'a> {
     }
 
     fn bind_stmt(&mut self, wildcard: &str, candidate: &Stmt) -> bool {
-        // Bare `STMT_` is anonymous; see [`Self::bind_expr`].
-        if is_anonymous_hole(wildcard, STMT_HOLE_PREFIX) {
+        // Bare `STMT` is anonymous; see [`Self::bind_expr`].
+        if hole_is_anonymous(wildcard, STMT_HOLE_KEYWORD) {
             return true;
         }
         match self.replacements.statements.get(wildcard) {
@@ -1846,7 +1844,7 @@ impl<'a> AstWildcardMatcher<'a> {
         }
     }
 
-    /// Match a statement list. `STMT_LIST_*;` holes split the needle into
+    /// Match a statement list. `STMT_LIST;` holes split the needle into
     /// fixed segments matched as an ordered subsequence with gaps (see
     /// [`Self::match_list_with_holes`]); with no hole this is an exact
     /// element-wise match.
@@ -1866,7 +1864,7 @@ impl<'a> AstWildcardMatcher<'a> {
         }
     }
 
-    /// Match a class member list. `CLASS_REST*;` holes split the needle
+    /// Match a class member list. `CLASS_REST;` holes split the needle
     /// into fixed segments matched as an ordered subsequence with gaps
     /// (see [`Self::match_list_with_holes`]); with no hole this is an
     /// exact element-wise match.
@@ -2113,10 +2111,10 @@ fn visit_computed_prop_name(prop_name: &mut PropName, visitor: &mut AlphaIdentCa
 struct WildcardIdents {
     expressions: BTreeSet<String>,
     statements: BTreeSet<String>,
-    /// `STMT_LIST_*` statement-list hole names (reserved from
+    /// `STMT_LIST` statement-list hole names (reserved from
     /// alpha-canonicalization like the single-node holes).
     statement_lists: BTreeSet<String>,
-    /// Whether the selector contains any `CLASS_REST*` class-member
+    /// Whether the selector contains any `CLASS_REST` class-member
     /// hole. The marker is a class field key (an `IdentName`, not an
     /// `Ident`), so it survives alpha-canonicalization without being
     /// reserved — only presence matters for routing.
@@ -2126,7 +2124,7 @@ struct WildcardIdents {
 impl WildcardIdents {
     /// True when the selector carries no holes of any kind, so the
     /// caller can take the plain `eq_ignore_span` fast path. List holes
-    /// count: a selector with only `STMT_LIST_*` / `CLASS_REST*` still
+    /// count: a selector with only `STMT_LIST` / `CLASS_REST` holes still
     /// needs the structural matcher.
     fn is_empty(&self) -> bool {
         self.expressions.is_empty()
@@ -2158,12 +2156,13 @@ impl Visit for WildcardIdentCollector {
 
     fn visit_stmt(&mut self, stmt: &Stmt) {
         if let Some(hole_name) = statement_hole_name(stmt) {
-            // `STMT_LIST_` is a prefix of `STMT_`, so it must win first.
-            if hole_name.starts_with(STMT_LIST_HOLE_PREFIX) {
+            // `STMT` is a keyword-prefix of `STMT_LIST`, so the list hole
+            // must win first.
+            if hole_name_for(hole_name, STMT_LIST_HOLE_KEYWORD).is_some() {
                 self.idents.statement_lists.insert(hole_name.to_string());
                 return;
             }
-            if hole_name.starts_with(STMT_HOLE_PREFIX) {
+            if hole_name_for(hole_name, STMT_HOLE_KEYWORD).is_some() {
                 self.idents.statements.insert(hole_name.to_string());
                 return;
             }
@@ -2184,11 +2183,7 @@ fn expression_hole_name(expr: &Expr) -> Option<&str> {
     let Expr::Ident(ident) = expr else {
         return None;
     };
-    ident
-        .sym
-        .as_ref()
-        .starts_with(EXPR_HOLE_PREFIX)
-        .then_some(ident.sym.as_ref())
+    hole_name_for(ident.sym.as_ref(), EXPR_HOLE_KEYWORD)
 }
 
 fn statement_hole_name(stmt: &Stmt) -> Option<&str> {
@@ -2201,21 +2196,34 @@ fn statement_hole_name(stmt: &Stmt) -> Option<&str> {
     Some(ident.sym.as_ref())
 }
 
-/// The name of a statement-list hole (`STMT_LIST_*;`) if `stmt` is one.
+/// The name of a statement-list hole (`STMT_LIST` / `STMT_LIST_*;`) if
+/// `stmt` is one.
 fn statement_list_hole_name(stmt: &Stmt) -> Option<&str> {
-    let name = statement_hole_name(stmt)?;
-    name.starts_with(STMT_LIST_HOLE_PREFIX).then_some(name)
+    hole_name_for(statement_hole_name(stmt)?, STMT_LIST_HOLE_KEYWORD)
 }
 
-/// Whether a hole name is the bare `prefix` with no suffix — the
-/// anonymous form, which matches independently at every occurrence
-/// instead of binding for cross-occurrence equality.
-fn is_anonymous_hole(name: &str, prefix: &str) -> bool {
-    name == prefix
+/// If `name` is a hole identifier for `keyword` — the bare keyword
+/// (anonymous) or a `<keyword>_<suffix>` (named) form — return it. The
+/// keyword must be followed by end-of-string or `_`, so `EXPR` and
+/// `EXPR_FOO` match for keyword `EXPR` but `EXPRESSION` does not.
+fn hole_name_for<'a>(name: &'a str, keyword: &str) -> Option<&'a str> {
+    let rest = name.strip_prefix(keyword)?;
+    (rest.is_empty() || rest.starts_with('_')).then_some(name)
+}
+
+/// Whether a hole name is the anonymous form: the bare keyword, or the
+/// keyword with a trailing underscore but no suffix. Anonymous holes
+/// match independently at every occurrence instead of binding for
+/// cross-occurrence equality.
+fn hole_is_anonymous(name: &str, keyword: &str) -> bool {
+    matches!(name.strip_prefix(keyword), Some("") | Some("_"))
 }
 
 /// Whether `member` is a `CLASS_REST;` class-member hole: a class field
-/// whose key is exactly the marker token and which has no initializer.
+/// whose key is exactly the keyword and which has no initializer. Matched
+/// as an exact token (not a `CLASS_REST_*` prefix) so it never collides
+/// with a real field whose name merely starts with `CLASS_REST`; since it
+/// never binds, a suffix would carry no meaning anyway.
 fn is_class_rest_hole(member: &ClassMember) -> bool {
     let ClassMember::ClassProp(prop) = member else {
         return false;
@@ -2223,6 +2231,6 @@ fn is_class_rest_hole(member: &ClassMember) -> bool {
     prop.value.is_none()
         && matches!(
             &prop.key,
-            PropName::Ident(ident) if ident.sym.as_ref() == CLASS_REST_HOLE_TOKEN
+            PropName::Ident(ident) if ident.sym.as_ref() == CLASS_REST_HOLE_KEYWORD
         )
 }

--- a/devinfra/js/debundle/source_match.rs
+++ b/devinfra/js/debundle/source_match.rs
@@ -16,18 +16,22 @@ use swc_ecma_visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 const EXPR_HOLE_PREFIX: &str = "EXPR_";
 const STMT_HOLE_PREFIX: &str = "STMT_";
 /// A bare `STMT_LIST_*;` expression-statement in a block body is a
-/// statement-**list** hole: it absorbs a contiguous run of candidate
-/// statements (including an empty run) at that position. Distinct from
-/// the single-statement `STMT_` hole, which matches exactly one
-/// statement. `STMT_LIST_` is checked before `STMT_` since it is a
-/// prefix of it.
+/// statement-**list** hole: it absorbs a run of candidate statements
+/// (including an empty run) at that position. Several may appear in one
+/// block, splitting the pinned statements into an ordered subsequence
+/// with gaps (see [`AstWildcardMatcher::match_list_with_holes`]).
+/// Distinct from the single-statement `STMT_` hole, which matches
+/// exactly one statement. `STMT_LIST_` is checked before `STMT_` since
+/// it is a prefix of it.
 const STMT_LIST_HOLE_PREFIX: &str = "STMT_LIST_";
 /// A bare `CLASS_REST;` class field (no initializer) is a class-member
-/// hole: it absorbs the remaining class members at that position. Lets
-/// a selector pin a class by a few stable members and ignore the rest.
-/// Matched as an exact token (not a prefix) so it never collides with a
-/// real field whose name merely starts with `CLASS_REST`, and because it
-/// never reuses, a suffix would be meaningless anyway.
+/// hole: it absorbs a run of class members at its position. Several may
+/// appear in one class body, bracketing pinned members so a selector can
+/// match a class by an ordered subset of its members and ignore the gaps
+/// (see [`AstWildcardMatcher::match_list_with_holes`]). Matched as an
+/// exact token (not a prefix) so it never collides with a real field
+/// whose name merely starts with `CLASS_REST`, and because it never
+/// reuses, a suffix would be meaningless anyway.
 const CLASS_REST_HOLE_TOKEN: &str = "CLASS_REST";
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -599,6 +603,35 @@ struct AstWildcardMatcher<'a> {
     alpha: bool,
     ident_forward: BTreeMap<Atom, Atom>,
     ident_backward: BTreeMap<Atom, Atom>,
+}
+
+/// A clone of the matcher's mutable binding state, captured before a
+/// tentative segment placement during ordered-subsequence (multi-hole)
+/// list matching and restored when that placement fails — so a
+/// half-applied segment never leaks identifier or wildcard bindings into
+/// the next attempt.
+#[derive(Clone)]
+struct MatcherState {
+    replacements: WildcardReplacements,
+    ident_forward: BTreeMap<Atom, Atom>,
+    ident_backward: BTreeMap<Atom, Atom>,
+}
+
+/// Loop-invariant inputs for the recursive ordered-subsequence search in
+/// [`AstWildcardMatcher::match_list_with_holes`]. Only the `seg_idx` and
+/// `cand_min` cursor arguments change as the search descends.
+struct SegmentSearch<'a, T> {
+    needle: &'a [T],
+    candidate: &'a [T],
+    /// `(needle_start, len)` of each maximal fixed (non-hole) run, in
+    /// source order.
+    segments: &'a [(usize, usize)],
+    /// Whether the first segment is pinned to the candidate's start
+    /// (true unless a hole leads the needle list).
+    anchored_left: bool,
+    /// Whether the last segment is pinned to the candidate's end (true
+    /// unless a hole trails the needle list).
+    anchored_right: bool,
 }
 
 impl<'a> AstWildcardMatcher<'a> {
@@ -1813,86 +1846,168 @@ impl<'a> AstWildcardMatcher<'a> {
         }
     }
 
-    /// Match a statement list, honoring a single `STMT_LIST_*` hole that
-    /// absorbs a contiguous run of candidate statements at its position.
-    /// With no hole this is an exact element-wise match. Two or more
-    /// statement-list holes in one block are ambiguous and never match.
+    /// Match a statement list. `STMT_LIST_*;` holes split the needle into
+    /// fixed segments matched as an ordered subsequence with gaps (see
+    /// [`Self::match_list_with_holes`]); with no hole this is an exact
+    /// element-wise match.
     fn match_stmt_slice(&mut self, needle: &[Stmt], candidate: &[Stmt]) -> bool {
-        let holes: Vec<usize> = needle
+        if needle
             .iter()
-            .enumerate()
-            .filter(|(_, stmt)| statement_list_hole_name(stmt).is_some())
-            .map(|(index, _)| index)
-            .collect();
-        match holes.as_slice() {
-            [] => self.match_slice(needle, candidate, Self::match_stmt),
-            &[hole] => self.match_list_around_hole(needle, candidate, hole, Self::match_stmt),
-            _ => false,
+            .any(|stmt| statement_list_hole_name(stmt).is_some())
+        {
+            self.match_list_with_holes(
+                needle,
+                candidate,
+                |stmt| statement_list_hole_name(stmt).is_some(),
+                Self::match_stmt,
+            )
+        } else {
+            self.match_slice(needle, candidate, Self::match_stmt)
         }
     }
 
-    /// Match a class member list, honoring a single `CLASS_REST*` hole
-    /// that absorbs the remaining members at its position. Members
-    /// pinned before/after the hole match the candidate's leading/
-    /// trailing members in order (see [`Self::match_list_around_hole`]).
-    /// Two or more `CLASS_REST*` holes in one class body are ambiguous
-    /// and never match.
+    /// Match a class member list. `CLASS_REST*;` holes split the needle
+    /// into fixed segments matched as an ordered subsequence with gaps
+    /// (see [`Self::match_list_with_holes`]); with no hole this is an
+    /// exact element-wise match.
     fn match_class_member_slice(
         &mut self,
         needle: &[ClassMember],
         candidate: &[ClassMember],
     ) -> bool {
-        let holes: Vec<usize> = needle
-            .iter()
-            .enumerate()
-            .filter(|(_, member)| is_class_rest_hole(member))
-            .map(|(index, _)| index)
-            .collect();
-        match holes.as_slice() {
-            [] => self.match_slice(needle, candidate, Self::match_class_member),
-            &[hole] => {
-                self.match_list_around_hole(needle, candidate, hole, Self::match_class_member)
-            }
-            _ => false,
+        if needle.iter().any(is_class_rest_hole) {
+            self.match_list_with_holes(
+                needle,
+                candidate,
+                is_class_rest_hole,
+                Self::match_class_member,
+            )
+        } else {
+            self.match_slice(needle, candidate, Self::match_class_member)
         }
     }
 
-    /// Match a list whose needle has exactly one list-hole at index
-    /// `hole`: the elements before it match the candidate prefix, the
-    /// elements after it match the candidate suffix, and the hole
-    /// absorbs the contiguous middle (any run, including empty). Like
-    /// the single-node holes, identifiers are matched positionally
-    /// post-alpha-canonicalization, so a hole is most robust at the end
-    /// of a list (a trailing hole keeps the matched prefix's identifier
-    /// numbering aligned with the candidate).
-    fn match_list_around_hole<T>(
+    /// Match a needle list carrying one or more list-holes against a
+    /// candidate list as an **ordered subsequence with gaps**. The holes
+    /// partition the needle into maximal fixed-element segments; each
+    /// segment must appear in the candidate as a contiguous block, the
+    /// segments in source order and non-overlapping, with the gaps
+    /// between them (plus any leading/trailing hole) absorbing arbitrary
+    /// runs of candidate elements — including empty runs. A leading hole
+    /// un-anchors the first segment from the candidate's start; a
+    /// trailing hole un-anchors the last segment from its end. A single
+    /// interior hole degenerates to the old contiguous prefix/suffix
+    /// match (both ends anchored, one gap in the middle).
+    ///
+    /// Matching is greedy-leftmost and commits the first placement under
+    /// which every segment matches, keeping the identifier/wildcard
+    /// bindings it accumulated. This is a pure existence check: the
+    /// interior alignment chosen when several placements are possible
+    /// never changes *which* enclosing declaration matched, and the
+    /// "matched more than one top-level declaration" ambiguity is still a
+    /// hard error in the caller that counts those matches.
+    fn match_list_with_holes<T>(
         &mut self,
         needle: &[T],
         candidate: &[T],
-        hole: usize,
-        mut match_item: impl FnMut(&mut Self, &T, &T) -> bool,
+        is_hole: impl Fn(&T) -> bool,
+        match_item: fn(&mut Self, &T, &T) -> bool,
     ) -> bool {
-        let prefix = hole;
-        let suffix = needle.len() - hole - 1;
-        if candidate.len() < prefix + suffix {
+        let mut segments: Vec<(usize, usize)> = Vec::new();
+        let mut idx = 0;
+        while idx < needle.len() {
+            if is_hole(&needle[idx]) {
+                idx += 1;
+                continue;
+            }
+            let start = idx;
+            while idx < needle.len() && !is_hole(&needle[idx]) {
+                idx += 1;
+            }
+            segments.push((start, idx - start));
+        }
+        // An all-holes needle pins nothing, so it matches any candidate
+        // run (including an empty one).
+        if segments.is_empty() {
+            return true;
+        }
+        let search = SegmentSearch {
+            needle,
+            candidate,
+            segments: &segments,
+            anchored_left: !is_hole(&needle[0]),
+            anchored_right: !is_hole(&needle[needle.len() - 1]),
+        };
+        self.place_segments(&search, 0, 0, match_item)
+    }
+
+    /// Recursive ordered-subsequence search backing
+    /// [`Self::match_list_with_holes`]. Places `segments[seg_idx..]` into
+    /// `candidate[cand_min..]`, trying the leftmost feasible start first
+    /// and rolling the matcher state back after each failed attempt.
+    /// Returns true — leaving the committed bindings in place — once
+    /// every remaining segment is placed.
+    fn place_segments<T>(
+        &mut self,
+        search: &SegmentSearch<T>,
+        seg_idx: usize,
+        cand_min: usize,
+        match_item: fn(&mut Self, &T, &T) -> bool,
+    ) -> bool {
+        let Some(&(needle_start, seg_len)) = search.segments.get(seg_idx) else {
+            return true; // every segment placed
+        };
+        let remaining: usize = search.segments[seg_idx..].iter().map(|(_, len)| len).sum();
+        // The latest start that still leaves room for this and every
+        // following segment; `None` means the candidate is too short.
+        let Some(latest_start) = search.candidate.len().checked_sub(remaining) else {
             return false;
+        };
+        let mut lo = cand_min;
+        let mut hi = latest_start;
+        if seg_idx == 0 && search.anchored_left {
+            // The first segment must start at the candidate's first element.
+            hi = hi.min(0);
         }
-        for index in 0..prefix {
-            if !match_item(self, &needle[index], &candidate[index]) {
-                return false;
+        if seg_idx == search.segments.len() - 1 && search.anchored_right {
+            // The last segment must end at the candidate's last element.
+            lo = lo.max(latest_start);
+        }
+        // An empty `lo..=hi` (e.g. an anchor pushed `lo` past `hi`) means
+        // no feasible placement, so the search backtracks.
+        for start in lo..=hi {
+            let snapshot = self.snapshot();
+            let mut segment_ok = true;
+            for offset in 0..seg_len {
+                if !match_item(
+                    self,
+                    &search.needle[needle_start + offset],
+                    &search.candidate[start + offset],
+                ) {
+                    segment_ok = false;
+                    break;
+                }
             }
-        }
-        let candidate_suffix_start = candidate.len() - suffix;
-        for offset in 0..suffix {
-            if !match_item(
-                self,
-                &needle[hole + 1 + offset],
-                &candidate[candidate_suffix_start + offset],
-            ) {
-                return false;
+            if segment_ok && self.place_segments(search, seg_idx + 1, start + seg_len, match_item) {
+                return true;
             }
+            self.restore(snapshot);
         }
-        true
+        false
+    }
+
+    fn snapshot(&self) -> MatcherState {
+        MatcherState {
+            replacements: self.replacements.clone(),
+            ident_forward: self.ident_forward.clone(),
+            ident_backward: self.ident_backward.clone(),
+        }
+    }
+
+    fn restore(&mut self, state: MatcherState) {
+        self.replacements = state.replacements;
+        self.ident_forward = state.ident_forward;
+        self.ident_backward = state.ident_backward;
     }
 
     fn match_slice<T>(


### PR DESCRIPTION
Two related improvements to `source_match` syntactic holes (one commit each). Builds on #2035 (merged), so this is standalone, not stacked.

## 1. Multi-hole ordered-subsequence matching

Generalizes list-hole matching (`STMT_LIST` in blocks, `CLASS_REST` in class bodies) from **a single contiguous hole** to **multiple non-contiguous holes**. Holes partition the needle into fixed segments matched as an **ordered subsequence with gaps**:

```js
class K {
  CLASS_REST;            // anything before
  tokenCounter = EXPR;   // pinned field
  CLASS_REST;            // anything between
  push() { STMT_LIST; }  // pinned method, body ignored
  CLASS_REST;            // anything after
}
```

matches any class that declares `tokenCounter` somewhere before a `push` method, ignoring every other member. Previously a second `CLASS_REST` / `STMT_LIST` in one list was rejected as "ambiguous, never matches".

- Pinned runs stay **contiguous and in source order**; each hole absorbs an arbitrary (possibly empty) run.
- A leading/trailing hole un-anchors that end; a single interior hole degenerates to the previous prefix/suffix behavior (backward compatible).
- The backtracking search checkpoints/restores the matcher's identifier bijection + wildcard bindings, so a half-applied segment never leaks.
- Interior alignment is greedy-leftmost and existence-only: it never changes *which* top-level declaration matched, so the only hard-error ambiguity is a fingerprint matching >1 top-level declaration (guarded by the preserved `Alpha`/`Beta` skeleton test).

## 2. Anonymous holes spelled as the bare keyword

The anonymous (non-binding) form is now the **bare keyword** — `EXPR`, `STMT`, `STMT_LIST` — instead of the trailing-underscore prefix (`EXPR_` etc.). The **named** binding form keeps `EXPR_<name>`:

```
foo(EXPR)            matches foo(123) and foo(456)
bar(EXPR, EXPR)      matches bar(1, 2)       // two holes independent
bar(EXPR_x, EXPR_x)  matches bar(1, 1) only  // named -> must be equal
```

Detection keys off the keyword followed by end-of-string or `_` (so `EXPRESSION` is not a hole). `CLASS_REST` is unchanged (already bare, never binds). The old `EXPR_`/`STMT_LIST_` bare-underscore spellings still resolve as anonymous, so existing selectors keep working.

## Tests

- Rewrote the old `two_class_rest_holes_never_match` → now brackets a pinned interior member and matches; added an interleaved-ordered match, an order-enforcement negative, and multiple `STMT_LIST` holes bracketing pinned statements.
- Updated the anonymous tests to the bare-keyword spelling; added an anonymous bare-`STMT` single-statement test.
- Full `//devinfra/js/debundle/...` subtree: **82/82 pass** (`buildbuddy:1c725936-b450-45a9-b2f2-279afb685bec`).
- Updated `docs/guide.md` and the hole doc comments.

https://claude.ai/code/session_013C7drQKK7n1DMBqwn2BGGv