### PR TITLE
[codex] Add source_match timing diagnostics

### DIFF
--- a/devinfra/js/debundle/docs/guide.md
+++ b/devinfra/js/debundle/docs/guide.md
@@ -269,6 +269,17 @@ members:
         match: 'const config = { kind: "selected", enabled: true };'
 ```
 
+When a dry run spends too long resolving selectors, rerun with
+`DUCKTAPE_SOURCE_MATCH_TIMINGS=1` to print one stderr line per
+`source_match` resolution. Set `DUCKTAPE_SOURCE_MATCH_TIMING_THRESHOLD_MS`
+to show only selectors at or above that duration. Each line names the module,
+selector kind, match count or resolved binding, elapsed milliseconds, and a
+compact selector preview. It also includes `selector_key` and `body_key`
+hashes: group by `body_key` to find duplicated expensive selector bodies, and
+by `selector_key` to find identical selector+target forms. For private bundle
+logs, set `DUCKTAPE_SOURCE_MATCH_TIMING_PREVIEW=0` to hide selector source while
+keeping keys, body indices, request ids, and binding summaries.
+
 `identifiers: alpha_all` treats binding/value identifiers in the selector
 as alpha-renamable placeholders while keeping literals, operators,
 member property names, object keys, and AST structure significant. This

--- a/devinfra/js/debundle/e2e/anonymous_statement_test.rs
+++ b/devinfra/js/debundle/e2e/anonymous_statement_test.rs
@@ -915,6 +915,96 @@ export { runtimeBinding, siblingBinding, Existing };
 }
 
 #[test]
+fn source_match_timing_env_reports_member_selector_resolution() {
+    let fixture = run_fixture_with_env(
+        FixtureOpts::new(
+            r#"function runtimeFormat(value) {
+  return value.trim().toUpperCase();
+}
+console.log(runtimeFormat(" ok "));
+export { runtimeFormat };
+"#,
+            vec![logical_module(
+                "format",
+                &[Member::source_alpha(
+                    "formatValue",
+                    r#"function formatValue(value) {
+  return value.trim().toUpperCase();
+}"#,
+                )],
+            )],
+        ),
+        &[("DUCKTAPE_SOURCE_MATCH_TIMINGS", "1")],
+    );
+
+    assert_entry_output(&fixture, "OK\n");
+    for required in [
+        "[debundle source_match]",
+        "request=static/app::format",
+        "kind=members[].selector.source_match export=`formatValue`",
+        "selector_key=",
+        "body_key=",
+        "body_indices=[0]",
+        "binding=runtimeFormat",
+        "selector=function formatValue(value) { return value.trim().toUpperCase(); }",
+    ] {
+        assert!(
+            fixture.stderr.contains(required),
+            "stderr missing {required:?}\nstderr:\n{}",
+            fixture.stderr,
+        );
+    }
+}
+
+#[test]
+fn source_match_timing_preview_can_be_disabled() {
+    let fixture = run_fixture_with_env(
+        FixtureOpts::new(
+            r#"function runtimeNormalize(value) {
+  return value.trim().toLowerCase();
+}
+console.log(runtimeNormalize(" OK "));
+export { runtimeNormalize };
+"#,
+            vec![logical_module(
+                "normalize",
+                &[Member::source_alpha(
+                    "normalizeValue",
+                    r#"function normalizeValue(value) {
+  return value.trim().toLowerCase();
+}"#,
+                )],
+            )],
+        ),
+        &[
+            ("DUCKTAPE_SOURCE_MATCH_TIMINGS", "1"),
+            ("DUCKTAPE_SOURCE_MATCH_TIMING_PREVIEW", "0"),
+        ],
+    );
+
+    assert_entry_output(&fixture, "ok\n");
+    for required in [
+        "[debundle source_match]",
+        "request=static/app::normalize",
+        "selector_key=",
+        "body_key=",
+        "body_indices=[0]",
+        "binding=runtimeNormalize",
+    ] {
+        assert!(
+            fixture.stderr.contains(required),
+            "stderr missing {required:?}\nstderr:\n{}",
+            fixture.stderr,
+        );
+    }
+    assert!(
+        !fixture.stderr.contains("function normalizeValue"),
+        "timing preview should be hidden when DUCKTAPE_SOURCE_MATCH_TIMING_PREVIEW=0\nstderr:\n{}",
+        fixture.stderr,
+    );
+}
+
+#[test]
 fn member_source_match_target_binding_uses_multideclarator_context() {
     let fixture = run_fixture(FixtureOpts::new(
         r#"const runtimeLocalPart = "primary",

--- a/devinfra/js/debundle/e2e/support.rs
+++ b/devinfra/js/debundle/e2e/support.rs
@@ -847,12 +847,16 @@ pub struct RejectedFixture {
 }
 
 pub fn run_fixture(opts: FixtureOpts<'_>) -> Fixture {
+    run_fixture_with_env(opts, &[])
+}
+
+pub fn run_fixture_with_env(opts: FixtureOpts<'_>, env: &[(&str, &str)]) -> Fixture {
     let setup = setup_fixture(&opts);
     let spec_path = setup.root.path().join("transform_spec.yaml");
     let spec = build_spec(&opts, &setup);
     write_yaml_file(&spec_path, &spec);
 
-    let result = spawn_transform(&spec_path);
+    let result = spawn_transform(&spec_path, env);
     assert!(
         result.status.success(),
         "debundler exited {:?}\nstdout:\n{}\nstderr:\n{}",
@@ -944,7 +948,7 @@ fn run_rejection_fixture_with_args(opts: FixtureOpts<'_>, extra_args: &[&str]) -
     let spec = build_spec(&opts, &setup);
     write_yaml_file(&spec_path, &spec);
 
-    let result = spawn_transform_with_args(&spec_path, extra_args);
+    let result = spawn_transform_with_args(&spec_path, extra_args, &[]);
     assert!(
         !result.status.success(),
         "expected spec to be rejected\nstdout:\n{}\nstderr:\n{}",
@@ -1329,15 +1333,22 @@ pub struct CommandResult {
     pub status: std::process::ExitStatus,
 }
 
-fn spawn_transform(spec_path: &Path) -> CommandResult {
-    run_debundler(spec_path, &[])
+fn spawn_transform(spec_path: &Path, env: &[(&str, &str)]) -> CommandResult {
+    run_debundler_with_env(spec_path, &[], env)
 }
 
-fn spawn_transform_with_args(spec_path: &Path, extra_args: &[&str]) -> CommandResult {
+fn spawn_transform_with_args(
+    spec_path: &Path,
+    extra_args: &[&str],
+    env: &[(&str, &str)],
+) -> CommandResult {
     let bin = debundler_path();
     let mut command = Command::new(&bin);
     command.arg("run").arg("--spec").arg(spec_path);
     command.args(extra_args);
+    for (name, value) in env {
+        command.env(name, value);
+    }
     let output = command
         .output()
         .unwrap_or_else(|e| panic!("spawn debundler {}: {e}", bin.display()));
@@ -1352,6 +1363,14 @@ fn spawn_transform_with_args(spec_path: &Path, extra_args: &[&str]) -> CommandRe
 /// captured stdio + exit status. Used by tests that exercise pipeline stages
 /// outside the logical-modules harness in [`run_fixture`].
 pub fn run_debundler(spec_path: &Path, package_roots: &[(&str, &Path)]) -> CommandResult {
+    run_debundler_with_env(spec_path, package_roots, &[])
+}
+
+pub fn run_debundler_with_env(
+    spec_path: &Path,
+    package_roots: &[(&str, &Path)],
+    env: &[(&str, &str)],
+) -> CommandResult {
     let bin = debundler_path();
     let mut command = Command::new(&bin);
     command.arg("run").arg("--spec").arg(spec_path);
@@ -1359,6 +1378,9 @@ pub fn run_debundler(spec_path: &Path, package_roots: &[(&str, &Path)]) -> Comma
         command
             .arg("--package-root")
             .arg(format!("{name}={}", dir.display()));
+    }
+    for (name, value) in env {
+        command.env(name, value);
     }
     let output = command
         .output()

--- a/devinfra/js/debundle/source_match.rs
+++ b/devinfra/js/debundle/source_match.rs
@@ -5,6 +5,8 @@
 //! semantics such as alpha-equivalent identifier matching.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, bail};
 use spec::{
@@ -41,6 +43,236 @@ const STMT_LIST_HOLE_KEYWORD: &str = "STMT_LIST";
 const CLASS_REST_HOLE_KEYWORD: &str = "CLASS_REST";
 const DECLARATORS_HOLE_KEYWORD: &str = "DECLARATORS";
 const ARGS_HOLE_KEYWORD: &str = "ARGS";
+
+const SOURCE_MATCH_TIMINGS_ENV: &str = "DUCKTAPE_SOURCE_MATCH_TIMINGS";
+const SOURCE_MATCH_TIMING_THRESHOLD_ENV: &str = "DUCKTAPE_SOURCE_MATCH_TIMING_THRESHOLD_MS";
+const SOURCE_MATCH_TIMING_PREVIEW_ENV: &str = "DUCKTAPE_SOURCE_MATCH_TIMING_PREVIEW";
+
+#[derive(Debug)]
+struct SourceMatchTimingConfig {
+    threshold: Duration,
+    include_preview: bool,
+}
+
+fn source_match_timing_config() -> Option<&'static SourceMatchTimingConfig> {
+    static CONFIG: OnceLock<Option<SourceMatchTimingConfig>> = OnceLock::new();
+    CONFIG
+        .get_or_init(|| {
+            let enabled = std::env::var(SOURCE_MATCH_TIMINGS_ENV).ok()?;
+            if matches!(
+                enabled.to_ascii_lowercase().as_str(),
+                "" | "0" | "false" | "off" | "no"
+            ) {
+                return None;
+            }
+            let threshold_ms = std::env::var(SOURCE_MATCH_TIMING_THRESHOLD_ENV)
+                .ok()
+                .and_then(|raw| raw.parse::<u64>().ok())
+                .unwrap_or(0);
+            let include_preview = std::env::var(SOURCE_MATCH_TIMING_PREVIEW_ENV)
+                .ok()
+                .is_none_or(|raw| {
+                    !matches!(
+                        raw.to_ascii_lowercase().as_str(),
+                        "" | "0" | "false" | "off" | "no"
+                    )
+                });
+            Some(SourceMatchTimingConfig {
+                threshold: Duration::from_millis(threshold_ms),
+                include_preview,
+            })
+        })
+        .as_ref()
+}
+
+fn trace_source_match<T>(
+    kind: &str,
+    request_id: &str,
+    selector: &AnonymousStatementSelector,
+    run: impl FnOnce() -> Result<T>,
+    summarize: impl FnOnce(&T) -> String,
+) -> Result<T> {
+    let Some(config) = source_match_timing_config() else {
+        return run();
+    };
+    let started = Instant::now();
+    let result = run();
+    let elapsed = started.elapsed();
+    if elapsed >= config.threshold {
+        let status = match &result {
+            Ok(value) => summarize(value),
+            Err(error) => format!("error={}", first_error_line(error)),
+        };
+        eprintln!(
+            "[debundle source_match] elapsed_ms={} request={} kind={} {} {}",
+            elapsed.as_millis(),
+            request_id,
+            kind,
+            status,
+            source_match_timing_selector_details(selector, config),
+        );
+    }
+    result
+}
+
+fn first_error_line(error: &anyhow::Error) -> String {
+    let mut line = error.to_string();
+    if let Some((first, _)) = line.split_once('\n') {
+        line = first.to_string();
+    }
+    truncate_for_log(&line, 160)
+}
+
+fn source_match_preview(source: &str) -> String {
+    let collapsed = source.split_whitespace().collect::<Vec<_>>().join(" ");
+    truncate_for_log(&collapsed, 180)
+}
+
+fn source_match_timing_selector_details(
+    selector: &AnonymousStatementSelector,
+    config: &SourceMatchTimingConfig,
+) -> String {
+    let mut fields = vec![
+        format!("selector_key={}", selector_timing_key(selector)),
+        format!("body_key={}", selector_body_timing_key(selector)),
+    ];
+    if let Some(target_binding) = selector.target_binding.as_deref() {
+        fields.push(format!("target_binding=`{target_binding}`"));
+    }
+    if let Some(target_statement) = selector.target_statement {
+        fields.push(format!("target_statement={target_statement}"));
+    }
+    if let Some(target_statements) = &selector.target_statements {
+        fields.push(format!("target_statements={target_statements:?}"));
+    }
+    if config.include_preview {
+        fields.push(format!(
+            "selector={}",
+            source_match_preview(&selector.match_source)
+        ));
+    }
+    fields.join(" ")
+}
+
+fn selector_body_timing_key(selector: &AnonymousStatementSelector) -> String {
+    let mut state = Fnv1a64::new();
+    state.update(b"body");
+    state.update(format!("{:?}", selector.identifiers).as_bytes());
+    state.update(b"\0");
+    state.update(normalized_selector_source(&selector.match_source).as_bytes());
+    format!("{:016x}", state.finish())
+}
+
+fn selector_timing_key(selector: &AnonymousStatementSelector) -> String {
+    let mut state = Fnv1a64::new();
+    state.update(b"selector");
+    state.update(format!("{:?}", selector.identifiers).as_bytes());
+    state.update(b"\0");
+    state.update(normalized_selector_source(&selector.match_source).as_bytes());
+    state.update(b"\0");
+    if let Some(target_binding) = selector.target_binding.as_deref() {
+        state.update(b"target_binding=");
+        state.update(target_binding.as_bytes());
+    }
+    state.update(b"\0");
+    if let Some(target_statement) = selector.target_statement {
+        state.update(format!("target_statement={target_statement}").as_bytes());
+    }
+    state.update(b"\0");
+    if let Some(target_statements) = &selector.target_statements {
+        state.update(format!("target_statements={target_statements:?}").as_bytes());
+    }
+    format!("{:016x}", state.finish())
+}
+
+fn normalized_selector_source(source: &str) -> String {
+    source.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+struct Fnv1a64 {
+    value: u64,
+}
+
+impl Fnv1a64 {
+    const OFFSET: u64 = 0xcbf29ce484222325;
+    const PRIME: u64 = 0x100000001b3;
+
+    fn new() -> Self {
+        Self {
+            value: Self::OFFSET,
+        }
+    }
+
+    fn update(&mut self, bytes: &[u8]) {
+        for byte in bytes {
+            self.value ^= u64::from(*byte);
+            self.value = self.value.wrapping_mul(Self::PRIME);
+        }
+    }
+
+    fn finish(&self) -> u64 {
+        self.value
+    }
+}
+
+fn truncate_for_log(value: &str, max_chars: usize) -> String {
+    if value.chars().count() <= max_chars {
+        return value.to_string();
+    }
+    let mut truncated = value.chars().take(max_chars).collect::<String>();
+    truncated.push_str("...");
+    truncated
+}
+
+fn render_timing_names<'a>(names: impl Iterator<Item = &'a str>) -> String {
+    const MAX_NAMES: usize = 6;
+    let names = names.collect::<Vec<_>>();
+    if names.is_empty() {
+        return "<none>".to_string();
+    }
+    let mut rendered = names
+        .iter()
+        .take(MAX_NAMES)
+        .map(|name| format!("`{name}`"))
+        .collect::<Vec<_>>();
+    if names.len() > MAX_NAMES {
+        rendered.push(format!("+{} more", names.len() - MAX_NAMES));
+    }
+    rendered.join(",")
+}
+
+fn render_timing_groups(groups: &[Vec<usize>]) -> String {
+    const MAX_GROUPS: usize = 4;
+    if groups.is_empty() {
+        return "[]".to_string();
+    }
+    let mut rendered = groups
+        .iter()
+        .take(MAX_GROUPS)
+        .map(|group| format!("{group:?}"))
+        .collect::<Vec<_>>();
+    if groups.len() > MAX_GROUPS {
+        rendered.push(format!("+{} more", groups.len() - MAX_GROUPS));
+    }
+    rendered.join(",")
+}
+
+fn render_timing_body_indices<'a>(indices: impl Iterator<Item = &'a usize>) -> String {
+    const MAX_INDICES: usize = 8;
+    let indices = indices.copied().collect::<Vec<_>>();
+    if indices.is_empty() {
+        return "[]".to_string();
+    }
+    let mut rendered = indices
+        .iter()
+        .take(MAX_INDICES)
+        .map(usize::to_string)
+        .collect::<Vec<_>>();
+    if indices.len() > MAX_INDICES {
+        rendered.push(format!("+{} more", indices.len() - MAX_INDICES));
+    }
+    format!("[{}]", rendered.join(","))
+}
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ResolvedMemberBinding {
@@ -236,12 +468,25 @@ pub fn member_binding_candidates(
     request_id: &str,
     selector: &AnonymousStatementSelector,
 ) -> Result<Vec<ResolvedMemberBinding>> {
-    Ok(
-        find_member_binding_matches(runtime_module, request_id, selector)?
-            .into_iter()
-            .map(|matched| matched.binding)
-            .collect(),
-    )
+    let matches = trace_source_match(
+        "members[].selector.source_match candidates",
+        request_id,
+        selector,
+        || find_member_binding_matches(runtime_module, request_id, selector),
+        |matches: &Vec<MemberBindingMatch>| {
+            format!(
+                "matches={} body_indices={} bindings={}",
+                matches.len(),
+                render_timing_body_indices(matches.iter().map(|matched| &matched.body_idx)),
+                render_timing_names(
+                    matches
+                        .iter()
+                        .map(|matched| matched.binding.binding_name.as_str())
+                )
+            )
+        },
+    )?;
+    Ok(matches.into_iter().map(|matched| matched.binding).collect())
 }
 
 pub fn resolve_anonymous_statement_body_index(
@@ -304,35 +549,51 @@ pub fn find_anonymous_statement_body_index_groups(
     request_id: &str,
     selector: &AnonymousStatementSelector,
 ) -> Result<Vec<Vec<usize>>> {
-    let parsed = js_ast::parse_js_module_ast(
-        &format!("<anonymous_statement match in {request_id}>"),
-        &selector.match_source,
+    trace_source_match(
+        "anonymous_statements[].source_match",
+        request_id,
+        selector,
+        || {
+            let parsed = js_ast::parse_js_module_ast(
+                &format!("<anonymous_statement match in {request_id}>"),
+                &selector.match_source,
+            )
+            .with_context(|| {
+                format!(
+                    "logical_module {request_id}: anonymous_statements[].match did not parse as JS:\n{}",
+                    selector.match_source
+                )
+            })?;
+            let target_indices =
+                anonymous_selector_target_statement_indices(request_id, selector, &parsed.body)?;
+            let mut groups = Vec::new();
+            for alignment in
+                find_matching_body_group_alignments(runtime_module, &parsed.body, selector)
+            {
+                let mut group = Vec::with_capacity(target_indices.len());
+                for target_idx in &target_indices {
+                    let Some(Some(body_idx)) = alignment.get(*target_idx) else {
+                        bail!(
+                            "logical_module {request_id}: anonymous_statements[].source_match \
+                             target statement {target_idx} was matched by a STMT_LIST hole instead \
+                             of a pinned selector statement. Refine the selector:\n{match_source}",
+                            match_source = selector.match_source,
+                        );
+                    };
+                    group.push(*body_idx);
+                }
+                groups.push(group);
+            }
+            Ok(groups)
+        },
+        |groups: &Vec<Vec<usize>>| {
+            format!(
+                "matches={} body_indices={}",
+                groups.len(),
+                render_timing_groups(groups)
+            )
+        },
     )
-    .with_context(|| {
-        format!(
-            "logical_module {request_id}: anonymous_statements[].match did not parse as JS:\n{}",
-            selector.match_source
-        )
-    })?;
-    let target_indices =
-        anonymous_selector_target_statement_indices(request_id, selector, &parsed.body)?;
-    let mut groups = Vec::new();
-    for alignment in find_matching_body_group_alignments(runtime_module, &parsed.body, selector) {
-        let mut group = Vec::with_capacity(target_indices.len());
-        for target_idx in &target_indices {
-            let Some(Some(body_idx)) = alignment.get(*target_idx) else {
-                bail!(
-                    "logical_module {request_id}: anonymous_statements[].source_match \
-                     target statement {target_idx} was matched by a STMT_LIST hole instead \
-                     of a pinned selector statement. Refine the selector:\n{match_source}",
-                    match_source = selector.match_source,
-                );
-            };
-            group.push(*body_idx);
-        }
-        groups.push(group);
-    }
-    Ok(groups)
 }
 
 /// Source-aware fragility signal for selector-debt reporting.
@@ -427,44 +688,91 @@ pub fn resolve_member_binding(
     export_name: &str,
     selector: &AnonymousStatementSelector,
 ) -> Result<ResolvedMemberBinding> {
-    let matches = find_member_binding_matches(runtime_module, request_id, selector)?;
-    let target_binding_hint = selector
-        .target_binding
-        .as_deref()
-        .map(|target| format!(" target_binding `{target}`"))
-        .unwrap_or_default();
-    match matches.as_slice() {
-        [single] => Ok(single.binding.clone()),
-        [] => {
-            let hint = source_match_no_match_hint(runtime_module, selector);
-            bail!(
-                "logical_module {request_id}: members[].selector.source_match for export \
-                 `{export_name}`{target_binding_hint} did not match any top-level declaration in the chunk. \
-                 Selector:\n{match_source}{hint}",
-                match_source = selector.match_source,
-                hint = hint.unwrap_or_default(),
+    let kind = format!("members[].selector.source_match export=`{export_name}`");
+    let matched = trace_source_match(
+        &kind,
+        request_id,
+        selector,
+        || {
+            let matches = find_member_binding_matches(runtime_module, request_id, selector)?;
+            let target_binding_hint = selector
+                .target_binding
+                .as_deref()
+                .map(|target| format!(" target_binding `{target}`"))
+                .unwrap_or_default();
+            match matches.as_slice() {
+                [single] => Ok(single.clone()),
+                [] => {
+                    let hint = source_match_no_match_hint(runtime_module, selector);
+                    bail!(
+                        "logical_module {request_id}: members[].selector.source_match for export \
+                         `{export_name}`{target_binding_hint} did not match any top-level declaration in the chunk. \
+                         Selector:\n{match_source}{hint}",
+                        match_source = selector.match_source,
+                        hint = hint.unwrap_or_default(),
+                    )
+                }
+                multiple => bail!(
+                    "logical_module {request_id}: members[].selector.source_match for export \
+                     `{export_name}`{target_binding_hint} is ambiguous — matched {} top-level statements at body \
+                     indices {:?} (bindings: {}). Refine the selector. Source:\n{match_source}",
+                    multiple.len(),
+                    multiple
+                        .iter()
+                        .map(|matched| matched.body_idx)
+                        .collect::<Vec<_>>(),
+                    multiple
+                        .iter()
+                        .map(|matched| matched.binding.binding_name.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                    match_source = selector.match_source,
+                ),
+            }
+        },
+        |matched| {
+            format!(
+                "body_indices=[{}] binding={}",
+                matched.body_idx, matched.binding.binding_name
             )
-        }
-        multiple => bail!(
-            "logical_module {request_id}: members[].selector.source_match for export \
-             `{export_name}`{target_binding_hint} is ambiguous — matched {} top-level statements at body \
-             indices {:?} (bindings: {}). Refine the selector. Source:\n{match_source}",
-            multiple.len(),
-            multiple
-                .iter()
-                .map(|matched| matched.body_idx)
-                .collect::<Vec<_>>(),
-            multiple
-                .iter()
-                .map(|matched| matched.binding.binding_name.as_str())
-                .collect::<Vec<_>>()
-                .join(", "),
-            match_source = selector.match_source,
-        ),
-    }
+        },
+    )?;
+    Ok(matched.binding)
 }
 
 pub fn resolve_member_binding_group(
+    runtime_module: &Module,
+    request_id: &str,
+    selector: &AnonymousStatementSelector,
+    exports_by_target: &BTreeMap<String, String>,
+) -> Result<BTreeMap<String, ResolvedMemberBinding>> {
+    trace_source_match(
+        "binding_groups[].source_match",
+        request_id,
+        selector,
+        || {
+            resolve_member_binding_group_impl(
+                runtime_module,
+                request_id,
+                selector,
+                exports_by_target,
+            )
+        },
+        |resolved| {
+            format!(
+                "targets={} bindings={}",
+                resolved.len(),
+                render_timing_names(
+                    resolved
+                        .values()
+                        .map(|matched| matched.binding_name.as_str())
+                )
+            )
+        },
+    )
+}
+
+fn resolve_member_binding_group_impl(
     runtime_module: &Module,
     request_id: &str,
     selector: &AnonymousStatementSelector,


### PR DESCRIPTION
## Summary

Adds opt-in timing diagnostics around debundle `source_match` resolution so slow selector/module combinations are visible during dry-runs without changing matcher semantics.

When `DUCKTAPE_SOURCE_MATCH_TIMINGS=1` is set, debundle emits concise stderr lines like:

```text
[debundle source_match] elapsed_ms=... request=... kind=... ... selector_key=... body_key=... body_indices=... selector=...
```

`DUCKTAPE_SOURCE_MATCH_TIMING_THRESHOLD_MS=<ms>` can be used to suppress fast resolutions and focus on slow selectors. `DUCKTAPE_SOURCE_MATCH_TIMING_PREVIEW=0` suppresses selector source previews while keeping request ids, selector keys, body keys, body indices, and binding summaries.

## Why

Downstream debundle porting runs can spend tens of seconds before failing on one selector. The current failure output identifies the selector that failed, but not which modules/selectors are consuming the most matcher time before that point. This PR gives spec authors and Ducktape workers a low-risk way to locate slow selectors first, group repeated expensive selector bodies by `body_key`, and share private-corpus timing logs without exposing selector source.

## Notes

- Covers member `source_match`, binding groups, and anonymous statement `source_match` resolution paths.
- Reports request id, selector kind, elapsed time, match/resolution summary, deterministic `selector_key` / `body_key`, body indices where available, and an optional collapsed selector preview.
- This is instrumentation only: no selector matching semantics are changed.
- Test fixtures are generic/anonymized.

## Validation

```sh
nix develop -c bazelisk --output_base=/tmp/bazel-ducktape-selector-timing test //devinfra/js/debundle/e2e:anonymous_statement_test --config=ci --config=rbe --remote_upload_local_results=false --remote_download_outputs=all --test_output=errors
nix develop -c pre-commit run --files devinfra/js/debundle/source_match.rs devinfra/js/debundle/e2e/anonymous_statement_test.rs devinfra/js/debundle/docs/guide.md
```

BuildBuddy invocations:

- https://app.buildbuddy.io/invocation/a33e713e-4ba1-4442-a0f9-ab8a9968bfb8
- https://app.buildbuddy.io/invocation/ccbd5b66-51e1-418c-ac39-4f876449c519