### PR TITLE
debundle: gate partial-swap consumers, fix boundary-rename and wrapper collisions

### DIFF
--- a/devinfra/js/debundle/docs/design.md
+++ b/devinfra/js/debundle/docs/design.md
@@ -2619,6 +2619,89 @@ where emission discovers new graph edges or silently mutates the
 assignment, because that reintroduces hidden closure behavior and
 makes diagnostics disagree with emitted output.
 
+## Vendor chunk swapping
+
+The `vendor` spec map classifies chunks as vendor code at one of four
+levels: `suppress` (annotation only — the chunk and its callers pass
+through byte-identical), `boundary_rename` (rewrite caller imports
+from vendor-local names to the vendor's public export names),
+`swap` (replace the whole chunk with an upstream npm package), and
+`partial_swap` / `bundled_partial_swap` (swap a subset of the chunk's
+exports against upstream packages and strip the swapped bodies from
+the residual chunk). Soundness edges that are deliberate contracts
+rather than missing features are documented here.
+
+### Full swap: callers are proxy/import-map-dependent
+
+`level: swap` removes the vendor chunk from the artifact. Caller
+imports of the removed chunk are **intentionally left dangling** in
+the plain `write_js_tree` output: the live-proxy / import-map layer
+(<../live_proxy/>) resolves the dangling chunk specifier to the
+swapped package at serve time. The plain emitted tree is therefore
+not directly runnable under bare Node when a full swap is configured.
+Pinned by `full_swap_with_caller_keeps_dangling_chunk_import_for_live_proxy`
+in <../e2e/vendor_swap_test.rs>.
+
+### Partial swap: consumer rewrites and the post-strip gate
+
+Per-symbol partial swaps rewrite two consumer shapes in retained
+files: named `ImportDecl` specifiers and `export { x } from
+"<chunk>"` re-exports of swapped names (`kind: named` / `default` /
+`namespace`). Shapes with no live rewrite — `import * as M` namespace
+imports of the chunk, `export *` from the chunk, and re-exports of
+`kind: member` symbols or bundled-swap symbols — are rejected by the
+**post-strip consumer gate** (`validate_partial_swap_consumers`),
+which scans every retained file after the strip pass and bails on any
+surviving reference to the stripped export surface. Over-restriction
+is the accepted failure mode: a namespace consumer that happens to
+read only non-swapped members is still rejected, because per-member
+usage is not analyzed.
+
+### Deliberate split-brain bypasses in the strip pass
+
+The strip pass bails on "split-brain" items — top-level items
+reachable both from the residual chunk's exports and from a swapped
+package's bodies, where stripping would leave the residual and the
+upstream package each holding half of a shared value. Two bypasses
+deliberately weaken that bail:
+
+- **Multi-package items**: the split-brain bail fires only when the
+  item is reachable from exactly **one** swapped package
+  (`packages.len() == 1` in <../vendor/strip.rs>). An item shared by
+  two or more swapped packages has no single upstream home, so it is
+  retained in the residual chunk and effectively duplicated relative
+  to the upstream packages.
+- **Shareable helpers**: items classified `shareable_helper`
+  (syntactically stateless shapes — function declarations,
+  primitive-literal consts, function-valued consts, intrinsic
+  aliases, Vite preload-map cells) are exempt from the split-brain
+  bail and may be duplicated between the residual chunk and the
+  upstream package.
+
+Both bypasses share the same rationale and the same risk. Rationale:
+duplicating a stateless value is observationally harmless, and
+bailing would reject many real specs. Risk: if a "helper" actually
+carries state (a memo cache, a registry object, a closure over a
+mutable cell — or a multi-package item holding module-level state),
+duplication forks that state — the residual chunk and the upstream
+package each get their own instance, and identity checks or cache
+coherence between them silently break. The `shareable_helper`
+classifier is syntactic and cannot see state hidden behind a
+function value; treat new classifier shapes with suspicion.
+
+### Wrapper re-exports are init-time snapshots, not live bindings
+
+The full-swap wrapper shapes (`named_from_default`,
+`named_from_module_default`, `named_from_json_default` in
+<../vendor/wrappers.rs>) emit `export const <name> = <default>.<name>;`
+/ `export const <name> = <default>;` statements. These evaluate
+**once at wrapper-module init**. Real ESM named exports are live
+bindings; the wrapper's are snapshots. This is a documented
+precondition on the upstream package: its default export's
+properties must not be reassigned after module init, and consumers
+must not rely on live-binding semantics for the wrapped names.
+(JSON wrappers are immune — JSON modules are inert data.)
+
 ## Empty logical modules
 
 A spec entry that resolves to zero owned bindings and no re-exports

--- a/devinfra/js/debundle/e2e/vendor_swap_test.rs
+++ b/devinfra/js/debundle/e2e/vendor_swap_test.rs
@@ -271,7 +271,7 @@ fn run_named_from_module_default_fixture(upstream_source: &str) -> VendorSwapFix
     run_full_swap_fixture(FullSwapFixtureArgs {
         temp_prefix: "vendor-swap-named-from-module-default-",
         chunk_source: "export { x as default };\nconst x = 0;\n",
-        wrapper_shape: "named_from_module_default",
+        wrapper_shape: Some("named_from_module_default"),
         upstream_source,
     })
 }
@@ -279,7 +279,8 @@ fn run_named_from_module_default_fixture(upstream_source: &str) -> VendorSwapFix
 struct FullSwapFixtureArgs<'a> {
     temp_prefix: &'a str,
     chunk_source: &'a str,
-    wrapper_shape: &'a str,
+    /// `None` runs the plain (wrapper-less) swap path.
+    wrapper_shape: Option<&'a str>,
     upstream_source: &'a str,
 }
 
@@ -300,17 +301,23 @@ fn run_full_swap_fixture(args: FullSwapFixtureArgs<'_>) -> VendorSwapFixture {
         args.upstream_source,
     );
 
