### PR TITLE
debundle: unify module identity across wire formats; fix gate describe evidence join

### DIFF
--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -78,6 +78,7 @@ rust_library(
         ":analysis",
         ":js_ast",
         ":output_layout",
+        ":spec",
         "@crates//:anyhow",
         "@crates//:rayon",
         "@crates//:relative-path",

--- a/devinfra/js/debundle/artifact.rs
+++ b/devinfra/js/debundle/artifact.rs
@@ -267,8 +267,22 @@ pub struct RootLogicalModulesSummary {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ChunkLogicalModulesSummary {
-    pub module_ids: Vec<String>,
+    /// Canonical [`spec::ModulePath`] per materialized module (the
+    /// chunk is implicit — this summary is per-chunk).
+    pub module_paths: Vec<spec::ModulePath>,
     pub target_dir: String,
+}
+
+/// Chunk-qualified canonical module reference for tree-level
+/// (cross-chunk) reports. Per-chunk reports denote a module by bare
+/// [`spec::ModulePath`] (their chunk is implicit); tree-wide reports
+/// qualify the same canonical path with its chunk id. There is no
+/// third spelling — the in-process `"<chunk_id>::<path>"` id never
+/// hits the wire.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+pub struct ModuleRef {
+    pub chunk_id: String,
+    pub path: spec::ModulePath,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -277,11 +291,21 @@ pub struct SelectedModuleLowering {
     pub chunk_id: String,
     pub exported_names: Vec<String>,
     pub file: String,
-    pub id: String,
     pub owner_ids: Vec<String>,
     pub residual: bool,
     pub target_file: String,
     pub target_path: String,
+}
+
+impl SelectedModuleLowering {
+    /// The module this lowering materialized, as a [`ModuleRef`].
+    pub fn module_ref(&self) -> ModuleRef {
+        ModuleRef {
+            chunk_id: self.chunk_id.clone(),
+            path: spec::ModulePath::parse(&self.target_path, "")
+                .expect("lowering target_path is a canonical module path"),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -315,7 +339,8 @@ pub struct ChunkDecompositionOutput {
 #[derive(Debug, Clone, Serialize)]
 pub struct ChunkValidationSummary {
     pub status: &'static str,
-    pub linker_order: Vec<String>,
+    /// Linker evaluation order, by canonical [`spec::ModulePath`].
+    pub linker_order: Vec<spec::ModulePath>,
 }
 
 /// One semantic owner-edge fact projected onto emitted module files.
@@ -422,10 +447,10 @@ pub struct OutputFileMetric {
     pub role: OutputRole,
     pub bytes: usize,
     pub lines: usize,
+    /// The materialized module emitted to this file, when the file is
+    /// a module (entry/runtime/other files carry `None`).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub module_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub module_path: Option<String>,
+    pub module: Option<ModuleRef>,
 }
 
 impl OutputMetrics {
@@ -467,7 +492,9 @@ pub struct DirectoryManifestIndex {
     pub directories: Vec<String>,
     pub files: Vec<String>,
     pub chunks: Vec<String>,
-    pub modules: Vec<String>,
+    /// Modules whose emitted file lives under this directory, as
+    /// chunk-qualified [`ModuleRef`]s.
+    pub modules: Vec<ModuleRef>,
     pub defined_symbols: BTreeMap<String, usize>,
     pub loc: usize,
     pub incoming: DirectoryBoundarySummary,
@@ -491,10 +518,10 @@ pub struct FileDependencyManifest {
     pub lines: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub chunk_id: Option<String>,
+    /// The materialized module emitted to this file, when the file is
+    /// a module, as a chunk-qualified [`ModuleRef`].
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub module_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub module_path: Option<String>,
+    pub module: Option<ModuleRef>,
     pub incoming: FileBoundarySummary,
     pub outgoing: FileBoundarySummary,
 }
@@ -528,7 +555,7 @@ pub struct DirectoryDependencyEdgeManifest {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ModuleDecompositionMetrics {
-    pub module_id: String,
+    pub module: ModuleRef,
     pub loc: usize,
     pub exported_symbol_count: usize,
     pub is_residual: bool,
@@ -552,15 +579,16 @@ impl DecompositionMetrics {
         let mut total_defined = 0usize;
 
         for lowering in lowerings {
+            let module_ref = lowering.module_ref();
             let loc: usize = file_metrics
                 .iter()
-                .filter(|f| f.module_id.as_deref() == Some(&lowering.id))
+                .filter(|f| f.module.as_ref() == Some(&module_ref))
                 .map(|f| f.lines)
                 .sum();
             total_exported += lowering.exported_names.len();
             total_defined += lowering.binding_names.len();
             per_module.push(ModuleDecompositionMetrics {
-                module_id: lowering.id.clone(),
+                module: module_ref,
                 loc,
                 exported_symbol_count: lowering.exported_names.len(),
                 is_residual: lowering.residual,
@@ -1248,9 +1276,9 @@ fn build_directory_dependency_manifests(
     decomposition_by_chunk: &HashMap<ChunkId, ChunkDecompositionOutput>,
     file_metrics: &[OutputFileMetric],
 ) -> Vec<DirectoryManifestIndex> {
-    let loc_by_module_id: BTreeMap<&str, usize> = file_metrics
+    let loc_by_module: BTreeMap<&ModuleRef, usize> = file_metrics
         .iter()
-        .filter_map(|metric| Some((metric.module_id.as_deref()?, metric.lines)))
+        .filter_map(|metric| Some((metric.module.as_ref()?, metric.lines)))
         .collect();
     let mut directories = BTreeMap::<String, DirectoryAccumulator>::new();
 
@@ -1275,14 +1303,12 @@ fn build_directory_dependency_manifests(
     for decomposition in decomposition_by_chunk.values() {
         for lowering in &decomposition.selected_module_lowerings {
             let file = join_module_path(&[&lowering.chunk_id, &lowering.target_file]);
-            let loc = loc_by_module_id
-                .get(lowering.id.as_str())
-                .copied()
-                .unwrap_or(0);
+            let module_ref = lowering.module_ref();
+            let loc = loc_by_module.get(&module_ref).copied().unwrap_or(0);
             let ancestors = memoize_ancestors(&mut ancestors_cache, &file).to_vec();
             for dir in ancestors {
                 let accumulator = directories.entry(dir).or_default();
-                accumulator.module_ids.insert(lowering.id.clone());
+                accumulator.modules.insert(module_ref.clone());
                 for binding_name in &lowering.binding_names {
                     let symbol = format!("{file}#{binding_name}");
                     *accumulator.defined_symbols.entry(symbol).or_default() += 1;
@@ -1391,8 +1417,7 @@ fn build_file_dependency_manifests(
                 bytes: metric.bytes,
                 lines: metric.lines,
                 chunk_id: metric.file.split('/').next().map(str::to_string),
-                module_id: metric.module_id.clone(),
-                module_path: metric.module_path.clone(),
+                module: metric.module.clone(),
                 incoming: boundary.incoming.into_file_summary(),
                 outgoing: boundary.outgoing.into_file_summary(),
             }
@@ -1405,7 +1430,7 @@ struct DirectoryAccumulator {
     directories: BTreeSet<String>,
     files: BTreeSet<String>,
     chunk_ids: BTreeSet<String>,
-    module_ids: BTreeSet<String>,
+    modules: BTreeSet<ModuleRef>,
     defined_symbols: BTreeMap<String, usize>,
     loc: usize,
     incoming: DirectionalDirectoryAccumulator,
@@ -1434,7 +1459,7 @@ impl DirectoryAccumulator {
             directories: self.directories.into_iter().collect(),
             files: self.files.into_iter().collect(),
             chunks: self.chunk_ids.into_iter().collect(),
-            modules: self.module_ids.into_iter().collect(),
+            modules: self.modules.into_iter().collect(),
             defined_symbols: self.defined_symbols,
             loc: self.loc,
             incoming,
@@ -1778,8 +1803,7 @@ fn output_file_metric(
         role,
         bytes: rendered.len(),
         lines: rendered.lines().count(),
-        module_id: lowering.map(|lowering| lowering.id.clone()),
-        module_path: lowering.map(|lowering| lowering.target_path.clone()),
+        module: lowering.map(SelectedModuleLowering::module_ref),
     })
 }
 

--- a/devinfra/js/debundle/chunk_analysis.rs
+++ b/devinfra/js/debundle/chunk_analysis.rs
@@ -89,13 +89,27 @@ impl ChunkAnalysis {
             .unwrap_or_else(|| binding.0.clone())
     }
 
-    /// Render `id` to a human-readable label (used in cycle reports).
-    pub fn module_name(&self, id: ModuleId) -> String {
+    /// Canonical module identity for `id` — the [`spec::ModulePath`]
+    /// every wire artifact (`owner_graph.json` module table,
+    /// `cycles.json`, `atomic_unit_conflicts.json`) and diagnostic
+    /// uses to denote this module. Parses the in-process
+    /// `LogicalModule.id` (`"<chunk_id>::<path>"`) down to the clean
+    /// path; panics on an out-of-range id or unparseable identity —
+    /// both are pipeline bugs, not user errors.
+    pub fn module_path(&self, id: ModuleId) -> spec::ModulePath {
         let LogicalModuleIndex(idx) = id.0;
-        self.logical_modules
-            .get(idx)
-            .map(|m| m.id.clone())
-            .unwrap_or_else(|| format!("<module#{idx}>"))
+        let module = self.logical_modules.get(idx).unwrap_or_else(|| {
+            panic!(
+                "ModuleId logical:{idx} out of range ({} logical modules)",
+                self.logical_modules.len()
+            )
+        });
+        spec::ModulePath::parse(&module.id, &self.chunk_id).unwrap_or_else(|e| {
+            panic!(
+                "logical module logical:{idx} has unparseable identity {:?}: {e}",
+                module.id
+            )
+        })
     }
 
     /// Which logical module owns a binding, if any.

--- a/devinfra/js/debundle/chunk_factorization.rs
+++ b/devinfra/js/debundle/chunk_factorization.rs
@@ -212,13 +212,13 @@ impl ChunkFactorization {
     pub fn validate(&self) -> FactorizationReport {
         let mut report =
             validate_factorization(&self.analysis.owner_graph, &self.partition, &|id| {
-                self.analysis.module_name(id)
+                self.analysis.module_path(id)
             });
         report.atomic_unit_conflicts = self.assembly_conflicts.clone();
         report.linker_order = self
             .linker_order
             .iter()
-            .map(|id| self.analysis.module_name(*id))
+            .map(|id| self.analysis.module_path(*id))
             .collect();
         report
     }

--- a/devinfra/js/debundle/cli/edit_gate.rs
+++ b/devinfra/js/debundle/cli/edit_gate.rs
@@ -42,10 +42,10 @@ use anonymous_resolution::{
 };
 use anyhow::{Context, Result, bail};
 use serde_yaml::Value;
-use spec::AnonymousStatementSelector;
+use spec::{AnonymousStatementSelector, ModulePath};
 use spec_modules::{
     ModuleClaims, ModuleFile, collect_module_files, is_module_yaml, module_claims,
-    read_module_claims,
+    module_path_from_file, read_module_claims,
 };
 
 /// How a spec-mutating CLI verb validates its edit. Replaces the
@@ -341,19 +341,28 @@ pub fn gate_post_edit_partition(
     )?;
 
     // ModuleId assignment: residual at logical:0, every surviving
-    // spec module gets a fresh logical:N starting at 1. The label
-    // map keeps the renderer's diagnostic readable — we use each
-    // module's chunk-relative path as its `module_name` callback
-    // output.
+    // spec module gets a fresh logical:N starting at 1. The path map
+    // renders diagnostics with the same canonical [`ModulePath`]
+    // every wire artifact uses (the module YAML's path relative to
+    // the modules root, `.yaml` stripped).
     let residual = ModuleId::logical(0);
     let mut of: Vec<ModuleId> = vec![residual; owner_graph.num_nodes()];
-    let mut module_label_by_id: HashMap<ModuleId, String> =
-        [(residual, "<residual>".to_string())].into_iter().collect();
+    let mut module_path_by_id: HashMap<ModuleId, ModulePath> = [(
+        residual,
+        ModulePath::parse("residual", "").expect("residual is a canonical path"),
+    )]
+    .into_iter()
+    .collect();
     let mut next_idx = 1usize;
     for (module_idx, module) in post_spec.modules.iter().enumerate() {
         let mid = ModuleId::logical(next_idx);
         next_idx += 1;
-        module_label_by_id.insert(mid, module.path.to_string_lossy().into_owned());
+        let raw = module_path_from_file(&module.path, modules_root);
+        module_path_by_id.insert(
+            mid,
+            ModulePath::parse(&raw, "")
+                .with_context(|| format!("module YAML {} path", module.path.display()))?,
+        );
         for name in module
             .claims
             .bindings
@@ -370,11 +379,13 @@ pub fn gate_post_edit_partition(
     }
     let partition = Partition::from_assignments(of, residual);
 
-    let module_name = |m: ModuleId| {
-        module_label_by_id
-            .get(&m)
-            .cloned()
-            .unwrap_or_else(|| format!("logical:{}", m.0.0))
+    let module_path = |m: ModuleId| {
+        module_path_by_id.get(&m).cloned().unwrap_or_else(|| {
+            panic!(
+                "module id logical:{} not assigned by the post-edit spec",
+                m.0.0
+            )
+        })
     };
 
     // Check 1 — atom splits. Run before cycles so the diagnostic
@@ -386,13 +397,13 @@ pub fn gate_post_edit_partition(
     let atomic_conflicts =
         detect_atomic_unit_conflicts(&atomic_units, &partition, &owner_graph_report);
     if !atomic_conflicts.is_empty() {
-        let summary = render_atomic_unit_conflict_summary(&atomic_conflicts, &module_name);
+        let summary = render_atomic_unit_conflict_summary(&atomic_conflicts, &module_path);
         eprintln!("error: post-edit spec splits one or more atomic units:\n{summary}");
         bail!("realizability gate rejected the edit (atom-split)");
     }
 
     // Check 2 — module-quotient cycles.
-    let report = validate_factorization(&owner_graph, &partition, &module_name);
+    let report = validate_factorization(&owner_graph, &partition, &module_path);
     if !report.cycles.is_empty() {
         let summary = render_cycle_summary(&report.cycles);
         eprintln!("error: post-edit spec is unrealizable:\n{summary}");

--- a/devinfra/js/debundle/cli/gate.rs
+++ b/devinfra/js/debundle/cli/gate.rs
@@ -29,11 +29,13 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 
 use analysis::{
-    BlockingSccEntry, CycleEdge, DepKind, EdgeRoleReport, OwnerGraphReport, StatementOrdinal,
+    BlockingSccEntry, CycleEdge, DepKind, EdgeRoleReport, ModuleKey, OwnerGraphReport,
+    StatementOrdinal,
 };
 use anyhow::{Context, Result};
 use clap::{Args as ClapArgs, Subcommand};
 use serde::Serialize;
+use spec::ModulePath;
 use swc_atoms::Atom;
 
 /// Top-level `debundle gate ...` argument node.
@@ -150,7 +152,7 @@ pub struct GateListReport {
 #[derive(Debug, Clone, Serialize)]
 pub struct GateDescribeReport {
     pub id: usize,
-    pub modules: Vec<String>,
+    pub modules: Vec<ModulePath>,
     pub cut: Vec<CycleEdge>,
     /// Every constraining cross-module edge inside the SCC,
     /// recomputed from `owner_graph.json` + `modules` (the wire
@@ -243,7 +245,7 @@ fn run_describe(args: GateDescribeArgs) -> Result<()> {
     let entry = find_entry(&entries, args.id)?;
     let graph = load_graph(&args.common)?;
 
-    let mut evidence = recompute_evidence(&graph, &entry.modules);
+    let mut evidence = recompute_evidence(&graph, &entry.modules)?;
     if let Some(binding) = &args.binding {
         evidence.retain(|e| edge_touches_binding(e, binding));
     }
@@ -409,14 +411,35 @@ fn edge_touches_binding(edge: &CycleEdge, binding: &str) -> bool {
 /// evidence count may differ by a small number of rows from the
 /// pre-trim value. The per-binding-pair blame view (the surface
 /// spec authors actually read) is unaffected.
-fn recompute_evidence(graph: &OwnerGraphReport, modules: &[String]) -> Vec<CycleEdge> {
-    // Owner id -> destination module key. The cycles.json `modules`
-    // entries are precisely these interned module keys.
-    let owner_module: HashMap<&str, &str> = graph
+///
+/// Join contract: `cycles.json` denotes modules by canonical
+/// [`ModulePath`]; each owner's `destination` is an interned
+/// [`ModuleKey`] that resolves to its path through the owner graph's
+/// module table (`module_graph.nodes`). A destination key missing
+/// from the table is a malformed owner graph and errors.
+fn recompute_evidence(graph: &OwnerGraphReport, modules: &[ModulePath]) -> Result<Vec<CycleEdge>> {
+    // Module table: interned key -> canonical path.
+    let path_by_key: HashMap<&ModuleKey, &ModulePath> = graph
+        .quotient
         .nodes
         .iter()
-        .map(|n| (n.id.as_str(), n.destination.as_str()))
+        .map(|entry| (&entry.key, &entry.path))
         .collect();
+    // Owner id -> canonical module path of its destination.
+    let owner_module: HashMap<&str, &ModulePath> = graph
+        .nodes
+        .iter()
+        .map(|n| {
+            let path = path_by_key.get(&n.destination).copied().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "owner {} has destination {} with no module-table entry",
+                    n.id,
+                    n.destination
+                )
+            })?;
+            Ok((n.id.as_str(), path))
+        })
+        .collect::<Result<_>>()?;
     // Owner id -> first declared binding (matches the heuristic
     // `from_binding_by_ordinal` builds in validation.rs).
     let owner_first_binding: HashMap<&str, Atom> = graph
@@ -441,10 +464,10 @@ fn recompute_evidence(graph: &OwnerGraphReport, modules: &[String]) -> Vec<Cycle
         })
         .collect();
 
-    let scc_modules: BTreeSet<&str> = modules.iter().map(|s| s.as_str()).collect();
+    let scc_modules: BTreeSet<&ModulePath> = modules.iter().collect();
 
     let mut out = Vec::new();
-    let mut seen_sequenced_pairs: BTreeSet<(&str, &str)> = BTreeSet::new();
+    let mut seen_sequenced_pairs: BTreeSet<(&ModulePath, &ModulePath)> = BTreeSet::new();
     for edge in &graph.edges {
         let Some(&from_mod) = owner_module.get(edge.source.as_str()) else {
             continue;
@@ -491,8 +514,8 @@ fn recompute_evidence(graph: &OwnerGraphReport, modules: &[String]) -> Vec<Cycle
             .cloned()
             .or_else(|| owner_first_binding.get(edge.source.as_str()).cloned());
         out.push(CycleEdge {
-            from: from_mod.to_string(),
-            to: to_mod.to_string(),
+            from: from_mod.clone(),
+            to: to_mod.clone(),
             statement_ordinal: edge.statement_ordinal,
             binding: edge.binding.clone(),
             from_binding,
@@ -515,14 +538,14 @@ fn recompute_evidence(graph: &OwnerGraphReport, modules: &[String]) -> Vec<Cycle
                 b.kind,
             ))
     });
-    out
+    Ok(out)
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
 struct BlamePairKey {
     from_label: String,
-    from: String,
-    to: String,
+    from: ModulePath,
+    to: ModulePath,
     to_label: String,
 }
 
@@ -559,7 +582,15 @@ mod tests {
         BindingReport, EdgeRoleReport, OwnerGraphEdgeReport, OwnerGraphNodeReport,
         OwnerGraphQuotientReport, OwnerGraphReport, StatementKind,
     };
-    use report_fixtures::module_ref;
+    use report_fixtures::{module_ref, module_table};
+
+    fn module_path(path: &str) -> ModulePath {
+        ModulePath::parse(path, "").unwrap()
+    }
+
+    fn module_paths(paths: &[&str]) -> Vec<ModulePath> {
+        paths.iter().copied().map(module_path).collect()
+    }
 
     fn owner_node(
         id: &str,
@@ -567,9 +598,10 @@ mod tests {
         bindings: &[&str],
         module_label: &str,
     ) -> OwnerGraphNodeReport {
-        // The destination key string is the module label so
-        // `recompute_evidence`'s `owner_module` lookup matches the SCC
-        // `modules` entries (which are these same keys).
+        // The destination key string is the module's path (the
+        // `report_fixtures` convention), so the module table built by
+        // `quotient_for` resolves it to the same `ModulePath` the SCC
+        // `modules` entries carry.
         OwnerGraphNodeReport {
             id: id.to_string(),
             statement_ordinal: StatementOrdinal(statement_ordinal),
@@ -607,9 +639,13 @@ mod tests {
         }
     }
 
-    fn empty_quotient() -> OwnerGraphQuotientReport {
+    /// Quotient carrying only the module table for the given
+    /// destination keys — `recompute_evidence` resolves owner
+    /// destinations through it.
+    fn quotient_for(module_labels: &[&str]) -> OwnerGraphQuotientReport {
+        let keys: Vec<ModuleKey> = module_labels.iter().map(|l| module_ref(l)).collect();
         OwnerGraphQuotientReport {
-            nodes: Vec::new(),
+            nodes: module_table(keys.iter()),
             edges: Vec::new(),
             sccs: Vec::new(),
         }
@@ -639,21 +675,21 @@ mod tests {
                 // mod_a -> mod_c (NOT in SCC — should be filtered out)
                 owner_edge("e2", "owner:0", "owner:2", DepKind::EagerUse, Some("c"), 0),
             ],
-            quotient: empty_quotient(),
+            quotient: quotient_for(&["mod_a", "mod_b", "mod_c"]),
             atomic_graph: empty_atomic_graph(),
         };
         let evidence =
-            super::recompute_evidence(&graph, &["mod_a".to_string(), "mod_b".to_string()]);
+            super::recompute_evidence(&graph, &module_paths(&["mod_a", "mod_b"])).unwrap();
         assert_eq!(evidence.len(), 2, "{evidence:#?}");
         assert!(
             evidence
                 .iter()
-                .any(|e| e.from == "mod_a" && e.to == "mod_b")
+                .any(|e| e.from == module_path("mod_a") && e.to == module_path("mod_b"))
         );
         assert!(
             evidence
                 .iter()
-                .any(|e| e.from == "mod_b" && e.to == "mod_a")
+                .any(|e| e.from == module_path("mod_b") && e.to == module_path("mod_a"))
         );
         // Source binding labels come from the source owner's first
         // declared binding.
@@ -678,10 +714,10 @@ mod tests {
                 Some("b"),
                 0,
             )],
-            quotient: empty_quotient(),
+            quotient: quotient_for(&["mod_a"]),
             atomic_graph: empty_atomic_graph(),
         };
-        let evidence = super::recompute_evidence(&graph, &["mod_a".to_string()]);
+        let evidence = super::recompute_evidence(&graph, &module_paths(&["mod_a"])).unwrap();
         assert!(evidence.is_empty(), "{evidence:#?}");
     }
 
@@ -703,11 +739,11 @@ mod tests {
                 Some("b"),
                 0,
             )],
-            quotient: empty_quotient(),
+            quotient: quotient_for(&["mod_a", "mod_b"]),
             atomic_graph: empty_atomic_graph(),
         };
         let evidence =
-            super::recompute_evidence(&graph, &["mod_a".to_string(), "mod_b".to_string()]);
+            super::recompute_evidence(&graph, &module_paths(&["mod_a", "mod_b"])).unwrap();
         assert_eq!(evidence.len(), 1);
         assert_eq!(evidence[0].kind, DepKind::LazyUse);
     }
@@ -743,8 +779,8 @@ mod tests {
     #[test]
     fn edge_touches_binding_matches_either_endpoint() {
         let edge = CycleEdge {
-            from: "mod_a".to_string(),
-            to: "mod_b".to_string(),
+            from: module_path("mod_a"),
+            to: module_path("mod_b"),
             statement_ordinal: StatementOrdinal(0),
             binding: Some(Atom::from("target")),
             from_binding: Some(Atom::from("source")),

--- a/devinfra/js/debundle/docs/wire_format.md
+++ b/devinfra/js/debundle/docs/wire_format.md
@@ -135,6 +135,31 @@ spelled one identity five ways — and the parallel `sccs[].labels` are
 gone. Residual-ness is read from the table's authoritative `residual`
 flag, never inferred from a key string.
 
+## Module identity everywhere else: `ModulePath` / `ModuleRef`
+
+Every artifact outside `owner_graph.json` denotes modules by
+canonical `ModulePath` — never by interned key, and never by the
+in-process `"<chunk_id>::<path>"` spelling (`LogicalModule.id`,
+which exists only in memory). Per-chunk files use the bare path (the
+chunk is implicit); tree-wide files qualify it with the chunk id as
+a `ModuleRef { chunk_id, path }` object.
+
+| File                         | Module-identity fields                                                                   |
+| ---------------------------- | ---------------------------------------------------------------------------------------- |
+| `cycles.json` (per chunk)    | `modules[]`, `cut[].from`, `cut[].to` — `ModulePath`                                     |
+| `atomic_unit_conflicts.json` | `claims[].module` — `ModulePath` (owners are `"owner:N"` strings)                        |
+| `modules.json` (per chunk)   | `final_module_contents[].path`, `requested_logical_modules[].target_path` — `ModulePath` |
+| tree `index.json` (per dir)  | `modules[]` — `ModuleRef`; per-file rows carry `module: ModuleRef`                       |
+| chunk summary `linker_order` | `ModulePath`                                                                             |
+| stderr rejection summaries   | every module named in cycle / atom-split / unmatched-claim blocks                        |
+
+Cross-file join recipe (what `debundle gate describe` does): resolve
+each owner's `destination` key through the owner graph's module table
+to its `path`, then intersect those paths with the SCC's
+`cycles.json` `modules` set. Both sides carry the same canonical
+`ModulePath` values, so the join is plain equality — no prefix
+stripping or string surgery.
+
 ## Related documents
 
 - `docs/design.md` §"Two classes of atom" — the realizability theorem

--- a/devinfra/js/debundle/e2e/BUILD.bazel
+++ b/devinfra/js/debundle/e2e/BUILD.bazel
@@ -324,21 +324,22 @@ rust_test(
     ],
 )
 
-# `debundle gate {list,describe,cut}` against a synthetic
-# owner_graph.json + cycles.json fixture pair. Covers the trimmed
-# wire shape, evidence-recompute from owner_graph.json, the
-# `--binding` filter, `--cycles` override, and error handling for
-# unknown ids.
+# `debundle gate {list,describe,cut}` against REAL pipeline
+# artifacts: a cyclic spec is rejected by `debundle run`, then the
+# gate CLI is exercised against the owner_graph.json + cycles.json it
+# wrote. Pins the canonical-ModulePath join between the two files
+# (non-empty recomputed evidence), the `--binding` filter, `--cycles`
+# override, and error handling for unknown ids.
 rust_test(
     name = "gate_cli_test",
     srcs = ["gate_cli_test.rs"],
     crate_root = "gate_cli_test.rs",
-    data = ["//devinfra/js/debundle"],
-    edition = "2024",
-    deps = [
-        "@crates//:serde_json",
-        "@crates//:tempfile",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
     ],
+    edition = "2024",
+    deps = _STANDARD_E2E_DEPS,
 )
 
 # `debundle scc` filters + `debundle cluster` neighbors against a

--- a/devinfra/js/debundle/e2e/gate_cli_test.rs
+++ b/devinfra/js/debundle/e2e/gate_cli_test.rs
@@ -1,282 +1,207 @@
-//! E2e for `debundle gate {list,describe,cut}` against a synthetic
-//! `owner_graph.json` + `cycles.json` pair. Exercises the binary,
-//! so the env-var / flag plumbing is covered alongside the report
-//! shapes.
+//! E2e for `debundle gate {list,describe,cut}` against REAL pipeline
+//! artifacts. A spec with a cross-module at-init cycle is rejected by
+//! `debundle run`, which writes `owner_graph.json` + `cycles.json`
+//! under the report root; the gate CLI is then exercised against
+//! those files.
+//!
+//! Driving the real materializer (instead of a hand-written JSON
+//! pair) pins the cross-file join contract: `gate describe`'s
+//! evidence recompute resolves each owner's destination `ModuleKey`
+//! through the owner graph's module table to the same canonical
+//! `ModulePath` the `cycles.json` `modules` entries carry. A
+//! vocabulary drift between the two files (e.g. the historical
+//! `"<chunk_id>::<path>"` spelling leaking into `cycles.json`) makes
+//! the join come up empty — and fails the non-empty-evidence
+//! assertions here.
 
+use std::collections::BTreeSet;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::Command;
 
-fn debundle_binary() -> PathBuf {
-    let runfiles_path = std::env::var("RUNFILES_DIR")
-        .or_else(|_| std::env::var("TEST_SRCDIR"))
-        .expect("runfiles env var");
-    Path::new(&runfiles_path).join("_main/devinfra/js/debundle/debundle")
-}
+use debundle_e2e_support::*;
 
-fn write(path: &Path, body: &str) {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).unwrap();
-    }
-    fs::write(path, body).unwrap();
-}
-
-/// Two-module cycle `mod_a <-> mod_b`. Each module has a single
-/// owner; the edge from `mod_a` to `mod_b` is at-init on binding
-/// `b1` and the reverse is at-init on `a1`. Both endpoints are
-/// in the SCC, so `gate describe 0` should recompute exactly two
-/// evidence edges.
-fn synthetic_graph_json() -> String {
-    serde_json::json!({
-        "chunk_id": "static/app",
-        "nodes": [
-            {
-                "id": "owner:0",
-                "statement_ordinal": 0,
-                "source_location": null,
-                "declared_bindings": [
-                    { "binding": "a1", "export_name": "a1" }
-                ],
-                "statement_kind": "var_decl",
-                "purity": { "kind": "pure" },
-                "destination": "mod_a"
-            },
-            {
-                "id": "owner:1",
-                "statement_ordinal": 1,
-                "source_location": null,
-                "declared_bindings": [
-                    { "binding": "b1", "export_name": "b1" }
-                ],
-                "statement_kind": "var_decl",
-                "purity": { "kind": "pure" },
-                "destination": "mod_b"
-            }
+/// Reject a two-module at-init cycle through the real pipeline:
+/// `mod_x = {A, D}` where `D = wrap(C)` reads `C` from `mod_y`, and
+/// `mod_y = {B, C}` where `B = wrap(A)` reads `A` from `mod_x`.
+fn rejected_cycle_fixture() -> RejectedFixture {
+    run_rejection_fixture(FixtureOpts::new(
+        r#"function wrap(x) { return { ref: x }; }
+const A = "a";
+const B = wrap(A);
+const C = "c";
+const D = wrap(C);
+console.log(B.ref, D.ref);
+export { A, B, C, D };
+"#,
+        vec![
+            logical_module("mod_x", &[Member::new("A"), Member::new("D")]),
+            logical_module("mod_y", &[Member::new("B"), Member::new("C")]),
         ],
-        "edges": [
-            {
-                "id": "e0",
-                "source": "owner:0",
-                "target": "owner:1",
-                "edge_kind": "eager_use",
-                "binding": "b1",
-                "statement_ordinal": 0,
-                "constrains_init_order": true
-            },
-            {
-                "id": "e1",
-                "source": "owner:1",
-                "target": "owner:0",
-                "edge_kind": "eager_use",
-                "binding": "a1",
-                "statement_ordinal": 1,
-                "constrains_init_order": true
-            }
-        ],
-        "module_graph": {
-            "nodes": [
-                { "key": "mod_a", "path": "mod_a", "residual": false },
-                { "key": "mod_b", "path": "mod_b", "residual": false }
-            ],
-            "edges": [],
-            "sccs": []
-        },
-        "atomic_graph": { "nodes": [], "edges": [] }
-    })
-    .to_string()
+    ))
 }
 
-/// Trimmed `cycles.json` shape: one blocking SCC with `id`, `modules`,
-/// and `cut`. Mirrors what the materializer writes after the wire-shape
-/// trim (no `evidence` field).
-fn synthetic_cycles_json() -> String {
-    serde_json::json!([
-        {
-            "id": 0,
-            "modules": ["mod_a", "mod_b"],
-            "cut": [
-                {
-                    "from": "mod_a",
-                    "to": "mod_b",
-                    "statement_ordinal": 0,
-                    "binding": "b1",
-                    "from_binding": "a1",
-                    "kind": "eager_use"
-                }
-            ]
-        }
-    ])
-    .to_string()
-}
-
-struct Fixture {
-    _dir: tempfile::TempDir,
-    graph_path: PathBuf,
-    modules_root: PathBuf,
-}
-
-fn fixture_with_default_cycles_layout() -> Fixture {
-    // Default `cycles.json` location: sibling of `--graph`. Place
-    // both under the same parent dir so `gate ...` resolves cycles.json
-    // without an explicit `--cycles` flag.
-    let dir = tempfile::tempdir().unwrap();
-    let graph_path = dir.path().join("reports/static/app/owner_graph.json");
-    let cycles_path = dir.path().join("reports/static/app/cycles.json");
-    let modules_root = dir.path().join("modules");
-    fs::create_dir_all(&modules_root).unwrap();
-    write(&graph_path, &synthetic_graph_json());
-    write(&cycles_path, &synthetic_cycles_json());
-    Fixture {
-        _dir: dir,
-        graph_path,
-        modules_root,
-    }
+fn graph_path(rejected: &RejectedFixture) -> PathBuf {
+    rejected.report_root.join("static/app/owner_graph.json")
 }
 
 fn run_gate(args: &[&str]) -> std::process::Output {
-    Command::new(debundle_binary())
+    Command::new(debundler_path())
         .args(args)
         .output()
         .expect("spawn debundle")
 }
 
+fn gate_json(args: &[&str]) -> serde_json::Value {
+    let out = run_gate(args);
+    assert!(
+        out.status.success(),
+        "gate {:?} exit: stderr={}",
+        args,
+        String::from_utf8_lossy(&out.stderr)
+    );
+    serde_json::from_slice(&out.stdout).expect("gate output is JSON")
+}
+
 #[test]
 fn gate_list_reports_each_blocking_scc() {
-    let fx = fixture_with_default_cycles_layout();
-    let out = run_gate(&[
+    let rejected = rejected_cycle_fixture();
+    let parsed = gate_json(&[
         "gate",
         "list",
         "--graph",
-        fx.graph_path.to_str().unwrap(),
-        "--modules",
-        fx.modules_root.to_str().unwrap(),
+        graph_path(&rejected).to_str().unwrap(),
         "--format",
         "json",
     ]);
-    assert!(
-        out.status.success(),
-        "gate list exit: stderr={}",
-        String::from_utf8_lossy(&out.stderr)
-    );
-    let parsed: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
     let entries = parsed["blocking_sccs"].as_array().unwrap();
-    assert_eq!(entries.len(), 1);
+    assert_eq!(entries.len(), 1, "{parsed}");
     assert_eq!(entries[0]["id"].as_u64(), Some(0));
     assert_eq!(entries[0]["module_count"].as_u64(), Some(2));
-    assert_eq!(entries[0]["cut_count"].as_u64(), Some(1));
+    assert!(entries[0]["cut_count"].as_u64().unwrap() >= 1, "{parsed}");
 }
 
 #[test]
-fn gate_cut_returns_the_actionable_edges() {
-    let fx = fixture_with_default_cycles_layout();
-    let out = run_gate(&[
-        "gate",
-        "cut",
-        "0",
-        "--graph",
-        fx.graph_path.to_str().unwrap(),
-        "--modules",
-        fx.modules_root.to_str().unwrap(),
-        "--format",
-        "json",
-    ]);
-    assert!(
-        out.status.success(),
-        "gate cut exit: stderr={}",
-        String::from_utf8_lossy(&out.stderr)
-    );
-    let parsed: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
-    assert_eq!(parsed["id"].as_u64(), Some(0));
-    let cut = parsed["cut"].as_array().unwrap();
-    assert_eq!(cut.len(), 1);
-    assert_eq!(cut[0]["from"].as_str(), Some("mod_a"));
-    assert_eq!(cut[0]["to"].as_str(), Some("mod_b"));
-    assert_eq!(cut[0]["kind"].as_str(), Some("eager_use"));
-}
-
-#[test]
-fn gate_describe_recomputes_evidence_from_owner_graph() {
-    let fx = fixture_with_default_cycles_layout();
-    let out = run_gate(&[
+fn gate_describe_recomputes_nonempty_evidence_from_real_artifacts() {
+    let rejected = rejected_cycle_fixture();
+    let parsed = gate_json(&[
         "gate",
         "describe",
         "0",
         "--graph",
-        fx.graph_path.to_str().unwrap(),
-        "--modules",
-        fx.modules_root.to_str().unwrap(),
+        graph_path(&rejected).to_str().unwrap(),
         "--format",
         "json",
     ]);
-    assert!(
-        out.status.success(),
-        "gate describe exit: stderr={}",
-        String::from_utf8_lossy(&out.stderr)
-    );
-    let parsed: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
     assert_eq!(parsed["id"].as_u64(), Some(0));
-    let modules = parsed["modules"].as_array().unwrap();
-    assert_eq!(modules.len(), 2);
+    let modules: BTreeSet<&str> = parsed["modules"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|m| m.as_str().unwrap())
+        .collect();
+    assert_eq!(
+        modules,
+        BTreeSet::from(["mod_x", "mod_y"]),
+        "SCC modules are canonical ModulePaths: {parsed}"
+    );
+    // The unified-identity contract: cycles.json modules and the
+    // recomputed evidence both use clean canonical paths — no
+    // interned `logical:N` keys, no `<chunk_id>::<path>` spelling.
     let evidence = parsed["evidence"].as_array().unwrap();
-    // Two intra-SCC cross-module owner edges; both should be in
-    // the recomputed evidence (cycles.json carries no evidence
-    // — the CLI recomputed it from owner_graph.json).
-    assert_eq!(evidence.len(), 2, "{parsed}");
+    assert!(
+        !evidence.is_empty(),
+        "evidence recompute joined zero owner-graph edges against the SCC modules — \
+         the two files speak different module vocabularies: {parsed}"
+    );
+    for e in evidence {
+        for endpoint in [&e["from"], &e["to"]] {
+            let path = endpoint.as_str().unwrap();
+            assert!(
+                modules.contains(path),
+                "evidence endpoint {path} outside SCC modules {modules:?}: {e}"
+            );
+            assert!(
+                !path.contains("::") && !path.starts_with("logical:"),
+                "evidence endpoint {path} is not a canonical ModulePath: {e}"
+            );
+        }
+    }
+    // Both directions of the at-init cycle appear, naming the
+    // bindings whose reads forced it.
     assert!(
         evidence
             .iter()
-            .any(|e| e["from"] == "mod_a" && e["to"] == "mod_b" && e["binding"] == "b1"),
-        "evidence missing mod_a -> mod_b: {parsed}"
+            .any(|e| e["from"] == "mod_y" && e["to"] == "mod_x" && e["binding"] == "A"),
+        "evidence missing mod_y -> mod_x via A: {parsed}"
     );
     assert!(
         evidence
             .iter()
-            .any(|e| e["from"] == "mod_b" && e["to"] == "mod_a" && e["binding"] == "a1"),
-        "evidence missing mod_b -> mod_a: {parsed}"
+            .any(|e| e["from"] == "mod_x" && e["to"] == "mod_y" && e["binding"] == "C"),
+        "evidence missing mod_x -> mod_y via C: {parsed}"
     );
 }
 
 #[test]
 fn gate_describe_binding_filter_narrows_evidence_to_one_symbol() {
-    let fx = fixture_with_default_cycles_layout();
-    let out = run_gate(&[
+    let rejected = rejected_cycle_fixture();
+    let parsed = gate_json(&[
         "gate",
         "describe",
         "0",
         "--graph",
-        fx.graph_path.to_str().unwrap(),
-        "--modules",
-        fx.modules_root.to_str().unwrap(),
+        graph_path(&rejected).to_str().unwrap(),
         "--binding",
-        "a1",
+        "A",
         "--format",
         "json",
     ]);
-    assert!(out.status.success());
-    let parsed: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
     let evidence = parsed["evidence"].as_array().unwrap();
-    // `a1` is the source binding for mod_a -> mod_b AND the target
-    // binding for mod_b -> mod_a; both rows are kept.
-    assert_eq!(evidence.len(), 2);
+    assert!(!evidence.is_empty(), "{parsed}");
     for e in evidence {
         assert!(
-            e["binding"] == "a1" || e["from_binding"] == "a1",
+            e["binding"] == "A" || e["from_binding"] == "A",
             "binding filter kept an unrelated row: {e}"
         );
     }
 }
 
 #[test]
+fn gate_cut_returns_the_actionable_edges() {
+    let rejected = rejected_cycle_fixture();
+    let parsed = gate_json(&[
+        "gate",
+        "cut",
+        "0",
+        "--graph",
+        graph_path(&rejected).to_str().unwrap(),
+        "--format",
+        "json",
+    ]);
+    assert_eq!(parsed["id"].as_u64(), Some(0));
+    let cut = parsed["cut"].as_array().unwrap();
+    assert!(!cut.is_empty(), "{parsed}");
+    for e in cut {
+        for endpoint in [&e["from"], &e["to"]] {
+            let path = endpoint.as_str().unwrap();
+            assert!(
+                path == "mod_x" || path == "mod_y",
+                "cut endpoint {path} outside the SCC: {e}"
+            );
+        }
+    }
+}
+
+#[test]
 fn gate_unknown_id_fails_cleanly() {
-    let fx = fixture_with_default_cycles_layout();
+    let rejected = rejected_cycle_fixture();
     let out = run_gate(&[
         "gate",
         "describe",
         "99",
         "--graph",
-        fx.graph_path.to_str().unwrap(),
-        "--modules",
-        fx.modules_root.to_str().unwrap(),
+        graph_path(&rejected).to_str().unwrap(),
     ]);
     assert!(!out.status.success(), "describe 99 should fail");
     let stderr = String::from_utf8_lossy(&out.stderr);
@@ -288,59 +213,35 @@ fn gate_unknown_id_fails_cleanly() {
 
 #[test]
 fn gate_cycles_override_picks_up_custom_path() {
-    // Put cycles.json somewhere other than the graph's sibling and
+    // Move the real cycles.json away from the graph's sibling and
     // make sure `--cycles` finds it.
-    let dir = tempfile::tempdir().unwrap();
-    let graph_path = dir.path().join("reports/static/app/owner_graph.json");
-    let cycles_path = dir.path().join("elsewhere/cycles.json");
-    let modules_root = dir.path().join("modules");
-    fs::create_dir_all(&modules_root).unwrap();
-    write(&graph_path, &synthetic_graph_json());
-    write(&cycles_path, &synthetic_cycles_json());
+    let rejected = rejected_cycle_fixture();
+    let sibling = rejected.report_root.join("static/app/cycles.json");
+    let moved = rejected.report_root.join("elsewhere/cycles.json");
+    fs::create_dir_all(moved.parent().unwrap()).unwrap();
+    fs::rename(&sibling, &moved).unwrap();
 
-    let out = run_gate(&[
+    let parsed = gate_json(&[
         "gate",
         "list",
         "--graph",
-        graph_path.to_str().unwrap(),
-        "--modules",
-        modules_root.to_str().unwrap(),
+        graph_path(&rejected).to_str().unwrap(),
         "--cycles",
-        cycles_path.to_str().unwrap(),
+        moved.to_str().unwrap(),
         "--format",
         "json",
     ]);
-    assert!(
-        out.status.success(),
-        "gate list with --cycles exit: stderr={}",
-        String::from_utf8_lossy(&out.stderr)
-    );
-    let parsed: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
     assert_eq!(parsed["blocking_sccs"].as_array().unwrap().len(), 1);
-}
 
-#[test]
-fn gate_list_runs_without_modules_flag() {
-    // `--modules` is optional (gate reads nothing from it). Omitting
-    // it — and clearing the env fallback — must still succeed.
-    let fx = fixture_with_default_cycles_layout();
-    let out = Command::new(debundle_binary())
-        .args([
-            "gate",
-            "list",
-            "--graph",
-            fx.graph_path.to_str().unwrap(),
-            "--format",
-            "json",
-        ])
-        .env_remove("DEBUNDLE_MODULES")
-        .output()
-        .expect("spawn debundle");
-    assert!(
-        out.status.success(),
-        "gate list without --modules exit: stderr={}",
-        String::from_utf8_lossy(&out.stderr)
-    );
-    let parsed: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
-    assert_eq!(parsed["blocking_sccs"].as_array().unwrap().len(), 1);
+    // With cycles.json gone from the default location and no
+    // `--cycles`, the gate reads the clean state: zero blocking SCCs.
+    let parsed = gate_json(&[
+        "gate",
+        "list",
+        "--graph",
+        graph_path(&rejected).to_str().unwrap(),
+        "--format",
+        "json",
+    ]);
+    assert_eq!(parsed["blocking_sccs"].as_array().unwrap().len(), 0);
 }

--- a/devinfra/js/debundle/e2e/realizability_test.rs
+++ b/devinfra/js/debundle/e2e/realizability_test.rs
@@ -441,14 +441,18 @@ export { A, B };
     assert_eq!(by_file["entry.js"]["role"], "top_level_entry");
     assert_eq!(by_file["entry.js"]["bytes"], entry.0);
     assert_eq!(by_file["modules/mod_a.js"]["role"], "named_module");
-    assert_eq!(by_file["modules/mod_a.js"]["module_path"], "mod_a");
+    assert_eq!(by_file["modules/mod_a.js"]["module"]["path"], "mod_a");
+    assert_eq!(
+        by_file["modules/mod_a.js"]["module"]["chunk_id"],
+        "static/app"
+    );
     assert_eq!(by_file["modules/mod_a.js"]["bytes"], named.0);
     assert_eq!(
         by_file["modules/residual/unhandled.js"]["role"],
         "residual_module",
     );
     assert_eq!(
-        by_file["modules/residual/unhandled.js"]["module_path"],
+        by_file["modules/residual/unhandled.js"]["module"]["path"],
         "residual/unhandled",
     );
     assert_eq!(
@@ -469,7 +473,7 @@ export { A, B };
     assert!(root_files.iter().any(|file| {
         file["file"] == "static/app/modules/mod_a.js"
             && file["role"] == "named_module"
-            && file["module_path"] == "mod_a"
+            && file["module"]["path"] == "mod_a"
     }));
 }
 

--- a/devinfra/js/debundle/lib.rs
+++ b/devinfra/js/debundle/lib.rs
@@ -67,10 +67,10 @@ pub use realizability::{
     record_gate_diagnostic_translation,
 };
 pub use reports::schema::{
-    AtomicGraphReport, AtomicUnitEdgeReport, AtomicUnitReport, BindingReport, EdgeRoleReport,
-    FactorizeDiagnosticReason, LineRange, ModuleEntry, ModuleKey, OwnerGraphEdgeReport,
-    OwnerGraphNodeReport, OwnerGraphQuotientReport, OwnerGraphReport, PeelCandidateStatus,
-    QuotientEdgeReport, QuotientSccReport, SourceLocation,
+    AtomicGraphReport, AtomicUnitConflictReport, AtomicUnitEdgeReport, AtomicUnitReport,
+    BindingReport, ConflictingClaimReport, EdgeRoleReport, FactorizeDiagnosticReason, LineRange,
+    ModuleEntry, ModuleKey, OwnerGraphEdgeReport, OwnerGraphNodeReport, OwnerGraphQuotientReport,
+    OwnerGraphReport, PeelCandidateStatus, QuotientEdgeReport, QuotientSccReport, SourceLocation,
 };
 pub use stage_one::{
     RebindFold, StageOneAnalysis, compute_rebind_folds, compute_stage_one_analysis,

--- a/devinfra/js/debundle/lowering/lower.rs
+++ b/devinfra/js/debundle/lowering/lower.rs
@@ -966,7 +966,6 @@ fn build_module_output(
         chunk_id: context.chunk_id.to_string(),
         exported_names,
         file: context.entry_file.to_string(),
-        id: plan.id.clone(),
         owner_ids,
         residual: !plan.explicit,
         target_file: plan.target_file.clone(),

--- a/devinfra/js/debundle/lowering/materialize/apply.rs
+++ b/devinfra/js/debundle/lowering/materialize/apply.rs
@@ -84,10 +84,10 @@ pub(super) fn materialized_chunk_artifact(
         })
         .collect();
     let logical_modules = ChunkLogicalModulesSummary {
-        module_ids: report
+        module_paths: report
             .final_module_contents
             .iter()
-            .map(|module| module.id.clone())
+            .map(|module| module.path.clone())
             .collect(),
         target_dir: target_dir.to_string(),
     };

--- a/devinfra/js/debundle/lowering/materialize/mod.rs
+++ b/devinfra/js/debundle/lowering/materialize/mod.rs
@@ -331,8 +331,8 @@ pub(super) fn materialize_logical_chunk(
         requested_logical_modules: requests
             .iter()
             .map(|request| RequestedLogicalModule {
-                id: request.id.clone(),
-                target_path: request.target_path.clone(),
+                target_path: spec::ModulePath::parse(&request.target_path, "")
+                    .expect("request target_path is a canonical module path"),
                 residual: request.residual,
             })
             .collect(),
@@ -501,18 +501,26 @@ fn validate_and_emit_reports(
     }
     if !factorization_report.atomic_unit_conflicts.is_empty() {
         if let Some(report_out_dir) = report_out_dir {
+            // Project onto the wire shape: owners as `"owner:N"`,
+            // modules as canonical `ModulePath` — the same entity
+            // keys `owner_graph.json` uses, so the file joins
+            // against the owner graph without string surgery.
+            let wire = ::analysis::AtomicUnitConflictReport::from_conflicts(
+                &factorization_report.atomic_unit_conflicts,
+                &|id| factorization.analysis.module_path(id),
+            );
             time_phase!(timings, "write_atomic_unit_conflicts_report", {
                 write_chunk_report_json(
                     report_out_dir,
                     chunk_id,
                     ATOMIC_UNIT_CONFLICTS_REPORT,
-                    &factorization_report.atomic_unit_conflicts,
+                    &wire,
                 )
             })?;
         }
         let summary = render_atomic_unit_conflict_summary(
             &factorization_report.atomic_unit_conflicts,
-            &|id| factorization.analysis.module_name(id),
+            &|id| factorization.analysis.module_path(id),
         );
         let causes = render_atomic_unit_cause_guidance(&factorization_report.atomic_unit_conflicts);
         bail!(
@@ -582,9 +590,9 @@ fn build_final_module_report(
             FinalModuleContent {
                 binding_names,
                 file: plan.target_file.clone(),
-                id: plan.id.clone(),
                 member_names,
-                path: plan.target_path.clone(),
+                path: spec::ModulePath::parse(&plan.target_path, "")
+                    .expect("plan target_path is a canonical module path"),
                 owner_ids,
                 residual: !plan.explicit,
             }

--- a/devinfra/js/debundle/lowering/materialize/plan_builder.rs
+++ b/devinfra/js/debundle/lowering/materialize/plan_builder.rs
@@ -238,7 +238,8 @@ impl ChunkPlanBuilder {
                 // resolve, so the missing claim is a no-op here).
                 self.unmatched_spec_claims.push(crate::UnmatchedSpecClaim {
                     chunk_id: ctx.chunk_id.to_string(),
-                    module_id: request.id.clone(),
+                    module_path: spec::ModulePath::parse(&request.target_path, "")
+                        .expect("request target_path is a canonical module path"),
                     binding_name: binding.clone(),
                     export_name: export_name.clone(),
                 });

--- a/devinfra/js/debundle/lowering/mod.rs
+++ b/devinfra/js/debundle/lowering/mod.rs
@@ -148,7 +148,8 @@ pub struct MaterializeLogicalModulesResult {
 #[derive(Debug, Clone, Serialize)]
 pub struct UnmatchedSpecClaim {
     pub chunk_id: String,
-    pub module_id: String,
+    /// Claiming module, by canonical [`spec::ModulePath`].
+    pub module_path: spec::ModulePath,
     pub binding_name: String,
     pub export_name: String,
 }
@@ -177,17 +178,18 @@ pub struct ChunkModulesCounts {
 pub struct FinalModuleContent {
     pub binding_names: Vec<String>,
     pub file: String,
-    pub id: String,
     pub member_names: Vec<String>,
-    pub path: String,
+    /// Canonical [`spec::ModulePath`] (the report is per-chunk, so
+    /// the chunk is implicit).
+    pub path: spec::ModulePath,
     pub owner_ids: Vec<String>,
     pub residual: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct RequestedLogicalModule {
-    pub id: String,
-    pub target_path: String,
+    /// Canonical [`spec::ModulePath`] of the requested target.
+    pub target_path: spec::ModulePath,
     pub residual: bool,
 }
 

--- a/devinfra/js/debundle/peel/factorize_tests.rs
+++ b/devinfra/js/debundle/peel/factorize_tests.rs
@@ -48,13 +48,16 @@ fn residual() -> ModuleId {
     ModuleId::logical(usize::MAX)
 }
 
-fn render(id: ModuleId) -> String {
+/// Canonical-path renderer for `validate_factorization`: the residual
+/// sentinel renders as `residual`, explicit modules as `mod_<idx>`.
+fn render(id: ModuleId) -> spec::ModulePath {
     let LogicalModuleIndex(idx) = id.0;
-    if idx == usize::MAX {
-        "<residual>".to_string()
+    let raw = if idx == usize::MAX {
+        "residual".to_string()
     } else {
         format!("mod_{idx}")
-    }
+    };
+    spec::ModulePath::parse(&raw, "").unwrap()
 }
 
 fn member_bindings(members: &[BindingReport]) -> Vec<String> {
@@ -1016,7 +1019,7 @@ fn validate_surfaces_linker_order_for_acyclic_spec() {
     let pos = |name: &str| -> usize {
         order
             .iter()
-            .position(|m| m == name)
+            .position(|m| m.as_str() == name)
             .unwrap_or_else(|| panic!("module {name} not in {order:?}"))
     };
     assert!(
@@ -1186,7 +1189,7 @@ fn partition_summary(factorization: &ChunkFactorization) -> Vec<(String, String)
                 .logical_module(LogicalModuleIndex(idx))
             {
                 Some(m) if m.residual => "<residual>".to_string(),
-                _ => render(dest),
+                _ => render(dest).to_string(),
             };
             (key, label)
         })

--- a/devinfra/js/debundle/pipeline.rs
+++ b/devinfra/js/debundle/pipeline.rs
@@ -274,10 +274,10 @@ pub fn run_transform_cli_with_options(
         let mut lines = String::new();
         for claim in &unmatched_spec_claims {
             lines.push_str(&format!(
-                "  - chunk {chunk_id}: module {module_id} claims binding `{binding}` (export `{export}`); \
+                "  - chunk {chunk_id}: module {module_path} claims binding `{binding}` (export `{export}`); \
                  no top-level declaration with that name exists in the chunk.\n",
                 chunk_id = claim.chunk_id,
-                module_id = claim.module_id,
+                module_path = claim.module_path,
                 binding = claim.binding_name,
                 export = claim.export_name,
             ));

--- a/devinfra/js/debundle/reports/mod.rs
+++ b/devinfra/js/debundle/reports/mod.rs
@@ -419,21 +419,11 @@ pub(crate) fn module_id_from_key(key: &ModuleKey) -> Option<ModuleId> {
 }
 
 /// Build the module-table entry for `id`: the single place its
-/// canonical [`spec::ModulePath`] and residual flag are recorded. The
-/// path comes from the module's `LogicalModule.id` (the production
-/// `<chunk>::<path>` spelling), normalized through `ModulePath::parse`.
+/// canonical [`spec::ModulePath`] and residual flag are recorded.
 pub(crate) fn module_entry(factorization: &ChunkFactorization, id: ModuleId) -> ModuleEntry {
-    let chunk_id = &factorization.analysis.chunk_id;
-    let raw = factorization.analysis.module_name(id);
-    let path = spec::ModulePath::parse(&raw, chunk_id).unwrap_or_else(|e| {
-        panic!(
-            "module {} has unparseable identity {raw:?}: {e}",
-            module_key(id)
-        )
-    });
     ModuleEntry {
         key: module_key(id),
-        path,
+        path: factorization.analysis.module_path(id),
         residual: is_residual_destination(factorization, id),
     }
 }

--- a/devinfra/js/debundle/reports/schema.rs
+++ b/devinfra/js/debundle/reports/schema.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use swc_atoms::Atom;
 
+use crate::factor_assembly::AtomicUnitConflict;
+use crate::ids::ModuleId;
 use crate::purity::Purity;
 use crate::{DepKind, StatementKind, StatementOrdinal};
 
@@ -238,6 +240,60 @@ pub struct AtomicUnitEdgeReport {
     pub edge_kinds: Vec<DepKind>,
     pub owner_edge_ids: Vec<String>,
     pub constrains_init_order: bool,
+}
+
+/// Wire shape for `atomic_unit_conflicts.json` (one entry per
+/// conflicting atomic unit). Projects the in-memory
+/// [`AtomicUnitConflict`] onto the shared entity-key formats: owners
+/// as `"owner:N"` strings (joining `owner_graph.json`'s `nodes[].id`)
+/// and modules as canonical [`spec::ModulePath`]s (joining the module
+/// table's `path`). The raw `OwnerId` / `ModuleId` indices never hit
+/// the wire.
+#[derive(Debug, Clone, Serialize)]
+pub struct AtomicUnitConflictReport {
+    /// Members as `"owner:N"` keys, sorted by owner id.
+    pub members: Vec<String>,
+    pub claims: Vec<ConflictingClaimReport>,
+    pub causes: Vec<DepKind>,
+}
+
+/// One claim row in [`AtomicUnitConflictReport`].
+#[derive(Debug, Clone, Serialize)]
+pub struct ConflictingClaimReport {
+    /// Claiming owner as an `"owner:N"` key.
+    pub owner: String,
+    pub binding_names: Vec<Atom>,
+    /// Claimed destination, by canonical [`spec::ModulePath`].
+    pub module: spec::ModulePath,
+}
+
+impl AtomicUnitConflictReport {
+    pub fn from_conflicts(
+        conflicts: &[AtomicUnitConflict],
+        module_path: &dyn Fn(ModuleId) -> spec::ModulePath,
+    ) -> Vec<Self> {
+        conflicts
+            .iter()
+            .map(|conflict| Self {
+                members: conflict
+                    .members
+                    .iter()
+                    .copied()
+                    .map(crate::reports::owner_key)
+                    .collect(),
+                claims: conflict
+                    .claims
+                    .iter()
+                    .map(|claim| ConflictingClaimReport {
+                        owner: crate::reports::owner_key(claim.owner),
+                        binding_names: claim.binding_names.clone(),
+                        module: module_path(claim.module),
+                    })
+                    .collect(),
+                causes: conflict.causes.iter().copied().collect(),
+            })
+            .collect()
+    }
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]

--- a/devinfra/js/debundle/spec.rs
+++ b/devinfra/js/debundle/spec.rs
@@ -681,9 +681,22 @@ pub const DEFAULT_RESIDUAL_MODULE_PATH: &str = "residual/unhandled";
 /// an honest identity test.
 ///
 /// [`parse`]: ModulePath::parse
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 #[serde(transparent)]
 pub struct ModulePath(String);
+
+/// Deserialization routes through [`ModulePath::parse`] (with no
+/// chunk-id prefix to strip) so wire data can't construct a
+/// non-canonical value — `parse` stays the only constructor.
+impl<'de> serde::Deserialize<'de> for ModulePath {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = String::deserialize(deserializer)?;
+        ModulePath::parse(&raw, "").map_err(serde::de::Error::custom)
+    }
+}
 
 impl ModulePath {
     /// Normalize an untrusted module identifier into canonical form.

--- a/devinfra/js/debundle/validation.rs
+++ b/devinfra/js/debundle/validation.rs
@@ -8,6 +8,7 @@ use crate::factor_assembly::AtomicUnitConflict;
 use crate::graph::{EndpointView, OwnerEdgeId, partition_endpoints};
 use crate::partition::Partition;
 use crate::realizability::{RealizabilityVerdict, SccRejection, check_realizability};
+use spec::ModulePath;
 use swc_atoms::Atom;
 
 use crate::{DepKind, ModuleId, OwnerGraph, StatementOrdinal};
@@ -26,7 +27,7 @@ pub struct FactorizationReport {
     /// (validation rejects). Captured here so debug tooling can
     /// see the linker's evaluation order without re-running
     /// materialization. See docs/design.md "Lemma 2".
-    pub linker_order: Vec<String>,
+    pub linker_order: Vec<ModulePath>,
     /// Clause-2 violations (cross-destination rebinding writes) from
     /// the realizability verdict, rendered for diagnostics. A
     /// rebinding write and the binding it reassigns belong to one
@@ -45,7 +46,7 @@ pub struct FactorizationReport {
 /// `cut` / `lazy_closure` rows the bail-message renderer consumes.
 #[derive(Debug, Clone, Serialize)]
 pub struct CycleReport {
-    pub modules: Vec<String>,
+    pub modules: Vec<ModulePath>,
     /// Spec-author-actionable cut: realizability-constraining
     /// (`at-init` or `side-effect`) reasons whose removal (by
     /// co-locating each binding pair into one module) lifts the
@@ -87,8 +88,13 @@ pub struct BlockingSccEntry {
     /// the CLI `gate describe`/`cut` commands resolve `<id>` against
     /// this index.
     pub id: usize,
-    /// Every module in the unrealizable SCC.
-    pub modules: Vec<String>,
+    /// Every module in the unrealizable SCC, by canonical
+    /// [`ModulePath`] — the same value as the owner-graph module
+    /// table's `path`, so consumers join `cycles.json` against
+    /// `owner_graph.json` by resolving destination keys through the
+    /// table (see `docs/wire_format.md` §"one canonical module
+    /// identity").
+    pub modules: Vec<ModulePath>,
     /// The actionable subset for spec authors: removing any of these
     /// edges (by co-locating the binding pair into one module) works
     /// toward breaking the SCC. See [`CycleReport::cut`] for the
@@ -120,8 +126,10 @@ impl BlockingSccEntry {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CycleEdge {
-    pub from: String,
-    pub to: String,
+    /// Source module, by canonical [`ModulePath`].
+    pub from: ModulePath,
+    /// Target module, by canonical [`ModulePath`].
+    pub to: ModulePath,
     pub statement_ordinal: StatementOrdinal,
     /// Target binding being read (declared in `to`'s module). `None`
     /// for sequenced edges (no symbol).
@@ -328,10 +336,10 @@ fn cut_pairs_count(cut: &[CycleEdge]) -> usize {
 pub fn validate_factorization(
     owner_graph: &OwnerGraph,
     partition: &Partition,
-    module_name: &dyn Fn(ModuleId) -> String,
+    module_path: &dyn Fn(ModuleId) -> ModulePath,
 ) -> FactorizationReport {
     let verdict = check_realizability(owner_graph, partition);
-    let cross_rebinds = render_cross_rebinds(owner_graph, &verdict, module_name);
+    let cross_rebinds = render_cross_rebinds(owner_graph, &verdict, module_path);
     if verdict.unrealizable_sccs.is_empty() {
         return FactorizationReport {
             cycles: Vec::new(),
@@ -365,7 +373,7 @@ pub fn validate_factorization(
                         owner_graph,
                         partition,
                         &diagnosis.constraining_owner_edges,
-                        module_name,
+                        module_path,
                         &from_binding_by_ordinal,
                     ),
                     Vec::new(),
@@ -378,20 +386,20 @@ pub fn validate_factorization(
                         owner_graph,
                         partition,
                         diagnosis.constraining_owner_edges.iter().copied(),
-                        module_name,
+                        module_path,
                         &from_binding_by_ordinal,
                     ),
                     lazy_closure_edges(
                         owner_graph,
                         partition,
                         &diagnosis.modules,
-                        module_name,
+                        module_path,
                         &from_binding_by_ordinal,
                     ),
                 ),
             };
             CycleReport {
-                modules: diagnosis.modules.iter().copied().map(module_name).collect(),
+                modules: diagnosis.modules.iter().copied().map(module_path).collect(),
                 cut,
                 lazy_closure,
             }
@@ -410,7 +418,7 @@ pub fn validate_factorization(
 fn render_cross_rebinds(
     owner_graph: &OwnerGraph,
     verdict: &RealizabilityVerdict,
-    module_name: &dyn Fn(ModuleId) -> String,
+    module_path: &dyn Fn(ModuleId) -> ModulePath,
 ) -> Vec<String> {
     verdict
         .cross_rebinds
@@ -423,9 +431,9 @@ fn render_cross_rebinds(
             };
             format!(
                 "{} --{}--> {} (binding `{}`)",
-                module_name(rebind.from),
+                module_path(rebind.from),
                 dep_kind_short(edge.reason.kind),
-                module_name(rebind.to),
+                module_path(rebind.to),
                 binding,
             )
         })
@@ -443,7 +451,7 @@ fn cycle_edges_for(
     owner_graph: &OwnerGraph,
     partition: &Partition,
     edge_ids: impl IntoIterator<Item = OwnerEdgeId>,
-    module_name: &dyn Fn(ModuleId) -> String,
+    module_path: &dyn Fn(ModuleId) -> ModulePath,
     from_binding_by_ordinal: &HashMap<StatementOrdinal, Atom>,
 ) -> Vec<CycleEdge> {
     let mut out: Vec<CycleEdge> = edge_ids
@@ -453,8 +461,8 @@ fn cycle_edges_for(
             let (from, to) = partition_endpoints(edge, partition, EndpointView::Gate)
                 .expect("verdict owner-edge provenance is cross-module in the gate view");
             CycleEdge {
-                from: module_name(from),
-                to: module_name(to),
+                from: module_path(from),
+                to: module_path(to),
                 statement_ordinal: edge.reason.statement_ordinal,
                 binding: edge.reason.binding.as_ref().map(|id| id.0.clone()),
                 from_binding: from_binding_by_ordinal
@@ -491,7 +499,7 @@ fn lazy_closure_edges(
     owner_graph: &OwnerGraph,
     partition: &Partition,
     modules: &BTreeSet<ModuleId>,
-    module_name: &dyn Fn(ModuleId) -> String,
+    module_path: &dyn Fn(ModuleId) -> ModulePath,
     from_binding_by_ordinal: &HashMap<StatementOrdinal, Atom>,
 ) -> Vec<CycleEdge> {
     let lazy_edge_ids = owner_graph.iter_edges().filter_map(|edge| {
@@ -508,7 +516,7 @@ fn lazy_closure_edges(
         owner_graph,
         partition,
         lazy_edge_ids,
-        module_name,
+        module_path,
         from_binding_by_ordinal,
     )
 }
@@ -516,11 +524,11 @@ fn lazy_closure_edges(
 /// Render a human-readable summary of atomic-unit conflicts for
 /// inclusion in the materializer's bail message. One block per
 /// conflict listing the unit's members and each member's claim. The
-/// `module_name` callback renders [`ModuleId`]s as the strings the
-/// spec author recognizes (e.g. `mod_0`, `<residual_entry>`).
+/// `module_path` callback resolves [`ModuleId`]s to the canonical
+/// [`ModulePath`]s the spec author recognizes.
 pub fn render_atomic_unit_conflict_summary(
     conflicts: &[AtomicUnitConflict],
-    module_name: &dyn Fn(ModuleId) -> String,
+    module_path: &dyn Fn(ModuleId) -> ModulePath,
 ) -> String {
     let mut out = String::new();
     for (idx, c) in conflicts.iter().enumerate() {
@@ -537,7 +545,7 @@ pub fn render_atomic_unit_conflict_summary(
         let mut conflicting_modules: Vec<String> = c
             .claims
             .iter()
-            .map(|claim| module_name(claim.module))
+            .map(|claim| module_path(claim.module).to_string())
             .collect::<HashSet<_>>()
             .into_iter()
             .collect();
@@ -565,7 +573,7 @@ pub fn render_atomic_unit_conflict_summary(
                 "    - {}{} → {}\n",
                 crate::reports::owner_key(claim.owner),
                 names,
-                module_name(claim.module),
+                module_path(claim.module),
             ));
         }
     }
@@ -595,7 +603,7 @@ fn compute_realizability_cut(
     owner_graph: &OwnerGraph,
     partition: &Partition,
     constraining_owner_edges: &[OwnerEdgeId],
-    module_name: &dyn Fn(ModuleId) -> String,
+    module_path: &dyn Fn(ModuleId) -> ModulePath,
     from_binding_by_ordinal: &HashMap<StatementOrdinal, Atom>,
 ) -> Vec<CycleEdge> {
     let mut by_pair: BTreeMap<(ModuleId, ModuleId), Vec<OwnerEdgeId>> = BTreeMap::new();
@@ -630,7 +638,7 @@ fn compute_realizability_cut(
         owner_graph,
         partition,
         cut_edge_ids,
-        module_name,
+        module_path,
         from_binding_by_ordinal,
     )
 }


### PR DESCRIPTION
## History findings

Re: "I thought we got rid of `logical:N` a while back" — partially right. **PR #1713** (`5b59a8fb3`, 2026-05-28, "introduce ModulePath newtype, fix self-merge at the root") did the big collapse, but only inside `owner_graph.json`:

- introduced `spec::ModulePath` with `parse()` as the only constructor (strips the in-process `"<chunk_id>::<path>"` prefix, lowercases, normalizes) — fixing the peel factorizer self-merge caused by two spellings comparing unequal;
- collapsed module identity in `owner_graph.json` to **one interned encoding**: `ModuleKey` (`"logical:N"`) as the sole module *reference* + `ModuleEntry { key, path, residual }` as the single module *table*;
- deleted `ModuleReportRef { id, label, residual, index, target_file }` (one identity spelled five ways) and the parallel `QuotientSccReport.labels`.

So `"logical:N"` was deliberately **kept** as the interned reference into the table — what was removed was the duplicated identity fields and `destination.id == "residual"` string checks. What #1713 explicitly deferred ("wire-visible follow-ups") never landed: `cycles.json` kept serializing the in-process `LogicalModule.id` (`"<chunk_id>::<path>"`), `atomic_unit_conflicts.json` serialized raw in-memory `OwnerId`/`ModuleId` indices, and the tree reports (`index.json`, `modules.json`) spelled modules a third way via `SelectedModuleLowering.id`.

**Verified breakage**: `gate describe`'s `recompute_evidence` intersected `cycles.json` modules (`"<chunk>::path"`) with owner-graph destinations (`"logical:N"`) as strings — disjoint vocabularies on real pipeline output, so evidence recompute returned zero rows. `e2e/gate_cli_test.rs` passed only because its hand-written fixture used the same made-up strings on both sides.

## Chosen scheme

One canonical identity, as #1713 intended:

- **`ModulePath`** is the module identity on every wire artifact and diagnostic. Per-chunk files carry the bare path (chunk implicit): `cycles.json` (`modules[]`, `cut[].from/to`), `atomic_unit_conflicts.json` (new `AtomicUnitConflictReport` wire shape: `"owner:N"` owners + `ModulePath` modules), `modules.json` (`path` / `target_path`), `linker_order`, stderr rejection summaries.
- **`ModuleRef { chunk_id, path }`** for tree-wide (cross-chunk) reports: `index.json` directory manifests (`modules[]`), per-file rows (`module`), decomposition metrics. Replaces the `"<chunk>::<path>"` `module_id` strings. `SelectedModuleLowering.id`, `FinalModuleContent.id`, `RequestedLogicalModule.id`, `UnmatchedSpecClaim.module_id` are gone.
- **Interning is kept** in `owner_graph.json` (`ModuleKey` + `ModuleEntry` table as single source of truth); everything else joins by `ModulePath` equality — no prefix stripping or string surgery.
- **Strong types end-to-end**: `validate_factorization` / `render_atomic_unit_conflict_summary` callbacks, `CycleEdge.from/to`, `BlockingSccEntry.modules`, `GateDescribeReport`, `ChunkValidationSummary.linker_order`, `ChunkLogicalModulesSummary` all use `ModulePath`/`ModuleRef` instead of raw `String`. `ModulePath::Deserialize` now routes through `parse()` so wire data can't construct a non-canonical value.

## Gate fix + e2e

- `cli/gate.rs recompute_evidence` resolves each owner's `destination` `ModuleKey` through the module table to its `ModulePath` and joins `cycles.json` by path equality; a destination missing from the table is an error instead of a silent skip.
- `e2e/gate_cli_test.rs` rewritten to drive the **real pipeline** (`debundle run` on a spec with a cross-module at-init cycle) and assert `gate describe` returns non-empty evidence on the real `owner_graph.json` + `cycles.json` — including explicit assertions that no module endpoint contains `::` or `logical:` — so the fixture can no longer drift from production output.

## Consumers checked/updated

- `cli/gate.rs`, `cli/edit_gate.rs` (post-edit gate diagnostics now render canonical paths; rebased over #2051's claims-model rewrite)
- `e2e/`: `gate_cli_test.rs` (rewritten onto the support harness), `realizability_test.rs` (new `module` ref shape), `peel/factorize_tests.rs`
- `skills/`, `live_proxy/`, `docs/` — grepped; none parse the removed fields (`module_id`, `final_module_contents[].id`, `module_ids`). `props/frontend/` has no debundle consumer (`bbr build //props/frontend/...` green).
- `docs/wire_format.md` (followed the rename from `WIRE_FORMAT.md`): new section "Module identity everywhere else: `ModulePath` / `ModuleRef`" with the per-file field table and the gate-describe join recipe.

## Testing

- `bbr test //devinfra/js/debundle/...` — 88/88 pass (`buildbuddy:9bcb477c-3e72-4029-b1f1-3f01d9ca12db`)
- `bbr build //props/frontend/...` — green

https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk)_