### PR TITLE
Validate tofu-controller backends

### DIFF
--- a/cluster/validation/BUILD.bazel
+++ b/cluster/validation/BUILD.bazel
@@ -88,6 +88,15 @@ py_library(
 )
 
 py_library(
+    name = "terraform_backends",
+    srcs = ["terraform_backends.py"],
+    deps = [
+        ":cluster",
+        ":k8s",
+    ],
+)
+
+py_library(
     name = "crd_layering",
     srcs = ["crd_layering.py"],
     deps = [":kustomize"],
@@ -139,6 +148,7 @@ py_library(
         ":helm_templates",
         ":image_automation",
         ":kustomize",
+        ":terraform_backends",
     ],
 )
 
@@ -214,6 +224,18 @@ py_test(
         ":k8s",
         ":kustomize",
         "@pypi//pytest",
+        "@pypi//pytest_bazel",
+    ],
+)
+
+py_test(
+    name = "test_terraform_backends",
+    srcs = ["test_terraform_backends.py"],
+    deps = [
+        ":cluster",
+        ":k8s",
+        ":kustomize",
+        ":terraform_backends",
         "@pypi//pytest_bazel",
     ],
 )

--- a/cluster/validation/k8s.py
+++ b/cluster/validation/k8s.py
@@ -89,6 +89,20 @@ class ImageRepositoryResource(K8sResource):
     """Flux `ImageRepository` — only its name is needed."""
 
 
+class TerraformBackendConfig(BaseModel):
+    model_config = ConfigDict(extra="ignore", populate_by_name=True, alias_generator=to_camel)
+    custom_configuration: str = ""
+
+
+class TerraformSpec(BaseModel):
+    model_config = ConfigDict(extra="ignore", populate_by_name=True, alias_generator=to_camel)
+    backend_config: TerraformBackendConfig | None = None
+
+
+class TerraformResource(K8sResource):
+    spec: TerraformSpec = Field(default_factory=TerraformSpec)
+
+
 class SecretRef(BaseModel):
     model_config = ConfigDict(extra="ignore")
     name: str = ""
@@ -154,6 +168,7 @@ _KIND_MODELS: dict[str, type[K8sResource]] = {
     "GitRepository": GitRepositoryResource,
     "ImageUpdateAutomation": ImageUpdateAutomationResource,
     "HelmRelease": HelmReleaseResource,
+    "Terraform": TerraformResource,
     "ImageRepository": ImageRepositoryResource,
     "ImagePolicy": ImagePolicyResource,
     "Receiver": ReceiverResource,

--- a/cluster/validation/terraform_backends.py
+++ b/cluster/validation/terraform_backends.py
@@ -1,0 +1,29 @@
+"""Validation for tofu-controller Terraform backend configuration."""
+
+from __future__ import annotations
+
+import re
+
+from cluster.validation.cluster import ParsedCluster
+from cluster.validation.k8s import TerraformResource
+
+_KUBERNETES_BACKEND_RE = re.compile(r'backend\s+"kubernetes"')
+
+
+def check_terraform_backends(cluster: ParsedCluster) -> list[str]:
+    """Reject Kubernetes Secret-backed tofu-controller state."""
+    errors: list[str] = []
+    for result in cluster.build_results:
+        for resource in result.resources:
+            if not isinstance(resource, TerraformResource):
+                continue
+            custom_config = ""
+            if resource.spec.backend_config is not None:
+                custom_config = resource.spec.backend_config.custom_configuration
+            if _KUBERNETES_BACKEND_RE.search(custom_config):
+                namespace = resource.namespace or "default"
+                errors.append(
+                    f'Terraform {namespace}/{resource.name} uses backend "kubernetes"; '
+                    'use backend "pg" for tofu-controller state so locks and state live outside etcd'
+                )
+    return errors

--- a/cluster/validation/test_terraform_backends.py
+++ b/cluster/validation/test_terraform_backends.py
@@ -1,0 +1,55 @@
+"""Unit tests for tofu-controller backend validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest_bazel
+
+from cluster.validation.cluster import ParsedCluster
+from cluster.validation.k8s import K8sResource, TerraformResource
+from cluster.validation.kustomize import KustomizeBuildResult
+from cluster.validation.terraform_backends import check_terraform_backends
+
+
+def _cluster_with_resource(resource: K8sResource) -> ParsedCluster:
+    return ParsedCluster(
+        build_results=[KustomizeBuildResult(kustomization_path=Path("kustomization.yaml"), resources=[resource])]
+    )
+
+
+def test_pg_backend_passes() -> None:
+    resource = TerraformResource.model_validate(
+        {
+            "apiVersion": "infra.contrib.fluxcd.io/v1alpha2",
+            "kind": "Terraform",
+            "metadata": {"name": "example", "namespace": "flux-system"},
+            "spec": {"backendConfig": {"customConfiguration": 'backend "pg" {\n  schema_name = "example"\n}'}},
+        }
+    )
+
+    assert check_terraform_backends(_cluster_with_resource(resource)) == []
+
+
+def test_kubernetes_backend_fails() -> None:
+    resource = TerraformResource.model_validate(
+        {
+            "apiVersion": "infra.contrib.fluxcd.io/v1alpha2",
+            "kind": "Terraform",
+            "metadata": {"name": "example", "namespace": "flux-system"},
+            "spec": {
+                "backendConfig": {"customConfiguration": 'backend "kubernetes" {\n  secret_suffix = "example"\n}'}
+            },
+        }
+    )
+
+    errors = check_terraform_backends(_cluster_with_resource(resource))
+
+    assert errors == [
+        'Terraform flux-system/example uses backend "kubernetes"; '
+        'use backend "pg" for tofu-controller state so locks and state live outside etcd'
+    ]
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/cluster/validation/validate_all.py
+++ b/cluster/validation/validate_all.py
@@ -18,6 +18,7 @@ Checks:
 11. Image automation <-> webhook: every ImageRepository is listed in the GitHub webhook
     receiver (so pushes reconcile immediately, not just on the 5m poll), and every ImagePolicy
     references a defined ImageRepository
+12. Terraform backends: tofu-controller Terraform CRs must not store state in Kubernetes Secrets
 
 See AGENTS.md section "Flux Kustomization Layering" for CRD layering details.
 """
@@ -44,6 +45,7 @@ from cluster.validation.health_checks import check_controller_health_checks
 from cluster.validation.helm_templates import validate_helm_templates
 from cluster.validation.image_automation import check_image_automation_webhook
 from cluster.validation.kustomize import KustomizeBuildError, run_kustomize_build
+from cluster.validation.terraform_backends import check_terraform_backends
 
 
 async def validate(
@@ -88,6 +90,7 @@ async def validate(
     errors.extend(check_controller_health_checks(cluster, root))
     errors.extend(check_image_automation_webhook(cluster))
     errors.extend(check_flux_bootstrap_auth(cluster, root))
+    errors.extend(check_terraform_backends(cluster))
 
     if not skip_flux_build:
         errors.extend(await validate_flux_build(root))


### PR DESCRIPTION
## Summary
- add a cluster validation check that rejects tofu-controller Terraform CRs using `backend "kubernetes"`
- parse Terraform CR backend config in the cluster validation resource model
- cover the check with a focused unit test

## Tests
- `bbr test //cluster/validation:test_terraform_backends`
- `bazelisk test --config=rbe //cluster/validation:test_terraform_backends //cluster/validation:test_cluster_integration`