### PR TITLE
docs: cut always-loaded agent context ~45%; embed token sweeps in knowledge_hygiene skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,63 +105,15 @@ Remote execution (RBE) and remote caching are the **expected defaults** — do n
 1. First, retry the Bash tool call with `dangerouslyDisableSandbox: true` — the Claude Code sandbox's `--unshare-net` breaks Bazel's gRPC DNS resolution even when the host is listed in the domain allowlist (see <docs/claude_code_sandbox.md>).
 2. If it still fails, **stop and report the connectivity issue to the user**. The user may need to recover the session start hook or check VPN/firewall state.
 
-### Downloading remote build outputs
+### Build outputs and invocation data
 
-`bbr` uses `--remote_download_minimal` by default, so artifacts stay on the runner. To fetch specific outputs:
-
-```bash
-# Fetch by regex (most common):
-bbr build //path/to:target --remote_download_regex='.*\.whl$'
-
-# Fetch all direct outputs of the requested targets:
-bbr build //path/to:target --remote_download_outputs=toplevel
-```
-
-Artifacts land at `bb-out/bazel-out/k8-fastbuild/bin/<pkg>/<name>` (not `bazel-bin/` — that symlink only exists in local workspaces).
-
-### Undeclared test outputs (golden PNGs, logs, HAR dumps)
-
-Tests write diagnostics to Bazel's `TEST_UNDECLARED_OUTPUTS_DIR`. These are
-uploaded to BuildBuddy automatically. Fetch them with `bbapi artifact`:
-
-```bash
-INV=$(cat ~/.cache/bbr/last_invocation_id)
-
-# List what's available (shows LABEL and NAME columns):
-bbapi artifact list "$INV"
-
-# Stream a specific file to stdout (pipe or redirect):
-bbapi artifact cat "$INV" pave_output.txt > local_copy.txt
-
-# Download to a file (defaults to the artifact's own filename):
-bbapi artifact download "$INV" pave_output.txt
-```
-
-`name-substr` is matched against `"label/name"` (e.g. `"test_render/test.outputs/empty.png"`).
-
-To update golden screenshots after a visual test run:
-
-```bash
-INV=$(cat ~/.cache/bbr/last_invocation_id)
-bbapi artifact download "$INV" "test.outputs/product_cash_runway.png"
-cp product_cash_runway.png augur/frontend/__screenshots__/product_cash_runway.png
-```
-
-The outer (bbr) invocation ID auto-resolves to the child Bazel invocation — either ID works.
-
-### Invocation tracking
-
-`bbr` writes the BuildBuddy invocation ID to `~/.cache/bbr/last_invocation_id`:
-
-```bash
-bbapi target <id>                    # List targets (auto-resolves workflow IDs)
-bbapi target log <id> <target>       # Fetch test log
-bbapi artifact list <id>             # List undeclared test outputs
-bbapi invocation <id>                # Invocation details (commit, branch, dirty)
-
-bbapi invocation list --tag session:<session-id>   # All invocations in this session
-bbapi target history --label //path:target          # Pass/fail timeline
-```
+`bbr` runs with `--remote_download_minimal`, so artifacts stay on the runner; fetch with
+`--remote_download_regex='...'` or `--remote_download_outputs=toplevel`. Fetched outputs
+land under `bb-out/bazel-out/k8-fastbuild/bin/<pkg>/<name>` (not `bazel-bin/` — that
+symlink only exists in local workspaces). `bbr` writes the invocation ID to
+`~/.cache/bbr/last_invocation_id`; undeclared test outputs, logs, target history, and
+invocation details come from `bbapi {artifact,target,invocation} ...`. Full recipes
+(golden screenshot updates, pass/fail timelines, log retrieval): `/buildbuddy_api` skill.
 
 ### Session bazelrc and `bb` vs `bazelisk`
 
@@ -205,7 +157,8 @@ applies at `spec.path` (e.g., `terraform.yaml`, `*.sops.yaml`). **Do not include
 `flux-kustomization.yaml` in local `kustomization.yaml` resources** — it causes
 redundant application.
 
-@cluster/docs/container-images.md
+Adding or publishing a container image (Bazel `oci_image`, GHCR push matrix, Flux image
+automation, tag policy): see <cluster/docs/container-images.md>.
 
 ## CI Configuration
 
@@ -290,39 +243,32 @@ if __name__ == "__main__":
 
 **No test skips for missing tools**: let the test fail. Tools come from Bazel runfiles or the RBE worker image.
 
-**Docker tests run on RBE, never locally**: Tests that use Docker (e.g., container E2E tests, proxy integration tests with mitmproxy testcontainers) are designed to run on BuildBuddy RBE workers, which have Docker available. **Never** skip these tests because Docker is unavailable locally, disable them, or claim they are "not runnable." They work on RBE — that is the intended execution environment. If RBE is not working, recover it by following the "Recovering from a Broken Session Start Hook" section above. Every environment in which agents operate will have BuildBuddy accessible, either automatically (session start hook) or through manual recovery. If you cannot restore BuildBuddy remote execution after following recovery steps, **abort and report the issue to the user** rather than working around it with local-only execution for tests that assume RBE.
+**Docker tests run on RBE, never locally**: tests that use Docker (container E2E,
+mitmproxy testcontainers) target BuildBuddy RBE workers, which have Docker. Never skip,
+stub, or declare them "not runnable" because Docker is missing locally. If RBE is
+unreachable, recover it (connectivity steps above) — or abort and report; never fall
+back to local-only execution for tests that assume RBE. Use the `py_test` macro from
+`//devinfra/python:defs.bzl` (not raw `@rules_python`) with `requires_docker = True`;
+the macro handles `env_inherit`, tags, and Docker exec properties — don't add them
+manually.
 
-Use `py_test` macro from `//devinfra/python:defs.bzl` (not the raw `@rules_python` `py_test`) and set `requires_docker = True`. The macro handles `env_inherit`, tags, and Docker exec properties automatically. Do not add `env_inherit = ["DUCKTAPE_DOCKER_CLIENT_KEY"]` or `tags = ["requires_docker"]` manually.
+**Use undeclared test outputs for log capture**: write diagnostics (container logs, HAR
+dumps, config snapshots) via `util.testing.undeclared_outputs.undeclared_outputs_dir()`,
+not test stdout/stderr. They upload to BuildBuddy and download to
+`bazel-testlogs/<target>/test.outputs/` (see "Build outputs and invocation data" above).
 
-**Use undeclared test outputs for log capture**: Write diagnostic data (container logs, HAR dumps, config snapshots) to Bazel's undeclared test outputs directory via `util.testing.undeclared_outputs.undeclared_outputs_dir()`. These are uploaded to BuildBuddy and retrievable from the invocation. Do not dump large blobs into test stdout/stderr — they clutter the test log and are harder to navigate. To read undeclared outputs from a test run:
+**Test timeouts mean hangs, not slowness**: a timeout means something is wedged
+(deadlock, container never ready, port nothing listens on) — do NOT bump
+`size`/`timeout`. Trace the blockage: `--test_output=streamed --test_arg=-s`, fixture
+logging, `docker ps`.
 
-```bash
-TEST_DIR=$(bb info bazel-testlogs)/path/to/test_target
-ls "$TEST_DIR/test.outputs/"          # list undeclared output files
-cat "$TEST_DIR/test.outputs/my.log"   # read a specific output
-```
+**Localizing test failures**: `bbapi target history` gives the pass/fail timeline —
+faster than `git bisect` since BuildBuddy already has the results. Recipes:
+`/buildbuddy_api` skill.
 
-On RBE, the outputs are downloaded to local testlogs dir after test completes (Bazel fetches them automatically). The mitmproxy fixture saves `proxy.har` to undeclared outputs as an example.
-
-**Test timeouts mean hangs, not slowness**: When a test times out, assume it is wedged — an internal operation is waiting on something that will never arrive (deadlock, stuck future, container that never becomes ready, connection to a port nothing is listening on). Do NOT bump `size`/`timeout` as a fix. Instead, trace the execution to find what is blocked: run with `--test_output=streamed --test_arg=-s`, add logging around fixture setup, check for stuck containers (`docker ps`), etc. A test that ran in 35s last week and now times out at 60s is not "slow" — something broke internally.
-
-**Localizing test failures with target history**: When a test is failing and you need to find when it broke, use `bbapi target history` to see the pass/fail timeline, then narrow to a commit range. This is faster than `git bisect` because BuildBuddy already has the results:
-
-```bash
-# 1. Check recent history for the failing target
-bbapi target history //path/to:test_target
-
-# 2. Identify the transition point (last pass → first fail)
-# 3. Use git log to find commits in that range
-git log --oneline <last-pass>..<first-fail>
-
-# 4. Read the test log from the first failing invocation
-bbapi target log <failing-invocation-id> test_target
-```
-
-Use the `/buildbuddy_api` skill for more details on the `bbapi` CLI.
-
-@devinfra/docs/syrupy_snapshots.md
+**Snapshot tests (syrupy)**: set `uses_syrupy = True` on `py_test` and put the `.ambr`
+files in `data`. Update/retrieval workflow (RBE and local):
+<devinfra/docs/syrupy_snapshots.md>.
 
 ### Live OpenAI API Tests
 

