### PR TITLE
airlock: populate real Google OAuth client credentials

### DIFF
--- a/cluster/k8s/agents/airlock/google-client-credentials.sops.yaml
+++ b/cluster/k8s/agents/airlock/google-client-credentials.sops.yaml
@@ -1,35 +1,33 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: google-client-credentials
-  namespace: airlock
-  annotations:
-    description: Google OAuth2 client credentials
+    name: google-client-credentials
+    namespace: airlock
 type: Opaque
 stringData:
-  client_id: ENC[AES256_GCM,data:TnPSTwq+YKBqbQ==,iv:kGAPmmDUiqNn7aK3y0Jd31mZzuWnDwBDjSIQe3QiN8k=,tag:D3KeLQh3W9WYQAyrk6THTA==,type:str]
-  client_secret: ENC[AES256_GCM,data:U3fLkTjGTCQ34Q==,iv:a2uQmZXHX1Bp7+aex5tIXYJeJgVtyjOVCHXrjYwGew8=,tag:zQXhN9lYQ7tBHFW9h2zmPA==,type:str]
+    client_id: ENC[AES256_GCM,data:Yy/MmUUvnQl0CqcPze7aGbKtArRHHWtoexyvgVsHktK8UJKNNCec8g7J0vbIfQ6ZVp+vpwP3Lt2odAyisBY+8oepSiLeJ/B3,iv:ADkX6oLE+39SOwNRSOdYcbg/tp9s9cv4bv07xzyJENc=,tag:hhSi3PI4LaxEFv6sL8A5Hw==,type:str]
+    client_secret: ENC[AES256_GCM,data:V7Bbl547/5zD0vxgOS61UwAm1qQFJr8N+y1H6iZ23O7B84M=,iv:rq2GPdyVmLUOfsfqKPpe7MzeceEgbqWMPh5So3T+rKI=,tag:/LkRpgEGhmPNdM7o30CSrQ==,type:str]
 sops:
-  age:
-    - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
-      enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBtYTczUExVNFBLT1V1NFEz
-        ZUJxUVdJTHNOTDlzU3NoVHZueWxGdEluaDNFCjZsS1MxY3c0VGlPQ1hRNzZVVElK
-        WEF5TUVMVGtBY0lKM0V0WUJOdG10T3MKLS0tIFFDU1RKQWdHRnZhMkFtOEdyU1l0
-        b2lqSFIycXpGQWJmd2RnM0ZpbVhpS1UKoPlezeTCg7fotw+cXlZQUtzqnyEMM6WX
-        8ZOaraeAhI08FFio9EbX73/yX+YcH/XhFbFpSuP8TOK7Eo64RB3JVA==
-        -----END AGE ENCRYPTED FILE-----
-    - recipient: age1nywlwepsyfxvyhqwkjquzz02nmus65gf6qewfjju4alym8f7se5qnua8na
-      enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2M25IVEhOYlJvYjlEcDBD
-        azBPRFRna3N4Q2tacjROejZEZFE2V01Yam1NCldsR21OYVU2L2dhK0cxMEtCbUVv
-        QmxHWTlLZXVuV1J1eE82T0Jia2ZwK2sKLS0tIG8zb3JvNnNnaEo0YVdLcFB3b2gy
-        RTA3amQzM1ZWV0IrZllJRWRsTFhGbjQK7RfTe7fzplikVV3XMq0bg0RZNpBKHEQh
-        HbHjW+z+TT6TsDE6SsOeqc/+QAd5Eh5BsrcJ46IoUhLerHPRo8W6AQ==
-        -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-04-05T19:50:16Z"
-  mac: ENC[AES256_GCM,data:Ts/hqBfKf8SM6pkthLS6HPLOJUfH5GvfFObsH5cIVXoqXHknLphHJEFvNNbhQtjSwhJcEA69itmmmDWzwKIkjtRFvCYNAKMhRBODBQx8I2axASPCNkXYzgr3oerYnjEbxUFCK0aSdZUNs7YbJiNS6/UdehYRQqkWTxKGcTs4dpw=,iv:P2jNouRQb5G6tyiQuPZrZcty0gH2UMdbIcRvf44EXbM=,tag:uLCqcne9dG9EKicvlFyCIA==,type:str]
-  encrypted_regex: ^(data|stringData)$
-  version: 3.12.1
+    age:
+        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2M0lsb3l1cXVhT3hCQXJj
+            cGxCWE5ZRW1SbURETVlUL1puV2ducU5ySVIwCnhGT1BBaGEwVFBTaDViSmVyNU9n
+            d1pwRGg3UkhyR2tyMGpOZFFZVFljNkEKLS0tIHJkRDBBWWtUNzBuUmNCTlg5YXRs
+            aENjbkRkcDRGZjJPd2VST0NMaWtkcTgK/4KKF7mI4gzvIAhZW9hlnZiW5AYCC5M4
+            3/cgGYOhOETO6Nu8AuHPQ8//evgvoGvZc09ODsEtrupSuOsBw0FvKQ==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1nywlwepsyfxvyhqwkjquzz02nmus65gf6qewfjju4alym8f7se5qnua8na
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLWEQ5dVYxZlVEci9RNW8w
+            R3V1NXFlYUpyd0V6RVZYMGtuQlNEY0I4RnpBClQxLzUwMUxtZGlBWmpRRG1kMC9U
+            TE91WlgyRnFBYkFYQTJ2cWNmcndnZGsKLS0tIGhwaUxLWTVOSzU1dzhVZDVxT3NK
+            QThTYndsRTBmbWlxeWxEOVpwdWNHeXcKiL27Zh16rBcYmwxdttYWnE3tJ7c6N09S
+            JIvk4SxT7OvYN3o2PjIHnAZcerTEP1Z4RmoAzMPUmG8lu7D8P/i2lg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-06-14T00:12:28Z"
+    mac: ENC[AES256_GCM,data:4mvGw6WKiK4//3zMyhUv2pS7fu+WAl2u+eKoWW07JBhjDiFuVn8MxaJpxj2PpEZwOLd8yIV46G8lUIJWZo8F17wUKxl6dVuOZOJCk0VqXM6ky3Cjt4oMZXe2QmUG0E/8fBWHHj8+ockLf0R916cdxMpd/XEhdGe7TdxtWOk7ZKs=,iv:cbnN1IeAX9Gj6xFVCPQFS8y6Yt5qOmNt23SBpB7YUIw=,tag:QLGY7tykZgdgSc+ZlPXSmw==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.1


### PR DESCRIPTION
## Problem

The `google-client-credentials` SOPS secret in `airlock` held `REPLACE_ME` placeholders (confirmed against the live cluster), so airlock built the Google authorize URL with `client_id=REPLACE_ME` and Google returned `Error 401: invalid_client`.

## Fix

Encrypt the real `web`-type Google OAuth client credentials into `cluster/k8s/agents/airlock/google-client-credentials.sops.yaml`. The client's redirect URI (`https://airlock.allegedly.works/oauth/callback/google`) already matches `config.yaml`.

## After merge

Flux reconciles the secret, then `kubectl rollout restart deployment/airlock -n airlock` so the pod re-reads `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET`.