### PR TITLE
loom/gym: reach docker-ci via in-cluster svc name (drop passthrough)

### DIFF
--- a/cluster/k8s/docker-ci/README.md
+++ b/cluster/k8s/docker-ci/README.md
@@ -73,7 +73,10 @@ openssl req -new -x509 -days 3650 -key ca-key.pem -sha256 -out ca.pem -subj '/CN
 # Server cert
 openssl ecparam -genkey -name prime256v1 -noout -out server-key.pem
 openssl req -new -key server-key.pem -sha256 -out server.csr -subj '/CN=docker-ci.allegedly.works'
-printf 'subjectAltName=DNS:docker-ci.allegedly.works\nextendedKeyUsage=serverAuth\n' > ext.cnf
+# SAN covers both the external name (RBE runners via the gateway TLSRoute) and the
+# in-cluster service name (the loom/gym eval Job connects direct, bypassing the
+# agent mitmproxy via NO_PROXY — see loom/gym/k8s/eval-job.yaml).
+printf 'subjectAltName=DNS:docker-ci.allegedly.works,DNS:docker-ci.docker-ci.svc.cluster.local\nextendedKeyUsage=serverAuth\n' > ext.cnf
 openssl x509 -req -days 3650 -sha256 -in server.csr -CA ca.pem -CAkey ca-key.pem \
   -CAcreateserial -out server-cert.pem -extfile ext.cnf
 

--- a/loom/gym/k8s/README.md
+++ b/loom/gym/k8s/README.md
@@ -6,10 +6,15 @@ ClusterIP. The daemon target, upstream, env, args, and image staging all live in
 `eval-job.yaml` (commented) — `claude-sandbox` is `baseline` PSA (no privileged →
 no local DinD), hence the remote daemon. This README is just the run procedure.
 
+The Job reaches docker-ci by its in-cluster service name (`docker-ci.docker-ci.svc`),
+which `NO_PROXY` excludes — so it connects direct, bypassing the agent mitmproxy
+entirely. That requires the svc name in the docker-ci server cert SAN (see
+`cluster/k8s/docker-ci/README.md`'s rotation step).
+
 Prereqs: `docker-ci` Running on OVH; the `ghcr.io/agentydragon/{loom-gym-eval,wayback-proxy,loom-gym-sandbox}`
-images published (on merge to `devel`); the mitmproxy `ignore_hosts` passthrough
-reconciled; and the reflected `litellm-master-key` + `claude-forgejo-credentials`
-secrets present in `claude-sandbox`.
+images published (on merge to `devel`); the docker-ci server cert carrying the svc
+SAN; and the reflected `litellm-master-key` + `claude-forgejo-credentials` secrets
+present in `claude-sandbox`.
 
 ## 1. Create the docker-ci mTLS secret (the only non-manifest step)
 

--- a/loom/gym/k8s/eval-job.yaml
+++ b/loom/gym/k8s/eval-job.yaml
@@ -30,7 +30,7 @@ spec:
               done
           env:
             - name: DOCKER_HOST
-              value: tcp://docker-ci.allegedly.works:2376
+              value: tcp://docker-ci.docker-ci.svc.cluster.local:2376
             - name: DOCKER_TLS_VERIFY
               value: "1"
             - name: DOCKER_CERT_PATH
@@ -58,11 +58,13 @@ spec:
             - --log-dir
             - /work/logs
           env:
-            # Remote daemon: the docker CLI talks to docker-ci over mTLS. The host
-            # must match the server cert SAN (docker-ci.allegedly.works), so we use
-            # the TLS-passthrough route rather than the bare ClusterIP.
+            # Remote daemon over mTLS. We target docker-ci by its in-cluster
+            # service name, which the cluster NO_PROXY excludes — so the connection
+            # goes direct, bypassing the agent mitmproxy entirely (no passthrough,
+            # no public-gateway hairpin). Requires this name in the docker-ci server
+            # cert SAN (alongside docker-ci.allegedly.works for external RBE).
             - name: DOCKER_HOST
-              value: tcp://docker-ci.allegedly.works:2376
+              value: tcp://docker-ci.docker-ci.svc.cluster.local:2376
             - name: DOCKER_TLS_VERIFY
               value: "1"
             - name: DOCKER_CERT_PATH


### PR DESCRIPTION
Pivots the in-cluster eval off the mitmproxy passthrough (which proved fragile — it routes the daemon's mTLS hop out to the public gateway and hairpins back in-cluster) to a **direct in-cluster service connection**.

- The eval Job now uses `DOCKER_HOST=tcp://docker-ci.docker-ci.svc.cluster.local:2376` (both the `stage-images` initContainer and the eval container). The cluster `NO_PROXY` excludes `.svc.cluster.local`, so the connection goes **direct, bypassing the agent mitmproxy entirely** — no passthrough, no hairpin. We already proved this path reaches the daemon; it failed only on the cert SAN.
- The docker-ci server cert rotation now adds `docker-ci.docker-ci.svc.cluster.local` to the SAN (alongside `docker-ci.allegedly.works` for external RBE).
- Docs updated; left the (harmless) `--ignore-hosts` passthrough config from #2072 in place.

**Requires a cert rotation** (CA key = admin) before the eval can run — see the rotation commands I'm posting separately. Until then the Job's mTLS verify fails on the svc name.

https://claude.ai/code/session_01AXSFxfCXddADoSKTjgF5Nz

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXSFxfCXddADoSKTjgF5Nz)_