### PR TITLE
loom/gym: in-cluster eval on docker-ci (driver image + mitmproxy passthrough)

### DIFF
--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -22,6 +22,7 @@ on:
       - "skills/freecad/Dockerfile.test"
       - "third_party/kubernetes-mcp-server-pin.txt"
       - "x/rtl_tcp/Dockerfile"
+      - "loom/gym/sandbox/**"
       - ".github/workflows/container-images.yml"
   workflow_dispatch:
 
@@ -129,6 +130,25 @@ jobs:
           context: x/rtl_tcp
           cache_from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/rtl-tcp:buildcache
           cache_to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/rtl-tcp:buildcache,mode=max
+
+  loom-gym-sandbox:
+    name: Loom Gym Sandbox
+    # The forecasting-eval agent environment (interactive python3 + sci toolkit).
+    # A Dockerfile rather than an oci_image because the agent shells into a general
+    # python env, not a single py_binary. The in-cluster eval Job pulls this from
+    # GHCR and tags it loom-gym-sandbox:latest into the docker-ci daemon.
+    if: github.ref_name == 'devel'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
+
+      - uses: ./.github/actions/ghcr-build-push
+        with:
+          image: ghcr.io/${{ github.repository_owner }}/loom-gym-sandbox
+          context: loom/gym/sandbox
 
   # `pin-digests` pushes via the ducktape-automation GitHub App so the commit
   # bypasses the main-protection ruleset (github-actions can't bypass on

--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -127,6 +127,10 @@ jobs:
               test_target: "//finance/beancount_export/...",
             }
           - { image: "//x/study_casino:image", image_name: study-casino, test_target: "//x/study_casino/..." }
+          - { image: "//loom/gym:eval_image", image_name: loom-gym-eval, test_target: "//loom/gym/..." }
+          # Wayback MITM proxy sidecar: the in-cluster eval driver pulls this from
+          # GHCR and tags it wayback-proxy:latest into the docker-ci daemon.
+          - { image: "//loom/wayback_proxy:image", image_name: wayback-proxy, test_target: "//loom/wayback_proxy/..." }
           # Untested images: always-push if content changed. Explicit
           # `test_target: ""` so the `matrix.test_target != ''` check on
           # the test step evaluates the same as on test-gated rows —

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -82,6 +82,7 @@ tf.download(
         "authentik": "goauthentik/authentik:2026.2.0",
         "aws": "hashicorp/aws:5.100.0",
         "external": "hashicorp/external:2.3.5",
+        "flux": "fluxcd/flux:1.7.6",
         "forgejo": "svalabs/forgejo:1.5.0",
         "github": "integrations/github:6.6.0",
         "grafana": "grafana/grafana:3.22.2",
@@ -340,7 +341,18 @@ apt.install(
     lock = "//finance/scraper:trixie_evidence.lock.json",
     manifest = "//finance/scraper:trixie_evidence.yaml",
 )
-use_repo(apt, "bookworm_cpap_sync", "bookworm_fc_vm_pod", "gnome_shell_test", "trixie_attic_rotation", "trixie_budget_exporter", "trixie_e2e", "trixie_evidence", "trixie_jwt_rotation")
+
+# loom/gym forecasting-eval driver: ca-certificates on debian:bookworm-slim so
+# `import pygit2` (via finance.evidence.checkout) can initialize libgit2's
+# OpenSSL cert locations — it fails the whole process at import without a system
+# CA bundle. (The docker CLI + compose plugin come from upstream static binaries,
+# not apt; see //loom/gym:BUILD.bazel.)
+apt.install(
+    name = "bookworm_loom_gym_eval",
+    lock = "//loom/gym:bookworm_loom_gym_eval.lock.json",
+    manifest = "//loom/gym:bookworm_loom_gym_eval.yaml",
+)
+use_repo(apt, "bookworm_cpap_sync", "bookworm_fc_vm_pod", "bookworm_loom_gym_eval", "gnome_shell_test", "trixie_attic_rotation", "trixie_budget_exporter", "trixie_e2e", "trixie_evidence", "trixie_jwt_rotation")
 
 # JavaScript/TypeScript (Node.js frontends)
 bazel_dep(name = "aspect_bazel_lib", version = "2.22.5")
@@ -893,15 +905,29 @@ http_file(
     urls = ["https://github.com/bazelbuild/bazelisk/releases/download/v1.25.0/bazelisk-linux-amd64"],
 )
 
-# Bazel 8.6.0 linux-amd64 — prepopulates Bazelisk's cache in the claude-hook
-# container E2E image so the nested `bazelisk build //:hello` does not fetch
-# from releases.bazel.build at test runtime.
+# Docker CLI (static binaries) + `docker compose` v2 plugin for the loom/gym
+# eval driver image. Inspect-AI's docker sandbox provider shells out to the
+# `docker` CLI and the `docker compose` plugin, neither of which Debian packages
+# as a v2 plugin (docker.io ships only the CLI/daemon; there is no
+# docker-compose-v2 in Debian main). Fetch the upstream static builds instead.
+# The tarball also bundles dockerd/containerd/runc; only `docker` is used here
+# (the eval talks to a remote daemon via $DOCKER_HOST), and //loom/gym packages
+# just the CLI into the image layer.
+http_archive(
+    name = "docker_cli_static",
+    build_file_content = 'exports_files(["docker/docker"])',
+    sha256 = "34eea64e9c3435f5af1b760827a56a561cd67fc2d6e9cd1813b8bb1e3ff7930b",
+    urls = ["https://download.docker.com/linux/static/stable/x86_64/docker-29.5.3.tgz"],
+)
+
+# docker compose v2 plugin binary — installed at the cli-plugins path so
+# `docker compose ...` resolves it.
 http_file(
-    name = "bazel_8_6_0_linux_amd64",
-    downloaded_file_path = "bazel",
+    name = "docker_compose_plugin",
+    downloaded_file_path = "docker-compose",
     executable = True,
-    sha256 = "9860da9c9386bbc023feed8f43af3105d338727d77b644fa6aeca45a4a11957c",
-    urls = ["https://releases.bazel.build/8.6.0/release/bazel-8.6.0-linux-x86_64"],
+    sha256 = "bd5835ccbbf06a42dcb5294c65e34a4634b34447afb9ed6fc7adf18a000e0f99",
+    urls = ["https://github.com/docker/compose/releases/download/v2.40.0/docker-compose-linux-x86_64"],
 )
 
 # Firecracker v1.12.1 — microVM VMM binary for Firecracker dev VMs on wyrm2.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -930,6 +930,17 @@ http_file(
     urls = ["https://github.com/docker/compose/releases/download/v2.40.0/docker-compose-linux-x86_64"],
 )
 
