### PR TITLE
debundle: CLI scripting surface — structured rejections, --format parity, dry-run reports

### DIFF
--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -724,6 +724,7 @@ rust_library(
         "cli/gate.rs",
         "cli/mod.rs",
         "cli/module.rs",
+        "cli/outcome.rs",
         "cli/yaml_edit.rs",
     ],
     crate_name = "debundle_cli",

--- a/devinfra/js/debundle/README.md
+++ b/devinfra/js/debundle/README.md
@@ -32,12 +32,16 @@ Mutating commands validate by default: `bindings assign`, `bindings
 unassign`, `modules merge`, and `modules delete` (of non-empty
 modules, with `--force`) run the realizability gate; `bindings
 rename` runs name-collision detection. `--dry-run` previews,
-`--no-verify` skips. Read-only commands accept `--format
-text|json|ndjson` (default `text` on tty, `json` on pipe).
+`--no-verify` skips. Read-only and mutating commands accept
+`--format text|json|ndjson` (default `text` on tty, `json` on pipe);
+the five mutating verbs share one JSON outcome schema, and gate
+rejections print a structured rejection object on stdout (see
+`docs/cli.md`).
 
 Common arg paths accept env-var defaults (`DEBUNDLE_GRAPH`,
-`DEBUNDLE_MODULES`, `DEBUNDLE_SOURCE_ROOT`, `DEBUNDLE_OUT`). Set them
-once per session.
+`DEBUNDLE_MODULES`, `DEBUNDLE_SOURCE_ROOT`, `DEBUNDLE_OUT`;
+`run --tree-source-root` reads the separate
+`DEBUNDLE_TREE_SOURCE_ROOT`). Set them once per session.
 
 ## Getting started
 

--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -256,43 +256,6 @@ Ideas it unlocked, still open:
   between seal and execute" contract is convention-held; making
   non-execute passes take `&Module` would let the compiler enforce it.
 
-## CLI scripting surface
-
-Work items on the machine-consumable CLI contract (distinct from the
-dogfood findings in <CLI_DOGFOOD.md>):
-
-- **Structured rejection diagnostics for edit-gate failures.**
-  `bindings {assign,unassign}` and `modules {merge,delete}` render
-  gate rejections as a prose blame report on stderr
-  (`cli/edit_gate.rs`) and bail; even with `--format json` there is
-  no machine-readable rejection payload on stdout, so agents scrape
-  stderr. Emit the blame report as JSON on stdout when a JSON format
-  is selected.
-- **`--format` parity for the five mutating verbs.**
-  `bindings {assign,unassign,rename}` take `--format`;
-  `modules {merge,delete}` print only a fixed summary line
-  (`cli/module.rs`). Define one outcome schema shared by all five.
-- **Edit-gate rejections leave no `cycles.json`.** The pipeline
-  writes `cycles.json` on gate rejection, but edit-gate rejections
-  (including `--dry-run` probes) write nothing, so
-  `debundle gate list`/`gate describe` cannot be pointed at the
-  failure that was just reported.
-- **`DEBUNDLE_SOURCE_ROOT` double meaning.** The same env var feeds
-  `run --tree-source-root` (spec-tree compile root, `pipeline.rs`)
-  and the query commands' `--source-root` (upstream snapshot root
-  for source-backed selectors). The two roots are different
-  directories in real corpora; one of the flags should get its own
-  env var.
-- **`resolve_id_as_module_path` swallows I/O errors.** The
-  `cli/mod.rs` helper applies `.ok()?` to the modules-tree walk, so
-  a failing `collect_module_files` silently degrades a module-path
-  id into a binding-name guess. Surface the error.
-- **`selection_with_*` sentinel hack.** `selection_with_proposal`
-  (`cli/mod.rs`) stuffs a sentinel empty-string `binding_id` that
-  `run_describe` must remember to clear. Make `SelectionArgs`
-  selection an enum (one variant per id kind) so the sentinel
-  disappears.
-
 ## CLI usability
 
 CLI usability and scripting-safety findings live in <CLI_DOGFOOD.md>.

--- a/devinfra/js/debundle/cli/binding.rs
+++ b/devinfra/js/debundle/cli/binding.rs
@@ -25,6 +25,7 @@ use spec::ModulePath;
 use spec_modules::{collect_module_files, is_residual_module_path, module_path_from_file};
 
 use crate::edit_gate::{Gate, post_edit_spec_from_docs};
+use crate::outcome::{GateOutcome, MutationOutcome};
 use crate::yaml_edit::{read_yaml, write_yaml_if_semantic_changed, yaml_semantically_changed};
 
 /// A chunk-top binding's public identity: the minified hygiene name
@@ -243,16 +244,17 @@ pub fn run_bindings_list(
 // `bindings rename`
 // ---------------------------------------------------------------------
 
-/// Outcome of a rename. Currently just confirms which file and index
-/// were touched; downstream callers may want to use the file path to
-/// produce a diff in a future iteration.
-#[derive(Debug, Clone)]
+/// Outcome of a rename. Shares the [`MutationOutcome`] core with the
+/// other four mutating verbs; the touched file (when any) is
+/// `outcome.files_written`.
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct RenameOutcome {
-    pub file: PathBuf,
-    pub binding_name: String,
+    #[serde(flatten)]
+    pub outcome: MutationOutcome,
+    /// Minified binding name of the renamed member.
+    pub binding: String,
     pub old_readable: Option<String>,
     pub new_readable: String,
-    pub action: &'static str,
 }
 
 /// Rename a single binding's readable `name:` without moving it.
@@ -292,17 +294,30 @@ pub fn rename_binding(
     } else if dry_run {
         "dry-run"
     } else {
-        "renamed"
+        "applied"
     };
     if changed && !dry_run {
         write_yaml_if_semantic_changed(&hit.file, &doc)?;
     }
     Ok(RenameOutcome {
-        file: hit.file,
-        binding_name: hit.name.minified().to_string(),
+        outcome: MutationOutcome {
+            verb: "rename",
+            action,
+            gate: if no_verify {
+                GateOutcome::Skipped
+            } else {
+                GateOutcome::NamesOnly
+            },
+            files_written: if changed {
+                vec![hit.file.display().to_string()]
+            } else {
+                Vec::new()
+            },
+            files_deleted: Vec::new(),
+        },
+        binding: hit.name.minified().to_string(),
         old_readable,
         new_readable: new.to_string(),
-        action,
     })
 }
 
@@ -383,10 +398,9 @@ struct BatchProposal {
 
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct AssignOutcome {
+    #[serde(flatten)]
+    pub outcome: MutationOutcome,
     pub moves_applied: usize,
-    pub files_written: Vec<String>,
-    pub files_deleted: Vec<String>,
-    pub action: &'static str,
 }
 
 /// Parse a positional `<sym>:<module>[:<readable>]` triple.
@@ -596,10 +610,14 @@ pub fn run_bindings_assign(
     let plan: Vec<PlannedMove> = by_identity.into_values().collect();
     if plan.is_empty() {
         return Ok(AssignOutcome {
+            outcome: MutationOutcome {
+                verb: "assign",
+                action: "noop",
+                gate: GateOutcome::NotRequired,
+                files_written: Vec::new(),
+                files_deleted: Vec::new(),
+            },
             moves_applied: 0,
-            files_written: Vec::new(),
-            files_deleted: Vec::new(),
-            action: "noop",
         });
     }
 
@@ -704,10 +722,14 @@ pub fn run_bindings_assign(
 
     let (files_written, files_deleted) = apply_doc_changes(&docs, &to_delete, dry_run)?;
     Ok(AssignOutcome {
+        outcome: MutationOutcome {
+            verb: "assign",
+            action: if dry_run { "dry-run" } else { "applied" },
+            gate: gate.outcome(),
+            files_written,
+            files_deleted,
+        },
         moves_applied: plan.len(),
-        files_written,
-        files_deleted,
-        action: if dry_run { "dry-run" } else { "applied" },
     })
 }
 
@@ -883,15 +905,13 @@ fn members_seq(doc: &Value) -> Option<&Vec<Value>> {
 // `bindings unassign`
 // ---------------------------------------------------------------------
 
-/// Outcome of an unassign batch. Mirrors [`AssignOutcome`] so the CLI
-/// printer can share a renderer if desired; the field set is
-/// deliberately the same shape.
+/// Outcome of an unassign batch. Mirrors [`AssignOutcome`]: the
+/// shared [`MutationOutcome`] core plus the verb-specific count.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct UnassignOutcome {
+    #[serde(flatten)]
+    pub outcome: MutationOutcome,
     pub unassigned: usize,
-    pub files_written: Vec<String>,
-    pub files_deleted: Vec<String>,
-    pub action: &'static str,
 }
 
 /// Remove one or more bindings from their current modules atomically.
@@ -935,10 +955,14 @@ pub fn run_bindings_unassign(
     }
     if plan.is_empty() {
         return Ok(UnassignOutcome {
+            outcome: MutationOutcome {
+                verb: "unassign",
+                action: "noop",
+                gate: GateOutcome::NotRequired,
+                files_written: Vec::new(),
+                files_deleted: Vec::new(),
+            },
             unassigned: 0,
-            files_written: Vec::new(),
-            files_deleted: Vec::new(),
-            action: "noop",
         });
     }
 
@@ -973,10 +997,14 @@ pub fn run_bindings_unassign(
 
     let (files_written, files_deleted) = apply_doc_changes(&docs, &to_delete, dry_run)?;
     Ok(UnassignOutcome {
+        outcome: MutationOutcome {
+            verb: "unassign",
+            action: if dry_run { "dry-run" } else { "applied" },
+            gate: gate.outcome(),
+            files_written,
+            files_deleted,
+        },
         unassigned: plan.len(),
-        files_written,
-        files_deleted,
-        action: if dry_run { "dry-run" } else { "applied" },
     })
 }
 
@@ -1198,7 +1226,7 @@ mod tests {
 
         let out = rename_binding(root, "XOe", "PluginSettings", false, false).unwrap();
 
-        assert_eq!(out.action, "unchanged");
+        assert_eq!(out.outcome.action, "unchanged");
         assert_eq!(read(root, "m.yaml"), original);
     }
 
@@ -1331,7 +1359,7 @@ mod tests {
             readable: None,
         }];
         let out = run_bindings_assign(root, moves, true, Gate::NamesOnly).unwrap();
-        assert_eq!(out.action, "dry-run");
+        assert_eq!(out.outcome.action, "dry-run");
         assert!(root.join("src.yaml").exists(), "src not deleted");
         let original = read(root, "src.yaml");
         assert!(original.contains("XOe"), "src unchanged");

--- a/devinfra/js/debundle/cli/edit_gate.rs
+++ b/devinfra/js/debundle/cli/edit_gate.rs
@@ -21,26 +21,44 @@
 //! `post_delete_spec`, `post_assign_spec`) and then calls
 //! `gate_post_edit_partition` which is the single entry point
 //! responsible for verdict + diagnostic rendering. The function bails
-//! with an `anyhow::Error` carrying the same `render_cycle_summary` /
-//! `render_atomic_unit_conflict_summary` text the materializer emits
-//! when its own gate rejects, so authors see one consistent
-//! diagnostic regardless of whether the rejection came from `debundle
-//! run` or a CLI edit verb.
+//! with a [`GateRejection`] error carrying the same
+//! `render_cycle_summary` / `render_atomic_unit_conflict_summary`
+//! text the materializer emits when its own gate rejects, so authors
+//! see one consistent diagnostic regardless of whether the rejection
+//! came from `debundle run` or a CLI edit verb. The error also
+//! carries a machine-readable [`GateRejectionReport`] payload (the
+//! same `BlockingSccEntry` / `AtomicUnitConflictReport` projections
+//! the pipeline writes to disk), which the CLI dispatchers serialize
+//! to stdout when a JSON format is selected.
+//!
+//! On rejection the gate also writes the same on-disk artifacts the
+//! pipeline writes — `cycles.json` / `atomic_unit_conflicts.json` as
+//! siblings of the supplied `owner_graph.json` (the location
+//! `debundle gate list/describe` reads by default) — so the
+//! documented `gate` follow-up queries work after an edit-gate or
+//! `--dry-run` rejection. Stale artifacts from a previous rejection
+//! are removed when the gate passes (or when the rejection kind
+//! changes), keeping `gate list` consistent with the latest verdict.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::fmt;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use ::gate::{render_atomic_unit_conflict_summary, render_cycle_summary, validate_factorization};
+use ::gate::{
+    BlockingSccEntry, render_atomic_unit_conflict_summary, render_cycle_summary,
+    validate_factorization,
+};
 use analysis::{
-    AtomicUnit, AtomicUnitConflict, ConflictingClaim, ModuleId, OwnerGraph, OwnerGraphReport,
-    OwnerId, Partition, compute_atomic_units,
+    AtomicUnit, AtomicUnitConflict, AtomicUnitConflictReport, ConflictingClaim, ModuleId,
+    OwnerGraph, OwnerGraphReport, OwnerId, Partition, compute_atomic_units,
 };
 use anonymous_resolution::{
     AnonymousStatementClaimSet, MemberSelectorClaimSet, resolve_anonymous_statement_claims,
     resolve_member_selector_claims,
 };
 use anyhow::{Context, Result, bail};
+use serde::Serialize;
 use serde_yaml::Value;
 use spec::{AnonymousStatementSelector, ModulePath};
 use spec_modules::{
@@ -95,6 +113,16 @@ impl<'a> Gate<'a> {
         !matches!(self, Self::Skip)
     }
 
+    /// The [`GateOutcome`] label a successful edit reports for this
+    /// validation mode.
+    pub fn outcome(&self) -> crate::outcome::GateOutcome {
+        match self {
+            Self::Run { .. } => crate::outcome::GateOutcome::Passed,
+            Self::NamesOnly => crate::outcome::GateOutcome::NamesOnly,
+            Self::Skip => crate::outcome::GateOutcome::Skipped,
+        }
+    }
+
     /// Run the realizability + atom-split gate against the post-edit
     /// spec when this is [`Gate::Run`]. `post_spec` is lazy so
     /// skipped gates don't pay for spec assembly.
@@ -110,6 +138,75 @@ impl<'a> Gate<'a> {
             Self::NamesOnly | Self::Skip => Ok(()),
         }
     }
+}
+
+/// Machine-readable projection of a realizability-gate rejection.
+/// Reuses the canonical wire shapes the pipeline writes on rejection
+/// (`cycles.json` → [`BlockingSccEntry`], `atomic_unit_conflicts.json`
+/// → [`AtomicUnitConflictReport`]) — there is no parallel schema.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum GateRejectionReport {
+    /// The post-edit spec splits one or more atomic units across
+    /// destination modules.
+    AtomSplit {
+        conflicts: Vec<AtomicUnitConflictReport>,
+    },
+    /// The post-edit module quotient carries blocking SCCs; each entry
+    /// names the SCC's module paths and the binding-pair cut edges.
+    UnrealizableCycles {
+        blocking_sccs: Vec<BlockingSccEntry>,
+    },
+}
+
+/// Error returned by [`gate_post_edit_partition`] on rejection. The
+/// `Display` text is the terse one-line verdict (the blame report has
+/// already gone to stderr); `report` is the structured payload CLI
+/// dispatchers serialize to stdout under a JSON format.
+#[derive(Debug)]
+pub struct GateRejection {
+    pub report: GateRejectionReport,
+    message: &'static str,
+}
+
+impl fmt::Display for GateRejection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.message)
+    }
+}
+
+impl std::error::Error for GateRejection {}
+
+/// Write a rejection artifact next to `owner_graph_path` — the
+/// default location `debundle gate list/describe/cut` resolves
+/// (`GateCommonArgs::resolved_cycles_path`).
+fn write_rejection_artifact<T: Serialize>(
+    owner_graph_path: &Path,
+    filename: &str,
+    value: &T,
+) -> Result<()> {
+    let path = rejection_artifact_path(owner_graph_path, filename);
+    fs::write(&path, serde_json::to_string_pretty(value)?)
+        .with_context(|| format!("writing {}", path.display()))
+}
+
+/// Remove a stale rejection artifact so `gate list` reflects the
+/// latest gate verdict (a missing `cycles.json` is the documented
+/// clean state). A pass clears both artifacts; each rejection kind
+/// clears the other kind's file.
+fn remove_rejection_artifact(owner_graph_path: &Path, filename: &str) -> Result<()> {
+    let path = rejection_artifact_path(owner_graph_path, filename);
+    if path.exists() {
+        fs::remove_file(&path).with_context(|| format!("removing stale {}", path.display()))?;
+    }
+    Ok(())
+}
+
+fn rejection_artifact_path(owner_graph_path: &Path, filename: &str) -> PathBuf {
+    owner_graph_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(filename)
 }
 
 #[derive(Debug, Clone)]
