### PR TITLE
[codex] Separate wayback filler selectors

### DIFF
--- a/cluster/k8s/wayback-cache/filler-deployment.yaml
+++ b/cluster/k8s/wayback-cache/filler-deployment.yaml
@@ -1,10 +1,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: wayback-cache-filler
+  name: wayback-cache-filler-workers
   namespace: wayback-cache
   labels:
-    app.kubernetes.io/name: wayback-cache
+    app.kubernetes.io/name: wayback-cache-filler
     app.kubernetes.io/component: filler
   annotations:
     reloader.stakater.com/auto: "true"
@@ -12,12 +12,12 @@ spec:
   replicas: 5
   selector:
     matchLabels:
-      app.kubernetes.io/name: wayback-cache
+      app.kubernetes.io/name: wayback-cache-filler
       app.kubernetes.io/component: filler
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: wayback-cache
+        app.kubernetes.io/name: wayback-cache-filler
         app.kubernetes.io/component: filler
     spec:
       nodeSelector:
@@ -28,14 +28,14 @@ spec:
           whenUnsatisfiable: DoNotSchedule
           labelSelector:
             matchLabels:
-              app.kubernetes.io/name: wayback-cache
+              app.kubernetes.io/name: wayback-cache-filler
               app.kubernetes.io/component: filler
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
                 matchLabels:
-                  app.kubernetes.io/name: wayback-cache
+                  app.kubernetes.io/name: wayback-cache-filler
                   app.kubernetes.io/component: filler
               topologyKey: kubernetes.io/hostname
       securityContext:

--- a/cluster/k8s/wayback-cache/filler-service.yaml
+++ b/cluster/k8s/wayback-cache/filler-service.yaml
@@ -4,11 +4,11 @@ metadata:
   name: wayback-cache-filler
   namespace: wayback-cache
   labels:
-    app.kubernetes.io/name: wayback-cache
+    app.kubernetes.io/name: wayback-cache-filler
     app.kubernetes.io/component: filler
 spec:
   selector:
-    app.kubernetes.io/name: wayback-cache
+    app.kubernetes.io/name: wayback-cache-filler
     app.kubernetes.io/component: filler
   ports:
     - port: 8080

--- a/cluster/k8s/wayback-cache/filler-servicemonitor.yaml
+++ b/cluster/k8s/wayback-cache/filler-servicemonitor.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: wayback-cache
+      app.kubernetes.io/name: wayback-cache-filler
       app.kubernetes.io/component: filler
   endpoints:
     - port: http


### PR DESCRIPTION
## Summary

- move filler worker pods to `app.kubernetes.io/name=wayback-cache-filler`
- rename the filler worker Deployment to `wayback-cache-filler-workers` so Flux prunes the old overlapping selector resource instead of mutating an immutable selector
- keep the filler Service and ServiceMonitor names stable while updating their selectors

## Why

The input Deployment must keep its historical selector `app.kubernetes.io/name=wayback-cache`. Filler pods sharing that label make Deployment selector tooling match both input and filler pods.

## Validation

- `kubectl kustomize cluster/k8s/wayback-cache`
- `nix develop -c pre-commit run --files cluster/k8s/wayback-cache/filler-deployment.yaml cluster/k8s/wayback-cache/filler-service.yaml cluster/k8s/wayback-cache/filler-servicemonitor.yaml`