### PR TITLE
[codex] Improve duplicate binding claim diagnostics

### DIFF
--- a/devinfra/js/debundle/e2e/cross_module_emission_test.rs
+++ b/devinfra/js/debundle/e2e/cross_module_emission_test.rs
@@ -215,13 +215,9 @@ console.log(w({ a: null, b: "d" }));
 
 #[test]
 fn duplicate_top_level_decl_claims_are_rejected() {
-    // Regression for the gaffer the upstream case: two YAMLs both claim the
-    // same input-bundle top-level binding (e.g. both `runtime.yaml`
-    // and `ai_conversation_node_accessor.yaml` export
-    // `AIConversationNodeAccessor` from binding `ho`). Previously the
-    // emitter put the body in one module and emitted
-    // `export { AIConversationNodeAccessor };` with no backing decl
-    // in the other — invalid JS that fails `import()` with
+    // Two YAMLs both claim the same input-bundle top-level binding. Previously
+    // the emitter put the body in one module and emitted `export { X };` with
+    // no backing decl in the other — invalid JS that fails `import()` with
     // "SyntaxError: Export 'X' is not defined in module".
     //
     // The spec author's options are: put both renames in one module,
@@ -237,19 +233,19 @@ fn duplicate_top_level_decl_claims_are_rejected() {
     // collapse to one `binding_assignment` entry, so the rejection
     // catches any way to spell the duplicate.
     let opts = FixtureOpts::new(
-        r#"class ho {
-  static isAIConversation() { return false; }
+        r#"class runtimeProcessor {
+  static isEnabled() { return false; }
 }
-console.log(ho);
-export { ho };
+console.log(runtimeProcessor);
+export { runtimeProcessor };
 "#,
         vec![
             (
                 "mod_a".to_string(),
                 json!({
                     "members": [{
-                        "name": "AIConversationNodeAccessor",
-                        "selector": { "binding": { "name": "ho", "kind": "class_declaration" } },
+                        "name": "RuntimeProcessor",
+                        "selector": { "binding": { "name": "runtimeProcessor", "kind": "class_declaration" } },
                     }],
                 }),
             ),
@@ -257,8 +253,8 @@ export { ho };
                 "mod_b".to_string(),
                 json!({
                     "members": [{
-                        "name": "AIConversationNodeAccessor",
-                        "selector": { "binding": { "name": "ho" } },
+                        "name": "RuntimeProcessorAlias",
+                        "selector": { "binding": { "name": "runtimeProcessor" } },
                     }],
                 }),
             ),
@@ -266,7 +262,74 @@ export { ho };
     );
     expect_rejection_containing_all(
         opts,
-        &["Duplicate binding claim", "\"ho\"", "mod_a", "mod_b"],
+        &[
+            "Duplicate binding claim",
+            "\"runtimeProcessor\"",
+            "mod_a",
+            "as `RuntimeProcessor`",
+            "members[].selector.binding as `RuntimeProcessor`",
+            "mod_b",
+            "as `RuntimeProcessorAlias`",
+        ],
+    );
+}
+
+#[test]
+fn duplicate_source_match_class_claims_report_exports_and_selector_origins() {
+    let class_selector = r#"class K {
+  CLASS_REST;
+  open() {
+    return "open";
+  }
+  CLASS_REST;
+  close() {
+    return "closed";
+  }
+  CLASS_REST;
+}"#;
+    let opts = FixtureOpts::new(
+        r#"class RuntimeCatalog {
+  constructor() {
+    this.count = 0;
+  }
+  open() {
+    return "open";
+  }
+  close() {
+    return "closed";
+  }
+}
+console.log(new RuntimeCatalog().close());
+export { RuntimeCatalog };
+"#,
+        vec![
+            logical_module(
+                "catalog/primary",
+                &[Member::source_alpha("PrimaryCatalog", class_selector)],
+            ),
+            logical_module(
+                "catalog/duplicate",
+                &[Member::source_alpha_target(
+                    "DuplicateCatalog",
+                    "K",
+                    class_selector,
+                )],
+            ),
+        ],
+    );
+
+    expect_rejection_containing_all(
+        opts,
+        &[
+            "Duplicate binding claim",
+            "\"RuntimeCatalog\"",
+            "catalog/primary",
+            "as `PrimaryCatalog`",
+            "members[].selector.source_match as `PrimaryCatalog`",
+            "catalog/duplicate",
+            "as `DuplicateCatalog`",
+            "members[].selector.source_match target_binding `K` as `DuplicateCatalog`",
+        ],
     );
 }
 

