### PR TITLE
debundle: collect all rename contributors through the ledger (PR 2/5)

### DIFF
--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -264,6 +264,24 @@ the same maps the pre-ledger code built. The two explicit contributors
 are converted (spec `chunk_renames`; plan-driven `export_name`s); the
 remaining-contributor inventory lives in `rename_ledger.rs`'s module doc.
 
+**PR 2 landed (2026-06):** every remaining contributor submits intents
+and every application site consumes a sealed projection — heuristic
+bound-source per-scope renames (`Function` scope; derived by
+`ScopedHeuristicNaturalizer` over a scratch clone, replayed by
+`SealedScopeRenameApplier`), heuristic free-source return-object aliases
+(`Module` scope, per deriving function; `drop_target_collisions` still
+runs at application until PR 3), entry- and module-side import-local
+mints (`Chunk` / `Module` scope, `ImportInduced`; minting itself stays
+in `import_emit.rs` until PR 3), and auto-grown residual public-export
+minting (new `EntryPublicExports` scope). Because contributor derivation
+still depends on earlier contributors' application, PR 2 seals at phase
+boundaries — one ledger instance per former private map (see the "Seal
+points" section of `rename_ledger.rs`'s module doc); PRs 3–4 collapse
+them into a single collect → seal → execute pass. Two previously
+silent last-write-wins shapes are now seal-time hard errors: two
+deriving functions free-aliasing one source to different targets, and
+two import-local mints disagreeing on one binding.
+
 Decisions taken (formerly the open-questions subsection below):
 
 1. **Same-priority conflicts are hard errors at seal**, naming both
@@ -278,13 +296,10 @@ Decisions taken (formerly the open-questions subsection below):
 
 Remaining PRs:
 
-- **PR 2 — collect**: convert the remaining contributors (heuristic
-  bound/free, import-local disambiguation, cross-module renames,
-  collision resolution) to submit intents; worklist in
-  `rename_ledger.rs`.
-- **PR 3 — seal**: move target-occupancy/capture validation into seal
-  against scope-accurate occupied sets; `_N`/`$N` minting becomes a
-  ledger service.
+- **PR 3 — seal**: move target-occupancy/capture validation (and the
+  free-source `drop_target_collisions` rule) into seal against
+  scope-accurate occupied sets; `_N`/`$N` minting becomes a ledger
+  service; collapse the per-phase ledger instances toward one.
 - **PR 4 — execute once**: one visitor pass (the post-#2052 rename
   visitor becomes the executor) updating the AST, export tables,
   `runtime_imports`, `binding_comments`, and cross-module indexes in
@@ -295,7 +310,7 @@ Remaining PRs:
   split, reverse lookups); afterwards the #2045 class is
   unrepresentable.
 
-The architecture sketch below remains the reference for PRs 2–5.
+The architecture sketch below remains the reference for PRs 3–5.
 
 The naturalizer / lowerer currently mutates identifiers in place across
 several independently-discovered passes and lets every downstream consumer
@@ -339,8 +354,9 @@ defensive reverse-lookups and path sanitizers can become ordinary
 mapping/path-building code once the final mapping makes body ASTs,
 runtime imports, and report tables agree before planning runs.
 
-Remaining prerequisite work (the contributor inventory and the scope
-model landed with PR 1 — see `lowering/rename_ledger.rs`):
+Remaining prerequisite work (the scope model landed with PR 1 and all
+contributors collect through the ledger as of PR 2 — see
+`lowering/rename_ledger.rs`):
 
 1. Inventory every downstream consumer that today reads identifier
    names off the AST or off pre-rename fact maps. Same call sites that