@@ -397,18 +494,50 @@ pub fn gate_post_edit_partition(
     let atomic_conflicts =
         detect_atomic_unit_conflicts(&atomic_units, &partition, &owner_graph_report);
     if !atomic_conflicts.is_empty() {
+        let conflicts = AtomicUnitConflictReport::from_conflicts(&atomic_conflicts, &module_path);
+        write_rejection_artifact(
+            owner_graph_path,
+            output_layout::ATOMIC_UNIT_CONFLICTS_REPORT,
+            &conflicts,
+        )?;
+        remove_rejection_artifact(owner_graph_path, output_layout::CYCLES_REPORT)?;
         let summary = render_atomic_unit_conflict_summary(&atomic_conflicts, &module_path);
         eprintln!("error: post-edit spec splits one or more atomic units:\n{summary}");
-        bail!("realizability gate rejected the edit (atom-split)");
+        return Err(GateRejection {
+            report: GateRejectionReport::AtomSplit { conflicts },
+            message: "realizability gate rejected the edit (atom-split)",
+        }
+        .into());
     }
 
     // Check 2 — module-quotient cycles.
     let report = validate_factorization(&owner_graph, &partition, &module_path);
     if !report.cycles.is_empty() {
+        let blocking_sccs = BlockingSccEntry::from_cycle_reports(&report.cycles);
+        write_rejection_artifact(
+            owner_graph_path,
+            output_layout::CYCLES_REPORT,
+            &blocking_sccs,
+        )?;
+        remove_rejection_artifact(
+            owner_graph_path,
+            output_layout::ATOMIC_UNIT_CONFLICTS_REPORT,
+        )?;
         let summary = render_cycle_summary(&report.cycles);
         eprintln!("error: post-edit spec is unrealizable:\n{summary}");
-        bail!("realizability gate rejected the edit");
+        return Err(GateRejection {
+            report: GateRejectionReport::UnrealizableCycles { blocking_sccs },
+            message: "realizability gate rejected the edit",
+        }
+        .into());
     }
+    // Pass: clear stale rejection artifacts from a previous rejected
+    // edit/run so `gate list` reports the documented clean state.
+    remove_rejection_artifact(owner_graph_path, output_layout::CYCLES_REPORT)?;
+    remove_rejection_artifact(
+        owner_graph_path,
+        output_layout::ATOMIC_UNIT_CONFLICTS_REPORT,
+    )?;
     Ok(())
 }
 

--- a/devinfra/js/debundle/cli/mod.rs
+++ b/devinfra/js/debundle/cli/mod.rs
@@ -3,6 +3,7 @@ pub mod comment;
 pub mod edit_gate;
 pub mod gate;
 pub mod module;
+pub mod outcome;
 pub mod yaml_edit;
 
 use std::path::PathBuf;
