### PR TITLE
langfuse: wire Authentik SSO login (OIDC)

### DIFF
--- a/cluster/docs/sso.md
+++ b/cluster/docs/sso.md
@@ -10,7 +10,7 @@ TF owns the client_secret lifecycle — no Vault, no ESO, no `!Env` drift.
 **Secret flow**: TF creates provider → reads `client_secret` → writes `kubernetes_secret`
 in `authentik` namespace → Reflector mirrors to consumer namespace(s).
 
-**Currently managed**: grafana, headlamp, openclaw-agent.
+**Currently managed**: grafana, headlamp, openclaw-agent, props, langfuse.
 
 ### Blueprint-managed providers (deprecated)
 

--- a/cluster/k8s/langfuse/app/helmrelease.yaml
+++ b/cluster/k8s/langfuse/app/helmrelease.yaml
@@ -30,7 +30,12 @@ spec:
   values:
     langfuse:
       features:
-        signUpDisabled: true
+        # SSO-only: email/password login is disabled below via
+        # AUTH_DISABLE_USERNAME_PASSWORD. Signup must stay enabled so the
+        # Authentik-gated SSO flow can establish the session on first login;
+        # access is bounded by the langfuse application's admins-group policy
+        # binding in Authentik (tf/gitops/sso-providers/provider_langfuse.tf).
+        signUpDisabled: false
       nodeSelector:
         topology.kubernetes.io/zone: hil-ovh
       nextauth:
@@ -72,6 +77,33 @@ spec:
       additionalEnv:
         - name: NODE_OPTIONS
           value: "--max-old-space-size=1536"
+        # --- Authentik SSO (generic OIDC relying party) ---
+        # Client credentials come from the langfuse-oidc-config secret, minted
+        # by tf/gitops/sso-providers/provider_langfuse.tf in the authentik
+        # namespace and reflected here by emberstack reflector.
+        - name: AUTH_CUSTOM_NAME
+          value: "Authentik"
+        - name: AUTH_CUSTOM_ISSUER
+          value: "https://auth.allegedly.works/application/o/langfuse/"
+        - name: AUTH_CUSTOM_SCOPE
+          value: "openid email profile"
+        - name: AUTH_CUSTOM_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: langfuse-oidc-config
+              key: client-id
+        - name: AUTH_CUSTOM_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: langfuse-oidc-config
+              key: client-secret
+        # Link the SSO identity to the headless-init admin user (same email)
+        # so login lands on the existing org/project instead of an empty one.
+        - name: AUTH_CUSTOM_ALLOW_ACCOUNT_LINKING
+          value: "true"
+        # SSO-only: disable email/password login and signup entirely.
+        - name: AUTH_DISABLE_USERNAME_PASSWORD
+          value: "true"
         - name: LANGFUSE_INIT_ORG_ID
           value: "langfuse-default-org"
         - name: LANGFUSE_INIT_ORG_NAME
@@ -90,10 +122,13 @@ spec:
             secretKeyRef:
               name: langfuse-secrets
               key: LANGFUSE_INIT_PROJECT_SECRET_KEY
+        # Email matches the Authentik identity (agentydragon@gmail.com) so the
+        # SSO account links to this org owner. Headless init adds this user as
+        # an owner of langfuse-default-org on startup.
         - name: LANGFUSE_INIT_USER_EMAIL
-          value: "admin@allegedly.works"
+          value: "agentydragon@gmail.com"
         - name: LANGFUSE_INIT_USER_NAME
-          value: "admin"
+          value: "Rai"
         - name: LANGFUSE_INIT_USER_PASSWORD
           valueFrom:
             secretKeyRef:

