### PR TITLE
Add Claude Code helper for Tana LiteLLM

### DIFF
--- a/cluster/k8s/litellm/tana/run_claude_code.sh
+++ b/cluster/k8s/litellm/tana/run_claude_code.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env sh
+set -eu
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: run_claude_code.sh [model] [claude-args...]
+
+Runs Claude Code through the Tana LiteLLM proxy.
+
+Environment:
+  TANA_LITELLM_API_KEY       LiteLLM proxy key. If unset, read from Kubernetes.
+  TANA_LITELLM_BASE_URL      Proxy URL. Default: https://tana-litellm.allegedly.works
+  TANA_LITELLM_MODEL         Model if no positional model is given.
+                             Default: claude-sonnet-4-20250514
+  TANA_LITELLM_NAMESPACE     Kubernetes namespace for key lookup. Default: litellm
+  TANA_LITELLM_SECRET        Kubernetes Secret for key lookup. Default: litellm-master-key
+  TANA_LITELLM_SECRET_KEY    Kubernetes Secret key. Default: api-key
+  TANA_LITELLM_PORT_FORWARD  Set to 1 to use kubectl port-forward instead of public DNS.
+  TANA_LITELLM_LOCAL_PORT    Local port for port-forward. Default: 4000
+  CLAUDE_BIN                 Claude Code binary. Default: claude
+
+Examples:
+  ./run_claude_code.sh
+  ./run_claude_code.sh --bare --print 'Say hi.'
+  ./run_claude_code.sh claude-sonnet-4-20250514 --dangerously-skip-permissions
+  TANA_LITELLM_PORT_FORWARD=1 ./run_claude_code.sh
+EOF
+}
+
+decode_base64() {
+  if printf '' | base64 -d >/dev/null 2>&1; then
+    base64 -d
+  else
+    base64 -D
+  fi
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+namespace="${TANA_LITELLM_NAMESPACE:-litellm}"
+secret="${TANA_LITELLM_SECRET:-litellm-master-key}"
+secret_key="${TANA_LITELLM_SECRET_KEY:-api-key}"
+base_url="${TANA_LITELLM_BASE_URL:-https://tana-litellm.allegedly.works}"
+model="${TANA_LITELLM_MODEL:-claude-sonnet-4-20250514}"
+claude_bin="${CLAUDE_BIN:-claude}"
+
+if [ "${1:-}" != "" ] && [ "${1#-}" = "$1" ]; then
+  model="$1"
+  shift
+fi
+
+if [ -z "${TANA_LITELLM_API_KEY:-}" ]; then
+  if ! command -v kubectl >/dev/null 2>&1; then
+    echo "TANA_LITELLM_API_KEY is unset and kubectl is not on PATH." >&2
+    exit 1
+  fi
+
+  encoded_key="$(kubectl -n "$namespace" get secret "$secret" -o "jsonpath={.data.${secret_key}}")"
+  if [ -z "$encoded_key" ]; then
+    echo "Secret ${namespace}/${secret} did not contain key ${secret_key}." >&2
+    exit 1
+  fi
+
+  TANA_LITELLM_API_KEY="$(printf '%s' "$encoded_key" | decode_base64)"
+  export TANA_LITELLM_API_KEY
+fi
+
+if [ "${TANA_LITELLM_PORT_FORWARD:-0}" = "1" ]; then
+  if ! command -v kubectl >/dev/null 2>&1; then
+    echo "TANA_LITELLM_PORT_FORWARD=1 requires kubectl on PATH." >&2
+    exit 1
+  fi
+
+  local_port="${TANA_LITELLM_LOCAL_PORT:-4000}"
+  port_forward_log="${TMPDIR:-/tmp}/tana-litellm-port-forward.$$.log"
+  kubectl -n "$namespace" port-forward svc/tana-litellm "${local_port}:4000" >"$port_forward_log" 2>&1 &
+  port_forward_pid="$!"
+
+  cleanup() {
+    kill "$port_forward_pid" >/dev/null 2>&1 || true
+    rm -f "$port_forward_log"
+  }
+  trap cleanup EXIT INT TERM
+
+  sleep 2
+  if ! kill -0 "$port_forward_pid" >/dev/null 2>&1; then
+    echo "kubectl port-forward failed:" >&2
+    cat "$port_forward_log" >&2
+    exit 1
+  fi
+
+  base_url="http://127.0.0.1:${local_port}"
+fi
+
+if ! command -v "$claude_bin" >/dev/null 2>&1; then
+  echo "Claude Code binary not found: $claude_bin" >&2
+  exit 1
+fi
+
+export ANTHROPIC_BASE_URL="${ANTHROPIC_BASE_URL:-$base_url}"
+export ANTHROPIC_AUTH_TOKEN="${ANTHROPIC_AUTH_TOKEN:-$TANA_LITELLM_API_KEY}"
+export ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-$TANA_LITELLM_API_KEY}"
+export ANTHROPIC_MODEL="${ANTHROPIC_MODEL:-$model}"
+export CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY="${CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY:-1}"
+
+echo "Starting Claude Code via ${ANTHROPIC_BASE_URL} with model ${ANTHROPIC_MODEL}" >&2
+if [ "${TANA_LITELLM_PORT_FORWARD:-0}" = "1" ]; then
+  "$claude_bin" "$@"
+  exit $?
+fi
+
+exec "$claude_bin" "$@"

