### PR TITLE
debundle: gate ladder PR 5 — perf validation + doc sync

### DIFF
--- a/devinfra/js/debundle/docs/design.md
+++ b/devinfra/js/debundle/docs/design.md
@@ -518,7 +518,7 @@ OwnerReportIndex)` reconstructs the typed IR from the JSON wire
    and avoids diagnostic evidence generation.
 4. `cycle_set()` also runs the unified gate per call.
 
-#### Cost and the upgrade path
+#### Cost and the tier ladder
 
 A from-scratch `check_realizability` call is `O(|V| + |E|)`. The
 kernel's merge-candidate greedy queries it `O(|V|)` times per round,
@@ -540,31 +540,60 @@ the I-graph adjacency, the `EsmEvaluationSimulator` per-pair bucket,
 and the cross-rebind set incrementally, touching only quotient edge
 buckets incident to the moved owners.
 
-Speculative queries split into two tiers. The hot boolean gate —
-`merge_preserves_invariants`, called once per candidate by the
-greedy's pop loop — does **not** touch the realizability index at
-all: it answers via `merge_creates_new_constraining_cycle`, a
-constraining-only Pearce–Kelly walk over the kernel-maintained
-`TopoOrder` and class adjacency (with a localized cone-DFS fallback
-when the class graph already contains cycles). Asymmetric I-cycles
-that the constraining-only walk cannot see are caught by
-`build_seed_quotient`'s post-seed `check_realizability` backstop
-over the final partition.
+Speculative queries — the hot boolean gate
+(`merge_preserves_invariants`, called once per candidate by the
+greedy's pop loop) and the diagnostic path
+(`would_be_cycles_after_contract`) — are one evaluation: the
+index's tier ladder
+(`ladder_decision_after_moving_owners_touching`), entered with the
+merge's post-state ModuleId from
+`projected_winner_module_after_merge` (mirroring the gate-residual
+override `project_partition` would apply) and the `±edge` overlay
+from `compute_merge_deltas`. Each tier either decides — provably
+equal to the full `check_realizability` verdict, restricted to
+diagnoses touching the post-merge module — or escalates:
 
-The diagnostic tier — `would_be_cycles_after_contract`, when it
-needs owner-level cycle evidence — computes the merge's post-state
-ModuleId via `projected_winner_module_after_merge` (mirroring the
-gate-residual override `project_partition` would apply), then routes
-through the index's `verdict_after_moving_owners_touching`. That
-path applies a per-edge overlay on the maintained graphs without
-mutating them and reads only SCCs touching the hypothetical
-destination — `O(|cone|)` per query, not `O(|V| + |E|)`. Speculative
-deltas are single-target by construction: a merge contracts two
-classes into one, so `compute_merge_deltas` only ever emits
-`MoveOwners` deltas targeting the single post-merge module.
-`realizability_cycles_after_contract` asserts this invariant; a
-future non-merge speculative mutation must implement a multi-target
-overlay deliberately rather than inherit the merge path.
+- **Tier 0 — delta-free short-circuit.** No deltas (both classes
+  already project to the post-merge module, e.g. merges inside the
+  gate-residual pile): post-state == pre-state, so accept iff the
+  cached pre-state touching verdict is clean.
+- **Tier 1 — constraining condensation order.** A maintained
+  `CondensationOrder` over the module-level constraining graph (a
+  union-find of SCC membership plus a Pearce–Kelly topological
+  order over the condensation DAG): reject iff the post-merge
+  module's constraining SCC is multi-module — an `O(α)` find, or a
+  PK window-DFS over the overlay-patched effective adjacency,
+  `O(|Δ|)` — or a clause-2 cross-rebind touches it. A tier-1
+  reject is exactly the `MutualConstrainingCycle` clause of the
+  full verdict; a pass establishes Pass 1 is clean and escalates.
+- **Tier 2 — I-graph condensation order.** A second
+  `CondensationOrder` over the I-graph (constraining ∪ lazy): if
+  the post-merge module's I-SCC is not multi-module, or contains
+  no effective constraining pair, Pass 2 is vacuous — accept.
+  When the overlay removes an edge internal to a multi-module
+  I-SCC (the one case where the maintained union-find is
+  stale-coarse), the tier falls back to the exact per-query
+  `OverlayGraphView::scc_containing` bidirectional DFS.
+- **Tier 3 — scoped ESM simulator.** The shared
+  `EsmEvaluationSimulator` over the overlay-patched I-SCC: reject
+  iff any TDZ pair. This is the same code `check_realizability`'s
+  Pass 2 executes — drift is impossible by construction.
+
+The tiers are short-circuits whose skip conditions are theorems
+about the predicate, not a second decision procedure. The boolean
+gate is the ladder with evidence materialization elided;
+`would_be_cycles_after_contract` is the same ladder, materializing
+owner-level evidence (through the index's non-mutating
+`verdict_after_moving_owners_touching` overlay) only on a reject —
+one entry point, two output shapes. Each query reads SCCs touching
+the hypothetical destination only — `O(|cone|)`, not
+`O(|V| + |E|)`. Speculative deltas are single-target by
+construction: a merge contracts two classes into one, so
+`compute_merge_deltas` only ever emits `MoveOwners` deltas
+targeting the single post-merge module; the ladder dispatch asserts
+this invariant, and a future non-merge speculative mutation must
+implement a multi-target overlay deliberately rather than inherit
+the merge path.
 
 The kernel's `ClassId ↔ ModuleId` mapping (`class_module_id`) is
 maintained alongside the index. Initialization assigns each
@@ -583,8 +612,8 @@ in sync.
 #### References
 
 The incremental realizability path draws on the following lines of
-research; cited here so the trade-offs in "Cost and the upgrade
-path" and "Why not Pearce-Kelly verbatim" can be cross-checked
+research; cited here so the trade-offs in "Cost and the tier
+ladder" and "Why not Pearce-Kelly verbatim" can be cross-checked
 against the primary sources.
 
 - **Bender, Fineman, Gilbert, Tarjan.** _Incremental Cycle
@@ -624,25 +653,27 @@ which is structurally closer to the bounded-cone local-search
 algorithms from pointer-analysis literature (Fähndrich–Foster–
 Su–Aiken; Hardekopf–Lin).
 
-The kernel does maintain its own derived state alongside the index —
-this is a deliberate, documented trade-off, not an accident:
+Pearce–Kelly's core does survive — as the heart of the
+realizability crate's `CondensationOrder` (window DFS, window Kahn,
+epoch visited-marks), re-keyed from kernel classes to condensation
+nodes of the index's maintained module graphs, with a union-find
+for SCC membership so the PK order lives over a structure that
+stays a DAG by construction even when the underlying graph is
+cyclic. Contraction monotonicity — vertex identification only ever
+coarsens the SCC partition — is what licenses a plain
+non-rollbackable union-find instead of full dynamic-SCC machinery
+(kernel-side index mutation is commit-only); committed removals
+internal to a multi-module SCC mark the membership stale-coarse and
+trigger tier 2's exact-DFS fallback rather than an eager split.
 
-- The Pearce–Kelly `TopoOrder` plus the class adjacency
-  (`out_edges`), which back the hot boolean merge gate
-  `merge_creates_new_constraining_cycle`. This is
-  **decision-making** derived state: the greedy accepts or rejects
-  merges on its answer, with the post-seed `check_realizability`
-  pass as the backstop for asymmetric I-cycles the constraining-only
-  walk cannot see.
-- The advisory `cached_cycles` heuristic on `rank_candidate`, which
-  is cache-not-source-of-truth.
-
-The "no bespoke parallel walks" invariant elsewhere in this document
-is therefore relaxed here for performance: routing the hot gate
-through the index would restore one source of truth at a per-query
-cost the greedy cannot currently afford. Whether to route through
-the index or keep the PK gate is an open question tracked in
-`ARCHITECTURE_BACKLOG.md`.
+The kernel itself maintains **no** decision-making derived order or
+cycle state: the gate ladder lives inside the index ("Cost and the
+tier ladder" above), so the "no bespoke parallel walks" invariant
+holds here too — one source of truth for accept/reject.
+`rank_candidate`'s cycle-reduction key byte reads the same
+maintained condensation through an `O(α)` union-find probe
+(`modules_share_constraining_multi_scc`) instead of an advisory
+cache.
 
 ## At-init call promotion
 

--- a/devinfra/js/debundle/perf/BUILD.bazel
+++ b/devinfra/js/debundle/perf/BUILD.bazel
@@ -1,0 +1,13 @@
+load("//devinfra/python:defs.bzl", "py_binary", "py_library")
+
+py_library(
+    name = "gen_synth_corpus",
+    srcs = ["gen_synth_corpus.py"],
+    visibility = ["//:__subpackages__"],
+)
+
+py_binary(
+    name = "gen_synth_corpus_bin",
+    main_module = "devinfra.js.debundle.perf.gen_synth_corpus",
+    deps = [":gen_synth_corpus"],
+)

--- a/devinfra/js/debundle/perf/gen_synth_corpus.py
+++ b/devinfra/js/debundle/perf/gen_synth_corpus.py
@@ -1,0 +1,190 @@
+"""Generate a synthetic debundle corpus at the gaffer-scale proposer shape.
+
+The proposer perf baseline in `perf/proposer.md` was historically measured
+against a private downstream fixture that public CI cannot access. This
+generator produces a public stand-in with the same graph shape the perf doc
+describes: `|V| ~= 10^4` owners, `|E| = O(|V|)`, block-clustered eager
+references (so the greedy proposer finds mergeable communities), a lazy-edge
+minority, at-init calls (exercising promotion), a sprinkle of asymmetric
+I-cycles (lazy forward, eager back — the shape that drives the gate ladder
+to tier 2/3), and a sampled export surface.
+
+`--claim-blocks N` assigns the first N blocks to pre-existing spec modules
+(`auto_partition/block_<k>`), both in the run spec's `logical_modules` (so
+the emitted owner graph carries non-residual destinations and the proposer
+seeds pre-existing-module classes) and as a spec-modules YAML tree for
+`modules propose`. Claiming a contiguous *prefix* keeps the spec
+realizable: claimed blocks only reference earlier (claimed) blocks, so all
+residual→claimed eager reads point at modules that evaluate first.
+`--claim-blocks 0` leaves the graph fully residual — every proposer merge
+is then a delta-free tier-0 query.
+
+Output layout under `--out`:
+
+    snapshot/package.json     ESM marker
+    snapshot/static/app.js    the synthetic chunk
+    extracted/js-files.txt    chunk list for `inputs.js_list_path`
+    spec.json                 minimal `debundle run` spec (absolute paths)
+    modules/                  spec-modules tree for `modules propose`
+
+Measurement recipe (see `perf/proposer.md` "How to run"):
+
+    gen_synth_corpus --out /tmp/synth --statements 10000 --seed 1 --claim-blocks 62
+    debundle run --spec /tmp/synth/spec.json
+    DEBUNDLE_TIMING=1 debundle modules propose \\
+        --graph /tmp/synth/out/reports/tree/static/app/owner_graph.json \\
+        --modules /tmp/synth/modules --format json >/dev/null
+"""
+
+import argparse
+import itertools
+import json
+import random
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Tuned so a 10k-statement corpus lands near the historical fixture shape:
+# blocks of 20-60 owners (proposal-sized communities), ~12% lazy function
+# owners, ~8% at-init calls, ~5% cross-block eager refs, ~10% exports.
+BLOCK_MIN = 20
+BLOCK_MAX = 60
+P_FUNCTION = 0.12
+P_AT_INIT_CALL = 0.20
+P_CROSS_BLOCK_REF = 0.05
+P_EXPORT = 0.10
+ASYMMETRIC_CYCLE_PAIRS = 15
+EXPORTS_PER_STATEMENT = 50
+
+
+@dataclass
+class Chunk:
+    source: str
+    # Block ordinal -> binding names declared in that block, in
+    # declaration order (claimable members for `--claim-blocks`).
+    blocks: dict[int, list[str]] = field(default_factory=dict)
+
+
+def generate_chunk(n_statements: int, rng: random.Random) -> Chunk:
+    lines = ['const anchor = "anchor";']
+    consts: list[str] = []
+    funcs: list[str] = []
+    block_consts: list[str] = []
+    exports = ["anchor"]
+    blocks: dict[int, list[str]] = {}
+    block = 0
+    block_left = 0
+    for i in range(n_statements):
+        if block_left == 0:
+            block += 1
+            block_left = rng.randint(BLOCK_MIN, BLOCK_MAX)
+            block_consts = []
+            blocks[block] = []
+        block_left -= 1
+        roll = rng.random()
+        if roll < P_FUNCTION and block_consts:
+            # Function owner: lazy reads of block consts (occasionally
+            # cross-block) that only constrain init order via promotion.
+            name = f"b{block}_f{i}"
+            refs = rng.sample(block_consts, k=min(len(block_consts), rng.randint(1, 2)))
+            if consts and rng.random() < P_CROSS_BLOCK_REF * 4:
+                refs.append(rng.choice(consts))
+            lines.append(f"function {name}() {{ return {' + '.join(refs)}; }}")
+            funcs.append(name)
+        elif roll < P_AT_INIT_CALL and funcs:
+            # At-init call: exercises eager-edge promotion through the
+            # callee's transitive lazy reads.
+            name = f"b{block}_w{i}"
+            lines.append(f"const {name} = {rng.choice(funcs[-40:])}();")
+            block_consts.append(name)
+            consts.append(name)
+        else:
+            name = f"b{block}_v{i}"
+            refs = rng.sample(block_consts, k=min(len(block_consts), rng.randint(1, 3)))
+            if consts and rng.random() < P_CROSS_BLOCK_REF:
+                refs.append(rng.choice(consts))
+            expr = " + ".join(refs) if refs else str(rng.randint(1, 1000))
+            lines.append(f"const {name} = {expr};")
+            block_consts.append(name)
+            consts.append(name)
+        blocks[block].append(name)
+        if rng.random() < P_EXPORT:
+            exports.append(name)
+    # Asymmetric I-cycles (lazy forward, eager back): each pair is a 2-owner
+    # I-SCC with one constraining edge. The extra block-const references give
+    # the greedy a reason to pull the two owners into different block cells,
+    # turning the pair into a cross-module I-cycle the ladder must escalate
+    # past tier 1 for (plan `incremental_gate_unification.md` tiers 2-3).
+    for pair in range(ASYMMETRIC_CYCLE_PAIRS):
+        fwd, back = rng.sample(consts, k=2)
+        lines.append(f"function x{pair}_f() {{ return x{pair}_v[0] + {fwd}; }}")
+        # Fresh array literal keeps the statement pure (no S-chain edge)
+        # while still eagerly reading the pair's function binding.
+        lines.append(f"const x{pair}_v = [x{pair}_f, {back}];")
+    lines.extend(
+        f"export {{ {', '.join(batch)} }};" for batch in itertools.batched(exports, EXPORTS_PER_STATEMENT, strict=False)
+    )
+    return Chunk(source="\n".join(lines) + "\n", blocks=blocks)
+
+
+def member_entry(name: str) -> dict[str, object]:
+    return {"name": name, "selector": {"binding": {"name": name}}}
+
+
+def write_corpus(out_root: Path, n_statements: int, seed: int, claim_blocks: int) -> None:
+    snapshot = out_root / "snapshot"
+    snapshot.joinpath("static").mkdir(parents=True, exist_ok=True)
+    extracted = out_root / "extracted"
+    extracted.mkdir(parents=True, exist_ok=True)
+    modules_root = out_root / "modules"
+    modules_root.mkdir(parents=True, exist_ok=True)
+
+    chunk = generate_chunk(n_statements, random.Random(seed))
+    snapshot.joinpath("package.json").write_text(json.dumps({"type": "module"}) + "\n")
+    snapshot.joinpath("static/app.js").write_text(chunk.source)
+    js_list_path = extracted / "js-files.txt"
+    js_list_path.write_text("static/app.js\n")
+
+    logical_modules: dict[str, dict[str, object]] = {"anchors/anchor": {"members": [member_entry("anchor")]}}
+    claimed_blocks = [k for k in chunk.blocks if k <= claim_blocks]
+    for k in claimed_blocks:
+        members = chunk.blocks[k]
+        logical_modules[f"auto_partition/block_{k}"] = {"members": [member_entry(m) for m in members]}
+        yaml_lines = ["members:"]
+        for m in members:
+            yaml_lines += [f"  - name: {m}", "    selector:", "      binding:", f"        name: {m}"]
+        module_yaml = modules_root / f"auto_partition/block_{k}.yaml"
+        module_yaml.parent.mkdir(parents=True, exist_ok=True)
+        module_yaml.write_text("\n".join(yaml_lines) + "\n")
+
+    spec = {
+        "inputs": {"input_root": str(snapshot), "js_list_path": str(js_list_path)},
+        "logical_modules": {"static/app": logical_modules},
+        "chunk_renames": {},
+        "unassigned_mode": {"static/app": {"kind": "inline_in_entry"}},
+        "materialize_logical_modules": {
+            "prune_other_chunks": False,
+            "report_out_dir": str(out_root / "out/reports/tree"),
+            "target_dir": "modules",
+        },
+        "write_js_tree": {"out_dir": str(out_root / "out")},
+    }
+    out_root.joinpath("spec.json").write_text(json.dumps(spec, indent=2) + "\n")
+    claimed = sum(len(chunk.blocks[k]) for k in claimed_blocks)
+    print(
+        f"synthetic corpus written to {out_root}: {n_statements} statements, "
+        f"{len(chunk.blocks)} blocks, {len(claimed_blocks)} claimed modules ({claimed} bindings)"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--statements", type=int, default=10_000)
+    parser.add_argument("--seed", type=int, default=1)
+    parser.add_argument("--claim-blocks", type=int, default=0)
+    args = parser.parse_args()
+    write_corpus(args.out, args.statements, args.seed, args.claim_blocks)
+
+
+if __name__ == "__main__":
+    main()

--- a/devinfra/js/debundle/perf/proposer.md
+++ b/devinfra/js/debundle/perf/proposer.md
@@ -7,51 +7,67 @@ items are deleted.
 
 ## Current state
 
-`modules propose --format json` against the tana `78d928dca7` fixture,
-source-built `-c opt` binary, 2026-05-27:
+The gate-ladder cutover (`plans/incremental_gate_unification.md`,
+PRs #2087/#2090/#2095/#2102) routed the hot boolean merge gate
+through the `RealizabilityIndex`'s tier ladder and deleted the
+kernel-side Pearce–Kelly walk, cone-DFS fallback, and
+`cached_cycles` machinery.
 
-| Metric                     |  Value |
-| -------------------------- | -----: |
-| Wall                       |  3.54s |
-| Proposals                  |     93 |
-| `scc_containing` calls     |     10 |
-| `scc_containing` wall      | 0.041s |
-| `verdict_touching` calls   |      5 |
-| Overlay simulator rebuilds |      5 |
-| Overlay simulator wall     | 0.148s |
-| Diagnostic translations    |      6 |
+The historical baseline corpus (a private downstream fixture, 9709
+owners, measured at 3.54s pre-cutover) is not available to public
+CI. The reproducible public stand-in is the synthetic corpus from
+`perf/gen_synth_corpus.py` (10k statements, seed 1; 10051 owners /
+22019 edges — same scale and shape class). Post-cutover validation
+numbers, `-c opt` binaries, interleaved pre/post runs on one host,
+2026-06-11:
 
-The proposer-latency problem is fixed. A source `fastbuild` binary
-measured 124.31s on the same workload; **never use `fastbuild` numbers
-for Rust wall comparisons** — always build `-c opt`.
+| Corpus variant                                          | Pre-cutover wall | Post-cutover wall | Proposals |
+| ------------------------------------------------------- | ---------------: | ----------------: | --------: |
+| fully residual (`--claim-blocks 0`)                     |         6.7–8.0s |          3.5–3.8s |      1216 |
+| 62 claimed modules (`--claim-blocks 62`, 2461 bindings) |        9.4–10.7s |          2.2–2.3s |       933 |
 
-Gate diagnostics are **not** the active wall problem: SCC lookup,
-simulator rebuild, and diagnostic translation counts are all single
-digits. The next proposer optimization must start from a fresh
-optimized profile, not from pre-fix gate counters.
+Proposal output is byte-identical pre↔post on both variants (the
+cutover's semantic fixes only bite on the cataloged corner shapes —
+none occur in either corpus). Gate-ladder tier distribution
+(`DEBUNDLE_TIMING=1`, post-cutover binary):
+
+| Variant  | Queries | Tier 0 accept | Tier 1 reject | Tier 2 accept | Tier 3 | Tier 1+2 wall |
+| -------- | ------: | ------------: | ------------: | ------------: | -----: | ------------: |
+| residual |    8834 |          8834 |             0 |             0 |      0 |        0.000s |
+| claimed  |    9944 |          6644 |           753 |          2547 |      0 |        0.265s |
+
+This is well inside the plan's ship budget (wall within noise of the
+pre-cutover number; tier-3 simulator builds in single digits;
+tier-1+2 cumulative ≤ 2× the old PK-gate hot path): the post-cutover
+proposer is 1.9× faster on the fully-residual shape and 4.3× faster
+on the claimed shape, tier-3 never fired, and overlay simulator
+rebuilds and `scc_containing` calls were both zero.
+
+**Never use `fastbuild` numbers for Rust wall comparisons** — always
+build `-c opt` (a `fastbuild` binary measured 35× slower on the
+historical fixture).
 
 The hot path asks a boolean question and avoids diagnostic-evidence
-generation:
+generation; the diagnostic path is the same ladder with evidence
+materialization enabled:
 
 ```text
 greedy_merge_to_convergence
 └── merge_preserves_invariants
     └── check_merge_boolean
