### PR TITLE
debundle: execute renames once from sealed ledger; update fact tables in lockstep (PR 4/5)

### DIFF
--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -300,6 +300,28 @@ guarantee; what still validates at application (and the remaining seal
 points PR 4 collapses) is inventoried in `rename_ledger.rs`'s module-doc
 "Seal points" section.
 
+**PR 4 landed (2026-06):** collect → seal → execute-once per ledger.
+No pre-seal trial application remains: capture facts reach seal from
+the **un-renamed** tree (the read-only `RenameCaptureProbe` over
+`RenameLedger::pending_renames_by_name` for the entry body; the derive
+clone's candidate walk for module bodies), the post-seal rename pass is
+the only mutation of each scope unit's AST, and the hand-maintained
+candidate-map mirrors are gone. The export-growth ledger merged into
+`lower_chunk`'s chunk ledger (one seal validates `Chunk` +
+`EntryPublicExports` together), collapsing five ledger instances to
+four. `plan_module_reference_needs`' linear reverse `.find` over the
+heuristic rename map is replaced by the sealed map's inverse projection
+(`RuntimeImportLookup::original_by_renamed`; injective by seal's
+target-collision rules). Documented blockers that stay (see
+`rename_ledger.rs` "Seal points"): the naturalizer's derive clone
+(enclosing scopes' subtree facts must reflect nested fired renames —
+scope-sensitive, not expressible as set transformations of sealed
+maps), the per-plan import ledger (collection needs post-naturalize
+facts plus entry's grown exports, which need every module's facts —
+a cross-module phase cycle), and `cross_module_chunk_renames`' separate
+application (it composes _sequentially_ with import-local mints; a
+single seal's priority rule would mis-resolve `x → y$1` vs `x → y`).
+
 Decisions taken (formerly the open-questions subsection below):
 
 1. **Same-priority conflicts are hard errors at seal**, naming both
@@ -314,19 +336,22 @@ Decisions taken (formerly the open-questions subsection below):
 
 Remaining PRs:
 
-- **PR 4 — execute once**: one visitor pass (the post-#2052 rename
-  visitor becomes the executor) updating the AST, export tables,
-  `runtime_imports`, `binding_comments`, and cross-module indexes in
-  lockstep, keyed by hygiene `Id` (deleting the seal-output string
-  projection, the pre-seal rename walks that feed capture facts to
-  seal, the naturalizer's derive-phase preview, and the remaining
-  per-phase ledger instances).
-- **PR 5 — cleanup**: delete the defensive era (`captured` sets,
-  `drop_subtree_captured_targets` where dominated, `merged`/`module_scope`
-  split, reverse lookups); afterwards the #2045 class is
-  unrepresentable.
+- **PR 5 — cleanup + the deep cuts PR 4 documented**: delete the
+  defensive era where seal's guarantee dominates (`captured` sets on
+  the executors, `drop_subtree_captured_targets` where dominated by
+  seal's subtree validation); attack the documented blockers — merge
+  the per-plan import ledger by planning references off un-renamed
+  body facts plus sealed-map reasoning at import emission (mind the
+  mint-seeding suffix-mint corner cases), fold
+  `cross_module_chunk_renames` into the sealed pipeline without
+  breaking its sequential composition with import-local mints, and key
+  the executor by hygiene `Id` end-to-end (deleting the seal-output
+  `*_by_name` string projection — requires emitting import/export
+  decls under real contexts instead of `new_no_ctxt`). The
+  `merged`/`module_scope` split stays as long as free-source aliases
+  apply function-locally while their intents live at `Module` scope.
 
-The architecture sketch below remains the reference for PRs 4–5.
+The architecture sketch below remains the reference for PR 5.
 
 The naturalizer / lowerer currently mutates identifiers in place across
 several independently-discovered passes and lets every downstream consumer

--- a/devinfra/js/debundle/lowering/exports.rs
+++ b/devinfra/js/debundle/lowering/exports.rs
@@ -310,7 +310,11 @@ pub(super) struct ExportGrowthFacts<'a> {
     pub(super) declaration_by_name: &'a HashMap<Id, usize>,
     pub(super) binding_assignment: &'a HashMap<Id, usize>,
     pub(super) pre_existing_entry_exports: &'a HashSet<Id>,
-    pub(super) entry_renames: &'a BTreeMap<String, String>,
+    /// ORIGINAL (pre-rename) names declared at the top level of the
+    /// post-split entry body. Collection runs before the entry rename
+    /// executor, so candidates are checked under their original names;
+    /// the seal's injectivity guarantees on the Chunk-scope map make
+    /// this equivalent to checking the post-rename declared set.
     pub(super) entry_declared_names: &'a HashSet<String>,
 }
 
@@ -324,7 +328,6 @@ pub(super) fn auto_grown_residual_exports(
         declaration_by_name,
         binding_assignment,
         pre_existing_entry_exports,
-        entry_renames,
         entry_declared_names,
     } = facts;
     let mut needed = BTreeSet::<String>::new();
@@ -363,10 +366,6 @@ pub(super) fn auto_grown_residual_exports(
     // `EntryExport.{local_name, exported_name}`, so the mint is
     // invisible to the moved body.
     for name in needed {
-        let final_local = entry_renames
-            .get(&name)
-            .cloned()
-            .unwrap_or_else(|| name.clone());
         // Only grow exports for bindings the final entry body
         // actually declares. A chunk-declared binding whose
         // declaring statement was claimed into a non-entry
@@ -378,7 +377,7 @@ pub(super) fn auto_grown_residual_exports(
         // `missing_residual_exports`, which
         // `residual_entry_imports_for_moved_body` rejects
         // loudly instead of emitting broken JS.
-        if !entry_declared_names.contains(&final_local) {
+        if !entry_declared_names.contains(&name) {
             continue;
         }
         let public_name = ledger.mint(RenameScope::EntryPublicExports, &name);

--- a/devinfra/js/debundle/lowering/lower.rs
+++ b/devinfra/js/debundle/lowering/lower.rs
@@ -192,11 +192,12 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
     // and "Lemma 2".
     let build_entry_imports_started = Instant::now();
     let mut entry_imports: Vec<(ModuleId, ModuleItem)> = Vec::new();
-    // Entry-body renames flow through a dedicated ledger: the
-    // chunk_renames entries staying in entry (Explicit) and the entry
-    // import-local mints (ImportInduced) submit Chunk-scope intents
-    // below; the sealed projection is the `body_renames` map the entry
-    // renamer applies. The two contributors' source sets are disjoint by
+    // Entry-side renames flow through ONE per-chunk ledger sealed once:
+    // the chunk_renames entries staying in entry (Explicit, Chunk scope),
+    // the entry import-local mints (ImportInduced, Chunk scope), and the
+    // auto-grown residual public exports (ImportInduced,
+    // EntryPublicExports scope — a separate namespace from local-binding
+    // renames). The Chunk-scope contributors' source sets are disjoint by
     // construction — chunk_renames seeding skips module-owned bindings,
     // mints fire only for module-owned bindings — so a seal conflict can
     // only come from one contributor disagreeing with itself.
@@ -205,8 +206,8 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
     // top-level names (root) and everything bound below them (nested).
     // Seal rejects chunk_renames targets colliding at the root level —
     // collecting every violation in one error — and asserts mints stayed
-    // clear of both levels; nested-capture facts come from the rename
-    // walk below.
+    // clear of both levels; nested-capture facts come from the read-only
+    // capture probe below.
     let entry_root_names = collect_occupied_local_names(&entry_body);
     let entry_nested_names = collect_nested_binding_names(&entry_body);
     let mut entry_ledger = RenameLedger::default();
@@ -223,12 +224,6 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
     // that collides with one of the chunk_renames' targets. Iterate
     // `chunk_renames` (a `HashMap`) in sorted order so the ledger's
     // intent order is stable.
-    // `entry_candidate_renames` mirrors the submitted intents so the
-    // rename walk below can run before seal and report precise capture
-    // facts into it; seal's Chunk projection reproduces this map exactly
-    // (debug-asserted below). The pre-seal walk is PR-4-deletable
-    // scaffolding, like the naturalizer's derive preview.
-    let mut entry_candidate_renames = BTreeMap::<String, String>::new();
     let mut sorted_renames: Vec<(&String, &String)> = chunk_renames.iter().collect();
     sorted_renames.sort_by(|a, b| a.0.cmp(b.0));
     for (binding, export_name) in sorted_renames {
@@ -244,7 +239,6 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
                 contributor: CHUNK_RENAMES_CONTRIBUTOR,
             },
         });
-        entry_candidate_renames.insert(binding.clone(), export_name.clone());
     }
     // Mints must additionally avoid every nested binding name, or the
     // follow-up body rewrite could capture references meant to resolve
@@ -304,7 +298,6 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
                         contributor: ENTRY_IMPORT_LOCAL_CONTRIBUTOR,
                     },
                 });
