### PR TITLE
[codex] debundle keep failed source_match claims unresolved

### DIFF
--- a/devinfra/js/debundle/e2e/cross_module_emission_test.rs
+++ b/devinfra/js/debundle/e2e/cross_module_emission_test.rs
@@ -404,6 +404,104 @@ export { RuntimeCatalog };
 }
 
 #[test]
+fn duplicate_source_match_members_in_one_module_report_member_origins() {
+    let class_selector = r#"class K {
+  CLASS_REST;
+  label() {
+    return "catalog";
+  }
+  CLASS_REST;
+}"#;
+    let opts = FixtureOpts::new(
+        r#"class RuntimeCatalog {
+  label() {
+    return "catalog";
+  }
+}
+console.log(new RuntimeCatalog().label());
+export { RuntimeCatalog };
+"#,
+        vec![logical_module(
+            "catalog/combined",
+            &[
+                Member::source_alpha("PrimaryCatalog", class_selector),
+                Member::source_alpha_target("DuplicateCatalog", "K", class_selector),
+            ],
+        )],
+    );
+
+    let rejected = run_keep_going_dry_run_rejection_fixture(opts);
+    let stderr = rejected.stderr;
+    for required in [
+        "duplicate source binding claims",
+        "source binding `RuntimeCatalog` claimed 2 times",
+        "export `PrimaryCatalog`",
+        "members[].selector.source_match as `PrimaryCatalog`",
+        "export `DuplicateCatalog`",
+        "members[].selector.source_match target_binding `K` as `DuplicateCatalog`",
+    ] {
+        assert!(
+            stderr.contains(required),
+            "stderr missing {required:?}\nstderr:\n{stderr}",
+        );
+    }
+    assert!(
+        !stderr.contains("duplicate source bindings:"),
+        "old blank duplicate list must not be emitted:\n{stderr}",
+    );
+}
+
+#[test]
+fn keep_going_drops_failed_source_match_members_in_same_module() {
+    let opts = FixtureOpts::new(
+        r#"function existingHelper(value) {
+  return value.trim();
+}
+console.log(existingHelper(" ok "));
+export { existingHelper };
+"#,
+        vec![logical_module(
+            "diagnostics/source_match",
+            &[
+                Member::source_alpha(
+                    "MissingFormatter",
+                    r#"function missingFormatter(value) {
+  return value.toLowerCase();
+}"#,
+                ),
+                Member::source_alpha(
+                    "MissingParser",
+                    r#"function missingParser(value) {
+  return Number(value);
+}"#,
+                ),
+            ],
+        )],
+    );
+
+    let rejected = run_keep_going_dry_run_rejection_fixture(opts);
+    let stderr = rejected.stderr;
+    for required in [
+        "Source-match selector diagnostic report: 2 unresolved selector(s) found",
+        "diagnostics/source_match",
+        "as `MissingFormatter`",
+        "as `MissingParser`",
+        "did not match any top-level declaration",
+        "missingFormatter",
+        "missingParser",
+    ] {
+        assert!(
+            stderr.contains(required),
+            "stderr missing {required:?}\nstderr:\n{stderr}",
+        );
+    }
+    assert!(
+        !stderr.contains("duplicate source binding"),
+        "failed source_match members must not become empty binding claims:\n{stderr}",
+    );
+}
+
+#[test]
 fn keep_going_reports_source_match_failures_and_duplicate_claims_together() {
     let missing_selector = r#"function selectedFormatter(value) {
   return value.toLowerCase();

--- a/devinfra/js/debundle/lowering/exports.rs
+++ b/devinfra/js/debundle/lowering/exports.rs
@@ -190,7 +190,42 @@ pub(super) fn reject_duplicate_member_bindings(
     id: &str,
     members: &[MemberRequest],
 ) -> Result<()> {
-    reject_duplicate_field(operation, id, "source bindings", members, |m| &m.binding)
+    let mut by_binding = BTreeMap::<String, Vec<&MemberRequest>>::new();
+    for member in members {
+        if member.source_match.is_some() {
+            continue;
+        }
+        by_binding
+            .entry(member.binding.clone())
+            .or_default()
+            .push(member);
+    }
+    let duplicates = by_binding
+        .into_iter()
+        .filter(|(_, members)| members.len() > 1)
+        .collect::<Vec<_>>();
+    if duplicates.is_empty() {
+        return Ok(());
+    }
+    let mut report = format!("{operation} {id} has duplicate source binding claims:");
+    for (binding, members) in duplicates {
+        let binding = if binding.is_empty() {
+            "<unresolved>".to_string()
+        } else {
+            format!("`{binding}`")
+        };
+        report.push_str(&format!(
+            "\n- source binding {binding} claimed {} times:",
+            members.len()
+        ));
+        for member in members {
+            report.push_str(&format!(
+                "\n  - export `{}` ({})",
+                member.export_name, member.claim_origin
+            ));
+        }
+    }
+    bail!("{report}");
 }
 
 fn reject_duplicate_field(

--- a/devinfra/js/debundle/lowering/plans.rs
+++ b/devinfra/js/debundle/lowering/plans.rs
@@ -80,7 +80,7 @@ impl MemberRequest {
         request_id: &str,
         cache: &mut BTreeMap<spec::AnonymousStatementSelector, source_match::ResolvedMemberBinding>,
     ) -> Result<()> {
-        let Some(selector) = self.source_match.take() else {
+        let Some(selector) = self.source_match.clone() else {
             return Ok(());
         };
         let resolved = match cache.get(&selector) {
@@ -99,6 +99,7 @@ impl MemberRequest {
         self.binding = resolved.binding_name;
         self.is_import_specifier =
             matches!(resolved.kind, Some(BindingSourceKind::ImportSpecifier));
+        self.source_match = None;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Follow-up after #2203:

- Keeps failed member-form `source_match` selectors unresolved until resolution succeeds, so `--keep-going` drops failed members instead of turning them into blank concrete binding claims.
- Improves same-module duplicate source binding diagnostics to list the claimed source binding plus each involved export/origin row.
- Adds generic e2e coverage for duplicate source-match members and failed source-match members in one module.

All fixtures are synthetic/generic; no downstream private snippets are included.

## Tests

- `nix develop -c pre-commit run --files devinfra/js/debundle/e2e/cross_module_emission_test.rs devinfra/js/debundle/lowering/exports.rs devinfra/js/debundle/lowering/plans.rs`
- `nix develop -c bazelisk --output_base=/tmp/bazel-ducktape-2202-resolve test //devinfra/js/debundle/e2e:cross_module_emission_test --config=nolint --config=rbe --remote_upload_local_results=false --remote_download_outputs=all`
  - BuildBuddy: https://app.buildbuddy.io/invocation/ef3db248-2eb6-4b7f-8d9e-314a8bf76b7b