### PR TITLE
debundle: remove dead code, stale comments, and a change-detector test

### DIFF
--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -434,19 +434,12 @@ rust_test(
 )
 
 # Integration tests for the QuotientGraph kernel. Compiled as a
-# separate crate against `:peel`'s public API so they bypass the
-# `peel_test` build (which is broken by misplaced helpers in
-# peel/factorize_tests.rs unrelated to the kernel).
+# separate crate so they exercise `:peel`'s public API — the same
+# surface external consumers of the kernel see.
 rust_test(
     name = "peel_quotient_integration_test",
     srcs = ["peel/quotient_integration_test.rs"],
     compile_data = [
-        # Source file included via `include_str!` by the
-        # `unification_eliminates_cell_pipeline` static check.
-        # Embedding the source at build time pins the absence of
-        # deleted symbols (`Cell`, `proposal_cells_from_atomic_graph`,
-        # `promote_anonymous_only_cell_to_extension`).
-        "peel/factorize.rs",
         "peel/golden/closed_residual_unit.json",
         "peel/golden/extend_active_via_anon.json",
         "peel/golden/residual_singletons.json",

--- a/devinfra/js/debundle/CODE_REVIEW.md
+++ b/devinfra/js/debundle/CODE_REVIEW.md
@@ -96,10 +96,6 @@ Unclear what the three strings mean. A named struct or comment would help.
 
 Every test in `purity_test.rs`, `object_plain_data_calls_test.rs`, `pure_members_test.rs`, and `at_init_s_chain_dataflow_test.rs` follows: create source with SE anchor + target binding + reader → run fixture → assert module source and entry output. A shared `assert_pure_cycle_break(source, logical_modules, module_path, contains, not_contains, expected_stdout)` in support.rs would eliminate ~300 lines.
 
-### `NodeOutput` struct is dead (`support.rs:484`)
-
-Identical to `CommandResult` (line 660). Only used in `assert_node_output` which internally converts to `CommandResult`. Remove and use `CommandResult` directly.
-
 ### `accepted_spec_runs_under_node_test.rs` — `★ RED test` markers
 
 Uses inline comment markers instead of `#[ignore]` with reason strings (like `purity_test.rs` does). Inconsistent.
@@ -113,10 +109,6 @@ Open structural follow-ups from the pipeline data-shape audit.
 ### `ChunkBundle` ownership ping-pong
 
 Ownership still passes through every stage via return: `artifact = result.artifact`. Could be cleaner with a builder or consuming pipeline, but each stage is now a pure function so the remaining smell is cosmetic.
-
-### Pipeline ordering — `generated_by_selected_module_lowering` flag
-
-`generated_by_selected_module_lowering` exists solely so `rewrite_chunk_entry_specifiers` can skip specifier rewriting on files synthesized by the lowering stage. This flag wouldn't be needed if specifier rewriting ran _before_ lowering. Investigate whether reordering the pipeline stages eliminates the need for the flag entirely.
 
 ---
 
@@ -170,4 +162,4 @@ No longer a standalone crate — absorbed into `swc_ecma_minifier` as `pub(crate
 
 3. **Simplify `StatementFacts`** (`facts/mod.rs`) — see the canonical "### `StatementFacts`" item under P3.
 
-4. **Consolidate the data-shape follow-ups** — remove the remaining `ChunkBundle` ownership ping-pong and the `generated_by_selected_module_lowering` ordering workaround if stage reordering makes that flag unnecessary.
+4. **Consolidate the data-shape follow-ups** — remove the remaining `ChunkBundle` ownership ping-pong.

--- a/devinfra/js/debundle/artifact.rs
+++ b/devinfra/js/debundle/artifact.rs
@@ -202,7 +202,6 @@ pub struct FileMetadata {
     pub chunk_file: String,
     pub role: FileRole,
     pub source_path: String,
-    pub generated_by_selected_module_lowering: bool,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize)]
@@ -1124,7 +1123,6 @@ pub fn load_js_chunks(
                 chunk_file: entry_file.clone(),
                 role: FileRole::Entry,
                 source_path: source_path.clone(),
-                generated_by_selected_module_lowering: false,
             },
         }];
         chunks.push(JsChunk {

--- a/devinfra/js/debundle/e2e/accepted_spec_runs_under_node_test.rs
+++ b/devinfra/js/debundle/e2e/accepted_spec_runs_under_node_test.rs
@@ -1,9 +1,11 @@
-//! RED test: a spec ducktape ACCEPTS should run under Node.
+//! Regression tests (originally RED) for "a spec ducktape ACCEPTS
+//! must run under Node".
 //!
 //! This is a generalization of #1681: that PR pinned the
 //! residual-class TDZ shape. This pins a different shape that
-//! the post-#1683 gate still accepts but TDZs at runtime —
-//! confirmed against a real an upstream bundle reproduction.
+//! the post-#1683 gate accepted while the emitted output TDZ'd
+//! at runtime — confirmed against a reproduction from a real
+//! upstream bundle.
 //!
 //! ## Invariant being pinned
 //!
@@ -46,20 +48,14 @@
 //! `mod_logger`; `mod_logger`'s body hasn't run; `T` is in
 //! TDZ; `ReferenceError`.
 //!
-//! ## Expected outcomes
+//! ## Pinned behavior
 //!
-//! - **Today (RED)**: gate accepts; Node throws
-//!   `ReferenceError: Cannot access 'T' before initialization`
-//!   when running the emitted entry. `assert_entry_output`
-//!   panics on the non-zero exit.
-//! - **After the fix**: either
-//!     - the gate rejects this shape (recognizing
-//!       cross-module-peeled at-init reads as needing
-//!       order enforcement that source_import_position can't
-//!       provide for this pattern), or
-//!     - `source_import_position` correctly puts `mod_logger`
-//!       before `mod_init` in entry's import list, so ESM
-//!       DFS visits `mod_logger` first.
+//! Before the fix, the gate accepted and Node threw
+//! `ReferenceError: Cannot access 'T' before initialization`
+//! when running the emitted entry. Now
+//! `source_import_position` puts `mod_logger` before `mod_init`
+//! in entry's import list, so ESM DFS visits `mod_logger`
+//! first and the emitted entry runs cleanly.
 
 use debundle_e2e_support::*;
 
@@ -115,9 +111,8 @@ fn at_init_through_deep_residual_chain_executes_under_node() {
     // Three-deep call chain: mod_init at-init → bootstrap (residual)
     // → startTracking (residual) → reads T (in mod_logger).
     //
-    // Matches the the upstream chain: an entry-side bootstrap statement → gR
-    // (an outer helper) → an inner helper →
-    // reads T.
+    // Matches the upstream chain: an entry-side bootstrap
+    // statement → an outer helper → an inner helper → reads T.
     let fixture = run_fixture(FixtureOpts::new(
         r#"let T = "ready";
 function startTracking() { return T; }
@@ -140,9 +135,9 @@ fn at_init_through_residual_function_executes_under_node() {
     // mod_init at-init calls a function decl that lives in
     // residual, whose body reads T (in mod_logger).
     //
-    // This matches the the upstream repro shape: an entry-side module's bootstrap
-    // anonymous statement calls `gR()` (an outer helper,
-    // a function decl in residual), whose body eventually
+    // This matches the upstream repro shape: an entry-side
+    // module's bootstrap anonymous statement calls an outer
+    // helper (a function decl in residual), whose body eventually
     // reads `T` (in `logger_module`). At-init
     // promotion through the residual function decl is what we
     // need to surface the eager_use edge `mod_init → mod_logger`
@@ -220,26 +215,25 @@ export { T, readT, init, disableDevMode, middleHelper, loggerReader };
 
 #[test]
 fn peeled_method_reassigning_top_level_let_executes_under_node() {
-    // ★ RED test: minimal reproduction of the
-    // `Assignment to constant variable` runtime crash hit
-    // when peeling the upstream `an upstream class` class.
+    // Regression test (originally RED): minimal reproduction of
+    // the `Assignment to constant variable` runtime crash hit
+    // when peeling an upstream class.
     //
-    // the upstream shape (paraphrased):
+    // Upstream shape (paraphrased):
     //
     //   let isSearchBeingRefreshedForNode = (n) => false;
-    //   class an upstream class {
+    //   class SearchManager {
     //     static setIsSearchBeingRefreshedForNodeHandler(e) {
     //       isSearchBeingRefreshedForNode = e;           // ← write
     //     }
     //   }
     //
-    // Before peeling `an upstream class`, the write lives in
-    // the same module as the `let` declaration: legal. After
-    // peeling `an upstream class` into its own module, the
-    // emitted file looks like:
+    // Before peeling the class, the write lives in the same
+    // module as the `let` declaration: legal. After peeling the
+    // class into its own module, the emitted file looks like:
     //
     //   import { isSearchBeingRefreshedForNode } from "../entry.js";
-    //   class an upstream class {
+    //   class SearchManager {
     //     static setIsSearchBeingRefreshedForNodeHandler(e) {
     //       isSearchBeingRefreshedForNode = e;
     //     }
@@ -249,12 +243,12 @@ fn peeled_method_reassigning_top_level_let_executes_under_node() {
     // throws `TypeError: Assignment to constant variable` the
     // first time it's called.
     //
-    // Ducktape's realizability gate today accepts this peel
-    // because the write is inside a method body (lazy
-    // position). The fix must either reject any peel whose
-    // emitted module assigns to a binding declared in another
-    // module, or rewrite the write through a setter exported
-    // from the declaring module.
+    // The realizability gate used to accept this peel because
+    // the write is inside a method body (lazy position), and the
+    // emitted module crashed at runtime. This test pins that a
+    // peel whose emitted module assigns to a binding declared in
+    // another module now executes correctly (the entry below must
+    // print the post-assignment value).
     let mut opts = FixtureOpts::new(
         r#"let counter = 0;
 class Counter {

--- a/devinfra/js/debundle/e2e/at_init_promotion_fndecl_direct_read_test.rs
+++ b/devinfra/js/debundle/e2e/at_init_promotion_fndecl_direct_read_test.rs
@@ -1,16 +1,17 @@
-//! RED test: a direct top-level eager read of a binding declared
-//! by a hoisted function declaration must NOT emit an `EagerUse`
-//! owner edge that `constrains_init_order`.
+//! Regression test (originally RED): a direct top-level eager
+//! read of a binding declared by a hoisted function declaration
+//! must NOT emit an `EagerUse` owner edge that
+//! `constrains_init_order`.
 //!
-//! Background: `graph.rs::target_is_hoisted` (lines 576-584)
-//! recognizes `StatementKind::FnDecl` as ESM-Phase-1 hoisted and
-//! excludes promoted at-init reads of FnDecl bindings from the
-//! call-graph closure that feeds the promoted-edge emission. But
-//! the *direct* top-level eager-read path (the loop over
-//! `stmt.eager_reads` around `graph.rs:342`) doesn't apply that
-//! filter: any top-level `const x = f()` where `f` is a
-//! hoisted `function f() {}` emits a direct `EagerUse` edge
-//! `caller → f_owner` with `constrains_init_order: true`.
+//! Background: `graph.rs::target_is_hoisted` recognizes
+//! `StatementKind::FnDecl` as ESM-Phase-1 hoisted and excludes
+//! promoted at-init reads of FnDecl bindings from the call-graph
+//! closure that feeds the promoted-edge emission. The *direct*
+//! top-level eager-read path (the loop over `stmt.eager_reads`
+//! in `graph.rs`) used to skip that filter: any top-level
+//! `const x = f()` where `f` is a hoisted `function f() {}`
+//! emitted a direct `EagerUse` edge `caller → f_owner` with
+//! `constrains_init_order: true`.
 //!
 //! ## Why this is over-conservative
 //!
@@ -24,7 +25,7 @@
 //! read manufactures a cross-module init-order constraint that
 //! no realizable trace actually demands.
 //!
-//! Compare with `target_is_hoisted` in `graph.rs:576-584`:
+//! Compare with `target_is_hoisted` in `graph.rs`:
 //!
 //! > Other declared kinds (`VarDecl`, `ClassDecl`) are kept:
 //! > const / let / class are TDZ-locked until their statement
@@ -33,9 +34,7 @@
 //!
 //! The same logic that justifies the FnDecl exclusion in
 //! promoted reads (no TDZ on hoisted bindings) applies to direct
-//! reads. The fix family: hoist the predicate to module scope
-//! (or reuse it as a free function) and gate the direct
-//! `stmt.eager_reads` loop with it.
+//! reads, which now share the predicate.
 //!
 //! ## Fixture
 //!
@@ -45,17 +44,14 @@
 //! `const x = f()` in residual sees a fully-bound `f` no matter
 //! what order modules run in.
 //!
-//! ## Expected outcomes
+//! ## Pinned behavior
 //!
-//! - **Today (RED)**: the owner-graph report emits an
-//!   `EagerUse` edge for binding `f` from the residual `const x`
-//!   statement to the FnDecl owner, with
-//!   `constrains_init_order: true`. The assertion in
-//!   `eager_use_to_fndecl_is_not_emitted` fails.
-//! - **After the proposed tightening**: the direct-read path in
-//!   `graph.rs` applies the same `target_is_hoisted` filter the
-//!   promoted-read path uses, so no `EagerUse` edge to a FnDecl
-//!   owner is emitted. The assertion passes.
+//! The owner-graph report used to emit an `EagerUse` edge for
+//! binding `f` from the residual `const x` statement to the
+//! FnDecl owner, with `constrains_init_order: true`. Now the
+//! direct-read path in `graph.rs` applies the same
+//! `target_is_hoisted` filter the promoted-read path uses, so no
+//! `EagerUse` edge to a FnDecl owner is emitted.
 
 use analysis::{DepKind, OwnerGraphReport};
 use debundle_e2e_support::*;

--- a/devinfra/js/debundle/e2e/at_init_s_chain_dataflow_test.rs
+++ b/devinfra/js/debundle/e2e/at_init_s_chain_dataflow_test.rs
@@ -1,10 +1,11 @@
-//! RED tests: the S-chain should consult per-statement dataflow
-//! before emitting a `Sequenced` owner edge between two
-//! consecutive impure top-level statements.
+//! Regression tests (originally RED) for the dataflow-aware
+//! S-chain: emission consults per-statement dataflow before
+//! emitting a `Sequenced` owner edge between two consecutive
+//! impure top-level statements.
 //!
-//! Background. `graph.rs` (S-chain emission around lines
-//! 469-478) walks every impure top-level statement in source
-//! order and unconditionally emits
+//! Background. The baseline S-chain emission in `graph.rs` walks
+//! every impure top-level statement in source order and
+//! unconditionally emits
 //!
 //! ```ignore
 //! raw_edges.push((curr, prev, EdgeReason::sequenced(curr.ord)));
@@ -25,9 +26,10 @@
 //! before B" and a "after B, before A" state because there is
 //! no shared cell to observe).
 //!
-//! Proposed refinement (the "full dataflow" S-chain): for each
-//! impure top-level statement, compute its write set and read
-//! set (rebinds + global property mutations + property writes;
+//! The refinement under test (the "full dataflow" S-chain,
+//! opt-in via `dataflow_aware_s_chain`): for each impure
+//! top-level statement, compute its write set and read set
+//! (rebinds + global property mutations + property writes;
 //! reads from bindings + global properties); emit
 //! `Sequenced(prev → curr)` only when
 //!
@@ -52,23 +54,23 @@
 //!
 //! 1. **Disjoint global property writes.** Two impure
 //!    statements that each `globalThis.X = ...` distinct,
-//!    independent property keys. Today: S-edge chains them.
-//!    After fix: writes are `{globalThis.alpha}` vs
-//!    `{globalThis.beta}` — disjoint — no edge.
+//!    independent property keys. The baseline S-edge chains
+//!    them; the dataflow-aware chain sees `{globalThis.alpha}`
+//!    vs `{globalThis.beta}` — disjoint — no edge.
 //!
 //! 2. **Fresh-local-only allocation after a global write.** A
 //!    `globalThis.tag = ...` followed by a `new LocalClass()`
 //!    or `Object.freeze({...})` call whose effect is confined
-//!    to a fresh local value. Today: both are impure, S-edge
-//!    chains them. After fix: the fresh-alloc statement's
-//!    write set is just its own binding and its read set
-//!    doesn't intersect `globalThis.tag` — no edge.
+//!    to a fresh local value. Both are impure, so the baseline
+//!    S-edge chains them; under dataflow the fresh-alloc
+//!    statement's write set is just its own binding and its
+//!    read set doesn't intersect `globalThis.tag` — no edge.
 //!
 //! 3. **Independent cross-module inits.** Two modules each
 //!    construct a one-off instance of a local class whose
-//!    constructor only touches `this`. Today: S-edge chains
-//!    them. After fix: each statement writes only its own
-//!    binding (plus the fresh instance); read sets are
+//!    constructor only touches `this`. The baseline S-edge
+//!    chains them; under dataflow each statement writes only
+//!    its own binding (plus the fresh instance); read sets are
 //!    disjoint — no edge.
 //!
 //! ## Test shape

--- a/devinfra/js/debundle/e2e/auto_grown_export_alias_collision_test.rs
+++ b/devinfra/js/debundle/e2e/auto_grown_export_alias_collision_test.rs
@@ -1,28 +1,28 @@
-//! RED test: when the chunk's source `export { … }` aliases a
-//! local binding to a public name `P`, and `auto_grown_residual_exports`
-//! would grow an export for a different local binding whose symbol
-//! is *also* `P`, the auto-grow pass produces a duplicate public
-//! export name and the chunk link-fails.
+//! Regression test (originally RED): when the chunk's source
+//! `export { … }` aliases a local binding to a public name `P`,
+//! and `auto_grown_residual_exports` would grow an export for a
+//! different local binding whose symbol is *also* `P`, the
+//! auto-grow pass used to produce a duplicate public export name
+//! and the chunk link-failed.
 //!
 //! Background. `lowering/exports.rs::auto_grown_residual_exports`
 //! gates each candidate against `pre_existing_entry_exports`, but
 //! that set stores LOCAL bindings (the `orig` side of `export {
-//! orig as exported }`). It never inspects the PUBLIC side — the
-//! `exported` names that are already taken in the chunk's emitted
-//! `export { … }` block. When a peeled module's body happens to
-//! reference a residual binding whose symbol happens to coincide
-//! with an alias used in the chunk's source export, the auto-grow
-//! pass blindly emits a fresh `export { <local> as <name> }`
-//! whose `<name>` collides with an existing public name.
+//! orig as exported }`). It used to never inspect the PUBLIC side
+//! — the `exported` names already taken in the chunk's emitted
+//! `export { … }` block. When a peeled module's body referenced a
+//! residual binding whose symbol coincided with an alias used in
+//! the chunk's source export, the auto-grow pass blindly emitted
+//! a fresh `export { <local> as <name> }` whose `<name>` collided
+//! with an existing public name.
 //!
 //! `validate_emitted_exports` (which runs late in the pipeline)
-//! catches the resulting duplicate-export module — surfacing the
+//! caught the resulting duplicate-export module — surfacing the
 //! bug as a build-time error rather than a silent blank page in
-//! Chromium — but the fix belongs upstream: the auto-grow pass
-//! should consult the set of public names already exported (the
-//! `exported` side of named export specifiers and `ExportDecl`
-//! bindings) and either rename the new export to a non-colliding
-//! public name or skip it entirely.
+//! Chromium — but the fix landed upstream: the auto-grow pass now
+//! consults the set of public names already exported
+//! (`pre_existing_public_export_names`) and mints a non-colliding
+//! suffixed name instead.
 //!
 //! ## Generalized pattern
 //!
@@ -47,16 +47,14 @@
 //!   so it grows `export { av }` — colliding with the source's
 //!   `X as av`.
 //!
-//! ## Expected outcomes
+//! ## Pinned behavior
 //!
-//! - **Today (RED)**: `validate_emitted_exports` rejects with a
-//!   duplicate-export error naming `av` in `entry.js`. The
-//!   fixture build fails at pipeline time.
-//! - **After the fix**: `auto_grown_residual_exports` either
-//!   renames the new export to a non-colliding public name
-//!   (e.g. `av$1`) or skips it (forcing the peeled module to
-//!   reach `av` by some other path the upstream invariant
-//!   allows). The fixture build succeeds and the entry runs.
+//! `validate_emitted_exports` used to reject with a
+//! duplicate-export error naming `av` in `entry.js` (the fixture
+//! build failed at pipeline time). Now
+//! `auto_grown_residual_exports` renames the new export to a
+//! non-colliding public name, so the fixture build succeeds and
+//! the entry runs.
 
 use debundle_e2e_support::*;
 
@@ -73,9 +71,9 @@ export { X as av, usesAv };
     );
     opts.unassigned_mode = unassigned_mode_inline();
     let fixture = run_fixture(opts);
-    // Today the build never reaches this point — validate_emitted_exports
-    // rejects on duplicate public name `av`. After the fix to
-    // `auto_grown_residual_exports`, the entry runs and emits this
-    // line.
+    // Before the fix the build never reached this point —
+    // validate_emitted_exports rejected on duplicate public name
+    // `av`. With the collision-aware auto-grow pass, the entry
+    // runs and emits this line.
     assert_entry_output(&fixture, "x-impl av-impl av-impl\n");
 }

