### PR TITLE
finance/evidence: trust egress CA bundle for augur-evidence clone

### DIFF
--- a/finance/evidence/BUILD.bazel
+++ b/finance/evidence/BUILD.bazel
@@ -41,6 +41,7 @@ py_test(
     deps = [
         ":checkout",
         "//:conftest",
+        "@pypi//pygit2",
         "@pypi//pytest",
         "@pypi//pytest_bazel",
     ],

--- a/finance/evidence/checkout.py
+++ b/finance/evidence/checkout.py
@@ -24,6 +24,21 @@ logger = logging.getLogger(__name__)
 EVIDENCE_REPO_URL = "https://git.allegedly.works/augur-evidence/augur-evidence.git"
 
 
+def _trust_egress_ca() -> None:
+    """Point libgit2 at the egress CA bundle that the environment already trusts.
+
+    libgit2 does not consult OpenSSL's ``SSL_CERT_FILE`` env var (the way
+    ``requests``/``curl`` do), so in a TLS-inspecting egress environment — e.g.
+    the Claude agent sandbox, where the Kyverno ``inject-mitmproxy`` policy
+    mounts the mitmproxy CA and sets ``SSL_CERT_FILE`` to it — the clone is
+    rejected with ``user rejected certificate for git.allegedly.works``. Mirror
+    that bundle into libgit2's own trust setting (``GIT_OPT_SET_SSL_CERT_LOCATIONS``).
+    A no-op when neither var is set (libgit2 then uses its built-in default).
+    """
+    if ca_file := os.environ.get("GIT_SSL_CAINFO") or os.environ.get("SSL_CERT_FILE"):
+        pygit2.settings.ssl_cert_file = ca_file
+
+
 def ensure_checkout() -> Path:
     if (configured := os.environ.get("AUGUR_EVIDENCE_DIR")) is not None:
         return Path(configured)
@@ -44,6 +59,7 @@ def ensure_checkout() -> Path:
             "  export AUGUR_EVIDENCE_GIT_USERNAME=$U AUGUR_EVIDENCE_GIT_PASSWORD=$P"
         )
     logger.info("cloning evidence repo to %s", checkout)
+    _trust_egress_ca()
     checkout.parent.mkdir(parents=True, exist_ok=True)
     callbacks = pygit2.RemoteCallbacks(credentials=pygit2.UserPass(username, password))
     pygit2.clone_repository(EVIDENCE_REPO_URL, str(checkout), depth=1, callbacks=callbacks)

--- a/finance/evidence/test_checkout.py
+++ b/finance/evidence/test_checkout.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pygit2
 import pytest
 import pytest_bazel
 
@@ -32,6 +33,50 @@ def test_cached_checkout_used_without_credentials(monkeypatch: pytest.MonkeyPatc
     checkout = tmp_path / ".cache" / "loom" / "augur-evidence"
     (checkout / ".git").mkdir(parents=True)
     assert ensure_checkout() == checkout
+
+
+class _RecordingSettings:
+    ssl_cert_file: str | None = None
+
+
+def _stub_clone(monkeypatch: pytest.MonkeyPatch) -> _RecordingSettings:
+    """Replace pygit2's network clone + global settings so the cold path is hermetic.
+
+    Returns the recording settings so callers can assert what libgit2 was pointed at.
+    """
+    settings = _RecordingSettings()
+    monkeypatch.setattr(pygit2, "settings", settings)
+
+    def fake_clone(url: str, path: str, **_: object) -> None:
+        (Path(path) / ".git").mkdir(parents=True)
+
+    monkeypatch.setattr(pygit2, "clone_repository", fake_clone)
+    return settings
+
+
+def test_clone_points_libgit2_at_egress_ca(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # libgit2 ignores SSL_CERT_FILE, so the cold clone must mirror it into the
+    # GIT_OPT_SET_SSL_CERT_LOCATIONS setting or the MITM egress cert is rejected.
+    _clear_evidence_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("AUGUR_EVIDENCE_GIT_USERNAME", "u")
+    monkeypatch.setenv("AUGUR_EVIDENCE_GIT_PASSWORD", "p")
+    ca = tmp_path / "mitmproxy-ca.pem"
+    ca.write_text("-----BEGIN CERTIFICATE-----\n")
+    monkeypatch.setenv("SSL_CERT_FILE", str(ca))
+    settings = _stub_clone(monkeypatch)
+    ensure_checkout()
+    assert settings.ssl_cert_file == str(ca)
+
+
+def test_clone_leaves_libgit2_default_trust_when_no_ca_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _clear_evidence_env(monkeypatch, tmp_path)
+    monkeypatch.delenv("GIT_SSL_CAINFO", raising=False)
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+    monkeypatch.setenv("AUGUR_EVIDENCE_GIT_USERNAME", "u")
+    monkeypatch.setenv("AUGUR_EVIDENCE_GIT_PASSWORD", "p")
+    settings = _stub_clone(monkeypatch)
+    ensure_checkout()
+    assert settings.ssl_cert_file is None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to #2074 / #2081. With docker-ci now reachable directly in-cluster over mTLS, the loom/gym eval Job got past staging and failed deeper, in its own driver:

```
_pygit2.GitError: user rejected certificate for git.allegedly.works
```

## Root cause

The augur-evidence `pygit2` clone egresses through the agent MITM proxy (`git.allegedly.works` is not a `.svc.cluster.local` name, so `NO_PROXY` doesn't exclude it). The Kyverno `inject-mitmproxy` policy mounts the mitmproxy CA at `/mitmproxy-ca/ca-cert.pem` and sets `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE` / `CURL_CA_BUNDLE` / `NODE_EXTRA_CA_CERTS` to it — which `requests`/`curl`/node honor, but **libgit2 does not consult `SSL_CERT_FILE`**. libgit2 needs the bundle set explicitly via `GIT_OPT_SET_SSL_CERT_LOCATIONS`, so it falls back to its built-in trust store (no mitmproxy CA) and rejects the MITM cert.

## Fix

`finance/evidence/checkout.py`: before the cold clone, mirror `GIT_SSL_CAINFO` / `SSL_CERT_FILE` into `pygit2.settings.ssl_cert_file` (`GIT_OPT_SET_SSL_CERT_LOCATIONS`). No-op when neither is set (libgit2 keeps its built-in default), so non-sandbox callers (augur fit pipeline) are unaffected. This mirrors the existing repo convention — `finance/scraper/test_fetch.py::test_ca_file_honors_ssl_cert_file` already honors `SSL_CERT_FILE` for the scraper's HTTP egress.

## Validation

- `//finance/evidence:test_checkout` passes on RBE (added two tests: sets the libgit2 trust location from `SSL_CERT_FILE`; leaves the default untouched when no CA env is present).
- Added the missing `@pypi//pygit2` test dep (mypy).
- pre-commit clean.

## After merge

The eval uses the prebuilt `ghcr.io/agentydragon/loom-gym-eval:latest`, so this only takes effect once that image is rebuilt by `push-images.yml` on `devel`. Then the failed `loom-gym-eval` Job is deleted and re-applied to close out the run.

https://claude.ai/code/session_01AXSFxfCXddADoSKTjgF5Nz

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXSFxfCXddADoSKTjgF5Nz)_