### PR TITLE
Fix Tana LiteLLM streamed tool call merging

### DIFF
--- a/tana/litellm_proxy/provider.py
+++ b/tana/litellm_proxy/provider.py
@@ -877,117 +877,174 @@ def _parse_tana_response(response: httpx.Response) -> TanaChatResult:
 
 
 def _parse_tana_stream_lines(lines: Iterator[str]) -> Iterator[GenericStreamingChunk]:
+    parser = _TanaStreamParser()
     for line in lines:
-        yield from _parse_tana_stream_line(line)
+        yield from parser.parse_line(line)
+    yield from parser.finish()
 
 
 async def _parse_tana_stream_lines_async(lines: AsyncIterator[str]) -> AsyncIterator[GenericStreamingChunk]:
+    parser = _TanaStreamParser()
     async for line in lines:
-        for chunk in _parse_tana_stream_line(line):
+        for chunk in parser.parse_line(line):
             yield chunk
+    for chunk in parser.finish():
+        yield chunk
 
 
 def _parse_tana_stream_line(line: str) -> list[GenericStreamingChunk]:
-    stripped = line.strip()
-    if not stripped:
+    parser = _TanaStreamParser()
+    chunks = parser.parse_line(line)
+    chunks.extend(parser.finish())
+    return chunks
+
+
+class _TanaStreamParser:
+    def __init__(self) -> None:
+        self._pending_tool_calls: dict[str, dict[str, Any]] = {}
+
+    def parse_line(self, line: str) -> list[GenericStreamingChunk]:
+        return self._parse_line(line)
+
+    def finish(self) -> list[GenericStreamingChunk]:
+        return self._flush_tool_call_chunks()
+
+    def _parse_line(self, line: str) -> list[GenericStreamingChunk]:
+        stripped = line.strip()
+        if not stripped:
+            return []
+
+        if stripped.startswith("data:"):
+            payload = stripped.removeprefix("data:").strip()
+            if payload == "[DONE]":
+                return []
+            try:
+                data = json.loads(payload)
+            except json.JSONDecodeError:
+                return []
+            if isinstance(data, Mapping):
+                return self._stream_chunks_from_event(data)
+            return []
+
+        if stripped.startswith(("d:", "e:")):
+            try:
+                data = json.loads(stripped[2:])
+            except json.JSONDecodeError:
+                return []
+            if not isinstance(data, Mapping):
+                return []
+            tool_chunks = self._flush_tool_call_chunks()
+            finish_reason = _stream_finish_reason(str(data.get("finishReason") or "stop"), bool(tool_chunks))
+            return [
+                *tool_chunks,
+                _stream_chunk(is_finished=True, finish_reason=finish_reason, usage=_normalize_stream_usage(data)),
+            ]
+
+        if stripped.startswith("0:"):
+            try:
+                text = json.loads(stripped[2:])
+            except json.JSONDecodeError:
+                return []
+            if isinstance(text, str) and text:
+                return [_stream_chunk(text=text)]
+
         return []
 
-    if stripped.startswith("data:"):
-        payload = stripped.removeprefix("data:").strip()
-        if payload == "[DONE]":
-            return []
-        try:
-            data = json.loads(payload)
-        except json.JSONDecodeError:
-            return []
-        if isinstance(data, Mapping):
-            return _stream_chunks_from_event(data)
-        return []
+    def _stream_chunks_from_event(self, data: Mapping[str, Any]) -> list[GenericStreamingChunk]:
+        event_type = data.get("type")
+        chunks: list[GenericStreamingChunk] = []
+        emitted_tools = False
 
-    if stripped.startswith(("d:", "e:")):
-        try:
-            data = json.loads(stripped[2:])
-        except json.JSONDecodeError:
-            return []
-        if not isinstance(data, Mapping):
-            return []
-        finish_reason = str(data.get("finishReason") or "stop")
-        return [_stream_chunk(is_finished=True, finish_reason=finish_reason, usage=_normalize_stream_usage(data))]
+        if event_type == "text-delta":
+            delta = data.get("delta")
+            if isinstance(delta, str) and delta:
+                chunks.append(_stream_chunk(text=delta))
 
-    if stripped.startswith("0:"):
-        try:
-            text = json.loads(stripped[2:])
-        except json.JSONDecodeError:
-            return []
-        if isinstance(text, str) and text:
-            return [_stream_chunk(text=text)]
+        if event_type in {"tool-input-available", "tool-input-error"}:
+            self._remember_tool_calls([data])
+            emitted_tools = True
 
-    return []
+        if event_type == "error":
+            error_text = data.get("errorText") or data.get("message") or data.get("error")
+            raise TanaProxyError(f"Tana streaming error: {error_text or json.dumps(data, ensure_ascii=False)}")
 
