### PR TITLE
debundle: enforce input-chunk admission checks for A1/A3/A4 assumptions

### DIFF
--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -259,6 +259,7 @@ rust_library(
         "analysis_hints.rs",
         "analysis_tests/mod.rs",
         "atomic_units.rs",
+        "chunk_admission.rs",
         "chunk_analysis.rs",
         "chunk_factorization.rs",
         "factor_assembly.rs",

--- a/devinfra/js/debundle/README.md
+++ b/devinfra/js/debundle/README.md
@@ -222,3 +222,35 @@ import of one of these names disables its global treatment chunk-wide.
 
 See `docs/design.md` → "Emission modes" for the precise dataflow-aware
 emission rule (including the write-after-read edges).
+
+## Input-chunk admission checks
+
+Every materialized chunk is screened against the statically checkable
+input assumptions of `docs/design.md` → "Conditions on the input
+chunk" before any quotient or lowering work (`chunk_admission.rs`,
+run from `stage_one::compute_stage_one_analysis` next to the A2
+top-level-await bail). The enforced shapes:
+
+- **A1** — direct `eval(...)` / seq-indirect `(0, eval)(...)` calls at
+  module top level.
+- **A3** — string-literal dynamic `import(...)` resolving back into
+  the same chunk (any depth), and non-literal specifiers at module
+  top level.
+- **A5** (minimal) — `import.meta` use at module top level beyond
+  `import.meta.url`.
+
+A2 (top-level `await`) bails in the same place; A4 (`with`) is
+rejected at parse time. Rejections name the chunk, the offending
+statement ordinal, and the matched shape. For audited corpora,
+disable individual checks per chunk in the spec:
+
+```yaml
+chunk_analysis_options:
+  static/app:
+    admission_overrides: [a1_eval]
+```
+
+Each override prints a one-line notice per run; an override that no
+longer suppresses any violation is reported as redundant (remove it).
+The deliberately unchecked residual shapes are listed in
+`docs/design.md` → "Coverage gaps".

--- a/devinfra/js/debundle/binding_targets.rs
+++ b/devinfra/js/debundle/binding_targets.rs
@@ -256,3 +256,14 @@ pub fn strip_parens(expr: &Expr) -> &Expr {
     }
     cur
 }
+
+/// Look through parens and comma sequences to a callee's final
+/// operand: `(0, eval)(...)` is an indirect eval call with the same
+/// arbitrary-cell-write power as a direct one.
+pub fn callee_base_expr(expr: &Expr) -> &Expr {
+    let mut cur = strip_parens(expr);
+    while let Expr::Seq(seq) = cur {
+        cur = strip_parens(seq.exprs.last().expect("SeqExpr is non-empty"));
+    }
+    cur
+}

