### PR TITLE
Bound wayback archive upstream timeouts

### DIFF
--- a/cluster/k8s/wayback-cache/deployment.yaml
+++ b/cluster/k8s/wayback-cache/deployment.yaml
@@ -44,6 +44,12 @@ spec:
               value: https://archive.org
             - name: WAYBACK_ARCHIVE_MAX_QUEUE_WAIT_SECONDS
               value: "60"
+            - name: WAYBACK_ARCHIVE_AVAILABILITY_TIMEOUT_SECONDS
+              value: "15"
+            - name: WAYBACK_ARCHIVE_CDX_TIMEOUT_SECONDS
+              value: "45"
+            - name: WAYBACK_ARCHIVE_REPLAY_TIMEOUT_SECONDS
+              value: "60"
             - name: WAYBACK_ARCHIVE_MAX_BODY_BYTES
               value: "10485760"
             - name: WAYBACK_ARCHIVE_MAX_METADATA_BYTES

--- a/loom/wayback_archive/PLAN.md
+++ b/loom/wayback_archive/PLAN.md
@@ -324,11 +324,11 @@ classification in the archive service because it needs Wayback-specific context.
 
 Initial v0 guesses from the eval data:
 
-| endpoint     | initial | min | max | timeout | reasoning                                                                                                                                  |
-| ------------ | ------- | --- | --- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| Availability | 8       | 1   | 32  | 10s     | Recent eval saw Availability stay healthy; keep it from becoming the bottleneck, but still back off on signal.                             |
-| CDX          | 2       | 1   | 6   | 120s    | CDX was around half `5xx` under the current static setup and has 10-25s latency, so start much lower than the implied old in-flight level. |
-| Replay       | 2       | 1   | 8   | 60s     | Replay was also high-`5xx`; allow modest parallelism for independent content fetches but adapt separately from CDX.                        |
+| endpoint     | initial | min | max | timeout | reasoning                                                                                                                                                                                       |
+| ------------ | ------- | --- | --- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Availability | 8       | 1   | 32  | 15s     | Recent eval saw Availability stay healthy; keep it from becoming the bottleneck, but still back off on signal.                                                                                  |
+| CDX          | 2       | 1   | 6   | 45s     | CDX was around half `5xx` under the current static setup and can hang; keep the request timeout below the 60s queue budget so one stuck fill does not pin the limiter after all waiters expire. |
+| Replay       | 2       | 1   | 8   | 60s     | Replay was also high-`5xx`; allow modest parallelism for independent content fetches but adapt separately from CDX.                                                                             |
 
 Window rules for v0:
 
@@ -342,6 +342,8 @@ Window rules for v0:
 - if `Retry-After` is present, set the endpoint limit to 0 until that deadline;
 - if a request waits more than the configured queue budget, return
   `503 + Retry-After` rather than letting the agent spin.
+- apply endpoint-specific upstream request timeouts in the IA client so stuck
+  fills are recorded as transient failures and release their limiter slots.
 
 Expose metrics per endpoint:
 

--- a/loom/wayback_archive/lib.rs
+++ b/loom/wayback_archive/lib.rs
@@ -26,6 +26,9 @@ use tokio::time::timeout;
 pub const DEFAULT_MAX_QUEUE_WAIT: Duration = Duration::from_secs(60);
 pub const DEFAULT_MAX_BODY_BYTES: usize = 10 * 1024 * 1024;
 pub const DEFAULT_MAX_METADATA_BYTES: usize = 10 * 1024 * 1024;
+pub const DEFAULT_AVAILABILITY_TIMEOUT: Duration = Duration::from_secs(15);
+pub const DEFAULT_CDX_TIMEOUT: Duration = Duration::from_secs(45);
+pub const DEFAULT_REPLAY_TIMEOUT: Duration = Duration::from_secs(60);
 
 const RETRY_AFTER_SECONDS: u64 = 30;
 const HEALTH_WINDOW: Duration = Duration::from_secs(30);
