### PR TITLE
[codex] Improve debundle structural selectors

### DIFF
--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -47,6 +47,12 @@ rust_library(
     ],
 )
 
+rust_test(
+    name = "source_match_test",
+    crate = ":source_match",
+    edition = "2024",
+)
+
 rust_library(
     name = "anonymous_resolution",
     srcs = ["anonymous_resolution.rs"],

--- a/devinfra/js/debundle/SELECTOR_BUGS.md
+++ b/devinfra/js/debundle/SELECTOR_BUGS.md
@@ -1,0 +1,306 @@
+# Selector Bugs And Gaps
+
+This note tracks selector issues found while porting a downstream debundle spec.
+Examples are intentionally generic and anonymized.
+
+## Stable Identifiers Are Only Local To One Match
+
+`source_match` with `identifiers: alpha_all` makes readable names usable for
+bindings that are local to the selected AST. It does not make those names a
+global aliasing layer across independently matched selectors.
+
+Observed failure mode:
+
+```js
+function readContext(node, limit = contextLimit) {
+  return renderNode(node).slice(0, limit);
+}
+
+async function produceResult(node, services) {
+  const context = readContext(node, contextLimit);
+  if (context.length < minContextChars) return [];
+  return services.run(context);
+}
+```
+
+If `readContext`, `contextLimit`, and `minContextChars` are captured by other
+selectors, a separate selector for `produceResult` that mentions those readable
+names can fail to match. In the split selector, those names are free references,
+not local binders. The matcher has no stable cross-selector environment saying
+that `readContext` means the already selected minified binding.
+
+Workarounds:
+
+- Put related declarations in one binding group when they are actually adjacent.
+- Replace cross-selector references with `EXPR_*` holes.
+- Fall back to raw binding selectors for large functions when grouping is not
+  possible.
+
+Desired behavior:
+
+- Either support a selector environment where previously exported readable names
+  can be referenced from later `source_match` selectors, or produce an error that
+  explains that free readable identifiers are not resolvable.
+
+## Multi-Declaration Source Matches Are Hard To Use
+
+Binding groups are useful for capturing multiple names from one stable selector,
+but source matches spanning more than one top-level declaration are fragile when
+the source has unrelated declarations between the anchors.
+
+Observed failure mode:
+
+```js
+const configLimit = 100,
+  minInputChars = 10,
+  resultLimit = 15;
+
+function helperA(input) {
+  return input.slice(0, configLimit);
+}
+
+function helperB(input) {
+  return helperA(input);
+}
+```
+
+A single binding group that tries to capture the constants and both functions
+fails if unrelated declarations sit between the constant run and function run.
+The error is reported as "target_binding did not match any top-level
+declaration", but it does not identify which part of the multi-declaration
+selector failed.
+
+Desired behavior:
+
+- Support non-contiguous selector groups, or document that binding-group
+  `source_match` only matches contiguous top-level items.
+- Improve diagnostics by showing the first unmatched selector item and whether
+  the candidate was rejected by shape prefiltering or by binding comparison.
+
+## Adjacent Binding Groups Can Miss Large Alpha-Renamed Functions
+
+A binding group over adjacent top-level declarations can still miss when a
+readable `alpha_all` selector targets a large function with many local
+renamings and helper calls.
+
+Observed pattern:
+
+```js
+const textDecoder = new TextDecoder();
+function decodeRecord(buffer) {
+  let offset = 0,
+    name,
+    children;
+  const fieldCount = readMapLength(buffer, offset);
+  offset += readPrefixLength(buffer[offset]);
+  for (let fieldIndex = 0; fieldIndex < fieldCount; fieldIndex++) {
+    const keyLength = readStringLength(buffer, offset);
+    offset += readPrefixLength(buffer[offset]);
+    const key = decodeString(buffer, offset, keyLength);
+    if (((offset += keyLength), key === "props")) {
+      const propCount = readMapLength(buffer, offset);
+      offset += readPrefixLength(buffer[offset]);
+      for (let propIndex = 0; propIndex < propCount; propIndex++) {
+        const propKeyLength = readStringLength(buffer, offset);
+        offset += readPrefixLength(buffer[offset]);
+        const propKey = decodeString(buffer, offset, propKeyLength);
+        if (((offset += propKeyLength), propKey === "name")) {
+          const nameLength = readStringLength(buffer, offset);
+          ((offset += readPrefixLength(buffer[offset])),
+            (name = decodeString(buffer, offset, nameLength)),
+            (offset += nameLength));
+        } else offset = skipValue(buffer, offset);
+      }
+    } else if (key === "children") {
+      const childCount = readArrayLength(buffer, offset);
+      ((offset += readPrefixLength(buffer[offset])), (children = new Array(childCount)));
+      for (let childIndex = 0; childIndex < childCount; childIndex++) {
+        const childLength = readStringLength(buffer, offset);
+        ((offset += readPrefixLength(buffer[offset])),
+          (children[childIndex] = decodeString(buffer, offset, childLength)),
+          (offset += childLength));
+      }
+    } else offset = skipValue(buffer, offset);
+    if (name !== void 0 && children !== void 0) break;
+  }
+  return [name, children];
+}
+```
+
+The declarations were adjacent and the literals/shape were distinctive, but
+the binding group reported a generic no-match for the function target. A raw
+binding fallback was needed for the large function, while a smaller neighboring
+helper remained expressible as a structural selector.
+
+Desired behavior:
+
+- Make adjacent binding groups with function declarations as reliable as
+  multi-declarator groups under `alpha_all`.
+- Add diagnostics for the first incompatible local binding or expression shape
+  when a large alpha-renamed function selector fails.
+
+## Declarator-List Holes Need Better Diagnostics
+
+`DECLARATORS_*` holes are useful for matching runs of variable declarators, but
+failures can be opaque when the hole placement is too broad or insufficiently
+anchored.
+
+Observed pattern:
+
+```js
+const DECLARATORS_BEFORE = null,
+  wantedA = 1,
+  wantedB = 2,
+  DECLARATORS_AFTER = null;
+```
+
+This is attractive when only two declarators in a long `const` run matter, but a
+miss looks the same as any other `source_match` miss. It is not obvious whether
+the list hole was unsupported by the selected Ducktape binary, was too greedy,
+or failed because the anchored declarators did not match.
+
+Desired behavior:
+
+- Make list-hole support explicit in diagnostics when a selector uses
+  `DECLARATORS_*`.
+- Report list-hole binding spans during verbose/debug selector matching.
+- Consider a safer syntax for "capture these declarators from a larger run" that
+  does not require fake `= null` declarators.
+
+## Alpha-Renamed Multi-Declarator Groups Can Miss
+
+A binding group over one `const` declaration matched when written with emitted
+local names, but missed when the same selector was written with readable names
+under `identifiers: alpha_all`.
+
+Observed pattern:
+
+```js
+const applyOverrides = (patch) => {
+    config = { ...config, ...patch };
+  },
+  readConfig = (key) => config[key],
+  isLocalMode = () => (runtime.LOCAL ? true : readConfig("ENV") === "local"),
+  isReplayMode = () => readConfig("REPLAY") === "true",
+  snapshotConfig = () => config;
+```
+
+The same shape using the emitted binding names matched and exported all five
+bindings. This suggests either alpha matching is not consistently applied across
+some multi-declarator arrow-function runs, or diagnostics hide a more specific
+sub-expression mismatch.
+
+Desired behavior:
+
+- Make alpha-renamed multi-declarator groups work consistently with individual
+  source matches.
+- When alpha matching rejects a candidate, report the first incompatible
+  identifier or property binding instead of a generic no-match.
+
+## Async Destructured Function Selectors Can Miss
+
+An `async function` with an object-pattern parameter failed to match even after
+the selector used explicit property bindings rather than shorthand.
+
+Observed pattern:
+
+```js
+async function runWithState({ itemPath: itemPath, items: items, promise: promise, state: state }) {
+  const states = [getState(toKey(itemPath))];
+  for (const item of items || []) states.push(getState(item.id));
+  action(() => {
+    states.forEach((entry) => {
+      entry.state = state;
+    });
+  });
+  try {
+    await promise;
+  } finally {
+    action(() => {
+      states.forEach((entry) => {
+        entry.state = void 0;
+      });
+    });
+  }
+}
+```
+
+The target function was identifiable by raw binding name, but the structured
+selector missed. This may be the same object-pattern limitation as shorthand
+destructuring misses, or a separate async-function matching issue.
+
+Desired behavior:
+
+- Treat shorthand and explicit object-pattern bindings equivalently where they
+  bind the same locals.
+- Make async function declarations with destructured parameters match under
+  `source_match`.
+- Include parameter-pattern mismatch details in no-match diagnostics.
+
+## Statement-List Holes Were Missing
+
+Status: addressed by `STMT_LIST_*` holes for block/function statement lists.
+
+Before this was added, `STMT_*` holes matched one statement and did not
+represent zero or more statements.
+
+Observed desired selector:
+
+```js
+async function runTask(input) {
+  STMT_LIST_SETUP;
+  try {
+    STMT_LIST_BODY;
+  } catch (error) {
+    STMT_HANDLE_ERROR;
+  }
+}
+```
+
+Today this has to be rewritten as several single-statement holes, and it fails
+when the number of setup/body statements changes.
+
+Implemented behavior:
+
+- `STMT_LIST_*` holes match zero or more statements in block/function statement
+  lists.
+- Top-level module-item list holes remain a separate possible extension.
+
+## Pinned Binary Versus Local Selector Syntax
+
+Downstream builds can accidentally run with an older pinned debundler even when
+the module is overridden to local Ducktape sources. New selector syntax then
+fails as a generic no-match rather than as an unsupported-hole error.
+
+Desired behavior:
+
+- Add a spec/schema feature version or selector capability check.
+- When a selector contains an unknown hole shape, fail with "unsupported selector
+  hole" rather than attempting to match it as ordinary JavaScript.
+
+## Duplicate Claims Should Use Declaration Identity
+
+Observed failure mode:
+
+```js
+const config = (() => {
+  const n = 15;
+  return { limit: n };
+})();
+
+function n(input) {
+  return input.remove();
+}
+```
+
+Two selectors can legitimately target different declarations that minify to the
+same short spelling. A constant selector and a function selector should not
+collide if they resolve to different AST bindings in different scopes.
+
+Desired behavior:
+
+- Track binding claims by declaration identity, not just emitted/minified
+  spelling.
+- Include declaration kind and source location in duplicate-claim diagnostics.
+  The current duplicate message is hard to evaluate when minified names are
+  reused.

--- a/devinfra/js/debundle/lowering/materialize/plan_builder.rs
+++ b/devinfra/js/debundle/lowering/materialize/plan_builder.rs
@@ -34,6 +34,91 @@ pub(super) struct ExplicitRequestContext<'a> {
     pub(super) runtime_import_facts: &'a RuntimeImportFacts,
 }
 