--- a/devinfra/js/debundle/lowering/exports.rs
+++ b/devinfra/js/debundle/lowering/exports.rs
@@ -284,9 +284,11 @@ pub(super) fn entry_exports_for_moved_bindings(
 /// export policy. See docs/design.md "Valid peels and atomic modules"
 /// (importability clause).
 ///
-/// Returns a `local → exported` map (with `local == exported`
-/// because we surface the residual binding's own name); the caller
-/// feeds it to `export_named_for_bindings`.
+/// Submits one `EntryPublicExports`-scope intent per grown export,
+/// keyed by the residual binding's original name and targeting the
+/// minted public name; the caller seals the ledger and maps originals
+/// to entry's post-rename locals before feeding
+/// `export_named_for_bindings`.
 ///
 /// Skips:
 /// - bindings already in `existing_exports` (the upstream source
@@ -300,15 +302,33 @@ pub(super) fn entry_exports_for_moved_bindings(
 /// - bindings owned by a logical module (`binding_assignment`), which
 ///   are imported directly module→module rather than mediated by
 ///   entry.
+pub(super) const AUTO_GROWN_EXPORT_CONTRIBUTOR: &str = "auto-grown residual export";
+
+/// The entry-side facts `auto_grown_residual_exports` consults; see
+/// `LowerChunkSpecFacts` and `lower_chunk` for the field provenance.
+pub(super) struct ExportGrowthFacts<'a> {
+    pub(super) declaration_by_name: &'a HashMap<Id, usize>,
+    pub(super) binding_assignment: &'a HashMap<Id, usize>,
+    pub(super) pre_existing_entry_exports: &'a HashSet<Id>,
+    pub(super) pre_existing_public_export_names: &'a HashSet<String>,
+    pub(super) entry_renames: &'a BTreeMap<String, String>,
+    pub(super) entry_declared_names: &'a HashSet<String>,
+}
+
 pub(super) fn auto_grown_residual_exports(
     body_facts_by_module: &[ModuleBodyFacts],
-    declaration_by_name: &HashMap<Id, usize>,
-    binding_assignment: &HashMap<Id, usize>,
-    pre_existing_entry_exports: &HashSet<Id>,
-    pre_existing_public_export_names: &HashSet<String>,
-    entry_renames: &BTreeMap<String, String>,
-    entry_declared_names: &HashSet<String>,
-) -> BTreeMap<String, String> {
+    facts: &ExportGrowthFacts<'_>,
+    chunk_top_level_mark: swc_common::Mark,
+    ledger: &mut RenameLedger,
+) {
+    let &ExportGrowthFacts {
+        declaration_by_name,
+        binding_assignment,
+        pre_existing_entry_exports,
+        pre_existing_public_export_names,
+        entry_renames,
+        entry_declared_names,
+    } = facts;
     let mut needed = BTreeSet::<String>::new();
     // `body_facts_by_module` is precomputed once upstream (see
     // `lower_chunk`); both this auto-grow pass and the per-plan
@@ -344,30 +364,34 @@ pub(super) fn auto_grown_residual_exports(
     // sym via `EntryExport.{local_name, exported_name}`, so the
     // mint is invisible to the moved body.
     let mut taken_public_names = pre_existing_public_export_names.clone();
-    needed
-        .into_iter()
-        .filter_map(|name| {
-            let final_local = entry_renames
-                .get(&name)
-                .cloned()
-                .unwrap_or_else(|| name.clone());
-            // Only grow exports for bindings the final entry body
-            // actually declares. A chunk-declared binding whose
-            // declaring statement was claimed into a non-entry
-            // module (e.g. a block-hoisted `var` inside an
-            // anonymously-claimed `try` statement) can't be
-            // mediated through entry — growing `export { name }`
-            // here would emit a SyntaxError-at-load entry module.
-            // Skipping leaves the reference in
-            // `missing_residual_exports`, which
-            // `residual_entry_imports_for_moved_body` rejects
-            // loudly instead of emitting broken JS.
-            if !entry_declared_names.contains(&final_local) {
-                return None;
-            }
-            let public_name =
-                import_emit::mint_unique_name(&name, |n| taken_public_names.insert(n.to_string()));
-            Some((final_local, public_name))
-        })
-        .collect()
+    for name in needed {
+        let final_local = entry_renames
+            .get(&name)
+            .cloned()
+            .unwrap_or_else(|| name.clone());
+        // Only grow exports for bindings the final entry body
+        // actually declares. A chunk-declared binding whose
+        // declaring statement was claimed into a non-entry
+        // module (e.g. a block-hoisted `var` inside an
+        // anonymously-claimed `try` statement) can't be
+        // mediated through entry — growing `export { name }`
+        // here would emit a SyntaxError-at-load entry module.
+        // Skipping leaves the reference in
+        // `missing_residual_exports`, which
+        // `residual_entry_imports_for_moved_body` rejects
+        // loudly instead of emitting broken JS.
+        if !entry_declared_names.contains(&final_local) {
+            continue;
+        }
+        let public_name =
+            import_emit::mint_unique_name(&name, |n| taken_public_names.insert(n.to_string()));
+        ledger.submit(RenameIntent {
+            scope: RenameScope::EntryPublicExports,
+            from: top_level_id(&name, chunk_top_level_mark),
+            to: public_name.as_str().into(),
+            origin: RenameOrigin::ImportInduced {
+                contributor: AUTO_GROWN_EXPORT_CONTRIBUTOR,
+            },
+        });
+    }
 }

--- a/devinfra/js/debundle/lowering/imports_cross.rs
+++ b/devinfra/js/debundle/lowering/imports_cross.rs
@@ -1,11 +1,41 @@
 //! Emit cross-module + residual-entry imports for a moved module body.
 //! Both call `disambiguate_*_import_locals` (import_emit.rs) to mint fresh
-//! locals when names collide with already-occupied bindings.
+//! locals when names collide with already-occupied bindings; the minted
+//! `original → fresh` renames are submitted into the consuming plan's
+//! import ledger (scope: that plan's `Module`, origin: `ImportInduced`)
+//! and applied from the sealed projection in `lower_single_plan`.
 
 use super::import_emit::{
     disambiguate_import_locals, disambiguate_residual_entry_import_locals, import_decl_for_plan,
 };
 use super::*;
+
+pub(super) const CROSS_MODULE_IMPORT_CONTRIBUTOR: &str = "cross-module import-local disambiguation";
+pub(super) const RESIDUAL_ENTRY_IMPORT_CONTRIBUTOR: &str =
+    "residual-entry import-local disambiguation";
+
+/// Where one plan's import-local mint renames go: the per-plan ledger
+/// plus the scope/key context its intents need.
+pub(super) struct ImportLocalRenameSink<'a> {
+    pub(super) module: ModuleId,
+    pub(super) chunk_top_level_mark: swc_common::Mark,
+    pub(super) ledger: &'a mut RenameLedger,
+}
+
+impl ImportLocalRenameSink<'_> {
+    /// Submit one minting pass's `original → fresh` renames as
+    /// `Module`-scope `ImportInduced` intents for the consuming plan.
+    fn submit(&mut self, renames: BTreeMap<String, String>, contributor: &'static str) {
+        for (original, fresh) in renames {
+            self.ledger.submit(RenameIntent {
+                scope: RenameScope::Module(self.module),
+                from: top_level_id(&original, self.chunk_top_level_mark),
+                to: fresh.as_str().into(),
+                origin: RenameOrigin::ImportInduced { contributor },
+            });
+        }
+    }
+}
 
 /// Build one `import { … } from "./<provider>.js";` per provider,
 /// tagged with the provider's `ModuleId`. UNSORTED — the caller
