### PR TITLE
debundle: doc sync, consumer-scan ruling, tombstone (vendor-into-emission PR 6)

### DIFF
--- a/devinfra/js/debundle/AGENTS.md
+++ b/devinfra/js/debundle/AGENTS.md
@@ -202,9 +202,9 @@ Syntax-derived facts likewise come from the SWC-backed parse/analysis
 path and flow through artifact manifests / indexes — not from
 phase-local rescans. The pipeline parses each chunk once in
 `prepare_js_chunks` and records imports, exports, dynamic-import
-shape, etc. on `ChunkManifest`; downstream stages (vendor renaming,
-specifier rewriting, owner-graph construction) consume those manifest
-facts through the centralized `ArtifactIndexes` query API
+shape, etc. on `ChunkManifest`; downstream consumers (vendor planning,
+emission-time specifier rewriting, owner-graph construction) consume
+those manifest facts through the centralized `ArtifactIndexes` query API
 (`resolve_runtime_import_reference`, `manifest_imports_targeting_chunk`,
 etc.) rather than re-walking the AST to answer "which chunk does this
 import resolve to" or "which chunks import this binding". Mutation
@@ -514,12 +514,12 @@ keep call sites typed.
 
 ## Spec-level `inputs`
 
-`load_js_chunks`, `prepare_js_chunks`, and `rewrite_chunk_entry_specifiers`
-are always-on preparation steps. The spec configures the load step via
-`inputs: { input_root, js_list_path }`; chunk preparation parses selected
-chunks, computes shallow program facts, and canonicalizes chunk entries in one
-parallel per-chunk pass. Specifier rewriting runs automatically after
-preparation and before data-gated transforms.
+`load_js_chunks` and `prepare_js_chunks` are always-on preparation steps.
+The spec configures the load step via `inputs: { input_root, js_list_path }`;
+chunk preparation parses selected chunks, computes shallow program facts, and
+canonicalizes chunk entries in one parallel per-chunk pass. Import-specifier
+canonicalization is applied at emission time by the unified pass-through
+directive rewriter (`vendor/passthrough.rs`), not as a separate stage.
 
 ## Spec-level declarative sections
 
@@ -545,9 +545,10 @@ structs in <spec.rs>.
 - `chunk_renames` — keyed by chunk id, then binding name. These are in-place
   readability renames for bindings that remain in the chunk entry.
 
-Transforms run in a fixed canonical order. Vendor and module materialization
-are gated by their data maps; tree and harness emission are gated by their
-output config fields. `rewrite_chunk_entry_specifiers` is always-on.
+Transforms run in a fixed canonical order. Vendor planning and module
+materialization are gated by their data maps; tree and harness emission are
+gated by their output config fields. The emission rewrite pass (specifier
+canonicalization plus vendor consumer surgery) is always-on.
 
 ## Materialize logical-modules `target_dir`
 

--- a/devinfra/js/debundle/ARCHITECTURE_BACKLOG.md
+++ b/devinfra/js/debundle/ARCHITECTURE_BACKLOG.md
@@ -9,6 +9,33 @@ Re-check file paths and line numbers against current `HEAD` before
 acting; this file intentionally describes shapes rather than frozen
 review line references.
 
+### Materialize-into-emit (next pipeline-trajectory step)
+
+The vendor collapse (`plans/vendor_into_emission.md`, tombstoned
+2026-06-12) removed every vendor mutation wave; the one remaining
+artifact mutation is `materialize_logical_modules`, which writes
+lowered module files back into the chunk bundle for `write_js_tree` /
+`emit_browser_harness` to re-read. The recorded next step
+(vendor_into_emission §4; docs/design.md "Pipeline trajectory"):
+lowered outputs feed tree / harness emission directly, dropping the
+bundle round-trip and the post-materialize index rebuild. The
+emission rewrites (`apply_emission_rewrites`) would become per-file
+emit steps in the same pass. No timetable; the e2e suite is the
+safety net.
+
+### Post-strip consumer scan retirement condition
+
+`vendor/mod.rs::validate_partial_swap_consumers` was kept at the end
+of the vendor collapse (open question 4's escape clause in the
+tombstoned plan): lowering can synthesize consumer directives inside
+materialized module bodies (`BindingKind::Imported` re-export imports
+in `lowering/lower.rs`, `export … from` re-exports in moved bodies)
+with no live rewrite at the construction site, and the plan-time
+gate's input-space enumeration cannot see them. Retire the scan only
+after (a) those construction paths consult the `VendorResolutionPlan`
+(live rewrite or plan-time rejection) and (b) e2e fixtures pin the
+synthesized-directive shapes failing without the scan.
+
 ### `owner` → `node` rename (deferred)
 
 Folding `OwnerId`/`OwnerIdx` into one `NodeId`, renaming `OwnerGraph*` →

--- a/devinfra/js/debundle/CODE_REVIEW.md
+++ b/devinfra/js/debundle/CODE_REVIEW.md
@@ -12,7 +12,7 @@ The simulator (`realizability/esm_simulator.rs`), the incremental quotient + ove
 
 ### `vendor/mod.rs` further split
 
