### PR TITLE
[codex] debundle: narrow at-init fallback edges

### DIFF
--- a/devinfra/js/debundle/README.md
+++ b/devinfra/js/debundle/README.md
@@ -219,6 +219,18 @@ every statement containing an unproven call is conservatively
 chained. That is the intended trade — the relaxation only fires where
 the analyzer can actually prove non-interference.
 
+Specs that have independently audited a call-heavy or annotation-heavy
+chunk may opt into `trusted_dataflow_summaries` alongside
+`dataflow_aware_s_chain`. That author-trusted flag restores the
+pre-tightening behavior for conservative-but-present summaries:
+unproven top-level calls/news, member writes, and similar ordinary
+summary bails stay impure, but use their syntactic
+binding/global-property read-write summary instead of becoming opaque
+barriers. Shapes that defeat write-cell extraction outright (`eval`,
+`with`, `Function`, computed global-object keys, global
+`defineProperty`, global `Proxy`) still fall back to conservative
+barriers regardless of the flag.
+
 Unshadowed `window` / `self` / `frames` / `top` are treated as the
 same object as `globalThis` for cell tracking: `window.tag = 1` and
 `globalThis.tag` are the same cell. A chunk-top-level declaration or

--- a/devinfra/js/debundle/analysis_hints.rs
+++ b/devinfra/js/debundle/analysis_hints.rs
@@ -41,8 +41,20 @@ pub struct AnalysisHints {
     /// keyed binding and `<prop>` is in the value set.
     /// See AGENTS.md "Declared purity".
     pub declared_pure_members: BTreeMap<String, BTreeSet<String>>,
+    /// Member names on a binding whose calls may receive callback-like
+    /// arguments but do not synchronously invoke them. The call itself is
+    /// still impure/ordered unless another hint says otherwise; this only
+    /// narrows at-init call promotion by not treating inline functions,
+    /// object literals containing functions, or first-order argument
+    /// callbacks as synchronously reachable fallback roots.
+    pub no_sync_callback_members: BTreeMap<String, BTreeSet<String>>,
     pub known_effects: BTreeMap<String, KnownEffect>,
     pub local_effect_policy: LocalEffectPolicy,
+    /// Author-trusted chunk-level opt-in that lets conservative-but-present
+    /// syntactic dataflow summaries drive S-chain emission instead of
+    /// falling back to opaque barriers. Set from
+    /// `OwnerGraphOptions::trusted_dataflow_summaries`.
+    pub trusted_dataflow_summaries: bool,
     /// Cross-module purity verdicts for this chunk's imported function
     /// bindings, keyed by local binding name. Produced by the program-level
     /// oracle (`crate::cross_module_purity`); empty in strictly per-chunk
@@ -63,8 +75,10 @@ impl AnalysisHints {
             declared_pure: declared_pure.clone(),
             declared_pure_new: BTreeSet::new(),
             declared_pure_members: BTreeMap::new(),
+            no_sync_callback_members: BTreeMap::new(),
             known_effects: BTreeMap::new(),
             local_effect_policy: LocalEffectPolicy::KnownEffectsOnly,
+            trusted_dataflow_summaries: false,
             imported_purities: BTreeMap::new(),
             fluent_bindings: BTreeSet::new(),
         }

--- a/devinfra/js/debundle/analysis_tests/mod.rs
+++ b/devinfra/js/debundle/analysis_tests/mod.rs
@@ -256,6 +256,281 @@ fn first_order_body_call_skips_after_await_in_async_body() {
 }
 
 #[test]
+fn promise_reaction_on_async_function_call_does_not_sync_promote_handler() {
+    let module = parse(
+        "async function setup() { await Promise.resolve(); } \
+         function handler() {} \
+         function boot() { setup().catch(() => handler()); }",
+    );
+    let facts = analyze_facts(&module);
+    assert_eq!(
+        facts[2].calls.first_order_lazy,
+        BTreeSet::from([test_id("setup")])
+    );
+    assert!(facts[2].calls.lazy.contains(&test_id("handler")));
+    assert!(
+        !facts[2]
+            .calls
+            .first_order_lazy
+            .contains(&test_id("handler"))
+    );
+    assert!(facts[2].first_order_unresolved_sources.is_empty());
+    assert!(!facts[2].first_order_unresolved_inline_fn);
+}
+
+#[test]
+fn arbitrary_member_catch_promotes_inline_callback_body_precisely() {
+    let module = parse(
+        "function makeThenable() { return { catch(f) { f(); } }; } \
+         function handler() {} \
+         function boot() { makeThenable().catch(() => handler()); }",
+    );
+    let facts = analyze_facts(&module);
+    assert!(
+        facts[2]
+            .first_order_unresolved_sources
+            .contains(&test_id("makeThenable"))
+    );
+    assert_eq!(
+        facts[2].calls.first_order_lazy,
+        BTreeSet::from([test_id("makeThenable"), test_id("handler")])
+    );
+    assert!(!facts[2].first_order_unresolved_inline_fn);
+}
+
+#[test]
+fn first_order_unresolved_inline_callback_collects_only_pre_await_effects() {
+    let module = parse(
+        "function before() {} \
+         function after() {} \
+         async function boot(items) { \
+           items.map(() => before()); \
+           await Promise.resolve(); \
+           items.map(() => after()); \
+         }",
+    );
+    let facts = analyze_facts(&module);
+    assert_eq!(
+        facts[2].calls.first_order_lazy,
+        BTreeSet::from([test_id("before")])
+    );
+    assert!(facts[2].calls.lazy.contains(&test_id("after")));
+    assert!(
+        !facts[2].calls.first_order_lazy.contains(&test_id("after")),
+        "post-await inline callbacks must not be treated as synchronously \
+         firing from an at-init caller"
+    );
+    assert!(!facts[2].first_order_unresolved_inline_fn);
+}
+
+#[test]
+fn parent_call_after_nested_await_is_not_first_order() {
+    let module = parse(
+        "function after() {} \
+         async function boot(store) { \
+           await (await store.keys()).reduce(async () => after(), Promise.resolve({})); \
+         }",
+    );
+    let facts = analyze_facts(&module);
+    assert!(facts[1].calls.lazy.contains(&test_id("after")));
+    assert!(
+        !facts[1].calls.first_order_lazy.contains(&test_id("after")),
+        "callbacks passed to a call whose receiver resumes after an inner \
+         await must not be promoted as first-order"
+    );
+    assert!(
+        !facts[1].first_order_unresolved_inline_fn,
+        "the post-await reduce call must not trigger whole-owner inline fallback"
+    );
+}
+
+#[test]
+fn load_feature_flags_reduce_callback_after_nested_await_is_not_first_order() {
+    let module = parse(
+        "const FeatureFlag = {}; \
+         function setFeatureEnabledForUser() {} \
+         async function loadFeatureFlags(featureFlagLocalForage) { \
+           return ( \
+             await Promise.all(Object.keys({}).map((i) => featureFlagLocalForage.setItem(i, true))), \
+             await (await featureFlagLocalForage.keys()).reduce(async (i, l) => { \
+               const d = await i; \
+               if (await featureFlagLocalForage.getItem(l)) { \
+                 d[l] = true; \
+                 const u = FeatureFlag[l]; \
+                 if (u) { \
+                   const p = await setFeatureEnabledForUser(u); \
+                   for (const h of p) d[FeatureFlag[h]] = true; \
+                 } \
+               } \
+               return d; \
+             }, Promise.resolve({})) \
+           ); \
+         }",
+    );
+    let facts = analyze_facts(&module);
+    assert!(
+        facts[2]
+            .calls
+            .lazy
+            .contains(&test_id("setFeatureEnabledForUser"))
+    );
+    assert!(
+        !facts[2]
+            .calls
+            .first_order_lazy
+            .contains(&test_id("setFeatureEnabledForUser")),
+        "calls inside the reducer callback happen after the keys() await"
+    );
+}
+
+#[test]
+fn no_sync_callback_member_hint_suppresses_at_init_inline_fallback() {
+    let module = parse(
+        "const later = 'ready'; \
+         const state = {}; \
+         state.setPending(() => later);",
+    );
+    let default_facts = analyze_facts(&module);
+    assert!(default_facts[2].at_init_unresolved_inline_fn);
+
+    let hints = AnalysisHints {
+        no_sync_callback_members: BTreeMap::from([(
+            "state".to_string(),
+            BTreeSet::from(["setPending".to_string()]),
+        )]),
+        ..AnalysisHints::default()
+    };
+    let facts = analyze_facts_with_hints(&module, &hints);
+    assert!(
+        facts[2]
+            .at_init_unresolved_sources
+            .contains(&test_id("state"))
+    );
+    assert!(
+        !facts[2].at_init_unresolved_inline_fn,
+        "audited callback-storing member calls should not promote \
+         callback bodies as at-init"
+    );
+    assert!(facts[2].reads.lazy.contains(&test_id("later")));
+}
+
+#[test]
+fn no_sync_callback_member_hint_does_not_cover_other_members() {
+    let module = parse(
+        "const later = 'ready'; \
+         const state = {}; \
+         state.invokeNow(() => later);",
+    );
+    let hints = AnalysisHints {
+        no_sync_callback_members: BTreeMap::from([(
+            "state".to_string(),
+            BTreeSet::from(["setPending".to_string()]),
+        )]),
+        ..AnalysisHints::default()
+    };
+    let facts = analyze_facts_with_hints(&module, &hints);
+    assert!(facts[2].at_init_unresolved_inline_fn);
+}
+
+#[test]
+fn no_sync_callback_member_hint_suppresses_argument_fallback_roots() {
+    let module = parse(
+        "const registry = { registerProvider() {} }; \
+         const data = 'ready'; \
+         const provider = { name: 'p', read() { return data; } }; \
+         registry.registerProvider(provider);",
+    );
+    let default_facts = analyze_facts(&module);
+    assert!(
+        default_facts[3]
+            .at_init_unresolved_sources
+            .contains(&test_id("provider"))
+    );
+
+    let hints = AnalysisHints {
+        no_sync_callback_members: BTreeMap::from([(
+            "registry".to_string(),
+            BTreeSet::from(["registerProvider".to_string()]),
+        )]),
+        ..AnalysisHints::default()
+    };
+    let facts = analyze_facts_with_hints(&module, &hints);
+    assert!(
+        facts[3].reads.eager.contains(&test_id("provider")),
+        "the provider argument is still evaluated at init"
+    );
+    assert!(
+        facts[3]
+            .at_init_unresolved_sources
+            .contains(&test_id("registry")),
+        "the unresolved member receiver still participates in fallback"
+    );
+    assert!(
+        !facts[3]
+            .at_init_unresolved_sources
+            .contains(&test_id("provider")),
+        "audited registration calls should not treat provider arguments \
+         as synchronously invoked fallback roots"
+    );
+
+    let graph = build_owner_graph(&facts).unwrap();
+    assert!(
+        graph.iter_edges().all(|edge| {
+            !(edge.from == OwnerId(3)
+                && edge.to == OwnerId(1)
+                && edge.reason.kind == DepKind::EagerUse)
+        }),
+        "provider method body reads must not be promoted through \
+         audited registration calls: {:#?}",
+        graph.iter_edges().collect::<Vec<_>>(),
+    );
+}
+
+#[test]
+fn no_sync_callback_member_hint_suppresses_first_order_argument_fallback_roots() {
+    let module = parse(
+        "const registry = { registerProvider() {} }; \
+         const data = 'ready'; \
+         const provider = { name: 'p', read() { return data; } }; \
+         function boot() { registry.registerProvider(provider); } \
+         boot();",
+    );
+    let hints = AnalysisHints {
+        no_sync_callback_members: BTreeMap::from([(
+            "registry".to_string(),
+            BTreeSet::from(["registerProvider".to_string()]),
+        )]),
+        ..AnalysisHints::default()
+    };
+    let facts = analyze_facts_with_hints(&module, &hints);
+    assert!(
+        facts[3]
+            .reads
+            .first_order_lazy
+            .contains(&test_id("provider")),
+        "the provider argument is still evaluated when boot runs"
+    );
+    assert!(
+        !facts[3]
+            .first_order_unresolved_sources
+            .contains(&test_id("provider")),
+        "audited registration calls inside a first-order body should not \
+         seed provider arguments as fallback roots"
+    );
+
+    let graph = build_owner_graph(&facts).unwrap();
+    assert!(
+        graph.iter_edges().all(|edge| {
+            !(edge.from == OwnerId(4)
+                && edge.to == OwnerId(1)
+                && edge.reason.kind == DepKind::EagerUse)
+        }),
+        "provider method body reads must not be promoted through boot(): {:#?}",
+        graph.iter_edges().collect::<Vec<_>>(),
+    );
+}
+
+#[test]
 fn function_body_reads_are_lazy() {
     let module = parse("function f() { return X; } const Y = 1;");
     let facts = analyze_facts(&module);

--- a/devinfra/js/debundle/docs/design.md
+++ b/devinfra/js/debundle/docs/design.md
@@ -394,7 +394,12 @@ the chunk spec picks one of two modes via
     (`(0, eval)(...)`) executes arbitrary writes. Classifier-Pure
     calls are exempt: `Pure` guarantees no observable writes and
     no global-prop reads, and binding-cell ordering is enforced by
-    binding edges + rebind co-location rather than the S-chain;
+    binding edges + rebind co-location rather than the S-chain.
+    A chunk may opt into the author-trusted
+    `trusted_dataflow_summaries` refinement to let this class of
+    opaque calls/news use the syntactic dataflow summary anyway;
+    shapes that defeat write-cell extraction outright still force
+    conservative barriers regardless of that flag;
   - member writes through a tracked binding (`obj.x = 1`,
     `obj.x++`, destructuring targets containing member
     expressions) — aliasing makes the written heap cell
@@ -741,6 +746,17 @@ projection: residual is the ESM DFS root and evaluates last, so an
 at-init call from residual code cannot observe a TDZ, and the
 emitter emits no entry-side phantom imports the gate could
 otherwise assume.
+
+**Audited callback-storage APIs.** Member-specific
+`no_sync_callback_members` hints narrow only the fallback roots for
+calls like `registry.register(fn)` or `state.set({ onDone() {} })`
+where the audited API stores callback-like arguments without
+synchronously invoking them. Receiver, callee, and non-callback
+arguments still evaluate and still feed normal read/rebind/effect
+summaries; the call also remains impure for S-chain ordering unless a
+separate purity hint applies. The hint suppresses the conservative
+"the callback may have run now" edge for inline functions, object
+literals containing functions, and first-order argument callbacks.
 
 **Residual limitations.** The fallback (and promotion generally)
 does not model function values that reach a call site through:

--- a/devinfra/js/debundle/e2e/at_init_cross_module_call_body_reads_test.rs
+++ b/devinfra/js/debundle/e2e/at_init_cross_module_call_body_reads_test.rs
@@ -134,6 +134,23 @@ fn at_init_call_to_cross_module_function_does_not_promote_body_reads() {
 }
 
 #[test]
+fn at_init_call_to_cross_module_setter_does_not_colocate_caller_with_state() {
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"let state = "initial";
+function setState(value) { state = value; }
+setState("updated");
+console.log(state);
+export { state, setState };
+"#,
+        vec![logical_module(
+            "mod_state",
+            &[Member::new("state"), Member::new("setState")],
+        )],
+    ));
+    assert_entry_output(&fixture, "updated\n");
+}
+
+#[test]
 fn at_init_call_keeps_owner_edge_marked_with_callee() {
     // The promoted owner edge is retained in the owner graph (the
     // analyzer's IR keeps it as evidence of the promotion), but with

--- a/devinfra/js/debundle/e2e/at_init_promotion_post_await_test.rs
+++ b/devinfra/js/debundle/e2e/at_init_promotion_post_await_test.rs
@@ -127,3 +127,29 @@ export { state, setState, asyncSetup };
     ));
     assert_entry_output(&fixture, "initial\n");
 }