+# Bazel 8.6.0 linux-amd64 — prepopulates Bazelisk's cache in the claude-hook
+# container E2E image so the nested `bazelisk build //:hello` does not fetch
+# from releases.bazel.build at test runtime.
+http_file(
+    name = "bazel_8_6_0_linux_amd64",
+    downloaded_file_path = "bazel",
+    executable = True,
+    sha256 = "9860da9c9386bbc023feed8f43af3105d338727d77b644fa6aeca45a4a11957c",
+    urls = ["https://releases.bazel.build/8.6.0/release/bazel-8.6.0-linux-x86_64"],
+)
+
 # Firecracker v1.12.1 — microVM VMM binary for Firecracker dev VMs on wyrm2.
 # The tarball contains the firecracker binary + jailer + tools. We extract
 # just the firecracker binary in devinfra/firecracker/BUILD.bazel.

--- a/cluster/k8s/agents/mitmproxy/ccnp-sandbox-proxy-egress.yaml
+++ b/cluster/k8s/agents/mitmproxy/ccnp-sandbox-proxy-egress.yaml
@@ -2,6 +2,18 @@
 # Allows: DNS, cluster-internal traffic, kube-apiserver, mitmproxy port 8080.
 # Blocks: direct external internet access.
 #
+# KNOWN GAP (intentionally left open for now; may be closed later):
+# This constrains egress from the sandbox *pods*, but not what a sandboxed agent
+# can launch elsewhere. Cluster-internal traffic is allowed (below), so an agent
+# that can reach the docker-ci DinD — and obtain its mTLS client cert — can
+# `docker run` a container there whose egress is NOT forced through mitmproxy.
+# Such a container has unrestricted internet access, so a sandboxed agent can use
+# it to fetch/exfiltrate outside the proxy, defeating this egress control. Closing
+# it means either denying sandbox pods access to docker-ci, or running agent
+# workloads on a locked-down "docker-for-agents" daemon that forces every
+# container's egress through mitmproxy. See also loom/gym/TODO.md (the loom eval's
+# per-sandbox archive clamp rests on the same assumption).
+#
 # To add a new sandbox namespace, add it to the namespaces list below
 # and add the corresponding mitmproxy-ca-cert SOPS secret + Kyverno
 # injection (already handled by inject-mitmproxy ClusterPolicy).

--- a/cluster/k8s/agents/mitmproxy/cnp-cloud-api-egress.yaml
+++ b/cluster/k8s/agents/mitmproxy/cnp-cloud-api-egress.yaml
@@ -44,3 +44,13 @@ spec:
               protocol: TCP
             - port: "8080"
               protocol: TCP
+    # The loom/gym eval driver (in claude-sandbox) reaches the docker-ci DinD by
+    # its public name through this proxy, which raw-tunnels it (ignore_hosts in
+    # deployment.yaml) so docker mTLS passes end-to-end. Allow mitmproxy to reach
+    # the daemon's mTLS port to establish that CONNECT tunnel.
+    - toFQDNs:
+        - matchName: docker-ci.allegedly.works
+      toPorts:
+        - ports:
+            - port: "2376"
+              protocol: TCP

--- a/cluster/k8s/agents/mitmproxy/deployment.yaml
+++ b/cluster/k8s/agents/mitmproxy/deployment.yaml
@@ -48,6 +48,13 @@ spec:
             - "8081"
             - --set
             - confdir=/mitmproxy-data
+            # Raw-tunnel the docker-ci DinD mTLS endpoint instead of intercepting
+            # it: the loom/gym eval driver in claude-sandbox reaches the daemon by
+            # its public name through this proxy, and docker mTLS must pass
+            # end-to-end (interception would break the client-cert handshake). The
+            # sandbox-escape implication is documented in ccnp-sandbox-proxy-egress.yaml.
+            - --ignore-hosts
+            - docker-ci\.allegedly\.works
           ports:
             - name: proxy
               containerPort: 8080

