### PR TITLE
debundle: author-asserted pure exports on the defining chunk

### DIFF
--- a/devinfra/js/debundle/cross_module_purity.rs
+++ b/devinfra/js/debundle/cross_module_purity.rs
@@ -103,8 +103,17 @@ impl ModulePurityFacts<'_> {
 
 /// Compute, per module, the imported-binding purity map to feed that module's
 /// `ChunkCodeGraph::build_full`. See the module docs for the fixpoint.
+///
+/// `asserted_pure` carries author-asserted pure exports keyed by defining
+/// module (`TransformSpec::chunk_export_purity`). Assertions are trusted
+/// axioms: they enter the verdict map as `Pure` even when the export's
+/// binding is not a classifiable chunk-top function (interop wrappers,
+/// re-exported callables), and the fixpoint never demotes them. An assertion
+/// naming a module or export the program doesn't have is reported to stderr
+/// as a dangling assertion (likely a typo or a stale entry) and ignored.
 pub fn resolve_imported_purities(
     modules: &BTreeMap<ModuleKey, ModulePurityFacts<'_>>,
+    asserted_pure: &BTreeMap<ModuleKey, BTreeSet<String>>,
 ) -> BTreeMap<ModuleKey, BTreeMap<String, Purity>> {
     // The fixpoint state: the verdict for each *function* export. A
     // `(module, export)` pair is in this map iff `export`'s local binding is a
@@ -120,6 +129,25 @@ pub fn resolve_imported_purities(
             if graph.function_purity(local).is_some() {
                 export_purity.insert((key.clone(), export_name.clone()), Purity::Pure);
             }
+        }
+    }
+
+    // Author-asserted axioms: pinned Pure, exempt from demotion below.
+    let mut pinned: BTreeSet<(ModuleKey, String)> = BTreeSet::new();
+    for (module, export_names) in asserted_pure {
+        for export_name in export_names {
+            let known_export = modules
+                .get(module)
+                .is_some_and(|facts| facts.exports.contains_key(export_name));
+            if !known_export {
+                eprintln!(
+                    "cross_module_purity: dangling pure_exports assertion \
+                     {module}:{export_name} — no such analyzed module export; ignoring"
+                );
+                continue;
+            }
+            export_purity.insert((module.clone(), export_name.clone()), Purity::Pure);
+            pinned.insert((module.clone(), export_name.clone()));
         }
     }
 
@@ -142,7 +170,7 @@ pub fn resolve_imported_purities(
             last_inputs.insert(key, imported);
             for (export_name, local) in &facts.exports {
                 let slot_key = (key.clone(), export_name.clone());
-                if !export_purity.contains_key(&slot_key) {
+                if !export_purity.contains_key(&slot_key) || pinned.contains(&slot_key) {
                     continue;
                 }
                 let Some(purity) = graph.function_purity(local) else {
@@ -221,7 +249,7 @@ mod tests {
             ),
             ("react".to_string(), facts(&react, &[], &[("memo", "memo")])),
         ]);
-        let resolved = resolve_imported_purities(&modules);
+        let resolved = resolve_imported_purities(&modules, &BTreeMap::new());
         assert!(resolved["app"]["memo"].is_pure());
     }
 
@@ -236,7 +264,7 @@ mod tests {
             ),
             ("lib".to_string(), facts(&lib, &[], &[("boot", "boot")])),
         ]);
-        let resolved = resolve_imported_purities(&modules);
+        let resolved = resolve_imported_purities(&modules, &BTreeMap::new());
         assert!(!resolved["app"]["boot"].is_pure());
     }
 
@@ -254,7 +282,7 @@ mod tests {
             ),
             ("c".to_string(), facts(&c, &[], &[("base", "base")])),
         ]);
-        let resolved = resolve_imported_purities(&modules);
+        let resolved = resolve_imported_purities(&modules, &BTreeMap::new());
         assert!(resolved["a"]["wrap"].is_pure());
     }
 
