### PR TITLE
Split Flux bootstrap reads from write auth

### DIFF
--- a/cluster/docs/bootstrap_dependencies.md
+++ b/cluster/docs/bootstrap_dependencies.md
@@ -57,19 +57,19 @@ No downstream regeneration needed — these are read-only inputs.
 Encrypted with admin age key (L0). These are the source of truth for
 secrets that Flux and tofu consume.
 
-| File                                                      | Contents                                                                   | Depends On                                                     | Depended On By                                                                                       |
-| --------------------------------------------------------- | -------------------------------------------------------------------------- | -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `secrets/nebula/ca.crt`                                   | Nebula CA public cert (plaintext)                                          | None                                                           | L2: tofu node cert signing; L7: NixOS workers, ansible                                               |
-| `secrets/nebula/ca.sops.key`                              | Nebula CA private key (SOPS bin)                                           | Admin age key                                                  | L2: tofu node cert signing                                                                           |
-| `secrets/nebula/*.sops.key`                               | Nebula host private keys (binary)                                          | Admin age key + host age key, or admin-only for mobile clients | L7: NixOS worker nebula mesh, ansible, mobile import generation                                      |
-| `secrets/nebula/*.crt`                                    | Nebula host public certs (plain)                                           | None                                                           | L7: NixOS worker nebula mesh, ansible, mobile import generation                                      |
-| `secrets/ducktape-automation.<date>.private-key.sops.pem` | GitHub App PEM (RSA, SOPS bin)                                             | Admin age key + cluster-secrets + ci                           | L5: Flux git auth (mirrored into `cluster/k8s/flux-system/ducktape-automation-github-app.sops.yaml`) |
-| `secrets/shared/cluster-secrets-age.yaml`                 | Age keypair (private + public)                                             | Admin age key                                                  | L5: Flux SOPS decryption (`sops-age-cluster-secrets` k8s secret)                                     |
-| `secrets/shared/cluster-tokens.yaml`                      | Proxmox API token; legacy HCloud token retained for account-history access | Admin age key + user age keys                                  | `.envrc` -> `PROXMOX_VE_API_TOKEN`                                                                   |
-| `secrets/ovh-credentials.sops.yaml`                       | OVH API credentials (AK/AS/CK)                                             | Admin age key + user age keys                                  | `terraform.tf` OVH provider → `ovh-nodes.tf` Kimsufi provisioning                                    |
-| `secrets/k8s-ca.crt`                                      | K8s cluster CA cert (plaintext)                                            | None                                                           | L7: kubelet TLS on NixOS workers                                                                     |
-| `secrets/k8s-worker.yaml`                                 | k8s bootstrap token                                                        | Admin age key                                                  | L7: kubelet TLS bootstrap on NixOS workers                                                           |
-| `cluster/k8s/**/*.sops.yaml` (27 files)                   | App credentials (API keys, tokens)                                         | Admin age key + cluster age key                                | L6: individual services + L5 Flux git auth (`ducktape-automation-github-app`)                        |
+| File                                                      | Contents                                                                   | Depends On                                                     | Depended On By                                                                                                     |
+| --------------------------------------------------------- | -------------------------------------------------------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `secrets/nebula/ca.crt`                                   | Nebula CA public cert (plaintext)                                          | None                                                           | L2: tofu node cert signing; L7: NixOS workers, ansible                                                             |
+| `secrets/nebula/ca.sops.key`                              | Nebula CA private key (SOPS bin)                                           | Admin age key                                                  | L2: tofu node cert signing                                                                                         |
+| `secrets/nebula/*.sops.key`                               | Nebula host private keys (binary)                                          | Admin age key + host age key, or admin-only for mobile clients | L7: NixOS worker nebula mesh, ansible, mobile import generation                                                    |
+| `secrets/nebula/*.crt`                                    | Nebula host public certs (plain)                                           | None                                                           | L7: NixOS worker nebula mesh, ansible, mobile import generation                                                    |
+| `secrets/ducktape-automation.<date>.private-key.sops.pem` | GitHub App PEM (RSA, SOPS bin)                                             | Admin age key + cluster-secrets + ci                           | L6: Flux private/write git auth (mirrored into `cluster/k8s/flux-system/ducktape-automation-github-app.sops.yaml`) |
+| `secrets/shared/cluster-secrets-age.yaml`                 | Age keypair (private + public)                                             | Admin age key                                                  | L5: Flux SOPS decryption (`sops-age-cluster-secrets` k8s secret)                                                   |
+| `secrets/shared/cluster-tokens.yaml`                      | Proxmox API token; legacy HCloud token retained for account-history access | Admin age key + user age keys                                  | `.envrc` -> `PROXMOX_VE_API_TOKEN`                                                                                 |
+| `secrets/ovh-credentials.sops.yaml`                       | OVH API credentials (AK/AS/CK)                                             | Admin age key + user age keys                                  | `terraform.tf` OVH provider → `ovh-nodes.tf` Kimsufi provisioning                                                  |
+| `secrets/k8s-ca.crt`                                      | K8s cluster CA cert (plaintext)                                            | None                                                           | L7: kubelet TLS on NixOS workers                                                                                   |
+| `secrets/k8s-worker.yaml`                                 | k8s bootstrap token                                                        | Admin age key                                                  | L7: kubelet TLS bootstrap on NixOS workers                                                                         |
+| `cluster/k8s/**/*.sops.yaml` (27 files)                   | App credentials (API keys, tokens)                                         | Admin age key + cluster age key                                | L6: individual services + L5 Flux git auth (`ducktape-automation-github-app`)                                      |
 
 **If nebula CA is lost**: Generate new CA with `nebula-cert ca`, write cert
 to `secrets/nebula/ca.crt`, encrypt key to `secrets/nebula/ca.sops.key`.
