### PR TITLE
[codex] loom: resolve wayback captures via availability API

### DIFF
--- a/cluster/k8s/wayback-cache/config/nginx.conf
+++ b/cluster/k8s/wayback-cache/config/nginx.conf
@@ -3,12 +3,12 @@
 #   tier 1 (:8080)          — PVC-backed proxy_cache; hits never touch IA.
 #   tier 2 (127.0.0.1:8081) — loopback-only; every request reaching it is by
 #                             construction a cold miss, so limit_req buckets pace
-#                             exactly the traffic IA sees — content fetches and
-#                             the slower CDX index queries throttled separately
-#                             so neither starves the other.
-# The cache is deliberately dumb: any path forwards verbatim to
-# web.archive.org (CDX queries and /web/<ts>id_/ fetches alike). Date
-# clamping is the per-agent wayback proxy's job (loom/wayback_proxy/).
+#                             exactly the traffic IA sees — replay content,
+#                             Availability lookups, and slower CDX index queries
+#                             are throttled separately so none starves another.
+# The cache is deliberately policy-dumb: /wayback/available forwards to
+# archive.org; /web/... and /cdx/... forward to web.archive.org. Date clamping is
+# the per-agent wayback proxy's job (loom/wayback_proxy/).
 # Workers must run as nginx (uid/gid 101): the deployment's fsGroup makes the
 # /cache PVC group-writable for exactly that gid.
 user nginx;
