### PR TITLE
[codex] Improve class source_match diagnostics

### DIFF
--- a/devinfra/js/debundle/docs/guide.md
+++ b/devinfra/js/debundle/docs/guide.md
@@ -506,6 +506,13 @@ leftmost is used; that interior choice never changes _which_ declaration
 matched, and a selector that matches more than one top-level declaration is
 still a hard error.
 
+For class fingerprints, keep method bodies as loose as the selector permits.
+If a stable method name and order are the real anchors, put `STMT_LIST;` in the
+method body and let `CLASS_REST;` absorb unrelated members. Spell concrete
+statements inside an anchored method only when those statements are part of the
+intended fingerprint; otherwise small upstream body drift will make the class
+miss even though the method anchors are still present.
+
 A hole works in **any** position — leading, middle, or trailing. Under
 `alpha_all`, identifiers match by an alpha-correspondence the matcher builds as
 it walks both trees, and a hole never contributes the identifiers it absorbs,

--- a/devinfra/js/debundle/e2e/syntactic_holes_test.rs
+++ b/devinfra/js/debundle/e2e/syntactic_holes_test.rs
@@ -668,9 +668,98 @@ export { Counter };
         &[
             "static/app::shapes",
             "did not match",
-            "Nearest candidate: top-level body index 0",
+            "Nearest class candidates:",
             "declares `Counter`",
             "selector class pinned member `a`",
+        ],
+    );
+}
+
+#[test]
+fn class_source_match_miss_reports_best_anchored_class_candidate() {
+    // The selector has all of the intended class's method anchors in order,
+    // but one method body is too exact. Diagnostics should point at that class
+    // and body mismatch, not at a later unrelated class that merely misses an
+    // anchor method.
+    let opts = FixtureOpts::new(
+        r#"class CatalogCache {
+  field = new Map();
+  constructor() {
+    this.ready = true;
+  }
+  refreshEntriesNow(scope, filter) {
+    if (filter.enabled) {
+      this.loadBatch(scope, filter);
+    }
+  }
+  loadBatch(scope, filter) {
+    return scope.prefix + filter.kind;
+  }
+  lookupEntryByKey(key, record) {
+    return key + record.id;
+  }
+  dropEntryByKey(key, record) {
+    return key;
+  }
+}
+class LaterCatalog {
+  configure() {
+    return true;
+  }
+  loadBatch(scope, filter) {
+    return scope.prefix + filter.kind;
+  }
+  lookupEntryByKey(key, record) {
+    return key + record.id;
+  }
+  dropEntryByKey(key, record) {
+    return key;
+  }
+}
+console.log(new CatalogCache().lookupEntryByKey("a", { id: "b" }));
+export { CatalogCache };
+"#,
+        vec![logical_module(
+            "catalog",
+            &[Member::source_alpha(
+                "CatalogCache",
+                r#"class K {
+  CLASS_REST;
+  refreshEntriesNow(scope, filter) {
+    if (filter.active) {
+      this.loadBatch(scope, filter);
+    }
+  }
+  CLASS_REST;
+  loadBatch(scope, filter) {
+    STMT_LIST;
+  }
+  CLASS_REST;
+  lookupEntryByKey(key, record) {
+    STMT_LIST;
+  }
+  CLASS_REST;
+  dropEntryByKey(key, record) {
+    STMT_LIST;
+  }
+  CLASS_REST;
+}"#,
+            )],
+        )],
+    );
+
+    expect_rejection_containing_all(
+        opts,
+        &[
+            "static/app::catalog",
+            "did not match",
+            "Nearest class candidates:",
+            "declares `CatalogCache`",
+            "members: `field`, `constructor`, `refreshEntriesNow`",
+            "matched 4/4 pinned member names in order",
+            "class member `refreshEntriesNow` matched by name",
+            "declares `LaterCatalog`",
+            "matched 0/4 pinned member names in order",
         ],
     );
 }

--- a/devinfra/js/debundle/source_match.rs
+++ b/devinfra/js/debundle/source_match.rs
@@ -1195,6 +1195,15 @@ struct MismatchReason {
     reason: String,
 }
 
