### PR TITLE
[codex] Enable LVM snapshot cloning for CDI

### DIFF
--- a/cluster/k8s/kubevirt/cdi/storageprofiles.yaml
+++ b/cluster/k8s/kubevirt/cdi/storageprofiles.yaml
@@ -29,7 +29,7 @@ spec:
   claimPropertySets:
     - accessModes: [ReadWriteOnce]
       volumeMode: Filesystem
-  cloneStrategy: copy
+  cloneStrategy: snapshot
 ---
 apiVersion: cdi.kubevirt.io/v1beta1
 kind: StorageProfile
@@ -39,7 +39,7 @@ spec:
   claimPropertySets:
     - accessModes: [ReadWriteOnce]
       volumeMode: Block
-  cloneStrategy: copy
+  cloneStrategy: snapshot
 ---
 apiVersion: cdi.kubevirt.io/v1beta1
 kind: StorageProfile
@@ -49,7 +49,7 @@ spec:
   claimPropertySets:
     - accessModes: [ReadWriteOnce]
       volumeMode: Filesystem
-  cloneStrategy: copy
+  cloneStrategy: snapshot
 ---
 apiVersion: cdi.kubevirt.io/v1beta1
 kind: StorageProfile
@@ -59,7 +59,7 @@ spec:
   claimPropertySets:
     - accessModes: [ReadWriteOnce]
       volumeMode: Filesystem
-  cloneStrategy: copy
+  cloneStrategy: snapshot
 ---
 apiVersion: cdi.kubevirt.io/v1beta1
 kind: StorageProfile
@@ -69,7 +69,7 @@ spec:
   claimPropertySets:
     - accessModes: [ReadWriteOnce]
       volumeMode: Block
-  cloneStrategy: copy
+  cloneStrategy: snapshot
 ---
 apiVersion: cdi.kubevirt.io/v1beta1
 kind: StorageProfile

--- a/cluster/k8s/openebs-lvm/kustomization.yaml
+++ b/cluster/k8s/openebs-lvm/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - sc-lvm-proxmox-hdd.yaml
   - sc-lvm-proxmox-hdd-shared.yaml
   - sc-lvm-proxmox-hdd-block.yaml
+  - volumesnapshotclass.yaml

--- a/cluster/k8s/openebs-lvm/volumesnapshotclass.yaml
+++ b/cluster/k8s/openebs-lvm/volumesnapshotclass.yaml
@@ -1,0 +1,8 @@
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: openebs-lvm-snapclass
+  annotations:
+    snapshot.storage.kubernetes.io/is-default-class: "true"
+driver: local.csi.openebs.io
+deletionPolicy: Delete


### PR DESCRIPTION
## Summary

- Follow up to #2162 by switching the OpenEBS LVM CDI `StorageProfile` entries from host-assisted `copy` cloning to snapshot-backed smart cloning.
- Add a default `VolumeSnapshotClass` for `local.csi.openebs.io` so CDI has the snapshot prerequisite for fast LVM thin-volume clones.
- Leave non-LVM profiles on `copy`; OpenEBS LVM does not support CSI volume-from-volume clone, so this intentionally uses CDI's `snapshot` path rather than `csi-clone`.

## Verification

- `kubectl kustomize cluster/k8s/kubevirt/cdi`
- `kubectl kustomize cluster/k8s/openebs-lvm`
- `kubectl apply --dry-run=server -k cluster/k8s/kubevirt/cdi`
- `kubectl apply --server-side --force-conflicts --dry-run=server -k cluster/k8s/kubevirt/cdi`
- `kubectl apply --server-side --dry-run=server -k cluster/k8s/openebs-lvm`
- `pre-commit run --files cluster/k8s/kubevirt/cdi/kustomization.yaml cluster/k8s/kubevirt/cdi/storageprofiles.yaml cluster/k8s/openebs-lvm/kustomization.yaml cluster/k8s/openebs-lvm/volumesnapshotclass.yaml`