### PR TITLE
debundle: build VendorResolutionPlan once post-prepare; manifests become plan projections (vendor-into-emission PR 2)

### DIFF
--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -157,6 +157,7 @@ rust_library(
     srcs = [
         "vendor/manifests.rs",
         "vendor/mod.rs",
+        "vendor/plan.rs",
         "vendor/strip.rs",
         "vendor/validate.rs",
         "vendor/wrappers.rs",

--- a/devinfra/js/debundle/CODE_REVIEW.md
+++ b/devinfra/js/debundle/CODE_REVIEW.md
@@ -12,7 +12,7 @@ The simulator (`realizability/esm_simulator.rs`), the incremental quotient + ove
 
 ### `vendor/mod.rs` further split
 
-Remaining: strip-specific helpers and annotation/identity logic could each lift out into their own modules alongside the already-extracted `vendor/{manifests,strip,validate,wrappers}.rs`.
+Remaining: strip-specific helpers and export/package-resolution helpers could each lift out into their own modules alongside the already-extracted `vendor/{manifests,plan,strip,validate,wrappers}.rs`.
 
 ### `purity/mod.rs` (~2570 lines) — remaining concerns
 
@@ -70,10 +70,6 @@ Domain graph (`graph.rs`) → rollback graph (`rollback_graph.rs`) → realizabi
 ### `pub(super)` everywhere in lowering/
 
 Nearly every struct field and function is `pub(super)`. This is "module-private exposed to the entire parent module" — everything accessible everywhere within `lowering/`. Fields should be `pub(super)` only on structs that are actually constructed/destructured across file boundaries.
-
-### Vendor manifest struct proliferation
-
-~26 manifest/counts/detail structs with similar shapes in `vendor/manifests.rs`. `PartialSwapResolutionManifest` and `BundledPartialSwapResolutionManifest` are field-for-field twins — a generic `ResolutionManifest<R>` collapses the pair. `PartialSwapSymbolTarget` (`vendor/mod.rs`) is likewise a field-for-field twin of `spec::PartialSwapSymbol`.
 
 ### `SourceImportResolution = Option<(String, String, String)>` (`plan_references.rs:41`)
 
@@ -169,6 +165,6 @@ No longer a standalone crate — absorbed into `swc_ecma_minifier` as `pub(crate
 
 1. **Extract `gate_perf_counters` from `realizability/mod.rs`** — see the P0 item; needs the recording-API entanglement untangled first.
 
-2. **Continue splitting `vendor/mod.rs`** — manifests, strip, wrappers, and validate/resolve helpers extracted; remaining: strip-specific helpers, annotation/identity logic.
+2. **Continue splitting `vendor/mod.rs`** — manifests, plan, strip, wrappers, and validate/resolve helpers extracted; remaining: strip-specific helpers, export/package-resolution helpers.
 
 3. **Consolidate the data-shape follow-ups** — remove the remaining `ChunkBundle` ownership ping-pong.

--- a/devinfra/js/debundle/pipeline.rs
+++ b/devinfra/js/debundle/pipeline.rs
@@ -17,14 +17,13 @@ use lowering::{
 };
 use prepare_chunks::prepare_js_chunks;
 use rewrite_specifiers::rewrite_chunk_entry_specifiers;
-use spec::{MaterializeLogicalModulesConfig, TransformSpec, VendorLevel};
+use spec::{MaterializeLogicalModulesConfig, TransformSpec};
 use spec_tree::{CompileSpecTreeOptions, compile_spec_tree};
 use validate_emitted_exports::validate_emitted_exports;
 use vendor::{
-    ApplyBundledPartialVendorSwapsOptions, ApplyPartialVendorSwapsOptions,
     ChunkBundledPartialSwapResolution, ChunkPartialSwapResolution, ChunkStripStats,
-    StripSwappedVendorExportsOptions, SwapVendorOptions, VendorResolution,
-    apply_bundled_partial_vendor_swaps, apply_partial_vendor_swaps, apply_vendor_annotations,
+    StripSwappedVendorExportsOptions, VendorPlanOptions, VendorResolution, VendorResolutionPlan,
+    apply_bundled_partial_vendor_swaps, apply_partial_vendor_swaps, build_vendor_resolution_plan,
     rename_vendor_exports, strip_swapped_vendor_exports_with_options, swap_vendor_chunks,
     validate_partial_swap_consumers,
 };
@@ -177,8 +176,26 @@ pub fn run_transform_cli_with_options(
         Ok((rewrite_result.artifact, ()))
     })?;
 
+    // Single post-prepare vendor resolution pass: validates every mark
+    // and resolves boundary mappings, swap targets, and partial-swap
+    // symbol tables once. The vendor waves below consume this plan
+    // instead of re-resolving the spec mid-pipeline.
+    let swap_cfg = &spec.swap_vendor_chunks;
+    let vendor_plan = build_vendor_resolution_plan(
+        indexed.artifact(),
+        &spec.vendor,
+        &VendorPlanOptions {
+            package_roots: &cli.package_roots,
+            packages_root: &cli.packages_root,
+            output_manifest_path: swap_cfg.output_manifest_path.as_deref(),
+            output_wrapper_dir: swap_cfg.output_wrapper_dir.as_deref(),
+        },
+    )?;
+    let write_vendor_outputs = swap_cfg.write && !options.dry_run;
+
     let full_swap_outcome;
-    (indexed, full_swap_outcome) = run_full_vendor_swaps(indexed, &spec, cli, !options.dry_run)?;
+    (indexed, full_swap_outcome) =
+        run_full_vendor_swaps(indexed, &vendor_plan, write_vendor_outputs)?;
     vendor_report.full = full_swap_outcome.full_swap_resolutions;
     chunk_records.retain(|chunk| {
         !full_swap_outcome
@@ -242,7 +259,8 @@ pub fn run_transform_cli_with_options(
     }
 
     let partial_outcome;
-    (indexed, partial_outcome) = run_partial_vendor_swaps(indexed, &spec, cli, !options.dry_run)?;
+    (indexed, partial_outcome) =
+        run_partial_vendor_swaps(indexed, &vendor_plan, write_vendor_outputs)?;
     vendor_report.partial = partial_outcome.partial_swap_resolutions;
     vendor_report.bundled_partial = partial_outcome.bundled_partial_swap_resolutions;
     vendor_report.strip_stats = partial_outcome.strip_stats;
@@ -371,53 +389,29 @@ struct FullVendorSwapOutcome {
 
 fn run_full_vendor_swaps(
     mut indexed: IndexedArtifact,
-    spec: &TransformSpec,
-    cli: &TransformCli,
+    plan: &VendorResolutionPlan,
     write_outputs: bool,
 ) -> Result<(IndexedArtifact, FullVendorSwapOutcome)> {
     let mut full_swap_resolutions = BTreeMap::new();
     let mut removed_chunk_ids = BTreeSet::new();
-    if !spec.vendor.is_empty() {
-        apply_vendor_annotations(indexed.artifact(), &spec.vendor)?;
-        if spec
-            .vendor
-            .values()
-            .any(|m| matches!(m.level, VendorLevel::BoundaryRename | VendorLevel::Swap(_)))
-        {
-            (indexed, _) = indexed.update(|artifact, indexes| {
-                let rename_result = rename_vendor_exports(artifact, &spec.vendor, indexes)?;
-                Ok((rename_result.artifact, ()))
+    if plan.has_boundary_renames() {
+        (indexed, _) = indexed.update(|artifact, indexes| {
+            let rename_result = rename_vendor_exports(artifact, plan, indexes)?;
+            Ok((rename_result.artifact, ()))
+        })?;
+    }
+    if plan.has_full_swaps() {
+        (indexed, (full_swap_resolutions, removed_chunk_ids)) =
+            indexed.update(|artifact, indexes| {
+                let swap_result = swap_vendor_chunks(artifact, plan, indexes, write_outputs)?;
+                Ok((
+                    swap_result.artifact,
+                    (
+                        swap_result.manifest.resolutions,
+                        swap_result.removed_chunk_ids,
+                    ),
+                ))
             })?;
-        }
-        if spec
-            .vendor
-            .values()
-            .any(|m| matches!(m.level, VendorLevel::Swap(_)))
-        {
-            let swap_cfg = &spec.swap_vendor_chunks;
-            (indexed, (full_swap_resolutions, removed_chunk_ids)) =
-                indexed.update(|artifact, indexes| {
-                    let swap_result = swap_vendor_chunks(
-                        artifact,
-                        &spec.vendor,
-                        indexes,
-                        SwapVendorOptions {
-                            package_roots: &cli.package_roots,
-                            packages_root: &cli.packages_root,
-                            output_manifest_path: swap_cfg.output_manifest_path.clone(),
-                            output_wrapper_dir: swap_cfg.output_wrapper_dir.clone(),
-                            write: swap_cfg.write && write_outputs,
-                        },
-                    )?;
-                    Ok((
-                        swap_result.artifact,
-                        (
-                            swap_result.manifest.resolutions,
-                            swap_result.removed_chunk_ids,
-                        ),
-                    ))
-                })?;
-        }
     }
     Ok((
         indexed,
@@ -442,39 +436,21 @@ struct PartialVendorSwapOutcome {
 /// materialize-time (e.g. `anonymous_statements: match: "ee({...})"`).
 fn run_partial_vendor_swaps(
     mut indexed: IndexedArtifact,
-    spec: &TransformSpec,
-    cli: &TransformCli,
+    plan: &VendorResolutionPlan,
     write_outputs: bool,
 ) -> Result<(IndexedArtifact, PartialVendorSwapOutcome)> {
     let mut partial_swap_resolutions = BTreeMap::new();
     let mut bundled_partial_swap_resolutions = BTreeMap::new();
     let mut strip_stats = BTreeMap::new();
-    let has_partial_swaps = spec
-        .vendor
-        .values()
-        .any(|m| matches!(m.level, VendorLevel::PartialSwap(_)));
-    let has_bundled_partial_swaps = spec
-        .vendor
-        .values()
-        .any(|m| matches!(m.level, VendorLevel::BundledPartialSwap(_)));
-    if !spec.vendor.is_empty() && (has_partial_swaps || has_bundled_partial_swaps) {
+    if plan.has_partial_swaps() || plan.has_bundled_partial_swaps() {
         let mut replacement_import_locals_by_chunk_path = BTreeMap::new();
-        if has_partial_swaps {
+        if plan.has_partial_swaps() {
             (indexed, partial_swap_resolutions) = indexed.update(|artifact, indexes| {
-                let partial_result = apply_partial_vendor_swaps(
-                    artifact,
-                    &spec.vendor,
-                    indexes,
-                    ApplyPartialVendorSwapsOptions {
-                        package_roots: &cli.package_roots,
-                        packages_root: &cli.packages_root,
-                    },
-                )?;
+                let partial_result = apply_partial_vendor_swaps(artifact, plan, indexes)?;
                 Ok((partial_result.artifact, partial_result.manifest.resolutions))
             })?;
         }
-        if has_bundled_partial_swaps {
-            let swap_cfg = &spec.swap_vendor_chunks;
+        if plan.has_bundled_partial_swaps() {
             (
                 indexed,
                 (
@@ -482,18 +458,8 @@ fn run_partial_vendor_swaps(
                     bundled_partial_swap_resolutions,
                 ),
             ) = indexed.update(|artifact, indexes| {
-                let bundled_result = apply_bundled_partial_vendor_swaps(
-                    artifact,
-                    &spec.vendor,
-                    indexes,
-                    ApplyBundledPartialVendorSwapsOptions {
-                        package_roots: &cli.package_roots,
-                        packages_root: &cli.packages_root,
-                        output_manifest_path: swap_cfg.output_manifest_path.clone(),
-                        output_wrapper_dir: swap_cfg.output_wrapper_dir.clone(),
-                        write: swap_cfg.write && write_outputs,
-                    },
-                )?;
+                let bundled_result =
+                    apply_bundled_partial_vendor_swaps(artifact, plan, indexes, write_outputs)?;
                 Ok((
                     bundled_result.artifact,
                     (
@@ -506,7 +472,7 @@ fn run_partial_vendor_swaps(
         (indexed, strip_stats) = indexed.update(|artifact, _indexes| {
             let strip_result = strip_swapped_vendor_exports_with_options(
                 artifact,
-                &spec.vendor,
+                plan,
                 StripSwappedVendorExportsOptions {
                     replacement_import_locals_by_chunk_path,
                 },
@@ -517,7 +483,7 @@ fn run_partial_vendor_swaps(
         // the stripped portion of a partially-swapped chunk's export
         // surface (unrewritten named imports / re-exports, namespace
         // imports, `export *`).
-        validate_partial_swap_consumers(indexed.artifact(), &spec.vendor, indexed.indexes())?;
+        validate_partial_swap_consumers(indexed.artifact(), plan, indexed.indexes())?;
     }
     Ok((
         indexed,

--- a/devinfra/js/debundle/vendor/manifests.rs
+++ b/devinfra/js/debundle/vendor/manifests.rs
@@ -1,50 +1,13 @@
 use std::collections::{BTreeMap, BTreeSet};
-use std::path::PathBuf;
 
 use serde::Serialize;
 use swc_ecma_ast::Id;
 
 use artifact::ChunkBundle;
-use spec::{PartialSwapKind, VendorRole, WrapperShape};
+use spec::{PartialSwapKind, WrapperShape};
 
 pub(crate) trait PartialSwapResolutionSymbols {
     fn symbols_mut(&mut self) -> &mut BTreeMap<String, PartialSwapSymbolResolution>;
-}
-
-#[derive(Debug, Clone)]
-pub struct VendorAnnotationsManifest {
-    pub counts: VendorAnnotationCounts,
-    pub annotations: Vec<VendorAnnotationSummary>,
-}
-
-#[derive(Debug, Clone)]
-pub struct VendorAnnotationCounts {
-    pub annotations: usize,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct VendorAnnotationSummary {
-    pub chunk_path: String,
-    pub chunk_id: String,
-    pub identity: String,
-    pub level: VendorAnnotationLevel,
-    pub role: VendorRole,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub version: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub package: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub subpath: Option<String>,
-}
-
-#[derive(Debug, Clone, Copy, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum VendorAnnotationLevel {
-    Suppress,
-    BoundaryRename,
-    Swap,
-    PartialSwap,
-    BundledPartialSwap,
 }
 
 #[derive(Debug, Clone)]
@@ -111,23 +74,17 @@ pub struct VendorResolutionCounts {
     pub swapped: usize,
 }
 
-#[derive(Debug, Clone)]
-pub struct SwapVendorOptions<'a> {
-    pub package_roots: &'a std::collections::HashMap<String, PathBuf>,
-    pub packages_root: &'a Option<PathBuf>,
-    pub output_manifest_path: Option<PathBuf>,
-    pub output_wrapper_dir: Option<PathBuf>,
-    pub write: bool,
-}
-
 pub struct ApplyPartialVendorSwapsResult {
     pub artifact: ChunkBundle,
-    pub manifest: PartialSwapResolutionManifest,
+    pub manifest: ResolutionManifest<ChunkPartialSwapResolution>,
 }
 
+/// Wire manifest of a partial-swap-family wave: per-chunk resolutions
+/// (projections of the vendor plan) keyed by chunk path, plus totals
+/// accumulated at application time.
 #[derive(Debug, Clone)]
-pub struct PartialSwapResolutionManifest {
-    pub resolutions: BTreeMap<String, ChunkPartialSwapResolution>,
+pub struct ResolutionManifest<R> {
+    pub resolutions: BTreeMap<String, R>,
     pub counts: PartialSwapResolutionCounts,
 }
 
@@ -171,22 +128,10 @@ pub struct PartialSwapResolutionCounts {
     pub references_rewritten: usize,
 }
 
-#[derive(Debug, Clone)]
-pub struct ApplyPartialVendorSwapsOptions<'a> {
-    pub package_roots: &'a std::collections::HashMap<String, PathBuf>,
-    pub packages_root: &'a Option<PathBuf>,
-}
-
 pub struct ApplyBundledPartialVendorSwapsResult {
     pub artifact: ChunkBundle,
-    pub manifest: BundledPartialSwapResolutionManifest,
+    pub manifest: ResolutionManifest<ChunkBundledPartialSwapResolution>,
     pub self_rewrite_import_locals_by_chunk_path: BTreeMap<String, BTreeSet<Id>>,
-}
-
-#[derive(Debug, Clone)]
-pub struct BundledPartialSwapResolutionManifest {
-    pub resolutions: BTreeMap<String, ChunkBundledPartialSwapResolution>,
-    pub counts: PartialSwapResolutionCounts,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -220,13 +165,4 @@ pub struct BundledPartialSwapPackageResolution {
     pub bundle_export: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub generated_facade_path: Option<String>,
-}
-
-#[derive(Debug, Clone)]
-pub struct ApplyBundledPartialVendorSwapsOptions<'a> {
-    pub package_roots: &'a std::collections::HashMap<String, PathBuf>,
-    pub packages_root: &'a Option<PathBuf>,
-    pub output_manifest_path: Option<PathBuf>,
-    pub output_wrapper_dir: Option<PathBuf>,
-    pub write: bool,
 }

--- a/devinfra/js/debundle/vendor/mod.rs
+++ b/devinfra/js/debundle/vendor/mod.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result, bail};
 use rayon::prelude::*;
 mod manifests;
+mod plan;
 mod strip;
 mod validate;
 mod wrappers;
@@ -16,123 +17,41 @@ use swc_ecma_visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 
 use analysis::local_namespace_iife_target;
 use artifact::{
-    ArtifactIndexes, ChunkBundle, ChunkId, ChunkTable, JsFile, JsFileAstParts,
-    get_chunk_entry_path, join_module_path, list_chunk_file_paths, manifest_relative_path,
-    module_path_dirname, normalize_module_path, relative_module_specifier,
+    ArtifactIndexes, ChunkBundle, ChunkId, ChunkTable, JsFile, JsFileAstParts, join_module_path,
+    list_chunk_file_paths, module_path_dirname, normalize_module_path, relative_module_specifier,
 };
 use binding_targets::{declaration_ids, declaration_name_strings, module_export_name};
+use js_ast::{ParsedJsModule, str_value};
 #[cfg(test)]
-use js_ast::emit_js_module;
-use js_ast::{ParsedJsModule, parse_js_module, str_value};
+use js_ast::{emit_js_module, parse_js_module};
 pub use manifests::*;
-use spec::{
-    BundledPartialSwapMark, PartialSwapKind, PartialSwapMark, PartialSwapPackage, SwapMark,
-    VendorLevel, VendorMark, WrapperShape,
-};
+use plan::{ChunkBundledPartialSwapPlan, ChunkPartialSwapPlan};
+pub use plan::{VendorPlanOptions, VendorResolutionPlan, build_vendor_resolution_plan};
+use spec::PartialSwapKind;
 pub use strip::{
     ChunkStripStats, StripSwappedVendorExportsOptions, strip_swapped_vendor_exports_with_options,
 };
-use validate::{
-    PartialSwapPackageCoords, ResolvePartialSwapPackageOptions, build_partial_swap_symbol_tables,
-    resolve_partial_swap_package, resolve_vendor_chunk, validate_partial_swap_symbols,
-    vendor_chunk_name, vendor_entry_ast,
-};
-use wrappers::{
-    generate_named_from_default_wrapper, generate_named_from_json_default_wrapper,
-    generate_named_from_module_default_wrapper, set_diff,
-    write_bundled_partial_swap_assets_if_requested, write_wrapper_if_requested,
-};
-
-pub fn apply_vendor_annotations(
-    artifact: &ChunkBundle,
-    vendor: &BTreeMap<String, VendorMark>,
-) -> Result<VendorAnnotationsManifest> {
-    let mut summaries = Vec::with_capacity(vendor.len());
-    for (chunk_path, mark) in vendor {
-        let chunk_name = vendor_chunk_name(chunk_path, "mark_vendor")?;
-        let chunk_id = artifact.chunk_table.get(&chunk_name).with_context(|| {
-            format!("vendor entry {chunk_path} targets unknown chunk: {chunk_name}")
-        })?;
-        if get_chunk_entry_path(artifact, chunk_id).is_none() {
-            bail!("vendor entry {chunk_path} targets missing chunk (chunk_id={chunk_name})");
-        }
-        let (level, package, version, subpath) = match &mark.level {
-            VendorLevel::Swap(swap) => (
-                VendorAnnotationLevel::Swap,
-                Some(swap.package.clone()),
-                Some(swap.version.clone()),
-                Some(swap.subpath.clone()),
-            ),
-            VendorLevel::BoundaryRename => {
-                (VendorAnnotationLevel::BoundaryRename, None, None, None)
-            }
-            VendorLevel::Suppress => (VendorAnnotationLevel::Suppress, None, None, None),
-            // Partial-swap is heterogeneous — multiple packages may live in
-            // one chunk. The summary line records the level only; per-symbol
-            // resolution detail surfaces through the partial-swap manifest.
-            VendorLevel::PartialSwap(_) => (VendorAnnotationLevel::PartialSwap, None, None, None),
-            VendorLevel::BundledPartialSwap(_) => {
-                (VendorAnnotationLevel::BundledPartialSwap, None, None, None)
-            }
-        };
-        summaries.push(VendorAnnotationSummary {
-            chunk_path: chunk_path.clone(),
-            chunk_id: chunk_name,
-            identity: mark.identity.clone(),
-            level,
-            role: mark.role,
-            version: version.clone(),
-            package,
-            subpath,
-        });
-    }
-
-    Ok(VendorAnnotationsManifest {
-        counts: VendorAnnotationCounts {
-            annotations: vendor.len(),
-        },
-        annotations: summaries,
-    })
-}
+use wrappers::{write_planned_bundled_assets, write_planned_wrapper};
 
 pub fn rename_vendor_exports(
     mut artifact: ChunkBundle,
-    vendor: &BTreeMap<String, VendorMark>,
+    plan: &VendorResolutionPlan,
     references: &ArtifactIndexes,
 ) -> Result<RenameVendorExportsResult> {
-    let mut ops = Vec::<RenameVendorExportOp>::new();
     let mut mappings = VendorExportMappings::new();
     let mut total_rewrites = 0usize;
     let mut chunks_with_mapping = 0usize;
     let mut details = Vec::new();
     let chunk_table = artifact.chunk_table.clone();
 
-    for (chunk_path, _mark) in vendor.iter().filter(|(_, mark)| {
-        matches!(
-            mark.level,
-            VendorLevel::BoundaryRename | VendorLevel::Swap(_)
-        )
-    }) {
-        let chunk = resolve_vendor_chunk(&artifact, "rename_vendor_exports", chunk_path)?;
-        let mapping = {
-            let vendor_ast = vendor_entry_ast(&artifact, "rename_vendor_exports", &chunk)?;
-            let mapping = collect_boundary_mapping(&vendor_ast.module);
-            validate_boundary_mapping_collisions(&vendor_ast.module, &mapping, chunk_path)?;
-            mapping
-        };
-        if !mapping.is_empty() {
+    for op in &plan.boundary_renames {
+        if !op.mapping.is_empty() {
             chunks_with_mapping += 1;
             mappings
-                .entry(chunk.chunk_id)
+                .entry(op.chunk_id)
                 .or_default()
-                .insert(chunk.entry_file.clone(), mapping.clone());
+                .insert(op.entry_file.clone(), op.mapping.clone());
         }
-        ops.push(RenameVendorExportOp {
-            chunk_path: chunk_path.clone(),
-            chunk_id: chunk.chunk_id,
-            entry_file: chunk.entry_file,
-            mapping,
-        });
     }
 
     let mut caller_counts_by_target = BTreeMap::<(ChunkId, String), BTreeMap<String, usize>>::new();
@@ -194,14 +113,14 @@ pub fn rename_vendor_exports(
         }
     }
 
-    let considered = ops.len();
-    for op in ops {
+    let considered = plan.boundary_renames.len();
+    for op in &plan.boundary_renames {
         let caller_counts = caller_counts_by_target
             .remove(&(op.chunk_id, op.entry_file.clone()))
             .unwrap_or_default();
         let chunk_rewrites = caller_counts.values().sum();
         details.push(RenameVendorExportsDetail {
-            chunk_path: op.chunk_path,
+            chunk_path: op.chunk_path.clone(),
             chunk_id: chunk_table.name(op.chunk_id).to_string(),
             mapping_size: op.mapping.len(),
             rewrites: chunk_rewrites,
@@ -227,13 +146,6 @@ pub fn rename_vendor_exports(
 
 /// chunk → entry file → vendor-local name → public export name.
 type VendorExportMappings = BTreeMap<ChunkId, BTreeMap<String, BTreeMap<String, String>>>;
-
-struct RenameVendorExportOp {
-    chunk_path: String,
-    chunk_id: ChunkId,
-    entry_file: String,
-    mapping: BTreeMap<String, String>,
-}
 
 struct VendorRenameFileJob {
     caller_chunk_index: usize,
@@ -278,299 +190,55 @@ fn rename_vendor_imports_in_file(
     }
 }
 
-struct SwapVendorJob {
-    chunk_path: String,
-    chunk_id: ChunkId,
-    entry_file: String,
-    package: String,
-    version: String,
-    subpath: String,
-    wrapper_shape: Option<WrapperShape>,
-    vendor_exports: BTreeSet<String>,
-    /// Chunk export names verified to alias the chunk's own default
-    /// export (bound to the same local binding). Consumed by the
-    /// `named_from_module_default` wrapper-shape check.
-    vendor_default_aliases: BTreeSet<String>,
-}
-
-fn resolve_vendor_swap(
-    job: SwapVendorJob,
-    import_alignment_index: &BTreeMap<ChunkId, Vec<ImportAlignmentRecord>>,
-    options: &SwapVendorOptions<'_>,
-    chunk_table: &ChunkTable,
-) -> Result<(ChunkId, VendorResolution)> {
-    let chunk_name = chunk_table.name(job.chunk_id);
-    let installed =
-        read_installed_package_metadata(&job.package, options.package_roots, options.packages_root)
-            .with_context(|| format!("reading metadata for package {}", job.package))?;
-    let installed_version = installed
-        .get("version")
-        .and_then(Value::as_str)
-        .context("package metadata missing version")?;
-    if installed_version != job.version {
-        bail!(
-            "swap_vendor_chunks vendor entry {} version mismatch for {}: spec={}, installed={installed_version}",
-            job.chunk_path,
-            job.package,
-            job.version,
-        );
-    }
-    let upstream_path = resolve_package_subpath(
-        &job.package,
-        &job.subpath,
-        options.package_roots,
-        options.packages_root,
-    )?;
-    let upstream_code = fs::read_to_string(&upstream_path)
-        .with_context(|| format!("reading {}", upstream_path.display()))?;
-    let mut generated_wrapper_path = None::<PathBuf>;
-
-    match job.wrapper_shape {
-        Some(WrapperShape::NamedFromDefault) => {
-            let upstream_ast =
-                parse_js_module(&upstream_path.display().to_string(), &upstream_code)?;
-            let object_keys =
-                collect_default_export_object_keys(&upstream_ast.module, &job.chunk_path)?;
-            let non_default_exports = job
-                .vendor_exports
-                .iter()
-                .filter(|name| name.as_str() != "default")
-                .cloned()
-                .collect::<BTreeSet<_>>();
-            let missing = set_diff(&non_default_exports, &object_keys);
-            if !missing.is_empty() {
-                bail!(
-                    "swap_vendor_chunks vendor entry {} named-from-default wrapper shape mismatch for {}@{}: vendor named exports missing from upstream default object keys=[{}]",
-                    job.chunk_path,
-                    job.package,
-                    job.version,
-                    missing.into_iter().collect::<Vec<_>>().join(",")
-                );
-            }
-            let wrapper = generate_named_from_default_wrapper(&upstream_ast, &non_default_exports)?;
-            generated_wrapper_path = write_wrapper_if_requested(
-                options.write,
-                options.output_wrapper_dir.as_deref(),
-                chunk_name,
-                &job.entry_file,
-                &wrapper,
-            )?;
-        }
-        Some(WrapperShape::NamedFromJsonDefault) => {
-            let upstream_json = serde_json::from_str::<Value>(&upstream_code).with_context(|| {
-                format!(
-                    "swap_vendor_chunks vendor entry {} named-from-json-default: upstream JSON parse failed",
-                    job.chunk_path
-                )
-            })?;
-            let object = upstream_json
-                .as_object()
-                .context("named-from-json-default upstream JSON must be an object")?;
-            let object_keys = object.keys().cloned().collect::<BTreeSet<_>>();
-            let non_default_exports = job
-                .vendor_exports
-                .iter()
-                .filter(|name| name.as_str() != "default")
-                .cloned()
-                .collect::<BTreeSet<_>>();
-            let missing = set_diff(&non_default_exports, &object_keys);
-            if !missing.is_empty() {
-                bail!(
-                    "swap_vendor_chunks vendor entry {} named-from-json-default wrapper shape mismatch for {}@{}: vendor named exports missing from upstream JSON keys=[{}]",
-                    job.chunk_path,
-                    job.package,
-                    job.version,
-                    missing.into_iter().collect::<Vec<_>>().join(",")
-                );
-            }
-            let wrapper =
-                generate_named_from_json_default_wrapper(&upstream_json, &non_default_exports)?;
-            generated_wrapper_path = write_wrapper_if_requested(
-                options.write,
-                options.output_wrapper_dir.as_deref(),
-                chunk_name,
-                &job.entry_file,
-                &wrapper,
-            )?;
-        }
-        Some(WrapperShape::NamedFromModuleDefault) => {
-            // The wrapper re-exports the upstream default under every
-            // vendor named-export name (`export const <name> =
-            // <default>;`). That equation only holds when the chunk
-            // itself binds <name> to the same local as its default
-            // export; anything else would silently alias an unrelated
-            // export to the upstream default.
-            let claimed = job
-                .vendor_exports
-                .iter()
-                .filter(|name| name.as_str() != "default")
-                .cloned()
-                .collect::<BTreeSet<_>>();
-            let unverified = set_diff(&claimed, &job.vendor_default_aliases);
-            if !unverified.is_empty() {
-                bail!(
-                    "swap_vendor_chunks vendor entry {} named-from-module-default: vendor named exports [{}] are not verified aliases of the chunk's default export; the wrapper would re-export the upstream default under unrelated names",
-                    job.chunk_path,
-                    unverified.into_iter().collect::<Vec<_>>().join(","),
-                );
-            }
-            let upstream_ast =
-                parse_js_module(&upstream_path.display().to_string(), &upstream_code)?;
-            let wrapper = generate_named_from_module_default_wrapper(
-                &upstream_ast,
-                &job.vendor_exports,
-                &job.chunk_path,
-            )?;
-            generated_wrapper_path = write_wrapper_if_requested(
-                options.write,
-                options.output_wrapper_dir.as_deref(),
-                chunk_name,
-                &job.entry_file,
-                &wrapper,
-            )?;
-        }
-        None => {
-            let upstream_ast =
-                parse_js_module(&upstream_path.display().to_string(), &upstream_code)?;
-            let upstream_exports = collect_exported_names(&upstream_ast.module);
-            let missing = set_diff(&job.vendor_exports, &upstream_exports);
-            if !missing.is_empty() {
-                bail!(
-                    "swap_vendor_chunks vendor entry {} export shape mismatch for {}@{}: vendor exports not found upstream=[{}]",
-                    job.chunk_path,
-                    job.package,
-                    job.version,
-                    missing.into_iter().collect::<Vec<_>>().join(",")
-                );
-            }
-        }
-    }
-
-    for record in import_alignment_index
-        .get(&job.chunk_id)
-        .into_iter()
-        .flatten()
-    {
-        for imported_name in &record.named_imports {
-            if job.vendor_exports.contains(imported_name) {
-                continue;
-            }
-            bail!(
-                "swap_vendor_chunks vendor entry {} import alignment failed: caller={}/{} imports unknown specifier \"{}\" from vendor {} (known: [{}])",
-                job.chunk_path,
-                chunk_table.name(record.caller_chunk_id),
-                record.caller_file,
-                imported_name,
-                chunk_name,
-                job.vendor_exports
-                    .iter()
-                    .cloned()
-                    .collect::<Vec<_>>()
-                    .join(",")
-            );
-        }
-    }
-
-    let generated_wrapper_path = generated_wrapper_path.as_ref().and_then(|path| {
-        options
-            .output_manifest_path
-            .as_deref()
-            .map(|manifest_path| manifest_relative_path(manifest_path, path))
-    });
-    Ok((
-        job.chunk_id,
-        VendorResolution {
-            chunk_id: chunk_name.to_string(),
-            chunk_path: job.chunk_path,
-            entry_file: job.entry_file,
-            package: job.package,
-            version: job.version,
-            subpath: job.subpath,
-            wrapper_shape: job.wrapper_shape,
-            generated_wrapper_path,
-        },
-    ))
-}
-
+/// Apply the plan's full swaps: verify caller import alignment against
+/// the current (post-rename) indexes, write planned wrappers, and
+/// remove the swapped chunks from the artifact. All resolution
+/// decisions (version checks, wrapper-shape validation, wrapper
+/// generation) were made at plan time.
 pub fn swap_vendor_chunks(
     mut artifact: ChunkBundle,
-    vendor: &BTreeMap<String, VendorMark>,
+    plan: &VendorResolutionPlan,
     references: &ArtifactIndexes,
-    options: SwapVendorOptions<'_>,
+    write: bool,
 ) -> Result<SwapVendorChunksResult> {
-    let ops: Vec<(&String, &VendorMark, &SwapMark)> = vendor
-        .iter()
-        .filter_map(|(chunk_path, mark)| match &mark.level {
-            VendorLevel::Swap(swap) => Some((chunk_path, mark, swap)),
-            _ => None,
-        })
-        .collect();
-    let swap_chunk_names = ops
-        .iter()
-        .map(|(chunk_path, _mark, _swap)| vendor_chunk_name(chunk_path, "swap_vendor_chunks"))
-        .collect::<Result<BTreeSet<_>>>()?;
     let chunk_table = artifact.chunk_table.clone();
-    let swap_chunk_ids: BTreeSet<ChunkId> = swap_chunk_names
-        .iter()
-        .filter_map(|name| chunk_table.get(name))
-        .collect();
+    let swap_chunk_ids: BTreeSet<ChunkId> =
+        plan.full_swaps.iter().map(|swap| swap.chunk_id).collect();
     let import_alignment_index = build_import_alignment_index(references, &swap_chunk_ids);
-    let jobs = ops
-        .iter()
-        .map(|(chunk_path, _mark, swap)| {
-            let chunk = resolve_vendor_chunk(&artifact, "swap_vendor_chunks", chunk_path)?;
-            let entry_ast = vendor_entry_ast(&artifact, "swap_vendor_chunks", &chunk)?;
-            let vendor_exports = collect_exported_names(&entry_ast.module);
-            let declared_default_aliases: BTreeSet<String> =
-                swap.default_export_aliases.iter().cloned().collect();
-            let unknown_aliases = set_diff(&declared_default_aliases, &vendor_exports);
-            if !unknown_aliases.is_empty() {
+    let mut removed_chunk_ids = BTreeSet::new();
+    let mut resolutions: BTreeMap<String, VendorResolution> = BTreeMap::new();
+    for swap in &plan.full_swaps {
+        for record in import_alignment_index
+            .get(&swap.chunk_id)
+            .into_iter()
+            .flatten()
+        {
+            for imported_name in &record.named_imports {
+                if swap.vendor_exports.contains(imported_name) {
+                    continue;
+                }
                 bail!(
-                    "swap_vendor_chunks vendor entry {} default_export_aliases names exports the chunk does not declare: [{}]",
-                    chunk_path,
-                    unknown_aliases.into_iter().collect::<Vec<_>>().join(",")
+                    "swap_vendor_chunks vendor entry {} import alignment failed: caller={}/{} imports unknown specifier \"{}\" from vendor {} (known: [{}])",
+                    swap.resolution.chunk_path,
+                    chunk_table.name(record.caller_chunk_id),
+                    record.caller_file,
+                    imported_name,
+                    swap.resolution.chunk_id,
+                    swap.vendor_exports
+                        .iter()
+                        .cloned()
+                        .collect::<Vec<_>>()
+                        .join(",")
                 );
             }
-            // Author-asserted default aliases (see `SwapMark::default_export_aliases`)
-            // join the statically verified set so a chunk that re-exports the package
-            // default under a minified name without its own `default` export can still
-            // pass the `named_from_module_default` soundness check.
-            let mut vendor_default_aliases =
-                verified_default_alias_export_names(&entry_ast.module);
-            vendor_default_aliases.extend(declared_default_aliases);
-            Ok(SwapVendorJob {
-                chunk_path: (*chunk_path).clone(),
-                chunk_id: chunk.chunk_id,
-                entry_file: chunk.entry_file,
-                package: swap.package.clone(),
-                version: swap.version.clone(),
-                subpath: swap.subpath.clone(),
-                wrapper_shape: swap.wrapper_shape,
-                vendor_exports,
-                vendor_default_aliases,
-            })
-        })
-        .collect::<Result<Vec<_>>>()?;
-    // Rayon workers don't inherit `GLOBALS`; re-set per worker so any
-    // `Mark::new()` / `Id` use stays in the caller's arena.
-    let resolved = GLOBALS.with(|globals| {
-        jobs.into_par_iter()
-            .map(|job| {
-                GLOBALS.set(globals, || {
-                    resolve_vendor_swap(job, &import_alignment_index, &options, &chunk_table)
-                })
-            })
-            .collect::<Result<Vec<_>>>()
-    })?;
-    let mut removed_chunk_ids = BTreeSet::new();
-    let resolutions: BTreeMap<String, VendorResolution> = resolved
-        .into_iter()
-        .map(|(chunk_id, resolution)| {
-            artifact.remove_chunk(chunk_id);
-            removed_chunk_ids.insert(chunk_table.name(chunk_id).to_string());
-            (resolution.chunk_path.clone(), resolution)
-        })
-        .collect();
+        }
+        if write && let Some(wrapper) = &swap.wrapper {
+            write_planned_wrapper(&wrapper.abs_path, &wrapper.source)?;
+        }
+        artifact.remove_chunk(swap.chunk_id);
+        removed_chunk_ids.insert(swap.resolution.chunk_id.clone());
+        resolutions.insert(swap.resolution.chunk_path.clone(), swap.resolution.clone());
+    }
 
     let swapped = resolutions.len();
     Ok(SwapVendorChunksResult {
@@ -1057,59 +725,20 @@ fn prop_name(name: &PropName) -> Option<String> {
 // imported local binding with a namespace member access. The chunk's
 // un-swapped exports keep working through the residual import.
 
-/// Per-chunk in-memory mapping built once and shared across parallel
-/// per-file rewriters. Keyed by the target chunk's [`ChunkId`].
-type PartialSwapMappings = BTreeMap<ChunkId, ChunkPartialSwapMapping>;
-
-#[derive(Debug, Clone)]
-struct ChunkPartialSwapMapping {
-    chunk_path: String,
-    /// package_name -> namespace + upstream coords.
-    packages: BTreeMap<String, PartialSwapPackage>,
-    /// chunk_export -> which package + upstream export.
-    symbols: BTreeMap<String, PartialSwapSymbolTarget>,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct PartialSwapSymbolTarget {
-    package: String,
-    kind: PartialSwapKind,
-    /// Only Some(_) when `kind == Member` or `kind == Named`.
-    upstream_export: Option<String>,
-    /// Optional implementation binding inside the target chunk. Used
-    /// when a swapped vendor helper is chunk-local rather than exported.
-    local: Option<String>,
-}
-
-type BundledPartialSwapMappings = BTreeMap<ChunkId, ChunkBundledPartialSwapMapping>;
-
-#[derive(Debug, Clone)]
-struct ChunkBundledPartialSwapMapping {
-    chunk_path: String,
-    packages: BTreeMap<String, BundledPartialSwapPackageTarget>,
-    symbols: BTreeMap<String, PartialSwapSymbolTarget>,
-}
-
 trait PartialSwapMappingEntry {
     fn chunk_path(&self) -> &str;
 }
 
-impl PartialSwapMappingEntry for ChunkPartialSwapMapping {
+impl PartialSwapMappingEntry for ChunkPartialSwapPlan {
     fn chunk_path(&self) -> &str {
         &self.chunk_path
     }
 }
 
-impl PartialSwapMappingEntry for ChunkBundledPartialSwapMapping {
+impl PartialSwapMappingEntry for ChunkBundledPartialSwapPlan {
     fn chunk_path(&self) -> &str {
         &self.chunk_path
     }
-}
-
-#[derive(Debug, Clone)]
-struct BundledPartialSwapPackageTarget {
-    namespace: Option<String>,
-    facade_app_path: String,
 }
 
 struct PartialSwapDispatchOutcome {
@@ -1232,137 +861,26 @@ where
     })
 }
 
+/// Apply the plan's partial swaps: rewrite consumer imports /
+/// references against the upstream packages. Validation and resolution
+/// happened at plan time; the manifest is the plan's resolution
+/// projection plus application-time rewrite counts.
 pub fn apply_partial_vendor_swaps(
     mut artifact: ChunkBundle,
-    vendor: &BTreeMap<String, VendorMark>,
+    plan: &VendorResolutionPlan,
     references: &ArtifactIndexes,
-    options: ApplyPartialVendorSwapsOptions<'_>,
 ) -> Result<ApplyPartialVendorSwapsResult> {
-    let ops: Vec<(&String, &PartialSwapMark)> = vendor
-        .iter()
-        .filter_map(|(chunk_path, mark)| match &mark.level {
-            VendorLevel::PartialSwap(partial) => Some((chunk_path, partial)),
-            _ => None,
-        })
-        .collect();
     let chunk_table = artifact.chunk_table.clone();
+    let mut resolutions: BTreeMap<String, ChunkPartialSwapResolution> = plan
+        .partial_swaps
+        .values()
+        .map(|partial| (partial.chunk_path.clone(), partial.resolution.clone()))
+        .collect();
 
-    let mut mappings: PartialSwapMappings = BTreeMap::new();
-    let mut resolutions: BTreeMap<String, ChunkPartialSwapResolution> = BTreeMap::new();
-
-    for (chunk_path, partial) in &ops {
-        let chunk = resolve_vendor_chunk(&artifact, "apply_partial_vendor_swaps", chunk_path)?;
-        let entry_ast = vendor_entry_ast(&artifact, "apply_partial_vendor_swaps", &chunk)?;
-        // `default` is a swappable name when the chunk binds it via the
-        // named form (`export { x as default }`), which the strip pass
-        // can map to a chunk-local binding.
-        let chunk_exports = collect_exported_names(&entry_ast.module);
-
-        validate_partial_swap_symbols::<PartialSwapPackage>(
-            "apply_partial_vendor_swaps",
-            chunk_path,
-            &chunk.chunk_name,
-            &chunk_exports,
-            &partial.symbols,
-            None,
-        )?;
-
-        // Per-package validation: installed version + upstream subpath
-        // exists + every declared upstream_export is actually a named
-        // export of the upstream subpath.
-        let resolve_options = ResolvePartialSwapPackageOptions {
-            stage: "apply_partial_vendor_swaps",
-            chunk_path,
-            package_roots: options.package_roots,
-            packages_root: options.packages_root,
-        };
-        let mut package_resolutions: BTreeMap<String, PartialSwapPackageResolution> =
-            BTreeMap::new();
-        for (package_name, package) in &partial.packages {
-            let any_member_for_package = partial
-                .symbols
-                .values()
-                .any(|s| s.package == *package_name && matches!(s.kind, PartialSwapKind::Member));
-            let upstream_path = resolve_partial_swap_package(
-                &resolve_options,
-                package_name,
-                PartialSwapPackageCoords::from(package),
-                any_member_for_package.then_some("kind=member"),
-            )?;
-            let upstream_code = fs::read_to_string(&upstream_path)
-                .with_context(|| format!("reading {}", upstream_path.display()))?;
-            let upstream_ast =
-                parse_js_module(&upstream_path.display().to_string(), &upstream_code)?;
-            let upstream_exports = collect_exported_names(&upstream_ast.module);
-            // Packages that re-export everything from a sibling module
-            // (`export * from "./other.js"`) can't be fully enumerated
-            // by a single-file `collect_exported_names`. Skip the strict
-            // name check in that case — the caller's spec is responsible
-            // for naming a real upstream symbol. (zod's `index.js` is the
-            // canonical example: `export * from "./v4/classic/external.js"`
-            // is the only way the named schemas like `object`, `array`
-            // become visible.)
-            let upstream_has_export_star = module_has_export_star(&upstream_ast.module);
-            for (chunk_export, symbol) in &partial.symbols {
-                if symbol.package != *package_name {
-                    continue;
-                }
-                // Only kind=member symbols cite an upstream named
-                // export; kind=namespace/default replace the whole
-                // import with a namespace/default reference, no
-                // member-name lookup needed.
-                let Some(upstream_export) = symbol.upstream_export.as_deref() else {
-                    continue;
-                };
-                if upstream_has_export_star {
-                    continue;
-                }
-                if !upstream_exports.contains(upstream_export) {
-                    bail!(
-                        "apply_partial_vendor_swaps vendor entry {chunk_path}: symbol `{chunk_export}` targets {package_name}#{upstream_export} but upstream does not export it (known: [{}])",
-                        upstream_exports
-                            .iter()
-                            .cloned()
-                            .collect::<Vec<_>>()
-                            .join(",")
-                    );
-                }
-            }
-            package_resolutions.insert(
-                package_name.clone(),
-                PartialSwapPackageResolution {
-                    namespace: package.namespace.clone(),
-                    version: package.version.clone(),
-                    subpath: package.subpath.clone(),
-                },
-            );
-        }
-
-        let (symbol_resolutions, chunk_targets) =
-            build_partial_swap_symbol_tables(&partial.symbols);
-        mappings.insert(
-            chunk.chunk_id,
-            ChunkPartialSwapMapping {
-                chunk_path: (*chunk_path).clone(),
-                packages: partial.packages.clone(),
-                symbols: chunk_targets,
-            },
-        );
-        resolutions.insert(
-            (*chunk_path).clone(),
-            ChunkPartialSwapResolution {
-                chunk_id: chunk.chunk_name,
-                chunk_path: (*chunk_path).clone(),
-                packages: package_resolutions,
-                symbols: symbol_resolutions,
-            },
-        );
-    }
-
-    if mappings.is_empty() {
+    if plan.partial_swaps.is_empty() {
         return Ok(ApplyPartialVendorSwapsResult {
             artifact,
-            manifest: PartialSwapResolutionManifest {
+            manifest: ResolutionManifest {
                 resolutions,
                 counts: PartialSwapResolutionCounts {
                     chunks: 0,
@@ -1376,7 +894,7 @@ pub fn apply_partial_vendor_swaps(
     let outcome = dispatch_partial_swap_jobs(
         &mut artifact,
         &chunk_table,
-        &mappings,
+        &plan.partial_swaps,
         references,
         &mut resolutions,
         rewrite_partial_swap_in_file,
@@ -1388,10 +906,10 @@ pub fn apply_partial_vendor_swaps(
         .sum();
     Ok(ApplyPartialVendorSwapsResult {
         artifact,
-        manifest: PartialSwapResolutionManifest {
+        manifest: ResolutionManifest {
             resolutions,
             counts: PartialSwapResolutionCounts {
-                chunks: ops.len(),
+                chunks: plan.partial_swaps.len(),
                 symbols: total_symbols,
                 references_rewritten: outcome.total_references,
             },
@@ -1399,152 +917,27 @@ pub fn apply_partial_vendor_swaps(
     })
 }
 
+/// Apply the plan's bundled partial swaps: write the planned bundle
+/// copy + facades, rewrite consumer imports / references against the
+/// facades, and seed the vendor chunk's self-rewrite. Validation,
+/// facade planning, and resolution happened at plan time.
 pub fn apply_bundled_partial_vendor_swaps(
     mut artifact: ChunkBundle,
-    vendor: &BTreeMap<String, VendorMark>,
+    plan: &VendorResolutionPlan,
     references: &ArtifactIndexes,
-    options: ApplyBundledPartialVendorSwapsOptions<'_>,
+    write: bool,
 ) -> Result<ApplyBundledPartialVendorSwapsResult> {
-    let ops: Vec<(&String, &BundledPartialSwapMark)> = vendor
-        .iter()
-        .filter_map(|(chunk_path, mark)| match &mark.level {
-            VendorLevel::BundledPartialSwap(bundled) => Some((chunk_path, bundled)),
-            _ => None,
-        })
-        .collect();
     let chunk_table = artifact.chunk_table.clone();
+    let mut resolutions: BTreeMap<String, ChunkBundledPartialSwapResolution> = plan
+        .bundled_partial_swaps
+        .values()
+        .map(|bundled| (bundled.chunk_path.clone(), bundled.resolution.clone()))
+        .collect();
 
-    let mut mappings: BundledPartialSwapMappings = BTreeMap::new();
-    let mut resolutions: BTreeMap<String, ChunkBundledPartialSwapResolution> = BTreeMap::new();
-
-    for (chunk_path, bundled) in &ops {
-        let chunk =
-            resolve_vendor_chunk(&artifact, "apply_bundled_partial_vendor_swaps", chunk_path)?;
-        let entry_ast = vendor_entry_ast(&artifact, "apply_bundled_partial_vendor_swaps", &chunk)?;
-        let chunk_exports = collect_exported_names(&entry_ast.module);
-
-        validate_partial_swap_symbols(
-            "apply_bundled_partial_vendor_swaps",
-            chunk_path,
-            &chunk.chunk_name,
-            &chunk_exports,
-            &bundled.symbols,
-            Some(&bundled.packages),
-        )?;
-
-        let bundle_code = fs::read_to_string(&bundled.bundle.path)
-            .with_context(|| format!("reading {}", bundled.bundle.path.display()))?;
-        let bundle_ast = parse_js_module(&bundled.bundle.path.display().to_string(), &bundle_code)?;
-        let bundle_exports = collect_exported_names(&bundle_ast.module);
-        for (package_name, package) in &bundled.packages {
-            if package.bundle_export != "default" && !is_valid_identifier(&package.bundle_export) {
-                bail!(
-                    "apply_bundled_partial_vendor_swaps vendor entry {chunk_path}: package `{package_name}` bundle_export `{}` is not a valid JS identifier",
-                    package.bundle_export
-                );
-            }
-            if !bundle_exports.contains(&package.bundle_export) {
-                bail!(
-                    "apply_bundled_partial_vendor_swaps vendor entry {chunk_path}: package `{package_name}` targets bundle export `{}` but bundle exports only [{}]",
-                    package.bundle_export,
-                    bundle_exports.iter().cloned().collect::<Vec<_>>().join(",")
-                );
-            }
-        }
-
-        let generated = write_bundled_partial_swap_assets_if_requested(
-            options.write,
-            options.output_wrapper_dir.as_deref(),
-            &chunk.chunk_name,
-            &bundled.bundle.path,
-            &bundle_code,
-            &bundled.packages,
-        )?;
-
-        let generated_bundle_path = options
-            .output_manifest_path
-            .as_deref()
-            .map(|manifest_path| manifest_relative_path(manifest_path, &generated.bundle_abs_path));
-        let bundle_resolution = BundledPartialSwapBundleResolution {
-            source_path: bundled.bundle.path.display().to_string(),
-            generated_bundle_path,
-        };
-
-        let mut package_resolutions: BTreeMap<String, BundledPartialSwapPackageResolution> =
-            BTreeMap::new();
-        let mut package_targets: BTreeMap<String, BundledPartialSwapPackageTarget> =
-            BTreeMap::new();
-        let resolve_options = ResolvePartialSwapPackageOptions {
-            stage: "apply_bundled_partial_vendor_swaps",
-            chunk_path,
-            package_roots: options.package_roots,
-            packages_root: options.packages_root,
-        };
-        for (package_name, package) in &bundled.packages {
-            let any_member_like_for_package = bundled.symbols.values().any(|s| {
-                s.package == *package_name
-                    && matches!(s.kind, PartialSwapKind::Member | PartialSwapKind::Named)
-            });
-            resolve_partial_swap_package(
-                &resolve_options,
-                package_name,
-                PartialSwapPackageCoords::from(package),
-                any_member_like_for_package.then_some("kind=member/named"),
-            )?;
-            let facade = generated.facades.get(package_name).with_context(|| {
-                format!(
-                    "apply_bundled_partial_vendor_swaps generated no facade for package `{package_name}`"
-                )
-            })?;
-            let generated_facade_path = options
-                .output_manifest_path
-                .as_deref()
-                .map(|manifest_path| manifest_relative_path(manifest_path, &facade.abs_path));
-            package_resolutions.insert(
-                package_name.clone(),
-                BundledPartialSwapPackageResolution {
-                    namespace: package.namespace.clone(),
-                    version: package.version.clone(),
-                    subpath: package.subpath.clone(),
-                    bundle_export: package.bundle_export.clone(),
-                    generated_facade_path,
-                },
-            );
-            package_targets.insert(
-                package_name.clone(),
-                BundledPartialSwapPackageTarget {
-                    namespace: package.namespace.clone(),
-                    facade_app_path: facade.app_path.clone(),
-                },
-            );
-        }
-
-        let (symbol_resolutions, chunk_targets) =
-            build_partial_swap_symbol_tables(&bundled.symbols);
-        mappings.insert(
-            chunk.chunk_id,
-            ChunkBundledPartialSwapMapping {
-                chunk_path: (*chunk_path).clone(),
-                packages: package_targets,
-                symbols: chunk_targets,
-            },
-        );
-        resolutions.insert(
-            (*chunk_path).clone(),
-            ChunkBundledPartialSwapResolution {
-                chunk_id: chunk.chunk_name,
-                chunk_path: (*chunk_path).clone(),
-                bundle: bundle_resolution,
-                packages: package_resolutions,
-                symbols: symbol_resolutions,
-            },
-        );
-    }
-
-    if mappings.is_empty() {
+    if plan.bundled_partial_swaps.is_empty() {
         return Ok(ApplyBundledPartialVendorSwapsResult {
             artifact,
-            manifest: BundledPartialSwapResolutionManifest {
+            manifest: ResolutionManifest {
                 resolutions,
                 counts: PartialSwapResolutionCounts {
                     chunks: 0,
@@ -1556,10 +949,16 @@ pub fn apply_bundled_partial_vendor_swaps(
         });
     }
 
+    if write {
+        for bundled in plan.bundled_partial_swaps.values() {
+            write_planned_bundled_assets(&bundled.assets)?;
+        }
+    }
+
     let outcome = dispatch_partial_swap_jobs(
         &mut artifact,
         &chunk_table,
-        &mappings,
+        &plan.bundled_partial_swaps,
         references,
         &mut resolutions,
         rewrite_bundled_partial_swap_in_file,
@@ -1568,9 +967,9 @@ pub fn apply_bundled_partial_vendor_swaps(
     let mut self_rewrite_import_locals_by_chunk_path: BTreeMap<String, BTreeSet<Id>> =
         BTreeMap::new();
     for (caller_chunk_id, locals) in &outcome.self_rewrite_locals_by_caller {
-        if let Some(mapping) = mappings.get(caller_chunk_id) {
+        if let Some(bundled) = plan.bundled_partial_swaps.get(caller_chunk_id) {
             self_rewrite_import_locals_by_chunk_path
-                .entry(mapping.chunk_path.clone())
+                .entry(bundled.chunk_path.clone())
                 .or_default()
                 .extend(locals.clone());
         }
@@ -1582,10 +981,10 @@ pub fn apply_bundled_partial_vendor_swaps(
         .sum();
     Ok(ApplyBundledPartialVendorSwapsResult {
         artifact,
-        manifest: BundledPartialSwapResolutionManifest {
+        manifest: ResolutionManifest {
             resolutions,
             counts: PartialSwapResolutionCounts {
-                chunks: ops.len(),
+                chunks: plan.bundled_partial_swaps.len(),
                 symbols: total_symbols,
                 references_rewritten: outcome.total_references,
             },
@@ -1616,7 +1015,7 @@ struct PartialSwapFileResult {
 fn rewrite_partial_swap_in_file(
     mut job: PartialSwapFileJob,
     references: &ArtifactIndexes,
-    mappings: &PartialSwapMappings,
+    mappings: &BTreeMap<ChunkId, ChunkPartialSwapPlan>,
     chunk_table: &ChunkTable,
     materialized_index: &MaterializedOutputChunkIndex,
 ) -> PartialSwapFileResult {
@@ -1768,7 +1167,7 @@ fn rewrite_partial_swap_export_from_decls(
     references: &ArtifactIndexes,
     chunk_table: &ChunkTable,
     materialized_index: &MaterializedOutputChunkIndex,
-    mappings: &PartialSwapMappings,
+    mappings: &BTreeMap<ChunkId, ChunkPartialSwapPlan>,
     references_by_symbol: &mut BTreeMap<(ChunkId, String), usize>,
 ) -> Vec<ModuleItem> {
     let mut new_body: Vec<ModuleItem> = Vec::with_capacity(original_body.len());
@@ -1859,7 +1258,7 @@ fn rewrite_partial_swap_export_from_decls(
 fn rewrite_bundled_partial_swap_in_file(
     mut job: PartialSwapFileJob,
     references: &ArtifactIndexes,
-    mappings: &BundledPartialSwapMappings,
+    mappings: &BTreeMap<ChunkId, ChunkBundledPartialSwapPlan>,
     chunk_table: &ChunkTable,
     materialized_index: &MaterializedOutputChunkIndex,
 ) -> PartialSwapFileResult {
@@ -2096,7 +1495,7 @@ struct SelfRewriteOutputs<'a> {
 
 fn seed_bundled_partial_swap_self_rewrites(
     module: &Module,
-    chunk_mapping: Option<&ChunkBundledPartialSwapMapping>,
+    chunk_mapping: Option<&ChunkBundledPartialSwapPlan>,
     chunk_table: &ChunkTable,
     caller_chunk_id: ChunkId,
     caller_file_path: &str,
@@ -2644,26 +2043,20 @@ fn make_namespace_reexport(source: &str, exported: &str) -> ModuleItem {
 /// because per-member usage is not analyzed here.
 pub fn validate_partial_swap_consumers(
     artifact: &ChunkBundle,
-    vendor: &BTreeMap<String, VendorMark>,
+    plan: &VendorResolutionPlan,
     references: &ArtifactIndexes,
 ) -> Result<()> {
     let chunk_table = &artifact.chunk_table;
-    let mut swapped_by_chunk: BTreeMap<ChunkId, BTreeSet<String>> = BTreeMap::new();
-    for (chunk_path, mark) in vendor {
-        let symbols = match &mark.level {
-            VendorLevel::PartialSwap(partial) => &partial.symbols,
-            VendorLevel::BundledPartialSwap(partial) => &partial.symbols,
-            _ => continue,
-        };
-        let chunk_name = vendor_chunk_name(chunk_path, "validate_partial_swap_consumers")?;
-        // An entry naming a chunk absent from the table can never match a
-        // resolved consumer target; the earlier apply stages already bail
-        // on unknown chunks.
-        let Some(chunk_id) = chunk_table.get(&chunk_name) else {
-            continue;
-        };
-        swapped_by_chunk.insert(chunk_id, symbols.keys().cloned().collect());
-    }
+    let swapped_by_chunk: BTreeMap<ChunkId, BTreeSet<String>> = plan
+        .partial_swaps
+        .iter()
+        .map(|(chunk_id, partial)| (*chunk_id, partial.symbols.keys().cloned().collect()))
+        .chain(
+            plan.bundled_partial_swaps
+                .iter()
+                .map(|(chunk_id, bundled)| (*chunk_id, bundled.symbols.keys().cloned().collect())),
+        )
+        .collect();
     if swapped_by_chunk.is_empty() {
         return Ok(());
     }
@@ -2814,7 +2207,7 @@ mod tests {
     use artifact::{
         ChunkAnalysisReport, ChunkArtifact, ChunkMetadata, FileMetadata, FileRole, JsChunk, JsFile,
     };
-    use spec::VendorRole;
+    use spec::{VendorLevel, VendorMark, VendorRole};
 
     #[test]
     fn rename_vendor_exports_rewrites_multiple_vendor_targets_in_one_call() {
@@ -2868,7 +2261,18 @@ export { b as beta };
             ]);
 
             let references = ArtifactIndexes::build(&artifact).unwrap();
-            let result = rename_vendor_exports(artifact, &vendor, &references).unwrap();
+            let plan = build_vendor_resolution_plan(
+                &artifact,
+                &vendor,
+                &VendorPlanOptions {
+                    package_roots: &HashMap::new(),
+                    packages_root: &None,
+                    output_manifest_path: None,
+                    output_wrapper_dir: None,
+                },
+            )
+            .unwrap();
+            let result = rename_vendor_exports(artifact, &plan, &references).unwrap();
             let artifact = result.artifact;
             let manifest = result.manifest;
 

--- a/devinfra/js/debundle/vendor/plan.rs
+++ b/devinfra/js/debundle/vendor/plan.rs
@@ -1,0 +1,687 @@
+//! Read-only vendor resolution plan: the single post-prepare resolution
+//! oracle for the vendor waves.
+//!
+//! `build_vendor_resolution_plan` runs once, immediately after chunk
+//! preparation. It validates every vendor mark against the artifact in
+//! one pass (unknown chunk / missing entry, boundary-mapping collisions,
+//! wrapper-shape + `default_export_aliases` soundness, partial-swap
+//! symbol/package shape, installed-package versions) and records the
+//! resolved decisions: boundary mappings, full-swap wrapper text and
+//! output paths, partial/bundled swap symbol tables and facade targets,
+//! plus the wire-facing resolution projections the vendor manifests are
+//! built from. The wave entry points (`rename_vendor_exports`,
+//! `swap_vendor_chunks`, `apply_partial_vendor_swaps`,
+//! `apply_bundled_partial_vendor_swaps`, strip) consume the plan instead
+//! of re-resolving marks mid-pipeline; application (caller rewrites,
+//! file writes, chunk removal, strip) stays in the waves.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use rayon::prelude::*;
+use serde_json::Value;
+use swc_common::GLOBALS;
+
+use artifact::{ChunkBundle, ChunkId, get_chunk_entry_path, manifest_relative_path};
+use js_ast::parse_js_module;
+use spec::{
+    PartialSwapKind, PartialSwapPackage, PartialSwapSymbol, VendorLevel, VendorMark, WrapperShape,
+};
+
+use crate::manifests::{
+    BundledPartialSwapBundleResolution, BundledPartialSwapPackageResolution,
+    ChunkBundledPartialSwapResolution, ChunkPartialSwapResolution, PartialSwapPackageResolution,
+    VendorResolution,
+};
+use crate::validate::{
+    PartialSwapPackageCoords, ResolvePartialSwapPackageOptions, ResolvedVendorChunk,
+    build_partial_swap_symbol_resolutions, resolve_partial_swap_package,
+    validate_partial_swap_symbols, vendor_chunk_name, vendor_entry_ast,
+};
+use crate::wrappers::{
+    PlannedBundledAssets, generate_named_from_default_wrapper,
+    generate_named_from_json_default_wrapper, generate_named_from_module_default_wrapper,
+    plan_bundled_partial_swap_assets, set_diff, wrapper_output_path,
+};
+use crate::{
+    collect_boundary_mapping, collect_default_export_object_keys, collect_exported_names,
+    is_valid_identifier, module_has_export_star, read_installed_package_metadata,
+    resolve_package_subpath, validate_boundary_mapping_collisions,
+    verified_default_alias_export_names,
+};
+
+#[derive(Debug, Clone)]
+pub struct VendorPlanOptions<'a> {
+    pub package_roots: &'a HashMap<String, PathBuf>,
+    pub packages_root: &'a Option<PathBuf>,
+    /// Manifest path generated wrapper / facade paths are recorded
+    /// relative to in the wire resolutions.
+    pub output_manifest_path: Option<&'a Path>,
+    /// Output directory wrappers and facade bundles are planned under.
+    pub output_wrapper_dir: Option<&'a Path>,
+}
+
+pub struct VendorResolutionPlan {
+    /// `boundary_rename` + `swap` marks in chunk-path order, each with
+    /// its vendor-local → public export mapping (possibly empty).
+    pub(crate) boundary_renames: Vec<BoundaryRenamePlan>,
+    pub(crate) full_swaps: Vec<FullSwapPlan>,
+    pub(crate) partial_swaps: BTreeMap<ChunkId, ChunkPartialSwapPlan>,
+    pub(crate) bundled_partial_swaps: BTreeMap<ChunkId, ChunkBundledPartialSwapPlan>,
+}
+
+impl VendorResolutionPlan {
+    pub fn has_boundary_renames(&self) -> bool {
+        !self.boundary_renames.is_empty()
+    }
+
+    pub fn has_full_swaps(&self) -> bool {
+        !self.full_swaps.is_empty()
+    }
+
+    pub fn has_partial_swaps(&self) -> bool {
+        !self.partial_swaps.is_empty()
+    }
+
+    pub fn has_bundled_partial_swaps(&self) -> bool {
+        !self.bundled_partial_swaps.is_empty()
+    }
+}
+
+pub(crate) struct BoundaryRenamePlan {
+    pub(crate) chunk_path: String,
+    pub(crate) chunk_id: ChunkId,
+    pub(crate) entry_file: String,
+    /// Vendor-local binding name → public export name.
+    pub(crate) mapping: BTreeMap<String, String>,
+}
+
+pub(crate) struct FullSwapPlan {
+    pub(crate) chunk_id: ChunkId,
+    /// The chunk's export surface, consumed by the swap wave's
+    /// import-alignment check (which runs post-rename against the
+    /// then-current indexes).
+    pub(crate) vendor_exports: BTreeSet<String>,
+    /// Generated wrapper text + absolute output path; written during
+    /// the swap wave when writes are enabled.
+    pub(crate) wrapper: Option<PlannedWrapper>,
+    /// Wire-facing resolution projected from this plan entry.
+    pub(crate) resolution: VendorResolution,
+}
+
+pub(crate) struct PlannedWrapper {
+    pub(crate) abs_path: PathBuf,
+    pub(crate) source: String,
+}
+
+pub(crate) struct ChunkPartialSwapPlan {
+    pub(crate) chunk_path: String,
+    pub(crate) entry_file: String,
+    /// package_name → upstream coords (namespace, version, subpath).
+    pub(crate) packages: BTreeMap<String, PartialSwapPackage>,
+    /// chunk_export → which package + how to rewrite it.
+    pub(crate) symbols: BTreeMap<String, PartialSwapSymbol>,
+    /// Wire-facing resolution skeleton (zero-initialized rewrite counts).
+    pub(crate) resolution: ChunkPartialSwapResolution,
+}
+
+pub(crate) struct ChunkBundledPartialSwapPlan {
+    pub(crate) chunk_path: String,
+    pub(crate) entry_file: String,
+    /// package_name → namespace + generated facade target.
+    pub(crate) packages: BTreeMap<String, BundledPartialSwapPackageTarget>,
+    /// chunk_export → which package + how to rewrite it.
+    pub(crate) symbols: BTreeMap<String, PartialSwapSymbol>,
+    /// Bundle copy + per-package facades; written during the bundled
+    /// wave when writes are enabled.
+    pub(crate) assets: PlannedBundledAssets,
+    /// Wire-facing resolution skeleton (zero-initialized rewrite counts).
+    pub(crate) resolution: ChunkBundledPartialSwapResolution,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct BundledPartialSwapPackageTarget {
+    pub(crate) namespace: Option<String>,
+    pub(crate) facade_app_path: String,
+}
+
+pub fn build_vendor_resolution_plan(
+    artifact: &ChunkBundle,
+    vendor: &BTreeMap<String, VendorMark>,
+    options: &VendorPlanOptions<'_>,
+) -> Result<VendorResolutionPlan> {
+    // Mark validation: every vendor entry must name a known chunk with
+    // an entry file, regardless of level. One consolidated pass; later
+    // phases reuse the resolved chunks.
+    let mut resolved_chunks: BTreeMap<&str, ResolvedVendorChunk> = BTreeMap::new();
+    for chunk_path in vendor.keys() {
+        let chunk_name = vendor_chunk_name(chunk_path, "mark_vendor")?;
+        let chunk_id = artifact.chunk_table.get(&chunk_name).with_context(|| {
+            format!("vendor entry {chunk_path} targets unknown chunk: {chunk_name}")
+        })?;
+        let entry_file = get_chunk_entry_path(artifact, chunk_id).with_context(|| {
+            format!("vendor entry {chunk_path} targets missing chunk (chunk_id={chunk_name})")
+        })?;
+        resolved_chunks.insert(
+            chunk_path.as_str(),
+            ResolvedVendorChunk {
+                chunk_id,
+                chunk_name,
+                entry_file,
+            },
+        );
+    }
+
+    Ok(VendorResolutionPlan {
+        boundary_renames: plan_boundary_renames(artifact, vendor, &resolved_chunks)?,
+        full_swaps: plan_full_swaps(artifact, vendor, &resolved_chunks, options)?,
+        partial_swaps: plan_partial_swaps(artifact, vendor, &resolved_chunks, options)?,
+        bundled_partial_swaps: plan_bundled_partial_swaps(
+            artifact,
+            vendor,
+            &resolved_chunks,
+            options,
+        )?,
+    })
+}
+
+fn plan_boundary_renames(
+    artifact: &ChunkBundle,
+    vendor: &BTreeMap<String, VendorMark>,
+    resolved_chunks: &BTreeMap<&str, ResolvedVendorChunk>,
+) -> Result<Vec<BoundaryRenamePlan>> {
+    let mut plans = Vec::new();
+    for (chunk_path, _mark) in vendor.iter().filter(|(_, mark)| {
+        matches!(
+            mark.level,
+            VendorLevel::BoundaryRename | VendorLevel::Swap(_)
+        )
+    }) {
+        let chunk = &resolved_chunks[chunk_path.as_str()];
+        let vendor_ast = vendor_entry_ast(artifact, "rename_vendor_exports", chunk)?;
+        let mapping = collect_boundary_mapping(&vendor_ast.module);
+        validate_boundary_mapping_collisions(&vendor_ast.module, &mapping, chunk_path)?;
+        plans.push(BoundaryRenamePlan {
+            chunk_path: chunk_path.clone(),
+            chunk_id: chunk.chunk_id,
+            entry_file: chunk.entry_file.clone(),
+            mapping,
+        });
+    }
+    Ok(plans)
+}
+
+struct FullSwapJob {
+    chunk_path: String,
+    chunk_id: ChunkId,
+    chunk_name: String,
+    entry_file: String,
+    package: String,
+    version: String,
+    subpath: String,
+    wrapper_shape: Option<WrapperShape>,
+    vendor_exports: BTreeSet<String>,
+    /// Chunk export names verified to alias the chunk's own default
+    /// export (bound to the same local binding). Consumed by the
+    /// `named_from_module_default` wrapper-shape check.
+    vendor_default_aliases: BTreeSet<String>,
+}
+
+fn plan_full_swaps(
+    artifact: &ChunkBundle,
+    vendor: &BTreeMap<String, VendorMark>,
+    resolved_chunks: &BTreeMap<&str, ResolvedVendorChunk>,
+    options: &VendorPlanOptions<'_>,
+) -> Result<Vec<FullSwapPlan>> {
+    let mut jobs = Vec::new();
+    for (chunk_path, mark) in vendor {
+        let VendorLevel::Swap(swap) = &mark.level else {
+            continue;
+        };
+        let chunk = &resolved_chunks[chunk_path.as_str()];
+        let entry_ast = vendor_entry_ast(artifact, "swap_vendor_chunks", chunk)?;
+        let vendor_exports = collect_exported_names(&entry_ast.module);
+        let declared_default_aliases: BTreeSet<String> =
+            swap.default_export_aliases.iter().cloned().collect();
+        let unknown_aliases = set_diff(&declared_default_aliases, &vendor_exports);
+        if !unknown_aliases.is_empty() {
+            bail!(
+                "swap_vendor_chunks vendor entry {} default_export_aliases names exports the chunk does not declare: [{}]",
+                chunk_path,
+                unknown_aliases.into_iter().collect::<Vec<_>>().join(",")
+            );
+        }
+        // Author-asserted default aliases (see `SwapMark::default_export_aliases`)
+        // join the statically verified set so a chunk that re-exports the package
+        // default under a minified name without its own `default` export can still
+        // pass the `named_from_module_default` soundness check.
+        let mut vendor_default_aliases = verified_default_alias_export_names(&entry_ast.module);
+        vendor_default_aliases.extend(declared_default_aliases);
+        jobs.push(FullSwapJob {
+            chunk_path: chunk_path.clone(),
+            chunk_id: chunk.chunk_id,
+            chunk_name: chunk.chunk_name.clone(),
+            entry_file: chunk.entry_file.clone(),
+            package: swap.package.clone(),
+            version: swap.version.clone(),
+            subpath: swap.subpath.clone(),
+            wrapper_shape: swap.wrapper_shape,
+            vendor_exports,
+            vendor_default_aliases,
+        });
+    }
+    // Rayon workers don't inherit `GLOBALS`; re-set per worker so any
+    // `Mark::new()` / `Id` use stays in the caller's arena.
+    GLOBALS.with(|globals| {
+        jobs.into_par_iter()
+            .map(|job| GLOBALS.set(globals, || resolve_full_swap(job, options)))
+            .collect::<Result<Vec<_>>>()
+    })
+}
+
+fn resolve_full_swap(job: FullSwapJob, options: &VendorPlanOptions<'_>) -> Result<FullSwapPlan> {
+    let installed =
+        read_installed_package_metadata(&job.package, options.package_roots, options.packages_root)
+            .with_context(|| format!("reading metadata for package {}", job.package))?;
+    let installed_version = installed
+        .get("version")
+        .and_then(Value::as_str)
+        .context("package metadata missing version")?;
+    if installed_version != job.version {
+        bail!(
+            "swap_vendor_chunks vendor entry {} version mismatch for {}: spec={}, installed={installed_version}",
+            job.chunk_path,
+            job.package,
+            job.version,
+        );
+    }
+    let upstream_path = resolve_package_subpath(
+        &job.package,
+        &job.subpath,
+        options.package_roots,
+        options.packages_root,
+    )?;
+    let upstream_code = fs::read_to_string(&upstream_path)
+        .with_context(|| format!("reading {}", upstream_path.display()))?;
+
+    let wrapper_source = match job.wrapper_shape {
+        Some(WrapperShape::NamedFromDefault) => {
+            let upstream_ast =
+                parse_js_module(&upstream_path.display().to_string(), &upstream_code)?;
+            let object_keys =
+                collect_default_export_object_keys(&upstream_ast.module, &job.chunk_path)?;
+            let non_default_exports = job
+                .vendor_exports
+                .iter()
+                .filter(|name| name.as_str() != "default")
+                .cloned()
+                .collect::<BTreeSet<_>>();
+            let missing = set_diff(&non_default_exports, &object_keys);
+            if !missing.is_empty() {
+                bail!(
+                    "swap_vendor_chunks vendor entry {} named-from-default wrapper shape mismatch for {}@{}: vendor named exports missing from upstream default object keys=[{}]",
+                    job.chunk_path,
+                    job.package,
+                    job.version,
+                    missing.into_iter().collect::<Vec<_>>().join(",")
+                );
+            }
+            Some(generate_named_from_default_wrapper(
+                &upstream_ast,
+                &non_default_exports,
+            )?)
+        }
+        Some(WrapperShape::NamedFromJsonDefault) => {
+            let upstream_json = serde_json::from_str::<Value>(&upstream_code).with_context(|| {
+                format!(
+                    "swap_vendor_chunks vendor entry {} named-from-json-default: upstream JSON parse failed",
+                    job.chunk_path
+                )
+            })?;
+            let object = upstream_json
+                .as_object()
+                .context("named-from-json-default upstream JSON must be an object")?;
+            let object_keys = object.keys().cloned().collect::<BTreeSet<_>>();
+            let non_default_exports = job
+                .vendor_exports
+                .iter()
+                .filter(|name| name.as_str() != "default")
+                .cloned()
+                .collect::<BTreeSet<_>>();
+            let missing = set_diff(&non_default_exports, &object_keys);
+            if !missing.is_empty() {
+                bail!(
+                    "swap_vendor_chunks vendor entry {} named-from-json-default wrapper shape mismatch for {}@{}: vendor named exports missing from upstream JSON keys=[{}]",
+                    job.chunk_path,
+                    job.package,
+                    job.version,
+                    missing.into_iter().collect::<Vec<_>>().join(",")
+                );
+            }
+            Some(generate_named_from_json_default_wrapper(
+                &upstream_json,
+                &non_default_exports,
+            )?)
+        }
+        Some(WrapperShape::NamedFromModuleDefault) => {
+            // The wrapper re-exports the upstream default under every
+            // vendor named-export name (`export const <name> =
+            // <default>;`). That equation only holds when the chunk
+            // itself binds <name> to the same local as its default
+            // export; anything else would silently alias an unrelated
+            // export to the upstream default.
+            let claimed = job
+                .vendor_exports
+                .iter()
+                .filter(|name| name.as_str() != "default")
+                .cloned()
+                .collect::<BTreeSet<_>>();
+            let unverified = set_diff(&claimed, &job.vendor_default_aliases);
+            if !unverified.is_empty() {
+                bail!(
+                    "swap_vendor_chunks vendor entry {} named-from-module-default: vendor named exports [{}] are not verified aliases of the chunk's default export; the wrapper would re-export the upstream default under unrelated names",
+                    job.chunk_path,
+                    unverified.into_iter().collect::<Vec<_>>().join(","),
+                );
+            }
+            let upstream_ast =
+                parse_js_module(&upstream_path.display().to_string(), &upstream_code)?;
+            Some(generate_named_from_module_default_wrapper(
+                &upstream_ast,
+                &job.vendor_exports,
+                &job.chunk_path,
+            )?)
+        }
+        None => {
+            let upstream_ast =
+                parse_js_module(&upstream_path.display().to_string(), &upstream_code)?;
+            let upstream_exports = collect_exported_names(&upstream_ast.module);
+            let missing = set_diff(&job.vendor_exports, &upstream_exports);
+            if !missing.is_empty() {
+                bail!(
+                    "swap_vendor_chunks vendor entry {} export shape mismatch for {}@{}: vendor exports not found upstream=[{}]",
+                    job.chunk_path,
+                    job.package,
+                    job.version,
+                    missing.into_iter().collect::<Vec<_>>().join(",")
+                );
+            }
+            None
+        }
+    };
+
+    let wrapper = wrapper_source
+        .zip(options.output_wrapper_dir)
+        .map(|(source, wrapper_dir)| PlannedWrapper {
+            abs_path: wrapper_output_path(wrapper_dir, &job.chunk_name, &job.entry_file),
+            source,
+        });
+    let generated_wrapper_path = wrapper.as_ref().and_then(|wrapper| {
+        options
+            .output_manifest_path
+            .map(|manifest_path| manifest_relative_path(manifest_path, &wrapper.abs_path))
+    });
+    Ok(FullSwapPlan {
+        chunk_id: job.chunk_id,
+        vendor_exports: job.vendor_exports,
+        wrapper,
+        resolution: VendorResolution {
+            chunk_id: job.chunk_name,
+            chunk_path: job.chunk_path,
+            entry_file: job.entry_file,
+            package: job.package,
+            version: job.version,
+            subpath: job.subpath,
+            wrapper_shape: job.wrapper_shape,
+            generated_wrapper_path,
+        },
+    })
+}
+
+fn plan_partial_swaps(
+    artifact: &ChunkBundle,
+    vendor: &BTreeMap<String, VendorMark>,
+    resolved_chunks: &BTreeMap<&str, ResolvedVendorChunk>,
+    options: &VendorPlanOptions<'_>,
+) -> Result<BTreeMap<ChunkId, ChunkPartialSwapPlan>> {
+    let mut plans = BTreeMap::new();
+    for (chunk_path, mark) in vendor {
+        let VendorLevel::PartialSwap(partial) = &mark.level else {
+            continue;
+        };
+        let chunk = &resolved_chunks[chunk_path.as_str()];
+        let entry_ast = vendor_entry_ast(artifact, "apply_partial_vendor_swaps", chunk)?;
+        // `default` is a swappable name when the chunk binds it via the
+        // named form (`export { x as default }`), which the strip pass
+        // can map to a chunk-local binding.
+        let chunk_exports = collect_exported_names(&entry_ast.module);
+
+        validate_partial_swap_symbols::<PartialSwapPackage>(
+            "apply_partial_vendor_swaps",
+            chunk_path,
+            &chunk.chunk_name,
+            &chunk_exports,
+            &partial.symbols,
+            None,
+        )?;
+
+        // Per-package validation: installed version + upstream subpath
+        // exists + every declared upstream_export is actually a named
+        // export of the upstream subpath.
+        let resolve_options = ResolvePartialSwapPackageOptions {
+            stage: "apply_partial_vendor_swaps",
+            chunk_path,
+            package_roots: options.package_roots,
+            packages_root: options.packages_root,
+        };
+        let mut package_resolutions: BTreeMap<String, PartialSwapPackageResolution> =
+            BTreeMap::new();
+        for (package_name, package) in &partial.packages {
+            let any_member_for_package = partial
+                .symbols
+                .values()
+                .any(|s| s.package == *package_name && matches!(s.kind, PartialSwapKind::Member));
+            let upstream_path = resolve_partial_swap_package(
+                &resolve_options,
+                package_name,
+                PartialSwapPackageCoords::from(package),
+                any_member_for_package.then_some("kind=member"),
+            )?;
+            let upstream_code = fs::read_to_string(&upstream_path)
+                .with_context(|| format!("reading {}", upstream_path.display()))?;
+            let upstream_ast =
+                parse_js_module(&upstream_path.display().to_string(), &upstream_code)?;
+            let upstream_exports = collect_exported_names(&upstream_ast.module);
+            // Packages that re-export everything from a sibling module
+            // (`export * from "./other.js"`) can't be fully enumerated
+            // by a single-file `collect_exported_names`. Skip the strict
+            // name check in that case — the caller's spec is responsible
+            // for naming a real upstream symbol. (zod's `index.js` is the
+            // canonical example: `export * from "./v4/classic/external.js"`
+            // is the only way the named schemas like `object`, `array`
+            // become visible.)
+            let upstream_has_export_star = module_has_export_star(&upstream_ast.module);
+            for (chunk_export, symbol) in &partial.symbols {
+                if symbol.package != *package_name {
+                    continue;
+                }
+                // Only kind=member symbols cite an upstream named
+                // export; kind=namespace/default replace the whole
+                // import with a namespace/default reference, no
+                // member-name lookup needed.
+                let Some(upstream_export) = symbol.upstream_export.as_deref() else {
+                    continue;
+                };
+                if upstream_has_export_star {
+                    continue;
+                }
+                if !upstream_exports.contains(upstream_export) {
+                    bail!(
+                        "apply_partial_vendor_swaps vendor entry {chunk_path}: symbol `{chunk_export}` targets {package_name}#{upstream_export} but upstream does not export it (known: [{}])",
+                        upstream_exports
+                            .iter()
+                            .cloned()
+                            .collect::<Vec<_>>()
+                            .join(",")
+                    );
+                }
+            }
+            package_resolutions.insert(
+                package_name.clone(),
+                PartialSwapPackageResolution {
+                    namespace: package.namespace.clone(),
+                    version: package.version.clone(),
+                    subpath: package.subpath.clone(),
+                },
+            );
+        }
+
+        plans.insert(
+            chunk.chunk_id,
+            ChunkPartialSwapPlan {
+                chunk_path: chunk_path.clone(),
+                entry_file: chunk.entry_file.clone(),
+                packages: partial.packages.clone(),
+                symbols: partial.symbols.clone(),
+                resolution: ChunkPartialSwapResolution {
+                    chunk_id: chunk.chunk_name.clone(),
+                    chunk_path: chunk_path.clone(),
+                    packages: package_resolutions,
+                    symbols: build_partial_swap_symbol_resolutions(&partial.symbols),
+                },
+            },
+        );
+    }
+    Ok(plans)
+}
+
+fn plan_bundled_partial_swaps(
+    artifact: &ChunkBundle,
+    vendor: &BTreeMap<String, VendorMark>,
+    resolved_chunks: &BTreeMap<&str, ResolvedVendorChunk>,
+    options: &VendorPlanOptions<'_>,
+) -> Result<BTreeMap<ChunkId, ChunkBundledPartialSwapPlan>> {
+    let mut plans = BTreeMap::new();
+    for (chunk_path, mark) in vendor {
+        let VendorLevel::BundledPartialSwap(bundled) = &mark.level else {
+            continue;
+        };
+        let chunk = &resolved_chunks[chunk_path.as_str()];
+        let entry_ast = vendor_entry_ast(artifact, "apply_bundled_partial_vendor_swaps", chunk)?;
+        let chunk_exports = collect_exported_names(&entry_ast.module);
+
+        validate_partial_swap_symbols(
+            "apply_bundled_partial_vendor_swaps",
+            chunk_path,
+            &chunk.chunk_name,
+            &chunk_exports,
+            &bundled.symbols,
+            Some(&bundled.packages),
+        )?;
+
+        let bundle_code = fs::read_to_string(&bundled.bundle.path)
+            .with_context(|| format!("reading {}", bundled.bundle.path.display()))?;
+        let bundle_ast = parse_js_module(&bundled.bundle.path.display().to_string(), &bundle_code)?;
+        let bundle_exports = collect_exported_names(&bundle_ast.module);
+        for (package_name, package) in &bundled.packages {
+            if package.bundle_export != "default" && !is_valid_identifier(&package.bundle_export) {
+                bail!(
+                    "apply_bundled_partial_vendor_swaps vendor entry {chunk_path}: package `{package_name}` bundle_export `{}` is not a valid JS identifier",
+                    package.bundle_export
+                );
+            }
+            if !bundle_exports.contains(&package.bundle_export) {
+                bail!(
+                    "apply_bundled_partial_vendor_swaps vendor entry {chunk_path}: package `{package_name}` targets bundle export `{}` but bundle exports only [{}]",
+                    package.bundle_export,
+                    bundle_exports.iter().cloned().collect::<Vec<_>>().join(",")
+                );
+            }
+        }
+
+        let assets = plan_bundled_partial_swap_assets(
+            options.output_wrapper_dir,
+            &chunk.chunk_name,
+            &bundled.bundle.path,
+            bundle_code,
+            &bundled.packages,
+        )?;
+
+        let generated_bundle_path = options
+            .output_manifest_path
+            .map(|manifest_path| manifest_relative_path(manifest_path, &assets.bundle_abs_path));
+        let bundle_resolution = BundledPartialSwapBundleResolution {
+            source_path: bundled.bundle.path.display().to_string(),
+            generated_bundle_path,
+        };
+
+        let mut package_resolutions: BTreeMap<String, BundledPartialSwapPackageResolution> =
+            BTreeMap::new();
+        let mut package_targets: BTreeMap<String, BundledPartialSwapPackageTarget> =
+            BTreeMap::new();
+        let resolve_options = ResolvePartialSwapPackageOptions {
+            stage: "apply_bundled_partial_vendor_swaps",
+            chunk_path,
+            package_roots: options.package_roots,
+            packages_root: options.packages_root,
+        };
+        for (package_name, package) in &bundled.packages {
+            let any_member_like_for_package = bundled.symbols.values().any(|s| {
+                s.package == *package_name
+                    && matches!(s.kind, PartialSwapKind::Member | PartialSwapKind::Named)
+            });
+            resolve_partial_swap_package(
+                &resolve_options,
+                package_name,
+                PartialSwapPackageCoords::from(package),
+                any_member_like_for_package.then_some("kind=member/named"),
+            )?;
+            let facade = assets.facades.get(package_name).with_context(|| {
+                format!(
+                    "apply_bundled_partial_vendor_swaps generated no facade for package `{package_name}`"
+                )
+            })?;
+            let generated_facade_path = options
+                .output_manifest_path
+                .map(|manifest_path| manifest_relative_path(manifest_path, &facade.abs_path));
+            package_resolutions.insert(
+                package_name.clone(),
+                BundledPartialSwapPackageResolution {
+                    namespace: package.namespace.clone(),
+                    version: package.version.clone(),
+                    subpath: package.subpath.clone(),
+                    bundle_export: package.bundle_export.clone(),
+                    generated_facade_path,
+                },
+            );
+            package_targets.insert(
+                package_name.clone(),
+                BundledPartialSwapPackageTarget {
+                    namespace: package.namespace.clone(),
+                    facade_app_path: facade.app_path.clone(),
+                },
+            );
+        }
+
+        plans.insert(
+            chunk.chunk_id,
+            ChunkBundledPartialSwapPlan {
+                chunk_path: chunk_path.clone(),
+                entry_file: chunk.entry_file.clone(),
+                packages: package_targets,
+                symbols: bundled.symbols.clone(),
+                assets,
+                resolution: ChunkBundledPartialSwapResolution {
+                    chunk_id: chunk.chunk_name.clone(),
+                    chunk_path: chunk_path.clone(),
+                    bundle: bundle_resolution,
+                    packages: package_resolutions,
+                    symbols: build_partial_swap_symbol_resolutions(&bundled.symbols),
+                },
+            },
+        );
+    }
+    Ok(plans)
+}

--- a/devinfra/js/debundle/vendor/strip.rs
+++ b/devinfra/js/debundle/vendor/strip.rs
@@ -15,11 +15,11 @@ use swc_ecma_codegen::text_writer::JsWriter;
 use swc_ecma_codegen::{Config, Emitter};
 use swc_ecma_visit::{Visit, VisitWith};
 
-use artifact::{ChunkBundle, JsFile, JsFileAstParts, get_chunk_entry_path};
+use artifact::{ChunkBundle, JsFile, JsFileAstParts};
 use js_ast::ParsedJsModule;
-use spec::{PartialSwapSymbol, VendorLevel, VendorMark};
+use spec::PartialSwapSymbol;
 
-use crate::validate::vendor_chunk_name;
+use crate::plan::VendorResolutionPlan;
 
 pub struct StripSwappedVendorExportsResult {
     pub artifact: ChunkBundle,
@@ -56,10 +56,42 @@ pub struct ChunkStripStats {
 /// byte-identical to pre-swap.
 pub fn strip_swapped_vendor_exports_with_options(
     mut artifact: ChunkBundle,
-    vendor: &BTreeMap<String, VendorMark>,
+    plan: &VendorResolutionPlan,
     options: StripSwappedVendorExportsOptions,
 ) -> Result<StripSwappedVendorExportsResult> {
-    let chunk_table = artifact.chunk_table.clone();
+    // Strip inputs come straight from the vendor plan: partial and
+    // bundled-partial entries, merged back into chunk-path order.
+    #[derive(Clone, Copy)]
+    struct StripSource<'a> {
+        chunk_path: &'a str,
+        chunk_name: &'a str,
+        chunk_id: ChunkId,
+        entry_file: &'a str,
+        symbols: &'a BTreeMap<String, PartialSwapSymbol>,
+    }
+    let sources: BTreeMap<&str, StripSource<'_>> = plan
+        .partial_swaps
+        .iter()
+        .map(|(chunk_id, partial)| StripSource {
+            chunk_path: &partial.chunk_path,
+            chunk_name: &partial.resolution.chunk_id,
+            chunk_id: *chunk_id,
+            entry_file: &partial.entry_file,
+            symbols: &partial.symbols,
+        })
+        .chain(
+            plan.bundled_partial_swaps
+                .iter()
+                .map(|(chunk_id, bundled)| StripSource {
+                    chunk_path: &bundled.chunk_path,
+                    chunk_name: &bundled.resolution.chunk_id,
+                    chunk_id: *chunk_id,
+                    entry_file: &bundled.entry_file,
+                    symbols: &bundled.symbols,
+                }),
+        )
+        .map(|source| (source.chunk_path, source))
+        .collect();
 
     // Phase 1 (sequential): pull every vendor entry's entry-file AST
     // out of the artifact and bundle the per-chunk inputs into a
@@ -67,29 +99,18 @@ pub fn strip_swapped_vendor_exports_with_options(
     // `&mut artifact`; doing the round-trip here means the actual
     // strip work can borrow only owned data and run in parallel.
     let mut jobs: Vec<StripJob<'_>> = Vec::new();
-    for (chunk_path, mark) in vendor {
-        let symbols = match &mark.level {
-            VendorLevel::PartialSwap(partial) => &partial.symbols,
-            VendorLevel::BundledPartialSwap(partial) => &partial.symbols,
-            _ => continue,
-        };
-
-        let chunk_name = vendor_chunk_name(chunk_path, "strip_swapped_vendor_exports")?;
-        let chunk_id = chunk_table.get(&chunk_name).with_context(|| {
-            format!(
-                "strip_swapped_vendor_exports vendor entry {chunk_path} targets unknown chunk: {chunk_name}"
-            )
-        })?;
-        let entry_relative_file = get_chunk_entry_path(&artifact, chunk_id).with_context(|| {
-            format!(
-                "strip_swapped_vendor_exports vendor entry {chunk_path} targets missing chunk (chunk_id={chunk_name})"
-            )
-        })?;
-
+    for source in sources.values() {
+        let StripSource {
+            chunk_path,
+            chunk_name,
+            chunk_id,
+            entry_file,
+            symbols,
+        } = *source;
         let js_chunk = artifact.js_chunk_mut(chunk_id)?;
-        let file = js_chunk.remove_file(&entry_relative_file).with_context(|| {
+        let file = js_chunk.remove_file(entry_file).with_context(|| {
             format!(
-                "strip_swapped_vendor_exports vendor entry {chunk_path}: entry file {entry_relative_file} missing from chunk {chunk_name}"
+                "strip_swapped_vendor_exports vendor entry {chunk_path}: entry file {entry_file} missing from chunk {chunk_name}"
             )
         })?;
         let (parts, ast) = file.into_ast_parts().with_context(|| {

--- a/devinfra/js/debundle/vendor/validate.rs
+++ b/devinfra/js/debundle/vendor/validate.rs
@@ -1,10 +1,9 @@
-//! Shared validate/resolve helpers for the vendor passes.
+//! Shared validate/resolve helpers for vendor-plan construction.
 //!
-//! `apply_partial_vendor_swaps` and `apply_bundled_partial_vendor_swaps`
-//! perform near-identical validation/resolution of their vendor marks;
-//! the shared pieces live here so the dispatchers shrink to
-//! mode-specific glue. Every helper takes a `stage` name so diagnostics
-//! keep their per-dispatcher prefix.
+//! The partial and bundled-partial plan phases perform near-identical
+//! validation/resolution of their vendor marks; the shared pieces live
+//! here so the phases shrink to mode-specific glue. Every helper takes
+//! a `stage` name so diagnostics keep their per-level prefix.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::PathBuf;
@@ -12,15 +11,12 @@ use std::path::PathBuf;
 use anyhow::{Context, Result, bail};
 use serde_json::Value;
 
-use artifact::{ChunkBundle, ChunkId, get_chunk_entry_path};
+use artifact::{ChunkBundle, ChunkId};
 use js_ast::ParsedJsModule;
 use spec::{BundledPartialSwapPackage, PartialSwapKind, PartialSwapPackage, PartialSwapSymbol};
 
 use crate::manifests::PartialSwapSymbolResolution;
-use crate::{
-    PartialSwapSymbolTarget, is_valid_identifier, read_installed_package_metadata,
-    resolve_package_subpath,
-};
+use crate::{is_valid_identifier, read_installed_package_metadata, resolve_package_subpath};
 
 /// Parse the vendor map key `<chunk_name>.js` into the chunk name.
 pub(crate) fn vendor_chunk_name(chunk_path: &str, stage: &str) -> Result<String> {
@@ -39,25 +35,6 @@ pub(crate) struct ResolvedVendorChunk {
     pub chunk_id: ChunkId,
     pub chunk_name: String,
     pub entry_file: String,
-}
-
-pub(crate) fn resolve_vendor_chunk(
-    artifact: &ChunkBundle,
-    stage: &str,
-    chunk_path: &str,
-) -> Result<ResolvedVendorChunk> {
-    let chunk_name = vendor_chunk_name(chunk_path, stage)?;
-    let chunk_id = artifact.chunk_table.get(&chunk_name).with_context(|| {
-        format!("{stage} vendor entry {chunk_path} targets unknown chunk: {chunk_name}")
-    })?;
-    let entry_file = get_chunk_entry_path(artifact, chunk_id).with_context(|| {
-        format!("{stage} vendor entry {chunk_path} targets missing chunk (chunk_id={chunk_name})")
-    })?;
-    Ok(ResolvedVendorChunk {
-        chunk_id,
-        chunk_name,
-        entry_file,
-    })
 }
 
 pub(crate) fn vendor_entry_ast<'a>(
@@ -226,35 +203,23 @@ pub(crate) fn resolve_partial_swap_package(
 }
 
 /// Build the wire-facing symbol resolutions (zero-initialized rewrite
-/// counts) and the in-memory rewrite targets from a mark's symbol map.
-pub(crate) fn build_partial_swap_symbol_tables(
+/// counts) from a mark's symbol map.
+pub(crate) fn build_partial_swap_symbol_resolutions(
     symbols: &BTreeMap<String, PartialSwapSymbol>,
-) -> (
-    BTreeMap<String, PartialSwapSymbolResolution>,
-    BTreeMap<String, PartialSwapSymbolTarget>,
-) {
-    let mut symbol_resolutions = BTreeMap::new();
-    let mut chunk_targets = BTreeMap::new();
-    for (chunk_export, symbol) in symbols {
-        symbol_resolutions.insert(
-            chunk_export.clone(),
-            PartialSwapSymbolResolution {
-                package: symbol.package.clone(),
-                kind: symbol.kind,
-                upstream_export: symbol.upstream_export.clone(),
-                local: symbol.local.clone(),
-                references_rewritten: 0,
-            },
-        );
-        chunk_targets.insert(
-            chunk_export.clone(),
-            PartialSwapSymbolTarget {
-                package: symbol.package.clone(),
-                kind: symbol.kind,
-                upstream_export: symbol.upstream_export.clone(),
-                local: symbol.local.clone(),
-            },
-        );
-    }
-    (symbol_resolutions, chunk_targets)
+) -> BTreeMap<String, PartialSwapSymbolResolution> {
+    symbols
+        .iter()
+        .map(|(chunk_export, symbol)| {
+            (
+                chunk_export.clone(),
+                PartialSwapSymbolResolution {
+                    package: symbol.package.clone(),
+                    kind: symbol.kind,
+                    upstream_export: symbol.upstream_export.clone(),
+                    local: symbol.local.clone(),
+                    references_rewritten: 0,
+                },
+            )
+        })
+        .collect()
 }

--- a/devinfra/js/debundle/vendor/wrappers.rs
+++ b/devinfra/js/debundle/vendor/wrappers.rs
@@ -234,46 +234,49 @@ pub(super) fn generate_named_from_module_default_wrapper(
     )
 }
 
-pub(super) fn write_wrapper_if_requested(
-    write: bool,
-    output_wrapper_dir: Option<&Path>,
+/// Absolute output path of a full-swap wrapper:
+/// `<output_wrapper_dir>/<chunk_id>/<entry_file>`.
+pub(super) fn wrapper_output_path(
+    output_wrapper_dir: &Path,
     chunk_id: &str,
     entry_file: &str,
-    source: &str,
-) -> Result<Option<PathBuf>> {
-    let Some(output_wrapper_dir) = output_wrapper_dir else {
-        return Ok(None);
-    };
-    let wrapper_abs_path = output_wrapper_dir
+) -> PathBuf {
+    output_wrapper_dir
         .join(path_from_module_path(chunk_id))
-        .join(path_from_module_path(entry_file));
-    if write {
-        if let Some(parent) = wrapper_abs_path.parent() {
-            fs::create_dir_all(parent)?;
-        }
-        fs::write(&wrapper_abs_path, source)?;
+        .join(path_from_module_path(entry_file))
+}
+
+pub(super) fn write_planned_wrapper(abs_path: &Path, source: &str) -> Result<()> {
+    if let Some(parent) = abs_path.parent() {
+        fs::create_dir_all(parent)?;
     }
-    Ok(Some(wrapper_abs_path))
+    fs::write(abs_path, source)?;
+    Ok(())
 }
 
-pub(super) struct BundledGeneratedAssets {
+/// Bundle copy + per-package facades planned for a bundled partial
+/// swap: paths and generated sources, computed at plan time; written
+/// by `write_planned_bundled_assets` during the bundled wave.
+pub(super) struct PlannedBundledAssets {
+    pub(super) bundle_source_path: PathBuf,
     pub(super) bundle_abs_path: PathBuf,
-    pub(super) facades: BTreeMap<String, BundledGeneratedFacade>,
+    pub(super) bundle_source: String,
+    pub(super) facades: BTreeMap<String, PlannedFacade>,
 }
 
-pub(super) struct BundledGeneratedFacade {
+pub(super) struct PlannedFacade {
     pub(super) abs_path: PathBuf,
     pub(super) app_path: String,
+    pub(super) source: String,
 }
 
-pub(super) fn write_bundled_partial_swap_assets_if_requested(
-    write: bool,
+pub(super) fn plan_bundled_partial_swap_assets(
     output_wrapper_dir: Option<&Path>,
     chunk_id: &str,
     bundle_source_path: &Path,
-    bundle_source: &str,
+    bundle_source: String,
     packages: &BTreeMap<String, BundledPartialSwapPackage>,
-) -> Result<BundledGeneratedAssets> {
+) -> Result<PlannedBundledAssets> {
     let output_wrapper_dir = output_wrapper_dir.with_context(|| {
         format!(
             "bundled_partial_swap for chunk {chunk_id} requires swap_vendor_chunks.output_wrapper_dir"
@@ -283,18 +286,6 @@ pub(super) fn write_bundled_partial_swap_assets_if_requested(
     let abs_dir = output_wrapper_dir.join(&chunk_path);
     let app_dir = PathBuf::from("vendors/generated").join(&chunk_path);
     let bundle_abs_path = abs_dir.join("bundle.js");
-    if write {
-        if let Some(parent) = bundle_abs_path.parent() {
-            fs::create_dir_all(parent)?;
-        }
-        fs::write(&bundle_abs_path, bundle_source).with_context(|| {
-            format!(
-                "copying bundled_partial_swap bundle {} to {}",
-                bundle_source_path.display(),
-                bundle_abs_path.display()
-            )
-        })?;
-    }
 
     let mut facades = BTreeMap::new();
     let mut slugs = BTreeMap::<String, String>::new();
@@ -306,29 +297,43 @@ pub(super) fn write_bundled_partial_swap_assets_if_requested(
             );
         }
         let file_name = format!("{slug}.js");
-        let abs_path = abs_dir.join(&file_name);
-        let app_path = app_dir.join(&file_name);
-        let facade_source = generate_bundled_partial_swap_facade(&package.bundle_export);
-        if write {
-            if let Some(parent) = abs_path.parent() {
-                fs::create_dir_all(parent)?;
-            }
-            fs::write(&abs_path, facade_source)
-                .with_context(|| format!("writing {}", abs_path.display()))?;
-        }
         facades.insert(
             package_name.clone(),
-            BundledGeneratedFacade {
-                abs_path,
-                app_path: path_to_module_string(&app_path),
+            PlannedFacade {
+                abs_path: abs_dir.join(&file_name),
+                app_path: path_to_module_string(&app_dir.join(&file_name)),
+                source: generate_bundled_partial_swap_facade(&package.bundle_export),
             },
         );
     }
 
-    Ok(BundledGeneratedAssets {
+    Ok(PlannedBundledAssets {
+        bundle_source_path: bundle_source_path.to_path_buf(),
         bundle_abs_path,
+        bundle_source,
         facades,
     })
+}
+
+pub(super) fn write_planned_bundled_assets(assets: &PlannedBundledAssets) -> Result<()> {
+    if let Some(parent) = assets.bundle_abs_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(&assets.bundle_abs_path, &assets.bundle_source).with_context(|| {
+        format!(
+            "copying bundled_partial_swap bundle {} to {}",
+            assets.bundle_source_path.display(),
+            assets.bundle_abs_path.display()
+        )
+    })?;
+    for facade in assets.facades.values() {
+        if let Some(parent) = facade.abs_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(&facade.abs_path, &facade.source)
+            .with_context(|| format!("writing {}", facade.abs_path.display()))?;
+    }
+    Ok(())
 }
 
 fn generate_bundled_partial_swap_facade(bundle_export: &str) -> String {


### PR DESCRIPTION
PR 2 of the staged implementation in [`plans/vendor_into_emission.md` §8](https://github.com/agentydragon/ducktape/blob/devel/devinfra/js/debundle/plans/vendor_into_emission.md) (design landed in #2110; PR 1 = #2112).

## What

- **`vendor/plan.rs` — read-only `VendorResolutionPlan`**, computed once immediately post-prepare from the #2112 validate/resolve helpers. It is the single resolution oracle: per-chunk `VendorLevel` disposition (the four typed collections), boundary-rename mappings, full-swap targets (validated version/subpath, wrapper-shape soundness, `default_export_aliases`, generated wrapper text + output path), partial/bundled symbol tables (spec `PartialSwapSymbol` maps), facade targets, and the wire-facing resolution skeletons.
- **Existing waves consume the plan instead of re-resolving.** `rename_vendor_exports`, `swap_vendor_chunks`, `apply_partial_vendor_swaps`, `apply_bundled_partial_vendor_swaps`, the strip pass, and the post-strip #2062 consumer gate now take `&VendorResolutionPlan`; resolution decisions are made once, application (caller rewrites, wrapper/facade writes, chunk removal, strip) stays where it was. The partial-swap dispatchers run directly over the plan's per-chunk entries (the old duplicate `Chunk*SwapMapping` structs are gone).
- **Mark validation consolidated into one post-prepare pass** (the doc's §2 "Classify" layer): unknown-chunk/missing-entry for every mark level, boundary-mapping collision checks, wrapper-shape + `default_export_aliases` checks, partial/bundled symbol+package validation, facade slug-collision checks. `apply_vendor_annotations` (whose manifest was write-only) is subsumed by plan construction and deleted. Per the doc's PR-2 row, **vendor validation failures move earlier** (before materialize) — diagnostics text is unchanged, only timing moves.
- **Manifests become plan projections:** generic `ResolutionManifest<R>` replaces the field-for-field twins `PartialSwapResolutionManifest`/`BundledPartialSwapResolutionManifest`; per-chunk resolutions are cloned from the plan and only the `references_rewritten` counters are filled at application time. `PartialSwapSymbolTarget` (twin of `spec::PartialSwapSymbol`) is deleted. The corresponding CODE_REVIEW.md entry is removed as landed (§6 of the doc).

## Wire / behavior compatibility

- `VendorSwapsReport` JSON shapes (`full` / `partial` / `bundled_partial` / `strip_stats`), wrapper + facade bytes and paths are byte-identical: the resolutions are built from the same inputs at plan time and the same generators produce wrapper/facade text (`vendor/wrappers.rs` unchanged in content, split into plan/write halves).
- Full `bbr test //devinfra/js/debundle/...`: **100/100 green**, including `e2e/vendor_swap_test.rs` with the #2062 consumer-gate + collision fixtures and #2084 `default_export_aliases` coverage, strip-stats pins (`partial_swap_keeps_megachunk_on_disk`, `partial_swap_strips_implementation_when_unreferenced`), and the live-proxy dangling-import contract. BuildBuddy invocation: `12978d28-b1b7-432e-b67d-6127bd78c42d`.

## Notes / deviations

- The full-swap **import-alignment check stays in `swap_vendor_chunks`** (application time): it validates caller named imports against post-`rename_vendor_exports` indexes, so hoisting it to plan time would change which specs pass. The doc's plan contents don't claim it.
- The PR-2 row's "consumer-shape classification as data" is deferred to PR 4 (where the plan-time consumer gate — its only reader — switches on); building the classification now would add a field with no consumer. The #2062 post-strip gate still runs, now reading its swapped-name sets from the plan.
- `references_rewritten` parity fixture is PR 3 scope per the doc (§5).

https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk)_