@@ -17,6 +18,7 @@ use crate::comment::{
 use crate::edit_gate::Gate;
 use crate::gate::{GateArgs, run_gate_cli};
 use crate::module::{DeleteArgs, MergeArgs, ModuleArgs, run_delete, run_merge, run_module_cli};
+use crate::outcome::{emit_gate_rejection_json, print_outcome_json};
 use anyhow::{Context, Result};
 use clap::{Args as ClapArgs, Parser, Subcommand};
 use peel::factorize::DEFAULT_SIZE_CAP_LINES;
@@ -621,152 +623,87 @@ fn deprecation_notice(old: &str, new: &str) {
 /// exactly one field. Module paths and logical module ids resolve
 /// through the same owner-graph/spec claim path as other structured
 /// IDs, so binding members and anonymous statements stay in sync.
-pub fn dispatch_id_selection(id: &str, modules_root: &std::path::Path) -> SelectionArgs {
+pub fn dispatch_id_selection(id: &str, modules_root: &std::path::Path) -> Result<SelectionArgs> {
     // Prefix-based dispatch covers the structured ID kinds emitted by
     // the analysis crate.
     if id.starts_with("owner:") {
-        return selection_with_owner(id);
+        return Ok(SelectionArgs {
+            owner_id: Some(id.to_string()),
+            ..SelectionArgs::default()
+        });
     }
     if id.starts_with("logical:") {
-        return selection_with_module(id);
+        return Ok(SelectionArgs {
+            module_id: Some(id.to_string()),
+            ..SelectionArgs::default()
+        });
     }
     if id.starts_with("atomic:") {
-        return selection_with_unit(id);
+        return Ok(SelectionArgs {
+            unit_id: Some(id.to_string()),
+            ..SelectionArgs::default()
+        });
     }
     if id.starts_with("diagnostic:") {
-        return selection_with_diagnostic(id);
+        return Ok(SelectionArgs {
+            diagnostic_id: Some(id.to_string()),
+            ..SelectionArgs::default()
+        });
     }
     // Module-path detection: try resolving `<modules>/<id>.yaml`.
     // Spec authors sometimes have flat module paths (no `/`); the
     // existence check is the only reliable disambiguator vs. binding
     // names that happen to spell a module-like word.
-    if let Some(module_path) = resolve_id_as_module_path(id, modules_root) {
-        return selection_with_module_path(&module_path);
+    if let Some(module_path) = resolve_id_as_module_path(id, modules_root)? {
+        return Ok(SelectionArgs {
+            module_path: Some(module_path),
+            ..SelectionArgs::default()
+        });
     }
     if id.starts_with("auto_partition_") || id.starts_with("extend:") {
-        return selection_with_proposal(id);
+        return Ok(SelectionArgs {
+            proposal_id: Some(id.to_string()),
+            ..SelectionArgs::default()
+        });
     }
     // Fall through: treat as a binding name (minified or readable).
-    selection_with_binding(id)
+    Ok(SelectionArgs {
+        binding_id: Some(id.to_string()),
+        ..SelectionArgs::default()
+    })
 }
 
-fn resolve_id_as_module_path(id: &str, modules_root: &std::path::Path) -> Option<String> {
+fn resolve_id_as_module_path(id: &str, modules_root: &std::path::Path) -> Result<Option<String>> {
     let module_id = id.strip_suffix(".yaml").unwrap_or(id);
     let candidate = modules_root.join(format!("{module_id}.yaml"));
     if candidate.is_file() {
-        return Some(module_id.to_string());
+        return Ok(Some(module_id.to_string()));
     }
     if module_id.contains('/') {
-        return None;
+        return Ok(None);
     }
 
     let filename = format!("{module_id}.yaml");
     let mut matches = collect_module_files(modules_root)
-        .ok()?
+        .with_context(|| format!("walking modules tree {}", modules_root.display()))?
         .into_iter()
         .filter(|path| {
             path.file_name()
                 .is_some_and(|name| name == filename.as_str())
         })
         .map(|path| module_path_from_file(&path, modules_root));
-    let first = matches.next()?;
+    let Some(first) = matches.next() else {
+        return Ok(None);
+    };
     if matches.next().is_some() {
-        return None;
+        return Ok(None);
     }
-    Some(first)
-}
-
-fn selection_with_owner(value: &str) -> SelectionArgs {
-    SelectionArgs {
-        owner_id: Some(value.to_string()),
-        module_path: None,
-        module_id: None,
-        binding_id: None,
-        proposal_id: None,
-        unit_id: None,
-        diagnostic_id: None,
-    }
-}
-
-fn selection_with_module(value: &str) -> SelectionArgs {
-    SelectionArgs {
-        owner_id: None,
-        module_path: None,
-        module_id: Some(value.to_string()),
-        binding_id: None,
-        proposal_id: None,
-        unit_id: None,
-        diagnostic_id: None,
-    }
-}
-
-fn selection_with_module_path(value: &str) -> SelectionArgs {
-    SelectionArgs {
-        owner_id: None,
-        module_path: Some(value.to_string()),
-        module_id: None,
-        binding_id: None,
-        proposal_id: None,
-        unit_id: None,
-        diagnostic_id: None,
-    }
-}
-
-fn selection_with_unit(value: &str) -> SelectionArgs {
-    SelectionArgs {
-        owner_id: None,
-        module_path: None,
-        module_id: None,
-        binding_id: None,
-        proposal_id: None,
-        unit_id: Some(value.to_string()),
-        diagnostic_id: None,
-    }
-}
-
-fn selection_with_diagnostic(value: &str) -> SelectionArgs {
-    SelectionArgs {
-        owner_id: None,
-        module_path: None,
-        module_id: None,
-        binding_id: None,
-        proposal_id: None,
-        unit_id: None,
-        diagnostic_id: Some(value.to_string()),
-    }
-}
-
-fn selection_with_proposal(value: &str) -> SelectionArgs {
-    SelectionArgs {
-        owner_id: None,
-        module_path: None,
-        module_id: None,
-        binding_id: Some(String::new()),
-        proposal_id: Some(value.to_string()),
-        unit_id: None,
-        diagnostic_id: None,
-    }
-}
-
-fn selection_with_binding(value: &str) -> SelectionArgs {
-    SelectionArgs {
-        owner_id: None,
-        module_path: None,
-        module_id: None,
-        binding_id: Some(value.to_string()),
-        proposal_id: None,
-        unit_id: None,
-        diagnostic_id: None,
-    }
+    Ok(Some(first))
 }
 
 fn run_describe(args: DescribeArgs) -> Result<()> {
     let format = OutputFormat::resolve(args.format);
-    let mut selection = dispatch_id_selection(&args.id, &args.common.modules_root);
-    // selection_with_proposal stuffs a sentinel binding_id; clear it.
-    if selection.proposal_id.is_some() {
-        selection.binding_id = None;
-    }
+    let selection = dispatch_id_selection(&args.id, &args.common.modules_root)?;
     let inner = ExplainArgs {
         common: args.common,
         selection,
@@ -782,10 +719,7 @@ fn run_describe(args: DescribeArgs) -> Result<()> {
 
 fn run_show_source(args: ShowSourceArgs) -> Result<()> {
     let format = OutputFormat::resolve(args.format);
-    let mut selection = dispatch_id_selection(&args.id, &args.common.modules_root);
-    if selection.proposal_id.is_some() {
-        selection.binding_id = None;
-    }
+    let selection = dispatch_id_selection(&args.id, &args.common.modules_root)?;
     let inner = SourceSliceArgs {
         common: args.common,
         selection,
@@ -1003,27 +937,22 @@ fn run_bindings_rename_cmd(args: BindingsRenameArgs) -> Result<()> {
         args.dry_run,
         args.no_verify,
     )?;
-    let format = OutputFormat::resolve(args.format);
-    match format {
+    match OutputFormat::resolve(args.format) {
         OutputFormat::Text => {
+            let file = out
+                .outcome
+                .files_written
+                .first()
+                .map(|f| format!(" ({f})"))
+                .unwrap_or_default();
             println!(
-                "{}: {} -> {} ({})",
-                out.action,
-                out.old_readable.as_deref().unwrap_or(&out.binding_name),
+                "{}: {} -> {}{file}",
+                out.outcome.action,
+                out.old_readable.as_deref().unwrap_or(&out.binding),
                 out.new_readable,
-                out.file.display()
             );
         }
-        OutputFormat::Json | OutputFormat::Ndjson => {
-            let payload = serde_json::json!({
-                "action": out.action,
-                "binding": out.binding_name,
-                "old_readable": out.old_readable,
-                "new_readable": out.new_readable,
-                "file": out.file.display().to_string(),
-            });
-            println!("{}", serde_json::to_string_pretty(&payload)?);
-        }
+        format => print_outcome_json(&out, format)?,
     }
     Ok(())
 }
@@ -1052,7 +981,13 @@ fn run_bindings_assign_cmd(args: BindingsAssignArgs) -> Result<()> {
         args.owner_graph_path.as_deref(),
         args.source_root.as_deref(),
     )?;
-    let out = run_bindings_assign(&args.modules_root, moves, args.dry_run, gate)?;
+    let out = match run_bindings_assign(&args.modules_root, moves, args.dry_run, gate) {
+        Ok(out) => out,
+        Err(err) => {
+            emit_gate_rejection_json("assign", args.format, &err);
+            return Err(err);
+        }
+    };
     let format = OutputFormat::resolve(args.format);
     print_assign_outcome(&out, format)
 }
@@ -1063,7 +998,13 @@ fn run_bindings_unassign_cmd(args: BindingsUnassignArgs) -> Result<()> {
         args.owner_graph_path.as_deref(),
         args.source_root.as_deref(),
     )?;
-    let out = run_bindings_unassign(&args.modules_root, args.syms, args.dry_run, gate)?;
+    let out = match run_bindings_unassign(&args.modules_root, args.syms, args.dry_run, gate) {
+        Ok(out) => out,
+        Err(err) => {
+            emit_gate_rejection_json("unassign", args.format, &err);
+            return Err(err);
+        }
+    };
     let format = OutputFormat::resolve(args.format);
     print_unassign_outcome(&out, format)
 }
@@ -1073,17 +1014,15 @@ fn print_unassign_outcome(out: &UnassignOutcome, format: OutputFormat) -> Result
         OutputFormat::Text => {
             println!(
                 "{}: {} unassign(s); {} file(s) written, {} file(s) deleted",
-                out.action,
+                out.outcome.action,
                 out.unassigned,
-                out.files_written.len(),
-                out.files_deleted.len()
+                out.outcome.files_written.len(),
+                out.outcome.files_deleted.len()
             );
+            Ok(())
         }
-        OutputFormat::Json | OutputFormat::Ndjson => {
-            println!("{}", serde_json::to_string_pretty(out)?);
-        }
+        format => print_outcome_json(out, format),
     }
-    Ok(())
 }
 
 fn print_assign_outcome(out: &AssignOutcome, format: OutputFormat) -> Result<()> {
@@ -1091,17 +1030,15 @@ fn print_assign_outcome(out: &AssignOutcome, format: OutputFormat) -> Result<()>
         OutputFormat::Text => {
             println!(
                 "{}: {} move(s); {} file(s) written, {} file(s) deleted",
-                out.action,
+                out.outcome.action,
                 out.moves_applied,
-                out.files_written.len(),
-                out.files_deleted.len()
+                out.outcome.files_written.len(),
+                out.outcome.files_deleted.len()
             );
+            Ok(())
         }
-        OutputFormat::Json | OutputFormat::Ndjson => {
-            println!("{}", serde_json::to_string_pretty(out)?);
-        }
+        format => print_outcome_json(out, format),
     }
-    Ok(())
 }
 
 fn run_modules_list(args: ModulesListArgs) -> Result<()> {
@@ -1647,7 +1584,7 @@ mod tests {
             "members: []\n",
         );
 
-        let selection = super::dispatch_id_selection("auto_partition_0499", &modules_root);
+        let selection = super::dispatch_id_selection("auto_partition_0499", &modules_root).unwrap();
 
         assert_eq!(
             selection.module_path.as_deref(),
@@ -1711,28 +1648,28 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let modules = tmp.path().to_path_buf();
         std::fs::create_dir_all(&modules).unwrap();
-        let sel = super::dispatch_id_selection("owner:42", &modules);
+        let sel = super::dispatch_id_selection("owner:42", &modules).unwrap();
         assert_eq!(sel.owner_id.as_deref(), Some("owner:42"));
     }
 
     #[test]
     fn dispatch_id_logical_prefix() {
         let tmp = tempfile::tempdir().unwrap();
-        let sel = super::dispatch_id_selection("logical:7", tmp.path());
+        let sel = super::dispatch_id_selection("logical:7", tmp.path()).unwrap();
         assert_eq!(sel.module_id.as_deref(), Some("logical:7"));
     }
 
     #[test]
     fn dispatch_id_atomic_prefix() {
         let tmp = tempfile::tempdir().unwrap();
-        let sel = super::dispatch_id_selection("atomic:7", tmp.path());
+        let sel = super::dispatch_id_selection("atomic:7", tmp.path()).unwrap();
         assert_eq!(sel.unit_id.as_deref(), Some("atomic:7"));
     }
 
     #[test]
     fn dispatch_id_diagnostic_prefix() {
         let tmp = tempfile::tempdir().unwrap();
-        let sel = super::dispatch_id_selection("diagnostic:size_cap_0001", tmp.path());
+        let sel = super::dispatch_id_selection("diagnostic:size_cap_0001", tmp.path()).unwrap();
         assert_eq!(
             sel.diagnostic_id.as_deref(),
             Some("diagnostic:size_cap_0001")
@@ -1742,7 +1679,7 @@ mod tests {
     #[test]
     fn dispatch_id_proposal_prefix() {
         let tmp = tempfile::tempdir().unwrap();
-        let sel = super::dispatch_id_selection("auto_partition_0042", tmp.path());
+        let sel = super::dispatch_id_selection("auto_partition_0042", tmp.path()).unwrap();
         assert_eq!(sel.proposal_id.as_deref(), Some("auto_partition_0042"));
     }
 
@@ -1752,14 +1689,14 @@ mod tests {
         let modules = tmp.path();
         std::fs::create_dir_all(modules.join("runtime")).unwrap();
         std::fs::write(modules.join("runtime/plugins.yaml"), "members: []\n").unwrap();
-        let sel = super::dispatch_id_selection("runtime/plugins", modules);
+        let sel = super::dispatch_id_selection("runtime/plugins", modules).unwrap();
         assert_eq!(sel.module_path.as_deref(), Some("runtime/plugins"));
     }
 
     #[test]
     fn dispatch_id_binding_otherwise() {
         let tmp = tempfile::tempdir().unwrap();
-        let sel = super::dispatch_id_selection("XOe", tmp.path());
+        let sel = super::dispatch_id_selection("XOe", tmp.path()).unwrap();
         assert_eq!(sel.binding_id.as_deref(), Some("XOe"));
     }
 

--- a/devinfra/js/debundle/cli/module.rs
+++ b/devinfra/js/debundle/cli/module.rs
@@ -25,9 +25,11 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, anyhow, bail};
 use clap::{Args as ClapArgs, Subcommand};
+use peel::OutputFormat;
 use serde_yaml::{Mapping, Value};
 
 use crate::edit_gate::{Gate, post_delete_spec, post_merge_spec};
+use crate::outcome::{GateOutcome, MutationOutcome, emit_gate_rejection_json, print_outcome_json};
 use crate::yaml_edit::{read_yaml, write_yaml_body_if_semantic_changed};
 
 /// Top-level `debundle module ...` argument shape.
@@ -75,6 +77,10 @@ pub struct MergeArgs {
     /// values when the gate checks anonymous statement selectors.
     #[arg(long = "source-root", env = "DEBUNDLE_SOURCE_ROOT")]
     pub source_root: Option<PathBuf>,
+
+    /// Output format. Default `text` on tty, `json` on pipe.
+    #[arg(long, value_enum)]
+    pub format: Option<OutputFormat>,
 }
 
 /// Summary returned by [`merge_modules`].
@@ -84,6 +90,24 @@ pub struct MergeSummary {
     pub target: PathBuf,
     /// Absolute paths of source files that were merged in and deleted.
     pub merged_sources: Vec<PathBuf>,
+}
+
+/// `modules merge` outcome: the shared [`MutationOutcome`] core
+/// (target in `files_written`, deleted sources in `files_deleted`)
+/// plus the merge target path.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct MergeOutcome {
+    #[serde(flatten)]
+    pub outcome: MutationOutcome,
+    pub target: String,
+}
+
+/// `modules delete` outcome: just the shared core (deleted paths in
+/// `files_deleted`).
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DeleteOutcome {
+    #[serde(flatten)]
+    pub outcome: MutationOutcome,
 }
 
 impl MergeSummary {
@@ -134,6 +158,10 @@ pub struct DeleteArgs {
     /// values when the gate checks anonymous statement selectors.
     #[arg(long = "source-root", env = "DEBUNDLE_SOURCE_ROOT")]
     pub source_root: Option<PathBuf>,
+
+    /// Output format. Default `text` on tty, `json` on pipe.
+    #[arg(long, value_enum)]
+    pub format: Option<OutputFormat>,
 }
 
 /// Summary returned by [`delete_modules`].
@@ -195,7 +223,7 @@ pub fn run_merge(merge: MergeArgs) -> Result<()> {
         merge.owner_graph_path.as_deref(),
         merge.source_root.as_deref(),
     )?;
-    gate.check(&merge.modules_root, || {
+    if let Err(err) = gate.check(&merge.modules_root, || {
         let target_abs = resolve_module_file(&merge.modules_root, &merge.target);
         let source_abs: Vec<PathBuf> = merge
             .sources
@@ -203,24 +231,55 @@ pub fn run_merge(merge: MergeArgs) -> Result<()> {
             .map(|p| resolve_module_file(&merge.modules_root, p))
             .collect();
         post_merge_spec(&merge.modules_root, &target_abs, &source_abs)
-    })?;
+    }) {
+        emit_gate_rejection_json("merge", merge.format, &err);
+        return Err(err);
+    }
 
     let sources: Vec<&Path> = merge.sources.iter().map(PathBuf::as_path).collect();
-    if merge.dry_run {
+    let (summary, action) = if merge.dry_run {
         // Dry-run shape preview: load each file to confirm shape
         // before reporting the action. The full validate+write
         // pass would be the same minus the final `fs::write` /
         // `fs::remove_file`.
-        let summary = preview_merge(&merge.modules_root, &merge.target, &sources)?;
-        println!(
-            "dry-run: would merge {} source(s) into {}",
-            summary.merged_sources.len(),
-            summary.target.display()
-        );
-        return Ok(());
+        (
+            preview_merge(&merge.modules_root, &merge.target, &sources)?,
+            "dry-run",
+        )
+    } else {
+        (
+            merge_modules(&merge.modules_root, &merge.target, &sources)?,
+            "applied",
+        )
+    };
+    let merge_outcome = MergeOutcome {
+        outcome: MutationOutcome {
+            verb: "merge",
+            action,
+            gate: gate.outcome(),
+            files_written: vec![summary.target.display().to_string()],
+            files_deleted: summary
+                .merged_sources
+                .iter()
+                .map(|p| p.display().to_string())
+                .collect(),
+        },
+        target: summary.target.display().to_string(),
+    };
+    match OutputFormat::resolve(merge.format) {
+        OutputFormat::Text => {
+            if merge.dry_run {
+                println!(
+                    "dry-run: would merge {} source(s) into {}",
+                    summary.merged_sources.len(),
+                    summary.target.display()
+                );
+            } else {
+                println!("{}", summary.summary_line());
+            }
+        }
+        format => print_outcome_json(&merge_outcome, format)?,
     }
-    let summary = merge_modules(&merge.modules_root, &merge.target, &sources)?;
-    println!("{}", summary.summary_line());
     Ok(())
 }
 
@@ -428,19 +487,45 @@ pub fn run_delete(args: DeleteArgs) -> Result<()> {
     // anonymous statements, so removing it leaves the partition
     // unchanged). For non-empty `--force` deletions we run the full
     // gate against the post-delete partition.
-    if !all_empty {
+    let gate_outcome = if all_empty {
+        GateOutcome::NotRequired
+    } else {
         let gate = Gate::from_cli(
             args.no_verify,
             args.owner_graph_path.as_deref(),
             args.source_root.as_deref(),
         )?;
-        gate.check(&args.modules_root, || {
+        if let Err(err) = gate.check(&args.modules_root, || {
             post_delete_spec(&args.modules_root, &paths_abs)
-        })?;
-    }
+        }) {
+            emit_gate_rejection_json("delete", args.format, &err);
+            return Err(err);
+        }
+        gate.outcome()
+    };
 
     let summary = delete_modules(&paths_abs, args.dry_run)?;
-    println!("{}", summary.summary_line());
+    let delete_outcome = DeleteOutcome {
+        outcome: MutationOutcome {
+            verb: "delete",
+            action: if summary.dry_run {
+                "dry-run"
+            } else {
+                "applied"
+            },
+            gate: gate_outcome,
+            files_written: Vec::new(),
+            files_deleted: summary
+                .deleted
+                .iter()
+                .map(|p| p.display().to_string())
+                .collect(),
+        },
+    };
+    match OutputFormat::resolve(args.format) {
+        OutputFormat::Text => println!("{}", summary.summary_line()),
+        format => print_outcome_json(&delete_outcome, format)?,
+    }
     Ok(())
 }
 
@@ -764,6 +849,7 @@ mod tests {
             force: false,
             owner_graph_path: None,
             source_root: None,
+            format: Some(OutputFormat::Text),
         };
         run_delete(args).expect("bare path resolves to the .yaml file");
         assert!(

--- a/devinfra/js/debundle/cli/outcome.rs
+++ b/devinfra/js/debundle/cli/outcome.rs
@@ -1,0 +1,103 @@
+//! Shared outcome schema for the five spec-mutating CLI verbs
+//! (`bindings {assign,unassign,rename}`, `modules {merge,delete}`).
+//!
+//! Every mutating verb prints one [`MutationOutcome`]-carrying object
+//! on stdout when a JSON format is selected (explicit `--format
+//! json|ndjson`, or stdout is a pipe): the shared core is
+//! `verb` / `action` / `gate` / `files_written` / `files_deleted`;
+//! verb-specific fields (`moves_applied`, `binding`, …) flatten in
+//! alongside it. When the realizability gate refuses the edit, the
+//! verbs instead print a [`GateRejectionOutcome`] (`action:
+//! "rejected"`) carrying the canonical rejection projections — the
+//! same `BlockingSccEntry` / `AtomicUnitConflictReport` wire shapes
+//! `cycles.json` / `atomic_unit_conflicts.json` use — and exit
+//! non-zero. See docs/cli.md § "Rejection diagnostics".
+
+use anyhow::Result;
+use peel::OutputFormat;
+use serde::Serialize;
+
+use crate::edit_gate::{GateRejection, GateRejectionReport};
+
+/// How a mutating verb's edit was validated, reported in the outcome
+/// so machine readers can tell a gate-checked apply from a
+/// `--no-verify` one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GateOutcome {
+    /// The realizability + atom-split gate ran against the post-edit
+    /// spec and passed.
+    Passed,
+    /// Name-collision validation only (no graph-backed gate for this
+    /// verb or edit).
+    NamesOnly,
+    /// Validation skipped via `--no-verify`.
+    Skipped,
+    /// No gate needed: the edit cannot change the partition (e.g.
+    /// deleting structurally empty modules, an empty batch).
+    NotRequired,
+}
+
+/// The shared outcome core. Verb-specific outcome structs embed this
+/// via `#[serde(flatten)]` so all five mutating verbs share one JSON
+/// schema family.
+#[derive(Debug, Clone, Serialize)]
+pub struct MutationOutcome {
+    /// Which mutating verb produced the outcome:
+    /// `assign` | `unassign` | `rename` | `merge` | `delete`.
+    pub verb: &'static str,
+    /// `applied` | `dry-run` | `noop` | `unchanged`.
+    pub action: &'static str,
+    pub gate: GateOutcome,
+    /// Files written (or, under `--dry-run`, that would be written).
+    pub files_written: Vec<String>,
+    /// Files deleted (or, under `--dry-run`, that would be deleted).
+    pub files_deleted: Vec<String>,
+}
+
+/// Stdout envelope for a realizability-gate rejection. `action:
+/// "rejected"` keeps it in the same schema family as the success
+/// outcomes; `rejection` carries the canonical per-SCC / per-conflict
+/// projections.
+#[derive(Debug, Serialize)]
+pub struct GateRejectionOutcome<'a> {
+    pub verb: &'static str,
+    pub action: &'static str,
+    pub rejection: &'a GateRejectionReport,
+}
+
+/// Print `value` as JSON on stdout: pretty for `json`, one line for
+/// `ndjson`. Callers handle `text` themselves.
+pub fn print_outcome_json<T: Serialize>(value: &T, format: OutputFormat) -> Result<()> {
+    match format {
+        OutputFormat::Json => println!("{}", serde_json::to_string_pretty(value)?),
+        OutputFormat::Ndjson => println!("{}", serde_json::to_string(value)?),
+        OutputFormat::Text => unreachable!("text outcomes are rendered per verb"),
+    }
+    Ok(())
+}
+
+/// If `err` is a realizability-gate rejection and a JSON format is
+/// selected (explicitly or because stdout is a pipe), mirror the
+/// stderr blame report as a structured [`GateRejectionOutcome`] on
+/// stdout so machine readers don't have to scrape prose. The error
+/// still propagates — the command exits non-zero either way.
+pub fn emit_gate_rejection_json(
+    verb: &'static str,
+    format: Option<OutputFormat>,
+    err: &anyhow::Error,
+) {
+    let Some(rejection) = err.downcast_ref::<GateRejection>() else {
+        return;
+    };
+    let format = OutputFormat::resolve(format);
+    if format == OutputFormat::Text {
+        return;
+    }
+    let outcome = GateRejectionOutcome {
+        verb,
+        action: "rejected",
+        rejection: &rejection.report,
+    };
+    print_outcome_json(&outcome, format).expect("rejection outcome serializes");
+}

--- a/devinfra/js/debundle/docs/cli.md
+++ b/devinfra/js/debundle/docs/cli.md
@@ -12,8 +12,8 @@ on-stderr convention as the rest of ducktape.
 ## Convention: validate-by-default for mutating commands
 
 Every command that **modifies the spec** (`bindings assign`,
-`bindings unassign`, `bindings rename`, `modules merge`) runs
-validation **by default** before
+`bindings unassign`, `bindings rename`, `modules merge`,
+`modules delete`) runs validation **by default** before
 writing changes back to disk. For commands that affect the chunk's
 factorization (anything that moves a binding between modules), that
 means the full realizability gate; for renames, it means name-
@@ -35,8 +35,12 @@ the gate would reject and you want to inspect the intermediate
 state without committing to it.
 
 `debundle run --dry-run` is separate: it runs pipeline parse/facts/gate
-checks and skips all emitted JS and report writes. There is no
-`debundle run --no-verify`.
+checks and skips emitted-JS and accept-path report writes. A gate
+rejection still writes `owner_graph.json` plus the rejection evidence
+(`cycles.json` / `atomic_unit_conflicts.json`) under
+`reports/tree/<chunk>/`, so `gate list` / `gate describe` work on the
+rejection that was just reported. There is no `debundle run
+--no-verify`.
 
 Read-only commands (queries, listings, source slicing) take
 neither flag — they have no side effects.
@@ -114,13 +118,13 @@ the right primitive.
 
 ### Quotient queries
 
-| Command                                                                                | Mutates? | Function                                                                                                                                                                                                                                                                                                                                               |
-| -------------------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `debundle scc [--binding <sym>] [--cycles-only] [--residual-only] [--singletons-only]` | no       | List SCCs in the module-quotient graph. Filter to a single binding's SCC or to a specific class. (Streaming output via `--format ndjson` — see "Output format" above.)                                                                                                                                                                                 |
-| `debundle cluster <sym>`                                                               | no       | List the module-quotient neighbors of a binding's owner. `<sym>` may be passed positionally or as `--binding <sym>`. Each neighbor (and the home module) is reported as both its interned `logical:N` id and its human path `label`, so output is legible without a second `describe`.                                                                 |
-| `debundle gate list`                                                                   | no       | List every blocking SCC in `cycles.json`. One row per entry: id, modules count, cut size. (Streaming via `--format ndjson`.) A missing `cycles.json` is the clean state — the pipeline writes it only on rejection — so it reports zero blocking SCCs (`[]`) and exits 0, distinct from a present-but-malformed file (which errors).                   |
-| `debundle gate describe <id> [--binding <sym>]`                                        | no       | Full picture for one blocking SCC: modules list, cut, plus the per-edge evidence recomputed on demand from `owner_graph.json` and the SCC's module set. Renders the same per-binding-pair blame view the realizability gate emits to stderr at rejection time. `--binding` narrows evidence to one symbol's contribution (handy for 1000-module SCCs). |
-| `debundle gate cut <id>`                                                               | no       | Just the cut edges for one blocking SCC. The actionable subset — spec authors read this to pick which back-edge to break.                                                                                                                                                                                                                              |
+| Command                                                                                | Mutates? | Function                                                                                                                                                                                                                                                                                                                                                                                          |
+| -------------------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `debundle scc [--binding <sym>] [--cycles-only] [--residual-only] [--singletons-only]` | no       | List SCCs in the module-quotient graph. Filter to a single binding's SCC or to a specific class. (Streaming output via `--format ndjson` — see "Output format" above.)                                                                                                                                                                                                                            |
+| `debundle cluster <sym>`                                                               | no       | List the module-quotient neighbors of a binding's owner. `<sym>` may be passed positionally or as `--binding <sym>`. Each neighbor (and the home module) is reported as both its interned `logical:N` id and its human path `label`, so output is legible without a second `describe`.                                                                                                            |
+| `debundle gate list`                                                                   | no       | List every blocking SCC in `cycles.json`. One row per entry: id, modules count, cut size. (Streaming via `--format ndjson`.) A missing `cycles.json` is the clean state — the pipeline and the edit gate write it only on rejection, and a passing edit gate clears a stale one — so it reports zero blocking SCCs (`[]`) and exits 0, distinct from a present-but-malformed file (which errors). |
+| `debundle gate describe <id> [--binding <sym>]`                                        | no       | Full picture for one blocking SCC: modules list, cut, plus the per-edge evidence recomputed on demand from `owner_graph.json` and the SCC's module set. Renders the same per-binding-pair blame view the realizability gate emits to stderr at rejection time. `--binding` narrows evidence to one symbol's contribution (handy for 1000-module SCCs).                                            |
+| `debundle gate cut <id>`                                                               | no       | Just the cut edges for one blocking SCC. The actionable subset — spec authors read this to pick which back-edge to break.                                                                                                                                                                                                                                                                         |
 
 The `gate` namespace names what is rejecting: the realizability
 gate. It complements `scc` (which lists every quotient SCC,
@@ -164,6 +168,12 @@ flag and an env var; the flag wins if both are set.
 | `--modules <dir>`     | `DEBUNDLE_MODULES`     | Per-module YAML tree root (the directory under `spec/modules/`).                                                                                                                                                                |
 | `--source-root <dir>` | `DEBUNDLE_SOURCE_ROOT` | Upstream snapshot root containing the original chunk bytes. Needed by `show-source`, by `describe` for IDs that resolve to a source location, and by `modules propose` to annotate anonymous-statement selector addressability. |
 
+`debundle run --tree-source-root` (the spec-tree compile root for
+source-relative paths in the tree-shaped config) reads its own env
+var, `DEBUNDLE_TREE_SOURCE_ROOT` — deliberately **not**
+`DEBUNDLE_SOURCE_ROOT`, because the two roots are different
+directories in real corpora (spec tree vs. upstream snapshot).
+
 Setting all three env vars in the shell once per session lets
 commands run without repeating the flags:
 
@@ -197,12 +207,29 @@ selection itself is a proposal/diagnostic id or `--include-proposals`
 is passed. Proposal-derived JSON fields are omitted when the factorizer
 is skipped.
 
-Mutating commands (`bindings assign`, `bindings unassign`,
-`bindings rename`, `modules merge`, `modules delete`) print a
-one-line "ok" / "would change N
-files" / "rejected" result. Combined with `--dry-run` they
-currently print only the verdict; a structured diff (post-mutation
-YAML preview) is a documented TODO in the codebase but not in v1.
+The five mutating verbs (`bindings assign`, `bindings unassign`,
+`bindings rename`, `modules merge`, `modules delete`) take the same
+`--format` flag with the same tty/pipe default. Under `text` they
+print a one-line "ok" / "would change N files" / "rejected" result.
+Under a JSON format each verb prints **one outcome object** sharing
+a common schema core:
+
+| Field           | Values                                                                                                                            |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `verb`          | `assign` \| `unassign` \| `rename` \| `merge` \| `delete`                                                                         |
+| `action`        | `applied` \| `dry-run` \| `noop` \| `unchanged` \| `rejected`                                                                     |
+| `gate`          | `passed` \| `names_only` \| `skipped` (`--no-verify`) \| `not_required` (edit cannot change the partition); success outcomes only |
+| `files_written` | Files written (or, under `--dry-run`, that would be written)                                                                      |
+| `files_deleted` | Files deleted (or, under `--dry-run`, that would be deleted)                                                                      |
+
+Verb-specific fields flatten in alongside the core: `moves_applied`
+(assign), `unassigned` (unassign), `binding` / `old_readable` /
+`new_readable` (rename), `target` (merge). Gate rejections replace
+the success object with a structured rejection object — see
+"Rejection diagnostics" below. Combined with `--dry-run` the outcome
+reports only the verdict and planned file set; a structured diff
+(post-mutation YAML preview) is a documented TODO in the codebase
+but not in v1.
 
 ## Batch atomicity (`bindings assign`)
 
@@ -344,8 +371,24 @@ the existing binding holding the name, the binding the rename
 would have given it.
 
 Both diagnostic shapes go to stderr; the command exits non-zero.
-With `--format json` the diagnostic is also serialized to stdout
-as a structured object so machine readers can parse it.
+Under a JSON format (explicit `--format json|ndjson`, or stdout is a
+pipe) a realizability-gate rejection additionally prints one
+structured object on stdout so machine readers don't scrape the
+prose: `{verb, action: "rejected", rejection}`, where
+`rejection.kind` is `atom_split` (with `conflicts`, the canonical
+`AtomicUnitConflictReport` projection) or `unrealizable_cycles`
+(with `blocking_sccs`, the canonical `BlockingSccEntry` projection).
+These are the **same wire shapes** `atomic_unit_conflicts.json` /
+`cycles.json` carry — there is no parallel rejection schema.
+
+Edit-gate rejections (including `--dry-run` probes) also write those
+artifacts to disk as siblings of `--graph` — the default location
+`gate list` / `gate describe` / `gate cut` read — so the documented
+follow-up queries work on the rejection that was just reported. A
+subsequent edit that passes the gate clears the stale artifacts.
+`debundle run` (and `run --dry-run`) writes the same files under
+`reports/tree/<chunk>/`, which is the same sibling-of-`owner_graph.json`
+layout.
 
 ## Out of scope
 

--- a/devinfra/js/debundle/docs/guide.md
+++ b/devinfra/js/debundle/docs/guide.md
@@ -19,6 +19,11 @@ export DEBUNDLE_OUT=<debundle-output-root>
 
 Flags win when both are set. Use this for one-off overrides.
 
+`DEBUNDLE_SOURCE_ROOT` feeds only the query commands' `--source-root`
+(the upstream snapshot root). `debundle run --tree-source-root` — the
+spec-tree compile root — reads the separate `DEBUNDLE_TREE_SOURCE_ROOT`,
+since the two roots are different directories in real corpora.
+
 If remote execution downloads only minimal outputs, request full outputs
 so side files are local:
 

--- a/devinfra/js/debundle/e2e/BUILD.bazel
+++ b/devinfra/js/debundle/e2e/BUILD.bazel
@@ -250,6 +250,23 @@ rust_test(
     ],
 )
 
+# Machine-consumable outcome contract for the five spec-mutating
+# verbs: `--format json` success outcomes share one schema core
+# (verb/action/gate/files_written/files_deleted), gate rejections
+# print structured JSON on stdout, and rejection artifacts land as
+# siblings of `--graph` where `gate list/describe` read them.
+rust_test(
+    name = "cli_mutation_outcome_test",
+    srcs = ["cli_mutation_outcome_test.rs"],
+    crate_root = "cli_mutation_outcome_test.rs",
+    data = ["//devinfra/js/debundle"],
+    edition = "2024",
+    deps = [
+        "@crates//:serde_json",
+        "@crates//:tempfile",
+    ],
+)
+
 # Edit-gate parity with `debundle run` for source_match member
 # selectors and binding_groups: claims the gate cannot model by
 # binding name alone must still partition (or hard-error), never

--- a/devinfra/js/debundle/e2e/bindings_assign_cli_test.rs
+++ b/devinfra/js/debundle/e2e/bindings_assign_cli_test.rs
@@ -70,7 +70,7 @@ fn rename_round_trip_validates_then_writes() {
         "members:\n  - selector: { binding: { name: XOe } }\n",
     );
     let out = rename_binding(root, "XOe", "PluginSettings", false, false).unwrap();
-    assert_eq!(out.action, "renamed");
+    assert_eq!(out.outcome.action, "applied");
     let body = read(root, "m.yaml");
     let doc: Value = serde_yaml::from_str(&body).unwrap();
     assert_eq!(doc["members"][0]["name"].as_str(), Some("PluginSettings"));
@@ -83,7 +83,7 @@ fn rename_dry_run_skips_write() {
     let body0 = "members:\n  - selector: { binding: { name: XOe } }\n";
     write(root, "m.yaml", body0);
     let out = rename_binding(root, "XOe", "PluginSettings", true, false).unwrap();
-    assert_eq!(out.action, "dry-run");
+    assert_eq!(out.outcome.action, "dry-run");
     assert_eq!(read(root, "m.yaml"), body0);
 }
 

--- a/devinfra/js/debundle/e2e/cli_mutation_outcome_test.rs
+++ b/devinfra/js/debundle/e2e/cli_mutation_outcome_test.rs
@@ -1,0 +1,594 @@
+//! E2e for the machine-consumable outcome contract shared by the five
+//! spec-mutating CLI verbs (`bindings {assign,unassign,rename}`,
+//! `modules {merge,delete}`):
+//!
+//! - every verb supports `--format json` and prints one outcome
+//!   object carrying the shared core (`verb` / `action` / `gate` /
+//!   `files_written` / `files_deleted`) plus verb-specific fields;
+//! - a realizability-gate rejection prints a structured rejection
+//!   object on stdout (`action: "rejected"`, `rejection.kind`,
+//!   canonical per-SCC / per-conflict projections) while the human
+//!   blame report stays on stderr;
+//! - edit-gate rejections write the same `cycles.json` /
+//!   `atomic_unit_conflicts.json` artifacts the pipeline writes, as
+//!   siblings of `--graph`, so `debundle gate list` works on the
+//!   failure that was just reported.
+//!
+//! Shells out to the built `debundle` binary against synthetic
+//! `owner_graph.json` fixtures (same shapes as
+//! `modules_gate_cli_test` / `bindings_assign_gate_cli_test`).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+fn debundle_binary() -> PathBuf {
+    let runfiles_path = std::env::var("RUNFILES_DIR")
+        .or_else(|_| std::env::var("TEST_SRCDIR"))
+        .expect("runfiles env var");
+    Path::new(&runfiles_path).join("_main/devinfra/js/debundle/debundle")
+}
+
+fn write(path: &Path, body: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, body).unwrap();
+}
+
+fn run_debundle(args: &[&str]) -> std::process::Output {
+    Command::new(debundle_binary())
+        .args(args)
+        .output()
+        .expect("spawn debundle")
+}
+
+fn parse_stdout_json(out: &std::process::Output) -> Value {
+    serde_json::from_slice(&out.stdout).unwrap_or_else(|err| {
+        panic!(
+            "stdout is not JSON ({err})\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr),
+        )
+    })
+}
+
+fn owner_node(id: &str, ordinal: usize, binding: &str, destination: &str) -> Value {
+    serde_json::json!({
+        "id": id,
+        "statement_ordinal": ordinal,
+        "declared_bindings": [ { "binding": binding, "export_name": binding } ],
+        "statement_kind": "var_decl",
+        "purity": { "kind": "pure" },
+        "destination": destination
+    })
+}
+
+fn eager_edge(id: &str, source: &str, target: &str, binding: &str, ordinal: usize) -> Value {
+    serde_json::json!({
+        "id": id,
+        "source": source,
+        "target": target,
+        "edge_kind": "eager_use",
+        "binding": binding,
+        "statement_ordinal": ordinal,
+        "constrains_init_order": true
+    })
+}
+
+fn graph(nodes: Vec<Value>, edges: Vec<Value>) -> String {
+    serde_json::json!({
+        "chunk_id": "test/chunk",
+        "nodes": nodes,
+        "edges": edges,
+        "module_graph": { "nodes": [], "edges": [], "sccs": [] },
+        "atomic_graph": { "nodes": [], "edges": [] }
+    })
+    .to_string()
+}
+
+/// alpha (module `a`) eager-reads beta (module `b`) — an acyclic
+/// cross-module read, so single-binding moves between the modules
+/// stay realizable. Positive-control graph.
+fn acyclic_graph() -> String {
+    graph(
+        vec![
+            owner_node("owner:0", 0, "alpha", "a"),
+            owner_node("owner:1", 1, "beta", "b"),
+        ],
+        vec![eager_edge("owner_edge:0", "owner:0", "owner:1", "beta", 0)],
+    )
+}
+
+/// alpha (owner:0) and beta (owner:1) form an atomic unit via mutual
+/// `eager_rebind` edges; both pre-claimed by `home/atom`. Moving one
+/// of them out splits the atom.
+fn atomic_unit_graph() -> String {
+    serde_json::json!({
+        "chunk_id": "test/chunk",
+        "nodes": [
+            owner_node("owner:0", 0, "alpha", "home/atom"),
+            owner_node("owner:1", 1, "beta", "home/atom"),
+        ],
+        "edges": [
+            {
+                "id": "owner_edge:0",
+                "source": "owner:0",
+                "target": "owner:1",
+                "edge_kind": "eager_rebind",
+                "binding": "beta",
+                "statement_ordinal": 0,
+                "constrains_init_order": true
+            },
+            {
+                "id": "owner_edge:1",
+                "source": "owner:1",
+                "target": "owner:0",
+                "edge_kind": "eager_rebind",
+                "binding": "alpha",
+                "statement_ordinal": 1,
+                "constrains_init_order": true
+            }
+        ],
+        "module_graph": { "nodes": [], "edges": [], "sccs": [] },
+        "atomic_graph": { "nodes": [], "edges": [] }
+    })
+    .to_string()
+}
+
+/// alpha (`a`) → gamma (`c`) → beta (`b`): a DAG quotient `a → c → b`
+/// that closes into the 2-cycle `m ↔ c` when `a` and `b` merge.
+fn merge_cycle_graph() -> String {
+    graph(
+        vec![
+            owner_node("owner:0", 0, "alpha", "a"),
+            owner_node("owner:1", 1, "beta", "b"),
+            owner_node("owner:2", 2, "gamma", "c"),
+        ],
+        vec![
+            eager_edge("owner_edge:0", "owner:0", "owner:2", "gamma", 0),
+            eager_edge("owner_edge:1", "owner:2", "owner:1", "beta", 2),
+        ],
+    )
+}
+
+fn one_member_module(binding: &str) -> String {
+    format!("members:\n  - selector: {{ binding: {{ name: {binding} }} }}\n")
+}
+
+fn write_acyclic_fixture(root: &Path) -> (PathBuf, PathBuf) {
+    let modules = root.join("modules");
+    let graph_path = root.join("owner_graph.json");
+    write(&graph_path, &acyclic_graph());
+    write(&modules.join("a.yaml"), &one_member_module("alpha"));
+    write(&modules.join("b.yaml"), &one_member_module("beta"));
+    (modules, graph_path)
+}
+
+// ---------------------------------------------------------------
+// `--format json` success outcomes: one shared schema core across
+// the five mutating verbs.
+// ---------------------------------------------------------------
+
+#[test]
+fn assign_json_outcome_carries_shared_core() {
+    let dir = tempfile::tempdir().unwrap();
+    let (modules, graph_path) = write_acyclic_fixture(dir.path());
+
+    let out = run_debundle(&[
+        "bindings",
+        "assign",
+        "--modules",
+        modules.to_str().unwrap(),
+        "--graph",
+        graph_path.to_str().unwrap(),
+        "--format",
+        "json",
+        "beta:c",
+    ]);
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let parsed = parse_stdout_json(&out);
+    assert_eq!(parsed["verb"], "assign", "{parsed}");
+    assert_eq!(parsed["action"], "applied", "{parsed}");
+    assert_eq!(parsed["gate"], "passed", "{parsed}");
+    assert_eq!(parsed["moves_applied"], 1, "{parsed}");
+    let written: Vec<&str> = parsed["files_written"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|f| f.as_str().unwrap())
+        .collect();
+    assert!(written.iter().any(|f| f.ends_with("c.yaml")), "{parsed}");
+    let deleted: Vec<&str> = parsed["files_deleted"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|f| f.as_str().unwrap())
+        .collect();
+    assert!(
+        deleted.iter().any(|f| f.ends_with("b.yaml")),
+        "drained source module must be reported deleted: {parsed}"
+    );
+}
+
+#[test]
+fn unassign_json_outcome_carries_shared_core() {
+    let dir = tempfile::tempdir().unwrap();
+    let (modules, graph_path) = write_acyclic_fixture(dir.path());
+
+    let out = run_debundle(&[
+        "bindings",
+        "unassign",
+        "--modules",
+        modules.to_str().unwrap(),
+        "--graph",
+        graph_path.to_str().unwrap(),
+        "--format",
+        "json",
+        "beta",
+    ]);
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let parsed = parse_stdout_json(&out);
+    assert_eq!(parsed["verb"], "unassign", "{parsed}");
+    assert_eq!(parsed["action"], "applied", "{parsed}");
+    assert_eq!(parsed["gate"], "passed", "{parsed}");
+    assert_eq!(parsed["unassigned"], 1, "{parsed}");
+}
+
+#[test]
+fn rename_json_outcome_carries_shared_core() {
+    let dir = tempfile::tempdir().unwrap();
+    let modules = dir.path().join("modules");
+    write(&modules.join("m.yaml"), &one_member_module("alpha"));
+
+    let out = run_debundle(&[
+        "bindings",
+        "rename",
+        "--modules",
+        modules.to_str().unwrap(),
+        "--format",
+        "json",
+        "alpha",
+        "ReadableAlpha",
+    ]);
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let parsed = parse_stdout_json(&out);
+    assert_eq!(parsed["verb"], "rename", "{parsed}");
+    assert_eq!(parsed["action"], "applied", "{parsed}");
+    assert_eq!(parsed["gate"], "names_only", "{parsed}");
+    assert_eq!(parsed["binding"], "alpha", "{parsed}");
+    assert_eq!(parsed["new_readable"], "ReadableAlpha", "{parsed}");
+    assert_eq!(parsed["files_written"].as_array().unwrap().len(), 1);
+    assert_eq!(parsed["files_deleted"].as_array().unwrap().len(), 0);
+}
+
+#[test]
+fn merge_json_outcome_carries_shared_core() {
+    let dir = tempfile::tempdir().unwrap();
+    let (modules, graph_path) = write_acyclic_fixture(dir.path());
+
+    let out = run_debundle(&[
+        "modules",
+        "merge",
+        "--modules",
+        modules.to_str().unwrap(),
+        "--graph",
+        graph_path.to_str().unwrap(),
+        "--format",
+        "json",
+        "--target",
+        "a.yaml",
+        "b.yaml",
+    ]);
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let parsed = parse_stdout_json(&out);
+    assert_eq!(parsed["verb"], "merge", "{parsed}");
+    assert_eq!(parsed["action"], "applied", "{parsed}");
+    assert_eq!(parsed["gate"], "passed", "{parsed}");
+    let written = parsed["files_written"].as_array().unwrap();
+    assert!(written[0].as_str().unwrap().ends_with("a.yaml"), "{parsed}");
+    let deleted = parsed["files_deleted"].as_array().unwrap();
+    assert_eq!(deleted.len(), 1, "{parsed}");
+    assert!(deleted[0].as_str().unwrap().ends_with("b.yaml"), "{parsed}");
+    assert!(
+        parsed["target"].as_str().unwrap().ends_with("a.yaml"),
+        "{parsed}"
+    );
+}
+
+#[test]
+fn merge_dry_run_json_outcome_reports_dry_run_action() {
+    let dir = tempfile::tempdir().unwrap();
+    let (modules, graph_path) = write_acyclic_fixture(dir.path());
+
+    let out = run_debundle(&[
+        "modules",
+        "merge",
+        "--modules",
+        modules.to_str().unwrap(),
+        "--graph",
+        graph_path.to_str().unwrap(),
+        "--format",
+        "json",
+        "--dry-run",
+        "--target",
+        "a.yaml",
+        "b.yaml",
+    ]);
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let parsed = parse_stdout_json(&out);
+    assert_eq!(parsed["verb"], "merge", "{parsed}");
+    assert_eq!(parsed["action"], "dry-run", "{parsed}");
+    assert!(modules.join("b.yaml").exists(), "dry-run must not delete");
+}
+
+#[test]
+fn delete_json_outcome_carries_shared_core() {
+    let dir = tempfile::tempdir().unwrap();
+    let modules = dir.path().join("modules");
+    write(&modules.join("ui/empty.yaml"), "members: []\n");
+
+    let out = run_debundle(&[
+        "modules",
+        "delete",
+        "--modules",
+        modules.to_str().unwrap(),
+        "--format",
+        "json",
+        "ui/empty.yaml",
+    ]);
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let parsed = parse_stdout_json(&out);
+    assert_eq!(parsed["verb"], "delete", "{parsed}");
+    assert_eq!(parsed["action"], "applied", "{parsed}");
+    // Deleting a structurally-empty module cannot change the
+    // partition, so no gate runs.
+    assert_eq!(parsed["gate"], "not_required", "{parsed}");
+    assert_eq!(parsed["files_written"].as_array().unwrap().len(), 0);
+    let deleted = parsed["files_deleted"].as_array().unwrap();
+    assert_eq!(deleted.len(), 1, "{parsed}");
+    assert!(
+        deleted[0].as_str().unwrap().ends_with("ui/empty.yaml"),
+        "{parsed}"
+    );
+}
+
+// ---------------------------------------------------------------
+// Structured gate rejections on stdout + on-disk artifacts.
+// ---------------------------------------------------------------
+
+#[test]
+fn assign_atom_split_rejection_emits_structured_json_and_artifact() {
+    let dir = tempfile::tempdir().unwrap();
+    let modules = dir.path().join("modules");
+    let graph_path = dir.path().join("owner_graph.json");
+    write(&graph_path, &atomic_unit_graph());
+    write(
+        &modules.join("home/atom.yaml"),
+        &format!(
+            "{}{}",
+            one_member_module("alpha"),
+            "  - selector: { binding: { name: beta } }\n"
+        ),
+    );
+
+    let out = run_debundle(&[
+        "bindings",
+        "assign",
+        "--modules",
+        modules.to_str().unwrap(),
+        "--graph",
+        graph_path.to_str().unwrap(),
+        "--format",
+        "json",
+        "alpha:dogfood/split",
+    ]);
+    assert!(!out.status.success(), "atom split must be rejected");
+    // Human blame report stays on stderr.
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("splits one or more atomic units"),
+        "stderr: {stderr}"
+    );
+    // Structured rejection on stdout.
+    let parsed = parse_stdout_json(&out);
+    assert_eq!(parsed["verb"], "assign", "{parsed}");
+    assert_eq!(parsed["action"], "rejected", "{parsed}");
+    assert_eq!(parsed["rejection"]["kind"], "atom_split", "{parsed}");
+    let conflicts = parsed["rejection"]["conflicts"].as_array().unwrap();
+    assert_eq!(conflicts.len(), 1, "{parsed}");
+    let claims = conflicts[0]["claims"].as_array().unwrap();
+    let claimed_modules: Vec<&str> = claims
+        .iter()
+        .map(|c| c["module"].as_str().unwrap())
+        .collect();
+    assert!(
+        claimed_modules.contains(&"dogfood/split") && claimed_modules.contains(&"home/atom"),
+        "claims must name both destinations: {parsed}"
+    );
+    // The same projection lands on disk next to --graph.
+    let artifact: Value = serde_json::from_str(
+        &fs::read_to_string(dir.path().join("atomic_unit_conflicts.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(artifact.as_array().unwrap().len(), 1, "{artifact}");
+}
+
+#[test]
+fn merge_cycle_rejection_emits_structured_json_and_gate_list_works() {
+    let dir = tempfile::tempdir().unwrap();
+    let modules = dir.path().join("modules");
+    let graph_path = dir.path().join("owner_graph.json");
+    write(&graph_path, &merge_cycle_graph());
+    write(&modules.join("a.yaml"), &one_member_module("alpha"));
+    write(&modules.join("b.yaml"), &one_member_module("beta"));
+    write(&modules.join("c.yaml"), &one_member_module("gamma"));
+
+    let out = run_debundle(&[
+        "modules",
+        "merge",
+        "--modules",
+        modules.to_str().unwrap(),
+        "--graph",
+        graph_path.to_str().unwrap(),
+        "--format",
+        "json",
+        "--target",
+        "a.yaml",
+        "b.yaml",
+    ]);
+    assert!(!out.status.success(), "merge-induced cycle must reject");
+    let parsed = parse_stdout_json(&out);
+    assert_eq!(parsed["verb"], "merge", "{parsed}");
+    assert_eq!(parsed["action"], "rejected", "{parsed}");
+    assert_eq!(
+        parsed["rejection"]["kind"], "unrealizable_cycles",
+        "{parsed}"
+    );
+    let sccs = parsed["rejection"]["blocking_sccs"].as_array().unwrap();
+    assert_eq!(sccs.len(), 1, "{parsed}");
+    let scc_modules: Vec<&str> = sccs[0]["modules"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|m| m.as_str().unwrap())
+        .collect();
+    assert!(
+        scc_modules.contains(&"a") && scc_modules.contains(&"c"),
+        "SCC must name the post-merge cycle members: {parsed}"
+    );
+    assert!(
+        !sccs[0]["cut"].as_array().unwrap().is_empty(),
+        "cut edges carry the binding-pair blame: {parsed}"
+    );
+
+    // The documented follow-up works on the rejection that was just
+    // reported: cycles.json landed next to --graph, where `gate list`
+    // looks by default.
+    let gate_out = run_debundle(&[
+        "gate",
+        "list",
+        "--graph",
+        graph_path.to_str().unwrap(),
+        "--format",
+        "json",
+    ]);
+    assert!(
+        gate_out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&gate_out.stderr)
+    );
+    let gate_parsed = parse_stdout_json(&gate_out);
+    let entries = gate_parsed["blocking_sccs"].as_array().unwrap();
+    assert_eq!(entries.len(), 1, "{gate_parsed}");
+    assert_eq!(entries[0]["module_count"].as_u64(), Some(2));
+}
+
+#[test]
+fn passing_edit_gate_clears_stale_rejection_artifacts() {
+    // A rejected merge leaves cycles.json; a subsequent edit that
+    // passes the gate must clear it so `gate list` reports the clean
+    // state again.
+    let dir = tempfile::tempdir().unwrap();
+    let modules = dir.path().join("modules");
+    let graph_path = dir.path().join("owner_graph.json");
+    write(&graph_path, &merge_cycle_graph());
+    write(&modules.join("a.yaml"), &one_member_module("alpha"));
+    write(&modules.join("b.yaml"), &one_member_module("beta"));
+    write(&modules.join("c.yaml"), &one_member_module("gamma"));
+
+    let rejected = run_debundle(&[
+        "modules",
+        "merge",
+        "--modules",
+        modules.to_str().unwrap(),
+        "--graph",
+        graph_path.to_str().unwrap(),
+        "--target",
+        "a.yaml",
+        "b.yaml",
+    ]);
+    assert!(!rejected.status.success());
+    assert!(dir.path().join("cycles.json").exists());
+
+    // Merging a + c is realizable (`{a,c} → b` stays a DAG).
+    let accepted = run_debundle(&[
+        "modules",
+        "merge",
+        "--modules",
+        modules.to_str().unwrap(),
+        "--graph",
+        graph_path.to_str().unwrap(),
+        "--target",
+        "a.yaml",
+        "c.yaml",
+    ]);
+    assert!(
+        accepted.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&accepted.stderr)
+    );
+    assert!(
+        !dir.path().join("cycles.json").exists(),
+        "stale cycles.json must be cleared by a passing gate"
+    );
+}
+
+#[test]
+fn rejection_without_json_format_keeps_stdout_text_free_of_json() {
+    // With `--format text`, the rejection path must not print the
+    // structured object — scripting callers opt in via JSON formats.
+    let dir = tempfile::tempdir().unwrap();
+    let modules = dir.path().join("modules");
+    let graph_path = dir.path().join("owner_graph.json");
+    write(&graph_path, &merge_cycle_graph());
+    write(&modules.join("a.yaml"), &one_member_module("alpha"));
+    write(&modules.join("b.yaml"), &one_member_module("beta"));
+    write(&modules.join("c.yaml"), &one_member_module("gamma"));
+
+    let out = run_debundle(&[
+        "modules",
+        "merge",
+        "--modules",
+        modules.to_str().unwrap(),
+        "--graph",
+        graph_path.to_str().unwrap(),
+        "--format",
+        "text",
+        "--target",
+        "a.yaml",
+        "b.yaml",
+    ]);
+    assert!(!out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stdout.contains("\"rejection\""),
+        "text format must not emit the JSON rejection object: {stdout}"
+    );
+}

--- a/devinfra/js/debundle/e2e/gate_cli_test.rs
+++ b/devinfra/js/debundle/e2e/gate_cli_test.rs
@@ -21,11 +21,11 @@ use std::process::Command;
 
 use debundle_e2e_support::*;
 
-/// Reject a two-module at-init cycle through the real pipeline:
+/// A two-module at-init cycle the gate must reject:
 /// `mod_x = {A, D}` where `D = wrap(C)` reads `C` from `mod_y`, and
 /// `mod_y = {B, C}` where `B = wrap(A)` reads `A` from `mod_x`.
-fn rejected_cycle_fixture() -> RejectedFixture {
-    run_rejection_fixture(FixtureOpts::new(
+fn cycle_fixture_opts() -> FixtureOpts<'static> {
+    FixtureOpts::new(
         r#"function wrap(x) { return { ref: x }; }
 const A = "a";
 const B = wrap(A);
@@ -38,7 +38,11 @@ export { A, B, C, D };
             logical_module("mod_x", &[Member::new("A"), Member::new("D")]),
             logical_module("mod_y", &[Member::new("B"), Member::new("C")]),
         ],
-    ))
+    )
+}
+
+fn rejected_cycle_fixture() -> RejectedFixture {
+    run_rejection_fixture(cycle_fixture_opts())
 }
 
 fn graph_path(rejected: &RejectedFixture) -> PathBuf {
@@ -208,6 +212,51 @@ fn gate_unknown_id_fails_cleanly() {
     assert!(
         stderr.contains("no blocking SCC with id 99"),
         "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn dry_run_rejection_materializes_gate_artifacts() {
+    // `debundle run --dry-run` keeps the no-output contract on the
+    // accept path, but a gate rejection must still write
+    // owner_graph.json + cycles.json at the standard report location
+    // so the documented `gate list/describe` follow-up works on the
+    // rejection that was just reported.
+    let rejected = run_dry_run_rejection_fixture(cycle_fixture_opts());
+    assert!(
+        !rejected.out_root.join("app").exists(),
+        "dry-run must not emit the JS tree"
+    );
+
+    let parsed = gate_json(&[
+        "gate",
+        "list",
+        "--graph",
+        graph_path(&rejected).to_str().unwrap(),
+        "--format",
+        "json",
+    ]);
+    assert_eq!(parsed["blocking_sccs"].as_array().unwrap().len(), 1);
+
+    let parsed = gate_json(&[
+        "gate",
+        "describe",
+        "0",
+        "--graph",
+        graph_path(&rejected).to_str().unwrap(),
+        "--format",
+        "json",
+    ]);
+    let modules: BTreeSet<&str> = parsed["modules"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|m| m.as_str().unwrap())
+        .collect();
+    assert_eq!(modules, BTreeSet::from(["mod_x", "mod_y"]), "{parsed}");
+    assert!(
+        !parsed["evidence"].as_array().unwrap().is_empty(),
+        "describe must recompute evidence from the dry-run owner graph: {parsed}"
     );
 }
 

--- a/devinfra/js/debundle/e2e/modules_delete_cli_test.rs
+++ b/devinfra/js/debundle/e2e/modules_delete_cli_test.rs
@@ -40,6 +40,10 @@ fn delete_empty_module_succeeds() {
             "--modules",
             root.to_str().unwrap(),
             "ui/empty.yaml",
+            // Stdout is a pipe here, which would default to JSON;
+            // pin the human text rendering explicitly.
+            "--format",
+            "text",
         ])
         .output()
         .expect("spawn debundle");
@@ -133,6 +137,8 @@ fn delete_multiple_atomic_all_succeed() {
             "a.yaml",
             "b.yaml",
             "c.yaml",
+            "--format",
+            "text",
         ])
         .output()
         .expect("spawn debundle");
@@ -166,6 +172,8 @@ fn dry_run_prints_verdict_without_deleting() {
             root.to_str().unwrap(),
             "ui/empty.yaml",
             "--dry-run",
+            "--format",
+            "text",
         ])
         .output()
         .expect("spawn debundle");

--- a/devinfra/js/debundle/e2e/support.rs
+++ b/devinfra/js/debundle/e2e/support.rs
@@ -650,6 +650,9 @@ pub struct Fixture {
 pub struct RejectedFixture {
     pub stderr: String,
     pub report_root: PathBuf,
+    /// The `write_js_tree` output root, exposed so dry-run callers can
+    /// assert the no-output contract (only `reports/` may exist).
+    pub out_root: PathBuf,
     // Held to keep the tempdir alive for the duration of assertions.
     _root: TempDir,
 }
@@ -734,12 +737,25 @@ pub fn expect_rejection_containing_all(opts: FixtureOpts<'_>, required_substring
 }
 
 pub fn run_rejection_fixture(opts: FixtureOpts<'_>) -> RejectedFixture {
+    run_rejection_fixture_with_args(opts, &[])
+}
+
+/// Like [`run_rejection_fixture`] but with `debundle run --dry-run`.
+/// Dry-run skips all emitted-JS and accept-path report writes but
+/// still materializes rejection evidence (`owner_graph.json` +
+/// `cycles.json` / `atomic_unit_conflicts.json`) under the standard
+/// per-chunk report layout.
+pub fn run_dry_run_rejection_fixture(opts: FixtureOpts<'_>) -> RejectedFixture {
+    run_rejection_fixture_with_args(opts, &["--dry-run"])
+}
+
+fn run_rejection_fixture_with_args(opts: FixtureOpts<'_>, extra_args: &[&str]) -> RejectedFixture {
     let setup = setup_fixture(&opts);
     let spec_path = setup.root.path().join("transform_spec.yaml");
     let spec = build_spec(&opts, &setup);
     write_yaml_file(&spec_path, &spec);
 
-    let result = spawn_transform(&spec_path);
+    let result = spawn_transform_with_args(&spec_path, extra_args);
     assert!(
         !result.status.success(),
         "expected spec to be rejected\nstdout:\n{}\nstderr:\n{}",
@@ -749,6 +765,7 @@ pub fn run_rejection_fixture(opts: FixtureOpts<'_>) -> RejectedFixture {
     RejectedFixture {
         stderr: result.stderr,
         report_root: setup.report_root,
+        out_root: setup.out_root,
         _root: setup.root,
     }
 }
@@ -1075,6 +1092,21 @@ pub struct CommandResult {
 
 fn spawn_transform(spec_path: &Path) -> CommandResult {
     run_debundler(spec_path, &[])
+}
+
+fn spawn_transform_with_args(spec_path: &Path, extra_args: &[&str]) -> CommandResult {
+    let bin = debundler_path();
+    let mut command = Command::new(&bin);
+    command.arg("run").arg("--spec").arg(spec_path);
+    command.args(extra_args);
+    let output = command
+        .output()
+        .unwrap_or_else(|e| panic!("spawn debundler {}: {e}", bin.display()));
+    CommandResult {
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        status: output.status,
+    }
 }
 
 /// Run `debundle run --spec <path> [--package-root <name>=<dir> ...]` and return its

--- a/devinfra/js/debundle/lowering/materialize/mod.rs
+++ b/devinfra/js/debundle/lowering/materialize/mod.rs
@@ -24,7 +24,7 @@ pub(super) struct ChunkContext<'a> {
     pub(super) chunk_id: &'a str,
     pub(super) file: Option<&'a str>,
     pub(super) target_dir: &'a str,
-    pub(super) report_out_dir: Option<&'a Path>,
+    pub(super) report_emission: &'a ReportEmission,
     /// Program-level cross-module purity output; this chunk's entries land
     /// in `AnalysisHints::imported_purities` / `declared_pure_members`.
     pub(super) cross_module_purities: &'a super::cross_module::CrossModulePurities,
@@ -74,7 +74,7 @@ pub(super) fn materialize_logical_chunk(
         chunk_id,
         file,
         target_dir,
-        report_out_dir,
+        report_emission,
         cross_module_purities,
     } = context;
     let ChunkSpec {
@@ -318,7 +318,7 @@ pub(super) fn materialize_logical_chunk(
     });
     validate_and_emit_reports(
         chunk_id,
-        report_out_dir,
+        report_emission,
         &factorization,
         &factorization_report,
         &mut timings,
@@ -532,13 +532,28 @@ fn collect_analysis_hints(
 /// Write per-chunk validation reports (owner graph, atomic-unit
 /// conflicts, cycles) and bail with a human-readable summary when
 /// the spec is unrealizable.
+///
+/// Under [`ReportEmission::OnRejection`] (the `debundle run
+/// --dry-run` mode) the accept path writes nothing, but a rejection
+/// still writes `owner_graph.json` plus the rejection evidence so
+/// the documented `debundle gate list/describe` follow-up works.
 fn validate_and_emit_reports(
     chunk_id: &str,
-    report_out_dir: Option<&Path>,
+    report_emission: &ReportEmission,
     factorization: &ChunkFactorization,
     factorization_report: &::gate::FactorizationReport,
     timings: &mut PhaseTimings,
 ) -> Result<()> {
+    let rejected = !factorization_report.atomic_unit_conflicts.is_empty()
+        || !factorization_report.cycles.is_empty();
+    // Full mode writes the owner graph unconditionally; OnRejection
+    // writes it only alongside rejection evidence (`gate describe`
+    // recomputes per-edge blame from it).
+    let report_out_dir = if rejected {
+        report_emission.rejection_dir()
+    } else {
+        report_emission.full_dir()
+    };
     if let Some(report_out_dir) = report_out_dir {
         let owner_graph_report = time_phase!(timings, "build_owner_graph_report", {
             factorization.owner_graph_report()

--- a/devinfra/js/debundle/lowering/mod.rs
+++ b/devinfra/js/debundle/lowering/mod.rs
@@ -209,12 +209,47 @@ pub struct RequestedLogicalModule {
     pub residual: bool,
 }
 
+/// Where (and when) per-chunk validation reports are written.
+#[derive(Debug, Clone)]
+pub enum ReportEmission {
+    /// No reports.
+    None,
+    /// Write every per-chunk report (owner graph, modules report,
+    /// rejection evidence) under this root. The directory is prepared
+    /// (must be empty) up front.
+    Full(PathBuf),
+    /// Write reports only when the realizability gate rejects. Used by
+    /// `debundle run --dry-run`: the accept path writes nothing (the
+    /// no-output contract), but a rejection still materializes
+    /// `owner_graph.json` + `cycles.json` / `atomic_unit_conflicts.json`
+    /// so the documented `debundle gate list/describe` follow-up works.
+    OnRejection(PathBuf),
+}
+
+impl ReportEmission {
+    /// Root for accept-path reports (owner graph, modules report).
+    pub fn full_dir(&self) -> Option<&Path> {
+        match self {
+            Self::Full(dir) => Some(dir),
+            Self::None | Self::OnRejection(_) => None,
+        }
+    }
+
+    /// Root for rejection evidence (written on gate rejection).
+    pub fn rejection_dir(&self) -> Option<&Path> {
+        match self {
+            Self::Full(dir) | Self::OnRejection(dir) => Some(dir),
+            Self::None => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct MaterializeLogicalModulesOptions {
     pub chunk_ids: Vec<String>,
     pub file: Option<String>,
     pub prune_other_chunks: bool,
-    pub report_out_dir: Option<PathBuf>,
+    pub report_emission: ReportEmission,
     pub target_dir: String,
 }
 
@@ -240,10 +275,8 @@ pub fn materialize_logical_modules(
         }
     }
 
-    let mut report_out_dir = None;
-    if let Some(dir) = &options.report_out_dir {
+    if let Some(dir) = options.report_emission.full_dir() {
         prepare_output_dir(dir)?;
-        report_out_dir = Some(dir.clone());
     }
 
     if options.prune_other_chunks {
@@ -277,7 +310,7 @@ pub fn materialize_logical_modules(
                             chunk_id,
                             file: options.file.as_deref(),
                             target_dir: &target_dir,
-                            report_out_dir: report_out_dir.as_deref(),
+                            report_emission: &options.report_emission,
                             cross_module_purities: &cross_module_purities,
                         },
                         spec: ChunkSpec {
@@ -296,7 +329,7 @@ pub fn materialize_logical_modules(
     let mut applied = Vec::<SelectedModuleLowering>::new();
     let mut unmatched_spec_claims = Vec::<UnmatchedSpecClaim>::new();
     for chunk_result in &chunk_results {
-        if let Some(report_out_dir) = &report_out_dir {
+        if let Some(report_out_dir) = options.report_emission.full_dir() {
             write_chunk_report_json(
                 report_out_dir,
                 artifact.chunk_table.name(chunk_result.chunk_id),

--- a/devinfra/js/debundle/peel/plan.rs
+++ b/devinfra/js/debundle/peel/plan.rs
@@ -223,7 +223,7 @@ pub struct SourceSliceArgs {
     pub format: Option<OutputFormat>,
 }
 
-#[derive(Debug, Clone, ClapArgs)]
+#[derive(Debug, Clone, Default, ClapArgs)]
 pub struct SelectionArgs {
     /// Select one owner id from `owner_graph.json`.
     #[arg(long = "owner-id")]

--- a/devinfra/js/debundle/pipeline.rs
+++ b/devinfra/js/debundle/pipeline.rs
@@ -11,7 +11,10 @@ use artifact::load_js_chunks;
 use artifact::write_json;
 use artifact::{ChunkDecompositionOutput, ChunkId};
 use emit_harness::{EmitBrowserHarnessOptions, emit_browser_harness};
-use lowering::{MaterializeLogicalModulesOptions, UnmatchedSpecClaim, materialize_logical_modules};
+use lowering::{
+    MaterializeLogicalModulesOptions, ReportEmission, UnmatchedSpecClaim,
+    materialize_logical_modules,
+};
 use prepare_chunks::prepare_js_chunks;
 use rewrite_specifiers::rewrite_chunk_entry_specifiers;
 use spec::{MaterializeLogicalModulesConfig, TransformSpec, VendorLevel};
@@ -61,7 +64,9 @@ pub struct TransformArgs {
     #[arg(long = "tree-vendor-marks")]
     pub tree_vendor_marks: Option<PathBuf>,
     /// Root for source-relative paths embedded in the tree-shaped config YAML.
-    #[arg(long = "tree-source-root", env = "DEBUNDLE_SOURCE_ROOT")]
+    /// Deliberately NOT `DEBUNDLE_SOURCE_ROOT`: that env var is the query
+    /// commands' upstream-snapshot root, a different directory in real corpora.
+    #[arg(long = "tree-source-root", env = "DEBUNDLE_TREE_SOURCE_ROOT")]
     pub tree_source_root: Option<PathBuf>,
     /// Output root used when compiling tree-shaped authoring sources.
     #[arg(long = "out-root", env = "DEBUNDLE_OUT")]
@@ -214,10 +219,16 @@ pub fn run_transform_cli_with_options(
                     chunk_ids: materialise_chunk_ids,
                     file,
                     prune_other_chunks,
-                    report_out_dir: if options.dry_run {
-                        None
-                    } else {
-                        report_out_dir
+                    // Dry-run keeps the no-output contract on the
+                    // accept path but still materializes rejection
+                    // evidence (owner graph + cycles/conflicts) at the
+                    // same reports/tree/<chunk>/ location a real run
+                    // uses, so `debundle gate list/describe` works on
+                    // the rejection that was just reported.
+                    report_emission: match report_out_dir {
+                        Some(dir) if options.dry_run => ReportEmission::OnRejection(dir),
+                        Some(dir) => ReportEmission::Full(dir),
+                        None => ReportEmission::None,
                     },
                     target_dir,
                 },

--- a/devinfra/js/debundle/plans/sanitization_program_2026_06.md
+++ b/devinfra/js/debundle/plans/sanitization_program_2026_06.md
@@ -139,6 +139,11 @@ documented `gate list/describe` follow-up works; split
 `DEBUNDLE_SOURCE_ROOT`'s double meaning; `.ok()?` swallow and sentinel-hack
 fixes.
 
+_Status (2026-06-11): landed — structured rejections + shared
+`MutationOutcome` schema (`cli/outcome.rs`), rejection artifacts on
+edit-gate and `run --dry-run` rejections, `DEBUNDLE_TREE_SOURCE_ROOT`
+split, `.ok()?` and sentinel fixes. TODO section removed._
+
 ## Track F — test infrastructure (week 3)
 
 1. **Randomized differentials**: proptest-generated owner graphs +


### PR DESCRIPTION
Track E of the sanitization program — lands the entire TODO.md "CLI scripting surface" section (section deleted; Track E tombstoned in `plans/sanitization_program_2026_06.md`).

## What's in here

**1. Structured JSON gate rejections on stdout** (`cli/outcome.rs`, `cli/edit_gate.rs`)

When a JSON format is selected (explicit `--format json|ndjson`, or stdout is a pipe), edit-gate rejections print one structured object on stdout instead of leaving agents to scrape stderr prose:

```json
{ "verb": "merge", "action": "rejected", "rejection": { "kind": "unrealizable_cycles", "blocking_sccs": [...] } }
```

`rejection.kind` is `atom_split` (carrying `AtomicUnitConflictReport` rows) or `unrealizable_cycles` (carrying `BlockingSccEntry` rows) — the **same canonical wire shapes** `atomic_unit_conflicts.json` / `cycles.json` use; no parallel schema. The human blame report stays on stderr; exit stays non-zero. `gate_post_edit_partition` now bails with a typed `GateRejection` error the dispatchers downcast.

**2. `--format` parity + one shared outcome schema across the five mutating verbs**

`modules {merge,delete}` gain `--format`; all five verbs (`bindings {assign,unassign,rename}`, `modules {merge,delete}`) now serialize a `MutationOutcome` core — `verb` / `action` (`applied|dry-run|noop|unchanged`) / `gate` (`passed|names_only|skipped|not_required`) / `files_written` / `files_deleted` — with verb-specific fields (`moves_applied`, `unassigned`, `binding`/`old_readable`/`new_readable`, `target`) flattened alongside.

**3. Rejection artifacts for `gate list/describe`**

- Edit-gate rejections (including `--dry-run` probes) write `cycles.json` / `atomic_unit_conflicts.json` as siblings of `--graph` — the default location `gate list/describe/cut` resolve — and a passing gate clears stale artifacts.
- `debundle run --dry-run` keeps the no-output contract on the accept path, but a rejection now materializes `owner_graph.json` + rejection evidence under `reports/tree/<chunk>/` (new `ReportEmission::{None,Full,OnRejection}` enum replacing `report_out_dir: Option<PathBuf>`).

**4. `DEBUNDLE_SOURCE_ROOT` split**

`run --tree-source-root` (spec-tree compile root) now reads its own `DEBUNDLE_TREE_SOURCE_ROOT`; `DEBUNDLE_SOURCE_ROOT` keeps only the query commands' upstream-snapshot meaning. The two roots are different directories in real corpora. Docs updated (`docs/cli.md`, `docs/guide.md`, `README.md`); `pipeline.bzl` passes the flag explicitly and is unaffected; no skill references the old var.

**5. Error-handling cleanups**

- `resolve_id_as_module_path` propagates modules-tree walk errors instead of `.ok()?`-swallowing them into a binding-name guess.
- `selection_with_*` helper family replaced with `Default`-based struct literals; the proposal sentinel empty-string `binding_id` (and `run_describe`'s remember-to-clear hack) is gone.

## Tests

- New `e2e/cli_mutation_outcome_test.rs`: per-verb JSON outcome core, structured atom-split and cycle rejections parsed from stdout, on-disk artifact emission next to `--graph`, stale-artifact clearing on a passing gate, text-format opt-out.
- `e2e/gate_cli_test.rs`: `run --dry-run` rejection materializes gate artifacts; `gate list`/`gate describe` work on them; no JS tree emitted.
- Full suite: `bbr test //devinfra/js/debundle/...` — 101/101 pass (rebased on devel past #2112).

`BAZEL_TEST_INVOCATIONS=buildbuddy:4dc33eb3-e529-482d-a64e-65c2945d6ed2`

https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk)_