### PR TITLE
debundle: named pinning tests for Lemmas 1/3/4/5 + Node-differential sweep

### DIFF
--- a/devinfra/js/debundle/CODE_REVIEW.md
+++ b/devinfra/js/debundle/CODE_REVIEW.md
@@ -103,10 +103,6 @@ The `e2e/support.rs` helper asserts against a literal `./static/app/entry.js`, s
 
 `peel/quotient_integration_test.rs` checks the incremental index against references that share too much code with the system under test: most verdict comparisons use the kernel's own `project_partition` output as the reference partition (blind to projection bugs), and only `replay_partition` rebuilds a quotient independently — and it compares only `cycle_set()`. Also missing: randomized merge/partition sequences (current corpora are fixed, ≤6 owners) and differential coverage of the gate-residual promotion transition.
 
-### Only Lemma 2 has a named pinning test
-
-docs/design.md proves Lemmas 1–5; only Lemma 2 appears in a test name (`e2e/lemma_two_rescued_asymmetric_cycle_test.rs`). Lemmas 1/3/4/5 — notably Lemma 4's lazy-read argument — have no named tripwire test that would fail if the proved property is weakened. Add one pinning e2e per lemma.
-
 ---
 
 ## Data Shape Smells

--- a/devinfra/js/debundle/e2e/BUILD.bazel
+++ b/devinfra/js/debundle/e2e/BUILD.bazel
@@ -94,7 +94,11 @@ _STANDARD_E2E_DEPS = [
         "runtime_tdz_on_imported_class_test",
         "accepted_spec_runs_under_node_test",
         "gate_rejection_scopes_to_bad_scc_test",
+        "lemma_one_linker_post_order_test",
         "lemma_two_rescued_asymmetric_cycle_test",
+        "lemma_three_at_init_read_test",
+        "lemma_four_lazy_read_cycle_test",
+        "lemma_five_side_effect_order_test",
         "asymmetric_non_residual_cycle_test",
         "mediator_reaches_asymmetric_cycle_test",
         "namespace_aggregator_split_tdz_test",
@@ -128,6 +132,26 @@ _STANDARD_E2E_DEPS = [
         "s_chain_dataflow_soundness_test",
     ]
 ]
+
+# Node-differential sweep: drives the real pipeline per fixture, then
+# compares the gate simulator's predicted evaluation post-order
+# (`gate::simulated_evaluation_post_order`) against the emitted tree's
+# actual Node evaluation order. Needs `:analysis` (owner graph,
+# partition) and `:gate` (the simulator) on top of the standard deps.
+rust_test(
+    name = "simulator_node_differential_sweep_test",
+    srcs = ["simulator_node_differential_sweep_test.rs"],
+    crate_root = "simulator_node_differential_sweep_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = _STANDARD_E2E_DEPS + [
+        "//devinfra/js/debundle:analysis",
+        "//devinfra/js/debundle:gate",
+    ],
+)
 
 # The factorizer-landability e2e test calls into the factorizer library
 # directly alongside the standard fixture pipeline.

--- a/devinfra/js/debundle/e2e/lemma_five_side_effect_order_test.rs
+++ b/devinfra/js/debundle/e2e/lemma_five_side_effect_order_test.rs
@@ -1,0 +1,45 @@
+//! Pins docs/design.md "Lemma 5 (Side-effect ordering)": for every
+//! source-order pair of side-effecting statements split across
+//! modules, the earlier statement fires before the later one,
+//! because the pair's `S`-edge forces the later statement's home
+//! module to import the earlier one's.
+//!
+//! The fixture makes the `S`-edge load-bearing: the two impure
+//! statements share no binding reads, so without the
+//! `mod_a_second → mod_b_first` S-edge nothing in `I` would order
+//! the modules and the import tie-break (`ModuleId` ascending —
+//! `mod_a_second` sorts first alphabetically, hence the deliberately
+//! inverted module names) would evaluate `mod_a_second` first,
+//! visibly printing "second" before "first". The S-edge both flips
+//! the entry's import order and materializes as a phantom
+//! side-effect import in `mod_a_second`, so a wrong topological
+//! choice cannot reorder the prints.
+
+use debundle_e2e_support::*;
+
+#[test]
+fn cross_module_impure_statements_fire_in_source_order() {
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"const loud_first = (console.log("first"), "f");
+const loud_second = (console.log("second"), "s");
+console.log(loud_first, loud_second);
+"#,
+        vec![
+            logical_module("mod_a_second", &[Member::new("loud_second")]),
+            logical_module("mod_b_first", &[Member::new("loud_first")]),
+        ],
+    ));
+    // The S-edge materializes as a phantom side-effect import: the
+    // later impure statement's module imports the earlier one's, so
+    // the linker cannot evaluate mod_a_second first.
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/modules/mod_a_second.js",
+        &["./mod_b_first.js"],
+        &[],
+    );
+    // Observation trace identical to the input chunk: "first" prints
+    // before "second" even though the statements now live in
+    // different modules.
+    assert_entry_output(&fixture, "first\nsecond\nf s\n");
+}