-                entry_candidate_renames.insert(local, fresh);
             }
         }
         entry_imports.push((
@@ -326,64 +319,24 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
         .sort_entry_imports(&mut entry_imports);
     let entry_imports: Vec<ModuleItem> = entry_imports.into_iter().map(|(_, it)| it).collect();
     timings.add("build_entry_imports", build_entry_imports_started.elapsed());
-    // Rename walk: apply the candidate map before seal so the visitor's
-    // scope stack reports precise capture facts (a target bound nested
-    // is harmless when the source is shadowed there — only the walk can
-    // decide that). When seal rejects below, the bail discards this
-    // (partially renamed) body with the whole run.
+    // Capture probe: a read-only walk of the un-renamed entry body with
+    // the pending Chunk-scope map, reporting the precise capture facts
+    // seal validates (a target bound nested is harmless when the source
+    // is shadowed there — only a scope-aware walk can decide that). The
+    // probe replaces the pre-seal trial application; the body is mutated
+    // only by the post-seal executor below.
+    let entry_candidate_renames = entry_ledger.pending_renames_by_name(&RenameScope::Chunk);
     let mut entry_captured = BTreeSet::new();
     if !entry_candidate_renames.is_empty() {
-        let rename_entry_body_started = Instant::now();
-        // Re-exports `export { local }` (without `from`) collapse `local`
-        // and the public exported name into a single ident. Renaming the
-        // orig would also rename the public name, breaking downstream
-        // consumers — so rewrite them to `export { fresh as local }`
-        // before the generic renamer visits the rest.
-        for item in entry_body.iter_mut() {
-            preserve_export_specifier_names(item, &entry_candidate_renames);
+        let probe_entry_captures_started = Instant::now();
+        let mut probe = RenameCaptureProbe::new(&entry_candidate_renames);
+        for item in entry_body.iter() {
+            item.visit_with(&mut probe);
         }
-        let mut renamer = IdentifierRenamer::new(&entry_candidate_renames);
-        for item in entry_body.iter_mut() {
-            item.visit_mut_with(&mut renamer);
-        }
-        entry_captured = renamer.captured;
-        timings.add("rename_entry_body", rename_entry_body_started.elapsed());
-    }
-    // Seal the entry ledger: the single validation point for entry-body
-    // renames. Conflicting targets (target name already taken by a body
-    // local that isn't being renamed away, or chosen by another
-    // chunk_renames entry, invalid as an identifier, or captured by a
-    // nested binding per the walk above) bail here with every violation
-    // listed, rather than producing invalid JS silently. `body_renames`
-    // is the sealed Chunk-scope projection — exactly the map the
-    // pre-ledger code accumulated inline across the chunk_renames
-    // seeding and the import-local mint loop above.
-    let sealed_entry_renames = entry_ledger.seal(&SealValidation {
-        occupancy: BTreeMap::from([(
-            RenameScope::Chunk,
-            ScopeOccupancy::Body {
-                label: chunk_id.to_string(),
-                root: entry_root_names,
-                nested: entry_nested_names,
-                captured: entry_captured,
-            },
-        )]),
-        reserved: BTreeSet::new(),
-    })?;
-    let body_renames = sealed_entry_renames.scope_renames_by_name(&RenameScope::Chunk);
-    debug_assert_eq!(
-        body_renames, entry_candidate_renames,
-        "sealed entry renames diverged from the candidate map the pre-seal walk applied",
-    );
-    let entry_binding_renames = body_renames;
-    if !entry_imports.is_empty() {
-        let splice_entry_imports_started = Instant::now();
-        let tail = entry_body.split_off(import_insert_index);
-        entry_body.extend(entry_imports);
-        entry_body.extend(tail);
+        entry_captured = probe.captured;
         timings.add(
-            "splice_entry_imports",
-            splice_entry_imports_started.elapsed(),
+            "probe_entry_captures",
+            probe_entry_captures_started.elapsed(),
         );
     }
     // Naturalize every moved body up front and cache the per-plan
@@ -425,34 +378,29 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
             body_facts_by_module.push(collect_module_body_facts(body));
         }
     });
