### PR TITLE
loom/gym/sandbox: document why the agent image is a Dockerfile

### DIFF
--- a/loom/gym/sandbox/Dockerfile
+++ b/loom/gym/sandbox/Dockerfile
@@ -3,6 +3,16 @@
 # so everything it needs must be in the image). This file is shown to the agent
 # verbatim in its system prompt (loom/gym/inspect_harness.py embeds it), so it is
 # the single source of truth for the inventory — there is no separate list to sync.
+#
+# Why a Dockerfile (not a Bazel oci_image like most images here): this is a full
+# interactive python3 environment the agent shells into, and its core is the pip
+# scientific stack (pymc, numpy, pandas, scikit-learn, arch, arviz, statsmodels).
+# Those aren't apt packages, so a rules_distroless apt layer can't install them;
+# and rules_python lays wheels out as runfiles, not the system site-packages a bare
+# `python3 -c ...` resolves. A Bazel build would need a rules_python venv layer
+# wired so interactive python3 finds it — more fragile than this, for no real gain.
+# So, like the RBE-worker / web_env images, it stays a Dockerfile; the GHA
+# container-images.yml job builds it and pushes it to GHCR.
 FROM python:3.13-slim
 
 # bash for the agent's bash tool; curl + ca-certificates for HTTPS fetches; g++ so


### PR DESCRIPTION
Follow-up to #2065. Records, in the Dockerfile itself, why `loom-gym-sandbox` is a Dockerfile rather than a Bazel `oci_image` like most images here:

- It's a full **interactive `python3`** env the agent shells into, and its core is the pip scientific stack (`pymc`/`numpy`/`pandas`/`scikit-learn`/`arch`/`arviz`/`statsmodels`).
- Those aren't apt packages, so a `rules_distroless` apt layer can't install them; and `rules_python` lays wheels out as runfiles, not the system `site-packages` a bare `python3 -c ...` resolves.
- A Bazel build would need a `rules_python` venv layer wired so interactive `python3` finds it — more fragile for no real gain — so like the RBE-worker / web_env images it stays a Dockerfile.

Comment-only; no behavior change.

https://claude.ai/code/session_01AXSFxfCXddADoSKTjgF5Nz

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXSFxfCXddADoSKTjgF5Nz)_