### PR TITLE
loom/gym: add --max-samples to cap eval concurrency

### DIFF
--- a/loom/gym/agent_eval.py
+++ b/loom/gym/agent_eval.py
@@ -64,6 +64,13 @@ def main() -> None:
     )
     parser.add_argument("--log-dir", type=Path, required=True, help="Inspect eval log directory.")
     parser.add_argument("--message-limit", type=int, default=80, help="Max conversation turns per sample.")
+    parser.add_argument(
+        "--max-samples",
+        type=int,
+        default=None,
+        help="Max samples to run concurrently (one docker sandbox each). Bounds docker-ci "
+        "network-pool usage; unset uses the Inspect default.",
+    )
     args = parser.parse_args()
     api_key = os.environ.get(args.api_key_env) or Path("/tmp/litellm_key").read_text().strip()
 
@@ -93,6 +100,7 @@ def main() -> None:
         log_dir=str(args.log_dir),
         display="plain",
         message_limit=args.message_limit,
+        max_samples=args.max_samples,
         # A transient per-sample failure (e.g. a flaky DNS/connection to the model
         # endpoint) should drop that sample, not abort the whole run.
         fail_on_error=False,

--- a/loom/gym/k8s/eval-job.yaml
+++ b/loom/gym/k8s/eval-job.yaml
@@ -59,6 +59,11 @@ spec:
             - http://litellm.litellm.svc.cluster.local:4000
             - --task-filter
             - manifold-
+            # Cap concurrent samples (one docker sandbox each) well under docker-ci's
+            # ~31-network address pool, leaving margin against orphaned networks from
+            # any interrupted run.
+            - --max-samples
+            - "8"
             - --wayback-upstream
             - http://wayback-cache.wayback-cache.svc.cluster.local:8080
             - --log-dir


### PR DESCRIPTION
Adds a `--max-samples` flag to cap eval concurrency, requested to bound docker-ci network-pool usage.

## Why

Inspect runs samples up to its default concurrency (~15-20 sandboxes observed in practice), and each sample creates a docker compose network on the shared docker-ci dind. Docker's default address pool caps at ~31 networks, so while a single clean run fits, **orphaned networks from an interrupted run can stack to exhaustion** — `Error response from daemon: all predefined address pools have been fully subnetted`, which blocks new sample sandboxes.

## Change

- `agent_eval.py`: new `--max-samples` arg, passed to `inspect_eval(max_samples=...)`. One sandbox per sample, so this directly bounds concurrent sandboxes/networks. Unset → Inspect default (unchanged behavior for other callers).
- `eval-job.yaml`: set `--max-samples 8` for the in-cluster Job — comfortable margin under the ~31 pool, survives leftover orphans.

## Validation

- `//loom/gym:agent_eval` builds + mypy-lints clean on RBE.
- pre-commit clean.

https://claude.ai/code/session_01AXSFxfCXddADoSKTjgF5Nz

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXSFxfCXddADoSKTjgF5Nz)_