### PR TITLE
debundle: full swap → emission-set exclusion + strip → vendor emission (vendor-into-emission PR 5)

### DIFF
--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -130,6 +130,7 @@ rust_test(
 rust_library(
     name = "vendor",
     srcs = [
+        "vendor/emission.rs",
         "vendor/manifests.rs",
         "vendor/mod.rs",
         "vendor/passthrough.rs",

--- a/devinfra/js/debundle/artifact.rs
+++ b/devinfra/js/debundle/artifact.rs
@@ -832,14 +832,6 @@ impl ChunkBundle {
         Ok(&mut self.chunk_mut(chunk_id)?.js)
     }
 
-    pub fn remove_chunk(&mut self, chunk_id: ChunkId) -> Option<ChunkArtifact> {
-        let index = self
-            .chunks
-            .iter()
-            .position(|chunk| chunk.chunk_id == chunk_id)?;
-        Some(self.chunks.remove(index))
-    }
-
     pub fn retain_chunks(&mut self, mut keep: impl FnMut(ChunkId) -> bool) {
         self.chunks.retain(|chunk| keep(chunk.chunk_id));
     }
@@ -1230,6 +1222,7 @@ pub fn materialize_artifact_scripts(
     app_root: &Path,
     report_tree_root: &Path,
     decomposition_by_chunk: &HashMap<ChunkId, ChunkDecompositionOutput>,
+    excluded_chunk_ids: &BTreeSet<ChunkId>,
 ) -> Result<MaterializedScripts> {
     let selected_module_by_chunk_file = selected_module_by_chunk_file(decomposition_by_chunk);
     // Per-chunk materialization is pure data-parallel: each call reads
@@ -1246,12 +1239,15 @@ pub fn materialize_artifact_scripts(
     // `JsFileBody::Ast` calls `emit_js_module_with_comments`, which drives
     // the swc emitter. Capture the parent thread's globals and re-set
     // inside each worker closure — mirrors `lower_chunk` and
-    // `vendor::strip::strip_swapped_vendor_exports_with_options`.
+    // `vendor::emission::apply_emission_rewrites`.
     let file_metrics: Vec<OutputFileMetric> = GLOBALS
         .with(|globals| -> Result<Vec<_>> {
             artifact
                 .list_chunk_ids()
                 .into_par_iter()
+                // Emission-set exclusion: fully vendor-swapped chunks
+                // stay in the bundle but are not emitted.
+                .filter(|chunk_id| !excluded_chunk_ids.contains(chunk_id))
                 .map(|chunk_id| {
                     GLOBALS.set(globals, || {
                         materialize_chunk_scripts(

--- a/devinfra/js/debundle/emit_harness.rs
+++ b/devinfra/js/debundle/emit_harness.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::{cell::RefCell, rc::Rc};
@@ -67,11 +67,18 @@ struct HtmlEntries {
     module_preloads: Vec<HtmlEntry>,
 }
 
+/// `chunk_records` carries the emission set only (the caller drops
+/// records of excluded chunks); `excluded_chunk_ids` lists chunks
+/// excluded from emission (fully vendor-swapped) — their files are not
+/// written, they contribute nothing to the rename queue, and an HTML
+/// entry/preload referencing one is rejected the same as a chunk the
+/// snapshot manifest never contained.
 pub fn emit_browser_harness(
     artifact: &ChunkBundle,
     options: &EmitBrowserHarnessOptions,
     chunk_records: &[ArtifactChunkRecord],
     decomposition_by_chunk: &HashMap<ChunkId, ChunkDecompositionOutput>,
+    excluded_chunk_ids: &BTreeSet<ChunkId>,
 ) -> Result<()> {
     let asset_summary_raw = fs::read_to_string(&options.asset_summary_path)
         .with_context(|| format!("reading {}", options.asset_summary_path.display()))?;
@@ -114,7 +121,7 @@ pub fn emit_browser_harness(
             .chunk_table
             .get(&chunk_name)
             .with_context(|| format!("Snapshot manifest does not contain chunk {chunk_name}"))?;
-        if !artifact.has_chunk(chunk_id) {
+        if !artifact.has_chunk(chunk_id) || excluded_chunk_ids.contains(&chunk_id) {
             bail!("Snapshot manifest does not contain chunk {chunk_name}");
         }
     }
@@ -127,6 +134,7 @@ pub fn emit_browser_harness(
         &app_root,
         &layout.tree_root(),
         decomposition_by_chunk,
+        excluded_chunk_ids,
     )?;
     let copied_assets = copy_snapshot_assets(&options.snapshot_root, &app_root)?;
     let bootstrap = build_bootstrap(artifact, &entry_scripts, &app_root, &app_root)?;
@@ -140,7 +148,8 @@ pub fn emit_browser_harness(
             chunks: chunk_records,
         },
     )?;
-    let queue = compute_identifier_rename_queue(artifact, decomposition_by_chunk)?;
+    let queue =
+        compute_identifier_rename_queue(artifact, decomposition_by_chunk, excluded_chunk_ids)?;
     write_queue(&layout.rename_queue_report(), &queue)?;
     let runtime = HarnessRuntimeReport {
         app_root: format!("../{}", output_layout::APP_DIR),

--- a/devinfra/js/debundle/identifier_rename_queue.rs
+++ b/devinfra/js/debundle/identifier_rename_queue.rs
@@ -39,7 +39,7 @@
 //! Rendered as `"<chunk_id>:<owner_file>:<ordinal>"` for human-readable
 //! diffing across runs.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::Path;
 
 use anyhow::Result;
@@ -91,6 +91,7 @@ pub struct IdentifierRenameQueue {
 pub fn compute_identifier_rename_queue(
     artifact: &ChunkBundle,
     decomposition_by_chunk: &HashMap<ChunkId, ChunkDecompositionOutput>,
+    excluded_chunk_ids: &BTreeSet<ChunkId>,
 ) -> Result<IdentifierRenameQueue> {
     // Per-chunk, per-file: walk the final AST to identify top-level
     // declarations whose names still match input-bundle names, then
@@ -105,6 +106,12 @@ pub fn compute_identifier_rename_queue(
     let mut interest_names_by_chunk = HashMap::<String, HashSet<String>>::new();
 
     for chunk_id_interned in artifact.list_chunk_ids() {
+        // Emission-set exclusion: fully vendor-swapped chunks are not
+        // emitted, so they contribute neither queue sites nor
+        // reference counts.
+        if excluded_chunk_ids.contains(&chunk_id_interned) {
+            continue;
+        }
         let chunk_id = artifact.chunk_table.name(chunk_id_interned);
         let chunk = artifact.js_chunk(chunk_id_interned)?;
         let input_names = input_names_by_chunk
@@ -146,6 +153,9 @@ pub fn compute_identifier_rename_queue(
     // resolves imports onto a stable cross-chunk binding identity, fold
     // that in here so a "names everywhere" symbol shows its true fanout.
     for chunk_id_interned in artifact.list_chunk_ids() {
+        if excluded_chunk_ids.contains(&chunk_id_interned) {
+            continue;
+        }
         let chunk_id = artifact.chunk_table.name(chunk_id_interned);
         let chunk = artifact.js_chunk(chunk_id_interned)?;
         let Some(of_interest) = interest_names_by_chunk.get(chunk_id) else {

--- a/devinfra/js/debundle/lowering/cross_module.rs
+++ b/devinfra/js/debundle/lowering/cross_module.rs
@@ -65,10 +65,17 @@ pub(super) struct CrossModulePurities {
 /// A chunk whose entry can neither be reused (retained AST) nor re-parsed
 /// stays opaque: its exports get no verdicts and imports of it stay
 /// unresolved (`unknown_call`), exactly as before this pass existed.
+///
+/// `excluded_chunks` (fully vendor-swapped chunks excluded from the
+/// emission set) stay opaque to the oracle: an excluded chunk's body
+/// is replaced by the upstream package at serve time, so verdicts
+/// derived from the bundle copy would assert purity about code that is
+/// never emitted. Imports of such chunks stay `unknown_call`.
 pub(super) fn collect_cross_module_imported_purities(
     artifact: &ChunkBundle,
     indexes: &ArtifactIndexes,
     chunk_export_purity: &BTreeMap<String, ChunkExportPurity>,
+    excluded_chunks: &BTreeSet<ChunkId>,
 ) -> CrossModulePurities {
     // Pass 1: re-parse entries stored as raw source so every chunk's body is
     // analyzable. Parse failures only warn — the pass is an analysis
@@ -76,6 +83,9 @@ pub(super) fn collect_cross_module_imported_purities(
     // behavior rather than failing the build.
     let mut reparsed: BTreeMap<ChunkId, ReparsedEntry> = BTreeMap::new();
     for chunk_artifact in &artifact.chunks {
+        if excluded_chunks.contains(&chunk_artifact.chunk_id) {
+            continue;
+        }
         let entry_file = &chunk_artifact.analysis.entry_file;
         let Some(file) = chunk_artifact.js.get_file(entry_file) else {
             continue;
@@ -112,6 +122,9 @@ pub(super) fn collect_cross_module_imported_purities(
     // available (retained AST or re-parsed entry).
     let mut modules = BTreeMap::new();
     for chunk_artifact in &artifact.chunks {
+        if excluded_chunks.contains(&chunk_artifact.chunk_id) {
+            continue;
+        }
         let chunk_name = artifact.chunk_table.name(chunk_artifact.chunk_id);
         let entry_file = &chunk_artifact.analysis.entry_file;
         let retained_ast = chunk_artifact

--- a/devinfra/js/debundle/lowering/mod.rs
+++ b/devinfra/js/debundle/lowering/mod.rs
@@ -309,10 +309,14 @@ pub fn materialize_logical_modules(
     // Program-level pass over ALL retained chunks (not just selected):
     // cross-module purity verdicts for each chunk's imported function
     // bindings, consumed per chunk via `AnalysisHints::imported_purities`.
+    // Fully-swapped vendor chunks stay opaque — they are excluded from
+    // the emission set and their bodies are replaced by the upstream
+    // package, so they must not contribute purity facts.
     let cross_module_purities = cross_module::collect_cross_module_imported_purities(
         &artifact,
         &artifact_indexes,
         chunk_export_purity,
+        &vendor_plan.full_swap_chunk_ids(),
     );
 
     let artifact_ref: &ChunkBundle = &artifact;

--- a/devinfra/js/debundle/pipeline.rs
+++ b/devinfra/js/debundle/pipeline.rs
@@ -21,10 +21,8 @@ use spec_tree::{CompileSpecTreeOptions, compile_spec_tree};
 use validate_emitted_exports::validate_emitted_exports;
 use vendor::{
     ChunkBundledPartialSwapResolution, ChunkPartialSwapResolution, ChunkStripStats,
-    StripSwappedVendorExportsOptions, VendorPlanOptions, VendorResolution,
-    apply_bundled_partial_swap_self_rewrites, build_partial_swap_resolutions,
-    build_vendor_resolution_plan, rewrite_passthrough_directives,
-    strip_swapped_vendor_exports_with_options, swap_vendor_chunks, validate_partial_swap_consumers,
+    VendorPlanOptions, VendorResolution, apply_emission_rewrites, build_partial_swap_resolutions,
+    build_vendor_resolution_plan, validate_partial_swap_consumers, write_planned_vendor_outputs,
 };
 use write_tree::{WriteTreeInput, write_js_tree};
 
@@ -166,7 +164,7 @@ pub fn run_transform_cli_with_options(
         .collect();
     let prepare_result = prepare_js_chunks(&spec, artifact)?;
     let counts = prepare_result.counts;
-    let mut chunk_records = prepare_result.chunk_records;
+    let chunk_records = prepare_result.chunk_records;
     let mut vendor_report = VendorSwapsReport::default();
 
     let mut indexed = IndexedArtifact::new(prepare_result.artifact)?;
@@ -174,9 +172,10 @@ pub fn run_transform_cli_with_options(
     // Single post-prepare vendor resolution pass: validates every mark,
     // resolves boundary mappings, swap targets, and partial-swap symbol
     // tables once, and runs the plan-time consumer gate
-    // (plans/vendor_into_emission.md §3.2) before anything is written.
-    // Vendor application below consumes this plan instead of
-    // re-resolving the spec mid-pipeline.
+    // (plans/vendor_into_emission.md §3.2) and the full-swap caller
+    // import-alignment check before anything is written. Vendor
+    // application below consumes this plan instead of re-resolving the
+    // spec mid-pipeline.
     let swap_cfg = &spec.swap_vendor_chunks;
     let vendor_plan = build_vendor_resolution_plan(
         indexed.artifact(),
@@ -191,26 +190,14 @@ pub fn run_transform_cli_with_options(
     )?;
     let write_vendor_outputs = swap_cfg.write && !options.dry_run;
 
-    // Full swaps: write planned wrappers and remove the swapped chunks
-    // so materialize never sees them. (Becomes an emission-set
-    // exclusion in PR 5 of plans/vendor_into_emission.md.)
-    if vendor_plan.has_full_swaps() {
-        let full_swap_outcome;
-        (indexed, full_swap_outcome) = indexed.update(|artifact, indexes| {
-            let swap_result =
-                swap_vendor_chunks(artifact, &vendor_plan, indexes, write_vendor_outputs)?;
-            Ok((
-                swap_result.artifact,
-                (
-                    swap_result.manifest.resolutions,
-                    swap_result.removed_chunk_ids,
-                ),
-            ))
-        })?;
-        let (full_swap_resolutions, removed_chunk_ids) = full_swap_outcome;
-        vendor_report.full = full_swap_resolutions;
-        chunk_records.retain(|chunk| !removed_chunk_ids.contains(&chunk.chunk_id));
-    }
+    // Full swaps are an emission-set exclusion
+    // (plans/vendor_into_emission.md §2.5): the swapped chunks stay in
+    // the bundle — nothing removes them, and the owner graph never
+    // contained vendor chunks — but emission, the rename queue, the
+    // emit-shape check, and the chunk reports skip them. Their
+    // wire-facing resolutions are projections of the plan.
+    let excluded_chunk_ids = vendor_plan.full_swap_chunk_ids();
+    vendor_report.full = vendor_plan.full_swap_resolutions();
 
     let mut module_count: usize = 0;
     let mut selected_lowerings: Vec<artifact::SelectedModuleLowering> = Vec::new();
@@ -238,7 +225,7 @@ pub fn run_transform_cli_with_options(
         // `materialize_logical_modules` derives its own per-run indexes
         // internally (it prunes chunks first); the pipeline indexes are
         // not consumed here, but the artifact mutates, so the update
-        // rebuilds them for the partial-swap stage below.
+        // rebuilds them for the emission rewrites below.
         (indexed, _) = indexed.update(|artifact, _indexes| {
             let materialize_result = materialize_logical_modules(
                 artifact,
@@ -277,63 +264,41 @@ pub fn run_transform_cli_with_options(
         })?;
     }
 
-    // Unified pass-through emission rewrite
-    // (plans/vendor_into_emission.md §2.4): one position-preserving
-    // directive pass over the files emitted without lowering — chunk
-    // entries (including materialized chunks' residual entries) and
-    // runtime files — performing specifier canonicalization (the old
-    // always-on stage 0), boundary-rename name mapping, and
-    // partial-swap consumer surgery from the vendor plan. Materialized
-    // module bodies were constructed from the same plan during
-    // lowering; suppress-marked chunks are skipped wholesale (open
-    // question 3). Runs after materialize so the per-symbol consumer
-    // rewrite cannot erase binding names spec selectors matched on.
+    // Emission rewrites (plans/vendor_into_emission.md §2.4–§2.5), one
+    // artifact pass over two disjoint file sets:
+    //
+    // * the unified pass-through directive rewrite over files emitted
+    //   without lowering in non-vendor chunks — specifier
+    //   canonicalization (the old always-on stage 0), boundary-rename
+    //   name mapping, and partial-swap consumer surgery from the
+    //   vendor plan (materialized module bodies were constructed from
+    //   the same plan during lowering; suppress-marked chunks are
+    //   skipped wholesale per open question 3; excluded full-swap
+    //   chunks are never rewritten);
+    // * the vendor residual computation for each partially-swapped
+    //   chunk — the canonicalize → self-rewrite → strip composition as
+    //   one function body, so the former stage ordering is structural
+    //   instead of a pipeline concern.
+    //
+    // Runs after materialize so the per-symbol consumer rewrite cannot
+    // erase binding names spec selectors matched on.
     let mut vendor_rewrite_counts = vendor_lowering_rewrites;
-    let passthrough_references;
-    (indexed, passthrough_references) = indexed.update(|artifact, indexes| {
-        let passthrough_result = rewrite_passthrough_directives(artifact, &vendor_plan, indexes)?;
+    let emission_outcome;
+    (indexed, emission_outcome) = indexed.update(|artifact, indexes| {
+        let emission_result = apply_emission_rewrites(artifact, &vendor_plan, indexes)?;
         Ok((
-            passthrough_result.artifact,
-            passthrough_result.references_by_symbol,
+            emission_result.artifact,
+            (
+                emission_result.references_by_symbol,
+                emission_result.strip_stats,
+            ),
         ))
     })?;
-    merge_rewrite_counts(&mut vendor_rewrite_counts, passthrough_references);
+    let (emission_references, strip_stats) = emission_outcome;
+    merge_rewrite_counts(&mut vendor_rewrite_counts, emission_references);
+    vendor_report.strip_stats = strip_stats;
 
     if vendor_plan.has_partial_swaps() || vendor_plan.has_bundled_partial_swaps() {
-        let mut replacement_import_locals_by_chunk_path = BTreeMap::new();
-        if vendor_plan.has_bundled_partial_swaps() {
-            // Bundled partial swaps' vendor-chunk side: write the
-            // bundle copy + facades and seed the chunk's self-rewrite
-            // (the strip below drops the replaced implementation).
-            let self_rewrite_outcome;
-            (indexed, self_rewrite_outcome) = indexed.update(|artifact, _indexes| {
-                let self_rewrite_result = apply_bundled_partial_swap_self_rewrites(
-                    artifact,
-                    &vendor_plan,
-                    write_vendor_outputs,
-                )?;
-                Ok((
-                    self_rewrite_result.artifact,
-                    (
-                        self_rewrite_result.self_rewrite_import_locals_by_chunk_path,
-                        self_rewrite_result.references_by_symbol,
-                    ),
-                ))
-            })?;
-            let (self_rewrite_locals, self_rewrite_references) = self_rewrite_outcome;
-            replacement_import_locals_by_chunk_path = self_rewrite_locals;
-            merge_rewrite_counts(&mut vendor_rewrite_counts, self_rewrite_references);
-        }
-        (indexed, vendor_report.strip_stats) = indexed.update(|artifact, _indexes| {
-            let strip_result = strip_swapped_vendor_exports_with_options(
-                artifact,
-                &vendor_plan,
-                StripSwappedVendorExportsOptions {
-                    replacement_import_locals_by_chunk_path,
-                },
-            )?;
-            Ok((strip_result.artifact, strip_result.manifest.per_chunk))
-        })?;
         // Post-strip differential tripwire behind the plan-time
         // consumer gate (vendor_into_emission §3.2, open question 4):
         // no retained file may still consume the stripped portion of a
@@ -344,8 +309,14 @@ pub fn run_transform_cli_with_options(
         build_partial_swap_resolutions(&vendor_plan, &vendor_rewrite_counts)?;
     let artifact = indexed.into_artifact();
 
+    // Vendor emission outputs: full-swap wrappers and bundled bundle
+    // copies / facades, plus the combined manifest — all write-gated
+    // behind `swap_vendor_chunks.write` (vendor_into_emission §2.5).
+    if write_vendor_outputs {
+        write_planned_vendor_outputs(&vendor_plan)?;
+    }
     write_vendor_swaps_report(
-        spec.swap_vendor_chunks.write && !options.dry_run,
+        write_vendor_outputs,
         spec.swap_vendor_chunks.output_manifest_path.as_deref(),
         &vendor_report,
     )?;
@@ -357,7 +328,18 @@ pub fn run_transform_cli_with_options(
     // pageerror) into an immediate build-time error pointing at the
     // exact file, name, and source lines. Runs unconditionally so
     // pipelines without vendor swaps still benefit.
-    validate_emitted_exports(&artifact)?;
+    validate_emitted_exports(&artifact, &excluded_chunk_ids)?;
+
+    // Chunk records of the emission set: records of excluded
+    // (fully-swapped) chunks are dropped from the emitted reports.
+    let excluded_chunk_names: BTreeSet<&str> = excluded_chunk_ids
+        .iter()
+        .map(|chunk_id| artifact.chunk_table.name(*chunk_id))
+        .collect();
+    let emitted_chunk_records: Vec<_> = chunk_records
+        .into_iter()
+        .filter(|record| !excluded_chunk_names.contains(record.chunk_id.as_str()))
+        .collect();
 
     if !options.dry_run
         && let Some(cfg) = &spec.write_js_tree
@@ -367,9 +349,10 @@ pub fn run_transform_cli_with_options(
             out_dir: &cfg.out_dir,
             lowerings: &selected_lowerings,
             counts: &counts,
-            chunk_records: &chunk_records,
+            chunk_records: &emitted_chunk_records,
             module_count,
             decomposition_by_chunk: &decomposition_by_chunk,
+            excluded_chunk_ids: &excluded_chunk_ids,
         })?;
     }
 
@@ -381,7 +364,13 @@ pub fn run_transform_cli_with_options(
             out_dir: cfg.out_dir.clone(),
             snapshot_root: cfg.snapshot_root.clone(),
         };
-        emit_browser_harness(&artifact, &opts, &chunk_records, &decomposition_by_chunk)?;
+        emit_browser_harness(
+            &artifact,
+            &opts,
+            &emitted_chunk_records,
+            &decomposition_by_chunk,
+            &excluded_chunk_ids,
+        )?;
     }
 
     // Defer unmatched-spec-claim failure to here so the build runs

--- a/devinfra/js/debundle/spec.rs
+++ b/devinfra/js/debundle/spec.rs
@@ -84,10 +84,10 @@ pub struct TransformSpec {
     pub chunk_export_purity: BTreeMap<String, ChunkExportPurity>,
 
     // --- per-stage configuration ---
-    /// Output configuration for `swap_vendor_chunks`. The stage runs
-    /// whenever `vendor` contains any `level: swap` entries; this field
-    /// only adds output paths and a `write` toggle. All inner fields
-    /// have defaults, so omitting `swap_vendor_chunks` is identical to
+    /// Output configuration for vendor swap emission outputs (wrappers,
+    /// facade bundles, the combined manifest); this field only adds
+    /// output paths and a `write` toggle. All inner fields have
+    /// defaults, so omitting `swap_vendor_chunks` is identical to
     /// supplying an empty object.
     #[serde(default)]
     pub swap_vendor_chunks: SwapVendorChunksConfig,

--- a/devinfra/js/debundle/validate_emitted_exports.rs
+++ b/devinfra/js/debundle/validate_emitted_exports.rs
@@ -34,19 +34,28 @@
 //! `pre_existing_public_export_names` and suffix-mints a
 //! non-colliding name.)
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use anyhow::{Result, bail};
 use binding_targets::{declaration_name_strings, module_export_name};
 use swc_common::Spanned;
 use swc_ecma_ast::*;
 
-use artifact::ChunkBundle;
+use artifact::{ChunkBundle, ChunkId};
 use js_ast::SourceLineIndex;
 
-pub fn validate_emitted_exports(artifact: &ChunkBundle) -> Result<()> {
+/// `excluded_chunk_ids`: chunks excluded from the emission set (fully
+/// vendor-swapped) — never emitted, so their export surfaces are not
+/// this check's business.
+pub fn validate_emitted_exports(
+    artifact: &ChunkBundle,
+    excluded_chunk_ids: &BTreeSet<ChunkId>,
+) -> Result<()> {
     let mut findings: Vec<FileFinding> = Vec::new();
     for chunk in &artifact.chunks {
+        if excluded_chunk_ids.contains(&chunk.chunk_id) {
+            continue;
+        }
         let chunk_name = artifact.chunk_table.name(chunk.chunk_id).to_string();
         for file in &chunk.js.files {
             let Some(ast) = file.ast() else {
@@ -300,7 +309,7 @@ mod tests {
                 "entry.js",
                 "const a = 1;\nconst b = 2;\nexport { a, b };\n",
             );
-            validate_emitted_exports(&bundle).expect("clean module passes");
+            validate_emitted_exports(&bundle, &BTreeSet::new()).expect("clean module passes");
         });
     }
 
@@ -316,8 +325,8 @@ function av() {}\n\
 export { BackgroundPattern as av };\n\
 export { av };\n";
             let bundle = bundle_with_file("chunk", "entry.js", source);
-            let err =
-                validate_emitted_exports(&bundle).expect_err("duplicate av should be rejected");
+            let err = validate_emitted_exports(&bundle, &BTreeSet::new())
+                .expect_err("duplicate av should be rejected");
             let msg = format!("{err}");
             assert!(msg.contains("`av` exported 2×"), "missing count: {msg}");
             assert!(msg.contains("entry.js"), "missing file: {msg}");
@@ -333,7 +342,7 @@ export const x = 1;\n\
 const y = 2;\n\
 export { y as x };\n";
             let bundle = bundle_with_file("c", "f.js", source);
-            let err = validate_emitted_exports(&bundle).expect_err("duplicate x");
+            let err = validate_emitted_exports(&bundle, &BTreeSet::new()).expect_err("duplicate x");
             let msg = format!("{err}");
             assert!(msg.contains("`x` exported 2×"), "{msg}");
             assert!(msg.contains("(decl)"), "decl shape missing: {msg}");
@@ -349,7 +358,8 @@ export default 1;\n\
 const fallback = 2;\n\
 export { fallback as default };\n";
             let bundle = bundle_with_file("c", "f.js", source);
-            let err = validate_emitted_exports(&bundle).expect_err("duplicate default");
+            let err =
+                validate_emitted_exports(&bundle, &BTreeSet::new()).expect_err("duplicate default");
             let msg = format!("{err}");
             assert!(msg.contains("`default` exported 2×"), "{msg}");
         });
@@ -367,7 +377,8 @@ const foo = 1;\n\
 export { foo };\n\
 export * from \"./sibling.js\";\n";
             let bundle = bundle_with_file("c", "f.js", source);
-            validate_emitted_exports(&bundle).expect("star re-export does not duplicate");
+            validate_emitted_exports(&bundle, &BTreeSet::new())
+                .expect("star re-export does not duplicate");
         });
     }
 
@@ -383,7 +394,8 @@ export * from \"./sibling.js\";\n";
                 "export const z = 1;\nconst zz = 2;\nexport { zz as z };\n",
                 FileRole::Module,
             );
-            let err = validate_emitted_exports(&bundle).expect_err("bad file flagged");
+            let err =
+                validate_emitted_exports(&bundle, &BTreeSet::new()).expect_err("bad file flagged");
             let msg = format!("{err}");
             assert!(msg.contains("bad.js"), "{msg}");
             assert!(!msg.contains("good.js"), "good.js should not appear: {msg}");
@@ -413,7 +425,7 @@ export * from \"./sibling.js\";\n";
                     source_path: "c.js".to_string(),
                 },
             });
-            validate_emitted_exports(&bundle).expect("source-only file skipped");
+            validate_emitted_exports(&bundle, &BTreeSet::new()).expect("source-only file skipped");
         });
     }
 }

--- a/devinfra/js/debundle/vendor/emission.rs
+++ b/devinfra/js/debundle/vendor/emission.rs
@@ -1,0 +1,410 @@
+//! Emission-time vendor application (vendor_into_emission §2.5, PR 5).
+//!
+//! One artifact pass with two disjoint file sets:
+//!
+//! * **Pass-through wave** — files emitted without lowering in
+//!   non-vendor chunks get the unified directive rewriter
+//!   (`passthrough::rewrite_passthrough_module`: canonicalization,
+//!   boundary-rename mapping, partial-swap consumer surgery).
+//!   Suppress-marked chunks are skipped (hands-off); full-swap chunks
+//!   are excluded from the emission set and never rewritten;
+//!   partially-swapped chunks are handled by the residual composition
+//!   below.
+//! * **Vendor residual emission** — each partially / bundled-partially
+//!   swapped chunk's residual is computed by [`emit_vendor_residual`]:
+//!   the canonicalize → self-rewrite → strip composition as one
+//!   function body, so the former stage ordering is structural rather
+//!   than a pipeline concern.
+//!
+//! Wrappers, facade bundles, and the bundle copy are emission outputs
+//! written by [`write_planned_vendor_outputs`] (write-gated behind
+//! `swap_vendor_chunks.write`).
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use anyhow::{Context, Result, bail};
+use rayon::prelude::*;
+use swc_common::GLOBALS;
+use swc_ecma_ast::Id;
+use swc_ecma_visit::VisitMutWith;
+
+use artifact::{
+    ArtifactIndexes, ChunkBundle, ChunkId, ChunkTable, FileRole, JsFile, JsFileAstParts,
+    list_chunk_file_paths,
+};
+use js_ast::ParsedJsModule;
+use spec::PartialSwapSymbol;
+
+use crate::passthrough::{PassthroughContext, rewrite_passthrough_module};
+use crate::plan::{ChunkBundledPartialSwapPlan, VendorResolutionPlan};
+use crate::strip::{ChunkStripStats, strip_one_chunk_with_replacement_imports};
+use crate::wrappers::{write_planned_bundled_assets, write_planned_wrapper};
+use crate::{
+    DeferredImport, IdentRewriteTarget, MaterializedOutputChunkIndex, PartialSwapIdentRewriter,
+    SelfRewriteOutputs, seed_bundled_partial_swap_self_rewrites,
+};
+
+pub struct EmissionRewriteResult {
+    pub artifact: ChunkBundle,
+    /// (swapped chunk, chunk export) → count of references rewritten in
+    /// pass-through files and vendor self-rewrites; folded into the
+    /// partial-swap manifests' `references_rewritten` alongside
+    /// lowering's construction-time counts.
+    pub references_by_symbol: BTreeMap<(ChunkId, String), usize>,
+    /// Per-chunk residual strip stats keyed by chunk path.
+    pub strip_stats: BTreeMap<String, ChunkStripStats>,
+}
+
+pub fn apply_emission_rewrites(
+    mut artifact: ChunkBundle,
+    plan: &VendorResolutionPlan,
+    references: &ArtifactIndexes,
+) -> Result<EmissionRewriteResult> {
+    let chunk_table = artifact.chunk_table.clone();
+    let materialized_index = MaterializedOutputChunkIndex::build(&chunk_table);
+    let context = PassthroughContext {
+        plan,
+        references,
+        chunk_table: &chunk_table,
+        materialized_index: &materialized_index,
+    };
+    let full_swap_chunks = plan.full_swap_chunk_ids();
+
+    // Pass-through wave over non-vendor chunks.
+    let mut jobs = Vec::new();
+    for (chunk_index, chunk_artifact) in artifact.chunks.iter_mut().enumerate() {
+        let chunk_id = chunk_artifact.chunk_id;
+        if plan.is_suppressed(chunk_id)
+            || full_swap_chunks.contains(&chunk_id)
+            || plan.partial_swaps.contains_key(&chunk_id)
+            || plan.bundled_partial_swaps.contains_key(&chunk_id)
+        {
+            continue;
+        }
+        let chunk_name = chunk_table.name(chunk_id).to_string();
+        for file_path in list_chunk_file_paths(&chunk_artifact.js) {
+            let Some(file) = chunk_artifact.js.get_file(&file_path) else {
+                continue;
+            };
+            // Materialized module files' specifiers are constructed by
+            // lowering from the same plan; only pass-through files
+            // (entries, runtime files) are rewritten here.
+            if file.metadata.role == FileRole::Module || file.ast().is_none() {
+                continue;
+            }
+            let (parts, ast) = chunk_artifact
+                .js
+                .remove_file(&file_path)
+                .and_then(|file| file.into_ast_parts())
+                .with_context(|| format!("missing AST for {chunk_name}/{file_path}"))?;
+            jobs.push(PassthroughFileJob {
+                chunk_index,
+                chunk_id,
+                file_path,
+                parts,
+                ast,
+            });
+        }
+    }
+
+    // Rayon workers don't inherit `GLOBALS`; re-set per worker so any
+    // `Mark::new()` / `Id` use stays in the caller's arena.
+    let context_ref = &context;
+    let results: Vec<PassthroughFileResult> = GLOBALS.with(|globals| {
+        jobs.into_par_iter()
+            .map(|mut job| {
+                GLOBALS.set(globals, || {
+                    let mut references_by_symbol = BTreeMap::new();
+                    rewrite_passthrough_module(
+                        &mut job.ast.module,
+                        job.chunk_id,
+                        &job.file_path,
+                        context_ref,
+                        &mut references_by_symbol,
+                    );
+                    PassthroughFileResult {
+                        chunk_index: job.chunk_index,
+                        parts: job.parts,
+                        ast: job.ast,
+                        references_by_symbol,
+                    }
+                })
+            })
+            .collect()
+    });
+
+    let mut references_by_symbol = BTreeMap::new();
+    for result in results {
+        for ((chunk_id, chunk_export), count) in result.references_by_symbol {
+            if !plan.partial_swaps.contains_key(&chunk_id)
+                && !plan.bundled_partial_swaps.contains_key(&chunk_id)
+            {
+                bail!(
+                    "pass-through rewrite reported references to `{chunk_export}` on chunk {}, which has no partial-swap plan",
+                    chunk_table.name(chunk_id)
+                );
+            }
+            *references_by_symbol
+                .entry((chunk_id, chunk_export))
+                .or_insert(0) += count;
+        }
+        artifact
+            .chunks
+            .get_mut(result.chunk_index)
+            .with_context(|| format!("missing chunk index {}", result.chunk_index))?
+            .js
+            .insert_file(JsFile::from_ast_parts(result.parts, result.ast));
+    }
+
+    // Vendor residual emission: one composition per swapped chunk.
+    let mut residual_jobs = Vec::new();
+    for (&chunk_id, partial) in &plan.partial_swaps {
+        residual_jobs.push(extract_residual_job(
+            &mut artifact,
+            &chunk_table,
+            chunk_id,
+            &partial.chunk_path,
+            &partial.entry_file,
+            &partial.symbols,
+            None,
+        )?);
+    }
+    for (&chunk_id, bundled) in &plan.bundled_partial_swaps {
+        residual_jobs.push(extract_residual_job(
+            &mut artifact,
+            &chunk_table,
+            chunk_id,
+            &bundled.chunk_path,
+            &bundled.entry_file,
+            &bundled.symbols,
+            Some(bundled),
+        )?);
+    }
+
+    let outputs: Vec<ResidualOutput> = GLOBALS.with(|globals| -> Result<Vec<ResidualOutput>> {
+        residual_jobs
+            .into_par_iter()
+            .map(|job| GLOBALS.set(globals, || emit_vendor_residual(job, context_ref)))
+            .collect()
+    })?;
+
+    let mut strip_stats = BTreeMap::new();
+    for output in outputs {
+        let js_chunk = artifact.js_chunk_mut(output.chunk_id)?;
+        for (parts, ast) in output.files {
+            js_chunk.insert_file(JsFile::from_ast_parts(parts, ast));
+        }
+        for (key, count) in output.references_by_symbol {
+            *references_by_symbol.entry(key).or_insert(0) += count;
+        }
+        strip_stats.insert(output.chunk_path, output.stats);
+    }
+
+    Ok(EmissionRewriteResult {
+        artifact,
+        references_by_symbol,
+        strip_stats,
+    })
+}
+
+struct PassthroughFileJob {
+    chunk_index: usize,
+    chunk_id: ChunkId,
+    file_path: String,
+    parts: JsFileAstParts,
+    ast: ParsedJsModule,
+}
+
+struct PassthroughFileResult {
+    chunk_index: usize,
+    parts: JsFileAstParts,
+    ast: ParsedJsModule,
+    references_by_symbol: BTreeMap<(ChunkId, String), usize>,
+}
+
+/// One partially-swapped chunk's residual inputs: every pass-through
+/// AST file of the chunk (owned), pulled out of the artifact so the
+/// residual computation can run as a parallel job over owned data.
+struct ResidualJob<'a> {
+    chunk_id: ChunkId,
+    chunk_path: &'a str,
+    entry_file: &'a str,
+    symbols: &'a BTreeMap<String, PartialSwapSymbol>,
+    bundled: Option<&'a ChunkBundledPartialSwapPlan>,
+    files: Vec<(String, JsFileAstParts, ParsedJsModule)>,
+}
+
+struct ResidualOutput {
+    chunk_id: ChunkId,
+    chunk_path: String,
+    files: Vec<(JsFileAstParts, ParsedJsModule)>,
+    references_by_symbol: BTreeMap<(ChunkId, String), usize>,
+    stats: ChunkStripStats,
+}
+
+fn extract_residual_job<'a>(
+    artifact: &mut ChunkBundle,
+    chunk_table: &ChunkTable,
+    chunk_id: ChunkId,
+    chunk_path: &'a str,
+    entry_file: &'a str,
+    symbols: &'a BTreeMap<String, PartialSwapSymbol>,
+    bundled: Option<&'a ChunkBundledPartialSwapPlan>,
+) -> Result<ResidualJob<'a>> {
+    let chunk_name = chunk_table.name(chunk_id).to_string();
+    let js_chunk = artifact.js_chunk_mut(chunk_id)?;
+    if js_chunk.get_file(entry_file).is_none() {
+        bail!(
+            "strip_swapped_vendor_exports vendor entry {chunk_path}: entry file {entry_file} missing from chunk {chunk_name}"
+        );
+    }
+    let mut files = Vec::new();
+    let mut has_entry_ast = false;
+    for file_path in list_chunk_file_paths(js_chunk) {
+        let Some(file) = js_chunk.get_file(&file_path) else {
+            continue;
+        };
+        if file.metadata.role == FileRole::Module || file.ast().is_none() {
+            continue;
+        }
+        let (parts, ast) = js_chunk
+            .remove_file(&file_path)
+            .and_then(|file| file.into_ast_parts())
+            .with_context(|| format!("missing AST for {chunk_name}/{file_path}"))?;
+        has_entry_ast |= file_path == entry_file;
+        files.push((file_path, parts, ast));
+    }
+    if !has_entry_ast {
+        bail!(
+            "strip_swapped_vendor_exports vendor entry {chunk_path}: chunk {chunk_name} entry has no AST"
+        );
+    }
+    Ok(ResidualJob {
+        chunk_id,
+        chunk_path,
+        entry_file,
+        symbols,
+        bundled,
+        files,
+    })
+}
+
+/// The residual computation (vendor_into_emission §2.5) as one function
+/// body. Per pass-through file of the swapped chunk:
+///
+/// 1. **canonicalize** — the unified directive rewrite (§2.4), which
+///    also applies any consumer-side surgery the chunk's own files need
+///    against *other* swapped chunks;
+/// 2. **self-rewrite** (bundled family) — facade import plus internal
+///    reference re-targeting, seeding the strip's
+///    `replacement_import_locals`;
+///
+/// then, on the entry module:
+///
+/// 3. **strip** — split var decls, strip swapped export specifiers,
+///    sweep unreachable top-level items. The strip-internal soundness
+///    gates (split-brain, observable-effect privacy, live-reads,
+///    export-surface invariance) live inside the strip and run
+///    unchanged on the same module shape the former stage order
+///    produced — the composition is structural here instead of a
+///    pipeline ordering concern.
+fn emit_vendor_residual(
+    job: ResidualJob<'_>,
+    context: &PassthroughContext<'_>,
+) -> Result<ResidualOutput> {
+    let ResidualJob {
+        chunk_id,
+        chunk_path,
+        entry_file,
+        symbols,
+        bundled,
+        mut files,
+    } = job;
+    let mut references_by_symbol: BTreeMap<(ChunkId, String), usize> = BTreeMap::new();
+    let mut replacement_import_locals: BTreeSet<Id> = BTreeSet::new();
+    for (file_path, _parts, ast) in &mut files {
+        rewrite_passthrough_module(
+            &mut ast.module,
+            chunk_id,
+            file_path,
+            context,
+            &mut references_by_symbol,
+        );
+        if bundled.is_some() {
+            let mut bindings: BTreeMap<Id, IdentRewriteTarget> = BTreeMap::new();
+            let mut prelude_imports: Vec<DeferredImport> = Vec::new();
+            let mut self_rewrite_import_locals: BTreeSet<Id> = BTreeSet::new();
+            seed_bundled_partial_swap_self_rewrites(
+                &ast.module,
+                bundled,
+                context.chunk_table,
+                chunk_id,
+                file_path,
+                SelfRewriteOutputs {
+                    bindings: &mut bindings,
+                    prelude_imports: &mut prelude_imports,
+                    references_by_symbol: &mut references_by_symbol,
+                    self_rewrite_import_locals: &mut self_rewrite_import_locals,
+                },
+            );
+            if !prelude_imports.is_empty() {
+                let mut prefixed = prelude_imports
+                    .drain(..)
+                    .map(DeferredImport::into_module_item)
+                    .collect::<Vec<_>>();
+                prefixed.append(&mut ast.module.body);
+                ast.module.body = prefixed;
+            }
+            if !bindings.is_empty() {
+                let mut rewriter = PartialSwapIdentRewriter {
+                    bindings: &bindings,
+                    references_by_symbol: &mut references_by_symbol,
+                };
+                ast.module.visit_mut_with(&mut rewriter);
+            }
+            replacement_import_locals.extend(self_rewrite_import_locals);
+        }
+    }
+    let entry_index = files
+        .iter()
+        .position(|(file_path, _, _)| file_path == entry_file)
+        .expect("residual job extraction verified the entry AST is present");
+    // Strip the entry last and keep it last in re-insertion order,
+    // matching the former stage order (strip re-appended the entry
+    // after the pass-through and self-rewrite waves).
+    let (_, _, entry_ast) = &mut files[entry_index];
+    let stats = strip_one_chunk_with_replacement_imports(
+        &mut entry_ast.module,
+        symbols,
+        chunk_path,
+        &replacement_import_locals,
+    )?;
+    let entry = files.remove(entry_index);
+    files.push(entry);
+    Ok(ResidualOutput {
+        chunk_id,
+        chunk_path: chunk_path.to_string(),
+        files: files
+            .into_iter()
+            .map(|(_, parts, ast)| (parts, ast))
+            .collect(),
+        references_by_symbol,
+        stats,
+    })
+}
+
+/// Write the plan's generated vendor emission outputs: full-swap
+/// wrappers plus bundled-partial-swap bundle copies and facades. The
+/// combined manifest is written separately by the pipeline next to its
+/// other reports.
+pub fn write_planned_vendor_outputs(plan: &VendorResolutionPlan) -> Result<()> {
+    for swap in &plan.full_swaps {
+        if let Some(wrapper) = &swap.wrapper {
+            write_planned_wrapper(&wrapper.abs_path, &wrapper.source)?;
+        }
+    }
+    for bundled in plan.bundled_partial_swaps.values() {
+        write_planned_bundled_assets(&bundled.assets)?;
+    }
+    Ok(())
+}

--- a/devinfra/js/debundle/vendor/manifests.rs
+++ b/devinfra/js/debundle/vendor/manifests.rs
@@ -1,21 +1,8 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 
 use serde::Serialize;
 
-use artifact::ChunkBundle;
 use spec::{PartialSwapKind, WrapperShape};
-
-#[derive(Debug, Clone)]
-pub struct VendorResolutionManifest {
-    pub resolutions: BTreeMap<String, VendorResolution>,
-    pub counts: VendorResolutionCounts,
-}
-
-pub struct SwapVendorChunksResult {
-    pub artifact: ChunkBundle,
-    pub manifest: VendorResolutionManifest,
-    pub removed_chunk_ids: BTreeSet<String>,
-}
 
 #[derive(Debug, Clone, Serialize)]
 pub struct VendorResolution {
@@ -29,11 +16,6 @@ pub struct VendorResolution {
     pub wrapper_shape: Option<WrapperShape>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub generated_wrapper_path: Option<String>,
-}
-
-#[derive(Debug, Clone)]
-pub struct VendorResolutionCounts {
-    pub swapped: usize,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/devinfra/js/debundle/vendor/mod.rs
+++ b/devinfra/js/debundle/vendor/mod.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
+mod emission;
 mod manifests;
 mod passthrough;
 mod plan;
@@ -17,88 +18,21 @@ use swc_ecma_visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 
 use analysis::local_namespace_iife_target;
 use artifact::{
-    ArtifactIndexes, ChunkBundle, ChunkId, ChunkTable, FileRole, JsFile, join_module_path,
-    list_chunk_file_paths, module_path_dirname, normalize_module_path, relative_module_specifier,
+    ArtifactIndexes, ChunkBundle, ChunkId, ChunkTable, join_module_path, list_chunk_file_paths,
+    module_path_dirname, normalize_module_path, relative_module_specifier,
 };
 use binding_targets::{declaration_ids, declaration_name_strings, module_export_name};
+pub use emission::{EmissionRewriteResult, apply_emission_rewrites, write_planned_vendor_outputs};
 use js_ast::str_value;
 #[cfg(test)]
 use js_ast::{emit_js_module, parse_js_module};
 pub use manifests::*;
-pub use passthrough::{PassthroughRewriteResult, rewrite_passthrough_directives};
 use plan::ChunkBundledPartialSwapPlan;
 pub use plan::{
     VendorImportAction, VendorPlanOptions, VendorResolutionPlan, build_vendor_resolution_plan,
 };
 use spec::PartialSwapKind;
-pub use strip::{
-    ChunkStripStats, StripSwappedVendorExportsOptions, strip_swapped_vendor_exports_with_options,
-};
-use wrappers::{write_planned_bundled_assets, write_planned_wrapper};
-
-/// Apply the plan's full swaps: verify caller import alignment against
-/// the current indexes, write planned wrappers, and remove the swapped
-/// chunks from the artifact. All resolution decisions (version checks,
-/// wrapper-shape validation, wrapper generation) were made at plan
-/// time. Caller-side directive handling (canonicalization of the
-/// intentionally dangling chunk specifier, boundary-rename name
-/// mapping) happens at the application sites — lowering and the
-/// pass-through emission rewriter.
-pub fn swap_vendor_chunks(
-    mut artifact: ChunkBundle,
-    plan: &VendorResolutionPlan,
-    references: &ArtifactIndexes,
-    write: bool,
-) -> Result<SwapVendorChunksResult> {
-    let chunk_table = artifact.chunk_table.clone();
-    let swap_chunk_ids: BTreeSet<ChunkId> =
-        plan.full_swaps.iter().map(|swap| swap.chunk_id).collect();
-    let import_alignment_index = build_import_alignment_index(references, &swap_chunk_ids);
-    let mut removed_chunk_ids = BTreeSet::new();
-    let mut resolutions: BTreeMap<String, VendorResolution> = BTreeMap::new();
-    for swap in &plan.full_swaps {
-        for record in import_alignment_index
-            .get(&swap.chunk_id)
-            .into_iter()
-            .flatten()
-        {
-            for imported_name in &record.named_imports {
-                if swap.vendor_exports.contains(imported_name) {
-                    continue;
-                }
-                bail!(
-                    "swap_vendor_chunks vendor entry {} import alignment failed: caller={}/{} imports unknown specifier \"{}\" from vendor {} (known: [{}])",
-                    swap.resolution.chunk_path,
-                    chunk_table.name(record.caller_chunk_id),
-                    record.caller_file,
-                    imported_name,
-                    swap.resolution.chunk_id,
-                    swap.vendor_exports
-                        .iter()
-                        .cloned()
-                        .collect::<Vec<_>>()
-                        .join(",")
-                );
-            }
-        }
-        if write && let Some(wrapper) = &swap.wrapper {
-            write_planned_wrapper(&wrapper.abs_path, &wrapper.source)?;
-        }
-        artifact.remove_chunk(swap.chunk_id);
-        removed_chunk_ids.insert(swap.resolution.chunk_id.clone());
-        resolutions.insert(swap.resolution.chunk_path.clone(), swap.resolution.clone());
-    }
-
-    let swapped = resolutions.len();
-    Ok(SwapVendorChunksResult {
-        artifact,
-        manifest: VendorResolutionManifest {
-            resolutions,
-            counts: VendorResolutionCounts { swapped },
-        },
-        removed_chunk_ids,
-    })
-}
+pub use strip::ChunkStripStats;
 
 /// Bail when a boundary-mapping key (a vendor-LOCAL binding name) is
 /// itself a genuine export name of the vendor entry bound to a
@@ -191,36 +125,6 @@ fn collect_boundary_mapping(module: &Module) -> BTreeMap<String, String> {
         }
     }
     mapping
-}
-
-#[derive(Debug, Clone)]
-struct ImportAlignmentRecord {
-    caller_chunk_id: ChunkId,
-    caller_file: String,
-    named_imports: Vec<String>,
-}
-
-fn build_import_alignment_index(
-    references: &ArtifactIndexes,
-    target_chunk_ids: &BTreeSet<ChunkId>,
-) -> BTreeMap<ChunkId, Vec<ImportAlignmentRecord>> {
-    let mut index = BTreeMap::<ChunkId, Vec<ImportAlignmentRecord>>::new();
-    for target_chunk_id in target_chunk_ids {
-        for import in references.manifest_imports_targeting_chunk(*target_chunk_id) {
-            if import.named_imports.is_empty() {
-                continue;
-            }
-            index
-                .entry(*target_chunk_id)
-                .or_default()
-                .push(ImportAlignmentRecord {
-                    caller_chunk_id: import.caller_chunk_id,
-                    caller_file: import.caller_file.clone(),
-                    named_imports: import.named_imports.clone(),
-                });
-        }
-    }
-    index
 }
 
 fn read_installed_package_metadata(
@@ -502,119 +406,22 @@ fn prop_name(name: &PropName) -> Option<String> {
 
 // === partial vendor swap =================================================
 //
-// `swap_vendor_chunks` operates on a *whole* chunk — it wraps the chunk's
-// upstream, rewrites caller imports to point at the wrapper, and removes
-// the chunk from the artifact. That doesn't work for mixed chunks: Vite
-// commonly bundles several packages (zod + @sentry/browser + react +
-// lodash + katex + mermaid) into one ESM chunk. Removing it would drop
-// every co-bundled package.
+// A full swap operates on a *whole* chunk — its caller imports point at
+// the upstream package and the chunk is excluded from the emission set.
+// That doesn't work for mixed chunks: Vite commonly bundles several
+// packages (zod + @sentry/browser + react + lodash + katex + mermaid)
+// into one ESM chunk. Excluding it would drop every co-bundled package.
 //
-// Partial swaps leave the chunk on disk and replace per-symbol consumer
-// references against upstream packages. The consumer side is applied at
-// two construction sites — lowering (materialized module bodies) and the
-// pass-through emission rewriter (`passthrough.rs`) — both consuming the
-// same `VendorResolutionPlan`. What remains here is the bundled family's
-// vendor-chunk **self-rewrite** (the seed of the residual computation:
-// re-target the chunk's own references at the facade so the strip pass
-// can drop the old implementation) and the manifest projection.
-
-pub struct BundledSelfRewriteResult {
-    pub artifact: ChunkBundle,
-    /// Synthetic facade import locals introduced by the self-rewrite,
-    /// keyed by chunk path; consumed by the strip pass's reachability
-    /// sweep.
-    pub self_rewrite_import_locals_by_chunk_path: BTreeMap<String, BTreeSet<Id>>,
-    /// (swapped chunk, chunk export) → self-rewrite reference counts,
-    /// folded into the same `references_rewritten` manifest fields as
-    /// the consumer-side counts.
-    pub references_by_symbol: BTreeMap<(ChunkId, String), usize>,
-}
-
-/// Apply the plan's bundled partial swaps' vendor-chunk side: write the
-/// planned bundle copy and facades, then re-target the vendor chunk's own
-/// pass-through files at the facade via
-/// `seed_bundled_partial_swap_self_rewrites` and the shared ident rewriter.
-/// Consumer-side rewrites live in the pass-through emission rewriter /
-/// lowering; validation, facade planning, and resolution happened at plan
-/// time.
-pub fn apply_bundled_partial_swap_self_rewrites(
-    mut artifact: ChunkBundle,
-    plan: &VendorResolutionPlan,
-    write: bool,
-) -> Result<BundledSelfRewriteResult> {
-    let chunk_table = artifact.chunk_table.clone();
-    let mut self_rewrite_import_locals_by_chunk_path: BTreeMap<String, BTreeSet<Id>> =
-        BTreeMap::new();
-    let mut references_by_symbol: BTreeMap<(ChunkId, String), usize> = BTreeMap::new();
-
-    if write {
-        for bundled in plan.bundled_partial_swaps.values() {
-            write_planned_bundled_assets(&bundled.assets)?;
-        }
-    }
-
-    for (&chunk_id, bundled) in &plan.bundled_partial_swaps {
-        let chunk_name = chunk_table.name(chunk_id).to_string();
-        let js_chunk = artifact.js_chunk_mut(chunk_id)?;
-        for file_path in list_chunk_file_paths(js_chunk) {
-            let Some(file) = js_chunk.get_file(&file_path) else {
-                continue;
-            };
-            if file.metadata.role == FileRole::Module || file.ast().is_none() {
-                continue;
-            }
-            let (parts, mut ast) = js_chunk
-                .remove_file(&file_path)
-                .and_then(|file| file.into_ast_parts())
-                .with_context(|| format!("missing AST for {chunk_name}/{file_path}"))?;
-
-            let mut bindings: BTreeMap<Id, IdentRewriteTarget> = BTreeMap::new();
-            let mut prelude_imports: Vec<DeferredImport> = Vec::new();
-            let mut self_rewrite_import_locals: BTreeSet<Id> = BTreeSet::new();
-            seed_bundled_partial_swap_self_rewrites(
-                &ast.module,
-                Some(bundled),
-                &chunk_table,
-                chunk_id,
-                &file_path,
-                SelfRewriteOutputs {
-                    bindings: &mut bindings,
-                    prelude_imports: &mut prelude_imports,
-                    references_by_symbol: &mut references_by_symbol,
-                    self_rewrite_import_locals: &mut self_rewrite_import_locals,
-                },
-            );
-            if !prelude_imports.is_empty() {
-                let mut prefixed = prelude_imports
-                    .drain(..)
-                    .map(DeferredImport::into_module_item)
-                    .collect::<Vec<_>>();
-                prefixed.append(&mut ast.module.body);
-                ast.module.body = prefixed;
-            }
-            if !bindings.is_empty() {
-                let mut rewriter = PartialSwapIdentRewriter {
-                    bindings: &bindings,
-                    references_by_symbol: &mut references_by_symbol,
-                };
-                ast.module.visit_mut_with(&mut rewriter);
-            }
-            if !self_rewrite_import_locals.is_empty() {
-                self_rewrite_import_locals_by_chunk_path
-                    .entry(bundled.chunk_path.clone())
-                    .or_default()
-                    .extend(self_rewrite_import_locals);
-            }
-            js_chunk.insert_file(JsFile::from_ast_parts(parts, ast));
-        }
-    }
-
-    Ok(BundledSelfRewriteResult {
-        artifact,
-        self_rewrite_import_locals_by_chunk_path,
-        references_by_symbol,
-    })
-}
+// Partial swaps emit the chunk as a computed residual and replace
+// per-symbol consumer references against upstream packages. The
+// consumer side is applied at two construction sites — lowering
+// (materialized module bodies) and the pass-through emission rewriter
+// (`passthrough.rs`) — both consuming the same `VendorResolutionPlan`.
+// What remains here is the bundled family's vendor-chunk
+// **self-rewrite seed** (re-target the chunk's own references at the
+// facade so the residual strip can drop the old implementation),
+// consumed by `emission::emit_vendor_residual`, and the manifest
+// projection.
 
 /// Project the plan's partial / bundled-partial resolutions into the
 /// wire manifest maps, folding the merged per-symbol rewrite counts
@@ -1359,8 +1166,15 @@ pub fn validate_partial_swap_consumers(
         return Ok(());
     }
     let materialized_index = MaterializedOutputChunkIndex::build(chunk_table);
+    // Full-swap chunks are excluded from the emission set; their files
+    // are never emitted, so their directives are not consumers (same
+    // rule as the plan-time gate).
+    let full_swap_chunks = plan.full_swap_chunk_ids();
     for chunk_artifact in &artifact.chunks {
         let caller_chunk_id = chunk_artifact.chunk_id;
+        if full_swap_chunks.contains(&caller_chunk_id) {
+            continue;
+        }
         let caller_chunk_name = chunk_table.name(caller_chunk_id);
         for file_path in list_chunk_file_paths(&chunk_artifact.js) {
             let Some(ast) = chunk_artifact
@@ -1571,7 +1385,7 @@ export { b as beta };
                 },
             )
             .unwrap();
-            let result = rewrite_passthrough_directives(artifact, &plan, &references).unwrap();
+            let result = apply_emission_rewrites(artifact, &plan, &references).unwrap();
             let artifact = result.artifact;
             assert!(
                 result.references_by_symbol.is_empty(),

--- a/devinfra/js/debundle/vendor/passthrough.rs
+++ b/devinfra/js/debundle/vendor/passthrough.rs
@@ -1,8 +1,11 @@
 //! Unified pass-through emission rewriter (vendor_into_emission §2.4,
 //! PR 4): the single position-preserving directive rewriter for files
 //! that are emitted without lowering — chunk entries (including
-//! materialized chunks' residual entries) and runtime files. One wave
-//! performs, per file:
+//! materialized chunks' residual entries) and runtime files. Driven by
+//! `vendor::emission::apply_emission_rewrites`, which applies it to
+//! non-vendor pass-through files as a wave and to vendor-chunk files
+//! as the first step of the per-chunk residual composition. Per file
+//! it performs:
 //!
 //! * **Specifier canonicalization** (the old always-on stage 0):
 //!   relative `import` / `export … from` / `export *` / `import()` /
@@ -27,19 +30,15 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use anyhow::{Context, Result, bail};
-use rayon::prelude::*;
-use swc_common::GLOBALS;
 use swc_ecma_ast::*;
 use swc_ecma_visit::{VisitMut, VisitMutWith};
 
 use artifact::{
-    ArtifactIndexes, ChunkBundle, ChunkId, ChunkTable, FileRole, ImportReferenceKind, JsFile,
-    JsFileAstParts, join_module_path, list_chunk_file_paths, module_path_dirname,
-    relative_module_path,
+    ArtifactIndexes, ChunkId, ChunkTable, ImportReferenceKind, join_module_path,
+    module_path_dirname, relative_module_path,
 };
 use binding_targets::module_export_name;
-use js_ast::{ParsedJsModule, set_str_value, str_value};
+use js_ast::{set_str_value, str_value};
 use spec::PartialSwapKind;
 
 use crate::plan::VendorResolutionPlan;
@@ -49,126 +48,23 @@ use crate::{
     make_namespace_reexport, new_url_expr, resolve_partial_swap_import_target,
 };
 
-pub struct PassthroughRewriteResult {
-    pub artifact: ChunkBundle,
-    /// (swapped chunk, chunk export) → count of consumer references
-    /// rewritten in pass-through files; folded into the partial-swap
-    /// manifests' `references_rewritten` alongside lowering's
-    /// construction-time counts.
-    pub references_by_symbol: BTreeMap<(ChunkId, String), usize>,
+pub(crate) struct PassthroughContext<'a> {
+    pub(crate) plan: &'a VendorResolutionPlan,
+    pub(crate) references: &'a ArtifactIndexes,
+    pub(crate) chunk_table: &'a ChunkTable,
+    pub(crate) materialized_index: &'a MaterializedOutputChunkIndex,
 }
 
-pub fn rewrite_passthrough_directives(
-    mut artifact: ChunkBundle,
-    plan: &VendorResolutionPlan,
-    references: &ArtifactIndexes,
-) -> Result<PassthroughRewriteResult> {
-    let chunk_table = artifact.chunk_table.clone();
-    let materialized_index = MaterializedOutputChunkIndex::build(&chunk_table);
-    let context = PassthroughContext {
-        plan,
-        references,
-        chunk_table: &chunk_table,
-        materialized_index: &materialized_index,
-    };
-
-    let mut jobs = Vec::new();
-    for (chunk_index, chunk_artifact) in artifact.chunks.iter_mut().enumerate() {
-        let chunk_id = chunk_artifact.chunk_id;
-        if plan.is_suppressed(chunk_id) {
-            continue;
-        }
-        let chunk_name = chunk_table.name(chunk_id).to_string();
-        for file_path in list_chunk_file_paths(&chunk_artifact.js) {
-            let Some(file) = chunk_artifact.js.get_file(&file_path) else {
-                continue;
-            };
-            // Materialized module files' specifiers are constructed by
-            // lowering from the same plan; only pass-through files
-            // (entries, runtime files) are rewritten here.
-            if file.metadata.role == FileRole::Module || file.ast().is_none() {
-                continue;
-            }
-            let (parts, ast) = chunk_artifact
-                .js
-                .remove_file(&file_path)
-                .and_then(|file| file.into_ast_parts())
-                .with_context(|| format!("missing AST for {chunk_name}/{file_path}"))?;
-            jobs.push(PassthroughFileJob {
-                chunk_index,
-                chunk_id,
-                file_path,
-                parts,
-                ast,
-            });
-        }
-    }
-
-    // Rayon workers don't inherit `GLOBALS`; re-set per worker so any
-    // `Mark::new()` / `Id` use stays in the caller's arena.
-    let context_ref = &context;
-    let results: Vec<PassthroughFileResult> = GLOBALS.with(|globals| {
-        jobs.into_par_iter()
-            .map(|job| GLOBALS.set(globals, || rewrite_passthrough_file(job, context_ref)))
-            .collect()
-    });
-
-    let mut references_by_symbol = BTreeMap::new();
-    for result in results {
-        for ((chunk_id, chunk_export), count) in result.references_by_symbol {
-            if !plan.partial_swaps.contains_key(&chunk_id)
-                && !plan.bundled_partial_swaps.contains_key(&chunk_id)
-            {
-                bail!(
-                    "pass-through rewrite reported references to `{chunk_export}` on chunk {}, which has no partial-swap plan",
-                    chunk_table.name(chunk_id)
-                );
-            }
-            *references_by_symbol
-                .entry((chunk_id, chunk_export))
-                .or_insert(0) += count;
-        }
-        artifact
-            .chunks
-            .get_mut(result.chunk_index)
-            .with_context(|| format!("missing chunk index {}", result.chunk_index))?
-            .js
-            .insert_file(JsFile::from_ast_parts(result.parts, result.ast));
-    }
-
-    Ok(PassthroughRewriteResult {
-        artifact,
-        references_by_symbol,
-    })
-}
-
-struct PassthroughContext<'a> {
-    plan: &'a VendorResolutionPlan,
-    references: &'a ArtifactIndexes,
-    chunk_table: &'a ChunkTable,
-    materialized_index: &'a MaterializedOutputChunkIndex,
-}
-
-struct PassthroughFileJob {
-    chunk_index: usize,
-    chunk_id: ChunkId,
-    file_path: String,
-    parts: JsFileAstParts,
-    ast: ParsedJsModule,
-}
-
-struct PassthroughFileResult {
-    chunk_index: usize,
-    parts: JsFileAstParts,
-    ast: ParsedJsModule,
-    references_by_symbol: BTreeMap<(ChunkId, String), usize>,
-}
-
-fn rewrite_passthrough_file(
-    mut job: PassthroughFileJob,
+/// Rewrite one pass-through module in place; rewritten partial-swap
+/// consumer reference counts are accumulated into
+/// `references_by_symbol`.
+pub(crate) fn rewrite_passthrough_module(
+    module: &mut Module,
+    caller_chunk_id: ChunkId,
+    caller_file_path: &str,
     context: &PassthroughContext<'_>,
-) -> PassthroughFileResult {
-    let module = &mut job.ast.module;
+    references_by_symbol: &mut BTreeMap<(ChunkId, String), usize>,
+) {
     let mut state = FileRewriteState {
         bindings: BTreeMap::new(),
         emitted_member_namespace_for: BTreeSet::new(),
@@ -180,8 +76,8 @@ fn rewrite_passthrough_file(
     // replacement plus boundary-rename name mapping, in position.
     module.body = rewrite_directive_items(
         std::mem::take(&mut module.body),
-        job.chunk_id,
-        &job.file_path,
+        caller_chunk_id,
+        caller_file_path,
         context,
         &mut state,
     );
@@ -194,8 +90,8 @@ fn rewrite_passthrough_file(
     // untouched.
     let mut canonicalizer = SourceCanonicalizer {
         context,
-        caller_chunk_id: job.chunk_id,
-        caller_file: &job.file_path,
+        caller_chunk_id,
+        caller_file: caller_file_path,
     };
     module.visit_mut_with(&mut canonicalizer);
 
@@ -209,11 +105,8 @@ fn rewrite_passthrough_file(
         module.visit_mut_with(&mut rewriter);
     }
 
-    PassthroughFileResult {
-        chunk_index: job.chunk_index,
-        parts: job.parts,
-        ast: job.ast,
-        references_by_symbol: state.references_by_symbol,
+    for (key, count) in state.references_by_symbol {
+        *references_by_symbol.entry(key).or_insert(0) += count;
     }
 }
 
@@ -345,9 +238,9 @@ fn rewrite_import_decl(
 
     // Boundary-rename name mapping (vendor-local → public) for named
     // specifiers targeting the boundary chunk's entry file. Index
-    // resolution carries the target file; the materialized fallback
-    // only fires for removed full-swap chunks, whose only consumable
-    // file is the entry.
+    // resolution carries the target file; when only the materialized
+    // fallback resolved, a full-swap target's sole consumable file is
+    // the entry.
     let targets_entry_file = match &resolved {
         Some(resolved) => context
             .plan
@@ -624,9 +517,9 @@ fn rewrite_export_from_decl(
 /// `RuntimeSourceRewriter`. Rewrites relative directive sources that
 /// resolve to another chunk into the artifact-relative form; sources
 /// already spelled as artifact output paths keep their spelling.
-/// Directives targeting a removed full-swap chunk (index resolution
-/// misses — the live-proxy dangling-import contract) canonicalize
-/// against the plan's recorded entry path instead.
+/// Directives targeting a full-swap chunk that index resolution misses
+/// (the live-proxy dangling-import contract) canonicalize against the
+/// plan's recorded entry path instead.
 struct SourceCanonicalizer<'a> {
     context: &'a PassthroughContext<'a>,
     caller_chunk_id: ChunkId,
@@ -649,9 +542,9 @@ impl SourceCanonicalizer<'_> {
             Some(resolved) if resolved.kind == ImportReferenceKind::ArtifactPath => return None,
             Some(resolved) => resolved.target_path,
             None => {
-                // Removed full-swap chunks resolve through the
-                // chunk-table prefix fallback; canonical entry path
-                // comes from the plan.
+                // Full-swap targets the index misses resolve through
+                // the chunk-table prefix fallback; canonical entry
+                // path comes from the plan.
                 let chunk = resolve_partial_swap_import_target(
                     source,
                     self.caller_chunk_id,

--- a/devinfra/js/debundle/vendor/plan.rs
+++ b/devinfra/js/debundle/vendor/plan.rs
@@ -8,13 +8,14 @@
 //! symbol/package shape, installed-package versions, consumer-shape
 //! classification) and records the resolved decisions: boundary
 //! mappings, full-swap wrapper text and output paths, partial/bundled
-//! swap symbol tables and facade targets, plus the wire-facing
-//! resolution projections the vendor manifests are built from. The
-//! application sites (`swap_vendor_chunks`, lowering's import
-//! construction, the pass-through emission rewriter, the bundled
-//! self-rewrite, strip) consume the plan instead of re-resolving marks
-//! mid-pipeline; application (directive rewrites, file writes, chunk
-//! removal, strip) stays at those sites.
+//! swap symbol tables and facade targets, full-swap caller import
+//! alignment, plus the wire-facing resolution projections the vendor
+//! manifests are built from. The application sites (lowering's import
+//! construction and the emission rewrites — the pass-through directive
+//! pass and the per-chunk vendor residual composition) consume the
+//! plan instead of re-resolving marks mid-pipeline; application
+//! (directive rewrites, residual computation, file writes) stays at
+//! those sites.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs;
@@ -86,10 +87,6 @@ pub struct VendorResolutionPlan {
 impl VendorResolutionPlan {
     pub fn has_boundary_renames(&self) -> bool {
         !self.boundary_renames.is_empty()
-    }
-
-    pub fn has_full_swaps(&self) -> bool {
-        !self.full_swaps.is_empty()
     }
 
     pub fn has_partial_swaps(&self) -> bool {
@@ -166,16 +163,34 @@ impl VendorResolutionPlan {
     }
 
     /// Output-tree path (`<chunk_name>/<entry_file>`) of a fully-swapped
-    /// chunk's entry. The chunk is removed from the artifact by
-    /// `swap_vendor_chunks`, so index resolution cannot canonicalize
-    /// directives that keep targeting it (the live-proxy dangling-import
-    /// contract); construction and the pass-through rewriter consult
-    /// this instead.
+    /// chunk's entry. Directives that keep targeting the excluded chunk
+    /// (the live-proxy dangling-import contract) canonicalize against
+    /// this recorded path; construction and the pass-through rewriter
+    /// consult it when index resolution misses.
     pub fn full_swap_target_path(&self, chunk: ChunkId) -> Option<String> {
         self.full_swaps
             .iter()
             .find(|swap| swap.chunk_id == chunk)
             .map(|swap| join_module_path(&[&swap.resolution.chunk_id, &swap.resolution.entry_file]))
+    }
+
+    /// Chunks excluded from the emission set: fully-swapped chunks stay
+    /// in the `ChunkBundle` (nothing removes them; the owner graph
+    /// never contained vendor chunks) but `write_js_tree` / harness
+    /// emission and the emission-output validations skip them
+    /// (vendor_into_emission §2.5).
+    pub fn full_swap_chunk_ids(&self) -> BTreeSet<ChunkId> {
+        self.full_swaps.iter().map(|swap| swap.chunk_id).collect()
+    }
+
+    /// Wire-facing full-swap resolutions keyed by chunk path — the
+    /// `full` section of the combined vendor swaps report, projected
+    /// straight from the plan.
+    pub fn full_swap_resolutions(&self) -> BTreeMap<String, VendorResolution> {
+        self.full_swaps
+            .iter()
+            .map(|swap| (swap.resolution.chunk_path.clone(), swap.resolution.clone()))
+            .collect()
     }
 
     pub fn is_suppressed(&self, chunk: ChunkId) -> bool {
@@ -240,12 +255,11 @@ pub(crate) struct BoundaryRenamePlan {
 
 pub(crate) struct FullSwapPlan {
     pub(crate) chunk_id: ChunkId,
-    /// The chunk's export surface, consumed by the swap wave's
-    /// import-alignment check (which runs post-rename against the
-    /// then-current indexes).
+    /// The chunk's export surface, consumed by the plan-time caller
+    /// import-alignment check.
     pub(crate) vendor_exports: BTreeSet<String>,
-    /// Generated wrapper text + absolute output path; written during
-    /// the swap wave when writes are enabled.
+    /// Generated wrapper text + absolute output path; written at emit
+    /// when writes are enabled.
     pub(crate) wrapper: Option<PlannedWrapper>,
     /// Wire-facing resolution projected from this plan entry.
     pub(crate) resolution: VendorResolution,
@@ -333,7 +347,43 @@ pub fn build_vendor_resolution_plan(
         suppressed,
     };
     validate_consumer_shapes(artifact, references, &plan)?;
+    validate_full_swap_import_alignment(artifact, references, &plan)?;
     Ok(plan)
+}
+
+/// Full-swap caller import alignment: every named import any caller
+/// directs at a fully-swapped chunk must name an export the chunk
+/// actually declares. Runs at plan time over the prepare-time manifest
+/// import index — the same inputs the former swap stage checked.
+fn validate_full_swap_import_alignment(
+    artifact: &ChunkBundle,
+    references: &ArtifactIndexes,
+    plan: &VendorResolutionPlan,
+) -> Result<()> {
+    let chunk_table = &artifact.chunk_table;
+    for swap in &plan.full_swaps {
+        for import in references.manifest_imports_targeting_chunk(swap.chunk_id) {
+            for imported_name in &import.named_imports {
+                if swap.vendor_exports.contains(imported_name) {
+                    continue;
+                }
+                bail!(
+                    "swap_vendor_chunks vendor entry {} import alignment failed: caller={}/{} imports unknown specifier \"{}\" from vendor {} (known: [{}])",
+                    swap.resolution.chunk_path,
+                    chunk_table.name(import.caller_chunk_id),
+                    import.caller_file,
+                    imported_name,
+                    swap.resolution.chunk_id,
+                    swap.vendor_exports
+                        .iter()
+                        .cloned()
+                        .collect::<Vec<_>>()
+                        .join(",")
+                );
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Plan-time consumer gate (vendor_into_emission §3.2): enumerate every
@@ -394,12 +444,9 @@ fn validate_consumer_shapes(
     }
     let chunk_table = &artifact.chunk_table;
     let materialized_index = MaterializedOutputChunkIndex::build(chunk_table);
-    // Full-swap chunks are removed from the artifact before any
-    // consumer rewrite runs; their files are never emitted, so their
-    // directives are not consumers (the post-strip scan never saw them
-    // either).
-    let full_swap_chunks: BTreeSet<ChunkId> =
-        plan.full_swaps.iter().map(|swap| swap.chunk_id).collect();
+    // Full-swap chunks are excluded from the emission set; their files
+    // are never emitted, so their directives are not consumers.
+    let full_swap_chunks = plan.full_swap_chunk_ids();
     for chunk_artifact in &artifact.chunks {
         let caller_chunk_id = chunk_artifact.chunk_id;
         if full_swap_chunks.contains(&caller_chunk_id) {

--- a/devinfra/js/debundle/vendor/strip.rs
+++ b/devinfra/js/debundle/vendor/strip.rs
@@ -1,40 +1,18 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
-use analysis::{
-    AnalysisHints, ChunkId, EffectCell, LocalEffectPolicy, StatementFacts, analyze_chunk,
-};
-use anyhow::{Context, Result, bail};
+use analysis::{AnalysisHints, EffectCell, LocalEffectPolicy, StatementFacts, analyze_chunk};
+use anyhow::{Result, bail};
 use binding_targets::{declaration_ids, declaration_name_strings, module_export_name};
-use rayon::prelude::*;
 use serde::Serialize;
 use swc_common::sync::Lrc;
-use swc_common::{DUMMY_SP, GLOBALS, SourceMap};
+use swc_common::{DUMMY_SP, SourceMap};
 use swc_ecma_ast::*;
 use swc_ecma_codegen::text_writer::JsWriter;
 use swc_ecma_codegen::{Config, Emitter};
 use swc_ecma_visit::{Visit, VisitWith};
 
-use artifact::{ChunkBundle, JsFile, JsFileAstParts};
-use js_ast::ParsedJsModule;
 use spec::PartialSwapSymbol;
-
-use crate::plan::VendorResolutionPlan;
-
-pub struct StripSwappedVendorExportsResult {
-    pub artifact: ChunkBundle,
-    pub manifest: StripSwappedVendorExportsManifest,
-}
-
-#[derive(Debug, Clone, Default)]
-pub struct StripSwappedVendorExportsOptions {
-    pub replacement_import_locals_by_chunk_path: BTreeMap<String, BTreeSet<Id>>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct StripSwappedVendorExportsManifest {
-    pub per_chunk: BTreeMap<String, ChunkStripStats>,
-}
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ChunkStripStats {
@@ -42,181 +20,6 @@ pub struct ChunkStripStats {
     pub stripped_export_specifiers: usize,
     pub dropped_top_level_items: usize,
     pub retained_top_level_items: usize,
-}
-
-/// Per-chunk pass that drops swapped names from the vendor entry's
-/// trailing `export { … }` block (Phase 1) and sweeps top-level
-/// bindings that are no longer reachable from the residual export
-/// surface plus retained side-effect statements (Phase 2).
-///
-/// Runs after the consumer-side rewrites (lowering construction + the
-/// pass-through emission rewriter) — every consumer already imports
-/// each swapped name from upstream,
-/// so the chunk's residual `export { … }` entries for those names
-/// are dead weight. Without this pass the on-disk vendor blob stays
-/// byte-identical to pre-swap.
-pub fn strip_swapped_vendor_exports_with_options(
-    mut artifact: ChunkBundle,
-    plan: &VendorResolutionPlan,
-    options: StripSwappedVendorExportsOptions,
-) -> Result<StripSwappedVendorExportsResult> {
-    // Strip inputs come straight from the vendor plan: partial and
-    // bundled-partial entries, merged back into chunk-path order.
-    #[derive(Clone, Copy)]
-    struct StripSource<'a> {
-        chunk_path: &'a str,
-        chunk_name: &'a str,
-        chunk_id: ChunkId,
-        entry_file: &'a str,
-        symbols: &'a BTreeMap<String, PartialSwapSymbol>,
-    }
-    let sources: BTreeMap<&str, StripSource<'_>> = plan
-        .partial_swaps
-        .iter()
-        .map(|(chunk_id, partial)| StripSource {
-            chunk_path: &partial.chunk_path,
-            chunk_name: &partial.resolution.chunk_id,
-            chunk_id: *chunk_id,
-            entry_file: &partial.entry_file,
-            symbols: &partial.symbols,
-        })
-        .chain(
-            plan.bundled_partial_swaps
-                .iter()
-                .map(|(chunk_id, bundled)| StripSource {
-                    chunk_path: &bundled.chunk_path,
-                    chunk_name: &bundled.resolution.chunk_id,
-                    chunk_id: *chunk_id,
-                    entry_file: &bundled.entry_file,
-                    symbols: &bundled.symbols,
-                }),
-        )
-        .map(|source| (source.chunk_path, source))
-        .collect();
-
-    // Phase 1 (sequential): pull every vendor entry's entry-file AST
-    // out of the artifact and bundle the per-chunk inputs into a
-    // `StripJob`. `remove_file`/`insert_file` on `ChunkBundle` need
-    // `&mut artifact`; doing the round-trip here means the actual
-    // strip work can borrow only owned data and run in parallel.
-    let mut jobs: Vec<StripJob<'_>> = Vec::new();
-    for source in sources.values() {
-        let StripSource {
-            chunk_path,
-            chunk_name,
-            chunk_id,
-            entry_file,
-            symbols,
-        } = *source;
-        let js_chunk = artifact.js_chunk_mut(chunk_id)?;
-        let file = js_chunk.remove_file(entry_file).with_context(|| {
-            format!(
-                "strip_swapped_vendor_exports vendor entry {chunk_path}: entry file {entry_file} missing from chunk {chunk_name}"
-            )
-        })?;
-        let (parts, ast) = file.into_ast_parts().with_context(|| {
-            format!(
-                "strip_swapped_vendor_exports vendor entry {chunk_path}: chunk {chunk_name} entry has no AST"
-            )
-        })?;
-
-        let replacement_import_locals = options
-            .replacement_import_locals_by_chunk_path
-            .get(chunk_path)
-            .cloned()
-            .unwrap_or_default();
-
-        jobs.push(StripJob {
-            chunk_path,
-            chunk_id,
-            symbols,
-            replacement_import_locals,
-            parts,
-            ast,
-        });
-    }
-
-    // Phase 2 (parallel): per-job strip work is pure data transformation —
-    // each job owns its `parts`/`ast` and reads only its own `symbols` and
-    // `replacement_import_locals`. No two jobs target the same chunk_id
-    // (vendor is a BTreeMap keyed by chunk_path, and chunk_path -> chunk_id
-    // is injective via `vendor_chunk_name`), so collecting outputs
-    // back into the artifact in Phase 3 doesn't risk write-write races.
-    //
-    // `swc_common::GLOBALS` is a `scoped_tls` thread-local that does NOT
-    // carry into rayon worker threads. The strip path currently doesn't
-    // mint fresh marks, but `Id` comparisons and any future swc work
-    // expect a live `Globals`; capture the parent thread's globals and
-    // re-set inside each worker, mirroring `lowering/mod.rs` and
-    // `lower_chunk`.
-    let outputs: Vec<StripOutput> = GLOBALS.with(|globals| -> Result<Vec<StripOutput>> {
-        jobs.into_par_iter()
-            .map(|job| GLOBALS.set(globals, || strip_one_job(job)))
-            .collect()
-    })?;
-
-    // Phase 3 (sequential): re-insert the stripped entry files and
-    // collect per-chunk stats in `vendor` iteration order (preserved by
-    // `Vec::into_par_iter().collect()`).
-    let mut per_chunk = BTreeMap::new();
-    for output in outputs {
-        let StripOutput {
-            chunk_path,
-            chunk_id,
-            parts,
-            ast,
-            stats,
-        } = output;
-        let js_chunk = artifact.js_chunk_mut(chunk_id)?;
-        js_chunk.insert_file(JsFile::from_ast_parts(parts, ast));
-        per_chunk.insert(chunk_path, stats);
-    }
-
-    Ok(StripSwappedVendorExportsResult {
-        artifact,
-        manifest: StripSwappedVendorExportsManifest { per_chunk },
-    })
-}
-
-struct StripJob<'a> {
-    chunk_path: &'a str,
-    chunk_id: ChunkId,
-    symbols: &'a BTreeMap<String, PartialSwapSymbol>,
-    replacement_import_locals: BTreeSet<Id>,
-    parts: JsFileAstParts,
-    ast: ParsedJsModule,
-}
-
-struct StripOutput {
-    chunk_path: String,
-    chunk_id: ChunkId,
-    parts: JsFileAstParts,
-    ast: ParsedJsModule,
-    stats: ChunkStripStats,
-}
-
-fn strip_one_job(job: StripJob<'_>) -> Result<StripOutput> {
-    let StripJob {
-        chunk_path,
-        chunk_id,
-        symbols,
-        replacement_import_locals,
-        parts,
-        mut ast,
-    } = job;
-    let stats = strip_one_chunk_with_replacement_imports(
-        &mut ast.module,
-        symbols,
-        chunk_path,
-        &replacement_import_locals,
-    )?;
-    Ok(StripOutput {
-        chunk_path: chunk_path.to_string(),
-        chunk_id,
-        parts,
-        ast,
-        stats,
-    })
 }
 
 #[cfg(test)]
@@ -228,7 +31,15 @@ fn strip_one_chunk(
     strip_one_chunk_with_replacement_imports(module, symbols, chunk_path, &BTreeSet::new())
 }
 
-fn strip_one_chunk_with_replacement_imports(
+/// Residual strip for one partially-swapped vendor entry: drops
+/// swapped names from the entry's `export { … }` surface (Phase 1) and
+/// sweeps top-level bindings no longer reachable from the residual
+/// export surface plus retained side-effect statements (Phase 2).
+/// Runs as the final step of the vendor residual composition
+/// (`vendor::emission::emit_vendor_residual`) — every consumer already
+/// imports each swapped name from upstream, so the entry's residual
+/// `export { … }` entries for those names are dead weight.
+pub(crate) fn strip_one_chunk_with_replacement_imports(
     module: &mut Module,
     symbols: &BTreeMap<String, PartialSwapSymbol>,
     chunk_path: &str,

--- a/devinfra/js/debundle/vendor/wrappers.rs
+++ b/devinfra/js/debundle/vendor/wrappers.rs
@@ -256,7 +256,7 @@ pub(super) fn write_planned_wrapper(abs_path: &Path, source: &str) -> Result<()>
 
 /// Bundle copy + per-package facades planned for a bundled partial
 /// swap: paths and generated sources, computed at plan time; written
-/// by `write_planned_bundled_assets` during the bundled wave.
+/// by `write_planned_bundled_assets` at emit.
 pub(super) struct PlannedBundledAssets {
     pub(super) bundle_source_path: PathBuf,
     pub(super) bundle_abs_path: PathBuf,

--- a/devinfra/js/debundle/write_tree.rs
+++ b/devinfra/js/debundle/write_tree.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::fs;
 use std::path::Path;
 
@@ -18,9 +18,15 @@ pub struct WriteTreeInput<'a> {
     pub out_dir: &'a Path,
     pub lowerings: &'a [SelectedModuleLowering],
     pub counts: &'a ArtifactCounts,
+    /// Chunk records of the emission set — the caller drops records of
+    /// excluded chunks before passing them in.
     pub chunk_records: &'a [ArtifactChunkRecord],
     pub module_count: usize,
     pub decomposition_by_chunk: &'a HashMap<ChunkId, ChunkDecompositionOutput>,
+    /// Chunks excluded from the emission set (fully vendor-swapped):
+    /// their files are not written and they contribute nothing to the
+    /// rename queue.
+    pub excluded_chunk_ids: &'a BTreeSet<ChunkId>,
 }
 
 pub fn write_js_tree(input: &WriteTreeInput) -> Result<()> {
@@ -35,6 +41,7 @@ pub fn write_js_tree(input: &WriteTreeInput) -> Result<()> {
         &layout.app_root(),
         &layout.tree_root(),
         input.decomposition_by_chunk,
+        input.excluded_chunk_ids,
     )?;
 
     let decomposition_metrics = if input.lowerings.is_empty() {
@@ -46,7 +53,11 @@ pub fn write_js_tree(input: &WriteTreeInput) -> Result<()> {
         ))
     };
 
-    let queue = compute_identifier_rename_queue(input.artifact, input.decomposition_by_chunk)?;
+    let queue = compute_identifier_rename_queue(
+        input.artifact,
+        input.decomposition_by_chunk,
+        input.excluded_chunk_ids,
+    )?;
     write_queue(&layout.rename_queue_report(), &queue)?;
     let manifest = ArtifactManifest {
         counts: input.counts.clone(),


### PR DESCRIPTION
PR 5 of [`devinfra/js/debundle/plans/vendor_into_emission.md`](devinfra/js/debundle/plans/vendor_into_emission.md) §8 (staging row 5: *"Full swap → emission-set exclusion (chunk removal deleted); strip → vendor emission (§2.5 composition); wrappers / facades / manifests written at emit; `swap_vendor_chunks` as a stage deleted"*; intermediate state: *"pipeline has no vendor stages; reports derive from plan + emission results"*). Predecessors: #2112, #2119, #2123, #2127.

## Full swap = emission-set exclusion (§2.5)

- `swap_vendor_chunks` as a stage is **deleted**; nothing removes chunks from the `ChunkBundle` (`ChunkBundle::remove_chunk` deleted — no callers remain). The owner graph never contained vendor chunks, so nothing in materialize changes role.
- Exclusion is a property of the emission set: `vendor_plan.full_swap_chunk_ids()` threads to `write_js_tree` / `emit_browser_harness` / `materialize_artifact_scripts` (files skipped), the rename queue (no sites/counts from excluded chunks), `validate_emitted_exports`, the post-emission consumer tripwire, and lowering's cross-module purity oracle (excluded chunks stay opaque — verdicts from a bundle copy that's replaced by the upstream package would be facts about never-emitted code).
- The `removed_chunk_ids` / `chunk_records.retain` dance in `pipeline.rs` dies; chunk reports (`chunks.json`, `output.json`) filter excluded records **from the plan** at the emission boundary. `vendor_report.full` is a plan projection (`full_swap_resolutions()`).
- The full-swap caller import-alignment check moves to plan time — identical inputs (prepare-time manifest import index; nothing mutated between the old plan build and swap wave since PR 4 deleted the rename wave), identical message, and it runs after the consumer-shape gate to preserve failure precedence.
- Harness entry/preload references to an excluded chunk fail exactly as they did when the chunk was removed.

## Strip-at-emit (§2.5 composition)

- New `vendor/emission.rs`: `apply_emission_rewrites` is the single artifact pass replacing three pipeline stages (pass-through wave, bundled self-rewrites, strip) and their per-stage index rebuilds.
- `emit_vendor_residual` is **one function body** per partially-swapped chunk: directive rewrite (canonicalize + consumer surgery, §2.4) → bundled facade self-rewrite → strip. The composition is structural; a future reordering bug is unrepresentable.
- Gate preservation (§3.1 table): the four strip-internal gates (split-brain + documented bypasses, observable-effect privacy, live-item-reads-dropped-decl, export-surface invariance) live inside `strip_one_chunk_with_replacement_imports` and moved **verbatim** — same predicates, same module shape (per-file order pass-through→self-rewrite→strip matches the old wave order), same `replacement_import_locals` accumulation, same diagnostics. Pinned by `partial_swap_rejects_split_brain_residual_reachability`, `partial_swap_rejects_observable_side_effect_reading_swapped_binding`, `partial_swap_keeps_side_effect_init` — all green unchanged.
- §3.2: plan-time consumer gate unchanged; the post-emission `validate_partial_swap_consumers` scan **stays on** as the differential tripwire (now skipping excluded chunks, whose files it never saw before). PR 6 retires it with fixture evidence.
- Wrappers, facade bundles + bundle copies, and the combined manifest are written at emit (`write_planned_vendor_outputs`), still gated behind `swap_vendor_chunks.write` — unchanged generators, unchanged paths/bytes (§5).
- `references_rewritten` keeps counting emitted references: lowering construction + pass-through + self-rewrite counts merge into the same per-symbol fields; the parity fixture is green unchanged.

## Deletions

`swap_vendor_chunks`, `apply_bundled_partial_swap_self_rewrites` / `BundledSelfRewriteResult`, the strip stage wrapper (`strip_swapped_vendor_exports_with_options` + result/options/manifest types and its 3-phase job plumbing), `SwapVendorChunksResult` / `VendorResolutionManifest` / `VendorResolutionCounts`, `build_import_alignment_index` / `ImportAlignmentRecord`, `VendorResolutionPlan::has_full_swaps`, `ChunkBundle::remove_chunk`.

## Deviations from the doc

- §2.5's `emit_vendor_residual` sketch says "clone at emit; input space untouched". In the PR-5 intermediate state, emission still reads file bodies from the artifact, so the residual is computed by the same in-place mutation pattern materialize uses — but inside the one-body composition. Making emission a pure function of the prepared artifact is the doc's *next* trajectory step (materialize-into-emit), explicitly out of scope.
- Not in the PR-5 row but required for behavior preservation: full-swap chunks are excluded from the cross-module purity oracle (`lowering/cross_module.rs`). Before, removal made them invisible to that pass; retaining them without exclusion would have added purity facts derived from never-emitted code and could change lowering decisions/emitted bytes.

## Verification

- `bbr test //devinfra/js/debundle/...` — 106/106 green (incl. `vendor_swap_test` with the #2062 consumer-gate + collision fixtures, #2084 `default_export_aliases` coverage, the `references_rewritten` parity fixture, the suppress byte-compat goldens, and `full_swap_with_caller_keeps_dangling_chunk_import_for_live_proxy`).
- `bbr build //...` green; `bbr test //...` green except the pre-existing `.live` API-key tests CI excludes (`buildbuddy:a10b93f3-bbdd-4b34-9940-91dc051b4fce`).

https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk)_