--- a/devinfra/js/debundle/chunk_admission.rs
+++ b/devinfra/js/debundle/chunk_admission.rs
@@ -1,0 +1,542 @@
+//! Input-chunk admission scan for the statically-checkable
+//! assumptions of docs/design.md §"Conditions on the input chunk"
+//! (A1 `eval`, A3 internal dynamic `import()`, A5 cheap
+//! `import.meta` reflection shapes). Runs in Stage A
+//! ([`crate::compute_stage_one_analysis`]) right next to the A2
+//! top-level-await bail, before any quotient or lowering work.
+//!
+//! The scan is deliberately partial — it enforces the cheap,
+//! low-false-positive sub-shapes of each assumption and leaves the
+//! rest as documented input-shape contracts (see docs/design.md
+//! §"Coverage gaps"). Per-check escape hatch:
+//! `chunk_analysis_options.<chunk>.admission_overrides` in the spec
+//! ([`spec::AdmissionOverrides`]) for chunks the author has audited.
+//!
+//! Notable residual gaps (documented, not checked):
+//!
+//! - **A1**: `eval` inside function bodies and other lazy positions.
+//!   A1's wording only bans module-top `eval`, but a lazy direct
+//!   `eval` can still read cross-module bindings dynamically when
+//!   the enclosing function is called after the split. Aliased eval
+//!   (`const e = eval; e(...)`) is also unchecked.
+//! - **A3**: non-literal dynamic-import specifiers in lazy positions
+//!   (`(n) => import(n)`), which could resolve to an internal module
+//!   at runtime. Only `Lit::Str` specifiers count as literal — the
+//!   same notion `prepare_js_chunks` / `rewrite_chunk_entry_specifiers`
+//!   use; a zero-expr template literal is treated as non-literal.
+//! - **A5**: `Function.prototype.toString` reads of chunk bindings,
+//!   `Reflect` descriptor inspection on namespace objects, and any
+//!   `import.meta` use inside lazy positions.
+//!
+//! **A4 (`with` blocks) is not checked here** because it never
+//! reaches Stage A: module code is strict per ECMA-262, and the
+//! production parser rejects `with` as a recoverable parse error
+//! even with `no_early_errors: true`
+//! (`js_ast::parse_module_from_source_file` fails on any recovered
+//! error). The rejection is pinned by
+//! `e2e/chunk_admission_test.rs::with_block_is_rejected_at_parse`.
+
+use anyhow::{Result, bail};
+use swc_ecma_ast::{
+    ArrowExpr, CallExpr, Callee, Class, ClassMember, Expr, Function, GetterProp, Key, Lit,
+    MemberExpr, MemberProp, MetaPropExpr, MetaPropKind, MethodProp, Module, PropName, SetterProp,
+};
+use swc_ecma_visit::{Visit, VisitWith};
+
+use binding_targets::{callee_base_expr, strip_parens};
+use spec::{AdmissionCheck, AdmissionOverrides};
+
+use crate::facts::top_level_item_views;
+
+/// Where a dynamic-import specifier resolves, from the caller chunk's
+/// perspective. Produced by the artifact-aware resolver the lowering
+/// layer passes into Stage A (Stage A itself is artifact-free).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DynamicImportTarget {
+    /// Resolves to a file of the chunk being analyzed — a debundled
+    /// internal module (A3 violation).
+    SameChunk,
+    /// Resolves to another chunk in the artifact (vendor / route
+    /// chunk). Allowed: the realizability proof treats these as
+    /// black-box leaves with their own evaluation (docs/design.md A3).
+    OtherChunk,
+    /// Does not resolve inside the artifact (external URL, bare
+    /// package specifier, missing file). Allowed.
+    External,
+}
+
+#[derive(Debug)]
+struct AdmissionViolation {
+    check: AdmissionCheck,
+    /// Source-order statement ordinal in the post-comma-split view
+    /// (`facts::top_level_item_views`), aligned with the A2 bail and
+    /// the owner-graph reports.
+    ordinal: usize,
+    description: String,
+}
+
+/// Scan `module` for admission violations and `bail!` on any that the
+/// spec does not override. Overridden violations print a one-line
+/// notice; configured overrides that suppress nothing print a
+/// redundant-override warning (mirroring the redundant-purity-hint
+/// diagnostics).
+pub fn enforce_chunk_admission(
+    chunk_id: &str,
+    module: &Module,
+    overrides: AdmissionOverrides,
+    resolve_dynamic_import: &dyn Fn(&str) -> DynamicImportTarget,
+) -> Result<()> {
+    let violations = scan_admission_violations(module, resolve_dynamic_import);
+    let (suppressed, fatal): (Vec<_>, Vec<_>) = violations
+        .into_iter()
+        .partition(|violation| overrides.contains(violation.check));
+    for violation in &suppressed {
+        eprintln!(
+            "notice: chunk {chunk_id}: admission check {check} overridden by spec \
+             (chunk_analysis_options.{chunk_id}.admission_overrides): statement \
+             #{ordinal}: {description}",
+            check = violation.check,
+            ordinal = violation.ordinal,
+            description = violation.description,
+        );
+    }
+    for check in overrides.iter() {
+        if !suppressed.iter().any(|violation| violation.check == check) {
+            eprintln!(
+                "warning: chunk {chunk_id}: admission override `{check}` is redundant — \
+                 the chunk has no {check} violation and the override is a no-op. \
+                 Remove it from chunk_analysis_options.{chunk_id}.admission_overrides.",
+            );
+        }
+    }
+    if !fatal.is_empty() {
+        let rendered = fatal
+            .iter()
+            .map(|violation| {
+                format!(
+                    "  statement #{ordinal}: [{check}] {description}",
+                    ordinal = violation.ordinal,
+                    check = violation.check,
+                    description = violation.description,
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        bail!(
+            "materialize_logical_modules: chunk {chunk_id} fails input-chunk admission \
+             (docs/design.md §\"Conditions on the input chunk\"):\n{rendered}\n\
+             The realizability theorem does not cover these shapes. Rework the chunk, or — \
+             after auditing that the shape is benign here — opt out per check via \
+             `chunk_analysis_options.{chunk_id}.admission_overrides` (e.g. `[{first}]`).",
+            first = fatal[0].check,
+        );
+    }
+    Ok(())
+}
+
+fn scan_admission_violations(
+    module: &Module,
+    resolve_dynamic_import: &dyn Fn(&str) -> DynamicImportTarget,
+) -> Vec<AdmissionViolation> {
+    let mut scan = AdmissionScan {
+        resolve_dynamic_import,
+        ordinal: 0,
+        lazy_depth: 0,
+        violations: Vec::new(),
+    };
+    for (ordinal, item) in top_level_item_views(&module.body).iter().enumerate() {
+        scan.ordinal = ordinal;
+        item.as_module_item().visit_with(&mut scan);
+    }
+    scan.violations
+}
+
+/// One-pass visitor over a single top-level statement. Tracks
+/// `lazy_depth` across function/arrow/method/getter/setter bodies and
+/// class instance-member initializers — the same lazy boundaries as
+/// `facts::StatementFactsCollector` — so the eager-only checks (A1,
+/// A3 non-literal, A5) fire only on code that runs during module
+/// evaluation, while the any-depth check (A3 literal target) still
+/// descends into lazy bodies.
+struct AdmissionScan<'r> {
+    resolve_dynamic_import: &'r dyn Fn(&str) -> DynamicImportTarget,
+    ordinal: usize,
+    lazy_depth: u32,
+    violations: Vec<AdmissionViolation>,
+}
+
+impl AdmissionScan<'_> {
+    fn record(&mut self, check: AdmissionCheck, description: String) {
+        self.violations.push(AdmissionViolation {
+            check,
+            ordinal: self.ordinal,
+            description,
+        });
+    }
+
+    fn descend_lazy(&mut self, f: impl FnOnce(&mut Self)) {
+        self.lazy_depth += 1;
+        f(self);
+        self.lazy_depth -= 1;
+    }
+
+    fn check_eval_callee(&mut self, callee: &Expr) {
+        // `callee_base_expr` looks through (possibly nested,
+        // paren-wrapped) comma sequences to the expression that
+        // produces the callee value: `(0, eval)(...)` and
+        // `((0, (0, eval)))(...)` both reach the trailing `eval`.
+        // Module code is strict, and strict mode forbids `eval` as a
+        // binding name — so an `eval` ident here is the global eval.
+        if matches!(callee_base_expr(callee), Expr::Ident(ident) if ident.sym.as_ref() == "eval") {
+            let shape = if matches!(strip_parens(callee), Expr::Seq(_)) {
+                "indirect `(…, eval)(...)` call"
+            } else {
+                "direct `eval(...)` call"
+            };
+            self.record(
+                AdmissionCheck::A1Eval,
+                format!(
+                    "{shape} at module top level — the static analyzer cannot see what \
+                     eval reads, so the at-init read graph `I` would be incomplete"
+                ),
+            );
+        }
+    }
+
+    fn check_dynamic_import(&mut self, node: &CallExpr) {
+        let literal = node.args.first().and_then(|arg| {
+            if arg.spread.is_some() {
+                return None;
+            }
+            match &*arg.expr {
+                Expr::Lit(Lit::Str(s)) => Some(s.value.to_string_lossy().to_string()),
+                _ => None,
+            }
+        });
+        match literal {
+            Some(specifier) => {
+                if (self.resolve_dynamic_import)(&specifier) == DynamicImportTarget::SameChunk {
+                    self.record(
+                        AdmissionCheck::A3DynamicImport,
+                        format!(
+                            "`import({specifier:?})` resolves into this chunk — dynamic \
+                             import of a debundled internal module routes around the \
+                             static import graph"
+                        ),
+                    );
+                }
+            }
+            None if self.lazy_depth == 0 => {
+                self.record(
+                    AdmissionCheck::A3DynamicImport,
+                    "dynamic `import(...)` with a non-literal specifier at module top \
+                     level — the target cannot be proven external to the debundled \
+                     module set"
+                        .to_string(),
+                );
+            }
+            None => {}
+        }
+    }
+}
+
+impl Visit for AdmissionScan<'_> {
+    fn visit_call_expr(&mut self, node: &CallExpr) {
+        match &node.callee {
+            Callee::Import(_) => self.check_dynamic_import(node),
+            Callee::Expr(expr) if self.lazy_depth == 0 => self.check_eval_callee(expr),
+            _ => {}
+        }
+        node.visit_children_with(self);
+    }
+
+    fn visit_member_expr(&mut self, node: &MemberExpr) {
+        if let Expr::MetaProp(meta) = strip_parens(&node.obj)
+            && meta.kind == MetaPropKind::ImportMeta
+        {
+            if self.lazy_depth == 0 {
+                match &node.prop {
+                    // `import.meta.url` is the one whitelisted shape (A5).
+                    MemberProp::Ident(prop) if prop.sym.as_ref() == "url" => {}
+                    MemberProp::Ident(prop) => {
+                        let prop = prop.sym.as_ref();
+                        self.record(
+                            AdmissionCheck::A5ImportMeta,
+                            format!(
+                                "`import.meta.{prop}` read at module top level — only \
+                                 `import.meta.url` is covered by the realizability theorem"
+                            ),
+                        );
+                    }
+                    _ => {
+                        self.record(
+                            AdmissionCheck::A5ImportMeta,
+                            "computed `import.meta[...]` access at module top level — only \
+                             `import.meta.url` is covered by the realizability theorem"
+                                .to_string(),
+                        );
+                    }
+                }
+            }
+            // Never descend into the `import.meta` object itself — the
+            // bare-`import.meta` visit below would double-flag it. A
+            // computed prop expression may still contain checked
+            // shapes, so visit just that.
+            if let MemberProp::Computed(computed) = &node.prop {
+                computed.expr.visit_with(self);
+            }
+            return;
+        }
+        node.visit_children_with(self);
+    }
+
+    fn visit_meta_prop_expr(&mut self, node: &MetaPropExpr) {
+        // Reached only for `import.meta` outside the member shapes
+        // intercepted above (e.g. passed as a value).
+        if node.kind == MetaPropKind::ImportMeta && self.lazy_depth == 0 {
+            self.record(
+                AdmissionCheck::A5ImportMeta,
+                "bare `import.meta` used as a value at module top level — namespace \
+                 reflection beyond `import.meta.url`"
+                    .to_string(),
+            );
+        }
+    }
+
+    // Lazy boundaries — mirror `facts::StatementFactsCollector`:
+    // eager parts (keys, static members, decorators, extends) stay at
+    // the current depth; bodies and instance initializers descend.
+    fn visit_function(&mut self, node: &Function) {
+        self.descend_lazy(|scan| node.visit_children_with(scan));
+    }
+
+    fn visit_arrow_expr(&mut self, node: &ArrowExpr) {
+        self.descend_lazy(|scan| node.visit_children_with(scan));
+    }
+
+    fn visit_method_prop(&mut self, node: &MethodProp) {
+        node.key.visit_with(self);
+        // Dispatches to `visit_function`, which descends.
+        node.function.visit_with(self);
+    }
+
+    fn visit_getter_prop(&mut self, node: &GetterProp) {
+        node.key.visit_with(self);
+        self.descend_lazy(|scan| {
+            if let Some(body) = &node.body {
+                body.visit_with(scan);
+            }
+        });
+    }
+
+    fn visit_setter_prop(&mut self, node: &SetterProp) {
+        node.key.visit_with(self);
+        node.param.visit_with(self);
+        self.descend_lazy(|scan| {
+            if let Some(body) = &node.body {
+                body.visit_with(scan);
+            }
+        });
+    }
+
+    fn visit_class(&mut self, node: &Class) {
+        for decorator in &node.decorators {
+            decorator.visit_with(self);
+        }
+        if let Some(super_class) = &node.super_class {
+            super_class.visit_with(self);
+        }
+        for member in &node.body {
+            member.visit_with(self);
+        }
+    }
+
+    fn visit_class_member(&mut self, member: &ClassMember) {
+        match member {
+            ClassMember::Method(method) => {
+                visit_computed_prop_name(self, &method.key);
+                // Dispatches to `visit_function`, which descends.
+                method.function.visit_with(self);
+            }
+            ClassMember::PrivateMethod(method) => {
+                method.function.visit_with(self);
+            }
+            ClassMember::Constructor(ctor) => {
+                self.descend_lazy(|scan| ctor.visit_children_with(scan));
+            }
+            ClassMember::ClassProp(prop) => {
+                visit_computed_prop_name(self, &prop.key);
+                if let Some(value) = &prop.value {
+                    if prop.is_static {
+                        value.visit_with(self);
+                    } else {
+                        self.descend_lazy(|scan| value.visit_with(scan));
+                    }
+                }
+            }
+            ClassMember::PrivateProp(prop) => {
+                if let Some(value) = &prop.value {
+                    if prop.is_static {
+                        value.visit_with(self);
+                    } else {
+                        self.descend_lazy(|scan| value.visit_with(scan));
+                    }
+                }
+            }
+            ClassMember::StaticBlock(block) => {
+                block.visit_with(self);
+            }
+            ClassMember::AutoAccessor(accessor) => {
+                if let Key::Public(name) = &accessor.key {
+                    visit_computed_prop_name(self, name);
+                }
+                if let Some(value) = &accessor.value {
+                    if accessor.is_static {
+                        value.visit_with(self);
+                    } else {
+                        self.descend_lazy(|scan| value.visit_with(scan));
+                    }
+                }
+            }
+            ClassMember::TsIndexSignature(_) | ClassMember::Empty(_) => {}
+        }
+    }
+}
+
+fn visit_computed_prop_name(scan: &mut AdmissionScan<'_>, name: &PropName) {
+    if let PropName::Computed(computed) = name {
+        computed.expr.visit_with(scan);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use swc_common::{FileName, SourceMap, sync::Lrc};
+    use swc_ecma_parser::{Parser, StringInput, Syntax, lexer::Lexer};
+
+    fn parse(source: &str) -> Module {
+        let cm: Lrc<SourceMap> = Default::default();
+        let fm = cm.new_source_file(
+            FileName::Custom("test.js".into()).into(),
+            source.to_string(),
+        );
+        let lexer = Lexer::new(
+            Syntax::Es(Default::default()),
+            Default::default(),
+            StringInput::from(&*fm),
+            None,
+        );
+        Parser::new_from(lexer)
+            .parse_module()
+            .expect("parse module")
+    }
+
+    fn scan(source: &str) -> Vec<(AdmissionCheck, usize)> {
+        scan_with_resolver(source, &|_| DynamicImportTarget::External)
+    }
+
+    fn scan_with_resolver(
+        source: &str,
+        resolve: &dyn Fn(&str) -> DynamicImportTarget,
+    ) -> Vec<(AdmissionCheck, usize)> {
+        scan_admission_violations(&parse(source), resolve)
+            .into_iter()
+            .map(|violation| (violation.check, violation.ordinal))
+            .collect()
+    }
+
+    /// Paren-wrapped nested comma sequences still reach the trailing
+    /// `eval`: the seq-aware callee unwrap is the point of this test.
+    #[test]
+    fn paren_wrapped_nested_seq_eval_is_flagged() {
+        assert_eq!(
+            scan("((0, (0, eval)))(\"x\");\n"),
+            vec![(AdmissionCheck::A1Eval, 0)]
+        );
+    }
+
+    /// `eval` inside a function body is a lazy position — A1 only
+    /// bans module-top eval (the body's eval is a documented residual
+    /// risk, not a violation).
+    #[test]
+    fn eval_in_function_body_is_not_flagged() {
+        assert_eq!(scan("function f() { return eval(\"1\"); }\n"), vec![]);
+    }
+
+    /// A class static block runs at class evaluation (eager), so an
+    /// eval there is module-top eval; an instance method body is lazy.
+    #[test]
+    fn class_static_block_is_eager_method_body_is_lazy() {
+        assert_eq!(
+            scan("class C { static { eval(\"1\"); } }\n"),
+            vec![(AdmissionCheck::A1Eval, 0)]
+        );
+        assert_eq!(scan("class C { m() { eval(\"1\"); } }\n"), vec![]);
+    }
+
+    /// Literal dynamic imports resolve through the caller-supplied
+    /// resolver: same-chunk targets are violations at any depth,
+    /// other-chunk / external targets are allowed.
+    #[test]
+    fn literal_dynamic_import_targets() {
+        let resolver = |specifier: &str| match specifier {
+            "./self.js" => DynamicImportTarget::SameChunk,
+            "./route.js" => DynamicImportTarget::OtherChunk,
+            _ => DynamicImportTarget::External,
+        };
+        assert_eq!(
+            scan_with_resolver("const f = () => import(\"./self.js\");\n", &resolver),
+            vec![(AdmissionCheck::A3DynamicImport, 0)]
+        );
+        assert_eq!(
+            scan_with_resolver(
+                "import(\"./route.js\");\nimport(\"https://cdn/x.js\");\n",
+                &resolver
+            ),
+            vec![]
+        );
+    }
+
+    /// A zero-expr template literal is non-literal for admission (the
+    /// rewrite/manifest passes only handle `Lit::Str` too): flagged at
+    /// top level, allowed in lazy positions.
+    #[test]
+    fn non_literal_specifier_only_flagged_at_top_level() {
+        assert_eq!(
+            scan("import(`./a.js`);\n"),
+            vec![(AdmissionCheck::A3DynamicImport, 0)]
+        );
+        assert_eq!(scan("const f = (n) => import(n);\n"), vec![]);
+    }
+
+    /// `import.meta.url` is whitelisted; other props, computed
+    /// access, and bare value use are flagged at top level only.
+    #[test]
+    fn import_meta_shapes() {
+        assert_eq!(scan("const u = import.meta.url;\n"), vec![]);
+        assert_eq!(
+            scan("const e = import.meta.env;\n"),
+            vec![(AdmissionCheck::A5ImportMeta, 0)]
+        );
+        assert_eq!(
+            scan("const k = import.meta[key];\n"),
+            vec![(AdmissionCheck::A5ImportMeta, 0)]
+        );
+        assert_eq!(
+            scan("const m = import.meta;\n"),
+            vec![(AdmissionCheck::A5ImportMeta, 0)]
+        );
+        assert_eq!(scan("const f = () => import.meta.env;\n"), vec![]);
+    }
+
+    /// Ordinals use the post-comma-split top-level view, matching the
+    /// A2 bail and the owner-graph reports.
+    #[test]
+    fn ordinals_align_with_comma_split_view() {
+        assert_eq!(
+            scan("const a = 1, b = 2;\neval(\"1\");\n"),
+            vec![(AdmissionCheck::A1Eval, 2)]
+        );
+    }
+}

--- a/devinfra/js/debundle/docs/design.md
+++ b/devinfra/js/debundle/docs/design.md
@@ -907,7 +907,14 @@ output, the Vite ecosystem, and most React/Vue/Angular SPAs.
 - **A1. No `eval` at module-top reading cross-module bindings
   dynamically.** `eval` opens an arbitrary read into the lexical
   scope at the call site; the static analyzer cannot see what it
-  references; `I` would be incomplete.
+  references; `I` would be incomplete. **Enforced (partially)**: the
+  input-chunk admission scan (`chunk_admission`, run by
+  `stage_one::compute_stage_one_analysis` next to the A2 bail)
+  rejects direct `eval(...)` and seq-indirect `(0, eval)(...)` calls
+  at module top level (looking through parens and comma sequences to
+  the callee), with the offending statement ordinal in the
+  diagnostic. Function-body `eval` and aliased `eval`
+  (`const e = eval`) remain unchecked — see §"Coverage gaps".
 - **A2. No top-level `await` in any emitted module.** TLA changes
   the linker's evaluation algorithm to AsyncCycleRoot semantics
   (TC39 §16.2.1.5.4 + §16.2.1.5.5). The proof's reverse-DFS
@@ -927,15 +934,44 @@ output, the Vite ecosystem, and most React/Vue/Angular SPAs.
   imports of vendor / route chunks are fine — the proof treats
   those as black-box leaves with their own evaluation. Internal
   dynamic imports would route around the static `import` graph,
-  invalidating `I` as a complete picture.
+  invalidating `I` as a complete picture. **Enforced (partially)**:
+  the admission scan resolves every string-literal `import(...)`
+  specifier through the artifact indexes (the same resolution the
+  specifier rewriter uses) and rejects, at any depth, specifiers
+  that resolve back into the chunk being debundled — `I` is the
+  per-chunk graph, so "internal" means same-chunk; other artifact
+  chunks stay black-box leaves per the sentence above (a
+  same-chunk-only rule also avoids over-flagging code-splitting
+  bundlers, whose route-chunk `import()` thunks are everywhere).
+  Non-literal specifiers in eager (module-top) position are also
+  rejected — soundness over completeness: the target cannot be
+  proven external. Non-literal specifiers in lazy positions are
+  allowed and remain a documented residual gap (only `Lit::Str`
+  counts as literal, matching `prepare_js_chunks` /
+  `rewrite_chunk_entry_specifiers`).
 - **A4. No `with` blocks.** Banned in strict mode (which ESM is
-  by spec); listed only for completeness.
+  by spec). **Enforced (at parse)**: even with the parser's
+  `no_early_errors: true` TypeScript syntax, `with` surfaces as a
+  recoverable parse error and `js_ast` fails chunk loading on any
+  recovered error, naming the strict-mode violation. Pinned by
+  `e2e/chunk_admission_test.rs::with_block_is_rejected_at_parse`;
+  no separate admission check is needed.
 - **A5. No reflection on module namespaces during evaluation.**
   No `Function.prototype.toString` reads of cross-module bodies
   whose result depends on evaluation order; no `Reflect`-based
   property descriptor inspection on the module namespace object
   during link; no `import.meta` introspection that depends on
