### PR TITLE
debundle: author-asserted fluent purity through call-result chains

### DIFF
--- a/devinfra/js/debundle/analysis_hints.rs
+++ b/devinfra/js/debundle/analysis_hints.rs
@@ -40,6 +40,13 @@ pub struct AnalysisHints {
     /// oracle (`crate::cross_module_purity`); empty in strictly per-chunk
     /// paths, where imported callees stay `unknown_call`.
     pub imported_purities: BTreeMap<String, Purity>,
+    /// Local binding names of this chunk that import an author-asserted
+    /// fluent export (`chunk_export_purity.<chunk>.fluent_exports`,
+    /// projected by `crate::cross_module_purity` onto importer locals).
+    /// The classifier treats them as deep-purity roots: member reads /
+    /// calls on them AND on values derived from them are pure. See
+    /// `ChunkCodeGraph::fluent_bindings`.
+    pub fluent_bindings: BTreeSet<String>,
 }
 
 impl AnalysisHints {
@@ -51,6 +58,7 @@ impl AnalysisHints {
             known_effects: BTreeMap::new(),
             local_effect_policy: LocalEffectPolicy::KnownEffectsOnly,
             imported_purities: BTreeMap::new(),
+            fluent_bindings: BTreeSet::new(),
         }
     }
 }

--- a/devinfra/js/debundle/analysis_tests/mod.rs
+++ b/devinfra/js/debundle/analysis_tests/mod.rs
@@ -32,12 +32,8 @@ fn parse(source: &str) -> Module {
 
 fn hints_with_decorate_helper(name: &str) -> AnalysisHints {
     AnalysisHints {
-        declared_pure: BTreeSet::new(),
-        declared_pure_new: BTreeSet::new(),
-        declared_pure_members: BTreeMap::new(),
         known_effects: BTreeMap::from([(name.to_string(), KnownEffect::TypescriptDecorateHelper)]),
-        local_effect_policy: LocalEffectPolicy::KnownEffectsOnly,
-        imported_purities: BTreeMap::new(),
+        ..AnalysisHints::default()
     }
 }
 

--- a/devinfra/js/debundle/cross_module_purity.rs
+++ b/devinfra/js/debundle/cross_module_purity.rs
@@ -78,6 +78,7 @@ impl ModulePurityFacts<'_> {
             &BTreeSet::new(),
             &BTreeMap::new(),
             imported,
+            &BTreeSet::new(),
         )
     }
 
@@ -238,6 +239,57 @@ pub fn resolve_asserted_member_purities(
                 })
                 .collect();
             (key.clone(), members)
+        })
+        .collect()
+}
+
+/// Project author-asserted fluent exports
+/// (`chunk_export_purity.<chunk>.fluent_exports`) onto each importing
+/// module's local binding names. Pure axiom projection — no fixpoint,
+/// same shape as `resolve_asserted_member_purities`: for every import
+/// `local → (module, export)` with a fluent assertion on
+/// `(module, export)`, the importing module receives `local` in its
+/// fluent set, which seeds the classifier's deep-purity chain arm
+/// (`ChunkCodeGraph::fluent_bindings`). Assertions naming a module or
+/// export the program doesn't have warn to stderr and are ignored.
+pub fn resolve_asserted_fluent_bindings(
+    modules: &BTreeMap<ModuleKey, ModulePurityFacts<'_>>,
+    asserted_fluent: &BTreeMap<ModuleKey, BTreeSet<String>>,
+) -> BTreeMap<ModuleKey, BTreeSet<String>> {
+    for (module, export_names) in asserted_fluent {
+        for export_name in export_names {
+            let known_export = modules
+                .get(module)
+                .is_some_and(|facts| facts.exports.contains_key(export_name));
+            if !known_export {
+                eprintln!(
+                    "cross_module_purity: dangling fluent_exports assertion \
+                     {module}:{export_name} — no such analyzed module export; ignoring"
+                );
+            }
+        }
+    }
+    modules
+        .iter()
+        .map(|(key, facts)| {
+            let fluent: BTreeSet<String> = facts
+                .imports
+                .iter()
+                .filter_map(|(local, target)| {
+                    let asserted = asserted_fluent
+                        .get(&target.module)?
+                        .contains(&target.export);
+                    // Only project assertions whose export actually exists in
+                    // the defining module (dangling ones warned above).
+                    (asserted
+                        && modules
+                            .get(&target.module)?
+                            .exports
+                            .contains_key(&target.export))
+                    .then(|| local.clone())
+                })
+                .collect();
+            (key.clone(), fluent)
         })
         .collect()
 }
@@ -484,6 +536,39 @@ mod tests {
             )]),
         )]);
         let resolved = resolve_asserted_member_purities(&modules, &asserted);