@@ -164,18 +164,27 @@ the bootstrap manifests. Or delete the `flux-system` namespace and re-run Phase 
 
 ### GitHub App authentication (runtime)
 
-The root `flux-system` GitRepository reads the public `ducktape` repo
-anonymously, so cold-start bootstrap does not require local access to the
-GitHub App private key. Flux then decrypts the SOPS-encrypted GitHub App Secret
-and uses it for private/write paths: the private `gaffer-private` GitRepository
-and image update automation pushes. The in-cluster Secret
-`flux-system/ducktape-automation-github-app` holds `githubAppID`,
-`githubAppInstallationID`, and `githubAppPrivateKey` — sourced from
-`secrets/ducktape-automation.<date>.private-key.sops.pem` and committed as a
-SOPS-encrypted Secret manifest at
+The raw Terraform bootstrap manifests must not depend on the GitHub App Secret:
+the root `flux-system` GitRepository reads the public `ducktape` repo
+anonymously, so cold-start bootstrap only needs network access to GitHub and the
+Terraform-created SOPS age Secret. After the root Kustomization starts
+reconciling, Flux decrypts the SOPS-encrypted GitHub App Secret and uses it for
+private/write paths:
+
+- `GitRepository/ducktape-write` in
+  `cluster/k8s/flux-image-automation-ghcr/ducktape-write-source.yaml` is the
+  authenticated checkout used by `ImageUpdateAutomation/all-images` to push
+  image-pin commits back to `ducktape/devel`.
+- `GitRepository/gaffer-private` in `cluster/k8s/gaffer-private-source/source.yaml`
+  uses the same Secret for private repo reads and image automation pushes to
+  `gaffer-private/main`.
+
+The in-cluster Secret `flux-system/ducktape-automation-github-app` holds
+`githubAppID`, `githubAppInstallationID`, and `githubAppPrivateKey` — sourced
+from `secrets/ducktape-automation.<date>.private-key.sops.pem` and committed as
+a SOPS-encrypted Secret manifest at
 `cluster/k8s/flux-system/ducktape-automation-github-app.sops.yaml` (encrypted
-to admin + cluster-secrets recipients). Image-update-automation pushes to
-`gaffer-private` ride on the same Secret.
+to admin + cluster-secrets recipients).
 
 **If the App PEM is rotated**: regenerate the App's private key in GitHub UI,
 overwrite `secrets/ducktape-automation.<date>.private-key.sops.pem` (bump the

--- a/cluster/k8s/BUILD.bazel
+++ b/cluster/k8s/BUILD.bazel
@@ -4,7 +4,10 @@ filegroup(
         "flux-system/gotk-components.yaml",
         "flux-system/gotk-sync.yaml",
     ],
-    visibility = ["//cluster/terraform/main:__pkg__"],
+    visibility = [
+        "//cluster/terraform/main:__pkg__",
+        "//cluster/validation:__pkg__",
+    ],
 )
 
 filegroup(

--- a/cluster/k8s/flux-image-automation-ghcr/ducktape-write-source.yaml
+++ b/cluster/k8s/flux-image-automation-ghcr/ducktape-write-source.yaml
@@ -1,0 +1,17 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: ducktape-write
+  namespace: flux-system
+  annotations:
+    description: "Authenticated ducktape checkout for image automation pushes. The root flux-system GitRepository stays anonymous so Terraform can cold-bootstrap Flux before this SOPS-managed GitHub App Secret exists."
+spec:
+  interval: 1m
+  provider: github
+  ref:
+    branch: devel
+  secretRef:
+    name: ducktape-automation-github-app
+  sparseCheckout:
+    - cluster/k8s/
+  url: https://github.com/agentydragon/ducktape.git

--- a/cluster/k8s/flux-image-automation-ghcr/image-update-automation.yaml
+++ b/cluster/k8s/flux-image-automation-ghcr/image-update-automation.yaml
@@ -7,7 +7,7 @@ spec:
   interval: 5m
   sourceRef:
     kind: GitRepository
-    name: flux-system
+    name: ducktape-write
   git:
     checkout:
       ref:

--- a/cluster/k8s/flux-image-automation-ghcr/kustomization.yaml
+++ b/cluster/k8s/flux-image-automation-ghcr/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ducktape-write-source.yaml
   - props-backend-image-repository.yaml
   - props-backend-image-policy.yaml
   - props-llm-proxy-image-repository.yaml

--- a/cluster/k8s/flux-system/gotk-sync.yaml
+++ b/cluster/k8s/flux-system/gotk-sync.yaml
@@ -7,11 +7,8 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1m0s
-  provider: github
   ref:
     branch: devel
-  secretRef:
-    name: ducktape-automation-github-app
   sparseCheckout:
     - cluster/k8s/
     - tf/gitops/

--- a/cluster/k8s/flux-system/kustomization.yaml
+++ b/cluster/k8s/flux-system/kustomization.yaml
@@ -5,7 +5,8 @@ resources:
   # gotk-components.yaml instead of overlay-only patches.
   - gotk-components.yaml
   # Keep root GitRepository fields that must survive raw Terraform bootstrap
-  # applies, such as auth and sparseCheckout, in gotk-sync.yaml.
+  # applies in gotk-sync.yaml. Runtime GitHub App auth belongs on separate
+  # Flux-managed sources because the Secret below is SOPS-decrypted by Flux.
   - gotk-sync.yaml
   - ducktape-automation-github-app.sops.yaml
 patches:

--- a/cluster/validation/BUILD.bazel
+++ b/cluster/validation/BUILD.bazel
@@ -170,9 +170,12 @@ py_test(
         ":cluster",
         ":dependencies",
         ":flux",
+        ":k8s",
+        ":kustomize",
         "//util/bazel:runfiles",
         "@pypi//pytest",
         "@pypi//pytest_bazel",
+        "@pypi//pyyaml",
     ],
 )
 
