### PR TITLE
cluster: stage Flux GitHub App auth

### DIFF
--- a/cluster/k8s/flux-system/kustomization.yaml
+++ b/cluster/k8s/flux-system/kustomization.yaml
@@ -16,6 +16,22 @@ patches:
       kind: GitRepository
       name: flux-system
     patch: |
+      # Bootstrap is deliberately two-stage:
+      # 1. cluster/terraform/main applies gotk-sync.yaml with anonymous HTTPS,
+      #    because ducktape is public and the GitHub App Secret is itself SOPS
+      #    encrypted in this repository.
+      # 2. Once the root Kustomization can fetch the repo, it decrypts
+      #    ducktape-automation-github-app.sops.yaml and this patch switches the
+      #    root GitRepository to GitHub App auth. ImageUpdateAutomation/all-images
+      #    uses this GitRepository for writes, and Flux has no separate push
+      #    credential field for the automation object.
+      - op: add
+        path: /spec/provider
+        value: github
+      - op: add
+        path: /spec/secretRef
+        value:
+          name: ducktape-automation-github-app
       - op: add
         path: /spec/sparseCheckout
         value:


### PR DESCRIPTION
## Summary

- keep the bootstrap `gotk-sync.yaml` anonymous for cold-start fetches of the public `ducktape` repo
- add a Flux-rendered patch that switches the root `GitRepository` to GitHub App auth after the SOPS-encrypted GitHub App Secret is applied
- document why this is a two-stage bootstrap path and why ImageUpdateAutomation needs the root `GitRepository` auth

## Validation

- `kubectl kustomize cluster/k8s/flux-system` renders `provider: github`, `secretRef: ducktape-automation-github-app`, and existing `sparseCheckout` on `GitRepository/flux-system`
- `bbr build //cluster/validation:validate_all`

## Live symptom

`ImageUpdateAutomation/flux-system/all-images` currently reports `failed to push to remote: authentication required: No anonymous write access.`