### PR TITLE
debundle: close soundness holes in fact extraction and the S-chain

### DIFF
--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -249,6 +249,7 @@ rust_library(
         "@crates//:swc_atoms",
         "@crates//:swc_ecma_ast",
         "@crates//:swc_ecma_utils",
+        "@crates//:swc_ecma_visit",
     ],
 )
 

--- a/devinfra/js/debundle/README.md
+++ b/devinfra/js/debundle/README.md
@@ -180,23 +180,45 @@ optimizations" for the soundness rule.
 The first such pass is the dataflow-aware S-chain in `graph.rs`, opted
 into per chunk via
 `chunk_analysis_options.<chunk_id>.dataflow_aware_s_chain` in the spec.
-It is sound when no top-level statement contains:
+Each impure top-level statement carries a `dataflow_summarizable` bit
+(`facts/wire.rs`); a statement keeps the relaxed per-cell emission only
+when it contains **none** of the following (all checked per statement,
+at-init positions only):
 
-- direct `eval(...)` / `(0, eval)(...)`
+- a call, `new`, optional call (`f?.()`), or tagged template the purity
+  classifier does not prove `Pure` — this covers `console.log(...)`
+  and other I/O, calls into chunk functions whose bodies write global
+  props, direct `eval(...)`, **and** indirect `(0, eval)(...)`
+- a member write through a binding: `obj.x = 1`, `obj.x++`,
+  destructuring assignment targets containing member expressions
+  (`[obj.x] = arr`)
 - `with (obj) { ... }`
 - `new Function(...)` / `Function(...)`
-- computed-key `globalThis[<expr>]` / `window[<expr>]` / `self[<expr>]`
-- `Object.defineProperty` / `Reflect.defineProperty` on a global
+- a computed-key access on an unshadowed global-object alias:
+  `globalThis[<expr>]` / `window[<expr>]` / `self[<expr>]` /
+  `frames[<expr>]` / `top[<expr>]`
+- `Object.defineProperty` / `Reflect.defineProperty` with a
+  global-object alias as the target
 - `new Proxy(<global>, ...)`
-- dynamic member-key reads/writes on outer-scope bindings the pass
-  would otherwise track
+- a read of a binding the global object may have escaped into:
+  `const g = globalThis; ... g.tag` taints `g` (transitively, through
+  bindings derived from it), and every statement reading a tainted
+  binding falls back
 
-Each impure top-level statement carries a `dataflow_summarizable` bit
-(`facts/wire.rs`). Statements that fail the check fall back to a
-strict S-edge against every prior impure owner and act as an opaque
-barrier for later statements, so the optimization is safe to enable
-even on bundles that mix audited and unaudited code — only the
-unsummarizable statements pay the conservative cost.
+Statements that fail the check fall back to the strictly-conservative
+S-chain (an edge to every prior impure owner; later statements treat
+them as opaque barriers), so the optimization is safe to enable even
+on bundles that mix audited and unaudited code — only the
+unsummarizable statements pay the conservative cost. Call-heavy
+top-level code therefore sees little benefit from the relaxation:
+every statement containing an unproven call is conservatively
+chained. That is the intended trade — the relaxation only fires where
+the analyzer can actually prove non-interference.
+
+Unshadowed `window` / `self` / `frames` / `top` are treated as the
+same object as `globalThis` for cell tracking: `window.tag = 1` and
+`globalThis.tag` are the same cell. A chunk-top-level declaration or
+import of one of these names disables its global treatment chunk-wide.
 
 See `docs/design.md` → "Emission modes" for the precise dataflow-aware
-emission rule.
+emission rule (including the write-after-read edges).

--- a/devinfra/js/debundle/analysis_tests/mod.rs
+++ b/devinfra/js/debundle/analysis_tests/mod.rs
@@ -691,9 +691,12 @@ sideEffect(C, E);
         assert_eq!(af.first_order_body_calls, bf.first_order_body_calls);
         assert_eq!(af.effects.reads, bf.effects.reads);
         assert_eq!(af.effects.writes, bf.effects.writes);
-        assert_eq!(
-            af.effects.dataflow_summarizable,
-            bf.effects.dataflow_summarizable
-        );
+        // `effects.dataflow_summarizable` is deliberately NOT
+        // compared: the opaque-at-init-call bail consults the purity
+        // classifier (declared-pure hints exempt a call from the
+        // bail), so the bit is policy-DEPENDENT by design. The
+        // structural bail shapes (`with`, dynamic global keys,
+        // member writes, global-object escape taint) remain
+        // policy-independent.
     }
 }

--- a/devinfra/js/debundle/artifact.rs
+++ b/devinfra/js/debundle/artifact.rs
@@ -1671,6 +1671,7 @@ fn dep_kind_key(kind: DepKind) -> &'static str {
         DepKind::LazyUse => "lazy_use",
         DepKind::EagerRebind => "eager_rebind",
         DepKind::LazyRebind => "lazy_rebind",
+        DepKind::DeferredRebind => "deferred_rebind",
         DepKind::Sequenced => "sequenced",
         DepKind::LocalEffect => "local_effect",
     }

--- a/devinfra/js/debundle/atomic_units.rs
+++ b/devinfra/js/debundle/atomic_units.rs
@@ -12,8 +12,10 @@
 //!
 //! * `EagerUse`: add `u → v` (u depends on v at init time).
 //! * `LazyUse`: skip (call-time read).
-//! * `EagerRebind` / `LazyRebind`: add both directions (declarer
-//!   and assigner of a mutable binding must co-locate).
+//! * `EagerRebind` / `LazyRebind` / `DeferredRebind`: add both
+//!   directions (declarer and assigner of a mutable binding must
+//!   co-locate — ESM imports are read-only whenever the write
+//!   fires, init-time or later).
 //! * `LocalEffect`: add both directions (target-local mutation must
 //!   co-locate with its target owner).
 //! * `Sequenced`: add `u → v`. Co-location is only forced when
@@ -95,7 +97,10 @@ pub fn compute_atomic_units(owner_graph: &OwnerGraph) -> Vec<AtomicUnit> {
                 g_atomic.add_edge(edge.from, edge.to, ());
             }
             DepKind::LazyUse => {}
-            DepKind::EagerRebind | DepKind::LazyRebind | DepKind::LocalEffect => {
+            DepKind::EagerRebind
+            | DepKind::LazyRebind
+            | DepKind::DeferredRebind
+            | DepKind::LocalEffect => {
                 g_atomic.add_edge(edge.from, edge.to, ());
                 g_atomic.add_edge(edge.to, edge.from, ());
             }

--- a/devinfra/js/debundle/binding_targets.rs
+++ b/devinfra/js/debundle/binding_targets.rs
@@ -1,6 +1,7 @@
 use swc_atoms::Atom;
 use swc_ecma_ast::*;
 use swc_ecma_utils::find_pat_ids;
+use swc_ecma_visit::{Visit, VisitWith};
 
 pub trait TargetAccessRecorder {
     /// Called for update expressions like `a++`, where the target binding is
@@ -33,6 +34,38 @@ pub fn binding_name_strings(pattern: &Pat) -> Vec<String> {
     binding_names(pattern)
         .map(|(atom, _)| atom.to_string())
         .collect()
+}
+
+/// `var` declarations hoist to the enclosing function/module scope
+/// out of blocks (`try { var impl = ...; } catch { var impl = ...; }`,
+/// `if`, loop bodies and heads). Collect the hoisted-`var` ids
+/// declared anywhere inside a statement. Function / arrow / accessor
+/// bodies are boundaries (`var` is function-scoped) and class bodies
+/// are their own scope (static blocks, field initializers).
+pub fn hoisted_var_ids(stmt: &Stmt) -> Vec<Id> {
+    let mut collector = HoistedVarCollector { names: Vec::new() };
+    stmt.visit_with(&mut collector);
+    collector.names
+}
+
+struct HoistedVarCollector {
+    names: Vec<Id>,
+}
+
+impl Visit for HoistedVarCollector {
+    fn visit_var_decl(&mut self, node: &VarDecl) {
+        if node.kind == VarDeclKind::Var {
+            for decl in &node.decls {
+                self.names.extend(binding_names(&decl.name));
+            }
+        }
+        node.visit_children_with(self);
+    }
+    fn visit_function(&mut self, _node: &Function) {}
+    fn visit_arrow_expr(&mut self, _node: &ArrowExpr) {}
+    fn visit_getter_prop(&mut self, _node: &GetterProp) {}
+    fn visit_setter_prop(&mut self, _node: &SetterProp) {}
+    fn visit_class(&mut self, _node: &Class) {}
 }
 
 /// Collect all `Id`s bound by a declaration. Covers `Fn`, `Class`,

--- a/devinfra/js/debundle/cli/gate.rs
+++ b/devinfra/js/debundle/cli/gate.rs
@@ -368,6 +368,7 @@ fn dep_kind_short(kind: DepKind) -> &'static str {
         DepKind::LazyUse => "lazy",
         DepKind::EagerRebind => "at-init rebind",
         DepKind::LazyRebind => "lazy rebind",
+        DepKind::DeferredRebind => "deferred rebind",
         DepKind::Sequenced => "side-effect",
         DepKind::LocalEffect => "local-effect",
     }

--- a/devinfra/js/debundle/docs/design.md
+++ b/devinfra/js/debundle/docs/design.md
@@ -365,26 +365,50 @@ the chunk spec picks one of two modes via
   every realizable schedule satisfies it.
 
 - **Dataflow-aware** (opt-in): per-statement `(writes, reads)`
-  effect summaries (`StatementEffectSummary` in `facts/mod.rs`) drive a
-  last-writer-precedes-reader-or-writer emission. For each impure
-  statement `curr`, emit `Sequenced(curr → prev)` only when `prev`
-  is the most recent prior writer of a cell in `curr.reads ∪
-curr.writes`. Soundness follows because any swap of two
-  consecutive impure statements with disjoint cells is unobservable
-  to any third party.
+  effect summaries (`StatementEffectSummary` in `facts/mod.rs`)
+  drive the emission. For each impure statement `curr`, emit
+  `Sequenced(curr → prev)` when `prev` is the most recent prior
+  writer of a cell in `curr.reads ∪ curr.writes`
+  (read-after-write / write-after-write), and when `prev` read a
+  cell `curr` writes since that cell's last write
+  (write-after-read — without it a later writer could be
+  scheduled before an earlier reader). Soundness follows because
+  any swap of two consecutive impure statements with disjoint
+  cells is unobservable to any third party.
 
   Effect cells are binding-storage cells (rebinds + identifier
-  reads) and static-key `globalThis.<prop>` cells. The mode is
-  **conditionally correct** (see AGENTS.md → "Conditionally-correct
-  optimizations"): statements containing constructs that defeat
-  static cell tracking — direct `eval(...)`, `with`,
-  `Function(...)` / `new Function(...)`, computed-key
-  `globalThis[<expr>]`, `defineProperty` on globals, `Proxy` on
-  globals — flip `dataflow_summarizable=false` and fall back to a
-  strict S-edge against every prior impure owner (also acting as
-  an opaque barrier for later statements). Auditing the input
-  bundle for these shapes is the precondition (see
-  `README.md` → "Conditionally-correct optimizations").
+  reads) and static-key `<global>.<prop>` cells, where `<global>`
+  is any unshadowed global-object alias (`globalThis`, `window`,
+  `self`, `frames`, `top`). The mode is **conditionally correct**
+  (see AGENTS.md → "Conditionally-correct optimizations"):
+  statements containing a shape that defeats static cell tracking
+  flip `dataflow_summarizable=false` and fall back to a strict
+  S-edge against every prior impure owner (also acting as an
+  opaque barrier for later statements). The bail shapes are:
+  - any at-init call, `new`, optional call, or tagged template the
+    purity classifier does not prove `Pure` — I/O (`console.log`)
+    is not a cell, callee bodies may write global props the
+    depth-0 cell recorder can't see, and indirect `eval`
+    (`(0, eval)(...)`) executes arbitrary writes. Classifier-Pure
+    calls are exempt: `Pure` guarantees no observable writes and
+    no global-prop reads, and binding-cell ordering is enforced by
+    binding edges + rebind co-location rather than the S-chain;
+  - member writes through a tracked binding (`obj.x = 1`,
+    `obj.x++`, destructuring targets containing member
+    expressions) — aliasing makes the written heap cell
+    unattributable;
+  - `with`, `Function(...)` / `new Function(...)`, computed-key
+    `<global>[<expr>]`, `defineProperty` on the global object,
+    `new Proxy(<global>, ...)`;
+  - statements tainted by a global-object alias escape: a bare
+    `globalThis`/`window`/... used as a _value_ (`const g =
+globalThis`) marks the bindings it flows into (transitively,
+    to a fixpoint) as suspects, and every statement reading a
+    suspect bails — `g.tag` touches the same cells as
+    `globalThis.tag` but the summary only sees `Binding(g)`.
+
+  See `README.md` → "Conditionally-correct optimizations" for the
+  user-facing precondition list.
 
 ### Relationship
 
@@ -655,13 +679,52 @@ multiply that. The promotion pass dedupes per `(caller, target-owner)`
 pair per kind, keeping the per-statement cost bounded by the
 transitive closure size rather than (closure × call-sites).
 
-**Limitations.** Indirect calls (`const g = f; g()`), method calls
-(`obj.method()`), and dynamic dispatch produce no promoted edges —
-the callee isn't statically a known chunk binding. These are
-conservatively unmodelled. A spec accepted by the relaxed predicate
-but unrealizable at runtime due to one of these uncaught
-interprocedural patterns is currently caught by the validator's
-strict rule (see below).
+**Resolvable callees.** A callee is precisely resolvable iff its
+binding is declared _directly as a function value_ (`function f`,
+single-declarator `const f = () => ...`, exported forms) and is
+never rebound anywhere in the chunk. Only resolvable callees feed
+the precise first-order closure above.
+
+**Unresolved-callee fallback.** Every other at-init call shape —
+member calls (`api.read()`), aliases (`const g = readB; g()`),
+IIFEs, optional-chain calls, tagged templates, conditional or
+rebound function bindings, and calls into resolvable functions
+whose own first-order bodies contain such calls — takes a
+conservative fallback (`graph.rs::UnresolvedCallFallback`). The
+fallback's premise: whatever function value the call invokes must
+have reached the call site through a binding the call expression
+mentions (callee root, arguments, computed keys) or through an
+inline function expression at the call. Each such root owner is
+expanded to the **full lazy closure** of every owner reachable from
+it through the chunk's read graph (eager + lazy reads), and the
+calling statement gets promoted `EagerUse` edges to every collected
+target — rebind targets included (order-only: write legality is
+separately enforced by the direct `LazyRebind`/`DeferredRebind`
+edge from the statement lexically containing the write).
+Fallback edges sourced in residual are dropped at partition
+projection: residual is the ESM DFS root and evaluates last, so an
+at-init call from residual code cannot observe a TDZ, and the
+emitter emits no entry-side phantom imports the gate could
+otherwise assume.
+
+**Residual limitations.** The fallback (and promotion generally)
+does not model function values that reach a call site through:
+
+- global/object property stashes (`globalThis.f = readB;` …
+  `globalThis.f()`),
+- rebound bindings (`let g; g = readB; g();` — the rebind forces
+  co-location of the rebinder with `g`'s declarer, but the flowed
+  value's closure is not followed),
+- parameters of chunk-declared functions
+  (`function h(cb) { cb(); } h(readB);`),
+- `new` expressions (constructor bodies are not promoted), or
+- other chunks (imports are outside single-chunk analysis).
+
+These are documented preconditions on the input bundle, not
+checked invariants — a bundle using one of these shapes to fire a
+TDZ-able cross-module read at init can be accepted and break at
+runtime. There is no separate validator safety net behind the
+promotion pass.
 
 ## Lemma 2: entry-side import ordering
 
@@ -1301,8 +1364,13 @@ of bindings is forced to co-locate, and the spec splits them."
 original output: bundlers can't emit JavaScript that TDZs at runtime
 (the bundle ran for someone). So every owner-level SCC of
 constraining edges (`EagerUse`, `Sequenced`, `EagerRebind`,
-`LazyRebind`, `LocalEffect`) reflects a _colocation invariant the
-bundler relied on_. Any spec assignment that routes the unit's
+`LazyRebind`, `DeferredRebind`, `LocalEffect`) reflects a
+_colocation invariant the bundler relied on_. (`DeferredRebind` —
+a rebind nested ≥2 closures deep or past an `await` — joins
+`G_atomic` bidirectionally like the other rebinds because ESM
+imports are read-only whenever the write fires, but it does NOT
+constrain init order: it is excluded from the constraining-edge
+subgraph the realizability gate and the I-graph use.) Any spec assignment that routes the unit's
 owners to different modules is invalid — `assemble_partition`
 detects this before the materializer touches the quotient. **No
 information about the spec is required to identify a structural
@@ -1386,8 +1454,9 @@ Five layers, bottom-up:
 
 1. **Owner graph** — fine-grained program facts (`graph.rs`).
    One vertex per top-level owner; edges record `EagerUse`,
-   `LazyUse`, `EagerRebind`, `LazyRebind`, `Sequenced`, and the
-   local-effect edges that target-local mutation produces. Each
+   `LazyUse`, `EagerRebind`, `LazyRebind`, `DeferredRebind`,
+   `Sequenced`, and the local-effect edges that target-local
+   mutation produces. Each
    edge records whether it constrains init/materialization order.
 2. **Atomic graph** — SCC condensation of the constraining-edge
    subgraph of the owner graph; a DAG of atomic units

--- a/devinfra/js/debundle/e2e/BUILD.bazel
+++ b/devinfra/js/debundle/e2e/BUILD.bazel
@@ -84,6 +84,9 @@ _STANDARD_E2E_DEPS = [
         "duplicate_export_test",
         "at_init_promotion_nested_closure_test",
         "at_init_promotion_post_await_test",
+        "at_init_unresolved_callee_test",
+        "hoisted_var_declaration_test",
+        "export_default_purity_test",
         "auto_grown_export_alias_collision_test",
         "reserved_word_mint_test",
         "runtime_tdz_on_imported_class_test",
@@ -120,6 +123,7 @@ _STANDARD_E2E_DEPS = [
         "at_init_promotion_fndecl_direct_read_test",
         "at_init_cross_module_call_body_reads_test",
         "at_init_s_chain_dataflow_test",
+        "s_chain_dataflow_soundness_test",
     ]
 ]
 

--- a/devinfra/js/debundle/e2e/at_init_promotion_nested_closure_test.rs
+++ b/devinfra/js/debundle/e2e/at_init_promotion_nested_closure_test.rs
@@ -1,82 +1,54 @@
-//! Regression test: at-init call promotion (and the direct
-//! `lazy_rebind` owner edge) must not propagate rebinds that
-//! lexically appear inside a nested closure but never fire at
-//! module-initialization time.
+//! Nested-closure rebinds and reads vs. the owner graph.
 //!
-//! Background: docs/design.md "At-init call promotion" makes the
-//! caller-statement of an at-init call inherit its callee's
-//! transitive `lazy_reads` and `lazy_rebinds`. The classifier in
-//! `facts.rs` now tracks a `lazy_depth` counter on each
-//! `LazyBoundary` visitor, with `first_order_lazy_*` collected
-//! when the visitor sits directly inside a function body (depth 1)
-//! and the coarse `lazy_*` covering any depth ≥1. Promotion and
-//! the direct `lazy_rebind` edge use the first-order subset so a
-//! rebind inside a nested arrow doesn't manufacture a cross-module
-//! constraint that nothing actually fires.
+//! Two distinct contracts meet here:
 //!
-//! ## Fixture
+//! 1. **Init-order**: a read or rebind inside a *nested* closure does
+//!    not fire when the enclosing function is invoked synchronously
+//!    at module init, so at-init call promotion and the constraining
+//!    `LazyRebind` edge must not manufacture init-order constraints
+//!    for it (the original purpose of this test — see the production
+//!    observation below).
+//! 2. **ESM read-only imports**: a rebind of a binding owned by a
+//!    *different* destination module is invalid at ANY time, not just
+//!    at init — the emitted module imports the binding, and an
+//!    assignment to an imported binding throws `TypeError` whenever
+//!    it fires. Before the fix, only first-order lazy rebinds emitted
+//!    edges, so a rebind nested two closures deep never reached the
+//!    cross-destination-rebind rejection: the gate accepted the split
+//!    spec and the emitted bundle threw as soon as the stored closure
+//!    ran (verified red with a post-init probe invoking
+//!    `globalThis.__updateState()`).
 //!
-//! ```js
-//! let state = "initial";
-//! function setupHandler() {
-//!     globalThis.__updateState = () => { state = "updated"; };
-//! }
-//! setupHandler();
-//! console.log(state);
-//! ```
+//! The fix adds a `DeferredRebind` edge kind for non-first-order lazy
+//! rebinds: it participates in cross-destination-rebind rejection and
+//! forced co-location (bidirectional `G_atomic`) but does NOT
+//! constrain init order (it is excluded from the constraining-edge
+//! subgraph and the I-graph).
 //!
-//! Spec: `state` → `mod_state`, `setupHandler` → `mod_handler`.
-//! Top-level `setupHandler()` + `console.log(state)` stay in
-//! residual.
+//! ## Production observation
 //!
-//! ## Why the spec is realizable
-//!
-//! When the chunk loads:
-//! 1. mod_state initializes `state = "initial"`.
-//! 2. mod_handler initializes `setupHandler` (function declaration).
-//! 3. Residual runs `setupHandler()` — which only assigns the
-//!    arrow function `() => { state = "updated"; }` to
-//!    `globalThis.__updateState`. The arrow body does NOT execute
-//!    here; nothing rebinds `state` at this point.
-//! 4. Residual runs `console.log(state)` → prints "initial".
-//!
-//! There is no actual cross-module rebind during initialization.
-//! The materializer can emit this spec and Node will run it
-//! correctly. The ESM linker has no ordering problem to solve.
-//!
-//! ## Implementation
-//!
-//! `BindingWriteCollector`, `LazyReadCollector`, and `CallCollector`
-//! each track a `lazy_depth: u32` counter. `descend_lazy` increments
-//! on entry to a function/arrow/method body and decrements on exit.
-//! Each collector exposes a `first_order_*` subset whose entries
-//! were recorded while `lazy_depth == 1`. Two graph sites consume
-//! the subset:
-//!
-//! - `graph.rs::push_binding_edge` for `EdgeReason::lazy_rebind` —
-//!   so a rebind inside a nested closure no longer creates the
-//!   bidirectional G_atomic constraint at `atomic_units.rs:82-85`.
-//! - `graph.rs::promote_at_init_calls` for the call graph and its
-//!   per-owner rebind/read seeds — so an at-init call only inherits
-//!   the synchronous part of the callee's body.
-//!
-//! Production observation: a real production chunk
-//! `static/index-EXAMPLE` produced 22 cross-module
-//! `eager_rebind` edges all sharing `statement_ordinal: 9705`
-//! (the top-level `try { ... Age(...) ... }` bootstrap), creating a
-//! 690-owner SCC spanning 11 modules. Every promoted rebind in
-//! that SCC traced back to deferred-callback writes inside event
-//! handlers nested in the bootstrap's call graph — none of them
-//! fire at module init.
+//! A real production chunk `static/index-EXAMPLE` produced 22
+//! cross-module `eager_rebind` edges all sharing
+//! `statement_ordinal: 9705` (the top-level `try { ... Age(...) ... }`
+//! bootstrap), creating a 690-owner SCC spanning 11 modules. Every
+//! promoted rebind in that SCC traced back to deferred-callback
+//! writes inside event handlers nested in the bootstrap's call graph
+//! — none of them fire at module init. Those writes still force
+//! co-location with the binding declarer (contract 2) but must not
+//! manufacture init-order constraints (contract 1).
 
 use debundle_e2e_support::*;
 
+/// Contract 1: a nested-closure *read* manufactures no init-order
+/// constraint. The split spec is realizable, the bundle prints the
+/// init-time value, and the stored closure keeps working post-init
+/// (ESM imports are readable at any time).
 #[test]
-fn at_init_call_does_not_promote_rebinds_from_nested_closures() {
+fn nested_closure_read_does_not_constrain_init_order() {
     let fixture = run_fixture(FixtureOpts::new(
         r#"let state = "initial";
 function setupHandler() {
-    globalThis.__updateState = () => { state = "updated"; };
+    globalThis.__readState = () => state;
 }
 setupHandler();
 console.log(state);
@@ -88,4 +60,64 @@ export { state, setupHandler };
         ],
     ));
     assert_entry_output(&fixture, "initial\n");
+    assert_generated_module_after_entry_script(
+        &fixture.out_root,
+        "console.log(globalThis.__readState());\n",
+        "initial\n",
+    );
+}
+
+/// Contract 2: a nested-closure *rebind* of a binding assigned to a
+/// different destination module is rejected. Before the fix this
+/// spec was accepted and the emitted bundle threw
+/// `TypeError: Assignment to constant variable.` the moment
+/// `globalThis.__updateState()` ran.
+#[test]
+fn nested_closure_rebind_across_destinations_is_rejected() {
+    expect_rejection(
+        FixtureOpts::new(
+            r#"let state = "initial";
+function setupHandler() {
+    globalThis.__updateState = () => { state = "updated"; };
+}
+setupHandler();
+console.log(state);
+export { state, setupHandler };
+"#,
+            vec![
+                logical_module("mod_state", &[Member::new("state")]),
+                logical_module("mod_handler", &[Member::new("setupHandler")]),
+            ],
+        ),
+        &["rebind", "read-only", "assignment", "mutable"],
+    );
+}
+
+/// Contract 2, green side: co-locating the rebinder with the binding
+/// declarer is accepted, and the post-init probe observes the update
+/// through the module's live export binding.
+#[test]
+fn nested_closure_rebind_colocated_updates_after_init() {
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"let state = "initial";
+function setupHandler() {
+    globalThis.__updateState = () => { state = "updated"; };
+}
+setupHandler();
+console.log(state);
+export { state, setupHandler };
+"#,
+        vec![logical_module(
+            "mod_state",
+            &[Member::new("state"), Member::new("setupHandler")],
+        )],
+    ));
+    assert_entry_output(&fixture, "initial\n");
+    assert_generated_module_after_entry_script(
+        &fixture.out_root,
+        "globalThis.__updateState();\n\
+         const mod = await import(\"./static/app/modules/mod_state.js\");\n\
+         console.log(mod.state);\n",
+        "updated\n",
+    );
 }