@@ -272,7 +300,7 @@ mod tests {
             ),
             ("c".to_string(), facts(&c, &[], &[("base", "base")])),
         ]);
-        let resolved = resolve_imported_purities(&modules);
+        let resolved = resolve_imported_purities(&modules, &BTreeMap::new());
         assert!(!resolved["a"]["wrap"].is_pure());
     }
 
@@ -284,7 +312,7 @@ mod tests {
             "app".to_string(),
             facts(&app, &[("ext", "vendor", "ext")], &[]),
         )]);
-        let resolved = resolve_imported_purities(&modules);
+        let resolved = resolve_imported_purities(&modules, &BTreeMap::new());
         assert!(!resolved["app"].contains_key("ext"));
     }
 
@@ -300,7 +328,62 @@ mod tests {
             ),
             ("lib".to_string(), facts(&lib, &[], &[("table", "table")])),
         ]);
-        let resolved = resolve_imported_purities(&modules);
+        let resolved = resolve_imported_purities(&modules, &BTreeMap::new());
         assert!(!resolved["app"].contains_key("table"));
+    }
+
+    #[test]
+    fn asserted_pure_export_overrides_inferred_impurity() {
+        // `observer` is genuinely impure to the classifier (writes a global),
+        // so inference demotes it. An author assertion pins it Pure, and the
+        // verdict propagates to the importing chunk.
+        let app = parse("const C = observer(x);");
+        let lib = parse("export function observer(c) { globalThis.__warned = 1; return c; }");
+        let modules = BTreeMap::from([
+            (
+                "app".to_string(),
+                facts(&app, &[("observer", "lib", "observer")], &[]),
+            ),
+            (
+                "lib".to_string(),
+                facts(&lib, &[], &[("observer", "observer")]),
+            ),
+        ]);
+        // Without the assertion: impure.
+        assert!(
+            !resolve_imported_purities(&modules, &BTreeMap::new())["app"]["observer"].is_pure()
+        );
+        // With the assertion on the defining chunk: pure, at every importer.
+        let asserted =
+            BTreeMap::from([("lib".to_string(), BTreeSet::from(["observer".to_string()]))]);
+        assert!(resolve_imported_purities(&modules, &asserted)["app"]["observer"].is_pure());
+    }
+
+    #[test]
+    fn asserted_pure_export_applies_to_a_non_function_callable() {
+        // The export is a re-exported interop value the classifier does not see
+        // as a chunk-top function, so inference yields no verdict. The
+        // assertion still admits it (author trust), reaching the importer.
+        let app = parse("const C = forwardRef(x);");
+        let lib = parse("const inner = makeRef();\nexport { inner as forwardRef };");
+        let modules = BTreeMap::from([
+            (
+                "app".to_string(),
+                facts(&app, &[("forwardRef", "lib", "forwardRef")], &[]),
+            ),
+            (
+                "lib".to_string(),
+                facts(&lib, &[], &[("forwardRef", "inner")]),
+            ),
+        ]);
+        assert!(
+            !resolve_imported_purities(&modules, &BTreeMap::new())["app"]
+                .contains_key("forwardRef")
+        );
+        let asserted = BTreeMap::from([(
+            "lib".to_string(),
+            BTreeSet::from(["forwardRef".to_string()]),
+        )]);
+        assert!(resolve_imported_purities(&modules, &asserted)["app"]["forwardRef"].is_pure());
     }
 }

--- a/devinfra/js/debundle/docs/design.md
+++ b/devinfra/js/debundle/docs/design.md
@@ -1050,6 +1050,17 @@ output, the Vite ecosystem, and most React/Vue/Angular SPAs.
   an incorrect spec selector can — soundness shifts to the spec
   author. See AGENTS.md "Declared purity".
 
