### PR TITLE
[codex] Preserve comments on debundle binding groups

### DIFF
--- a/devinfra/js/debundle/cli/edit_gate.rs
+++ b/devinfra/js/debundle/cli/edit_gate.rs
@@ -411,10 +411,10 @@ pub fn gate_post_edit_partition(
                     let mut selectors = module.claims.member_selectors.clone();
                     let request_id = module.path.to_string_lossy();
                     for group in &module.claims.binding_groups {
-                        for (_, selector) in
+                        for expanded in
                             source_match::binding_group_member_selectors(&request_id, group)?
                         {
-                            selectors.insert(selector);
+                            selectors.insert(expanded.selector);
                         }
                     }
                     Ok(selectors)

--- a/devinfra/js/debundle/docs/guide.md
+++ b/devinfra/js/debundle/docs/guide.md
@@ -307,6 +307,8 @@ binding_groups:
       localPart: SYSTEM_EMAIL_LOCAL_PART
       domain: SYSTEM_EMAIL_DOMAIN
       address: systemEmailAddress
+    comments:
+      address: Primary address shown to operators.
 ```
 
 When the selector source already uses the desired public names, use
@@ -325,7 +327,8 @@ binding_groups:
 
 `adopt_names: [nameOne, nameTwo]` adopts only the listed selector-local
 bindings. An explicit `exports` entry on the same group overrides the adopted
-public name for that selector-local binding.
+public name for that selector-local binding. `comments` is keyed by
+selector-local binding name and emits like `members[].comment` after expansion.
 
 For anonymous side-effect statements, prefer `source_match` when
 minified helper or class names drift, but keep selectors unique. If two

--- a/devinfra/js/debundle/e2e/support.rs
+++ b/devinfra/js/debundle/e2e/support.rs
@@ -44,6 +44,7 @@ pub struct BindingGroup {
     source_match: FixtureSourceMatch,
     adopt_names: Option<FixtureAdoptNames>,
     exports: BTreeMap<&'static str, &'static str>,
+    comments: BTreeMap<&'static str, &'static str>,
 }
 
 impl BindingGroup {
@@ -63,6 +64,7 @@ impl BindingGroup {
             },
             adopt_names: None,
             exports: exports.iter().copied().collect(),
+            comments: BTreeMap::new(),
         }
     }
 
@@ -76,6 +78,7 @@ impl BindingGroup {
             },
             adopt_names: Some(FixtureAdoptNames::All(true)),
             exports: BTreeMap::new(),
+            comments: BTreeMap::new(),
         }
     }
 
@@ -92,6 +95,7 @@ impl BindingGroup {
             },
             adopt_names: Some(FixtureAdoptNames::Names(names.to_vec())),
             exports: BTreeMap::new(),
+            comments: BTreeMap::new(),
         }
     }
 
@@ -108,7 +112,13 @@ impl BindingGroup {
             },
             adopt_names: Some(FixtureAdoptNames::All(true)),
             exports: exports.iter().copied().collect(),
+            comments: BTreeMap::new(),
         }
+    }
+
+    pub fn with_comments(mut self, comments: &[(&'static str, &'static str)]) -> Self {
+        self.comments = comments.iter().copied().collect();
+        self
     }
 }
 
@@ -216,6 +226,8 @@ struct FixtureBindingGroup {
     adopt_names: Option<FixtureAdoptNames>,
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     exports: BTreeMap<&'static str, &'static str>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    comments: BTreeMap<&'static str, &'static str>,
 }
 
 #[derive(Clone, Serialize)]
@@ -357,6 +369,7 @@ fn fixture_binding_groups(binding_groups: &[BindingGroup]) -> Vec<FixtureBinding
             source_match: group.source_match.clone(),
             adopt_names: group.adopt_names.clone(),
             exports: group.exports.clone(),
+            comments: group.comments.clone(),
         })
         .collect()
 }

--- a/devinfra/js/debundle/e2e/syntactic_holes_test.rs
+++ b/devinfra/js/debundle/e2e/syntactic_holes_test.rs
@@ -144,6 +144,41 @@ export { first, second };
 }
 
 #[test]
+fn binding_group_comments_emit_for_each_target_binding() {
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"var first = 1 + 2, second = Number.parseInt("4", 10);
+console.log(first + second);
+export { first, second };
+"#,
+        vec![logical_module_with_binding_groups(
+            "pair",
+            &[],
+            &[BindingGroup::source_alpha(
+                r#"var left = EXPR_LEFT, right = EXPR_RIGHT;"#,
+                &[("left", "first_value"), ("right", "second_value")],
+            )
+            .with_comments(&[
+                ("left", "First selected value."),
+                ("right", "Second selected value."),
+            ])],
+        )],
+    ));
+
+    assert_entry_output(&fixture, "7\n");
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/modules/pair.js",
+        &[
+            "// First selected value.",
+            "var first_value = 1 + 2",
+            "// Second selected value.",
+            r#"var second_value = Number.parseInt("4", 10)"#,
+        ],
+        &[],
+    );
+}
+
+#[test]
 fn anonymous_source_match_stmt_prefix_hole_matches_arbitrary_nested_statement() {
     let fixture = run_fixture(FixtureOpts::new(
         r#"if (true) {

--- a/devinfra/js/debundle/lowering/plans.rs
+++ b/devinfra/js/debundle/lowering/plans.rs
@@ -302,19 +302,17 @@ pub(super) fn build_members(
         .collect::<Result<Vec<_>>>()?;
 
     for group in binding_groups {
-        for (export_name, selector) in
-            source_match::binding_group_member_selectors(request_id, group)?
-        {
+        for expanded in source_match::binding_group_member_selectors(request_id, group)? {
             requests.push(MemberRequest {
                 binding: String::new(),
-                export_name,
-                source_match: Some(selector),
+                export_name: expanded.export_name,
+                source_match: Some(expanded.selector),
                 is_import_specifier: false,
                 purity: MemberPurity::Default,
                 effect: MemberEffect::Default,
                 pure_members: Vec::new(),
                 no_sync_callback_members: Vec::new(),
-                comment: None,
+                comment: expanded.comment,
             });
         }
     }

--- a/devinfra/js/debundle/source_match.rs
+++ b/devinfra/js/debundle/source_match.rs
@@ -76,10 +76,16 @@ pub fn source_match_declared_binding_names(
 /// member assembly (`lowering::build_members`) and the CLI edit gate
 /// consume, so the two always agree on which owners a binding group
 /// claims.
+pub struct BindingGroupMemberSelector {
+    pub export_name: String,
+    pub selector: AnonymousStatementSelector,
+    pub comment: Option<String>,
+}
+
 pub fn binding_group_member_selectors(
     request_id: &str,
     group: &BindingGroup,
-) -> Result<Vec<(String, AnonymousStatementSelector)>> {
+) -> Result<Vec<BindingGroupMemberSelector>> {
     if group.source_match.target_binding.is_some() {
         bail!(
             "logical_module {request_id}: binding_groups[].source_match must not include \
@@ -87,12 +93,30 @@ pub fn binding_group_member_selectors(
         );
     }
     let exports = effective_binding_group_exports(group, request_id)?;
+    let unknown_comments = group
+        .comments
+        .keys()
+        .filter(|name| !exports.contains_key(*name))
+        .cloned()
+        .collect::<Vec<_>>();
+    if !unknown_comments.is_empty() {
+        bail!(
+            "logical_module {request_id}: binding_groups[].comments names bindings that \
+             are not exported by the group: {}",
+            unknown_comments.join(", ")
+        );
+    }
     Ok(exports
         .into_iter()
         .map(|(target_binding, export_name)| {
             let mut selector = group.source_match.selector();
-            selector.target_binding = Some(target_binding);
-            (export_name, selector)
+            selector.target_binding = Some(target_binding.clone());
+            let comment = group.comments.get(&target_binding).cloned();
+            BindingGroupMemberSelector {
+                export_name,
+                selector,
+                comment,
+            }
         })
         .collect())
 }

--- a/devinfra/js/debundle/spec.rs
+++ b/devinfra/js/debundle/spec.rs
@@ -750,6 +750,12 @@ pub struct BindingGroup {
     pub adopt_names: BindingGroupAdoptNames,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub exports: BTreeMap<String, String>,
+    /// Optional per-binding comments keyed by selector-local binding name.
+    /// These are equivalent to `members[].comment` after the binding group is
+    /// expanded, but stay attached to the structural binding selected by the
+    /// group even when `exports` renames it.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub comments: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq, Default)]


### PR DESCRIPTION
## Summary
- add `binding_groups[].comments` keyed by selector-local binding name
- carry binding-group comments through expansion into generated member comments
- document the form and cover it with a generic e2e fixture

## Validation
- `nix develop -c bazelisk --output_base=/tmp/bazel-ducktape-bg-comments-rebased test //devinfra/js/debundle/e2e:syntactic_holes_test //devinfra/js/debundle:source_match_test //devinfra/js/debundle:spec_modules_test --config=nolint`
- `nix develop -c pre-commit run --files devinfra/js/debundle/spec.rs devinfra/js/debundle/source_match.rs devinfra/js/debundle/lowering/plans.rs devinfra/js/debundle/cli/edit_gate.rs devinfra/js/debundle/e2e/support.rs devinfra/js/debundle/e2e/syntactic_holes_test.rs devinfra/js/debundle/docs/guide.md`