+    let mut vendor_mark = json!({
+        "level": "swap",
+        "identity": format!("{PACKAGE_NAME}/{SUBPATH}"),
+        "package": PACKAGE_NAME,
+        "version": PACKAGE_VERSION,
+        "subpath": SUBPATH,
+    });
+    if let Some(wrapper_shape) = args.wrapper_shape {
+        vendor_mark
+            .as_object_mut()
+            .expect("vendor mark is a JSON object")
+            .insert("wrapper_shape".to_string(), json!(wrapper_shape));
+    }
     let spec_path = ws.root.path().join("transform_spec.yaml");
     let spec = json!({
         "vendor": {
-            CHUNK_PATH: {
-                "level": "swap",
-                "identity": format!("{PACKAGE_NAME}/{SUBPATH}"),
-                "package": PACKAGE_NAME,
-                "version": PACKAGE_VERSION,
-                "subpath": SUBPATH,
-                "wrapper_shape": args.wrapper_shape,
-            },
+            CHUNK_PATH: vendor_mark,
         },
         "inputs": { "input_root": &ws.snapshot_root, "js_list_path": &ws.js_list_path },
         "swap_vendor_chunks": {
@@ -493,7 +500,7 @@ fn run_named_from_default_fixture(args: NamedFromDefaultFixtureArgs<'_>) -> Vend
     run_full_swap_fixture(FullSwapFixtureArgs {
         temp_prefix: "vendor-swap-named-from-default-",
         chunk_source: args.chunk_source,
-        wrapper_shape: "named_from_default",
+        wrapper_shape: Some("named_from_default"),
         upstream_source: args.upstream_source,
     })
 }
@@ -1820,4 +1827,761 @@ fn run_partial_swap_kind_fixture(args: PartialSwapKindFixtureArgs<'_>) -> Partia
     vendor.insert("symbols".into(), Value::Object(symbols));
 
     run_partial_swap_raw(ws, vendor, &[(args.package_name, &package_root)])
+}
+
+// ─── partial-swap consumer soundness ────────────────────────────────────
+//
+// The per-symbol rewrite handles `ImportDecl` consumers. Two other consumer
+// shapes can reference a partially-swapped chunk's export surface:
+// `export { x } from "<chunk>"` re-exports and `import * as M from
+// "<chunk>"` namespace imports. Re-exports of `named`/`default`/`namespace`
+// kind symbols are rewritten against the upstream package; everything else
+// (member-kind re-exports, namespace imports, `export *`) must make the
+// pipeline bail — the strip pass removes those names from the chunk's
+// export surface, so an unrewritten consumer either link-fails (re-export)
+// or silently reads `undefined` (namespace member).
+
+fn setup_partial_swap_consumer_fixture(
+    prefix: &str,
+    chunk_source: &str,
+    caller_source: &str,
+    package_name: &str,
+    version: &str,
+    subpath: &str,
+    upstream_source: &str,
+) -> (VendorTestWorkspace, PathBuf) {
+    const MEGACHUNK_PATH: &str = "static/megachunk.js";
+    const CALLER_PATH: &str = "static/app.js";
+    let ws = VendorTestWorkspace::new(prefix);
+    ws.write_chunk(MEGACHUNK_PATH, chunk_source);
+    ws.write_chunk(CALLER_PATH, caller_source);
+    ws.write_js_list(&format!("{MEGACHUNK_PATH}\n{CALLER_PATH}\n"));
+    let package_root = ws.write_upstream_package(
+        &format!("upstream/{package_name}"),
+        package_name,
+        version,
+        subpath,
+        upstream_source,
+    );
+    (ws, package_root)
+}
+
+fn partial_swap_vendor(
+    identity: &str,
+    packages: Value,
+    symbols: Value,
+) -> serde_json::Map<String, Value> {
+    let mut vendor = serde_json::Map::new();
+    vendor.insert("level".into(), json!("partial_swap"));
+    vendor.insert("identity".into(), json!(identity));
+    vendor.insert("packages".into(), packages);
+    vendor.insert("symbols".into(), symbols);
+    vendor
+}
+
+fn emitted_app_root(fixture: &PartialSwapFixture) -> PathBuf {
+    fixture
+        .caller_emitted_path
+        .ancestors()
+        .nth(3)
+        .expect("app root above static/app/entry.js")
+        .to_path_buf()
+}
+
+/// Provide a minimal ESM `node_modules/<name>` in the emitted app root so
+/// node can resolve the bare package specifiers the swap rewrites emit.
+fn install_node_module(app_root: &Path, name: &str, version: &str, source: &str) {
+    write_text_file(
+        &app_root.join(format!("node_modules/{name}/package.json")),
+        &format!(
+            "{{ \"name\": \"{name}\", \"version\": \"{version}\", \"type\": \"module\", \"main\": \"index.js\" }}\n"
+        ),
+    );
+    write_text_file(
+        &app_root.join(format!("node_modules/{name}/index.js")),
+        source,
+    );
+}
+
+#[test]
+fn partial_swap_rewrites_named_kind_reexport_from_consumer() {
+    // `export { e6 as zodBoolean } from "<chunk>"` of a kind=named swapped
+    // symbol must be rewritten to re-export the upstream package, exactly
+    // like ImportDecl consumers — otherwise the strip pass removes `e6`
+    // from the chunk's export surface while the re-export still references
+    // it, guaranteeing a module-link failure in the emitted tree.
+    let (ws, package_root) = setup_partial_swap_consumer_fixture(
+        "vendor-partial-swap-reexport-named-",
+        "export const e6 = () => \"UPSTREAM\";\nexport const keepMe = () => 7;\n",
+        "export { e6 as zodBoolean, keepMe } from \"../megachunk/entry.js\";\n",
+        "zod",
+        "3.23.8",
+        "lib/index.mjs",
+        "export const boolean = () => \"UPSTREAM\";\n",
+    );
+    let vendor = partial_swap_vendor(
+        "named re-export consumer fixture",
+        json!({ "zod": { "version": "3.23.8", "subpath": "lib/index.mjs" } }),
+        json!({ "e6": { "package": "zod", "kind": "named", "upstream_export": "boolean" } }),
+    );
+    let fixture = run_partial_swap_raw(ws, vendor, &[("zod", &package_root)]);
+
+    assert!(
+        fixture.result.status.success(),
+        "debundler exited {:?}\nstdout:\n{}\nstderr:\n{}",
+        fixture.result.status.code(),
+        fixture.result.stdout,
+        fixture.result.stderr,
+    );
+    let caller = fs::read_to_string(&fixture.caller_emitted_path).expect("caller emitted");
+    assert!(
+        caller.contains("export { boolean as zodBoolean } from \"zod\""),
+        "re-export of swapped name should target the upstream package:\n{caller}",
+    );
+    assert!(
+        caller.contains("keepMe") && caller.contains("../megachunk/entry.js"),
+        "non-swapped re-export stays on the residual chunk:\n{caller}",
+    );
+    assert!(
+        !caller.contains("e6"),
+        "no re-export of the stripped chunk name may survive:\n{caller}",
+    );
+
+    let app_root = emitted_app_root(&fixture);
+    install_node_module(
+        &app_root,
+        "zod",
+        "3.23.8",
+        "export const boolean = () => \"UPSTREAM\";\n",
+    );
+    let probe_path = app_root.join("__run_reexport_named.mjs");
+    write_text_file(
+        &probe_path,
+        "const m = await import(\"./static/app/entry.js\");\n\
+         console.log(`${m.zodBoolean()}:${m.keepMe()}`);\n",
+    );
+    assert_node_output(&probe_path, "UPSTREAM:7\n", "");
+}
+
+#[test]
+fn partial_swap_rewrites_default_kind_reexport_from_consumer() {
+    let (ws, package_root) = setup_partial_swap_consumer_fixture(
+        "vendor-partial-swap-reexport-default-",
+        "export const aQ = (...args) => args.join(\"+\");\nexport const keepMe = () => 7;\n",
+        "export { aQ as z, keepMe } from \"../megachunk/entry.js\";\n",
+        "clsx",
+        "2.1.1",
+        "dist/clsx.mjs",
+        "export default (...args) => args.join(\"+\");\n",
+    );
+    let vendor = partial_swap_vendor(
+        "default re-export consumer fixture",
+        json!({ "clsx": { "version": "2.1.1", "subpath": "dist/clsx.mjs" } }),
+        json!({ "aQ": { "package": "clsx", "kind": "default" } }),
+    );
+    let fixture = run_partial_swap_raw(ws, vendor, &[("clsx", &package_root)]);
+
+    assert!(
+        fixture.result.status.success(),
+        "debundler exited {:?}\nstdout:\n{}\nstderr:\n{}",
+        fixture.result.status.code(),
+        fixture.result.stdout,
+        fixture.result.stderr,
+    );
+    let caller = fs::read_to_string(&fixture.caller_emitted_path).expect("caller emitted");
+    assert!(
+        caller.contains("export { default as z } from \"clsx\""),
+        "re-export of a kind=default symbol should forward the package default:\n{caller}",
+    );
+
+    let app_root = emitted_app_root(&fixture);
+    install_node_module(
+        &app_root,
+        "clsx",
+        "2.1.1",
+        "export default (...args) => args.join(\"+\");\n",
+    );
+    let probe_path = app_root.join("__run_reexport_default.mjs");
+    write_text_file(
+        &probe_path,
+        "const m = await import(\"./static/app/entry.js\");\n\
+         console.log(m.z(\"a\", \"b\"));\n",
+    );
+    assert_node_output(&probe_path, "a+b\n", "");
+}
+
+#[test]
+fn partial_swap_rewrites_namespace_kind_reexport_from_consumer() {
+    let (ws, package_root) = setup_partial_swap_consumer_fixture(
+        "vendor-partial-swap-reexport-namespace-",
+        "export const a = { useState: () => 1 };\nexport const keepMe = () => 7;\n",
+        "export { a as React, keepMe } from \"../megachunk/entry.js\";\n",
+        "react",
+        "18.3.1",
+        "index.js",
+        "export const useState = () => 1;\n",
+    );
+    let vendor = partial_swap_vendor(
+        "namespace re-export consumer fixture",
+        json!({ "react": { "version": "18.3.1", "subpath": "index.js" } }),
+        json!({ "a": { "package": "react", "kind": "namespace" } }),
+    );
+    let fixture = run_partial_swap_raw(ws, vendor, &[("react", &package_root)]);
+
+    assert!(
+        fixture.result.status.success(),
+        "debundler exited {:?}\nstdout:\n{}\nstderr:\n{}",
+        fixture.result.status.code(),
+        fixture.result.stdout,
+        fixture.result.stderr,
+    );
+    let caller = fs::read_to_string(&fixture.caller_emitted_path).expect("caller emitted");
+    assert!(
+        caller.contains("export * as React from \"react\""),
+        "re-export of a kind=namespace symbol should forward the package namespace:\n{caller}",
+    );
+
+    let app_root = emitted_app_root(&fixture);
+    install_node_module(
+        &app_root,
+        "react",
+        "18.3.1",
+        "export const useState = () => 1;\n",
+    );
+    let probe_path = app_root.join("__run_reexport_namespace.mjs");
+    write_text_file(
+        &probe_path,
+        "const m = await import(\"./static/app/entry.js\");\n\
+         console.log(m.React.useState());\n",
+    );
+    assert_node_output(&probe_path, "1\n", "");
+}
+
+#[test]
+fn partial_swap_bails_on_namespace_import_of_partially_swapped_chunk() {
+    // `import * as M from "<chunk>"` then `M.e6` — the strip pass removes
+    // `e6` from the chunk's export surface, so the member read would
+    // silently evaluate to `undefined` at runtime. The post-strip consumer
+    // gate must reject the spec instead of emitting the broken tree.
+    let (ws, package_root) = setup_partial_swap_consumer_fixture(
+        "vendor-partial-swap-namespace-consumer-",
+        "export const e6 = () => true;\nexport const keepMe = () => 7;\n",
+        "import * as M from \"../megachunk/entry.js\";\nexport const r = M.e6();\n",
+        "zod",
+        "3.23.8",
+        "lib/index.mjs",
+        "export const boolean = () => true;\n",
+    );
+    let vendor = partial_swap_vendor(
+        "namespace consumer fixture",
+        json!({ "zod": { "version": "3.23.8", "subpath": "lib/index.mjs", "namespace": "z" } }),
+        json!({ "e6": { "package": "zod", "upstream_export": "boolean" } }),
+    );
+    let fixture = run_partial_swap_raw(ws, vendor, &[("zod", &package_root)]);
+
+    assert!(
+        !fixture.result.status.success(),
+        "debundler must reject a namespace import of a partially-swapped chunk\nstdout:\n{}\nstderr:\n{}",
+        fixture.result.stdout,
+        fixture.result.stderr,
+    );
+    assert!(
+        fixture.result.stderr.contains("namespace")
+            && fixture.result.stderr.contains("static/megachunk"),
+        "expected namespace-consumer gate diagnostic in stderr:\n{}",
+        fixture.result.stderr,
+    );
+}
+
+#[test]
+fn partial_swap_bails_on_member_kind_reexport_from_consumer() {
+    // kind=member symbols rewrite references to `<namespace>.<export>`
+    // member accesses — that shape has no live re-export equivalent, so a
+    // re-export consumer of a member-kind symbol must hard-fail rather
+    // than silently survive the strip with a dangling export name.
+    let (ws, package_root) = setup_partial_swap_consumer_fixture(
+        "vendor-partial-swap-member-reexport-",
+        "export const e6 = () => true;\n",
+        "export { e6 as zodBoolean } from \"../megachunk/entry.js\";\n",
+        "zod",
+        "3.23.8",
+        "lib/index.mjs",
+        "export const boolean = () => true;\n",
+    );
+    let vendor = partial_swap_vendor(
+        "member re-export consumer fixture",
+        json!({ "zod": { "version": "3.23.8", "subpath": "lib/index.mjs", "namespace": "z" } }),
+        json!({ "e6": { "package": "zod", "upstream_export": "boolean" } }),
+    );
+    let fixture = run_partial_swap_raw(ws, vendor, &[("zod", &package_root)]);
+
+    assert!(
+        !fixture.result.status.success(),
+        "debundler must reject a member-kind re-export consumer\nstdout:\n{}\nstderr:\n{}",
+        fixture.result.stdout,
+        fixture.result.stderr,
+    );
+    assert!(
+        fixture.result.stderr.contains("e6") && fixture.result.stderr.contains("re-export"),
+        "expected re-export gate diagnostic naming the swapped symbol:\n{}",
+        fixture.result.stderr,
+    );
+}
+
+#[test]
+fn partial_swap_bails_on_export_star_from_partially_swapped_chunk() {
+    // `export * from "<chunk>"` re-exports whatever survives the strip —
+    // the swapped names silently vanish from the re-exporter's surface.
+    let (ws, package_root) = setup_partial_swap_consumer_fixture(
+        "vendor-partial-swap-export-star-",
+        "export const e6 = () => true;\nexport const keepMe = () => 7;\n",
+        "export * from \"../megachunk/entry.js\";\n",
+        "zod",
+        "3.23.8",
+        "lib/index.mjs",
+        "export const boolean = () => true;\n",
+    );
+    let vendor = partial_swap_vendor(
+        "export-star consumer fixture",
+        json!({ "zod": { "version": "3.23.8", "subpath": "lib/index.mjs", "namespace": "z" } }),
+        json!({ "e6": { "package": "zod", "upstream_export": "boolean" } }),
+    );
+    let fixture = run_partial_swap_raw(ws, vendor, &[("zod", &package_root)]);
+
+    assert!(
+        !fixture.result.status.success(),
+        "debundler must reject `export *` from a partially-swapped chunk\nstdout:\n{}\nstderr:\n{}",
+        fixture.result.stdout,
+        fixture.result.stderr,
+    );
+    assert!(
+        fixture.result.stderr.contains("export *")
+            && fixture.result.stderr.contains("static/megachunk"),
+        "expected export-star gate diagnostic in stderr:\n{}",
+        fixture.result.stderr,
+    );
+}
+
+// ─── boundary_rename / suppress ─────────────────────────────────────────
+
+#[test]
+fn boundary_rename_rewrites_caller_imports_end_to_end() {
+    const VENDOR_PATH: &str = "static/vendor.js";
+    const APP_PATH: &str = "static/app.js";
+    let ws = VendorTestWorkspace::new("vendor-boundary-rename-");
+    ws.write_chunk(VENDOR_PATH, "const a = 1;\nexport { a as alpha };\n");
+    ws.write_chunk(
+        APP_PATH,
+        "import { a } from \"../vendor/entry.js\";\nconsole.log(a);\n",
+    );
+    ws.write_js_list(&format!("{VENDOR_PATH}\n{APP_PATH}\n"));
+
+    let spec_path = ws.root.path().join("transform_spec.yaml");
+    let spec = json!({
+        "vendor": {
+            VENDOR_PATH: { "level": "boundary_rename", "identity": "boundary rename fixture" },
+        },
+        "inputs": { "input_root": &ws.snapshot_root, "js_list_path": &ws.js_list_path },
+        "write_js_tree": { "out_dir": &ws.out_root },
+    });
+    write_yaml_file(&spec_path, &spec);
+    let result = run_debundler(&spec_path, &[]);
+    assert!(
+        result.status.success(),
+        "debundler exited {:?}\nstdout:\n{}\nstderr:\n{}",
+        result.status.code(),
+        result.stdout,
+        result.stderr,
+    );
+
+    let caller =
+        fs::read_to_string(ws.out_root.join("app/static/app/entry.js")).expect("caller emitted");
+    assert!(
+        caller.contains("import { alpha as a }"),
+        "caller import should be rewritten to the vendor's public export name:\n{caller}",
+    );
+    let probe_path = ws.out_root.join("__run_boundary_rename.mjs");
+    write_text_file(
+        &probe_path,
+        "await import(\"./app/static/app/entry.js\");\n",
+    );
+    assert_node_output(&probe_path, "1\n", "");
+}
+
+#[test]
+fn boundary_rename_bails_when_mapping_key_is_a_real_export_of_another_local() {
+    // The boundary mapping is keyed by vendor-LOCAL name (`export { a as
+    // alpha }` → a→alpha). If the vendor ALSO genuinely exports the name
+    // `a` bound to a *different* local (`export { z as a }`), a caller's
+    // `import { a }` refers to local `z` — rewriting it to `import { alpha
+    // as a }` would silently rebind it to local `a`'s value. The stage must
+    // bail on the colliding shape.
+    const VENDOR_PATH: &str = "static/vendor.js";
+    const APP_PATH: &str = "static/app.js";
+    let ws = VendorTestWorkspace::new("vendor-boundary-rename-collision-");
+    ws.write_chunk(
+        VENDOR_PATH,
+        "const a = \"local-a\";\nconst z = \"local-z\";\nexport { a as alpha, z as a };\n",
+    );
+    ws.write_chunk(
+        APP_PATH,
+        "import { a } from \"../vendor/entry.js\";\nconsole.log(a);\n",
+    );
+    ws.write_js_list(&format!("{VENDOR_PATH}\n{APP_PATH}\n"));
+
+    let spec_path = ws.root.path().join("transform_spec.yaml");
+    let spec = json!({
+        "vendor": {
+            VENDOR_PATH: { "level": "boundary_rename", "identity": "boundary rename collision fixture" },
+        },
+        "inputs": { "input_root": &ws.snapshot_root, "js_list_path": &ws.js_list_path },
+        "write_js_tree": { "out_dir": &ws.out_root },
+    });
+    write_yaml_file(&spec_path, &spec);
+    let result = run_debundler(&spec_path, &[]);
+    assert!(
+        !result.status.success(),
+        "debundler must reject a boundary mapping key that collides with a real export\nstdout:\n{}\nstderr:\n{}",
+        result.stdout,
+        result.stderr,
+    );
+    assert!(
+        result.stderr.contains("collides") && result.stderr.contains("`a`"),
+        "expected boundary-rename collision diagnostic in stderr:\n{}",
+        result.stderr,
+    );
+}
+
+#[test]
+fn suppress_vendor_chunk_passes_through_unchanged() {
+    // `level: suppress` is annotation-only: no boundary rename, no swap,
+    // no strip. The chunk and its callers must pass through untouched.
+    const VENDOR_PATH: &str = "static/vendor.js";
+    const APP_PATH: &str = "static/app.js";
+    let ws = VendorTestWorkspace::new("vendor-suppress-");
+    ws.write_chunk(VENDOR_PATH, "const a = 1;\nexport { a as alpha };\n");
+    ws.write_chunk(
+        APP_PATH,
+        "import { alpha } from \"../vendor/entry.js\";\nconsole.log(alpha);\n",
+    );
+    ws.write_js_list(&format!("{VENDOR_PATH}\n{APP_PATH}\n"));
+
+    let spec_path = ws.root.path().join("transform_spec.yaml");
+    let spec = json!({
+        "vendor": {
+            VENDOR_PATH: { "level": "suppress", "identity": "suppress fixture" },
+        },
+        "inputs": { "input_root": &ws.snapshot_root, "js_list_path": &ws.js_list_path },
+        "write_js_tree": { "out_dir": &ws.out_root },
+    });
+    write_yaml_file(&spec_path, &spec);
+    let result = run_debundler(&spec_path, &[]);
+    assert!(
+        result.status.success(),
+        "debundler exited {:?}\nstdout:\n{}\nstderr:\n{}",
+        result.status.code(),
+        result.stdout,
+        result.stderr,
+    );
+
+    let vendor = fs::read_to_string(ws.out_root.join("app/static/vendor/entry.js"))
+        .expect("vendor chunk emitted");
+    assert!(
+        vendor.contains("export { a as alpha }"),
+        "suppressed vendor chunk's export surface must be unchanged:\n{vendor}",
+    );
+    let caller =
+        fs::read_to_string(ws.out_root.join("app/static/app/entry.js")).expect("caller emitted");
+    assert!(
+        caller.contains("import { alpha } from \"../vendor/entry.js\""),
+        "caller import of a suppressed chunk must be unchanged:\n{caller}",
+    );
+    let probe_path = ws.out_root.join("__run_suppress.mjs");
+    write_text_file(
+        &probe_path,
+        "await import(\"./app/static/app/entry.js\");\n",
+    );
+    assert_node_output(&probe_path, "1\n", "");
+}
+
+// ─── full swap: caller contract + export-shape validation ───────────────
+
+#[test]
+fn full_swap_with_caller_keeps_dangling_chunk_import_for_live_proxy() {
+    // `level: swap` removes the vendor chunk from the artifact; callers'
+    // imports of the removed chunk are intentionally left as-is in the
+    // plain `write_js_tree` output. The emitted tree is proxy-dependent:
+    // the live-proxy/import-map layer resolves the dangling specifier to
+    // the swapped package at serve time. This test pins that contract.
+    const CHUNK_PATH: &str = "static/lib-X.js";
+    const APP_PATH: &str = "static/app.js";
+    const PACKAGE_NAME: &str = "lib";
+    let ws = VendorTestWorkspace::new("vendor-full-swap-caller-");
+    ws.write_chunk(CHUNK_PATH, "export const ping = () => \"vendor\";\n");
+    ws.write_chunk(
+        APP_PATH,
+        "import { ping } from \"../lib-X/entry.js\";\nconsole.log(ping());\n",
+    );
+    ws.write_js_list(&format!("{CHUNK_PATH}\n{APP_PATH}\n"));
+    let package_root = ws.write_upstream_package(
+        "upstream",
+        PACKAGE_NAME,
+        "1.0.0",
+        "dist/index.mjs",
+        "export const ping = () => \"pkg\";\n",
+    );
+
+    let spec_path = ws.root.path().join("transform_spec.yaml");
+    let spec = json!({
+        "vendor": {
+            CHUNK_PATH: {
+                "level": "swap",
+                "identity": "lib/dist/index.mjs",
+                "package": PACKAGE_NAME,
+                "version": "1.0.0",
+                "subpath": "dist/index.mjs",
+            },
+        },
+        "inputs": { "input_root": &ws.snapshot_root, "js_list_path": &ws.js_list_path },
+        "swap_vendor_chunks": {
+            "output_manifest_path": &ws.manifest_path,
+            "output_wrapper_dir": &ws.wrapper_root,
+            "write": true,
+        },
+        "write_js_tree": { "out_dir": &ws.out_root },
+    });
+    write_yaml_file(&spec_path, &spec);
+    let result = run_debundler(&spec_path, &[(PACKAGE_NAME, &package_root)]);
+    assert!(
+        result.status.success(),
+        "debundler exited {:?}\nstdout:\n{}\nstderr:\n{}",
+        result.status.code(),
+        result.stdout,
+        result.stderr,
+    );
+
+    assert!(
+        !ws.out_root.join("app/static/lib-X").exists(),
+        "fully-swapped chunk must be removed from the emitted tree",
+    );
+    let caller =
+        fs::read_to_string(ws.out_root.join("app/static/app/entry.js")).expect("caller emitted");
+    assert!(
+        caller.contains("../lib-X/entry.js"),
+        "caller's import of the removed chunk is intentionally left dangling \
+         (resolved by the live-proxy/import-map at serve time):\n{caller}",
+    );
+}
+
+#[test]
+fn full_swap_without_wrapper_requires_upstream_default_for_default_export() {
+    // `export default x;` (ExportDefaultExpr) must participate in the
+    // no-wrapper export-shape check the same way `export { x as default }`
+    // does: if the upstream package has no default export, callers that
+    // import the chunk's default would break post-swap.
+    let fixture = run_full_swap_fixture(FullSwapFixtureArgs {
+        temp_prefix: "vendor-full-swap-default-expr-",
+        chunk_source: "const x = 0;\nexport default x;\n",
+        wrapper_shape: None,
+        upstream_source: "export const unrelated = 1;\n",
+    });
+    assert!(
+        !fixture.result.status.success(),
+        "debundler must reject a default-exporting chunk swapped against an upstream without a default\nstdout:\n{}\nstderr:\n{}",
+        fixture.result.stdout,
+        fixture.result.stderr,
+    );
+    assert!(
+        fixture.result.stderr.contains("export shape mismatch")
+            && fixture.result.stderr.contains("default"),
+        "expected export-shape mismatch naming `default` in stderr:\n{}",
+        fixture.result.stderr,
+    );
+}
+
+#[test]
+fn full_swap_without_wrapper_accepts_named_default_alias_when_upstream_has_default() {
+    let fixture = run_full_swap_fixture(FullSwapFixtureArgs {
+        temp_prefix: "vendor-full-swap-named-default-",
+        chunk_source: "const x = 0;\nexport { x as default };\n",
+        wrapper_shape: None,
+        upstream_source: "const d = 1;\nexport default d;\n",
+    });
+    assert!(
+        fixture.result.status.success(),
+        "debundler exited {:?}\nstdout:\n{}\nstderr:\n{}",
+        fixture.result.status.code(),
+        fixture.result.stdout,
+        fixture.result.stderr,
+    );
+}
+
+// ─── wrapper synthetic-local collisions ─────────────────────────────────
+
+#[test]
+fn named_from_default_wrapper_avoids_upstream_default_local_collision() {
+    // The wrapper hoists upstream's default into a synthetic local
+    // (historically `_d`). If the upstream module body already binds that
+    // name, naive injection produces a duplicate-declaration SyntaxError.
+    let fixture = run_named_from_default_fixture(NamedFromDefaultFixtureArgs {
+        upstream_source: "const _d = \"taken\";\nexport default { ping: () => _d };\n",
+        chunk_source: "export { ping } from \"lib\";\n",
+    });
+    assert!(
+        fixture.result.status.success(),
+        "debundler exited {:?}\nstdout:\n{}\nstderr:\n{}",
+        fixture.result.status.code(),
+        fixture.result.stdout,
+        fixture.result.stderr,
+    );
+    let probe_path = fixture
+        .wrapper_path
+        .parent()
+        .expect("wrapper has parent dir")
+        .join("__probe.mjs");
+    write_text_file(
+        &probe_path,
+        "const m = await import(\"./entry.js\");\nconsole.log(m.ping());\n",
+    );
+    assert_node_output(&probe_path, "taken\n", "");
+}
+
+#[test]
+fn named_from_module_default_wrapper_avoids_upstream_default_local_collision() {
+    let upstream_source = "const __vendor_default__ = \"taken\";\n\
+                           export default function getter() { return __vendor_default__; }\n";
+    let fixture = run_named_from_module_default_fixture(upstream_source);
+    assert!(
+        fixture.result.status.success(),
+        "debundler exited {:?}\nstdout:\n{}\nstderr:\n{}",
+        fixture.result.status.code(),
+        fixture.result.stdout,
+        fixture.result.stderr,
+    );
+    let probe_path = fixture
+        .wrapper_path
+        .parent()
+        .expect("wrapper has parent dir")
+        .join("__probe.mjs");
+    write_text_file(
+        &probe_path,
+        "const m = await import(\"./entry.js\");\nconsole.log(m.default());\n",
+    );
+    assert_node_output(&probe_path, "taken\n", "");
+}
+
+// ─── named_from_module_default named-export verification ────────────────
+
+#[test]
+fn named_from_module_default_rejects_unverified_named_exports() {
+    // The wrapper emits `export const <name> = <default>;` for every
+    // vendor named export. That equation only holds when the chunk itself
+    // binds `<name>` to the same local as its default export. A genuine
+    // independent export (`export { y as other }`) must make the swap
+    // bail instead of silently re-exporting the upstream default under
+    // an unrelated name.
+    let fixture = run_full_swap_fixture(FullSwapFixtureArgs {
+        temp_prefix: "vendor-swap-module-default-overclaim-",
+        chunk_source: "const x = 0;\nconst y = 1;\nexport { x as default, y as other };\n",
+        wrapper_shape: Some("named_from_module_default"),
+        upstream_source: "export default function f() { return \"pkg\"; }\n",
+    });
+    assert!(
+        !fixture.result.status.success(),
+        "debundler must reject named exports that are not verified aliases of the chunk default\nstdout:\n{}\nstderr:\n{}",
+        fixture.result.stdout,
+        fixture.result.stderr,
+    );
+    assert!(
+        fixture.result.stderr.contains("named-from-module-default")
+            && fixture.result.stderr.contains("other"),
+        "expected over-claim diagnostic naming `other` in stderr:\n{}",
+        fixture.result.stderr,
+    );
+}
+
+#[test]
+fn named_from_module_default_accepts_verified_default_aliases() {
+    let fixture = run_full_swap_fixture(FullSwapFixtureArgs {
+        temp_prefix: "vendor-swap-module-default-alias-",
+        chunk_source: "const x = () => \"val\";\nexport { x as default, x as alias };\n",
+        wrapper_shape: Some("named_from_module_default"),
+        upstream_source: "export default function f() { return \"val\"; }\n",
+    });
+    assert!(
+        fixture.result.status.success(),
+        "debundler exited {:?}\nstdout:\n{}\nstderr:\n{}",
+        fixture.result.status.code(),
+        fixture.result.stdout,
+        fixture.result.stderr,
+    );
+    let probe_path = fixture
+        .wrapper_path
+        .parent()
+        .expect("wrapper has parent dir")
+        .join("__probe.mjs");
+    write_text_file(
+        &probe_path,
+        "const m = await import(\"./entry.js\");\nconsole.log(m.alias === m.default);\n",
+    );
+    assert_node_output(&probe_path, "true\n", "");
+}
+
+// ─── named_from_json_default ────────────────────────────────────────────
+
+#[test]
+fn named_from_json_default_generates_named_pulls_from_json_keys() {
+    let fixture = run_full_swap_fixture(FullSwapFixtureArgs {
+        temp_prefix: "vendor-swap-named-from-json-default-",
+        chunk_source: "export { version, flag } from \"lib\";\n",
+        wrapper_shape: Some("named_from_json_default"),
+        upstream_source: "{ \"version\": \"1.2.3\", \"flag\": true }\n",
+    });
+    assert!(
+        fixture.result.status.success(),
+        "debundler exited {:?}\nstdout:\n{}\nstderr:\n{}",
+        fixture.result.status.code(),
+        fixture.result.stdout,
+        fixture.result.stderr,
+    );
+    let wrapper_source = fs::read_to_string(&fixture.wrapper_path).expect("wrapper exists");
+    assert!(
+        wrapper_source.contains("export const version = _d.version;")
+            && wrapper_source.contains("export const flag = _d.flag;")
+            && wrapper_source.contains("export default _d;"),
+        "JSON wrapper should pull each named export off the parsed default:\n{wrapper_source}",
+    );
+    let probe_path = fixture
+        .wrapper_path
+        .parent()
+        .expect("wrapper has parent dir")
+        .join("__probe.mjs");
+    write_text_file(
+        &probe_path,
+        "const m = await import(\"./entry.js\");\n\
+         console.log(`${m.version}:${m.flag}:${m.default.version}`);\n",
+    );
+    assert_node_output(&probe_path, "1.2.3:true:1.2.3\n", "");
+}
+
+#[test]
+fn named_from_json_default_rejects_names_missing_from_json() {
+    let fixture = run_full_swap_fixture(FullSwapFixtureArgs {
+        temp_prefix: "vendor-swap-named-from-json-default-missing-",
+        chunk_source: "export { missing } from \"lib\";\n",
+        wrapper_shape: Some("named_from_json_default"),
+        upstream_source: "{ \"version\": \"1.2.3\" }\n",
+    });
+    assert!(
+        !fixture.result.status.success(),
+        "debundler must reject vendor named exports missing from the upstream JSON keys",
+    );
+    assert!(
+        fixture
+            .result
+            .stderr
+            .contains("named-from-json-default wrapper shape mismatch"),
+        "expected JSON wrapper shape mismatch in stderr:\n{}",
+        fixture.result.stderr,
+    );
 }

--- a/devinfra/js/debundle/pipeline.rs
+++ b/devinfra/js/debundle/pipeline.rs
@@ -24,6 +24,7 @@ use vendor::{
     StripSwappedVendorExportsOptions, SwapVendorOptions, VendorResolution,
     apply_bundled_partial_vendor_swaps, apply_partial_vendor_swaps, apply_vendor_annotations,
     rename_vendor_exports, strip_swapped_vendor_exports_with_options, swap_vendor_chunks,
+    validate_partial_swap_consumers,
 };
 use write_tree::{WriteTreeInput, write_js_tree};
 
@@ -473,6 +474,11 @@ fn run_partial_vendor_swaps(
         )?;
         artifact = strip_result.artifact;
         strip_stats = strip_result.manifest.per_chunk;
+        // Post-strip soundness gate: no retained file may still consume
+        // the stripped portion of a partially-swapped chunk's export
+        // surface (unrewritten named imports / re-exports, namespace
+        // imports, `export *`).
+        validate_partial_swap_consumers(&artifact, &spec.vendor, artifact_indexes)?;
     }
     Ok(PartialVendorSwapResult {
         artifact,

--- a/devinfra/js/debundle/vendor/mod.rs
+++ b/devinfra/js/debundle/vendor/mod.rs
@@ -125,7 +125,9 @@ pub fn rename_vendor_exports(
                 .with_context(|| {
                     format!("rename_vendor_exports vendor chunk {chunk_name} is missing entry AST")
                 })?;
-            collect_boundary_mapping(&vendor_ast.module)
+            let mapping = collect_boundary_mapping(&vendor_ast.module);
+            validate_boundary_mapping_collisions(&vendor_ast.module, &mapping, chunk_path)?;
+            mapping
         };
         if !mapping.is_empty() {
             chunks_with_mapping += 1;
@@ -293,6 +295,10 @@ struct SwapVendorJob {
     subpath: String,
     wrapper_shape: Option<WrapperShape>,
     vendor_exports: BTreeSet<String>,
+    /// Chunk export names verified to alias the chunk's own default
+    /// export (bound to the same local binding). Consumed by the
+    /// `named_from_module_default` wrapper-shape check.
+    vendor_default_aliases: BTreeSet<String>,
 }
 
 fn resolve_vendor_swap(
@@ -384,7 +390,7 @@ fn resolve_vendor_swap(
                 );
             }
             let wrapper =
-                generate_named_from_json_default_wrapper(&upstream_json, &non_default_exports);
+                generate_named_from_json_default_wrapper(&upstream_json, &non_default_exports)?;
             generated_wrapper_path = write_wrapper_if_requested(
                 options.write,
                 options.output_wrapper_dir.as_deref(),
@@ -394,6 +400,26 @@ fn resolve_vendor_swap(
             )?;
         }
         Some(WrapperShape::NamedFromModuleDefault) => {
+            // The wrapper re-exports the upstream default under every
+            // vendor named-export name (`export const <name> =
+            // <default>;`). That equation only holds when the chunk
+            // itself binds <name> to the same local as its default
+            // export; anything else would silently alias an unrelated
+            // export to the upstream default.
+            let claimed = job
+                .vendor_exports
+                .iter()
+                .filter(|name| name.as_str() != "default")
+                .cloned()
+                .collect::<BTreeSet<_>>();
+            let unverified = set_diff(&claimed, &job.vendor_default_aliases);
+            if !unverified.is_empty() {
+                bail!(
+                    "swap_vendor_chunks vendor entry {} named-from-module-default: vendor named exports [{}] are not verified aliases of the chunk's default export; the wrapper would re-export the upstream default under unrelated names",
+                    job.chunk_path,
+                    unverified.into_iter().collect::<Vec<_>>().join(","),
+                );
+            }
             let upstream_ast =
                 parse_js_module(&upstream_path.display().to_string(), &upstream_code)?;
             let wrapper = generate_named_from_module_default_wrapper(
@@ -412,7 +438,7 @@ fn resolve_vendor_swap(
         None => {
             let upstream_ast =
                 parse_js_module(&upstream_path.display().to_string(), &upstream_code)?;
-            let upstream_exports = collect_exported_names(&upstream_ast.module, true);
+            let upstream_exports = collect_exported_names(&upstream_ast.module);
             let missing = set_diff(&job.vendor_exports, &upstream_exports);
             if !missing.is_empty() {
                 bail!(
@@ -522,7 +548,8 @@ pub fn swap_vendor_chunks(
                 version: swap.version.clone(),
                 subpath: swap.subpath.clone(),
                 wrapper_shape: swap.wrapper_shape,
-                vendor_exports: collect_exported_names(&entry_ast.module, false),
+                vendor_exports: collect_exported_names(&entry_ast.module),
+                vendor_default_aliases: verified_default_alias_export_names(&entry_ast.module),
             })
         })
         .collect::<Result<Vec<_>>>()?;
@@ -572,6 +599,69 @@ fn chunk_id_from_chunk_path(chunk_path: &str, stage: &str) -> Result<String> {
         bail!("{stage}: chunk path must end in .js: {chunk_path}");
     };
     Ok(chunk_id.to_string())
+}
+
+/// Bail when a boundary-mapping key (a vendor-LOCAL binding name) is
+/// itself a genuine export name of the vendor entry bound to a
+/// *different* local. The caller-side rewrite treats `import { k }` as
+/// "the caller spelled export `<mapping[k]>` by its vendor-local name" —
+/// but when the vendor really exports the name `k` (from another local),
+/// that import is legitimate and rewriting it would silently rebind the
+/// caller to the wrong value.
+fn validate_boundary_mapping_collisions(
+    module: &Module,
+    mapping: &BTreeMap<String, String>,
+    chunk_path: &str,
+) -> Result<()> {
+    if mapping.is_empty() {
+        return Ok(());
+    }
+    // export name -> Some(local sym) when the export aliases a plain
+    // local binding; None when its local identity is not a local ident
+    // (forwarded `export … from`, string-literal orig).
+    let mut export_locals: BTreeMap<String, Option<String>> = BTreeMap::new();
+    for item in &module.body {
+        match item {
+            ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(named)) => {
+                for specifier in &named.specifiers {
+                    let ExportSpecifier::Named(named_spec) = specifier else {
+                        continue;
+                    };
+                    let exported = named_spec
+                        .exported
+                        .as_ref()
+                        .map(module_export_name)
+                        .unwrap_or_else(|| module_export_name(&named_spec.orig));
+                    let local = match (&named.src, &named_spec.orig) {
+                        (None, ModuleExportName::Ident(local)) => Some(local.sym.to_string()),
+                        _ => None,
+                    };
+                    export_locals.insert(exported, local);
+                }
+            }
+            ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(export_decl)) => {
+                for name in declaration_name_strings(&export_decl.decl) {
+                    export_locals.insert(name.clone(), Some(name));
+                }
+            }
+            _ => {}
+        }
+    }
+    for local_name in mapping.keys() {
+        let Some(identity) = export_locals.get(local_name) else {
+            continue;
+        };
+        if identity.as_deref() != Some(local_name.as_str()) {
+            let bound_to = identity
+                .as_deref()
+                .map(|local| format!("local `{local}`"))
+                .unwrap_or_else(|| "a non-local origin".to_string());
+            bail!(
+                "rename_vendor_exports vendor entry {chunk_path}: boundary mapping key `{local_name}` collides with a genuine export named `{local_name}` bound to {bound_to}; rewriting caller imports of `{local_name}` would silently rebind them to the wrong value",
+            );
+        }
+    }
+    Ok(())
 }
 
 fn collect_boundary_mapping(module: &Module) -> BTreeMap<String, String> {
@@ -844,15 +934,17 @@ fn module_has_export_star(module: &Module) -> bool {
     })
 }
 
-fn collect_exported_names(module: &Module, include_default: bool) -> BTreeSet<String> {
+/// Export names of `module`. The `default` name is included whether it
+/// comes from an `export default …` declaration or the named form
+/// `export { x as default }` — the two spellings are equivalent on the
+/// module's export surface.
+fn collect_exported_names(module: &Module) -> BTreeSet<String> {
     let mut names = BTreeSet::new();
     for item in &module.body {
         match item {
             ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultDecl(_))
             | ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultExpr(_)) => {
-                if include_default {
-                    names.insert("default".to_string());
-                }
+                names.insert("default".to_string());
             }
             ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(export_decl)) => {
                 for name in declaration_name_strings(&export_decl.decl) {
@@ -876,6 +968,49 @@ fn collect_exported_names(module: &Module, include_default: bool) -> BTreeSet<St
         }
     }
     names
+}
+
+/// Export names of `module` that are verified aliases of its default
+/// export — bound to the same local binding as the default. Empty when
+/// the default's local identity cannot be established.
+fn verified_default_alias_export_names(module: &Module) -> BTreeSet<String> {
+    let by_export = collect_local_idents_by_export_name(module);
+    let default_id = by_export
+        .get("default")
+        .cloned()
+        .or_else(|| default_export_decl_local_id(module));
+    let Some(default_id) = default_id else {
+        return BTreeSet::new();
+    };
+    by_export
+        .iter()
+        .filter(|(name, id)| name.as_str() != "default" && **id == default_id)
+        .map(|(name, _)| name.clone())
+        .collect()
+}
+
+/// Local binding `Id` of the module's `export default …` declaration,
+/// when the default is a plain local identifier (or a named fn/class).
+fn default_export_decl_local_id(module: &Module) -> Option<Id> {
+    for item in &module.body {
+        match item {
+            ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultExpr(default_expr)) => {
+                let Expr::Ident(ident) = &*default_expr.expr else {
+                    return None;
+                };
+                return Some(ident.to_id());
+            }
+            ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultDecl(default_decl)) => {
+                return match &default_decl.decl {
+                    DefaultDecl::Fn(function) => function.ident.as_ref().map(Ident::to_id),
+                    DefaultDecl::Class(class) => class.ident.as_ref().map(Ident::to_id),
+                    DefaultDecl::TsInterfaceDecl(_) => None,
+                };
+            }
+            _ => {}
+        }
+    }
+    None
 }
 
 fn collect_default_export_object_keys(
@@ -1088,9 +1223,11 @@ where
     let mut self_rewrite_import_locals = Vec::new();
     for result in results {
         for ((chunk_name, chunk_export), count) in &result.references_by_symbol {
-            let mapping = mappings_ref
-                .get(chunk_name)
-                .expect("symbol rewritten against a chunk that wasn't in the mappings");
+            let Some(mapping) = mappings_ref.get(chunk_name) else {
+                bail!(
+                    "partial-swap dispatch: file rewrite reported references to `{chunk_export}` on chunk {chunk_name}, which has no partial-swap mapping"
+                );
+            };
             if let Some(resolution) = resolutions.get_mut(mapping.chunk_path())
                 && let Some(symbol_resolution) = resolution.symbols_mut().get_mut(chunk_export)
             {
@@ -1155,7 +1292,10 @@ pub fn apply_partial_vendor_swaps(
             .with_context(|| {
                 format!("apply_partial_vendor_swaps vendor chunk {chunk_name} is missing entry AST")
             })?;
-        let chunk_exports = collect_exported_names(&entry_ast.module, false);
+        // `default` is a swappable name when the chunk binds it via the
+        // named form (`export { x as default }`), which the strip pass
+        // can map to a chunk-local binding.
+        let chunk_exports = collect_exported_names(&entry_ast.module);
 
         // Validate every declared chunk_export exists as an actual export
         // on the chunk; otherwise the per-symbol rewrite would silently
@@ -1238,7 +1378,7 @@ pub fn apply_partial_vendor_swaps(
                 .with_context(|| format!("reading {}", upstream_path.display()))?;
             let upstream_ast =
                 parse_js_module(&upstream_path.display().to_string(), &upstream_code)?;
-            let upstream_exports = collect_exported_names(&upstream_ast.module, true);
+            let upstream_exports = collect_exported_names(&upstream_ast.module);
             // Packages that re-export everything from a sibling module
             // (`export * from "./other.js"`) can't be fully enumerated
             // by a single-file `collect_exported_names`. Skip the strict
@@ -1407,7 +1547,7 @@ pub fn apply_bundled_partial_vendor_swaps(
                     "apply_bundled_partial_vendor_swaps vendor chunk {chunk_name} is missing entry AST"
                 )
             })?;
-        let chunk_exports = collect_exported_names(&entry_ast.module, false);
+        let chunk_exports = collect_exported_names(&entry_ast.module);
 
         for (chunk_export, symbol) in &bundled.symbols {
             if !chunk_exports.contains(chunk_export) && symbol.local.is_none() {
@@ -1447,7 +1587,7 @@ pub fn apply_bundled_partial_vendor_swaps(
         let bundle_code = fs::read_to_string(&bundled.bundle.path)
             .with_context(|| format!("reading {}", bundled.bundle.path.display()))?;
         let bundle_ast = parse_js_module(&bundled.bundle.path.display().to_string(), &bundle_code)?;
-        let bundle_exports = collect_exported_names(&bundle_ast.module, true);
+        let bundle_exports = collect_exported_names(&bundle_ast.module);
         for (package_name, package) in &bundled.packages {
             if package.bundle_export != "default" && !is_valid_identifier(&package.bundle_export) {
                 bail!(
@@ -1777,6 +1917,20 @@ fn rewrite_partial_swap_in_file(
         },
     );
 
+    // Pass A2: rewrite `export { x } from "<vendor-chunk>"` re-exports of
+    // swapped names. The strip pass removes those names from the chunk's
+    // export surface, so an unrewritten re-export would link-fail.
+    module.body = rewrite_partial_swap_export_from_decls(
+        std::mem::take(&mut module.body),
+        job.caller_chunk_id,
+        &job.file_path,
+        references,
+        chunk_table,
+        materialized_index,
+        mappings,
+        &mut references_by_symbol,
+    );
+
     // Pass B: rewrite every Expr::Ident reference to a tracked local
     // binding into `<namespace>.<upstream_export>`. Only kind=member
     // populates `bindings`; kind=namespace and kind=default leave the
@@ -1797,6 +1951,115 @@ fn rewrite_partial_swap_in_file(
         references_by_symbol,
         self_rewrite_import_locals: BTreeSet::new(),
     }
+}
+
+/// Rewrite `export { <chunk_export> as <name> } from "<vendor-chunk>"`
+/// re-exports of swapped names against the upstream package:
+///
+/// * `kind: named`     → `export { <upstream_export> as <name> } from "<pkg>"`
+/// * `kind: default`   → `export { default as <name> } from "<pkg>"`
+/// * `kind: namespace` → `export * as <name> from "<pkg>"`
+/// * `kind: member`    → retained — a member access off a namespace import
+///   has no live re-export equivalent; the post-strip consumer gate bails
+///   with a precise diagnostic instead.
+///
+/// Bundled partial swaps are not rewritten here (their facade default is
+/// only member-addressable); the consumer gate covers them.
+#[allow(clippy::too_many_arguments)] // mirrors rewrite_swap_import_decls' resolution context
+fn rewrite_partial_swap_export_from_decls(
+    original_body: Vec<ModuleItem>,
+    caller_chunk_id: ChunkId,
+    caller_file_path: &str,
+    references: &ArtifactIndexes,
+    chunk_table: &ChunkTable,
+    materialized_index: &MaterializedOutputChunkIndex,
+    mappings: &PartialSwapMappings,
+    references_by_symbol: &mut BTreeMap<(String, String), usize>,
+) -> Vec<ModuleItem> {
+    let mut new_body: Vec<ModuleItem> = Vec::with_capacity(original_body.len());
+    for item in original_body {
+        let ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(mut named)) = item else {
+            new_body.push(item);
+            continue;
+        };
+        let Some(src) = named.src.as_deref() else {
+            new_body.push(ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(named)));
+            continue;
+        };
+        let source = str_value(src);
+        let Some(target_chunk_id) = resolve_partial_swap_import_target(
+            &source,
+            caller_chunk_id,
+            caller_file_path,
+            references,
+            chunk_table,
+            materialized_index,
+        ) else {
+            new_body.push(ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(named)));
+            continue;
+        };
+        let target_chunk_name = chunk_table.name(target_chunk_id).to_string();
+        let chunk_mapping = if target_chunk_id == caller_chunk_id {
+            None
+        } else {
+            mappings.get(&target_chunk_name)
+        };
+        let Some(chunk_mapping) = chunk_mapping else {
+            new_body.push(ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(named)));
+            continue;
+        };
+        let mut retained: Vec<ExportSpecifier> = Vec::new();
+        let mut replacements: Vec<ModuleItem> = Vec::new();
+        for specifier in std::mem::take(&mut named.specifiers) {
+            let ExportSpecifier::Named(named_spec) = &specifier else {
+                retained.push(specifier);
+                continue;
+            };
+            let orig_name = module_export_name(&named_spec.orig);
+            let exported_name = named_spec
+                .exported
+                .as_ref()
+                .map(module_export_name)
+                .unwrap_or_else(|| orig_name.clone());
+            let Some(target) = chunk_mapping.symbols.get(&orig_name) else {
+                retained.push(specifier);
+                continue;
+            };
+            if !is_valid_identifier(&exported_name) {
+                retained.push(specifier);
+                continue;
+            }
+            let replacement = match target.kind {
+                PartialSwapKind::Named => target
+                    .upstream_export
+                    .as_deref()
+                    .map(|upstream| make_named_reexport(&target.package, upstream, &exported_name)),
+                PartialSwapKind::Default => Some(make_named_reexport(
+                    &target.package,
+                    "default",
+                    &exported_name,
+                )),
+                PartialSwapKind::Namespace => {
+                    Some(make_namespace_reexport(&target.package, &exported_name))
+                }
+                PartialSwapKind::Member => None,
+            };
+            let Some(replacement) = replacement else {
+                retained.push(specifier);
+                continue;
+            };
+            replacements.push(replacement);
+            *references_by_symbol
+                .entry((chunk_mapping.chunk_id.clone(), orig_name))
+                .or_insert(0) += 1;
+        }
+        new_body.extend(replacements);
+        if !retained.is_empty() {
+            named.specifiers = retained;
+            new_body.push(ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(named)));
+        }
+    }
+    new_body
 }
 
 fn rewrite_bundled_partial_swap_in_file(
@@ -2079,7 +2342,8 @@ fn seed_bundled_partial_swap_self_rewrites(
             caller_file_path,
             &package_coords.facade_app_path,
         );
-        let local = unique_synthetic_ident("__debundle_bps", chunk_export, &mut used_idents);
+        let local =
+            unique_synthetic_ident(&format!("__debundle_bps_{chunk_export}"), &mut used_idents);
         match target.kind {
             PartialSwapKind::Member | PartialSwapKind::Named => {
                 let upstream_export = target
@@ -2121,10 +2385,9 @@ fn seed_bundled_partial_swap_self_rewrites(
     }
 }
 
-fn unique_synthetic_ident(prefix: &str, export_name: &str, used: &mut BTreeSet<String>) -> String {
-    let base = format!("{prefix}_{export_name}");
-    if used.insert(base.clone()) {
-        return base;
+fn unique_synthetic_ident(base: &str, used: &mut BTreeSet<String>) -> String {
+    if used.insert(base.to_string()) {
+        return base.to_string();
     }
     let mut i = 2usize;
     loop {
@@ -2528,6 +2791,213 @@ fn make_named_import(package: &str, local: &str, upstream_export: &str) -> Modul
         with: None,
         phase: ImportPhase::Evaluation,
     }))
+}
+
+/// `export { <orig> as <exported> } from "<source>"` (alias omitted when
+/// the names match).
+fn make_named_reexport(source: &str, orig: &str, exported: &str) -> ModuleItem {
+    let exported_name = (orig != exported)
+        .then(|| ModuleExportName::Ident(Ident::new_no_ctxt(exported.into(), DUMMY_SP)));
+    ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(NamedExport {
+        span: DUMMY_SP,
+        specifiers: vec![ExportSpecifier::Named(ExportNamedSpecifier {
+            span: DUMMY_SP,
+            orig: ModuleExportName::Ident(Ident::new_no_ctxt(orig.into(), DUMMY_SP)),
+            exported: exported_name,
+            is_type_only: false,
+        })],
+        src: Some(Box::new(Str {
+            span: DUMMY_SP,
+            value: source.into(),
+            raw: None,
+        })),
+        type_only: false,
+        with: None,
+    }))
+}
+
+/// `export * as <exported> from "<source>"`.
+fn make_namespace_reexport(source: &str, exported: &str) -> ModuleItem {
+    ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(NamedExport {
+        span: DUMMY_SP,
+        specifiers: vec![ExportSpecifier::Namespace(ExportNamespaceSpecifier {
+            span: DUMMY_SP,
+            name: ModuleExportName::Ident(Ident::new_no_ctxt(exported.into(), DUMMY_SP)),
+        })],
+        src: Some(Box::new(Str {
+            span: DUMMY_SP,
+            value: source.into(),
+            raw: None,
+        })),
+        type_only: false,
+        with: None,
+    }))
+}
+
+/// Post-strip cross-chunk soundness gate for partial vendor swaps.
+///
+/// `apply_partial_vendor_swaps` / `apply_bundled_partial_vendor_swaps`
+/// rewrite `ImportDecl` named specifiers (and, for non-bundled swaps,
+/// rewritable `export … from` re-exports); the strip pass then removes
+/// every swapped name from the vendor chunk's export surface. Any
+/// consumer that survived those rewrites while still referencing the
+/// stripped surface yields a broken emitted tree:
+///
+/// * a named import / re-export of a swapped name link-fails;
+/// * a namespace import (`import * as M`) silently reads `undefined`
+///   for swapped members;
+/// * `export *` silently drops the swapped names from the re-exporter.
+///
+/// Scan every retained file of every chunk and bail with a precise
+/// diagnostic on the first surviving consumer. Over-restriction is the
+/// accepted failure mode: a namespace consumer that only reads
+/// non-swapped members would work at runtime, but is rejected anyway
+/// because per-member usage is not analyzed here.
+pub fn validate_partial_swap_consumers(
+    artifact: &ChunkBundle,
+    vendor: &BTreeMap<String, VendorMark>,
+    references: &ArtifactIndexes,
+) -> Result<()> {
+    let chunk_table = &artifact.chunk_table;
+    let mut swapped_by_chunk: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for (chunk_path, mark) in vendor {
+        let symbols = match &mark.level {
+            VendorLevel::PartialSwap(partial) => &partial.symbols,
+            VendorLevel::BundledPartialSwap(partial) => &partial.symbols,
+            _ => continue,
+        };
+        swapped_by_chunk.insert(
+            chunk_id_from_chunk_path(chunk_path, "validate_partial_swap_consumers")?,
+            symbols.keys().cloned().collect(),
+        );
+    }
+    if swapped_by_chunk.is_empty() {
+        return Ok(());
+    }
+    let materialized_index = MaterializedOutputChunkIndex::build(chunk_table);
+    for chunk_artifact in &artifact.chunks {
+        let caller_chunk_id = chunk_artifact.chunk_id;
+        let caller_chunk_name = chunk_table.name(caller_chunk_id);
+        for file_path in list_chunk_file_paths(&chunk_artifact.js) {
+            let Some(ast) = chunk_artifact
+                .js
+                .get_file(&file_path)
+                .and_then(|file| file.ast())
+            else {
+                continue;
+            };
+            for item in &ast.module.body {
+                let ModuleItem::ModuleDecl(decl) = item else {
+                    continue;
+                };
+                let source = match decl {
+                    ModuleDecl::Import(import) => str_value(&import.src),
+                    ModuleDecl::ExportNamed(named) => {
+                        let Some(src) = named.src.as_deref() else {
+                            continue;
+                        };
+                        str_value(src)
+                    }
+                    ModuleDecl::ExportAll(export_all) => str_value(&export_all.src),
+                    _ => continue,
+                };
+                let Some(target_chunk_id) = resolve_partial_swap_import_target(
+                    &source,
+                    caller_chunk_id,
+                    &file_path,
+                    references,
+                    chunk_table,
+                    &materialized_index,
+                ) else {
+                    continue;
+                };
+                let target_chunk_name = chunk_table.name(target_chunk_id);
+                let Some(swapped) = swapped_by_chunk.get(target_chunk_name) else {
+                    continue;
+                };
+                let consumer = format!("{caller_chunk_name}/{file_path}");
+                check_partial_swap_consumer_decl(decl, swapped, &consumer, target_chunk_name)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn check_partial_swap_consumer_decl(
+    decl: &ModuleDecl,
+    swapped: &BTreeSet<String>,
+    consumer: &str,
+    target_chunk_name: &str,
+) -> Result<()> {
+    let swapped_list = || swapped.iter().cloned().collect::<Vec<_>>().join(",");
+    match decl {
+        ModuleDecl::Import(import) => {
+            for specifier in &import.specifiers {
+                match specifier {
+                    ImportSpecifier::Named(named) => {
+                        let imported = named
+                            .imported
+                            .as_ref()
+                            .map(module_export_name)
+                            .unwrap_or_else(|| named.local.sym.to_string());
+                        if swapped.contains(&imported) {
+                            bail!(
+                                "partial-swap consumer gate: {consumer} imports swapped name `{imported}` from partially-swapped vendor chunk {target_chunk_name}; the rewrite did not cover this consumer and the stripped chunk no longer exports it",
+                            );
+                        }
+                    }
+                    ImportSpecifier::Namespace(_) => {
+                        bail!(
+                            "partial-swap consumer gate: {consumer} namespace-imports partially-swapped vendor chunk {target_chunk_name}; swapped members [{}] would read as `undefined` on the namespace object — namespace consumers of partially-swapped chunks are unsupported, restructure the spec",
+                            swapped_list(),
+                        );
+                    }
+                    ImportSpecifier::Default(_) => {
+                        if swapped.contains("default") {
+                            bail!(
+                                "partial-swap consumer gate: {consumer} default-imports partially-swapped vendor chunk {target_chunk_name} whose `default` export was swapped",
+                            );
+                        }
+                    }
+                }
+            }
+        }
+        ModuleDecl::ExportNamed(named) => {
+            for specifier in &named.specifiers {
+                match specifier {
+                    ExportSpecifier::Named(named_spec) => {
+                        let orig = module_export_name(&named_spec.orig);
+                        if swapped.contains(&orig) {
+                            bail!(
+                                "partial-swap consumer gate: {consumer} re-exports swapped name `{orig}` from partially-swapped vendor chunk {target_chunk_name}; this re-export shape has no live rewrite (kind=member symbols and bundled swaps cannot be expressed as re-exports) and the stripped chunk no longer exports it",
+                            );
+                        }
+                    }
+                    ExportSpecifier::Namespace(_) => {
+                        bail!(
+                            "partial-swap consumer gate: {consumer} re-exports the namespace of partially-swapped vendor chunk {target_chunk_name} (`export * as …`); swapped members [{}] would read as `undefined`",
+                            swapped_list(),
+                        );
+                    }
+                    ExportSpecifier::Default(_) => {
+                        if swapped.contains("default") {
+                            bail!(
+                                "partial-swap consumer gate: {consumer} re-exports the swapped `default` of partially-swapped vendor chunk {target_chunk_name}",
+                            );
+                        }
+                    }
+                }
+            }
+        }
+        ModuleDecl::ExportAll(_) => {
+            bail!(
+                "partial-swap consumer gate: {consumer} uses `export *` from partially-swapped vendor chunk {target_chunk_name}; swapped names [{}] would silently vanish from the re-exporter's surface",
+                swapped_list(),
+            );
+        }
+        _ => {}
+    }
+    Ok(())
 }
 
 fn is_valid_identifier(name: &str) -> bool {

--- a/devinfra/js/debundle/vendor/strip.rs
+++ b/devinfra/js/debundle/vendor/strip.rs
@@ -5,9 +5,7 @@ use analysis::{
     AnalysisHints, ChunkId, EffectCell, LocalEffectPolicy, StatementFacts, analyze_chunk,
 };
 use anyhow::{Context, Result, bail};
-use binding_targets::{
-    binding_name_strings, declaration_ids, declaration_name_strings, module_export_name,
-};
+use binding_targets::{declaration_ids, declaration_name_strings, module_export_name};
 use rayon::prelude::*;
 use serde::Serialize;
 use swc_common::sync::Lrc;
@@ -217,7 +215,7 @@ fn strip_one_chunk_with_replacement_imports(
     split_top_level_var_decls(module);
     let stripped = strip_export_specifiers(module, symbols, chunk_path)?;
     let stripped_export_specifiers = stripped.len();
-    let post_strip_exports = collect_exported_names(module);
+    let post_strip_exports = super::collect_exported_names(module);
 
     let dropped_total_before = module.body.len();
     sweep_unreachable_top_level(
@@ -231,7 +229,7 @@ fn strip_one_chunk_with_replacement_imports(
     let dropped = dropped_total_before - retained;
 
     // Phase 2 must not change the export surface relative to Phase 1.
-    let post_dce_exports = collect_exported_names(module);
+    let post_dce_exports = super::collect_exported_names(module);
     if post_dce_exports != post_strip_exports {
         let removed: Vec<_> = post_strip_exports
             .difference(&post_dce_exports)
@@ -725,13 +723,11 @@ fn sweep_unreachable_top_level(
         );
     }
 
-    let mut original = std::mem::take(&mut module.body);
-    for (i, is_live) in live.iter().enumerate().rev() {
-        if !*is_live {
-            original.remove(i);
-        }
-    }
-    module.body = original;
+    module.body = std::mem::take(&mut module.body)
+        .into_iter()
+        .zip(live.iter())
+        .filter_map(|(item, &is_live)| is_live.then_some(item))
+        .collect();
     Ok(())
 }
 
@@ -1595,53 +1591,6 @@ fn matches_global_intrinsic(name: &str) -> bool {
             | "WeakRef"
             | "WeakSet"
     )
-}
-
-/// Subset of [`collect_exported_names`] in `vendor.rs`: returns the
-/// post-mutation export surface of `module`. Local re-exports
-/// (`export { x as y }`), `export const x = …`, `export function`,
-/// `export class`, `export default …` all count.
-fn collect_exported_names(module: &Module) -> BTreeSet<String> {
-    let mut out = BTreeSet::new();
-    for item in &module.body {
-        match item {
-            ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultDecl(_))
-            | ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultExpr(_)) => {
-                out.insert("default".to_string());
-            }
-            ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(export_decl)) => {
-                match &export_decl.decl {
-                    Decl::Fn(f) => {
-                        out.insert(f.ident.sym.to_string());
-                    }
-                    Decl::Class(c) => {
-                        out.insert(c.ident.sym.to_string());
-                    }
-                    Decl::Var(v) => {
-                        for d in &v.decls {
-                            out.extend(binding_name_strings(&d.name));
-                        }
-                    }
-                    _ => {}
-                }
-            }
-            ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(named)) => {
-                for spec in &named.specifiers {
-                    if let ExportSpecifier::Named(named_spec) = spec {
-                        out.insert(
-                            named_spec
-                                .exported
-                                .as_ref()
-                                .map(module_export_name)
-                                .unwrap_or_else(|| module_export_name(&named_spec.orig)),
-                        );
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
-    out
 }
 
 #[cfg(test)]

--- a/devinfra/js/debundle/vendor/wrappers.rs
+++ b/devinfra/js/debundle/vendor/wrappers.rs
@@ -17,7 +17,12 @@ pub(super) fn generate_named_from_default_wrapper(
     named_exports: &BTreeSet<String>,
 ) -> Result<String> {
     let mut body = Vec::new();
-    let default_local = Ident::new_no_ctxt("_d".into(), DUMMY_SP);
+    // The synthetic local hoisting upstream's default must not collide
+    // with any identifier the upstream body already uses — a duplicate
+    // top-level `const` is a module-level SyntaxError.
+    let mut used_idents = super::module_used_idents(&upstream_ast.module);
+    let default_local_name = super::unique_synthetic_ident("_d", &mut used_idents);
+    let default_local = Ident::new_no_ctxt(default_local_name.as_str().into(), DUMMY_SP);
     for item in &upstream_ast.module.body {
         match item {
             ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultExpr(default_expr)) => {
@@ -40,9 +45,9 @@ pub(super) fn generate_named_from_default_wrapper(
             _ => body.push(item.clone()),
         }
     }
-    body.push(export_default_ident("_d"));
+    body.push(export_default_ident(&default_local_name));
     for name in named_exports {
-        body.push(export_const_member(name, "_d", name));
+        body.push(export_const_member(name, &default_local_name, name));
     }
     emit_js_module(
         &ParsedJsModule {
@@ -62,14 +67,16 @@ pub(super) fn generate_named_from_default_wrapper(
 pub(super) fn generate_named_from_json_default_wrapper(
     upstream_json: &Value,
     named_exports: &BTreeSet<String>,
-) -> String {
-    let body = serde_json::to_string_pretty(upstream_json).unwrap_or_else(|_| "{}".to_string());
+) -> Result<String> {
+    // `_d` cannot collide here: the wrapper body is pure JSON data, so
+    // no upstream identifier exists to clash with.
+    let body = serde_json::to_string_pretty(upstream_json)?;
     let named = named_exports
         .iter()
         .map(|name| format!("export const {name} = _d.{name};"))
         .collect::<Vec<_>>()
         .join("\n");
-    format!("const _d = {body};\nexport default _d;\n{named}\n")
+    Ok(format!("const _d = {body};\nexport default _d;\n{named}\n"))
 }
 
 pub(super) fn generate_named_from_module_default_wrapper(
@@ -77,7 +84,10 @@ pub(super) fn generate_named_from_module_default_wrapper(
     vendor_exports: &BTreeSet<String>,
     chunk_path: &str,
 ) -> Result<String> {
-    let default_local_name = "__vendor_default__";
+    // Avoid duplicate-declaration SyntaxErrors when the upstream body
+    // already binds the synthetic default-local name.
+    let mut used_idents = super::module_used_idents(&upstream_ast.module);
+    let default_local_name = &super::unique_synthetic_ident("__vendor_default__", &mut used_idents);
     let mut found_default = false;
     let mut deferred_default_alias: Option<String> = None;
     let mut body = Vec::new();
@@ -93,7 +103,7 @@ pub(super) fn generate_named_from_module_default_wrapper(
                     decls: vec![VarDeclarator {
                         span: DUMMY_SP,
                         name: Pat::Ident(BindingIdent {
-                            id: Ident::new_no_ctxt(default_local_name.into(), DUMMY_SP),
+                            id: Ident::new_no_ctxt(default_local_name.as_str().into(), DUMMY_SP),
                             type_ann: None,
                         }),
                         init: Some(default_expr.expr.clone()),


### PR DESCRIPTION
Fixes a batch of vendor-swap soundness edges in `devinfra/js/debundle/vendor/`. Every behavioral fix landed failing-e2e-first: with the test changes applied but production code reverted, 11 of the new fixtures fail (verified on invocation `abede24b-8ed0-4351-9e0b-1c163d84856a`); the remainder are deliberate invariant pins.

## Partial-swap consumer soundness (top priority)

The per-symbol rewrite only handled `ModuleDecl::Import` consumers; `export { e6 } from "<vendor-chunk>"` re-exports and `import * as M` namespace imports of a partially-swapped chunk survived unrewritten while the strip pass removed the names from the chunk's export surface — yielding a link error (re-export) or silent `M.e6 === undefined` (namespace member).

- **Rewrite** (`rewrite_partial_swap_export_from_decls`): `export … from` re-exports of swapped names are now rewritten against the upstream package — `kind: named` → `export { upstream as name } from "pkg"`, `kind: default` → `export { default as name } from "pkg"`, `kind: namespace` → `export * as name from "pkg"`. Runtime-verified under Node.
- **Mandatory post-strip gate** (`validate_partial_swap_consumers`, wired in `pipeline.rs` after the strip): scans all retained files of all chunks and bails with a precise diagnostic on any surviving consumer of the stripped surface — unrewritten named imports/re-exports, namespace imports, default imports of a swapped `default`, member-kind re-exports (no live rewrite exists), bundled-swap re-exports, and `export *`. Over-restriction is the accepted failure mode per the soundness contract.

## Boundary rename collision

`rename_vendor_exports` keys its mapping by vendor-local name. If the vendor also genuinely exports that name bound to a *different* local (`export { a as alpha, z as a }`), the caller's `import { a }` was silently rebound to the wrong value. Now bails with a diagnostic naming the colliding export.

## Wrapper fixes

- Synthetic default locals `_d` / `__vendor_default__` are now minted via `unique_synthetic_ident` against the upstream module's used identifiers — an upstream body that already binds the name no longer produces a duplicate-declaration SyntaxError.
- `named_from_module_default` aliased **every** vendor named export to the upstream default with no validation. It now requires each named export to be a verified alias of the chunk's own default binding (same local `Id`), mirroring `named_from_default`'s key-subset check; over-claims bail.

## `export { x as default }` asymmetry

`collect_exported_names(_, include_default=false)` returned `default` from the `ExportNamed` arm anyway. All call sites need default included, so the parameter is gone and the duplicate helper copy in `strip.rs` is consolidated into the single `vendor/mod.rs` helper. Both directions tested: a default-exporting chunk swapped against a default-less upstream bails; `export { x as default }` against an upstream with a default passes.

## New invariant pins

- `named_from_json_default`: generated named pulls run under Node; names missing from the upstream JSON keys bail (previously zero coverage).
- Full swap **with** a caller chunk: the caller's import of the removed chunk is intentionally left dangling in the plain `write_js_tree` output — the live-proxy/import-map layer resolves it at serve time. Pinned and documented.
- `suppress` chunks and their callers pass through byte-identical.
- `boundary_rename` end-to-end: caller import rewritten and tree runs under Node.

## Docs

New "Vendor chunk swapping" section in `docs/design.md`: the full-swap caller contract, the consumer gate, the two deliberate split-brain bypasses (multi-package items bail only at `packages.len() == 1`; `shareable_helper` exemption) with their shared stateful-helper risk, and wrappers' init-time-snapshot re-exports as a documented precondition on upstream packages (no post-init reassignment of the default's properties; no live-binding reliance).

## Nits

- `sweep_unreachable_top_level`: O(n²) reverse `Vec::remove` loop → single `filter_map` pass.
- `generate_named_from_json_default_wrapper`: serde error was swallowed via `unwrap_or_else(|_| "{}")` → propagated.
- Partial-swap dispatch: `expect` on a missing chunk mapping → `bail!` with context.

## Testing

- `bbr test //devinfra/js/debundle/...` — 90/90 green.
- Red-first verification: production diff stashed, `vendor_swap_test` fails 11/45 (`abede24b-8ed0-4351-9e0b-1c163d84856a`).
- Full `bbr build //...` + `bbr test //...` — 719 pass; only the 6 `.live` external-API tests fail (pre-existing, excluded in CI by tag filter).
- `BAZEL_TEST_INVOCATIONS=buildbuddy:a50cec2a-324d-4ca6-880b-01462cbbab26`

https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk)_