### PR TITLE
debundle: gate ladder PR 3 — tier ladder in the RealizabilityIndex

### DIFF
--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -515,11 +515,13 @@ rust_test(
     ],
 )
 
-# Differential harness skeleton for the gate-ladder unification
-# (plans/incremental_gate_unification.md §7.1, PR 1 of §8): compares
-# the kernel's hot boolean merge gate against the touching-filtered
-# `check_realizability` reference, with the known-divergence catalog
-# encoded as expected failures.
+# Differential harness for the gate-ladder unification
+# (plans/incremental_gate_unification.md §7.1, PRs 1+3 of §8):
+# compares the kernel's hot boolean merge gate against the
+# touching-filtered `check_realizability` reference (known-divergence
+# catalog encoded as expected failures until the PR 4 cutover) and
+# asserts the index's tier ladder strictly equals the reference with
+# per-tier skip soundness.
 rust_test(
     name = "peel_gate_differential_test",
     srcs = ["peel/gate_differential_test.rs"],

--- a/devinfra/js/debundle/gate.rs
+++ b/devinfra/js/debundle/gate.rs
@@ -21,9 +21,9 @@ pub use chunk_analysis::ChunkAnalysis;
 pub use chunk_factorization::ChunkFactorization;
 pub use esm_import_order::EsmImportOrder;
 pub use realizability::{
-    CondensationOrder, CrossRebindEdge, DeltaHandle, PartitionDelta, RealizabilityIndex,
-    RealizabilityVerdict, SccDiagnosis, SccRejection, SccTimingReporter, check_realizability,
-    check_realizability_touching, record_gate_diagnostic_translation,
+    CondensationOrder, CrossRebindEdge, DeltaHandle, LadderDecision, PartitionDelta,
+    RealizabilityIndex, RealizabilityVerdict, SccDiagnosis, SccRejection, SccTimingReporter,
+    check_realizability, check_realizability_touching, record_gate_diagnostic_translation,
 };
 pub use rollback_graph::RollbackDiGraph;
 pub use validation::{

--- a/devinfra/js/debundle/peel/gate_differential_test.rs
+++ b/devinfra/js/debundle/peel/gate_differential_test.rs
@@ -19,19 +19,23 @@
 //! fixture assertions flip to agreement and this harness becomes a
 //! strict-equality check (and the catalog is deleted).
 //!
-//! Skeleton caveats (completed by Track F1 in later PRs):
-//! - generation uses a deterministic xorshift sweep over small
-//!   synthetic reports rather than proptest (no proptest dep in the
-//!   crate universe yet);
-//! - per-tier skip-soundness assertions arrive with the ladder
-//!   itself (PR 3).
+//! PR 3 additions: every comparison also runs the index's tier
+//! ladder (`QuotientGraph::ladder_decision_for_merge`) and asserts
+//! **strict equality** against the reference plus per-tier skip
+//! soundness (§7.1) — the ladder has no divergence catalog; only the
+//! legacy class-level gate keeps one until PR 4 routes
+//! `check_merge_boolean` through the ladder.
+//!
+//! Skeleton caveat (completed by Track F1 in later PRs): generation
+//! uses a deterministic xorshift sweep over small synthetic reports
+//! rather than proptest (no proptest dep in the crate universe yet).
 
 use std::collections::{BTreeMap, BTreeSet};
 
 use analysis::ids::{LogicalModuleIndex, ModuleId};
 use analysis::partition::Partition;
 use analysis::{DepKind, OwnerGraphNodeReport, OwnerGraphReport};
-use gate::{RealizabilityVerdict, SccRejection, check_realizability_touching};
+use gate::{LadderDecision, RealizabilityVerdict, SccRejection, check_realizability_touching};
 use peel::quotient::{
     ClassId, OwnerIdx, PartitionGroup, QuotientGraph, SpecModuleGroup, build_seed_quotient,
     greedy_step,
@@ -233,6 +237,60 @@ fn classify_divergence(gate_accepts: bool, reference: &RealizabilityVerdict) -> 
     DivergenceClass::CrossRebindBlindness
 }
 
+/// PR 3 (plan §8): the tier ladder must equal the reference predicate
+/// on EVERY query — the divergence catalog does not apply to it — and
+/// each deciding tier must be certified by the reference shape its
+/// skip-condition theorem names (plan §7.1 tier-skip soundness), so a
+/// ladder bug localizes to its tier.
+fn assert_ladder_matches_reference(
+    c1: ClassId,
+    c2: ClassId,
+    ladder: LadderDecision,
+    reference: &RealizabilityVerdict,
+) {
+    assert_eq!(
+        ladder.accepts(),
+        reference.is_realizable(),
+        "({c1:?}, {c2:?}): ladder {ladder:?} diverges from the reference \
+         predicate: {reference:#?}",
+    );
+    let mutual_cycle = reference
+        .unrealizable_sccs
+        .iter()
+        .any(|scc| scc.rejection == SccRejection::MutualConstrainingCycle);
+    let tdz = reference
+        .unrealizable_sccs
+        .iter()
+        .any(|scc| scc.rejection == SccRejection::EsmEvaluationTdz);
+    match ladder {
+        LadderDecision::ConstrainingCycleReject => assert!(
+            mutual_cycle,
+            "({c1:?}, {c2:?}): tier-1 reject must be certified by a \
+             MutualConstrainingCycle touching M: {reference:#?}",
+        ),
+        LadderDecision::CrossRebindReject => assert!(
+            !reference.cross_rebinds.is_empty(),
+            "({c1:?}, {c2:?}): tier-1 rebind reject must be certified by a \
+             clause-2 cross-rebind touching M: {reference:#?}",
+        ),
+        LadderDecision::SimulatorReject => assert!(
+            tdz,
+            "({c1:?}, {c2:?}): tier-3 reject must be certified by an \
+             EsmEvaluationTdz diagnosis touching M: {reference:#?}",
+        ),
+        LadderDecision::NoMultiModuleISccAccept | LadderDecision::NoConstrainingPairAccept => {
+            assert!(
+                !tdz,
+                "({c1:?}, {c2:?}): tier-2 vacuity claims Pass 2 produced \
+                 nothing touching M: {reference:#?}",
+            )
+        }
+        LadderDecision::DeltaFreeAccept
+        | LadderDecision::DeltaFreeReject
+        | LadderDecision::SimulatorAccept => {}
+    }
+}
+
 /// Run one gate-vs-reference comparison. Returns `None` when the
 /// non-cycle preconditions fail (the gate's `false` would not be a
 /// predicate decision).
@@ -255,6 +313,10 @@ fn compare_gate_to_reference(
     let pre_dirty =
         !check_realizability_touching(owner_graph, &pre_partition, post_module).is_realizable();
     let gate_accepts = q.merge_preserves_invariants(c1, c2);
+    // The ladder is the post-state predicate itself, so its equality
+    // claim is NOT scoped to clean pre-states — assert on every query.
+    let ladder = q.ladder_decision_for_merge(c1, c2);
+    assert_ladder_matches_reference(c1, c2, ladder, &reference);
     Some(if gate_accepts == reference.is_realizable() {
         QueryOutcome::Agree
     } else if pre_dirty {

--- a/devinfra/js/debundle/peel/quotient.rs
+++ b/devinfra/js/debundle/peel/quotient.rs
@@ -69,7 +69,8 @@ use std::collections::{BTreeMap, BTreeSet, BinaryHeap};
 
 use analysis::{DepKind, ModuleId, OwnerGraph, OwnerGraphReport, OwnerId, Partition};
 use gate::{
-    PartitionDelta, RealizabilityIndex, RealizabilityVerdict, record_gate_diagnostic_translation,
+    LadderDecision, PartitionDelta, RealizabilityIndex, RealizabilityVerdict,
+    record_gate_diagnostic_translation,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::Serialize;
@@ -1316,6 +1317,35 @@ impl QuotientGraph {
             })
             .collect();
         self.translate_verdict_with_owner_modules(&verdict, &owner_modules, Some((c1, c2)))
+    }
+
+    /// Tier-laddered boolean gate decision for the speculative merge
+    /// `(c1, c2)` (`plans/incremental_gate_unification.md` §3; PR 3 of
+    /// §8). Derives the same single-target move
+    /// `realizability_cycles_after_contract` computes and routes it
+    /// through the index's ladder instead of the evidence-producing
+    /// verdict. NOT yet consulted by `check_merge_boolean` — the PR 4
+    /// cutover does that; until then the differential harness and
+    /// `DEBUNDLE_GATE_ORACLE` runs exercise it.
+    ///
+    /// Caller contract: `(c1, c2)` must pass the non-cycle merge
+    /// preconditions (same as the other speculative cycle queries).
+    pub fn ladder_decision_for_merge(&self, c1: ClassId, c2: ClassId) -> LadderDecision {
+        let (winner, loser) = if c1 < c2 { (c1, c2) } else { (c2, c1) };
+        let (post_module, deltas) = self.compute_merge_deltas(winner, loser);
+        let mut owners: Vec<OwnerId> = Vec::new();
+        for delta in &deltas {
+            let PartitionDelta::MoveOwners { owners: moved, to } = delta;
+            debug_assert_eq!(
+                *to, post_module,
+                "speculative deltas are single-target by construction",
+            );
+            owners.extend(moved.iter().copied());
+        }
+        owners.sort();
+        owners.dedup();
+        self.realizability_index
+            .ladder_decision_after_moving_owners_touching(&self.owner_graph, &owners, post_module)
     }
 
     /// `translate_verdict_to_evidence` parameterized by an explicit

--- a/devinfra/js/debundle/realizability/incremental_quotient.rs
+++ b/devinfra/js/debundle/realizability/incremental_quotient.rs
@@ -13,6 +13,7 @@ use analysis::partition::Partition;
 
 use crate::rollback_graph::{GraphMark, RollbackDiGraph};
 
+use super::condensation_order::CondensationOrder;
 use super::esm_simulator::EsmEvaluationSimulator;
 use super::{
     CrossRebindEdge, RealizabilityVerdict, SccDiagnosis, SccRejection, gate_perf_counters,
@@ -114,6 +115,54 @@ pub(super) enum EdgeContributionKind {
     Import { constraining: bool, sequenced: bool },
 }
 
+/// How the gate ladder decided one boolean realizability query
+/// (`plans/incremental_gate_unification.md` §3; PR 3 of §8). Each
+/// variant names the tier that decided and the skip-condition theorem
+/// (or exact evaluation) certifying the decision — the differential
+/// harness asserts per-variant tier-skip soundness against the pure
+/// reference predicate.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum LadderDecision {
+    /// Tier 0: the move's overlay is empty (post-state == pre-state)
+    /// and the committed pre-state touching verdict is clean.
+    DeltaFreeAccept,
+    /// Tier 0: empty overlay, but the pre-state touching verdict
+    /// already carries a violation at the target module.
+    DeltaFreeReject,
+    /// Tier 1: the target's post-move constraining SCC is
+    /// multi-module — precisely a `MutualConstrainingCycle` diagnosis
+    /// touching the target (clause 3, Pass 1).
+    ConstrainingCycleReject,
+    /// Tier 1: a cross-module rebinding write touches the target
+    /// (clause 2).
+    CrossRebindReject,
+    /// Tier 2: the target's post-move I-SCC is single-module — Pass 2
+    /// is vacuous (modules outside any I-cycle cannot be rejected by
+    /// the simulator).
+    NoMultiModuleISccAccept,
+    /// Tier 2: the target's post-move I-SCC is multi-module but
+    /// carries no effective constraining pair — pure-lazy I-cycles
+    /// never TDZ (Lemma 2), so Pass 2 is vacuous.
+    NoConstrainingPairAccept,
+    /// Tier 3: the scoped ESM evaluation simulator found no TDZ pair.
+    SimulatorAccept,
+    /// Tier 3: the simulator proved a TDZ — an `EsmEvaluationTdz`
+    /// diagnosis touching the target.
+    SimulatorReject,
+}
+
+impl LadderDecision {
+    pub fn accepts(self) -> bool {
+        matches!(
+            self,
+            Self::DeltaFreeAccept
+                | Self::NoMultiModuleISccAccept
+                | Self::NoConstrainingPairAccept
+                | Self::SimulatorAccept
+        )
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub(super) struct QuotientOverlay {
     pub(super) i_delta: BTreeMap<(ModuleId, ModuleId), isize>,
@@ -125,6 +174,19 @@ pub(super) struct QuotientOverlay {
 }
 
 impl QuotientOverlay {
+    /// True when the move changes no quotient contribution at all —
+    /// the ladder's tier-0 "delta-free" condition (post-state ==
+    /// pre-state). Stricter than [`super::overlay_is_simulator_noop`],
+    /// which ignores cross-rebind edits.
+    pub(super) fn is_empty(&self) -> bool {
+        self.i_delta.is_empty()
+            && self.constraining_delta.is_empty()
+            && self.constraining_added.is_empty()
+            && self.constraining_removed.is_empty()
+            && self.cross_rebind_added.is_empty()
+            && self.cross_rebind_removed.is_empty()
+    }
+
     pub(super) fn add_contribution(&mut self, contribution: EdgeContribution) {
         match contribution.kind {
             EdgeContributionKind::Rebind => {
@@ -449,6 +511,21 @@ pub(super) struct IncrementalQuotient {
     /// `Cell` (not `RefCell`) because the value is `Copy` and we only
     /// read/write a single bool.
     pub(super) base_snapshot_stale: Cell<bool>,
+    /// Tier-1 structure of the gate ladder (plan §3/§4): SCC
+    /// condensation order maintained over `constraining_graph`.
+    /// Updated in the same `add_current_edge` / `remove_current_edge`
+    /// funnel that maintains the graph; invalidated (lazy rebuild) by
+    /// `rollback_graphs` — undo is off the hot path. `RefCell` because
+    /// queries need `&mut` (path halving, lazy rebuild) while the
+    /// verdict/ladder API is `&self`, matching the simulator caches.
+    pub(super) constraining_order: RefCell<CondensationOrder<ModuleId>>,
+    /// Tier-2 structure: the same condensation order over `i_graph`.
+    pub(super) i_order: RefCell<CondensationOrder<ModuleId>>,
+    /// Tier-0 memo: `verdict_touching(module).is_realizable()` for the
+    /// current committed quotient state. Cleared on every quotient
+    /// mutation — including cross-rebind edits, which bypass
+    /// `invalidate_cached_simulator`.
+    pub(super) cached_touching_clean: RefCell<BTreeMap<ModuleId, bool>>,
 }
 
 impl IncrementalQuotient {
@@ -466,6 +543,11 @@ impl IncrementalQuotient {
             // base-snapshot rebuild — matches what a real
             // snapshot-per-push design would do on startup.
             base_snapshot_stale: Cell::new(true),
+            // Both orders start stale and lazily rebuild from their
+            // base graph on the first ladder query.
+            constraining_order: RefCell::new(CondensationOrder::new()),
+            i_order: RefCell::new(CondensationOrder::new()),
+            cached_touching_clean: RefCell::new(BTreeMap::new()),
         };
         for edge in owner_graph.iter_edges() {
             quotient.add_current_edge(edge, partition, true);
@@ -481,6 +563,9 @@ impl IncrementalQuotient {
         *self.cached_base_simulator.borrow_mut() = None;
         *self.cached_base_i_successors.borrow_mut() = None;
         *self.cached_base_constraining_pairs.borrow_mut() = None;
+        // Every path that invalidates the simulator also changed the
+        // graphs/buckets the tier-0 touching verdict reads.
+        self.cached_touching_clean.get_mut().clear();
         // DEBUNDLE_TIMING=1 only: the next gate query will emulate a
         // fresh base-SCC snapshot rebuild. The flag costs one
         // unconditional store per invalidation (a few thousand per
@@ -589,6 +674,12 @@ impl IncrementalQuotient {
     pub(super) fn rollback_graphs(&mut self, i_mark: GraphMark, constraining_mark: GraphMark) {
         self.i_graph.rollback_to(i_mark);
         self.constraining_graph.rollback_to(constraining_mark);
+        // Out-of-band base mutation for the condensation orders (the
+        // undo path): invalidate + lazy rebuild on the next query
+        // instead of journaled rollback — undo is off the hot path
+        // everywhere (plan §4, journal interaction).
+        self.constraining_order.get_mut().invalidate();
+        self.i_order.get_mut().invalidate();
         // Graph topology just changed; drop the cached simulator.
         self.invalidate_cached_simulator();
     }
@@ -619,6 +710,9 @@ impl IncrementalQuotient {
                     owner_edge: edge.id,
                 },
             );
+            // Rebinds bypass the simulator/graph invalidation but DO
+            // change the touching verdict the tier-0 memo caches.
+            self.cached_touching_clean.get_mut().clear();
             return;
         }
 
@@ -627,12 +721,16 @@ impl IncrementalQuotient {
         self.invalidate_cached_simulator();
         if update_graphs {
             self.i_graph.increment_edge(from, to);
+            self.i_order.get_mut().insert_edge(&self.i_graph, from, to);
         }
         if !edge.reason.constrains_init_order() {
             return;
         }
         if update_graphs {
             self.constraining_graph.increment_edge(from, to);
+            self.constraining_order
+                .get_mut()
+                .insert_edge(&self.constraining_graph, from, to);
         }
         let bucket = self.constraining_buckets.entry((from, to)).or_default();
         bucket.insert_edge(edge.id, edge.reason.is_sequenced());
@@ -656,6 +754,9 @@ impl IncrementalQuotient {
         };
         if edge.reason.is_rebind() {
             self.cross_rebinds.remove(&edge.id);
+            // Mirror `add_current_edge`: rebind edits change the
+            // touching verdict the tier-0 memo caches.
+            self.cached_touching_clean.get_mut().clear();
             return;
         }
 
@@ -664,12 +765,16 @@ impl IncrementalQuotient {
         self.invalidate_cached_simulator();
         if update_graphs {
             self.i_graph.decrement_edge(from, to);
+            self.i_order.get_mut().remove_edge(&self.i_graph, from, to);
         }
         if !edge.reason.constrains_init_order() {
             return;
         }
         if update_graphs {
             self.constraining_graph.decrement_edge(from, to);
+            self.constraining_order
+                .get_mut()
+                .remove_edge(&self.constraining_graph, from, to);
         }
         let pair = (from, to);
         let mut remove_bucket = false;
@@ -833,27 +938,10 @@ impl IncrementalQuotient {
         let i_modules = i_graph_view.scc_containing(module);
         let i_scc_size = i_modules.len();
         if i_modules.len() >= 2 && !reported.contains(&i_modules) {
-            let constraining_pairs = self.constraining_pairs_with_overlay(overlay);
-            let any_inside_scc = constraining_pairs.iter().any(|(from, to)| {
-                i_modules.contains(from)
-                    && i_modules.contains(to)
-                    && !self
-                        .constraining_bucket_with_overlay((*from, *to), overlay)
-                        .is_empty()
-            });
+            let any_inside_scc = self.overlay_constraining_pair_inside(&i_modules, overlay);
             i_scc_had_constraining_pair = any_inside_scc;
             if any_inside_scc {
-                let simulation = self.build_simulator(Some(overlay));
-                let effective_pairs: BTreeSet<(ModuleId, ModuleId)> = constraining_pairs
-                    .into_iter()
-                    .filter(|pair| {
-                        !self
-                            .constraining_bucket_with_overlay(*pair, overlay)
-                            .is_empty()
-                    })
-                    .collect();
-                let tdz_pairs: Vec<(ModuleId, ModuleId)> =
-                    simulation.tdz_pairs(&i_modules, &effective_pairs).collect();
+                let tdz_pairs = self.overlay_tdz_pairs(&i_modules, overlay);
                 if !tdz_pairs.is_empty() {
                     let constraining_owner_edges =
                         self.tdz_constraining_edges(&tdz_pairs, Some(overlay));
@@ -874,6 +962,196 @@ impl IncrementalQuotient {
             !verdict.is_realizable(),
         );
         verdict
+    }
+
+    /// Whether `modules` contains both endpoints of an effective
+    /// constraining pair under `overlay` — the Pass-2 candidacy test
+    /// shared by `verdict_with_overlay_touching` and the ladder's
+    /// tier 2 (pure-lazy I-SCCs never TDZ).
+    pub(super) fn overlay_constraining_pair_inside(
+        &self,
+        modules: &BTreeSet<ModuleId>,
+        overlay: &QuotientOverlay,
+    ) -> bool {
+        self.constraining_pairs_with_overlay(overlay)
+            .iter()
+            .any(|(from, to)| {
+                modules.contains(from)
+                    && modules.contains(to)
+                    && !self
+                        .constraining_bucket_with_overlay((*from, *to), overlay)
+                        .is_empty()
+            })
+    }
+
+    /// TDZ-violating constraining pairs inside `modules` under
+    /// `overlay` — the exact Pass-2 evaluation (overlay-patched
+    /// simulator build + post-order check). Shared by the
+    /// evidence-producing `verdict_with_overlay_touching` and the
+    /// ladder's tier 3, so the two cannot drift.
+    pub(super) fn overlay_tdz_pairs(
+        &self,
+        modules: &BTreeSet<ModuleId>,
+        overlay: &QuotientOverlay,
+    ) -> Vec<(ModuleId, ModuleId)> {
+        let simulation = self.build_simulator(Some(overlay));
+        let effective_pairs: BTreeSet<(ModuleId, ModuleId)> = self
+            .constraining_pairs_with_overlay(overlay)
+            .into_iter()
+            .filter(|pair| {
+                !self
+                    .constraining_bucket_with_overlay(*pair, overlay)
+                    .is_empty()
+            })
+            .collect();
+        simulation.tdz_pairs(modules, &effective_pairs).collect()
+    }
+
+    /// Tier-0 memo: `verdict_touching(module).is_realizable()` against
+    /// the committed quotient state, cached until the next mutation.
+    fn touching_is_clean(&self, module: ModuleId) -> bool {
+        if let Some(&clean) = self.cached_touching_clean.borrow().get(&module) {
+            return clean;
+        }
+        let clean = self.verdict_touching(module).is_realizable();
+        self.cached_touching_clean
+            .borrow_mut()
+            .insert(module, clean);
+        clean
+    }
+
+    /// Allocation-free boolean twin of
+    /// `cross_rebinds_touching_with_overlay` for the ladder's tier-1
+    /// clause-2 check.
+    fn any_cross_rebind_touching_with_overlay(
+        &self,
+        module: ModuleId,
+        overlay: &QuotientOverlay,
+    ) -> bool {
+        self.cross_rebinds.iter().any(|(edge_id, rebind)| {
+            !overlay.cross_rebind_removed.contains(edge_id)
+                && (rebind.from == module || rebind.to == module)
+        }) || overlay
+            .cross_rebind_added
+            .values()
+            .any(|rebind| rebind.from == module || rebind.to == module)
+    }
+
+    /// Tier-laddered boolean evaluation of the touching predicate
+    /// (`plans/incremental_gate_unification.md` §3): each tier either
+    /// decides — its skip condition is a theorem about
+    /// `verdict_with_overlay_touching(module, overlay)` — or
+    /// escalates, and tier 3 runs the same scoped-simulator
+    /// evaluation the verdict path runs, so the boolean cannot drift
+    /// from the evidence-producing form.
+    pub(super) fn ladder_decide(
+        &self,
+        module: ModuleId,
+        overlay: &QuotientOverlay,
+    ) -> LadderDecision {
+        // Tier 0: delta-free move — post-state == pre-state, so the
+        // (cached) committed-state touching verdict decides.
+        if overlay.is_empty() {
+            let decision = if self.touching_is_clean(module) {
+                LadderDecision::DeltaFreeAccept
+            } else {
+                LadderDecision::DeltaFreeReject
+            };
+            gate_perf_counters::record_ladder_decision(decision, None, None, None);
+            return decision;
+        }
+
+        // `DEBUNDLE_TIMING=1` shadow path; see
+        // `verdict_with_overlay_touching` for the rationale.
+        self.maybe_record_base_snapshot();
+
+        // Tier 1: clause 2 (cross-rebinds touching `module`) and
+        // Pass 1 — is `module`'s post-move constraining SCC
+        // multi-module? — on the maintained constraining condensation.
+        let tier1_start = if gate_perf_counters::enabled() {
+            Some(Instant::now())
+        } else {
+            None
+        };
+        let tier1 = if self.constraining_order.borrow_mut().would_join_multi_scc(
+            &self.constraining_graph,
+            &overlay.constraining_delta,
+            module,
+            module,
+        ) {
+            Some(LadderDecision::ConstrainingCycleReject)
+        } else if self.any_cross_rebind_touching_with_overlay(module, overlay) {
+            Some(LadderDecision::CrossRebindReject)
+        } else {
+            None
+        };
+        let tier1_nanos =
+            tier1_start.map(|start| gate_perf_counters::elapsed_to_u64(start.elapsed()));
+        if let Some(decision) = tier1 {
+            gate_perf_counters::record_ladder_decision(decision, tier1_nanos, None, None);
+            return decision;
+        }
+
+        // Tier 2: Pass-2 vacuity on the I-condensation. Overlay
+        // removals inside a multi-module I-SCC route through the
+        // exact bidirectional fallback inside `would_join_multi_scc`
+        // (plan §3, tier-2 exactness caveat).
+        let tier2_start = if gate_perf_counters::enabled() {
+            Some(Instant::now())
+        } else {
+            None
+        };
+        let multi_i_scc = self.i_order.borrow_mut().would_join_multi_scc(
+            &self.i_graph,
+            &overlay.i_delta,
+            module,
+            module,
+        );
+        if !multi_i_scc {
+            let tier2_nanos =
+                tier2_start.map(|start| gate_perf_counters::elapsed_to_u64(start.elapsed()));
+            gate_perf_counters::record_ladder_decision(
+                LadderDecision::NoMultiModuleISccAccept,
+                tier1_nanos,
+                tier2_nanos,
+                None,
+            );
+            return LadderDecision::NoMultiModuleISccAccept;
+        }
+        // Multi-module I-SCC (rare): materialize its member set —
+        // the constraining-pair lookup needs it, exactly as
+        // `verdict_with_overlay_touching` computes it.
+        let i_modules =
+            OverlayGraphView::new(&self.i_graph, &overlay.i_delta).scc_containing(module);
+        let pair_inside = self.overlay_constraining_pair_inside(&i_modules, overlay);
+        let tier2_nanos =
+            tier2_start.map(|start| gate_perf_counters::elapsed_to_u64(start.elapsed()));
+        if !pair_inside {
+            gate_perf_counters::record_ladder_decision(
+                LadderDecision::NoConstrainingPairAccept,
+                tier1_nanos,
+                tier2_nanos,
+                None,
+            );
+            return LadderDecision::NoConstrainingPairAccept;
+        }
+
+        // Tier 3: exact Pass 2 — the shared scoped-simulator
+        // evaluation.
+        let tier3_start = if gate_perf_counters::enabled() {
+            Some(Instant::now())
+        } else {
+            None
+        };
+        let decision = if self.overlay_tdz_pairs(&i_modules, overlay).is_empty() {
+            LadderDecision::SimulatorAccept
+        } else {
+            LadderDecision::SimulatorReject
+        };
+        let tier3_nanos =
+            tier3_start.map(|start| gate_perf_counters::elapsed_to_u64(start.elapsed()));
+        gate_perf_counters::record_ladder_decision(decision, tier1_nanos, tier2_nanos, tier3_nanos);
+        decision
     }
 
     /// Resolve a list of TDZ-violating `(from, to)` pairs to their

--- a/devinfra/js/debundle/realizability/mod.rs
+++ b/devinfra/js/debundle/realizability/mod.rs
@@ -49,7 +49,7 @@ mod incremental_quotient;
 
 pub use condensation_order::CondensationOrder;
 use esm_simulator::EsmEvaluationSimulator;
-pub use incremental_quotient::{DeltaHandle, PartitionDelta};
+pub use incremental_quotient::{DeltaHandle, LadderDecision, PartitionDelta};
 use incremental_quotient::{IncrementalQuotient, JournalEntry, QuotientOverlay};
 
 /// Canonical in-memory diagnosis of one offending module-quotient
@@ -521,8 +521,79 @@ impl RealizabilityIndex {
         let overlay = self
             .quotient
             .overlay_for_move(owner_graph, &self.partition, owners, to);
-        self.quotient.verdict_with_overlay_touching(to, &overlay)
+        let verdict = self.quotient.verdict_with_overlay_touching(to, &overlay);
+        if gate_oracle_enabled() {
+            // Oracle mode (plan §7.2): the boolean tier ladder must
+            // agree with the evidence-producing verdict on every
+            // diagnostic-path query.
+            let decision = self.quotient.ladder_decide(to, &overlay);
+            assert_eq!(
+                decision.accepts(),
+                verdict.is_realizable(),
+                "DEBUNDLE_GATE_ORACLE: ladder {decision:?} diverges from the overlay \
+                 verdict for {to:?}: {verdict:#?}",
+            );
+        }
+        verdict
     }
+
+    /// Tier-laddered decision for a hypothetical owner move, filtered
+    /// to the target module (`plans/incremental_gate_unification.md`
+    /// §3; PR 3 of §8). Exactly equal to
+    /// `verdict_after_moving_owners_touching(..).is_realizable()` with
+    /// evidence materialization elided: tiers 0–2 are short-circuits
+    /// whose skip conditions are theorems about the predicate, tier 3
+    /// runs the shared simulator path. With `DEBUNDLE_GATE_ORACLE`
+    /// set, every query is additionally cross-checked against the
+    /// pure touching-filtered reference and divergence panics.
+    pub fn ladder_decision_after_moving_owners_touching(
+        &self,
+        owner_graph: &OwnerGraph,
+        owners: &[OwnerId],
+        to: ModuleId,
+    ) -> LadderDecision {
+        let overlay = self
+            .quotient
+            .overlay_for_move(owner_graph, &self.partition, owners, to);
+        let decision = self.quotient.ladder_decide(to, &overlay);
+        if gate_oracle_enabled() {
+            let mut post_partition = self.partition.clone();
+            for &owner in owners {
+                post_partition.set(owner, to);
+            }
+            let reference = check_realizability_touching(owner_graph, &post_partition, to);
+            assert_eq!(
+                decision.accepts(),
+                reference.is_realizable(),
+                "DEBUNDLE_GATE_ORACLE: ladder {decision:?} diverges from the pure \
+                 reference for {to:?}: {reference:#?}",
+            );
+        }
+        decision
+    }
+
+    /// Boolean form of
+    /// [`Self::ladder_decision_after_moving_owners_touching`] — the
+    /// §8 PR 3 gate-ladder entry point. PR 4 routes the kernel's
+    /// `check_merge_boolean` here.
+    pub fn would_remain_realizable_after_moving_owners_touching(
+        &self,
+        owner_graph: &OwnerGraph,
+        owners: &[OwnerId],
+        to: ModuleId,
+    ) -> bool {
+        self.ladder_decision_after_moving_owners_touching(owner_graph, owners, to)
+            .accepts()
+    }
+}
+
+/// One-time cached `DEBUNDLE_GATE_ORACLE` probe (plan §7.2): when set,
+/// every ladder query cross-checks against the reference predicate and
+/// panics on divergence. Off by default — the reference is
+/// `O(V + E)` per query.
+fn gate_oracle_enabled() -> bool {
+    static ORACLE_ENABLED: OnceLock<bool> = OnceLock::new();
+    *ORACLE_ENABLED.get_or_init(|| std::env::var_os("DEBUNDLE_GATE_ORACLE").is_some())
 }
 
 /// True when `overlay` introduces no changes the ESM evaluation
@@ -631,6 +702,50 @@ pub mod gate_perf_counters {
 
     pub(super) static DIAGNOSTIC_TRANSLATION_CALLS: AtomicUsize = AtomicUsize::new(0);
     pub(super) static DIAGNOSTIC_TRANSLATION_ACTIVE: AtomicUsize = AtomicUsize::new(0);
+
+    // -- Gate-ladder per-tier counters (plan §3; PR 3 of §8) ----------------
+
+    pub(super) static LADDER_TIER0_ACCEPT: AtomicUsize = AtomicUsize::new(0);
+    pub(super) static LADDER_TIER0_REJECT: AtomicUsize = AtomicUsize::new(0);
+    pub(super) static LADDER_TIER1_CYCLE_REJECT: AtomicUsize = AtomicUsize::new(0);
+    pub(super) static LADDER_TIER1_CROSS_REBIND_REJECT: AtomicUsize = AtomicUsize::new(0);
+    pub(super) static LADDER_TIER2_NO_MULTI_ISCC_ACCEPT: AtomicUsize = AtomicUsize::new(0);
+    pub(super) static LADDER_TIER2_NO_PAIR_ACCEPT: AtomicUsize = AtomicUsize::new(0);
+    pub(super) static LADDER_TIER3_ACCEPT: AtomicUsize = AtomicUsize::new(0);
+    pub(super) static LADDER_TIER3_REJECT: AtomicUsize = AtomicUsize::new(0);
+    /// Per-tier cumulative wall time in nanoseconds
+    /// (`DEBUNDLE_TIMING=1` only; zero otherwise).
+    pub(super) static LADDER_TIER1_NANOS: AtomicU64 = AtomicU64::new(0);
+    pub(super) static LADDER_TIER2_NANOS: AtomicU64 = AtomicU64::new(0);
+    pub(super) static LADDER_TIER3_NANOS: AtomicU64 = AtomicU64::new(0);
+
+    pub(super) fn record_ladder_decision(
+        decision: LadderDecision,
+        tier1_nanos: Option<u64>,
+        tier2_nanos: Option<u64>,
+        tier3_nanos: Option<u64>,
+    ) {
+        let counter = match decision {
+            LadderDecision::DeltaFreeAccept => &LADDER_TIER0_ACCEPT,
+            LadderDecision::DeltaFreeReject => &LADDER_TIER0_REJECT,
+            LadderDecision::ConstrainingCycleReject => &LADDER_TIER1_CYCLE_REJECT,
+            LadderDecision::CrossRebindReject => &LADDER_TIER1_CROSS_REBIND_REJECT,
+            LadderDecision::NoMultiModuleISccAccept => &LADDER_TIER2_NO_MULTI_ISCC_ACCEPT,
+            LadderDecision::NoConstrainingPairAccept => &LADDER_TIER2_NO_PAIR_ACCEPT,
+            LadderDecision::SimulatorAccept => &LADDER_TIER3_ACCEPT,
+            LadderDecision::SimulatorReject => &LADDER_TIER3_REJECT,
+        };
+        counter.fetch_add(1, Ordering::Relaxed);
+        if let Some(nanos) = tier1_nanos {
+            LADDER_TIER1_NANOS.fetch_add(nanos, Ordering::Relaxed);
+        }
+        if let Some(nanos) = tier2_nanos {
+            LADDER_TIER2_NANOS.fetch_add(nanos, Ordering::Relaxed);
+        }
+        if let Some(nanos) = tier3_nanos {
+            LADDER_TIER3_NANOS.fetch_add(nanos, Ordering::Relaxed);
+        }
+    }
 
     // -- Reservoir-sampled histograms --------------------------------------
     //
@@ -983,6 +1098,37 @@ pub mod gate_perf_counters {
         let _ = writeln!(
             out,
             "  overlay simulator rebuilds: {overlay_rebuilds}, cumulative {overlay_rebuild_secs:.3}s, per-call avg {overlay_rebuild_per_call_us:.3} µs"
+        );
+
+        let tier0_accept = LADDER_TIER0_ACCEPT.load(Ordering::Relaxed);
+        let tier0_reject = LADDER_TIER0_REJECT.load(Ordering::Relaxed);
+        let tier1_cycle = LADDER_TIER1_CYCLE_REJECT.load(Ordering::Relaxed);
+        let tier1_rebind = LADDER_TIER1_CROSS_REBIND_REJECT.load(Ordering::Relaxed);
+        let tier2_no_scc = LADDER_TIER2_NO_MULTI_ISCC_ACCEPT.load(Ordering::Relaxed);
+        let tier2_no_pair = LADDER_TIER2_NO_PAIR_ACCEPT.load(Ordering::Relaxed);
+        let tier3_accept = LADDER_TIER3_ACCEPT.load(Ordering::Relaxed);
+        let tier3_reject = LADDER_TIER3_REJECT.load(Ordering::Relaxed);
+        let ladder_total = tier0_accept
+            + tier0_reject
+            + tier1_cycle
+            + tier1_rebind
+            + tier2_no_scc
+            + tier2_no_pair
+            + tier3_accept
+            + tier3_reject;
+        let _ = writeln!(
+            out,
+            "gate ladder: {ladder_total} queries; tier0 {tier0_accept} accept / {tier0_reject} reject; \
+             tier1 {tier1_cycle} cycle-reject + {tier1_rebind} rebind-reject; \
+             tier2 {tier2_no_scc} no-multi-iscc + {tier2_no_pair} no-pair accept; \
+             tier3 {tier3_accept} accept / {tier3_reject} reject"
+        );
+        let tier1_secs = LADDER_TIER1_NANOS.load(Ordering::Relaxed) as f64 / 1e9;
+        let tier2_secs = LADDER_TIER2_NANOS.load(Ordering::Relaxed) as f64 / 1e9;
+        let tier3_secs = LADDER_TIER3_NANOS.load(Ordering::Relaxed) as f64 / 1e9;
+        let _ = writeln!(
+            out,
+            "  ladder wall: tier1 {tier1_secs:.3}s, tier2 {tier2_secs:.3}s, tier3 {tier3_secs:.3}s"
         );
 
         let diagnostic_calls = DIAGNOSTIC_TRANSLATION_CALLS.load(Ordering::Relaxed);

--- a/devinfra/js/debundle/realizability/tests.rs
+++ b/devinfra/js/debundle/realizability/tests.rs
@@ -1004,3 +1004,199 @@ fn incremental_simulator_matches_rebuild_after_each_delta() {
         }
     }
 }
+
+// ---------------------------------------------------------------------
+// Gate-ladder tests (plans/incremental_gate_unification.md §3; PR 3
+// of §8): the tier-laddered boolean must equal the evidence-producing
+// overlay verdict on every move query, with each fixture pinning the
+// tier expected to decide it.
+// ---------------------------------------------------------------------
+
+/// Assert the ladder, the boolean wrapper, and the overlay verdict
+/// agree for one move query; return the decision for tier pinning.
+fn assert_ladder_matches_verdict(
+    index: &RealizabilityIndex,
+    owner_graph: &OwnerGraph,
+    owners: &[OwnerId],
+    to: ModuleId,
+) -> LadderDecision {
+    let decision = index.ladder_decision_after_moving_owners_touching(owner_graph, owners, to);
+    let verdict = index.verdict_after_moving_owners_touching(owner_graph, owners, to);
+    assert_eq!(
+        decision.accepts(),
+        verdict.is_realizable(),
+        "ladder {decision:?} diverges from the overlay verdict for move \
+         {owners:?} → {to:?}: {verdict:#?}",
+    );
+    assert_eq!(
+        decision.accepts(),
+        index.would_remain_realizable_after_moving_owners_touching(owner_graph, owners, to),
+    );
+    decision
+}
+
+#[test]
+fn ladder_tier0_delta_free_move_accepts_on_clean_state() {
+    let source = "const a = 1; const b = a + 1;";
+    let owner_graph = parse_and_build(source);
+    let index = RealizabilityIndex::from_partition(
+        &owner_graph,
+        Partition::new(&owner_graph, module_id(0)),
+    );
+    // Owner 1 already lives in module 0 — the move is delta-free.
+    let decision = assert_ladder_matches_verdict(&index, &owner_graph, &[OwnerId(1)], module_id(0));
+    assert_eq!(decision, LadderDecision::DeltaFreeAccept);
+}
+
+#[test]
+fn ladder_tier0_delta_free_move_rejects_on_dirty_pre_state() {
+    // Mutual constraining cycle committed between modules 1 and 2; a
+    // delta-free move touching module 1 must reject (post == pre, and
+    // the pre-state touching verdict is dirty).
+    let source = "const a = b + 1; const b = a + 1;";
+    let owner_graph = parse_and_build(source);
+    let mut partition = Partition::new(&owner_graph, module_id(0));
+    partition.set(OwnerId(0), module_id(1));
+    partition.set(OwnerId(1), module_id(2));
+    let index = RealizabilityIndex::from_partition(&owner_graph, partition);
+    let decision = assert_ladder_matches_verdict(&index, &owner_graph, &[OwnerId(0)], module_id(1));
+    assert_eq!(decision, LadderDecision::DeltaFreeReject);
+}
+
+#[test]
+fn ladder_tier1_rejects_constraining_cycle_move() {
+    // Moving `b` out of residual closes the mutual eager 2-cycle —
+    // a Pass-1 reject the constraining condensation decides.
+    let source = "const a = b + 1; const b = a + 1;";
+    let owner_graph = parse_and_build(source);
+    let index = RealizabilityIndex::from_partition(
+        &owner_graph,
+        Partition::new(&owner_graph, module_id(0)),
+    );
+    let decision = assert_ladder_matches_verdict(&index, &owner_graph, &[OwnerId(1)], module_id(1));
+    assert_eq!(decision, LadderDecision::ConstrainingCycleReject);
+}
+
+#[test]
+fn ladder_tier1_rejects_cross_rebind_move() {
+    // Moving the writer out of residual turns the intra-module rebind
+    // into a clause-2 cross-module rebinding write.
+    let source = "let a = 0; function b() { a = 1; }";
+    let owner_graph = parse_and_build(source);
+    let index = RealizabilityIndex::from_partition(
+        &owner_graph,
+        Partition::new(&owner_graph, module_id(0)),
+    );
+    let decision = assert_ladder_matches_verdict(&index, &owner_graph, &[OwnerId(1)], module_id(1));
+    assert_eq!(decision, LadderDecision::CrossRebindReject);
+}
+
+#[test]
+fn ladder_tier2_accepts_acyclic_cross_module_move() {
+    // The move adds one constraining edge and closes nothing — the
+    // I-condensation proves Pass 2 vacuous without a simulator build.
+    let source = "const a = 1; const b = a + 1;";
+    let owner_graph = parse_and_build(source);
+    let index = RealizabilityIndex::from_partition(
+        &owner_graph,
+        Partition::new(&owner_graph, module_id(0)),
+    );
+    let decision = assert_ladder_matches_verdict(&index, &owner_graph, &[OwnerId(1)], module_id(1));
+    assert_eq!(decision, LadderDecision::NoMultiModuleISccAccept);
+}
+
+#[test]
+fn ladder_tier2_accepts_pure_lazy_cycle_move() {
+    // The move closes a pure-lazy I-cycle: multi-module I-SCC with no
+    // constraining pair inside — Lemma 2 says it never TDZs.
+    let source = "function a() { return b(); } function b() { return a(); }";
+    let owner_graph = parse_and_build(source);
+    let index = RealizabilityIndex::from_partition(
+        &owner_graph,
+        Partition::new(&owner_graph, module_id(0)),
+    );
+    let decision = assert_ladder_matches_verdict(&index, &owner_graph, &[OwnerId(1)], module_id(1));
+    assert_eq!(decision, LadderDecision::NoConstrainingPairAccept);
+}
+
+#[test]
+fn ladder_tier3_accepts_lemma_two_rescued_move() {
+    // The `lemma_two_rescues_asymmetric_cycle...` shape reached via a
+    // speculative move: dep_value + lazy_reader sit in mod 1; moving
+    // cross_value to mod 2 closes the asymmetric I-SCC {1, 2} with a
+    // constraining pair, so the ladder must run the simulator — which
+    // rescues (Lemma 2).
+    let source = "const dep_value = \"alpha\"; const cross_value = dep_value + \"-beta\"; function lazy_reader() { return cross_value; } console.log(dep_value, cross_value, lazy_reader());";
+    let owner_graph = parse_and_build(source);
+    let mut partition = Partition::new(&owner_graph, module_id(0));
+    partition.set(OwnerId(0), module_id(1));
+    partition.set(OwnerId(2), module_id(1));
+    let index = RealizabilityIndex::from_partition(&owner_graph, partition);
+    let decision = assert_ladder_matches_verdict(&index, &owner_graph, &[OwnerId(1)], module_id(2));
+    assert_eq!(decision, LadderDecision::SimulatorAccept);
+}
+
+#[test]
+fn ladder_tier3_rejects_tdz_move() {
+    // Asymmetric I-SCC with the constraining edge pointing INTO
+    // residual (the `constraining_edge_into_residual_inside_scc`
+    // shape, reached via a move): residual is the DFS root and
+    // evaluates last, so the moved statement's eager read of `seed`
+    // TDZs. Pass 1 is clean (one constraining direction) and the
+    // I-SCC carries a constraining pair, so only tier 3 can decide.
+    let source = "const seed = 1; const x = seed + 1; function readX() { return x; }";
+    let owner_graph = parse_and_build(source);
+    let index = RealizabilityIndex::from_partition(
+        &owner_graph,
+        Partition::new(&owner_graph, module_id(0)),
+    );
+    let decision = assert_ladder_matches_verdict(&index, &owner_graph, &[OwnerId(1)], module_id(1));
+    assert_eq!(decision, LadderDecision::SimulatorReject);
+}
+
+/// Condensation-order maintenance: the ladder stays equal to the
+/// overlay verdict across committed pushes (incremental edge
+/// insert/remove), `commit`, and `undo` (invalidate + lazy rebuild,
+/// plan §4's journal interaction).
+#[test]
+fn ladder_matches_verdict_across_push_commit_undo() {
+    let source = "const a = b + 1; const b = a + 1; function c() { return a; }";
+    let owner_graph = parse_and_build(source);
+    let mut index = RealizabilityIndex::from_partition(
+        &owner_graph,
+        Partition::new(&owner_graph, module_id(0)),
+    );
+    let sweep = |index: &RealizabilityIndex| {
+        for owner in 0..owner_graph.num_nodes() {
+            for module in 0..4 {
+                assert_ladder_matches_verdict(
+                    index,
+                    &owner_graph,
+                    &[OwnerId(owner)],
+                    module_id(module),
+                );
+            }
+        }
+    };
+    sweep(&index);
+    index.push(
+        &owner_graph,
+        PartitionDelta::MoveOwners {
+            owners: vec![OwnerId(1)],
+            to: module_id(1),
+        },
+    );
+    sweep(&index);
+    index.commit();
+    sweep(&index);
+    let speculative = index.push(
+        &owner_graph,
+        PartitionDelta::MoveOwners {
+            owners: vec![OwnerId(2)],
+            to: module_id(2),
+        },
+    );
+    sweep(&index);
+    index.undo(&owner_graph, speculative);
+    sweep(&index);
+}


### PR DESCRIPTION
PR 3 of [`plans/incremental_gate_unification.md`](https://github.com/agentydragon/ducktape/blob/devel/devinfra/js/debundle/plans/incremental_gate_unification.md) §8 (after #2087 / PR 1 and #2090 / PR 2): the tier-laddered boolean evaluation of the realizability predicate (§3) lands inside the index, behind the existing entry points. **Existing callers untouched** — the kernel's `check_merge_boolean` still runs the PK/cone class-level walk until the PR 4 cutover, so the predicate's granularity, seed diagnostics, and corpus output are unchanged in this PR.

## What §8 defines for PR 3

> **PR 3 (M) — ladder in the index.** `IncrementalQuotient` gains the two maintained instances and a boolean `would_remain_realizable_after_moving_owners_touching` implementing tiers 0–3 (this completes `perf/proposer.md` backlog #2's short-circuit sketch); `DEBUNDLE_GATE_ORACLE` cross-check; per-tier counters wired into `gate_perf_counters`. Existing callers untouched.

## Changes

- **Two maintained `CondensationOrder` instances** on `IncrementalQuotient` (constraining-graph and I-graph), updated incrementally in the `add_current_edge` / `remove_current_edge` funnel and invalidated (lazy rebuild) in `rollback_graphs` — undo stays off the hot path per §4's journal-interaction decision.
- **`RealizabilityIndex::would_remain_realizable_after_moving_owners_touching`** (plus a `LadderDecision`-returning twin so counters/tests can see which tier decided), implementing §3's tiers:
  - **Tier 0** — empty move overlay (post == pre): decided by a per-committed-state memo of `verdict_touching(M).is_realizable()`, invalidated on every quotient mutation including cross-rebind edits.
  - **Tier 1** — clause-2 cross-rebind check + overlay-aware `would_join_multi_scc(M, M)` on the constraining condensation (a tier-1 reject is exactly a `MutualConstrainingCycle` touching `M`).
  - **Tier 2** — Pass-2 vacuity via `would_join_multi_scc` on the I-condensation; the removal-inside-multi-SCC exactness caveat routes through `CondensationOrder`'s built-in bidirectional fallback (PR 2); the rare multi case materializes the I-SCC via the existing `OverlayGraphView::scc_containing` for the constraining-pair lookup.
  - **Tier 3** — the shared scoped-simulator evaluation. The Pass-2 block of `verdict_with_overlay_touching` is factored into `overlay_constraining_pair_inside` / `overlay_tdz_pairs`, and tier 3 calls the same helpers — boolean and evidence forms literally run one implementation, "Decide/Explain as output verbosity".
- **`DEBUNDLE_GATE_ORACLE=1`** (§7.2): every ladder query cross-checks against the pure `check_realizability_touching` reference on the post-move partition, and every diagnostic-path `verdict_after_moving_owners_touching` cross-checks against the ladder; divergence panics. Off by default.
- **Per-tier counters** (`gate_perf_counters`): decision counts per tier/outcome plus `DEBUNDLE_TIMING`-gated per-tier cumulative wall times, reported by the existing `SccTimingReporter` — the §7.5 perf-gate inputs ("tier-3 builds in single digits; tier-1+2 wall ≤ 2× PK").
- **Differential harness (PR 1's deferred caveat)**: `QuotientGraph::ladder_decision_for_merge` exposes the kernel-side query (`compute_merge_deltas` → ladder), and every fixture + randomized-sweep comparison now asserts **strict ladder-vs-reference equality** (no catalog — asserted even on dirty pre-states, since the ladder is the post-state predicate itself) plus §7.1 **tier-skip soundness** (tier-1 reject ⇒ `MutualConstrainingCycle` / cross-rebind in the reference; tier-2 accept ⇒ no `EsmEvaluationTdz`; tier-3 reject ⇒ `EsmEvaluationTdz`). The PR-1 fixtures that pin the *legacy gate's* divergences are unchanged and still diverge — they now simultaneously prove the ladder fixes those same queries.
- New index-level tests pin which tier decides each canonical shape (delta-free clean/dirty, constraining 2-cycle, promotion-created cross-rebind, acyclic cross edge, pure-lazy cycle, Lemma-2 rescue, constraining-edge-into-residual TDZ) and that the ladder tracks the overlay verdict across push/commit/undo (exercising incremental maintenance and invalidate-on-undo).

## Deviations from §8 / notes

- §8's text only names the boolean entry point; the `LadderDecision` enum twin was added so the harness's tier-skip-soundness assertions and the per-tier counters don't have to re-derive which tier decided. The boolean wrapper keeps the §8 name.
- The plan's tier-2′ "exact SCC fallback" counter is not separately surfaced: the fallback lives inside `CondensationOrder::would_join_multi_scc` (PR 2) and isn't observable from the ladder; tier-3 build counts are already covered by the existing simulator-rebuild counters.
- The oracle additionally cross-checks the diagnostic verdict path against the ladder (not just ladder vs pure reference) so `DEBUNDLE_GATE_ORACLE=1 modules propose` exercises the ladder on real corpora *before* the PR 4 cutover — §7.2's oracle would otherwise have no production caller in this PR.
- AGENTS.md's "props/frontend debundle green" verification layer: no `props/frontend/debundle/` corpus exists at devel HEAD, so that layer is vacuous here (and production behavior is unchanged anyway).

## Behavior diffs

None. The hot gate, seed diagnostics, and proposal output are byte-identical — the §7.3 pinning tests remain `#[ignore]`d (un-ignored in PR 4 per §8, where the class→module granularity change happens and e2e/corpus diffs get reviewed against the catalog).

## Testing

`bbr test //devinfra/js/debundle/...` — 100/100 green, including the differential harness now exercising the ladder on every query.
`BAZEL_TEST_INVOCATIONS=buildbuddy:40b3da70-0913-497e-b952-472411db048f`

https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk)_