### PR TITLE
[codex] debundle aggregate source_match keep-going diagnostics

### DIFF
--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -214,10 +214,11 @@ Still to do:
 - Full lowering matrix: binding placement reports, attached side-effects,
   staged-shell edge cases beyond the focused fixture.
 - Extend `debundle run --keep-going` beyond materialization duplicate binding
-  claims. Source-match selector misses currently fail during selector
-  resolution before plan-building has an accumulator, so batching those needs a
-  request-level diagnostic collection pass that can keep enough unresolved
-  claim context without mutating the canonical lowering plan.
+  claims. Member-form `source_match` selector misses and ambiguities now
+  aggregate at request resolution time by skipping unresolved members from the
+  canonical lowering plan and reporting them at finalize. Remaining follow-up:
+  do the same for anonymous statement selector misses / ambiguities, which still
+  fail in `resolve_anonymous_statement_ordinals`.
 - Owner-fragment modeling parity for nested declarations and re-exports.
 - Keep new analysis tooling on the existing owner graph and embedded atomic
   DAG side outputs; do not add parallel selected-owner cache formats.

--- a/devinfra/js/debundle/e2e/cross_module_emission_test.rs
+++ b/devinfra/js/debundle/e2e/cross_module_emission_test.rs
@@ -404,6 +404,69 @@ export { RuntimeCatalog };
 }
 
 #[test]
+fn keep_going_reports_source_match_failures_and_duplicate_claims_together() {
+    let missing_selector = r#"function selectedFormatter(value) {
+  return value.toLowerCase();
+}"#;
+    let ambiguous_selector = r#"function repeatedHelper() {
+  return "shared";
+}"#;
+    let opts = FixtureOpts::new(
+        r#"function renderCard(value) {
+  return value.trim();
+}
+function decoratePrimary() {
+  return "shared";
+}
+function decorateSecondary() {
+  return "shared";
+}
+console.log(renderCard(" ok "), decoratePrimary(), decorateSecondary());
+export { renderCard, decoratePrimary, decorateSecondary };
+"#,
+        vec![
+            logical_module(
+                "diagnostics/missing",
+                &[Member::source_alpha("MissingFormatter", missing_selector)],
+            ),
+            logical_module("owners/card", &[Member::new("renderCard")]),
+            logical_module(
+                "duplicates/card",
+                &[Member::renamed("renderCardAgain", "renderCard")],
+            ),
+            logical_module(
+                "diagnostics/ambiguous",
+                &[Member::source_alpha("AmbiguousHelper", ambiguous_selector)],
+            ),
+        ],
+    );
+
+    let rejected = run_keep_going_dry_run_rejection_fixture(opts);
+    let stderr = rejected.stderr;
+    for required in [
+        "Source-match selector diagnostic report: 2 unresolved selector(s) found",
+        "diagnostics/missing",
+        "as `MissingFormatter`",
+        "did not match any top-level declaration",
+        "diagnostics/ambiguous",
+        "as `AmbiguousHelper`",
+        "is ambiguous",
+        "decoratePrimary",
+        "decorateSecondary",
+        "Duplicate binding claim report: 1 duplicate claim(s) found",
+        "\"renderCard\"",
+        "owners/card",
+        "duplicates/card",
+        "as `renderCardAgain`",
+    ] {
+        assert!(
+            stderr.contains(required),
+            "stderr missing {required:?}\nstderr:\n{stderr}",
+        );
+    }
+}
+
+#[test]
 fn readable_import_without_collision() {
     // Single-plan sanity: a spec rename becomes the consumer-side import
     // local too; no input-bundle alias is needed when there is no collision.

--- a/devinfra/js/debundle/lowering/materialize/plan_builder.rs
+++ b/devinfra/js/debundle/lowering/materialize/plan_builder.rs
@@ -80,6 +80,50 @@ fn render_duplicate_binding_claims(duplicates: &[DuplicateBindingClaim]) -> Stri
     report
 }
 
