### PR TITLE
debundle: cross-module function-purity oracle (greatest-fixpoint core, 2a/2)

### DIFF
--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -258,6 +258,7 @@ rust_library(
     srcs = [
         "analysis_hints.rs",
         "atomic_units.rs",
+        "cross_module_purity.rs",
         "factor_assembly.rs",
         "facts/local_effects.rs",
         "facts/mod.rs",

--- a/devinfra/js/debundle/cross_module_purity.rs
+++ b/devinfra/js/debundle/cross_module_purity.rs
@@ -1,0 +1,297 @@
+//! Program-level cross-module function-purity oracle.
+//!
+//! The per-chunk purity classifier ([`crate::purity::ChunkCodeGraph`])
+//! treats a call to an imported binding as `unknown_call` — it cannot see
+//! into the other module's body. On a real app bundle that is the dominant
+//! impurity (every `memo(fn)` / `forwardRef(fn)` factory wrap), and via the
+//! dataflow-aware S-chain it over-merges atomic factor units.
+//!
+//! This oracle closes that gap. Given every module's entry body plus its
+//! resolved imports and exports, it computes, per module, the purity verdict
+//! for each imported function binding — the map fed to that module's
+//! [`ChunkCodeGraph::build_full`] (`imported_purities`).
+//!
+//! ## Algorithm — greatest fixpoint
+//!
+//! Purity forms a two-point lattice `Pure ⊐ NotPure`. Every function export
+//! starts optimistic (`Pure`); each round rebuilds every module's
+//! `ChunkCodeGraph` with the imported purities resolved from the *current*
+//! export verdicts, reads each export's local function purity, and **demotes**
+//! any that turned out impure. Demotion is monotone (a verdict only ever moves
+//! `Pure → NotPure`) over a finite domain, so the iteration converges; the
+//! result is the greatest (most-pure) sound fixpoint. Starting optimistic is
+//! what lets a function that is pure except for calling a same-cycle peer stay
+//! `Pure`.
+//!
+//! Soundness is conservative by construction: an import whose target module or
+//! export is absent (external/vendor module not analyzed, a non-function
+//! export, an unresolved re-export) simply gets no entry, so the call stays
+//! `unknown_call` exactly as before. The oracle only ever *removes*
+//! false-impurity; it never asserts purity it did not derive from a body.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use swc_ecma_ast::ModuleItem;
+
+use crate::facts::{compute_shadowed_globals, top_level_item_views};
+use crate::purity::{ChunkCodeGraph, Purity};
+
+/// Stable key identifying a module in the program (the chunk name).
+pub type ModuleKey = String;
+
+/// An import of a single named/default binding, already resolved to the
+/// module that defines it and the export read. Namespace imports
+/// (`import * as ns`) are intentionally not represented: their call sites are
+/// member calls (`ns.foo()`), not the bare-`Ident` callee the imported-purity
+/// arm handles.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedImport {
+    /// The module that defines the imported binding.
+    pub module: ModuleKey,
+    /// The export name read from that module.
+    pub export: String,
+}
+
+/// One module's purity-relevant surface for the oracle.
+pub struct ModulePurityFacts<'a> {
+    /// The module entry's top-level items (caller-owned parsed AST).
+    pub body: &'a [ModuleItem],
+    /// Local import binding name → the export it resolves to.
+    pub imports: BTreeMap<String, ResolvedImport>,
+    /// Export name → the local binding this module re-exports under it.
+    pub exports: BTreeMap<String, String>,
+}
+
+impl ModulePurityFacts<'_> {
+    /// Build this module's `ChunkCodeGraph` with the supplied imported-binding
+    /// purities. Only the cross-module map varies across fixpoint rounds; the
+    /// declared-purity inputs are not consulted here (the oracle reasons about
+    /// inferred body purity, and declared annotations only ever make a binding
+    /// *more* pure, so omitting them keeps the verdict conservative).
+    fn build_graph(&self, imported: &BTreeMap<String, Purity>) -> ChunkCodeGraph {
+        let views = top_level_item_views(self.body);
+        let shadowed = compute_shadowed_globals(&views);
+        ChunkCodeGraph::build_full(
+            &views,
+            &shadowed,
+            &BTreeSet::new(),
+            &BTreeSet::new(),
+            &BTreeMap::new(),
+            imported,
+        )
+    }
+
+    /// The imported-binding purities for this module under the current
+    /// program-wide export verdicts: each local import bound to a *function*
+    /// export of an analyzed module gets that export's verdict; anything
+    /// unresolved is omitted (stays `unknown_call`).
+    fn imported_purities(
+        &self,
+        export_purity: &BTreeMap<(ModuleKey, String), Purity>,
+    ) -> BTreeMap<String, Purity> {
+        self.imports
+            .iter()
+            .filter_map(|(local, target)| {
+                let key = (target.module.clone(), target.export.clone());
+                export_purity
+                    .get(&key)
+                    .map(|purity| (local.clone(), purity.clone()))
+            })
+            .collect()
+    }
+}
+
+/// Compute, per module, the imported-binding purity map to feed that module's
+/// `ChunkCodeGraph::build_full`. See the module docs for the fixpoint.
+pub fn resolve_imported_purities(
+    modules: &BTreeMap<ModuleKey, ModulePurityFacts<'_>>,
+) -> BTreeMap<ModuleKey, BTreeMap<String, Purity>> {
+    // The fixpoint state: the verdict for each *function* export. A
+    // `(module, export)` pair is in this map iff `export`'s local binding is a
+    // chunk-top function (so calling the import is meaningful); we seed those
+    // optimistically with `Pure`. Non-function exports never enter the map, so
+    // imports bound to them stay unresolved (`unknown_call`).
+    let mut export_purity: BTreeMap<(ModuleKey, String), Purity> = BTreeMap::new();
+    for (key, facts) in modules {
+        // Build once with no resolved imports to discover which exports are
+        // functions; their concrete verdict is refined by the loop below.
+        let graph = facts.build_graph(&BTreeMap::new());
+        for (export_name, local) in &facts.exports {
+            if graph.function_purity(local).is_some() {
+                export_purity.insert((key.clone(), export_name.clone()), Purity::Pure);
+            }
+        }
+    }
+
+    // Greatest-fixpoint: rebuild every module with the current cross-module
+    // verdicts and demote any function export that is impure under them. A
+    // verdict only moves Pure → NotPure, so this terminates.
+    loop {
+        let mut changed = false;
+        for (key, facts) in modules {
+            let imported = facts.imported_purities(&export_purity);
+            let graph = facts.build_graph(&imported);
+            for (export_name, local) in &facts.exports {
+                let slot_key = (key.clone(), export_name.clone());
+                if !export_purity.contains_key(&slot_key) {
+                    continue;
+                }
+                let Some(purity) = graph.function_purity(local) else {
+                    continue;
+                };
+                if export_purity[&slot_key].is_pure() && !purity.is_pure() {
+                    export_purity.insert(slot_key, purity);
+                    changed = true;
+                }
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+
+    modules
+        .iter()
+        .map(|(key, facts)| (key.clone(), facts.imported_purities(&export_purity)))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use swc_common::{FileName, sync::Lrc};
+    use swc_ecma_ast::Module;
+    use swc_ecma_parser::{Parser, StringInput, Syntax, lexer::Lexer};
+
+    fn parse(source: &str) -> Module {
+        let cm: Lrc<swc_common::SourceMap> = Default::default();
+        let fm = cm.new_source_file(FileName::Custom("m.js".into()).into(), source.to_string());
+        let lexer = Lexer::new(
+            Syntax::Es(Default::default()),
+            Default::default(),
+            StringInput::from(&*fm),
+            None,
+        );
+        Parser::new_from(lexer).parse_module().unwrap()
+    }
+
+    fn facts<'a>(
+        module: &'a Module,
+        imports: &[(&str, &str, &str)],
+        exports: &[(&str, &str)],
+    ) -> ModulePurityFacts<'a> {
+        ModulePurityFacts {
+            body: &module.body,
+            imports: imports
+                .iter()
+                .map(|(local, source, export)| {
+                    (
+                        (*local).to_string(),
+                        ResolvedImport {
+                            module: (*source).to_string(),
+                            export: (*export).to_string(),
+                        },
+                    )
+                })
+                .collect(),
+            exports: exports
+                .iter()
+                .map(|(name, local)| ((*name).to_string(), (*local).to_string()))
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn pure_function_import_is_resolved_pure() {
+        let app = parse("const C = memo(x);");
+        let react = parse("export function memo(t) { return { type: t }; }");
+        let modules = BTreeMap::from([
+            (
+                "app".to_string(),
+                facts(&app, &[("memo", "react", "memo")], &[]),
+            ),
+            ("react".to_string(), facts(&react, &[], &[("memo", "memo")])),
+        ]);
+        let resolved = resolve_imported_purities(&modules);
+        assert!(resolved["app"]["memo"].is_pure());
+    }
+
+    #[test]
+    fn impure_function_import_is_resolved_impure() {
+        let app = parse("const C = boot(x);");
+        let lib = parse("export function boot() { globalSink(); }");
+        let modules = BTreeMap::from([
+            (
+                "app".to_string(),
+                facts(&app, &[("boot", "lib", "boot")], &[]),
+            ),
+            ("lib".to_string(), facts(&lib, &[], &[("boot", "boot")])),
+        ]);
+        let resolved = resolve_imported_purities(&modules);
+        assert!(!resolved["app"]["boot"].is_pure());
+    }
+
+    #[test]
+    fn purity_propagates_across_a_module_chain() {
+        // c.base (pure) → b.wrap (calls base) → a imports wrap.
+        let a = parse("const W = wrap();");
+        let b = parse("import { base } from \"c\";\nexport function wrap() { return base(); }");
+        let c = parse("export function base() { return 1; }");
+        let modules = BTreeMap::from([
+            ("a".to_string(), facts(&a, &[("wrap", "b", "wrap")], &[])),
+            (
+                "b".to_string(),
+                facts(&b, &[("base", "c", "base")], &[("wrap", "wrap")]),
+            ),
+            ("c".to_string(), facts(&c, &[], &[("base", "base")])),
+        ]);
+        let resolved = resolve_imported_purities(&modules);
+        assert!(resolved["a"]["wrap"].is_pure());
+    }
+
+    #[test]
+    fn impurity_propagates_back_across_a_module_chain() {
+        // c.base (impure) demotes b.wrap, which demotes a's `wrap` import.
+        let a = parse("const W = wrap();");
+        let b = parse("import { base } from \"c\";\nexport function wrap() { return base(); }");
+        let c = parse("export function base() { globalSink(); }");
+        let modules = BTreeMap::from([
+            ("a".to_string(), facts(&a, &[("wrap", "b", "wrap")], &[])),
+            (
+                "b".to_string(),
+                facts(&b, &[("base", "c", "base")], &[("wrap", "wrap")]),
+            ),
+            ("c".to_string(), facts(&c, &[], &[("base", "base")])),
+        ]);
+        let resolved = resolve_imported_purities(&modules);
+        assert!(!resolved["a"]["wrap"].is_pure());
+    }
+
+    #[test]
+    fn import_of_an_unanalyzed_module_stays_unknown() {
+        // `vendor` is not in the module set (external/opaque) → no entry.
+        let app = parse("const C = ext(x);");
+        let modules = BTreeMap::from([(
+            "app".to_string(),
+            facts(&app, &[("ext", "vendor", "ext")], &[]),
+        )]);
+        let resolved = resolve_imported_purities(&modules);
+        assert!(!resolved["app"].contains_key("ext"));
+    }
+
+    #[test]
+    fn import_of_a_non_function_export_stays_unknown() {
+        // A data export is not callable → no purity entry, stays unknown_call.
+        let app = parse("const C = table(x);");
+        let lib = parse("export const table = 42;");
+        let modules = BTreeMap::from([
+            (
+                "app".to_string(),
+                facts(&app, &[("table", "lib", "table")], &[]),
+            ),
+            ("lib".to_string(), facts(&lib, &[], &[("table", "table")])),
+        ]);
+        let resolved = resolve_imported_purities(&modules);
+        assert!(!resolved["app"].contains_key("table"));
+    }
+}

--- a/devinfra/js/debundle/lib.rs
+++ b/devinfra/js/debundle/lib.rs
@@ -18,6 +18,7 @@
 
 pub mod analysis_hints;
 pub mod atomic_units;
+pub mod cross_module_purity;
 pub mod factor_assembly;
 pub mod facts;
 pub mod graph;


### PR DESCRIPTION
Second increment of **cross-module purity**. #2088 added the *consumption* arm (an imported callee with a `Pure` verdict classifies the call pure). This PR adds the analysis that *produces* those verdicts.

## What

`cross_module_purity::resolve_imported_purities` computes, per module, the purity verdict for each imported function binding — the `imported_purities` map fed to that module's `ChunkCodeGraph::build_full`.

It runs a **greatest fixpoint** over the cross-module call graph:
- Purity is the two-point lattice `Pure ⊐ NotPure`. Every function export starts optimistic (`Pure`).
- Each round rebuilds every module's `ChunkCodeGraph` with the imported purities resolved from the *current* export verdicts, reads each export's local function purity, and **demotes** any that turned out impure.
- Demotion is monotone over a finite domain ⇒ converges to the greatest sound fixpoint. Starting optimistic is what keeps a function `Pure` when its only "impurity" is calling a same-cycle peer (mutually-recursive or cyclic-import functions).

**Conservative by construction:** an import whose target module or export is absent — an external/vendor module not in the set, a non-function export, an unresolved re-export — gets no entry, so the call stays `unknown_call` exactly as before. The oracle only ever *removes* false impurity; it never asserts purity it didn't derive from a body. Namespace imports (`import * as ns`) aren't represented — their call sites are member calls, not the bare-`Ident` callee the consumption arm handles.

## Why this retires `unknown_call`

On a real app bundle, `unknown_call` (calls to imported factories like `memo`/`forwardRef`) is the dominant impurity and — via the dataflow-aware S-chain — the largest driver of over-merged atomic units (on Tana it alone shrinks the conflicting unit from 1,887 owners → ~397). Most such factories are pure functions in their own module, which this oracle now sees.

## Scope / interface

The oracle takes **already-resolved** imports (`ResolvedImport { module, export }`), which keeps it a pure function unit-tested in isolation. Resolving each chunk's import specifiers against the artifact (`ImportRecord`/`ExportAliasRecord`/`ArtifactIndexes`) and threading the per-chunk result through `lowering → compute_stage_one_analysis → build_full` is the **next increment** (the `CLEANUP` marker from #2088 in `facts/mod.rs` marks the consumer build site). Until then the oracle is unused in production — a library `pub` API awaiting its caller.

## Tests

Six cases in-module: pure and impure function imports resolve correctly; purity propagates forward and impurity propagates backward across a three-module chain (a→b→c); and imports of an unanalyzed module or a non-function export stay unresolved.

`//devinfra/js/debundle:analysis_test` passes locally.

https://claude.ai/code/session_01Bp8cANKC1Ktc92T7SM1kcx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bp8cANKC1Ktc92T7SM1kcx)_