### PR TITLE
[codex] Add keep-going duplicate claim diagnostics

### DIFF
--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -213,6 +213,11 @@ Still to do:
 
 - Full lowering matrix: binding placement reports, attached side-effects,
   staged-shell edge cases beyond the focused fixture.
+- Extend `debundle run --keep-going` beyond materialization duplicate binding
+  claims. Source-match selector misses currently fail during selector
+  resolution before plan-building has an accumulator, so batching those needs a
+  request-level diagnostic collection pass that can keep enough unresolved
+  claim context without mutating the canonical lowering plan.
 - Owner-fragment modeling parity for nested declarations and re-exports.
 - Keep new analysis tooling on the existing owner graph and embedded atomic
   DAG side outputs; do not add parallel selected-owner cache formats.

--- a/devinfra/js/debundle/cli/mod.rs
+++ b/devinfra/js/debundle/cli/mod.rs
@@ -436,8 +436,15 @@ pub fn run_debundle_cli(args: DebundleArgs) -> Result<()> {
     match args.command {
         DebundleCommand::Run(args) => {
             let dry_run = args.dry_run;
+            let keep_going = args.keep_going;
             let cli = args.resolve()?;
-            run_transform_cli_with_options(&cli, TransformRunOptions { dry_run })?;
+            run_transform_cli_with_options(
+                &cli,
+                TransformRunOptions {
+                    dry_run,
+                    keep_going,
+                },
+            )?;
             if dry_run {
                 println!("dry-run: transform pipeline checks passed; no outputs written");
             }
@@ -1195,12 +1202,14 @@ mod tests {
                 "--spec",
                 "spec.yaml",
                 "--dry-run",
+                "--keep-going",
                 "--package-root",
                 "pkg=/tmp/pkg",
                 "--packages-root",
                 "/tmp/packages",
             ]);
             assert!(args.dry_run);
+            assert!(args.keep_going);
             let cli = args.resolve().expect("resolve cli");
             assert_eq!(
                 cli.spec_source,

--- a/devinfra/js/debundle/docs/cli.md
+++ b/devinfra/js/debundle/docs/cli.md
@@ -39,8 +39,10 @@ checks and skips emitted-JS and accept-path report writes. A gate
 rejection still writes `owner_graph.json` plus the rejection evidence
 (`cycles.json` / `atomic_unit_conflicts.json`) under
 `reports/tree/<chunk>/`, so `gate list` / `gate describe` work on the
-rejection that was just reported. There is no `debundle run
---no-verify`.
+rejection that was just reported. Add `--keep-going` to collect all
+supported diagnostics from a pass instead of stopping at the first one;
+currently this aggregates duplicate binding claims with module/export/origin
+evidence. There is no `debundle run --no-verify`.
 
 Read-only commands (queries, listings, source slicing) take
 neither flag — they have no side effects.
@@ -67,9 +69,9 @@ with a list. Use the minified form to disambiguate.
 
 ### Pipeline
 
-| Command        | Mutates?                 | Function                                                                                                                                                                                 |
-| -------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `debundle run` | yes (emits JS + reports) | Run the full transform pipeline: parse + facts + owner_graph + atomic_units + realizability gate + lower + emit. `--dry-run` runs pipeline checks without writing emitted JS or reports. |
+| Command        | Mutates?                 | Function                                                                                                                                                                                                                                                                   |
+| -------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `debundle run` | yes (emits JS + reports) | Run the full transform pipeline: parse + facts + owner_graph + atomic_units + realizability gate + lower + emit. `--dry-run` runs pipeline checks without writing emitted JS or reports. `--keep-going` aggregates supported diagnostics such as duplicate binding claims. |
 
 ### Bindings
 

--- a/devinfra/js/debundle/docs/guide.md
+++ b/devinfra/js/debundle/docs/guide.md
@@ -75,6 +75,12 @@ spec first.
 Use `debundle run --dry-run` to run pipeline parse/facts/gate checks
 without writing emitted JS or reports.
 
+Add `--keep-going` during broad spec migrations to continue through supported
+diagnostic failures and report all findings from that pass. Today this
+aggregates duplicate binding claims during materialization plan building,
+including the chunk, binding, existing owner/export/origin, and competing
+owner/export/origin.
+
 ## Workflow: investigating a binding end-to-end
 
 When a binding's role is unclear or a proposal is suspicious:

--- a/devinfra/js/debundle/e2e/cross_module_emission_test.rs
+++ b/devinfra/js/debundle/e2e/cross_module_emission_test.rs
@@ -275,6 +275,76 @@ export { runtimeProcessor };
 }
 
 #[test]
+fn duplicate_top_level_decl_claims_are_reported_together() {
+    let opts = FixtureOpts::new(
+        r#"const runtimeService = "service";
+const runtimeCache = "cache";
+console.log(runtimeService, runtimeCache);
+export { runtimeService, runtimeCache };
+"#,
+        vec![
+            (
+                "owners/service".to_string(),
+                json!({
+                    "members": [{
+                        "name": "service",
+                        "selector": { "binding": { "name": "runtimeService" } },
+                    }],
+                }),
+            ),
+            (
+                "duplicates/service".to_string(),
+                json!({
+                    "members": [{
+                        "name": "serviceAgain",
+                        "selector": { "binding": { "name": "runtimeService" } },
+                    }],
+                }),
+            ),
+            (
+                "owners/cache".to_string(),
+                json!({
+                    "members": [{
+                        "name": "cache",
+                        "selector": { "binding": { "name": "runtimeCache" } },
+                    }],
+                }),
+            ),
+            (
+                "duplicates/cache".to_string(),
+                json!({
+                    "members": [{
+                        "name": "cacheAgain",
+                        "selector": { "binding": { "name": "runtimeCache" } },
+                    }],
+                }),
+            ),
+        ],
+    );
+
+    let rejected = run_keep_going_dry_run_rejection_fixture(opts);
+    let stderr = rejected.stderr;
+    for required in [
+        "Duplicate binding claim report: 2 duplicate claim(s) found",
+        "\"runtimeService\"",
+        "owners/service",
+        "as `service`",
+        "duplicates/service",
+        "as `serviceAgain`",
+        "\"runtimeCache\"",
+        "owners/cache",
+        "as `cache`",
+        "duplicates/cache",
+        "as `cacheAgain`",
+    ] {
+        assert!(
+            stderr.contains(required),
+            "stderr missing {required:?}\nstderr:\n{stderr}",
+        );
+    }
+}
+
+#[test]
 fn duplicate_source_match_class_claims_report_exports_and_selector_origins() {
     let class_selector = r#"class K {
   CLASS_REST;

--- a/devinfra/js/debundle/e2e/support.rs
+++ b/devinfra/js/debundle/e2e/support.rs
@@ -942,6 +942,12 @@ pub fn run_dry_run_rejection_fixture(opts: FixtureOpts<'_>) -> RejectedFixture {
     run_rejection_fixture_with_args(opts, &["--dry-run"])
 }
 
+/// Like [`run_dry_run_rejection_fixture`] but asks the pipeline to continue
+/// through supported diagnostics and report all findings from the pass.
+pub fn run_keep_going_dry_run_rejection_fixture(opts: FixtureOpts<'_>) -> RejectedFixture {
+    run_rejection_fixture_with_args(opts, &["--dry-run", "--keep-going"])
+}
+
 fn run_rejection_fixture_with_args(opts: FixtureOpts<'_>, extra_args: &[&str]) -> RejectedFixture {
     let setup = setup_fixture(&opts);
     let spec_path = setup.root.path().join("transform_spec.yaml");

--- a/devinfra/js/debundle/lowering/materialize/mod.rs
+++ b/devinfra/js/debundle/lowering/materialize/mod.rs
@@ -24,6 +24,7 @@ pub(super) struct ChunkContext<'a> {
     pub(super) chunk_id: &'a str,
     pub(super) file: Option<&'a str>,
     pub(super) target_dir: &'a str,
+    pub(super) keep_going: bool,
     pub(super) report_emission: &'a ReportEmission,
     /// Program-level cross-module purity output; this chunk's entries land
     /// in `AnalysisHints::imported_purities` / `declared_pure_members`.
@@ -82,6 +83,7 @@ pub(super) fn materialize_logical_chunk(
         chunk_id,
         file,
         target_dir,
+        keep_going,
         report_emission,
         cross_module_purities,
         vendor_import_oracle,
@@ -157,7 +159,7 @@ pub(super) fn materialize_logical_chunk(
     let residual_request = requests.iter().find(|request| request.residual).cloned();
 
     let build_module_plans_started = Instant::now();
-    let mut builder = ChunkPlanBuilder::new();
+    let mut builder = ChunkPlanBuilder::new(keep_going);
     let mut imported_binding_resolver =
         ArtifactSourceImportResolutionCache::new(artifact, artifact_indexes);
     let mut imported_from_by_src = BTreeMap::<String, String>::new();
@@ -279,7 +281,7 @@ pub(super) fn materialize_logical_chunk(
         bindings_catalogue,
         anonymous_ordinal_assignment,
         unmatched_spec_claims,
-    } = builder.finalize();
+    } = builder.finalize()?;
     // Plan structure is final — collect the explicit rename contributors
     // into the chunk's rename ledger and seal it. Seal hard-errors when
     // same-priority intents disagree on one binding's target; the sealed

--- a/devinfra/js/debundle/lowering/materialize/plan_builder.rs
+++ b/devinfra/js/debundle/lowering/materialize/plan_builder.rs
@@ -12,6 +12,74 @@
 use super::super::ordinal::body_index_for_statement_ordinal;
 use super::*;
 
+#[derive(Debug, Clone)]
+struct DuplicateClaimSite {
+    module_id: String,
+    export_name: Option<String>,
+    claim_origin: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct DuplicateBindingClaim {
+    chunk_id: String,
+    binding: String,
+    existing: DuplicateClaimSite,
+    duplicate: DuplicateClaimSite,
+}
+
+impl DuplicateBindingClaim {
+    fn render(&self) -> String {
+        format!(
+            "binding {:?} in chunk {:?}: already claimed by {}; duplicate claim by {}",
+            self.binding,
+            self.chunk_id,
+            render_duplicate_claim_site(&self.existing),
+            render_duplicate_claim_site(&self.duplicate),
+        )
+    }
+}
+
+fn render_duplicate_claim_site(site: &DuplicateClaimSite) -> String {
+    let export = site
+        .export_name
+        .as_deref()
+        .map(|name| format!(" as `{name}`"))
+        .unwrap_or_default();
+    let origin = site
+        .claim_origin
+        .as_deref()
+        .map(|origin| format!(" ({origin})"))
+        .unwrap_or_default();
+    format!("module {}{export}{origin}", site.module_id)
+}
+
+fn render_duplicate_binding_claims(duplicates: &[DuplicateBindingClaim]) -> String {
+    let mut duplicates = duplicates.iter().collect::<Vec<_>>();
+    duplicates.sort_by(|a, b| {
+        (
+            a.chunk_id.as_str(),
+            a.binding.as_str(),
+            a.duplicate.module_id.as_str(),
+            a.duplicate.export_name.as_deref().unwrap_or_default(),
+        )
+            .cmp(&(
+                b.chunk_id.as_str(),
+                b.binding.as_str(),
+                b.duplicate.module_id.as_str(),
+                b.duplicate.export_name.as_deref().unwrap_or_default(),
+            ))
+    });
+    let mut report = format!(
+        "Duplicate binding claim report: {} duplicate claim(s) found. Each binding may belong to exactly one logical module. Different selector forms (`{{name: foo}}` vs `{{name: foo, kind: class_declaration}}`) that resolve to the same source declaration still count as duplicates. To expose a binding under multiple readable names, list all the renames in one module.",
+        duplicates.len()
+    );
+    for duplicate in &duplicates {
+        report.push_str("\n- ");
+        report.push_str(&duplicate.render());
+    }
+    report
+}
+
 /// Output of `ChunkPlanBuilder::finalize`: everything downstream
 /// `lower_chunk` + the chunk-report builder need from the plan
 /// construction phase.
@@ -170,10 +238,20 @@ pub(super) struct ChunkPlanBuilder {
     /// name-collision checks. The map is dropped by
     /// `drop_explicit_request_scratch`.
     catalogue_index_by_name: HashMap<String, BindingKind>,
+    /// Duplicate binding claims found while processing explicit
+    /// requests. We keep scanning later requests after recording a
+    /// duplicate so one run can report all duplicate claim sites in
+    /// this chunk.
+    duplicate_binding_claims: Vec<DuplicateBindingClaim>,
+    /// Opt-in diagnostics mode. When false, duplicate binding claims
+    /// keep the historical fail-fast behavior. When true, duplicate
+    /// members are skipped from canonical ownership state so later
+    /// requests in this chunk can still be checked and reported.
+    keep_going: bool,
 }
 
 impl ChunkPlanBuilder {
-    pub(super) fn new() -> Self {
+    pub(super) fn new(keep_going: bool) -> Self {
         Self {
             binding_assignment: HashMap::new(),
             anonymous_ordinal_assignment: BTreeMap::new(),
@@ -182,6 +260,8 @@ impl ChunkPlanBuilder {
             residual_plan_index: None,
             unmatched_spec_claims: Vec::new(),
             catalogue_index_by_name: HashMap::new(),
+            duplicate_binding_claims: Vec::new(),
+            keep_going,
         }
     }
 
@@ -242,61 +322,63 @@ impl ChunkPlanBuilder {
             .collect();
         let dest_target_file = target_file_for_request(ctx.target_dir, &request.target_path)?;
         let module_id = ModuleId(LogicalModuleIndex(index));
+        let mut duplicate_bindings = BTreeSet::<String>::new();
         for member in &request.members {
             if let Some(existing_kind) = self.catalogue_index_by_name.get(member.binding.as_str()) {
-                let (existing_id, existing_export_name, existing_origin) = match existing_kind {
+                let existing = match existing_kind {
                     BindingKind::Owned {
                         module: ModuleId(LogicalModuleIndex(owner_index)),
                     } => {
                         let plan = self.module_plans.get(*owner_index);
-                        (
-                            plan.map(|plan| plan.id.clone())
+                        DuplicateClaimSite {
+                            module_id: plan
+                                .map(|plan| plan.id.clone())
                                 .unwrap_or_else(|| format!("<plan#{owner_index}>")),
-                            plan.and_then(|plan| plan.bindings.get(member.binding.as_str()))
+                            export_name: plan
+                                .and_then(|plan| plan.bindings.get(member.binding.as_str()))
                                 .cloned(),
-                            plan.and_then(|plan| {
-                                plan.binding_claim_origins.get(member.binding.as_str())
-                            })
-                            .cloned(),
-                        )
+                            claim_origin: plan
+                                .and_then(|plan| {
+                                    plan.binding_claim_origins.get(member.binding.as_str())
+                                })
+                                .cloned(),
+                        }
                     }
                     BindingKind::Imported {
                         re_exporter: ModuleId(LogicalModuleIndex(re_index)),
                         public_name,
                         ..
-                    } => (
-                        self.module_plans
-                            .get(*re_index)
-                            .map(|plan| plan.id.clone())
-                            .unwrap_or_else(|| format!("<plan#{re_index}>")),
-                        Some(public_name.to_string()),
-                        None,
-                    ),
+                    } => {
+                        let plan = self.module_plans.get(*re_index);
+                        DuplicateClaimSite {
+                            module_id: plan
+                                .map(|plan| plan.id.clone())
+                                .unwrap_or_else(|| format!("<plan#{re_index}>")),
+                            export_name: Some(public_name.to_string()),
+                            claim_origin: plan
+                                .and_then(|plan| {
+                                    plan.binding_claim_origins.get(member.binding.as_str())
+                                })
+                                .cloned(),
+                        }
+                    }
                 };
-                let existing_export = existing_export_name
-                    .as_deref()
-                    .map(|name| format!(" as `{name}`"))
-                    .unwrap_or_default();
-                let existing_origin = existing_origin
-                    .as_deref()
-                    .map(|origin| format!(" ({origin})"))
-                    .unwrap_or_default();
-                bail!(
-                    "Duplicate binding claim for {:?} in chunk {:?}: already \
-                     claimed by module {existing_id}{existing_export}{existing_origin} \
-                     and now also claimed by module {} as `{}` ({}). Each binding \
-                     may belong to exactly one logical module. \
-                     Different selector forms (`{{name: foo}}` vs \
-                     `{{name: foo, kind: class_declaration}}`) that resolve to the \
-                     same source declaration still count as duplicates. To expose a \
-                     binding under multiple readable names, list all the renames in \
-                     one module.",
-                    member.binding,
-                    ctx.chunk_id,
-                    request.id,
-                    member.export_name,
-                    member.claim_origin,
-                );
+                let duplicate = DuplicateBindingClaim {
+                    chunk_id: ctx.chunk_id.to_string(),
+                    binding: member.binding.clone(),
+                    existing,
+                    duplicate: DuplicateClaimSite {
+                        module_id: request.id.clone(),
+                        export_name: Some(member.export_name.clone()),
+                        claim_origin: Some(member.claim_origin.clone()),
+                    },
+                };
+                if !self.keep_going {
+                    bail!("{}", render_duplicate_binding_claims(&[duplicate]));
+                }
+                self.duplicate_binding_claims.push(duplicate);
+                duplicate_bindings.insert(member.binding.clone());
+                continue;
             }
             if member.is_import_specifier {
                 let (imported_name, imported_from) = resolve_imported_binding(
@@ -354,6 +436,7 @@ impl ChunkPlanBuilder {
         let binding_comments: BTreeMap<String, String> = request
             .members
             .iter()
+            .filter(|member| !duplicate_bindings.contains(member.binding.as_str()))
             .filter_map(|member| {
                 member
                     .comment
@@ -364,6 +447,7 @@ impl ChunkPlanBuilder {
         let binding_claim_origins: BTreeMap<String, String> = request
             .members
             .iter()
+            .filter(|member| !duplicate_bindings.contains(member.binding.as_str()))
             .map(|member| (member.binding.clone(), member.claim_origin.clone()))
             .collect();
         self.module_plans.push(ModulePlan {
@@ -757,13 +841,19 @@ impl ChunkPlanBuilder {
         self.residual_plan_index
     }
 
-    pub(super) fn finalize(self) -> ChunkPlan {
-        ChunkPlan {
+    pub(super) fn finalize(self) -> Result<ChunkPlan> {
+        if !self.duplicate_binding_claims.is_empty() {
+            bail!(
+                "{}",
+                render_duplicate_binding_claims(&self.duplicate_binding_claims)
+            );
+        }
+        Ok(ChunkPlan {
             module_plans: self.module_plans,
             binding_assignment: self.binding_assignment,
             bindings_catalogue: self.bindings_catalogue,
             anonymous_ordinal_assignment: self.anonymous_ordinal_assignment,
             unmatched_spec_claims: self.unmatched_spec_claims,
-        }
+        })
     }
 }

--- a/devinfra/js/debundle/lowering/mod.rs
+++ b/devinfra/js/debundle/lowering/mod.rs
@@ -258,6 +258,7 @@ pub struct MaterializeLogicalModulesOptions {
     pub chunk_ids: Vec<String>,
     pub file: Option<String>,
     pub prune_other_chunks: bool,
+    pub keep_going: bool,
     pub report_emission: ReportEmission,
     pub target_dir: String,
 }
@@ -344,6 +345,7 @@ pub fn materialize_logical_modules(
                             chunk_id,
                             file: options.file.as_deref(),
                             target_dir: &target_dir,
+                            keep_going: options.keep_going,
                             report_emission: &options.report_emission,
                             cross_module_purities: &cross_module_purities,
                             vendor_import_oracle: vendor_import_oracle.as_ref(),

--- a/devinfra/js/debundle/pipeline.rs
+++ b/devinfra/js/debundle/pipeline.rs
@@ -36,6 +36,7 @@ pub struct TransformCli {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct TransformRunOptions {
     pub dry_run: bool,
+    pub keep_going: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -76,6 +77,11 @@ pub struct TransformArgs {
     /// Run pipeline checks without writing emitted JS or reports.
     #[arg(long)]
     pub dry_run: bool,
+    /// Continue through supported spec-diagnostic failures and report all
+    /// findings from the pass. Currently aggregates duplicate binding claims
+    /// during materialization plan building.
+    #[arg(long)]
+    pub keep_going: bool,
 }
 
 impl TransformArgs {
@@ -239,6 +245,7 @@ pub fn run_transform_cli_with_options(
                     chunk_ids: materialise_chunk_ids,
                     file,
                     prune_other_chunks,
+                    keep_going: options.keep_going,
                     // Dry-run keeps the no-output contract on the
                     // accept path but still materializes rejection
                     // evidence (owner graph + cycles/conflicts) at the
@@ -883,7 +890,10 @@ mod tests {
                     package_roots: HashMap::new(),
                     packages_root: None,
                 },
-                TransformRunOptions { dry_run: true },
+                TransformRunOptions {
+                    dry_run: true,
+                    keep_going: false,
+                },
             )?;
 
             assert!(js_out.join("stale.txt").exists());


### PR DESCRIPTION
## Summary
- Add `debundle run --keep-going` and thread it through the transform/materialization options.
- In materialization plan building, keep default duplicate binding claim behavior fail-fast, but when `--keep-going` is set, collect duplicate binding claims across later requests in the chunk and emit one sorted report.
- Include chunk id, claimed binding, existing owner/export/origin, and competing owner/export/origin in each report row.
- Add generic e2e coverage for two independent duplicate binding claims surfaced in one `--dry-run --keep-going` run.
- Document current scope and add a TODO for source_match miss aggregation.

## Why
Broad selector/spec migrations should not require fixing one duplicate claim only to rerun and discover the next. This gives spec authors a small keep-going mode for the current fail-fast materialization-plan path while preserving default fail-fast behavior.

## Design notes
- Scope is duplicate binding claims within one chunk's materialization plan-building pass.
- Duplicate members are skipped from canonical ownership state while `--keep-going` continues scanning later requests, then the plan fails before lower_chunk consumes the inconsistent plan.
- Source-match selector misses still fail during selector resolution before plan-building owns an accumulator. `TODO.md` now tracks the needed request-level diagnostic collection pass.
- Based on `origin/devel` `fc0a9bd9b7adafe8c80ddaf00a5003a81375231d`.

## Validation
- `nix develop -c pre-commit run --files devinfra/js/debundle/pipeline.rs devinfra/js/debundle/cli/mod.rs devinfra/js/debundle/lowering/mod.rs devinfra/js/debundle/lowering/materialize/mod.rs devinfra/js/debundle/lowering/materialize/plan_builder.rs devinfra/js/debundle/e2e/support.rs devinfra/js/debundle/e2e/cross_module_emission_test.rs devinfra/js/debundle/docs/guide.md devinfra/js/debundle/docs/cli.md devinfra/js/debundle/TODO.md`
- `nix develop -c bazelisk --output_base=/tmp/bazel-ducktape-keep-going test //devinfra/js/debundle/e2e:cross_module_emission_test //devinfra/js/debundle:cli_test --config=ci --config=rbe --remote_upload_local_results=false --remote_download_outputs=all --test_output=errors`
  - BuildBuddy: https://app.buildbuddy.io/invocation/c162bac0-2a4f-4079-998d-858d9478cee0