### PR TITLE
airlock: populate real Oura OAuth client credentials

### DIFF
--- a/cluster/k8s/agents/airlock/oura-client-credentials.sops.yaml
+++ b/cluster/k8s/agents/airlock/oura-client-credentials.sops.yaml
@@ -1,35 +1,35 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: oura-client-credentials
-  namespace: airlock
-  annotations:
-    description: Oura health API OAuth2 credentials
+    name: oura-client-credentials
+    namespace: airlock
+    annotations:
+        description: Oura health API OAuth2 credentials
 type: Opaque
 stringData:
-  client_id: ENC[AES256_GCM,data:tJmp6ywrCGd+Dw==,iv:EZN9flTDdMn0j0z/ntUnxTXWH5AtXfwCKcDq0ohcaU4=,tag:+nVYe1AmsuVzkndJKItfRw==,type:str]
-  client_secret: ENC[AES256_GCM,data:FgLQI7tE7JhYeg==,iv:O5Fs6VzEu4BZAEvieQK6QcggWglF6FRsMIJ1z0zUMz8=,tag:npjzb3SwBIfiluo703/mAQ==,type:str]
+    client_id: ENC[AES256_GCM,data:bfi23VPAbbUs3z/ocw792JDX3Zt2WvDjeXovLiV79zwT/5nA,iv:DM686I93GxTLCgNCHQX7SwpV6DCckHeAEhcgc06Qygg=,tag:dQpODRRgezZFzVlATV8vxA==,type:str]
+    client_secret: ENC[AES256_GCM,data:fo/weQpw99+aPs3/Wc13mh0kxTK6HJ+WpjzOmCSUhnSP2ikX+h5iJglFtw==,iv:vWpwMEheCAvYIvBjHrgU0U38c9ltcKdTVl+80+jOAhY=,tag:vqGqEENLcR5yZ3AH2bdCGA==,type:str]
 sops:
-  age:
-    - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
-      enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPL1h1TTNoZFVDK2lJckhM
-        cVJKL1dHQjFHQUtWUkFnL0VPaG9ycHRXOUhzClgrbWlXYmJxTjc4VGlOdGdpd1FQ
-        T2pSWm1yVVBIUVFQbmpXSDM2UGJKQjQKLS0tIEdCd3gvaGJSWTlKMzloVjFObHhT
-        MEZlQWJmZkt2SGtuZUpoUjVXQTRtZlEK5KQZYPfJvxfo+14M3cDgMY0Zo44kBieo
-        ft6ZCqWkewYmLQIAdCTcvQalel2UaQLE5Gv40JH1H1k5wBoX23xvZA==
-        -----END AGE ENCRYPTED FILE-----
-    - recipient: age1nywlwepsyfxvyhqwkjquzz02nmus65gf6qewfjju4alym8f7se5qnua8na
-      enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA5OEJkVjExNVpaL3M0eG0x
-        KzVuMWtrV3U4QktZeURwc0I1eU1FeUxyK3hFCmtXQTJBdHBSSzI4eDBLd2o1MUxN
-        b2pwZ2JjSlBmb1FQMjBlU1VJbHFHZzgKLS0tIEtkYU9DUGNhUFhDenRnS2ZQMm9y
-        VjhqTHFYMzNXNDdJL3QrY1dVakczRncKOqQ+at90wfXL8lG46jy8O1rT3VO0PJey
-        1DlefrVO+WxwqGPp83wEUCti/gPYf3tdGPsxhjcbXhWwpao3XiE4Dg==
-        -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-04-05T19:50:16Z"
-  mac: ENC[AES256_GCM,data:E8jNw5tKCC+2Ot2+l46WnkQ3nnwjIGfBgMzXMKo1pyA1k0k+AumR9oMjGkhgBb1IzVTR5L/5Szz9zJcak3CduoMbW1fw3X4hM+uzBnaYpvFXCdAd1Rec5XoWiT8y+HMTBXLZSsCJrD9Y+fbylvXKiiXU/GMj/QwDLifhQduy/IE=,iv:9aJj2oXBMQ0Od+D2lvIHVdurWXLuEZWphRTGnFfrVHk=,tag:yz5cGidoexrJHxbqAqkEPw==,type:str]
-  encrypted_regex: ^(data|stringData)$
-  version: 3.12.1
+    age:
+        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxYjAzNUo2MkRlSmE2ZXkv
+            c3BaNFE2bHQzUWVPVW9Fd3lrbk9GREdUcnlzCkd2WHhQc1ZyclhpZlBCMld4QUJy
+            Z1RVaENzRmxYd0FTbjBkcDJ4Sm43bUkKLS0tIDRlaGJ1L01FVktUZHgxUUJwZ3BI
+            TnoxdlJ5d3Q1aVB4eG1pdHlWNHpUVUEKxpEsSb6TkK32rDxbo9w+ZwRNbupkmnal
+            FPOTpVpZJUm2EkD0DfAb8BhMtSwFzREzKiGHuM3ccajK9EoymaX/Gg==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1nywlwepsyfxvyhqwkjquzz02nmus65gf6qewfjju4alym8f7se5qnua8na
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvSVJBTmhYZW5KT1Z1S3hk
+            VjhndG56blE0b2xXQlJ3K2lkbXhRR0JLdEU4Cm1Tc0hGUkxDdldnTlBveDRxM0M5
+            SmRoQk0yUmF3RUV1eXVyc0w4WFVJOUEKLS0tIG1NMU1nNTM5NXpHOUNjbUFjcFNj
+            WTIvTk1nV1BWZ2FRWUExa09naGh0NHMK5SrHtMF61nNmHBlz6jRzAiY9YoeM6LEH
+            ZBkBLUjE4TIBPvjX5qewRj/nFk+SHg1SM/3MTByb5mm3/rloI2TDdw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-06-14T00:31:30Z"
+    mac: ENC[AES256_GCM,data:Ora4L23zHKP6DaTXzOjyczHBuPeulzNoMlvP5Mh0EQT/7RRLp8396q1GHIa0ebuAVwrmrs26ES83lRKd/7qY+S/R17SBk5HBWkGucqIHFkK8X50DtvSLrVhMhBNuKIrnbFKHjUtItNjf+ZGS9r2piTLp0oXl0UQxQiNEfe6fymo=,iv:YXIiYp9spwRsfbywkglQJHsX/aCetsmkiHIzMTaoaeQ=,tag:cWU+W01T7TDUJsBVztMtIQ==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.1


### PR DESCRIPTION
Same fix as #2204 but for Oura. `oura-client-credentials` held `REPLACE_ME` placeholders, so the Oura authorize URL used `client_id=REPLACE_ME` and Oura returned `400 invalid_request / Invalid Token`.

Encrypts the real client credentials. The `redirect_uri` and scopes already match `config.yaml`. On merge, Flux reconciles the secret and Stakater Reloader (`reloader.stakater.com/auto: true`) auto-restarts airlock.