-Remaining: strip-specific helpers and export/package-resolution helpers could each lift out into their own modules alongside the already-extracted `vendor/{manifests,plan,strip,validate,wrappers}.rs`.
+The vendor-into-emission collapse left `vendor/{emission,manifests,passthrough,plan,strip,validate,wrappers}.rs` extracted and deleted the dispatcher/job plumbing; `mod.rs` (~1.3K lines + tests) still mixes package/subpath resolution helpers, export-surface collection helpers, `MaterializedOutputChunkIndex`, the shared import factories (`DeferredImport` / `IdentRewriteTarget` / `PartialSwapIdentRewriter` and the `make_*` constructors), and the post-strip consumer scan — each liftable into its own module.
 
 ### `purity/mod.rs` (~2570 lines) — remaining concerns
 
@@ -161,6 +161,6 @@ No longer a standalone crate — absorbed into `swc_ecma_minifier` as `pub(crate
 
 1. **Extract `gate_perf_counters` from `realizability/mod.rs`** — see the P0 item; needs the recording-API entanglement untangled first.
 
-2. **Continue splitting `vendor/mod.rs`** — manifests, plan, strip, wrappers, and validate/resolve helpers extracted; remaining: strip-specific helpers, export/package-resolution helpers.
+2. **Continue splitting `vendor/mod.rs`** — emission, manifests, passthrough, plan, strip, validate, wrappers extracted; remaining: package-resolution helpers, export-surface helpers, the import factories, the consumer scan.
 
 3. **Consolidate the data-shape follow-ups** — remove the remaining `ChunkBundle` ownership ping-pong.

--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -42,7 +42,7 @@ Not the round-trip minimum — the spec should exercise realistic-ish
 module extraction and rename paths, the same shape a private-corpus
 spec runs. Concretely:
 
-- `apply_vendor_annotations` + `swap_vendor_chunks` over a couple of
+- `vendor` marks with `level: swap` over a couple of
   Excalidraw's actual vendor chunks (React, Roughjs, Pointers, etc.)
   so vendor-swap edge cases (`named_from_default`,
   `named_from_module_default`, default-only, JSON-default) get covered
@@ -56,9 +56,9 @@ spec runs. Concretely:
 - A small set of `logical_modules` rename entries on identifiers
   visible in the compiled output. Goal: exercise the rename pipeline
   at realistic aggressiveness.
-- `emit_browser_harness`, relying on the always-on
-  `rewrite_chunk_entry_specifiers` transform, so the output is a
-  runnable app the live proxy can serve.
+- `emit_browser_harness`, relying on the always-on emission-time
+  specifier canonicalization, so the output is a runnable app the
+  live proxy can serve.
 
 The exact module list / rename list is part of the implementation —
 pick stable shapes that are unlikely to drift wildly when Excalidraw

--- a/devinfra/js/debundle/docs/design.md
+++ b/devinfra/js/debundle/docs/design.md
@@ -998,8 +998,8 @@ output, the Vite ecosystem, and most React/Vue/Angular SPAs.
   rejected — soundness over completeness: the target cannot be
   proven external. Non-literal specifiers in lazy positions are
   allowed and remain a documented residual gap (only `Lit::Str`
-  counts as literal, matching `prepare_js_chunks` /
-  `rewrite_chunk_entry_specifiers`).
+  counts as literal, matching `prepare_js_chunks` and the
+  pass-through emission rewriter in `vendor/passthrough.rs`).
 - **A4. No `with` blocks.** Banned in strict mode (which ESM is
   by spec). **Enforced (at parse)**: even with the parser's
   `no_early_errors: true` TypeScript syntax, `with` surfaces as a
@@ -2211,33 +2211,42 @@ status without building emitted JS.
 
 ### Pipeline trajectory
 
-The current pipeline (`pipeline.rs`) enumerates a long sequence of
-named stages — `LoadJsChunks`, `PrepareJsChunks`, `BuildArtifactIndexes`,
-`RewriteChunkEntrySpecifiers`, `ApplyVendorAnnotations`,
-`RenameVendorExports`, `SwapVendorChunks`, `MaterializeLogicalModules`,
-`ApplyPartialVendorSwaps`, `StripSwappedVendorExports`, `WriteJsTree`,
-`EmitBrowserHarness` — that read like a JS-file-tree-rewriting pipeline.
-That shape is a holdover: an earlier incarnation passed trees of JS
-files between stages and each stage rewrote them in place.
+The pipeline (`pipeline.rs`) is a fixed composition over three layers:
 
-The current analyzer operates on the owner graph and a partition, with
-late materialization to emitted JS at the end. Most of the named stages
-are orchestration overhead around what is, semantically, a small set of
-functions over `(owner_graph, partition)` plus the shared realizability
-primitive.
+- **Classify (input space).** Load + prepare (one parallel per-chunk
+  parse computing shallow program facts), then one read-only vendor
+  resolution pass (`build_vendor_resolution_plan`) that validates every
+  `vendor` mark, resolves boundary mappings / swap targets / per-symbol
+  tables, and runs the plan-time consumer gate before anything is
+  written. Spec selectors always match prepare-time input-space ASTs;
+  nothing mutates them.
+- **Plan.** Lowering plans plus the `VendorResolutionPlan` as the
+  single resolution oracle for import construction — both lowering's
+  per-plan directive construction and the emission-time rewriting of
+  non-lowered files consult it.
+- **Emit.** `materialize_logical_modules` is the single artifact
+  mutation wave; `apply_emission_rewrites` then performs the
+  pass-through directive rewrite (specifier canonicalization,
+  boundary-rename mapping, partial-swap consumer surgery) and computes
+  each partially-swapped vendor chunk's residual (self-rewrite + strip)
+  as one function body. Fully-swapped chunks are an emission-set
+  exclusion, not an artifact removal; wrappers / facades / manifests
+  are emission outputs.
 
-The direction of travel is to collapse the stage structure. Each stage
-becomes a function over the analyzer's typed state, the JS-tree
-intermediate snapshots between stages are dropped, and the pipeline
-becomes the composition of those functions. The unification of the
-gate and planner checks on the realizability primitive is a precondition
-for this collapse: it removes the parallel walks and planner-internal
-caches that made the stage boundaries necessary as state-passing seams.
+This is the landed shape of the vendor-into-emission collapse
+(`plans/vendor_into_emission.md`, tombstoned 2026-06): the former
+stage braid — specifier rewriting, vendor renaming, and swapping
+braided around materialization across seven artifact mutations — is
+gone, and vendor operations contribute zero mutation waves.
 
-The e2e tests in `devinfra/js/debundle/e2e/` pin observable chunk →
-emitted-JS behavior. They are the safety net that makes this collapse
-possible without behaviour drift. No timetable is committed; this
-section documents the direction.
+The remaining trajectory step is collapsing materialize-into-emit:
+`materialize_logical_modules` still writes lowered module files back
+into the chunk bundle for the emission stages to re-read, where the
+lowered outputs could feed `write_js_tree` / harness emission directly
+without the bundle round-trip. Tracked in ARCHITECTURE_BACKLOG.md; no
+timetable is committed. The e2e tests in `devinfra/js/debundle/e2e/`
+pin observable chunk → emitted-JS behavior and are the safety net for
+that step, as they were for the vendor collapse.
 
 ## Selector vocabulary and matching
 
@@ -2829,9 +2838,10 @@ and `owner_y`, then re-run quotient validation."
 
 The transform is a fixed data flow over explicit artifact phases:
 input loading produces loaded chunk data; preparation produces the
-parsed/prepared chunk artifact consumed by rewrite, vendor,
-logical-materialization, and output stages. The pipeline should not
-grow a second mutable "state" object parallel to those phase outputs.
+parsed/prepared chunk artifact consumed by the vendor plan,
+logical materialization, emission rewrites, and output emission. The
+pipeline should not grow a second mutable "state" object parallel to
+those phase outputs.
 
 The flat transform spec is YAML decoded directly into typed serde
 structures. It carries inputs, declarative data maps, and optional
@@ -2851,20 +2861,19 @@ peel-set hyperedges so authoring tools can mostly project and filter
 debundler facts instead of re-analyzing JavaScript or private repo
 YAML conventions.
 
-| Step                             | Module                       | Runs when                                                                                                                                                          |
-| -------------------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `load_transform_spec`            | <pipeline.rs>                | Always; loads either the flat YAML spec or the tree-shaped authoring spec.                                                                                         |
-| `validate_transform_spec`        | <spec.rs>                    | Always after spec load.                                                                                                                                            |
-| `load_js_chunks`                 | <artifact.rs>                | Always; configured by `inputs`.                                                                                                                                    |
-| `prepare_js_chunks`              | <prepare_chunks.rs>          | Always. In one parallel per-chunk pass, parses every chunk with SWC, computes shallow program facts, and canonicalizes entries.                                    |
-| `build_artifact_indexes`         | <artifact.rs>                | Always after preparation. Builds chunk id, source path, output path, and import-reference indexes for later stages.                                                |
-| `rewrite_chunk_entry_specifiers` | <rewrite_specifiers.rs>      | Always, after chunk preparation and before data-gated transforms.                                                                                                  |
-| `apply_vendor_annotations`       | <vendor/>                    | When the `vendor` map is non-empty.                                                                                                                                |
-| `rename_vendor_exports`          | <vendor/>                    | When a `vendor` entry has `level: boundary_rename` or `level: swap`.                                                                                               |
-| `swap_vendor_chunks`             | <vendor/>                    | When a `vendor` entry has `level: swap`.                                                                                                                           |
-| `materialize_logical_modules`    | <lowering/> + analysis files | When `logical_modules`, `unassigned_mode`, or `chunk_renames` is non-empty. Computes facts, quotients the owner graph into `I ∪ S`, validates, emits.              |
-| `write_js_tree`                  | <write_tree.rs>              | When `write_js_tree` output config is present; writes JS tree reports with exact `output_metrics` and directory reports when logical modules exist.                |
-| `emit_browser_harness`           | <emit_harness.rs>            | When `emit_browser_harness` output config is present; writes browser harness reports with exact `output_metrics` and directory reports when logical modules exist. |
+| Step                           | Module                        | Runs when                                                                                                                                                                                                                               |
+| ------------------------------ | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `load_transform_spec`          | <pipeline.rs>                 | Always; loads either the flat YAML spec or the tree-shaped authoring spec.                                                                                                                                                              |
+| `validate_transform_spec`      | <spec.rs>                     | Always after spec load.                                                                                                                                                                                                                 |
+| `load_js_chunks`               | <artifact.rs>                 | Always; configured by `inputs`.                                                                                                                                                                                                         |
+| `prepare_js_chunks`            | <prepare_chunks.rs>           | Always. In one parallel per-chunk pass, parses every chunk with SWC, computes shallow program facts, and canonicalizes entries.                                                                                                         |
+| `build_artifact_indexes`       | <artifact.rs>                 | Always after preparation. Builds chunk id, source path, output path, and import-reference indexes for later stages.                                                                                                                     |
+| `build_vendor_resolution_plan` | <vendor/plan.rs>              | Always after index build. Read-only: validates every `vendor` mark, resolves boundary mappings / swap targets / partial-swap symbol tables, runs the plan-time consumer gate.                                                           |
+| `materialize_logical_modules`  | <lowering/> + analysis files  | When `logical_modules`, `unassigned_mode`, or `chunk_renames` is non-empty. Computes facts, quotients the owner graph into `I ∪ S`, validates, emits.                                                                                   |
+| `apply_emission_rewrites`      | <vendor/emission.rs>          | Always. Pass-through directive rewrite (specifier canonicalization, boundary-rename mapping, partial-swap consumer surgery) over files emitted without lowering, plus the per-vendor-chunk residual composition (self-rewrite + strip). |
+| `validate_emitted_exports`     | <validate_emitted_exports.rs> | Always; duplicate-public-export tripwire over the emission set (excluded full-swap chunks are skipped).                                                                                                                                 |
+| `write_js_tree`                | <write_tree.rs>               | When `write_js_tree` output config is present; writes JS tree reports with exact `output_metrics` and directory reports when logical modules exist.                                                                                     |
+| `emit_browser_harness`         | <emit_harness.rs>             | When `emit_browser_harness` output config is present; writes browser harness reports with exact `output_metrics` and directory reports when logical modules exist.                                                                      |
 
 Within `materialize_logical_modules`, the substages are:
 
@@ -2922,29 +2931,51 @@ rather than missing features are documented here.
 
 ### Full swap: callers are proxy/import-map-dependent
 
-`level: swap` removes the vendor chunk from the artifact. Caller
-imports of the removed chunk are **intentionally left dangling** in
-the plain `write_js_tree` output: the live-proxy / import-map layer
-(<../live_proxy/>) resolves the dangling chunk specifier to the
-swapped package at serve time. The plain emitted tree is therefore
-not directly runnable under bare Node when a full swap is configured.
-Pinned by `full_swap_with_caller_keeps_dangling_chunk_import_for_live_proxy`
+`level: swap` excludes the vendor chunk from the **emission set** —
+nothing removes it from the artifact, and the owner graph never
+contained vendor chunks; `write_js_tree`, harness emission, the
+emit-shape check, and the chunk reports skip it, and a wrapper module
+is written in its place. Caller imports of the excluded chunk are
+**intentionally left dangling** in the plain `write_js_tree` output:
+the live-proxy / import-map layer (<../live_proxy/>) resolves the
+dangling chunk specifier to the swapped package at serve time. The
+plain emitted tree is therefore not directly runnable under bare Node
+when a full swap is configured. Pinned by
+`full_swap_with_caller_keeps_dangling_chunk_import_for_live_proxy`
 in <../e2e/vendor_swap_test.rs>.
 
-### Partial swap: consumer rewrites and the post-strip gate
+### Partial swap: consumer rewrites and the consumer gates
 
-Per-symbol partial swaps rewrite two consumer shapes in retained
-files: named `ImportDecl` specifiers and `export { x } from
-"<chunk>"` re-exports of swapped names (`kind: named` / `default` /
-`namespace`). Shapes with no live rewrite — `import * as M` namespace
-imports of the chunk, `export *` from the chunk, and re-exports of
-`kind: member` symbols or bundled-swap symbols — are rejected by the
-**post-strip consumer gate** (`validate_partial_swap_consumers`),
-which scans every retained file after the strip pass and bails on any
-surviving reference to the stripped export surface. Over-restriction
-is the accepted failure mode: a namespace consumer that happens to
-read only non-swapped members is still rejected, because per-member
-usage is not analyzed.
+Per-symbol partial swaps rewrite two consumer shapes — named
+`ImportDecl` specifiers and `export { x } from "<chunk>"` re-exports
+of swapped names (`kind: named` / `default` / `namespace`) — at two
+application sites driven by the same `VendorResolutionPlan` oracle:
+lowering's import construction for materialized module bodies, and
+the pass-through emission rewriter for files emitted without
+lowering. Shapes with no live rewrite — `import * as M` namespace
+imports of the chunk, `export *` from the chunk, re-exports of
+`kind: member` symbols or bundled-swap symbols, and any rewrite-needing
+consumer inside a hands-off `suppress`-marked chunk — are rejected by
+the **plan-time consumer gate**
+(`vendor/plan.rs::validate_consumer_shapes`) before any output is
+written.
+
+A second, post-strip scan (`validate_partial_swap_consumers` in
+<../vendor/mod.rs>) re-checks every retained file of the
+post-materialize artifact and bails on any surviving reference to the
+stripped export surface. It is load-bearing, not a redundant
+tripwire: lowering can synthesize consumer directives inside
+materialized module bodies (`BindingKind::Imported` re-export
+imports, `export … from` re-exports in moved bodies) that have no
+live rewrite at the construction site and that the plan-time gate —
+which enumerates input-space directives — cannot see. Retiring it
+requires construction-site coverage plus fixtures first (see
+ARCHITECTURE_BACKLOG.md "Post-strip consumer scan retirement
+condition").
+
+Over-restriction is the accepted failure mode for both gates: a
+namespace consumer that happens to read only non-swapped members is
+still rejected, because per-member usage is not analyzed.
 
 ### Deliberate split-brain bypasses in the strip pass
 
@@ -3582,9 +3613,9 @@ Primary:
 
 Secondary:
 
-- <vendor/>, <rewrite_specifiers.rs>, <emit_harness.rs>,
-  <write_tree.rs>, <identifier_rename_queue.rs> — supporting
-  transforms and side-output producers.
+- <vendor/>, <emit_harness.rs>, <write_tree.rs>,
+  <identifier_rename_queue.rs> — supporting transforms and
+  side-output producers.
 
 Tracking:
 

--- a/devinfra/js/debundle/docs/guide.md
+++ b/devinfra/js/debundle/docs/guide.md
@@ -645,7 +645,7 @@ Typical debundle outputs include:
 - executable JS under `app/`
 - root reports under `reports/`: `output.json`, `chunks.json`,
   `runtime.json`, `source_assets.json`, `provenance.json`,
-  `rename_queue.json`, `vendor_swaps.json` when those stages run
+  `rename_queue.json`, `vendor_swaps.json` when those outputs are configured
 - per-chunk reports under `reports/tree/<chunk-id>/`: `chunk.json`,
   `modules.json`, `owner_graph.json`
 - `reports/tree/<chunk-id>/cycles.json` or

--- a/devinfra/js/debundle/e2e/vendor_swap_test.rs
+++ b/devinfra/js/debundle/e2e/vendor_swap_test.rs
@@ -2102,8 +2102,9 @@ fn run_partial_swap_kind_fixture(args: PartialSwapKindFixtureArgs<'_>) -> Partia
 // "<chunk>"` namespace imports. Re-exports of `named`/`default`/`namespace`
 // kind symbols are rewritten against the upstream package; everything else
 // (member-kind re-exports, namespace imports, `export *`) must make the
