### PR TITLE
[codex] debundle document decorator binding groups

### DIFF
--- a/devinfra/js/debundle/docs/guide.md
+++ b/devinfra/js/debundle/docs/guide.md
@@ -389,6 +389,33 @@ binding_groups:
       replaySlot: replayBridge
 ```
 
+Decorator/property setup calls fit the same pattern. Use the class declaration
+as the binding context, keep durable property strings exact, and claim the
+decorator calls by index:
+
+```yaml
+binding_groups:
+  - source_match:
+      identifiers: alpha_all
+      target_statements: [1, 2]
+      match: |
+        class DecoratedModel {
+          CLASS_REST;
+          report() {
+            STMT_LIST;
+          }
+          CLASS_REST;
+        }
+        decorate(["observable"], DecoratedModel.prototype, "state");
+        decorate(["observable"], DecoratedModel.prototype, "title");
+    adopt_names: [DecoratedModel]
+```
+
+Under `alpha_all`, `decorate` and `DecoratedModel` are selector-local names:
+they only require a consistent structural correspondence inside this selector,
+so the runtime helper and class binding may be minified differently. The
+strings `"state"` and `"title"` remain exact anchors.
+
 When a few useful bindings sit inside a larger `var`/`let`/`const` declaration
 list, use declarator-list holes instead of spelling unrelated siblings:
 

--- a/devinfra/js/debundle/e2e/anonymous_statement_test.rs
+++ b/devinfra/js/debundle/e2e/anonymous_statement_test.rs
@@ -729,6 +729,62 @@ false || (recordSlot = "record");"#,
 }
 
 #[test]
+fn binding_group_claims_decorated_class_and_decorator_statements_from_one_selector() {
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"function applyPropertyDecorator(markers, target, property) {
+  target[`_${property}`] = markers.length;
+}
+class RuntimeModel {
+  report() {
+    return `${this._state}:${this._title}`;
+  }
+}
+applyPropertyDecorator(["observable"], RuntimeModel.prototype, "state");
+applyPropertyDecorator(["observable"], RuntimeModel.prototype, "title");
+console.log(new RuntimeModel().report());
+export { RuntimeModel };
+"#,
+        vec![logical_module_with_binding_groups(
+            "decorated_model",
+            &[],
+            &[BindingGroup::source_alpha_adopt_names(
+                r#"class DecoratedModel {
+  CLASS_REST;
+  report() {
+    STMT_LIST;
+  }
+  CLASS_REST;
+}
+decorate(["observable"], DecoratedModel.prototype, "state");
+decorate(["observable"], DecoratedModel.prototype, "title");"#,
+                &["DecoratedModel"],
+            )
+            .with_target_statements(&[1, 2])],
+        )],
+    ));
+
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/modules/decorated_model.js",
+        &[
+            "class DecoratedModel",
+            "applyPropertyDecorator([",
+            "DecoratedModel.prototype",
+            r#""state""#,
+            r#""title""#,
+        ],
+        &["class RuntimeModel", "function applyPropertyDecorator"],
+    );
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/modules/residual/unhandled.js",
+        &["function applyPropertyDecorator"],
+        &["RuntimeModel.prototype", "DecoratedModel.prototype"],
+    );
+    assert_entry_output(&fixture, "1:1\n");
+}
+
+#[test]
 fn binding_group_target_statements_supports_stmt_list_context_gap() {
     let fixture = run_fixture(FixtureOpts::new(
         r#"let runtimeRecord, runtimeReplay;


### PR DESCRIPTION
## Summary

- Adds a synthetic e2e fixture showing one `binding_groups[].source_match` can export a decorated class and claim multiple decorator/property setup calls with `target_statements`.
- Documents the generic decorator/property selector pattern in the debundle guide, using `alpha_all`, class/body holes, exact property-string anchors, and `adopt_names`.

## Tests

- `nix develop -c bazelisk --output_base=/tmp/bazel-ducktape-decorator-selector-docs-rebased test --config=rbe //devinfra/js/debundle/e2e:anonymous_statement_test`
  - BuildBuddy: https://app.buildbuddy.io/invocation/99fed521-3959-405c-a071-5f21667d2d8e
- `nix develop -c pre-commit run --files devinfra/js/debundle/e2e/anonymous_statement_test.rs devinfra/js/debundle/docs/guide.md`

Fixtures are synthetic/generic; no downstream private snippets are included.