--- a/devinfra/js/debundle/e2e/lemma_four_lazy_read_cycle_test.rs
+++ b/devinfra/js/debundle/e2e/lemma_four_lazy_read_cycle_test.rs
@@ -1,0 +1,44 @@
+//! Pins docs/design.md "Lemma 4 (Lazy-read correctness)": lazy
+//! cross-module reads (reads inside function bodies) fire only after
+//! their target binding is initialized, under ANY evaluation order
+//! the linker picks. A mutual lazy cycle is therefore accepted, and
+//! post-init calls in both directions see initialized bindings —
+//! whichever module the linker's DFS happens to enter first.
+
+use debundle_e2e_support::*;
+
+#[test]
+fn mutual_lazy_cycle_post_init_calls_in_both_directions_see_initialized_bindings() {
+    // mod_a owns A and readB; readB() lazily reads B (in mod_b).
+    // mod_b owns B and readA; readA() lazily reads A (in mod_a).
+    // No cross-module read fires at-init: when the linker evaluates
+    // either module, no top-level statement reaches into the other
+    // one. The function bodies only run *after* both modules finish
+    // evaluating — no TDZ.
+    //
+    // The SCC in the imports graph `I` is `{mod_a, mod_b}`, but it
+    // carries no at-init (`R`) and no side-effect (`S`) cross-module
+    // edges — only `L` edges. The realizability gate must accept
+    // this spec; rejecting would over-restrict the realizable subset
+    // of `I ∪ S` cycles. Lemma 4's claim is the runtime half: both
+    // lazy directions (mod_a's body read of B and mod_b's body read
+    // of A) resolve to initialized bindings when residual's
+    // post-init calls fire.
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"const A = "a-value";
+const B = "b-value";
+function readA() { return A; }
+function readB() { return B; }
+console.log(readA(), readB());
+export { A, B, readA, readB };
+"#,
+        vec![
+            logical_module("mod_a", &[Member::new("A"), Member::new("readB")]),
+            logical_module("mod_b", &[Member::new("B"), Member::new("readA")]),
+        ],
+    ));
+    // ESM evaluates both modules to completion before the residual
+    // entry's `console.log(readA(), readB())` fires; both function
+    // bodies see fully-assigned bindings.
+    assert_entry_output(&fixture, "a-value b-value\n");
+}

--- a/devinfra/js/debundle/e2e/lemma_one_linker_post_order_test.rs
+++ b/devinfra/js/debundle/e2e/lemma_one_linker_post_order_test.rs
@@ -1,0 +1,74 @@
+//! Pins docs/design.md "Lemma 1 (Linker order is post-order over
+//! `I`)": ECMA-262's `InnerModuleEvaluation` evaluates the emitted
+//! modules in a post-order DFS linearization of the imports graph
+//! `I`, rooted at the entry.
+//!
+//! The fixture is a diamond: residual eager-reads `left_val` and
+//! `right_val`, whose initializers each eager-read `base_val`. All
+//! initializers are pure, so `I` carries only the diamond's `R`
+//! edges — no `S` edges constrain the order. Per-module marker
+//! prints (appended to the emitted files after the debundler runs,
+//! so the analyzed graph is untouched) record each module body's
+//! completion on stdout; the observed order must be a post-order
+//! DFS over `I` rooted at the entry: the shared dependency before
+//! either dependent, every dependent before residual, residual
+//! last.
+//!
+//! Which of `mod_left` / `mod_right` evaluates first is the import
+//! tie-break's choice — that steering is Lemma 2's contract (pinned
+//! by `lemma_two_rescued_asymmetric_cycle_test` and siblings), so
+//! this test only asserts the post-order relations Lemma 1 itself
+//! proves.
+
+use debundle_e2e_support::*;
+
+#[test]
+fn diamond_evaluation_order_is_post_order_dfs_over_imports() {
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"const base_val = "b";
+const left_val = base_val + "-l";
+const right_val = base_val + "-r";
+console.log(left_val, right_val);
+"#,
+        vec![
+            logical_module("mod_base", &[Member::new("base_val")]),
+            logical_module("mod_left", &[Member::new("left_val")]),
+            logical_module("mod_right", &[Member::new("right_val")]),
+        ],
+    ));
+    // Behaviour preservation first — the marker instrumentation
+    // below mutates the emitted files.
+    assert_entry_output(&fixture, "b-l b-r\n");
+
+    let order =
+        node_module_evaluation_order(&fixture, &["mod_base", "mod_left", "mod_right", "entry"]);
+    let position = |label: &str| {
+        order
+            .iter()
+            .position(|entry| entry == label)
+            .unwrap_or_else(|| panic!("module {label} never evaluated; order: {order:?}"))
+    };
+    assert_eq!(
+        order.len(),
+        4,
+        "every module evaluates exactly once: {order:?}"
+    );
+    // Post-order over I: every module's I-dependencies complete
+    // before its own body does.
+    assert!(
+        position("mod_base") < position("mod_left"),
+        "mod_left eager-reads base_val, so mod_base must evaluate first: {order:?}",
+    );
+    assert!(
+        position("mod_base") < position("mod_right"),
+        "mod_right eager-reads base_val, so mod_base must evaluate first: {order:?}",
+    );
+    // Rooted at the entry: the DFS root's body (which hosts
+    // residual's statements) runs only after every requested module
+    // unwinds.
+    assert_eq!(
+        order.last().map(String::as_str),
+        Some("entry"),
+        "the DFS root evaluates last in post-order: {order:?}",
+    );
+}

