### PR TITLE
debundle: aggregate anonymous selector diagnostics

### DIFF
--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -213,12 +213,6 @@ Still to do:
 
 - Full lowering matrix: binding placement reports, attached side-effects,
   staged-shell edge cases beyond the focused fixture.
-- Extend `debundle run --keep-going` beyond materialization duplicate binding
-  claims. Member-form `source_match` selector misses and ambiguities now
-  aggregate at request resolution time by skipping unresolved members from the
-  canonical lowering plan and reporting them at finalize. Remaining follow-up:
-  do the same for anonymous statement selector misses / ambiguities, which still
-  fail in `resolve_anonymous_statement_ordinals`.
 - Owner-fragment modeling parity for nested declarations and re-exports.
 - Keep new analysis tooling on the existing owner graph and embedded atomic
   DAG side outputs; do not add parallel selected-owner cache formats.

--- a/devinfra/js/debundle/e2e/anonymous_statement_test.rs
+++ b/devinfra/js/debundle/e2e/anonymous_statement_test.rs
@@ -235,6 +235,48 @@ export { X, Existing };
     );
 }
 
+#[test]
+fn keep_going_reports_anonymous_statement_failures_and_duplicate_claims_together() {
+    let opts = FixtureOpts::new(
+        r#"console.log("dup");
+const marker = 1;
+console.log("dup");
+export { marker };
+"#,
+        vec![
+            logical_module_with_anon("diagnostics/missing", &[], &[r#"console.log("missing");"#]),
+            logical_module_with_anon("diagnostics/ambiguous", &[], &[r#"console.log("dup");"#]),
+            logical_module("owners/marker", &[Member::new("marker")]),
+            logical_module(
+                "duplicates/marker",
+                &[Member::renamed("markerAgain", "marker")],
+            ),
+        ],
+    );
+
+    let rejected = run_keep_going_dry_run_rejection_fixture(opts);
+    let stderr = rejected.stderr;
+    for required in [
+        "Anonymous statement selector diagnostic report: 2 unresolved selector(s) found",
+        "diagnostics/missing",
+        "did not match any top-level statement group",
+        r#"console.log("missing")"#,
+        "diagnostics/ambiguous",
+        "ambiguous",
+        r#"console.log("dup")"#,
+        "Duplicate binding claim report: 1 duplicate claim(s) found",
+        "\"marker\"",
+        "owners/marker",
+        "duplicates/marker",
+        "as `markerAgain`",
+    ] {
+        assert!(
+            stderr.contains(required),
+            "stderr missing {required:?}\nstderr:\n{stderr}",
+        );
+    }
+}
+
 // Pin source-order interleaving of anonymous-statement members
 // and named members within the same logical module.
 //

--- a/devinfra/js/debundle/lowering/anonymous.rs
+++ b/devinfra/js/debundle/lowering/anonymous.rs
@@ -13,6 +13,18 @@ pub(super) struct ResolvedAnonymousStatement {
     pub(super) comment: Option<String>,
 }
 
+#[derive(Debug, Clone)]
+pub(super) struct AnonymousStatementDiagnostic {
+    pub(super) module_id: String,
+    pub(super) message: String,
+}
+
+impl AnonymousStatementDiagnostic {
+    pub(super) fn render(&self) -> String {
+        format!("module {}: {}", self.module_id, self.message)
+    }
+}
+
 /// Resolve every anonymous statement entry on `request` to a
 /// pre-split body index in `runtime_module`'s top-level body. The
 /// resolver requires exactly one match per entry — a 0-match or
@@ -20,14 +32,26 @@ pub(super) struct ResolvedAnonymousStatement {
 pub(super) fn resolve_anonymous_statement_ordinals(
     request: &LogicalRequest,
     runtime_module: &Module,
+    keep_going: bool,
+    diagnostics: &mut Vec<AnonymousStatementDiagnostic>,
 ) -> Result<Vec<ResolvedAnonymousStatement>> {
     let mut resolved = Vec::new();
     for statement in &request.anonymous_statements {
-        let ordinals = source_match::resolve_anonymous_statement_body_indices(
+        let ordinals = match source_match::resolve_anonymous_statement_body_indices(
             runtime_module,
             &request.id,
             &statement.selector,
-        )?;
+        ) {
+            Ok(ordinals) => ordinals,
+            Err(error) if keep_going => {
+                diagnostics.push(AnonymousStatementDiagnostic {
+                    module_id: request.id.clone(),
+                    message: format!("{error:#}"),
+                });
+                continue;
+            }
+            Err(error) => return Err(error),
+        };
         for ordinal in ordinals {
             resolved.push(ResolvedAnonymousStatement {
                 ordinal,

--- a/devinfra/js/debundle/lowering/materialize/plan_builder.rs
+++ b/devinfra/js/debundle/lowering/materialize/plan_builder.rs
@@ -124,6 +124,22 @@ fn render_source_match_diagnostics(diagnostics: &[SourceMatchDiagnostic]) -> Str
     report
 }
 
+fn render_anonymous_statement_diagnostics(diagnostics: &[AnonymousStatementDiagnostic]) -> String {
+    let mut diagnostics = diagnostics.iter().collect::<Vec<_>>();
+    diagnostics.sort_by(|a, b| a.module_id.cmp(&b.module_id));
+    let mut report = format!(
+        "Anonymous statement selector diagnostic report: {} unresolved selector(s) found. \
+         Under --keep-going, anonymous statements with unresolved selectors are skipped from \
+         canonical ownership so the rest of the chunk can still be checked.",
+        diagnostics.len()
+    );
+    for diagnostic in &diagnostics {
+        report.push_str("\n- ");
+        report.push_str(&diagnostic.render());
+    }
+    report
+}
+
 /// Output of `ChunkPlanBuilder::finalize`: everything downstream
 /// `lower_chunk` + the chunk-report builder need from the plan
 /// construction phase.
@@ -327,6 +343,12 @@ pub(super) struct ChunkPlanBuilder {
     /// canonical plan so later modules in the chunk can still be
     /// checked for independent selector and duplicate-claim failures.
     source_match_diagnostics: Vec<SourceMatchDiagnostic>,
+    /// Anonymous statement selectors that did not resolve. In
+    /// keep-going mode, unresolved anonymous statements are omitted
+    /// from canonical ownership so later modules in the chunk can
+    /// still be checked for independent selector and duplicate-claim
+    /// failures.
+    anonymous_statement_diagnostics: Vec<AnonymousStatementDiagnostic>,
     /// Opt-in diagnostics mode. When false, duplicate binding claims
     /// keep the historical fail-fast behavior. When true, duplicate
     /// members are skipped from canonical ownership state so later
@@ -346,6 +368,7 @@ impl ChunkPlanBuilder {
             catalogue_index_by_name: HashMap::new(),
             duplicate_binding_claims: Vec::new(),
             source_match_diagnostics: Vec::new(),
+            anonymous_statement_diagnostics: Vec::new(),
             keep_going,
         }
     }
@@ -371,8 +394,12 @@ impl ChunkPlanBuilder {
         )?;
         reject_duplicate_member_bindings("logical_module", &request.id, &request.members)?;
         let mut bindings = HashMap::<String, String>::new();
-        let anonymous_statement_claims =
-            resolve_anonymous_statement_ordinals(request, ctx.runtime_module)?;
+        let anonymous_statement_claims = resolve_anonymous_statement_ordinals(
+            request,
+            ctx.runtime_module,
+            self.keep_going,
+            &mut self.anonymous_statement_diagnostics,
+        )?;
         for claim in &anonymous_statement_claims {
             if let Some(existing) = self
                 .anonymous_ordinal_assignment
@@ -936,6 +963,11 @@ impl ChunkPlanBuilder {
         if !self.source_match_diagnostics.is_empty() {
             reports.push(render_source_match_diagnostics(
                 &self.source_match_diagnostics,
+            ));
+        }
+        if !self.anonymous_statement_diagnostics.is_empty() {
+            reports.push(render_anonymous_statement_diagnostics(
+                &self.anonymous_statement_diagnostics,
             ));
         }
         if !self.duplicate_binding_claims.is_empty() {

--- a/devinfra/js/debundle/lowering/mod.rs
+++ b/devinfra/js/debundle/lowering/mod.rs
@@ -61,7 +61,7 @@ mod util;
 mod vendor_imports;
 mod visitors;
 
-use anonymous::resolve_anonymous_statement_ordinals;
+use anonymous::{AnonymousStatementDiagnostic, resolve_anonymous_statement_ordinals};
 use body_facts::{ModuleBodyFacts, collect_module_body_facts};
 use chunk_ast::{
     ChunkAstAnalysis, TopLevelDecl, analyze_chunk_ast, binding_ids, binding_names, declaration_ids,


### PR DESCRIPTION
## Summary

- extend `debundle run --keep-going` to aggregate unresolved `anonymous_statements` selector misses / ambiguities
- skip only unresolved anonymous statements from canonical ownership so later modules in the chunk can still be checked
- add a generic e2e fixture that reports two anonymous selector failures and a duplicate binding claim in one dry run
- remove the completed TODO item from `devinfra/js/debundle/TODO.md`

## Downstream profile

Built this branch's debundle binary with #2201 included and reran the broad Gaffer 660 dry-run shape against `/tmp/gaffer-tana-web-6602072d13-port`:

- command shape: `debundle run --dry-run --keep-going` with `DUCKTAPE_SOURCE_MATCH_TIMINGS=1`, threshold `100ms`, preview disabled
- result: `exit=1 elapsed=101.560s stderr_lines=123`
- current downstream failure after the existing selector/spec edits: `logical_module static/index-DZ6JtwaK::features/notifications/notificationSchemas has duplicate source bindings`
- no anonymous selector failures were reached in this current downstream state, so this PR is an ergonomics / keep-going breadth improvement rather than a measured wall-time reduction for the exact current Gaffer failure
- the timing tail is still dominated by member-form `source_match` selectors, with many `members[].selector.source_match` entries around `125-250ms` and one observed `1386ms` selector in `app/desktop/desktopEventBridge`; next perf work should target additional member-selector prefilters or cached candidate indexing

## Validation

- `nix develop -c pre-commit run --files devinfra/js/debundle/TODO.md devinfra/js/debundle/lowering/anonymous.rs devinfra/js/debundle/lowering/materialize/plan_builder.rs devinfra/js/debundle/lowering/mod.rs devinfra/js/debundle/e2e/anonymous_statement_test.rs`
- `nix develop -c bbr test --config=nolint //devinfra/js/debundle/e2e:anonymous_statement_test`
- `nix develop -c bbr test --config=nolint //devinfra/js/debundle/e2e:anonymous_statement_test //devinfra/js/debundle/e2e:cross_module_emission_test`
- `nix develop -c bbr build --remote_download_outputs=all --config=nolint //devinfra/js/debundle:debundle`