-  order. (Standard `import.meta.url` is fine.)
+  order. (Standard `import.meta.url` is fine.) **Enforced
+  (minimally)**: the admission scan rejects only the cheap,
+  low-false-positive sub-shape — `import.meta` use at module top
+  level beyond `import.meta.url` (named props like
+  `import.meta.env`, computed `import.meta[...]`, and bare
+  `import.meta` as a value). The other A5 sub-shapes
+  (`Function.prototype.toString` reads, `Reflect` descriptor
+  inspection, lazy-position `import.meta`) are deliberately
+  unchecked: a precise analysis would over-flag mainstream
+  bundles, which is the worse failure mode here. They remain
+  input-shape contracts — see §"Coverage gaps".
 - **A6. The input chunk runs to completion in the original
   bundler's load.** Observational equivalence has no baseline if
   the input chunk itself diverges, hangs, or throws during
@@ -1047,12 +1083,22 @@ output, the Vite ecosystem, and most React/Vue/Angular SPAs.
   patch intrinsics would need the affected whitelist entries
   disabled for soundness.)
 
-A1–A5 are statically checkable on each chunk: grep for top-level
-`await`, dynamic `import()` of internal paths, `eval`, and `with`.
-A2 in particular is enforced by the TLA scan inside fact analysis —
+A1–A5 are statically checkable on each chunk, and each now has an
+enforced core. A2 is enforced by the TLA scan inside fact analysis —
 `stage_one::compute_stage_one_analysis` `bail!`s with the offending
 statement ordinal as soon as fact analysis returns, before any
