### PR TITLE
Tie public DNS records to cluster node roster

### DIFF
--- a/cluster/validation/BUILD.bazel
+++ b/cluster/validation/BUILD.bazel
@@ -317,6 +317,19 @@ py_test(
 )
 
 py_test(
+    name = "test_dns_records",
+    srcs = ["test_dns_records.py"],
+    data = [
+        "//:nebula-mesh.json",
+        "//tf/gitops/dns-records:main.tf",
+    ],
+    deps = [
+        "//util/bazel:runfiles",
+        "@pypi//pytest_bazel",
+    ],
+)
+
+py_test(
     name = "test_cluster_integration",
     srcs = ["test_cluster_integration.py"],
     data = [

--- a/cluster/validation/test_dns_records.py
+++ b/cluster/validation/test_dns_records.py
@@ -1,0 +1,83 @@
+"""Validates public DNS records against the cluster node roster."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest_bazel
+
+from util.bazel.runfiles import get_required_path
+
+_LOCAL_LIST_RE_TEMPLATE = r"(?ms)^\s*{name}\s*=\s*\[(?P<body>.*?)^\s*\]"
+_IP_LITERAL_RE = re.compile(r'"(?P<ip>\d+\.\d+\.\d+\.\d+)"')
+
+
+def _terraform_local_ips(path: Path, name: str) -> set[str]:
+    pattern = re.compile(_LOCAL_LIST_RE_TEMPLATE.format(name=re.escape(name)))
+    match = pattern.search(path.read_text())
+    assert match is not None, f"{path}: missing local.{name} list"
+    return {match.group("ip") for match in _IP_LITERAL_RE.finditer(match.group("body"))}
+
+
+def _mesh_hosts(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text())
+    hosts = data.get("hosts")
+    assert isinstance(hosts, dict), f"{path}: expected top-level hosts object"
+    return hosts
+
+
+def _endpoint_ip(host: dict[str, Any]) -> str | None:
+    endpoint = host.get("endpoint")
+    if not isinstance(endpoint, str):
+        return None
+    ip, separator, port = endpoint.rpartition(":")
+    assert separator, f"endpoint {endpoint!r} must be host:port"
+    assert port == "4242", f"endpoint {endpoint!r} should use the Nebula public port"
+    return ip
+
+
+def _public_kubernetes_node_ips(hosts: dict[str, Any]) -> set[str]:
+    return {
+        ip
+        for host in hosts.values()
+        if host.get("role") in {"control-plane", "worker"}
+        for ip in [_endpoint_ip(host)]
+        if ip is not None
+    }
+
+
+def _public_control_plane_ips(hosts: dict[str, Any]) -> set[str]:
+    return {
+        ip
+        for host in hosts.values()
+        if host.get("role") == "control-plane"
+        for ip in [_endpoint_ip(host)]
+        if ip is not None
+    }
+
+
+def test_wildcard_dns_records_match_public_kubernetes_nodes() -> None:
+    """allegedly.works and *.allegedly.works should resolve to all public k8s nodes."""
+    hosts = _mesh_hosts(get_required_path("_main/nebula-mesh.json"))
+    dns_records_tf = get_required_path("_main/tf/gitops/dns-records/main.tf")
+
+    expected = _public_kubernetes_node_ips(hosts)
+    assert expected, "nebula-mesh.json should contain at least one public Kubernetes node"
+    assert _terraform_local_ips(dns_records_tf, "public_gateway_ips") == expected
+
+
+def test_api_dns_record_matches_public_control_plane_nodes() -> None:
+    """api.allegedly.works should resolve to public control-plane nodes only."""
+    hosts = _mesh_hosts(get_required_path("_main/nebula-mesh.json"))
+    dns_records_tf = get_required_path("_main/tf/gitops/dns-records/main.tf")
+
+    expected = _public_control_plane_ips(hosts)
+    assert expected, "nebula-mesh.json should contain at least one public control-plane node"
+    assert _terraform_local_ips(dns_records_tf, "kube_api_ips") == expected
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/tf/gitops/dns-records/BUILD.bazel
+++ b/tf/gitops/dns-records/BUILD.bazel
@@ -1,5 +1,10 @@
 load("@rules_tf//tf:def.bzl", "tf_module", "tf_providers_versions")
 
+exports_files(
+    ["main.tf"],
+    visibility = ["//cluster/validation:__pkg__"],
+)
+
 tf_providers_versions(
     name = "providers",
     providers = {

--- a/tf/gitops/dns-records/main.tf
+++ b/tf/gitops/dns-records/main.tf
@@ -17,21 +17,16 @@ terraform {
 locals {
   domain = "allegedly.works"
 
-  # Public Gateway node IPs. Update when public Gateway-capable nodes change.
-  # Comments name the current node (post talos-* → ovh-ns* renames). An IP listed
-  # here lands in the `*.allegedly.works` round-robin, so a dead IP gives every
-  # consumer a ~1/N transient failure rate — only list IPs whose node is currently
-  # announcing the Cilium gateway.
+  # Public Gateway node IPs. This should match every public OVH Kubernetes node
+  # in nebula-mesh.json with role=control-plane or role=worker. The validation
+  # test in cluster/validation/test_dns_records.py fails if this hand-written
+  # Terraform list drifts from that roster.
   public_gateway_ips = [
     "147.135.37.175", # ovh-ns102453 (formerly talos-kimsufi-cp-0)
     "147.135.39.162", # ovh-ns103656 (formerly talos-kimsufi-worker-0)
+    "147.135.39.176", # ovh-ns103711 (formerly talos-kimsufi-worker-1)
+    "147.135.104.5",  # ovh-ns104952 (formerly talos-ks-game-worker-0)
     "147.135.104.16", # ovh-ns104963 (formerly talos-ks-game-worker-1)
-    # Dropped 2026-06-02: `.176` (ovh-ns103711, formerly talos-kimsufi-worker-1) and
-    # `.5` (ovh-ns104952, formerly talos-ks-game-worker-0) — both nodes are up but
-    # the IPs return RST (Cilium L2 announce not active on these post-rename), so
-    # the augur oauth2-proxy and similar consumers intermittently fail OIDC
-    # discovery when their DNS round-robin lands on one. Restore once L2
-    # announcement / per-node public-IP wiring is fixed.
   ]
 
   # Kubernetes API endpoints — every control-plane node, not just the ones whose
@@ -65,7 +60,7 @@ import {
   id = "Z02901943N8ZFQFOD9P5I_allegedly.works_A"
 }
 
-# Wildcard A record — all subdomains resolve to VPS nodes
+# Wildcard A record — all subdomains resolve to public Kubernetes nodes.
 resource "aws_route53_record" "wildcard" {
   #checkov:skip=CKV2_AWS_23:A records point to external public gateway nodes, not AWS resources
   zone_id         = var.route53_zone_id


### PR DESCRIPTION
## Summary
- add the missing public OVH Kubernetes node IPs to `*.allegedly.works` / apex Route53 records
- add a validation test that derives expected public wildcard/apex IPs and API IPs from `nebula-mesh.json`
- export `tf/gitops/dns-records/main.tf` to the validation package so the test can inspect the Terraform locals

## Root cause
`tf/gitops/dns-records/main.tf` had a hand-maintained `public_gateway_ips` list that explicitly omitted `ovh-ns103711` (`147.135.39.176`) and `ovh-ns104952` (`147.135.104.5`). The SSOT in `nebula-mesh.json` still has all five public OVH Kubernetes nodes.

## Live caveat
Current live Gateway behavior still has a separate problem: HTTP/80 answers on all five public OVH node IPs, but HTTPS/443 resets on the three control-plane IPs while working on the two worker IPs. `Gateway/gateway-system/cluster-gateway` is also `Programmed=False` with `AddressNotAssigned`. This PR prevents DNS/SSOT drift but does not fix that Cilium/Gateway HTTPS path.

## Tests
- `bazelisk test --config=rbe //cluster/validation:test_dns_records`
- `bazelisk build --config=rbe //tf/gitops/dns-records:dns-records`
- commit hook pre-commit suite