--- a/tana/litellm_proxy/TODO.md
+++ b/tana/litellm_proxy/TODO.md
@@ -22,6 +22,8 @@ source-faithful to that evidence.
 - Add Anthropic-compatible smoke tests through LiteLLM Proxy:
   - `/v1/messages`
   - streaming `/v1/messages`
+  - Claude Code-shaped streaming `/v1/messages` with Anthropic system content
+    blocks, `cache_control`, `tool_use`, and `tool_result` transcript entries
   - `/v1/messages/count_tokens`
   - tool use and tool-result continuation
 - Make Tana auth deployment-safe:
@@ -68,7 +70,6 @@ source-faithful to that evidence.
     `gaffer-private/tana/re`
   - if moving the adapter implementation to `gaffer-private`, define how the
     Ducktape image build consumes it without ad-hoc cross-repo state
-- Fix and cover async streaming end to end through LiteLLM's custom handler.
 - Preserve richer finish reasons instead of returning only `stop` or
   `tool_calls`.
 - Preserve cache usage metadata:

--- a/tana/litellm_proxy/provider.py
+++ b/tana/litellm_proxy/provider.py
@@ -400,7 +400,9 @@ class TanaLiteLLM(CustomLLM):
         optional_params = kwargs.get("optional_params") or {}
         return self._client.stream_completion(model, messages, optional_params)
 
