### PR TITLE
[codex] Configure CDI storage profiles

### DIFF
--- a/cluster/k8s/kubevirt/cdi/kustomization.yaml
+++ b/cluster/k8s/kubevirt/cdi/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - cdi.yaml
+  - storageprofiles.yaml

--- a/cluster/k8s/kubevirt/cdi/storageprofiles.yaml
+++ b/cluster/k8s/kubevirt/cdi/storageprofiles.yaml
@@ -1,0 +1,94 @@
+# CDI creates StorageProfile objects automatically, but it cannot infer PVC
+# claim properties for our local/custom provisioners. Declare the safe defaults
+# so DataVolumes do not have to guess access mode or volume mode.
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: StorageProfile
+metadata:
+  name: local-path-ovh
+spec:
+  claimPropertySets:
+    - accessModes: [ReadWriteOnce]
+      volumeMode: Filesystem
+  cloneStrategy: copy
+---
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: StorageProfile
+metadata:
+  name: local-path-proxmox
+spec:
+  claimPropertySets:
+    - accessModes: [ReadWriteOnce]
+      volumeMode: Filesystem
+  cloneStrategy: copy
+---
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: StorageProfile
+metadata:
+  name: lvm-proxmox-hdd
+spec:
+  claimPropertySets:
+    - accessModes: [ReadWriteOnce]
+      volumeMode: Filesystem
+  cloneStrategy: copy
+---
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: StorageProfile
+metadata:
+  name: lvm-proxmox-hdd-block
+spec:
+  claimPropertySets:
+    - accessModes: [ReadWriteOnce]
+      volumeMode: Block
+  cloneStrategy: copy
+---
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: StorageProfile
+metadata:
+  name: lvm-proxmox-hdd-shared
+spec:
+  claimPropertySets:
+    - accessModes: [ReadWriteOnce]
+      volumeMode: Filesystem
+  cloneStrategy: copy
+---
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: StorageProfile
+metadata:
+  name: lvm-proxmox-ssd
+spec:
+  claimPropertySets:
+    - accessModes: [ReadWriteOnce]
+      volumeMode: Filesystem
+  cloneStrategy: copy
+---
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: StorageProfile
+metadata:
+  name: lvm-proxmox-ssd-block
+spec:
+  claimPropertySets:
+    - accessModes: [ReadWriteOnce]
+      volumeMode: Block
+  cloneStrategy: copy
+---
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: StorageProfile
+metadata:
+  name: proxmox-csi-retain
+spec:
+  claimPropertySets:
+    - accessModes: [ReadWriteOnce]
+      volumeMode: Filesystem
+  cloneStrategy: copy
+---
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: StorageProfile
+metadata:
+  name: seaweedfs-ovh
+spec:
+  claimPropertySets:
+    - accessModes: [ReadWriteMany]
+      volumeMode: Filesystem
+    - accessModes: [ReadWriteOnce]
+      volumeMode: Filesystem
+  cloneStrategy: copy


### PR DESCRIPTION
## Summary

- Add declarative CDI `StorageProfile` specs for the nine custom/local StorageClasses that CDI cannot infer.
- Set conservative `ReadWriteOnce` filesystem defaults for local-path, Proxmox CSI, and non-block OpenEBS LVM classes.
- Set block volume mode for the `*-block` LVM classes.
- Advertise `seaweedfs-ovh` as filesystem RWX and RWO, matching the live RWX smoke test plus current RWO PVC usage.

## Verification

- `kubectl kustomize cluster/k8s/kubevirt/cdi`
- `kubectl apply --dry-run=server -k cluster/k8s/kubevirt/cdi`
- `kubectl apply --server-side --dry-run=server -k cluster/k8s/kubevirt/cdi`
- `pre-commit run --files cluster/k8s/kubevirt/cdi/kustomization.yaml cluster/k8s/kubevirt/cdi/storageprofiles.yaml`

## Live SeaweedFS RWX Check

Created a temporary `ReadWriteMany` PVC using `seaweedfs-ovh` in `claude-sandbox`, mounted it from two pods pinned to different OVH nodes, wrote from `ovh-ns103656`, and read the same file from `ovh-ns103711`. The reader observed the writer output. Temporary test resources were deleted.