-quotient or lowering work. A6 (no module-eval reentry) is relied
+quotient or lowering work. A1, A3, and A5 are enforced (to the
+per-assumption strengths described above) by the input-chunk
+admission scan in `chunk_admission`, which
+`compute_stage_one_analysis` runs right after the A2 bail; its
+diagnostics carry the chunk id, the offending statement ordinal,
+and the matched shape. A4 is enforced at parse time. The admission
+scan is on by default for every materialized chunk; for audited
+corpora a spec can disable individual checks per chunk via
+`chunk_analysis_options.<chunk>.admission_overrides`
+(`[a1_eval, a3_dynamic_import, a5_import_meta]`) — every override
+use prints a one-line notice, and overrides that no longer suppress
+anything are reported as redundant. A6 (no module-eval reentry) is relied
 on by observation: the unmodified bundle loads in the browser.
 A7 (multi-chunk DAG) is satisfied by typical bundlers' vendor-leaf
 chunking. A8 (whitelist receivers not shadowed) is dropped to
@@ -1203,14 +1249,30 @@ It does not establish:
 - **Top-level await (A2 violation).** Async modules use a
   different evaluation algorithm (`InnerModuleEvaluation` returns
   a Promise; cyclic async-module groups have AsyncCycleRoot
-  semantics). A separate proof would be needed; the validator
-  has no analysis of TLA today. If a future bundle introduces
-  TLA, the materializer should refuse the chunk explicitly.
+  semantics). A separate proof would be needed; instead the
+  materializer refuses TLA chunks explicitly (the Stage A bail
+  described under A2 above).
 - **Dynamic eval / reflection bypassing the static graph (A1, A5
   violations).** The `I` graph is incomplete in this case;
   cycle-freeness in `I` doesn't imply cycle-freeness in the
-  actual evaluation graph. The materializer cannot rule this out
-  statically; treat A1/A5 as input-shape contracts on the bundler.
+  actual evaluation graph. The admission scan rejects the
+  module-top shapes (direct / seq-indirect `eval` calls,
+  non-`url` `import.meta` use, eager non-literal `import()`),
+  but cannot rule out the rest statically. The shapes that remain
+  pure input-shape contracts on the bundler:
+  - `eval` in function bodies and other lazy positions — A1's
+    wording only bans module-top eval, but a lazy direct `eval`
+    still reads its lexical scope dynamically when the enclosing
+    function is called after the split, and the split may have
+    moved the bindings it names into other modules.
+  - aliased eval (`const e = eval; e(...)`) and `eval` reached
+    through any value flow.
+  - non-literal dynamic-import specifiers in lazy positions,
+    which could resolve to an internal module at runtime.
+  - `Function.prototype.toString` reads of cross-module bodies
+    and `Reflect`-based descriptor inspection of namespace
+    objects (the fuzzier A5 sub-shapes; checking them cheaply
+    without over-flagging mainstream bundles is not possible).
 - **Cross-chunk imports through CommonJS interop.** ECMA-262's
   evaluation rules don't apply to CJS modules; a CJS module's
   `module.exports` mutation can fire mid-evaluation in arbitrary

