### PR TITLE
[codex] Add Wayback archive acquisition telemetry

### DIFF
--- a/loom/gym/TODO.md
+++ b/loom/gym/TODO.md
@@ -1,16 +1,14 @@
 # loom/gym TODO
 
-- **Internet Archive throttling — deploy and measure the Availability-first path.**
-  The eval works end-to-end in `claude-sandbox`, but archive.org returned ~900-950
-  HTTP `502`/`504` per run on cold CDX-index queries, producing ~8-13 `nan`
-  (no-answer) samples. The proxy now resolves normal URLs through
-  `archive.org/wayback/available` first, falls back to clamped CDX only when
-  Availability cannot preserve semantics, and the cache routes/logs
-  `/wayback/available` separately from replay/CDX. After rollout, run another
-  33-task eval and compare CDX volume, IA `502`/`504`, `x-rl`/`Retry-After`, and
-  `nan` count. Findings, the metrics/observability runbook, operational gotchas,
-  and next steps (adaptive backoff → self-hosted shard) are in
-  <../plans/wayback_ia_throttling.md>.
+- **Archive-backed eval reliability — deploy and evaluate the limiter telemetry
+  fix.** After the limiter/telemetry PR lands, wait for image publish and Flux
+  reconcile, manually reprobe the known bad CDX query, burst-test cold CDX/replay
+  misses, and confirm `in_flight` returns to zero while
+  `wayback_archive_acquisition_failures_total{endpoint,reason,status}` separates
+  queue timeout from upstream retry/backoff. Then rerun the 33-task `glm-4.5`
+  panel with `--message-limit 1000` and `--compaction-threshold-tokens 115000`.
+  Findings and the runbook are in <../plans/wayback_ia_throttling.md>; the
+  archive-service design/status is in <../wayback_archive/PLAN.md>.
 
 - **Rename `baseline_llm.py`.** Once the bare one-shot LLM scaffold is gone, the
   module is purely the shared answer-schema + parse library (`question_schema`,

--- a/loom/plans/wayback_ia_throttling.md
+++ b/loom/plans/wayback_ia_throttling.md
@@ -1,6 +1,6 @@
 # Wayback cache vs. Internet Archive rate-limiting — findings & plan
 
-Status as of **2026-06-11**. Handoff for whoever next works on making the
+Status as of **2026-06-12**. Handoff for whoever next works on making the
 `loom/gym` eval's archived web access reliable. Companion to
 <../wayback_proxy/README.md> (the proxy implementation),
 <../docs/archive_org_apis.md> (API notes), and <../gym/TODO.md>.
@@ -8,17 +8,22 @@ Status as of **2026-06-11**. Handoff for whoever next works on making the
 ## TL;DR
 
 The `loom/gym` eval now runs end-to-end in `claude-sandbox` (it was fully hung;
-see "What shipped" below). The remaining quality problem is **archive.org
-failing a large fraction of our cold CDX-index queries** — typically ~900-950
-HTTP `502`/`504` per 33-task run — which makes agents loop on failed fetches and
-burn their message budget, yielding ~8-13 `nan` (no-answer) samples per run.
+see "What shipped" below). The original nginx/PVC cache failure was
+**archive.org failing a large fraction of cold CDX-index queries** — typically
+~900-950 HTTP `502`/`504` per 33-task run — which made agents loop on failed
+fetches and burn their message budget, yielding ~8-13 `nan` (no-answer) samples
+per run.
 
-We added Prometheus metrics and proved that the static mitigations we tried
-(bigger keepalive pool, longer CDX TTL, lower concurrency) **shuffle the failure
-mode without reducing the failure volume**. The next moves are _not_ more static
-tuning: **(1) route the timestamp clamp off the rate-limited CDX endpoint onto
-the availability API; (2) capture IA's own rate-limit signal and back off
-adaptively.** Details below.
+The Rust write-through archive replacement is now merged/deployed and changed
+the failure shape, but did **not** improve the cold eval outcome yet. The
+2026-06-12 run completed in 2:22:15 with 15/33 submissions, 18/33 no-answer
+samples, mean proper-loss 1.218 over submitted samples, and 860 upstream-error
+records in the driver summary (`855x 503`, `5x 403`). The old direct IA
+TCP-refusal / `502` mode is gone; the visible failure is now cache-side `503`
+backpressure/acquisition miss delay. The next PR fixes the stuck/leaked CDX
+limiter path, adds queue-timeout/upstream-failure visibility, and verifies proxy
+`503 + Retry-After` retry behavior. After it deploys, rerun with the merged
+1000-turn + Inspect compaction config.
 
 ## What shipped this session (all merged to `devel`)
 
@@ -70,6 +75,93 @@ Conclusion: the bottleneck is **IA failing our cold-CDX volume regardless of how
 politely we hold the socket**. Levers that can actually move it must _reduce or
 reroute that cold volume_, or _react_ to IA's failures — not adjust connection
 mechanics.
