### PR TITLE
debundle: add imported-callee purity consumption to the classifier (cross-module purity, 1/2)

### DIFF
--- a/devinfra/js/debundle/facts/mod.rs
+++ b/devinfra/js/debundle/facts/mod.rs
@@ -554,6 +554,11 @@ where
         &hints.declared_pure,
         &hints.declared_pure_new,
         &hints.declared_pure_members,
+        // CLEANUP(2026-06-11): pass the program-level cross-module purity
+        // oracle here once it is threaded through stage_one. The consumer
+        // arm in `classify_callee_call` already reads it; an empty map
+        // keeps the strictly per-chunk behavior until then.
+        &BTreeMap::new(),
     );
     let local_effect_context =
         local_effects::LocalEffectContext::for_body(&body, hints.local_effect_policy);

--- a/devinfra/js/debundle/purity/classifier_tests.rs
+++ b/devinfra/js/debundle/purity/classifier_tests.rs
@@ -117,6 +117,7 @@ fn classify_with_declared_pure_members(
         &BTreeSet::new(),
         &BTreeSet::new(),
         &declared_pure_members,
+        &BTreeMap::new(),
     );
     let var = match module.body.last().expect("non-empty body") {
         ModuleItem::Stmt(Stmt::Decl(Decl::Var(var))) => var,
@@ -1058,4 +1059,69 @@ fn coercion_of_non_primitive_const_stays_unknown() {
     // A const whose init is not statically result-primitive (a bare
     // import/member read) is not admitted either.
     assert!(!classify_built("const o = globalThis.x;", "`${o}`").is_pure());
+}
+
+/// Classify `expr_src` with a populated cross-module imported-purity
+/// map (as the program-level oracle would supply). Each `(name,
+/// purity)` records the verdict for an imported function binding.
+fn classify_with_imported_purities(
+    prefix: &str,
+    expr_src: &str,
+    imports: &[(&str, Purity)],
+) -> Purity {
+    let module = parse(&format!("{prefix}\nconst _ = {expr_src};"));
+    let body = top_level_item_views(&module.body);
+    let shadowed = compute_shadowed_globals(&body);
+    let imported_purities: BTreeMap<String, Purity> = imports
+        .iter()
+        .map(|(name, purity)| ((*name).to_string(), purity.clone()))
+        .collect();
+    let graph = ChunkCodeGraph::build_full(
+        &body,
+        &shadowed,
+        &BTreeSet::new(),
+        &BTreeSet::new(),
+        &BTreeMap::new(),
+        &imported_purities,
+    );
+    let var = match module.body.last().expect("non-empty body") {
+        ModuleItem::Stmt(Stmt::Decl(Decl::Var(var))) => var,
+        other => panic!("expected last stmt to be `const _ = …;`, got {other:?}"),
+    };
+    let init = var.decls[0].init.as_deref().expect("init expected");
+    classify_expr_purity(init, &shadowed, &BTreeSet::new(), &BTreeSet::new(), &graph)
+}
+
+fn impure_verdict() -> Purity {
+    Purity::from_reason(PurityRule::UnknownCall, swc_common::DUMMY_SP)
+}
+
+#[test]
+fn imported_pure_callee_makes_call_pure() {
+    // The oracle resolved `memo` (an imported function) as pure, so
+    // `memo(arg)` classifies pure when the args are pure.
+    assert!(classify_with_imported_purities("", "memo(x)", &[("memo", Purity::Pure)]).is_pure());
+    assert!(
+        classify_with_imported_purities("", "memo(() => {})", &[("memo", Purity::Pure)]).is_pure()
+    );
+}
+
+#[test]
+fn imported_impure_callee_keeps_call_impure() {
+    assert!(!classify_with_imported_purities("", "run(x)", &[("run", impure_verdict())]).is_pure());
+}
+
+#[test]
+fn imported_callee_without_verdict_stays_unknown() {
+    // No oracle entry → the call stays `unknown_call`, today's behavior.
+    assert!(!classify_with_imported_purities("", "f(x)", &[]).is_pure());
+}
+
+#[test]
+fn imported_pure_callee_still_classifies_arguments() {
+    // `memo` is pure, but a possibly-object operand coerced in the arg
+    // keeps the whole call impure — args are classified independently.
+    assert!(
+        !classify_with_imported_purities("", "memo(A + 1)", &[("memo", Purity::Pure)]).is_pure()
+    );
 }

--- a/devinfra/js/debundle/purity/graph_purity_tests.rs
+++ b/devinfra/js/debundle/purity/graph_purity_tests.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 use super::*;
 use crate::facts::{compute_shadowed_globals, top_level_item_views};
@@ -1300,6 +1300,7 @@ fn body_shadowed_pure_member_binding_is_not_pure() {
         &BTreeSet::new(),
         &BTreeSet::new(),
         &declared_pure_members,
+        &BTreeMap::new(),
     );
     assert_eq!(graph.function_purity("f").map(|p| p.is_pure()), Some(false));
     assert_eq!(graph.function_purity("g").map(|p| p.is_pure()), Some(true));

--- a/devinfra/js/debundle/purity/mod.rs
+++ b/devinfra/js/debundle/purity/mod.rs
@@ -49,6 +49,13 @@ pub struct ChunkCodeGraph {
     /// classified separately at its declaration site; only the
     /// *value* class matters here. See `collect_primitive_const_bindings`.
     primitive_const_bindings: BTreeSet<String>,
+    /// Purity verdict for chunk-top bindings that are imports of a
+    /// function from another module, keyed by local binding name.
+    /// Populated by the program-level cross-module purity oracle;
+    /// empty in the strictly per-chunk path, so an imported callee with
+    /// no entry stays `unknown_call` as before. A body-local binding
+    /// that shadows the import is not resolved through this map.
+    imported_purities: BTreeMap<String, Purity>,
 }
 
 #[derive(Debug, Clone)]
@@ -109,6 +116,7 @@ impl ChunkCodeGraph {
             declared_pure,
             declared_pure_new,
             &BTreeMap::new(),
+            &BTreeMap::new(),
         )
     }
 
