### PR TITLE
wayback-cache: raise CDX cache TTL 7d -> 365d

### DIFF
--- a/cluster/k8s/wayback-cache/config/nginx.conf
+++ b/cluster/k8s/wayback-cache/config/nginx.conf
@@ -85,12 +85,17 @@ http {
             proxy_pass http://127.0.0.1:8081;
         }
 
-        # CDX index queries are NOT immutable: IA backfills old crawls and
-        # applies takedowns retroactively. A 7d staleness bound keeps repeat
-        # lookups off IA while still tracking the index; the per-run
-        # evidence manifest — not this cache — is the reproducibility record.
+        # CDX index queries are NOT strictly immutable (IA backfills old crawls
+        # and applies takedowns retroactively), but every query clamps to a
+        # historical `to=<as_of>` timestamp, so "closest capture ≤ as_of" is
+        # effectively stable — backfill of old crawls and takedowns are rare.
+        # CDX is the cache's bottleneck: highest-volume path, heavily throttled
+        # at IA (10-25s/query), and the dominant source of cold-miss 502s. A
+        # long (1y) TTL keeps that traffic off archive.org across runs; the
+        # per-run evidence manifest — not this cache — is the reproducibility
+        # record, so staleness here costs nothing.
         location /cdx/ {
-            proxy_cache_valid 200 7d;
+            proxy_cache_valid 200 365d;
             proxy_pass http://127.0.0.1:8081;
         }
     }


### PR DESCRIPTION
Raises the wayback-cache CDX index cache TTL from **7d → 365d**.

## Why

Measured during a loom/gym eval run, the CDX index API is the cache's bottleneck:

| path | client reqs | cold misses → IA | hit rate |
|------|---:|---:|---:|
| `/web` content | 533 | 203 | 62% |
| **`/cdx` index** | 1536 | 1104 | **28%** |

And of the 1104 cold CDX misses, **only 181 succeeded — 777×502, 117×503, 28×504** (~84% failure). archive.org refuses connections under the CDX query burst (`connect() failed (111: Connection refused)`), and CDX is 3× the volume of content fetches.

## Change

`proxy_cache_valid 200 7d` → `365d` on the `/cdx/` location.

Each CDX query clamps to a historical `to=<as_of>` timestamp, so "closest capture ≤ as_of" is effectively stable (IA backfill of old crawls and takedowns are rare). The per-run evidence manifest — not this cache — is the reproducibility record, so a long staleness bound costs nothing while keeping warmed CDX lookups off archive.org across runs instead of expiring weekly.

## Rollout

No manual action: the deployment has `reloader.stakater.com/auto` and the config is a hash-suffixed `configMapGenerator`, so Flux applying the changed `nginx.conf` rolls the pod automatically.

https://claude.ai/code/session_01AXSFxfCXddADoSKTjgF5Nz

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXSFxfCXddADoSKTjgF5Nz)_