### PR TITLE
cluster: put Flux controller args in component base

### DIFF
--- a/cluster/k8s/flux-system/gotk-components.yaml
+++ b/cluster/k8s/flux-system/gotk-components.yaml
@@ -3377,6 +3377,8 @@ spec:
         - --log-level=info
         - --log-encoding=json
         - --enable-leader-election
+        - --concurrent=8
+        - --requeue-dependency=30s
         env:
         - name: RUNTIME_NAMESPACE
           valueFrom:

--- a/cluster/k8s/flux-system/kustomization.yaml
+++ b/cluster/k8s/flux-system/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  # Keep controller args that must survive raw Terraform bootstrap applies in
+  # gotk-components.yaml instead of overlay-only patches.
   - gotk-components.yaml
   # Keep root GitRepository fields that must survive raw Terraform bootstrap
   # applies, such as auth and sparseCheckout, in gotk-sync.yaml.
@@ -14,22 +16,3 @@ patches:
       - op: add
         path: /metadata/labels/goldilocks.fairwinds.com~1enabled
         value: "false"
-  # Reconcile with moderate fan-out. With 244 Kustomizations and dependsOn
-  # chains up to 9 deep, the upstream defaults serialise propagation:
-  #   --concurrent=4          — at most 4 Kustomizations in flight at a time
-  #   --requeue-dependency=30s — wait 30s before re-checking a not-yet-ready dep
-  # Keep some extra fan-out so healthy pushes still settle promptly, but keep
-  # dependency retries at the upstream interval. A 5s retry loop amplified
-  # unhealthy dependency chains into persistent kustomize-controller churn and
-  # control-plane disk writes.
-  - target:
-      kind: Deployment
-      name: kustomize-controller
-      namespace: flux-system
-    patch: |
-      - op: add
-        path: /spec/template/spec/containers/0/args/-
-        value: --concurrent=8
-      - op: add
-        path: /spec/template/spec/containers/0/args/-
-        value: --requeue-dependency=30s


### PR DESCRIPTION
## Summary

- move the `kustomize-controller` args that tune reconcile fan-out into `gotk-components.yaml`
- remove the now-redundant Kustomize patch for those args
- document that controller args needed during raw Terraform bootstrap should live in the component base manifest

## Validation

- `kubectl kustomize cluster/k8s/flux-system` renders `--concurrent=8` and `--requeue-dependency=30s` on `Deployment/kustomize-controller`
- `kubectl diff -f cluster/k8s/flux-system/gotk-components.yaml` is empty against live, so raw Terraform bootstrap apply no longer wants to remove those args
- `bbr build //cluster/validation:validate_all`

## Note

This resolves the remaining raw `gotk-components.yaml` mismatch found while reviewing `null_resource.flux_bootstrap`.