+
+#[test]
+fn promise_catch_handler_on_async_call_is_not_promoted_as_at_init() {
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"let handled = "no";
+function markHandled() { handled = "yes"; }
+async function asyncSetup() {
+    await Promise.resolve();
+}
+function boot() {
+    asyncSetup().catch(() => markHandled());
+}
+boot();
+console.log(handled);
+export { handled, markHandled, asyncSetup, boot };
+"#,
+        vec![
+            logical_module(
+                "mod_handler",
+                &[Member::new("handled"), Member::new("markHandled")],
+            ),
+            logical_module("mod_setup", &[Member::new("asyncSetup")]),
+        ],
+    ));
+    assert_entry_output(&fixture, "no\n");
+}

--- a/devinfra/js/debundle/e2e/at_init_s_chain_dataflow_test.rs
+++ b/devinfra/js/debundle/e2e/at_init_s_chain_dataflow_test.rs
@@ -96,6 +96,13 @@ fn dataflow_opts<'a>(source: &'a str, logical_modules: Vec<LogicalModuleEntry>) 
     FixtureOpts::new(source, logical_modules).with_dataflow_aware_s_chain()
 }
 
+fn trusted_dataflow_opts<'a>(
+    source: &'a str,
+    logical_modules: Vec<LogicalModuleEntry>,
+) -> FixtureOpts<'a> {
+    dataflow_opts(source, logical_modules).with_trusted_dataflow_summaries()
+}
+
 fn owner_for_binding<'a>(graph: &'a OwnerGraphReport, binding: &str) -> &'a str {
     let node = graph
         .nodes
@@ -233,6 +240,44 @@ export { Holder1, Holder2, instA, instB };
     let owner_a = owner_for_binding(&graph, "instA");
     let owner_b = owner_for_binding(&graph, "instB");
     assert_kept_sequenced_between(&graph, owner_a, owner_b);
+}
+
+#[test]
+fn trusted_constructor_calls_use_dataflow_summary() {
+    // The default above remains conservative because an unproven
+    // `new` may have arbitrary observable effects. Some real bundle
+    // specs are separately audited and accept the old dataflow
+    // assumption for conservative-but-present summaries: calls/news
+    // stay impure, but they do not become barriers against every
+    // prior impure owner. In that trusted mode these two constructor
+    // calls touch disjoint binding cells, so there is no S-edge
+    // between them.
+    let fixture = run_fixture(trusted_dataflow_opts(
+        r#"class Holder1 { constructor() { this.kind = "h1"; } }
+class Holder2 { constructor() { this.kind = "h2"; } }
+const instA = new Holder1();
+const instB = new Holder2();
+console.log(instA.kind, instB.kind);
+export { Holder1, Holder2, instA, instB };
+"#,
+        vec![
+            logical_module("mod_a", &[Member::new("Holder1"), Member::new("instA")]),
+            logical_module("mod_b", &[Member::new("Holder2"), Member::new("instB")]),
+        ],
+    ));
+    assert_entry_output(&fixture, "h1 h2\n");
+
+    let graph: OwnerGraphReport =
+        read_json(&fixture.report_root.join("static/app/owner_graph.json"));
+    let owner_a = owner_for_binding(&graph, "instA");
+    let owner_b = owner_for_binding(&graph, "instB");
+    let offending = sequenced_edges_between(&graph, owner_a, owner_b);
+    assert!(
+        offending.is_empty(),
+        "trusted dataflow summarization should not add an unrelated S-edge \
+         between constructor calls whose syntactic summaries touch disjoint \
+         binding cells. Offending edges: {offending:#?}\n\nFull graph: {graph:#?}",
+    );
 }
 
 #[test]

--- a/devinfra/js/debundle/e2e/at_init_unresolved_callee_test.rs
+++ b/devinfra/js/debundle/e2e/at_init_unresolved_callee_test.rs
@@ -19,6 +19,28 @@
 //! and are rejected.
 
 use debundle_e2e_support::*;
+use serde_json::Value;
+
+fn owner_for_binding(graph: &Value, binding: &str) -> String {
+    graph
+        .get("nodes")
+        .and_then(Value::as_array)
+        .and_then(|nodes| {
+            nodes.iter().find(|node| {
+                node.get("declared_bindings")
+                    .and_then(Value::as_array)
+                    .is_some_and(|bindings| {
+                        bindings
+                            .iter()
+                            .any(|b| b.get("binding").and_then(Value::as_str) == Some(binding))
+                    })
+            })
+        })
+        .and_then(|node| node.get("id"))
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("no owner-graph node declares binding `{binding}`"))
+        .to_string()
+}
 
 /// `const g = readB; const r = g();` — the alias `g` is a VarDecl,
 /// not a function declaration, so the old promotion pass skipped the
@@ -107,4 +129,135 @@ export { VALUE, get, indirect, r };
         ],
     ));
     assert_entry_output(&fixture, "v\n");
+}
+
+#[test]
+fn plain_array_collection_methods_do_not_promote_element_function_bodies() {
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"const later = "ready";
+const tools = [{ name: "tool", systemNodeId: "tool-id", run: () => later }];
+const toolCopies = tools.map((tool) => ({ ...tool }));
+const byName = Object.fromEntries(tools.map((tool) => [tool.name, tool]));
+const ids = [...tools.filter((tool) => tool.systemNodeId).map((tool) => tool.systemNodeId)];
+const copiedIds = [...toolCopies.map((tool) => tool.systemNodeId)];
+const byId = {};
+tools.forEach((tool) => {
+  tool.systemNodeId && (byId[tool.systemNodeId] = tool.name);
+});
+export { later, tools, toolCopies, byName, ids, copiedIds, byId };
+"#,
+        vec![logical_module(
+            "collections",
+            &[
+                Member::new("byName"),
+                Member::new("ids"),
+                Member::new("copiedIds"),
+                Member::new("byId"),
+            ],
+        )],
+    ));
+
+    let graph: Value = read_json(&fixture.report_root.join("static/app/owner_graph.json"));
+    let later_owner = owner_for_binding(&graph, "later");
+    let promoted_to_later: Vec<_> = graph
+        .get("edges")
+        .and_then(Value::as_array)
+        .expect("owner graph edges array")
+        .iter()
+        .filter(|edge| {
+            edge.get("target").and_then(Value::as_str) == Some(later_owner.as_str())
+                && edge.get("edge_kind").and_then(Value::as_str) == Some("eager_use")
+                && edge
+                    .get("role")
+                    .and_then(|role| role.get("kind"))
+                    .and_then(Value::as_str)
+                    == Some("promoted_at_init")
+        })
+        .collect();
+    assert!(
+        promoted_to_later.is_empty(),
+        "static Array collection methods must not promote lazy reads \
+         from function-valued elements; got {promoted_to_later:#?}\n\n\
+         Full owner graph: {graph:#?}",
+    );
+    assert_entry_output(&fixture, "");
+}
+
+#[test]
+fn global_event_listener_callback_is_not_promoted_as_at_init() {
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"const later = "ready";
+typeof window < "u" &&
+  window.addEventListener("beforeunload", () => {
+    console.log(later);
+  });
+export { later };
+"#,
+        vec![logical_module("later_mod", &[Member::new("later")])],
+    ));
+
+    let graph: Value = read_json(&fixture.report_root.join("static/app/owner_graph.json"));
+    let later_owner = owner_for_binding(&graph, "later");
+    let promoted_to_later: Vec<_> = graph
+        .get("edges")
+        .and_then(Value::as_array)
+        .expect("owner graph edges array")
+        .iter()
+        .filter(|edge| {
+            edge.get("target").and_then(Value::as_str) == Some(later_owner.as_str())
+                && edge.get("edge_kind").and_then(Value::as_str) == Some("eager_use")
+                && edge
+                    .get("role")
+                    .and_then(|role| role.get("kind"))
+                    .and_then(Value::as_str)
+                    == Some("promoted_at_init")
+        })
+        .collect();
+    assert!(
+        promoted_to_later.is_empty(),
+        "global addEventListener registration must not promote lazy callback reads; \
+         got {promoted_to_later:#?}\n\nFull owner graph: {graph:#?}",
+    );
+    assert_entry_output(&fixture, "");
+}
+
+#[test]
+fn dom_event_listener_callback_is_not_promoted_as_at_init() {
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"const later = "ready";
+const document = {
+  querySelector: () => ({ addEventListener() {} }),
+};
+const button = document.querySelector("button");
+button?.addEventListener("click", () => {
+  console.log(later);
+});
+export { later, document, button };
+"#,
+        vec![logical_module("later_mod", &[Member::new("later")])],
+    ));
+
+    let graph: Value = read_json(&fixture.report_root.join("static/app/owner_graph.json"));
+    let later_owner = owner_for_binding(&graph, "later");
+    let promoted_to_later: Vec<_> = graph
+        .get("edges")
+        .and_then(Value::as_array)
+        .expect("owner graph edges array")
+        .iter()
+        .filter(|edge| {
+            edge.get("target").and_then(Value::as_str) == Some(later_owner.as_str())
+                && edge.get("edge_kind").and_then(Value::as_str) == Some("eager_use")
+                && edge
+                    .get("role")
+                    .and_then(|role| role.get("kind"))
+                    .and_then(Value::as_str)
+                    == Some("promoted_at_init")
+        })
+        .collect();
+    assert!(
+        promoted_to_later.is_empty(),
+        "DOM addEventListener registration must not promote lazy callback reads; \
+         got {promoted_to_later:#?}\n\nFull owner graph: {graph:#?}",
+    );
+    assert_entry_output(&fixture, "");
 }

