### PR TITLE
aiquota: detect over-plan when 5h window is exhausted

### DIFF
--- a/aiquota/render/test_view_model.py
+++ b/aiquota/render/test_view_model.py
@@ -48,6 +48,16 @@ def test_prepaid_exhausted_with_feature_on_is_over_plan() -> None:
     assert currently_over_plan(fetch)
 
 
+def test_short_window_exhausted_with_feature_on_is_over_plan() -> None:
+    # 5h window exhausted (burning extra) but 7d window still has headroom.
+    fetch = _fetch(
+        short_window=QuotaWindow(used_percent=105, reset_seconds=1200, window_seconds=18000),
+        long_window=QuotaWindow(used_percent=96, reset_seconds=86400, window_seconds=604800),
+        extra_usage=ExtraUsage(is_enabled=True, monthly_limit_usd=4600, used_usd=3120, utilization=67),
+    )
+    assert currently_over_plan(fetch)
+
+
 def test_extra_status_transitions() -> None:
     quotas = AllQuotas(
         providers=[

--- a/aiquota/render/view_model.py
+++ b/aiquota/render/view_model.py
@@ -56,15 +56,18 @@ def currently_over_plan(out: ProviderFetch) -> bool:
 
     `extra_usage.is_enabled` only signals "feature enabled on the account",
     and `extra_usage.used_usd` is a cumulative monthly tally — neither says
-    anything about "right now". The real signal is the 7d window being
-    exhausted (every further call now hits the monthly bill).
+    anything about "right now". The real signal is *any* rate-limit window
+    being exhausted (every further call now hits the monthly bill).
     """
     if not isinstance(out.result, FetchSuccess):
         return False
     extra = out.result.extra_usage
-    long = out.result.long_window
     if extra is None or not extra.is_enabled:
         return False
+    short = out.result.short_window
+    long = out.result.long_window
+    if short is not None and short.used_percent >= _OVER_PLAN_PERCENT:
+        return True
     return long is not None and long.used_percent >= _OVER_PLAN_PERCENT
 
 


### PR DESCRIPTION
## Bug

The GNOME extension showed the normal pace deviation (e.g. `claude -4%`) even when the user was actively burning extra usage through the 5-hour quota being exhausted. It should have shown the dollar amount with ⚡.

## Root cause

`currently_over_plan()` in `aiquota/render/view_model.py` only checked the **7-day** window (`long_window.used_percent >= 100%`). When the 5-hour window was exhausted but the 7-day window still had headroom, the function returned `False`, so the extension rendered the normal pace text instead of the dollar figure.

## Fix

Check **both** windows: if *either* the short (5h) or long (7d) window is ≥100% and extra usage is enabled, the user is over plan and the extension shows `$X ⚡`.

## Test plan

- [x] New test `test_short_window_exhausted_with_feature_on_is_over_plan` covers the exact scenario (5h @ 105%, 7d @ 96%, extra enabled)
- [x] All existing tests pass (6/6)