### PR TITLE
debundle: classify coercions of primitive-const bindings as pure

### DIFF
--- a/devinfra/js/debundle/purity/classifier_tests.rs
+++ b/devinfra/js/debundle/purity/classifier_tests.rs
@@ -1012,3 +1012,50 @@ fn object_calls_shadowed_receiver_stays_unknown() {
         !(classify_with_module("const Object = userland;", "Object.entries({a: 1})")).is_pure()
     );
 }
+
+/// Classify `expr_src` against a fully built `ChunkCodeGraph` for the
+/// wrapping `prefix` module, so chunk-top binding facts — including the
+/// primitive-`const` set — are populated.
+fn classify_built(prefix: &str, expr_src: &str) -> Purity {
+    let module = parse(&format!("{prefix}\nconst _ = {expr_src};"));
+    let body = top_level_item_views(&module.body);
+    let shadowed = compute_shadowed_globals(&body);
+    let graph = ChunkCodeGraph::build(&body, &shadowed, &BTreeSet::new());
+    let var = match module.body.last().expect("non-empty body") {
+        ModuleItem::Stmt(Stmt::Decl(Decl::Var(var))) => var,
+        other => panic!("expected last stmt to be `const _ = …;`, got {other:?}"),
+    };
+    let init = var.decls[0].init.as_deref().expect("init expected");
+    classify_expr_purity(init, &shadowed, &BTreeSet::new(), &BTreeSet::new(), &graph)
+}
+
+#[test]
+fn coercion_of_primitive_const_binding_is_pure() {
+    // A chunk-top `const` bound to a primitive is immutable and carries
+    // no user accessors, so ToString / ToNumber on a reference fires no
+    // user code — the coercion is pure.
+    assert!(classify_built("const s = \"x\";", "`v=${s}`").is_pure());
+    assert!(classify_built("const n = 5;", "-n").is_pure());
+    assert!(classify_built("const a = 1; const b = 2;", "a + b").is_pure());
+    // Transitive through another primitive const, and a computed key.
+    assert!(classify_built("const a = \"x\"; const b = `${a}!`;", "`${b}`").is_pure());
+    assert!(classify_built("const k = \"id\";", "({ [k]: 1 })").is_pure());
+}
+
+#[test]
+fn coercion_of_let_or_var_binding_stays_unknown() {
+    // `let` / `var` can be rebound to an object later, so the binding is
+    // not provably primitive and the coercion stays conservative.
+    assert!(!classify_built("let s = \"x\";", "`${s}`").is_pure());
+    assert!(!classify_built("var s = \"x\";", "`${s}`").is_pure());
+}
+
+#[test]
+fn coercion_of_non_primitive_const_stays_unknown() {
+    // `const o = {}` is a const but not primitive — interpolating it runs
+    // user `toString` / `[Symbol.toPrimitive]`.
+    assert!(!classify_built("const o = {};", "`${o}`").is_pure());
+    // A const whose init is not statically result-primitive (a bare
+    // import/member read) is not admitted either.
+    assert!(!classify_built("const o = globalThis.x;", "`${o}`").is_pure());
+}

