### PR TITLE
[codex] Fix debundle coverage source_match claims

### DIFF
--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -453,6 +453,8 @@ rust_library(
         ":analysis",
         ":anonymous_resolution",
         ":gate",
+        ":js_ast",
+        ":source_match",
         ":spec",
         ":spec_modules",
         "@crates//:anyhow",

--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -118,18 +118,6 @@ observed. (The `owner:<id>`-in-spec-notes framing that used to live here was
 stale — no such mechanism exists; `owner:N` ids are machine-generated graph
 keys and a `describe`/`show-source` input, not a spec authoring hint.)
 
-## Coverage views ignore `source_match` member claims
-
-The CLI edit gate now resolves `members[].selector.source_match` and
-`binding_groups:` claims through the same source-backed path `debundle run`
-uses (`spec_modules::ModuleClaims::{member_selectors,binding_groups}` +
-`anonymous_resolution::resolve_member_selector_claims`). The read-only
-coverage/describe views in `peel/plan.rs` still consume only
-`claims.bindings` + `claims.anonymous_selectors`, so a module whose members
-are claimed via `source_match` under-reports in `debundle coverage` /
-`describe <module>`. Diagnostics-only (no soundness impact); wire the same
-resolution through those views when it next matters.
-
 ## Completed-plan follow-ups
 
 - **Peel proposer contraction cleanup.** The quotient-contraction

--- a/devinfra/js/debundle/e2e/top_level_query_cli_test.rs
+++ b/devinfra/js/debundle/e2e/top_level_query_cli_test.rs
@@ -207,6 +207,54 @@ anonymous_statements:
     )
 }
 
+fn fixture_with_structural_member_claim(module_yaml: &str) -> (TempDir, CommonArgs) {
+    let dir = TempDir::new().unwrap();
+    let graph_path = dir.path().join("owner_graph.json");
+    let modules_root = dir.path().join("spec/modules");
+    let alpha = owner("owner:0", 0, "alpha", "alpha");
+    let beta = owner("owner:1", 1, "beta", "beta");
+    let report = OwnerGraphReport {
+        chunk_id: "static/index".to_string(),
+        nodes: vec![alpha.clone(), beta.clone()],
+        edges: Vec::new(),
+        quotient: OwnerGraphQuotientReport {
+            nodes: residual_table(),
+            edges: Vec::new(),
+            sccs: Vec::<QuotientSccReport>::new(),
+        },
+        atomic_graph: AtomicGraphReport {
+            nodes: vec![AtomicUnitReport {
+                id: "atomic:0".to_string(),
+                owner_ids: vec![alpha.id.clone(), beta.id.clone()],
+                members: vec![member("alpha", "alpha"), member("beta", "beta")],
+                anonymous_statement_owner_ids: Vec::new(),
+                destinations: vec![module_ref("residual")],
+                causes: Vec::new(),
+                size_lines_estimate: 2,
+                source_line_range: Some([1, 2]),
+                ordinal_span: 1,
+            }],
+            edges: Vec::new(),
+        },
+    };
+    write(&graph_path, &serde_json::to_string(&report).unwrap());
+    write(
+        &modules_root.join("features/structural_member.yaml"),
+        module_yaml,
+    );
+    write(
+        &dir.path().join("static/index.js"),
+        "const alpha = 1;\nconst beta = alpha + 1;\n",
+    );
+    (
+        dir,
+        CommonArgs {
+            owner_graph_path: graph_path,
+            modules_root,
+        },
+    )
+}
+
 fn fixture_with_anonymous_only_module_claim() -> (TempDir, CommonArgs) {
     let dir = TempDir::new().unwrap();
     let graph_path = dir.path().join("owner_graph.json");
@@ -254,6 +302,59 @@ fn fixture_with_anonymous_only_module_claim() -> (TempDir, CommonArgs) {
             modules_root,
         },
     )
