### PR TITLE
[codex] Fix contextual target_binding alpha matching

### DIFF
--- a/devinfra/js/debundle/docs/guide.md
+++ b/devinfra/js/debundle/docs/guide.md
@@ -291,6 +291,27 @@ members:
             address = `${localPart}@${domain}`;
 ```
 
+When the selected declaration is too generic by itself, include adjacent
+top-level statements as context in the same `match`. The whole statement range
+must match uniquely, but only `target_binding` is claimed:
+
+```yaml
+members:
+  - name: selectedSessions
+    selector:
+      source_match:
+        identifiers: alpha_all
+        target_binding: sessions
+        match: |
+          const sessions = new Map(EXPR);
+          function closeSessions() {
+            return sessions.clear();
+          }
+          function getSession(name) {
+            return sessions.get(name);
+          }
+```
+
 Use `binding_groups` when several exports come from the same
 multi-declarator or short declaration context. This is sugar for several
 `members[].selector.source_match` entries with the same `match` and

--- a/devinfra/js/debundle/e2e/anonymous_statement_test.rs
+++ b/devinfra/js/debundle/e2e/anonymous_statement_test.rs
@@ -989,6 +989,51 @@ for (const context of traceContexts)
 }
 
 #[test]
+fn member_source_match_target_binding_uses_adjacent_function_consumers_as_context() {
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"const runtimeRecordSessions = new Map([["main", "record"]]);
+function closeRecordSessions() {
+  return runtimeRecordSessions.clear();
+}
+function getRecordSession(name) {
+  return runtimeRecordSessions.get(name);
+}
+const runtimeReplaySessions = new Map([["main", "replay"]]);
+function closeReplaySessions() {
+  return runtimeRecordSessions.clear();
+}
+function getReplaySession(name) {
+  return runtimeReplaySessions.get(name);
+}
+console.log(getRecordSession("main"), getReplaySession("main"));
+export { runtimeRecordSessions, runtimeReplaySessions };
+"#,
+        vec![logical_module(
+            "sessions",
+            &[Member::source_alpha_target(
+                "recordSessions",
+                "sessions",
+                r#"const sessions = new Map(EXPR);
+function closeSessions() {
+  return sessions.clear();
+}
+function getSession(name) {
+  return sessions.get(name);
+}"#,
+            )],
+        )],
+    ));
+
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/modules/sessions.js",
+        &["const recordSessions = new Map", "\"record\""],
+        &["runtimeReplaySessions"],
+    );
+    assert_entry_output(&fixture, "record replay\n");
+}
+
+#[test]
 fn member_source_match_variable_declarator_still_rejects_ambiguous_matches() {
     let opts = FixtureOpts::new(
         r#"const firstRuntime = { kind: "selected", enabled: true },

--- a/devinfra/js/debundle/source_match.rs
+++ b/devinfra/js/debundle/source_match.rs
@@ -1128,20 +1128,30 @@ fn find_matching_body_ranges(
     if needles.is_empty() || needles.len() > runtime_module.body.len() {
         return Vec::new();
     }
-    let prepared: Vec<PreparedNeedle> = needles
-        .iter()
-        .map(|needle| PreparedNeedle::new(needle, selector))
-        .collect();
+    if let [needle] = needles {
+        let prepared = PreparedNeedle::new(needle, selector);
+        return runtime_module
+            .body
+            .iter()
+            .enumerate()
+            .filter_map(|(body_idx, candidate)| prepared.matches(candidate).then_some(body_idx))
+            .collect();
+    }
+    let wildcard_idents = wildcard_ident_names_for_module_items(needles);
+    let alpha = selector.identifiers == SourceMatchIdentifierMode::AlphaAll;
     runtime_module
         .body
         .windows(needles.len())
         .enumerate()
         .filter_map(|(body_idx, candidates)| {
-            prepared
-                .iter()
-                .zip(candidates)
-                .all(|(needle, candidate)| needle.matches(candidate))
-                .then_some(body_idx)
+            SyntaxContext::within_ignored_ctxt(|| {
+                let mut matcher = AstWildcardMatcher::new(selector, &wildcard_idents, alpha);
+                needles
+                    .iter()
+                    .zip(candidates)
+                    .all(|(needle, candidate)| matcher.match_module_item(needle, candidate))
+            })
+            .then_some(body_idx)
         })
         .collect()
 }


### PR DESCRIPTION
## Summary

Fix multi-statement `members[].selector.source_match` selectors with `target_binding` so the whole matched top-level range shares one alpha/wildcard matcher.

This lets a member selector use adjacent top-level consumer functions as context to identify a generic singleton binding, while still claiming only the selected `target_binding`.

## Root Cause

`find_matching_body_ranges` previously prepared and matched each statement independently. For alpha selectors, that meant the target binding identifier could remap separately in each statement of a multi-statement selector. A selector like:

```js
const sessions = new Map(EXPR);
function closeSessions() { return sessions.clear(); }
function getSession(name) { return sessions.get(name); }
```

could incorrectly match a range where the declaration and each consumer function referenced different runtime bindings, because each statement rebuilt its own alpha environment.

The fix preserves the single-statement fast path but uses one `AstWildcardMatcher` across each multi-statement candidate range.

## Tests

Added a generic e2e fixture with two `new Map(...)` singleton declarations. The selected declaration is ambiguous alone; it becomes unique only when the following consumer functions reference the same selected binding. A nearby almost-match is rejected because one consumer points at the wrong singleton.

Existing coverage already checks ambiguity remains a hard error when contextual ranges still match multiple candidates.

## Docs

Updated the selector authoring guide to document multi-statement `target_binding` context: the full statement range must match uniquely, but only `target_binding` is claimed.

## Validation

- `nix develop -c rustfmt devinfra/js/debundle/source_match.rs devinfra/js/debundle/e2e/anonymous_statement_test.rs`
- `nix develop -c bazelisk --output_base=/tmp/bazel-ducktape-contextual-member-source-match test //devinfra/js/debundle/e2e:anonymous_statement_test --config=ci --config=rbe --remote_upload_local_results=false --remote_download_outputs=all --test_output=errors`
- `nix develop -c pre-commit run --files devinfra/js/debundle/source_match.rs devinfra/js/debundle/e2e/anonymous_statement_test.rs devinfra/js/debundle/docs/guide.md`