### PR TITLE
debundle: add default_export_aliases escape hatch for named_from_module_default swaps

### DIFF
--- a/devinfra/js/debundle/docs/design.md
+++ b/devinfra/js/debundle/docs/design.md
@@ -2890,6 +2890,21 @@ properties must not be reassigned after module init, and consumers
 must not rely on live-binding semantics for the wrapped names.
 (JSON wrappers are immune — JSON modules are inert data.)
 
+`named_from_module_default` additionally requires each non-`default`
+vendor export to be a **verified alias** of the chunk's own `default`
+export — i.e. the chunk binds the name to the same local as its
+`default` (`export { x as default, x as alias }`). This rejects a
+chunk that exports an unrelated binding (`export { x as default, y as
+other }`), which would otherwise silently re-export the package
+default under `other`. A chunk that re-exports the package default
+under a single minified name with no `default` export of its own
+(`export { Ft as c }`, as Vite emits for a default-only re-export)
+cannot be verified from the chunk alone. For that case the swap mark
+carries `default_export_aliases: [<name>...]`, an author-asserted list
+admitted as verified aliases — the author is responsible for
+confirming the binding really is the package default (e.g. by its
+runtime identity/version).
+
 ## Empty logical modules
 
 A spec entry that resolves to zero owned bindings and no re-exports

--- a/devinfra/js/debundle/e2e/vendor_swap_test.rs
+++ b/devinfra/js/debundle/e2e/vendor_swap_test.rs
@@ -273,6 +273,7 @@ fn run_named_from_module_default_fixture(upstream_source: &str) -> VendorSwapFix
         chunk_source: "export { x as default };\nconst x = 0;\n",
         wrapper_shape: Some("named_from_module_default"),
         upstream_source,
+        default_export_aliases: &[],
     })
 }
 
@@ -282,6 +283,9 @@ struct FullSwapFixtureArgs<'a> {
     /// `None` runs the plain (wrapper-less) swap path.
     wrapper_shape: Option<&'a str>,
     upstream_source: &'a str,