+  `chunk_export_purity.<chunk>.pure_exports` is the cross-module form
+  of the same contract, addressed to the **defining** chunk rather than
+  a consumer: it asserts that calls to the named exports of that chunk
+  have no observable side effects. The cross-module purity oracle seeds
+  these as pinned-`Pure` axioms (exempt from fixpoint demotion) and
+  propagates them to every importing chunk, so a vendor factory that the
+  static classifier cannot bless — or cannot even see as a chunk-top
+  function (interop re-export) — is asserted once where the audited code
+  lives instead of at each call site. Same author-trust contract;
+  dangling assertions (no such analyzed export) warn and are ignored.
+
 - **A10. Spec-declared local-effect annotations are
   author-trusted.** The spec format also admits an optional
   per-member `effect:` field for named helper bindings whose

--- a/devinfra/js/debundle/lowering/cross_module.rs
+++ b/devinfra/js/debundle/lowering/cross_module.rs
@@ -4,7 +4,7 @@
 //! `AnalysisHints::imported_purities` so the per-chunk classifier can see
 //! through calls to imported functions instead of bailing `unknown_call`.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use analysis::cross_module_purity::{ModulePurityFacts, ResolvedImport, resolve_imported_purities};
 use analysis::purity::Purity;
@@ -13,6 +13,7 @@ use artifact::{
 };
 use js_ast::ParsedJsModule;
 use program_analysis::analyze_program_shallow;
+use spec::ChunkExportPurity;
 use swc_ecma_ast::{Decl, ModuleDecl, ModuleItem, Pat};
 
 /// Binding names introduced by an exported declaration (`export function`/
@@ -52,6 +53,7 @@ struct ReparsedEntry {
 pub(super) fn collect_cross_module_imported_purities(
     artifact: &ChunkBundle,
     indexes: &ArtifactIndexes,
+    chunk_export_purity: &BTreeMap<String, ChunkExportPurity>,
 ) -> BTreeMap<String, BTreeMap<String, Purity>> {
     // Pass 1: re-parse entries stored as raw source so every chunk's body is
     // analyzable. Parse failures only warn — the pass is an analysis
@@ -178,5 +180,10 @@ pub(super) fn collect_cross_module_imported_purities(
             },
         );
     }
-    resolve_imported_purities(&modules)
+    let asserted_pure: BTreeMap<String, BTreeSet<String>> = chunk_export_purity
+        .iter()
+        .filter(|(_, assertion)| !assertion.pure_exports.is_empty())
+        .map(|(chunk, assertion)| (chunk.clone(), assertion.pure_exports.clone()))
+        .collect();
+    resolve_imported_purities(&modules, &asserted_pure)
 }

