### PR TITLE
fix wayback archive runtime image

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -351,7 +351,15 @@ apt.install(
     lock = "//loom/gym:bookworm_loom_gym_eval.lock.json",
     manifest = "//loom/gym:bookworm_loom_gym_eval.yaml",
 )
-use_repo(apt, "bookworm_cpap_sync", "bookworm_fc_vm_pod", "bookworm_loom_gym_eval", "gnome_shell_test", "trixie_attic_rotation", "trixie_budget_exporter", "trixie_ca_certificates", "trixie_e2e", "trixie_jwt_rotation")
+
+# wayback archive service: libssl + CA bundle on debian:trixie-slim for the
+# Rust runtime image.
+apt.install(
+    name = "trixie_wayback_archive",
+    lock = "//loom/wayback_archive:trixie_wayback_archive.lock.json",
+    manifest = "//loom/wayback_archive:trixie_wayback_archive.yaml",
+)
+use_repo(apt, "bookworm_cpap_sync", "bookworm_fc_vm_pod", "bookworm_loom_gym_eval", "gnome_shell_test", "trixie_attic_rotation", "trixie_budget_exporter", "trixie_ca_certificates", "trixie_e2e", "trixie_jwt_rotation", "trixie_wayback_archive")
 
 # JavaScript/TypeScript (Node.js frontends)
 bazel_dep(name = "aspect_bazel_lib", version = "2.22.5")

--- a/loom/wayback_archive/BUILD.bazel
+++ b/loom/wayback_archive/BUILD.bazel
@@ -2,6 +2,12 @@ load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
 
+# Apt manifest + lockfile for rules_distroless (referenced from MODULE.bazel).
+exports_files([
+    "trixie_wayback_archive.yaml",
+    "trixie_wayback_archive.lock.json",
+])
+
 rust_library(
     name = "wayback_archive_lib",
     srcs = [
@@ -56,10 +62,13 @@ pkg_tar(
 
 oci_image(
     name = "image",
-    base = "@debian_slim_linux_amd64",
+    base = "@debian_trixie_slim_linux_amd64",
     entrypoint = ["/usr/local/bin/wayback_archive"],
     labels = {"org.opencontainers.image.source": "https://github.com/agentydragon/ducktape"},
-    tars = [":binary_layer"],
+    tars = [
+        "@trixie_wayback_archive//:flat",
+        ":binary_layer",
+    ],
     user = "1000:1000",
     visibility = ["//visibility:public"],
 )

--- a/loom/wayback_archive/trixie_wayback_archive.lock.json
+++ b/loom/wayback_archive/trixie_wayback_archive.lock.json
@@ -1,0 +1,192 @@
+{
+  "packages": [
+    {
+      "arch": "amd64",
+      "dependencies": [
+        {
+          "key": "debconf_1.5.91_amd64",
+          "name": "debconf",
+          "version": "1.5.91"
+        },
+        {
+          "key": "openssl_3.5.4-1_deb13u2_amd64",
+          "name": "openssl",
+          "version": "3.5.4-1~deb13u2"
+        },
+        {
+          "key": "libssl3t64_3.5.4-1_deb13u2_amd64",
+          "name": "libssl3t64",
+          "version": "3.5.4-1~deb13u2"
+        },
+        {
+          "key": "openssl-provider-legacy_3.5.4-1_deb13u2_amd64",
+          "name": "openssl-provider-legacy",
+          "version": "3.5.4-1~deb13u2"
+        },
+        {
+          "key": "libc6_2.41-12-p-deb13u1_amd64",
+          "name": "libc6",
+          "version": "2.41-12+deb13u1"
+        },
+        {
+          "key": "libgcc-s1_14.2.0-19_amd64",
+          "name": "libgcc-s1",
+          "version": "14.2.0-19"
+        },
+        {
+          "key": "gcc-14-base_14.2.0-19_amd64",
+          "name": "gcc-14-base",
+          "version": "14.2.0-19"
+        },
+        {
+          "key": "zlib1g_1-1.3.dfsg-p-really1.3.1-1-p-b1_amd64",
+          "name": "zlib1g",
+          "version": "1:1.3.dfsg+really1.3.1-1+b1"
+        },
+        {
+          "key": "libzstd1_1.5.7-p-dfsg-1_amd64",
+          "name": "libzstd1",
+          "version": "1.5.7+dfsg-1"
+        }
+      ],
+      "key": "ca-certificates_20250419_amd64",
+      "name": "ca-certificates",
+      "sha256": "ef590f89563aa4b46c8260d49d1cea0fc1b181d19e8df3782694706adf05c184",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/c/ca-certificates/ca-certificates_20250419_all.deb"
+      ],
+      "version": "20250419"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "debconf_1.5.91_amd64",
+      "name": "debconf",
+      "sha256": "1ddc7e6c5925f748eefb7ca811d98e049f18c158bb21fbc7e122262ce6011e49",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/d/debconf/debconf_1.5.91_all.deb"
+      ],
+      "version": "1.5.91"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "openssl_3.5.4-1_deb13u2_amd64",
+      "name": "openssl",
+      "sha256": "583f2881a9ed89e480d46caa3de39a6f0e174d259077a98c8b6cc3d46166e1e5",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian-security/20260301T000000Z/pool/updates/main/o/openssl/openssl_3.5.4-1~deb13u2_amd64.deb"
+      ],
+      "version": "3.5.4-1~deb13u2"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [
+        {
+          "key": "openssl-provider-legacy_3.5.4-1_deb13u2_amd64",
+          "name": "openssl-provider-legacy",
+          "version": "3.5.4-1~deb13u2"
+        },
+        {
+          "key": "zlib1g_1-1.3.dfsg-p-really1.3.1-1-p-b1_amd64",
+          "name": "zlib1g",
+          "version": "1:1.3.dfsg+really1.3.1-1+b1"
+        },
+        {
+          "key": "libc6_2.41-12-p-deb13u1_amd64",
+          "name": "libc6",
+          "version": "2.41-12+deb13u1"
+        },
+        {
+          "key": "libgcc-s1_14.2.0-19_amd64",
+          "name": "libgcc-s1",
+          "version": "14.2.0-19"
+        },
+        {
+          "key": "gcc-14-base_14.2.0-19_amd64",
+          "name": "gcc-14-base",
+          "version": "14.2.0-19"
+        },
+        {
+          "key": "libzstd1_1.5.7-p-dfsg-1_amd64",
+          "name": "libzstd1",
+          "version": "1.5.7+dfsg-1"
+        }
+      ],
+      "key": "libssl3t64_3.5.4-1_deb13u2_amd64",
+      "name": "libssl3t64",
+      "sha256": "4a832fbdfc6ae292e4846eab6a6bf3687958c37ebcfd970e49169774d66d1231",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian-security/20260301T000000Z/pool/updates/main/o/openssl/libssl3t64_3.5.4-1~deb13u2_amd64.deb"
+      ],
+      "version": "3.5.4-1~deb13u2"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "openssl-provider-legacy_3.5.4-1_deb13u2_amd64",
+      "name": "openssl-provider-legacy",
+      "sha256": "69e406fb6f02261bc6ea3477fc38bab86fd66afc6d58a946e51d7832ae8c89e1",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian-security/20260301T000000Z/pool/updates/main/o/openssl/openssl-provider-legacy_3.5.4-1~deb13u2_amd64.deb"
+      ],
+      "version": "3.5.4-1~deb13u2"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libc6_2.41-12-p-deb13u1_amd64",
+      "name": "libc6",
+      "sha256": "0a51c7ba7c59b3c664b836fe33c5184e6f5a869f57e86613381e954d74282b66",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/g/glibc/libc6_2.41-12+deb13u1_amd64.deb"
+      ],
+      "version": "2.41-12+deb13u1"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libgcc-s1_14.2.0-19_amd64",
+      "name": "libgcc-s1",
+      "sha256": "3c71917b490d1a17aed43196a2787a256ecf060526cdb20216a74bedc061b150",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/g/gcc-14/libgcc-s1_14.2.0-19_amd64.deb"
+      ],
+      "version": "14.2.0-19"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "gcc-14-base_14.2.0-19_amd64",
+      "name": "gcc-14-base",
+      "sha256": "5b6825de4263824b78c4c51f6476414f3b4e89c2ab63e81dc8b9b5501e867cf6",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/g/gcc-14/gcc-14-base_14.2.0-19_amd64.deb"
+      ],
+      "version": "14.2.0-19"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "zlib1g_1-1.3.dfsg-p-really1.3.1-1-p-b1_amd64",
+      "name": "zlib1g",
+      "sha256": "015be740d6236ad114582dea500c1d907f29e16d6db00566ca32fb68d71ac90d",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/z/zlib/zlib1g_1.3.dfsg+really1.3.1-1+b1_amd64.deb"
+      ],
+      "version": "1:1.3.dfsg+really1.3.1-1+b1"
+    },
+    {
+      "arch": "amd64",
+      "dependencies": [],
+      "key": "libzstd1_1.5.7-p-dfsg-1_amd64",
+      "name": "libzstd1",
+      "sha256": "2f6a2aeacfc925eba8b00ac9139bc4bfccf8cacb09eb93de067074b26948eef9",
+      "urls": [
+        "https://snapshot.debian.org/archive/debian/20260301T000000Z/pool/main/libz/libzstd/libzstd1_1.5.7+dfsg-1_amd64.deb"
+      ],
+      "version": "1.5.7+dfsg-1"
+    }
+  ],
+  "version": 1
+}