--- a/tf/gitops/sso-providers/provider_langfuse.tf
+++ b/tf/gitops/sso-providers/provider_langfuse.tf
@@ -1,0 +1,71 @@
+# ============================================================================
+# Langfuse — OIDC login for the LLM observability dashboard
+# (langfuse.allegedly.works)
+#
+# Langfuse is a NextAuth relying party that speaks generic OIDC via its
+# AUTH_CUSTOM_* env vars. This provider mints the confidential client; the
+# client_id/secret are written to a K8s secret in the authentik namespace and
+# reflected into the langfuse namespace, where the HelmRelease consumes them as
+# AUTH_CUSTOM_CLIENT_ID / AUTH_CUSTOM_CLIENT_SECRET. Login is gated to the
+# admins group; email/password login is disabled in the chart (SSO-only).
+# ============================================================================
+
+resource "authentik_provider_oauth2" "langfuse" {
+  name               = "langfuse-oauth2"
+  client_id          = "langfuse"
+  client_type        = "confidential"
+  authorization_flow = data.authentik_flow.implicit_consent.id
+  invalidation_flow  = data.authentik_flow.invalidation.id
+  signing_key        = data.authentik_certificate_key_pair.self_signed.id
+
+  issuer_mode                = "per_provider"
+  include_claims_in_id_token = true
+
+  property_mappings = [
+    data.authentik_property_mapping_provider_scope.openid.id,
+    data.authentik_property_mapping_provider_scope.email.id,
+    data.authentik_property_mapping_provider_scope.profile.id,
+  ]
+
+  allowed_redirect_uris = [
+    {
+      matching_mode = "strict"
+      url           = "https://langfuse.allegedly.works/api/auth/callback/custom"
+    },
+  ]
+}
+
+resource "authentik_application" "langfuse" {
+  name              = "Langfuse"
+  slug              = "langfuse"
+  protocol_provider = authentik_provider_oauth2.langfuse.id
+  meta_description  = "LLM observability and tracing dashboard"
+  meta_launch_url   = "https://langfuse.allegedly.works"
+  meta_icon         = "https://cdn.simpleicons.org/langfuse"
+}
+
+# Gate login to the admins group (which contains agentydragon). Authentik is
+# the sole authentication path, so this binding is the access boundary.
+resource "authentik_policy_binding" "langfuse_admins" {
+  target = authentik_application.langfuse.uuid
+  group  = data.authentik_group.admins.id
+  order  = 0
+}
+
+resource "kubernetes_secret" "langfuse_oidc" {
+  metadata {
+    name      = "langfuse-oidc-config"
+    namespace = "authentik"
+    annotations = {
+      "reflector.v1.k8s.emberstack.com/reflection-allowed"            = "true"
+      "reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces" = "langfuse"
+      "reflector.v1.k8s.emberstack.com/reflection-auto-enabled"       = "true"
+      "reflector.v1.k8s.emberstack.com/reflection-auto-namespaces"    = "langfuse"
+    }
+  }
+
+  data = {
+    client-id     = authentik_provider_oauth2.langfuse.client_id
+    client-secret = authentik_provider_oauth2.langfuse.client_secret
+  }
+}


### PR DESCRIPTION
## Problem

`langfuse.allegedly.works` only exposed email/password login — no SSO button at all — violating the cluster's "SSO required for all in-scope applications" directive. There was no Authentik OAuth2 provider for langfuse in `tf/gitops/sso-providers/`, and the HelmRelease had no `AUTH_CUSTOM_*` wiring.

## Changes

- **`tf/gitops/sso-providers/provider_langfuse.tf`** (new) — TF-managed Authentik confidential OAuth2 provider + application `langfuse`, gated to the admins group, redirect URI `…/api/auth/callback/custom`. Mirrors the props/grafana pattern: client credentials are written to a `langfuse-oidc-config` secret in the `authentik` namespace and reflected into the `langfuse` namespace by emberstack reflector.
- **`cluster/k8s/langfuse/app/helmrelease.yaml`** — wired langfuse as a generic OIDC relying party:
  - `AUTH_CUSTOM_*` env vars (issuer `https://auth.allegedly.works/application/o/langfuse/`, client id/secret from the reflected secret).
  - **SSO-only**: `AUTH_DISABLE_USERNAME_PASSWORD=true` disables email/password; `signUpDisabled: false` so the Authentik-gated SSO flow can establish the session (access bounded by the admins-group policy binding).
  - **Identity mapping**: repointed `LANGFUSE_INIT_USER_EMAIL` → `agentydragon@gmail.com` and enabled `AUTH_CUSTOM_ALLOW_ACCOUNT_LINKING=true`, so the SSO identity links to the existing `langfuse-default-org` owner (keeps access to the litellm project/traces) instead of an empty workspace.
- **`cluster/docs/sso.md`** — added langfuse to the TF-managed provider list.

## Validation

- `//tf/gitops/sso-providers:{validate,lint}` (terraform validate + tflint) — pass
- pre-commit: kubeconform, checkov, tflint, prettier, markdownlint — pass
- No Bazel test targets depend on the changed files (langfuse YAML isn't in any Bazel package; TF module is gated by build-time validate/lint).

## Rollout note

Applies via GitOps once on `devel`: the tofu-controller `Terraform` CR creates the Authentik provider + `langfuse-oidc-config` secret, the reflector mirrors it into the `langfuse` namespace, and Flux rolls the HelmRelease. Until the reflector populates the secret, langfuse-web may briefly show `CreateContainerConfigError` (same eventual-consistency behavior as props/grafana).

https://claude.ai/code/session_01TiN3GUKz5gWgJJb56w3KSu

---
_Generated by [Claude Code](https://claude.ai/code/session_01TiN3GUKz5gWgJJb56w3KSu)_