--- a/devinfra/js/debundle/lowering/mod.rs
+++ b/devinfra/js/debundle/lowering/mod.rs
@@ -31,7 +31,8 @@ use artifact::{
 use js_ast::{ParsedJsModule, format_comment_block_lines, set_str_value, str_value};
 use output_layout::MODULES_REPORT;
 use spec::{
-    BindingSourceKind, ChunkRenames, LogicalModule, MemberEffect, MemberPurity, UnassignedMode,
+    BindingSourceKind, ChunkExportPurity, ChunkRenames, LogicalModule, MemberEffect, MemberPurity,
+    UnassignedMode,
 };
 
 mod anonymous;
@@ -218,6 +219,7 @@ pub fn materialize_logical_modules(
     chunk_renames: &BTreeMap<String, ChunkRenames>,
     unassigned_mode: &BTreeMap<String, UnassignedMode>,
     chunk_analysis_options: &BTreeMap<String, OwnerGraphOptions>,
+    chunk_export_purity: &BTreeMap<String, ChunkExportPurity>,
     options: MaterializeLogicalModulesOptions,
 ) -> Result<MaterializeLogicalModulesResult> {
     if options.chunk_ids.is_empty() {
@@ -246,8 +248,11 @@ pub fn materialize_logical_modules(
     // Program-level pass over ALL retained chunks (not just selected):
     // cross-module purity verdicts for each chunk's imported function
     // bindings, consumed per chunk via `AnalysisHints::imported_purities`.
-    let cross_module_purities =
-        cross_module::collect_cross_module_imported_purities(&artifact, &artifact_indexes);
+    let cross_module_purities = cross_module::collect_cross_module_imported_purities(
+        &artifact,
+        &artifact_indexes,
+        chunk_export_purity,
+    );
 
     let artifact_ref: &ChunkBundle = &artifact;
     // SWC's `swc_common::GLOBALS` is a `scoped_tls` thread-local, so the

--- a/devinfra/js/debundle/pipeline.rs
+++ b/devinfra/js/debundle/pipeline.rs
@@ -209,6 +209,7 @@ pub fn run_transform_cli_with_options(
                 &spec.chunk_renames,
                 &spec.unassigned_mode,
                 &spec.chunk_analysis_options,
+                &spec.chunk_export_purity,
                 MaterializeLogicalModulesOptions {
                     chunk_ids: materialise_chunk_ids,
                     file,

--- a/devinfra/js/debundle/pipeline.rs
+++ b/devinfra/js/debundle/pipeline.rs
@@ -967,6 +967,7 @@ mod tests {
             chunk_renames: BTreeMap::new(),
             unassigned_mode: BTreeMap::new(),
             chunk_analysis_options: BTreeMap::new(),
+            chunk_export_purity: BTreeMap::new(),
             swap_vendor_chunks: SwapVendorChunksConfig::default(),
             materialize_logical_modules: MaterializeLogicalModulesConfig::default(),
             write_js_tree: None,

--- a/devinfra/js/debundle/spec.rs
+++ b/devinfra/js/debundle/spec.rs
@@ -72,6 +72,16 @@ pub struct TransformSpec {
     /// spec explicitly opts in.
     #[serde(default)]
     pub chunk_analysis_options: BTreeMap<String, OwnerGraphOptions>,
+    /// Author-asserted purity of a chunk's exports, keyed by the
+    /// *defining* chunk. The cross-module purity oracle seeds these as
+    /// trusted axioms (pinned `Pure`, exempt from fixpoint demotion) and
+    /// propagates them to every importing chunk — the assertion is made
+    /// once, where the audited code lives, not per consumer. Same trust
+    /// contract as member-level `purity: pure` (docs/design.md A9):
+    /// an incorrect assertion can produce a buggy debundle; soundness
+    /// shifts to the spec author.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub chunk_export_purity: BTreeMap<String, ChunkExportPurity>,
 
     // --- per-stage configuration ---
     /// Output configuration for `swap_vendor_chunks`. The stage runs
@@ -95,6 +105,20 @@ pub struct TransformSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub emit_browser_harness: Option<EmitBrowserHarnessConfig>,
+}
+
+/// Author-asserted purity for one defining chunk's exports. See
+/// [`TransformSpec::chunk_export_purity`].
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ChunkExportPurity {
+    /// Export names whose *calls* the author asserts have no observable
+    /// side effects. Applies to the export regardless of how the binding
+    /// is produced (function declaration, function-valued const, interop
+    /// wrapper), so it also covers callables the static classifier cannot
+    /// see into.
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub pure_exports: BTreeSet<String>,
 }
 
 /// Per-chunk owner-graph build options. Each field defaults to the

--- a/devinfra/js/debundle/spec_tree.rs
+++ b/devinfra/js/debundle/spec_tree.rs
@@ -8,11 +8,11 @@ use serde::Deserialize;
 use output_layout::DebundleOutputLayout;
 use spec::{
     AnonymousStatement, BindingGroup, BundledPartialSwapBundle, BundledPartialSwapMark,
-    BundledPartialSwapPackage, ChunkRenames, EmitBrowserHarnessConfig, LoadJsChunksArgs,
-    LogicalModule, MaterializeLogicalModulesConfig, Member, MemberEffect, MemberPurity,
-    OwnerGraphOptions, PartialSwapMark, PartialSwapPackage, PartialSwapSymbol, SwapMark,
-    SwapVendorChunksConfig, TransformSpec, UnassignedMode, VendorLevel, VendorMark, VendorRole,
-    WrapperShape,
+    BundledPartialSwapPackage, ChunkExportPurity, ChunkRenames, EmitBrowserHarnessConfig,
+    LoadJsChunksArgs, LogicalModule, MaterializeLogicalModulesConfig, Member, MemberEffect,
+    MemberPurity, OwnerGraphOptions, PartialSwapMark, PartialSwapPackage, PartialSwapSymbol,
+    SwapMark, SwapVendorChunksConfig, TransformSpec, UnassignedMode, VendorLevel, VendorMark,
+    VendorRole, WrapperShape,
 };
 use spec_modules::{
     collect_module_files, load_binding_patch_members, module_path_from_file, read_module_file,
@@ -45,6 +45,10 @@ struct AuthoringConfig {
     /// strictly-conservative analysis path unless it opts in here.
     #[serde(default)]
     chunk_analysis_options: BTreeMap<String, OwnerGraphOptions>,
+    /// Author-asserted pure exports, keyed by defining chunk. See
+    /// `TransformSpec::chunk_export_purity`.
+    #[serde(default)]
+    chunk_export_purity: BTreeMap<String, ChunkExportPurity>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -162,6 +166,7 @@ pub fn compile_spec_tree(options: &CompileSpecTreeOptions) -> Result<TransformSp
         chunk_renames: chunk_renames_map(&config.main_chunk_id, binding_patch_members),
         unassigned_mode: config.unassigned_mode,
         chunk_analysis_options: config.chunk_analysis_options,
+        chunk_export_purity: config.chunk_export_purity,
         swap_vendor_chunks: SwapVendorChunksConfig {
             output_manifest_path: Some(layout.vendor_manifest_path.clone()),
             output_wrapper_dir: Some(layout.vendor_wrapper_root.clone()),


### PR DESCRIPTION
Builds directly on the merged cross-module purity trio (#2088/#2094/#2098). The oracle resolves and propagates *inferred* purity, but real vendor factories are genuinely effectful to the conservative classifier — mobx-react `observer` writes a global; React's static-copy helpers use `defineProperty`/`console.warn` — or aren't visible as chunk-top functions at all (CJS interop re-exports). Inference will (correctly) never bless those.

## What

A **definition-side** author-trust surface, keyed by the defining chunk:

```yaml
chunk_export_purity:
  static/vendor-BPNhzNbc:
    pure_exports: [o]        # mobx observer, author-audited
```

The oracle seeds each asserted export as a **pinned `Pure` axiom** (exempt from fixpoint demotion), and its existing fixpoint propagates it to **every importing chunk** — one assertion, all consumers, made where the audited code lives rather than repeated per call site. Assertions also admit exports whose binding isn't a classifiable chunk-top function (interop wrappers), which inference can't reach. A dangling assertion (no such analyzed export) warns to stderr and is ignored.

Same author-trust contract as member-level `purity: pure` (design.md A9) — soundness shifts to the author — now extended to imported callees, which previously had no spec surface.

Threaded `TransformSpec.chunk_export_purity` (+ the tree-config `chunk_export_purity:` block) → `materialize` → the cross-module pass → `resolve_imported_purities`.

## Validation (Tana web)

Asserting the vendor megachunk's exports pure shrinks the main chunk's atomic-factor-unit conflict from **1868 → 1253 owners**. The residue is member-call factories reached through namespace imports (`ns.forwardRef(...)`), which the bare-`Ident` verdict arm doesn't cover — a separate follow-up.

## Tests

Oracle-level: an assertion pins an inferred-impure export `Pure` and propagates it to the importer; an assertion admits a non-function callable export that inference yields no verdict for. `analysis_test` + `spec_test` pass; changed crates are rustfmt/clippy-clean.

https://claude.ai/code/session_01Bp8cANKC1Ktc92T7SM1kcx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bp8cANKC1Ktc92T7SM1kcx)_