### PR TITLE
debundle: introduce RenameLedger; collect explicit rename contributors (PR 1/5)

### DIFF
--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -557,6 +557,7 @@ rust_library(
         "lowering/ordinal.rs",
         "lowering/plan_references.rs",
         "lowering/plans.rs",
+        "lowering/rename_ledger.rs",
         "lowering/rewrite_runtime.rs",
         "lowering/runtime_imports.rs",
         "lowering/scope_names.rs",
@@ -586,6 +587,12 @@ rust_library(
         "@crates//:swc_ecma_ast",
         "@crates//:swc_ecma_visit",
     ],
+)
+
+rust_test(
+    name = "lowering_test",
+    crate = ":lowering",
+    edition = "2024",
 )
 
 rust_library(

--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -254,8 +254,48 @@ Scope-aware down-payments have landed in `lowering/visitors.rs` /
   scope-local heuristic renames can no longer remap a top-level export
   specifier or orphan a member comment.
 
-The collect→validate→execute **ledger/intent-buffer** architecture below
-remains the open work.
+**PR 1 landed (2026-06):** `lowering/rename_ledger.rs` holds the intent
+buffer — `RenameLedger` accumulating `RenameIntent { scope, from: Id, to,
+origin }` with scopes `Chunk | Module(ModuleId) | Function(span)` and
+priority derived from origin (explicit > import-induced > heuristic).
+`seal()` hard-errors when same-priority intents disagree on one binding's
+target (naming both contributors) and projects the surviving intents into
+the same maps the pre-ledger code built. The two explicit contributors
+are converted (spec `chunk_renames`; plan-driven `export_name`s); the
+remaining-contributor inventory lives in `rename_ledger.rs`'s module doc.
+
+Decisions taken (formerly the open-questions subsection below):
+
+1. **Same-priority conflicts are hard errors at seal**, naming both
+   contributors — silent suppression is the trap the ledger closes.
+2. **The `$N`-suffix minting scheme stays as-is** when
+   `disambiguate_import_locals`' minting becomes a ledger service (PR 3);
+   readability is a separate, later naturalizer concern.
+3. **Structural-mutation contract: no structural moves between seal and
+   execute.** Most moves already happen pre-seal (the materializer seals
+   after `ChunkPlan` finalization); the `&Module` type-level barrier for
+   non-execute passes lands with the execute-once pass.
+
+Remaining PRs:
+
+- **PR 2 — collect**: convert the remaining contributors (heuristic
+  bound/free, import-local disambiguation, cross-module renames,
+  collision resolution) to submit intents; worklist in
+  `rename_ledger.rs`.
+- **PR 3 — seal**: move target-occupancy/capture validation into seal
+  against scope-accurate occupied sets; `_N`/`$N` minting becomes a
+  ledger service.
+- **PR 4 — execute once**: one visitor pass (the post-#2052 rename
+  visitor becomes the executor) updating the AST, export tables,
+  `runtime_imports`, `binding_comments`, and cross-module indexes in
+  lockstep, keyed by hygiene `Id` (deleting the seal-output string
+  projection).
+- **PR 5 — cleanup**: delete the defensive era (`captured` sets,
+  `drop_subtree_captured_targets` where dominated, `merged`/`module_scope`
+  split, reverse lookups); afterwards the #2045 class is
+  unrepresentable.
+
+The architecture sketch below remains the reference for PRs 2–5.
 
 The naturalizer / lowerer currently mutates identifiers in place across
 several independently-discovered passes and lets every downstream consumer
@@ -299,65 +339,17 @@ defensive reverse-lookups and path sanitizers can become ordinary
 mapping/path-building code once the final mapping makes body ASTs,
 runtime imports, and report tables agree before planning runs.
 
-Prerequisite work before designing the pipeline:
+Remaining prerequisite work (the contributor inventory and the scope
+model landed with PR 1 — see `lowering/rename_ledger.rs`):
 
-1. Inventory every current rename contributor in `lowering/` and
-   adjacent files. Examples already known:
-   `collect_return_object_alias_renames` and
-   `collect_naturalization_renames_from_function` in
-   `lowering/naturalize.rs`; `RenameAndShorthandNaturalizer` and
-   `naturalize_object_literal_shorthand` in `lowering/visitors.rs`;
-   `disambiguate_import_locals` in `lowering/util.rs`; the chunk-level
-   `chunk_renames` map that flows out of factorize; and any
-   collision-resolution code path that mutates `module_import_renames`
-   at the orchestration site. Capture each contributor's _kind_
-   (explicit / heuristic / collision / chunk-level), _scope_ (function
-   / module / chunk / cross-chunk), and _current side-effect surface_.
-
-2. Inventory every downstream consumer that today reads identifier
+1. Inventory every downstream consumer that today reads identifier
    names off the AST or off pre-rename fact maps. Same call sites that
    currently need defensive bridging.
 
-3. Decide on the scope model. Per-function naturalizer renames don't
-   need to be visible at chunk scope; chunk_renames don't need to
-   reach per-function naturalizer collection. The intent buffer should
-   reject cross-scope writes by construction.
-
-4. Design must not block on landing small defensive fixes. Land them
+2. Design must not block on landing small defensive fixes. Land them
    case by case as bugs are discovered. Removing redundant defensive
    patches is part of the pipeline-landing cleanup, not the architecture
    work itself.
-
-Likely multiple PRs.
-
-### RenameLedger (PR2) open questions
-
-Before implementing the pipeline above, pin these three design questions:
-
-1. **Conflict policy for same-priority heuristic disagreements.** When
-   two heuristic contributors propose conflicting renames at the same
-   priority (e.g. `collect_return_object_alias_renames` says `sA →
-propKeyA` and `collect_naturalization_renames_from_function` says
-   `sA → propKeyB`), does the ledger panic at seal citing both
-   submitters, or silently suppress the lower one? Default proposal:
-   panic loudly, with both contributors named in the error — silent
-   suppression is the trap PR2 is meant to close.
-2. **Disambiguation name minter.** `disambiguate_import_locals` today
-   appends `_1`, `_2`, ... suffixes until a free name is found. When
-   that becomes a `RenameLedger` method (so the ledger owns "what
-   names are taken in this chunk"), does the scheme stay as-is, or
-   switch to something more readable (`name_from_module`, etc.)?
-   Default proposal: keep `_N` scheme; readability is a separate
-   concern best handled by a later naturalizer pass.
-3. **Structural mutations during COLLECT.** Today
-   `materialize_logical_modules` moves declarations between modules
-   in-place during the collect phase. Tighten the contract to either:
-   - "no structural moves between seal and execute" (pragmatic — most
-     moves already happen pre-seal, and the type-level barrier
-     `&Module` in non-execute passes lands cleanly), or
-   - "all structural moves pre-COLLECT" (cleaner architecturally but
-     requires reordering the materializer to compute a final body
-     order before any rename intents are submitted).
 
 ## CLI scripting surface
 

--- a/devinfra/js/debundle/lowering/chunk_renames.rs
+++ b/devinfra/js/debundle/lowering/chunk_renames.rs
@@ -1,29 +1,33 @@
-//! Validate + collect chunk-level `chunk_renames` from the spec.
+//! Collect chunk-level `chunk_renames` from the spec into the rename
+//! ledger (scope: `Chunk`, origin: `Explicit`). Duplicate members that
+//! disagree on one binding's target surface as a seal-time conflict
+//! naming both entries.
 
 use super::*;
 
+pub(super) const CHUNK_RENAMES_CONTRIBUTOR: &str = "spec chunk_renames member";
+
 pub(super) fn collect_chunk_renames(
     chunk_renames: &ChunkRenames,
-) -> Result<HashMap<String, String>> {
-    let mut renames = HashMap::<String, String>::new();
+    chunk_top_level_mark: swc_common::Mark,
+    ledger: &mut RenameLedger,
+) -> Result<()> {
     for member in &chunk_renames.members {
         let Some(binding_selector) = &member.selector.binding else {
             bail!(
                 "chunk_renames: members[].selector.source_match is not supported here; use selector.binding.name"
             );
         };
-        let binding = binding_selector.name.clone();
+        let binding = &binding_selector.name;
         let export_name = member.name.clone().unwrap_or_else(|| binding.clone());
-        if let Some(existing) = renames.get(&binding) {
-            if existing != &export_name {
-                bail!(
-                    "chunk_renames: binding {binding} already renamed to \
-                     {existing}; refusing to overwrite with {export_name}"
-                );
-            }
-        } else {
-            renames.insert(binding, export_name);
-        }
+        ledger.submit(RenameIntent {
+            scope: RenameScope::Chunk,
+            from: top_level_id(binding, chunk_top_level_mark),
+            to: export_name.into(),
+            origin: RenameOrigin::Explicit {
+                contributor: CHUNK_RENAMES_CONTRIBUTOR,
+            },
+        });
     }
-    Ok(renames)
+    Ok(())
 }

--- a/devinfra/js/debundle/lowering/lower.rs
+++ b/devinfra/js/debundle/lowering/lower.rs
@@ -67,7 +67,13 @@ pub(super) struct LowerChunkPlan<'a> {
 /// emission time. Held in `LowerChunkInputs::spec_facts`.
 pub(super) struct LowerChunkSpecFacts<'a> {
     pub(super) runtime_import_facts: &'a RuntimeImportFacts,
-    /// In-place renames from `TransformSpec::chunk_renames`. Applied
+    /// The chunk's sealed rename ledger (explicit contributors collected
+    /// and conflict-validated in `materialize_logical_chunk`). The
+    /// per-plan naturalize pass below queries its Module-scope maps;
+    /// `chunk_renames` is its Chunk-scope projection.
+    pub(super) sealed_renames: &'a SealedRenames,
+    /// In-place renames from `TransformSpec::chunk_renames` — the sealed
+    /// ledger's Chunk-scope projection. Applied
     /// to bindings staying in entry's body — i.e. those *not* in
     /// `binding_assignment`. Bindings claimed by a logical module
     /// take their rename from the module plan; entries here for
@@ -126,6 +132,7 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
     } = plan;
     let LowerChunkSpecFacts {
         runtime_import_facts,
+        sealed_renames,
         chunk_renames,
         pre_existing_entry_exports,
         pre_existing_public_export_names,
@@ -379,7 +386,8 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
     time_phase!(timings, "module.naturalize_body", {
         for (index, plan) in module_plans.iter().enumerate() {
             let mut body = std::mem::take(&mut selected_by_module[index]);
-            let renames = naturalize_module_body(&mut body, plan)?;
+            let plan_driven = sealed_renames.module_renames_by_name(ModuleId::logical(index));
+            let renames = naturalize_module_body(&mut body, plan, plan_driven)?;
             naturalized_bodies.push(body);
             local_renames_by_module.push(renames);
         }

--- a/devinfra/js/debundle/lowering/materialize/mod.rs
+++ b/devinfra/js/debundle/lowering/materialize/mod.rs
@@ -178,14 +178,6 @@ pub(super) fn materialize_logical_chunk(
     )?;
     timings.add("build_module_plans", build_module_plans_started.elapsed());
 
-    let chunk_renames_map = time_phase!(timings, "collect_chunk_renames", {
-        chunk_renames
-            .get(chunk_id)
-            .map(collect_chunk_renames)
-            .transpose()
-    })?
-    .unwrap_or_default();
-
     let analysis_hints: AnalysisHints = time_phase!(timings, "collect_analysis_hints", {
         collect_analysis_hints(&explicit_requests, chunk_renames.get(chunk_id))
     });
@@ -246,6 +238,21 @@ pub(super) fn materialize_logical_chunk(
         anonymous_ordinal_assignment,
         unmatched_spec_claims,
     } = builder.finalize();
+    // Plan structure is final — collect the explicit rename contributors
+    // into the chunk's rename ledger and seal it. Seal hard-errors when
+    // same-priority intents disagree on one binding's target; the sealed
+    // output feeds the same application sites the pre-ledger maps fed
+    // (Chunk scope → `chunk_renames_map` below, Module scope → the
+    // per-plan naturalize pass in `lower_chunk`).
+    let sealed_renames = time_phase!(timings, "seal_rename_ledger", {
+        let mut ledger = RenameLedger::default();
+        if let Some(renames) = chunk_renames.get(chunk_id) {
+            collect_chunk_renames(renames, chunk_top_level_mark, &mut ledger)?;
+        }
+        collect_plan_export_rename_intents(&module_plans, chunk_top_level_mark, &mut ledger);
+        ledger.seal()
+    })?;
+    let chunk_renames_map = sealed_renames.chunk_renames_by_name();
     let (logical_modules, default_destination) =
         time_phase!(timings, "project_factorization_modules", {
             project_factorization_modules_with_sentinel(
@@ -314,6 +321,7 @@ pub(super) fn materialize_logical_chunk(
             },
             spec_facts: LowerChunkSpecFacts {
                 runtime_import_facts: &runtime_import_facts,
+                sealed_renames: &sealed_renames,
                 chunk_renames: &chunk_renames_map,
                 pre_existing_entry_exports: &pre_existing_entry_exports,
                 pre_existing_public_export_names: &pre_existing_public_export_names,

--- a/devinfra/js/debundle/lowering/mod.rs
+++ b/devinfra/js/debundle/lowering/mod.rs
@@ -49,6 +49,7 @@ mod naturalize;
 mod ordinal;
 mod plan_references;
 mod plans;
+pub mod rename_ledger;
 mod rewrite_runtime;
 mod runtime_imports;
 mod scope_names;
@@ -83,12 +84,13 @@ use materialize::{
     ChunkContext, ChunkSpec, MaterializeLogicalChunkInputs, apply_materialized_logical_chunks,
     materialize_logical_chunk,
 };
-use naturalize::{NaturalizedRenames, naturalize_module_body};
+use naturalize::{NaturalizedRenames, collect_plan_export_rename_intents, naturalize_module_body};
 use plan_references::{
     ArtifactSourceImportResolutionCache, EntryExport, ModuleReferenceNeeds, RuntimeImportLookup,
     collect_imported_reexports_by_module, plan_module_reference_needs,
 };
 use plans::{LogicalRequest, MemberRequest, ModulePlan, logical_requests_for_chunk};
+use rename_ledger::{RenameIntent, RenameLedger, RenameOrigin, RenameScope, SealedRenames};
 use rewrite_runtime::rewrite_runtime_sources_for_target;
 use runtime_imports::{
     RuntimeImportFacts, RuntimeImportInfo, RuntimeImportKind, imported_binding_named_specifier,

--- a/devinfra/js/debundle/lowering/naturalize.rs
+++ b/devinfra/js/debundle/lowering/naturalize.rs
@@ -1,7 +1,10 @@
 //! Naturalization: rewrite body identifiers to readable names + collapse
-//! `{ x: x }` shorthand. Combines plan-driven renames (from spec) with
-//! heuristic renames derived from the AST (return-object aliases,
-//! destructure unpacks, constructor `this.x = param` mappings).
+//! `{ x: x }` shorthand. Combines plan-driven renames (spec `export_name`s,
+//! collected into the rename ledger by
+//! [`collect_plan_export_rename_intents`] and arriving here as the sealed
+//! Module-scope map) with heuristic renames derived from the AST
+//! (return-object aliases, destructure unpacks, constructor
+//! `this.x = param` mappings).
 //!
 //! `naturalize_module_body` is the public entry. Heuristic renames are
 //! split by what their source name resolves to:
@@ -46,22 +49,46 @@ pub(super) struct NaturalizedRenames {
     pub(super) module_scope: BTreeMap<String, String>,
 }
 
+/// Collect each plan's spec-driven `export_name` renames into the ledger
+/// (scope: that plan's [`ModuleId`], origin: `Explicit`). Applies the same
+/// filter the pre-ledger `plan_driven` map applied: self-renames and
+/// non-identifier targets never become intents. Iterates `plan.bindings`
+/// (a `HashMap`) in sorted order so the ledger's intent order — and any
+/// seal-time diagnostics — don't vary by hash seed.
+pub(super) fn collect_plan_export_rename_intents(
+    module_plans: &[ModulePlan],
+    chunk_top_level_mark: swc_common::Mark,
+    ledger: &mut RenameLedger,
+) {
+    for (index, plan) in module_plans.iter().enumerate() {
+        let mut sorted_bindings: Vec<(&String, &String)> = plan.bindings.iter().collect();
+        sorted_bindings.sort_by(|a, b| a.0.cmp(b.0));
+        for (local, exported) in sorted_bindings {
+            if local != exported && is_valid_js_identifier(exported) {
+                ledger.submit(RenameIntent {
+                    scope: RenameScope::Module(ModuleId::logical(index)),
+                    from: top_level_id(local, chunk_top_level_mark),
+                    to: exported.as_str().into(),
+                    origin: RenameOrigin::Explicit {
+                        contributor: PLAN_EXPORT_NAME_CONTRIBUTOR,
+                    },
+                });
+            }
+        }
+    }
+}
+
+pub(super) const PLAN_EXPORT_NAME_CONTRIBUTOR: &str = "logical_module member export_name";
+
+/// `plan_driven` is this plan's sealed Module-scope rename map
+/// (`SealedRenames::module_renames_by_name`); sorted (`BTreeMap`)
+/// iteration keeps the rename-precedence the visitor applies when two
+/// locals compete for the same target independent of hash seed.
 pub(super) fn naturalize_module_body(
     body: &mut [ModuleItem],
     plan: &ModulePlan,
+    plan_driven: BTreeMap<String, String>,
 ) -> Result<NaturalizedRenames> {
-    let mut plan_driven = BTreeMap::<String, String>::new();
-    // Stable iteration over `plan.bindings` (a HashMap) so the order
-    // renames land in `plan_driven` — and thus the rename-precedence the
-    // visitor applies when two locals compete for the same target —
-    // doesn't vary by hash seed.
-    let mut sorted_bindings: Vec<(&String, &String)> = plan.bindings.iter().collect();
-    sorted_bindings.sort_by(|a, b| a.0.cmp(b.0));
-    for (local, exported) in sorted_bindings {
-        if local != exported && is_valid_js_identifier(exported) {
-            plan_driven.insert(local.clone(), exported.clone());
-        }
-    }
     let mut free_heuristic = BTreeMap::<String, String>::new();
     for item in body.iter() {
         collect_free_alias_renames_from_item(item, &mut free_heuristic);

--- a/devinfra/js/debundle/lowering/rename_ledger.rs
+++ b/devinfra/js/debundle/lowering/rename_ledger.rs
@@ -1,0 +1,527 @@
+//! `RenameLedger` — the intent buffer of the collect → validate →
+//! execute-once rename pipeline (sanitization program Track B; TODO.md
+//! "Rename pipeline: collect → validate → execute _once_").
+//!
+//! Rename contributors submit [`RenameIntent`]s instead of building their
+//! own maps; [`RenameLedger::seal`] validates the intents and freezes them
+//! into [`SealedRenames`], whose queries reproduce exactly the maps the
+//! pre-ledger code built so the existing application sites (the
+//! string-keyed rename visitors in `visitors.rs`) stay unchanged.
+//!
+//! Current seal validation: no two same-priority intents may disagree on
+//! one `(scope, from)` binding's target — a hard error naming both
+//! contributors. A higher-priority intent (explicit > import-induced >
+//! heuristic) silently wins over a disagreeing lower-priority one.
+//! Target-occupancy / capture validation still happens at the application
+//! sites (`naturalize_module_body`'s root-collision pre-check, the
+//! visitors' `captured` sets); moving it into seal against scope-accurate
+//! occupied sets is PR 3. The single execute pass is PR 4.
+//!
+//! ## Contract: no structural moves between seal and execute
+//!
+//! Adopted (decided 2026-06): once a chunk's ledger is sealed, no pass may
+//! move declarations between modules — structural moves (entry-body split,
+//! residual sweep, rebind folds, mini-factor synthesis) must all happen
+//! before collection finishes. In PR 1 the materializer already satisfies
+//! the collection side (intents are collected from the finalized
+//! `ChunkPlan`); the contract becomes mechanically enforceable when the
+//! execute-once pass lands (PR 4) and non-execute passes take `&Module`.
+//!
+//! ## Hygiene boundary
+//!
+//! Intents are keyed by hygiene-aware [`Id`] — post-#2042 the chunk AST
+//! carries real `SyntaxContext`s and bare-string keys are how rename bugs
+//! breed. Contributors that only have a spec string resolve it at the
+//! collection point via `top_level_id(name, chunk_top_level_mark)`. The
+//! seal output is projected back to bare syms at the query boundary
+//! (`*_by_name`) because the post-#2052 application visitors are still
+//! string-keyed; the projection asserts that no two hygiene contexts share
+//! a sym within one scope. PR 4's executor consumes `Id`s directly and
+//! deletes the projection.
+//!
+//! ## Contributor inventory
+//!
+//! Converted (submit intents):
+//!
+//! - Spec `chunk_renames` — `chunk_renames.rs::collect_chunk_renames`
+//!   (scope: `Chunk`, origin: `Explicit`).
+//! - Plan-driven spec `export_name`s —
+//!   `naturalize.rs::collect_plan_export_rename_intents` (scope:
+//!   `Module`, origin: `Explicit`).
+//!
+//! Remaining (PR 2 worklist; each keeps building its own map today):
+//!
+//! - Heuristic bound-source scope-local renames — `naturalize.rs`:
+//!   `collect_naturalization_renames_from_pattern`,
+//!   `collect_naturalization_renames_from_constructor`, and root-bound
+//!   return-object aliases, derived and applied per function-like node by
+//!   `ScopedHeuristicNaturalizer::{visit_mut_function, visit_mut_arrow_expr,
+//!   visit_mut_constructor}` (scope: `Function`, origin: `Heuristic`).
+//! - Heuristic free-source return-object aliases — `naturalize.rs`:
+//!   `collect_free_alias_renames_from_item`, merged module-wide via
+//!   `drop_target_collisions` (scope: `Module`, origin: `Heuristic`).
+//! - Import-local disambiguation (fresh-local `$N` minting) —
+//!   `import_emit.rs`: `disambiguate_import_locals`,
+//!   `disambiguate_residual_entry_import_locals`, `mint_unique_name`;
+//!   entry-side call site in `lower.rs` (entry-import build seeding
+//!   `body_renames`), module-side call sites in
+//!   `imports_cross.rs::cross_module_imports_for_plan` and
+//!   `imports_cross.rs::residual_entry_imports_for_moved_body` (scope:
+//!   `Chunk` / `Module`, origin: `ImportInduced`). Minting becomes a
+//!   ledger service in PR 3; decided 2026-06: the `$N` suffix scheme
+//!   stays as-is (readability is a later naturalizer concern).
+//! - Cross-module rename application to moved bodies — the
+//!   `module_import_renames` map accumulated across the two
+//!   `imports_cross.rs` helpers above and applied in
+//!   `lower.rs::lower_single_plan` (origin: `ImportInduced`).
+//! - Collision-resolving public-name minting —
+//!   `exports.rs::auto_grown_residual_exports` (suffix-mints a grown
+//!   public export past pre-existing public names; origin:
+//!   `ImportInduced`).
+//!
+//! Vendor boundary renames (`vendor/`) run in a separate pipeline stage on
+//! different artifacts and are out of this ledger's scope.
+
+use std::collections::{BTreeMap, HashMap};
+use std::fmt;
+
+use analysis::ModuleId;
+use anyhow::{Result, bail};
+use swc_atoms::Atom;
+use swc_common::Span;
+use swc_ecma_ast::Id;
+
+/// Identity of one function-like deriving scope (function / arrow /
+/// constructor): the node's source span in the chunk AST. The per-scope
+/// heuristic machinery (#2057's `ScopedHeuristicNaturalizer`) identifies a
+/// deriving scope as the function-like node it is visiting; the span is
+/// that node's persistent key — a chunk AST parses from a single
+/// `SourceFile`, so two distinct function-like nodes never share a span.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct FunctionScopeId {
+    pub lo: u32,
+    pub hi: u32,
+}
+
+impl From<Span> for FunctionScopeId {
+    fn from(span: Span) -> Self {
+        Self {
+            lo: span.lo.0,
+            hi: span.hi.0,
+        }
+    }
+}
+
+/// Where a rename applies. Intents in one scope are invisible to queries
+/// for any other scope — the ledger rejects cross-scope leakage by
+/// construction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum RenameScope {
+    /// Bindings staying in the chunk's residual entry body.
+    Chunk,
+    /// Module-wide renames within one emitted logical module. The identity
+    /// is the same [`ModuleId`] (index into the finalized `module_plans`
+    /// list) that `binding_assignment` and the factorization partition use
+    /// to identify a binding's deriving module.
+    Module(ModuleId),
+    /// Scope-local renames derived by one function-like node.
+    Function(FunctionScopeId),
+}
+
+impl fmt::Display for RenameScope {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RenameScope::Chunk => write!(f, "chunk scope"),
+            RenameScope::Module(ModuleId(index)) => write!(f, "module #{}", index.0),
+            RenameScope::Function(span) => write!(f, "function@{}..{}", span.lo, span.hi),
+        }
+    }
+}
+
+/// Which kind of contributor proposed a rename. Carries the contributor
+/// name so seal-time conflicts can name both sides.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum RenameOrigin {
+    /// Spec-author decision (chunk_renames member, plan `export_name`).
+    Explicit { contributor: &'static str },
+    /// Mechanical rename required to emit valid imports (fresh-local
+    /// minting, cross-module import aliases).
+    ImportInduced { contributor: &'static str },
+    /// Cosmetic readability rename inferred from the AST.
+    Heuristic { contributor: &'static str },
+}
+
+impl RenameOrigin {
+    pub fn priority(&self) -> RenamePriority {
+        match self {
+            RenameOrigin::Explicit { .. } => RenamePriority::Explicit,
+            RenameOrigin::ImportInduced { .. } => RenamePriority::ImportInduced,
+            RenameOrigin::Heuristic { .. } => RenamePriority::Heuristic,
+        }
+    }
+
+    pub fn contributor(&self) -> &'static str {
+        match self {
+            RenameOrigin::Explicit { contributor }
+            | RenameOrigin::ImportInduced { contributor }
+            | RenameOrigin::Heuristic { contributor } => contributor,
+        }
+    }
+}
+
+impl fmt::Display for RenameOrigin {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RenameOrigin::Explicit { contributor } => write!(f, "explicit({contributor})"),
+            RenameOrigin::ImportInduced { contributor } => {
+                write!(f, "import-induced({contributor})")
+            }
+            RenameOrigin::Heuristic { contributor } => write!(f, "heuristic({contributor})"),
+        }
+    }
+}
+
+/// Conflict-resolution rank derived from [`RenameOrigin`]: explicit >
+/// import-induced > heuristic (variant order ascending).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum RenamePriority {
+    Heuristic,
+    ImportInduced,
+    Explicit,
+}
+
+/// One contributor's proposal to rename `from` to `to` within `scope`.
+#[derive(Debug, Clone)]
+pub struct RenameIntent {
+    pub scope: RenameScope,
+    /// Hygiene-aware source binding. Contributors that only have a bare
+    /// spec string resolve it at the collection point via
+    /// `top_level_id(name, chunk_top_level_mark)`.
+    pub from: Id,
+    pub to: Atom,
+    pub origin: RenameOrigin,
+}
+
+/// Accumulates [`RenameIntent`]s during the collect phase; consumed by
+/// [`Self::seal`].
+#[derive(Debug, Default)]
+pub struct RenameLedger {
+    intents: Vec<RenameIntent>,
+}
+
+impl RenameLedger {
+    pub fn submit(&mut self, intent: RenameIntent) {
+        self.intents.push(intent);
+    }
+
+    /// Validate and freeze the collected intents. Per `(scope, from)`
+    /// group, the highest-priority intents must agree on one target —
+    /// disagreement at equal priority is a hard error naming every
+    /// contributor on each side. Lower-priority disagreement loses
+    /// silently. Identical duplicates collapse. Every conflict in the
+    /// ledger is reported in one error, not just the first.
+    pub fn seal(self) -> Result<SealedRenames> {
+        let mut groups: BTreeMap<(RenameScope, Id), Vec<RenameIntent>> = BTreeMap::new();
+        for intent in self.intents {
+            groups
+                .entry((intent.scope, intent.from.clone()))
+                .or_default()
+                .push(intent);
+        }
+        let mut by_scope: BTreeMap<RenameScope, BTreeMap<Id, Atom>> = BTreeMap::new();
+        let mut conflicts = Vec::new();
+        for ((scope, from), intents) in groups {
+            let top_priority = intents
+                .iter()
+                .map(|intent| intent.origin.priority())
+                .max()
+                .expect("groups hold at least one intent");
+            // Distinct targets proposed at the top priority, each with the
+            // (sorted, deduped) contributors proposing it.
+            let mut by_target: BTreeMap<&Atom, Vec<RenameOrigin>> = BTreeMap::new();
+            for intent in &intents {
+                if intent.origin.priority() == top_priority {
+                    let origins = by_target.entry(&intent.to).or_default();
+                    if !origins.contains(&intent.origin) {
+                        origins.push(intent.origin);
+                    }
+                }
+            }
+            if by_target.len() > 1 {
+                let sides = by_target
+                    .iter()
+                    .map(|(to, origins)| {
+                        let origins = origins
+                            .iter()
+                            .map(|origin| origin.to_string())
+                            .collect::<Vec<_>>()
+                            .join(", ");
+                        format!("`{to}` (per {origins})")
+                    })
+                    .collect::<Vec<_>>()
+                    .join(" vs ");
+                conflicts.push(format!(
+                    "{scope}: binding `{}` renamed to {sides} at equal priority; \
+                     same-priority contributors must agree",
+                    from.0,
+                ));
+                continue;
+            }
+            let to = by_target
+                .keys()
+                .next()
+                .expect("non-conflicting groups have exactly one target");
+            by_scope
+                .entry(scope)
+                .or_default()
+                .insert(from, (*to).clone());
+        }
+        if !conflicts.is_empty() {
+            bail!(
+                "conflicting rename intents:\n  - {}",
+                conflicts.join("\n  - "),
+            );
+        }
+        Ok(SealedRenames { by_scope })
+    }
+}
+
+/// The validated, read-only output of [`RenameLedger::seal`]: per scope,
+/// the final `from → to` mapping. Queries reproduce exactly the maps the
+/// pre-ledger code built so the existing application sites consume them
+/// unchanged.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct SealedRenames {
+    by_scope: BTreeMap<RenameScope, BTreeMap<Id, Atom>>,
+}
+
+impl SealedRenames {
+    /// Chunk-scope renames projected to bare names — the map
+    /// `LowerChunkSpecFacts::chunk_renames` consumes (pre-ledger:
+    /// `collect_chunk_renames`'s output).
+    pub fn chunk_renames_by_name(&self) -> HashMap<String, String> {
+        self.scope_renames_by_name(&RenameScope::Chunk)
+            .into_iter()
+            .collect()
+    }
+
+    /// One module's plan-driven renames projected to bare names, sorted —
+    /// the `plan_driven` map `naturalize_module_body` consumes
+    /// (pre-ledger: derived inline from `plan.bindings`).
+    pub fn module_renames_by_name(&self, module: ModuleId) -> BTreeMap<String, String> {
+        self.scope_renames_by_name(&RenameScope::Module(module))
+    }
+
+    /// Typed per-scope view (tests, the future execute-once pass).
+    pub fn scope_renames(&self, scope: &RenameScope) -> Option<&BTreeMap<Id, Atom>> {
+        self.by_scope.get(scope)
+    }
+
+    /// Project one scope's sealed renames onto bare syms for the
+    /// string-keyed application visitors. Lossy iff two hygiene contexts
+    /// share a sym within one scope — the current contributors resolve
+    /// every `from` through one chunk-top-level context, so that cannot
+    /// happen; assert rather than silently merge if it ever does.
+    fn scope_renames_by_name(&self, scope: &RenameScope) -> BTreeMap<String, String> {
+        let Some(renames) = self.by_scope.get(scope) else {
+            return BTreeMap::new();
+        };
+        let mut by_name = BTreeMap::new();
+        for (from, to) in renames {
+            let previous = by_name.insert(from.0.to_string(), to.to_string());
+            assert!(
+                previous.is_none(),
+                "two hygiene contexts share sym `{}` in {scope}; \
+                 the string-keyed application boundary cannot express this",
+                from.0,
+            );
+        }
+        by_name
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use swc_common::SyntaxContext;
+
+    fn id(sym: &str) -> Id {
+        (Atom::from(sym), SyntaxContext::empty())
+    }
+
+    fn intent(scope: RenameScope, from: &str, to: &str, origin: RenameOrigin) -> RenameIntent {
+        RenameIntent {
+            scope,
+            from: id(from),
+            to: Atom::from(to),
+            origin,
+        }
+    }
+
+    const A: RenameOrigin = RenameOrigin::Explicit {
+        contributor: "contributor_a",
+    };
+    const B: RenameOrigin = RenameOrigin::Explicit {
+        contributor: "contributor_b",
+    };
+
+    #[test]
+    fn same_priority_conflict_errors_naming_both_contributors() {
+        let mut ledger = RenameLedger::default();
+        ledger.submit(intent(RenameScope::Chunk, "a", "first", A));
+        ledger.submit(intent(RenameScope::Chunk, "a", "second", B));
+        let message = ledger.seal().unwrap_err().to_string();
+        assert!(message.contains("contributor_a"), "{message}");
+        assert!(message.contains("contributor_b"), "{message}");
+        assert!(message.contains("`first`"), "{message}");
+        assert!(message.contains("`second`"), "{message}");
+    }
+
+    #[test]
+    fn reports_every_conflict_in_one_error() {
+        let mut ledger = RenameLedger::default();
+        ledger.submit(intent(RenameScope::Chunk, "a", "first", A));
+        ledger.submit(intent(RenameScope::Chunk, "a", "second", B));
+        ledger.submit(intent(RenameScope::Chunk, "b", "third", A));
+        ledger.submit(intent(RenameScope::Chunk, "b", "fourth", B));
+        let message = ledger.seal().unwrap_err().to_string();
+        assert!(message.contains("binding `a`"), "{message}");
+        assert!(message.contains("binding `b`"), "{message}");
+    }
+
+    #[test]
+    fn identical_duplicate_intents_collapse() {
+        let mut ledger = RenameLedger::default();
+        ledger.submit(intent(RenameScope::Chunk, "a", "readable", A));
+        ledger.submit(intent(RenameScope::Chunk, "a", "readable", B));
+        let sealed = ledger.seal().unwrap();
+        assert_eq!(
+            sealed.chunk_renames_by_name(),
+            HashMap::from([("a".to_string(), "readable".to_string())]),
+        );
+    }
+
+    #[test]
+    fn higher_priority_wins_over_disagreeing_lower_priority() {
+        let mut ledger = RenameLedger::default();
+        ledger.submit(intent(
+            RenameScope::Chunk,
+            "a",
+            "heuristic_name",
+            RenameOrigin::Heuristic {
+                contributor: "alias_inference",
+            },
+        ));
+        ledger.submit(intent(RenameScope::Chunk, "a", "explicit_name", A));
+        let sealed = ledger.seal().unwrap();
+        assert_eq!(
+            sealed.chunk_renames_by_name(),
+            HashMap::from([("a".to_string(), "explicit_name".to_string())]),
+        );
+    }
+
+    #[test]
+    fn cross_scope_intents_do_not_leak_or_conflict() {
+        let function_scope = RenameScope::Function(FunctionScopeId { lo: 10, hi: 20 });
+        let module_scope = RenameScope::Module(ModuleId::logical(0));
+        let mut ledger = RenameLedger::default();
+        // Same `from`, different targets — fine across scopes.
+        ledger.submit(intent(
+            function_scope,
+            "e",
+            "value",
+            RenameOrigin::Heuristic {
+                contributor: "destructure_unpack",
+            },
+        ));
+        ledger.submit(intent(module_scope, "e", "registry", A));
+        let sealed = ledger.seal().unwrap();
+        assert_eq!(
+            sealed.module_renames_by_name(ModuleId::logical(0)),
+            BTreeMap::from([("e".to_string(), "registry".to_string())]),
+        );
+        assert!(sealed.chunk_renames_by_name().is_empty());
+        assert_eq!(
+            sealed.scope_renames(&function_scope),
+            Some(&BTreeMap::from([(id("e"), Atom::from("value"))])),
+        );
+        assert_eq!(sealed.scope_renames(&RenameScope::Chunk), None);
+    }
+
+    #[test]
+    fn module_queries_are_isolated_per_module() {
+        let mut ledger = RenameLedger::default();
+        ledger.submit(intent(
+            RenameScope::Module(ModuleId::logical(0)),
+            "a",
+            "x",
+            A,
+        ));
+        ledger.submit(intent(
+            RenameScope::Module(ModuleId::logical(1)),
+            "b",
+            "y",
+            A,
+        ));
+        let sealed = ledger.seal().unwrap();
+        assert_eq!(
+            sealed.module_renames_by_name(ModuleId::logical(0)),
+            BTreeMap::from([("a".to_string(), "x".to_string())]),
+        );
+        assert_eq!(
+            sealed.module_renames_by_name(ModuleId::logical(1)),
+            BTreeMap::from([("b".to_string(), "y".to_string())]),
+        );
+        assert!(
+            sealed
+                .module_renames_by_name(ModuleId::logical(2))
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn submission_order_does_not_change_seal_output() {
+        let intents = [
+            intent(RenameScope::Chunk, "z", "zulu", A),
+            intent(RenameScope::Chunk, "a", "alpha", B),
+            intent(RenameScope::Module(ModuleId::logical(3)), "m", "mike", A),
+            intent(
+                RenameScope::Function(FunctionScopeId { lo: 1, hi: 2 }),
+                "f",
+                "foxtrot",
+                RenameOrigin::Heuristic {
+                    contributor: "alias_inference",
+                },
+            ),
+        ];
+        let mut forward = RenameLedger::default();
+        for i in &intents {
+            forward.submit(i.clone());
+        }
+        let mut reverse = RenameLedger::default();
+        for i in intents.iter().rev() {
+            reverse.submit(i.clone());
+        }
+        assert_eq!(forward.seal().unwrap(), reverse.seal().unwrap());
+    }
+
+    #[test]
+    fn hygiene_distinct_ids_are_distinct_keys() {
+        // Two bindings spelled the same but carrying different
+        // SyntaxContexts are different ledger keys — no conflict.
+        let other_ctxt = (Atom::from("a"), SyntaxContext::from_u32(7));
+        let mut ledger = RenameLedger::default();
+        ledger.submit(intent(RenameScope::Chunk, "a", "first", A));
+        ledger.submit(RenameIntent {
+            scope: RenameScope::Module(ModuleId::logical(0)),
+            from: other_ctxt.clone(),
+            to: Atom::from("second"),
+            origin: B,
+        });
+        let sealed = ledger.seal().unwrap();
+        assert_eq!(
+            sealed.scope_renames(&RenameScope::Module(ModuleId::logical(0))),
+            Some(&BTreeMap::from([(other_ctxt, Atom::from("second"))])),
+        );
+    }
+}

--- a/devinfra/js/debundle/plans/sanitization_program_2026_06.md
+++ b/devinfra/js/debundle/plans/sanitization_program_2026_06.md
@@ -57,7 +57,11 @@ rename-pinning e2e tests:
 1. Types + inventory: `RenameLedger` of `RenameIntent { scope, from, to,
 origin, priority }`, scopes Chunk/Module/Function, **keyed by hygiene
    `Id`** (post-#2042 contexts are why string keys breed bugs). Adopt the
-   "no structural moves between seal and execute" contract.
+   "no structural moves between seal and execute" contract. _(Landed
+   2026-06: `lowering/rename_ledger.rs`, including the seal-time
+   same-priority conflict check and the two explicit contributors —
+   spec `chunk_renames` + plan `export_name`s; see TODO.md's rename
+   pipeline section for decisions and the remaining ladder.)_
 2. Collect: convert contributors (spec `export_name`s, bound/free
    heuristics, import-local `_N` minting, `chunk_renames`, cross-module,
    collision resolution) one at a time to emit intents.


### PR DESCRIPTION
Track B PR 1 of `plans/sanitization_program_2026_06.md` (rename pipeline: collect → validate → execute _once_). Introduces the ledger types and converts the first two contributors to collect-into-ledger, with **zero behavior change** — the existing visitors keep applying, and the full e2e suite (99 targets, including the ~90 rename-pinning tests) passes unchanged.

## Type design (`lowering/rename_ledger.rs`)

- `RenameIntent { scope: RenameScope, from: Id, to: Atom, origin: RenameOrigin }` — keyed by **hygiene-aware `Id`** (post-#2042 `SyntaxContext`s are why string keys breed bugs). Contributors that only have a spec string resolve it at the collection point via `top_level_id(name, chunk_top_level_mark)`.
- `RenameOrigin = Explicit | ImportInduced | Heuristic`, each carrying the contributor name for diagnostics; `RenamePriority` is derived from origin (explicit > import-induced > heuristic), not stored.
- `RenameLedger::seal(self) -> Result<SealedRenames>` validates that no two **same-priority** intents disagree on one `(scope, from)` binding's target — a hard error naming **both** contributors (all conflicts reported in one error, matching the existing multi-violation chunk_renames reporting style). Higher priority silently wins over disagreeing lower priority; identical duplicates collapse.
- `SealedRenames` queries reproduce exactly the maps the pre-ledger code built (`chunk_renames_by_name()` → the `HashMap` `LowerChunkSpecFacts::chunk_renames` consumes; `module_renames_by_name(ModuleId)` → the `plan_driven` `BTreeMap` `naturalize_module_body` consumes). The string projection asserts no two hygiene contexts share a sym within a scope; PR 4's executor consumes `Id`s directly and deletes the projection.
- Target-occupancy/capture validation deliberately **stays at the application sites** (that move is PR 3).

## Scope-identity choice

`RenameScope = Chunk | Module(ModuleId) | Function(FunctionScopeId)`:

- **Module** reuses `ModuleId(LogicalModuleIndex)` — the same identity `binding_assignment` and the factorization partition use for a binding's deriving module (#2057-era per-scope machinery), indexing the finalized `module_plans` list.
- **Function** is the deriving node's source span (`FunctionScopeId { lo, hi }`). #2057's `ScopedHeuristicNaturalizer` identifies deriving scopes as the function-like node it visits; the span is that node's persistent key (chunk ASTs parse from a single `SourceFile`, so spans are unique per node).

Also adopts the maintainer-decided contract: **no structural moves between seal and execute** — the materializer seals after `ChunkPlan` finalization; the type-level `&Module` barrier lands with the execute-once pass (PR 4).

## Contributors converted (both Explicit)

1. **Spec `chunk_renames`** — `chunk_renames.rs::collect_chunk_renames` now submits Chunk-scope intents; the old in-collector duplicate-conflict bail becomes the seal conflict error (semantics preserved: same-binding-same-target dedups, same-binding-different-target hard-errors; the multi-violation validation in `lower.rs` pinned by `surfaces_every_chunk_rename_violation_at_once` is untouched).
2. **Plan-driven spec `export_name`s** — `naturalize.rs::collect_plan_export_rename_intents` submits Module-scope intents (same filter as the old inline derivation: self-renames and non-identifier targets never become intents); `naturalize_module_body` now consumes the sealed map instead of deriving its own.

The module doc carries the full **remaining-contributor inventory** (PR 2 worklist) with `file::fn` references: heuristic bound-source scope-local renames, heuristic free-source aliases, import-local `$N` disambiguation minting (entry- and module-side call sites), cross-module rename application to moved bodies, and collision-resolving public-name minting.

## Tests

- New `:lowering_test` unit tests for the ledger: same-priority conflict names both contributors, all conflicts in one error, duplicate collapse, priority dominance, cross-scope isolation (Function intents invisible to Module/Chunk queries; per-module isolation), submission-order determinism, hygiene-distinct `Id`s as distinct keys.
- Full `bbr test //devinfra/js/debundle/...`: 99/99 green — `buildbuddy:2b5da3c4-a342-4efd-baab-e9074f8b9793`.

## Remaining PR ladder (recorded in TODO.md)

- **PR 2 — collect**: convert remaining contributors to submit intents.
- **PR 3 — seal**: move target-occupancy/capture validation into seal against scope-accurate occupied sets; `$N` minting becomes a ledger service (decided: scheme stays as-is).
- **PR 4 — execute once**: single visitor pass updating AST + fact tables in lockstep, keyed by `Id`.
- **PR 5 — cleanup**: delete the defensive era (`captured` sets, dominated `drop_subtree_captured_targets`, `merged`/`module_scope` split, reverse lookups).

https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk)_