-    async def astreaming(
+    # LiteLLM's base type annotates this as a coroutine, but the streaming
+    # dispatcher consumes the returned object as an async iterator.
+    async def astreaming(  # type: ignore[override]
         self,
         model: str,
         messages: list[Any],
@@ -421,7 +423,10 @@ class TanaLiteLLM(CustomLLM):
     ) -> AsyncIterator[GenericStreamingChunk]:
         del api_base, custom_prompt_dict, model_response, print_verbose, encoding, api_key
         del logging_obj, acompletion, litellm_params, logger_fn, headers, timeout, client
-        return self._client.astream_completion(model, cast(Sequence[Mapping[str, Any]], messages), optional_params)
+        async for chunk in self._client.astream_completion(
+            model, cast(Sequence[Mapping[str, Any]], messages), optional_params
+        ):
+            yield chunk
 
 
 def register_litellm_provider(handler: TanaLiteLLM | None = None) -> TanaLiteLLM:
@@ -530,6 +535,7 @@ def _dynamic_tool_from_function(function: Mapping[str, Any]) -> dict[str, Any]:
 
 def _normalize_messages(messages: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
     normalized: list[dict[str, Any]] = []
+    tool_names_by_id: dict[str, str] = {}
     for message in messages:
         if not isinstance(message, Mapping):
             raise TanaProxyError(f"expected LiteLLM message mappings, got {type(message).__name__}")
@@ -537,17 +543,51 @@ def _normalize_messages(messages: Sequence[Mapping[str, Any]]) -> list[dict[str,
         if role is None:
             raise TanaProxyError(f"message is missing required role: {message!r}")
         content = _normalize_content(message.get("content", ""))
+        system_provider_options: dict[str, Any] | None = None
+        if role == "system":
+            content, system_provider_options = _normalize_system_content(content)
+        if role == "user" and _content_has_tool_result(content):
+            role = "tool"
+            content = _tool_result_parts(content)
         tool_calls = message.get("tool_calls")
         if tool_calls is None:
             tool_calls = message.get("toolCalls")
         if tool_calls is not None:
             content = _append_content_parts(content, _normalize_tool_call_parts(tool_calls))
         if role == "tool":
-            content = _normalize_tool_result_content(message, content)
+            content = _normalize_tool_result_content(message, content, tool_names_by_id)
         normalized_message = {"role": role, "content": content}
-        _copy_first_set(message, normalized_message, ("providerOptions", "provider_options"), "providerOptions")
+        if system_provider_options is not None:
+            _merge_provider_options(normalized_message, system_provider_options)
+        _merge_first_set_provider_options(message, normalized_message, ("providerOptions", "provider_options"))
+        _copy_first_set(message, normalized_message, ("cache_control", "cacheControl"), "cache_control")
+        _move_anthropic_cache_control(normalized_message)
         normalized.append(normalized_message)
+        _remember_tool_call_names(content, tool_names_by_id)
     return normalized
+
+
+def _normalize_system_content(content: Any) -> tuple[str, dict[str, Any] | None]:
+    if isinstance(content, str):
+        return content, None
+    if not isinstance(content, Sequence) or isinstance(content, (bytes, bytearray)):
+        return str(content or ""), None
+
+    text_blocks: list[str] = []
+    provider_options: dict[str, Any] = {}
+    for part in content:
+        if isinstance(part, str):
+            text_blocks.append(part)
+            continue
+        if not isinstance(part, Mapping):
+            continue
+        part_provider_options = part.get("providerOptions")
+        if isinstance(part_provider_options, Mapping):
+            _merge_provider_options_value(provider_options, part_provider_options)
+        part_text = part.get("text")
+        if isinstance(part_text, str):
+            text_blocks.append(part_text)
+    return "\n".join(text_blocks), provider_options or None
 
 
 def _normalize_content(content: Any) -> Any:
@@ -562,9 +602,17 @@ def _normalize_content_part(part: Any) -> Any:
     normalized = dict(part)
     if normalized.get("type") == "input_text":
         normalized["type"] = "text"
+    if normalized.get("type") == "tool_use":
+        normalized["type"] = "tool-call"
+        _move_alias(normalized, "id", "toolCallId")
+        _move_alias(normalized, "name", "toolName")
+    if normalized.get("type") == "tool_result":
+        normalized["type"] = "tool-result"
+        _move_alias(normalized, "tool_use_id", "toolCallId")
     _move_alias(normalized, "provider_options", "providerOptions")
     _move_alias(normalized, "tool_call_id", "toolCallId")
     _move_alias(normalized, "tool_name", "toolName")
+    _move_anthropic_cache_control(normalized)
     if normalized.get("type") == "tool-call":
         arguments = normalized.pop("arguments", None)
         if arguments is not None and normalized.get("input") is None:
@@ -572,7 +620,8 @@ def _normalize_content_part(part: Any) -> Any:
     if normalized.get("type") == "tool-result":
         result_content = normalized.pop("content", None)
         if result_content is not None and normalized.get("output") is None:
-            normalized["output"] = result_content
+            normalized["output"] = _normalize_tool_result_output(result_content, bool(normalized.get("is_error")))
+        normalized.pop("is_error", None)
     return normalized
 
 
@@ -631,7 +680,23 @@ def _append_content_parts(content: Any, parts: Sequence[dict[str, Any]]) -> Any:
     return [content, *parts]
 
 
-def _normalize_tool_result_content(message: Mapping[str, Any], content: Any) -> Any:
+def _content_has_tool_result(content: Any) -> bool:
+    return (
+        isinstance(content, Sequence)
+        and not isinstance(content, (bytes, bytearray, str))
+        and any(isinstance(part, Mapping) and part.get("type") == "tool-result" for part in content)
+    )
+
+
+def _tool_result_parts(content: Any) -> list[Any]:
+    if not isinstance(content, Sequence) or isinstance(content, (bytes, bytearray, str)):
+        return [content]
+    return [part for part in content if isinstance(part, Mapping) and part.get("type") == "tool-result"]
+
+
+def _normalize_tool_result_content(
+    message: Mapping[str, Any], content: Any, tool_names_by_id: Mapping[str, str]
+) -> Any:
     tool_call_id = message.get("toolCallId") or message.get("tool_call_id")
     tool_name = message.get("toolName") or message.get("name")
     if isinstance(content, Sequence) and not isinstance(content, (bytes, bytearray, str)):
@@ -644,17 +709,49 @@ def _normalize_tool_result_content(message: Mapping[str, Any], content: Any) -> 
                 normalized_part = dict(normalized_part)
                 if tool_call_id is not None and normalized_part.get("toolCallId") is None:
                     normalized_part["toolCallId"] = tool_call_id
-                if tool_name is not None and normalized_part.get("toolName") is None:
-                    normalized_part["toolName"] = tool_name
+                part_tool_call_id = normalized_part.get("toolCallId")
+                part_tool_name = tool_name
+                if not isinstance(part_tool_name, str) and isinstance(part_tool_call_id, str):
+                    part_tool_name = tool_names_by_id.get(part_tool_call_id)
+                if isinstance(part_tool_name, str) and normalized_part.get("toolName") is None:
+                    normalized_part["toolName"] = part_tool_name
             normalized_parts.append(normalized_part)
         if has_tool_result:
             return normalized_parts
     if not isinstance(tool_call_id, str) or not tool_call_id:
         raise TanaProxyError(f"tool message is missing tool_call_id/toolCallId: {message!r}")
-    result_part: dict[str, Any] = {"type": "tool-result", "toolCallId": tool_call_id, "output": content}
+    result_part: dict[str, Any] = {
+        "type": "tool-result",
+        "toolCallId": tool_call_id,
+        "output": _normalize_tool_result_output(content),
+    }
+    if not isinstance(tool_name, str):
+        tool_name = tool_names_by_id.get(tool_call_id)
     if isinstance(tool_name, str) and tool_name:
         result_part["toolName"] = tool_name
     return [result_part]
+
+
+def _normalize_tool_result_output(output: Any, is_error: bool = False) -> Any:
+    if isinstance(output, Mapping) and isinstance(output.get("type"), str):
+        return output
+    if isinstance(output, str):
+        return {"type": "error-text" if is_error else "text", "value": output}
+    if isinstance(output, Sequence) and not isinstance(output, (bytes, bytearray, str)):
+        return {"type": "content", "value": [_normalize_content_part(part) for part in output]}
+    return {"type": "error-json" if is_error else "json", "value": output}
+
+
+def _remember_tool_call_names(content: Any, tool_names_by_id: dict[str, str]) -> None:
+    if not isinstance(content, Sequence) or isinstance(content, (bytes, bytearray, str)):
+        return
+    for part in content:
+        if not isinstance(part, Mapping) or part.get("type") != "tool-call":
+            continue
+        tool_call_id = part.get("toolCallId")
+        tool_name = part.get("toolName")
+        if isinstance(tool_call_id, str) and isinstance(tool_name, str):
+            tool_names_by_id[tool_call_id] = tool_name
 
 
 def _parse_tool_arguments(arguments: Any) -> Any:
@@ -702,10 +799,57 @@ def _copy_first_set(source: Mapping[str, Any], dest: dict[str, Any], source_keys
             return
 
 
+def _merge_first_set_provider_options(
+    source: Mapping[str, Any], dest: dict[str, Any], source_keys: Sequence[str]
+) -> None:
+    for source_key in source_keys:
+        value = source.get(source_key)
+        if value is not None:
+            _merge_provider_options(dest, value)
+            return
+
+
+def _merge_provider_options(mapping: dict[str, Any], provider_options: Any) -> None:
+    if not isinstance(provider_options, Mapping):
+        mapping["providerOptions"] = provider_options
+        return
+
+    merged = dict(mapping["providerOptions"]) if isinstance(mapping.get("providerOptions"), dict) else {}
+    _merge_provider_options_value(merged, provider_options)
+    mapping["providerOptions"] = merged
+
+
+def _merge_provider_options_value(dest: dict[str, Any], provider_options: Mapping[str, Any]) -> None:
+    for provider, options in provider_options.items():
+        current = dest.get(provider)
+        if isinstance(current, Mapping) and isinstance(options, Mapping):
+            dest[provider] = {**current, **options}
+        else:
+            dest[provider] = options
+
+
 def _move_alias(mapping: dict[str, Any], source_key: str, dest_key: str) -> None:
     value = mapping.pop(source_key, None)
     if value is not None and mapping.get(dest_key) is None:
         mapping[dest_key] = value
+
+
+def _move_anthropic_cache_control(mapping: dict[str, Any]) -> None:
+    cache_control = mapping.pop("cache_control", None)
+    if cache_control is None:
+        cache_control = mapping.pop("cacheControl", None)
+    if cache_control is None:
+        return
+
+    provider_options = mapping.get("providerOptions")
+    if not isinstance(provider_options, dict):
+        provider_options = {}
+    anthropic_options = provider_options.get("anthropic")
+    if not isinstance(anthropic_options, dict):
+        anthropic_options = {}
+    anthropic_options["cacheControl"] = cache_control
+    provider_options["anthropic"] = anthropic_options
+    mapping["providerOptions"] = provider_options
 
 
 def _parse_tana_response(response: httpx.Response) -> TanaChatResult:

--- a/tana/litellm_proxy/test_provider.py
+++ b/tana/litellm_proxy/test_provider.py
@@ -120,18 +120,14 @@ def test_client_maps_message_envelopes_without_prompt_collapsing() -> None:
             return await client.chat_completion(
                 "claude-test",
                 [
-                    {
-                        "role": "system",
-                        "content": "You are concise.",
-                        "provider_options": {"anthropic": {"cacheControl": {"type": "ephemeral"}}},
-                    },
+                    {"role": "system", "content": "You are concise.", "cache_control": {"type": "ephemeral"}},
                     {
                         "role": "user",
                         "content": [
                             {
                                 "type": "input_text",
                                 "text": "call the tool later",
-                                "provider_options": {"anthropic": {"cacheControl": {"type": "ephemeral"}}},
+                                "cache_control": {"type": "ephemeral"},
                             },
                             {"type": "reasoning", "text": "prior scratchpad"},
                         ],
@@ -196,7 +192,7 @@ def test_client_maps_message_envelopes_without_prompt_collapsing() -> None:
                             "type": "tool-result",
                             "toolCallId": "call-1",
                             "toolName": "lookup_demo_fact",
-                            "output": '{"ok":true}',
+                            "output": {"type": "text", "value": '{"ok":true}'},
                         }
                     ],
                 },
@@ -291,6 +287,141 @@ def test_client_maps_tool_request_to_llm_proxy_next() -> None:
     ]
 
 
+def test_client_maps_claude_code_style_tool_request_to_llm_proxy_next() -> None:
+    seen_bodies: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "securetoken.googleapis.com":
+            return httpx.Response(
+                200, json={"id_token": "id-token-1", "refresh_token": "refresh-2", "expires_in": "3600"}
+            )
+        assert request.url == "https://app.tana.inc/functions/llmProxyNext"
+        seen_bodies.append(json.loads(request.content.decode("utf-8")))
+        return httpx.Response(200, headers={"content-type": "application/json"}, json={"text": "ok"})
+
+    async def run() -> TanaChatResult:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+            client = TanaProxyClient(TanaProxyConfig(refresh_token="refresh-1"), http_client=http)
+            return await client.chat_completion(
+                "claude-sonnet-4-20250514",
+                [
+                    {
+                        "role": "system",
+                        "content": [
+                            {"type": "text", "text": "You are Claude Code.", "cache_control": {"type": "ephemeral"}}
+                        ],
+                        "cache_control": {"type": "ephemeral"},
+                    },
+                    {"role": "user", "content": "Summarize this repository."},
+                ],
+                {
+                    "tools": [
+                        {
+                            "type": "function",
+                            "function": {
+                                "name": "LSP__getDiagnostics",
+                                "description": "Get language-server diagnostics.",
+                                "parameters": {"type": "object", "properties": {}},
+                            },
+                        }
+                    ],
+                    "max_tokens": 32000,
+                },
+            )
+
+    result = asyncio.run(run())
+
+    assert result.text == "ok"
+    body = seen_bodies[0]
+    assert body["isStreaming"] is False
+    assert body["args"]["userContext"] == "Ask Tana"
+    assert body["args"]["options"]["maxOutputTokens"] == 32000
+    assert body["dynamicTools"] == [
+        {
+            "name": "LSP__getDiagnostics",
+            "description": "Get language-server diagnostics.",
+            "kind": "mcpTool",
+            "runtime": "client",
+            "schema": {"type": "object", "properties": {}},
+        }
+    ]
+    assert body["args"]["messages"][0] == {
+        "role": "system",
+        "content": "You are Claude Code.",
+        "providerOptions": {"anthropic": {"cacheControl": {"type": "ephemeral"}}},
+    }
+    assert "cache_control" not in json.dumps(body)
+
+
+def test_client_maps_anthropic_tool_transcript_to_tana_messages() -> None:
+    seen_bodies: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "securetoken.googleapis.com":
+            return httpx.Response(
+                200, json={"id_token": "id-token-1", "refresh_token": "refresh-2", "expires_in": "3600"}
+            )
+        assert request.url == "https://app.tana.inc/functions/llmProxyNext"
+        seen_bodies.append(json.loads(request.content.decode("utf-8")))
+        return httpx.Response(200, headers={"content-type": "application/json"}, json={"text": "ok"})
+
+    async def run() -> TanaChatResult:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+            client = TanaProxyClient(TanaProxyConfig(refresh_token="refresh-1"), http_client=http)
+            return await client.chat_completion(
+                "claude-sonnet-4-20250514",
+                [
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "text", "text": "Let me inspect that."},
+                            {"type": "tool_use", "id": "toolu_1", "name": "LSP", "input": {}},
+                        ],
+                    },
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": "toolu_1",
+                                "content": "InputValidationError",
+                                "is_error": True,
+                                "cache_control": {"type": "ephemeral"},
+                            }
+                        ],
+                    },
+                ],
+                {"tools": [{"type": "function", "function": {"name": "LSP"}}]},
+            )
+
+    result = asyncio.run(run())
+
+    assert result.text == "ok"
+    assert seen_bodies[0]["args"]["messages"] == [
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "Let me inspect that."},
+                {"type": "tool-call", "toolCallId": "toolu_1", "toolName": "LSP", "input": {}},
+            ],
+        },
+        {
+            "role": "tool",
+            "content": [
+                {
+                    "type": "tool-result",
+                    "toolCallId": "toolu_1",
+                    "toolName": "LSP",
+                    "output": {"type": "error-text", "value": "InputValidationError"},
+                    "providerOptions": {"anthropic": {"cacheControl": {"type": "ephemeral"}}},
+                }
+            ],
+        },
+    ]
+    assert "tool_use" not in json.dumps(seen_bodies[0])
+    assert "tool_result" not in json.dumps(seen_bodies[0])
+
+
 def test_client_streams_text_chunks_from_llm_proxy() -> None:
     seen_bodies: list[dict[str, Any]] = []
 
