### PR TITLE
debundle: close purity classifier soundness holes (coercion, shadowing, destructuring, escape)

### DIFF
--- a/devinfra/js/debundle/AGENTS.md
+++ b/devinfra/js/debundle/AGENTS.md
@@ -299,6 +299,14 @@ The analysis engine carries an inline TODO listing patterns
 that would become admissible once a primitive-arg gate exists —
 treat that as the queue for safe whitelist growth.
 
+All whitelist admission arguments additionally assume **intrinsic
+integrity** (docs/design.md A11): the chunk runs with unmodified
+built-in prototypes. Prototype pollution (e.g. replacing
+`Set.prototype.add` or `Array.prototype[Symbol.iterator]`) defeats
+every whitelist entry whose ECMA-262 citation describes the
+standard built-in; the analyzer cannot detect it because the
+pollution may live outside the analyzed chunk.
+
 ### Declared purity
 
 The spec format admits optional per-member `purity:` annotations.

--- a/devinfra/js/debundle/docs/design.md
+++ b/devinfra/js/debundle/docs/design.md
@@ -931,6 +931,27 @@ output, the Vite ecosystem, and most React/Vue/Angular SPAs.
   same review burden as `purity: "pure"`; the difference is that the
   trusted claim is local target mutation, not absence of effects.
 
+- **A11. Intrinsic integrity: the chunk runs with unmodified
+  built-in prototypes and intrinsics.** Every purity-whitelist
+  admission argument cites ECMA-262 behavior of the _standard_
+  built-ins: `Set.prototype.add` doing SameValueZero,
+  `Array.prototype[Symbol.iterator]` being the built-in array
+  iterator, `Object.prototype.toString` firing no user code, a
+  plain constructor's `prototype` being an own data property. If
+  code that runs before the chunk pollutes those prototypes
+  (`Set.prototype.add = function () { globalThis.boom = 1; … }`,
+  replacing `Array.prototype[Symbol.iterator]`, installing
+  `Object.prototype[Symbol.toPrimitive]`), a `Pure`-classified
+  statement like `new Set(["a"])` fires user code, S edges drop,
+  and the theorem's ordering claim no longer holds. Unlike A8
+  (chunk-top shadowing), this is **not** detected — pollution can
+  live in another chunk, a vendor bundle, or host code, outside
+  what the analyzer sees. Production bundles we target don't
+  monkey-patch intrinsics; the assumption is relied on by
+  observation, like A6. (Membrane/zone-style frameworks that DO
+  patch intrinsics would need the affected whitelist entries
+  disabled for soundness.)
+
 A1–A5 are statically checkable on each chunk: grep for top-level
 `await`, dynamic `import()` of internal paths, `eval`, and `with`.
 A2 in particular is enforced by `find_top_level_await` —
@@ -946,7 +967,9 @@ purity is author-trusted) is satisfied by spec review — every
 `purity: "pure"` annotation is an explicit, reviewable trust
 claim. A10 (declared local effects) is likewise satisfied by spec
 review, with analyzer shape checks limiting the trusted surface to
-the admitted helper-call forms.
+the admitted helper-call forms. A11 (intrinsic integrity) is not
+statically checkable — pollution can originate outside the analyzed
+chunk — and is relied on by observation of the target bundles.
 
 ### Lemmas
 

