### PR TITLE
[codex] Split wayback archive input and filler

### DIFF
--- a/cluster/k8s/wayback-cache/deployment.yaml
+++ b/cluster/k8s/wayback-cache/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     reloader.stakater.com/auto: "true"
 spec:
-  replicas: 1
+  replicas: 5
   selector:
     matchLabels:
       app.kubernetes.io/name: wayback-cache
@@ -19,6 +19,20 @@ spec:
     spec:
       nodeSelector:
         topology.kubernetes.io/zone: hil-ovh
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: wayback-cache
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: wayback-cache
+              topologyKey: kubernetes.io/hostname
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/cluster/k8s/wayback-cache/filler-config.yaml
+++ b/cluster/k8s/wayback-cache/filler-config.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: wayback-cache-filler-config
+  namespace: wayback-cache
+  labels:
+    app.kubernetes.io/name: wayback-cache
+    app.kubernetes.io/component: filler
+data:
+  config.yaml: |
+    queue_wait_seconds: 180
+    upstream:
+      web: https://web.archive.org
+      availability: https://archive.org
+      timeouts_seconds:
+        availability: 15
+        cdx: 45
+        replay: 60
+    body_limits:
+      replay_bytes: 10485760
+      metadata_bytes: 10485760
+    store:
+      database_url_env: WAYBACK_ARCHIVE_DATABASE_URL
+      s3:
+        endpoint: http://seaweedfs-s3.seaweedfs.svc:8333
+        bucket: wayback-archive
+        region: us-east-1
+        allow_http: true
+        access_key_id_env: WAYBACK_ARCHIVE_S3_ACCESS_KEY_ID
+        secret_access_key_env: WAYBACK_ARCHIVE_S3_SECRET_ACCESS_KEY

--- a/cluster/k8s/wayback-cache/filler-deployment.yaml
+++ b/cluster/k8s/wayback-cache/filler-deployment.yaml
@@ -1,25 +1,43 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: wayback-cache
+  name: wayback-cache-filler
   namespace: wayback-cache
   labels:
     app.kubernetes.io/name: wayback-cache
-    app.kubernetes.io/component: input
+    app.kubernetes.io/component: filler
   annotations:
     reloader.stakater.com/auto: "true"
 spec:
-  replicas: 2
+  replicas: 5
   selector:
     matchLabels:
       app.kubernetes.io/name: wayback-cache
-      app.kubernetes.io/component: input
+      app.kubernetes.io/component: filler
   template:
     metadata:
       labels:
         app.kubernetes.io/name: wayback-cache
-        app.kubernetes.io/component: input
+        app.kubernetes.io/component: filler
     spec:
+      nodeSelector:
+        topology.kubernetes.io/zone: hil-ovh
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: wayback-cache
+              app.kubernetes.io/component: filler
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: wayback-cache
+                  app.kubernetes.io/component: filler
+              topologyKey: kubernetes.io/hostname
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -28,9 +46,11 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       containers:
-        - name: archive
+        - name: filler
           image: ghcr.io/agentydragon/wayback-archive:devel-20260612103812-835487e # {"$imagepolicy": "flux-system:wayback-archive"}
           imagePullPolicy: Always
+          command:
+            - /usr/local/bin/wayback_archive_filler
           env:
             - name: RUST_LOG
               value: info
@@ -49,11 +69,6 @@ spec:
                 secretKeyRef:
                   name: s3-identity-wayback-archive
                   key: secretKey
-            - name: WAYBACK_ARCHIVE_AUTH_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: wayback-cache-token
-                  key: token
           volumeMounts:
             - name: config
               mountPath: /etc/wayback-archive
@@ -61,9 +76,6 @@ spec:
           ports:
             - name: http
               containerPort: 8080
-              protocol: TCP
-            - name: authed
-              containerPort: 8090
               protocol: TCP
           livenessProbe:
             httpGet:
@@ -94,4 +106,4 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: wayback-cache-input-config
+            name: wayback-cache-filler-config

--- a/cluster/k8s/wayback-cache/filler-service.yaml
+++ b/cluster/k8s/wayback-cache/filler-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: wayback-cache-filler
+  namespace: wayback-cache
+  labels:
+    app.kubernetes.io/name: wayback-cache
+    app.kubernetes.io/component: filler
+spec:
+  selector:
+    app.kubernetes.io/name: wayback-cache
+    app.kubernetes.io/component: filler
+  ports:
+    - port: 8080
+      targetPort: 8080
+      protocol: TCP
+      name: http

--- a/cluster/k8s/wayback-cache/filler-servicemonitor.yaml
+++ b/cluster/k8s/wayback-cache/filler-servicemonitor.yaml
@@ -1,13 +1,13 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: wayback-cache
+  name: wayback-cache-filler
   namespace: wayback-cache
 spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: wayback-cache
-      app.kubernetes.io/component: input
+      app.kubernetes.io/component: filler
   endpoints:
     - port: http
       path: /metrics

--- a/cluster/k8s/wayback-cache/input-config.yaml
+++ b/cluster/k8s/wayback-cache/input-config.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: wayback-cache-input-config
+  namespace: wayback-cache
+  labels:
+    app.kubernetes.io/name: wayback-cache
+    app.kubernetes.io/component: input
+data:
+  config.yaml: |
+    queue_wait_seconds: 180
+    store:
+      database_url_env: WAYBACK_ARCHIVE_DATABASE_URL
+      s3:
+        endpoint: http://seaweedfs-s3.seaweedfs.svc:8333
+        bucket: wayback-archive
+        region: us-east-1
+        allow_http: true
+        access_key_id_env: WAYBACK_ARCHIVE_S3_ACCESS_KEY_ID
+        secret_access_key_env: WAYBACK_ARCHIVE_S3_SECRET_ACCESS_KEY

--- a/cluster/k8s/wayback-cache/kustomization.yaml
+++ b/cluster/k8s/wayback-cache/kustomization.yaml
@@ -3,6 +3,11 @@ kind: Kustomization
 
 resources:
   - deployment.yaml
+  - input-config.yaml
+  - filler-deployment.yaml
+  - filler-config.yaml
+  - filler-service.yaml
+  - filler-servicemonitor.yaml
   - service.yaml
   - httproute.yaml
   - servicemonitor.yaml

--- a/cluster/k8s/wayback-cache/service.yaml
+++ b/cluster/k8s/wayback-cache/service.yaml
@@ -7,9 +7,11 @@ metadata:
   namespace: wayback-cache
   labels:
     app.kubernetes.io/name: wayback-cache
+    app.kubernetes.io/component: input
 spec:
   selector:
     app.kubernetes.io/name: wayback-cache
+    app.kubernetes.io/component: input
   ports:
     - port: 8080
       targetPort: 8080

