### PR TITLE
debundle: move rename validation into ledger seal (PR 3/5)

### DIFF
--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -269,25 +269,43 @@ and every application site consumes a sealed projection — heuristic
 bound-source per-scope renames (`Function` scope; derived by
 `ScopedHeuristicNaturalizer` over a scratch clone, replayed by
 `SealedScopeRenameApplier`), heuristic free-source return-object aliases
-(`Module` scope, per deriving function; `drop_target_collisions` still
-runs at application until PR 3), entry- and module-side import-local
-mints (`Chunk` / `Module` scope, `ImportInduced`; minting itself stays
-in `import_emit.rs` until PR 3), and auto-grown residual public-export
-minting (new `EntryPublicExports` scope). Because contributor derivation
-still depends on earlier contributors' application, PR 2 seals at phase
-boundaries — one ledger instance per former private map (see the "Seal
-points" section of `rename_ledger.rs`'s module doc); PRs 3–4 collapse
-them into a single collect → seal → execute pass. Two previously
-silent last-write-wins shapes are now seal-time hard errors: two
-deriving functions free-aliasing one source to different targets, and
-two import-local mints disagreeing on one binding.
+(`Module` scope, per deriving function), entry- and module-side
+import-local mints (`Chunk` / `Module` scope, `ImportInduced`), and
+auto-grown residual public-export minting (new `EntryPublicExports`
+scope). Because contributor derivation still depends on earlier
+contributors' application, PR 2 seals at phase boundaries — one ledger
+instance per former private map. Two previously silent last-write-wins
+shapes are now seal-time hard errors: two deriving functions
+free-aliasing one source to different targets, and two import-local
+mints disagreeing on one binding.
+
+**PR 3 landed (2026-06):** seal is the single validation point.
+`RenameLedger::seal` takes per-scope occupancy facts (`SealValidation` /
+`ScopeOccupancy`: root vs nested binding names from `scope_names.rs`,
+the rename walk's observed capture pairs, deriving-subtree bound/mention
+sets for `Function` scopes) and applies all target validation there:
+explicit failures reproduce the pre-ledger hard errors (`invalid
+chunk_renames spec`, `collides with an existing top-level local`,
+`captured by a nested binding`, …), heuristic failures drop silently
+(over-suppression OK, capture never), import-induced failures are
+internal invariant violations. Cross-priority disagreement resolves
+silently by priority; same-priority disagreement stays a hard error.
+`$N` minting is a ledger service (`mint` / `seed_taken` / `claim` own
+the per-scope taken sets; `import_emit.rs` and `exports.rs` request
+mints). The per-module naturalize ledger absorbed the plan-driven
+explicit renames, so one seal resolves explicit-vs-heuristic priority,
+the module-global target-collision rule (`merge_module_renames`), and
+occupancy. Application sites now only `debug_assert!` seal's no-capture
+guarantee; what still validates at application (and the remaining seal
+points PR 4 collapses) is inventoried in `rename_ledger.rs`'s module-doc
+"Seal points" section.
 
 Decisions taken (formerly the open-questions subsection below):
 
 1. **Same-priority conflicts are hard errors at seal**, naming both
    contributors — silent suppression is the trap the ledger closes.
-2. **The `$N`-suffix minting scheme stays as-is** when
-   `disambiguate_import_locals`' minting becomes a ledger service (PR 3);
+2. **The `$N`-suffix minting scheme stays as-is** now that
+   `disambiguate_import_locals`' minting is a ledger service (PR 3);
    readability is a separate, later naturalizer concern.
 3. **Structural-mutation contract: no structural moves between seal and
    execute.** Most moves already happen pre-seal (the materializer seals
@@ -296,21 +314,19 @@ Decisions taken (formerly the open-questions subsection below):
 
 Remaining PRs:
 
-- **PR 3 — seal**: move target-occupancy/capture validation (and the
-  free-source `drop_target_collisions` rule) into seal against
-  scope-accurate occupied sets; `_N`/`$N` minting becomes a ledger
-  service; collapse the per-phase ledger instances toward one.
 - **PR 4 — execute once**: one visitor pass (the post-#2052 rename
   visitor becomes the executor) updating the AST, export tables,
   `runtime_imports`, `binding_comments`, and cross-module indexes in
   lockstep, keyed by hygiene `Id` (deleting the seal-output string
-  projection).
+  projection, the pre-seal rename walks that feed capture facts to
+  seal, the naturalizer's derive-phase preview, and the remaining
+  per-phase ledger instances).
 - **PR 5 — cleanup**: delete the defensive era (`captured` sets,
   `drop_subtree_captured_targets` where dominated, `merged`/`module_scope`
   split, reverse lookups); afterwards the #2045 class is
   unrepresentable.
 
-The architecture sketch below remains the reference for PRs 3–5.
+The architecture sketch below remains the reference for PRs 4–5.
 
 The naturalizer / lowerer currently mutates identifiers in place across
 several independently-discovered passes and lets every downstream consumer

--- a/devinfra/js/debundle/e2e/reserved_word_mint_test.rs
+++ b/devinfra/js/debundle/e2e/reserved_word_mint_test.rs
@@ -2,8 +2,8 @@
 //! reserved JS word must not surface verbatim into an emitted import
 //! clause.
 //!
-//! Background. `lowering/import_emit.rs::mint_unique_name` is the single
-//! name minter behind `disambiguate_import_locals`,
+//! Background. `lowering/rename_ledger.rs::RenameLedger::mint` is the
+//! single name minter behind `disambiguate_import_locals`,
 //! `disambiguate_residual_entry_import_locals`, and
 //! `auto_grown_residual_exports`. It used to return its `base` verbatim
 //! whenever the claim closure accepted it, never consulting
@@ -32,7 +32,7 @@
 //!   from "./modules/mod_x.js"` into `entry.js`. Node rejects the entry
 //!   with a SyntaxError ("Unexpected reserved word"), so
 //!   `assert_entry_output` fails at the node step.
-//! - **After the fix**: `mint_unique_name` rejects the reserved base via
+//! - **After the fix**: `RenameLedger::mint` rejects the reserved base via
 //!   `is_valid_js_identifier` and suffixes it to `default$1`, emitting
 //!   `import { default$1 as default } from "..."` — a valid identifier
 //!   that parses and runs.

--- a/devinfra/js/debundle/lowering/exports.rs
+++ b/devinfra/js/debundle/lowering/exports.rs
@@ -310,7 +310,6 @@ pub(super) struct ExportGrowthFacts<'a> {
     pub(super) declaration_by_name: &'a HashMap<Id, usize>,
     pub(super) binding_assignment: &'a HashMap<Id, usize>,
     pub(super) pre_existing_entry_exports: &'a HashSet<Id>,
-    pub(super) pre_existing_public_export_names: &'a HashSet<String>,
     pub(super) entry_renames: &'a BTreeMap<String, String>,
     pub(super) entry_declared_names: &'a HashSet<String>,
 }
@@ -325,7 +324,6 @@ pub(super) fn auto_grown_residual_exports(
         declaration_by_name,
         binding_assignment,
         pre_existing_entry_exports,
-        pre_existing_public_export_names,
         entry_renames,
         entry_declared_names,
     } = facts;
@@ -351,19 +349,19 @@ pub(super) fn auto_grown_residual_exports(
             needed.insert(id.0.as_ref().to_string());
         }
     }
