### PR TITLE
debundle: record member source_match perf followup

### DIFF
--- a/devinfra/js/debundle/perf/proposer.md
+++ b/devinfra/js/debundle/perf/proposer.md
@@ -195,6 +195,52 @@ ducktape_version)` per chunk and skip lowering, codegen, and reports
   atoms / owner_graph / atomic_units / realizability / factorize /
   peel_candidates reports they do not need.
 
+### Member-form `source_match` selector resolution
+
+The Gaffer 660 migration loop still spends most of its broad
+`debundle run --dry-run --keep-going` wall time in member-form
+`source_match` selectors after the literal-initializer fast path
+(#2201) and selector aggregation (#2200/#2203).
+
+Current downstream profile snapshot, 2026-06-14, using the broad Gaffer
+660 command shape with `DUCKTAPE_SOURCE_MATCH_TIMINGS=1`,
+`DUCKTAPE_SOURCE_MATCH_TIMING_THRESHOLD_MS=100`, and preview disabled:
+
+- wall: ~129s to the current aggregate duplicate-claim report;
+- timing lines: 129 `members[].selector.source_match` entries above
+  100ms;
+- representative early hot selectors: `hotkeyModifierSortOrder`
+  ~202ms, `compareHotkeyModifierOrder` ~258ms,
+  `composeNormalizedHotkey` ~423ms, plus many 120–250ms selectors
+  across bootstrap, panel, AI, search, and style modules.
+
+Two bounded per-declarator prefilter experiments were tried and rejected:
+
+- nested string-literal multiset prefilter for single-declarator
+  selectors: sound, but it scanned candidate initializer subtrees and
+  worsened the broad run to 128.951s;
+- exact primitive-literal initializer key (`string`/`bool`/`number`/`null`):
+  cheap and tested, but broad run remained 128.955s with 129 timing
+  lines, so it did not materially improve the real workload.
+
+Next credible implementation: add a shared per-chunk source-match
+candidate index/cache rather than more ad hoc per-selector filters. The
+index should be built once per chunk during materialization and reused
+across member/binding-group selectors. Candidate keys to try, with
+counters before changing semantics:
+
+- top-level body kind + declaration kind + var kind/declarator count;
+- declared-binding count and, in exact identifier mode, declared-binding
+  names;
+- cheap literal fingerprints for top-level statements/declarators,
+  computed once per body item;
+- parsed selector/prepared-needle reuse keyed by normalized selector body
+  so repeated selector families do not reparse or rebuild matcher state.
+
+Treat a candidate-index PR as successful only if it shows a wall-time
+drop or a large reduction in timed selector count on the broad Gaffer
+gate; isolated unit wins are not enough for this path.
+
 ### Materialize-stage hot-loop optimizations
 
 Ordered by leverage. Re-profile before implementation if the consumer


### PR DESCRIPTION
## Summary

- records the current member-form `source_match` broad-run profile from the Gaffer 660 migration loop
- documents two bounded prefilter experiments that did not produce a validated improvement
- captures the next credible implementation plan: a shared per-chunk candidate index/cache reused across member and binding-group selectors

## Profile Evidence

Current broad downstream shape after #2203/#2202 on current `devel`:

- `debundle run --dry-run --keep-going`
- `DUCKTAPE_SOURCE_MATCH_TIMINGS=1`
- `DUCKTAPE_SOURCE_MATCH_TIMING_THRESHOLD_MS=100`
- preview disabled
- result: about `129s` to the current aggregate duplicate-claim report
- timing output: `129` member-form `source_match` entries over `100ms`
- representative early hot selectors: `hotkeyModifierSortOrder` around `202ms`, `compareHotkeyModifierOrder` around `258ms`, `composeNormalizedHotkey` around `423ms`

Rejected experiments:

- nested string-literal multiset prefilter: sound but worsened the broad run to `128.951s` because it scanned candidate initializer subtrees
- exact primitive-literal initializer prefilter: cheap and unit-tested, but broad run remained `128.955s` with `129` timing lines, so it did not materially improve this workload

## Validation

- `nix develop -c pre-commit run --files devinfra/js/debundle/perf/proposer.md`
- experimental source_match unit validation before reverting code experiment: `nix develop -c bbr test --config=nolint //devinfra/js/debundle:source_match_test`

No code optimization is included in this PR; it is the requested precise TODO/perf note after failing to find a small validated improvement.