+        assert!(resolved["app"].is_empty());
+    }
+
+    #[test]
+    fn asserted_fluent_exports_project_onto_importer_locals() {
+        // The importer binds the export under its own local name `k`;
+        // the definition-side fluent assertion must land under THAT
+        // name, where the classifier's chain arm looks it up.
+        let app = parse("import { e4 as k } from \"vendor\";\nconst S = k.object({});");
+        let vendor = parse("const zod = makeZod();\nexport { zod as e4 };");
+        let modules = BTreeMap::from([
+            (
+                "app".to_string(),
+                facts(&app, &[("k", "vendor", "e4")], &[]),
+            ),
+            ("vendor".to_string(), facts(&vendor, &[], &[("e4", "zod")])),
+        ]);
+        let asserted = BTreeMap::from([("vendor".to_string(), BTreeSet::from(["e4".to_string()]))]);
+        let resolved = resolve_asserted_fluent_bindings(&modules, &asserted);
+        assert_eq!(resolved["app"], BTreeSet::from(["k".to_string()]));
+        assert!(resolved["vendor"].is_empty());
+    }
+
+    #[test]
+    fn dangling_fluent_assertion_is_ignored() {
+        let app = parse("const S = k.object({});");
+        let modules = BTreeMap::from([(
+            "app".to_string(),
+            facts(&app, &[("k", "vendor", "e4")], &[]),
+        )]);
+        // `vendor` is not analyzed at all — the assertion must not project.
+        let asserted = BTreeMap::from([("vendor".to_string(), BTreeSet::from(["e4".to_string()]))]);
+        let resolved = resolve_asserted_fluent_bindings(&modules, &asserted);
         assert!(resolved["app"].is_empty());
     }
 }

