### PR TITLE
debundle: scope local property writes as LocalEffect (opt-in)

### DIFF
--- a/devinfra/js/debundle/README.md
+++ b/devinfra/js/debundle/README.md
@@ -227,6 +227,19 @@ import of one of these names disables its global treatment chunk-wide.
 See `docs/design.md` → "Emission modes" for the precise dataflow-aware
 emission rule (including the write-after-read edges).
 
+The second such pass is local-property-write effect scoping, opted into
+per chunk via `chunk_analysis_options.<chunk_id>.local_property_effects`.
+A whole statement of the shape `X.prop = <pure-rhs>;` (or a
+comma-sequence of such) where `X` is a chunk-top declared binding — the
+React `C.displayName = "…"` annotation idiom — classifies as a local
+effect on `X` (Pure + a bidirectional `LocalEffect` co-location edge to
+`X`'s declaration) instead of joining the S-chain. Statements outside
+the shape (compound assignment, computed non-literal keys, `__proto__`
+segments, impure RHS, writes through imports) keep the conservative
+classification. The author-audited precondition is documented on the
+spec field (`spec::OwnerGraphOptions::local_property_effects`) and in
+`docs/design.md` → A10.
+
 ## Input-chunk admission checks
 
 Every materialized chunk is screened against the statically checkable

--- a/devinfra/js/debundle/analysis_hints.rs
+++ b/devinfra/js/debundle/analysis_hints.rs
@@ -20,6 +20,14 @@ pub enum LocalEffectPolicy {
     #[default]
     KnownEffectsOnly,
     VendorPrune,
+    /// Recognize whole-statement local property writes —
+    /// `X.prop = <pure>;` where `X` is a chunk-top declared binding —
+    /// as a local effect on `X` instead of a globally-ordered side
+    /// effect. Opt-in via
+    /// `chunk_analysis_options.<chunk>.local_property_effects`; see
+    /// that field's doc (`spec::OwnerGraphOptions`) for the soundness
+    /// precondition the spec author accepts.
+    LocalPropertyWrites,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/devinfra/js/debundle/analysis_tests/mod.rs
+++ b/devinfra/js/debundle/analysis_tests/mod.rs
@@ -418,6 +418,95 @@ fn vendor_prune_policy_records_static_object_local_effects() {
     assert!(vendor_facts[1].purity.is_pure());
 }
 
+/// Analyze under `LocalEffectPolicy::LocalPropertyWrites`.
+fn analyze_facts_with_property_writes(module: &Module) -> Vec<StatementFacts> {
+    let hints = AnalysisHints {
+        local_effect_policy: LocalEffectPolicy::LocalPropertyWrites,
+        ..AnalysisHints::default()
+    };
+    analyze_facts_with_hints(module, &hints)
+}
+
+#[test]
+fn local_property_writes_policy_scopes_annotation_write_to_declarer() {
+    // The React annotation idiom: `C.displayName = "..."` right after
+    // the component declaration. Under the policy the write is a local
+    // effect on `C` (statement classifies Pure, LocalEffect edge keeps
+    // it co-located with the declarer); under the default policy it
+    // stays a globally-ordered impure statement.
+    let module = parse(r#"function C() { return 1; } C.displayName = "C";"#);
+    let default_facts = analyze_facts(&module);
+    assert!(default_facts[1].local_effects.is_empty());
+    assert!(!default_facts[1].purity.is_pure());
+
+    let facts = analyze_facts_with_property_writes(&module);
+    assert_eq!(facts[1].local_effects, BTreeSet::from([test_id("C")]));
+    assert!(facts[1].purity.is_pure());
+}
+
+#[test]
+fn local_property_writes_policy_handles_comma_sequences_and_nested_paths() {
+    // Minified annotation runs comma-join writes; a nested static
+    // path (`C.propTypes.id`) still roots at `C`.
+    let module = parse(
+        r#"function C() { return 1; } function D() { return 2; }
+(C.displayName = "C", D.propTypes.id = 1);"#,
+    );
+    let facts = analyze_facts_with_property_writes(&module);
+    assert_eq!(
+        facts[2].local_effects,
+        BTreeSet::from([test_id("C"), test_id("D")])
+    );
+    assert!(facts[2].purity.is_pure());
+}
+
+#[test]
+fn local_property_writes_policy_rejects_disqualifying_shapes() {
+    // Each statement must fall back to the conservative path: compound
+    // assignment (reads the property — getter risk on a
+    // written-through object), impure RHS, computed non-literal key,
+    // `__proto__` segment (prototype rewiring, not a data-property
+    // effect), and a write through an IMPORT (mutates another module's
+    // value — must stay globally ordered).
+    let module = parse(
+        r#"import { ext } from "./other.js";
+function C() { return 1; }
+const key = "k";
+C.count += 1;
+C.x = io();
+C[key] = 1;
+C.__proto__.hack = 1;
+ext.tag = "t";"#,
+    );
+    let facts = analyze_facts_with_property_writes(&module);
+    for (ordinal, label) in [
+        (3, "compound assignment"),
+        (4, "impure RHS"),
+        (5, "computed non-literal key"),
+        (6, "__proto__ segment"),
+        (7, "import-rooted write"),
+    ] {
+        assert!(
+            facts[ordinal].local_effects.is_empty(),
+            "{label} must not be recognized"
+        );
+        assert!(
+            !facts[ordinal].purity.is_pure(),
+            "{label} must stay conservatively impure"
+        );
+    }
+}
+
+#[test]
+fn local_property_writes_policy_admits_string_literal_computed_key() {
+    // A string-literal computed key (`C["k"]`) is a static name —
+    // same admission as the vendor recognizers' `static_member_name`.
+    let module = parse(r#"function C() { return 1; } C["k"] = 1;"#);
+    let facts = analyze_facts_with_property_writes(&module);
+    assert_eq!(facts[1].local_effects, BTreeSet::from([test_id("C")]));
+    assert!(facts[1].purity.is_pure());
+}
+
 #[test]
 fn vendor_prune_policy_records_intrinsic_alias_local_effects() {
     let module = parse(

--- a/devinfra/js/debundle/docs/design.md
+++ b/devinfra/js/debundle/docs/design.md
@@ -1154,6 +1154,24 @@ member names`, it projects onto each importing chunk's local binding
   same review burden as `purity: "pure"`; the difference is that the
   trusted claim is local target mutation, not absence of effects.
 
+  `chunk_analysis_options.<chunk>.local_property_effects` is the
+  chunk-wide structural sibling of the same idea, for plain
+  data-property annotation writes rather than helper calls: a whole
+  statement of the shape `X.prop = <pure-rhs>;` (or a comma-sequence of
+  such), where every member-path segment is a static non-`__proto__`
+  name and `X` is a chunk-top declared binding, is classified as a
+  local effect on `X` instead of a globally-ordered side effect — the
+  React `C.displayName = "…"` / `C.defaultProps = {…}` idiom. The
+  statement gets the same target-local co-location edge as the
+  decorator helper (it cannot be split away from `X`'s declaration) and
+  leaves the side-effect chain. Anything outside the shape — compound
+  assignment, computed non-literal key, impure RHS, a write through an
+  import — keeps conservative classification. The flag's soundness
+  precondition (no cross-destination top-level read of an annotated
+  binding's properties textually before the write) is documented on the
+  spec field and is the author's audit obligation, like every entry in
+  this section.
+
 - **A11. Intrinsic integrity: the chunk runs with unmodified
   built-in prototypes and intrinsics.** Every purity-whitelist
   admission argument cites ECMA-262 behavior of the _standard_

--- a/devinfra/js/debundle/e2e/chunk_rename_cross_module_test.rs
+++ b/devinfra/js/debundle/e2e/chunk_rename_cross_module_test.rs
@@ -29,6 +29,7 @@ fn chunk_rename_propagates_into_peeled_module_body() {
     // The renaming MUST propagate to b_module.js: its import line
     // and its `const b = cx();` callsite both need the new alias.
     let opts = FixtureOpts {
+        local_property_effects: false,
         chunk_export_purity: &[],
         extra_chunks: &[],
         source: r#"import { f as cx } from "./vendor.js";

--- a/devinfra/js/debundle/e2e/cross_module_emission_test.rs
+++ b/devinfra/js/debundle/e2e/cross_module_emission_test.rs
@@ -619,6 +619,7 @@ fn residual_public_export_name_does_not_capture_unrelated_chunk_renamed_import()
     // The entry import must therefore be `B as entryHelper`, not
     // `B as vendorHelper`.
     let opts = FixtureOpts {
+        local_property_effects: false,
         chunk_export_purity: &[],
         extra_chunks: &[],
         source: r#"import { o as B } from "./vendor.js";

--- a/devinfra/js/debundle/e2e/mini_factors_test.rs
+++ b/devinfra/js/debundle/e2e/mini_factors_test.rs
@@ -18,6 +18,7 @@ export const b = 2;
 #[test]
 fn catchall_keeps_unclaimed_bindings_in_residual() {
     let opts = FixtureOpts {
+        local_property_effects: false,
         chunk_export_purity: &[],
         extra_chunks: &[],
         source: FIXTURE_SOURCE,
@@ -47,6 +48,7 @@ fn catchall_keeps_unclaimed_bindings_in_residual() {
 #[test]
 fn mini_factors_synthesizes_one_module_per_unclaimed_unit() {
     let opts = FixtureOpts {
+        local_property_effects: false,
         chunk_export_purity: &[],
         extra_chunks: &[],
         source: FIXTURE_SOURCE,

--- a/devinfra/js/debundle/e2e/purity_test.rs
+++ b/devinfra/js/debundle/e2e/purity_test.rs
@@ -949,6 +949,7 @@ fn chunk_rename_with_purity_pure_propagates_to_call_classifier() {
     //   declared_pure → cx() is Pure → b is Pure → no S-chain
     //   participation. Only edge: residual → b_module. DAG.
     let opts = FixtureOpts {
+        local_property_effects: false,
         chunk_export_purity: &[],
         extra_chunks: &[],
         source: r#"import { f as cx } from "./vendor.js";
@@ -1323,4 +1324,80 @@ fn asserted_fluent_export_chains_emit_no_s_cycle() {
         .with_chunk_export_purity(&[("static/vendorlib", json!({ "fluent_exports": ["e4"] }))]),
     );
     assert!(fixture.entry_path.exists());
+}
+
+/// React annotation idiom: each component declaration is followed by
+/// a `displayName` data-property write. The writes are anonymous
+/// statements (no declared bindings) whose only effect is on the
+/// component binding directly above them.
+const ANNOTATION_WRITE_ENTRY: &str = r#"function A() { return 1; }
+A.displayName = "A";
+function B() { return 2; }
+B.displayName = "B";
+function C() { return 3; }
+C.displayName = "C";
+console.log(A, B, C);
+export { A, B, C };
+"#;
+
+/// The natural spec for [`ANNOTATION_WRITE_ENTRY`]: each component
+/// goes to its module WITH its annotation write (anonymous-statement
+/// claims). Both policy tests share it; only the flag differs.
+fn annotation_write_modules() -> Vec<LogicalModuleEntry> {
+    vec![
+        logical_module_with_anon(
+            "mod_a",
+            &[Member::new("A"), Member::new("C")],
+            &[r#"A.displayName = "A";"#, r#"C.displayName = "C";"#],
+        ),
+        logical_module_with_anon("mod_b", &[Member::new("B")], &[r#"B.displayName = "B";"#]),
+    ]
+}
+
+#[test]
+fn annotation_property_writes_without_policy_emit_s_cycle() {
+    // Baseline pin: under the default policy every `X.displayName = …`
+    // is an `assign_or_update` impure statement; the S-chain forces
+    // their source order across the interleaved destinations
+    // (mod_a → mod_b → mod_a), which cycles — even though each write
+    // is claimed right next to its component.
+    expect_rejection(
+        FixtureOpts::new(ANNOTATION_WRITE_ENTRY, annotation_write_modules()),
+        &["cycle", "mod_a", "mod_b", "side-effect"],
+    );
+}
+
+#[test]
+fn annotation_property_writes_with_policy_co_locate_and_realize() {
+    // Same spec, flag on: the writes classify Pure with a LocalEffect
+    // on their component binding; the claims agree with the forced
+    // co-location, only `console.log` remains impure, no S-cycle.
+    let fixture = run_fixture(
+        FixtureOpts::new(ANNOTATION_WRITE_ENTRY, annotation_write_modules())
+            .with_local_property_effects(),
+    );
+    assert!(fixture.entry_path.exists());
+}
+
+#[test]
+fn annotation_property_write_cannot_be_split_from_its_declarer() {
+    // Constraint-preservation pin: the policy scopes the effect, it
+    // does not erase it. Claiming the write into a DIFFERENT module
+    // than its target binding still conflicts — the LocalEffect edge
+    // forces co-location with the declarer.
+    expect_rejection(
+        FixtureOpts::new(
+            ANNOTATION_WRITE_ENTRY,
+            vec![
+                logical_module("mod_a", &[Member::new("A"), Member::new("C")]),
+                logical_module_with_anon(
+                    "mod_b",
+                    &[Member::new("B")],
+                    &[r#"A.displayName = "A";"#],
+                ),
+            ],
+        )
+        .with_local_property_effects(),
+        &["atomic", "cycle", "co-locate"],
+    );
 }

--- a/devinfra/js/debundle/e2e/residual_member_rename_test.rs
+++ b/devinfra/js/debundle/e2e/residual_member_rename_test.rs
@@ -16,6 +16,7 @@ use debundle_e2e_support::*;
 #[test]
 fn logical_module_at_catchall_target_renames_and_absorbs_overflow() {
     let opts = FixtureOpts {
+        local_property_effects: false,
         chunk_export_purity: &[],
         extra_chunks: &[],
         source: r#"function a() { return 1; }

--- a/devinfra/js/debundle/e2e/support.rs
+++ b/devinfra/js/debundle/e2e/support.rs
@@ -527,6 +527,11 @@ pub struct FixtureOpts<'a> {
     /// (`chunk_analysis_options.<chunk>.admission_overrides`), e.g.
     /// `&["a1_eval"]`. Default empty — all admission checks enforced.
     pub admission_overrides: &'a [&'a str],
+    /// Opt into local-property-write effect scoping for this chunk
+    /// (`chunk_analysis_options.<chunk>.local_property_effects`).
+    /// Default `false` — property writes stay globally-ordered side
+    /// effects.
+    pub local_property_effects: bool,
     pub extra_files: &'a [(&'a str, &'a str)],
     /// Additional input chunks `(snapshot-relative path, source)` listed in
     /// `js-files.txt` alongside the entry chunk. Unlike `extra_files`
@@ -555,6 +560,7 @@ impl<'a> FixtureOpts<'a> {
             unassigned_mode: unassigned_mode_catchall_file(None),
             dataflow_aware_s_chain: false,
             admission_overrides: &[],
+            local_property_effects: false,
             extra_files: &[],
             extra_chunks: &[],
             chunk_export_purity: &[],
@@ -586,6 +592,13 @@ impl<'a> FixtureOpts<'a> {
     /// `chunk_analysis_options:` in YAML.
     pub fn with_dataflow_aware_s_chain(mut self) -> Self {
         self.dataflow_aware_s_chain = true;
+        self
+    }
+
+    /// Enable local-property-write effect scoping for this chunk (see
+    /// the `local_property_effects` field).
+    pub fn with_local_property_effects(mut self) -> Self {
+        self.local_property_effects = true;
         self
     }
 
@@ -982,6 +995,9 @@ fn build_spec<'a>(opts: &FixtureOpts<'_>, setup: &'a FixtureSetup) -> TransformS
     let mut analysis_options = serde_json::Map::new();
     if opts.dataflow_aware_s_chain {
         analysis_options.insert("dataflow_aware_s_chain".to_string(), Value::Bool(true));
+    }
+    if opts.local_property_effects {
+        analysis_options.insert("local_property_effects".to_string(), Value::Bool(true));
     }
     if !opts.admission_overrides.is_empty() {
         analysis_options.insert(

--- a/devinfra/js/debundle/facts/local_effects.rs
+++ b/devinfra/js/debundle/facts/local_effects.rs
@@ -7,10 +7,17 @@ use swc_ecma_ast::*;
 
 use super::{TopLevelItemView, collect_declared_names, var_decl_of_item};
 use crate::analysis_hints::LocalEffectPolicy;
+use crate::purity::{ChunkCodeGraph, classify_expr_purity};
 
 #[derive(Debug, Default)]
 pub(crate) struct LocalEffectContext {
-    vendor_prune_declared_bindings: BTreeSet<Id>,
+    /// Chunk-top declared binding names. Populated under both
+    /// non-default policies: `VendorPrune` uses it to scope its
+    /// recognizers' write targets, `LocalPropertyWrites` to require
+    /// the written-through root to be chunk-declared (a property
+    /// write through an *import* mutates another module's value and
+    /// stays a globally-ordered effect).
+    declared_bindings: BTreeSet<Id>,
     vendor_prune_commonjs_module_bindings: BTreeSet<Id>,
     vendor_prune_intrinsic_local_effect_callees: BTreeSet<Id>,
 }
@@ -20,14 +27,19 @@ impl LocalEffectContext {
         body: &[TopLevelItemView<'_>],
         local_effect_policy: LocalEffectPolicy,
     ) -> Self {
-        if local_effect_policy != LocalEffectPolicy::VendorPrune {
-            return Self::default();
-        }
         let mut context = Self::default();
+        if local_effect_policy == LocalEffectPolicy::KnownEffectsOnly {
+            return context;
+        }
         for item in body {
             context
-                .vendor_prune_declared_bindings
+                .declared_bindings
                 .extend(collect_declared_names(item.as_module_item()));
+        }
+        if local_effect_policy != LocalEffectPolicy::VendorPrune {
+            return context;
+        }
+        for item in body {
             context
                 .vendor_prune_commonjs_module_bindings
                 .extend(vendor_prune_commonjs_module_bindings(item.as_module_item()));
@@ -45,6 +57,109 @@ impl LocalEffectContext {
 
     pub(crate) fn local_effect_targets(&self, item: &ModuleItem) -> BTreeSet<Id> {
         vendor_prune_local_effect_targets(item, self)
+    }
+
+    /// Recognize a whole-statement local property write under
+    /// `LocalEffectPolicy::LocalPropertyWrites`: an expression
+    /// statement that is one `X.prop = <pure-rhs>` assignment (or a
+    /// comma-sequence of such), every member-path segment a static
+    /// non-`__proto__` name, every root `X` a chunk-top declared
+    /// binding, every RHS classifier-Pure. Returns the set of written
+    /// roots (the statement's local-effect targets), or empty when any
+    /// part of the statement falls outside that shape — partial
+    /// recognition would under-account the unrecognized remainder's
+    /// effects, so it's all or nothing (same contract as the
+    /// VendorPrune recognizers).
+    ///
+    /// The RHS check uses the strict expression classifier rather than
+    /// the vendor recognizers' structural `namespace_iife_local_init_is_pure`
+    /// — a getter-bearing RHS read (`X.a = Y.b`) must disqualify, and
+    /// the classifier is the component that proves that.
+    pub(crate) fn local_property_write_targets(
+        &self,
+        item: &ModuleItem,
+        shadowed: &BTreeSet<&'static str>,
+        declared_pure: &BTreeSet<String>,
+        graph: &ChunkCodeGraph,
+    ) -> BTreeSet<Id> {
+        let ModuleItem::Stmt(Stmt::Expr(expr_stmt)) = item else {
+            return BTreeSet::new();
+        };
+        let mut targets = BTreeSet::new();
+        if self.collect_local_property_writes(
+            &expr_stmt.expr,
+            shadowed,
+            declared_pure,
+            graph,
+            &mut targets,
+        ) && !targets.is_empty()
+        {
+            targets
+        } else {
+            BTreeSet::new()
+        }
+    }
+
+    fn collect_local_property_writes(
+        &self,
+        expr: &Expr,
+        shadowed: &BTreeSet<&'static str>,
+        declared_pure: &BTreeSet<String>,
+        graph: &ChunkCodeGraph,
+        targets: &mut BTreeSet<Id>,
+    ) -> bool {
+        match strip_parens(expr) {
+            Expr::Seq(seq) => seq.exprs.iter().all(|expr| {
+                self.collect_local_property_writes(expr, shadowed, declared_pure, graph, targets)
+            }),
+            // Plain `=` only: a compound assignment (`+=` etc.) also
+            // READS the property, and a read on a written-through (so
+            // non-PlainData) object may fire a getter.
+            Expr::Assign(assign) if assign.op == AssignOp::Assign => {
+                let AssignTarget::Simple(SimpleAssignTarget::Member(member)) = &assign.left else {
+                    return false;
+                };
+                let Some(root) = static_member_write_root(member) else {
+                    return false;
+                };
+                if !self.declared_bindings.contains(&root) {
+                    return false;
+                }
+                if !classify_expr_purity(
+                    &assign.right,
+                    shadowed,
+                    &BTreeSet::new(),
+                    declared_pure,
+                    graph,
+                )
+                .is_pure()
+                {
+                    return false;
+                }
+                targets.insert(root);
+                true
+            }
+            _ => false,
+        }
+    }
+}
+
+/// The root identifier of a member-write target whose every path
+/// segment (including the final written property) is a static name
+/// and none is `__proto__` (a `__proto__` write rewires the prototype
+/// chain — not a plain data-property effect on the root). `None` for
+/// computed non-literal segments or a non-`Ident` root.
+fn static_member_write_root(member: &MemberExpr) -> Option<Id> {
+    if static_member_name(&member.prop)
+        .as_deref()
+        .is_none_or(|prop| prop == "__proto__")
+    {
+        return None;
+    }
+    match strip_parens(&member.obj) {
+        Expr::Ident(root) => Some(root.to_id()),
+        Expr::Member(inner) => static_member_write_root(inner),
+        _ => None,
     }
 }
 
@@ -360,14 +475,12 @@ fn vendor_prune_expr_local_effect_targets(
 ) -> BTreeSet<Id> {
     match strip_parens(expr) {
         Expr::Assign(assign) => {
-            let mut recorder =
-                LocalEffectRecorder::new(&local_effect_context.vendor_prune_declared_bindings);
+            let mut recorder = LocalEffectRecorder::new(&local_effect_context.declared_bindings);
             record_assign_target(&assign.left, &mut recorder);
             recorder.local_effects
         }
         Expr::Update(update) => {
-            let mut recorder =
-                LocalEffectRecorder::new(&local_effect_context.vendor_prune_declared_bindings);
+            let mut recorder = LocalEffectRecorder::new(&local_effect_context.declared_bindings);
             record_update_target(&update.arg, &mut recorder);
             recorder.local_effects
         }
@@ -436,10 +549,7 @@ fn vendor_prune_inline_namespace_iife_target(
         return None;
     }
     let target = local_namespace_iife_arg_target(&call.args[0].expr)?;
-    if !local_effect_context
-        .vendor_prune_declared_bindings
-        .contains(&target)
-    {
+    if !local_effect_context.declared_bindings.contains(&target) {
         return None;
     }
     let Callee::Expr(callee) = &call.callee else {

--- a/devinfra/js/debundle/facts/mod.rs
+++ b/devinfra/js/debundle/facts/mod.rs
@@ -758,12 +758,7 @@ fn assemble_statement_facts(
         cell_writes_summarizable,
         dataflow_summarizable,
     } = structural;
-    let local_effects = collect_local_effects(
-        item,
-        &hints.known_effects,
-        local_effect_context,
-        hints.local_effect_policy,
-    );
+    let local_effects = collect_local_effects(item, shadowed, hints, graph, local_effect_context);
     let purity = item_purity(
         item,
         kind,
@@ -1025,16 +1020,28 @@ fn item_purity(
 
 fn collect_local_effects(
     item: &ModuleItem,
-    known_effects: &BTreeMap<String, KnownEffect>,
+    shadowed: &BTreeSet<&'static str>,
+    hints: &AnalysisHints,
+    graph: &ChunkCodeGraph,
     local_effect_context: &local_effects::LocalEffectContext,
-    local_effect_policy: LocalEffectPolicy,
 ) -> BTreeSet<Id> {
     let mut out = BTreeSet::new();
-    if let Some(target) = recognized_local_effect_target(item, known_effects) {
+    if let Some(target) = recognized_local_effect_target(item, &hints.known_effects) {
         out.insert(target);
     }
-    if local_effect_policy == LocalEffectPolicy::VendorPrune {
-        out.extend(local_effect_context.local_effect_targets(item));
+    match hints.local_effect_policy {
+        LocalEffectPolicy::KnownEffectsOnly => {}
+        LocalEffectPolicy::VendorPrune => {
+            out.extend(local_effect_context.local_effect_targets(item));
+        }
+        LocalEffectPolicy::LocalPropertyWrites => {
+            out.extend(local_effect_context.local_property_write_targets(
+                item,
+                shadowed,
+                &hints.declared_pure,
+                graph,
+            ));
+        }
     }
     out
 }

--- a/devinfra/js/debundle/lowering/materialize/mod.rs
+++ b/devinfra/js/debundle/lowering/materialize/mod.rs
@@ -182,6 +182,12 @@ pub(super) fn materialize_logical_chunk(
     )?;
     timings.add("build_module_plans", build_module_plans_started.elapsed());
 
+    // Fetched before hints assembly: `local_property_effects` selects
+    // the facts pass's local-effect policy, which travels in the hints.
+    let owner_graph_options = chunk_analysis_options
+        .get(chunk_id)
+        .copied()
+        .unwrap_or_default();
     let analysis_hints: AnalysisHints = time_phase!(timings, "collect_analysis_hints", {
         let mut hints = collect_analysis_hints(&explicit_requests, chunk_renames.get(chunk_id));
         hints.imported_purities = cross_module_purities
@@ -206,6 +212,9 @@ pub(super) fn materialize_logical_chunk(
         if let Some(fluent) = cross_module_purities.fluent.get(chunk_id) {
             hints.fluent_bindings.extend(fluent.iter().cloned());
         }
+        if owner_graph_options.local_property_effects {
+            hints.local_effect_policy = LocalEffectPolicy::LocalPropertyWrites;
+        }
         hints
     });
     let line_index = time_phase!(timings, "build_source_line_index", {
@@ -213,10 +222,6 @@ pub(super) fn materialize_logical_chunk(
     });
     // Stage A: spec-independent analysis (facts + owner graph +
     // structural atomic units). See `stage_one/mod.rs` for the composer.
-    let owner_graph_options = chunk_analysis_options
-        .get(chunk_id)
-        .copied()
-        .unwrap_or_default();
     // A3 admission resolver: where does a dynamic-import specifier in
     // this chunk's entry land? Same artifact resolution the specifier
     // rewriter uses; `SameChunk` marks a debundled internal module.

--- a/devinfra/js/debundle/lowering/mod.rs
+++ b/devinfra/js/debundle/lowering/mod.rs
@@ -10,7 +10,7 @@ use swc_ecma_ast::*;
 use swc_ecma_visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 
 use analysis::{
-    AnalysisHints, AtomicUnitConflict, BindingKind, DepKind, KnownEffect,
+    AnalysisHints, AtomicUnitConflict, BindingKind, DepKind, KnownEffect, LocalEffectPolicy,
     LogicalModule as FactorizationLogicalModule, LogicalModuleIndex, ModuleId, OwnerGraphAndUnits,
     OwnerGraphOptions, OwnerId, RedundantPurityHint, top_level_id,
 };

--- a/devinfra/js/debundle/spec.rs
+++ b/devinfra/js/debundle/spec.rs
@@ -186,6 +186,35 @@ pub struct OwnerGraphOptions {
     /// suppresses anything.
     #[serde(default, skip_serializing_if = "AdmissionOverrides::is_empty")]
     pub admission_overrides: AdmissionOverrides,
+    /// Classify whole-statement local property writes —
+    /// `X.prop = <pure-rhs>;` (or a comma-sequence of such) where `X`
+    /// is a chunk-top declared binding — as a *local effect on `X`*
+    /// instead of a globally-ordered side effect. The statement leaves
+    /// the S-chain and instead gets a bidirectional `LocalEffect` edge
+    /// to `X`'s declaring statement, forcing co-location with the
+    /// declaration (so the write still cannot be split away from `X`).
+    /// This is the React annotation idiom — `C.displayName = "…"`,
+    /// `C.defaultProps = {…}` — which is otherwise an
+    /// `assign_or_update` impurity that chains otherwise-unrelated
+    /// statements into one atomic unit.
+    ///
+    /// **Soundness precondition (author-audited):** all writes to `X`
+    /// co-locate with `X`'s declaration, and a cross-module reader of
+    /// `X` observes them only after `X`'s module fully initializes
+    /// (ESM import ordering) — i.e. the reader sees the *post-write*
+    /// value. That is behavior-preserving exactly when no top-level
+    /// statement destined to a different module reads the written
+    /// property *textually before* the write in the original chunk.
+    /// Annotation writes placed directly after the declaration they
+    /// annotate (the idiom this targets) satisfy this by construction;
+    /// a chunk that read-then-writes an annotated binding's property
+    /// across destinations does not, and must not enable this flag.
+    /// Statements containing anything beyond such writes (compound
+    /// assignment, computed non-literal keys, `__proto__` segments,
+    /// impure RHS, non-chunk-top targets) keep the conservative
+    /// classification regardless of this flag.
+    #[serde(default)]
+    pub local_property_effects: bool,
 }
 
 /// One named input-chunk admission check, identified by the


### PR DESCRIPTION
P2 of the residual-impurity series (P1: #2115). Targets the second-largest mass in Tana's residual 1281-owner unit: 948 `assign_or_update` reasons, dominated by React annotation writes — `C.displayName = "…"`, `C.defaultProps = {…}` — onto locally-declared components. Each is a plain data-property write whose only effect is on that one binding, yet it classifies as a globally-ordered side effect and S-chains with every other impure top-level statement.

## What

`chunk_analysis_options.<chunk>.local_property_effects` (default **off**) — a per-chunk conditionally-correct opt-in, same family as `dataflow_aware_s_chain`. Under it, a whole statement of the shape `X.prop = <pure-rhs>;` (or a comma-sequence of such) is classified as a **local effect on `X`**: the statement classifies Pure and gets the existing bidirectional `LocalEffect` co-location edge to `X`'s declaration — the same edge the A10 `typescript_decorate_helper` annotation uses — so it leaves the S-chain but can never be split away from its declarer.

Recognition is all-or-nothing per statement (partial recognition would under-account the remainder), and deliberately strict:
- `=` only — compound assignment also *reads* the property, and a read on a written-through (hence non-PlainData) object may fire a getter;
- every member-path segment a static non-`__proto__` name (string-literal computed keys admitted, same as the vendor recognizers);
- root `X` must be **chunk-top declared** — a write through an import mutates another module's value and stays globally ordered;
- RHS must be strictly classifier-Pure (not the vendor recognizers' structural check — `X.a = Y.b` with a getter-bearing read must disqualify).

**Soundness precondition (author-audited, documented on the spec field + design.md A10 + README):** co-locating writes with the declarer means a cross-module reader observes the *post-write* value (ESM init ordering). That is behavior-preserving exactly when no top-level statement destined to another module reads the annotated binding's properties textually *before* the write. Annotation writes placed directly after the declaration they annotate — the idiom this targets — satisfy this by construction.

Plumbing: `LocalEffectPolicy::LocalPropertyWrites`; the materializer maps the per-chunk flag into the facts-pass policy; the recognizer reuses the chunk-declared-bindings set (field renamed from `vendor_prune_declared_bindings`, now shared by both non-default policies).

## Tests

- Facts-level ×4: annotation write → `local_effects = {C}` + Pure (and conservative under the default policy); comma-sequence + nested path roots; five disqualifying shapes (compound op, impure RHS, computed non-literal key, `__proto__`, import-rooted) stay conservative; string-literal computed key admitted.
- e2e trio sharing one Tana-shaped spec (each write claimed beside its component): **rejects** without the flag (S-cycle baseline pin), **realizes** with it, and a constraint-preservation pin — claiming a write into a *different* module than its target binding still conflicts.
- Full `//devinfra/js/debundle/...` after rebasing onto #2115: 101/101 with lint (clippy + rustfmt) on.

https://claude.ai/code/session_01Bp8cANKC1Ktc92T7SM1kcx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bp8cANKC1Ktc92T7SM1kcx)_