+struct ClassCandidateHint {
+    body_idx: usize,
+    declared: Vec<String>,
+    member_labels: Vec<String>,
+    matched_pinned_labels: usize,
+    pinned_label_count: usize,
+    reason: MismatchReason,
+}
+
 fn source_match_no_match_hint(
     runtime_module: &Module,
     selector: &AnonymousStatementSelector,
@@ -1210,6 +1219,15 @@ fn source_match_no_match_hint(
     let wildcard_idents = wildcard_ident_names(needle);
     let alpha = selector.identifiers == SourceMatchIdentifierMode::AlphaAll;
     SyntaxContext::within_ignored_ctxt(|| {
+        if let Some(hint) = class_source_match_no_match_hint(
+            runtime_module,
+            needle,
+            selector,
+            &wildcard_idents,
+            alpha,
+        ) {
+            return Some(hint);
+        }
         runtime_module
             .body
             .iter()
@@ -1246,6 +1264,187 @@ fn source_match_no_match_hint(
                 )
             })
     })
+}
+
+fn class_source_match_no_match_hint(
+    runtime_module: &Module,
+    needle: &ModuleItem,
+    selector: &AnonymousStatementSelector,
+    wildcard_idents: &WildcardIdents,
+    alpha: bool,
+) -> Option<String> {
+    let needle_class = module_item_class_decl(needle)?;
+    let pinned_label_count = needle_class
+        .class
+        .body
+        .iter()
+        .filter(|member| !is_class_rest_hole(member) && class_member_label(member).is_some())
+        .count();
+    if pinned_label_count == 0 {
+        return None;
+    }
+
+    let mut candidates = runtime_module
+        .body
+        .iter()
+        .enumerate()
+        .filter_map(|(body_idx, candidate)| {
+            let candidate_class = module_item_class_decl(candidate)?;
+            let reason = first_class_decl_mismatch_reason(
+                needle_class,
+                candidate_class,
+                selector,
+                wildcard_idents,
+                alpha,
+            )?;
+            let declared = declared_bindings(candidate)
+                .into_iter()
+                .map(|binding| binding.binding_name)
+                .collect::<Vec<_>>();
+            let member_labels = candidate_class
+                .class
+                .body
+                .iter()
+                .filter_map(class_member_label)
+                .collect::<Vec<_>>();
+            let matched_pinned_labels = count_pinned_class_member_labels_in_order(
+                &needle_class.class,
+                &candidate_class.class,
+            );
+            Some(ClassCandidateHint {
+                body_idx,
+                declared,
+                member_labels,
+                matched_pinned_labels,
+                pinned_label_count,
+                reason,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    if candidates.is_empty() {
+        return None;
+    }
+
+    candidates.sort_by(|left, right| {
+        right
+            .matched_pinned_labels
+            .cmp(&left.matched_pinned_labels)
+            .then_with(|| right.reason.score.cmp(&left.reason.score))
+            .then_with(|| left.body_idx.cmp(&right.body_idx))
+    });
+
+    let rendered = candidates
+        .iter()
+        .take(3)
+        .map(render_class_candidate_hint)
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    Some(format!("\nNearest class candidates:\n{rendered}"))
+}
+
+fn first_class_decl_mismatch_reason(
+    needle: &ClassDecl,
+    candidate: &ClassDecl,
+    selector: &AnonymousStatementSelector,
+    wildcard_idents: &WildcardIdents,
+    alpha: bool,
+) -> Option<MismatchReason> {
+    let mut matcher = AstWildcardMatcher::new(selector, wildcard_idents, alpha);
+    if matcher.match_decl(
+        &Decl::Class(needle.clone()),
+        &Decl::Class(candidate.clone()),
+    ) {
+        return None;
+    }
+    Some(first_decl_mismatch_reason(
+        &Decl::Class(needle.clone()),
+        &Decl::Class(candidate.clone()),
+        selector,
+        wildcard_idents,
+        alpha,
+    ))
+}
+
+fn render_class_candidate_hint(candidate: &ClassCandidateHint) -> String {
+    let declared_hint = if candidate.declared.is_empty() {
+        "declares no bindings".to_string()
+    } else {
+        format!(
+            "declares {}",
+            candidate
+                .declared
+                .iter()
+                .map(|name| format!("`{name}`"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    };
+    let member_hint = render_class_member_labels(&candidate.member_labels);
+    format!(
+        "- top-level body index {body_idx} ({declared_hint}); members: {member_hint}; \
+         matched {matched}/{total} pinned member names in order. First mismatch: {reason}",
+        body_idx = candidate.body_idx,
+        matched = candidate.matched_pinned_labels,
+        total = candidate.pinned_label_count,
+        reason = candidate.reason.reason,
+    )
+}
+
+fn render_class_member_labels(labels: &[String]) -> String {
+    const MAX_LABELS: usize = 12;
+    if labels.is_empty() {
+        return "<none>".to_string();
+    }
+    let mut rendered = labels
+        .iter()
+        .take(MAX_LABELS)
+        .map(|label| format!("`{label}`"))
+        .collect::<Vec<_>>();
+    if labels.len() > MAX_LABELS {
+        rendered.push(format!("... +{} more", labels.len() - MAX_LABELS));
+    }
+    rendered.join(", ")
+}
+
+fn count_pinned_class_member_labels_in_order(needle: &Class, candidate: &Class) -> usize {
+    let mut candidate_start = 0;
+    let mut matched = 0;
+    for needle_member in &needle.body {
+        if is_class_rest_hole(needle_member) {
+            continue;
+        }
+        let Some(needle_label) = class_member_label(needle_member) else {
+            continue;
+        };
+        let Some(candidate_idx) = candidate
+            .body
+            .iter()
+            .enumerate()
+            .skip(candidate_start)
+            .find_map(|(candidate_idx, candidate_member)| {
+                (class_member_label(candidate_member).as_deref() == Some(needle_label.as_str()))
+                    .then_some(candidate_idx)
+            })
+        else {
+            break;
+        };
+        matched += 1;
+        candidate_start = candidate_idx + 1;
+    }
+    matched
+}
+
+fn module_item_class_decl(item: &ModuleItem) -> Option<&ClassDecl> {
+    match item {
+        ModuleItem::Stmt(Stmt::Decl(Decl::Class(class))) => Some(class),
+        ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
+            decl: Decl::Class(class),
+            ..
+        })) => Some(class),
+        _ => None,
+    }
 }
 
 fn first_mismatch_reason(


### PR DESCRIPTION
## Summary

Improve `source_match` no-match diagnostics for class selectors that use `CLASS_REST` and interior method anchors.

When a class selector misses, Ducktape now reports the nearest class candidates separately, including declared bindings, visible member labels, how many pinned selector members matched in order, and the first mismatch reason. This makes it easier to trim class selectors down to stable method anchors plus `STMT_LIST` bodies instead of copying large implementation bodies or falling back to minified names.

The guide now explicitly recommends using `STMT_LIST;` inside anchored methods when method name/order is the stable signal.

## Root Cause / Use Case

The existing generic nearest-candidate ranking could choose an unrelated later class because a "missing pinned member" scored higher than the intended class whose pinned method names were present but whose body/signature differed. That made lean class skeleton selectors hard to debug: the error pointed at the wrong class and did not show the candidate method names.

This PR keeps matching semantics unchanged and only improves class-specific miss diagnostics.

## Backlog Triage

Current debundle selector lane priority after this PR:

1. Contextual `near`/`before`/`after` selectors or groups for helper/decorator boilerplate adjacent to a distinctive class/decorator call.
2. Literal initializer selector for unique top-level literal-initialized bindings, following `plans/literal_initializer_selector.md`.
3. Better multi-declarator / anonymous statement grouping with holes so specs can avoid duplicated overlapping selectors.
4. Source-aware selector debt/perf diagnostics for broad holes and near-ambiguous structural matches.
5. Duplicate-claim diagnostics by declaration identity.

## Validation

- `nix develop -c rustfmt devinfra/js/debundle/source_match.rs devinfra/js/debundle/e2e/syntactic_holes_test.rs`
- `nix develop -c bazelisk --output_base=/tmp/bazel-ducktape-class-hole test //devinfra/js/debundle/e2e:syntactic_holes_test --config=ci --config=rbe --remote_upload_local_results=false --remote_download_outputs=all --test_output=errors`
- `nix develop -c pre-commit run --files devinfra/js/debundle/source_match.rs devinfra/js/debundle/e2e/syntactic_holes_test.rs devinfra/js/debundle/docs/guide.md`

Note: a plain `git commit` hook run failed outside `nix develop` because ambient `rustfmt`, `prettier`, and Ducktape hook binaries were not on PATH; the same pre-commit file set passed under `nix develop`, so the commit was made with `--no-verify`.