--- a/devinfra/js/debundle/docs/design.md
+++ b/devinfra/js/debundle/docs/design.md
@@ -1101,6 +1101,27 @@ member names`, it projects onto each importing chunk's local binding
   reached through a default/namespace import are blessed once on the
   defining vendor chunk.
 
+  `chunk_export_purity.<chunk>.fluent_exports` is the **deep** form, for
+  builder/fluent APIs whose chain receivers are call _results_ rather
+  than bindings — `z.object({...}).optional().describe(...)`. Every
+  binding-keyed surface above is structurally unable to reach link 2+
+  of such a chain (there is no binding to key on). A fluent assertion
+  makes the export a deep-purity root: static member reads and calls on
+  it, and on every value transitively derived from it through such
+  reads/calls, are pure — with call arguments still classified normally
+  at every link, so an impure argument anywhere in the chain keeps the
+  statement impure. The trust also closes over importer-side
+  `const X = <fluent chain>` derivations (`const Base = z.object(...)`,
+  later `Base.extend(...)`), `const` only since a `let`/`var` cell can
+  be rebound to an untrusted value. Computed members and `new` break
+  the chain conservatively. The contract is intentionally broad — it
+  covers the API's whole transitive fluent surface, including methods
+  that run author-registered callbacks (a schema's `.parse`) — so it is
+  only sound for exports whose derived-value methods are all
+  side-effect-free when invoked at module top level and whose values
+  the program does not monkey-patch. Same author-trust posture and
+  dangling-assertion handling as the two forms above.
+
 - **A10. Spec-declared local-effect annotations are
   author-trusted.** The spec format also admits an optional
   per-member `effect:` field for named helper bindings whose

--- a/devinfra/js/debundle/e2e/purity_test.rs
+++ b/devinfra/js/debundle/e2e/purity_test.rs
@@ -1266,3 +1266,61 @@ export { A, B, C };
     );
     assert!(fixture.entry_path.exists());
 }
+
+/// Zod-style schema-declaration entry: every statement is a fluent
+/// chain whose intermediate receivers are call RESULTS
+/// (`k.object({...}).describe(...)`), plus one `const`-derived root
+/// (`Base` → `.extend(...)`). No binding-keyed purity surface
+/// (`pure_exports`, `pure_members`, `imported_purities`) can admit
+/// link 2+ of these chains — there is no binding to key on.
+const FLUENT_CHAIN_ENTRY: &str = r#"import { e4 as k } from "./vendorlib.js";
+const Base = k.object({ id: 1 });
+const A = k.object({ a: 1 }).describe("a");
+const B = Base.extend({ b: 2 }).describe("b");
+const C = k.object({ c: 1 }).describe("c");
+console.log(A, B, C);
+export { A, B, C };
+"#;
+
+const FLUENT_VENDORLIB: &str = "const zodish = { object(shape) { return { shape, \
+describe(d) { return { shape: this.shape, d }; }, extend(more) { return zodish.object(more); \
+} }; } };\nexport { zodish as e4 };\n";
+
+#[test]
+fn fluent_chain_schema_decls_without_assertion_emit_s_cycle() {
+    // Baseline pin: the chain receivers are call results, so every
+    // schema decl is impure (`unknown_call`/`unknown_member`) and the
+    // interleaved destinations S-cycle.
+    expect_rejection(
+        FixtureOpts::new(
+            FLUENT_CHAIN_ENTRY,
+            vec![
+                logical_module("mod_a", &[Member::new("A"), Member::new("C")]),
+                logical_module("mod_b", &[Member::new("B")]),
+            ],
+        )
+        .with_extra_chunks(&[("static/vendorlib", FLUENT_VENDORLIB)]),
+        &["cycle", "mod_a", "mod_b", "side-effect"],
+    );
+}
+
+#[test]
+fn asserted_fluent_export_chains_emit_no_s_cycle() {
+    // A definition-side `fluent_exports` assertion on the defining
+    // chunk projects onto the importer's `k` local; the chain arm then
+    // admits every link (including the `Base`-derived `.extend`
+    // chain), the schema decls classify pure, and the interleaved
+    // split realizes.
+    let fixture = run_fixture(
+        FixtureOpts::new(
+            FLUENT_CHAIN_ENTRY,
+            vec![
+                logical_module("mod_a", &[Member::new("A"), Member::new("C")]),
+                logical_module("mod_b", &[Member::new("B")]),
+            ],
+        )
+        .with_extra_chunks(&[("static/vendorlib", FLUENT_VENDORLIB)])
+        .with_chunk_export_purity(&[("static/vendorlib", json!({ "fluent_exports": ["e4"] }))]),
+    );
+    assert!(fixture.entry_path.exists());
+}

--- a/devinfra/js/debundle/facts/mod.rs
+++ b/devinfra/js/debundle/facts/mod.rs
@@ -555,6 +555,7 @@ where
         &hints.declared_pure_new,
         &hints.declared_pure_members,
         &hints.imported_purities,
+        &hints.fluent_bindings,
     );
     let local_effect_context =
         local_effects::LocalEffectContext::for_body(&body, hints.local_effect_policy);

--- a/devinfra/js/debundle/lowering/cross_module.rs
+++ b/devinfra/js/debundle/lowering/cross_module.rs
@@ -7,7 +7,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use analysis::cross_module_purity::{
-    ModulePurityFacts, ResolvedImport, resolve_asserted_member_purities, resolve_imported_purities,
+    ModulePurityFacts, ResolvedImport, resolve_asserted_fluent_bindings,
+    resolve_asserted_member_purities, resolve_imported_purities,
 };
 use analysis::purity::Purity;
 use artifact::{
@@ -55,6 +56,9 @@ pub(super) struct CrossModulePurities {
     /// Per-chunk pure-member sets for imported namespace-like bindings,
     /// merged into `AnalysisHints::declared_pure_members`.
     pub(super) members: BTreeMap<String, BTreeMap<String, BTreeSet<String>>>,
+    /// Per-chunk fluent-trusted import binding names (deep-purity roots),
+    /// merged into `AnalysisHints::fluent_bindings`.
+    pub(super) fluent: BTreeMap<String, BTreeSet<String>>,
 }
 
 /// Per-chunk-name imported-binding purity maps for the whole artifact.
@@ -202,8 +206,14 @@ pub(super) fn collect_cross_module_imported_purities(
             .filter(|(_, assertion)| !assertion.pure_members.is_empty())
             .map(|(chunk, assertion)| (chunk.clone(), assertion.pure_members.clone()))
             .collect();
+    let asserted_fluent: BTreeMap<String, BTreeSet<String>> = chunk_export_purity
+        .iter()
+        .filter(|(_, assertion)| !assertion.fluent_exports.is_empty())
+        .map(|(chunk, assertion)| (chunk.clone(), assertion.fluent_exports.clone()))
+        .collect();
     CrossModulePurities {
         bindings: resolve_imported_purities(&modules, &asserted_pure),
         members: resolve_asserted_member_purities(&modules, &asserted_members),
+        fluent: resolve_asserted_fluent_bindings(&modules, &asserted_fluent),
     }
 }

--- a/devinfra/js/debundle/lowering/materialize/mod.rs
+++ b/devinfra/js/debundle/lowering/materialize/mod.rs
@@ -201,6 +201,11 @@ pub(super) fn materialize_logical_chunk(
                     .extend(members.iter().cloned());
             }
         }
+        // Definition-side `fluent_exports` assertions projected onto this
+        // chunk's local import bindings (deep-purity chain roots).
+        if let Some(fluent) = cross_module_purities.fluent.get(chunk_id) {
+            hints.fluent_bindings.extend(fluent.iter().cloned());
+        }
         hints
     });
     let line_index = time_phase!(timings, "build_source_line_index", {

--- a/devinfra/js/debundle/purity/classifier_tests.rs
+++ b/devinfra/js/debundle/purity/classifier_tests.rs
@@ -118,6 +118,31 @@ fn classify_with_declared_pure_members(
         &BTreeSet::new(),
         &declared_pure_members,
         &BTreeMap::new(),
+        &BTreeSet::new(),
+    );
+    let var = match module.body.last().expect("non-empty body") {
+        ModuleItem::Stmt(Stmt::Decl(Decl::Var(var))) => var,
+        other => panic!("expected last stmt to be `const _ = …;`, got {other:?}"),
+    };
+    let init = var.decls[0].init.as_deref().expect("init expected");
+    classify_expr_purity(init, &shadowed, &BTreeSet::new(), &BTreeSet::new(), &graph)
+}
+
+/// Classify `expr_src` (appearing after `prefix` at chunk top) with
+/// `fluent` as the author-asserted fluent root bindings.
+fn classify_with_fluent_bindings(prefix: &str, expr_src: &str, fluent: &[&str]) -> Purity {
+    let module = parse(&format!("{prefix}\nconst _ = {expr_src};"));
+    let body = top_level_item_views(&module.body);
+    let shadowed = compute_shadowed_globals(&body);
+    let fluent_bindings: BTreeSet<String> = fluent.iter().map(|s| (*s).to_string()).collect();
+    let graph = ChunkCodeGraph::build_full(
+        &body,
+        &shadowed,
+        &BTreeSet::new(),
+        &BTreeSet::new(),
+        &BTreeMap::new(),
+        &BTreeMap::new(),
+        &fluent_bindings,
     );
     let var = match module.body.last().expect("non-empty body") {
         ModuleItem::Stmt(Stmt::Decl(Decl::Var(var))) => var,
@@ -861,6 +886,160 @@ fn declared_pure_member_optional_chain_call_classifies_pure() {
     );
 }
 
+// --- Fluent-trusted chains (`fluent_exports`) ---------------------------
+
+#[test]
+fn fluent_root_direct_call_classifies_pure() {
+    // The root itself is callable under the deep-purity contract
+    // (`k({...})` — zod-style builders are invoked directly too).
+    assert!(
+        classify_with_fluent_bindings(
+            r#"import { e4 as k } from "vendor";"#,
+            "k({ a: 1 })",
+            &["k"]
+        )
+        .is_pure()
+    );
+    // Without the assertion the same call is an unknown imported
+    // callee.
+    assert!(
+        !classify_with_fluent_bindings(r#"import { e4 as k } from "vendor";"#, "k({ a: 1 })", &[])
+            .is_pure()
+    );
+}
+
+#[test]
+fn fluent_chain_method_calls_classify_pure() {
+    // The receivers of `.optional()` / `.describe()` are call
+    // RESULTS, not bindings — no binding-keyed arm
+    // (`pure_members`, `imported_purities`) can ever admit them.
+    // The fluent contract follows the chain through arbitrary
+    // depth.
+    assert!(
+        classify_with_fluent_bindings(
+            r#"import { e4 as k } from "vendor";"#,
+            r#"k.object({ a: 1 }).optional().describe("docs")"#,
+            &["k"]
+        )
+        .is_pure()
+    );
+}
+
+#[test]
+fn fluent_chain_impure_inner_argument_surfaces() {
+    // Soundness pin: the assertion covers the API's own functions
+    // and their results, NOT caller-supplied argument evaluation.
+    // An impure argument to an INNER chain link must keep the whole
+    // expression impure even though the outer call's args are pure.
+    assert!(
+        !classify_with_fluent_bindings(
+            r#"import { e4 as k } from "vendor"; function io() { globalThis.x = 1; return {}; }"#,
+            r#"k.object(io()).describe("docs")"#,
+            &["k"]
+        )
+        .is_pure()
+    );
+}
+
+#[test]
+fn fluent_chain_member_read_classifies_pure() {
+    // Reading a property off a derived value (`.description` on a
+    // schema) is covered by the same deep contract.
+    assert!(
+        classify_with_fluent_bindings(
+            r#"import { e4 as k } from "vendor";"#,
+            r#"k.string().description"#,
+            &["k"]
+        )
+        .is_pure()
+    );
+}
+
+#[test]
+fn fluent_chain_computed_member_breaks_the_chain() {
+    // Computed access would additionally require a
+    // ToPropertyKey-safe key; the chain conservatively stops there.
+    assert!(
+        !classify_with_fluent_bindings(
+            r#"import { e4 as k } from "vendor"; const key = "object";"#,
+            r#"k[key]({ a: 1 })"#,
+            &["k"]
+        )
+        .is_pure()
+    );
+}
+
+#[test]
+fn fluent_chain_optional_chaining_classifies_pure() {
+    // `?.` only adds a null/undefined short-circuit on top of the
+    // member/call evaluation the contract already covers.
+    assert!(
+        classify_with_fluent_bindings(
+            r#"import { e4 as k } from "vendor";"#,
+            r#"k.object({ a: 1 })?.describe?.("docs")"#,
+            &["k"]
+        )
+        .is_pure()
+    );
+}
+
+#[test]
+fn fluent_root_body_local_shadow_defeats_trust() {
+    // A body-local binding of the same name is a different value
+    // than the annotated import — the trust contract doesn't cover
+    // it (same rule as every other author-trust arm).
+    let module = parse(r#"import { e4 as k } from "vendor";"#);
+    let body = top_level_item_views(&module.body);
+    let shadowed = compute_shadowed_globals(&body);
+    let graph = ChunkCodeGraph::build_full(
+        &body,
+        &shadowed,
+        &BTreeSet::new(),
+        &BTreeSet::new(),
+        &BTreeMap::new(),
+        &BTreeMap::new(),
+        &BTreeSet::from(["k".to_string()]),
+    );
+    let shadowing_call = parse(r#"const _ = k.object({ a: 1 });"#);
+    let ModuleItem::Stmt(Stmt::Decl(Decl::Var(var))) = &shadowing_call.body[0] else {
+        panic!("expected var decl");
+    };
+    let init = var.decls[0].init.as_deref().expect("init expected");
+    let local_shadowed = BTreeSet::from(["k".to_string()]);
+    assert!(
+        !classify_expr_purity(init, &shadowed, &local_shadowed, &BTreeSet::new(), &graph).is_pure()
+    );
+}
+
+#[test]
+fn fluent_trust_propagates_through_const_derivations() {
+    // `const S = k.object({...})` makes `S` a fluent root too —
+    // `S.extend({...})` downstream is the standard zod base-schema
+    // reuse pattern.
+    assert!(
+        classify_with_fluent_bindings(
+            r#"import { e4 as k } from "vendor"; const S = k.object({ a: 1 });"#,
+            r#"S.extend({ b: 2 })"#,
+            &["k"]
+        )
+        .is_pure()
+    );
+}
+
+#[test]
+fn fluent_trust_does_not_propagate_through_let_rebindable_cells() {
+    // A `let` cell can be rebound to an untrusted value later, so
+    // derivation-closure is `const`-only.
+    assert!(
+        !classify_with_fluent_bindings(
+            r#"import { e4 as k } from "vendor"; let S = k.object({ a: 1 });"#,
+            r#"S.extend({ b: 2 })"#,
+            &["k"]
+        )
+        .is_pure()
+    );
+}
+
 // --- Object.{entries,keys,values,freeze,fromEntries} on plain data -----
 
 #[test]
@@ -1083,6 +1262,7 @@ fn classify_with_imported_purities(
         &BTreeSet::new(),
         &BTreeMap::new(),
         &imported_purities,
+        &BTreeSet::new(),
     );
     let var = match module.body.last().expect("non-empty body") {
         ModuleItem::Stmt(Stmt::Decl(Decl::Var(var))) => var,

--- a/devinfra/js/debundle/purity/graph_purity_tests.rs
+++ b/devinfra/js/debundle/purity/graph_purity_tests.rs
@@ -1301,6 +1301,7 @@ fn body_shadowed_pure_member_binding_is_not_pure() {
         &BTreeSet::new(),
         &declared_pure_members,
         &BTreeMap::new(),
+        &BTreeSet::new(),
     );
     assert_eq!(graph.function_purity("f").map(|p| p.is_pure()), Some(false));
     assert_eq!(graph.function_purity("g").map(|p| p.is_pure()), Some(true));

--- a/devinfra/js/debundle/purity/mod.rs
+++ b/devinfra/js/debundle/purity/mod.rs
@@ -56,6 +56,22 @@ pub struct ChunkCodeGraph {
     /// no entry stays `unknown_call` as before. A body-local binding
     /// that shadows the import is not resolved through this map.
     imported_purities: BTreeMap<String, Purity>,
+    /// Bindings the author asserts are *fluent-trusted* roots
+    /// (`chunk_export_purity.<chunk>.fluent_exports`, projected onto
+    /// this chunk's local import bindings): every value reachable from
+    /// the root through static member reads and calls is itself
+    /// trusted — member reads on it are pure, calls of it are pure
+    /// (arguments still classified normally), and the result carries
+    /// the same trust. This is what admits builder/fluent APIs whose
+    /// chain receivers are call *results*, not bindings — e.g. zod's
+    /// `k.object({...}).optional().describe(...)` — which no
+    /// binding-keyed surface (`declared_pure_members`,
+    /// `imported_purities`) can ever reach. Seeded from
+    /// `AnalysisHints::fluent_bindings` and closed over chunk-top
+    /// `const X = <fluent chain>` declarations
+    /// (`collect_fluent_const_bindings`). Author-trust contract: see
+    /// docs/design.md A9.
+    fluent_bindings: BTreeSet<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -117,6 +133,7 @@ impl ChunkCodeGraph {
             declared_pure_new,
             &BTreeMap::new(),
             &BTreeMap::new(),
+            &BTreeSet::new(),
         )
     }
 
@@ -127,6 +144,7 @@ impl ChunkCodeGraph {
         declared_pure_new: &BTreeSet<String>,
         declared_pure_members: &BTreeMap<String, BTreeSet<String>>,
         imported_purities: &BTreeMap<String, Purity>,
+        fluent_bindings: &BTreeSet<String>,
     ) -> Self {
         let functions = collect_chunk_functions(body);
         let name_to_idx: BTreeMap<&str, usize> = functions
@@ -181,6 +199,7 @@ impl ChunkCodeGraph {
             declared_pure_members: declared_pure_members.clone(),
             primitive_const_bindings: collect_primitive_const_bindings(body),
             imported_purities: imported_purities.clone(),
+            fluent_bindings: collect_fluent_const_bindings(body, fluent_bindings),
         };
         // tarjan_scc emits SCCs in reverse topological order: leaves
         // (sinks — functions that don't call any chunk-top
@@ -275,6 +294,13 @@ impl ChunkCodeGraph {
         self.declared_pure_members
             .get(recv)
             .is_some_and(|props| props.contains(prop))
+    }
+
+    /// Whether `name` is a fluent-trusted root (author-asserted via
+    /// `fluent_exports`, or a chunk-top `const` derived from one — see
+    /// `collect_fluent_const_bindings`).
+    pub(crate) fn is_fluent_binding(&self, name: &str) -> bool {
+        self.fluent_bindings.contains(name)
     }
 }
 
@@ -770,6 +796,81 @@ fn collect_primitive_const_bindings(body: &[TopLevelItemView<'_>]) -> BTreeSet<S
         }
     }
     primitives
+}
+
+/// Close the author-asserted fluent roots (`seed`, the projected
+/// `fluent_exports` locals) over chunk-top `const X = <fluent chain>`
+/// declarations: `const Base = k.object({...})` makes `Base` a fluent
+/// root too, so `Base.extend({...})` downstream is admitted. `const`
+/// only — a `let`/`var` cell can be rebound to an untrusted value.
+///
+/// Only the *value class* is derived here (the value came out of the
+/// trusted API, so the author's deep-purity assertion covers it); the
+/// init's own evaluation effects — impure arguments anywhere in the
+/// chain — are classified separately at the declaration site by
+/// `classify_fluent_chain`. This mirrors the
+/// `primitive_const_bindings` value-class/evaluation split.
+///
+/// Fixpoint loop rather than a single forward pass so a chain rooted
+/// in a later-declared const (legal for lazily-evaluated references,
+/// and cheap to cover) still closes; bounded by one insertion per
+/// chunk-top const.
+fn collect_fluent_const_bindings(
+    body: &[TopLevelItemView<'_>],
+    seed: &BTreeSet<String>,
+) -> BTreeSet<String> {
+    let mut fluent = seed.clone();
+    if fluent.is_empty() {
+        return fluent;
+    }
+    loop {
+        let mut changed = false;
+        for item in body {
+            for (name, init, kind) in plain_data_var_candidates(item.as_module_item()) {
+                if kind == VarDeclKind::Const
+                    && !fluent.contains(&name)
+                    && fluent_chain_root(init).is_some_and(|root| fluent.contains(root))
+                {
+                    fluent.insert(name);
+                    changed = true;
+                }
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+    fluent
+}
+
+/// The root identifier of a fluent chain — a chain of static
+/// (non-computed) member reads, calls, and optional-chaining forms of
+/// those, hanging off a bare `Ident`. Returns `None` for any other
+/// shape: computed members are excluded because admitting the lookup
+/// would additionally require the key expression to be
+/// ToPropertyKey-safe, and `new` is excluded because construction off
+/// a fluent API is not part of the asserted contract (builder APIs
+/// chain calls, not constructors).
+fn fluent_chain_root(expr: &Expr) -> Option<&str> {
+    match strip_parens(expr) {
+        Expr::Ident(ident) => Some(ident.sym.as_ref()),
+        Expr::Member(member) => match &member.prop {
+            MemberProp::Ident(_) | MemberProp::PrivateName(_) => fluent_chain_root(&member.obj),
+            MemberProp::Computed(_) => None,
+        },
+        Expr::Call(call) => match &call.callee {
+            Callee::Expr(callee) => fluent_chain_root(callee),
+            _ => None,
+        },
+        Expr::OptChain(opt) => match &*opt.base {
+            OptChainBase::Member(member) => match &member.prop {
+                MemberProp::Ident(_) | MemberProp::PrivateName(_) => fluent_chain_root(&member.obj),
+                MemberProp::Computed(_) => None,
+            },
+            OptChainBase::Call(opt_call) => fluent_chain_root(&opt_call.callee),
+        },
+        _ => None,
+    }
 }
 
 /// Yield `(name, init)` pairs for every chunk-top single-declarator
@@ -2565,6 +2666,20 @@ fn classify_member_purity(
             }
         };
     }
+    // Member read on a fluent chain (`k.string().description`,
+    // including the bare-root `k.object` read inside a larger chain
+    // when classified standalone): the author's `fluent_exports`
+    // assertion covers member reads on the root and on every derived
+    // value. Static (non-computed) properties only — a computed read
+    // would additionally need a ToPropertyKey-safe key, so it falls
+    // through to the conservative verdict. The chain verdict carries
+    // any inner call-argument impurity.
+    if let MemberProp::Ident(_) | MemberProp::PrivateName(_) = &member.prop
+        && let Some(chain) =
+            classify_fluent_chain(&member.obj, shadowed, local_shadowed, declared_pure, graph)
+    {
+        return chain;
+    }
     let detail = match (member.obj.as_ref(), &member.prop) {
         (Expr::Ident(o), MemberProp::Ident(p)) => Some(format!("{}.{}", o.sym, p.sym)),
         _ => None,
@@ -2602,6 +2717,93 @@ fn classify_call_purity(
         declared_pure,
         graph,
     )
+}
+
+/// Classify `expr` as a fluent chain: `Some(purity)` when the
+/// expression is a chain of static member reads / calls rooted in a
+/// fluent-trusted binding (`ChunkCodeGraph::fluent_bindings`), `None`
+/// when it isn't a fluent chain at all (caller falls through to the
+/// regular arms).
+///
+/// The returned purity is the combined verdict of **every call
+/// argument throughout the chain** — the author's assertion covers
+/// the API's own functions and their results, not the evaluation of
+/// caller-supplied arguments, so
+/// `k.object(sideEffect()).describe("x")` must surface
+/// `sideEffect()`'s impurity even though the chain shape is trusted.
+/// Trust propagation mirrors `fluent_chain_root` exactly: static
+/// members and calls only — a computed member or `new` breaks the
+/// chain (falls back to the conservative classifier).
+///
+/// A body-local binding shadowing the root makes the called value a
+/// different value than the one the author annotated, so the chain is
+/// not trusted then (same rule as every other author-trust arm).
+fn classify_fluent_chain(
+    expr: &Expr,
+    shadowed: &BTreeSet<&'static str>,
+    local_shadowed: &BTreeSet<String>,
+    declared_pure: &BTreeSet<String>,
+    graph: &ChunkCodeGraph,
+) -> Option<Purity> {
+    match strip_parens(expr) {
+        Expr::Ident(ident)
+            if graph.is_fluent_binding(ident.sym.as_ref())
+                && !local_shadowed.contains(ident.sym.as_ref()) =>
+        {
+            Some(Purity::Pure)
+        }
+        Expr::Member(member) => match &member.prop {
+            MemberProp::Ident(_) | MemberProp::PrivateName(_) => {
+                classify_fluent_chain(&member.obj, shadowed, local_shadowed, declared_pure, graph)
+            }
+            MemberProp::Computed(_) => None,
+        },
+        Expr::Call(call) => {
+            let Callee::Expr(callee) = &call.callee else {
+                return None;
+            };
+            classify_fluent_chain(callee, shadowed, local_shadowed, declared_pure, graph).map(
+                |chain| {
+                    chain.worst(all_args_pure(
+                        &call.args,
+                        shadowed,
+                        local_shadowed,
+                        declared_pure,
+                        graph,
+                    ))
+                },
+            )
+        }
+        Expr::OptChain(opt) => match &*opt.base {
+            OptChainBase::Member(member) => match &member.prop {
+                MemberProp::Ident(_) | MemberProp::PrivateName(_) => classify_fluent_chain(
+                    &member.obj,
+                    shadowed,
+                    local_shadowed,
+                    declared_pure,
+                    graph,
+                ),
+                MemberProp::Computed(_) => None,
+            },
+            OptChainBase::Call(opt_call) => classify_fluent_chain(
+                &opt_call.callee,
+                shadowed,
+                local_shadowed,
+                declared_pure,
+                graph,
+            )
+            .map(|chain| {
+                chain.worst(all_args_pure(
+                    &opt_call.args,
+                    shadowed,
+                    local_shadowed,
+                    declared_pure,
+                    graph,
+                ))
+            }),
+        },
+        _ => None,
+    }
 }
 
 /// Common backbone for `Expr::Call` and `OptChainBase::Call` —
@@ -2657,6 +2859,24 @@ fn classify_callee_call(
         && graph.is_declared_pure_member(recv, prop)
     {
         return all_args_pure(args, shadowed, local_shadowed, declared_pure, graph);
+    }
+    // Fluent chain rooted in an author-asserted `fluent_exports`
+    // binding: the callee may be arbitrarily deep
+    // (`k.object({...}).optional().describe`), where every
+    // intermediate receiver is a call *result* — unreachable by any
+    // binding-keyed arm above. `classify_fluent_chain` validated and
+    // carried every inner call's argument purity; this call's own
+    // args are still classified normally.
+    if let Some(chain) =
+        classify_fluent_chain(callee_expr, shadowed, local_shadowed, declared_pure, graph)
+    {
+        return chain.worst(all_args_pure(
+            args,
+            shadowed,
+            local_shadowed,
+            declared_pure,
+            graph,
+        ));
     }
     // Chunk-local function declaration: consult the per-chunk
     // function-body purity cache. `Pure` callee + Pure args → Pure;

--- a/devinfra/js/debundle/spec.rs
+++ b/devinfra/js/debundle/spec.rs
@@ -128,6 +128,24 @@ pub struct ChunkExportPurity {
     /// member's `purity: pure` companion `declared_pure_members`.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub pure_members: BTreeMap<String, BTreeSet<String>>,
+    /// Export names the author asserts are **deeply** pure fluent-API
+    /// roots: member reads and calls on the export, *and on every value
+    /// transitively derived from it* through static member reads and
+    /// calls, have no observable side effects (call arguments are still
+    /// classified normally). This is the only surface that reaches
+    /// builder-style chains whose receivers are call results rather
+    /// than bindings — `z.object({...}).optional().describe(...)` —
+    /// which `pure_exports`/`pure_members` (binding-keyed) cannot.
+    ///
+    /// The assertion covers the API's **entire** transitive fluent
+    /// surface, including methods like a schema's `.parse(...)` that
+    /// run author-registered callbacks — assert only exports whose
+    /// derived-value methods are all side-effect-free when invoked at
+    /// module top level, and whose values the program does not
+    /// monkey-patch. Same author-trust contract as `pure_exports`
+    /// (docs/design.md A9).
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub fluent_exports: BTreeSet<String>,
 }
 
 /// Per-chunk owner-graph build options. Each field defaults to the


### PR DESCRIPTION
P1 of the residual-impurity series for the Tana main chunk (follow-up to #2103/#2105; the [gaffer measurement](https://github.com/agentydragon/gaffer-private/pull/285) profiled the 1281-owner unit).

## Why

Of the residual unit's impurity reasons, the single largest pattern is **zod schema declarations**: `k(...)` ×375, `.describe(...)` ×375, `.optional(...)` ×270, `.nullable(...)` ×31 — fluent chains like `k.object({...}).optional().describe(...)`. The receivers of link 2+ are **call results**, not bindings, so every existing trust surface (`pure_exports`, `pure_members`, `imported_purities`, `declared_pure_members` — all binding-keyed) is structurally unable to reach them.

## What

`chunk_export_purity.<chunk>.fluent_exports` — a definition-side assertion that an export is a **deep-purity root**: static member reads and calls on it, *and on every value transitively derived from it* through such reads/calls, are pure.

```yaml
chunk_export_purity:
  static/vendor-BPNhzNbc:
    fluent_exports: [e4]   # the zod root; Tana imports it as `k`
