### PR TITLE
[codex] Document wayback eval fetch counters

### DIFF
--- a/loom/gym/TODO.md
+++ b/loom/gym/TODO.md
@@ -1,15 +1,16 @@
 # loom/gym TODO
 
-- **Archive-backed eval reliability — deploy and evaluate the limiter telemetry
-  fix.** After the limiter/telemetry PR lands, wait for image publish and Flux
-  reconcile, manually reprobe the known bad CDX query, burst-test cold CDX/replay
-  misses, and confirm `in_flight` returns to zero while
+- **Archive-backed eval reliability — tune CDX after the completed limiter
+  rerun.** The 33-task `glm-4.5` archive-backed rerun with
+  `--message-limit 1000` and `--compaction-threshold-tokens 115000` completed
+  with 33/33 scored answers; the run notes and filler fetch counters are in
+  <../wayback_archive/PLAN.md>. Remaining work: manually reprobe the known bad
+  CDX query, burst-test cold CDX/replay misses, and confirm `in_flight` returns
+  to zero while
   `wayback_archive_acquisition_failures_total{endpoint,reason,status}` separates
-  queue timeout from upstream retry/backoff. Then rerun the 33-task `glm-4.5`
-  panel with `--message-limit 1000` and `--compaction-threshold-tokens 115000`.
-  Archive-service design/status is in <../wayback_archive/PLAN.md>, the
-  eval-run procedure is in <k8s/README.md>, and IA API notes are in
-  <../docs/archive_org_apis.md>.
+  queue timeout from upstream retry/backoff. Archive-service design/status is in
+  <../wayback_archive/PLAN.md>, the eval-run procedure is in <k8s/README.md>,
+  and IA API notes are in <../docs/archive_org_apis.md>.
 
 - **Rename `baseline_llm.py`.** Once the bare one-shot LLM scaffold is gone, the
   module is purely the shared answer-schema + parse library (`question_schema`,

--- a/loom/wayback_archive/PLAN.md
+++ b/loom/wayback_archive/PLAN.md
@@ -4,9 +4,9 @@ Last trimmed: 2026-06-12.
 
 Status: v0 is live. The old nginx/PVC `wayback-cache` backend was replaced in
 place by the Rust archive service: CNPG metadata, SeaweedFS S3 replay bodies,
-Prometheus metrics, and a public bearer-auth `:8090` listener. The current PR
-splits that service into input pods and filler pods connected by a Postgres fill
-queue with `LISTEN/NOTIFY` wakeups.
+Prometheus metrics, and a public bearer-auth `:8090` listener. The service is
+split into input pods and filler pods connected by a Postgres fill queue with
+`LISTEN/NOTIFY` wakeups.
 
 Companions:
 
@@ -120,9 +120,54 @@ CDX limit and in-flight were both 1, so fresh CDX misses could spend the whole
 queue budget waiting for the single slot.
 
 The run predates the current eval harness defaults: `--message-limit 1000` and
-Inspect summary compaction via `--compaction-threshold-tokens 115000`.
-Rerunning with that config is still needed, but cache warmth alone is unlikely
-to fix the core issue because agents choose new URLs dynamically.
+Inspect summary compaction via `--compaction-threshold-tokens 115000`. The
+rerun below shows those harness changes eliminated no-answer samples, but cache
+warmth alone is unlikely to fix the core issue because agents choose new URLs
+dynamically.
+
+## Second Eval Finding
+
+Rerun after the input/filler split, proxy `503 + Retry-After` handling, limiter
+RAII, and eval harness `message_limit=1000` / compaction defaults:
+
+- date: 2026-06-12;
+- job: `claude-sandbox/loom-gym-eval`;
+- Langfuse session: `loom-gym-20260612T105627Z`;
+- target: `http://wayback-cache.wayback-cache.svc.cluster.local:8080`;
+- model/config: `glm-4.5`, `--task-filter manifold-`, `--max-samples 4`,
+  `--message-limit 1000`, `--compaction-threshold-tokens 115000`;
+- result: 33 scored answers out of 33, `0` no-answer, `0` `nan`;
+- mean proper loss: 1.164;
+- wall time: 2:39:58;
+- model usage: 31,759,673 tokens total
+  (`I=1,318,383`, `CR=29,916,020`, `O=525,270`, `CW=0`);
+- driver upstream-error summary from sample metadata: `500x 503`, `20x 403`.
+
+The run still saw many archive failures, but the failures no longer translated
+into no-answer samples. Agents were able to continue and submit every answer.
+
+Post-rollout filler logs, covering the tail of the run after the separate filler
+Deployment was reconciled:
+
+| filler pod | claimed |    CDX | Availability | Replay | completed | retryable | upstream fetch timeout | limiter queue timeout | upstream transient |
+| ---------- | ------: | -----: | -----------: | -----: | --------: | --------: | ---------------------: | --------------------: | -----------------: |
+| `25zzs`    |      74 |     30 |           24 |     20 |        66 |         8 |                      3 |                     3 |                  2 |
+| `2wl6n`    |      33 |     16 |           11 |      6 |        26 |         7 |                      2 |                     2 |                  3 |
+| `99w2r`    |      25 |     12 |            6 |      7 |        17 |         8 |                      3 |                     3 |                  2 |
+| `ccb2p`    |      29 |     18 |            8 |      3 |        23 |         6 |                      0 |                     3 |                  3 |
+| `n8cdl`    |      18 |     11 |            2 |      5 |        10 |         8 |                      3 |                     4 |                  1 |
+| **total**  | **179** | **87** |       **51** | **41** |   **142** |    **37** |                 **11** |                **15** |             **11** |
+
+Interpretation:
+
+- Postgres leasing spread work across all five filler pods; this was not a
+  single-hot-worker problem.
+- CDX remained the dominant fill class and the dominant retry source.
+- Queue timeouts and upstream timeouts both mattered. The service needs both
+  endpoint limiter tuning and better visibility into input-side wait time before
+  raising concurrency broadly.
+- Availability and replay were materially healthier than CDX in this window,
+  so endpoint-specific concurrency/backoff remains the right shape.
 
 ## Active Next Steps
 
@@ -136,15 +181,10 @@ to fix the core issue because agents choose new URLs dynamically.
      separates limiter queue timeout from upstream retry/backoff.
    - Confirm input-side fill waits are visible in
      `wayback_archive_input_fill_wait_duration_seconds`.
-2. Rerun the 33-task `glm-4.5` panel with:
-   - `--message-limit 1000`
-   - `--compaction-threshold-tokens 115000`
-3. Record archive-service endpoint counters in the final eval notes, not just
-   driver-level aggregate `503` counts.
-4. Tune filler concurrency if cache-side `503` remains dominant. CDX staying at
+2. Tune filler concurrency if cache-side `503` remains dominant. CDX staying at
    low concurrency protects IA but serializes cold misses enough to hurt the
    agent loop.
-5. Keep `wayback_proxy` retry/wait behavior covered: `503 + Retry-After` should
+3. Keep `wayback_proxy` retry/wait behavior covered: `503 + Retry-After` should
    be an enforced wait while the proxy has budget, and an agent-visible failure
    only after waiting would exceed that budget.
 


### PR DESCRIPTION
## Summary

- Record the completed archive-backed loom/gym eval rerun in `loom/wayback_archive/PLAN.md`.
- Add the filler fetch-counter breakdown for CDX, Availability, and Replay fills.
- Update `loom/gym/TODO.md` so completed rerun work is no longer listed as pending.

## Validation

- `git diff --check origin/devel...HEAD`
- `nix develop -c pre-commit run --files loom/wayback_archive/PLAN.md loom/gym/TODO.md`