--- a/devinfra/js/debundle/e2e/lemma_three_at_init_read_test.rs
+++ b/devinfra/js/debundle/e2e/lemma_three_at_init_read_test.rs
@@ -1,0 +1,36 @@
+//! Pins docs/design.md "Lemma 3 (At-init read correctness)": in an
+//! accepted spec, every at-init read in module `M` of a binding
+//! owned by module `M'` sees that binding initialized at the moment
+//! of the read — the `R`-edge `M → M'` forces the linker to evaluate
+//! `M'` fully before any line of `M`'s body runs.
+//!
+//! Only the accept side lives here. The rejection side (an `R` cycle
+//! no evaluation order can satisfy) is pinned by
+//! `realizability_test::cyclic_spec_is_rejected_with_clear_error`,
+//! and the runtime TDZ shape the gate exists to prevent by
+//! `runtime_tdz_on_imported_class_test`.
+
+use debundle_e2e_support::*;
+
+#[test]
+fn accepted_cross_module_at_init_read_observes_initialized_value() {
+    // mod_a owns x1 + x2; x2's initializer at-init reads `y.id` from
+    // mod_b (computed key — the read fires while mod_a's body
+    // evaluates). R-edge mod_a → mod_b; the ESM linker evaluates
+    // mod_b first, so the read observes y fully initialized: the
+    // emitted bundle prints the same values the input chunk does. A
+    // TDZ (or an undefined-keyed x2) would change the output.
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"const x1 = { id: "x1" };
+const y = { id: "k" };
+const x2 = { [y.id]: "v" };
+console.log(x1.id, y.id, x2[y.id]);
+export { x1, y, x2 };
+"#,
+        vec![
+            logical_module("mod_a", &[Member::new("x1"), Member::new("x2")]),
+            logical_module("mod_b", &[Member::new("y")]),
+        ],
+    ));
+    assert_entry_output(&fixture, "x1 k v\n");
+}

--- a/devinfra/js/debundle/e2e/realizability_test.rs
+++ b/devinfra/js/debundle/e2e/realizability_test.rs
@@ -133,38 +133,8 @@ export { A, B, readB };
     assert_entry_output(&fixture, "a-value-postfix\n");
 }
 