--- a/STYLE.md
+++ b/STYLE.md
@@ -198,6 +198,15 @@ test.
 **Heuristics**: if deleting it loses zero information, delete it. "Why" earns its place;
 "what" rarely does. Public API boundaries tolerate more verbosity than internal code.
 
+### Deviations, Not Re-explanations
+
+When this repo uses a standard mechanism with a repo-specific difference, document only
+the difference, labeled **Deviation:**, with a brief pointer to the standard mechanism —
+never re-explain the standard behavior. Example: "Standard Flux image automation;
+deviation: register the `ImageRepository` with the webhook receiver." House vocabulary:
+**deviation** = intentional divergence from stock; **gotcha** = surprising behavior that
+bites.
+
 ### Local File Links in Markdown
 
 - `@path/to/file.md` (own line) — transclusion, for content agents must always load

--- a/STYLE.md
+++ b/STYLE.md
@@ -1,6 +1,8 @@
 # Code Style Guide
 
-Style and convention rules for this repository. Package-specific elaborations belong in that package's AGENTS.md, but general rules belong here.
+Repository-wide style and convention rules. Package-specific elaborations belong
+in that package's AGENTS.md. Rules are stated tersely and assume fluency with the
+standard tools; examples appear only where they define a repo-specific format.
 
 ## Repository Documentation Structure
 
@@ -15,167 +17,116 @@ Style and convention rules for this repository. Package-specific elaborations be
 
 ### Rules
 
-- **README.md**: What it is, how to set up, how to run. No agent-specific instructions.
-- **AGENTS.md**:
-  - First line: `@README.md` (if README exists)
-  - Then: Agent-specific instructions (idioms, "always do X", "never do Y", conventions)
-  - Package-specific elaborations of STYLE.md rules go here
-  - **Nesting/inheritance**: Agents read AGENTS.md files from the repo root down to the current package. A sub-folder AGENTS.md must not repeat instructions already covered by a parent AGENTS.md. If `foo/AGENTS.md` says X, `foo/bar/AGENTS.md` should not repeat X. Only document what is new or different at this level.
-- **CLAUDE.md**: Always exactly one line: `@AGENTS.md`
-- **STYLE.md**: Repository-wide rules. If a rule applies across packages, it belongs here, not in a package's AGENTS.md.
+- **README.md**: what it is, how to set up, how to run. No agent-specific instructions.
+  Keep it lean — everything in a README ships to agents via transclusion; deep reference
+  and historical context belong in `docs/` behind links.
+- **AGENTS.md**: first line `@README.md` (if a README exists), then agent-only
+  prescriptions. A sub-folder AGENTS.md must not repeat anything a parent AGENTS.md
+  already covers — document only what is new or different at this level.
+- **CLAUDE.md**: always exactly one line: `@AGENTS.md`.
+- **STYLE.md**: rules that apply across packages live here, not in a package AGENTS.md.
 
 ### @-Transclusion Syntax
 
-- Must be on its own line: `@AGENTS.md`
-- Supports relative paths: `@../../STYLE.md`
-- Must be the only content on that line
+`@path/to/file.md` alone on its own line; relative paths supported. Transclude only
+content every reader of the host file needs — task-specific docs get a `<path>` pointer
+instead, so they load on demand.
 
 ## General
 
