### PR TITLE
Fix Mimir gateway scrape

### DIFF
--- a/cluster/k8s/monitoring/mimir/helmrelease.yaml
+++ b/cluster/k8s/monitoring/mimir/helmrelease.yaml
@@ -183,6 +183,12 @@ spec:
 
     gateway:
       replicas: 1
+      # The gateway is nginx and serves /ready/proxy routes, not Mimir's
+      # Prometheus /metrics endpoint. Keep it out of the chart-generated
+      # ServiceMonitor so TargetDown only covers real Mimir components.
+      service:
+        labels:
+          prometheus.io/service-monitor: "false"
       resources:
         requests:
           cpu: 10m


### PR DESCRIPTION
## Summary

- Label the Mimir nginx gateway service with `prometheus.io/service-monitor: "false"`.
- This makes the chart-generated `mimir-gateway` ServiceMonitor skip the gateway, which serves `/ready` and proxy routes but not Mimir's `/metrics` endpoint.

## Validation

- `kubectl kustomize cluster/k8s/monitoring/mimir`
- `helm template mimir grafana/mimir-distributed --version 6.0.6 --namespace monitoring -f /tmp/mimir-values-updated.yaml`
- `kubectl apply --dry-run=server -f cluster/k8s/monitoring/mimir/helmrelease.yaml`
- `nix develop -c pre-commit run --files cluster/k8s/monitoring/mimir/helmrelease.yaml`