--- a/loom/gym/BUILD.bazel
+++ b/loom/gym/BUILD.bazel
@@ -127,6 +127,8 @@ py_library(
 py_library(
     name = "inspect_harness",
     srcs = ["inspect_harness.py"],
+    # Embedded verbatim into the agent system prompt (see _SANDBOX_DOCKERFILE).
+    data = ["sandbox/Dockerfile"],
     deps = [
         ":baseline_llm",
         ":dossier",

--- a/loom/gym/BUILD.bazel
+++ b/loom/gym/BUILD.bazel
@@ -1,27 +1,20 @@
+load("@aspect_rules_py//py:defs.bzl", "py_image_layer", aspect_py_binary = "py_binary")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//devinfra/python:defs.bzl", "py_binary", "py_library", "py_test")
+load("//props:oci.bzl", "py_image_entrypoint", "py_image_env")
+
+# Apt manifest + lockfile for rules_distroless (referenced from MODULE.bazel).
+exports_files([
+    "bookworm_loom_gym_eval.yaml",
+    "bookworm_loom_gym_eval.lock.json",
+])
 
 # keep
 py_binary(
     name = "compare_eval_runs",
     main_module = "loom.gym.compare_runs",
     deps = [":compare_runs"],
-)
-
-py_library(
-    name = "analyze_baselines",
-    srcs = ["analyze_baselines.py"],
-    deps = [
-        ":market_seed_tasks",
-        ":scoring",
-        "@pypi//inspect_ai",
-        "@pypi//matplotlib",
-    ],
-)
-
-py_binary(
-    name = "analyze_baselines_bin",
-    main_module = "loom.gym.analyze_baselines",
-    deps = [":analyze_baselines"],
 )
 
 # keep
@@ -367,4 +360,64 @@ py_test(
         "@pypi//pyyaml",
         "@pypi//types_pyyaml",
     ],
+)
+
+# ── OCI image (driver for the in-cluster forecasting-eval Job) ────────────────
+#
+# Bundles the Python eval driver with the `docker` CLI + `docker compose` v2
+# plugin (upstream static binaries; see @docker_cli_static / @docker_compose_plugin
+# in MODULE.bazel). Inspect-AI's docker sandbox provider shells out to both to
+# spin up docker-compose sandboxes on the daemon at $DOCKER_HOST.
+
+# /usr/local/bin/docker — the Docker CLI.
+pkg_tar(
+    name = "docker_cli_layer",
+    srcs = ["@docker_cli_static//:docker/docker"],
+    mode = "0755",
+    package_dir = "/usr/local/bin",
+    remap_paths = {"docker/docker": "docker"},
+)
+
+# /usr/libexec/docker/cli-plugins/docker-compose — the `docker compose` v2
+# plugin. The CLI auto-discovers plugins under this libexec path.
+pkg_tar(
+    name = "docker_compose_layer",
+    srcs = ["@docker_compose_plugin//file"],
+    mode = "0755",
+    package_dir = "/usr/libexec/docker/cli-plugins",
+    remap_paths = {"docker-compose": "docker-compose"},
+)
+
+aspect_py_binary(
+    name = "agent_eval_image_bin",
+    main = "agent_eval.py",
+    deps = [":agent_eval"],
+)
+
+py_image_layer(
+    name = "agent_eval_layers",
+    binary = ":agent_eval_image_bin",
+    group = "1000",
+    owner = "1000",
+)
+
+oci_image(
+    name = "eval_image",
+    base = "@debian_slim_linux_amd64",
+    entrypoint = py_image_entrypoint("agent_eval_image_bin"),
+    env = py_image_env(binary_name = "agent_eval_image_bin"),
+    labels = {"org.opencontainers.image.source": "https://github.com/agentydragon/ducktape"},
+    tars = [
+        "@bookworm_loom_gym_eval//:flat",
+        ":docker_cli_layer",
+        ":docker_compose_layer",
+        ":agent_eval_layers",
+    ],
+    user = "1000:1000",
+)
+
+oci_load(
+    name = "eval_load",
+    image = ":eval_image",
+    repo_tags = ["loom-gym-eval:latest"],
 )

--- a/loom/gym/TODO.md
+++ b/loom/gym/TODO.md
@@ -25,3 +25,10 @@
   network still can't reach the live internet. The per-sandbox MITM clamp then becomes
   defense-in-depth rather than the sole barrier. A per-run throwaway daemon (torn down
   after each eval) is an alternative that also bounds blast radius.
+
+- **Automate sandbox-image staging into the in-cluster eval Job.** `loom/gym/k8s/`
+  currently documents a manual step 2 (pull `wayback-proxy` from GHCR + `docker build`
+  `loom-gym-sandbox` into the docker-ci daemon before running the Job). Fold this into
+  an initContainer on `eval-job.yaml` (docker CLI + the mTLS secret), so a run is a
+  single `kubectl apply`. The sandbox Dockerfile has no local context, so
+  `docker build -t loom-gym-sandbox:latest -` from a ConfigMap-mounted Dockerfile works.

--- a/loom/gym/TODO.md
+++ b/loom/gym/TODO.md
@@ -25,10 +25,3 @@
   network still can't reach the live internet. The per-sandbox MITM clamp then becomes
   defense-in-depth rather than the sole barrier. A per-run throwaway daemon (torn down
   after each eval) is an alternative that also bounds blast radius.
-
-- **Automate sandbox-image staging into the in-cluster eval Job.** `loom/gym/k8s/`
-  currently documents a manual step 2 (pull `wayback-proxy` from GHCR + `docker build`
-  `loom-gym-sandbox` into the docker-ci daemon before running the Job). Fold this into
-  an initContainer on `eval-job.yaml` (docker CLI + the mTLS secret), so a run is a
-  single `kubectl apply`. The sandbox Dockerfile has no local context, so
-  `docker build -t loom-gym-sandbox:latest -` from a ConfigMap-mounted Dockerfile works.

--- a/loom/gym/bookworm_loom_gym_eval.lock.json
+++ b/loom/gym/bookworm_loom_gym_eval.lock.json
@@ -1,0 +1,113 @@
+{
+  "packages": [
+    {
+      "arch": "amd64",
+      "dependencies": [
+        {
+          "key": "debconf_1.5.82_amd64",
+          "name": "debconf",
+          "version": "1.5.82"
+        },
+        {
+          "key": "openssl_3.0.18-1_deb12u2_amd64",
+          "name": "openssl",
+          "version": "3.0.18-1~deb12u2"
+        },
+        {
+          "key": "libssl3_3.0.18-1_deb12u2_amd64",
+          "name": "libssl3",
+          "version": "3.0.18-1~deb12u2"
+        },
+        {
+          "key": "libc6_2.36-9-p-deb12u13_amd64",
+          "name": "libc6",
+          "version": "2.36-9+deb12u13"
+        },
+        {
+          "key": "libgcc-s1_12.2.0-14-p-deb12u1_amd64",
+          "name": "libgcc-s1",
+          "version": "12.2.0-14+deb12u1"
+        },
+        {
+          "key": "gcc-12-base_12.2.0-14-p-deb12u1_amd64",
+          "name": "gcc-12-base",
+          "version": "12.2.0-14+deb12u1"
+        }
+      ],
+      "key": "ca-certificates_20230311-p-deb12u1_amd64",
+      "name": "ca-certificates",
+      "sha256": "0d5f444f594e48c1e16a41d8fc628a09b24c658916a1274025c2330f2a802bed",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/c/ca-certificates/ca-certificates_20230311+deb12u1_all.deb"
+      ],
+      "version": "20230311+deb12u1"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "debconf_1.5.82_amd64",
+      "name": "debconf",
+      "sha256": "74ab14194a3762b2fc717917dcfda42929ab98e3c59295a063344dc551cd7cc8",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/d/debconf/debconf_1.5.82_all.deb"
+      ],
+      "version": "1.5.82"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "openssl_3.0.18-1_deb12u2_amd64",
+      "name": "openssl",
+      "sha256": "9107c374e0f760d5d7c9c7372788d4e618e1433db4fdef9a3a25788dfd5588bb",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian-security/20260301T000000Z/pool/updates/main/o/openssl/openssl_3.0.18-1~deb12u2_amd64.deb"
+      ],
+      "version": "3.0.18-1~deb12u2"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libssl3_3.0.18-1_deb12u2_amd64",
+      "name": "libssl3",
+      "sha256": "ed44f11b74763cded2ad406f4de4d585ea27b0ce6377e7c8d98c2ddf2ed35cb3",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian-security/20260301T000000Z/pool/updates/main/o/openssl/libssl3_3.0.18-1~deb12u2_amd64.deb"
+      ],
+      "version": "3.0.18-1~deb12u2"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libc6_2.36-9-p-deb12u13_amd64",
+      "name": "libc6",
+      "sha256": "3d8072c73b017e907bbf44b7db870687888a991961d74f1ecbba6b9458f32a2c",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/g/glibc/libc6_2.36-9+deb12u13_amd64.deb"
+      ],
+      "version": "2.36-9+deb12u13"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libgcc-s1_12.2.0-14-p-deb12u1_amd64",
+      "name": "libgcc-s1",
+      "sha256": "3016e62cb4b7cd8038822870601f5ed131befe942774d0f745622cc77d8a88f7",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/g/gcc-12/libgcc-s1_12.2.0-14+deb12u1_amd64.deb"
+      ],
+      "version": "12.2.0-14+deb12u1"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "gcc-12-base_12.2.0-14-p-deb12u1_amd64",
+      "name": "gcc-12-base",
+      "sha256": "1896a2aacf4ad681ff5eacc24a5b0ca4d5d9c9b9c9e4b6de5197bc1e116ea619",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/g/gcc-12/gcc-12-base_12.2.0-14+deb12u1_amd64.deb"
+      ],
+      "version": "12.2.0-14+deb12u1"
+    }
+  ],
+  "version": 1
+}