--- a/devinfra/js/debundle/lowering/materialize/plan_builder.rs
+++ b/devinfra/js/debundle/lowering/materialize/plan_builder.rs
@@ -244,27 +244,48 @@ impl ChunkPlanBuilder {
         let module_id = ModuleId(LogicalModuleIndex(index));
         for member in &request.members {
             if let Some(existing_kind) = self.catalogue_index_by_name.get(member.binding.as_str()) {
-                let existing_id = match existing_kind {
+                let (existing_id, existing_export_name, existing_origin) = match existing_kind {
                     BindingKind::Owned {
                         module: ModuleId(LogicalModuleIndex(owner_index)),
-                    } => self
-                        .module_plans
-                        .get(*owner_index)
-                        .map(|plan| plan.id.clone())
-                        .unwrap_or_else(|| format!("<plan#{owner_index}>")),
+                    } => {
+                        let plan = self.module_plans.get(*owner_index);
+                        (
+                            plan.map(|plan| plan.id.clone())
+                                .unwrap_or_else(|| format!("<plan#{owner_index}>")),
+                            plan.and_then(|plan| plan.bindings.get(member.binding.as_str()))
+                                .cloned(),
+                            plan.and_then(|plan| {
+                                plan.binding_claim_origins.get(member.binding.as_str())
+                            })
+                            .cloned(),
+                        )
+                    }
                     BindingKind::Imported {
                         re_exporter: ModuleId(LogicalModuleIndex(re_index)),
+                        public_name,
                         ..
-                    } => self
-                        .module_plans
-                        .get(*re_index)
-                        .map(|plan| plan.id.clone())
-                        .unwrap_or_else(|| format!("<plan#{re_index}>")),
+                    } => (
+                        self.module_plans
+                            .get(*re_index)
+                            .map(|plan| plan.id.clone())
+                            .unwrap_or_else(|| format!("<plan#{re_index}>")),
+                        Some(public_name.to_string()),
+                        None,
+                    ),
                 };
+                let existing_export = existing_export_name
+                    .as_deref()
+                    .map(|name| format!(" as `{name}`"))
+                    .unwrap_or_default();
+                let existing_origin = existing_origin
+                    .as_deref()
+                    .map(|origin| format!(" ({origin})"))
+                    .unwrap_or_default();
                 bail!(
                     "Duplicate binding claim for {:?} in chunk {:?}: already \
-                     claimed by module {existing_id} and now also claimed by module \
-                     {}. Each binding may belong to exactly one logical module. \
+                     claimed by module {existing_id}{existing_export}{existing_origin} \
+                     and now also claimed by module {} as `{}` ({}). Each binding \
+                     may belong to exactly one logical module. \
                      Different selector forms (`{{name: foo}}` vs \
                      `{{name: foo, kind: class_declaration}}`) that resolve to the \
                      same source declaration still count as duplicates. To expose a \
@@ -273,6 +294,8 @@ impl ChunkPlanBuilder {
                     member.binding,
                     ctx.chunk_id,
                     request.id,
+                    member.export_name,
+                    member.claim_origin,
                 );
             }
             if member.is_import_specifier {
@@ -338,6 +361,11 @@ impl ChunkPlanBuilder {
                     .map(|c| (member.binding.clone(), c.clone()))
             })
             .collect();
+        let binding_claim_origins: BTreeMap<String, String> = request
+            .members
+            .iter()
+            .map(|member| (member.binding.clone(), member.claim_origin.clone()))
+            .collect();
         self.module_plans.push(ModulePlan {
             id: request.id.clone(),
             target_file: dest_target_file,
@@ -348,6 +376,7 @@ impl ChunkPlanBuilder {
             anonymous_statement_comments,
             comment: request.comment.clone(),
             binding_comments,
+            binding_claim_origins,
         });
         Ok(())
     }
@@ -501,6 +530,7 @@ impl ChunkPlanBuilder {
                     anonymous_statement_comments: BTreeMap::new(),
                     comment: None,
                     binding_comments: BTreeMap::new(),
+                    binding_claim_origins: BTreeMap::new(),
                 });
                 self.residual_plan_index = Some(residual_index);
             }
@@ -669,6 +699,7 @@ impl ChunkPlanBuilder {
                 anonymous_statement_comments: BTreeMap::new(),
                 comment: None,
                 binding_comments: BTreeMap::new(),
+                binding_claim_origins: BTreeMap::new(),
             });
         }
         Ok(())