+
+## Rust archive cold-run result (2026-06-12)
+
+After replacing the nginx/PVC cache with `loom/wayback_archive` and deploying it
+under the existing `wayback-cache` service, the first full eval was:
+
+- model/config: `glm-4.5`, `--task-filter manifold-`, `--max-samples 8`,
+  `message_limit=80` (the run predated the merged 1000-turn + compaction config);
+- job: `claude-sandbox/loom-gym-eval`, completed successfully;
+- wall time: 2:22:15;
+- submitted answers: 15/33;
+- no-answer / `nan`: 18/33;
+- mean proper-loss over submitted samples: 1.218;
+- total model usage: 15,044,226 tokens
+  (`1,163,969` input, `13,505,106` cache read, `375,151` output);
+- served fetch mentions in the driver summary: 1,084;
+- upstream-error records in the driver summary: `855x 503`, `5x 403`.
+
+Worst upstream-error samples:
+
+| sample                                | result | upstream errors     |
+| ------------------------------------- | ------ | ------------------- |
+| `scotus-upholds-trump-tariffs`        | nan    | `65x 503`           |
+| `labor-wins-2025-australian-election` | nan    | `53x 503`, `1x 403` |
+| `trump-2025-nobel-peace-prize`        | scored | `46x 503`           |
+| `russia-ukraine-ceasefire-aug-2025`   | scored | `43x 503`, `1x 403` |
+| `verstappen-2024-f1-title`            | nan    | `36x 503`, `1x 403` |
+| `afd-beats-spd-2025`                  | nan    | `35x 503`           |
+| `uk-wealth-tax-2025`                  | scored | `35x 503`           |
+| `capital-one-discover-merger`         | nan    | `34x 503`           |
+| `mangione-murder-conviction-2025`     | nan    | `33x 503`           |
+| `us-govt-shutdown-2025`               | nan    | `32x 503`           |
+
+Interpretation:
+
+- This is worse than the prior nginx/PVC runs on wall time and no-answer rate.
+  Do not expect cache warmth alone to fix this: agents branch to new URLs, so a
+  second run only partially reuses the first run's fills.
+- The no-answer samples are still non-submissions after exhausting the agent
+  loop, not evaluator crashes. Partial structured logs showed every no-answer
+  sample available at that point had exactly 80 messages and an empty answer
+  (`JSONDecodeError`); final logs show the same empty-answer signature for the
+  additional no-answer samples.
+- The failure mode moved from direct IA connection refusals / IA `502` to
+  archive-service `503` backpressure while acquisitions are slow or backing off.
+  That is the right _shape_ operationally, but it still consumes too much agent
+  budget.
+- A post-merge metrics scrape showed no active limiter backoff, with limits
+  `availability=16`, `cdx=1`, `replay=8` and one in-flight CDX/replay request at
+  scrape time. CDX being pinned at `1` during/after the run is consistent with
+  the service protecting IA but serializing enough cold misses to hurt eval
+  throughput. Follow-up live probes showed the sharper issue: with
+  `limit=1` and `in_flight=1`, fresh CDX misses wait the 60s queue budget and
+  return `503 + Retry-After` without ever proving the URL has no capture.
+
+Follow-up diagnosis on the highest-error URLs:
+
+- The failures were mostly **not missing captures**. For
+  `scotus-upholds-trump-tariffs`, the eval only fetched six unique sites
+  (`reuters`, `apnews`, `bbc`, `wsj`, `abajournal`, `foxnews`) but recorded
+  `65x 503`. The archive DB has Availability `200` rows and replay `200` rows
+  at or before `2026-01-10T23:59:59` for all six.
+- A live probe for the exact SCOTUS CDX query
+  `url=http://www.reuters.com/&to=20260110235959&output=json&limit=-1`
+  returned our `503` after about 60s with body
+  `archive acquisition is backing off`, while the corresponding Availability
+  query returned `200` in about 0.3s with capture `20260110235953`.
+- Partial structured samples show the same pattern. `afd-beats-spd-2025`
+  served 50 captures; its 35 upstream errors were our backing-off `503`s
+  (`31` CDX, `4` replay). `verstappen-2024-f1-title` had 36 backing-off CDX
+  `503`s plus one real CDX `403` for an IA-auth-gated query.
+- The durable fix should come before another comparison run: limiter permits are
+  now cancellation-safe/RAII so a dropped or wedged acquisition cannot leak
+  `in_flight`, and archive acquisition failures now emit counters/logs split by
+  endpoint, reason, and upstream status (`single_flight_queue_timeout`,
+  `limiter_queue_timeout`, `upstream_retry_after`,
+  `upstream_transient_status`, `upstream_fetch_timeout`,
+  `upstream_fetch_error`). The 1000-turn + compaction config is still useful,
+  but it should not mask a stuck CDX limiter.
+
+Next comparison should use the merged eval config from #2141:
+`--message-limit 1000` plus `--compaction-threshold-tokens 115000` for GLM-4.5.
+Run it after deploying the limiter/telemetry PR so we compare against a healthy
+online-fill service rather than a CDX queue that has stopped admitting new work.
+Track: submissions, wall time, served fetches, archive `503` by reason/status,
+IA transient classifications, limiter limits/in-flight, queue wait expirations,
+and second-run hit rate as a secondary signal.
 
 ## What we learned about archive.org's behavior
 

--- a/loom/wayback_archive/PLAN.md
+++ b/loom/wayback_archive/PLAN.md
@@ -1,10 +1,9 @@
 # Wayback write-through archive service plan
 
-Status: plan drafted 2026-06-12; v0 replacement PR in progress. The PR
-replaces nginx/PVC `wayback-cache` in place with one Rust archive-service pod,
-one CNPG instance, and SeaweedFS S3 replay bodies. After merge, wait for image
-publish and Flux reconcile, smoke-test the live service, then run the eval
-comparison.
+Status: plan drafted 2026-06-12; v0 replacement merged, reconciled, and
+smoke-tested. The PR replaced nginx/PVC `wayback-cache` in place with one Rust
+archive-service pod, one CNPG instance, and SeaweedFS S3 replay bodies. The
+first full cold eval completed; see "First eval result" below.
 Companion to
 <../plans/wayback_ia_throttling.md>, <../wayback_proxy/README.md>, and
 <../docs/archive_org_apis.md>.
@@ -33,6 +32,69 @@ The per-agent `wayback_proxy` remains the policy layer for intercepted live-web
 URLs: it enforces `WAYBACK_AS_OF`, rejects future captures, emits evidence
 manifests, and points at this cluster service as its upstream.
 
