### PR TITLE
wayback-cache: bigger upstream keepalive pool + richer access log

### DIFF
--- a/cluster/k8s/wayback-cache/config/nginx.conf
+++ b/cluster/k8s/wayback-cache/config/nginx.conf
@@ -20,7 +20,22 @@ events {
 }
 
 http {
-    access_log /dev/stdout;
+    # Custom format so cache and upstream behavior are directly countable from
+    # the access log (the default 'combined' format hides both). Fields:
+    #   cache=  $upstream_cache_status — HIT/MISS/EXPIRED/STALE/UPDATING or '-'
+    #           (served without an upstream). Measures cache effectiveness.
+    #   up=     $upstream_status — IA's HTTP status, comma-joined per
+    #           proxy_next_upstream retry. Empty/'-' on a connection-level
+    #           failure (e.g. IA RST), which is how we count "upstream refused
+    #           TCP" vs IA returning an HTTP error.
+    #    rt=/uct=/urt= total / upstream-connect / upstream-response seconds —
+    #           surfaces the slow IA CDX latency and connect stalls.
+    #   tries=  $upstream_addr — the upstream(s) tried (one per retry).
+    log_format wayback '$remote_addr [$time_local] "$request" $status '
+                       'cache=$upstream_cache_status up=$upstream_status '
+                       'rt=$request_time uct=$upstream_connect_time urt=$upstream_response_time '
+                       'tries=$upstream_addr bytes=$body_bytes_sent';
+    access_log /dev/stdout wayback;
 
     # Bearer token for the gateway-facing listener (:8090). Injected at
     # container start by nginx:alpine's envsubst from $WAYBACK_CACHE_TOKEN
@@ -47,9 +62,25 @@ http {
 
     # DNS resolved once at nginx startup; the Recreate deployment strategy
     # means a pod restart re-resolves if IA rotates IPs.
+    #
+    # HYPOTHESIS (2026-06-11): the dominant eval failure is web.archive.org
+    # *refusing new TCP connections* per source IP — ~900 `connect() failed
+    # (111: Connection refused)` per run, surfaced as 502. It's connection-level
+    # (a RST on connect, not an HTTP 429/503) and stays flat when sample
+    # concurrency is halved, so it tracks our *new-connection rate*, not request
+    # volume. A bigger keepalive pool lets nginx reuse persistent upstream
+    # connections instead of opening fresh ones for IA to reject. Size to cover
+    # in-flight CDX concurrency (rate x IA latency ~= 60 r/m x ~20s ~= 20) with
+    # headroom; keepalive_requests high so a hot connection isn't recycled after
+    # nginx's default 1000; keepalive_timeout long enough to survive limit_req
+    # pacing between requests. Validate by re-measuring the refused-connection
+    # count in the new `wayback` access log; if it doesn't drop, IA is limiting
+    # by source IP / total connections rather than new-connection rate.
     upstream ia {
         server web.archive.org:443;
-        keepalive 8;
+        keepalive 64;
+        keepalive_timeout 120s;
+        keepalive_requests 10000;
     }
 
     server { # tier 1: PVC-backed cache
@@ -122,6 +153,10 @@ http {
         # so neither does — they differ only in rate bucket and read timeout.)
         proxy_http_version 1.1;
         proxy_set_header Connection "";
+        # SO_KEEPALIVE on the pooled upstream sockets so idle keepalive
+        # connections to IA are detected/dropped if IA silently closes them,
+        # keeping the reused pool healthy between paced requests.
+        proxy_socket_keepalive on;
         proxy_set_header Host web.archive.org;
         proxy_set_header User-Agent "ducktape-wayback-cache/1 (+agentydragon@gmail.com)";
         # Deterministic bytes: no content-encoding variants in the cache, so


### PR DESCRIPTION
Tests the hypothesis that the wayback-cache's IA 502s come from **per-IP new-TCP-connection refusal**, by giving nginx a connection pool large enough to reuse — and adds the logging to measure whether it works.

## Hypothesis

Across two eval runs, the dominant upstream failure is `connect() failed (111: Connection refused)` to `web.archive.org` (~900/run), surfaced as 502. Two properties point at **per-IP new-connection-rate limiting** rather than request-volume throttling:
- It's **connection-level** (a RST on connect), not an HTTP 429/503 from IA.
- It **didn't drop when sample concurrency was halved** (`--max-samples 8`): 874 → 930 refusals in a *shorter* run.

If IA limits *new* connections, reusing persistent ones should sidestep it. The keepalive pool was only **8** — far under the in-flight CDX concurrency (≈ 60 r/m × ~10-25 s IA latency ≈ **20**), so the overflow opened fresh connections every cycle.

## Changes

- `upstream ia`: `keepalive 8 → 64`, `+ keepalive_timeout 120s`, `+ keepalive_requests 10000`
- tier-2 server: `proxy_socket_keepalive on` (drop silently-closed pooled conns)
- **access log**: default `combined` → custom `wayback` format exposing `$upstream_cache_status`, `$upstream_status`, `$request_time`, `$upstream_connect_time`, `$upstream_response_time`, `$upstream_addr`. Now cache hit/miss and "upstream refused TCP" (empty `up=` on a 502) are countable straight from the log — so the next run *measures* whether the pool helped.

The full rationale + validation note is in the config comments.

## Rollout

Auto-rolls: deployment has `reloader.stakater.com/auto` + hash-suffixed `configMapGenerator`. **Caveat in the comment:** if the refusals *don't* drop after this, IA is limiting by source IP / total connections, not new-connection rate.

https://claude.ai/code/session_01AXSFxfCXddADoSKTjgF5Nz

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXSFxfCXddADoSKTjgF5Nz)_