-        └── would_violate_cycle_gate_after_contract
-            └── merge_creates_new_constraining_cycle
-```
+        └── ladder_decision_for_merge
+            └── realizability_index::ladder_decision_after_moving_owners_touching
+                ├── tier 0: delta-free → cached pre-state verdict
+                ├── tier 1: constraining CondensationOrder (DSU + PK window-DFS)
+                ├── tier 2: I-graph CondensationOrder (scc_containing fallback
+                │           on removal-inside-SCC overlays)
+                └── tier 3: shared EsmEvaluationSimulator over the I-SCC
 
-The full verdict/evidence path remains for `contract` and explicit
-diagnostic queries:
-
-```text
 contract / explicit diagnostic query
 └── would_be_cycles_after_contract
+    ├── ladder_decision_for_merge          (accept → no evidence)
     └── realizability_index::verdict_after_moving_owners_touching
-        └── verdict_with_overlay_touching(to, &overlay)
-            ├── constraining_graph.scc_containing(to)
-            ├── i_graph_view.scc_containing(to)
-            └── build_simulator / translate_verdict_with_owner_modules
+        └── build_simulator / translate_verdict_with_owner_modules
 ```
 
 ## Optimization policy
@@ -88,6 +104,11 @@ cousin `verdict_touching`:
    owner-module vector size, unrealizable-SCC count.
 7. Base-graph snapshot rebuilds: opt-in shadow `tarjan_scc` over each
    stale base graph to estimate snapshot+clone designs.
+8. Gate-ladder per-tier counters: decision counts per
+   `LadderDecision` variant (tier-0 accept/reject, tier-1
+   cycle/rebind reject, tier-2 accepts, tier-3 accept/reject) plus
+   per-tier cumulative wall under `DEBUNDLE_TIMING=1` — the "gate
+   ladder:" / "ladder wall:" stderr lines.
 
 When `DEBUNDLE_TIMING` is unset, normal runs pay only the cheap counter
 path (atomic increments + bounded integer histograms): no
@@ -103,19 +124,22 @@ hot-path hypothesis; keep cheap `O(1)` counters ungated and gate only
 timing / report output / extra traversals behind
 `gate_perf_counters::enabled()`.
 
-How to run:
+How to run (on the reproducible synthetic corpus; substitute your own
+`GRAPH`/`MODULES` for a real corpus):
 
 ```bash
 direnv exec . bash -lc 'bazelisk build //devinfra/js/debundle:debundle \
     -c opt --@rules_rust//:extra_rustc_flag=-Cdebuginfo=1 \
     --remote_download_outputs=toplevel'