@@ -23,7 +53,7 @@ pub(super) fn cross_module_imports_for_plan(
     imports_by_provider: BTreeMap<usize, BTreeMap<String, String>>,
     factorization: &ChunkFactorization,
     occupied: &mut BTreeSet<String>,
-    renames: &mut BTreeMap<String, String>,
+    sink: &mut ImportLocalRenameSink<'_>,
 ) -> Vec<(ModuleId, ModuleItem)> {
     imports_by_provider
         .into_iter()
@@ -32,7 +62,9 @@ pub(super) fn cross_module_imports_for_plan(
                 .analysis
                 .logical_module(LogicalModuleIndex(provider_index))
                 .map(|provider| {
-                    let resolved = disambiguate_import_locals(&bindings, occupied, renames);
+                    let mut minted = BTreeMap::new();
+                    let resolved = disambiguate_import_locals(&bindings, occupied, &mut minted);
+                    sink.submit(minted, CROSS_MODULE_IMPORT_CONTRIBUTOR);
                     (
                         ModuleId(LogicalModuleIndex(provider_index)),
                         import_decl_for_plan(from_file, &provider.target_file, &resolved),
@@ -83,7 +115,7 @@ pub(super) fn residual_entry_imports_for_moved_body(
     imports: BTreeMap<String, EntryExport>,
     missing_exports: BTreeSet<String>,
     occupied: &mut BTreeSet<String>,
-    renames: &mut BTreeMap<String, String>,
+    sink: &mut ImportLocalRenameSink<'_>,
 ) -> Result<Vec<ModuleItem>> {
     if !missing_exports.is_empty() {
         // Defense-in-depth: `auto_grown_residual_exports` is supposed
@@ -102,7 +134,9 @@ pub(super) fn residual_entry_imports_for_moved_body(
     if imports.is_empty() {
         return Ok(Vec::new());
     }
-    let resolved = disambiguate_residual_entry_import_locals(&imports, occupied, renames);
+    let mut minted = BTreeMap::new();
+    let resolved = disambiguate_residual_entry_import_locals(&imports, occupied, &mut minted);
+    sink.submit(minted, RESIDUAL_ENTRY_IMPORT_CONTRIBUTOR);
     Ok(vec![import_decl_for_plan(from_file, entry_file, &resolved)])
 }
 

--- a/devinfra/js/debundle/lowering/lower.rs
+++ b/devinfra/js/debundle/lowering/lower.rs
@@ -10,6 +10,7 @@ use rayon::prelude::*;
 use swc_common::GLOBALS;
 use swc_common::{BytePos, Spanned};
 
+use super::chunk_renames::CHUNK_RENAMES_CONTRIBUTOR;
 use super::import_emit::{
     disambiguate_import_locals, import_decl_for_plan, preserve_export_specifier_names,
     relative_source,
@@ -18,6 +19,8 @@ use super::scope_names::{collect_local_binding_names, collect_occupied_local_nam
 use super::util::{is_valid_js_identifier, remaining_item_after_selection};
 use super::*;
 use crate::time_phase;
+
+pub(super) const ENTRY_IMPORT_LOCAL_CONTRIBUTOR: &str = "entry import-local disambiguation";
 
 const LOWERING_FILE_PRAGMA: &str =
     "// @ducktape-generated kind=lowerer-helper stage=selected_module_lowering ignore=detectors";
@@ -188,13 +191,21 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
     let build_entry_imports_started = Instant::now();
     let mut entry_imports: Vec<(ModuleId, ModuleItem)> = Vec::new();
     let mut occupied = collect_occupied_local_names(&entry_body);
-    let mut body_renames = BTreeMap::<String, String>::new();
-    // Seed body_renames with `chunk_renames` entries for bindings
-    // staying in entry's body (not claimed by any logical module).
-    // Bindings owned by a logical module take their rename from the
-    // module plan via the disambiguate-imports pass below;
-    // chunk_renames entries for those bindings are silently
-    // dropped here (the logical-module rename wins).
+    // Entry-body renames flow through a dedicated ledger: the accepted
+    // chunk_renames entries (Explicit) and the entry import-local mints
+    // (ImportInduced) submit Chunk-scope intents below; the sealed
+    // projection is the `body_renames` map the entry renamer applies.
+    // The two contributors' source sets are disjoint by construction —
+    // chunk_renames seeding skips module-owned bindings, mints fire only
+    // for module-owned bindings — so a seal conflict can only come from
+    // one contributor disagreeing with itself.
+    let mut entry_ledger = RenameLedger::default();
+    // Submit `chunk_renames` intents for bindings staying in entry's
+    // body (not claimed by any logical module). Bindings owned by a
+    // logical module take their rename from the module plan via the
+    // disambiguate-imports pass below; chunk_renames entries for those
+    // bindings are silently dropped here (the logical-module rename
+    // wins).
     //
     // Each accepted target name is reserved in `occupied` before the
     // import-disambiguation pass runs, so a later cross-module
@@ -211,13 +222,12 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
         renamed_away.insert(binding.clone());
     }
     // Iterate `chunk_renames` (a `HashMap`) in sorted order so the
-    // collected error list and the `body_renames` insertion order
-    // are stable. Collect every violation rather than `bail!`ing on
-    // the first one so a spec author sees the full set in one
-    // round-trip; the "duplicate target" branch in particular only
-    // surfaces after `occupied.insert` returned false, so the
-    // earlier-rename whose target was duplicated is implied by the
-    // sort order.
+    // collected error list and the ledger's intent order are stable.
+    // Collect every violation rather than `bail!`ing on the first one
+    // so a spec author sees the full set in one round-trip; the
+    // "duplicate target" branch in particular only surfaces after
+    // `occupied.insert` returned false, so the earlier-rename whose
+    // target was duplicated is implied by the sort order.
     let mut sorted_renames: Vec<(&String, &String)> = chunk_renames.iter().collect();
     sorted_renames.sort_by(|a, b| a.0.cmp(b.0));
     let mut errors = Vec::<String>::new();
@@ -255,7 +265,14 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
             ));
             continue;
         }
-        body_renames.insert(binding.clone(), export_name.clone());
+        entry_ledger.submit(RenameIntent {
+            scope: RenameScope::Chunk,
+            from: top_level_id(binding, chunk_top_level_mark),
+            to: export_name.as_str().into(),
+            origin: RenameOrigin::Explicit {
+                contributor: CHUNK_RENAMES_CONTRIBUTOR,
+            },
+        });
     }
     if !errors.is_empty() {
         bail!("invalid chunk_renames spec:\n  - {}", errors.join("\n  - "));
@@ -302,7 +319,14 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
         for (local, fresh) in emit_renames {
             let local_id = top_level_id(&local, chunk_top_level_mark);
             if binding_assignment.get(&local_id).copied() == Some(module_index) {
-                body_renames.insert(local, fresh);
+                entry_ledger.submit(RenameIntent {
+                    scope: RenameScope::Chunk,
+                    from: local_id,
+                    to: fresh.as_str().into(),
+                    origin: RenameOrigin::ImportInduced {
+                        contributor: ENTRY_IMPORT_LOCAL_CONTRIBUTOR,
+                    },
+                });
             }
         }
         entry_imports.push((
@@ -324,6 +348,11 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
         .sort_entry_imports(&mut entry_imports);
     let entry_imports: Vec<ModuleItem> = entry_imports.into_iter().map(|(_, it)| it).collect();
     timings.add("build_entry_imports", build_entry_imports_started.elapsed());
+    // Seal the entry ledger: `body_renames` is its Chunk-scope projection
+    // — exactly the map the pre-ledger code accumulated inline across the
+    // chunk_renames seeding and the import-local mint loop above.
+    let sealed_entry_renames = entry_ledger.seal()?;
+    let body_renames = sealed_entry_renames.scope_renames_by_name(&RenameScope::Chunk);
     let entry_binding_renames = body_renames.clone();
     if !body_renames.is_empty() {
         let rename_entry_body_started = Instant::now();
@@ -387,7 +416,13 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
         for (index, plan) in module_plans.iter().enumerate() {
             let mut body = std::mem::take(&mut selected_by_module[index]);
             let plan_driven = sealed_renames.module_renames_by_name(ModuleId::logical(index));
-            let renames = naturalize_module_body(&mut body, plan, plan_driven)?;
+            let renames = naturalize_module_body(
+                &mut body,
+                plan,
+                ModuleId::logical(index),
+                plan_driven,
+                chunk_top_level_mark,
+            )?;
             naturalized_bodies.push(body);
             local_renames_by_module.push(renames);
         }
@@ -420,15 +455,39 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
             .iter()
             .flat_map(|item| top_level_declaration_names(item).0)
             .collect();
-        let auto_grow = auto_grown_residual_exports(
+        let mut export_ledger = RenameLedger::default();
+        auto_grown_residual_exports(
             &body_facts_by_module,
-            declaration_by_name,
-            binding_assignment,
-            pre_existing_entry_exports,
-            pre_existing_public_export_names,
-            &entry_binding_renames,
-            &entry_declared_names,
+            &ExportGrowthFacts {
+                declaration_by_name,
+                binding_assignment,
+                pre_existing_entry_exports,
+                pre_existing_public_export_names,
+                entry_renames: &entry_binding_renames,
+                entry_declared_names: &entry_declared_names,
+            },
+            chunk_top_level_mark,
+            &mut export_ledger,
         );
+        // The sealed map is keyed by the residual binding's original
+        // name; the emitted export clause is keyed by entry's
+        // post-rename local, so remap through `entry_binding_renames`
+        // at application. A single contributor over a set-deduped
+        // source set cannot produce a seal conflict.
+        let sealed_exports = export_ledger.seal()?;
+        let auto_grow: BTreeMap<String, String> = sealed_exports
+            .scope_renames_by_name(&RenameScope::EntryPublicExports)
+            .into_iter()
+            .map(|(original, public_name)| {
+                (
+                    entry_binding_renames
+                        .get(&original)
+                        .cloned()
+                        .unwrap_or(original),
+                    public_name,
+                )
+            })
+            .collect();
         if !auto_grow.is_empty() {
             entry_body.push(export_named_for_bindings(&auto_grow));
         }
@@ -712,7 +771,17 @@ fn lower_single_plan(
             },
         )
     });
-    let mut module_import_renames = BTreeMap::<String, String>::new();
+    // Import-local mints for this plan's body flow through a per-plan
+    // ledger (scope: this plan's `Module`, origin: `ImportInduced`);
+    // the sealed projection below is the rename map the body renamer
+    // applies.
+    let module = ModuleId::logical(index);
+    let mut import_ledger = RenameLedger::default();
+    let mut import_rename_sink = ImportLocalRenameSink {
+        module,
+        chunk_top_level_mark,
+        ledger: &mut import_ledger,
+    };
     let mut module_import_locals = collect_local_binding_names(&body);
     // All intra-chunk imports (cross-module binding imports, phantom
     // side-effect imports, and the residual-entry import) are
@@ -729,7 +798,7 @@ fn lower_single_plan(
             cross_module_imports_by_provider,
             factorization,
             &mut module_import_locals,
-            &mut module_import_renames,
+            &mut import_rename_sink,
         )
     });
     // Phantom side-effect imports surface at-init-promotion-derived
@@ -751,9 +820,13 @@ fn lower_single_plan(
             residual_entry_imports,
             missing_residual_exports,
             &mut module_import_locals,
-            &mut module_import_renames,
+            &mut import_rename_sink,
         )
     })?;
+    // Seal the per-plan import ledger; the Module-scope projection is
+    // the import-local rename map the pre-ledger code accumulated
+    // across the two minting passes above.
+    let module_import_renames = import_ledger.seal()?.module_renames_by_name(module);
     if !module_import_renames.is_empty() {
         let mut renamer = IdentifierRenamer::new(&module_import_renames);
         for item in body.iter_mut() {

--- a/devinfra/js/debundle/lowering/mod.rs
+++ b/devinfra/js/debundle/lowering/mod.rs
@@ -64,12 +64,13 @@ use chunk_ast::{
 };
 use chunk_renames::collect_chunk_renames;
 use exports::{
-    auto_grown_residual_exports, entry_exports_for_moved_bindings, export_named_for_bindings,
-    reject_duplicate_export_names, reject_duplicate_member_bindings, trim_dead_named_specifiers,
+    ExportGrowthFacts, auto_grown_residual_exports, entry_exports_for_moved_bindings,
+    export_named_for_bindings, reject_duplicate_export_names, reject_duplicate_member_bindings,
+    trim_dead_named_specifiers,
 };
 use imports_cross::{
-    collect_entry_exports_by_original_local, cross_module_imports_for_plan, final_module_exports,
-    phantom_side_effect_imports, residual_entry_imports_for_moved_body,
+    ImportLocalRenameSink, collect_entry_exports_by_original_local, cross_module_imports_for_plan,
+    final_module_exports, phantom_side_effect_imports, residual_entry_imports_for_moved_body,
 };
 use imports_runtime::{
     group_specifiers_into_import_decls, import_decl_module_item, resolve_imported_binding,

--- a/devinfra/js/debundle/lowering/naturalize.rs
+++ b/devinfra/js/debundle/lowering/naturalize.rs
@@ -21,13 +21,22 @@
 //! - **Bound sources** (destructured params, constructor
 //!   `this.x = param` assignments, return-object aliases of the
 //!   function's own root bindings) rename a binding owned by a single
-//!   scope. `ScopedHeuristicNaturalizer` validates and applies them per
+//!   scope. `ScopedHeuristicNaturalizer` derives and validates them per
 //!   deriving scope, with no module-global uniqueness requirement: two
 //!   sibling scopes reusing the same minified spelling (`e` → `value`
 //!   here, `e` → `registry` there) are independent renames (#2045).
 //!   They stay out of the returned map so a scope-local rename can
 //!   never remap an unrelated top-level export or runtime reimport
 //!   that happens to share the spelling.
+//!
+//! Both heuristic families submit intents into a per-module
+//! [`RenameLedger`] sealed before any heuristic rename is applied
+//! (free sources at `Module` scope, bound sources at `Function` scope);
+//! `SealedScopeRenameApplier` replays the sealed per-scope maps onto the
+//! real body, and the returned merged map is rebuilt from the sealed
+//! Module-scope intents.
+
+use swc_common::Span;
 
 use super::scope_names::{
     BindingNameCollector, collect_binding_names_in, collect_occupied_local_names,
@@ -79,6 +88,8 @@ pub(super) fn collect_plan_export_rename_intents(
 }
 
 pub(super) const PLAN_EXPORT_NAME_CONTRIBUTOR: &str = "logical_module member export_name";
+pub(super) const FREE_ALIAS_CONTRIBUTOR: &str = "return-object alias (free source)";
+pub(super) const SCOPED_HEURISTIC_CONTRIBUTOR: &str = "scope-local heuristic naturalizer";
 
 /// `plan_driven` is this plan's sealed Module-scope rename map
 /// (`SealedRenames::module_renames_by_name`); sorted (`BTreeMap`)
@@ -87,11 +98,37 @@ pub(super) const PLAN_EXPORT_NAME_CONTRIBUTOR: &str = "logical_module member exp
 pub(super) fn naturalize_module_body(
     body: &mut [ModuleItem],
     plan: &ModulePlan,
+    module: ModuleId,
     plan_driven: BTreeMap<String, String>,
+    chunk_top_level_mark: swc_common::Mark,
 ) -> Result<NaturalizedRenames> {
-    let mut free_heuristic = BTreeMap::<String, String>::new();
+    // Both heuristic contributors submit into this per-module ledger,
+    // sealed below before any heuristic rename is applied.
+    // `free_heuristic` is the derive-phase scratch view of the same
+    // Module-scope intents: the bound-source derive pass needs the
+    // module-global collision rules resolved before the ledger can seal
+    // (sealing also waits for the derive pass's Function-scope intents).
+    // Free aliases are submitted per deriving function, so two functions
+    // aliasing one free source to different targets — previously a
+    // silent last-write-wins on this map — are a seal-time conflict.
+    let mut ledger = RenameLedger::default();
+    let mut per_function_free = Vec::<BTreeMap<String, String>>::new();
     for item in body.iter() {
-        collect_free_alias_renames_from_item(item, &mut free_heuristic);
+        collect_free_alias_renames_from_item(item, &mut per_function_free);
+    }
+    let mut free_heuristic = BTreeMap::<String, String>::new();
+    for aliases in per_function_free {
+        for (from, to) in aliases {
+            ledger.submit(RenameIntent {
+                scope: RenameScope::Module(module),
+                from: top_level_id(&from, chunk_top_level_mark),
+                to: to.as_str().into(),
+                origin: RenameOrigin::Heuristic {
+                    contributor: FREE_ALIAS_CONTRIBUTOR,
+                },
+            });
+            free_heuristic.insert(from, to);
+        }
     }
     // The merged map is what callers read back as the local-name → readable
     // lookup (runtime-reimport bridge, export remapping). Plan-driven names
@@ -170,30 +207,57 @@ pub(super) fn naturalize_module_body(
         reserved.insert(from.clone());
         reserved.insert(to.clone());
     }
-    let mut scoped = ScopedHeuristicNaturalizer {
+    // Derive pass: run the scoped heuristic machinery over a scratch
+    // clone of the body. It performs exactly the pre-ledger
+    // derive-and-apply walk — outer scopes validate against subtrees
+    // that already carry their nested scopes' renames — but the
+    // mutations land on the clone; the real body is only renamed by the
+    // sealed-output applier below. Each fired per-scope map is submitted
+    // as Function-scope intents. The clone is deleted with PR 4's
+    // execute-once pass.
+    let mut derive_body = body.to_vec();
+    let mut deriver = ScopedHeuristicNaturalizer {
         free_allowed: &free_effective,
         reserved: &reserved,
+        ledger: &mut ledger,
     };
+    for item in derive_body.iter_mut() {
+        item.visit_mut_with(&mut deriver);
+    }
+    let sealed = ledger.seal()?;
+    // Apply pass: replay the sealed per-scope maps onto the real body in
+    // the same order the derive pass fired them (children first), so each
+    // scope's map applies to the same intermediate tree state the
+    // derivation validated against.
+    let mut applier = SealedScopeRenameApplier { sealed: &sealed };
     for item in body.iter_mut() {
-        item.visit_mut_with(&mut scoped);
+        item.visit_mut_with(&mut applier);
     }
 
     Ok(NaturalizedRenames {
-        merged,
+        // The merged map consumers read is rebuilt from the sealed
+        // Module-scope (free-source) intents — identical to the derive
+        // scratch `merged` whenever seal succeeded.
+        merged: drop_target_collisions(plan_driven, sealed.module_renames_by_name(module)),
         module_scope: plan_driven_effective,
     })
 }
 
-/// Walks the module body and applies heuristic naturalization renames
-/// scope-locally: at each function/constructor/arrow it derives that node's
-/// own heuristic renames (param destructure aliases, return-object aliases,
-/// `this.x = param` constructor assignments) and rewrites only that node's
-/// subtree. Bound-source renames fire when their readable target passes the
-/// per-scope safety checks in [`Self::validated_bound`]; free-source
-/// renames fire when they survived the module-global collision rules
-/// (`free_allowed`). A rename derived from one scope never leaks into a
-/// sibling/parent scope, and `RenameAndShorthandNaturalizer`'s nested
-/// shadow-suppression still guards any further-nested re-binding subtree.
+/// The derive pass of the per-scope heuristic pipeline: walks a scratch
+/// clone of the module body and, at each function/constructor/arrow,
+/// derives that node's own heuristic renames (param destructure aliases,
+/// return-object aliases, `this.x = param` constructor assignments),
+/// validates them, submits the fired map as Function-scope intents, and
+/// rewrites the (clone's) subtree so enclosing scopes validate against
+/// the post-rename nested state — exactly the pre-ledger
+/// derive-and-apply order. Bound-source renames fire when their readable
+/// target passes the per-scope safety checks in [`Self::validated_bound`];
+/// free-source renames fire when they survived the module-global
+/// collision rules (`free_allowed`). A rename derived from one scope
+/// never leaks into a sibling/parent scope, and
+/// `RenameAndShorthandNaturalizer`'s nested shadow-suppression still
+/// guards any further-nested re-binding subtree. The real body is
+/// renamed by [`SealedScopeRenameApplier`] from the sealed ledger.
 struct ScopedHeuristicNaturalizer<'a> {
     /// Free-source renames that survived module-global collision-dropping;
     /// a node's locally-derived free alias only fires if it appears here.
@@ -201,6 +265,67 @@ struct ScopedHeuristicNaturalizer<'a> {
     /// Module-wide rename sources and targets (plan-driven + free); a
     /// scope-local rename must not target any of them.
     reserved: &'a BTreeSet<String>,
+    /// Sink for the fired per-scope maps (Function-scope intents).
+    ledger: &'a mut RenameLedger,
+}
+
+/// Replays the sealed Function-scope heuristic renames onto the real
+/// module body, children-first — the same order
+/// [`ScopedHeuristicNaturalizer`] fired them in on the derive clone, so
+/// each scope's map applies to the same intermediate tree state the
+/// derivation validated against.
+struct SealedScopeRenameApplier<'a> {
+    sealed: &'a SealedRenames,
+}
+
+impl SealedScopeRenameApplier<'_> {
+    fn scope_map(&self, span: Span) -> BTreeMap<String, String> {
+        self.sealed
+            .scope_renames_by_name(&RenameScope::Function(span.into()))
+    }
+}
+
+impl VisitMut for SealedScopeRenameApplier<'_> {
+    fn visit_mut_function(&mut self, function: &mut Function) {
+        function.visit_mut_children_with(self);
+        let local = self.scope_map(function.span);
+        if local.is_empty() {
+            return;
+        }
+        let mut renamer = RenameAndShorthandNaturalizer::new(&local);
+        function.params.visit_mut_with(&mut renamer);
+        rename_root_body(&mut renamer, function.body.as_mut());
+        assert_no_heuristic_capture(&renamer);
+    }
+
+    fn visit_mut_arrow_expr(&mut self, arrow: &mut ArrowExpr) {
+        arrow.visit_mut_children_with(self);
+        let local = self.scope_map(arrow.span);
+        if local.is_empty() {
+            return;
+        }
+        let mut renamer = RenameAndShorthandNaturalizer::new(&local);
+        arrow.params.visit_mut_with(&mut renamer);
+        match &mut *arrow.body {
+            BlockStmtOrExpr::BlockStmt(block) => rename_root_body(&mut renamer, Some(block)),
+            BlockStmtOrExpr::Expr(expr) => expr.visit_mut_with(&mut renamer),
+        }
+        assert_no_heuristic_capture(&renamer);
+    }
+
+    fn visit_mut_constructor(&mut self, constructor: &mut Constructor) {
+        constructor.visit_mut_children_with(self);
+        let local = self.scope_map(constructor.span);
+        if local.is_empty() {
+            return;
+        }
+        let mut renamer = RenameAndShorthandNaturalizer::new(&local);
+        for param in &mut constructor.params {
+            param.visit_mut_with(&mut renamer);
+        }
+        rename_root_body(&mut renamer, constructor.body.as_mut());
+        assert_no_heuristic_capture(&renamer);
+    }
 }
 
 /// Name sets describing one function-like subtree, gathered in a single
@@ -326,6 +451,25 @@ fn collect_pat_binding_names(pat: &Pat, out: &mut BTreeSet<String>) {
 }
 
 impl ScopedHeuristicNaturalizer<'_> {
+    /// Record one deriving scope's fired rename map as Function-scope
+    /// intents. The sources are function-local bindings whose hygiene
+    /// context the string-keyed derivation never resolves; the
+    /// string-era key is encoded as the empty `SyntaxContext` (the
+    /// sealed by-name projection is what the apply pass consumes; see
+    /// the ledger module doc's hygiene-boundary section).
+    fn submit_scope_intents(&mut self, span: Span, local: &BTreeMap<String, String>) {
+        for (from, to) in local {
+            self.ledger.submit(RenameIntent {
+                scope: RenameScope::Function(span.into()),
+                from: (from.as_str().into(), SyntaxContext::empty()),
+                to: to.as_str().into(),
+                origin: RenameOrigin::Heuristic {
+                    contributor: SCOPED_HEURISTIC_CONTRIBUTOR,
+                },
+            });
+        }
+    }
+
     /// Per-scope safety checks for bound-source renames. A rename fires
     /// only when its readable target is globally unreserved, absent from
     /// the scope's subtree (renaming onto a name the subtree already
@@ -460,6 +604,7 @@ impl VisitMut for ScopedHeuristicNaturalizer<'_> {
         if local.is_empty() {
             return;
         }
+        self.submit_scope_intents(function.span, &local);
         // Params and the root body share this function's scope, where the
         // renamed name is bound exactly once and every reference resolves to
         // it. Drive past the root param/block scope (visiting params and the
@@ -482,6 +627,7 @@ impl VisitMut for ScopedHeuristicNaturalizer<'_> {
         if local.is_empty() {
             return;
         }
+        self.submit_scope_intents(arrow.span, &local);
         let mut renamer = RenameAndShorthandNaturalizer::new(&local);
         arrow.params.visit_mut_with(&mut renamer);
         match &mut *arrow.body {
@@ -500,6 +646,7 @@ impl VisitMut for ScopedHeuristicNaturalizer<'_> {
         if local.is_empty() {
             return;
         }
+        self.submit_scope_intents(constructor.span, &local);
         let mut renamer = RenameAndShorthandNaturalizer::new(&local);
         for param in &mut constructor.params {
             param.visit_mut_with(&mut renamer);
@@ -548,26 +695,36 @@ pub(super) fn drop_target_collisions(
 /// of names the deriving function does not bind anywhere (typically
 /// source-chunk import aliases). These are the only heuristic renames
 /// that rewrite references of top-level bindings and therefore the only
-/// ones that join the module-global merged map.
-fn collect_free_alias_renames_from_item(item: &ModuleItem, renames: &mut BTreeMap<String, String>) {
+/// ones that join the module-global merged map. Each deriving function's
+/// aliases are pushed as a separate map so the caller can submit them as
+/// per-function ledger intents.
+fn collect_free_alias_renames_from_item(
+    item: &ModuleItem,
+    per_function: &mut Vec<BTreeMap<String, String>>,
+) {
     match item {
-        ModuleItem::Stmt(Stmt::Decl(decl)) => collect_free_alias_renames_from_decl(decl, renames),
+        ModuleItem::Stmt(Stmt::Decl(decl)) => {
+            collect_free_alias_renames_from_decl(decl, per_function)
+        }
         ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(export_decl)) => {
-            collect_free_alias_renames_from_decl(&export_decl.decl, renames);
+            collect_free_alias_renames_from_decl(&export_decl.decl, per_function);
         }
         _ => {}
     }
 }
 
-fn collect_free_alias_renames_from_decl(decl: &Decl, renames: &mut BTreeMap<String, String>) {
+fn collect_free_alias_renames_from_decl(
+    decl: &Decl,
+    per_function: &mut Vec<BTreeMap<String, String>>,
+) {
     match decl {
         Decl::Fn(function) => {
-            collect_free_alias_renames_from_function(&function.function, renames);
+            collect_free_alias_renames_from_function(&function.function, per_function);
         }
         Decl::Var(var) => {
             for declarator in &var.decls {
                 if let Some(Expr::Fn(function)) = declarator.init.as_deref() {
-                    collect_free_alias_renames_from_function(&function.function, renames);
+                    collect_free_alias_renames_from_function(&function.function, per_function);
                 }
             }
         }
@@ -577,7 +734,7 @@ fn collect_free_alias_renames_from_decl(decl: &Decl, renames: &mut BTreeMap<Stri
 
 fn collect_free_alias_renames_from_function(
     function: &Function,
-    renames: &mut BTreeMap<String, String>,
+    per_function: &mut Vec<BTreeMap<String, String>>,
 ) {
     let Some(body) = function.body.as_ref() else {
         return;
@@ -588,10 +745,12 @@ fn collect_free_alias_renames_from_function(
         return;
     }
     let facts = collect_subtree_name_facts(function);
-    for (from, to) in aliases {
-        if !facts.bound.contains(&from) {
-            renames.insert(from, to);
-        }
+    let renames: BTreeMap<String, String> = aliases
+        .into_iter()
+        .filter(|(from, _)| !facts.bound.contains(from))
+        .collect();
+    if !renames.is_empty() {
+        per_function.push(renames);
     }
 }
 

--- a/devinfra/js/debundle/lowering/rename_ledger.rs
+++ b/devinfra/js/debundle/lowering/rename_ledger.rs
@@ -27,6 +27,20 @@
 //! `ChunkPlan`); the contract becomes mechanically enforceable when the
 //! execute-once pass lands (PR 4) and non-execute passes take `&Module`.
 //!
+//! ## Seal points (PR 2 era)
+//!
+//! Contributor derivation is interleaved with application across the
+//! lowering pipeline — a later contributor derives from the AST state an
+//! earlier contributor's application produced (heuristics read the
+//! post-plan-rename body; import-local minting reads the post-naturalize
+//! body) — so PR 2 seals at phase boundaries: each former private rename
+//! map is its own ledger instance, collected and sealed exactly where
+//! that map used to be complete, with the application site consuming the
+//! sealed projection. The instances are listed in the contributor
+//! inventory below. PR 3 (minting as a ledger service, seal-time
+//! occupancy validation) and PR 4 (execute once) collapse them toward a
+//! single collect → seal → execute pass.
+//!
 //! ## Hygiene boundary
 //!
 //! Intents are keyed by hygiene-aware [`Id`] — post-#2042 the chunk AST
@@ -39,45 +53,53 @@
 //! a sym within one scope. PR 4's executor consumes `Id`s directly and
 //! deletes the projection.
 //!
+//! `Function`-scope heuristic sources are function-local bindings whose
+//! hygiene context the string-keyed derivation never resolves; they are
+//! keyed by `(sym, SyntaxContext::empty())` until PR 4's executor keys
+//! application by real `Id`s. Within one function scope a sym maps to at
+//! most one rename, so the empty-context encoding cannot collide.
+//!
 //! ## Contributor inventory
 //!
-//! Converted (submit intents):
+//! All rename contributors submit intents (PR 2):
 //!
 //! - Spec `chunk_renames` — `chunk_renames.rs::collect_chunk_renames`
-//!   (scope: `Chunk`, origin: `Explicit`).
+//!   (scope: `Chunk`, origin: `Explicit`; chunk ledger sealed in
+//!   `materialize_logical_chunk`).
 //! - Plan-driven spec `export_name`s —
 //!   `naturalize.rs::collect_plan_export_rename_intents` (scope:
-//!   `Module`, origin: `Explicit`).
-//!
-//! Remaining (PR 2 worklist; each keeps building its own map today):
-//!
+//!   `Module`, origin: `Explicit`; same chunk ledger).
 //! - Heuristic bound-source scope-local renames — `naturalize.rs`:
 //!   `collect_naturalization_renames_from_pattern`,
 //!   `collect_naturalization_renames_from_constructor`, and root-bound
-//!   return-object aliases, derived and applied per function-like node by
-//!   `ScopedHeuristicNaturalizer::{visit_mut_function, visit_mut_arrow_expr,
-//!   visit_mut_constructor}` (scope: `Function`, origin: `Heuristic`).
+//!   return-object aliases, derived per function-like node by
+//!   `ScopedHeuristicNaturalizer` over a scratch clone of the module body
+//!   (scope: `Function`, origin: `Heuristic`); the per-module ledger seals
+//!   in `naturalize_module_body` and `SealedScopeRenameApplier` replays
+//!   the sealed per-scope maps onto the real body.
 //! - Heuristic free-source return-object aliases — `naturalize.rs`:
-//!   `collect_free_alias_renames_from_item`, merged module-wide via
-//!   `drop_target_collisions` (scope: `Module`, origin: `Heuristic`).
+//!   `collect_free_alias_renames_from_item`, submitted per deriving
+//!   function (scope: `Module`, origin: `Heuristic`; same per-module
+//!   ledger). The module-global target-collision rule
+//!   (`drop_target_collisions`) still runs at application; moving it into
+//!   seal is PR 3.
 //! - Import-local disambiguation (fresh-local `$N` minting) —
 //!   `import_emit.rs`: `disambiguate_import_locals`,
-//!   `disambiguate_residual_entry_import_locals`, `mint_unique_name`;
-//!   entry-side call site in `lower.rs` (entry-import build seeding
-//!   `body_renames`), module-side call sites in
-//!   `imports_cross.rs::cross_module_imports_for_plan` and
-//!   `imports_cross.rs::residual_entry_imports_for_moved_body` (scope:
-//!   `Chunk` / `Module`, origin: `ImportInduced`). Minting becomes a
-//!   ledger service in PR 3; decided 2026-06: the `$N` suffix scheme
-//!   stays as-is (readability is a later naturalizer concern).
-//! - Cross-module rename application to moved bodies — the
-//!   `module_import_renames` map accumulated across the two
-//!   `imports_cross.rs` helpers above and applied in
-//!   `lower.rs::lower_single_plan` (origin: `ImportInduced`).
+//!   `disambiguate_residual_entry_import_locals`, `mint_unique_name`.
+//!   The entry-side call site in `lower.rs::lower_chunk` submits into the
+//!   entry-body ledger (scope: `Chunk`, origin: `ImportInduced`); the
+//!   module-side call sites `imports_cross.rs::cross_module_imports_for_plan`
+//!   and `imports_cross.rs::residual_entry_imports_for_moved_body` submit
+//!   into the per-plan import ledger sealed in `lower_single_plan`
+//!   (scope: `Module`, origin: `ImportInduced`) — this is the
+//!   cross-module rename application to moved bodies. Minting itself
+//!   becomes a ledger service in PR 3; decided 2026-06: the `$N` suffix
+//!   scheme stays as-is (readability is a later naturalizer concern).
 //! - Collision-resolving public-name minting —
 //!   `exports.rs::auto_grown_residual_exports` (suffix-mints a grown
-//!   public export past pre-existing public names; origin:
-//!   `ImportInduced`).
+//!   public export past pre-existing public names; scope:
+//!   `EntryPublicExports`, origin: `ImportInduced`; sealed in
+//!   `lower_chunk`'s export-growth phase).
 //!
 //! Vendor boundary renames (`vendor/`) run in a separate pipeline stage on
 //! different artifacts and are out of this ledger's scope.
@@ -126,6 +148,12 @@ pub enum RenameScope {
     Module(ModuleId),
     /// Scope-local renames derived by one function-like node.
     Function(FunctionScopeId),
+    /// Public export-name allocations on the chunk's residual entry — a
+    /// separate namespace from local-binding renames: `from` is the
+    /// residual binding's top-level `Id`, `to` the public name entry's
+    /// grown `export { … }` clause assigns it
+    /// (`exports.rs::auto_grown_residual_exports`).
+    EntryPublicExports,
 }
 
 impl fmt::Display for RenameScope {
@@ -134,6 +162,7 @@ impl fmt::Display for RenameScope {
             RenameScope::Chunk => write!(f, "chunk scope"),
             RenameScope::Module(ModuleId(index)) => write!(f, "module #{}", index.0),
             RenameScope::Function(span) => write!(f, "function@{}..{}", span.lo, span.hi),
+            RenameScope::EntryPublicExports => write!(f, "entry public exports"),
         }
     }
 }
@@ -320,9 +349,11 @@ impl SealedRenames {
     /// Project one scope's sealed renames onto bare syms for the
     /// string-keyed application visitors. Lossy iff two hygiene contexts
     /// share a sym within one scope — the current contributors resolve
-    /// every `from` through one chunk-top-level context, so that cannot
-    /// happen; assert rather than silently merge if it ever does.
-    fn scope_renames_by_name(&self, scope: &RenameScope) -> BTreeMap<String, String> {
+    /// every `from` through one context per scope (chunk-top-level for
+    /// `Chunk`/`Module`/`EntryPublicExports`, the string-era empty context
+    /// for `Function`), so that cannot happen; assert rather than silently
+    /// merge if it ever does.
+    pub fn scope_renames_by_name(&self, scope: &RenameScope) -> BTreeMap<String, String> {
         let Some(renames) = self.by_scope.get(scope) else {
             return BTreeMap::new();
         };
@@ -503,6 +534,80 @@ mod tests {
             reverse.submit(i.clone());
         }
         assert_eq!(forward.seal().unwrap(), reverse.seal().unwrap());
+    }
+
+    #[test]
+    fn entry_public_exports_scope_is_isolated_from_chunk_scope() {
+        // The export-name namespace is separate from local-binding
+        // renames: one binding may simultaneously carry a Chunk-scope
+        // local rename and an EntryPublicExports-scope public-name
+        // allocation without conflicting.
+        let mint = RenameOrigin::ImportInduced {
+            contributor: "auto-grown residual export",
+        };
+        let mut ledger = RenameLedger::default();
+        ledger.submit(intent(RenameScope::Chunk, "a", "readable", A));
+        ledger.submit(intent(RenameScope::EntryPublicExports, "a", "a$1", mint));
+        let sealed = ledger.seal().unwrap();
+        assert_eq!(
+            sealed.scope_renames_by_name(&RenameScope::Chunk),
+            BTreeMap::from([("a".to_string(), "readable".to_string())]),
+        );
+        assert_eq!(
+            sealed.scope_renames_by_name(&RenameScope::EntryPublicExports),
+            BTreeMap::from([("a".to_string(), "a$1".to_string())]),
+        );
+    }
+
+    #[test]
+    fn import_induced_conflict_is_a_hard_error_naming_both_minters() {
+        let cross = RenameOrigin::ImportInduced {
+            contributor: "cross-module import-local disambiguation",
+        };
+        let residual = RenameOrigin::ImportInduced {
+            contributor: "residual-entry import-local disambiguation",
+        };
+        let module = RenameScope::Module(ModuleId::logical(0));
+        let mut ledger = RenameLedger::default();
+        ledger.submit(intent(module, "x", "x$1", cross));
+        ledger.submit(intent(module, "x", "x$2", residual));
+        let message = ledger.seal().unwrap_err().to_string();
+        assert!(
+            message.contains("cross-module import-local disambiguation"),
+            "{message}"
+        );
+        assert!(
+            message.contains("residual-entry import-local disambiguation"),
+            "{message}"
+        );
+    }
+
+    #[test]
+    fn function_scope_projection_returns_per_scope_string_maps() {
+        let heuristic = RenameOrigin::Heuristic {
+            contributor: "scope-local heuristic naturalizer",
+        };
+        let outer = RenameScope::Function(FunctionScopeId { lo: 1, hi: 100 });
+        let inner = RenameScope::Function(FunctionScopeId { lo: 10, hi: 20 });
+        let mut ledger = RenameLedger::default();
+        // Sibling/nested scopes reusing one minified spelling with
+        // different targets are independent renames (#2045) — no conflict.
+        ledger.submit(intent(outer, "e", "value", heuristic));
+        ledger.submit(intent(inner, "e", "registry", heuristic));
+        let sealed = ledger.seal().unwrap();
+        assert_eq!(
+            sealed.scope_renames_by_name(&outer),
+            BTreeMap::from([("e".to_string(), "value".to_string())]),
+        );
+        assert_eq!(
+            sealed.scope_renames_by_name(&inner),
+            BTreeMap::from([("e".to_string(), "registry".to_string())]),
+        );
+        assert!(
+            sealed
+                .scope_renames_by_name(&RenameScope::Function(FunctionScopeId { lo: 2, hi: 3 }))
+                .is_empty()
+        );
     }
 
     #[test]


### PR DESCRIPTION
Track B PR 2 of the rename-pipeline ladder (sanitization program, follows #2086): every remaining rename contributor now **submits `RenameIntent`s** into a `RenameLedger` instead of building a private map, and every application site **consumes a sealed projection**. Zero behavior change — the rename-pinning e2e suite passes unchanged (100/100, no fixture edits).

## Contributors converted

| Contributor | Scope / origin | Collection | Seal point |
|---|---|---|---|
| Heuristic bound-source per-scope renames (#2057 machinery: param destructures, constructor `this.x = param`, root-bound return-object aliases) | `Function(span)` / `Heuristic` | `ScopedHeuristicNaturalizer` becomes the derive pass over a scratch clone of the module body | per-module ledger in `naturalize_module_body` |
| Heuristic free-source return-object aliases | `Module` / `Heuristic`, submitted per deriving function | `collect_free_alias_renames_from_item` | same per-module ledger |
| Entry-side import-local `$N` mints + accepted `chunk_renames` entries | `Chunk` / `ImportInduced` + `Explicit` | entry-import build in `lower_chunk` | entry ledger sealed before the entry-body renamer |
| Module-side import-local mints (cross-module + residual-entry) | `Module` / `ImportInduced` | `ImportLocalRenameSink` threaded through the two `imports_cross.rs` helpers | per-plan ledger sealed in `lower_single_plan` |
| Auto-grown residual public-export minting | new **`EntryPublicExports`** scope / `ImportInduced` | `exports.rs::auto_grown_residual_exports` | export ledger in `lower_chunk`'s export-growth phase |

Per the PR-2 contract: `$N` minting itself stays in `import_emit.rs` (ledger service in PR 3), and the free-source `drop_target_collisions` rule still runs at application (moves into seal in PR 3).

## Per-scope heuristic application semantics preserved exactly

The pre-ledger scoped pass derived and applied in one walk, with outer scopes validating against subtrees that already carried their nested scopes' renames. To keep that exact semantics while making application consume sealed output:

- **Derive pass** = the unmodified pre-ledger walk, run on a scratch clone; each fired per-scope map (post-validation, exactly what the old code applied) is submitted as `Function`-scope intents keyed by the node's span.
- **Apply pass** (`SealedScopeRenameApplier`) replays the sealed per-scope maps onto the real body children-first — the same order the derive pass fired them — using the same `RenameAndShorthandNaturalizer` mechanics and capture assert.

The clone is a PR-2 transitional cost, deleted with PR 4's execute-once pass.

## Seal points (phase-boundary ledgers)

Contributor derivation is interleaved with application (heuristics read the post-plan-rename body; import minting reads the post-naturalize body), so a single chunk-wide collect-then-seal isn't reachable until PRs 3–4. PR 2 therefore seals at phase boundaries: one ledger instance per former private map, collected and sealed exactly where that map used to be complete. The new "Seal points" section in `rename_ledger.rs`'s module doc records the instances; PRs 3–4 collapse them.

## By-construction equivalence argument

- Each ledger instance is collected at the exact program point where the old private map was complete, from the same derivation code, submitting the same post-validation decisions the old code inserted.
- Within each instance, contributor source-sets are disjoint (entry ledger: chunk_renames skips module-owned bindings, mints fire only for module-owned ones; per-plan ledger: cross-module vs residual-entry bindings partition by `binding_assignment`) or set-deduped (auto-grow's `needed` set; one map per function scope) — so seal resolves every group to the single proposed target and `scope_renames_by_name` reproduces the old map verbatim.
- The heuristic derive pass is the old pass on an identical tree; the applier replays its recorded maps in the same order onto the same intermediate states, so the final body is identical by induction.
- `merged` / `module_scope` / `entry_binding_renames` / `auto_grow` are rebuilt from sealed projections and equal their pre-ledger values whenever seal succeeds.

## Seal strictness

Two shapes that previously last-wrote silently are now seal-time hard errors (real prior badness the ledger exists to catch):

1. two deriving functions free-aliasing one source binding to different targets;
2. two import-local mints disagreeing on one binding (e.g. one original minted differently by two providers).

No existing test exercises either shape, so nothing needed updating and **no strictness deferrals to PR 3 were necessary**.

## Misc

- `RenameScope::EntryPublicExports` added (export-name namespace is separate from local-binding renames); `SealedRenames::scope_renames_by_name` made public as the generic projection query.
- `Function`-scope intents use `(sym, SyntaxContext::empty())` keys — function-local bindings have no resolvable context in the string-keyed era; documented in the hygiene-boundary section, fixed by PR 4's `Id`-keyed executor.
- Ledger unit tests added: `EntryPublicExports` isolation, import-induced mint conflicts naming both minters, per-scope `Function` projections.
- Module-doc inventory updated (all contributors converted); TODO.md ladder advanced (PR 2 landed, PR 3 scope grew the per-phase-ledger collapse).

Tests: `bbr test //devinfra/js/debundle/...` — 100/100 green.
`BAZEL_TEST_INVOCATIONS=buildbuddy:2d8a3bca-4e87-469f-8a7b-3fa4cf90f548`

https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk)_