### PR TITLE
Fix Tana Anthropic stream tail handling

### DIFF
--- a/tana/litellm_proxy/provider.py
+++ b/tana/litellm_proxy/provider.py
@@ -398,7 +398,7 @@ class TanaLiteLLM(CustomLLM):
         model = _required_kwarg("model", kwargs)
         messages = _required_kwarg("messages", kwargs)
         optional_params = kwargs.get("optional_params") or {}
-        return self._client.stream_completion(model, messages, optional_params)
+        yield from _filter_stream_chunks(self._client.stream_completion(model, messages, optional_params))
 
     # LiteLLM's base type annotates this as a coroutine, but the streaming
     # dispatcher consumes the returned object as an async iterator.
@@ -426,7 +426,11 @@ class TanaLiteLLM(CustomLLM):
         async for chunk in self._client.astream_completion(
             model, cast(Sequence[Mapping[str, Any]], messages), optional_params
         ):
+            if _is_empty_nonterminal_stream_chunk(chunk):
+                continue
             yield chunk
+            if _is_terminal_stream_chunk(chunk):
+                break
 
 
 def register_litellm_provider(handler: TanaLiteLLM | None = None) -> TanaLiteLLM:
@@ -899,19 +903,52 @@ def _parse_tana_stream_line(line: str) -> list[GenericStreamingChunk]:
     return chunks
 
 
+def _filter_stream_chunks(chunks: Iterator[GenericStreamingChunk]) -> Iterator[GenericStreamingChunk]:
+    for chunk in chunks:
+        if _is_empty_nonterminal_stream_chunk(chunk):
+            continue
+        yield chunk
+        if _is_terminal_stream_chunk(chunk):
+            break
+
+
+def _is_empty_nonterminal_stream_chunk(chunk: GenericStreamingChunk) -> bool:
+    return (
+        not _is_terminal_stream_chunk(chunk)
+        and chunk.get("text") == ""
+        and chunk.get("tool_use") is None
+        and chunk.get("usage") is None
+        and chunk.get("provider_specific_fields") is None
+    )
+
+
+def _is_terminal_stream_chunk(chunk: GenericStreamingChunk) -> bool:
+    return bool(chunk.get("is_finished") or chunk.get("finish_reason"))
+
+
 class _TanaStreamParser:
     def __init__(self) -> None:
         self._pending_tool_calls: dict[str, dict[str, Any]] = {}
+        self._emitted_tool_calls = False
+        self._finished = False
 
     def parse_line(self, line: str) -> list[GenericStreamingChunk]:
         return self._parse_line(line)
 
     def finish(self) -> list[GenericStreamingChunk]:
-        return self._flush_tool_call_chunks()
+        if self._finished:
+            return []
+        tool_chunks = self._flush_tool_call_chunks()
+        if not tool_chunks:
+            return []
+        self._finished = True
+        return [*tool_chunks, _stream_chunk(is_finished=True, finish_reason="tool_calls")]
 
     def _parse_line(self, line: str) -> list[GenericStreamingChunk]:
         stripped = line.strip()
         if not stripped:
+            return []
+        if self._finished:
             return []
 
         if stripped.startswith("data:"):
@@ -933,12 +970,7 @@ class _TanaStreamParser:
                 return []
             if not isinstance(data, Mapping):
                 return []
-            tool_chunks = self._flush_tool_call_chunks()
-            finish_reason = _stream_finish_reason(str(data.get("finishReason") or "stop"), bool(tool_chunks))
-            return [
-                *tool_chunks,
-                _stream_chunk(is_finished=True, finish_reason=finish_reason, usage=_normalize_stream_usage(data)),
-            ]
+            return self._finish_chunks(str(data.get("finishReason") or "stop"), _normalize_stream_usage(data))
 
         if stripped.startswith("0:"):
             try:
@@ -972,29 +1004,20 @@ class _TanaStreamParser:
             message_metadata = data.get("messageMetadata")
             if isinstance(message_metadata, Mapping):
                 self._remember_tool_calls(message_metadata.get("toolCalls"))
