### PR TITLE
debundle: delete the defensive rename era; finalize ledger architecture (PR 5/5)

### DIFF
--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -228,185 +228,33 @@ mock browser bundle. Extend to:
 - Unusual dynamic import forms.
 - HTML/runtime asset layouts outside the current corpus.
 
-## Rename pipeline: collect → validate → execute _once_
+## Rename pipeline
 
-Scope-aware down-payments have landed in `lowering/visitors.rs` /
-`lowering/naturalize.rs` / `lowering/lower.rs`:
+The collect → seal → execute-once `RenameLedger` pipeline landed 2026-06
+(PRs #2086/#2091/#2101/#2106 plus the PR-5 defensive-era cleanup);
+`lowering/rename_ledger.rs`'s module doc is the architecture reference.
+Ideas it unlocked, still open:
 
-- **Source shadowing**: the in-place rename visitors
-  (`IdentifierRenamer`, `RenameAndShorthandNaturalizer`) carry a
-  `RenameScopeStack` and suppress a rename inside subtrees that re-bind
-  the source name.
-- **Target capture**: the same scope stack tracks rename TARGETS; a
-  rename whose target is shadowed at the reference is withheld and
-  recorded in the visitor's `captured` set, which every caller checks
-  and rejects on (no silent capture, no partial application). Heuristic
-  naturalizer renames pre-filter targets bound anywhere in the deriving
-  node's subtree and are suppressed entirely instead.
-- **Shorthand expansion**: renaming a binding read/declared through
-  `{ a }` / `const { a } = o` shorthand expands to the key-value form
-  (`{ a: b }`) so property keys survive the rename.
-- **Labels**: label idents and their `break`/`continue` references are
-  excluded from renaming (separate namespace).
-- **Era-keyed consumers**: export locals and `binding_comments` keys
-  remap through the module-scope (plan-driven) rename map only —
-  `NaturalizedRenames` splits it from the merged heuristic map so
-  scope-local heuristic renames can no longer remap a top-level export
-  specifier or orphan a member comment.
-
-**PR 1 landed (2026-06):** `lowering/rename_ledger.rs` holds the intent
-buffer — `RenameLedger` accumulating `RenameIntent { scope, from: Id, to,
-origin }` with scopes `Chunk | Module(ModuleId) | Function(span)` and
-priority derived from origin (explicit > import-induced > heuristic).
-`seal()` hard-errors when same-priority intents disagree on one binding's
-target (naming both contributors) and projects the surviving intents into
-the same maps the pre-ledger code built. The two explicit contributors
-are converted (spec `chunk_renames`; plan-driven `export_name`s); the
-remaining-contributor inventory lives in `rename_ledger.rs`'s module doc.
-
-**PR 2 landed (2026-06):** every remaining contributor submits intents
-and every application site consumes a sealed projection — heuristic
-bound-source per-scope renames (`Function` scope; derived by
-`ScopedHeuristicNaturalizer` over a scratch clone, replayed by
-`SealedScopeRenameApplier`), heuristic free-source return-object aliases
-(`Module` scope, per deriving function), entry- and module-side
-import-local mints (`Chunk` / `Module` scope, `ImportInduced`), and
-auto-grown residual public-export minting (new `EntryPublicExports`
-scope). Because contributor derivation still depends on earlier
-contributors' application, PR 2 seals at phase boundaries — one ledger
-instance per former private map. Two previously silent last-write-wins
-shapes are now seal-time hard errors: two deriving functions
-free-aliasing one source to different targets, and two import-local
-mints disagreeing on one binding.
-
-**PR 3 landed (2026-06):** seal is the single validation point.
-`RenameLedger::seal` takes per-scope occupancy facts (`SealValidation` /
-`ScopeOccupancy`: root vs nested binding names from `scope_names.rs`,
-the rename walk's observed capture pairs, deriving-subtree bound/mention
-sets for `Function` scopes) and applies all target validation there:
-explicit failures reproduce the pre-ledger hard errors (`invalid
-chunk_renames spec`, `collides with an existing top-level local`,
-`captured by a nested binding`, …), heuristic failures drop silently
-(over-suppression OK, capture never), import-induced failures are
-internal invariant violations. Cross-priority disagreement resolves
-silently by priority; same-priority disagreement stays a hard error.
-`$N` minting is a ledger service (`mint` / `seed_taken` / `claim` own
-the per-scope taken sets; `import_emit.rs` and `exports.rs` request
-mints). The per-module naturalize ledger absorbed the plan-driven
-explicit renames, so one seal resolves explicit-vs-heuristic priority,
-the module-global target-collision rule (`merge_module_renames`), and
-occupancy. Application sites now only `debug_assert!` seal's no-capture
-guarantee; what still validates at application (and the remaining seal
-points PR 4 collapses) is inventoried in `rename_ledger.rs`'s module-doc
-"Seal points" section.
-
-**PR 4 landed (2026-06):** collect → seal → execute-once per ledger.
-No pre-seal trial application remains: capture facts reach seal from
-the **un-renamed** tree (the read-only `RenameCaptureProbe` over
-`RenameLedger::pending_renames_by_name` for the entry body; the derive
-clone's candidate walk for module bodies), the post-seal rename pass is
-the only mutation of each scope unit's AST, and the hand-maintained
-candidate-map mirrors are gone. The export-growth ledger merged into
-`lower_chunk`'s chunk ledger (one seal validates `Chunk` +
-`EntryPublicExports` together), collapsing five ledger instances to
-four. `plan_module_reference_needs`' linear reverse `.find` over the
-heuristic rename map is replaced by the sealed map's inverse projection
-(`RuntimeImportLookup::original_by_renamed`; injective by seal's
-target-collision rules). Documented blockers that stay (see
-`rename_ledger.rs` "Seal points"): the naturalizer's derive clone
-(enclosing scopes' subtree facts must reflect nested fired renames —
-scope-sensitive, not expressible as set transformations of sealed
-maps), the per-plan import ledger (collection needs post-naturalize
-facts plus entry's grown exports, which need every module's facts —
-a cross-module phase cycle), and `cross_module_chunk_renames`' separate
-application (it composes _sequentially_ with import-local mints; a
-single seal's priority rule would mis-resolve `x → y$1` vs `x → y`).
-
-Decisions taken (formerly the open-questions subsection below):
-
-1. **Same-priority conflicts are hard errors at seal**, naming both
-   contributors — silent suppression is the trap the ledger closes.
-2. **The `$N`-suffix minting scheme stays as-is** now that
-   `disambiguate_import_locals`' minting is a ledger service (PR 3);
-   readability is a separate, later naturalizer concern.
-3. **Structural-mutation contract: no structural moves between seal and
-   execute.** Most moves already happen pre-seal (the materializer seals
-   after `ChunkPlan` finalization); the `&Module` type-level barrier for
-   non-execute passes lands with the execute-once pass.
-
-Remaining PRs:
-
-- **PR 5 — cleanup + the deep cuts PR 4 documented**: delete the
-  defensive era where seal's guarantee dominates (`captured` sets on
-  the executors, `drop_subtree_captured_targets` where dominated by
-  seal's subtree validation); attack the documented blockers — merge
-  the per-plan import ledger by planning references off un-renamed
-  body facts plus sealed-map reasoning at import emission (mind the
-  mint-seeding suffix-mint corner cases), fold
-  `cross_module_chunk_renames` into the sealed pipeline without
-  breaking its sequential composition with import-local mints, and key
-  the executor by hygiene `Id` end-to-end (deleting the seal-output
-  `*_by_name` string projection — requires emitting import/export
-  decls under real contexts instead of `new_no_ctxt`). The
-  `merged`/`module_scope` split stays as long as free-source aliases
-  apply function-locally while their intents live at `Module` scope.
-
-The architecture sketch below remains the reference for PR 5.
-
-The naturalizer / lowerer currently mutates identifiers in place across
-several independently-discovered passes and lets every downstream consumer
-(import planning, cross-module binding lookup, fact collection,
-source-map fragment emission, export tables) read whatever name happens
-to exist when _it_ runs. The problematic shape is a rename in one layer
-followed by a downstream layer keying off the wrong-era name. Localized
-defensive patches on individual consumers leave the same trap waiting
-for the next consumer that does not know about the rename.
-
-The proposed architectural fix is a single **collect → validate → execute
-(once)** rename pipeline:
-
-- **Collect**: every rename contributor submits _intents_ into a single
-  buffer instead of mutating the AST. Contributors include explicit
-  spec-specified renames, naturalizer heuristics (return-object alias
-  inference, shorthand-collapse readback, future readable-name
-  autonaming), import-induced renames (`{ sA as propKeyA }`),
-  collision-resolution renames, and chunk-level renames produced by
-  factorize. Each intent is `(scope, original_name, new_name, reason,
-priority, invariants_it_assumes)`.
-
-- **Validate**: resolve conflicts deterministically before any AST
-  mutation. Priority order is explicit > import-induced > heuristic.
-  Surface contradictions (`sA → propKeyA` _and_ `sA → propKeyB` in the
-  same scope) as hard errors at validation time, not as silent
-  last-write-wins behavior at AST mutation time. Output is a stable,
-  read-only mapping `(scope, original_name) → final_name` and the
-  inverse `(scope, final_name) → original_name`.
-
-- **Execute once**: one pass applies the resolved mapping to the AST
-  _and_ updates every fact table (`runtime_imports`, `referenced_idents`,
-  export tables, source-map fragments, cross-module binding indexes) in
-  lockstep, keyed by the original name. After execute, no later pass
-  invents a rename — every consumer that needs to bridge between
-  pre-rename and post-rename names consults the same finalized mapping.
-
-Direct consequence: the family of "X-layer renamed it, Y-layer didn't
-notice" bugs collapses to one architectural boundary. Existing
-defensive reverse-lookups and path sanitizers can become ordinary
-mapping/path-building code once the final mapping makes body ASTs,
-runtime imports, and report tables agree before planning runs.
-
-Remaining prerequisite work (the scope model landed with PR 1 and all
-contributors collect through the ledger as of PR 2 — see
-`lowering/rename_ledger.rs`):
-
-1. Inventory every downstream consumer that today reads identifier
-   names off the AST or off pre-rename fact maps. Same call sites that
-   currently need defensive bridging.
-
-2. Design must not block on landing small defensive fixes. Land them
-   case by case as bugs are discovered. Removing redundant defensive
-   patches is part of the pipeline-landing cleanup, not the architecture
-   work itself.
+- **Id-keyed rename executor.** Seal output is still projected to bare
+  syms (`SealedRenames::*_by_name`) because the application visitors are
+  string-keyed. Deleting the projection requires (a) emitting
+  import/export decls under real syntax contexts instead of
+  `Ident::new_no_ctxt` — today a single rename must hit both a no-ctxt
+  emitted import local and the real-ctxt body references, which only
+  sym-keyed application can do — and (b) hygiene-resolving the
+  `Function`-scope heuristic sources (currently keyed
+  `(sym, SyntaxContext::empty())`). Until then the by-name projection is
+  the executor boundary; its two-contexts-one-sym assert is the tripwire.
+- **Aggressive auto-naturalization.** Now safe to build: every rename
+  flows through one seal, so a new auto-naming heuristic contributor
+  (readable names for still-minified bindings, driven by the
+  unrenamed-symbol priority-queue side output) only needs to submit
+  intents plus deriving-subtree facts — conflict resolution, occupancy,
+  and capture validation come for free, and the
+  renamed-it/didn't-notice miscompile class (#2045) is unrepresentable.
+- **Type-level structural-move barrier.** The "no structural moves
+  between seal and execute" contract is convention-held; making
+  non-execute passes take `&Module` would let the compiler enforce it.
 
 ## CLI scripting surface
 

--- a/devinfra/js/debundle/lowering/lower.rs
+++ b/devinfra/js/debundle/lowering/lower.rs
@@ -1007,12 +1007,12 @@ fn lower_single_plan(
     });
     time_phase!(timings, "module.final_exports", {
         if let Some(exports) = &selected_exports_by_module[index] {
-            // Export locals remap through `module_scope` only: heuristic
-            // renames are scope-local and never rename the top-level
-            // declaration an export specifier refers to, so mapping
-            // through the merged map can emit `export { x as y }` for an
-            // `x` that was never declared (a load-time SyntaxError).
-            let mut exports = final_module_exports(exports, &local_renames.module_scope);
+            // Export locals remap through the explicit map only: heuristic
+            // renames never rename the top-level declaration an export
+            // specifier refers to, so mapping through the merged map can
+            // emit `export { x as y }` for an `x` that was never declared
+            // (a load-time SyntaxError).
+            let mut exports = final_module_exports(exports, &local_renames.explicit);
             exports.extend(
                 import_member_exports
                     .iter()
@@ -1032,7 +1032,7 @@ fn lower_single_plan(
             entry_file,
             source_path,
         };
-        build_module_output(plan, body, &local_renames.module_scope, &output_context)
+        build_module_output(plan, body, &local_renames.explicit, &output_context)
     });
     Ok((file, record, lowering, timings))
 }
@@ -1040,7 +1040,7 @@ fn lower_single_plan(
 fn build_module_output(
     plan: &ModulePlan,
     body: Vec<ModuleItem>,
-    module_scope_renames: &BTreeMap<String, String>,
+    explicit_renames: &BTreeMap<String, String>,
     context: &ModuleOutputContext<'_>,
 ) -> (JsFile, (String, FileRole), SelectedModuleLowering) {
     let mut sorted_plan_bindings: Vec<(&String, &String)> = plan.bindings.iter().collect();
@@ -1087,14 +1087,14 @@ fn build_module_output(
     // `plan.binding_comments` is keyed by the member's ORIGINAL binding
     // name, but `attach_binding_comments` matches the names the emitted
     // declarations carry AFTER naturalization renamed them — re-key
-    // through the applied module-scope renames or renamed members lose
+    // through the applied explicit renames or renamed members lose
     // their comments.
     let binding_comments: BTreeMap<String, String> = plan
         .binding_comments
         .iter()
         .map(|(binding, comment)| {
             (
-                module_scope_renames
+                explicit_renames
                     .get(binding)
                     .cloned()
                     .unwrap_or_else(|| binding.clone()),

--- a/devinfra/js/debundle/lowering/naturalize.rs
+++ b/devinfra/js/debundle/lowering/naturalize.rs
@@ -44,25 +44,28 @@
 
 use swc_common::Span;
 
-use super::scope_names::{
-    BindingNameCollector, collect_binding_names_in, collect_nested_binding_names,
-    collect_occupied_local_names,
-};
+use super::scope_names::{collect_nested_binding_names, collect_occupied_local_names};
 use super::util::is_valid_js_identifier;
 use super::*;
 
-/// The rename maps `naturalize_module_body` applied, split by scope.
+/// The rename maps `naturalize_module_body` applied, split by what may
+/// consume them. The split is final design, not a transition state:
+/// free-source heuristic aliases rewrite references function-locally
+/// without renaming any top-level declaration, so the two consumer
+/// families need different maps (see the ledger module doc's
+/// "Boundaries that validate at application").
 pub(super) struct NaturalizedRenames {
-    /// Plan-driven + heuristic, original → readable. The reverse lookup
-    /// for bridging post-rename body syms back to pre-rename fact-table
-    /// keys (`RuntimeImportLookup`).
+    /// Plan-driven + surviving free heuristics, original → readable. The
+    /// reverse lookup for bridging post-rename body syms back to
+    /// pre-rename fact-table keys (`RuntimeImportLookup`).
     pub(super) merged: BTreeMap<String, String>,
-    /// Plan-driven renames applied module-wide to top-level declarations.
-    /// The ONLY map export locals and binding-comment keys may be remapped
-    /// through: heuristic entries are scope-local and never rename a
-    /// top-level declaration, so mapping a top-level name through `merged`
-    /// can remap an export/comment whose declaration kept its name.
-    pub(super) module_scope: BTreeMap<String, String>,
+    /// Plan-driven (explicit) renames only — the renames that actually
+    /// rename a top-level declaration module-wide. The ONLY map export
+    /// locals and binding-comment keys may be remapped through: heuristic
+    /// entries never rename a top-level declaration, so mapping a
+    /// top-level name through `merged` can remap an export/comment whose
+    /// declaration kept its name.
+    pub(super) explicit: BTreeMap<String, String>,
 }
 
 /// Collect each plan's spec-driven `export_name` renames into the ledger
@@ -190,7 +193,7 @@ pub(super) fn naturalize_module_body(
     // scopes' subtree facts (bound/mention sets) must reflect the nested
     // scopes' fired renames, and a flat set transformation of the sealed
     // nested maps cannot reproduce the scope-sensitive application the
-    // clone walk performs (see TODO.md "Rename pipeline", PR-5 notes).
+    // clone walk performs (see the ledger module doc's "Derive clone").
     let mut derive_body = body.to_vec();
     let mut plan_captured = BTreeSet::new();
     if plan_driven.is_empty() {
@@ -233,17 +236,17 @@ pub(super) fn naturalize_module_body(
     // heuristic maps in the same order the derive pass fired them
     // (children first), so each scope's map applies to the same
     // intermediate tree state the derivation validated against.
-    let module_scope = sealed.module_explicit_renames_by_name(module);
+    let explicit = sealed.module_explicit_renames_by_name(module);
     debug_assert_eq!(
-        module_scope, plan_driven,
+        explicit, plan_driven,
         "sealed module-wide explicit renames diverged from the candidate map the derive clone applied",
     );
-    if module_scope.is_empty() {
+    if explicit.is_empty() {
         for item in body.iter_mut() {
             item.visit_mut_with(&mut ShorthandNaturalizer);
         }
     } else {
-        let mut naturalizer = RenameAndShorthandNaturalizer::new(&module_scope);
+        let mut naturalizer = RenameAndShorthandNaturalizer::new(&explicit);
         for item in body.iter_mut() {
             item.visit_mut_with(&mut naturalizer);
         }
@@ -260,7 +263,7 @@ pub(super) fn naturalize_module_body(
 
     Ok(NaturalizedRenames {
         merged: sealed.module_renames_by_name(module),
-        module_scope,
+        explicit,
     })
 }
 
@@ -274,10 +277,10 @@ pub(super) fn naturalize_module_body(
 /// enclosing scopes derive against the post-rename nested state —
 /// exactly the pre-ledger derive-and-apply order. The clone mutation
 /// uses a local preview of seal's rules ([`Self::validated_bound`] +
-/// `drop_subtree_captured_targets`), so the clone and the sealed output
-/// agree. The clone is what makes the enclosing scopes' subtree facts
-/// reflect nested fired renames precisely — see the ledger module doc's
-/// "Seal points" for why set-level reasoning can't replace it.
+/// the free-copy bound-target filter), so the clone and the sealed
+/// output agree. The clone is what makes the enclosing scopes' subtree
+/// facts reflect nested fired renames precisely — see the ledger module
+/// doc's "Derive clone" for why set-level reasoning can't replace it.
 /// Free-source renames fire only when they survived the module-global
 /// collision rules (`free_allowed`). A rename derived from one scope
 /// never leaks into a sibling/parent scope, and
@@ -576,32 +579,11 @@ impl ScopedHeuristicNaturalizer<'_> {
     }
 }
 
-/// Drop heuristic renames whose target `node`'s subtree binds. Applying
-/// such a rename would either collide with the binding or be suppressed
-/// only inside the binding's scope — leaving the declaration renamed but
-/// some references not (a silent capture/miscompile). Heuristic renames
-/// are cosmetic, so whole-entry suppression is the sound fallback.
-fn drop_subtree_captured_targets<N>(
-    local: BTreeMap<String, String>,
-    node: &N,
-) -> BTreeMap<String, String>
-where
-    N: VisitWith<BindingNameCollector>,
-{
-    if local.is_empty() {
-        return local;
-    }
-    let bound = collect_binding_names_in(node);
-    local
-        .into_iter()
-        .filter(|(_, to)| !bound.contains(to))
-        .collect()
-}
-
-/// Debug-time invariant check after a heuristic scope-local rename pass:
-/// seal's per-scope target validation (target absent from the subtree's
-/// mentions / bound names) makes captures impossible. A non-empty
-/// `captured` set means seal's guarantee was violated.
+/// Debug-time invariant tripwire after the post-seal heuristic
+/// scope-local executor pass: seal's per-scope target validation (target
+/// absent from the subtree's mentions / bound names) makes captures
+/// impossible. A non-empty `captured` set means seal's guarantee was
+/// violated.
 fn assert_no_heuristic_capture(renamer: &RenameAndShorthandNaturalizer<'_>) {
     debug_assert!(
         renamer.captured.is_empty(),
@@ -642,12 +624,17 @@ impl VisitMut for ScopedHeuristicNaturalizer<'_> {
         self.classify_function_aliases(function, &facts, &mut bound, &mut free);
         // Preview of seal's per-scope rules, deciding what fires on this
         // clone. Free-source aliases get no `mentions` check, but any
-        // whose target the subtree binds is dropped: applying one would
-        // be suppressed only inside the re-binding scope, leaving a
-        // partially renamed body. (Bound-source renames are covered by
-        // `validated_bound`, which rejects targets the subtree so much
-        // as mentions.)
-        let mut local = drop_subtree_captured_targets(free.clone(), &*function);
+        // whose target the subtree binds is dropped — seal's free-copy
+        // rule, read off the same `facts.bound` set submitted to it:
+        // applying one would be suppressed only inside the re-binding
+        // scope, leaving a partially renamed body. (Bound-source renames
+        // are covered by `validated_bound`, which rejects targets the
+        // subtree so much as mentions.)
+        let mut local: BTreeMap<String, String> = free
+            .iter()
+            .filter(|(_, to)| !facts.bound.contains(to.as_str()))
+            .map(|(from, to)| (from.clone(), to.clone()))
+            .collect();
         local.extend(self.validated_bound(bound.clone(), &facts));
         self.submit_scope_intents(function.span, &bound, &free, facts);
         if local.is_empty() {
@@ -661,7 +648,6 @@ impl VisitMut for ScopedHeuristicNaturalizer<'_> {
         let mut renamer = RenameAndShorthandNaturalizer::new(&local);
         function.params.visit_mut_with(&mut renamer);
         rename_root_body(&mut renamer, function.body.as_mut());
-        assert_no_heuristic_capture(&renamer);
     }
 
     fn visit_mut_arrow_expr(&mut self, arrow: &mut ArrowExpr) {
@@ -682,7 +668,6 @@ impl VisitMut for ScopedHeuristicNaturalizer<'_> {
             BlockStmtOrExpr::BlockStmt(block) => rename_root_body(&mut renamer, Some(block)),
             BlockStmtOrExpr::Expr(expr) => expr.visit_mut_with(&mut renamer),
         }
-        assert_no_heuristic_capture(&renamer);
     }
 
     fn visit_mut_constructor(&mut self, constructor: &mut Constructor) {
@@ -700,7 +685,6 @@ impl VisitMut for ScopedHeuristicNaturalizer<'_> {
             param.visit_mut_with(&mut renamer);
         }
         rename_root_body(&mut renamer, constructor.body.as_mut());
-        assert_no_heuristic_capture(&renamer);
     }
 }
 

--- a/devinfra/js/debundle/lowering/rename_ledger.rs
+++ b/devinfra/js/debundle/lowering/rename_ledger.rs
@@ -1,12 +1,28 @@
-//! `RenameLedger` — the intent buffer of the collect → validate →
-//! execute-once rename pipeline (sanitization program Track B; TODO.md
-//! "Rename pipeline: collect → validate → execute _once_").
+//! `RenameLedger` — the collect → seal → execute-once rename pipeline.
 //!
-//! Rename contributors submit [`RenameIntent`]s instead of building their
-//! own maps; [`RenameLedger::seal`] validates the intents and freezes them
-//! into [`SealedRenames`], whose queries reproduce exactly the maps the
-//! pre-ledger code built so the existing application sites (the
-//! string-keyed rename visitors in `visitors.rs`) stay unchanged.
+//! Every rename a lowered chunk applies flows through one architectural
+//! boundary: contributors submit [`RenameIntent`]s during the collect
+//! phase instead of building their own maps, [`RenameLedger::seal`]
+//! validates the intents and freezes them into the read-only
+//! [`SealedRenames`], and one post-seal executor pass per scope unit is
+//! the only mutation of that unit's AST. No pass invents a rename after
+//! seal; consumers that bridge pre- and post-rename names consult the
+//! sealed maps (e.g. `RuntimeImportLookup::original_by_renamed`, the
+//! inverse projection — injective by seal's target-collision rules).
+//! There is no pre-seal trial application: capture facts reach seal from
+//! read-only walks of the **un-renamed** body. This makes the
+//! "X-layer renamed it, Y-layer keyed off the wrong-era name" bug class
+//! unrepresentable rather than defended against.
+//!
+//! ## Scopes, origins, priorities
+//!
+//! An intent renames `from` to `to` within one [`RenameScope`]
+//! (`Chunk` | `Module` | `Function` | `EntryPublicExports`); intents in
+//! one scope are invisible to queries for any other scope. The
+//! [`RenameOrigin`] names the contributor (for conflict diagnostics)
+//! and derives the conflict priority: explicit (spec-author decision) >
+//! import-induced (mechanical, required to emit valid imports) >
+//! heuristic (cosmetic readability).
 //!
 //! ## Seal validation
 //!
@@ -50,40 +66,37 @@
 //! taken set from the body's occupied names ([`RenameLedger::seed_taken`]
 //! / [`RenameLedger::claim`]) and request fresh names with
 //! [`RenameLedger::mint`], which suffix-mints `base$N` past collisions
-//! (decided 2026-06: the `$N` scheme stays; readability is a later
+//! (the `$N` scheme is the minting contract; readability is a later
 //! naturalizer concern). Import-local disambiguation (`import_emit.rs`)
 //! and public-export growth (`exports.rs`) mint through the ledger.
 //!
 //! ## Contract: no structural moves between seal and execute
 //!
-//! Adopted (decided 2026-06): once a chunk's ledger is sealed, no pass may
-//! move declarations between modules — structural moves (entry-body split,
-//! residual sweep, rebind folds, mini-factor synthesis) must all happen
-//! before collection finishes. The materializer satisfies the collection
-//! side (intents are collected from the finalized `ChunkPlan`), and as of
-//! PR 4 every ledger executes post-seal only. Making the contract
-//! type-level (non-execute passes take `&Module`) is remaining work.
+//! Once a chunk's ledger is sealed, no pass may move declarations
+//! between modules — structural moves (entry-body split, residual
+//! sweep, rebind folds, mini-factor synthesis) all happen before
+//! collection finishes. The materializer satisfies the collection side
+//! (intents are collected from the finalized `ChunkPlan`), and every
+//! ledger executes post-seal only.
 //!
-//! ## Seal points (PR 4 era)
+//! ## The four ledgers
 //!
-//! Four ledger instances remain, and each follows the same discipline:
-//! collect every intent, seal once, then execute — the post-seal rename
-//! pass is the only mutation of the scope unit's AST, and no pre-seal
-//! trial application exists (capture facts come from read-only probes /
-//! the derive clone over the un-renamed body):
+//! Four ledger instances cover a chunk's lowering. Each follows the
+//! same discipline — collect every intent, seal once, execute once —
+//! and each is a separate instance for a structural reason, not code
+//! shape:
 //!
 //! - **Chunk explicit ledger** (`materialize_logical_chunk`): spec
 //!   `chunk_renames` + plan `export_name`s; conflict-validated only (the
 //!   post-split bodies its targets must avoid don't exist yet — its
-//!   intents are re-collected into the two ledgers below, which validate
-//!   occupancy). Sealed before factorization, which consumes the
-//!   Chunk-scope projection. It cannot merge downstream: its Chunk
-//!   projection is an input to plan building and factorization, which
-//!   run before the post-split bodies exist.
-//! - **Chunk ledger** (`lower_chunk`): the chunk_renames entries staying
+//!   intents are re-collected into the two body-validating ledgers
+//!   below). It cannot merge downstream: its sealed Chunk projection is
+//!   an input to plan building and factorization, which run before the
+//!   post-split bodies exist.
+//! - **Entry ledger** (`lower_chunk`): the chunk_renames entries staying
 //!   in entry plus entry import-local mints (`Chunk` scope) AND the
-//!   auto-grown residual public exports (`EntryPublicExports` scope —
-//!   PR 4 absorbed the former export-growth ledger). One seal validates
+//!   auto-grown residual public exports (`EntryPublicExports` scope — a
+//!   separate namespace from local-binding renames). One seal validates
 //!   entry's post-split body occupancy (capture facts from the read-only
 //!   `RenameCaptureProbe`) and the public-export namespace; one executor
 //!   pass applies the Chunk map to the entry body.
@@ -95,49 +108,63 @@
 //!   rule ([`merge_module_renames`]), and per-scope occupancy. The
 //!   executor (sealed module-wide walk + `SealedScopeRenameApplier`) is
 //!   the only mutation of the real body; derivation runs on a scratch
-//!   clone of the un-renamed body (see below for why the clone stays).
+//!   clone of the un-renamed body (see "Derive clone").
 //! - **Per-plan import ledger** (`lower_single_plan`): cross-module +
-//!   residual-entry import-local mints. It cannot merge into the
-//!   naturalize ledger because of a cross-module phase ordering, not
-//!   mere code shape: collection needs this module's post-naturalize
-//!   body facts AND entry's grown export list, which itself needs every
-//!   module's post-naturalize facts — so the naturalize seal would have
-//!   to stay open across a chunk-wide phase whose inputs require the
-//!   naturalize application to have already run. Breaking the cycle
-//!   means planning references off un-renamed facts plus sealed-map
-//!   reasoning at import emission (PR 5 candidate; changes mint seeding
-//!   and is not behavior-preserving in suffix-mint corner cases).
+//!   residual-entry import-local mints. Separate from the naturalize
+//!   ledger because of a cross-module phase cycle, not code shape:
+//!   collection needs this module's post-naturalize body facts AND
+//!   entry's grown export list, which itself needs every module's
+//!   post-naturalize facts — the naturalize seal would have to stay
+//!   open across a chunk-wide phase whose inputs require the naturalize
+//!   application to have already run. Collapsing the two would mean
+//!   planning references off un-renamed facts plus sealed-map reasoning
+//!   at import emission, which changes mint seeding and is not
+//!   behavior-preserving in suffix-mint corner cases; the two-ledger
+//!   split is the accepted design.
 //!
-//! What still validates at the application site (PR 5 candidates):
+//! ## Boundaries that validate at application
 //!
-//! - The free-alias subtree-capture filter
-//!   (`naturalize.rs::drop_subtree_captured_targets`): free aliases apply
-//!   function-locally while their intents live at `Module` scope; seal
-//!   checks them against the deriving subtree's bound names when the
-//!   derive pass submits `Function`-scope copies, but the module-level
-//!   occupancy of free-alias targets is not checked (matching pre-ledger
-//!   behavior).
-//! - `chunk_renames` applied to *moved module bodies*
+//! Two scope-aware checks live at application sites by design — they
+//! validate facts only the application point can see, and are part of
+//! the architecture rather than residual defense:
+//!
+//! - **`chunk_renames` over moved module bodies**
 //!   (`lower_single_plan`'s `cross_module_chunk_renames` pass): the
-//!   entry-side seal validates against entry's body only; a target can
-//!   still collide inside a moved body, and that application keeps its
-//!   reachable bail. It also cannot fold into the per-plan import
-//!   ledger's seal: the two maps deliberately compose *sequentially*
-//!   (an import-local mint may rename `x → y$1` precisely because the
-//!   chunk-rename target `y` was taken, and the cross map's `x → y`
-//!   must then no-op), while one seal's priority rule would resolve the
+//!   entry-side seal validates against entry's post-split body only, so
+//!   a target can still be captured inside a moved body; that
+//!   application's capture check is the moved body's only occupancy
+//!   validation for spec renames and keeps its reachable bail. The pass
+//!   also deliberately composes *sequentially* with the import ledger's
+//!   mints rather than sealing with them: an import-local mint may
+//!   rename `x → y$1` precisely because the chunk-rename target `y` was
+//!   taken, and the cross map's `x → y` must then no-op on the
+//!   already-renamed refs — one seal's priority rule would resolve the
 //!   pair to the explicit target and desync body refs from the emitted
 //!   import local.
-//! - The derive-phase clone in `naturalize_module_body` (the scratch
-//!   clone + `validated_bound` / `drop_subtree_captured_targets` /
-//!   [`merge_module_renames`] pre-computation): the per-scope derive
-//!   cascade needs each enclosing scope's subtree name facts to reflect
-//!   the nested scopes' fired renames (the application is
-//!   scope-sensitive — a flat set transformation of the sealed nested
-//!   maps over the un-renamed facts both over- and under-suppresses),
-//!   so the clone walk is the precise fact source. Seal re-derives the
-//!   same decisions from the submitted facts; the clone never touches
-//!   the real body.
+//! - **Free-alias function-local application**: free-source
+//!   return-object aliases rewrite references function-locally while
+//!   their intents live at `Module` scope (they join the module-wide
+//!   merged map so runtime-import planning can reverse-resolve them).
+//!   The module-level occupancy of their targets is deliberately not
+//!   checked; the deriving subtree's bound-name rule — applied at seal
+//!   to their `Function`-scope copies — is the capture guard. This is
+//!   also why `NaturalizedRenames` keeps its `merged` / `explicit`
+//!   split: export locals and binding-comment keys may remap only
+//!   through renames that actually rename a top-level declaration.
+//!
+//! ## Derive clone
+//!
+//! `naturalize_module_body` derives heuristics on a scratch clone of
+//! the un-renamed body: the per-scope derive cascade needs each
+//! enclosing scope's subtree name facts to reflect the nested scopes'
+//! fired renames (the application is scope-sensitive — a flat set
+//! transformation of the sealed nested maps over the un-renamed facts
+//! both over- and under-suppresses), so the clone walk is the precise
+//! fact source. The clone's local preview applies the same rules seal
+//! re-derives from the submitted facts, so clone and sealed output
+//! agree; the clone never touches the real body, whose only mutation is
+//! the post-seal executor. The clone's plan-driven walk doubles as the
+//! Module-scope capture probe.
 //!
 //! ## Hygiene boundary
 //!
@@ -146,24 +173,26 @@
 //! breed. Contributors that only have a spec string resolve it at the
 //! collection point via `top_level_id(name, chunk_top_level_mark)`. The
 //! seal output is projected back to bare syms at the query boundary
-//! (`*_by_name`) because the post-#2052 application visitors are still
-//! string-keyed; the projection asserts that no two hygiene contexts share
-//! a sym within one scope. An `Id`-keyed executor that deletes the
-//! projection is remaining (PR 5) work.
+//! (`*_by_name`) because the application visitors are string-keyed; the
+//! projection asserts that no two hygiene contexts share a sym within
+//! one scope — that assert is the boundary's tripwire. Deleting the
+//! projection (an `Id`-keyed executor) requires emitting import/export
+//! decls under real contexts instead of `Ident::new_no_ctxt` (today one
+//! rename must hit both a no-ctxt emitted import local and the
+//! real-ctxt body references, which only sym-keyed application can do)
+//! and hygiene-resolving the `Function`-scope heuristic sources; see
+//! TODO.md "Rename pipeline".
 //!
 //! `Function`-scope heuristic sources are function-local bindings whose
 //! hygiene context the string-keyed derivation never resolves; they are
-//! keyed by `(sym, SyntaxContext::empty())` until the executor keys
-//! application by real `Id`s (remaining work — the post-#2052 visitors
-//! are string-keyed, and re-keying them is entangled with emitting
-//! import/export decls under real contexts instead of `new_no_ctxt`).
-//! Within one function scope a sym maps to at most one rename, so the
-//! empty-context encoding cannot collide.
+//! keyed by `(sym, SyntaxContext::empty())`. Within one function scope a
+//! sym maps to at most one rename, so the empty-context encoding cannot
+//! collide.
 //!
 //! ## Contributor inventory
 //!
-//! All rename contributors submit intents (PR 2) and all validation is
-//! seal-time (PR 3):
+//! Every rename contributor submits intents and all validation is
+//! seal-time:
 //!
 //! - Spec `chunk_renames` — `chunk_renames.rs::collect_chunk_renames`
 //!   (scope: `Chunk`, origin: `Explicit`; chunk explicit ledger, then
@@ -359,9 +388,10 @@ pub enum ScopeOccupancy {
         /// nested binding" error.
         captured: BTreeSet<(String, String)>,
     },
-    /// `Function` scopes: the deriving subtree's name facts, mirroring
-    /// the pre-ledger `validated_bound` / `drop_subtree_captured_targets`
-    /// checks.
+    /// `Function` scopes: the deriving subtree's name facts. Seal's
+    /// per-scope rules over them are the same rules the derive clone's
+    /// local preview applies (`validated_bound` + the free-copy
+    /// bound-target filter), so clone and sealed output agree.
     Subtree {
         /// Names bound anywhere under the deriving node. Classifies each
         /// intent (bound-source vs free-source) and rejects free-alias
@@ -772,8 +802,8 @@ fn validate_function_scope(
 /// in the same scope. This is the module-level target-collision rule
 /// seal applies to free-source aliases; `naturalize_module_body` calls it
 /// directly for the derive-phase preview (`free_allowed`) on the scratch
-/// clone (see the module doc's "Seal points" section for why the clone
-/// stays).
+/// clone (see the module doc's "Derive clone" section for why the clone
+/// is the fact source).
 pub fn merge_module_renames(
     mut explicit: BTreeMap<String, String>,
     heuristic: BTreeMap<String, String>,
@@ -838,7 +868,8 @@ impl SealedRenames {
         self.scope_renames_at_priority(&RenameScope::Module(module), RenamePriority::Explicit)
     }
 
-    /// Typed per-scope view (tests, the future execute-once pass).
+    /// Typed per-scope view (tests; the production executors consume the
+    /// by-name projection — see the module doc's "Hygiene boundary").
     pub fn scope_renames(&self, scope: &RenameScope) -> Option<BTreeMap<Id, Atom>> {
         self.by_scope.get(scope).map(|renames| {
             renames

--- a/devinfra/js/debundle/lowering/scope_names.rs
+++ b/devinfra/js/debundle/lowering/scope_names.rs
@@ -57,10 +57,10 @@ pub(super) fn collect_occupied_local_names(body: &[ModuleItem]) -> BTreeSet<Stri
 }
 
 /// Visitor behind [`collect_local_binding_names`] /
-/// [`collect_binding_names_in`]: records every name bound anywhere under
-/// the visited node (declarations, params, patterns, fn/class expr names,
-/// import specifier locals).
-pub(super) struct BindingNameCollector {
+/// [`collect_nested_binding_names`]: records every name bound anywhere
+/// under the visited node (declarations, params, patterns, fn/class expr
+/// names, import specifier locals).
+struct BindingNameCollector {
     names: BTreeSet<String>,
 }
 
@@ -104,21 +104,6 @@ impl Visit for BindingNameCollector {
     fn visit_import_star_as_specifier(&mut self, specifier: &ImportStarAsSpecifier) {
         self.names.insert(specifier.local.sym.to_string());
     }
-}
-
-/// Names bound anywhere under one AST node (a function, arrow,
-/// constructor, …). Used to suppress renames whose target a node's
-/// subtree binds — applying such a rename would capture the rewritten
-/// references.
-pub(super) fn collect_binding_names_in<N>(node: &N) -> BTreeSet<String>
-where
-    N: VisitWith<BindingNameCollector>,
-{
-    let mut collector = BindingNameCollector {
-        names: BTreeSet::new(),
-    };
-    node.visit_with(&mut collector);
-    collector.names
 }
 
 /// Names bound anywhere under `body`. This is stricter than file-scope

--- a/devinfra/js/debundle/lowering/visitors.rs
+++ b/devinfra/js/debundle/lowering/visitors.rs
@@ -32,11 +32,17 @@
 //! `a` -> `b` at a point where an enclosing scope binds `b` would make
 //! the rewritten reference resolve to the inner `b` (capture). The
 //! visitors do not apply such a rename; they record the offending
-//! `(source, target)` pair in `captured` instead. A partial
+//! `(source, target)` pair in `captured` instead — a partial
 //! application (decl renamed at top level, captured reference left
-//! as-is) is itself a miscompile, so callers MUST check `captured`
-//! after the pass and reject (or discard the mutated body) when it is
-//! non-empty.
+//! as-is) is itself a miscompile. The recorded set has three consumer
+//! classes: the read-only `RenameCaptureProbe` walks the un-renamed
+//! body to feed the ledger seal the capture facts it hard-errors on;
+//! the post-seal executors `debug_assert!` it is empty (seal already
+//! rejected captures — a non-empty set means probe and executor
+//! diverged); and the moved-module-body `chunk_renames` application
+//! bails on it, the one application whose body occupancy seal cannot
+//! see (see `rename_ledger.rs` "Boundaries that validate at
+//! application").
 //!
 //! ## Shorthand expansion
 //!
@@ -345,8 +351,8 @@ macro_rules! impl_rename_visit_mut {
 /// capture-checked rename lookup. The lookup returns the rename target for
 /// `name` only when applying it is safe at the current traversal point;
 /// when the target is shadowed it records the `(source, target)` pair in
-/// `self.captured` and returns `None` (see module docs: callers MUST check
-/// `captured`).
+/// `self.captured` and returns `None` (see the module docs' "Target
+/// capture" for who consumes the set).
 macro_rules! impl_rename_helpers {
     () => {
         fn with_rename_scope<F: FnOnce(&mut Self)>(&mut self, scope: BTreeSet<String>, f: F) {
@@ -520,7 +526,8 @@ pub(super) struct IdentifierRenamer<'a> {
     scopes: RenameScopeStack,
     /// `(source, target)` pairs whose rename was withheld because the
     /// target was shadowed at the reference. Non-empty after a pass means
-    /// the mutated body is partially renamed — callers MUST reject it.
+    /// the mutated body is partially renamed (see the module docs'
+    /// "Target capture" for the consumer classes).
     pub(super) captured: BTreeSet<(String, String)>,
 }
 

--- a/devinfra/js/debundle/plans/sanitization_program_2026_06.md
+++ b/devinfra/js/debundle/plans/sanitization_program_2026_06.md
@@ -51,20 +51,20 @@ perf baseline for the program.
    — blocked rows are not landable, implemented; `BindingId` interning
    — deferred, perf-triggered, see the backlog's decided-state note.
 
-## Track B — RenameLedger (weeks 1–2)
+## Track B — RenameLedger (weeks 1–2) — complete (2026-06)
 
 The structural fix for the rename-bug family (#2052/#2057 were
 down-payments). Five PRs, each independently green against the ~90
-rename-pinning e2e tests:
+rename-pinning e2e tests — all landed
+(#2086/#2091/#2101/#2106 + the PR-5 cleanup):
 
 1. Types + inventory: `RenameLedger` of `RenameIntent { scope, from, to,
 origin, priority }`, scopes Chunk/Module/Function, **keyed by hygiene
    `Id`** (post-#2042 contexts are why string keys breed bugs). Adopt the
    "no structural moves between seal and execute" contract. _(Landed
-   2026-06: `lowering/rename_ledger.rs`, including the seal-time
+   2026-06: #2086 — `lowering/rename_ledger.rs`, including the seal-time
    same-priority conflict check and the two explicit contributors —
-   spec `chunk_renames` + plan `export_name`s; see TODO.md's rename
-   pipeline section for decisions and the remaining ladder.)_
+   spec `chunk_renames` + plan `export_name`s.)_
 2. Collect: convert contributors (spec `export_name`s, bound/free
    heuristics, import-local `_N` minting, `chunk_renames`, cross-module,
    collision resolution) one at a time to emit intents. _(Landed
@@ -72,24 +72,26 @@ origin, priority }`, scopes Chunk/Module/Function, **keyed by hygiene
 3. Seal: explicit > import-induced > heuristic; same-priority conflicts are
    hard errors naming both contributors; target-occupancy validated at seal
    time against scope-accurate occupied sets; `_N` minting becomes a ledger
-   service. _(Landed 2026-06; see TODO.md's "PR 3 landed" entry and the
-   "Seal points" section of `lowering/rename_ledger.rs` for what stays at
-   the application sites until PR 4.)_
+   service. _(Landed 2026-06: #2101.)_
 4. Execute once: the post-seal rename pass is the only mutation per scope
    unit; capture facts reach seal from the un-renamed tree. _(Landed
-   2026-06: read-only `RenameCaptureProbe` + `pending_renames_by_name`
+   2026-06: #2106 — read-only `RenameCaptureProbe` + `pending_renames_by_name`
    replace the pre-seal trial walks, the export-growth ledger merged into
    `lower_chunk`'s chunk ledger, and `plan_references`' reverse `.find`
-   became the sealed map's inverse projection. The naturalizer's derive
-   clone, the per-plan import ledger, and `cross_module_chunk_renames`'
-   separate application stay with documented reasons — see TODO.md's
-   "PR 4 landed" entry and `rename_ledger.rs` "Seal points".)_
-5. Cleanup: delete the defensive era (`captured` sets,
-   `drop_subtree_captured_targets` where dominated, reverse lookups) and
-   attack PR 4's documented blockers (import-ledger merge,
-   `Id`-keyed executor deleting the `*_by_name` projection). Afterwards
-   the #2045 class is unrepresentable and aggressive auto-naturalization
-   becomes safe to build.
+   became the sealed map's inverse projection.)_
+5. Cleanup: delete the defensive era and resolve PR 4's documented
+   blockers. _(Landed 2026-06: the dominated `drop_subtree_captured_targets`
+   subtree re-walk and the clone-side capture asserts are deleted (the
+   post-seal executors keep the single `debug_assert!` tripwire layer);
+   the import-ledger merge and `cross_module_chunk_renames` folding are
+   finalized as design — the cross-module phase cycle and the sequential
+   mint composition are documented invariants in `rename_ledger.rs`'s
+   "The four ledgers" / "Boundaries that validate at application" — as
+   are the derive clone and the `merged`/`explicit` map split. The
+   `Id`-keyed executor is re-filed in TODO.md "Rename pipeline" (blocked
+   on real-context import/export emission). The #2045 class is
+   unrepresentable; aggressive auto-naturalization is now a TODO.md
+   capability item.)_
 
 ## Track C — vendor-into-emission collapse (weeks 2–3)
 


### PR DESCRIPTION
Track B finale (predecessors: #2086, #2091, #2101, #2106). Zero behavior change; full `bbr test //devinfra/js/debundle/...` green (100/100, `buildbuddy:382e74ba-cbe7-4a12-944e-32f6cad9e4a5`), including the rename-pinning e2e suite and the `rename_ledger` proptest targets unchanged.

## Deletions (seal's guarantees now dominate)

- **`drop_subtree_captured_targets` + `collect_binding_names_in`** (`naturalize.rs` / `scope_names.rs`): the clone-side free-copy rule now filters on the already-collected `facts.bound` — the exact set submitted to seal, whose `validate_function_scope` applies the identical `!bound.contains(to)` rule. Deletes a redundant second full-subtree walk per deriving function; same predicate, so the clone and the sealed output still agree byte-for-byte. `BindingNameCollector` becomes private to `scope_names.rs`.
- **Clone-side `assert_no_heuristic_capture` calls** in `ScopedHeuristicNaturalizer` (3 sites): the derive preview rules (target absent from the subtree's bound/mention sets) make capture provably impossible on the scratch clone. The post-seal executors keep exactly ONE `debug_assert!` tripwire layer each (`SealedScopeRenameApplier`, the module-wide executor, the entry executor, the import-renames executor) — no stacked layers remain.
- **Defensive reverse-lookups**: none left to delete — PR 4 already replaced the last one with the sealed map's inverse projection (`RuntimeImportLookup::original_by_renamed`), which is ordinary mapping code, not defense.

## PR-4 remainder dispositions

| Item | Disposition |
| --- | --- |
| (a) derive clone | **Finalized as design**: the per-scope derive cascade needs enclosing scopes' subtree facts to reflect nested fired renames; a flat set transformation of sealed maps both over- and under-suppresses. Now the "Derive clone" section of the module doc. |
| (b) import-ledger merge into the per-plan seal | **Finalized as design**: the cross-module phase cycle (collection needs post-naturalize facts + entry's grown exports, which need every module's facts) means a merge requires planning off un-renamed facts — documented by PR 4 as not behavior-preserving in suffix-mint corner cases, which this PR's zero-behavior-change contract forbids. "The four ledgers" section. |
| (c) `cross_module_chunk_renames` sequential composition | **Finalized as design**: it deliberately composes *sequentially* with import-local mints (`x → y$1` minted because `y` was taken; the cross map's `x → y` must then no-op); one seal's priority rule would desync body refs from the emitted import local. Its capture bail stays as the moved body's only occupancy validation — boundary validation, not defense. |
| (d) `merged`/`module_scope` split | **Finalized as design** + misleading name fixed: `NaturalizedRenames.module_scope` → `explicit` (both maps are module-scope; they differ by priority — explicit-only vs explicit+surviving-free-heuristics). Export locals and binding comments remap through `explicit` only. |
| (e) Id-keyed executor / deleting `*_by_name` | **Not landable in this PR**, with the precise blocker documented: a single rename must today hit both a `new_no_ctxt` emitted import local and the real-ctxt body references, which only sym-keyed application can do; `Function`-scope heuristic sources are additionally keyed `(sym, SyntaxContext::empty())`. Landing it requires real-context import/export emission first — re-filed as the lead item in TODO.md "Rename pipeline". The by-name projection is the documented executor boundary; its two-contexts-one-sym assert is the tripwire. |

## Steady-state doc

`rename_ledger.rs`'s module doc is rewritten from ladder-narrative to architecture description: collect → seal → execute-once contract; scopes/origins/priorities; seal validation (conflicts, occupancy, reference-precise capture facts from read-only probes of the un-renamed body); `$N` minting; the no-structural-moves contract; **The four ledgers** (each instance's structural reason to exist); **Boundaries that validate at application** (the two by-design application-site checks); **Derive clone**; the hygiene boundary. All per-PR narrative deleted.

TODO.md's 180-line rename-pipeline section collapses to a tombstone ("landed, PRs #2086/#2091/#2101/#2106 + this") plus the genuinely-open ideas filed as their own items: Id-keyed executor, aggressive auto-naturalization (now safe — every rename flows through one seal, so #2045-class miscompiles are unrepresentable), and the `&Module` type-level move barrier. `plans/sanitization_program_2026_06.md` Track B is marked complete with per-item landed/finalized annotations.

https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk)_