### PR TITLE
Tag loom gym eval traces for Langfuse

### DIFF
--- a/loom/gym/BUILD.bazel
+++ b/loom/gym/BUILD.bazel
@@ -168,6 +168,16 @@ py_library(
 )
 
 py_test(
+    name = "test_agent_eval",
+    srcs = ["test_agent_eval.py"],
+    deps = [
+        ":agent_eval",
+        "//:conftest",
+        "@pypi//pytest_bazel",
+    ],
+)
+
+py_test(
     name = "test_baseline_llm",
     srcs = ["test_baseline_llm.py"],
     deps = [

--- a/loom/gym/agent_eval.py
+++ b/loom/gym/agent_eval.py
@@ -20,7 +20,9 @@ import argparse
 import logging
 import os
 from collections import Counter
+from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 from inspect_ai import eval as inspect_eval
 from inspect_ai.model import get_model
@@ -34,6 +36,39 @@ from loom.gym.series_tasks import admissible_tasks
 logger = logging.getLogger(__name__)
 
 LITELLM_BASE_URL = "https://litellm.allegedly.works"
+DEFAULT_LANGFUSE_TAGS = "loom-gym"
+
+
+def _parse_csv(value: str) -> list[str]:
+    return [part.strip() for part in value.split(",") if part.strip()]
+
+
+def _default_eval_session_id(now: datetime | None = None) -> str:
+    timestamp = (now or datetime.now(UTC)).astimezone(UTC).strftime("%Y%m%dT%H%M%SZ")
+    return f"loom-gym-{timestamp}"
+
+
+def _litellm_metadata(
+    *,
+    session_id: str,
+    tags: list[str],
+    model_id: str,
+    endpoint_model: str,
+    task_filter: str | None,
+    archive: bool,
+    wayback_upstream: str,
+) -> dict[str, Any]:
+    return {
+        "trace_user_id": "loom-gym",
+        "session_id": session_id,
+        "tags": tags,
+        "loom.eval.session_id": session_id,
+        "loom.eval.model_id": model_id,
+        "loom.eval.endpoint_model": endpoint_model,
+        "loom.eval.task_filter": task_filter or "",
+        "loom.eval.archive": archive,
+        "loom.eval.wayback_upstream": wayback_upstream if archive else "",
+    }
 
 
 def main() -> None:
@@ -71,6 +106,16 @@ def main() -> None:
         help="Max samples to run concurrently (one docker sandbox each). Bounds docker-ci "
         "network-pool usage; unset uses the Inspect default.",
     )
+    parser.add_argument(
+        "--langfuse-tags",
+        default=DEFAULT_LANGFUSE_TAGS,
+        help="Comma-separated tags attached to LiteLLM/Langfuse traces and the Inspect eval log.",
+    )
+    parser.add_argument(
+        "--langfuse-session-id",
+        default=None,
+        help="Session id attached to LiteLLM/Langfuse traces; default is a generated loom-gym timestamp.",
+    )
     args = parser.parse_args()
     api_key = os.environ.get(args.api_key_env) or Path("/tmp/litellm_key").read_text().strip()
 
@@ -85,8 +130,28 @@ def main() -> None:
     mode = "no-archive" if args.no_archive else f"archive (upstream {args.wayback_upstream})"
     print(f"{len(tasks)} tasks for {args.model_id} via {args.base_url} [{mode}]")
 
+    endpoint_model = args.endpoint_model or f"{args.model_id}-anthropic"
+    langfuse_tags = _parse_csv(args.langfuse_tags)
+    langfuse_session_id = args.langfuse_session_id or _default_eval_session_id()
+    metadata = _litellm_metadata(
+        session_id=langfuse_session_id,
+        tags=langfuse_tags,
+        model_id=args.model_id,
+        endpoint_model=endpoint_model,
+        task_filter=args.task_filter,
+        archive=not args.no_archive,
+        wayback_upstream=args.wayback_upstream,
+    )
+    print(f"litellm/langfuse session_id={langfuse_session_id} tags={','.join(langfuse_tags) or '-'}")
+
     model = get_model(
-        f"anthropic/{args.endpoint_model or f'{args.model_id}-anthropic'}", base_url=args.base_url, api_key=api_key
+        f"anthropic/{endpoint_model}",
+        base_url=args.base_url,
+        api_key=api_key,
+        # Anthropic Messages only permits a narrow `metadata` object. LiteLLM consumes
+        # `litellm_metadata` before forwarding upstream, so Langfuse can still group
+        # and filter these traces without sending invalid provider payloads.
+        extra_body={"litellm_metadata": metadata},
     )
     logs = inspect_eval(
         agent_eval_task(
@@ -99,6 +164,8 @@ def main() -> None:
         model=model,
         log_dir=str(args.log_dir),
         display="plain",
+        tags=langfuse_tags,
+        metadata={"litellm_metadata": metadata},
         message_limit=args.message_limit,
         max_samples=args.max_samples,
         # A transient per-sample failure (e.g. a flaky DNS/connection to the model

--- a/loom/gym/k8s/eval-job.yaml
+++ b/loom/gym/k8s/eval-job.yaml
@@ -66,6 +66,8 @@ spec:
             - "8"
             - --wayback-upstream
             - http://wayback-cache.wayback-cache.svc.cluster.local:8080
+            - --langfuse-tags
+            - loom-gym,wayback-archive,manifold
             - --log-dir
             - /work/logs
           env:

--- a/loom/gym/test_agent_eval.py
+++ b/loom/gym/test_agent_eval.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest_bazel
+
+from loom.gym.agent_eval import _default_eval_session_id, _litellm_metadata, _parse_csv
+
+
+def test_parse_csv_trims_empty_values() -> None:
+    assert _parse_csv("loom-gym, wayback-archive,,manifold ") == ["loom-gym", "wayback-archive", "manifold"]
+
+
+def test_default_eval_session_id_uses_utc_timestamp() -> None:
+    assert _default_eval_session_id(datetime(2026, 6, 12, 5, 25, 14, tzinfo=UTC)) == "loom-gym-20260612T052514Z"
+
+
+def test_litellm_metadata_carries_langfuse_and_eval_fields() -> None:
+    metadata = _litellm_metadata(
+        session_id="loom-gym-test",
+        tags=["loom-gym", "wayback-archive"],
+        model_id="glm-4.5",
+        endpoint_model="glm-4.5-anthropic",
+        task_filter="manifold-",
+        archive=True,
+        wayback_upstream="http://wayback-cache",
+    )
+
+    assert metadata == {
+        "trace_user_id": "loom-gym",
+        "session_id": "loom-gym-test",
+        "tags": ["loom-gym", "wayback-archive"],
+        "loom.eval.session_id": "loom-gym-test",
+        "loom.eval.model_id": "glm-4.5",
+        "loom.eval.endpoint_model": "glm-4.5-anthropic",
+        "loom.eval.task_filter": "manifold-",
+        "loom.eval.archive": True,
+        "loom.eval.wayback_upstream": "http://wayback-cache",
+    }
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()


### PR DESCRIPTION
## Summary
- Add LiteLLM/Langfuse metadata wiring to `loom/gym:agent_eval_bin` for Anthropic-shaped eval requests.
- Pass tags/session metadata into Inspect eval logs as well.
- Tag the on-demand wayback archive eval job as `loom-gym,wayback-archive,manifold`.
- Add focused tests for tag/session metadata helpers.

## Validation
- `bbr test //loom/gym:test_agent_eval`
- `pre-commit run --files loom/gym/agent_eval.py loom/gym/test_agent_eval.py loom/gym/BUILD.bazel loom/gym/k8s/eval-job.yaml`