### PR TITLE
[codex] disable kube-proxy monitoring

### DIFF
--- a/cluster/k8s/monitoring/stack/helmrelease.yaml
+++ b/cluster/k8s/monitoring/stack/helmrelease.yaml
@@ -48,7 +48,9 @@ spec:
         kubeApiserverAvailability: true
         kubeApiserverSlos: true
         kubelet: true
-        kubeProxy: true
+        # kube-proxy is intentionally absent: Cilium runs kube-proxy replacement,
+        # so the stock KubeProxyDown rule would always be noise here.
+        kubeProxy: false
         kubePrometheusGeneral: true
         kubePrometheusNodeRecording: true
         kubernetesApps: true
@@ -291,4 +293,6 @@ spec:
     kubeScheduler:
       enabled: true
     kubeProxy:
-      enabled: true
+      # kube-proxy is intentionally absent: Cilium runs kube-proxy replacement,
+      # so do not create the stock kube-proxy Service/ServiceMonitor.
+      enabled: false


### PR DESCRIPTION
## Summary

- Disable the kube-prometheus-stack stock kube-proxy rule bundle.
- Disable the stock kube-proxy Service/ServiceMonitor resources.
- Add YAML comments explaining that kube-proxy is intentionally absent because Cilium runs kube-proxy replacement.

## Why

The cluster does not run kube-proxy. Cilium is configured with kube-proxy replacement, so the stock `KubeProxyDown` rule fires permanently on `absent(up{job="kube-proxy"})` even though this is expected for the cluster.

## Validation

- `kubectl kustomize cluster/k8s/monitoring/stack`
- `git diff --check -- cluster/k8s/monitoring/stack/helmrelease.yaml`
- `nix develop -c pre-commit run --files cluster/k8s/monitoring/stack/helmrelease.yaml`