### PR TITLE
cluster: put Flux sparse checkout in sync base

### DIFF
--- a/cluster/k8s/flux-system/gotk-sync.yaml
+++ b/cluster/k8s/flux-system/gotk-sync.yaml
@@ -12,6 +12,9 @@ spec:
     branch: devel
   secretRef:
     name: ducktape-automation-github-app
+  sparseCheckout:
+    - cluster/k8s/
+    - tf/gitops/
   url: https://github.com/agentydragon/ducktape.git
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1

--- a/cluster/k8s/flux-system/kustomization.yaml
+++ b/cluster/k8s/flux-system/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - gotk-components.yaml
+  # Keep root GitRepository fields that must survive raw Terraform bootstrap
+  # applies, such as auth and sparseCheckout, in gotk-sync.yaml.
   - gotk-sync.yaml
   - ducktape-automation-github-app.sops.yaml
 patches:
@@ -12,31 +14,6 @@ patches:
       - op: add
         path: /metadata/labels/goldilocks.fairwinds.com~1enabled
         value: "false"
-  - target:
-      kind: GitRepository
-      name: flux-system
-    patch: |
-      # Bootstrap is deliberately two-stage:
-      # 1. cluster/terraform/main applies gotk-sync.yaml with anonymous HTTPS,
-      #    because ducktape is public and the GitHub App Secret is itself SOPS
-      #    encrypted in this repository.
-      # 2. Once the root Kustomization can fetch the repo, it decrypts
-      #    ducktape-automation-github-app.sops.yaml and this patch switches the
-      #    root GitRepository to GitHub App auth. ImageUpdateAutomation/all-images
-      #    uses this GitRepository for writes, and Flux has no separate push
-      #    credential field for the automation object.
-      - op: add
-        path: /spec/provider
-        value: github
-      - op: add
-        path: /spec/secretRef
-        value:
-          name: ducktape-automation-github-app
-      - op: add
-        path: /spec/sparseCheckout
-        value:
-          - cluster/k8s/
-          - tf/gitops/
   # Reconcile with moderate fan-out. With 244 Kustomizations and dependsOn
   # chains up to 9 deep, the upstream defaults serialise propagation:
   #   --concurrent=4          — at most 4 Kustomizations in flight at a time


### PR DESCRIPTION
## Summary

- move the root `GitRepository` `sparseCheckout` into `gotk-sync.yaml`, which is the manifest Terraform applies raw during bootstrap
- remove the now-redundant root `GitRepository` Kustomize patch
- add a short comment that root GitRepository fields needed during raw bootstrap belong in the sync base manifest

## Validation

- `kubectl kustomize cluster/k8s/flux-system` renders `provider: github`, `secretRef: ducktape-automation-github-app`, and `sparseCheckout` on `GitRepository/flux-system`
- `kubectl diff -f cluster/k8s/flux-system/gotk-sync.yaml` is empty against the live cluster
- `bbr build //cluster/validation:validate_all`

## Note

This aligns the raw `gotk-sync.yaml` apply path with the live Flux-rendered root GitRepository. It does not solve the separate `gotk-components.yaml` raw-apply issue for the kustomize-controller args.