-#[test]
-fn accepts_cycle_when_all_back_edges_are_lazy() {
-    // mod_a owns A and readB; readB() lazily reads B.
-    // mod_b owns B and readA; readA() lazily reads A.
-    // No cross-module read fires at-init: when the linker
-    // evaluates either module, no top-level statement reaches
-    // into the other one. The function bodies only run *after*
-    // both modules finish evaluating — no TDZ.
-    //
-    // The SCC in the imports graph `I` is `{mod_a, mod_b}`, but
-    // it carries no at-init (`R`) and no side-effect (`S`)
-    // cross-module edges — only `L` edges. The realizability
-    // gate must accept this spec; rejecting would over-restrict
-    // the realizable subset of `I ∪ S` cycles.
-    let fixture = run_fixture(FixtureOpts::new(
-        r#"const A = "a-value";
-const B = "b-value";
-function readA() { return A; }
-function readB() { return B; }
-console.log(readA(), readB());
-export { A, B, readA, readB };
-"#,
-        vec![
-            logical_module("mod_a", &[Member::new("A"), Member::new("readB")]),
-            logical_module("mod_b", &[Member::new("B"), Member::new("readA")]),
-        ],
-    ));
-    // ESM evaluates both modules to completion before the
-    // residual entry's `console.log(readA(), readB())` fires;
-    // both function bodies see fully-assigned bindings.
-    assert_entry_output(&fixture, "a-value b-value\n");
-}
+// The mutual lazy-only cycle acceptance (Lemma 4's named pin) lives
+// in `lemma_four_lazy_read_cycle_test`.
 
 #[test]
 fn owner_graph_report_is_written_for_successful_specs() {
@@ -655,26 +625,8 @@ export { a1, a2, b1 };
     );
 }
 
-// --- Acyclic specs and cross-module init order ----------------------------
-
-#[test]
-fn init_call_order_respects_cross_module_dependency() {
-    // mod_a owns x1 + x2 (x2 reads y.id at-init); mod_b owns y.
-    // R-edge mod_a → mod_b; ESM linker evaluates mod_b first.
-    let fixture = run_fixture(FixtureOpts::new(
-        r#"const x1 = { id: "x1" };
-const y = { id: "k" };
-const x2 = { [y.id]: "v" };
-console.log(x1.id, y.id, x2[y.id]);
-export { x1, y, x2 };
-"#,
-        vec![
-            logical_module("mod_a", &[Member::new("x1"), Member::new("x2")]),
-            logical_module("mod_b", &[Member::new("y")]),
-        ],
-    ));
-    assert_entry_output(&fixture, "x1 k v\n");
-}
+// Acyclic cross-module at-init read correctness (Lemma 3's named
+// pin) lives in `lemma_three_at_init_read_test`.
 
 // --- Side-effect ordering (`S`) ------------------------------------------
 

