### PR TITLE
fix wayback archive IA TLS client

### DIFF
--- a/loom/wayback_archive/BUILD.bazel
+++ b/loom/wayback_archive/BUILD.bazel
@@ -23,6 +23,7 @@ rust_library(
         "@crates//:anyhow",
         "@crates//:bytes",
         "@crates//:http",
+        "@crates//:log",
         "@crates//:object_store",
         "@crates//:prometheus",
         "@crates//:reqwest",

--- a/loom/wayback_archive/lib.rs
+++ b/loom/wayback_archive/lib.rs
@@ -7,6 +7,7 @@ use anyhow::{Context, Result, anyhow};
 use async_trait::async_trait;
 use bytes::Bytes;
 use http::{HeaderMap, StatusCode};
+use log::warn;
 use object_store::aws::AmazonS3Builder;
 use object_store::path::Path as ObjectPath;
 use object_store::{ObjectStore, ObjectStoreExt, PutPayload};
@@ -720,6 +721,7 @@ impl ReqwestIaClient {
             web_upstream: web_upstream.trim_end_matches('/').to_string(),
             availability_upstream: availability_upstream.trim_end_matches('/').to_string(),
             client: reqwest::Client::builder()
+                .use_rustls_tls()
                 .redirect(reqwest::redirect::Policy::none())
                 .user_agent("ducktape-wayback-archive/1 (+agentydragon@gmail.com)")
                 .build()?,
@@ -1352,7 +1354,12 @@ impl ArchiveService {
                 }
                 stored_metadata_response(metadata)
             }
-            Err(_error) => {
+            Err(error) => {
+                warn!(
+                    "IA metadata fetch failed for endpoint={} query={}: {error:#}",
+                    request.key.endpoint.as_str(),
+                    request.key.normalized_query
+                );
                 limiter.record(AcquisitionOutcome::TransientFailure).await;
                 ArchiveResponse::retry_after(request.key.endpoint)
             }
@@ -1417,7 +1424,11 @@ impl ArchiveService {
                 }
                 stored_replay_response(replay)
             }
-            Err(_error) => {
+            Err(error) => {
+                warn!(
+                    "IA replay fetch failed for capture_ts={} modifier={} original_url={}: {error:#}",
+                    key.capture_ts, key.modifier, key.original_url
+                );
                 self.replay_limiter
                     .record(AcquisitionOutcome::TransientFailure)
                     .await;


### PR DESCRIPTION
## Summary
- force the wayback archive IA client to use reqwest/rustls instead of feature-unified native TLS
- log upstream IA metadata/replay fetch errors before backing off
- add the `log` crate to the archive library Bazel deps

## Validation
- `pre-commit run --files loom/wayback_archive/lib.rs loom/wayback_archive/BUILD.bazel`
- `bbr test //loom/wayback_archive:wayback_archive_test` (BuildBuddy invocation `e3548611-c881-434a-a131-bac2f1fa5b65`)
- `bbr build //loom/wayback_archive:image --remote_download_outputs=toplevel` (BuildBuddy invocation `948a9bff-c5e3-4281-9946-0ab01bc9cdaf`)

## Notes
Manual in-cluster testing of the deployed image showed the archive service could TCP-connect to archive.org/web.archive.org but immediately returned `503 archive acquisition is backing off`. A direct curl pod in the same namespace succeeded against IA, while the archive image lacked the generated `/etc/ssl/certs/ca-certificates.crt` bundle. Forcing rustls avoids depending on the distroless postinst-generated OpenSSL bundle.