### PR TITLE
Restore Flux image automation auth

### DIFF
--- a/cluster/k8s/flux-system/gotk-sync.yaml
+++ b/cluster/k8s/flux-system/gotk-sync.yaml
@@ -7,8 +7,11 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1m0s
+  provider: github
   ref:
     branch: devel
+  secretRef:
+    name: ducktape-automation-github-app
   url: https://github.com/agentydragon/ducktape.git
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1

--- a/cluster/k8s/litellm/tana/deployment.yaml
+++ b/cluster/k8s/litellm/tana/deployment.yaml
@@ -21,7 +21,7 @@ spec:
       terminationGracePeriodSeconds: 90
       containers:
         - name: litellm
-          image: ghcr.io/agentydragon/tana-litellm-proxy:devel-20260611022136-18cf07f # {"$imagepolicy": "flux-system:tana-litellm-proxy"}
+          image: ghcr.io/agentydragon/tana-litellm-proxy:devel-20260611051224-5a5bcab # {"$imagepolicy": "flux-system:tana-litellm-proxy"}
           imagePullPolicy: Always
           args: ["--config", "/etc/litellm/config.yaml"]
           ports:


### PR DESCRIPTION
## Summary
- restore GitHub App auth on the root `flux-system` GitRepository so image automation can push image tag updates again
- bump `tana-litellm` to the already-published post-merge image `devel-20260611051224-5a5bcab`

## Context
While monitoring the Tana LiteLLM rollout, Flux reflected the new image tag but `ImageUpdateAutomation/all-images` could not push the manifest update:

`failed to update source: failed to push to remote: authentication required: No anonymous write access.`

The current `devel` version of `cluster/k8s/flux-system/gotk-sync.yaml` no longer had `provider: github` or `secretRef: ducktape-automation-github-app`, so the root GitRepository was fetched anonymously and image automation had no write credentials.

## Testing
- `kubectl kustomize cluster/k8s/flux-system` renders `provider: github`, `secretRef: ducktape-automation-github-app`, and the existing sparse checkout together
- `nix develop -c bazelisk test //cluster/k8s/litellm/tana:test_generate_tana_litellm`  
  BuildBuddy: https://app.buildbuddy.io/invocation/d79e8923-2f74-4435-8e96-8b74c3f68408
- `nix develop -c pre-commit run --files cluster/k8s/flux-system/gotk-sync.yaml cluster/k8s/litellm/tana/deployment.yaml`