@@ -713,10 +716,50 @@ pub struct ReqwestIaClient {
     web_upstream: String,
     availability_upstream: String,
     client: reqwest::Client,
+    timeouts: UpstreamTimeouts,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UpstreamTimeouts {
+    pub availability: Duration,
+    pub cdx: Duration,
+    pub replay: Duration,
+}
+
+impl Default for UpstreamTimeouts {
+    fn default() -> Self {
+        Self {
+            availability: DEFAULT_AVAILABILITY_TIMEOUT,
+            cdx: DEFAULT_CDX_TIMEOUT,
+            replay: DEFAULT_REPLAY_TIMEOUT,
+        }
+    }
+}
+
+impl UpstreamTimeouts {
+    fn for_endpoint(self, endpoint: Endpoint) -> Duration {
+        match endpoint {
+            Endpoint::Availability => self.availability,
+            Endpoint::Cdx => self.cdx,
+            Endpoint::Replay => self.replay,
+        }
+    }
 }
 
 impl ReqwestIaClient {
     pub fn new(web_upstream: String, availability_upstream: String) -> Result<Self> {
+        Self::with_timeouts(
+            web_upstream,
+            availability_upstream,
+            UpstreamTimeouts::default(),
+        )
+    }
+
+    pub fn with_timeouts(
+        web_upstream: String,
+        availability_upstream: String,
+        timeouts: UpstreamTimeouts,
+    ) -> Result<Self> {
         Ok(Self {
             web_upstream: web_upstream.trim_end_matches('/').to_string(),
             availability_upstream: availability_upstream.trim_end_matches('/').to_string(),
@@ -725,6 +768,7 @@ impl ReqwestIaClient {
                 .redirect(reqwest::redirect::Policy::none())
                 .user_agent("ducktape-wayback-archive/1 (+agentydragon@gmail.com)")
                 .build()?,
+            timeouts,
         })
     }
 
@@ -748,6 +792,7 @@ impl ReqwestIaClient {
             .client
             .get(format!("{base_url}{path}{query_suffix}"))
             .header(reqwest::header::ACCEPT_ENCODING, "identity")
+            .timeout(self.timeouts.for_endpoint(request.key.endpoint))
             .send()
             .await?;
         let status = response.status().as_u16();
@@ -772,6 +817,7 @@ impl IaClient for ReqwestIaClient {
             .client
             .get(format!("{}{}", self.web_upstream, key.ia_path()))
             .header(reqwest::header::ACCEPT_ENCODING, "identity")
+            .timeout(self.timeouts.replay)
             .send()
             .await?;
         let status = response.status().as_u16();
@@ -1988,6 +2034,40 @@ mod tests {
         assert!(limiter.acquire().await);
         limiter.record(AcquisitionOutcome::TransientFailure).await;
         assert_eq!(limiter.current_limit().await, 2);
+    }
+
+    #[tokio::test]
+    async fn reqwest_metadata_fetch_honors_endpoint_timeout() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (_socket, _peer) = listener.accept().await.unwrap();
+            tokio::time::sleep(Duration::from_secs(5)).await;
+        });
+        let client = ReqwestIaClient::with_timeouts(
+            format!("http://{address}"),
+            format!("http://{address}"),
+            UpstreamTimeouts {
+                availability: Duration::from_millis(100),
+                cdx: Duration::from_secs(5),
+                replay: Duration::from_secs(5),
+            },
+        )
+        .unwrap();
+        let request = parse_metadata_request(
+            "/wayback/available",
+            Some("url=https://example.com/&timestamp=20200101000000"),
+        )
+        .unwrap();
+
+        let started = Instant::now();
+        let result = client
+            .fetch_metadata(&request, DEFAULT_MAX_METADATA_BYTES)
+            .await;
+
+        assert!(result.is_err());
+        assert!(started.elapsed() < Duration::from_secs(2));
+        server.abort();
     }
 
     fn content_type_headers() -> HeaderMap {

--- a/loom/wayback_archive/main.rs
+++ b/loom/wayback_archive/main.rs
@@ -9,9 +9,10 @@ use axum::http::{HeaderMap, HeaderName, HeaderValue, Response, StatusCode, heade
 use axum::{Router, routing::get};
 use log::info;
 use wayback_archive::{
-    AdaptiveLimiter, ArchiveResponse, ArchiveService, ArchiveStore, DEFAULT_MAX_BODY_BYTES,
-    DEFAULT_MAX_METADATA_BYTES, DEFAULT_MAX_QUEUE_WAIT, LimiterConfig, MemoryArchiveStore,
-    PostgresArchiveStore, ReqwestIaClient, S3BlobStore,
+    AdaptiveLimiter, ArchiveResponse, ArchiveService, ArchiveStore, DEFAULT_AVAILABILITY_TIMEOUT,
+    DEFAULT_CDX_TIMEOUT, DEFAULT_MAX_BODY_BYTES, DEFAULT_MAX_METADATA_BYTES,
+    DEFAULT_MAX_QUEUE_WAIT, DEFAULT_REPLAY_TIMEOUT, LimiterConfig, MemoryArchiveStore,
+    PostgresArchiveStore, ReqwestIaClient, S3BlobStore, UpstreamTimeouts,
 };
 
 #[tokio::main]
@@ -38,6 +39,17 @@ async fn main() -> Result<()> {
         .and_then(|value| value.parse::<u64>().ok())
         .map(Duration::from_secs)
         .unwrap_or(DEFAULT_MAX_QUEUE_WAIT);
+    let timeouts = UpstreamTimeouts {
+        availability: duration_from_env_secs(
+            "WAYBACK_ARCHIVE_AVAILABILITY_TIMEOUT_SECONDS",
+            DEFAULT_AVAILABILITY_TIMEOUT,
+        ),
+        cdx: duration_from_env_secs("WAYBACK_ARCHIVE_CDX_TIMEOUT_SECONDS", DEFAULT_CDX_TIMEOUT),
+        replay: duration_from_env_secs(
+            "WAYBACK_ARCHIVE_REPLAY_TIMEOUT_SECONDS",
+            DEFAULT_REPLAY_TIMEOUT,
+        ),
+    };
 
     let store: Arc<dyn ArchiveStore> =
         if let Ok(database_url) = std::env::var("WAYBACK_ARCHIVE_DATABASE_URL") {
@@ -63,7 +75,11 @@ async fn main() -> Result<()> {
     let service = Arc::new(
         ArchiveService::new(
             store,
-            Arc::new(ReqwestIaClient::new(web_upstream, availability_upstream)?),
+            Arc::new(ReqwestIaClient::with_timeouts(
+                web_upstream,
+                availability_upstream,
+                timeouts,
+            )?),
         )
         .with_endpoint_limiters(
             availability_limiter,
@@ -112,6 +128,14 @@ async fn main() -> Result<()> {
         axum::serve(listener, app).await?;
     }
     Ok(())
+}
+
+fn duration_from_env_secs(name: &str, default: Duration) -> Duration {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .map(Duration::from_secs)
+        .unwrap_or(default)
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
## Summary

- add endpoint-specific total IA request timeouts to the Rust wayback archive client
- expose timeout env vars and pin deployment defaults: Availability 15s, CDX 45s, Replay 60s
- update the archive plan notes to match the timeout behavior

## Notes

The normal resolver CDX fallback already uses `to=<as_of>&output=json&limit=-1`, which is the one-row latest-before-cutoff query shape. This change addresses the observed hang mode where a CDX fill can outlive callers and keep its limiter slot occupied.

## Validation

- `pre-commit run --files loom/wayback_archive/lib.rs loom/wayback_archive/main.rs loom/wayback_archive/PLAN.md cluster/k8s/wayback-cache/deployment.yaml`
- `bbr test //loom/wayback_archive:wayback_archive_test` (BuildBuddy invocation `48637f1b-c39e-478e-9d6e-41e693f3aa18`, Bazel invocation `7484c4b5-2568-44a5-91bc-b32558857654`)