### PR TITLE
debundle: author-asserted pure members for namespace-imported callees

### DIFF
--- a/devinfra/js/debundle/cross_module_purity.rs
+++ b/devinfra/js/debundle/cross_module_purity.rs
@@ -193,6 +193,55 @@ pub fn resolve_imported_purities(
         .collect()
 }
 
+/// Project author-asserted pure members of exported namespace-like objects
+/// (`chunk_export_purity.<chunk>.pure_members`) onto each importing module's
+/// local binding names. Pure axiom projection — no fixpoint: for every import
+/// `local → (module, export)` with an assertion on `(module, export)`, the
+/// importing module receives `local → member set`, which feeds the classifier's
+/// member-call trust arm (`declared_pure_members`). Assertions naming a module
+/// or export the program doesn't have warn to stderr and are ignored.
+pub fn resolve_asserted_member_purities(
+    modules: &BTreeMap<ModuleKey, ModulePurityFacts<'_>>,
+    asserted_members: &BTreeMap<ModuleKey, BTreeMap<String, BTreeSet<String>>>,
+) -> BTreeMap<ModuleKey, BTreeMap<String, BTreeSet<String>>> {
+    for (module, by_export) in asserted_members {
+        for export_name in by_export.keys() {
+            let known_export = modules
+                .get(module)
+                .is_some_and(|facts| facts.exports.contains_key(export_name));
+            if !known_export {
+                eprintln!(
+                    "cross_module_purity: dangling pure_members assertion \
+                     {module}:{export_name} — no such analyzed module export; ignoring"
+                );
+            }
+        }
+    }
+    modules
+        .iter()
+        .map(|(key, facts)| {
+            let members: BTreeMap<String, BTreeSet<String>> = facts
+                .imports
+                .iter()
+                .filter_map(|(local, target)| {
+                    let asserted = asserted_members
+                        .get(&target.module)?
+                        .get(&target.export)?
+                        .clone();
+                    // Only project assertions whose export actually exists in
+                    // the defining module (dangling ones warned above).
+                    modules
+                        .get(&target.module)?
+                        .exports
+                        .contains_key(&target.export)
+                        .then(|| (local.clone(), asserted))
+                })
+                .collect();
+            (key.clone(), members)
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -385,5 +434,56 @@ mod tests {
             BTreeSet::from(["forwardRef".to_string()]),
         )]);
         assert!(resolve_imported_purities(&modules, &asserted)["app"]["forwardRef"].is_pure());
+    }
+
+    #[test]
+    fn asserted_pure_members_project_onto_importer_locals() {
+        // The defining chunk exports an interop namespace object; the
+        // importer binds it locally as `b`. A definition-side member
+        // assertion lands on the importer under ITS local name.
+        let app = parse("import { reactns as b } from \"vendor\";\nconst C = b.forwardRef(x);");
+        let vendor = parse("const ns = makeInterop();\nexport { ns as reactns };");
+        let modules = BTreeMap::from([
+            (
+                "app".to_string(),
+                facts(&app, &[("b", "vendor", "reactns")], &[]),
+            ),
+            (
+                "vendor".to_string(),
+                facts(&vendor, &[], &[("reactns", "ns")]),
+            ),
+        ]);
+        let asserted = BTreeMap::from([(
+            "vendor".to_string(),
+            BTreeMap::from([(
+                "reactns".to_string(),
+                BTreeSet::from(["forwardRef".to_string(), "memo".to_string()]),
+            )]),
+        )]);
+        let resolved = resolve_asserted_member_purities(&modules, &asserted);
+        assert_eq!(
+            resolved["app"]["b"],
+            BTreeSet::from(["forwardRef".to_string(), "memo".to_string()])
+        );
+        assert!(resolved["vendor"].is_empty());
+    }
+
+    #[test]
+    fn dangling_member_assertion_is_ignored() {
+        let app = parse("const C = b.forwardRef(x);");
+        let modules = BTreeMap::from([(
+            "app".to_string(),
+            facts(&app, &[("b", "vendor", "reactns")], &[]),
+        )]);
+        // `vendor` is not analyzed at all — the assertion must not project.
+        let asserted = BTreeMap::from([(
+            "vendor".to_string(),
+            BTreeMap::from([(
+                "reactns".to_string(),
+                BTreeSet::from(["forwardRef".to_string()]),
+            )]),
+        )]);
+        let resolved = resolve_asserted_member_purities(&modules, &asserted);
+        assert!(resolved["app"].is_empty());
     }
 }