--- a/loom/gym/bookworm_loom_gym_eval.yaml
+++ b/loom/gym/bookworm_loom_gym_eval.yaml
@@ -1,0 +1,25 @@
+# Deb packages layered on debian:bookworm-slim for the loom/gym forecasting-eval
+# driver image. The eval driver imports `finance.evidence.checkout`, which
+# imports pygit2; libgit2 fails at import without a system CA bundle (it
+# initializes its OpenSSL cert locations eagerly). ca-certificates also covers
+# TLS to the LiteLLM endpoint and any registries.
+#
+# (The `docker` CLI + `docker compose` v2 plugin are NOT installed via apt:
+# Debian main has no docker-compose-v2 package, so those come from the upstream
+# static binaries pinned in MODULE.bazel; see //loom/gym:BUILD.bazel.)
+#
+# Regenerate the lock file after any change:
+#   bazel run @bookworm_loom_gym_eval//:lock
+version: 1
+
+sources:
+  - channel: bookworm main
+    url: https://snapshot.debian.org/archive/debian/20260301T000000Z
+  - channel: bookworm-security main
+    url: https://snapshot.debian.org/archive/debian-security/20260301T000000Z
+
+archs:
+  - "amd64"
+
+packages:
+  - "ca-certificates"

--- a/loom/gym/inspect_harness.py
+++ b/loom/gym/inspect_harness.py
@@ -191,12 +191,21 @@ def _sandbox_compose(
     }
 
 
