### PR TITLE
Allow SeaweedFS operator in GitOps policy

### DIFF
--- a/cluster/k8s/kyverno/policies/require-gitops.yaml
+++ b/cluster/k8s/kyverno/policies/require-gitops.yaml
@@ -68,6 +68,10 @@ spec:
               - kind: ServiceAccount
                 name: grafana-operator
                 namespace: monitoring
+          - subjects:
+              - kind: ServiceAccount
+                name: seaweedfs-operator
+                namespace: seaweedfs
           # Allow Authentik (creates outpost Deployments from provider CRs)
           - subjects:
               - kind: ServiceAccount


### PR DESCRIPTION
## Summary

- Allow the SeaweedFS operator service account to update generated workloads under the Kyverno `require-gitops` policy.
- Keeps the policy in Audit mode; this only removes SeaweedFS operator audit violations and keeps the allowlist ready if the policy is later enforced.

## Testing

- `kubectl apply --dry-run=server -f cluster/k8s/kyverno/policies/require-gitops.yaml`
- `SKIP=no-commit-to-branch nix develop -c pre-commit run --files cluster/k8s/kyverno/policies/require-gitops.yaml`