### PR TITLE
airlock/frontend: fix router not reacting to menu clicks

### DIFF
--- a/airlock/frontend/App.svelte
+++ b/airlock/frontend/App.svelte
@@ -28,7 +28,7 @@
     return { kind: "list" };
   }
 
-  const route = parseRoute();
+  let route = $state<Route>(parseRoute());
 
   let pending = $state<Action[]>([]);
   let recent = $state<Action[]>([]);
@@ -42,45 +42,76 @@
     [pending, recent] = await Promise.all([api.listActions("pending"), api.listActions(undefined, 20)]);
   }
 
-  onMount(async () => {
-    // Best-effort deployment info — never blocks the page.
-    try {
-      const api = await getApiClient();
-      deploymentInfo = await api.getDeploymentInfo();
-    } catch {
-      // ignore — footer is hidden if we can't get it
-    }
-    if (route.kind === "action") {
+  onMount(() => {
+    // Re-parse the route on every hash navigation so menu clicks update the page,
+    // not just the URL.
+    const onHashChange = () => {
+      route = parseRoute();
+    };
+    window.addEventListener("hashchange", onHashChange);
+
+    // Best-effort deployment info — route-independent, loaded once for the footer.
+    (async () => {
       try {
         const api = await getApiClient();
-        await api.subscribeAction<Action>(route.sessionKey, route.actionSeq, (a) => {
-          action = a;
-          loading = false;
-          error = null;
-        });
-        if (loading) {
-          error = "Failed to read action resource";
-          loading = false;
-        }
-      } catch (err) {
-        error = String(err);
-        loading = false;
+        deploymentInfo = await api.getDeploymentInfo();
+      } catch {
+        // ignore — footer is hidden if we can't get it
       }
-    } else if (route.kind === "list") {
-      try {
-        await loadList();
-      } catch (e) {
-        error = String(e);
-      } finally {
-        loading = false;
-      }
+    })();
+
+    return () => window.removeEventListener("hashchange", onHashChange);
+  });
+
+  // Load route-specific data whenever the route changes. The cleanup tears down
+  // the previous route's subscription so stale callbacks don't mutate state.
+  $effect(() => {
+    const current = route;
+    let cancelled = false;
+    let unsubscribe: (() => void) | undefined;
+
+    loading = true;
+    error = null;
+    action = null;
+
+    (async () => {
       const api = await getApiClient();
-      api.onListChanged(() => {
-        loadList();
-      });
-    } else {
-      loading = false;
-    }
+      if (cancelled) return;
+      if (current.kind === "action") {
+        try {
+          unsubscribe = await api.subscribeAction<Action>(current.sessionKey, current.actionSeq, (a) => {
+            action = a;
+            loading = false;
+            error = null;
+          });
+          if (loading && !cancelled) {
+            error = "Failed to read action resource";
+            loading = false;
+          }
+        } catch (err) {
+          if (!cancelled) {
+            error = String(err);
+            loading = false;
+          }
+        }
+      } else if (current.kind === "list") {
+        try {
+          await loadList();
+        } catch (e) {
+          if (!cancelled) error = String(e);
+        } finally {
+          if (!cancelled) loading = false;
+        }
+        unsubscribe = api.onListChanged(() => loadList());
+      } else {
+        loading = false;
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      unsubscribe?.();
+    };
   });
 </script>
 


### PR DESCRIPTION
## Problem

Clicking a top-nav menu item (Actions / Backends / OAuth) changed the URL hash but **not** the page content; loading the URL directly worked. Reported alongside an `ERR_INCOMPLETE_CHUNKED_ENCODING` on `/api/events` (separate — see note).

## Root cause

`App.svelte` parsed the route **once** at component init:

```js
const route = parseRoute();  // read window.location.hash once, never again
```

`route` was a plain `const` with no `hashchange` listener, so `<a href="#/oauth">` updated `window.location.hash` (URL changes, `hashchange` fires) but nothing re-ran `parseRoute()` or re-rendered. Direct loads worked because `parseRoute()` ran at mount with the correct hash.

## Fix

- `route` is now `$state`, updated by a `hashchange` listener registered in `onMount` (removed on destroy).
- Route-dependent data loading moved from the one-shot `onMount` into a `$effect` keyed on `route`, with cleanup that tears down the previous route's subscription (`subscribeAction` / `onListChanged` both return unsubscribers) so stale callbacks can't mutate state after navigation.
- Deployment-info (footer, route-independent) stays a one-time load in `onMount`.

## Tests

- `bbr build //airlock/frontend:bundle` — compiles.
- `bbr test //airlock/frontend/...` — 16/16 visual tests pass (they render pages directly via the harness, so routing is unaffected).

## Note (not fixed here)

`ERR_INCOMPLETE_CHUNKED_ENCODING` on `/api/events` is the long-lived SSE stream being cut (likely a gateway/HTTPRoute idle timeout). The client already auto-reconnects after 3s (`api.ts` `connectSSE` catch). Worth a separate look at the gateway stream timeout if live updates lag, but it's unrelated to the click bug.