### PR TITLE
[codex] Fix control plane metrics scrapes

### DIFF
--- a/cluster/terraform/main/infrastructure.tf
+++ b/cluster/terraform/main/infrastructure.tf
@@ -168,15 +168,42 @@ locals {
     ]
   }
 
+  # Host ingress firewall for kube-controller-manager/kube-scheduler metrics.
+  # Those static pods must bind off loopback for ServiceMonitor scrapes, but the
+  # metrics ports should remain unreachable from public node IPs.
+  control_plane_metrics_firewall_config = yamlencode({
+    apiVersion = "v1alpha1"
+    kind       = "NetworkRuleConfig"
+    name       = "kube-control-plane-metrics"
+    portSelector = {
+      protocol = "tcp"
+      ports    = [10257, 10259]
+    }
+    ingress = [
+      { subnet = "10.42.0.0/16" },
+      { subnet = "10.244.0.0/16" },
+    ]
+  })
+
   # Controlplane cluster config — includes etcd, apiServer, and inline
   # manifests that Talos rejects on worker nodes.
   common_cluster_config = {
     allowSchedulingOnControlPlanes = false
     apiServer                      = local.api_server_config
-    discovery                      = { enabled = true }
-    etcd                           = { advertisedSubnets = ["10.42.0.0/16"] }
-    network                        = { cni = { name = "none" } }
-    proxy                          = { disabled = true }
+    controllerManager = {
+      extraArgs = {
+        "bind-address" = "0.0.0.0"
+      }
+    }
+    discovery = { enabled = true }
+    etcd      = { advertisedSubnets = ["10.42.0.0/16"] }
+    network   = { cni = { name = "none" } }
+    proxy     = { disabled = true }
+    scheduler = {
+      extraArgs = {
+        "bind-address" = "0.0.0.0"
+      }
+    }
     # Talos CCM as inline manifest — removes cloud-provider taint before Flux.
     # Cilium stays as a null_resource helm install because it is large and is
     # easier to manage once the k8s API is reachable.

--- a/cluster/terraform/main/ovh-nodes.tf
+++ b/cluster/terraform/main/ovh-nodes.tf
@@ -491,6 +491,7 @@ data "talos_machine_configuration" "kimsufi" {
     local.kimsufi_user_volume_config_patches[each.key],
     local.kimsufi_eno1_peer_route_patches[each.key],
     local.kimsufi_cloud_provider_external_patches[each.key],
+    each.value.role == "controlplane" ? [local.control_plane_metrics_firewall_config] : [],
     local.nebula_machine_patches[each.key],
   )
 }
@@ -611,6 +612,7 @@ data "talos_machine_configuration" "kimsufi_cp" {
     local.kimsufi_user_volume_config_patches[each.key],
     local.kimsufi_eno1_peer_route_patches[each.key],
     local.kimsufi_cloud_provider_external_patches[each.key],
+    [local.control_plane_metrics_firewall_config],
     local.nebula_machine_patches[each.key],
   )
 }

--- a/cluster/terraform/main/proxmox-nodes.tf
+++ b/cluster/terraform/main/proxmox-nodes.tf
@@ -232,6 +232,7 @@ data "talos_machine_configuration" "proxmox" {
       }),
     ],
     each.value.type == "worker" ? [local.worker_link_config] : [],
+    each.value.type == "controlplane" ? [local.control_plane_metrics_firewall_config] : [],
     local.nebula_machine_patches[each.key],
   )
 }


### PR DESCRIPTION
## Summary

- Bind kube-controller-manager and kube-scheduler metrics to `0.0.0.0` in Talos control-plane config so the existing ServiceMonitors can scrape node IP endpoints.
- Add a Talos `NetworkRuleConfig` for TCP `10257`/`10259` allowing only `10.42.0.0/16` and `10.244.0.0/16`, keeping those metrics ports blocked on public node IPs.
- Attach the firewall config patch to OVH Kimsufi control planes and future Proxmox control planes.

## Rollout

Applied one control-plane node at a time using Terraform-rendered machine configs with Talos `--mode=try`, then persisted with `--mode=no-reboot`, then converged each node with a narrow saved OpenTofu plan against the CNPG PG backend:

- `talos_machine_configuration_apply.kimsufi["kimsufi_worker0"]` / `10.42.0.13`
- `talos_machine_configuration_apply.kimsufi["kimsufi_worker1"]` / `10.42.0.14`
- `talos_machine_configuration_apply.kimsufi_cp["kimsufi_cp0"]` / `10.42.0.15`

## Verification

- `tofu validate`
- `pre-commit run --files cluster/terraform/main/infrastructure.tf cluster/terraform/main/ovh-nodes.tf cluster/terraform/main/proxmox-nodes.tf`
- All three nodes remained `Ready` after apply.
- Static pods on all three nodes now include `--bind-address=0.0.0.0` for kube-controller-manager and kube-scheduler.
- Private probes return authenticated responses on all targets: `https://10.42.0.{13,14,15}:10257/metrics` and `:10259/metrics` returned `403` rather than connection refused.
- Public probes on `147.135.39.162`, `147.135.39.176`, and `147.135.37.175` for ports `10257`/`10259` stayed blocked.
- Mimir query showed `up=1` for all six control-plane targets.
- Alertmanager no longer has active unsilenced `TargetDown` alerts for kube-controller-manager or kube-scheduler.