--- a/devinfra/js/debundle/purity/mod.rs
+++ b/devinfra/js/debundle/purity/mod.rs
@@ -40,6 +40,15 @@ pub struct ChunkCodeGraph {
     /// admitted as pure with args evaluated normally. Author-trust
     /// contract; see AGENTS.md "Declared purity".
     declared_pure_members: BTreeMap<String, BTreeSet<String>>,
+    /// Chunk-top `const X = <result-primitive init>` binding names.
+    /// `const` makes the binding immutable, and a primitive value
+    /// carries no user accessors, so a `ToString` / `ToNumber` /
+    /// `ToPropertyKey` coercion of a reference to `X` fires no user
+    /// code — `X` is admitted as result-primitive wherever it is not
+    /// locally shadowed. The init's own evaluation effects are
+    /// classified separately at its declaration site; only the
+    /// *value* class matters here. See `collect_primitive_const_bindings`.
+    primitive_const_bindings: BTreeSet<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -161,6 +170,7 @@ impl ChunkCodeGraph {
             bindings,
             pure_new_constructors: declared_pure_new.clone(),
             declared_pure_members: declared_pure_members.clone(),
+            primitive_const_bindings: collect_primitive_const_bindings(body),
         };
         // tarjan_scc emits SCCs in reverse topological order: leaves
         // (sinks — functions that don't call any chunk-top
@@ -713,6 +723,37 @@ fn collect_plain_data_bindings(
         .into_iter()
         .filter(|n| !disqualified.contains(n))
         .collect()
+}
+
+/// Chunk-top `const X = <init>` names whose init evaluates to a
+/// **primitive** value, resolving references to earlier such consts.
+/// `const` guarantees the binding never rebinds, and a primitive
+/// carries no user accessors, so coercing a reference to the name
+/// fires no user code regardless of how the init was computed (the
+/// init's own evaluation effects are classified at its declaration
+/// site — only the resulting value class matters here). `let` / `var`
+/// are excluded: a later non-primitive rebind would invalidate the
+/// claim.
+///
+/// Forward pass in source order: a const resolves only references to
+/// consts declared before it — exactly the set visible without
+/// hitting the temporal dead zone. Function/arrow inits never reach
+/// here (`plain_data_var_candidates` filters them) and are not
+/// primitive anyway.
+fn collect_primitive_const_bindings(body: &[TopLevelItemView<'_>]) -> BTreeSet<String> {
+    let mut primitives: BTreeSet<String> = BTreeSet::new();
+    let no_local_shadow: BTreeSet<String> = BTreeSet::new();
+    for item in body {
+        for (name, init, kind) in plain_data_var_candidates(item.as_module_item()) {
+            if kind == VarDeclKind::Const
+                && !primitives.contains(&name)
+                && is_result_primitive(init, &primitives, &no_local_shadow)
+            {
+                primitives.insert(name);
+            }
+        }
+    }
+    primitives
 }
 
 /// Yield `(name, init)` pairs for every chunk-top single-declarator
@@ -1861,7 +1902,7 @@ pub(crate) fn classify_expr_purity(
             .iter()
             .map(|e| {
                 let p = classify_expr_purity(e, shadowed, local_shadowed, declared_pure, graph);
-                if is_result_primitive(e) {
+                if is_result_primitive(e, &graph.primitive_const_bindings, local_shadowed) {
                     p
                 } else {
                     p.worst(Purity::from_reason_with_detail(
@@ -1905,7 +1946,8 @@ pub(crate) fn classify_expr_purity(
                 // `[Symbol.toPrimitive]`. Pure only when the
                 // operand is statically primitive-valued.
                 UnaryOp::Plus | UnaryOp::Minus | UnaryOp::Tilde => {
-                    if is_result_primitive(&u.arg) {
+                    if is_result_primitive(&u.arg, &graph.primitive_const_bindings, local_shadowed)
+                    {
                         arg_purity
                     } else {
                         arg_purity.worst(Purity::from_reason_with_detail(
@@ -1960,7 +2002,13 @@ pub(crate) fn classify_expr_purity(
                 // on object operands. Pure only when both operands
                 // are statically primitive-valued.
                 _ => {
-                    if is_result_primitive(&b.left) && is_result_primitive(&b.right) {
+                    if is_result_primitive(&b.left, &graph.primitive_const_bindings, local_shadowed)
+                        && is_result_primitive(
+                            &b.right,
+                            &graph.primitive_const_bindings,
+                            local_shadowed,
+                        )
+                    {
                         operands
                     } else {
                         operands.worst(Purity::from_reason_with_detail(
@@ -2484,7 +2532,12 @@ fn classify_member_purity(
                     declared_pure,
                     graph,
                 );
-                if is_safe_property_key(&computed.expr, shadowed, local_shadowed) {
+                if is_safe_property_key(
+                    &computed.expr,
+                    shadowed,
+                    local_shadowed,
+                    &graph.primitive_const_bindings,
+                ) {
                     key_purity
                 } else {
                     key_purity.worst(Purity::from_reason_with_detail(
@@ -2843,7 +2896,11 @@ fn is_primitive_literal(expr: &Expr) -> bool {
 ///   (`&&` / `||` / `??` return one of their operands verbatim;
 ///   everything else — arithmetic, relational, equality, bitwise,
 ///   `in`, `instanceof` — returns a number/string/bigint/boolean);
-/// * conditionals whose both branches are result-primitive.
+/// * conditionals whose both branches are result-primitive;
+/// * a reference to a chunk-top `const` provably bound to a
+///   primitive value (`primitives`, from
+///   `collect_primitive_const_bindings`), when the name is not
+///   locally shadowed.
 ///
 /// The global `undefined` is deliberately NOT admitted: it is an
 /// ordinary (shadowable) global binding, not a keyword, and the
@@ -2852,16 +2909,30 @@ fn is_primitive_literal(expr: &Expr) -> bool {
 ///
 /// No admitted shape can produce a Symbol, so ToString on a
 /// result-primitive value never hits the symbol TypeError path.
-fn is_result_primitive(expr: &Expr) -> bool {
+fn is_result_primitive(
+    expr: &Expr,
+    primitives: &BTreeSet<String>,
+    local_shadowed: &BTreeSet<String>,
+) -> bool {
     match strip_parens(expr) {
         Expr::Lit(Lit::Str(_) | Lit::Num(_) | Lit::Bool(_) | Lit::Null(_) | Lit::BigInt(_)) => true,
         Expr::Tpl(_) => true,
+        // A chunk-top `const` provably bound to a primitive value: the
+        // binding is immutable and the value carries no user accessors,
+        // so coercing it fires no user code — unless a local binding
+        // shadows the name in the current scope.
+        Expr::Ident(id) => {
+            primitives.contains(id.sym.as_ref()) && !local_shadowed.contains(id.sym.as_ref())
+        }
         Expr::Unary(u) => u.op != UnaryOp::Delete,
         Expr::Bin(b) => !matches!(
             b.op,
             BinaryOp::LogicalAnd | BinaryOp::LogicalOr | BinaryOp::NullishCoalescing
         ),
-        Expr::Cond(c) => is_result_primitive(&c.cons) && is_result_primitive(&c.alt),
+        Expr::Cond(c) => {
+            is_result_primitive(&c.cons, primitives, local_shadowed)
+                && is_result_primitive(&c.alt, primitives, local_shadowed)
+        }
         _ => false,
     }
 }
@@ -2877,8 +2948,9 @@ fn is_safe_property_key(
     key: &Expr,
     shadowed: &BTreeSet<&'static str>,
     local_shadowed: &BTreeSet<String>,
+    primitives: &BTreeSet<String>,
 ) -> bool {
-    if is_result_primitive(key) {
+    if is_result_primitive(key, primitives, local_shadowed) {
         return true;
     }
     if let Expr::Member(member) = strip_parens(key)
@@ -2972,7 +3044,12 @@ fn classify_propname_purity(
         PropName::Computed(c) => {
             let key_purity =
                 classify_expr_purity(&c.expr, shadowed, local_shadowed, declared_pure, graph);
-            if is_safe_property_key(&c.expr, shadowed, local_shadowed) {
+            if is_safe_property_key(
+                &c.expr,
+                shadowed,
+                local_shadowed,
+                &graph.primitive_const_bindings,
+            ) {
                 key_purity
             } else {
                 key_purity.worst(Purity::from_reason_with_detail(
@@ -3022,7 +3099,13 @@ pub(crate) fn class_has_static_observable(
     let key_observable = |key: &PropName| match key {
         PropName::Ident(_) | PropName::Str(_) | PropName::Num(_) | PropName::BigInt(_) => false,
         PropName::Computed(c) => {
-            value_impure(&c.expr) || !is_safe_property_key(&c.expr, shadowed, local_shadowed)
+            value_impure(&c.expr)
+                || !is_safe_property_key(
+                    &c.expr,
+                    shadowed,
+                    local_shadowed,
+                    &graph.primitive_const_bindings,
+                )
         }
     };
     if !class.decorators.is_empty() {


### PR DESCRIPTION
## What

Teaches the purity classifier that a coercion (`ToString` / `ToNumber` / `ToPropertyKey`) of a reference to a chunk-top `const` bound to a primitive value fires no user code, so it is no longer flagged `coercing_operator`.

## Why

The dataflow-aware S-chain (at-init side-effect ordering) only constrains statements the purity classifier marks impure — `emit_s_chain` filters on `!purity.is_pure()`. As the classifier's own docs note, purity precision is what keeps the cross-module S graph sparse; without it the S graph "would be dense enough to reject realistic specs for trivially pure const sequences."

`is_result_primitive` (the gate deciding whether an operator's ToPrimitive coercion of its operand is safe) was purely syntactic — `Expr::Ident → false`. So a coercion of a reference to a chunk-top `const kU = "..."` was classified impure (`coercing_operator`) even though `kU` is an immutable primitive that carries no user accessors. On a real app bundle this marks a large class of ordinary top-level statements (template literals, arithmetic, computed keys over string/number constants) as at-init side effects, chaining them into the S-chain and forcing co-location of otherwise-independent modules.

This was surfaced peeling Tana's web bundle, where the tightened purity classification collapsed a large swath of the main chunk into one unrealizable atomic unit; `coercing_operator` was a notable contributor.

## How

- A new `collect_primitive_const_bindings` pass records chunk-top `const X = <init>` names whose init evaluates to a primitive value, resolving references to earlier such consts (forward pass, TDZ-respecting).
- `is_result_primitive` now admits a reference to such a binding when the name is not locally shadowed.
- `const` only: `let` / `var` are excluded because a later non-primitive rebind would invalidate the claim. The init's *own* evaluation effects remain classified at its declaration site — only the resulting value class matters at the reference, so an init like `const s = a + b` (primitive-valued, possibly-impure to evaluate) still admits references to `s`.

Soundness rests on two language guarantees: `const` bindings never rebind, and a primitive value cannot carry a user accessor or `[Symbol.toPrimitive]`, so coercing it is engine-only.

## Tests

`classifier_tests.rs` adds a `classify_built` helper (classifies against a fully built `ChunkCodeGraph`) and cases covering: template / unary / binary / computed-key coercions over primitive consts are pure (incl. transitive consts); `let` / `var` bindings stay conservative; non-primitive `const` (object, or non-result-primitive init) stays conservative.

`//devinfra/js/debundle:analysis_test` passes locally.

https://claude.ai/code/session_01Bp8cANKC1Ktc92T7SM1kcx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bp8cANKC1Ktc92T7SM1kcx)_