### PR TITLE
langfuse: fix SSO OIDC discovery (drop trailing slash from issuer)

### DIFF
--- a/cluster/k8s/langfuse/app/helmrelease.yaml
+++ b/cluster/k8s/langfuse/app/helmrelease.yaml
@@ -84,7 +84,11 @@ spec:
         - name: AUTH_CUSTOM_NAME
           value: "Authentik"
         - name: AUTH_CUSTOM_ISSUER
-          value: "https://auth.allegedly.works/application/o/langfuse/"
+          # No trailing slash: next-auth builds the discovery URL as
+          # ${AUTH_CUSTOM_ISSUER}/.well-known/openid-configuration, and a
+          # trailing slash yields a double slash that Authentik 301-redirects —
+          # openid-client doesn't follow redirects on discovery (OAuthSignin).
+          value: "https://auth.allegedly.works/application/o/langfuse"
         - name: AUTH_CUSTOM_SCOPE
           value: "openid email profile"
         - name: AUTH_CUSTOM_CLIENT_ID


### PR DESCRIPTION
## Problem

Follow-up to #2117 (which wired Authentik SSO for langfuse and is already merged). The SSO button renders, but clicking it fails with next-auth `OAuthSignin` and the langfuse-web pod logs:

```
[next-auth][error][SIGNIN_OAUTH_ERROR]
OPError: expected 200 OK, got: 301 Moved Permanently
    at Issuer.discover (.../openid-client@5.7.1/lib/issuer.js:152)
  providerId: 'custom'
```

## Root cause

next-auth builds the OIDC discovery URL by concatenating `${AUTH_CUSTOM_ISSUER}/.well-known/openid-configuration`. The issuer value had a **trailing slash**, so the result was:

```
https://auth.allegedly.works/application/o/langfuse//.well-known/openid-configuration   ← double slash
```

Authentik 301-redirects that to the single-slash form, and openid-client does **not** follow redirects during discovery — so discovery fails before the authorization URL is even built.

Verified externally:

| URL | Status |
| --- | --- |
| `…/langfuse//.well-known/openid-configuration` (double slash) | **301** |
| `…/langfuse/.well-known/openid-configuration` (single slash) | **200** |

## Fix

Drop the trailing slash from `AUTH_CUSTOM_ISSUER` → `https://auth.allegedly.works/application/o/langfuse`. next-auth then builds the correct single-slash discovery URL (200). The discovery document's `issuer` claim keeps its own trailing slash and is only used for `iss`-claim validation, so the OIDC flow stays self-consistent.

## Validation

- pre-commit: kubeconform, prettier — pass
- No Bazel test targets depend on the changed file.
- Takes effect once on `devel` and Flux rolls the langfuse-web pod.

https://claude.ai/code/session_01TiN3GUKz5gWgJJb56w3KSu

---
_Generated by [Claude Code](https://claude.ai/code/session_01TiN3GUKz5gWgJJb56w3KSu)_