--- a/devinfra/js/debundle/e2e/simulator_node_differential_sweep_test.rs
+++ b/devinfra/js/debundle/e2e/simulator_node_differential_sweep_test.rs
@@ -1,0 +1,236 @@
+//! Node-differential sweep over the accepted asymmetric / phantom /
+//! tie-break fixture family: the realizability gate's evaluation
+//! simulator must predict exactly the ECMA-262 Phase-2 evaluation
+//! order Node produces for the emitted tree.
+//!
+//! Emitter and simulator both consume `EsmImportOrder` (the shared
+//! single source of truth — see `esm_import_order`), so a divergence
+//! here means the gate's verdict has stopped describing the bundle
+//! the emitter produces: an accepted spec could TDZ under Node, or a
+//! runnable spec could be over-rejected. Each case runs the real
+//! pipeline, instruments the emitted module files with per-module
+//! marker prints (after the debundler runs, so the analyzed graph is
+//! untouched), and compares the observed completion order against
+//! `gate::simulated_evaluation_post_order` on the same owner graph
+//! and partition.
+//!
+//! Generalizes the single-shape unit pin
+//! `realizability::tests::simulator_post_order_matches_emitted_evaluation_order`
+//! (the gaffer asymmetric cycle) into a sweep; that pin keeps the
+//! hand-derived expected order at the unit level, this sweep pins the
+//! simulator against the live Node runtime across the family.
+
+use std::collections::BTreeMap;
+
+use analysis::facts::analyze_chunk;
+use analysis::graph::build_owner_graph;
+use analysis::ids::{LogicalModuleIndex, ModuleId};
+use analysis::{AnalysisHints, OwnerGraph, Partition};
+use debundle_e2e_support::*;
+use gate::simulated_evaluation_post_order;
+use swc_common::{FileName, SourceMap, sync::Lrc};
+use swc_ecma_parser::{Parser, StringInput, Syntax, lexer::Lexer};
+
+struct SweepCase {
+    name: &'static str,
+    source: &'static str,
+    /// `(module name, member bindings)`, alphabetical by module name.
+    /// The pipeline indexes logical-module plans in spec-map order
+    /// (alphabetical by target path) with the residual sentinel last;
+    /// the hand-built partition below mirrors that numbering so the
+    /// simulator's `ModuleId` tie-breaks match the emitted tree's.
+    modules: &'static [(&'static str, &'static [&'static str])],
+}
+
+const SWEEP: &[SweepCase] = &[
+    // The gaffer over-rejection shape (#2071): asymmetric I-cycle
+    // whose only residual-side reference points at the constraining
+    // edge's TARGET (the dependency). Node side originally pinned by
+    // `asymmetric_non_residual_cycle_test::dependency_only_residual_reference_into_asymmetric_cycle_runs_under_node`.
+    SweepCase {
+        name: "asymmetric_dependency_only_residual_reference",
+        source: "const schemas_target = \"v\";\n\
+                 function lazy_back() { return ids_val; }\n\
+                 const ids_val = schemas_target;\n\
+                 console.log(schemas_target);\n",
+        modules: &[
+            ("mod_ids", &["ids_val"]),
+            ("mod_schemas", &["schemas_target", "lazy_back"]),
+        ],
+    },
+    // Lemma 2's rescued asymmetric cycle: residual at-init reads
+    // both SCC members; entry's intra-SCC reversal imports the
+    // dependent first.
+    SweepCase {
+        name: "asymmetric_cycle_residual_reads_both",
+        source: "const dep_value = \"alpha\";\n\
+                 const cross_value = dep_value + \"-beta\";\n\
+                 function lazy_reader() { return cross_value; }\n\
+                 console.log(dep_value, cross_value, lazy_reader());\n",
+        modules: &[
+            ("mod_dep", &["dep_value", "lazy_reader"]),
+            ("mod_dependent", &["cross_value"]),
+        ],
+    },
+    // Mediator-only entrant: residual's statements never reference
+    // the SCC directly; the entry's universal per-plan imports still
+    // DFS into the SCC at the dependent first.
+    SweepCase {
+        name: "mediator_only_entrant_into_asymmetric_cycle",
+        source: "const dep_value = \"alpha\";\n\
+                 const cross_value = dep_value + \"-beta\";\n\
+                 function lazy_reader() { return cross_value; }\n\
+                 function mediator_helper() { return dep_value + lazy_reader(); }\n\
+                 const mediator_init = mediator_helper();\n\
+                 console.log(mediator_init);\n",
+        modules: &[
+            ("mod_dep", &["dep_value", "lazy_reader"]),
+            ("mod_dependent", &["cross_value"]),
+            ("mod_mediator", &["mediator_helper", "mediator_init"]),
+        ],
+    },
+    // Pure mutual lazy cycle: no constraining edge between the SCC
+    // members, so their relative order is decided purely by the
+    // shared tie-break (`ModuleId` ascending) — the case where a
+    // simulator/emitter tie-break drift would slip past every
+    // TDZ-anchored test.
+    SweepCase {
+        name: "pure_lazy_cycle_tie_break",
+        source: "const a_value = \"a\";\n\
+                 const b_value = \"b\";\n\
+                 function read_a() { return a_value; }\n\
+                 function read_b() { return b_value; }\n\
+                 console.log(read_a(), read_b());\n",
+        modules: &[
+            ("mod_a", &["a_value", "read_b"]),
+            ("mod_b", &["b_value", "read_a"]),
+        ],
+    },
+    // Phantom side-effect chain: the impure statements share no
+    // binding reads, so the only cross-module ordering constraint is
+    // the S-edge, emitted as a phantom side-effect import (the
+    // Lemma 5 shape — see `lemma_five_side_effect_order_test`).
+    SweepCase {
+        name: "phantom_side_effect_chain",
+        source: "const loud_first = (console.log(\"first\"), \"f\");\n\
+                 const loud_second = (console.log(\"second\"), \"s\");\n\
+                 console.log(loud_first, loud_second);\n",
+        modules: &[
+            ("mod_a_second", &["loud_second"]),
+            ("mod_b_first", &["loud_first"]),
+        ],
+    },
+];
+
+/// Parse `source` and build the owner graph through the same
+/// analysis path the pipeline uses (mirrors
+/// `realizability::tests::parse_and_build`).
+fn parse_and_build(source: &str) -> OwnerGraph {
+    let cm: Lrc<SourceMap> = Default::default();
+    let fm = cm.new_source_file(
+        FileName::Custom("test.js".into()).into(),
+        source.to_string(),
+    );
+    let lexer = Lexer::new(
+        Syntax::Es(Default::default()),
+        Default::default(),
+        StringInput::from(&*fm),
+        None,
+    );
+    let module = Parser::new_from(lexer)
+        .parse_module()
+        .expect("parse module");
+    let facts = analyze_chunk(&module, &AnalysisHints::default(), None, |_| None).facts;
+    build_owner_graph(&facts).unwrap()
+}
+
+/// Build the partition matching the case's spec assignment:
+/// module index = position in the (alphabetical) module list,
+/// residual = the sentinel index after every named module.
+fn partition_for(owner_graph: &OwnerGraph, case: &SweepCase) -> Partition {
+    let residual = ModuleId(LogicalModuleIndex(case.modules.len()));
+    let mut partition = Partition::new(owner_graph, residual);
+    for (index, (module_name, bindings)) in case.modules.iter().enumerate() {
+        for binding in *bindings {
+            let owner = owner_graph
+                .iter_nodes()
+                .find(|node| node.declared.iter().any(|id| id.0.as_ref() == *binding))
+                .unwrap_or_else(|| {
+                    panic!(
+                        "{}: no owner declares binding {binding} for {module_name}",
+                        case.name
+                    )
+                });
+            partition.set(owner.id, ModuleId(LogicalModuleIndex(index)));
+        }
+    }
+    partition
+}
+
+#[test]
+fn simulator_post_order_matches_node_evaluation_order_across_fixture_family() {
+    for case in SWEEP {
+        assert!(
+            case.modules.is_sorted_by_key(|(name, _)| *name),
+            "{}: modules must be listed alphabetically so the hand-built \
+             ModuleIds match the pipeline's plan indexing",
+            case.name,
+        );
+
+        // Simulator side: predicted post-order on the same owner
+        // graph + partition the pipeline derives from the spec.
+        let owner_graph = parse_and_build(case.source);
+        let partition = partition_for(&owner_graph, case);
+        let post_order = simulated_evaluation_post_order(&owner_graph, &partition);
+        // The simulator's residual node is the ESM DFS root — the
+        // emitted entry file (the sweep's residual statements are all
+        // anonymous, so no catchall module file materializes).
+        let label_of = |module: ModuleId| -> &'static str {
+            let ModuleId(LogicalModuleIndex(index)) = module;
+            case.modules
+                .get(index)
+                .map(|(name, _)| *name)
+                .unwrap_or("entry")
+        };
+        let predicted: Vec<&str> = {
+            let by_rank: BTreeMap<usize, ModuleId> = post_order
+                .iter()
+                .map(|(module, rank)| (*rank, *module))
+                .collect();
+            by_rank.into_values().map(label_of).collect()
+        };
+        assert_eq!(
+            predicted.len(),
+            case.modules.len() + 1,
+            "{}: every module (plus residual) must be reachable in the \
+             simulator's universe; predicted: {predicted:?}",
+            case.name,
+        );
+
+        // Node side: run the real pipeline, instrument the emitted
+        // modules, observe the actual evaluation completion order.
+        let mut instrumented: Vec<&str> = case.modules.iter().map(|(name, _)| *name).collect();
+        instrumented.push("entry");
+        let fixture = run_fixture(FixtureOpts::new(
+            case.source,
+            case.modules
+                .iter()
+                .map(|(name, bindings)| {
+                    let members: Vec<Member> = bindings
+                        .iter()
+                        .map(|binding| Member::new(binding))
+                        .collect();
+                    logical_module(name, &members)
+                })
+                .collect(),
+        ));
+        let actual = node_module_evaluation_order(&fixture, &instrumented);
+
+        assert_eq!(
+            actual, predicted,
+            "{}: simulator-predicted post-order must match the emitted \
+             tree's actual Node evaluation order",
+            case.name,
+        );
+    }
+}