--- a/devinfra/js/debundle/e2e/chunk_rename_cross_module_test.rs
+++ b/devinfra/js/debundle/e2e/chunk_rename_cross_module_test.rs
@@ -38,7 +38,6 @@ export { a, b, c };
 "#,
         logical_modules: vec![logical_module("b_module", &[Member::new("b")])],
         chunk_renames: Some(json!({
-            "id": "chunk_renames__static_app",
             "members": [
                 {
                     "name": "getMobxGlobalState",

--- a/devinfra/js/debundle/e2e/chunk_renames_test.rs
+++ b/devinfra/js/debundle/e2e/chunk_renames_test.rs
@@ -39,7 +39,6 @@ use serde_json::{Value, json};
 /// single binding; the helper hides the wire shape.
 fn chunk_rename(rename_to: &str, from_binding: &str) -> Value {
     json!({
-        "id": "chunk_renames__static_app",
         "members": [
             {
                 "name": rename_to,
@@ -236,7 +235,6 @@ export { alpha, bravo, charlie, delta };
         vec![],
     )
     .with_chunk_renames(json!({
-        "id": "chunk_renames__static_app",
         "members": [
             // Invalid JS identifier — should report a "not a valid JS identifier" error.
             { "name": "1-bad-ident", "selector": { "binding": { "name": "alpha" } } },

--- a/devinfra/js/debundle/e2e/cross_module_emission_test.rs
+++ b/devinfra/js/debundle/e2e/cross_module_emission_test.rs
@@ -631,7 +631,6 @@ export { St as B, Ite };
             &[Member::renamed("runConsumer", "Ite")],
         )],
         chunk_renames: Some(json!({
-            "id": "chunk_renames__static_app",
             "members": [
                 {
                     "name": "vendorHelper",

--- a/devinfra/js/debundle/e2e/pure_members_test.rs
+++ b/devinfra/js/debundle/e2e/pure_members_test.rs
@@ -54,7 +54,6 @@ export {{ a, b, c }};
         Self {
             source,
             pure_members: json!({
-                "id": "chunk_renames__static_app",
                 "members": [
                     {
                         "name": "React",

--- a/devinfra/js/debundle/e2e/purity_test.rs
+++ b/devinfra/js/debundle/e2e/purity_test.rs
@@ -2,13 +2,12 @@
 //! for the realizability gate's `S` (side-effect ordering)
 //! sub-graph.
 //!
-//! Most tests run in CI. A few remain `#[ignore]`d as desiderata
+//! Most tests run in CI. Two remain `#[ignore]`d as desiderata
 //! for future work — each ignore-reason names the specific
 //! analysis still missing (fresh-literal-arg gate for
-//! `Object.freeze`, `Expr::New` whitelist for `Set`/`Map`/`RegExp`,
-//! escape analysis for IIFE patterns, lazy-back-edge I-cycle
-//! relaxation for cross-module mutual recursion). Their bodies
-//! become regression fixtures the moment those analyses land.
+//! `Object.freeze`, `Expr::New` whitelist for `Set`/`Map`/`RegExp`).
+//! Their bodies become regression fixtures the moment those
+//! analyses land.
 //!
 //! # Background
 //!
@@ -904,7 +903,6 @@ export { a, b, c };
 "#,
         logical_modules: vec![logical_module("b_module", &[Member::new("b")])],
         chunk_renames: Some(json!({
-            "id": "chunk_renames__static_app",
             "members": [
                 {
                     "name": "getMobxGlobalState",

--- a/devinfra/js/debundle/e2e/realizability_test.rs
+++ b/devinfra/js/debundle/e2e/realizability_test.rs
@@ -289,7 +289,6 @@ export { Leaf, Dep, Existing };
         vec![logical_module("existing", &[Member::new("Existing")])],
     );
     opts.chunk_renames = Some(json!({
-        "id": "chunk_renames__static_app",
         "members": [
             { "name": "ReadableLeaf", "selector": { "binding": { "name": "Leaf" } } },
             { "name": "ReadableDep", "selector": { "binding": { "name": "Dep" } } }

--- a/devinfra/js/debundle/e2e/rename_shadowed_inner_binding_test.rs
+++ b/devinfra/js/debundle/e2e/rename_shadowed_inner_binding_test.rs
@@ -17,7 +17,6 @@ use serde_json::{Value, json};
 
 fn chunk_rename(rename_to: &str, from_binding: &str) -> Value {
     json!({
-        "id": "chunk_renames__static_app",
         "members": [
             {
                 "name": rename_to,

--- a/devinfra/js/debundle/e2e/runtime_tdz_on_imported_class_test.rs
+++ b/devinfra/js/debundle/e2e/runtime_tdz_on_imported_class_test.rs
@@ -1,8 +1,8 @@
-//! RED test: a chunk the realizability gate ACCEPTS should
-//! actually execute under Node when materialized. Today the
-//! gate sometimes accepts a partition whose emitted ESM graph
-//! TDZs at runtime — the gate's proof is unsound for this
-//! shape.
+//! Regression test (originally RED): a chunk the realizability
+//! gate ACCEPTS must actually execute under Node when
+//! materialized. The gate used to accept a partition whose
+//! emitted ESM graph TDZ'd at runtime — its proof was unsound
+//! for this shape.
 //!
 //! ## Shape
 //!
@@ -47,7 +47,7 @@
 //!    until its line runs. The body crashes with
 //!    `ReferenceError: Cannot access 'Backend' before initialization`.
 //!
-//! ## Why ducktape accepts
+//! ## Why ducktape accepted
 //!
 //! The cycle `entry ↔ mod_logger` carries:
 //!
@@ -66,26 +66,23 @@
 //! puts the cycle dependent (here `mod_logger`) FIRST in entry's
 //! source so the linker's DFS lands entry first.
 //!
-//! That claim is the bug. The cycle dependent (`mod_logger`)
+//! That claim was the bug. The cycle dependent (`mod_logger`)
 //! being put FIRST in entry's source means ESM's DFS visits it
 //! FIRST, not entry first — so post-order evaluation runs
 //! mod_logger's body before entry's body. Backend is TDZ at
 //! mod_logger's evaluation. Lemma 2's direction is inverted for
-//! the `(at-init forward, lazy back)` shape we hit here.
+//! the `(at-init forward, lazy back)` shape hit here.
 //!
-//! ## Expected outcomes
+//! ## Pinned behavior
 //!
-//! - **Today**: pipeline accepts the spec; Node throws
-//!   `ReferenceError: Cannot access 'Backend' before initialization`
-//!   when running the emitted entry.
-//! - **After the fix (this PR)**: the realizability gate
-//!   recognizes the asymmetric-cycle shape `(at-init forward, lazy
-//!   back)` and rejects the spec. The materializer can't emit
-//!   working JS for this partition — ESM hoists all imports above
-//!   any statement, so re-sequencing `source_import_position` is
-//!   never going to put entry's `class Backend` declaration before
-//!   `mod_logger`'s `new Backend()`. The only sound outcome is
-//!   reject loudly so the spec author sees the conflict.
+//! The realizability gate recognizes the asymmetric-cycle shape
+//! `(at-init forward, lazy back)` and rejects the spec. The
+//! materializer can't emit working JS for this partition — ESM
+//! hoists all imports above any statement, so re-sequencing
+//! `source_import_position` is never going to put entry's
+//! `class Backend` declaration before `mod_logger`'s
+//! `new Backend()`. The only sound outcome is to reject loudly
+//! so the spec author sees the conflict.
 
 use debundle_e2e_support::*;
 

--- a/devinfra/js/debundle/e2e/support.rs
+++ b/devinfra/js/debundle/e2e/support.rs
@@ -110,13 +110,6 @@ impl BindingGroup {
             exports: exports.iter().copied().collect(),
         }
     }
-
-    pub fn source_alpha_with_syntactic_holes(
-        match_source: impl Into<String>,
-        exports: &[(&'static str, &'static str)],
-    ) -> Self {
-        Self::source_alpha(match_source, exports)
-    }
 }
 
 impl Member {
@@ -174,13 +167,6 @@ impl Member {
             }),
             comment: None,
         }
-    }
-
-    pub fn source_alpha_with_syntactic_holes(
-        name: &'static str,
-        match_source: impl Into<String>,
-    ) -> Self {
-        Self::source_alpha(name, match_source)
     }
 
     /// Attach an author comment to be emitted above the binding's owner
@@ -248,8 +234,6 @@ struct FixtureAnonymousStatement {
     source_match: Option<FixtureSourceMatch>,
     #[serde(skip_serializing_if = "Option::is_none")]
     comment: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    note: Option<String>,
 }
 
 #[derive(Clone, Serialize)]
@@ -269,7 +253,6 @@ impl FixtureAnonymousStatement {
             match_source: Some(match_source.into()),
             source_match: None,
             comment: None,
-            note: None,
         }
     }
 
@@ -283,7 +266,6 @@ impl FixtureAnonymousStatement {
                 match_source: match_source.into(),
             }),
             comment: None,
-            note: None,
         }
     }
 
@@ -303,21 +285,6 @@ impl FixtureAnonymousStatement {
                 match_source: match_source.into(),
             }),
             comment: None,
-            note: None,
-        }
-    }
-
-    fn alpha_all_with_syntactic_holes(match_source: impl Into<String>) -> Self {
-        Self {
-            match_source: None,
-            source_match: Some(FixtureSourceMatch {
-                identifiers: "alpha_all",
-                target_binding: None,
-                wildcard_string_literals: Vec::new(),
-                match_source: match_source.into(),
-            }),
-            comment: None,
-            note: None,
         }
     }
 
@@ -511,25 +478,6 @@ pub fn logical_module_with_anon_alpha_string_wildcards(
     )
 }
 
-pub fn logical_module_with_anon_alpha_syntactic_holes(
-    path: &str,
-    members: &[Member],
-    anon_match: &str,
-) -> LogicalModuleEntry {
-    (
-        path.to_string(),
-        serde_json::to_value(LogicalModuleBody {
-            comment: None,
-            members: fixture_members(members),
-            binding_groups: Vec::new(),
-            anonymous_statements: vec![FixtureAnonymousStatement::alpha_all_with_syntactic_holes(
-                anon_match,
-            )],
-        })
-        .expect("logical module fixture must serialize"),
-    )
-}
-
 pub fn logical_module_with_anon_comment(
     path: &str,
     members: &[Member],
@@ -654,8 +602,6 @@ pub struct Fixture {
     pub entry_path: PathBuf,
     pub out_root: PathBuf,
     pub report_root: PathBuf,
-    #[allow(dead_code)]
-    pub snapshot_root: PathBuf,
     // Held to keep the tempdir alive for the duration of assertions.
     _root: TempDir,
 }
@@ -699,7 +645,6 @@ pub fn run_fixture(opts: FixtureOpts<'_>) -> Fixture {
         entry_path,
         out_root: app_root,
         report_root: setup.report_root,
-        snapshot_root: setup.snapshot_root,
         _root: setup.root,
     }
 }
@@ -876,12 +821,6 @@ pub fn assert_generated_module_after_entry_script(
          {source}",
     );
     assert_generated_module_script(out_root, &wrapped, expected_stdout);
-}
-
-pub struct NodeOutput {
-    pub stdout: String,
-    pub stderr: String,
-    pub status: std::process::ExitStatus,
 }
 
 pub fn assert_node_output(path: &Path, expected_stdout: &str, expected_stderr: &str) {

--- a/devinfra/js/debundle/e2e/syntactic_holes_test.rs
+++ b/devinfra/js/debundle/e2e/syntactic_holes_test.rs
@@ -33,7 +33,7 @@ export { actual };
 "#,
         vec![logical_module(
             "calc",
-            &[Member::source_alpha_with_syntactic_holes(
+            &[Member::source_alpha(
                 "calc_value",
                 r#"const readable = Math.max(EXPR_LEFT, EXPR_RIGHT);"#,
             )],
@@ -76,7 +76,7 @@ export { actual };
 "#,
         vec![logical_module(
             "calc",
-            &[Member::source_alpha_with_syntactic_holes(
+            &[Member::source_alpha(
                 "calc_value",
                 r#"const readable = [
   EXPR_A,
@@ -118,7 +118,7 @@ export { first, second };
         vec![logical_module_with_binding_groups(
             "pair",
             &[],
-            &[BindingGroup::source_alpha_with_syntactic_holes(
+            &[BindingGroup::source_alpha(
                 r#"var left = EXPR_LEFT, right = EXPR_RIGHT;"#,
                 &[("left", "first_value"), ("right", "second_value")],
             )],
@@ -153,7 +153,7 @@ fn anonymous_source_match_stmt_prefix_hole_matches_arbitrary_nested_statement() 
 const marker = "ready";
 export { marker };
 "#,
-        vec![logical_module_with_anon_alpha_syntactic_holes(
+        vec![logical_module_with_anon_alpha(
             "init",
             &[Member::new("marker")],
             r#"if (true) {
@@ -190,7 +190,7 @@ if (true) {
 }
 export { marker };
 "#,
-        vec![logical_module_with_anon_alpha_syntactic_holes(
+        vec![logical_module_with_anon_alpha(
             "init",
             &[Member::new("marker")],
             r#"if (true) {
@@ -224,7 +224,7 @@ fn anonymous_source_match_stmt_list_hole_absorbs_contiguous_statements() {
 const marker = "ready";
 export { marker };
 "#,
-        vec![logical_module_with_anon_alpha_syntactic_holes(
+        vec![logical_module_with_anon_alpha(
             "init",
             &[Member::new("marker")],
             r#"if (true) {
@@ -260,7 +260,7 @@ fn anonymous_source_match_stmt_list_hole_absorbs_empty_run() {
 const marker = "ready";
 export { marker };
 "#,
-        vec![logical_module_with_anon_alpha_syntactic_holes(
+        vec![logical_module_with_anon_alpha(
             "init",
             &[Member::new("marker")],
             r#"if (true) {
@@ -303,7 +303,7 @@ export { Counter };
 "#,
         vec![logical_module(
             "shapes",
-            &[Member::source_alpha_with_syntactic_holes(
+            &[Member::source_alpha(
                 "Counter",
                 r#"class K {
   constructor() {
@@ -351,7 +351,7 @@ export { Alpha };
 "#,
         vec![logical_module(
             "shapes",
-            &[Member::source_alpha_with_syntactic_holes(
+            &[Member::source_alpha(
                 "Selected",
                 r#"class K {
   run() {
@@ -386,7 +386,7 @@ export { Counter };
 "#,
         vec![logical_module(
             "shapes",
-            &[Member::source_alpha_with_syntactic_holes(
+            &[Member::source_alpha(
                 "Selected",
                 r#"class K {
   b() {
@@ -416,7 +416,7 @@ export { actual };
 "#,
         vec![logical_module(
             "calc",
-            &[Member::source_alpha_with_syntactic_holes(
+            &[Member::source_alpha(
                 "calc_value",
                 r#"const readable = Math.max(EXPR, EXPR);"#,
             )],
@@ -444,7 +444,7 @@ fn anonymous_stmt_hole_matches_one_arbitrary_statement() {
 const marker = "ready";
 export { marker };
 "#,
-        vec![logical_module_with_anon_alpha_syntactic_holes(
+        vec![logical_module_with_anon_alpha(
             "init",
             &[Member::new("marker")],
             r#"if (true) {
@@ -487,7 +487,7 @@ export { Counter };
 "#,
         vec![logical_module(
             "shapes",
-            &[Member::source_alpha_with_syntactic_holes(
+            &[Member::source_alpha(
                 "Counter",
                 r#"class K {
   constructor() {
@@ -538,7 +538,7 @@ export { Counter };
 "#,
         vec![logical_module(
             "shapes",
-            &[Member::source_alpha_with_syntactic_holes(
+            &[Member::source_alpha(
                 "Counter",
                 r#"class K {
   CLASS_REST;
@@ -594,7 +594,7 @@ export { Widget };
 "#,
         vec![logical_module(
             "shapes",
-            &[Member::source_alpha_with_syntactic_holes(
+            &[Member::source_alpha(
                 "Widget",
                 r#"class K {
   CLASS_REST;
@@ -652,7 +652,7 @@ export { Widget };
 "#,
         vec![logical_module(
             "shapes",
-            &[Member::source_alpha_with_syntactic_holes(
+            &[Member::source_alpha(
                 "Selected",
                 r#"class K {
   CLASS_REST;
@@ -688,7 +688,7 @@ fn anonymous_source_match_multiple_stmt_list_holes_bracket_pinned_statements() {
 const marker = "ready";
 export { marker };
 "#,
-        vec![logical_module_with_anon_alpha_syntactic_holes(
+        vec![logical_module_with_anon_alpha(
             "init",
             &[Member::new("marker")],
             r#"if (true) {
@@ -737,7 +737,7 @@ export { Counter };
 "#,
         vec![logical_module(
             "shapes",
-            &[Member::source_alpha_with_syntactic_holes(
+            &[Member::source_alpha(
                 "Counter",
                 r#"class K {
   CLASS_REST;
@@ -778,7 +778,7 @@ export { total };
 "#,
         vec![logical_module(
             "calc",
-            &[Member::source_alpha_with_syntactic_holes(
+            &[Member::source_alpha(
                 "calc_total",
                 r#"const readable = Math.max(EXPR, limit);"#,
             )],

--- a/devinfra/js/debundle/js_ast.rs
+++ b/devinfra/js/debundle/js_ast.rs
@@ -1,13 +1,10 @@
 use std::collections::BTreeMap;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Result, bail};
 use swc_atoms::Atom;
 use swc_common::comments::{Comment, CommentKind, Comments, SingleThreadedComments};
 use swc_common::sync::Lrc;
-use swc_common::{
-    BytePos, DUMMY_SP, EqIgnoreSpan, FileName, GLOBALS, Globals, Mark, SourceMap, Spanned,
-    SyntaxContext,
-};
+use swc_common::{BytePos, DUMMY_SP, FileName, GLOBALS, Globals, Mark, SourceMap, Spanned};
 use swc_ecma_ast::{Decl, Module, ModuleDecl, ModuleItem, Pat, Stmt, Str};
 use swc_ecma_codegen::text_writer::JsWriter;
 use swc_ecma_codegen::{Config, Emitter};
@@ -246,75 +243,6 @@ fn parse_module_from_source_file(source_name: &str, fm: &swc_common::SourceFile)
 
 pub fn emit_js_module(parsed: &ParsedJsModule, header_lines: &[String]) -> Result<String> {
     emit_js_module_with_comments(parsed, header_lines, &BTreeMap::new(), &BTreeMap::new())
-}
-
-/// Resolve one `anonymous_statements[].match` selector to a top-level
-/// body index in `runtime_module`. Equality ignores spans and syntax
-/// contexts because selector snippets and runtime chunks are parsed
-/// independently.
-pub fn resolve_anonymous_statement_body_index(
-    runtime_module: &Module,
-    request_id: &str,
-    match_source: &str,
-) -> Result<usize> {
-    let matches = find_anonymous_statement_body_indices(runtime_module, request_id, match_source)?;
-    match matches.as_slice() {
-        [single] => Ok(*single),
-        [] => bail!(
-            "logical_module {request_id}: anonymous_statements[].match did not match any \
-             top-level statement in the chunk. Selector:\n{match_source}",
-        ),
-        multiple => bail!(
-            "logical_module {request_id}: anonymous_statements[].match is ambiguous — \
-             matched {} top-level statements at body indices {:?}. Refine the selector. \
-             Source:\n{match_source}",
-            multiple.len(),
-            multiple,
-        ),
-    }
-}
-
-/// Find every top-level body index matched by one
-/// `anonymous_statements[].match` selector. The selector must parse
-/// as exactly one top-level statement; zero matches in the runtime
-/// module are represented as `Ok(Vec::new())`.
-pub fn find_anonymous_statement_body_indices(
-    runtime_module: &Module,
-    request_id: &str,
-    match_source: &str,
-) -> Result<Vec<usize>> {
-    let parsed = parse_js_module_ast(
-        &format!("<anonymous_statement match in {request_id}>"),
-        match_source,
-    )
-    .with_context(|| {
-        format!(
-            "logical_module {request_id}: anonymous_statements[].match did not parse as JS:\n{match_source}"
-        )
-    })?;
-    let parsed_items: Vec<&ModuleItem> = parsed.body.iter().collect();
-    let needle = match parsed_items.as_slice() {
-        [single] => *single,
-        [] => bail!(
-            "logical_module {request_id}: anonymous_statements[].match parsed to zero \
-             statements; selector source must contain exactly one top-level \
-             statement:\n{match_source}",
-        ),
-        _ => bail!(
-            "logical_module {request_id}: anonymous_statements[].match parsed to {} \
-             statements; selector source must contain exactly one top-level \
-             statement:\n{match_source}",
-            parsed_items.len(),
-        ),
-    };
-    Ok(SyntaxContext::within_ignored_ctxt(|| {
-        runtime_module
-            .body
-            .iter()
-            .enumerate()
-            .filter_map(|(body_idx, item)| needle.eq_ignore_span(item).then_some(body_idx))
-            .collect()
-    }))
 }
 
 /// Number of post-comma-list-split positions a top-level body item

--- a/devinfra/js/debundle/lowering/chunk_renames.rs
+++ b/devinfra/js/debundle/lowering/chunk_renames.rs
@@ -6,11 +6,10 @@ pub(super) fn collect_chunk_renames(
     chunk_renames: &ChunkRenames,
 ) -> Result<HashMap<String, String>> {
     let mut renames = HashMap::<String, String>::new();
-    let id = chunk_renames.id.as_deref().unwrap_or("chunk_renames");
     for member in &chunk_renames.members {
         let Some(binding_selector) = &member.selector.binding else {
             bail!(
-                "chunk_renames {id}: members[].selector.source_match is not supported here; use selector.binding.name"
+                "chunk_renames: members[].selector.source_match is not supported here; use selector.binding.name"
             );
         };
         let binding = binding_selector.name.clone();
@@ -18,7 +17,7 @@ pub(super) fn collect_chunk_renames(
         if let Some(existing) = renames.get(&binding) {
             if existing != &export_name {
                 bail!(
-                    "chunk_renames {id}: binding {binding} already renamed to \
+                    "chunk_renames: binding {binding} already renamed to \
                      {existing}; refusing to overwrite with {export_name}"
                 );
             }

--- a/devinfra/js/debundle/lowering/io.rs
+++ b/devinfra/js/debundle/lowering/io.rs
@@ -1,4 +1,5 @@
 use super::*;
+use output_layout::OWNER_GRAPH_REPORT;
 use std::fs;
 use std::io::BufWriter;
 
@@ -22,7 +23,7 @@ pub(super) fn write_chunk_report_json<T: Serialize>(
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
-    if filename == "owner_graph.json" {
+    if filename == OWNER_GRAPH_REPORT {
         // This side output is large enough on real app chunks that pretty
         // printing meaningfully affects local and remote test artifact size.
         // Keep small human-first reports pretty; keep the graph jq-first.

--- a/devinfra/js/debundle/lowering/lower.rs
+++ b/devinfra/js/debundle/lowering/lower.rs
@@ -430,7 +430,6 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
             chunk_file: entry_file.to_string(),
             role: FileRole::Entry,
             source_path: source_path.to_string(),
-            generated_by_selected_module_lowering: false,
         },
     }];
     let mut file_records = vec![(entry_file.to_string(), FileRole::Entry)];
@@ -901,7 +900,6 @@ fn build_module_output(
             chunk_file: plan.target_file.clone(),
             role: FileRole::Module,
             source_path: context.source_path.to_string(),
-            generated_by_selected_module_lowering: true,
         },
     };
     let record = (plan.target_file.clone(), FileRole::Module);

--- a/devinfra/js/debundle/lowering/materialize/mod.rs
+++ b/devinfra/js/debundle/lowering/materialize/mod.rs
@@ -10,10 +10,10 @@ pub(super) use apply::apply_materialized_logical_chunks;
 use plan_builder::{ChunkPlan, ChunkPlanBuilder, ExplicitRequestContext};
 
 use super::io::write_chunk_report_json;
-use super::ordinal::statement_ordinal_for_body_index;
 use super::util::{render_atomic_unit_cause_guidance, target_file_for_request};
 use super::*;
 use crate::time_phase;
+use js_ast::statement_ordinal_for_body_index;
 use output_layout::{ATOMIC_UNIT_CONFLICTS_REPORT, CYCLES_REPORT, OWNER_GRAPH_REPORT};
 
 /// Per-chunk inputs that identify the chunk and where its outputs

--- a/devinfra/js/debundle/lowering/ordinal.rs
+++ b/devinfra/js/debundle/lowering/ordinal.rs
@@ -1,40 +1,11 @@
 use super::*;
 
-/// Number of post-comma-list-split positions a top-level body
-/// item produces. `var x = …, y = …;` is one body item but two
-/// post-split owners (and therefore two `StatementOrdinal`s in
-/// the owner graph). All other top-level items count as one.
-/// Mirrors the splitting in `facts::top_level_item_views`.
-pub(super) fn post_split_top_level_count(item: &ModuleItem) -> usize {
-    fn decl_count(decl: &Decl) -> usize {
-        match decl {
-            Decl::Var(var) if var.decls.len() > 1 => var.decls.len(),
-            _ => 1,
-        }
-    }
-    match item {
-        ModuleItem::Stmt(Stmt::Decl(decl)) => decl_count(decl),
-        ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(export_decl)) => {
-            decl_count(&export_decl.decl)
-        }
-        _ => 1,
-    }
-}
+use js_ast::post_split_top_level_count;
 
-/// Convert a pre-split body index to the first post-split
-/// `StatementOrdinal` value for that body item. For anonymous
-/// statements (which never split), this is the only ordinal in
-/// the resulting range.
-pub(super) fn statement_ordinal_for_body_index(body: &[ModuleItem], body_idx: usize) -> usize {
-    body[..body_idx]
-        .iter()
-        .map(post_split_top_level_count)
-        .sum()
-}
-
-/// Inverse of [`statement_ordinal_for_body_index`]: given a post-split
-/// statement ordinal, return the pre-split body index of the body item
-/// that produced it. Returns `None` if the ordinal is past the body.
+/// Inverse of [`js_ast::statement_ordinal_for_body_index`]: given a
+/// post-split statement ordinal, return the pre-split body index of the
+/// body item that produced it. Returns `None` if the ordinal is past
+/// the body.
 pub(super) fn body_index_for_statement_ordinal(
     body: &[ModuleItem],
     stmt_ordinal: usize,

--- a/devinfra/js/debundle/peel/factorize.rs
+++ b/devinfra/js/debundle/peel/factorize.rs
@@ -475,15 +475,6 @@ fn emit_proposals(
     size_cap_lines: usize,
     context: &FactorizeContext,
 ) -> Vec<FactorizeProposal> {
-    // Build owner-to-class for every owner. The renderer's edge
-    // attribution treats classes as the unit of accounting (the
-    // pre-commit-4 code keyed by "cell_idx", a parallel index; the
-    // ClassId itself is now the natural key).
-    let mut owner_to_class: HashMap<usize, ClassId> = HashMap::new();
-    for (i, _) in graph.nodes.iter().enumerate() {
-        owner_to_class.insert(i, quotient.class_of(OwnerIdx(i)));
-    }
-
     // Candidate classes: every live class that isn't the residual
     // catch-all and either has owners or carries module labels. We
     // skip classes whose only members are spec-module owners with

--- a/devinfra/js/debundle/peel/quotient.rs
+++ b/devinfra/js/debundle/peel/quotient.rs
@@ -2790,16 +2790,3 @@ fn lowest_owner_idx<'a>(
 // compile-time guarantee (no public method exists)" approach the
 // plan calls for; the test `contract_never_un_contracts` in
 // `quotient_integration_test.rs` exercises the post-condition.
-
-#[cfg(test)]
-mod tests {
-    // Inline tests live next to the kernel for fast iteration but
-    // would only run under the (currently-broken) `:peel_test`
-    // target. The `:peel_quotient_integration_test` target compiles
-    // an integration test (`peel/quotient_integration_test.rs`)
-    // against the `:peel` library's public API, which is the path
-    // that actually exercises the kernel today.
-    //
-    // Leave this scaffolding in place so when `peel_test` is fixed,
-    // dropping a unit test here just works.
-}

--- a/devinfra/js/debundle/peel/quotient_integration_test.rs
+++ b/devinfra/js/debundle/peel/quotient_integration_test.rs
@@ -1,7 +1,7 @@
 //! Integration tests for the `peel::quotient` kernel and the
 //! `factorize` renderer-over-quotient. Compiled against `:peel`'s
-//! public API as a separate crate; bypasses the broken `:peel_test`
-//! target.
+//! public API as a separate crate — the same surface external
+//! consumers of the kernel see.
 //!
 //! Test list (commit 1 + 1b of `plans/peel_proposer_contraction_model.md`):
 //!
@@ -1441,21 +1441,14 @@ fn boolean_merge_gate_matches_diagnostic_cycle_gate() {
 }
 
 #[test]
+#[ignore = "needs GAFFER_OWNER_GRAPH pointing at a real corpus owner_graph.json; run manually"]
 fn greedy_on_gaffer_chunk_completes_under_one_minute() {
-    // Benchmark: real owner_graph.json from a recent gaffer cache.
-    // The fixture is pointed at via GAFFER_OWNER_GRAPH; absence
-    // skips the test (the CI cache may not have one). Local
-    // validation provides the path explicitly. We run the full
-    // factorize pipeline (cells + greedy + emit) since the greedy
-    // is only meaningful with the cells-derived partition's
+    // Benchmark: real owner_graph.json from a recent gaffer cache,
+    // pointed at via GAFFER_OWNER_GRAPH. We run the full factorize
+    // pipeline (cells + greedy + emit) since the greedy is only
+    // meaningful with the cells-derived partition's
     // pre-existing-module markings.
-    let path = match std::env::var("GAFFER_OWNER_GRAPH") {
-        Ok(p) => p,
-        Err(_) => {
-            eprintln!("skipped: GAFFER_OWNER_GRAPH not set");
-            return;
-        }
-    };
+    let path = std::env::var("GAFFER_OWNER_GRAPH").expect("GAFFER_OWNER_GRAPH must be set");
     let body = std::fs::read_to_string(&path).expect("read GAFFER_OWNER_GRAPH");
     let report: OwnerGraphReport = serde_json::from_str(&body).expect("parse owner_graph.json");
     // The factorize CLI loads active claims from a modules-root
@@ -2666,35 +2659,6 @@ fn incremental_kernel_query_matches_rebuild_after_each_contract() {
             );
         }
     }
-}
-
-#[test]
-fn unification_eliminates_cell_pipeline() {
-    // Static check: the `Cell` IR struct and the
-    // `proposal_cells_from_atomic_graph` symbol no longer exist
-    // in the peel crate's source. Embedding the source file at
-    // build time lets us assert at runtime that no recidivist
-    // restoration of the deleted symbols slipped back in.
-    //
-    // A direct compile-time guarantee (no public symbol exists)
-    // would be Rust's `peel::factorize::proposal_cells_from_atomic_graph`
-    // failing to compile — but the function is `fn` (module-
-    // private) in factorize.rs, so we can't probe for it from
-    // outside the crate. The source-embedded grep covers both
-    // module-private and public surfaces uniformly.
-    let factorize_src: &str = include_str!("factorize.rs");
-    assert!(
-        !factorize_src.contains("fn proposal_cells_from_atomic_graph"),
-        "`proposal_cells_from_atomic_graph` was deleted in commit 4; do not restore",
-    );
-    assert!(
-        !factorize_src.contains("struct Cell {"),
-        "the `Cell` IR struct was deleted in commit 4; do not restore",
-    );
-    assert!(
-        !factorize_src.contains("fn promote_anonymous_only_cell_to_extension"),
-        "`promote_anonymous_only_cell_to_extension` was deleted in commit 4 — subsumed by the greedy's 'extend single consumer' merges",
-    );
 }
 
 // ---------------------------------------------------------------------

--- a/devinfra/js/debundle/prepare_chunks.rs
+++ b/devinfra/js/debundle/prepare_chunks.rs
@@ -305,7 +305,6 @@ fn canonical_parsed_file(chunk_id: &str, source_path: &str, parsed: ParsedJsModu
             chunk_file: CANONICAL_CHUNK_ENTRY_FILE.to_string(),
             role: FileRole::Entry,
             source_path: source_path.to_string(),
-            generated_by_selected_module_lowering: false,
         },
     }
 }

--- a/devinfra/js/debundle/program_analysis.rs
+++ b/devinfra/js/debundle/program_analysis.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use swc_common::Spanned;
 use swc_ecma_ast::*;
@@ -9,10 +9,7 @@ use artifact::{
     ImportSpecifierKind, ImportSpecifierRecord, KeptTopLevelDeclarationRecord, ParserOptionsRecord,
     TopLevelDeclarationKind,
 };
-use binding_targets::{
-    TargetAccessRecorder, binding_names, member_root_sym, module_export_name, record_assign_target,
-    record_member_target, record_pat_write, record_update_target,
-};
+use binding_targets::{binding_names, member_root_sym, module_export_name};
 use js_ast::{ParsedJsModule, SourceLineIndex, str_value};
 
 /// True when a specifier string is a relative module path that
@@ -87,7 +84,6 @@ pub struct OwnerRecord {
     pub names: Vec<String>,
     pub ordinal: usize,
     pub kind: TopLevelDeclarationKind,
-    pub accesses: IdentifierAccesses,
 }
 
 /// If `item` is a top-level declaration of a kind we anchor extraction on,
@@ -118,41 +114,9 @@ fn classify_top_level_decl(item: &ModuleItem) -> Option<(TopLevelDeclarationKind
     }
 }
 
-impl From<TopLevelDeclarationKind> for AccessSourceKind {
-    fn from(kind: TopLevelDeclarationKind) -> Self {
-        match kind {
-            TopLevelDeclarationKind::Function => AccessSourceKind::Function,
-            TopLevelDeclarationKind::Class => AccessSourceKind::Class,
-            TopLevelDeclarationKind::Variable => AccessSourceKind::Variable,
-        }
-    }
-}
-
 pub struct SideEffectRecord {
     pub id: String,
     pub ordinal: usize,
-    pub accesses: IdentifierAccesses,
-    pub runtime_sensitive: bool,
-    pub replayable: bool,
-}
-
-/// Result of one fused per-statement walk: the identifier-access
-/// sets the previous `IdentifierAccessCollector` produced, plus the
-/// `runtime_sensitive` flag the previous `RuntimeSensitiveCollector`
-/// produced. Both used to walk the same item AST independently.
-struct ItemFacts {
-    accesses: IdentifierAccesses,
-    runtime_sensitive: bool,
-}
-
-#[derive(Default, Clone)]
-pub struct IdentifierAccesses {
-    eager_reads: HashSet<String>,
-    lazy_reads: HashSet<String>,
-    eager_writes: HashSet<String>,
-    lazy_writes: HashSet<String>,
-    eager_member_writes: HashSet<String>,
-    lazy_member_writes: HashSet<String>,
 }
 
 pub fn analyze_program_shallow(parsed: &ParsedJsModule) -> ProgramAnalysis {
@@ -227,29 +191,19 @@ pub fn analyze_program_shallow(parsed: &ParsedJsModule) -> ProgramAnalysis {
         }
 
         if let Some((kind, names)) = classify_top_level_decl(item) {
-            // Owners never read `runtime_sensitive`; we still let the
-            // fused collector compute it (essentially free — one bool
-            // write inside the same walk) so the per-item walk count
-            // stays at one for every item.
-            let facts = collect_item_facts(item, kind.into());
             owners.push(OwnerRecord {
                 id: format!("owner_{:05}", owners.len()),
                 line: item_line(&line_index, item),
                 names,
                 ordinal,
                 kind,
-                accesses: facts.accesses,
             });
             continue;
         }
 
-        let facts = collect_item_facts(item, AccessSourceKind::SideEffect);
         side_effects.push(SideEffectRecord {
             id: format!("side_effect_{:05}", side_effects.len()),
             ordinal,
-            runtime_sensitive: facts.runtime_sensitive,
-            replayable: matches!(item, ModuleItem::Stmt(Stmt::Expr(_))),
-            accesses: facts.accesses,
         });
     }
 
@@ -374,29 +328,6 @@ fn item_line(line_index: &SourceLineIndex, item: &ModuleItem) -> Option<usize> {
     line_index.line_for_span(item.span())
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum AccessPhase {
-    Eager,
-    Lazy,
-}
-
-#[derive(Clone, Copy)]
-enum AccessSourceKind {
-    Variable,
-    Function,
-    Class,
-    SideEffect,
-}
-
-fn collect_item_facts(item: &ModuleItem, source_kind: AccessSourceKind) -> ItemFacts {
-    let mut collector = StatementItemCollector::new(source_kind);
-    item.visit_with(&mut collector);
-    ItemFacts {
-        accesses: collector.accesses,
-        runtime_sensitive: collector.runtime_sensitive,
-    }
-}
-
 /// Single-pass module-level walk producing every fact set the
 /// stage-one analyzer needs that does not depend on per-statement
 /// phase tracking:
@@ -474,173 +405,5 @@ impl Visit for ModuleScanVisitor {
             self.has_rewritable_specifier = true;
         }
         node.visit_children_with(self);
-    }
-}
-
-/// Fused per-statement collector. Walks one `ModuleItem` once and
-/// produces both `IdentifierAccesses` (phase-bucketed reads/writes)
-/// and the `runtime_sensitive` flag (true on `import(...)`,
-/// `eval(...)`, `import.meta`, `await`). Replaces the previous
-/// `IdentifierAccessCollector` + `RuntimeSensitiveCollector` pair
-/// that each ran a separate `visit_with` over the same item.
-struct StatementItemCollector {
-    accesses: IdentifierAccesses,
-    phase: AccessPhase,
-    runtime_sensitive: bool,
-}
-
-impl Visit for StatementItemCollector {
-    fn visit_ident(&mut self, node: &Ident) {
-        self.record_read(node.sym.as_ref());
-    }
-
-    fn visit_binding_ident(&mut self, _node: &BindingIdent) {}
-
-    fn visit_import_decl(&mut self, _node: &ImportDecl) {}
-
-    fn visit_named_export(&mut self, _node: &NamedExport) {}
-
-    fn visit_export_default_decl(&mut self, _node: &ExportDefaultDecl) {}
-
-    fn visit_fn_decl(&mut self, node: &FnDecl) {
-        self.with_phase(AccessPhase::Lazy, |collector| {
-            node.function.visit_with(collector);
-        });
-    }
-
-    fn visit_fn_expr(&mut self, node: &FnExpr) {
-        self.with_phase(AccessPhase::Lazy, |collector| {
-            node.function.visit_with(collector);
-        });
-    }
-
-    fn visit_function(&mut self, node: &Function) {
-        self.with_phase(AccessPhase::Lazy, |collector| {
-            node.visit_children_with(collector);
-        });
-    }
-
-    fn visit_arrow_expr(&mut self, node: &ArrowExpr) {
-        self.with_phase(AccessPhase::Lazy, |collector| {
-            node.visit_children_with(collector);
-        });
-    }
-
-    fn visit_assign_expr(&mut self, node: &AssignExpr) {
-        record_assign_target(&node.left, self);
-        node.right.visit_with(self);
-    }
-
-    fn visit_for_in_stmt(&mut self, node: &ForInStmt) {
-        match &node.left {
-            ForHead::VarDecl(_) => {}
-            ForHead::Pat(pattern) => record_pat_write(pattern, self),
-            ForHead::UsingDecl(_) => {}
-        }
-        node.right.visit_with(self);
-        node.body.visit_with(self);
-    }
-
-    fn visit_for_of_stmt(&mut self, node: &ForOfStmt) {
-        match &node.left {
-            ForHead::VarDecl(_) => {}
-            ForHead::Pat(pattern) => record_pat_write(pattern, self),
-            ForHead::UsingDecl(_) => {}
-        }
-        node.right.visit_with(self);
-        node.body.visit_with(self);
-    }
-
-    fn visit_unary_expr(&mut self, node: &UnaryExpr) {
-        if node.op == UnaryOp::Delete
-            && let Expr::Member(member) = &*node.arg
-        {
-            record_member_target(member, self);
-            return;
-        }
-        node.visit_children_with(self);
-    }
-
-    fn visit_update_expr(&mut self, node: &UpdateExpr) {
-        record_update_target(&node.arg, self);
-    }
-
-    // Runtime-sensitivity hooks (previously `RuntimeSensitiveCollector`).
-    // These set `runtime_sensitive` and otherwise continue the default
-    // traversal so the access-collection logic above keeps seeing
-    // identifiers nested inside the trigger.
-
-    fn visit_call_expr(&mut self, node: &CallExpr) {
-        if !self.runtime_sensitive
-            && (matches!(node.callee, Callee::Import(_))
-                || matches!(&node.callee, Callee::Expr(expr) if matches!(&**expr, Expr::Ident(ident) if ident.sym == *"eval")))
-        {
-            self.runtime_sensitive = true;
-        }
-        node.visit_children_with(self);
-    }
-
-    fn visit_meta_prop_expr(&mut self, _node: &MetaPropExpr) {
-        self.runtime_sensitive = true;
-    }
-
-    fn visit_await_expr(&mut self, node: &AwaitExpr) {
-        self.runtime_sensitive = true;
-        node.visit_children_with(self);
-    }
-}
-
-impl StatementItemCollector {
-    fn new(source_kind: AccessSourceKind) -> Self {
-        Self {
-            accesses: IdentifierAccesses::default(),
-            phase: match source_kind {
-                AccessSourceKind::Function => AccessPhase::Lazy,
-                _ => AccessPhase::Eager,
-            },
-            runtime_sensitive: false,
-        }
-    }
-
-    fn with_phase(&mut self, phase: AccessPhase, visit: impl FnOnce(&mut Self)) {
-        let previous = self.phase;
-        self.phase = phase;
-        visit(self);
-        self.phase = previous;
-    }
-
-    fn record_read(&mut self, name: &str) {
-        match self.phase {
-            AccessPhase::Eager => self.accesses.eager_reads.insert(name.to_string()),
-            AccessPhase::Lazy => self.accesses.lazy_reads.insert(name.to_string()),
-        };
-    }
-
-    fn record_write(&mut self, name: &str) {
-        match self.phase {
-            AccessPhase::Eager => self.accesses.eager_writes.insert(name.to_string()),
-            AccessPhase::Lazy => self.accesses.lazy_writes.insert(name.to_string()),
-        };
-    }
-
-    fn record_member_write(&mut self, name: &str) {
-        match self.phase {
-            AccessPhase::Eager => self.accesses.eager_member_writes.insert(name.to_string()),
-            AccessPhase::Lazy => self.accesses.lazy_member_writes.insert(name.to_string()),
-        };
-    }
-}
-
-impl TargetAccessRecorder for StatementItemCollector {
-    fn record_binding_read(&mut self, id: &Id) {
-        self.record_read(id.0.as_ref());
-    }
-
-    fn record_binding_write(&mut self, id: &Id) {
-        self.record_write(id.0.as_ref());
-    }
-
-    fn record_member_write(&mut self, id: &Id) {
-        StatementItemCollector::record_member_write(self, id.0.as_ref());
     }
 }

--- a/devinfra/js/debundle/realizability.rs
+++ b/devinfra/js/debundle/realizability.rs
@@ -1495,9 +1495,8 @@ impl IncrementalQuotient {
         owners: &[OwnerId],
         to: ModuleId,
     ) -> QuotientOverlay {
+        let impacted_edges = impacted_owner_edges(owner_graph, owners);
         let owners: BTreeSet<OwnerId> = owners.iter().copied().collect();
-        let impacted_owners: Vec<OwnerId> = owners.iter().copied().collect();
-        let impacted_edges = impacted_owner_edges(owner_graph, &impacted_owners);
         let mut overlay = QuotientOverlay::default();
         for edge_id in impacted_edges {
             let edge = owner_graph.edge(edge_id);

--- a/devinfra/js/debundle/rewrite_specifiers.rs
+++ b/devinfra/js/debundle/rewrite_specifiers.rs
@@ -6,9 +6,8 @@ use swc_ecma_ast::*;
 use swc_ecma_visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 
 use artifact::{
-    ArtifactIndexes, ChunkBundle, ChunkId, ChunkTable, FileRole, ImportReferenceKind, JsFile,
-    JsFileAstParts, get_chunk_entry_path, join_module_path, module_path_dirname,
-    relative_module_path,
+    ArtifactIndexes, ChunkBundle, ChunkId, ChunkTable, ImportReferenceKind, JsFile, JsFileAstParts,
+    get_chunk_entry_path, join_module_path, module_path_dirname, relative_module_path,
 };
 use js_ast::{ParsedJsModule, set_str_value, str_value};
 
@@ -48,7 +47,7 @@ pub fn rewrite_chunk_entry_specifiers(
             let Some(file) = chunk_artifact.js.get_file(&file_path) else {
                 continue;
             };
-            if !should_rewrite_file(file) {
+            if !file.is_ast() {
                 continue;
             }
             let file = chunk_artifact
@@ -155,12 +154,6 @@ pub fn runtime_js_href(
         .join(chunk_name.split('/').collect::<std::path::PathBuf>())
         .join(entry_file.split('/').collect::<std::path::PathBuf>());
     Ok(artifact::relative_module_specifier(out_dir, &entry_path))
-}
-
-fn should_rewrite_file(file: &JsFile) -> bool {
-    file.is_ast()
-        && !(file.metadata.role == FileRole::Module
-            && file.metadata.generated_by_selected_module_lowering)
 }
 
 /// Returns true when the parsed module contains any specifier that

--- a/devinfra/js/debundle/spec.rs
+++ b/devinfra/js/debundle/spec.rs
@@ -203,9 +203,6 @@ pub struct EmitBrowserHarnessConfig {
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ChunkRenames {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(default)]
-    pub id: Option<String>,
     #[serde(default)]
     pub members: Vec<Member>,
 }
@@ -605,11 +602,6 @@ impl std::error::Error for AnonymousStatementSelectorError {}
 #[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq, Ord, PartialOrd)]
 #[serde(deny_unknown_fields)]
 pub struct SourceMatch {
-    /// Optional documentary kind for future selector families. Anonymous
-    /// statement resolution currently always parses `match` as exactly one
-    /// top-level statement.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub kind: Option<String>,
     #[serde(
         default,
         skip_serializing_if = "is_default_source_match_identifier_mode"

--- a/devinfra/js/debundle/spec_tree.rs
+++ b/devinfra/js/debundle/spec_tree.rs
@@ -491,7 +491,6 @@ fn chunk_renames_map(
     BTreeMap::from([(
         main_chunk_id.to_string(),
         ChunkRenames {
-            id: None,
             members: binding_patch_members,
         },
     )])

--- a/devinfra/js/debundle/validate_emitted_exports.rs
+++ b/devinfra/js/debundle/validate_emitted_exports.rs
@@ -27,13 +27,12 @@
 //! materialization or strip, so this pass has no leverage on them and
 //! the upstream chunk shape itself is the upstream's contract.
 //!
-//! This stage doesn't *fix* the underlying generation bug — the
-//! emit-side paths that produced the duplicate still need patching
-//! (the immediate one is `auto_grown_residual_exports` in
-//! `lowering/exports.rs`, which compares local binding names to
-//! `pre_existing_entry_exports` but never checks whether the public
-//! name it's about to grow would collide with an existing alias's
-//! public name). It just makes the failure mode unmissable.
+//! This stage doesn't *fix* an underlying generation bug — it makes
+//! the failure mode unmissable when an emit-side path regresses.
+//! (The original offender, `auto_grown_residual_exports` in
+//! `lowering/exports.rs`, now checks candidates against
+//! `pre_existing_public_export_names` and suffix-mints a
+//! non-colliding name.)
 
 use std::collections::BTreeMap;
 
@@ -263,7 +262,6 @@ mod tests {
                 chunk_file: file_name.to_string(),
                 role,
                 source_path: format!("{chunk_name}.js"),
-                generated_by_selected_module_lowering: false,
             },
         };
         if let Some(existing) = bundle.chunks.iter_mut().find(|c| c.chunk_id == chunk_id) {
@@ -413,7 +411,6 @@ export * from \"./sibling.js\";\n";
                     chunk_file: "raw.js".to_string(),
                     role: FileRole::Module,
                     source_path: "c.js".to_string(),
-                    generated_by_selected_module_lowering: false,
                 },
             });
             validate_emitted_exports(&bundle).expect("source-only file skipped");

--- a/devinfra/js/debundle/vendor/mod.rs
+++ b/devinfra/js/debundle/vendor/mod.rs
@@ -2716,7 +2716,6 @@ export { b as beta };
                         chunk_file: entry_file.clone(),
                         role: FileRole::Entry,
                         source_path: format!("{chunk_id}.js"),
-                        generated_by_selected_module_lowering: false,
                     },
                 }],
                 metadata: ChunkMetadata {


### PR DESCRIPTION
Dead-code / stale-comment sweep of `devinfra/js/debundle/`. Each removal with its justification:

1. **`unification_eliminates_cell_pipeline` test deleted** (`peel/quotient_integration_test.rs`) — pure change-detector: `include_str!`-grepped `factorize.rs` for symbols deleted long ago; exercises no behavior. Also dropped `peel/factorize.rs` from the target's `compile_data` (golden JSONs kept).
2. **`NodeOutput` struct deleted** (`e2e/support.rs`) — zero references; duplicate of `CommandResult`. Its CODE_REVIEW.md P5 entry removed.
3. **Write-only analysis payload deleted** (`program_analysis.rs`) — `IdentifierAccesses`, `OwnerRecord.accesses`, `SideEffectRecord.{accesses,runtime_sensitive,replayable}` and the fused `StatementItemCollector` that populated them. No reader anywhere (verified: not serialized into reports/schema, not consumed by `live_proxy/*.py`, skills, or e2e fixtures). Kills one full AST walk per top-level statement.
4. **`generated_by_selected_module_lowering` flag deleted** (`artifact.rs` + 6 construction sites + `should_rewrite_file` reader) — its only reader guarded against re-rewriting lowered modules, but `rewrite_chunk_entry_specifiers` runs exactly once, pre-materialize (`pipeline.rs:168`); verified no post-materialize call exists. The CODE_REVIEW.md "Pipeline ordering" item is removed (investigation concluded: the flag was already unreachable).
5. **Duplicate anonymous-statement resolution + ordinal helpers deduplicated** — `js_ast.rs`'s weaker `resolve_anonymous_statement_body_index` / `find_anonymous_statement_body_indices` deleted (canonical versions live in `source_match.rs`); the duplicate `post_split_top_level_count` / `statement_ordinal_for_body_index` in `lowering/ordinal.rs` deleted in favor of the `js_ast.rs` versions (which `anonymous_resolution.rs` already used).
6. **Dead spec fields removed** — `SourceMatch.kind` (documentary-only, never read) and `ChunkRenames.id` (only ever interpolated into its own error message). No in-repo spec files use them; e2e JSON fixtures carrying `"id"` updated in the same commit (required by `deny_unknown_fields`).
7. **`peel/factorize.rs` dead `owner_to_class` map** (built, never read, plus stale comment) and **`realizability.rs` `impacted_owners` no-op alias** removed.
8. **Stale ":peel_test is broken" comments fixed** (`BUILD.bazel`, `peel/quotient_integration_test.rs` header) — `:peel_test` passes on RBE. Empty `mod tests {}` scaffolding in `peel/quotient.rs` deleted. The integration test stays a separate crate; its rationale now correctly states it exercises `:peel`'s public API.
9. **RED-test headers rewritten** on 5 green e2e tests (`accepted_spec_runs_under_node`, `at_init_s_chain_dataflow`, `runtime_tdz_on_imported_class`, `at_init_promotion_fndecl_direct_read`, `auto_grown_export_alias_collision`) as "Regression test (originally RED) for …", dropping rot-prone pinned line numbers. Mangled redaction artifacts ("the upstream `an upstream class` class", "the the") fixed. `purity_test.rs` ignored-desiderata count corrected (four → two).
10. **Vacuous benchmark fixed** — `greedy_on_gaffer_chunk_completes_under_one_minute` silently early-returned when `GAFFER_OWNER_GRAPH` was unset (i.e. always, in CI); now `#[ignore = "needs GAFFER_OWNER_GRAPH pointing at a real corpus owner_graph.json; run manually"]`.
11. **No-op `*_with_syntactic_holes` alias constructors deleted** (`e2e/support.rs`: `BindingGroup`, `Member`, `FixtureAnonymousStatement`, `logical_module_with_anon_alpha_syntactic_holes`) — byte-identical to their non-suffixed counterparts; ~20 call sites in `syntactic_holes_test.rs` updated. Dead `FixtureAnonymousStatement.note` (never set non-None) and `Fixture.snapshot_root` (`#[allow(dead_code)]`, no reader) deleted.
12. **`lowering/io.rs` filename literal** `"owner_graph.json"` replaced with the existing `output_layout::OWNER_GRAPH_REPORT` constant.
13. **`validate_emitted_exports.rs` module doc updated** — the "fix belongs upstream" paragraph was stale; `auto_grown_residual_exports` now checks `pre_existing_public_export_names` and mints non-colliding names.

Nothing skipped: all 13 claims held at HEAD (rebased onto current `devel`).

Net: −701/+181 lines. Full `bbr test //devinfra/js/debundle/...` green: 83/83 (BuildBuddy invocation `183f9243-36c7-478b-b1b3-296d15d14ba1`).

https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk)_