--- a/devinfra/js/debundle/e2e/BUILD.bazel
+++ b/devinfra/js/debundle/e2e/BUILD.bazel
@@ -55,6 +55,7 @@ _STANDARD_E2E_DEPS = [
     for name in [
         "anonymous_statement_test",
         "binding_group_adopt_names_test",
+        "chunk_admission_test",
         "comma_list_owner_split_test",
         "lowering_test",
         "mini_factors_test",

--- a/devinfra/js/debundle/e2e/at_init_s_chain_dataflow_test.rs
+++ b/devinfra/js/debundle/e2e/at_init_s_chain_dataflow_test.rs
@@ -288,17 +288,25 @@ fn bail_out_keeps_s_edge_when_statement_uses_direct_eval() {
     // whether its syntactic write set is otherwise disjoint from the
     // prior statement's writes. See `README.md` →
     // "Conditionally-correct optimizations" for the full bail-out list.
-    let fixture = run_fixture(dataflow_opts(
-        r#"const tagA = (globalThis.alpha = "alpha-val", "tag-a");
+    //
+    // Top-level eval also violates the A1 admission check
+    // (chunk_admission_test pins that rejection); this fixture opts
+    // out via the spec override so the per-statement dataflow bail-out
+    // stays exercised on its own.
+    let fixture = run_fixture(
+        dataflow_opts(
+            r#"const tagA = (globalThis.alpha = "alpha-val", "tag-a");
 const tagB = (eval("globalThis.beta = 'beta-val'"), "tag-b");
 console.log(tagA, tagB, globalThis.alpha, globalThis.beta);
 export { tagA, tagB };
 "#,
-        vec![
-            logical_module("mod_a", &[Member::new("tagA")]),
-            logical_module("mod_b", &[Member::new("tagB")]),
-        ],
-    ));
+            vec![
+                logical_module("mod_a", &[Member::new("tagA")]),
+                logical_module("mod_b", &[Member::new("tagB")]),
+            ],
+        )
+        .with_admission_overrides(&["a1_eval"]),
+    );
     assert_entry_output(&fixture, "tag-a tag-b alpha-val beta-val\n");
 
     let graph: OwnerGraphReport =

--- a/devinfra/js/debundle/e2e/chunk_admission_test.rs
+++ b/devinfra/js/debundle/e2e/chunk_admission_test.rs
@@ -1,0 +1,228 @@
+//! Input-chunk admission checks (docs/design.md A1/A3/A5): chunks
+//! containing shapes outside the realizability theorem's input subset
+//! are rejected before any quotient or lowering work, with the
+//! offending statement ordinal in the diagnostic; audited chunks can
+//! opt out per check via
+//! `chunk_analysis_options.<chunk>.admission_overrides`. A4 (`with`)
+//! is rejected earlier, at parse (module code is strict) — pinned
+//! here too. The A2 (top-level await) sibling bail is pinned in
+//! `realizability_test.rs::top_level_await_is_rejected`.
+
+use debundle_e2e_support::{
+    FixtureOpts, Member, assert_entry_output, expect_rejection_containing_all, logical_module,
+    run_fixture,
+};
+
+// --- A1: no `eval` at module top level -----------------------------------
+
+#[test]
+fn top_level_direct_eval_is_rejected() {
+    expect_rejection_containing_all(
+        FixtureOpts::new(
+            r#"const A = 1;
+eval("globalThis.tag = 1");
+console.log(A);
+export { A };
+"#,
+            vec![logical_module("mod_x", &[Member::new("A")])],
+        ),
+        // Diagnostic contract: the assumption tag, the offending
+        // statement ordinal, and the override spelling.
+        &["a1_eval", "statement #1", "eval", "admission_overrides"],
+    );
+}
+
+#[test]
+fn top_level_indirect_seq_eval_is_rejected() {
+    // `(0, eval)(...)` — the callee hides behind a comma sequence;
+    // the admission scan must look through parens AND SeqExpr.
+    expect_rejection_containing_all(
+        FixtureOpts::new(
+            r#"const A = 1;
+(0, eval)("globalThis.tag = 1");
+export { A };
+"#,
+            vec![logical_module("mod_x", &[Member::new("A")])],
+        ),
+        &["a1_eval", "statement #1", "eval"],
+    );
+}
+
+#[test]
+fn eval_inside_function_body_is_allowed() {
+    // A1 only bans module-top eval. A lazy (function-body) eval is a
+    // documented residual risk, not an admission violation — see
+    // docs/design.md §"Coverage gaps".
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"function reader() {
+  return eval("1 + 1");
+}
+const A = "ok";
+console.log(A);
+export { A, reader };
+"#,
+        vec![logical_module("mod_x", &[Member::new("A")])],
+    ));
+    assert_entry_output(&fixture, "ok\n");
+}
+
+// --- A3: no dynamic import of debundled internal modules -----------------
+
+#[test]
+fn dynamic_import_of_own_chunk_is_rejected() {
+    // The literal specifier resolves back into the chunk being
+    // debundled — an internal dynamic import that routes around the
+    // static import graph `I`.
+    expect_rejection_containing_all(
+        FixtureOpts::new(
+            r#"const A = 1;
+const again = () => import("./app.js");
+export { A, again };
+"#,
+            vec![logical_module("mod_x", &[Member::new("A")])],
+        ),
+        &[
+            "a3_dynamic_import",
+            "statement #1",
+            "resolves into this chunk",
+        ],
+    );
+}
+
+#[test]
+fn top_level_non_literal_dynamic_import_is_rejected() {
+    expect_rejection_containing_all(
+        FixtureOpts::new(
+            r#"const name = "./extra.js";
+import(name);
+const A = 1;
+export { A };
+"#,
+            vec![logical_module("mod_x", &[Member::new("A")])],
+        ),
+        &["a3_dynamic_import", "statement #1", "non-literal"],
+    );
+}
+
+#[test]
+fn external_and_lazy_dynamic_imports_are_allowed() {
+    // External literal targets are black-box leaves (allowed even at
+    // top level); non-literal specifiers are allowed in lazy
+    // positions (documented residual gap).
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"const lazyByName = (name) => import(name);
+const loadVendor = () => import("some-external-package");
+const A = "ok";
+console.log(A);
+export { A, lazyByName, loadVendor };
+"#,
+        vec![logical_module("mod_x", &[Member::new("A")])],
+    ));
+    assert_entry_output(&fixture, "ok\n");
+}
+
+// --- A4: no `with` blocks -------------------------------------------------
+
+#[test]
+fn with_block_is_rejected_at_parse() {
+    // Module code is strict per ECMA-262, and the parser surfaces
+    // `with` as a recoverable parse error that fails chunk loading —
+    // so A4 never reaches the Stage A admission scan and needs no AST
+    // check there. This test pins the parse-time rejection (and that
+    // the error message names the strict-mode `with` ban, not just an
+    // opaque error count).
+    expect_rejection_containing_all(
+        FixtureOpts::new(
+            r#"const obj = { x: 1 };
+function f() {
+  with (obj) {
+    return x;
+  }
+}
+const A = 1;
+export { A, f };
+"#,
+            vec![logical_module("mod_x", &[Member::new("A")])],
+        ),
+        &["failed to parse", "with"],
+    );
+}
+
+// --- A5: no namespace reflection beyond `import.meta.url` ----------------
+
+#[test]
+fn top_level_import_meta_reflection_is_rejected() {
+    expect_rejection_containing_all(
+        FixtureOpts::new(
+            r#"const env = import.meta.env;
+const A = 1;
+export { A, env };
+"#,
+            vec![logical_module("mod_x", &[Member::new("A")])],
+        ),
+        &["a5_import_meta", "statement #0", "import.meta.env"],
+    );
+}
+
+#[test]
+fn import_meta_url_is_allowed() {
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"const here = import.meta.url;
+const A = "ok";
+console.log(A);
+export { A, here };
+"#,
+        vec![logical_module("mod_x", &[Member::new("A")])],
+    ));
+    assert_entry_output(&fixture, "ok\n");
+}
+
+// --- Spec-level override escape hatch -------------------------------------
+
+#[test]
+fn admission_override_admits_audited_chunk_with_notice() {
+    let fixture = run_fixture(
+        FixtureOpts::new(
+            r#"const A = "ok";
+eval("1 + 1");
+console.log(A);
+export { A };
+"#,
+            vec![logical_module("mod_x", &[Member::new("A")])],
+        )
+        .with_admission_overrides(&["a1_eval"]),
+    );
+    // Every override use prints a one-line notice naming the check
+    // and the suppressed violation.
+    assert!(
+        fixture
+            .stderr
+            .contains("admission check a1_eval overridden by spec"),
+        "stderr missing override notice:\n{}",
+        fixture.stderr,
+    );
+    assert_entry_output(&fixture, "ok\n");
+}
+
+#[test]
+fn redundant_admission_override_warns() {
+    // An override that no longer suppresses anything is stale trust
+    // surface — surfaced like redundant purity hints.
+    let fixture = run_fixture(
+        FixtureOpts::new(
+            r#"const A = "ok";
+console.log(A);
+export { A };
+"#,
+            vec![logical_module("mod_x", &[Member::new("A")])],
+        )
+        .with_admission_overrides(&["a5_import_meta"]),
+    );
+    assert!(
+        fixture
+            .stderr
+            .contains("admission override `a5_import_meta` is redundant"),
+        "stderr missing redundant-override warning:\n{}",
+        fixture.stderr,
+    );
+}

--- a/devinfra/js/debundle/e2e/chunk_rename_cross_module_test.rs
+++ b/devinfra/js/debundle/e2e/chunk_rename_cross_module_test.rs
@@ -54,6 +54,7 @@ export { a, b, c };
         chunk_id: "static/app",
         unassigned_mode: unassigned_mode_catchall_file(None),
         dataflow_aware_s_chain: false,