@@ -285,12 +288,14 @@ py_test(
     srcs = ["test_cluster_integration.py"],
     data = [
         "//cluster/k8s:cluster_all_files",
+        "//cluster/k8s:flux_bootstrap_files",
         "@multitool//tools/kustomize",
     ],
     deps = [
         ":checks",
         ":cluster",
         ":dependencies",
+        ":flux",
         ":health_checks",
         ":image_automation",
         ":kustomize",

--- a/cluster/validation/flux.py
+++ b/cluster/validation/flux.py
@@ -7,13 +7,24 @@ import re
 from collections import Counter
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import yaml
 from pydantic import BaseModel, ConfigDict
 from pydantic.alias_generators import to_camel
 
-from cluster.validation.k8s import Condition, parse_k8s_resources
+from cluster.validation.k8s import (
+    Condition,
+    GitRepositoryResource,
+    ImageUpdateAutomationResource,
+    K8sResource,
+    parse_k8s_resource_file,
+    parse_k8s_resources,
+)
 from cluster.validation.tool_resolve import resolve_tool
+
+if TYPE_CHECKING:
+    from cluster.validation.cluster import ParsedCluster
 
 
 class DependsOn(BaseModel):
@@ -262,5 +273,80 @@ async def validate_flux_build(k8s_dir: Path) -> list[str]:
         errors.append("No Flux Kustomization resources found in flux build output")
     if resource_counts.get("GitRepository", 0) == 0:
         errors.append("No GitRepository resource found in flux build output")
+
+    return errors
+
+
+def _resource_key(resource: K8sResource) -> tuple[str, str]:
+    return (resource.namespace, resource.name)
+
+
+def _sops_managed_secret_keys(k8s_dir: Path) -> set[tuple[str, str]]:
+    keys: set[tuple[str, str]] = set()
+    for sops_file in k8s_dir.rglob("*.sops.yaml"):
+        for resource in parse_k8s_resource_file(sops_file):
+            if resource.kind == "Secret":
+                keys.add(_resource_key(resource))
+    return keys
+
+
+def _bootstrap_gitrepositories(k8s_dir: Path) -> list[GitRepositoryResource]:
+    bootstrap_sync = k8s_dir / "flux-system" / "gotk-sync.yaml"
+    if not bootstrap_sync.exists():
+        return []
+    return [
+        resource for resource in parse_k8s_resource_file(bootstrap_sync) if isinstance(resource, GitRepositoryResource)
+    ]
+
+
+def check_flux_bootstrap_auth(cluster: ParsedCluster, k8s_dir: Path) -> list[str]:
+    """Check that cold bootstrap reads are public and runtime write sources are authenticated."""
+    errors: list[str] = []
+    sops_secrets = _sops_managed_secret_keys(k8s_dir)
+
+    for source in _bootstrap_gitrepositories(k8s_dir):
+        if source.spec.provider == "github":
+            errors.append(
+                f"Raw bootstrap GitRepository '{source.namespace}/{source.name}' sets provider=github. "
+                "Terraform applies gotk-sync.yaml before Flux can decrypt SOPS Secrets; keep bootstrap "
+                "sources anonymous or use a Secret created before source-controller fetches the repo."
+            )
+        if source.spec.secret_ref and (source.namespace, source.spec.secret_ref.name) in sops_secrets:
+            errors.append(
+                f"Raw bootstrap GitRepository '{source.namespace}/{source.name}' references SOPS-managed "
+                f"Secret '{source.namespace}/{source.spec.secret_ref.name}'. That creates a cold-start "
+                "cycle because source-controller needs git auth before kustomize-controller can decrypt "
+                "and apply the Secret."
+            )
+
+    git_repositories: dict[tuple[str, str], GitRepositoryResource] = {}
+    image_automations: list[ImageUpdateAutomationResource] = []
+    for result in cluster.build_results:
+        for resource in result.resources:
+            if isinstance(resource, GitRepositoryResource):
+                git_repositories[_resource_key(resource)] = resource
+            elif isinstance(resource, ImageUpdateAutomationResource):
+                image_automations.append(resource)
+
+    for automation in image_automations:
+        source_ref = automation.spec.source_ref
+        if source_ref.kind != "GitRepository":
+            continue
+        source_namespace = source_ref.namespace or automation.namespace
+        source_key = (source_namespace, source_ref.name)
+        source = git_repositories.get(source_key)
+        if source is None:
+            errors.append(
+                f"ImageUpdateAutomation '{automation.namespace}/{automation.name}' references missing "
+                f"GitRepository '{source_namespace}/{source_ref.name}'."
+            )
+            continue
+        if source.spec.secret_ref is None or not source.spec.secret_ref.name:
+            errors.append(
+                f"ImageUpdateAutomation '{automation.namespace}/{automation.name}' uses GitRepository "
+                f"'{source.namespace}/{source.name}' without a secretRef. Image automation writes commits "
+                "back to git, so the referenced source must carry push-capable credentials instead of "
+                "reusing the anonymous bootstrap source."
+            )
 
     return errors

--- a/cluster/validation/k8s.py
+++ b/cluster/validation/k8s.py
@@ -89,6 +89,38 @@ class ImageRepositoryResource(K8sResource):
     """Flux `ImageRepository` — only its name is needed."""
 
 
+class SecretRef(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    name: str = ""
+
+
+class FluxSourceRef(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    kind: str = "GitRepository"
+    name: str = ""
+    namespace: str | None = None
+
+
+class GitRepositorySpec(BaseModel):
+    model_config = ConfigDict(extra="ignore", populate_by_name=True, alias_generator=to_camel)
+    url: str = ""
+    provider: str | None = None
+    secret_ref: SecretRef | None = None
+
+
+class GitRepositoryResource(K8sResource):
+    spec: GitRepositorySpec = Field(default_factory=GitRepositorySpec)
+
+
+class ImageUpdateAutomationSpec(BaseModel):
+    model_config = ConfigDict(extra="ignore", populate_by_name=True, alias_generator=to_camel)
+    source_ref: FluxSourceRef = Field(default_factory=FluxSourceRef)
+
+
+class ImageUpdateAutomationResource(K8sResource):
+    spec: ImageUpdateAutomationSpec = Field(default_factory=ImageUpdateAutomationSpec)
+
+
 class _ImageRepositoryRef(BaseModel):
     model_config = ConfigDict(extra="ignore")
     name: str = ""
@@ -119,6 +151,8 @@ class ReceiverResource(K8sResource):
 
 
 _KIND_MODELS: dict[str, type[K8sResource]] = {
+    "GitRepository": GitRepositoryResource,
+    "ImageUpdateAutomation": ImageUpdateAutomationResource,
     "HelmRelease": HelmReleaseResource,
     "ImageRepository": ImageRepositoryResource,
     "ImagePolicy": ImagePolicyResource,

--- a/cluster/validation/test_cluster_integration.py
+++ b/cluster/validation/test_cluster_integration.py
@@ -26,6 +26,7 @@ from cluster.validation.checks import (
 )
 from cluster.validation.cluster import ParsedCluster, parse_cluster
 from cluster.validation.dependencies import validate_dependencies
+from cluster.validation.flux import check_flux_bootstrap_auth
 from cluster.validation.health_checks import check_controller_health_checks, check_retry_policy
 from cluster.validation.image_automation import check_image_automation_webhook
 from cluster.validation.kustomize import KustomizeBuildResult, run_kustomize_build
@@ -88,6 +89,12 @@ def test_image_automation_webhook_consistency(cluster: ParsedCluster) -> None:
     raw-YAML-walking bug.
     """
     errors = check_image_automation_webhook(cluster)
+    assert not errors, "\n".join(errors)
+
+
+def test_flux_bootstrap_auth_split(cluster: ParsedCluster, k8s_dir: Path) -> None:
+    """Cold bootstrap sources must not depend on Flux-decrypted auth; write sources must."""
+    errors = check_flux_bootstrap_auth(cluster, k8s_dir)
     assert not errors, "\n".join(errors)
 
 

--- a/cluster/validation/test_flux.py
+++ b/cluster/validation/test_flux.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 import pytest_bazel
 
 from cluster.validation.cluster import ParsedCluster
 from cluster.validation.dependencies import CyclicDependencyError, assert_no_cycles
-from cluster.validation.flux import parse_flux_kustomizations
+from cluster.validation.flux import check_flux_bootstrap_auth, parse_flux_kustomizations
+from cluster.validation.k8s import parse_k8s_resources
+from cluster.validation.kustomize import KustomizeBuildResult
 from util.bazel.runfiles import get_required_path
 
 
@@ -33,6 +37,108 @@ class TestParseFluxKustomization:
         cluster = ParsedCluster(flux_kustomizations=kustomizations)
         with pytest.raises(CyclicDependencyError):
             assert_no_cycles(cluster.graph)
+
+
+def _write_yaml(path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+def _cluster_with_resources(*docs: dict) -> ParsedCluster:
+    result = KustomizeBuildResult(
+        kustomization_path=Path("cluster/k8s/synthetic/kustomization.yaml"), resources=parse_k8s_resources(docs)
+    )
+    return ParsedCluster(build_results=[result])
+
+
+def _git_repository(name: str, *, secret_name: str | None = None) -> dict:
+    spec: dict = {"url": "https://github.com/agentydragon/ducktape.git", "ref": {"branch": "devel"}}
+    if secret_name:
+        spec["provider"] = "github"
+        spec["secretRef"] = {"name": secret_name}
+    return {
+        "apiVersion": "source.toolkit.fluxcd.io/v1",
+        "kind": "GitRepository",
+        "metadata": {"name": name, "namespace": "flux-system"},
+        "spec": spec,
+    }
+
+
+def _image_update_automation(source_name: str) -> dict:
+    return {
+        "apiVersion": "image.toolkit.fluxcd.io/v1beta2",
+        "kind": "ImageUpdateAutomation",
+        "metadata": {"name": "all-images", "namespace": "flux-system"},
+        "spec": {
+            "sourceRef": {"kind": "GitRepository", "name": source_name},
+            "git": {
+                "checkout": {"ref": {"branch": "devel"}},
+                "commit": {"author": {"name": "flux-image-automation", "email": "flux@allegedly.works"}},
+                "push": {"branch": "devel"},
+            },
+            "update": {"strategy": "Setters", "path": "./cluster/k8s"},
+        },
+    }
+
+
+def test_bootstrap_gitrepository_cannot_depend_on_sops_managed_auth(tmp_path: Path) -> None:
+    """source-controller needs the bootstrap source before Flux can decrypt SOPS resources."""
+    _write_yaml(
+        tmp_path / "flux-system" / "gotk-sync.yaml",
+        """
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: flux-system
+  namespace: flux-system
+spec:
+  interval: 1m
+  provider: github
+  secretRef:
+    name: ducktape-automation-github-app
+  url: https://github.com/agentydragon/ducktape.git
+""",
+    )
+    _write_yaml(
+        tmp_path / "flux-system" / "ducktape-automation-github-app.sops.yaml",
+        """
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ducktape-automation-github-app
+  namespace: flux-system
+type: Opaque
+stringData:
+  githubAppPrivateKey: ENC[AES256_GCM,data:example]
+""",
+    )
+
+    errors = check_flux_bootstrap_auth(ParsedCluster(), tmp_path)
+    assert any("sets provider=github" in error for error in errors)
+    assert any("references SOPS-managed Secret" in error for error in errors)
+
+
+def test_image_update_automation_requires_authenticated_source(tmp_path: Path) -> None:
+    _write_yaml(tmp_path / "flux-system" / "gotk-sync.yaml", "")
+    cluster = _cluster_with_resources(_git_repository("flux-system"), _image_update_automation("flux-system"))
+
+    errors = check_flux_bootstrap_auth(cluster, tmp_path)
+
+    assert errors == [
+        "ImageUpdateAutomation 'flux-system/all-images' uses GitRepository "
+        "'flux-system/flux-system' without a secretRef. Image automation writes commits back to git, so the "
+        "referenced source must carry push-capable credentials instead of reusing the anonymous bootstrap source."
+    ]
+
+
+def test_authenticated_image_update_source_is_valid(tmp_path: Path) -> None:
+    _write_yaml(tmp_path / "flux-system" / "gotk-sync.yaml", "")
+    cluster = _cluster_with_resources(
+        _git_repository("ducktape-write", secret_name="ducktape-automation-github-app"),
+        _image_update_automation("ducktape-write"),
+    )
+
+    assert check_flux_bootstrap_auth(cluster, tmp_path) == []
 
 
 if __name__ == "__main__":

--- a/cluster/validation/validate_all.py
+++ b/cluster/validation/validate_all.py
@@ -38,7 +38,7 @@ from cluster.validation.checks import (
 from cluster.validation.cluster import parse_cluster
 from cluster.validation.crd_layering import CrdLayeringViolationError, check_crd_layering
 from cluster.validation.dependencies import validate_dependencies
-from cluster.validation.flux import validate_flux_build
+from cluster.validation.flux import check_flux_bootstrap_auth, validate_flux_build
 from cluster.validation.health_checks import check_controller_health_checks
 from cluster.validation.helm_templates import validate_helm_templates
 from cluster.validation.image_automation import check_image_automation_webhook
@@ -86,6 +86,7 @@ async def validate(
     errors.extend(validate_dependencies(cluster, root))
     errors.extend(check_controller_health_checks(cluster, root))
     errors.extend(check_image_automation_webhook(cluster))
+    errors.extend(check_flux_bootstrap_auth(cluster, root))
 
     if not skip_flux_build:
         errors.extend(await validate_flux_build(root))


### PR DESCRIPTION
## Summary

- keep the raw Terraform-applied root `GitRepository/flux-system` anonymous for public `ducktape` reads
- add `GitRepository/ducktape-write` for GitHub App authenticated image automation pushes
- point `ImageUpdateAutomation/all-images` at the write source and document the two-stage auth model
- add semantic Flux auth validation so bootstrap sources cannot depend on Flux-decrypted SOPS secrets and image automation must use an authenticated source

## Validation

- `kubectl kustomize cluster/k8s/flux-system`
- `kubectl kustomize cluster/k8s/flux-image-automation-ghcr`
- `bbr build //cluster/validation:validate_all`
- `bbr test //cluster/validation:test_flux`
- `bbr test //cluster/validation:test_cluster_integration`