@@ -22,6 +22,7 @@ events {
 http {
     # Custom format so cache and upstream behavior are directly countable from
     # the access log (the default 'combined' format hides both). Fields:
+    #   origin= archive.org or web.archive.org — included in the cache key.
     #   cache=  $upstream_cache_status — HIT/MISS/EXPIRED/STALE/UPDATING or '-'
     #           (served without an upstream). Measures cache effectiveness.
     #   up=     $upstream_status — IA's HTTP status, comma-joined per
@@ -32,7 +33,9 @@ http {
     #           surfaces the slow IA CDX latency and connect stalls.
     #   tries=  $upstream_addr — the upstream(s) tried (one per retry).
     log_format wayback '$remote_addr [$time_local] "$request" $status '
-                       'cache=$upstream_cache_status up=$upstream_status '
+                       'origin=$wayback_cache_origin cache=$upstream_cache_status up=$upstream_status '
+                       'xrl="$upstream_http_x_rl" retry_after="$upstream_http_retry_after" '
+                       'xna="$upstream_http_x_na" '
                        'rt=$request_time uct=$upstream_connect_time urt=$upstream_response_time '
                        'tries=$upstream_addr bytes=$body_bytes_sent';
     access_log /dev/stdout wayback;
@@ -44,7 +47,10 @@ http {
     # single-valued. The rich `wayback` format above still goes to stdout for
     # Loki/manual analysis. UDP drops under load are acceptable for sampling.
     log_format wayback_metrics '$remote_addr "$request" $status '
-                               'cache=$upstream_cache_status up="$upstream_status" rt=$request_time';
+                               'origin=$wayback_cache_origin cache=$upstream_cache_status '
+                               'up="$upstream_status" rt=$request_time '
+                               'xrl="$upstream_http_x_rl" retry_after="$upstream_http_retry_after" '
+                               'xna="$upstream_http_x_na"';
     access_log syslog:server=127.0.0.1:5140,tag=wayback,severity=info,nohostname wayback_metrics;
 
     # Bearer token for the gateway-facing listener (:8090). Injected at
@@ -59,15 +65,21 @@ http {
         "Bearer ${WAYBACK_CACHE_TOKEN}" 1;
     }
 
+    map $uri $wayback_cache_origin {
+        ~^/wayback/available$ archive.org;
+        default web.archive.org;
+    }
+
     # Snapshot bytes at a fixed 14-digit timestamp are immutable.
     # use_temp_path=off avoids cross-filesystem renames onto the PVC.
     proxy_cache_path /cache levels=1:2 keys_zone=wayback:64m max_size=18g
                      inactive=3650d use_temp_path=off;
 
-    # Content fetches (immutable snapshot bytes) and CDX index queries are paced
-    # separately: CDX is slow at IA (10-25s/query) but every clamp needs one, so
-    # sharing one bucket made cold bursts queue CDX behind content and 504.
+    # Content fetches (immutable snapshot bytes), Availability lookups, and CDX
+    # index queries are paced separately: CDX is slow at IA (10-25s/query), while
+    # Availability is the proxy's default timestamp-selection path.
     limit_req_zone $server_name zone=ia_upstream:1m rate=30r/m;
+    limit_req_zone $server_name zone=ia_available:1m rate=60r/m;
     limit_req_zone $server_name zone=ia_cdx:1m rate=60r/m;
 
     # DNS resolved once at nginx startup; the Recreate deployment strategy
@@ -93,11 +105,18 @@ http {
         keepalive_requests 10000;
     }
 
+    upstream ia_available {
+        server archive.org:443;
+        keepalive 64;
+        keepalive_timeout 120s;
+        keepalive_requests 10000;
+    }
+
     server { # tier 1: PVC-backed cache
         listen 8080;
 
         proxy_cache wayback;
-        proxy_cache_key $request_uri;
+        proxy_cache_key "$wayback_cache_origin$request_uri";
         proxy_cache_lock on; # collapse concurrent identical misses
         # Lock timeouts must ride out tier-2 limit_req delays
         # (burst 60 at 30r/m queues up to ~120s).
@@ -122,6 +141,16 @@ http {
         # cached briefly so transient IA flakiness doesn't stick.
         location / {
             proxy_cache_valid 200 302 3650d;
+            proxy_cache_valid 404 1h;
+            proxy_pass http://127.0.0.1:8081;
+        }
+
+        # Availability answers are timestamp-index metadata, not immutable
+        # replay bytes, but they are stable enough to cache across eval runs.
+        # The proxy still validates returned timestamps and can fall back to CDX
+        # for unavailable/future answers.
+        location = /wayback/available {
+            proxy_cache_valid 200 365d;
             proxy_cache_valid 404 1h;
             proxy_pass http://127.0.0.1:8081;
         }
@@ -158,7 +187,7 @@ http {
         listen 127.0.0.1:8081;
         server_name wayback-upstream;
 
-        # Common IA upstream settings, inherited by both locations below. (A
+        # Common IA upstream settings, inherited by all locations below. (A
         # location that set its own proxy_set_header would inherit none of these,
         # so neither does — they differ only in rate bucket and read timeout.)
         proxy_http_version 1.1;
@@ -167,13 +196,13 @@ http {
         # connections to IA are detected/dropped if IA silently closes them,
         # keeping the reused pool healthy between paced requests.
         proxy_socket_keepalive on;
-        proxy_set_header Host web.archive.org;
+        proxy_set_header Host $wayback_cache_origin;
         proxy_set_header User-Agent "ducktape-wayback-cache/1 (+agentydragon@gmail.com)";
         # Deterministic bytes: no content-encoding variants in the cache, so
         # per-agent evidence sha256s are stable.
         proxy_set_header Accept-Encoding "identity";
         proxy_ssl_server_name on;
-        proxy_ssl_name web.archive.org;
+        proxy_ssl_name $wayback_cache_origin;
         proxy_ssl_verify on;
         proxy_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
         proxy_connect_timeout 10s;
@@ -189,7 +218,15 @@ http {
         proxy_next_upstream_tries 3;
         proxy_next_upstream_timeout 60s;
 
-        # CDX index lookups are slow at IA (10-25s) and every clamp issues one:
+        # Availability is the proxy's hot timestamp-selection path.
+        location = /wayback/available {
+            limit_req zone=ia_available burst=30;
+            proxy_read_timeout 60s;
+            proxy_pass https://ia_available;
+        }
+
+        # CDX index lookups are slow at IA (10-25s) and remain as compatibility
+        # passthrough plus fallback for cases Availability cannot represent:
         # give them a more generous bucket and a longer read timeout so a queued
         # query rides out the wait instead of 504-ing, and never competes with
         # content fetches for the same tokens.

--- a/cluster/k8s/wayback-cache/config/nginxlog-exporter.hcl
+++ b/cluster/k8s/wayback-cache/config/nginxlog-exporter.hcl
@@ -3,7 +3,7 @@
 # (udp 127.0.0.1:5140); this parses it into Prometheus metrics scraped at :4040.
 #
 # Emitted (namespace "wayback"):
-#   wayback_http_response_count_total{method,status,cache,up} — request counts.
+#   wayback_http_response_count_total{method,status,origin,cache,up,...} — request counts.
 #     * cache hit rate  = ratio of {cache="HIT"} to total.
 #     * IA TCP refusals = {status="502", up=~"-.*"} (no upstream HTTP response).
 #     * IA HTTP errors  = {status="502", up!~"-.*"} etc.
@@ -15,7 +15,7 @@ listen {
 }
 
 namespace "wayback" {
-  format = "$remote_addr \"$request\" $status cache=$upstream_cache_status up=\"$upstream_status\" rt=$request_time"
+  format = "$remote_addr \"$request\" $status origin=$wayback_cache_origin cache=$upstream_cache_status up=\"$upstream_status\" rt=$request_time xrl=\"$upstream_http_x_rl\" retry_after=\"$upstream_http_retry_after\" xna=\"$upstream_http_x_na\""
 
   source {
     syslog {
@@ -25,11 +25,23 @@ namespace "wayback" {
     }
   }
 
-  # Promote the two custom fields to metric labels (both low-cardinality).
+  # Promote low-cardinality custom fields to metric labels.
+  relabel "origin" {
+    from = "wayback_cache_origin"
+  }
   relabel "cache" {
     from = "upstream_cache_status"
   }
   relabel "up" {
     from = "upstream_status"
+  }
+  relabel "xrl" {
+    from = "upstream_http_x_rl"
+  }
+  relabel "retry_after" {
+    from = "upstream_http_retry_after"
+  }
+  relabel "xna" {
+    from = "upstream_http_x_na"
   }
 }

--- a/loom/gym/TODO.md
+++ b/loom/gym/TODO.md
@@ -1,14 +1,15 @@
 # loom/gym TODO
 
-- **Internet Archive throttling — the eval runs but IA fails ~⅓ of cold fetches.**
-  The eval now works end-to-end in `claude-sandbox`, but archive.org returns
-  ~900-950 HTTP `502`/`504` per run on cold CDX-index queries, producing ~8-13
-  `nan` (no-answer) samples. Static mitigations (keepalive pool, CDX TTL,
-  concurrency cap) were proven via metrics to shuffle the failure mode without
-  reducing volume. Findings, the metrics/observability runbook, operational
-  gotchas (broken `exec`/`port-forward`, cluster access via SOPS JWT, docker-ci
-  network pool, Flux source lag), and the prioritized next plan (availability-API
-  clamp → signal capture → adaptive backoff → self-hosted shard) are written up in
+- **Internet Archive throttling — deploy and measure the Availability-first path.**
+  The eval works end-to-end in `claude-sandbox`, but archive.org returned ~900-950
+  HTTP `502`/`504` per run on cold CDX-index queries, producing ~8-13 `nan`
+  (no-answer) samples. The proxy now resolves normal URLs through
+  `archive.org/wayback/available` first, falls back to clamped CDX only when
+  Availability cannot preserve semantics, and the cache routes/logs
+  `/wayback/available` separately from replay/CDX. After rollout, run another
+  33-task eval and compare CDX volume, IA `502`/`504`, `x-rl`/`Retry-After`, and
+  `nan` count. Findings, the metrics/observability runbook, operational gotchas,
+  and next steps (adaptive backoff → self-hosted shard) are in
   <../plans/wayback_ia_throttling.md>.
 
 - **Rename `baseline_llm.py`.** Once the bare one-shot LLM scaffold is gone, the

--- a/loom/plans/archive_org_apis.md
+++ b/loom/plans/archive_org_apis.md
@@ -1,0 +1,287 @@
+# Archive.org APIs relevant to the Wayback proxy/cache
+
+Status: notes from official Internet Archive developer docs checked on
+2026-06-11, plus loom-specific observations from the current
+`wayback-cache`/`wayback_proxy` work.
+
+The short version for loom: use the **Availability API** for the normal
+"pick a capture near `as_of`" path if it validates cleanly, use **Wayback
+replay URLs** for bytes, keep **CDX** as a compatibility/debug/fallback path,
+and treat the rest of archive.org's item/catalog APIs as out of scope for the
+date-clamped browsing proxy.
+
+## Sources
+
+- Internet Archive developer portal:
+  <https://archive.org/developers/>
+- Availability API tutorial:
+  <https://archive.org/developers/tutorial-get-snapshot-wayback.html>
+- CDX tutorial:
+  <https://archive.org/developers/tutorial-compare-snapshot-wayback.html>
+- Automated access guidance:
+  <https://archive.org/developers/bots.html>
+- Item metadata API:
+  <https://archive.org/developers/metadata.html>
+- S3-like item storage API:
+  <https://archive.org/developers/ias3.html>
+- Python/CLI wrapper docs:
+  <https://archive.org/developers/internetarchive/index.html>
+
+## Wayback APIs
+
+### Availability API
+
+Endpoint:
+
+```text
+GET https://archive.org/wayback/available?url=<url>
+```
+
+Observed/expected timestamp form for loom to validate:
+
+```text
+GET https://archive.org/wayback/available?url=<url>&timestamp=<YYYYMMDDhhmmss>
+```
+
+Officially documented response shape:
+
+```json
+{
+  "url": "http://example.com/",
+  "archived_snapshots": {
+    "closest": {
+      "status": "200",
+      "available": true,
+      "url": "http://web.archive.org/web/20180427130634/https://example.com/",
+      "timestamp": "20180427130634"
+    }
+  }
+}
+```
+
+Why it matters here:
+
+- It queries `archive.org`, not `web.archive.org/cdx/search/cdx`, so it may avoid
+  the cold-CDX failure mode seen in the eval.
+- It returns one chosen snapshot instead of the whole capture list, which matches
+  the proxy's hot path if the chosen snapshot is correct.
+- It should become the default resolver only after tests confirm the timestamp
+  parameter returns a capture at or before `WAYBACK_AS_OF`, not simply the
+  nearest capture on either side.
+
+Validation questions before replacing CDX:
+
+- Does `timestamp=<as_of_ts>` always return `closest.timestamp <= as_of_ts`?
+  If not, the proxy must reject future timestamps and either return 404 or fall
+  back to CDX.
+- Does the API return archived non-200 captures, or only captures it considers
+  "available"? Current replay behavior treats archived 404/500 pages as valid
+  historical content when replay carries `Memento-Datetime`.
+- Does `closest.url` already point at the desired replay path, or does the proxy
+  need to normalize it to `/web/<timestamp>id_/<original-url>` to get raw bytes
+  without Wayback rewriting?
+- What headers appear under load (`x-rl`, `retry-after`, `x-na`, status 429 vs
+  502/504)? Capture them in `wayback-cache` logs before tuning.
+
+Recommended loom use:
+
+- Normal URL lookup: Availability API -> validate timestamp -> fetch replay
+  bytes.
+- Cache it with a long but not infinite TTL. Like CDX, availability answers can
+  drift if IA backfills older captures or applies takedowns.
+- Keep enough response metadata in the proxy's upstream-error manifest to debug
+  `available=false`, 429, 502, and malformed responses.
+
+### CDX Server API
+
+Endpoint:
+
+```text
+GET https://web.archive.org/cdx/search/cdx?url=<url>
+```
+
+Current proxy hot-path shape:
+
+```text
+GET /cdx/search/cdx?url=<url>&to=<as_of_ts>&output=json&limit=-1
+```
+
+The documented default row fields are:
+
+- `urlkey`
+- `timestamp` (`YYYYMMDDhhmmss`)
+- `original`
+- `mimetype`
+- `statuscode`
+- `digest`
+- `length`
+
+Why it matters here:
+
+- It is the most expressive Wayback index API: complete capture lists, filtering,
+  debug comparison between captures, and exact fallback when Availability is too
+  lossy.
+- It is also the endpoint that dominated the eval's cold-miss failures
+  (`/cdx/search/cdx` 502/504 volume), so it should leave the hot path if
+  Availability validates.
+
+Recommended loom use:
+
+- Keep direct agent CDX requests clamped: any user-supplied `to=` must be bounded
+  by `WAYBACK_AS_OF`, and requests without `to=` get `to=WAYBACK_AS_OF`.
+- Keep CDX in tests/fake IA until Availability semantics are covered by tests.
+- Use CDX for diagnostics, richer offline analysis, and fallback if Availability
+  cannot preserve the proxy's current semantics.
+
+### Wayback replay URLs
+
+Replay URL shape:
+
+```text
+https://web.archive.org/web/<timestamp><modifier>/<url>
+https://web.archive.org/web/<timestamp>id_/<url>
+```
+
+The `id_` modifier is the important one for loom: it asks Wayback for raw replay
+bytes instead of rewritten/bannered HTML. The proxy already fetches with
+`Accept-Encoding: identity` so evidence hashes are stable.
+
+Recommended loom use:
+
+- After timestamp selection, always fetch raw bytes via `/web/<ts>id_/<url>`.
+- Follow archive-internal redirects only while re-validating every redirected
+  timestamp against `WAYBACK_AS_OF`.
+- Return off-archive captured redirects back to the client so the next request
+  re-enters the proxy and is resolved under the clamp.
+- Treat replay 4xx/5xx with `Memento-Datetime` as archived content; treat
+  replay 4xx/5xx without `Memento-Datetime` as IA/cache failure.
+
+### Save Page Now
+
+Save Page Now captures current live pages for future citation. That is useful
+for ingestion workflows, but not for the `loom/gym` as-of eval: creating a new
+capture in 2026 must not make post-`as_of` information available to an agent.
+
+Recommended loom use:
+
+- Do not call Save Page Now from the proxy or eval.
+- It could be useful only in a separate data-preparation pipeline that records
+  present-day evidence for future tasks.
+
+## Archive.org item/catalog APIs
+
+These APIs operate on archive.org "items" (collections of files plus metadata),
+not Wayback captures. They are useful for general archive.org automation, but
+not for choosing replay captures in the proxy.
+
+### Item Metadata API
+
+Endpoint family:
+
+```text
+GET https://archive.org/metadata/<identifier>
+```
+
+It reads metadata and file listings for archive.org items. Writes require
+authentication.
+
+Use for loom:
+
+- Not needed for date-clamped web browsing.
+- Potentially useful if a future pipeline stores curated eval artifacts as
+  archive.org items and needs metadata/file inventory.
+
+### S3-like API (`ias3`)
+
+Endpoint family:
+
+```text
+https://s3.us.archive.org/<item>/<file>
+```
+
+It maps archive.org items to S3-like buckets and files to S3-like keys; `PUT`
+creates/uploads item files and ingests them through Archive's backend.
+
+Use for loom:
+
+- Not needed for the proxy/cache.
+- Potentially useful for publishing or backing up generated artifacts, subject
+  to IA's collection and authentication rules.
+
+### Advanced search / item search
+
+Endpoint:
+
+```text
+GET https://archive.org/advancedsearch.php?...&output=json
+```
+
+This searches archive.org item metadata, not the Wayback web crawl index.
+
+Use for loom:
+
+- Not a replacement for Wayback capture lookup.
+- Could help discover archive.org-hosted datasets/items, but not ordinary web
+  URL snapshots.
+
+### Changes, tasks, views, relationships, reviews
+
+The developer portal also documents:
+
+- Changes API: discover changed archive.org item identifiers.
+- Tasks API: inspect upload/derive/catalog tasks.
+- Views API: item/collection engagement counts.
+- Relationships and reviews APIs: item/user metadata surfaces.
+
+Use for loom:
+
+- Not relevant to the Wayback proxy/cache path.
+- Keep them out of the proxy unless a separate artifact-publication workflow
+  needs them.
+
+## Automated access rules that matter here
+
+The official automated-access guidance says automated callers should:
+
+- Send a descriptive `User-Agent`.
+- Add delays or concurrency limits for bulk work.
+- Honor `429 Too Many Requests` and `Retry-After`.
+- Cache responses.
+- Handle errors gracefully with backoff.
+
+The current `wayback-cache` already sends a descriptive User-Agent and caches
+responses. Next cache changes should log enough upstream headers to distinguish:
+
+- clean rate limiting: `429` and/or `Retry-After`;
+- IA-specific signals: observed `x-rl`, `x-na`, `x-app-server`, `x-ts`, `x-tr`;
+- overload/failure: `502`/`504` without retry hints.
+
+## Proxy/cache division after the Availability change
+
+Proxy responsibilities:
+
+- Own all date policy.
+- Hold one immutable `WAYBACK_AS_OF`.
+- Resolve normal URLs through Availability first.
+- Validate every returned or redirected timestamp itself.
+- Fetch raw replay bytes.
+- Emit served-evidence and upstream-error manifest records.
+- Clamp or reject explicit archive URLs and CDX requests.
+
+Cache responsibilities:
+
+- Be policy-dumb: cache and pace upstream requests, do not decide dates.
+- Support at least two upstream host classes:
+  - `archive.org` for `/wayback/available`;
+  - `web.archive.org` for `/web/...` and retained `/cdx/...`.
+- Include the upstream host/class in the cache key once multiple origins share a
+  cache, so `/path` collisions cannot cross hosts.
+- Export metrics split by upstream host, path class, cache status, response
+  status, upstream status, and selected IA signal headers.
+- Avoid amplifying IA failures: do not blindly retry high-rate 502/504 bursts
+  without a circuit breaker or adaptive backoff.
+
+Open design choice: keep one nginx cache that routes by path to both IA hosts,
+or split into two ClusterIP services/caches (`wayback-replay-cache` and
+`wayback-availability-cache`) so cache keys, metrics, and rate limits are
+naturally separated. Splitting is more YAML but less clever.

--- a/loom/plans/wayback_ia_throttling.md
+++ b/loom/plans/wayback_ia_throttling.md
@@ -2,7 +2,8 @@
 
 Status as of **2026-06-11**. Handoff for whoever next works on making the
 `loom/gym` eval's archived web access reliable. Companion to
-<wayback_proxy.md> (the proxy design) and <../gym/TODO.md>.
+<wayback_proxy.md> (the proxy design), <archive_org_apis.md> (API notes), and
+<../gym/TODO.md>.
 
 ## TL;DR
 
@@ -98,8 +99,10 @@ hostname_blocked` (a hard block, distinct from the cluster's
 
 Replace the CDX `/cdx/search/cdx` timestamp clamp in `loom/wayback_proxy/` with
 `archive.org/wayback/available?url=<url>&timestamp=<YYYYMMDDhhmmss>`. This
-sidesteps the rate-limited, mostly-failing CDX endpoint entirely (the dominant
-source of the `502`s). Implementation lives in `loom/wayback_proxy/proxy.py` /
+sidesteps the rate-limited, mostly-failing CDX endpoint for the common path (the
+dominant source of the `502`s). CDX should remain as a clamped passthrough and
+fallback for cases Availability cannot represent cleanly, such as archived
+non-200 captures. Implementation lives in `loom/wayback_proxy/proxy.py` /
 `addon.py` (the date-clamp logic) + tests (`test_proxy.py`, `fake_ia.py`).
 
 Verify before committing:
@@ -114,6 +117,11 @@ Verify before committing:
 - its rate limits / `x-rl` behavior under the eval's volume (it may have its own
   limits — measure, don't assume).
 
+Implementation note: the intended shape is Availability-first for normal URLs,
+strict timestamp validation in the proxy, and CDX fallback only when
+Availability is unavailable/future or cannot preserve current semantics (for
+example archived non-200 captures).
+
 ### 2. Capture IA's signal headers on the cache (cheap; do before #3)
 
 Add `$upstream_http_x_rl`, `$upstream_http_retry_after`, `$upstream_http_x_na` to
@@ -122,6 +130,11 @@ the wayback-cache nginx access log (a `log_format` addition) and/or the exporter
 **after** an eval finishes (rolling the cache mid-run drops in-flight fetches).
 Then one run tells us definitively whether IA sends a retry/limit signal on the
 `502`/CDX path we actually fail on. This is the "measure before tuning" step.
+
+Implementation note: the cache log/exporter should split metrics by `origin`
+(`archive.org` vs `web.archive.org`) and include the low-cardinality signal
+headers so the post-rollout eval can distinguish Availability pressure from
+replay/CDX pressure.
 
 ### 3. Adaptive backoff / respect-signal (after #2's data)
 

--- a/loom/plans/wayback_proxy.md
+++ b/loom/plans/wayback_proxy.md
@@ -39,9 +39,11 @@ Three layers: `agent → per-agent proxy → shared cache → web.archive.org`.
 
 1. **Per-agent date-clamping proxy** ("time machine"). A plain HTTP proxy
    configured with one task's `as_of`. For any requested URL it resolves the
-   newest capture ≤ `as_of` (CDX `to=`), serves the `id_` raw bytes (no IA
-   banner/rewriting), follows IA's 302 timestamp-canonicalization internally,
-   and returns 404 when no pre-`as_of` capture exists. Existing piece:
+   newest capture ≤ `as_of` through the Wayback Availability API first, falls
+   back to clamped CDX when Availability cannot represent the case cleanly,
+   serves the `id_` raw bytes (no IA banner/rewriting), follows IA's 302
+   timestamp-canonicalization internally, and returns 404 when no pre-`as_of`
+   capture exists. Existing piece:
    [WaybackProxy](https://github.com/richardg867/WaybackProxy) is exactly
    this shape (built so retro browsers can browse the web of a configured
    date). Run it as the sidecar with its date pinned per instance and its
@@ -53,13 +55,16 @@ Three layers: `agent → per-agent proxy → shared cache → web.archive.org`.
 2. **Shared pull-through cache** (cluster service `wayback-cache`). Dumb
    two-tier nginx: tier 1 is a PVC-backed `proxy_cache` (snapshot content at
    a fixed 14-digit timestamp is immutable → effectively infinite validity,
+   Availability/CDX metadata is cached with long TTLs, and
    `proxy_cache_lock` collapses concurrent misses); misses forward to a
    loopback-only tier 2 where **every request is by construction a cold
-   miss**, so a `limit_req` token bucket there paces exactly the traffic IA
-   sees while cache hits are never throttled. Contact User-Agent on the
-   upstream hop. Draft manifests exist (namespace / pvc / configmap-generated
-   nginx.conf / deployment / service / flux-kustomization), parked pending
-   go-ahead; the config essence:
+   miss**, so `limit_req` token buckets pace exactly the traffic IA sees while
+   cache hits are never throttled. `/wayback/available` routes to
+   `archive.org`; replay/CDX routes to `web.archive.org`; the origin class is
+   part of the cache key. Contact User-Agent on the upstream hop. Draft
+   manifests exist (namespace / pvc / configmap-generated nginx.conf /
+   deployment / service / flux-kustomization), parked pending go-ahead; the
+   config essence:
 
    ```nginx
    proxy_cache_path /cache keys_zone=wayback:64m max_size=18g inactive=3650d;

--- a/loom/wayback_proxy/BUILD.bazel
+++ b/loom/wayback_proxy/BUILD.bazel
@@ -9,6 +9,7 @@ py_library(
     srcs = ["proxy.py"],
     deps = [
         "@pypi//aiohttp",
+        "@pypi//multidict",
         "@pypi//pydantic",
         "@pypi//yarl",
     ],

--- a/loom/wayback_proxy/BUILD.bazel
+++ b/loom/wayback_proxy/BUILD.bazel
@@ -9,6 +9,7 @@ py_library(
     srcs = ["proxy.py"],
     deps = [
         "@pypi//aiohttp",
+        "@pypi//pydantic",
         "@pypi//yarl",
     ],
 )

--- a/loom/wayback_proxy/README.md
+++ b/loom/wayback_proxy/README.md
@@ -1,8 +1,10 @@
 # Wayback proxy — date-clamped web access for sandboxed agents
 
 The per-agent "time machine" from the [wayback proxy plan](../plans/wayback_proxy.md):
-a forward proxy that answers every URL with the newest Internet Archive
-capture at-or-before `WAYBACK_AS_OF`, served as raw `id_` bytes. No capture at
+a forward proxy that answers every URL with the newest Internet Archive capture
+at-or-before `WAYBACK_AS_OF`, served as raw `id_` bytes. Normal URLs resolve via
+the Wayback Availability API first, with CDX as a fallback for cases Availability
+does not represent cleanly (for example archived non-200 captures). No capture at
 or before the cutoff → 404. Explicit `web.archive.org/web/<ts>/…` requests are
 clamped (`ts ≤ as_of`), CDX queries get their `to=` bound clamped, and redirect
 hops are re-clamped (IA canonicalizes toward the _closest_ capture, which can
@@ -58,9 +60,12 @@ docker compose down -v
 ```
 
 Knobs (compose env interpolation): `WAYBACK_AS_OF` (ISO date, default
-`2020-06-01`), `WAYBACK_UPSTREAM` (default `https://web.archive.org`).
-`WAYBACK_CONFDIR` (default `~/.mitmproxy`) is where the CA is generated; the
-demo points it at a volume shared read-only with the agent.
+`2020-06-01`), `WAYBACK_UPSTREAM` (replay/CDX upstream, default
+`https://web.archive.org`), `WAYBACK_AVAILABILITY_UPSTREAM` (Availability API
+upstream; defaults to `https://archive.org` in direct-IA mode and to
+`WAYBACK_UPSTREAM` when a shared cache is configured). `WAYBACK_CONFDIR`
+(default `~/.mitmproxy`) is where the CA is generated; the demo points it at a
+volume shared read-only with the agent.
 
 ## Using the shared cluster cache
 
@@ -87,8 +92,9 @@ bbr test //loom/wayback_proxy:test_proxy        # addon semantics vs canned fake
 bbr test //loom/wayback_proxy:test_compose_e2e  # the compose demo, end to end (Docker)
 ```
 
-`fake_ia.py` pins the IA contract the proxy relies on (CDX header-row JSON,
-scheme-insensitive urlkey matching, empty body on no matches, `Memento-Datetime`
-on replays, 302 timestamp canonicalization, captured live-web redirects).
+`fake_ia.py` pins the IA contract the proxy relies on (Availability JSON, CDX
+header-row JSON, scheme-insensitive urlkey matching, empty CDX body on no
+matches, `Memento-Datetime` on replays, 302 timestamp canonicalization, captured
+live-web redirects).
 `test_compose_e2e.py` proves both http and https fetches resolve to the clamped
 capture while direct egress stays physically blocked.

--- a/loom/wayback_proxy/fake_ia.py
+++ b/loom/wayback_proxy/fake_ia.py
@@ -1,12 +1,13 @@
 """Canned Internet Archive stand-in for wayback proxy tests.
 
-Implements just enough of the CDX API (``/cdx/search/cdx`` with ``url``,
-``to``, ``limit=-1``, ``output=json``) and the ``/web/<ts><modifier>/<url>``
-replay endpoint, from a literal capture table. Deliberately independent of
-proxy.py — this module is the test oracle pinning what we believe IA does:
-header-row CDX JSON, empty body when no captures match, ``Memento-Datetime``
-on replayed captures (including archived 404s), 302 timestamp
-canonicalization, and captured live-web redirects.
+Implements just enough of the Availability API (``/wayback/available``), the
+CDX API (``/cdx/search/cdx`` with ``url``, ``to``, ``limit=-1``,
+``output=json``), and the ``/web/<ts><modifier>/<url>`` replay endpoint, from a
+literal capture table. Deliberately independent of proxy.py — this module is
+the test oracle pinning what we believe IA does: Availability's single closest
+snapshot JSON, header-row CDX JSON, empty CDX body when no captures match,
+``Memento-Datetime`` on replayed captures (including archived 404s), 302
+timestamp canonicalization, and captured live-web redirects.
 
 Runs in the test process: in-process for test_proxy.py, bound on 0.0.0.0 for
 the compose e2e (the proxy container reaches it via host.docker.internal).
@@ -22,6 +23,7 @@ from datetime import date
 from aiohttp import web
 
 CDX_PATH = "/cdx/search/cdx"
+AVAILABILITY_PATH = "/wayback/available"
 CDX_HEADER = ["urlkey", "timestamp", "original", "mimetype", "statuscode", "digest", "length"]
 MEMENTO_HEADER = {"Memento-Datetime": "Wed, 15 Jan 2020 10:30:00 GMT"}
 
@@ -65,6 +67,11 @@ GONE_BODY = b"not found, as of 2020\n"
 # CDX itself fails for this URL (tests 503 -> 502 mapping).
 CDX_BROKEN_URL = "http://cdx-broken.example/"
 
+# CDX fails for this URL, but Availability succeeds. Proves normal browsing does
+# not touch CDX on the happy path.
+CDX_FAILS_BUT_AVAILABLE_URL = "http://available-only.example/"
+CDX_FAILS_BUT_AVAILABLE_BODY = b"served without touching cdx\n"
+
 
 @dataclass(frozen=True)
 class Replay:
@@ -82,6 +89,7 @@ CDX_CAPTURES: dict[str, list[tuple[str, str]]] = {
     DRIFT_URL: [(DRIFT_LISTED_TS, DRIFT_URL)],
     MOVED_URL: [(GOOD_TS, MOVED_URL)],
     GONE_URL: [(GOOD_TS, GONE_URL)],
+    CDX_FAILS_BUT_AVAILABLE_URL: [(GOOD_TS, CDX_FAILS_BUT_AVAILABLE_URL)],
 }
 
 # Replay table: (timestamp, original URL) -> response.
@@ -94,6 +102,7 @@ REPLAYS: dict[tuple[str, str], Replay] = {
     (TOO_NEW_TS, DRIFT_URL): Replay(body=b"post-as_of content that must never be served\n"),
     (GOOD_TS, MOVED_URL): Replay(redirect_to=MOVED_TARGET),
     (GOOD_TS, GONE_URL): Replay(status=404, body=GONE_BODY),
+    (GOOD_TS, CDX_FAILS_BUT_AVAILABLE_URL): Replay(body=CDX_FAILS_BUT_AVAILABLE_BODY),
 }
 
 
@@ -112,7 +121,7 @@ def _captures_for(url: str) -> list[tuple[str, str]]:
 
 def _cdx_response(request: web.BaseRequest) -> web.Response:
     url = request.query["url"]
-    if url == CDX_BROKEN_URL:
+    if url in (CDX_BROKEN_URL, CDX_FAILS_BUT_AVAILABLE_URL):
         return web.Response(status=503, text="CDX is having a bad day\n")
     to_ts = request.query.get("to", "99999999999999").ljust(14, "9")
     matching = [capture for capture in _captures_for(url) if capture[0] <= to_ts]
@@ -127,8 +136,46 @@ def _cdx_response(request: web.BaseRequest) -> web.Response:
     return web.Response(body=json.dumps(rows).encode(), content_type="application/json")
 
 
+def _availability_response(request: web.BaseRequest) -> web.Response:
+    url = request.query["url"]
+    timestamp = request.query.get("timestamp", "99999999999999").ljust(14, "9")
+    captures = _captures_for(url)
+
+    # The real API appears to center "closest" around the requested timestamp,
+    # not necessarily "newest <= timestamp"; force the future-only fixture to
+    # exercise the proxy's own future-timestamp guard and CDX fallback.
+    matching = [capture for capture in captures if capture[0] <= timestamp]
+    if not matching and captures:
+        matching = [captures[0]]
+
+    # Model Availability being less expressive than CDX: archived non-200
+    # captures may not be returned as "available", so the proxy must fall back to
+    # CDX to preserve historical 404/500 semantics.
+    if url == GONE_URL or not matching:
+        payload = {"url": url, "archived_snapshots": {}}
+        return web.Response(body=json.dumps(payload).encode(), content_type="application/json")
+
+    ts, original = matching[-1]
+    payload = {
+        "url": url,
+        "archived_snapshots": {
+            "closest": {
+                "status": "200",
+                "available": True,
+                "url": f"http://web.archive.org/web/{ts}/{original}",
+                "timestamp": ts,
+            }
+        },
+    }
+    return web.Response(
+        body=json.dumps(payload).encode(), content_type="application/json", headers={"x-rl": "0", "x-na": "0"}
+    )
+
+
 async def handle(request: web.BaseRequest) -> web.StreamResponse:
     raw_path = request.raw_path
+    if raw_path.startswith(AVAILABILITY_PATH):
+        return _availability_response(request)
     if raw_path.startswith(CDX_PATH):
         return _cdx_response(request)
     if (match := _WEB_RE.match(raw_path)) is not None:

--- a/loom/wayback_proxy/proxy.py
+++ b/loom/wayback_proxy/proxy.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from typing import TextIO
 
 import aiohttp
+from multidict import CIMultiDictProxy
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 from yarl import URL
 
@@ -428,7 +429,9 @@ class WaybackResolver:
             return {"Authorization": self._config.upstream_auth}
         return {}
 
-    def _emit_upstream_error(self, request_url: str, status: int, body: bytes, headers: object | None = None) -> None:
+    def _emit_upstream_error(
+        self, request_url: str, status: int, body: bytes, headers: CIMultiDictProxy[str] | None = None
+    ) -> None:
         """Upstream-failure record: archive/cache returned HTTP ≥400 unexpectedly
         (an IA bad gateway or a rate-limit notice, not an archived error page).
 

--- a/loom/wayback_proxy/proxy.py
+++ b/loom/wayback_proxy/proxy.py
@@ -10,8 +10,10 @@ lives in ``addon.py`` / ``server.py``. See loom/plans/wayback_proxy.md.
 Configuration (env, parsed by :class:`Config`): ``WAYBACK_AS_OF`` (required ISO
 date, inclusive), ``WAYBACK_UPSTREAM`` (default ``https://web.archive.org``;
 point at the wayback-cache cluster service to share a pull-through cache),
+``WAYBACK_AVAILABILITY_UPSTREAM`` (defaults to ``https://archive.org`` for
+direct-IA mode, or ``WAYBACK_UPSTREAM`` when a cache is configured),
 ``WAYBACK_UPSTREAM_AUTH`` (``Authorization`` header for the authed cache route),
-``WAYBACK_MANIFEST_PATH`` (write the manifest to this file instead of stdout —
+``WAYBACK_MANIFEST_PATH`` (write the manifest to this file instead of stdout -
 the gym scorer reads it out of the sandbox per sample).
 """
 
@@ -34,6 +36,8 @@ logger = logging.getLogger(__name__)
 
 CDX_PATH = "/cdx/search/cdx"
 ARCHIVE_HOST = "web.archive.org"
+AVAILABILITY_HOST = "archive.org"
+AVAILABILITY_PATH = "/wayback/available"
 MAX_REDIRECT_HOPS = 10
 MAX_BODY_BYTES = 64 * 2**20
 # Upstream error bodies (IA/cache 5xx pages) are captured to the manifest for
@@ -44,6 +48,7 @@ MAX_ERROR_BODY_BYTES = 4096
 # "/web/<ts><modifier?>/<url>" — IA replay path. Modifiers are two letters
 # plus underscore (id_, if_, im_, js_, cs_, ...).
 _WEB_PATH_RE = re.compile(r"^/web/(\d{4,14})([a-z]{2}_)?/(.*)$")
+_IA_SIGNAL_HEADERS = ("retry-after", "x-rl", "x-na", "x-app-server", "x-ts", "x-tr")
 
 
 class NoCaptureError(Exception):
@@ -89,6 +94,51 @@ def pick_capture(cdx_rows: list[list[str]]) -> tuple[str, str] | None:
     return newest[ts_index], newest[original_index]
 
 
+def _truthy_availability(value: object) -> bool:
+    return value is True or value in {"true", "True", "1", 1}
+
+
+def pick_available_capture(payload: object, as_of_ts: str) -> tuple[str, str] | None:
+    """Return (timestamp, original URL) from a Wayback Availability response.
+
+    ``None`` means the response is well-formed but not sufficient for the proxy's
+    strict as-of semantics (no closest capture, unavailable, or closest is after
+    the clamp). The caller can then fall back to CDX. Malformed responses raise
+    :class:`UpstreamError`.
+    """
+    if not isinstance(payload, dict):
+        raise UpstreamError(f"Availability returned non-object JSON: {type(payload).__name__}")
+    snapshots = payload.get("archived_snapshots", {})
+    if not isinstance(snapshots, dict):
+        raise UpstreamError(f"Availability archived_snapshots is {type(snapshots).__name__}, not object")
+    closest = snapshots.get("closest")
+    if closest is None:
+        return None
+    if not isinstance(closest, dict):
+        raise UpstreamError(f"Availability closest is {type(closest).__name__}, not object")
+    if not _truthy_availability(closest.get("available")):
+        return None
+    timestamp = closest.get("timestamp")
+    if not isinstance(timestamp, str) or not re.fullmatch(r"\d{4,14}", timestamp):
+        raise UpstreamError(f"Availability timestamp has unexpected value: {timestamp!r}")
+    replay_url_raw = closest.get("url")
+    if not isinstance(replay_url_raw, str):
+        raise UpstreamError(f"Availability replay url has unexpected value: {replay_url_raw!r}")
+    try:
+        replay_url = URL(replay_url_raw, encoded=True)
+    except ValueError as e:
+        raise UpstreamError(f"Availability replay url is invalid: {replay_url_raw!r}") from e
+    parsed = parse_web_path(replay_url.raw_path_qs)
+    if parsed is None:
+        raise UpstreamError(f"Availability replay url is not a Wayback replay path: {replay_url_raw!r}")
+    replay_ts, _modifier, original = parsed
+    if timestamp != replay_ts:
+        raise UpstreamError(f"Availability timestamp {timestamp} does not match replay URL timestamp {replay_ts}")
+    if not ts_allowed(timestamp, as_of_ts):
+        return None
+    return timestamp, original
+
+
 @dataclass(frozen=True)
 class Config:
     as_of: date
@@ -99,20 +149,31 @@ class Config:
     # only ever contacts `upstream`). Used when upstream is the authed public
     # route of the shared cache; None for direct IA or the unauthed ClusterIP.
     upstream_auth: str | None = None
+    # Base URL for /wayback/available. If None, direct web.archive.org upstreams
+    # use archive.org; custom/cache upstreams use the same base as `upstream`.
+    availability_upstream: str | None = None
 
     @classmethod
     def from_env(cls) -> Config:
         as_of_raw = os.environ.get("WAYBACK_AS_OF")
         if as_of_raw is None:
             raise RuntimeError("WAYBACK_AS_OF must be set to the ISO information-cutoff date")
+        upstream_env = os.environ.get("WAYBACK_UPSTREAM")
+        upstream = (upstream_env or f"https://{ARCHIVE_HOST}").rstrip("/")
+        availability_env = os.environ.get("WAYBACK_AVAILABILITY_UPSTREAM")
         manifest_raw = os.environ.get("WAYBACK_MANIFEST_PATH")
         return cls(
             as_of=date.fromisoformat(as_of_raw),
-            upstream=os.environ.get("WAYBACK_UPSTREAM", f"https://{ARCHIVE_HOST}").rstrip("/"),
+            upstream=upstream,
             port=int(os.environ.get("PORT", "8080")),
             manifest_path=Path(manifest_raw) if manifest_raw is not None else None,
             # Empty (the compose default when no auth) is treated as unset.
             upstream_auth=os.environ.get("WAYBACK_UPSTREAM_AUTH") or None,
+            availability_upstream=(
+                availability_env.rstrip("/")
+                if availability_env
+                else (upstream if upstream_env else f"https://{AVAILABILITY_HOST}")
+            ),
         )
 
     @property
@@ -126,6 +187,14 @@ class Config:
         if host is None:
             raise RuntimeError(f"WAYBACK_UPSTREAM has no host: {self.upstream!r}")
         return host
+
+    @property
+    def availability_base(self) -> str:
+        if self.availability_upstream is not None:
+            return self.availability_upstream.rstrip("/")
+        if self.upstream_host == ARCHIVE_HOST:
+            return f"https://{AVAILABILITY_HOST}"
+        return self.upstream
 
 
 @dataclass(frozen=True)
@@ -195,10 +264,12 @@ class WaybackResolver:
         params["to"] = (
             min(requested_to.ljust(14, "9"), self._config.as_of_ts) if requested_to else self._config.as_of_ts
         )
-        async with self._session.get(URL(self._config.upstream + CDX_PATH), params=params) as response:
+        async with self._session.get(
+            URL(self._config.upstream + CDX_PATH), params=params, headers=self._auth_headers_for(self._config.upstream)
+        ) as response:
             body = await response.content.read(MAX_BODY_BYTES)
             if response.status != 200:
-                self._emit_upstream_error(str(response.url), response.status, body)
+                self._emit_upstream_error(str(response.url), response.status, body, response.headers)
                 raise UpstreamError(f"CDX query failed with HTTP {response.status}")
             return ProxyResponse(
                 status=200, headers={"Content-Type": response.headers.get("Content-Type", "text/plain")}, body=body
@@ -206,11 +277,39 @@ class WaybackResolver:
 
     async def _resolve_capture(self, target: URL) -> tuple[str, str]:
         """Newest (timestamp, original URL) capture of `target` at or before as_of."""
+        if (picked := await self._resolve_capture_via_availability(target)) is not None:
+            return picked
+        return await self._resolve_capture_via_cdx(target)
+
+    async def _resolve_capture_via_availability(self, target: URL) -> tuple[str, str] | None:
+        params = {"url": str(target), "timestamp": self._config.as_of_ts}
+        availability_base = self._config.availability_base
+        async with self._session.get(
+            URL(availability_base + AVAILABILITY_PATH), params=params, headers=self._auth_headers_for(availability_base)
+        ) as response:
+            if response.status != 200:
+                body = await response.content.read(MAX_ERROR_BODY_BYTES)
+                self._emit_upstream_error(str(response.url), response.status, body, response.headers)
+                raise UpstreamError(f"Availability lookup failed with HTTP {response.status}")
+            raw = await response.content.read(MAX_BODY_BYTES)
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as e:
+            raise UpstreamError(f"Availability returned invalid JSON: {e}") from e
+        return pick_available_capture(payload, self._config.as_of_ts)
+
+    async def _resolve_capture_via_cdx(self, target: URL) -> tuple[str, str]:
+        """CDX fallback for unavailable/future Availability answers and archived non-200 captures."""
         params = {"url": str(target), "to": self._config.as_of_ts, "output": "json", "limit": "-1"}
-        async with self._session.get(URL(self._config.upstream + CDX_PATH), params=params) as response:
+        async with self._session.get(
+            URL(self._config.upstream + CDX_PATH), params=params, headers=self._auth_headers_for(self._config.upstream)
+        ) as response:
             if response.status != 200:
                 self._emit_upstream_error(
-                    str(response.url), response.status, await response.content.read(MAX_ERROR_BODY_BYTES)
+                    str(response.url),
+                    response.status,
+                    await response.content.read(MAX_ERROR_BODY_BYTES),
+                    response.headers,
                 )
                 raise UpstreamError(f"CDX lookup failed with HTTP {response.status}")
             raw = await response.content.read(MAX_BODY_BYTES)
@@ -242,9 +341,8 @@ class WaybackResolver:
         current = URL(f"{self._config.upstream}/web/{ts}{modifier}/{url}", encoded=True)
         final_ts = ts
         for _ in range(MAX_REDIRECT_HOPS):
-            async with self._session.get(
-                current, allow_redirects=False, headers={"Accept-Encoding": "identity"}
-            ) as response:
+            headers = {"Accept-Encoding": "identity", **self._auth_headers_for(self._config.upstream)}
+            async with self._session.get(current, allow_redirects=False, headers=headers) as response:
                 if response.status in (301, 302, 303, 307, 308):
                     location = response.headers.get("Location")
                     if location is None:
@@ -275,7 +373,7 @@ class WaybackResolver:
                 # 404s/500s (which are correct as-of content). Error statuses
                 # without it are the archive/cache itself failing.
                 if response.status >= 400 and "Memento-Datetime" not in response.headers:
-                    self._emit_upstream_error(str(response.url), response.status, body)
+                    self._emit_upstream_error(str(response.url), response.status, body, response.headers)
                     raise UpstreamError(f"archive upstream returned HTTP {response.status} for {current}")
                 content_type = response.headers.get("Content-Type", "application/octet-stream")
                 return Snapshot(ts=final_ts, status=response.status, content_type=content_type, body=body)
@@ -303,19 +401,29 @@ class WaybackResolver:
         )
         print(line, file=self._manifest, flush=True)
 
-    def _emit_upstream_error(self, request_url: str, status: int, body: bytes) -> None:
+    def _auth_headers_for(self, upstream_base: str) -> dict[str, str]:
+        if self._config.upstream_auth is not None and upstream_base.rstrip("/") == self._config.upstream:
+            return {"Authorization": self._config.upstream_auth}
+        return {}
+
+    def _emit_upstream_error(self, request_url: str, status: int, body: bytes, headers: object | None = None) -> None:
         """Upstream-failure record: archive/cache returned HTTP ≥400 unexpectedly
         (an IA bad gateway or a rate-limit notice, not an archived error page).
 
         Shares the manifest with served records, tagged by `kind`, so the harness
         surfaces a degraded run's failures per sample instead of swallowing the
         body into an opaque 502."""
-        line = json.dumps(
-            {
-                "kind": "upstream_error",
-                "request_url": request_url,
-                "status": status,
-                "body": body[:MAX_ERROR_BODY_BYTES].decode("utf-8", errors="replace"),
+        record = {
+            "kind": "upstream_error",
+            "request_url": request_url,
+            "status": status,
+            "body": body[:MAX_ERROR_BODY_BYTES].decode("utf-8", errors="replace"),
+        }
+        if headers is not None:
+            signal_headers = {
+                name: value for name in _IA_SIGNAL_HEADERS if (value := headers.get(name, None)) is not None
             }
-        )
+            if signal_headers:
+                record["headers"] = signal_headers
+        line = json.dumps(record)
         print(line, file=self._manifest, flush=True)

--- a/loom/wayback_proxy/proxy.py
+++ b/loom/wayback_proxy/proxy.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from typing import TextIO
 
 import aiohttp
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 from yarl import URL
 
 logger = logging.getLogger(__name__)
@@ -98,6 +99,33 @@ def _truthy_availability(value: object) -> bool:
     return value is True or value in {"true", "True", "1", 1}
 
 
+class AvailabilityClosest(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    available: object = False
+    timestamp: str
+    url: str
+
+    @field_validator("timestamp")
+    @classmethod
+    def _validate_timestamp(cls, value: str) -> str:
+        if re.fullmatch(r"\d{4,14}", value) is None:
+            raise ValueError("must be a 4-14 digit IA timestamp")
+        return value
+
+
+class ArchivedSnapshots(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    closest: AvailabilityClosest | None = None
+
+
+class AvailabilityResponse(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    archived_snapshots: ArchivedSnapshots = Field(default_factory=ArchivedSnapshots)
+
+
 def pick_available_capture(payload: object, as_of_ts: str) -> tuple[str, str] | None:
     """Return (timestamp, original URL) from a Wayback Availability response.
 
@@ -106,24 +134,18 @@ def pick_available_capture(payload: object, as_of_ts: str) -> tuple[str, str] | 
     the clamp). The caller can then fall back to CDX. Malformed responses raise
     :class:`UpstreamError`.
     """
-    if not isinstance(payload, dict):
-        raise UpstreamError(f"Availability returned non-object JSON: {type(payload).__name__}")
-    snapshots = payload.get("archived_snapshots", {})
-    if not isinstance(snapshots, dict):
-        raise UpstreamError(f"Availability archived_snapshots is {type(snapshots).__name__}, not object")
-    closest = snapshots.get("closest")
+    try:
+        response = AvailabilityResponse.model_validate(payload)
+    except ValidationError as e:
+        raise UpstreamError(f"Availability response shape is unexpected: {e}") from e
+
+    closest = response.archived_snapshots.closest
     if closest is None:
         return None
-    if not isinstance(closest, dict):
-        raise UpstreamError(f"Availability closest is {type(closest).__name__}, not object")
-    if not _truthy_availability(closest.get("available")):
+    if not _truthy_availability(closest.available):
         return None
-    timestamp = closest.get("timestamp")
-    if not isinstance(timestamp, str) or not re.fullmatch(r"\d{4,14}", timestamp):
-        raise UpstreamError(f"Availability timestamp has unexpected value: {timestamp!r}")
-    replay_url_raw = closest.get("url")
-    if not isinstance(replay_url_raw, str):
-        raise UpstreamError(f"Availability replay url has unexpected value: {replay_url_raw!r}")
+    timestamp = closest.timestamp
+    replay_url_raw = closest.url
     try:
         replay_url = URL(replay_url_raw, encoded=True)
     except ValueError as e:

--- a/loom/wayback_proxy/server.py
+++ b/loom/wayback_proxy/server.py
@@ -40,11 +40,8 @@ async def amain(config: Config, manifest: TextIO) -> None:
     logger.info(
         "wayback proxy: as_of=%s upstream=%s port=%d confdir=%s", config.as_of, config.upstream, config.port, ca_dir
     )
-    # Authorization rides on every request; the proxy only ever GETs `upstream`
-    # (off-archive redirects are returned to the client, never followed).
-    headers = {"Authorization": config.upstream_auth} if config.upstream_auth is not None else {}
     # Total timeout rides out wayback-cache limit_req delays (burst 60 @ 30r/m).
-    async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=300), headers=headers) as session:
+    async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=300)) as session:
         resolver = WaybackResolver(config, session, manifest)
         options = Options(listen_host="0.0.0.0", listen_port=config.port, confdir=str(ca_dir))
         master = DumpMaster(options, with_termlog=False, with_dumper=False)

--- a/loom/wayback_proxy/test_proxy.py
+++ b/loom/wayback_proxy/test_proxy.py
@@ -24,7 +24,14 @@ from yarl import URL
 
 from loom.wayback_proxy import fake_ia
 from loom.wayback_proxy.addon import HEALTH_HOST, WaybackAddon
-from loom.wayback_proxy.proxy import Config, WaybackResolver, parse_web_path, pick_capture, ts_allowed
+from loom.wayback_proxy.proxy import (
+    Config,
+    WaybackResolver,
+    parse_web_path,
+    pick_available_capture,
+    pick_capture,
+    ts_allowed,
+)
 
 AS_OF_TS = "20200601235959"
 
@@ -95,6 +102,13 @@ async def test_https_request_is_served_without_rewriting_to_http(fetch: Fetch) -
     result = await fetch("https://example.com/")
     assert result.status == 200
     assert result.body == fake_ia.EXAMPLE_BODY
+    assert result.headers["X-Wayback-Timestamp"] == fake_ia.GOOD_TS
+
+
+async def test_normal_lookup_uses_availability_not_cdx(fetch: Fetch) -> None:
+    result = await fetch(fake_ia.CDX_FAILS_BUT_AVAILABLE_URL)
+    assert result.status == 200
+    assert result.body == fake_ia.CDX_FAILS_BUT_AVAILABLE_BODY
     assert result.headers["X-Wayback-Timestamp"] == fake_ia.GOOD_TS
 
 
@@ -226,6 +240,49 @@ def test_pick_capture() -> None:
     assert pick_capture(rows) == ("20200101000000", "https://b/")
 
 
+def test_pick_available_capture() -> None:
+    payload = {
+        "archived_snapshots": {
+            "closest": {
+                "status": "200",
+                "available": True,
+                "url": "http://web.archive.org/web/20200101000000/https://example.com/?q=1",
+                "timestamp": "20200101000000",
+            }
+        }
+    }
+    assert pick_available_capture(payload, AS_OF_TS) == ("20200101000000", "https://example.com/?q=1")
+
+
+def test_pick_available_capture_rejects_future_closest() -> None:
+    payload = {
+        "archived_snapshots": {
+            "closest": {
+                "status": "200",
+                "available": True,
+                "url": f"http://web.archive.org/web/{fake_ia.TOO_NEW_TS}/https://example.com/",
+                "timestamp": fake_ia.TOO_NEW_TS,
+            }
+        }
+    }
+    assert pick_available_capture(payload, AS_OF_TS) is None
+
+
+def test_pick_available_capture_ignores_unavailable() -> None:
+    assert pick_available_capture({"archived_snapshots": {}}, AS_OF_TS) is None
+    payload = {
+        "archived_snapshots": {
+            "closest": {
+                "status": "404",
+                "available": False,
+                "url": "http://web.archive.org/web/20200101000000/https://example.com/",
+                "timestamp": "20200101000000",
+            }
+        }
+    }
+    assert pick_available_capture(payload, AS_OF_TS) is None
+
+
 def test_config_requires_as_of(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("WAYBACK_AS_OF", raising=False)
     with pytest.raises(RuntimeError, match="WAYBACK_AS_OF"):
@@ -235,6 +292,20 @@ def test_config_requires_as_of(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_config_as_of_ts() -> None:
     config = Config(as_of=date(2020, 6, 1), upstream="https://web.archive.org", port=8080)
     assert config.as_of_ts == AS_OF_TS
+
+
+def test_config_uses_archive_org_for_direct_availability() -> None:
+    config = Config(as_of=date(2020, 6, 1), upstream="https://web.archive.org", port=8080)
+    assert config.availability_base == "https://archive.org"
+
+
+def test_config_from_env_uses_cache_for_availability(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("WAYBACK_AS_OF", "2020-06-01")
+    monkeypatch.setenv("WAYBACK_UPSTREAM", "http://wayback-cache.local:8080")
+    monkeypatch.delenv("WAYBACK_AVAILABILITY_UPSTREAM", raising=False)
+    config = Config.from_env()
+    assert config.upstream == "http://wayback-cache.local:8080"
+    assert config.availability_base == "http://wayback-cache.local:8080"
 
 
 if __name__ == "__main__":

--- a/loom/wayback_proxy/test_proxy.py
+++ b/loom/wayback_proxy/test_proxy.py
@@ -26,6 +26,7 @@ from loom.wayback_proxy import fake_ia
 from loom.wayback_proxy.addon import HEALTH_HOST, WaybackAddon
 from loom.wayback_proxy.proxy import (
     Config,
+    UpstreamError,
     WaybackResolver,
     parse_web_path,
     pick_available_capture,
@@ -281,6 +282,21 @@ def test_pick_available_capture_ignores_unavailable() -> None:
         }
     }
     assert pick_available_capture(payload, AS_OF_TS) is None
+
+
+def test_pick_available_capture_rejects_malformed_shape() -> None:
+    payload = {
+        "archived_snapshots": {
+            "closest": {
+                "status": "200",
+                "available": True,
+                "url": "http://web.archive.org/web/20200101000000/https://example.com/",
+                "timestamp": "not-a-timestamp",
+            }
+        }
+    }
+    with pytest.raises(UpstreamError, match="Availability response shape"):
+        pick_available_capture(payload, AS_OF_TS)
 
 
 def test_config_requires_as_of(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

- resolve normal Wayback proxy lookups through `archive.org/wayback/available` before falling back to clamped CDX
- route/cache `/wayback/available` separately from replay/CDX in `wayback-cache`, with origin-aware cache keys and IA signal-header metrics
- update fake IA coverage, proxy tests, and the Loom handoff/API docs for the new proxy/cache split

## Why

The eval was spending a large amount of cold traffic on `web.archive.org/cdx/search/cdx`, where IA was returning many `502`/`504` failures. Availability gives the proxy a cheaper single-capture lookup for the common path while keeping CDX available for passthrough and fallback cases such as archived non-200 captures.

## Validation

- `git diff --check`
- `bbr test //loom/wayback_proxy:test_proxy //loom/wayback_proxy:test_compose_e2e //loom/wayback_proxy:test_live_ia`

Note: I could not run local `nginx -t` because `nginx` is not installed in this environment; the cache config was reviewed statically and covered by the existing repo hooks where applicable.