-- **Modern Python**: Use `|` for unions, walrus operator (`:=`), `match` statements. Target Python 3.13+.
-- **Enter async early**: Programs with more than trivial async usage should enter `async` at the outermost level. The sync `main()` should do minimal setup (logging, arg parsing) then immediately call `asyncio.run(async_main(...))`. Do not scatter `asyncio.run()` calls deep in the call stack or call it multiple times. All async work belongs under a single `asyncio.run()` at the top.
-- **No large code blobs embedded in YAML/JSON**: Do not inline Python scripts, shell scripts, or large configuration blocks as string values in Kubernetes manifests, Helm values, or other YAML/JSON files. Embedded code cannot be linted, formatted, or type-checked by standard tools (ruff, shellcheck, mypy). Instead, keep code in its native file format (`.py`, `.sh`) and mount it into containers via `configMapGenerator` (kustomize) or `ConfigMap` with file references. This applies to any embedded block longer than ~5 lines.
-- **Imports at module top**: Place all imports at the top of files. Only use in-function imports to break a proven circular dependency, and add a one-line comment at that import explaining the cycle it avoids.
-- **No suspicious nullability**: If a field is optional, it must be for a clear transitional reason or represent an intentional, valid state with defined behavior. Otherwise, model as non-nullable and remove guards. For external inputs (API payloads, hook inputs): if a field may be absent, use `None` as the default — never use empty string `""`, empty list `[]`, or other "zero values" to represent absence. A field is either guaranteed present (no default) or optional (`| None = None`).
-- **No dead code**: Remove unused code, unused imports, and historical comments that no longer reflect the behavior.
-- **No redundant derived fields**: API responses should not include both a collection and a trivially computable function of it (e.g., returning both a list and its `len()`). The consumer can compute `len(items)` themselves. Exception: pagination, where `total_count` represents the full count before offset/limit slicing — this is not derivable from the returned page.
-- **Every field needs a reader**: A field in structured data (Pydantic models, config schemas, YAML/JSON payloads) exists for machines — to be processed, validated against, or displayed to an end user. A field that is only ever _set_ and never read is dead payload: it implies a contract that doesn't exist and travels through parsers and diffs for no reason. Two common offenders:
-  - Authoring-only annotations (provenance, "why this entry exists") modeled as schema fields. Those belong in inert comments next to the data — in a config file, write a YAML `#` comment above the entry, not a `note:` field nothing consumes.
-  - Write-only fields that survived a refactor: code populates them at every construction site, but no consumer remains. Delete the field, not just the readers.
-- **No unnecessary aliasing**: Avoid renaming imports (`import foo as bar`), assigning fixtures to local variables, trivial parameter aliasing (`slug = snapshot_slug`), or any other form of aliasing unless it adds real semantic value or is required to avoid a collision. Prefer using variables under their actual names. Include a comment when an alias is genuinely needed. Do not create "convenience" re-export aliases like `AgentEvent = EventType` — import from the module that actually defines the symbol. Aliases are only justified at public API boundaries (e.g., `__init__.py` re-exports for external consumers) or when adapting between internal/external naming conventions.
-- **Import from the defining module**: Always import a symbol from the module that defines it, not from a module that happens to re-export or re-import it. If `SecretSource` is defined in `config.py`, import it from `config`, not from `secret_sources` which happens to import it. This keeps the dependency graph honest and makes it clear where types originate.
-- **No dynamic attribute probing**: Avoid `getattr`/`hasattr`/`setattr` unless justified and documented. In tests, prefer direct attribute access with precise expectations.
-- **No exception swallowing**: Never use bare `except:` or broad `except Exception:` as a silent fallback. Catch specific exception types, let exceptions propagate, or re-raise with precise context. Do not default to empty values on error. **Real errors must surface** - if a config file has invalid syntax, a source file won't parse, or I/O fails, that's a bug the user needs to know about. Silently returning empty defaults hides the problem.
-
-  Bad examples (do not do these):
-
-  ```python
-  # ❌ Invalid config silently ignored - user thinks they have no config
-  try:
-      data = tomllib.loads(config_path.read_text())
-  except (OSError, tomllib.TOMLDecodeError):
-      data = {}  # Pretend config doesn't exist
-
-  # ❌ Syntax errors in source code silently skipped
-  try:
-      tree = ast.parse(source)
-  except (OSError, SyntaxError):
-      continue  # Skip broken files without warning
-
-  # ❌ Narrowing exception type doesn't fix the swallowing problem
-  except tomllib.TOMLDecodeError:
-      data = {}  # Still wrong - invalid TOML is a real error
-  ```
-
-  The fix is usually to let the exception propagate, or at minimum log a warning so the user knows something is wrong.
-
-  **Exception**: Broad `except Exception:` is acceptable for cleanup-before-reraise patterns (like a context manager's `__exit__`). If you catch broadly, perform cleanup (rollback, close resource), then immediately `raise`, that's fine—no information is lost.
-
-- **Prefer exceptions over error lists**: Functions that validate or check preconditions should raise exceptions on failure, not return lists of errors. Exceptions provide immediate control flow, clear error types, and standard patterns for callers.
-- **Let exceptions propagate**: Self-explanatory exceptions with actionable messages should propagate to the existing error boundary (CLI wrapper, request handler, FastMCP tool handler) rather than being caught and reformatted at each call site. Define error boundaries once (e.g., in a CLI entry point or request middleware), not repeatedly throughout the code. FastMCP already converts unhandled exceptions to MCP errors with the exception message - use this pattern. Only catch exceptions when you need to transform them, add context, or handle them differently than the default boundary.
-- **Do not restate parser/I/O exceptions**: Do not wrap config file reads or parser calls in `try`/`except` blocks that only say "invalid file" or "could not read file" before re-raising. The original `OSError`, YAML/TOML/JSON parser exception, or Pydantic `ValidationError` already includes the useful traceback and failure details. Add a wrapper only when it supplies non-obvious domain context, recovery behavior, or a stable public error contract.
-- **Exceptions are for exceptional things**: Don't use exceptions for expected control flow. Prefer: query preconditions first, then execute without catch. Avoid: execute with catch, then parse what went wrong from the exception.
-
-  ```python
-  # ❌ Using exception for expected control flow
-  try:
-      info = supervisor.get_process_info(name)
-      return info.state == "RUNNING"
-  except Fault as e:
-      if e.faultCode == BAD_NAME:
-          return False  # Service doesn't exist - but this was foreseeable
-      raise
-
-  # ✓ Query preconditions first
-  if not supervisor.service_exists(name):
-      return False
-  info = supervisor.get_process_info(name)
-  return info.state == "RUNNING"
-  ```
-
-- **Don't wrap bugs in try/except**: If an error represents a programming bug, let it crash — don't catch and return early.
-- **Express code concisely**: Every line should do work. Inline a non-repeated subexpression if it saves a line, unless the computation is complex enough that a name aids readability. Don't add no-op short-circuits (`if not items: return` before a loop that would be a no-op anyway). Don't create intermediate variables just to hold a value used once.
-- **Strict data mapping**: When parsing enums/typed values from persistence or inputs, do not ignore invalid values. Validate early or raise; do not `continue` on exceptions.
-- **Prefer functional style**: Use concise comprehensions and idiomatic patterns. Keep public interfaces typed with Pydantic where appropriate.
-- **Functions over classes**: Only use classes when you have state to manage. If `__init__` just does `self.x = SomeClass()` with no real state, use functions instead.
-- **Use framework features**: Prefer built-in validation (e.g., typer `exists=True`) over manual checks.
-- **Prefer precise types**: Use discriminated unions, Protocols, TypedDicts, or concrete Pydantic models for heterogeneous values. `Any`/`object` is acceptable only when a field truly allows any value and no stronger contract exists; document such cases.
-- **Make invalid states unrepresentable**: Prefer algebraic types (discriminated unions) over flags and optional fields that allow nonsensical combinations. A model with `hook_installed: bool` and `pid: int | None` permits `hook_installed=False, pid=42` — instead use a union of distinct result types where each variant carries exactly the fields that make sense for it. In Python code, dispatch on union variants with `isinstance` checks (which let mypy narrow the type), not string comparisons on discriminator fields. In templates (Mako/Jinja) where `isinstance` is unavailable, `kind` string checks are acceptable.
-- **Typed concurrency messages**: Actor/mailbox patterns should use explicit dataclasses or Pydantic models for messages and result types—never `dict[str, T]`.
-- **Dataclasses over Pydantic for internal types**: Use `@dataclass` (or `@dataclass(frozen=True)`) for types that are purely internal — constructed, passed around, and accessed as typed objects without serialization, deserialization, or validation. Reserve Pydantic `BaseModel` for API boundaries, config parsing, and cases that need `model_dump()`, `model_validate()`, JSON schema, or Field validators.
-- **Use Pydantic as typed objects**: Access fields directly (`model.field`), not via `dict.get(...)` or `model["field"]`. Parse dicts into typed models at the boundary. Only use `dict.get(...)` for truly untyped external payloads (raw DB rows, HTTP headers, environment vars).
-- **Construct Pydantic models, not dicts**: When creating test data or structured values, construct typed Pydantic models directly (`BaseExecResult(exit=Exited(exit_code=0), ...)`) rather than building dicts that match the schema. This ensures mypy catches field renames and type changes at every construction site, instead of silently producing invalid dicts.
-- **Never mock Pydantic models**: Do not use `Mock()` or `MagicMock()` to fake Pydantic models in tests—construct real instances with test data. Mocking bypasses validation and hides type errors.
-- **No unnecessary model_dump()**: Use typed attributes on Pydantic objects directly. Dump only at I/O boundaries (logging/serialization), not to re-parse fields for logic.
-- **Pydantic Field descriptions for per-field docs**: When documenting individual fields on a Pydantic model, use `Field(description=...)` instead of a class-level docstring that lists fields. The description goes where the field is defined, not in a separate "Fields:" section.
-
-  ```python
-  # ✓ Per-field descriptions via Field()
-  class PostToolUseOutput(BaseModel):
-      decision: Literal["block"] | None = Field(default=None, description="Set to 'block' to re-prompt Claude")
-      reason: str | None = Field(default=None, description="Feedback shown to Claude when decision='block'")
-
-  # ❌ Class docstring restating field names
-  class PostToolUseOutput(BaseModel):
-      """Fields:
-          decision: Set to "block" to re-prompt Claude.
-          reason: Feedback shown to Claude when decision="block".
-      """
-      decision: Literal["block"] | None = None
-      reason: str | None = None
-  ```
-
-- **Shorten obvious docstrings**: If a function name and signature tell the whole story, collapse the docstring to a single line. Remove Args/Returns sections that just echo the signature.
-
-  ```python
-  # ✓ Single-line when function name + types are sufficient
-  def get_required_path(rlocation: str) -> Path:
-      """Resolve a runfiles path to an absolute Path, raising if missing."""
-
-  # ❌ Multi-line restating what's obvious
-  def get_required_path(rlocation: str) -> Path:
-      """Get path to a file or directory from runfiles, checking it exists.
-
-      Args:
-          rlocation: Runfiles path (e.g., "_main/devinfra/claude/session_start")
-      Returns:
-          Absolute Path to the file or directory.
-      Raises:
-          RuntimeError: If the path cannot be located or doesn't exist.
-      """
-  ```
-
-- **Explicit keyword arguments**: Instantiate Pydantic models and call functions with explicit keyword arguments (`Model(field=value)`) rather than `**kwargs` unpacking when the arguments are known. Prefer `Model.model_validate(data)` over `TypeAdapter(...).validate_python(...)` unless you explicitly need adapter semantics.
-- **Use enum values directly**: Reference enum values as `EnumClass.VALUE`, not as string literals. For StrEnum, use the value directly without `.value` (StrEnum instances are already strings): `f"{AgentType.CRITIC}_suffix"` not `f"{AgentType.CRITIC.value}_suffix"` or `f"critic_suffix"`.
-- **Compact CLI output**: CLI output should preserve vertical space. Merge related information onto single lines instead of spreading across multiple lines without good reason. Vertical space is at a premium.
-- **Use `{x=}` f-string debugging format**: In error messages, log messages, and debug strings, prefer `f"{x=}"` over `f"x={x!r}"` or `f"x={x}"`. The `=` specifier is more concise and automatically includes the variable name and `repr()`.
-- **Logging**: In modules that log, declare a module-level logger at the top: `logger = logging.getLogger(__name__)`. Do not call `logging.getLogger(...)` inside functions/classes. Do not store the logger on `self`.
-- **Paths**: Prefer `pathlib.Path` objects; only call `str(path)` when an external API requires a string.
-- **No string forward references**: Avoid string-based forward references in type annotations. Reorder classes or split files to remove cycles. When cross-module cycles exist, use `if TYPE_CHECKING:` imports with real symbols (not quoted names). Do not rely on `model_rebuild()` where reordering can avoid forward refs.
-- **No unnecessary `__init__.py`**: Do not create `__init__.py` files for packages that only contain Bazel targets. Bazel auto-generates stub `__init__.py` files via `imports = [...]` in `py_library`/`py_test` rules. Only create `__init__.py` when you need to expose a public API or configure the package namespace.
-- **Avoid `__all__` unless required**: Do not define `__all__` in modules unless there's a specific need (e.g., controlling `from module import *` behavior for a public API, or suppressing lint warnings for re-exports in `__init__.py`). Most modules don't need it.
-- **Iterate correctly**: Use `.values()` not `.items()` when key is unused. Don't reimplement pagination/batching when the client class already provides it.
-- **Simple string ops over regex**: Don't use `re.compile()` for simple substring checks — use `str.lower()` + `in`.
-- **No grab-bag modules**: No `core.py`, `utils.py`, `constants.py`. Name modules by what they do. Organize by domain/feature, not by role (classes vs functions vs constants).
-- **Flat over nested**: Don't create `parsers/base.py`, `parsers/constants.py`, `parsers/__init__.py` when you can just have `parsers.py`. If a subdirectory has <3 files, flatten it.
-- **Prefer sets for unordered collections**: When a collection's order is semantically irrelevant (changed files, unique IDs, tags), use `set[T]` instead of `list[T]`. Sets make the "no duplicates, order doesn't matter" intent explicit and provide O(1) membership testing. Use lists only when order matters or duplicates are valid.
-- **Prefer `more_itertools` over manual iterator patterns**: Use `more_itertools` when it expresses intent more clearly than raw Python. Key utilities:
-  - `one(iterable)` — extract the single element, raise if zero or multiple. Use instead of `next(iter(x))` when exactly one item is expected. Prefer over length checks followed by indexing. Also use for searching a collection for exactly one expected match (e.g., `one(x for x in items if x.id == target_id)`) instead of handrolled filter-and-check loops.
-  - `first(iterable)` / `first(iterable, default=...)` — get the first element. Use instead of `next(iter(x))` or `next(iter(x), default)` when taking the first of potentially many.
-  - Use `itertools.batched` (stdlib since 3.12) instead of `for i in range(0, len(x), n): batch = x[i:i+n]`.
-  - Choose `one()` vs `first()` based on semantics: if receiving multiple items is a bug, use `one()` to enforce the invariant. If multiple items are valid and you want the first, use `first()`.
+- **Modern Python (3.13+)**: `|` unions, `:=`, `match`.
+- **Enter async early**: a single `asyncio.run(async_main(...))` at the top of `main()`;
+  never scattered or nested deeper in the call stack.
+- **No large code blobs in YAML/JSON**: any embedded script/config block longer than ~5
+  lines lives in its native file (`.py`, `.sh`) and is mounted via `configMapGenerator`
+  or a `ConfigMap` file reference, so it stays lintable and type-checkable.
+- **Imports at module top**; in-function imports only to break a proven circular
+  dependency, with a one-line comment naming the cycle.
+- **No suspicious nullability**: an optional field must represent an intentional,
+  defined absent state (or a named transition). Absence is `None` — never `""`/`[]`
+  zero values. A field is either required (no default) or `| None = None`.
+- **No dead code**: remove unused code, unused imports, and historical comments.
+- **No redundant derived fields**: don't return a collection plus a trivially computable
+  function of it (a list and its `len()`). Exception: pagination `total_count`.
+- **Every field needs a reader**: a set-but-never-read field is dead payload. Authoring
+  provenance goes in inert `#` comments next to the data, not schema fields (`note:`);
+  delete write-only fields that survived refactors.
+- **No unnecessary aliasing**: no import renames, fixture re-assignment, trivial
+  parameter aliasing, or convenience re-exports (`AgentEvent = EventType`). Aliases only
+  at public API boundaries (`__init__.py` re-exports) or to avoid collisions, with a
+  comment.
+- **Import from the defining module**, never from a module that happens to re-export
+  the symbol.
+- **No dynamic attribute probing** (`getattr`/`hasattr`/`setattr`) unless justified and
+  documented; in tests, assert attributes directly.
+- **Exceptions**:
+  - **Never swallow**: no bare/broad `except` as a silent fallback, no defaulting to
+    empty values on parse/IO errors — real errors must surface. Broad catch is fine
+    only for cleanup-then-`raise` (e.g. `__exit__`).
+  - **Raise, don't return error lists**, from validation/precondition checks.
+  - **Let them propagate** to the single error boundary (CLI wrapper, request
+    middleware, FastMCP handler — FastMCP already converts unhandled exceptions to MCP
+    errors). Catch only to transform, add context, or genuinely handle.
+  - **Don't restate parser/IO exceptions**: no wrappers that just say "invalid file" —
+    the original `OSError`/parser error/`ValidationError` already carries the details.
+  - **Not control flow**: query preconditions first and execute without catch; don't
+    execute-catch-and-parse-the-fault for foreseeable states.
+  - **Bugs crash**: don't catch errors that indicate programming bugs.
+- **Express code concisely**: every line does work; inline single-use subexpressions;
+  no no-op short-circuits; no single-use intermediate variables.
+- **Strict data mapping**: invalid enum/typed inputs raise early; never `continue`
+  past them.
+- **Prefer functional style**: comprehensions and idiomatic patterns.
+- **Functions over classes** when there's no state to manage.
+- **Use framework features** (e.g. typer `exists=True`) over manual checks.
+- **Precise types**: discriminated unions, Protocols, TypedDicts, concrete models.
+  `Any`/`object` only when truly anything is allowed; document such cases.
+- **Make invalid states unrepresentable**: a union of variant types over flag+optional
+  combos that permit nonsense (`hook_installed=False, pid=42`). Dispatch on variants
+  with `isinstance` (mypy narrows), not discriminator-string compares — except in
+  Mako/Jinja templates, where `kind` strings are acceptable.
+- **Typed concurrency messages**: dataclasses/models for actor/mailbox messages and
+  results, never `dict[str, T]`.
+- **Dataclasses for internal types, Pydantic at boundaries**: `@dataclass` for purely
+  internal typed objects; `BaseModel` where you need (de)serialization, validation,
+  JSON schema, or Field validators.
+- **Pydantic as typed objects**: direct attribute access (`model.field`), parse dicts
+  into models at the boundary; `dict.get(...)` only for truly untyped external payloads.
+  Construct models, not schema-shaped dicts, in tests; never `Mock()` a Pydantic model;
+  no `model_dump()` except at I/O boundaries.
+- **`Field(description=...)`** for per-field docs, not a class docstring listing fields.
+- **Shorten obvious docstrings** to one line; drop Args/Returns sections that echo the
+  signature.
+- **Explicit keyword arguments** when arguments are known; `Model.model_validate(data)`
+  over `TypeAdapter(...)` unless adapter semantics are needed.
+- **Enums**: `EnumClass.VALUE`, not string literals. StrEnum is already a string — no
+  `.value` in f-strings.
+- **Compact CLI output**: merge related information onto single lines; vertical space
+  is at a premium.
+- **`f"{x=}"`** in error/log/debug strings, not `f"x={x!r}"`.
+- **Logging**: module-level `logger = logging.getLogger(__name__)` only — never inside
+  functions or stored on `self`.
+- **`pathlib.Path`** throughout; `str(path)` only when an external API requires it.
+- **No string forward references**: reorder/split files to remove cycles; for
+  cross-module cycles use `if TYPE_CHECKING:` with real symbols, not quoted names or
+  `model_rebuild()`.
+- **No unnecessary `__init__.py`**: Bazel auto-generates stubs via `imports = [...]`;
+  create one only to expose a public API or configure the namespace.
+- **No `__all__`** without a specific need (public `import *` surface, `__init__.py`
+  re-export lint).
+- **No grab-bag modules** (`core.py`, `utils.py`, `constants.py`): name modules by what
+  they do; organize by domain, not by role.
+- **Flat over nested**: a subdirectory with <3 files gets flattened.
+- **Sets for unordered collections** (`set[T]`); lists only when order or duplicates
+  matter.
+- **Prefer `more_itertools`**: `one()` when more than one match is a bug, `first()`
+  when many are valid and you want the first; `itertools.batched` over manual slicing.
 
 ## Tombstones
 
-When removing something that cannot be deleted atomically — because downstream consumers
-need a transition period (old clients still reading a serialized field, a service being
-decommissioned still holding an OAuth registration, a deprecated API still called by code
-being migrated) — leave a **tombstone**: a dated marker that records what was removed and
-the condition under which the tombstone itself can be deleted.
-
-**Tag**: `CLEANUP` followed by the ISO date the tombstone was added (today's date when you
-write it — useful for spotting stale tombstones during review). The condition text encodes
-when to remove it:
+When a removal can't be atomic — downstream consumers need a transition period — leave a
+**tombstone**: a dated marker recording what was removed and the verifiable condition for
+deleting the marker itself:
 
 ```python
 # CLEANUP(2026-03-22): Remove field once all clients are on ≥v2.3
@@ -183,189 +134,84 @@ when to remove it:
 old_field: str | None = None
 ```
 
-**Rules:**
-
-- The condition must be specific and verifiable — "once commit X ships to all releases" or
-  "after YYYY-MM-DD", not "when safe".
-- Delete the tombstone (and any code/config it guards) once the condition is met. Tombstones
-  are not permanent fixtures.
-- Tombstones are **not** historical comments. "Used to do X" explains the past and should be
-  deleted; a `CLEANUP` comment is an active work item near the code it refers to.
-- Cross-cutting cleanup that spans many files belongs in `TODO.md`; tombstones are for
-  localized removals where the marker lives right next to the thing being cleaned up.
+- The condition must be specific and verifiable ("after YYYY-MM-DD", "once commit X
+  ships"), not "when safe".
+- Delete the tombstone (and what it guards) once the condition is met — it's an active
+  work item, not a historical comment ("used to do X" gets deleted, not tombstoned).
+- Cross-cutting cleanup spanning many files goes in `TODO.md`; tombstones are for
+  localized removals next to the thing being cleaned up.
 
 ## SQLAlchemy
 
-- **Prefer SQLAlchemy ORM over raw SQL**: In projects using SQLAlchemy, prefer the ORM query interface over raw SQL strings. The ORM provides type safety, IDE support, and protection against SQL injection. Use raw SQL only when the ORM would make the query significantly less readable (e.g., complex window functions, CTEs, or database-specific features not well-supported by the ORM).
-
-  ```python
-  # ✓ Prefer ORM queries
-  session.query(User).filter(User.email == email).first()
-  session.query(TruePositiveOccurrenceORM).filter_by(snapshot_slug=slug).all()
-
-  # ❌ Avoid raw SQL for simple queries
-  session.execute(text("SELECT * FROM users WHERE email = :email"), {"email": email})
-  ```
-
-  Raw SQL is acceptable when:
-  - Using complex PostgreSQL-specific features (window functions, recursive CTEs, LATERAL joins)
-  - Performance-critical queries where the ORM generates suboptimal SQL
-  - Database administrative operations (GRANT, CREATE FUNCTION, etc.)
-  - The equivalent ORM query would be significantly harder to read or maintain
+**ORM over raw SQL.** Raw SQL only for DB-specific features the ORM handles poorly
+(window functions, recursive CTEs, LATERAL joins), performance-critical queries,
+administrative DDL, or when the ORM equivalent would be markedly less readable.
 
 ## Build System (Bazel)
 
-- **Use `main_module` for `py_binary` targets**: When a `py_binary` needs the same source file as a `py_library`, use `main_module` instead of duplicating `srcs`. The `py_library` declares all deps; the `py_binary` just references the library. This avoids dep duplication and ensures the mypy lint aspect checks deps in one place.
+**Use `main_module` for `py_binary` targets** that share a `py_library`'s source — the
+library declares all deps once (keeping the mypy aspect single-sourced); the binary has
+no `srcs`:
 
-  ```python
-  py_library(
-      name = "session_start_lib",
-      srcs = ["session_start.py"],
-      imports = ["../.."],
-      deps = [":settings", "@pypi//mako"],
-  )
-
-  # CORRECT - main_module, no srcs
-  py_binary(
-      name = "session_start",
-      main_module = "devinfra.claude.session_start",
-      imports = ["../.."],
-      deps = [":session_start_lib"],
-  )
-
-  # WRONG - duplicates srcs and requires duplicating deps for mypy
-  py_binary(
-      name = "session_start",
-      srcs = ["session_start.py"],
-      deps = [":session_start_lib", "@pypi//mako"],
-  )
-  ```
+```python
+py_binary(
+    name = "session_start",
+    main_module = "devinfra.claude.session_start",
+    imports = ["../.."],
+    deps = [":session_start_lib"],
+)
+```
 
 ## Testing
 
-- **Test file placement**: Tests for module `a/b/c.py` should be in `a/b/test_c.py`. Keep test files adjacent to the modules they test. This makes it easy to find tests and ensures test coverage is visible in directory listings. Integration tests that span multiple modules can use descriptive names like `test_agent_mcp_integration.py`.
-- **DRY test fixtures**: Extract shared setup logic into pytest fixtures. Avoid duplicating fixture definitions across test files. Prefer conftest.py for fixtures used by multiple test modules.
-- **Fixture imports belong in conftest.py, not test files**: Never import pytest fixtures directly in `test_*.py` files. Instead, add fixture imports to the nearest `conftest.py`. Ruff ignores F401 in conftest files via `per-file-ignores` in `ruff.toml` (`"**/conftest.py" = ["F401"]`), so no `# noqa` comments are needed. Importing fixtures in test files causes F811 (redefinition) when the same name appears as a test function parameter.
-- **Concise test bodies**: Keep test functions focused on assertions. Delegate setup to fixtures.
-- **Update tests with production code**: When editing production code, check what tests use the interfaces you touched and propagate edits. Type signature changes, parameter changes, renamed functions, or changed behavior require corresponding test updates.
-- **No pure change-detector tests**: Do not add tests that only assert a
-  checked-in constant, enum value, fixture field, or config literal equals the
-  same literal copied into the test. These tests exercise no behavior and only
-  force mechanical updates when intentional data changes. Prefer tests that
-  prove semantics: parsing rejects invalid values, invariants hold, generated
-  schemas contain required structure, or representative calculations/flows
-  produce expected results. Example: testing that `FooMode.BAR == "bar"` is
-  usually not useful; testing that an unknown mode is rejected or that BAR mode
-  changes runtime behavior is useful.
-- **No lint silencing without approval**: Do not add ignore rules or silence individual lint errors unless explicitly approved.
-- **Use pre-commit**: Prefer `pre-commit run --all-files` over manually running individual tools (ruff, mypy, etc.) since pre-commit is configured correctly for this repository.
-- **Use `textwrap.dedent` for inline multiline strings**: When embedding multiline strings in tests (YAML, JSON, scripts), use `textwrap.dedent()` to maintain proper indentation in the test file while removing leading whitespace from the string content:
-
-  ```python
-  from textwrap import dedent
-
-  # ✓ Readable indentation with dedent
-  yaml_content = dedent("""
-      apiVersion: v1
-      kind: ConfigMap
-      metadata:
-        name: test
-  """)
-
-  # ❌ Flush-left strings break visual flow
-  yaml_content = """
-  apiVersion: v1
-  kind: ConfigMap
-  metadata:
-    name: test
-  """
-  ```
+- **Placement**: tests for `a/b/c.py` go in `a/b/test_c.py`, adjacent to the module.
+  Cross-module integration tests get descriptive names
+  (`test_agent_mcp_integration.py`).
+- **Fixtures**: shared setup in fixtures; fixtures used by multiple modules in
+  `conftest.py`. Never import fixtures in `test_*.py` files — import them in the
+  nearest `conftest.py` (ruff ignores F401 there via `per-file-ignores`; test-file
+  imports cause F811 collisions with parameter names).
+- **Concise test bodies**: assertions in tests, setup in fixtures.
+- **Update tests with production code**: signature/behavior changes propagate to the
+  tests that use them, in the same change.
+- **No pure change-detector tests**: don't assert a checked-in literal equals itself
+  copied into the test. Test semantics: invalid values rejected, invariants hold,
+  behavior differs by mode.
+- **No lint silencing without approval**: no ignore rules or per-line silencing unless
+  explicitly approved.
+- **Use pre-commit**: `pre-commit run --all-files` over invoking individual tools.
+- **`textwrap.dedent`** for inline multiline strings (YAML, JSON, scripts) so test
+  indentation stays readable.
 
 ## Documentation
 
-### What to Remove
+**Remove**: docstrings/comments that restate the name, signature, or next line; Args/
+Returns sections echoing types; trivial class docstrings; historical "used to" comments;
+`# === Section ===` banners; changelog comments.
 
-- **Restating docstrings**: Docstrings that just repeat function name, parameter names, or return type without adding insight
-- **Restating comments**: Comments that describe what the next line does when the code is self-explanatory
-- **Parameter echoing**: Args sections that just list parameter names and types already in the signature
-- **Returns echoing**: Returns sections that restate the return type annotation
-- **Trivial class docstrings**: Docstrings like "A class that represents X" where X is the class name
-- **Historical comments**: Comments about removed code, old behavior, or "used to be X"
-- **Section banners**: `# ========== Section ==========` comments that add visual noise without information
-- **Changelog comments**: `# Added in v1.2` or `# Modified 2024-01-15` that belong in version control
+**Keep**: TODOs/FIXMEs near their context; non-obvious behavior (edge cases, invariants,
+preconditions, contracts); why-comments; system/integration context not visible locally
+(action at a distance, shared-state mutation); disambiguation of ambiguous names
+("container-side path" vs "host-side"); test intent comments naming the edge case under
+test.
 
-### What to Keep
-
-- **TODOs/FIXMEs**: Valid work items belong in code near the relevant context, not just in issue trackers
-- **Useful module-level docstrings**: Those that concisely summarize the file's purpose when not redundant with other docs
-- **Non-obvious behavior docs**: Edge cases, error conditions, invariants, contracts, preconditions ("caller must ensure..."), important caveats
-- **Why comments**: Comments explaining rationale, not what the code does
-- **External context docs**: Comments/docstrings explaining why something exists, how it integrates into the broader system, or its role in architecture not obvious from local context
-- **System context**: What the function does in wider system context, action at a distance, mutations to shared state
-- **Disambiguation docs**: Docstrings that clarify ambiguous naming (e.g., "container-side path" vs "host-side path", "UTC timestamp" vs "local time"). If a name could be misinterpreted, either rename it to be unambiguous or keep documentation that clarifies
-- **Test intent comments**: Comments in tests that describe what specific edge case, subtlety, or behavior the test is verifying. These clarify the test's purpose beyond what the test name conveys and help future readers understand why the test exists
-
-### Decision Heuristics
-
-- **Delete test**: If removing the doc/comment loses zero information, remove it
-- **Signature coverage**: If signature + types tell the whole story, docstring is redundant
-- **Why vs what**: Comments explaining "why" are valuable; comments describing "what" are usually redundant
-- **Non-obvious behavior**: Keep docs that explain edge cases, error conditions, or non-intuitive behavior
-- **API boundaries**: Public API docs may justify more verbosity; internal code should be minimal
+**Heuristics**: if deleting it loses zero information, delete it. "Why" earns its place;
+"what" rarely does. Public API boundaries tolerate more verbosity than internal code.
 
 ### Local File Links in Markdown
 
-For references to local files in documentation:
-
-- **For LLM agents**: Use `@path/to/file.md` transclusion syntax (on its own line)
-- **For clickable links without custom text**: Use angle brackets: `<path/to/file.md>`
-- **For links with custom text**: Use standard markdown: `[custom text](path/to/file.md)`
-
-**Do NOT use** `[path/to/file.md](path/to/file.md)` - this duplicates the path unnecessarily.
-
-```markdown
-# Good
-
-@docs/architecture.md
-See <docs/schema.md> for details.
-See the [architecture guide](docs/architecture.md) for details.
-
-# Bad - duplicates path
-
-See [docs/schema.md](docs/schema.md) for details.
-```
+- `@path/to/file.md` (own line) — transclusion, for content agents must always load
+- `<path/to/file.md>` — clickable link without custom text
+- `[custom text](path/to/file.md)` — link with custom text
+- Never `[path](path)` — duplicates the path
 
 ### Inline Code in Prose
 
-Use backtick inline code (`` `...` ``) or fenced code blocks for any code-like token in markdown prose: variable names, function names, CLI flags, file paths, config keys, env vars, glob patterns, hostnames, and similar. Do not write code tokens as plain text — formatters like prettier will escape special characters (e.g., `*` → `\*`), and unformatted code tokens are harder to read.
-
-```markdown
-# Good
-
-- Reduce `file-read*` to the minimum required
-- Set `JUPYTER_*` dirs and `HOME`
-- Map `fs.read_paths` → ro binds
-
-# Bad — code tokens as plain text (prettier will mangle the \*)
-
-- Reduce file-read\* to the minimum required
-- Set JUPYTER\_\* dirs and HOME
-- Map fs.read_paths → ro binds
-```
+Backtick every code-like token in markdown prose: flags, paths, config keys, env vars,
+globs, hostnames. Plain-text code tokens are harder to read and prettier escapes their
+special characters (`*` → `\*`).
 
 ### Brace-Expansion Shorthand for Lists
 
-When listing multiple items that share a common prefix, prefer brace-expansion shorthand over naming each individually. Only use when there are 2+ suffixed variants (single-item braces like `foo-{bar}` are worse than plain `foo-bar`).
-
-```markdown
-# Good — concise, pattern is clear
-
-- **Gitea**: `gitea-{namespace,secrets,db,admin-token,servicemonitor}`
-- **kagent**: `kagent-{crds,db,secrets}`
-- Directories: `k8s/langfuse/{namespace,secrets,db,app}/`
-
-# Bad — verbose, every item spelled out
-
-- **Gitea**: `gitea`, `gitea-namespace`, `gitea-secrets`, `gitea-db`,
-  `gitea-admin-token`, `gitea-servicemonitor`
-```
+Prefer `gitea-{namespace,secrets,db,admin-token}` over spelling out each item. Only with
+2+ suffixed variants — single-item braces (`foo-{bar}`) are worse than `foo-bar`.

--- a/cluster/README.md
+++ b/cluster/README.md
@@ -96,24 +96,8 @@ CNPG database placement (OVH-HA vs Proxmox-single) follows <docs/cnpg_convention
 
 ## GPU (NVIDIA)
 
-wyrm2 is a NixOS machine (not Talos) joined as a K8s worker via `k8s-worker.nix` and
-Nebula mesh. It provides 2x RTX 5090 GPUs to the cluster.
-
-**Stack**: NixOS `hardware.nvidia-container-toolkit` generates CDI specs at
-`/var/run/cdi/` → containerd configured with `nvidia-container-runtime.cdi` as a named
-runtime → `RuntimeClass` resource maps `nvidia` handler to that runtime → NVIDIA device
-plugin (Helm chart) discovers GPUs via NVML and advertises `nvidia.com/gpu` resources.
-
-**How it works**: The device plugin uses the default `envvar` strategy — it sets
-`NVIDIA_VISIBLE_DEVICES` on workload containers. Pods requesting GPUs must specify
-`runtimeClassName: nvidia` so containerd routes them through `nvidia-container-runtime.cdi`,
-which reads the env var and injects GPU devices/libraries via host CDI specs.
-
-**Key files**:
-
-- `nix/nixos/modules/k8s-worker.nix` — containerd nvidia runtime config, CDI settings
-- `cluster/k8s/nvidia-device-plugin/helmrelease.yaml` — device plugin + RuntimeClass
-- `cluster/k8s/ollama/deployment.yaml` — example GPU workload (`runtimeClassName: nvidia`)
+wyrm2 (NixOS, 2x RTX 5090) provides `nvidia.com/gpu` resources; GPU pods need
+`runtimeClassName: nvidia`. Runtime stack and key files: <docs/gpu.md>.
 
 ## Failure Modes
 
@@ -137,27 +121,9 @@ secret flow, NetworkPolicy template, and blueprint tombstone rules.
 
 ## ActivityWatch
 
-Personal activity tracking via [aw-server-rust](https://github.com/ActivityWatch/aw-server-rust).
-Accessible at `activitywatch:5600` via Nebula mesh (lighthouse DNS resolves the cert name).
-No built-in auth; Nebula mesh membership is the trust boundary.
-
-- **Server**: `aw-server-rust` on Proxmox, SQLite on `local-path-proxmox` (1Gi PVC)
-- **Sidecar**: Nebula container joins the mesh (`10.42.0.40`, cert name `activitywatch`)
-- **Image**: `ghcr.io/agentydragon/aw-server`, built with Bazel (`//third_party/activitywatch:image`) and pushed by the `push-images.yml` GHA matrix
-- **Certs**: SOPS secret (`k8s/activitywatch/nebula-certs.sops.yaml`)
-- **Read-only proxy**: nginx sidecar on port 5601 (Service `activitywatch-readonly`),
-  allows GET + POST `/api/0/query` only. `openclaw-sandbox` and `claude-sandbox` namespaces
-  have CiliumNetworkPolicy access to this port.
-
-### Desktop Client Setup
-
-Watchers run locally, heartbeat to cluster via Nebula mesh. Config managed by
-Nix home-manager (`nix/home/services/activitywatch.nix`).
-
-1. Ensure Nebula is running on the host (NixOS workers have it via `nebula.nix`)
-2. Apply config: `home-manager switch --flake ~/code/ducktape#<hostname>`
-3. Start: `aw-qt` (runs `aw-watcher-afk`, `aw-watcher-window`)
-4. Verify: `curl http://activitywatch:5600/api/0/info`
+Personal activity tracking at `activitywatch:5600` over Nebula mesh (no built-in auth;
+mesh membership is the trust boundary). Architecture and desktop client setup:
+<docs/activitywatch.md>.
 
 ## Repository Structure
 

--- a/cluster/docs/activitywatch.md
+++ b/cluster/docs/activitywatch.md
@@ -1,0 +1,23 @@
+# ActivityWatch
+
+Personal activity tracking via [aw-server-rust](https://github.com/ActivityWatch/aw-server-rust).
+Accessible at `activitywatch:5600` via Nebula mesh (lighthouse DNS resolves the cert name).
+No built-in auth; Nebula mesh membership is the trust boundary.
+
+- **Server**: `aw-server-rust` on Proxmox, SQLite on `local-path-proxmox` (1Gi PVC)
+- **Sidecar**: Nebula container joins the mesh (`10.42.0.40`, cert name `activitywatch`)
+- **Image**: `ghcr.io/agentydragon/aw-server`, built with Bazel (`//third_party/activitywatch:image`) and pushed by the `push-images.yml` GHA matrix
+- **Certs**: SOPS secret (`k8s/activitywatch/nebula-certs.sops.yaml`)
+- **Read-only proxy**: nginx sidecar on port 5601 (Service `activitywatch-readonly`),
+  allows GET + POST `/api/0/query` only. `openclaw-sandbox` and `claude-sandbox` namespaces
+  have CiliumNetworkPolicy access to this port.
+
+## Desktop Client Setup
+
+Watchers run locally, heartbeat to cluster via Nebula mesh. Config managed by
+Nix home-manager (`nix/home/services/activitywatch.nix`).
+
+1. Ensure Nebula is running on the host (NixOS workers have it via `nebula.nix`)
+2. Apply config: `home-manager switch --flake ~/code/ducktape#<hostname>`
+3. Start: `aw-qt` (runs `aw-watcher-afk`, `aw-watcher-window`)
+4. Verify: `curl http://activitywatch:5600/api/0/info`

--- a/cluster/docs/gpu.md
+++ b/cluster/docs/gpu.md
@@ -1,0 +1,20 @@
+# GPU (NVIDIA) on wyrm2
+
+wyrm2 is a NixOS machine (not Talos) joined as a K8s worker via `k8s-worker.nix` and
+Nebula mesh. It provides 2x RTX 5090 GPUs to the cluster.
+
+**Stack**: NixOS `hardware.nvidia-container-toolkit` generates CDI specs at
+`/var/run/cdi/` → containerd configured with `nvidia-container-runtime.cdi` as a named
+runtime → `RuntimeClass` resource maps `nvidia` handler to that runtime → NVIDIA device
+plugin (Helm chart) discovers GPUs via NVML and advertises `nvidia.com/gpu` resources.
+
+**How it works**: The device plugin uses the default `envvar` strategy — it sets
+`NVIDIA_VISIBLE_DEVICES` on workload containers. Pods requesting GPUs must specify
+`runtimeClassName: nvidia` so containerd routes them through `nvidia-container-runtime.cdi`,
+which reads the env var and injects GPU devices/libraries via host CDI specs.
+
+**Key files**:
+
+- `nix/nixos/modules/k8s-worker.nix` — containerd nvidia runtime config, CDI settings
+- `cluster/k8s/nvidia-device-plugin/helmrelease.yaml` — device plugin + RuntimeClass
+- `cluster/k8s/ollama/deployment.yaml` — example GPU workload (`runtimeClassName: nvidia`)

--- a/cluster/docs/inference/README.md
+++ b/cluster/docs/inference/README.md
@@ -75,4 +75,4 @@ incident or migration, write a focused doc and link it from this README.
 
 - <../../k8s/ollama/> — current cluster Ollama deployment
 - <../../../x/local_llm/> — wyrm2 host scripts (vLLM/Ollama/comfyui)
-- <../../README.md#gpu-nvidia> — GPU/CDI runtime stack on wyrm2
+- <../gpu.md> — GPU/CDI runtime stack on wyrm2

--- a/devinfra/claude/README.md
+++ b/devinfra/claude/README.md
@@ -3,11 +3,6 @@
 Session hooks, statusline, and Claude Code API models for Claude Code
 web environments.
 
-## References
-
-- [Claude Code Hooks API](https://docs.anthropic.com/en/docs/claude-code/hooks)
-- [Settings JSON Schema](https://json.schemastore.org/claude-code-settings.json)
-
 ## Networking
 
 Current Claude Code web containers reach the internet without any per-tool
@@ -30,10 +25,6 @@ what the Rust hook daemon guarantees to every Claude Code session (on CLI and on
 web). Read that first if you want to know **what** the daemon does for the
 agent — this README covers **how** those behaviors are implemented.
 
-## Components
-
-- **Session Start Hook**: Sets up the development environment for Claude Code web sessions.
-
 ## Session Start Hook
 
 The hook runs at the start of each Claude Code web session and:
@@ -45,39 +36,31 @@ follow-up.
 
 ### PATH Shims (self-contained Rust runtime)
 
-7. Bazelisk binary provided by Nix devShell (on PATH)
-8. Installs PATH shims at `<session_dir>/bin/{bazelisk,bazel,bb,bbr}` — small
-   shell scripts that `exec claude-hook shim <name>` (PATH-resolved at invocation
-   time). The Rust shim runtime resolves the real binary outside the shim dir
-   and never calls back into the session-start daemon.
+Installs PATH shims at `<session_dir>/bin/{bazelisk,bazel,bb,bbr}` — small
+shell scripts that `exec claude-hook shim <name>` (PATH-resolved at invocation
+time). The Rust shim runtime resolves the real binary outside the shim dir
+and never calls back into the session-start daemon.
 
-   `bazel` and `bazelisk` inject the session bazelrc and translate any inherited
-   `HTTP_PROXY` / `HTTPS_PROXY` value into Java proxy JVM properties so Bazel's
-   grpc-java clients can reach BuildBuddy through Claude's proxy. `bb` and `bbr`
-   are real-binary resolution wrappers only.
+`bazel` and `bazelisk` inject the session bazelrc and translate any inherited
+`HTTP_PROXY` / `HTTPS_PROXY` value into Java proxy JVM properties so Bazel's
+grpc-java clients can reach BuildBuddy through Claude's proxy. `bb` and `bbr`
+are real-binary resolution wrappers only.
 
-   The `git` shim is installed only when the active profile enables at least one
-   `git_shim` safety flag. Its per-flag policy can block `git add -A` / `git add .`,
-   `git stash`, or `git commit --amend`.
+The `git` shim is installed only when the active profile enables at least one
+`git_shim` safety flag. Its per-flag policy can block `git add -A` / `git add .`,
+`git stash`, or `git commit --amend`.
 
-   Because `claude-hook` is resolved via PATH at exec time (not baked as a store
-   path at install time), `nix profile install` / `home-manager switch` takes
-   effect for all subsequent shim invocations without restarting the session.
+Because `claude-hook` is resolved via PATH at exec time (not baked as a store
+path at install time), `nix profile install` / `home-manager switch` takes
+effect for all subsequent shim invocations without restarting the session.
 
-### Git Hooks
+### Git Hooks and Environment
 
-9. Installs git pre-commit hooks via pre-commit framework
-
-### Development Tools
-
-Note: flux, kustomize, helm are now Bazel-managed via `@multitool//tools/*`.
-Nix formatting uses `nixfmt` from the Nix devShell.
-
-### Environment Configuration
-
-12. Sets up environment variables in `CLAUDE_ENV_FILE`
-
-See `.claude/settings.json` for hook configuration.
+Installs git pre-commit hooks (pre-commit framework) and writes environment
+variables to `CLAUDE_ENV_FILE`. Bazelisk comes from the Nix devShell; flux,
+kustomize, helm are Bazel-managed via `@multitool//tools/*`; Nix formatting
+uses `nixfmt` from the devShell. See `.claude/settings.json` for hook
+configuration.
 
 ## Observed: `Setup` and `SessionStart` Use Different Session IDs
 
@@ -112,27 +95,6 @@ old ID, the client finds no socket for the old ID and tries to start a _second_ 
 - **Session-global files** (bazelisk binary at `~/.cache/claude-hooks/bazelisk`): shared
   across all session IDs, safe for concurrent daemons.
 
-## Historical: Explicit Egress Proxy
-
-Earlier Claude Code web containers injected `HTTPS_PROXY=http://<container_id>:<jwt>@<host>:<port>`
-into the process environment. The hook daemon previously ran a substantial
-subsystem under `devinfra/claude/auth_proxy/` to handle it:
-
-- Load the TLS inspection CA from `/usr/local/share/ca-certificates/swp-ca-production.crt`
-- Build a Java truststore (`cacerts.jks`) for Bazel JVM's HTTPS
-- Build a combined CA bundle (`combined_ca.pem`) for `SSL_CERT_FILE`, `CURL_CA_BUNDLE`, etc.
-- Start a UDS proxy (`UdsRemoteProxy`) that Bazel used via `--remote_proxy=unix:<path>`
-  to work around gRPC-Java's `Authenticator` installation timing bug with HTTP
-  CONNECT proxies.
-- A BES interceptor that inspected Bazel build events and forwarded them to BuildBuddy.
-
-Current containers reach the internet without any of that — outbound
-HTTPS to public hosts just works, and Anthropic's CA is already in the
-system CA bundle if TLS is being inspected somewhere upstream. The
-entire `auth_proxy/` subsystem was removed; see git log for the
-removal. If Anthropic reverts to explicit proxy env vars, restore the
-subsystem from history.
-
 ## Configuration
 
 | Environment Variable                    | Default | Description          |
@@ -146,6 +108,8 @@ See `settings.py` for the full configuration schema.
 
 ## References
 
+- [Claude Code Hooks API](https://docs.anthropic.com/en/docs/claude-code/hooks)
+- [Settings JSON Schema](https://json.schemastore.org/claude-code-settings.json)
 - [Claude Code on the Web](https://www.anthropic.com/news/claude-code-on-the-web) - Product announcement
 - [Claude Code Sandboxing](https://www.anthropic.com/engineering/claude-code-sandboxing) - Network isolation architecture
 - [Enterprise Network Configuration](https://docs.anthropic.com/en/docs/claude-code/corporate-proxy) - Proxy and CA configuration
@@ -154,13 +118,7 @@ See `settings.py` for the full configuration schema.
 ## Files
 
 Agent shell files live under `<session_dir>` = `~/.claude/session-env/<session_id>/`.
-
-Historical Python container-runtime files (in `<session_dir>/supervisor/`):
-
-- `supervisord.conf` - Supervisor main configuration
-- `supervisord.{log,pid}` - Supervisor daemon state
-
-Note: the Rust daemon does not currently set up supervisor or Docker.
+The Rust daemon does not set up supervisor or Docker.
 
 Rust hook daemon files (in `/tmp/claude-hd/<session_id>/`):
 
@@ -170,22 +128,10 @@ Rust hook daemon files (in `/tmp/claude-hd/<session_id>/`):
 - `daemon.err.log` - Daemon stderr
 - `startup_failure.json` - client startup backoff marker
 
-## Known Limitations
+## Historical Context
 
-### Historical (gVisor era): 9p filesystem doesn't support Unix socket hard links
-
-**Affected**: gVisor-era Claude Code web sandbox, where root `/` was 9p.
-Current sessions run on Firecracker microVMs with an ext4 root, so the
-trigger no longer exists — kept because the TCP-socket configuration below is
-still what ships.
-
-**Root cause**: Supervisord uses hard links for atomic Unix socket creation (`link()` syscall). The 9p filesystem doesn't support hard linking Unix domain sockets, returning `EOPNOTSUPP` (errno 95). When the hard link fails, supervisord misinterprets this as a stale socket and enters an infinite retry loop.
-
-**Solution**: Use TCP socket (`inet_http_server`) instead of Unix socket. The supervisor_setup module now configures supervisor to listen on `127.0.0.1:19001` by default. This avoids the 9p filesystem limitation entirely.
-
-Configuration via environment variable:
-
-- `DUCKTAPE_CLAUDE_HOOKS_SUPERVISOR_PORT`: Override TCP port (default: 19001)
+The explicit egress proxy era (`auth_proxy/` subsystem) and the gVisor/9p origin of the
+TCP supervisor port: <archive/2026_06_12_gvisor_era_networking.md>.
 
 ## OTEL Tracing
 

--- a/devinfra/claude/archive/2026_06_12_gvisor_era_networking.md
+++ b/devinfra/claude/archive/2026_06_12_gvisor_era_networking.md
@@ -1,0 +1,44 @@
+# gVisor-Era Networking and Supervisor Workarounds
+
+Historical context for Claude Code web sessions before the Firecracker migration
+(pre-2026-06) and before Anthropic dropped the explicit egress proxy. Nothing here
+is current behavior; see <../README.md> § Networking for the current state.
+
+## Explicit Egress Proxy
+
+Earlier Claude Code web containers injected `HTTPS_PROXY=http://<container_id>:<jwt>@<host>:<port>`
+into the process environment. The hook daemon previously ran a substantial
+subsystem under `devinfra/claude/auth_proxy/` to handle it:
+
+- Load the TLS inspection CA from `/usr/local/share/ca-certificates/swp-ca-production.crt`
+- Build a Java truststore (`cacerts.jks`) for Bazel JVM's HTTPS
+- Build a combined CA bundle (`combined_ca.pem`) for `SSL_CERT_FILE`, `CURL_CA_BUNDLE`, etc.
+- Start a UDS proxy (`UdsRemoteProxy`) that Bazel used via `--remote_proxy=unix:<path>`
+  to work around gRPC-Java's `Authenticator` installation timing bug with HTTP
+  CONNECT proxies.
+- A BES interceptor that inspected Bazel build events and forwarded them to BuildBuddy.
+
+Current containers reach the internet without any of that — outbound HTTPS to public
+hosts just works, and Anthropic's CA is already in the system CA bundle if TLS is being
+inspected somewhere upstream. The entire `auth_proxy/` subsystem was removed; see git
+log for the removal. If Anthropic reverts to explicit proxy env vars, restore the
+subsystem from history.
+
+## 9p Filesystem: No Unix Socket Hard Links (origin of the TCP supervisor port)
+
+**Affected**: gVisor-era Claude Code web sandbox, where root `/` was 9p. Current
+sessions run on Firecracker microVMs with an ext4 root, so the trigger no longer
+exists — recorded because the TCP-socket configuration below is still what ships.
+
+**Root cause**: Supervisord uses hard links for atomic Unix socket creation (`link()`
+syscall). The 9p filesystem doesn't support hard linking Unix domain sockets, returning
+`EOPNOTSUPP` (errno 95). When the hard link fails, supervisord misinterprets this as a
+stale socket and enters an infinite retry loop.
+
+**Solution**: TCP socket (`inet_http_server`) on `127.0.0.1:19001` instead of a Unix
+socket (`DUCKTAPE_CLAUDE_HOOKS_SUPERVISOR_PORT` overrides the port).
+
+## Python Container-Runtime Files
+
+The retired Python daemon kept supervisor state in `<session_dir>/supervisor/`:
+`supervisord.conf`, `supervisord.{log,pid}`.

--- a/skills/knowledge_hygiene/SKILL.md
+++ b/skills/knowledge_hygiene/SKILL.md
@@ -101,7 +101,7 @@ Examples of information to remove or compress:
 - Boilerplate descriptions of fixtures, examples, or generated files where the filename and surrounding convention already convey the same fact
 - Copied lists like "service `xyzzy` permits `foo` values `bar`, `baz`, `quux`" when `xyzzy.yaml` is the real owner of allowed values
 
-If a standard mechanism differs here in one respect, keep only the delta and point to the standard mechanism briefly. Example: "This is a Foo framework job; use normal `fooctl` job commands. Delta: the job needs the `analytics-prod` profile."
+If a standard mechanism differs here in one respect, keep only the deviation and point to the standard mechanism briefly. Example: "This is a Foo framework job; use normal `fooctl` job commands. Deviation: the job needs the `analytics-prod` profile."
 Usually replace volatile mirrors with a pointer plus any durable meaning, policy, or gotcha the source does not contain. Generated Markdown/reference output is an exception, not the default; suggest it only when readers genuinely need the full volatile list inline and there is already a natural generation path.
 
 ### 5. Token-Cost Sweep

--- a/skills/knowledge_hygiene/SKILL.md
+++ b/skills/knowledge_hygiene/SKILL.md
@@ -20,7 +20,7 @@ Audit artifacts such as:
 - Issue/PR templates, release notes, changelogs, operational checklists, and automation output meant to be read as guidance
 
 Code, config, tests, schemas, and runtime probes are evidence sources, not the primary target, unless the user explicitly expands scope.
-Comments and docstrings are in scope when the problem is informational: e.g. they restate the name/signature, repeat obvious type facts, or describe a generic framework behavior without a local twist.
+Comments and docstrings are in scope when the problem is informational: e.g. they restate the name/signature, repeat obvious type facts, or describe a generic framework behavior without a local deviation.
 
 ## Non-Goals
 

--- a/skills/knowledge_hygiene/SKILL.md
+++ b/skills/knowledge_hygiene/SKILL.md
@@ -101,10 +101,38 @@ Examples of information to remove or compress:
 - Boilerplate descriptions of fixtures, examples, or generated files where the filename and surrounding convention already convey the same fact
 - Copied lists like "service `xyzzy` permits `foo` values `bar`, `baz`, `quux`" when `xyzzy.yaml` is the real owner of allowed values
 
-If a standard mechanism has one local wrinkle, keep only the wrinkle and point to the standard mechanism briefly. Example: "This is a Foo framework job; use normal `fooctl` job commands. Local wrinkle: the job needs the `analytics-prod` profile."
+If a standard mechanism differs here in one respect, keep only the delta and point to the standard mechanism briefly. Example: "This is a Foo framework job; use normal `fooctl` job commands. Delta: the job needs the `analytics-prod` profile."
 Usually replace volatile mirrors with a pointer plus any durable meaning, policy, or gotcha the source does not contain. Generated Markdown/reference output is an exception, not the default; suggest it only when readers genuinely need the full volatile list inline and there is already a natural generation path.
 
-### 5. Rank Suggestions
+### 5. Token-Cost Sweep
+
+Token cost = size × load frequency. Inventory which surfaces are **always loaded**
+into agent context versus read on demand:
+
+- The instruction-file transclusion closure from repo root (e.g. `CLAUDE.md` →
+  `AGENTS.md` → `README.md` + `@`-transcluded topic docs + style guides) — every session
+- Skill `description:` frontmatter, MCP server instructions, generated session
+  banners — every session
+- Per-tree instruction files (transcluding their READMEs) — every session touching
+  that tree
+- Everything else — only when actually read
+
+A 100-token cut in an always-loaded file outweighs a 1,000-token cut in an on-demand
+doc. Sweep the always-loaded surfaces for, in descending value:
+
+- **Teaching material for generic practice**: good/bad example pairs and rationale
+  paragraphs for rules a strong model already follows. State the rule in one
+  imperative line; keep an example only when it defines a repo-specific format.
+- **Task-specific docs transcluded wholesale**: convert the transclusion to a one-line
+  pointer so the doc loads on demand.
+- **Duplication with skills or reference docs**: keep the two-line essentials inline
+  and point at the canonical recipe.
+- **Human-oriented depth shipped to agents via README transclusion**: deep reference,
+  setup walkthroughs, and historical context move to linked (not transcluded) docs.
+- **Repetition for emphasis**: a rule stated three times with escalating bold is one
+  rule.
+
+### 6. Rank Suggestions
 
 Score each candidate by:
 
@@ -113,6 +141,7 @@ Score each candidate by:
 - Cost: small edit, link/redirect, consolidation, archive/tombstone, source-of-truth pointer, ownership/process change
 - Blast radius: one page, topic cluster, repo-wide docs, external KB, runtime docs
 - Decay rate: likelihood of drifting further if ignored
+- Load frequency: always-loaded agent context outweighs on-demand reading
 
 Favor high-confidence, high-impact, low-cost fixes first.
 


### PR DESCRIPTION
Cuts the always-loaded agent context chain (`CLAUDE.md` → `AGENTS.md` → `README.md` + `STYLE.md` + transcluded topic docs) from ~8,100 to ~4,400 words — pedagogy and duplication removed, no repo-specific rule or gotcha lost. Follow-up to #2172 from the knowledge-hygiene audit.

- **STYLE.md** (4,160 → 1,597 words): every rule as a one-line imperative; good/bad example blocks for generic practice removed; examples kept only where they define a repo-specific format (tombstone `CLEANUP` tag, `main_module` pattern, link syntax, brace expansion)
- **AGENTS.md** (2,417 → 1,974): the three `bbapi` recipe sections collapsed into one short "Build outputs and invocation data" block pointing at the `/buildbuddy_api` skill; Docker-on-RBE rule stated once instead of three times; `container-images.md` and `syrupy_snapshots.md` demoted from `@`-transclusion to on-demand pointers
- **cluster/README.md** (1,270 → 1,040): GPU/CDI stack → `cluster/docs/gpu.md`, ActivityWatch reference → `cluster/docs/activitywatch.md`, short pointers left behind; inference doc anchor updated
- **devinfra/claude/README.md** (1,537 → 1,216): egress-proxy era + gVisor/9p supervisor history → `devinfra/claude/archive/2026_06_12_gvisor_era_networking.md`; duplicate `## References` sections merged; orphaned step numbering cleaned
- **knowledge_hygiene skill**: new "Token-Cost Sweep" process step (weight findings by size × load frequency, always-loaded surfaces first) and a load-frequency ranking criterion; "local wrinkle" phrasing → "deviation"

Markdown-only; all pre-commit hooks pass.

https://claude.ai/code/session_01V3sFwY3cRo49gae9A1ppnC