--- a/devinfra/js/debundle/e2e/at_init_s_chain_dataflow_test.rs
+++ b/devinfra/js/debundle/e2e/at_init_s_chain_dataflow_test.rs
@@ -203,13 +203,16 @@ export { tagA, boxedB };
 }
 
 #[test]
-fn s_chain_skips_independent_cross_module_constructor_calls() {
-    // Two modules each call a constructor whose only effect is
-    // writing to its own freshly-allocated `this`. The
-    // constructors touch no shared cell. Today's S-chain links
-    // them; with dataflow, the write sets are each
-    // `{instance_X}` and the read sets are each `{ClassX}` —
-    // disjoint pairwise.
+fn unproven_constructor_calls_keep_conservative_s_edge() {
+    // Two modules each call a constructor the purity classifier
+    // can't prove pure (`new <chunk class>` is `UnknownNew` without
+    // a `pure_new` annotation). An unproven call/new may touch any
+    // cell — the opaque-call rule keeps the conservative S edge
+    // between the two statements even though their syntactic cell
+    // sets are disjoint. This deliberately pins the conservative
+    // behavior: relaxing it requires proving the constructor
+    // cell-confined (e.g. a `pure_new` spec annotation), not
+    // assuming it.
     let fixture = run_fixture(dataflow_opts(
         r#"class Holder1 { constructor() { this.kind = "h1"; } }
 class Holder2 { constructor() { this.kind = "h2"; } }
@@ -229,15 +232,7 @@ export { Holder1, Holder2, instA, instB };
         read_json(&fixture.report_root.join("static/app/owner_graph.json"));
     let owner_a = owner_for_binding(&graph, "instA");
     let owner_b = owner_for_binding(&graph, "instB");
-    let offending = sequenced_edges_between(&graph, owner_a, owner_b);
-    assert!(
-        offending.is_empty(),
-        "no Sequenced edge should link `instA`'s owner to \
-         `instB`'s owner: each `new HolderN()` only mutates its \
-         own `this`, so their cross-module init order is \
-         unobservable. Offending edges: {offending:#?}\n\nFull \
-         graph: {graph:#?}",
-    );
+    assert_kept_sequenced_between(&graph, owner_a, owner_b);
 }
 
 #[test]

--- a/devinfra/js/debundle/e2e/at_init_unresolved_callee_test.rs
+++ b/devinfra/js/debundle/e2e/at_init_unresolved_callee_test.rs
@@ -1,0 +1,110 @@
+//! Soundness regression: at-init calls whose callee can't be resolved
+//! to a chunk-declared function must not be silently skipped by
+//! at-init call promotion (`graph.rs::promote_at_init_calls`).
+//!
+//! Before the fix, `at_init_calls` recorded only bare-`Ident` callees
+//! and promotion silently `continue`d when a callee didn't resolve to
+//! a chunk function — so an at-init call routed through a
+//! single-assignment alias (`const g = readB; g();`) or an
+//! object-literal method (`api.read()`) fired its body's TDZ-locked
+//! cross-module reads at runtime without any owner-graph edge. The
+//! gate accepted the spec; the emitted bundle threw a TDZ
+//! `ReferenceError` under node.
+//!
+//! The fix gives statements with unresolvable at-init callees a
+//! conservative fallback: the statement eagerly depends on the
+//! transitive lazy closures of every chunk binding it reads at-init
+//! (following initializer read chains), so the canonical
+//! gate-accepted-but-TDZ shapes below now close a constraining cycle
+//! and are rejected.
+
+use debundle_e2e_support::*;
+
+/// `const g = readB; const r = g();` — the alias `g` is a VarDecl,
+/// not a function declaration, so the old promotion pass skipped the
+/// call entirely. `readB`'s body reads `B` (mod_b), and mod_b
+/// eagerly reads `A` (mod_a): an asymmetric cycle the simulator
+/// accepted while the runtime TDZ'd on `g()`.
+#[test]
+fn aliased_at_init_call_closing_cross_module_cycle_is_rejected() {
+    expect_rejection(
+        FixtureOpts::new(
+            r#"const A = 1;
+const B = A + 1;
+function readB() { return B; }
+const g = readB;
+const r = g();
+console.log(r);
+export { A, B, g, r, readB };
+"#,
+            vec![
+                logical_module(
+                    "mod_a",
+                    &[
+                        Member::new("A"),
+                        Member::new("readB"),
+                        Member::new("g"),
+                        Member::new("r"),
+                    ],
+                ),
+                logical_module("mod_b", &[Member::new("B")]),
+            ],
+        ),
+        &["cycle", "unrealizable"],
+    );
+}
+
+/// Method-call variant: `const api = { read: () => B }; api.read();`
+/// — the callee is a member expression, never recorded in
+/// `at_init_calls` at all before the fix.
+#[test]
+fn object_literal_method_at_init_call_closing_cycle_is_rejected() {
+    expect_rejection(
+        FixtureOpts::new(
+            r#"const A = 1;
+const B = A + 1;
+const api = { read: () => B };
+const r = api.read();
+console.log(r);
+export { A, B, api, r };
+"#,
+            vec![
+                logical_module(
+                    "mod_a",
+                    &[Member::new("A"), Member::new("api"), Member::new("r")],
+                ),
+                logical_module("mod_b", &[Member::new("B")]),
+            ],
+        ),
+        &["cycle", "unrealizable"],
+    );
+}
+
+/// Green companion: the fallback emits a *correct* constraint (not a
+/// blanket rejection) when the aliased call's transitive reads are
+/// acyclic — the emitted bundle runs and the cross-module read is
+/// ordered.
+#[test]
+fn aliased_at_init_call_with_acyclic_closure_is_accepted_and_runs() {
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"const VALUE = "v";
+const get = () => VALUE;
+const indirect = get;
+const r = indirect();
+console.log(r);
+export { VALUE, get, indirect, r };
+"#,
+        vec![
+            logical_module("mod_val", &[Member::new("VALUE")]),
+            logical_module(
+                "mod_use",
+                &[
+                    Member::new("get"),
+                    Member::new("indirect"),
+                    Member::new("r"),
+                ],
+            ),
+        ],
+    ));
+    assert_entry_output(&fixture, "v\n");
+}

--- a/devinfra/js/debundle/e2e/export_default_purity_test.rs
+++ b/devinfra/js/debundle/e2e/export_default_purity_test.rs
@@ -1,0 +1,90 @@
+//! Soundness regression: `classify_item` maps non-`ExportDecl`
+//! module declarations to `StatementKind::Export`, and `item_purity`
+//! mapped every `Export` to `Pure` — so `export default sideEffect()`
+//! and `export default class C { static { ... } }` dropped out of the
+//! S-chain entirely. Statements in other modules could then be
+//! ordered around the default export's side effect, reordering the
+//! bundle's observable init sequence.
+//!
+//! The fix routes `ExportDefaultExpr` through `classify_expr_purity`
+//! and `ExportDefaultDecl(Class)` through
+//! `class_has_static_observable`.
+
+use debundle_e2e_support::*;
+
+/// `export default (globalThis.seq += "D")` is impure. With the S
+/// edge restored, `after` (mod_z) is sequenced after the default
+/// export, which lives in entry — entry evaluates last under ESM, so
+/// the spec is unrealizable and must be rejected. Before the fix the
+/// default export was "pure": the spec was accepted and the emitted
+/// bundle printed `SZD` instead of the original `SDZ`.
+#[test]
+fn impure_export_default_expr_restores_s_chain_ordering() {
+    expect_rejection(
+        FixtureOpts::new(
+            r#"const init = (globalThis.seq = "S", "i");
+export default (globalThis.seq = globalThis.seq + "D");
+const after = (globalThis.seq = globalThis.seq + "Z", "z");
+console.log(globalThis.seq, init, after);
+export { init, after };
+"#,
+            vec![
+                logical_module("mod_i", &[Member::new("init")]),
+                logical_module("mod_z", &[Member::new("after")]),
+            ],
+        )
+        .with_unassigned_mode(unassigned_mode_inline()),
+        &["cycle", "unrealizable"],
+    );
+}
+
+/// Same shape with `export default class` carrying an observable
+/// static block.
+#[test]
+fn export_default_class_with_static_block_restores_s_chain_ordering() {
+    expect_rejection(
+        FixtureOpts::new(
+            r#"const init = (globalThis.seq = "S", "i");
+export default class Boot {
+  static {
+    globalThis.seq = globalThis.seq + "C";
+  }
+}
+const after = (globalThis.seq = globalThis.seq + "Z", "z");
+console.log(globalThis.seq, init, after);
+export { init, after };
+"#,
+            vec![
+                logical_module("mod_i", &[Member::new("init")]),
+                logical_module("mod_z", &[Member::new("after")]),
+            ],
+        )
+        .with_unassigned_mode(unassigned_mode_inline()),
+        &["cycle", "unrealizable"],
+    );
+}
+
+/// Green companion: with only the *earlier* impure statement peeled
+/// off, the restored S edge (`default → init`) is satisfiable
+/// (mod_i before entry) and the bundle preserves the original
+/// `SCZ` sequence.
+#[test]
+fn export_default_class_static_block_ordering_is_preserved_when_realizable() {
+    let fixture = run_fixture(
+        FixtureOpts::new(
+            r#"const init = (globalThis.seq = "S", "i");
+export default class Boot {
+  static {
+    globalThis.seq = globalThis.seq + "C";
+  }
+}
+const after = (globalThis.seq = globalThis.seq + "Z", "z");
+console.log(globalThis.seq, init, after);
+export { init, after };
+"#,
+            vec![logical_module("mod_i", &[Member::new("init")])],
+        )
+        .with_unassigned_mode(unassigned_mode_inline()),
+    );
+    assert_entry_output(&fixture, "SCZ i z\n");
+}

--- a/devinfra/js/debundle/e2e/hoisted_var_declaration_test.rs
+++ b/devinfra/js/debundle/e2e/hoisted_var_declaration_test.rs
@@ -1,0 +1,92 @@
+//! Soundness regression: `var` declarations hoist out of blocks
+//! (`try`/`catch`, `if`, loops) to the enclosing function or module
+//! scope, but `collect_declared_names` (facts/mod.rs) only looked at
+//! direct top-level `Stmt::Decl` items. A statement like
+//!
+//! ```js
+//! try { var impl = detect(); } catch (e) { var impl = fallback(); }
+//! ```
+//!
+//! declared `impl` invisibly: readers of `impl` got no owner-graph
+//! edge and no import wiring (the emitted reader module referenced a
+//! name that doesn't exist in its scope — runtime `ReferenceError`),
+//! and `try { var Math = shim; } catch {}` defeated the A8
+//! shadowed-globals computation (the purity whitelist still treated
+//! `Math.floor` as the pristine global).
+
+use debundle_e2e_support::*;
+
+/// Reader split away from a block-hoisted `var` whose declaring
+/// statement is anonymously claimed into another module. Before the
+/// fix the spec was silently accepted with no ordering edge and no
+/// import wiring — the emitted `mod_reader` crashed with
+/// `ReferenceError: impl is not defined` under node. After the fix
+/// the `try` statement owns `impl`: the reader's eager edge orders
+/// `mod_impl` first and the binding-adoption pass exports/imports it
+/// across the split.
+#[test]
+fn reader_of_block_hoisted_var_in_claimed_statement_is_wired() {
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"try { var impl = "primary"; } catch (e) { var impl = "fallback"; }
+const reader = impl + "-read";
+console.log(reader);
+export { reader };
+"#,
+        vec![
+            logical_module_with_anon(
+                "mod_impl",
+                &[],
+                &[r#"try { var impl = "primary"; } catch (e) { var impl = "fallback"; }"#],
+            ),
+            logical_module("mod_reader", &[Member::new("reader")]),
+        ],
+    ));
+    assert_entry_output(&fixture, "primary-read\n");
+}
+
+/// Green companion: co-locating the reader with the declaring `try`
+/// statement is accepted and preserves behavior — the new ownership
+/// edge is same-module and imposes no cross-module constraint.
+#[test]
+fn block_hoisted_var_colocated_with_reader_runs() {
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"try { var impl = "primary"; } catch (e) { var impl = "fallback"; }
+const reader = impl + "-read";
+console.log(reader);
+export { reader };
+"#,
+        vec![logical_module_with_anon(
+            "mod_a",
+            &[Member::new("reader")],
+            &[r#"try { var impl = "primary"; } catch (e) { var impl = "fallback"; }"#],
+        )],
+    ));
+    assert_entry_output(&fixture, "primary-read\n");
+}
+
+/// A8 shadowing: `try { var Math = shim; } catch {}` makes every
+/// unqualified `Math.<prop>` in the chunk a read of the shim, not
+/// the global. Before the fix the shim declaration was invisible, so
+/// `const out = Math.PI` classified Pure (whitelisted
+/// `PURE_STATIC_PROPS` read of the pristine global): the spec was
+/// accepted, `Math` resolved to the real global in the emitted
+/// `mod_out`, and the bundle printed `3.14...` instead of the
+/// original `shimmed`. After the fix `Math` is chunk-declared: the
+/// statement is no longer whitelisted-pure and the read gets an
+/// eager owner edge into entry, which evaluates last —
+/// unrealizable, rejected.
+#[test]
+fn block_hoisted_var_shadowing_whitelisted_global_is_rejected() {
+    expect_rejection(
+        FixtureOpts::new(
+            r#"try { var Math = { PI: "shimmed" }; } catch (e) {}
+const out = Math.PI;
+console.log(out);
+export { out };
+"#,
+            vec![logical_module("mod_out", &[Member::new("out")])],
+        )
+        .with_unassigned_mode(unassigned_mode_inline()),
+        &["cycle", "unrealizable", "not exported"],
+    );
+}

