### PR TITLE
[codex] Add binding group comment regressions

### DIFF
--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -187,6 +187,25 @@ private corpus details in Ducktape.
   helper declaration may be syntactically identical across many classes,
   but it becomes unambiguous when selected near the class or decorator
   calls whose property strings identify the target.
+- **Combined binding-and-statement groups.** Add or design one selector form
+  that matches a short top-level source window once, exports one or more
+  bindings from it, and claims selected anonymous statements from the same
+  matched window. The motivating generic shape is a declaration plus adjacent
+  side-effect assignments:
+
+  ```js
+  let recordBridge, replayBridge;
+  condition && (replayBridge = api.replay);
+  condition || (recordBridge = api.record);
+  ```
+
+  Today authors must duplicate the same `source_match` body once under
+  `binding_groups:` for the declarators and again under
+  `anonymous_statements:` with `target_statements: [1, 2]` for the side-effect
+  statements. A combined form should support explicit statement indices, an
+  `all` mode consistent with anonymous `target_statements`, and diagnostics
+  that identify whether binding capture or statement-target resolution failed.
+
 - **Constrained hole matching.** Multi-hole selectors need cheap local
   constraints so authors can say that a hole appears only as a specific
   argument, callback body, object property value, or statement-list slot. This

--- a/devinfra/js/debundle/e2e/syntactic_holes_test.rs
+++ b/devinfra/js/debundle/e2e/syntactic_holes_test.rs
@@ -311,6 +311,72 @@ export { first, second };
 }
 
 #[test]
+fn binding_group_comments_emit_for_adopted_names() {
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"const primary = 10, secondary = 20;
+console.log(primary + secondary);
+export { primary, secondary };
+"#,
+        vec![logical_module_with_binding_groups(
+            "settings",
+            &[],
+            &[BindingGroup::source_alpha_adopt_all(
+                r#"const primary = EXPR_PRIMARY, secondary = EXPR_SECONDARY;"#,
+            )
+            .with_comments(&[
+                ("primary", "Primary selected value."),
+                ("secondary", "Secondary selected value."),
+            ])],
+        )],
+    ));
+
+    assert_entry_output(&fixture, "30\n");
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/modules/settings.js",
+        &[
+            "// Primary selected value.",
+            "const primary = 10",
+            "// Secondary selected value.",
+            "secondary = 20",
+        ],
+        &[],
+    );
+}
+
+#[test]
+fn binding_group_comments_reject_unknown_selector_local_key() {
+    let opts = FixtureOpts::new(
+        r#"const primary = 10, secondary = 20;
+console.log(primary + secondary);
+export { primary, secondary };
+"#,
+        vec![logical_module_with_binding_groups(
+            "settings",
+            &[],
+            &[BindingGroup::source_alpha_adopt_names(
+                r#"const primary = EXPR_PRIMARY, secondary = EXPR_SECONDARY;"#,
+                &["primary"],
+            )
+            .with_comments(&[
+                ("primary", "Primary selected value."),
+                ("secondary", "This binding is not exported by the group."),
+            ])],
+        )],
+    );
+
+    expect_rejection_containing_all(
+        opts,
+        &[
+            "static/app::settings",
+            "binding_groups[].comments",
+            "not exported by the group",
+            "secondary",
+        ],
+    );
+}
+
+#[test]
 fn member_source_match_declarator_holes_select_binding_from_wider_const_list() {
     let fixture = run_fixture(FixtureOpts::new(
         r#"const runtimePrefix = "prefix",

--- a/devinfra/js/debundle/spec_modules.rs
+++ b/devinfra/js/debundle/spec_modules.rs
@@ -373,6 +373,42 @@ members:
     }
 
     #[test]
+    fn read_module_file_accepts_binding_group_comments() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("x.yaml");
+        fs::write(
+            &path,
+            r#"binding_groups:
+  - source_match:
+      identifiers: alpha_all
+      match: "const primary = EXPR_PRIMARY, secondary = EXPR_SECONDARY;"
+    adopt_names: true
+    comments:
+      primary: |
+        Primary selected value.
+      secondary: Secondary selected value.
+"#,
+        )
+        .unwrap();
+
+        let module = read_module_file(&path).unwrap();
+        assert_eq!(module.binding_groups.len(), 1);
+        assert_eq!(
+            module.binding_groups[0].comments,
+            BTreeMap::from([
+                (
+                    "primary".to_string(),
+                    "Primary selected value.\n".to_string()
+                ),
+                (
+                    "secondary".to_string(),
+                    "Secondary selected value.".to_string()
+                ),
+            ]),
+        );
+    }
+
+    #[test]
     fn read_module_file_accepts_comment_field_on_anonymous_statement() {
         // `AnonymousStatement` accepts `comment:` alongside `note:`
         // (both `Option<String>`). `comment:` is the JS-visible prose


### PR DESCRIPTION
## Summary

Pin `binding_groups[].comments` behavior with focused generic tests:

- parser accepts `comments:` inside a binding group
- comments keyed by selector-local names emit for `adopt_names: true`
- comments whose selector-local key is not exported by the group fail with a useful diagnostic

Current `devel` already contains the core `binding_groups[].comments` plumbing, so this PR keeps the change scoped to acceptance coverage and the related backlog note.

## Follow-up Tracked

Added a `TODO.md` item for a combined binding-and-statement group selector. The desired form should match one source window once, export selected bindings, and claim selected anonymous statements from that same match, avoiding duplicated `binding_groups:` and `anonymous_statements:` templates.

## Validation

- `nix develop -c rustfmt devinfra/js/debundle/e2e/syntactic_holes_test.rs devinfra/js/debundle/spec_modules.rs`
- `nix develop -c bazelisk --output_base=/tmp/bazel-ducktape-binding-group-comments test //devinfra/js/debundle/e2e:syntactic_holes_test //devinfra/js/debundle:spec_modules_test --config=ci --config=rbe --remote_upload_local_results=false --remote_download_outputs=all --test_output=errors`
- `nix develop -c pre-commit run --files devinfra/js/debundle/e2e/syntactic_holes_test.rs devinfra/js/debundle/spec_modules.rs devinfra/js/debundle/TODO.md`