### PR TITLE
debundle: file program followups into tracking docs

### DIFF
--- a/devinfra/js/debundle/ARCHITECTURE_BACKLOG.md
+++ b/devinfra/js/debundle/ARCHITECTURE_BACKLOG.md
@@ -37,6 +37,10 @@ path.
 
 ## Encapsulation + module boundaries
 
+### `:analysis` is a Bazel god-crate
+
+The `analysis` `rust_library` (`BUILD.bazel`) compiles ~29 srcs spanning the owner graph (`graph.rs`), the realizability gate (`realizability.rs`), fact extraction (`facts/`), purity (`purity/`), admission (`chunk_admission.rs`), validation, reports, and `stage_one` as one crate. Module boundaries inside it are convention-only; splitting along the existing directory seams would make them compiler-enforced and cut incremental rebuild scope.
+
 ### `ChunkFactorization` is yet another per-chunk IR/report layer
 
 `chunk_factorization.rs::ChunkFactorization` holds `analysis: Arc<ChunkAnalysis>` plus partition + dep_graph + linker_order + maps. Then `validate()` returns a `FactorizationReport` which is yet a third "report" type alongside `ChunkAnalysisReport` and the IR `ChunkAnalysis`. The naming hierarchy is:
@@ -149,6 +153,8 @@ After the rename, `chunk_analysis::ChunkAnalysis` (IR) and `artifact::ChunkAnaly
 
 **Decision needed**: whether the report types are auto-derivable from IR types, or whether they intentionally diverge (e.g. the report has fields the IR doesn't, like `parser: ParserOptionsRecord` for reproducibility).
 
+A related collapse with zero wire change is available today: `artifact.rs::ChunkManifest::from_analysis` copies `ChunkAnalysisReport` into `ChunkManifest` field-by-field; embedding the report struct with `#[serde(flatten)]` removes one duplication layer while keeping the serialized shape identical.
+
 ### Gate simulator ↔ materializer import-order sharing (RESOLVED)
 
 The historical drift surface — the emitter placed phantom side-effect imports first in each emitted module while the simulator sorted ALL of a module's I-successors in one `linker_position` list, residual's missing universal entry imports, and the `usize::MAX` tie-break mismatch — is resolved: both sides now consume one shared ordering implementation, `esm_import_order::EsmImportOrder` (`sort_entry_imports` / `sort_module_imports`), built from the canonical `ChunkConstrainingEdgeSet`. The emitter renders the entry's per-plan import list (named imports for binding-owning plans, side-effect-only imports for binding-less plans) and each module's merged intra-chunk import list (binding + phantom + residual-entry, one sort) from it; the simulator (`realizability::EsmIGraph`) uses the same two sorts as DFS neighbor order, with residual fanning out to every I-graph module exactly as the emitted entry does. Do not reintroduce per-side ordering rules — encode any ordering requirement in `EsmImportOrder` so both sides inherit it.