@@ -118,6 +126,7 @@ impl ChunkCodeGraph {
         declared_pure: &BTreeSet<String>,
         declared_pure_new: &BTreeSet<String>,
         declared_pure_members: &BTreeMap<String, BTreeSet<String>>,
+        imported_purities: &BTreeMap<String, Purity>,
     ) -> Self {
         let functions = collect_chunk_functions(body);
         let name_to_idx: BTreeMap<&str, usize> = functions
@@ -171,6 +180,7 @@ impl ChunkCodeGraph {
             pure_new_constructors: declared_pure_new.clone(),
             declared_pure_members: declared_pure_members.clone(),
             primitive_const_bindings: collect_primitive_const_bindings(body),
+            imported_purities: imported_purities.clone(),
         };
         // tarjan_scc emits SCCs in reverse topological order: leaves
         // (sinks — functions that don't call any chunk-top
@@ -249,6 +259,12 @@ impl ChunkCodeGraph {
 
     pub(crate) fn is_declared_pure_new(&self, name: &str) -> bool {
         self.pure_new_constructors.contains(name)
+    }
+
+    /// Cross-module purity verdict for an imported function binding,
+    /// when the program-level oracle resolved one.
+    pub(crate) fn imported_purity(&self, name: &str) -> Option<Purity> {
+        self.imported_purities.get(name).cloned()
     }
 
     /// Whether `<recv>.<prop>(args)` is admitted as pure by an author
@@ -2651,6 +2667,23 @@ fn classify_callee_call(
     if let Expr::Ident(ident) = callee_expr
         && !local_shadowed.contains(ident.sym.as_ref())
         && let Some(callee_purity) = graph.function_purity(ident.sym.as_ref())
+    {
+        return callee_purity.worst(all_args_pure(
+            args,
+            shadowed,
+            local_shadowed,
+            declared_pure,
+            graph,
+        ));
+    }
+    // Imported function with a cross-module purity verdict from the
+    // program-level oracle (`imported_purities`). Same shape as the
+    // chunk-local arm: a `Pure` import + Pure args → Pure; an impure
+    // import inherits its reasons. A body-local binding of the same name
+    // shadows the import, so the called value is unknown then.
+    if let Expr::Ident(ident) = callee_expr
+        && !local_shadowed.contains(ident.sym.as_ref())
+        && let Some(callee_purity) = graph.imported_purity(ident.sym.as_ref())
     {
         return callee_purity.worst(all_args_pure(
             args,


### PR DESCRIPTION
First of two increments toward **cross-module purity**, whose goal is to retire `unknown_call` — calls to imported factory functions (`memo`, `forwardRef`, …) that the per-chunk classifier can't see into. On real app bundles `unknown_call` is the dominant impurity, and (via the dataflow-aware S-chain) a major driver of over-merged atomic units.

This PR is the **consumption side**: the interface a future oracle plugs into, with no behavior change yet.

## What

- New `imported_purities: BTreeMap<String, Purity>` on `ChunkCodeGraph` — a per-chunk map from a local binding name to the cross-module purity verdict for the imported function it binds.
- A new arm in `classify_callee_call`, mirroring the existing chunk-local-function arm: an imported callee with a `Pure` verdict and pure args → the call is pure; an impure verdict inherits its reasons; an imported name with no entry stays `unknown_call`; a body-local binding of the same name shadows the import (not resolved through the map).
- `build_full` takes the map; **every current caller passes an empty map**, so emitted output is unchanged. A `CLEANUP` marker at the fact-extraction build site (`facts/mod.rs`) marks where the program-level oracle will supply the real map.

## Why split

The oracle (increment 2/2) is the larger, cross-cutting piece: resolve each chunk's imports to their defining modules (`ImportRecord` + `ExportAliasRecord` + `chunk_table`), then compute `(module, export) → Purity` via a global SCC fixpoint over the cross-module call graph, and thread it through `lowering → compute_stage_one_analysis → build_full`. Landing the consumption interface first keeps that PR focused on the analysis, and keeps this one a small, reviewable, no-op-on-output change.

## Tests

Four cases in `classifier_tests.rs` (new `classify_with_imported_purities` helper): a `Pure` imported callee makes the call pure; an impure verdict keeps it impure; an absent verdict stays `unknown_call`; and a pure imported callee still classifies its arguments (an impure arg keeps the call impure).

`//devinfra/js/debundle:analysis_test` passes locally.

https://claude.ai/code/session_01Bp8cANKC1Ktc92T7SM1kcx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bp8cANKC1Ktc92T7SM1kcx)_