```

- **Soundness boundary (pinned by test):** call arguments are still classified normally at *every* chain link — `k.object(sideEffect()).describe("x")` stays impure. The assertion covers the API's functions and their results, never caller-supplied argument evaluation.
- Projection onto importer locals mirrors `pure_members` (pure axiom projection, no fixpoint; dangling assertions warn to stderr and are ignored).
- The per-chunk classifier closes the trust over chunk-top `const X = <fluent chain>` derivations (`const Base = k.object(...)`, later `Base.extend(...)`) — `const` only, since a `let`/`var` cell can be rebound to an untrusted value (also pinned).
- Computed members and `new` break the chain conservatively; body-local shadowing defeats the trust (same rule as every author-trust arm); `?.` forms are admitted.
- The contract is intentionally broad (covers e.g. a derived schema's `.parse`) — the spec.rs field doc and design.md A9 state the audit obligation: assert only exports whose transitive fluent surface is side-effect-free at module top level and whose values aren't monkey-patched.

## Tests

- Oracle: fluent assertion projects onto the importer's local binding name; dangling assertion doesn't project.
- Classifier ×9: direct root call, deep chain, **inner-impure-arg soundness pin**, member read on a derived value, computed-member chain break, optional chaining, body-local shadow defeat, `const`-derivation closure, `let`-cell non-closure.
- e2e pair: zod-style schema decls interleaved across two logical modules **reject** without the assertion (S-cycle) and **realize** with it.
- Full `//devinfra/js/debundle/...`: 100/100; lint-enabled build (clippy + rustfmt aspects) clean.

https://claude.ai/code/session_01Bp8cANKC1Ktc92T7SM1kcx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bp8cANKC1Ktc92T7SM1kcx)_