-
-def _stream_chunks_from_event(data: Mapping[str, Any]) -> list[GenericStreamingChunk]:
-    event_type = data.get("type")
-    chunks: list[GenericStreamingChunk] = []
-    emitted_tools = False
-
-    if event_type == "text-delta":
-        delta = data.get("delta")
-        if isinstance(delta, str) and delta:
-            chunks.append(_stream_chunk(text=delta))
-
-    if event_type in {"tool-input-available", "tool-input-error"}:
-        chunks.extend(_tool_call_stream_chunks([data]))
-        emitted_tools = True
-
-    if event_type == "error":
-        error_text = data.get("errorText") or data.get("message") or data.get("error")
-        raise TanaProxyError(f"Tana streaming error: {error_text or json.dumps(data, ensure_ascii=False)}")
-
-    if event_type == "finish":
-        message_metadata = data.get("messageMetadata")
-        if isinstance(message_metadata, Mapping):
-            chunks.extend(_tool_call_stream_chunks(message_metadata.get("toolCalls")))
-            provider_fields: dict[str, Any] = {}
-            _copy_if_set(message_metadata, provider_fields, "providerMetadata", "tana_providerMetadata")
-            _copy_if_set(message_metadata, provider_fields, "warnings", "tana_warnings")
-            _copy_if_set(message_metadata, provider_fields, "response", "tana_response")
-            finish_reason = str(data.get("finishReason") or message_metadata.get("finishReason") or "stop")
-            chunks.append(
-                _stream_chunk(
-                    is_finished=True,
-                    finish_reason=finish_reason,
-                    usage=_normalize_stream_usage(message_metadata),
-                    provider_specific_fields=provider_fields or None,
+        if event_type == "finish":
+            message_metadata = data.get("messageMetadata")
+            if isinstance(message_metadata, Mapping):
+                self._remember_tool_calls(message_metadata.get("toolCalls"))
+                tool_chunks = self._flush_tool_call_chunks()
+                chunks.extend(tool_chunks)
+                provider_fields: dict[str, Any] = {}
+                _copy_if_set(message_metadata, provider_fields, "providerMetadata", "tana_providerMetadata")
+                _copy_if_set(message_metadata, provider_fields, "warnings", "tana_warnings")
+                _copy_if_set(message_metadata, provider_fields, "response", "tana_response")
+                finish_reason = _stream_finish_reason(
+                    str(data.get("finishReason") or message_metadata.get("finishReason") or "stop"), bool(tool_chunks)
                 )
-            )
-        else:
-            chunks.append(
-                _stream_chunk(
-                    is_finished=True,
-                    finish_reason=str(data.get("finishReason") or "stop"),
-                    usage=_normalize_stream_usage(data),
+                chunks.append(
+                    _stream_chunk(
+                        is_finished=True,
+                        finish_reason=finish_reason,
+                        usage=_normalize_stream_usage(message_metadata),
+                        provider_specific_fields=provider_fields or None,
+                    )
                 )
-            )
+            else:
+                tool_chunks = self._flush_tool_call_chunks()
+                chunks.extend(tool_chunks)
+                finish_reason = _stream_finish_reason(str(data.get("finishReason") or "stop"), bool(tool_chunks))
+                chunks.append(
+                    _stream_chunk(is_finished=True, finish_reason=finish_reason, usage=_normalize_stream_usage(data))
+                )
+            return chunks
+
+        if not emitted_tools:
+            self._remember_tool_calls([data])
+        self._remember_tool_calls(data.get("toolCalls"))
         return chunks
 
-    if not emitted_tools:
-        chunks.extend(_tool_call_stream_chunks([data]))
-    chunks.extend(_tool_call_stream_chunks(data.get("toolCalls")))
-    return chunks
+    def _remember_tool_calls(self, value: Any) -> None:
+        if value is None:
+            return
+        raw_tool_calls = value if isinstance(value, list) else list(value) if isinstance(value, tuple) else [value]
+        for raw_tool_call in raw_tool_calls:
+            if not isinstance(raw_tool_call, Mapping):
+                continue
+            normalized = _normalize_tana_tool_call(raw_tool_call)
+            if normalized is None:
+                continue
+            tool_call_id = str(normalized["toolCallId"])
+            self._pending_tool_calls[tool_call_id] = _merge_tana_tool_call(
+                self._pending_tool_calls.get(tool_call_id), normalized
+            )
+
+    def _flush_tool_call_chunks(self) -> list[GenericStreamingChunk]:
+        chunks: list[GenericStreamingChunk] = []
+        for index, tool_call in enumerate(self._pending_tool_calls.values()):
+            chunk = _openai_tool_call_chunk(tool_call, index, streaming_delta=False)
+            if chunk is not None:
+                chunks.append(_stream_chunk(tool_use=chunk))
+        self._pending_tool_calls.clear()
+        return chunks
 
 
-def _tool_call_stream_chunks(value: Any) -> list[GenericStreamingChunk]:
-    if value is None:
-        return []
-    raw_tool_calls = value if isinstance(value, list) else list(value) if isinstance(value, tuple) else [value]
-    chunks: list[GenericStreamingChunk] = []
-    for index, raw_tool_call in enumerate(raw_tool_calls):
-        if not isinstance(raw_tool_call, Mapping):
+def _merge_tana_tool_call(existing: Mapping[str, Any] | None, new: Mapping[str, Any]) -> dict[str, Any]:
+    merged = dict(existing or {})
+    for key, value in new.items():
+        if value is None:
             continue
-        tool_call = _openai_tool_call_chunk(raw_tool_call, index, streaming_delta=True)
-        if tool_call is not None:
-            chunks.append(_stream_chunk(tool_use=tool_call))
-    return chunks
+        if key == "input" and key in merged and _is_empty_json_object(value) and not _is_empty_json_object(merged[key]):
+            continue
+        merged[key] = value
+    if "input" not in merged:
+        merged["input"] = {}
+    return merged
+
+
+def _stream_finish_reason(finish_reason: str, has_tool_calls: bool) -> str:
+    if has_tool_calls and finish_reason in {"", "stop", "end_turn"}:
+        return "tool_calls"
+    return finish_reason
 
 
 def _openai_tool_call_chunk(

--- a/tana/litellm_proxy/test_provider.py
+++ b/tana/litellm_proxy/test_provider.py
@@ -516,16 +516,14 @@ def test_client_streams_tool_calls_from_llm_proxy_next() -> None:
         )
 
     tool_chunks = [chunk for chunk in chunks if chunk.get("tool_use") is not None]
-    assert len(tool_chunks) == 2
-    initial_tool_use = tool_chunks[0]["tool_use"]
-    assert initial_tool_use is not None
-    assert initial_tool_use["function"]["arguments"] == ""
-    tool_use = tool_chunks[1]["tool_use"]
+    assert len(tool_chunks) == 1
+    tool_use = tool_chunks[0]["tool_use"]
     assert tool_use is not None
     assert tool_use["id"] == "call-1"
     assert tool_use["type"] == "function"
     assert tool_use["function"]["name"] == "lookup_demo_fact"
     assert json.loads(tool_use["function"]["arguments"]) == {"topic": "tana-litellm-tool"}
+    assert chunks[-1]["finish_reason"] == "tool_calls"
     assert chunks[-1]["usage"] == {"prompt_tokens": 4, "completion_tokens": 5, "total_tokens": 9}
     assert seen_bodies[0]["isStreaming"] is True
     assert seen_bodies[0]["args"]["userContext"] == "Ask Tana"
@@ -539,6 +537,143 @@ def test_client_streams_tool_calls_from_llm_proxy_next() -> None:
     }
     assert "cache_control" not in json.dumps(seen_bodies[0])
     assert seen_bodies[0]["dynamicTools"][0]["runtime"] == "client"
+
+
+def test_client_streams_zero_arg_tool_call_from_llm_proxy_next() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "securetoken.googleapis.com":
+            return httpx.Response(
+                200, json={"id_token": "id-token-1", "refresh_token": "refresh-2", "expires_in": "3600"}
+            )
+        assert request.url == "https://app.tana.inc/functions/llmProxyNext"
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=(
+                b'data: {"type":"tool-input-available","toolCallId":"call-1",'
+                b'"toolName":"list_projects","input":{}}\n'
+                b'data: {"type":"finish","messageMetadata":{"finishReason":"stop"}}\n'
+            ),
+        )
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as http:
+        client = TanaProxyClient(TanaProxyConfig(refresh_token="refresh-1"), sync_http_client=http)
+        chunks = list(
+            client.stream_completion(
+                "claude-test",
+                [{"role": "user", "content": "list projects"}],
+                {"tools": [{"type": "function", "function": {"name": "list_projects"}}]},
+            )
+        )
+
+    tool_chunks = [chunk for chunk in chunks if chunk.get("tool_use") is not None]
+    assert len(tool_chunks) == 1
+    tool_use = tool_chunks[0]["tool_use"]
+    assert tool_use is not None
+    assert tool_use["function"]["name"] == "list_projects"
+    assert json.loads(tool_use["function"]["arguments"]) == {}
+    assert chunks[-1]["finish_reason"] == "tool_calls"
+
+
+def test_anthropic_messages_stream_has_single_merged_tool_block() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "securetoken.googleapis.com":
+            return httpx.Response(
+                200, json={"id_token": "id-token-1", "refresh_token": "refresh-2", "expires_in": "3600"}
+            )
+        assert request.url == "https://app.tana.inc/functions/llmProxyNext"
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=(
+                b'data: {"type":"tool-input-available","toolCallId":"call-1",'
+                b'"toolName":"echo_tool","input":{}}\n'
+                b'data: {"type":"tool-input-available","toolCallId":"call-1",'
+                b'"toolName":"echo_tool","input":{"value":"hi"}}\n'
+                b'data: {"type":"finish","messageMetadata":{"finishReason":"stop",'
+                b'"usage":{"inputTokens":4,"outputTokens":5}}}\n'
+            ),
+        )
+
+    original_custom_provider_map = list(litellm.custom_provider_map)
+    original_provider_list = list(litellm.provider_list)
+    original_custom_providers = list(litellm._custom_providers)
+    original_model_list_set = set(litellm.model_list_set)
+
+    async def collect_events() -> list[dict[str, Any]]:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+            client = TanaProxyClient(TanaProxyConfig(refresh_token="refresh-1"), http_client=http)
+            register_litellm_provider(TanaLiteLLM(client))
+            stream = await litellm.anthropic.messages.acreate(
+                model="tana/claude-test",
+                max_tokens=64,
+                stream=True,
+                messages=[{"role": "user", "content": "call echo_tool"}],
+                tools=[
+                    {
+                        "name": "echo_tool",
+                        "description": "Echo a value.",
+                        "input_schema": {
+                            "type": "object",
+                            "properties": {"value": {"type": "string"}},
+                            "required": ["value"],
+                        },
+                    }
+                ],
+            )
+            raw_events = [event async for event in cast(AsyncIterator[Any], stream)]
+            return [_decode_anthropic_sse_event(event) for event in raw_events]
+
+    try:
+        events = asyncio.run(collect_events())
+    finally:
+        litellm.custom_provider_map = original_custom_provider_map
+        litellm.provider_list = original_provider_list
+        litellm._custom_providers = original_custom_providers
+        litellm.model_list_set = original_model_list_set
+
+    started_blocks: set[int] = set()
+    stopped_blocks: set[int] = set()
+    for event in events:
+        event_type = event.get("type")
+        index = event.get("index")
+        if event_type == "content_block_start":
+            assert isinstance(index, int)
+            started_blocks.add(index)
+        if event_type == "content_block_delta":
+            assert isinstance(index, int)
+            assert index in started_blocks
+            assert index not in stopped_blocks
+        if event_type == "content_block_stop":
+            assert isinstance(index, int)
+            stopped_blocks.add(index)
+
+    tool_starts = [
+        event
+        for event in events
+        if event.get("type") == "content_block_start" and event.get("content_block", {}).get("type") == "tool_use"
+    ]
+    tool_deltas = [
+        event
+        for event in events
+        if event.get("type") == "content_block_delta" and event.get("delta", {}).get("type") == "input_json_delta"
+    ]
+    message_deltas = [event for event in events if event.get("type") == "message_delta"]
+    assert len(tool_starts) == 1
+    assert tool_starts[0]["content_block"] == {"type": "tool_use", "id": "call-1", "name": "echo_tool", "input": {}}
+    assert len(tool_deltas) == 1
+    assert json.loads(tool_deltas[0]["delta"]["partial_json"]) == {"value": "hi"}
+    assert message_deltas[-1]["delta"]["stop_reason"] == "tool_use"
+
+
+def _decode_anthropic_sse_event(event: Any) -> dict[str, Any]:
+    if isinstance(event, dict):
+        return event
+    event_text = event.decode("utf-8") if isinstance(event, (bytes, bytearray)) else str(event)
+    for line in event_text.splitlines():
+        if line.startswith("data:"):
+            return cast(dict[str, Any], json.loads(line.removeprefix("data:").strip()))
+    raise AssertionError(f"Anthropic stream event is missing data line: {event_text!r}")
 
 
 def test_reads_refresh_token_from_kubernetes_secret_json() -> None:


### PR DESCRIPTION
## Summary
- Buffer Tana streaming tool-input events by `toolCallId` and emit one merged tool call instead of an initial `{}` call followed by a duplicate real call.
- Preserve valid zero-argument tool calls and mark tool-call streams with the OpenAI `tool_calls` finish reason.
- Add regressions for raw Tana stream parsing and LiteLLM Anthropic SSE output shape.

## Validation
- `bbr test //tana/litellm_proxy:test_provider` passed
  - BuildBuddy child invocation: `193d710d-cbd3-4fd9-a18d-1d053c64331b`
- Commit hook passed: ruff check/format, pytest-main-check, enforce-bazel-tests