### PR TITLE
loom/gym: reach litellm by in-cluster svc name in the eval Job

### DIFF
--- a/loom/gym/k8s/eval-job.yaml
+++ b/loom/gym/k8s/eval-job.yaml
@@ -51,6 +51,12 @@ spec:
           args:
             - --model-id
             - glm-4.5
+            # Reach litellm by its in-cluster service name (NO_PROXY excludes
+            # .svc.cluster.local), so the model API calls go direct and skip the
+            # agent mitmproxy — whose MITM cert the model client (httpx) doesn't
+            # trust, which otherwise hangs every call. Same bypass as DOCKER_HOST.
+            - --base-url
+            - http://litellm.litellm.svc.cluster.local:4000
             - --task-filter
             - manifold-
             - --wayback-upstream


### PR DESCRIPTION
Third and final fix for the in-cluster loom/gym eval (after #2093, #2096).

## Symptom

With the clone (#2096) and cert-perms (#2096) fixes in place, the eval reached the actual run but **stalled with zero samples completing** — driver idle at **1m CPU**, ~20 docker-ci sandboxes up for 17+ min, no errors logged.

## Cause

The eval driver's model calls (`httpx`, via the Inspect anthropic provider) egress through the agent mitmproxy and target `https://litellm.allegedly.works`. Unlike `curl`/`requests`, **`httpx` doesn't trust the mitmproxy MITM cert** from `SSL_CERT_FILE`/`REQUESTS_CA_BUNDLE`, so every glm-4.5 call silently hangs.

## Fix

Point `--base-url` at the in-cluster service `http://litellm.litellm.svc.cluster.local:4000`. `NO_PROXY` excludes `.svc.cluster.local`, so model calls go **direct, bypassing the MITM entirely** — the same in-cluster-svc bypass already used for `DOCKER_HOST` and the wayback cache. Manifest-only (a CLI arg), no image rebuild.

## Validation

- In-cluster litellm svc probed reachable/fast: `/health` 200 in ~5ms, `/v1/models` 401 (direct, `--noproxy`).
- The official run (rebuilt image carrying #2096's clone fix + this `--base-url`) jumped from **1m CPU (hung)** to **41m CPU (actively processing)** with 30 sandboxes — model calls now flow. Watching it through to final scores.

https://claude.ai/code/session_01AXSFxfCXddADoSKTjgF5Nz

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXSFxfCXddADoSKTjgF5Nz)_