--- a/devinfra/js/debundle/lowering/plans.rs
+++ b/devinfra/js/debundle/lowering/plans.rs
@@ -67,6 +67,10 @@ pub(super) struct MemberRequest {
     /// `// ...` block above the binding's owner statement in the
     /// generated module body. See [`spec::Member::comment`].
     pub(super) comment: Option<String>,
+    /// Short spec-facing description of how this member claim was authored.
+    /// Used only in diagnostics after source-match selectors have resolved to
+    /// concrete source bindings.
+    pub(super) claim_origin: String,
 }
 
 impl MemberRequest {
@@ -169,6 +173,10 @@ pub(super) struct ModulePlan {
     /// the binding's owner statement in the generated module body.
     /// See [`spec::Member::comment`].
     pub(super) binding_comments: BTreeMap<String, String>,
+    /// Local-name → short spec-facing origin for each owned binding claim.
+    /// This is diagnostic metadata; lowering behavior is driven by
+    /// [`ModulePlan::bindings`].
+    pub(super) binding_claim_origins: BTreeMap<String, String>,
 }
 
 pub(super) fn logical_requests_for_chunk(
@@ -295,6 +303,22 @@ pub(super) fn build_members(
                     (String::new(), export_name, Some(selector), false)
                 }
             };
+            let claim_origin = match &m.selector.source_match {
+                Some(selector) => match selector.target_binding.as_deref() {
+                    Some(target) => format!(
+                        "members[].selector.source_match target_binding `{target}` as `{}`",
+                        m.name.as_deref().unwrap_or("<unnamed>")
+                    ),
+                    None => format!(
+                        "members[].selector.source_match as `{}`",
+                        m.name.as_deref().unwrap_or("<unnamed>")
+                    ),
+                },
+                None => format!(
+                    "members[].selector.binding as `{}`",
+                    m.name.as_deref().unwrap_or(&binding)
+                ),
+            };
             Ok(MemberRequest {
                 binding,
                 export_name,
@@ -305,12 +329,14 @@ pub(super) fn build_members(
                 pure_members: m.pure_members.clone(),
                 no_sync_callback_members: m.no_sync_callback_members.clone(),
                 comment: m.comment.clone(),
+                claim_origin,
             })
         })
         .collect::<Result<Vec<_>>>()?;
 
     for group in binding_groups {
         for expanded in source_match::binding_group_member_selectors(request_id, group)? {
+            let target_binding = expanded.selector.target_binding.clone();
             requests.push(MemberRequest {
                 binding: String::new(),
                 export_name: expanded.export_name,
@@ -321,6 +347,10 @@ pub(super) fn build_members(
                 pure_members: Vec::new(),
                 no_sync_callback_members: Vec::new(),
                 comment: expanded.comment,
+                claim_origin: match target_binding {
+                    Some(target) => format!("binding_groups[].exports[`{target}`]"),
+                    None => "binding_groups[]".to_string(),
+                },
             });
         }
     }


### PR DESCRIPTION
## Summary

Improves duplicate binding-claim diagnostics so collisions name both sides' public export names and the selector form that produced each claim.

Example duplicate errors now distinguish shapes like:

- an existing `members[].selector.binding` claim exporting `ExportA`
- a new `members[].selector.source_match` claim with `target_binding: K` exporting `ExportB`
- binding-group claims such as `binding_groups[].exports[selectorLocal]`

## Why

When lean structural selectors resolve unexpectedly to the same source binding, the old diagnostic only named the source binding and modules. That is not enough for class-shaped `source_match` / binding-group authoring: spec authors need to know which public export and selector entry on each side caused the duplicate so they can remove the accidental duplicate or intentionally put aliases in one module.

## Notes

- This is diagnostics-only; selector matching and lowering semantics are unchanged.
- Adds diagnostic-only claim-origin metadata to `MemberRequest` / `ModulePlan`.
- Keeps fixtures generic/anonymized and rewrites an older duplicate-claim test fixture/comment away from private-shaped names.

## Validation

```sh
nix develop -c bazelisk --output_base=/tmp/bazel-ducktape-class-claim test //devinfra/js/debundle/e2e:cross_module_emission_test --config=ci --config=rbe --remote_upload_local_results=false --remote_download_outputs=all --test_output=errors
nix develop -c pre-commit run --files devinfra/js/debundle/lowering/plans.rs devinfra/js/debundle/lowering/materialize/plan_builder.rs devinfra/js/debundle/e2e/cross_module_emission_test.rs
```