--- a/devinfra/js/debundle/e2e/chunk_rename_cross_module_test.rs
+++ b/devinfra/js/debundle/e2e/chunk_rename_cross_module_test.rs
@@ -30,6 +30,7 @@ fn chunk_rename_propagates_into_peeled_module_body() {
     // and its `const b = cx();` callsite both need the new alias.
     let opts = FixtureOpts {
         local_property_effects: false,
+        trusted_dataflow_summaries: false,
         chunk_export_purity: &[],
         extra_chunks: &[],
         source: r#"import { f as cx } from "./vendor.js";

--- a/devinfra/js/debundle/e2e/cross_module_emission_test.rs
+++ b/devinfra/js/debundle/e2e/cross_module_emission_test.rs
@@ -31,7 +31,7 @@ export { b };
 }
 
 #[test]
-fn rejects_extracted_binding_assigned_by_residual_owner() {
+fn folds_unclaimed_assigner_with_extracted_mutable_binding() {
     // This is the minimal shape behind the an upstream boot-progress
     // `Assignment to constant variable` failure: the spec peels a
     // mutable binding, while a still-residual function assigns to
@@ -40,12 +40,10 @@ fn rejects_extracted_binding_assigned_by_residual_owner() {
     // assignment because imported ESM bindings are read-only in the
     // importing module.
     //
-    // The realizability/factorization validation phase must reject this
-    // spec before emission. A binding with a cross-destination
-    // assignment cannot be safely peeled unless every top-level
-    // owner that may assign it is peeled into the same destination,
-    // or the emitter grows a sound live-mutation bridge for that
-    // binding.
+    // Rebind-only atomic-unit folding extends the explicit `state`
+    // destination to cover the unclaimed assigner `b`. That keeps the
+    // assignment local to the module that owns `a`; the residual entry
+    // imports and calls `b` instead of assigning an imported binding.
     let mut opts = FixtureOpts::new(
         r#"let a = 0;
 function b() {
@@ -58,10 +56,27 @@ export { a };
         vec![logical_module("state", &[Member::new("a")])],
     );
     opts.unassigned_mode = unassigned_mode_inline();
-    expect_rejection_containing_all(
-        opts,
-        &["assignment", "assigner", "mutable", "cross-destination"],
+    let fixture = run_fixture(opts);
+
+    assert_module_exports(
+        &fixture.out_root,
+        "static/app/modules/state.js",
+        &["a", "b"],
+        &[],
     );
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/modules/state.js",
+        &["let a = 0;", "function b()", "a = 1;"],
+        &[],
+    );
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/entry.js",
+        &["import { a, b }"],
+        &["a = 1;"],
+    );
+    assert_entry_output(&fixture, "1\n");
 }
 
 #[test]
@@ -620,6 +635,7 @@ fn residual_public_export_name_does_not_capture_unrelated_chunk_renamed_import()
     // `B as vendorHelper`.
     let opts = FixtureOpts {
         local_property_effects: false,
+        trusted_dataflow_summaries: false,
         chunk_export_purity: &[],
         extra_chunks: &[],
         source: r#"import { o as B } from "./vendor.js";

--- a/devinfra/js/debundle/e2e/mini_factors_test.rs
+++ b/devinfra/js/debundle/e2e/mini_factors_test.rs
@@ -19,6 +19,7 @@ export const b = 2;
 fn catchall_keeps_unclaimed_bindings_in_residual() {
     let opts = FixtureOpts {
         local_property_effects: false,
+        trusted_dataflow_summaries: false,
         chunk_export_purity: &[],
         extra_chunks: &[],
         source: FIXTURE_SOURCE,
@@ -49,6 +50,7 @@ fn catchall_keeps_unclaimed_bindings_in_residual() {
 fn mini_factors_synthesizes_one_module_per_unclaimed_unit() {
     let opts = FixtureOpts {
         local_property_effects: false,
+        trusted_dataflow_summaries: false,
         chunk_export_purity: &[],
         extra_chunks: &[],
         source: FIXTURE_SOURCE,

--- a/devinfra/js/debundle/e2e/pure_members_test.rs
+++ b/devinfra/js/debundle/e2e/pure_members_test.rs
@@ -15,12 +15,34 @@
 //! AGENTS.md "Declared purity".
 
 use debundle_e2e_support::*;
-use serde_json::json;
+use serde_json::{Value, json};
 
 const VENDOR_FILE: &[(&str, &str)] = &[(
     "static/app/vendor.js",
-    "export function makePure(arg) { return arg; }\n",
+    "export function makePure(arg) { return arg; }\n\
+     export function forwardRef(render) { return { render }; }\n",
 )];
+
+fn owner_for_binding(graph: &Value, binding: &str) -> String {
+    graph
+        .get("nodes")
+        .and_then(Value::as_array)
+        .and_then(|nodes| {
+            nodes.iter().find(|node| {
+                node.get("declared_bindings")
+                    .and_then(Value::as_array)
+                    .is_some_and(|bindings| {
+                        bindings
+                            .iter()
+                            .any(|b| b.get("binding").and_then(Value::as_str) == Some(binding))
+                    })
+            })
+        })
+        .and_then(|node| node.get("id"))
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("no owner-graph node declares binding `{binding}`"))
+        .to_string()
+}
 
 /// Cycle-forcing fixture body parameterized by the per-case knobs.
 ///
@@ -137,4 +159,72 @@ fn pure_members_call_with_impure_arg_does_not_admit() {
         &["makePure"],
     );
     expect_rejection_containing_all(case.opts(), &["cycle", "b_module", "residual"]);
+}
+
+#[test]
+fn pure_members_member_call_does_not_promote_callback_body_reads() {
+    // React-style factories such as `forwardRef` store the render
+    // callback but do not invoke it at module init. The pure-members
+    // assertion already says `ns.forwardRef(...)` is an audited pure
+    // call site; at-init promotion must still record ordinary eager
+    // argument reads, but it must not treat the callback body's lazy
+    // reads as if they fired during the wrapper declaration.
+    let pure_members = json!({
+        "members": [
+            {
+                "name": "ReactLike",
+                "selector": {
+                    "binding": {
+                        "name": "ns",
+                        "kind": "import_specifier",
+                    },
+                },
+                "pure_members": ["forwardRef"],
+            },
+        ],
+    });
+    let fixture = run_fixture(
+        FixtureOpts::new(
+            r#"import * as ns from "./vendor.js";
+const component = ns.forwardRef(() => later);
+const later = "ready";
+console.log(typeof component, later);
+export { component, later };
+"#,
+            vec![logical_module(
+                "component_module",
+                &[Member::new("component")],
+            )],
+        )
+        .with_chunk_renames(pure_members)
+        .with_extra_files(VENDOR_FILE),
+    );
+
+    let graph: Value = read_json(&fixture.report_root.join("static/app/owner_graph.json"));
+    let component_owner = owner_for_binding(&graph, "component");
+    let later_owner = owner_for_binding(&graph, "later");
+    let promoted: Vec<_> = graph
+        .get("edges")
+        .and_then(Value::as_array)
+        .expect("owner graph edges array")
+        .iter()
+        .filter(|edge| {
+            edge.get("source").and_then(Value::as_str) == Some(component_owner.as_str())
+                && edge.get("target").and_then(Value::as_str) == Some(later_owner.as_str())
+                && edge.get("edge_kind").and_then(Value::as_str) == Some("eager_use")
+                && edge
+                    .get("role")
+                    .and_then(|role| role.get("kind"))
+                    .and_then(Value::as_str)
+                    == Some("promoted_at_init")
+        })
+        .collect();
+
+    assert!(
+        promoted.is_empty(),
+        "`ns.forwardRef(() => later)` should not promote the callback \
+         body's lazy read of `later` into an at-init eager edge; got \
+         {promoted:#?}\n\nFull owner graph: {graph:#?}",
+    );
+    assert_entry_output(&fixture, "object ready\n");
 }

--- a/devinfra/js/debundle/e2e/purity_test.rs
+++ b/devinfra/js/debundle/e2e/purity_test.rs
@@ -950,6 +950,7 @@ fn chunk_rename_with_purity_pure_propagates_to_call_classifier() {
     //   participation. Only edge: residual → b_module. DAG.
     let opts = FixtureOpts {
         local_property_effects: false,
+        trusted_dataflow_summaries: false,
         chunk_export_purity: &[],
         extra_chunks: &[],
         source: r#"import { f as cx } from "./vendor.js";

--- a/devinfra/js/debundle/e2e/residual_member_rename_test.rs
+++ b/devinfra/js/debundle/e2e/residual_member_rename_test.rs
@@ -17,6 +17,7 @@ use debundle_e2e_support::*;
 fn logical_module_at_catchall_target_renames_and_absorbs_overflow() {
     let opts = FixtureOpts {
         local_property_effects: false,
+        trusted_dataflow_summaries: false,
         chunk_export_purity: &[],
         extra_chunks: &[],
         source: r#"function a() { return 1; }

--- a/devinfra/js/debundle/e2e/support.rs
+++ b/devinfra/js/debundle/e2e/support.rs
@@ -523,6 +523,10 @@ pub struct FixtureOpts<'a> {
     /// adjacent-impure chain. Tests that exercise the relaxation set
     /// this `true`.
     pub dataflow_aware_s_chain: bool,
+    /// Author-trusted companion to `dataflow_aware_s_chain`: conservative
+    /// but present dataflow summaries are used instead of global S-chain
+    /// barriers.
+    pub trusted_dataflow_summaries: bool,
     /// Input-chunk admission checks to disable for this chunk
     /// (`chunk_analysis_options.<chunk>.admission_overrides`), e.g.
     /// `&["a1_eval"]`. Default empty — all admission checks enforced.
@@ -559,6 +563,7 @@ impl<'a> FixtureOpts<'a> {
             chunk_id: "static/app",
             unassigned_mode: unassigned_mode_catchall_file(None),
             dataflow_aware_s_chain: false,
+            trusted_dataflow_summaries: false,
             admission_overrides: &[],
             local_property_effects: false,
             extra_files: &[],
@@ -592,6 +597,12 @@ impl<'a> FixtureOpts<'a> {
     /// `chunk_analysis_options:` in YAML.
     pub fn with_dataflow_aware_s_chain(mut self) -> Self {
         self.dataflow_aware_s_chain = true;
+        self
+    }
+
+    /// Enable the trusted dataflow-summary opt-in for this chunk.
+    pub fn with_trusted_dataflow_summaries(mut self) -> Self {
+        self.trusted_dataflow_summaries = true;
         self
     }
 
@@ -1039,6 +1050,9 @@ fn build_spec<'a>(opts: &FixtureOpts<'_>, setup: &'a FixtureSetup) -> TransformS
     let mut analysis_options = serde_json::Map::new();
     if opts.dataflow_aware_s_chain {
         analysis_options.insert("dataflow_aware_s_chain".to_string(), Value::Bool(true));
+    }
+    if opts.trusted_dataflow_summaries {
+        analysis_options.insert("trusted_dataflow_summaries".to_string(), Value::Bool(true));
     }
     if opts.local_property_effects {
         analysis_options.insert("local_property_effects".to_string(), Value::Bool(true));

--- a/devinfra/js/debundle/facts/mod.rs
+++ b/devinfra/js/debundle/facts/mod.rs
@@ -62,6 +62,12 @@ impl PositionBucketed<BTreeSet<Id>> {
             self.first_order_lazy.insert(id.clone());
         }
     }
+
+    fn extend(&mut self, other: Self) {
+        self.eager.extend(other.eager);
+        self.lazy.extend(other.lazy);
+        self.first_order_lazy.extend(other.first_order_lazy);
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -372,6 +378,7 @@ where
     let body = top_level_item_views(&module.body);
     let shadowed = compute_shadowed_globals(&body);
     let global_object_names = unshadowed_global_object_aliases(&body);
+    let async_direct_function_bindings = collect_async_direct_function_bindings(&body);
     let mut top_level_await = None;
     let mut per_statement: Vec<StructuralStatementFacts> = body
         .iter()
@@ -387,7 +394,11 @@ where
             }
             let kind = classify_item(item);
             let declared = collect_declared_names(item);
-            let mut collector = StatementFactsCollector::new(global_object_names.clone());
+            let mut collector = StatementFactsCollector::new(
+                global_object_names.clone(),
+                async_direct_function_bindings.clone(),
+                !shadowed.contains("Promise"),
+            );
             item.visit_with(&mut collector);
             let source_location = source_path.and_then(|source_path| {
                 line_range_for_span(item.span()).map(|(start_line, end_line)| SourceLocation {
@@ -799,8 +810,55 @@ fn assemble_statement_facts(
     // calls are exempt: Pure guarantees no observable writes and no
     // global-prop reads, and binding-cell ordering is enforced by
     // binding edges + rebind co-location rather than the S-chain.
-    let dataflow_summarizable =
-        dataflow_summarizable && !has_opaque_at_init_call(item, shadowed, hints, graph);
+    let trusted_summary = hints.trusted_dataflow_summaries && cell_writes_summarizable;
+    let dataflow_summarizable = trusted_summary
+        || dataflow_summarizable && !has_opaque_at_init_call(item, shadowed, hints, graph);
+    // A pure top-level statement may still eagerly read ordinary
+    // argument bindings (`pureWrap(B)`), and those reads stay in
+    // `reads.eager`. What purity rules out is the unresolved-call
+    // fallback's stronger assumption that opaque member calls or
+    // wrapper calls may synchronously invoke function-valued
+    // arguments / object-held functions at module init. Dropping only
+    // the at-init fallback roots preserves direct R edges while
+    // avoiding promoted callback-body reads for audited pure factories
+    // such as React `forwardRef`.
+    let no_sync_arg_sources = no_sync_member_argument_fallback_sources(item, hints);
+    let mut first_order_unresolved_sources = first_order_unresolved_sources;
+    for id in &no_sync_arg_sources.first_order_lazy {
+        first_order_unresolved_sources.remove(id);
+    }
+    let (at_init_unresolved_sources, at_init_unresolved_inline_fn, first_order_unresolved_sources) =
+        if purity.is_pure() {
+            (BTreeSet::new(), false, first_order_unresolved_sources)
+        } else {
+            let safe_array_sources =
+                safe_plain_array_at_init_fallback_sources(item, shadowed, graph);
+            let mut at_init_unresolved_sources = at_init_unresolved_sources;
+            for id in &no_sync_arg_sources.eager {
+                at_init_unresolved_sources.remove(id);
+            }
+
+            if safe_array_sources.is_empty() {
+                let at_init_unresolved_inline_fn = at_init_unresolved_inline_fn
+                    && has_untrusted_at_init_unresolved_inline_fn_call(item, hints);
+                (
+                    at_init_unresolved_sources,
+                    at_init_unresolved_inline_fn,
+                    first_order_unresolved_sources,
+                )
+            } else {
+                (
+                    at_init_unresolved_sources
+                        .difference(&safe_array_sources)
+                        .cloned()
+                        .collect(),
+                    at_init_unresolved_inline_fn
+                        && has_untrusted_at_init_unresolved_inline_fn_call(item, hints),
+                    first_order_unresolved_sources,
+                )
+            }
+        };
+
     StatementFacts {
         ordinal,
         source_location,
@@ -821,6 +879,169 @@ fn assemble_statement_facts(
         purity,
         kind,
     }
+}
+
+fn safe_plain_array_at_init_fallback_sources(
+    item: &ModuleItem,
+    shadowed: &BTreeSet<&'static str>,
+    graph: &ChunkCodeGraph,
+) -> BTreeSet<Id> {
+    let mut out = BTreeSet::new();
+    if let Some(var) = var_decl_of_item(item) {
+        for decl in &var.decls {
+            let Some(init) = decl.init.as_deref() else {
+                continue;
+            };
+            if let Some(root) = object_from_entries_plain_array_chain_root(init, shadowed, graph) {
+                out.insert(root);
+            }
+            if let Some(root) = plain_array_map_filter_chain_root(init, graph) {
+                out.insert(root);
+            }
+            collect_array_literal_plain_array_spread_roots(init, graph, &mut out);
+        }
+    }
+    if let ModuleItem::Stmt(Stmt::Expr(expr)) = item
+        && let Some(root) = plain_array_for_each_root(&expr.expr, graph)
+    {
+        out.insert(root);
+    }
+    out
+}
+
+fn object_from_entries_plain_array_chain_root(
+    expr: &Expr,
+    shadowed: &BTreeSet<&'static str>,
+    graph: &ChunkCodeGraph,
+) -> Option<Id> {
+    let Expr::Call(call) = strip_parens(expr) else {
+        return None;
+    };
+    if call.args.len() != 1 || call.args[0].spread.is_some() || shadowed.contains("Object") {
+        return None;
+    }
+    let Callee::Expr(callee) = &call.callee else {
+        return None;
+    };
+    let Expr::Member(member) = strip_parens(callee) else {
+        return None;
+    };
+    if !matches!(
+        (member.obj.as_ref(), &member.prop),
+        (Expr::Ident(obj), MemberProp::Ident(prop))
+            if obj.sym.as_ref() == "Object" && prop.sym.as_ref() == "fromEntries"
+    ) {
+        return None;
+    }
+    plain_array_map_filter_chain_root(&call.args[0].expr, graph)
+}
+
+fn collect_array_literal_plain_array_spread_roots(
+    expr: &Expr,
+    graph: &ChunkCodeGraph,
+    out: &mut BTreeSet<Id>,
+) {
+    let Expr::Array(array) = strip_parens(expr) else {
+        return;
+    };
+    for elem in array.elems.iter().flatten() {
+        if elem.spread.is_some()
+            && let Some(root) = plain_array_map_filter_chain_root(&elem.expr, graph)
+        {
+            out.insert(root);
+        }
+    }
+}
+
+fn plain_array_for_each_root(expr: &Expr, graph: &ChunkCodeGraph) -> Option<Id> {
+    let Expr::Call(call) = strip_parens(expr) else {
+        return None;
+    };
+    if call.args.len() != 1 || call.args[0].spread.is_some() {
+        return None;
+    }
+    let Callee::Expr(callee) = &call.callee else {
+        return None;
+    };
+    let Expr::Member(member) = strip_parens(callee) else {
+        return None;
+    };
+    if !matches!(&member.prop, MemberProp::Ident(prop) if prop.sym.as_ref() == "forEach")
+        || !callback_has_no_sync_invocation(&call.args[0].expr)
+    {
+        return None;
+    }
+    match strip_parens(member.obj.as_ref()) {
+        Expr::Ident(recv) if graph.is_plain_array(recv.sym.as_ref()) => Some(recv.to_id()),
+        _ => None,
+    }
+}
+
+fn plain_array_map_filter_chain_root(expr: &Expr, graph: &ChunkCodeGraph) -> Option<Id> {
+    let Expr::Call(call) = strip_parens(expr) else {
+        return None;
+    };
+    if call.args.len() != 1 || call.args[0].spread.is_some() {
+        return None;
+    }
+    let Callee::Expr(callee) = &call.callee else {
+        return None;
+    };
+    let Expr::Member(member) = strip_parens(callee) else {
+        return None;
+    };
+    if !matches!(
+        &member.prop,
+        MemberProp::Ident(prop) if matches!(prop.sym.as_ref(), "filter" | "map")
+    ) || !callback_has_no_sync_invocation(&call.args[0].expr)
+    {
+        return None;
+    }
+    match strip_parens(member.obj.as_ref()) {
+        Expr::Ident(recv) if graph.is_plain_array(recv.sym.as_ref()) => Some(recv.to_id()),
+        other => plain_array_map_filter_chain_root(other, graph),
+    }
+}
+
+fn callback_has_no_sync_invocation(expr: &Expr) -> bool {
+    let mut finder = SyncInvocationFinder::default();
+    match strip_parens(expr) {
+        Expr::Arrow(arrow) => arrow.body.visit_with(&mut finder),
+        Expr::Fn(function) => {
+            if let Some(body) = &function.function.body {
+                body.visit_with(&mut finder);
+            }
+        }
+        _ => return false,
+    }
+    !finder.found
+}
+
+#[derive(Default)]
+struct SyncInvocationFinder {
+    found: bool,
+}
+
+impl Visit for SyncInvocationFinder {
+    fn visit_call_expr(&mut self, _node: &CallExpr) {
+        self.found = true;
+    }
+
+    fn visit_opt_call(&mut self, _node: &OptCall) {
+        self.found = true;
+    }
+
+    fn visit_new_expr(&mut self, _node: &NewExpr) {
+        self.found = true;
+    }
+
+    fn visit_tagged_tpl(&mut self, _node: &TaggedTpl) {
+        self.found = true;
+    }
+
+    fn visit_function(&mut self, _node: &Function) {}
+    fn visit_arrow_expr(&mut self, _node: &ArrowExpr) {}
+    fn visit_class(&mut self, _node: &Class) {}
 }
 
 /// Walks a statement looking for an at-init (lazy-depth-0) call/new
@@ -912,6 +1133,244 @@ fn has_opaque_at_init_call(
     };
     item.visit_with(&mut finder);
     finder.found
+}
+
+fn has_untrusted_at_init_unresolved_inline_fn_call(
+    item: &ModuleItem,
+    hints: &AnalysisHints,
+) -> bool {
+    let mut finder = UntrustedAtInitInlineFnFallbackFinder {
+        no_sync_callback_members: &hints.no_sync_callback_members,
+        found: false,
+        lazy_depth: 0,
+    };
+    item.visit_with(&mut finder);
+    finder.found
+}
+
+fn no_sync_member_argument_fallback_sources(
+    item: &ModuleItem,
+    hints: &AnalysisHints,
+) -> PositionBucketed<BTreeSet<Id>> {
+    let mut collector = NoSyncMemberArgumentSourceCollector {
+        no_sync_callback_members: &hints.no_sync_callback_members,
+        sources: PositionBucketed::default(),
+        lazy_depth: 0,
+        past_await: false,
+    };
+    item.visit_with(&mut collector);
+    collector.sources
+}
+
+fn is_static_event_listener_registration(callee: &Expr, args: &[ExprOrSpread]) -> bool {
+    args.len() >= 2
+        && args
+            .first()
+            .is_some_and(|arg| is_static_event_name(&arg.expr))
+        && expr_is_add_event_listener_member(callee)
+}
+
+fn is_static_event_name(expr: &Expr) -> bool {
+    match strip_parens(expr) {
+        Expr::Lit(Lit::Str(_)) => true,
+        Expr::Tpl(Tpl { exprs, .. }) => exprs.is_empty(),
+        _ => false,
+    }
+}
+
+fn expr_is_add_event_listener_member(expr: &Expr) -> bool {
+    match strip_parens(expr) {
+        Expr::Member(member) => member_is_add_event_listener(member),
+        Expr::OptChain(opt) => match opt.base.as_ref() {
+            OptChainBase::Member(member) => member_is_add_event_listener(member),
+            OptChainBase::Call(_) => false,
+        },
+        _ => false,
+    }
+}
+
+fn member_is_add_event_listener(member: &MemberExpr) -> bool {
+    matches!(
+        &member.prop,
+        MemberProp::Ident(prop) if prop.sym.as_ref() == "addEventListener"
+    )
+}
+
+fn is_no_sync_callback_member_call(
+    callee: &Expr,
+    no_sync_callback_members: &BTreeMap<String, BTreeSet<String>>,
+) -> bool {
+    match strip_parens(callee) {
+        Expr::Member(member) => member_matches_no_sync_callback(member, no_sync_callback_members),
+        Expr::OptChain(opt) => match opt.base.as_ref() {
+            OptChainBase::Member(member) => {
+                member_matches_no_sync_callback(member, no_sync_callback_members)
+            }
+            OptChainBase::Call(_) => false,
+        },
+        _ => false,
+    }
+}
+
+fn member_matches_no_sync_callback(
+    member: &MemberExpr,
+    no_sync_callback_members: &BTreeMap<String, BTreeSet<String>>,
+) -> bool {
+    let Expr::Ident(receiver) = strip_parens(member.obj.as_ref()) else {
+        return false;
+    };
+    let MemberProp::Ident(prop) = &member.prop else {
+        return false;
+    };
+    no_sync_callback_members
+        .get(receiver.sym.as_ref())
+        .is_some_and(|props| props.contains(prop.sym.as_ref()))
+}
+
+struct NoSyncMemberArgumentSourceCollector<'a> {
+    no_sync_callback_members: &'a BTreeMap<String, BTreeSet<String>>,
+    sources: PositionBucketed<BTreeSet<Id>>,
+    lazy_depth: u32,
+    past_await: bool,
+}
+
+impl NoSyncMemberArgumentSourceCollector<'_> {
+    fn collect_no_sync_args(&mut self, args: &[ExprOrSpread]) {
+        if self.lazy_depth > 1 || (self.lazy_depth == 1 && self.past_await) {
+            return;
+        }
+        for arg in args {
+            let mut sources = UnresolvedCallSourceCollector::default();
+            arg.expr.visit_with(&mut sources);
+            for id in sources.idents {
+                self.sources.record(&id, self.lazy_depth, self.past_await);
+            }
+        }
+    }
+}
+
+impl LazyBoundary for NoSyncMemberArgumentSourceCollector<'_> {
+    fn lazy_depth_mut(&mut self) -> &mut u32 {
+        &mut self.lazy_depth
+    }
+
+    fn past_await_mut(&mut self) -> &mut bool {
+        &mut self.past_await
+    }
+}
+
+impl Visit for NoSyncMemberArgumentSourceCollector<'_> {
+    fn visit_call_expr(&mut self, node: &CallExpr) {
+        if let Callee::Expr(callee) = &node.callee
+            && is_no_sync_callback_member_call(callee, self.no_sync_callback_members)
+        {
+            self.collect_no_sync_args(&node.args);
+        }
+        node.visit_children_with(self);
+    }
+
+    fn visit_opt_call(&mut self, node: &OptCall) {
+        if is_no_sync_callback_member_call(&node.callee, self.no_sync_callback_members) {
+            self.collect_no_sync_args(&node.args);
+        }
+        node.visit_children_with(self);
+    }
+
+    fn visit_await_expr(&mut self, node: &AwaitExpr) {
+        node.visit_children_with(self);
+        self.past_await = true;
+    }
+
+    fn visit_function(&mut self, node: &Function) {
+        lazy_visit_function(self, node);
+    }
+    fn visit_arrow_expr(&mut self, node: &ArrowExpr) {
+        lazy_visit_arrow_expr(self, node);
+    }
+    fn visit_method_prop(&mut self, node: &MethodProp) {
+        lazy_visit_method_prop(self, node);
+    }
+    fn visit_getter_prop(&mut self, node: &GetterProp) {
+        lazy_visit_getter_prop(self, node);
+    }
+    fn visit_setter_prop(&mut self, node: &SetterProp) {
+        lazy_visit_setter_prop(self, node);
+    }
+    fn visit_class(&mut self, node: &Class) {
+        lazy_visit_class(self, node);
+    }
+}
+
+struct UntrustedAtInitInlineFnFallbackFinder<'a> {
+    no_sync_callback_members: &'a BTreeMap<String, BTreeSet<String>>,
+    found: bool,
+    lazy_depth: u32,
+}
+
+impl UntrustedAtInitInlineFnFallbackFinder<'_> {
+    fn is_no_sync_callback_member_call(&self, node: &CallExpr) -> bool {
+        let Callee::Expr(callee) = &node.callee else {
+            return false;
+        };
+        is_no_sync_callback_member_call(callee, self.no_sync_callback_members)
+    }
+
+    fn node_has_inline_fn<N: VisitWith<UnresolvedCallSourceCollector>>(&self, node: &N) -> bool {
+        let mut sources = UnresolvedCallSourceCollector::default();
+        node.visit_with(&mut sources);
+        sources.inline_fn
+    }
+}
+
+impl Visit for UntrustedAtInitInlineFnFallbackFinder<'_> {
+    fn visit_call_expr(&mut self, node: &CallExpr) {
+        if self.found {
+            return;
+        }
+        if self.lazy_depth == 0 {
+            match &node.callee {
+                Callee::Expr(callee) => match strip_parens(callee) {
+                    Expr::Ident(_) => {}
+                    _ if self.node_has_inline_fn(node)
+                        && !is_static_event_listener_registration(callee, &node.args)
+                        && !self.is_no_sync_callback_member_call(node) =>
+                    {
+                        self.found = true;
+                        return;
+                    }
+                    _ => {}
+                },
+                Callee::Import(_) | Callee::Super(_) => {}
+            }
+        }
+        node.visit_children_with(self);
+    }
+
+    fn visit_opt_call(&mut self, node: &OptCall) {
+        if self.lazy_depth == 0
+            && self.node_has_inline_fn(node)
+            && !is_static_event_listener_registration(&node.callee, &node.args)
+        {
+            self.found = true;
+            return;
+        }
+        node.visit_children_with(self);
+    }
+
+    fn visit_tagged_tpl(&mut self, node: &TaggedTpl) {
+        if self.lazy_depth == 0 && self.node_has_inline_fn(node) {
+            self.found = true;
+            return;
+        }
+        node.visit_children_with(self);
+    }
+
+    fn visit_function(&mut self, _node: &Function) {}
+    fn visit_arrow_expr(&mut self, _node: &ArrowExpr) {}
+    fn visit_method_prop(&mut self, _node: &MethodProp) {}
+    fn visit_getter_prop(&mut self, _node: &GetterProp) {}
+    fn visit_setter_prop(&mut self, _node: &SetterProp) {}
+    fn visit_class(&mut self, _node: &Class) {}
 }
 
 fn item_purity(
@@ -1251,6 +1710,47 @@ fn declares_direct_function(item: &ModuleItem) -> bool {
     }
 }
 
+fn collect_async_direct_function_bindings(body: &[TopLevelItemView<'_>]) -> BTreeSet<Id> {
+    body.iter()
+        .filter_map(|item| async_direct_function_binding(item.as_module_item()))
+        .collect()
+}
+
+fn async_direct_function_binding(item: &ModuleItem) -> Option<Id> {
+    match item {
+        ModuleItem::Stmt(Stmt::Decl(Decl::Fn(fn_decl))) if fn_decl.function.is_async => {
+            Some(fn_decl.ident.to_id())
+        }
+        ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(decl)) => match &decl.decl {
+            Decl::Fn(fn_decl) if fn_decl.function.is_async => Some(fn_decl.ident.to_id()),
+            _ => var_decl_of_item(item).and_then(async_var_function_binding),
+        },
+        ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultDecl(decl)) => match &decl.decl {
+            DefaultDecl::Fn(fn_expr) if fn_expr.function.is_async => {
+                fn_expr.ident.as_ref().map(|ident| ident.to_id())
+            }
+            _ => None,
+        },
+        _ => var_decl_of_item(item).and_then(async_var_function_binding),
+    }
+}
+
+fn async_var_function_binding(var: &VarDecl) -> Option<Id> {
+    if var.decls.len() != 1 {
+        return None;
+    }
+    let Pat::Ident(binding) = &var.decls[0].name else {
+        return None;
+    };
+    let init = var.decls[0].init.as_deref().map(strip_parens)?;
+    let is_async = match init {
+        Expr::Fn(fn_expr) => fn_expr.function.is_async,
+        Expr::Arrow(arrow) => arrow.is_async,
+        _ => false,
+    };
+    is_async.then(|| binding.id.to_id())
+}
+
 /// Shared trait for visitors that track lazy nesting depth and the
 /// per-body "past first await" boundary.
 ///
@@ -1333,16 +1833,24 @@ struct StatementFactsCollector {
     /// (`globalThis`, `window`, ...). See
     /// [`unshadowed_global_object_aliases`].
     global_object_names: BTreeSet<&'static str>,
+    async_direct_function_bindings: BTreeSet<Id>,
+    promise_global_unshadowed: bool,
     lazy_depth: u32,
     past_await: bool,
 }
 
 impl StatementFactsCollector {
-    fn new(global_object_names: BTreeSet<&'static str>) -> Self {
+    fn new(
+        global_object_names: BTreeSet<&'static str>,
+        async_direct_function_bindings: BTreeSet<Id>,
+        promise_global_unshadowed: bool,
+    ) -> Self {
         Self {
             cell_writes_summarizable: true,
             dataflow_summarizable: true,
             global_object_names,
+            async_direct_function_bindings,
+            promise_global_unshadowed,
             ..Self::default()
         }
     }
@@ -1368,19 +1876,114 @@ impl StatementFactsCollector {
     /// statement takes the read-closure fallback over those sources;
     /// in a first-order body they propagate to at-init callers
     /// through the promotion call graph.
-    fn record_unresolved_call<N: VisitWith<UnresolvedCallSourceCollector>>(&mut self, node: &N) {
+    fn record_unresolved_call<N>(&mut self, node: &N)
+    where
+        N: VisitWith<UnresolvedCallSourceCollector> + VisitWith<SyncInlineEffectCollector>,
+    {
         if self.lazy_depth > 1 || (self.lazy_depth == 1 && self.past_await) {
             return;
         }
         let mut sources = UnresolvedCallSourceCollector::default();
         node.visit_with(&mut sources);
+        let needs_owner_inline_fallback = if sources.inline_fn && self.lazy_depth > 0 {
+            let mut inline_effects =
+                SyncInlineEffectCollector::new(self.lazy_depth, self.past_await);
+            node.visit_with(&mut inline_effects);
+            let needs_owner_fallback = inline_effects.needs_owner_fallback;
+            self.merge_sync_inline_effects(inline_effects.effects);
+            needs_owner_fallback
+        } else {
+            sources.inline_fn
+        };
         if self.lazy_depth == 0 {
             self.at_init_unresolved_sources.extend(sources.idents);
-            self.at_init_unresolved_inline_fn |= sources.inline_fn;
+            self.at_init_unresolved_inline_fn |= needs_owner_inline_fallback;
         } else {
             self.first_order_unresolved_sources.extend(sources.idents);
-            self.first_order_unresolved_inline_fn |= sources.inline_fn;
+            self.first_order_unresolved_inline_fn |= needs_owner_inline_fallback;
         }
+    }
+
+    fn merge_sync_inline_effects(&mut self, effects: SyncInlineEffects) {
+        self.reads.extend(effects.reads);
+        self.rebinds.extend(effects.rebinds);
+        self.calls.extend(effects.calls);
+        self.at_init_unresolved_sources
+            .extend(effects.unresolved_sources.eager);
+        self.first_order_unresolved_sources
+            .extend(effects.unresolved_sources.first_order_lazy);
+    }
+
+    fn is_known_promise_reaction_call(&self, node: &CallExpr) -> bool {
+        let Callee::Expr(callee) = &node.callee else {
+            return false;
+        };
+        let Expr::Member(member) = strip_parens(callee) else {
+            return false;
+        };
+        if !matches!(
+            &member.prop,
+            MemberProp::Ident(prop)
+                if matches!(prop.sym.as_ref(), "then" | "catch" | "finally")
+        ) {
+            return false;
+        }
+        self.is_known_promise_expr(member.obj.as_ref())
+    }
+
+    fn is_known_promise_expr(&self, expr: &Expr) -> bool {
+        match strip_parens(expr) {
+            Expr::Call(call) => {
+                self.is_async_direct_function_call(call) || self.is_promise_static_call(call)
+            }
+            Expr::New(new_expr) => {
+                self.promise_global_unshadowed
+                    && matches!(strip_parens(&new_expr.callee), Expr::Ident(ident) if ident.sym.as_ref() == "Promise")
+            }
+            _ => false,
+        }
+    }
+
+    fn is_known_event_listener_registration_call(&self, node: &CallExpr) -> bool {
+        let Callee::Expr(callee) = &node.callee else {
+            return false;
+        };
+        is_static_event_listener_registration(callee, &node.args)
+    }
+
+    fn is_known_event_listener_registration_opt_call(&self, node: &OptCall) -> bool {
+        is_static_event_listener_registration(&node.callee, &node.args)
+    }
+
+    fn is_async_direct_function_call(&self, call: &CallExpr) -> bool {
+        let Callee::Expr(callee) = &call.callee else {
+            return false;
+        };
+        let Expr::Ident(ident) = strip_parens(callee) else {
+            return false;
+        };
+        self.async_direct_function_bindings.contains(&ident.to_id())
+    }
+
+    fn is_promise_static_call(&self, call: &CallExpr) -> bool {
+        if !self.promise_global_unshadowed {
+            return false;
+        }
+        let Callee::Expr(callee) = &call.callee else {
+            return false;
+        };
+        let Expr::Member(member) = strip_parens(callee) else {
+            return false;
+        };
+        matches!(strip_parens(member.obj.as_ref()), Expr::Ident(obj) if obj.sym.as_ref() == "Promise")
+            && matches!(
+                &member.prop,
+                MemberProp::Ident(prop)
+                    if matches!(
+                        prop.sym.as_ref(),
+                        "resolve" | "reject" | "all" | "allSettled" | "any" | "race"
+                    )
+            )
     }
 
     /// Bail only the S-chain's "which cells does this touch"
@@ -1458,6 +2061,210 @@ impl Visit for UnresolvedCallSourceCollector {
     }
     fn visit_setter_prop(&mut self, _node: &SetterProp) {
         self.inline_fn = true;
+    }
+}
+
+#[derive(Default)]
+struct SyncInlineEffects {
+    reads: PositionBucketed<BTreeSet<Id>>,
+    rebinds: PositionBucketed<BTreeSet<Id>>,
+    calls: PositionBucketed<BTreeSet<Id>>,
+    unresolved_sources: PositionBucketed<BTreeSet<Id>>,
+}
+
+/// Effects from inline function arguments that an unresolved call may
+/// invoke synchronously. The containing statement/function already has
+/// its own lazy-depth position; if the callback fires immediately, the
+/// callback body's pre-await effects happen at that same position.
+struct SyncInlineEffectCollector {
+    effects: SyncInlineEffects,
+    outer_lazy_depth: u32,
+    outer_past_await: bool,
+    inline_depth: u32,
+    past_await: bool,
+    needs_owner_fallback: bool,
+}
+
+impl SyncInlineEffectCollector {
+    fn new(outer_lazy_depth: u32, outer_past_await: bool) -> Self {
+        Self {
+            effects: SyncInlineEffects::default(),
+            outer_lazy_depth,
+            outer_past_await,
+            inline_depth: 0,
+            past_await: false,
+            needs_owner_fallback: false,
+        }
+    }
+
+    fn active(&self) -> bool {
+        self.inline_depth > 0 && !self.outer_past_await && !self.past_await
+    }
+
+    fn record_read(&mut self, id: &Id) {
+        if self.active() {
+            self.effects
+                .reads
+                .record(id, self.outer_lazy_depth, self.outer_past_await);
+        }
+    }
+
+    fn record_write(&mut self, id: &Id) {
+        if self.active() {
+            self.effects
+                .rebinds
+                .record(id, self.outer_lazy_depth, self.outer_past_await);
+        }
+    }
+
+    fn record_call(&mut self, id: &Id) {
+        if self.active() {
+            self.effects
+                .calls
+                .record(id, self.outer_lazy_depth, self.outer_past_await);
+        }
+    }
+
+    fn record_unresolved_call<N: VisitWith<UnresolvedCallSourceCollector>>(&mut self, node: &N) {
+        if !self.active() {
+            return;
+        }
+        let mut sources = UnresolvedCallSourceCollector::default();
+        node.visit_with(&mut sources);
+        for id in sources.idents {
+            self.effects.unresolved_sources.record(
+                &id,
+                self.outer_lazy_depth,
+                self.outer_past_await,
+            );
+        }
+    }
+
+    fn visit_inline_function_body(&mut self, visit_body: impl FnOnce(&mut Self)) {
+        if self.outer_past_await || self.past_await {
+            return;
+        }
+        let saved_past_await = self.past_await;
+        self.past_await = false;
+        self.inline_depth += 1;
+        visit_body(self);
+        self.inline_depth -= 1;
+        self.past_await = saved_past_await;
+    }
+}
+
+impl TargetAccessRecorder for SyncInlineEffectCollector {
+    fn record_binding_write(&mut self, id: &Id) {
+        self.record_write(id);
+    }
+
+    fn record_member_write(&mut self, _id: &Id) {}
+}
+
+impl Visit for SyncInlineEffectCollector {
+    fn visit_ident(&mut self, node: &Ident) {
+        self.record_read(&node.to_id());
+    }
+
+    fn visit_binding_ident(&mut self, _node: &BindingIdent) {}
+
+    fn visit_function(&mut self, node: &Function) {
+        self.visit_inline_function_body(|s| {
+            for param in &node.params {
+                param.visit_with(s);
+            }
+            if let Some(body) = &node.body {
+                body.visit_with(s);
+            }
+        });
+    }
+
+    fn visit_arrow_expr(&mut self, node: &ArrowExpr) {
+        self.visit_inline_function_body(|s| {
+            for param in &node.params {
+                param.visit_with(s);
+            }
+            node.body.visit_with(s);
+        });
+    }
+
+    fn visit_class(&mut self, _node: &Class) {
+        self.needs_owner_fallback = true;
+    }
+
+    fn visit_await_expr(&mut self, node: &AwaitExpr) {
+        node.arg.visit_with(self);
+        if self.inline_depth > 0 {
+            self.past_await = true;
+        }
+    }
+
+    fn visit_call_expr(&mut self, node: &CallExpr) {
+        if let Callee::Expr(callee) = &node.callee {
+            callee.visit_with(self);
+        }
+        for arg in &node.args {
+            arg.visit_with(self);
+        }
+        if self.active() {
+            match &node.callee {
+                Callee::Expr(callee) => match strip_parens(callee) {
+                    Expr::Ident(ident) => self.record_call(&ident.to_id()),
+                    _ => self.record_unresolved_call(node),
+                },
+                Callee::Import(_) | Callee::Super(_) => {}
+            }
+        }
+    }
+
+    fn visit_opt_call(&mut self, node: &OptCall) {
+        node.callee.visit_with(self);
+        for arg in &node.args {
+            arg.visit_with(self);
+        }
+        self.record_unresolved_call(node);
+    }
+
+    fn visit_tagged_tpl(&mut self, node: &TaggedTpl) {
+        node.tag.visit_with(self);
+        node.tpl.visit_with(self);
+        self.record_unresolved_call(node);
+    }
+
+    fn visit_assign_expr(&mut self, node: &AssignExpr) {
+        if self.active() {
+            record_assign_target(&node.left, self);
+        }
+        node.visit_children_with(self);
+    }
+
+    fn visit_update_expr(&mut self, node: &UpdateExpr) {
+        if self.active() {
+            record_update_target(&node.arg, self);
+        }
+        node.arg.visit_with(self);
+    }
+
+    fn visit_for_in_stmt(&mut self, node: &ForInStmt) {
+        if self.active()
+            && let ForHead::Pat(pattern) = &node.left
+        {
+            record_pat_write(pattern, self);
+        }
+        node.left.visit_with(self);
+        node.right.visit_with(self);
+        node.body.visit_with(self);
+    }
+
+    fn visit_for_of_stmt(&mut self, node: &ForOfStmt) {
+        if self.active()
+            && let ForHead::Pat(pattern) = &node.left
+        {
+            record_pat_write(pattern, self);
+        }
+        node.left.visit_with(self);
+        node.right.visit_with(self);
+        node.body.visit_with(self);
     }
 }
 
@@ -1621,10 +2428,24 @@ impl Visit for StatementFactsCollector {
     // ...)` / `Reflect.defineProperty(globalThis, ...)`, and
     // `new Proxy(globalThis, ...)`.
     fn visit_call_expr(&mut self, node: &CallExpr) {
+        // Callee/argument expressions evaluate before the call. If one
+        // of them contains an `await` in an async body, the call itself
+        // happens after suspension and must not be first-order.
+        if let Callee::Expr(callee) = &node.callee {
+            callee.visit_with(self);
+        }
+        for arg in &node.args {
+            arg.visit_with(self);
+        }
         match &node.callee {
             Callee::Expr(callee) => match strip_parens(callee) {
                 Expr::Ident(ident) => self.record_call(&ident.to_id()),
-                _ => self.record_unresolved_call(node),
+                _ if !self.is_known_promise_reaction_call(node)
+                    && !self.is_known_event_listener_registration_call(node) =>
+                {
+                    self.record_unresolved_call(node);
+                }
+                _ => {}
             },
             // `import(...)` evaluates another chunk asynchronously —
             // it never synchronously runs this chunk's functions.
@@ -1654,10 +2475,15 @@ impl Visit for StatementFactsCollector {
                 self.bail_cell_writes();
             }
         }
-        node.visit_children_with(self);
     }
 
     fn visit_new_expr(&mut self, node: &NewExpr) {
+        node.callee.visit_with(self);
+        if let Some(args) = &node.args {
+            for arg in args {
+                arg.visit_with(self);
+            }
+        }
         if self.lazy_depth == 0
             && let Expr::Ident(ident) = strip_parens(&node.callee)
         {
@@ -1676,20 +2502,25 @@ impl Visit for StatementFactsCollector {
                 _ => {}
             }
         }
-        node.visit_children_with(self);
     }
 
     fn visit_opt_call(&mut self, node: &OptCall) {
         // `f?.()` / `obj?.m()`: the callee is never a resolvable
         // bare-Ident shape for promotion.
-        self.record_unresolved_call(node);
-        node.visit_children_with(self);
+        node.callee.visit_with(self);
+        for arg in &node.args {
+            arg.visit_with(self);
+        }
+        if !self.is_known_event_listener_registration_opt_call(node) {
+            self.record_unresolved_call(node);
+        }
     }
 
     fn visit_tagged_tpl(&mut self, node: &TaggedTpl) {
         // `` tag`...` `` invokes the tag function.
+        node.tag.visit_with(self);
+        node.tpl.visit_with(self);
         self.record_unresolved_call(node);
-        node.visit_children_with(self);
     }
 
     fn visit_member_expr(&mut self, node: &MemberExpr) {

--- a/devinfra/js/debundle/graph.rs
+++ b/devinfra/js/debundle/graph.rs
@@ -1031,11 +1031,12 @@ fn emit_s_chain(
 /// reads/rebinds too. See docs/design.md "At-init call promotion".
 ///
 /// Per-statement dedup: at most one promoted eager edge per
-/// (caller, target-owner) pair, and at most one promoted rebind edge
-/// per (caller, target-owner) pair. Without dedup, a single
-/// at-init call to a function with N transitive lazy reads would emit
-/// N edges from the caller, and multiple at-init calls in the same
-/// statement would multiply that further.
+/// (caller, target-owner) pair. Rebind targets are also promoted as
+/// eager order edges; the write site's direct rebind edge enforces
+/// write legality. Without dedup, a single at-init call to a
+/// function with N transitive lazy reads would emit N edges from the
+/// caller, and multiple at-init calls in the same statement would
+/// multiply that further.
 fn promote_at_init_calls(
     facts: &[StatementFacts],
     binding_owner: &HashMap<Id, OwnerId>,
@@ -1243,12 +1244,46 @@ fn promote_at_init_calls(
         }
         let caller = OwnerId(stmt.ordinal.0);
         let mut promoted_read_targets: BTreeSet<OwnerId> = BTreeSet::new();
-        let mut promoted_rebind_targets: BTreeSet<OwnerId> = BTreeSet::new();
-        let mut fallback_roots = fallback_roots_of(
-            &stmt.at_init_unresolved_sources,
-            stmt.at_init_unresolved_inline_fn,
-            caller,
-        );
+        let mut fallback_roots = fallback_roots_of(&stmt.at_init_unresolved_sources, false, caller);
+        if stmt.at_init_unresolved_inline_fn
+            && let Some(&scc_idx) = scc_of.get(&caller)
+        {
+            fallback_roots.extend(scc_fallback_roots[scc_idx].iter().copied());
+            for target_binding in &scc_reads[scc_idx] {
+                let Some(target_owner) = binding_owner.get(target_binding) else {
+                    continue;
+                };
+                if caller == *target_owner {
+                    continue;
+                }
+                if !promoted_read_targets.insert(*target_owner) {
+                    continue;
+                }
+                raw_edges.push((
+                    caller,
+                    *target_owner,
+                    EdgeReason::eager_use(stmt.ordinal, target_binding.clone())
+                        .promoted_at_init(caller),
+                ));
+            }
+            for target_binding in &scc_rebinds[scc_idx] {
+                let Some(target_owner) = binding_owner.get(target_binding) else {
+                    continue;
+                };
+                if caller == *target_owner {
+                    continue;
+                }
+                if !promoted_read_targets.insert(*target_owner) {
+                    continue;
+                }
+                raw_edges.push((
+                    caller,
+                    *target_owner,
+                    EdgeReason::eager_use(stmt.ordinal, target_binding.clone())
+                        .promoted_at_init(caller),
+                ));
+            }
+        }
         for callee_id in &stmt.calls.eager {
             let Some(callee_owner) = resolvable_callee(callee_id) else {
                 // A bare-Ident callee that isn't chunk-declared is a
@@ -1289,13 +1324,13 @@ fn promote_at_init_calls(
                 if caller == *target_owner {
                     continue;
                 }
-                if !promoted_rebind_targets.insert(*target_owner) {
+                if !promoted_read_targets.insert(*target_owner) {
                     continue;
                 }
                 raw_edges.push((
                     caller,
                     *target_owner,
-                    EdgeReason::eager_rebind(stmt.ordinal, target_binding.clone())
+                    EdgeReason::eager_use(stmt.ordinal, target_binding.clone())
                         .promoted_at_init(callee_owner),
                 ));
             }

--- a/devinfra/js/debundle/lowering/materialize/mod.rs
+++ b/devinfra/js/debundle/lowering/materialize/mod.rs
@@ -224,6 +224,7 @@ pub(super) fn materialize_logical_chunk(
         if owner_graph_options.local_property_effects {
             hints.local_effect_policy = LocalEffectPolicy::LocalPropertyWrites;
         }
+        hints.trusted_dataflow_summaries = owner_graph_options.trusted_dataflow_summaries;
         hints
     });
     let line_index = time_phase!(timings, "build_source_line_index", {

--- a/devinfra/js/debundle/lowering/plans.rs
+++ b/devinfra/js/debundle/lowering/plans.rs
@@ -59,6 +59,10 @@ pub(super) struct MemberRequest {
     /// AGENTS.md "Declared purity". Empty when the spec doesn't carry a
     /// `pure_members` entry for this member.
     pub(super) pure_members: Vec<String>,
+    /// Property names on the bound value whose calls do not
+    /// synchronously invoke callback arguments. The call may still be
+    /// impure; this only narrows callback-body at-init promotion.
+    pub(super) no_sync_callback_members: Vec<String>,
     /// Per-member human-readable comment from the spec. Emitted as a
     /// `// ...` block above the binding's owner statement in the
     /// generated module body. See [`spec::Member::comment`].
@@ -105,6 +109,13 @@ impl MemberRequest {
                 .entry(self.binding.clone())
                 .or_default()
                 .extend(self.pure_members.iter().cloned());
+        }
+        if !self.no_sync_callback_members.is_empty() {
+            hints
+                .no_sync_callback_members
+                .entry(self.binding.clone())
+                .or_default()
+                .extend(self.no_sync_callback_members.iter().cloned());
         }
         if let Some(effect) = known_effect_from_member_effect(self.effect) {
             hints.known_effects.insert(self.binding.clone(), effect);
@@ -276,6 +287,7 @@ pub(super) fn build_members(
                 purity: m.purity,
                 effect: m.effect,
                 pure_members: m.pure_members.clone(),
+                no_sync_callback_members: m.no_sync_callback_members.clone(),
                 comment: m.comment.clone(),
             })
         })
@@ -293,6 +305,7 @@ pub(super) fn build_members(
                 purity: MemberPurity::Default,
                 effect: MemberEffect::Default,
                 pure_members: Vec::new(),
+                no_sync_callback_members: Vec::new(),
                 comment: None,
             });
         }

--- a/devinfra/js/debundle/purity/classifier_tests.rs
+++ b/devinfra/js/debundle/purity/classifier_tests.rs
@@ -1143,6 +1143,42 @@ fn object_freeze_on_plain_object_literal_classifies_pure() {
 }
 
 #[test]
+fn object_freeze_on_vite_namespace_facade_classifies_pure() {
+    assert!(
+        (classify(
+            r#"Object.freeze(Object.defineProperty(
+                { __proto__: null, run: handler },
+                Symbol.toStringTag,
+                { value: "Module" }
+            ))"#,
+        ))
+        .is_pure()
+    );
+}
+
+#[test]
+fn object_define_property_namespace_facade_requires_fresh_target() {
+    assert!(
+        !(classify(r#"Object.defineProperty(target, Symbol.toStringTag, { value: "Module" })"#))
+            .is_pure()
+    );
+}
+
+#[test]
+fn object_define_property_namespace_facade_rejects_accessor_descriptor() {
+    assert!(
+        !(classify(
+            r#"Object.defineProperty(
+                { __proto__: null, run: handler },
+                Symbol.toStringTag,
+                { get: () => handler }
+            )"#,
+        ))
+        .is_pure()
+    );
+}
+
+#[test]
 fn object_keys_on_plain_array_literal_classifies_pure() {
     // Array literals are ordinary objects with integer-index
     // own data properties — same admission as object literals.

--- a/devinfra/js/debundle/purity/graph_purity_tests.rs
+++ b/devinfra/js/debundle/purity/graph_purity_tests.rs
@@ -262,6 +262,14 @@ fn is_plain_data(src: &str, name: &str) -> bool {
     graph.is_plain_data(name)
 }
 
+fn is_plain_array(src: &str, name: &str) -> bool {
+    let module = parse(src);
+    let body = top_level_item_views(&module.body);
+    let shadowed = compute_shadowed_globals(&body);
+    let graph = ChunkCodeGraph::build(&body, &shadowed, &BTreeSet::new());
+    graph.is_plain_array(name)
+}
+
 #[test]
 fn plain_data_const_object_literal_is_tracked() {
     // A vanilla data shape: KeyValue with non-computed keys,
@@ -274,6 +282,49 @@ fn plain_data_const_object_literal_is_tracked() {
 #[test]
 fn plain_data_const_array_literal_is_tracked() {
     assert!(is_plain_data("const TA = [1, 2, 3];", "TA"));
+}
+
+#[test]
+fn plain_array_const_collection_methods_are_tracked() {
+    let src = r#"
+const later = "ready";
+const tools = [{ name: "tool", systemNodeId: "tool-id", run: () => later }];
+const byName = Object.fromEntries(tools.map((tool) => [tool.name, tool]));
+const ids = [...tools.filter((tool) => tool.systemNodeId).map((tool) => tool.systemNodeId)];
+tools.forEach((tool) => {
+  tool.systemNodeId && (globalThis.byId = tool.name);
+});
+export { tools };
+"#;
+    assert!(is_plain_array(src, "tools"));
+}
+
+#[test]
+fn plain_array_const_derived_by_non_mutating_methods_is_tracked() {
+    let src = r#"
+const later = "ready";
+const pairs = [["tool", "tool-id"]];
+const tools = pairs.map(([name, systemNodeId]) => ({
+  name,
+  systemNodeId,
+  run: () => later,
+}));
+const filtered = tools.filter((tool) => tool.systemNodeId);
+const cloned = filtered.slice();
+export { tools, filtered, cloned };
+"#;
+    assert!(is_plain_array(src, "pairs"));
+    assert!(is_plain_array(src, "tools"));
+    assert!(is_plain_array(src, "filtered"));
+    assert!(is_plain_array(src, "cloned"));
+}
+
+#[test]
+fn plain_array_const_mutating_method_is_not_tracked() {
+    assert!(!is_plain_array(
+        "const values = []; values.push(1);",
+        "values"
+    ));
 }
 
 #[test]

--- a/devinfra/js/debundle/purity/mod.rs
+++ b/devinfra/js/debundle/purity/mod.rs
@@ -50,6 +50,13 @@ pub struct ChunkCodeGraph {
     /// classified separately at its declaration site; only the
     /// *value* class matters here. See `collect_primitive_const_bindings`.
     primitive_const_bindings: BTreeSet<String>,
+    /// Chunk-top `const X = [..]` bindings that remain static ordinary
+    /// arrays under the same no-escape scan as `PlainData`, and are
+    /// never used as the receiver of unknown/mutating array methods.
+    /// At-init fallback uses this to avoid treating `X.map(cb)` /
+    /// `X.forEach(cb)` as if those built-ins might invoke functions
+    /// held inside `X`; the callback body is still modeled separately.
+    plain_array_bindings: BTreeSet<String>,
     /// Purity verdict for chunk-top bindings that are imports of a
     /// function from another module, keyed by local binding name.
     /// Populated by the program-level cross-module purity oracle;
@@ -199,6 +206,7 @@ impl ChunkCodeGraph {
             pure_new_constructors: declared_pure_new.clone(),
             declared_pure_members: declared_pure_members.clone(),
             primitive_const_bindings: collect_primitive_const_bindings(body),
+            plain_array_bindings: collect_plain_array_bindings(body, shadowed),
             imported_purities: imported_purities.clone(),
             fluent_bindings: collect_fluent_const_bindings(body, fluent_bindings),
         };
@@ -275,6 +283,12 @@ impl ChunkCodeGraph {
     /// `ChunkBinding::PlainData`).
     pub(crate) fn is_plain_data(&self, name: &str) -> bool {
         matches!(self.bindings.get(name), Some(ChunkBinding::PlainData))
+    }
+
+    /// Whether `name` is a static ordinary array binding suitable for
+    /// array-method at-init fallback refinement.
+    pub(crate) fn is_plain_array(&self, name: &str) -> bool {
+        self.plain_array_bindings.contains(name)
     }
 
     pub(crate) fn is_declared_pure_new(&self, name: &str) -> bool {
@@ -766,6 +780,93 @@ fn collect_plain_data_bindings(
         .into_iter()
         .filter(|n| !disqualified.contains(n))
         .collect()
+}
+
+const SAFE_PLAIN_ARRAY_METHODS: &[&str] = &["filter", "flatMap", "forEach", "map", "slice"];
+const ARRAY_PRODUCING_METHODS: &[&str] = &["filter", "flatMap", "map", "slice"];
+
+fn collect_plain_array_bindings(
+    body: &[TopLevelItemView<'_>],
+    shadowed: &BTreeSet<&'static str>,
+) -> BTreeSet<String> {
+    let mut const_inits = Vec::new();
+    for item in body {
+        const_inits.extend(
+            plain_data_var_candidates(item.as_module_item())
+                .into_iter()
+                .filter_map(|(name, init, kind)| {
+                    (kind == VarDeclKind::Const).then_some((name, init))
+                }),
+        );
+    }
+    let mut candidates = BTreeSet::new();
+    loop {
+        let before = candidates.len();
+        for (name, init) in &const_inits {
+            if expr_returns_plain_array(init, &candidates) {
+                candidates.insert(name.clone());
+            }
+        }
+        if candidates.len() == before {
+            break;
+        }
+    }
+    if candidates.is_empty() {
+        return BTreeSet::new();
+    }
+
+    let mut plain_data_scanner = PlainDataWriteScanner {
+        candidates: &candidates,
+        shadowed,
+        disqualified: BTreeSet::new(),
+        shadowing_scopes: Vec::new(),
+    };
+    let mut method_scanner = PlainArrayMethodScanner {
+        candidates: &candidates,
+        disqualified: BTreeSet::new(),
+        shadowing_scopes: Vec::new(),
+    };
+    for item in body {
+        let item = item.as_module_item();
+        item.visit_with(&mut plain_data_scanner);
+        item.visit_with(&mut method_scanner);
+    }
+
+    let mut disqualified = plain_data_scanner.disqualified;
+    disqualified.extend(method_scanner.disqualified);
+    candidates
+        .into_iter()
+        .filter(|name| !disqualified.contains(name))
+        .collect()
+}
+
+fn expr_returns_plain_array(expr: &Expr, known_plain_arrays: &BTreeSet<String>) -> bool {
+    match strip_parens(expr) {
+        Expr::Array(_) => true,
+        Expr::Ident(ident) => known_plain_arrays.contains(ident.sym.as_ref()),
+        Expr::Call(call) => {
+            let Callee::Expr(callee) = &call.callee else {
+                return false;
+            };
+            let Expr::Member(member) = strip_parens(callee) else {
+                return false;
+            };
+            matches!(
+                &member.prop,
+                MemberProp::Ident(prop) if ARRAY_PRODUCING_METHODS.contains(&prop.sym.as_ref())
+            ) && expr_is_plain_array_receiver(member.obj.as_ref(), known_plain_arrays)
+        }
+        _ => false,
+    }
+}
+
+fn expr_is_plain_array_receiver(expr: &Expr, known_plain_arrays: &BTreeSet<String>) -> bool {
+    match strip_parens(expr) {
+        Expr::Array(_) => true,
+        Expr::Ident(ident) => known_plain_arrays.contains(ident.sym.as_ref()),
+        Expr::Call(_) => expr_returns_plain_array(expr, known_plain_arrays),
+        _ => false,
+    }
 }
 
 /// Chunk-top `const X = <init>` names whose init evaluates to a
@@ -1711,6 +1812,109 @@ impl Visit for PlainDataWriteScanner<'_> {
                 BlockStmtOrExpr::Expr(expr) if matches!(strip_parens(expr), Expr::Ident(_)) => {}
                 body => body.visit_with(s),
             }
+        });
+    }
+
+    fn visit_function(&mut self, node: &Function) {
+        let scope = self.shadowed_by_params(node.params.iter().map(|p| &p.pat));
+        self.with_scope(scope, |s| node.visit_children_with(s));
+    }
+}
+
+struct PlainArrayMethodScanner<'a> {
+    candidates: &'a BTreeSet<String>,
+    disqualified: BTreeSet<String>,
+    shadowing_scopes: Vec<BTreeSet<String>>,
+}
+
+impl PlainArrayMethodScanner<'_> {
+    fn is_shadowed(&self, name: &str) -> bool {
+        self.shadowing_scopes
+            .iter()
+            .any(|scope| scope.contains(name))
+    }
+
+    fn with_scope<F: FnOnce(&mut Self)>(&mut self, scope: BTreeSet<String>, f: F) {
+        self.shadowing_scopes.push(scope);
+        f(self);
+        self.shadowing_scopes.pop();
+    }
+
+    fn disqualify_if_candidate(&mut self, name: &str) {
+        if !self.is_shadowed(name) && self.candidates.contains(name) {
+            self.disqualified.insert(name.to_string());
+        }
+    }
+
+    fn shadowed_by_params<'a, I>(&self, params: I) -> BTreeSet<String>
+    where
+        I: IntoIterator<Item = &'a Pat>,
+    {
+        let mut out = BTreeSet::new();
+        for param in params {
+            self.collect_shadowed_by_pat(param, &mut out);
+        }
+        out
+    }
+
+    fn collect_shadowed_by_pat(&self, pat: &Pat, out: &mut BTreeSet<String>) {
+        match pat {
+            Pat::Ident(ident) => {
+                let name = ident.id.sym.as_ref();
+                if self.candidates.contains(name) {
+                    out.insert(name.to_string());
+                }
+            }
+            Pat::Rest(rest) => self.collect_shadowed_by_pat(&rest.arg, out),
+            Pat::Assign(assign) => self.collect_shadowed_by_pat(&assign.left, out),
+            Pat::Array(array) => {
+                for elem in array.elems.iter().flatten() {
+                    self.collect_shadowed_by_pat(elem, out);
+                }
+            }
+            Pat::Object(object) => {
+                for prop in &object.props {
+                    match prop {
+                        ObjectPatProp::KeyValue(kv) => self.collect_shadowed_by_pat(&kv.value, out),
+                        ObjectPatProp::Assign(assign) => {
+                            let name = assign.key.sym.as_ref();
+                            if self.candidates.contains(name) {
+                                out.insert(name.to_string());
+                            }
+                        }
+                        ObjectPatProp::Rest(rest) => self.collect_shadowed_by_pat(&rest.arg, out),
+                    }
+                }
+            }
+            Pat::Expr(_) | Pat::Invalid(_) => {}
+        }
+    }
+}
+
+impl Visit for PlainArrayMethodScanner<'_> {
+    fn visit_call_expr(&mut self, node: &CallExpr) {
+        if let Callee::Expr(callee) = &node.callee
+            && let Expr::Member(member) = strip_parens(callee)
+            && let Expr::Ident(recv) = strip_parens(member.obj.as_ref())
+        {
+            let allowed = match &member.prop {
+                MemberProp::Ident(prop) => SAFE_PLAIN_ARRAY_METHODS.contains(&prop.sym.as_ref()),
+                MemberProp::Computed(_) | MemberProp::PrivateName(_) => false,
+            };
+            if !allowed {
+                self.disqualify_if_candidate(recv.sym.as_ref());
+            }
+        }
+        node.visit_children_with(self);
+    }
+
+    fn visit_arrow_expr(&mut self, node: &ArrowExpr) {
+        let scope = self.shadowed_by_params(node.params.iter());
+        self.with_scope(scope, |s| {
+            for param in &node.params {
+                param.visit_with(s);
+            }
+            node.body.visit_with(s);
         });
     }
 
@@ -2908,6 +3112,22 @@ fn classify_callee_call(
             graph,
         ));
     }
+    // Vite/Rollup namespace facade:
+    // `Object.defineProperty({ __proto__: null, ...exports },
+    // Symbol.toStringTag, { value: "Module" })`. The mutation targets a
+    // fresh object and installs a data descriptor only, so no user code
+    // fires. The generic `Object.defineProperty(t, ...)` form remains
+    // unknown below.
+    if is_pure_object_define_property_on_fresh_namespace(
+        callee_expr,
+        args,
+        shadowed,
+        local_shadowed,
+        declared_pure,
+        graph,
+    ) {
+        return Purity::Pure;
+    }
     // Chunk-local function declaration: consult the per-chunk
     // function-body purity cache. `Pure` callee + Pure args → Pure;
     // non-Pure callee inherits its reasons (so the chain points
@@ -3031,6 +3251,145 @@ fn callee_summary(callee_expr: &Expr) -> Option<String> {
     }
 }
 
+fn is_pure_object_define_property_on_fresh_namespace(
+    callee_expr: &Expr,
+    args: &[ExprOrSpread],
+    shadowed: &BTreeSet<&'static str>,
+    local_shadowed: &BTreeSet<String>,
+    declared_pure: &BTreeSet<String>,
+    graph: &ChunkCodeGraph,
+) -> bool {
+    let Expr::Member(member) = strip_parens(callee_expr) else {
+        return false;
+    };
+    if !matches!(
+        (member.obj.as_ref(), &member.prop),
+        (Expr::Ident(obj), MemberProp::Ident(prop))
+            if obj.sym.as_ref() == "Object" && prop.sym.as_ref() == "defineProperty"
+    ) || shadowed.contains("Object")
+        || local_shadowed.contains("Object")
+        || args.len() != 3
+        || args.iter().any(|arg| arg.spread.is_some())
+    {
+        return false;
+    }
+    is_fresh_namespace_object_literal(
+        &args[0].expr,
+        shadowed,
+        local_shadowed,
+        declared_pure,
+        graph,
+    ) && is_symbol_to_string_tag(&args[1].expr, shadowed, local_shadowed)
+        && is_data_descriptor_literal(
+            &args[2].expr,
+            shadowed,
+            local_shadowed,
+            declared_pure,
+            graph,
+        )
+}
+
+fn is_fresh_namespace_object_literal(
+    expr: &Expr,
+    shadowed: &BTreeSet<&'static str>,
+    local_shadowed: &BTreeSet<String>,
+    declared_pure: &BTreeSet<String>,
+    graph: &ChunkCodeGraph,
+) -> bool {
+    let Expr::Object(obj) = strip_parens(expr) else {
+        return false;
+    };
+    obj.props.iter().all(|prop| match prop {
+        PropOrSpread::Spread(_) => false,
+        PropOrSpread::Prop(prop) => match prop.as_ref() {
+            Prop::Shorthand(_) => true,
+            Prop::KeyValue(kv) => {
+                if prop_name_is(&kv.key, "__proto__") {
+                    return matches!(strip_parens(&kv.value), Expr::Lit(Lit::Null(_)));
+                }
+                prop_name_is_static_data_key(&kv.key)
+                    && classify_expr_purity(
+                        &kv.value,
+                        shadowed,
+                        local_shadowed,
+                        declared_pure,
+                        graph,
+                    )
+                    .is_pure()
+            }
+            Prop::Getter(_) | Prop::Setter(_) | Prop::Method(_) | Prop::Assign(_) => false,
+        },
+    })
+}
+
+fn is_symbol_to_string_tag(
+    expr: &Expr,
+    shadowed: &BTreeSet<&'static str>,
+    local_shadowed: &BTreeSet<String>,
+) -> bool {
+    let Expr::Member(member) = strip_parens(expr) else {
+        return false;
+    };
+    matches!(
+        (member.obj.as_ref(), &member.prop),
+        (Expr::Ident(obj), MemberProp::Ident(prop))
+            if obj.sym.as_ref() == "Symbol"
+                && prop.sym.as_ref() == "toStringTag"
+                && !shadowed.contains("Symbol")
+                && !local_shadowed.contains("Symbol")
+    )
+}
+
+fn is_data_descriptor_literal(
+    expr: &Expr,
+    shadowed: &BTreeSet<&'static str>,
+    local_shadowed: &BTreeSet<String>,
+    declared_pure: &BTreeSet<String>,
+    graph: &ChunkCodeGraph,
+) -> bool {
+    let Expr::Object(obj) = strip_parens(expr) else {
+        return false;
+    };
+    obj.props.iter().all(|prop| match prop {
+        PropOrSpread::Spread(_) => false,
+        PropOrSpread::Prop(prop) => match prop.as_ref() {
+            Prop::KeyValue(kv) => {
+                prop_name_is_static_data_key(&kv.key)
+                    && !prop_name_is(&kv.key, "get")
+                    && !prop_name_is(&kv.key, "set")
+                    && classify_expr_purity(
+                        &kv.value,
+                        shadowed,
+                        local_shadowed,
+                        declared_pure,
+                        graph,
+                    )
+                    .is_pure()
+            }
+            Prop::Shorthand(_)
+            | Prop::Getter(_)
+            | Prop::Setter(_)
+            | Prop::Method(_)
+            | Prop::Assign(_) => false,
+        },
+    })
+}
+
+fn prop_name_is_static_data_key(name: &PropName) -> bool {
+    matches!(
+        name,
+        PropName::Ident(_) | PropName::Str(_) | PropName::Num(_) | PropName::BigInt(_)
+    )
+}
+
+fn prop_name_is(name: &PropName, expected: &str) -> bool {
+    match name {
+        PropName::Ident(ident) => ident.sym.as_ref() == expected,
+        PropName::Str(s) => s.value.to_string_lossy() == expected,
+        PropName::Num(_) | PropName::BigInt(_) | PropName::Computed(_) => false,
+    }
+}
+
 /// Whether `arg` is a sound argument shape for the
 /// `PURE_OBJECT_CALLS_ON_PLAIN_DATA` admission rule at the given
 /// `Object.<prop>` callsite. Two admissible shapes:
@@ -3098,6 +3457,19 @@ fn is_pure_plain_data_arg_for(
         // sources) is handled by the standard literal classifier.
         Expr::Array(_) => {
             classify_expr_purity(arg, shadowed, local_shadowed, declared_pure, graph).is_pure()
+        }
+        Expr::Call(call) if prop == "freeze" => {
+            let Callee::Expr(callee) = &call.callee else {
+                return false;
+            };
+            is_pure_object_define_property_on_fresh_namespace(
+                callee,
+                &call.args,
+                shadowed,
+                local_shadowed,
+                declared_pure,
+                graph,
+            )
         }
         _ => false,
     }

--- a/devinfra/js/debundle/spec.rs
+++ b/devinfra/js/debundle/spec.rs
@@ -177,6 +177,23 @@ pub struct OwnerGraphOptions {
     /// check.
     #[serde(default)]
     pub dataflow_aware_s_chain: bool,
+    /// Author-trusted refinement for chunks using
+    /// `dataflow_aware_s_chain`: let statements whose ordinary
+    /// dataflow summary is conservative-but-present use that syntactic
+    /// read/write summary instead of becoming opaque S-chain barriers.
+    ///
+    /// This preserves the conservative default added for generic JS.
+    /// Enabling it shifts the same review burden as other
+    /// conditionally-correct options to the spec author: every such
+    /// top-level statement must be audited either to have no observable
+    /// order dependency with unrelated top-level effects, or to expose
+    /// all ordering-relevant state through the analyzer's binding/global
+    /// property summaries. Shapes that defeat write-cell extraction
+    /// outright (`eval`, `with`, `Function`, computed global-object
+    /// keys, global `defineProperty`, global `Proxy`) still fall back to
+    /// conservative barriers regardless of this flag.
+    #[serde(default)]
+    pub trusted_dataflow_summaries: bool,
     /// Input-chunk admission checks (docs/design.md A1/A3/A5) the
     /// spec author has audited and explicitly disabled for this
     /// chunk. YAML surface is a list of check names
@@ -1028,6 +1045,16 @@ pub struct Member {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     #[serde(default)]
     pub pure_members: Vec<String>,
+    /// Property names on the bound value whose calls may receive callback-like
+    /// arguments but do not synchronously invoke them. The call remains an
+    /// opaque side-effecting member call for purity / S-chain purposes; this
+    /// only narrows at-init call promotion by not treating inline functions,
+    /// object literals containing functions, or first-order argument callbacks
+    /// as synchronously reachable fallback roots for audited callback-storing
+    /// APIs.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    pub no_sync_callback_members: Vec<String>,
     /// Optional human-readable comment emitted as a `// ...` block
     /// immediately above the binding's owner statement in the
     /// generated JS. Per-line literal `// ` prefix; empty input


### PR DESCRIPTION
## Summary

This PR restores useful precision in debundle's at-init analysis after the recent conservative tightenings, without making ordinary impure calls pure.

Key changes:
- Adds targeted fallback narrowing for audited callback-storage APIs (`no_sync_callback_members`).
- Keeps no-sync member calls impure/ordered while suppressing callback argument fallback roots that are not synchronously invoked.
- Preserves direct argument evaluation/read edges, and applies the cleanup inside first-order function bodies used by at-init promotion.
- Narrows known async Promise reaction handlers, DOM/static event listener callbacks, plain-array collection callbacks, and trusted S-chain dataflow summaries for audited chunks.
- Adds regression coverage for the Tana-shaped at-init cycles, no-sync member arguments, post-await first-order boundaries, plain array callbacks, event listeners, pure members, and trusted S-chain summaries.

## Why

`gaffer-private`'s Tana web debundle target drifted red after the debundle refactors/tightenings. The failing cycle was caused by conservative fallback promotion treating callback-registration/data-shape arguments as synchronously invoked at module init and by call-heavy audited S-chain summaries becoming opaque barriers.

This keeps the stricter defaults, but gives specs and recognized safe shapes enough precision to recover the Tana factorization without broad purity claims.

## Validation

- `nix develop --command bazelisk --output_base=/tmp/codex-bazel-ducktape-at-init-rbe test //devinfra/js/debundle/... --config=rbe --remote_timeout=3m --test_output=errors --experimental_ui_max_stdouterr_bytes=20971520`
- `nix develop --command bazelisk --output_base=/tmp/codex-bazel-gaffer-tana-re-source-fix test //tana/re/... --config=nolint --config=rbe --platforms= --remote_upload_local_results=false --remote_download_outputs=all --config=source-debundler --override_module=ducktape=/tmp/codex-ducktape-debundle-scope-jun11a --experimental_ui_max_stdouterr_bytes=20971520 --test_output=errors`