--- a/loom/wayback_archive/BUILD.bazel
+++ b/loom/wayback_archive/BUILD.bazel
@@ -11,6 +11,10 @@ exports_files([
 rust_library(
     name = "wayback_archive_lib",
     srcs = [
+        "backend/mod.rs",
+        "backend/worker.rs",
+        "frontend/mod.rs",
+        "frontend/service.rs",
         "ia_client.rs",
         "lib.rs",
         "limiter.rs",
@@ -18,6 +22,8 @@ rust_library(
         "path.rs",
         "response.rs",
         "service.rs",
+        "shared/config.rs",
+        "shared/mod.rs",
         "store/memory.rs",
         "store/mod.rs",
         "store/postgres.rs",
@@ -42,6 +48,7 @@ rust_library(
         "@crates//:sea-orm",
         "@crates//:serde",
         "@crates//:serde_json",
+        "@crates//:serde_yaml",
         "@crates//:sha2",
         "@crates//:tokio",
     ],
@@ -62,6 +69,21 @@ rust_binary(
     ],
 )
 
+rust_binary(
+    name = "wayback_archive_filler",
+    srcs = ["filler_main.rs"],
+    edition = "2024",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":wayback_archive_lib",
+        "@crates//:anyhow",
+        "@crates//:axum",
+        "@crates//:env_logger",
+        "@crates//:log",
+        "@crates//:tokio",
+    ],
+)
+
 rust_test(
     name = "wayback_archive_test",
     crate = ":wayback_archive_lib",
@@ -69,7 +91,10 @@ rust_test(
 
 pkg_tar(
     name = "binary_layer",
-    srcs = [":wayback_archive"],
+    srcs = [
+        ":wayback_archive",
+        ":wayback_archive_filler",
+    ],
     package_dir = "/usr/local/bin",
 )
 

--- a/loom/wayback_archive/PLAN.md
+++ b/loom/wayback_archive/PLAN.md
@@ -3,9 +3,10 @@
 Last trimmed: 2026-06-12.
 
 Status: v0 is live. The old nginx/PVC `wayback-cache` backend was replaced in
-place by the Rust archive service: one pod, one CNPG instance, SeaweedFS S3
-replay bodies, Prometheus metrics, and a public bearer-auth `:8090` listener.
-This file now tracks only current service shape and remaining reliability work.
+place by the Rust archive service: CNPG metadata, SeaweedFS S3 replay bodies,
+Prometheus metrics, and a public bearer-auth `:8090` listener. The archive
+service now runs one replica per OVH node and uses shared fill leases so
+identical cold misses do not stampede IA across replicas.
 
 Companions:
 
@@ -47,22 +48,26 @@ Storage is semantic, not opaque HTTP cache files.
 - Replay identity is `(capture_ts, modifier, canonical_original_url)`.
 - Replay bodies live in SeaweedFS S3, keyed by content hash.
 - CNPG Postgres is authoritative for replay records, Availability/CDX metadata,
-  aliases, stable negatives, fill attempts, limiter snapshots, and audit/debug
-  history.
+  cross-replica fill leases, aliases, stable negatives, fill attempts, limiter
+  snapshots, and audit/debug history.
 - A DB metadata row must not commit before its referenced blob exists. If an S3
   write succeeds and the DB commit fails, the result is an orphan blob that can
   be garbage-collected later.
 - Replay bodies over the configured cap, default 10 MiB, are classified as
   `body_too_large`; they are not retried as transient IA failures.
 
-The v0 deployment intentionally runs one archive-service pod. In-process
-single-flight is sufficient for identical misses inside that pod. Before
-scaling above one replica, add Postgres-backed fill leases or advisory locks
-keyed by endpoint and semantic request key.
+The v0 deployment runs multiple archive-service pods, spread across OVH nodes
+so cold IA fills can use distinct node egress IPs. In-process single-flight
+deduplicates identical misses inside a pod. Postgres-backed fill leases
+deduplicate identical misses across pods, keyed by endpoint and semantic
+request key. Lease waiters poll the shared store today; `LISTEN/NOTIFY` would
+be a cleaner wakeup path once this coordination becomes hot enough to matter.
 
 IA acquisition is endpoint-aware:
 
-- Availability, CDX, and replay have separate adaptive in-flight limiters.
+- Availability, CDX, and replay have separate adaptive in-flight limiters in
+  each pod. This is intentional while pod placement is tied to node egress IP:
+  one node/IP getting throttled should not globally stop other node/IPs.
 - Queue waits are bounded by `WAYBACK_ARCHIVE_MAX_QUEUE_WAIT_SECONDS`
   (default 60s).
 - Over-budget waits return `503 + Retry-After`.
@@ -113,7 +118,8 @@ to fix the core issue because agents choose new URLs dynamically.
 
 ## Active Next Steps
 
-1. Verify the deployed limiter telemetry fix in the live service.
+1. Verify the deployed multi-replica lease + limiter behavior in the live
+   service.
    - Reprobe the known bad CDX path.
    - Burst cold CDX and replay misses.
    - Confirm `wayback_archive_limiter_in_flight{endpoint="cdx"}` returns to 0.
@@ -131,6 +137,14 @@ to fix the core issue because agents choose new URLs dynamically.
 5. Keep `wayback_proxy` retry/wait behavior covered: `503 + Retry-After` should
    be an enforced wait while the proxy has budget, and an agent-visible failure
    only after waiting would exceed that budget.
+6. Decide whether to split the service into two binaries/containers:
+   - `archive-input`: accepts agent/proxy HTTP, serves cache hits, owns request
+     parsing and cache policy.
+   - `archive-filler`: node-pinned egress workers with per-node IA
+     limiter/backoff state.
+     This would separate input routing from output egress-IP selection. Postgres
+     has the primitives for the middle: lease rows, queue rows with
+     `FOR UPDATE SKIP LOCKED`, and `LISTEN/NOTIFY` for wakeups.
 
 ## Hardening Backlog
 
@@ -139,8 +153,12 @@ to fix the core issue because agents choose new URLs dynamically.
   `wayback_proxy`.
 - Add alias rows for IA canonicalization redirects and equivalent replay URL
   spellings.
-- Add Postgres fill leases/advisory locks before scaling archive-service pods
-  above one replica.
+- Replace cross-replica lease polling with Postgres `LISTEN/NOTIFY` so waiters
+  wake immediately when a peer fills or releases a semantic key.
+- If random Service input routing still sends requests to pods whose node/IP is
+  backed off while another node/IP is healthy, split input and filler/egress as
+  above or add an output-side scheduler/Envoy layer that understands per-egress
+  health.
 - Decide `wayback-archive-db` backup/failover policy before moving from a
   single CNPG instance to the OVH-HA profile.
 - Add orphan-blob garbage collection.

--- a/loom/wayback_archive/PLAN.md
+++ b/loom/wayback_archive/PLAN.md
@@ -4,9 +4,9 @@ Last trimmed: 2026-06-12.
 
 Status: v0 is live. The old nginx/PVC `wayback-cache` backend was replaced in
 place by the Rust archive service: CNPG metadata, SeaweedFS S3 replay bodies,
-Prometheus metrics, and a public bearer-auth `:8090` listener. The archive
-service now runs one replica per OVH node and uses shared fill leases so
-identical cold misses do not stampede IA across replicas.
+Prometheus metrics, and a public bearer-auth `:8090` listener. The current PR
+splits that service into input pods and filler pods connected by a Postgres fill
+queue with `LISTEN/NOTIFY` wakeups.
 
 Companions:
 
@@ -48,27 +48,35 @@ Storage is semantic, not opaque HTTP cache files.
 - Replay identity is `(capture_ts, modifier, canonical_original_url)`.
 - Replay bodies live in SeaweedFS S3, keyed by content hash.
 - CNPG Postgres is authoritative for replay records, Availability/CDX metadata,
-  cross-replica fill leases, aliases, stable negatives, fill attempts, limiter
-  snapshots, and audit/debug history.
+  fill locks, fill queue rows, and fill-change notifications.
 - A DB metadata row must not commit before its referenced blob exists. If an S3
   write succeeds and the DB commit fails, the result is an orphan blob that can
   be garbage-collected later.
 - Replay bodies over the configured cap, default 10 MiB, are classified as
   `body_too_large`; they are not retried as transient IA failures.
 
-The v0 deployment runs multiple archive-service pods, spread across OVH nodes
-so cold IA fills can use distinct node egress IPs. In-process single-flight
-deduplicates identical misses inside a pod. Postgres-backed fill leases
-deduplicate identical misses across pods, keyed by endpoint and semantic
-request key. Lease waiters poll the shared store today; `LISTEN/NOTIFY` would
-be a cleaner wakeup path once this coordination becomes hot enough to matter.
+The deployment is split into two roles:
+
+- `wayback-cache` input pods accept agent/proxy HTTP, serve cache hits, enqueue
+  cache misses, and wait up to the configured queue budget for a stored result.
+- `wayback-cache-filler` pods claim due fill queue rows and perform IA egress.
+  They are spread across OVH nodes so cold IA fills can use distinct node
+  egress IPs.
+
+Postgres queue rows deduplicate identical cold misses across input pods. Idle
+fillers and input waiters use `LISTEN/NOTIFY` so a newly enqueued fill or a
+completed fill wakes peers immediately instead of relying on polling.
+
+Runtime settings are loaded from typed YAML mounted at
+`/etc/wayback-archive/config.yaml`. Secrets remain env-backed by name: DB URL,
+S3 access key, S3 secret key, and optional bearer token.
 
 IA acquisition is endpoint-aware:
 
 - Availability, CDX, and replay have separate adaptive in-flight limiters in
   each pod. This is intentional while pod placement is tied to node egress IP:
   one node/IP getting throttled should not globally stop other node/IPs.
-- Queue waits are bounded by `WAYBACK_ARCHIVE_MAX_QUEUE_WAIT_SECONDS`
+- Queue waits are bounded by `queue_wait_seconds` in the mounted config
   (default 60s).
 - Over-budget waits return `503 + Retry-After`.
 - Transient IA failures (`502`, `503`, `504`, timeouts, connection resets,
@@ -118,7 +126,7 @@ to fix the core issue because agents choose new URLs dynamically.
 
 ## Active Next Steps
 
-1. Verify the deployed multi-replica lease + limiter behavior in the live
+1. Verify the deployed input/filler queue + limiter behavior in the live
    service.
    - Reprobe the known bad CDX path.
    - Burst cold CDX and replay misses.
@@ -126,25 +134,19 @@ to fix the core issue because agents choose new URLs dynamically.
    - Confirm
      `wayback_archive_acquisition_failures_total{endpoint,reason,status}`
      separates limiter queue timeout from upstream retry/backoff.
+   - Confirm input-side fill waits are visible in
+     `wayback_archive_input_fill_wait_duration_seconds`.
 2. Rerun the 33-task `glm-4.5` panel with:
    - `--message-limit 1000`
    - `--compaction-threshold-tokens 115000`
 3. Record archive-service endpoint counters in the final eval notes, not just
    driver-level aggregate `503` counts.
-4. Tune CDX acquisition if cache-side `503` remains dominant. CDX staying at
-   concurrency 1 protects IA but serializes cold misses enough to hurt the agent
-   loop.
+4. Tune filler concurrency if cache-side `503` remains dominant. CDX staying at
+   low concurrency protects IA but serializes cold misses enough to hurt the
+   agent loop.
 5. Keep `wayback_proxy` retry/wait behavior covered: `503 + Retry-After` should
    be an enforced wait while the proxy has budget, and an agent-visible failure
    only after waiting would exceed that budget.
-6. Decide whether to split the service into two binaries/containers:
-   - `archive-input`: accepts agent/proxy HTTP, serves cache hits, owns request
-     parsing and cache policy.
-   - `archive-filler`: node-pinned egress workers with per-node IA
-     limiter/backoff state.
-     This would separate input routing from output egress-IP selection. Postgres
-     has the primitives for the middle: lease rows, queue rows with
-     `FOR UPDATE SKIP LOCKED`, and `LISTEN/NOTIFY` for wakeups.
 
 ## Hardening Backlog
 
@@ -153,12 +155,8 @@ to fix the core issue because agents choose new URLs dynamically.
   `wayback_proxy`.
 - Add alias rows for IA canonicalization redirects and equivalent replay URL
   spellings.
-- Replace cross-replica lease polling with Postgres `LISTEN/NOTIFY` so waiters
-  wake immediately when a peer fills or releases a semantic key.
-- If random Service input routing still sends requests to pods whose node/IP is
-  backed off while another node/IP is healthy, split input and filler/egress as
-  above or add an output-side scheduler/Envoy layer that understands per-egress
-  health.
+- Decide whether filler pods should stay as an OVH-spread Deployment, become a
+  DaemonSet, or run on roaming nodes once node/IP policy is clearer.
 - Decide `wayback-archive-db` backup/failover policy before moving from a
   single CNPG instance to the OVH-HA profile.
 - Add orphan-blob garbage collection.
@@ -169,9 +167,8 @@ to fix the core issue because agents choose new URLs dynamically.
 
 - Multiple replay URL spellings for the same capture map to one stored replay
   record.
-- Concurrent identical semantic misses produce one IA backend fetch per service
-  replica; cross-replica duplication is blocked before replica count exceeds
-  one.
+- Concurrent identical semantic misses produce one due fill queue row and one
+  claimed filler attempt at a time.
 - A repeated eval run reuses captures filled by previous runs without touching
   IA for those captures.
 - IA `502/503/504`, connection resets, and timeouts are not cached as archive

--- a/loom/wayback_archive/backend/mod.rs
+++ b/loom/wayback_archive/backend/mod.rs
@@ -1,0 +1,3 @@
+mod worker;
+
+pub use worker::ArchiveFiller;

--- a/loom/wayback_archive/backend/worker.rs
+++ b/loom/wayback_archive/backend/worker.rs
@@ -1,0 +1,87 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use anyhow::Result;
+use log::{info, warn};
+
+use crate::service::ArchiveService;
+use crate::store::ArchiveStore;
+use crate::types::FillAttemptResult;
+
+const CLAIM_TTL: Duration = Duration::from_secs(300);
+const IDLE_WAIT: Duration = Duration::from_secs(30);
+
+pub struct ArchiveFiller {
+    store: Arc<dyn ArchiveStore>,
+    service: Arc<ArchiveService>,
+    worker_id: String,
+    lease_counter: AtomicU64,
+}
+
+impl ArchiveFiller {
+    pub fn new(store: Arc<dyn ArchiveStore>, service: Arc<ArchiveService>) -> Self {
+        let hostname = std::env::var("HOSTNAME").unwrap_or_else(|_| "local".to_string());
+        Self {
+            store,
+            service,
+            worker_id: format!("{hostname}:{}", std::process::id()),
+            lease_counter: AtomicU64::new(0),
+        }
+    }
+
+    pub async fn run_forever(&self) -> Result<()> {
+        info!("filler worker started id={}", self.worker_id);
+        loop {
+            match self.run_once().await {
+                Ok(true) => {}
+                Ok(false) => {
+                    let _ = self.store.wait_for_fill_queue_change(IDLE_WAIT).await;
+                }
+                Err(error) => {
+                    warn!("filler loop failed error={error:#}");
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                }
+            }
+        }
+    }
+
+    pub async fn run_once(&self) -> Result<bool> {
+        let owner = self.next_owner();
+        let Some(job) = self.store.claim_next_fill(&owner, CLAIM_TTL).await? else {
+            return Ok(false);
+        };
+        let key = job.request.lease_key();
+        let endpoint = job.request.endpoint();
+        info!("claimed fill endpoint={} key={}", endpoint.as_str(), key);
+        match self.service.process_fill_request(job.request.clone()).await {
+            FillAttemptResult::Completed => {
+                self.store.complete_fill(&job).await?;
+                info!("completed fill endpoint={} key={}", endpoint.as_str(), key);
+            }
+            FillAttemptResult::RetryAfter {
+                retry_after,
+                status,
+            } => {
+                self.store
+                    .retry_fill(&job, retry_after, status, Some("retryable fill result"))
+                    .await?;
+                warn!(
+                    "retryable fill endpoint={} key={} status={} retry_after={:?}",
+                    endpoint.as_str(),
+                    key,
+                    status
+                        .map(|status| status.to_string())
+                        .unwrap_or_else(|| "none".to_string()),
+                    retry_after
+                );
+            }
+        }
+        Ok(true)
+    }
+
+    fn next_owner(&self) -> String {
+        let sequence = self.lease_counter.fetch_add(1, Ordering::Relaxed);
+        format!("{}:{sequence}", self.worker_id)
+    }
+}

--- a/loom/wayback_archive/filler_main.rs
+++ b/loom/wayback_archive/filler_main.rs
@@ -1,0 +1,87 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use anyhow::Result;
+use axum::body::Body;
+use axum::extract::State;
+use axum::http::{Response, StatusCode, header};
+use axum::{Router, routing::get};
+use log::info;
+use wayback_archive::{
+    AdaptiveLimiter, ArchiveFiller, ArchiveService, LimiterConfig, ReqwestIaClient,
+    archive_config_from_env, archive_store_from_config,
+};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    env_logger::init();
+    let config = archive_config_from_env()?;
+    let settings = config.settings();
+    let store = archive_store_from_config(&config).await?;
+    let replay_limiter = Arc::new(AdaptiveLimiter::new(LimiterConfig {
+        queue_wait: settings.queue_wait,
+        ..LimiterConfig::replay()
+    }));
+    let availability_limiter = Arc::new(AdaptiveLimiter::new(LimiterConfig {
+        queue_wait: settings.queue_wait,
+        ..LimiterConfig::availability()
+    }));
+    let cdx_limiter = Arc::new(AdaptiveLimiter::new(LimiterConfig {
+        queue_wait: settings.queue_wait,
+        ..LimiterConfig::cdx()
+    }));
+    let service = Arc::new(
+        ArchiveService::new(
+            store.clone(),
+            Arc::new(ReqwestIaClient::with_timeouts(
+                settings.web_upstream,
+                settings.availability_upstream,
+                settings.timeouts,
+            )?),
+        )
+        .with_endpoint_limiters(
+            availability_limiter,
+            cdx_limiter,
+            replay_limiter,
+            settings.queue_wait,
+        )
+        .with_max_body_bytes(settings.max_body_bytes)
+        .with_max_metadata_bytes(settings.max_metadata_bytes),
+    );
+    let app = Router::new()
+        .route("/healthz", get(|| async { "ok\n" }))
+        .route("/readyz", get(|| async { "ok\n" }))
+        .route("/metrics", get(metrics))
+        .with_state(service.clone());
+    let address = SocketAddr::from(([0, 0, 0, 0], settings.port));
+    info!("metrics listener on {address}");
+    let listener = tokio::net::TcpListener::bind(address).await?;
+
+    tokio::try_join!(
+        async {
+            axum::serve(listener, app)
+                .await
+                .map_err(anyhow::Error::from)
+        },
+        async { ArchiveFiller::new(store, service).run_forever().await },
+    )?;
+    Ok(())
+}
+
+async fn metrics(State(service): State<Arc<ArchiveService>>) -> Response<Body> {
+    match service.metrics().await {
+        Ok(metrics) => Response::builder()
+            .status(StatusCode::OK)
+            .header(
+                header::CONTENT_TYPE,
+                "text/plain; version=0.0.4; charset=utf-8",
+            )
+            .body(Body::from(metrics))
+            .expect("response construction should not fail"),
+        Err(error) => Response::builder()
+            .status(StatusCode::INTERNAL_SERVER_ERROR)
+            .header(header::CONTENT_TYPE, "text/plain; charset=utf-8")
+            .body(Body::from(format!("metrics encoding failed: {error}\n")))
+            .expect("response construction should not fail"),
+    }
+}

--- a/loom/wayback_archive/frontend/mod.rs
+++ b/loom/wayback_archive/frontend/mod.rs
@@ -1,0 +1,3 @@
+mod service;
+
+pub use service::ArchiveInputService;

--- a/loom/wayback_archive/frontend/service.rs
+++ b/loom/wayback_archive/frontend/service.rs
@@ -1,0 +1,203 @@
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use http::StatusCode;
+use log::warn;
+use prometheus::{Encoder, HistogramOpts, HistogramVec, Registry, TextEncoder};
+
+use crate::path::{parse_metadata_request, parse_replay_path};
+use crate::response::{ArchiveResponse, stored_metadata_response, stored_replay_response};
+use crate::store::ArchiveStore;
+use crate::types::{Endpoint, FillRequest, MetadataKey, MetadataRequest, ReplayKey};
+use crate::{DEFAULT_MAX_QUEUE_WAIT, RETRY_AFTER_SECONDS};
+
+const WAIT_BUCKETS: [f64; 12] = [
+    0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0,
+];
+
+pub struct ArchiveInputService {
+    store: Arc<dyn ArchiveStore>,
+    queue_wait: Duration,
+    fill_wait_duration: HistogramVec,
+}
+
+impl ArchiveInputService {
+    pub fn new(store: Arc<dyn ArchiveStore>) -> Self {
+        Self {
+            store,
+            queue_wait: DEFAULT_MAX_QUEUE_WAIT,
+            fill_wait_duration: HistogramVec::new(
+                HistogramOpts::new(
+                    "wayback_archive_input_fill_wait_duration_seconds",
+                    "Duration spent waiting for a queued fill to become available in the cache.",
+                )
+                .buckets(WAIT_BUCKETS.to_vec()),
+                &["archive_endpoint", "outcome"],
+            )
+            .expect("input fill wait metric definition is valid"),
+        }
+    }
+
+    pub fn with_queue_wait(mut self, queue_wait: Duration) -> Self {
+        self.queue_wait = queue_wait;
+        self
+    }
+
+    pub async fn handle_path(&self, path: &str) -> ArchiveResponse {
+        self.handle_request(path, None).await
+    }
+
+    pub async fn handle_request(&self, path: &str, query: Option<&str>) -> ArchiveResponse {
+        if let Some(request) = parse_metadata_request(path, query) {
+            return self.handle_metadata(request).await;
+        }
+        let Some(key) = parse_replay_path(path) else {
+            return ArchiveResponse::text(
+                StatusCode::NOT_FOUND,
+                "unsupported wayback archive path\n",
+            );
+        };
+        self.handle_replay(key).await
+    }
+
+    pub async fn metrics(&self) -> Result<String> {
+        let registry = Registry::new();
+        registry.register(Box::new(self.fill_wait_duration.clone()))?;
+        let mut output = Vec::new();
+        TextEncoder::new().encode(&registry.gather(), &mut output)?;
+        String::from_utf8(output).context("prometheus text encoder emitted invalid UTF-8")
+    }
+
+    async fn handle_metadata(&self, request: MetadataRequest) -> ArchiveResponse {
+        match self.store.get_metadata(&request.key).await {
+            Ok(Some(metadata)) => return stored_metadata_response(metadata),
+            Ok(None) => {}
+            Err(error) => {
+                warn!(
+                    "metadata cache read failed key={} error={error:#}",
+                    request.key
+                );
+                return ArchiveResponse::text(
+                    StatusCode::BAD_GATEWAY,
+                    "archive metadata cache read failed\n",
+                );
+            }
+        }
+        let fill = FillRequest::Metadata(request.clone());
+        if let Err(error) = self.store.enqueue_fill(fill.clone()).await {
+            warn!(
+                "metadata fill enqueue failed key={} error={error:#}",
+                request.key
+            );
+            return ArchiveResponse::text(StatusCode::BAD_GATEWAY, "archive fill enqueue failed\n");
+        }
+        self.wait_for_metadata(fill, &request.key).await
+    }
+
+    async fn handle_replay(&self, key: ReplayKey) -> ArchiveResponse {
+        match self.store.get_replay(&key).await {
+            Ok(Some(replay)) => return stored_replay_response(replay),
+            Ok(None) => {}
+            Err(error) => {
+                warn!("replay cache read failed key={key} error={error:#}");
+                return ArchiveResponse::text(
+                    StatusCode::BAD_GATEWAY,
+                    "archive cache read failed\n",
+                );
+            }
+        }
+        let fill = FillRequest::Replay(key.clone());
+        if let Err(error) = self.store.enqueue_fill(fill.clone()).await {
+            warn!("replay fill enqueue failed key={key} error={error:#}");
+            return ArchiveResponse::text(StatusCode::BAD_GATEWAY, "archive fill enqueue failed\n");
+        }
+        self.wait_for_replay(fill, &key).await
+    }
+
+    async fn wait_for_metadata(&self, fill: FillRequest, key: &MetadataKey) -> ArchiveResponse {
+        let started = Instant::now();
+        let deadline = started + self.queue_wait;
+        let lease_key = fill.lease_key();
+        loop {
+            match self.store.get_metadata(key).await {
+                Ok(Some(metadata)) => {
+                    self.record_fill_wait(key.endpoint, "filled", started.elapsed());
+                    return stored_metadata_response(metadata);
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    warn!("metadata cache read failed key={key} error={error:#}");
+                    return ArchiveResponse::text(
+                        StatusCode::BAD_GATEWAY,
+                        "archive metadata cache read failed\n",
+                    );
+                }
+            }
+            let Some(wait) = deadline.checked_duration_since(Instant::now()) else {
+                self.record_fill_wait(key.endpoint, "timeout", started.elapsed());
+                return ArchiveResponse::retry_after_duration(
+                    key.endpoint,
+                    Some(Duration::from_secs(RETRY_AFTER_SECONDS)),
+                );
+            };
+            match self.store.wait_for_fill_change(&lease_key, wait).await {
+                Ok(_) => {}
+                Err(error) => {
+                    warn!("fill wait failed key={lease_key} error={error:#}");
+                    self.record_fill_wait(key.endpoint, "error", started.elapsed());
+                    return ArchiveResponse::text(
+                        StatusCode::BAD_GATEWAY,
+                        "archive fill wait failed\n",
+                    );
+                }
+            }
+        }
+    }
+
+    async fn wait_for_replay(&self, fill: FillRequest, key: &ReplayKey) -> ArchiveResponse {
+        let started = Instant::now();
+        let deadline = started + self.queue_wait;
+        let lease_key = fill.lease_key();
+        loop {
+            match self.store.get_replay(key).await {
+                Ok(Some(replay)) => {
+                    self.record_fill_wait(Endpoint::Replay, "filled", started.elapsed());
+                    return stored_replay_response(replay);
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    warn!("replay cache read failed key={key} error={error:#}");
+                    return ArchiveResponse::text(
+                        StatusCode::BAD_GATEWAY,
+                        "archive cache read failed\n",
+                    );
+                }
+            }
+            let Some(wait) = deadline.checked_duration_since(Instant::now()) else {
+                self.record_fill_wait(Endpoint::Replay, "timeout", started.elapsed());
+                return ArchiveResponse::retry_after_duration(
+                    Endpoint::Replay,
+                    Some(Duration::from_secs(RETRY_AFTER_SECONDS)),
+                );
+            };
+            match self.store.wait_for_fill_change(&lease_key, wait).await {
+                Ok(_) => {}
+                Err(error) => {
+                    warn!("fill wait failed key={lease_key} error={error:#}");
+                    self.record_fill_wait(Endpoint::Replay, "error", started.elapsed());
+                    return ArchiveResponse::text(
+                        StatusCode::BAD_GATEWAY,
+                        "archive fill wait failed\n",
+                    );
+                }
+            }
+        }
+    }
+
+    fn record_fill_wait(&self, endpoint: Endpoint, outcome: &str, duration: Duration) {
+        self.fill_wait_duration
+            .with_label_values(&[endpoint.as_str(), outcome])
+            .observe(duration.as_secs_f64());
+    }
+}

--- a/loom/wayback_archive/ia_client.rs
+++ b/loom/wayback_archive/ia_client.rs
@@ -10,7 +10,7 @@ use crate::{DEFAULT_AVAILABILITY_TIMEOUT, DEFAULT_CDX_TIMEOUT, DEFAULT_REPLAY_TI
 
 #[derive(Debug, Clone)]
 pub struct UpstreamResponse {
-    pub status: u16,
+    pub status: http::StatusCode,
     pub headers: HeaderMap,
     pub body: Bytes,
 }
@@ -113,7 +113,7 @@ impl ReqwestIaClient {
             .timeout(self.timeouts.for_endpoint(request.key.endpoint))
             .send()
             .await?;
-        let status = response.status().as_u16();
+        let status = response.status();
         let headers = response.headers().clone();
         let body = response.bytes().await?;
         Ok(UpstreamResponse {
@@ -138,7 +138,7 @@ impl IaClient for ReqwestIaClient {
             .timeout(self.timeouts.replay)
             .send()
             .await?;
-        let status = response.status().as_u16();
+        let status = response.status();
         let headers = response.headers().clone();
         let body = response.bytes().await?;
         Ok(UpstreamResponse {

--- a/loom/wayback_archive/lib.rs
+++ b/loom/wayback_archive/lib.rs
@@ -1,13 +1,18 @@
+mod backend;
+mod frontend;
 mod ia_client;
 mod limiter;
 mod metrics;
 mod path;
 mod response;
 mod service;
+mod shared;
 mod store;
 mod types;
 mod util;
 
+pub use backend::ArchiveFiller;
+pub use frontend::ArchiveInputService;
 pub use ia_client::{IaClient, ReqwestIaClient, UpstreamResponse, UpstreamTimeouts};
 pub use limiter::{
     AcquisitionOutcome, AdaptiveLimiter, LimiterConfig, LimiterPermit, LimiterSnapshot,
@@ -15,13 +20,17 @@ pub use limiter::{
 pub use path::{parse_metadata_request, parse_replay_path};
 pub use response::ArchiveResponse;
 pub use service::ArchiveService;
+pub use shared::{
+    ArchiveConfig, ArchiveSettings, archive_config_from_env, archive_settings_from_env,
+    archive_store_from_config, archive_store_from_env,
+};
 pub use store::{
     ArchiveStore, BlobRef, BlobStore, MemoryArchiveStore, MemoryBlobStore, PostgresArchiveStore,
     S3BlobStore,
 };
 pub use types::{
-    Endpoint, FillLeaseKey, MetadataKey, MetadataRecord, MetadataRequest, ReplayKey, ReplayRecord,
-    StoredMetadata, StoredReplay,
+    Endpoint, FillAttemptResult, FillLeaseKey, FillRequest, MetadataKey, MetadataRecord,
+    MetadataRequest, ReplayKey, ReplayRecord, StoredMetadata, StoredReplay,
 };
 
 use std::time::Duration;
@@ -46,7 +55,7 @@ mod tests {
     use async_trait::async_trait;
     use bytes::Bytes;
     use http::header::CONTENT_TYPE;
-    use http::{HeaderMap, HeaderValue};
+    use http::{HeaderMap, HeaderValue, StatusCode};
     use tokio::sync::{Mutex, oneshot};
 
     use super::*;
@@ -58,9 +67,9 @@ mod tests {
     fn response_header(response: &ArchiveResponse, name: &str) -> Option<String> {
         response
             .headers
-            .iter()
-            .find(|(header_name, _)| header_name == name)
-            .map(|(_, value)| value.clone())
+            .get(name)
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_string)
     }
 
     #[test]
@@ -108,7 +117,7 @@ mod tests {
     #[tokio::test]
     async fn availability_miss_is_fetched_and_cached_by_normalized_query() {
         let client = Arc::new(CountingClient::ok_json(
-            200,
+            StatusCode::OK,
             br#"{"archived_snapshots":{"closest":{"available":true}}}"#,
         ));
         let service = ArchiveService::new(Arc::new(MemoryArchiveStore::new()), client.clone());
@@ -126,8 +135,8 @@ mod tests {
             )
             .await;
 
-        assert_eq!(first.status, 200);
-        assert_eq!(second.status, 200);
+        assert_eq!(first.status, StatusCode::OK);
+        assert_eq!(second.status, StatusCode::OK);
         assert_eq!(second.body, first.body);
         assert_eq!(client.calls.load(Ordering::SeqCst), 1);
     }
@@ -135,7 +144,7 @@ mod tests {
     #[tokio::test]
     async fn cdx_miss_is_fetched_and_cached() {
         let client = Arc::new(CountingClient::ok_json(
-            200,
+            StatusCode::OK,
             br#"[["timestamp","original"],["20200101000000","https://example.com/"]]"#,
         ));
         let service = ArchiveService::new(Arc::new(MemoryArchiveStore::new()), client.clone());
@@ -153,8 +162,8 @@ mod tests {
             )
             .await;
 
-        assert_eq!(first.status, 200);
-        assert_eq!(second.status, 200);
+        assert_eq!(first.status, StatusCode::OK);
+        assert_eq!(second.status, StatusCode::OK);
         assert_eq!(second.body, first.body);
         assert_eq!(client.calls.load(Ordering::SeqCst), 1);
     }
@@ -163,12 +172,12 @@ mod tests {
     async fn metadata_502_is_not_cached() {
         let client = Arc::new(CountingClient::new(vec![
             UpstreamResponse {
-                status: 502,
+                status: StatusCode::BAD_GATEWAY,
                 headers: HeaderMap::new(),
                 body: Bytes::from_static(b"bad gateway"),
             },
             UpstreamResponse {
-                status: 200,
+                status: StatusCode::OK,
                 headers: json_headers(),
                 body: Bytes::from_static(br#"{"ok":true}"#),
             },
@@ -214,8 +223,8 @@ mod tests {
             )
             .await;
 
-        assert_eq!(first.status, 503);
-        assert_eq!(second.status, 200);
+        assert_eq!(first.status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(second.status, StatusCode::OK);
         assert_eq!(second.body, Bytes::from_static(br#"{"ok":true}"#));
         assert_eq!(client.calls.load(Ordering::SeqCst), 2);
     }
@@ -225,7 +234,7 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert("retry-after", header_value("7"));
         let client = Arc::new(CountingClient::new(vec![UpstreamResponse {
-            status: 503,
+            status: StatusCode::SERVICE_UNAVAILABLE,
             headers,
             body: Bytes::from_static(b"try later"),
         }]));
@@ -263,7 +272,7 @@ mod tests {
             )
             .await;
 
-        assert_eq!(response.status, 503);
+        assert_eq!(response.status, StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(
             response_header(&response, "retry-after").as_deref(),
             Some("7")
@@ -283,7 +292,10 @@ mod tests {
 
     #[tokio::test]
     async fn limiter_queue_timeout_is_reported_by_reason() {
-        let client = Arc::new(CountingClient::ok(200, b"won't be fetched".as_slice()));
+        let client = Arc::new(CountingClient::ok(
+            StatusCode::OK,
+            b"won't be fetched".as_slice(),
+        ));
         let limiter = Arc::new(AdaptiveLimiter::new(LimiterConfig {
             initial: 1,
             min: 1,
@@ -300,7 +312,7 @@ mod tests {
             .handle_path("/web/20200115103000id_/https://example.com/")
             .await;
 
-        assert_eq!(response.status, 503);
+        assert_eq!(response.status, StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(client.calls.load(Ordering::SeqCst), 0);
         assert!(service.metrics().await.unwrap().contains(
             "wayback_archive_acquisition_failures_total{endpoint=\"replay\",reason=\"limiter_queue_timeout\",status=\"none\"} 1"
@@ -310,7 +322,7 @@ mod tests {
 
     #[tokio::test]
     async fn oversized_metadata_is_stable_policy_result() {
-        let client = Arc::new(CountingClient::ok_json(200, b"too big"));
+        let client = Arc::new(CountingClient::ok_json(StatusCode::OK, b"too big"));
         let service = ArchiveService::new(Arc::new(MemoryArchiveStore::new()), client.clone())
             .with_max_metadata_bytes(3);
 
@@ -327,21 +339,21 @@ mod tests {
             )
             .await;
 
-        assert_eq!(first.status, 413);
-        assert_eq!(second.status, 413);
+        assert_eq!(first.status, StatusCode::PAYLOAD_TOO_LARGE);
+        assert_eq!(second.status, StatusCode::PAYLOAD_TOO_LARGE);
         assert_eq!(client.calls.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]
     async fn replay_miss_is_fetched_and_cached() {
-        let client = Arc::new(CountingClient::ok(200, b"hello".as_slice()));
+        let client = Arc::new(CountingClient::ok(StatusCode::OK, b"hello".as_slice()));
         let service = ArchiveService::new(Arc::new(MemoryArchiveStore::new()), client.clone());
         let path = "/web/20200115103000id_/https://example.com/";
 
         let first = service.handle_path(path).await;
         let second = service.handle_path(path).await;
 
-        assert_eq!(first.status, 200);
+        assert_eq!(first.status, StatusCode::OK);
         assert_eq!(first.body, Bytes::from_static(b"hello"));
         assert_eq!(second.body, Bytes::from_static(b"hello"));
         assert_eq!(client.calls.load(Ordering::SeqCst), 1);
@@ -355,7 +367,7 @@ mod tests {
             header_value("Wed, 15 Jan 2020 10:30:00 GMT"),
         );
         let client = Arc::new(CountingClient::new(vec![UpstreamResponse {
-            status: 404,
+            status: StatusCode::NOT_FOUND,
             headers,
             body: Bytes::from_static(b"archived not found"),
         }]));
@@ -368,8 +380,8 @@ mod tests {
             .handle_path("/web/20200115103000id_/http://gone.example/page")
             .await;
 
-        assert_eq!(first.status, 404);
-        assert_eq!(second.status, 404);
+        assert_eq!(first.status, StatusCode::NOT_FOUND);
+        assert_eq!(second.status, StatusCode::NOT_FOUND);
         assert_eq!(second.body, Bytes::from_static(b"archived not found"));
         assert_eq!(client.calls.load(Ordering::SeqCst), 1);
     }
@@ -378,12 +390,12 @@ mod tests {
     async fn ia_502_is_not_cached() {
         let client = Arc::new(CountingClient::new(vec![
             UpstreamResponse {
-                status: 502,
+                status: StatusCode::BAD_GATEWAY,
                 headers: HeaderMap::new(),
                 body: Bytes::from_static(b"bad gateway"),
             },
             UpstreamResponse {
-                status: 200,
+                status: StatusCode::OK,
                 headers: content_type_headers(),
                 body: Bytes::from_static(b"eventual success"),
             },
@@ -404,8 +416,8 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(2)).await;
         let second = service.handle_path(path).await;
 
-        assert_eq!(first.status, 503);
-        assert_eq!(second.status, 200);
+        assert_eq!(first.status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(second.status, StatusCode::OK);
         assert_eq!(second.body, Bytes::from_static(b"eventual success"));
         assert_eq!(client.calls.load(Ordering::SeqCst), 2);
     }
@@ -415,7 +427,7 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert("retry-after", header_value("11"));
         let client = Arc::new(CountingClient::new(vec![UpstreamResponse {
-            status: 503,
+            status: StatusCode::SERVICE_UNAVAILABLE,
             headers,
             body: Bytes::from_static(b"try later"),
         }]));
@@ -424,7 +436,7 @@ mod tests {
             .handle_path("/web/20200115103000id_/https://example.com/")
             .await;
 
-        assert_eq!(response.status, 503);
+        assert_eq!(response.status, StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(
             response_header(&response, "retry-after").as_deref(),
             Some("11")
@@ -433,7 +445,7 @@ mod tests {
 
     #[tokio::test]
     async fn oversized_replay_is_stable_policy_result() {
-        let client = Arc::new(CountingClient::ok(200, b"too big".as_slice()));
+        let client = Arc::new(CountingClient::ok(StatusCode::OK, b"too big".as_slice()));
         let service = ArchiveService::new(Arc::new(MemoryArchiveStore::new()), client.clone())
             .with_max_body_bytes(3);
         let path = "/web/20200115103000id_/https://example.com/";
@@ -441,8 +453,8 @@ mod tests {
         let first = service.handle_path(path).await;
         let second = service.handle_path(path).await;
 
-        assert_eq!(first.status, 413);
-        assert_eq!(second.status, 413);
+        assert_eq!(first.status, StatusCode::PAYLOAD_TOO_LARGE);
+        assert_eq!(second.status, StatusCode::PAYLOAD_TOO_LARGE);
         assert_eq!(client.calls.load(Ordering::SeqCst), 1);
     }
 
@@ -474,8 +486,8 @@ mod tests {
 
         let first = first.await.unwrap();
         let second = second.await.unwrap();
-        assert_eq!(first.status, 200);
-        assert_eq!(second.status, 200);
+        assert_eq!(first.status, StatusCode::OK);
+        assert_eq!(second.status, StatusCode::OK);
         assert_eq!(client.calls.load(Ordering::SeqCst), 1);
     }
 
@@ -506,8 +518,8 @@ mod tests {
 
         let first = first.await.unwrap();
         let second = second.await.unwrap();
-        assert_eq!(first.status, 200);
-        assert_eq!(second.status, 200);
+        assert_eq!(first.status, StatusCode::OK);
+        assert_eq!(second.status, StatusCode::OK);
         assert_eq!(client.calls.load(Ordering::SeqCst), 1);
     }
 
@@ -607,7 +619,7 @@ mod tests {
     }
 
     impl CountingClient {
-        fn ok(status: u16, body: &[u8]) -> Self {
+        fn ok(status: StatusCode, body: &[u8]) -> Self {
             Self::new(vec![UpstreamResponse {
                 status,
                 headers: content_type_headers(),
@@ -615,7 +627,7 @@ mod tests {
             }])
         }
 
-        fn ok_json(status: u16, body: &[u8]) -> Self {
+        fn ok_json(status: StatusCode, body: &[u8]) -> Self {
             Self::new(vec![UpstreamResponse {
                 status,
                 headers: json_headers(),
@@ -655,7 +667,7 @@ mod tests {
             self.calls.fetch_add(1, Ordering::SeqCst);
             let mut responses = self.responses.lock().await;
             Ok(responses.pop_front().unwrap_or_else(|| UpstreamResponse {
-                status: 200,
+                status: StatusCode::OK,
                 headers: content_type_headers(),
                 body: Bytes::from_static(b"default success"),
             }))
@@ -679,7 +691,7 @@ mod tests {
                 release.await.unwrap();
             }
             Ok(UpstreamResponse {
-                status: 200,
+                status: StatusCode::OK,
                 headers: content_type_headers(),
                 body: Bytes::from_static(b"single flight"),
             })

--- a/loom/wayback_archive/lib.rs
+++ b/loom/wayback_archive/lib.rs
@@ -20,7 +20,7 @@ pub use store::{
     S3BlobStore,
 };
 pub use types::{
-    Endpoint, MetadataKey, MetadataRecord, MetadataRequest, ReplayKey, ReplayRecord,
+    Endpoint, FillLeaseKey, MetadataKey, MetadataRecord, MetadataRequest, ReplayKey, ReplayRecord,
     StoredMetadata, StoredReplay,
 };
 
@@ -465,6 +465,38 @@ mod tests {
         });
         let second = tokio::spawn({
             let service = service.clone();
+            async move { service.handle_path(path).await }
+        });
+        while client.calls.load(Ordering::SeqCst) == 0 {
+            tokio::task::yield_now().await;
+        }
+        release_send.send(()).unwrap();
+
+        let first = first.await.unwrap();
+        let second = second.await.unwrap();
+        assert_eq!(first.status, 200);
+        assert_eq!(second.status, 200);
+        assert_eq!(client.calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn concurrent_identical_misses_share_fill_lease_across_services() {
+        let (release_send, release_recv) = oneshot::channel();
+        let client = Arc::new(BlockingClient {
+            calls: AtomicUsize::new(0),
+            release: Mutex::new(Some(release_recv)),
+        });
+        let store = Arc::new(MemoryArchiveStore::new());
+        let first_service = Arc::new(ArchiveService::new(store.clone(), client.clone()));
+        let second_service = Arc::new(ArchiveService::new(store, client.clone()));
+        let path = "/web/20200115103000id_/https://example.com/";
+
+        let first = tokio::spawn({
+            let service = first_service.clone();
+            async move { service.handle_path(path).await }
+        });
+        let second = tokio::spawn({
+            let service = second_service.clone();
             async move { service.handle_path(path).await }
         });
         while client.calls.load(Ordering::SeqCst) == 0 {

--- a/loom/wayback_archive/main.rs
+++ b/loom/wayback_archive/main.rs
@@ -1,94 +1,24 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::time::Duration;
 
 use anyhow::Result;
 use axum::body::Body;
 use axum::extract::{OriginalUri, State};
-use axum::http::{HeaderMap, HeaderName, HeaderValue, Response, StatusCode, header};
+use axum::http::{HeaderMap, HeaderValue, Response, StatusCode, header};
 use axum::{Router, routing::get};
 use log::info;
 use wayback_archive::{
-    AdaptiveLimiter, ArchiveResponse, ArchiveService, ArchiveStore, DEFAULT_AVAILABILITY_TIMEOUT,
-    DEFAULT_CDX_TIMEOUT, DEFAULT_MAX_BODY_BYTES, DEFAULT_MAX_METADATA_BYTES,
-    DEFAULT_MAX_QUEUE_WAIT, DEFAULT_REPLAY_TIMEOUT, LimiterConfig, MemoryArchiveStore,
-    PostgresArchiveStore, ReqwestIaClient, S3BlobStore, UpstreamTimeouts,
+    ArchiveInputService, ArchiveResponse, archive_config_from_env, archive_store_from_config,
 };
 
 #[tokio::main]
 async fn main() -> Result<()> {
     env_logger::init();
-    let port = std::env::var("PORT")
-        .ok()
-        .and_then(|value| value.parse::<u16>().ok())
-        .unwrap_or(8080);
-    let web_upstream = std::env::var("WAYBACK_ARCHIVE_WEB_UPSTREAM")
-        .unwrap_or_else(|_| "https://web.archive.org".to_string());
-    let availability_upstream = std::env::var("WAYBACK_ARCHIVE_AVAILABILITY_UPSTREAM")
-        .unwrap_or_else(|_| "https://archive.org".to_string());
-    let max_body_bytes = std::env::var("WAYBACK_ARCHIVE_MAX_BODY_BYTES")
-        .ok()
-        .and_then(|value| value.parse::<usize>().ok())
-        .unwrap_or(DEFAULT_MAX_BODY_BYTES);
-    let max_metadata_bytes = std::env::var("WAYBACK_ARCHIVE_MAX_METADATA_BYTES")
-        .ok()
-        .and_then(|value| value.parse::<usize>().ok())
-        .unwrap_or(DEFAULT_MAX_METADATA_BYTES);
-    let queue_wait = std::env::var("WAYBACK_ARCHIVE_MAX_QUEUE_WAIT_SECONDS")
-        .ok()
-        .and_then(|value| value.parse::<u64>().ok())
-        .map(Duration::from_secs)
-        .unwrap_or(DEFAULT_MAX_QUEUE_WAIT);
-    let timeouts = UpstreamTimeouts {
-        availability: duration_from_env_secs(
-            "WAYBACK_ARCHIVE_AVAILABILITY_TIMEOUT_SECONDS",
-            DEFAULT_AVAILABILITY_TIMEOUT,
-        ),
-        cdx: duration_from_env_secs("WAYBACK_ARCHIVE_CDX_TIMEOUT_SECONDS", DEFAULT_CDX_TIMEOUT),
-        replay: duration_from_env_secs(
-            "WAYBACK_ARCHIVE_REPLAY_TIMEOUT_SECONDS",
-            DEFAULT_REPLAY_TIMEOUT,
-        ),
-    };
-
-    let store: Arc<dyn ArchiveStore> =
-        if let Ok(database_url) = std::env::var("WAYBACK_ARCHIVE_DATABASE_URL") {
-            info!("using Postgres metadata store and S3 blob store");
-            let blobs = Arc::new(S3BlobStore::from_env()?);
-            Arc::new(PostgresArchiveStore::new(database_url, blobs).await?)
-        } else {
-            info!("using in-memory archive store");
-            Arc::new(MemoryArchiveStore::new())
-        };
-    let replay_limiter = Arc::new(AdaptiveLimiter::new(LimiterConfig {
-        queue_wait,
-        ..LimiterConfig::replay()
-    }));
-    let availability_limiter = Arc::new(AdaptiveLimiter::new(LimiterConfig {
-        queue_wait,
-        ..LimiterConfig::availability()
-    }));
-    let cdx_limiter = Arc::new(AdaptiveLimiter::new(LimiterConfig {
-        queue_wait,
-        ..LimiterConfig::cdx()
-    }));
+    let config = archive_config_from_env()?;
+    let settings = config.settings();
     let service = Arc::new(
-        ArchiveService::new(
-            store,
-            Arc::new(ReqwestIaClient::with_timeouts(
-                web_upstream,
-                availability_upstream,
-                timeouts,
-            )?),
-        )
-        .with_endpoint_limiters(
-            availability_limiter,
-            cdx_limiter,
-            replay_limiter,
-            queue_wait,
-        )
-        .with_max_body_bytes(max_body_bytes)
-        .with_max_metadata_bytes(max_metadata_bytes),
+        ArchiveInputService::new(archive_store_from_config(&config).await?)
+            .with_queue_wait(settings.queue_wait),
     );
 
     let app = Router::new()
@@ -97,19 +27,12 @@ async fn main() -> Result<()> {
         .route("/metrics", get(metrics))
         .fallback(handle)
         .with_state(service.clone());
-    let address = SocketAddr::from(([0, 0, 0, 0], port));
-    info!("wayback archive listening on {address}");
+    let address = SocketAddr::from(([0, 0, 0, 0], settings.port));
+    info!("listening on {address}");
     let listener = tokio::net::TcpListener::bind(address).await?;
 
-    if let Some(auth_token) = std::env::var("WAYBACK_ARCHIVE_AUTH_TOKEN")
-        .ok()
-        .filter(|value| !value.is_empty())
-    {
-        let auth_port = std::env::var("WAYBACK_ARCHIVE_AUTH_PORT")
-            .ok()
-            .and_then(|value| value.parse::<u16>().ok())
-            .unwrap_or(8090);
-        let auth_address = SocketAddr::from(([0, 0, 0, 0], auth_port));
+    if let Some(auth_token) = settings.auth_token {
+        let auth_address = SocketAddr::from(([0, 0, 0, 0], settings.auth_port));
         let auth_listener = tokio::net::TcpListener::bind(auth_address).await?;
         let auth_state = Arc::new(AuthedState {
             service,
@@ -120,7 +43,7 @@ async fn main() -> Result<()> {
             .route("/readyz", get(handle_authed_health))
             .fallback(handle_authed)
             .with_state(auth_state);
-        info!("wayback archive bearer-authed listener on {auth_address}");
+        info!("bearer-authed listener on {auth_address}");
         tokio::try_join!(async { axum::serve(listener, app).await }, async {
             axum::serve(auth_listener, auth_app).await
         },)?;
@@ -130,22 +53,14 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-fn duration_from_env_secs(name: &str, default: Duration) -> Duration {
-    std::env::var(name)
-        .ok()
-        .and_then(|value| value.parse::<u64>().ok())
-        .map(Duration::from_secs)
-        .unwrap_or(default)
-}
-
 #[derive(Clone)]
 struct AuthedState {
-    service: Arc<ArchiveService>,
+    service: Arc<ArchiveInputService>,
     authorization_header: HeaderValue,
 }
 
 async fn handle(
-    State(service): State<Arc<ArchiveService>>,
+    State(service): State<Arc<ArchiveInputService>>,
     OriginalUri(uri): OriginalUri,
 ) -> Response<Body> {
     into_axum_response(service.handle_request(uri.path(), uri.query()).await)
@@ -188,7 +103,7 @@ fn unauthorized_response() -> Response<Body> {
         .expect("response construction should not fail")
 }
 
-async fn metrics(State(service): State<Arc<ArchiveService>>) -> Response<Body> {
+async fn metrics(State(service): State<Arc<ArchiveInputService>>) -> Response<Body> {
     match service.metrics().await {
         Ok(metrics) => Response::builder()
             .status(StatusCode::OK)
@@ -207,15 +122,9 @@ async fn metrics(State(service): State<Arc<ArchiveService>>) -> Response<Body> {
 }
 
 fn into_axum_response(response: ArchiveResponse) -> Response<Body> {
-    let mut builder = Response::builder()
-        .status(StatusCode::from_u16(response.status).unwrap_or(StatusCode::BAD_GATEWAY));
-    for (name, value) in response.headers {
-        if let (Ok(name), Ok(value)) = (
-            HeaderName::from_bytes(name.as_bytes()),
-            HeaderValue::from_str(&value),
-        ) {
-            builder = builder.header(name, value);
-        }
+    let mut builder = Response::builder().status(response.status);
+    for (name, value) in response.headers.iter() {
+        builder = builder.header(name, value);
     }
     builder
         .body(Body::from(response.body))

--- a/loom/wayback_archive/response.rs
+++ b/loom/wayback_archive/response.rs
@@ -1,25 +1,27 @@
 use std::time::Duration;
 
 use bytes::Bytes;
-use http::StatusCode;
+use http::{HeaderMap, HeaderValue, StatusCode, header};
 
-use crate::types::Endpoint;
+use crate::types::{Endpoint, StoredMetadata, StoredReplay};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ArchiveResponse {
-    pub status: u16,
-    pub headers: Vec<(String, String)>,
+    pub status: StatusCode,
+    pub headers: HeaderMap,
     pub body: Bytes,
 }
 
 impl ArchiveResponse {
     pub(crate) fn text(status: StatusCode, text: impl Into<String>) -> Self {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("text/plain; charset=utf-8"),
+        );
         Self {
-            status: status.as_u16(),
-            headers: vec![(
-                "content-type".to_string(),
-                "text/plain; charset=utf-8".to_string(),
-            )],
+            status,
+            headers,
             body: Bytes::from(text.into()),
         }
     }
@@ -29,22 +31,53 @@ impl ArchiveResponse {
     }
 
     pub(crate) fn retry_after_duration(endpoint: Endpoint, duration: Option<Duration>) -> Self {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("text/plain; charset=utf-8"),
+        );
+        headers.insert(
+            header::RETRY_AFTER,
+            HeaderValue::from_str(
+                &retry_after_seconds(duration)
+                    .unwrap_or_else(|| endpoint.retry_after_seconds())
+                    .to_string(),
+            )
+            .expect("retry-after seconds must be a valid header value"),
+        );
         Self {
-            status: StatusCode::SERVICE_UNAVAILABLE.as_u16(),
-            headers: vec![
-                (
-                    "content-type".to_string(),
-                    "text/plain; charset=utf-8".to_string(),
-                ),
-                (
-                    "retry-after".to_string(),
-                    retry_after_seconds(duration)
-                        .unwrap_or_else(|| endpoint.retry_after_seconds())
-                        .to_string(),
-                ),
-            ],
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            headers,
             body: Bytes::from("archive acquisition is backing off\n"),
         }
+    }
+}
+
+pub(crate) fn stored_replay_response(replay: StoredReplay) -> ArchiveResponse {
+    match replay {
+        StoredReplay::Capture(record) => ArchiveResponse {
+            status: record.status,
+            headers: record.headers,
+            body: record.body,
+        },
+        StoredReplay::BodyTooLarge { observed_size, .. } => ArchiveResponse::text(
+            StatusCode::PAYLOAD_TOO_LARGE,
+            format!("archived replay body is too large: {observed_size} bytes\n"),
+        ),
+    }
+}
+
+pub(crate) fn stored_metadata_response(metadata: StoredMetadata) -> ArchiveResponse {
+    match metadata {
+        StoredMetadata::Response(record) => ArchiveResponse {
+            status: record.status,
+            headers: record.headers,
+            body: record.body,
+        },
+        StoredMetadata::BodyTooLarge { observed_size, .. } => ArchiveResponse::text(
+            StatusCode::PAYLOAD_TOO_LARGE,
+            format!("archived metadata response is too large: {observed_size} bytes\n"),
+        ),
     }
 }
 

--- a/loom/wayback_archive/service.rs
+++ b/loom/wayback_archive/service.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
@@ -7,7 +8,7 @@ use http::{HeaderMap, StatusCode};
 use log::warn;
 use prometheus::{Encoder, GaugeVec, Opts, Registry, TextEncoder};
 use tokio::sync::{Mutex, Notify};
-use tokio::time::timeout;
+use tokio::time::{sleep, timeout};
 
 use crate::ia_client::{IaClient, UpstreamResponse};
 use crate::limiter::{AcquisitionOutcome, AdaptiveLimiter, LimiterConfig};
@@ -19,11 +20,14 @@ use crate::path::{parse_metadata_request, parse_replay_path};
 use crate::response::ArchiveResponse;
 use crate::store::ArchiveStore;
 use crate::types::{
-    Endpoint, MetadataKey, MetadataRecord, MetadataRequest, ReplayKey, ReplayRecord,
+    Endpoint, FillLeaseKey, MetadataKey, MetadataRecord, MetadataRequest, ReplayKey, ReplayRecord,
     StoredMetadata, StoredReplay,
 };
 use crate::util::sha256_hex;
 use crate::{DEFAULT_MAX_BODY_BYTES, DEFAULT_MAX_METADATA_BYTES, DEFAULT_MAX_QUEUE_WAIT};
+
+const SHARED_FILL_POLL_INTERVAL: Duration = Duration::from_millis(250);
+static NEXT_INSTANCE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug)]
 struct FillFlights<T> {
@@ -52,10 +56,14 @@ pub struct ArchiveService {
     max_body_bytes: usize,
     max_metadata_bytes: usize,
     queue_wait: Duration,
+    instance_id: String,
+    lease_counter: AtomicU64,
 }
 
 impl ArchiveService {
     pub fn new(store: Arc<dyn ArchiveStore>, client: Arc<dyn IaClient>) -> Self {
+        let hostname = std::env::var("HOSTNAME").unwrap_or_else(|_| "local".to_string());
+        let instance_sequence = NEXT_INSTANCE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
         Self {
             store,
             client,
@@ -68,6 +76,8 @@ impl ArchiveService {
             max_body_bytes: DEFAULT_MAX_BODY_BYTES,
             max_metadata_bytes: DEFAULT_MAX_METADATA_BYTES,
             queue_wait: DEFAULT_MAX_QUEUE_WAIT,
+            instance_id: format!("{hostname}:{}:{instance_sequence}", std::process::id()),
+            lease_counter: AtomicU64::new(0),
         }
     }
 
@@ -264,7 +274,7 @@ impl ArchiveService {
             );
             return ArchiveResponse::retry_after(request.key.endpoint);
         }
-        let response = self.fill_metadata(request.clone()).await;
+        let response = self.fill_metadata_with_shared_lease(request.clone()).await;
         self.leave_metadata_fill(&request.key).await;
         response
     }
@@ -304,7 +314,7 @@ impl ArchiveService {
             );
             return ArchiveResponse::retry_after(Endpoint::Replay);
         }
-        let response = self.fill_replay(key.clone()).await;
+        let response = self.fill_replay_with_shared_lease(key.clone()).await;
         self.leave_fill(&key).await;
         response
     }
@@ -417,6 +427,182 @@ impl ArchiveService {
             flights.notify.clone()
         };
         notify.notify_waiters();
+    }
+
+    async fn fill_metadata_with_shared_lease(&self, request: MetadataRequest) -> ArchiveResponse {
+        let endpoint = request.key.endpoint;
+        let lease_key = FillLeaseKey::metadata(&request.key);
+        let owner = self.next_lease_owner();
+        let started = Instant::now();
+        let deadline = started + self.queue_wait;
+        let mut waiter = None;
+        loop {
+            match self.store.get_metadata(&request.key).await {
+                Ok(Some(metadata)) => {
+                    drop(waiter);
+                    self.metrics.record_single_flight_wait_duration(
+                        endpoint,
+                        SingleFlightWaitOutcome::FilledByPeer,
+                        started.elapsed(),
+                    );
+                    return stored_metadata_response(metadata);
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    warn!(
+                        "wayback archive metadata cache read failed while waiting for lease key={lease_key} error={error:#}"
+                    );
+                    return ArchiveResponse::text(
+                        StatusCode::BAD_GATEWAY,
+                        "archive metadata cache read failed\n",
+                    );
+                }
+            }
+            match self
+                .store
+                .try_acquire_fill_lease(&lease_key, &owner, self.fill_lease_ttl())
+                .await
+            {
+                Ok(true) => {
+                    if let Some(waiter) = waiter.take() {
+                        drop(waiter);
+                        self.metrics.record_single_flight_wait_duration(
+                            endpoint,
+                            SingleFlightWaitOutcome::Owner,
+                            started.elapsed(),
+                        );
+                    }
+                    let response = self.fill_metadata(request.clone()).await;
+                    if let Err(error) = self.store.release_fill_lease(&lease_key, &owner).await {
+                        warn!(
+                            "wayback archive fill lease release failed key={lease_key} error={error:#}"
+                        );
+                    }
+                    return response;
+                }
+                Ok(false) => {}
+                Err(error) => {
+                    warn!(
+                        "wayback archive fill lease acquire failed key={lease_key} error={error:#}"
+                    );
+                    return self.fill_metadata(request).await;
+                }
+            }
+
+            if waiter.is_none() {
+                waiter = Some(self.metrics.begin_single_flight_wait(endpoint));
+            }
+            let Some(wait) = deadline.checked_duration_since(Instant::now()) else {
+                drop(waiter);
+                self.metrics.record_single_flight_wait_duration(
+                    endpoint,
+                    SingleFlightWaitOutcome::Timeout,
+                    started.elapsed(),
+                );
+                self.record_shared_fill_timeout(endpoint, &lease_key);
+                return ArchiveResponse::retry_after(endpoint);
+            };
+            sleep(wait.min(SHARED_FILL_POLL_INTERVAL)).await;
+        }
+    }
+
+    async fn fill_replay_with_shared_lease(&self, key: ReplayKey) -> ArchiveResponse {
+        let lease_key = FillLeaseKey::replay(&key);
+        let owner = self.next_lease_owner();
+        let started = Instant::now();
+        let deadline = started + self.queue_wait;
+        let mut waiter = None;
+        loop {
+            match self.store.get_replay(&key).await {
+                Ok(Some(replay)) => {
+                    drop(waiter);
+                    self.metrics.record_single_flight_wait_duration(
+                        Endpoint::Replay,
+                        SingleFlightWaitOutcome::FilledByPeer,
+                        started.elapsed(),
+                    );
+                    return stored_replay_response(replay);
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    warn!(
+                        "wayback archive cache read failed while waiting for lease key={lease_key} error={error:#}"
+                    );
+                    return ArchiveResponse::text(
+                        StatusCode::BAD_GATEWAY,
+                        "archive cache read failed\n",
+                    );
+                }
+            }
+            match self
+                .store
+                .try_acquire_fill_lease(&lease_key, &owner, self.fill_lease_ttl())
+                .await
+            {
+                Ok(true) => {
+                    if let Some(waiter) = waiter.take() {
+                        drop(waiter);
+                        self.metrics.record_single_flight_wait_duration(
+                            Endpoint::Replay,
+                            SingleFlightWaitOutcome::Owner,
+                            started.elapsed(),
+                        );
+                    }
+                    let response = self.fill_replay(key.clone()).await;
+                    if let Err(error) = self.store.release_fill_lease(&lease_key, &owner).await {
+                        warn!(
+                            "wayback archive fill lease release failed key={lease_key} error={error:#}"
+                        );
+                    }
+                    return response;
+                }
+                Ok(false) => {}
+                Err(error) => {
+                    warn!(
+                        "wayback archive fill lease acquire failed key={lease_key} error={error:#}"
+                    );
+                    return self.fill_replay(key).await;
+                }
+            }
+
+            if waiter.is_none() {
+                waiter = Some(self.metrics.begin_single_flight_wait(Endpoint::Replay));
+            }
+            let Some(wait) = deadline.checked_duration_since(Instant::now()) else {
+                drop(waiter);
+                self.metrics.record_single_flight_wait_duration(
+                    Endpoint::Replay,
+                    SingleFlightWaitOutcome::Timeout,
+                    started.elapsed(),
+                );
+                self.record_shared_fill_timeout(Endpoint::Replay, &lease_key);
+                return ArchiveResponse::retry_after(Endpoint::Replay);
+            };
+            sleep(wait.min(SHARED_FILL_POLL_INTERVAL)).await;
+        }
+    }
+
+    fn next_lease_owner(&self) -> String {
+        let sequence = self.lease_counter.fetch_add(1, Ordering::Relaxed);
+        format!("{}:{sequence}", self.instance_id)
+    }
+
+    fn fill_lease_ttl(&self) -> Duration {
+        self.queue_wait + Duration::from_secs(120)
+    }
+
+    fn record_shared_fill_timeout(&self, endpoint: Endpoint, key: &FillLeaseKey) {
+        warn!(
+            "wayback archive acquisition failed endpoint={} reason={} status=none key={}",
+            endpoint.as_str(),
+            AcquisitionFailureReason::SingleFlightQueueTimeout.as_str(),
+            key
+        );
+        self.metrics.record_acquisition_failure(
+            endpoint,
+            AcquisitionFailureReason::SingleFlightQueueTimeout,
+            None,
+        );
     }
 
     async fn fill_metadata(&self, request: MetadataRequest) -> ArchiveResponse {

--- a/loom/wayback_archive/service.rs
+++ b/loom/wayback_archive/service.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
-use http::{HeaderMap, StatusCode};
+use http::{HeaderMap, HeaderName, StatusCode};
 use log::warn;
 use prometheus::{Encoder, GaugeVec, Opts, Registry, TextEncoder};
 use tokio::sync::{Mutex, Notify};
@@ -17,11 +17,11 @@ use crate::metrics::{
     UpstreamFetchResult,
 };
 use crate::path::{parse_metadata_request, parse_replay_path};
-use crate::response::ArchiveResponse;
+use crate::response::{ArchiveResponse, stored_metadata_response, stored_replay_response};
 use crate::store::ArchiveStore;
 use crate::types::{
-    Endpoint, FillLeaseKey, MetadataKey, MetadataRecord, MetadataRequest, ReplayKey, ReplayRecord,
-    StoredMetadata, StoredReplay,
+    Endpoint, FillAttemptResult, FillLeaseKey, FillRequest, MetadataKey, MetadataRecord,
+    MetadataRequest, ReplayKey, ReplayRecord, StoredMetadata, StoredReplay,
 };
 use crate::util::sha256_hex;
 use crate::{DEFAULT_MAX_BODY_BYTES, DEFAULT_MAX_METADATA_BYTES, DEFAULT_MAX_QUEUE_WAIT};
@@ -239,6 +239,14 @@ impl ArchiveService {
         String::from_utf8(output).context("prometheus text encoder emitted invalid UTF-8")
     }
 
+    pub async fn process_fill_request(&self, request: FillRequest) -> FillAttemptResult {
+        let response = match request {
+            FillRequest::Metadata(request) => self.fill_metadata(request).await,
+            FillRequest::Replay(key) => self.fill_replay(key).await,
+        };
+        fill_response_result(&response)
+    }
+
     pub async fn handle_metadata(&self, request: MetadataRequest) -> ArchiveResponse {
         match self.store.get_metadata(&request.key).await {
             Ok(Some(metadata)) => return stored_metadata_response(metadata),
@@ -262,7 +270,7 @@ impl ArchiveService {
                 }
             }
             warn!(
-                "wayback archive acquisition failed endpoint={} reason={} status=none key={}",
+                "acquisition failed endpoint={} reason={} status=none key={}",
                 request.key.endpoint.as_str(),
                 AcquisitionFailureReason::SingleFlightQueueTimeout.as_str(),
                 request.key
@@ -302,7 +310,7 @@ impl ArchiveService {
                 }
             }
             warn!(
-                "wayback archive acquisition failed endpoint={} reason={} status=none key={}",
+                "acquisition failed endpoint={} reason={} status=none key={}",
                 Endpoint::Replay.as_str(),
                 AcquisitionFailureReason::SingleFlightQueueTimeout.as_str(),
                 key
@@ -450,7 +458,7 @@ impl ArchiveService {
                 Ok(None) => {}
                 Err(error) => {
                     warn!(
-                        "wayback archive metadata cache read failed while waiting for lease key={lease_key} error={error:#}"
+                        "metadata cache read failed while waiting for lease key={lease_key} error={error:#}"
                     );
                     return ArchiveResponse::text(
                         StatusCode::BAD_GATEWAY,
@@ -474,17 +482,13 @@ impl ArchiveService {
                     }
                     let response = self.fill_metadata(request.clone()).await;
                     if let Err(error) = self.store.release_fill_lease(&lease_key, &owner).await {
-                        warn!(
-                            "wayback archive fill lease release failed key={lease_key} error={error:#}"
-                        );
+                        warn!("fill lease release failed key={lease_key} error={error:#}");
                     }
                     return response;
                 }
                 Ok(false) => {}
                 Err(error) => {
-                    warn!(
-                        "wayback archive fill lease acquire failed key={lease_key} error={error:#}"
-                    );
+                    warn!("fill lease acquire failed key={lease_key} error={error:#}");
                     return self.fill_metadata(request).await;
                 }
             }
@@ -526,7 +530,7 @@ impl ArchiveService {
                 Ok(None) => {}
                 Err(error) => {
                     warn!(
-                        "wayback archive cache read failed while waiting for lease key={lease_key} error={error:#}"
+                        "cache read failed while waiting for lease key={lease_key} error={error:#}"
                     );
                     return ArchiveResponse::text(
                         StatusCode::BAD_GATEWAY,
@@ -550,17 +554,13 @@ impl ArchiveService {
                     }
                     let response = self.fill_replay(key.clone()).await;
                     if let Err(error) = self.store.release_fill_lease(&lease_key, &owner).await {
-                        warn!(
-                            "wayback archive fill lease release failed key={lease_key} error={error:#}"
-                        );
+                        warn!("fill lease release failed key={lease_key} error={error:#}");
                     }
                     return response;
                 }
                 Ok(false) => {}
                 Err(error) => {
-                    warn!(
-                        "wayback archive fill lease acquire failed key={lease_key} error={error:#}"
-                    );
+                    warn!("fill lease acquire failed key={lease_key} error={error:#}");
                     return self.fill_replay(key).await;
                 }
             }
@@ -593,7 +593,7 @@ impl ArchiveService {
 
     fn record_shared_fill_timeout(&self, endpoint: Endpoint, key: &FillLeaseKey) {
         warn!(
-            "wayback archive acquisition failed endpoint={} reason={} status=none key={}",
+            "acquisition failed endpoint={} reason={} status=none key={}",
             endpoint.as_str(),
             AcquisitionFailureReason::SingleFlightQueueTimeout.as_str(),
             key
@@ -615,7 +615,7 @@ impl ArchiveService {
                 limiter_wait_started.elapsed(),
             );
             warn!(
-                "wayback archive acquisition failed endpoint={} reason={} status=none key={}",
+                "acquisition failed endpoint={} reason={} status=none key={}",
                 request.key.endpoint.as_str(),
                 AcquisitionFailureReason::LimiterQueueTimeout.as_str(),
                 request.key
@@ -648,7 +648,7 @@ impl ArchiveService {
                 self.metrics.record_upstream_fetch_duration(
                     request.key.endpoint,
                     UpstreamFetchResult::BodyTooLarge,
-                    Some(response.status),
+                    Some(response.status.as_u16()),
                     upstream_duration,
                 );
                 permit.record(AcquisitionOutcome::Healthy);
@@ -674,21 +674,21 @@ impl ArchiveService {
                 self.metrics.record_upstream_fetch_duration(
                     request.key.endpoint,
                     UpstreamFetchResult::from_upstream_failure(reason),
-                    Some(response.status),
+                    Some(response.status.as_u16()),
                     upstream_duration,
                 );
                 warn!(
-                    "wayback archive acquisition failed endpoint={} reason={} status={} key={} retry_after={:?}",
+                    "acquisition failed endpoint={} reason={} status={} key={} retry_after={:?}",
                     request.key.endpoint.as_str(),
                     reason.as_str(),
-                    response.status,
+                    response.status.as_u16(),
                     request.key,
                     retry_after
                 );
                 self.metrics.record_acquisition_failure(
                     request.key.endpoint,
                     reason,
-                    Some(response.status),
+                    Some(response.status.as_u16()),
                 );
                 permit.record(
                     retry_after
@@ -701,7 +701,7 @@ impl ArchiveService {
                 self.metrics.record_upstream_fetch_duration(
                     request.key.endpoint,
                     UpstreamFetchResult::Stored,
-                    Some(response.status),
+                    Some(response.status.as_u16()),
                     upstream_duration,
                 );
                 permit.record(AcquisitionOutcome::Healthy);
@@ -731,7 +731,7 @@ impl ArchiveService {
                     upstream_duration,
                 );
                 warn!(
-                    "wayback archive acquisition failed endpoint={} reason={} status=none key={} error={error:#}",
+                    "acquisition failed endpoint={} reason={} status=none key={} error={error:#}",
                     request.key.endpoint.as_str(),
                     reason.as_str(),
                     request.key
@@ -754,7 +754,7 @@ impl ArchiveService {
                 limiter_wait_started.elapsed(),
             );
             warn!(
-                "wayback archive acquisition failed endpoint={} reason={} status=none key={}",
+                "acquisition failed endpoint={} reason={} status=none key={}",
                 Endpoint::Replay.as_str(),
                 AcquisitionFailureReason::LimiterQueueTimeout.as_str(),
                 key
@@ -783,7 +783,7 @@ impl ArchiveService {
                 self.metrics.record_upstream_fetch_duration(
                     Endpoint::Replay,
                     UpstreamFetchResult::BodyTooLarge,
-                    Some(response.status),
+                    Some(response.status.as_u16()),
                     upstream_duration,
                 );
                 permit.record(AcquisitionOutcome::Healthy);
@@ -809,21 +809,21 @@ impl ArchiveService {
                 self.metrics.record_upstream_fetch_duration(
                     Endpoint::Replay,
                     UpstreamFetchResult::from_upstream_failure(reason),
-                    Some(response.status),
+                    Some(response.status.as_u16()),
                     upstream_duration,
                 );
                 warn!(
-                    "wayback archive acquisition failed endpoint={} reason={} status={} key={} retry_after={:?}",
+                    "acquisition failed endpoint={} reason={} status={} key={} retry_after={:?}",
                     Endpoint::Replay.as_str(),
                     reason.as_str(),
-                    response.status,
+                    response.status.as_u16(),
                     key,
                     retry_after
                 );
                 self.metrics.record_acquisition_failure(
                     Endpoint::Replay,
                     reason,
-                    Some(response.status),
+                    Some(response.status.as_u16()),
                 );
                 permit.record(
                     retry_after
@@ -836,7 +836,7 @@ impl ArchiveService {
                 self.metrics.record_upstream_fetch_duration(
                     Endpoint::Replay,
                     UpstreamFetchResult::Stored,
-                    Some(response.status),
+                    Some(response.status.as_u16()),
                     upstream_duration,
                 );
                 permit.record(AcquisitionOutcome::Healthy);
@@ -867,7 +867,7 @@ impl ArchiveService {
                     upstream_duration,
                 );
                 warn!(
-                    "wayback archive acquisition failed endpoint={} reason={} status=none key={} error={error:#}",
+                    "acquisition failed endpoint={} reason={} status=none key={} error={error:#}",
                     Endpoint::Replay.as_str(),
                     reason.as_str(),
                     key
@@ -889,64 +889,53 @@ impl ArchiveService {
     }
 }
 
-fn stored_replay_response(replay: StoredReplay) -> ArchiveResponse {
-    match replay {
-        StoredReplay::Capture(record) => ArchiveResponse {
-            status: record.status,
-            headers: record.headers,
-            body: record.body,
-        },
-        StoredReplay::BodyTooLarge { observed_size, .. } => ArchiveResponse::text(
-            StatusCode::PAYLOAD_TOO_LARGE,
-            format!("archived replay body is too large: {observed_size} bytes\n"),
-        ),
+fn fill_response_result(response: &ArchiveResponse) -> FillAttemptResult {
+    if response.status == StatusCode::SERVICE_UNAVAILABLE
+        || response.status == StatusCode::BAD_GATEWAY
+        || response.status == StatusCode::GATEWAY_TIMEOUT
+    {
+        return FillAttemptResult::RetryAfter {
+            retry_after: retry_after_response_duration(response),
+            status: Some(response.status.as_u16()),
+        };
     }
+    FillAttemptResult::Completed
 }
 
-fn stored_metadata_response(metadata: StoredMetadata) -> ArchiveResponse {
-    match metadata {
-        StoredMetadata::Response(record) => ArchiveResponse {
-            status: record.status,
-            headers: record.headers,
-            body: record.body,
-        },
-        StoredMetadata::BodyTooLarge { observed_size, .. } => ArchiveResponse::text(
-            StatusCode::PAYLOAD_TOO_LARGE,
-            format!("archived metadata response is too large: {observed_size} bytes\n"),
-        ),
+fn retry_after_response_duration(response: &ArchiveResponse) -> Option<Duration> {
+    response
+        .headers
+        .get("retry-after")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u64>().ok())
+        .map(Duration::from_secs)
+}
+
+fn selected_headers(headers: &HeaderMap) -> HeaderMap {
+    selected_header_names(headers, &["content-type", "location", "memento-datetime"])
+}
+
+fn selected_metadata_headers(headers: &HeaderMap) -> HeaderMap {
+    selected_header_names(headers, &["content-type", "retry-after"])
+}
+
+fn selected_header_names(headers: &HeaderMap, names: &[&'static str]) -> HeaderMap {
+    let mut selected = HeaderMap::new();
+    for name in names {
+        if let Some(value) = headers.get(*name) {
+            selected.insert(HeaderName::from_static(name), value.clone());
+        }
     }
-}
-
-fn selected_headers(headers: &HeaderMap) -> Vec<(String, String)> {
-    ["content-type", "location", "memento-datetime"]
-        .into_iter()
-        .filter_map(|name| {
-            headers
-                .get(name)
-                .and_then(|value| value.to_str().ok())
-                .map(|value| (name.to_string(), value.to_string()))
-        })
-        .collect()
-}
-
-fn selected_metadata_headers(headers: &HeaderMap) -> Vec<(String, String)> {
-    ["content-type", "retry-after"]
-        .into_iter()
-        .filter_map(|name| {
-            headers
-                .get(name)
-                .and_then(|value| value.to_str().ok())
-                .map(|value| (name.to_string(), value.to_string()))
-        })
-        .collect()
+    selected
 }
 
 fn is_transient_replay_failure(response: &UpstreamResponse) -> bool {
-    response.status >= 400 && response.headers.get("memento-datetime").is_none()
+    (response.status.is_client_error() || response.status.is_server_error())
+        && response.headers.get("memento-datetime").is_none()
 }
 
 fn is_transient_metadata_failure(response: &UpstreamResponse) -> bool {
-    response.status == 429 || response.status >= 500
+    response.status == StatusCode::TOO_MANY_REQUESTS || response.status.is_server_error()
 }
 
 fn upstream_error_reason(error: &anyhow::Error) -> AcquisitionFailureReason {

--- a/loom/wayback_archive/shared/config.rs
+++ b/loom/wayback_archive/shared/config.rs
@@ -1,0 +1,244 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use log::info;
+use serde::Deserialize;
+
+use crate::ia_client::UpstreamTimeouts;
+use crate::store::{ArchiveStore, MemoryArchiveStore, PostgresArchiveStore, S3BlobStore};
+use crate::{
+    DEFAULT_AVAILABILITY_TIMEOUT, DEFAULT_CDX_TIMEOUT, DEFAULT_MAX_BODY_BYTES,
+    DEFAULT_MAX_METADATA_BYTES, DEFAULT_MAX_QUEUE_WAIT, DEFAULT_REPLAY_TIMEOUT,
+};
+
+const DEFAULT_CONFIG_PATH: &str = "/etc/wayback-archive/config.yaml";
+const DEFAULT_AUTH_TOKEN_ENV: &str = "WAYBACK_ARCHIVE_AUTH_TOKEN";
+const DEFAULT_DATABASE_URL_ENV: &str = "WAYBACK_ARCHIVE_DATABASE_URL";
+const DEFAULT_S3_ACCESS_KEY_ID_ENV: &str = "WAYBACK_ARCHIVE_S3_ACCESS_KEY_ID";
+const DEFAULT_S3_SECRET_ACCESS_KEY_ENV: &str = "WAYBACK_ARCHIVE_S3_SECRET_ACCESS_KEY";
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct ArchiveConfig {
+    pub port: u16,
+    pub auth_port: u16,
+    pub auth_token_env: Option<String>,
+    pub queue_wait_seconds: u64,
+    pub upstream: UpstreamConfig,
+    pub body_limits: BodyLimitConfig,
+    pub store: StoreConfig,
+}
+
+impl Default for ArchiveConfig {
+    fn default() -> Self {
+        Self {
+            port: 8080,
+            auth_port: 8090,
+            auth_token_env: Some(DEFAULT_AUTH_TOKEN_ENV.to_string()),
+            queue_wait_seconds: DEFAULT_MAX_QUEUE_WAIT.as_secs(),
+            upstream: UpstreamConfig::default(),
+            body_limits: BodyLimitConfig::default(),
+            store: StoreConfig::default(),
+        }
+    }
+}
+
+impl ArchiveConfig {
+    pub fn settings(&self) -> ArchiveSettings {
+        ArchiveSettings {
+            port: self.port,
+            auth_port: self.auth_port,
+            auth_token: optional_env(self.auth_token_env.as_deref()),
+            web_upstream: self.upstream.web.clone(),
+            availability_upstream: self.upstream.availability.clone(),
+            max_body_bytes: self.body_limits.replay_bytes,
+            max_metadata_bytes: self.body_limits.metadata_bytes,
+            queue_wait: Duration::from_secs(self.queue_wait_seconds),
+            timeouts: UpstreamTimeouts {
+                availability: Duration::from_secs(self.upstream.timeouts_seconds.availability),
+                cdx: Duration::from_secs(self.upstream.timeouts_seconds.cdx),
+                replay: Duration::from_secs(self.upstream.timeouts_seconds.replay),
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct UpstreamConfig {
+    pub web: String,
+    pub availability: String,
+    pub timeouts_seconds: UpstreamTimeoutSeconds,
+}
+
+impl Default for UpstreamConfig {
+    fn default() -> Self {
+        Self {
+            web: "https://web.archive.org".to_string(),
+            availability: "https://archive.org".to_string(),
+            timeouts_seconds: UpstreamTimeoutSeconds::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct UpstreamTimeoutSeconds {
+    pub availability: u64,
+    pub cdx: u64,
+    pub replay: u64,
+}
+
+impl Default for UpstreamTimeoutSeconds {
+    fn default() -> Self {
+        Self {
+            availability: DEFAULT_AVAILABILITY_TIMEOUT.as_secs(),
+            cdx: DEFAULT_CDX_TIMEOUT.as_secs(),
+            replay: DEFAULT_REPLAY_TIMEOUT.as_secs(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct BodyLimitConfig {
+    pub replay_bytes: usize,
+    pub metadata_bytes: usize,
+}
+
+impl Default for BodyLimitConfig {
+    fn default() -> Self {
+        Self {
+            replay_bytes: DEFAULT_MAX_BODY_BYTES,
+            metadata_bytes: DEFAULT_MAX_METADATA_BYTES,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct StoreConfig {
+    pub database_url_env: Option<String>,
+    pub s3: Option<S3Config>,
+}
+
+impl Default for StoreConfig {
+    fn default() -> Self {
+        Self {
+            database_url_env: Some(DEFAULT_DATABASE_URL_ENV.to_string()),
+            s3: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct S3Config {
+    pub endpoint: Option<String>,
+    pub bucket: Option<String>,
+    pub region: String,
+    pub allow_http: bool,
+    pub access_key_id_env: Option<String>,
+    pub secret_access_key_env: Option<String>,
+}
+
+impl Default for S3Config {
+    fn default() -> Self {
+        Self {
+            endpoint: None,
+            bucket: None,
+            region: "us-east-1".to_string(),
+            allow_http: true,
+            access_key_id_env: Some(DEFAULT_S3_ACCESS_KEY_ID_ENV.to_string()),
+            secret_access_key_env: Some(DEFAULT_S3_SECRET_ACCESS_KEY_ENV.to_string()),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ArchiveSettings {
+    pub port: u16,
+    pub auth_port: u16,
+    pub auth_token: Option<String>,
+    pub web_upstream: String,
+    pub availability_upstream: String,
+    pub max_body_bytes: usize,
+    pub max_metadata_bytes: usize,
+    pub queue_wait: Duration,
+    pub timeouts: UpstreamTimeouts,
+}
+
+pub fn archive_config_from_env() -> Result<ArchiveConfig> {
+    if let Some(path) = optional_env(Some("WAYBACK_ARCHIVE_CONFIG")).map(PathBuf::from) {
+        return load_archive_config(&path);
+    }
+
+    let default_path = Path::new(DEFAULT_CONFIG_PATH);
+    if default_path.exists() {
+        return load_archive_config(default_path);
+    }
+
+    Ok(ArchiveConfig::default())
+}
+
+pub fn archive_settings_from_env() -> Result<ArchiveSettings> {
+    Ok(archive_config_from_env()?.settings())
+}
+
+pub async fn archive_store_from_env() -> Result<Arc<dyn ArchiveStore>> {
+    let config = archive_config_from_env()?;
+    archive_store_from_config(&config).await
+}
+
+pub async fn archive_store_from_config(config: &ArchiveConfig) -> Result<Arc<dyn ArchiveStore>> {
+    let Some(database_url) = optional_env(config.store.database_url_env.as_deref()) else {
+        info!("using in-memory archive store");
+        return Ok(Arc::new(MemoryArchiveStore::new()));
+    };
+
+    info!("using Postgres metadata store and S3 blob store");
+    let s3 = config
+        .store
+        .s3
+        .as_ref()
+        .context("store.s3 must be configured when database_url_env is set")?;
+    let blobs = Arc::new(S3BlobStore::new(
+        s3.endpoint
+            .clone()
+            .context("store.s3.endpoint must be configured")?,
+        s3.bucket
+            .clone()
+            .context("store.s3.bucket must be configured")?,
+        required_env(
+            s3.access_key_id_env.as_deref(),
+            "store.s3.access_key_id_env",
+        )?,
+        required_env(
+            s3.secret_access_key_env.as_deref(),
+            "store.s3.secret_access_key_env",
+        )?,
+        s3.region.clone(),
+        s3.allow_http,
+    )?);
+    Ok(Arc::new(
+        PostgresArchiveStore::new(database_url, blobs).await?,
+    ))
+}
+
+fn load_archive_config(path: &Path) -> Result<ArchiveConfig> {
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("reading archive config {}", path.display()))?;
+    serde_yaml::from_str(&raw).with_context(|| format!("parsing archive config {}", path.display()))
+}
+
+fn optional_env(name: Option<&str>) -> Option<String> {
+    name.and_then(|name| std::env::var(name).ok())
+        .filter(|value| !value.is_empty())
+}
+
+fn required_env(name: Option<&str>, field: &str) -> Result<String> {
+    let name = name.with_context(|| format!("{field} must be configured"))?;
+    std::env::var(name).with_context(|| format!("{name} must be set"))
+}

--- a/loom/wayback_archive/shared/mod.rs
+++ b/loom/wayback_archive/shared/mod.rs
@@ -1,0 +1,6 @@
+mod config;
+
+pub use config::{
+    ArchiveConfig, ArchiveSettings, archive_config_from_env, archive_settings_from_env,
+    archive_store_from_config, archive_store_from_env,
+};

--- a/loom/wayback_archive/store/memory.rs
+++ b/loom/wayback_archive/store/memory.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::time::{Duration, Instant};
 
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
@@ -6,13 +7,20 @@ use bytes::Bytes;
 use tokio::sync::Mutex;
 
 use crate::store::{ArchiveStore, BlobRef, BlobStore, blob_key};
-use crate::types::{MetadataKey, ReplayKey, StoredMetadata, StoredReplay};
+use crate::types::{FillLeaseKey, MetadataKey, ReplayKey, StoredMetadata, StoredReplay};
 use crate::util::sha256_hex;
 
 #[derive(Default)]
 pub struct MemoryArchiveStore {
     replays: Mutex<HashMap<ReplayKey, StoredReplay>>,
     metadata: Mutex<HashMap<MetadataKey, StoredMetadata>>,
+    leases: Mutex<HashMap<FillLeaseKey, MemoryLease>>,
+}
+
+#[derive(Debug, Clone)]
+struct MemoryLease {
+    owner: String,
+    expires_at: Instant,
 }
 
 impl MemoryArchiveStore {
@@ -46,6 +54,38 @@ impl ArchiveStore for MemoryArchiveStore {
             StoredMetadata::BodyTooLarge { key, .. } => key.clone(),
         };
         self.metadata.lock().await.insert(key, metadata);
+        Ok(())
+    }
+
+    async fn try_acquire_fill_lease(
+        &self,
+        key: &FillLeaseKey,
+        owner: &str,
+        ttl: Duration,
+    ) -> Result<bool> {
+        let mut leases = self.leases.lock().await;
+        let now = Instant::now();
+        if leases
+            .get(key)
+            .is_some_and(|lease| lease.expires_at > now && lease.owner != owner)
+        {
+            return Ok(false);
+        }
+        leases.insert(
+            key.clone(),
+            MemoryLease {
+                owner: owner.to_string(),
+                expires_at: now + ttl,
+            },
+        );
+        Ok(true)
+    }
+
+    async fn release_fill_lease(&self, key: &FillLeaseKey, owner: &str) -> Result<()> {
+        let mut leases = self.leases.lock().await;
+        if leases.get(key).is_some_and(|lease| lease.owner == owner) {
+            leases.remove(key);
+        }
         Ok(())
     }
 }

--- a/loom/wayback_archive/store/memory.rs
+++ b/loom/wayback_archive/store/memory.rs
@@ -4,10 +4,13 @@ use std::time::{Duration, Instant};
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use bytes::Bytes;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Notify};
+use tokio::time::timeout;
 
-use crate::store::{ArchiveStore, BlobRef, BlobStore, blob_key};
-use crate::types::{FillLeaseKey, MetadataKey, ReplayKey, StoredMetadata, StoredReplay};
+use crate::store::{ArchiveStore, BlobRef, BlobStore, ClaimedFill, blob_key};
+use crate::types::{
+    FillLeaseKey, FillRequest, MetadataKey, ReplayKey, StoredMetadata, StoredReplay,
+};
 use crate::util::sha256_hex;
 
 #[derive(Default)]
@@ -15,12 +18,21 @@ pub struct MemoryArchiveStore {
     replays: Mutex<HashMap<ReplayKey, StoredReplay>>,
     metadata: Mutex<HashMap<MetadataKey, StoredMetadata>>,
     leases: Mutex<HashMap<FillLeaseKey, MemoryLease>>,
+    fills: Mutex<HashMap<FillLeaseKey, MemoryFill>>,
+    fill_notify: Notify,
 }
 
 #[derive(Debug, Clone)]
 struct MemoryLease {
     owner: String,
     expires_at: Instant,
+}
+
+#[derive(Debug, Clone)]
+struct MemoryFill {
+    request: FillRequest,
+    lease: Option<MemoryLease>,
+    next_attempt: Instant,
 }
 
 impl MemoryArchiveStore {
@@ -55,6 +67,86 @@ impl ArchiveStore for MemoryArchiveStore {
         };
         self.metadata.lock().await.insert(key, metadata);
         Ok(())
+    }
+
+    async fn enqueue_fill(&self, request: FillRequest) -> Result<()> {
+        let key = request.lease_key();
+        self.fills.lock().await.entry(key).or_insert(MemoryFill {
+            request,
+            lease: None,
+            next_attempt: Instant::now(),
+        });
+        self.fill_notify.notify_waiters();
+        Ok(())
+    }
+
+    async fn claim_next_fill(&self, owner: &str, ttl: Duration) -> Result<Option<ClaimedFill>> {
+        let mut fills = self.fills.lock().await;
+        let now = Instant::now();
+        let Some(fill) = fills.values_mut().find(|fill| {
+            fill.next_attempt <= now
+                && fill
+                    .lease
+                    .as_ref()
+                    .is_none_or(|lease| lease.expires_at <= now)
+        }) else {
+            return Ok(None);
+        };
+        fill.lease = Some(MemoryLease {
+            owner: owner.to_string(),
+            expires_at: now + ttl,
+        });
+        Ok(Some(ClaimedFill {
+            request: fill.request.clone(),
+            owner: owner.to_string(),
+        }))
+    }
+
+    async fn complete_fill(&self, job: &ClaimedFill) -> Result<()> {
+        let mut fills = self.fills.lock().await;
+        let key = job.request.lease_key();
+        if fills
+            .get(&key)
+            .and_then(|fill| fill.lease.as_ref())
+            .is_some_and(|lease| lease.owner == job.owner)
+        {
+            fills.remove(&key);
+            self.fill_notify.notify_waiters();
+        }
+        Ok(())
+    }
+
+    async fn retry_fill(
+        &self,
+        job: &ClaimedFill,
+        retry_after: Option<Duration>,
+        _status: Option<u16>,
+        _error: Option<&str>,
+    ) -> Result<()> {
+        let mut fills = self.fills.lock().await;
+        let key = job.request.lease_key();
+        if let Some(fill) = fills.get_mut(&key)
+            && fill
+                .lease
+                .as_ref()
+                .is_some_and(|lease| lease.owner == job.owner)
+        {
+            fill.lease = None;
+            fill.next_attempt = Instant::now()
+                + retry_after.unwrap_or_else(|| {
+                    Duration::from_secs(job.request.endpoint().retry_after_seconds())
+                });
+            self.fill_notify.notify_waiters();
+        }
+        Ok(())
+    }
+
+    async fn wait_for_fill_change(&self, _key: &FillLeaseKey, wait: Duration) -> Result<bool> {
+        Ok(timeout(wait, self.fill_notify.notified()).await.is_ok())
+    }
+
+    async fn wait_for_fill_queue_change(&self, wait: Duration) -> Result<bool> {
+        Ok(timeout(wait, self.fill_notify.notified()).await.is_ok())
     }
 
     async fn try_acquire_fill_lease(

--- a/loom/wayback_archive/store/mod.rs
+++ b/loom/wayback_archive/store/mod.rs
@@ -1,8 +1,10 @@
+use std::time::Duration;
+
 use anyhow::Result;
 use async_trait::async_trait;
 use bytes::Bytes;
 
-use crate::types::{MetadataKey, ReplayKey, StoredMetadata, StoredReplay};
+use crate::types::{FillLeaseKey, MetadataKey, ReplayKey, StoredMetadata, StoredReplay};
 
 mod memory;
 mod postgres;
@@ -18,6 +20,13 @@ pub trait ArchiveStore: Send + Sync {
     async fn put_replay(&self, replay: StoredReplay) -> Result<()>;
     async fn get_metadata(&self, key: &MetadataKey) -> Result<Option<StoredMetadata>>;
     async fn put_metadata(&self, metadata: StoredMetadata) -> Result<()>;
+    async fn try_acquire_fill_lease(
+        &self,
+        key: &FillLeaseKey,
+        owner: &str,
+        ttl: Duration,
+    ) -> Result<bool>;
+    async fn release_fill_lease(&self, key: &FillLeaseKey, owner: &str) -> Result<()>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/loom/wayback_archive/store/mod.rs
+++ b/loom/wayback_archive/store/mod.rs
@@ -4,7 +4,9 @@ use anyhow::Result;
 use async_trait::async_trait;
 use bytes::Bytes;
 
-use crate::types::{FillLeaseKey, MetadataKey, ReplayKey, StoredMetadata, StoredReplay};
+use crate::types::{
+    FillLeaseKey, FillRequest, MetadataKey, ReplayKey, StoredMetadata, StoredReplay,
+};
 
 mod memory;
 mod postgres;
@@ -20,6 +22,18 @@ pub trait ArchiveStore: Send + Sync {
     async fn put_replay(&self, replay: StoredReplay) -> Result<()>;
     async fn get_metadata(&self, key: &MetadataKey) -> Result<Option<StoredMetadata>>;
     async fn put_metadata(&self, metadata: StoredMetadata) -> Result<()>;
+    async fn enqueue_fill(&self, request: FillRequest) -> Result<()>;
+    async fn claim_next_fill(&self, owner: &str, ttl: Duration) -> Result<Option<ClaimedFill>>;
+    async fn complete_fill(&self, job: &ClaimedFill) -> Result<()>;
+    async fn retry_fill(
+        &self,
+        job: &ClaimedFill,
+        retry_after: Option<Duration>,
+        status: Option<u16>,
+        error: Option<&str>,
+    ) -> Result<()>;
+    async fn wait_for_fill_queue_change(&self, timeout: Duration) -> Result<bool>;
+    async fn wait_for_fill_change(&self, key: &FillLeaseKey, timeout: Duration) -> Result<bool>;
     async fn try_acquire_fill_lease(
         &self,
         key: &FillLeaseKey,
@@ -27,6 +41,12 @@ pub trait ArchiveStore: Send + Sync {
         ttl: Duration,
     ) -> Result<bool>;
     async fn release_fill_lease(&self, key: &FillLeaseKey, owner: &str) -> Result<()>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClaimedFill {
+    pub request: FillRequest,
+    pub owner: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/loom/wayback_archive/store/postgres.rs
+++ b/loom/wayback_archive/store/postgres.rs
@@ -4,19 +4,26 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use bytes::Bytes;
+use http::{HeaderMap, HeaderName, HeaderValue, StatusCode};
+use log::{info, warn};
 use sea_orm::entity::prelude::*;
 use sea_orm::sea_query::{Expr, OnConflict};
+use sea_orm::sqlx::postgres::PgListener;
 use sea_orm::{
     ColumnTrait, Condition, ConnectionTrait, Database, DatabaseConnection, DbBackend, EntityTrait,
-    QueryFilter, Schema, Set, TryInsertResult,
+    QueryFilter, QueryOrder, Schema, Set, Statement, TryInsertResult,
 };
 use serde_json::Value;
+use tokio::sync::broadcast;
+use tokio::time::timeout;
 
-use crate::store::{ArchiveStore, BlobStore};
+use crate::store::{ArchiveStore, BlobStore, ClaimedFill};
 use crate::types::{
-    Endpoint, FillLeaseKey, MetadataKey, MetadataRecord, ReplayKey, ReplayRecord, StoredMetadata,
-    StoredReplay,
+    Endpoint, FillLeaseKey, FillRequest, MetadataKey, MetadataRecord, ReplayKey, ReplayRecord,
+    StoredMetadata, StoredReplay,
 };
+
+const FILL_NOTIFY_CHANNEL: &str = "wayback_fill_changed";
 
 mod replay_record {
     use sea_orm::entity::prelude::*;
@@ -90,16 +97,49 @@ mod fill_lease {
     impl ActiveModelBehavior for ActiveModel {}
 }
 
+mod fill_queue {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "wayback_fill_queue")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub endpoint: String,
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub fill_key: String,
+        pub request: Json,
+        pub attempts: i32,
+        pub next_attempt_at_ms: i64,
+        pub lease_owner: Option<String>,
+        pub lease_expires_at_ms: Option<i64>,
+        pub last_status: Option<i32>,
+        pub last_error: Option<String>,
+        pub updated_at_ms: i64,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
 pub struct PostgresArchiveStore {
     db: DatabaseConnection,
     blobs: Arc<dyn BlobStore>,
+    notifications: broadcast::Sender<String>,
 }
 
 impl PostgresArchiveStore {
     pub async fn new(database_url: String, blobs: Arc<dyn BlobStore>) -> Result<Self> {
         let db = Database::connect(database_url).await?;
-        let store = Self { db, blobs };
+        let (notifications, _) = broadcast::channel(1024);
+        let store = Self {
+            db,
+            blobs,
+            notifications,
+        };
         store.migrate().await?;
+        store.spawn_notification_listener();
         Ok(store)
     }
 
@@ -126,6 +166,65 @@ impl PostgresArchiveStore {
         self.db
             .execute(self.db.get_database_backend().build(&create_table))
             .await?;
+        let create_table = schema
+            .create_table_from_entity(fill_queue::Entity)
+            .if_not_exists()
+            .to_owned();
+        self.db
+            .execute(self.db.get_database_backend().build(&create_table))
+            .await?;
+        Ok(())
+    }
+
+    fn spawn_notification_listener(&self) {
+        let pool = self.db.get_postgres_connection_pool().clone();
+        let sender = self.notifications.clone();
+        tokio::spawn(async move {
+            loop {
+                match PgListener::connect_with(&pool).await {
+                    Ok(mut listener) => {
+                        listener.ignore_pool_close_event(true);
+                        if let Err(error) = listener.listen(FILL_NOTIFY_CHANNEL).await {
+                            warn!(
+                                "Postgres LISTEN setup failed channel={FILL_NOTIFY_CHANNEL} error={error:#}"
+                            );
+                            tokio::time::sleep(Duration::from_secs(1)).await;
+                            continue;
+                        }
+                        info!("listening for Postgres fill notifications");
+                        loop {
+                            match listener.recv().await {
+                                Ok(notification) => {
+                                    let _ = sender.send(notification.payload().to_string());
+                                }
+                                Err(error) => {
+                                    warn!("Postgres notification receive failed error={error:#}");
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    Err(error) => {
+                        warn!("Postgres LISTEN connection failed error={error:#}");
+                    }
+                }
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+        });
+    }
+
+    async fn notify_fill_changed(&self, key: &FillLeaseKey) -> Result<()> {
+        self.db
+            .execute(Statement::from_sql_and_values(
+                DbBackend::Postgres,
+                "SELECT pg_notify($1, $2)",
+                [
+                    FILL_NOTIFY_CHANNEL.to_string().into(),
+                    key.to_string().into(),
+                ],
+            ))
+            .await?;
+        let _ = self.notifications.send(key.to_string());
         Ok(())
     }
 }
@@ -158,11 +257,11 @@ impl ArchiveStore for PostgresArchiveStore {
         let body = self.blobs.get_body(&blob_key).await?;
         Ok(Some(StoredReplay::Capture(ReplayRecord {
             key: key.clone(),
-            status: row
-                .status
-                .ok_or_else(|| anyhow!("replay row missing status for {key}"))?
-                .try_into()?,
-            headers: serde_json::from_value(row.headers)?,
+            status: stored_status(
+                row.status
+                    .ok_or_else(|| anyhow!("replay row missing status for {key}"))?,
+            )?,
+            headers: headers_from_json(row.headers)?,
             blob_key: Some(blob_key),
             sha256: row
                 .sha256
@@ -183,17 +282,18 @@ impl ArchiveStore for PostgresArchiveStore {
                 record.blob_key = Some(blob.key.clone());
                 record.sha256 = blob.sha256.clone();
                 record.body_size = blob.size;
-                let classification = if record.status >= 400 {
-                    "archived_error"
-                } else {
-                    "served_capture"
-                };
+                let classification =
+                    if record.status.is_client_error() || record.status.is_server_error() {
+                        "archived_error"
+                    } else {
+                        "served_capture"
+                    };
                 let active = replay_record::ActiveModel {
                     capture_ts: Set(record.key.capture_ts),
                     modifier: Set(record.key.modifier),
                     canonical_original_url: Set(record.key.original_url),
-                    status: Set(Some(record.status as i32)),
-                    headers: Set(serde_json::to_value(&record.headers)?),
+                    status: Set(Some(i32::from(record.status.as_u16()))),
+                    headers: Set(headers_to_json(&record.headers)?),
                     blob_key: Set(Some(blob.key)),
                     sha256: Set(Some(blob.sha256)),
                     body_size: Set(Some(blob.size as i64)),
@@ -257,11 +357,11 @@ impl ArchiveStore for PostgresArchiveStore {
             .ok_or_else(|| anyhow!("metadata row missing body for {key}"))?;
         Ok(Some(StoredMetadata::Response(MetadataRecord {
             key,
-            status: row
-                .status
-                .ok_or_else(|| anyhow!("metadata row missing status"))?
-                .try_into()?,
-            headers: serde_json::from_value(row.headers)?,
+            status: stored_status(
+                row.status
+                    .ok_or_else(|| anyhow!("metadata row missing status"))?,
+            )?,
+            headers: headers_from_json(row.headers)?,
             sha256: row
                 .sha256
                 .ok_or_else(|| anyhow!("metadata row missing sha256"))?,
@@ -280,8 +380,8 @@ impl ArchiveStore for PostgresArchiveStore {
                 let active = metadata_record::ActiveModel {
                     endpoint: Set(record.key.endpoint.as_str().to_string()),
                     normalized_query: Set(record.key.normalized_query),
-                    status: Set(Some(record.status as i32)),
-                    headers: Set(serde_json::to_value(&record.headers)?),
+                    status: Set(Some(i32::from(record.status.as_u16()))),
+                    headers: Set(headers_to_json(&record.headers)?),
                     body: Set(Some(record.body.to_vec())),
                     sha256: Set(Some(record.sha256)),
                     body_size: Set(Some(record.body_size as i64)),
@@ -312,6 +412,153 @@ impl ArchiveStore for PostgresArchiveStore {
             }
         }
         Ok(())
+    }
+
+    async fn enqueue_fill(&self, request: FillRequest) -> Result<()> {
+        let key = request.lease_key();
+        let now_ms = epoch_ms();
+        let active = fill_queue::ActiveModel {
+            endpoint: Set(key.endpoint.as_str().to_string()),
+            fill_key: Set(key.key.clone()),
+            request: Set(serde_json::to_value(&request)?),
+            attempts: Set(0),
+            next_attempt_at_ms: Set(now_ms),
+            lease_owner: Set(None),
+            lease_expires_at_ms: Set(None),
+            last_status: Set(None),
+            last_error: Set(None),
+            updated_at_ms: Set(now_ms),
+        };
+        let mut conflict =
+            OnConflict::columns([fill_queue::Column::Endpoint, fill_queue::Column::FillKey]);
+        conflict.do_nothing();
+        fill_queue::Entity::insert(active)
+            .on_conflict(conflict.to_owned())
+            .do_nothing()
+            .exec(&self.db)
+            .await?;
+        self.notify_fill_changed(&key).await?;
+        Ok(())
+    }
+
+    async fn claim_next_fill(&self, owner: &str, ttl: Duration) -> Result<Option<ClaimedFill>> {
+        for _ in 0..5 {
+            let now_ms = epoch_ms();
+            let Some(row) = fill_queue::Entity::find()
+                .filter(fill_due_condition(now_ms))
+                .order_by_asc(fill_queue::Column::NextAttemptAtMs)
+                .one(&self.db)
+                .await?
+            else {
+                return Ok(None);
+            };
+            let updated = fill_queue::Entity::update_many()
+                .col_expr(
+                    fill_queue::Column::LeaseOwner,
+                    Expr::value(owner.to_string()),
+                )
+                .col_expr(
+                    fill_queue::Column::LeaseExpiresAtMs,
+                    Expr::value(now_ms + duration_ms(ttl)),
+                )
+                .col_expr(fill_queue::Column::UpdatedAtMs, Expr::value(now_ms))
+                .filter(fill_row_condition(&row.endpoint, &row.fill_key))
+                .filter(fill_due_condition(now_ms))
+                .exec(&self.db)
+                .await?;
+            if updated.rows_affected == 0 {
+                continue;
+            }
+            let request = serde_json::from_value(row.request)?;
+            return Ok(Some(ClaimedFill {
+                request,
+                owner: owner.to_string(),
+            }));
+        }
+        Ok(None)
+    }
+
+    async fn complete_fill(&self, job: &ClaimedFill) -> Result<()> {
+        let key = job.request.lease_key();
+        fill_queue::Entity::delete_many()
+            .filter(fill_row_condition(key.endpoint.as_str(), &key.key))
+            .filter(fill_queue::Column::LeaseOwner.eq(job.owner.clone()))
+            .exec(&self.db)
+            .await?;
+        self.notify_fill_changed(&key).await?;
+        Ok(())
+    }
+
+    async fn retry_fill(
+        &self,
+        job: &ClaimedFill,
+        retry_after: Option<Duration>,
+        status: Option<u16>,
+        error: Option<&str>,
+    ) -> Result<()> {
+        let key = job.request.lease_key();
+        let now_ms = epoch_ms();
+        let retry_after = retry_after
+            .unwrap_or_else(|| Duration::from_secs(job.request.endpoint().retry_after_seconds()));
+        fill_queue::Entity::update_many()
+            .col_expr(
+                fill_queue::Column::Attempts,
+                Expr::col(fill_queue::Column::Attempts).add(1),
+            )
+            .col_expr(
+                fill_queue::Column::NextAttemptAtMs,
+                Expr::value(now_ms + duration_ms(retry_after)),
+            )
+            .col_expr(
+                fill_queue::Column::LeaseOwner,
+                Expr::value(Option::<String>::None),
+            )
+            .col_expr(
+                fill_queue::Column::LeaseExpiresAtMs,
+                Expr::value(Option::<i64>::None),
+            )
+            .col_expr(
+                fill_queue::Column::LastStatus,
+                Expr::value(status.map(i32::from)),
+            )
+            .col_expr(
+                fill_queue::Column::LastError,
+                Expr::value(error.map(str::to_string)),
+            )
+            .col_expr(fill_queue::Column::UpdatedAtMs, Expr::value(now_ms))
+            .filter(fill_row_condition(key.endpoint.as_str(), &key.key))
+            .filter(fill_queue::Column::LeaseOwner.eq(job.owner.clone()))
+            .exec(&self.db)
+            .await?;
+        self.notify_fill_changed(&key).await?;
+        Ok(())
+    }
+
+    async fn wait_for_fill_queue_change(&self, wait: Duration) -> Result<bool> {
+        let mut receiver = self.notifications.subscribe();
+        let notified = async move {
+            matches!(
+                receiver.recv().await,
+                Ok(_) | Err(broadcast::error::RecvError::Lagged(_))
+            )
+        };
+        Ok(timeout(wait, notified).await.unwrap_or(false))
+    }
+
+    async fn wait_for_fill_change(&self, key: &FillLeaseKey, wait: Duration) -> Result<bool> {
+        let key = key.to_string();
+        let mut receiver = self.notifications.subscribe();
+        let notified = async move {
+            loop {
+                match receiver.recv().await {
+                    Ok(payload) if payload == key => return true,
+                    Ok(_) => {}
+                    Err(broadcast::error::RecvError::Lagged(_)) => return true,
+                    Err(broadcast::error::RecvError::Closed) => return false,
+                }
+            }
+        };
+        Ok(timeout(wait, notified).await.unwrap_or(false))
     }
 
     async fn try_acquire_fill_lease(
@@ -409,12 +656,24 @@ fn metadata_upsert_conflict() -> OnConflict {
     conflict.to_owned()
 }
 
+fn fill_due_condition(now_ms: i64) -> Condition {
+    Condition::all()
+        .add(fill_queue::Column::NextAttemptAtMs.lte(now_ms))
+        .add(
+            Condition::any()
+                .add(fill_queue::Column::LeaseOwner.is_null())
+                .add(fill_queue::Column::LeaseExpiresAtMs.lte(now_ms)),
+        )
+}
+
+fn fill_row_condition(endpoint: &str, fill_key: &str) -> Condition {
+    Condition::all()
+        .add(fill_queue::Column::Endpoint.eq(endpoint.to_string()))
+        .add(fill_queue::Column::FillKey.eq(fill_key.to_string()))
+}
+
 fn metadata_endpoint_from_str(endpoint: &str) -> Option<Endpoint> {
-    match endpoint {
-        "availability" => Some(Endpoint::Availability),
-        "cdx" => Some(Endpoint::Cdx),
-        _ => None,
-    }
+    Endpoint::from_str(endpoint).filter(|endpoint| *endpoint != Endpoint::Replay)
 }
 
 fn epoch_ms() -> i64 {
@@ -428,4 +687,37 @@ fn epoch_ms() -> i64 {
 
 fn duration_ms(duration: Duration) -> i64 {
     duration.as_millis().try_into().unwrap_or(i64::MAX)
+}
+
+fn stored_status(status: i32) -> Result<StatusCode> {
+    let status: u16 = status
+        .try_into()
+        .map_err(|_| anyhow!("stored status out of range: {status}"))?;
+    StatusCode::from_u16(status).map_err(|error| anyhow!("stored status invalid: {error}"))
+}
+
+fn headers_to_json(headers: &HeaderMap) -> Result<Value> {
+    Ok(Value::Array(
+        headers
+            .iter()
+            .filter_map(|(name, value)| {
+                value
+                    .to_str()
+                    .ok()
+                    .map(|value| Value::Array(vec![name.as_str().into(), value.into()]))
+            })
+            .collect(),
+    ))
+}
+
+fn headers_from_json(value: Value) -> Result<HeaderMap> {
+    let pairs = serde_json::from_value::<Vec<(String, String)>>(value)?;
+    let mut headers = HeaderMap::new();
+    for (name, value) in pairs {
+        headers.insert(
+            HeaderName::from_bytes(name.as_bytes())?,
+            HeaderValue::from_str(&value)?,
+        );
+    }
+    Ok(headers)
 }

--- a/loom/wayback_archive/store/postgres.rs
+++ b/loom/wayback_archive/store/postgres.rs
@@ -1,19 +1,21 @@
 use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use bytes::Bytes;
 use sea_orm::entity::prelude::*;
-use sea_orm::sea_query::OnConflict;
+use sea_orm::sea_query::{Expr, OnConflict};
 use sea_orm::{
     ColumnTrait, Condition, ConnectionTrait, Database, DatabaseConnection, DbBackend, EntityTrait,
-    QueryFilter, Schema, Set,
+    QueryFilter, Schema, Set, TryInsertResult,
 };
 use serde_json::Value;
 
 use crate::store::{ArchiveStore, BlobStore};
 use crate::types::{
-    Endpoint, MetadataKey, MetadataRecord, ReplayKey, ReplayRecord, StoredMetadata, StoredReplay,
+    Endpoint, FillLeaseKey, MetadataKey, MetadataRecord, ReplayKey, ReplayRecord, StoredMetadata,
+    StoredReplay,
 };
 
 mod replay_record {
@@ -68,6 +70,26 @@ mod metadata_record {
     impl ActiveModelBehavior for ActiveModel {}
 }
 
+mod fill_lease {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "wayback_fill_leases")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub endpoint: String,
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub lease_key: String,
+        pub owner: String,
+        pub expires_at_ms: i64,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
 pub struct PostgresArchiveStore {
     db: DatabaseConnection,
     blobs: Arc<dyn BlobStore>,
@@ -92,6 +114,13 @@ impl PostgresArchiveStore {
             .await?;
         let create_table = schema
             .create_table_from_entity(metadata_record::Entity)
+            .if_not_exists()
+            .to_owned();
+        self.db
+            .execute(self.db.get_database_backend().build(&create_table))
+            .await?;
+        let create_table = schema
+            .create_table_from_entity(fill_lease::Entity)
             .if_not_exists()
             .to_owned();
         self.db
@@ -284,6 +313,65 @@ impl ArchiveStore for PostgresArchiveStore {
         }
         Ok(())
     }
+
+    async fn try_acquire_fill_lease(
+        &self,
+        key: &FillLeaseKey,
+        owner: &str,
+        ttl: Duration,
+    ) -> Result<bool> {
+        let now_ms = epoch_ms();
+        let expires_at_ms = now_ms + duration_ms(ttl);
+        let endpoint = key.endpoint.as_str().to_string();
+        let lease_key = key.key.clone();
+
+        let updated = fill_lease::Entity::update_many()
+            .col_expr(fill_lease::Column::Owner, Expr::value(owner.to_string()))
+            .col_expr(fill_lease::Column::ExpiresAtMs, Expr::value(expires_at_ms))
+            .filter(
+                Condition::all()
+                    .add(fill_lease::Column::Endpoint.eq(endpoint.clone()))
+                    .add(fill_lease::Column::LeaseKey.eq(lease_key.clone()))
+                    .add(fill_lease::Column::ExpiresAtMs.lte(now_ms)),
+            )
+            .exec(&self.db)
+            .await?;
+        if updated.rows_affected > 0 {
+            return Ok(true);
+        }
+
+        let active = fill_lease::ActiveModel {
+            endpoint: Set(endpoint),
+            lease_key: Set(lease_key),
+            owner: Set(owner.to_string()),
+            expires_at_ms: Set(expires_at_ms),
+        };
+        let mut conflict =
+            OnConflict::columns([fill_lease::Column::Endpoint, fill_lease::Column::LeaseKey]);
+        conflict.do_nothing();
+        match fill_lease::Entity::insert(active)
+            .on_conflict(conflict.to_owned())
+            .do_nothing()
+            .exec(&self.db)
+            .await?
+        {
+            TryInsertResult::Inserted(_) => Ok(true),
+            TryInsertResult::Conflicted | TryInsertResult::Empty => Ok(false),
+        }
+    }
+
+    async fn release_fill_lease(&self, key: &FillLeaseKey, owner: &str) -> Result<()> {
+        fill_lease::Entity::delete_many()
+            .filter(
+                Condition::all()
+                    .add(fill_lease::Column::Endpoint.eq(key.endpoint.as_str()))
+                    .add(fill_lease::Column::LeaseKey.eq(key.key.clone()))
+                    .add(fill_lease::Column::Owner.eq(owner.to_string())),
+            )
+            .exec(&self.db)
+            .await?;
+        Ok(())
+    }
 }
 
 fn replay_upsert_conflict() -> OnConflict {
@@ -327,4 +415,17 @@ fn metadata_endpoint_from_str(endpoint: &str) -> Option<Endpoint> {
         "cdx" => Some(Endpoint::Cdx),
         _ => None,
     }
+}
+
+fn epoch_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock must be after unix epoch")
+        .as_millis()
+        .try_into()
+        .unwrap_or(i64::MAX)
+}
+
+fn duration_ms(duration: Duration) -> i64 {
+    duration.as_millis().try_into().unwrap_or(i64::MAX)
 }

--- a/loom/wayback_archive/store/s3.rs
+++ b/loom/wayback_archive/store/s3.rs
@@ -36,18 +36,6 @@ impl S3BlobStore {
             store: Arc::new(store),
         })
     }
-
-    pub fn from_env() -> Result<Self> {
-        Self::new(
-            required_env("WAYBACK_ARCHIVE_S3_ENDPOINT")?,
-            required_env("WAYBACK_ARCHIVE_S3_BUCKET")?,
-            required_env("WAYBACK_ARCHIVE_S3_ACCESS_KEY_ID")?,
-            required_env("WAYBACK_ARCHIVE_S3_SECRET_ACCESS_KEY")?,
-            std::env::var("WAYBACK_ARCHIVE_S3_REGION").unwrap_or_else(|_| "us-east-1".to_string()),
-            std::env::var("WAYBACK_ARCHIVE_S3_ALLOW_HTTP")
-                .map_or(true, |value| value == "1" || value == "true"),
-        )
-    }
 }
 
 #[async_trait]
@@ -78,8 +66,4 @@ impl BlobStore for S3BlobStore {
             .bytes()
             .await?)
     }
-}
-
-fn required_env(name: &str) -> Result<String> {
-    std::env::var(name).with_context(|| format!("{name} must be set"))
 }

--- a/loom/wayback_archive/types.rs
+++ b/loom/wayback_archive/types.rs
@@ -64,6 +64,34 @@ impl Display for ReplayKey {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct FillLeaseKey {
+    pub endpoint: Endpoint,
+    pub key: String,
+}
+
+impl FillLeaseKey {
+    pub(crate) fn replay(key: &ReplayKey) -> Self {
+        Self {
+            endpoint: Endpoint::Replay,
+            key: key.to_string(),
+        }
+    }
+
+    pub(crate) fn metadata(key: &MetadataKey) -> Self {
+        Self {
+            endpoint: key.endpoint,
+            key: key.normalized_query.clone(),
+        }
+    }
+}
+
+impl Display for FillLeaseKey {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}", self.endpoint.as_str(), self.key)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StoredReplay {
     Capture(ReplayRecord),

--- a/loom/wayback_archive/types.rs
+++ b/loom/wayback_archive/types.rs
@@ -1,10 +1,14 @@
 use std::fmt::{Display, Formatter};
+use std::time::Duration;
 
 use bytes::Bytes;
+use http::{HeaderMap, StatusCode};
+use serde::{Deserialize, Serialize};
 
 use crate::RETRY_AFTER_SECONDS;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Endpoint {
     Availability,
     Cdx,
@@ -29,6 +33,15 @@ impl Endpoint {
         }
     }
 
+    pub(crate) fn from_str(value: &str) -> Option<Self> {
+        match value {
+            "availability" => Some(Endpoint::Availability),
+            "cdx" => Some(Endpoint::Cdx),
+            "replay" => Some(Endpoint::Replay),
+            _ => None,
+        }
+    }
+
     pub(crate) fn metadata_path(self) -> Option<&'static str> {
         match self {
             Endpoint::Availability => Some("/wayback/available"),
@@ -38,7 +51,7 @@ impl Endpoint {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ReplayKey {
     pub capture_ts: String,
     pub modifier: String,
@@ -64,7 +77,7 @@ impl Display for ReplayKey {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct FillLeaseKey {
     pub endpoint: Endpoint,
     pub key: String,
@@ -92,6 +105,38 @@ impl Display for FillLeaseKey {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum FillRequest {
+    Metadata(MetadataRequest),
+    Replay(ReplayKey),
+}
+
+impl FillRequest {
+    pub(crate) fn endpoint(&self) -> Endpoint {
+        match self {
+            FillRequest::Metadata(request) => request.key.endpoint,
+            FillRequest::Replay(_) => Endpoint::Replay,
+        }
+    }
+
+    pub(crate) fn lease_key(&self) -> FillLeaseKey {
+        match self {
+            FillRequest::Metadata(request) => FillLeaseKey::metadata(&request.key),
+            FillRequest::Replay(key) => FillLeaseKey::replay(key),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FillAttemptResult {
+    Completed,
+    RetryAfter {
+        retry_after: Option<Duration>,
+        status: Option<u16>,
+    },
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StoredReplay {
     Capture(ReplayRecord),
@@ -104,15 +149,15 @@ pub enum StoredReplay {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReplayRecord {
     pub key: ReplayKey,
-    pub status: u16,
-    pub headers: Vec<(String, String)>,
+    pub status: StatusCode,
+    pub headers: HeaderMap,
     pub body: Bytes,
     pub blob_key: Option<String>,
     pub sha256: String,
     pub body_size: usize,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct MetadataKey {
     pub endpoint: Endpoint,
     pub normalized_query: String,
@@ -124,7 +169,7 @@ impl Display for MetadataKey {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MetadataRequest {
     pub key: MetadataKey,
     pub raw_query: String,
@@ -142,8 +187,8 @@ pub enum StoredMetadata {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MetadataRecord {
     pub key: MetadataKey,
-    pub status: u16,
-    pub headers: Vec<(String, String)>,
+    pub status: StatusCode,
+    pub headers: HeaderMap,
     pub body: Bytes,
     pub sha256: String,
     pub body_size: usize,


### PR DESCRIPTION
## Summary

- split the Wayback archive service into input and filler binaries/pods: input serves cache hits and enqueues misses, filler workers claim queued fills and perform IA egress
- add Postgres-backed fill queue storage with LISTEN/NOTIFY wakeups for queued work and completed fills, while keeping the in-memory store implementation for tests
- move runtime settings into typed serde-loaded YAML ConfigMaps, leaving only DB/S3/auth secrets as env-backed values, and keep cached statuses/headers typed as `StatusCode`/`HeaderMap`
- update Kubernetes manifests for input/filler Services, ServiceMonitors, mounted config files, and the current plan notes

## Validation

- `bbr test //loom/wayback_archive:wayback_archive_test`
- `bbr build //loom/wayback_archive:wayback_archive //loom/wayback_archive:wayback_archive_filler //loom/wayback_archive:image`
- `kubectl kustomize cluster/k8s/wayback-cache`
- `nix develop -c pre-commit run --files ...` on all changed files