+fn resolve_request_source_matches(
+    request: &mut LogicalRequest,
+    runtime_module: &Module,
+) -> Result<()> {
+    let mut grouped_by_selector: BTreeMap<spec::AnonymousStatementSelector, Vec<usize>> =
+        BTreeMap::new();
+    for (idx, member) in request.members.iter().enumerate() {
+        let Some(selector) = &member.source_match else {
+            continue;
+        };
+        if selector.target_binding.is_none() {
+            continue;
+        }
+        let mut group_selector = selector.clone();
+        group_selector.target_binding = None;
+        grouped_by_selector
+            .entry(group_selector)
+            .or_default()
+            .push(idx);
+    }
+
+    let mut resolved_member_indices = BTreeSet::new();
+    for (selector, member_indices) in grouped_by_selector {
+        if member_indices.len() < 2 {
+            continue;
+        }
+        let mut exports_by_target = BTreeMap::new();
+        let mut has_duplicate_target = false;
+        for idx in &member_indices {
+            let member = &request.members[*idx];
+            let target_binding = member
+                .source_match
+                .as_ref()
+                .and_then(|selector| selector.target_binding.clone())
+                .expect("grouped selectors always have target_binding");
+            if exports_by_target
+                .insert(target_binding, member.export_name.clone())
+                .is_some()
+            {
+                has_duplicate_target = true;
+            }
+        }
+        if has_duplicate_target {
+            continue;
+        }
+        let resolved = source_match::resolve_member_binding_group(
+            runtime_module,
+            &request.id,
+            &selector,
+            &exports_by_target,
+        )?;
+        for idx in member_indices {
+            let member = &mut request.members[idx];
+            let target_binding = member
+                .source_match
+                .as_ref()
+                .and_then(|selector| selector.target_binding.as_ref())
+                .expect("grouped selectors always have target_binding");
+            let resolved = resolved.get(target_binding).with_context(|| {
+                format!("binding group resolver did not return target_binding `{target_binding}`")
+            })?;
+            apply_resolved_member_binding(member, resolved.clone());
+            resolved_member_indices.insert(idx);
+        }
+    }
+
+    let mut source_match_cache = BTreeMap::new();
+    for (idx, member) in request.members.iter_mut().enumerate() {
+        if resolved_member_indices.contains(&idx) {
+            continue;
+        }
+        member.resolve_source_match(runtime_module, &request.id, &mut source_match_cache)?;
+    }
+    Ok(())
+}
+
+fn apply_resolved_member_binding(
+    member: &mut MemberRequest,
+    resolved: source_match::ResolvedMemberBinding,
+) {
+    member.binding = resolved.binding_name;
+    member.is_import_specifier = matches!(resolved.kind, Some(BindingSourceKind::ImportSpecifier));
+    member.source_match = None;
+}
+
 /// Builds a `ChunkPlan` from spec requests and chunk AST analysis.
 ///
 /// Owns the five mutable maps (`binding_assignment`,