+# The sandbox image's Dockerfile is the single source of truth for the agent's
+# toolkit. We show it verbatim so the inventory in the prompt can never drift from
+# what's actually installed (read at import; it ships as runfiles data of this lib).
+_SANDBOX_DOCKERFILE = (Path(__file__).resolve().parent / "sandbox" / "Dockerfile").read_text()
+
+_TOOLKIT = (
+    "python3 is available; your sandbox is built from this Dockerfile, so rely on exactly what it "
+    "installs (run analysis with e.g. `python3 - <<'PY' ... PY` or `python3 -c '...'`):\n"
+    f"```dockerfile\n{_SANDBOX_DOCKERFILE}```"
+)
+
 AGENT_PROMPT = (
     "You are a careful forecaster. You have one tool: bash. Data files are under /data (start with "
     "/data/README.txt). Each bash call runs in a FRESH shell — variables and working state do NOT "
-    "persist between calls, so make every command self-contained. python3 is available; the image "
-    "(loom/gym/sandbox/Dockerfile) has pandas, numpy, scipy, statsmodels, python-dateutil, requests, "
-    "and curl preinstalled, so run analysis with e.g. `python3 - <<'PY' ... PY` or `python3 -c '...'`. "
+    "persist between calls, so make every command self-contained. " + _TOOLKIT + "\n"
     "You have access to a snapshotted archive of today's internet through a preconfigured proxy: "
     "ordinary http:// and https:// URLs both work (curl, urllib, and requests honor the proxy and its "
     "CA automatically) — use it to gather information. If /data/sources.txt exists, it lists URLs worth "
@@ -207,9 +216,7 @@ AGENT_PROMPT = (
 AGENT_PROMPT_NO_ARCHIVE = (
     "You are a careful forecaster. You have one tool: bash. Data files are under /data (start with "
     "/data/README.txt). Each bash call runs in a FRESH shell — variables and working state do NOT "
-    "persist between calls, so make every command self-contained. python3 is available; the image "
-    "(loom/gym/sandbox/Dockerfile) has pandas, numpy, scipy, statsmodels, python-dateutil, requests, "
-    "and curl preinstalled, so run analysis with e.g. `python3 - <<'PY' ... PY` or `python3 -c '...'`. "
+    "persist between calls, so make every command self-contained. " + _TOOLKIT + "\n"
     "You have NO network access: rely only on the /data files and your own knowledge. "
     "When confident, call the submit tool with your forecast — its arguments are the structured "
     "answer fields, which the tool schema enforces."

--- a/loom/gym/k8s/README.md
+++ b/loom/gym/k8s/README.md
@@ -19,9 +19,10 @@ mitmproxy, which raw-tunnels that host (`ignore_hosts`, see
 ## Prerequisites (per cluster, mostly one-time)
 
 1. **`docker-ci` up on OVH** — `kubectl -n docker-ci get pod` shows `Running`.
-2. **Images in GHCR** — the `push-images` workflow has published
-   `ghcr.io/agentydragon/loom-gym-eval` and `…/wayback-proxy` (matrix rows in
-   `.github/workflows/push-images.yml`). New images land after a merge to `devel`.
+2. **Images in GHCR** (all under `ghcr.io/agentydragon/`, published on merge to
+   `devel`): `loom-gym-eval` and `wayback-proxy` (oci_image matrix rows in
+   `push-images.yml`), and `loom-gym-sandbox` (Dockerfile job in
+   `container-images.yml` — it's an interactive python env, not a `py_binary`).
 3. **mitmproxy passthrough reconciled** — the `ignore_hosts` + egress rule for
    `docker-ci.allegedly.works:2376` are live (merged + Flux-reconciled).
 4. **Reflected secrets present** in `claude-sandbox`: `litellm-master-key`,
@@ -42,37 +43,21 @@ kubectl -n claude-sandbox create secret generic docker-ci-client \
 rm -f /tmp/dc-key.pem
 ```
 
-## 2. Stage the sandbox images into docker-ci
-
-The compose marks both images `x-local` (no registry pull at sandbox-create time),
-so they must already exist on the daemon under their `:latest` tags. Run a one-shot
-docker-CLI pod against docker-ci (DinD has clean egress, so the GHCR pull and the
-PyPI install both work daemon-side):
-
-```bash
-# wayback-proxy: pull the newest devel tag from GHCR and retag local
-docker pull ghcr.io/agentydragon/wayback-proxy:<devel-tag>
-docker tag  ghcr.io/agentydragon/wayback-proxy:<devel-tag> wayback-proxy:latest
-
-# loom-gym-sandbox: build from the Dockerfile (no local context → build from stdin)
-docker build -t loom-gym-sandbox:latest - < loom/gym/sandbox/Dockerfile
-```
-
-with `DOCKER_HOST=tcp://docker-ci.allegedly.works:2376`, `DOCKER_TLS_VERIFY=1`,
-`DOCKER_CERT_PATH` pointing at the `docker-ci-client` material. (TODO: fold this
-into the Job as an initContainer — see `loom/gym/TODO.md`.)
-
-## 3. Run the eval
+## 2. Run the eval
 
 ```bash
 kubectl apply -f loom/gym/k8s/eval-job.yaml
 kubectl -n claude-sandbox logs -f job/loom-gym-eval
 ```
 
-Edit `args` in `eval-job.yaml` for model/task-filter/arms (defaults:
-`glm-4.5`, `manifold-`, archive arm, in-cluster cache upstream).
+The Job's `stage-images` initContainer first pulls `wayback-proxy` and
+`loom-gym-sandbox` from GHCR (`:latest`) and tags them into the docker-ci daemon
+under the bare `:latest` names the compose expects (`x-local` — no pull at
+sandbox-create). Then the `eval` container runs. Edit `args` in `eval-job.yaml`
+for model / task-filter / arms (defaults: `glm-4.5`, `manifold-`, archive arm,
+in-cluster cache upstream).
 
-## 4. Fetch results
+## 3. Fetch results
 
 `.eval` logs are written to `/work/logs` on the pod's emptyDir. Before the Job's
 `ttlSecondsAfterFinished` reaps it:

--- a/loom/gym/k8s/README.md
+++ b/loom/gym/k8s/README.md
@@ -1,37 +1,20 @@
 # In-cluster loom/gym eval
 
-Run the forecasting eval as an on-demand Kubernetes Job in `claude-sandbox`. The
-driver orchestrates Inspect-AI docker-compose sandboxes on the **docker-ci** DinD
-over mTLS; the contestant + wayback-proxy containers run on that daemon and reach
-the wayback cache by its in-cluster ClusterIP (no public gateway → no Envoy 60s
-cap). Applied by hand (not Flux) — a Job runs once and is not continuously
-reconciled.
+On-demand Job that runs the forecasting eval against the **docker-ci** DinD over
+mTLS, with the sandbox containers reaching the wayback cache via its in-cluster
+ClusterIP. The daemon target, upstream, env, args, and image staging all live in
+`eval-job.yaml` (commented) — `claude-sandbox` is `baseline` PSA (no privileged →
+no local DinD), hence the remote daemon. This README is just the run procedure.
 
-## Why a remote daemon (not DinD in claude-sandbox)
+Prereqs: `docker-ci` Running on OVH; the `ghcr.io/agentydragon/{loom-gym-eval,wayback-proxy,loom-gym-sandbox}`
+images published (on merge to `devel`); the mitmproxy `ignore_hosts` passthrough
+reconciled; and the reflected `litellm-master-key` + `claude-forgejo-credentials`
+secrets present in `claude-sandbox`.
 
-`claude-sandbox` enforces `baseline` PodSecurity, which forbids `privileged`, so a
-DinD sidecar can't run here. `docker-ci` is the cluster's privileged-PSA home for
-exactly this. The driver reaches it by its **public name**
-(`docker-ci.allegedly.works:2376`, matching the cert SAN) through the agent
-mitmproxy, which raw-tunnels that host (`ignore_hosts`, see
-`cluster/k8s/agents/mitmproxy/deployment.yaml`) so docker mTLS passes end-to-end.
+## 1. Create the docker-ci mTLS secret (the only non-manifest step)
 
-## Prerequisites (per cluster, mostly one-time)
-
-1. **`docker-ci` up on OVH** — `kubectl -n docker-ci get pod` shows `Running`.
-2. **Images in GHCR** (all under `ghcr.io/agentydragon/`, published on merge to
-   `devel`): `loom-gym-eval` and `wayback-proxy` (oci_image matrix rows in
-   `push-images.yml`), and `loom-gym-sandbox` (Dockerfile job in
-   `container-images.yml` — it's an interactive python env, not a `py_binary`).
-3. **mitmproxy passthrough reconciled** — the `ignore_hosts` + egress rule for
-   `docker-ci.allegedly.works:2376` are live (merged + Flux-reconciled).
-4. **Reflected secrets present** in `claude-sandbox`: `litellm-master-key`,
-   `claude-forgejo-credentials` (the latter feeds `ensure_checkout`).
-
-## 1. Create the docker-ci mTLS client secret
-
-The public certs are in-repo; the client key is SOPS-encrypted (claude-web can
-decrypt). From the repo root, in the devshell (`SOPS_AGE_KEY` set):
+Public certs are in-repo; the client key is SOPS-encrypted (claude-web can decrypt).
+From the repo root in the devshell:
 
 ```bash
 sops -d secrets/docker-ci/client-key.sops.pem > /tmp/dc-key.pem
@@ -43,26 +26,14 @@ kubectl -n claude-sandbox create secret generic docker-ci-client \
 rm -f /tmp/dc-key.pem
 ```
 
-## 2. Run the eval
+## 2. Run and fetch results
 
 ```bash
 kubectl apply -f loom/gym/k8s/eval-job.yaml
 kubectl -n claude-sandbox logs -f job/loom-gym-eval
-```
 
-The Job's `stage-images` initContainer first pulls `wayback-proxy` and
-`loom-gym-sandbox` from GHCR (`:latest`) and tags them into the docker-ci daemon
-under the bare `:latest` names the compose expects (`x-local` — no pull at
-sandbox-create). Then the `eval` container runs. Edit `args` in `eval-job.yaml`
-for model / task-filter / arms (defaults: `glm-4.5`, `manifold-`, archive arm,
-in-cluster cache upstream).
-
-## 3. Fetch results
-
-`.eval` logs are written to `/work/logs` on the pod's emptyDir. Before the Job's
-`ttlSecondsAfterFinished` reaps it:
-
-```bash
 POD=$(kubectl -n claude-sandbox get pod -l job-name=loom-gym-eval -o name)
 kubectl -n claude-sandbox cp "${POD#pod/}:/work/logs" ./eval-logs
 ```
+
+Tune model / task-filter / arms via `args` in `eval-job.yaml`.

--- a/loom/gym/k8s/README.md
+++ b/loom/gym/k8s/README.md
@@ -1,0 +1,83 @@
+# In-cluster loom/gym eval
+
+Run the forecasting eval as an on-demand Kubernetes Job in `claude-sandbox`. The
+driver orchestrates Inspect-AI docker-compose sandboxes on the **docker-ci** DinD
+over mTLS; the contestant + wayback-proxy containers run on that daemon and reach
+the wayback cache by its in-cluster ClusterIP (no public gateway → no Envoy 60s
+cap). Applied by hand (not Flux) — a Job runs once and is not continuously
+reconciled.
+
+## Why a remote daemon (not DinD in claude-sandbox)
+
+`claude-sandbox` enforces `baseline` PodSecurity, which forbids `privileged`, so a
+DinD sidecar can't run here. `docker-ci` is the cluster's privileged-PSA home for
+exactly this. The driver reaches it by its **public name**
+(`docker-ci.allegedly.works:2376`, matching the cert SAN) through the agent
+mitmproxy, which raw-tunnels that host (`ignore_hosts`, see
+`cluster/k8s/agents/mitmproxy/deployment.yaml`) so docker mTLS passes end-to-end.
+
+## Prerequisites (per cluster, mostly one-time)
+
+1. **`docker-ci` up on OVH** — `kubectl -n docker-ci get pod` shows `Running`.
+2. **Images in GHCR** — the `push-images` workflow has published
+   `ghcr.io/agentydragon/loom-gym-eval` and `…/wayback-proxy` (matrix rows in
+   `.github/workflows/push-images.yml`). New images land after a merge to `devel`.
+3. **mitmproxy passthrough reconciled** — the `ignore_hosts` + egress rule for
+   `docker-ci.allegedly.works:2376` are live (merged + Flux-reconciled).
+4. **Reflected secrets present** in `claude-sandbox`: `litellm-master-key`,
+   `claude-forgejo-credentials` (the latter feeds `ensure_checkout`).
+
+## 1. Create the docker-ci mTLS client secret
+
+The public certs are in-repo; the client key is SOPS-encrypted (claude-web can
+decrypt). From the repo root, in the devshell (`SOPS_AGE_KEY` set):
+
+```bash
+sops -d secrets/docker-ci/client-key.sops.pem > /tmp/dc-key.pem
+kubectl -n claude-sandbox create secret generic docker-ci-client \
+  --from-file=ca.pem=cluster/k8s/docker-ci/certs/ca.pem \
+  --from-file=cert.pem=cluster/k8s/docker-ci/certs/client-cert.pem \
+  --from-file=key.pem=/tmp/dc-key.pem \
+  --dry-run=client -o yaml | kubectl apply -f -
+rm -f /tmp/dc-key.pem
+```
+
+## 2. Stage the sandbox images into docker-ci
+
+The compose marks both images `x-local` (no registry pull at sandbox-create time),
+so they must already exist on the daemon under their `:latest` tags. Run a one-shot
+docker-CLI pod against docker-ci (DinD has clean egress, so the GHCR pull and the
+PyPI install both work daemon-side):
+
+```bash
+# wayback-proxy: pull the newest devel tag from GHCR and retag local
+docker pull ghcr.io/agentydragon/wayback-proxy:<devel-tag>
+docker tag  ghcr.io/agentydragon/wayback-proxy:<devel-tag> wayback-proxy:latest
+
+# loom-gym-sandbox: build from the Dockerfile (no local context → build from stdin)
+docker build -t loom-gym-sandbox:latest - < loom/gym/sandbox/Dockerfile
+```
+
+with `DOCKER_HOST=tcp://docker-ci.allegedly.works:2376`, `DOCKER_TLS_VERIFY=1`,
+`DOCKER_CERT_PATH` pointing at the `docker-ci-client` material. (TODO: fold this
+into the Job as an initContainer — see `loom/gym/TODO.md`.)
+
+## 3. Run the eval
+
+```bash
+kubectl apply -f loom/gym/k8s/eval-job.yaml
+kubectl -n claude-sandbox logs -f job/loom-gym-eval
+```
+
+Edit `args` in `eval-job.yaml` for model/task-filter/arms (defaults:
+`glm-4.5`, `manifold-`, archive arm, in-cluster cache upstream).
+
+## 4. Fetch results
+
+`.eval` logs are written to `/work/logs` on the pod's emptyDir. Before the Job's
+`ttlSecondsAfterFinished` reaps it:
+
+```bash
+POD=$(kubectl -n claude-sandbox get pod -l job-name=loom-gym-eval -o name)
+kubectl -n claude-sandbox cp "${POD#pod/}:/work/logs" ./eval-logs
+```

--- a/loom/gym/k8s/eval-job.yaml
+++ b/loom/gym/k8s/eval-job.yaml
@@ -14,6 +14,37 @@ spec:
   template:
     spec:
       restartPolicy: Never
+      initContainers:
+        # Stage the sandbox images into the docker-ci daemon under the bare
+        # :latest tags the compose expects (x-local — no pull at sandbox-create
+        # time). The daemon has clean egress, so it does the GHCR pull; we retag.
+        - name: stage-images
+          image: docker:27-cli
+          command:
+            - sh
+            - -ceu
+            - |
+              for img in wayback-proxy loom-gym-sandbox; do
+                docker pull "ghcr.io/agentydragon/$img:latest"
+                docker tag "ghcr.io/agentydragon/$img:latest" "$img:latest"
+              done
+          env:
+            - name: DOCKER_HOST
+              value: tcp://docker-ci.allegedly.works:2376
+            - name: DOCKER_TLS_VERIFY
+              value: "1"
+            - name: DOCKER_CERT_PATH
+              value: /certs
+          volumeMounts:
+            - name: certs
+              mountPath: /certs
+              readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
       containers:
         - name: eval
           image: ghcr.io/agentydragon/loom-gym-eval:latest

--- a/loom/gym/k8s/eval-job.yaml
+++ b/loom/gym/k8s/eval-job.yaml
@@ -1,0 +1,87 @@
+# On-demand loom/gym forecasting-eval run. Applied by hand (not Flux) into
+# claude-sandbox; the driver orchestrates Inspect-AI docker-compose sandboxes on
+# the in-cluster docker-ci DinD over mTLS, and the contestant/proxy containers
+# reach the wayback cache via its in-cluster ClusterIP (no public gateway, so no
+# Envoy 60s cap). See README.md for the create-secret + apply + fetch-results flow.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: loom-gym-eval
+  namespace: claude-sandbox
+spec:
+  backoffLimit: 0 # an eval run is not idempotent — never auto-retry
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: eval
+          image: ghcr.io/agentydragon/loom-gym-eval:latest
+          args:
+            - --model-id
+            - glm-4.5
+            - --task-filter
+            - manifold-
+            - --wayback-upstream
+            - http://wayback-cache.wayback-cache.svc.cluster.local:8080
+            - --log-dir
+            - /work/logs
+          env:
+            # Remote daemon: the docker CLI talks to docker-ci over mTLS. The host
+            # must match the server cert SAN (docker-ci.allegedly.works), so we use
+            # the TLS-passthrough route rather than the bare ClusterIP.
+            - name: DOCKER_HOST
+              value: tcp://docker-ci.allegedly.works:2376
+            - name: DOCKER_TLS_VERIFY
+              value: "1"
+            - name: DOCKER_CERT_PATH
+              value: /certs
+            # pygit2 ensure_checkout clones augur-evidence under $HOME/.cache; logs
+            # and compose temp dirs also want a writable home on the emptyDir.
+            - name: HOME
+              value: /work
+            - name: TMPDIR
+              value: /work
+            - name: LITELLM_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: litellm-master-key
+                  key: api-key
+            - name: AUGUR_EVIDENCE_GIT_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: claude-forgejo-credentials
+                  key: username
+            - name: AUGUR_EVIDENCE_GIT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: claude-forgejo-credentials
+                  key: password
+          volumeMounts:
+            - name: certs
+              mountPath: /certs
+              readOnly: true
+            - name: work
+              mountPath: /work
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              # The heavy work (sandbox containers) runs on docker-ci, not here;
+              # this is just the Inspect driver + model HTTP calls.
+              cpu: "2"
+              memory: 4Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+      volumes:
+        - name: certs
+          secret:
+            secretName: docker-ci-client
+            defaultMode: 0400
+        - name: work
+          emptyDir: {}

--- a/loom/gym/sandbox/Dockerfile
+++ b/loom/gym/sandbox/Dockerfile
@@ -1,20 +1,31 @@
-# Forecasting-gym agent sandbox. The contestant agent runs bash here; python3
-# is on PATH with a data-analysis toolkit baked in (no network at runtime, so
-# everything it needs must be in the image). The agent is told this inventory
-# in its system prompt — keep loom/gym/inspect_harness.py:AGENT_PROMPT in sync.
+# Forecasting-gym agent sandbox. The contestant agent runs bash here; python3 is
+# on PATH with a data-analysis + modeling toolkit baked in (no network at runtime,
+# so everything it needs must be in the image). This file is shown to the agent
+# verbatim in its system prompt (loom/gym/inspect_harness.py embeds it), so it is
+# the single source of truth for the inventory — there is no separate list to sync.
 FROM python:3.13-slim
 
+# bash for the agent's bash tool; curl + ca-certificates for HTTPS fetches; g++ so
+# pytensor (pymc's backend) can compile its C ops at runtime.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends bash curl ca-certificates g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+# Pinned and resolved together for python 3.13: core data analysis (pandas, numpy,
+# scipy, statsmodels), probabilistic + ML modeling (scikit-learn, pymc, arviz,
+# arch), and fetch + HTML parsing (requests, beautifulsoup4, lxml).
 RUN pip install --no-cache-dir \
     pandas==2.2.3 \
     numpy==2.2.1 \
     scipy==1.15.1 \
     statsmodels==0.14.4 \
     python-dateutil==2.9.0.post0 \
-    requests==2.32.3
-
-# bash for the agent's bash tool; curl/ca-certificates for proxy fetches.
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends bash curl ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
+    scikit-learn==1.9.0 \
+    pymc==6.0.1 \
+    arviz==1.1.0 \
+    arch==8.0.0 \
+    requests==2.32.3 \
+    beautifulsoup4==4.15.0 \
+    lxml==6.1.1
 
 CMD ["bash"]


### PR DESCRIPTION
Builds on #2061 (merged). Makes the loom/gym forecasting eval runnable **in-cluster** against the now-OVH `docker-ci` DinD, and documents a sandbox-egress gap.

## Driver image
- `//loom/gym:eval_image` → `ghcr.io/agentydragon/loom-gym-eval`: a `py_image` of the `agent_eval` driver **plus the docker CLI + compose v2 plugin** (inspect shells out to `docker compose`; Debian has no `docker-compose-v2` package, so upstream static binaries via `http_archive`) and a `ca-certificates` layer (pygit2/`ensure_checkout` needs a CA bundle). RBE-build clean; `docker 29.5.3` + `compose v2.40.0` verified inside the image.
- `push-images` matrix rows for `loom-gym-eval` and `wayback-proxy`.

## Reaching docker-ci from claude-sandbox
claude-sandbox enforces `baseline` PSA (no privileged → no DinD here) **and** forces all egress through the agent mitmproxy. So the driver targets `docker-ci` by its **public name** (matching the cert SAN), and mitmproxy **raw-tunnels** it:
- `ignore_hosts` for `docker-ci.allegedly.works` (no TLS interception → docker mTLS passes end-to-end).
- egress allowance `mitmproxy → docker-ci.allegedly.works:2376` (its policy only permitted specific FQDNs on :443, which is why the CONNECT hung).

## The Job
`loom/gym/k8s/eval-job.yaml` + README: runs in `claude-sandbox`, mounts a `docker-ci-client` mTLS secret, upstream = **in-cluster** `wayback-cache` ClusterIP (no Envoy 60s cap). README covers secret creation, staging the two sandbox images into the daemon, and result retrieval.

## Documented security gap (intentionally left open)
A sandboxed agent — egress-restricted to mitmproxy — can `docker run` a container on `docker-ci` whose egress is **not** forced through the proxy, escaping the egress control. Recorded in `ccnp-sandbox-proxy-egress.yaml` (the guarantee with the hole) with close options (deny docker-ci, or a locked-down docker-for-agents daemon), per @agentydragon's request to keep-but-document.

## Validation / remaining
- RBE build of `eval_image` clean; harness change + image proven in #2061's path.
- **Not yet e2e-run**: needs the images in GHCR (post-merge `push-images`) and the mitmproxy passthrough reconciled. The mTLS path was verified live (the svc-name probe reached the daemon; only SAN/route differed).
- Follow-up TODO: fold the sandbox-image staging (pull `wayback-proxy`, `docker build` `loom-gym-sandbox`) into a Job initContainer for one-`apply` runs.

https://claude.ai/code/session_01AXSFxfCXddADoSKTjgF5Nz

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXSFxfCXddADoSKTjgF5Nz)_