### PR TITLE
[codex] Allow Codex GitHub PR app tools

### DIFF
--- a/nix/home/codex/default.nix
+++ b/nix/home/codex/default.nix
@@ -94,6 +94,20 @@ let
     history = {
       persistence = "save-all";
     };
+    apps = {
+      github = {
+        tools = {
+          # Raw codex_apps GitHub connector tool names exposed as
+          # mcp__codex_apps__github.<tool>.
+          _create_pull_request = {
+            approval_mode = "approve";
+          };
+          _update_pull_request = {
+            approval_mode = "approve";
+          };
+        };
+      };
+    };
     # Pair the built-in trusted-command heuristic with our generated execpolicy
     # allow rules under $CODEX_HOME/rules/default.rules so safe commands auto-run,
     # while the agent can explicitly request approval to run other commands

--- a/nix/home/codex/merge_test.py
+++ b/nix/home/codex/merge_test.py
@@ -97,5 +97,41 @@ def test_main_prints_unmanaged_toml_and_preserves_live_only_config(tmp_path, mon
     assert result["projects"]["/repo"]["trust_level"] == "trusted"
 
 
+def test_main_adds_github_pr_app_tool_approvals(tmp_path, monkeypatch) -> None:
+    base = tmp_path / "config.nix-base.toml"
+    live = tmp_path / "config.toml"
+    base.write_text(
+        textwrap.dedent(
+            """
+            [apps.github.tools._create_pull_request]
+            approval_mode = "approve"
+
+            [apps.github.tools._update_pull_request]
+            approval_mode = "approve"
+            """
+        )
+    )
+    live.write_text(
+        textwrap.dedent(
+            """
+            model = "local"
+
+            [apps.github]
+            enabled = true
+            """
+        )
+    )
+    monkeypatch.setenv("BASE", str(base))
+    monkeypatch.setenv("LIVE", str(live))
+
+    merge.main()
+
+    result = tomllib.loads(live.read_text())
+    assert result["model"] == "local"
+    assert result["apps"]["github"]["enabled"] is True
+    assert result["apps"]["github"]["tools"]["_create_pull_request"]["approval_mode"] == "approve"
+    assert result["apps"]["github"]["tools"]["_update_pull_request"]["approval_mode"] == "approve"
+
+
 if __name__ == "__main__":
     pytest_bazel.main()


### PR DESCRIPTION
## Summary

- Configure Codex Home Manager settings to approve the GitHub app connector PR creation and PR update tools by default.
- Add a merge regression test showing the generated app-tool approvals are added to an existing live Codex config without clobbering existing `[apps.github]` settings.

## Why

Codex PR workflows use the `codex_apps` GitHub connector, not shell `gh pr create`. The relevant raw tool names are `_create_pull_request` and `_update_pull_request`, so the persistent approval belongs under `apps.github.tools` in Codex config.

## Validation

- `pre-commit run --files nix/home/codex/default.nix nix/home/codex/merge_test.py`
- `bbr test //nix/home/codex:merge_test`
- `nix build --impure .#nixosConfigurations.rugged.config.home-manager.users.agentydragon.home.activationPackage`