### PR TITLE
[codex] Support contextual anonymous debundle selectors

### DIFF
--- a/devinfra/js/debundle/anonymous_resolution.rs
+++ b/devinfra/js/debundle/anonymous_resolution.rs
@@ -297,35 +297,39 @@ fn resolve_anonymous_statement_claims_in_globals(
 
     for (module_idx, claims) in claims_by_module.iter().enumerate() {
         for selector in claims.selectors {
-            let mut matches = Vec::<(String, OwnerId)>::new();
+            let mut match_groups = Vec::<Vec<(String, OwnerId)>>::new();
             for (source_path, parsed) in &parsed_by_source {
-                let body_indices = source_match::find_anonymous_statement_body_indices(
+                let body_index_groups = source_match::find_anonymous_statement_body_index_groups(
                     &parsed.module,
                     &claims.module_path.to_string_lossy(),
                     selector,
                 )?;
-                for body_idx in body_indices {
-                    let statement_ordinal =
-                        js_ast::statement_ordinal_for_body_index(&parsed.module.body, body_idx);
-                    let Some(&owner) = anonymous_owner_by_source_ordinal
-                        .get(&(source_path.clone(), statement_ordinal))
-                    else {
-                        bail!(
-                            "module {} anonymous statement selector matched source {} body index \
-                             {} / statement ordinal {}, but owner_graph.json has no anonymous \
-                             owner at that source position",
-                            claims.module_path.display(),
-                            source_path,
-                            body_idx,
-                            statement_ordinal,
-                        );
-                    };
-                    matches.push((source_path.clone(), owner));
+                for body_indices in body_index_groups {
+                    let mut owners = Vec::with_capacity(body_indices.len());
+                    for body_idx in body_indices {
+                        let statement_ordinal =
+                            js_ast::statement_ordinal_for_body_index(&parsed.module.body, body_idx);
+                        let Some(&owner) = anonymous_owner_by_source_ordinal
+                            .get(&(source_path.clone(), statement_ordinal))
+                        else {
+                            bail!(
+                                "module {} anonymous statement selector matched source {} body \
+                                 index {} / statement ordinal {}, but owner_graph.json has no \
+                                 anonymous owner at that source position",
+                                claims.module_path.display(),
+                                source_path,
+                                body_idx,
+                                statement_ordinal,
+                            );
+                        };
+                        owners.push((source_path.clone(), owner));
+                    }
+                    match_groups.push(owners);
                 }
             }
-            match matches.as_slice() {
-                [(_, owner)] => {
-                    out[module_idx].insert(*owner);
+            match match_groups.as_slice() {
+                [owners] => {
+                    out[module_idx].extend(owners.iter().map(|(_, owner)| *owner));
                 }
                 [] => bail!(
                     "module {} anonymous statement selector did not match any source statement:\n{}",
@@ -333,8 +337,8 @@ fn resolve_anonymous_statement_claims_in_globals(
                     selector.match_source,
                 ),
                 multiple => bail!(
-                    "module {} anonymous statement selector matched {} source statements; refine \
-                     the selector:\n{}",
+                    "module {} anonymous statement selector matched {} source statement groups; \
+                     refine the selector:\n{}",
                     claims.module_path.display(),
                     multiple.len(),
                     selector.match_source,

--- a/devinfra/js/debundle/docs/guide.md
+++ b/devinfra/js/debundle/docs/guide.md
@@ -249,9 +249,10 @@ Default to this ladder when writing or repairing selectors:
 1. Use `selector.source_match` / `binding_groups` for the declaration,
    statement, class, or small surrounding AST shape that is semantically
    stable.
-2. Add `EXPR`, `STMT`, `STMT_LIST`, or `CLASS_REST` holes for volatile
-   minified subtrees, helper bodies, statement runs, or class members that
-   are not part of the durable identity of the target.
+2. Add `EXPR`, `STMT`, `ARGS`, `STMT_LIST`, `CLASS_REST`, or `DECLARATORS`
+   holes for volatile minified subtrees, noisy arguments, helper bodies,
+   statement runs, class members, or sibling declarators that are not part of
+   the durable identity of the target.
 3. Keep exact literals, property names, object keys, operators, and ordering
    when they carry the stable signal.
 4. Use `selector.binding.name` only for already-stable semantic names or as
@@ -380,6 +381,34 @@ Only the indexed statement is claimed; the surrounding context is used for
 matching and must be claimed separately if it should move with the anonymous
 statement.
 
+Use `target_statements` when one structural selector should claim several
+anonymous statements. It accepts either an explicit zero-based index list, or
+`all` to claim every non-hole top-level statement in the selector:
+
+```yaml
+anonymous_statements:
+  - source_match:
+      identifiers: alpha_all
+      target_statements: [1, 2]
+      match: |
+        const contextValue = "stable";
+        console.log("first side effect");
+        console.log("second side effect");
+
+  - source_match:
+      identifiers: alpha_all
+      target_statements: all
+      match: |
+        console.log("before");
+        STMT_LIST;
+        console.log("after");
+```
+
+At top level in an anonymous-statement selector, `STMT_LIST;` absorbs a run of
+module-body statements that should be used only as skipped context. A
+`target_statement` or `target_statements` index must point at a pinned
+statement, not at the `STMT_LIST` hole.
+
 Do not solve ambiguity with opaque hashes. A selector should be readable
 enough for a reviewer to audit and edit. When an anonymous statement needs
 nearby declarations to be unique, prefer `target_statement` over spreading
@@ -409,11 +438,11 @@ anonymous_statements:
         }
 ```
 
-Each hole keyword has two forms. The **bare keyword** is an anonymous
+Single-node holes have two forms. The **bare keyword** is an anonymous
 wildcard: every occurrence matches independently, so there's no need to mint a
 unique name per throwaway placeholder. The **named form** `KEYWORD_name` binds
-for cross-occurrence equality — the same name must match the same
-candidate subtree/statement everywhere it appears. So `EXPR` is the identifier
+for cross-occurrence equality — the same name must match the same candidate
+subtree/statement everywhere it appears. So `EXPR` is the identifier
 expression that matches one arbitrary expression subtree, and `EXPR_left`
 matches one too but forces every `EXPR_left` to be the same subtree; `STMT` and
 `STMT_setup` are the single-statement equivalents. For example, `foo(EXPR)`
@@ -423,16 +452,27 @@ matches a call whose two arguments are identical. These are still structural
 selectors: surrounding syntax is exact after the identifier policy is applied,
 and ambiguous matches are rejected rather than resolved by source order.
 
-Two variable-length **list holes** absorb a contiguous run rather than a
-single node — ideal for pinning a class by a stable skeleton without copying
-its whole minified body:
+Variable-length **list holes** absorb a contiguous run rather than a single
+node. Their optional suffixes are labels for readability; they do not bind the
+absorbed sequence for cross-occurrence equality.
 
-- A bare `STMT_LIST;` statement (or named `STMT_LIST_name;`) in a block body
-  matches any run of statements (including none) at that position — e.g. a
-  method or function body you do not want to spell out.
-- A bare `CLASS_REST;` class field (no initializer) matches a run of class
+- `ARGS` (or `ARGS_name`) in a call or `new` argument list matches any run of
+  arguments, including none. Use it to pin stable arguments without spelling
+  volatile generated siblings:
+
+  ```js
+  register("stable", ARGS_BEFORE, selectedValue, ARGS_AFTER);
+  ```
+
+- `STMT_LIST;` (or `STMT_LIST_name;`) in a block body matches any run of
+  statements, including none. At top level it is supported in
+  `anonymous_statements[].source_match` selectors that use `target_statement`
+  or `target_statements`.
+- `CLASS_REST;` as a class field (no initializer) matches a run of class
   members — "this class by these members, ignore the rest". `CLASS_REST` is an
   exact token (not a prefix).
+- `DECLARATORS` (or `DECLARATORS_name = null`) inside one variable declaration
+  matches a run of declarators.
 
 ```yaml
 members:

--- a/devinfra/js/debundle/docs/guide.md
+++ b/devinfra/js/debundle/docs/guide.md
@@ -361,11 +361,29 @@ reject the spec as ambiguous rather than picking by source order.
 Refine the selector with an exact statement, a stable literal/property
 difference, or a deliberately small surrounding context.
 
+When the anonymous statement needs surrounding declarations for a unique
+structural match, include that context and set `target_statement` to the
+zero-based index of the statement to claim:
+
+```yaml
+anonymous_statements:
+  - source_match:
+      identifiers: alpha_all
+      target_statement: 1
+      match: |
+        const selectedLeft = "left",
+          selectedRight = "right";
+        console.log(`${selectedLeft}:${selectedRight}`);
+```
+
+Only the indexed statement is claimed; the surrounding context is used for
+matching and must be claimed separately if it should move with the anonymous
+statement.
+
 Do not solve ambiguity with opaque hashes. A selector should be readable
-enough for a reviewer to audit and edit. When two selectors only differ
-by a large copied helper body plus one neighboring line, treat that as a
-tooling gap: prefer a future contextual selector (`before` / `after` /
-`near`) over spreading duplicated boilerplate.
+enough for a reviewer to audit and edit. When an anonymous statement needs
+nearby declarations to be unique, prefer `target_statement` over spreading
+duplicated boilerplate.
 
 Use syntactic holes as the normal way to keep structural selectors portable:
 pin the stable skeleton, and leave unstable minified details as holes instead

--- a/devinfra/js/debundle/e2e/anonymous_statement_test.rs
+++ b/devinfra/js/debundle/e2e/anonymous_statement_test.rs
@@ -540,6 +540,45 @@ export { RuntimeSubject, Existing };
 }
 
 #[test]
+fn alpha_anonymous_statement_target_statement_uses_context_but_claims_only_target() {
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"const runtimeLeft = "left",
+  runtimeRight = "right";
+console.log(`${runtimeLeft}:${runtimeRight}`);
+const Existing = "existing";
+console.log(Existing);
+export { runtimeLeft, runtimeRight, Existing };
+"#,
+        vec![logical_module_with_anon_alpha_target_statement(
+            "selected_pair",
+            &[Member::new("runtimeLeft"), Member::new("runtimeRight")],
+            r#"const selectedLeft = "left",
+  selectedRight = "right";
+console.log(`${selectedLeft}:${selectedRight}`);"#,
+            1,
+        )],
+    ));
+
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/modules/selected_pair.js",
+        &[
+            "const runtimeLeft",
+            "const runtimeRight",
+            "console.log(`${runtimeLeft}:${runtimeRight}`)",
+        ],
+        &["const Existing"],
+    );
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/modules/residual/unhandled.js",
+        &["const Existing"],
+        &["runtimeLeft}:${runtimeRight"],
+    );
+    assert_entry_output(&fixture, "left:right\nexisting\n");
+}
+
+#[test]
 fn alpha_anonymous_statement_selector_keeps_member_properties_significant() {
     let fixture = run_fixture(FixtureOpts::new(
         r#"const selectedValue = "selected";

--- a/devinfra/js/debundle/e2e/anonymous_statement_test.rs
+++ b/devinfra/js/debundle/e2e/anonymous_statement_test.rs
@@ -617,6 +617,38 @@ console.log("second selected");"#,
 }
 
 #[test]
+fn alpha_anonymous_statement_target_statements_match_assignment_targets_from_context() {
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"let runtimeRecord, runtimeReplay;
+true && (runtimeReplay = "replay");
+false || (runtimeRecord = "record");
+console.log(`${runtimeReplay}:${runtimeRecord}`);
+export { runtimeRecord, runtimeReplay };
+"#,
+        vec![logical_module_with_anon_alpha_target_statements(
+            "bridge_slots",
+            &[Member::new("runtimeRecord"), Member::new("runtimeReplay")],
+            r#"let selectedRecord, selectedReplay;
+true && (selectedReplay = "replay");
+false || (selectedRecord = "record");"#,
+            &[1, 2],
+        )],
+    ));
+
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/modules/bridge_slots.js",
+        &[
+            "let runtimeRecord",
+            "runtimeReplay = \"replay\"",
+            "runtimeRecord = \"record\"",
+        ],
+        &["selectedRecord", "selectedReplay"],
+    );
+    assert_entry_output(&fixture, "replay:record\n");
+}
+
+#[test]
 fn alpha_anonymous_statement_target_statements_all_supports_top_level_stmt_list_hole() {
     let fixture = run_fixture(FixtureOpts::new(
         r#"console.log("before selected");

--- a/devinfra/js/debundle/e2e/anonymous_statement_test.rs
+++ b/devinfra/js/debundle/e2e/anonymous_statement_test.rs
@@ -579,6 +579,81 @@ console.log(`${selectedLeft}:${selectedRight}`);"#,
 }
 
 #[test]
+fn alpha_anonymous_statement_target_statements_claims_multiple_targets_from_one_selector() {
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"const runtimeContext = "context";
+console.log("first selected");
+console.log("second selected");
+const Existing = "existing";
+console.log(Existing);
+export { runtimeContext, Existing };
+"#,
+        vec![logical_module_with_anon_alpha_target_statements(
+            "selected_logs",
+            &[],
+            r#"const selectorContext = "context";
+console.log("first selected");
+console.log("second selected");"#,
+            &[1, 2],
+        )],
+    ));
+
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/modules/selected_logs.js",
+        &[
+            r#"console.log("first selected")"#,
+            r#"console.log("second selected")"#,
+        ],
+        &["runtimeContext", "Existing"],
+    );
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/modules/residual/unhandled.js",
+        &["const runtimeContext", "const Existing"],
+        &["first selected", "second selected"],
+    );
+    assert_entry_output(&fixture, "first selected\nsecond selected\nexisting\n");
+}
+
+#[test]
+fn alpha_anonymous_statement_target_statements_all_supports_top_level_stmt_list_hole() {
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"console.log("before selected");
+const skippedContext = "skip";
+console.log("after selected");
+const Existing = "existing";
+console.log(Existing);
+export { skippedContext, Existing };
+"#,
+        vec![logical_module_with_anon_alpha_target_statements_all(
+            "selected_logs",
+            &[],
+            r#"console.log("before selected");
+STMT_LIST;
+console.log("after selected");"#,
+        )],
+    ));
+
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/modules/selected_logs.js",
+        &[
+            r#"console.log("before selected")"#,
+            r#"console.log("after selected")"#,
+        ],
+        &["skippedContext", "Existing", "STMT_LIST"],
+    );
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/modules/residual/unhandled.js",
+        &["const skippedContext", "const Existing"],
+        &["before selected", "after selected"],
+    );
+    assert_entry_output(&fixture, "before selected\nafter selected\nexisting\n");
+}
+
+#[test]
 fn alpha_anonymous_statement_selector_keeps_member_properties_significant() {
     let fixture = run_fixture(FixtureOpts::new(
         r#"const selectedValue = "selected";

--- a/devinfra/js/debundle/e2e/support.rs
+++ b/devinfra/js/debundle/e2e/support.rs
@@ -59,6 +59,7 @@ impl BindingGroup {
             source_match: FixtureSourceMatch {
                 identifiers: "alpha_all",
                 target_binding: None,
+                target_statement: None,
                 wildcard_string_literals: Vec::new(),
                 match_source: match_source.into(),
             },
@@ -73,6 +74,7 @@ impl BindingGroup {
             source_match: FixtureSourceMatch {
                 identifiers: "alpha_all",
                 target_binding: None,
+                target_statement: None,
                 wildcard_string_literals: Vec::new(),
                 match_source: match_source.into(),
             },
@@ -90,6 +92,7 @@ impl BindingGroup {
             source_match: FixtureSourceMatch {
                 identifiers: "alpha_all",
                 target_binding: None,
+                target_statement: None,
                 wildcard_string_literals: Vec::new(),
                 match_source: match_source.into(),
             },
@@ -107,6 +110,7 @@ impl BindingGroup {
             source_match: FixtureSourceMatch {
                 identifiers: "alpha_all",
                 target_binding: None,
+                target_statement: None,
                 wildcard_string_literals: Vec::new(),
                 match_source: match_source.into(),
             },
@@ -152,6 +156,7 @@ impl Member {
             source_match: Some(FixtureSourceMatch {
                 identifiers: "alpha_all",
                 target_binding: None,
+                target_statement: None,
                 wildcard_string_literals: Vec::new(),
                 match_source: match_source.into(),
             }),
@@ -172,6 +177,7 @@ impl Member {
             source_match: Some(FixtureSourceMatch {
                 identifiers: "alpha_all",
                 target_binding: Some(target_binding.into()),
+                target_statement: None,
                 wildcard_string_literals: Vec::new(),
                 match_source: match_source.into(),
             }),
@@ -253,6 +259,8 @@ struct FixtureSourceMatch {
     identifiers: &'static str,
     #[serde(skip_serializing_if = "Option::is_none")]
     target_binding: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    target_statement: Option<usize>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     wildcard_string_literals: Vec<String>,
     #[serde(rename = "match")]
@@ -274,6 +282,7 @@ impl FixtureAnonymousStatement {
             source_match: Some(FixtureSourceMatch {
                 identifiers: "alpha_all",
                 target_binding: None,
+                target_statement: None,
                 wildcard_string_literals: Vec::new(),
                 match_source: match_source.into(),
             }),
@@ -290,10 +299,28 @@ impl FixtureAnonymousStatement {
             source_match: Some(FixtureSourceMatch {
                 identifiers: "alpha_all",
                 target_binding: None,
+                target_statement: None,
                 wildcard_string_literals: wildcard_string_literals
                     .iter()
                     .map(|literal| (*literal).to_string())
                     .collect(),
+                match_source: match_source.into(),
+            }),
+            comment: None,
+        }
+    }
+
+    fn alpha_all_target_statement(
+        match_source: impl Into<String>,
+        target_statement: usize,
+    ) -> Self {
+        Self {
+            match_source: None,
+            source_match: Some(FixtureSourceMatch {
+                identifiers: "alpha_all",
+                target_binding: None,
+                target_statement: Some(target_statement),
+                wildcard_string_literals: Vec::new(),
                 match_source: match_source.into(),
             }),
             comment: None,
@@ -467,6 +494,27 @@ pub fn logical_module_with_anon_alpha(
             members: fixture_members(members),
             binding_groups: Vec::new(),
             anonymous_statements: vec![FixtureAnonymousStatement::alpha_all(anon_match)],
+        })
+        .expect("logical module fixture must serialize"),
+    )
+}
+
+pub fn logical_module_with_anon_alpha_target_statement(
+    path: &str,
+    members: &[Member],
+    anon_match: &str,
+    target_statement: usize,
+) -> LogicalModuleEntry {
+    (
+        path.to_string(),
+        serde_json::to_value(LogicalModuleBody {
+            comment: None,
+            members: fixture_members(members),
+            binding_groups: Vec::new(),
+            anonymous_statements: vec![FixtureAnonymousStatement::alpha_all_target_statement(
+                anon_match,
+                target_statement,
+            )],
         })
         .expect("logical module fixture must serialize"),
     )

--- a/devinfra/js/debundle/e2e/support.rs
+++ b/devinfra/js/debundle/e2e/support.rs
@@ -60,6 +60,7 @@ impl BindingGroup {
                 identifiers: "alpha_all",
                 target_binding: None,
                 target_statement: None,
+                target_statements: None,
                 wildcard_string_literals: Vec::new(),
                 match_source: match_source.into(),
             },
@@ -75,6 +76,7 @@ impl BindingGroup {
                 identifiers: "alpha_all",
                 target_binding: None,
                 target_statement: None,
+                target_statements: None,
                 wildcard_string_literals: Vec::new(),
                 match_source: match_source.into(),
             },
@@ -93,6 +95,7 @@ impl BindingGroup {
                 identifiers: "alpha_all",
                 target_binding: None,
                 target_statement: None,
+                target_statements: None,
                 wildcard_string_literals: Vec::new(),
                 match_source: match_source.into(),
             },
@@ -111,6 +114,7 @@ impl BindingGroup {
                 identifiers: "alpha_all",
                 target_binding: None,
                 target_statement: None,
+                target_statements: None,
                 wildcard_string_literals: Vec::new(),
                 match_source: match_source.into(),
             },
@@ -157,6 +161,7 @@ impl Member {
                 identifiers: "alpha_all",
                 target_binding: None,
                 target_statement: None,
+                target_statements: None,
                 wildcard_string_literals: Vec::new(),
                 match_source: match_source.into(),
             }),
@@ -178,6 +183,7 @@ impl Member {
                 identifiers: "alpha_all",
                 target_binding: Some(target_binding.into()),
                 target_statement: None,
+                target_statements: None,
                 wildcard_string_literals: Vec::new(),
                 match_source: match_source.into(),
             }),
@@ -261,10 +267,19 @@ struct FixtureSourceMatch {
     target_binding: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     target_statement: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    target_statements: Option<FixtureTargetStatements>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     wildcard_string_literals: Vec<String>,
     #[serde(rename = "match")]
     match_source: String,
+}
+
+#[derive(Clone, Serialize)]
+#[serde(untagged)]
+enum FixtureTargetStatements {
+    Indices(Vec<usize>),
+    All(&'static str),
 }
 
 impl FixtureAnonymousStatement {
@@ -283,6 +298,7 @@ impl FixtureAnonymousStatement {
                 identifiers: "alpha_all",
                 target_binding: None,
                 target_statement: None,
+                target_statements: None,
                 wildcard_string_literals: Vec::new(),
                 match_source: match_source.into(),
             }),
@@ -300,6 +316,7 @@ impl FixtureAnonymousStatement {
                 identifiers: "alpha_all",
                 target_binding: None,
                 target_statement: None,
+                target_statements: None,
                 wildcard_string_literals: wildcard_string_literals
                     .iter()
                     .map(|literal| (*literal).to_string())
@@ -320,6 +337,42 @@ impl FixtureAnonymousStatement {
                 identifiers: "alpha_all",
                 target_binding: None,
                 target_statement: Some(target_statement),
+                target_statements: None,
+                wildcard_string_literals: Vec::new(),
+                match_source: match_source.into(),
+            }),
+            comment: None,
+        }
+    }
+
+    fn alpha_all_target_statements(
+        match_source: impl Into<String>,
+        target_statements: &[usize],
+    ) -> Self {
+        Self {
+            match_source: None,
+            source_match: Some(FixtureSourceMatch {
+                identifiers: "alpha_all",
+                target_binding: None,
+                target_statement: None,
+                target_statements: Some(FixtureTargetStatements::Indices(
+                    target_statements.to_vec(),
+                )),
+                wildcard_string_literals: Vec::new(),
+                match_source: match_source.into(),
+            }),
+            comment: None,
+        }
+    }
+
+    fn alpha_all_target_statements_all(match_source: impl Into<String>) -> Self {
+        Self {
+            match_source: None,
+            source_match: Some(FixtureSourceMatch {
+                identifiers: "alpha_all",
+                target_binding: None,
+                target_statement: None,
+                target_statements: Some(FixtureTargetStatements::All("all")),
                 wildcard_string_literals: Vec::new(),
                 match_source: match_source.into(),
             }),
@@ -514,6 +567,46 @@ pub fn logical_module_with_anon_alpha_target_statement(
             anonymous_statements: vec![FixtureAnonymousStatement::alpha_all_target_statement(
                 anon_match,
                 target_statement,
+            )],
+        })
+        .expect("logical module fixture must serialize"),
+    )
+}
+
+pub fn logical_module_with_anon_alpha_target_statements(
+    path: &str,
+    members: &[Member],
+    anon_match: &str,
+    target_statements: &[usize],
+) -> LogicalModuleEntry {
+    (
+        path.to_string(),
+        serde_json::to_value(LogicalModuleBody {
+            comment: None,
+            members: fixture_members(members),
+            binding_groups: Vec::new(),
+            anonymous_statements: vec![FixtureAnonymousStatement::alpha_all_target_statements(
+                anon_match,
+                target_statements,
+            )],
+        })
+        .expect("logical module fixture must serialize"),
+    )
+}
+
+pub fn logical_module_with_anon_alpha_target_statements_all(
+    path: &str,
+    members: &[Member],
+    anon_match: &str,
+) -> LogicalModuleEntry {
+    (
+        path.to_string(),
+        serde_json::to_value(LogicalModuleBody {
+            comment: None,
+            members: fixture_members(members),
+            binding_groups: Vec::new(),
+            anonymous_statements: vec![FixtureAnonymousStatement::alpha_all_target_statements_all(
+                anon_match,
             )],
         })
         .expect("logical module fixture must serialize"),

--- a/devinfra/js/debundle/e2e/syntactic_holes_test.rs
+++ b/devinfra/js/debundle/e2e/syntactic_holes_test.rs
@@ -1,16 +1,17 @@
 //! End-to-end coverage for `source_match` syntactic holes.
 //!
-//! Each hole keyword has a bare anonymous form (matches independently,
-//! never binds) and a named `KEYWORD_name` form (binds for
-//! cross-occurrence equality).
-//!
 //! Single-node holes:
 //! - Expression holes (`EXPR` / `EXPR_name`) are selector-local
 //!   identifier expressions; they match one arbitrary expression subtree.
 //! - Statement holes (`STMT` / `STMT_name`) are selector-local bare
 //!   expression statements; they match exactly one statement.
+//! The bare single-node keyword matches independently at every occurrence;
+//! the named form binds for cross-occurrence equality.
 //!
 //! List holes (variable-length):
+//! - `ARGS` / `ARGS_name` in a call or `new` argument list absorbs a run
+//!   of arguments (including an empty run) — e.g. match a stable
+//!   important argument without spelling noisy generated siblings.
 //! - `STMT_LIST` / `STMT_LIST_name;` in a block body absorbs a run of
 //!   statements (including an empty run) — e.g. a method body you don't
 //!   want to pin.
@@ -19,6 +20,8 @@
 //! - `DECLARATORS` / `DECLARATORS_name = null` in a variable declaration
 //!   absorbs a run of declarators — e.g. match a few stable entries in a
 //!   wider `const` list without spelling unrelated siblings.
+//! List-hole suffixes are labels for readability; they do not bind the
+//! absorbed run for equality.
 //!
 //! Several list holes may appear in one block or class body: they split
 //! the pinned statements/members into an ordered subsequence with gaps,
@@ -108,6 +111,48 @@ export { actual };
             "true ? 10 : 11",
         ],
         &[],
+    );
+}
+
+#[test]
+fn member_source_match_argument_list_holes_skip_unimportant_arguments() {
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"function joinParts(...parts) {
+  return parts.join("|");
+}
+function ignoredPart(label) {
+  return `ignored:${label}`;
+}
+const importantValue = "important";
+const actual = joinParts("stable", ignoredPart("left"), importantValue, ignoredPart("right"));
+console.log(actual);
+export { actual };
+"#,
+        vec![logical_module(
+            "joined",
+            &[Member::source_alpha(
+                "joinedValue",
+                r#"const selectedValue = joinParts("stable", ARGS_BEFORE, importantValue, ARGS_AFTER);"#,
+            )],
+        )],
+    ));
+
+    assert_entry_output(&fixture, "stable|ignored:left|important|ignored:right\n");
+    assert_module_exports(
+        &fixture.out_root,
+        "static/app/modules/joined.js",
+        &["joinedValue"],
+        &["actual"],
+    );
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/modules/joined.js",
+        &[
+            "ignoredPart(\"left\")",
+            "importantValue",
+            "ignoredPart(\"right\")",
+        ],
+        &["ARGS_BEFORE", "ARGS_AFTER"],
     );
 }
 

--- a/devinfra/js/debundle/e2e/syntactic_holes_test.rs
+++ b/devinfra/js/debundle/e2e/syntactic_holes_test.rs
@@ -5,6 +5,7 @@
 //!   identifier expressions; they match one arbitrary expression subtree.
 //! - Statement holes (`STMT` / `STMT_name`) are selector-local bare
 //!   expression statements; they match exactly one statement.
+//!
 //! The bare single-node keyword matches independently at every occurrence;
 //! the named form binds for cross-occurrence equality.
 //!
@@ -20,6 +21,7 @@
 //! - `DECLARATORS` / `DECLARATORS_name = null` in a variable declaration
 //!   absorbs a run of declarators — e.g. match a few stable entries in a
 //!   wider `const` list without spelling unrelated siblings.
+//!
 //! List-hole suffixes are labels for readability; they do not bind the
 //! absorbed run for equality.
 //!

--- a/devinfra/js/debundle/lowering/anonymous.rs
+++ b/devinfra/js/debundle/lowering/anonymous.rs
@@ -21,17 +21,19 @@ pub(super) fn resolve_anonymous_statement_ordinals(
     request: &LogicalRequest,
     runtime_module: &Module,
 ) -> Result<Vec<ResolvedAnonymousStatement>> {
-    let mut resolved = Vec::with_capacity(request.anonymous_statements.len());
+    let mut resolved = Vec::new();
     for statement in &request.anonymous_statements {
-        let ordinal = source_match::resolve_anonymous_statement_body_index(
+        let ordinals = source_match::resolve_anonymous_statement_body_indices(
             runtime_module,
             &request.id,
             &statement.selector,
         )?;
-        resolved.push(ResolvedAnonymousStatement {
-            ordinal,
-            comment: statement.comment.clone(),
-        });
+        for ordinal in ordinals {
+            resolved.push(ResolvedAnonymousStatement {
+                ordinal,
+                comment: statement.comment.clone(),
+            });
+        }
     }
     Ok(resolved)
 }

--- a/devinfra/js/debundle/source_match.rs
+++ b/devinfra/js/debundle/source_match.rs
@@ -97,6 +97,12 @@ pub fn binding_group_member_selectors(
              `target_binding`; use the `exports` keys to choose selector-local bindings"
         );
     }
+    if group.source_match.target_statement.is_some() {
+        bail!(
+            "logical_module {request_id}: binding_groups[].source_match must not include \
+             `target_statement`; use it only on anonymous_statements[].source_match"
+        );
+    }
     let exports = effective_binding_group_exports(group, request_id)?;
     let unknown_comments = group
         .comments
@@ -253,6 +259,30 @@ pub fn find_anonymous_statement_body_indices(
         )
     })?;
     let parsed_items: Vec<&ModuleItem> = parsed.body.iter().collect();