--- a/devinfra/js/debundle/docs/design.md
+++ b/devinfra/js/debundle/docs/design.md
@@ -1061,6 +1061,15 @@ output, the Vite ecosystem, and most React/Vue/Angular SPAs.
   lives instead of at each call site. Same author-trust contract;
   dangling assertions (no such analyzed export) warn and are ignored.
 
+  `chunk_export_purity.<chunk>.pure_members` is the member-call form, for
+  CJS-interop namespace exports whose factories are reached as member
+  calls at the importer (`ns.forwardRef(...)`). Keyed `export name →
+member names`, it projects onto each importing chunk's local binding
+  for that export and feeds the same member-call trust arm as a spec
+  member's `declared_pure_members` — so React's `forwardRef`/`memo`
+  reached through a default/namespace import are blessed once on the
+  defining vendor chunk.
+
 - **A10. Spec-declared local-effect annotations are
   author-trusted.** The spec format also admits an optional
   per-member `effect:` field for named helper bindings whose

--- a/devinfra/js/debundle/e2e/chunk_rename_cross_module_test.rs
+++ b/devinfra/js/debundle/e2e/chunk_rename_cross_module_test.rs
@@ -29,6 +29,7 @@ fn chunk_rename_propagates_into_peeled_module_body() {
     // The renaming MUST propagate to b_module.js: its import line
     // and its `const b = cx();` callsite both need the new alias.
     let opts = FixtureOpts {
+        chunk_export_purity: &[],
         extra_chunks: &[],
         source: r#"import { f as cx } from "./vendor.js";
 const a = (() => 1)();

--- a/devinfra/js/debundle/e2e/cross_module_emission_test.rs
+++ b/devinfra/js/debundle/e2e/cross_module_emission_test.rs
@@ -619,6 +619,7 @@ fn residual_public_export_name_does_not_capture_unrelated_chunk_renamed_import()
     // The entry import must therefore be `B as entryHelper`, not
     // `B as vendorHelper`.
     let opts = FixtureOpts {
+        chunk_export_purity: &[],
         extra_chunks: &[],
         source: r#"import { o as B } from "./vendor.js";
 const St = value => "row:" + value;

--- a/devinfra/js/debundle/e2e/mini_factors_test.rs
+++ b/devinfra/js/debundle/e2e/mini_factors_test.rs
@@ -18,6 +18,7 @@ export const b = 2;
 #[test]
 fn catchall_keeps_unclaimed_bindings_in_residual() {
     let opts = FixtureOpts {
+        chunk_export_purity: &[],
         extra_chunks: &[],
         source: FIXTURE_SOURCE,
         logical_modules: vec![],
@@ -46,6 +47,7 @@ fn catchall_keeps_unclaimed_bindings_in_residual() {
 #[test]
 fn mini_factors_synthesizes_one_module_per_unclaimed_unit() {
     let opts = FixtureOpts {
+        chunk_export_purity: &[],
         extra_chunks: &[],
         source: FIXTURE_SOURCE,
         logical_modules: vec![],

--- a/devinfra/js/debundle/e2e/purity_test.rs
+++ b/devinfra/js/debundle/e2e/purity_test.rs
@@ -949,6 +949,7 @@ fn chunk_rename_with_purity_pure_propagates_to_call_classifier() {
     //   declared_pure → cx() is Pure → b is Pure → no S-chain
     //   participation. Only edge: residual → b_module. DAG.
     let opts = FixtureOpts {
+        chunk_export_purity: &[],
         extra_chunks: &[],
         source: r#"import { f as cx } from "./vendor.js";
 const a = (() => 1)();
@@ -1230,4 +1231,38 @@ export { A, B, C };
         )]),
         &["cycle", "mod_a", "mod_b", "side-effect"],
     );
+}
+
+#[test]
+fn asserted_pure_namespace_member_calls_emit_no_s_cycle() {
+    // CJS-interop shape: the importer binds a namespace-like export of another
+    // chunk as `ns` and reaches the factory as a MEMBER call, `ns.make(...)`.
+    // Inference can't see `make` is pure (the namespace object is opaque), so
+    // the three calls split across modules would S-cycle. A definition-side
+    // `chunk_export_purity.pure_members` assertion on the defining chunk's
+    // export projects onto the importer's `ns` local and admits the calls.
+    let fixture = run_fixture(
+        FixtureOpts::new(
+            r#"import { reactish as ns } from "./vendorlib.js";
+const A = ns.make(function () { return "a"; });
+const B = ns.make(function () { return "b"; });
+const C = ns.make(function () { return "c"; });
+console.log(A, B, C);
+export { A, B, C };
+"#,
+            vec![
+                logical_module("mod_a", &[Member::new("A"), Member::new("C")]),
+                logical_module("mod_b", &[Member::new("B")]),
+            ],
+        )
+        .with_extra_chunks(&[(
+            "static/vendorlib",
+            "const reactish = { make(f) { return { impl: f }; } };\nexport { reactish };\n",
+        )])
+        .with_chunk_export_purity(&[(
+            "static/vendorlib",
+            json!({ "pure_members": { "reactish": ["make"] } }),
+        )]),
+    );
+    assert!(fixture.entry_path.exists());
 }

--- a/devinfra/js/debundle/e2e/residual_member_rename_test.rs
+++ b/devinfra/js/debundle/e2e/residual_member_rename_test.rs
@@ -16,6 +16,7 @@ use debundle_e2e_support::*;
 #[test]
 fn logical_module_at_catchall_target_renames_and_absorbs_overflow() {
     let opts = FixtureOpts {
+        chunk_export_purity: &[],
         extra_chunks: &[],
         source: r#"function a() { return 1; }
 function b() { return 2; }

--- a/devinfra/js/debundle/e2e/support.rs
+++ b/devinfra/js/debundle/e2e/support.rs
@@ -309,6 +309,8 @@ struct TransformSpecFixture<'a> {
     unassigned_mode: BTreeMap<String, Value>,
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     chunk_analysis_options: BTreeMap<String, Value>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    chunk_export_purity: BTreeMap<String, Value>,
     materialize_logical_modules: MaterializeLogicalModulesFixture<'a>,
     write_js_tree: WriteJsTreeFixture<'a>,
 }
@@ -531,6 +533,10 @@ pub struct FixtureOpts<'a> {
     /// (post-run runtime siblings), these are debundled artifact chunks the
     /// transform analyzes — e.g. an import target for cross-chunk tests.
     pub extra_chunks: &'a [(&'a str, &'a str)],
+    /// `chunk_export_purity` entries as `(defining chunk_id, JSON assertion)`,
+    /// where the JSON is a `{ "pure_exports": [...], "pure_members": {...} }`
+    /// object. Default empty.
+    pub chunk_export_purity: &'a [(&'a str, Value)],
 }
 
 impl<'a> FixtureOpts<'a> {
@@ -551,6 +557,7 @@ impl<'a> FixtureOpts<'a> {
             admission_overrides: &[],
             extra_files: &[],
             extra_chunks: &[],
+            chunk_export_purity: &[],
         }
     }
 
@@ -558,6 +565,12 @@ impl<'a> FixtureOpts<'a> {
     /// e.g. an import target whose exports feed the cross-module purity oracle.
     pub fn with_extra_chunks(mut self, extra_chunks: &'a [(&'a str, &'a str)]) -> Self {
         self.extra_chunks = extra_chunks;
+        self
+    }
+
+    /// Attach `chunk_export_purity` author assertions (see the field).
+    pub fn with_chunk_export_purity(mut self, entries: &'a [(&'a str, Value)]) -> Self {
+        self.chunk_export_purity = entries;
         self
     }
 
@@ -963,6 +976,12 @@ fn build_spec<'a>(opts: &FixtureOpts<'_>, setup: &'a FixtureSetup) -> TransformS
         chunk_analysis_options.insert(chunk_id.to_string(), Value::Object(analysis_options));
     }
 
+    let chunk_export_purity: BTreeMap<String, Value> = opts
+        .chunk_export_purity
+        .iter()
+        .map(|(chunk, assertion)| ((*chunk).to_string(), assertion.clone()))
+        .collect();
+
     TransformSpecFixture {
         inputs: TransformInputsFixture {
             input_root: &setup.snapshot_root,
@@ -972,6 +991,7 @@ fn build_spec<'a>(opts: &FixtureOpts<'_>, setup: &'a FixtureSetup) -> TransformS
         chunk_renames,
         unassigned_mode,
         chunk_analysis_options,
+        chunk_export_purity,
         materialize_logical_modules: MaterializeLogicalModulesFixture {
             prune_other_chunks: false,
             report_out_dir: &setup.report_root,

--- a/devinfra/js/debundle/lowering/cross_module.rs
+++ b/devinfra/js/debundle/lowering/cross_module.rs
@@ -6,7 +6,9 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use analysis::cross_module_purity::{ModulePurityFacts, ResolvedImport, resolve_imported_purities};
+use analysis::cross_module_purity::{
+    ModulePurityFacts, ResolvedImport, resolve_asserted_member_purities, resolve_imported_purities,
+};
 use analysis::purity::Purity;
 use artifact::{
     ArtifactIndexes, ChunkBundle, ChunkId, ExportAliasRecord, ImportRecord, ImportSpecifierKind,
@@ -46,6 +48,15 @@ struct ReparsedEntry {
     export_aliases: Vec<ExportAliasRecord>,
 }
 
+/// Output of the program-level purity pass, keyed by chunk name.
+pub(super) struct CrossModulePurities {
+    /// Per-chunk imported-binding verdicts (`AnalysisHints::imported_purities`).
+    pub(super) bindings: BTreeMap<String, BTreeMap<String, Purity>>,
+    /// Per-chunk pure-member sets for imported namespace-like bindings,
+    /// merged into `AnalysisHints::declared_pure_members`.
+    pub(super) members: BTreeMap<String, BTreeMap<String, BTreeSet<String>>>,
+}
+
 /// Per-chunk-name imported-binding purity maps for the whole artifact.
 /// A chunk whose entry can neither be reused (retained AST) nor re-parsed
 /// stays opaque: its exports get no verdicts and imports of it stay
@@ -54,7 +65,7 @@ pub(super) fn collect_cross_module_imported_purities(
     artifact: &ChunkBundle,
     indexes: &ArtifactIndexes,
     chunk_export_purity: &BTreeMap<String, ChunkExportPurity>,
-) -> BTreeMap<String, BTreeMap<String, Purity>> {
+) -> CrossModulePurities {
     // Pass 1: re-parse entries stored as raw source so every chunk's body is
     // analyzable. Parse failures only warn — the pass is an analysis
     // refinement, and an unparseable chunk degrades to today's conservative
@@ -185,5 +196,14 @@ pub(super) fn collect_cross_module_imported_purities(
         .filter(|(_, assertion)| !assertion.pure_exports.is_empty())
         .map(|(chunk, assertion)| (chunk.clone(), assertion.pure_exports.clone()))
         .collect();
-    resolve_imported_purities(&modules, &asserted_pure)
+    let asserted_members: BTreeMap<String, BTreeMap<String, BTreeSet<String>>> =
+        chunk_export_purity
+            .iter()
+            .filter(|(_, assertion)| !assertion.pure_members.is_empty())
+            .map(|(chunk, assertion)| (chunk.clone(), assertion.pure_members.clone()))
+            .collect();
+    CrossModulePurities {
+        bindings: resolve_imported_purities(&modules, &asserted_pure),
+        members: resolve_asserted_member_purities(&modules, &asserted_members),
+    }
 }

--- a/devinfra/js/debundle/lowering/materialize/mod.rs
+++ b/devinfra/js/debundle/lowering/materialize/mod.rs
@@ -25,10 +25,9 @@ pub(super) struct ChunkContext<'a> {
     pub(super) file: Option<&'a str>,
     pub(super) target_dir: &'a str,
     pub(super) report_out_dir: Option<&'a Path>,
-    /// Program-level cross-module purity verdicts, keyed by chunk name;
-    /// this chunk's entry (if any) lands in `AnalysisHints::imported_purities`.
-    pub(super) cross_module_purities:
-        &'a BTreeMap<String, BTreeMap<String, analysis::purity::Purity>>,
+    /// Program-level cross-module purity output; this chunk's entries land
+    /// in `AnalysisHints::imported_purities` / `declared_pure_members`.
+    pub(super) cross_module_purities: &'a super::cross_module::CrossModulePurities,
 }
 
 /// Spec-derived per-chunk inputs: logical-module layout, chunk
@@ -186,9 +185,22 @@ pub(super) fn materialize_logical_chunk(
     let analysis_hints: AnalysisHints = time_phase!(timings, "collect_analysis_hints", {
         let mut hints = collect_analysis_hints(&explicit_requests, chunk_renames.get(chunk_id));
         hints.imported_purities = cross_module_purities
+            .bindings
             .get(chunk_id)
             .cloned()
             .unwrap_or_default();
+        // Definition-side `pure_members` assertions projected onto this
+        // chunk's local import bindings; merged (not overwritten) so spec
+        // member annotations and cross-module assertions coexist.
+        if let Some(member_sets) = cross_module_purities.members.get(chunk_id) {
+            for (binding, members) in member_sets {
+                hints
+                    .declared_pure_members
+                    .entry(binding.clone())
+                    .or_default()
+                    .extend(members.iter().cloned());
+            }
+        }
         hints
     });
     let line_index = time_phase!(timings, "build_source_line_index", {

--- a/devinfra/js/debundle/spec.rs
+++ b/devinfra/js/debundle/spec.rs
@@ -119,6 +119,15 @@ pub struct ChunkExportPurity {
     /// see into.
     #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
     pub pure_exports: BTreeSet<String>,
+    /// Member names on an exported namespace-like object whose *calls*
+    /// the author asserts have no observable side effects, keyed by the
+    /// export name. Covers CJS-interop namespace exports whose factories
+    /// are reached as member calls at the importer (`ns.forwardRef(...)`):
+    /// each importing chunk's local binding for the export receives the
+    /// member set, feeding the same member-call trust arm as a spec
+    /// member's `purity: pure` companion `declared_pure_members`.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub pure_members: BTreeMap<String, BTreeSet<String>>,
 }
 
 /// Per-chunk owner-graph build options. Each field defaults to the


### PR DESCRIPTION
Closes the residue from #2103. Once the bare `pure_exports` were asserted, Tana's main-chunk atomic unit dropped from 1,868 → 1,253 owners; the remainder is dominated by factories invoked as **member calls** — React's `forwardRef`/`memo` come from a CJS-interop default/namespace import and are called as `ns.forwardRef(...)`, not a bare-`Ident` call. Neither inference nor `pure_exports` reaches those.

## What

Adds `pure_members` to `chunk_export_purity`, keyed by export name:

```yaml
chunk_export_purity:
  static/vendor-BPNhzNbc:
    pure_members:
      o: [forwardRef, memo, createElement]   # the React interop namespace
```

A program-level projection (`resolve_asserted_member_purities`) maps each assertion onto **every importing chunk's local binding** for that export — pure axiom projection, no fixpoint — and the result is merged into that chunk's `AnalysisHints::declared_pure_members`. That feeds the classifier's existing member-call trust arm — the same one a spec member's `purity: pure` companion `declared_pure_members` already drives — so `ns.forwardRef(x)` is admitted. The assertion is still made once, on the defining vendor chunk. Dangling assertions warn and are ignored.

## Tests

Oracle-level: a member assertion projects onto importer locals under their local binding name; a dangling assertion does not project. e2e: three `ns.make(...)` calls split across two logical modules build cleanly only with the member assertion (without it they S-cycle). The e2e harness gains `with_chunk_export_purity`. All affected suites + `analysis_test`/`spec_test`/`pipeline_test` pass; changed crates rustfmt/clippy-clean.

https://claude.ai/code/session_01Bp8cANKC1Ktc92T7SM1kcx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bp8cANKC1Ktc92T7SM1kcx)_