### PR TITLE
debundle: drop unreachable multi-target speculative fallback; assert single-target invariant

### DIFF
--- a/devinfra/js/debundle/ARCHITECTURE_BACKLOG.md
+++ b/devinfra/js/debundle/ARCHITECTURE_BACKLOG.md
@@ -165,10 +165,6 @@ Remaining known approximation: the simulator roots at `partition.residual()` (th
 
 The peel kernel's hot boolean merge gate is `merge_creates_new_constraining_cycle` (a constraining-only Pearce–Kelly walk over the kernel-maintained `TopoOrder` + class adjacency in `peel/quotient.rs`), with `build_seed_quotient`'s post-seed `check_realizability` pass as the backstop for asymmetric I-cycles. docs/design.md §"Why not Pearce–Kelly verbatim" documents this as the current trade-off. The open question: route the hot gate through the `RealizabilityIndex` (one source of truth, slower per query) vs. keep the PK gate (fast, but a second decision-making derived structure the kernel must keep consistent).
 
-### `peel/quotient.rs` multi-target merge fallback is unreachable
-
-`realizability_cycles_after_contract` keeps a scoped push/verdict/undo fallback for merges whose deltas target multiple modules, but `compute_merge_deltas` only ever emits deltas targeting the single post-merge module, so the `single_target` fast path always wins and the fallback is dead code (the design note that motivated it is stale). Either delete the fallback and the multi-target framing in the module docs, or implement a transition that actually produces multi-target deltas — decide.
-
 ### `BindingId`/`BindingTable` interning: implement or delete
 
 docs/design.md sketches a compact interned binding form (`BindingId(usize)` newtype + `BindingTable` of dense indices) and explicitly marks it **not implemented** — an aspirational optimization. Decide: implement it (it is also the natural fix for the BTree-keyed-by-cloned-`Id` hot paths flagged in CODE_REVIEW.md) or delete the passage so design.md describes only the real representation.

--- a/devinfra/js/debundle/CODE_REVIEW.md
+++ b/devinfra/js/debundle/CODE_REVIEW.md
@@ -142,7 +142,7 @@ The `e2e/support.rs` helper asserts against a literal `./static/app/entry.js`, s
 
 ### Differential coverage gaps in the incremental-quotient tests
 
-`peel/quotient_integration_test.rs` checks the incremental index against references that share too much code with the system under test: most verdict comparisons use the kernel's own `project_partition` output as the reference partition (blind to projection bugs), and only `replay_partition` rebuilds a quotient independently — and it compares only `cycle_set()`. Also missing: randomized merge/partition sequences (current corpora are fixed, ≤6 owners) and differential coverage of the gate-residual promotion transition (whose multi-target fallback in `peel/quotient.rs` is otherwise unexercised — see the unreachable-fallback item in ARCHITECTURE_BACKLOG.md).
+`peel/quotient_integration_test.rs` checks the incremental index against references that share too much code with the system under test: most verdict comparisons use the kernel's own `project_partition` output as the reference partition (blind to projection bugs), and only `replay_partition` rebuilds a quotient independently — and it compares only `cycle_set()`. Also missing: randomized merge/partition sequences (current corpora are fixed, ≤6 owners) and differential coverage of the gate-residual promotion transition.
 
 ### Only Lemma 2 has a named pinning test
 

--- a/devinfra/js/debundle/docs/design.md
+++ b/devinfra/js/debundle/docs/design.md
@@ -453,9 +453,11 @@ pure function:
   index's current state.
 - Each push records its inverse on a journal. Callers undo deltas in LIFO
   order to back out of a hypothetical or failed exploration. The peel
-  kernel (`peel/quotient.rs`) drives this push/undo machinery for its
-  speculative merge queries; `peel/factorize.rs` is a renderer over the
-  kernel's quotient and never touches the journal directly.
+  kernel (`peel/quotient.rs`) pushes committed merge deltas permanently
+  (journal truncated via `commit`); its speculative merge queries read the
+  index through the non-mutating overlay path instead. `peel/factorize.rs`
+  is a renderer over the kernel's quotient and never touches the journal
+  directly.
 - Candidate peel checks use the same push/read/undo API as other
   hypothetical questions, but read only SCCs and rebinds touching the fresh
   destination. A new directed edge `u -> v` can create a cycle exactly when
@@ -552,15 +554,15 @@ needs owner-level cycle evidence — computes the merge's post-state
 ModuleId via `projected_winner_module_after_merge` (mirroring the
 gate-residual override `project_partition` would apply), then routes
 through the index's `verdict_after_moving_owners_touching`. That
-fast path applies a per-edge overlay on the maintained graphs
-without mutating them and reads only SCCs touching the hypothetical
-destination — `O(|cone|)` per query, not `O(|V| + |E|)`. A scoped
-push/verdict/undo fallback exists for multi-target moves, but it is
-currently unreachable: `compute_merge_deltas` only ever emits
-`MoveOwners` deltas targeting the single post-merge module, so every
-speculative query takes the single-target fast path. The fallback is
-stale pending a code decision (delete it, or keep it against future
-delta shapes).
+path applies a per-edge overlay on the maintained graphs without
+mutating them and reads only SCCs touching the hypothetical
+destination — `O(|cone|)` per query, not `O(|V| + |E|)`. Speculative
+deltas are single-target by construction: a merge contracts two
+classes into one, so `compute_merge_deltas` only ever emits
+`MoveOwners` deltas targeting the single post-merge module.
+`realizability_cycles_after_contract` asserts this invariant; a
+future non-merge speculative mutation must implement a multi-target
+overlay deliberately rather than inherit the merge path.
 
 The kernel's `ClassId ↔ ModuleId` mapping (`class_module_id`) is
 maintained alongside the index. Initialization assigns each

--- a/devinfra/js/debundle/peel/quotient.rs
+++ b/devinfra/js/debundle/peel/quotient.rs
@@ -56,9 +56,9 @@
 //! contract, the kernel pushes a `PartitionDelta::MoveOwners` for the
 //! loser class's owners onto the index; the index updates only the
 //! quotient edge buckets incident to the moved owners. Per query,
-//! the kernel uses `verdict_after_moving_owners_touching` for
-//! single-target moves or a scoped push/undo for the rare
-//! multi-target case (gate-residual collapse transitions).
+//! the kernel uses `verdict_after_moving_owners_touching` — every
+//! speculative merge delta targets the single post-merge module
+//! (asserted in `realizability_cycles_after_contract`).
 //!
 //! See docs/design.md "Peel planner unification (Track A) → Cost and the
 //! upgrade path" for the per-merge cost analysis and the references
@@ -318,10 +318,10 @@ pub struct QuotientGraph {
     /// Synced to the kernel's current class projection after every
     /// committed mutation (`contract`, `from_report*`). Speculative
     /// queries (`merge_preserves_invariants`,
-    /// `would_be_cycles_after_contract`) push deltas via
-    /// `verdict_after_moving_owners_touching` (single-target moves)
-    /// or scoped push/undo (multi-target). See the module-level
-    /// docstring's "Cost of the unified gate" section.
+    /// `would_be_cycles_after_contract`) read it non-mutatingly via
+    /// `verdict_after_moving_owners_touching` (all speculative moves
+    /// are single-target). See the module-level docstring's "Cost of
+    /// the unified gate" section.
     realizability_index: RealizabilityIndex,
     /// Cached `class_id -> module_id` mapping mirroring what
     /// `project_partition(None)` would assign. Maintained alongside
@@ -705,8 +705,8 @@ impl QuotientGraph {
     /// State mutation: this hot boolean path does not materialize
     /// diagnostic evidence, so the persistent realizability index is
     /// not touched. `would_be_cycles_after_contract` remains the
-    /// diagnostic path and performs scoped push/undo work when it
-    /// needs owner-level cycle evidence.
+    /// diagnostic path and reads the index through the non-mutating
+    /// overlay query when it needs owner-level cycle evidence.
     pub fn merge_preserves_invariants(&mut self, c1: ClassId, c2: ClassId) -> bool {
         self.check_merge_boolean(c1, c2)
     }
@@ -778,8 +778,8 @@ impl QuotientGraph {
         if self.merge_creates_new_constraining_cycle(c1, c2) {
             // Use the persistent realizability index to materialize
             // the cycle's owner_ids / classes for the diagnostic.
-            // The index handles the push/undo dance internally so
-            // its committed partition is restored on return.
+            // The overlay query reads the index without mutating it,
+            // so its committed partition is untouched.
             let merged_class = if c1 < c2 { c1 } else { c2 };
             let detailed = self.realizability_cycles_after_contract(c1, c2);
             let new_cycles: Vec<CycleClassSet> = detailed
@@ -979,8 +979,8 @@ impl QuotientGraph {
         // The deltas above are committed — nothing will undo them —
         // so drop their rollback state. Without this, the index's
         // journals grow without bound across the greedy's committed
-        // merges (speculative push/undo pairs are balanced and leave
-        // no entries behind).
+        // merges (speculative queries read through the non-mutating
+        // overlay and never touch the journal).
         self.realizability_index.commit();
         // If `post_module` was freshly minted, bump the counter so
         // subsequent merges don't collide.
@@ -1273,71 +1273,55 @@ impl QuotientGraph {
     }
 
     /// Incremental hypothetical query: cycle evidence after merging
-    /// `(c1, c2)`, without committing the merge. Uses the persistent
-    /// realizability index's `verdict_after_moving_owners_touching`
-    /// fast path when the merge is a single-target move (all deltas
-    /// share the same post-merge `ModuleId`), falling back to a
-    /// scoped push/verdict/undo for the rare multi-target case (e.g.,
-    /// gate-residual promotion transitions). The fast path avoids
-    /// mutating the index's graphs and reads only SCCs touching the
-    /// target module, which is the key cost saving on gaffer-scale
-    /// inputs.
+    /// `(c1, c2)`, without committing the merge. Routes through the
+    /// persistent realizability index's
+    /// `verdict_after_moving_owners_touching` overlay path: every
+    /// delta moves owners into the single post-merge `ModuleId`, so
+    /// the index's graphs are never mutated and only SCCs touching
+    /// the target module are read — the key cost saving on
+    /// gaffer-scale inputs.
     fn realizability_cycles_after_contract(&mut self, c1: ClassId, c2: ClassId) -> CycleEvidence {
         let (winner, loser) = if c1 < c2 { (c1, c2) } else { (c2, c1) };
         let (post_module, deltas) = self.compute_merge_deltas(winner, loser);
-        let single_target = deltas.iter().all(|d| match d {
-            PartitionDelta::MoveOwners { to, .. } => *to == post_module,
-        });
-        if single_target {
-            let mut owners: Vec<OwnerId> = Vec::new();
-            for d in &deltas {
-                let PartitionDelta::MoveOwners { owners: o, .. } = d;
-                owners.extend(o.iter().copied());
-            }
-            owners.sort();
-            owners.dedup();
-            let verdict = self
-                .realizability_index
-                .verdict_after_moving_owners_touching(&self.owner_graph, &owners, post_module);
-            let owner_count = self.owner_ids.len().min(self.owner_graph.num_nodes());
-            let owners_set: BTreeSet<OwnerId> = owners.iter().copied().collect();
-            let owner_modules: Vec<ModuleId> = (0..owner_count)
-                .map(|i| {
-                    let id = OwnerId(i);
-                    if owners_set.contains(&id) {
-                        post_module
-                    } else {
-                        self.realizability_index.partition().of(id)
-                    }
-                })
-                .collect();
-            return self.translate_verdict_with_owner_modules(
-                &verdict,
-                &owner_modules,
-                Some((c1, c2)),
-            );
+        // Producing invariant: `compute_merge_deltas` only ever emits
+        // `MoveOwners` into the single post-merge module.
+        assert!(
+            deltas.iter().all(|d| match d {
+                PartitionDelta::MoveOwners { to, .. } => *to == post_module,
+            }),
+            "speculative deltas are single-target by construction (merges contract \
+             two classes into one); implement a multi-target overlay deliberately \
+             before adding a non-merge mutation"
+        );
+        let mut owners: Vec<OwnerId> = Vec::new();
+        for d in &deltas {
+            let PartitionDelta::MoveOwners { owners: o, .. } = d;
+            owners.extend(o.iter().copied());
         }
-        // Multi-target fallback: push deltas, snapshot verdict +
-        // per-owner module, then undo.
-        let mut handles = Vec::with_capacity(deltas.len());
-        for delta in deltas {
-            handles.push(self.realizability_index.push(&self.owner_graph, delta));
-        }
-        let verdict = self.realizability_index.verdict();
+        owners.sort();
+        owners.dedup();
+        let verdict = self
+            .realizability_index
+            .verdict_after_moving_owners_touching(&self.owner_graph, &owners, post_module);
         let owner_count = self.owner_ids.len().min(self.owner_graph.num_nodes());
-        let post_push_modules: Vec<ModuleId> = (0..owner_count)
-            .map(|owner_idx| self.realizability_index.partition().of(OwnerId(owner_idx)))
+        let owners_set: BTreeSet<OwnerId> = owners.iter().copied().collect();
+        let owner_modules: Vec<ModuleId> = (0..owner_count)
+            .map(|i| {
+                let id = OwnerId(i);
+                if owners_set.contains(&id) {
+                    post_module
+                } else {
+                    self.realizability_index.partition().of(id)
+                }
+            })
             .collect();
-        for handle in handles.into_iter().rev() {
-            self.realizability_index.undo(&self.owner_graph, handle);
-        }
-        self.translate_verdict_with_owner_modules(&verdict, &post_push_modules, Some((c1, c2)))
+        self.translate_verdict_with_owner_modules(&verdict, &owner_modules, Some((c1, c2)))
     }
 
     /// `translate_verdict_to_evidence` parameterized by an explicit
-    /// per-owner ModuleId vector. Used by speculative queries that
-    /// read the post-push verdict but commit the undo before the
-    /// translation runs.
+    /// per-owner ModuleId vector. Used by speculative queries whose
+    /// verdict comes from a non-mutating overlay, so the index's
+    /// partition never reflects the hypothetical move.
     ///
     /// Perf (#12prime): the naive translation iterated all
     /// `self.owner_ids` per SCC — O(K * num_owners), ~10% self in

--- a/devinfra/js/debundle/peel/quotient_integration_test.rs
+++ b/devinfra/js/debundle/peel/quotient_integration_test.rs
@@ -1042,7 +1042,7 @@ fn incremental_index_matches_rebuild_on_synthetic_specs() {
     //
     // Pins commit 5's wiring: the index's committed partition stays
     // synchronized with the kernel's class projection across both
-    // committed mutations and speculative push/undo queries. RED if
+    // committed mutations and speculative overlay queries. RED if
     // the index is forked from the kernel; GREEN when the wiring is
     // correct.
     use peel::quotient::{ClassId, PartitionGroup};


### PR DESCRIPTION
Implements the maintainer decision from the ARCHITECTURE_BACKLOG entry "`peel/quotient.rs` multi-target merge fallback is unreachable": delete the speculative multi-target push/verdict/undo fallback and replace it with a loud invariant.

## What changed

- **`peel/quotient.rs`** — `realizability_cycles_after_contract` no longer computes a `single_target` flag to dispatch between the non-mutating overlay path (`verdict_after_moving_owners_touching`) and a scoped push/verdict/undo fallback over the index journal. The fallback was unreachable by construction: `compute_merge_deltas` only ever emits `MoveOwners` deltas targeting the single post-merge module (a merge contracts two classes into one). The flag is replaced with an `assert!` at the speculative-query entry, with a one-line comment citing the producing invariant (`compute_merge_deltas`):
  > speculative deltas are single-target by construction (merges contract two classes into one); implement a multi-target overlay deliberately before adding a non-merge mutation
- **Committed-push journal machinery untouched** — `merge_classes_unchecked` / `set_class_pre_existing_module` still `push` + `commit` permanently, and `RealizabilityIndex::{push,undo,scoped,verdict,commit}` in `realizability.rs` are all still reachable from committed paths and differential tests; nothing there was multi-target-only, so no `realizability.rs` code is deleted (`verdict_after_moving_owners_touching` is single-destination by signature; no multi-destination overlay variant existed).
- **`docs/design.md`** — the fallback passage marked stale by #2046 now describes reality: single-target invariant + the assert; the "Iterative, undo-aware shape" bullet no longer claims the kernel drives push/undo for speculative queries.
- **`ARCHITECTURE_BACKLOG.md`** — decision entry resolved and removed.
- **`CODE_REVIEW.md`**, **`peel/quotient_integration_test.rs`** — stale "push/undo fallback" phrasing in adjacent prose/comments updated; no behavioral test changes (existing speculative-query and differential tests stay green).

`plans/incremental_gate_unification.md` is intentionally not touched (covered by a parallel design-doc worker).

## Testing

`bbr test //devinfra/js/debundle/...` — 96/96 pass.
`BAZEL_TEST_INVOCATIONS=buildbuddy:1a51308f-c0b8-4c45-8bf9-5b9caca9bfd3`

## Coordination

A parallel branch `claude/debundle-a2-crate-split` may move/split these files (`realizability.rs`, `peel/quotient.rs`). It does not exist on the remote at PR creation time; whichever of the two merges second takes a trivial rebase — this diff is kept minimal to ease that.

https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk)_