### PR TITLE
debundle: whitelist WHATWG no-arg constructors + URLSearchParams string form

### DIFF
--- a/devinfra/js/debundle/purity/classifier_tests.rs
+++ b/devinfra/js/debundle/purity/classifier_tests.rs
@@ -579,6 +579,74 @@ fn unshadowed_builtin_new_is_pure() {
 }
 
 #[test]
+fn whatwg_platform_constructors_no_args_are_pure() {
+    // No-arg WHATWG constructors: TextDecoder defaults to "utf-8"
+    // (cannot reach the RangeError label-validation path),
+    // TextEncoder takes no parameters, URLSearchParams constructs an
+    // empty query list. None fires user code.
+    assert!((classify("new TextDecoder()")).is_pure());
+    assert!((classify("new TextEncoder()")).is_pure());
+    assert!((classify("new URLSearchParams()")).is_pure());
+}
+
+#[test]
+fn text_decoder_with_label_arg_stays_unknown() {
+    // Even a LITERAL label is not admitted: an invalid label throws
+    // RangeError at construction — an observable init effect under
+    // statement reordering — and validating labels statically would
+    // mean embedding the encodings registry.
+    assert!(!(classify(r#"new TextDecoder("utf-8")"#)).is_pure());
+}
+
+#[test]
+fn url_search_params_string_literal_arg_is_pure() {
+    // The string branch of `new URLSearchParams(init)` parses
+    // application/x-www-form-urlencoded, which is total over
+    // arbitrary strings (never throws) and fires no user code.
+    assert!((classify(r#"new URLSearchParams("a=1&b=2")"#)).is_pure());
+}
+
+#[test]
+fn url_search_params_non_literal_args_stay_unknown() {
+    // A non-literal string-valued expression would need value-class
+    // tracking to prove it can't be an object whose ToString fires
+    // user code; the record/iterable form fires [[Get]]/iterator
+    // protocol on user values.
+    assert!(!(classify("new URLSearchParams(q)")).is_pure());
+    assert!(!(classify("new URLSearchParams({ a: 1 })")).is_pure());
+    assert!(!(classify("new URLSearchParams(`a=${x}`)")).is_pure());
+}
+
+#[test]
+fn regexp_constructor_stays_unknown_even_with_literal_args() {
+    // Deliberate exclusion (see PURE_BUILTIN_NEW_STRING_LITERAL_ARG
+    // doc): pattern compilation can throw SyntaxError at
+    // construction; admitting RegExp soundly needs a static
+    // ECMA-262 pattern validator.
+    assert!(!(classify(r#"new RegExp("a+", "g")"#)).is_pure());
+}
+
+#[test]
+fn shadowed_whatwg_constructor_falls_back_to_unknown() {
+    // The new tables join SHADOW_TRACKED_GLOBALS via the derived
+    // union, so a chunk-top rebind disables the whitelist.
+    assert!(
+        !(classify_with_module(
+            "const TextDecoder = class { constructor() { globalThis.boom = 1; } };",
+            "new TextDecoder()"
+        ))
+        .is_pure()
+    );
+    assert!(
+        !(classify_with_module(
+            "function URLSearchParams() {}",
+            r#"new URLSearchParams("a=1")"#
+        ))
+        .is_pure()
+    );
+}
+
+#[test]
 fn shadowed_builtin_new_falls_back_to_unknown() {
     // SOUNDNESS: `compute_shadowed_globals` must track every name
     // any whitelist table keys on (SHADOW_TRACKED_GLOBALS — the

--- a/devinfra/js/debundle/purity/mod.rs
+++ b/devinfra/js/debundle/purity/mod.rs
@@ -16,8 +16,9 @@ use crate::SourceLocation;
 use crate::facts::TopLevelItemView;
 use whitelists::{
     PLAIN_DATA_HOSTILE_BUILTINS, PURE_BUILTIN_NEW_ARRAY_ITERABLE, PURE_BUILTIN_NEW_NO_ARGS,
-    PURE_GLOBAL_CALLS, PURE_GLOBAL_CALLS_WITH_PRIMITIVE_ARGS, PURE_OBJECT_CALLS_ON_PLAIN_DATA,
-    PURE_STATIC_CALLS, PURE_STATIC_FUNCTION_REFS, PURE_STATIC_PROPS,
+    PURE_BUILTIN_NEW_STRING_LITERAL_ARG, PURE_GLOBAL_CALLS, PURE_GLOBAL_CALLS_WITH_PRIMITIVE_ARGS,
+    PURE_OBJECT_CALLS_ON_PLAIN_DATA, PURE_STATIC_CALLS, PURE_STATIC_FUNCTION_REFS,
+    PURE_STATIC_PROPS,
 };
 
 /// Chunk-wide code graph: indexes top-level bindings and answers
@@ -2408,6 +2409,25 @@ fn classify_new_expr_purity(
         && !shadowed.contains(name)
         && !local_shadowed.contains(name)
         && arg_count == 0
+    {
+        return Purity::Pure;
+    }
+    // `new X("literal")` against PURE_BUILTIN_NEW_STRING_LITERAL_ARG.
+    // The argument must be a string LITERAL (no spread): the
+    // admission arguments on the table are about parsing a string —
+    // a non-literal expression would additionally need value-class
+    // tracking to prove it can't be an object whose ToString fires
+    // user code.
+    if let Some(name) = PURE_BUILTIN_NEW_STRING_LITERAL_ARG
+        .iter()
+        .copied()
+        .find(|n| *n == callee.sym.as_ref())
+        && !shadowed.contains(name)
+        && !local_shadowed.contains(name)
+        && let Some(args) = new_expr.args.as_ref()
+        && args.len() == 1
+        && args[0].spread.is_none()
+        && matches!(args[0].expr.as_ref(), Expr::Lit(Lit::Str(_)))
     {
         return Purity::Pure;
     }

--- a/devinfra/js/debundle/purity/whitelists.rs
+++ b/devinfra/js/debundle/purity/whitelists.rs
@@ -123,7 +123,51 @@ pub(super) const PURE_GLOBAL_CALLS_WITH_PRIMITIVE_ARGS: &[&str] = &["Symbol"];
 /// code (no iterator protocol, no getters fired). Same admission
 /// contract as `PURE_GLOBAL_CALLS`. `Set` / `Map` also accept
 /// an Array-literal iterable; see `PURE_BUILTIN_NEW_ARRAY_ITERABLE`.
-pub(super) const PURE_BUILTIN_NEW_NO_ARGS: &[&str] = &["Map", "Set", "WeakMap", "WeakSet", "Array"];
+///
+/// WHATWG platform constructors, same no-arg contract:
+/// * `TextDecoder`: Encoding §"new TextDecoder(label, options)" —
+///   label defaults to `"utf-8"`, which is a known label, so the
+///   no-arg form cannot reach the RangeError throw path and runs no
+///   user code. The WITH-label form is intentionally NOT admitted:
+///   an invalid label throws RangeError at construction, an
+///   observable init effect under reordering, and validating labels
+///   statically would mean embedding the encodings registry.
+/// * `TextEncoder`: Encoding §"new TextEncoder()" — takes no
+///   parameters at all; constructs a utf-8 encoder, no throw path,
+///   no user code.
+/// * `URLSearchParams`: URL §"new URLSearchParams(init)" — with init
+///   absent the query list is empty; no parsing, no user code. The
+///   one-string-arg form is also pure — see
+///   `PURE_BUILTIN_NEW_STRING_LITERAL_ARG`.
+pub(super) const PURE_BUILTIN_NEW_NO_ARGS: &[&str] = &[
+    "Map",
+    "Set",
+    "WeakMap",
+    "WeakSet",
+    "Array",
+    "TextDecoder",
+    "TextEncoder",
+    "URLSearchParams",
+];
+
+/// Built-in constructors whose 1-arg form is pure when the argument
+/// is a single string **literal** (`Lit::Str`, no spread). Admission
+/// argument per entry:
+/// * `URLSearchParams`: URL §"new URLSearchParams(init)", string
+///   branch — the input is parsed as `application/x-www-form-urlencoded`,
+///   which is defined total over arbitrary strings (never throws) and
+///   fires no user code. A non-literal string-valued expression is NOT
+///   admitted because proving string-ness statically would need value
+///   tracking; a literal needs none.
+///
+/// `RegExp` is deliberately absent: even with literal pattern/flags
+/// args, ECMA-262 §22.2.4 compiles the pattern at construction and
+/// throws SyntaxError on an invalid one — a deterministic but
+/// observable init effect under statement reordering. Admitting it
+/// soundly requires statically validating the pattern against the
+/// ECMA-262 grammar (a `regress`-style validator), tracked as the
+/// ignore-reason of `inferred_pure_collection_constructors_with_literal_args_emit_no_s_cycle`.
+pub(super) const PURE_BUILTIN_NEW_STRING_LITERAL_ARG: &[&str] = &["URLSearchParams"];
 
 /// Built-in container constructors whose 1-arg form is pure when
 /// the argument is an Array literal with all-Pure elements (no holes;
@@ -248,5 +292,6 @@ pub(crate) static SHADOW_TRACKED_GLOBALS: LazyLock<BTreeSet<&'static str>> = Laz
     names.extend(PURE_GLOBAL_CALLS_WITH_PRIMITIVE_ARGS.iter().copied());
     names.extend(PURE_BUILTIN_NEW_NO_ARGS.iter().copied());
     names.extend(PURE_BUILTIN_NEW_ARRAY_ITERABLE.iter().copied());
+    names.extend(PURE_BUILTIN_NEW_STRING_LITERAL_ARG.iter().copied());
     names
 });


### PR DESCRIPTION
P3 of the residual-impurity series (P1: #2115, P2: #2118). Targets the `unknown_new` slice of Tana's residual unit (1,314 reasons; the single-line sample shows `TextDecoder` ×3, `RegExp` ×3, `URLSearchParams` ×2, `Promise` ×2 among intrinsics) with the entries that genuinely satisfy the existing whitelist admission contract — spec citation, no user-code path, no observable throw.

## What

- `PURE_BUILTIN_NEW_NO_ARGS` += `TextDecoder`, `TextEncoder`, `URLSearchParams`. `TextDecoder()` defaults to the known `"utf-8"` label so the RangeError validation path is unreachable; `TextEncoder()` takes no parameters; `URLSearchParams()` constructs an empty query list.
- New `PURE_BUILTIN_NEW_STRING_LITERAL_ARG = ["URLSearchParams"]`: the string branch parses `application/x-www-form-urlencoded`, which is total over arbitrary strings (never throws) and fires no user code. Literal-only — a non-literal string expression would need value-class tracking to exclude objects whose `ToString` fires user code.
- The new table joins `SHADOW_TRACKED_GLOBALS` via the derived union, so chunk-top rebinds disable the whitelist (pinned by test).

## Documented exclusions (justification in the table docs)

- **`TextDecoder` with a label, even literal** — an invalid label throws RangeError at construction, an observable init effect under statement reordering; admitting it statically means embedding the encodings registry.
- **`RegExp`, even with literal args** — pattern compilation can throw SyntaxError (ECMA-262 §22.2.4); sound admission needs a static ECMA-262 pattern validator. Matches the long-standing ignore-reason on `inferred_pure_collection_constructors_with_literal_args_emit_no_s_cycle`.
- **`Promise`** — the executor runs synchronously at construction; Tana's instances capture the resolver via an outer-binding write, which is genuinely effectful.

Honest sizing: this is the smallest of the three levers on Tana (the `unknown_new` mass is mostly local classes inside multi-line statements, not intrinsics). It's included because the entries are cheap, contract-clean, and recur in every web bundle.

## Tests

Six new classifier tests: no-arg positives; TextDecoder-with-label negative; URLSearchParams string-literal positive; non-literal/record/template negatives; RegExp exclusion pin; shadowing fallback for the new tables. Full `//devinfra/js/debundle/...`: 101/101 with lint (clippy + rustfmt) on.

https://claude.ai/code/session_01Bp8cANKC1Ktc92T7SM1kcx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bp8cANKC1Ktc92T7SM1kcx)_