+BIN=./bazel-out/k8-opt/bin/devinfra/js/debundle/debundle
 
-GRAPH=/path/to/owner_graph.json
-MODULES=/path/to/spec/modules
+python3 devinfra/js/debundle/perf/gen_synth_corpus.py \
+    --out /tmp/synth --statements 10000 --seed 1 --claim-blocks 62
+"$BIN" run --spec /tmp/synth/spec.json
 
-DEBUNDLE_TIMING=1 ./bazel-out/k8-opt/bin/devinfra/js/debundle/debundle \
-    modules propose \
-    --modules "$MODULES" --graph "$GRAPH" --format json \
+DEBUNDLE_TIMING=1 "$BIN" modules propose \
+    --graph /tmp/synth/out/reports/tree/static/app/owner_graph.json \
+    --modules /tmp/synth/modules --format json \
     > /tmp/propose.json 2> /tmp/timing.txt
 cat /tmp/timing.txt
 ```
@@ -131,44 +155,12 @@ If proposer wall becomes material again, collect a fresh optimized
 profile and fresh `DEBUNDLE_TIMING=1` report and treat that as the new
 source of truth for choosing work.
 
-### #2 — Broaden the boolean gate into `RealizabilityIndex` (conditional)
-
-Only if a fresh profile shows simulator/diagnostic work hot outside the
-quotient cycle gate. Add a
-`would_remain_realizable_after_moving_owners_touching`-style boolean
-query and short-circuit in order:
-
-- cross-gate rebind touching the post-move target rejects;
-- constraining SCC containing the target with size >= 2 rejects;
-- I-SCC size < 2 accepts;
-- I-SCC without an effective constraining pair accepts;
-- only then build/run the simulator.
-
-Keep the full verdict/evidence path as the diagnostics path and as a
-debug oracle.
-
-### #3 — Incremental SCC maintenance on the gate view (conditional)
-
-Only if a fresh profile shows `scc_containing` hot again. See the
-"Conditional SCC gate design" appendix for the V1.5 / V2 designs. The
-narrow snapshot+clone design works iff `base SCCs <= ~1000` and overlay
-`delta.len()` is much smaller than 50; tana's observed shape fits.
-Prefer the broader class-aware gate boundary if it stays reviewable —
-it also removes projection and diagnostic overhead.
-
 ### #4 — Skip `build_simulator` rebuild when inputs are unchanged (conditional)
 
 `build_simulator` has a strict-zero fast path (`overlay_is_simulator_noop`).
 A looser check could reuse the base simulator when the overlay's
 `i_delta` adds no new `(from, to)` pair and only references base edges
 that remain positive. Verify against a fresh profile first.
-
-### #5 — Incrementalize `rebuild_class_to_cycle_indices` (corner case)
-
-`update_cycle_cache_after_merge` calls `rebuild_class_to_cycle_indices`
-after every merge, which clears `class_to_cycle_indices` and re-walks
-the entire `cached_cycles` vec — `O(sum of cycle sizes)` per merge. Only
-matters when `cached_cycles` is non-empty. Defer until profiles show it.
 
 ### #6 — `sync_index_after_merge` to the persistent realizability index
 
@@ -256,104 +248,7 @@ Tighten before the next large peel loop:
 - Do not revive the base-SCC cache + overlay-short-circuit approach. The
   proposer queries the move destination `to`, and candidate overlay
   edges are incident to `to`, so the overlay touches the queried SCC in
-  the representative workload.
-
----
-
-## Appendix: Conditional SCC gate design
-
-Future-plan reference for `OverlayGraphView::scc_containing` and related
-proposer gate work. **Not an active implementation plan** — current
-optimized tana proposer wall is 3.54s and gate diagnostics are not the
-bottleneck. Do not implement incremental SCC maintenance unless a fresh
-optimized profile shows `scc_containing` hot again.
-
-The narrow SCC target replaces this per-query shape:
-
-```text
-O(reachable_forward(to) + reachable_reverse(to))
-```
-
-with an affected-region query over a maintained quotient view:
-
-```text
-O(D + R)
-```
-
-where `D` is the overlay size / moved-owner incident-edge count for one
-candidate and `R` is the target-specific reachable region. Worst-case
-`R` is still the whole quotient graph, so this is a better
-parameterization, not a better theoretical bound.
-
-### V1.5: targeted condensation reachability
-
-Keeps a per-base-graph snapshot:
-
-```rust
-struct BaseSnapshot {
-    sccs: Vec<Vec<ModuleId>>,
-    scc_of: HashMap<ModuleId, usize>,
-    condensation_mult: HashMap<(usize, usize), u32>,
-    condensation_out: Vec<Vec<usize>>,
-    condensation_in: Vec<Vec<usize>>,
-}
-```
-
-Per query: map `to` and overlay endpoints to base SCCs (synthetic
-singleton SCCs for absent endpoints); project module-edge deltas into
-SCC-edge deltas; if an overlay removal zeroes an edge inside one base
-SCC, fall back to the full DFS (the base SCC may split); run forward and
-reverse reachability from `target_scc` over effective condensation
-edges; intersect visited sets and materialize member modules. Lowest-risk
-SCC-only design — keeps the module-projection model, needs only localized
-query changes.
-
-### V2: owner-SCC index plus partition view
-
-The owner graph is constant during `modules propose`; only its
-projection through the current module partition changes. V2 computes
-owner SCCs once and maintains a partition view:
-
-```rust
-struct OwnerSccIndex {
-    owner_sccs: Vec<Vec<OwnerId>>,
-    owner_scc_of: HashMap<OwnerId, usize>,
-    cross_scc_out: Vec<Vec<usize>>,
-    cross_scc_in: Vec<Vec<usize>>,
-}
-
-struct PartitionView {
-    member_count: Vec<HashMap<ModuleId, u32>>,
-    multi_module_sccs: HashSet<usize>,
-    owner_sccs_per_module: HashMap<ModuleId, HashSet<usize>>,
-}
-```
-
-Every owner move updates `PartitionView` in the same push/undo lifecycle
-as `RealizabilityIndex`. Per-overlay queries apply a temporary diff, run
-bidirectional BFS through represented owner SCCs, and materialize the
-target component's modules. Faster steady state than V1.5, but more
-maintenance surface.
-
-### Edge cases to cover
-
-- Overlay endpoints absent from the base graph.
-- Overlay removals that can split one base SCC.
-- Duplicate owner moves in one candidate overlay.
-- Push/undo rollback of `PartitionView` and any boolean index state.
-- Multi-target / non-standard gate transitions that cannot be modeled as
-  one post-merge target module — fall back to scoped push/verdict/undo
-  or model explicitly.
-- Diagnostic drift: boolean pass/reject must stay byte-identical to the
-  full verdict path for emitted proposals and reported blockers.
-
-### Tests and gates before shipping any SCC design
-
-- Unit tests for empty overlays, absent endpoints, base-internal
-  edge-removal fallback, duplicate moves, and rollback.
-- Oracle tests comparing boolean results with the full verdict path
-  across synthetic graphs and the tana fixture.
-- Corpus gate: `modules propose --format json` byte-identical against
-  current head.
-- Benchmark gate: optimized wall improves by >= 3s averaged across
-  interleaved runs, or the change does not ship as a perf fix.
+  the representative workload. The landed `CondensationOrder` ladder
+  (tiers 1–2) is the maintained-SCC design that works here — it answers
+  the gate from the condensation and only falls back to
+  `OverlayGraphView::scc_containing` on removal-inside-SCC overlays.

--- a/devinfra/js/debundle/plans/incremental_gate_unification.md
+++ b/devinfra/js/debundle/plans/incremental_gate_unification.md
@@ -1,5 +1,46 @@
 # Incremental gate unification: an exact and fast merge gate
 
+> **TOMBSTONE (2026-06-11): completed.** All five PRs landed —
+> #2087 (predicate pinning + reference), #2090 (`CondensationOrder`),
+> #2095 (tier ladder in the index), #2102 (cutover + deletions:
+> `peel/topo_order.rs`, `cone_dfs_creates_new_cycle`, the
+> `cached_cycles` family, and the multi-target fallback are gone),
+> and the PR 5 perf-validation/doc-sync pass. The ladder decides the
+> hot gate; docs/design.md ("Cost and the tier ladder", "Why not
+> Pearce–Kelly verbatim") describes the landed shape and
+> `perf/proposer.md` carries the post-cutover baseline (1.9–4.3×
+> faster than the PK gate on the synthetic gaffer-scale corpora,
+> tier-3 hits zero, byte-identical proposals). The body below is
+> retained as design history only.
+>
+> Open-question resolutions:
+>
+> 1. **Atomic-unit anomaly** — confirmed and fixed: the
+>    deterministic fixtures in `peel/gate_differential_test.rs` pin
+>    the residual-pile over-rejection and its tier-0 fix; whether a
+>    real corpus ever hit it is moot now that the predicate is exact.
+> 2. **Inter-cell cycle policing** — still open, deliberately not
+>    re-encoded in the gate. `peel/factorize.rs`'s
+>    `BlockedResidualDependency` status polices mutually-cyclic
+>    residual cells downstream; if that proves insufficient at
+>    `bindings assign` time, the factorizer needs a render-time
+>    cell-DAG check (a proposal-shape invariant, not a realizability
+>    one).
+> 3. **Diff envelope for the corpus gate** — resolved empirically:
+>    PR 4's e2e/corpus diffs all traced to the cataloged semantic
+>    fixes, and the PR 5 synthetic-corpus comparison is
+>    byte-identical pre↔post. Gaffer-scale diff review happens at the
+>    next private re-peel.
+> 4. **Tier-3 worst case** — accepted and measured: zero tier-3
+>    builds on the synthetic corpora, single digits on the historical
+>    fixture. Revisit only with a profile, per `perf/proposer.md`'s
+>    optimization policy.
+> 5. **`rank_candidate` byte 0** — decided in PR 4: the `O(α)` DSU
+>    probe (`modules_share_constraining_multi_scc`) replaced the
+>    stale cache; ranked-order drift on already-unrealizable seeds is
+>    accepted (rationale at the `rank_candidate` key-byte comment in
+>    `peel/quotient.rs`).
+
 Design for replacing the peel kernel's hot boolean merge gate — today a
 constraining-only Pearce–Kelly walk that is blind to Pass-2 — with a
 tier-laddered evaluation of the realizability primitive itself: exactly

--- a/devinfra/js/debundle/plans/sanitization_program_2026_06.md
+++ b/devinfra/js/debundle/plans/sanitization_program_2026_06.md
@@ -40,13 +40,16 @@ perf baseline for the program.
    only after untangling its index entanglement — see CODE_REVIEW). Pure
    moves, no behavior change; makes the wished-for boundaries
    compiler-enforced and shrinks rebuild times.
-3. **Decision batch (maintainer, ≤1h total).** Two calls remain open and
-   gate later tracks: PK-gate vs realizability-index for the peel kernel;
-   delete-or-implement the unreachable multi-target fallback in
-   `peel/quotient.rs`. Both have backlog entries with the trade-offs.
-   (Decided 2026-06: `landable_today` for cross-residual proposals —
-   blocked rows are not landable, implemented; `BindingId` interning —
-   deferred, perf-triggered, see the backlog's decided-state note.)
+3. **Decision batch (maintainer, ≤1h total). _(Done 2026-06.)_** All
+   four calls are closed: PK-gate vs realizability-index — resolved by
+   the gate-ladder series (`plans/incremental_gate_unification.md`,
+   tombstoned; PRs #2087/#2090/#2095/#2102 plus the perf-validation
+   doc-sync pass), which routed the hot gate through the index's tier
+   ladder and deleted the kernel PK walk; the unreachable multi-target
+   fallback in `peel/quotient.rs` — deleted in #2102 (single-target
+   assert in its place); `landable_today` for cross-residual proposals
+   — blocked rows are not landable, implemented; `BindingId` interning
+   — deferred, perf-triggered, see the backlog's decided-state note.
 
 ## Track B — RenameLedger (weeks 1–2)
 
@@ -139,8 +142,10 @@ fixes.
    mutation/overlay sequences vs `tarjan_scc` brute force) and
    `lowering/rename_ledger_proptest.rs` (public seal contract). The
    remaining F1 step is migrating the gate-differential harness
-   (`peel/gate_differential_test.rs`) to proptest strategies,
-   scheduled with gate-ladder PR 4+.
+   (`peel/gate_differential_test.rs`) from its deterministic xorshift
+   sweep to proptest strategies — unblocked now that the gate-ladder
+   series has landed (the harness already asserts strict
+   gate-vs-reference equality post-cutover).
 2. **Lemma pinning**: named tests for Lemmas 1/3/4/5 (only Lemma 2 has
    them); extend the #2071 Node-differential to a fixture sweep.
 3. **Excalidraw public smoke** (TODO's big standing item): the

--- a/devinfra/js/debundle/realizability/incremental_quotient.rs
+++ b/devinfra/js/debundle/realizability/incremental_quotient.rs
@@ -338,8 +338,8 @@ impl<'a> OverlayGraphView<'a> {
         let overlay_empty = self.delta.is_empty();
         // Classify each overlay entry as addition vs removal in
         // the effective graph. Cheap: linear in `delta.len()`
-        // which is small by design (<50 in practice; see
-        // tana measurements in `perf/proposer.md`).
+        // which is small by design (<50 in practice; see the
+        // corpus-shape notes in `perf/proposer.md`).
         let mut additions = 0usize;
         let mut removals = 0usize;
         for &(from, to) in self.delta.keys() {


### PR DESCRIPTION
Final PR of `plans/incremental_gate_unification.md` §8, closing out the gate-ladder series (#2087 predicate pinning, #2090 `CondensationOrder`, #2095 tier ladder, #2102 cutover + deletions).

## Perf validation (§7.5)

The historical baseline fixture (private downstream corpus, 9709 owners, 3.54s pre-cutover) is not available here — noted in `perf/proposer.md`. This PR adds a reproducible public stand-in at the documented gaffer scale: `perf/gen_synth_corpus.py` (10051 owners / 22019 edges; block-clustered eager refs, lazy minority, at-init calls, asymmetric I-cycles, sampled exports; `--claim-blocks N` bakes a realizable prefix of pre-existing spec modules into the emitted owner graph).

Interleaved `-c opt` runs of `modules propose`, pre-cutover (`3113ee3b9`) vs post-cutover (`e37d965c4`) binaries, same host:

| Corpus variant | Pre-cutover wall | Post-cutover wall | Speedup | Proposals |
|---|---:|---:|---:|---:|
| fully residual (`--claim-blocks 0`) | 6.7–8.0s | 3.5–3.8s | ~1.9× | 1216, byte-identical |
| 62 claimed modules (`--claim-blocks 62`, 2461 bindings) | 9.4–10.7s | 2.2–2.3s | ~4.3× | 933, byte-identical |

Gate-ladder tier distribution (`DEBUNDLE_TIMING=1`, post binary):

| Variant | Queries | Tier 0 accept | Tier 1 reject | Tier 2 accept | Tier 3 | Tier 1+2 wall |
|---|---:|---:|---:|---:|---:|---:|
| residual | 8834 | 8834 | 0 | 0 | 0 | 0.000s |
| claimed | 9944 | 6644 | 753 | 2547 | 0 | 0.265s |

**vs the §7.5 ship budget:** wall is far inside "within run-to-run noise" (it *improved* 1.9–4.3× — the deleted cone-DFS fallback and `cached_cycles` maintenance were the dominant pre-cutover gate cost on these shapes); tier-3 simulator builds in single digits (zero; overlay simulator rebuilds and `scc_containing` calls also zero); tier-1+2 cumulative 0.265s, trivially ≤ 2× the old PK hot path. Outputs are byte-identical pre↔post on both corpora — the cutover's semantic fixes only fire on the cataloged corner shapes.

## Doc sync

- **docs/design.md** — "Cost and the upgrade path" → "Cost and the tier ladder", rewritten for the landed ladder (tiers 0–3, one entry point / two output shapes, single-target assert); "Why not Pearce–Kelly verbatim" loses the relaxed-invariant paragraph: the kernel keeps **no** decision-making derived state, the PK core survives inside `CondensationOrder`, `rank_candidate` byte 0 reads the DSU probe.
- **perf/proposer.md** — new public baseline + tier tables; ladder call tree; per-tier counters added to the counter reference; "How to run" uses the synthetic corpus; deleted resolved backlog #2 (implemented as the ladder), #3 + appendix V1.5/V2 (subsumed by `CondensationOrder`), #5 (died with `cached_cycles`).
- **ARCHITECTURE_BACKLOG.md** — verified clean: both gate entries (PK-vs-index, multi-target fallback) were already deleted by #2102; nothing stale remains.
- **plans/incremental_gate_unification.md** — tombstoned (completed 2026-06-11) with per-open-question resolution notes; Q2 (inter-cell cycle policing) is recorded as the one genuinely still-open follow-up, owned by the factorizer layer.
- **plans/sanitization_program_2026_06.md** — Track A3 decision batch marked done; Track F1 note updated (gate-differential proptest migration unblocked, still open).
- **realizability/incremental_quotient.rs** — one dangling comment pointer to the removed tana measurements fixed.

Leftover-reference grep: the remaining `TopoOrder`/`cached_cycles` mentions are intentional provenance notes (`condensation_order.rs` header, `rank_candidate` byte-0 comment, proposer.md cutover summary).

Tests: `bbr test //devinfra/js/debundle/...` — 100/100 green (`BAZEL_TEST_INVOCATIONS=buildbuddy:91d666bb-687a-4791-90e9-5bc6a716ef4a`).

https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk)_