+#[derive(Debug, Clone)]
+struct SourceMatchDiagnostic {
+    module_id: String,
+    export_name: String,
+    claim_origin: String,
+    message: String,
+}
+
+impl SourceMatchDiagnostic {
+    fn render(&self) -> String {
+        format!(
+            "module {} as `{}` ({}): {}",
+            self.module_id, self.export_name, self.claim_origin, self.message
+        )
+    }
+}
+
+fn render_source_match_diagnostics(diagnostics: &[SourceMatchDiagnostic]) -> String {
+    let mut diagnostics = diagnostics.iter().collect::<Vec<_>>();
+    diagnostics.sort_by(|a, b| {
+        (
+            a.module_id.as_str(),
+            a.export_name.as_str(),
+            a.claim_origin.as_str(),
+        )
+            .cmp(&(
+                b.module_id.as_str(),
+                b.export_name.as_str(),
+                b.claim_origin.as_str(),
+            ))
+    });
+    let mut report = format!(
+        "Source-match selector diagnostic report: {} unresolved selector(s) found. \
+         Under --keep-going, members with unresolved source_match selectors are skipped from \
+         canonical ownership so the rest of the chunk can still be checked.",
+        diagnostics.len()
+    );
+    for diagnostic in &diagnostics {
+        report.push_str("\n- ");
+        report.push_str(&diagnostic.render());
+    }
+    report
+}
+
 /// Output of `ChunkPlanBuilder::finalize`: everything downstream
 /// `lower_chunk` + the chunk-report builder need from the plan
 /// construction phase.
