### PR TITLE
[codex] Wire VolSync metrics auth

### DIFF
--- a/cluster/k8s/volsync/helmrelease.yaml
+++ b/cluster/k8s/volsync/helmrelease.yaml
@@ -30,6 +30,20 @@ spec:
         name: backube
         namespace: flux-system
       interval: 12h
+  # The VolSync chart protects /metrics with Kubernetes token auth, but its
+  # generated ServiceMonitor does not send a bearer token. Alloy already has
+  # RBAC for GET /metrics, so patch the scrape endpoint to use Alloy's mounted
+  # service-account token instead of disabling VolSync metrics auth.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: ServiceMonitor
+              name: volsync
+            patch: |
+              - op: add
+                path: /spec/endpoints/0/bearerTokenFile
+                value: /var/run/secrets/kubernetes.io/serviceaccount/token
   values:
     manageCRDs: true
     nodeSelector:


### PR DESCRIPTION
## Summary

- keep VolSync metrics auth enabled
- patch the chart-generated `ServiceMonitor` so Alloy sends its mounted Kubernetes service-account bearer token when scraping `/metrics`
- document why this is a post-render patch: the pinned VolSync chart protects `/metrics` but does not expose ServiceMonitor auth fields in values

## Validation

- `kubectl kustomize cluster/k8s/volsync > /tmp/volsync-kustomize.yaml`
- `kubectl apply --dry-run=server -f cluster/k8s/volsync/helmrelease.yaml`
- simulated Helm render plus Kustomize post-render patch; verified the rendered VolSync `ServiceMonitor` includes `bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token`
- `kubectl auth can-i get /metrics --as=system:serviceaccount:monitoring:alloy` -> `yes`
- `nix develop -c pre-commit run --files cluster/k8s/volsync/helmrelease.yaml`