### PR TITLE
debundle: wire never-registered asymmetric_non_residual_cycle e2e test

### DIFF
--- a/devinfra/js/debundle/e2e/BUILD.bazel
+++ b/devinfra/js/debundle/e2e/BUILD.bazel
@@ -84,6 +84,7 @@ _STANDARD_E2E_DEPS = [
         "runtime_tdz_on_imported_class_test",
         "accepted_spec_runs_under_node_test",
         "lemma_two_rescued_asymmetric_cycle_test",
+        "asymmetric_non_residual_cycle_test",
         "mediator_reaches_asymmetric_cycle_test",
         "namespace_aggregator_split_tdz_test",
         "spec_comments_test",


### PR DESCRIPTION
## What

`e2e/asymmetric_non_residual_cycle_test.rs` was added in #2008 but never listed in `e2e/BUILD.bazel`'s standard-test comprehension — it has never compiled or run. Its siblings `lemma_two_rescued_asymmetric_cycle_test` and `mediator_reaches_asymmetric_cycle_test` were wired; this one fell through. It is one of three Lemma-2 acceptance fixtures (the gate must accept an asymmetric I-cycle between two non-residual modules when residual is the only outside importer).

This PR adds the missing `rust_test` entry next to its siblings in the standard e2e list. No other changes.

## Verification

- The orphaned test compiles against the current `support.rs` API unmodified and **passes green**: invocation [`fc453c61-cf7c-4dda-ada3-a501ca51ad66`](https://app.buildbuddy.io/invocation/fc453c61-cf7c-4dda-ada3-a501ca51ad66) (`asserts node output "alpha alpha-beta alpha-beta\n"`).
- Full `bbr test //devinfra/js/debundle/...`: 83/83 pass — invocation [`c5bff6cf-3859-46be-bfa8-014a1aa54877`](https://app.buildbuddy.io/invocation/c5bff6cf-3859-46be-bfa8-014a1aa54877).
- `bb run //devinfra/lint:buildifier` clean.

https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk)_