--- a/devinfra/js/debundle/e2e/s_chain_dataflow_soundness_test.rs
+++ b/devinfra/js/debundle/e2e/s_chain_dataflow_soundness_test.rs
@@ -1,0 +1,290 @@
+//! Soundness holes in the dataflow-aware S-chain
+//! (`graph.rs::emit_s_chain`, opt-in via
+//! `chunk_analysis_options.<chunk>.dataflow_aware_s_chain`).
+//!
+//! Each test pins one hole by asserting the owner graph carries the
+//! `Sequenced` edge the bundle's observable semantics require (red
+//! before the fix: edge absent), plus a runtime check that the
+//! emitted bundle preserves the original output once the edge exists.
+//!
+//! Holes covered:
+//!
+//! - **Write-after-read (WAR)**: last-writer-only tracking missed the
+//!   edge from a writer to readers since the last write — a later
+//!   writer could be scheduled before an earlier reader.
+//! - **Opaque calls**: a call/new the purity classifier can't prove
+//!   pure may touch any cell (I/O, globals via callee bodies,
+//!   indirect `eval`); the statement must fall back to the
+//!   conservative chain.
+//! - **Member/update writes**: `obj.x = 1` recorded only a read of
+//!   `obj`; `globalThis.count++` recorded no write at all; aliasing
+//!   `globalThis` into a binding escaped the cell tracking entirely.
+//! - **window/self**: only the literal `globalThis` was treated as
+//!   the global object, despite README claiming otherwise.
+
+use analysis::{DepKind, OwnerGraphReport};
+use debundle_e2e_support::*;
+
+fn dataflow_opts<'a>(source: &'a str, logical_modules: Vec<LogicalModuleEntry>) -> FixtureOpts<'a> {
+    FixtureOpts::new(source, logical_modules).with_dataflow_aware_s_chain()
+}
+
+fn owner_for_binding<'a>(graph: &'a OwnerGraphReport, binding: &str) -> &'a str {
+    let node = graph
+        .nodes
+        .iter()
+        .find(|node| node.declared_bindings.iter().any(|b| b.binding == binding))
+        .unwrap_or_else(|| panic!("no owner-graph node declares binding `{binding}`"));
+    node.id.as_str()
+}
+
+fn owner_for_ordinal(graph: &OwnerGraphReport, ordinal: usize) -> &str {
+    let node = graph
+        .nodes
+        .iter()
+        .find(|node| node.statement_ordinal.0 == ordinal)
+        .unwrap_or_else(|| panic!("no owner-graph node with ordinal {ordinal}"));
+    node.id.as_str()
+}
+
+/// Assert a `Sequenced` edge `later → earlier` exists (the
+/// "earlier must evaluate first" constraint).
+fn assert_sequenced_edge(graph: &OwnerGraphReport, later: &str, earlier: &str) {
+    let found = graph
+        .edges
+        .iter()
+        .any(|e| e.edge_kind == DepKind::Sequenced && e.source == later && e.target == earlier);
+    assert!(
+        found,
+        "expected Sequenced edge {later} -> {earlier}; edges: {:#?}",
+        graph.edges,
+    );
+}
+
+fn read_owner_graph(fixture: &Fixture) -> OwnerGraphReport {
+    read_json(&fixture.report_root.join("static/app/owner_graph.json"))
+}
+
+/// WAR: `limit`'s write of `globalThis.flag` must be sequenced after
+/// `snapshot`'s read of it, even though the last *writer* of the cell
+/// is the earlier statement.
+#[test]
+fn write_after_read_emits_sequenced_edge() {
+    let fixture = run_fixture(dataflow_opts(
+        r#"globalThis.flag = "first";
+const snapshot = globalThis.flag;
+const limit = (globalThis.flag = "second", "L");
+console.log(snapshot + limit);
+export { snapshot, limit };
+"#,
+        vec![
+            logical_module_with_anon("mod_w", &[], &[r#"globalThis.flag = "first";"#]),
+            logical_module("mod_read", &[Member::new("snapshot")]),
+            logical_module("mod_w2", &[Member::new("limit")]),
+        ],
+    ));
+    assert_entry_output(&fixture, "firstL\n");
+    let graph = read_owner_graph(&fixture);
+    assert_sequenced_edge(
+        &graph,
+        owner_for_binding(&graph, "limit"),
+        owner_for_binding(&graph, "snapshot"),
+    );
+}
+
+/// Opaque calls: two `console.log` statements touch no common cell
+/// the analyzer can see, but I/O is not a cell — their order is
+/// observable and must be preserved via the conservative fallback.
+#[test]
+fn console_log_pair_keeps_conservative_order() {
+    let fixture = run_fixture(dataflow_opts(
+        r#"const seed = "s";
+console.log("one");
+const base = "two" + seed;
+console.log(base);
+export { seed, base };
+"#,
+        vec![
+            logical_module("mod_seed", &[Member::new("seed")]),
+            logical_module_with_anon("mod_one", &[], &[r#"console.log("one");"#]),
+            logical_module_with_anon("mod_two", &[Member::new("base")], &["console.log(base);"]),
+        ],
+    ));
+    assert_entry_output(&fixture, "one\ntwos\n");
+    let graph = read_owner_graph(&fixture);
+    // ordinals: 0 = seed, 1 = log("one"), 2 = base, 3 = log(base)
+    assert_sequenced_edge(
+        &graph,
+        owner_for_ordinal(&graph, 3),
+        owner_for_ordinal(&graph, 1),
+    );
+}
+
+/// Opaque calls through chunk functions: `setup()` writes a global
+/// prop from inside its body (invisible to the depth-0-gated cell
+/// recorder); the reader of that prop must still be ordered after
+/// the call statement.
+#[test]
+fn at_init_call_writing_global_in_body_is_ordered_before_reader() {
+    let fixture = run_fixture(dataflow_opts(
+        r#"function setup() { globalThis.mode = "ready"; }
+setup();
+const got = globalThis.mode;
+console.log(got);
+export { got };
+"#,
+        vec![
+            logical_module_with_anon("mod_boot", &[], &["setup();"]),
+            logical_module("mod_read", &[Member::new("got")]),
+        ],
+    ));
+    assert_entry_output(&fixture, "ready\n");
+    let graph = read_owner_graph(&fixture);
+    // ordinals: 0 = setup decl, 1 = setup(), 2 = got, 3 = log
+    assert_sequenced_edge(
+        &graph,
+        owner_for_binding(&graph, "got"),
+        owner_for_ordinal(&graph, 1),
+    );
+}
+
+/// Member writes: `registry.mode = "on"` mutates state reachable
+/// from `registry`; the reader of `registry.mode` must be ordered
+/// after it.
+#[test]
+fn member_write_through_binding_is_ordered_before_reader() {
+    let fixture = run_fixture(dataflow_opts(
+        r#"const registry = {};
+registry.mode = "on";
+const snap = registry.mode;
+console.log(snap);
+export { registry, snap };
+"#,
+        vec![
+            logical_module_with_anon(
+                "mod_w",
+                &[Member::new("registry")],
+                &[r#"registry.mode = "on";"#],
+            ),
+            logical_module("mod_read", &[Member::new("snap")]),
+        ],
+    ));
+    assert_entry_output(&fixture, "on\n");
+    let graph = read_owner_graph(&fixture);
+    // ordinals: 0 = registry, 1 = member write, 2 = snap, 3 = log
+    assert_sequenced_edge(
+        &graph,
+        owner_for_binding(&graph, "snap"),
+        owner_for_ordinal(&graph, 1),
+    );
+}
+
+/// Update expressions: `globalThis.count++` writes the cell; the
+/// reader must be ordered after the increment, not just after the
+/// initial assignment.
+#[test]
+fn global_prop_update_expr_records_write() {
+    let fixture = run_fixture(dataflow_opts(
+        r#"globalThis.count = 1;
+globalThis.count++;
+const got = globalThis.count;
+console.log(got);
+export { got };
+"#,
+        vec![
+            logical_module_with_anon("mod_a", &[], &["globalThis.count = 1;"]),
+            logical_module_with_anon("mod_b", &[], &["globalThis.count++;"]),
+            logical_module("mod_read", &[Member::new("got")]),
+        ],
+    ));
+    assert_entry_output(&fixture, "2\n");
+    let graph = read_owner_graph(&fixture);
+    // ordinals: 0 = init, 1 = increment, 2 = got, 3 = log
+    assert_sequenced_edge(
+        &graph,
+        owner_for_binding(&graph, "got"),
+        owner_for_ordinal(&graph, 1),
+    );
+}
+
+/// Aliasing: `const g = globalThis; const got = g.tag;` reads a
+/// global prop through an alias the cell tracker can't see —
+/// statements touching the alias must bail to the conservative
+/// chain so they stay ordered after the direct writer.
+#[test]
+fn global_this_alias_read_is_ordered_after_direct_writer() {
+    let fixture = run_fixture(dataflow_opts(
+        r#"const g = globalThis;
+globalThis.tag = "x";
+const got = g.tag;
+console.log(got);
+export { g, got };
+"#,
+        vec![
+            logical_module_with_anon("mod_w", &[], &[r#"globalThis.tag = "x";"#]),
+            logical_module("mod_read", &[Member::new("got")]),
+        ],
+    ));
+    assert_entry_output(&fixture, "x\n");
+    let graph = read_owner_graph(&fixture);
+    // ordinals: 0 = g, 1 = tag write, 2 = got, 3 = log
+    assert_sequenced_edge(
+        &graph,
+        owner_for_binding(&graph, "got"),
+        owner_for_ordinal(&graph, 1),
+    );
+}
+
+/// window/self: an unshadowed `window` is the same object as
+/// `globalThis`; writes through it must hit the same cells.
+#[test]
+fn window_alias_prop_write_orders_reader() {
+    let fixture = run_fixture(dataflow_opts(
+        r#"globalThis.window = globalThis;
+window.tag = "w";
+const got = window.tag;
+console.log(got);
+export { got };
+"#,
+        vec![
+            logical_module_with_anon("mod_boot", &[], &["globalThis.window = globalThis;"]),
+            logical_module_with_anon("mod_w", &[], &[r#"window.tag = "w";"#]),
+            logical_module("mod_read", &[Member::new("got")]),
+        ],
+    ));
+    assert_entry_output(&fixture, "w\n");
+    let graph = read_owner_graph(&fixture);
+    // ordinals: 0 = boot, 1 = window.tag write, 2 = got, 3 = log
+    assert_sequenced_edge(
+        &graph,
+        owner_for_binding(&graph, "got"),
+        owner_for_ordinal(&graph, 1),
+    );
+}
+
+/// Indirect eval: `(0, eval)(...)` executes in global scope and can
+/// touch any cell — the statement must fall back to the conservative
+/// chain (subsumed by the opaque-call rule).
+#[test]
+fn indirect_eval_is_a_barrier() {
+    let fixture = run_fixture(dataflow_opts(
+        r#"globalThis.alpha = "a";
+const tagB = ((0, eval)("globalThis.beta = globalThis.alpha + 'b'"), "t");
+const got = globalThis.beta;
+console.log(got, tagB);
+export { tagB, got };
+"#,
+        vec![
+            logical_module_with_anon("mod_a", &[], &[r#"globalThis.alpha = "a";"#]),
+            logical_module("mod_b", &[Member::new("tagB")]),
+            logical_module("mod_read", &[Member::new("got")]),
+        ],
+    ));
+    assert_entry_output(&fixture, "ab t\n");
+    let graph = read_owner_graph(&fixture);
+    assert_sequenced_edge(
+        &graph,
+        owner_for_binding(&graph, "got"),
+        owner_for_binding(&graph, "tagB"),
+    );
+}

--- a/devinfra/js/debundle/facts/mod.rs
+++ b/devinfra/js/debundle/facts/mod.rs
@@ -10,7 +10,7 @@ pub use wire::{
 };
 
 use binding_targets::{
-    TargetAccessRecorder, declaration_ids, record_assign_target, record_pat_write,
+    TargetAccessRecorder, declaration_ids, hoisted_var_ids, record_assign_target, record_pat_write,
     record_update_target, strip_parens,
 };
 use serde::{Deserialize, Serialize};
@@ -73,6 +73,35 @@ pub struct StatementFacts {
     /// (e.g. `function f() { g(); } f();` at top level promotes
     /// through `g`'s body too).
     pub body_calls: BTreeSet<Id>,
+    /// Bindings referenced in the callee or arguments of at-init
+    /// calls promotion can't follow (member calls `api.read()`,
+    /// optional-chain calls, tagged templates). A function value
+    /// invoked by such a call must have flowed through one of these
+    /// bindings — or through an inline function expression (see
+    /// `at_init_unresolved_inline_fn`) — so `promote_at_init_calls`
+    /// makes the statement eagerly depend on the transitive lazy
+    /// closures of the chunk-declared subset.
+    pub at_init_unresolved_sources: BTreeSet<Id>,
+    /// `true` when an unresolved at-init call carries an inline
+    /// function/arrow/class expression: the statement's own lazy
+    /// closures may fire synchronously (IIFE,
+    /// `arr.forEach(x => ...)`).
+    pub at_init_unresolved_inline_fn: bool,
+    /// First-order pre-await body counterpart of
+    /// `at_init_unresolved_sources`; propagated to at-init callers
+    /// through the promotion call graph.
+    pub first_order_unresolved_sources: BTreeSet<Id>,
+    /// First-order pre-await body counterpart of
+    /// `at_init_unresolved_inline_fn`.
+    pub first_order_unresolved_inline_fn: bool,
+    /// `true` when the statement's declared binding is directly a
+    /// function value: a `function` declaration (incl. exported and
+    /// `export default` forms) or a single-declarator
+    /// `var/let/const` whose initializer is a function/arrow
+    /// expression. Promotion treats only at-init calls to such
+    /// bindings (when never rebound) as precisely resolvable;
+    /// everything else takes the conservative fallback.
+    pub declares_direct_function: bool,
     /// Subset of `body_calls` whose call sites sit in a function's
     /// **first-order** body. The promotion call graph uses this so
     /// that calls lexically nested inside a closure of the body
@@ -113,6 +142,21 @@ pub enum EffectCell {
 pub struct StatementEffectSummary {
     pub writes: BTreeSet<EffectCell>,
     pub reads: BTreeSet<EffectCell>,
+    /// `false` when the statement contains a shape that defeats any
+    /// static reasoning about which cells it WRITES (`with`, direct
+    /// or indirect `eval`, `Function(...)`, dynamic-key
+    /// `globalThis[expr]`, `defineProperty`/`Proxy` on the global).
+    /// Consumed by the vendor strip's swap-privacy gate, whose call
+    /// side effects are covered by its own island-reachability
+    /// analysis.
+    pub cell_writes_summarizable: bool,
+    /// `false` whenever `cell_writes_summarizable` is `false`, and
+    /// additionally for shapes that defeat the dataflow-aware
+    /// S-chain's stronger "which cells does this statement TOUCH"
+    /// question: opaque (not classifier-Pure) at-init calls/news
+    /// (I/O is not a cell; callee bodies may touch globals), member
+    /// writes through bindings (aliasing), and statements tainted by
+    /// a global-object alias escape.
     pub dataflow_summarizable: bool,
 }
 
@@ -235,8 +279,14 @@ pub(crate) struct StructuralStatementFacts {
     at_init_calls: BTreeSet<Id>,
     lazy_calls: BTreeSet<Id>,
     first_order_lazy_calls: BTreeSet<Id>,
+    at_init_unresolved_sources: BTreeSet<Id>,
+    at_init_unresolved_inline_fn: bool,
+    first_order_unresolved_sources: BTreeSet<Id>,
+    first_order_unresolved_inline_fn: bool,
+    declares_direct_function: bool,
     global_writes: BTreeSet<String>,
     global_reads: BTreeSet<String>,
+    cell_writes_summarizable: bool,
     dataflow_summarizable: bool,
 }
 
@@ -285,8 +335,9 @@ where
 {
     let body = top_level_item_views(&module.body);
     let shadowed = compute_shadowed_globals(&body);
+    let global_object_names = unshadowed_global_object_aliases(&body);
     let mut top_level_await = None;
-    let per_statement = body
+    let mut per_statement: Vec<StructuralStatementFacts> = body
         .iter()
         .enumerate()
         .map(|(ordinal, item)| {
@@ -300,7 +351,7 @@ where
             }
             let kind = classify_item(item);
             let declared = collect_declared_names(item);
-            let mut collector = StatementFactsCollector::new();
+            let mut collector = StatementFactsCollector::new(global_object_names.clone());
             item.visit_with(&mut collector);
             let source_location = source_path.and_then(|source_path| {
                 line_range_for_span(item.span()).map(|(start_line, end_line)| SourceLocation {
@@ -323,17 +374,155 @@ where
                 at_init_calls: collector.at_init_calls,
                 lazy_calls: collector.lazy_calls,
                 first_order_lazy_calls: collector.first_order_lazy_calls,
+                at_init_unresolved_sources: collector.at_init_unresolved_sources,
+                at_init_unresolved_inline_fn: collector.at_init_unresolved_inline_fn,
+                first_order_unresolved_sources: collector.first_order_unresolved_sources,
+                first_order_unresolved_inline_fn: collector.first_order_unresolved_inline_fn,
+                declares_direct_function: declares_direct_function(item),
                 global_writes: collector.global_writes,
                 global_reads: collector.global_reads,
+                cell_writes_summarizable: collector.cell_writes_summarizable,
                 dataflow_summarizable: collector.dataflow_summarizable,
             }
         })
         .collect();
+    apply_global_escape_taint(&body, &global_object_names, &mut per_statement);
     StructuralChunkAnalysis {
         body,
         shadowed,
         per_statement,
         top_level_await,
+    }
+}
+
+/// Identifier names that, when not shadowed by a chunk-top-level
+/// declaration or import, evaluate to the global object in the
+/// runtimes the debundler targets (browsers: `window` / `self` /
+/// `frames` / `top`; Node and workers: `globalThis` / `self`).
+const GLOBAL_OBJECT_ALIASES: [&str; 5] = ["globalThis", "window", "self", "frames", "top"];
+
+/// The subset of [`GLOBAL_OBJECT_ALIASES`] no chunk-top-level
+/// declaration (incl. block-hoisted `var`s) or import shadows.
+/// Block-scoped `let`/`const` redeclarations of an alias *inside* a
+/// top-level statement are not detected; treating such an access as
+/// global only over-approximates the cell sets (extra `Sequenced`
+/// edges), which is sound.
+fn unshadowed_global_object_aliases(body: &[TopLevelItemView<'_>]) -> BTreeSet<&'static str> {
+    let mut declared: BTreeSet<String> = BTreeSet::new();
+    for item in body {
+        let item = item.as_module_item();
+        for id in collect_declared_names(item) {
+            declared.insert(id.0.to_string());
+        }
+        if let ModuleItem::ModuleDecl(ModuleDecl::Import(import)) = item {
+            for spec in &import.specifiers {
+                let local = match spec {
+                    ImportSpecifier::Named(named) => named.local.sym.as_ref(),
+                    ImportSpecifier::Default(default) => default.local.sym.as_ref(),
+                    ImportSpecifier::Namespace(namespace) => namespace.local.sym.as_ref(),
+                };
+                declared.insert(local.to_string());
+            }
+        }
+    }
+    GLOBAL_OBJECT_ALIASES
+        .iter()
+        .copied()
+        .filter(|alias| !declared.contains(*alias))
+        .collect()
+}
+
+/// Global-object aliasing taint. A statement that lets the global
+/// object escape as a *value* (`const g = globalThis;`,
+/// `register(window)`, a function body returning `self`) defeats
+/// per-cell tracking for every binding the value flows into:
+/// `g.tag` reads/writes the same cells as `globalThis.tag` but the
+/// per-statement summary only sees `Binding(g)`. Conservative rule:
+///
+/// 1. A statement containing a bare global-object alias outside
+///    member-base position is tainted.
+/// 2. Bindings written (declared/rebound) by tainted statements are
+///    suspects.
+/// 3. Any statement reading a suspect is tainted (fixpoint).
+///
+/// Tainted statements get `dataflow_summarizable = false` — the
+/// dataflow-aware S-chain falls back to the strict adjacent-impure
+/// edge for them.
+fn apply_global_escape_taint(
+    body: &[TopLevelItemView<'_>],
+    global_object_names: &BTreeSet<&'static str>,
+    per_statement: &mut [StructuralStatementFacts],
+) {
+    let mut tainted: Vec<bool> = body
+        .iter()
+        .map(|item| {
+            let mut finder = GlobalObjectEscapeFinder {
+                names: global_object_names,
+                escaped: false,
+            };
+            item.as_module_item().visit_with(&mut finder);
+            finder.escaped
+        })
+        .collect();
+    let mut suspects: BTreeSet<Id> = BTreeSet::new();
+    loop {
+        let mut changed = false;
+        for (idx, facts) in per_statement.iter().enumerate() {
+            if !tainted[idx]
+                && facts
+                    .at_init_reads
+                    .iter()
+                    .chain(facts.lazy_reads.iter())
+                    .any(|id| suspects.contains(id))
+            {
+                tainted[idx] = true;
+                changed = true;
+            }
+            if tainted[idx] {
+                for id in facts
+                    .declared
+                    .iter()
+                    .chain(facts.at_init_writes.iter())
+                    .chain(facts.lazy_writes.iter())
+                {
+                    changed |= suspects.insert(id.clone());
+                }
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+    for (idx, facts) in per_statement.iter_mut().enumerate() {
+        if tainted[idx] {
+            facts.dataflow_summarizable = false;
+        }
+    }
+}
+
+/// Detects a global-object alias used as a value. `globalThis.x` /
+/// `window[k]` use the alias as a property base — not an escape —
+/// so member-base positions are skipped; any other occurrence
+/// (initializer, argument, return value, array/object element)
+/// counts.
+struct GlobalObjectEscapeFinder<'a> {
+    names: &'a BTreeSet<&'static str>,
+    escaped: bool,
+}
+
+impl Visit for GlobalObjectEscapeFinder<'_> {
+    fn visit_ident(&mut self, node: &Ident) {
+        if self.names.contains(node.sym.as_ref()) {
+            self.escaped = true;
+        }
+    }
+    fn visit_binding_ident(&mut self, _node: &BindingIdent) {}
+    fn visit_member_expr(&mut self, node: &MemberExpr) {
+        match strip_parens(&node.obj) {
+            Expr::Ident(ident) if self.names.contains(ident.sym.as_ref()) => {}
+            other => other.visit_with(self),
+        }
+        node.prop.visit_with(self);
     }
 }
 
@@ -557,8 +746,14 @@ fn assemble_statement_facts(
         at_init_calls,
         lazy_calls,
         first_order_lazy_calls,
+        at_init_unresolved_sources,
+        at_init_unresolved_inline_fn,
+        first_order_unresolved_sources,
+        first_order_unresolved_inline_fn,
+        declares_direct_function,
         global_writes,
         global_reads,
+        cell_writes_summarizable,
         dataflow_summarizable,
     } = structural;
     let local_effects = collect_local_effects(
@@ -575,6 +770,15 @@ fn assemble_statement_facts(
         graph,
         !local_effects.is_empty(),
     );
+    // Opaque at-init calls: a call/new the purity classifier can't
+    // prove Pure may touch any cell (I/O like `console.log`, global
+    // props written inside callee bodies, indirect eval) — the
+    // statement must fall back to the strict S-chain. Classifier-Pure
+    // calls are exempt: Pure guarantees no observable writes and no
+    // global-prop reads, and binding-cell ordering is enforced by
+    // binding edges + rebind co-location rather than the S-chain.
+    let dataflow_summarizable =
+        dataflow_summarizable && !has_opaque_at_init_call(item, shadowed, hints, graph);
     let mut effects_writes = BTreeSet::<EffectCell>::new();
     for name in declared.iter().chain(at_init_writes.iter()) {
         effects_writes.insert(EffectCell::Binding(name.clone()));
@@ -592,6 +796,7 @@ fn assemble_statement_facts(
     let effects = StatementEffectSummary {
         writes: effects_writes,
         reads: effects_reads,
+        cell_writes_summarizable,
         dataflow_summarizable,
     };
     StatementFacts {
@@ -608,10 +813,106 @@ fn assemble_statement_facts(
         at_init_calls,
         body_calls: lazy_calls,
         first_order_body_calls: first_order_lazy_calls,
+        at_init_unresolved_sources,
+        at_init_unresolved_inline_fn,
+        first_order_unresolved_sources,
+        first_order_unresolved_inline_fn,
+        declares_direct_function,
         effects,
         purity,
         kind,
     }
+}
+
+/// Walks a statement looking for an at-init (lazy-depth-0) call/new
+/// expression the purity classifier does not prove `Pure`. See the
+/// call site in [`assemble_statement_facts`] for the soundness
+/// rationale.
+struct OpaqueAtInitCallFinder<'a> {
+    shadowed: &'a BTreeSet<&'static str>,
+    hints: &'a AnalysisHints,
+    graph: &'a ChunkCodeGraph,
+    found: bool,
+    lazy_depth: u32,
+    past_await: bool,
+}
+
+impl LazyBoundary for OpaqueAtInitCallFinder<'_> {
+    fn lazy_depth_mut(&mut self) -> &mut u32 {
+        &mut self.lazy_depth
+    }
+    fn past_await_mut(&mut self) -> &mut bool {
+        &mut self.past_await
+    }
+}
+
+impl Visit for OpaqueAtInitCallFinder<'_> {
+    fn visit_expr(&mut self, expr: &Expr) {
+        if self.found {
+            return;
+        }
+        if self.lazy_depth == 0 {
+            let opaque = match expr {
+                Expr::Call(_) | Expr::New(_) => !classify_expr_purity(
+                    expr,
+                    self.shadowed,
+                    &BTreeSet::new(),
+                    &self.hints.declared_pure,
+                    self.graph,
+                )
+                .is_pure(),
+                // Tagged templates invoke the tag function; the
+                // classifier has no pure tag whitelist.
+                Expr::TaggedTpl(_) => true,
+                Expr::OptChain(opt) => matches!(&*opt.base, OptChainBase::Call(_)),
+                _ => false,
+            };
+            if opaque {
+                self.found = true;
+                return;
+            }
+        }
+        expr.visit_children_with(self);
+    }
+    fn visit_function(&mut self, node: &Function) {
+        lazy_visit_function(self, node);
+    }
+    fn visit_arrow_expr(&mut self, node: &ArrowExpr) {
+        lazy_visit_arrow_expr(self, node);
+    }
+    fn visit_method_prop(&mut self, node: &MethodProp) {
+        lazy_visit_method_prop(self, node);
+    }
+    fn visit_getter_prop(&mut self, node: &GetterProp) {
+        lazy_visit_getter_prop(self, node);
+    }
+    fn visit_setter_prop(&mut self, node: &SetterProp) {
+        lazy_visit_setter_prop(self, node);
+    }
+    fn visit_class(&mut self, node: &Class) {
+        lazy_visit_class(self, node);
+    }
+    fn visit_class_member(&mut self, member: &ClassMember) {
+        lazy_visit_class_member(self, member);
+    }
+}
+
+fn has_opaque_at_init_call(
+    item: &ModuleItem,
+    shadowed: &BTreeSet<&'static str>,
+    hints: &AnalysisHints,
+    graph: &ChunkCodeGraph,
+) -> bool {
+    let mut finder = OpaqueAtInitCallFinder {
+        shadowed,
+        hints,
+        graph,
+        found: false,
+        lazy_depth: 0,
+        past_await: false,
+    };
+    item.visit_with(&mut finder);
+    finder.found
 }
 
 fn item_purity(
@@ -623,7 +924,45 @@ fn item_purity(
     has_local_effect: bool,
 ) -> Purity {
     match kind {
-        StatementKind::Import | StatementKind::Export | StatementKind::FnDecl => Purity::Pure,
+        StatementKind::Import | StatementKind::FnDecl => Purity::Pure,
+        // `export { ... }` / `export * from ...` / `export default
+        // function` run no code at init — but `export default <expr>`
+        // evaluates the expression and `export default class` runs
+        // observable static parts (extends, static blocks, computed
+        // keys), so those route through the regular classifiers.
+        StatementKind::Export => match item {
+            ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultExpr(default_expr)) => {
+                classify_expr_purity(
+                    &default_expr.expr,
+                    shadowed,
+                    &BTreeSet::new(),
+                    &hints.declared_pure,
+                    graph,
+                )
+            }
+            ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultDecl(_)) => match class_of_item(item) {
+                Some(c)
+                    if class_has_static_observable(
+                        c,
+                        shadowed,
+                        &BTreeSet::new(),
+                        &hints.declared_pure,
+                        graph,
+                    ) =>
+                {
+                    Purity::NotPure {
+                        reasons: vec![PurityReason {
+                            rule: PurityRule::ClassStaticObservable,
+                            span: c.span,
+                            source_location: None,
+                            detail: None,
+                        }],
+                    }
+                }
+                _ => Purity::Pure,
+            },
+            _ => Purity::Pure,
+        },
         StatementKind::VarDecl if has_local_effect => Purity::Pure,
         // Top-level (non-function-body) scope: a chunk-top read of a
         // PlainData const is legitimately pure, so no PlainData name is
@@ -861,12 +1200,44 @@ pub(crate) fn collect_declared_names(item: &ModuleItem) -> BTreeSet<Id> {
                 .unwrap_or_default(),
             _ => BTreeSet::new(),
         },
+        // `var` declarations hoist to module scope out of blocks
+        // (`try { var impl = ...; } catch { var impl = ...; }`,
+        // `if`, loop bodies). The enclosing top-level statement is
+        // the binding's owner.
+        ModuleItem::Stmt(stmt) => hoisted_var_ids(stmt).into_iter().collect(),
         _ => BTreeSet::new(),
     }
 }
 
 fn declaration_names(decl: &Decl) -> BTreeSet<Id> {
     declaration_ids(decl).into_iter().collect()
+}
+
+/// `true` when the statement's declared binding is directly a
+/// function value. See [`StatementFacts::declares_direct_function`].
+fn declares_direct_function(item: &ModuleItem) -> bool {
+    match item {
+        ModuleItem::Stmt(Stmt::Decl(Decl::Fn(_))) => true,
+        ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(decl))
+            if matches!(decl.decl, Decl::Fn(_)) =>
+        {
+            true
+        }
+        ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultDecl(decl))
+            if matches!(decl.decl, DefaultDecl::Fn(_)) =>
+        {
+            true
+        }
+        _ => var_decl_of_item(item).is_some_and(|var| {
+            var.decls.len() == 1
+                && matches!(&var.decls[0].name, Pat::Ident(_))
+                && var.decls[0]
+                    .init
+                    .as_deref()
+                    .map(strip_parens)
+                    .is_some_and(|init| matches!(init, Expr::Fn(_) | Expr::Arrow(_)))
+        }),
+    }
 }
 
 /// Shared trait for visitors that track lazy nesting depth and the
@@ -946,17 +1317,28 @@ struct StatementFactsCollector {
     at_init_calls: BTreeSet<Id>,
     lazy_calls: BTreeSet<Id>,
     first_order_lazy_calls: BTreeSet<Id>,
+    at_init_unresolved_sources: BTreeSet<Id>,
+    at_init_unresolved_inline_fn: bool,
+    first_order_unresolved_sources: BTreeSet<Id>,
+    first_order_unresolved_inline_fn: bool,
     global_writes: BTreeSet<String>,
     global_reads: BTreeSet<String>,
+    cell_writes_summarizable: bool,
     dataflow_summarizable: bool,
+    /// Unshadowed global-object alias names for this chunk
+    /// (`globalThis`, `window`, ...). See
+    /// [`unshadowed_global_object_aliases`].
+    global_object_names: BTreeSet<&'static str>,
     lazy_depth: u32,
     past_await: bool,
 }
 
 impl StatementFactsCollector {
-    fn new() -> Self {
+    fn new(global_object_names: BTreeSet<&'static str>) -> Self {
         Self {
+            cell_writes_summarizable: true,
             dataflow_summarizable: true,
+            global_object_names,
             ..Self::default()
         }
     }
@@ -994,12 +1376,51 @@ impl StatementFactsCollector {
         }
     }
 
+    /// A call whose callee promotion can never resolve syntactically
+    /// (member call, IIFE, optional-chain call, tagged template).
+    /// Record the bindings the call mentions (callee root, argument
+    /// idents, computed keys) — the only channels through which a
+    /// chunk function value can reach the call — plus whether the
+    /// call carries an inline function expression. At-init the
+    /// statement takes the read-closure fallback over those sources;
+    /// in a first-order body they propagate to at-init callers
+    /// through the promotion call graph.
+    fn record_unresolved_call<N: VisitWith<UnresolvedCallSourceCollector>>(&mut self, node: &N) {
+        if self.lazy_depth > 1 || (self.lazy_depth == 1 && self.past_await) {
+            return;
+        }
+        let mut sources = UnresolvedCallSourceCollector::default();
+        node.visit_with(&mut sources);
+        if self.lazy_depth == 0 {
+            self.at_init_unresolved_sources.extend(sources.idents);
+            self.at_init_unresolved_inline_fn |= sources.inline_fn;
+        } else {
+            self.first_order_unresolved_sources.extend(sources.idents);
+            self.first_order_unresolved_inline_fn |= sources.inline_fn;
+        }
+    }
+
+    /// Bail only the S-chain's "which cells does this touch"
+    /// question (member writes, alias shapes). The vendor strip's
+    /// write-cell view stays summarizable.
     fn bail_summarizable(&mut self) {
         self.dataflow_summarizable = false;
     }
 
+    /// Bail every consumer: the statement may WRITE arbitrary cells
+    /// (`with`, eval, `Function(...)`, dynamic global keys,
+    /// `defineProperty`/`Proxy` on the global object).
+    fn bail_cell_writes(&mut self) {
+        self.cell_writes_summarizable = false;
+        self.dataflow_summarizable = false;
+    }
+
+    fn is_global_object_expr(&self, expr: &Expr) -> bool {
+        matches!(strip_parens(expr), Expr::Ident(i) if self.global_object_names.contains(i.sym.as_ref()))
+    }
+
     fn record_global_prop(&mut self, member: &MemberExpr, is_write: bool) {
-        if !is_global_this_expr(&member.obj) {
+        if !self.is_global_object_expr(&member.obj) {
             return;
         }
         let key = match &member.prop {
@@ -1007,7 +1428,7 @@ impl StatementFactsCollector {
             MemberProp::Computed(ComputedPropName { expr, .. }) => match strip_parens(expr) {
                 Expr::Lit(Lit::Str(s)) => Some(s.value.to_string_lossy().into_owned()),
                 _ => {
-                    self.bail_summarizable();
+                    self.bail_cell_writes();
                     return;
                 }
             },
@@ -1023,6 +1444,40 @@ impl StatementFactsCollector {
     }
 }
 
+/// Collects the ident reads and inline-function presence inside an
+/// unresolved call expression. Static member prop names are
+/// `IdentName`s (not `Ident`s) and are not collected; function /
+/// arrow / class / accessor interiors are skipped — their contents
+/// are already covered by the owner's lazy sets, which the
+/// `inline_fn` flag pulls into the fallback closure.
+#[derive(Default)]
+struct UnresolvedCallSourceCollector {
+    idents: BTreeSet<Id>,
+    inline_fn: bool,
+}
+
+impl Visit for UnresolvedCallSourceCollector {
+    fn visit_ident(&mut self, node: &Ident) {
+        self.idents.insert(node.to_id());
+    }
+    fn visit_binding_ident(&mut self, _node: &BindingIdent) {}
+    fn visit_function(&mut self, _node: &Function) {
+        self.inline_fn = true;
+    }
+    fn visit_arrow_expr(&mut self, _node: &ArrowExpr) {
+        self.inline_fn = true;
+    }
+    fn visit_class(&mut self, _node: &Class) {
+        self.inline_fn = true;
+    }
+    fn visit_getter_prop(&mut self, _node: &GetterProp) {
+        self.inline_fn = true;
+    }
+    fn visit_setter_prop(&mut self, _node: &SetterProp) {
+        self.inline_fn = true;
+    }
+}
+
 impl LazyBoundary for StatementFactsCollector {
     fn lazy_depth_mut(&mut self) -> &mut u32 {
         &mut self.lazy_depth
@@ -1035,6 +1490,19 @@ impl LazyBoundary for StatementFactsCollector {
 impl TargetAccessRecorder for StatementFactsCollector {
     fn record_binding_write(&mut self, id: &Id) {
         self.record_write(id);
+    }
+
+    fn record_member_write(&mut self, id: &Id) {
+        // Property writes through a tracked binding (`obj.x = 1`,
+        // `obj.x++`, `(a?.b).c = 1`) mutate heap state the cell
+        // summary can't attribute: aliasing makes the write
+        // invisible to readers going through a different binding.
+        // Global-object roots are handled precisely (static key) or
+        // bailed (dynamic key / deep chain) at the assign/update
+        // visitors.
+        if self.lazy_depth == 0 && !self.global_object_names.contains(id.0.as_ref()) {
+            self.bail_summarizable();
+        }
     }
 }
 
@@ -1094,10 +1562,31 @@ impl Visit for StatementFactsCollector {
 
     fn visit_assign_expr(&mut self, node: &AssignExpr) {
         record_assign_target(&node.left, self);
-        if self.lazy_depth == 0
-            && let AssignTarget::Simple(SimpleAssignTarget::Member(member)) = &node.left
-        {
-            self.record_global_prop(member, /*is_write=*/ true);
+        if self.lazy_depth == 0 {
+            match &node.left {
+                AssignTarget::Simple(_) => {
+                    if let Some(member) = simple_assign_member_target(&node.left) {
+                        if self.is_global_object_expr(&member.obj) {
+                            // `globalThis.tag = ...`: a precisely
+                            // tracked cell (dynamic keys bail inside
+                            // `record_global_prop`).
+                            self.record_global_prop(member, /*is_write=*/ true);
+                        } else {
+                            // Member write through a binding or a
+                            // deeper global chain (`globalThis.a.b`):
+                            // not attributable to a static cell.
+                            self.bail_summarizable();
+                        }
+                    }
+                }
+                AssignTarget::Pat(pat) => {
+                    // Destructuring targets may smuggle member
+                    // writes: `[obj.x] = arr`.
+                    if assign_target_pat_has_member_target(pat) {
+                        self.bail_summarizable();
+                    }
+                }
+            }
         }
         node.left.visit_with(self);
         node.right.visit_with(self);
@@ -1105,6 +1594,19 @@ impl Visit for StatementFactsCollector {
 
     fn visit_update_expr(&mut self, node: &UpdateExpr) {
         record_update_target(&node.arg, self);
+        if self.lazy_depth == 0 {
+            match strip_parens(&node.arg) {
+                // `count++`: binding read+write, handled by
+                // `record_update_target` + the child visit.
+                Expr::Ident(_) => {}
+                Expr::Member(member) if self.is_global_object_expr(&member.obj) => {
+                    // `globalThis.count++` reads and writes the cell.
+                    self.record_global_prop(member, /*is_write=*/ true);
+                    self.record_global_prop(member, /*is_write=*/ false);
+                }
+                _ => self.bail_summarizable(),
+            }
+        }
         node.arg.visit_with(self);
     }
 
@@ -1126,18 +1628,32 @@ impl Visit for StatementFactsCollector {
         node.body.visit_with(self);
     }
 
+    // The S-chain's dataflow-summarizability of calls/news is
+    // decided in the policy phase (`has_opaque_at_init_call`): any
+    // at-init call or `new` the purity classifier can't prove Pure
+    // bails `dataflow_summarizable`. The structural checks below
+    // additionally flip `cell_writes_summarizable` for the shapes
+    // that defeat WRITE-cell reasoning outright: direct and indirect
+    // `eval`, `Function(...)`, `Object.defineProperty(globalThis,
+    // ...)` / `Reflect.defineProperty(globalThis, ...)`, and
+    // `new Proxy(globalThis, ...)`.
     fn visit_call_expr(&mut self, node: &CallExpr) {
-        if let Some(callee) = call_callee_ident(node) {
-            self.record_call(&callee.to_id());
+        match &node.callee {
+            Callee::Expr(callee) => match strip_parens(callee) {
+                Expr::Ident(ident) => self.record_call(&ident.to_id()),
+                _ => self.record_unresolved_call(node),
+            },
+            // `import(...)` evaluates another chunk asynchronously —
+            // it never synchronously runs this chunk's functions.
+            // `super(...)` can't appear at chunk top level.
+            Callee::Import(_) | Callee::Super(_) => {}
         }
         if self.lazy_depth == 0 {
             if let Callee::Expr(expr) = &node.callee
-                && let Expr::Ident(ident) = strip_parens(expr)
+                && let Expr::Ident(ident) = callee_base_expr(expr)
+                && matches!(ident.sym.as_ref(), "eval" | "Function")
             {
-                match ident.sym.as_ref() {
-                    "eval" | "Function" => self.bail_summarizable(),
-                    _ => {}
-                }
+                self.bail_cell_writes();
             }
             if let Callee::Expr(expr) = &node.callee
                 && let Expr::Member(member) = strip_parens(expr)
@@ -1150,9 +1666,9 @@ impl Visit for StatementFactsCollector {
                 && node
                     .args
                     .first()
-                    .is_some_and(|a| is_global_this_expr(&a.expr))
+                    .is_some_and(|a| self.is_global_object_expr(&a.expr))
             {
-                self.bail_summarizable();
+                self.bail_cell_writes();
             }
         }
         node.visit_children_with(self);
@@ -1163,20 +1679,33 @@ impl Visit for StatementFactsCollector {
             && let Expr::Ident(ident) = strip_parens(&node.callee)
         {
             match ident.sym.as_ref() {
-                "Function" => self.bail_summarizable(),
+                "Function" => self.bail_cell_writes(),
                 "Proxy" => {
                     let proxies_global = node
                         .args
                         .as_ref()
                         .and_then(|args| args.first())
-                        .is_some_and(|a| is_global_this_expr(&a.expr));
+                        .is_some_and(|a| self.is_global_object_expr(&a.expr));
                     if proxies_global {
-                        self.bail_summarizable();
+                        self.bail_cell_writes();
                     }
                 }
                 _ => {}
             }
         }
+        node.visit_children_with(self);
+    }
+
+    fn visit_opt_call(&mut self, node: &OptCall) {
+        // `f?.()` / `obj?.m()`: the callee is never a resolvable
+        // bare-Ident shape for promotion.
+        self.record_unresolved_call(node);
+        node.visit_children_with(self);
+    }
+
+    fn visit_tagged_tpl(&mut self, node: &TaggedTpl) {
+        // `` tag`...` `` invokes the tag function.
+        self.record_unresolved_call(node);
         node.visit_children_with(self);
     }
 
@@ -1189,7 +1718,7 @@ impl Visit for StatementFactsCollector {
 
     fn visit_with_stmt(&mut self, node: &WithStmt) {
         if self.lazy_depth == 0 {
-            self.bail_summarizable();
+            self.bail_cell_writes();
         }
         node.visit_children_with(self);
     }
@@ -1217,8 +1746,61 @@ impl Visit for StatementFactsCollector {
     }
 }
 
-fn is_global_this_expr(expr: &Expr) -> bool {
-    matches!(strip_parens(expr), Expr::Ident(i) if i.sym.as_ref() == "globalThis")
+/// Look through parens and comma sequences to a callee's final
+/// operand: `(0, eval)(...)` is an indirect eval call with the same
+/// arbitrary-cell-write power as a direct one.
+fn callee_base_expr(expr: &Expr) -> &Expr {
+    let mut cur = strip_parens(expr);
+    while let Expr::Seq(seq) = cur {
+        cur = strip_parens(seq.exprs.last().expect("SeqExpr is non-empty"));
+    }
+    cur
+}
+
+/// The member expression a simple assignment target writes through,
+/// unwrapping parens (`(globalThis.x) = 1`). `None` for ident,
+/// opt-chain, and pattern targets.
+fn simple_assign_member_target(target: &AssignTarget) -> Option<&MemberExpr> {
+    let AssignTarget::Simple(simple) = target else {
+        return None;
+    };
+    match simple {
+        SimpleAssignTarget::Member(member) => Some(member),
+        SimpleAssignTarget::Paren(paren) => match strip_parens(&paren.expr) {
+            Expr::Member(member) => Some(member),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// `true` if a destructuring assignment target contains a member
+/// expression (`[obj.x] = arr`, `({ k: obj.x } = o)`) — a property
+/// write the binding-pattern walker doesn't record.
+fn assign_target_pat_has_member_target(pat: &AssignTargetPat) -> bool {
+    fn pat_has_expr(pat: &Pat) -> bool {
+        match pat {
+            Pat::Ident(_) | Pat::Invalid(_) => false,
+            Pat::Expr(_) => true,
+            Pat::Array(array) => array.elems.iter().flatten().any(pat_has_expr),
+            Pat::Object(object) => object.props.iter().any(|prop| match prop {
+                ObjectPatProp::KeyValue(kv) => pat_has_expr(&kv.value),
+                ObjectPatProp::Assign(_) => false,
+                ObjectPatProp::Rest(rest) => pat_has_expr(&rest.arg),
+            }),
+            Pat::Assign(assign) => pat_has_expr(&assign.left),
+            Pat::Rest(rest) => pat_has_expr(&rest.arg),
+        }
+    }
+    match pat {
+        AssignTargetPat::Array(array) => array.elems.iter().flatten().any(pat_has_expr),
+        AssignTargetPat::Object(object) => object.props.iter().any(|prop| match prop {
+            ObjectPatProp::KeyValue(kv) => pat_has_expr(&kv.value),
+            ObjectPatProp::Assign(_) => false,
+            ObjectPatProp::Rest(rest) => pat_has_expr(&rest.arg),
+        }),
+        AssignTargetPat::Invalid(_) => false,
+    }
 }
 
 fn lazy_visit_function<V: LazyBoundary>(v: &mut V, node: &Function) {

--- a/devinfra/js/debundle/facts/wire.rs
+++ b/devinfra/js/debundle/facts/wire.rs
@@ -87,6 +87,7 @@ impl EffectCellReport {
 pub struct StatementEffectSummaryReport {
     pub writes: Vec<EffectCellReport>,
     pub reads: Vec<EffectCellReport>,
+    pub cell_writes_summarizable: bool,
     pub dataflow_summarizable: bool,
 }
 
@@ -103,6 +104,7 @@ impl StatementEffectSummaryReport {
                 .iter()
                 .map(EffectCellReport::from_cell)
                 .collect(),
+            cell_writes_summarizable: summary.cell_writes_summarizable,
             dataflow_summarizable: summary.dataflow_summarizable,
         }
     }
@@ -111,6 +113,7 @@ impl StatementEffectSummaryReport {
         StatementEffectSummary {
             writes: self.writes.iter().map(EffectCellReport::to_cell).collect(),
             reads: self.reads.iter().map(EffectCellReport::to_cell).collect(),
+            cell_writes_summarizable: self.cell_writes_summarizable,
             dataflow_summarizable: self.dataflow_summarizable,
         }
     }
@@ -137,6 +140,11 @@ pub struct StatementFactsReport {
     pub at_init_calls: Vec<IdReport>,
     pub body_calls: Vec<IdReport>,
     pub first_order_body_calls: Vec<IdReport>,
+    pub at_init_unresolved_sources: Vec<IdReport>,
+    pub at_init_unresolved_inline_fn: bool,
+    pub first_order_unresolved_sources: Vec<IdReport>,
+    pub first_order_unresolved_inline_fn: bool,
+    pub declares_direct_function: bool,
     pub effects: StatementEffectSummaryReport,
     pub purity: Purity,
     pub kind: StatementKind,
@@ -158,6 +166,11 @@ impl StatementFactsReport {
             at_init_calls: ids_to_wire(&facts.at_init_calls),
             body_calls: ids_to_wire(&facts.body_calls),
             first_order_body_calls: ids_to_wire(&facts.first_order_body_calls),
+            at_init_unresolved_sources: ids_to_wire(&facts.at_init_unresolved_sources),
+            at_init_unresolved_inline_fn: facts.at_init_unresolved_inline_fn,
+            first_order_unresolved_sources: ids_to_wire(&facts.first_order_unresolved_sources),
+            first_order_unresolved_inline_fn: facts.first_order_unresolved_inline_fn,
+            declares_direct_function: facts.declares_direct_function,
             effects: StatementEffectSummaryReport::from_summary(&facts.effects),
             purity: facts.purity.clone(),
             kind: facts.kind,
@@ -179,6 +192,11 @@ impl StatementFactsReport {
             at_init_calls: ids_from_wire(&self.at_init_calls),
             body_calls: ids_from_wire(&self.body_calls),
             first_order_body_calls: ids_from_wire(&self.first_order_body_calls),
+            at_init_unresolved_sources: ids_from_wire(&self.at_init_unresolved_sources),
+            at_init_unresolved_inline_fn: self.at_init_unresolved_inline_fn,
+            first_order_unresolved_sources: ids_from_wire(&self.first_order_unresolved_sources),
+            first_order_unresolved_inline_fn: self.first_order_unresolved_inline_fn,
+            declares_direct_function: self.declares_direct_function,
             effects: self.effects.to_summary(),
             purity: self.purity.clone(),
             kind: self.kind,

--- a/devinfra/js/debundle/graph.rs
+++ b/devinfra/js/debundle/graph.rs
@@ -140,6 +140,14 @@ impl EdgeReason {
             role: EdgeRole::Direct,
         }
     }
+    pub(crate) fn deferred_rebind(so: StatementOrdinal, b: Id) -> Self {
+        Self {
+            kind: DepKind::DeferredRebind,
+            statement_ordinal: so,
+            binding: Some(b),
+            role: EdgeRole::Direct,
+        }
+    }
     pub(crate) fn sequenced(so: StatementOrdinal) -> Self {
         Self {
             kind: DepKind::Sequenced,
@@ -202,16 +210,23 @@ impl EdgeReason {
         self.statement_ordinal
     }
     pub fn is_rebind(&self) -> bool {
-        matches!(self.kind, DepKind::EagerRebind | DepKind::LazyRebind)
+        matches!(
+            self.kind,
+            DepKind::EagerRebind | DepKind::LazyRebind | DepKind::DeferredRebind
+        )
     }
     pub fn is_sequenced(&self) -> bool {
         self.kind == DepKind::Sequenced
     }
-    /// Every kind except `LazyUse` constrains realizability.
-    /// Stated as exclusion so adding a new `DepKind` variant
-    /// forces an explicit decision here.
+    /// Every kind except `LazyUse` and `DeferredRebind` constrains
+    /// realizability. `DeferredRebind` writes never fire at module
+    /// init (the write site is nested ≥2 closures deep or past an
+    /// await), so they impose no init-order constraint — but they
+    /// still participate in cross-destination-rebind rejection and
+    /// `G_atomic` co-location, because ESM imports are read-only at
+    /// ANY time, not just during init.
     pub fn constrains_init_order(&self) -> bool {
-        self.kind != DepKind::LazyUse
+        !matches!(self.kind, DepKind::LazyUse | DepKind::DeferredRebind)
     }
 }
 
@@ -222,6 +237,12 @@ pub enum DepKind {
     LazyUse,
     EagerRebind,
     LazyRebind,
+    /// Rebinding write that only fires after module init (nested ≥2
+    /// closures deep, or past an `await` in an async body). Rejected
+    /// across destinations like the other rebinds (ESM imports are
+    /// read-only whenever the write fires), but excluded from
+    /// init-order constraints and the I-graph.
+    DeferredRebind,
     Sequenced,
     LocalEffect,
 }
@@ -702,22 +723,36 @@ pub fn build_owner_graph_with(facts: &[StatementFacts], options: OwnerGraphOptio
             );
         }
         // Only first-order body rebinds emit a constraining
-        // `LazyRebind` edge. A rebind inside a nested closure
-        // (e.g. an arrow stashed on `globalThis` by the body)
-        // doesn't fire when the function is invoked synchronously;
-        // emitting an edge for it manufactures a bidirectional
-        // G_atomic constraint (atomic_units.rs:82-85) that forces
-        // co-location with the rebind target even though no
-        // synchronous-trace rebind exists. See the e2e test
-        // `at_init_promotion_nested_closure_test` for the
-        // rationale; the same first-order narrowing is what
-        // promote_at_init_calls uses.
+        // `LazyRebind` edge: a rebind inside a nested closure (e.g.
+        // an arrow stashed on `globalThis` by the body) doesn't fire
+        // when the function is invoked synchronously, so it must not
+        // constrain init order or feed at-init call promotion. See
+        // the e2e test `at_init_promotion_nested_closure_test`.
         for binding in &stmt.first_order_lazy_rebinds {
             push_binding_edge(
                 &mut raw_edges,
                 from,
                 binding,
                 EdgeReason::lazy_rebind,
+                stmt.ordinal,
+            );
+        }
+        // Deeper-nested (or post-await) rebinds still rebind the
+        // binding cell whenever they DO fire — and ESM imports are
+        // read-only at any time, not just during init. Emit a
+        // non-init-constraining `DeferredRebind` edge so
+        // cross-destination splits are rejected and `G_atomic`
+        // forces co-location, without manufacturing an init-order
+        // constraint nothing fires at init.
+        for binding in &stmt.lazy_rebinds {
+            if stmt.first_order_lazy_rebinds.contains(binding) {
+                continue;
+            }
+            push_binding_edge(
+                &mut raw_edges,
+                from,
+                binding,
+                EdgeReason::deferred_rebind,
                 stmt.ordinal,
             );
         }
@@ -845,14 +880,22 @@ fn emit_s_chain(
         return;
     }
 
-    // Dataflow-aware emission: last-writer-precedes-reader-or-writer.
-    // For each impure `curr`, emit an incoming Sequenced edge from the
-    // most recent prior impure owner that wrote any cell in
-    // `curr.reads ∪ curr.writes`. Statements with
-    // `dataflow_summarizable = false` are treated as touching every
-    // cell — they get edges to every prior impure owner and become a
-    // barrier for subsequent statements.
+    // Dataflow-aware emission. For each impure `curr`, emit an
+    // incoming Sequenced edge from:
+    //
+    // - the most recent prior impure owner that wrote any cell in
+    //   `curr.reads ∪ curr.writes` (read-after-write /
+    //   write-after-write), and
+    // - every prior impure owner that READ a cell `curr` writes
+    //   since that cell's last write (write-after-read — without
+    //   this, a later writer could be scheduled before an earlier
+    //   reader and the reader would observe the new value).
+    //
+    // Statements with `dataflow_summarizable = false` are treated as
+    // touching every cell — they get edges to every prior impure
+    // owner and become a barrier for subsequent statements.
     let mut last_writer: BTreeMap<EffectCell, OwnerId> = BTreeMap::new();
+    let mut readers_since_last_write: BTreeMap<EffectCell, BTreeSet<OwnerId>> = BTreeMap::new();
     let mut prior_impure_owners: Vec<OwnerId> = Vec::new();
     let mut opaque_barrier: Option<OwnerId> = None;
     for stmt in facts.iter().filter(|s| !s.purity.is_pure()) {
@@ -862,6 +905,11 @@ fn emit_s_chain(
             for cell in stmt.effects.reads.iter().chain(stmt.effects.writes.iter()) {
                 if let Some(&to) = last_writer.get(cell) {
                     targets.insert(to);
+                }
+            }
+            for cell in &stmt.effects.writes {
+                if let Some(readers) = readers_since_last_write.get(cell) {
+                    targets.extend(readers.iter().copied());
                 }
             }
             // Non-summarizable prior statements are barriers: any later
@@ -883,8 +931,17 @@ fn emit_s_chain(
                 raw_edges.push((from, to, EdgeReason::sequenced(stmt.ordinal)));
             }
         }
-        for cell in &stmt.effects.writes {
-            last_writer.insert(cell.clone(), from);
+        if stmt.effects.dataflow_summarizable {
+            for cell in &stmt.effects.writes {
+                last_writer.insert(cell.clone(), from);
+                readers_since_last_write.remove(cell);
+            }
+            for cell in &stmt.effects.reads {
+                readers_since_last_write
+                    .entry(cell.clone())
+                    .or_default()
+                    .insert(from);
+            }
         }
         prior_impure_owners.push(from);
     }
@@ -907,24 +964,88 @@ fn promote_at_init_calls(
     binding_owner: &HashMap<Id, OwnerId>,
     raw_edges: &mut Vec<(OwnerId, OwnerId, EdgeReason)>,
 ) {
+    let mut stmt_by_owner: BTreeMap<OwnerId, &StatementFacts> = BTreeMap::new();
+    for stmt in facts {
+        stmt_by_owner.insert(OwnerId(stmt.ordinal.0), stmt);
+    }
+
+    // Bindings rebound anywhere in the chunk: their value at call
+    // time may not be the function lexically defined at their owner,
+    // so calls to them are not precisely resolvable.
+    let rebound: BTreeSet<&Id> = facts
+        .iter()
+        .flat_map(|s| s.eager_rebinds.iter().chain(s.lazy_rebinds.iter()))
+        .collect();
+
+    // A callee binding is precisely resolvable iff (a) its declaring
+    // statement binds it directly to a function value (`function f`,
+    // `const f = () => ...`) and (b) it is never rebound. Everything
+    // else — aliases (`const g = readB`), object-literal methods,
+    // conditional initializers, rebound functions — takes the
+    // conservative read-closure fallback below.
+    let resolvable_callee = |id: &Id| -> Option<OwnerId> {
+        let owner = binding_owner.get(id)?;
+        let stmt = stmt_by_owner.get(owner)?;
+        (stmt.declares_direct_function && !rebound.contains(id)).then_some(*owner)
+    };
+
     // 1. Build the call graph: owner → owner edges for each
-    //    chunk-declared function callee reachable via *first-order*
-    //    body_calls. Nested-closure calls (e.g. inside an arrow
-    //    returned by the body) don't fire when the body is invoked
-    //    synchronously, so they don't belong on the promotion call
-    //    graph — see docs/design.md "At-init call promotion" and the e2e
-    //    test `at_init_promotion_nested_closure_test`.
+    //    resolvable callee reachable via *first-order* body_calls.
+    //    Nested-closure calls (e.g. inside an arrow returned by the
+    //    body) don't fire when the body is invoked synchronously, so
+    //    they don't belong on the promotion call graph — see
+    //    docs/design.md "At-init call promotion" and the e2e test
+    //    `at_init_promotion_nested_closure_test`.
     //
     //    Add every owner whose body has any first-order lazy reads /
-    //    rebinds / calls as a node — those are the callable owners
-    //    whose body closures we may need to promote, even if the body
-    //    itself makes no calls (e.g. `function readB() { return B; }`).
+    //    rebinds / calls — or an unresolvable first-order callee — as
+    //    a node, so the closure pass below covers it even if it makes
+    //    no resolvable calls (e.g. `function readB() { return B; }`).
+    //
+    //    Per-owner "fallback roots": owners through which a function
+    //    value could reach a call the owner's first-order body makes
+    //    but promotion can't follow — the owners of bindings the
+    //    unresolved call mentions, the owners of chunk-declared
+    //    Ident callees that aren't direct never-rebound functions,
+    //    and the owner itself when the unresolved call carries an
+    //    inline function expression. At-init callers inherit these
+    //    roots transitively through the call graph and expand them
+    //    via [`UnresolvedCallFallback`].
+    let fallback_roots_of =
+        |sources: &BTreeSet<Id>, inline_fn: bool, self_owner: OwnerId| -> BTreeSet<OwnerId> {
+            let mut roots: BTreeSet<OwnerId> = sources
+                .iter()
+                .filter_map(|id| binding_owner.get(id).copied())
+                .collect();
+            if inline_fn {
+                roots.insert(self_owner);
+            }
+            roots
+        };
+    let owner_first_order_roots = |stmt: &StatementFacts| -> BTreeSet<OwnerId> {
+        let owner = OwnerId(stmt.ordinal.0);
+        let mut roots = fallback_roots_of(
+            &stmt.first_order_unresolved_sources,
+            stmt.first_order_unresolved_inline_fn,
+            owner,
+        );
+        for callee_id in &stmt.first_order_body_calls {
+            if resolvable_callee(callee_id).is_none()
+                && let Some(&callee_owner) = binding_owner.get(callee_id)
+            {
+                roots.insert(callee_owner);
+            }
+        }
+        roots
+    };
     let mut call_graph: DiGraphMap<OwnerId, ()> = DiGraphMap::new();
     for stmt in facts {
         let owner = OwnerId(stmt.ordinal.0);
         if !stmt.first_order_body_calls.is_empty()
             || !stmt.first_order_lazy_reads.is_empty()
             || !stmt.first_order_lazy_rebinds.is_empty()
+            || !stmt.first_order_unresolved_sources.is_empty()
+            || stmt.first_order_unresolved_inline_fn
         {
             call_graph.add_node(owner);
         }
@@ -935,15 +1056,12 @@ fn promote_at_init_calls(
         }
         let caller = OwnerId(stmt.ordinal.0);
         for callee_id in &stmt.first_order_body_calls {
-            let Some(callee_owner) = binding_owner.get(callee_id) else {
+            let Some(callee_owner) = resolvable_callee(callee_id) else {
                 continue;
             };
-            call_graph.add_node(*callee_owner);
-            call_graph.add_edge(caller, *callee_owner, ());
+            call_graph.add_node(callee_owner);
+            call_graph.add_edge(caller, callee_owner, ());
         }
-    }
-    if call_graph.node_count() == 0 {
-        return;
     }
 
     // 2. Tarjan SCC. `tarjan_scc` returns SCCs in reverse topological
@@ -970,10 +1088,6 @@ fn promote_at_init_calls(
     //    fire the realizability hazard. `var` is technically hoisted
     //    too but is rare enough not to warrant a separate distinction
     //    in StatementKind.
-    let mut stmt_by_owner: BTreeMap<OwnerId, &StatementFacts> = BTreeMap::new();
-    for stmt in facts {
-        stmt_by_owner.insert(OwnerId(stmt.ordinal.0), stmt);
-    }
     let target_is_hoisted = |id: &Id| -> bool {
         let Some(target_owner) = binding_owner.get(id) else {
             return false;
@@ -985,17 +1099,21 @@ fn promote_at_init_calls(
     };
     let mut scc_reads: Vec<BTreeSet<Id>> = vec![BTreeSet::new(); sccs.len()];
     let mut scc_rebinds: Vec<BTreeSet<Id>> = vec![BTreeSet::new(); sccs.len()];
+    let mut scc_fallback_roots: Vec<BTreeSet<OwnerId>> = vec![BTreeSet::new(); sccs.len()];
 
     // 4. Closure over the call graph. Iterate SCCs in
     //    reverse-topological order (leaves first). For each SCC,
-    //    union members' own seeds plus successor SCC closures.
+    //    union members' own seeds plus successor SCC closures, and
+    //    propagate fallback roots the same way.
     for (scc_idx, scc) in sccs.iter().enumerate() {
         let mut reads: BTreeSet<Id> = BTreeSet::new();
         let mut rebinds: BTreeSet<Id> = BTreeSet::new();
+        let mut roots: BTreeSet<OwnerId> = BTreeSet::new();
         for owner in scc {
             let Some(stmt) = stmt_by_owner.get(owner) else {
                 continue;
             };
+            roots.extend(owner_first_order_roots(stmt));
             for id in &stmt.first_order_lazy_reads {
                 if binding_owner.contains_key(id) && !target_is_hoisted(id) {
                     reads.insert(id.clone());
@@ -1017,10 +1135,12 @@ fn promote_at_init_calls(
                 }
                 reads.extend(scc_reads[target_scc].iter().cloned());
                 rebinds.extend(scc_rebinds[target_scc].iter().cloned());
+                roots.extend(scc_fallback_roots[target_scc].iter().copied());
             }
         }
         scc_reads[scc_idx] = reads;
         scc_rebinds[scc_idx] = rebinds;
+        scc_fallback_roots[scc_idx] = roots;
     }
 
     // 5. Emit promoted edges with per-statement, per-kind dedup.
@@ -1032,20 +1152,42 @@ fn promote_at_init_calls(
     //    evaluated, so the manufactured constraint from R to the
     //    target's module is redundant with the already-recorded
     //    R -> callee-module edge. See [`EdgeRole`].
+    //
+    //    Statements whose at-init calls can't all be resolved take
+    //    the conservative fallback in addition: see
+    //    [`UnresolvedCallFallback`].
+    let mut fallback: Option<UnresolvedCallFallback> = None;
     for stmt in facts {
-        if stmt.at_init_calls.is_empty() {
+        if stmt.at_init_calls.is_empty()
+            && stmt.at_init_unresolved_sources.is_empty()
+            && !stmt.at_init_unresolved_inline_fn
+        {
             continue;
         }
         let caller = OwnerId(stmt.ordinal.0);
         let mut promoted_read_targets: BTreeSet<OwnerId> = BTreeSet::new();
         let mut promoted_rebind_targets: BTreeSet<OwnerId> = BTreeSet::new();
+        let mut fallback_roots = fallback_roots_of(
+            &stmt.at_init_unresolved_sources,
+            stmt.at_init_unresolved_inline_fn,
+            caller,
+        );
         for callee_id in &stmt.at_init_calls {
-            let Some(callee_owner) = binding_owner.get(callee_id) else {
+            let Some(callee_owner) = resolvable_callee(callee_id) else {
+                // A bare-Ident callee that isn't chunk-declared is a
+                // global/import — out of single-chunk analysis scope
+                // (documented precondition in docs/design.md). A
+                // chunk-declared but unresolvable callee falls back
+                // through the read closure of its own owner.
+                if let Some(&callee_owner) = binding_owner.get(callee_id) {
+                    fallback_roots.insert(callee_owner);
+                }
                 continue;
             };
-            let Some(&scc_idx) = scc_of.get(callee_owner) else {
+            let Some(&scc_idx) = scc_of.get(&callee_owner) else {
                 continue;
             };
+            fallback_roots.extend(scc_fallback_roots[scc_idx].iter().copied());
             for target_binding in &scc_reads[scc_idx] {
                 let Some(target_owner) = binding_owner.get(target_binding) else {
                     continue;
@@ -1060,7 +1202,7 @@ fn promote_at_init_calls(
                     caller,
                     *target_owner,
                     EdgeReason::eager_use(stmt.ordinal, target_binding.clone())
-                        .promoted_at_init(*callee_owner),
+                        .promoted_at_init(callee_owner),
                 ));
             }
             for target_binding in &scc_rebinds[scc_idx] {
@@ -1077,9 +1219,153 @@ fn promote_at_init_calls(
                     caller,
                     *target_owner,
                     EdgeReason::eager_rebind(stmt.ordinal, target_binding.clone())
-                        .promoted_at_init(*callee_owner),
+                        .promoted_at_init(callee_owner),
                 ));
             }
+        }
+        if fallback_roots.is_empty() {
+            continue;
+        }
+        let fallback =
+            fallback.get_or_insert_with(|| UnresolvedCallFallback::build(facts, binding_owner));
+        for root in fallback_roots {
+            let (closure_reads, closure_rebinds) = fallback.closures_for(root);
+            // Rebind targets get an *order* constraint only (EagerUse,
+            // not EagerRebind): assignment to a TDZ-locked binding
+            // throws until its statement runs, so the target must
+            // evaluate before the caller — but write LEGALITY
+            // (read-only imports) is already enforced by the direct
+            // `LazyRebind` / `DeferredRebind` edge from the statement
+            // lexically containing the write, which forces the write
+            // site to co-locate with the declarer. Emitting
+            // `EagerRebind` here would force the *caller* into the
+            // co-location unit too, rejecting realizable shapes
+            // (`c.bump(1)` calling a co-located setter).
+            for target_binding in closure_reads.iter().chain(closure_rebinds.iter()) {
+                if target_is_hoisted(target_binding) {
+                    continue;
+                }
+                let Some(target_owner) = binding_owner.get(target_binding) else {
+                    continue;
+                };
+                if caller == *target_owner || !promoted_read_targets.insert(*target_owner) {
+                    continue;
+                }
+                raw_edges.push((
+                    caller,
+                    *target_owner,
+                    EdgeReason::eager_use(stmt.ordinal, target_binding.clone())
+                        .promoted_at_init(caller),
+                ));
+            }
+        }
+    }
+}
+
+/// Conservative fallback for at-init calls promotion can't resolve
+/// (member calls, IIFEs, aliases, tagged templates, calls into
+/// functions whose own bodies contain such calls).
+///
+/// Premise: whatever function value an unresolvable at-init call
+/// invokes, it must have reached the call site through one of the
+/// bindings the call expression mentions (callee root, arguments,
+/// computed keys) or through an inline function expression at the
+/// call. Each such "root" owner is expanded to the **full lazy
+/// closure** of every owner reachable from it through the chunk's
+/// read graph: edges `O → owner(b)` for every chunk binding `b` the
+/// owner `O` reads (eagerly or lazily), with every reachable owner
+/// contributing its `lazy_reads` / `lazy_rebinds` at any nesting
+/// depth. The caller statement then eagerly depends on every
+/// collected target.
+///
+/// Documented residual preconditions (see docs/design.md "At-init
+/// call promotion" → Limitations): function values that reach the
+/// call site through global/object property stashes, through rebound
+/// bindings (`let g; g = readB; g()`), through parameters of
+/// chunk-declared functions (`function h(cb) { cb(); }`), via `new`,
+/// or from other chunks are not modelled.
+///
+/// Fallback-only edges carry `EdgeRole::PromotedAtInit` with
+/// `callee_owner = caller`, so neither projection view ever drops
+/// them — there is no precisely-known callee module whose evaluation
+/// could make the constraint redundant.
+struct UnresolvedCallFallback {
+    scc_of: BTreeMap<OwnerId, usize>,
+    scc_reads: Vec<BTreeSet<Id>>,
+    scc_rebinds: Vec<BTreeSet<Id>>,
+}
+
+impl UnresolvedCallFallback {
+    fn build(facts: &[StatementFacts], binding_owner: &HashMap<Id, OwnerId>) -> Self {
+        let mut read_graph: DiGraphMap<OwnerId, ()> = DiGraphMap::new();
+        for stmt in facts {
+            let owner = OwnerId(stmt.ordinal.0);
+            read_graph.add_node(owner);
+            for id in stmt.eager_reads.iter().chain(stmt.lazy_reads.iter()) {
+                if let Some(&target) = binding_owner.get(id) {
+                    read_graph.add_edge(owner, target, ());
+                }
+            }
+        }
+        let mut stmt_by_owner: BTreeMap<OwnerId, &StatementFacts> = BTreeMap::new();
+        for stmt in facts {
+            stmt_by_owner.insert(OwnerId(stmt.ordinal.0), stmt);
+        }
+        let sccs = tarjan_scc(&read_graph);
+        let mut scc_of: BTreeMap<OwnerId, usize> = BTreeMap::new();
+        for (idx, scc) in sccs.iter().enumerate() {
+            for owner in scc {
+                scc_of.insert(*owner, idx);
+            }
+        }
+        let mut scc_reads: Vec<BTreeSet<Id>> = vec![BTreeSet::new(); sccs.len()];
+        let mut scc_rebinds: Vec<BTreeSet<Id>> = vec![BTreeSet::new(); sccs.len()];
+        for (scc_idx, scc) in sccs.iter().enumerate() {
+            let mut reads: BTreeSet<Id> = BTreeSet::new();
+            let mut rebinds: BTreeSet<Id> = BTreeSet::new();
+            for owner in scc {
+                let Some(stmt) = stmt_by_owner.get(owner) else {
+                    continue;
+                };
+                for id in &stmt.lazy_reads {
+                    if binding_owner.contains_key(id) {
+                        reads.insert(id.clone());
+                    }
+                }
+                for id in &stmt.lazy_rebinds {
+                    if binding_owner.contains_key(id) {
+                        rebinds.insert(id.clone());
+                    }
+                }
+            }
+            for owner in scc {
+                for (_, target, _) in read_graph.edges(*owner) {
+                    let Some(&target_scc) = scc_of.get(&target) else {
+                        continue;
+                    };
+                    if target_scc == scc_idx {
+                        continue;
+                    }
+                    reads.extend(scc_reads[target_scc].iter().cloned());
+                    rebinds.extend(scc_rebinds[target_scc].iter().cloned());
+                }
+            }
+            scc_reads[scc_idx] = reads;
+            scc_rebinds[scc_idx] = rebinds;
+        }
+        Self {
+            scc_of,
+            scc_reads,
+            scc_rebinds,
+        }
+    }
+
+    fn closures_for(&self, owner: OwnerId) -> (&BTreeSet<Id>, &BTreeSet<Id>) {
+        static EMPTY: std::sync::OnceLock<BTreeSet<Id>> = std::sync::OnceLock::new();
+        let empty = EMPTY.get_or_init(BTreeSet::new);
+        match self.scc_of.get(&owner) {
+            Some(&idx) => (&self.scc_reads[idx], &self.scc_rebinds[idx]),
+            None => (empty, empty),
         }
     }
 }
@@ -1135,6 +1421,23 @@ pub(crate) fn partition_endpoints(
     let from = partition.of(edge.from);
     let to = partition.of(edge.to);
     if from == to {
+        return None;
+    }
+    // Fallback-promoted edges (marked by `callee_owner == edge.from`,
+    // see `UnresolvedCallFallback`) record "this statement's
+    // unresolvable at-init call may invoke chunk functions reading
+    // `to`'s bindings". When the caller lands in residual, the
+    // constraint is vacuous: residual is the ESM DFS root and its
+    // body runs only after every transitively-imported module has
+    // fully evaluated, so no at-init call from residual code can
+    // observe a TDZ. Dropping the edge in BOTH views also keeps the
+    // gate's assumed I-topology in sync with the emitter, which
+    // emits phantom side-effect imports for moved modules but not
+    // for entry.
+    if let EdgeRole::PromotedAtInit { callee_owner } = edge.reason.role
+        && callee_owner == edge.from
+        && from == partition.residual()
+    {
         return None;
     }
     if view == EndpointView::Lenient

--- a/devinfra/js/debundle/lowering/chunk_ast.rs
+++ b/devinfra/js/debundle/lowering/chunk_ast.rs
@@ -186,6 +186,17 @@ pub(super) fn top_level_declaration_names(item: &ModuleItem) -> (Vec<String>, bo
         ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(export_decl)) => {
             (declaration_names(&export_decl.decl), true)
         }
+        // `var`s hoist to module scope out of `try`/`if`/loop blocks;
+        // the enclosing statement is the declarer. Keeps
+        // `declaration_by_name` in sync with the analyzer's
+        // `collect_declared_names`.
+        ModuleItem::Stmt(stmt) => (
+            binding_targets::hoisted_var_ids(stmt)
+                .iter()
+                .map(|(atom, _)| atom.to_string())
+                .collect(),
+            false,
+        ),
         _ => (Vec::new(), false),
     }
 }
@@ -196,6 +207,7 @@ pub(super) fn top_level_declaration_ids(item: &ModuleItem) -> Vec<Id> {
         ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(export_decl)) => {
             declaration_ids(&export_decl.decl)
         }
+        ModuleItem::Stmt(stmt) => binding_targets::hoisted_var_ids(stmt),
         _ => Vec::new(),
     }
 }

--- a/devinfra/js/debundle/lowering/exports.rs
+++ b/devinfra/js/debundle/lowering/exports.rs
@@ -307,6 +307,7 @@ pub(super) fn auto_grown_residual_exports(
     pre_existing_entry_exports: &HashSet<Id>,
     pre_existing_public_export_names: &HashSet<String>,
     entry_renames: &BTreeMap<String, String>,
+    entry_declared_names: &HashSet<String>,
 ) -> BTreeMap<String, String> {
     let mut needed = BTreeSet::<String>::new();
     // `body_facts_by_module` is precomputed once upstream (see
@@ -345,14 +346,28 @@ pub(super) fn auto_grown_residual_exports(
     let mut taken_public_names = pre_existing_public_export_names.clone();
     needed
         .into_iter()
-        .map(|name| {
+        .filter_map(|name| {
             let final_local = entry_renames
                 .get(&name)
                 .cloned()
                 .unwrap_or_else(|| name.clone());
+            // Only grow exports for bindings the final entry body
+            // actually declares. A chunk-declared binding whose
+            // declaring statement was claimed into a non-entry
+            // module (e.g. a block-hoisted `var` inside an
+            // anonymously-claimed `try` statement) can't be
+            // mediated through entry — growing `export { name }`
+            // here would emit a SyntaxError-at-load entry module.
+            // Skipping leaves the reference in
+            // `missing_residual_exports`, which
+            // `residual_entry_imports_for_moved_body` rejects
+            // loudly instead of emitting broken JS.
+            if !entry_declared_names.contains(&final_local) {
+                return None;
+            }
             let public_name =
                 import_emit::mint_unique_name(&name, |n| taken_public_names.insert(n.to_string()));
-            (final_local, public_name)
+            Some((final_local, public_name))
         })
         .collect()
 }

--- a/devinfra/js/debundle/lowering/lower.rs
+++ b/devinfra/js/debundle/lowering/lower.rs
@@ -395,6 +395,10 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
         // by construction (see docs/design.md "Valid peels and atomic
         // modules", importability clause). The grow set excludes
         // names already in entry's source-level exports.
+        let entry_declared_names: HashSet<String> = entry_body
+            .iter()
+            .flat_map(|item| top_level_declaration_names(item).0)
+            .collect();
         let auto_grow = auto_grown_residual_exports(
             &body_facts_by_module,
             declaration_by_name,
@@ -402,6 +406,7 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
             pre_existing_entry_exports,
             pre_existing_public_export_names,
             &entry_binding_renames,
+            &entry_declared_names,
         );
         if !auto_grow.is_empty() {
             entry_body.push(export_named_for_bindings(&auto_grow));

--- a/devinfra/js/debundle/lowering/materialize/mod.rs
+++ b/devinfra/js/debundle/lowering/materialize/mod.rs
@@ -169,6 +169,7 @@ pub(super) fn materialize_logical_chunk(
     drop(imported_binding_resolver);
     builder.drop_explicit_request_scratch();
     builder.pull_destructure_siblings(&destructure_siblings, chunk_top_level_mark)?;
+    builder.adopt_bindings_of_claimed_anonymous_statements(&declarations);
     builder.add_residual_sweep(
         residual_request.as_ref(),
         chunk_unassigned_mode.catchall_file_target(),

--- a/devinfra/js/debundle/lowering/materialize/plan_builder.rs
+++ b/devinfra/js/debundle/lowering/materialize/plan_builder.rs
@@ -333,6 +333,39 @@ impl ChunkPlanBuilder {
         Ok(())
     }
 
+    /// Bindings declared by an anonymously-claimed statement (e.g. a
+    /// block-hoisted `var` inside a claimed `try` statement) belong
+    /// to the module that claims the statement: the declaration is
+    /// emitted there, so binding ownership, exports, and
+    /// cross-module import wiring must follow it. Runs before the
+    /// residual sweep so the sweep doesn't route these bindings to
+    /// the catchall while their declaring statement lives elsewhere
+    /// (which emitted an `export { name }` whose declaration is in a
+    /// different file — a SyntaxError at load).
+    pub(super) fn adopt_bindings_of_claimed_anonymous_statements(
+        &mut self,
+        declarations: &[TopLevelDecl],
+    ) {
+        for decl in declarations {
+            let Some(&plan_index) = self.anonymous_ordinal_assignment.get(&decl.ordinal) else {
+                continue;
+            };
+            let module = ModuleId(LogicalModuleIndex(plan_index));
+            for (name, id) in &decl.bindings {
+                if self.binding_assignment.contains_key(id) {
+                    continue;
+                }
+                self.binding_assignment.insert(id.clone(), plan_index);
+                self.module_plans[plan_index]
+                    .bindings
+                    .entry(name.clone())
+                    .or_insert_with(|| name.clone());
+                self.bindings_catalogue
+                    .insert(id.clone(), BindingKind::Owned { module });
+            }
+        }
+    }
+
     /// Residual sweep: route every chunk top-level binding the spec
     /// did not claim to the chunk's catchall destination.
     ///

--- a/devinfra/js/debundle/lowering/mod.rs
+++ b/devinfra/js/debundle/lowering/mod.rs
@@ -55,7 +55,7 @@ use anonymous::resolve_anonymous_statement_ordinals;
 use body_facts::{ModuleBodyFacts, collect_module_body_facts};
 use chunk_ast::{
     ChunkAstAnalysis, TopLevelDecl, analyze_chunk_ast, binding_ids, binding_names, declaration_ids,
-    declaration_names, top_level_declaration_ids,
+    declaration_names, top_level_declaration_ids, top_level_declaration_names,
 };
 use chunk_renames::collect_chunk_renames;
 use exports::{

--- a/devinfra/js/debundle/lowering/util.rs
+++ b/devinfra/js/debundle/lowering/util.rs
@@ -153,7 +153,7 @@ pub(super) fn render_atomic_unit_cause_guidance(conflicts: &[AtomicUnitConflict]
                 "EagerUse cycle: a top-level statement reads a binding at-init; \
                  splitting reader and declarer across modules forms an evaluation-order cycle. "
             }
-            DepKind::EagerRebind | DepKind::LazyRebind => {
+            DepKind::EagerRebind | DepKind::LazyRebind | DepKind::DeferredRebind => {
                 "Rebind: a function or top-level statement performs an assignment \
                  to a mutable binding owned by a different module — the resulting ESM \
                  import would be read-only, so this cross-destination assignment is invalid. \

--- a/devinfra/js/debundle/peel/quotient.rs
+++ b/devinfra/js/debundle/peel/quotient.rs
@@ -358,7 +358,7 @@ fn edge_weight(kind: DepKind) -> u32 {
     match kind {
         DepKind::EagerUse | DepKind::EagerRebind => 4,
         DepKind::Sequenced => 2,
-        DepKind::LazyUse | DepKind::LazyRebind => 1,
+        DepKind::LazyUse | DepKind::LazyRebind | DepKind::DeferredRebind => 1,
         DepKind::LocalEffect => 2,
     }
 }

--- a/devinfra/js/debundle/stage_one/rebind_fold.rs
+++ b/devinfra/js/debundle/stage_one/rebind_fold.rs
@@ -96,10 +96,12 @@ pub fn compute_rebind_folds(
         if unit.causes.is_empty() {
             continue;
         }
-        let rebind_only = unit
-            .causes
-            .iter()
-            .all(|cause| matches!(cause, DepKind::LazyRebind | DepKind::EagerRebind));
+        let rebind_only = unit.causes.iter().all(|cause| {
+            matches!(
+                cause,
+                DepKind::LazyRebind | DepKind::EagerRebind | DepKind::DeferredRebind
+            )
+        });
         if !rebind_only {
             continue;
         }

--- a/devinfra/js/debundle/validation.rs
+++ b/devinfra/js/debundle/validation.rs
@@ -309,6 +309,7 @@ fn dep_kind_short(kind: DepKind) -> &'static str {
         DepKind::LazyUse => "lazy",
         DepKind::EagerRebind => "at-init rebind",
         DepKind::LazyRebind => "lazy rebind",
+        DepKind::DeferredRebind => "deferred rebind",
         DepKind::Sequenced => "side-effect",
         DepKind::LocalEffect => "local-effect",
     }

--- a/devinfra/js/debundle/vendor/strip.rs
+++ b/devinfra/js/debundle/vendor/strip.rs
@@ -1107,6 +1107,10 @@ struct ItemAnalysis {
     /// Outer-observable storage cells this statement writes at-init
     /// (binding rebinds and static-key `globalThis.<prop>` writes).
     /// Empty/incomplete unless `effects_summarizable` is true.
+    /// Carries the WRITE-cell view (`cell_writes_summarizable`):
+    /// the strip's call side effects are covered by its own
+    /// island-reachability analysis, so the S-chain's stronger
+    /// opaque-call bail does not apply here.
     observable_writes: BTreeSet<EffectCell>,
     /// False when the statement contains a shape the analyzer cannot
     /// statically summarize (dynamic `globalThis[expr]`, `with`,
@@ -1172,7 +1176,7 @@ fn item_analysis_from_fact(item: &ModuleItem, fact: &StatementFacts) -> ItemAnal
         side_effect,
         shareable_helper: item_is_shareable_helper(item),
         observable_writes: fact.effects.writes.clone(),
-        effects_summarizable: fact.effects.dataflow_summarizable,
+        effects_summarizable: fact.effects.cell_writes_summarizable,
     }
 }
 


### PR DESCRIPTION
Closes a set of under-restriction soundness holes in the debundler's fact extraction (`facts/mod.rs`) and side-effect chain (`graph.rs`): shapes where the validator accepted a spec whose emitted bundle misbehaves at runtime. Every hole landed with a minimal e2e fixture verified red against the pre-fix tree (BuildBuddy invocation `21e63e08-2390-41e3-8cc3-a314aec3c25d` shows all five new test targets failing pre-fix; the two reshaped hoisted-`var` fixtures were re-verified red via stash in `redcheck` runs).

## Strict path (always-on analyses)

### 1. At-init promotion: unresolvable callees silently skipped

**Counterexample (gate-accepted, runtime TDZ):** mod_a: `const A = 1; function readB(){return B;} const g = readB; const r = g();` / mod_b: `const B = A + 1;` — asymmetric I-cycle, the simulator accepted it, `g()` threw `ReferenceError` under node. Method-call variant: `const api = { read: () => B }; api.read();`. `at_init_calls` recorded only bare-`Ident` callees (so `api.read()` was invisible), and promotion `continue`d on callees that didn't resolve to a chunk function (so the alias `g` was skipped). design.md's claimed "validator's strict rule" safety net did not exist.

**Fix (task option (a)+(b) hybrid):** a callee is *precisely resolvable* only when its binding is declared directly as a function value (`function f`, single-declarator `const f = () => …`) and never rebound. Everything else takes a conservative fallback: the statement eagerly depends on the full lazy closures of every owner reachable (through the chunk's read graph) from the bindings the unresolved call mentions — callee root, arguments, computed keys — plus the statement's own closures when the call carries an inline function (IIFE, `arr.forEach(x => …)`). The fallback propagates transitively through the promotion call graph (a resolvable callee whose body contains an unresolved call escalates its at-init callers). Two deliberate scoping decisions that need a maintainer eye:

- **Fallback rebind targets get order-only `EagerUse` edges**, not `EagerRebind`: write legality is already enforced by the direct `LazyRebind`/`DeferredRebind` edge from the statement lexically containing the write; emitting `EagerRebind` from the *caller* forced the call site into the co-location unit and rejected realizable pinned shapes (`accepted_spec_runs_under_node_test::peeled_method_reassigning_top_level_let`).
- **Fallback edges sourced in residual are dropped at partition projection** (`partition_endpoints`): residual is the ESM DFS root and evaluates last, so an at-init call from residual code cannot observe a TDZ — and the emitter emits no entry-side phantom imports, so keeping these edges would feed the Pass-2 simulator an I-topology the emitted bundle doesn't have (it flipped `mediator_reaches_asymmetric_cycle_test` from reject to accept while the bundle still TDZ'd). Marked by the `PromotedAtInit { callee_owner == from }` convention.

Residual unmodelled channels (global stashes, rebound bindings, function parameters, `new`, cross-chunk) are now documented as preconditions in design.md's Limitations, replacing the dangling claim.

Tests: `e2e/at_init_unresolved_callee_test.rs` (alias + method-call rejections, acyclic green companion).

### 2. Nested-closure rebinds never reached cross-rebind rejection

Only `first_order_lazy_rebinds` emitted edges; a rebind two closures deep (`globalThis.__updateState = () => { state = "updated" }`) emitted nothing, so the split spec was accepted and the emitted bundle threw `TypeError` the moment the stored closure ran — the ESM read-only-imports rule is time-independent. New `DepKind::DeferredRebind` participates in cross-destination-rebind rejection (`is_rebind()`) and bidirectional `G_atomic` co-location, but **not** in init-order constraints (`constrains_init_order() == false`) or the I-graph — preserving the original purpose of the nested-closure narrowing (no manufactured init-order constraints; post-await test still green).

Tests: reworked `e2e/at_init_promotion_nested_closure_test.rs` — split spec now rejected; co-located spec green with a post-init `assert_generated_module_after_entry_script` probe observing the update through the live export binding; the init-order contract retained via a nested-*read* fixture with a post-init probe.

### 3. Block-hoisted `var` declarations were invisible

`try { var impl = "primary"; } catch (e) { var impl = "fallback"; }` declared `impl` invisibly: readers got no owner edge and no import wiring (runtime `ReferenceError`), and `try { var Math = shim; } catch {}` defeated the A8 shadowed-globals computation (`Math.PI` still classified as the pristine whitelisted global). Fix: shared `binding_targets::hoisted_var_ids` (function/arrow/accessor/class boundaries) feeds `collect_declared_names`, the shadowed-globals set, and the lowering side's `declaration_by_name`. Two emission-side consequences: bindings declared by anonymously-claimed statements now follow the claiming module (`adopt_bindings_of_claimed_anonymous_statements` — ownership, exports, cross-module imports), and the auto-grow pass only grows entry exports for names the final entry body actually declares (previously it could emit `export { impl }` with no backing declaration — SyntaxError at load). The `compute_shadowed_globals` edit is just the hoist-aware feed via `collect_declared_names`, per the parallel-branch constraint.

Tests: `e2e/hoisted_var_declaration_test.rs` (split reader wired end-to-end; co-located green; `Math.PI` shim variant rejected).

### 4. `export default` purity

`classify_item` maps non-`ExportDecl` module decls to `Export` and `item_purity` mapped `Export → Pure`, so `export default sideEffect()` and `export default class C { static { … } }` dropped out of the S-chain and other modules' statements reordered around them. `ExportDefaultExpr` now routes through `classify_expr_purity`, `ExportDefaultDecl(Class)` through `class_has_static_observable`.

Tests: `e2e/export_default_purity_test.rs` (both shapes rejected when the restored edge is unsatisfiable; green companion pinning preserved `SCZ` ordering).

## Dataflow-aware S-chain (opt-in mode)

### 5. Write-after-read edges

Last-writer-only tracking missed WAR: `globalThis.flag = "first"; const snapshot = globalThis.flag; globalThis.flag = "second";` let the second writer schedule before the reader. `emit_s_chain` now tracks `readers_since_last_write` per cell; a writer sequences after every reader since the cell's last write.

### 6. Opaque calls

Any at-init call / `new` / optional call / tagged template the purity classifier does **not** prove `Pure` flips `dataflow_summarizable = false` (policy-phase check, so classifier-Pure calls — whitelists, `pure`/`pure_new` annotations, recursively-pure chunk functions — stay summarizable). This covers `console.log` pairs (I/O isn't a cell), `function f(){globalThis.x=1} f();` (the depth-0-gated cell recorder can't see callee bodies), and subsumes indirect `(0, eval)(…)`. This deliberately degrades the optimization for call-heavy code — documented honestly in README. The pinned constructor-call test was updated accordingly (`unproven_constructor_calls_keep_conservative_s_edge`): `new <chunk class>` is `UnknownNew` without a `pure_new` annotation, so it keeps the conservative edge by design.

### 7. Member/update writes and globalThis aliasing

`obj.x = 1` recorded only a read of `obj`; `globalThis.count++` recorded no write; `const g = globalThis; g.tag = "x"` escaped entirely. Now: member writes through bindings (including destructuring targets like `[obj.x] = arr` and paren/opt-chain forms) bail the statement; update-exprs on global props record write+read cells; a bare global-object alias used as a value taints the bindings it flows into (transitive fixpoint) and statements reading suspects bail.

### 8. window/self

Unshadowed `window`/`self`/`frames`/`top` now share `globalThis`'s cell namespace and bail shapes (README claimed this; the code only matched the literal `globalThis`). Chunk-top-level declarations or imports of those names disable the global treatment. Indirect eval needed no `strip_parens` semantics change — the opaque-call rule subsumes it for the S-chain, and a local `callee_base_expr` helper (parens + comma sequences) feeds the structural eval/Function check.

**Vendor strip interaction:** the strip's swap-privacy gate consumed `dataflow_summarizable` with narrower "which cells does this *write*" semantics; the opaque-call bail would have rejected its pinned droppable-island fixtures. The bit is split: structural `cell_writes_summarizable` (old semantics + indirect eval, for the strip) vs. `dataflow_summarizable` (S-chain, with items 6–8). The strip's global-prop-write-via-alias blind spot is pre-existing and out of scope here.

Tests: `e2e/s_chain_dataflow_soundness_test.rs` (8 fixtures: WAR, console pairs, body global writes, member writes, update-exprs, alias reads, window, indirect eval — each with an owner-graph `Sequenced`-edge assertion plus a runtime output check).

## Docs

README's "Conditionally-correct optimizations" precondition list rewritten to exactly match the implemented checks; design.md's emission-modes section synced (WAR rule, bail list, global aliases) and the at-init promotion section rewritten (resolvable-callee rule, fallback, honest residual limitations).

## Not done (follow-ups)

- Duplicate top-level declarations still last-insert-win in `build_owner_graph_with`'s `binding_owner` map (graph.rs).
- `OwnerGraph::from_report` still silently `continue`s on edges whose endpoints don't resolve.

## Verification

- `bbr test //devinfra/js/debundle/...` — 86/86 green (`e1bcd3b9-53d5-45bb-96aa-94be9792b008`).
- `bbr build //props/frontend/...` — green (no in-repo `debundle_pipeline` consumer exists on this branch; the props/frontend debundle corpus described in AGENTS.md is not present here, so the private-corpus smoke remains for the maintainer).
- Red-first verification: `21e63e08-2390-41e3-8cc3-a314aec3c25d` (all new fixtures failing pre-fix, for the documented reasons).

https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk)_