### PR TITLE
wayback-cache: export Prometheus metrics from the access log

### DIFF
--- a/cluster/k8s/wayback-cache/config/nginx.conf
+++ b/cluster/k8s/wayback-cache/config/nginx.conf
@@ -37,6 +37,16 @@ http {
                        'tries=$upstream_addr bytes=$body_bytes_sent';
     access_log /dev/stdout wayback;
 
+    # Lean, single-line-safe variant streamed over loopback syslog to the
+    # prometheus-nginxlog-exporter sidecar (turns the log into Prometheus
+    # metrics). Quote $upstream_status so the per-retry comma-list (e.g.
+    # "-, -, -" on a refused connect) stays one field; everything else here is
+    # single-valued. The rich `wayback` format above still goes to stdout for
+    # Loki/manual analysis. UDP drops under load are acceptable for sampling.
+    log_format wayback_metrics '$remote_addr "$request" $status '
+                               'cache=$upstream_cache_status up="$upstream_status" rt=$request_time';
+    access_log syslog:server=127.0.0.1:5140,tag=wayback,severity=info,nohostname wayback_metrics;
+
     # Bearer token for the gateway-facing listener (:8090). Injected at
     # container start by nginx:alpine's envsubst from $WAYBACK_CACHE_TOKEN
     # (NGINX_ENVSUBST_FILTER restricts substitution to this one var so nginx's

--- a/cluster/k8s/wayback-cache/config/nginxlog-exporter.hcl
+++ b/cluster/k8s/wayback-cache/config/nginxlog-exporter.hcl
@@ -1,0 +1,35 @@
+# prometheus-nginxlog-exporter config for the wayback-cache sidecar.
+# nginx streams the lean `wayback_metrics` access line over loopback syslog
+# (udp 127.0.0.1:5140); this parses it into Prometheus metrics scraped at :4040.
+#
+# Emitted (namespace "wayback"):
+#   wayback_http_response_count_total{method,status,cache,up} — request counts.
+#     * cache hit rate  = ratio of {cache="HIT"} to total.
+#     * IA TCP refusals = {status="502", up=~"-.*"} (no upstream HTTP response).
+#     * IA HTTP errors  = {status="502", up!~"-.*"} etc.
+#   wayback_http_response_time_seconds{...} — request-duration histogram.
+listen {
+  port = 4040
+  address = "0.0.0.0"
+  metrics_endpoint = "/metrics"
+}
+
+namespace "wayback" {
+  format = "$remote_addr \"$request\" $status cache=$upstream_cache_status up=\"$upstream_status\" rt=$request_time"
+
+  source {
+    syslog {
+      listen_address = "udp://127.0.0.1:5140"
+      format = "rfc3164"
+      tags = ["wayback"]
+    }
+  }
+
+  # Promote the two custom fields to metric labels (both low-cardinality).
+  relabel "cache" {
+    from = "upstream_cache_status"
+  }
+  relabel "up" {
+    from = "upstream_status"
+  }
+}

--- a/cluster/k8s/wayback-cache/deployment.yaml
+++ b/cluster/k8s/wayback-cache/deployment.yaml
@@ -73,10 +73,43 @@ spec:
               port: 8080
             initialDelaySeconds: 2
             periodSeconds: 5
+        # Turns the nginx access log into Prometheus metrics. nginx streams the
+        # lean `wayback_metrics` line over loopback syslog (udp :5140, same pod
+        # netns); this parses it and serves /metrics on :4040 (scraped by the
+        # ServiceMonitor). Stateless — no shared log file, so no rotation needed.
+        - name: metrics
+          image: quay.io/martinhelmich/prometheus-nginxlog-exporter:v1.11.0
+          args:
+            - -config-file=/etc/nginxlog-exporter/config.hcl
+          ports:
+            - containerPort: 4040
+              name: metrics
+          volumeMounts:
+            - name: exporter-config
+              mountPath: /etc/nginxlog-exporter
+              readOnly: true
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65534
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
       volumes:
         - name: config
           configMap:
             name: wayback-cache-config
+        - name: exporter-config
+          configMap:
+            name: wayback-cache-exporter-config
         - name: cache
           persistentVolumeClaim:
             claimName: wayback-cache-data-ovh

--- a/cluster/k8s/wayback-cache/flux-kustomization.yaml
+++ b/cluster/k8s/wayback-cache/flux-kustomization.yaml
@@ -24,3 +24,4 @@ spec:
       namespace: wayback-cache
   dependsOn:
     - name: seaweedfs-csi
+    - name: monitoring-stack # ServiceMonitor CRD for the metrics sidecar

--- a/cluster/k8s/wayback-cache/kustomization.yaml
+++ b/cluster/k8s/wayback-cache/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - deployment.yaml
   - service.yaml
   - httproute.yaml
+  - servicemonitor.yaml
   - token.sops.yaml
 
 configMapGenerator:
@@ -14,3 +15,7 @@ configMapGenerator:
     namespace: wayback-cache
     files:
       - config/nginx.conf
+  - name: wayback-cache-exporter-config
+    namespace: wayback-cache
+    files:
+      - config.hcl=config/nginxlog-exporter.hcl

--- a/cluster/k8s/wayback-cache/service.yaml
+++ b/cluster/k8s/wayback-cache/service.yaml
@@ -6,6 +6,8 @@ kind: Service
 metadata:
   name: wayback-cache
   namespace: wayback-cache
+  labels:
+    app.kubernetes.io/name: wayback-cache
 spec:
   selector:
     app.kubernetes.io/name: wayback-cache
@@ -19,3 +21,8 @@ spec:
       targetPort: 8090
       protocol: TCP
       name: authed
+    # prometheus-nginxlog-exporter sidecar; scraped by the ServiceMonitor.
+    - port: 4040
+      targetPort: 4040
+      protocol: TCP
+      name: metrics

--- a/cluster/k8s/wayback-cache/servicemonitor.yaml
+++ b/cluster/k8s/wayback-cache/servicemonitor.yaml
@@ -1,0 +1,13 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: wayback-cache
+  namespace: wayback-cache
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: wayback-cache
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s


### PR DESCRIPTION
Option 2 from the metrics discussion: a sidecar turns the wayback-cache access log into Prometheus metrics (scraped via ServiceMonitor), so cache hit rate and IA throttling are queryable instead of grep-reconstructed.

## Tool choice

`mtail` has no reliably-published image, so I used **`prometheus-nginxlog-exporter`** (`quay.io/martinhelmich/prometheus-nginxlog-exporter:v1.11.0`) — the maintained, nginx-specific exporter. Same sidecar+ServiceMonitor architecture.

## How it works (no shared log file → no rotation/growth problem)

- nginx gains a lean `wayback_metrics` `log_format` streamed over **loopback syslog** (`udp 127.0.0.1:5140`, same pod netns). `$upstream_status` is quoted so the per-retry comma-list stays one field. The rich `wayback` format still goes to stdout for Loki.
- the sidecar parses that syslog stream and serves `/metrics` on `:4040`; a `ServiceMonitor` scrapes it.

## Metrics (namespace `wayback`)

- `wayback_http_response_count_total{method,status,cache,up}`
  - cache hit rate = `{cache="HIT"}` / total
  - **IA TCP refusals** = `{status="502", up=~"-.*"}` — the metric this whole thread was about: how often archive.org refused the connection (vs returned an HTTP error)
- `wayback_http_response_time_seconds` — request-duration histogram

## Wiring / rollout

- `service.yaml`: `metrics` port 4040 + `app.kubernetes.io/name` label for the SM selector
- `servicemonitor.yaml` (new), `nginxlog-exporter.hcl` (new, via configMapGenerator)
- `flux-kustomization.yaml`: `dependsOn` `monitoring-stack` (ServiceMonitor CRD) — required by the cluster validator
- Auto-rolls via the existing `reloader` + hash-suffixed `configMapGenerator`.

Validated: `kubectl kustomize` renders correctly (right keys in each configMap, sidecar mounts), pre-commit clean (kubeconform + cluster-validate).

Once merged + rolled, the next eval run will populate these — and directly answer whether the #2111 keepalive change actually dropped the TCP refusals.

https://claude.ai/code/session_01AXSFxfCXddADoSKTjgF5Nz

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXSFxfCXddADoSKTjgF5Nz)_