@@ -158,6 +164,22 @@ Remaining known approximation: the simulator roots at `partition.residual()` (th
 ### Should the kernel's merge gate route through the realizability index?
 
 The peel kernel's hot boolean merge gate is `merge_creates_new_constraining_cycle` (a constraining-only Pearce–Kelly walk over the kernel-maintained `TopoOrder` + class adjacency in `peel/quotient.rs`), with `build_seed_quotient`'s post-seed `check_realizability` pass as the backstop for asymmetric I-cycles. docs/design.md §"Why not Pearce–Kelly verbatim" documents this as the current trade-off. The open question: route the hot gate through the `RealizabilityIndex` (one source of truth, slower per query) vs. keep the PK gate (fast, but a second decision-making derived structure the kernel must keep consistent).
+
+### `peel/quotient.rs` multi-target merge fallback is unreachable
+
+`realizability_cycles_after_contract` keeps a scoped push/verdict/undo fallback for merges whose deltas target multiple modules, but `compute_merge_deltas` only ever emits deltas targeting the single post-merge module, so the `single_target` fast path always wins and the fallback is dead code (the design note that motivated it is stale). Either delete the fallback and the multi-target framing in the module docs, or implement a transition that actually produces multi-target deltas — decide.
+
+### `BindingId`/`BindingTable` interning: implement or delete
+
+docs/design.md sketches a compact interned binding form (`BindingId(usize)` newtype + `BindingTable` of dense indices) and explicitly marks it **not implemented** — an aspirational optimization. Decide: implement it (it is also the natural fix for the BTree-keyed-by-cloned-`Id` hot paths flagged in CODE_REVIEW.md) or delete the passage so design.md describes only the real representation.
+
+### `landable_today` for proposals with cross-residual-cell edges
+
+`peel/factorize.rs` sets `status: BlockedResidualDependency` when a proposal has outgoing constraining edges into other residual cells, but `landable_today` still reflects only anonymous-statement addressability — such a proposal can carry `landable_today: true` while being un-promotable alone. Flipping landability would change the documented `bindings assign --batch` contract (it rejects rows with `landable_today: false`), so this is a deliberate maintainer decision, not an oversight.
+
+### A11 intrinsic integrity: from observed assumption to checked precondition
+
+docs/design.md documents A11 (the chunk runs with unmodified built-in prototypes) as relied on by observation — prototype pollution defeats every purity-whitelist admission argument and is not detected. A `compute_shadowed_globals`-style top-level scan over the analyzed chunks for `<Builtin>.prototype.<x> = ...` assignment shapes would convert the in-corpus half of the assumption into a checked precondition; pollution originating outside the analyzed chunks (host code, other bundles) necessarily stays an assumption.
 
 ### Do anonymous statements deserve a first-class `OwnerKind`?
 

--- a/devinfra/js/debundle/CODE_REVIEW.md
+++ b/devinfra/js/debundle/CODE_REVIEW.md
@@ -6,14 +6,14 @@ Full-package review of `devinfra/js/debundle/` (~47K lines). Findings prioritize
 
 ## P0 — God Modules
 
-### `realizability.rs` (~3265 lines) — largest file in the crate
+### `realizability.rs` (~3300 lines) — largest file in the crate
 
 Four separable concerns plus a large test module live in one file. Suggested split:
 
-- `gate_perf_counters` (~lines 1858–2343) → its own module.
-- `EsmEvaluationSimulator` + `EsmIGraph` → `esm_simulator.rs`.
+- `gate_perf_counters` (a ~490-line `pub mod` near the end) → its own module. Caveat from a prior attempt: the counters are entangled with index internals — `use super::*`, `pub(super)` recording APIs called from inside `RealizabilityIndex` query methods, and shadow state (`IncrementalQuotient::base_snapshot_stale`) that exists only for the timing path. A clean move needs that coupling untangled first (e.g. a narrow recording trait), not just a file move.
+- `EsmEvaluationSimulator` + `EsmIGraph` → `esm_simulator.rs` (the shared import ordering itself already lives in `esm_import_order.rs`).
 - `IncrementalQuotient` + the overlay machinery → its own file.
-- The `#[cfg(test)]` module (~920 lines, from line 2345) → a sibling test file.
+- The `#[cfg(test)]` module (~950 lines) → a sibling test file.
 
 ### `vendor/mod.rs` further split
 
@@ -28,13 +28,21 @@ Whitelist tables already in `purity/whitelists.rs`; long PlainData /
 scanning, and TS enum IIFE recognition still live in `mod.rs` —
 could be sub-split further if it keeps growing.
 
-### `facts/mod.rs` (1357 lines, 2 concerns)
+### `facts/mod.rs` (~1930 lines, 2 concerns)
 
 `StatementFacts` carries many derivable `BTreeSet<Id>` sets that every construction site must keep mutually consistent — see the canonical "### `StatementFacts`" item under P3.
 
 ---
 
 ## P1 — Major Duplication
+
+### Partial-swap validation near-duplication in `vendor/mod.rs`
+
+`apply_partial_vendor_swaps` and `apply_bundled_partial_vendor_swaps` each carry a ~250-line validate/resolve block that differs only in manifest type and bundled-vs-unbundled wiring. Lift shared validate/resolve helpers into a `vendor/validate.rs` so the two dispatchers shrink to mode-specific glue.
+
+### Two parallel top-level fact extractors
+
+`program_analysis.rs::analyze_program_shallow` (import/export records, owner records, side-effect ordinals, rewritable-specifier booleans) keeps its own top-level traversal and declaration classification (`classify_top_level_decl`) alongside the `facts/` walk the analysis pipeline uses. The two rule sets can drift independently; fold the shallow extractor into the facts traversal or derive its records from `StatementFacts`.
 
 ### Test fixture builders in peel/ remaining duplicates
 
@@ -43,6 +51,15 @@ could be sub-split further if it keeps growing.
 ---
 
 ## P2 — Structural Issues
+
+### `graph.rs` — silent-skip hazards
+
+- `build_owner_graph_with` populates `binding_owner` with plain inserts, so duplicate top-level declarations (legal JS: two `var x;`, two `function f() {}`) silently resolve last-insert-wins and earlier declarators get no incoming edges. Detect duplicates and error (or model multi-owner bindings explicitly).
+- `OwnerGraph::from_report` silently `continue`s past edges whose endpoints don't resolve in the node table. A malformed or version-skewed `owner_graph.json` loses edges without a diagnostic — and the planner-side gate then reasons over a weaker graph. Make unresolvable endpoints a hard error (strict mapping).
+
+### `cli/mod.rs` — still a grab-bag (~1800 lines)
+
+After the module/binding/comment/gate extractions, `cli/mod.rs` still hosts the full `scc` and `cluster` command implementations plus their text renderers (`run_scc`, `render_scc_text`, `run_cluster`, `render_cluster_text`) alongside arg structs and dispatch. Move them to sibling modules like the other commands.
 
 ### `lowering/lower.rs` — monolithic function (partially extracted)
 
@@ -64,9 +81,12 @@ Each returns `self.root.join(CONSTANT)`. Replace with a data-driven approach: `r
 
 `rollback_graph.rs`, `artifact.rs`, `realizability.rs` all use BTree collections exclusively. For structures with many lookups, `HashMap`/`HashSet` would be faster. If deterministic iteration is needed, document it at the struct level. `RollbackDiGraph` in particular does many lookups per operation where hash-based would be measurably faster.
 
-### `StatementFacts` (facts/mod.rs) — ~10 BTreeSet<Id> fields
+### `StatementFacts` (facts/mod.rs) — ~18 fields, triple-repeated position pattern
 
-`declared`, `eager_reads`, `eager_rebinds`, `lazy_reads`, `lazy_rebinds`, `first_order_lazy_reads`, `first_order_lazy_rebinds`, `local_effects`, `at_init_calls`, `body_calls`, `first_order_body_calls`. Several are derivable (e.g. the `first_order_*` sets are subsets of their parent). Every construction site must keep the sets mutually consistent. Consider computing derived sets on demand or using a builder that enforces invariants.
+The eager/lazy/first-order shape repeats three times — reads (`eager_reads`/`lazy_reads`/`first_order_lazy_reads`), rebinds (`eager_rebinds`/`lazy_rebinds`/`first_order_lazy_rebinds`), and calls (`at_init_calls`/`body_calls`/`first_order_body_calls`). A `PositionBucketed<T> { eager, lazy, first_order_lazy }` cuts 9 fields to 3 and makes the "first-order ⊆ lazy" subset invariants structural instead of per-construction-site discipline. Two related cleanups:
+
+- The internal `StructuralStatementFacts` spells the same sets in a different vocabulary and renames field-by-field mid-pipeline (`at_init_reads`→`eager_reads`, `at_init_writes`→`eager_rebinds`, `lazy_calls`→`body_calls`, `first_order_lazy_calls`→`first_order_body_calls`). Unify on one vocabulary.
+- The `effects` summary is assembled at construction from the other sets plus the global read/write scans; its `Binding`-cell half restates `declared`/`eager_reads`/`eager_rebinds`, leaving only the `GlobalProp` half as new information. Consider deriving it on demand.
 
 ### `DepKind` 6-way split vs primary constraining/non-constraining axis
 
@@ -82,7 +102,15 @@ Nearly every struct field and function is `pub(super)`. This is "module-private 
 
 ### Vendor manifest struct proliferation
 
-~15 manifest/counts/detail structs with similar shapes in `vendor.rs`. `PartialSwapResolutionManifest` and `BundledPartialSwapResolutionManifest` are nearly structurally identical. Consider a parameterized base type.
+~26 manifest/counts/detail structs with similar shapes in `vendor/manifests.rs`. `PartialSwapResolutionManifest` and `BundledPartialSwapResolutionManifest` are field-for-field twins — a generic `ResolutionManifest<R>` collapses the pair. `PartialSwapSymbolTarget` (`vendor/mod.rs`) is likewise a field-for-field twin of `spec::PartialSwapSymbol`.
+
+### Stringly chunk identity in vendor code
+
+Vendor passes juggle `String` chunk names against the typed `ChunkId` index: `vendor/mod.rs` resolves names through `chunk_table` to a `ChunkId`, then stores the _name_ back into fields and locals called `chunk_id`. The double meaning invites mixups; thread the typed `ChunkId` and convert to names only at message/wire boundaries.
+
+### `ChunkAnalysis` pub inputs + private derived caches
+
+`chunk_analysis.rs` exposes `facts`, `bindings`, `logical_modules`, `chunk_renames`, `owner_graph` as `pub` fields while `build()` precomputes private lookup tables (`owner_report_ids_by_binding`, `binding_lookup_by_id`) from them. Mutating a pub field after construction silently stales the caches. Privatize the inputs behind accessors so the staleness hazard is unrepresentable.
 
 ### `SourceImportResolution = Option<(String, String, String)>` (`plan_references.rs:41`)
 
@@ -99,6 +127,26 @@ Every test in `purity_test.rs`, `object_plain_data_calls_test.rs`, `pure_members
 ### `accepted_spec_runs_under_node_test.rs` — `★ RED test` markers
 
 Uses inline comment markers instead of `#[ignore]` with reason strings (like `purity_test.rs` does). Inconsistent.
+
+### `logical_module_with_*` constructor sprawl in `e2e/support.rs`
+
+Six `logical_module_with_*` variants (binding groups, comment, anon, anon-alpha, anon-alpha-wildcards, anon-comment) plus the base `logical_module` differ only in which optional pieces they populate. A small builder replaces the family.
+
+### `assert_generated_module_after_entry_script` hardcodes the entry path
+
+The `e2e/support.rs` helper asserts against a literal `./static/app/entry.js`, so fixtures built with `with_chunk_id` can't use it. Derive the expected specifier from the fixture's chunk id.
+
+### Whitespace OR-chain assertions
+
+`e2e/comma_list_owner_split_test.rs` asserts emitted-code shapes via chains like `contains("{ x, y }") || contains("{x, y}") || contains("{x,y}")`. Parse and compare AST (or normalize whitespace) instead of enumerating printer styles.
+
+### Differential coverage gaps in the incremental-quotient tests
+
+`peel/quotient_integration_test.rs` checks the incremental index against references that share too much code with the system under test: most verdict comparisons use the kernel's own `project_partition` output as the reference partition (blind to projection bugs), and only `replay_partition` rebuilds a quotient independently — and it compares only `cycle_set()`. Also missing: randomized merge/partition sequences (current corpora are fixed, ≤6 owners) and differential coverage of the gate-residual promotion transition (whose multi-target fallback in `peel/quotient.rs` is otherwise unexercised — see the unreachable-fallback item in ARCHITECTURE_BACKLOG.md).
+
+### Only Lemma 2 has a named pinning test
+
+docs/design.md proves Lemmas 1–5; only Lemma 2 appears in a test name (`e2e/lemma_two_rescued_asymmetric_cycle_test.rs`). Lemmas 1/3/4/5 — notably Lemma 4's lazy-read argument — have no named tripwire test that would fail if the proved property is weakened. Add one pinning e2e per lemma.
 
 ---
 

--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -187,7 +187,16 @@ Still to do:
 ## Performance
 
 Proposer-gate, `debundle run`, and materialize-stage performance work
-all live in <perf/proposer.md>.
+all live in <perf/proposer.md>. Known lowering-side items not yet in
+that log:
+
+- `JsChunk::{get_file,get_file_mut,remove_file}` (`artifact.rs`) are
+  linear scans over `files`, so passes that touch every file go O(n²)
+  per chunk. A path-keyed index fixes it.
+- `split_entry_body` (`lowering/lower.rs`) clones every retained
+  statement out of the chunk AST even though the chunk body is
+  replaced wholesale afterward; a draining/move-based split avoids
+  the full-AST clone.
 
 ## Factorize / atomic-DAG docs drift
 
@@ -349,6 +358,43 @@ propKeyA` and `collect_naturalization_renames_from_function` says
    - "all structural moves pre-COLLECT" (cleaner architecturally but
      requires reordering the materializer to compute a final body
      order before any rename intents are submitted).
+
+## CLI scripting surface
+
+Work items on the machine-consumable CLI contract (distinct from the
+dogfood findings in <CLI_DOGFOOD.md>):
+
+- **Structured rejection diagnostics for edit-gate failures.**
+  `bindings {assign,unassign}` and `modules {merge,delete}` render
+  gate rejections as a prose blame report on stderr
+  (`cli/edit_gate.rs`) and bail; even with `--format json` there is
+  no machine-readable rejection payload on stdout, so agents scrape
+  stderr. Emit the blame report as JSON on stdout when a JSON format
+  is selected.
+- **`--format` parity for the five mutating verbs.**
+  `bindings {assign,unassign,rename}` take `--format`;
+  `modules {merge,delete}` print only a fixed summary line
+  (`cli/module.rs`). Define one outcome schema shared by all five.
+- **Edit-gate rejections leave no `cycles.json`.** The pipeline
+  writes `cycles.json` on gate rejection, but edit-gate rejections
+  (including `--dry-run` probes) write nothing, so
+  `debundle gate list`/`gate describe` cannot be pointed at the
+  failure that was just reported.
+- **`DEBUNDLE_SOURCE_ROOT` double meaning.** The same env var feeds
+  `run --tree-source-root` (spec-tree compile root, `pipeline.rs`)
+  and the query commands' `--source-root` (upstream snapshot root
+  for source-backed selectors). The two roots are different
+  directories in real corpora; one of the flags should get its own
+  env var.
+- **`resolve_id_as_module_path` swallows I/O errors.** The
+  `cli/mod.rs` helper applies `.ok()?` to the modules-tree walk, so
+  a failing `collect_module_files` silently degrades a module-path
+  id into a binding-name guess. Surface the error.
+- **`selection_with_*` sentinel hack.** `selection_with_proposal`
+  (`cli/mod.rs`) stuffs a sentinel empty-string `binding_id` that
+  `run_describe` must remember to clear. Make `SelectionArgs`
+  selection an enum (one variant per id kind) so the sentinel
+  disappears.
 
 ## CLI usability
 


### PR DESCRIPTION
Final PR of the debundle review-and-fix program (#2044, #2046, #2047, #2051–#2053, #2057–#2059, #2062, #2064, #2066, #2067, #2071): files every deferred/skipped item into the crate's tracking docs so nothing is lost. Docs-only; every candidate was re-verified against current `devel` HEAD before filing.

## Filed into CODE_REVIEW.md (code-quality backlog)

- **P1 — Partial-swap validation near-duplication**: `apply_partial_vendor_swaps` vs `apply_bundled_partial_vendor_swaps` ~250-line twin validate/resolve blocks → lift into `vendor/validate.rs`.
- **P1 — Two parallel top-level fact extractors**: `program_analysis.rs::analyze_program_shallow`'s remainder duplicates traversal/classification rules with `facts/`.
- **P2 — `graph.rs` silent-skip hazards**: duplicate top-level declarations last-insert-win in `binding_owner` (verified at HEAD); `OwnerGraph::from_report` silently drops edges with unresolvable endpoints (verified at HEAD).
- **P2 — `cli/mod.rs` grab-bag**: `run_scc`/`run_cluster` + text renderers still live in the ~1800-line dispatch module post-#2066.
- **P3 — refined "Vendor manifest struct proliferation"**: updated count/path (~26 structs in `vendor/manifests.rs`), added the generic `ResolutionManifest<R>` collapse and the `PartialSwapSymbolTarget` ↔ `spec::PartialSwapSymbol` twin.
- **P3 — Stringly chunk identity in vendor code** (String names stored in `chunk_id` fields vs typed `ChunkId`).
- **P3 — `ChunkAnalysis` pub inputs + private derived caches** (cache-staleness hazard; privatize behind accessors).
- **P3 — refined `StatementFacts` entry**: `PositionBucketed<T>` cuts the eager/lazy/first-order triple from 9 fields to 3; `StructuralStatementFacts`→`StatementFacts` mid-pipeline vocabulary renames (verified: `at_init_reads`→`eager_reads` etc.); `effects` summary largely derivable.
- **P0 — refined `realizability.rs` split entry**: updated sizes to HEAD, added #2053's finding that `gate_perf_counters` is entangled with index internals (`pub(super)` recording API, `base_snapshot_stale` shadow state) — a clean move needs untangling first.
- **P5 — test debt**: `logical_module_with_*` constructor family wants a builder (six variants at HEAD, not seven); `assert_generated_module_after_entry_script` hardcodes `./static/app/entry.js`; whitespace OR-chain assertions in `comma_list_owner_split_test.rs`.
- **P5 — differential-test gaps**: most quotient differentials use the kernel's own `project_partition` as reference; only `replay_partition` rebuilds independently and only checks `cycle_set()`; no randomized partition sequences; no gate-residual promotion differential.
- **P5 — only Lemma 2 has a named pinning test** (Lemmas 1/3/4/5 have no tripwire).

## Filed into ARCHITECTURE_BACKLOG.md (architecture)

- **`:analysis` Bazel god-crate** (~29 srcs spanning graph/gate/facts/purity/validation/reports/stage_one).
- **`peel/quotient.rs` multi-target merge fallback is unreachable** (verified: `compute_merge_deltas` only emits `post_module`-targeted deltas, so `single_target` is always true) — delete or implement; decide.
- **`ChunkManifest` ⊃ `ChunkAnalysisReport` field-by-field** → `#[serde(flatten)]`, merged into the existing "auto-derived from IR" open-decision entry (zero wire change).
- **`BindingId`/`BindingTable` interning: implement or delete** (design.md marks it aspirational; implementing also addresses the BTree-hot-path item in CODE_REVIEW.md).
- **`landable_today` for cross-residual-cell proposals** (verified at HEAD: `status` is truthful but `landable_today` reflects only anonymous addressability; flipping it changes the `bindings assign --batch` contract — maintainer decision).
- **A11 intrinsic-integrity scan**: `compute_shadowed_globals`-style top-level scan for `<Builtin>.prototype.<x> =` shapes to convert the in-corpus half of the assumption into a checked precondition.

## Filed into TODO.md (work items)

- **New "CLI scripting surface" section**: structured JSON rejection diagnostics on stdout for edit-gate failures (verified: `cli/edit_gate.rs` still emits prose to stderr + bail, even under `--format json`); `--format` parity for `modules {merge,delete}` (verified: assign/unassign/rename have it, merge/delete print fixed summary lines); edit-gate/`--dry-run` rejections leave no `cycles.json` for `gate list`/`describe` (verified); `DEBUNDLE_SOURCE_ROOT` double meaning between `run --tree-source-root` (`pipeline.rs`) and query `--source-root` (verified); `resolve_id_as_module_path` swallows I/O errors via `.ok()?` (verified); `selection_with_*` sentinel hack (verified post-#2066: `selection_with_proposal` still stuffs an empty-string `binding_id`).
- **Performance section additions** (lowering-side, not covered by `perf/proposer.md`): `JsChunk::{get_file,get_file_mut,remove_file}` linear scans (O(n²) per chunk); `split_entry_body` clones every retained statement though the chunk body is replaced wholesale (verified unfixed post-#2071).

## Candidates verified already fixed / already tracked (not re-filed)

- **#2071's self-filed items** — Pass-2 candidate SCC enumeration without universal residual edges, and the catchall-plan root approximation — both already present in ARCHITECTURE_BACKLOG.md's import-order entry. Not duplicated.
- **PK-gate vs realizability-index open question** (#2046) — already present in ARCHITECTURE_BACKLOG.md ("Should the kernel's merge gate route through the realizability index?").
- **Peel coverage views ignore `source_match` member claims** (#2051's worker) — already present in TODO.md and verified still accurate at HEAD (`peel/plan.rs` consumes only `claims.bindings` + `claims.anonymous_selectors`).
- **Admission residual risks** (#2067) — function-body/aliased `eval`, lazy non-literal dynamic import, and the fuzzier A5 reflection sub-shapes are all documented in docs/design.md's residual-risk section as deliberate input-shape contracts ("checking them cheaply without over-flagging is not possible"). No follow-up work is intended, so no TODO entry was added — the design.md documentation suffices.
- **Gate/emitter import-order unification** (#2071) — landed; the shared `EsmImportOrder` invariant entry already exists in ARCHITECTURE_BACKLOG.md.

Pre-commit: `pre-commit run --all-files` all green.

BAZEL_TEST_INVOCATIONS=none: documentation-only change

https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk)_