--- a/devinfra/js/debundle/docs/purity_soundness.md
+++ b/devinfra/js/debundle/docs/purity_soundness.md
@@ -36,6 +36,30 @@ setPrototypeOf,assign}` /
   `X` as first arg. Plain-ident writes whose RHS is not a
   plain-literal also disqualify.
 
+- **No escaping references.** The write scan above is name-based: it
+  only catches mutations spelled through the candidate's own
+  identifier. An alias (`const Y = X; Object.defineProperty(Y, …)`)
+  or any captured reference (call argument, array element, object
+  property value) would defeat it, so the scan also treats every
+  bare candidate `Ident` outside a short list of provably
+  non-capturing read positions (member receiver, spread source,
+  `typeof`/`!`/`void` operand, `Object.{keys,values,entries,freeze,
+fromEntries}` single argument with `Object` unshadowed, the vetted
+  TS-enum-IIFE argument, `return X` / `() => X`, `export { X }`) as
+  an escape and disqualifies the candidate.
+
+  **Residual assumption for `return X` / `export { X }`:** consumers
+  of a returned or exported PlainData reference (chunk-internal
+  callers of the returning function; importers of the exported
+  binding in other modules of the same debundle) are assumed not to
+  install accessors on it. For exports this is the same single-bundle
+  closed-world view the rest of the analysis takes; for returns it
+  admits the ubiquitous accessor pattern `const get = () => CONFIG;`
+  without a whole-program escape analysis. A consumer calling
+  `Object.defineProperty` on the received reference would break the
+  read-purity claim — the same way a chunk-external mutation already
+  could (the scan only ever sees one chunk).
+
 - **Re-bind soundness for `let`.** Reads on `X` after a re-bind see
   the new plain-literal value; reads before still saw the old
   plain-literal value. At no program point does `X` hold an

--- a/devinfra/js/debundle/e2e/purity_test.rs
+++ b/devinfra/js/debundle/e2e/purity_test.rs
@@ -141,12 +141,14 @@ export { userSchema, productSchema, orderSchema };
 }
 
 #[test]
-#[ignore = "blocked on Expr::New whitelist with per-constructor arg-shape gate \
-            (Step E in the purity-desiderata follow-up plan)"]
+#[ignore = "blocked on a RegExp entry in the Expr::New whitelist: Set/Map array-literal \
+            forms landed (PURE_BUILTIN_NEW_ARRAY_ITERABLE; see the new_map / new_set / \
+            new_map_with_array_of_pure_pairs tests below), but `new RegExp(\"a+\")` still \
+            classifies UnknownNew"]
 fn inferred_pure_collection_constructors_with_literal_args_emit_no_s_cycle() {
     // `new Set([...])`, `new Map([...])`, `new RegExp("...")` with
-    // literal-only args are pure by built-in catalogue. The
-    // current classifier marks all `Expr::New` as `Unknown`.
+    // literal-only args are pure by built-in catalogue. Set/Map
+    // are handled; RegExp is the remaining blocker.
     let fixture = run_fixture(FixtureOpts::new(
         r#"const tagsA = new Set(["alpha", "beta"]);
 const tagsB = new Set(["gamma"]);
@@ -257,13 +259,18 @@ export { A, B, C };
 
 #[test]
 fn inferred_pure_recursive_function_classified_pure() {
-    // Mutually recursive pure functions: `even(n)` calls
-    // `odd(n - 1)`; `odd(n)` calls `even(n - 1)`. Recursive
-    // analysis must terminate (memoize per-function visit
-    // status) and conclude both pure.
+    // Mutually recursive pure functions: `even` calls `odd` and
+    // vice versa. Recursive analysis must terminate (memoize
+    // per-function visit status) and conclude both pure. The
+    // decrement goes through `prev` (literal-equality ternaries)
+    // rather than `n - 1`: arithmetic on an opaque param is a
+    // coercing operator on a possibly-object operand and
+    // classifies NotPure by design — this test pins recursion
+    // termination, not arithmetic.
     let fixture = run_fixture(FixtureOpts::new(
-        r#"function even(n) { return n === 0 ? true : odd(n - 1); }
-function odd(n) { return n === 0 ? false : even(n - 1); }
+        r#"function prev(n) { return n === 4 ? 3 : n === 3 ? 2 : n === 2 ? 1 : 0; }
+function even(n) { return n === 0 ? true : odd(prev(n)); }
+function odd(n) { return n === 0 ? false : even(prev(n)); }
 const fourEven = even(4);
 const fiveOdd = odd(5);
 console.log(fourEven, fiveOdd);
@@ -348,6 +355,54 @@ const a1 = caller("a1");
 const b1 = caller("b1");
 const a2 = caller("a2");
 console.log(a1.label, b1.label, a2.label, globalThis.touched);
+export { a1, a2, b1 };
+"#,
+            vec![
+                logical_module("mod_a", &[Member::new("a1"), Member::new("a2")]),
+                logical_module("mod_b", &[Member::new("b1")]),
+            ],
+        ),
+        &["cycle", "mod_a", "mod_b", "side-effect"],
+    );
+}
+
+#[test]
+fn coercing_operator_on_opaque_operand_still_emits_s_edges() {
+    // SOUNDNESS: `obj + 1` runs ToPrimitive on `obj` — a user
+    // `valueOf` can fire arbitrary code, so the statements stay
+    // side-effecting and the interleaved modules still close an
+    // S cycle the gate must reject. Pins the coercing-operator
+    // gate at the pipeline level (the classifier previously
+    // admitted `A + 1` as pure).
+    expect_rejection_containing_all(
+        FixtureOpts::new(
+            r#"const a1 = obj + 1;
+const b1 = obj + 2;
+const a2 = obj + 3;
+console.log(a1, b1, a2);
+export { a1, a2, b1 };
+"#,
+            vec![
+                logical_module("mod_a", &[Member::new("a1"), Member::new("a2")]),
+                logical_module("mod_b", &[Member::new("b1")]),
+            ],
+        ),
+        &["cycle", "mod_a", "mod_b", "side-effect"],
+    );
+}
+
+#[test]
+fn destructuring_declarators_still_emit_s_edges() {
+    // SOUNDNESS: `const { a1 } = src` fires `src`'s getters at
+    // declaration time — the statements stay side-effecting and
+    // interleaved modules close an S cycle the gate must reject.
+    expect_rejection_containing_all(
+        FixtureOpts::new(
+            r#"const src = make();
+const { a1 } = src;
+const { b1 } = src;
+const { a2 } = src;
+console.log(a1, b1, a2);
 export { a1, a2, b1 };
 "#,
             vec![

--- a/devinfra/js/debundle/facts/mod.rs
+++ b/devinfra/js/debundle/facts/mod.rs
@@ -21,7 +21,7 @@ use swc_ecma_visit::{Visit, VisitWith};
 use crate::analysis_hints::{AnalysisHints, KnownEffect, LocalEffectPolicy};
 use crate::purity::{
     ChunkCodeGraph, Purity, PurityReason, PurityRule, RedundantPureMemberHint, RedundantPurityHint,
-    WHITELIST_RECEIVERS, class_has_static_observable, classify_expr_purity,
+    SHADOW_TRACKED_GLOBALS, class_has_static_observable, classify_expr_purity,
     classify_var_decl_purity, detect_redundant_pure_member_hints, detect_redundant_purity_hints,
 };
 use crate::{SourceLocation, StatementOrdinal};
@@ -492,19 +492,23 @@ pub(crate) fn top_level_item_views(body: &[ModuleItem]) -> Vec<TopLevelItemView<
     out
 }
 
-/// Walk `body` and collect the subset of `WHITELIST_RECEIVERS`
-/// that are declared at the chunk's top-level scope (`var/let/const`,
+/// Walk `body` and collect the subset of `SHADOW_TRACKED_GLOBALS`
+/// (the union of every global name any purity-whitelist table keys
+/// on — receivers like `Math`/`Object`, global callables like
+/// `Boolean`/`Symbol`, pure-new builtins like `Map`/`Set`) that are
+/// declared at the chunk's top-level scope (`var/let/const`,
 /// `function`, `class`, exported decls) or bound by an import
 /// specifier (default / namespace / named). The classifier consults
-/// this set to skip the whitelist for any receiver the chunk
-/// shadows — `const Math = …` and
-/// `import { Math } from "./userland"` both make `Math.PI` an
-/// Unknown read, not the global constant. See docs/design.md A8.
+/// this set to skip the whitelist for any name the chunk shadows —
+/// `const Math = …` and `import { Math } from "./userland"` both
+/// make `Math.PI` an Unknown read, and `const Map = class { … }`
+/// makes `new Map()` an Unknown construction, not the built-in.
+/// See docs/design.md A8.
 pub(crate) fn compute_shadowed_globals(body: &[TopLevelItemView<'_>]) -> BTreeSet<&'static str> {
     let mut shadowed = BTreeSet::new();
     let try_shadow = |name: &str, into: &mut BTreeSet<&'static str>| {
-        if let Some(global) = WHITELIST_RECEIVERS.iter().copied().find(|r| *r == name) {
-            into.insert(global);
+        if let Some(global) = SHADOW_TRACKED_GLOBALS.get(name) {
+            into.insert(*global);
         }
     };
     for item in body {

--- a/devinfra/js/debundle/peel/factorize_tests.rs
+++ b/devinfra/js/debundle/peel/factorize_tests.rs
@@ -562,7 +562,11 @@ fn pure_const_decl_is_not_side_effecting() {
     assert_eq!(has_side_effect_for("const X = { a: 1 };"), vec![false]);
     assert_eq!(has_side_effect_for("const X = [1, 2, 3];"), vec![false]);
     assert_eq!(has_side_effect_for("const X = OTHER;"), vec![false]);
-    assert_eq!(has_side_effect_for("const X = A + B;"), vec![false]);
+    assert_eq!(has_side_effect_for("const X = 1 + 2;"), vec![false]);
+    // `A + B` on opaque Idents runs ToPrimitive — possible user
+    // `valueOf` — and is side-effecting under the coercing-operator
+    // gate (see purity classifier_tests).
+    assert_eq!(has_side_effect_for("const X = A + B;"), vec![true]);
 }
 
 #[test]

--- a/devinfra/js/debundle/purity/classifier_tests.rs
+++ b/devinfra/js/debundle/purity/classifier_tests.rs
@@ -146,9 +146,62 @@ fn classify_pure_unary_and_binary() {
     assert!((classify("-1")).is_pure());
     assert!((classify("!FOO")).is_pure());
     assert!((classify("typeof FOO")).is_pure());
-    assert!((classify("A + 1")).is_pure());
+    assert!((classify("void FOO")).is_pure());
     assert!((classify("A && B")).is_pure());
+    assert!((classify("A || B")).is_pure());
+    assert!((classify("A ?? B")).is_pure());
+    assert!((classify("A === B")).is_pure());
+    assert!((classify("A !== B")).is_pure());
     assert!((classify("A ? B : C")).is_pure());
+    // Coercing operators on statically-primitive operands stay
+    // pure: the engine's ToPrimitive of a primitive runs no user
+    // code. Nested coercing results are themselves primitive.
+    assert!((classify("1 + 2")).is_pure());
+    assert!((classify("'a' + 1")).is_pure());
+    assert!((classify("1 + 2 + 3")).is_pure());
+    assert!((classify("1e3 * 60 * 60")).is_pure());
+    assert!((classify("-(1 + 2)")).is_pure());
+    assert!((classify("~0")).is_pure());
+    assert!((classify("(typeof A) + '!'")).is_pure());
+    assert!((classify("(A === B) | 0")).is_pure());
+}
+
+#[test]
+fn classify_coercing_operators_on_possibly_object_operands_are_not_pure() {
+    // SOUNDNESS: ToPrimitive / ToNumber / ToString on an object
+    // operand fires user `valueOf` / `toString` /
+    // `[Symbol.toPrimitive]`. An opaque Ident can hold an object,
+    // so coercing operators only classify pure when every coerced
+    // operand is statically primitive-valued. (`A + 1` was
+    // previously pinned pure — deliberate conservative shift.)
+    assert!(!(classify("A + 1")).is_pure());
+    assert!(!(classify("A - 1")).is_pure());
+    assert!(!(classify("A * B")).is_pure());
+    assert!(!(classify("A < 10")).is_pure());
+    assert!(!(classify("A >= B")).is_pure());
+    assert!(!(classify("A == null")).is_pure());
+    assert!(!(classify("A != B")).is_pure());
+    assert!(!(classify("A & 1")).is_pure());
+    assert!(!(classify("A << 2")).is_pure());
+    assert!(!(classify("+A")).is_pure());
+    assert!(!(classify("-A")).is_pure());
+    assert!(!(classify("~A")).is_pure());
+    // The shadowable global `undefined` is an ordinary binding the
+    // shadow pass doesn't track — deliberately NOT admitted as a
+    // primitive operand.
+    assert!(!(classify("A == undefined")).is_pure());
+    assert!(!(classify("undefined + 1")).is_pure());
+}
+
+#[test]
+fn classify_in_and_instanceof_are_not_pure() {
+    // `in` fires the proxy `has` trap on its RHS; `instanceof`
+    // fires `@@hasInstance` / reads `.prototype` on its RHS. The
+    // interesting RHS is always an object, so no primitive-operand
+    // gate can admit these.
+    assert!(!(classify("'k' in o")).is_pure());
+    assert!(!(classify("x instanceof C")).is_pure());
+    assert!(!(classify("'k' in { k: 1 }")).is_pure());
 }
 
 #[test]
@@ -179,7 +232,13 @@ fn classify_member_access_is_unknown() {
 #[test]
 fn classify_object_literal_pure_when_props_pure() {
     assert!((classify("({ a: 1, b: 'x' })")).is_pure());
-    assert!((classify("({ [k]: 1 })")).is_pure());
+    // Computed keys run ToPropertyKey on the key VALUE — an opaque
+    // Ident can hold an object whose `toString` fires. Pure only
+    // for statically-primitive keys and well-known symbols.
+    assert!((classify("({ ['k']: 1 })")).is_pure());
+    assert!((classify("({ [1 + 2]: 1 })")).is_pure());
+    assert!((classify("({ [Symbol.iterator]: 1 })")).is_pure());
+    assert!(!(classify("({ [k]: 1 })")).is_pure());
     // Computed key with member access — getter could fire.
     assert!(!(classify("({ [k.x]: 1 })")).is_pure());
     // Spread of an arbitrary expr — iterator could fire.
@@ -230,8 +289,14 @@ fn classify_class_expr_pure_without_static_init() {
 }
 
 #[test]
-fn classify_template_with_pure_exprs_is_pure() {
-    assert!((classify("`a${A}b${1+2}c`")).is_pure());
+fn classify_template_interpolation_requires_primitive_values() {
+    // Interpolation runs ToString on the value — pure only when
+    // the interpolated expression is statically primitive-valued.
+    assert!((classify("`a${1 + 2}b${'x'}c`")).is_pure());
+    assert!((classify("`a${`inner${1}`}b`")).is_pure());
+    assert!((classify("`a${typeof A}b`")).is_pure());
+    // An opaque Ident can hold an object whose `toString` fires.
+    assert!(!(classify("`a${A}b`")).is_pure());
     assert!(!(classify("`a${foo()}`")).is_pure());
 }
 
@@ -295,32 +360,51 @@ fn whitelist_static_calls_unknown_arg_infects() {
 // --- PURE_STATIC_FUNCTION_REFS: read-vs-call distinction ---------------
 
 #[test]
-fn static_function_ref_object_aliases_are_pure() {
+fn static_function_ref_aliases_are_pure() {
     // Bare member READS access own data properties of the
-    // built-in `Object` per ECMA-262 §20.1.2 — no getter
-    // fires, no observable side effect. Aliasing the function
-    // value into a binding stays pure (the value isn't called).
-    assert!((classify("Object.defineProperty")).is_pure());
-    assert!((classify("Object.freeze")).is_pure());
-    assert!((classify("Object.values")).is_pure());
-    assert!((classify("Object.keys")).is_pure());
+    // built-in receiver per ECMA-262 — no getter fires, no
+    // observable side effect. Aliasing the function value into a
+    // binding stays pure (the value isn't called). Table-driven
+    // over the whole whitelist so every entry (current and
+    // future) carries its positive direction.
+    for &(recv, prop) in PURE_STATIC_FUNCTION_REFS {
+        let src = format!("{recv}.{prop}");
+        assert!(
+            classify(&src).is_pure(),
+            "expected function-ref read `{src}` to classify Pure"
+        );
+    }
 }
 
 #[test]
-fn static_function_ref_object_calls_remain_unknown() {
+fn static_function_ref_calls_remain_unknown() {
     // The CALL form of each function-ref entry is unsafe on
     // arbitrary args (see `PURE_STATIC_FUNCTION_REFS`
     // doc-comment for why each is excluded from
     // `PURE_STATIC_CALLS`). The function-ref entry only opens
-    // the read path; the general call must stay Unknown so the
-    // soundness contract holds.
+    // the read path; the general (opaque-binding-arg) call must
+    // stay Unknown so the soundness contract holds. Table-driven
+    // over the whole whitelist; entries that are also in
+    // `PURE_STATIC_CALLS` (currently `Object.is`) are call-pure
+    // by their own admission contract and skipped here.
     //
     // Note: a subset of these calls (`Object.{keys, values,
     // entries, freeze, fromEntries}`) becomes Pure when called
     // with a syntactically plain-data argument — pinned in the
-    // `object_*` tests below. The negatives here use opaque
-    // bindings / non-literal expressions that fall outside that
-    // narrow shape, so they still classify Unknown.
+    // `object_*` tests below. The opaque-Ident args used here
+    // fall outside that narrow shape.
+    for &(recv, prop) in PURE_STATIC_FUNCTION_REFS {
+        if PURE_STATIC_CALLS.contains(&(recv, prop)) {
+            continue;
+        }
+        let src = format!("{recv}.{prop}(o, p)");
+        assert!(
+            !classify(&src).is_pure(),
+            "expected function-ref CALL `{src}` to stay Unknown"
+        );
+    }
+    // Representative shapes with literal extra args, pinning that
+    // arg purity alone never admits the call.
     assert!(!(classify("Object.defineProperty(t, 'k', { value: 1 })")).is_pure());
     assert!(!(classify("Object.freeze(o)")).is_pure());
     assert!(!(classify("Object.values(o)")).is_pure());
@@ -455,6 +539,126 @@ fn import_specifier_locals_shadow_whitelist() {
         ))
         .is_pure()
     );
+}
+
+// --- Whitelist: shadow tracking covers every table -----------------------
+
+#[test]
+fn unshadowed_builtin_new_is_pure() {
+    // Positive control for the shadow-tracking fix: with no
+    // chunk-top rebind, the `new <Container>()` whitelists fire.
+    assert!((classify("new Map()")).is_pure());
+    assert!((classify("new Set()")).is_pure());
+    assert!((classify("new Set(['a', 'b'])")).is_pure());
+}
+
+#[test]
+fn shadowed_builtin_new_falls_back_to_unknown() {
+    // SOUNDNESS: `compute_shadowed_globals` must track every name
+    // any whitelist table keys on (SHADOW_TRACKED_GLOBALS — the
+    // derived union), not just WHITELIST_RECEIVERS. A chunk-top
+    // `const Map = class { … }` rebinds the name; `new Map()` then
+    // constructs the user class, which can run arbitrary code.
+    assert!(
+        !(classify_with_module(
+            "const Map = class { constructor() { globalThis.boom = 1; } };",
+            "new Map()"
+        ))
+        .is_pure()
+    );
+    assert!(!(classify_with_module("function Set() {}", "new Set()")).is_pure());
+    assert!(
+        !(classify_with_module(
+            r#"import { Map } from "./userland.js";"#,
+            "new Map([['k', 1]])"
+        ))
+        .is_pure()
+    );
+    // Shadowed global callables fall back the same way.
+    assert!(!(classify_with_module("const Symbol = userland;", "Symbol('x')")).is_pure());
+}
+
+// --- Class definition eager-evaluation effects ---------------------------
+
+#[test]
+fn classify_class_extends_expr_effects_propagate() {
+    // `extends <expr>` evaluates at class-definition time.
+    assert!(!(classify("class extends io() {}")).is_pure());
+    // A plain Ident superclass is admitted (reading `.prototype`
+    // off an ordinary constructor fires no user code; A11 covers
+    // the exotic-object case).
+    assert!((classify("class extends B {}")).is_pure());
+}
+
+#[test]
+fn classify_class_computed_keys_require_safe_primitive_keys() {
+    // Computed member keys evaluate eagerly AND run ToPropertyKey
+    // on the value — any member kind, static or not.
+    assert!(!(classify("class { [io()]() {} }")).is_pure());
+    assert!(!(classify("class { [k]() {} }")).is_pure());
+    assert!(!(classify("class { [k] = 1; }")).is_pure());
+    assert!(!(classify("class { static [k] = 1; }")).is_pure());
+    // Primitive and well-known-symbol keys are safe.
+    assert!((classify("class { ['m']() {} }")).is_pure());
+    assert!((classify("class { [Symbol.iterator]() {} }")).is_pure());
+    assert!((classify("class { ['x'] = io(); }")).is_pure()); // instance init is lazy
+}
+
+/// Parse a single class declaration with decorators /
+/// auto-accessors enabled and run `class_has_static_observable`
+/// on it with empty shadow/annotation context.
+fn class_observable(src: &str) -> bool {
+    let cm: Lrc<swc_common::SourceMap> = Default::default();
+    let fm = cm.new_source_file(FileName::Custom("test.js".into()).into(), src.to_string());
+    let lexer = Lexer::new(
+        Syntax::Es(swc_ecma_parser::EsSyntax {
+            decorators: true,
+            auto_accessors: true,
+            ..Default::default()
+        }),
+        Default::default(),
+        StringInput::from(&*fm),
+        None,
+    );
+    let module = Parser::new_from(lexer).parse_module().unwrap();
+    let class = module
+        .body
+        .iter()
+        .find_map(|item| match item {
+            ModuleItem::Stmt(Stmt::Decl(Decl::Class(cls))) => Some(&cls.class),
+            _ => None,
+        })
+        .expect("expected a class declaration");
+    class_has_static_observable(
+        class,
+        &BTreeSet::new(),
+        &BTreeSet::new(),
+        &BTreeSet::new(),
+        &ChunkCodeGraph::default(),
+    )
+}
+
+#[test]
+fn class_decorators_are_observable() {
+    // Decorator application CALLS the decorator function at
+    // class-definition time — any decorator (class-level or
+    // member-level) is observable.
+    assert!(class_observable("@dec class C {}"));
+    assert!(class_observable("class C { @dec m() {} }"));
+    assert!(class_observable("class C { @dec x = 1; }"));
+    assert!(class_observable("class C { @dec accessor x = 1; }"));
+    // Positive control: same members without decorators.
+    assert!(!class_observable("class C { m() {} x = 1; }"));
+}
+
+#[test]
+fn class_static_auto_accessor_initializer_is_observable() {
+    // `static accessor x = <expr>` runs the initializer at
+    // class-definition time, like a static field.
+    assert!(class_observable("class C { static accessor x = io(); }"));
+    assert!(!class_observable("class C { static accessor x = 1; }"));
+    // Instance auto-accessor initializers are lazy.
+    assert!(!class_observable("class C { accessor x = io(); }"));
 }
 
 // --- Declared purity (spec annotation) ---------------------------------

--- a/devinfra/js/debundle/purity/graph_purity_tests.rs
+++ b/devinfra/js/debundle/purity/graph_purity_tests.rs
@@ -98,13 +98,28 @@ fn fn_purity_propagates_transitive_impurity() {
 fn fn_purity_mutual_recursion_converges_pure() {
     // `even` and `odd` only reference each other inside their
     // bodies. Optimistic init (Pure) holds through the
-    // fixed-point — neither body has an impure operation.
+    // fixed-point — neither body has an impure operation. (The
+    // recursion argument is passed through unchanged: `n - 1`
+    // would be a coercing operator on a possibly-object operand,
+    // which classifies NotPure by design — this test pins
+    // fixed-point convergence, not arithmetic.)
     let src = r#"
-    function even(n) { return n === 0 ? true : odd(n - 1); }
-    function odd(n) { return n === 0 ? false : even(n - 1); }
+    function even(n) { return n === 0 ? true : odd(n); }
+    function odd(n) { return n === 0 ? false : even(n); }
 "#;
     assert_eq!(fn_purity(src, "even"), Some(true));
     assert_eq!(fn_purity(src, "odd"), Some(true));
+}
+
+#[test]
+fn fn_purity_param_arithmetic_is_not_pure() {
+    // SOUNDNESS: `n - 1` runs ToNumeric on `n`; a caller can pass
+    // an object whose `valueOf` fires arbitrary code, so a body
+    // coercing an opaque param is not pure-callable.
+    assert_eq!(
+        fn_purity("function dec(n) { return n - 1; }", "dec"),
+        Some(false)
+    );
 }
 
 #[test]
@@ -768,7 +783,10 @@ fn plain_data_let_with_plain_literal_replacement_is_tracked() {
     const getEnv = (k) => envConfig[k];
 "#;
     assert!(is_plain_data(src, "envConfig"));
-    assert_eq!(fn_purity(src, "getEnv"), Some(true));
+    // `getEnv` is no longer inferred pure: `envConfig[k]` runs
+    // ToPropertyKey on the opaque key `k` (user `toString` on an
+    // object key) — see `plain_data_computed_read_with_opaque_key_is_not_pure`.
+    assert_eq!(fn_purity(src, "getEnv"), Some(false));
 }
 
 #[test]
@@ -838,13 +856,13 @@ fn plain_data_let_chain_collapses_env_config_walkthrough_shape() {
     //       (mr.FUNCTIONS_EMULATOR ? true : getEnv("REACT_APP_ENV") === "emulator");
     //   const getSystemConfig = () => envConfig;
     //
-    // Today (pre-this-extension) the spec author needed
-    // `purity: pure` hints on `getEnv` / `isEmulatorEnv` /
-    // `getSystemConfig` in
-    // `runtime/environment/{env_config,config}.yaml` because
-    // `envConfig` was `let` and member access on it flagged
-    // `unknown_member`. With the let+mutator extension every
-    // helper in the chain classifies pure with zero hints.
+    // The let+mutator extension keeps `envConfig` PlainData and
+    // static-prop readers pure. The opaque-key accessor `getEnv`
+    // (and its transitive caller `isEmulatorEnv`) are NOT inferred
+    // pure under the ToPropertyKey gate — `envConfig[n]` coerces an
+    // opaque key — so those two still need `purity: pure` hints in
+    // `runtime/environment/{env_config,config}.yaml` when the spec
+    // author wants their call sites S-edge-free.
     let src = r#"
     const mr = { FUNCTIONS_EMULATOR: false };
     let envConfig = {
@@ -861,8 +879,8 @@ fn plain_data_let_chain_collapses_env_config_walkthrough_shape() {
 "#;
     assert!(is_plain_data(src, "envConfig"));
     assert!(is_plain_data(src, "mr"));
-    assert_eq!(fn_purity(src, "getEnv"), Some(true));
-    assert_eq!(fn_purity(src, "isEmulatorEnv"), Some(true));
+    assert_eq!(fn_purity(src, "getEnv"), Some(false));
+    assert_eq!(fn_purity(src, "isEmulatorEnv"), Some(false));
     assert_eq!(fn_purity(src, "getSystemConfig"), Some(true));
     // `applySystemConfigOverrides` itself is impure (it writes
     // to envConfig); call sites still need to anchor it via
@@ -981,24 +999,36 @@ fn plain_data_disqualified_by_define_property_call() {
 }
 
 #[test]
-fn plain_data_read_through_chunk_local_helper_collapses_chain() {
-    // The flagship case from the recursive-purity proposal: a
-    // chunk-local `const TA = { ... }` data shape and a helper
-    // `const Me = (n) => TA[n]` that reads a key on it. Today
-    // (pre-PlainData), `TA[n]` flags `unknown_member` and `Me`
-    // classifies impure — so any call `Me("FOO")` cascades to
-    // impure and any owner statement containing it picks up a
-    // spurious `S`-edge. With PlainData tracking, `TA[n]` is
-    // pure (key `n` is a pure Ident; receiver is PlainData) →
-    // `Me` is pure → `Me("FOO")` is pure → the call site's
-    // surrounding statement classifies pure with zero
-    // `purity: pure` hints.
+fn plain_data_computed_read_with_opaque_key_is_not_pure() {
+    // SOUNDNESS (ToPropertyKey): `TA[n]` runs ToPropertyKey on the
+    // key VALUE before the (accessor-free) lookup on the PlainData
+    // receiver. A caller can pass an object `n` whose `toString`
+    // fires arbitrary code, so the accessor body is NOT
+    // pure-callable even though the receiver is PlainData.
+    // (This deliberately re-restricts the earlier
+    // `Me = (n) => TA[n]` flagship shape; recovering it needs a
+    // primitive-args-at-callsite gate or a `purity: pure` hint.)
     let src = r#"
     const TA = { FOO: "bar", BAZ: "qux" };
     const Me = (n) => TA[n];
 "#;
     assert!(is_plain_data(src, "TA"));
-    assert_eq!(fn_purity(src, "Me"), Some(true));
+    assert_eq!(fn_purity(src, "Me"), Some(false));
+}
+
+#[test]
+fn plain_data_computed_read_with_primitive_key_is_pure() {
+    // Positive direction for the ToPropertyKey gate: statically
+    // primitive keys (literals, well-known symbols) keep the
+    // PlainData computed read pure.
+    let src = r#"
+    const TA = { FOO: "bar", BAZ: "qux" };
+    const readFoo = () => TA["FOO"];
+    const readZero = () => TA[0];
+"#;
+    assert!(is_plain_data(src, "TA"));
+    assert_eq!(fn_purity(src, "readFoo"), Some(true));
+    assert_eq!(fn_purity(src, "readZero"), Some(true));
 }
 
 #[test]
@@ -1021,12 +1051,14 @@ fn plain_data_chain_collapses_size_33_walkthrough_shape() {
     // `(internal purity research notes)`: a config
     // table `TA`, an accessor `Me`, an env-derived predicate
     // `$i`, and a top-level binding `gF` whose init is an
-    // object literal whose values are calls to `Me`. Today the
-    // peel author has to add four `purity: pure` hints (Me,
-    // $i, vR, Oge) to flip the cycle. With recursive purity
-    // via PlainData, every helper in the chain classifies
-    // pure with no hints — `gF`'s owner statement reclassifies
-    // pure on its own.
+    // object literal whose values are calls to `Me`.
+    //
+    // Under the ToPropertyKey gate, the opaque-key accessor
+    // `Me = (n) => TA[n]` is NOT inferred pure (an object key
+    // fires user `toString`), so the inference-only collapse of
+    // this chain no longer happens — the spec author keeps the
+    // `purity: pure` hint on `Me` (one hint instead of four:
+    // hint-pure `Me` lets `$i` / `vR` / `Oge` infer pure).
     let src = r#"
     const TA = { ENV: "emulator", KEY: "x" };
     const mr = { FUNCTIONS_EMULATOR: false };
@@ -1035,13 +1067,13 @@ fn plain_data_chain_collapses_size_33_walkthrough_shape() {
     const vR = (x) => Me(x);
     const Oge = () => vR("KEY");
 "#;
-    assert_eq!(fn_purity(src, "Me"), Some(true));
-    assert_eq!(fn_purity(src, "$i"), Some(true));
-    assert_eq!(fn_purity(src, "vR"), Some(true));
-    assert_eq!(fn_purity(src, "Oge"), Some(true));
-    // And the top-level `const gF = { apiKey: Me("KEY"), ... }`
-    // owner statement reclassifies pure: every value is a call
-    // to a now-pure chunk-local helper.
+    assert_eq!(fn_purity(src, "Me"), Some(false));
+    assert_eq!(fn_purity(src, "$i"), Some(false));
+    assert_eq!(fn_purity(src, "vR"), Some(false));
+    assert_eq!(fn_purity(src, "Oge"), Some(false));
+    // With a single `purity: pure` hint on `Me`, the rest of the
+    // chain (and the `gF` owner statement) infers pure.
+    let hinted: BTreeSet<String> = BTreeSet::from(["Me".to_string()]);
     let full = format!(
         r#"
     {src}
@@ -1049,14 +1081,20 @@ fn plain_data_chain_collapses_size_33_walkthrough_shape() {
 "#
     );
     let module = parse(&full);
-    let facts = analyze_facts(&module);
+    let facts = analyze_chunk(
+        &module,
+        &AnalysisHints::from_declared_pure(&hinted),
+        None,
+        |_| None,
+    )
+    .facts;
     let gf_fact = facts
         .iter()
         .find(|f| f.declared.contains(&test_id("gF")))
         .expect("gF fact missing from chunk analysis");
     assert!(
         gf_fact.purity.is_pure(),
-        "gF should classify pure with recursive purity, got {:?}",
+        "gF should classify pure with a single hint on Me, got {:?}",
         gf_fact.purity,
     );
 }
@@ -1175,4 +1213,273 @@ fn fn_purity_mutual_recursion_with_external_impure_callee() {
     assert_eq!(fn_purity(src, "c"), Some(false));
     assert_eq!(fn_purity(src, "a"), Some(false));
     assert_eq!(fn_purity(src, "b"), Some(false));
+}
+
+// --- Body-level shadowing of global tables / chunk graph / annotations --
+
+/// `fn_purity` with an explicit declared-pure set.
+fn fn_purity_with_declared_pure(src: &str, name: &str, declared: &[&str]) -> Option<bool> {
+    let module = parse(src);
+    let body = top_level_item_views(&module.body);
+    let shadowed = compute_shadowed_globals(&body);
+    let declared_pure: BTreeSet<String> = declared.iter().map(|s| (*s).to_string()).collect();
+    let graph = ChunkCodeGraph::build(&body, &shadowed, &declared_pure);
+    graph.function_purity(name).map(|p| p.is_pure())
+}
+
+#[test]
+fn body_shadowed_chunk_function_call_is_not_pure() {
+    // SOUNDNESS: inside `outer`, the param `helper` shadows the
+    // chunk-top pure function of the same name — the called value
+    // is whatever the caller passed.
+    let src = r#"
+    function helper() { return 1; }
+    function outer(helper) { return helper(); }
+    function control() { return helper(); }
+"#;
+    assert_eq!(fn_purity(src, "outer"), Some(false));
+    assert_eq!(fn_purity(src, "control"), Some(true));
+}
+
+#[test]
+fn body_shadowed_whitelist_receiver_is_not_pure() {
+    // SOUNDNESS: a param named `Math` shadows the global inside
+    // the body; `Math.PI` there reads a user object (getter risk).
+    let src = r#"
+    function f(Math) { return Math.PI; }
+    function g() { return Math.PI; }
+    function h(Array) { return Array.isArray([]); }
+"#;
+    assert_eq!(fn_purity(src, "f"), Some(false));
+    assert_eq!(fn_purity(src, "g"), Some(true));
+    assert_eq!(fn_purity(src, "h"), Some(false));
+}
+
+#[test]
+fn body_shadowed_builtin_new_is_not_pure() {
+    // SOUNDNESS: a param named `Map` shadows the builtin; `new
+    // Map()` constructs the caller-supplied class.
+    let src = r#"
+    function f(Map) { return new Map(); }
+    function g() { return new Map(); }
+"#;
+    assert_eq!(fn_purity(src, "f"), Some(false));
+    assert_eq!(fn_purity(src, "g"), Some(true));
+}
+
+#[test]
+fn body_shadowed_declared_pure_binding_is_not_pure() {
+    // SOUNDNESS: `purity: pure` is a trust contract on the
+    // chunk-top binding `dp`; a param of the same name is a
+    // different value the author never vouched for.
+    let src = r#"
+    function f(dp) { return dp(); }
+    function g() { return dp(); }
+"#;
+    assert_eq!(fn_purity_with_declared_pure(src, "f", &["dp"]), Some(false));
+    assert_eq!(fn_purity_with_declared_pure(src, "g", &["dp"]), Some(true));
+}
+
+#[test]
+fn body_shadowed_pure_member_binding_is_not_pure() {
+    // SOUNDNESS: same for `pure_members` — `b.forwardRef(...)` on
+    // a param `b` is not the annotated vendor namespace.
+    let src = r#"
+    import * as b from "vendor";
+    function f(b) { return b.forwardRef(1); }
+    function g() { return b.forwardRef(1); }
+"#;
+    let module = parse(src);
+    let body = top_level_item_views(&module.body);
+    let shadowed = compute_shadowed_globals(&body);
+    let declared_pure_members: BTreeMap<String, BTreeSet<String>> =
+        BTreeMap::from([("b".to_string(), BTreeSet::from(["forwardRef".to_string()]))]);
+    let graph = ChunkCodeGraph::build_full(
+        &body,
+        &shadowed,
+        &BTreeSet::new(),
+        &BTreeSet::new(),
+        &declared_pure_members,
+    );
+    assert_eq!(graph.function_purity("f").map(|p| p.is_pure()), Some(false));
+    assert_eq!(graph.function_purity("g").map(|p| p.is_pure()), Some(true));
+}
+
+// --- Parameter evaluation (defaults / destructuring) --------------------
+
+#[test]
+fn fn_purity_impure_param_default_makes_function_not_pure() {
+    // Default-value expressions evaluate at call time, exactly
+    // like body code.
+    assert_eq!(
+        fn_purity("const f = (x = (globalThis.boom = 1)) => 1;", "f"),
+        Some(false)
+    );
+    assert_eq!(
+        fn_purity("function g(x = io()) { return 1; }", "g"),
+        Some(false)
+    );
+}
+
+#[test]
+fn fn_purity_pure_param_default_stays_pure() {
+    assert_eq!(fn_purity("const f = (x = 1) => x;", "f"), Some(true));
+    assert_eq!(fn_purity("const g = (x = []) => x;", "g"), Some(true));
+}
+
+#[test]
+fn fn_purity_destructuring_param_makes_function_not_pure() {
+    // Destructuring a parameter fires getters (object pattern) or
+    // the iterator protocol (array pattern) on the argument.
+    assert_eq!(fn_purity("const f = ({ a }) => a;", "f"), Some(false));
+    assert_eq!(fn_purity("const g = ([x]) => x;", "g"), Some(false));
+    assert_eq!(
+        fn_purity("function h({ a } = {}) { return a; }", "h"),
+        Some(false)
+    );
+}
+
+#[test]
+fn fn_purity_rest_param_stays_pure() {
+    // A rest param builds a fresh array from the arguments list —
+    // no user-code path.
+    assert_eq!(fn_purity("const f = (...xs) => xs;", "f"), Some(true));
+}
+
+// --- Iteration statements / destructuring declarators in bodies ---------
+
+#[test]
+fn fn_purity_for_of_makes_function_not_pure() {
+    // for-of fires the iterated value's `[Symbol.iterator]`.
+    assert_eq!(
+        fn_purity("function f(xs) { for (const x of xs) {} return 1; }", "f"),
+        Some(false)
+    );
+}
+
+#[test]
+fn fn_purity_for_in_makes_function_not_pure() {
+    // for-in enumeration fires proxy ownKeys/getOwnPropertyDescriptor
+    // traps on the enumerated value.
+    assert_eq!(
+        fn_purity("function f(o) { for (const k in o) {} return 1; }", "f"),
+        Some(false)
+    );
+}
+
+#[test]
+fn fn_purity_plain_loops_stay_pure() {
+    // Plain `while` / C-style `for` introduce no protocol firing
+    // beyond their (independently classified) sub-expressions.
+    assert_eq!(
+        fn_purity(
+            "function f(flag) { while (flag) { flag = false; } return 1; }",
+            "f"
+        ),
+        Some(false) // the assign is impure — control for the loop itself below
+    );
+    assert_eq!(
+        fn_purity("function g(flag) { while (flag) {} return 1; }", "g"),
+        Some(true)
+    );
+}
+
+#[test]
+fn fn_purity_destructuring_declarator_makes_function_not_pure() {
+    // `const {a} = o` fires o's getters; `const [x] = o` fires the
+    // iterator protocol.
+    assert_eq!(
+        fn_purity("function f(o) { const { a } = o; return a; }", "f"),
+        Some(false)
+    );
+    assert_eq!(
+        fn_purity("function g(o) { const [x] = o; return x; }", "g"),
+        Some(false)
+    );
+    assert_eq!(
+        fn_purity("function h(o) { const a = o; return a; }", "h"),
+        Some(true)
+    );
+}
+
+// --- PlainData escape analysis ------------------------------------------
+
+#[test]
+fn plain_data_alias_escape_disqualifies() {
+    // SOUNDNESS: the write scan is name-based; an alias defeats it
+    // (`Object.defineProperty(Y, …)` would install an accessor the
+    // scan can't see). Escape itself disqualifies.
+    assert!(!is_plain_data("const X = { a: 1 }; const Y = X;", "X"));
+    assert!(!is_plain_data(
+        r#"const X = { a: 1 }; const Y = X; Object.defineProperty(Y, "a", { get: () => io() });"#,
+        "X"
+    ));
+}
+
+#[test]
+fn plain_data_call_arg_escape_disqualifies() {
+    assert!(!is_plain_data("const X = { a: 1 }; f(X);", "X"));
+    assert!(!is_plain_data("const X = { a: 1 }; new Thing(X);", "X"));
+}
+
+#[test]
+fn plain_data_container_value_escape_disqualifies() {
+    assert!(!is_plain_data("const X = { a: 1 }; const arr = [X];", "X"));
+    assert!(!is_plain_data(
+        "const X = { a: 1 }; const o = { x: X };",
+        "X"
+    ));
+    assert!(!is_plain_data("const X = { a: 1 }; const o = { X };", "X"));
+}
+
+#[test]
+fn plain_data_conditional_alias_escape_disqualifies() {
+    // `flag ? X : null` evaluates to X itself — a captured alias.
+    assert!(!is_plain_data(
+        "const X = { a: 1 }; const Y = flag ? X : null;",
+        "X"
+    ));
+    assert!(!is_plain_data(
+        "const X = { a: 1 }; const Y = X || {};",
+        "X"
+    ));
+}
+
+#[test]
+fn plain_data_non_capturing_reads_keep_admission() {
+    // The short list of provably non-capturing positions must NOT
+    // disqualify: member receiver, spread source, typeof/!/void,
+    // Object.keys-style single arg, return / concise arrow body,
+    // export specifier.
+    assert!(is_plain_data("const X = { a: 1 }; const v = X.a;", "X"));
+    assert!(is_plain_data(
+        "const X = { a: 1 }; const Y = { ...X };",
+        "X"
+    ));
+    assert!(is_plain_data("const X = [1]; const Y = [...X];", "X"));
+    assert!(is_plain_data(
+        "const X = { a: 1 }; const t = typeof X;",
+        "X"
+    ));
+    assert!(is_plain_data("const X = { a: 1 }; const b = !X;", "X"));
+    assert!(is_plain_data(
+        "const X = { a: 1 }; const ks = Object.keys(X);",
+        "X"
+    ));
+    assert!(is_plain_data(
+        "const X = { a: 1 }; function f() { return X; }",
+        "X"
+    ));
+    assert!(is_plain_data("const X = { a: 1 }; const f = () => X;", "X"));
+    assert!(is_plain_data("const X = { a: 1 }; export { X };", "X"));
+}
+
+#[test]
+fn plain_data_object_keys_escape_exemption_requires_unshadowed_object() {
+    // With `Object` rebound at chunk top, `Object.keys(X)` calls a
+    // user function — the arg is a real escape.
+    assert!(!is_plain_data(
+        "const userland = 1; const Object = userland; const X = { a: 1 }; const ks = Object.keys(X);",
+        "X"
+    ));
 }

--- a/devinfra/js/debundle/purity/mod.rs
+++ b/devinfra/js/debundle/purity/mod.rs
@@ -1,6 +1,6 @@
 mod whitelists;
 
-pub(crate) use whitelists::WHITELIST_RECEIVERS;
+pub(crate) use whitelists::{SHADOW_TRACKED_GLOBALS, WHITELIST_RECEIVERS};
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -150,7 +150,7 @@ impl ChunkCodeGraph {
         // in the chunk. Function-bound `const` initializers are already
         // tracked as `Function`; this pass only adds non-function
         // plain-data shapes.
-        for name in collect_plain_data_bindings(body) {
+        for name in collect_plain_data_bindings(body, shadowed) {
             // Functions take precedence: a chunk-top `const f = () => ...`
             // is registered as Function and must not be re-registered as
             // PlainData (calling it is the interesting question, not
@@ -436,6 +436,11 @@ impl Visit for CallCollector<'_> {
 #[derive(Debug, Clone)]
 struct ChunkFunction<'a> {
     name: String,
+    /// Parameter patterns. Default-value expressions evaluate at call
+    /// time and destructuring patterns fire getters / the iterator
+    /// protocol on the argument, so they participate in the body's
+    /// purity classification (`classify_param_purity`).
+    params: Vec<&'a Pat>,
     /// Block-bodied function/arrow.
     block_body: Option<&'a BlockStmt>,
     /// Concise-arrow expression body (`(x) => expr`).
@@ -443,17 +448,28 @@ struct ChunkFunction<'a> {
     /// Every binding-ident name introduced by this function — its
     /// params plus every `BindingIdent` declared anywhere in its body
     /// (vars, nested function params, catch bindings, …). Over-approx
-    /// is sound: these names lexically shadow chunk-top PlainData
-    /// candidates so member reads on them must not be admitted as pure.
+    /// is sound: these names lexically shadow chunk-top bindings,
+    /// whitelist receivers, and spec-annotated names, so references
+    /// to them inside the body must not resolve through the global
+    /// tables / chunk graph.
     param_and_body_bindings: BTreeSet<String>,
 }
 
 impl ChunkFunction<'_> {
-    /// Drive a `Visit` visitor over this function's body. Block
+    /// Drive a `Visit` visitor over this function's parameter
+    /// patterns and body. Params are included because default-value
+    /// expressions evaluate at call time exactly like body code —
+    /// both the purity walk (`BodyPurityCollector`) and the
+    /// call-graph walk (`CallCollector`) must see them (a call edge
+    /// hidden in a param default would otherwise skip SCC ordering
+    /// and freeze the callee at its optimistic `Pure` init). Block
     /// bodies recurse via `visit_with`; concise-arrow expression
     /// bodies fire `visit_expr` directly so the visitor's
     /// `visit_call_expr` / `visit_expr` overrides catch the body.
     fn visit_body_with<V: Visit + ?Sized>(&self, visitor: &mut V) {
+        for pat in &self.params {
+            pat.visit_with(visitor);
+        }
         if let Some(block) = self.block_body {
             block.visit_with(visitor);
         }
@@ -525,6 +541,7 @@ fn push_fn_decl<'a>(fn_decl: &'a FnDecl, out: &mut Vec<ChunkFunction<'a>>) {
     let block_body = fn_decl.function.body.as_ref();
     out.push(ChunkFunction {
         name: fn_decl.ident.sym.to_string(),
+        params: fn_decl.function.params.iter().map(|p| &p.pat).collect(),
         block_body,
         expr_body: None,
         param_and_body_bindings: collect_function_bindings(
@@ -557,6 +574,7 @@ fn push_var_functions<'a>(var: &'a VarDecl, out: &mut Vec<ChunkFunction<'a>>) {
                 let block_body = fn_expr.function.body.as_ref();
                 out.push(ChunkFunction {
                     name,
+                    params: fn_expr.function.params.iter().map(|p| &p.pat).collect(),
                     block_body,
                     expr_body: None,
                     param_and_body_bindings: collect_function_bindings(
@@ -570,6 +588,7 @@ fn push_var_functions<'a>(var: &'a VarDecl, out: &mut Vec<ChunkFunction<'a>>) {
                 BlockStmtOrExpr::BlockStmt(block) => {
                     out.push(ChunkFunction {
                         name,
+                        params: arrow.params.iter().collect(),
                         block_body: Some(block),
                         expr_body: None,
                         param_and_body_bindings: collect_function_bindings(
@@ -582,6 +601,7 @@ fn push_var_functions<'a>(var: &'a VarDecl, out: &mut Vec<ChunkFunction<'a>>) {
                 BlockStmtOrExpr::Expr(expr) => {
                     out.push(ChunkFunction {
                         name,
+                        params: arrow.params.iter().collect(),
                         block_body: None,
                         expr_body: Some(expr.as_ref()),
                         param_and_body_bindings: collect_function_bindings(
@@ -629,7 +649,10 @@ fn push_var_functions<'a>(var: &'a VarDecl, out: &mut Vec<ChunkFunction<'a>>) {
 ///
 /// Returns the list of qualified names; the caller registers them as
 /// `ChunkBinding::PlainData` in the graph.
-fn collect_plain_data_bindings(body: &[TopLevelItemView<'_>]) -> Vec<String> {
+fn collect_plain_data_bindings(
+    body: &[TopLevelItemView<'_>],
+    shadowed: &BTreeSet<&'static str>,
+) -> Vec<String> {
     // Aggregate every chunk-top init expression per binding name.
     // The same name can have multiple inits for `var`-bound bindings
     // (`var X = a; var X = b;`); every init must independently pass
@@ -654,10 +677,23 @@ fn collect_plain_data_bindings(body: &[TopLevelItemView<'_>]) -> Vec<String> {
     }
     // Scan the entire chunk body (including function/class bodies) for
     // anything that could install an accessor or change the prototype
-    // of any candidate: member writes / updates / deletes on `X.k` /
-    // `X[k]`, and `Object.defineProperty(X, ...)` /
-    // `Object.defineProperties(X, ...)` / `Object.setPrototypeOf(X, ...)`
-    // / `Reflect.{defineProperty,defineProperties,setPrototypeOf,set}(X, ...)`.
+    // of any candidate, or let the candidate's object reference ESCAPE
+    // into code we can't analyze:
+    //
+    // * member writes / updates / deletes on `X.k` / `X[k]`;
+    // * calls to the hostile builtins in `PLAIN_DATA_HOSTILE_BUILTINS`
+    //   (`Object.{defineProperty,defineProperties,setPrototypeOf,assign}`,
+    //   `Reflect.{defineProperty,set,setPrototypeOf,deleteProperty}`)
+    //   with `X` as the first argument;
+    // * any *escaping* bare reference to `X` — as a call/new argument,
+    //   array element, object property value, alias RHS (`const Y = X`,
+    //   `obj.k = X`), or any other position not on the scanner's short
+    //   list of provably non-capturing reads (member receiver, spread
+    //   source, `typeof`/`!`/`void` operand, return value / concise
+    //   arrow body). Once the reference is aliased, a write through the
+    //   alias (`Object.defineProperty(Y, …)`) would defeat the
+    //   name-based write scan, so escape itself disqualifies.
+    //
     // Plain data-property writes (`X.foo = bar`) don't install
     // accessors and don't change the prototype chain, but the
     // conservative check rejects them anyway — the cost is dropping
@@ -665,6 +701,7 @@ fn collect_plain_data_bindings(body: &[TopLevelItemView<'_>]) -> Vec<String> {
     // benefit is one short rule that's easy to audit.
     let mut scanner = PlainDataWriteScanner {
         candidates: &candidates,
+        shadowed,
         disqualified: BTreeSet::new(),
         shadowing_scopes: Vec::new(),
     };
@@ -776,7 +813,7 @@ fn is_plain_data_init(expr: &Expr, binding: &str, kind: VarDeclKind) -> bool {
 pub(crate) fn classify_var_decl_purity(
     var: &VarDecl,
     shadowed: &BTreeSet<&'static str>,
-    plain_data_shadowed: &BTreeSet<String>,
+    local_shadowed: &BTreeSet<String>,
     declared_pure: &BTreeSet<String>,
     graph: &ChunkCodeGraph,
 ) -> Purity {
@@ -785,13 +822,25 @@ pub(crate) fn classify_var_decl_purity(
         .filter_map(|decl| {
             let init = decl.init.as_deref()?;
             let Pat::Ident(binding) = &decl.name else {
-                return Some(classify_expr_purity(
+                // Destructuring declarators (`const {a} = o`,
+                // `const [x] = o`) fire getters / the iterator
+                // protocol on the initializer value — user code the
+                // init expression's own classification doesn't see.
+                // Simplest sound rule: any non-Ident pattern makes
+                // the statement not pure, regardless of init shape.
+                // (A fresh-plain-data-literal RHS would be sound to
+                // admit; deliberately not done — the shape is rare
+                // at chunk top and the uniform rule is easier to
+                // audit.)
+                let pattern_purity = param_destructuring_purity(&decl.name)
+                    .unwrap_or_else(|| Purity::from_reason(PurityRule::Other, decl.span));
+                return Some(pattern_purity.worst(classify_expr_purity(
                     init,
                     shadowed,
-                    plain_data_shadowed,
+                    local_shadowed,
                     declared_pure,
                     graph,
-                ));
+                )));
             };
             let name = binding.id.sym.as_ref();
             if var.kind == VarDeclKind::Var
@@ -803,7 +852,7 @@ pub(crate) fn classify_var_decl_purity(
                 Some(classify_expr_purity(
                     init,
                     shadowed,
-                    plain_data_shadowed,
+                    local_shadowed,
                     declared_pure,
                     graph,
                 ))
@@ -883,6 +932,14 @@ fn is_ts_enum_iife_init_for_binding(expr: &Expr, binding: &str) -> bool {
     let Expr::Call(call) = cur else {
         return false;
     };
+    is_ts_enum_iife_call_for_binding(call, binding)
+}
+
+/// `CallExpr`-level form of `is_ts_enum_iife_init_for_binding`, used
+/// both from the var-init admission and by `PlainDataWriteScanner` to
+/// exempt the vetted `X || (X = {})` argument occurrence of the enum
+/// binding from the escape scan.
+fn is_ts_enum_iife_call_for_binding(call: &CallExpr, binding: &str) -> bool {
     let Callee::Expr(callee_expr) = &call.callee else {
         return false;
     };
@@ -1080,11 +1137,36 @@ fn is_plain_data_prop(prop: &PropOrSpread) -> bool {
 }
 
 /// Visitor that disqualifies plain-data candidates seen as the target
-/// of a member write/update/delete, or as the first argument to one
-/// of a small set of accessor- / prototype-installing built-ins.
-/// Skips the right side of `X.k = ...` only in the sense that
-/// recursing through `expr` still picks up nested cases — every
-/// expression node visits its children.
+/// of a member write/update/delete, as the first argument to one of a
+/// small set of accessor- / prototype-installing built-ins, or in any
+/// ESCAPING position.
+///
+/// **Escape analysis.** The write scan above is name-based: it only
+/// catches mutations spelled through the candidate's own identifier.
+/// An alias (`const Y = X; Object.defineProperty(Y, …)`) or any other
+/// captured reference (call argument, array element, object property
+/// value) defeats it. The scanner therefore treats every bare
+/// candidate `Ident` as an escape — and disqualifies — unless the
+/// occurrence is in one of a short list of provably non-capturing
+/// read positions:
+///
+/// * member-access receiver (`X.k`, `X[k]`, `X?.k`) — a read;
+/// * spread source (`{...X}`, `[...X]`, `f(...X)`) — copies values /
+///   iterates; the receiver object's identity is not captured;
+/// * `typeof X` / `!X` / `void X` operands — transient inspection;
+/// * single argument of `Object.{keys,values,entries,freeze,
+///   fromEntries}` with the global `Object` unshadowed — read-only /
+///   descriptor-tightening builtins that install no accessors (the
+///   same set `PURE_OBJECT_CALLS_ON_PLAIN_DATA` admits);
+/// * the vetted `X || (X = {})` argument of a recognized TS-enum
+///   IIFE init (`is_ts_enum_iife_call_for_binding`);
+/// * `return X` / concise arrow body `() => X` — accepted by scope
+///   decision: consumers of chunk-internal return values (like
+///   importers of an exported PlainData binding) are assumed not to
+///   install accessors on it; see docs/purity_soundness.md §
+///   "ChunkBinding::PlainData" for the residual-assumption note.
+///   Export specifiers (`export { X }`) are non-escaping under the
+///   same assumption.
 ///
 /// **Function/arrow parameter scope tracking.** When entering a
 /// function or arrow body whose parameters include names that
@@ -1105,6 +1187,10 @@ fn is_plain_data_prop(prop: &PropOrSpread) -> bool {
 /// would have been admissible), never false positives.
 struct PlainDataWriteScanner<'a> {
     candidates: &'a BTreeSet<String>,
+    /// Chunk-top shadowed-globals set (A8): consulted by the
+    /// `Object.{keys,…}(X)` non-escaping-position exemption, which
+    /// must not fire when the chunk rebinds `Object`.
+    shadowed: &'a BTreeSet<&'static str>,
     disqualified: BTreeSet<String>,
     /// Stack of per-scope candidate-shadowing sets. Each scope entry
     /// is the subset of `candidates` shadowed by the function/arrow
@@ -1320,10 +1406,79 @@ impl Visit for PlainDataWriteScanner<'_> {
         if node.op == UnaryOp::Delete {
             self.disqualify_member_receiver(&node.arg);
         }
+        // `typeof X` / `!X` / `void X` are transient inspections of
+        // the value — the reference isn't captured. Skip the bare
+        // candidate Ident so the escape default doesn't fire.
+        if matches!(node.op, UnaryOp::TypeOf | UnaryOp::Bang | UnaryOp::Void)
+            && matches!(strip_parens(&node.arg), Expr::Ident(_))
+        {
+            return;
+        }
+        node.visit_children_with(self);
+    }
+
+    // ESCAPE DEFAULT: any bare candidate Ident reached by the
+    // traversal is a captured reference (alias RHS, call/new arg,
+    // array element, object property value, shorthand prop, …) and
+    // disqualifies. The non-capturing read positions on the short
+    // list in the struct doc-comment are skipped by the overrides
+    // below before traversal reaches the Ident.
+    fn visit_ident(&mut self, node: &Ident) {
+        self.disqualify_if_candidate(node.sym.as_ref());
+    }
+
+    // Binding positions (declarator names, params, catch bindings)
+    // introduce a binding rather than reading the candidate's value
+    // — not an escape.
+    fn visit_binding_ident(&mut self, _node: &BindingIdent) {}
+
+    // `export { X }` is non-escaping by scope decision (see the
+    // struct doc-comment): importers of an exported PlainData
+    // binding are assumed not to install accessors on it.
+    fn visit_export_named_specifier(&mut self, _node: &ExportNamedSpecifier) {}
+
+    // Member-access receivers are reads, not captures. Skip an
+    // Ident receiver (candidate or not); everything else (nested
+    // receivers, computed keys) is traversed normally.
+    fn visit_member_expr(&mut self, node: &MemberExpr) {
+        if !matches!(strip_parens(&node.obj), Expr::Ident(_)) {
+            node.obj.visit_with(self);
+        }
+        node.prop.visit_with(self);
+    }
+
+    // Spread sources (`{...X}`, `[...X]`, `f(...X)`) copy values /
+    // iterate; the receiver object's identity is not captured.
+    fn visit_spread_element(&mut self, node: &SpreadElement) {
+        if matches!(strip_parens(&node.expr), Expr::Ident(_)) {
+            return;
+        }
+        node.visit_children_with(self);
+    }
+
+    fn visit_expr_or_spread(&mut self, node: &ExprOrSpread) {
+        if node.spread.is_some() && matches!(strip_parens(&node.expr), Expr::Ident(_)) {
+            return;
+        }
+        node.visit_children_with(self);
+    }
+
+    // `return X` is non-escaping by scope decision (see the struct
+    // doc-comment's residual-assumption note).
+    fn visit_return_stmt(&mut self, node: &ReturnStmt) {
+        if let Some(arg) = node.arg.as_deref()
+            && matches!(strip_parens(arg), Expr::Ident(_))
+        {
+            return;
+        }
         node.visit_children_with(self);
     }
 
     fn visit_call_expr(&mut self, node: &CallExpr) {
+        // Hostile accessor-/prototype-installing builtins with the
+        // candidate as first arg. Redundant with the escape default
+        // (a call arg is an escape) but kept as an explicit,
+        // self-documenting check.
         if let Callee::Expr(callee) = &node.callee
             && let Expr::Member(member) = callee.as_ref()
             && let (Expr::Ident(obj), MemberProp::Ident(prop)) = (member.obj.as_ref(), &member.prop)
@@ -1336,12 +1491,58 @@ impl Visit for PlainDataWriteScanner<'_> {
         {
             self.disqualify_if_candidate(target.sym.as_ref());
         }
+        // `Object.{keys,values,entries,freeze,fromEntries}(X)` with
+        // the global `Object` unshadowed — read-only /
+        // descriptor-tightening builtins that install no accessors
+        // (the same set `PURE_OBJECT_CALLS_ON_PLAIN_DATA` admits).
+        // Skip the argument so the escape default doesn't fire.
+        if let Callee::Expr(callee) = &node.callee
+            && let Expr::Member(member) = callee.as_ref()
+            && let (Expr::Ident(obj), MemberProp::Ident(prop)) = (member.obj.as_ref(), &member.prop)
+            && obj.sym.as_ref() == "Object"
+            && !self.shadowed.contains("Object")
+            && PURE_OBJECT_CALLS_ON_PLAIN_DATA
+                .iter()
+                .any(|(_, p)| *p == prop.sym.as_ref())
+            && node.args.len() == 1
+            && node.args[0].spread.is_none()
+            && matches!(strip_parens(&node.args[0].expr), Expr::Ident(_))
+        {
+            // Receiver `Object` and the static prop carry no
+            // candidate refs; nothing else to visit.
+            return;
+        }
+        // The vetted `X || (X = {})` argument of a recognized
+        // TS-enum IIFE init: the only callee shapes the recognizer
+        // admits are inline arrow/function expressions whose bodies
+        // mutate their own parameter — visit the callee (the
+        // param-scope tracking exempts same-named param writes) and
+        // skip the vetted argument.
+        if self
+            .candidates
+            .iter()
+            .any(|c| !self.is_shadowed(c) && is_ts_enum_iife_call_for_binding(node, c))
+        {
+            node.callee.visit_with(self);
+            return;
+        }
         node.visit_children_with(self);
     }
 
     fn visit_arrow_expr(&mut self, node: &ArrowExpr) {
         let scope = self.shadowed_by_params(node.params.iter());
-        self.with_scope(scope, |s| node.visit_children_with(s));
+        self.with_scope(scope, |s| {
+            for param in &node.params {
+                param.visit_with(s);
+            }
+            // A concise body that is a bare candidate Ident is the
+            // `() => X` return position — non-escaping by the same
+            // scope decision as `return X`.
+            match node.body.as_ref() {
+                BlockStmtOrExpr::Expr(expr) if matches!(strip_parens(expr), Expr::Ident(_)) => {}
+                body => body.visit_with(s),
+            }
+        });
     }
 
     fn visit_function(&mut self, node: &Function) {
@@ -1357,28 +1558,69 @@ fn classify_function_body(
     graph: &ChunkCodeGraph,
 ) -> Purity {
     // Names bound by this function (its params and every binding
-    // declared anywhere in its body) shadow chunk-top PlainData
-    // candidates of the same name. Restricting to names that are
-    // actually plain-data keeps the set small; correctness only
-    // requires that every shadowing name be excluded, so a larger
-    // set would also be sound. Lexical scope is constant across one
-    // classification tree (nested function/arrow bodies are not
-    // walked), so this single set suffices for the whole body.
-    let plain_data_shadowed: BTreeSet<String> = function
-        .param_and_body_bindings
+    // declared anywhere in its body) lexically shadow EVERY outer
+    // resolution path of the same name: chunk-top PlainData
+    // candidates, chunk-top function bindings, whitelist receivers
+    // (`Math`, `Object`, …), pure-new builtins (`Map`, `Set`, …),
+    // and spec-annotated `declared_pure` / `pure_members` /
+    // `pure_new` bindings. A reference to a shadowed name inside
+    // the body is a *different value* than the one the global
+    // tables / chunk graph / spec author describe, so none of those
+    // shortcuts may fire for it. Over-approximation (collecting
+    // bindings from nested scopes too) is sound: extra names only
+    // make more reads conservative. Lexical scope is constant
+    // across one classification tree (nested function/arrow bodies
+    // are not walked), so this single set suffices for the whole
+    // body.
+    let local_shadowed = &function.param_and_body_bindings;
+    // Destructuring parameters fire getters (object patterns) or
+    // the iterator protocol (array patterns) on the caller's
+    // argument at call time — user code the body's expression walk
+    // never sees. A function with any destructuring param is not
+    // pure-callable. Default-value expressions are classified by
+    // the body walk below (`visit_body_with` drives the visitor
+    // over the param patterns too).
+    let param_purity = function
+        .params
         .iter()
-        .filter(|name| graph.is_plain_data(name))
-        .cloned()
-        .collect();
+        .filter_map(|pat| param_destructuring_purity(pat))
+        .fold(Purity::Pure, Purity::worst);
     let mut collector = BodyPurityCollector {
         purity: Purity::Pure,
         shadowed,
-        plain_data_shadowed: &plain_data_shadowed,
+        local_shadowed,
         declared_pure,
         graph,
     };
     function.visit_body_with(&mut collector);
-    collector.purity
+    param_purity.worst(collector.purity)
+}
+
+/// `Some(NotPure)` when `pat` contains a destructuring pattern that
+/// fires user code on the bound value at evaluation time: object
+/// patterns run `[[Get]]` per key (user getters / proxy traps),
+/// array patterns run the iterator protocol. Plain idents and rest
+/// params (fresh array from the arguments list) contribute nothing;
+/// default-value expressions are classified separately as
+/// expressions by the body walk.
+fn param_destructuring_purity(pat: &Pat) -> Option<Purity> {
+    match pat {
+        Pat::Ident(_) => None,
+        Pat::Rest(rest) => param_destructuring_purity(&rest.arg),
+        Pat::Assign(assign) => param_destructuring_purity(&assign.left),
+        Pat::Array(arr) => Some(Purity::from_reason_with_detail(
+            PurityRule::DestructuringPattern,
+            arr.span,
+            "array destructuring fires the iterator protocol on the bound value".to_string(),
+        )),
+        Pat::Object(obj) => Some(Purity::from_reason_with_detail(
+            PurityRule::DestructuringPattern,
+            obj.span,
+            "object destructuring fires [[Get]] (user getters / proxy traps) on the bound value"
+                .to_string(),
+        )),
+        Pat::Invalid(_) | Pat::Expr(_) => Some(Purity::from_reason(PurityRule::Other, pat.span())),
+    }
 }
 
 /// Visitor that walks a function body and accumulates the worst
@@ -1389,11 +1631,12 @@ fn classify_function_body(
 struct BodyPurityCollector<'a> {
     purity: Purity,
     shadowed: &'a BTreeSet<&'static str>,
-    /// Chunk-top PlainData names shadowed by a binding of the function
-    /// whose body is being walked (its params / body declarations).
-    /// A `recv.k` read on such a name must NOT be admitted as pure —
-    /// the lexical `recv` is the local binding, not the plain-data const.
-    plain_data_shadowed: &'a BTreeSet<String>,
+    /// Every name bound by the function whose body is being walked
+    /// (its params / body declarations). References to such names
+    /// must not resolve through any global table, chunk-graph
+    /// binding, or spec annotation — the lexical binding is a
+    /// different value than the outer one those describe.
+    local_shadowed: &'a BTreeSet<String>,
     declared_pure: &'a BTreeSet<String>,
     graph: &'a ChunkCodeGraph,
 }
@@ -1412,7 +1655,7 @@ impl Visit for BodyPurityCollector<'_> {
         let p = classify_expr_purity(
             expr,
             self.shadowed,
-            self.plain_data_shadowed,
+            self.local_shadowed,
             self.declared_pure,
             self.graph,
         );
@@ -1435,6 +1678,44 @@ impl Visit for BodyPurityCollector<'_> {
     fn visit_debugger_stmt(&mut self, node: &DebuggerStmt) {
         let dbg_reason = Purity::from_reason(PurityRule::DebuggerStmt, node.span);
         self.purity = std::mem::replace(&mut self.purity, Purity::Pure).worst(dbg_reason);
+    }
+
+    // Iteration statements fire user code beyond their
+    // sub-expressions: `for-of` (and `for await-of`) runs the
+    // iterated value's `[Symbol.iterator]` / `[Symbol.asyncIterator]`
+    // protocol; `for-in` runs `[[OwnPropertyKeys]]` /
+    // `[[GetOwnPropertyDescriptor]]` per step, which a Proxy traps.
+    // The RHS expression's own evaluation is classified by the
+    // regular recursion, but the protocol firing is invisible to it
+    // — flag the statement itself.
+    fn visit_for_of_stmt(&mut self, node: &ForOfStmt) {
+        let reason = Purity::from_reason_with_detail(
+            PurityRule::IterationProtocol,
+            node.span,
+            "for-of fires the iterator protocol on the iterated value".to_string(),
+        );
+        self.purity = std::mem::replace(&mut self.purity, Purity::Pure).worst(reason);
+        node.visit_children_with(self);
+    }
+
+    fn visit_for_in_stmt(&mut self, node: &ForInStmt) {
+        let reason = Purity::from_reason_with_detail(
+            PurityRule::IterationProtocol,
+            node.span,
+            "for-in enumeration can fire proxy traps on the enumerated value".to_string(),
+        );
+        self.purity = std::mem::replace(&mut self.purity, Purity::Pure).worst(reason);
+        node.visit_children_with(self);
+    }
+
+    // `const {a} = o` / `const [x] = o` inside a body fire getters /
+    // the iterator protocol on the initializer value — effects the
+    // init expression's own classification doesn't cover.
+    fn visit_var_declarator(&mut self, node: &VarDeclarator) {
+        if let Some(reason) = param_destructuring_purity(&node.name) {
+            self.purity = std::mem::replace(&mut self.purity, Purity::Pure).worst(reason);
+        }
+        node.visit_children_with(self);
     }
 }
 
@@ -1494,6 +1775,27 @@ pub enum PurityRule {
     ObjectAssignProp,
     ClassStaticObservable,
     BareControlFlow,
+    /// A coercing operator (`+`, `-`, relational, loose equality,
+    /// `~`, unary `+`/`-`, template interpolation, `in`,
+    /// `instanceof`) whose operand is not statically known to be a
+    /// primitive. ToPrimitive / ToNumber / ToString /
+    /// `[Symbol.hasInstance]` / proxy-`has` on an object operand
+    /// fires user code.
+    CoercingOperator,
+    /// A computed property key (`obj[key]`, `{[key]: v}`,
+    /// `class { [key]() {} }`) whose key expression is not
+    /// statically known to be a primitive (or a whitelisted
+    /// `Symbol.*` well-known symbol). ToPropertyKey on an object
+    /// key fires `toString` / `[Symbol.toPrimitive]`.
+    ToPropertyKeyCoercion,
+    /// `for-of` / `for await-of` / `for-in` — iteration fires the
+    /// iterator protocol or proxy enumeration traps on the
+    /// iterated value.
+    IterationProtocol,
+    /// A destructuring pattern (declarator name or function
+    /// parameter) — object patterns fire `[[Get]]`, array patterns
+    /// fire the iterator protocol on the bound value.
+    DestructuringPattern,
     Other,
 }
 
@@ -1541,7 +1843,7 @@ impl Purity {
 pub(crate) fn classify_expr_purity(
     expr: &Expr,
     shadowed: &BTreeSet<&'static str>,
-    plain_data_shadowed: &BTreeSet<String>,
+    local_shadowed: &BTreeSet<String>,
     declared_pure: &BTreeSet<String>,
     graph: &ChunkCodeGraph,
 ) -> Purity {
@@ -1549,17 +1851,34 @@ pub(crate) fn classify_expr_purity(
         Expr::Lit(_) => Purity::Pure,
         Expr::Ident(_) => Purity::Pure,
         Expr::This(_) | Expr::MetaProp(_) => Purity::Pure,
+        // Template interpolation runs ToString on each interpolated
+        // value — an object operand fires user `toString` /
+        // `[Symbol.toPrimitive]`. Each interpolation must therefore
+        // be statically primitive-valued in addition to being pure
+        // to evaluate.
         Expr::Tpl(tpl) => tpl
             .exprs
             .iter()
-            .map(|e| classify_expr_purity(e, shadowed, plain_data_shadowed, declared_pure, graph))
+            .map(|e| {
+                let p = classify_expr_purity(e, shadowed, local_shadowed, declared_pure, graph);
+                if is_result_primitive(e) {
+                    p
+                } else {
+                    p.worst(Purity::from_reason_with_detail(
+                        PurityRule::CoercingOperator,
+                        e.span(),
+                        "template interpolation runs ToString on a possibly-object value"
+                            .to_string(),
+                    ))
+                }
+            })
             .fold(Purity::Pure, Purity::worst),
         Expr::Fn(_) | Expr::Arrow(_) => Purity::Pure,
         Expr::Class(class_expr) => {
             if class_has_static_observable(
                 &class_expr.class,
                 shadowed,
-                plain_data_shadowed,
+                local_shadowed,
                 declared_pure,
                 graph,
             ) {
@@ -1569,38 +1888,106 @@ pub(crate) fn classify_expr_purity(
             }
         }
         Expr::Paren(p) => {
-            classify_expr_purity(&p.expr, shadowed, plain_data_shadowed, declared_pure, graph)
+            classify_expr_purity(&p.expr, shadowed, local_shadowed, declared_pure, graph)
         }
-        Expr::Unary(u) => match u.op {
-            UnaryOp::Delete => Purity::from_reason(PurityRule::DeleteOperator, u.span),
-            // typeof / void / +/-/!/~ on a pure operand are pure
-            // (they may coerce, but coercion of an Ident or Lit
-            // doesn't run user code).
-            _ => classify_expr_purity(&u.arg, shadowed, plain_data_shadowed, declared_pure, graph),
-        },
+        Expr::Unary(u) => {
+            let arg_purity =
+                classify_expr_purity(&u.arg, shadowed, local_shadowed, declared_pure, graph);
+            match u.op {
+                UnaryOp::Delete => Purity::from_reason(PurityRule::DeleteOperator, u.span),
+                // `typeof` has no coercion path; `void` discards;
+                // `!` runs ToBoolean, which is type-cased and fires
+                // no user code on any value (ECMA-262 §7.1.2).
+                // Pure iff the operand is.
+                UnaryOp::TypeOf | UnaryOp::Void | UnaryOp::Bang => arg_purity,
+                // Unary `+` / `-` / `~` run ToNumber / ToNumeric —
+                // on an object operand that fires user `valueOf` /
+                // `[Symbol.toPrimitive]`. Pure only when the
+                // operand is statically primitive-valued.
+                UnaryOp::Plus | UnaryOp::Minus | UnaryOp::Tilde => {
+                    if is_result_primitive(&u.arg) {
+                        arg_purity
+                    } else {
+                        arg_purity.worst(Purity::from_reason_with_detail(
+                            PurityRule::CoercingOperator,
+                            u.span,
+                            format!("unary {} runs ToNumber on a possibly-object operand", u.op),
+                        ))
+                    }
+                }
+            }
+        }
         Expr::Bin(b) => {
-            classify_expr_purity(&b.left, shadowed, plain_data_shadowed, declared_pure, graph)
-                .worst(classify_expr_purity(
-                    &b.right,
-                    shadowed,
-                    plain_data_shadowed,
-                    declared_pure,
-                    graph,
-                ))
+            let operands =
+                classify_expr_purity(&b.left, shadowed, local_shadowed, declared_pure, graph)
+                    .worst(classify_expr_purity(
+                        &b.right,
+                        shadowed,
+                        local_shadowed,
+                        declared_pure,
+                        graph,
+                    ));
+            match b.op {
+                // No-coercion operators: short-circuit logicals
+                // evaluate operands as-is; strict (in)equality is
+                // type-cased with no ToPrimitive path (ECMA-262
+                // §7.2.16 IsStrictlyEqual).
+                BinaryOp::LogicalAnd
+                | BinaryOp::LogicalOr
+                | BinaryOp::NullishCoalescing
+                | BinaryOp::EqEqEq
+                | BinaryOp::NotEqEq => operands,
+                // `in` runs ToPropertyKey on the LHS and HasProperty
+                // on the RHS (proxy `has` trap); `instanceof` runs
+                // GetMethod(RHS, @@hasInstance) and reads
+                // `RHS.prototype` (proxy `get` trap). The
+                // interesting RHS is always an object, so no
+                // primitive-operand gate can admit these.
+                BinaryOp::In | BinaryOp::InstanceOf => {
+                    operands.worst(Purity::from_reason_with_detail(
+                        PurityRule::CoercingOperator,
+                        b.span,
+                        format!(
+                            "`{}` can fire proxy traps / @@hasInstance on its operand",
+                            b.op
+                        ),
+                    ))
+                }
+                // Every remaining operator (arithmetic, relational,
+                // loose equality, bitwise, shifts, `+`) coerces its
+                // operands via ToPrimitive / ToNumeric, which fires
+                // user `valueOf` / `toString` / `[Symbol.toPrimitive]`
+                // on object operands. Pure only when both operands
+                // are statically primitive-valued.
+                _ => {
+                    if is_result_primitive(&b.left) && is_result_primitive(&b.right) {
+                        operands
+                    } else {
+                        operands.worst(Purity::from_reason_with_detail(
+                            PurityRule::CoercingOperator,
+                            b.span,
+                            format!(
+                                "binary {} runs ToPrimitive on a possibly-object operand",
+                                b.op
+                            ),
+                        ))
+                    }
+                }
+            }
         }
         Expr::Cond(c) => {
-            classify_expr_purity(&c.test, shadowed, plain_data_shadowed, declared_pure, graph)
+            classify_expr_purity(&c.test, shadowed, local_shadowed, declared_pure, graph)
                 .worst(classify_expr_purity(
                     &c.cons,
                     shadowed,
-                    plain_data_shadowed,
+                    local_shadowed,
                     declared_pure,
                     graph,
                 ))
                 .worst(classify_expr_purity(
                     &c.alt,
                     shadowed,
-                    plain_data_shadowed,
+                    local_shadowed,
                     declared_pure,
                     graph,
                 ))
@@ -1608,20 +1995,18 @@ pub(crate) fn classify_expr_purity(
         Expr::Seq(s) => s
             .exprs
             .iter()
-            .map(|e| classify_expr_purity(e, shadowed, plain_data_shadowed, declared_pure, graph))
+            .map(|e| classify_expr_purity(e, shadowed, local_shadowed, declared_pure, graph))
             .fold(Purity::Pure, Purity::worst),
         Expr::Array(arr) => {
-            classify_array_literal_purity(arr, shadowed, plain_data_shadowed, declared_pure, graph)
+            classify_array_literal_purity(arr, shadowed, local_shadowed, declared_pure, graph)
         }
         Expr::Object(obj) => obj
             .props
             .iter()
-            .map(|prop| {
-                classify_prop_purity(prop, shadowed, plain_data_shadowed, declared_pure, graph)
-            })
+            .map(|prop| classify_prop_purity(prop, shadowed, local_shadowed, declared_pure, graph))
             .fold(Purity::Pure, Purity::worst),
         Expr::Member(member) => {
-            classify_member_purity(member, shadowed, plain_data_shadowed, declared_pure, graph)
+            classify_member_purity(member, shadowed, local_shadowed, declared_pure, graph)
         }
         Expr::SuperProp(s) => Purity::from_reason(PurityRule::SuperProp, s.span),
         // Optional chaining (`recv?.prop`, `recv?.()`) only adds a
@@ -1634,28 +2019,24 @@ pub(crate) fn classify_expr_purity(
         // docs/design.md "Open design questions / OptChain purity".
         Expr::OptChain(opt) => match &*opt.base {
             OptChainBase::Member(member) => {
-                classify_member_purity(member, shadowed, plain_data_shadowed, declared_pure, graph)
+                classify_member_purity(member, shadowed, local_shadowed, declared_pure, graph)
             }
             OptChainBase::Call(opt_call) => classify_callee_call(
                 &opt_call.callee,
                 &opt_call.args,
                 opt.span,
                 shadowed,
-                plain_data_shadowed,
+                local_shadowed,
                 declared_pure,
                 graph,
             ),
         },
         Expr::Call(call) => {
-            classify_call_purity(call, shadowed, plain_data_shadowed, declared_pure, graph)
+            classify_call_purity(call, shadowed, local_shadowed, declared_pure, graph)
         }
-        Expr::New(new_expr) => classify_new_expr_purity(
-            new_expr,
-            shadowed,
-            plain_data_shadowed,
-            declared_pure,
-            graph,
-        ),
+        Expr::New(new_expr) => {
+            classify_new_expr_purity(new_expr, shadowed, local_shadowed, declared_pure, graph)
+        }
         Expr::TaggedTpl(t) => Purity::from_reason(PurityRule::TaggedTpl, t.span),
         Expr::Assign(a) => Purity::from_reason(PurityRule::AssignOrUpdate, a.span),
         Expr::Update(u) => Purity::from_reason(PurityRule::AssignOrUpdate, u.span),
@@ -1670,7 +2051,7 @@ pub(crate) fn classify_expr_purity(
 fn classify_array_literal_purity(
     arr: &ArrayLit,
     shadowed: &BTreeSet<&'static str>,
-    plain_data_shadowed: &BTreeSet<String>,
+    local_shadowed: &BTreeSet<String>,
     declared_pure: &BTreeSet<String>,
     graph: &ChunkCodeGraph,
 ) -> Purity {
@@ -1681,7 +2062,7 @@ fn classify_array_literal_purity(
             classify_array_literal_element_purity(
                 elem,
                 shadowed,
-                plain_data_shadowed,
+                local_shadowed,
                 declared_pure,
                 graph,
             )
@@ -1692,7 +2073,7 @@ fn classify_array_literal_purity(
 fn classify_array_literal_element_purity(
     elem: &ExprOrSpread,
     shadowed: &BTreeSet<&'static str>,
-    plain_data_shadowed: &BTreeSet<String>,
+    local_shadowed: &BTreeSet<String>,
     declared_pure: &BTreeSet<String>,
     graph: &ChunkCodeGraph,
 ) -> Purity {
@@ -1701,19 +2082,13 @@ fn classify_array_literal_element_purity(
             &elem.expr,
             None,
             shadowed,
-            plain_data_shadowed,
+            local_shadowed,
             declared_pure,
             graph,
         )
         .unwrap_or_else(|| Purity::from_reason(PurityRule::ArraySpread, sp));
     }
-    classify_expr_purity(
-        &elem.expr,
-        shadowed,
-        plain_data_shadowed,
-        declared_pure,
-        graph,
-    )
+    classify_expr_purity(&elem.expr, shadowed, local_shadowed, declared_pure, graph)
 }
 
 /// Array spread is only side-effect-free when the source is known to
@@ -1729,7 +2104,7 @@ fn classify_fresh_array_spread_source(
     expr: &Expr,
     for_iterable: Option<&str>,
     shadowed: &BTreeSet<&'static str>,
-    plain_data_shadowed: &BTreeSet<String>,
+    local_shadowed: &BTreeSet<String>,
     declared_pure: &BTreeSet<String>,
     graph: &ChunkCodeGraph,
 ) -> Option<Purity> {
@@ -1738,7 +2113,7 @@ fn classify_fresh_array_spread_source(
             &p.expr,
             for_iterable,
             shadowed,
-            plain_data_shadowed,
+            local_shadowed,
             declared_pure,
             graph,
         ),
@@ -1751,39 +2126,33 @@ fn classify_fresh_array_spread_source(
                         arr.span,
                         callee,
                         shadowed,
-                        plain_data_shadowed,
+                        local_shadowed,
                         declared_pure,
                         graph,
                     )
                 })
                 .fold(Purity::Pure, Purity::worst)
         } else {
-            classify_array_literal_purity(arr, shadowed, plain_data_shadowed, declared_pure, graph)
+            classify_array_literal_purity(arr, shadowed, local_shadowed, declared_pure, graph)
         }),
         Expr::Cond(cond) => Some(
-            classify_expr_purity(
-                &cond.test,
-                shadowed,
-                plain_data_shadowed,
-                declared_pure,
-                graph,
-            )
-            .worst(classify_fresh_array_spread_source(
-                &cond.cons,
-                for_iterable,
-                shadowed,
-                plain_data_shadowed,
-                declared_pure,
-                graph,
-            )?)
-            .worst(classify_fresh_array_spread_source(
-                &cond.alt,
-                for_iterable,
-                shadowed,
-                plain_data_shadowed,
-                declared_pure,
-                graph,
-            )?),
+            classify_expr_purity(&cond.test, shadowed, local_shadowed, declared_pure, graph)
+                .worst(classify_fresh_array_spread_source(
+                    &cond.cons,
+                    for_iterable,
+                    shadowed,
+                    local_shadowed,
+                    declared_pure,
+                    graph,
+                )?)
+                .worst(classify_fresh_array_spread_source(
+                    &cond.alt,
+                    for_iterable,
+                    shadowed,
+                    local_shadowed,
+                    declared_pure,
+                    graph,
+                )?),
         ),
         _ => None,
     }
@@ -1855,7 +2224,7 @@ fn static_member_pair(member: &MemberExpr) -> Option<(&'static str, &'static str
 fn classify_new_expr_purity(
     new_expr: &NewExpr,
     shadowed: &BTreeSet<&'static str>,
-    plain_data_shadowed: &BTreeSet<String>,
+    local_shadowed: &BTreeSet<String>,
     declared_pure: &BTreeSet<String>,
     graph: &ChunkCodeGraph,
 ) -> Purity {
@@ -1872,6 +2241,7 @@ fn classify_new_expr_purity(
         .copied()
         .find(|n| *n == callee.sym.as_ref())
         && !shadowed.contains(name)
+        && !local_shadowed.contains(name)
         && arg_count == 0
     {
         return Purity::Pure;
@@ -1881,6 +2251,7 @@ fn classify_new_expr_purity(
         .copied()
         .find(|n| *n == callee.sym.as_ref())
         && !shadowed.contains(name)
+        && !local_shadowed.contains(name)
         && let Some(args) = new_expr.args.as_ref()
         && args.len() == 1
         && args[0].spread.is_none()
@@ -1895,7 +2266,7 @@ fn classify_new_expr_purity(
             &args[0].expr,
             name,
             shadowed,
-            plain_data_shadowed,
+            local_shadowed,
             declared_pure,
             graph,
         );
@@ -1909,9 +2280,14 @@ fn classify_new_expr_purity(
         )
         .worst(inner);
     }
-    if graph.is_declared_pure_new(callee.sym.as_ref()) {
+    // `pure_new` is an author trust contract on the chunk-top
+    // binding; a body-local binding of the same name is a different
+    // value the contract doesn't cover.
+    if !local_shadowed.contains(callee.sym.as_ref())
+        && graph.is_declared_pure_new(callee.sym.as_ref())
+    {
         let args = new_expr.args.as_deref().unwrap_or(&[]);
-        let arg_purity = all_args_pure(args, shadowed, plain_data_shadowed, declared_pure, graph);
+        let arg_purity = all_args_pure(args, shadowed, local_shadowed, declared_pure, graph);
         if arg_purity.is_pure() {
             return Purity::Pure;
         }
@@ -1949,7 +2325,7 @@ fn classify_array_literal_for_iterable(
     expr: &Expr,
     callee: &str,
     shadowed: &BTreeSet<&'static str>,
-    plain_data_shadowed: &BTreeSet<String>,
+    local_shadowed: &BTreeSet<String>,
     declared_pure: &BTreeSet<String>,
     graph: &ChunkCodeGraph,
 ) -> Purity {
@@ -1968,7 +2344,7 @@ fn classify_array_literal_for_iterable(
                 arr.span,
                 callee,
                 shadowed,
-                plain_data_shadowed,
+                local_shadowed,
                 declared_pure,
                 graph,
             )
@@ -1981,7 +2357,7 @@ fn classify_iterable_element(
     arr_span: Span,
     callee: &str,
     shadowed: &BTreeSet<&'static str>,
-    plain_data_shadowed: &BTreeSet<String>,
+    local_shadowed: &BTreeSet<String>,
     declared_pure: &BTreeSet<String>,
     graph: &ChunkCodeGraph,
 ) -> Purity {
@@ -1999,27 +2375,15 @@ fn classify_iterable_element(
             &elem.expr,
             Some(callee),
             shadowed,
-            plain_data_shadowed,
+            local_shadowed,
             declared_pure,
             graph,
         )
         .unwrap_or_else(|| Purity::from_reason(PurityRule::ArraySpread, sp));
     }
     match callee {
-        "Set" => classify_expr_purity(
-            &elem.expr,
-            shadowed,
-            plain_data_shadowed,
-            declared_pure,
-            graph,
-        ),
-        "Map" => classify_map_entry(
-            &elem.expr,
-            shadowed,
-            plain_data_shadowed,
-            declared_pure,
-            graph,
-        ),
+        "Set" => classify_expr_purity(&elem.expr, shadowed, local_shadowed, declared_pure, graph),
+        "Map" => classify_map_entry(&elem.expr, shadowed, local_shadowed, declared_pure, graph),
         _ => Purity::from_reason_with_detail(
             PurityRule::Other,
             elem.expr.span(),
@@ -2031,7 +2395,7 @@ fn classify_iterable_element(
 fn classify_map_entry(
     entry_expr: &Expr,
     shadowed: &BTreeSet<&'static str>,
-    plain_data_shadowed: &BTreeSet<String>,
+    local_shadowed: &BTreeSet<String>,
     declared_pure: &BTreeSet<String>,
     graph: &ChunkCodeGraph,
 ) -> Purity {
@@ -2062,7 +2426,7 @@ fn classify_map_entry(
                 Purity::from_reason(PurityRule::ArraySpread, e.spread.unwrap())
             }
             Some(e) => {
-                classify_expr_purity(&e.expr, shadowed, plain_data_shadowed, declared_pure, graph)
+                classify_expr_purity(&e.expr, shadowed, local_shadowed, declared_pure, graph)
             }
         })
         .fold(Purity::Pure, Purity::worst)
@@ -2084,12 +2448,13 @@ fn classify_map_entry(
 fn classify_member_purity(
     member: &MemberExpr,
     shadowed: &BTreeSet<&'static str>,
-    plain_data_shadowed: &BTreeSet<String>,
+    local_shadowed: &BTreeSet<String>,
     declared_pure: &BTreeSet<String>,
     graph: &ChunkCodeGraph,
 ) -> Purity {
     if let Some((recv, prop)) = static_member_pair(member)
         && !shadowed.contains(recv)
+        && !local_shadowed.contains(recv)
         && (PURE_STATIC_PROPS.contains(&(recv, prop))
             || PURE_STATIC_FUNCTION_REFS.contains(&(recv, prop)))
     {
@@ -2101,17 +2466,34 @@ fn classify_member_purity(
         // shadows the chunk-top PlainData const, so `recv` here is the
         // local (possibly a getter-bearing object), not the plain-data
         // shape. Admitting it as pure would be a soundness hole.
-        && !plain_data_shadowed.contains(recv.sym.as_ref())
+        && !local_shadowed.contains(recv.sym.as_ref())
     {
         return match &member.prop {
             MemberProp::Ident(_) | MemberProp::PrivateName(_) => Purity::Pure,
-            MemberProp::Computed(computed) => classify_expr_purity(
-                &computed.expr,
-                shadowed,
-                plain_data_shadowed,
-                declared_pure,
-                graph,
-            ),
+            // Computed access runs ToPropertyKey on the key VALUE
+            // before the (accessor-free) lookup on the PlainData
+            // receiver — an object key fires user `toString` /
+            // `[Symbol.toPrimitive]`. The key must therefore be
+            // statically primitive-valued (or a well-known Symbol)
+            // in addition to being pure to evaluate.
+            MemberProp::Computed(computed) => {
+                let key_purity = classify_expr_purity(
+                    &computed.expr,
+                    shadowed,
+                    local_shadowed,
+                    declared_pure,
+                    graph,
+                );
+                if is_safe_property_key(&computed.expr, shadowed, local_shadowed) {
+                    key_purity
+                } else {
+                    key_purity.worst(Purity::from_reason_with_detail(
+                        PurityRule::ToPropertyKeyCoercion,
+                        computed.span,
+                        "computed key runs ToPropertyKey on a possibly-object value".to_string(),
+                    ))
+                }
+            }
         };
     }
     let detail = match (member.obj.as_ref(), &member.prop) {
@@ -2131,7 +2513,7 @@ fn classify_member_purity(
 fn classify_call_purity(
     call: &CallExpr,
     shadowed: &BTreeSet<&'static str>,
-    plain_data_shadowed: &BTreeSet<String>,
+    local_shadowed: &BTreeSet<String>,
     declared_pure: &BTreeSet<String>,
     graph: &ChunkCodeGraph,
 ) -> Purity {
@@ -2147,7 +2529,7 @@ fn classify_call_purity(
         &call.args,
         call.span,
         shadowed,
-        plain_data_shadowed,
+        local_shadowed,
         declared_pure,
         graph,
     )
@@ -2165,21 +2547,25 @@ fn classify_callee_call(
     args: &[ExprOrSpread],
     call_span: Span,
     shadowed: &BTreeSet<&'static str>,
-    plain_data_shadowed: &BTreeSet<String>,
+    local_shadowed: &BTreeSet<String>,
     declared_pure: &BTreeSet<String>,
     graph: &ChunkCodeGraph,
 ) -> Purity {
     // Author-declared pure binding: a chunk-local function whose
     // spec member carries `purity: "pure"`. The annotation is an
     // explicit override and wins over both the whitelist and the
-    // shadowing check (the spec author asserts that THIS bound
-    // value is pure regardless of what its body does or whether
-    // an import shadows the name). See AGENTS.md "Declared
-    // purity".
+    // chunk-top (A8) shadowing check — the spec author asserts that
+    // THIS bound value is pure regardless of what its body does or
+    // whether an import shadows the name. It does NOT win over a
+    // body-local binding of the same name (`local_shadowed`): a
+    // function param or local var is a *different value* than the
+    // chunk-top binding the author annotated, so the trust contract
+    // doesn't cover it. See AGENTS.md "Declared purity".
     if let Expr::Ident(ident) = callee_expr
         && declared_pure.contains(ident.sym.as_ref())
+        && !local_shadowed.contains(ident.sym.as_ref())
     {
-        return all_args_pure(args, shadowed, plain_data_shadowed, declared_pure, graph);
+        return all_args_pure(args, shadowed, local_shadowed, declared_pure, graph);
     }
     // Author-declared pure member call: a binding whose spec member
     // carries `pure_members: [<prop>, …]`. Admits
@@ -2191,25 +2577,32 @@ fn classify_callee_call(
     // and the opt-call form (`b.forwardRef?.(args)`, callee =
     // `Expr::Member`) qualify under the same admission rule via
     // `static_member_obj_prop`. As with `purity: pure` on a
-    // direct-Ident call, the annotation overrides shadowing — the
-    // spec author asserts THIS bound value is pure regardless of
-    // where it came from. See AGENTS.md "Declared purity".
+    // direct-Ident call, the annotation overrides chunk-top (A8)
+    // shadowing — the spec author asserts THIS bound value is pure
+    // regardless of where it came from — but NOT a body-local
+    // binding of the same name (a param/local is a different value
+    // than the annotated chunk-top binding). See AGENTS.md
+    // "Declared purity".
     if let Some((recv, prop)) = static_member_obj_prop(callee_expr)
+        && !local_shadowed.contains(recv)
         && graph.is_declared_pure_member(recv, prop)
     {
-        return all_args_pure(args, shadowed, plain_data_shadowed, declared_pure, graph);
+        return all_args_pure(args, shadowed, local_shadowed, declared_pure, graph);
     }
     // Chunk-local function declaration: consult the per-chunk
     // function-body purity cache. `Pure` callee + Pure args → Pure;
     // non-Pure callee inherits its reasons (so the chain points
     // back through to the unhandled construct in the function body).
+    // A body-local binding of the same name shadows the chunk-top
+    // function — the called value is unknown then.
     if let Expr::Ident(ident) = callee_expr
+        && !local_shadowed.contains(ident.sym.as_ref())
         && let Some(callee_purity) = graph.function_purity(ident.sym.as_ref())
     {
         return callee_purity.worst(all_args_pure(
             args,
             shadowed,
-            plain_data_shadowed,
+            local_shadowed,
             declared_pure,
             graph,
         ));
@@ -2218,9 +2611,10 @@ fn classify_callee_call(
     if let Expr::Member(member) = callee_expr
         && let Some((recv, prop)) = static_member_pair(member)
         && !shadowed.contains(recv)
+        && !local_shadowed.contains(recv)
         && PURE_STATIC_CALLS.contains(&(recv, prop))
     {
-        return all_args_pure(args, shadowed, plain_data_shadowed, declared_pure, graph);
+        return all_args_pure(args, shadowed, local_shadowed, declared_pure, graph);
     }
     // `Object.{entries,keys,values,freeze}(<plain-data arg>)` /
     // `Object.fromEntries(<entry-array literal>)` — admitted when
@@ -2233,6 +2627,7 @@ fn classify_callee_call(
     if let Expr::Member(member) = callee_expr
         && let Some((recv, prop)) = static_member_pair(member)
         && !shadowed.contains(recv)
+        && !local_shadowed.contains(recv)
         && PURE_OBJECT_CALLS_ON_PLAIN_DATA.contains(&(recv, prop))
         && args.len() == 1
         && args[0].spread.is_none()
@@ -2240,7 +2635,7 @@ fn classify_callee_call(
             prop,
             &args[0].expr,
             shadowed,
-            plain_data_shadowed,
+            local_shadowed,
             declared_pure,
             graph,
         )
@@ -2254,8 +2649,9 @@ fn classify_callee_call(
             .copied()
             .find(|n| *n == ident.sym.as_ref())
         && !shadowed.contains(name)
+        && !local_shadowed.contains(name)
     {
-        return all_args_pure(args, shadowed, plain_data_shadowed, declared_pure, graph);
+        return all_args_pure(args, shadowed, local_shadowed, declared_pure, graph);
     }
     // `globalCallable(prim_lit, …)` against
     // PURE_GLOBAL_CALLS_WITH_PRIMITIVE_ARGS. Every argument
@@ -2270,6 +2666,7 @@ fn classify_callee_call(
             .copied()
             .find(|n| *n == ident.sym.as_ref())
         && !shadowed.contains(name)
+        && !local_shadowed.contains(name)
         && args
             .iter()
             .all(|arg| arg.spread.is_none() && is_primitive_literal(&arg.expr))
@@ -2328,7 +2725,7 @@ fn is_pure_plain_data_arg_for(
     prop: &str,
     arg: &Expr,
     shadowed: &BTreeSet<&'static str>,
-    plain_data_shadowed: &BTreeSet<String>,
+    local_shadowed: &BTreeSet<String>,
     declared_pure: &BTreeSet<String>,
     graph: &ChunkCodeGraph,
 ) -> bool {
@@ -2342,7 +2739,7 @@ fn is_pure_plain_data_arg_for(
             && is_fresh_entry_array_for_from_entries(
                 arg,
                 shadowed,
-                plain_data_shadowed,
+                local_shadowed,
                 declared_pure,
                 graph,
             );
@@ -2353,19 +2750,18 @@ fn is_pure_plain_data_arg_for(
         // local binding of the same name lexically shadows it, in which
         // case `ident` is the local (possibly getter-bearing) value.
         Expr::Ident(ident) => {
-            graph.is_plain_data(ident.sym.as_ref())
-                && !plain_data_shadowed.contains(ident.sym.as_ref())
+            graph.is_plain_data(ident.sym.as_ref()) && !local_shadowed.contains(ident.sym.as_ref())
         }
         // Fresh object literal with no accessor channels.
         Expr::Object(obj) => {
             obj.props.iter().all(is_plain_data_prop)
-                && classify_expr_purity(arg, shadowed, plain_data_shadowed, declared_pure, graph)
+                && classify_expr_purity(arg, shadowed, local_shadowed, declared_pure, graph)
                     .is_pure()
         }
         // Fresh array literal; element purity (including spread
         // sources) is handled by the standard literal classifier.
         Expr::Array(_) => {
-            classify_expr_purity(arg, shadowed, plain_data_shadowed, declared_pure, graph).is_pure()
+            classify_expr_purity(arg, shadowed, local_shadowed, declared_pure, graph).is_pure()
         }
         _ => false,
     }
@@ -2381,7 +2777,7 @@ fn is_pure_plain_data_arg_for(
 fn is_fresh_entry_array_for_from_entries(
     arg: &Expr,
     shadowed: &BTreeSet<&'static str>,
-    plain_data_shadowed: &BTreeSet<String>,
+    local_shadowed: &BTreeSet<String>,
     declared_pure: &BTreeSet<String>,
     graph: &ChunkCodeGraph,
 ) -> bool {
@@ -2403,14 +2799,8 @@ fn is_fresh_entry_array_for_from_entries(
         }
         entry.elems.iter().flatten().all(|kv| {
             kv.spread.is_none()
-                && classify_expr_purity(
-                    &kv.expr,
-                    shadowed,
-                    plain_data_shadowed,
-                    declared_pure,
-                    graph,
-                )
-                .is_pure()
+                && classify_expr_purity(&kv.expr, shadowed, local_shadowed, declared_pure, graph)
+                    .is_pure()
         })
     })
 }
@@ -2435,10 +2825,78 @@ fn is_primitive_literal(expr: &Expr) -> bool {
     )
 }
 
+/// Whether evaluating `expr` is statically guaranteed to produce a
+/// **primitive** value, so a parent operator's ToPrimitive /
+/// ToString / ToNumber / ToPropertyKey coercion of the RESULT
+/// cannot fire user code. This predicate only answers "is the
+/// resulting value primitive?" — the operand's own evaluation
+/// effects are classified separately by the regular purity
+/// recursion.
+///
+/// Admitted result-primitive shapes:
+/// * primitive literals (string / number / boolean / null / bigint;
+///   regex literals are objects and excluded);
+/// * template literals (always evaluate to a string);
+/// * any unary operator except `delete` (`typeof` → string, `void`
+///   → undefined, `!` → boolean, `+`/`-`/`~` → number/bigint);
+/// * any binary operator except the short-circuit logicals
+///   (`&&` / `||` / `??` return one of their operands verbatim;
+///   everything else — arithmetic, relational, equality, bitwise,
+///   `in`, `instanceof` — returns a number/string/bigint/boolean);
+/// * conditionals whose both branches are result-primitive.
+///
+/// The global `undefined` is deliberately NOT admitted: it is an
+/// ordinary (shadowable) global binding, not a keyword, and the
+/// shadowed-globals pass doesn't track it. Over-restriction is the
+/// acceptable failure mode.
+///
+/// No admitted shape can produce a Symbol, so ToString on a
+/// result-primitive value never hits the symbol TypeError path.
+fn is_result_primitive(expr: &Expr) -> bool {
+    match strip_parens(expr) {
+        Expr::Lit(Lit::Str(_) | Lit::Num(_) | Lit::Bool(_) | Lit::Null(_) | Lit::BigInt(_)) => true,
+        Expr::Tpl(_) => true,
+        Expr::Unary(u) => u.op != UnaryOp::Delete,
+        Expr::Bin(b) => !matches!(
+            b.op,
+            BinaryOp::LogicalAnd | BinaryOp::LogicalOr | BinaryOp::NullishCoalescing
+        ),
+        Expr::Cond(c) => is_result_primitive(&c.cons) && is_result_primitive(&c.alt),
+        _ => false,
+    }
+}
+
+/// Whether `key` is a safe computed property key: ToPropertyKey on
+/// its value fires no user code. True for result-primitive
+/// expressions (string/number coercion of a primitive is
+/// engine-only) and for whitelisted well-known-symbol reads
+/// (`Symbol.iterator` etc. — Symbols are valid property keys with
+/// no coercion path), provided neither the global `Symbol` nor a
+/// local binding shadows the receiver.
+fn is_safe_property_key(
+    key: &Expr,
+    shadowed: &BTreeSet<&'static str>,
+    local_shadowed: &BTreeSet<String>,
+) -> bool {
+    if is_result_primitive(key) {
+        return true;
+    }
+    if let Expr::Member(member) = strip_parens(key)
+        && let Some((recv, prop)) = static_member_pair(member)
+        && recv == "Symbol"
+        && !shadowed.contains(recv)
+        && !local_shadowed.contains(recv)
+        && PURE_STATIC_PROPS.contains(&(recv, prop))
+    {
+        return true;
+    }
+    false
+}
+
 fn all_args_pure(
     args: &[ExprOrSpread],
     shadowed: &BTreeSet<&'static str>,
-    plain_data_shadowed: &BTreeSet<String>,
+    local_shadowed: &BTreeSet<String>,
     declared_pure: &BTreeSet<String>,
     graph: &ChunkCodeGraph,
 ) -> Purity {
@@ -2448,13 +2906,8 @@ fn all_args_pure(
             let spread = arg
                 .spread
                 .map(|sp| Purity::from_reason(PurityRule::ArraySpread, sp));
-            let body = classify_expr_purity(
-                &arg.expr,
-                shadowed,
-                plain_data_shadowed,
-                declared_pure,
-                graph,
-            );
+            let body =
+                classify_expr_purity(&arg.expr, shadowed, local_shadowed, declared_pure, graph);
             spread.unwrap_or(Purity::Pure).worst(body)
         })
         .fold(Purity::Pure, Purity::worst)
@@ -2463,7 +2916,7 @@ fn all_args_pure(
 fn classify_prop_purity(
     prop: &PropOrSpread,
     shadowed: &BTreeSet<&'static str>,
-    plain_data_shadowed: &BTreeSet<String>,
+    local_shadowed: &BTreeSet<String>,
     declared_pure: &BTreeSet<String>,
     graph: &ChunkCodeGraph,
 ) -> Purity {
@@ -2473,34 +2926,24 @@ fn classify_prop_purity(
             // iterator (array spread) or property iteration
             // (object spread). Either can fire a getter or a
             // user-defined `[Symbol.iterator]`.
-            classify_expr_purity(
-                &spread.expr,
-                shadowed,
-                plain_data_shadowed,
-                declared_pure,
-                graph,
-            )
-            .worst(Purity::from_reason(
-                PurityRule::ObjectSpread,
-                spread.expr.span(),
-            ))
+            classify_expr_purity(&spread.expr, shadowed, local_shadowed, declared_pure, graph)
+                .worst(Purity::from_reason(
+                    PurityRule::ObjectSpread,
+                    spread.expr.span(),
+                ))
         }
         PropOrSpread::Prop(prop) => match prop.as_ref() {
             Prop::Shorthand(_) => Purity::Pure,
-            Prop::KeyValue(kv) => classify_propname_purity(
-                &kv.key,
-                shadowed,
-                plain_data_shadowed,
-                declared_pure,
-                graph,
-            )
-            .worst(classify_expr_purity(
-                &kv.value,
-                shadowed,
-                plain_data_shadowed,
-                declared_pure,
-                graph,
-            )),
+            Prop::KeyValue(kv) => {
+                classify_propname_purity(&kv.key, shadowed, local_shadowed, declared_pure, graph)
+                    .worst(classify_expr_purity(
+                        &kv.value,
+                        shadowed,
+                        local_shadowed,
+                        declared_pure,
+                        graph,
+                    ))
+            }
             Prop::Assign(a) => Purity::from_reason(PurityRule::ObjectAssignProp, a.key.span),
             // `{ get x() {}, set x(v) {}, m() {} }` — defining a
             // method or accessor is pure; invoking it is not, and
@@ -2513,7 +2956,7 @@ fn classify_prop_purity(
 fn classify_propname_purity(
     name: &PropName,
     shadowed: &BTreeSet<&'static str>,
-    plain_data_shadowed: &BTreeSet<String>,
+    local_shadowed: &BTreeSet<String>,
     declared_pure: &BTreeSet<String>,
     graph: &ChunkCodeGraph,
 ) -> Purity {
@@ -2521,44 +2964,100 @@ fn classify_propname_purity(
         PropName::Ident(_) | PropName::Str(_) | PropName::Num(_) | PropName::BigInt(_) => {
             Purity::Pure
         }
+        // Defining a property under a computed key runs
+        // ToPropertyKey on the key value — an object key fires user
+        // `toString` / `[Symbol.toPrimitive]`. The key must be
+        // statically primitive-valued (or a well-known Symbol) in
+        // addition to being pure to evaluate.
         PropName::Computed(c) => {
-            classify_expr_purity(&c.expr, shadowed, plain_data_shadowed, declared_pure, graph)
+            let key_purity =
+                classify_expr_purity(&c.expr, shadowed, local_shadowed, declared_pure, graph);
+            if is_safe_property_key(&c.expr, shadowed, local_shadowed) {
+                key_purity
+            } else {
+                key_purity.worst(Purity::from_reason_with_detail(
+                    PurityRule::ToPropertyKeyCoercion,
+                    c.span,
+                    "computed key runs ToPropertyKey on a possibly-object value".to_string(),
+                ))
+            }
         }
     }
 }
 
 /// Whether a class declaration runs observable code at class-decl
-/// time. Static blocks always run; static fields run their
-/// initializer. `extends <expr>` is at-init: the expression itself
-/// runs, but `extends` references are tracked as `R`-edges
-/// elsewhere — here we only report whether the class itself
-/// _additionally_ has observable side-effecting init code.
+/// time. Eagerly-evaluated class parts (aligned with the fact
+/// collector's `visit_eager_member_parts` / `visit_class_decl`):
+///
+/// * **decorators** (class-level or member-level) — decorator
+///   application CALLS the decorator function at class-definition
+///   time; any decorator present is observable.
+/// * **`extends <expr>`** — the superclass expression evaluates at
+///   class-definition time; an impure expression (e.g.
+///   `extends f()`) is observable. A pure-classified expression
+///   (Ident etc.) is admitted: reading `.prototype` off a plain
+///   constructor fires no user code (function `prototype` is an
+///   own data property; the Proxy-superclass case falls under
+///   assumption A11, intrinsic/exotic-object integrity).
+/// * **computed member keys** (any member kind, static or not) —
+///   key expressions evaluate eagerly AND their values undergo
+///   ToPropertyKey (user `toString` on object keys), so the key
+///   must be pure and statically primitive-valued (or a well-known
+///   `Symbol.*`).
+/// * **static field / static auto-accessor initializers** — run at
+///   class-definition time; impure initializer is observable.
+///
+/// Static blocks always run. Instance field/accessor initializers,
+/// constructor and method bodies are lazy and not consulted.
 pub(crate) fn class_has_static_observable(
     class: &Class,
     shadowed: &BTreeSet<&'static str>,
-    plain_data_shadowed: &BTreeSet<String>,
+    local_shadowed: &BTreeSet<String>,
     declared_pure: &BTreeSet<String>,
     graph: &ChunkCodeGraph,
 ) -> bool {
+    let value_impure = |v: &Expr| {
+        !classify_expr_purity(v, shadowed, local_shadowed, declared_pure, graph).is_pure()
+    };
+    let key_observable = |key: &PropName| match key {
+        PropName::Ident(_) | PropName::Str(_) | PropName::Num(_) | PropName::BigInt(_) => false,
+        PropName::Computed(c) => {
+            value_impure(&c.expr) || !is_safe_property_key(&c.expr, shadowed, local_shadowed)
+        }
+    };
+    if !class.decorators.is_empty() {
+        return true;
+    }
+    if let Some(super_class) = class.super_class.as_deref()
+        && value_impure(super_class)
+    {
+        return true;
+    }
     class.body.iter().any(|member| match member {
         ClassMember::StaticBlock(_) => true,
-        ClassMember::ClassProp(prop) if prop.is_static => prop
-            .value
-            .as_deref()
-            .map(|v| {
-                classify_expr_purity(v, shadowed, plain_data_shadowed, declared_pure, graph)
-                    != Purity::Pure
-            })
-            .unwrap_or(false),
-        ClassMember::PrivateProp(prop) if prop.is_static => prop
-            .value
-            .as_deref()
-            .map(|v| {
-                classify_expr_purity(v, shadowed, plain_data_shadowed, declared_pure, graph)
-                    != Purity::Pure
-            })
-            .unwrap_or(false),
-        _ => false,
+        ClassMember::Method(method) => {
+            !method.function.decorators.is_empty() || key_observable(&method.key)
+        }
+        ClassMember::PrivateMethod(method) => !method.function.decorators.is_empty(),
+        ClassMember::Constructor(_) => false,
+        ClassMember::ClassProp(prop) => {
+            !prop.decorators.is_empty()
+                || key_observable(&prop.key)
+                || (prop.is_static && prop.value.as_deref().is_some_and(value_impure))
+        }
+        ClassMember::PrivateProp(prop) => {
+            !prop.decorators.is_empty()
+                || (prop.is_static && prop.value.as_deref().is_some_and(value_impure))
+        }
+        ClassMember::AutoAccessor(accessor) => {
+            !accessor.decorators.is_empty()
+                || (match &accessor.key {
+                    Key::Public(name) => key_observable(name),
+                    Key::Private(_) => false,
+                })
+                || (accessor.is_static && accessor.value.as_deref().is_some_and(value_impure))
+        }
+        ClassMember::TsIndexSignature(_) | ClassMember::Empty(_) => false,
     })
 }
 

--- a/devinfra/js/debundle/purity/redundant_hints_tests.rs
+++ b/devinfra/js/debundle/purity/redundant_hints_tests.rs
@@ -54,9 +54,9 @@ fn analyze_redundant_hints(
 #[test]
 fn redundant_hint_on_pure_function_is_reported() {
     // `f` is a chunk-local arrow whose body classifies pure on
-    // its own (returns a primitive literal). The hint is a no-op
+    // its own (returns a fresh literal). The hint is a no-op
     // — the analyzer reaches the same verdict without it.
-    let got = redundant_hints("const f = (x) => x + 1;", &["f"]);
+    let got = redundant_hints("const f = (x) => ({ val: x });", &["f"]);
     assert_eq!(
         got,
         vec![("f".to_string(), RedundantPurityReason::InferredPureFunction)]
@@ -115,16 +115,16 @@ fn hint_on_unknown_binding_is_not_reported() {
 #[test]
 fn hint_chain_keeps_only_genuinely_redundant_entries() {
     // `a` calls `b`; `b`'s body is itself pure (returns
-    // `x + 1`). Per-hint independent removal:
+    // `[x]`). Per-hint independent removal:
     // - Drop `a`'s hint → analyzer probes `a` with declared_pure
     //   = {b}. Inside `a`'s body, `b(x)` is hint-pure → `a`'s
     //   body classifies pure → `a` reported redundant.
     // - Drop `b`'s hint → analyzer probes `b` with declared_pure
-    //   = {a}. `b`'s body `x + 1` is pure on its own (no calls
+    //   = {a}. `b`'s body `[x]` is pure on its own (no calls
     //   at all) → `b` reported redundant.
     // Both hints are redundant.
     let src = r#"
-    const b = (x) => x + 1;
+    const b = (x) => [x];
     const a = (x) => b(x);
 "#;
     let got = redundant_hints(src, &["a", "b"]);
@@ -174,7 +174,7 @@ fn no_hints_produces_no_warnings() {
     // functions. The analyzer doesn't invent warnings about
     // "you could have added a hint here" — it only reports
     // existing hints that are redundant.
-    let got = redundant_hints("const f = (x) => x + 1;", &[]);
+    let got = redundant_hints("const f = (x) => [x];", &[]);
     assert!(
         got.is_empty(),
         "empty declared_pure must produce no warnings; got {got:?}"
@@ -182,23 +182,26 @@ fn no_hints_produces_no_warnings() {
 }
 
 #[test]
-fn redundant_hint_on_let_with_whole_object_replacement_is_reported() {
+fn hint_on_opaque_key_accessor_is_load_bearing() {
     // The gaffer env_config shape: `let X = {…}` with whole-
-    // object replacement writes; `purity: pure` on the
-    // accessor function `getX` is redundant once X admits as
-    // PlainData (Part 2). This is the test that pins the
-    // motivating downstream removal — if it fails after some
-    // future refactor, the gaffer hint-removal regresses.
+    // object replacement writes keeps X PlainData, but the
+    // accessor `getEnv = (n) => envConfig[n]` coerces an opaque
+    // key via ToPropertyKey (user `toString` on an object key),
+    // so it is NOT inferred pure. The `purity: pure` hint on it
+    // is genuinely load-bearing and must not be flagged
+    // redundant. A static-prop accessor IS inferred pure and its
+    // hint flagged.
     let src = r#"
     let envConfig = { REACT_APP_ENV: "production" };
     const applyOverrides = (n) => { envConfig = { ...envConfig, ...n }; };
     const getEnv = (n) => envConfig[n];
+    const getAppEnv = () => envConfig.REACT_APP_ENV;
 "#;
-    let got = redundant_hints(src, &["getEnv"]);
+    let got = redundant_hints(src, &["getEnv", "getAppEnv"]);
     assert_eq!(
         got,
         vec![(
-            "getEnv".to_string(),
+            "getAppEnv".to_string(),
             RedundantPurityReason::InferredPureFunction
         )]
     );

--- a/devinfra/js/debundle/purity/whitelists.rs
+++ b/devinfra/js/debundle/purity/whitelists.rs
@@ -5,6 +5,9 @@
 //! citation showing no user-callback path; "common in practice" is not
 //! sufficient.
 
+use std::collections::BTreeSet;
+use std::sync::LazyLock;
+
 /// Builtins that can install an accessor or rewire the prototype chain
 /// of their first argument. Any candidate appearing as the first
 /// positional arg of one of these calls is disqualified from
@@ -226,3 +229,24 @@ pub(super) const PURE_OBJECT_CALLS_ON_PLAIN_DATA: &[(&str, &str)] = &[
 /// e.g. `const Math = …` makes `Math.PI` fall back to `Unknown`.
 pub(crate) const WHITELIST_RECEIVERS: &[&str] =
     &["Math", "Array", "Symbol", "Number", "Boolean", "Object"];
+
+/// Every global name any whitelist table keys on, derived as the
+/// union of all tables. `compute_shadowed_globals` tracks exactly
+/// this set, so adding a table (or an entry naming a new global)
+/// automatically extends shadow tracking — a name missing from the
+/// tracked set would make the classifier blind to `const Map = …`
+/// at chunk top and let `new Map()` classify `Pure` against a
+/// user-defined value.
+pub(crate) static SHADOW_TRACKED_GLOBALS: LazyLock<BTreeSet<&'static str>> = LazyLock::new(|| {
+    let mut names: BTreeSet<&'static str> = BTreeSet::new();
+    names.extend(WHITELIST_RECEIVERS.iter().copied());
+    names.extend(PURE_STATIC_PROPS.iter().map(|(r, _)| *r));
+    names.extend(PURE_STATIC_CALLS.iter().map(|(r, _)| *r));
+    names.extend(PURE_STATIC_FUNCTION_REFS.iter().map(|(r, _)| *r));
+    names.extend(PURE_OBJECT_CALLS_ON_PLAIN_DATA.iter().map(|(r, _)| *r));
+    names.extend(PURE_GLOBAL_CALLS.iter().copied());
+    names.extend(PURE_GLOBAL_CALLS_WITH_PRIMITIVE_ARGS.iter().copied());
+    names.extend(PURE_BUILTIN_NEW_NO_ARGS.iter().copied());
+    names.extend(PURE_BUILTIN_NEW_ARRAY_ITERABLE.iter().copied());
+    names
+});


### PR DESCRIPTION
Every hole below let a Pure-classified statement fire user code, dropping S edges the realizability theorem needs. Per the soundness-over-completeness contract, several fixes are deliberate conservative shifts; affected pinned expectations are updated with notes.

## 1. Dead shadow tracking for non-receiver whitelist names

**Counterexample:** `const Map = class { constructor() { globalThis.boom = 1; } }; new Map();` classified Pure — `compute_shadowed_globals` only inserted `WHITELIST_RECEIVERS`, so the `PURE_BUILTIN_NEW_*` shadow checks compared against a set that could never contain `Map`.

**Fix (structural):** `SHADOW_TRACKED_GLOBALS` is derived as the union of every whitelist table (receivers, static props/calls/function-refs, plain-data calls, global calls, primitive-arg calls, builtin-new tables); `compute_shadowed_globals` tracks exactly that set, so a future table can't lack shadow coverage. Paired tests: `shadowed_builtin_new_falls_back_to_unknown` / `unshadowed_builtin_new_is_pure`.

## 2. Body-level shadowing only handled for PlainData

**Counterexample:** `function helper() { return 1; } function outer(helper) { return helper(); }` — the param `helper` is a caller-supplied value, but the body resolved it through the chunk function-purity cache and classified `outer` Pure. Same hole for whitelist receivers (`function f(Math) { return Math.PI; }`), builtin-new (`function f(Map) { return new Map(); }`), and spec annotations (`declared_pure`, `pure_members`, `pure_new` — a param is a different value than the binding the author vouched for).

**Fix:** the existing `plain_data_shadowed` mechanism is generalized to `local_shadowed` = all `param_and_body_bindings`, gated at every global-table / chunk-graph / annotation resolution site. The `purity: pure` override still wins over chunk-top (A8) shadowing per the documented contract — only body-local bindings defeat it.

## 3. Operator/template coercion

**Counterexample:** `const A = obj + 1;` classified Pure, but `+` runs ToPrimitive on `obj`, firing user `valueOf` that can write globals.

**Fix:** op discrimination. `&& || ?? === !== ! typeof void` and comma stay operand-purity-only. Coercing ops (`+ - * / % ** < <= > >= == != << >> >>> & | ^`, unary `+ - ~`, template interpolation) are Pure only when each coerced operand is statically primitive-valued (`is_result_primitive`: literals, templates, non-logical binary results, unary results, primitive-branch conditionals; shadowable `undefined` deliberately not admitted). `in`/`instanceof` are never Pure (proxy `has` / `@@hasInstance` on the RHS object). **Deliberate conservative shift:** `A + 1` (classifier_tests:149) now NotPure; mutual-recursion fixtures rewritten to avoid `n - 1`. e2e pin: `coercing_operator_on_opaque_operand_still_emits_s_edges`.

## 4. Destructuring declarators

**Counterexample:** `const {a} = o;` classified by init purity only — object patterns fire getters, array patterns fire the iterator protocol.

**Fix:** non-Ident declarator patterns classify NotPure (simplest sound; a fresh-plain-data-RHS carve-out was considered and deliberately not taken — documented at the rule). Covered at chunk top (`classify_var_decl_purity`) and inside bodies (`BodyPurityCollector::visit_var_declarator`). e2e pin: `destructuring_declarators_still_emit_s_edges`.

## 5. Parameter evaluation

**Counterexample:** `const f = (x = (globalThis.boom = 1)) => 1;` was pure-callable — `visit_body_with` never visited params.

**Fix:** params are now driven through both the purity walk (default exprs classify like body code) and the call-graph walk (a call edge hidden in a default no longer skips SCC ordering and freezes the callee at optimistic Pure). Destructuring params make the function not pure-callable.

## 6. Class definition effects

**Fix:** `class_has_static_observable` now covers `extends <expr>` side effects (`class extends f() {}`), computed member keys for any member kind with a ToPropertyKey primitivity gate (well-known `Symbol.*` keys admitted), static auto-accessor initializers, and decorators (application calls the decorator at definition time) — aligned with the fact collector's eager-member-parts view.

## 7. Iteration statements in bodies

**Counterexample:** `function f(xs) { for (const x of xs) {} }` was Pure — for-of fires `[Symbol.iterator]`, for-in fires proxy enumeration traps.

**Fix:** `BodyPurityCollector` flags for-of / for await-of / for-in with a new `IterationProtocol` reason. Plain `while`/C-style `for` stay purity-neutral.

## 8. ToPropertyKey on computed reads

**Counterexample:** `const TA = {...}; const Me = (n) => TA[n];` was Pure — ToPropertyKey on an object key fires user `toString` even though the PlainData receiver is accessor-free.

**Fix:** computed keys (PlainData member reads, object-literal keys, class member keys) require statically-primitive keys or well-known `Symbol.*`. **Deliberate re-restriction:** the pinned `getEnv = (n) => envConfig[n]` walkthrough shapes (graph_purity_tests:768 etc.) now expect NotPure, with notes that one `purity: pure` hint on the accessor recovers the chain (`plain_data_chain_collapses_size_33_walkthrough_shape` shows 1 hint instead of 4). The redundant-hint test for that shape flips to load-bearing (`hint_on_opaque_key_accessor_is_load_bearing`).

## 9. PlainData escape analysis

**Counterexample:** `const X = {a:1}; const Y = X; Object.defineProperty(Y, "a", {get: ...});` kept X PlainData — the hostile-write scan is name-based and only caught literal-first-arg shapes.

**Fix:** any escaping bare candidate reference (alias RHS, call/new arg, array element, object property value, conditional alias) disqualifies. A short allowlist of provably non-capturing positions keeps admission: member receiver, spread source, `typeof`/`!`/`void`, `Object.{keys,values,entries,freeze,fromEntries}` single arg with `Object` unshadowed, the vetted TS-enum-IIFE argument, `return X` / `() => X`, `export { X }` (the return/export residual assumption is documented in docs/purity_soundness.md).

## 10. Debt

- `PURE_STATIC_FUNCTION_REFS` alias-pure / call-unknown tests are now table-driven over all 22 entries (entries also in `PURE_STATIC_CALLS` are call-pure by their own contract and skipped in the negative direction).
- Intrinsic integrity (prototype pollution of `Set.prototype.add` / `Array.prototype[Symbol.iterator]` defeats whitelist citations) documented as assumption **A11** in docs/design.md, with an AGENTS.md pointer in "Pure-call whitelist soundness".
- Stale `#[ignore]` on the collection-constructor e2e narrowed: Set/Map array-literal forms landed (`PURE_BUILTIN_NEW_ARRAY_ITERABLE`); remaining blocker is `new RegExp(...)`.
- The `Reflect.defineProperties` comment fix (nonexistent builtin) landed as part of the rewritten hostile-builtins comment block.

## Verification

- `bbr test //devinfra/js/debundle/...` — 82/82 green
- `bbr build //props/frontend/...` — green (the former `props/frontend/debundle` pipeline corpus no longer exists on devel; this is the remaining coverage there)
- `bbr build //...` green; `bbr test //...` — only pre-existing `.live` credential-gated tests fail (CI-excluded by tag)

https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk)_