-    // `taken_public_names` accumulates every public name already
-    // committed to entry's export list — the source-level set we
-    // were handed, plus each new grown public name as we mint it.
-    // When a candidate's natural public name collides, suffix-mint
-    // a fresh `<name>$<n>` instead of skipping: skipping forces the
-    // peeled module's body reference to resolve as an unexported
-    // residual binding and `residual_entry_imports_for_moved_body`
-    // would bail with "moved module references residual entry
-    // binding(s) not exported by entry". The peeled module's
-    // importer side renames the import back to the original local
-    // sym via `EntryExport.{local_name, exported_name}`, so the
-    // mint is invisible to the moved body.
-    let mut taken_public_names = pre_existing_public_export_names.clone();
+    // The ledger's `EntryPublicExports` taken-name set holds every
+    // public name already committed to entry's export list — the
+    // source-level set the caller seeded, plus each new grown public
+    // name as it is minted. When a candidate's natural public name
+    // collides, suffix-mint a fresh `<name>$<n>` instead of skipping:
+    // skipping forces the peeled module's body reference to resolve as
+    // an unexported residual binding and
+    // `residual_entry_imports_for_moved_body` would bail with "moved
+    // module references residual entry binding(s) not exported by
+    // entry". The peeled module's importer side renames the import back
+    // to the original local sym via
+    // `EntryExport.{local_name, exported_name}`, so the mint is
+    // invisible to the moved body.
     for name in needed {
         let final_local = entry_renames
             .get(&name)
@@ -383,8 +381,7 @@ pub(super) fn auto_grown_residual_exports(
         if !entry_declared_names.contains(&final_local) {
             continue;
         }
-        let public_name =
-            import_emit::mint_unique_name(&name, |n| taken_public_names.insert(n.to_string()));
+        let public_name = ledger.mint(RenameScope::EntryPublicExports, &name);
         ledger.submit(RenameIntent {
             scope: RenameScope::EntryPublicExports,
             from: top_level_id(&name, chunk_top_level_mark),

--- a/devinfra/js/debundle/lowering/import_emit.rs
+++ b/devinfra/js/debundle/lowering/import_emit.rs
@@ -1,37 +1,17 @@
-use super::util::is_valid_js_identifier;
 use super::*;
-
-pub(super) fn mint_unique_name(base: &str, mut try_claim: impl FnMut(&str) -> bool) -> String {
-    // A reserved word (`default`, `class`, `await`, …) used verbatim as a
-    // local would surface straight into an emitted `import {...}` /
-    // `export {...}` clause and produce un-parseable JS. Suffixing turns
-    // it into a valid identifier (`default$1`), so only offer `base`
-    // directly when it is a usable identifier. `$`-suffixed candidates are
-    // always valid, so the loop below always terminates with a parseable
-    // name.
-    if is_valid_js_identifier(base) && try_claim(base) {
-        return base.to_string();
-    }
-    let mut suffix = 1usize;
-    loop {
-        let candidate = format!("{base}${suffix}");
-        if try_claim(&candidate) {
-            return candidate;
-        }
-        suffix += 1;
-    }
-}
 
 /// Map plan-side `original -> exported` to `actual_local -> exported`.
 ///
 /// When a spec gives a binding a readable exported name, prefer that
 /// readable name as the consumer-side local too. That keeps the final
 /// emitted tree from retaining the input-bundle name merely as an import
-/// alias. Collisions still mint a fresh local and get recorded in
-/// `renames` so the entry body can be rewritten after emission.
+/// alias. Collisions still mint a fresh local through the ledger's
+/// taken-name service ([`RenameLedger::mint`]) and get recorded in
+/// `renames` so the consuming body can be rewritten after emission.
 pub(super) fn disambiguate_import_locals(
     bindings: &BTreeMap<String, String>,
-    occupied: &mut BTreeSet<String>,
+    ledger: &mut RenameLedger,
+    scope: RenameScope,
     renames: &mut BTreeMap<String, String>,
 ) -> BTreeMap<String, String> {
     bindings
@@ -42,7 +22,7 @@ pub(super) fn disambiguate_import_locals(
             } else {
                 original.as_str()
             };
-            let actual = mint_unique_name(preferred, |n| occupied.insert(n.to_string()));
+            let actual = ledger.mint(scope, preferred);
             if actual != *original {
                 renames.insert(original.clone(), actual.clone());
             }
@@ -62,14 +42,15 @@ pub(super) fn disambiguate_import_locals(
 /// the original chunk.
 pub(super) fn disambiguate_residual_entry_import_locals(
     bindings: &BTreeMap<String, EntryExport>,
-    occupied: &mut BTreeSet<String>,
+    ledger: &mut RenameLedger,
+    scope: RenameScope,
     renames: &mut BTreeMap<String, String>,
 ) -> BTreeMap<String, String> {
     bindings
         .iter()
         .map(|(original, entry_export)| {
             let preferred = entry_export.local_name.as_str();
-            let actual = mint_unique_name(preferred, |n| occupied.insert(n.to_string()));
+            let actual = ledger.mint(scope, preferred);
             if actual != *original {
                 renames.insert(original.clone(), actual.clone());
             }

--- a/devinfra/js/debundle/lowering/imports_cross.rs
+++ b/devinfra/js/debundle/lowering/imports_cross.rs
@@ -1,9 +1,10 @@
 //! Emit cross-module + residual-entry imports for a moved module body.
-//! Both call `disambiguate_*_import_locals` (import_emit.rs) to mint fresh
-//! locals when names collide with already-occupied bindings; the minted
-//! `original → fresh` renames are submitted into the consuming plan's
-//! import ledger (scope: that plan's `Module`, origin: `ImportInduced`)
-//! and applied from the sealed projection in `lower_single_plan`.
+//! Both call `disambiguate_*_import_locals` (import_emit.rs), which mint
+//! fresh locals through the consuming plan's import ledger
+//! (`RenameLedger::mint`, seeded with the body's binding names); the
+//! minted `original → fresh` renames are submitted into the same ledger
+//! (scope: that plan's `Module`, origin: `ImportInduced`) and applied
+//! from the sealed projection in `lower_single_plan`.
 
 use super::import_emit::{
     disambiguate_import_locals, disambiguate_residual_entry_import_locals, import_decl_for_plan,
@@ -23,6 +24,10 @@ pub(super) struct ImportLocalRenameSink<'a> {
 }
 
 impl ImportLocalRenameSink<'_> {
+    fn scope(&self) -> RenameScope {
+        RenameScope::Module(self.module)
+    }
+
     /// Submit one minting pass's `original → fresh` renames as
     /// `Module`-scope `ImportInduced` intents for the consuming plan.
     fn submit(&mut self, renames: BTreeMap<String, String>, contributor: &'static str) {
@@ -52,7 +57,6 @@ pub(super) fn cross_module_imports_for_plan(
     from_file: &str,
     imports_by_provider: BTreeMap<usize, BTreeMap<String, String>>,
     factorization: &ChunkFactorization,
-    occupied: &mut BTreeSet<String>,
     sink: &mut ImportLocalRenameSink<'_>,
 ) -> Vec<(ModuleId, ModuleItem)> {
     imports_by_provider
@@ -63,7 +67,9 @@ pub(super) fn cross_module_imports_for_plan(
                 .logical_module(LogicalModuleIndex(provider_index))
                 .map(|provider| {
                     let mut minted = BTreeMap::new();
-                    let resolved = disambiguate_import_locals(&bindings, occupied, &mut minted);
+                    let scope = sink.scope();
+                    let resolved =
+                        disambiguate_import_locals(&bindings, sink.ledger, scope, &mut minted);
                     sink.submit(minted, CROSS_MODULE_IMPORT_CONTRIBUTOR);
                     (
                         ModuleId(LogicalModuleIndex(provider_index)),
@@ -114,7 +120,6 @@ pub(super) fn residual_entry_imports_for_moved_body(
     from_file: &str,
     imports: BTreeMap<String, EntryExport>,
     missing_exports: BTreeSet<String>,
-    occupied: &mut BTreeSet<String>,
     sink: &mut ImportLocalRenameSink<'_>,
 ) -> Result<Vec<ModuleItem>> {
     if !missing_exports.is_empty() {
@@ -135,7 +140,9 @@ pub(super) fn residual_entry_imports_for_moved_body(
         return Ok(Vec::new());
     }
     let mut minted = BTreeMap::new();
-    let resolved = disambiguate_residual_entry_import_locals(&imports, occupied, &mut minted);
+    let scope = sink.scope();
+    let resolved =
+        disambiguate_residual_entry_import_locals(&imports, sink.ledger, scope, &mut minted);
     sink.submit(minted, RESIDUAL_ENTRY_IMPORT_CONTRIBUTOR);
     Ok(vec![import_decl_for_plan(from_file, entry_file, &resolved)])
 }

--- a/devinfra/js/debundle/lowering/lower.rs
+++ b/devinfra/js/debundle/lowering/lower.rs
@@ -15,8 +15,10 @@ use super::import_emit::{
     disambiguate_import_locals, import_decl_for_plan, preserve_export_specifier_names,
     relative_source,
 };
-use super::scope_names::{collect_local_binding_names, collect_occupied_local_names};
-use super::util::{is_valid_js_identifier, remaining_item_after_selection};
+use super::scope_names::{
+    collect_local_binding_names, collect_nested_binding_names, collect_occupied_local_names,
+};
+use super::util::remaining_item_after_selection;
 use super::*;
 use crate::time_phase;
 
@@ -190,16 +192,25 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
     // and "Lemma 2".
     let build_entry_imports_started = Instant::now();
     let mut entry_imports: Vec<(ModuleId, ModuleItem)> = Vec::new();
-    let mut occupied = collect_occupied_local_names(&entry_body);
-    // Entry-body renames flow through a dedicated ledger: the accepted
-    // chunk_renames entries (Explicit) and the entry import-local mints
-    // (ImportInduced) submit Chunk-scope intents below; the sealed
-    // projection is the `body_renames` map the entry renamer applies.
-    // The two contributors' source sets are disjoint by construction —
-    // chunk_renames seeding skips module-owned bindings, mints fire only
-    // for module-owned bindings — so a seal conflict can only come from
-    // one contributor disagreeing with itself.
+    // Entry-body renames flow through a dedicated ledger: the
+    // chunk_renames entries staying in entry (Explicit) and the entry
+    // import-local mints (ImportInduced) submit Chunk-scope intents
+    // below; the sealed projection is the `body_renames` map the entry
+    // renamer applies. The two contributors' source sets are disjoint by
+    // construction — chunk_renames seeding skips module-owned bindings,
+    // mints fire only for module-owned bindings — so a seal conflict can
+    // only come from one contributor disagreeing with itself.
+    //
+    // Occupancy facts for seal validation: the post-split entry body's
+    // top-level names (root) and everything bound below them (nested).
+    // Seal rejects chunk_renames targets colliding at the root level —
+    // collecting every violation in one error — and asserts mints stayed
+    // clear of both levels; nested-capture facts come from the rename
+    // walk below.
+    let entry_root_names = collect_occupied_local_names(&entry_body);
+    let entry_nested_names = collect_nested_binding_names(&entry_body);
     let mut entry_ledger = RenameLedger::default();
+    entry_ledger.seed_taken(RenameScope::Chunk, entry_root_names.iter().cloned());
     // Submit `chunk_renames` intents for bindings staying in entry's
     // body (not claimed by any logical module). Bindings owned by a
     // logical module take their rename from the module plan via the
@@ -207,64 +218,24 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
     // bindings are silently dropped here (the logical-module rename
     // wins).
     //
-    // Each accepted target name is reserved in `occupied` before the
-    // import-disambiguation pass runs, so a later cross-module
-    // import doesn't mint a fresh local that collides with one of
-    // the chunk_renames' targets. Conflicting targets (target name
-    // already taken by a body local that isn't being renamed away,
-    // or by another chunk_renames entry, or invalid as an
-    // identifier) bail rather than producing invalid JS silently.
-    let mut renamed_away = BTreeSet::<String>::new();
-    for binding in chunk_renames.keys() {
-        if is_module_owned(binding) {
-            continue;
-        }
-        renamed_away.insert(binding.clone());
-    }
-    // Iterate `chunk_renames` (a `HashMap`) in sorted order so the
-    // collected error list and the ledger's intent order are stable.
-    // Collect every violation rather than `bail!`ing on the first one
-    // so a spec author sees the full set in one round-trip; the
-    // "duplicate target" branch in particular only surfaces after
-    // `occupied.insert` returned false, so the earlier-rename whose
-    // target was duplicated is implied by the sort order.
+    // Each target name is claimed before the import-disambiguation pass
+    // runs, so a later cross-module import doesn't mint a fresh local
+    // that collides with one of the chunk_renames' targets. Iterate
+    // `chunk_renames` (a `HashMap`) in sorted order so the ledger's
+    // intent order is stable.
+    // `entry_candidate_renames` mirrors the submitted intents so the
+    // rename walk below can run before seal and report precise capture
+    // facts into it; seal's Chunk projection reproduces this map exactly
+    // (debug-asserted below). The pre-seal walk is PR-4-deletable
+    // scaffolding, like the naturalizer's derive preview.
+    let mut entry_candidate_renames = BTreeMap::<String, String>::new();
     let mut sorted_renames: Vec<(&String, &String)> = chunk_renames.iter().collect();
     sorted_renames.sort_by(|a, b| a.0.cmp(b.0));
-    let mut errors = Vec::<String>::new();
     for (binding, export_name) in sorted_renames {
         if is_module_owned(binding) {
             continue;
         }
-        if !is_valid_js_identifier(export_name) {
-            errors.push(format!(
-                "chunk_renames target {export_name} for binding {binding} is not a valid JS identifier",
-            ));
-            continue;
-        }
-        if export_name != binding {
-            // A body local that's also being renamed away vacates
-            // its slot in `occupied` — it's safe to reuse. Anything
-            // else still in `occupied` would collide.
-            let target_already_taken =
-                occupied.contains(export_name) && !renamed_away.contains(export_name);
-            if target_already_taken {
-                errors.push(format!(
-                    "chunk_renames target {export_name} for binding {binding} collides with an existing top-level local",
-                ));
-                continue;
-            }
-        }
-        if !occupied.insert(export_name.clone()) && export_name != binding {
-            // `occupied.insert` returns false if already present;
-            // for the rename-to-self case (export_name == binding)
-            // that's expected. For any other case the target was
-            // already chosen by a previous chunk_renames entry —
-            // duplicate target.
-            errors.push(format!(
-                "chunk_renames target {export_name} for binding {binding} duplicates an earlier rename target",
-            ));
-            continue;
-        }
+        entry_ledger.claim(RenameScope::Chunk, export_name);
         entry_ledger.submit(RenameIntent {
             scope: RenameScope::Chunk,
             from: top_level_id(binding, chunk_top_level_mark),
@@ -273,11 +244,12 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
                 contributor: CHUNK_RENAMES_CONTRIBUTOR,
             },
         });
+        entry_candidate_renames.insert(binding.clone(), export_name.clone());
     }
-    if !errors.is_empty() {
-        bail!("invalid chunk_renames spec:\n  - {}", errors.join("\n  - "));
-    }
-    occupied.extend(collect_local_binding_names(&entry_body));
+    // Mints must additionally avoid every nested binding name, or the
+    // follow-up body rewrite could capture references meant to resolve
+    // to the import.
+    entry_ledger.seed_taken(RenameScope::Chunk, collect_local_binding_names(&entry_body));
     for (module_index, plan) in module_plans.iter().enumerate() {
         // Drop bindings that don't exist anywhere (no entry in
         // `binding_assignment`). Bindings owned by another plan stay
@@ -310,7 +282,12 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
             continue;
         }
         let mut emit_renames = BTreeMap::<String, String>::new();
-        let resolved = disambiguate_import_locals(&live_bindings, &mut occupied, &mut emit_renames);
+        let resolved = disambiguate_import_locals(
+            &live_bindings,
+            &mut entry_ledger,
+            RenameScope::Chunk,
+            &mut emit_renames,
+        );
         // A rename only propagates to consumer-body references when the
         // moved decl actually belongs to this plan. Plans that listed a
         // binding without owning the decl emit a dangling import; the
@@ -327,6 +304,7 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
                         contributor: ENTRY_IMPORT_LOCAL_CONTRIBUTOR,
                     },
                 });
+                entry_candidate_renames.insert(local, fresh);
             }
         }
         entry_imports.push((
@@ -348,13 +326,13 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
         .sort_entry_imports(&mut entry_imports);
     let entry_imports: Vec<ModuleItem> = entry_imports.into_iter().map(|(_, it)| it).collect();
     timings.add("build_entry_imports", build_entry_imports_started.elapsed());
-    // Seal the entry ledger: `body_renames` is its Chunk-scope projection
-    // — exactly the map the pre-ledger code accumulated inline across the
-    // chunk_renames seeding and the import-local mint loop above.
-    let sealed_entry_renames = entry_ledger.seal()?;
-    let body_renames = sealed_entry_renames.scope_renames_by_name(&RenameScope::Chunk);
-    let entry_binding_renames = body_renames.clone();
-    if !body_renames.is_empty() {
+    // Rename walk: apply the candidate map before seal so the visitor's
+    // scope stack reports precise capture facts (a target bound nested
+    // is harmless when the source is shadowed there — only the walk can
+    // decide that). When seal rejects below, the bail discards this
+    // (partially renamed) body with the whole run.
+    let mut entry_captured = BTreeSet::new();
+    if !entry_candidate_renames.is_empty() {
         let rename_entry_body_started = Instant::now();
         // Re-exports `export { local }` (without `from`) collapse `local`
         // and the public exported name into a single ident. Renaming the
@@ -362,27 +340,42 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
         // consumers — so rewrite them to `export { fresh as local }`
         // before the generic renamer visits the rest.
         for item in entry_body.iter_mut() {
-            preserve_export_specifier_names(item, &body_renames);
+            preserve_export_specifier_names(item, &entry_candidate_renames);
         }
-        let mut renamer = IdentifierRenamer::new(&body_renames);
+        let mut renamer = IdentifierRenamer::new(&entry_candidate_renames);
         for item in entry_body.iter_mut() {
             item.visit_mut_with(&mut renamer);
         }
-        if !renamer.captured.is_empty() {
-            // A rename target was bound in a scope where the (un-shadowed)
-            // source is referenced — applying it would capture the
-            // reference. A pre-check can't decide this precisely (a target
-            // bound nested is harmless when the source is shadowed in that
-            // same scope), so the visitor detects it at the exact reference
-            // and we reject here. The body is partially renamed at this
-            // point; bailing discards the run before anything is emitted.
-            bail!(
-                "chunk_renames for chunk {chunk_id} would be captured by a nested binding: {:?}",
-                renamer.captured,
-            );
-        }
+        entry_captured = renamer.captured;
         timings.add("rename_entry_body", rename_entry_body_started.elapsed());
     }
+    // Seal the entry ledger: the single validation point for entry-body
+    // renames. Conflicting targets (target name already taken by a body
+    // local that isn't being renamed away, or chosen by another
+    // chunk_renames entry, invalid as an identifier, or captured by a
+    // nested binding per the walk above) bail here with every violation
+    // listed, rather than producing invalid JS silently. `body_renames`
+    // is the sealed Chunk-scope projection — exactly the map the
+    // pre-ledger code accumulated inline across the chunk_renames
+    // seeding and the import-local mint loop above.
+    let sealed_entry_renames = entry_ledger.seal(&SealValidation {
+        occupancy: BTreeMap::from([(
+            RenameScope::Chunk,
+            ScopeOccupancy::Body {
+                label: chunk_id.to_string(),
+                root: entry_root_names,
+                nested: entry_nested_names,
+                captured: entry_captured,
+            },
+        )]),
+        reserved: BTreeSet::new(),
+    })?;
+    let body_renames = sealed_entry_renames.scope_renames_by_name(&RenameScope::Chunk);
+    debug_assert_eq!(
+        body_renames, entry_candidate_renames,
+        "sealed entry renames diverged from the candidate map the pre-seal walk applied",
+    );
+    let entry_binding_renames = body_renames;
     if !entry_imports.is_empty() {
         let splice_entry_imports_started = Instant::now();
         let tail = entry_body.split_off(import_insert_index);
@@ -455,14 +448,20 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
             .iter()
             .flat_map(|item| top_level_declaration_names(item).0)
             .collect();
+        // The ledger owns the public-name namespace: seed it with the
+        // source-level public names so `auto_grown_residual_exports`'
+        // mints suffix past them.
         let mut export_ledger = RenameLedger::default();
+        export_ledger.seed_taken(
+            RenameScope::EntryPublicExports,
+            pre_existing_public_export_names.iter().cloned(),
+        );
         auto_grown_residual_exports(
             &body_facts_by_module,
             &ExportGrowthFacts {
                 declaration_by_name,
                 binding_assignment,
                 pre_existing_entry_exports,
-                pre_existing_public_export_names,
                 entry_renames: &entry_binding_renames,
                 entry_declared_names: &entry_declared_names,
             },
@@ -473,8 +472,21 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
         // name; the emitted export clause is keyed by entry's
         // post-rename local, so remap through `entry_binding_renames`
         // at application. A single contributor over a set-deduped
-        // source set cannot produce a seal conflict.
-        let sealed_exports = export_ledger.seal()?;
+        // source set cannot produce a seal conflict; the occupancy
+        // check asserts the mints stayed clear of pre-existing public
+        // names.
+        let sealed_exports = export_ledger.seal(&SealValidation {
+            occupancy: BTreeMap::from([(
+                RenameScope::EntryPublicExports,
+                ScopeOccupancy::Body {
+                    label: chunk_id.to_string(),
+                    root: pre_existing_public_export_names.iter().cloned().collect(),
+                    nested: BTreeSet::new(),
+                    captured: BTreeSet::new(),
+                },
+            )]),
+            reserved: BTreeSet::new(),
+        })?;
         let auto_grow: BTreeMap<String, String> = sealed_exports
             .scope_renames_by_name(&RenameScope::EntryPublicExports)
             .into_iter()
@@ -773,16 +785,21 @@ fn lower_single_plan(
     });
     // Import-local mints for this plan's body flow through a per-plan
     // ledger (scope: this plan's `Module`, origin: `ImportInduced`);
-    // the sealed projection below is the rename map the body renamer
-    // applies.
+    // the ledger's taken-name set is seeded with every name bound
+    // anywhere in the body so mints stay capture-free, and the sealed
+    // projection below is the rename map the body renamer applies.
     let module = ModuleId::logical(index);
+    let module_local_names = collect_local_binding_names(&body);
     let mut import_ledger = RenameLedger::default();
+    import_ledger.seed_taken(
+        RenameScope::Module(module),
+        module_local_names.iter().cloned(),
+    );
     let mut import_rename_sink = ImportLocalRenameSink {
         module,
         chunk_top_level_mark,
         ledger: &mut import_ledger,
     };
-    let mut module_import_locals = collect_local_binding_names(&body);
     // All intra-chunk imports (cross-module binding imports, phantom
     // side-effect imports, and the residual-entry import) are
     // collected as `(target ModuleId, decl)` pairs and ordered by ONE
@@ -797,7 +814,6 @@ fn lower_single_plan(
             &plan.target_file,
             cross_module_imports_by_provider,
             factorization,
-            &mut module_import_locals,
             &mut import_rename_sink,
         )
     });
@@ -819,30 +835,41 @@ fn lower_single_plan(
             &plan.target_file,
             residual_entry_imports,
             missing_residual_exports,
-            &mut module_import_locals,
             &mut import_rename_sink,
         )
     })?;
     // Seal the per-plan import ledger; the Module-scope projection is
     // the import-local rename map the pre-ledger code accumulated
-    // across the two minting passes above.
-    let module_import_renames = import_ledger.seal()?.module_renames_by_name(module);
+    // across the two minting passes above. Seal asserts the mints
+    // stayed clear of every name bound anywhere in the body.
+    let module_import_renames = import_ledger
+        .seal(&SealValidation {
+            occupancy: BTreeMap::from([(
+                RenameScope::Module(module),
+                ScopeOccupancy::Body {
+                    label: plan.id.clone(),
+                    root: BTreeSet::new(),
+                    nested: module_local_names,
+                    captured: BTreeSet::new(),
+                },
+            )]),
+            reserved: BTreeSet::new(),
+        })?
+        .module_renames_by_name(module);
     if !module_import_renames.is_empty() {
         let mut renamer = IdentifierRenamer::new(&module_import_renames);
         for item in body.iter_mut() {
             item.visit_mut_with(&mut renamer);
         }
-        if !renamer.captured.is_empty() {
-            // Import-local renames are minted against every name bound
-            // anywhere in the body (`collect_local_binding_names`), so a
-            // capture here is an internal invariant violation, not a
-            // user-facing spec error.
-            bail!(
-                "materialize_logical_modules: import-local renames for module {} were captured by a nested binding: {:?}. This is an internal invariant violation in import-local minting.",
-                plan.id,
-                renamer.captured,
-            );
-        }
+        // Import-local renames are minted from the ledger's taken set,
+        // which seal validated against every name bound anywhere in the
+        // body — a capture here would mean seal's guarantee broke.
+        debug_assert!(
+            renamer.captured.is_empty(),
+            "import-local renames for module {} captured despite seal validation: {:?}",
+            plan.id,
+            renamer.captured,
+        );
     }
     // Re-import any source-chunk import-specifier-bound locals that
     // moved code in `body` references but no top-level decl

--- a/devinfra/js/debundle/lowering/materialize/mod.rs
+++ b/devinfra/js/debundle/lowering/materialize/mod.rs
@@ -253,14 +253,19 @@ pub(super) fn materialize_logical_chunk(
     // same-priority intents disagree on one binding's target; the sealed
     // output feeds the same application sites the pre-ledger maps fed
     // (Chunk scope → `chunk_renames_map` below, Module scope → the
-    // per-plan naturalize pass in `lower_chunk`).
+    // per-plan naturalize pass in `lower_chunk`). No occupancy facts are
+    // passed: the post-split bodies these renames must not collide with
+    // don't exist yet, so target occupancy is validated downstream — the
+    // entry ledger in `lower_chunk` re-collects the Chunk-scope intents
+    // and the per-module naturalize ledgers re-collect the Module-scope
+    // ones, each sealing against its body's occupancy.
     let sealed_renames = time_phase!(timings, "seal_rename_ledger", {
         let mut ledger = RenameLedger::default();
         if let Some(renames) = chunk_renames.get(chunk_id) {
             collect_chunk_renames(renames, chunk_top_level_mark, &mut ledger)?;
         }
         collect_plan_export_rename_intents(&module_plans, chunk_top_level_mark, &mut ledger);
-        ledger.seal()
+        ledger.seal(&SealValidation::default())
     })?;
     let chunk_renames_map = sealed_renames.chunk_renames_by_name();
     let (logical_modules, default_destination) =

--- a/devinfra/js/debundle/lowering/mod.rs
+++ b/devinfra/js/debundle/lowering/mod.rs
@@ -94,7 +94,10 @@ use plan_references::{
     collect_imported_reexports_by_module, plan_module_reference_needs,
 };
 use plans::{LogicalRequest, MemberRequest, ModulePlan, logical_requests_for_chunk};
-use rename_ledger::{RenameIntent, RenameLedger, RenameOrigin, RenameScope, SealedRenames};
+use rename_ledger::{
+    RenameIntent, RenameLedger, RenameOrigin, RenameScope, ScopeOccupancy, SealValidation,
+    SealedRenames, merge_module_renames,
+};
 use rewrite_runtime::rewrite_runtime_sources_for_target;
 use runtime_imports::{
     RuntimeImportFacts, RuntimeImportInfo, RuntimeImportKind, imported_binding_named_specifier,

--- a/devinfra/js/debundle/lowering/naturalize.rs
+++ b/devinfra/js/debundle/lowering/naturalize.rs
@@ -15,31 +15,36 @@
 //!   returned merged map because `plan_module_reference_needs`
 //!   reverse-resolves the post-rename name through it to emit the
 //!   runtime reimport (`import { t as options }`), and they keep the
-//!   module-global target-uniqueness rule (`drop_target_collisions`) —
-//!   two of them onto one target would collide in module scope.
+//!   module-global target-uniqueness rule
+//!   (`rename_ledger::merge_module_renames`, applied at seal) — two of
+//!   them onto one target would collide in module scope.
 //!
 //! - **Bound sources** (destructured params, constructor
 //!   `this.x = param` assignments, return-object aliases of the
 //!   function's own root bindings) rename a binding owned by a single
-//!   scope. `ScopedHeuristicNaturalizer` derives and validates them per
-//!   deriving scope, with no module-global uniqueness requirement: two
-//!   sibling scopes reusing the same minified spelling (`e` → `value`
-//!   here, `e` → `registry` there) are independent renames (#2045).
-//!   They stay out of the returned map so a scope-local rename can
-//!   never remap an unrelated top-level export or runtime reimport
-//!   that happens to share the spelling.
+//!   scope. `ScopedHeuristicNaturalizer` derives them per deriving scope,
+//!   with no module-global uniqueness requirement: two sibling scopes
+//!   reusing the same minified spelling (`e` → `value` here,
+//!   `e` → `registry` there) are independent renames (#2045). They stay
+//!   out of the returned map so a scope-local rename can never remap an
+//!   unrelated top-level export or runtime reimport that happens to
+//!   share the spelling.
 //!
-//! Both heuristic families submit intents into a per-module
-//! [`RenameLedger`] sealed before any heuristic rename is applied
-//! (free sources at `Module` scope, bound sources at `Function` scope);
-//! `SealedScopeRenameApplier` replays the sealed per-scope maps onto the
-//! real body, and the returned merged map is rebuilt from the sealed
-//! Module-scope intents.
+//! All three contributor families — the plan's explicit `export_name`
+//! renames (re-collected from the chunk ledger's sealed projection),
+//! free-source aliases (`Module` scope), and bound-source heuristics
+//! (`Function` scope, submitted raw with each deriving subtree's name
+//! facts) — share one per-module [`RenameLedger`], and its seal is the
+//! single validation point: explicit-vs-heuristic priority, target
+//! collisions, and occupancy. `SealedScopeRenameApplier` replays the
+//! sealed per-scope maps onto the real body; the application sites only
+//! `debug_assert!` seal's no-capture guarantee.
 
 use swc_common::Span;
 
 use super::scope_names::{
-    BindingNameCollector, collect_binding_names_in, collect_occupied_local_names,
+    BindingNameCollector, collect_binding_names_in, collect_nested_binding_names,
+    collect_occupied_local_names,
 };
 use super::util::is_valid_js_identifier;
 use super::*;
@@ -91,8 +96,10 @@ pub(super) const PLAN_EXPORT_NAME_CONTRIBUTOR: &str = "logical_module member exp
 pub(super) const FREE_ALIAS_CONTRIBUTOR: &str = "return-object alias (free source)";
 pub(super) const SCOPED_HEURISTIC_CONTRIBUTOR: &str = "scope-local heuristic naturalizer";
 
-/// `plan_driven` is this plan's sealed Module-scope rename map
-/// (`SealedRenames::module_renames_by_name`); sorted (`BTreeMap`)
+/// `plan_driven` is this plan's sealed Module-scope rename map from the
+/// chunk explicit ledger (`SealedRenames::module_renames_by_name`),
+/// re-collected into the per-module ledger so its targets are
+/// occupancy-validated against this body at seal; sorted (`BTreeMap`)
 /// iteration keeps the rename-precedence the visitor applies when two
 /// locals compete for the same target independent of hash seed.
 pub(super) fn naturalize_module_body(
@@ -102,16 +109,29 @@ pub(super) fn naturalize_module_body(
     plan_driven: BTreeMap<String, String>,
     chunk_top_level_mark: swc_common::Mark,
 ) -> Result<NaturalizedRenames> {
-    // Both heuristic contributors submit into this per-module ledger,
-    // sealed below before any heuristic rename is applied.
-    // `free_heuristic` is the derive-phase scratch view of the same
-    // Module-scope intents: the bound-source derive pass needs the
-    // module-global collision rules resolved before the ledger can seal
-    // (sealing also waits for the derive pass's Function-scope intents).
+    // Occupancy facts for seal-time target validation, computed against
+    // the pre-rename body (intents are keyed by original names).
+    let root_names = collect_occupied_local_names(body);
+    let nested_names = collect_nested_binding_names(body);
+    // One per-module ledger holds every naturalization contributor:
+    // plan-driven explicit renames, free-source aliases, and the
+    // bound-source per-scope heuristics submitted by the derive pass
+    // below. A single seal resolves explicit-vs-heuristic priority,
+    // target collisions, and occupancy.
+    let mut ledger = RenameLedger::default();
+    for (from, to) in &plan_driven {
+        ledger.submit(RenameIntent {
+            scope: RenameScope::Module(module),
+            from: top_level_id(from, chunk_top_level_mark),
+            to: to.as_str().into(),
+            origin: RenameOrigin::Explicit {
+                contributor: PLAN_EXPORT_NAME_CONTRIBUTOR,
+            },
+        });
+    }
     // Free aliases are submitted per deriving function, so two functions
     // aliasing one free source to different targets — previously a
-    // silent last-write-wins on this map — are a seal-time conflict.
-    let mut ledger = RenameLedger::default();
+    // silent last-write-wins — are a seal-time conflict.
     let mut per_function_free = Vec::<BTreeMap<String, String>>::new();
     for item in body.iter() {
         collect_free_alias_renames_from_item(item, &mut per_function_free);
@@ -130,72 +150,37 @@ pub(super) fn naturalize_module_body(
             free_heuristic.insert(from, to);
         }
     }
-    // The merged map is what callers read back as the local-name → readable
-    // lookup (runtime-reimport bridge, export remapping). Plan-driven names
-    // are top-level module bindings and rename module-wide (suppressed in
-    // any subtree that re-binds them); free heuristic names rename only
-    // within the function that derived them, via the scoped pass below.
-    let merged = drop_target_collisions(plan_driven.clone(), free_heuristic);
-    let plan_driven_effective: BTreeMap<String, String> = merged
-        .iter()
-        .filter(|(local, _)| plan_driven.contains_key(*local))
-        .map(|(local, target)| (local.clone(), target.clone()))
-        .collect();
-    let free_effective: BTreeMap<String, String> = merged
+    // Derive-phase preview of seal's module-level rules: the bound-source
+    // derive pass needs the surviving free set (`free_allowed`) and the
+    // reserved set before the ledger can seal (sealing also waits for the
+    // derive pass's Function-scope intents). `merge_module_renames` is
+    // the same rule seal applies, so the preview and the sealed output
+    // agree; the preview is deleted with PR 4's execute-once pass.
+    let merged_preview = merge_module_renames(plan_driven.clone(), free_heuristic);
+    let free_effective: BTreeMap<String, String> = merged_preview
         .iter()
         .filter(|(local, _)| !plan_driven.contains_key(*local))
         .map(|(local, target)| (local.clone(), target.clone()))
         .collect();
 
     // Module-wide pass: plan-driven renames + shorthand collapse when the
-    // plan renames anything, shorthand collapse alone otherwise.
-    if plan_driven_effective.is_empty() {
+    // plan renames anything, shorthand collapse alone otherwise. The walk
+    // runs before seal so the visitor's scope stack reports precise
+    // capture facts (a target bound nested is harmless when the source is
+    // shadowed there — only the walk can decide that); seal turns them
+    // into the hard error, and its bail discards this (partially renamed)
+    // body with the whole pipeline run before anything is emitted.
+    let mut plan_captured = BTreeSet::new();
+    if plan_driven.is_empty() {
         for item in body.iter_mut() {
             item.visit_mut_with(&mut ShorthandNaturalizer);
         }
     } else {
-        // Validate plan-driven targets against the body's top-level scope
-        // before any mutation: renaming a declaration onto a name another
-        // top-level binding already uses produces a duplicate declaration
-        // (a load-time SyntaxError). A top-level binding that is itself
-        // renamed away vacates its slot and is allowed. Nested-scope target
-        // collisions are NOT pre-checked here — a target bound in a nested
-        // scope is harmless unless the un-shadowed source is referenced
-        // inside that scope, which the renamer detects precisely at the
-        // reference (see the `captured` check below).
-        let root_names = collect_occupied_local_names(body);
-        let mut errors = Vec::new();
-        for (from, to) in &plan_driven_effective {
-            if root_names.contains(to) && !plan_driven_effective.contains_key(to) {
-                errors.push(format!(
-                    "rename of binding {from} to {to} collides with another top-level binding in the module body",
-                ));
-            }
-        }
-        if !errors.is_empty() {
-            bail!(
-                "invalid renames for module {}:\n  - {}",
-                plan.id,
-                errors.join("\n  - "),
-            );
-        }
-
-        let mut naturalizer = RenameAndShorthandNaturalizer::new(&plan_driven_effective);
+        let mut naturalizer = RenameAndShorthandNaturalizer::new(&plan_driven);
         for item in body.iter_mut() {
             item.visit_mut_with(&mut naturalizer);
         }
-        if !naturalizer.captured.is_empty() {
-            // A rename target was bound in a scope where the un-shadowed
-            // source is referenced — applying it would make the renamed
-            // reference resolve to the inner binding. The body is
-            // partially renamed at this point; the bail discards the
-            // whole pipeline run before anything is emitted.
-            bail!(
-                "renames for module {} would be captured by a nested binding: {:?}",
-                plan.id,
-                naturalizer.captured,
-            );
-        }
+        plan_captured = naturalizer.captured;
     }
 
     // Names a scope-local rename must never target: anything the plan or a
@@ -203,28 +188,43 @@ pub(super) fn naturalize_module_body(
     // onto one of these would capture module-level references inside the
     // scope (or collide with the free rename applied in the same scope).
     let mut reserved = BTreeSet::<String>::new();
-    for (from, to) in plan_driven.iter().chain(merged.iter()) {
+    for (from, to) in plan_driven.iter().chain(merged_preview.iter()) {
         reserved.insert(from.clone());
         reserved.insert(to.clone());
     }
     // Derive pass: run the scoped heuristic machinery over a scratch
     // clone of the body. It performs exactly the pre-ledger
-    // derive-and-apply walk — outer scopes validate against subtrees
+    // derive-and-apply walk — outer scopes derive against subtrees
     // that already carry their nested scopes' renames — but the
     // mutations land on the clone; the real body is only renamed by the
-    // sealed-output applier below. Each fired per-scope map is submitted
-    // as Function-scope intents. The clone is deleted with PR 4's
-    // execute-once pass.
+    // sealed-output applier below. Each scope's raw candidates are
+    // submitted as Function-scope intents together with the deriving
+    // subtree's name facts, which seal validates them against. The clone
+    // is deleted with PR 4's execute-once pass.
     let mut derive_body = body.to_vec();
+    let mut occupancy = BTreeMap::new();
     let mut deriver = ScopedHeuristicNaturalizer {
         free_allowed: &free_effective,
         reserved: &reserved,
         ledger: &mut ledger,
+        occupancy: &mut occupancy,
     };
     for item in derive_body.iter_mut() {
         item.visit_mut_with(&mut deriver);
     }
-    let sealed = ledger.seal()?;
+    occupancy.insert(
+        RenameScope::Module(module),
+        ScopeOccupancy::Body {
+            label: plan.id.clone(),
+            root: root_names,
+            nested: nested_names,
+            captured: plan_captured,
+        },
+    );
+    let sealed = ledger.seal(&SealValidation {
+        occupancy,
+        reserved,
+    })?;
     // Apply pass: replay the sealed per-scope maps onto the real body in
     // the same order the derive pass fired them (children first), so each
     // scope's map applies to the same intermediate tree state the
@@ -235,11 +235,8 @@ pub(super) fn naturalize_module_body(
     }
 
     Ok(NaturalizedRenames {
-        // The merged map consumers read is rebuilt from the sealed
-        // Module-scope (free-source) intents — identical to the derive
-        // scratch `merged` whenever seal succeeded.
-        merged: drop_target_collisions(plan_driven, sealed.module_renames_by_name(module)),
-        module_scope: plan_driven_effective,
+        merged: sealed.module_renames_by_name(module),
+        module_scope: sealed.module_explicit_renames_by_name(module),
     })
 }
 
@@ -247,12 +244,15 @@ pub(super) fn naturalize_module_body(
 /// clone of the module body and, at each function/constructor/arrow,
 /// derives that node's own heuristic renames (param destructure aliases,
 /// return-object aliases, `this.x = param` constructor assignments),
-/// validates them, submits the fired map as Function-scope intents, and
-/// rewrites the (clone's) subtree so enclosing scopes validate against
-/// the post-rename nested state — exactly the pre-ledger
-/// derive-and-apply order. Bound-source renames fire when their readable
-/// target passes the per-scope safety checks in [`Self::validated_bound`];
-/// free-source renames fire when they survived the module-global
+/// submits the raw candidates as Function-scope intents together with
+/// the subtree's name facts (seal validates them via
+/// [`ScopeOccupancy::Subtree`]), and rewrites the (clone's) subtree so
+/// enclosing scopes derive against the post-rename nested state —
+/// exactly the pre-ledger derive-and-apply order. The clone mutation
+/// uses a local preview of seal's rules ([`Self::validated_bound`] +
+/// `drop_subtree_captured_targets`), so the clone and the sealed output
+/// agree; the preview is deleted with PR 4's execute-once pass.
+/// Free-source renames fire only when they survived the module-global
 /// collision rules (`free_allowed`). A rename derived from one scope
 /// never leaks into a sibling/parent scope, and
 /// `RenameAndShorthandNaturalizer`'s nested shadow-suppression still
@@ -265,8 +265,11 @@ struct ScopedHeuristicNaturalizer<'a> {
     /// Module-wide rename sources and targets (plan-driven + free); a
     /// scope-local rename must not target any of them.
     reserved: &'a BTreeSet<String>,
-    /// Sink for the fired per-scope maps (Function-scope intents).
+    /// Sink for the per-scope raw candidates (Function-scope intents).
     ledger: &'a mut RenameLedger,
+    /// Sink for each deriving subtree's name facts; passed to seal so it
+    /// can validate the scope's intents.
+    occupancy: &'a mut BTreeMap<RenameScope, ScopeOccupancy>,
 }
 
 /// Replays the sealed Function-scope heuristic renames onto the real
@@ -451,16 +454,27 @@ fn collect_pat_binding_names(pat: &Pat, out: &mut BTreeSet<String>) {
 }
 
 impl ScopedHeuristicNaturalizer<'_> {
-    /// Record one deriving scope's fired rename map as Function-scope
-    /// intents. The sources are function-local bindings whose hygiene
+    /// Record one deriving scope's raw candidates as Function-scope
+    /// intents together with the subtree facts seal validates them
+    /// against. The sources are function-local bindings whose hygiene
     /// context the string-keyed derivation never resolves; the
     /// string-era key is encoded as the empty `SyntaxContext` (the
     /// sealed by-name projection is what the apply pass consumes; see
     /// the ledger module doc's hygiene-boundary section).
-    fn submit_scope_intents(&mut self, span: Span, local: &BTreeMap<String, String>) {
-        for (from, to) in local {
+    fn submit_scope_intents(
+        &mut self,
+        span: Span,
+        bound: &BTreeMap<String, String>,
+        free: &BTreeMap<String, String>,
+        facts: SubtreeNameFacts,
+    ) {
+        if bound.is_empty() && free.is_empty() {
+            return;
+        }
+        let scope = RenameScope::Function(span.into());
+        for (from, to) in free.iter().chain(bound.iter()) {
             self.ledger.submit(RenameIntent {
-                scope: RenameScope::Function(span.into()),
+                scope,
                 from: (from.as_str().into(), SyntaxContext::empty()),
                 to: to.as_str().into(),
                 origin: RenameOrigin::Heuristic {
@@ -468,6 +482,13 @@ impl ScopedHeuristicNaturalizer<'_> {
                 },
             });
         }
+        self.occupancy.insert(
+            scope,
+            ScopeOccupancy::Subtree {
+                bound: facts.bound,
+                mentions: facts.mentions,
+            },
+        );
     }
 
     /// Per-scope safety checks for bound-source renames. A rename fires
@@ -551,14 +572,14 @@ where
         .collect()
 }
 
-/// Invariant check after a heuristic scope-local rename pass: the
-/// subtree pre-filter must have made captures impossible. A non-empty
-/// `captured` set means the body is partially renamed — crash loudly
-/// rather than emit a miscompile.
+/// Debug-time invariant check after a heuristic scope-local rename pass:
+/// seal's per-scope target validation (target absent from the subtree's
+/// mentions / bound names) makes captures impossible. A non-empty
+/// `captured` set means seal's guarantee was violated.
 fn assert_no_heuristic_capture(renamer: &RenameAndShorthandNaturalizer<'_>) {
-    assert!(
+    debug_assert!(
         renamer.captured.is_empty(),
-        "heuristic rename captured despite subtree pre-filter: {:?}",
+        "heuristic rename captured despite seal validation: {:?}",
         renamer.captured,
     );
 }
@@ -593,18 +614,19 @@ impl VisitMut for ScopedHeuristicNaturalizer<'_> {
         }
         let mut free = BTreeMap::new();
         self.classify_function_aliases(function, &facts, &mut bound, &mut free);
-        // Free-source aliases get no `mentions` pre-check from
-        // `validated_bound`, so drop any whose target the subtree binds:
-        // applying one would be suppressed only inside the re-binding
-        // scope, tripping the capture assert below on a partially renamed
-        // body. (Bound-source renames are already covered — `validated_bound`
-        // rejects targets the subtree so much as mentions.)
-        let mut local = drop_subtree_captured_targets(free, &*function);
-        local.extend(self.validated_bound(bound, &facts));
+        // Preview of seal's per-scope rules, deciding what fires on this
+        // clone. Free-source aliases get no `mentions` check, but any
+        // whose target the subtree binds is dropped: applying one would
+        // be suppressed only inside the re-binding scope, leaving a
+        // partially renamed body. (Bound-source renames are covered by
+        // `validated_bound`, which rejects targets the subtree so much
+        // as mentions.)
+        let mut local = drop_subtree_captured_targets(free.clone(), &*function);
+        local.extend(self.validated_bound(bound.clone(), &facts));
+        self.submit_scope_intents(function.span, &bound, &free, facts);
         if local.is_empty() {
             return;
         }
-        self.submit_scope_intents(function.span, &local);
         // Params and the root body share this function's scope, where the
         // renamed name is bound exactly once and every reference resolves to
         // it. Drive past the root param/block scope (visiting params and the
@@ -623,11 +645,11 @@ impl VisitMut for ScopedHeuristicNaturalizer<'_> {
         for param in &arrow.params {
             collect_naturalization_renames_from_pattern(param, &mut bound);
         }
-        let local = self.validated_bound(bound, &facts);
+        let local = self.validated_bound(bound.clone(), &facts);
+        self.submit_scope_intents(arrow.span, &bound, &BTreeMap::new(), facts);
         if local.is_empty() {
             return;
         }
-        self.submit_scope_intents(arrow.span, &local);
         let mut renamer = RenameAndShorthandNaturalizer::new(&local);
         arrow.params.visit_mut_with(&mut renamer);
         match &mut *arrow.body {
@@ -642,11 +664,11 @@ impl VisitMut for ScopedHeuristicNaturalizer<'_> {
         let facts = collect_subtree_name_facts(&*constructor);
         let mut bound = BTreeMap::new();
         collect_naturalization_renames_from_constructor(constructor, &mut bound);
-        let local = self.validated_bound(bound, &facts);
+        let local = self.validated_bound(bound.clone(), &facts);
+        self.submit_scope_intents(constructor.span, &bound, &BTreeMap::new(), facts);
         if local.is_empty() {
             return;
         }
-        self.submit_scope_intents(constructor.span, &local);
         let mut renamer = RenameAndShorthandNaturalizer::new(&local);
         for param in &mut constructor.params {
             param.visit_mut_with(&mut renamer);
@@ -654,41 +676,6 @@ impl VisitMut for ScopedHeuristicNaturalizer<'_> {
         rename_root_body(&mut renamer, constructor.body.as_mut());
         assert_no_heuristic_capture(&renamer);
     }
-}
-
-/// Merge `heuristic` into `plan_driven`, dropping any heuristic mapping
-/// whose target is either already claimed by `plan_driven` or shared with
-/// another heuristic source. Two sources renamed onto the same target
-/// would collapse distinct bindings into a duplicate decl as soon as both
-/// happen to live in the same scope.
-pub(super) fn drop_target_collisions(
-    mut plan_driven: BTreeMap<String, String>,
-    heuristic: BTreeMap<String, String>,
-) -> BTreeMap<String, String> {
-    // Only effective heuristic mappings (locals not already in plan_driven)
-    // contribute to the collision count. Counting skipped entries inflates
-    // counts[target] and can drop unrelated heuristic mappings that have only
-    // one effective claimant.
-    let mut counts = BTreeMap::<String, usize>::new();
-    for target in plan_driven.values() {
-        *counts.entry(target.clone()).or_default() += 1;
-    }
-    for (local, target) in &heuristic {
-        if plan_driven.contains_key(local) {
-            continue;
-        }
-        *counts.entry(target.clone()).or_default() += 1;
-    }
-    for (local, target) in heuristic {
-        if plan_driven.contains_key(&local) {
-            continue;
-        }
-        if counts.get(&target).copied().unwrap_or(0) > 1 {
-            continue;
-        }
-        plan_driven.insert(local, target);
-    }
-    plan_driven
 }
 
 /// Collect a top-level item's free-source return-object aliases: renames

--- a/devinfra/js/debundle/lowering/rename_ledger.rs
+++ b/devinfra/js/debundle/lowering/rename_ledger.rs
@@ -8,14 +8,49 @@
 //! pre-ledger code built so the existing application sites (the
 //! string-keyed rename visitors in `visitors.rs`) stay unchanged.
 //!
-//! Current seal validation: no two same-priority intents may disagree on
-//! one `(scope, from)` binding's target — a hard error naming both
-//! contributors. A higher-priority intent (explicit > import-induced >
-//! heuristic) silently wins over a disagreeing lower-priority one.
-//! Target-occupancy / capture validation still happens at the application
-//! sites (`naturalize_module_body`'s root-collision pre-check, the
-//! visitors' `captured` sets); moving it into seal against scope-accurate
-//! occupied sets is PR 3. The single execute pass is PR 4.
+//! ## Seal validation (PR 3 era)
+//!
+//! Seal is the single validation point for ledger renames:
+//!
+//! - **Conflicts**: no two same-priority intents may disagree on one
+//!   `(scope, from)` binding's target — a hard error naming both
+//!   contributors. A higher-priority intent (explicit > import-induced >
+//!   heuristic) silently wins over a disagreeing lower-priority one.
+//! - **Target occupancy**: callers pass per-scope [`ScopeOccupancy`]
+//!   facts in [`SealValidation`]; seal rejects targets the scope already
+//!   binds. Explicit intents failing validation are hard errors carrying
+//!   the same messages the pre-ledger application-site checks raised
+//!   (`invalid chunk_renames spec`, `collides with an existing top-level
+//!   local`, `would be captured by a nested binding`, …). Heuristic
+//!   intents failing validation are dropped silently (over-suppression is
+//!   acceptable; capture is not). Import-induced intents are minted by
+//!   the ledger itself against the same occupancy, so a failure is an
+//!   internal invariant violation.
+//! - **Capture facts, not conservative sets**: capture is
+//!   reference-precise — a target bound in a nested scope is harmless
+//!   when the source is shadowed (or never referenced) inside that scope,
+//!   and the e2e suite pins valid specs of exactly that shape. A flat
+//!   occupied-name set cannot express this, so the caller supplies the
+//!   `(source, target)` pairs the rename visitor's scope stack actually
+//!   withheld ([`ScopeOccupancy::Body::captured`], from the visitor's
+//!   `captured` set on the pre-seal application/preview walk), and seal
+//!   turns them into the hard error. PR 4's executor folds this walk into
+//!   the execute pass itself.
+//!
+//! Scopes without an entry in `SealValidation::occupancy` get conflict
+//! validation only — used by the chunk-level explicit ledger sealed
+//! before lowering, whose intents are re-collected and occupancy-checked
+//! by the downstream ledgers once the post-split bodies exist.
+//!
+//! ## Name minting
+//!
+//! The ledger owns "names taken in scope": callers seed each scope's
+//! taken set from the body's occupied names ([`RenameLedger::seed_taken`]
+//! / [`RenameLedger::claim`]) and request fresh names with
+//! [`RenameLedger::mint`], which suffix-mints `base$N` past collisions
+//! (decided 2026-06: the `$N` scheme stays; readability is a later
+//! naturalizer concern). Import-local disambiguation (`import_emit.rs`)
+//! and public-export growth (`exports.rs`) mint through the ledger.
 //!
 //! ## Contract: no structural moves between seal and execute
 //!
@@ -27,19 +62,59 @@
 //! `ChunkPlan`); the contract becomes mechanically enforceable when the
 //! execute-once pass lands (PR 4) and non-execute passes take `&Module`.
 //!
-//! ## Seal points (PR 2 era)
+//! ## Seal points (PR 3 era)
 //!
-//! Contributor derivation is interleaved with application across the
-//! lowering pipeline — a later contributor derives from the AST state an
-//! earlier contributor's application produced (heuristics read the
-//! post-plan-rename body; import-local minting reads the post-naturalize
-//! body) — so PR 2 seals at phase boundaries: each former private rename
-//! map is its own ledger instance, collected and sealed exactly where
-//! that map used to be complete, with the application site consuming the
-//! sealed projection. The instances are listed in the contributor
-//! inventory below. PR 3 (minting as a ledger service, seal-time
-//! occupancy validation) and PR 4 (execute once) collapse them toward a
-//! single collect → seal → execute pass.
+//! Contributor derivation is still interleaved with application across
+//! the lowering pipeline — a later contributor derives from the AST state
+//! an earlier contributor's application produced — so each phase keeps
+//! its own ledger instance, but every instance now seals with occupancy
+//! validation and the application sites only assert seal's guarantee:
+//!
+//! - **Chunk explicit ledger** (`materialize_logical_chunk`): spec
+//!   `chunk_renames` + plan `export_name`s; conflict-validated only (the
+//!   post-split bodies its targets must avoid don't exist yet — its
+//!   intents are re-collected into the two ledgers below, which validate
+//!   occupancy). Sealed before factorization, which consumes the
+//!   Chunk-scope projection.
+//! - **Entry ledger** (`lower_chunk`): the chunk_renames entries staying
+//!   in entry plus entry import-local mints; seal validates against
+//!   entry's post-split body occupancy.
+//! - **Per-module naturalize ledger** (`naturalize_module_body`): the
+//!   plan's export_name renames (Explicit), free-source return-object
+//!   aliases (Heuristic, `Module` scope), and bound-source scope-local
+//!   heuristics (Heuristic, `Function` scope) — one seal resolves
+//!   explicit-vs-heuristic priority, the module-level target-collision
+//!   rule ([`merge_module_renames`]), and per-scope occupancy.
+//! - **Per-plan import ledger** (`lower_single_plan`): cross-module +
+//!   residual-entry import-local mints; collection needs the
+//!   post-naturalize body facts, so it cannot merge into the naturalize
+//!   ledger until PR 4's execute-once pass removes the intermediate
+//!   application.
+//! - **Export-growth ledger** (`lower_chunk`): auto-grown residual public
+//!   exports (`EntryPublicExports` scope). Collection needs the moved
+//!   bodies' post-naturalize facts and the sealed entry renames, so it
+//!   stays a separate instance until PR 4.
+//!
+//! What still validates at the application site (PR 4 scope):
+//!
+//! - The free-alias subtree-capture filter
+//!   (`naturalize.rs::drop_subtree_captured_targets`): free aliases apply
+//!   function-locally while their intents live at `Module` scope; seal
+//!   checks them against the deriving subtree's bound names when the
+//!   derive pass submits `Function`-scope copies, but the module-level
+//!   occupancy of free-alias targets is not checked (matching pre-ledger
+//!   behavior).
+//! - `chunk_renames` applied to *moved module bodies*
+//!   (`lower_single_plan`'s `cross_module_chunk_renames` pass): the
+//!   entry-side seal validates against entry's body only; a target can
+//!   still collide inside a moved body, and that application keeps its
+//!   reachable bail.
+//! - The derive-phase preview in `naturalize_module_body` (the scratch
+//!   clone + `validated_bound` / `drop_subtree_captured_targets` /
+//!   [`merge_module_renames`] pre-computation): the per-scope derive
+//!   cascade needs each scope's fired map before enclosing scopes derive;
+//!   seal re-derives the same decisions from the submitted facts, and the
+//!   preview is deleted with PR 4's executor.
 //!
 //! ## Hygiene boundary
 //!
@@ -61,44 +136,38 @@
 //!
 //! ## Contributor inventory
 //!
-//! All rename contributors submit intents (PR 2):
+//! All rename contributors submit intents (PR 2) and all validation is
+//! seal-time (PR 3):
 //!
 //! - Spec `chunk_renames` — `chunk_renames.rs::collect_chunk_renames`
-//!   (scope: `Chunk`, origin: `Explicit`; chunk ledger sealed in
-//!   `materialize_logical_chunk`).
+//!   (scope: `Chunk`, origin: `Explicit`; chunk explicit ledger, then
+//!   re-collected into the entry ledger which validates occupancy).
 //! - Plan-driven spec `export_name`s —
 //!   `naturalize.rs::collect_plan_export_rename_intents` (scope:
-//!   `Module`, origin: `Explicit`; same chunk ledger).
-//! - Heuristic bound-source scope-local renames — `naturalize.rs`:
-//!   `collect_naturalization_renames_from_pattern`,
-//!   `collect_naturalization_renames_from_constructor`, and root-bound
-//!   return-object aliases, derived per function-like node by
-//!   `ScopedHeuristicNaturalizer` over a scratch clone of the module body
-//!   (scope: `Function`, origin: `Heuristic`); the per-module ledger seals
-//!   in `naturalize_module_body` and `SealedScopeRenameApplier` replays
-//!   the sealed per-scope maps onto the real body.
-//! - Heuristic free-source return-object aliases — `naturalize.rs`:
-//!   `collect_free_alias_renames_from_item`, submitted per deriving
+//!   `Module`, origin: `Explicit`; chunk explicit ledger, then
+//!   re-collected into the per-module naturalize ledger which validates
+//!   occupancy).
+//! - Heuristic bound-source scope-local renames — `naturalize.rs`,
+//!   derived per function-like node by `ScopedHeuristicNaturalizer`
+//!   (scope: `Function`, origin: `Heuristic`); raw candidates are
+//!   submitted with the deriving subtree's name facts and seal applies
+//!   the validity rules ([`ScopeOccupancy::Subtree`]).
+//! - Heuristic free-source return-object aliases — `naturalize.rs::
+//!   collect_free_alias_renames_from_item`, submitted per deriving
 //!   function (scope: `Module`, origin: `Heuristic`; same per-module
-//!   ledger). The module-global target-collision rule
-//!   (`drop_target_collisions`) still runs at application; moving it into
-//!   seal is PR 3.
+//!   ledger; the module-global target-collision rule runs at seal via
+//!   [`merge_module_renames`]).
 //! - Import-local disambiguation (fresh-local `$N` minting) —
-//!   `import_emit.rs`: `disambiguate_import_locals`,
-//!   `disambiguate_residual_entry_import_locals`, `mint_unique_name`.
-//!   The entry-side call site in `lower.rs::lower_chunk` submits into the
-//!   entry-body ledger (scope: `Chunk`, origin: `ImportInduced`); the
-//!   module-side call sites `imports_cross.rs::cross_module_imports_for_plan`
-//!   and `imports_cross.rs::residual_entry_imports_for_moved_body` submit
-//!   into the per-plan import ledger sealed in `lower_single_plan`
-//!   (scope: `Module`, origin: `ImportInduced`) — this is the
-//!   cross-module rename application to moved bodies. Minting itself
-//!   becomes a ledger service in PR 3; decided 2026-06: the `$N` suffix
-//!   scheme stays as-is (readability is a later naturalizer concern).
+//!   `import_emit.rs::disambiguate_*` mint through
+//!   [`RenameLedger::mint`]. The entry-side call site in
+//!   `lower.rs::lower_chunk` submits into the entry ledger (scope:
+//!   `Chunk`, origin: `ImportInduced`); the module-side call sites in
+//!   `imports_cross.rs` submit into the per-plan import ledger (scope:
+//!   `Module`, origin: `ImportInduced`).
 //! - Collision-resolving public-name minting —
-//!   `exports.rs::auto_grown_residual_exports` (suffix-mints a grown
-//!   public export past pre-existing public names; scope:
-//!   `EntryPublicExports`, origin: `ImportInduced`; sealed in
+//!   `exports.rs::auto_grown_residual_exports` (mints a grown public
+//!   export past pre-existing public names via [`RenameLedger::mint`];
+//!   scope: `EntryPublicExports`, origin: `ImportInduced`; sealed in
 //!   `lower_chunk`'s export-growth phase).
 //!
 //! Vendor boundary renames (`vendor/`) run in a separate pipeline stage on
@@ -112,6 +181,8 @@ use anyhow::{Result, bail};
 use swc_atoms::Atom;
 use swc_common::Span;
 use swc_ecma_ast::Id;
+
+use super::util::is_valid_js_identifier;
 
 /// Identity of one function-like deriving scope (function / arrow /
 /// constructor): the node's source span in the chunk AST. The per-scope
@@ -137,6 +208,9 @@ impl From<Span> for FunctionScopeId {
 /// Where a rename applies. Intents in one scope are invisible to queries
 /// for any other scope — the ledger rejects cross-scope leakage by
 /// construction.
+///
+/// Variant order matters for seal: `Module` validates before `Function`
+/// (the free-alias survival check reads the Module-scope survivors).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum RenameScope {
     /// Bindings staying in the chunk's residual entry body.
@@ -231,11 +305,66 @@ pub struct RenameIntent {
     pub origin: RenameOrigin,
 }
 
-/// Accumulates [`RenameIntent`]s during the collect phase; consumed by
+/// Per-scope name-occupancy facts seal validates rename targets against.
+#[derive(Debug)]
+pub enum ScopeOccupancy {
+    /// `Chunk` / `Module` / `EntryPublicExports` scopes: occupancy of one
+    /// emitted body (or public-export namespace).
+    Body {
+        /// Identity used in error messages: the chunk id for `Chunk`
+        /// scope, the plan id for `Module` scopes.
+        label: String,
+        /// Names bound at the scope's root (top) level. An explicit
+        /// rename target colliding here is a hard error unless the name
+        /// is vacated — i.e. it is itself the source of another explicit
+        /// rename in the same scope.
+        root: BTreeSet<String>,
+        /// Names bound strictly below the root level
+        /// (`scope_names::collect_nested_binding_names`). Ledger-minted
+        /// targets must avoid them (mints claim from a taken set seeded
+        /// with both levels; a collision is an internal invariant
+        /// violation).
+        nested: BTreeSet<String>,
+        /// `(source, target)` pairs the rename visitor's scope stack
+        /// withheld on the pre-seal application/preview walk of this
+        /// scope's body: the target was shadowed at a reference of the
+        /// un-shadowed source, so applying the rename would capture.
+        /// Seal turns these into the hard "would be captured by a
+        /// nested binding" error.
+        captured: BTreeSet<(String, String)>,
+    },
+    /// `Function` scopes: the deriving subtree's name facts, mirroring
+    /// the pre-ledger `validated_bound` / `drop_subtree_captured_targets`
+    /// checks.
+    Subtree {
+        /// Names bound anywhere under the deriving node. Classifies each
+        /// intent (bound-source vs free-source) and rejects free-alias
+        /// targets the subtree binds.
+        bound: BTreeSet<String>,
+        /// Every value/binding identifier sym mentioned in the subtree.
+        /// Bound-source heuristic targets must be absent from it.
+        mentions: BTreeSet<String>,
+    },
+}
+
+/// Validation context for [`RenameLedger::seal`]. Scopes absent from
+/// `occupancy` get conflict/priority validation only.
+#[derive(Debug, Default)]
+pub struct SealValidation {
+    pub occupancy: BTreeMap<RenameScope, ScopeOccupancy>,
+    /// Names the module-wide renames reserve (sources + targets of the
+    /// module's explicit + surviving free renames). `Function`-scope
+    /// bound-source heuristic targets must avoid them.
+    pub reserved: BTreeSet<String>,
+}
+
+/// Accumulates [`RenameIntent`]s during the collect phase and owns the
+/// per-scope taken-name sets behind [`Self::mint`]; consumed by
 /// [`Self::seal`].
 #[derive(Debug, Default)]
 pub struct RenameLedger {
     intents: Vec<RenameIntent>,
+    taken: BTreeMap<RenameScope, BTreeSet<String>>,
 }
 
 impl RenameLedger {
@@ -243,13 +372,62 @@ impl RenameLedger {
         self.intents.push(intent);
     }
 
-    /// Validate and freeze the collected intents. Per `(scope, from)`
-    /// group, the highest-priority intents must agree on one target —
-    /// disagreement at equal priority is a hard error naming every
-    /// contributor on each side. Lower-priority disagreement loses
-    /// silently. Identical duplicates collapse. Every conflict in the
-    /// ledger is reported in one error, not just the first.
-    pub fn seal(self) -> Result<SealedRenames> {
+    /// Seed `scope`'s taken-name set with names [`Self::mint`] must avoid
+    /// (the body's occupied names, pre-existing public exports, …).
+    pub fn seed_taken(&mut self, scope: RenameScope, names: impl IntoIterator<Item = String>) {
+        self.taken.entry(scope).or_default().extend(names);
+    }
+
+    /// Claim `name` in `scope` so later mints avoid it; returns whether
+    /// the name was newly claimed.
+    pub fn claim(&mut self, scope: RenameScope, name: &str) -> bool {
+        self.taken
+            .entry(scope)
+            .or_default()
+            .insert(name.to_string())
+    }
+
+    /// Mint a fresh name in `scope`: `base` itself when it is a usable
+    /// identifier and untaken, else the first untaken `base$N`. The
+    /// minted name is claimed.
+    ///
+    /// A reserved word (`default`, `class`, `await`, …) used verbatim as
+    /// a local would surface straight into an emitted `import {...}` /
+    /// `export {...}` clause and produce un-parseable JS. Suffixing turns
+    /// it into a valid identifier (`default$1`), so only offer `base`
+    /// directly when it is a usable identifier. `$`-suffixed candidates
+    /// are always valid, so the loop below always terminates with a
+    /// parseable name.
+    pub fn mint(&mut self, scope: RenameScope, base: &str) -> String {
+        let taken = self.taken.entry(scope).or_default();
+        if is_valid_js_identifier(base) && taken.insert(base.to_string()) {
+            return base.to_string();
+        }
+        let mut suffix = 1usize;
+        loop {
+            let candidate = format!("{base}${suffix}");
+            if taken.insert(candidate.clone()) {
+                return candidate;
+            }
+            suffix += 1;
+        }
+    }
+
+    /// Validate and freeze the collected intents.
+    ///
+    /// Conflict resolution per `(scope, from)` group: the highest-priority
+    /// intents must agree on one target — disagreement at equal priority
+    /// is a hard error naming every contributor on each side.
+    /// Lower-priority disagreement loses silently. Identical duplicates
+    /// collapse. Every conflict in the ledger is reported in one error,
+    /// not just the first.
+    ///
+    /// Target validation runs per scope against `validation.occupancy`
+    /// (see the module doc's "Seal validation" section): explicit
+    /// failures are hard errors reproducing the pre-ledger messages,
+    /// heuristic failures are silent drops, import-induced failures are
+    /// internal invariant violations.
+    pub fn seal(self, validation: &SealValidation) -> Result<SealedRenames> {
         let mut groups: BTreeMap<(RenameScope, Id), Vec<RenameIntent>> = BTreeMap::new();
         for intent in self.intents {
             groups
@@ -257,7 +435,8 @@ impl RenameLedger {
                 .or_default()
                 .push(intent);
         }
-        let mut by_scope: BTreeMap<RenameScope, BTreeMap<Id, Atom>> = BTreeMap::new();
+        let mut by_scope: BTreeMap<RenameScope, BTreeMap<Id, (Atom, RenamePriority)>> =
+            BTreeMap::new();
         let mut conflicts = Vec::new();
         for ((scope, from), intents) in groups {
             let top_priority = intents
@@ -304,7 +483,7 @@ impl RenameLedger {
             by_scope
                 .entry(scope)
                 .or_default()
-                .insert(from, (*to).clone());
+                .insert(from, ((*to).clone(), top_priority));
         }
         if !conflicts.is_empty() {
             bail!(
@@ -312,17 +491,269 @@ impl RenameLedger {
                 conflicts.join("\n  - "),
             );
         }
-        Ok(SealedRenames { by_scope })
+
+        // Target validation, scope by scope. `Module` scopes validate
+        // before `Function` scopes (RenameScope variant order), so the
+        // free-alias survival check below sees the Module survivors.
+        let mut surviving_module_heuristics = BTreeSet::<(String, String)>::new();
+        let mut sealed: BTreeMap<RenameScope, BTreeMap<Id, (Atom, RenamePriority)>> =
+            BTreeMap::new();
+        for (scope, winners) in by_scope {
+            let kept = match validation.occupancy.get(&scope) {
+                None => winners,
+                Some(ScopeOccupancy::Body {
+                    label,
+                    root,
+                    nested,
+                    captured,
+                }) => validate_body_scope(&scope, label, root, nested, captured, winners)?,
+                Some(ScopeOccupancy::Subtree { bound, mentions }) => validate_function_scope(
+                    bound,
+                    mentions,
+                    &validation.reserved,
+                    &surviving_module_heuristics,
+                    winners,
+                ),
+            };
+            if matches!(scope, RenameScope::Module(_)) {
+                for (from, (to, priority)) in &kept {
+                    if *priority == RenamePriority::Heuristic {
+                        surviving_module_heuristics.insert((from.0.to_string(), to.to_string()));
+                    }
+                }
+            }
+            if !kept.is_empty() {
+                sealed.insert(scope, kept);
+            }
+        }
+        Ok(SealedRenames { by_scope: sealed })
     }
 }
 
+/// Target validation for `Chunk` / `Module` / `EntryPublicExports`
+/// scopes. Explicit intents replay the pre-ledger application-site
+/// checks (hard errors, same messages); import-induced intents assert
+/// the mint invariant; heuristic intents (free-source aliases) get the
+/// [`merge_module_renames`] target-collision rule — their occupancy is
+/// deliberately NOT checked here, matching pre-ledger behavior (they
+/// apply function-locally; the subtree check runs on their
+/// `Function`-scope copies).
+fn validate_body_scope(
+    scope: &RenameScope,
+    label: &str,
+    root: &BTreeSet<String>,
+    nested: &BTreeSet<String>,
+    captured: &BTreeSet<(String, String)>,
+    mut winners: BTreeMap<Id, (Atom, RenamePriority)>,
+) -> Result<BTreeMap<Id, (Atom, RenamePriority)>> {
+    let chunk_style = matches!(scope, RenameScope::Chunk);
+    // Sources of explicit renames vacate their root-level slot: a target
+    // equal to another explicit rename's source is allowed past the
+    // root-collision check (the binding is being renamed away) — but
+    // only at the root level; a same-named nested binding stays
+    // occupied. Chunk-style validation still reports such targets as
+    // duplicates (the pre-ledger loop's growing occupied set already
+    // held every root name), while module-style validation has no
+    // duplicate-against-root rule, so chain/swap renames are allowed.
+    let vacated: BTreeSet<String> = winners
+        .iter()
+        .filter(|(_, (_, priority))| *priority == RenamePriority::Explicit)
+        .map(|(from, _)| from.0.to_string())
+        .collect();
+    let mut errors = Vec::new();
+    // Chunk-style: grows with accepted targets so an earlier accepted
+    // target occupies the name for later entries (sorted-by-source
+    // order, matching the pre-ledger loop). Module-style: tracks rename
+    // targets only, so two explicit renames sharing one target surface
+    // (plan building already rejects duplicate export names; this is the
+    // seal-side guarantee).
+    let mut taken: BTreeSet<String> = if chunk_style {
+        root.iter().cloned().collect()
+    } else {
+        BTreeSet::new()
+    };
+    for (from, (to, priority)) in &winners {
+        if *priority != RenamePriority::Explicit {
+            continue;
+        }
+        let from = from.0.as_ref();
+        let to = to.as_ref();
+        if chunk_style && !is_valid_js_identifier(to) {
+            errors.push(format!(
+                "chunk_renames target {to} for binding {from} is not a valid JS identifier",
+            ));
+            continue;
+        }
+        let occupied_for_collision = if chunk_style { &taken } else { root };
+        if to != from && occupied_for_collision.contains(to) && !vacated.contains(to) {
+            errors.push(if chunk_style {
+                format!(
+                    "chunk_renames target {to} for binding {from} collides with an existing top-level local",
+                )
+            } else {
+                format!(
+                    "rename of binding {from} to {to} collides with another top-level binding in the module body",
+                )
+            });
+            continue;
+        }
+        if !taken.insert(to.to_string()) && to != from {
+            errors.push(if chunk_style {
+                format!(
+                    "chunk_renames target {to} for binding {from} duplicates an earlier rename target",
+                )
+            } else {
+                format!(
+                    "rename of binding {from} to {to} duplicates another rename target in the module",
+                )
+            });
+            continue;
+        }
+    }
+    if !errors.is_empty() {
+        if chunk_style {
+            bail!("invalid chunk_renames spec:\n  - {}", errors.join("\n  - "));
+        }
+        bail!(
+            "invalid renames for module {label}:\n  - {}",
+            errors.join("\n  - "),
+        );
+    }
+    // Capture facts the caller's rename walk observed: applying these
+    // renames would make a reference resolve to a nested binding of the
+    // target name. The pre-seal walk's mutation is discarded with the
+    // whole run by this bail.
+    if !captured.is_empty() {
+        if chunk_style {
+            bail!(
+                "chunk_renames for chunk {label} would be captured by a nested binding: {captured:?}",
+            );
+        }
+        bail!("renames for module {label} would be captured by a nested binding: {captured:?}",);
+    }
+    for (from, (to, priority)) in &winners {
+        if *priority == RenamePriority::ImportInduced
+            && (root.contains(to.as_ref()) || nested.contains(to.as_ref()))
+        {
+            bail!(
+                "internal invariant violation: ledger-minted rename target {to} for binding {} collides with an occupied name in {scope}; minting must claim from the scope's seeded taken set",
+                from.0,
+            );
+        }
+    }
+    // Heuristic (free-source) target collisions: drop losers silently.
+    let explicit_by_name: BTreeMap<String, String> = winners
+        .iter()
+        .filter(|(_, (_, priority))| *priority != RenamePriority::Heuristic)
+        .map(|(from, (to, _))| (from.0.to_string(), to.to_string()))
+        .collect();
+    let heuristic_by_name: BTreeMap<String, String> = winners
+        .iter()
+        .filter(|(_, (_, priority))| *priority == RenamePriority::Heuristic)
+        .map(|(from, (to, _))| (from.0.to_string(), to.to_string()))
+        .collect();
+    if !heuristic_by_name.is_empty() {
+        let merged = merge_module_renames(explicit_by_name, heuristic_by_name);
+        winners.retain(|from, (to, priority)| {
+            *priority != RenamePriority::Heuristic
+                || merged.get(from.0.as_ref()).map(String::as_str) == Some(to.as_ref())
+        });
+    }
+    Ok(winners)
+}
+
+/// Target validation for `Function` scopes, replaying the pre-ledger
+/// per-scope heuristic rules. An intent whose source the subtree binds is
+/// a bound-source rename (`validated_bound` rules: target unique among
+/// the scope's bound-source targets, unreserved, absent from the
+/// subtree's mentions, not another bound source). An intent whose source
+/// the subtree does NOT bind is a free-source alias copy: its target must
+/// not be bound in the subtree and its `(from, to)` pair must have
+/// survived Module-scope validation. Failures drop silently
+/// (over-suppression is acceptable for heuristics).
+fn validate_function_scope(
+    bound: &BTreeSet<String>,
+    mentions: &BTreeSet<String>,
+    reserved: &BTreeSet<String>,
+    surviving_module_heuristics: &BTreeSet<(String, String)>,
+    mut winners: BTreeMap<Id, (Atom, RenamePriority)>,
+) -> BTreeMap<Id, (Atom, RenamePriority)> {
+    let bound_sources: BTreeSet<String> = winners
+        .keys()
+        .map(|from| from.0.to_string())
+        .filter(|sym| bound.contains(sym))
+        .collect();
+    let mut bound_target_counts = BTreeMap::<String, usize>::new();
+    for (from, (to, _)) in &winners {
+        if bound.contains(from.0.as_ref()) {
+            *bound_target_counts.entry(to.to_string()).or_default() += 1;
+        }
+    }
+    winners.retain(|from, (to, priority)| {
+        if *priority != RenamePriority::Heuristic {
+            return true;
+        }
+        let to = to.as_ref();
+        if bound.contains(from.0.as_ref()) {
+            bound_target_counts.get(to).copied() == Some(1)
+                && !reserved.contains(to)
+                && !mentions.contains(to)
+                && !bound_sources.contains(to)
+        } else {
+            !bound.contains(to)
+                && surviving_module_heuristics.contains(&(from.0.to_string(), to.to_string()))
+        }
+    });
+    winners
+}
+
+/// Merge `heuristic` into `explicit`, dropping any heuristic mapping
+/// whose source `explicit` already renames, whose target `explicit`
+/// claims, or whose target is shared with another effective heuristic
+/// source. Two sources renamed onto the same target would collapse
+/// distinct bindings into a duplicate decl as soon as both happen to live
+/// in the same scope. This is the module-level target-collision rule
+/// seal applies to free-source aliases; `naturalize_module_body` calls it
+/// directly for the derive-phase preview (`free_allowed`), which is
+/// deleted with PR 4's executor.
+pub fn merge_module_renames(
+    mut explicit: BTreeMap<String, String>,
+    heuristic: BTreeMap<String, String>,
+) -> BTreeMap<String, String> {
+    // Only effective heuristic mappings (sources not already renamed by
+    // `explicit`) contribute to the collision count. Counting skipped
+    // entries inflates counts[target] and can drop unrelated heuristic
+    // mappings that have only one effective claimant.
+    let mut counts = BTreeMap::<String, usize>::new();
+    for target in explicit.values() {
+        *counts.entry(target.clone()).or_default() += 1;
+    }
+    for (source, target) in &heuristic {
+        if explicit.contains_key(source) {
+            continue;
+        }
+        *counts.entry(target.clone()).or_default() += 1;
+    }
+    for (source, target) in heuristic {
+        if explicit.contains_key(&source) {
+            continue;
+        }
+        if counts.get(&target).copied().unwrap_or(0) > 1 {
+            continue;
+        }
+        explicit.insert(source, target);
+    }
+    explicit
+}
+
 /// The validated, read-only output of [`RenameLedger::seal`]: per scope,
-/// the final `from → to` mapping. Queries reproduce exactly the maps the
-/// pre-ledger code built so the existing application sites consume them
-/// unchanged.
+/// the final `from → to` mapping (with the winning priority retained so
+/// origin-split queries can separate plan-driven renames from
+/// heuristics). Queries reproduce exactly the maps the pre-ledger code
+/// built so the existing application sites consume them unchanged.
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct SealedRenames {
-    by_scope: BTreeMap<RenameScope, BTreeMap<Id, Atom>>,
+    by_scope: BTreeMap<RenameScope, BTreeMap<Id, (Atom, RenamePriority)>>,
 }
 
 impl SealedRenames {
@@ -335,16 +766,28 @@ impl SealedRenames {
             .collect()
     }
 
-    /// One module's plan-driven renames projected to bare names, sorted —
-    /// the `plan_driven` map `naturalize_module_body` consumes
-    /// (pre-ledger: derived inline from `plan.bindings`).
+    /// One module's renames projected to bare names, sorted — plan-driven
+    /// and surviving free-source heuristics merged (pre-ledger: the
+    /// `NaturalizedRenames::merged` map).
     pub fn module_renames_by_name(&self, module: ModuleId) -> BTreeMap<String, String> {
         self.scope_renames_by_name(&RenameScope::Module(module))
     }
 
+    /// One module's *explicit* (plan-driven) renames only — the map
+    /// export locals and binding-comment keys remap through (heuristic
+    /// entries are scope-local and never rename a top-level declaration).
+    pub fn module_explicit_renames_by_name(&self, module: ModuleId) -> BTreeMap<String, String> {
+        self.scope_renames_at_priority(&RenameScope::Module(module), RenamePriority::Explicit)
+    }
+
     /// Typed per-scope view (tests, the future execute-once pass).
-    pub fn scope_renames(&self, scope: &RenameScope) -> Option<&BTreeMap<Id, Atom>> {
-        self.by_scope.get(scope)
+    pub fn scope_renames(&self, scope: &RenameScope) -> Option<BTreeMap<Id, Atom>> {
+        self.by_scope.get(scope).map(|renames| {
+            renames
+                .iter()
+                .map(|(from, (to, _))| (from.clone(), to.clone()))
+                .collect()
+        })
     }
 
     /// Project one scope's sealed renames onto bare syms for the
@@ -355,11 +798,30 @@ impl SealedRenames {
     /// for `Function`), so that cannot happen; assert rather than silently
     /// merge if it ever does.
     pub fn scope_renames_by_name(&self, scope: &RenameScope) -> BTreeMap<String, String> {
+        self.scope_renames_by_name_filtered(scope, |_| true)
+    }
+
+    fn scope_renames_at_priority(
+        &self,
+        scope: &RenameScope,
+        priority: RenamePriority,
+    ) -> BTreeMap<String, String> {
+        self.scope_renames_by_name_filtered(scope, |p| p == priority)
+    }
+
+    fn scope_renames_by_name_filtered(
+        &self,
+        scope: &RenameScope,
+        keep: impl Fn(RenamePriority) -> bool,
+    ) -> BTreeMap<String, String> {
         let Some(renames) = self.by_scope.get(scope) else {
             return BTreeMap::new();
         };
         let mut by_name = BTreeMap::new();
-        for (from, to) in renames {
+        for (from, (to, priority)) in renames {
+            if !keep(*priority) {
+                continue;
+            }
             let previous = by_name.insert(from.0.to_string(), to.to_string());
             assert!(
                 previous.is_none(),
@@ -390,11 +852,51 @@ mod tests {
         }
     }
 
+    fn names(names: &[&str]) -> BTreeSet<String> {
+        names.iter().map(|n| n.to_string()).collect()
+    }
+
+    fn body_occupancy(scope: RenameScope, root: &[&str], nested: &[&str]) -> SealValidation {
+        body_occupancy_with_captures(scope, root, nested, &[])
+    }
+
+    fn body_occupancy_with_captures(
+        scope: RenameScope,
+        root: &[&str],
+        nested: &[&str],
+        captured: &[(&str, &str)],
+    ) -> SealValidation {
+        SealValidation {
+            occupancy: BTreeMap::from([(
+                scope,
+                ScopeOccupancy::Body {
+                    label: "spec_x".to_string(),
+                    root: names(root),
+                    nested: names(nested),
+                    captured: captured
+                        .iter()
+                        .map(|(from, to)| (from.to_string(), to.to_string()))
+                        .collect(),
+                },
+            )]),
+            reserved: BTreeSet::new(),
+        }
+    }
+
     const A: RenameOrigin = RenameOrigin::Explicit {
         contributor: "contributor_a",
     };
     const B: RenameOrigin = RenameOrigin::Explicit {
         contributor: "contributor_b",
+    };
+    const HEURISTIC: RenameOrigin = RenameOrigin::Heuristic {
+        contributor: "scope-local heuristic naturalizer",
+    };
+    const FREE: RenameOrigin = RenameOrigin::Heuristic {
+        contributor: "return-object alias (free source)",
+    };
+    const MINT: RenameOrigin = RenameOrigin::ImportInduced {
+        contributor: "entry import-local disambiguation",
     };
 
     #[test]
@@ -402,7 +904,10 @@ mod tests {
         let mut ledger = RenameLedger::default();
         ledger.submit(intent(RenameScope::Chunk, "a", "first", A));
         ledger.submit(intent(RenameScope::Chunk, "a", "second", B));
-        let message = ledger.seal().unwrap_err().to_string();
+        let message = ledger
+            .seal(&SealValidation::default())
+            .unwrap_err()
+            .to_string();
         assert!(message.contains("contributor_a"), "{message}");
         assert!(message.contains("contributor_b"), "{message}");
         assert!(message.contains("`first`"), "{message}");
@@ -416,7 +921,10 @@ mod tests {
         ledger.submit(intent(RenameScope::Chunk, "a", "second", B));
         ledger.submit(intent(RenameScope::Chunk, "b", "third", A));
         ledger.submit(intent(RenameScope::Chunk, "b", "fourth", B));
-        let message = ledger.seal().unwrap_err().to_string();
+        let message = ledger
+            .seal(&SealValidation::default())
+            .unwrap_err()
+            .to_string();
         assert!(message.contains("binding `a`"), "{message}");
         assert!(message.contains("binding `b`"), "{message}");
     }
@@ -426,7 +934,7 @@ mod tests {
         let mut ledger = RenameLedger::default();
         ledger.submit(intent(RenameScope::Chunk, "a", "readable", A));
         ledger.submit(intent(RenameScope::Chunk, "a", "readable", B));
-        let sealed = ledger.seal().unwrap();
+        let sealed = ledger.seal(&SealValidation::default()).unwrap();
         assert_eq!(
             sealed.chunk_renames_by_name(),
             HashMap::from([("a".to_string(), "readable".to_string())]),
@@ -445,7 +953,7 @@ mod tests {
             },
         ));
         ledger.submit(intent(RenameScope::Chunk, "a", "explicit_name", A));
-        let sealed = ledger.seal().unwrap();
+        let sealed = ledger.seal(&SealValidation::default()).unwrap();
         assert_eq!(
             sealed.chunk_renames_by_name(),
             HashMap::from([("a".to_string(), "explicit_name".to_string())]),
@@ -467,7 +975,7 @@ mod tests {
             },
         ));
         ledger.submit(intent(module_scope, "e", "registry", A));
-        let sealed = ledger.seal().unwrap();
+        let sealed = ledger.seal(&SealValidation::default()).unwrap();
         assert_eq!(
             sealed.module_renames_by_name(ModuleId::logical(0)),
             BTreeMap::from([("e".to_string(), "registry".to_string())]),
@@ -475,7 +983,7 @@ mod tests {
         assert!(sealed.chunk_renames_by_name().is_empty());
         assert_eq!(
             sealed.scope_renames(&function_scope),
-            Some(&BTreeMap::from([(id("e"), Atom::from("value"))])),
+            Some(BTreeMap::from([(id("e"), Atom::from("value"))])),
         );
         assert_eq!(sealed.scope_renames(&RenameScope::Chunk), None);
     }
@@ -495,7 +1003,7 @@ mod tests {
             "y",
             A,
         ));
-        let sealed = ledger.seal().unwrap();
+        let sealed = ledger.seal(&SealValidation::default()).unwrap();
         assert_eq!(
             sealed.module_renames_by_name(ModuleId::logical(0)),
             BTreeMap::from([("a".to_string(), "x".to_string())]),
@@ -534,7 +1042,10 @@ mod tests {
         for i in intents.iter().rev() {
             reverse.submit(i.clone());
         }
-        assert_eq!(forward.seal().unwrap(), reverse.seal().unwrap());
+        assert_eq!(
+            forward.seal(&SealValidation::default()).unwrap(),
+            reverse.seal(&SealValidation::default()).unwrap(),
+        );
     }
 
     #[test]
@@ -549,7 +1060,7 @@ mod tests {
         let mut ledger = RenameLedger::default();
         ledger.submit(intent(RenameScope::Chunk, "a", "readable", A));
         ledger.submit(intent(RenameScope::EntryPublicExports, "a", "a$1", mint));
-        let sealed = ledger.seal().unwrap();
+        let sealed = ledger.seal(&SealValidation::default()).unwrap();
         assert_eq!(
             sealed.scope_renames_by_name(&RenameScope::Chunk),
             BTreeMap::from([("a".to_string(), "readable".to_string())]),
@@ -572,7 +1083,10 @@ mod tests {
         let mut ledger = RenameLedger::default();
         ledger.submit(intent(module, "x", "x$1", cross));
         ledger.submit(intent(module, "x", "x$2", residual));
-        let message = ledger.seal().unwrap_err().to_string();
+        let message = ledger
+            .seal(&SealValidation::default())
+            .unwrap_err()
+            .to_string();
         assert!(
             message.contains("cross-module import-local disambiguation"),
             "{message}"
@@ -585,17 +1099,14 @@ mod tests {
 
     #[test]
     fn function_scope_projection_returns_per_scope_string_maps() {
-        let heuristic = RenameOrigin::Heuristic {
-            contributor: "scope-local heuristic naturalizer",
-        };
         let outer = RenameScope::Function(FunctionScopeId { lo: 1, hi: 100 });
         let inner = RenameScope::Function(FunctionScopeId { lo: 10, hi: 20 });
         let mut ledger = RenameLedger::default();
         // Sibling/nested scopes reusing one minified spelling with
         // different targets are independent renames (#2045) — no conflict.
-        ledger.submit(intent(outer, "e", "value", heuristic));
-        ledger.submit(intent(inner, "e", "registry", heuristic));
-        let sealed = ledger.seal().unwrap();
+        ledger.submit(intent(outer, "e", "value", HEURISTIC));
+        ledger.submit(intent(inner, "e", "registry", HEURISTIC));
+        let sealed = ledger.seal(&SealValidation::default()).unwrap();
         assert_eq!(
             sealed.scope_renames_by_name(&outer),
             BTreeMap::from([("e".to_string(), "value".to_string())]),
@@ -624,10 +1135,434 @@ mod tests {
             to: Atom::from("second"),
             origin: B,
         });
-        let sealed = ledger.seal().unwrap();
+        let sealed = ledger.seal(&SealValidation::default()).unwrap();
         assert_eq!(
             sealed.scope_renames(&RenameScope::Module(ModuleId::logical(0))),
-            Some(&BTreeMap::from([(other_ctxt, Atom::from("second"))])),
+            Some(BTreeMap::from([(other_ctxt, Atom::from("second"))])),
+        );
+    }
+
+    // --- minting ---
+
+    #[test]
+    fn mint_returns_base_when_untaken_and_suffixes_past_collisions() {
+        let mut ledger = RenameLedger::default();
+        ledger.seed_taken(RenameScope::Chunk, ["taken".to_string()]);
+        assert_eq!(ledger.mint(RenameScope::Chunk, "fresh"), "fresh");
+        // The minted name is claimed: a second request suffixes.
+        assert_eq!(ledger.mint(RenameScope::Chunk, "fresh"), "fresh$1");
+        assert_eq!(ledger.mint(RenameScope::Chunk, "fresh"), "fresh$2");
+        assert_eq!(ledger.mint(RenameScope::Chunk, "taken"), "taken$1");
+    }
+
+    #[test]
+    fn mint_never_offers_a_reserved_word_verbatim() {
+        let mut ledger = RenameLedger::default();
+        assert_eq!(ledger.mint(RenameScope::Chunk, "default"), "default$1");
+    }
+
+    #[test]
+    fn mint_taken_sets_are_per_scope() {
+        let mut ledger = RenameLedger::default();
+        ledger.seed_taken(RenameScope::Chunk, ["name".to_string()]);
+        assert_eq!(ledger.mint(RenameScope::Chunk, "name"), "name$1");
+        assert_eq!(
+            ledger.mint(RenameScope::Module(ModuleId::logical(0)), "name"),
+            "name",
+        );
+    }
+
+    #[test]
+    fn claim_reserves_a_name_for_later_mints() {
+        let mut ledger = RenameLedger::default();
+        assert!(ledger.claim(RenameScope::Chunk, "readable"));
+        assert!(!ledger.claim(RenameScope::Chunk, "readable"));
+        assert_eq!(ledger.mint(RenameScope::Chunk, "readable"), "readable$1");
+    }
+
+    // --- explicit occupancy validation (hard errors) ---
+
+    #[test]
+    fn chunk_explicit_target_colliding_with_root_binding_is_a_hard_error() {
+        let mut ledger = RenameLedger::default();
+        ledger.submit(intent(RenameScope::Chunk, "a", "delta", A));
+        let message = ledger
+            .seal(&body_occupancy(RenameScope::Chunk, &["a", "delta"], &[]))
+            .unwrap_err()
+            .to_string();
+        assert!(message.contains("invalid chunk_renames spec"), "{message}");
+        assert!(
+            message.contains("collides with an existing top-level local"),
+            "{message}"
+        );
+    }
+
+    #[test]
+    fn chunk_explicit_violations_surface_together() {
+        let mut ledger = RenameLedger::default();
+        ledger.submit(intent(RenameScope::Chunk, "alpha", "1-bad-ident", A));
+        ledger.submit(intent(RenameScope::Chunk, "bravo", "delta", A));
+        ledger.submit(intent(RenameScope::Chunk, "charlie", "shared", A));
+        ledger.submit(intent(RenameScope::Chunk, "delta", "shared", A));
+        let message = ledger
+            .seal(&body_occupancy(
+                RenameScope::Chunk,
+                &["alpha", "bravo", "charlie", "delta"],
+                &[],
+            ))
+            .unwrap_err()
+            .to_string();
+        assert!(message.contains("not a valid JS identifier"), "{message}");
+        assert!(
+            message.contains("collides with an existing top-level local"),
+            "{message}"
+        );
+        assert!(
+            message.contains("duplicates an earlier rename target"),
+            "{message}"
+        );
+    }
+
+    #[test]
+    fn chunk_chain_rename_onto_vacated_name_reports_duplicate() {
+        // Chain renames a→b, b→c at Chunk scope: `b`'s vacated root slot
+        // routes the violation past the "collides" branch, but the
+        // growing occupied set (which holds every root name) still
+        // reports it — the pre-ledger loop's exact semantics.
+        let mut ledger = RenameLedger::default();
+        ledger.submit(intent(RenameScope::Chunk, "a", "b", A));
+        ledger.submit(intent(RenameScope::Chunk, "b", "c", A));
+        let message = ledger
+            .seal(&body_occupancy(RenameScope::Chunk, &["a", "b"], &[]))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            message.contains("duplicates an earlier rename target"),
+            "{message}"
+        );
+    }
+
+    #[test]
+    fn module_swap_renames_are_allowed_via_vacating() {
+        // Module-scope explicit renames may swap two bindings' names:
+        // each target's root slot is vacated by the other rename, and
+        // module-style validation has no duplicate-against-root rule.
+        let module = RenameScope::Module(ModuleId::logical(0));
+        let mut ledger = RenameLedger::default();
+        ledger.submit(intent(module, "a", "b", A));
+        ledger.submit(intent(module, "b", "a", A));
+        let sealed = ledger
+            .seal(&body_occupancy(module, &["a", "b"], &[]))
+            .unwrap();
+        assert_eq!(
+            sealed.module_renames_by_name(ModuleId::logical(0)),
+            BTreeMap::from([
+                ("a".to_string(), "b".to_string()),
+                ("b".to_string(), "a".to_string()),
+            ]),
+        );
+    }
+
+    #[test]
+    fn observed_capture_facts_are_a_hard_error() {
+        // The caller's rename walk reports `(source, target)` pairs the
+        // scope stack withheld; seal rejects with the pre-ledger message.
+        let mut ledger = RenameLedger::default();
+        ledger.submit(intent(RenameScope::Chunk, "a", "b", A));
+        let message = ledger
+            .seal(&body_occupancy_with_captures(
+                RenameScope::Chunk,
+                &["a", "f"],
+                &["b"],
+                &[("a", "b")],
+            ))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            message.contains("captured by a nested binding"),
+            "{message}"
+        );
+    }
+
+    #[test]
+    fn nested_bound_target_without_observed_capture_is_allowed() {
+        // Reference-precision: a target bound only in a nested scope
+        // where the source is shadowed (or never referenced) does not
+        // capture — the rename walk reports no pair, so seal accepts.
+        let mut ledger = RenameLedger::default();
+        ledger.submit(intent(RenameScope::Chunk, "a", "b", A));
+        let sealed = ledger
+            .seal(&body_occupancy(RenameScope::Chunk, &["a", "f"], &["b"]))
+            .unwrap();
+        assert_eq!(
+            sealed.chunk_renames_by_name(),
+            HashMap::from([("a".to_string(), "b".to_string())]),
+        );
+    }
+
+    #[test]
+    fn module_explicit_target_colliding_with_root_binding_is_a_hard_error() {
+        let module = RenameScope::Module(ModuleId::logical(0));
+        let mut ledger = RenameLedger::default();
+        ledger.submit(intent(module, "a", "readable", A));
+        let message = ledger
+            .seal(&body_occupancy(module, &["a", "readable"], &[]))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            message.contains("invalid renames for module spec_x"),
+            "{message}"
+        );
+        assert!(
+            message.contains(
+                "rename of binding a to readable collides with another top-level binding"
+            ),
+            "{message}"
+        );
+    }
+
+    #[test]
+    fn minted_target_colliding_with_occupancy_is_an_invariant_error() {
+        // Mints come from the ledger's own taken set; a collision means
+        // the caller seeded the wrong occupancy — an internal bug, not a
+        // spec error.
+        let mut ledger = RenameLedger::default();
+        ledger.submit(intent(RenameScope::Chunk, "x", "x$1", MINT));
+        let message = ledger
+            .seal(&body_occupancy(RenameScope::Chunk, &["x", "x$1"], &[]))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            message.contains("internal invariant violation"),
+            "{message}"
+        );
+    }
+
+    // --- heuristic drop policies ---
+
+    #[test]
+    fn module_heuristics_sharing_a_target_are_both_dropped() {
+        let module = RenameScope::Module(ModuleId::logical(0));
+        let mut ledger = RenameLedger::default();
+        ledger.submit(intent(module, "a", "shared", FREE));
+        ledger.submit(intent(module, "b", "shared", FREE));
+        ledger.submit(intent(module, "c", "unique", FREE));
+        let sealed = ledger.seal(&body_occupancy(module, &[], &[])).unwrap();
+        assert_eq!(
+            sealed.module_renames_by_name(ModuleId::logical(0)),
+            BTreeMap::from([("c".to_string(), "unique".to_string())]),
+        );
+    }
+
+    #[test]
+    fn module_heuristic_targeting_an_explicit_target_is_dropped() {
+        let module = RenameScope::Module(ModuleId::logical(0));
+        let mut ledger = RenameLedger::default();
+        ledger.submit(intent(module, "a", "winner", A));
+        ledger.submit(intent(module, "b", "winner", FREE));
+        let sealed = ledger.seal(&body_occupancy(module, &["a"], &[])).unwrap();
+        assert_eq!(
+            sealed.module_renames_by_name(ModuleId::logical(0)),
+            BTreeMap::from([("a".to_string(), "winner".to_string())]),
+        );
+        assert_eq!(
+            sealed.module_explicit_renames_by_name(ModuleId::logical(0)),
+            BTreeMap::from([("a".to_string(), "winner".to_string())]),
+        );
+    }
+
+    #[test]
+    fn module_explicit_query_excludes_heuristic_survivors() {
+        let module = RenameScope::Module(ModuleId::logical(0));
+        let mut ledger = RenameLedger::default();
+        ledger.submit(intent(module, "a", "plan_name", A));
+        ledger.submit(intent(module, "t", "options", FREE));
+        let sealed = ledger.seal(&body_occupancy(module, &["a"], &[])).unwrap();
+        assert_eq!(
+            sealed.module_renames_by_name(ModuleId::logical(0)),
+            BTreeMap::from([
+                ("a".to_string(), "plan_name".to_string()),
+                ("t".to_string(), "options".to_string()),
+            ]),
+        );
+        assert_eq!(
+            sealed.module_explicit_renames_by_name(ModuleId::logical(0)),
+            BTreeMap::from([("a".to_string(), "plan_name".to_string())]),
+        );
+    }
+
+    // --- Function-scope occupancy (validated_bound replay) ---
+
+    fn function_validation(
+        scope: RenameScope,
+        bound: &[&str],
+        mentions: &[&str],
+        reserved: &[&str],
+    ) -> SealValidation {
+        SealValidation {
+            occupancy: BTreeMap::from([(
+                scope,
+                ScopeOccupancy::Subtree {
+                    bound: names(bound),
+                    mentions: names(mentions),
+                },
+            )]),
+            reserved: names(reserved),
+        }
+    }
+
+    #[test]
+    fn bound_source_heuristic_dropped_when_target_mentioned_in_subtree() {
+        let scope = RenameScope::Function(FunctionScopeId { lo: 1, hi: 9 });
+        let mut ledger = RenameLedger::default();
+        ledger.submit(intent(scope, "e", "value", HEURISTIC));
+        let sealed = ledger
+            .seal(&function_validation(scope, &["e"], &["e", "value"], &[]))
+            .unwrap();
+        assert!(sealed.scope_renames_by_name(&scope).is_empty());
+    }
+
+    #[test]
+    fn bound_source_heuristic_dropped_when_target_reserved_module_wide() {
+        let scope = RenameScope::Function(FunctionScopeId { lo: 1, hi: 9 });
+        let mut ledger = RenameLedger::default();
+        ledger.submit(intent(scope, "e", "options", HEURISTIC));
+        let sealed = ledger
+            .seal(&function_validation(scope, &["e"], &["e"], &["options"]))
+            .unwrap();
+        assert!(sealed.scope_renames_by_name(&scope).is_empty());
+    }
+
+    #[test]
+    fn bound_source_heuristics_sharing_a_target_are_both_dropped() {
+        let scope = RenameScope::Function(FunctionScopeId { lo: 1, hi: 9 });
+        let mut ledger = RenameLedger::default();
+        ledger.submit(intent(scope, "e", "value", HEURISTIC));
+        ledger.submit(intent(scope, "n", "value", HEURISTIC));
+        ledger.submit(intent(scope, "k", "kept", HEURISTIC));
+        let sealed = ledger
+            .seal(&function_validation(
+                scope,
+                &["e", "n", "k"],
+                &["e", "n", "k"],
+                &[],
+            ))
+            .unwrap();
+        assert_eq!(
+            sealed.scope_renames_by_name(&scope),
+            BTreeMap::from([("k".to_string(), "kept".to_string())]),
+        );
+    }
+
+    #[test]
+    fn bound_source_heuristic_dropped_when_target_is_another_source() {
+        let scope = RenameScope::Function(FunctionScopeId { lo: 1, hi: 9 });
+        let mut ledger = RenameLedger::default();
+        ledger.submit(intent(scope, "e", "n", HEURISTIC));
+        ledger.submit(intent(scope, "n", "fresh", HEURISTIC));
+        let sealed = ledger
+            .seal(&function_validation(scope, &["e", "n"], &["e", "n"], &[]))
+            .unwrap();
+        assert_eq!(
+            sealed.scope_renames_by_name(&scope),
+            BTreeMap::from([("n".to_string(), "fresh".to_string())]),
+        );
+    }
+
+    #[test]
+    fn free_alias_copy_dropped_when_target_bound_in_subtree() {
+        // Free-source aliases (source NOT bound in the subtree) are
+        // exempt from the mentions rule but must not target a name the
+        // subtree binds.
+        let module = RenameScope::Module(ModuleId::logical(0));
+        let scope = RenameScope::Function(FunctionScopeId { lo: 1, hi: 9 });
+        let mut ledger = RenameLedger::default();
+        ledger.submit(intent(module, "t", "options", FREE));
+        ledger.submit(intent(scope, "t", "options", FREE));
+        let mut validation = function_validation(scope, &["options"], &["t", "options"], &[]);
+        validation.occupancy.insert(
+            module,
+            ScopeOccupancy::Body {
+                label: "spec_x".to_string(),
+                root: BTreeSet::new(),
+                nested: BTreeSet::new(),
+                captured: BTreeSet::new(),
+            },
+        );
+        let sealed = ledger.seal(&validation).unwrap();
+        // The Module-scope intent survives (merged-map bridge); the
+        // Function-scope application copy is suppressed.
+        assert_eq!(
+            sealed.module_renames_by_name(ModuleId::logical(0)),
+            BTreeMap::from([("t".to_string(), "options".to_string())]),
+        );
+        assert!(sealed.scope_renames_by_name(&scope).is_empty());
+    }
+
+    #[test]
+    fn free_alias_copy_survives_when_target_only_mentioned() {
+        let module = RenameScope::Module(ModuleId::logical(0));
+        let scope = RenameScope::Function(FunctionScopeId { lo: 1, hi: 9 });
+        let mut ledger = RenameLedger::default();
+        ledger.submit(intent(module, "t", "options", FREE));
+        ledger.submit(intent(scope, "t", "options", FREE));
+        let mut validation = function_validation(scope, &[], &["t", "options"], &[]);
+        validation.occupancy.insert(
+            module,
+            ScopeOccupancy::Body {
+                label: "spec_x".to_string(),
+                root: BTreeSet::new(),
+                nested: BTreeSet::new(),
+                captured: BTreeSet::new(),
+            },
+        );
+        let sealed = ledger.seal(&validation).unwrap();
+        assert_eq!(
+            sealed.scope_renames_by_name(&scope),
+            BTreeMap::from([("t".to_string(), "options".to_string())]),
+        );
+    }
+
+    #[test]
+    fn free_alias_copy_dropped_when_module_intent_lost_collision() {
+        // Two deriving functions free-alias different sources onto one
+        // target: both Module-scope intents drop (target collision), so
+        // both Function-scope application copies must drop too.
+        let module = RenameScope::Module(ModuleId::logical(0));
+        let f1 = RenameScope::Function(FunctionScopeId { lo: 1, hi: 9 });
+        let mut ledger = RenameLedger::default();
+        ledger.submit(intent(module, "t", "options", FREE));
+        ledger.submit(intent(module, "u", "options", FREE));
+        ledger.submit(intent(f1, "t", "options", FREE));
+        let mut validation = function_validation(f1, &[], &["t"], &[]);
+        validation.occupancy.insert(
+            module,
+            ScopeOccupancy::Body {
+                label: "spec_x".to_string(),
+                root: BTreeSet::new(),
+                nested: BTreeSet::new(),
+                captured: BTreeSet::new(),
+            },
+        );
+        let sealed = ledger.seal(&validation).unwrap();
+        assert!(
+            sealed
+                .module_renames_by_name(ModuleId::logical(0))
+                .is_empty()
+        );
+        assert!(sealed.scope_renames_by_name(&f1).is_empty());
+    }
+
+    #[test]
+    fn scopes_without_occupancy_skip_target_validation() {
+        // The chunk-level explicit ledger seals before the post-split
+        // bodies exist; its intents are occupancy-validated downstream.
+        let mut ledger = RenameLedger::default();
+        ledger.submit(intent(RenameScope::Chunk, "a", "delta", A));
+        let sealed = ledger.seal(&SealValidation::default()).unwrap();
+        assert_eq!(
+            sealed.chunk_renames_by_name(),
+            HashMap::from([("a".to_string(), "delta".to_string())]),
         );
     }
 }

--- a/devinfra/js/debundle/lowering/rename_ledger_proptest.rs
+++ b/devinfra/js/debundle/lowering/rename_ledger_proptest.rs
@@ -1,19 +1,20 @@
-//! Proptest suite for the public `RenameLedger` seal contract
-//! (rename pipeline PR 2 surface, #2091): seal determinism under
-//! intent permutation and duplication, priority dominance,
-//! same-priority conflicts always erroring naming both origins, and
-//! per-scope validation isolation.
+//! Proptest suite for the public `RenameLedger` seal contract: seal
+//! determinism under intent permutation and duplication, priority
+//! dominance, same-priority conflicts always erroring naming both
+//! origins, per-scope validation isolation, and occupancy-driven
+//! silent drops of colliding heuristic targets.
 //!
 //! Deliberately written against the public `submit`/`seal`/
-//! `SealedRenames` query API only — seal-internal validation is in
-//! flux (PR 3 moves occupancy/capture validation into seal), and these
-//! properties must survive that change unedited or with mechanical
-//! signature updates only. Case counts are bounded for CI (see
+//! `SealedRenames` query API only. The core properties seal with
+//! `SealValidation::default()` — scopes absent from `occupancy` get
+//! conflict/priority validation only — so they hold regardless of
+//! occupancy facts; the drop property supplies `ScopeOccupancy::Body`
+//! facts explicitly. Case counts are bounded for CI (see
 //! [`ci_config`]); override locally via
 //! `bbr test //devinfra/js/debundle:lowering_test
 //! --test_env=PROPTEST_CASES=2000`.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use analysis::ModuleId;
 use proptest::prelude::*;
@@ -24,7 +25,8 @@ use swc_common::SyntaxContext;
 use swc_ecma_ast::Id;
 
 use super::rename_ledger::{
-    FunctionScopeId, RenameIntent, RenameLedger, RenameOrigin, RenameScope, SealedRenames,
+    FunctionScopeId, RenameIntent, RenameLedger, RenameOrigin, RenameScope, ScopeOccupancy,
+    SealValidation, SealedRenames,
 };
 
 /// Source-binding pool, disjoint from [`TARGETS`] so a generated
@@ -91,7 +93,9 @@ fn seal_all(intents: Vec<RenameIntent>) -> Result<SealedRenames, String> {
     for intent in intents {
         ledger.submit(intent);
     }
-    ledger.seal().map_err(|error| error.to_string())
+    ledger
+        .seal(&SealValidation::default())
+        .map_err(|error| error.to_string())
 }
 
 /// Bounded case count for CI; a `PROPTEST_CASES` env override still
@@ -164,10 +168,10 @@ proptest! {
             origin: RenameOrigin::Explicit { contributor: "explicit_winner" },
         });
         let sealed = ledger
-            .seal()
+            .seal(&SealValidation::default())
             .map_err(|error| TestCaseError::fail(error.to_string()))?;
         let expected = BTreeMap::from([(id(from), Atom::from(explicit_to))]);
-        prop_assert_eq!(sealed.scope_renames(&scope), Some(&expected));
+        prop_assert_eq!(sealed.scope_renames(&scope), Some(expected));
     }
 
     /// Two intents at the same priority disagreeing on one
@@ -194,7 +198,7 @@ proptest! {
             to: Atom::from(TARGETS[target_b]),
             origin: origin_at(priority_kind, CONTRIBUTORS[contributor_b]),
         });
-        let message = match ledger.seal() {
+        let message = match ledger.seal(&SealValidation::default()) {
             Ok(_) => return Err(TestCaseError::fail(
                 "same-priority disagreement sealed successfully",
             )),
@@ -249,5 +253,55 @@ proptest! {
                 );
             }
         }
+    }
+
+    /// Occupancy-validated body scopes drop colliding heuristic targets
+    /// silently (PR 3 seal-drop behavior): with `ScopeOccupancy::Body`
+    /// facts supplied, a heuristic rename survives seal iff no other
+    /// heuristic source in the scope claims the same target — and the
+    /// losers never turn the seal into an error.
+    #[test]
+    fn body_occupancy_drops_colliding_heuristic_targets(
+        renames in proptest::collection::btree_map(
+            select(&SOURCES[..]),
+            select(&TARGETS[..]),
+            0..=SOURCES.len(),
+        ),
+    ) {
+        let scope = RenameScope::Module(ModuleId::logical(0));
+        let mut ledger = RenameLedger::default();
+        for (&from, &to) in &renames {
+            ledger.submit(RenameIntent {
+                scope,
+                from: id(from),
+                to: Atom::from(to),
+                origin: RenameOrigin::Heuristic { contributor: "alias" },
+            });
+        }
+        let validation = SealValidation {
+            occupancy: BTreeMap::from([(scope, ScopeOccupancy::Body {
+                label: "m0".to_string(),
+                root: BTreeSet::new(),
+                nested: BTreeSet::new(),
+                captured: BTreeSet::new(),
+            })]),
+            reserved: BTreeSet::new(),
+        };
+        let sealed = ledger
+            .seal(&validation)
+            .map_err(|error| TestCaseError::fail(format!(
+                "heuristic collisions must drop silently, not error: {error}",
+            )))?;
+        let mut target_counts = BTreeMap::<&str, usize>::new();
+        for &to in renames.values() {
+            *target_counts.entry(to).or_default() += 1;
+        }
+        let expected: BTreeMap<Id, Atom> = renames
+            .iter()
+            .filter(|(_, to)| target_counts[**to] == 1)
+            .map(|(&from, &to)| (id(from), Atom::from(to)))
+            .collect();
+        let expected = (!expected.is_empty()).then_some(expected);
+        prop_assert_eq!(sealed.scope_renames(&scope), expected);
     }
 }

--- a/devinfra/js/debundle/lowering/scope_names.rs
+++ b/devinfra/js/debundle/lowering/scope_names.rs
@@ -134,3 +134,97 @@ pub(super) fn collect_local_binding_names(body: &[ModuleItem]) -> BTreeSet<Strin
     }
     collector.names
 }
+
+/// Names bound strictly below `body`'s top level — everything
+/// [`collect_local_binding_names`] sees except the top-level declarations'
+/// own root names (which [`collect_occupied_local_names`] reports). Seal
+/// validation distinguishes the two: a rename target colliding with a
+/// top-level name is a root collision (vacatable by renaming that binding
+/// away); a target bound anywhere below the top level could capture
+/// renamed references and is rejected outright. A name bound at BOTH
+/// levels (`const a = () => { let a; }`) appears in both sets.
+pub(super) fn collect_nested_binding_names(body: &[ModuleItem]) -> BTreeSet<String> {
+    let mut collector = BindingNameCollector {
+        names: BTreeSet::new(),
+    };
+    for item in body {
+        match item {
+            // Import locals are root bindings; imports contain nothing else.
+            ModuleItem::ModuleDecl(ModuleDecl::Import(_)) => {}
+            ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(export_decl)) => {
+                collect_nested_from_decl(&export_decl.decl, &mut collector);
+            }
+            // The declared name is a root binding; only the body is nested.
+            ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultDecl(default_decl)) => {
+                match &default_decl.decl {
+                    DefaultDecl::Fn(function) => function.function.visit_with(&mut collector),
+                    DefaultDecl::Class(class) => class.class.visit_with(&mut collector),
+                    DefaultDecl::TsInterfaceDecl(_) => {}
+                }
+            }
+            ModuleItem::Stmt(Stmt::Decl(decl)) => collect_nested_from_decl(decl, &mut collector),
+            // Non-declaration statements bind nothing at the root level;
+            // anything they bind (for-heads, block-scoped decls, function
+            // expressions) is nested. `var` hoisted out of a top-level
+            // block is recorded as nested too — over-restriction, matching
+            // the rename visitors' block-shadow over-suppression.
+            other => other.visit_with(&mut collector),
+        }
+    }
+    collector.names
+}
+
+fn collect_nested_from_decl(decl: &Decl, collector: &mut BindingNameCollector) {
+    match decl {
+        // The declared name is the root binding; params and body are nested.
+        Decl::Fn(function) => function.function.visit_with(collector),
+        Decl::Class(class) => class.class.visit_with(collector),
+        Decl::Var(var) => {
+            for declarator in &var.decls {
+                collect_nested_from_root_pat(&declarator.name, collector);
+                if let Some(init) = &declarator.init {
+                    init.visit_with(collector);
+                }
+            }
+        }
+        _ => decl.visit_with(collector),
+    }
+}
+
+/// Walk a top-level declarator pattern recording only bindings that are
+/// NOT the pattern's own root binders: pattern defaults and computed keys
+/// can contain function expressions whose params/locals are nested.
+fn collect_nested_from_root_pat(pat: &Pat, collector: &mut BindingNameCollector) {
+    match pat {
+        Pat::Ident(_) => {}
+        Pat::Rest(rest) => collect_nested_from_root_pat(&rest.arg, collector),
+        Pat::Assign(assign) => {
+            collect_nested_from_root_pat(&assign.left, collector);
+            assign.right.visit_with(collector);
+        }
+        Pat::Array(array) => {
+            for elem in array.elems.iter().flatten() {
+                collect_nested_from_root_pat(elem, collector);
+            }
+        }
+        Pat::Object(object) => {
+            for prop in &object.props {
+                match prop {
+                    ObjectPatProp::KeyValue(key_value) => {
+                        if let PropName::Computed(computed) = &key_value.key {
+                            computed.expr.visit_with(collector);
+                        }
+                        collect_nested_from_root_pat(&key_value.value, collector);
+                    }
+                    ObjectPatProp::Assign(assign) => {
+                        if let Some(value) = &assign.value {
+                            value.visit_with(collector);
+                        }
+                    }
+                    ObjectPatProp::Rest(rest) => collect_nested_from_root_pat(&rest.arg, collector),
+                }
+            }
+        }
+        Pat::Invalid(_) | Pat::Expr(_) => {}
+    }
+}

--- a/devinfra/js/debundle/plans/sanitization_program_2026_06.md
+++ b/devinfra/js/debundle/plans/sanitization_program_2026_06.md
@@ -64,11 +64,14 @@ origin, priority }`, scopes Chunk/Module/Function, **keyed by hygiene
    pipeline section for decisions and the remaining ladder.)_
 2. Collect: convert contributors (spec `export_name`s, bound/free
    heuristics, import-local `_N` minting, `chunk_renames`, cross-module,
-   collision resolution) one at a time to emit intents.
+   collision resolution) one at a time to emit intents. _(Landed
+   2026-06: #2091.)_
 3. Seal: explicit > import-induced > heuristic; same-priority conflicts are
    hard errors naming both contributors; target-occupancy validated at seal
    time against scope-accurate occupied sets; `_N` minting becomes a ledger
-   service.
+   service. _(Landed 2026-06; see TODO.md's "PR 3 landed" entry and the
+   "Seal points" section of `lowering/rename_ledger.rs` for what stays at
+   the application sites until PR 4.)_
 4. Execute once: one visitor pass (the post-#2052 rename visitor becomes the
    executor) updating export tables, `runtime_imports`, `binding_comments`,
    and cross-module indexes in lockstep.


### PR DESCRIPTION
Track B PR 3/5 of the sanitization program (`plans/sanitization_program_2026_06.md`): seal becomes the single validation point of the collect → validate → execute-once rename pipeline.

## What moved into seal

- **Priority resolution centralized**: `RenameLedger::seal` resolves cross-priority disagreement silently by priority (Explicit > ImportInduced > Heuristic); same-priority disagreement stays the existing hard error naming both contributors.
- **Target-occupancy + capture validation**: seal takes per-scope occupancy facts (`SealValidation` / `ScopeOccupancy`) — root vs nested binding names (new `scope_names::collect_nested_binding_names` for the split), the rename walk's observed capture pairs for `Chunk`/`Module` body scopes, and deriving-subtree bound/mention sets for `Function` scopes. Explicit failures are hard errors reproducing the pre-ledger messages verbatim (`invalid chunk_renames spec`, `collides with an existing top-level local`, `duplicates an earlier rename target`, `captured by a nested binding`, …, including the Chunk-scope vacated-slot/chain/duplicate semantics and the Module-scope swap allowance). Heuristic failures are dropped silently (over-suppression OK, capture never). Import-induced failures are internal invariant violations — mints come from the ledger's own taken sets.
- **`$N` minting is a ledger service**: `mint` / `seed_taken` / `claim` own the per-scope taken-name sets (the `$N` scheme stays); `import_emit.rs`'s two disambiguation passes and `exports.rs::auto_grown_residual_exports` request mints; `mint_unique_name` is deleted.
- **Per-module seal-point collapse**: the per-module naturalize ledger absorbed the plan-driven explicit `export_name` renames, so one seal per module resolves explicit-vs-heuristic priority, the module-global target-collision rule (`merge_module_renames` — `drop_target_collisions` moved into the ledger), and occupancy. The inline `chunk_renames` validation loop in `lower_chunk` and the pre-mutation root-collision check in `naturalize_module_body` are deleted (subsumed by seal); the post-application capture bails became `debug_assert!`s of seal's guarantee.

## PR-4 remainder

Inventoried in `rename_ledger.rs`'s module-doc "Seal points (PR 3 era)" section:

- Contributor derivation is still interleaved with application, so each phase keeps its own ledger instance (chunk explicit, entry, per-module naturalize, per-plan import, export-growth). The per-plan import and export-growth ledgers need post-naturalize body facts and cannot merge until PR 4's execute-once pass removes the intermediate application.
- The pre-seal rename walks (entry body, module body) still run before seal to report reference-precise capture facts — a flat occupied-name set cannot express "target bound nested is harmless when the source is shadowed there", and the e2e suite pins valid specs of exactly that shape. Seal turns the walk's facts into the hard error; PR 4's executor folds the walk into the execute pass.
- The naturalizer's derive-phase preview (scratch clone + `validated_bound` / `drop_subtree_captured_targets` / `merge_module_renames` pre-computation) — the per-scope derive cascade needs each scope's fired map before enclosing scopes derive; seal re-derives the same decisions from the submitted facts.
- `lower_single_plan`'s `cross_module_chunk_renames` pass keeps its reachable capture bail: the entry-side seal validates against entry's body only, and a target can still collide inside a moved module body.

## Behavior

Zero observable behavior change: the full `//devinfra/js/debundle/...` suite (100 targets, including the rename-pinning e2e tests) passes unchanged; no irreducible diffs found. New ledger unit tests pin drop-vs-error policy per origin, mint collision/reserved-word/per-scope semantics, vacated-slot/chain/swap rules, capture-fact rejection, and reference-precision acceptance.

Docs: module doc rewritten for the PR-3-era contract; TODO.md ladder advanced (PR 3 landed entry, remaining PRs 4–5); plan file Track B items 2–3 marked landed.

`BAZEL_TEST_INVOCATIONS=buildbuddy:4bffe76e-f307-4107-a242-3668ee3ecd70`

https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk)_