--- a/devinfra/js/debundle/e2e/support.rs
+++ b/devinfra/js/debundle/e2e/support.rs
@@ -895,6 +895,50 @@ pub fn assert_generated_module_after_entry_script(
     assert_generated_module_script(out_root, &wrapped, expected_stdout);
 }
 
+/// Append a marker print to each listed emitted module file, run the
+/// entry under Node, and return the order in which the instrumented
+/// module bodies finished evaluating — the observable ECMA-262
+/// Phase-2 evaluation post-order (docs/design.md "Lemma 1").
+///
+/// `modules` are logical-module paths under the chunk's `modules/`
+/// directory; the special name `"entry"` resolves to the chunk's
+/// `entry.js` — the ESM DFS root, which hosts residual's unclaimed
+/// anonymous statements and corresponds to the gate simulator's
+/// residual node. The instrumentation happens after the debundler
+/// has run, so it perturbs neither the analyzed graph nor the
+/// realizability verdict — but it does mutate the emitted files, so
+/// run `assert_entry_output`-style checks before calling this.
+pub fn node_module_evaluation_order(fixture: &Fixture, modules: &[&str]) -> Vec<String> {
+    const MARKER: &str = "__module_eval__:";
+    for label in modules {
+        let rel_path = if *label == "entry" {
+            format!("{}/entry.js", fixture.chunk_id)
+        } else {
+            format!("{}/modules/{label}.js", fixture.chunk_id)
+        };
+        let path = fixture.out_root.join(&rel_path);
+        let mut code = fs::read_to_string(&path)
+            .unwrap_or_else(|err| panic!("read emitted module {rel_path}: {err}"));
+        code.push_str(&format!("\nconsole.log(\"{MARKER}{label}\");\n"));
+        fs::write(&path, code).unwrap();
+    }
+    let result = run_node_script(&fixture.entry_path);
+    assert!(
+        result.status.success(),
+        "node {} exited {:?}\nstdout:\n{}\nstderr:\n{}",
+        fixture.entry_path.display(),
+        result.status.code(),
+        result.stdout,
+        result.stderr,
+    );
+    result
+        .stdout
+        .lines()
+        .filter_map(|line| line.strip_prefix(MARKER))
+        .map(str::to_string)
+        .collect()
+}
+
 pub fn assert_node_output(path: &Path, expected_stdout: &str, expected_stderr: &str) {
     let result = run_node_script(path);
     assert!(

--- a/devinfra/js/debundle/gate.rs
+++ b/devinfra/js/debundle/gate.rs
@@ -24,6 +24,7 @@ pub use realizability::{
     CondensationOrder, CrossRebindEdge, DeltaHandle, LadderDecision, PartitionDelta,
     RealizabilityIndex, RealizabilityVerdict, SccDiagnosis, SccRejection, SccTimingReporter,
     check_realizability, check_realizability_touching, record_gate_diagnostic_translation,
+    simulated_evaluation_post_order,
 };
 pub use rollback_graph::RollbackDiGraph;
 pub use validation::{

--- a/devinfra/js/debundle/plans/sanitization_program_2026_06.md
+++ b/devinfra/js/debundle/plans/sanitization_program_2026_06.md
@@ -175,6 +175,12 @@ split, `.ok()?` and sentinel fixes. TODO section removed._
    gate-vs-reference equality post-cutover).
 2. **Lemma pinning**: named tests for Lemmas 1/3/4/5 (only Lemma 2 has
    them); extend the #2071 Node-differential to a fixture sweep.
+   _Status (2026-06-11): landed — one named pinning e2e per lemma
+   (`e2e/lemma_{one,three,four,five}_\*\_test.rs` alongside the existing
+Lemma 2 pin) and the Node-differential sweep
+(`e2e/simulator_node_differential_sweep_test.rs`: simulator-predicted
+   post-order vs instrumented Node evaluation order across the accepted
+   asymmetric / phantom / tie-break family)._
 3. **Excalidraw public smoke** (TODO's big standing item): the
    realistic-corpus CI layer the fix wave repeatedly found missing
    (`props/frontend/debundle` no longer exists). Build the Bazel-managed

--- a/devinfra/js/debundle/realizability/mod.rs
+++ b/devinfra/js/debundle/realizability/mod.rs
@@ -333,6 +333,26 @@ pub fn check_realizability_touching(
     }
 }
 
+/// Simulator-predicted ECMA-262 Phase-2 evaluation post-order for a
+/// partition's emitted module tree: lower index = body evaluates
+/// earlier; modules unreachable from residual are absent. Exposed for
+/// Node-differential pins (`e2e/simulator_node_differential_sweep_test`)
+/// that compare this prediction against the evaluation order Node
+/// actually produces for the emitted tree.
+pub fn simulated_evaluation_post_order(
+    owner_graph: &OwnerGraph,
+    partition: &Partition,
+) -> BTreeMap<ModuleId, usize> {
+    let canonical = chunk_constraining_module_edges(owner_graph, partition);
+    let constraining_pairs: BTreeSet<(ModuleId, ModuleId)> = canonical.pairs().collect();
+    EsmEvaluationSimulator::build(
+        &canonical.i_successors,
+        &constraining_pairs,
+        partition.residual(),
+    )
+    .post_order
+}
+
 /// Mutable index over a working partition. The single shared
 /// implementation of the three-clause predicate, exposed in the
 /// transactional shape docs/design.md "Realizability primitive" prescribes.

--- a/devinfra/js/debundle/realizability/tests.rs
+++ b/devinfra/js/debundle/realizability/tests.rs
@@ -301,6 +301,11 @@ fn pass_two_simulator_models_entry_universal_imports_for_runtime_dfs() {
 /// `mod_schemas`' body evaluates before `mod_ids`'. Emitter and
 /// simulator both consume `EsmImportOrder`, so this pin guards
 /// the shared-ordering contract from the gate side.
+///
+/// This pin keeps the hand-derived expected order at the unit level;
+/// `e2e/simulator_node_differential_sweep_test` generalizes it into a
+/// live differential (simulator prediction vs instrumented Node run)
+/// across the accepted asymmetric / phantom / tie-break family.
 #[test]
 fn simulator_post_order_matches_emitted_evaluation_order() {
     // owner_0: const schemas_target = "v"      (mod_schemas)


### PR DESCRIPTION
Track F2 of `plans/sanitization_program_2026_06.md`: every lemma of the realizability theorem (docs/design.md §"Lemmas") now has a named pinning e2e asserting observable behavior — previously only Lemma 2 did. `grep -ri lemma` over `e2e/` + the realizability tests now finds all five.

## Per-lemma pins

- **Lemma 1** — `e2e/lemma_one_linker_post_order_test.rs` (**new**): pure-`R` diamond (`mod_left`/`mod_right` eager-read `mod_base`; residual reads both). Per-module marker prints — appended to the emitted files *after* the debundler runs via the new `support::node_module_evaluation_order` helper, so the analyzed graph is untouched — prove Node evaluates a post-order DFS linearization of `I` rooted at the entry (dependency before dependents, entry last). Left/right tie order is deliberately not pinned (that steering is Lemma 2's contract).
- **Lemma 3** — `e2e/lemma_three_at_init_read_test.rs` (**moved + renamed**): the accepted-side pin `realizability_test::init_call_order_respects_cross_module_dependency` moved into a dedicated file as `accepted_cross_module_at_init_read_observes_initialized_value`, module doc citing the lemma and referencing the existing rejection-side coverage (`cyclic_spec_is_rejected_with_clear_error`, `runtime_tdz_on_imported_class_test`) instead of duplicating it.
- **Lemma 4** — `e2e/lemma_four_lazy_read_cycle_test.rs` (**moved + renamed**): `realizability_test::accepts_cycle_when_all_back_edges_are_lazy` becomes `mutual_lazy_cycle_post_init_calls_in_both_directions_see_initialized_bindings` — mutual lazy cycle accepted, residual's post-init calls in both directions (`readA` in `mod_b` → `A` in `mod_a`, `readB` in `mod_a` → `B` in `mod_b`) observe initialized bindings.
- **Lemma 5** — `e2e/lemma_five_side_effect_order_test.rs` (**new**): two impure statements with no shared binding reads split across modules whose names invert the `ModuleId` tie-break (`mod_a_second` holds the later print) — the `S`-edge is load-bearing: without it the import tie-break would evaluate `mod_a_second` first and visibly reorder the prints. Asserts both the source-order stdout and the `S`-edge's materialization as a phantom side-effect import.

## Node-differential sweep

`e2e/simulator_node_differential_sweep_test.rs` (**new**) generalizes #2071's `simulator_post_order_matches_emitted_evaluation_order` pin into a sweep over the accepted asymmetric / phantom / tie-break family:

1. gaffer dependency-only residual reference (the #2071 shape),
2. rescued asymmetric cycle with residual reading both SCC members,
3. mediator-only entrant into an asymmetric cycle,
4. pure mutual lazy cycle (order decided purely by the shared tie-break),
5. phantom side-effect chain.

Per case: the simulator's prediction — via the new `gate::simulated_evaluation_post_order` (thin public wrapper over the internal `EsmEvaluationSimulator`) on a partition numbered the way the pipeline numbers plans (alphabetical, residual sentinel last, so `ModuleId` tie-breaks match) — must equal the actual Node evaluation order observed through per-module marker prints on the emitted tree. The unit pin keeps the hand-derived expected order at the unit level and now cross-references the sweep.

## Housekeeping

- `CODE_REVIEW.md`: deleted the "Only Lemma 2 has a named pinning test" entry.
- `plans/sanitization_program_2026_06.md`: F2 item marked landed.

## Testing

Full `bbr test //devinfra/js/debundle/...` green (107/107).

`BAZEL_TEST_INVOCATIONS=buildbuddy:f9649081-b0f8-4d5e-86f3-9976fbaecaa0`

Note: #2119 (vendor-emit-2) also touches `CODE_REVIEW.md`; if it lands first this branch rebases (second-to-merge rebases per coordination note).

https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk)_