### PR TITLE
[codex] Configure loom gym compaction and budget

### DIFF
--- a/loom/gym/agent_eval.py
+++ b/loom/gym/agent_eval.py
@@ -98,7 +98,7 @@ def main() -> None:
         "knowledge. The --wayback-upstream* args are then unused.",
     )
     parser.add_argument("--log-dir", type=Path, required=True, help="Inspect eval log directory.")
-    parser.add_argument("--message-limit", type=int, default=80, help="Max conversation turns per sample.")
+    parser.add_argument("--message-limit", type=int, default=1000, help="Max conversation turns per sample.")
     parser.add_argument(
         "--max-samples",
         type=int,
@@ -115,6 +115,12 @@ def main() -> None:
         "--langfuse-session-id",
         default=None,
         help="Session id attached to LiteLLM/Langfuse traces; default is a generated loom-gym timestamp.",
+    )
+    parser.add_argument(
+        "--compaction-threshold-tokens",
+        type=int,
+        default=0,
+        help="Enable Inspect LLM-summary compaction above this input-token estimate; 0 disables compaction.",
     )
     args = parser.parse_args()
     api_key = os.environ.get(args.api_key_env) or Path("/tmp/litellm_key").read_text().strip()
@@ -160,6 +166,7 @@ def main() -> None:
             wayback_upstream=args.wayback_upstream,
             wayback_upstream_auth=os.environ.get(args.wayback_upstream_auth_env, ""),
             archive=not args.no_archive,
+            compaction_threshold_tokens=args.compaction_threshold_tokens or None,
         ),
         model=model,
         log_dir=str(args.log_dir),

--- a/loom/gym/inspect_harness.py
+++ b/loom/gym/inspect_harness.py
@@ -39,6 +39,7 @@ import yaml
 from inspect_ai import Task as InspectTask
 from inspect_ai.agent import AgentSubmit, react
 from inspect_ai.dataset import MemoryDataset, Sample
+from inspect_ai.model import CompactionSummary
 from inspect_ai.scorer import Score, Target, mean, scorer
 from inspect_ai.solver import TaskState
 from inspect_ai.tool import ToolDef, ToolParams, ToolResult, bash
@@ -221,7 +222,6 @@ AGENT_PROMPT_NO_ARCHIVE = (
     "When confident, call the submit tool with your forecast — its arguments are the structured "
     "answer fields, which the tool schema enforces."
 )
-
 # Container path the proxy sidecar writes its served-evidence manifest to;
 # the scorer reads it back per sample (W3 of the wayback proxy plan).
 MANIFEST_PATH = "/tmp/wayback-manifest.jsonl"
@@ -378,6 +378,7 @@ def agent_eval_task(
     agent_image: str = SANDBOX_IMAGE_TAG,
     compose_dir: Path | None = None,
     archive: bool = True,
+    compaction_threshold_tokens: int | None = None,
 ) -> list[InspectTask]:
     """Inspect tasks over gym tasks: one sandbox compose per distinct as_of, and
     one Inspect task per distinct answer schema. The react submit tool carries a
@@ -399,6 +400,9 @@ def agent_eval_task(
     by_schema: dict[str, list[Task]] = defaultdict(list)
     for task in tasks:
         by_schema[json.dumps(question_schema(task.question), sort_keys=True)].append(task)
+    compaction = (
+        CompactionSummary(threshold=compaction_threshold_tokens) if compaction_threshold_tokens is not None else None
+    )
     return [
         InspectTask(
             name=f"agent_eval_{group[0].question.kind}_{index}",
@@ -409,6 +413,7 @@ def agent_eval_task(
                 prompt=AGENT_PROMPT if archive else AGENT_PROMPT_NO_ARCHIVE,
                 tools=[bash(timeout=180)],
                 submit=AgentSubmit(tool=_submit_tool(group[0].question), answer_only=True),
+                compaction=compaction,
             ),
             scorer=gym_proper_loss(archive=archive),
         )

--- a/loom/gym/k8s/eval-job.yaml
+++ b/loom/gym/k8s/eval-job.yaml
@@ -64,6 +64,12 @@ spec:
             # any interrupted run.
             - --max-samples
             - "8"
+            - --message-limit
+            - "1000"
+            # GLM-4.5 has a 128k context window; compact around 90% so the
+            # next turn still has room for tool schemas and output.
+            - --compaction-threshold-tokens
+            - "115000"
             - --wayback-upstream
             - http://wayback-cache.wayback-cache.svc.cluster.local:8080
             - --langfuse-tags

--- a/loom/gym/test_inspect_harness.py
+++ b/loom/gym/test_inspect_harness.py
@@ -9,6 +9,7 @@ from collections.abc import Iterator
 from datetime import date
 from pathlib import Path
 from textwrap import dedent
+from typing import Any
 
 import pytest
 import pytest_bazel
@@ -16,7 +17,8 @@ import yaml
 
 # Aliased to avoid shadowing the builtin.
 from inspect_ai import eval as inspect_eval
-from inspect_ai.model import ModelOutput, get_model
+from inspect_ai.model import CompactionSummary, ModelOutput, get_model
+from inspect_ai.solver import Generate, Solver, TaskState
 from more_itertools import one
 
 from loom.gym.dossier import series_dossier
@@ -100,6 +102,27 @@ def test_submit_tool_enforces_answer_shape() -> None:
     assert tool.parameters.additionalProperties is False
     # A well-formed call echoes the structured args as JSON for the scorer to parse.
     assert json.loads(asyncio.run(tool.tool(p=0.8))) == {"p": 0.8}
+
+
+def test_agent_eval_task_wires_optional_summary_compaction(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    react_kwargs: dict[str, Any] = {}
+
+    def fake_react(**kwargs: Any) -> Solver:
+        react_kwargs.update(kwargs)
+
+        async def fake_solver(state: TaskState, generate: Generate) -> TaskState:
+            del generate
+            return state
+
+        return fake_solver
+
+    monkeypatch.setattr("loom.gym.inspect_harness.react", fake_react)
+
+    one(agent_eval_task([EVIDENCE_TASK], [RAMP], compose_dir=tmp_path, compaction_threshold_tokens=115_000))
+
+    compaction = react_kwargs["compaction"]
+    assert isinstance(compaction, CompactionSummary)
+    assert compaction.threshold == 115_000
 
 
 def test_evidence_lands_as_url_file_never_in_prompt(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- raise the loom gym default message limit to 1000 turns
- add a CLI `--compaction-threshold-tokens` knob that wires Inspect `CompactionSummary` into the react agent without custom summary instructions
- set the in-cluster eval job to use `--message-limit 1000` and a GLM-4.5-appropriate `--compaction-threshold-tokens 115000`

## Validation

- `pre-commit run --files loom/gym/agent_eval.py loom/gym/inspect_harness.py loom/gym/test_inspect_harness.py loom/gym/k8s/eval-job.yaml`
- `bbr test //loom/gym:test_agent_eval //loom/gym:test_inspect_harness`