-                tool_chunks = self._flush_tool_call_chunks()
-                chunks.extend(tool_chunks)
                 provider_fields: dict[str, Any] = {}
                 _copy_if_set(message_metadata, provider_fields, "providerMetadata", "tana_providerMetadata")
                 _copy_if_set(message_metadata, provider_fields, "warnings", "tana_warnings")
                 _copy_if_set(message_metadata, provider_fields, "response", "tana_response")
-                finish_reason = _stream_finish_reason(
-                    str(data.get("finishReason") or message_metadata.get("finishReason") or "stop"), bool(tool_chunks)
-                )
-                chunks.append(
-                    _stream_chunk(
-                        is_finished=True,
-                        finish_reason=finish_reason,
-                        usage=_normalize_stream_usage(message_metadata),
+                chunks.extend(
+                    self._finish_chunks(
+                        str(data.get("finishReason") or message_metadata.get("finishReason") or "stop"),
+                        _normalize_stream_usage(message_metadata),
                         provider_specific_fields=provider_fields or None,
                     )
                 )
             else:
-                tool_chunks = self._flush_tool_call_chunks()
-                chunks.extend(tool_chunks)
-                finish_reason = _stream_finish_reason(str(data.get("finishReason") or "stop"), bool(tool_chunks))
-                chunks.append(
-                    _stream_chunk(is_finished=True, finish_reason=finish_reason, usage=_normalize_stream_usage(data))
+                chunks.extend(
+                    self._finish_chunks(str(data.get("finishReason") or "stop"), _normalize_stream_usage(data))
                 )
             return chunks
 
@@ -1025,7 +1048,26 @@ class _TanaStreamParser:
             if chunk is not None:
                 chunks.append(_stream_chunk(tool_use=chunk))
         self._pending_tool_calls.clear()
+        if chunks:
+            self._emitted_tool_calls = True
         return chunks
+
+    def _finish_chunks(
+        self, finish_reason: str, usage: dict[str, int] | None, provider_specific_fields: dict[str, Any] | None = None
+    ) -> list[GenericStreamingChunk]:
+        if self._finished:
+            return []
+        tool_chunks = self._flush_tool_call_chunks()
+        self._finished = True
+        return [
+            *tool_chunks,
+            _stream_chunk(
+                is_finished=True,
+                finish_reason=_stream_finish_reason(finish_reason, bool(tool_chunks) or self._emitted_tool_calls),
+                usage=usage,
+                provider_specific_fields=provider_specific_fields,
+            ),
+        ]
 
 
 def _merge_tana_tool_call(existing: Mapping[str, Any] | None, new: Mapping[str, Any]) -> dict[str, Any]:

--- a/tana/litellm_proxy/test_provider.py
+++ b/tana/litellm_proxy/test_provider.py
@@ -666,6 +666,209 @@ def test_anthropic_messages_stream_has_single_merged_tool_block() -> None:
     assert message_deltas[-1]["delta"]["stop_reason"] == "tool_use"
 
 
+def test_anthropic_messages_stream_finishes_eof_tool_call_without_orphan_delta() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "securetoken.googleapis.com":
+            return httpx.Response(
+                200, json={"id_token": "id-token-1", "refresh_token": "refresh-2", "expires_in": "3600"}
+            )
+        assert request.url == "https://app.tana.inc/functions/llmProxyNext"
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=(
+                b'data: {"type":"tool-input-available","toolCallId":"call-1",'
+                b'"toolName":"echo_tool","input":{}}\n'
+                b'data: {"type":"tool-input-available","toolCallId":"call-1",'
+                b'"toolName":"echo_tool","input":{"value":"hi"}}\n'
+            ),
+        )
+
+    original_custom_provider_map = list(litellm.custom_provider_map)
+    original_provider_list = list(litellm.provider_list)
+    original_custom_providers = list(litellm._custom_providers)
+    original_model_list_set = set(litellm.model_list_set)
+
+    async def collect_events() -> list[dict[str, Any]]:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+            client = TanaProxyClient(TanaProxyConfig(refresh_token="refresh-1"), http_client=http)
+            register_litellm_provider(TanaLiteLLM(client))
+            stream = await litellm.anthropic.messages.acreate(
+                model="tana/claude-test",
+                max_tokens=64,
+                stream=True,
+                messages=[{"role": "user", "content": "call echo_tool"}],
+                tools=[
+                    {
+                        "name": "echo_tool",
+                        "description": "Echo a value.",
+                        "input_schema": {
+                            "type": "object",
+                            "properties": {"value": {"type": "string"}},
+                            "required": ["value"],
+                        },
+                    }
+                ],
+            )
+            raw_events = [event async for event in cast(AsyncIterator[Any], stream)]
+            return [_decode_anthropic_sse_event(event) for event in raw_events]
+
+    try:
+        events = asyncio.run(collect_events())
+    finally:
+        litellm.custom_provider_map = original_custom_provider_map
+        litellm.provider_list = original_provider_list
+        litellm._custom_providers = original_custom_providers
+        litellm.model_list_set = original_model_list_set
+
+    started_blocks: set[int] = set()
+    stopped_blocks: set[int] = set()
+    for event in events:
+        event_type = event.get("type")
+        index = event.get("index")
+        if event_type == "content_block_start":
+            assert isinstance(index, int)
+            started_blocks.add(index)
+        if event_type == "content_block_delta":
+            assert isinstance(index, int)
+            assert index in started_blocks
+            assert index not in stopped_blocks
+        if event_type == "content_block_stop":
+            assert isinstance(index, int)
+            stopped_blocks.add(index)
+
+    tool_starts = [
+        event
+        for event in events
+        if event.get("type") == "content_block_start" and event.get("content_block", {}).get("type") == "tool_use"
+    ]
+    tool_deltas = [
+        event
+        for event in events
+        if event.get("type") == "content_block_delta" and event.get("delta", {}).get("type") == "input_json_delta"
+    ]
+    message_deltas = [event for event in events if event.get("type") == "message_delta"]
+    assert len(tool_starts) == 1
+    assert tool_starts[0]["content_block"] == {"type": "tool_use", "id": "call-1", "name": "echo_tool", "input": {}}
+    assert len(tool_deltas) == 1
+    assert json.loads(tool_deltas[0]["delta"]["partial_json"]) == {"value": "hi"}
+    assert message_deltas[-1]["delta"]["stop_reason"] == "tool_use"
+
+
+def test_anthropic_messages_stream_ignores_empty_chunk_after_tool_finish() -> None:
+    class FakeClient(_NoStreamingClient):
+        async def chat_completion(
+            self, model: str, messages: Sequence[Mapping[str, Any]], optional_params: Mapping[str, Any] | None = None
+        ) -> TanaChatResult:
+            raise AssertionError("streaming test should not call non-streaming chat_completion")
+
+        async def astream_completion(
+            self, model: str, messages: Sequence[Mapping[str, Any]], optional_params: Mapping[str, Any] | None = None
+        ) -> AsyncIterator[GenericStreamingChunk]:
+            assert model == "claude-test"
+            assert messages == [{"role": "user", "content": "call echo_tool"}]
+            assert optional_params is not None
+            assert "tools" in optional_params
+            yield GenericStreamingChunk(
+                text="",
+                tool_use={
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {"name": "echo_tool", "arguments": '{"value": "hi"}'},
+                    "index": 0,
+                },
+                is_finished=False,
+                finish_reason="",
+                usage=None,
+                index=0,
+            )
+            yield GenericStreamingChunk(
+                text="",
+                tool_use=None,
+                is_finished=True,
+                finish_reason="tool_calls",
+                usage={"prompt_tokens": 4, "completion_tokens": 5, "total_tokens": 9},
+                index=0,
+            )
+            yield GenericStreamingChunk(
+                text="", tool_use=None, is_finished=False, finish_reason="", usage=None, index=0
+            )
+
+    original_custom_provider_map = list(litellm.custom_provider_map)
+    original_provider_list = list(litellm.provider_list)
+    original_custom_providers = list(litellm._custom_providers)
+    original_model_list_set = set(litellm.model_list_set)
+
+    async def collect_events() -> list[dict[str, Any]]:
+        register_litellm_provider(TanaLiteLLM(FakeClient()))
+        stream = await litellm.anthropic.messages.acreate(
+            model="tana/claude-test",
+            max_tokens=64,
+            stream=True,
+            messages=[{"role": "user", "content": "call echo_tool"}],
+            tools=[
+                {
+                    "name": "echo_tool",
+                    "description": "Echo a value.",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"value": {"type": "string"}},
+                        "required": ["value"],
+                    },
+                }
+            ],
+        )
+        raw_events = [event async for event in cast(AsyncIterator[Any], stream)]
+        return [_decode_anthropic_sse_event(event) for event in raw_events]
+
+    try:
+        events = asyncio.run(collect_events())
+    finally:
+        litellm.custom_provider_map = original_custom_provider_map
+        litellm.provider_list = original_provider_list
+        litellm._custom_providers = original_custom_providers
+        litellm.model_list_set = original_model_list_set
+
+    started_blocks: set[int] = set()
+    stopped_blocks: set[int] = set()
+    for event in events:
+        event_type = event.get("type")
+        index = event.get("index")
+        if event_type == "content_block_start":
+            assert isinstance(index, int)
+            started_blocks.add(index)
+        if event_type == "content_block_delta":
+            assert isinstance(index, int)
+            assert index in started_blocks
+            assert index not in stopped_blocks
+        if event_type == "content_block_stop":
+            assert isinstance(index, int)
+            stopped_blocks.add(index)
+
+    tool_starts = [
+        event
+        for event in events
+        if event.get("type") == "content_block_start" and event.get("content_block", {}).get("type") == "tool_use"
+    ]
+    tool_deltas = [
+        event
+        for event in events
+        if event.get("type") == "content_block_delta" and event.get("delta", {}).get("type") == "input_json_delta"
+    ]
+    text_deltas = [
+        event
+        for event in events
+        if event.get("type") == "content_block_delta" and event.get("delta", {}).get("type") == "text_delta"
+    ]
+    message_deltas = [event for event in events if event.get("type") == "message_delta"]
+    assert len(tool_starts) == 1
+    assert tool_starts[0]["content_block"] == {"type": "tool_use", "id": "call-1", "name": "echo_tool", "input": {}}
+    assert len(tool_deltas) == 1
+    assert json.loads(tool_deltas[0]["delta"]["partial_json"]) == {"value": "hi"}
+    assert text_deltas == []
+    assert message_deltas[-1]["delta"]["stop_reason"] == "tool_use"
+
+
 def _decode_anthropic_sse_event(event: Any) -> dict[str, Any]:
     if isinstance(event, dict):
         return event


### PR DESCRIPTION
## Summary

- Treat Tana stream finish records as terminal and synthesize a `tool_calls` finish when EOF follows a buffered tool call.
- Drop empty non-terminal Tana stream chunks and stop forwarding after the first terminal chunk before LiteLLM's Anthropic adapter sees them.
- Add Anthropic `/v1/messages` regressions for EOF tool-call streams and empty chunks after tool finish.

## Notes

The Tana client parser treats empty text records as no-ops and `finish` / `d:` / `e:` records as terminal. LiteLLM's Anthropic stream wrapper can turn an empty custom-provider chunk after a tool block into an orphan `content_block_delta`, so this provider now enforces the same no-op/terminal semantics before handing chunks to LiteLLM.

Live raw upstream probing is currently partially blocked by Tana `llmProxyNext` returning HTTP 429 for direct probes, but the deployed proxy had already reproduced the downstream malformed Anthropic SSE shape.

## Test

- `bbr test //tana/litellm_proxy:test_provider` (BuildBuddy invocation `4ce07f93-3fd3-4aaa-8884-96ae7c8b7174`, child Bazel invocation `23da08f8-c9ea-4a83-9242-e52afa2454ef`)