-    time_phase!(timings, "entry_exports_and_trim", {
-        for export in entry_exports_for_moved_bindings(
-            declarations,
-            binding_assignment,
-            &entry_binding_renames,
-        ) {
-            entry_body.push(export);
-        }
-        // Auto-grow entry's export list for any residual binding a
-        // moved module body references. Without this, the per-module
-        // emit path below would surface a "moved module references
-        // residual entry binding(s) … not exported by entry"
-        // rejection — i.e. would refuse to emit valid JS — for any
-        // peel whose body happens to read a top-level binding that
-        // the upstream source didn't already `export {...}`.
-        // Emitting the export here makes the assignment importable
-        // by construction (see docs/design.md "Valid peels and atomic
-        // modules", importability clause). The grow set excludes
-        // names already in entry's source-level exports.
+    // Auto-grow entry's export list for any residual binding a
+    // moved module body references. Without this, the per-module
+    // emit path below would surface a "moved module references
+    // residual entry binding(s) … not exported by entry"
+    // rejection — i.e. would refuse to emit valid JS — for any
+    // peel whose body happens to read a top-level binding that
+    // the upstream source didn't already `export {...}`.
+    // Emitting the export makes the assignment importable
+    // by construction (see docs/design.md "Valid peels and atomic
+    // modules", importability clause). The grow set excludes
+    // names already in entry's source-level exports.
+    //
+    // The mints land in the chunk ledger's `EntryPublicExports` scope —
+    // a separate namespace from the Chunk-scope local renames — seeded
+    // with the source-level public names so the grown names suffix past
+    // them. Intents are keyed by the residual binding's ORIGINAL name;
+    // the emitted clause remaps to entry's post-rename local below.
+    time_phase!(timings, "collect_export_growth", {
         let entry_declared_names: HashSet<String> = entry_body
             .iter()
             .flat_map(|item| top_level_declaration_names(item).0)
             .collect();
-        // The ledger owns the public-name namespace: seed it with the
-        // source-level public names so `auto_grown_residual_exports`'
-        // mints suffix past them.
-        let mut export_ledger = RenameLedger::default();
-        export_ledger.seed_taken(
+        entry_ledger.seed_taken(
             RenameScope::EntryPublicExports,
             pre_existing_public_export_names.iter().cloned(),
         );
@@ -462,32 +410,97 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
                 declaration_by_name,
                 binding_assignment,
                 pre_existing_entry_exports,
-                entry_renames: &entry_binding_renames,
                 entry_declared_names: &entry_declared_names,
             },
             chunk_top_level_mark,
-            &mut export_ledger,
+            &mut entry_ledger,
         );
-        // The sealed map is keyed by the residual binding's original
-        // name; the emitted export clause is keyed by entry's
-        // post-rename local, so remap through `entry_binding_renames`
-        // at application. A single contributor over a set-deduped
-        // source set cannot produce a seal conflict; the occupancy
-        // check asserts the mints stayed clear of pre-existing public
-        // names.
-        let sealed_exports = export_ledger.seal(&SealValidation {
-            occupancy: BTreeMap::from([(
-                RenameScope::EntryPublicExports,
-                ScopeOccupancy::Body {
-                    label: chunk_id.to_string(),
-                    root: pre_existing_public_export_names.iter().cloned().collect(),
-                    nested: BTreeSet::new(),
-                    captured: BTreeSet::new(),
-                },
-            )]),
+    });
+    // Seal the chunk ledger: the single validation point for every
+    // entry-side rename. Chunk scope: conflicting targets (target name
+    // already taken by a body local that isn't being renamed away, or
+    // chosen by another chunk_renames entry, invalid as an identifier,
+    // or captured by a nested binding per the probe above) bail here
+    // with every violation listed, rather than producing invalid JS
+    // silently. EntryPublicExports scope: a single contributor over a
+    // set-deduped source set cannot conflict; the occupancy check
+    // asserts the mints stayed clear of pre-existing public names.
+    let sealed_entry_renames = time_phase!(timings, "seal_entry_ledger", {
+        entry_ledger.seal(&SealValidation {
+            occupancy: BTreeMap::from([
+                (
+                    RenameScope::Chunk,
+                    ScopeOccupancy::Body {
+                        label: chunk_id.to_string(),
+                        root: entry_root_names,
+                        nested: entry_nested_names,
+                        captured: entry_captured,
+                    },
+                ),
+                (
+                    RenameScope::EntryPublicExports,
+                    ScopeOccupancy::Body {
+                        label: chunk_id.to_string(),
+                        root: pre_existing_public_export_names.iter().cloned().collect(),
+                        nested: BTreeSet::new(),
+                        captured: BTreeSet::new(),
+                    },
+                ),
+            ]),
             reserved: BTreeSet::new(),
-        })?;
-        let auto_grow: BTreeMap<String, String> = sealed_exports
+        })
+    })?;
+    let entry_binding_renames = sealed_entry_renames.scope_renames_by_name(&RenameScope::Chunk);
+    debug_assert_eq!(
+        entry_binding_renames, entry_candidate_renames,
+        "sealed entry renames diverged from the pending map the capture probe walked",
+    );
+    // Execute once: the single rename pass over the entry body, applying
+    // the sealed Chunk-scope map. Re-exports `export { local }` (without
+    // `from`) collapse `local` and the public exported name into a single
+    // ident; renaming the orig would also rename the public name, so
+    // rewrite them to `export { fresh as local }` before the generic
+    // renamer visits the rest. The probe above already fed seal the walk's
+    // capture verdict, so a capture here means probe and executor diverged.
+    if !entry_binding_renames.is_empty() {
+        let rename_entry_body_started = Instant::now();
+        for item in entry_body.iter_mut() {
+            preserve_export_specifier_names(item, &entry_binding_renames);
+        }
+        let mut renamer = IdentifierRenamer::new(&entry_binding_renames);
+        for item in entry_body.iter_mut() {
+            item.visit_mut_with(&mut renamer);
+        }
+        debug_assert!(
+            renamer.captured.is_empty(),
+            "entry rename executor captured despite seal validation: {:?}",
+            renamer.captured,
+        );
+        timings.add("rename_entry_body", rename_entry_body_started.elapsed());
+    }
+    if !entry_imports.is_empty() {
+        let splice_entry_imports_started = Instant::now();
+        let tail = entry_body.split_off(import_insert_index);
+        entry_body.extend(entry_imports);
+        entry_body.extend(tail);
+        timings.add(
+            "splice_entry_imports",
+            splice_entry_imports_started.elapsed(),
+        );
+    }
+    time_phase!(timings, "entry_exports_and_trim", {
+        for export in entry_exports_for_moved_bindings(
+            declarations,
+            binding_assignment,
+            &entry_binding_renames,
+        ) {
+            entry_body.push(export);
+        }
+        // The sealed EntryPublicExports map is keyed by the residual
+        // binding's original name; the emitted export clause is keyed by
+        // entry's post-rename local, so remap through
+        // `entry_binding_renames` at application.
+        let auto_grow: BTreeMap<String, String> = sealed_entry_renames
             .scope_renames_by_name(&RenameScope::EntryPublicExports)
             .into_iter()
             .map(|(original, public_name)| {
@@ -779,7 +792,11 @@ fn lower_single_plan(
             entry_exports_by_original_local,
             RuntimeImportLookup {
                 imports: runtime_import_facts,
-                heuristic_renames: &local_renames.merged,
+                original_by_renamed: local_renames
+                    .merged
+                    .iter()
+                    .map(|(pre, post)| (post.clone(), pre.clone()))
+                    .collect(),
             },
         )
     });

--- a/devinfra/js/debundle/lowering/mod.rs
+++ b/devinfra/js/debundle/lowering/mod.rs
@@ -104,7 +104,9 @@ use runtime_imports::{
     record_runtime_imports, runtime_reimport_specifier,
 };
 use util::normalize_optional_relative_dir;
-use visitors::{IdentifierRenamer, RenameAndShorthandNaturalizer, ShorthandNaturalizer};
+use visitors::{
+    IdentifierRenamer, RenameAndShorthandNaturalizer, RenameCaptureProbe, ShorthandNaturalizer,
+};
 
 macro_rules! time_phase {
     ($timings:expr, $name:expr, $body:block) => {{

--- a/devinfra/js/debundle/lowering/naturalize.rs
+++ b/devinfra/js/debundle/lowering/naturalize.rs
@@ -36,9 +36,11 @@
 //! (`Function` scope, submitted raw with each deriving subtree's name
 //! facts) — share one per-module [`RenameLedger`], and its seal is the
 //! single validation point: explicit-vs-heuristic priority, target
-//! collisions, and occupancy. `SealedScopeRenameApplier` replays the
-//! sealed per-scope maps onto the real body; the application sites only
-//! `debug_assert!` seal's no-capture guarantee.
+//! collisions, and occupancy. Derivation (and the capture probe for the
+//! module-wide map) runs on a scratch clone of the un-renamed body; the
+//! real body is mutated only by the post-seal executor (sealed
+//! module-wide walk + `SealedScopeRenameApplier`), whose application
+//! sites only `debug_assert!` seal's no-capture guarantee.
 
 use swc_common::Span;
 
@@ -155,33 +157,13 @@ pub(super) fn naturalize_module_body(
     // reserved set before the ledger can seal (sealing also waits for the
     // derive pass's Function-scope intents). `merge_module_renames` is
     // the same rule seal applies, so the preview and the sealed output
-    // agree; the preview is deleted with PR 4's execute-once pass.
+    // agree.
     let merged_preview = merge_module_renames(plan_driven.clone(), free_heuristic);
     let free_effective: BTreeMap<String, String> = merged_preview
         .iter()
         .filter(|(local, _)| !plan_driven.contains_key(*local))
         .map(|(local, target)| (local.clone(), target.clone()))
         .collect();
-
-    // Module-wide pass: plan-driven renames + shorthand collapse when the
-    // plan renames anything, shorthand collapse alone otherwise. The walk
-    // runs before seal so the visitor's scope stack reports precise
-    // capture facts (a target bound nested is harmless when the source is
-    // shadowed there — only the walk can decide that); seal turns them
-    // into the hard error, and its bail discards this (partially renamed)
-    // body with the whole pipeline run before anything is emitted.
-    let mut plan_captured = BTreeSet::new();
-    if plan_driven.is_empty() {
-        for item in body.iter_mut() {
-            item.visit_mut_with(&mut ShorthandNaturalizer);
-        }
-    } else {
-        let mut naturalizer = RenameAndShorthandNaturalizer::new(&plan_driven);
-        for item in body.iter_mut() {
-            item.visit_mut_with(&mut naturalizer);
-        }
-        plan_captured = naturalizer.captured;
-    }
 
     // Names a scope-local rename must never target: anything the plan or a
     // free rename reads or writes module-wide. Renaming a scope's binding
@@ -192,16 +174,36 @@ pub(super) fn naturalize_module_body(
         reserved.insert(from.clone());
         reserved.insert(to.clone());
     }
-    // Derive pass: run the scoped heuristic machinery over a scratch
-    // clone of the body. It performs exactly the pre-ledger
-    // derive-and-apply walk — outer scopes derive against subtrees
-    // that already carry their nested scopes' renames — but the
-    // mutations land on the clone; the real body is only renamed by the
-    // sealed-output applier below. Each scope's raw candidates are
-    // submitted as Function-scope intents together with the deriving
-    // subtree's name facts, which seal validates them against. The clone
-    // is deleted with PR 4's execute-once pass.
+    // Derive clone: a scratch copy of the UN-renamed body that the
+    // module-wide candidate walk and the per-scope derive pass run on.
+    // The real body is mutated only by the post-seal executor below.
+    //
+    // The candidate plan-driven walk on the clone doubles as the capture
+    // probe for the Module scope: its scope stack reports the precise
+    // capture facts seal validates (a target bound nested is harmless
+    // when the source is shadowed there). The derive pass then performs
+    // exactly the pre-ledger derive-and-apply walk — outer scopes derive
+    // against subtrees that already carry their nested scopes' renames —
+    // submitting each scope's raw candidates as Function-scope intents
+    // together with the deriving subtree's name facts. The clone cannot
+    // be replaced by reasoning over the un-renamed tree alone: outer
+    // scopes' subtree facts (bound/mention sets) must reflect the nested
+    // scopes' fired renames, and a flat set transformation of the sealed
+    // nested maps cannot reproduce the scope-sensitive application the
+    // clone walk performs (see TODO.md "Rename pipeline", PR-5 notes).
     let mut derive_body = body.to_vec();
+    let mut plan_captured = BTreeSet::new();
+    if plan_driven.is_empty() {
+        for item in derive_body.iter_mut() {
+            item.visit_mut_with(&mut ShorthandNaturalizer);
+        }
+    } else {
+        let mut naturalizer = RenameAndShorthandNaturalizer::new(&plan_driven);
+        for item in derive_body.iter_mut() {
+            item.visit_mut_with(&mut naturalizer);
+        }
+        plan_captured = naturalizer.captured;
+    }
     let mut occupancy = BTreeMap::new();
     let mut deriver = ScopedHeuristicNaturalizer {
         free_allowed: &free_effective,
@@ -225,10 +227,32 @@ pub(super) fn naturalize_module_body(
         occupancy,
         reserved,
     })?;
-    // Apply pass: replay the sealed per-scope maps onto the real body in
-    // the same order the derive pass fired them (children first), so each
-    // scope's map applies to the same intermediate tree state the
-    // derivation validated against.
+    // Execute: the single mutation of the real body, entirely from the
+    // sealed output. Layer 1 applies the sealed module-wide explicit map
+    // (plus shorthand collapse); layer 2 replays the sealed per-scope
+    // heuristic maps in the same order the derive pass fired them
+    // (children first), so each scope's map applies to the same
+    // intermediate tree state the derivation validated against.
+    let module_scope = sealed.module_explicit_renames_by_name(module);
+    debug_assert_eq!(
+        module_scope, plan_driven,
+        "sealed module-wide explicit renames diverged from the candidate map the derive clone applied",
+    );
+    if module_scope.is_empty() {
+        for item in body.iter_mut() {
+            item.visit_mut_with(&mut ShorthandNaturalizer);
+        }
+    } else {
+        let mut naturalizer = RenameAndShorthandNaturalizer::new(&module_scope);
+        for item in body.iter_mut() {
+            item.visit_mut_with(&mut naturalizer);
+        }
+        debug_assert!(
+            naturalizer.captured.is_empty(),
+            "module-wide renames captured despite seal validation: {:?}",
+            naturalizer.captured,
+        );
+    }
     let mut applier = SealedScopeRenameApplier { sealed: &sealed };
     for item in body.iter_mut() {
         item.visit_mut_with(&mut applier);
@@ -236,7 +260,7 @@ pub(super) fn naturalize_module_body(
 
     Ok(NaturalizedRenames {
         merged: sealed.module_renames_by_name(module),
-        module_scope: sealed.module_explicit_renames_by_name(module),
+        module_scope,
     })
 }
 
@@ -251,7 +275,9 @@ pub(super) fn naturalize_module_body(
 /// exactly the pre-ledger derive-and-apply order. The clone mutation
 /// uses a local preview of seal's rules ([`Self::validated_bound`] +
 /// `drop_subtree_captured_targets`), so the clone and the sealed output
-/// agree; the preview is deleted with PR 4's execute-once pass.
+/// agree. The clone is what makes the enclosing scopes' subtree facts
+/// reflect nested fired renames precisely — see the ledger module doc's
+/// "Seal points" for why set-level reasoning can't replace it.
 /// Free-source renames fire only when they survived the module-global
 /// collision rules (`free_allowed`). A rename derived from one scope
 /// never leaks into a sibling/parent scope, and

--- a/devinfra/js/debundle/lowering/plan_references.rs
+++ b/devinfra/js/debundle/lowering/plan_references.rs
@@ -133,13 +133,16 @@ pub(super) fn collect_imported_reexports_by_module(
     by_module
 }
 
-/// `naturalize_module_body`) provides the reverse lookup when the
-/// body has been renamed. The long-term fix is the
-/// collect→validate→execute-once rename pipeline tracked in
-/// <devinfra/js/debundle/TODO.md> ("Rename pipeline").
+/// Runtime-import lookup that bridges post-rename body syms back to the
+/// pre-rename keys of the source chunk's import map by consulting the
+/// inverse projection of the module's sealed rename map.
 pub(super) struct RuntimeImportLookup<'a> {
     pub(super) imports: &'a RuntimeImportFacts,
-    pub(super) heuristic_renames: &'a BTreeMap<String, String>,
+    /// Post-rename sym → original sym: the inverse of the module's
+    /// sealed merged rename map. Injective by seal's target-collision
+    /// rules (explicit duplicates are hard errors; heuristic target
+    /// collisions drop both sides), so the inversion is lossless.
+    pub(super) original_by_renamed: BTreeMap<String, String>,
 }
 
 pub(super) fn plan_module_reference_needs<'a>(
@@ -200,24 +203,23 @@ pub(super) fn plan_module_reference_needs<'a>(
         if body_facts.imported_locals.contains(body_id) {
             continue;
         }
-        // Direct hit when the body still uses the original local. Fall back to
-        // a reverse lookup through `heuristic_renames` when a naturalizer pass
-        // renamed the binding (e.g. `sA` → `propKeyA` from a return-object
-        // alias collapse): the body now references `(propKeyA, ctxt=X)`, but
-        // the source chunk's import map is keyed by `(sA, ctxt=X)`. The
-        // recovered `RuntimeImportInfo` keeps `imported = "sA"`, so emit
-        // produces `import { sA as propKeyA } from "<src>"` via
+        // Direct hit when the body still uses the original local. Fall
+        // back to the sealed map's inverse projection when a naturalizer
+        // pass renamed the binding (e.g. `sA` → `propKeyA` from a
+        // return-object alias collapse): the body now references
+        // `(propKeyA, ctxt=X)`, but the source chunk's import map is
+        // keyed by `(sA, ctxt=X)`. The recovered `RuntimeImportInfo`
+        // keeps `imported = "sA"`, so emit produces
+        // `import { sA as propKeyA } from "<src>"` via
         // `runtime_reimport_specifier`'s local-vs-imported branch. The
-        // naturalizer's in-place sym mutation preserves `ctxt`, so we
-        // reconstruct the pre-rename Id by pairing the pre-rename sym
-        // (looked up in heuristic_renames as the entry whose value
-        // matches the body sym) with the body Id's own ctxt.
+        // naturalizer's in-place sym mutation preserves `ctxt`, so the
+        // pre-rename Id is the inverse-mapped sym paired with the body
+        // Id's own ctxt.
         let info = runtime_imports.imports.imports.get(body_id).or_else(|| {
             runtime_imports
-                .heuristic_renames
-                .iter()
-                .find(|(_, post)| post.as_str() == name_str)
-                .and_then(|(pre, _)| {
+                .original_by_renamed
+                .get(name_str)
+                .and_then(|pre| {
                     let pre_id: Id = (pre.as_str().into(), body_id.1);
                     runtime_imports.imports.imports.get(&pre_id)
                 })

--- a/devinfra/js/debundle/lowering/rename_ledger.rs
+++ b/devinfra/js/debundle/lowering/rename_ledger.rs
@@ -8,7 +8,7 @@
 //! pre-ledger code built so the existing application sites (the
 //! string-keyed rename visitors in `visitors.rs`) stay unchanged.
 //!
-//! ## Seal validation (PR 3 era)
+//! ## Seal validation
 //!
 //! Seal is the single validation point for ledger renames:
 //!
@@ -31,11 +31,13 @@
 //!   when the source is shadowed (or never referenced) inside that scope,
 //!   and the e2e suite pins valid specs of exactly that shape. A flat
 //!   occupied-name set cannot express this, so the caller supplies the
-//!   `(source, target)` pairs the rename visitor's scope stack actually
-//!   withheld ([`ScopeOccupancy::Body::captured`], from the visitor's
-//!   `captured` set on the pre-seal application/preview walk), and seal
-//!   turns them into the hard error. PR 4's executor folds this walk into
-//!   the execute pass itself.
+//!   `(source, target)` pairs a scope-aware walk of the **un-renamed**
+//!   body withholds ([`ScopeOccupancy::Body::captured`]): the read-only
+//!   `RenameCaptureProbe` over [`RenameLedger::pending_renames_by_name`]
+//!   for the entry body, the derive clone's candidate walk for module
+//!   bodies. Seal turns them into the hard error; the post-seal executor
+//!   `debug_assert!`s its own capture set is empty, pinning probe and
+//!   executor to one verdict.
 //!
 //! Scopes without an entry in `SealValidation::occupancy` get conflict
 //! validation only — used by the chunk-level explicit ledger sealed
@@ -57,45 +59,56 @@
 //! Adopted (decided 2026-06): once a chunk's ledger is sealed, no pass may
 //! move declarations between modules — structural moves (entry-body split,
 //! residual sweep, rebind folds, mini-factor synthesis) must all happen
-//! before collection finishes. In PR 1 the materializer already satisfies
-//! the collection side (intents are collected from the finalized
-//! `ChunkPlan`); the contract becomes mechanically enforceable when the
-//! execute-once pass lands (PR 4) and non-execute passes take `&Module`.
+//! before collection finishes. The materializer satisfies the collection
+//! side (intents are collected from the finalized `ChunkPlan`), and as of
+//! PR 4 every ledger executes post-seal only. Making the contract
+//! type-level (non-execute passes take `&Module`) is remaining work.
 //!
-//! ## Seal points (PR 3 era)
+//! ## Seal points (PR 4 era)
 //!
-//! Contributor derivation is still interleaved with application across
-//! the lowering pipeline — a later contributor derives from the AST state
-//! an earlier contributor's application produced — so each phase keeps
-//! its own ledger instance, but every instance now seals with occupancy
-//! validation and the application sites only assert seal's guarantee:
+//! Four ledger instances remain, and each follows the same discipline:
+//! collect every intent, seal once, then execute — the post-seal rename
+//! pass is the only mutation of the scope unit's AST, and no pre-seal
+//! trial application exists (capture facts come from read-only probes /
+//! the derive clone over the un-renamed body):
 //!
 //! - **Chunk explicit ledger** (`materialize_logical_chunk`): spec
 //!   `chunk_renames` + plan `export_name`s; conflict-validated only (the
 //!   post-split bodies its targets must avoid don't exist yet — its
 //!   intents are re-collected into the two ledgers below, which validate
 //!   occupancy). Sealed before factorization, which consumes the
-//!   Chunk-scope projection.
-//! - **Entry ledger** (`lower_chunk`): the chunk_renames entries staying
-//!   in entry plus entry import-local mints; seal validates against
-//!   entry's post-split body occupancy.
+//!   Chunk-scope projection. It cannot merge downstream: its Chunk
+//!   projection is an input to plan building and factorization, which
+//!   run before the post-split bodies exist.
+//! - **Chunk ledger** (`lower_chunk`): the chunk_renames entries staying
+//!   in entry plus entry import-local mints (`Chunk` scope) AND the
+//!   auto-grown residual public exports (`EntryPublicExports` scope —
+//!   PR 4 absorbed the former export-growth ledger). One seal validates
+//!   entry's post-split body occupancy (capture facts from the read-only
+//!   `RenameCaptureProbe`) and the public-export namespace; one executor
+//!   pass applies the Chunk map to the entry body.
 //! - **Per-module naturalize ledger** (`naturalize_module_body`): the
 //!   plan's export_name renames (Explicit), free-source return-object
 //!   aliases (Heuristic, `Module` scope), and bound-source scope-local
 //!   heuristics (Heuristic, `Function` scope) — one seal resolves
 //!   explicit-vs-heuristic priority, the module-level target-collision
-//!   rule ([`merge_module_renames`]), and per-scope occupancy.
+//!   rule ([`merge_module_renames`]), and per-scope occupancy. The
+//!   executor (sealed module-wide walk + `SealedScopeRenameApplier`) is
+//!   the only mutation of the real body; derivation runs on a scratch
+//!   clone of the un-renamed body (see below for why the clone stays).
 //! - **Per-plan import ledger** (`lower_single_plan`): cross-module +
-//!   residual-entry import-local mints; collection needs the
-//!   post-naturalize body facts, so it cannot merge into the naturalize
-//!   ledger until PR 4's execute-once pass removes the intermediate
-//!   application.
-//! - **Export-growth ledger** (`lower_chunk`): auto-grown residual public
-//!   exports (`EntryPublicExports` scope). Collection needs the moved
-//!   bodies' post-naturalize facts and the sealed entry renames, so it
-//!   stays a separate instance until PR 4.
+//!   residual-entry import-local mints. It cannot merge into the
+//!   naturalize ledger because of a cross-module phase ordering, not
+//!   mere code shape: collection needs this module's post-naturalize
+//!   body facts AND entry's grown export list, which itself needs every
+//!   module's post-naturalize facts — so the naturalize seal would have
+//!   to stay open across a chunk-wide phase whose inputs require the
+//!   naturalize application to have already run. Breaking the cycle
+//!   means planning references off un-renamed facts plus sealed-map
+//!   reasoning at import emission (PR 5 candidate; changes mint seeding
+//!   and is not behavior-preserving in suffix-mint corner cases).
 //!
-//! What still validates at the application site (PR 4 scope):
+//! What still validates at the application site (PR 5 candidates):
 //!
 //! - The free-alias subtree-capture filter
 //!   (`naturalize.rs::drop_subtree_captured_targets`): free aliases apply
@@ -108,13 +121,23 @@
 //!   (`lower_single_plan`'s `cross_module_chunk_renames` pass): the
 //!   entry-side seal validates against entry's body only; a target can
 //!   still collide inside a moved body, and that application keeps its
-//!   reachable bail.
-//! - The derive-phase preview in `naturalize_module_body` (the scratch
+//!   reachable bail. It also cannot fold into the per-plan import
+//!   ledger's seal: the two maps deliberately compose *sequentially*
+//!   (an import-local mint may rename `x → y$1` precisely because the
+//!   chunk-rename target `y` was taken, and the cross map's `x → y`
+//!   must then no-op), while one seal's priority rule would resolve the
+//!   pair to the explicit target and desync body refs from the emitted
+//!   import local.
+//! - The derive-phase clone in `naturalize_module_body` (the scratch
 //!   clone + `validated_bound` / `drop_subtree_captured_targets` /
 //!   [`merge_module_renames`] pre-computation): the per-scope derive
-//!   cascade needs each scope's fired map before enclosing scopes derive;
-//!   seal re-derives the same decisions from the submitted facts, and the
-//!   preview is deleted with PR 4's executor.
+//!   cascade needs each enclosing scope's subtree name facts to reflect
+//!   the nested scopes' fired renames (the application is
+//!   scope-sensitive — a flat set transformation of the sealed nested
+//!   maps over the un-renamed facts both over- and under-suppresses),
+//!   so the clone walk is the precise fact source. Seal re-derives the
+//!   same decisions from the submitted facts; the clone never touches
+//!   the real body.
 //!
 //! ## Hygiene boundary
 //!
@@ -125,14 +148,17 @@
 //! seal output is projected back to bare syms at the query boundary
 //! (`*_by_name`) because the post-#2052 application visitors are still
 //! string-keyed; the projection asserts that no two hygiene contexts share
-//! a sym within one scope. PR 4's executor consumes `Id`s directly and
-//! deletes the projection.
+//! a sym within one scope. An `Id`-keyed executor that deletes the
+//! projection is remaining (PR 5) work.
 //!
 //! `Function`-scope heuristic sources are function-local bindings whose
 //! hygiene context the string-keyed derivation never resolves; they are
-//! keyed by `(sym, SyntaxContext::empty())` until PR 4's executor keys
-//! application by real `Id`s. Within one function scope a sym maps to at
-//! most one rename, so the empty-context encoding cannot collide.
+//! keyed by `(sym, SyntaxContext::empty())` until the executor keys
+//! application by real `Id`s (remaining work — the post-#2052 visitors
+//! are string-keyed, and re-keying them is entangled with emitting
+//! import/export decls under real contexts instead of `new_no_ctxt`).
+//! Within one function scope a sym maps to at most one rename, so the
+//! empty-context encoding cannot collide.
 //!
 //! ## Contributor inventory
 //!
@@ -411,6 +437,37 @@ impl RenameLedger {
             }
             suffix += 1;
         }
+    }
+
+    /// Pre-seal projection of the collected intents for `scope`: per
+    /// source sym, the highest-priority proposed target (same-priority
+    /// disagreement resolves arbitrarily here — seal is the validator
+    /// and hard-errors on it before any output is consumed). Callers use
+    /// this to run the read-only capture probe over the un-renamed body
+    /// so seal receives reference-precise capture facts without a trial
+    /// application; on a successful seal the projection equals the
+    /// sealed by-name map (debug-asserted at the call sites).
+    pub fn pending_renames_by_name(&self, scope: &RenameScope) -> BTreeMap<String, String> {
+        let mut best: BTreeMap<String, (Atom, RenamePriority)> = BTreeMap::new();
+        for intent in &self.intents {
+            if intent.scope != *scope {
+                continue;
+            }
+            let priority = intent.origin.priority();
+            match best.entry(intent.from.0.to_string()) {
+                std::collections::btree_map::Entry::Vacant(slot) => {
+                    slot.insert((intent.to.clone(), priority));
+                }
+                std::collections::btree_map::Entry::Occupied(mut slot) => {
+                    if priority > slot.get().1 {
+                        slot.insert((intent.to.clone(), priority));
+                    }
+                }
+            }
+        }
+        best.into_iter()
+            .map(|(from, (to, _))| (from, to.to_string()))
+            .collect()
     }
 
     /// Validate and freeze the collected intents.
@@ -714,8 +771,9 @@ fn validate_function_scope(
 /// distinct bindings into a duplicate decl as soon as both happen to live
 /// in the same scope. This is the module-level target-collision rule
 /// seal applies to free-source aliases; `naturalize_module_body` calls it
-/// directly for the derive-phase preview (`free_allowed`), which is
-/// deleted with PR 4's executor.
+/// directly for the derive-phase preview (`free_allowed`) on the scratch
+/// clone (see the module doc's "Seal points" section for why the clone
+/// stays).
 pub fn merge_module_renames(
     mut explicit: BTreeMap<String, String>,
     heuristic: BTreeMap<String, String>,

--- a/devinfra/js/debundle/lowering/runtime_imports.rs
+++ b/devinfra/js/debundle/lowering/runtime_imports.rs
@@ -8,8 +8,9 @@ pub(super) struct RuntimeImportFacts {
     /// import site) to the `RuntimeImportInfo` describing where it came
     /// from. Keyed by the **pre-rename** `Id` because the map is built
     /// before any naturalizer pass runs; `plan_module_reference_needs`
-    /// bridges the rename via `heuristic_renames` when the body has been
-    /// renamed.
+    /// bridges the rename via the sealed rename map's inverse projection
+    /// (`RuntimeImportLookup::original_by_renamed`) when the body has
+    /// been renamed.
     pub(super) imports: HashMap<Id, RuntimeImportInfo>,
 }
 

--- a/devinfra/js/debundle/lowering/visitors.rs
+++ b/devinfra/js/debundle/lowering/visitors.rs
@@ -373,6 +373,147 @@ macro_rules! impl_rename_helpers {
     };
 }
 
+/// Read-only mirror of the renaming visitors: walks the same reference
+/// sites with the same shadow tracking, but instead of mutating it only
+/// records the `(source, target)` pairs the rename map would withhold
+/// (target shadowed at a reference of the un-shadowed source). This is
+/// how seal receives reference-precise capture facts from the
+/// **un-renamed** tree — the executor (the single post-seal rename pass)
+/// then `debug_assert!`s that its own `captured` set is empty, pinning
+/// the probe and the executor to the same verdict.
+///
+/// MUST stay traversal-identical to `impl_rename_visit_mut!`: every site
+/// the mutating visitors consult the rename map at, the probe consults
+/// it at too, with the same scope pushes.
+pub(super) struct RenameCaptureProbe<'a> {
+    renames: &'a BTreeMap<String, String>,
+    targets: BTreeSet<String>,
+    scopes: RenameScopeStack,
+    /// See [`IdentifierRenamer::captured`].
+    pub(super) captured: BTreeSet<(String, String)>,
+}
+
+impl<'a> RenameCaptureProbe<'a> {
+    pub(super) fn new(renames: &'a BTreeMap<String, String>) -> Self {
+        Self {
+            renames,
+            targets: rename_targets(renames),
+            scopes: RenameScopeStack::default(),
+            captured: BTreeSet::new(),
+        }
+    }
+
+    impl_rename_helpers!();
+
+    /// Consult the rename map for `name` exactly like the mutating
+    /// visitors do (recording a capture when the target is shadowed),
+    /// discarding the would-be target.
+    fn probe(&mut self, name: &str) {
+        if self.scopes.is_shadowed(name) {
+            return;
+        }
+        let _ = self.rename_target_for(name);
+    }
+}
+
+impl Visit for RenameCaptureProbe<'_> {
+    fn visit_ident(&mut self, ident: &Ident) {
+        self.probe(ident.sym.as_ref());
+    }
+
+    fn visit_import_named_specifier(&mut self, spec: &ImportNamedSpecifier) {
+        // Mirror: the mutating visitor only consults the map for the
+        // local; `imported` is a public name, never renamed.
+        self.probe(spec.local.sym.as_ref());
+    }
+
+    fn visit_prop_name(&mut self, prop_name: &PropName) {
+        if let PropName::Computed(computed) = prop_name {
+            computed.visit_children_with(self);
+        }
+    }
+
+    fn visit_member_prop(&mut self, member_prop: &MemberProp) {
+        if let MemberProp::Computed(computed) = member_prop {
+            computed.visit_children_with(self);
+        }
+    }
+
+    fn visit_prop(&mut self, prop: &Prop) {
+        let Prop::Shorthand(ident) = prop else {
+            prop.visit_children_with(self);
+            return;
+        };
+        self.probe(ident.sym.as_ref());
+    }
+
+    fn visit_object_pat_prop(&mut self, prop: &ObjectPatProp) {
+        let ObjectPatProp::Assign(assign) = prop else {
+            prop.visit_children_with(self);
+            return;
+        };
+        if let Some(value) = &assign.value {
+            value.visit_with(self);
+        }
+        self.probe(assign.key.id.sym.as_ref());
+    }
+
+    fn visit_labeled_stmt(&mut self, labeled: &LabeledStmt) {
+        labeled.body.visit_with(self);
+    }
+
+    fn visit_break_stmt(&mut self, _break_stmt: &BreakStmt) {}
+
+    fn visit_continue_stmt(&mut self, _continue_stmt: &ContinueStmt) {}
+
+    fn visit_named_export(&mut self, named: &NamedExport) {
+        if named.src.is_none() {
+            named.specifiers.visit_with(self);
+        }
+    }
+
+    fn visit_export_named_specifier(&mut self, spec: &ExportNamedSpecifier) {
+        spec.orig.visit_with(self);
+    }
+
+    fn visit_function(&mut self, function: &Function) {
+        let scope =
+            shadowed_by_params(function.params.iter().map(|p| &p.pat), &self.rename_names());
+        self.with_rename_scope(scope, |s| function.visit_children_with(s));
+    }
+
+    fn visit_arrow_expr(&mut self, arrow: &ArrowExpr) {
+        let scope = shadowed_by_params(arrow.params.iter(), &self.rename_names());
+        self.with_rename_scope(scope, |s| arrow.visit_children_with(s));
+    }
+
+    fn visit_constructor(&mut self, constructor: &Constructor) {
+        let params = constructor.params.iter().filter_map(|p| match p {
+            ParamOrTsParamProp::Param(param) => Some(&param.pat),
+            ParamOrTsParamProp::TsParamProp(_) => None,
+        });
+        let scope = shadowed_by_params(params, &self.rename_names());
+        self.with_rename_scope(scope, |s| constructor.visit_children_with(s));
+    }
+
+    fn visit_catch_clause(&mut self, clause: &CatchClause) {
+        let scope = match &clause.param {
+            Some(pat) => {
+                let mut out = BTreeSet::new();
+                collect_shadowed_by_pat(pat, &self.rename_names(), &mut out);
+                out
+            }
+            None => BTreeSet::new(),
+        };
+        self.with_rename_scope(scope, |s| clause.visit_children_with(s));
+    }
+
+    fn visit_block_stmt(&mut self, block: &BlockStmt) {
+        let scope = shadowed_by_block_decls(&block.stmts, &self.rename_names());
+        self.with_rename_scope(scope, |s| block.visit_children_with(s));
+    }
+}
+
 pub(super) struct IdentifierRenamer<'a> {
     pub(super) renames: &'a BTreeMap<String, String>,
     targets: BTreeSet<String>,

--- a/devinfra/js/debundle/plans/sanitization_program_2026_06.md
+++ b/devinfra/js/debundle/plans/sanitization_program_2026_06.md
@@ -72,13 +72,21 @@ origin, priority }`, scopes Chunk/Module/Function, **keyed by hygiene
    service. _(Landed 2026-06; see TODO.md's "PR 3 landed" entry and the
    "Seal points" section of `lowering/rename_ledger.rs` for what stays at
    the application sites until PR 4.)_
-4. Execute once: one visitor pass (the post-#2052 rename visitor becomes the
-   executor) updating export tables, `runtime_imports`, `binding_comments`,
-   and cross-module indexes in lockstep.
+4. Execute once: the post-seal rename pass is the only mutation per scope
+   unit; capture facts reach seal from the un-renamed tree. _(Landed
+   2026-06: read-only `RenameCaptureProbe` + `pending_renames_by_name`
+   replace the pre-seal trial walks, the export-growth ledger merged into
+   `lower_chunk`'s chunk ledger, and `plan_references`' reverse `.find`
+   became the sealed map's inverse projection. The naturalizer's derive
+   clone, the per-plan import ledger, and `cross_module_chunk_renames`'
+   separate application stay with documented reasons — see TODO.md's
+   "PR 4 landed" entry and `rename_ledger.rs` "Seal points".)_
 5. Cleanup: delete the defensive era (`captured` sets,
-   `drop_subtree_captured_targets` where dominated, `merged`/`module_scope`
-   split, reverse lookups). Afterwards the #2045 class is unrepresentable
-   and aggressive auto-naturalization becomes safe to build.
+   `drop_subtree_captured_targets` where dominated, reverse lookups) and
+   attack PR 4's documented blockers (import-ledger merge,
+   `Id`-keyed executor deleting the `*_by_name` projection). Afterwards
+   the #2045 class is unrepresentable and aggressive auto-naturalization
+   becomes safe to build.
 
 ## Track C — vendor-into-emission collapse (weeks 2–3)
 


### PR DESCRIPTION
Track B PR 4 of 5 (rename pipeline: collect → validate → execute _once_). Predecessors: #2086 (PR 1), #2091 (PR 2), #2101 (PR 3).

## What changed

Every rename ledger now follows **collect → seal → execute-once**: no pre-seal trial application remains anywhere in the lowering pipeline, and the post-seal rename pass is the only mutation of each scope unit's AST.

### Capture facts from the un-renamed tree

- New read-only `RenameCaptureProbe` (`visitors.rs`) mirrors the renaming visitors' scope-aware traversal exactly but only records the `(source, target)` pairs the map would withhold. The entry body's capture facts now come from probing the un-renamed body with `RenameLedger::pending_renames_by_name` (new pre-seal projection query) — the pre-seal mutating walk and the hand-maintained `entry_candidate_renames` mirror die. The executor `debug_assert!`s its own capture set is empty, pinning probe and executor to one verdict.
- `naturalize_module_body`: the real body is mutated only by the post-seal executor (sealed module-wide explicit walk + `SealedScopeRenameApplier`). The derive clone now starts from the **un-renamed** body and its candidate plan-driven walk doubles as the Module-scope capture probe.

### Ledger instances: 5 → 4

The export-growth ledger merged into `lower_chunk`'s chunk ledger: one collection, one seal validating `Chunk` + `EntryPublicExports` occupancy together, one executor pass over the entry body. `auto_grown_residual_exports` now checks candidates against the un-renamed entry declared-name set by original name (equivalent under seal's injectivity/vacating rules; `ExportGrowthFacts` drops `entry_renames`).

### Consumers consult the sealed mapping

`plan_module_reference_needs`' linear reverse `.find` over the heuristic rename map is replaced by the sealed map's inverse projection (`RuntimeImportLookup::original_by_renamed` — injective because seal's target-collision rules reject/drop shared targets), killing the deferred-from-PR-3 reverse lookup.

## Blockers kept, with documented reasons (PR 5 candidates)

Inventoried in `rename_ledger.rs` "Seal points" and TODO.md:

- **Naturalizer derive clone**: enclosing scopes' subtree name facts must reflect nested scopes' fired renames; the application is scope-sensitive (a reference to `f` inside a grandchild that re-binds `f` stays `f`), so a flat set transformation of sealed nested maps over un-renamed facts both over- and under-suppresses. The clone walk is the precise fact source; it never touches the real body.
- **Per-plan import ledger**: collection needs this module's post-naturalize facts **and** entry's grown export list, which needs every module's post-naturalize facts — a cross-module phase cycle. Breaking it means planning off un-renamed facts + sealed-map reasoning at import emission, which changes mint seeding (suffix-mint corner cases are not behavior-preserving).
- **`cross_module_chunk_renames`' separate application**: it composes *sequentially* with import-local mints (`x → y$1` minted because chunk-rename target `y` was taken; the cross map's `x → y` must then no-op). A single seal's priority rule would resolve the pair to the explicit target and desync body refs from the emitted import local.
- **`merged`/`module_scope` split**: still load-bearing — free-source aliases apply function-locally while their intents live at `Module` scope, so export locals/binding comments must remap through the explicit-only projection.
- **String projection**: `*_by_name` remains at the executor boundary (visitors are string-keyed post-#2052); `Id`-keyed application is entangled with emitting import/export decls under real syntax contexts instead of `new_no_ctxt`.

## Behavior

Zero observable change: full `//devinfra/js/debundle/...` suite — 100 tests, including the rename-pinning e2e suite and both proptest targets (`rename_ledger_proptest`, `condensation_order_proptest`) — green unchanged, no fixture updates.

`BAZEL_TEST_INVOCATIONS=buildbuddy:1f21c7f8-c291-447e-a648-e721b405f211`

https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk)_