+}
+
+fn assert_structural_member_claim_visible_to_queries(module_yaml: &str) {
+    let (_dir, common) = fixture_with_structural_member_claim(module_yaml);
+    let coverage = run_patch_plan_report(&PatchPlanArgs {
+        common: common.clone(),
+        limit: 0,
+        include_proposals: false,
+        source_root: None,
+        format: None,
+    })
+    .unwrap();
+
+    assert_eq!(coverage.summary.total_patch_sets, 1);
+    assert_eq!(coverage.summary.complete_patch_sets, 1);
+    assert_eq!(coverage.summary.split_patch_sets, 0);
+    let row = &coverage.rows[0];
+    assert_eq!(row.path, "features/structural_member");
+    assert_eq!(row.status, PatchPlanStatus::CompleteUnits);
+    assert_eq!(row.requested_binding_ids, vec!["alpha", "beta"]);
+    assert_eq!(row.complete_unit_ids, vec!["atomic:0"]);
+    assert!(row.missing_binding_ids.is_empty());
+    assert!(row.missing_owner_ids.is_empty());
+
+    let describe = run_explain_report(&ExplainArgs {
+        common,
+        selection: SelectionArgs {
+            owner_id: None,
+            module_path: Some("features/structural_member".to_string()),
+            module_id: None,
+            binding_id: None,
+            proposal_id: None,
+            unit_id: None,
+            diagnostic_id: None,
+        },
+        size_cap_lines: 10_000,
+        source_root: None,
+        limit: 0,
+        include_proposals: false,
+        format: None,
+    })
+    .unwrap();
+
+    assert_eq!(describe.owner_ids, vec!["owner:0", "owner:1"]);
+    assert_eq!(
+        describe
+            .bindings
+            .iter()
+            .map(|binding| binding.binding.as_str())
+            .collect::<Vec<_>>(),
+        vec!["alpha", "beta"]
+    );
+    assert_eq!(describe.atomic_units[0].id, "atomic:0");
 }
 
 fn fixture_with_ambiguous_anonymous_statements() -> (TempDir, CommonArgs) {
@@ -372,6 +473,32 @@ fn coverage_counts_anonymous_statement_selectors_as_claims() {
     assert_eq!(row.status, PatchPlanStatus::CompleteUnits);
     assert_eq!(row.complete_unit_ids, vec!["atomic:0"]);
     assert!(row.missing_anonymous_owner_ids.is_empty());
+}
+
+#[test]
+fn coverage_and_describe_count_source_match_member_selectors_as_claims() {
+    assert_structural_member_claim_visible_to_queries(
+        r#"members:
+  - name: Alpha
+    selector:
+      source_match:
+        match: 'const alpha = 1;'
+  - selector: { binding: { name: beta } }
+"#,
+    );
+}
+
+#[test]
+fn coverage_and_describe_count_binding_groups_as_member_claims() {
+    assert_structural_member_claim_visible_to_queries(
+        r#"binding_groups:
+  - source_match:
+      match: 'const alpha = 1;'
+    exports: { alpha: Alpha }
+members:
+  - selector: { binding: { name: beta } }
+"#,
+    );
 }
 
 #[test]

--- a/devinfra/js/debundle/peel/plan.rs
+++ b/devinfra/js/debundle/peel/plan.rs
@@ -14,7 +14,10 @@ use super::factorize::{
     DEFAULT_SIZE_CAP_LINES, FactorizeDiagnosticReport, FactorizeProposal, PeelFactorizeOptions,
     PeelFactorizeReport, analyze_peel_factorize, analyze_peel_factorize_on_graph,
 };
-use anonymous_resolution::{AnonymousStatementClaimSet, resolve_anonymous_statement_claims};
+use anonymous_resolution::{
+    AnonymousStatementClaimSet, MemberSelectorClaimSet, resolve_anonymous_statement_claims,
+    resolve_member_selector_claims,
+};
 use anyhow::{Context, Result, bail};
 use clap::{Args as ClapArgs, Subcommand, ValueEnum};
 use serde::Serialize;
@@ -1066,12 +1069,34 @@ fn patch_plan_rows(
             &claim_sets,
         )?
     };
+    let member_bindings_by_set = {
+        let claim_sets: Vec<MemberSelectorClaimSet> = patch_sets
+            .iter()
+            .map(|patch_set| MemberSelectorClaimSet {
+                module_path: &patch_set.file,
+                selectors: &patch_set.member_selectors,
+            })
+            .collect();
+        resolve_member_selector_claims(
+            graph,
+            owner_graph_path,
+            modules_root,
+            source_root,
+            &claim_sets,
+        )?
+    };
     patch_sets
         .into_iter()
         .zip(anonymous_owners_by_set)
