### PR TITLE
debundle: gate ladder PR 1 — predicate pinning + reference

### DIFF
--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -514,6 +514,24 @@ rust_test(
     ],
 )
 
+# Differential harness skeleton for the gate-ladder unification
+# (plans/incremental_gate_unification.md §7.1, PR 1 of §8): compares
+# the kernel's hot boolean merge gate against the touching-filtered
+# `check_realizability` reference, with the known-divergence catalog
+# encoded as expected failures.
+rust_test(
+    name = "peel_gate_differential_test",
+    srcs = ["peel/gate_differential_test.rs"],
+    crate_root = "peel/gate_differential_test.rs",
+    edition = "2024",
+    deps = [
+        ":analysis",
+        ":gate",
+        ":peel",
+        ":report_fixtures",
+    ],
+)
+
 rust_library(
     name = "spec_tree",
     srcs = ["spec_tree.rs"],

--- a/devinfra/js/debundle/gate.rs
+++ b/devinfra/js/debundle/gate.rs
@@ -23,7 +23,7 @@ pub use esm_import_order::EsmImportOrder;
 pub use realizability::{
     CrossRebindEdge, DeltaHandle, PartitionDelta, RealizabilityIndex, RealizabilityVerdict,
     SccDiagnosis, SccRejection, SccTimingReporter, check_realizability,
-    record_gate_diagnostic_translation,
+    check_realizability_touching, record_gate_diagnostic_translation,
 };
 pub use validation::{
     BlockingSccEntry, CycleEdge, CycleReport, FactorizationReport,

--- a/devinfra/js/debundle/peel/gate_differential_test.rs
+++ b/devinfra/js/debundle/peel/gate_differential_test.rs
@@ -1,0 +1,653 @@
+//! Differential harness skeleton for the gate-ladder unification
+//! (`plans/incremental_gate_unification.md` §7.1; PR 1 of §8).
+//!
+//! Compares the kernel's hot boolean merge gate
+//! (`QuotientGraph::merge_preserves_invariants`) against the plan-§2
+//! **reference predicate**: `gate(c1, c2)` should accept iff
+//! `check_realizability_touching(owner_graph, post_partition, M)` is
+//! realizable, where `M` is the post-merge module and
+//! `post_partition` is built by an independent reference projection
+//! (NOT the kernel's own `project_partition`).
+//!
+//! The current gate is a constraining-only class-level walk and is
+//! KNOWN to diverge from the reference; every divergence the harness
+//! observes must fall into the catalog below ([`DivergenceClass`]),
+//! and the deterministic fixtures assert that each cataloged
+//! divergence actually occurs today — the "known-divergence catalog
+//! encoded as expected failures". When PR 4 routes
+//! `check_merge_boolean` through the realizability ladder, those
+//! fixture assertions flip to agreement and this harness becomes a
+//! strict-equality check (and the catalog is deleted).
+//!
+//! Skeleton caveats (completed by Track F1 in later PRs):
+//! - generation uses a deterministic xorshift sweep over small
+//!   synthetic reports rather than proptest (no proptest dep in the
+//!   crate universe yet);
+//! - per-tier skip-soundness assertions arrive with the ladder
+//!   itself (PR 3).
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use analysis::ids::{LogicalModuleIndex, ModuleId};
+use analysis::partition::Partition;
+use analysis::{DepKind, OwnerGraphNodeReport, OwnerGraphReport};
+use gate::{RealizabilityVerdict, SccRejection, check_realizability_touching};
+use peel::quotient::{
+    ClassId, OwnerIdx, PartitionGroup, QuotientGraph, SpecModuleGroup, build_seed_quotient,
+    greedy_step,
+};
+use report_fixtures::{active_owner, atomic_unit_for, graph_of, owner_edge, residual_owner};
+
+const CAP_LINES: usize = 10_000;
+
+fn module_id(index: usize) -> ModuleId {
+    ModuleId(LogicalModuleIndex(index))
+}
+
+// ---------------------------------------------------------------------
+// Independent reference projection.
+//
+// Rebuilds the module-level partition from the kernel's *public*
+// class-membership surface plus the report's own residual flags —
+// per the Track F note, deliberately not the kernel's
+// `project_partition`. Projection rules (docs/design.md / plan §2):
+//   * a class maps to the residual module `logical(0)` iff it is the
+//     marked residual catch-all, or it is not anchored to a
+//     pre-existing module and every member owner is residual-destined
+//     per the report;
+//   * every other class gets a distinct module id, assigned in
+//     ascending `ClassId` order starting at 1.
+// ---------------------------------------------------------------------
+
+/// Owner ids the report marks residual-destined (the gate-residual
+/// pile), derived from the report's module table only.
+fn residual_owner_ids(report: &OwnerGraphReport) -> BTreeSet<String> {
+    report
+        .nodes
+        .iter()
+        .filter(|node| report.is_residual(&node.destination))
+        .map(|node| node.id.clone())
+        .collect()
+}
+
+fn class_maps_to_residual(
+    q: &QuotientGraph,
+    residual_ids: &BTreeSet<String>,
+    class: ClassId,
+) -> bool {
+    q.class_is_residual(class)
+        || (!q.class_is_pre_existing_module(class)
+            && q.class_members(class)
+                .all(|owner| residual_ids.contains(q.owner_id(owner))))
+}
+
+/// Pre-state class → module map plus the next free module index.
+fn reference_class_modules(
+    q: &QuotientGraph,
+    residual_ids: &BTreeSet<String>,
+) -> (BTreeMap<ClassId, ModuleId>, usize) {
+    let mut map = BTreeMap::new();
+    let mut next = 1usize;
+    for class in q.iter_classes() {
+        let module = if class_maps_to_residual(q, residual_ids, class) {
+            module_id(0)
+        } else {
+            let module = module_id(next);
+            next += 1;
+            module
+        };
+        map.insert(class, module);
+    }
+    (map, next)
+}
+
+/// The module the merged `(c1, c2)` class maps to under the reference
+/// projection, in the pre-state's module-id space (stable ids let the
+/// pre- and post-state verdicts talk about the same `M`).
+fn reference_post_module(
+    q: &QuotientGraph,
+    residual_ids: &BTreeSet<String>,
+    pre_modules: &BTreeMap<ClassId, ModuleId>,
+    next_fresh: usize,
+    c1: ClassId,
+    c2: ClassId,
+) -> ModuleId {
+    let (winner, loser) = (c1.min(c2), c1.max(c2));
+    if q.class_is_residual(winner) || q.class_is_residual(loser) {
+        return module_id(0);
+    }
+    let pre_existing =
+        q.class_is_pre_existing_module(winner) || q.class_is_pre_existing_module(loser);
+    if !pre_existing
+        && q.class_members(winner)
+            .chain(q.class_members(loser))
+            .all(|owner| residual_ids.contains(q.owner_id(owner)))
+    {
+        return module_id(0);
+    }
+    // Mixed or pre-existing: reuse the winner's non-residual slot,
+    // else the loser's, else mint a fresh id (the gate-residual
+    // promotion transition).
+    [pre_modules[&winner], pre_modules[&loser]]
+        .into_iter()
+        .find(|module| *module != module_id(0))
+        .unwrap_or(module_id(next_fresh))
+}
+
+/// Owner-indexed partition from a class → module map, with the
+/// optional speculative `(winner ∪ loser) → M` overlay applied.
+fn reference_partition(
+    q: &QuotientGraph,
+    class_modules: &BTreeMap<ClassId, ModuleId>,
+    overlay: Option<(ClassId, ClassId, ModuleId)>,
+) -> Partition {
+    let residual = module_id(0);
+    let mut of = vec![residual; q.owner_graph_for_tests().num_nodes()];
+    for class in q.iter_classes() {
+        let module = match overlay {
+            Some((c1, c2, post)) if class == c1 || class == c2 => post,
+            _ => class_modules[&class],
+        };
+        for owner in q.class_members(class) {
+            of[owner.0] = module;
+        }
+    }
+    Partition::from_assignments(of, residual)
+}
+
+// ---------------------------------------------------------------------
+// Query comparison + the known-divergence catalog.
+// ---------------------------------------------------------------------
+
+/// Catalog of divergences the current (pre-ladder) gate is known to
+/// produce against the reference predicate. Anything outside this
+/// enum fails the harness. PR 4 empties the catalog.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum DivergenceClass {
+    /// Gate rejects, reference accepts: the class-level walk sees a
+    /// cycle among classes that project into one module (plan §2's
+    /// atomic-unit anomaly and pass-3 class-cycle rejections).
+    ClassLevelOverRejection,
+    /// Gate accepts, reference rejects with `EsmEvaluationTdz`: the
+    /// hot gate is blind to Pass 2 (plan §1 item 1).
+    Pass2Blindness,
+    /// Gate accepts, reference rejects with a
+    /// `MutualConstrainingCycle`: the class graph is finer than the
+    /// module projection, so a cycle through two *distinct* residual
+    /// classes is invisible at class granularity (plan §1 item 2).
+    ModuleGranularityPass1,
+    /// Gate accepts, reference rejects with a clause-2 cross-rebind:
+    /// the hot gate never checks rebinds, and a gate-residual
+    /// promotion can turn an intra-residual rebind into a
+    /// cross-module one (a caveat to plan §3's "merges only ever
+    /// convert cross-rebinds to intra-module" formality claim).
+    CrossRebindBlindness,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum QueryOutcome {
+    Agree,
+    /// The PRE-state verdict touching `M` is already unrealizable.
+    /// The plan-§2 equality claim ("touching-filtered and
+    /// full-verdict accept/reject coincide") is scoped to realizable
+    /// pre-states, so these queries are outside the harness's
+    /// equality domain and are tallied, not compared.
+    DirtyPreState,
+    Diverged(DivergenceClass),
+}
+
+/// Public replica of the kernel's non-cycle merge preconditions
+/// (same class / emptiness / residual stickiness / line cap). The
+/// reference predicate covers only the cycle clause, so the harness
+/// compares only when these pass.
+fn preconditions_pass(q: &QuotientGraph, c1: ClassId, c2: ClassId) -> bool {
+    c1 != c2
+        && q.class_members(c1).next().is_some()
+        && q.class_members(c2).next().is_some()
+        && q.class_is_residual(c1) == q.class_is_residual(c2)
+        && q.class_lines(c1).saturating_add(q.class_lines(c2)) <= CAP_LINES
+}
+
+fn classify_divergence(gate_accepts: bool, reference: &RealizabilityVerdict) -> DivergenceClass {
+    if !gate_accepts {
+        return DivergenceClass::ClassLevelOverRejection;
+    }
+    if reference
+        .unrealizable_sccs
+        .iter()
+        .any(|scc| scc.rejection == SccRejection::MutualConstrainingCycle)
+    {
+        return DivergenceClass::ModuleGranularityPass1;
+    }
+    if reference
+        .unrealizable_sccs
+        .iter()
+        .any(|scc| scc.rejection == SccRejection::EsmEvaluationTdz)
+    {
+        return DivergenceClass::Pass2Blindness;
+    }
+    assert!(
+        !reference.cross_rebinds.is_empty(),
+        "a rejecting reference verdict with no SCCs must carry cross-rebinds: {reference:#?}",
+    );
+    DivergenceClass::CrossRebindBlindness
+}
+
+/// Run one gate-vs-reference comparison. Returns `None` when the
+/// non-cycle preconditions fail (the gate's `false` would not be a
+/// predicate decision).
+fn compare_gate_to_reference(
+    report: &OwnerGraphReport,
+    q: &mut QuotientGraph,
+    c1: ClassId,
+    c2: ClassId,
+) -> Option<QueryOutcome> {
+    if !preconditions_pass(q, c1, c2) {
+        return None;
+    }
+    let residual_ids = residual_owner_ids(report);
+    let (pre_modules, next_fresh) = reference_class_modules(q, &residual_ids);
+    let post_module = reference_post_module(q, &residual_ids, &pre_modules, next_fresh, c1, c2);
+    let pre_partition = reference_partition(q, &pre_modules, None);
+    let post_partition = reference_partition(q, &pre_modules, Some((c1, c2, post_module)));
+    let owner_graph = q.owner_graph_for_tests();
+    let reference = check_realizability_touching(owner_graph, &post_partition, post_module);
+    let pre_dirty =
+        !check_realizability_touching(owner_graph, &pre_partition, post_module).is_realizable();
+    let gate_accepts = q.merge_preserves_invariants(c1, c2);
+    Some(if gate_accepts == reference.is_realizable() {
+        QueryOutcome::Agree
+    } else if pre_dirty {
+        QueryOutcome::DirtyPreState
+    } else {
+        QueryOutcome::Diverged(classify_divergence(gate_accepts, &reference))
+    })
+}
+
+// ---------------------------------------------------------------------
+// Deterministic divergence fixtures — the catalog's expected failures.
+// Each asserts the divergence the current gate produces TODAY; when
+// PR 4 lands the ladder, these flip to `Agree` and the catalog dies.
+// ---------------------------------------------------------------------
+
+fn make_module_group(module_id: &str, owner_idxs: Vec<usize>) -> PartitionGroup {
+    PartitionGroup {
+        owner_idxs: owner_idxs.into_iter().map(OwnerIdx).collect(),
+        is_pre_existing_module: true,
+        label: Some(module_id.to_string()),
+    }
+}
+
+/// Sanity anchor: on a clean acyclic shape the gate and the reference
+/// agree on every precondition-passing pair (both directions —
+/// accepts and rejects).
+#[test]
+fn gate_matches_reference_on_clean_chain() {
+    let a = active_owner("owner:a", 1, &["BindingA"], 10, "ui/a");
+    let h = active_owner("owner:h", 2, &["BindingH"], 10, "ui/h");
+    let b = active_owner("owner:b", 3, &["BindingB"], 10, "ui/b");
+    let report = graph_of(
+        vec![a.clone(), h.clone(), b.clone()],
+        vec![
+            owner_edge("edge:0", "owner:a", "owner:h", DepKind::EagerUse, true),
+            owner_edge("edge:1", "owner:h", "owner:b", DepKind::EagerUse, true),
+        ],
+        vec![
+            atomic_unit_for("atomic:0", &[&a]),
+            atomic_unit_for("atomic:1", &[&h]),
+            atomic_unit_for("atomic:2", &[&b]),
+        ],
+        vec![],
+    );
+    let groups = vec![
+        make_module_group("ui/a", vec![0]),
+        make_module_group("ui/h", vec![1]),
+        make_module_group("ui/b", vec![2]),
+    ];
+    let (mut q, _) =
+        QuotientGraph::from_report_with_partition_extended(&report, CAP_LINES, &groups);
+    let live: Vec<ClassId> = q.iter_classes().collect();
+    for i in 0..live.len() {
+        for j in (i + 1)..live.len() {
+            let outcome = compare_gate_to_reference(&report, &mut q, live[i], live[j])
+                .expect("chain classes pass preconditions");
+            assert_eq!(
+                outcome,
+                QueryOutcome::Agree,
+                "({:?}, {:?}) must agree on the clean chain",
+                live[i],
+                live[j],
+            );
+        }
+    }
+}
+
+/// Expected failure (plan §2, atomic-unit anomaly): merging two
+/// members of a residual-pile constraining 3-cycle is a delta-free
+/// no-op for the reference, but the class-level gate rejects it.
+#[test]
+fn gate_over_rejects_residual_pile_cycle_merge() {
+    let a = residual_owner("owner:a", 1, &["BindingA"], 5);
+    let b = residual_owner("owner:b", 2, &["BindingB"], 5);
+    let c = residual_owner("owner:c", 3, &["BindingC"], 5);
+    let report = graph_of(
+        vec![a.clone(), b.clone(), c.clone()],
+        vec![
+            owner_edge("edge:0", "owner:a", "owner:b", DepKind::EagerUse, true),
+            owner_edge("edge:1", "owner:b", "owner:c", DepKind::EagerUse, true),
+            owner_edge("edge:2", "owner:c", "owner:a", DepKind::EagerUse, true),
+        ],
+        vec![
+            atomic_unit_for("atomic:0", &[&a]),
+            atomic_unit_for("atomic:1", &[&b]),
+            atomic_unit_for("atomic:2", &[&c]),
+        ],
+        vec![],
+    );
+    let mut q = QuotientGraph::from_report(&report, CAP_LINES);
+    let ca = q.class_of(q.owner_idx_of("owner:a").unwrap());
+    let cb = q.class_of(q.owner_idx_of("owner:b").unwrap());
+    let outcome = compare_gate_to_reference(&report, &mut q, ca, cb).unwrap();
+    assert_eq!(
+        outcome,
+        QueryOutcome::Diverged(DivergenceClass::ClassLevelOverRejection),
+        "current gate is expected to over-reject this residual-pile \
+         merge; if this now AGREES, the ladder landed — un-ignore the \
+         §7.3 pinning tests and flip this harness to strict equality",
+    );
+}
+
+/// Expected failure (plan §1 item 1): a merge that closes an
+/// asymmetric I-SCC whose constraining pair TDZs is accepted by the
+/// hot gate but rejected by the reference with `EsmEvaluationTdz`.
+#[test]
+fn gate_accepts_pass2_tdz_merge_reference_rejects() {
+    let x = active_owner("owner:x", 1, &["BindingX"], 10, "ui/x");
+    let r = residual_owner("owner:r", 2, &["BindingR"], 5);
+    let h = residual_owner("owner:h", 3, &["BindingH"], 5);
+    let report = graph_of(
+        vec![x.clone(), r.clone(), h.clone()],
+        vec![
+            owner_edge("edge:0", "owner:x", "owner:r", DepKind::EagerUse, true),
+            owner_edge("edge:1", "owner:r", "owner:h", DepKind::LazyUse, false),
+        ],
+        vec![
+            atomic_unit_for("atomic:0", &[&x]),
+            atomic_unit_for("atomic:1", &[&r]),
+            atomic_unit_for("atomic:2", &[&h]),
+        ],
+        vec![],
+    );
+    let groups = vec![make_module_group("ui/x", vec![0])];
+    let (mut q, group_ids) =
+        QuotientGraph::from_report_with_partition_extended(&report, CAP_LINES, &groups);
+    let cx = group_ids[0];
+    let ch = q.class_of(q.owner_idx_of("owner:h").unwrap());
+    let outcome = compare_gate_to_reference(&report, &mut q, cx, ch).unwrap();
+    assert_eq!(
+        outcome,
+        QueryOutcome::Diverged(DivergenceClass::Pass2Blindness),
+        "current gate is expected to be Pass-2-blind here; if this now \
+         AGREES, the ladder landed — un-ignore the §7.3 pinning tests \
+         and flip this harness to strict equality",
+    );
+}
+
+/// Expected failure (plan §1 item 2): the class graph is finer than
+/// the module projection. `a → r1` and `r2 → b` involve two distinct
+/// residual classes, so promoting `b` into `ui/a` closes the
+/// module-level mutual cycle `M ↔ R` without any class-level cycle.
+#[test]
+fn gate_accepts_module_granularity_pass1_cycle_reference_rejects() {
+    let a = active_owner("owner:a", 1, &["BindingA"], 10, "ui/a");
+    let r1 = residual_owner("owner:r1", 2, &["BindingR1"], 5);
+    let r2 = residual_owner("owner:r2", 3, &["BindingR2"], 5);
+    let b = residual_owner("owner:b", 4, &["BindingB"], 5);
+    let report = graph_of(
+        vec![a.clone(), r1.clone(), r2.clone(), b.clone()],
+        vec![
+            owner_edge("edge:0", "owner:a", "owner:r1", DepKind::EagerUse, true),
+            owner_edge("edge:1", "owner:r2", "owner:b", DepKind::EagerUse, true),
+        ],
+        vec![
+            atomic_unit_for("atomic:0", &[&a]),
+            atomic_unit_for("atomic:1", &[&r1]),
+            atomic_unit_for("atomic:2", &[&r2]),
+            atomic_unit_for("atomic:3", &[&b]),
+        ],
+        vec![],
+    );
+    let groups = vec![make_module_group("ui/a", vec![0])];
+    let (mut q, group_ids) =
+        QuotientGraph::from_report_with_partition_extended(&report, CAP_LINES, &groups);
+    let ca = group_ids[0];
+    let cb = q.class_of(q.owner_idx_of("owner:b").unwrap());
+    let outcome = compare_gate_to_reference(&report, &mut q, ca, cb).unwrap();
+    assert_eq!(
+        outcome,
+        QueryOutcome::Diverged(DivergenceClass::ModuleGranularityPass1),
+        "current gate is expected to miss the module-granularity \
+         Pass-1 cycle; if this now AGREES, the ladder landed — \
+         un-ignore the §7.3 pinning tests and flip this harness to \
+         strict equality",
+    );
+}
+
+/// Expected failure (clause-2 caveat to plan §3): a rebind between
+/// two residual-pile owners is intra-module pre-merge; promoting the
+/// writer's class into `ui/a` makes it a cross-module rebind the hot
+/// gate never checks.
+#[test]
+fn gate_accepts_promotion_created_cross_rebind_reference_rejects() {
+    let a = active_owner("owner:a", 1, &["BindingA"], 10, "ui/a");
+    let h = residual_owner("owner:h", 2, &["BindingH"], 5);
+    let r = residual_owner("owner:r", 3, &["BindingR"], 5);
+    let report = graph_of(
+        vec![a.clone(), h.clone(), r.clone()],
+        vec![owner_edge(
+            "edge:0",
+            "owner:h",
+            "owner:r",
+            DepKind::EagerRebind,
+            true,
+        )],
+        vec![
+            atomic_unit_for("atomic:0", &[&a]),
+            atomic_unit_for("atomic:1", &[&h]),
+            atomic_unit_for("atomic:2", &[&r]),
+        ],
+        vec![],
+    );
+    let groups = vec![make_module_group("ui/a", vec![0])];
+    let (mut q, group_ids) =
+        QuotientGraph::from_report_with_partition_extended(&report, CAP_LINES, &groups);
+    let ca = group_ids[0];
+    let ch = q.class_of(q.owner_idx_of("owner:h").unwrap());
+    let outcome = compare_gate_to_reference(&report, &mut q, ca, ch).unwrap();
+    assert_eq!(
+        outcome,
+        QueryOutcome::Diverged(DivergenceClass::CrossRebindBlindness),
+        "current gate is expected to be blind to promotion-created \
+         cross-rebinds; if this now AGREES, the ladder landed — \
+         un-ignore the §7.3 pinning tests and flip this harness to \
+         strict equality",
+    );
+}
+
+// ---------------------------------------------------------------------
+// Randomized sweep over small synthetic reports.
+// ---------------------------------------------------------------------
+
+/// Deterministic xorshift64 — placeholder for the Track F1 proptest
+/// generator; no external dep, fully reproducible.
+struct Rng(u64);
+
+impl Rng {
+    fn next(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x
+    }
+
+    fn below(&mut self, n: usize) -> usize {
+        (self.next() % n as u64) as usize
+    }
+
+    fn chance(&mut self, percent: u64) -> bool {
+        self.next() % 100 < percent
+    }
+}
+
+/// Random small report: mixed residual/active owners, mixed
+/// `DepKind`s (including lazy back-edges and rebinds), singleton
+/// atomic units plus the occasional multi-member unit, and spec
+/// module groups derived from the active destinations.
+fn random_report(rng: &mut Rng) -> (OwnerGraphReport, Vec<SpecModuleGroup>) {
+    let owner_count = 4 + rng.below(5);
+    let nodes: Vec<OwnerGraphNodeReport> = (0..owner_count)
+        .map(|i| {
+            let id = format!("owner:{i}");
+            let binding = format!("B{i}");
+            if rng.chance(55) {
+                residual_owner(&id, i + 1, &[&binding], 5)
+            } else {
+                let module = rng.below(3);
+                active_owner(&id, i + 1, &[&binding], 5, &format!("ui/m{module}"))
+            }
+        })
+        .collect();
+
+    let mut edges = Vec::new();
+    for source in 0..owner_count {
+        for target in 0..owner_count {
+            if source == target || !rng.chance(22) {
+                continue;
+            }
+            let (kind, constrains) = match rng.below(8) {
+                0..=3 => (DepKind::EagerUse, true),
+                4..=5 => (DepKind::LazyUse, false),
+                6 => (DepKind::Sequenced, true),
+                _ => (DepKind::EagerRebind, true),
+            };
+            edges.push(owner_edge(
+                &format!("edge:{}", edges.len()),
+                &nodes[source].id,
+                &nodes[target].id,
+                kind,
+                constrains,
+            ));
+        }
+    }
+
+    let mut units: Vec<_> = nodes
+        .iter()
+        .enumerate()
+        .map(|(i, node)| atomic_unit_for(&format!("atomic:{i}"), &[node]))
+        .collect();
+    if owner_count >= 2 && rng.chance(40) {
+        let a = rng.below(owner_count);
+        let b = rng.below(owner_count);
+        if a != b {
+            units.push(atomic_unit_for(
+                &format!("atomic:{}", units.len()),
+                &[&nodes[a], &nodes[b]],
+            ));
+        }
+    }
+
+    // Spec module groups: active owners grouped by destination path.
+    let mut by_module: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for node in &nodes {
+        let path = node.destination.as_str().to_string();
+        if path != "residual" {
+            by_module.entry(path).or_default().push(node.id.clone());
+        }
+    }
+    let spec: Vec<SpecModuleGroup> = by_module
+        .into_iter()
+        .map(|(module_id, owner_ids)| SpecModuleGroup {
+            module_id,
+            owner_ids,
+        })
+        .collect();
+
+    let report = graph_of(nodes, edges, units, vec![]);
+    (report, spec)
+}
+
+/// Sweep: seed each random report through the REAL seed entry point
+/// (`build_seed_quotient`), then alternate full pairwise gate-vs-
+/// reference comparison rounds with committed mutations (the real
+/// greedy driver, plus directly-contracted gate-accepted pairs).
+/// Every divergence must be a cataloged [`DivergenceClass`];
+/// `classify_divergence` panics on any rejecting-reference shape
+/// outside the catalog.
+#[test]
+fn randomized_gate_divergences_stay_within_catalog() {
+    let mut tally: BTreeMap<&'static str, usize> = BTreeMap::new();
+    for seed in 1..=60u64 {
+        let mut rng = Rng(seed.wrapping_mul(0x9E37_79B9_7F4A_7C15));
+        let (report, spec) = random_report(&mut rng);
+        let (mut q, _rejected) =
+            build_seed_quotient(&report, &report.atomic_graph.nodes, &spec, CAP_LINES);
+        for _round in 0..6 {
+            let live: Vec<ClassId> = q.iter_classes().collect();
+            let mut accepted_pair: Option<(ClassId, ClassId)> = None;
+            for i in 0..live.len() {
+                for j in (i + 1)..live.len() {
+                    let Some(outcome) =
+                        compare_gate_to_reference(&report, &mut q, live[i], live[j])
+                    else {
+                        *tally.entry("preconditions_failed").or_default() += 1;
+                        continue;
+                    };
+                    let key = match outcome {
+                        QueryOutcome::Agree => "agree",
+                        QueryOutcome::DirtyPreState => "dirty_pre_state",
+                        QueryOutcome::Diverged(DivergenceClass::ClassLevelOverRejection) => {
+                            "class_level_over_rejection"
+                        }
+                        QueryOutcome::Diverged(DivergenceClass::Pass2Blindness) => {
+                            "pass2_blindness"
+                        }
+                        QueryOutcome::Diverged(DivergenceClass::ModuleGranularityPass1) => {
+                            "module_granularity_pass1"
+                        }
+                        QueryOutcome::Diverged(DivergenceClass::CrossRebindBlindness) => {
+                            "cross_rebind_blindness"
+                        }
+                    };
+                    *tally.entry(key).or_default() += 1;
+                    if matches!(outcome, QueryOutcome::Agree)
+                        && accepted_pair.is_none()
+                        && q.merge_preserves_invariants(live[i], live[j])
+                    {
+                        accepted_pair = Some((live[i], live[j]));
+                    }
+                }
+            }
+            // Commit a mutation through a real entry point so later
+            // rounds compare against evolved committed state.
+            let mutated = if rng.chance(50) {
+                greedy_step(&mut q).is_some()
+            } else if let Some((c1, c2)) = accepted_pair {
+                q.contract(c1, c2).is_ok()
+            } else {
+                false
+            };
+            if !mutated {
+                break;
+            }
+        }
+    }
+    let agreed = tally.get("agree").copied().unwrap_or(0);
+    assert!(
+        agreed >= 100,
+        "sweep must exercise a meaningful number of in-domain \
+         agreeing queries; tally: {tally:?}",
+    );
+    eprintln!("gate-vs-reference sweep tally: {tally:?}");
+}

--- a/devinfra/js/debundle/peel/quotient_integration_test.rs
+++ b/devinfra/js/debundle/peel/quotient_integration_test.rs
@@ -192,6 +192,130 @@ fn seed_skips_unrealizable_spec_module_contraction_and_reports() {
     assert_ne!(q.class_of(b1_idx), q.class_of(b2_idx));
 }
 
+// ---------- Gate-ladder pinning tests (plans/incremental_gate_unification.md §7.3). ----------
+//
+// These pin the module-level gate predicate decided in the plan's §2.
+// They assert the DESIRED behavior, which the current class-level
+// PK/cone gate gets wrong, so they are `#[ignore]`d until PR 4 of the
+// plan's §8 cuts the boolean gate over to the realizability ladder and
+// un-ignores them. The current (wrong) behavior is pinned by the
+// differential harness's divergence catalog in
+// `peel/gate_differential_test.rs`. The third §7.3 case — preservation
+// of `seed_skips_unrealizable_spec_module_contraction_and_reports` —
+// is the existing (non-ignored) test above.
+
+/// §2's atomic-unit anomaly: a 3-owner atomic unit whose members form
+/// a constraining cycle `a → b → c → a` exists precisely because its
+/// members MUST co-locate, and the module-level predicate accepts the
+/// contractions (all three owners project to the residual module, so
+/// every merge is a delta-free no-op). The current class-level gate
+/// rejects them: the class graph is `!is_dag` from construction, the
+/// cone-DFS fallback finds the pre-existing (transient) path
+/// `b → c → a`, and the unit cannot seed.
+#[test]
+#[ignore = "gate ladder PR 4 (plans/incremental_gate_unification.md §8): the \
+            class-level cycle gate over-rejects merges internal to the residual \
+            module; un-ignore when check_merge_boolean routes through the ladder"]
+fn seed_co_locates_constraining_cycle_atomic_unit() {
+    let a = residual_owner("owner:a", 1, &["BindingA"], 5);
+    let b = residual_owner("owner:b", 2, &["BindingB"], 5);
+    let c = residual_owner("owner:c", 3, &["BindingC"], 5);
+    let edges = vec![
+        owner_edge("edge:0", "owner:a", "owner:b", DepKind::EagerUse, true),
+        owner_edge("edge:1", "owner:b", "owner:c", DepKind::EagerUse, true),
+        owner_edge("edge:2", "owner:c", "owner:a", DepKind::EagerUse, true),
+    ];
+    let unit = atomic_unit_for("atomic:0", &[&a, &b, &c]);
+    let report = graph_of(
+        vec![a.clone(), b.clone(), c.clone()],
+        edges,
+        vec![unit],
+        vec![],
+    );
+    let (q, rejected) = build_seed_quotient(&report, &report.atomic_graph.nodes, &[], 10_000);
+    assert!(
+        rejected.is_empty(),
+        "atomic-unit contractions internal to the residual module are \
+         delta-free no-ops under the module-level predicate and must \
+         not be rejected: {rejected:?}",
+    );
+    let a_idx = q.owner_idx_of("owner:a").unwrap();
+    let b_idx = q.owner_idx_of("owner:b").unwrap();
+    let c_idx = q.owner_idx_of("owner:c").unwrap();
+    assert_eq!(q.class_of(a_idx), q.class_of(b_idx));
+    assert_eq!(q.class_of(b_idx), q.class_of(c_idx));
+}
+
+/// §1's Pass-2 blindness: a merge that closes an asymmetric I-SCC
+/// (eager forward, lazy back) where the `EsmEvaluationSimulator`
+/// proves TDZ must be rejected AT THE MERGE, with
+/// `EsmEvaluationTdz`-backed evidence. The current hot gate sees only
+/// constraining class edges, accepts, and commits; the only backstop
+/// is `build_seed_quotient`'s post-seed `PostSeedUnrealizableScc`
+/// report, which does not undo the merge.
+///
+/// Shape: pre-existing module `ui/x` = {x}; residual-pile owners `r`
+/// (stays) and `h` (the merge candidate). `x` eager-reads `r`'s
+/// binding (constraining `M → R`); `r` lazily reads `h`'s binding
+/// (intra-residual pre-merge, becomes the lazy back-edge `R → M` once
+/// `h` is promoted into `ui/x`). The post-merge I-SCC `{M, R}`
+/// carries a constraining pair targeting residual — the DFS root
+/// evaluates last, so `M`'s eager read of `r`'s binding TDZs.
+#[test]
+#[ignore = "gate ladder PR 4 (plans/incremental_gate_unification.md §8): the \
+            hot boolean gate is blind to Pass-2 (EsmEvaluationTdz) rejections; \
+            un-ignore when check_merge_boolean routes through the ladder"]
+fn merge_closing_asymmetric_i_cycle_is_rejected_at_the_merge() {
+    let x = active_owner("owner:x", 1, &["BindingX"], 10, "ui/x");
+    let r = residual_owner("owner:r", 2, &["BindingR"], 5);
+    let h = residual_owner("owner:h", 3, &["BindingH"], 5);
+    let edges = vec![
+        owner_edge("edge:0", "owner:x", "owner:r", DepKind::EagerUse, true),
+        owner_edge("edge:1", "owner:r", "owner:h", DepKind::LazyUse, false),
+    ];
+    let report = graph_of(
+        vec![x.clone(), r.clone(), h.clone()],
+        edges,
+        vec![
+            atomic_unit_for("atomic:0", &[&x]),
+            atomic_unit_for("atomic:1", &[&r]),
+            atomic_unit_for("atomic:2", &[&h]),
+        ],
+        vec![],
+    );
+    let groups = vec![make_module_group("ui/x", vec![0])];
+    let (mut q, group_ids) =
+        QuotientGraph::from_report_with_partition_extended(&report, 10_000, &groups);
+    let cx = group_ids[0];
+    let ch = q.class_of(q.owner_idx_of("owner:h").unwrap());
+
+    // The pre-merge state is realizable; the merge alone closes the
+    // TDZ cycle, so the gate must reject it.
+    assert!(q.realizability_verdict().is_realizable());
+    assert!(
+        !q.merge_preserves_invariants(cx, ch),
+        "merging owner:h into ui/x closes the asymmetric I-cycle \
+         {{ui/x, residual}} with a TDZ'ing constraining pair; the \
+         boolean gate must reject",
+    );
+    let evidence = q
+        .would_be_cycles_after_contract(cx, ch)
+        .expect("diagnostic gate must surface the Pass-2 rejection");
+    let evidence_owners: Vec<&str> = evidence
+        .cycles
+        .iter()
+        .flat_map(|cycle| cycle.owner_ids.iter().map(String::as_str))
+        .collect();
+    assert!(
+        evidence_owners.contains(&"owner:x"),
+        "evidence must mention the eager reader: {evidence_owners:?}",
+    );
+    assert!(
+        q.contract(cx, ch).is_err(),
+        "contract must refuse to commit the TDZ-closing merge",
+    );
+}
+
 #[test]
 fn seed_atomic_unit_contractions_never_rejected_on_well_formed_input() {
     // Regression guard: across a handful of well-formed fixtures,

--- a/devinfra/js/debundle/realizability/mod.rs
+++ b/devinfra/js/debundle/realizability/mod.rs
@@ -295,6 +295,40 @@ pub fn check_realizability(
     verdict
 }
 
+/// Touching-filtered form of [`check_realizability`]: the same pure
+/// from-scratch verdict, restricted to diagnoses involving `module`.
+///
+/// This is the gate ladder's **reference predicate**
+/// (`plans/incremental_gate_unification.md` §2): a speculative merge
+/// with post-merge module `M` is acceptable iff
+/// `check_realizability_touching(owner_graph, post_partition, M)`
+/// `.is_realizable()`. Pre-existing violations not touching `M` are
+/// intentionally ignored, matching
+/// [`RealizabilityIndex::verdict_after_moving_owners_touching`]'s
+/// semantics on both the hot and diagnostic paths.
+///
+/// Differential-harness / oracle use only — `O(N + M)` per call, far
+/// too slow for the proposer's per-pop gate.
+pub fn check_realizability_touching(
+    owner_graph: &OwnerGraph,
+    partition: &Partition,
+    module: ModuleId,
+) -> RealizabilityVerdict {
+    let full = check_realizability(owner_graph, partition);
+    RealizabilityVerdict {
+        unrealizable_sccs: full
+            .unrealizable_sccs
+            .into_iter()
+            .filter(|scc| scc.modules.contains(&module))
+            .collect(),
+        cross_rebinds: full
+            .cross_rebinds
+            .into_iter()
+            .filter(|rebind| rebind.from == module || rebind.to == module)
+            .collect(),
+    }
+}
+
 /// Mutable index over a working partition. The single shared
 /// implementation of the three-clause predicate, exposed in the
 /// transactional shape docs/design.md "Realizability primitive" prescribes.

--- a/devinfra/js/debundle/realizability/tests.rs
+++ b/devinfra/js/debundle/realizability/tests.rs
@@ -85,6 +85,64 @@ fn constraining_cycle_across_two_modules_is_unrealizable() {
     );
 }
 
+/// The touching-filtered reference predicate
+/// (`plans/incremental_gate_unification.md` §2): an SCC diagnosis is
+/// kept only when the queried module participates in it. A module
+/// outside every diagnosis sees a realizable verdict even though the
+/// full verdict is unrealizable.
+#[test]
+fn touching_filter_keeps_only_diagnoses_involving_the_queried_module() {
+    // Mutual eager cycle between mod 1 and mod 2; owner 2 (`const c`)
+    // is an unrelated clean module 3.
+    let source = "const a = b + 1; const b = a + 1; const c = 1;";
+    let owner_graph = parse_and_build(source);
+    let mut partition = Partition::new(&owner_graph, module_id(0));
+    partition.set(OwnerId(0), module_id(1));
+    partition.set(OwnerId(1), module_id(2));
+    partition.set(OwnerId(2), module_id(3));
+    assert!(!check_realizability(&owner_graph, &partition).is_realizable());
+    let touching_cycle = check_realizability_touching(&owner_graph, &partition, module_id(1));
+    assert!(
+        !touching_cycle.is_realizable(),
+        "module 1 is in the SCC; the diagnosis must survive the filter: {touching_cycle:#?}",
+    );
+    let touching_clean = check_realizability_touching(&owner_graph, &partition, module_id(3));
+    assert!(
+        touching_clean.is_realizable(),
+        "module 3 touches no diagnosis; pre-existing violations \
+         elsewhere must not surface: {touching_clean:#?}",
+    );
+}
+
+/// Clause-2 side of the touching filter: a cross-module rebind is
+/// kept iff the queried module is one of its endpoints.
+#[test]
+fn touching_filter_keeps_only_cross_rebinds_at_the_queried_module() {
+    // owner_0: let a = 1 (residual). owner_1: a = 2 (mod 1 — a
+    // cross-module top-level rebinding write). owner_2: const z
+    // (mod 2, unrelated).
+    let source = "let a = 1; a = 2; const z = 3;";
+    let owner_graph = parse_and_build(source);
+    let mut partition = Partition::new(&owner_graph, module_id(0));
+    partition.set(OwnerId(1), module_id(1));
+    partition.set(OwnerId(2), module_id(2));
+    let full = check_realizability(&owner_graph, &partition);
+    assert!(
+        !full.cross_rebinds.is_empty(),
+        "fixture must produce a cross-module rebind: {full:#?}",
+    );
+    let touching_writer = check_realizability_touching(&owner_graph, &partition, module_id(1));
+    assert!(
+        !touching_writer.cross_rebinds.is_empty(),
+        "module 1 is the rebind's writer side: {touching_writer:#?}",
+    );
+    let touching_clean = check_realizability_touching(&owner_graph, &partition, module_id(2));
+    assert!(
+        touching_clean.is_realizable(),
+        "module 2 is on neither rebind endpoint: {touching_clean:#?}",
+    );
+}
+
 /// A pure lazy-read cycle (mutual references inside function
 /// bodies) is realizable: ESM evaluates the lazy side first, no
 /// TDZ. Verdict must be empty even when the modules form a cycle


### PR DESCRIPTION
PR 1 (S) of [`plans/incremental_gate_unification.md` §8](https://github.com/agentydragon/ducktape/blob/devel/devinfra/js/debundle/plans/incremental_gate_unification.md#8-staged-prs) (merged as #2080): predicate pinning + reference. No production behavior changes — the boolean gate is untouched until PR 4.

## What's in PR 1 per the plan

1. **The pure touching-filtered `reference` function** (§2/§7.1): `check_realizability_touching(owner_graph, partition, module)` in `realizability/mod.rs`, exported from `:gate`. Same pure verdict as `check_realizability`, restricted to diagnoses touching `M` — the ladder's reference predicate. PR 3's `DEBUNDLE_GATE_ORACLE` and the harness consume it. Unit tests cover both the SCC and clause-2 (cross-rebind) sides of the filter.

2. **§7.3 pinning tests** in `peel/quotient_integration_test.rs`, asserting the **desired** module-level behavior, `#[ignore]`d with reasons naming PR 4 (per the `ARCHITECTURE_BACKLOG.md` ignored-test standard):
   - `seed_co_locates_constraining_cycle_atomic_unit` — the 3-member-constraining-cycle atomic unit must seed. Verified failing today (run with `--test_arg=--ignored`), which **settles §9 open question 1 synthetically**: the §2 anomaly is a reproduced failure, not just a reading of the code.
   - `merge_closing_asymmetric_i_cycle_is_rejected_at_the_merge` — a merge closing a TDZ'ing asymmetric I-SCC must be rejected at the merge with `EsmEvaluationTdz`-backed evidence. Verified failing today (the hot gate accepts; only the post-seed backstop reports).
   - Preservation of `seed_skips_unrealizable_spec_module_contraction_and_reports`: the existing test stays green untouched.

3. **Differential harness skeleton** (`peel/gate_differential_test.rs`, new `rust_test` target): an independent reference projection built from the kernel's *public* surface + the report's own residual flags (per the Track F note, not the kernel's `project_partition`); gate-vs-reference comparison after every boolean gate query; pre-state-dirty queries tallied separately (the §2 equality claim is scoped to realizable pre-states); and the **known-divergence catalog encoded as expected failures** — deterministic fixtures assert each cataloged divergence occurs today, so PR 4's cutover flips them loudly to agreement:
   - `ClassLevelOverRejection` (§2 atomic-unit anomaly / pass-3 class-cycle rejections)
   - `Pass2Blindness` (§1 item 1)
   - `ModuleGranularityPass1` (§1 item 2 — cycle through two distinct residual classes, invisible at class granularity)
   - `CrossRebindBlindness` — see finding below.

## Finding: caveat to §3's cross-rebind "formality" claim

§3 tier 1 says "merges only ever convert cross-rebinds to intra-module, so on realizable pre-states this is a formality." Not quite: a **gate-residual promotion** (orphan class merged into a pre-existing module) moves owners *out* of module 0, turning an intra-residual rebind into a cross-module clause-2 violation. The current hot gate never checks rebinds and accepts; the reference rejects. Pinned by `gate_accepts_promotion_created_cross_rebind_reference_rejects` and cataloged — the ladder's tier-1 `cross_rebinds_touching_with_overlay` check covers it in PR 3/4.

## Deviations from the plan (post-merge reality)

- **Paths**: realizability now lives at `realizability/{mod,esm_simulator,incremental_quotient,tests}.rs` inside the `:gate` crate (A2 crate split, #2083), so the reference function landed there rather than the plan's pre-split `realizability.rs`.
- **Proptest**: §7.1's full Track F1 harness specifies proptest; there is no proptest in the crate universe yet, so the skeleton uses a deterministic seeded xorshift generator over small synthetic reports (mixed `DepKind`s incl. lazy back-edges and rebinds, residual-destined owners, atomic units, spec modules) driving the real `build_seed_quotient`/`greedy_step`/`contract` entry points. Adding proptest + the full generator is part of completing Track F1 in the later PRs.
- **Per-query tier-skip-soundness assertions** (§7.1) require the ladder tiers and arrive with PR 3, not the skeleton.

## Testing

- `bbr test //devinfra/js/debundle/...` — 99/99 green (BuildBuddy invocation `734fc925-de36-4d56-a28e-3e68be21f735`).
- Ignored pinning tests confirmed failing under `--test_arg=--ignored` (expected until PR 4).

No PR 2+ scope: no `CondensationOrder`, no `cached_cycles` deletion, no gate cutover.

https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk)_