+        admission_overrides: &[],
         extra_files: &[(
             "static/app/vendor.js",
             "export function f() { return 1; }\n",

--- a/devinfra/js/debundle/e2e/cross_module_emission_test.rs
+++ b/devinfra/js/debundle/e2e/cross_module_emission_test.rs
@@ -645,6 +645,7 @@ export { St as B, Ite };
         chunk_id: "static/app",
         unassigned_mode: unassigned_mode_inline(),
         dataflow_aware_s_chain: false,
+        admission_overrides: &[],
         extra_files: &[(
             "static/app/vendor.js",
             r#"export function o(value) {

--- a/devinfra/js/debundle/e2e/mini_factors_test.rs
+++ b/devinfra/js/debundle/e2e/mini_factors_test.rs
@@ -24,6 +24,7 @@ fn catchall_keeps_unclaimed_bindings_in_residual() {
         chunk_id: "static/app",
         unassigned_mode: unassigned_mode_catchall_file(None),
         dataflow_aware_s_chain: false,
+        admission_overrides: &[],
         extra_files: &[],
     };
     let fixture = run_fixture(opts);
@@ -50,6 +51,7 @@ fn mini_factors_synthesizes_one_module_per_unclaimed_unit() {
         chunk_id: "static/app",
         unassigned_mode: unassigned_mode_mini_factors(),
         dataflow_aware_s_chain: false,
+        admission_overrides: &[],
         extra_files: &[],
     };
     let fixture = run_fixture(opts);

--- a/devinfra/js/debundle/e2e/purity_test.rs
+++ b/devinfra/js/debundle/e2e/purity_test.rs
@@ -974,6 +974,7 @@ export { a, b, c };
         chunk_id: "static/app",
         unassigned_mode: unassigned_mode_catchall_file(None),
         dataflow_aware_s_chain: false,
+        admission_overrides: &[],
         extra_files: &[(
             "static/app/vendor.js",
             "export function f() { return 1; }\n",

--- a/devinfra/js/debundle/e2e/residual_member_rename_test.rs
+++ b/devinfra/js/debundle/e2e/residual_member_rename_test.rs
@@ -33,6 +33,7 @@ export { a, b };
         chunk_id: "static/app",
         unassigned_mode: unassigned_mode_catchall_file(None),
         dataflow_aware_s_chain: false,
+        admission_overrides: &[],
         extra_files: &[],
     };
     let fixture = run_fixture(opts);

--- a/devinfra/js/debundle/e2e/s_chain_dataflow_soundness_test.rs
+++ b/devinfra/js/debundle/e2e/s_chain_dataflow_soundness_test.rs
@@ -267,19 +267,26 @@ export { got };
 /// chain (subsumed by the opaque-call rule).
 #[test]
 fn indirect_eval_is_a_barrier() {
-    let fixture = run_fixture(dataflow_opts(
-        r#"globalThis.alpha = "a";
+    // Top-level indirect eval also violates the A1 admission check
+    // (chunk_admission_test pins that rejection); this fixture opts
+    // out via the spec override so the per-statement dataflow
+    // bail-out stays exercised on its own.
+    let fixture = run_fixture(
+        dataflow_opts(
+            r#"globalThis.alpha = "a";
 const tagB = ((0, eval)("globalThis.beta = globalThis.alpha + 'b'"), "t");
 const got = globalThis.beta;
 console.log(got, tagB);
 export { tagB, got };
 "#,
-        vec![
-            logical_module_with_anon("mod_a", &[], &[r#"globalThis.alpha = "a";"#]),
-            logical_module("mod_b", &[Member::new("tagB")]),
-            logical_module("mod_read", &[Member::new("got")]),
-        ],
-    ));
+            vec![
+                logical_module_with_anon("mod_a", &[], &[r#"globalThis.alpha = "a";"#]),
+                logical_module("mod_b", &[Member::new("tagB")]),
+                logical_module("mod_read", &[Member::new("got")]),
+            ],
+        )
+        .with_admission_overrides(&["a1_eval"]),
+    );
     assert_entry_output(&fixture, "ab t\n");
     let graph = read_owner_graph(&fixture);
     assert_sequenced_edge(

--- a/devinfra/js/debundle/e2e/support.rs
+++ b/devinfra/js/debundle/e2e/support.rs
@@ -521,6 +521,10 @@ pub struct FixtureOpts<'a> {
     /// adjacent-impure chain. Tests that exercise the relaxation set
     /// this `true`.
     pub dataflow_aware_s_chain: bool,
+    /// Input-chunk admission checks to disable for this chunk
+    /// (`chunk_analysis_options.<chunk>.admission_overrides`), e.g.
+    /// `&["a1_eval"]`. Default empty — all admission checks enforced.
+    pub admission_overrides: &'a [&'a str],
     pub extra_files: &'a [(&'a str, &'a str)],
 }
 
@@ -539,8 +543,16 @@ impl<'a> FixtureOpts<'a> {
             chunk_id: "static/app",
             unassigned_mode: unassigned_mode_catchall_file(None),
             dataflow_aware_s_chain: false,
+            admission_overrides: &[],
             extra_files: &[],
         }
+    }
+
+    /// Disable the named admission checks for this chunk via
+    /// `chunk_analysis_options.<chunk>.admission_overrides`.
+    pub fn with_admission_overrides(mut self, overrides: &'a [&'a str]) -> Self {
+        self.admission_overrides = overrides;
+        self
     }
 
     /// Enable the dataflow-aware S-chain emission for this chunk. Used
@@ -602,6 +614,9 @@ pub struct Fixture {
     pub entry_path: PathBuf,
     pub out_root: PathBuf,
     pub report_root: PathBuf,
+    /// The debundler's stderr from the successful run, for asserting
+    /// on warnings/notices (e.g. admission-override notices).
+    pub stderr: String,
     // Held to keep the tempdir alive for the duration of assertions.
     _root: TempDir,
 }
@@ -645,6 +660,7 @@ pub fn run_fixture(opts: FixtureOpts<'_>) -> Fixture {
         entry_path,
         out_root: app_root,
         report_root: setup.report_root,
+        stderr: result.stderr,
         _root: setup.root,
     }
 }
@@ -910,11 +926,18 @@ fn build_spec<'a>(opts: &FixtureOpts<'_>, setup: &'a FixtureSetup) -> TransformS
     unassigned_mode.insert(chunk_id.to_string(), opts.unassigned_mode.clone());
 
     let mut chunk_analysis_options = BTreeMap::new();
+    let mut analysis_options = serde_json::Map::new();
     if opts.dataflow_aware_s_chain {
-        chunk_analysis_options.insert(
-            chunk_id.to_string(),
-            serde_json::json!({ "dataflow_aware_s_chain": true }),
+        analysis_options.insert("dataflow_aware_s_chain".to_string(), Value::Bool(true));
+    }
+    if !opts.admission_overrides.is_empty() {
+        analysis_options.insert(
+            "admission_overrides".to_string(),
+            serde_json::json!(opts.admission_overrides),
         );
+    }
+    if !analysis_options.is_empty() {
+        chunk_analysis_options.insert(chunk_id.to_string(), Value::Object(analysis_options));
     }
 
     TransformSpecFixture {

--- a/devinfra/js/debundle/facts/mod.rs
+++ b/devinfra/js/debundle/facts/mod.rs
@@ -10,8 +10,8 @@ pub use wire::{
 };
 
 use binding_targets::{
-    TargetAccessRecorder, declaration_ids, hoisted_var_ids, record_assign_target, record_pat_write,
-    record_update_target, strip_parens,
+    TargetAccessRecorder, callee_base_expr, declaration_ids, hoisted_var_ids, record_assign_target,
+    record_pat_write, record_update_target, strip_parens,
 };
 use serde::{Deserialize, Serialize};
 use swc_common::{Span, Spanned};
@@ -1744,17 +1744,6 @@ impl Visit for StatementFactsCollector {
     fn visit_class_member(&mut self, member: &ClassMember) {
         lazy_visit_class_member(self, member);
     }
-}
-
-/// Look through parens and comma sequences to a callee's final
-/// operand: `(0, eval)(...)` is an indirect eval call with the same
-/// arbitrary-cell-write power as a direct one.
-fn callee_base_expr(expr: &Expr) -> &Expr {
-    let mut cur = strip_parens(expr);
-    while let Expr::Seq(seq) = cur {
-        cur = strip_parens(seq.exprs.last().expect("SeqExpr is non-empty"));
-    }
-    cur
 }
 
 /// The member expression a simple assignment target writes through,

--- a/devinfra/js/debundle/js_ast.rs
+++ b/devinfra/js/debundle/js_ast.rs
@@ -233,9 +233,18 @@ fn parse_module_from_source_file(source_name: &str, fm: &swc_common::SourceFile)
         .map_err(|error| anyhow::anyhow!("failed to parse {source_name}: {:?}", error.kind()))?;
     let recovered = parser.take_errors();
     if !recovered.is_empty() {
+        // Include each recovered error's message so the rejection is
+        // actionable — e.g. a `with` statement in module (strict)
+        // code surfaces as its strict-mode syntax error here
+        // (docs/design.md A4) rather than as an opaque count.
+        let details = recovered
+            .iter()
+            .map(|error| error.kind().msg())
+            .collect::<Vec<_>>()
+            .join("; ");
         bail!(
-            "failed to parse {source_name}: {} recoverable parser error(s)",
-            recovered.len()
+            "failed to parse {source_name}: {count} recoverable parser error(s): {details}",
+            count = recovered.len(),
         );
     }
     Ok(module)

--- a/devinfra/js/debundle/lib.rs
+++ b/devinfra/js/debundle/lib.rs
@@ -16,6 +16,7 @@
 
 mod analysis_hints;
 mod atomic_units;
+mod chunk_admission;
 mod chunk_analysis;
 mod chunk_factorization;
 mod factor_assembly;
@@ -35,6 +36,7 @@ pub use atomic_units::{
     AtomicUnit, OwnerGraphAndUnits, compute_atomic_units, compute_owner_graph_and_units,
     compute_owner_graph_and_units_with,
 };
+pub use chunk_admission::{DynamicImportTarget, enforce_chunk_admission};
 pub use chunk_analysis::ChunkAnalysis;
 pub use chunk_factorization::ChunkFactorization;
 pub use factor_assembly::{

--- a/devinfra/js/debundle/lowering/materialize/mod.rs
+++ b/devinfra/js/debundle/lowering/materialize/mod.rs
@@ -198,6 +198,22 @@ pub(super) fn materialize_logical_chunk(
         .get(chunk_id)
         .copied()
         .unwrap_or_default();
+    // A3 admission resolver: where does a dynamic-import specifier in
+    // this chunk's entry land? Same artifact resolution the specifier
+    // rewriter uses; `SameChunk` marks a debundled internal module.
+    let resolve_dynamic_import = |specifier: &str| match artifact_indexes
+        .resolve_runtime_import_reference(
+            specifier,
+            chunk_id_interned,
+            &target_file,
+            &artifact.chunk_table,
+        ) {
+        Some(resolved) if resolved.target_chunk_id == chunk_id_interned => {
+            DynamicImportTarget::SameChunk
+        }
+        Some(_) => DynamicImportTarget::OtherChunk,
+        None => DynamicImportTarget::External,
+    };
     let stage_one = time_phase!(timings, "compute_stage_one_analysis", {
         compute_stage_one_analysis(
             chunk_id,
@@ -206,6 +222,7 @@ pub(super) fn materialize_logical_chunk(
             Some(&source_path),
             |span| line_index.line_range_for_span(span),
             owner_graph_options,
+            &resolve_dynamic_import,
         )?
     });
     let StageOneAnalysis {

--- a/devinfra/js/debundle/lowering/mod.rs
+++ b/devinfra/js/debundle/lowering/mod.rs
@@ -10,11 +10,11 @@ use swc_ecma_ast::*;
 use swc_ecma_visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 
 use analysis::{
-    AnalysisHints, AtomicUnitConflict, BindingKind, ChunkFactorization, DepKind, KnownEffect,
-    LogicalModule as FactorizationLogicalModule, LogicalModuleIndex, ModuleId, OwnerGraphAndUnits,
-    OwnerGraphOptions, OwnerId, RebindFold, RedundantPurityHint, StageOneAnalysis,
-    compute_rebind_folds, compute_stage_one_analysis, render_atomic_unit_conflict_summary,
-    render_cycle_summary, top_level_id,
+    AnalysisHints, AtomicUnitConflict, BindingKind, ChunkFactorization, DepKind,
+    DynamicImportTarget, KnownEffect, LogicalModule as FactorizationLogicalModule,
+    LogicalModuleIndex, ModuleId, OwnerGraphAndUnits, OwnerGraphOptions, OwnerId, RebindFold,
+    RedundantPurityHint, StageOneAnalysis, compute_rebind_folds, compute_stage_one_analysis,
+    render_atomic_unit_conflict_summary, render_cycle_summary, top_level_id,
 };
 use artifact::{
     ArtifactIndexes, ArtifactSourceImportResolver, ChunkAnalysisReport, ChunkArtifact, ChunkBundle,

--- a/devinfra/js/debundle/spec.rs
+++ b/devinfra/js/debundle/spec.rs
@@ -126,6 +126,107 @@ pub struct OwnerGraphOptions {
     /// check.
     #[serde(default)]
     pub dataflow_aware_s_chain: bool,
+    /// Input-chunk admission checks (docs/design.md A1/A3/A5) the
+    /// spec author has audited and explicitly disabled for this
+    /// chunk. YAML surface is a list of check names
+    /// (`admission_overrides: [a1_eval, a5_import_meta]`). Every configured
+    /// override prints a one-line notice when it suppresses a
+    /// violation, and a redundant-override warning when it no longer
+    /// suppresses anything.
+    #[serde(default, skip_serializing_if = "AdmissionOverrides::is_empty")]
+    pub admission_overrides: AdmissionOverrides,
+}
+
+/// One named input-chunk admission check, identified by the
+/// docs/design.md assumption it enforces. Used both as the
+/// spec-override list-element type and as the violation tag in
+/// admission diagnostics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AdmissionCheck {
+    /// A1: no `eval(...)` / `(0, eval)(...)` at module top level.
+    A1Eval,
+    /// A3: no dynamic `import()` of a debundled internal module
+    /// (same-chunk literal target, or non-literal specifier at
+    /// module top level).
+    A3DynamicImport,
+    /// A5 (partial): no `import.meta` reflection beyond
+    /// `import.meta.url` at module top level.
+    A5ImportMeta,
+}
+
+impl AdmissionCheck {
+    /// The spec-facing snake_case name (the `admission_overrides`
+    /// list element spelling), for diagnostics.
+    pub fn spec_name(self) -> &'static str {
+        match self {
+            Self::A1Eval => "a1_eval",
+            Self::A3DynamicImport => "a3_dynamic_import",
+            Self::A5ImportMeta => "a5_import_meta",
+        }
+    }
+}
+
+impl fmt::Display for AdmissionCheck {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.spec_name())
+    }
+}
+
+/// Per-chunk escape hatch for the input-chunk admission scan: the set
+/// of checks disabled for an audited chunk. Serialized as a list of
+/// [`AdmissionCheck`] names so the YAML reads as
+/// `admission_overrides: [a1_eval, ...]`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(from = "Vec<AdmissionCheck>", into = "Vec<AdmissionCheck>")]
+pub struct AdmissionOverrides {
+    pub a1_eval: bool,
+    pub a3_dynamic_import: bool,
+    pub a5_import_meta: bool,
+}
+
+impl AdmissionOverrides {
+    pub fn is_empty(&self) -> bool {
+        *self == Self::default()
+    }
+
+    pub fn contains(&self, check: AdmissionCheck) -> bool {
+        match check {
+            AdmissionCheck::A1Eval => self.a1_eval,
+            AdmissionCheck::A3DynamicImport => self.a3_dynamic_import,
+            AdmissionCheck::A5ImportMeta => self.a5_import_meta,
+        }
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = AdmissionCheck> + '_ {
+        [
+            AdmissionCheck::A1Eval,
+            AdmissionCheck::A3DynamicImport,
+            AdmissionCheck::A5ImportMeta,
+        ]
+        .into_iter()
+        .filter(|check| self.contains(*check))
+    }
+}
+
+impl From<Vec<AdmissionCheck>> for AdmissionOverrides {
+    fn from(checks: Vec<AdmissionCheck>) -> Self {
+        let mut overrides = Self::default();
+        for check in checks {
+            match check {
+                AdmissionCheck::A1Eval => overrides.a1_eval = true,
+                AdmissionCheck::A3DynamicImport => overrides.a3_dynamic_import = true,
+                AdmissionCheck::A5ImportMeta => overrides.a5_import_meta = true,
+            }
+        }
+        overrides
+    }
+}
+
+impl From<AdmissionOverrides> for Vec<AdmissionCheck> {
+    fn from(overrides: AdmissionOverrides) -> Self {
+        overrides.iter().collect()
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -940,4 +1041,44 @@ pub enum MemberEffect {
     /// effect on the target class/prototype instead of as a global
     /// side-effect-order edge. See docs/design.md A10.
     TypescriptDecorateHelper,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The YAML override list parses into the typed set and unknown
+    /// check names are rejected (strict data mapping).
+    #[test]
+    fn admission_overrides_parse_from_list() {
+        let options: OwnerGraphOptions =
+            serde_json::from_str(r#"{ "admission_overrides": ["a1_eval", "a5_import_meta"] }"#)
+                .unwrap();
+        assert!(options.admission_overrides.contains(AdmissionCheck::A1Eval));
+        assert!(
+            options
+                .admission_overrides
+                .contains(AdmissionCheck::A5ImportMeta)
+        );
+        assert!(
+            !options
+                .admission_overrides
+                .contains(AdmissionCheck::A3DynamicImport)
+        );
+
+        let invalid: Result<OwnerGraphOptions, _> =
+            serde_json::from_str(r#"{ "admission_overrides": ["a99_bogus"] }"#);
+        assert!(invalid.is_err(), "unknown admission check must be rejected");
+    }
+
+    /// Default (empty) overrides serialize away entirely so untouched
+    /// specs round-trip without a spurious `admission_overrides: []`.
+    #[test]
+    fn empty_admission_overrides_are_skipped_on_serialize() {
+        let serialized = serde_json::to_string(&OwnerGraphOptions::default()).unwrap();
+        assert!(
+            !serialized.contains("admission_overrides"),
+            "default overrides must not serialize: {serialized}"
+        );
+    }
 }

--- a/devinfra/js/debundle/stage_one/mod.rs
+++ b/devinfra/js/debundle/stage_one/mod.rs
@@ -11,19 +11,25 @@
 //! - the structural atomic units (owner-level SCCs of `G_atomic`),
 //!   which any valid factorization must keep co-located.
 //!
-//! The composer also owns the two side-effects that derive purely
+//! The composer also owns the side-effects that derive purely
 //! from Stage A output:
 //!
 //! - stderr warnings for redundant-purity / redundant-pure-member
 //!   spec hints the analyzer can already infer;
 //! - the fatal bail when a chunk contains a top-level `await` (which
-//!   the realizability theorem does not cover).
+//!   the realizability theorem does not cover);
+//! - the input-chunk admission scan for the other statically
+//!   checkable input assumptions (docs/design.md A1/A3/A5; see
+//!   `chunk_admission`), including its override notices.
 //!
 //! Stage A is a pure function of `(chunk_id, module, hints,
-//! owner_graph_options)` plus the spec-free `source_path` annotation
-//! and the line-index callback for source-location resolution. It
-//! does not read the spec, the partition, chunk renames, or the
-//! unassigned-mode policy — those are Stage B inputs.
+//! owner_graph_options)` plus the spec-free `source_path` annotation,
+//! the line-index callback for source-location resolution, and the
+//! caller-supplied dynamic-import resolver (the A3 admission check
+//! needs "which chunk does this specifier land in", but Stage A
+//! itself stays artifact-free). It does not read the spec, the
+//! partition, chunk renames, or the unassigned-mode policy — those
+//! are Stage B inputs.
 //!
 //! Stage A is materialized only in memory, by callers
 //! (today: `materialize_logical_chunk`) that call
@@ -51,6 +57,7 @@ use swc_ecma_ast::Module;
 
 use crate::AnalysisHints;
 use crate::atomic_units::{OwnerGraphAndUnits, compute_owner_graph_and_units_with};
+use crate::chunk_admission::{DynamicImportTarget, enforce_chunk_admission};
 use crate::facts::{ChunkFactAnalysis, analyze_chunk};
 use crate::graph::OwnerGraphOptions;
 use crate::purity::{RedundantPureMemberReason, RedundantPurityReason};
@@ -72,11 +79,16 @@ pub struct StageOneAnalysis {
 
 /// Run Stage A: analyze the chunk's facts, emit any
 /// redundant-purity-hint diagnostics, fail fast if the chunk has
-/// top-level `await`, then derive the owner graph + structural atomic
-/// units.
+/// top-level `await` or fails the input-chunk admission scan, then
+/// derive the owner graph + structural atomic units.
 ///
 /// Returns `Err` if the chunk has top-level `await` (the realizability
-/// theorem does not cover async modules — see docs/design.md A2).
+/// theorem does not cover async modules — see docs/design.md A2) or
+/// violates a non-overridden admission check (docs/design.md
+/// A1/A3/A5; see `chunk_admission`). `resolve_dynamic_import`
+/// supplies the artifact-aware "where does this dynamic-import
+/// specifier land" answer for the A3 check — Stage A itself stays
+/// artifact-free.
 pub fn compute_stage_one_analysis<F>(
     chunk_id: &str,
     module: &Module,
@@ -84,6 +96,7 @@ pub fn compute_stage_one_analysis<F>(
     source_path: Option<&str>,
     line_range_for_span: F,
     owner_graph_options: OwnerGraphOptions,
+    resolve_dynamic_import: &dyn Fn(&str) -> DynamicImportTarget,
 ) -> Result<StageOneAnalysis>
 where
     F: FnMut(Span) -> Option<(usize, usize)>,
@@ -99,6 +112,12 @@ where
             ordinal = ord.0,
         );
     }
+    enforce_chunk_admission(
+        chunk_id,
+        module,
+        owner_graph_options.admission_overrides,
+        resolve_dynamic_import,
+    )?;
     let owner_graph_and_units =
         compute_owner_graph_and_units_with(&fact_analysis.facts, owner_graph_options);
     Ok(StageOneAnalysis {
@@ -183,6 +202,7 @@ mod tests {
             None,
             |_| None,
             OwnerGraphOptions::default(),
+            &|_| DynamicImportTarget::External,
         )
         .expect("stage one");
 
@@ -217,6 +237,7 @@ mod tests {
             None,
             |_| None,
             OwnerGraphOptions::default(),
+            &|_| DynamicImportTarget::External,
         );
         let err = result.expect_err("TLA chunks must fail Stage A");
         let msg = format!("{err:#}");


### PR DESCRIPTION
## What

`docs/design.md` §"Conditions on the input chunk" calls A1–A5 "statically checkable on each chunk", but only A2 (top-level await) was actually enforced (the TLA bail in `stage_one`). This PR adds an input-chunk admission scan — a new module `chunk_admission.rs` with its own SWC visitor — run by `stage_one::compute_stage_one_analysis` right next to the existing A2 bail, before any quotient or lowering work. Each rejection mirrors the A2 UX: chunk id + offending statement ordinal (post-comma-split view, aligned with owner-graph reports) + the matched shape, plus the override spelling to use after auditing.

## Per-check strength

- **A1 (`eval`) — enforced, module-top only**: direct `eval(...)` and seq-indirect `(0, eval)(...)`; the callee is unwrapped through parens AND comma sequences (no seq-aware helper existed on devel, so the scan carries its own ~10-line unwrap; #2064's, if it lands one, can be unified later). Module code is strict, so an `eval` ident can only be the global eval. **Residual gaps (documented in design.md "Coverage gaps")**: function-body eval — A1's wording only bans module-top eval, but a lazy direct eval can still read cross-module bindings dynamically when called after the split — and aliased eval (`const e = eval`).
- **A3 (internal dynamic import) — enforced**: string-literal `import(...)` specifiers are resolved through `ArtifactIndexes::resolve_runtime_import_reference` (the same resolution the specifier rewriter uses, threaded into Stage A as a callback so Stage A stays artifact-free). A specifier resolving back **into the same chunk** is rejected at any depth — `I` is the per-chunk graph, so that is the "debundled internal module" case. Specifiers resolving to *other* artifact chunks are allowed: design.md explicitly treats vendor/route chunks as black-box leaves, and flagging them would reject every code-splitting bundle (esbuild/SvelteKit `import()` thunks are everywhere) — the worse failure mode. **Non-literal specifiers at top level: bail** (soundness over completeness; no e2e fixture or in-repo corpus relies on them — `props/frontend/debundle/` does not exist in-tree). Non-literal specifiers in lazy positions stay a documented gap; "literal" means `Lit::Str`, matching `prepare_js_chunks` / `rewrite_chunk_entry_specifiers`.
- **A4 (`with`) — enforced at parse, no admission code**: verified experimentally that even with the production parser's `no_early_errors: true` TS syntax, `with` surfaces as a recoverable parse error and `js_ast` fails chunk loading. Per the no-dead-code instruction the visitor check was removed; instead the parse rejection is pinned by `with_block_is_rejected_at_parse`, and `js_ast::parse_module_from_source_file` now includes the recovered errors' messages (previously an opaque "N recoverable parser error(s)"). There is consequently no `a4_with` override — a parse error can't be meaningfully overridden.
- **A5 (namespace reflection) — minimal by design**: only the cheap, low-false-positive sub-shape is checked: module-top `import.meta` use beyond `import.meta.url` (named props like `import.meta.env`, computed `import.meta[...]`, bare `import.meta` as a value). `Function.prototype.toString` reads and `Reflect` descriptor inspection are deliberately **not** checked — a precise analysis would over-flag mainstream bundles. The decision and the unchecked sub-shapes are documented in design.md (A5 bullet + "Coverage gaps").

## Escape hatch

On by default for `debundle run`. Per-chunk, per-check override following the existing `chunk_analysis_options` pattern:

```yaml
chunk_analysis_options:
  static/app:
    admission_overrides: [a1_eval]
```

Every override use prints a one-line notice; an override that no longer suppresses anything warns as redundant (mirroring redundant purity hints). One existing fixture (`at_init_s_chain_dataflow_test::bail_out_keeps_s_edge_when_statement_uses_direct_eval`) intentionally uses top-level eval to pin the dataflow bail-out path — it now opts out via `a1_eval` with a comment.

## Tests

- `e2e/chunk_admission_test.rs`: violating chunk → rejection with the right diagnostic (A1 direct + seq-indirect, A3 same-chunk + top-level non-literal, A4 parse, A5 `import.meta.env`); clean/benign chunk → passes (function-body eval, external + lazy dynamic imports, `import.meta.url`); override → passes with notice; stale override → redundant warning.
- Unit tests in `chunk_admission.rs` for visitor corner cases (paren-wrapped nested seq eval, static-block-eager vs method-body-lazy class positions, template-literal specifiers, ordinal alignment with the comma-split view).
- A2's existing bail remains pinned by `realizability_test.rs::top_level_await_is_rejected` (still present post-merges).
- `spec.rs` tests: override list parsing, unknown check name rejected, empty overrides skipped on serialize.

`bbr test //devinfra/js/debundle/...`: 92/92 green (buildbuddy:98a01fb6-6f75-42a9-a88e-e6805eb98073); `bbr build //...` green.

## Coordination with #2064

Implemented as a new module with its own visitor (no `StatementFactsCollector` changes) and wired in `stage_one/mod.rs` next to the A2 bail, per the conflict-minimization plan — #2064's at-init fallback / hoisted-vars / dataflow-collector work doesn't touch these seams, but **this PR may need a trivial rebase if #2064 merges first** (shared neighborhoods: `lowering/materialize/mod.rs` around the `compute_stage_one_analysis` call, `at_init_s_chain_dataflow_test.rs`). The A3/A1 admission bails are about the strict path's global input assumptions and are complementary to #2064's opaque-call bails in dataflow mode.

https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk)_