### PR TITLE
debundle: derive cycle reports from the canonical verdict; diagnose Pass-2 rejections

### DIFF
--- a/devinfra/js/debundle/chunk_factorization.rs
+++ b/devinfra/js/debundle/chunk_factorization.rs
@@ -10,7 +10,7 @@ use crate::graph::{
 };
 use crate::partition::Partition;
 use crate::reports::build_owner_graph_report;
-use crate::validation::validate_factorization_with_quotient;
+use crate::validation::validate_factorization;
 
 use crate::{
     FactorizationReport, LogicalModule, LogicalModuleIndex, ModuleId, ModuleQuotient,
@@ -47,10 +47,8 @@ pub struct ChunkFactorization {
     pub assembly_conflicts: Vec<AtomicUnitConflict>,
     pub dep_graph: ModuleQuotient,
     /// SCC partition of `dep_graph` in `tarjan_scc` reverse-
-    /// topological order. Precomputed at build time so downstream
-    /// consumers (`validation::validate_factorization` via the
-    /// verdict's `scc_partition`, `reports::build_quotient_scc_reports`)
-    /// share one walk.
+    /// topological order. Precomputed at build time for
+    /// `reports::build_quotient_scc_reports`.
     dep_graph_sccs: Vec<Vec<ModuleId>>,
     /// Topological linearization of `I ∪ S`, dependency-first
     /// (the module at index 0 must evaluate before any other; the
@@ -212,12 +210,10 @@ impl ChunkFactorization {
     /// Run SCC analysis over the dep graph. Spec authors consume the
     /// resulting report to fix any cycles or atomic-unit conflicts.
     pub fn validate(&self) -> FactorizationReport {
-        let mut report = validate_factorization_with_quotient(
-            &self.analysis.owner_graph,
-            &self.partition,
-            &self.dep_graph,
-            &|id| self.analysis.module_name(id),
-        );
+        let mut report =
+            validate_factorization(&self.analysis.owner_graph, &self.partition, &|id| {
+                self.analysis.module_name(id)
+            });
         report.atomic_unit_conflicts = self.assembly_conflicts.clone();
         report.linker_order = self
             .linker_order

--- a/devinfra/js/debundle/cli/gate.rs
+++ b/devinfra/js/debundle/cli/gate.rs
@@ -152,9 +152,9 @@ pub struct GateDescribeReport {
     pub id: usize,
     pub modules: Vec<String>,
     pub cut: Vec<CycleEdge>,
-    /// Recomputed from `owner_graph.json` + `modules`. Same shape
-    /// as the in-memory `CycleReport.evidence` the gate emitted to
-    /// stderr at rejection time.
+    /// Every constraining cross-module edge inside the SCC,
+    /// recomputed from `owner_graph.json` + `modules` (the wire
+    /// entry carries only `modules` + `cut`).
     pub evidence: Vec<CycleEdge>,
 }
 

--- a/devinfra/js/debundle/e2e/BUILD.bazel
+++ b/devinfra/js/debundle/e2e/BUILD.bazel
@@ -83,9 +83,11 @@ _STANDARD_E2E_DEPS = [
         "reserved_word_mint_test",
         "runtime_tdz_on_imported_class_test",
         "accepted_spec_runs_under_node_test",
+        "gate_rejection_scopes_to_bad_scc_test",
         "lemma_two_rescued_asymmetric_cycle_test",
         "mediator_reaches_asymmetric_cycle_test",
         "namespace_aggregator_split_tdz_test",
+        "pass_two_tdz_cut_diagnosis_test",
         "spec_comments_test",
         "syntactic_holes_test",
     ]

--- a/devinfra/js/debundle/e2e/gate_rejection_scopes_to_bad_scc_test.rs
+++ b/devinfra/js/debundle/e2e/gate_rejection_scopes_to_bad_scc_test.rs
@@ -1,0 +1,114 @@
+//! A gate rejection must blame ONLY the SCCs the realizability
+//! verdict diagnosed as unrealizable. A rescued asymmetric I-cycle
+//! (Lemma 2's source-import reversal makes it evaluate without TDZ;
+//! the gate's Pass-2 simulator accepts it) that happens to coexist
+//! with a genuinely unrealizable SCC in the same chunk must NOT be
+//! reported as a blocker alongside the real one.
+//!
+//! Shape: one chunk combining two disjoint asymmetric I-cycles that
+//! differ only in how ESM's evaluation DFS reaches them:
+//!
+//! - the rescued pair (`mod_ok_dep` / `mod_ok_dependent`): eager
+//!   forward edge, lazy back-edge, residual is the only entrant —
+//!   the shape `lemma_two_rescued_asymmetric_cycle_test` pins as
+//!   accepted, and
+//! - the broken pair (`mod_bad_dep` / `mod_bad_dependent`): same
+//!   internal shape, but reachable only through `mod_mediator`
+//!   (residual never references its bindings directly) — the shape
+//!   `mediator_reaches_asymmetric_cycle_test` pins as a Pass-2
+//!   (ESM-evaluation-simulator) rejection: DFS enters via the
+//!   mediator's dependency-first imports, the lazy back-edge fires
+//!   the cycle, and `bad_cross` reads `bad_dep` mid-evaluation.
+//!
+//! Both real blockers must stay Pass-2 (no mutual constraining
+//! cycle): a Pass-1 SCC anywhere empties the chunk-wide constraining
+//! linker order (`chunk_linker_order_from_pairs` returns `[]` on a
+//! cyclic input), which degrades the simulator's import ordering for
+//! every other SCC and makes the gate itself (correctly, mirroring
+//! emit) reject otherwise-rescued shapes.
+//!
+//! The historical bug: once ANY SCC was unrealizable, the validator
+//! re-walked every quotient SCC (`verdict.scc_partition()`) and
+//! reported each one carrying any constraining edge between members
+//! — over-reporting the rescued pair as a second blocker.
+
+use debundle_e2e_support::*;
+use serde_json::Value;
+
+fn combined_fixture<'a>() -> FixtureOpts<'a> {
+    FixtureOpts::new(
+        r#"const ok_dep = "alpha";
+const ok_cross = ok_dep + "-beta";
+function ok_lazy_reader() { return ok_cross; }
+const bad_dep = "gamma";
+const bad_cross = bad_dep + "-delta";
+function bad_lazy_reader() { return bad_cross; }
+function mediator_helper() { return bad_dep + "-via-mediator-" + bad_lazy_reader(); }
+const mediator_init = mediator_helper();
+console.log(ok_dep, ok_cross, ok_lazy_reader(), mediator_init);
+export { ok_dep, ok_cross, ok_lazy_reader, mediator_init };
+"#,
+        vec![
+            logical_module(
+                "mod_ok_dep",
+                &[Member::new("ok_dep"), Member::new("ok_lazy_reader")],
+            ),
+            logical_module("mod_ok_dependent", &[Member::new("ok_cross")]),
+            logical_module(
+                "mod_bad_dep",
+                &[Member::new("bad_dep"), Member::new("bad_lazy_reader")],
+            ),
+            logical_module("mod_bad_dependent", &[Member::new("bad_cross")]),
+            logical_module(
+                "mod_mediator",
+                &[Member::new("mediator_helper"), Member::new("mediator_init")],
+            ),
+        ],
+    )
+}
+
+#[test]
+fn rescued_asymmetric_scc_is_not_reported_alongside_real_blocker() {
+    let rejected = run_rejection_fixture(combined_fixture());
+    let stderr_lower = rejected.stderr.to_lowercase();
+    for required in ["unrealizable", "mod_bad_dep", "mod_bad_dependent"] {
+        assert!(
+            stderr_lower.contains(required),
+            "stderr must blame the mediator-reached SCC ({required:?} missing):\n{}",
+            rejected.stderr,
+        );
+    }
+    assert!(
+        !stderr_lower.contains("mod_ok"),
+        "rescued asymmetric SCC (mod_ok_dep/mod_ok_dependent) must not be \
+         reported as a blocker:\n{}",
+        rejected.stderr,
+    );
+
+    let cycles_path = rejected
+        .report_root
+        .join("static")
+        .join("app")
+        .join("cycles.json");
+    let cycles: Vec<Value> = read_json(&cycles_path);
+    assert_eq!(
+        cycles.len(),
+        1,
+        "only the genuinely unrealizable SCC may appear in cycles.json: {cycles:?}",
+    );
+    let modules: Vec<&str> = cycles[0]["modules"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|m| m.as_str().unwrap())
+        .collect();
+    assert!(
+        modules.iter().any(|m| m.contains("mod_bad_dep"))
+            && modules.iter().any(|m| m.contains("mod_bad_dependent")),
+        "blocking entry must list the mediator-reached I-cycle members: {modules:?}",
+    );
+    assert!(
+        modules.iter().all(|m| !m.contains("mod_ok")),
+        "rescued SCC members leaked into the blocking entry: {modules:?}",
+    );
+}

--- a/devinfra/js/debundle/e2e/pass_two_tdz_cut_diagnosis_test.rs
+++ b/devinfra/js/debundle/e2e/pass_two_tdz_cut_diagnosis_test.rs
@@ -1,0 +1,101 @@
+//! Pass-2 (ESM-evaluation-simulator) rejections must be diagnosable:
+//! the bail summary names the TDZ binding pair and the lazy
+//! back-edge that closes the I-cycle, and `cycles.json` carries a
+//! non-empty `cut` naming the violated at-init read.
+//!
+//! The fixture is the mediator shape from
+//! `mediator_reaches_asymmetric_cycle_test` (see that test's module
+//! doc for the full DFS walkthrough): the constraining subgraph of
+//! the `{mod_dep, mod_dependent}` SCC is acyclic (one forward
+//! `EagerUse`, one lazy back-edge), so a feedback-arc-set over
+//! constraining edges alone finds nothing to cut. The cut must
+//! instead come from the simulator's violated post-order check:
+//! `cross_value` (mod_dependent) at-init reads `dep_value`
+//! (mod_dep) while mod_dep's body is still mid-evaluation.
+
+use debundle_e2e_support::*;
+use serde_json::Value;
+
+fn mediator_fixture<'a>() -> FixtureOpts<'a> {
+    FixtureOpts::new(
+        r#"const dep_value = "alpha";
+const cross_value = dep_value + "-beta";
+function lazy_reader() { return cross_value; }
+function mediator_helper() { return dep_value + "-via-mediator-" + lazy_reader(); }
+const mediator_init = mediator_helper();
+console.log(mediator_init);
+export { mediator_init };
+"#,
+        vec![
+            logical_module(
+                "mod_dep",
+                &[Member::new("dep_value"), Member::new("lazy_reader")],
+            ),
+            logical_module("mod_dependent", &[Member::new("cross_value")]),
+            logical_module(
+                "mod_mediator",
+                &[Member::new("mediator_helper"), Member::new("mediator_init")],
+            ),
+        ],
+    )
+}
+
+#[test]
+fn pass_two_rejection_summary_names_tdz_binding_pair_and_lazy_closure() {
+    // The summary must blame the violated at-init read as a binding
+    // pair (reader binding, target binding, both module names) and
+    // name the lazy read that closes the I-cycle — not print
+    // "0 R/S edge(s)" with no rows, which is what the FAS-only cut
+    // computation produced for asymmetric (Pass-2) rejections.
+    expect_rejection_containing_all(
+        mediator_fixture(),
+        &[
+            "unrealizable",
+            "cross_value",
+            "dep_value",
+            "at-init",
+            "mod_dep",
+            "mod_dependent",
+            "closes through lazy read",
+            "lazy_reader",
+        ],
+    );
+}
+
+#[test]
+fn pass_two_rejection_cycles_json_has_nonempty_cut() {
+    let rejected = run_rejection_fixture(mediator_fixture());
+    let cycles_path = rejected
+        .report_root
+        .join("static")
+        .join("app")
+        .join("cycles.json");
+    let cycles: Vec<Value> = read_json(&cycles_path);
+    assert_eq!(cycles.len(), 1, "expected one blocking SCC: {cycles:?}");
+    let entry = &cycles[0];
+    let modules: Vec<&str> = entry["modules"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|m| m.as_str().unwrap())
+        .collect();
+    assert!(
+        modules.iter().any(|m| m.contains("mod_dep"))
+            && modules.iter().any(|m| m.contains("mod_dependent")),
+        "blocking SCC must list the I-cycle members: {modules:?}",
+    );
+    let cut = entry["cut"].as_array().unwrap();
+    assert!(
+        !cut.is_empty(),
+        "Pass-2 rejection must carry a non-empty cut (the violated at-init reads): {entry}",
+    );
+    // The cut names the violated constraining edge with both bindings.
+    assert!(
+        cut.iter().any(|edge| {
+            edge["binding"].as_str() == Some("dep_value")
+                && edge["from_binding"].as_str() == Some("cross_value")
+                && edge["kind"].as_str() == Some("eager_use")
+        }),
+        "cut must name the violated at-init read cross_value -> dep_value: {cut:?}",
+    );
+}

--- a/devinfra/js/debundle/lib.rs
+++ b/devinfra/js/debundle/lib.rs
@@ -63,7 +63,7 @@ pub use purity::{
 };
 pub use realizability::{
     CrossRebindEdge, DeltaHandle, PartitionDelta, RealizabilityIndex, RealizabilityVerdict,
-    SccDiagnosis, SccTimingReporter, check_realizability, check_realizability_with_quotient,
+    SccDiagnosis, SccRejection, SccTimingReporter, check_realizability,
     record_gate_diagnostic_translation,
 };
 pub use reports::schema::{
@@ -78,7 +78,6 @@ pub use stage_one::{
 pub use validation::{
     BlockingSccEntry, CycleEdge, CycleReport, FactorizationReport,
     render_atomic_unit_conflict_summary, render_cycle_summary, validate_factorization,
-    validate_factorization_with_quotient,
 };
 
 #[cfg(test)]

--- a/devinfra/js/debundle/lowering/materialize/mod.rs
+++ b/devinfra/js/debundle/lowering/materialize/mod.rs
@@ -522,8 +522,8 @@ fn validate_and_emit_reports(
     }
     if !factorization_report.cycles.is_empty() {
         if let Some(report_out_dir) = report_out_dir {
-            // Trim the wire shape before writing: drop `evidence`,
-            // keep `id` (array index), `modules`, `cut`. Evidence is
+            // Trim the wire shape before writing: keep `id` (array
+            // index), `modules`, `cut`. Per-edge evidence is
             // recomputable from `owner_graph.json` + this entry's
             // `modules` set via `debundle gate describe <id>`. See
             // `validation.rs` `BlockingSccEntry` for the schema and
@@ -538,6 +538,20 @@ fn validate_and_emit_reports(
         bail!(
             "materialize_logical_modules: chunk {chunk_id} — spec is unrealizable: {n} module-quotient SCC(s) with at-init / side-effect edges between members. Each SCC names the binding pairs whose split forced the cycle; co-locate them or break a back-edge. Full per-cycle evidence at reports/tree/{chunk_id}/cycles.json; owner graph at reports/tree/{chunk_id}/owner_graph.json. Summary:\n{summary}",
             n = factorization_report.cycles.len(),
+        );
+    }
+    // Defense-in-depth on the accept path: a cross-destination
+    // rebinding write (clause 2) always co-locates with its target in
+    // one atomic factor unit, so a spec splitting them must have
+    // produced an `atomic_unit_conflicts` bail above. Reaching this
+    // point with a non-empty clause-2 verdict means the atomic-unit
+    // glue and the realizability gate disagree — refuse to emit
+    // rather than materialize a bundle that reassigns an ESM import.
+    if !factorization_report.cross_rebinds.is_empty() {
+        bail!(
+            "materialize_logical_modules: chunk {chunk_id} — realizability verdict carries {n} cross-destination rebind(s) but no atomic-unit conflict or blocking SCC was reported; this should be unreachable (rebinding writes co-locate with their target via atomic factor units). Rebinds:\n  {rebinds}",
+            n = factorization_report.cross_rebinds.len(),
+            rebinds = factorization_report.cross_rebinds.join("\n  "),
         );
     }
     Ok(())

--- a/devinfra/js/debundle/realizability.rs
+++ b/devinfra/js/debundle/realizability.rs
@@ -42,9 +42,8 @@ use rustc_hash::FxHashSet;
 
 use crate::OwnerId;
 use crate::graph::{
-    ModuleQuotient, OwnerEdge, OwnerEdgeId, OwnerGraph, build_module_quotient,
-    chunk_constraining_module_edges, chunk_linker_order_from_pairs,
-    chunk_source_import_order_from_adjacency, position_lookup,
+    OwnerEdge, OwnerEdgeId, OwnerGraph, chunk_constraining_module_edges,
+    chunk_linker_order_from_pairs, chunk_source_import_order_from_adjacency, position_lookup,
 };
 use crate::ids::ModuleId;
 use crate::partition::Partition;
@@ -70,11 +69,37 @@ use crate::rollback_graph::{GraphMark, RollbackDiGraph};
 pub struct SccDiagnosis {
     /// Modules participating in the cycle.
     pub modules: BTreeSet<ModuleId>,
-    /// Every constraining owner-edge whose endpoints both fall inside
-    /// `modules` and that crosses module boundaries — i.e. the
-    /// owner-level evidence the cycle is composed of. Stable order by
-    /// `OwnerEdgeId`.
+    /// Constraining owner-edge evidence the rejection is composed of,
+    /// in stable `OwnerEdgeId` order. The exact edge set depends on
+    /// `rejection`:
+    ///
+    /// - [`SccRejection::MutualConstrainingCycle`]: every constraining
+    ///   cross-module owner edge whose endpoints both fall inside
+    ///   `modules`.
+    /// - [`SccRejection::EsmEvaluationTdz`]: only the owner edges
+    ///   backing the constraining `(from, to)` pairs whose simulated
+    ///   post-order check failed — the surgical set whose removal
+    ///   (by co-locating the binding pair) lifts the violation.
     pub constraining_owner_edges: Vec<OwnerEdgeId>,
+    /// Which gate pass rejected this SCC.
+    pub rejection: SccRejection,
+}
+
+/// How the realizability gate decided an SCC is unrealizable. See
+/// docs/design.md "Lemma 2: entry-side import ordering" for the
+/// two-pass gating rule.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum SccRejection {
+    /// Pass 1: the SCC is cyclic in the constraining-edge subgraph
+    /// alone — a mutual-eager cycle no source import order can
+    /// satisfy.
+    MutualConstrainingCycle,
+    /// Pass 2: the constraining subgraph of the SCC is acyclic, but
+    /// the full I-graph (constraining ∪ lazy back-edges) is cyclic
+    /// and the ESM evaluation simulator proved a TDZ: some
+    /// constraining edge's target evaluates at or after its source
+    /// under the materializer's actual import-order choices.
+    EsmEvaluationTdz,
 }
 
 /// Cross-destination rebinding write. ESM imports are read-only in the
@@ -94,13 +119,6 @@ pub struct CrossRebindEdge {
 pub struct RealizabilityVerdict {
     pub unrealizable_sccs: Vec<SccDiagnosis>,
     pub cross_rebinds: Vec<CrossRebindEdge>,
-    /// SCCs of the module-quotient graph (`build_module_quotient`),
-    /// in `tarjan_scc` reverse-topological order. Populated only by
-    /// the free function [`check_realizability`]; the
-    /// `RealizabilityIndex` verdict paths (which work off cached
-    /// constraining + I subgraphs and never materialise the full
-    /// module quotient) leave this empty.
-    scc_partition: Vec<Vec<ModuleId>>,
 }
 
 impl RealizabilityVerdict {
@@ -120,53 +138,18 @@ impl RealizabilityVerdict {
         }
         out
     }
-
-    /// SCCs of the module-quotient graph. See the field doc on
-    /// `scc_partition`. Only populated by [`check_realizability`];
-    /// callers that consume `RealizabilityIndex::verdict*` outputs
-    /// get an empty slice.
-    pub fn scc_partition(&self) -> &[Vec<ModuleId>] {
-        &self.scc_partition
-    }
 }
 
-/// Pure-function form. Builds the constraining-edge quotient, runs
-/// Tarjan, surfaces multi-module SCCs and cross-rebinds. The
+/// Pure-function form. Builds the canonical constraining edge set,
+/// runs Tarjan, surfaces multi-module SCCs and cross-rebinds. The
 /// correctness reference for the `RealizabilityIndex`'s incremental
 /// backing (verified by differential test in the
 /// `RealizabilityIndex` step 1b follow-up).
-///
-/// Thin wrapper over [`check_realizability_with_quotient`] for callers
-/// that don't already have a built `ModuleQuotient`. If you do
-/// (e.g. `ChunkFactorization::build_with`, which materialises
-/// `dep_graph = build_module_quotient(...)` for its own use), pass it
-/// to the `_with_quotient` form to avoid a redundant
-/// `build_module_quotient` + `tarjan_scc` pass.
 pub fn check_realizability(
     owner_graph: &OwnerGraph,
     partition: &Partition,
 ) -> RealizabilityVerdict {
-    let quotient = build_module_quotient(owner_graph, partition);
-    check_realizability_with_quotient(owner_graph, partition, &quotient)
-}
-
-/// Same as [`check_realizability`], but takes a pre-built
-/// `ModuleQuotient` to read SCCs from instead of constructing one
-/// from `(owner_graph, partition)` internally. The quotient must be
-/// the one produced by `build_module_quotient(owner_graph, partition)`
-/// for the same arguments — `build_module_quotient` is deterministic,
-/// so any two `ModuleQuotient`s built that way are equivalent and
-/// `quotient.sccs()` is byte-identical to a fresh
-/// `build_module_quotient(...).sccs()`.
-pub fn check_realizability_with_quotient(
-    owner_graph: &OwnerGraph,
-    partition: &Partition,
-    quotient: &ModuleQuotient,
-) -> RealizabilityVerdict {
-    let mut verdict = RealizabilityVerdict {
-        scc_partition: quotient.sccs(),
-        ..RealizabilityVerdict::default()
-    };
+    let mut verdict = RealizabilityVerdict::default();
 
     // Cross-destination rebinds are a separate clause-2 violation and
     // not part of the I-graph. Collect them in a single pass over
@@ -233,6 +216,7 @@ pub fn check_realizability_with_quotient(
         verdict.unrealizable_sccs.push(SccDiagnosis {
             modules,
             constraining_owner_edges: owner_edges,
+            rejection: SccRejection::MutualConstrainingCycle,
         });
     }
 
@@ -300,6 +284,7 @@ pub fn check_realizability_with_quotient(
             verdict.unrealizable_sccs.push(SccDiagnosis {
                 modules,
                 constraining_owner_edges: owner_edges,
+                rejection: SccRejection::EsmEvaluationTdz,
             });
         }
     }
@@ -1163,7 +1148,6 @@ impl IncrementalQuotient {
         let mut verdict = RealizabilityVerdict {
             unrealizable_sccs: Vec::new(),
             cross_rebinds: self.cross_rebinds.values().cloned().collect(),
-            ..RealizabilityVerdict::default()
         };
         let mut reported = BTreeSet::<BTreeSet<ModuleId>>::new();
 
@@ -1176,6 +1160,7 @@ impl IncrementalQuotient {
             verdict.unrealizable_sccs.push(SccDiagnosis {
                 modules,
                 constraining_owner_edges,
+                rejection: SccRejection::MutualConstrainingCycle,
             });
         }
 
@@ -1205,6 +1190,7 @@ impl IncrementalQuotient {
                 verdict.unrealizable_sccs.push(SccDiagnosis {
                     modules,
                     constraining_owner_edges,
+                    rejection: SccRejection::EsmEvaluationTdz,
                 });
             }
         }
@@ -1216,7 +1202,6 @@ impl IncrementalQuotient {
         let mut verdict = RealizabilityVerdict {
             unrealizable_sccs: Vec::new(),
             cross_rebinds: self.cross_rebinds_touching(module),
-            ..RealizabilityVerdict::default()
         };
         let mut reported = BTreeSet::<BTreeSet<ModuleId>>::new();
         let mut i_scc_had_constraining_pair = false;
@@ -1233,6 +1218,7 @@ impl IncrementalQuotient {
             verdict.unrealizable_sccs.push(SccDiagnosis {
                 modules: constraining_modules,
                 constraining_owner_edges,
+                rejection: SccRejection::MutualConstrainingCycle,
             });
         }
 
@@ -1256,6 +1242,7 @@ impl IncrementalQuotient {
                     verdict.unrealizable_sccs.push(SccDiagnosis {
                         modules: i_modules,
                         constraining_owner_edges,
+                        rejection: SccRejection::EsmEvaluationTdz,
                     });
                 }
             }
@@ -1279,7 +1266,6 @@ impl IncrementalQuotient {
         let mut verdict = RealizabilityVerdict {
             unrealizable_sccs: Vec::new(),
             cross_rebinds: self.cross_rebinds_touching_with_overlay(module, overlay),
-            ..RealizabilityVerdict::default()
         };
         let mut reported = BTreeSet::<BTreeSet<ModuleId>>::new();
         let mut i_scc_had_constraining_pair = false;
@@ -1301,6 +1287,7 @@ impl IncrementalQuotient {
             verdict.unrealizable_sccs.push(SccDiagnosis {
                 modules: constraining_modules,
                 constraining_owner_edges,
+                rejection: SccRejection::MutualConstrainingCycle,
             });
         }
 
@@ -1335,6 +1322,7 @@ impl IncrementalQuotient {
                     verdict.unrealizable_sccs.push(SccDiagnosis {
                         modules: i_modules,
                         constraining_owner_edges,
+                        rejection: SccRejection::EsmEvaluationTdz,
                     });
                 }
             }
@@ -1719,10 +1707,13 @@ impl RealizabilityIndex {
     }
 
     /// Roll back the delta identified by `handle`. Must be the top of
-    /// the journal; debug builds panic otherwise. `pub` for the same
-    /// peel-internal reasons as [`Self::push`] — prefer [`Self::scoped`].
+    /// the journal; panics otherwise — also in release builds, since
+    /// the index backs committed planner state and an out-of-LIFO
+    /// undo silently corrupts the maintained quotient. `pub` for the
+    /// same peel-internal reasons as [`Self::push`] — prefer
+    /// [`Self::scoped`].
     pub fn undo(&mut self, owner_graph: &OwnerGraph, handle: DeltaHandle) {
-        debug_assert_eq!(
+        assert_eq!(
             handle.0 + 1,
             self.journal.len(),
             "RealizabilityIndex::undo called out of LIFO order \
@@ -2377,39 +2368,6 @@ mod tests {
             .expect("parse module");
         let facts = analyze_chunk(&module, &AnalysisHints::default(), None, |_| None).facts;
         build_owner_graph(&facts)
-    }
-
-    /// `check_realizability` is a thin wrapper around
-    /// `check_realizability_with_quotient` that builds the quotient
-    /// fresh. Both forms must produce byte-identical verdicts (incl.
-    /// `scc_partition`, `unrealizable_sccs`, `cross_rebinds`) on the
-    /// same `(owner_graph, partition, build_module_quotient(...))`
-    /// triple. This pins the wrapper-equivalence used by
-    /// `ChunkFactorization::build_with` to share its already-built
-    /// `dep_graph` instead of building a second quotient inside
-    /// validation.
-    #[test]
-    fn check_realizability_with_quotient_matches_pure_form() {
-        // A constraining cross-module cycle so every verdict field
-        // (incl. `unrealizable_sccs` and `scc_partition`) is populated
-        // — exercises more than just the empty-verdict happy path.
-        let source = "const a = b + 1; const b = a + 1;";
-        let owner_graph = parse_and_build(source);
-        let mut partition = Partition::new(&owner_graph, module_id(0));
-        partition.set(OwnerId(1), module_id(1));
-
-        let pure_form = check_realizability(&owner_graph, &partition);
-        let quotient = build_module_quotient(&owner_graph, &partition);
-        let threaded = check_realizability_with_quotient(&owner_graph, &partition, &quotient);
-
-        assert_eq!(
-            pure_form, threaded,
-            "wrapper-vs-threaded forms must yield byte-identical verdicts",
-        );
-        assert!(
-            !pure_form.is_realizable(),
-            "fixture should produce a non-empty verdict to exercise all fields",
-        );
     }
 
     /// Two top-level constants in different modules, with one reading
@@ -3115,7 +3073,6 @@ mod tests {
                 .filter(|rebind| rebind.from == module || rebind.to == module)
                 .cloned()
                 .collect(),
-            ..RealizabilityVerdict::default()
         }
     }
 

--- a/devinfra/js/debundle/validation.rs
+++ b/devinfra/js/debundle/validation.rs
@@ -1,16 +1,16 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
-use petgraph::algo::{condensation, greedy_feedback_arc_set};
+use petgraph::algo::greedy_feedback_arc_set;
 use petgraph::graph::DiGraph;
 use serde::{Deserialize, Serialize};
 
 use crate::factor_assembly::AtomicUnitConflict;
-use crate::graph::build_module_quotient;
+use crate::graph::{EndpointView, OwnerEdgeId, partition_endpoints};
 use crate::partition::Partition;
-use crate::realizability::{RealizabilityVerdict, check_realizability_with_quotient};
+use crate::realizability::{RealizabilityVerdict, SccRejection, check_realizability};
 use swc_atoms::Atom;
 
-use crate::{DepKind, ModuleId, ModuleQuotient, OwnerGraph, StatementOrdinal};
+use crate::{DepKind, ModuleId, OwnerGraph, StatementOrdinal};
 
 /// Result of validating a module dep graph.
 #[derive(Debug, Clone, Serialize)]
@@ -27,52 +27,59 @@ pub struct FactorizationReport {
     /// see the linker's evaluation order without re-running
     /// materialization. See docs/design.md "Lemma 2".
     pub linker_order: Vec<String>,
+    /// Clause-2 violations (cross-destination rebinding writes) from
+    /// the realizability verdict, rendered for diagnostics. A
+    /// rebinding write and the binding it reassigns belong to one
+    /// atomic factor unit, so a spec splitting them surfaces as an
+    /// `atomic_unit_conflicts` entry first — on the accept path
+    /// (`cycles` and `atomic_unit_conflicts` both empty) this list
+    /// must be empty too, and the materializer bails if that
+    /// invariant ever breaks (`validate_and_emit_reports`).
+    pub cross_rebinds: Vec<String>,
 }
 
 /// Validator's rendered projection of one unrealizable SCC. The
 /// in-memory primitive is [`crate::realizability::SccDiagnosis`]
-/// (typed `ModuleId`s + `OwnerEdgeId` evidence); this shape adds
-/// stringified module names plus the `evidence` and FAS `cut`
-/// decorations the bail-message renderer consumes.
+/// (typed `ModuleId`s + `OwnerEdgeId` evidence); this shape
+/// stringifies the module names and decorates the diagnosis with the
+/// `cut` / `lazy_closure` rows the bail-message renderer consumes.
 #[derive(Debug, Clone, Serialize)]
 pub struct CycleReport {
     pub modules: Vec<String>,
-    pub evidence: Vec<CycleEdge>,
-    /// Spec-author-actionable cut: a near-minimum set of
-    /// realizability-constraining (`at-init` or `side-effect`)
-    /// reasons whose removal would lift the cycle's realizability
-    /// violation. Computed by [`compute_realizability_cut`].
+    /// Spec-author-actionable cut: realizability-constraining
+    /// (`at-init` or `side-effect`) reasons whose removal (by
+    /// co-locating each binding pair into one module) lifts the
+    /// SCC's realizability violation. Derived from the verdict's
+    /// owner-edge provenance per [`SccRejection`] kind:
+    ///
+    /// - [`SccRejection::MutualConstrainingCycle`]: a near-minimum
+    ///   feedback arc set over the SCC's constraining edges,
+    ///   computed by [`compute_realizability_cut`].
+    /// - [`SccRejection::EsmEvaluationTdz`]: exactly the
+    ///   constraining edges whose simulated ESM post-order check
+    ///   failed — the at-init reads that TDZ at runtime.
     ///
     /// The cut never includes `lazy` reasons — lazy edges don't
     /// constrain ESM evaluation order, so removing one cannot help
-    /// fix a cycle. Each entry corresponds to (and shares its
-    /// shape with) a row in `evidence`.
-    ///
-    /// The algorithm builds a `DiGraph` containing only the
-    /// constraining (`R`/`S`) cross-module edges induced by `scc`,
-    /// then runs `petgraph::algo::condensation` once to find the
-    /// constraining-subgraph SCCs. Each non-trivial SCC is fed to
-    /// `petgraph::algo::greedy_feedback_arc_set` (Eades-Lin-Smyth,
-    /// 1993, `O(V + E)`); the returned FAS edges name the cut
-    /// (one cut entry per constraining reason on each picked edge).
-    /// Sound (removing every FAS edge breaks every cycle in the
-    /// constraining subgraph) and heuristic-minimum (petgraph's
-    /// FAS approximates within a constant factor on dense
-    /// instances).
+    /// fix a cycle. Non-empty for every blocking SCC.
     pub cut: Vec<CycleEdge>,
+    /// Populated only for [`SccRejection::EsmEvaluationTdz`]
+    /// rejections: the lazy cross-module read edges between SCC
+    /// members. For this rejection class the constraining subgraph
+    /// alone is acyclic — these are the back-edges that close the
+    /// I-cycle the ESM evaluation simulator walked, listed so the
+    /// bail summary can show how the cycle forms even though no
+    /// lazy edge is ever part of the cut.
+    pub lazy_closure: Vec<CycleEdge>,
 }
 
 /// Trimmed wire shape for `cycles.json` (one entry per blocking SCC).
 ///
-/// The materializer's in-memory `CycleReport` also carries an
-/// `evidence` field — the full list of constraining cross-module
-/// edges inside the SCC, keyed by ordinal — but that list is
-/// recomputable from `owner_graph.json` + this entry's `modules`
-/// set, so it's stripped before serializing to keep the on-disk
-/// shape small (a 1335-module SCC's evidence is multi-MB; the
-/// trimmed entry is ~100 KB).
-///
-/// Consumers that need the per-edge evidence re-derive it via
+/// The full list of constraining cross-module edges inside the SCC
+/// is recomputable from `owner_graph.json` + this entry's `modules`
+/// set, so the wire entry carries only the modules and the cut (a
+/// 1335-module SCC's full evidence is multi-MB; the trimmed entry is
+/// ~100 KB). Consumers that need per-edge evidence re-derive it via
 /// `debundle gate describe <id>` (see `devinfra/js/debundle/docs/cli.md`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BlockingSccEntry {
@@ -82,10 +89,10 @@ pub struct BlockingSccEntry {
     pub id: usize,
     /// Every module in the unrealizable SCC.
     pub modules: Vec<String>,
-    /// Near-minimum feedback-arc-set over the SCC's constraining
-    /// (`at-init` / `side-effect`) edges. The actionable subset for
-    /// spec authors: removing any of these edges (by co-locating
-    /// the binding pair into one module) would break the SCC.
+    /// The actionable subset for spec authors: removing any of these
+    /// edges (by co-locating the binding pair into one module) works
+    /// toward breaking the SCC. See [`CycleReport::cut`] for the
+    /// per-rejection-kind derivation.
     pub cut: Vec<CycleEdge>,
 }
 
@@ -144,7 +151,7 @@ pub struct CycleEdge {
 /// **binding pairs**, not just module pairs, so spec authors can act
 /// directly: "move `X` (mod_A) and `Y` (mod_B) into one module."
 ///
-/// Full per-cycle evidence + cut still goes to
+/// Full per-cycle cut still goes to
 /// `reports/tree/<chunk_id>/cycles.json`. This summary keeps the
 /// inline bail message terse: one header line per SCC plus the top-K
 /// binding-pair blame rows.
@@ -155,6 +162,10 @@ pub struct CycleEdge {
 /// bindings render as `<anon stmt #ord>` so every row has a stable
 /// human-readable label even when the source statement declares no
 /// binding (top-level `console.log`, side-effecting expressions).
+///
+/// For ESM-evaluation-simulator (Pass-2 / TDZ) rejections, the cut
+/// rows are followed by the lazy back-edges that close the I-cycle
+/// (`CycleReport::lazy_closure`), in the same binding-pair format.
 ///
 /// The text retains the words "unrealizable" and "cycle" so existing
 /// rejection-keyword tests (`expect_rejection` in the e2e harness)
@@ -185,11 +196,14 @@ pub fn render_cycle_summary(cycles: &[CycleReport]) -> String {
         let mut ranked: Vec<(BindingPairKey<'_>, BindingPairAgg)> = groups.into_iter().collect();
         ranked.sort_by(|a, b| b.1.count.cmp(&a.1.count).then(a.0.cmp(&b.0)));
 
-        if ranked.is_empty() {
-            // Defensive — the SCC is rejected because at least one
-            // R/S edge exists, so the cut should be non-empty.
-            continue;
-        }
+        // Every blocking SCC carries a non-empty cut by construction:
+        // Pass-1 runs FAS over a strongly connected constraining
+        // subgraph; Pass-2 reports only SCCs with a non-empty
+        // simulator-violated TDZ set.
+        debug_assert!(
+            !ranked.is_empty(),
+            "blocking SCC #{i} rendered with an empty cut: {cycle:?}",
+        );
 
         out.push_str(
             "  Binding pairs forcing the cycle (count: source binding (module) → kind → target binding (module)):\n",
@@ -211,6 +225,36 @@ pub fn render_cycle_summary(cycles: &[CycleReport]) -> String {
                 ranked.len() - TOP_K,
             ));
         }
+
+        if !cycle.lazy_closure.is_empty() {
+            out.push_str(
+                "  Constraining subgraph alone is acyclic; the I-cycle closes through lazy read(s) below, and the ESM evaluation simulator proved the at-init pair(s) above evaluate under TDZ (docs/design.md \"Lemma 2\"):\n",
+            );
+            let mut lazy_groups: HashMap<BindingPairKey<'_>, usize> = HashMap::new();
+            for edge in &cycle.lazy_closure {
+                *lazy_groups.entry(BindingPairKey::of(edge)).or_insert(0) += 1;
+            }
+            let mut lazy_ranked: Vec<(BindingPairKey<'_>, usize)> =
+                lazy_groups.into_iter().collect();
+            lazy_ranked.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+            for (key, count) in lazy_ranked.iter().take(TOP_K) {
+                out.push_str(&format!(
+                    "    {n:>4}x  {from_b} ({from_m})  --lazy-->  {to_b} ({to_m})\n",
+                    n = count,
+                    from_b = key.from_label,
+                    from_m = key.from,
+                    to_b = key.to_label,
+                    to_m = key.to,
+                ));
+            }
+            if lazy_ranked.len() > TOP_K {
+                out.push_str(&format!(
+                    "    … +{} more lazy binding pair(s)\n",
+                    lazy_ranked.len() - TOP_K,
+                ));
+            }
+        }
+
         out.push_str(
             "  Fix: co-locate each (source, target) binding pair above into one logical module, or break the SCC's back-edges in the spec.\n",
         );
@@ -270,54 +314,30 @@ fn cut_pairs_count(cut: &[CycleEdge]) -> usize {
     seen.len()
 }
 
-/// Find SCCs in the dep graph and produce a report listing every
-/// non-trivial cycle (size > 1 OR a self-loop). Trivial single-node
-/// non-self-loop SCCs are dropped.
+/// Project the realizability verdict onto the validator's rendered
+/// report: one [`CycleReport`] per [`crate::realizability::SccDiagnosis`].
 ///
-/// [`crate::realizability::check_realizability`] gates this whole function
-/// (early return when its verdict is empty). The historical asymmetry between
-/// a "strict" validator and a "relaxed" primitive is gone: the primitive's
-/// tightened clause-3 rule rejects both the symmetric-constraining-cycle case
-/// (any multi-module SCC in the constraining subgraph) and the
-/// residual-in-cycle case (any multi-module SCC in `I` containing
-/// residual with a constraining edge whose target is residual), and
-/// `lower_chunk` realizes Lemma 2's source-import-order steering for
-/// every spec that makes it past the gate. See docs/design.md "Lemma 2:
-/// entry-side import ordering" for the order-steering algorithm and
-/// the residual-in-cycle carve-out.
-///
-/// The cycle reports this function emits are advisory evidence for
-/// spec authors — when the primitive rejects, this function walks
-/// the quotient and prints which modules + edges are involved so
-/// the author can pick a colocation or move that breaks the cycle.
+/// The verdict is the single source of truth for *which* SCCs block
+/// materialization (docs/design.md "Realizability primitive" —
+/// "Invariant: no bespoke parallel walks"); this function only
+/// decorates each diagnosis's owner-edge provenance into the
+/// stringified, binding-pair-labelled rows spec authors read. In
+/// particular, an asymmetric I-cycle that Lemma 2's source-import
+/// reversal rescues never appears here, even when another SCC in the
+/// same chunk is genuinely unrealizable.
 pub fn validate_factorization(
     owner_graph: &OwnerGraph,
     partition: &Partition,
     module_name: &dyn Fn(ModuleId) -> String,
 ) -> FactorizationReport {
-    let quotient = build_module_quotient(owner_graph, partition);
-    validate_factorization_with_quotient(owner_graph, partition, &quotient, module_name)
-}
-
-/// Same as [`validate_factorization`] but takes a pre-built
-/// `ModuleQuotient` so callers that already constructed one (notably
-/// `ChunkFactorization::build_with`, which caches it as
-/// `self.dep_graph`) don't pay for a second
-/// `build_module_quotient` + `tarjan_scc` pass on the way through
-/// the realizability check.
-pub fn validate_factorization_with_quotient(
-    owner_graph: &OwnerGraph,
-    partition: &Partition,
-    quotient: &ModuleQuotient,
-    module_name: &dyn Fn(ModuleId) -> String,
-) -> FactorizationReport {
-    let verdict: RealizabilityVerdict =
-        check_realizability_with_quotient(owner_graph, partition, quotient);
+    let verdict = check_realizability(owner_graph, partition);
+    let cross_rebinds = render_cross_rebinds(owner_graph, &verdict, module_name);
     if verdict.unrealizable_sccs.is_empty() {
         return FactorizationReport {
             cycles: Vec::new(),
             atomic_unit_conflicts: Vec::new(),
             linker_order: Vec::new(),
+            cross_rebinds,
         };
     }
     // statement_ordinal → first declared binding of the owner that
@@ -335,59 +355,162 @@ pub fn validate_factorization_with_quotient(
                 .map(|id| (node.statement_ordinal, id.0.clone()))
         })
         .collect();
-    let graph = quotient;
-    let mut cycles = Vec::new();
-    for scc in verdict.scc_partition() {
-        let in_scc: HashSet<ModuleId> = scc.iter().copied().collect();
-        let is_cycle = scc.len() > 1 || (scc.len() == 1 && graph.contains_edge(scc[0], scc[0]));
-        if !is_cycle {
-            continue;
-        }
-        // Realizability filter (per docs/design.md "The realizability
-        // theorem"): an `I ∪ S` SCC is unrealizable iff at least
-        // one cross-module edge between its members carries a
-        // realizability-constraining reason — an at-init read
-        // (`R`) or a side-effect ordering edge (`S`). Lazy reads
-        // alone don't constrain it: the ESM linker evaluates the
-        // SCC in *some* order, and the lazy reads only fire
-        // afterwards (no TDZ, no missed side-effect ordering).
-        let scc_constrains_evaluation_order = scc.iter().any(|&from| {
-            scc.iter()
-                .any(|&to| from != to && graph.has_init_order_constraining_edge(from, to))
-        });
-        if !scc_constrains_evaluation_order {
-            continue;
-        }
-        let mut evidence = Vec::new();
-        for (from, to, weight) in graph.all_edges() {
-            if !in_scc.contains(&from) || !in_scc.contains(&to) {
-                continue;
+    let cycles = verdict
+        .unrealizable_sccs
+        .iter()
+        .map(|diagnosis| {
+            let (cut, lazy_closure) = match diagnosis.rejection {
+                SccRejection::MutualConstrainingCycle => (
+                    compute_realizability_cut(
+                        owner_graph,
+                        partition,
+                        &diagnosis.constraining_owner_edges,
+                        module_name,
+                        &from_binding_by_ordinal,
+                    ),
+                    Vec::new(),
+                ),
+                // The diagnosis's owner edges ARE the cut: the
+                // simulator surfaced exactly the constraining
+                // `(from, to)` pairs whose post-order check failed.
+                SccRejection::EsmEvaluationTdz => (
+                    cycle_edges_for(
+                        owner_graph,
+                        partition,
+                        diagnosis.constraining_owner_edges.iter().copied(),
+                        module_name,
+                        &from_binding_by_ordinal,
+                    ),
+                    lazy_closure_edges(
+                        owner_graph,
+                        partition,
+                        &diagnosis.modules,
+                        module_name,
+                        &from_binding_by_ordinal,
+                    ),
+                ),
+            };
+            CycleReport {
+                modules: diagnosis.modules.iter().copied().map(module_name).collect(),
+                cut,
+                lazy_closure,
             }
-            for reason in &weight.reasons {
-                evidence.push(CycleEdge {
-                    from: module_name(from),
-                    to: module_name(to),
-                    statement_ordinal: reason.statement_ordinal,
-                    binding: reason.binding.as_ref().map(|id| id.0.clone()),
-                    from_binding: from_binding_by_ordinal
-                        .get(&reason.statement_ordinal)
-                        .cloned(),
-                    kind: reason.kind,
-                });
-            }
-        }
-        let cut = compute_realizability_cut(graph, scc, module_name, &from_binding_by_ordinal);
-        cycles.push(CycleReport {
-            modules: scc.iter().copied().map(module_name).collect(),
-            evidence,
-            cut,
-        });
-    }
+        })
+        .collect();
     FactorizationReport {
         cycles,
         atomic_unit_conflicts: Vec::new(),
         linker_order: Vec::new(),
+        cross_rebinds,
     }
+}
+
+/// Render the verdict's clause-2 cross-rebind diagnoses as
+/// human-readable lines for [`FactorizationReport::cross_rebinds`].
+fn render_cross_rebinds(
+    owner_graph: &OwnerGraph,
+    verdict: &RealizabilityVerdict,
+    module_name: &dyn Fn(ModuleId) -> String,
+) -> Vec<String> {
+    verdict
+        .cross_rebinds
+        .iter()
+        .map(|rebind| {
+            let edge = owner_graph.edge(rebind.owner_edge);
+            let binding = match &edge.reason.binding {
+                Some(id) => id.0.to_string(),
+                None => format!("<anon stmt #{}>", edge.reason.statement_ordinal.0),
+            };
+            format!(
+                "{} --{}--> {} (binding `{}`)",
+                module_name(rebind.from),
+                dep_kind_short(edge.reason.kind),
+                module_name(rebind.to),
+                binding,
+            )
+        })
+        .collect()
+}
+
+/// Project verdict owner-edge provenance onto rendered [`CycleEdge`]
+/// rows, sorted deterministically
+/// `(from, to, statement_ordinal, binding, kind)` so test snapshots
+/// compare cleanly. Endpoints use the gate view
+/// ([`EndpointView::Gate`]) — the same projection the realizability
+/// primitive used to produce the edges, so promoted at-init edges
+/// keep their cross-module endpoints.
+fn cycle_edges_for(
+    owner_graph: &OwnerGraph,
+    partition: &Partition,
+    edge_ids: impl IntoIterator<Item = OwnerEdgeId>,
+    module_name: &dyn Fn(ModuleId) -> String,
+    from_binding_by_ordinal: &HashMap<StatementOrdinal, Atom>,
+) -> Vec<CycleEdge> {
+    let mut out: Vec<CycleEdge> = edge_ids
+        .into_iter()
+        .map(|edge_id| {
+            let edge = owner_graph.edge(edge_id);
+            let (from, to) = partition_endpoints(edge, partition, EndpointView::Gate)
+                .expect("verdict owner-edge provenance is cross-module in the gate view");
+            CycleEdge {
+                from: module_name(from),
+                to: module_name(to),
+                statement_ordinal: edge.reason.statement_ordinal,
+                binding: edge.reason.binding.as_ref().map(|id| id.0.clone()),
+                from_binding: from_binding_by_ordinal
+                    .get(&edge.reason.statement_ordinal)
+                    .cloned(),
+                kind: edge.reason.kind,
+            }
+        })
+        .collect();
+    out.sort_by(|a, b| {
+        (
+            a.from.as_str(),
+            a.to.as_str(),
+            a.statement_ordinal,
+            &a.binding,
+            a.kind,
+        )
+            .cmp(&(
+                b.from.as_str(),
+                b.to.as_str(),
+                b.statement_ordinal,
+                &b.binding,
+                b.kind,
+            ))
+    });
+    out
+}
+
+/// Lazy cross-module read edges between members of `modules`, gate
+/// view. For a [`SccRejection::EsmEvaluationTdz`] rejection the
+/// constraining subgraph alone is acyclic — these are the back-edges
+/// closing the I-cycle the ESM evaluation simulator walked.
+fn lazy_closure_edges(
+    owner_graph: &OwnerGraph,
+    partition: &Partition,
+    modules: &BTreeSet<ModuleId>,
+    module_name: &dyn Fn(ModuleId) -> String,
+    from_binding_by_ordinal: &HashMap<StatementOrdinal, Atom>,
+) -> Vec<CycleEdge> {
+    let lazy_edge_ids = owner_graph.iter_edges().filter_map(|edge| {
+        if edge.reason.kind != DepKind::LazyUse
+            || owner_graph.node(edge.from).is_none()
+            || owner_graph.node(edge.to).is_none()
+        {
+            return None;
+        }
+        let (from, to) = partition_endpoints(edge, partition, EndpointView::Gate)?;
+        (modules.contains(&from) && modules.contains(&to)).then_some(edge.id)
+    });
+    cycle_edges_for(
+        owner_graph,
+        partition,
+        lazy_edge_ids,
+        module_name,
+        from_binding_by_ordinal,
+    )
 }
 
 /// Render a human-readable summary of atomic-unit conflicts for
@@ -450,130 +573,64 @@ pub fn render_atomic_unit_conflict_summary(
 }
 
 /// Compute a near-minimum cut of realizability-constraining edges
-/// inside `scc` whose removal makes the SCC realizable.
+/// whose removal makes a [`SccRejection::MutualConstrainingCycle`]
+/// SCC realizable.
 ///
-/// One-shot algorithm:
-/// 1. Build a `DiGraph<ModuleId, ()>` containing only the
-///    realizability-constraining (`R`/`S`) cross-module edges
-///    between members of `scc`. `LazyUse`-only edges are dropped
-///    up front — they don't constrain ESM evaluation order, so no
-///    cut entry can be a lazy edge by construction. This replaces
-///    the old loop's post-FAS "fallback scan for an R/S edge"
-///    hack: FAS now sees only edges that could legitimately be in
-///    the cut.
-/// 2. Run `petgraph::algo::condensation` once to partition the
-///    constraining subgraph into SCCs.
-/// 3. For each non-trivial condensation node (a real SCC of the
-///    constraining subgraph), induce its subgraph and run
-///    `petgraph::algo::greedy_feedback_arc_set` (Eades-Lin-Smyth,
-///    1993, `O(V + E)`). Every FAS edge contributes its R/S
-///    reasons to the cut.
+/// Input is the diagnosis's owner-edge provenance — every
+/// constraining cross-module owner edge inside the SCC, in the gate
+/// view. The algorithm groups the owner edges by their gate-view
+/// module pair, builds a `DiGraph` with one edge per pair (strongly
+/// connected by construction: the diagnosis's modules are one SCC of
+/// the constraining subgraph), and runs
+/// `petgraph::algo::greedy_feedback_arc_set` (Eades-Lin-Smyth, 1993,
+/// `O(V + E)`). Every FAS-picked pair contributes its owner edges to
+/// the cut.
 ///
-/// Soundness: removing every FAS edge makes the constraining
-/// subgraph of `scc` acyclic, so the surviving cross-module edges
-/// have a valid evaluation order — realizable per the docs/design.md
-/// realizability theorem. Cuts are sorted deterministically
-/// `(from, to, statement_ordinal, binding, kind)` so test
-/// snapshots compare cleanly.
+/// Soundness: removing every FAS pair makes the SCC's constraining
+/// subgraph acyclic, so the surviving cross-module edges have a
+/// valid evaluation order — realizable per the docs/design.md
+/// realizability theorem. Heuristic-minimum: petgraph's FAS
+/// approximates within a constant factor on dense instances.
 fn compute_realizability_cut(
-    graph: &ModuleQuotient,
-    scc: &[ModuleId],
+    owner_graph: &OwnerGraph,
+    partition: &Partition,
+    constraining_owner_edges: &[OwnerEdgeId],
     module_name: &dyn Fn(ModuleId) -> String,
     from_binding_by_ordinal: &HashMap<StatementOrdinal, Atom>,
 ) -> Vec<CycleEdge> {
-    if scc.len() < 2 {
-        return Vec::new();
-    }
-    // Constraining-only induced subgraph on `scc`, as a `DiGraph`
-    // (index-based node ids required by `greedy_feedback_arc_set`).
-    // Node weight carries the original `ModuleId`; edge weight
-    // carries the `(from, to)` pair so we can recover the
-    // underlying `EdgeMetadata` from `graph` after FAS.
-    let in_scc: HashSet<ModuleId> = scc.iter().copied().collect();
-    let mut constraining: DiGraph<ModuleId, (ModuleId, ModuleId)> = DiGraph::new();
-    let mut idx_of: HashMap<ModuleId, _> = HashMap::with_capacity(scc.len());
-    for &m in scc {
-        idx_of.insert(m, constraining.add_node(m));
-    }
-    for (from, to, weight) in graph.all_edges() {
-        if from == to || !in_scc.contains(&from) || !in_scc.contains(&to) {
-            continue;
-        }
-        if !weight.constrains_init_order() {
-            continue;
-        }
-        constraining.add_edge(idx_of[&from], idx_of[&to], (from, to));
+    let mut by_pair: BTreeMap<(ModuleId, ModuleId), Vec<OwnerEdgeId>> = BTreeMap::new();
+    for &edge_id in constraining_owner_edges {
+        let edge = owner_graph.edge(edge_id);
+        let (from, to) = partition_endpoints(edge, partition, EndpointView::Gate)
+            .expect("verdict owner-edge provenance is cross-module in the gate view");
+        by_pair.entry((from, to)).or_default().push(edge_id);
     }
 
-    // Condense once to the SCC DAG. `make_acyclic = true` drops
-    // self-loops and parallel edges between condensation nodes;
-    // we only need the membership lists (each condensation node's
-    // `Vec<ModuleId>` weight) to find non-trivial SCCs.
-    let condensed = condensation(constraining, true);
-
-    let mut cut: Vec<CycleEdge> = Vec::new();
-    for node in condensed.node_indices() {
-        let members: &Vec<ModuleId> = &condensed[node];
-        if members.len() < 2 {
-            continue;
-        }
-        let in_s: HashSet<ModuleId> = members.iter().copied().collect();
-
-        // Sub-SCC subgraph rebuilt from the original quotient,
-        // restricted to constraining edges between members.
-        let mut induced: DiGraph<ModuleId, (ModuleId, ModuleId)> = DiGraph::new();
-        let mut sub_idx_of: HashMap<ModuleId, _> = HashMap::with_capacity(members.len());
-        for &m in members {
-            sub_idx_of.insert(m, induced.add_node(m));
-        }
-        for (from, to, weight) in graph.all_edges() {
-            if from == to || !in_s.contains(&from) || !in_s.contains(&to) {
-                continue;
-            }
-            if !weight.constrains_init_order() {
-                continue;
-            }
-            induced.add_edge(sub_idx_of[&from], sub_idx_of[&to], (from, to));
-        }
-
-        for fas_edge in greedy_feedback_arc_set(&induced) {
-            let (u, v) = *fas_edge.weight();
-            let weight = graph
-                .edge_weight(u, v)
-                .expect("FAS edge endpoints came from the module quotient");
-            for reason in &weight.reasons {
-                if !reason.constrains_init_order() {
-                    continue;
-                }
-                cut.push(CycleEdge {
-                    from: module_name(u),
-                    to: module_name(v),
-                    statement_ordinal: reason.statement_ordinal,
-                    binding: reason.binding.as_ref().map(|id| id.0.clone()),
-                    from_binding: from_binding_by_ordinal
-                        .get(&reason.statement_ordinal)
-                        .cloned(),
-                    kind: reason.kind,
-                });
-            }
+    // Module-pair graph (index-based node ids required by
+    // `greedy_feedback_arc_set`). Edge weight carries the
+    // `(from, to)` pair so FAS picks map back to `by_pair`.
+    let mut pair_graph: DiGraph<ModuleId, (ModuleId, ModuleId)> = DiGraph::new();
+    let mut idx_of: HashMap<ModuleId, _> = HashMap::new();
+    for &(from, to) in by_pair.keys() {
+        for module in [from, to] {
+            idx_of
+                .entry(module)
+                .or_insert_with(|| pair_graph.add_node(module));
         }
     }
+    for &(from, to) in by_pair.keys() {
+        pair_graph.add_edge(idx_of[&from], idx_of[&to], (from, to));
+    }
 
-    cut.sort_by(|a, b| {
-        (
-            a.from.as_str(),
-            a.to.as_str(),
-            a.statement_ordinal,
-            &a.binding,
-            a.kind,
-        )
-            .cmp(&(
-                b.from.as_str(),
-                b.to.as_str(),
-                b.statement_ordinal,
-                &b.binding,
-                b.kind,
-            ))
-    });
-    cut
+    let mut cut_edge_ids: Vec<OwnerEdgeId> = Vec::new();
+    for fas_edge in greedy_feedback_arc_set(&pair_graph) {
+        cut_edge_ids.extend_from_slice(&by_pair[fas_edge.weight()]);
+    }
+    cycle_edges_for(
+        owner_graph,
+        partition,
+        cut_edge_ids,
+        module_name,
+        from_binding_by_ordinal,
+    )
 }


### PR DESCRIPTION
## What

Makes the materializer's validator consume the realizability gate's canonical verdict instead of re-deriving blockers with its own quotient walk, and makes Pass-2 (ESM-evaluation-simulator / TDZ) rejections diagnosable.

### Consume the canonical verdict

`validate_factorization` early-returned on an empty verdict but otherwise rebuilt `cycles` from `verdict.scc_partition()` — the **Lenient-view** quotient SCC partition (promoted edges dropped) filtered by a lenient `has_init_order_constraining_edge` check. That is exactly the "bespoke parallel walk" docs/design.md ("Realizability primitive") forbids: once any SCC was bad, every constraining-edge quotient SCC (including Lemma-2-rescued asymmetric I-cycles) was over-reported as a blocker, and view drift could in principle silently accept a gate-rejected spec.

Now:

- `SccDiagnosis` carries an `SccRejection` discriminator (`MutualConstrainingCycle` = Pass-1, `EsmEvaluationTdz` = Pass-2), set by the pure-function gate and all `RealizabilityIndex` verdict paths consistently.
- `CycleReport`s are derived one-per-diagnosis from `verdict.unrealizable_sccs`, using the diagnosis's gate-view owner-edge provenance.
- The dead `scc_partition` field and the now-pointless `check_realizability_with_quotient` / `validate_factorization_with_quotient` variants are removed — the parallel-walk surface no longer exists at the type level (`check_realizability` no longer needs a quotient at all).
- Dropped the write-only `CycleReport.evidence` decoration (multi-MB on large SCCs, computed at every rejection, zero readers — `debundle gate describe` recomputes evidence from `owner_graph.json`). `cycles.json` wire shape (`id`/`modules`/`cut`) unchanged.

### Useful Pass-2 diagnosis

`compute_realizability_cut` ran FAS over the constraining-only subgraph — acyclic **by definition** for Pass-2 rejections — so `cut: []`, the summary printed "0 R/S edge(s)", and the defensive `continue` omitted all binding-pair blame for the subtlest rejection class.

- Pass-2 cuts are now the diagnosis's surgical owner-edge set: exactly the constraining `(from, to)` pairs whose simulated post-order check failed. The `cut` doc ("whose removal would lift the violation") is now true.
- The bail summary additionally renders the lazy back-edges that close the I-cycle (`CycleReport::lazy_closure`) in the same binding-pair blame format.
- Pass-1 cuts now run FAS over the verdict's gate-view provenance rather than the Lenient quotient (which is blind to cross-module promoted at-init edges, previously yielding an empty cut for promotion-closed cycles).

### Defense-in-depth

- Materializer accept path bails when the verdict carries cross-destination rebinds but no atomic-unit conflict / blocking SCC was reported (should be unreachable: rebinding writes co-locate with their target via atomic factor units).
- `RealizabilityIndex::undo` enforces LIFO order with a release-mode `assert_eq!` (was `debug_assert_eq!`) — the index backs committed planner state.

### Tests (failing-first against the old validator)

- `e2e/gate_rejection_scopes_to_bad_scc_test`: a rescued asymmetric SCC coexisting with a real Pass-2 blocker (mediator shape) is no longer reported as a second blocker; `cycles.json` has exactly the one real entry. Note: the real blocker must itself be Pass-2 — a Pass-1 mutual cycle anywhere empties the chunk-wide constraining linker order, so the gate (correctly, mirroring emit) rejects otherwise-rescued shapes too; the test module doc records this.
- `e2e/pass_two_tdz_cut_diagnosis_test`: a Lemma-2-shaped mediator rejection's summary names the TDZ binding pair (`cross_value` → `dep_value`), names the lazy read closing the I-cycle, and `cycles.json` carries a non-empty `cut` with the violated at-init read.

Skipped the optional `gate_perf_counters` module split — it references `RealizabilityIndex` internals and would have bloated the diff beyond a clean pure move.

## Testing

`bbr test //devinfra/js/debundle/...` — 84/84 green (BuildBuddy invocation `53229dc2-0911-4df1-b0cc-83474a0d593b`). Repo-wide `bbr test //...` green except pre-existing `.live` API-credential tests excluded from CI.

https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk)_