### PR TITLE
debundle: wire proptest; property suites for CondensationOrder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,6 +295,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -915,6 +930,7 @@ dependencies = [
  "nix",
  "parking_lot",
  "petgraph",
+ "proptest",
  "rayon",
  "relative-path",
  "reqwest 0.12.28",
@@ -2578,6 +2594,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.11.1",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "psm"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2606,6 +2641,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -2746,6 +2787,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3171,6 +3221,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "rusty-leveldb"
@@ -4409,6 +4471,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4545,6 +4613,15 @@ checksum = "6ba782755fc073877e567c2253c0be48e4aa9a254c232d36d3985dfae0bd5205"
 dependencies = [
  "libc",
  "nix",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,9 @@ relative-path = "^2.0.1"
 lol_html = "^2.8.1"
 humantime = "^2.3.0"
 rayon = "^1.12.0"
+# debundle property-based test suites (test-only consumer; single
+# [dependencies] section because crate_universe pins one root manifest)
+proptest = "^1.6.0"
 # tana/firebase_session_extractor
 rusty-leveldb = "^4.0.1"
 v8_valueserializer = "^0.1.2"

--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -309,6 +309,7 @@ rust_library(
         "esm_import_order.rs",
         "gate.rs",
         "realizability/condensation_order.rs",
+        "realizability/condensation_order_proptest.rs",
         "realizability/esm_simulator.rs",
         "realizability/incremental_quotient.rs",
         "realizability/mod.rs",
@@ -336,6 +337,7 @@ rust_test(
     crate = ":gate",
     edition = "2024",
     deps = [
+        "@crates//:proptest",
         "@crates//:serde_json",
         "@crates//:swc_common",
         "@crates//:swc_ecma_parser",
@@ -580,6 +582,7 @@ rust_library(
         "lowering/plan_references.rs",
         "lowering/plans.rs",
         "lowering/rename_ledger.rs",
+        "lowering/rename_ledger_proptest.rs",
         "lowering/rewrite_runtime.rs",
         "lowering/runtime_imports.rs",
         "lowering/scope_names.rs",
@@ -615,6 +618,7 @@ rust_test(
     name = "lowering_test",
     crate = ":lowering",
     edition = "2024",
+    deps = ["@crates//:proptest"],
 )
 
 rust_library(

--- a/devinfra/js/debundle/lowering/mod.rs
+++ b/devinfra/js/debundle/lowering/mod.rs
@@ -50,6 +50,8 @@ mod ordinal;
 mod plan_references;
 mod plans;
 pub mod rename_ledger;
+#[cfg(test)]
+mod rename_ledger_proptest;
 mod rewrite_runtime;
 mod runtime_imports;
 mod scope_names;

--- a/devinfra/js/debundle/lowering/rename_ledger.rs
+++ b/devinfra/js/debundle/lowering/rename_ledger.rs
@@ -104,7 +104,7 @@
 //! Vendor boundary renames (`vendor/`) run in a separate pipeline stage on
 //! different artifacts and are out of this ledger's scope.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt;
 
 use analysis::ModuleId;
@@ -266,14 +266,15 @@ impl RenameLedger {
                 .max()
                 .expect("groups hold at least one intent");
             // Distinct targets proposed at the top priority, each with the
-            // (sorted, deduped) contributors proposing it.
-            let mut by_target: BTreeMap<&Atom, Vec<RenameOrigin>> = BTreeMap::new();
+            // (sorted, deduped) contributors proposing it — a BTreeSet so
+            // the rendered conflict is independent of submission order.
+            let mut by_target: BTreeMap<&Atom, BTreeSet<RenameOrigin>> = BTreeMap::new();
             for intent in &intents {
                 if intent.origin.priority() == top_priority {
-                    let origins = by_target.entry(&intent.to).or_default();
-                    if !origins.contains(&intent.origin) {
-                        origins.push(intent.origin);
-                    }
+                    by_target
+                        .entry(&intent.to)
+                        .or_default()
+                        .insert(intent.origin);
                 }
             }
             if by_target.len() > 1 {

--- a/devinfra/js/debundle/lowering/rename_ledger_proptest.rs
+++ b/devinfra/js/debundle/lowering/rename_ledger_proptest.rs
@@ -1,0 +1,253 @@
+//! Proptest suite for the public `RenameLedger` seal contract
+//! (rename pipeline PR 2 surface, #2091): seal determinism under
+//! intent permutation and duplication, priority dominance,
+//! same-priority conflicts always erroring naming both origins, and
+//! per-scope validation isolation.
+//!
+//! Deliberately written against the public `submit`/`seal`/
+//! `SealedRenames` query API only — seal-internal validation is in
+//! flux (PR 3 moves occupancy/capture validation into seal), and these
+//! properties must survive that change unedited or with mechanical
+//! signature updates only. Case counts are bounded for CI (see
+//! [`ci_config`]); override locally via
+//! `bbr test //devinfra/js/debundle:lowering_test
+//! --test_env=PROPTEST_CASES=2000`.
+
+use std::collections::BTreeMap;
+
+use analysis::ModuleId;
+use proptest::prelude::*;
+use proptest::sample::select;
+use proptest::test_runner::TestCaseError;
+use swc_atoms::Atom;
+use swc_common::SyntaxContext;
+use swc_ecma_ast::Id;
+
+use super::rename_ledger::{
+    FunctionScopeId, RenameIntent, RenameLedger, RenameOrigin, RenameScope, SealedRenames,
+};
+
+/// Source-binding pool, disjoint from [`TARGETS`] so a generated
+/// rename never maps a name to itself.
+const SOURCES: [&str; 4] = ["a", "b", "c", "d"];
+const TARGETS: [&str; 3] = ["n0", "n1", "n2"];
+const CONTRIBUTORS: [&str; 3] = ["alpha", "beta", "gamma"];
+
+fn id(sym: &str) -> Id {
+    (Atom::from(sym), SyntaxContext::empty())
+}
+
+fn origin_at(priority_kind: usize, contributor: &'static str) -> RenameOrigin {
+    match priority_kind {
+        0 => RenameOrigin::Explicit { contributor },
+        1 => RenameOrigin::ImportInduced { contributor },
+        _ => RenameOrigin::Heuristic { contributor },
+    }
+}
+
+fn arb_origin() -> impl Strategy<Value = RenameOrigin> {
+    (0..3usize, select(&CONTRIBUTORS[..]))
+        .prop_map(|(kind, contributor)| origin_at(kind, contributor))
+}
+
+fn arb_scope() -> impl Strategy<Value = RenameScope> {
+    prop_oneof![
+        Just(RenameScope::Chunk),
+        (0..3usize).prop_map(|index| RenameScope::Module(ModuleId::logical(index))),
+        prop_oneof![
+            Just(FunctionScopeId { lo: 1, hi: 9 }),
+            Just(FunctionScopeId { lo: 10, hi: 20 }),
+        ]
+        .prop_map(RenameScope::Function),
+        Just(RenameScope::EntryPublicExports),
+    ]
+}
+
+fn arb_intent() -> impl Strategy<Value = RenameIntent> {
+    (
+        arb_scope(),
+        select(&SOURCES[..]),
+        select(&TARGETS[..]),
+        arb_origin(),
+    )
+        .prop_map(|(scope, from, to, origin)| RenameIntent {
+            scope,
+            from: id(from),
+            to: Atom::from(to),
+            origin,
+        })
+}
+
+/// A pair of distinct indices into `0..n`.
+fn distinct_pair(n: usize) -> impl Strategy<Value = (usize, usize)> {
+    (0..n, 0..n - 1)
+        .prop_map(|(first, second)| (first, if second >= first { second + 1 } else { second }))
+}
+
+/// Submit all intents into a fresh ledger and seal. Errors projected
+/// to their message so results are comparable.
+fn seal_all(intents: Vec<RenameIntent>) -> Result<SealedRenames, String> {
+    let mut ledger = RenameLedger::default();
+    for intent in intents {
+        ledger.submit(intent);
+    }
+    ledger.seal().map_err(|error| error.to_string())
+}
+
+/// Bounded case count for CI; a `PROPTEST_CASES` env override still
+/// wins for longer local runs (`ProptestConfig::default()` reads it).
+fn ci_config(cases: u32) -> ProptestConfig {
+    let mut config = ProptestConfig::default();
+    if std::env::var_os("PROPTEST_CASES").is_none() {
+        config.cases = cases;
+    }
+    config
+}
+
+proptest! {
+    #![proptest_config(ci_config(128))]
+
+    /// Seal output (or the full conflict error) is independent of
+    /// intent submission order.
+    #[test]
+    fn seal_is_deterministic_under_intent_permutation(
+        (intents, shuffled) in proptest::collection::vec(arb_intent(), 0..12)
+            .prop_flat_map(|intents| {
+                let shuffled = Just(intents.clone()).prop_shuffle();
+                (Just(intents), shuffled)
+            }),
+    ) {
+        prop_assert_eq!(seal_all(intents), seal_all(shuffled));
+    }
+
+    /// Submitting every intent twice seals identically to submitting
+    /// it once — identical duplicates collapse.
+    #[test]
+    fn duplicate_submissions_do_not_change_seal(
+        intents in proptest::collection::vec(arb_intent(), 0..10),
+    ) {
+        let doubled: Vec<RenameIntent> = intents
+            .iter()
+            .flat_map(|intent| [intent.clone(), intent.clone()])
+            .collect();
+        prop_assert_eq!(seal_all(intents), seal_all(doubled));
+    }
+
+    /// A single explicit intent dominates any set of disagreeing
+    /// lower-priority (import-induced / heuristic) intents on the same
+    /// `(scope, from)`: seal succeeds and resolves to the explicit
+    /// target, regardless of how the lower-priority intents conflict
+    /// among themselves at their own priority tiers.
+    #[test]
+    fn explicit_intent_dominates_lower_priority_disagreement(
+        scope in arb_scope(),
+        from in select(&SOURCES[..]),
+        explicit_to in select(&TARGETS[..]),
+        lower in proptest::collection::vec(
+            (select(&TARGETS[..]), 1..3usize, select(&CONTRIBUTORS[..])),
+            0..6,
+        ),
+    ) {
+        let mut ledger = RenameLedger::default();
+        for (to, priority_kind, contributor) in lower {
+            ledger.submit(RenameIntent {
+                scope,
+                from: id(from),
+                to: Atom::from(to),
+                origin: origin_at(priority_kind, contributor),
+            });
+        }
+        ledger.submit(RenameIntent {
+            scope,
+            from: id(from),
+            to: Atom::from(explicit_to),
+            origin: RenameOrigin::Explicit { contributor: "explicit_winner" },
+        });
+        let sealed = ledger
+            .seal()
+            .map_err(|error| TestCaseError::fail(error.to_string()))?;
+        let expected = BTreeMap::from([(id(from), Atom::from(explicit_to))]);
+        prop_assert_eq!(sealed.scope_renames(&scope), Some(&expected));
+    }
+
+    /// Two intents at the same priority disagreeing on one
+    /// `(scope, from)` target always seal to a hard error whose
+    /// message names both origins' contributors and both targets.
+    #[test]
+    fn same_priority_disagreement_errors_naming_both_origins(
+        scope in arb_scope(),
+        from in select(&SOURCES[..]),
+        priority_kind in 0..3usize,
+        (target_a, target_b) in distinct_pair(TARGETS.len()),
+        (contributor_a, contributor_b) in distinct_pair(CONTRIBUTORS.len()),
+    ) {
+        let mut ledger = RenameLedger::default();
+        ledger.submit(RenameIntent {
+            scope,
+            from: id(from),
+            to: Atom::from(TARGETS[target_a]),
+            origin: origin_at(priority_kind, CONTRIBUTORS[contributor_a]),
+        });
+        ledger.submit(RenameIntent {
+            scope,
+            from: id(from),
+            to: Atom::from(TARGETS[target_b]),
+            origin: origin_at(priority_kind, CONTRIBUTORS[contributor_b]),
+        });
+        let message = match ledger.seal() {
+            Ok(_) => return Err(TestCaseError::fail(
+                "same-priority disagreement sealed successfully",
+            )),
+            Err(error) => error.to_string(),
+        };
+        for needle in [
+            CONTRIBUTORS[contributor_a],
+            CONTRIBUTORS[contributor_b],
+            TARGETS[target_a],
+            TARGETS[target_b],
+        ] {
+            prop_assert!(
+                message.contains(needle),
+                "conflict error omits `{}`: {}",
+                needle, message,
+            );
+        }
+    }
+
+    /// Scopes validate independently: the combined ledger seals iff
+    /// every per-scope subset seals on its own, and a successful
+    /// combined seal answers each scope's queries exactly as the
+    /// scope's intents sealed in isolation — no cross-scope leakage.
+    #[test]
+    fn seal_validates_each_scope_independently(
+        intents in proptest::collection::vec(arb_intent(), 0..14),
+    ) {
+        let mut by_scope: BTreeMap<RenameScope, Vec<RenameIntent>> = BTreeMap::new();
+        for intent in &intents {
+            by_scope.entry(intent.scope).or_default().push(intent.clone());
+        }
+        let per_scope: BTreeMap<RenameScope, Result<SealedRenames, String>> = by_scope
+            .into_iter()
+            .map(|(scope, scope_intents)| (scope, seal_all(scope_intents)))
+            .collect();
+        match seal_all(intents) {
+            Ok(combined) => {
+                for (scope, result) in &per_scope {
+                    let solo = match result {
+                        Ok(solo) => solo,
+                        Err(error) => return Err(TestCaseError::fail(format!(
+                            "combined seal succeeded but {scope} alone fails: {error}",
+                        ))),
+                    };
+                    prop_assert_eq!(combined.scope_renames(scope), solo.scope_renames(scope));
+                }
+            }
+            Err(_) => {
+                prop_assert!(
+                    per_scope.values().any(|result| result.is_err()),
+                    "combined seal failed but every scope seals in isolation",
+                );
+            }
+        }
+    }
+}

--- a/devinfra/js/debundle/plans/sanitization_program_2026_06.md
+++ b/devinfra/js/debundle/plans/sanitization_program_2026_06.md
@@ -130,6 +130,14 @@ fixes.
    `check_realizability`, with an _independent_ reference partition builder
    (the flagship differential currently shares the kernel's own
    projection); cover the gate-residual promotion transition.
+   _Status (2026-06)_: proptest is wired into the Rust/Bazel build
+   (`@crates//:proptest`) and the first property suites landed —
+   `realizability/condensation_order_proptest.rs` (digraph
+   mutation/overlay sequences vs `tarjan_scc` brute force) and
+   `lowering/rename_ledger_proptest.rs` (public seal contract). The
+   remaining F1 step is migrating the gate-differential harness
+   (`peel/gate_differential_test.rs`) to proptest strategies,
+   scheduled with gate-ladder PR 4+.
 2. **Lemma pinning**: named tests for Lemmas 1/3/4/5 (only Lemma 2 has
    them); extend the #2071 Node-differential to a fixture sweep.
 3. **Excalidraw public smoke** (TODO's big standing item): the

--- a/devinfra/js/debundle/realizability/condensation_order.rs
+++ b/devinfra/js/debundle/realizability/condensation_order.rs
@@ -1023,24 +1023,28 @@ fn effective_count<N: Copy + Ord>(
     base.edge_count(from, to) as isize + overlay.get(&(from, to)).copied().unwrap_or(0)
 }
 
+/// Brute-force reference implementations shared by the pinned-seed
+/// xorshift suites below and the proptest differential suite
+/// (`condensation_order_proptest.rs`).
 #[cfg(test)]
-mod tests {
+pub(super) mod test_support {
     use std::collections::{BTreeMap, BTreeSet};
 
     use petgraph::algo::tarjan_scc;
     use petgraph::graphmap::DiGraphMap;
 
-    use super::*;
+    use super::CondensationOrder;
+    use crate::rollback_graph::RollbackDiGraph;
 
     /// Sentinel for the identified `{u, v}` node in the brute-force
     /// reference graphs.
     const MERGED: usize = usize::MAX;
 
-    fn no_overlay() -> BTreeMap<(usize, usize), isize> {
+    pub fn no_overlay() -> BTreeMap<(usize, usize), isize> {
         BTreeMap::new()
     }
 
-    fn graph(edges: &[(usize, usize)]) -> RollbackDiGraph<usize> {
+    pub fn graph(edges: &[(usize, usize)]) -> RollbackDiGraph<usize> {
         let mut graph = RollbackDiGraph::new();
         for &(a, b) in edges {
             graph.increment_edge(a, b);
@@ -1048,41 +1052,22 @@ mod tests {
         graph
     }
 
-    /// Build a fresh `CondensationOrder` that has seen every edge of
-    /// `base` via `insert_edge` (after a forced initial rebuild on an
-    /// empty graph, so the incremental insertion path is exercised).
-    fn order_via_inserts(base: &RollbackDiGraph<usize>) -> CondensationOrder<usize> {
-        let mut order = CondensationOrder::new();
-        let empty = RollbackDiGraph::<usize>::new();
-        // Force the initial rebuild on the empty graph so subsequent
-        // insert_edge calls run the incremental PK path, not rebuild.
-        assert!(!order.is_in_multi_scc(&empty, 0));
-        let mut shadow = RollbackDiGraph::new();
-        for (a, b) in base.edge_pairs() {
-            for _ in 0..base.edge_count(a, b) {
-                shadow.increment_edge(a, b);
-                order.insert_edge(&shadow, a, b);
-            }
-        }
-        order
-    }
-
     /// Test-side contraction-alias mirror, independent of the
     /// structure's internal union-find.
     #[derive(Clone, Default)]
-    struct TestAlias {
+    pub struct TestAlias {
         parent: BTreeMap<usize, usize>,
     }
 
     impl TestAlias {
-        fn find(&self, mut x: usize) -> usize {
+        pub fn find(&self, mut x: usize) -> usize {
             while let Some(&p) = self.parent.get(&x) {
                 x = p;
             }
             x
         }
 
-        fn union(&mut self, winner: usize, loser: usize) {
+        pub fn union(&mut self, winner: usize, loser: usize) {
             let rw = self.find(winner);
             let rl = self.find(loser);
             if rw != rl {
@@ -1114,7 +1099,7 @@ mod tests {
     /// the effective graph with `u`'s and `v`'s alias classes
     /// identified into a sentinel node; true iff the sentinel's SCC
     /// has size ≥ 2.
-    fn brute_would_join(
+    pub fn brute_would_join(
         base: &RollbackDiGraph<usize>,
         alias: &TestAlias,
         overlay: &BTreeMap<(usize, usize), isize>,
@@ -1159,7 +1144,7 @@ mod tests {
 
     /// Assert `is_in_multi_scc` matches the brute-force partition for
     /// every node in the universe.
-    fn assert_multi_matches_brute(
+    pub fn assert_multi_matches_brute(
         order: &mut CondensationOrder<usize>,
         base: &RollbackDiGraph<usize>,
         alias: &TestAlias,
@@ -1175,6 +1160,33 @@ mod tests {
                 "{context}: is_in_multi_scc({n}) diverges from tarjan",
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeMap, BTreeSet};
+
+    use super::test_support::*;
+    use super::*;
+
+    /// Build a fresh `CondensationOrder` that has seen every edge of
+    /// `base` via `insert_edge` (after a forced initial rebuild on an
+    /// empty graph, so the incremental insertion path is exercised).
+    fn order_via_inserts(base: &RollbackDiGraph<usize>) -> CondensationOrder<usize> {
+        let mut order = CondensationOrder::new();
+        let empty = RollbackDiGraph::<usize>::new();
+        // Force the initial rebuild on the empty graph so subsequent
+        // insert_edge calls run the incremental PK path, not rebuild.
+        assert!(!order.is_in_multi_scc(&empty, 0));
+        let mut shadow = RollbackDiGraph::new();
+        for (a, b) in base.edge_pairs() {
+            for _ in 0..base.edge_count(a, b) {
+                shadow.increment_edge(a, b);
+                order.insert_edge(&shadow, a, b);
+            }
+        }
+        order
     }
 
     #[test]

--- a/devinfra/js/debundle/realizability/condensation_order_proptest.rs
+++ b/devinfra/js/debundle/realizability/condensation_order_proptest.rs
@@ -1,0 +1,205 @@
+//! Proptest differential suite for [`CondensationOrder`]: random
+//! digraphs driven through proptest-generated interleaved sequences of
+//! edge insertions / removals / contractions / invalidations with
+//! speculative overlay queries, checked **after every operation**
+//! against a petgraph `tarjan_scc` brute-force recompute (the shared
+//! reference implementations in `condensation_order::test_support`).
+//!
+//! Complements the pinned-seed xorshift suites in
+//! `condensation_order.rs` — those stay as fast fixed-seed
+//! regressions; this suite explores fresh cases per run with
+//! proptest's shrinking. The case count is bounded for CI (see
+//! [`ci_config`]); for a longer local run override it via
+//! `bbr test //devinfra/js/debundle:gate_test
+//! --test_env=PROPTEST_CASES=2000`.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use proptest::prelude::*;
+use proptest::test_runner::TestCaseError;
+
+use super::CondensationOrder;
+use super::condensation_order::test_support::{
+    TestAlias, assert_multi_matches_brute, brute_would_join,
+};
+use crate::rollback_graph::RollbackDiGraph;
+
+/// Node universe size. Small enough that the brute-force recompute
+/// after every operation stays cheap; large enough for nontrivial
+/// SCC / condensation shapes.
+const NODES: usize = 8;
+
+/// One committed mutation against the base graph + maintained order.
+#[derive(Debug, Clone, Copy)]
+enum Op {
+    InsertEdge(usize, usize),
+    RemoveEdge(usize, usize),
+    Contract { winner: usize, loser: usize },
+    Invalidate,
+}
+
+/// Speculative overlay entry: `remove` zeroes the base edge's
+/// multiplicity (no-op when the edge is absent at query time),
+/// otherwise the entry adds one edge.
+#[derive(Debug, Clone, Copy)]
+struct OverlayEntry {
+    from: usize,
+    to: usize,
+    remove: bool,
+}
+
+/// One step: a committed mutation plus a speculative
+/// `would_join_multi_scc` query (pair + overlay) differential-checked
+/// on top of the mutated state.
+#[derive(Debug, Clone)]
+struct Step {
+    op: Op,
+    query: (usize, usize),
+    overlay: Vec<OverlayEntry>,
+}
+
+fn arb_node() -> impl Strategy<Value = usize> {
+    0..NODES
+}
+
+fn arb_op() -> impl Strategy<Value = Op> {
+    prop_oneof![
+        4 => (arb_node(), arb_node()).prop_map(|(a, b)| Op::InsertEdge(a, b)),
+        3 => (arb_node(), arb_node()).prop_map(|(a, b)| Op::RemoveEdge(a, b)),
+        2 => (arb_node(), arb_node()).prop_map(|(winner, loser)| Op::Contract { winner, loser }),
+        1 => Just(Op::Invalidate),
+    ]
+}
+
+fn arb_overlay_entries() -> impl Strategy<Value = Vec<OverlayEntry>> {
+    proptest::collection::vec(
+        (arb_node(), arb_node(), any::<bool>()).prop_map(|(from, to, remove)| OverlayEntry {
+            from,
+            to,
+            remove,
+        }),
+        0..3,
+    )
+}
+
+fn arb_step() -> impl Strategy<Value = Step> {
+    (arb_op(), (arb_node(), arb_node()), arb_overlay_entries())
+        .prop_map(|(op, query, overlay)| Step { op, query, overlay })
+}
+
+/// Resolve generated overlay entries against the *current* base
+/// graph: `remove` entries zero out an existing edge's multiplicity,
+/// additions contribute `+1` — the `QuotientOverlay` delta shape.
+fn build_overlay(
+    base: &RollbackDiGraph<usize>,
+    entries: &[OverlayEntry],
+) -> BTreeMap<(usize, usize), isize> {
+    let mut overlay = BTreeMap::new();
+    for entry in entries {
+        if entry.from == entry.to {
+            continue;
+        }
+        if entry.remove {
+            let count = base.edge_count(entry.from, entry.to);
+            if count > 0 {
+                overlay.insert((entry.from, entry.to), -(count as isize));
+            }
+        } else {
+            *overlay.entry((entry.from, entry.to)).or_insert(0) += 1;
+        }
+    }
+    overlay
+}
+
+/// Bounded case count for CI; a `PROPTEST_CASES` env override still
+/// wins for longer local runs (`ProptestConfig::default()` reads it).
+fn ci_config(cases: u32) -> ProptestConfig {
+    let mut config = ProptestConfig::default();
+    if std::env::var_os("PROPTEST_CASES").is_none() {
+        config.cases = cases;
+    }
+    config
+}
+
+proptest! {
+    #![proptest_config(ci_config(64))]
+
+    /// After every committed operation: the internal invariants hold
+    /// (`validate` — rank/inverse agreement, the topological rank
+    /// order over the condensation, module-count bookkeeping),
+    /// per-node multi-SCC membership matches a fresh tarjan
+    /// recompute, and a speculative overlay query matches the
+    /// brute-force identified-graph reference.
+    #[test]
+    fn mutation_sequences_match_brute_force(
+        steps in proptest::collection::vec(arb_step(), 1..50),
+    ) {
+        let universe: BTreeSet<usize> = (0..NODES).collect();
+        let mut base = RollbackDiGraph::new();
+        let mut alias = TestAlias::default();
+        let mut order = CondensationOrder::new();
+        for (step_index, step) in steps.iter().enumerate() {
+            match step.op {
+                Op::InsertEdge(a, b) => {
+                    if a != b {
+                        base.increment_edge(a, b);
+                        order.insert_edge(&base, a, b);
+                    }
+                }
+                Op::RemoveEdge(a, b) => {
+                    if a != b && base.edge_count(a, b) > 0 {
+                        base.decrement_edge(a, b);
+                        order.remove_edge(&base, a, b);
+                    }
+                }
+                Op::Contract { winner, loser } => {
+                    if winner != loser {
+                        order.apply_contract(&base, winner, loser);
+                        alias.union(winner, loser);
+                    }
+                }
+                Op::Invalidate => order.invalidate(),
+            }
+            let context = format!("step {step_index}: {:?}", step.op);
+            assert_multi_matches_brute(&mut order, &base, &alias, &universe, &context);
+            if let Err(violation) = order.validate(&base) {
+                return Err(TestCaseError::fail(format!("{context}: {violation}")));
+            }
+            let overlay = build_overlay(&base, &step.overlay);
+            let (u, v) = step.query;
+            prop_assert_eq!(
+                order.would_join_multi_scc(&base, &overlay, u, v),
+                brute_would_join(&base, &alias, &overlay, u, v),
+                "{}: would_join({}, {}) overlay={:?}",
+                context, u, v, overlay,
+            );
+        }
+    }
+
+    /// Cold start: `would_join_multi_scc` on a fresh order (the first
+    /// query triggers the lazy rebuild) matches the brute-force
+    /// reference for random graphs + overlays.
+    #[test]
+    fn cold_start_would_join_matches_brute_force(
+        edges in proptest::collection::vec((arb_node(), arb_node()), 0..30),
+        entries in arb_overlay_entries(),
+        u in arb_node(),
+        v in arb_node(),
+    ) {
+        let mut base = RollbackDiGraph::new();
+        for &(a, b) in &edges {
+            if a != b {
+                base.increment_edge(a, b);
+            }
+        }
+        let overlay = build_overlay(&base, &entries);
+        let alias = TestAlias::default();
+        let mut order = CondensationOrder::new();
+        prop_assert_eq!(
+            order.would_join_multi_scc(&base, &overlay, u, v),
+            brute_would_join(&base, &alias, &overlay, u, v),
+            "would_join({}, {}) overlay={:?}",
+            u, v, overlay,
+        );
+    }
+}

--- a/devinfra/js/debundle/realizability/mod.rs
+++ b/devinfra/js/debundle/realizability/mod.rs
@@ -44,6 +44,8 @@ use analysis::ids::ModuleId;
 use analysis::partition::Partition;
 
 mod condensation_order;
+#[cfg(test)]
+mod condensation_order_proptest;
 mod esm_simulator;
 mod incremental_quotient;
 


### PR DESCRIPTION
## What

Wires **proptest 1.6** into the Rust crate universe (root `Cargo.toml` + `Cargo.Bazel.lock` repin, `@crates//:proptest` in BUILD deps) and lands the first property suites:

- **`realizability/condensation_order_proptest.rs`** — random digraphs driven through proptest-generated insert/remove/contract/invalidate sequences with speculative overlay queries, differentially checked after every operation against a petgraph `tarjan_scc` brute-force recompute (shared reference impls extracted to `condensation_order::test_support`). Existing pinned-seed xorshift suites kept as fast fixed-seed regressions. Cases shrink on failure; counts are CI-bounded via a `PROPTEST_CASES`-respecting config.
- **`lowering/rename_ledger_proptest.rs`** — RenameLedger properties were **included** (not deferred): public seal-API determinism under permutation/duplication, explicit-priority dominance, same-priority conflict errors naming both origins, per-scope validation isolation. `RenameLedger` conflict rendering switched to `BTreeSet` so conflict messages are submission-order independent.

Also adds a note to `devinfra/js/debundle/plans/sanitization_program_2026_06.md` (no `TODO.md` change).

## Repin fallout

None — the repin adds proptest and its transitive deps (`bit-set`, `bit-vec`, `quick-error`, `rand_xorshift`, `rusty-fork`, `unarray`, `wait-timeout`) to `Cargo.lock`; no existing crate versions moved. Full-universe `bbr build //...` is green.

## Verification

- `bbr build //...` — green (7808 actions, invocation `6af90dbf-127a-45d8-8764-ab5ade9a9685`)
- `bbr test //devinfra/js/debundle/...` — 100/100 pass (invocation `eaf63dcd-e9cb-4304-870b-59ffb7f035c2`)
- `bbr test //devinfra/js/debundle:gate_test //devinfra/js/debundle:lowering_test --nocache_test_results` — both executed fresh and pass; test logs confirm `condensation_order_proptest::{cold_start_would_join_matches_brute_force,mutation_sequences_match_brute_force}` and all five `rename_ledger_proptest::*` properties ran (invocation `d288dcae-ecb0-47c1-a9ed-7f035edac10f`)

## Interaction note

Branch `claude/debundle-gate-ladder-4` (in flight) deletes `peel/topo_order.rs` and edits the gate area — whichever merges second rebases.

https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk)_