+## First eval result
+
+Run date: 2026-06-12. Job: `claude-sandbox/loom-gym-eval`. Target:
+`http://wayback-cache.wayback-cache.svc.cluster.local:8080`. Model/config:
+`glm-4.5`, `--task-filter manifold-`, `--max-samples 8`, old
+`message_limit=80`.
+
+Result:
+
+- status: success;
+- wall time: 2:22:15;
+- submitted answers: 15/33;
+- no-answer / `nan`: 18/33;
+- mean proper-loss over submitted samples: 1.218;
+- total model usage: 15,044,226 tokens;
+- served fetch mentions in final driver summary: 1,084;
+- upstream-error records in final driver summary: `855x 503`, `5x 403`.
+
+This did not beat the previous nginx/PVC cache runs on score, wall time, or
+submission rate. It did change the failure mode: direct IA refusals/`502`s are
+no longer the primary visible problem, but archive-service `503` backpressure
+and slow cold acquisition still make agents spend too much of the loop on failed
+or delayed archive probes. That is acceptable for a first cold-fill proof of
+plumbing, not sufficient for the eval goal.
+
+Important caveat: this run predated the merged eval-harness update that raises
+the default message budget to `1000` and enables Inspect summary compaction with
+`--compaction-threshold-tokens 115000` for the GLM-4.5 job. That config is still
+useful, but cache warmth is unlikely to solve the core problem by itself:
+agents choose new URLs, so online miss behavior remains the eval-critical path.
+
+Follow-up diagnosis: the high-error URLs generally were not unarchived. For the
+worst sample (`scotus-upholds-trump-tariffs`), the archive DB has Availability
+`200` rows and replay `200` rows for all six unique fetched sites at or before
+the task's `2026-01-10` clamp. A live Availability probe for
+`http://www.reuters.com/` returned `200` in about 0.3s, but the exact CDX query
+for the same URL/as-of waited about 60s and returned our
+`503 archive acquisition is backing off`. Metrics at that point showed
+`wayback_archive_limiter_limit{endpoint="cdx"} 1` and
+`wayback_archive_limiter_in_flight{endpoint="cdx"} 1`. That means fresh CDX
+misses can spend the whole queue budget waiting for a slot rather than proving
+anything about capture availability.
+
+Immediate follow-ups:
+
+- limiter permits are now cancellation-safe/RAII in the Rust archive service, so
+  dropped or wedged acquisitions release `in_flight` without recording a false
+  health sample;
+- acquisition failures now emit counters/logs split by endpoint, reason, and
+  upstream status, so queue-wait `503` can be separated from upstream
+  timeout/backoff `503`;
+- after deploy, manually reprobe the known bad CDX path and burst cold misses to
+  verify `in_flight` returns to zero and the new reason counters move;
+- then rerun the 33-task panel with the 1000-turn + compaction job config;
+- record archive-service status counters by endpoint/path in final eval notes,
+  not just the driver-level `503` aggregate;
+- reduce cache-side `503` volume from acquisition backpressure: CDX stayed at
+  concurrency 1 under load, which protects IA but serializes cold misses enough
+  to hurt the agent loop;
+- `wayback_proxy` treats `503 + Retry-After` as an enforced wait/retry while it
+  still has retry budget, and returns `503 + Retry-After` to the agent only when
+  that wait would exceed the proxy budget.
+
 ## Non-goals
 
 - Do not try to enumerate or prefetch the eval URL universe. Agents discover
@@ -45,7 +107,7 @@ manifests, and points at this cluster service as its upstream.
 
 ## Current reality
 
-Before this PR, `cluster/k8s/wayback-cache/` was nginx `proxy_cache`. The v0
+Before the replacement, `cluster/k8s/wayback-cache/` was nginx `proxy_cache`. The v0
 replacement keeps the `wayback-cache` Service/hostname but swaps the backend to
 the Rust archive service. The nginx behavior below is the baseline being
 replaced.
@@ -472,16 +534,17 @@ Follow-up hardening:
 
 Post-merge rollout checklist:
 
-1. Confirm GHCR image publish and Flux image automation update the
+1. ✅ Confirm GHCR image publish and Flux image automation update the
    `wayback-cache` Deployment image.
-2. Confirm Flux reconciles `wayback-cache-namespace`, `wayback-archive-db`,
+2. ✅ Confirm Flux reconciles `wayback-cache-namespace`, `wayback-archive-db`,
    `seaweedfs-wayback-archive-bucket`, `seaweedfs-secrets`, and `wayback-cache`.
-3. Smoke-test in-cluster `/healthz`, `/metrics`, `/wayback/available`, `/cdx`,
+3. ✅ Smoke-test in-cluster `/healthz`, `/metrics`, `/wayback/available`, `/cdx`,
    and replay miss fill.
-4. Smoke-test public `wayback-cache.allegedly.works` through the bearer-auth
+4. ✅ Smoke-test public `wayback-cache.allegedly.works` through the bearer-auth
    `:8090` listener.
-5. Run the eval comparison against the replacement service and compare it to the
-   prior approaches.
+5. ✅ Run the first cold eval comparison against the replacement service.
+6. TODO: fix the stuck/leaked CDX limiter path, then rerun with the merged
+   1000-turn + compaction eval job config.
 
 ## Acceptance criteria
 

--- a/loom/wayback_archive/lib.rs
+++ b/loom/wayback_archive/lib.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt::{Display, Formatter, Write};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex as StdMutex, MutexGuard as StdMutexGuard};
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, anyhow};
@@ -11,7 +11,7 @@ use log::warn;
 use object_store::aws::AmazonS3Builder;
 use object_store::path::Path as ObjectPath;
 use object_store::{ObjectStore, ObjectStoreExt, PutPayload};