@@ -105,6 +149,8 @@ pub(super) struct ExplicitRequestContext<'a> {
 fn resolve_request_source_matches(
     request: &mut LogicalRequest,
     runtime_module: &Module,
+    keep_going: bool,
+    diagnostics: &mut Vec<SourceMatchDiagnostic>,
 ) -> Result<()> {
     let mut grouped_by_selector: BTreeMap<spec::AnonymousStatementSelector, Vec<usize>> =
         BTreeMap::new();
@@ -147,12 +193,28 @@ fn resolve_request_source_matches(
         if has_duplicate_target {
             continue;
         }
-        let resolved = source_match::resolve_member_binding_group(
+        let resolved = match source_match::resolve_member_binding_group(
             runtime_module,
             &request.id,
             &selector,
             &exports_by_target,
-        )?;
+        ) {
+            Ok(resolved) => resolved,
+            Err(error) if keep_going => {
+                let message = format!("{error:#}");
+                for idx in member_indices {
+                    let member = &request.members[idx];
+                    diagnostics.push(SourceMatchDiagnostic {
+                        module_id: request.id.clone(),
+                        export_name: member.export_name.clone(),
+                        claim_origin: member.claim_origin.clone(),
+                        message: message.clone(),
+                    });
+                }
+                continue;
+            }
+            Err(error) => return Err(error),
+        };
         for idx in member_indices {
             let member = &mut request.members[idx];
             let target_binding = member
@@ -173,7 +235,24 @@ fn resolve_request_source_matches(
         if resolved_member_indices.contains(&idx) {
             continue;
         }
-        member.resolve_source_match(runtime_module, &request.id, &mut source_match_cache)?;
+        if let Err(error) =
+            member.resolve_source_match(runtime_module, &request.id, &mut source_match_cache)
+        {
+            if !keep_going {
+                return Err(error);
+            }
+            diagnostics.push(SourceMatchDiagnostic {
+                module_id: request.id.clone(),
+                export_name: member.export_name.clone(),
+                claim_origin: member.claim_origin.clone(),
+                message: format!("{error:#}"),
+            });
+        }
+    }
+    if keep_going {
+        request
+            .members
+            .retain(|member| member.source_match.is_none());
     }
     Ok(())
 }
@@ -243,6 +322,11 @@ pub(super) struct ChunkPlanBuilder {
     /// duplicate so one run can report all duplicate claim sites in
     /// this chunk.
     duplicate_binding_claims: Vec<DuplicateBindingClaim>,
+    /// Member-form `source_match` selectors that did not resolve.
+    /// In keep-going mode, unresolved members are omitted from the
+    /// canonical plan so later modules in the chunk can still be
+    /// checked for independent selector and duplicate-claim failures.
+    source_match_diagnostics: Vec<SourceMatchDiagnostic>,
     /// Opt-in diagnostics mode. When false, duplicate binding claims
     /// keep the historical fail-fast behavior. When true, duplicate
     /// members are skipped from canonical ownership state so later
@@ -261,6 +345,7 @@ impl ChunkPlanBuilder {
             unmatched_spec_claims: Vec::new(),
             catalogue_index_by_name: HashMap::new(),
             duplicate_binding_claims: Vec::new(),
+            source_match_diagnostics: Vec::new(),
             keep_going,
         }
     }
@@ -278,7 +363,12 @@ impl ChunkPlanBuilder {
         imported_binding_resolver: &mut ArtifactSourceImportResolutionCache<'_>,
         imported_from_by_src: &mut BTreeMap<String, String>,
     ) -> Result<()> {
-        resolve_request_source_matches(request, ctx.runtime_module)?;
+        resolve_request_source_matches(
+            request,
+            ctx.runtime_module,
+            self.keep_going,
+            &mut self.source_match_diagnostics,
+        )?;
         reject_duplicate_member_bindings("logical_module", &request.id, &request.members)?;
         let mut bindings = HashMap::<String, String>::new();
         let anonymous_statement_claims =
@@ -842,11 +932,19 @@ impl ChunkPlanBuilder {
     }
 
     pub(super) fn finalize(self) -> Result<ChunkPlan> {
+        let mut reports = Vec::new();
+        if !self.source_match_diagnostics.is_empty() {
+            reports.push(render_source_match_diagnostics(
+                &self.source_match_diagnostics,
+            ));
+        }
         if !self.duplicate_binding_claims.is_empty() {
-            bail!(
-                "{}",
-                render_duplicate_binding_claims(&self.duplicate_binding_claims)
-            );
+            reports.push(render_duplicate_binding_claims(
+                &self.duplicate_binding_claims,
+            ));
+        }
+        if !reports.is_empty() {
+            bail!("{}", reports.join("\n\n"));
         }
         Ok(ChunkPlan {
             module_plans: self.module_plans,

--- a/devinfra/js/debundle/pipeline.rs
+++ b/devinfra/js/debundle/pipeline.rs
@@ -78,8 +78,8 @@ pub struct TransformArgs {
     #[arg(long)]
     pub dry_run: bool,
     /// Continue through supported spec-diagnostic failures and report all
-    /// findings from the pass. Currently aggregates duplicate binding claims
-    /// during materialization plan building.
+    /// findings from the pass. Currently aggregates materialization duplicate
+    /// binding claims plus member-form source_match misses and ambiguities.
     #[arg(long)]
     pub keep_going: bool,
 }


### PR DESCRIPTION
## Summary

- Extends `debundle run --keep-going` materialization diagnostics to collect member-form `source_match` misses and ambiguous selector failures instead of stopping at the first unresolved selector.
- Skips unresolved source-match members from the canonical lowering plan in keep-going mode, then reports them at finalize alongside duplicate binding claim diagnostics.
- Adds a synthetic e2e regression that reports two source-match selector failures and one duplicate binding claim in a single keep-going run.
- Updates the debundle TODO/help wording to mark member-form selector aggregation as implemented and leave anonymous statement selector aggregation as the next follow-up.

## Validation

- `nix develop -c pre-commit run --files devinfra/js/debundle/lowering/materialize/plan_builder.rs devinfra/js/debundle/e2e/cross_module_emission_test.rs devinfra/js/debundle/pipeline.rs devinfra/js/debundle/TODO.md`
- `nix develop -c bazelisk --output_base=/tmp/bazel-ducktape-aggregate-selector-diagnostics-rbe test --config=rbe //devinfra/js/debundle/e2e:cross_module_emission_test`
  - BuildBuddy: https://app.buildbuddy.io/invocation/c085cd65-9db2-465b-9447-6a8e8816b6c4

Note: local non-RBE Bazel attempts failed before compiling repo code because the rules_rust `process_wrapper` bootstrap could not find `ld` under the local strict action environment. The RBE validation above passed.