### PR TITLE
debundle: Track D — type-shape and strict-mapping cleanups

### DIFF
--- a/devinfra/js/debundle/ARCHITECTURE_BACKLOG.md
+++ b/devinfra/js/debundle/ARCHITECTURE_BACKLOG.md
@@ -143,14 +143,6 @@ These files document the same project from multiple perspectives. Skimming them,
 
 ## Concerns to discuss before deciding
 
-### Should `ChunkAnalysisReport` be auto-derived from the IR?
-
-After the rename, `chunk_analysis::ChunkAnalysis` (IR) and `artifact::ChunkAnalysisReport` (JSON wire) still coexist as parallel definitions. The longer-term question is whether the report shape should be derived from the IR shape via a wire-format adapter (the way `OwnerGraph` ↔ `OwnerGraphReport` works). If yes, the two types collapse into one IR + one auto-derived report.
-
-**Decision needed**: whether the report types are auto-derivable from IR types, or whether they intentionally diverge (e.g. the report has fields the IR doesn't, like `parser: ParserOptionsRecord` for reproducibility).
-
-A related collapse with zero wire change is available today: `artifact.rs::ChunkManifest::from_analysis` copies `ChunkAnalysisReport` into `ChunkManifest` field-by-field; embedding the report struct with `#[serde(flatten)]` removes one duplication layer while keeping the serialized shape identical.
-
 ### Gate simulator ↔ materializer import-order sharing (RESOLVED)
 
 The historical drift surface — the emitter placed phantom side-effect imports first in each emitted module while the simulator sorted ALL of a module's I-successors in one `linker_position` list, residual's missing universal entry imports, and the `usize::MAX` tie-break mismatch — is resolved: both sides now consume one shared ordering implementation, `esm_import_order::EsmImportOrder` (`sort_entry_imports` / `sort_module_imports`), built from the canonical `ChunkConstrainingEdgeSet`. The emitter renders the entry's per-plan import list (named imports for binding-owning plans, side-effect-only imports for binding-less plans) and each module's merged intra-chunk import list (binding + phantom + residual-entry, one sort) from it; the simulator (`realizability::EsmIGraph`) uses the same two sorts as DFS neighbor order, with residual fanning out to every I-graph module exactly as the emitted entry does. Do not reintroduce per-side ordering rules — encode any ordering requirement in `EsmImportOrder` so both sides inherit it.

--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -725,6 +725,7 @@ rust_library(
         "cli/mod.rs",
         "cli/module.rs",
         "cli/outcome.rs",
+        "cli/scc_cluster.rs",
         "cli/yaml_edit.rs",
     ],
     crate_name = "debundle_cli",

--- a/devinfra/js/debundle/CODE_REVIEW.md
+++ b/devinfra/js/debundle/CODE_REVIEW.md
@@ -23,10 +23,6 @@ Whitelist tables already in `purity/whitelists.rs`; long PlainData /
 scanning, and TS enum IIFE recognition still live in `mod.rs` —
 could be sub-split further if it keeps growing.
 
-### `facts/mod.rs` (~1930 lines, 2 concerns)
-
-`StatementFacts` carries many derivable `BTreeSet<Id>` sets that every construction site must keep mutually consistent — see the canonical "### `StatementFacts`" item under P3.
-
 ---
 
 ## P1 — Major Duplication
@@ -42,15 +38,6 @@ could be sub-split further if it keeps growing.
 ---
 
 ## P2 — Structural Issues
-
-### `graph.rs` — silent-skip hazards
-
-- `build_owner_graph_with` populates `binding_owner` with plain inserts, so duplicate top-level declarations (legal JS: two `var x;`, two `function f() {}`) silently resolve last-insert-wins and earlier declarators get no incoming edges. Detect duplicates and error (or model multi-owner bindings explicitly).
-- `OwnerGraph::from_report` silently `continue`s past edges whose endpoints don't resolve in the node table. A malformed or version-skewed `owner_graph.json` loses edges without a diagnostic — and the planner-side gate then reasons over a weaker graph. Make unresolvable endpoints a hard error (strict mapping).
-
-### `cli/mod.rs` — still a grab-bag (~1800 lines)
-
-After the module/binding/comment/gate extractions, `cli/mod.rs` still hosts the full `scc` and `cluster` command implementations plus their text renderers (`run_scc`, `render_scc_text`, `run_cluster`, `render_cluster_text`) alongside arg structs and dispatch. Move them to sibling modules like the other commands.
 
 ### `lowering/lower.rs` — monolithic function (partially extracted)
 
@@ -72,13 +59,6 @@ Each returns `self.root.join(CONSTANT)`. Replace with a data-driven approach: `r
 
 `rollback_graph.rs`, `artifact.rs`, `realizability/` all use BTree collections exclusively. For structures with many lookups, `HashMap`/`HashSet` would be faster. If deterministic iteration is needed, document it at the struct level. `RollbackDiGraph` in particular does many lookups per operation where hash-based would be measurably faster.
 
-### `StatementFacts` (facts/mod.rs) — ~18 fields, triple-repeated position pattern
-
-The eager/lazy/first-order shape repeats three times — reads (`eager_reads`/`lazy_reads`/`first_order_lazy_reads`), rebinds (`eager_rebinds`/`lazy_rebinds`/`first_order_lazy_rebinds`), and calls (`at_init_calls`/`body_calls`/`first_order_body_calls`). A `PositionBucketed<T> { eager, lazy, first_order_lazy }` cuts 9 fields to 3 and makes the "first-order ⊆ lazy" subset invariants structural instead of per-construction-site discipline. Two related cleanups:
-
-- The internal `StructuralStatementFacts` spells the same sets in a different vocabulary and renames field-by-field mid-pipeline (`at_init_reads`→`eager_reads`, `at_init_writes`→`eager_rebinds`, `lazy_calls`→`body_calls`, `first_order_lazy_calls`→`first_order_body_calls`). Unify on one vocabulary.
-- The `effects` summary is assembled at construction from the other sets plus the global read/write scans; its `Binding`-cell half restates `declared`/`eager_reads`/`eager_rebinds`, leaving only the `GlobalProp` half as new information. Consider deriving it on demand.
-
 ### `DepKind` 6-way split vs primary constraining/non-constraining axis
 
 Callers in realizability/, validation.rs, facts/mod.rs frequently partition into constraining vs non-constraining via `constrains_init_order()`. Make this a first-class type distinction.
@@ -94,10 +74,6 @@ Nearly every struct field and function is `pub(super)`. This is "module-private 
 ### Vendor manifest struct proliferation
 
 ~26 manifest/counts/detail structs with similar shapes in `vendor/manifests.rs`. `PartialSwapResolutionManifest` and `BundledPartialSwapResolutionManifest` are field-for-field twins — a generic `ResolutionManifest<R>` collapses the pair. `PartialSwapSymbolTarget` (`vendor/mod.rs`) is likewise a field-for-field twin of `spec::PartialSwapSymbol`.
-
-### `ChunkAnalysis` pub inputs + private derived caches
-
-`chunk_analysis.rs` exposes `facts`, `bindings`, `logical_modules`, `chunk_renames`, `owner_graph` as `pub` fields while `build()` precomputes private lookup tables (`owner_report_ids_by_binding`, `binding_lookup_by_id`) from them. Mutating a pub field after construction silently stales the caches. Privatize the inputs behind accessors so the staleness hazard is unrepresentable.
 
 ### `SourceImportResolution = Option<(String, String, String)>` (`plan_references.rs:41`)
 
@@ -195,6 +171,4 @@ No longer a standalone crate — absorbed into `swc_ecma_minifier` as `pub(crate
 
 2. **Continue splitting `vendor/mod.rs`** — manifests, strip, wrappers, and validate/resolve helpers extracted; remaining: strip-specific helpers, annotation/identity logic.
 
-3. **Simplify `StatementFacts`** (`facts/mod.rs`) — see the canonical "### `StatementFacts`" item under P3.
-
-4. **Consolidate the data-shape follow-ups** — remove the remaining `ChunkBundle` ownership ping-pong.
+3. **Consolidate the data-shape follow-ups** — remove the remaining `ChunkBundle` ownership ping-pong.

--- a/devinfra/js/debundle/analysis_tests/factorization_validation.rs
+++ b/devinfra/js/debundle/analysis_tests/factorization_validation.rs
@@ -57,7 +57,7 @@ fn cycle_detected_between_two_modules() {
     let mut binding_assignment = HashMap::new();
     binding_assignment.insert(test_id("A"), logical(0));
     binding_assignment.insert(test_id("B"), logical(1));
-    let owner_graph = build_owner_graph(&facts);
+    let owner_graph = build_owner_graph(&facts).unwrap();
     let partition =
         Partition::from_binding_assignment(&owner_graph, &binding_assignment, residual());
     let report = validate_factorization(&owner_graph, &partition, &render);
@@ -73,7 +73,7 @@ fn dag_has_no_cycles() {
     binding_assignment.insert(test_id("A"), logical(0));
     binding_assignment.insert(test_id("B"), logical(1));
     binding_assignment.insert(test_id("C"), logical(2));
-    let owner_graph = build_owner_graph(&facts);
+    let owner_graph = build_owner_graph(&facts).unwrap();
     let partition =
         Partition::from_binding_assignment(&owner_graph, &binding_assignment, residual());
     let report = validate_factorization(&owner_graph, &partition, &render);
@@ -104,7 +104,7 @@ fn mixed_cycle_without_at_init_call_is_realizable() {
     binding_assignment.insert(test_id("A"), logical(0));
     binding_assignment.insert(test_id("readB"), logical(0));
     binding_assignment.insert(test_id("B"), logical(1));
-    let owner_graph = build_owner_graph(&facts);
+    let owner_graph = build_owner_graph(&facts).unwrap();
     let partition =
         Partition::from_binding_assignment(&owner_graph, &binding_assignment, residual());
     let report = validate_factorization(&owner_graph, &partition, &render);
@@ -122,10 +122,10 @@ fn mixed_cycle_without_at_init_call_is_realizable() {
 /// owner to the target binding's owner.
 #[test]
 fn at_init_call_promotion_materializes_owner_edge() {
-    // owner 0: function readB { return B; } (lazy_reads = {B})
+    // owner 0: function readB { return B; } (reads.lazy = {B})
     // owner 1: const A = 1
-    // owner 2: const triggerInit = readB(); (at_init_calls = {readB})
-    // owner 3: const B = A + 1; (declared = {B}, eager_reads = {A})
+    // owner 2: const triggerInit = readB(); (calls.eager = {readB})
+    // owner 3: const B = A + 1; (declared = {B}, reads.eager = {A})
     // Promotion should add an EagerUse edge owner 2 → owner 3
     // because triggerInit at-init-calls readB whose body reads B.
     let module = parse(
@@ -133,12 +133,12 @@ fn at_init_call_promotion_materializes_owner_edge() {
     );
     let facts = analyze_facts(&module);
     assert_eq!(
-        facts[2].at_init_calls,
+        facts[2].calls.eager,
         BTreeSet::from([test_id("readB")]),
-        "triggerInit's at_init_calls must include readB: {:?}",
-        facts[2].at_init_calls,
+        "triggerInit's calls.eager must include readB: {:?}",
+        facts[2].calls.eager,
     );
-    let owner_graph = build_owner_graph(&facts);
+    let owner_graph = build_owner_graph(&facts).unwrap();
     let promoted: Vec<_> = owner_graph
         .iter_edges()
         .filter(|e| e.from == OwnerId(2) && e.to == OwnerId(3))
@@ -176,7 +176,7 @@ fn at_init_call_promotion_closes_otherwise_relaxed_cycle() {
     binding_assignment.insert(test_id("triggerInit"), logical(0));
     binding_assignment.insert(test_id("A"), logical(0));
     binding_assignment.insert(test_id("B"), logical(1));
-    let owner_graph = build_owner_graph(&facts);
+    let owner_graph = build_owner_graph(&facts).unwrap();
     let partition =
         Partition::from_binding_assignment(&owner_graph, &binding_assignment, residual());
     let report = validate_factorization(&owner_graph, &partition, &render);
@@ -210,7 +210,7 @@ fn cut_emits_side_effect_edges_for_s_only_cycle() {
     binding_assignment.insert(test_id("a1"), logical(0));
     binding_assignment.insert(test_id("a2"), logical(0));
     binding_assignment.insert(test_id("b1"), logical(1));
-    let owner_graph = build_owner_graph(&facts);
+    let owner_graph = build_owner_graph(&facts).unwrap();
     let partition =
         Partition::from_binding_assignment(&owner_graph, &binding_assignment, residual());
     let report = validate_factorization(&owner_graph, &partition, &render);
@@ -244,7 +244,7 @@ fn cut_is_absent_for_lazy_only_cycle() {
     binding_assignment.insert(test_id("A"), logical(0));
     binding_assignment.insert(test_id("helperB"), logical(1));
     binding_assignment.insert(test_id("B"), logical(1));
-    let owner_graph = build_owner_graph(&facts);
+    let owner_graph = build_owner_graph(&facts).unwrap();
     let partition =
         Partition::from_binding_assignment(&owner_graph, &binding_assignment, residual());
     let report = validate_factorization(&owner_graph, &partition, &render);
@@ -363,7 +363,7 @@ fn factorization_for(source: &str, ownership: &[(&str, ModuleId)]) -> ChunkFacto
     });
     ChunkFactorization::build(
         "test_chunk".to_string(),
-        facts,
+        &facts,
         bindings,
         logical_modules,
         HashMap::new(),
@@ -405,7 +405,7 @@ fn factorization_with_residual_module(
     ];
     ChunkFactorization::build(
         "test_chunk".to_string(),
-        facts,
+        &facts,
         bindings,
         logical_modules,
         HashMap::new(),
@@ -420,13 +420,17 @@ fn owner_graph_retains_reads_to_unassigned_declared_bindings() {
     let factorization = factorization_for("const A = X + 1; const X = 42;", &[("A", logical(0))]);
 
     assert!(
-        factorization.analysis.owner_graph.iter_edges().any(|edge| {
-            edge.from == OwnerId(0)
-                && edge.to == OwnerId(1)
-                && edge.reason.kind() == DepKind::EagerUse
-                && edge.reason.statement_ordinal() == StatementOrdinal(0)
-                && edge.reason.binding().is_some_and(|id| id.0 == "X")
-        }),
+        factorization
+            .analysis
+            .owner_graph()
+            .iter_edges()
+            .any(|edge| {
+                edge.from == OwnerId(0)
+                    && edge.to == OwnerId(1)
+                    && edge.reason.kind() == DepKind::EagerUse
+                    && edge.reason.statement_ordinal() == StatementOrdinal(0)
+                    && edge.reason.binding().is_some_and(|id| id.0 == "X")
+            }),
         "owner graph should retain the unassigned declared provider edge",
     );
     // The residual is the synthesized logical module at index 1
@@ -686,7 +690,7 @@ const impure = new Something(), pureBrand = Symbol("Brand");"#;
 
     let module = parse(source);
     let facts = analyze_facts(&module);
-    let graph = build_owner_graph(&facts);
+    let graph = build_owner_graph(&facts).unwrap();
     let impure_owner = owner_for_binding(&graph, "impure");
     let brand_owner = owner_for_binding(&graph, "pureBrand");
     assert_ne!(
@@ -719,7 +723,7 @@ fn split_three_declarator_let() {
 fn split_comma_list_attributes_later_declarator_read_to_later_owner() {
     let module = parse(r#"const first = Symbol("First"), second = first;"#);
     let facts = analyze_facts(&module);
-    let graph = build_owner_graph(&facts);
+    let graph = build_owner_graph(&facts).unwrap();
     let first_owner = owner_for_binding(&graph, "first");
     let second_owner = owner_for_binding(&graph, "second");
     let first_binding = test_id("first");
@@ -746,7 +750,7 @@ fn split_comma_list_rebind_unit_sticks_to_mutable_declarator_only() {
 mutable = mutable + 1;"#,
     );
     let facts = analyze_facts(&module);
-    let graph = build_owner_graph(&facts);
+    let graph = build_owner_graph(&facts).unwrap();
     let mutable_owner = owner_for_binding(&graph, "mutable");
     let peer_owner = owner_for_binding(&graph, "peer");
     let assign_owner = OwnerId(2);
@@ -1036,7 +1040,7 @@ fn validate_returns_empty_linker_order_for_cyclic_spec() {
 fn atomic_units_for(source: &str) -> Vec<AtomicUnit> {
     let module = parse(source);
     let facts = analyze_facts(&module);
-    let owner_graph = build_owner_graph(&facts);
+    let owner_graph = build_owner_graph(&facts).unwrap();
     compute_atomic_units(&owner_graph)
 }
 
@@ -1153,7 +1157,7 @@ fn atomic_units_lazy_rebind_merges() {
 fn partition_summary(factorization: &ChunkFactorization) -> Vec<(String, String)> {
     let mut out: Vec<(String, String)> = factorization
         .analysis
-        .owner_graph
+        .owner_graph()
         .iter_nodes()
         .map(|node| {
             let declared: Vec<String> = node.declared.iter().map(|id| id.0.to_string()).collect();

--- a/devinfra/js/debundle/analysis_tests/mod.rs
+++ b/devinfra/js/debundle/analysis_tests/mod.rs
@@ -46,7 +46,7 @@ fn analyze_facts(module: &Module) -> Vec<StatementFacts> {
 }
 
 /// A direct call `f()` at the chunk top level records `f` in the
-/// statement's `at_init_calls` set. Drives at-init call promotion
+/// statement's `calls.eager` set. Drives at-init call promotion
 /// per docs/design.md "At-init call promotion".
 #[test]
 fn at_init_call_recorded() {
@@ -54,15 +54,15 @@ fn at_init_call_recorded() {
     let facts = analyze_facts(&module);
     assert_eq!(facts.len(), 2);
     // function decl: callee never recorded for the decl itself.
-    assert!(facts[0].at_init_calls.is_empty());
-    assert!(facts[0].body_calls.is_empty());
+    assert!(facts[0].calls.eager.is_empty());
+    assert!(facts[0].calls.lazy.is_empty());
     // call statement: f() is at-init, no body reads.
-    assert_eq!(facts[1].at_init_calls, BTreeSet::from([test_id("f")]),);
-    assert!(facts[1].body_calls.is_empty());
+    assert_eq!(facts[1].calls.eager, BTreeSet::from([test_id("f")]),);
+    assert!(facts[1].calls.lazy.is_empty());
 }
 
-/// A call inside a function body lives in `body_calls`, not
-/// `at_init_calls`. The call only fires when the function is
+/// A call inside a function body lives in `calls.lazy`, not
+/// `calls.eager`. The call only fires when the function is
 /// invoked, so promotion treats it as a lazy edge of the
 /// containing function.
 #[test]
@@ -70,8 +70,8 @@ fn body_call_recorded() {
     let module = parse("function f() { g(); } function g() {}");
     let facts = analyze_facts(&module);
     // f's decl: its body calls g lazily.
-    assert!(facts[0].at_init_calls.is_empty());
-    assert_eq!(facts[0].body_calls, BTreeSet::from([test_id("g")]),);
+    assert!(facts[0].calls.eager.is_empty());
+    assert_eq!(facts[0].calls.lazy, BTreeSet::from([test_id("g")]),);
 }
 
 /// Indirect calls (`const g = f; g()`) are skipped — the callee
@@ -83,7 +83,7 @@ fn indirect_call_not_recorded() {
     let facts = analyze_facts(&module);
     // Last statement: `g()` records `g`, not `f`. (The aliasing
     // is unmodeled; callee resolution only sees `g`.)
-    assert_eq!(facts[2].at_init_calls, BTreeSet::from([test_id("g")]),);
+    assert_eq!(facts[2].calls.eager, BTreeSet::from([test_id("g")]),);
 }
 
 /// Method calls (`obj.method()`) are skipped — callee is a
@@ -92,49 +92,49 @@ fn indirect_call_not_recorded() {
 fn method_call_not_recorded() {
     let module = parse("const obj = {}; obj.method();");
     let facts = analyze_facts(&module);
-    // Last statement: no at_init_calls. `obj` is still recorded
+    // Last statement: no calls.eager. `obj` is still recorded
     // as an eager read.
-    assert!(facts[1].at_init_calls.is_empty());
-    assert!(facts[1].eager_reads.contains(&test_id("obj")));
+    assert!(facts[1].calls.eager.is_empty());
+    assert!(facts[1].reads.eager.contains(&test_id("obj")));
 }
 
 /// Class static field initializers fire at-init (class evaluation
-/// time). Calls in static initializers go into `at_init_calls`.
+/// time). Calls in static initializers go into `calls.eager`.
 #[test]
 fn class_static_init_call_is_at_init() {
     let module = parse("function f() {} class C { static x = f(); }");
     let facts = analyze_facts(&module);
-    assert_eq!(facts[1].at_init_calls, BTreeSet::from([test_id("f")]),);
-    assert!(facts[1].body_calls.is_empty());
+    assert_eq!(facts[1].calls.eager, BTreeSet::from([test_id("f")]),);
+    assert!(facts[1].calls.lazy.is_empty());
 }
 
 /// Class instance field initializers fire per-construction, not
-/// at class-decl time. Calls inside them are `body_calls`,
+/// at class-decl time. Calls inside them are `calls.lazy`,
 /// matching how the existing read collectors treat instance
 /// fields as lazy.
 #[test]
 fn class_instance_field_call_is_lazy() {
     let module = parse("function f() {} class C { x = f(); }");
     let facts = analyze_facts(&module);
-    assert!(facts[1].at_init_calls.is_empty());
-    assert_eq!(facts[1].body_calls, BTreeSet::from([test_id("f")]),);
+    assert!(facts[1].calls.eager.is_empty());
+    assert_eq!(facts[1].calls.lazy, BTreeSet::from([test_id("f")]),);
 }
 
 /// Nested calls in argument positions are still seen by the
 /// collector. `console.log(readB())` records both `console` (in
-/// eager_reads) and `readB` (in at_init_calls).
+/// reads.eager) and `readB` (in calls.eager).
 #[test]
 fn nested_call_arguments_record_inner_callee() {
     let module = parse("function readB() {} console.log(readB());");
     let facts = analyze_facts(&module);
     // The console.log statement: console is an eager read.
     // readB is recorded as an at-init call. console.log is a
-    // method call, so it's NOT in at_init_calls.
-    assert!(facts[1].eager_reads.contains(&test_id("console")));
-    assert_eq!(facts[1].at_init_calls, BTreeSet::from([test_id("readB")]),);
+    // method call, so it's NOT in calls.eager.
+    assert!(facts[1].reads.eager.contains(&test_id("console")));
+    assert_eq!(facts[1].calls.eager, BTreeSet::from([test_id("readB")]),);
 }
 
-/// VarDecl-bound arrow functions participate in body_calls the
+/// VarDecl-bound arrow functions participate in calls.lazy the
 /// same way function declarations do. `const f = () => g()` is
 /// a function carrier; the `g()` inside is lazy.
 #[test]
@@ -142,12 +142,12 @@ fn vardecl_arrow_body_call_recorded() {
     let module = parse("function g() {} const f = () => g();");
     let facts = analyze_facts(&module);
     // f's vardecl: g() is a lazy body call.
-    assert!(facts[1].at_init_calls.is_empty());
-    assert_eq!(facts[1].body_calls, BTreeSet::from([test_id("g")]),);
+    assert!(facts[1].calls.eager.is_empty());
+    assert_eq!(facts[1].calls.lazy, BTreeSet::from([test_id("g")]),);
 }
 
 /// A binding rebind inside a function's immediate body
-/// shows up in both `lazy_rebinds` and `first_order_lazy_rebinds`.
+/// shows up in both `rebinds.lazy` and `rebinds.first_order_lazy`.
 /// At-init promotion and the direct `lazy_rebind` owner edge
 /// both read from the first-order subset.
 #[test]
@@ -155,9 +155,9 @@ fn first_order_lazy_rebind_in_immediate_body() {
     let module = parse("let s = 0; function f() { s = 1; }");
     let facts = analyze_facts(&module);
     // f's decl: body rebinds s at depth 1.
-    assert_eq!(facts[1].lazy_rebinds, BTreeSet::from([test_id("s")]));
+    assert_eq!(facts[1].rebinds.lazy, BTreeSet::from([test_id("s")]));
     assert_eq!(
-        facts[1].first_order_lazy_rebinds,
+        facts[1].rebinds.first_order_lazy,
         BTreeSet::from([test_id("s")])
     );
 }
@@ -165,21 +165,21 @@ fn first_order_lazy_rebind_in_immediate_body() {
 /// A binding rebind inside a class method body sits at depth 1
 /// (the method's function body is the immediate body, just like
 /// a bare `function f() { ... }`). Must show up in
-/// `first_order_lazy_rebinds` so the owner-graph emits a
+/// `rebinds.first_order_lazy` so the owner-graph emits a
 /// constraining `LazyRebind` edge for it.
 #[test]
 fn first_order_lazy_rebind_in_class_method_body() {
     let module = parse("let counter = 0; class C { bump(b) { counter = b; } }");
     let facts = analyze_facts(&module);
-    assert_eq!(facts[1].lazy_rebinds, BTreeSet::from([test_id("counter")]));
+    assert_eq!(facts[1].rebinds.lazy, BTreeSet::from([test_id("counter")]));
     assert_eq!(
-        facts[1].first_order_lazy_rebinds,
+        facts[1].rebinds.first_order_lazy,
         BTreeSet::from([test_id("counter")])
     );
 }
 
 /// A binding rebind inside a nested closure (depth ≥ 2) shows
-/// up in `lazy_rebinds` but NOT in `first_order_lazy_rebinds`
+/// up in `rebinds.lazy` but NOT in `rebinds.first_order_lazy`
 /// — invoking the outer function synchronously only stashes
 /// the closure; the rebind doesn't fire. See
 /// `at_init_promotion_nested_closure_test`.
@@ -190,8 +190,8 @@ fn first_order_lazy_rebind_skips_nested_closure() {
          function f() { globalThis.fire = () => { s = 1; }; }",
     );
     let facts = analyze_facts(&module);
-    assert_eq!(facts[1].lazy_rebinds, BTreeSet::from([test_id("s")]));
-    assert!(facts[1].first_order_lazy_rebinds.is_empty());
+    assert_eq!(facts[1].rebinds.lazy, BTreeSet::from([test_id("s")]));
+    assert!(facts[1].rebinds.first_order_lazy.is_empty());
 }
 
 /// Same depth distinction for calls: a call in the immediate
@@ -204,14 +204,14 @@ fn first_order_body_call_skips_nested_closure() {
          function f() { globalThis.fire = () => { g(); }; }",
     );
     let facts = analyze_facts(&module);
-    assert_eq!(facts[1].body_calls, BTreeSet::from([test_id("g")]));
-    assert!(facts[1].first_order_body_calls.is_empty());
+    assert_eq!(facts[1].calls.lazy, BTreeSet::from([test_id("g")]));
+    assert!(facts[1].calls.first_order_lazy.is_empty());
 }
 
 /// A rebind that lexically precedes the first `await` in an async
 /// function body runs synchronously when the function is invoked
 /// (the engine doesn't suspend until it reaches the await), so it
-/// belongs in `first_order_lazy_rebinds`.
+/// belongs in `rebinds.first_order_lazy`.
 #[test]
 fn first_order_lazy_rebind_keeps_pre_await_in_async_body() {
     let module = parse(
@@ -219,9 +219,9 @@ fn first_order_lazy_rebind_keeps_pre_await_in_async_body() {
          async function f() { s = 1; await Promise.resolve(); }",
     );
     let facts = analyze_facts(&module);
-    assert_eq!(facts[1].lazy_rebinds, BTreeSet::from([test_id("s")]));
+    assert_eq!(facts[1].rebinds.lazy, BTreeSet::from([test_id("s")]));
     assert_eq!(
-        facts[1].first_order_lazy_rebinds,
+        facts[1].rebinds.first_order_lazy,
         BTreeSet::from([test_id("s")])
     );
 }
@@ -229,8 +229,8 @@ fn first_order_lazy_rebind_keeps_pre_await_in_async_body() {
 /// A rebind that lexically follows the first `await` in an async
 /// function body runs in a microtask after the at-init caller has
 /// finished — it doesn't fire synchronously when the function is
-/// invoked, so it must not appear in `first_order_lazy_rebinds`.
-/// The coarse `lazy_rebinds` still records it (it IS lazy from the
+/// invoked, so it must not appear in `rebinds.first_order_lazy`.
+/// The coarse `rebinds.lazy` still records it (it IS lazy from the
 /// chunk's top-level POV). See `at_init_promotion_post_await_test`.
 #[test]
 fn first_order_lazy_rebind_skips_after_await_in_async_body() {
@@ -239,8 +239,8 @@ fn first_order_lazy_rebind_skips_after_await_in_async_body() {
          async function f() { await Promise.resolve(); s = 1; }",
     );
     let facts = analyze_facts(&module);
-    assert_eq!(facts[1].lazy_rebinds, BTreeSet::from([test_id("s")]));
-    assert!(facts[1].first_order_lazy_rebinds.is_empty());
+    assert_eq!(facts[1].rebinds.lazy, BTreeSet::from([test_id("s")]));
+    assert!(facts[1].rebinds.first_order_lazy.is_empty());
 }
 
 /// Same await-boundary distinction for body calls.
@@ -251,8 +251,8 @@ fn first_order_body_call_skips_after_await_in_async_body() {
          async function f() { await Promise.resolve(); g(); }",
     );
     let facts = analyze_facts(&module);
-    assert_eq!(facts[1].body_calls, BTreeSet::from([test_id("g")]));
-    assert!(facts[1].first_order_body_calls.is_empty());
+    assert_eq!(facts[1].calls.lazy, BTreeSet::from([test_id("g")]));
+    assert!(facts[1].calls.first_order_lazy.is_empty());
 }
 
 #[test]
@@ -262,11 +262,11 @@ fn function_body_reads_are_lazy() {
     assert_eq!(facts.len(), 2);
     // f() declares "f"; its body reference to X is lazy.
     assert_eq!(facts[0].declared, BTreeSet::from([test_id("f")]));
-    assert!(!facts[0].eager_reads.contains(&test_id("X")));
+    assert!(!facts[0].reads.eager.contains(&test_id("X")));
     assert_eq!(facts[0].kind, StatementKind::FnDecl);
     // Y declares "Y"; init is `1` (no reads).
     assert_eq!(facts[1].declared, BTreeSet::from([test_id("Y")]));
-    assert!(facts[1].eager_reads.is_empty());
+    assert!(facts[1].reads.eager.is_empty());
 }
 
 #[test]
@@ -275,8 +275,8 @@ fn class_extends_clause_eager_read() {
     let facts = analyze_facts(&module);
     assert_eq!(facts.len(), 1);
     // extends A is eager; method body reference to X is lazy.
-    assert!(facts[0].eager_reads.contains(&test_id("A")));
-    assert!(!facts[0].eager_reads.contains(&test_id("X")));
+    assert!(facts[0].reads.eager.contains(&test_id("A")));
+    assert!(!facts[0].reads.eager.contains(&test_id("X")));
 }
 
 #[test]
@@ -284,14 +284,14 @@ fn computed_key_eager_read() {
     let module = parse("const M = { [k.foo]: 1 };");
     let facts = analyze_facts(&module);
     // The key expression `k.foo` reads `k` at-init.
-    assert!(facts[0].eager_reads.contains(&test_id("k")));
+    assert!(facts[0].reads.eager.contains(&test_id("k")));
 }
 
 #[test]
 fn class_static_init_eager_read() {
     let module = parse("class C { static x = Y; }");
     let facts = analyze_facts(&module);
-    assert!(facts[0].eager_reads.contains(&test_id("Y")));
+    assert!(facts[0].reads.eager.contains(&test_id("Y")));
 }
 
 #[test]
@@ -300,7 +300,7 @@ fn class_instance_init_is_lazy() {
     let facts = analyze_facts(&module);
     // Instance field initializer evaluates per-instance, not at
     // class-decl time.
-    assert!(!facts[0].eager_reads.contains(&test_id("Y")));
+    assert!(!facts[0].reads.eager.contains(&test_id("Y")));
 }
 
 #[test]
@@ -317,7 +317,7 @@ console.log("tail");"#,
     assert_eq!(facts[4].local_effects, BTreeSet::from([test_id("C")]));
     assert!(facts[4].purity.is_pure());
 
-    let graph = build_owner_graph(&facts);
+    let graph = build_owner_graph(&facts).unwrap();
     let local_effects: Vec<_> = graph
         .iter_edges()
         .filter(|edge| edge.reason.kind == DepKind::LocalEffect)
@@ -550,7 +550,7 @@ fn vendor_prune_policy_records_namespace_iife_local_effects() {
     let facts = analyze_facts_with_hints(&module, &hints);
     assert_eq!(facts[1].local_effects, BTreeSet::from([test_id("ns")]));
     assert!(facts[1].purity.is_pure());
-    assert!(facts[1].lazy_reads.contains(&test_id("wrap")));
+    assert!(facts[1].reads.lazy.contains(&test_id("wrap")));
 }
 
 #[test]
@@ -679,18 +679,18 @@ sideEffect(C, E);
         assert_eq!(af.ordinal, bf.ordinal);
         assert_eq!(af.kind, bf.kind);
         assert_eq!(af.declared, bf.declared);
-        assert_eq!(af.eager_reads, bf.eager_reads);
-        assert_eq!(af.eager_rebinds, bf.eager_rebinds);
-        assert_eq!(af.lazy_reads, bf.lazy_reads);
-        assert_eq!(af.lazy_rebinds, bf.lazy_rebinds);
-        assert_eq!(af.first_order_lazy_reads, bf.first_order_lazy_reads);
-        assert_eq!(af.first_order_lazy_rebinds, bf.first_order_lazy_rebinds);
-        assert_eq!(af.at_init_calls, bf.at_init_calls);
-        assert_eq!(af.body_calls, bf.body_calls);
-        assert_eq!(af.first_order_body_calls, bf.first_order_body_calls);
-        assert_eq!(af.effects.reads, bf.effects.reads);
-        assert_eq!(af.effects.writes, bf.effects.writes);
-        // `effects.dataflow_summarizable` is deliberately NOT
+        assert_eq!(af.reads.eager, bf.reads.eager);
+        assert_eq!(af.rebinds.eager, bf.rebinds.eager);
+        assert_eq!(af.reads.lazy, bf.reads.lazy);
+        assert_eq!(af.rebinds.lazy, bf.rebinds.lazy);
+        assert_eq!(af.reads.first_order_lazy, bf.reads.first_order_lazy);
+        assert_eq!(af.rebinds.first_order_lazy, bf.rebinds.first_order_lazy);
+        assert_eq!(af.calls.eager, bf.calls.eager);
+        assert_eq!(af.calls.lazy, bf.calls.lazy);
+        assert_eq!(af.calls.first_order_lazy, bf.calls.first_order_lazy);
+        assert_eq!(af.effects().reads, bf.effects().reads);
+        assert_eq!(af.effects().writes, bf.effects().writes);
+        // `dataflow_summarizable` is deliberately NOT
         // compared: the opaque-at-init-call bail consults the purity
         // classifier (declared-pure hints exempt a call from the
         // bail), so the bit is policy-DEPENDENT by design. The

--- a/devinfra/js/debundle/artifact.rs
+++ b/devinfra/js/debundle/artifact.rs
@@ -354,18 +354,13 @@ pub struct DirectoryDependencyFact {
 }
 
 /// Per-chunk report serialized to `reports/tree/<chunk>/chunk.json` at write time.
+/// The analysis report is flattened so the serialized shape is the
+/// analysis fields followed by the decomposition/metrics fields —
+/// identical to the previous field-by-field copy.
 #[derive(Debug, Clone, Serialize)]
 pub struct ChunkManifest {
-    pub chunk_id: String,
-    pub source_path: String,
-    pub parser: ParserOptionsRecord,
-    pub entry_file: String,
-    pub counts: ChunkCounts,
-    pub files: Vec<ChunkFileRecord>,
-    pub imports: Vec<ImportRecord>,
-    pub export_aliases: Vec<ExportAliasRecord>,
-    pub unresolved_exports: Vec<ExportAliasRecord>,
-    pub kept_top_level_declarations: Vec<KeptTopLevelDeclarationRecord>,
+    #[serde(flatten)]
+    pub analysis: ChunkAnalysisReport,
     pub validation: ChunkValidationSummary,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub logical_modules: Option<ChunkLogicalModulesSummary>,
@@ -380,16 +375,7 @@ impl ChunkManifest {
         output_metrics: OutputMetrics,
     ) -> Self {
         Self {
-            chunk_id: analysis.chunk_id.clone(),
-            source_path: analysis.source_path.clone(),
-            parser: analysis.parser.clone(),
-            entry_file: analysis.entry_file.clone(),
-            counts: analysis.counts.clone(),
-            files: analysis.files.clone(),
-            imports: analysis.imports.clone(),
-            export_aliases: analysis.export_aliases.clone(),
-            unresolved_exports: analysis.unresolved_exports.clone(),
-            kept_top_level_declarations: analysis.kept_top_level_declarations.clone(),
+            analysis: analysis.clone(),
             validation: decomposition.map_or_else(
                 || ChunkValidationSummary {
                     status: "not_materialized",

--- a/devinfra/js/debundle/atomic_units.rs
+++ b/devinfra/js/debundle/atomic_units.rs
@@ -29,7 +29,10 @@ use petgraph::graphmap::DiGraphMap;
 use serde::{Deserialize, Serialize};
 
 use crate::facts::StatementFacts;
-use crate::graph::{DepKind, OwnerGraph, OwnerGraphOptions, OwnerId, build_owner_graph_with};
+use crate::graph::{
+    DepKind, DuplicateTopLevelDeclaration, OwnerGraph, OwnerGraphOptions, OwnerId,
+    build_owner_graph_with,
+};
 
 /// One atomic factor unit: a set of owners that any valid
 /// factorization must keep co-located, plus the `DepKind`s of the
@@ -61,7 +64,9 @@ pub struct OwnerGraphAndUnits {
 /// default (strictly-conservative) [`OwnerGraphOptions`] — call
 /// [`compute_owner_graph_and_units_with`] when the chunk spec opts
 /// into conditionally-correct refinements.
-pub fn compute_owner_graph_and_units(facts: &[StatementFacts]) -> OwnerGraphAndUnits {
+pub fn compute_owner_graph_and_units(
+    facts: &[StatementFacts],
+) -> Result<OwnerGraphAndUnits, DuplicateTopLevelDeclaration> {
     compute_owner_graph_and_units_with(facts, OwnerGraphOptions::default())
 }
 
@@ -70,13 +75,13 @@ pub fn compute_owner_graph_and_units(facts: &[StatementFacts]) -> OwnerGraphAndU
 pub fn compute_owner_graph_and_units_with(
     facts: &[StatementFacts],
     options: OwnerGraphOptions,
-) -> OwnerGraphAndUnits {
-    let owner_graph = build_owner_graph_with(facts, options);
+) -> Result<OwnerGraphAndUnits, DuplicateTopLevelDeclaration> {
+    let owner_graph = build_owner_graph_with(facts, options)?;
     let atomic_units = compute_atomic_units(&owner_graph);
-    OwnerGraphAndUnits {
+    Ok(OwnerGraphAndUnits {
         owner_graph,
         atomic_units,
-    }
+    })
 }
 
 /// Compute atomic factor units for an owner graph. Returns one unit

--- a/devinfra/js/debundle/chunk_analysis.rs
+++ b/devinfra/js/debundle/chunk_analysis.rs
@@ -1,11 +1,10 @@
 //! Per-chunk analysis state: inputs, IR, and input-derived caches.
 //!
 //! [`ChunkAnalysis`] is what's known about a chunk before factorize
-//! runs — the facts harvested from the AST, the spec-supplied
-//! logical modules and chunk renames, the owner graph derived from
-//! those facts, and the small lookup caches that depend only on
-//! inputs. The factorize algorithm consumes a `ChunkAnalysis` plus
-//! a default destination to produce a
+//! runs — the spec-supplied logical modules, the binding catalogue,
+//! the owner graph derived from the chunk facts, and the small
+//! lookup caches that depend only on inputs. The factorize algorithm
+//! consumes a `ChunkAnalysis` plus a default destination to produce a
 //! [`crate::ChunkFactorization`] — the partition-and-derived state
 //! that depends on which logical-module assignment the spec chose.
 
@@ -15,32 +14,23 @@ use swc_atoms::Atom;
 use swc_ecma_ast::Id;
 
 use analysis::reports::owner_key;
-use analysis::{
-    BindingKind, LogicalModule, LogicalModuleIndex, ModuleId, OwnerGraph, StatementFacts,
-};
+use analysis::{BindingKind, LogicalModule, LogicalModuleIndex, ModuleId, OwnerGraph};
 
 /// Per-chunk inputs + IR + input-derived caches.
 ///
 /// Constructed once per chunk and held by reference (typically via
 /// `Arc<ChunkAnalysis>`) by every [`crate::ChunkFactorization`]
 /// candidate that explores a partition over the same owner graph.
+/// All fields are private: the lookup tables are precomputed from the
+/// inputs at [`ChunkAnalysis::build`] time, so a mutable input field
+/// would silently stale the caches. Read access goes through the
+/// accessors below.
 #[derive(Debug, Clone)]
 pub struct ChunkAnalysis {
-    pub chunk_id: String,
-    pub facts: Vec<StatementFacts>,
-    /// All top-level bindings of the chunk indexed by local name.
-    /// Iteration order is undefined; consumers that need a
-    /// deterministic order (emit sites, error messages) must sort
-    /// the keys themselves.
-    pub bindings: HashMap<Id, BindingKind>,
-    pub logical_modules: Vec<LogicalModule>,
-    /// In-place readability renames for bindings that stay in
-    /// entry. Iteration order is undefined; the
-    /// `materialize_logical_modules` validation pass sorts the
-    /// keys before iterating so any spec errors it emits stay
-    /// deterministic.
-    pub chunk_renames: HashMap<Id, Atom>,
-    pub owner_graph: OwnerGraph,
+    chunk_id: String,
+    bindings: HashMap<Id, BindingKind>,
+    logical_modules: Vec<LogicalModule>,
+    owner_graph: OwnerGraph,
     owner_report_ids_by_binding: HashMap<Id, Vec<String>>,
     binding_lookup_by_id: HashMap<Id, BindingLookupInfo>,
 }
@@ -58,27 +48,48 @@ impl ChunkAnalysis {
     /// Build a `ChunkAnalysis` reusing a caller-supplied owner graph.
     /// `bindings` should already have every `Owned` binding the spec
     /// assigned and every `Imported` binding the spec re-exports.
+    ///
+    /// `chunk_renames` (in-place readability renames for bindings
+    /// that stay in entry) feed the export-name lookup table but are
+    /// not retained beyond construction.
     pub fn build(
         chunk_id: String,
-        facts: Vec<StatementFacts>,
         owner_graph: OwnerGraph,
         bindings: HashMap<Id, BindingKind>,
         logical_modules: Vec<LogicalModule>,
-        chunk_renames: HashMap<Id, Atom>,
+        chunk_renames: &HashMap<Id, Atom>,
     ) -> Self {
         let owner_report_ids_by_binding = build_owner_report_ids_by_binding(&owner_graph);
         let binding_lookup_by_id =
-            build_binding_lookup_by_id(&bindings, &chunk_renames, &logical_modules);
+            build_binding_lookup_by_id(&bindings, chunk_renames, &logical_modules);
         Self {
             chunk_id,
-            facts,
             bindings,
             logical_modules,
-            chunk_renames,
             owner_graph,
             owner_report_ids_by_binding,
             binding_lookup_by_id,
         }
+    }
+
+    pub fn chunk_id(&self) -> &str {
+        &self.chunk_id
+    }
+
+    /// All top-level bindings of the chunk indexed by local name.
+    /// Iteration order is undefined; consumers that need a
+    /// deterministic order (emit sites, error messages) must sort
+    /// the keys themselves.
+    pub fn bindings(&self) -> &HashMap<Id, BindingKind> {
+        &self.bindings
+    }
+
+    pub fn logical_modules(&self) -> &[LogicalModule] {
+        &self.logical_modules
+    }
+
+    pub fn owner_graph(&self) -> &OwnerGraph {
+        &self.owner_graph
     }
 
     /// Pre-computed export name for a chunk binding, falling back

--- a/devinfra/js/debundle/chunk_factorization.rs
+++ b/devinfra/js/debundle/chunk_factorization.rs
@@ -62,18 +62,23 @@ impl ChunkFactorization {
     /// units internally. Call sites that already have those precomputed
     /// (e.g. the materializer reuses them for mini-factor synthesis)
     /// should call [`Self::build_with`] instead.
+    ///
+    /// Panics on facts where two statements declare the same binding
+    /// (`analysis::DuplicateTopLevelDeclaration`) — the production
+    /// path goes through `compute_stage_one_analysis`, which surfaces
+    /// that as a spec-facing error before any factorization runs.
     pub fn build(
         chunk_id: String,
-        facts: Vec<analysis::StatementFacts>,
+        facts: &[analysis::StatementFacts],
         bindings: HashMap<swc_ecma_ast::Id, analysis::BindingKind>,
         logical_modules: Vec<LogicalModule>,
         chunk_renames: HashMap<swc_ecma_ast::Id, swc_atoms::Atom>,
         default_destination: ModuleId,
     ) -> Self {
-        let precomputed = compute_owner_graph_and_units(&facts);
+        let precomputed =
+            compute_owner_graph_and_units(facts).expect("chunk facts declare a binding twice");
         Self::build_with(
             chunk_id,
-            facts,
             precomputed,
             bindings,
             logical_modules,
@@ -88,7 +93,6 @@ impl ChunkFactorization {
     /// factorization doesn't redo the work.
     pub fn build_with(
         chunk_id: String,
-        facts: Vec<analysis::StatementFacts>,
         precomputed: OwnerGraphAndUnits,
         bindings: HashMap<swc_ecma_ast::Id, analysis::BindingKind>,
         logical_modules: Vec<LogicalModule>,
@@ -133,11 +137,10 @@ impl ChunkFactorization {
         );
         let analysis = Arc::new(ChunkAnalysis::build(
             chunk_id,
-            facts,
             owner_graph,
             bindings,
             logical_modules,
-            chunk_renames,
+            &chunk_renames,
         ));
         Self {
             analysis,
@@ -170,7 +173,7 @@ impl ChunkFactorization {
     /// resulting report to fix any cycles or atomic-unit conflicts.
     pub fn validate(&self) -> FactorizationReport {
         let mut report =
-            validate_factorization(&self.analysis.owner_graph, &self.partition, &|id| {
+            validate_factorization(self.analysis.owner_graph(), &self.partition, &|id| {
                 self.analysis.module_path(id)
             });
         report.atomic_unit_conflicts = self.assembly_conflicts.clone();

--- a/devinfra/js/debundle/cli/edit_gate.rs
+++ b/devinfra/js/debundle/cli/edit_gate.rs
@@ -360,7 +360,8 @@ pub fn gate_post_edit_partition(
     // which is fine for `check_realizability`/`validate_factorization`
     // (both consume the partition we build below, not the per-owner
     // declared field).
-    let (owner_graph, _index) = OwnerGraph::from_report(&owner_graph_report, &[]);
+    let (owner_graph, _index) = OwnerGraph::from_report(&owner_graph_report, &[])
+        .with_context(|| format!("reconstructing owner graph {}", owner_graph_path.display()))?;
 
     // owner_by_binding_name uses the Atom-only declared_bindings the
     // wire shape carries; that's enough because the spec author also

--- a/devinfra/js/debundle/cli/mod.rs
+++ b/devinfra/js/debundle/cli/mod.rs
@@ -4,6 +4,7 @@ pub mod edit_gate;
 pub mod gate;
 pub mod module;
 pub mod outcome;
+pub mod scc_cluster;
 pub mod yaml_edit;
 
 use std::path::PathBuf;
@@ -19,14 +20,15 @@ use crate::edit_gate::Gate;
 use crate::gate::{GateArgs, run_gate_cli};
 use crate::module::{DeleteArgs, MergeArgs, ModuleArgs, run_delete, run_merge, run_module_cli};
 use crate::outcome::{emit_gate_rejection_json, print_outcome_json};
+use crate::scc_cluster::{ClusterArgs, SccArgs, run_cluster, run_scc};
 use anyhow::{Context, Result};
 use clap::{Args as ClapArgs, Parser, Subcommand};
 use peel::factorize::DEFAULT_SIZE_CAP_LINES;
 use peel::{
     CommonArgs as PeelCommonArgs, ExplainArgs, GraphSummaryArgs, OutputFormat, PatchPlanArgs,
     PeelArgs, PeelCommand, PlanWorkArgs, SelectionArgs, SourceSliceArgs, UnitsArgs, print_report,
-    resolve_binding_owners, run_explain_report, run_graph_summary_report, run_patch_plan_report,
-    run_plan_work_report, run_source_slice_report, run_units_report,
+    run_explain_report, run_graph_summary_report, run_patch_plan_report, run_plan_work_report,
+    run_source_slice_report, run_units_report,
 };
 use pipeline::{TransformArgs, TransformRunOptions, run_transform_cli_with_options};
 use selector_debt::{SelectorDebtReport, compute_selector_debt, render_selector_debt_text};
@@ -141,99 +143,6 @@ pub struct SelectorDebtArgs {
     /// emits one tagged object per row plus a final `summary` line.
     #[arg(long, value_enum)]
     pub format: Option<OutputFormat>,
-}
-
-/// Args for `debundle scc`.
-#[derive(Debug, ClapArgs)]
-pub struct SccArgs {
-    #[command(flatten)]
-    pub common: PeelCommonArgs,
-
-    /// Restrict output to the SCC containing this binding's home module.
-    #[arg(long = "binding")]
-    pub binding: Option<String>,
-
-    /// Restrict to SCCs that are true cycles (≥2 modules in a loop).
-    #[arg(long = "cycles-only")]
-    pub cycles_only: bool,
-
-    /// Restrict to SCCs containing the residual catch-all module.
-    #[arg(long = "residual-only")]
-    pub residual_only: bool,
-
-    /// Restrict to singleton (size-1) SCCs.
-    #[arg(long = "singletons-only")]
-    pub singletons_only: bool,
-
-    /// Output format. Default `text` on tty, `json` on pipe.
-    #[arg(long, value_enum)]
-    pub format: Option<OutputFormat>,
-}
-
-/// Args for `debundle cluster <sym>`.
-#[derive(Debug, ClapArgs)]
-pub struct ClusterArgs {
-    /// Binding identifier (minified or readable). May also be supplied
-    /// as `--binding <sym>` (the spelling some operator skills use).
-    pub sym: Option<String>,
-
-    /// Alias for the positional `<sym>`.
-    #[arg(long = "binding")]
-    pub binding: Option<String>,
-
-    #[command(flatten)]
-    pub common: PeelCommonArgs,
-
-    /// Output format. Default `text` on tty, `json` on pipe.
-    #[arg(long, value_enum)]
-    pub format: Option<OutputFormat>,
-}
-
-impl ClusterArgs {
-    /// Resolve the binding from either the positional `<sym>` or the
-    /// `--binding` alias; exactly one must be present.
-    fn resolve_sym(&self) -> Result<&str> {
-        match (self.sym.as_deref(), self.binding.as_deref()) {
-            (Some(sym), None) | (None, Some(sym)) => Ok(sym),
-            (Some(_), Some(_)) => {
-                anyhow::bail!("pass the binding once: positional <sym> or --binding, not both")
-            }
-            (None, None) => {
-                anyhow::bail!("missing binding: pass it positionally or as --binding <sym>")
-            }
-        }
-    }
-}
-
-#[derive(Debug, Clone, serde::Serialize)]
-pub struct SccReport {
-    pub sccs: Vec<SccEntry>,
-}
-
-#[derive(Debug, Clone, serde::Serialize)]
-pub struct SccEntry {
-    pub id: String,
-    pub modules: Vec<String>,
-    pub labels: Vec<String>,
-    pub is_cycle: bool,
-    pub realizable: bool,
-}
-
-/// A module-quotient node as both its interned `logical:N` id and its
-/// human-readable path label, so cluster output is legible without a
-/// second `describe` round-trip (CLI_DOGFOOD #2).
-#[derive(Debug, Clone, serde::Serialize)]
-pub struct ModuleRef {
-    pub id: String,
-    pub label: String,
-}
-
-#[derive(Debug, Clone, serde::Serialize)]
-pub struct ClusterReport {
-    pub binding: String,
-    pub home_module: ModuleRef,
-    pub incoming_modules: Vec<ModuleRef>,
-    pub outgoing_modules: Vec<ModuleRef>,
 }
 
 /// Args for `debundle modules ...`. Aggregates the existing
@@ -730,171 +639,6 @@ fn run_show_source(args: ShowSourceArgs) -> Result<()> {
     };
     let report = run_source_slice_report(&inner)?;
     print_report(&report, format, render_source_slice_text).context("writing show-source output")
-}
-
-fn run_scc(args: SccArgs) -> Result<()> {
-    let graph: analysis::OwnerGraphReport = serde_json::from_str(
-        &std::fs::read_to_string(&args.common.owner_graph_path)
-            .with_context(|| format!("reading {}", args.common.owner_graph_path.display()))?,
-    )
-    .with_context(|| {
-        format!(
-            "parsing owner graph {}",
-            args.common.owner_graph_path.display()
-        )
-    })?;
-    // If a binding was supplied, find its owner -> destination module
-    // first; we restrict SCCs to ones containing that destination.
-    // Uses the shared `resolve_binding_owners` helper so minified and
-    // readable name forms both resolve.
-    let restrict_to_module: Option<analysis::ModuleKey> = if let Some(sym) = &args.binding {
-        let owner = resolve_binding_owners(&graph, sym)
-            .into_iter()
-            .next()
-            .ok_or_else(|| anyhow::anyhow!("no owner declares binding {sym:?}"))?;
-        Some(owner.destination.clone())
-    } else {
-        None
-    };
-
-    let mut entries: Vec<SccEntry> = Vec::new();
-    for scc in &graph.quotient.sccs {
-        let is_cycle = scc.is_cycle;
-        let is_singleton = scc.modules.len() == 1;
-        let touches_residual = scc.modules.iter().any(|m| graph.is_residual(m));
-        if args.cycles_only && !is_cycle {
-            continue;
-        }
-        if args.singletons_only && !is_singleton {
-            continue;
-        }
-        if args.residual_only && !touches_residual {
-            continue;
-        }
-        if let Some(want) = &restrict_to_module {
-            if !scc.modules.contains(want) {
-                continue;
-            }
-        }
-        // Resolve each interned key to its human path via the module
-        // table for the `labels` view; the wire stores the path once.
-        let labels: Vec<String> = scc
-            .modules
-            .iter()
-            .map(|key| {
-                graph
-                    .module(key)
-                    .map(|entry| entry.path.to_string())
-                    .unwrap_or_else(|| key.as_str().to_string())
-            })
-            .collect();
-        entries.push(SccEntry {
-            id: scc.id.clone(),
-            modules: scc.modules.iter().map(|k| k.as_str().to_string()).collect(),
-            labels,
-            is_cycle,
-            realizable: scc.realizable,
-        });
-    }
-    let report = SccReport { sccs: entries };
-    let format = OutputFormat::resolve(args.format);
-    if format == OutputFormat::Ndjson {
-        for entry in &report.sccs {
-            println!("{}", serde_json::to_string(entry)?);
-        }
-        return Ok(());
-    }
-    print_report(&report, format, render_scc_text).context("writing scc output")
-}
-
-fn render_scc_text(report: &SccReport, out: &mut String) {
-    out.push_str(&format!("{} scc(s)\n", report.sccs.len()));
-    for scc in &report.sccs {
-        let flags = match (scc.is_cycle, scc.realizable) {
-            (true, true) => "[cycle,realizable]",
-            (true, false) => "[cycle,UNREALIZABLE]",
-            (false, _) => "",
-        };
-        out.push_str(&format!(
-            "  {}  modules=[{}]  {}\n",
-            scc.id,
-            scc.modules.join(", "),
-            flags
-        ));
-    }
-}
-
-fn run_cluster(args: ClusterArgs) -> Result<()> {
-    let sym = args.resolve_sym()?;
-    let graph: analysis::OwnerGraphReport = serde_json::from_str(
-        &std::fs::read_to_string(&args.common.owner_graph_path)
-            .with_context(|| format!("reading {}", args.common.owner_graph_path.display()))?,
-    )?;
-    // Use the shared `resolve_binding_owners` helper (same code path
-    // `describe` / `show-source` / `scc --binding` use), so minified
-    // and readable names both work.
-    let owner = resolve_binding_owners(&graph, sym)
-        .into_iter()
-        .next()
-        .ok_or_else(|| anyhow::anyhow!("no owner declares binding {sym:?}"))?;
-    let home_key = &owner.destination;
-    // Dedup + sort by interned id; carry the path label alongside.
-    let mut incoming: std::collections::BTreeMap<String, ModuleRef> =
-        std::collections::BTreeMap::new();
-    let mut outgoing: std::collections::BTreeMap<String, ModuleRef> =
-        std::collections::BTreeMap::new();
-    for edge in &graph.quotient.edges {
-        if &edge.target == home_key && &edge.source != home_key {
-            let module_ref = resolve_module_ref(&graph, &edge.source);
-            incoming.insert(module_ref.id.clone(), module_ref);
-        }
-        if &edge.source == home_key && &edge.target != home_key {
-            let module_ref = resolve_module_ref(&graph, &edge.target);
-            outgoing.insert(module_ref.id.clone(), module_ref);
-        }
-    }
-    let report = ClusterReport {
-        binding: sym.to_string(),
-        home_module: resolve_module_ref(&graph, home_key),
-        incoming_modules: incoming.into_values().collect(),
-        outgoing_modules: outgoing.into_values().collect(),
-    };
-    let format = OutputFormat::resolve(args.format);
-    print_report(&report, format, render_cluster_text).context("writing cluster output")
-}
-
-/// Pair an interned module key with its human path label, falling back
-/// to the raw key string when the module table has no entry for it.
-fn resolve_module_ref(graph: &analysis::OwnerGraphReport, key: &analysis::ModuleKey) -> ModuleRef {
-    ModuleRef {
-        id: key.as_str().to_string(),
-        label: graph
-            .module(key)
-            .map(|entry| entry.path.to_string())
-            .unwrap_or_else(|| key.as_str().to_string()),
-    }
-}
-
-fn render_cluster_text(report: &ClusterReport, out: &mut String) {
-    out.push_str(&format!(
-        "binding={} home={} ({})\n",
-        report.binding, report.home_module.label, report.home_module.id,
-    ));
-    out.push_str(&format!(
-        "  incoming: {}\n",
-        join_module_labels(&report.incoming_modules)
-    ));
-    out.push_str(&format!(
-        "  outgoing: {}\n",
-        join_module_labels(&report.outgoing_modules)
-    ));
-}
-
-fn join_module_labels(refs: &[ModuleRef]) -> String {
-    refs.iter()
-        .map(|module_ref| module_ref.label.as_str())
-        .collect::<Vec<_>>()
-        .join(", ")
 }
 
 fn run_bindings_list_cmd(args: BindingsListNsArgs) -> Result<()> {

--- a/devinfra/js/debundle/cli/scc_cluster.rs
+++ b/devinfra/js/debundle/cli/scc_cluster.rs
@@ -1,0 +1,264 @@
+//! `debundle scc` / `debundle cluster`: module-quotient SCC listing
+//! and per-binding neighbor queries over a generated owner graph.
+
+use anyhow::{Context, Result};
+use clap::Args as ClapArgs;
+use peel::{CommonArgs as PeelCommonArgs, OutputFormat, print_report, resolve_binding_owners};
+
+/// Args for `debundle scc`.
+#[derive(Debug, ClapArgs)]
+pub struct SccArgs {
+    #[command(flatten)]
+    pub common: PeelCommonArgs,
+
+    /// Restrict output to the SCC containing this binding's home module.
+    #[arg(long = "binding")]
+    pub binding: Option<String>,
+
+    /// Restrict to SCCs that are true cycles (≥2 modules in a loop).
+    #[arg(long = "cycles-only")]
+    pub cycles_only: bool,
+
+    /// Restrict to SCCs containing the residual catch-all module.
+    #[arg(long = "residual-only")]
+    pub residual_only: bool,
+
+    /// Restrict to singleton (size-1) SCCs.
+    #[arg(long = "singletons-only")]
+    pub singletons_only: bool,
+
+    /// Output format. Default `text` on tty, `json` on pipe.
+    #[arg(long, value_enum)]
+    pub format: Option<OutputFormat>,
+}
+
+/// Args for `debundle cluster <sym>`.
+#[derive(Debug, ClapArgs)]
+pub struct ClusterArgs {
+    /// Binding identifier (minified or readable). May also be supplied
+    /// as `--binding <sym>` (the spelling some operator skills use).
+    pub sym: Option<String>,
+
+    /// Alias for the positional `<sym>`.
+    #[arg(long = "binding")]
+    pub binding: Option<String>,
+
+    #[command(flatten)]
+    pub common: PeelCommonArgs,
+
+    /// Output format. Default `text` on tty, `json` on pipe.
+    #[arg(long, value_enum)]
+    pub format: Option<OutputFormat>,
+}
+
+impl ClusterArgs {
+    /// Resolve the binding from either the positional `<sym>` or the
+    /// `--binding` alias; exactly one must be present.
+    fn resolve_sym(&self) -> Result<&str> {
+        match (self.sym.as_deref(), self.binding.as_deref()) {
+            (Some(sym), None) | (None, Some(sym)) => Ok(sym),
+            (Some(_), Some(_)) => {
+                anyhow::bail!("pass the binding once: positional <sym> or --binding, not both")
+            }
+            (None, None) => {
+                anyhow::bail!("missing binding: pass it positionally or as --binding <sym>")
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SccReport {
+    pub sccs: Vec<SccEntry>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SccEntry {
+    pub id: String,
+    pub modules: Vec<String>,
+    pub labels: Vec<String>,
+    pub is_cycle: bool,
+    pub realizable: bool,
+}
+
+/// A module-quotient node as both its interned `logical:N` id and its
+/// human-readable path label, so cluster output is legible without a
+/// second `describe` round-trip (CLI_DOGFOOD #2).
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ModuleRef {
+    pub id: String,
+    pub label: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ClusterReport {
+    pub binding: String,
+    pub home_module: ModuleRef,
+    pub incoming_modules: Vec<ModuleRef>,
+    pub outgoing_modules: Vec<ModuleRef>,
+}
+
+pub fn run_scc(args: SccArgs) -> Result<()> {
+    let graph: analysis::OwnerGraphReport = serde_json::from_str(
+        &std::fs::read_to_string(&args.common.owner_graph_path)
+            .with_context(|| format!("reading {}", args.common.owner_graph_path.display()))?,
+    )
+    .with_context(|| {
+        format!(
+            "parsing owner graph {}",
+            args.common.owner_graph_path.display()
+        )
+    })?;
+    // If a binding was supplied, find its owner -> destination module
+    // first; we restrict SCCs to ones containing that destination.
+    // Uses the shared `resolve_binding_owners` helper so minified and
+    // readable name forms both resolve.
+    let restrict_to_module: Option<analysis::ModuleKey> = if let Some(sym) = &args.binding {
+        let owner = resolve_binding_owners(&graph, sym)
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("no owner declares binding {sym:?}"))?;
+        Some(owner.destination.clone())
+    } else {
+        None
+    };
+
+    let mut entries: Vec<SccEntry> = Vec::new();
+    for scc in &graph.quotient.sccs {
+        let is_cycle = scc.is_cycle;
+        let is_singleton = scc.modules.len() == 1;
+        let touches_residual = scc.modules.iter().any(|m| graph.is_residual(m));
+        if args.cycles_only && !is_cycle {
+            continue;
+        }
+        if args.singletons_only && !is_singleton {
+            continue;
+        }
+        if args.residual_only && !touches_residual {
+            continue;
+        }
+        if let Some(want) = &restrict_to_module {
+            if !scc.modules.contains(want) {
+                continue;
+            }
+        }
+        // Resolve each interned key to its human path via the module
+        // table for the `labels` view; the wire stores the path once.
+        let labels: Vec<String> = scc
+            .modules
+            .iter()
+            .map(|key| {
+                graph
+                    .module(key)
+                    .map(|entry| entry.path.to_string())
+                    .unwrap_or_else(|| key.as_str().to_string())
+            })
+            .collect();
+        entries.push(SccEntry {
+            id: scc.id.clone(),
+            modules: scc.modules.iter().map(|k| k.as_str().to_string()).collect(),
+            labels,
+            is_cycle,
+            realizable: scc.realizable,
+        });
+    }
+    let report = SccReport { sccs: entries };
+    let format = OutputFormat::resolve(args.format);
+    if format == OutputFormat::Ndjson {
+        for entry in &report.sccs {
+            println!("{}", serde_json::to_string(entry)?);
+        }
+        return Ok(());
+    }
+    print_report(&report, format, render_scc_text).context("writing scc output")
+}
+
+fn render_scc_text(report: &SccReport, out: &mut String) {
+    out.push_str(&format!("{} scc(s)\n", report.sccs.len()));
+    for scc in &report.sccs {
+        let flags = match (scc.is_cycle, scc.realizable) {
+            (true, true) => "[cycle,realizable]",
+            (true, false) => "[cycle,UNREALIZABLE]",
+            (false, _) => "",
+        };
+        out.push_str(&format!(
+            "  {}  modules=[{}]  {}\n",
+            scc.id,
+            scc.modules.join(", "),
+            flags
+        ));
+    }
+}
+
+pub fn run_cluster(args: ClusterArgs) -> Result<()> {
+    let sym = args.resolve_sym()?;
+    let graph: analysis::OwnerGraphReport = serde_json::from_str(
+        &std::fs::read_to_string(&args.common.owner_graph_path)
+            .with_context(|| format!("reading {}", args.common.owner_graph_path.display()))?,
+    )?;
+    // Use the shared `resolve_binding_owners` helper (same code path
+    // `describe` / `show-source` / `scc --binding` use), so minified
+    // and readable names both work.
+    let owner = resolve_binding_owners(&graph, sym)
+        .into_iter()
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("no owner declares binding {sym:?}"))?;
+    let home_key = &owner.destination;
+    // Dedup + sort by interned id; carry the path label alongside.
+    let mut incoming: std::collections::BTreeMap<String, ModuleRef> =
+        std::collections::BTreeMap::new();
+    let mut outgoing: std::collections::BTreeMap<String, ModuleRef> =
+        std::collections::BTreeMap::new();
+    for edge in &graph.quotient.edges {
+        if &edge.target == home_key && &edge.source != home_key {
+            let module_ref = resolve_module_ref(&graph, &edge.source);
+            incoming.insert(module_ref.id.clone(), module_ref);
+        }
+        if &edge.source == home_key && &edge.target != home_key {
+            let module_ref = resolve_module_ref(&graph, &edge.target);
+            outgoing.insert(module_ref.id.clone(), module_ref);
+        }
+    }
+    let report = ClusterReport {
+        binding: sym.to_string(),
+        home_module: resolve_module_ref(&graph, home_key),
+        incoming_modules: incoming.into_values().collect(),
+        outgoing_modules: outgoing.into_values().collect(),
+    };
+    let format = OutputFormat::resolve(args.format);
+    print_report(&report, format, render_cluster_text).context("writing cluster output")
+}
+
+/// Pair an interned module key with its human path label, falling back
+/// to the raw key string when the module table has no entry for it.
+fn resolve_module_ref(graph: &analysis::OwnerGraphReport, key: &analysis::ModuleKey) -> ModuleRef {
+    ModuleRef {
+        id: key.as_str().to_string(),
+        label: graph
+            .module(key)
+            .map(|entry| entry.path.to_string())
+            .unwrap_or_else(|| key.as_str().to_string()),
+    }
+}
+
+fn render_cluster_text(report: &ClusterReport, out: &mut String) {
+    out.push_str(&format!(
+        "binding={} home={} ({})\n",
+        report.binding, report.home_module.label, report.home_module.id,
+    ));
+    out.push_str(&format!(
+        "  incoming: {}\n",
+        join_module_labels(&report.incoming_modules)
+    ));
+    out.push_str(&format!(
+        "  outgoing: {}\n",
+        join_module_labels(&report.outgoing_modules)
+    ));
+}
+
+fn join_module_labels(refs: &[ModuleRef]) -> String {
+    refs.iter()
+        .map(|module_ref| module_ref.label.as_str())
+        .collect::<Vec<_>>()
+        .join(", ")
+}

--- a/devinfra/js/debundle/docs/design.md
+++ b/devinfra/js/debundle/docs/design.md
@@ -690,13 +690,13 @@ partition-independent: intra-module promoted edges are dropped by the
 quotient automatically, so the same promoted owner graph drives
 hypothetical planner partitions and the validator's actual one.
 
-**Algorithm.** For each top-level chunk statement S with `at_init_calls`
+**Algorithm.** For each top-level chunk statement S with `calls.eager`
 non-empty, walk the chunk call graph (among chunk-declared functions)
 in reverse topological order to compute, per function-owner F,
 `reachable_lazy_reads[F]` and `reachable_lazy_rebinds[F]` — the
 fixpoint closure of F's body lazy reads/rebinds plus the closures of
 every chunk function F calls. Then for each callee C in S's
-`at_init_calls`, emit promoted edges from S's owner to every owner
+`calls.eager`, emit promoted edges from S's owner to every owner
 declaring a binding in C's reachable closures.
 
 **Hoisted-target filter.** Promoted reads filter out targets whose

--- a/devinfra/js/debundle/e2e/BUILD.bazel
+++ b/devinfra/js/debundle/e2e/BUILD.bazel
@@ -83,6 +83,7 @@ _STANDARD_E2E_DEPS = [
         "object_literal_import_collapse_test",
         "object_literal_return_shorthand_drops_import_test",
         "duplicate_export_test",
+        "duplicate_top_level_declaration_test",
         "at_init_promotion_nested_closure_test",
         "at_init_promotion_post_await_test",
         "at_init_unresolved_callee_test",

--- a/devinfra/js/debundle/e2e/at_init_promotion_fndecl_direct_read_test.rs
+++ b/devinfra/js/debundle/e2e/at_init_promotion_fndecl_direct_read_test.rs
@@ -7,7 +7,7 @@
 //! `StatementKind::FnDecl` as ESM-Phase-1 hoisted and excludes
 //! promoted at-init reads of FnDecl bindings from the call-graph
 //! closure that feeds the promoted-edge emission. The *direct*
-//! top-level eager-read path (the loop over `stmt.eager_reads`
+//! top-level eager-read path (the loop over `stmt.reads.eager`
 //! in `graph.rs`) used to skip that filter: any top-level
 //! `const x = f()` where `f` is a hoisted `function f() {}`
 //! emitted a direct `EagerUse` edge `caller → f_owner` with

--- a/devinfra/js/debundle/e2e/at_init_unresolved_callee_test.rs
+++ b/devinfra/js/debundle/e2e/at_init_unresolved_callee_test.rs
@@ -2,7 +2,7 @@
 //! to a chunk-declared function must not be silently skipped by
 //! at-init call promotion (`graph.rs::promote_at_init_calls`).
 //!
-//! Before the fix, `at_init_calls` recorded only bare-`Ident` callees
+//! Before the fix, `calls.eager` recorded only bare-`Ident` callees
 //! and promotion silently `continue`d when a callee didn't resolve to
 //! a chunk function — so an at-init call routed through a
 //! single-assignment alias (`const g = readB; g();`) or an
@@ -56,7 +56,7 @@ export { A, B, g, r, readB };
 
 /// Method-call variant: `const api = { read: () => B }; api.read();`
 /// — the callee is a member expression, never recorded in
-/// `at_init_calls` at all before the fix.
+/// `calls.eager` at all before the fix.
 #[test]
 fn object_literal_method_at_init_call_closing_cycle_is_rejected() {
     expect_rejection(

--- a/devinfra/js/debundle/e2e/duplicate_top_level_declaration_test.rs
+++ b/devinfra/js/debundle/e2e/duplicate_top_level_declaration_test.rs
@@ -1,0 +1,58 @@
+//! Strict owner mapping: two distinct top-level statements declaring
+//! the same binding (`var dup = 1; var dup = 2;` — legal JS) used to
+//! be modeled last-insert-wins in `build_owner_graph_with`'s
+//! `binding_owner` table, so every edge into the earlier declaration's
+//! owner was silently dropped and the earlier statement could be
+//! ordered after its readers. The analyzer now rejects such chunks
+//! outright (soundness over completeness — see AGENTS.md).
+
+use debundle_e2e_support::*;
+
+#[test]
+fn duplicate_top_level_var_declaration_is_rejected() {
+    expect_rejection_containing_all(
+        FixtureOpts::new(
+            r#"var dup = "first";
+var dup = "second";
+console.log(dup);
+export { dup };
+"#,
+            vec![logical_module("mod_a", &[Member::new("dup")])],
+        ),
+        &["duplicate top-level declaration", "dup"],
+    );
+}
+
+#[test]
+fn duplicate_function_declaration_is_rejected() {
+    expect_rejection_containing_all(
+        FixtureOpts::new(
+            r#"function pick() { return "first"; }
+function pick() { return "second"; }
+console.log(pick());
+export { pick };
+"#,
+            vec![logical_module("mod_a", &[Member::new("pick")])],
+        ),
+        &["duplicate top-level declaration", "pick"],
+    );
+}
+
+/// Distinct bindings that merely share a name across scopes (a
+/// top-level `dup` and a function-local `dup`) are not duplicates:
+/// the owner table is keyed by hygienic identity, not name.
+#[test]
+fn same_name_in_inner_scope_is_not_a_duplicate() {
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"var dup = "outer";
+function shadow() { var dup = "inner"; return dup; }
+console.log(dup, shadow());
+export { dup, shadow };
+"#,
+        vec![logical_module(
+            "mod_a",
+            &[Member::new("dup"), Member::new("shadow")],
+        )],
+    ));
+    assert_entry_output(&fixture, "outer inner\n");
+}

--- a/devinfra/js/debundle/e2e/realizability_test.rs
+++ b/devinfra/js/debundle/e2e/realizability_test.rs
@@ -366,6 +366,19 @@ export { A, B };
     assert_entry_output(&fixture, "a-value b-value\n");
 
     let manifest: serde_json::Value = read_json(&fixture.report_root.join("static/app/chunk.json"));
+    // Wire-shape pin: the analysis-report fields stay flattened at the
+    // manifest's top level (`ChunkManifest` embeds `ChunkAnalysisReport`
+    // via `#[serde(flatten)]`), not nested under an `analysis` key.
+    for key in ["chunk_id", "source_path", "entry_file", "counts", "files"] {
+        assert!(
+            manifest.get(key).is_some(),
+            "chunk.json should carry analysis field {key:?} at top level",
+        );
+    }
+    assert!(
+        manifest.get("analysis").is_none(),
+        "chunk.json must not nest the analysis report under an `analysis` key",
+    );
     let entry_path = fixture.out_root.join("static/app/entry.js");
     let named_path = fixture.out_root.join("static/app/modules/mod_a.js");
     let residual_path = fixture

--- a/devinfra/js/debundle/facts/mod.rs
+++ b/devinfra/js/debundle/facts/mod.rs
@@ -4,10 +4,7 @@ mod local_effects;
 pub mod wire;
 
 pub use local_effects::local_namespace_iife_target;
-pub use wire::{
-    ChunkFactsReport, EffectCellReport, IdReport, StatementEffectSummaryReport,
-    StatementFactsReport,
-};
+pub use wire::{ChunkFactsReport, IdReport, StatementFactsReport};
 
 use binding_targets::{
     TargetAccessRecorder, callee_base_expr, declaration_ids, hoisted_var_ids, record_assign_target,
@@ -26,53 +23,76 @@ use crate::purity::{
 };
 use crate::{SourceLocation, StatementOrdinal};
 
+/// One value per syntactic position bucket. Collapses the repeated
+/// eager / lazy / first-order-lazy triples (reads, rebinds, calls)
+/// into a single shape so the "first-order ⊆ lazy" subset invariant
+/// lives in one place ([`Self::record`]) instead of at every
+/// construction site.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PositionBucketed<T> {
+    /// At-init position: outside any function/arrow/method/getter/
+    /// setter body, constructor body, or instance class-field
+    /// initializer.
+    pub eager: T,
+    /// Inside a lazy syntactic position, at any nesting depth. May
+    /// overlap with `eager` if the same name appears in both eager
+    /// and lazy positions of the statement.
+    pub lazy: T,
+    /// Subset of `lazy` whose sites sit in a function's
+    /// **first-order, pre-await** body (depth 1 from this statement).
+    /// Used by at-init call promotion: a synchronous call to the
+    /// function only runs its immediate pre-await body, so sites
+    /// inside nested function/arrow definitions or past an `await`
+    /// don't promote to the caller.
+    pub first_order_lazy: T,
+}
+
+impl PositionBucketed<BTreeSet<Id>> {
+    /// Record `id` in the bucket the cursor position selects: `eager`
+    /// at depth 0; `lazy` at depth ≥ 1, additionally `first_order_lazy`
+    /// at depth 1 before the body's first `await`. Maintains the
+    /// `first_order_lazy ⊆ lazy` invariant structurally.
+    fn record(&mut self, id: &Id, lazy_depth: u32, past_await: bool) {
+        if lazy_depth == 0 {
+            self.eager.insert(id.clone());
+            return;
+        }
+        self.lazy.insert(id.clone());
+        if lazy_depth == 1 && !past_await {
+            self.first_order_lazy.insert(id.clone());
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct StatementFacts {
     pub ordinal: StatementOrdinal,
     pub source_location: Option<SourceLocation>,
     pub declared: BTreeSet<Id>,
-    pub eager_reads: BTreeSet<Id>,
-    pub eager_rebinds: BTreeSet<Id>,
-    /// Reads happening only inside lazy syntactic positions (function
-    /// bodies, instance class-field initializers, getters/setters,
-    /// constructor bodies). May overlap with `eager_reads` if the
-    /// same name appears in both eager and lazy positions of the
-    /// statement.
-    pub lazy_reads: BTreeSet<Id>,
-    /// Rebinding writes happening only inside lazy syntactic
-    /// positions. Member writes (`obj.x = ...`) are intentionally
-    /// excluded: mutating an imported object is legal, but rebinding
-    /// the imported binding cell is not.
-    pub lazy_rebinds: BTreeSet<Id>,
-    /// Subset of `lazy_reads` whose read sites sit in a function's
-    /// **first-order** body (depth 1 from this statement). Used by
-    /// at-init call promotion: a synchronous call to the function
-    /// only runs its immediate body, so reads inside nested
-    /// function/arrow definitions don't promote to the caller.
-    pub first_order_lazy_reads: BTreeSet<Id>,
-    /// Subset of `lazy_rebinds` whose write sites sit in a function's
-    /// first-order body. See `first_order_lazy_reads`.
-    pub first_order_lazy_rebinds: BTreeSet<Id>,
+    /// Identifier reads, bucketed by syntactic position.
+    pub reads: PositionBucketed<BTreeSet<Id>>,
+    /// Rebinding writes, bucketed by syntactic position. Member
+    /// writes (`obj.x = ...`) are intentionally excluded: mutating an
+    /// imported object is legal, but rebinding the imported binding
+    /// cell is not.
+    pub rebinds: PositionBucketed<BTreeSet<Id>>,
     /// Target-local mutations produced by recognized trusted helper
     /// calls. Each binding is the class/prototype owner that must
     /// co-locate with the mutating statement.
     pub local_effects: BTreeSet<Id>,
-    /// Bare-identifier callees of `CallExpr` nodes seen at-init —
-    /// i.e. outside any function/arrow/method body. Used by the
-    /// owner-graph build to drive at-init call promotion: a call from
-    /// statement S to chunk-declared function `f` is treated as
-    /// transitively reading everything `f`'s body lazily reads. See
-    /// docs/design.md "At-init call promotion". Indirect calls
-    /// (`const g = f; g()`), method calls (`obj.method()`), and
-    /// computed callees are skipped — the callee must be a direct
-    /// `Ident`.
-    pub at_init_calls: BTreeSet<Id>,
-    /// Same as `at_init_calls` but for calls inside lazy positions.
-    /// Used by the owner-graph build to reconstruct the chunk call
-    /// graph so that promotion can transitively follow call chains
-    /// (e.g. `function f() { g(); } f();` at top level promotes
-    /// through `g`'s body too).
-    pub body_calls: BTreeSet<Id>,
+    /// Bare-identifier callees of `CallExpr` nodes, bucketed by
+    /// syntactic position. Indirect calls (`const g = f; g()`),
+    /// method calls (`obj.method()`), and computed callees are
+    /// skipped — the callee must be a direct `Ident`. The owner-graph
+    /// build uses `eager` to drive at-init call promotion (a call
+    /// from statement S to chunk-declared function `f` transitively
+    /// reads everything `f`'s body lazily reads — see docs/design.md
+    /// "At-init call promotion") and `lazy` to reconstruct the chunk
+    /// call graph so promotion follows call chains (e.g.
+    /// `function f() { g(); } f();` promotes through `g`'s body too).
+    /// `first_order_lazy` keeps calls nested inside a closure of the
+    /// body from appearing as direct callees of the outer function.
+    pub calls: PositionBucketed<BTreeSet<Id>>,
     /// Bindings referenced in the callee or arguments of at-init
     /// calls promotion can't follow (member calls `api.read()`,
     /// optional-chain calls, tagged templates). A function value
@@ -102,26 +122,60 @@ pub struct StatementFacts {
     /// bindings (when never rebound) as precisely resolvable;
     /// everything else takes the conservative fallback.
     pub declares_direct_function: bool,
-    /// Subset of `body_calls` whose call sites sit in a function's
-    /// **first-order** body. The promotion call graph uses this so
-    /// that calls lexically nested inside a closure of the body
-    /// don't appear as direct callees of the outer function — they
-    /// don't fire when the outer function is invoked synchronously.
-    pub first_order_body_calls: BTreeSet<Id>,
-    /// Per-statement (writes, reads) summary used by the
-    /// dataflow-aware S-chain emission in `graph.rs`. Tracks the
-    /// outer-observable cells the statement touches at-init:
-    /// binding cells (declared / rebound / read) and static-key
-    /// `globalThis.<prop>` cells. See `README.md` →
+    /// Static-key `globalThis.<prop>` cells the statement writes
+    /// at-init (`globalThis.tag = ...` records `"tag"`). Dynamic-key
+    /// accesses bail `cell_writes_summarizable` instead.
+    pub global_writes: BTreeSet<String>,
+    /// Static-key `globalThis.<prop>` cells the statement reads
+    /// at-init.
+    pub global_reads: BTreeSet<String>,
+    /// `false` when the statement contains a shape that defeats any
+    /// static reasoning about which cells it WRITES (`with`, direct
+    /// or indirect `eval`, `Function(...)`, dynamic-key
+    /// `globalThis[expr]`, `defineProperty`/`Proxy` on the global).
+    /// Consumed by the vendor strip's swap-privacy gate, whose call
+    /// side effects are covered by its own island-reachability
+    /// analysis.
+    pub cell_writes_summarizable: bool,
+    /// `false` whenever `cell_writes_summarizable` is `false`, and
+    /// additionally for shapes that defeat the dataflow-aware
+    /// S-chain's stronger "which cells does this statement TOUCH"
+    /// question: opaque (not classifier-Pure) at-init calls/news
+    /// (I/O is not a cell; callee bodies may touch globals), member
+    /// writes through bindings (aliasing), and statements tainted by
+    /// a global-object alias escape. Downstream passes must treat
+    /// the statement as touching every cell. See `README.md` →
     /// "Conditionally-correct optimizations" for the soundness
-    /// precondition; `effects.dataflow_summarizable=false`
-    /// means the statement contains a shape we can't statically
-    /// summarize (dynamic `globalThis[<expr>]`, `with`, direct
-    /// `eval`, `Function(...)` constructor, etc.) and downstream
-    /// passes must treat it as touching every cell.
-    pub effects: StatementEffectSummary,
+    /// precondition.
+    pub dataflow_summarizable: bool,
     pub purity: Purity,
     pub kind: StatementKind,
+}
+
+impl StatementFacts {
+    /// Per-statement (writes, reads) cell summary used by the
+    /// dataflow-aware S-chain emission in `graph.rs` and the vendor
+    /// strip's swap-privacy gate. Derived on demand: the
+    /// `Binding`-cell half restates `declared` / `reads.eager` /
+    /// `rebinds.eager`; only the `GlobalProp` half (`global_writes` /
+    /// `global_reads`) is stored state.
+    pub fn effects(&self) -> StatementEffectSummary {
+        let mut writes = BTreeSet::<EffectCell>::new();
+        for name in self.declared.iter().chain(self.rebinds.eager.iter()) {
+            writes.insert(EffectCell::Binding(name.clone()));
+        }
+        for key in &self.global_writes {
+            writes.insert(EffectCell::GlobalProp(key.clone()));
+        }
+        let mut reads = BTreeSet::<EffectCell>::new();
+        for name in &self.reads.eager {
+            reads.insert(EffectCell::Binding(name.clone()));
+        }
+        for key in &self.global_reads {
+            reads.insert(EffectCell::GlobalProp(key.clone()));
+        }
+        StatementEffectSummary { writes, reads }
+    }
 }
 
 /// One outer-observable storage location a statement can read or
@@ -138,26 +192,14 @@ pub enum EffectCell {
     GlobalProp(String),
 }
 
-#[derive(Debug, Clone, Default)]
+/// The (writes, reads) cell view of one statement, derived by
+/// [`StatementFacts::effects`]. The summarizability bits live on
+/// [`StatementFacts`] directly (`cell_writes_summarizable`,
+/// `dataflow_summarizable`).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct StatementEffectSummary {
     pub writes: BTreeSet<EffectCell>,
     pub reads: BTreeSet<EffectCell>,
-    /// `false` when the statement contains a shape that defeats any
-    /// static reasoning about which cells it WRITES (`with`, direct
-    /// or indirect `eval`, `Function(...)`, dynamic-key
-    /// `globalThis[expr]`, `defineProperty`/`Proxy` on the global).
-    /// Consumed by the vendor strip's swap-privacy gate, whose call
-    /// side effects are covered by its own island-reachability
-    /// analysis.
-    pub cell_writes_summarizable: bool,
-    /// `false` whenever `cell_writes_summarizable` is `false`, and
-    /// additionally for shapes that defeat the dataflow-aware
-    /// S-chain's stronger "which cells does this statement TOUCH"
-    /// question: opaque (not classifier-Pure) at-init calls/news
-    /// (I/O is not a cell; callee bodies may touch globals), member
-    /// writes through bindings (aliasing), and statements tainted by
-    /// a global-object alias escape.
-    pub dataflow_summarizable: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -270,15 +312,9 @@ pub(crate) struct StructuralStatementFacts {
     source_location: Option<SourceLocation>,
     kind: StatementKind,
     declared: BTreeSet<Id>,
-    at_init_reads: BTreeSet<Id>,
-    lazy_reads: BTreeSet<Id>,
-    first_order_lazy_reads: BTreeSet<Id>,
-    at_init_writes: BTreeSet<Id>,
-    lazy_writes: BTreeSet<Id>,
-    first_order_lazy_writes: BTreeSet<Id>,
-    at_init_calls: BTreeSet<Id>,
-    lazy_calls: BTreeSet<Id>,
-    first_order_lazy_calls: BTreeSet<Id>,
+    reads: PositionBucketed<BTreeSet<Id>>,
+    rebinds: PositionBucketed<BTreeSet<Id>>,
+    calls: PositionBucketed<BTreeSet<Id>>,
     at_init_unresolved_sources: BTreeSet<Id>,
     at_init_unresolved_inline_fn: bool,
     first_order_unresolved_sources: BTreeSet<Id>,
@@ -365,15 +401,9 @@ where
                 source_location,
                 kind,
                 declared,
-                at_init_reads: collector.at_init_reads,
-                lazy_reads: collector.lazy_reads,
-                first_order_lazy_reads: collector.first_order_lazy_reads,
-                at_init_writes: collector.at_init_writes,
-                lazy_writes: collector.lazy_writes,
-                first_order_lazy_writes: collector.first_order_lazy_writes,
-                at_init_calls: collector.at_init_calls,
-                lazy_calls: collector.lazy_calls,
-                first_order_lazy_calls: collector.first_order_lazy_calls,
+                reads: collector.reads,
+                rebinds: collector.rebinds,
+                calls: collector.calls,
                 at_init_unresolved_sources: collector.at_init_unresolved_sources,
                 at_init_unresolved_inline_fn: collector.at_init_unresolved_inline_fn,
                 first_order_unresolved_sources: collector.first_order_unresolved_sources,
@@ -470,9 +500,10 @@ fn apply_global_escape_taint(
         for (idx, facts) in per_statement.iter().enumerate() {
             if !tainted[idx]
                 && facts
-                    .at_init_reads
+                    .reads
+                    .eager
                     .iter()
-                    .chain(facts.lazy_reads.iter())
+                    .chain(facts.reads.lazy.iter())
                     .any(|id| suspects.contains(id))
             {
                 tainted[idx] = true;
@@ -482,8 +513,8 @@ fn apply_global_escape_taint(
                 for id in facts
                     .declared
                     .iter()
-                    .chain(facts.at_init_writes.iter())
-                    .chain(facts.lazy_writes.iter())
+                    .chain(facts.rebinds.eager.iter())
+                    .chain(facts.rebinds.lazy.iter())
                 {
                     changed |= suspects.insert(id.clone());
                 }
@@ -739,15 +770,9 @@ fn assemble_statement_facts(
         source_location,
         kind,
         declared,
-        at_init_reads,
-        lazy_reads,
-        first_order_lazy_reads,
-        at_init_writes,
-        lazy_writes,
-        first_order_lazy_writes,
-        at_init_calls,
-        lazy_calls,
-        first_order_lazy_calls,
+        reads,
+        rebinds,
+        calls,
         at_init_unresolved_sources,
         at_init_unresolved_inline_fn,
         first_order_unresolved_sources,
@@ -781,46 +806,23 @@ fn assemble_statement_facts(
     // binding edges + rebind co-location rather than the S-chain.
     let dataflow_summarizable =
         dataflow_summarizable && !has_opaque_at_init_call(item, shadowed, hints, graph);
-    let mut effects_writes = BTreeSet::<EffectCell>::new();
-    for name in declared.iter().chain(at_init_writes.iter()) {
-        effects_writes.insert(EffectCell::Binding(name.clone()));
-    }
-    for key in &global_writes {
-        effects_writes.insert(EffectCell::GlobalProp(key.clone()));
-    }
-    let mut effects_reads = BTreeSet::<EffectCell>::new();
-    for name in &at_init_reads {
-        effects_reads.insert(EffectCell::Binding(name.clone()));
-    }
-    for key in &global_reads {
-        effects_reads.insert(EffectCell::GlobalProp(key.clone()));
-    }
-    let effects = StatementEffectSummary {
-        writes: effects_writes,
-        reads: effects_reads,
-        cell_writes_summarizable,
-        dataflow_summarizable,
-    };
     StatementFacts {
         ordinal,
         source_location,
         declared,
-        eager_reads: at_init_reads,
-        eager_rebinds: at_init_writes,
-        lazy_reads,
-        lazy_rebinds: lazy_writes,
-        first_order_lazy_reads,
-        first_order_lazy_rebinds: first_order_lazy_writes,
+        reads,
+        rebinds,
         local_effects,
-        at_init_calls,
-        body_calls: lazy_calls,
-        first_order_body_calls: first_order_lazy_calls,
+        calls,
         at_init_unresolved_sources,
         at_init_unresolved_inline_fn,
         first_order_unresolved_sources,
         first_order_unresolved_inline_fn,
         declares_direct_function,
-        effects,
+        global_writes,
+        global_reads,
+        cell_writes_summarizable,
+        dataflow_summarizable,
         purity,
         kind,
     }
@@ -1291,34 +1293,27 @@ trait LazyBoundary: Visit {
 /// each re-implemented the same `LazyBoundary` boilerplate and walked
 /// the same AST.
 ///
-/// Bucketing rules:
+/// Bucketing rules (see [`PositionBucketed::record`]):
 ///
-/// - `lazy_depth == 0` (eager, top of the statement): reads land in
-///   `at_init_reads`, rebind writes in `at_init_writes`, direct
-///   `f(...)` callees in `at_init_calls`; static-key
-///   `globalThis.<prop>` accesses contribute to
-///   `global_writes`/`global_reads`; bail-out shapes flip
-///   `dataflow_summarizable` to `false`.
+/// - `lazy_depth == 0` (eager, top of the statement): reads, rebind
+///   writes, and direct `f(...)` callees land in the respective
+///   `eager` buckets; static-key `globalThis.<prop>` accesses
+///   contribute to `global_writes`/`global_reads`; bail-out shapes
+///   flip `dataflow_summarizable` to `false`.
 /// - `lazy_depth >= 1` (inside a function/arrow/method/getter/setter
 ///   body, constructor body, or instance class-field initializer):
-///   reads/writes/calls land in `lazy_*`. The subset whose call sites
-///   sit at `lazy_depth == 1 && !past_await` also lands in
-///   `first_order_lazy_*` — used by at-init call promotion, which
+///   reads/writes/calls land in the `lazy` buckets. The subset whose
+///   sites sit at `lazy_depth == 1 && !past_await` also lands in
+///   `first_order_lazy` — used by at-init call promotion, which
 ///   only inherits effects from a callee's immediate pre-await body.
 /// - Bail-out shapes nested inside lazy scopes are deliberately not
 ///   recorded: at-init call promotion handles transitive effects via
 ///   the call graph, not via per-statement syntactic checks.
 #[derive(Default)]
 struct StatementFactsCollector {
-    at_init_reads: BTreeSet<Id>,
-    lazy_reads: BTreeSet<Id>,
-    first_order_lazy_reads: BTreeSet<Id>,
-    at_init_writes: BTreeSet<Id>,
-    lazy_writes: BTreeSet<Id>,
-    first_order_lazy_writes: BTreeSet<Id>,
-    at_init_calls: BTreeSet<Id>,
-    lazy_calls: BTreeSet<Id>,
-    first_order_lazy_calls: BTreeSet<Id>,
+    reads: PositionBucketed<BTreeSet<Id>>,
+    rebinds: PositionBucketed<BTreeSet<Id>>,
+    calls: PositionBucketed<BTreeSet<Id>>,
     at_init_unresolved_sources: BTreeSet<Id>,
     at_init_unresolved_inline_fn: bool,
     first_order_unresolved_sources: BTreeSet<Id>,
@@ -1346,36 +1341,15 @@ impl StatementFactsCollector {
     }
 
     fn record_read(&mut self, id: &Id) {
-        if self.lazy_depth == 0 {
-            self.at_init_reads.insert(id.clone());
-            return;
-        }
-        self.lazy_reads.insert(id.clone());
-        if self.lazy_depth == 1 && !self.past_await {
-            self.first_order_lazy_reads.insert(id.clone());
-        }
+        self.reads.record(id, self.lazy_depth, self.past_await);
     }
 
     fn record_write(&mut self, id: &Id) {
-        if self.lazy_depth == 0 {
-            self.at_init_writes.insert(id.clone());
-            return;
-        }
-        self.lazy_writes.insert(id.clone());
-        if self.lazy_depth == 1 && !self.past_await {
-            self.first_order_lazy_writes.insert(id.clone());
-        }
+        self.rebinds.record(id, self.lazy_depth, self.past_await);
     }
 
     fn record_call(&mut self, id: &Id) {
-        if self.lazy_depth == 0 {
-            self.at_init_calls.insert(id.clone());
-            return;
-        }
-        self.lazy_calls.insert(id.clone());
-        if self.lazy_depth == 1 && !self.past_await {
-            self.first_order_lazy_calls.insert(id.clone());
-        }
+        self.calls.record(id, self.lazy_depth, self.past_await);
     }
 
     /// A call whose callee promotion can never resolve syntactically
@@ -1525,11 +1499,11 @@ impl Visit for StatementFactsCollector {
     // this chunk's entry to keep the export surface intact. The
     // realizability primitive's I-graph cycle check needs to see
     // that materializer-induced lazy import edge, so record each
-    // `orig` Ident as a LAZY read (placed directly into `lazy_reads`,
+    // `orig` Ident as a LAZY read (placed directly into `reads.lazy`,
     // bypassing `record_read`'s lazy-depth bucketing — these reads
     // are semantically deferred regardless of where the export
     // specifier sits syntactically). Not added to
-    // `first_order_lazy_reads`: re-exports aren't reachable through
+    // `reads.first_order_lazy`: re-exports aren't reachable through
     // at-init call promotion, so excluding them from that subset
     // prevents the promotion pass from inventing spurious eager
     // edges for re-exported bindings.
@@ -1547,7 +1521,7 @@ impl Visit for StatementFactsCollector {
                 continue;
             };
             if let ModuleExportName::Ident(ident) = &named.orig {
-                self.lazy_reads.insert(ident.to_id());
+                self.reads.lazy.insert(ident.to_id());
             }
         }
     }
@@ -1842,7 +1816,7 @@ fn lazy_visit_class_member<V: LazyBoundary>(v: &mut V, member: &ClassMember) {
         // No outer descend here — a method body must land at
         // lazy_depth 1, the same as a bare `function f() { ... }`,
         // so rebinds in the immediate body show up in
-        // `first_order_lazy_rebinds` and the owner-graph emits the
+        // `rebinds.first_order_lazy` and the owner-graph emits the
         // constraining `LazyRebind` edge that catches cross-module
         // writes to imported bindings (ESM rejects at runtime).
         ClassMember::Method(method) => {

--- a/devinfra/js/debundle/facts/wire.rs
+++ b/devinfra/js/debundle/facts/wire.rs
@@ -26,8 +26,8 @@ use swc_ecma_ast::Id;
 
 use crate::purity::Purity;
 use crate::{
-    ChunkFactAnalysis, EffectCell, RedundantPureMemberHint, RedundantPurityHint, SourceLocation,
-    StatementEffectSummary, StatementFacts, StatementKind, StatementOrdinal,
+    ChunkFactAnalysis, PositionBucketed, RedundantPureMemberHint, RedundantPurityHint,
+    SourceLocation, StatementFacts, StatementKind, StatementOrdinal,
 };
 
 /// In-memory mirror of `Id = (Atom, SyntaxContext)`. Stored as
@@ -55,72 +55,10 @@ impl IdReport {
     }
 }
 
-/// In-memory mirror of `EffectCell`. Used as a `Globals`-independent
-/// carrier so callers can pattern-match without holding the SWC
-/// `Globals` that minted the underlying `Id`.
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
-pub enum EffectCellReport {
-    Binding { id: IdReport },
-    GlobalProp { key: String },
-}
-
-impl EffectCellReport {
-    pub fn from_cell(cell: &EffectCell) -> Self {
-        match cell {
-            EffectCell::Binding(id) => EffectCellReport::Binding {
-                id: IdReport::from_id(id),
-            },
-            EffectCell::GlobalProp(key) => EffectCellReport::GlobalProp { key: key.clone() },
-        }
-    }
-
-    pub fn to_cell(&self) -> EffectCell {
-        match self {
-            EffectCellReport::Binding { id } => EffectCell::Binding(id.to_id()),
-            EffectCellReport::GlobalProp { key } => EffectCell::GlobalProp(key.clone()),
-        }
-    }
-}
-
-/// In-memory mirror of `StatementEffectSummary`.
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct StatementEffectSummaryReport {
-    pub writes: Vec<EffectCellReport>,
-    pub reads: Vec<EffectCellReport>,
-    pub cell_writes_summarizable: bool,
-    pub dataflow_summarizable: bool,
-}
-
-impl StatementEffectSummaryReport {
-    pub fn from_summary(summary: &StatementEffectSummary) -> Self {
-        Self {
-            writes: summary
-                .writes
-                .iter()
-                .map(EffectCellReport::from_cell)
-                .collect(),
-            reads: summary
-                .reads
-                .iter()
-                .map(EffectCellReport::from_cell)
-                .collect(),
-            cell_writes_summarizable: summary.cell_writes_summarizable,
-            dataflow_summarizable: summary.dataflow_summarizable,
-        }
-    }
-
-    pub fn to_summary(&self) -> StatementEffectSummary {
-        StatementEffectSummary {
-            writes: self.writes.iter().map(EffectCellReport::to_cell).collect(),
-            reads: self.reads.iter().map(EffectCellReport::to_cell).collect(),
-            cell_writes_summarizable: self.cell_writes_summarizable,
-            dataflow_summarizable: self.dataflow_summarizable,
-        }
-    }
-}
-
 /// Wire mirror of `StatementFacts`. Field-by-field 1:1 with the native
-/// type — see `facts/mod.rs` for the per-field invariants.
+/// type — see `facts/mod.rs` for the per-field invariants. The derived
+/// `effects()` summary is not mirrored: it reconstructs from the
+/// mirrored fields.
 ///
 /// `Id` sets are mirrored as `Vec<IdReport>` (in `BTreeSet` iteration
 /// order); the reverse conversion re-collects into a `BTreeSet`, so set
@@ -130,22 +68,19 @@ pub struct StatementFactsReport {
     pub ordinal: StatementOrdinal,
     pub source_location: Option<SourceLocation>,
     pub declared: Vec<IdReport>,
-    pub eager_reads: Vec<IdReport>,
-    pub eager_rebinds: Vec<IdReport>,
-    pub lazy_reads: Vec<IdReport>,
-    pub lazy_rebinds: Vec<IdReport>,
-    pub first_order_lazy_reads: Vec<IdReport>,
-    pub first_order_lazy_rebinds: Vec<IdReport>,
+    pub reads: PositionBucketed<Vec<IdReport>>,
+    pub rebinds: PositionBucketed<Vec<IdReport>>,
+    pub calls: PositionBucketed<Vec<IdReport>>,
     pub local_effects: Vec<IdReport>,
-    pub at_init_calls: Vec<IdReport>,
-    pub body_calls: Vec<IdReport>,
-    pub first_order_body_calls: Vec<IdReport>,
     pub at_init_unresolved_sources: Vec<IdReport>,
     pub at_init_unresolved_inline_fn: bool,
     pub first_order_unresolved_sources: Vec<IdReport>,
     pub first_order_unresolved_inline_fn: bool,
     pub declares_direct_function: bool,
-    pub effects: StatementEffectSummaryReport,
+    pub global_writes: BTreeSet<String>,
+    pub global_reads: BTreeSet<String>,
+    pub cell_writes_summarizable: bool,
+    pub dataflow_summarizable: bool,
     pub purity: Purity,
     pub kind: StatementKind,
 }
@@ -156,22 +91,19 @@ impl StatementFactsReport {
             ordinal: facts.ordinal,
             source_location: facts.source_location.clone(),
             declared: ids_to_wire(&facts.declared),
-            eager_reads: ids_to_wire(&facts.eager_reads),
-            eager_rebinds: ids_to_wire(&facts.eager_rebinds),
-            lazy_reads: ids_to_wire(&facts.lazy_reads),
-            lazy_rebinds: ids_to_wire(&facts.lazy_rebinds),
-            first_order_lazy_reads: ids_to_wire(&facts.first_order_lazy_reads),
-            first_order_lazy_rebinds: ids_to_wire(&facts.first_order_lazy_rebinds),
+            reads: bucketed_to_wire(&facts.reads),
+            rebinds: bucketed_to_wire(&facts.rebinds),
+            calls: bucketed_to_wire(&facts.calls),
             local_effects: ids_to_wire(&facts.local_effects),
-            at_init_calls: ids_to_wire(&facts.at_init_calls),
-            body_calls: ids_to_wire(&facts.body_calls),
-            first_order_body_calls: ids_to_wire(&facts.first_order_body_calls),
             at_init_unresolved_sources: ids_to_wire(&facts.at_init_unresolved_sources),
             at_init_unresolved_inline_fn: facts.at_init_unresolved_inline_fn,
             first_order_unresolved_sources: ids_to_wire(&facts.first_order_unresolved_sources),
             first_order_unresolved_inline_fn: facts.first_order_unresolved_inline_fn,
             declares_direct_function: facts.declares_direct_function,
-            effects: StatementEffectSummaryReport::from_summary(&facts.effects),
+            global_writes: facts.global_writes.clone(),
+            global_reads: facts.global_reads.clone(),
+            cell_writes_summarizable: facts.cell_writes_summarizable,
+            dataflow_summarizable: facts.dataflow_summarizable,
             purity: facts.purity.clone(),
             kind: facts.kind,
         }
@@ -182,22 +114,19 @@ impl StatementFactsReport {
             ordinal: self.ordinal,
             source_location: self.source_location.clone(),
             declared: ids_from_wire(&self.declared),
-            eager_reads: ids_from_wire(&self.eager_reads),
-            eager_rebinds: ids_from_wire(&self.eager_rebinds),
-            lazy_reads: ids_from_wire(&self.lazy_reads),
-            lazy_rebinds: ids_from_wire(&self.lazy_rebinds),
-            first_order_lazy_reads: ids_from_wire(&self.first_order_lazy_reads),
-            first_order_lazy_rebinds: ids_from_wire(&self.first_order_lazy_rebinds),
+            reads: bucketed_from_wire(&self.reads),
+            rebinds: bucketed_from_wire(&self.rebinds),
+            calls: bucketed_from_wire(&self.calls),
             local_effects: ids_from_wire(&self.local_effects),
-            at_init_calls: ids_from_wire(&self.at_init_calls),
-            body_calls: ids_from_wire(&self.body_calls),
-            first_order_body_calls: ids_from_wire(&self.first_order_body_calls),
             at_init_unresolved_sources: ids_from_wire(&self.at_init_unresolved_sources),
             at_init_unresolved_inline_fn: self.at_init_unresolved_inline_fn,
             first_order_unresolved_sources: ids_from_wire(&self.first_order_unresolved_sources),
             first_order_unresolved_inline_fn: self.first_order_unresolved_inline_fn,
             declares_direct_function: self.declares_direct_function,
-            effects: self.effects.to_summary(),
+            global_writes: self.global_writes.clone(),
+            global_reads: self.global_reads.clone(),
+            cell_writes_summarizable: self.cell_writes_summarizable,
+            dataflow_summarizable: self.dataflow_summarizable,
             purity: self.purity.clone(),
             kind: self.kind,
         }
@@ -250,4 +179,22 @@ fn ids_to_wire(set: &BTreeSet<Id>) -> Vec<IdReport> {
 
 fn ids_from_wire(list: &[IdReport]) -> BTreeSet<Id> {
     list.iter().map(IdReport::to_id).collect()
+}
+
+fn bucketed_to_wire(bucketed: &PositionBucketed<BTreeSet<Id>>) -> PositionBucketed<Vec<IdReport>> {
+    PositionBucketed {
+        eager: ids_to_wire(&bucketed.eager),
+        lazy: ids_to_wire(&bucketed.lazy),
+        first_order_lazy: ids_to_wire(&bucketed.first_order_lazy),
+    }
+}
+
+fn bucketed_from_wire(
+    bucketed: &PositionBucketed<Vec<IdReport>>,
+) -> PositionBucketed<BTreeSet<Id>> {
+    PositionBucketed {
+        eager: ids_from_wire(&bucketed.eager),
+        lazy: ids_from_wire(&bucketed.lazy),
+        first_order_lazy: ids_from_wire(&bucketed.first_order_lazy),
+    }
 }

--- a/devinfra/js/debundle/graph.rs
+++ b/devinfra/js/debundle/graph.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::fmt;
 
 use petgraph::algo::tarjan_scc;
 use petgraph::graphmap::DiGraphMap;
@@ -412,10 +413,16 @@ impl OwnerGraph {
     /// match the original `OwnerEdgeId`s that produced the report.
     /// The gate only uses them as opaque identifiers in its evidence
     /// listing.
+    ///
+    /// Errors with [`UnresolvedOwnerEdgeEndpoint`] when an edge
+    /// references an owner id missing from the report's node table —
+    /// a malformed or version-skewed `owner_graph.json`. Silently
+    /// dropping such edges would hand the planner-side gate a weaker
+    /// graph than the one the report described.
     pub fn from_report(
         report: &crate::OwnerGraphReport,
         facts: &[crate::StatementFactsReport],
-    ) -> (Self, OwnerReportIndex) {
+    ) -> Result<(Self, OwnerReportIndex), UnresolvedOwnerEdgeEndpoint> {
         let owner_ids: Vec<String> = report.nodes.iter().map(|n| n.id.clone()).collect();
         let by_id: HashMap<String, OwnerId> = owner_ids
             .iter()
@@ -449,10 +456,17 @@ impl OwnerGraph {
 
         let mut edges: Vec<OwnerEdge> = Vec::with_capacity(report.edges.len());
         for edge in &report.edges {
-            let (Some(&from), Some(&to)) = (by_id.get(&edge.source), by_id.get(&edge.target))
-            else {
-                continue;
+            let resolve = |endpoint: &String| {
+                by_id
+                    .get(endpoint)
+                    .copied()
+                    .ok_or_else(|| UnresolvedOwnerEdgeEndpoint {
+                        edge_id: edge.id.clone(),
+                        endpoint: endpoint.clone(),
+                    })
             };
+            let from = resolve(&edge.source)?;
+            let to = resolve(&edge.target)?;
             // Round-trip the edge role so the planner-side gate runs
             // the same cross-module-promotion filter as the
             // materializer.
@@ -495,9 +509,31 @@ impl OwnerGraph {
             callee_edges,
         };
         let index = OwnerReportIndex { owner_ids, by_id };
-        (graph, index)
+        Ok((graph, index))
     }
 }
+
+/// An `owner_graph.json` edge references an owner id absent from the
+/// report's node table. See [`OwnerGraph::from_report`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnresolvedOwnerEdgeEndpoint {
+    pub edge_id: String,
+    /// The owner id (e.g. `owner:42`) that didn't resolve.
+    pub endpoint: String,
+}
+
+impl fmt::Display for UnresolvedOwnerEdgeEndpoint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "owner graph edge {} references owner {} which is not in the report's node table \
+             (malformed or version-skewed owner_graph.json)",
+            self.edge_id, self.endpoint,
+        )
+    }
+}
+
+impl std::error::Error for UnresolvedOwnerEdgeEndpoint {}
 
 /// Per-edge metadata. One physical `(from, to)` ESM `import`
 /// directive can be backed by multiple reasons (e.g. several
@@ -616,6 +652,35 @@ impl ModuleQuotient {
     }
 }
 
+/// Two distinct top-level statements declare the same binding
+/// (`var x = 1; var x = 2;` — legal JS, but the owner graph models
+/// each binding as having exactly one owning statement). Letting the
+/// last declaration win would silently drop every edge into the
+/// earlier owner, so the earlier statement could be ordered after its
+/// readers. Rejecting the chunk is the accepted over-restriction
+/// (AGENTS.md "Soundness over completeness").
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DuplicateTopLevelDeclaration {
+    pub binding: swc_atoms::Atom,
+    pub first: StatementOrdinal,
+    pub second: StatementOrdinal,
+}
+
+impl fmt::Display for DuplicateTopLevelDeclaration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "duplicate top-level declaration of binding `{}`: statements #{} and #{} both \
+             declare it; the owner graph requires a single owning statement per binding. \
+             Rewrite the chunk so the binding is declared once (e.g. merge the declarations \
+             or rename one of them).",
+            self.binding, self.first.0, self.second.0,
+        )
+    }
+}
+
+impl std::error::Error for DuplicateTopLevelDeclaration {}
+
 /// Build the fine owner graph from per-statement facts. Pure IR
 /// construction: no module assignment, no quotient. Module-level
 /// dependencies are derived later by [`build_module_quotient`]
@@ -624,17 +689,28 @@ impl ModuleQuotient {
 /// Uses default (strictly-conservative) [`OwnerGraphOptions`]. Call
 /// [`build_owner_graph_with`] when the chunk spec opts into
 /// conditionally-correct refinements.
-pub fn build_owner_graph(facts: &[StatementFacts]) -> OwnerGraph {
+pub fn build_owner_graph(
+    facts: &[StatementFacts],
+) -> Result<OwnerGraph, DuplicateTopLevelDeclaration> {
     build_owner_graph_with(facts, OwnerGraphOptions::default())
 }
 
 /// Like [`build_owner_graph`] but takes per-chunk [`OwnerGraphOptions`].
-pub fn build_owner_graph_with(facts: &[StatementFacts], options: OwnerGraphOptions) -> OwnerGraph {
+pub fn build_owner_graph_with(
+    facts: &[StatementFacts],
+    options: OwnerGraphOptions,
+) -> Result<OwnerGraph, DuplicateTopLevelDeclaration> {
     let mut binding_owner = HashMap::<Id, OwnerId>::new();
     let mut nodes = Vec::<OwnerNode>::with_capacity(facts.len());
     for stmt in facts {
         for binding in &stmt.declared {
-            binding_owner.insert(binding.clone(), OwnerId(stmt.ordinal.0));
+            if let Some(prev) = binding_owner.insert(binding.clone(), OwnerId(stmt.ordinal.0)) {
+                return Err(DuplicateTopLevelDeclaration {
+                    binding: binding.0.clone(),
+                    first: StatementOrdinal(prev.0),
+                    second: stmt.ordinal,
+                });
+            }
         }
         let id = OwnerId(stmt.ordinal.0);
         nodes.push(OwnerNode {
@@ -692,7 +768,7 @@ pub fn build_owner_graph_with(facts: &[StatementFacts], options: OwnerGraphOptio
     };
     for stmt in facts {
         let from = OwnerId(stmt.ordinal.0);
-        for binding in &stmt.eager_reads {
+        for binding in &stmt.reads.eager {
             if target_is_hoisted(binding) {
                 continue;
             }
@@ -704,7 +780,7 @@ pub fn build_owner_graph_with(facts: &[StatementFacts], options: OwnerGraphOptio
                 stmt.ordinal,
             );
         }
-        for binding in &stmt.lazy_reads {
+        for binding in &stmt.reads.lazy {
             push_binding_edge(
                 &mut raw_edges,
                 from,
@@ -713,7 +789,7 @@ pub fn build_owner_graph_with(facts: &[StatementFacts], options: OwnerGraphOptio
                 stmt.ordinal,
             );
         }
-        for binding in &stmt.eager_rebinds {
+        for binding in &stmt.rebinds.eager {
             push_binding_edge(
                 &mut raw_edges,
                 from,
@@ -728,7 +804,7 @@ pub fn build_owner_graph_with(facts: &[StatementFacts], options: OwnerGraphOptio
         // when the function is invoked synchronously, so it must not
         // constrain init order or feed at-init call promotion. See
         // the e2e test `at_init_promotion_nested_closure_test`.
-        for binding in &stmt.first_order_lazy_rebinds {
+        for binding in &stmt.rebinds.first_order_lazy {
             push_binding_edge(
                 &mut raw_edges,
                 from,
@@ -744,8 +820,8 @@ pub fn build_owner_graph_with(facts: &[StatementFacts], options: OwnerGraphOptio
         // cross-destination splits are rejected and `G_atomic`
         // forces co-location, without manufacturing an init-order
         // constraint nothing fires at init.
-        for binding in &stmt.lazy_rebinds {
-            if stmt.first_order_lazy_rebinds.contains(binding) {
+        for binding in &stmt.rebinds.lazy {
+            if stmt.rebinds.first_order_lazy.contains(binding) {
                 continue;
             }
             push_binding_edge(
@@ -827,13 +903,13 @@ pub fn build_owner_graph_with(facts: &[StatementFacts], options: OwnerGraphOptio
         }
     }
 
-    OwnerGraph {
+    Ok(OwnerGraph {
         nodes,
         edges,
         out_edges,
         in_edges,
         callee_edges,
-    }
+    })
 }
 
 /// Side-effect ordering edges (`S` per docs/design.md "Module dep graphs").
@@ -900,14 +976,15 @@ fn emit_s_chain(
     let mut opaque_barrier: Option<OwnerId> = None;
     for stmt in facts.iter().filter(|s| !s.purity.is_pure()) {
         let from = OwnerId(stmt.ordinal.0);
+        let effects = stmt.effects();
         let mut targets: BTreeSet<OwnerId> = BTreeSet::new();
-        if stmt.effects.dataflow_summarizable {
-            for cell in stmt.effects.reads.iter().chain(stmt.effects.writes.iter()) {
+        if stmt.dataflow_summarizable {
+            for cell in effects.reads.iter().chain(effects.writes.iter()) {
                 if let Some(&to) = last_writer.get(cell) {
                     targets.insert(to);
                 }
             }
-            for cell in &stmt.effects.writes {
+            for cell in &effects.writes {
                 if let Some(readers) = readers_since_last_write.get(cell) {
                     targets.extend(readers.iter().copied());
                 }
@@ -931,14 +1008,14 @@ fn emit_s_chain(
                 raw_edges.push((from, to, EdgeReason::sequenced(stmt.ordinal)));
             }
         }
-        if stmt.effects.dataflow_summarizable {
-            for cell in &stmt.effects.writes {
-                last_writer.insert(cell.clone(), from);
-                readers_since_last_write.remove(cell);
+        if stmt.dataflow_summarizable {
+            for cell in effects.writes {
+                readers_since_last_write.remove(&cell);
+                last_writer.insert(cell, from);
             }
-            for cell in &stmt.effects.reads {
+            for cell in effects.reads {
                 readers_since_last_write
-                    .entry(cell.clone())
+                    .entry(cell)
                     .or_default()
                     .insert(from);
             }
@@ -974,7 +1051,7 @@ fn promote_at_init_calls(
     // so calls to them are not precisely resolvable.
     let rebound: BTreeSet<&Id> = facts
         .iter()
-        .flat_map(|s| s.eager_rebinds.iter().chain(s.lazy_rebinds.iter()))
+        .flat_map(|s| s.rebinds.eager.iter().chain(s.rebinds.lazy.iter()))
         .collect();
 
     // A callee binding is precisely resolvable iff (a) its declaring
@@ -990,7 +1067,7 @@ fn promote_at_init_calls(
     };
 
     // 1. Build the call graph: owner → owner edges for each
-    //    resolvable callee reachable via *first-order* body_calls.
+    //    resolvable callee reachable via *first-order* calls.lazy.
     //    Nested-closure calls (e.g. inside an arrow returned by the
     //    body) don't fire when the body is invoked synchronously, so
     //    they don't belong on the promotion call graph — see
@@ -1029,7 +1106,7 @@ fn promote_at_init_calls(
             stmt.first_order_unresolved_inline_fn,
             owner,
         );
-        for callee_id in &stmt.first_order_body_calls {
+        for callee_id in &stmt.calls.first_order_lazy {
             if resolvable_callee(callee_id).is_none()
                 && let Some(&callee_owner) = binding_owner.get(callee_id)
             {
@@ -1041,9 +1118,9 @@ fn promote_at_init_calls(
     let mut call_graph: DiGraphMap<OwnerId, ()> = DiGraphMap::new();
     for stmt in facts {
         let owner = OwnerId(stmt.ordinal.0);
-        if !stmt.first_order_body_calls.is_empty()
-            || !stmt.first_order_lazy_reads.is_empty()
-            || !stmt.first_order_lazy_rebinds.is_empty()
+        if !stmt.calls.first_order_lazy.is_empty()
+            || !stmt.reads.first_order_lazy.is_empty()
+            || !stmt.rebinds.first_order_lazy.is_empty()
             || !stmt.first_order_unresolved_sources.is_empty()
             || stmt.first_order_unresolved_inline_fn
         {
@@ -1051,11 +1128,11 @@ fn promote_at_init_calls(
         }
     }
     for stmt in facts {
-        if stmt.first_order_body_calls.is_empty() {
+        if stmt.calls.first_order_lazy.is_empty() {
             continue;
         }
         let caller = OwnerId(stmt.ordinal.0);
-        for callee_id in &stmt.first_order_body_calls {
+        for callee_id in &stmt.calls.first_order_lazy {
             let Some(callee_owner) = resolvable_callee(callee_id) else {
                 continue;
             };
@@ -1074,7 +1151,7 @@ fn promote_at_init_calls(
         }
     }
 
-    // 3. Per-owner seeds: own lazy_reads / lazy_rebinds resolved to
+    // 3. Per-owner seeds: own reads.lazy / rebinds.lazy resolved to
     //    BindingId. Filters out targets whose owner is a function
     //    declaration — function bindings are hoisted at module
     //    instantiation (Phase 1 of ESM linking), so a cross-module
@@ -1114,12 +1191,12 @@ fn promote_at_init_calls(
                 continue;
             };
             roots.extend(owner_first_order_roots(stmt));
-            for id in &stmt.first_order_lazy_reads {
+            for id in &stmt.reads.first_order_lazy {
                 if binding_owner.contains_key(id) && !target_is_hoisted(id) {
                     reads.insert(id.clone());
                 }
             }
-            for id in &stmt.first_order_lazy_rebinds {
+            for id in &stmt.rebinds.first_order_lazy {
                 if binding_owner.contains_key(id) {
                     rebinds.insert(id.clone());
                 }
@@ -1158,7 +1235,7 @@ fn promote_at_init_calls(
     //    [`UnresolvedCallFallback`].
     let mut fallback: Option<UnresolvedCallFallback> = None;
     for stmt in facts {
-        if stmt.at_init_calls.is_empty()
+        if stmt.calls.eager.is_empty()
             && stmt.at_init_unresolved_sources.is_empty()
             && !stmt.at_init_unresolved_inline_fn
         {
@@ -1172,7 +1249,7 @@ fn promote_at_init_calls(
             stmt.at_init_unresolved_inline_fn,
             caller,
         );
-        for callee_id in &stmt.at_init_calls {
+        for callee_id in &stmt.calls.eager {
             let Some(callee_owner) = resolvable_callee(callee_id) else {
                 // A bare-Ident callee that isn't chunk-declared is a
                 // global/import — out of single-chunk analysis scope
@@ -1274,7 +1351,7 @@ fn promote_at_init_calls(
 /// closure** of every owner reachable from it through the chunk's
 /// read graph: edges `O → owner(b)` for every chunk binding `b` the
 /// owner `O` reads (eagerly or lazily), with every reachable owner
-/// contributing its `lazy_reads` / `lazy_rebinds` at any nesting
+/// contributing its `reads.lazy` / `rebinds.lazy` at any nesting
 /// depth. The caller statement then eagerly depends on every
 /// collected target.
 ///
@@ -1301,7 +1378,7 @@ impl UnresolvedCallFallback {
         for stmt in facts {
             let owner = OwnerId(stmt.ordinal.0);
             read_graph.add_node(owner);
-            for id in stmt.eager_reads.iter().chain(stmt.lazy_reads.iter()) {
+            for id in stmt.reads.eager.iter().chain(stmt.reads.lazy.iter()) {
                 if let Some(&target) = binding_owner.get(id) {
                     read_graph.add_edge(owner, target, ());
                 }
@@ -1327,12 +1404,12 @@ impl UnresolvedCallFallback {
                 let Some(stmt) = stmt_by_owner.get(owner) else {
                     continue;
                 };
-                for id in &stmt.lazy_reads {
+                for id in &stmt.reads.lazy {
                     if binding_owner.contains_key(id) {
                         reads.insert(id.clone());
                     }
                 }
-                for id in &stmt.lazy_rebinds {
+                for id in &stmt.rebinds.lazy {
                     if binding_owner.contains_key(id) {
                         rebinds.insert(id.clone());
                     }
@@ -1838,7 +1915,52 @@ mod chunk_constraining_module_edges_tests {
             .parse_module()
             .expect("parse module");
         let facts = analyze_chunk(&module, &AnalysisHints::default(), None, |_| None).facts;
-        build_owner_graph(&facts)
+        build_owner_graph(&facts).unwrap()
+    }
+
+    fn parse_facts(source: &str) -> Vec<crate::StatementFacts> {
+        let cm: Lrc<SourceMap> = Default::default();
+        let fm = cm.new_source_file(
+            FileName::Custom("test.js".into()).into(),
+            source.to_string(),
+        );
+        let lexer = Lexer::new(
+            Syntax::Es(Default::default()),
+            Default::default(),
+            StringInput::from(&*fm),
+            None,
+        );
+        let module = Parser::new_from(lexer)
+            .parse_module()
+            .expect("parse module");
+        analyze_chunk(&module, &AnalysisHints::default(), None, |_| None).facts
+    }
+
+    /// Strict mapping: two top-level statements declaring the same
+    /// binding (legal JS) must error instead of silently letting the
+    /// last declaration win — last-insert-wins drops every edge into
+    /// the earlier owner.
+    #[test]
+    fn duplicate_top_level_declarations_error() {
+        let err = build_owner_graph(&parse_facts("var x = 1;\nvar x = 2;\n")).unwrap_err();
+        assert_eq!(err.binding.as_ref(), "x");
+        assert_eq!(err.first, StatementOrdinal(0));
+        assert_eq!(err.second, StatementOrdinal(1));
+        assert!(
+            err.to_string().contains("duplicate top-level declaration"),
+            "{err}"
+        );
+    }
+
+    /// Same name in distinct scopes is hygienically distinct — no
+    /// duplicate. Comma-split declarators of *different* names are
+    /// also fine.
+    #[test]
+    fn distinct_bindings_with_shared_name_are_not_duplicates() {
+        build_owner_graph(&parse_facts(
+            "var x = 1;\nfunction f() { var x = 2; return x; }\nconst y = 3, z = 4;\n",
+        ))
+        .unwrap();
     }
 
     /// Pure cross-module lazy edge must not appear in the canonical
@@ -2056,7 +2178,7 @@ mod edge_role_wire_format_tests {
                 edges: Vec::new(),
             },
         };
-        let (graph, _) = OwnerGraph::from_report(&report, &[]);
+        let (graph, _) = OwnerGraph::from_report(&report, &[]).unwrap();
         assert_eq!(graph.num_edges(), 1);
         assert_eq!(graph.edge(OwnerEdgeId(0)).reason.role(), EdgeRole::Direct);
     }
@@ -2093,7 +2215,7 @@ mod edge_role_wire_format_tests {
                 edges: Vec::new(),
             },
         };
-        let (graph, _) = OwnerGraph::from_report(&report, &[]);
+        let (graph, _) = OwnerGraph::from_report(&report, &[]).unwrap();
         assert_eq!(graph.num_edges(), 1);
         assert_eq!(
             graph.edge(OwnerEdgeId(0)).reason.role(),
@@ -2214,7 +2336,7 @@ mod declared_round_trip_tests {
             .parse_module()
             .expect("parse module");
         let analysis = analyze_chunk(&module, &AnalysisHints::default(), None, |_| None);
-        let owner_graph = build_owner_graph(&analysis.facts);
+        let owner_graph = build_owner_graph(&analysis.facts).unwrap();
         let facts_reports: Vec<StatementFactsReport> = analysis
             .facts
             .iter()
@@ -2318,7 +2440,7 @@ mod declared_round_trip_tests {
             "fixture must have at least one declared-binding owner",
         );
 
-        let (round_tripped, _) = OwnerGraph::from_report(&report, &facts);
+        let (round_tripped, _) = OwnerGraph::from_report(&report, &facts).unwrap();
 
         assert_eq!(
             round_tripped.nodes.len(),
@@ -2364,7 +2486,7 @@ mod declared_round_trip_tests {
             residual,
         );
 
-        let (round_tripped, _) = OwnerGraph::from_report(&report, &facts);
+        let (round_tripped, _) = OwnerGraph::from_report(&report, &facts).unwrap();
         let restored_units = crate::atomic_units::compute_atomic_units(&round_tripped);
         let restored_outcome = assemble_partition(
             &round_tripped,
@@ -2385,5 +2507,23 @@ mod declared_round_trip_tests {
         (0..owner_count)
             .map(|i| partition.of(crate::OwnerId(i)))
             .collect()
+    }
+
+    /// Strict mapping: an edge referencing an owner id missing from
+    /// the node table (malformed / version-skewed `owner_graph.json`)
+    /// must be a hard error, not a silently dropped edge — the
+    /// planner-side gate would otherwise reason over a weaker graph.
+    #[test]
+    fn from_report_errors_on_unresolvable_edge_endpoint() {
+        let (_, _, mut report, _, _) = build_and_serialize("const a = 1;\nconst b = a + 1;\n");
+        assert!(
+            !report.edges.is_empty(),
+            "fixture must produce at least one edge"
+        );
+        report.edges[0].target = "owner:999".to_string();
+        let err = OwnerGraph::from_report(&report, &[]).unwrap_err();
+        assert_eq!(err.endpoint, "owner:999");
+        assert_eq!(err.edge_id, report.edges[0].id);
+        assert!(err.to_string().contains("owner:999"), "{err}");
     }
 }

--- a/devinfra/js/debundle/lib.rs
+++ b/devinfra/js/debundle/lib.rs
@@ -36,16 +36,16 @@ pub use factor_assembly::{
     AssemblyOutcome, AtomicUnitConflict, ConflictingClaim, assemble_partition,
 };
 pub use facts::{
-    ChunkFactAnalysis, ChunkFactsReport, EffectCell, EffectCellReport, IdReport,
-    StatementEffectSummary, StatementEffectSummaryReport, StatementFacts, StatementFactsReport,
-    StatementKind, analyze_chunk, find_top_level_await, local_namespace_iife_target,
+    ChunkFactAnalysis, ChunkFactsReport, EffectCell, IdReport, PositionBucketed,
+    StatementEffectSummary, StatementFacts, StatementFactsReport, StatementKind, analyze_chunk,
+    find_top_level_await, local_namespace_iife_target,
 };
 pub use graph::{
-    ChunkConstrainingEdgeSet, DepKind, EdgeMetadata, EdgeReason, EdgeRole, ModuleQuotient,
-    OwnerEdge, OwnerEdgeId, OwnerGraph, OwnerGraphOptions, OwnerId, OwnerNode, OwnerReportIndex,
-    build_module_quotient, build_owner_graph, build_owner_graph_with,
-    chunk_constraining_module_edges, chunk_linker_order, chunk_source_import_order,
-    position_lookup,
+    ChunkConstrainingEdgeSet, DepKind, DuplicateTopLevelDeclaration, EdgeMetadata, EdgeReason,
+    EdgeRole, ModuleQuotient, OwnerEdge, OwnerEdgeId, OwnerGraph, OwnerGraphOptions, OwnerId,
+    OwnerNode, OwnerReportIndex, UnresolvedOwnerEdgeEndpoint, build_module_quotient,
+    build_owner_graph, build_owner_graph_with, chunk_constraining_module_edges, chunk_linker_order,
+    chunk_source_import_order, position_lookup,
 };
 pub use ids::{
     BindingKind, ChunkId, ChunkTable, LogicalModule, LogicalModuleIndex, ModuleId,

--- a/devinfra/js/debundle/lowering/lower.rs
+++ b/devinfra/js/debundle/lowering/lower.rs
@@ -516,7 +516,7 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
         if !auto_grow.is_empty() {
             entry_body.push(export_named_for_bindings(&auto_grow));
         }
-        trim_dead_named_specifiers(&mut entry_body, &factorization.analysis.bindings);
+        trim_dead_named_specifiers(&mut entry_body, factorization.analysis.bindings());
     });
     let entry_exports_by_original_local = time_phase!(timings, "collect_entry_exports", {
         collect_entry_exports_by_original_local(
@@ -964,7 +964,7 @@ fn lower_single_plan(
         rewrite_runtime_sources_for_target(&mut body, chunk_id, entry_file, &plan.target_file);
     });
     // ImportSpecifier-bound members (`BindingKind::Imported` in
-    // `factorization.analysis.bindings`): for each `Imported` binding whose
+    // `factorization.analysis.bindings()`): for each `Imported` binding whose
     // `re_exported_by` map names this module, emit a re-import
     // (using the local name as the alias) plus mirror the
     // public-name export. Per-destination relative paths are

--- a/devinfra/js/debundle/lowering/materialize/mod.rs
+++ b/devinfra/js/debundle/lowering/materialize/mod.rs
@@ -310,7 +310,6 @@ pub(super) fn materialize_logical_chunk(
     let factorization = time_phase!(timings, "build_factorization", {
         ChunkFactorization::build_with(
             chunk_id.to_string(),
-            analysis.facts,
             precomputed,
             bindings_catalogue,
             logical_modules,
@@ -677,7 +676,7 @@ fn build_directory_dependency_facts(
     factorization: &ChunkFactorization,
 ) -> Vec<DirectoryDependencyFact> {
     let mut facts = Vec::new();
-    for edge in factorization.analysis.owner_graph.iter_edges() {
+    for edge in factorization.analysis.owner_graph().iter_edges() {
         let source_module = factorization.partition.of(edge.from);
         let target_module = factorization.partition.of(edge.to);
         if source_module == target_module {
@@ -718,10 +717,8 @@ fn module_output_file(
     factorization: &ChunkFactorization,
     module: ModuleId,
 ) -> Option<String> {
-    let ModuleId(LogicalModuleIndex(idx)) = module;
     factorization
         .analysis
-        .logical_modules
-        .get(idx)
+        .logical_module(module.0)
         .map(|logical| join_module_path(&[chunk_id, &logical.target_file]))
 }

--- a/devinfra/js/debundle/lowering/plan_references.rs
+++ b/devinfra/js/debundle/lowering/plan_references.rs
@@ -98,12 +98,12 @@ pub(super) fn collect_imported_reexports_by_module(
     module_count: usize,
 ) -> Vec<Vec<ImportedReexport>> {
     let mut by_module: Vec<Vec<ImportedReexport>> = (0..module_count).map(|_| Vec::new()).collect();
-    // Stable iteration order on `factorization.analysis.bindings` (HashMap): the
+    // Stable iteration order on `factorization.analysis.bindings()` (HashMap): the
     // recorded sequence determines the emit order of
     // `import { ... }` statements per module body and we want that
     // source-level shape pinned.
     let mut sorted_bindings: Vec<(&Id, &BindingKind)> =
-        factorization.analysis.bindings.iter().collect();
+        factorization.analysis.bindings().iter().collect();
     sorted_bindings.sort_by(|a, b| a.0.0.cmp(&b.0.0));
     for (id, kind) in sorted_bindings {
         // The body of this loop refers to the sym-typed `local` name
@@ -262,7 +262,7 @@ fn collect_phantom_side_effect_providers(
 ) {
     let module_id = ModuleId(LogicalModuleIndex(module_index));
     let residual = factorization.partition.residual();
-    let owner_graph = &factorization.analysis.owner_graph;
+    let owner_graph = factorization.analysis.owner_graph();
     for (owner_id, owner_module) in factorization.partition.iter() {
         if owner_module != module_id {
             continue;

--- a/devinfra/js/debundle/peel/factorize.rs
+++ b/devinfra/js/debundle/peel/factorize.rs
@@ -323,7 +323,7 @@ fn factorize_with_context(
         &graph.atomic_graph.nodes,
         &spec_modules,
         size_cap_lines,
-    );
+    )?;
     // Mutates the quotient in place; the returned merge-step list is unused here.
     greedy_merge_to_convergence(&mut quotient);
 

--- a/devinfra/js/debundle/peel/gate_differential_test.rs
+++ b/devinfra/js/debundle/peel/gate_differential_test.rs
@@ -295,7 +295,7 @@ fn gate_matches_reference_on_clean_chain() {
         make_module_group("ui/b", vec![2]),
     ];
     let (mut q, _) =
-        QuotientGraph::from_report_with_partition_extended(&report, CAP_LINES, &groups);
+        QuotientGraph::from_report_with_partition_extended(&report, CAP_LINES, &groups).unwrap();
     let live: Vec<ClassId> = q.iter_classes().collect();
     for i in 0..live.len() {
         for j in (i + 1)..live.len() {
@@ -329,7 +329,7 @@ fn gate_accepts_residual_pile_cycle_merge() {
         ],
         vec![],
     );
-    let mut q = QuotientGraph::from_report(&report, CAP_LINES);
+    let mut q = QuotientGraph::from_report(&report, CAP_LINES).unwrap();
     let ca = q.class_of(q.owner_idx_of("owner:a").unwrap());
     let cb = q.class_of(q.owner_idx_of("owner:b").unwrap());
     let ladder = compare_gate_to_reference(&report, &mut q, ca, cb).unwrap();
@@ -364,7 +364,7 @@ fn gate_rejects_pass2_tdz_merge() {
     );
     let groups = vec![make_module_group("ui/x", vec![0])];
     let (mut q, group_ids) =
-        QuotientGraph::from_report_with_partition_extended(&report, CAP_LINES, &groups);
+        QuotientGraph::from_report_with_partition_extended(&report, CAP_LINES, &groups).unwrap();
     let cx = group_ids[0];
     let ch = q.class_of(q.owner_idx_of("owner:h").unwrap());
     let ladder = compare_gate_to_reference(&report, &mut q, cx, ch).unwrap();
@@ -402,7 +402,7 @@ fn gate_rejects_module_granularity_pass1_cycle() {
     );
     let groups = vec![make_module_group("ui/a", vec![0])];
     let (mut q, group_ids) =
-        QuotientGraph::from_report_with_partition_extended(&report, CAP_LINES, &groups);
+        QuotientGraph::from_report_with_partition_extended(&report, CAP_LINES, &groups).unwrap();
     let ca = group_ids[0];
     let cb = q.class_of(q.owner_idx_of("owner:b").unwrap());
     let ladder = compare_gate_to_reference(&report, &mut q, ca, cb).unwrap();
@@ -440,7 +440,7 @@ fn gate_rejects_promotion_created_cross_rebind() {
     );
     let groups = vec![make_module_group("ui/a", vec![0])];
     let (mut q, group_ids) =
-        QuotientGraph::from_report_with_partition_extended(&report, CAP_LINES, &groups);
+        QuotientGraph::from_report_with_partition_extended(&report, CAP_LINES, &groups).unwrap();
     let ca = group_ids[0];
     let ch = q.class_of(q.owner_idx_of("owner:h").unwrap());
     let ladder = compare_gate_to_reference(&report, &mut q, ca, ch).unwrap();
@@ -572,7 +572,7 @@ fn randomized_gate_equals_reference() {
         let mut rng = Rng(seed.wrapping_mul(0x9E37_79B9_7F4A_7C15));
         let (report, spec) = random_report(&mut rng);
         let (mut q, _rejected) =
-            build_seed_quotient(&report, &report.atomic_graph.nodes, &spec, CAP_LINES);
+            build_seed_quotient(&report, &report.atomic_graph.nodes, &spec, CAP_LINES).unwrap();
         for _round in 0..6 {
             let live: Vec<ClassId> = q.iter_classes().collect();
             let mut accepted_pair: Option<(ClassId, ClassId)> = None;

--- a/devinfra/js/debundle/peel/quotient.rs
+++ b/devinfra/js/debundle/peel/quotient.rs
@@ -381,8 +381,11 @@ impl QuotientGraph {
     /// consumer (e.g. running `assemble_partition` against the
     /// reconstructed graph) needs `declared`, switch this call to
     /// pass the chunk's `StatementFactsReport` slice.
-    pub fn from_report(report: &OwnerGraphReport, cap_lines: usize) -> Self {
-        let (owner_graph, _) = OwnerGraph::from_report(report, &[]);
+    pub fn from_report(
+        report: &OwnerGraphReport,
+        cap_lines: usize,
+    ) -> Result<Self, analysis::UnresolvedOwnerEdgeEndpoint> {
+        let (owner_graph, _) = OwnerGraph::from_report(report, &[])?;
         let owner_ids: Vec<String> = report.nodes.iter().map(|n| n.id.clone()).collect();
         let owner_id_to_idx: FxHashMap<String, OwnerIdx> = owner_ids
             .iter()
@@ -428,12 +431,16 @@ impl QuotientGraph {
         let mut owner_weighted_edges: Vec<WeightedOwnerEdge> =
             Vec::with_capacity(report.edges.len());
         for edge in &report.edges {
-            let (Some(&s), Some(&t)) = (
-                owner_id_to_idx.get(edge.source.as_str()),
-                owner_id_to_idx.get(edge.target.as_str()),
-            ) else {
-                continue;
+            // Endpoint resolution can't fail here: the
+            // `OwnerGraph::from_report` call above already errored on
+            // any edge whose endpoint is missing from the node table.
+            let resolve = |endpoint: &str| {
+                owner_id_to_idx
+                    .get(endpoint)
+                    .copied()
+                    .expect("validated by OwnerGraph::from_report")
             };
+            let (s, t) = (resolve(&edge.source), resolve(&edge.target));
             owner_weighted_edges.push(WeightedOwnerEdge {
                 from: s,
                 to: t,
@@ -501,7 +508,7 @@ impl QuotientGraph {
             next_module_idx,
         };
         q.rebuild_class_adjacency();
-        q
+        Ok(q)
     }
 
     /// Build a quotient over `report.nodes` and immediately contract
@@ -526,7 +533,7 @@ impl QuotientGraph {
         report: &OwnerGraphReport,
         cap_lines: usize,
         groups: &[Vec<OwnerIdx>],
-    ) -> (Self, Vec<ClassId>) {
+    ) -> Result<(Self, Vec<ClassId>), analysis::UnresolvedOwnerEdgeEndpoint> {
         let extended_groups: Vec<PartitionGroup> = groups
             .iter()
             .map(|owner_idxs| PartitionGroup {
@@ -547,8 +554,8 @@ impl QuotientGraph {
         report: &OwnerGraphReport,
         cap_lines: usize,
         groups: &[PartitionGroup],
-    ) -> (Self, Vec<ClassId>) {
-        let mut q = Self::from_report(report, cap_lines);
+    ) -> Result<(Self, Vec<ClassId>), analysis::UnresolvedOwnerEdgeEndpoint> {
+        let mut q = Self::from_report(report, cap_lines)?;
         let mut group_class_ids = Vec::with_capacity(groups.len());
         for group in groups {
             let mut winner: Option<ClassId> = None;
@@ -577,7 +584,7 @@ impl QuotientGraph {
         // callers see the correct initial state.
         q.rebuild_class_adjacency();
         q.rebuild_realizability_index();
-        (q, group_class_ids)
+        Ok((q, group_class_ids))
     }
 
     /// The class an owner currently belongs to.
@@ -2113,8 +2120,8 @@ pub fn build_seed_quotient(
     atomic_units: &[analysis::AtomicUnitReport],
     spec_modules: &[SpecModuleGroup],
     cap_lines: usize,
-) -> (QuotientGraph, Vec<SeedContractionRejected>) {
-    let mut q = QuotientGraph::from_report(report, cap_lines);
+) -> Result<(QuotientGraph, Vec<SeedContractionRejected>), analysis::UnresolvedOwnerEdgeEndpoint> {
+    let mut q = QuotientGraph::from_report(report, cap_lines)?;
     let mut rejected = Vec::<SeedContractionRejected>::new();
 
     // ---- Pass 1: atomic units. Canonical order: lowest OwnerIdx
@@ -2432,7 +2439,7 @@ pub fn build_seed_quotient(
         }
     }
 
-    (q, rejected)
+    Ok((q, rejected))
 }
 
 fn resolve_owner_idxs(q: &QuotientGraph, owner_ids: &[String]) -> Vec<OwnerIdx> {

--- a/devinfra/js/debundle/peel/quotient_integration_test.rs
+++ b/devinfra/js/debundle/peel/quotient_integration_test.rs
@@ -51,7 +51,8 @@ fn seed_pre_contracts_atomic_units() {
         vec![unit.clone()],
         vec![],
     );
-    let (q, rejected) = build_seed_quotient(&report, &report.atomic_graph.nodes, &[], 10_000);
+    let (q, rejected) =
+        build_seed_quotient(&report, &report.atomic_graph.nodes, &[], 10_000).unwrap();
     assert!(
         rejected.is_empty(),
         "well-formed atomic unit must not produce rejections: {rejected:?}",
@@ -82,7 +83,8 @@ fn seed_pre_contracts_spec_modules() {
         module_id: "mod_alpha".to_string(),
         owner_ids: vec!["owner:a".to_string(), "owner:b".to_string()],
     }];
-    let (q, rejected) = build_seed_quotient(&report, &report.atomic_graph.nodes, &spec, 10_000);
+    let (q, rejected) =
+        build_seed_quotient(&report, &report.atomic_graph.nodes, &spec, 10_000).unwrap();
     assert!(
         rejected.is_empty(),
         "well-formed spec module must not produce rejections: {rejected:?}",
@@ -135,7 +137,8 @@ fn seed_skips_unrealizable_spec_module_contraction_and_reports() {
             owner_ids: vec!["owner:b1".to_string(), "owner:b2".to_string()],
         },
     ];
-    let (q, rejected) = build_seed_quotient(&report, &report.atomic_graph.nodes, &spec, 10_000);
+    let (q, rejected) =
+        build_seed_quotient(&report, &report.atomic_graph.nodes, &spec, 10_000).unwrap();
 
     // Exactly one of the two contractions must be rejected. The
     // canonical order is mod_alpha first (lex), so mod_alpha
@@ -225,7 +228,8 @@ fn seed_co_locates_constraining_cycle_atomic_unit() {
         vec![unit],
         vec![],
     );
-    let (q, rejected) = build_seed_quotient(&report, &report.atomic_graph.nodes, &[], 10_000);
+    let (q, rejected) =
+        build_seed_quotient(&report, &report.atomic_graph.nodes, &[], 10_000).unwrap();
     assert!(
         rejected.is_empty(),
         "atomic-unit contractions internal to the residual module are \
@@ -275,7 +279,7 @@ fn merge_closing_asymmetric_i_cycle_is_rejected_at_the_merge() {
     );
     let groups = vec![make_module_group("ui/x", vec![0])];
     let (mut q, group_ids) =
-        QuotientGraph::from_report_with_partition_extended(&report, 10_000, &groups);
+        QuotientGraph::from_report_with_partition_extended(&report, 10_000, &groups).unwrap();
     let cx = group_ids[0];
     let ch = q.class_of(q.owner_idx_of("owner:h").unwrap());
 
@@ -319,7 +323,8 @@ fn seed_atomic_unit_contractions_never_rejected_on_well_formed_input() {
         fixture_two_units_no_edges(),
     ];
     for (label, report) in fixtures {
-        let (_q, rejected) = build_seed_quotient(&report, &report.atomic_graph.nodes, &[], 10_000);
+        let (_q, rejected) =
+            build_seed_quotient(&report, &report.atomic_graph.nodes, &[], 10_000).unwrap();
         let atomic_rejections: Vec<&SeedContractionRejected> = rejected
             .iter()
             .filter(|r| matches!(r, SeedContractionRejected::AtomicUnit { .. }))
@@ -434,10 +439,10 @@ fn seed_rejection_diagnostic_is_canonical() {
 
     let report_a = make_report();
     let (_q1, rejected_a) =
-        build_seed_quotient(&report_a, &report_a.atomic_graph.nodes, &spec, 10_000);
+        build_seed_quotient(&report_a, &report_a.atomic_graph.nodes, &spec, 10_000).unwrap();
     let report_b = make_report();
     let (_q2, rejected_b) =
-        build_seed_quotient(&report_b, &report_b.atomic_graph.nodes, &spec, 10_000);
+        build_seed_quotient(&report_b, &report_b.atomic_graph.nodes, &spec, 10_000).unwrap();
 
     let json_a = serde_json::to_string_pretty(&rejected_a).unwrap();
     let json_b = serde_json::to_string_pretty(&rejected_b).unwrap();
@@ -475,7 +480,7 @@ fn contract_never_un_contracts() {
         ],
         vec![],
     );
-    let mut q = QuotientGraph::from_report(&report, 10_000);
+    let mut q = QuotientGraph::from_report(&report, 10_000).unwrap();
     let a_idx = q.owner_idx_of("owner:a").unwrap();
     let b_idx = q.owner_idx_of("owner:b").unwrap();
     let c_idx = q.owner_idx_of("owner:c").unwrap();
@@ -542,7 +547,8 @@ fn partition_constructor_contracts_each_group() {
         vec![OwnerIdx(0), OwnerIdx(1)],
         vec![OwnerIdx(2), OwnerIdx(3)],
     ];
-    let (q, class_ids) = QuotientGraph::from_report_with_partition(&report, 10_000, &groups);
+    let (q, class_ids) =
+        QuotientGraph::from_report_with_partition(&report, 10_000, &groups).unwrap();
     assert_eq!(class_ids.len(), 2, "one class id per input group");
 
     let a_idx = q.owner_idx_of("owner:a").unwrap();
@@ -741,7 +747,7 @@ fn greedy_extends_existing_module_with_only_consumer() {
 
     let groups = vec![make_module_group("ui/x", vec![0])];
     let (mut q, group_ids) =
-        QuotientGraph::from_report_with_partition_extended(&report, 10_000, &groups);
+        QuotientGraph::from_report_with_partition_extended(&report, 10_000, &groups).unwrap();
     let contractions = greedy_merge_to_convergence(&mut q);
 
     // Exactly one contraction merging owner:anon's class into the
@@ -779,7 +785,7 @@ fn greedy_absorbs_tiny_named_helper_into_unique_consumer() {
 
     let groups = vec![make_module_group("ui/x", vec![0])];
     let (mut q, group_ids) =
-        QuotientGraph::from_report_with_partition_extended(&report, 10_000, &groups);
+        QuotientGraph::from_report_with_partition_extended(&report, 10_000, &groups).unwrap();
     let contractions = greedy_merge_to_convergence(&mut q);
 
     assert_eq!(contractions.len(), 1, "got: {contractions:?}");
@@ -812,7 +818,8 @@ fn greedy_terminates_at_convergence() {
     );
 
     let groups = vec![make_module_group("ui/x", vec![0])];
-    let (mut q, _) = QuotientGraph::from_report_with_partition_extended(&report, 10_000, &groups);
+    let (mut q, _) =
+        QuotientGraph::from_report_with_partition_extended(&report, 10_000, &groups).unwrap();
     let before = q.iter_classes().count();
     let contractions = greedy_merge_to_convergence(&mut q);
     let after = q.iter_classes().count();
@@ -852,7 +859,8 @@ fn greedy_never_splits_existing_spec_module() {
     );
 
     let groups = vec![make_module_group("ui/x", vec![0, 1])];
-    let (mut q, _) = QuotientGraph::from_report_with_partition_extended(&report, 10_000, &groups);
+    let (mut q, _) =
+        QuotientGraph::from_report_with_partition_extended(&report, 10_000, &groups).unwrap();
     let _ = greedy_merge_to_convergence(&mut q);
 
     let a1_idx = q.owner_idx_of("owner:a1").unwrap();
@@ -903,7 +911,7 @@ fn greedy_never_merges_into_residual() {
 
     let groups = vec![make_module_group("ui/x", vec![0])];
     let (mut q, group_ids) =
-        QuotientGraph::from_report_with_partition_extended(&report, 10_000, &groups);
+        QuotientGraph::from_report_with_partition_extended(&report, 10_000, &groups).unwrap();
     let residual_idx = q.owner_idx_of("owner:residual_catchall").unwrap();
     let residual_class = q.class_of(residual_idx);
     // Designate the catch-all class as the sticky residual sink; the
@@ -1041,12 +1049,13 @@ fn incremental_state_matches_rebuild_on_synthetic_specs() {
 
     for (label, report, groups) in fixtures {
         let (mut incremental, _) =
-            QuotientGraph::from_report_with_partition_extended(&report, 10_000, &groups);
+            QuotientGraph::from_report_with_partition_extended(&report, 10_000, &groups).unwrap();
 
         // After construction, the cached cycle set must equal a
         // from-scratch rebuild.
         let cached = incremental.cycle_set();
         let rebuilt = QuotientGraph::from_report_with_partition_extended(&report, 10_000, &groups)
+            .unwrap()
             .0
             .cycle_set();
         assert_eq!(
@@ -1111,7 +1120,8 @@ fn replay_partition(
             label: None,
         })
         .collect();
-    let (q, _) = QuotientGraph::from_report_with_partition_extended(report, cap_lines, &groups);
+    let (q, _) =
+        QuotientGraph::from_report_with_partition_extended(report, cap_lines, &groups).unwrap();
     q
 }
 
@@ -1298,7 +1308,7 @@ fn incremental_index_matches_rebuild_on_synthetic_specs() {
 
     for (label, report, groups) in fixtures {
         let (mut q, _) =
-            QuotientGraph::from_report_with_partition_extended(&report, 10_000, &groups);
+            QuotientGraph::from_report_with_partition_extended(&report, 10_000, &groups).unwrap();
 
         // Initial assertion: incremental verdict matches rebuild.
         {
@@ -1387,7 +1397,8 @@ fn boolean_merge_gate_matches_diagnostic_cycle_gate() {
         make_module_group("ui/h", vec![1]),
         make_module_group("ui/b", vec![2]),
     ];
-    let (q, _) = QuotientGraph::from_report_with_partition_extended(&report, 10_000, &groups);
+    let (q, _) =
+        QuotientGraph::from_report_with_partition_extended(&report, 10_000, &groups).unwrap();
 
     for (left, right, expected_preserves) in [
         (ClassId(0), ClassId(1), true),
@@ -1478,7 +1489,8 @@ fn greedy_merges_three_clusters_under_cap() {
         make_module_group("ui/b", vec![1]),
         make_module_group("ui/c", vec![2]),
     ];
-    let (mut q, _) = QuotientGraph::from_report_with_partition_extended(&report, 150, &groups);
+    let (mut q, _) =
+        QuotientGraph::from_report_with_partition_extended(&report, 150, &groups).unwrap();
     let contractions = greedy_merge_to_convergence(&mut q);
     assert_eq!(
         contractions.len(),
@@ -1520,7 +1532,8 @@ fn greedy_stops_at_cap() {
         make_module_group("ui/b", vec![1]),
         make_module_group("ui/c", vec![2]),
     ];
-    let (mut q, _) = QuotientGraph::from_report_with_partition_extended(&report, 40, &groups);
+    let (mut q, _) =
+        QuotientGraph::from_report_with_partition_extended(&report, 40, &groups).unwrap();
     let contractions = greedy_merge_to_convergence(&mut q);
     assert_eq!(
         contractions.len(),
@@ -1573,7 +1586,8 @@ fn greedy_resolves_realizability_cycle_by_merging() {
         make_module_group("ui/a", vec![0]),
         make_module_group("ui/b", vec![1]),
     ];
-    let (mut q, _) = QuotientGraph::from_report_with_partition_extended(&report, 10_000, &groups);
+    let (mut q, _) =
+        QuotientGraph::from_report_with_partition_extended(&report, 10_000, &groups).unwrap();
     let contractions = greedy_merge_to_convergence(&mut q);
     assert_eq!(
         contractions.len(),
@@ -2019,7 +2033,8 @@ fn pass3_diagnostic_walk_never_commits_a_merge() {
         module_id: "mod_alpha".to_string(),
         owner_ids: vec!["owner:foo".to_string()],
     }];
-    let (q, rejected) = build_seed_quotient(&report, &report.atomic_graph.nodes, &spec, 10_000);
+    let (q, rejected) =
+        build_seed_quotient(&report, &report.atomic_graph.nodes, &spec, 10_000).unwrap();
 
     let reachability_rejections: Vec<&SeedContractionRejected> = rejected
         .iter()
@@ -2074,7 +2089,7 @@ fn owner_graph_and_partition_from_spec(
     spec: &[peel::quotient::SpecModuleGroup],
 ) -> (analysis::OwnerGraph, analysis::Partition) {
     use std::collections::HashMap;
-    let (owner_graph, index) = analysis::OwnerGraph::from_report(report, &[]);
+    let (owner_graph, index) = analysis::OwnerGraph::from_report(report, &[]).unwrap();
     // Module-id assignment: residual goes to ModuleId(0). Every
     // distinct spec module gets its own ModuleId starting at 1.
     let residual = analysis::ModuleId::logical(0);
@@ -2249,7 +2264,8 @@ fn planner_seed_rejection_matches_materializer_verdict_on_asymmetric_cycle() {
 
     // Planner-side verdict.
     let (_q, rejected) =
-        peel::quotient::build_seed_quotient(&report, &report.atomic_graph.nodes, &spec, 10_000);
+        peel::quotient::build_seed_quotient(&report, &report.atomic_graph.nodes, &spec, 10_000)
+            .unwrap();
     let planner_has_rejection = !rejected.is_empty();
 
     // The two MUST agree. If the materializer says unrealizable, the
@@ -2540,7 +2556,8 @@ fn planner_and_materializer_agree_on_corpus() {
             &case.report.atomic_graph.nodes,
             &case.spec,
             10_000,
-        );
+        )
+        .unwrap();
         let planner_has_rejection = !rejected.is_empty();
 
         assert_eq!(
@@ -2610,7 +2627,8 @@ fn incremental_kernel_query_matches_rebuild_after_each_contract() {
         let (mut incremental, _) =
             peel::quotient::QuotientGraph::from_report_with_partition_extended(
                 &report, 10_000, &groups,
-            );
+            )
+            .unwrap();
 
         loop {
             let one = peel::quotient::greedy_step(&mut incremental);
@@ -2646,8 +2664,10 @@ fn build_fixture(
     groups: &[peel::quotient::PartitionGroup],
     cap_lines: usize,
 ) -> (QuotientGraph, QuotientGraph) {
-    let (q_a, _) = QuotientGraph::from_report_with_partition_extended(report, cap_lines, groups);
-    let (q_b, _) = QuotientGraph::from_report_with_partition_extended(report, cap_lines, groups);
+    let (q_a, _) =
+        QuotientGraph::from_report_with_partition_extended(report, cap_lines, groups).unwrap();
+    let (q_b, _) =
+        QuotientGraph::from_report_with_partition_extended(report, cap_lines, groups).unwrap();
     (q_a, q_b)
 }
 
@@ -2882,7 +2902,8 @@ fn gate_bypassing_partition_cycle_surfaces_and_recovers() {
         &report,
         10_000,
         &[vec![OwnerIdx(0), OwnerIdx(2)]],
-    );
+    )
+    .unwrap();
     let merged = group_classes[0];
     let b_class = q.class_of(OwnerIdx(1));
     assert_eq!(q.class_of(OwnerIdx(0)), merged);

--- a/devinfra/js/debundle/plans/sanitization_program_2026_06.md
+++ b/devinfra/js/debundle/plans/sanitization_program_2026_06.md
@@ -117,17 +117,29 @@ consolidation (`ResolutionManifest<R>`), typed chunk identity.
 
 ## Track D — type-shape and strict-mapping cleanups (week 2, parallel)
 
-- `StatementFacts`: `PositionBucketed<T>` (9 fields → 3, structural subset
-  invariants), unify the `StructuralStatementFacts` vocabulary, derive
-  `effects`.
-- `ChunkManifest` → `#[serde(flatten)]` over `ChunkAnalysisReport` (zero
-  wire change; resolves the backlog's auto-derive open decision).
-- `ChunkAnalysis` field privatization (cache-staleness hazard).
-- Fold `program_analysis.rs`'s remainder into the facts walk (two parallel
-  extractors with divergent traversal rules).
-- `graph.rs` strict mapping: error on duplicate top-level declarations and
-  on `from_report` edges with unresolvable endpoints.
-- `cli/mod.rs`: move scc/cluster implementations + renderers out.
+_Status (2026-06): landed, except the `program_analysis.rs` fold._
+
+- Done: `StatementFacts` `PositionBucketed<T>` (9 fields → 3, structural
+  subset invariants), unified `StructuralStatementFacts` vocabulary,
+  derived `effects()`.
+- Done: `ChunkManifest` → `#[serde(flatten)]` over `ChunkAnalysisReport`
+  (zero wire change; resolved the backlog's auto-derive open decision).
+- Done: `ChunkAnalysis` field privatization (cache-staleness hazard).
+- **Open** — fold `program_analysis.rs`'s remainder into the facts walk
+  (two parallel extractors with divergent traversal rules). Not a
+  mechanical fold: the shallow extractor runs at prepare time on a plain
+  parse of _every_ chunk and feeds `artifact::ChunkAnalysisReport`
+  records, while the facts walk runs at stage one on resolver-processed
+  ASTs of materialized chunks in a crate (`analysis`) that doesn't (and
+  shouldn't) depend on `artifact`. Folding needs a redesign of when/where
+  manifest records are computed, or a shared declaration classifier
+  extracted to `binding_targets`. Tracked by CODE_REVIEW's "Two parallel
+  top-level fact extractors" P1 item, which stays open.
+- Done: `graph.rs` strict mapping — `DuplicateTopLevelDeclaration` error
+  instead of last-insert-wins, `from_report` hard error on unresolvable
+  edge endpoints.
+- Done: `cli/mod.rs` scc/cluster implementations + renderers moved to
+  `cli/scc_cluster.rs`.
 
 ## Track E — CLI scripting surface (week 2–3, parallel)
 

--- a/devinfra/js/debundle/realizability/tests.rs
+++ b/devinfra/js/debundle/realizability/tests.rs
@@ -30,7 +30,7 @@ fn parse_and_build(source: &str) -> OwnerGraph {
         .parse_module()
         .expect("parse module");
     let facts = analyze_chunk(&module, &AnalysisHints::default(), None, |_| None).facts;
-    build_owner_graph(&facts)
+    build_owner_graph(&facts).unwrap()
 }
 
 /// Two top-level constants in different modules, with one reading

--- a/devinfra/js/debundle/report_builders.rs
+++ b/devinfra/js/debundle/report_builders.rs
@@ -53,7 +53,7 @@ pub(crate) fn build_owner_graph_report(factorization: &ChunkFactorization) -> Ow
     let (nodes, edges) = nodes_edges;
     let quotient_sccs = build_quotient_scc_reports(factorization, &quotient_edges);
     OwnerGraphReport {
-        chunk_id: factorization.analysis.chunk_id.clone(),
+        chunk_id: factorization.analysis.chunk_id().to_string(),
         nodes,
         edges,
         quotient: OwnerGraphQuotientReport {
@@ -73,7 +73,7 @@ fn build_owner_nodes_and_edges(
     factorization: &ChunkFactorization,
 ) -> (Vec<OwnerGraphNodeReport>, Vec<OwnerGraphEdgeReport>) {
     let partition = &factorization.partition;
-    let owner_graph = &factorization.analysis.owner_graph;
+    let owner_graph = factorization.analysis.owner_graph();
     let nodes = owner_graph
         .iter_nodes()
         .map(|node| OwnerGraphNodeReport {
@@ -120,7 +120,7 @@ where
 
 fn build_quotient_node_reports(factorization: &ChunkFactorization) -> Vec<ModuleEntry> {
     let mut modules = BTreeSet::<ModuleId>::new();
-    for idx in 0..factorization.analysis.logical_modules.len() {
+    for idx in 0..factorization.analysis.logical_modules().len() {
         modules.insert(ModuleId(LogicalModuleIndex(idx)));
     }
     for (_, module) in factorization.partition.iter() {
@@ -148,7 +148,7 @@ pub(crate) fn build_quotient_edge_reports(
     // variant) so the final `edge_kinds: Vec<DepKind>` stays sorted
     // without a per-pair sort.
     let partition = &factorization.partition;
-    let owner_graph = &factorization.analysis.owner_graph;
+    let owner_graph = factorization.analysis.owner_graph();
     let mut accum: std::collections::HashMap<(ModuleId, ModuleId), QuotientEdgeAccumulator> =
         std::collections::HashMap::with_capacity(owner_graph.num_edges());
     let mut seen_side_effect_module_pairs: std::collections::HashSet<(ModuleId, ModuleId)> =
@@ -212,7 +212,7 @@ fn build_atomic_unit_report(
     let mut max_ordinal = 0usize;
     for owner_id in &unit.members {
         owner_ids.push(owner_key(*owner_id));
-        if let Some(node) = factorization.analysis.owner_graph.node(*owner_id) {
+        if let Some(node) = factorization.analysis.owner_graph().node(*owner_id) {
             if node.declared.is_empty() {
                 anonymous_statement_owner_ids.push(owner_key(*owner_id));
             }
@@ -246,7 +246,7 @@ fn build_atomic_unit_report(
 }
 
 fn build_atomic_graph_report(factorization: &ChunkFactorization) -> AtomicGraphReport {
-    let owner_graph = &factorization.analysis.owner_graph;
+    let owner_graph = factorization.analysis.owner_graph();
     let mut units = factorization.atomic_units.clone();
     units.sort_by_key(|unit| unit.members.iter().copied().min().map(|owner| owner.0));
     // `unit_by_owner` is lookup-only after construction — a `HashMap`
@@ -385,11 +385,9 @@ fn quotient_edge_indices_by_source(
 /// projection in reports to gate residual-only predicates without
 /// string-matching module ids or labels.
 pub(crate) fn is_residual_destination(factorization: &ChunkFactorization, id: ModuleId) -> bool {
-    let LogicalModuleIndex(idx) = id.0;
     factorization
         .analysis
-        .logical_modules
-        .get(idx)
+        .logical_module(id.0)
         .is_some_and(|module| module.residual)
 }
 

--- a/devinfra/js/debundle/stage_one/mod.rs
+++ b/devinfra/js/debundle/stage_one/mod.rs
@@ -53,7 +53,7 @@ mod rebind_fold;
 pub use chunk_admission::{DynamicImportTarget, enforce_chunk_admission};
 pub use rebind_fold::{RebindFold, compute_rebind_folds};
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use swc_common::Span;
 use swc_ecma_ast::Module;
 
@@ -120,7 +120,8 @@ where
         resolve_dynamic_import,
     )?;
     let owner_graph_and_units =
-        compute_owner_graph_and_units_with(&fact_analysis.facts, owner_graph_options);
+        compute_owner_graph_and_units_with(&fact_analysis.facts, owner_graph_options)
+            .with_context(|| format!("building owner graph for chunk {chunk_id}"))?;
     Ok(StageOneAnalysis {
         fact_analysis,
         owner_graph_and_units,

--- a/devinfra/js/debundle/vendor/strip.rs
+++ b/devinfra/js/debundle/vendor/strip.rs
@@ -1142,12 +1142,12 @@ fn analyze_prune_items(module: &Module, chunk_path: &str) -> Result<Vec<ItemAnal
 }
 
 fn item_analysis_from_fact(item: &ModuleItem, fact: &StatementFacts) -> ItemAnalysis {
-    let mut reads = fact.eager_reads.clone();
-    reads.extend(fact.lazy_reads.iter().cloned());
-    reads.extend(fact.eager_rebinds.iter().cloned());
-    reads.extend(fact.lazy_rebinds.iter().cloned());
-    reads.extend(fact.at_init_calls.iter().cloned());
-    reads.extend(fact.body_calls.iter().cloned());
+    let mut reads = fact.reads.eager.clone();
+    reads.extend(fact.reads.lazy.iter().cloned());
+    reads.extend(fact.rebinds.eager.iter().cloned());
+    reads.extend(fact.rebinds.lazy.iter().cloned());
+    reads.extend(fact.calls.eager.iter().cloned());
+    reads.extend(fact.calls.lazy.iter().cloned());
     for id in &fact.declared {
         reads.remove(id);
     }
@@ -1167,8 +1167,8 @@ fn item_analysis_from_fact(item: &ModuleItem, fact: &StatementFacts) -> ItemAnal
         export_aliases: export_aliases_for_item(item),
         side_effect,
         shareable_helper: item_is_shareable_helper(item),
-        observable_writes: fact.effects.writes.clone(),
-        effects_summarizable: fact.effects.cell_writes_summarizable,
+        observable_writes: fact.effects().writes,
+        effects_summarizable: fact.cell_writes_summarizable,
     }
 }
 


### PR DESCRIPTION
Track D of `plans/sanitization_program_2026_06.md` (one PR).

## Landed

1. **`StatementFacts` → `PositionBucketed<T>`** (`facts/mod.rs`, `facts/wire.rs`): the eager/lazy/first-order triples for reads, rebinds, and calls collapse from 9 fields to 3 `PositionBucketed<BTreeSet<Id>>` fields; the `first_order_lazy ⊆ lazy` subset invariant is enforced in a single `record()` helper instead of per-construction-site discipline. `StructuralStatementFacts` now uses the same vocabulary (the field-by-field mid-pipeline renames `at_init_reads`→`eager_reads`, `lazy_calls`→`body_calls`, … are gone). The `effects` cell summary is now derived on demand via `StatementFacts::effects()` — only the `GlobalProp` half (`global_writes`/`global_reads`) and the summarizability bits are stored; the `Binding`-cell half no longer restates `declared`/`reads.eager`/`rebinds.eager`. The now-unused `EffectCellReport`/`StatementEffectSummaryReport` wire mirrors are deleted. Zero behavior change.
2. **`ChunkManifest` → `#[serde(flatten)]` over `ChunkAnalysisReport`** (`artifact.rs`): removes the field-by-field copy. Zero wire change — pinned by a new top-level-key assertion on `chunk.json` in `e2e/realizability_test.rs`. The `ARCHITECTURE_BACKLOG.md` auto-derive entry is resolved and deleted.
3. **`ChunkAnalysis` field privatization** (`chunk_analysis.rs`): all fields private behind accessors so mutating an input can't silently stale the precomputed lookup tables; `facts` and `chunk_renames` are no longer retained past construction. (Started by the previous worker; verified and finished.)
4. **`graph.rs` strict mapping** (failing tests first):
   - `build_owner_graph{,_with}` returns `Err(DuplicateTopLevelDeclaration)` when two top-level statements declare the same binding, instead of last-insert-wins silently dropping every edge into the earlier owner. Surfaced as a spec-facing rejection through stage one; pinned by the new `e2e/duplicate_top_level_declaration_test.rs` (plus a hygiene-negative case: same name in an inner scope is not a duplicate).
   - `OwnerGraph::from_report` returns `Err(UnresolvedOwnerEdgeEndpoint)` on edges whose endpoints don't resolve in the node table, instead of silently dropping them and handing the planner-side gate a weaker graph. Propagated through `QuotientGraph::from_report{,_with_partition,_with_partition_extended}` and `build_seed_quotient` (planner CLI) and `cli/edit_gate.rs`.
5. **`cli/mod.rs` slimming**: the `scc`/`cluster` command implementations, arg structs, and text renderers moved to `cli/scc_cluster.rs` — purely mechanical, no behavior change (kept mechanical per coordination with the Track E worker who owns the CLI gate-rejection/output paths).

`CODE_REVIEW.md` entries for all landed items are deleted; the Track D section of the plan carries a status note.

## Skipped (with rationale)

**Fold `program_analysis.rs` into the facts walk** — not a mechanical fold: `analyze_program_shallow` runs at *prepare* time on a plain (non-resolver) parse of **every** chunk and feeds `artifact::ChunkAnalysisReport` records, while the facts walk runs at *stage one* on resolver-processed ASTs of materialized chunks, in a crate (`analysis`) that doesn't and shouldn't depend on `artifact`. Folding requires redesigning when/where manifest records are computed (or extracting a shared declaration classifier into `binding_targets`). Rationale recorded in the plan's Track D status note; the CODE_REVIEW "Two parallel top-level fact extractors" P1 entry stays open.

## Verification

- `bbr test //devinfra/js/debundle/...` — 101/101 green: `BAZEL_TEST_INVOCATIONS=buildbuddy:11e2cc51-73bc-4327-990d-63f4e3b2dabd`
- The duplicate-declaration e2e was confirmed red against the pre-fix binary (invocation `6c415b36-7982-42c7-81aa-d0bf3856848b`) before the fix landed.
- No `//props/frontend/debundle` targets exist at HEAD (the realistic-shape corpus lives downstream), so the synthetic suite is the in-repo gate.

https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk)_