@@ -371,7 +502,15 @@ def test_client_streams_tool_calls_from_llm_proxy_next() -> None:
         chunks = list(
             client.stream_completion(
                 "claude-test",
-                [{"role": "user", "content": "call the tool"}],
+                [
+                    {
+                        "role": "system",
+                        "content": [
+                            {"type": "text", "text": "You are Claude Code.", "cache_control": {"type": "ephemeral"}}
+                        ],
+                    },
+                    {"role": "user", "content": "call the tool"},
+                ],
                 {"tools": [{"type": "function", "function": {"name": "lookup_demo_fact"}}]},
             )
         )
@@ -390,6 +529,15 @@ def test_client_streams_tool_calls_from_llm_proxy_next() -> None:
     assert chunks[-1]["usage"] == {"prompt_tokens": 4, "completion_tokens": 5, "total_tokens": 9}
     assert seen_bodies[0]["isStreaming"] is True
     assert seen_bodies[0]["args"]["userContext"] == "Ask Tana"
+    assert seen_bodies[0]["args"]["messages"][0] == {
+        "role": "system",
+        "content": "You are Claude Code.",
+        "providerOptions": {"anthropic": {"cacheControl": {"type": "ephemeral"}}},
+    }
+    assert seen_bodies[0]["args"]["messages"][0]["providerOptions"] == {
+        "anthropic": {"cacheControl": {"type": "ephemeral"}}
+    }
+    assert "cache_control" not in json.dumps(seen_bodies[0])
     assert seen_bodies[0]["dynamicTools"][0]["runtime"] == "client"
 
 
