### PR TITLE
debundle: don't let import-specifier export names disqualify PlainData candidates

### DIFF
--- a/devinfra/js/debundle/purity/graph_purity_tests.rs
+++ b/devinfra/js/debundle/purity/graph_purity_tests.rs
@@ -1485,3 +1485,22 @@ fn plain_data_object_keys_escape_exemption_requires_unshadowed_object() {
         "X"
     ));
 }
+
+#[test]
+fn plain_data_enum_survives_import_specifier_name_collision() {
+    // `import { j as a }` — the IMPORTED side (`j`) is the source
+    // module's export NAME, pure module metadata; the only binding the
+    // statement introduces is the local `a`. Regression: the escape
+    // default used to fire on the imported-name `Ident`, so a chunk
+    // importing any export whose NAME collides with a local PlainData
+    // candidate (here the enum binding `j`) silently lost the
+    // candidate — on real bundles, where vendor chunks export
+    // hundreds of single-letter names, this killed most enum
+    // admissions by name coincidence.
+    let src = r#"
+    import { j as a } from "./vendor.js";
+    var j = ((n) => ((n[(n.A = 0)] = "A"), n))(j || {});
+    const probe = j.A;
+"#;
+    assert!(is_plain_data(src, "j"));
+}

--- a/devinfra/js/debundle/purity/mod.rs
+++ b/devinfra/js/debundle/purity/mod.rs
@@ -1596,6 +1596,16 @@ impl Visit for PlainDataWriteScanner<'_> {
     // binding are assumed not to install accessors on it.
     fn visit_export_named_specifier(&mut self, _node: &ExportNamedSpecifier) {}
 
+    // `import { <exported> as <local> }` — the local side is a
+    // BindingIdent (already skipped); the imported side is the SOURCE
+    // module's export name, pure module metadata that never reads any
+    // local binding's value. Without this override the escape default
+    // fired on the imported-name `Ident`, disqualifying an unrelated
+    // local candidate that happens to share its spelling — real
+    // bundles import hundreds of single-letter vendor export names,
+    // so candidate enums named `j`/`a`/… were lost to coincidence.
+    fn visit_import_named_specifier(&mut self, _node: &ImportNamedSpecifier) {}
+
     // Member-access receivers are reads, not captures. Skip an
     // Ident receiver (candidate or not); everything else (nested
     // receivers, computed keys) is traversed normally.


### PR DESCRIPTION
Follow-up to the residual-impurity series (#2115/#2118/#2120) — the planned "extend the TS-enum recognizer to numeric enums" turned out to be a misdiagnosis: the numeric reverse-mapping IIFE shape was **already recognized and tested**. The real bug is sharper.

## The bug

Tana's permission enum (`var j = ((n) => ((n[(n.UNSAFE_ALLOW_ALWAYS = 0)] = "UNSAFE_ALLOW_ALWAYS"), …, n))(j || {})`) classified all 645 of its member reads `unknown_member` even though the shape admits, the chunk never writes through `j`, and `j` never escapes. Exhaustively classifying every identifier-`j` occurrence in the chunk left exactly one bare-ident hit outside the enum's own IIFE arg:

```js
import { ..., j as a, ... } from "./vendor-....js";
```

The vendor chunk happens to **export something named `j`**. `PlainDataWriteScanner` overrides export specifiers as non-escaping but not import specifiers, so the *imported-name* `Ident("j")` — pure module metadata; the only binding the statement introduces is the local `a` — fell into the scanner's escape default and disqualified the unrelated local enum binding by spelling coincidence.

Real bundles import hundreds of single-letter vendor export names, so this silently killed most single-letter enum/namespace PlainData candidates — on Tana, `j` alone accounts for a third of the residual unit's remaining `unknown_member` mass.

## The fix

A no-op `visit_import_named_specifier` override (the local side is a `BindingIdent`, already skipped by the existing override). Regression test pins the import-collision shape; the isolated numeric-enum shape was already covered by the `plain_data_ts_enum_iife_*` suite.

Full `//devinfra/js/debundle/...`: 102/102 with lint (clippy + rustfmt) on.

https://claude.ai/code/session_01Bp8cANKC1Ktc92T7SM1kcx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bp8cANKC1Ktc92T7SM1kcx)_