+    if let Some(target_statement) = selector.target_statement {
+        if parsed_items.is_empty() {
+            bail!(
+                "logical_module {request_id}: anonymous_statements[].source_match with \
+                 target_statement parsed to zero statements:\n{match_source}",
+                match_source = selector.match_source,
+            );
+        }
+        if target_statement >= parsed_items.len() {
+            bail!(
+                "logical_module {request_id}: anonymous_statements[].source_match \
+                 target_statement {target_statement} is out of range for {} parsed \
+                 top-level statements:\n{match_source}",
+                parsed_items.len(),
+                match_source = selector.match_source,
+            );
+        }
+        return Ok(
+            find_matching_body_ranges(runtime_module, &parsed.body, selector)
+                .into_iter()
+                .map(|body_idx| body_idx + target_statement)
+                .collect(),
+        );
+    }
     let needle = match parsed_items.as_slice() {
         [single] => *single,
         [] => bail!(

--- a/devinfra/js/debundle/source_match.rs
+++ b/devinfra/js/debundle/source_match.rs
@@ -2403,7 +2403,8 @@ impl<'a> AstWildcardMatcher<'a> {
     ) -> bool {
         match (needle, candidate) {
             (SimpleAssignTarget::Ident(needle), SimpleAssignTarget::Ident(candidate)) => {
-                needle.eq_ignore_span(candidate)
+                needle.type_ann.eq_ignore_span(&candidate.type_ann)
+                    && self.match_ident(&needle.id, &candidate.id)
             }
             (SimpleAssignTarget::Member(needle), SimpleAssignTarget::Member(candidate)) => {
                 self.match_member_expr(needle, candidate)

--- a/devinfra/js/debundle/source_match.rs
+++ b/devinfra/js/debundle/source_match.rs
@@ -9,29 +9,30 @@ use std::collections::{BTreeMap, BTreeSet};
 use anyhow::{Context, Result, bail};
 use spec::{
     AnonymousStatementSelector, BindingGroup, BindingGroupAdoptNames, BindingSourceKind,
-    SourceMatch, SourceMatchIdentifierMode,
+    SourceMatch, SourceMatchIdentifierMode, TargetStatements, TargetStatementsAll,
 };
 use swc_atoms::{Atom, Wtf8Atom};
 use swc_common::{EqIgnoreSpan, SyntaxContext};
 use swc_ecma_ast::*;
 use swc_ecma_visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 
-/// Syntactic-hole keywords. The **bare keyword** is the anonymous form:
-/// it matches independently at every occurrence and never binds, so
-/// authors don't have to mint a unique name per throwaway placeholder. A
-/// `<keyword>_<name>` identifier is the **named** form, which binds for
-/// cross-occurrence equality — the same name must match the same
-/// subtree/statement everywhere it appears.
+/// Syntactic-hole keywords. For single-node holes, the **bare keyword**
+/// is the anonymous form: it matches independently at every occurrence
+/// and never binds, so authors don't have to mint a unique name per
+/// throwaway placeholder. A `<keyword>_<name>` identifier is the
+/// **named** form, which binds for cross-occurrence equality — the same
+/// name must match the same subtree/statement everywhere it appears.
 ///
 /// `EXPR` matches one arbitrary expression and `STMT` one arbitrary
-/// statement. `STMT_LIST` and `CLASS_REST` are variable-length list holes
-/// (see [`AstWildcardMatcher::match_list_with_holes`]): `STMT_LIST`
-/// absorbs a run of block statements and `CLASS_REST` a run of class
-/// members; several may appear in one list, splitting the pinned
-/// elements into an ordered subsequence with gaps. `DECLARATORS`
-/// similarly absorbs a run of variable declarators inside one
-/// `var`/`let`/`const` declaration, so selectors can pin a few stable
-/// declarators without naming the unrelated siblings around them.
+/// statement. `ARGS`, `STMT_LIST`, `CLASS_REST`, and `DECLARATORS` are
+/// variable-length list holes (see
+/// [`AstWildcardMatcher::match_list_with_holes`]): `ARGS` absorbs a run
+/// of call/new arguments, `STMT_LIST` absorbs a run of block statements
+/// (or top-level anonymous selector statements), `CLASS_REST` absorbs a
+/// run of class members, and `DECLARATORS` absorbs a run of variable
+/// declarators inside one `var`/`let`/`const` declaration. List-hole
+/// suffixes are labels for readability; they do not bind the absorbed
+/// sequence for cross-occurrence equality.
 /// `STMT_LIST` must be checked before `STMT`, since `STMT` is a
 /// keyword-prefix of it.
 const EXPR_HOLE_KEYWORD: &str = "EXPR";
@@ -39,6 +40,7 @@ const STMT_HOLE_KEYWORD: &str = "STMT";
 const STMT_LIST_HOLE_KEYWORD: &str = "STMT_LIST";
 const CLASS_REST_HOLE_KEYWORD: &str = "CLASS_REST";
 const DECLARATORS_HOLE_KEYWORD: &str = "DECLARATORS";
+const ARGS_HOLE_KEYWORD: &str = "ARGS";
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ResolvedMemberBinding {
@@ -101,6 +103,12 @@ pub fn binding_group_member_selectors(
         bail!(
             "logical_module {request_id}: binding_groups[].source_match must not include \
              `target_statement`; use it only on anonymous_statements[].source_match"
+        );
+    }
+    if group.source_match.target_statements.is_some() {
+        bail!(
+            "logical_module {request_id}: binding_groups[].source_match must not include \
+             `target_statements`; use it only on anonymous_statements[].source_match"
         );
     }
     let exports = effective_binding_group_exports(group, request_id)?;
@@ -224,17 +232,35 @@ pub fn resolve_anonymous_statement_body_index(
     request_id: &str,
     selector: &AnonymousStatementSelector,
 ) -> Result<usize> {
-    let matches = find_anonymous_statement_body_indices(runtime_module, request_id, selector)?;
+    let matches = resolve_anonymous_statement_body_indices(runtime_module, request_id, selector)?;
     match matches.as_slice() {
         [single] => Ok(*single),
+        multiple => bail!(
+            "logical_module {request_id}: anonymous_statements[].source_match resolved to {} \
+             top-level statements at body indices {:?}; expected exactly one. Use the plural \
+             resolver for selectors with `target_statements`.",
+            multiple.len(),
+            multiple,
+        ),
+    }
+}
+
+pub fn resolve_anonymous_statement_body_indices(
+    runtime_module: &Module,
+    request_id: &str,
+    selector: &AnonymousStatementSelector,
+) -> Result<Vec<usize>> {
+    let matches = find_anonymous_statement_body_index_groups(runtime_module, request_id, selector)?;
+    match matches.as_slice() {
+        [single] => Ok(single.clone()),
         [] => bail!(
             "logical_module {request_id}: anonymous_statements[].match did not match any \
-             top-level statement in the chunk. Selector:\n{match_source}",
+             top-level statement group in the chunk. Selector:\n{match_source}",
             match_source = selector.match_source,
         ),
         multiple => bail!(
             "logical_module {request_id}: anonymous_statements[].match is ambiguous — \
-             matched {} top-level statements at body indices {:?}. Refine the selector. \
+             matched {} top-level statement groups at body indices {:?}. Refine the selector. \
              Source:\n{match_source}",
             multiple.len(),
             multiple,
@@ -248,6 +274,19 @@ pub fn find_anonymous_statement_body_indices(
     request_id: &str,
     selector: &AnonymousStatementSelector,
 ) -> Result<Vec<usize>> {
+    Ok(
+        find_anonymous_statement_body_index_groups(runtime_module, request_id, selector)?
+            .into_iter()
+            .flatten()
+            .collect(),
+    )
+}
+
+pub fn find_anonymous_statement_body_index_groups(
+    runtime_module: &Module,
+    request_id: &str,
+    selector: &AnonymousStatementSelector,
+) -> Result<Vec<Vec<usize>>> {
     let parsed = js_ast::parse_js_module_ast(
         &format!("<anonymous_statement match in {request_id}>"),
         &selector.match_source,
@@ -258,48 +297,25 @@ pub fn find_anonymous_statement_body_indices(
             selector.match_source
         )
     })?;
-    let parsed_items: Vec<&ModuleItem> = parsed.body.iter().collect();
-    if let Some(target_statement) = selector.target_statement {
-        if parsed_items.is_empty() {
-            bail!(
-                "logical_module {request_id}: anonymous_statements[].source_match with \
-                 target_statement parsed to zero statements:\n{match_source}",
-                match_source = selector.match_source,
-            );
+    let target_indices =
+        anonymous_selector_target_statement_indices(request_id, selector, &parsed.body)?;
+    let mut groups = Vec::new();
+    for alignment in find_matching_body_group_alignments(runtime_module, &parsed.body, selector) {
+        let mut group = Vec::with_capacity(target_indices.len());
+        for target_idx in &target_indices {
+            let Some(Some(body_idx)) = alignment.get(*target_idx) else {
+                bail!(
+                    "logical_module {request_id}: anonymous_statements[].source_match \
+                     target statement {target_idx} was matched by a STMT_LIST hole instead \
+                     of a pinned selector statement. Refine the selector:\n{match_source}",
+                    match_source = selector.match_source,
+                );
+            };
+            group.push(*body_idx);
         }
-        if target_statement >= parsed_items.len() {
-            bail!(
-                "logical_module {request_id}: anonymous_statements[].source_match \
-                 target_statement {target_statement} is out of range for {} parsed \
-                 top-level statements:\n{match_source}",
-                parsed_items.len(),
-                match_source = selector.match_source,
-            );
-        }
-        return Ok(
-            find_matching_body_ranges(runtime_module, &parsed.body, selector)
-                .into_iter()
-                .map(|body_idx| body_idx + target_statement)
-                .collect(),
-        );
+        groups.push(group);
     }
-    let needle = match parsed_items.as_slice() {
-        [single] => *single,
-        [] => bail!(
-            "logical_module {request_id}: anonymous_statements[].match parsed to zero \
-             statements; selector source must contain exactly one top-level \
-             statement:\n{match_source}",
-            match_source = selector.match_source,
-        ),
-        _ => bail!(
-            "logical_module {request_id}: anonymous_statements[].match parsed to {} \
-             statements; selector source must contain exactly one top-level \
-             statement:\n{match_source}",
-            parsed_items.len(),
-            match_source = selector.match_source,
-        ),
-    };
-    Ok(find_matching_body_indices(runtime_module, needle, selector))
+    Ok(groups)
 }
 
 pub fn resolve_member_binding(
@@ -1118,6 +1134,214 @@ fn find_matching_body_ranges(
                 .then_some(body_idx)
         })
         .collect()
+}
+
+fn find_matching_body_group_alignments(
+    runtime_module: &Module,
+    needles: &[ModuleItem],
+    selector: &AnonymousStatementSelector,
+) -> Vec<Vec<Option<usize>>> {
+    if needles.is_empty() {
+        return Vec::new();
+    }
+    let mut segments: Vec<(usize, usize)> = Vec::new();
+    let mut idx = 0;
+    while idx < needles.len() {
+        if module_item_list_hole_name(&needles[idx]).is_some() {
+            idx += 1;
+            continue;
+        }
+        let start = idx;
+        while idx < needles.len() && module_item_list_hole_name(&needles[idx]).is_none() {
+            idx += 1;
+        }
+        segments.push((start, idx - start));
+    }
+    if segments.is_empty() {
+        return Vec::new();
+    }
+
+    let wildcard_idents = wildcard_ident_names_for_module_items(needles);
+    let alpha = selector.identifiers == SourceMatchIdentifierMode::AlphaAll;
+    SyntaxContext::within_ignored_ctxt(|| {
+        let mut matcher = AstWildcardMatcher::new(selector, &wildcard_idents, alpha);
+        let search = SegmentSearch {
+            needle: needles,
+            candidate: &runtime_module.body,
+            segments: &segments,
+            anchored_left: false,
+            anchored_right: false,
+        };
+        let mut alignment = vec![None; needles.len()];
+        let mut matches = Vec::new();
+        place_module_item_segments(&mut matcher, &search, 0, 0, &mut alignment, &mut matches);
+        matches
+    })
+}
+
+fn place_module_item_segments(
+    matcher: &mut AstWildcardMatcher<'_>,
+    search: &SegmentSearch<'_, ModuleItem>,
+    seg_idx: usize,
+    cand_min: usize,
+    alignment: &mut [Option<usize>],
+    matches: &mut Vec<Vec<Option<usize>>>,
+) {
+    let Some(&(needle_start, seg_len)) = search.segments.get(seg_idx) else {
+        matches.push(alignment.to_vec());
+        return;
+    };
+    let remaining: usize = search.segments[seg_idx..].iter().map(|(_, len)| len).sum();
+    let Some(latest_start) = search.candidate.len().checked_sub(remaining) else {
+        return;
+    };
+    for start in cand_min..=latest_start {
+        let snapshot = matcher.snapshot();
+        let alignment_snapshot = alignment.to_vec();
+        let mut segment_ok = true;
+        for offset in 0..seg_len {
+            let needle_idx = needle_start + offset;
+            let candidate_idx = start + offset;
+            if !matcher
+                .match_module_item(&search.needle[needle_idx], &search.candidate[candidate_idx])
+            {
+                segment_ok = false;
+                break;
+            }
+            alignment[needle_idx] = Some(candidate_idx);
+        }
+        if segment_ok {
+            place_module_item_segments(
+                matcher,
+                search,
+                seg_idx + 1,
+                start + seg_len,
+                alignment,
+                matches,
+            );
+        }
+        matcher.restore(snapshot);
+        alignment.copy_from_slice(&alignment_snapshot);
+    }
+}
+
+fn anonymous_selector_target_statement_indices(
+    request_id: &str,
+    selector: &AnonymousStatementSelector,
+    parsed_items: &[ModuleItem],
+) -> Result<Vec<usize>> {
+    if selector.target_statement.is_some() && selector.target_statements.is_some() {
+        bail!(
+            "logical_module {request_id}: anonymous_statements[].source_match cannot include \
+             both `target_statement` and `target_statements`:\n{match_source}",
+            match_source = selector.match_source,
+        );
+    }
+    if let Some(target_statement) = selector.target_statement {
+        if parsed_items.is_empty() {
+            bail!(
+                "logical_module {request_id}: anonymous_statements[].source_match with \
+                 target_statement parsed to zero statements:\n{match_source}",
+                match_source = selector.match_source,
+            );
+        }
+        return validate_anonymous_target_statement_indices(
+            request_id,
+            selector,
+            parsed_items,
+            vec![target_statement],
+            "target_statement",
+        );
+    }
+    if let Some(target_statements) = &selector.target_statements {
+        if parsed_items.is_empty() {
+            bail!(
+                "logical_module {request_id}: anonymous_statements[].source_match with \
+                 target_statements parsed to zero statements:\n{match_source}",
+                match_source = selector.match_source,
+            );
+        }
+        let indices = match target_statements {
+            TargetStatements::Indices(indices) => indices.clone(),
+            TargetStatements::All(TargetStatementsAll::All) => parsed_items
+                .iter()
+                .enumerate()
+                .filter_map(|(idx, item)| module_item_list_hole_name(item).is_none().then_some(idx))
+                .collect(),
+        };
+        return validate_anonymous_target_statement_indices(
+            request_id,
+            selector,
+            parsed_items,
+            indices,
+            "target_statements",
+        );
+    }
+
+    match parsed_items {
+        [] => bail!(
+            "logical_module {request_id}: anonymous_statements[].match parsed to zero \
+             statements; selector source must contain exactly one top-level statement:\n{match_source}",
+            match_source = selector.match_source,
+        ),
+        [single] if module_item_list_hole_name(single).is_some() => bail!(
+            "logical_module {request_id}: anonymous_statements[].match parsed to a STMT_LIST \
+             hole; selector source must contain a pinned top-level statement to claim:\n{match_source}",
+            match_source = selector.match_source,
+        ),
+        [_] => Ok(vec![0]),
+        _ => bail!(
+            "logical_module {request_id}: anonymous_statements[].match parsed to {} statements; \
+             selector source must contain exactly one top-level statement unless \
+             `target_statement` or `target_statements` is set:\n{match_source}",
+            parsed_items.len(),
+            match_source = selector.match_source,
+        ),
+    }
+}
+
+fn validate_anonymous_target_statement_indices(
+    request_id: &str,
+    selector: &AnonymousStatementSelector,
+    parsed_items: &[ModuleItem],
+    indices: Vec<usize>,
+    field_name: &str,
+) -> Result<Vec<usize>> {
+    if indices.is_empty() {
+        bail!(
+            "logical_module {request_id}: anonymous_statements[].source_match \
+             `{field_name}` selected no top-level statements:\n{match_source}",
+            match_source = selector.match_source,
+        );
+    }
+    let mut seen = BTreeSet::new();
+    for idx in &indices {
+        if !seen.insert(*idx) {
+            bail!(
+                "logical_module {request_id}: anonymous_statements[].source_match \
+                 `{field_name}` contains duplicate index {idx}:\n{match_source}",
+                match_source = selector.match_source,
+            );
+        }
+        if *idx >= parsed_items.len() {
+            bail!(
+                "logical_module {request_id}: anonymous_statements[].source_match \
+                 `{field_name}` index {idx} is out of range for {} parsed top-level \
+                 statements:\n{match_source}",
+                parsed_items.len(),
+                match_source = selector.match_source,
+            );
+        }
+        if module_item_list_hole_name(&parsed_items[*idx]).is_some() {
+            bail!(
+                "logical_module {request_id}: anonymous_statements[].source_match \
+                 `{field_name}` index {idx} points at a STMT_LIST hole, not a pinned \
+                 selector statement:\n{match_source}",
+                match_source = selector.match_source,
+            );
+        }
+    }
+    Ok(indices)
 }
 
 /// Needle-derived matching state hoisted out of the per-candidate
@@ -1991,7 +2215,7 @@ impl<'a> AstWildcardMatcher<'a> {
     fn match_call_expr(&mut self, needle: &CallExpr, candidate: &CallExpr) -> bool {
         needle.type_args.eq_ignore_span(&candidate.type_args)
             && self.match_callee(&needle.callee, &candidate.callee)
-            && self.match_slice(&needle.args, &candidate.args, Self::match_expr_or_spread)
+            && self.match_expr_or_spread_slice(&needle.args, &candidate.args)
     }
 
     fn match_callee(&mut self, needle: &Callee, candidate: &Callee) -> bool {
@@ -2019,6 +2243,30 @@ impl<'a> AstWildcardMatcher<'a> {
             (Some(needle), Some(candidate)) => self.match_expr_or_spread(needle, candidate),
             (None, None) => true,
             _ => false,
+        }
+    }
+
+    /// Match a call/new argument list. `ARGS` / `ARGS_*` holes split
+    /// the needle into fixed argument segments matched as an ordered
+    /// subsequence with gaps; with no hole this is an exact element-wise
+    /// match.
+    fn match_expr_or_spread_slice(
+        &mut self,
+        needle: &[ExprOrSpread],
+        candidate: &[ExprOrSpread],
+    ) -> bool {
+        if needle
+            .iter()
+            .any(|arg| argument_list_hole_name(arg).is_some())
+        {
+            self.match_list_with_holes(
+                needle,
+                candidate,
+                |arg| argument_list_hole_name(arg).is_some(),
+                Self::match_expr_or_spread,
+            )
+        } else {
+            self.match_slice(needle, candidate, Self::match_expr_or_spread)
         }
     }
 
@@ -2206,7 +2454,7 @@ impl<'a> AstWildcardMatcher<'a> {
             (OptChainBase::Call(needle), OptChainBase::Call(candidate)) => {
                 needle.type_args.eq_ignore_span(&candidate.type_args)
                     && self.match_expr(&needle.callee, &candidate.callee)
-                    && self.match_slice(&needle.args, &candidate.args, Self::match_expr_or_spread)
+                    && self.match_expr_or_spread_slice(&needle.args, &candidate.args)
             }
             _ => false,
         }
@@ -2500,9 +2748,7 @@ impl<'a> AstWildcardMatcher<'a> {
         candidate: &Option<Vec<ExprOrSpread>>,
     ) -> bool {
         match (needle, candidate) {
-            (Some(needle), Some(candidate)) => {
-                self.match_slice(needle, candidate, Self::match_expr_or_spread)
-            }
+            (Some(needle), Some(candidate)) => self.match_expr_or_spread_slice(needle, candidate),
             (None, None) => true,
             _ => false,
         }
@@ -2810,6 +3056,8 @@ impl AlphaIdentCanonicalizer {
                 .iter()
                 .chain(&wildcard_idents.statements)
                 .chain(&wildcard_idents.statement_lists)
+                .chain(&wildcard_idents.declarator_lists)
+                .chain(&wildcard_idents.argument_lists)
                 .cloned()
                 .collect(),
             ..Self::default()
@@ -2891,6 +3139,9 @@ struct WildcardIdents {
     /// pseudo-declarators and must not be alpha-canonicalized as real
     /// bindings.
     declarator_lists: BTreeSet<String>,
+    /// `ARGS` argument-list hole names. These are pseudo-arguments and
+    /// must route to ordered-subsequence argument matching.
+    argument_lists: BTreeSet<String>,
     /// Whether the selector contains any `CLASS_REST` class-member
     /// hole. The marker is a class field key (an `IdentName`, not an
     /// `Ident`), so it survives alpha-canonicalization without being
@@ -2908,8 +3159,17 @@ impl WildcardIdents {
             && self.statements.is_empty()
             && self.statement_lists.is_empty()
             && self.declarator_lists.is_empty()
+            && self.argument_lists.is_empty()
             && !self.class_rest_present
     }
+}
+
+fn wildcard_ident_names_for_module_items(needles: &[ModuleItem]) -> WildcardIdents {
+    let mut collector = WildcardIdentCollector::default();
+    for needle in needles {
+        needle.visit_with(&mut collector);
+    }
+    collector.idents
 }
 
 fn wildcard_ident_names(needle: &ModuleItem) -> WildcardIdents {
@@ -2963,6 +3223,14 @@ impl Visit for WildcardIdentCollector {
         }
         declarator.visit_children_with(self);
     }
+
+    fn visit_expr_or_spread(&mut self, expr_or_spread: &ExprOrSpread) {
+        if let Some(hole_name) = argument_list_hole_name(expr_or_spread) {
+            self.idents.argument_lists.insert(hole_name.to_string());
+            return;
+        }
+        expr_or_spread.visit_children_with(self);
+    }
 }
 
 fn expression_hole_name(expr: &Expr) -> Option<&str> {
@@ -2988,6 +3256,16 @@ fn statement_list_hole_name(stmt: &Stmt) -> Option<&str> {
     hole_name_for(statement_hole_name(stmt)?, STMT_LIST_HOLE_KEYWORD)
 }
 
+/// The name of a top-level statement-list hole (`STMT_LIST` /
+/// `STMT_LIST_*;`) if `item` is one. Module declarations cannot be
+/// holes because the selector syntax is an expression statement.
+fn module_item_list_hole_name(item: &ModuleItem) -> Option<&str> {
+    let ModuleItem::Stmt(stmt) = item else {
+        return None;
+    };
+    statement_list_hole_name(stmt)
+}
+
 /// The name of a declarator-list hole (`DECLARATORS` /
 /// `DECLARATORS_*`) if `declarator` is one. The initializer is ignored:
 /// `const` syntax requires one, so selectors usually write
@@ -2997,6 +3275,20 @@ fn declarator_list_hole_name(declarator: &VarDeclarator) -> Option<&str> {
         return None;
     };
     hole_name_for(ident.id.sym.as_ref(), DECLARATORS_HOLE_KEYWORD)
+}
+
+/// The name of an argument-list hole (`ARGS` / `ARGS_*`) if
+/// `expr_or_spread` is one. The hole token itself is a plain identifier
+/// argument; the run it absorbs may contain spread or non-spread
+/// arguments.
+fn argument_list_hole_name(expr_or_spread: &ExprOrSpread) -> Option<&str> {
+    if expr_or_spread.spread.is_some() {
+        return None;
+    }
+    let Expr::Ident(ident) = expr_or_spread.expr.as_ref() else {
+        return None;
+    };
+    hole_name_for(ident.sym.as_ref(), ARGS_HOLE_KEYWORD)
 }
 
 /// If `name` is a hole identifier for `keyword` — the bare keyword

--- a/devinfra/js/debundle/spec.rs
+++ b/devinfra/js/debundle/spec.rs
@@ -785,6 +785,7 @@ impl AnonymousStatement {
                 match_source: match_source.clone(),
                 identifiers: SourceMatchIdentifierMode::Exact,
                 target_binding: None,
+                target_statement: None,
                 wildcard_string_literals: BTreeSet::new(),
             }),
             (None, Some(source_match)) if source_match.target_binding.is_some() => {
@@ -830,6 +831,13 @@ pub struct SourceMatch {
     /// binding from it. Invalid on `anonymous_statements[].source_match`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub target_binding: Option<String>,
+    /// Zero-based top-level statement index to claim when this source match is
+    /// used as an `anonymous_statements[].source_match`. This lets a selector
+    /// include surrounding declarations as context while moving only the
+    /// intended anonymous statement. Invalid on `members[].selector.source_match`
+    /// and `binding_groups[].source_match`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_statement: Option<usize>,
     /// String-literal placeholder values in `match` that should match any
     /// candidate string literal at the same AST position. Use this for
     /// volatile generated literals while keeping all other strings exact.
@@ -845,6 +853,7 @@ impl SourceMatch {
             match_source: self.match_source.clone(),
             identifiers: self.identifiers,
             target_binding: self.target_binding.clone(),
+            target_statement: self.target_statement,
             wildcard_string_literals: self.wildcard_string_literals.clone(),
         }
     }
@@ -855,6 +864,7 @@ pub struct AnonymousStatementSelector {
     pub match_source: String,
     pub identifiers: SourceMatchIdentifierMode,
     pub target_binding: Option<String>,
+    pub target_statement: Option<usize>,
     pub wildcard_string_literals: BTreeSet<String>,
 }
 
@@ -864,6 +874,7 @@ impl AnonymousStatementSelector {
             match_source: match_source.into(),
             identifiers: SourceMatchIdentifierMode::Exact,
             target_binding: None,
+            target_statement: None,
             wildcard_string_literals: BTreeSet::new(),
         }
     }
@@ -1092,6 +1103,11 @@ impl MemberSelector {
     pub fn selected(&self) -> std::result::Result<MemberSelectorSpec, MemberSelectorError> {
         match (&self.binding, &self.source_match) {
             (Some(binding), None) => Ok(MemberSelectorSpec::Binding(binding.clone())),
+            (None, Some(source_match)) if source_match.target_statement.is_some() => {
+                Err(MemberSelectorError {
+                    message: "members[].selector.source_match cannot include `target_statement`",
+                })
+            }
             (None, Some(source_match)) => {
                 Ok(MemberSelectorSpec::SourceMatch(source_match.selector()))
             }

--- a/devinfra/js/debundle/spec.rs
+++ b/devinfra/js/debundle/spec.rs
@@ -786,11 +786,20 @@ impl AnonymousStatement {
                 identifiers: SourceMatchIdentifierMode::Exact,
                 target_binding: None,
                 target_statement: None,
+                target_statements: None,
                 wildcard_string_literals: BTreeSet::new(),
             }),
             (None, Some(source_match)) if source_match.target_binding.is_some() => {
                 Err(AnonymousStatementSelectorError {
                     message: "anonymous_statements source_match cannot include `target_binding`",
+                })
+            }
+            (None, Some(source_match))
+                if source_match.target_statement.is_some()
+                    && source_match.target_statements.is_some() =>
+            {
+                Err(AnonymousStatementSelectorError {
+                    message: "anonymous_statements source_match cannot include both `target_statement` and `target_statements`",
                 })
             }
             (None, Some(source_match)) => Ok(source_match.selector()),
@@ -838,6 +847,12 @@ pub struct SourceMatch {
     /// and `binding_groups[].source_match`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub target_statement: Option<usize>,
+    /// Top-level statement indices to claim when this source match is used as
+    /// an `anonymous_statements[].source_match`, or `all` to claim every
+    /// non-hole statement in the selector. This is the multi-statement form of
+    /// `target_statement`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_statements: Option<TargetStatements>,
     /// String-literal placeholder values in `match` that should match any
     /// candidate string literal at the same AST position. Use this for
     /// volatile generated literals while keeping all other strings exact.
@@ -854,9 +869,23 @@ impl SourceMatch {
             identifiers: self.identifiers,
             target_binding: self.target_binding.clone(),
             target_statement: self.target_statement,
+            target_statements: self.target_statements.clone(),
             wildcard_string_literals: self.wildcard_string_literals.clone(),
         }
     }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq, Ord, PartialOrd)]
+#[serde(untagged)]
+pub enum TargetStatements {
+    Indices(Vec<usize>),
+    All(TargetStatementsAll),
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq, Ord, PartialOrd)]
+#[serde(rename_all = "snake_case")]
+pub enum TargetStatementsAll {
+    All,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
@@ -865,6 +894,7 @@ pub struct AnonymousStatementSelector {
     pub identifiers: SourceMatchIdentifierMode,
     pub target_binding: Option<String>,
     pub target_statement: Option<usize>,
+    pub target_statements: Option<TargetStatements>,
     pub wildcard_string_literals: BTreeSet<String>,
 }
 
@@ -875,6 +905,7 @@ impl AnonymousStatementSelector {
             identifiers: SourceMatchIdentifierMode::Exact,
             target_binding: None,
             target_statement: None,
+            target_statements: None,
             wildcard_string_literals: BTreeSet::new(),
         }
     }
@@ -1106,6 +1137,11 @@ impl MemberSelector {
             (None, Some(source_match)) if source_match.target_statement.is_some() => {
                 Err(MemberSelectorError {
                     message: "members[].selector.source_match cannot include `target_statement`",
+                })
+            }
+            (None, Some(source_match)) if source_match.target_statements.is_some() => {
+                Err(MemberSelectorError {
+                    message: "members[].selector.source_match cannot include `target_statements`",
                 })
             }
             (None, Some(source_match)) => {

--- a/devinfra/js/debundle/spec_modules.rs
+++ b/devinfra/js/debundle/spec_modules.rs
@@ -332,6 +332,7 @@ anonymous_statements:
                     identifiers: spec::SourceMatchIdentifierMode::AlphaAll,
                     target_binding: None,
                     target_statement: None,
+                    target_statements: None,
                     wildcard_string_literals: BTreeSet::new(),
                 },
             ])

--- a/devinfra/js/debundle/spec_modules.rs
+++ b/devinfra/js/debundle/spec_modules.rs
@@ -331,6 +331,7 @@ anonymous_statements:
                     match_source: "register(Co);".to_string(),
                     identifiers: spec::SourceMatchIdentifierMode::AlphaAll,
                     target_binding: None,
+                    target_statement: None,
                     wildcard_string_literals: BTreeSet::new(),
                 },
             ])


### PR DESCRIPTION
## Summary
- add `source_match.target_statement` for anonymous statement selectors, so surrounding declarations can be used as structural context while claiming only the intended statement
- keep `target_statement` invalid on member selectors and binding groups
- document the form and cover it with generic debundle e2e tests

## Tests
- `nix develop -c pre-commit run --files devinfra/js/debundle/spec.rs devinfra/js/debundle/source_match.rs devinfra/js/debundle/spec_modules.rs devinfra/js/debundle/e2e/support.rs devinfra/js/debundle/e2e/anonymous_statement_test.rs devinfra/js/debundle/docs/guide.md`
- `nix develop -c bazelisk --output_base=/tmp/bazel-ducktape-target-statement test //devinfra/js/debundle/e2e:anonymous_statement_test //devinfra/js/debundle/e2e:syntactic_holes_test //devinfra/js/debundle:source_match_test //devinfra/js/debundle:spec_modules_test --config=nolint`