--- a/loom/wayback_archive/trixie_wayback_archive.yaml
+++ b/loom/wayback_archive/trixie_wayback_archive.yaml
@@ -1,0 +1,21 @@
+# Runtime deb packages layered on debian:trixie-slim for the Rust wayback
+# archive image. The binary is built on the RBE worker and currently links
+# OpenSSL through root-manifest feature unification, so the container needs
+# libssl at runtime. Trixie also satisfies the binary's GLIBC_2.39 requirement.
+#
+# Regenerate the lock file after any change:
+#   bazel run @trixie_wayback_archive//:lock
+version: 1
+
+sources:
+  - channel: trixie main
+    url: https://snapshot.debian.org/archive/debian/20260301T000000Z
+  - channel: trixie-security main
+    url: https://snapshot.debian.org/archive/debian-security/20260301T000000Z
+
+archs:
+  - "amd64"
+
+packages:
+  - "ca-certificates"
+  - "libssl3t64"


### PR DESCRIPTION
## Summary
- move the wayback archive Rust image to Debian 13 slim so it satisfies the RBE-built binary's GLIBC_2.39 requirement
- add a pinned Trixie runtime apt layer for libssl3t64 and ca-certificates

## Validation
- `bbr build //loom/wayback_archive:image --remote_download_outputs=toplevel`
- `bbr test //loom/wayback_archive:wayback_archive_test`
- `pre-commit run --files MODULE.bazel loom/wayback_archive/BUILD.bazel loom/wayback_archive/trixie_wayback_archive.yaml loom/wayback_archive/trixie_wayback_archive.lock.json`