@@ -113,9 +198,7 @@ impl ChunkPlanBuilder {
         imported_binding_resolver: &mut ArtifactSourceImportResolutionCache<'_>,
         imported_from_by_src: &mut BTreeMap<String, String>,
     ) -> Result<()> {
-        for member in &mut request.members {
-            member.resolve_source_match(ctx.runtime_module, &request.id)?;
-        }
+        resolve_request_source_matches(request, ctx.runtime_module)?;
         reject_duplicate_member_bindings("logical_module", &request.id, &request.members)?;
         let mut bindings = HashMap::<String, String>::new();
         let anonymous_statement_claims =

--- a/devinfra/js/debundle/lowering/plans.rs
+++ b/devinfra/js/debundle/lowering/plans.rs
@@ -74,16 +74,24 @@ impl MemberRequest {
         &mut self,
         runtime_module: &Module,
         request_id: &str,
+        cache: &mut BTreeMap<spec::AnonymousStatementSelector, source_match::ResolvedMemberBinding>,
     ) -> Result<()> {
         let Some(selector) = self.source_match.take() else {
             return Ok(());
         };
-        let resolved = source_match::resolve_member_binding(
-            runtime_module,
-            request_id,
-            &self.export_name,
-            &selector,
-        )?;
+        let resolved = match cache.get(&selector) {
+            Some(resolved) => resolved.clone(),
+            None => {
+                let resolved = source_match::resolve_member_binding(
+                    runtime_module,
+                    request_id,
+                    &self.export_name,
+                    &selector,
+                )?;
+                cache.insert(selector, resolved.clone());
+                resolved
+            }
+        };
         self.binding = resolved.binding_name;
         self.is_import_specifier =
             matches!(resolved.kind, Some(BindingSourceKind::ImportSpecifier));

--- a/devinfra/js/debundle/source_match.rs
+++ b/devinfra/js/debundle/source_match.rs
@@ -282,6 +282,137 @@ pub fn resolve_member_binding(
     }
 }
 
+pub fn resolve_member_binding_group(
+    runtime_module: &Module,
+    request_id: &str,
+    selector: &AnonymousStatementSelector,
+    exports_by_target: &BTreeMap<String, String>,
+) -> Result<BTreeMap<String, ResolvedMemberBinding>> {
+    if selector.target_binding.is_some() {
+        bail!(
+            "logical_module {request_id}: binding group resolver received a selector with \
+             target_binding already set"
+        );
+    }
+    let parsed = js_ast::parse_js_module_ast(
+        &format!("<binding group source_match in {request_id}>"),
+        &selector.match_source,
+    )
+    .with_context(|| {
+        format!(
+            "logical_module {request_id}: binding_groups[].source_match did not parse as JS:\n{}",
+            selector.match_source
+        )
+    })?;
+    if parsed.body.is_empty() {
+        bail!(
+            "logical_module {request_id}: binding_groups[].source_match parsed to zero \
+             statements; selector source must contain at least one top-level statement:\n{match_source}",
+            match_source = selector.match_source,
+        );
+    }
+    if parsed.body.len() == 1 && selector_single_var_declarator(&parsed.body[0]).is_some() {
+        let mut resolved = BTreeMap::new();
+        for (target_binding, export_name) in exports_by_target {
+            let mut selector = selector.clone();
+            selector.target_binding = Some(target_binding.clone());
+            resolved.insert(
+                target_binding.clone(),
+                resolve_member_binding(runtime_module, request_id, export_name, &selector)?,
+            );
+        }
+        return Ok(resolved);
+    }
+
+    let mut target_locations = BTreeMap::new();
+    for target_binding in exports_by_target.keys() {
+        target_locations.insert(
+            target_binding.clone(),
+            selector_binding_location(&parsed.body, request_id, selector, target_binding)?,
+        );
+    }
+
+    let target_hint = exports_by_target
+        .iter()
+        .map(|(target_binding, export_name)| {
+            format!("target_binding `{target_binding}` for export `{export_name}`")
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    let ranges = find_matching_body_ranges(runtime_module, &parsed.body, selector);
+    let body_idx = match ranges.as_slice() {
+        [single] => *single,
+        [] => bail!(
+            "logical_module {request_id}: binding_groups[].source_match for targets \
+             `{target_hint}` did not match any top-level declaration range in the chunk. \
+             Selector:\n{match_source}",
+            match_source = selector.match_source,
+        ),
+        multiple => bail!(
+            "logical_module {request_id}: binding_groups[].source_match for targets \
+             `{target_hint}` is ambiguous — matched {} top-level declaration ranges at body \
+             indices {:?}. Refine the selector. Source:\n{match_source}",
+            multiple.len(),
+            multiple,
+            match_source = selector.match_source,
+        ),
+    };
+
+    let mut resolved = BTreeMap::new();
+    for (target_binding, (target_item_idx, target_binding_idx)) in target_locations {
+        let matched_body_idx = body_idx + target_item_idx;
+        let item = runtime_module.body.get(matched_body_idx).with_context(|| {
+            format!("body index {matched_body_idx} disappeared while resolving source_match")
+        })?;
+        let declared = declared_bindings(item);
+        let Some(binding) = declared.get(target_binding_idx) else {
+            bail!(
+                "logical_module {request_id}: binding_groups[].source_match target_binding \
+                 `{target_binding}` matched top-level statement at body index {matched_body_idx}, but \
+                 the matched statement declares only {} bindings. Source:\n{match_source}",
+                declared.len(),
+                match_source = selector.match_source,
+            );
+        };
+        resolved.insert(target_binding, binding.clone());
+    }
+    Ok(resolved)
+}
+
+fn selector_binding_location(
+    needles: &[ModuleItem],
+    request_id: &str,
+    selector: &AnonymousStatementSelector,
+    target_binding: &str,
+) -> Result<(usize, usize)> {
+    let selector_binding_locations: Vec<(usize, usize)> = needles
+        .iter()
+        .enumerate()
+        .flat_map(|(item_idx, item)| {
+            declared_bindings(item).into_iter().enumerate().filter_map(
+                move |(binding_idx, binding)| {
+                    (binding.binding_name == target_binding).then_some((item_idx, binding_idx))
+                },
+            )
+        })
+        .collect();
+    match selector_binding_locations.as_slice() {
+        [single] => Ok(*single),
+        [] => bail!(
+            "logical_module {request_id}: members[].selector.source_match target_binding \
+             `{target_binding}` is not declared by the selector source:\n{match_source}",
+            match_source = selector.match_source,
+        ),
+        multiple => bail!(
+            "logical_module {request_id}: members[].selector.source_match target_binding \
+             `{target_binding}` is ambiguous within the selector source at statement/binding \
+             indices {:?}. Refine the selector source:\n{match_source}",
+            multiple,
+            match_source = selector.match_source,
+        ),
+    }
+}
+
 fn find_member_binding_matches(
     runtime_module: &Module,
     request_id: &str,
@@ -379,32 +510,8 @@ fn find_matching_target_bindings(
     selector: &AnonymousStatementSelector,
     target_binding: &str,
 ) -> Result<Vec<MemberBindingMatch>> {
-    let selector_binding_locations: Vec<(usize, usize)> = needles
-        .iter()
-        .enumerate()
-        .flat_map(|(item_idx, item)| {
-            declared_bindings(item).into_iter().enumerate().filter_map(
-                move |(binding_idx, binding)| {
-                    (binding.binding_name == target_binding).then_some((item_idx, binding_idx))
-                },
-            )
-        })
-        .collect();
-    let (target_item_idx, target_binding_idx) = match selector_binding_locations.as_slice() {
-        [single] => *single,
-        [] => bail!(
-            "logical_module {request_id}: members[].selector.source_match target_binding \
-             `{target_binding}` is not declared by the selector source:\n{match_source}",
-            match_source = selector.match_source,
-        ),
-        multiple => bail!(
-            "logical_module {request_id}: members[].selector.source_match target_binding \
-             `{target_binding}` is ambiguous within the selector source at statement/binding \
-             indices {:?}. Refine the selector source:\n{match_source}",
-            multiple,
-            match_source = selector.match_source,
-        ),
-    };
+    let (target_item_idx, target_binding_idx) =
+        selector_binding_location(needles, request_id, selector, target_binding)?;
     let mut matches = Vec::new();
     for body_idx in find_matching_body_ranges(runtime_module, needles, selector) {
         let matched_body_idx = body_idx + target_item_idx;


### PR DESCRIPTION
## Summary

Rebased onto current `devel` and narrowed the PR to the remaining structural-selector improvements that are not already merged:

- resolve repeated member-form selectors from `binding_groups` as one grouped source match when they share the same selector and target different bindings
- cache identical member `source_match` resolutions within a logical module request
- expose `//devinfra/js/debundle:source_match_test` as a direct Bazel test target
- add anonymized selector bug/gap notes in `devinfra/js/debundle/SELECTOR_BUGS.md`

Several earlier pieces from this branch, including syntactic holes, `binding_groups[].adopt_names`, and class/statement-list selector work, are already present on `devel` after the rebase.

## Validation

- `nix develop -c bazelisk --output_base=/tmp/bazel-ducktape-pr2167-ci test //devinfra/js/debundle/e2e:anonymous_statement_test --config=nolint`
- `nix develop -c bazelisk --output_base=/tmp/bazel-ducktape-pr2167-ci test //devinfra/js/debundle:source_match_test //devinfra/js/debundle/e2e:syntactic_holes_test //devinfra/js/debundle/e2e:anonymous_statement_test --config=nolint`
- `nix develop -c pre-commit run --files devinfra/js/debundle/source_match.rs`
- `nix develop -c pre-commit run --files devinfra/js/debundle/BUILD.bazel devinfra/js/debundle/SELECTOR_BUGS.md devinfra/js/debundle/lowering/materialize/plan_builder.rs devinfra/js/debundle/lowering/plans.rs devinfra/js/debundle/source_match.rs`