+    /// Upstream named exports asserted as package-default aliases
+    /// (`SwapMark::default_export_aliases`). Empty for most fixtures.
+    default_export_aliases: &'a [&'a str],
 }
 
 fn run_full_swap_fixture(args: FullSwapFixtureArgs<'_>) -> VendorSwapFixture {
@@ -313,6 +317,15 @@ fn run_full_swap_fixture(args: FullSwapFixtureArgs<'_>) -> VendorSwapFixture {
             .as_object_mut()
             .expect("vendor mark is a JSON object")
             .insert("wrapper_shape".to_string(), json!(wrapper_shape));
+    }
+    if !args.default_export_aliases.is_empty() {
+        vendor_mark
+            .as_object_mut()
+            .expect("vendor mark is a JSON object")
+            .insert(
+                "default_export_aliases".to_string(),
+                json!(args.default_export_aliases),
+            );
     }
     let spec_path = ws.root.path().join("transform_spec.yaml");
     let spec = json!({
@@ -502,6 +515,7 @@ fn run_named_from_default_fixture(args: NamedFromDefaultFixtureArgs<'_>) -> Vend
         chunk_source: args.chunk_source,
         wrapper_shape: Some("named_from_default"),
         upstream_source: args.upstream_source,
+        default_export_aliases: &[],
     })
 }
 
@@ -2384,6 +2398,7 @@ fn full_swap_without_wrapper_requires_upstream_default_for_default_export() {
         chunk_source: "const x = 0;\nexport default x;\n",
         wrapper_shape: None,
         upstream_source: "export const unrelated = 1;\n",
+        default_export_aliases: &[],
     });
     assert!(
         !fixture.result.status.success(),
@@ -2406,6 +2421,7 @@ fn full_swap_without_wrapper_accepts_named_default_alias_when_upstream_has_defau
         chunk_source: "const x = 0;\nexport { x as default };\n",
         wrapper_shape: None,
         upstream_source: "const d = 1;\nexport default d;\n",
+        default_export_aliases: &[],
     });
     assert!(
         fixture.result.status.success(),
@@ -2485,6 +2501,7 @@ fn named_from_module_default_rejects_unverified_named_exports() {
         chunk_source: "const x = 0;\nconst y = 1;\nexport { x as default, y as other };\n",
         wrapper_shape: Some("named_from_module_default"),
         upstream_source: "export default function f() { return \"pkg\"; }\n",
+        default_export_aliases: &[],
     });
     assert!(
         !fixture.result.status.success(),
@@ -2507,6 +2524,7 @@ fn named_from_module_default_accepts_verified_default_aliases() {
         chunk_source: "const x = () => \"val\";\nexport { x as default, x as alias };\n",
         wrapper_shape: Some("named_from_module_default"),
         upstream_source: "export default function f() { return \"val\"; }\n",
+        default_export_aliases: &[],
     });
     assert!(
         fixture.result.status.success(),
@@ -2527,6 +2545,65 @@ fn named_from_module_default_accepts_verified_default_aliases() {
     assert_node_output(&probe_path, "true\n", "");
 }
 
+#[test]
+fn named_from_module_default_rejects_single_named_export_without_assertion() {
+    // Tana's cytoscape chunk shape: the package default is re-exported under
+    // a single minified name (`export { Ft as c }`) with no `default` export
+    // of its own. The static check cannot prove `c` aliases the package
+    // default from the chunk alone, so without an explicit assertion the
+    // swap must bail rather than silently re-export the default under `c`.
+    let fixture = run_full_swap_fixture(FullSwapFixtureArgs {
+        temp_prefix: "vendor-swap-module-default-single-unasserted-",
+        chunk_source: "const Ft = () => \"cy\";\nexport { Ft as c };\n",
+        wrapper_shape: Some("named_from_module_default"),
+        upstream_source: "export default function f() { return \"cy\"; }\n",
+        default_export_aliases: &[],
+    });
+    assert!(
+        !fixture.result.status.success(),
+        "debundler must reject an unasserted single-named-export chunk\nstdout:\n{}\nstderr:\n{}",
+        fixture.result.stdout,
+        fixture.result.stderr,
+    );
+    assert!(
+        fixture.result.stderr.contains("named-from-module-default")
+            && fixture.result.stderr.contains("c"),
+        "expected unverified-alias diagnostic naming `c` in stderr:\n{}",
+        fixture.result.stderr,
+    );
+}
+
+#[test]
+fn named_from_module_default_admits_authored_default_alias() {
+    // Same chunk shape as above, but the author asserts via
+    // `default_export_aliases` that `c` is the package default. The swap
+    // then succeeds and the wrapper re-exports the package default under `c`.
+    let fixture = run_full_swap_fixture(FullSwapFixtureArgs {
+        temp_prefix: "vendor-swap-module-default-single-asserted-",
+        chunk_source: "const Ft = () => \"cy\";\nexport { Ft as c };\n",
+        wrapper_shape: Some("named_from_module_default"),
+        upstream_source: "export default function f() { return \"cy\"; }\n",
+        default_export_aliases: &["c"],
+    });
+    assert!(
+        fixture.result.status.success(),
+        "debundler exited {:?}\nstdout:\n{}\nstderr:\n{}",
+        fixture.result.status.code(),
+        fixture.result.stdout,
+        fixture.result.stderr,
+    );
+    let probe_path = fixture
+        .wrapper_path
+        .parent()
+        .expect("wrapper has parent dir")
+        .join("__probe.mjs");
+    write_text_file(
+        &probe_path,
+        "const m = await import(\"./entry.js\");\nconsole.log(m.c === m.default && m.c() === \"cy\");\n",
+    );
+    assert_node_output(&probe_path, "true\n", "");
+}
+
 // ─── named_from_json_default ────────────────────────────────────────────
 
 #[test]
@@ -2536,6 +2613,7 @@ fn named_from_json_default_generates_named_pulls_from_json_keys() {
         chunk_source: "export { version, flag } from \"lib\";\n",
         wrapper_shape: Some("named_from_json_default"),
         upstream_source: "{ \"version\": \"1.2.3\", \"flag\": true }\n",
+        default_export_aliases: &[],
     });
     assert!(
         fixture.result.status.success(),
@@ -2571,6 +2649,7 @@ fn named_from_json_default_rejects_names_missing_from_json() {
         chunk_source: "export { missing } from \"lib\";\n",
         wrapper_shape: Some("named_from_json_default"),
         upstream_source: "{ \"version\": \"1.2.3\" }\n",
+        default_export_aliases: &[],
     });
     assert!(
         !fixture.result.status.success(),

--- a/devinfra/js/debundle/spec.rs
+++ b/devinfra/js/debundle/spec.rs
@@ -418,6 +418,19 @@ pub struct SwapMark {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub wrapper_shape: Option<WrapperShape>,
+    /// Upstream named exports the author asserts are aliases of the
+    /// swapped package's default export. The `named_from_module_default`
+    /// soundness check normally verifies, from the upstream chunk alone,
+    /// that each named export shares a local binding with the chunk's own
+    /// `default` export. A chunk that re-exports the package default under
+    /// a single minified name without also exporting it as `default`
+    /// (`export { Ft as c }`) gives the static check nothing to anchor on,
+    /// so it cannot prove the alias even when it holds. Listing the export
+    /// name here records the author's verified assertion (e.g. confirmed by
+    /// the binding's runtime identity/version) and admits it as a default
+    /// alias. Only consulted for `wrapper_shape: named_from_module_default`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub default_export_aliases: Vec<String>,
 }
 
 /// Per-symbol vendor swap on a mixed chunk. The chunk stays on disk

--- a/devinfra/js/debundle/spec_tree.rs
+++ b/devinfra/js/debundle/spec_tree.rs
@@ -83,6 +83,10 @@ struct VendorMarkSource {
     subpath: Option<String>,
     #[serde(default)]
     wrapper_shape: Option<WrapperShape>,
+    /// `swap`-only: upstream named exports asserted as aliases of the
+    /// package default (see `spec::SwapMark::default_export_aliases`).
+    #[serde(default)]
+    default_export_aliases: Vec<String>,
     /// `partial_swap` / `bundled_partial_swap`: per-package upstream
     /// coordinates. Bundled swaps also require `bundle_export`.
     #[serde(default)]
@@ -311,6 +315,7 @@ impl VendorMarkSource {
                         format!("vendor mark {} missing subpath", self.chunk_path)
                     })?,
                     wrapper_shape: self.wrapper_shape,
+                    default_export_aliases: self.default_export_aliases,
                 }))
             }
             VendorLevelSource::PartialSwap => {
@@ -401,6 +406,7 @@ impl VendorMarkSource {
             || self.version.is_some()
             || self.subpath.is_some()
             || self.wrapper_shape.is_some()
+            || !self.default_export_aliases.is_empty()
         {
             bail!(
                 "vendor mark {} has swap-only fields but level is not swap",

--- a/devinfra/js/debundle/vendor/mod.rs
+++ b/devinfra/js/debundle/vendor/mod.rs
@@ -540,6 +540,24 @@ pub fn swap_vendor_chunks(
                 .with_context(|| {
                     format!("swap_vendor_chunks vendor chunk {chunk_name} is missing entry AST")
                 })?;
+            let vendor_exports = collect_exported_names(&entry_ast.module);
+            let declared_default_aliases: BTreeSet<String> =
+                swap.default_export_aliases.iter().cloned().collect();
+            let unknown_aliases = set_diff(&declared_default_aliases, &vendor_exports);
+            if !unknown_aliases.is_empty() {
+                bail!(
+                    "swap_vendor_chunks vendor entry {} default_export_aliases names exports the chunk does not declare: [{}]",
+                    chunk_path,
+                    unknown_aliases.into_iter().collect::<Vec<_>>().join(",")
+                );
+            }
+            // Author-asserted default aliases (see `SwapMark::default_export_aliases`)
+            // join the statically verified set so a chunk that re-exports the package
+            // default under a minified name without its own `default` export can still
+            // pass the `named_from_module_default` soundness check.
+            let mut vendor_default_aliases =
+                verified_default_alias_export_names(&entry_ast.module);
+            vendor_default_aliases.extend(declared_default_aliases);
             Ok(SwapVendorJob {
                 chunk_path: (*chunk_path).clone(),
                 chunk_name,
@@ -548,8 +566,8 @@ pub fn swap_vendor_chunks(
                 version: swap.version.clone(),
                 subpath: swap.subpath.clone(),
                 wrapper_shape: swap.wrapper_shape,
-                vendor_exports: collect_exported_names(&entry_ast.module),
-                vendor_default_aliases: verified_default_alias_export_names(&entry_ast.module),
+                vendor_exports,
+                vendor_default_aliases,
             })
         })
         .collect::<Result<Vec<_>>>()?;


### PR DESCRIPTION
## What

Adds an author-asserted `default_export_aliases` field to the vendor swap mark, so a `named_from_module_default` swap can be applied to a chunk that re-exports the package default under a single minified name **without** also exporting it as `default`.

## Why

The `named_from_module_default` soundness check requires every claimed named export to be a *verified alias of the chunk's own `default` export* — i.e. the chunk binds the name to the same local as its `default` (`export { x as default, x as alias }`). This correctly rejects an unrelated export being silently re-exported as the package default.

But a chunk that re-exports the package default under a single minified name with **no `default` export of its own** — e.g. `export { Ft as c }`, which is what Vite emits for a default-only re-export — gives the static check nothing to anchor on, so it can't prove the alias even when it genuinely holds, and the swap bails.

This surfaced peeling Tana's web bundle: its cytoscape chunk is exactly `export { Ft as c }`, where `Ft` is the cytoscape default (carries `Ft.use` / `Ft.version`). There was no way to express the (true) assertion that `c` is the package default.

## How

- `default_export_aliases: [<name>...]` on the swap mark (flat `SwapMark` and tree `VendorMarkSource`), unioned into the gate's verified-alias set.
- Validated against the chunk's real exports, so a typo'd name is a hard error rather than silently dead.
- Restricted to swap-level marks (rejected on non-swap levels, like the other swap-only fields).
- Soundness shifts to the spec author, consistent with the existing declared-purity (`purity: pure` / `pure_new`) and `effect:` annotations. Documented under design.md's wrapper-shape section.

## Tests

Two e2e regressions mirroring the Tana cytoscape shape (`export { Ft as c }`, no `default`):
- without the assertion → bails naming `c` (unverified alias);
- with `default_export_aliases: [c]` → succeeds, and a runtime probe confirms the wrapper re-exports the package default under `c`.

https://claude.ai/code/session_01Bp8cANKC1Ktc92T7SM1kcx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bp8cANKC1Ktc92T7SM1kcx)_