-        .map(|(patch_set, anonymous_owners)| {
-            let mut requested_binding_ids: Vec<String> =
-                patch_set.bindings.iter().cloned().collect();
+        .zip(member_bindings_by_set)
+        .map(|((patch_set, anonymous_owners), member_bindings)| {
+            let claimed_bindings: BTreeSet<String> = patch_set
+                .bindings
+                .iter()
+                .chain(&member_bindings)
+                .cloned()
+                .collect();
+            let mut requested_binding_ids: Vec<String> = claimed_bindings.iter().cloned().collect();
             requested_binding_ids.sort();
 
             let mut requested_owner_ids = BTreeSet::<String>::new();
@@ -1110,7 +1135,7 @@ fn patch_plan_rows(
                 let unit_owners: BTreeSet<String> = unit.owner_ids.iter().cloned().collect();
                 let bindings_complete = unit_bindings
                     .iter()
-                    .all(|binding| patch_set.bindings.contains(binding));
+                    .all(|binding| claimed_bindings.contains(binding));
                 let owners_complete = unit_owners
                     .iter()
                     .all(|owner_id| requested_owner_ids.contains(owner_id));
@@ -1121,7 +1146,7 @@ fn patch_plan_rows(
                     missing_binding_ids.extend(
                         unit_bindings
                             .into_iter()
-                            .filter(|binding| !patch_set.bindings.contains(binding)),
+                            .filter(|binding| !claimed_bindings.contains(binding)),
                     );
                     missing_owner_ids.extend(
                         unit_owners
@@ -1169,6 +1194,7 @@ struct PatchSet {
     file: PathBuf,
     bindings: BTreeSet<String>,
     anonymous_selectors: BTreeSet<spec::AnonymousStatementSelector>,
+    member_selectors: BTreeSet<spec::AnonymousStatementSelector>,
 }
 
 fn load_patch_sets(modules_root: &Path) -> Result<Vec<PatchSet>> {
@@ -1184,6 +1210,7 @@ fn load_patch_sets(modules_root: &Path) -> Result<Vec<PatchSet>> {
             file: binding_patches_path,
             bindings: patch_bindings,
             anonymous_selectors: BTreeSet::new(),
+            member_selectors: BTreeSet::new(),
         });
     }
     for file in collect_module_files(modules_root)? {
@@ -1191,14 +1218,32 @@ fn load_patch_sets(modules_root: &Path) -> Result<Vec<PatchSet>> {
         if !claims.has_claims() {
             continue;
         }
+        let member_selectors = expanded_member_selectors(&file, &claims)?;
         sets.push(PatchSet {
             path: module_path_from_file(&file, modules_root),
             file,
             bindings: claims.bindings,
             anonymous_selectors: claims.anonymous_selectors,
+            member_selectors,
         });
     }
     Ok(sets)
+}
+
+fn expanded_member_selectors(
+    module_path: &Path,
+    claims: &spec_modules::ModuleClaims,
+) -> Result<BTreeSet<spec::AnonymousStatementSelector>> {
+    js_ast::with_swc_globals(|| {
+        let mut selectors = claims.member_selectors.clone();
+        let request_id = module_path.to_string_lossy();
+        for group in &claims.binding_groups {
+            for expanded in source_match::binding_group_member_selectors(&request_id, group)? {
+                selectors.insert(expanded.selector);
+            }
+        }
+        Ok(selectors)
+    })
 }
 
 /// Map each declared (minified) binding name to its owner id.
@@ -1486,6 +1531,25 @@ fn resolve_module_path_owner_ids(
     let mut owner_ids = BTreeSet::<String>::new();
     let mut unknown_binding_ids = Vec::<String>::new();
     for binding in &claims.bindings {
+        if let Some(owner_id) = binding_to_owner.get(binding) {
+            owner_ids.insert(owner_id.clone());
+        } else {
+            unknown_binding_ids.push(binding.clone());
+        }
+    }
+    let member_selectors = expanded_member_selectors(&yaml_path, &claims)?;
+    let member_claim_sets = [MemberSelectorClaimSet {
+        module_path: &yaml_path,
+        selectors: &member_selectors,
+    }];
+    let member_bindings = resolve_member_selector_claims(
+        graph,
+        &common.owner_graph_path,
+        &common.modules_root,
+        source_root,
+        &member_claim_sets,
+    )?;
+    for binding in &member_bindings[0] {
         if let Some(owner_id) = binding_to_owner.get(binding) {
             owner_ids.insert(owner_id.clone());
         } else {


### PR DESCRIPTION
## Summary

- Resolve `members[].selector.source_match` claims for `debundle coverage` and module-path `debundle describe` through the shared source-backed member selector resolver.
- Expand `binding_groups:` through the same helper used by the run/edit-gate path before coverage/describe ownership accounting.
- Add generic top-level query regressions for both direct `source_match` members and `binding_groups`.
- Remove the completed TODO entry.

## Validation

- `nix develop -c pre-commit run --files devinfra/js/debundle/BUILD.bazel devinfra/js/debundle/TODO.md devinfra/js/debundle/e2e/top_level_query_cli_test.rs devinfra/js/debundle/peel/plan.rs`
- `nix develop -c bbr test //devinfra/js/debundle/e2e:top_level_query_cli_test`
- `nix develop -c bbr test //devinfra/js/debundle:peel_test //devinfra/js/debundle/e2e:edit_gate_source_match_cli_test`
- `nix develop -c bbr test //devinfra/js/debundle/e2e:all`