### PR TITLE
[codex] Keep wayback cache deployment selector stable

### DIFF
--- a/cluster/k8s/wayback-cache/deployment.yaml
+++ b/cluster/k8s/wayback-cache/deployment.yaml
@@ -13,7 +13,6 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: wayback-cache
-      app.kubernetes.io/component: input
   template:
     metadata:
       labels:


### PR DESCRIPTION
## Summary

- keep the existing `wayback-cache` Deployment selector as `app.kubernetes.io/name=wayback-cache`
- leave `app.kubernetes.io/component=input` on the pod template so Services and ServiceMonitors can still select input pods after rollout

## Why

Flux reconciliation of #2164 failed because Kubernetes rejects changes to `Deployment.spec.selector` as immutable.

## Validation

- `kubectl kustomize cluster/k8s/wayback-cache`
- `nix develop -c pre-commit run --files cluster/k8s/wayback-cache/deployment.yaml`