-use prometheus::{Encoder, GaugeVec, Opts, Registry, TextEncoder};
+use prometheus::{Encoder, GaugeVec, IntCounterVec, Opts, Registry, TextEncoder};
 use sea_orm::entity::prelude::*;
 use sea_orm::sea_query::OnConflict;
 use sea_orm::{
@@ -42,6 +42,8 @@ pub enum Endpoint {
 }
 
 impl Endpoint {
+    const ALL: [Endpoint; 3] = [Endpoint::Availability, Endpoint::Cdx, Endpoint::Replay];
+
     fn retry_after_seconds(self) -> u64 {
         match self {
             Endpoint::Availability => 5,
@@ -63,6 +65,88 @@ impl Endpoint {
             Endpoint::Cdx => Some("/cdx/search/cdx"),
             Endpoint::Replay => None,
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum AcquisitionFailureReason {
+    SingleFlightQueueTimeout,
+    LimiterQueueTimeout,
+    UpstreamRetryAfter,
+    UpstreamTransientStatus,
+    UpstreamFetchTimeout,
+    UpstreamFetchError,
+}
+
+impl AcquisitionFailureReason {
+    fn as_str(self) -> &'static str {
+        match self {
+            AcquisitionFailureReason::SingleFlightQueueTimeout => "single_flight_queue_timeout",
+            AcquisitionFailureReason::LimiterQueueTimeout => "limiter_queue_timeout",
+            AcquisitionFailureReason::UpstreamRetryAfter => "upstream_retry_after",
+            AcquisitionFailureReason::UpstreamTransientStatus => "upstream_transient_status",
+            AcquisitionFailureReason::UpstreamFetchTimeout => "upstream_fetch_timeout",
+            AcquisitionFailureReason::UpstreamFetchError => "upstream_fetch_error",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct AcquisitionFailureKey {
+    endpoint: Endpoint,
+    reason: AcquisitionFailureReason,
+    status: Option<u16>,
+}
+
+#[derive(Debug, Default)]
+struct ArchiveMetrics {
+    acquisition_attempts: StdMutex<HashMap<Endpoint, u64>>,
+    acquisition_failures: StdMutex<HashMap<AcquisitionFailureKey, u64>>,
+}
+
+impl ArchiveMetrics {
+    fn record_acquisition_attempt(&self, endpoint: Endpoint) {
+        let mut attempts = self
+            .acquisition_attempts
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *attempts.entry(endpoint).or_default() += 1;
+    }
+
+    fn record_acquisition_failure(
+        &self,
+        endpoint: Endpoint,
+        reason: AcquisitionFailureReason,
+        status: Option<u16>,
+    ) {
+        let key = AcquisitionFailureKey {
+            endpoint,
+            reason,
+            status,
+        };
+        let mut failures = self
+            .acquisition_failures
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *failures.entry(key).or_default() += 1;
+    }
+
+    fn acquisition_failure_counts(&self) -> Vec<(AcquisitionFailureKey, u64)> {
+        self.acquisition_failures
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .iter()
+            .map(|(key, count)| (*key, *count))
+            .collect()
+    }
+
+    fn acquisition_attempt_counts(&self) -> Vec<(Endpoint, u64)> {
+        self.acquisition_attempts
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .iter()
+            .map(|(endpoint, count)| (*endpoint, *count))
+            .collect()
     }
 }
 
@@ -924,14 +1008,42 @@ pub struct LimiterSnapshot {
 #[derive(Debug)]
 pub struct AdaptiveLimiter {
     config: LimiterConfig,
-    state: Mutex<LimiterState>,
+    state: StdMutex<LimiterState>,
     notify: Notify,
+}
+
+#[derive(Debug)]
+#[must_use = "dropping a limiter permit releases its in-flight slot"]
+pub struct LimiterPermit {
+    limiter: Option<Arc<AdaptiveLimiter>>,
+}
+
+impl LimiterPermit {
+    fn new(limiter: Arc<AdaptiveLimiter>) -> Self {
+        Self {
+            limiter: Some(limiter),
+        }
+    }
+
+    pub fn record(mut self, outcome: AcquisitionOutcome) {
+        if let Some(limiter) = self.limiter.take() {
+            limiter.release(Some(outcome));
+        }
+    }
+}
+
+impl Drop for LimiterPermit {
+    fn drop(&mut self) {
+        if let Some(limiter) = self.limiter.take() {
+            limiter.release(None);
+        }
+    }
 }
 
 impl AdaptiveLimiter {
     pub fn new(config: LimiterConfig) -> Self {
         Self {
-            state: Mutex::new(LimiterState {
+            state: StdMutex::new(LimiterState {
                 current_limit: config.initial,
                 in_flight: 0,
                 backoff_until: None,
@@ -942,32 +1054,30 @@ impl AdaptiveLimiter {
         }
     }
 
-    pub async fn acquire(&self) -> bool {
+    pub async fn acquire(self: Arc<Self>) -> Option<LimiterPermit> {
         let deadline = Instant::now() + self.config.queue_wait;
         loop {
             let wait = {
-                let mut state = self.state.lock().await;
+                let mut state = self.lock_state();
                 let now = Instant::now();
                 if state.backoff_until.is_some_and(|until| until <= now) {
                     state.backoff_until = None;
                 }
                 if state.backoff_until.is_none() && state.in_flight < state.current_limit {
                     state.in_flight += 1;
-                    return true;
+                    return Some(LimiterPermit::new(self.clone()));
                 }
                 deadline.checked_duration_since(now)
             };
-            let Some(wait) = wait else {
-                return false;
-            };
+            let wait = wait?;
             if timeout(wait, self.notify.notified()).await.is_err() {
-                return false;
+                return None;
             }
         }
     }
 
     pub async fn retry_after(&self) -> Option<Duration> {
-        let mut state = self.state.lock().await;
+        let mut state = self.lock_state();
         let now = Instant::now();
         if state.backoff_until.is_some_and(|until| until <= now) {
             state.backoff_until = None;
@@ -977,24 +1087,30 @@ impl AdaptiveLimiter {
             .and_then(|until| until.checked_duration_since(now))
     }
 
-    pub async fn record(&self, outcome: AcquisitionOutcome) {
-        let mut state = self.state.lock().await;
+    fn release(&self, outcome: Option<AcquisitionOutcome>) {
+        let mut state = self.lock_state();
         state.in_flight = state.in_flight.saturating_sub(1);
+        if let Some(outcome) = outcome {
+            self.record_outcome(&mut state, outcome);
+        }
+        self.notify.notify_waiters();
+    }
+
+    fn record_outcome(&self, state: &mut LimiterState, outcome: AcquisitionOutcome) {
         let now = Instant::now();
         match outcome {
-            AcquisitionOutcome::Healthy => self.record_health(&mut state, now, false),
+            AcquisitionOutcome::Healthy => self.record_health(state, now, false),
             AcquisitionOutcome::TransientFailure => {
-                self.record_health(&mut state, now, true);
+                self.record_health(state, now, true);
                 state.current_limit = (state.current_limit / 2).max(self.config.min);
                 state.backoff_until = Some(now + self.config.failure_cooldown);
             }
             AcquisitionOutcome::RetryAfter(duration) => {
-                self.record_health(&mut state, now, true);
+                self.record_health(state, now, true);
                 state.current_limit = self.config.min;
                 state.backoff_until = Some(now + duration);
             }
         }
-        self.notify.notify_waiters();
     }
 
     fn record_health(&self, state: &mut LimiterState, now: Instant, failed: bool) {
@@ -1026,11 +1142,11 @@ impl AdaptiveLimiter {
     }
 
     pub async fn current_limit(&self) -> usize {
-        self.state.lock().await.current_limit
+        self.lock_state().current_limit
     }
 
     pub async fn snapshot(&self) -> LimiterSnapshot {
-        let mut state = self.state.lock().await;
+        let mut state = self.lock_state();
         let now = Instant::now();
         if state.backoff_until.is_some_and(|until| until <= now) {
             state.backoff_until = None;
@@ -1052,6 +1168,12 @@ impl AdaptiveLimiter {
             recent_events: state.events.len(),
             recent_failures: state.events.iter().filter(|event| event.failed).count(),
         }
+    }
+
+    fn lock_state(&self) -> StdMutexGuard<'_, LimiterState> {
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 }
 
@@ -1078,6 +1200,7 @@ pub struct ArchiveService {
     replay_limiter: Arc<AdaptiveLimiter>,
     metadata_flights: Mutex<FillFlights<MetadataKey>>,
     replay_flights: Mutex<FillFlights<ReplayKey>>,
+    metrics: Arc<ArchiveMetrics>,
     max_body_bytes: usize,
     max_metadata_bytes: usize,
     queue_wait: Duration,
@@ -1093,6 +1216,7 @@ impl ArchiveService {
             replay_limiter: Arc::new(AdaptiveLimiter::new(LimiterConfig::replay())),
             metadata_flights: Mutex::new(FillFlights::default()),
             replay_flights: Mutex::new(FillFlights::default()),
+            metrics: Arc::new(ArchiveMetrics::default()),
             max_body_bytes: DEFAULT_MAX_BODY_BYTES,
             max_metadata_bytes: DEFAULT_MAX_METADATA_BYTES,
             queue_wait: DEFAULT_MAX_QUEUE_WAIT,
@@ -1187,12 +1311,27 @@ impl ArchiveService {
             ),
             &["endpoint"],
         )?;
+        let acquisition_attempts = IntCounterVec::new(
+            Opts::new(
+                "wayback_archive_acquisition_attempts_total",
+                "Archive miss acquisitions attempted against IA.",
+            ),
+            &["endpoint"],
+        )?;
+        let acquisition_failures = IntCounterVec::new(
+            Opts::new(
+                "wayback_archive_acquisition_failures_total",
+                "Archive miss acquisitions that returned a retryable/backpressure response before storing a result.",
+            ),
+            &["endpoint", "reason", "status"],
+        )?;
 
-        for (endpoint, limiter) in [
-            (Endpoint::Availability, self.availability_limiter.clone()),
-            (Endpoint::Cdx, self.cdx_limiter.clone()),
-            (Endpoint::Replay, self.replay_limiter.clone()),
-        ] {
+        for endpoint in Endpoint::ALL {
+            let limiter = match endpoint {
+                Endpoint::Availability => self.availability_limiter.clone(),
+                Endpoint::Cdx => self.cdx_limiter.clone(),
+                Endpoint::Replay => self.replay_limiter.clone(),
+            };
             let snapshot = limiter.snapshot().await;
             let labels = &[endpoint.as_str()];
             limit
@@ -1211,12 +1350,28 @@ impl ArchiveService {
                 .with_label_values(labels)
                 .set(snapshot.recent_failures as f64);
         }
+        for (endpoint, count) in self.metrics.acquisition_attempt_counts() {
+            acquisition_attempts
+                .with_label_values(&[endpoint.as_str()])
+                .inc_by(count);
+        }
+        for (key, count) in self.metrics.acquisition_failure_counts() {
+            let status = key
+                .status
+                .map(|status| status.to_string())
+                .unwrap_or_else(|| "none".to_string());
+            acquisition_failures
+                .with_label_values(&[key.endpoint.as_str(), key.reason.as_str(), &status])
+                .inc_by(count);
+        }
 
         registry.register(Box::new(limit))?;
         registry.register(Box::new(in_flight))?;
         registry.register(Box::new(backoff_seconds))?;
         registry.register(Box::new(recent_events))?;
         registry.register(Box::new(recent_failures))?;
+        registry.register(Box::new(acquisition_attempts))?;
+        registry.register(Box::new(acquisition_failures))?;
 
         let mut output = Vec::new();
         TextEncoder::new().encode(&registry.gather(), &mut output)?;
@@ -1245,6 +1400,17 @@ impl ArchiveService {
                     );
                 }
             }
+            warn!(
+                "wayback archive acquisition failed endpoint={} reason={} status=none key={}",
+                request.key.endpoint.as_str(),
+                AcquisitionFailureReason::SingleFlightQueueTimeout.as_str(),
+                request.key
+            );
+            self.metrics.record_acquisition_failure(
+                request.key.endpoint,
+                AcquisitionFailureReason::SingleFlightQueueTimeout,
+                None,
+            );
             return ArchiveResponse::retry_after(request.key.endpoint);
         }
         let response = self.fill_metadata(request.clone()).await;
@@ -1274,6 +1440,17 @@ impl ArchiveService {
                     );
                 }
             }
+            warn!(
+                "wayback archive acquisition failed endpoint={} reason={} status=none key={}",
+                Endpoint::Replay.as_str(),
+                AcquisitionFailureReason::SingleFlightQueueTimeout.as_str(),
+                key
+            );
+            self.metrics.record_acquisition_failure(
+                Endpoint::Replay,
+                AcquisitionFailureReason::SingleFlightQueueTimeout,
+                None,
+            );
             return ArchiveResponse::retry_after(Endpoint::Replay);
         }
         let response = self.fill_replay(key.clone()).await;
@@ -1345,19 +1522,32 @@ impl ArchiveService {
 
     async fn fill_metadata(&self, request: MetadataRequest) -> ArchiveResponse {
         let limiter = self.metadata_limiter(request.key.endpoint);
-        if !limiter.acquire().await {
+        let Some(permit) = limiter.clone().acquire().await else {
+            warn!(
+                "wayback archive acquisition failed endpoint={} reason={} status=none key={}",
+                request.key.endpoint.as_str(),
+                AcquisitionFailureReason::LimiterQueueTimeout.as_str(),
+                request.key
+            );
+            self.metrics.record_acquisition_failure(
+                request.key.endpoint,
+                AcquisitionFailureReason::LimiterQueueTimeout,
+                None,
+            );
             return ArchiveResponse::retry_after_duration(
                 request.key.endpoint,
                 limiter.retry_after().await,
             );
-        }
+        };
+        self.metrics
+            .record_acquisition_attempt(request.key.endpoint);
         let upstream = self
             .client
             .fetch_metadata(&request, self.max_metadata_bytes)
             .await;
         match upstream {
             Ok(response) if response.body.len() > self.max_metadata_bytes => {
-                limiter.record(AcquisitionOutcome::Healthy).await;
+                permit.record(AcquisitionOutcome::Healthy);
                 let metadata = StoredMetadata::BodyTooLarge {
                     key: request.key,
                     observed_size: response.body.len(),
@@ -1372,17 +1562,33 @@ impl ArchiveService {
             }
             Ok(response) if is_transient_metadata_failure(&response) => {
                 let retry_after = retry_after_duration(&response.headers);
-                limiter
-                    .record(
-                        retry_after
-                            .map(AcquisitionOutcome::RetryAfter)
-                            .unwrap_or(AcquisitionOutcome::TransientFailure),
-                    )
-                    .await;
+                let reason = if retry_after.is_some() {
+                    AcquisitionFailureReason::UpstreamRetryAfter
+                } else {
+                    AcquisitionFailureReason::UpstreamTransientStatus
+                };
+                warn!(
+                    "wayback archive acquisition failed endpoint={} reason={} status={} key={} retry_after={:?}",
+                    request.key.endpoint.as_str(),
+                    reason.as_str(),
+                    response.status,
+                    request.key,
+                    retry_after
+                );
+                self.metrics.record_acquisition_failure(
+                    request.key.endpoint,
+                    reason,
+                    Some(response.status),
+                );
+                permit.record(
+                    retry_after
+                        .map(AcquisitionOutcome::RetryAfter)
+                        .unwrap_or(AcquisitionOutcome::TransientFailure),
+                );
                 ArchiveResponse::retry_after_duration(request.key.endpoint, retry_after)
             }
             Ok(response) => {
-                limiter.record(AcquisitionOutcome::Healthy).await;
+                permit.record(AcquisitionOutcome::Healthy);
                 let record = MetadataRecord {
                     key: request.key,
                     status: response.status,
@@ -1402,29 +1608,46 @@ impl ArchiveService {
             }
             Err(error) => {
                 warn!(
-                    "IA metadata fetch failed for endpoint={} query={}: {error:#}",
+                    "wayback archive acquisition failed endpoint={} reason={} status=none key={} error={error:#}",
                     request.key.endpoint.as_str(),
-                    request.key.normalized_query
+                    upstream_error_reason(&error).as_str(),
+                    request.key
                 );
-                limiter.record(AcquisitionOutcome::TransientFailure).await;
+                self.metrics.record_acquisition_failure(
+                    request.key.endpoint,
+                    upstream_error_reason(&error),
+                    None,
+                );
+                permit.record(AcquisitionOutcome::TransientFailure);
                 ArchiveResponse::retry_after(request.key.endpoint)
             }
         }
     }
 
     async fn fill_replay(&self, key: ReplayKey) -> ArchiveResponse {
-        if !self.replay_limiter.acquire().await {
+        let limiter = self.replay_limiter.clone();
+        let Some(permit) = limiter.clone().acquire().await else {
+            warn!(
+                "wayback archive acquisition failed endpoint={} reason={} status=none key={}",
+                Endpoint::Replay.as_str(),
+                AcquisitionFailureReason::LimiterQueueTimeout.as_str(),
+                key
+            );
+            self.metrics.record_acquisition_failure(
+                Endpoint::Replay,
+                AcquisitionFailureReason::LimiterQueueTimeout,
+                None,
+            );
             return ArchiveResponse::retry_after_duration(
                 Endpoint::Replay,
-                self.replay_limiter.retry_after().await,
+                limiter.retry_after().await,
             );
-        }
+        };
+        self.metrics.record_acquisition_attempt(Endpoint::Replay);
         let upstream = self.client.fetch_replay(&key, self.max_body_bytes).await;
         match upstream {
             Ok(response) if response.body.len() > self.max_body_bytes => {
-                self.replay_limiter
-                    .record(AcquisitionOutcome::Healthy)
-                    .await;
+                permit.record(AcquisitionOutcome::Healthy);
                 let replay = StoredReplay::BodyTooLarge {
                     key,
                     observed_size: response.body.len(),
@@ -1439,19 +1662,33 @@ impl ArchiveService {
             }
             Ok(response) if is_transient_replay_failure(&response) => {
                 let retry_after = retry_after_duration(&response.headers);
-                self.replay_limiter
-                    .record(
-                        retry_after
-                            .map(AcquisitionOutcome::RetryAfter)
-                            .unwrap_or(AcquisitionOutcome::TransientFailure),
-                    )
-                    .await;
+                let reason = if retry_after.is_some() {
+                    AcquisitionFailureReason::UpstreamRetryAfter
+                } else {
+                    AcquisitionFailureReason::UpstreamTransientStatus
+                };
+                warn!(
+                    "wayback archive acquisition failed endpoint={} reason={} status={} key={} retry_after={:?}",
+                    Endpoint::Replay.as_str(),
+                    reason.as_str(),
+                    response.status,
+                    key,
+                    retry_after
+                );
+                self.metrics.record_acquisition_failure(
+                    Endpoint::Replay,
+                    reason,
+                    Some(response.status),
+                );
+                permit.record(
+                    retry_after
+                        .map(AcquisitionOutcome::RetryAfter)
+                        .unwrap_or(AcquisitionOutcome::TransientFailure),
+                );
                 ArchiveResponse::retry_after_duration(Endpoint::Replay, retry_after)
             }
             Ok(response) => {
-                self.replay_limiter
-                    .record(AcquisitionOutcome::Healthy)
-                    .await;
+                permit.record(AcquisitionOutcome::Healthy);
                 let record = ReplayRecord {
                     key,
                     status: response.status,
@@ -1472,12 +1709,17 @@ impl ArchiveService {
             }
             Err(error) => {
                 warn!(
-                    "IA replay fetch failed for capture_ts={} modifier={} original_url={}: {error:#}",
-                    key.capture_ts, key.modifier, key.original_url
+                    "wayback archive acquisition failed endpoint={} reason={} status=none key={} error={error:#}",
+                    Endpoint::Replay.as_str(),
+                    upstream_error_reason(&error).as_str(),
+                    key
                 );
-                self.replay_limiter
-                    .record(AcquisitionOutcome::TransientFailure)
-                    .await;
+                self.metrics.record_acquisition_failure(
+                    Endpoint::Replay,
+                    upstream_error_reason(&error),
+                    None,
+                );
+                permit.record(AcquisitionOutcome::TransientFailure);
                 ArchiveResponse::retry_after(Endpoint::Replay)
             }
         }
@@ -1550,6 +1792,18 @@ fn is_transient_replay_failure(response: &UpstreamResponse) -> bool {
 
 fn is_transient_metadata_failure(response: &UpstreamResponse) -> bool {
     response.status == 429 || response.status >= 500
+}
+
+fn upstream_error_reason(error: &anyhow::Error) -> AcquisitionFailureReason {
+    if error.chain().any(|cause| {
+        cause
+            .downcast_ref::<reqwest::Error>()
+            .is_some_and(reqwest::Error::is_timeout)
+    }) {
+        AcquisitionFailureReason::UpstreamFetchTimeout
+    } else {
+        AcquisitionFailureReason::UpstreamFetchError
+    }
 }
 
 fn retry_after_duration(headers: &HeaderMap) -> Option<Duration> {
@@ -1848,6 +2102,36 @@ mod tests {
                 .unwrap()
                 .contains("wayback_archive_limiter_backoff_seconds{endpoint=\"availability\"}")
         );
+        assert!(service.metrics().await.unwrap().contains(
+            "wayback_archive_acquisition_failures_total{endpoint=\"availability\",reason=\"upstream_retry_after\",status=\"503\"} 1"
+        ));
+    }
+
+    #[tokio::test]
+    async fn limiter_queue_timeout_is_reported_by_reason() {
+        let client = Arc::new(CountingClient::ok(200, b"won't be fetched".as_slice()));
+        let limiter = Arc::new(AdaptiveLimiter::new(LimiterConfig {
+            initial: 1,
+            min: 1,
+            max: 1,
+            queue_wait: Duration::from_millis(1),
+            failure_cooldown: Duration::from_millis(1),
+            severe_failure_cooldown: Duration::from_millis(1),
+        }));
+        let held = limiter.clone().acquire().await.expect("held permit");
+        let service = ArchiveService::new(Arc::new(MemoryArchiveStore::new()), client.clone())
+            .with_limits(limiter, Duration::from_millis(50));
+
+        let response = service
+            .handle_path("/web/20200115103000id_/https://example.com/")
+            .await;
+
+        assert_eq!(response.status, 503);
+        assert_eq!(client.calls.load(Ordering::SeqCst), 0);
+        assert!(service.metrics().await.unwrap().contains(
+            "wayback_archive_acquisition_failures_total{endpoint=\"replay\",reason=\"limiter_queue_timeout\",status=\"none\"} 1"
+        ));
+        drop(held);
     }
 
     #[tokio::test]
@@ -2023,17 +2307,46 @@ mod tests {
 
     #[tokio::test]
     async fn limiter_reduces_limit_on_failures() {
-        let limiter = AdaptiveLimiter::new(LimiterConfig {
+        let limiter = Arc::new(AdaptiveLimiter::new(LimiterConfig {
             initial: 4,
             min: 1,
             max: 8,
             queue_wait: Duration::from_millis(10),
             failure_cooldown: Duration::from_millis(1),
             severe_failure_cooldown: Duration::from_millis(1),
-        });
-        assert!(limiter.acquire().await);
-        limiter.record(AcquisitionOutcome::TransientFailure).await;
+        }));
+        let permit = limiter.clone().acquire().await.expect("limiter permit");
+
+        permit.record(AcquisitionOutcome::TransientFailure);
+
         assert_eq!(limiter.current_limit().await, 2);
+    }
+
+    #[tokio::test]
+    async fn limiter_permit_drop_releases_in_flight_without_health_sample() {
+        let limiter = Arc::new(AdaptiveLimiter::new(LimiterConfig {
+            initial: 1,
+            min: 1,
+            max: 1,
+            queue_wait: Duration::from_millis(10),
+            failure_cooldown: Duration::from_millis(1),
+            severe_failure_cooldown: Duration::from_millis(1),
+        }));
+        let permit = limiter.clone().acquire().await.expect("first permit");
+        assert_eq!(limiter.snapshot().await.in_flight, 1);
+
+        drop(permit);
+
+        let snapshot = limiter.snapshot().await;
+        assert_eq!(snapshot.in_flight, 0);
+        assert_eq!(snapshot.recent_events, 0);
+        let second = limiter
+            .clone()
+            .acquire()
+            .await
+            .expect("permit released on drop");
+        assert_eq!(limiter.snapshot().await.in_flight, 1);
+        drop(second);
     }
 
     #[tokio::test]

--- a/loom/wayback_proxy/fake_ia.py
+++ b/loom/wayback_proxy/fake_ia.py
@@ -77,6 +77,10 @@ CDX_FAILS_BUT_AVAILABLE_BODY = b"served without touching cdx\n"
 REPLAY_RETRY_AFTER_ONCE_URL = "http://retry-after-once.example/"
 REPLAY_RETRY_AFTER_ONCE_BODY = b"served after retry-after\n"
 
+# Replay always returns 503 + Retry-After longer than the proxy's configured
+# wait budget in the corresponding test.
+REPLAY_RETRY_AFTER_EXHAUSTS_BUDGET_URL = "http://retry-after-exhausts-budget.example/"
+
 
 @dataclass(frozen=True)
 class Replay:
@@ -96,6 +100,7 @@ CDX_CAPTURES: dict[str, list[tuple[str, str]]] = {
     GONE_URL: [(GOOD_TS, GONE_URL)],
     CDX_FAILS_BUT_AVAILABLE_URL: [(GOOD_TS, CDX_FAILS_BUT_AVAILABLE_URL)],
     REPLAY_RETRY_AFTER_ONCE_URL: [(GOOD_TS, REPLAY_RETRY_AFTER_ONCE_URL)],
+    REPLAY_RETRY_AFTER_EXHAUSTS_BUDGET_URL: [(GOOD_TS, REPLAY_RETRY_AFTER_EXHAUSTS_BUDGET_URL)],
 }
 
 # Replay table: (timestamp, original URL) -> response.
@@ -110,6 +115,7 @@ REPLAYS: dict[tuple[str, str], Replay] = {
     (GOOD_TS, GONE_URL): Replay(status=404, body=GONE_BODY),
     (GOOD_TS, CDX_FAILS_BUT_AVAILABLE_URL): Replay(body=CDX_FAILS_BUT_AVAILABLE_BODY),
     (GOOD_TS, REPLAY_RETRY_AFTER_ONCE_URL): Replay(body=REPLAY_RETRY_AFTER_ONCE_BODY),
+    (GOOD_TS, REPLAY_RETRY_AFTER_EXHAUSTS_BUDGET_URL): Replay(body=b"unreachable\n"),
 }
 
 REPLAY_RETRY_AFTER_COUNTS: dict[tuple[str, str], int] = {}
@@ -195,6 +201,8 @@ async def handle(request: web.BaseRequest) -> web.StreamResponse:
             REPLAY_RETRY_AFTER_COUNTS[key] = count + 1
             if count == 0:
                 return web.Response(status=503, text="archive shard busy\n", headers={"Retry-After": "0"})
+        if (ts, inner) == (GOOD_TS, REPLAY_RETRY_AFTER_EXHAUSTS_BUDGET_URL):
+            return web.Response(status=503, text="archive shard still busy\n", headers={"Retry-After": "5"})
         replay = REPLAYS.get((ts, inner))
         if replay is None:
             return web.Response(status=404, text="snapshot not found\n")  # IA-level miss: no Memento header

--- a/loom/wayback_proxy/test_proxy.py
+++ b/loom/wayback_proxy/test_proxy.py
@@ -69,24 +69,28 @@ async def addon(fake_upstream: str, manifest: io.StringIO) -> AsyncIterator[Wayb
 @pytest.fixture
 def fetch(addon: WaybackAddon) -> Fetch:
     async def fetch_via_addon(url: str) -> FetchResult:
-        # Set request components from the URL directly (rather than the
-        # round-trip-lossy Request.url setter) so nested archive paths like
-        # /web/<ts>/https://… survive verbatim into the addon.
-        parsed = URL(url, encoded=True)
-        assert parsed.host is not None
-        flow = tflow.tflow()
-        flow.response = None
-        flow.request.scheme = parsed.scheme
-        flow.request.host = parsed.host
-        flow.request.port = parsed.port or (443 if parsed.scheme == "https" else 80)
-        flow.request.path = parsed.raw_path_qs
-        flow.request.headers["host"] = parsed.host
-        await addon.request(flow)
-        response = flow.response
-        assert response is not None, "addon must set flow.response for every request"
-        return FetchResult(status=response.status_code, headers=response.headers, body=response.content)
+        return await _fetch_with_addon(addon, url)
 
     return fetch_via_addon
+
+
+async def _fetch_with_addon(addon: WaybackAddon, url: str) -> FetchResult:
+    # Set request components from the URL directly (rather than the
+    # round-trip-lossy Request.url setter) so nested archive paths like
+    # /web/<ts>/https://… survive verbatim into the addon.
+    parsed = URL(url, encoded=True)
+    assert parsed.host is not None
+    flow = tflow.tflow()
+    flow.response = None
+    flow.request.scheme = parsed.scheme
+    flow.request.host = parsed.host
+    flow.request.port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    flow.request.path = parsed.raw_path_qs
+    flow.request.headers["host"] = parsed.host
+    await addon.request(flow)
+    response = flow.response
+    assert response is not None, "addon must set flow.response for every request"
+    return FetchResult(status=response.status_code, headers=response.headers, body=response.content)
 
 
 async def test_serves_newest_capture_at_or_before_as_of(fetch: Fetch) -> None:
@@ -125,6 +129,23 @@ async def test_retry_after_503_is_waited_and_retried(fetch: Fetch, manifest: io.
     assert records[0]["status"] == 503
     assert records[0]["headers"]["retry-after"] == "0"
     assert records[1]["kind"] == "served"
+
+
+async def test_retry_after_503_returns_to_agent_when_wait_exceeds_budget(
+    fake_upstream: str, manifest: io.StringIO
+) -> None:
+    config = Config(as_of=fake_ia.AS_OF, upstream=fake_upstream, port=0, upstream_retry_max_wait_seconds=0.001)
+    async with aiohttp.ClientSession() as session:
+        addon = WaybackAddon(WaybackResolver(config, session, manifest))
+        result = await _fetch_with_addon(addon, fake_ia.REPLAY_RETRY_AFTER_EXHAUSTS_BUDGET_URL)
+
+    assert result.status == 503
+    assert result.headers["retry-after"] == "5"
+
+    records = [json.loads(line) for line in manifest.getvalue().splitlines()]
+    assert records[0]["kind"] == "upstream_error"
+    assert records[0]["status"] == 503
+    assert records[0]["headers"]["retry-after"] == "5"
 
 
 async def test_manifest_records_served_evidence(fetch: Fetch, manifest: io.StringIO) -> None:


### PR DESCRIPTION
## Summary

- make the Rust Wayback archive adaptive limiter use an RAII permit so dropped/cancelled acquisitions release `in_flight` without recording a false health sample
- add archive acquisition counters/logs split by endpoint, failure reason, and upstream status
- add proxy test coverage for the existing `503 + Retry-After` behavior: retry while budget remains, return `503 + Retry-After` when the wait would exceed budget
- update Wayback archive/eval notes so completed work is not left as a TODO

## Failure Reasons

`wayback_archive_acquisition_failures_total{endpoint,reason,status}` now distinguishes:

- `single_flight_queue_timeout`
- `limiter_queue_timeout`
- `upstream_retry_after`
- `upstream_transient_status`
- `upstream_fetch_timeout`
- `upstream_fetch_error`

## Validation

- `bbr test //loom/wayback_archive:wayback_archive_test //loom/wayback_proxy:test_proxy`
- `pre-commit run --files loom/wayback_archive/lib.rs loom/wayback_proxy/fake_ia.py loom/wayback_proxy/test_proxy.py loom/plans/wayback_ia_throttling.md loom/wayback_archive/PLAN.md loom/gym/TODO.md`