### PR TITLE
[codex] Add trailing declarator hole regression

### DIFF
--- a/devinfra/js/debundle/e2e/syntactic_holes_test.rs
+++ b/devinfra/js/debundle/e2e/syntactic_holes_test.rs
@@ -472,6 +472,42 @@ export { runtimePrefix, runtimeFormat, runtimeLabels, runtimeRead, runtimeSuffix
 }
 
 #[test]
+fn binding_group_trailing_declarator_hole_absorbs_later_declarators() {
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"const selectedA = () => "a",
+  selectedB = () => "b",
+  laterC = () => "c";
+console.log(selectedA() + selectedB() + laterC());
+export { selectedA, selectedB, laterC };
+"#,
+        vec![logical_module_with_binding_groups(
+            "bridges",
+            &[],
+            &[BindingGroup::source_alpha(
+                r#"const selectedA = EXPR_A,
+  selectedB = EXPR_B,
+  DECLARATORS_AFTER = null;"#,
+                &[("selectedA", "recordBridge"), ("selectedB", "replayBridge")],
+            )],
+        )],
+    ));
+
+    assert_entry_output(&fixture, "abc\n");
+    assert_module_exports(
+        &fixture.out_root,
+        "static/app/modules/bridges.js",
+        &["recordBridge", "replayBridge"],
+        &["selectedA", "selectedB"],
+    );
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/modules/bridges.js",
+        &["const recordBridge", "const replayBridge"],
+        &["laterC", "DECLARATORS_AFTER"],
+    );
+}
+
+#[test]
 fn anonymous_source_match_stmt_prefix_hole_matches_arbitrary_nested_statement() {
     let fixture = run_fixture(FixtureOpts::new(
         r#"if (true) {


### PR DESCRIPTION
## Summary

Add a focused generic e2e regression for `DECLARATORS_AFTER = null` in a `binding_groups[].source_match` selector.

The fixture pins two leading declarators, uses a trailing declarator-list hole, and verifies the selector matches a longer top-level `const` declaration while exporting only the two pinned bindings. This captures the downstream-reported shape without private corpus names or code.

## Notes

Current `devel` already supports this shape; the new test passed without matcher changes. If downstream still reports `selector has 3 declarator(s), candidate has 2`, that likely indicates an older pinned Ducktape binary or a nearby selector variant not covered by this exact generic shape.

## Validation

- `nix develop -c rustfmt devinfra/js/debundle/e2e/syntactic_holes_test.rs`
- `nix develop -c bazelisk --output_base=/tmp/bazel-ducktape-trailing-declarator-hole test //devinfra/js/debundle/e2e:syntactic_holes_test --config=ci --config=rbe --remote_upload_local_results=false --remote_download_outputs=all --test_output=errors`
- `nix develop -c pre-commit run --files devinfra/js/debundle/e2e/syntactic_holes_test.rs`