-// pipeline bail — the strip pass removes those names from the chunk's
-// export surface, so an unrewritten consumer either link-fails (re-export)
+// pipeline bail (the plan-time consumer gate rejects them before any
+// output) — the strip pass removes those names from the chunk's export
+// surface, so an unrewritten consumer either link-fails (re-export)
 // or silently reads `undefined` (namespace member).
 
 fn setup_partial_swap_consumer_fixture(
@@ -2326,8 +2327,8 @@ fn partial_swap_rewrites_namespace_kind_reexport_from_consumer() {
 fn partial_swap_bails_on_namespace_import_of_partially_swapped_chunk() {
     // `import * as M from "<chunk>"` then `M.e6` — the strip pass removes
     // `e6` from the chunk's export surface, so the member read would
-    // silently evaluate to `undefined` at runtime. The post-strip consumer
-    // gate must reject the spec instead of emitting the broken tree.
+    // silently evaluate to `undefined` at runtime. The consumer gate must
+    // reject the spec instead of emitting the broken tree.
     let (ws, package_root) = setup_partial_swap_consumer_fixture(
         "vendor-partial-swap-namespace-consumer-",
         "export const e6 = () => true;\nexport const keepMe = () => 7;\n",

--- a/devinfra/js/debundle/perf/proposer.md
+++ b/devinfra/js/debundle/perf/proposer.md
@@ -237,7 +237,7 @@ Tighten before the next large peel loop:
 - Add focused regression coverage for `ArtifactIndexes` rebuild
   boundaries as more structural artifact mutations are optimized.
 - Profile the debundle action around `materialize_logical_modules` and
-  `rename_vendor_exports`; avoid whole-graph clone/rescan patterns where
+  `apply_emission_rewrites`; avoid whole-graph clone/rescan patterns where
   a graph pass or indexed lookup can answer the same question.
 - Consider changing per-chunk `file_records` from an ordered vector of
   `(file, role)` pairs into a typed map if output consumers do not depend

--- a/devinfra/js/debundle/pipeline.rs
+++ b/devinfra/js/debundle/pipeline.rs
@@ -299,10 +299,11 @@ pub fn run_transform_cli_with_options(
     vendor_report.strip_stats = strip_stats;
 
     if vendor_plan.has_partial_swaps() || vendor_plan.has_bundled_partial_swaps() {
-        // Post-strip differential tripwire behind the plan-time
-        // consumer gate (vendor_into_emission §3.2, open question 4):
-        // no retained file may still consume the stripped portion of a
-        // partially-swapped chunk's export surface.
+        // Post-strip consumer gate: no retained file may still consume
+        // the stripped portion of a partially-swapped chunk's export
+        // surface. Load-bearing behind the plan-time gate — it covers
+        // directives lowering synthesized inside materialized module
+        // bodies (see `validate_partial_swap_consumers`).
         validate_partial_swap_consumers(indexed.artifact(), &vendor_plan, indexed.indexes())?;
     }
     (vendor_report.partial, vendor_report.bundled_partial) =

--- a/devinfra/js/debundle/plans/sanitization_program_2026_06.md
+++ b/devinfra/js/debundle/plans/sanitization_program_2026_06.md
@@ -1,5 +1,39 @@
 # Debundle sanitization program — 2026-06
 
+> **Status (2026-06-12): program complete**, except the explicitly
+> deferred items below — each re-filed in its tracking doc, none
+> silently dropped. Track A landed (A1 `IndexedArtifact` threading in
+> #2077, A2 crate split, A3 decision batch closed). Track B
+> (RenameLedger) complete. Track C (vendor-into-emission) complete —
+> `plans/vendor_into_emission.md` is tombstoned with the PR list
+> (#2110/#2112/#2119/#2123/#2127/#2129 + close-out) and per-open-question
+> resolutions; `validate_emitted_exports` was kept as a tripwire (the
+> collapse did not make it provably redundant), and the post-strip
+> consumer scan was also kept (open question 4's escape clause fired —
+> see the tombstone). Track D landed except item 4. Track E landed.
+> Track F: F1/F2 landed except F1's remaining harness migration; F4
+> partially landed; F3 deferred.
+>
+> Still open after program close:
+>
+> - **F3 Excalidraw public smoke** — deferred pending maintainer
+>   discussion; the design entry stays in TODO.md ("Excalidraw
+>   live-browser smoke").
+> - **Track D item 4** — the `program_analysis.rs` fold into the facts
+>   walk, deferred with the architectural rationale recorded below
+>   (prepare-time vs stage-one computation and crate boundaries);
+>   CODE_REVIEW.md's "Two parallel top-level fact extractors" P1 entry
+>   stays open.
+> - **F1 remaining step** — migrating `peel/gate_differential_test.rs`
+>   from its deterministic xorshift sweep to proptest strategies (the
+>   condensation-order and rename-ledger proptest suites landed; the
+>   harness still carries its "placeholder for the Track F1 proptest"
+>   marker).
+> - **F4 small test debt** — support.rs builder consolidation, the
+>   hardcoded entry path in `assert_generated_module_after_entry_script`,
+>   and whitespace OR-chain assertions remain open as CODE_REVIEW.md P5
+>   entries.
+
 A ~3-week program of structural cleanups following the 2026-06-11 full review
 and its 16-PR fix wave (#2044–#2073). Goal: convert the remaining
 convention-held invariants into structure, make module boundaries

--- a/devinfra/js/debundle/plans/vendor_into_emission.md
+++ b/devinfra/js/debundle/plans/vendor_into_emission.md
@@ -1,5 +1,59 @@
 # Vendor-into-emission: collapsing the vendor waves into plan/emit
 
+> **TOMBSTONE (2026-06-12): completed.** All six PRs landed — #2110
+> (this design), #2112 (PR 1: `vendor/validate.rs` extraction + typed
+> `ChunkId`), #2119 (PR 2: `VendorResolutionPlan` computed once
+> post-prepare; manifests become plan projections), #2123 (PR 3:
+> lowering constructs vendor-swap imports for materialized module
+> bodies), #2127 (PR 4: unified pass-through directive rewriter +
+> plan-time consumer gate; `rewrite_specifiers.rs` deleted), #2129
+> (PR 5: full swap → emission-set exclusion; strip → vendor emission as
+> one function body), and the PR 6 close-out. The pipeline body is
+> load → prepare → classify/plan → materialize → emission rewrites →
+> emit → reports; vendor contributes zero mutation waves. docs/design.md
+> ("Pipeline trajectory", "Vendor chunk swapping") describes the landed
+> shape. The §4 next trajectory step — materialize-into-emit — is filed
+> in ARCHITECTURE_BACKLOG.md. The body below is retained as design
+> history only.
+>
+> Open-question resolutions:
+>
+> 1. **`ImportTarget` placement** — landed per recommendation as a
+>    planner-boundary enum, narrower still than the sketch:
+>    `lowering/vendor_imports.rs::ImportTarget` is lowering-local and
+>    even the `Module(ModuleId)` variant is deferred until a list
+>    actually mixes module and external targets. `ModuleId` untouched.
+> 2. **External import ordering inside module files** — accepted as
+>    designed: package imports join the runtime re-import block; entry /
+>    pass-through directives are rewritten in position. Pinned by the
+>    bundled-swap runtime fixture.
+> 3. **Suppress-level byte-compat** — resolved per recommendation:
+>    suppress-marked chunks skip the emission rewriter wholesale
+>    (`vendor/passthrough.rs`), making the documented "hands-off"
+>    contract true; the plan-time consumer gate rejects suppress files
+>    whose imports would have needed rewriting.
+> 4. **Retiring the post-emission consumer scan** — **the escape clause
+>    fired; the scan stays.** The #2062 fixtures all fail at plan time
+>    (they are pass-through consumers), but §3.2's "coverage is equal by
+>    construction" claim is corrected: the scan covers a class the
+>    plan-time gate's input-space enumeration cannot see — consumer
+>    directives lowering synthesizes inside materialized module bodies
+>    (`BindingKind::Imported` re-export imports in `lowering/lower.rs`,
+>    `export … from` re-exports in moved bodies), which have no live
+>    rewrite at the construction site. `validate_partial_swap_consumers`
+>    is therefore retained as load-bearing coverage, not a differential
+>    tripwire; the retirement condition (construction-site coverage +
+>    fixtures) is filed in ARCHITECTURE_BACKLOG.md.
+> 5. **Strip's local re-analysis** — kept as designed: the residual
+>    computation re-runs `analyze_chunk` on the post-self-rewrite
+>    module; the manifest-facts rule governs input-space facts only.
+> 6. **`references_rewritten` drift** — no drift to adjudicate: the
+>    PR 3 parity fixture pinned count equality across the application
+>    sites; the field keeps counting emitted references.
+>
+> `validate_emitted_exports` is kept per the §3.3 ruling, re-pointed at
+> the emission set in PR 5 (it skips excluded full-swap chunks).
+
 Design for Track C of `plans/sanitization_program_2026_06.md` — the last
 genuinely unnatural pipeline ordering: vendor operations braided around
 materialization (full swaps before, partial swaps + strip after), three

--- a/devinfra/js/debundle/vendor/mod.rs
+++ b/devinfra/js/debundle/vendor/mod.rs
@@ -1116,9 +1116,7 @@ fn make_namespace_reexport(source: &str, exported: &str) -> ModuleItem {
     }))
 }
 
-/// Post-strip cross-chunk soundness gate for partial vendor swaps —
-/// retained as a **differential tripwire** behind the plan-time
-/// consumer gate (vendor_into_emission §3.2, open question 4).
+/// Post-strip cross-chunk soundness gate for partial vendor swaps.
 ///
 /// The pass-through emission rewriter and lowering's import
 /// construction rewrite `ImportDecl` named specifiers (and, for
@@ -1132,14 +1130,17 @@ fn make_namespace_reexport(source: &str, exported: &str) -> ModuleItem {
 ///   for swapped members;
 /// * `export *` silently drops the swapped names from the re-exporter.
 ///
-/// The plan-time gate rejects these shapes before any emission; this
-/// scan re-checks the post-strip artifact, additionally covering
-/// directives that lowering moved into or synthesized inside
-/// materialized module bodies (e.g. `export … from` re-exports in moved
-/// bodies and `BindingKind::Imported` re-export imports — shapes with
-/// no live rewrite at the construction site). PR 6 of the plan retires
-/// it only with fixture evidence that the plan-time gate fires on every
-/// case this scan does.
+/// The plan-time gate (`plan.rs::validate_consumer_shapes`) rejects
+/// these shapes in input space before any emission. This scan is not a
+/// redundant tripwire behind it: it re-checks the post-materialize
+/// artifact, covering directives that lowering moved into or
+/// synthesized inside materialized module bodies (`export … from`
+/// re-exports in moved bodies, `BindingKind::Imported` re-export
+/// imports) — shapes with no live rewrite at the construction site,
+/// invisible to the plan-time gate's input-space enumeration. Retire it
+/// only after those construction paths consult the plan and fixtures
+/// pin the synthesized-directive shapes (ARCHITECTURE_BACKLOG.md
+/// "Post-strip consumer scan retirement condition").
 ///
 /// Scan every retained file of every chunk and bail with a precise
 /// diagnostic on the first surviving consumer. Over-restriction is the

--- a/devinfra/js/debundle/vendor/plan.rs
+++ b/devinfra/js/debundle/vendor/plan.rs
@@ -150,8 +150,7 @@ impl VendorResolutionPlan {
 
     /// Boundary-rename mapping consult for construction-time naming
     /// (vendor_into_emission §2.4): vendor-local export name → public
-    /// name for a `boundary_rename` / `swap` chunk. Load-bearing since
-    /// the pre-materialize `rename_vendor_exports` wave was deleted:
+    /// name for a `boundary_rename` / `swap` chunk. Load-bearing:
     /// source ASTs reach lowering with the vendor-local names, and the
     /// public name is applied at import construction.
     pub fn boundary_public_export_name(&self, chunk: ChunkId, vendor_local: &str) -> Option<&str> {
@@ -391,10 +390,11 @@ fn validate_full_swap_import_alignment(
 /// shapes that have no live rewrite at either application site — before
 /// any output is written. The classification is the same one the
 /// rewriters perform, so a consumer the rewriter misses cannot pass the
-/// gate. The post-strip `validate_partial_swap_consumers` scan stays on
-/// as a differential tripwire (it additionally covers directives that
-/// lowering moves or synthesizes inside materialized module bodies)
-/// until PR 6 retires it with fixture evidence.
+/// gate. This enumeration sees input space only; the post-strip
+/// `validate_partial_swap_consumers` scan stays on as load-bearing
+/// coverage for directives that lowering moves or synthesizes inside
+/// materialized module bodies (see its doc for the retirement
+/// condition).
 ///
 /// Over-restriction is the accepted failure mode: a namespace consumer
 /// reading only unswapped members is still rejected.


### PR DESCRIPTION
Final PR of the vendor-into-emission series (`plans/vendor_into_emission.md`, #2110; implementation PRs #2112 / #2119 / #2123 / #2127 / #2129 — all merged). §8's PR-6 row: remaining deletions, doc sync, tombstone.

## Tripwire-retirement decision: the post-strip consumer scan STAYS

Open question 4's escape clause fired. Evidence assessment:

- **What the #2062 fixtures show**: all consumer-gate fixtures (`partial_swap_bails_on_{namespace_import,member_kind_reexport,export_star}…`) use pass-through consumers (no `logical_modules`), so they fail at **plan time** — `build_vendor_resolution_plan` runs before any emission, and both gates emit identical `partial-swap consumer gate:` diagnostics. For pass-through shapes, plan-time coverage is demonstrated.
- **What they do not show**: the scan covers a reachable class the plan-time gate **cannot** see by construction. The plan gate enumerates input-space directives; lowering can *synthesize* consumer directives inside materialized module bodies — `BindingKind::Imported` re-export imports (`lowering/lower.rs` builds these via `imported_binding_named_specifier` without consulting the `VendorReimportOracle`) and `export … from` re-exports in moved bodies. Those have no live rewrite at the construction site, and the pass-through emission rewriter skips `FileRole::Module` files. The post-strip scan is the only check on that path.
- **Ruling**: §3.2's "coverage is equal by construction" claim is corrected per the doc's own instruction ("if any case is reachable post-emission but not at plan time, the scan stays and this doc's claim gets corrected"). `validate_partial_swap_consumers` is retained as **load-bearing coverage**, not a differential tripwire; its doc comment, `vendor/plan.rs`, and `pipeline.rs` comments now say so. The retirement condition — construction-site plan consultation plus fixtures pinning the synthesized-directive shapes — is filed in `ARCHITECTURE_BACKLOG.md` ("Post-strip consumer scan retirement condition").

`validate_emitted_exports` stays per the §3.3 ruling (kept as tripwire; already re-pointed at the emission set in PR 5 via `excluded_chunk_ids`).

## Deletions

The §7 code deletions all landed in PRs 4–5 (`rewrite_specifiers.rs`, `swap_vendor_chunks` stage, `removed_chunk_ids` retain-dance, dispatcher/job plumbing, `rename_vendor_exports` sweep); this PR's sweep found **no remaining dead code** — `MaterializedOutputChunkIndex` and `resolve_materialized_output_import_target` survive deliberately as the resolution substrate shared by the plan gate / oracle / scan. What remained was stale prose: deleted-stage references in `docs/design.md`, `AGENTS.md`, `TODO.md`, `perf/proposer.md`, `docs/guide.md`, two e2e fixture comments mis-attributing rejections to the post-strip gate, and a historical clause in `vendor/plan.rs`.

## Doc sync

- **`docs/design.md`**: "Pipeline trajectory" rewritten — the collapse it described as direction-of-travel is done; it now describes the landed Classify / Plan / Emit shape and records the remaining step (materialize-into-emit, also filed in `ARCHITECTURE_BACKLOG.md`). Architecture stage table updated (deleted stages out; `build_vendor_resolution_plan`, `apply_emission_rewrites`, `validate_emitted_exports` in). "Vendor chunk swapping" updated: full swap as emission-set exclusion; "Partial swap" section now describes both consumer gates and why the post-strip one is load-bearing. Dead `rewrite_specifiers.rs` file reference removed.
- **`AGENTS.md`**: "Spec-level inputs" and transform-order paragraphs no longer name `rewrite_chunk_entry_specifiers`; canonicalization is described at its emission-time home (`vendor/passthrough.rs`).
- **README**: no stale pipeline cheat-sheet found (verified — it documents commands, not stages).
- **`docs/wire_format.md`**: verified no change needed — manifest shapes were preserved by design (§5; `VendorResolution` / partial / bundled / strip-stats serialize as before).

## Tombstone + program close-out

- `plans/vendor_into_emission.md` tombstoned (dated, PR list, all six open-question resolutions — including OQ3 suppress-skip, OQ6 no `references_rewritten` drift, and the OQ4 ruling above). The §2.5/§4 next-trajectory step (materialize-into-emit) is recorded in `ARCHITECTURE_BACKLOG.md` so it isn't lost.
- `plans/sanitization_program_2026_06.md` gets a dated close-out header: **program complete** except — F3 Excalidraw smoke (deferred pending maintainer discussion; TODO.md design entry kept), Track D item 4 `program_analysis` fold (deferred with architectural rationale; CODE_REVIEW P1 entry stays open), F1's remaining gate-differential proptest migration (harness still carries its xorshift placeholder marker — verified at HEAD), and F4 small test debt (still open as CODE_REVIEW P5 entries).

## Backlog sweep

- `CODE_REVIEW.md` "vendor/mod.rs further split" updated to HEAD reality (seven extracted modules; what actually remains in the ~1.3K-line `mod.rs`); "Top Highest-Impact Actions" item 2 matched. The PR 1/2 entries (validate/resolve dedup, typed chunk identity, `ResolutionManifest<R>`) were already deleted by their PRs.
- `ARCHITECTURE_BACKLOG.md`: two new entries (materialize-into-emit; consumer-scan retirement condition). No entries found that the collapse resolved and nobody deleted.
- `TODO.md`: Excalidraw entry kept (per F3 deferral), de-staled.

## Verification

- `bbr test //devinfra/js/debundle/...` — 106/106 pass (`fc19c87d-4915-41cd-baac-8f3adcc8ce2a`)
- `bbr build //...` — green (`f112f2f9-6942-48db-865d-2649b7b268d9`)
- No production behavior change: `.rs` edits are comments only.

https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGbmY298bxThK5ytoTUJEk)_