### PR TITLE
debundle: make artifact-index freshness structural across pipeline mutations

### DIFF
--- a/devinfra/js/debundle/artifact.rs
+++ b/devinfra/js/debundle/artifact.rs
@@ -1119,6 +1119,51 @@ impl ArtifactIndexes {
     }
 }
 
+/// A [`ChunkBundle`] paired with the [`ArtifactIndexes`] built from exactly
+/// that bundle.
+///
+/// The indexes are only reachable together with the artifact they were built
+/// from, and every mutation goes through [`IndexedArtifact::update`], which
+/// rebuilds the indexes from the mutated bundle. This makes it a type error
+/// to hold indexes that are older than the artifact — the pipeline-level
+/// stale-index bug class (consumers resolving imports against indexes built
+/// before materialize created module files or vendor swaps removed chunks).
+pub struct IndexedArtifact {
+    artifact: ChunkBundle,
+    indexes: ArtifactIndexes,
+}
+
+impl IndexedArtifact {
+    pub fn new(artifact: ChunkBundle) -> Result<Self> {
+        let indexes = ArtifactIndexes::build(&artifact)?;
+        Ok(Self { artifact, indexes })
+    }
+
+    pub fn artifact(&self) -> &ChunkBundle {
+        &self.artifact
+    }
+
+    /// Indexes matching the current artifact. Borrowing them keeps `self`
+    /// borrowed, so they cannot outlive the next [`Self::update`].
+    pub fn indexes(&self) -> &ArtifactIndexes {
+        &self.indexes
+    }
+
+    pub fn into_artifact(self) -> ChunkBundle {
+        self.artifact
+    }
+
+    /// Run an artifact mutation against the matching indexes, then rebuild
+    /// the indexes from the mutated bundle.
+    pub fn update<T>(
+        self,
+        mutate: impl FnOnce(ChunkBundle, &ArtifactIndexes) -> Result<(ChunkBundle, T)>,
+    ) -> Result<(Self, T)> {
+        let (artifact, value) = mutate(self.artifact, &self.indexes)?;
+        Ok((Self::new(artifact)?, value))
+    }
+}
+
 pub fn load_js_chunks(
     input_root: &Path,
     js_list_path: &Path,

--- a/devinfra/js/debundle/e2e/vendor_swap_test.rs
+++ b/devinfra/js/debundle/e2e/vendor_swap_test.rs
@@ -920,6 +920,115 @@ fn run_partial_swap_fixture(args: PartialSwapFixtureArgs<'_>) -> PartialSwapFixt
 }
 
 #[test]
+fn partial_swap_skips_materialized_module_import_colliding_with_vendor_source_path() {
+    // Regression for stale `ArtifactIndexes` reuse in the pipeline:
+    // `materialize_logical_modules` creates `pkg/util.js` inside chunk
+    // `static/app` and rewires the entry to `import { q } from
+    // "./pkg/util.js"`. Resolving that import against indexes built
+    // *before* materialization misses the new file in the
+    // output-path index and falls back to source-path resolution:
+    // `static/app.js` + `./pkg/util.js` → `static/pkg/util.js`,
+    // which collides with the partially-swapped vendor chunk. The
+    // partial-swap rewrite then misroutes the entry's import of its
+    // own materialized module to the vendor package. With indexes
+    // rebuilt post-materialize, the import resolves to the caller
+    // chunk itself and is skipped.
+    const VENDOR_PATH: &str = "static/pkg/util.js";
+    const APP_PATH: &str = "static/app.js";
+    const PACKAGE_NAME: &str = "obs";
+    const PACKAGE_VERSION: &str = "1.0.0";
+    const SUBPATH: &str = "index.js";
+
+    let ws = VendorTestWorkspace::new("vendor-partial-swap-materialized-collision-");
+    ws.write_chunk(
+        VENDOR_PATH,
+        "export const q = () => \"vendor\";\nexport const keep = () => 7;\n",
+    );
+    ws.write_chunk(
+        APP_PATH,
+        "const q = () => \"app\";\nexport function out() { return q(); }\n",
+    );
+    ws.write_js_list(&format!("{VENDOR_PATH}\n{APP_PATH}\n"));
+    let package_root = ws.write_upstream_package(
+        &format!("upstream/{PACKAGE_NAME}"),
+        PACKAGE_NAME,
+        PACKAGE_VERSION,
+        SUBPATH,
+        "export const q = () => \"package\";\n",
+    );
+
+    let spec_path = ws.root.path().join("transform_spec.yaml");
+    let spec = json!({
+        "vendor": {
+            VENDOR_PATH: {
+                "level": "partial_swap",
+                "identity": "materialized sibling collision fixture",
+                "packages": {
+                    PACKAGE_NAME: {
+                        "namespace": "z",
+                        "version": PACKAGE_VERSION,
+                        "subpath": SUBPATH,
+                    },
+                },
+                "symbols": {
+                    "q": { "package": PACKAGE_NAME, "upstream_export": "q" },
+                },
+            },
+        },
+        "inputs": { "input_root": &ws.snapshot_root, "js_list_path": &ws.js_list_path },
+        "swap_vendor_chunks": {
+            "output_manifest_path": &ws.manifest_path,
+            "output_wrapper_dir": &ws.wrapper_root,
+            "write": true,
+        },
+        "logical_modules": {
+            "static/app": {
+                "pkg/util": {
+                    "members": [
+                        { "name": "q", "selector": { "binding": { "name": "q" } } },
+                    ],
+                },
+            },
+        },
+        "unassigned_mode": {
+            "static/app": { "kind": "inline_in_entry" },
+        },
+        "materialize_logical_modules": {
+            "prune_other_chunks": false,
+        },
+        "write_js_tree": { "out_dir": &ws.out_root },
+    });
+    write_yaml_file(&spec_path, &spec);
+
+    let result = run_debundler(&spec_path, &[(PACKAGE_NAME, &package_root)]);
+    assert!(
+        result.status.success(),
+        "debundler exited {:?}\nstdout:\n{}\nstderr:\n{}",
+        result.status.code(),
+        result.stdout,
+        result.stderr,
+    );
+
+    let entry_path = ws.out_root.join("app/static/app/entry.js");
+    let entry = fs::read_to_string(&entry_path).expect("app entry emitted");
+    assert!(
+        entry.contains("pkg/util.js"),
+        "entry must keep importing its own materialized module:\n{entry}",
+    );
+    assert!(
+        !entry.contains(&format!("from \"{PACKAGE_NAME}\"")),
+        "entry's materialized-module import must not be misrouted to the vendor package:\n{entry}",
+    );
+
+    let probe_path = ws.out_root.join("__run_materialized_collision.mjs");
+    write_text_file(
+        &probe_path,
+        "const { out } = await import(\"./app/static/app/entry.js\");\nconsole.log(out());\n",
+    );
+    assert_node_output(&probe_path, "app\n", "");
+}
+
+#[test]
 fn partial_swap_namespace_kind_replaces_whole_import() {
     // Caller has `import { a as React } from "../megachunk/entry.js"`
     // where the chunk export `a` is the package's whole namespace

--- a/devinfra/js/debundle/pipeline.rs
+++ b/devinfra/js/debundle/pipeline.rs
@@ -6,8 +6,7 @@ use anyhow::{Context, Result, bail};
 use clap::Args as ClapArgs;
 use serde::Serialize;
 
-use artifact::ArtifactIndexes;
-use artifact::ChunkBundle;
+use artifact::IndexedArtifact;
 use artifact::load_js_chunks;
 use artifact::write_json;
 use artifact::{ChunkDecompositionOutput, ChunkId};
@@ -163,20 +162,24 @@ pub fn run_transform_cli_with_options(
         .into_iter()
         .collect();
     let prepare_result = prepare_js_chunks(&spec, artifact)?;
-    let artifact_indexes = ArtifactIndexes::build(&prepare_result.artifact)?;
-
-    let rewrite_result =
-        rewrite_chunk_entry_specifiers(prepare_result.artifact, &artifact_indexes)?;
-    let mut artifact = rewrite_result.artifact;
     let counts = prepare_result.counts;
     let mut chunk_records = prepare_result.chunk_records;
     let mut vendor_report = VendorSwapsReport::default();
 
-    let full_swap_result =
-        run_full_vendor_swaps(artifact, &artifact_indexes, &spec, cli, !options.dry_run)?;
-    artifact = full_swap_result.artifact;
-    vendor_report.full = full_swap_result.full_swap_resolutions;
-    chunk_records.retain(|chunk| !full_swap_result.removed_chunk_ids.contains(&chunk.chunk_id));
+    let mut indexed = IndexedArtifact::new(prepare_result.artifact)?;
+    (indexed, _) = indexed.update(|artifact, indexes| {
+        let rewrite_result = rewrite_chunk_entry_specifiers(artifact, indexes)?;
+        Ok((rewrite_result.artifact, ()))
+    })?;
+
+    let full_swap_outcome;
+    (indexed, full_swap_outcome) = run_full_vendor_swaps(indexed, &spec, cli, !options.dry_run)?;
+    vendor_report.full = full_swap_outcome.full_swap_resolutions;
+    chunk_records.retain(|chunk| {
+        !full_swap_outcome
+            .removed_chunk_ids
+            .contains(&chunk.chunk_id)
+    });
 
     let mut module_count: usize = 0;
     let mut selected_lowerings: Vec<artifact::SelectedModuleLowering> = Vec::new();
@@ -195,37 +198,43 @@ pub fn run_transform_cli_with_options(
             report_out_dir,
             target_dir,
         } = spec.materialize_logical_modules.clone();
-        let materialize_result = materialize_logical_modules(
-            artifact,
-            &spec.logical_modules,
-            &spec.chunk_renames,
-            &spec.unassigned_mode,
-            &spec.chunk_analysis_options,
-            MaterializeLogicalModulesOptions {
-                chunk_ids: materialise_chunk_ids,
-                file,
-                prune_other_chunks,
-                report_out_dir: if options.dry_run {
-                    None
-                } else {
-                    report_out_dir
+        // `materialize_logical_modules` derives its own per-run indexes
+        // internally (it prunes chunks first); the pipeline indexes are
+        // not consumed here, but the artifact mutates, so the update
+        // rebuilds them for the partial-swap stage below.
+        (indexed, _) = indexed.update(|artifact, _indexes| {
+            let materialize_result = materialize_logical_modules(
+                artifact,
+                &spec.logical_modules,
+                &spec.chunk_renames,
+                &spec.unassigned_mode,
+                &spec.chunk_analysis_options,
+                MaterializeLogicalModulesOptions {
+                    chunk_ids: materialise_chunk_ids,
+                    file,
+                    prune_other_chunks,
+                    report_out_dir: if options.dry_run {
+                        None
+                    } else {
+                        report_out_dir
+                    },
+                    target_dir,
                 },
-                target_dir,
-            },
-        )?;
-        artifact = materialize_result.artifact;
-        module_count = materialize_result.module_count;
-        selected_lowerings = materialize_result.selected_lowerings;
-        decomposition_by_chunk = materialize_result.decomposition_by_chunk;
-        unmatched_spec_claims = materialize_result.unmatched_spec_claims;
+            )?;
+            module_count = materialize_result.module_count;
+            selected_lowerings = materialize_result.selected_lowerings;
+            decomposition_by_chunk = materialize_result.decomposition_by_chunk;
+            unmatched_spec_claims = materialize_result.unmatched_spec_claims;
+            Ok((materialize_result.artifact, ()))
+        })?;
     }
 
-    let partial_result =
-        run_partial_vendor_swaps(artifact, &artifact_indexes, &spec, cli, !options.dry_run)?;
-    artifact = partial_result.artifact;
-    vendor_report.partial = partial_result.partial_swap_resolutions;
-    vendor_report.bundled_partial = partial_result.bundled_partial_swap_resolutions;
-    vendor_report.strip_stats = partial_result.strip_stats;
+    let partial_outcome;
+    (indexed, partial_outcome) = run_partial_vendor_swaps(indexed, &spec, cli, !options.dry_run)?;
+    vendor_report.partial = partial_outcome.partial_swap_resolutions;
+    vendor_report.bundled_partial = partial_outcome.bundled_partial_swap_resolutions;
+    vendor_report.strip_stats = partial_outcome.strip_stats;
+    let artifact = indexed.into_artifact();
 
     write_vendor_swaps_report(
         spec.swap_vendor_chunks.write && !options.dry_run,
@@ -343,31 +352,30 @@ fn validate_transform_spec(spec: &TransformSpec) -> Result<()> {
     Ok(())
 }
 
-struct FullVendorSwapResult {
-    artifact: ChunkBundle,
+struct FullVendorSwapOutcome {
     full_swap_resolutions: BTreeMap<String, VendorResolution>,
     removed_chunk_ids: BTreeSet<String>,
 }
 
 fn run_full_vendor_swaps(
-    artifact: ChunkBundle,
-    artifact_indexes: &ArtifactIndexes,
+    mut indexed: IndexedArtifact,
     spec: &TransformSpec,
     cli: &TransformCli,
     write_outputs: bool,
-) -> Result<FullVendorSwapResult> {
-    let mut artifact = artifact;
+) -> Result<(IndexedArtifact, FullVendorSwapOutcome)> {
     let mut full_swap_resolutions = BTreeMap::new();
     let mut removed_chunk_ids = BTreeSet::new();
     if !spec.vendor.is_empty() {
-        apply_vendor_annotations(&artifact, &spec.vendor)?;
+        apply_vendor_annotations(indexed.artifact(), &spec.vendor)?;
         if spec
             .vendor
             .values()
             .any(|m| matches!(m.level, VendorLevel::BoundaryRename | VendorLevel::Swap(_)))
         {
-            let rename_result = rename_vendor_exports(artifact, &spec.vendor, artifact_indexes)?;
-            artifact = rename_result.artifact;
+            (indexed, _) = indexed.update(|artifact, indexes| {
+                let rename_result = rename_vendor_exports(artifact, &spec.vendor, indexes)?;
+                Ok((rename_result.artifact, ()))
+            })?;
         }
         if spec
             .vendor
@@ -375,32 +383,40 @@ fn run_full_vendor_swaps(
             .any(|m| matches!(m.level, VendorLevel::Swap(_)))
         {
             let swap_cfg = &spec.swap_vendor_chunks;
-            let swap_result = swap_vendor_chunks(
-                artifact,
-                &spec.vendor,
-                artifact_indexes,
-                SwapVendorOptions {
-                    package_roots: &cli.package_roots,
-                    packages_root: &cli.packages_root,
-                    output_manifest_path: swap_cfg.output_manifest_path.clone(),
-                    output_wrapper_dir: swap_cfg.output_wrapper_dir.clone(),
-                    write: swap_cfg.write && write_outputs,
-                },
-            )?;
-            artifact = swap_result.artifact;
-            full_swap_resolutions = swap_result.manifest.resolutions;
-            removed_chunk_ids = swap_result.removed_chunk_ids;
+            (indexed, (full_swap_resolutions, removed_chunk_ids)) =
+                indexed.update(|artifact, indexes| {
+                    let swap_result = swap_vendor_chunks(
+                        artifact,
+                        &spec.vendor,
+                        indexes,
+                        SwapVendorOptions {
+                            package_roots: &cli.package_roots,
+                            packages_root: &cli.packages_root,
+                            output_manifest_path: swap_cfg.output_manifest_path.clone(),
+                            output_wrapper_dir: swap_cfg.output_wrapper_dir.clone(),
+                            write: swap_cfg.write && write_outputs,
+                        },
+                    )?;
+                    Ok((
+                        swap_result.artifact,
+                        (
+                            swap_result.manifest.resolutions,
+                            swap_result.removed_chunk_ids,
+                        ),
+                    ))
+                })?;
         }
     }
-    Ok(FullVendorSwapResult {
-        artifact,
-        full_swap_resolutions,
-        removed_chunk_ids,
-    })
+    Ok((
+        indexed,
+        FullVendorSwapOutcome {
+            full_swap_resolutions,
+            removed_chunk_ids,
+        },
+    ))
 }
 
-struct PartialVendorSwapResult {
-    artifact: ChunkBundle,
+struct PartialVendorSwapOutcome {
     partial_swap_resolutions: BTreeMap<String, ChunkPartialSwapResolution>,
     bundled_partial_swap_resolutions: BTreeMap<String, ChunkBundledPartialSwapResolution>,
     strip_stats: BTreeMap<String, ChunkStripStats>,
@@ -413,13 +429,11 @@ struct PartialVendorSwapResult {
 /// `binding_patches` / `logical_modules` selectors still rely on at
 /// materialize-time (e.g. `anonymous_statements: match: "ee({...})"`).
 fn run_partial_vendor_swaps(
-    artifact: ChunkBundle,
-    artifact_indexes: &ArtifactIndexes,
+    mut indexed: IndexedArtifact,
     spec: &TransformSpec,
     cli: &TransformCli,
     write_outputs: bool,
-) -> Result<PartialVendorSwapResult> {
-    let mut artifact = artifact;
+) -> Result<(IndexedArtifact, PartialVendorSwapOutcome)> {
     let mut partial_swap_resolutions = BTreeMap::new();
     let mut bundled_partial_swap_resolutions = BTreeMap::new();
     let mut strip_stats = BTreeMap::new();
@@ -434,58 +448,73 @@ fn run_partial_vendor_swaps(
     if !spec.vendor.is_empty() && (has_partial_swaps || has_bundled_partial_swaps) {
         let mut replacement_import_locals_by_chunk_path = BTreeMap::new();
         if has_partial_swaps {
-            let partial_result = apply_partial_vendor_swaps(
-                artifact,
-                &spec.vendor,
-                artifact_indexes,
-                ApplyPartialVendorSwapsOptions {
-                    package_roots: &cli.package_roots,
-                    packages_root: &cli.packages_root,
-                },
-            )?;
-            artifact = partial_result.artifact;
-            partial_swap_resolutions = partial_result.manifest.resolutions;
+            (indexed, partial_swap_resolutions) = indexed.update(|artifact, indexes| {
+                let partial_result = apply_partial_vendor_swaps(
+                    artifact,
+                    &spec.vendor,
+                    indexes,
+                    ApplyPartialVendorSwapsOptions {
+                        package_roots: &cli.package_roots,
+                        packages_root: &cli.packages_root,
+                    },
+                )?;
+                Ok((partial_result.artifact, partial_result.manifest.resolutions))
+            })?;
         }
         if has_bundled_partial_swaps {
             let swap_cfg = &spec.swap_vendor_chunks;
-            let bundled_result = apply_bundled_partial_vendor_swaps(
+            (
+                indexed,
+                (
+                    replacement_import_locals_by_chunk_path,
+                    bundled_partial_swap_resolutions,
+                ),
+            ) = indexed.update(|artifact, indexes| {
+                let bundled_result = apply_bundled_partial_vendor_swaps(
+                    artifact,
+                    &spec.vendor,
+                    indexes,
+                    ApplyBundledPartialVendorSwapsOptions {
+                        package_roots: &cli.package_roots,
+                        packages_root: &cli.packages_root,
+                        output_manifest_path: swap_cfg.output_manifest_path.clone(),
+                        output_wrapper_dir: swap_cfg.output_wrapper_dir.clone(),
+                        write: swap_cfg.write && write_outputs,
+                    },
+                )?;
+                Ok((
+                    bundled_result.artifact,
+                    (
+                        bundled_result.self_rewrite_import_locals_by_chunk_path,
+                        bundled_result.manifest.resolutions,
+                    ),
+                ))
+            })?;
+        }
+        (indexed, strip_stats) = indexed.update(|artifact, _indexes| {
+            let strip_result = strip_swapped_vendor_exports_with_options(
                 artifact,
                 &spec.vendor,
-                artifact_indexes,
-                ApplyBundledPartialVendorSwapsOptions {
-                    package_roots: &cli.package_roots,
-                    packages_root: &cli.packages_root,
-                    output_manifest_path: swap_cfg.output_manifest_path.clone(),
-                    output_wrapper_dir: swap_cfg.output_wrapper_dir.clone(),
-                    write: swap_cfg.write && write_outputs,
+                StripSwappedVendorExportsOptions {
+                    replacement_import_locals_by_chunk_path,
                 },
             )?;
-            artifact = bundled_result.artifact;
-            replacement_import_locals_by_chunk_path =
-                bundled_result.self_rewrite_import_locals_by_chunk_path;
-            bundled_partial_swap_resolutions = bundled_result.manifest.resolutions;
-        }
-        let strip_result = strip_swapped_vendor_exports_with_options(
-            artifact,
-            &spec.vendor,
-            StripSwappedVendorExportsOptions {
-                replacement_import_locals_by_chunk_path,
-            },
-        )?;
-        artifact = strip_result.artifact;
-        strip_stats = strip_result.manifest.per_chunk;
+            Ok((strip_result.artifact, strip_result.manifest.per_chunk))
+        })?;
         // Post-strip soundness gate: no retained file may still consume
         // the stripped portion of a partially-swapped chunk's export
         // surface (unrewritten named imports / re-exports, namespace
         // imports, `export *`).
-        validate_partial_swap_consumers(&artifact, &spec.vendor, artifact_indexes)?;
+        validate_partial_swap_consumers(indexed.artifact(), &spec.vendor, indexed.indexes())?;
     }
-    Ok(PartialVendorSwapResult {
-        artifact,
-        partial_swap_resolutions,
-        bundled_partial_swap_resolutions,
-        strip_stats,
-    })
+    Ok((
+        indexed,
+        PartialVendorSwapOutcome {
+            partial_swap_resolutions,
+            bundled_partial_swap_resolutions,
+            strip_stats,
+        },
+    ))
 }
 
 #[derive(Debug, Default, Serialize)]


### PR DESCRIPTION
Track A1 of `devinfra/js/debundle/plans/sanitization_program_2026_06.md`.

## Staleness analysis

`run_transform_cli_with_options` built `ArtifactIndexes` once post-prepare and reused that value for (1) `rewrite_chunk_entry_specifiers`, (2) `run_full_vendor_swaps`, and (3) `run_partial_vendor_swaps` — stage (3) running **after** `materialize_logical_modules` replaced/created chunk files and full swaps removed chunks (`materialize` rebuilds fresh indexes internally for itself, an implicit admission the shared ones go stale).

Which fields each consumer reads:

- (1) and the rename/swap consumers resolve via `resolve_runtime_import_reference` (`output_path_index`, `file_source_paths`, `chunk_source_paths`, `source_chunk_index`, `entry_files`) and `manifest_imports_targeting_chunk` (built from `analysis.imports`, which specifier rewriting and renaming do not mutate). Between prepare → rewrite → full swaps, none of these fields' inputs change, so a rebuild before full swaps is behaviorally a no-op — full swaps with the post-prepare indexes were correct (the new structure rebuilds anyway, as the uniform mechanism).
- (3) is where staleness bites: after materialize, `output_path_index`/`file_source_paths` are missing every materialized module file, and after full swaps `source_chunk_index`/`entry_files` retain removed chunks. The `MaterializedOutputChunkIndex` fallback (built fresh from the live `chunk_table`) papers over the *miss* case — but not the *mis-hit* case, where stale resolution returns a wrong `Some(...)` before the fallback is ever consulted.

## Red repro — yes, observable at HEAD

`partial_swap_skips_materialized_module_import_colliding_with_vendor_source_path` (e2e, `vendor_swap_test.rs`): materialize creates `pkg/util.js` inside chunk `static/app` and rewires the entry to `import { q } from "./pkg/util.js"`. Resolving that import against pre-materialize indexes misses the new file in `output_path_index` and falls through to source-path resolution: `static/app.js` + `./pkg/util.js` → `static/pkg/util.js`, which collides with a partially-swapped vendor chunk. At HEAD the partial-swap rewrite misroutes the entry's import of its **own materialized module** to the vendor package — the emitted entry becomes `import * as z from "obs"` with a broken bare `q()` reference left behind (the #2062 post-strip consumer gate resolves through the same stale indexes, so it stays green on the mis-rewritten output). With fresh indexes the import resolves to the caller chunk itself and is correctly skipped.

## Structural design

New `artifact::IndexedArtifact { artifact: ChunkBundle, indexes: ArtifactIndexes }` with private fields:

- `new(ChunkBundle)` builds the indexes; `artifact()` / `indexes()` borrow both from the same value (borrowing keeps `self` borrowed, so indexes can't outlive the next mutation); `into_artifact()` exits at the pipeline tail.
- `update(self, FnOnce(ChunkBundle, &ArtifactIndexes) -> Result<(ChunkBundle, T)>) -> Result<(Self, T)>` is the only mutation path: the closure receives the artifact by value together with the indexes that match it, and the returned bundle gets freshly rebuilt indexes.

The pipeline threads one `IndexedArtifact` through rewrite → full swaps (rename + swap as separate updates) → materialize → partial swaps → bundled partial swaps → strip, and the post-strip consumer gate now validates with `indexed.artifact()` + `indexed.indexes()` — guaranteed consistent. There is no standalone `artifact_indexes` binding left at the pipeline level, so holding indexes older than the artifact no longer typechecks. Leaf mutation functions keep their `(ChunkBundle, &ArtifactIndexes)` signatures — they are only reachable through `update`, which supplies matched pairs; this was the lightest design that achieves the invariant without forcing rebuild plumbing into every vendor/lowering internal.

Rebuild cost is one pass over chunk manifests per mutation (6 rebuilds max per run); the full debundle suite runs at the same speed as before (`vendor_swap_test` 1.6s, suite green in ~2min wall on RBE).

Backlog note: no TODO.md/CODE_REVIEW.md entry existed for this item (the known #2073 ledger miss), so there was nothing to delete.

Tests: `bbr test //devinfra/js/debundle/...` — 96/96 green (`buildbuddy:31e70a56-c073-475f-873b-698e434c10c7`); the new e2e was verified red at HEAD (`buildbuddy:42e246aa-4363-4d00-b2ac-9d785558ec3f`) before the fix.

https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk)_