@@ -588,7 +736,7 @@ def test_litellm_handler_astreaming_yields_chunks() -> None:
 
     async def collect_chunks() -> list[GenericStreamingChunk]:
         handler = TanaLiteLLM(FakeClient())
-        stream = await handler.astreaming(
+        stream = handler.astreaming(
             model="claude-test",
             messages=[{"role": "user", "content": "hi"}],
             api_base="",
@@ -607,6 +755,37 @@ def test_litellm_handler_astreaming_yields_chunks() -> None:
     assert chunks[0]["text"] == "async-pong"
     assert chunks[-1]["is_finished"] is True
     assert chunks[-1]["finish_reason"] == "stop"
+
+
+def test_litellm_routes_async_streaming_to_custom_provider() -> None:
+    class FakeClient(_NoStreamingClient):
+        async def chat_completion(
+            self, model: str, messages: Sequence[Mapping[str, Any]], optional_params: Mapping[str, Any] | None = None
+        ) -> TanaChatResult:
+            raise AssertionError("async streaming test should not call non-streaming chat_completion")
+
+        async def astream_completion(
+            self, model: str, messages: Sequence[Mapping[str, Any]], optional_params: Mapping[str, Any] | None = None
+        ) -> AsyncIterator[GenericStreamingChunk]:
+            assert model == "claude-test"
+            assert messages == [{"role": "user", "content": "hi"}]
+            assert optional_params == {"stream": True}
+            yield GenericStreamingChunk(
+                text="async-route-pong", is_finished=False, finish_reason="", usage=None, index=0
+            )
+            yield GenericStreamingChunk(text="", is_finished=True, finish_reason="stop", usage=None, index=0)
+
+    async def collect_chunks() -> list[Any]:
+        register_litellm_provider(TanaLiteLLM(FakeClient()))
+        stream = await litellm.acompletion(
+            model="tana/claude-test", messages=[{"role": "user", "content": "hi"}], stream=True
+        )
+        return [chunk async for chunk in stream]
+
+    chunks = asyncio.run(collect_chunks())
+
+    assert chunks[0].choices[0].delta.content == "async-route-pong"
+    assert chunks[-1].choices[0].finish_reason == "stop"
 
 
 def test_registers_tana_as_litellm_custom_provider() -> None:


### PR DESCRIPTION
## Summary
- add a `run_claude_code.sh` helper for running Claude Code against the Tana LiteLLM proxy
- fix the Tana custom provider async streaming contract so LiteLLM receives an async iterator
- normalize Claude Code / Anthropic pass-through message shapes for Tana: system content blocks, `cache_control`, `tool_use`, and `tool_result`
- record the remaining proxy-level Claude Code smoke-test gap in `tana/litellm_proxy/TODO.md`

## Testing
- `sh -n cluster/k8s/litellm/tana/run_claude_code.sh`
- `nix develop -c pre-commit run --files cluster/k8s/litellm/tana/run_claude_code.sh tana/litellm_proxy/provider.py tana/litellm_proxy/test_provider.py tana/litellm_proxy/TODO.md`
- `nix develop -c bazelisk test //tana/litellm_proxy/... //cluster/k8s/litellm/tana:test_generate_tana_litellm`  
  BuildBuddy: https://app.buildbuddy.io/invocation/33376f72-6f53-45bc-821c-0f55d2a63551
- Real Claude Code `--print` smoke against a local Tana LiteLLM proxy on `127.0.0.1:4003` returned a repository-context answer and logged successful LiteLLM/Langfuse spans.
- Real Claude Code `--bare --print` smoke against the same local proxy returned successfully and logged successful LiteLLM/Langfuse spans.