### PR TITLE
debundle: cache repeated member source matches per chunk

### DIFF
--- a/devinfra/js/debundle/e2e/cross_module_emission_test.rs
+++ b/devinfra/js/debundle/e2e/cross_module_emission_test.rs
@@ -404,6 +404,76 @@ export { RuntimeCatalog };
 }
 
 #[test]
+fn repeated_source_match_selectors_reuse_chunk_cache_across_modules() {
+    let class_selector = r#"class K {
+  CLASS_REST;
+  label() {
+    return "catalog";
+  }
+  CLASS_REST;
+}"#;
+    let opts = FixtureOpts::new(
+        r#"class RuntimeCatalog {
+  label() {
+    return "catalog";
+  }
+}
+console.log(new RuntimeCatalog().label());
+export { RuntimeCatalog };
+"#,
+        vec![
+            logical_module(
+                "catalog/primary",
+                &[Member::source_alpha_target(
+                    "PrimaryCatalog",
+                    "K",
+                    class_selector,
+                )],
+            ),
+            logical_module(
+                "catalog/duplicate",
+                &[Member::source_alpha_target(
+                    "DuplicateCatalog",
+                    "K",
+                    class_selector,
+                )],
+            ),
+        ],
+    );
+
+    let rejected = run_keep_going_dry_run_rejection_fixture_with_env(
+        opts,
+        &[
+            ("DUCKTAPE_SOURCE_MATCH_TIMINGS", "1"),
+            ("DUCKTAPE_SOURCE_MATCH_TIMING_PREVIEW", "0"),
+        ],
+    );
+    let stderr = rejected.stderr;
+    for required in [
+        "Duplicate binding claim",
+        "\"RuntimeCatalog\"",
+        "catalog/primary",
+        "catalog/duplicate",
+    ] {
+        assert!(
+            stderr.contains(required),
+            "stderr missing {required:?}\nstderr:\n{stderr}",
+        );
+    }
+    let timing_lines = stderr
+        .lines()
+        .filter(|line| {
+            line.contains("[debundle source_match]")
+                && line.contains("kind=members[].selector.source_match")
+        })
+        .count();
+    assert_eq!(
+        timing_lines, 1,
+        "repeated cross-module selector should resolve once per chunk\nstderr:\n{stderr}",
+    );
+}
+
+#[test]
 fn duplicate_source_match_members_in_one_module_report_member_origins() {
     let class_selector = r#"class K {
   CLASS_REST;

--- a/devinfra/js/debundle/e2e/support.rs
+++ b/devinfra/js/debundle/e2e/support.rs
@@ -948,13 +948,28 @@ pub fn run_keep_going_dry_run_rejection_fixture(opts: FixtureOpts<'_>) -> Reject
     run_rejection_fixture_with_args(opts, &["--dry-run", "--keep-going"])
 }
 
+pub fn run_keep_going_dry_run_rejection_fixture_with_env(
+    opts: FixtureOpts<'_>,
+    env: &[(&str, &str)],
+) -> RejectedFixture {
+    run_rejection_fixture_with_args_and_env(opts, &["--dry-run", "--keep-going"], env)
+}
+
 fn run_rejection_fixture_with_args(opts: FixtureOpts<'_>, extra_args: &[&str]) -> RejectedFixture {
+    run_rejection_fixture_with_args_and_env(opts, extra_args, &[])
+}
+
+fn run_rejection_fixture_with_args_and_env(
+    opts: FixtureOpts<'_>,
+    extra_args: &[&str],
+    env: &[(&str, &str)],
+) -> RejectedFixture {
     let setup = setup_fixture(&opts);
     let spec_path = setup.root.path().join("transform_spec.yaml");
     let spec = build_spec(&opts, &setup);
     write_yaml_file(&spec_path, &spec);
 
-    let result = spawn_transform_with_args(&spec_path, extra_args, &[]);
+    let result = spawn_transform_with_args(&spec_path, extra_args, env);
     assert!(
         !result.status.success(),
         "expected spec to be rejected\nstdout:\n{}\nstderr:\n{}",

--- a/devinfra/js/debundle/lowering/materialize/plan_builder.rs
+++ b/devinfra/js/debundle/lowering/materialize/plan_builder.rs
@@ -140,6 +140,25 @@ fn render_anonymous_statement_diagnostics(diagnostics: &[AnonymousStatementDiagn
     report
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct SourceMatchGroupCacheKey {
+    selector: spec::AnonymousStatementSelector,
+    target_bindings: Vec<String>,
+}
+
+impl SourceMatchGroupCacheKey {
+    fn new(
+        selector: spec::AnonymousStatementSelector,
+        exports_by_target: &BTreeMap<String, String>,
+    ) -> Self {
+        let target_bindings = exports_by_target.keys().cloned().collect();
+        Self {
+            selector,
+            target_bindings,
+        }
+    }
+}
+
 /// Output of `ChunkPlanBuilder::finalize`: everything downstream
 /// `lower_chunk` + the chunk-report builder need from the plan
 /// construction phase.
@@ -167,6 +186,14 @@ fn resolve_request_source_matches(
     runtime_module: &Module,
     keep_going: bool,
     diagnostics: &mut Vec<SourceMatchDiagnostic>,
+    source_match_cache: &mut BTreeMap<
+        spec::AnonymousStatementSelector,
+        source_match::ResolvedMemberBinding,
+    >,
+    source_match_group_cache: &mut BTreeMap<
+        SourceMatchGroupCacheKey,
+        BTreeMap<String, source_match::ResolvedMemberBinding>,
+    >,
 ) -> Result<()> {
     let mut grouped_by_selector: BTreeMap<spec::AnonymousStatementSelector, Vec<usize>> =
         BTreeMap::new();
@@ -209,27 +236,35 @@ fn resolve_request_source_matches(
         if has_duplicate_target {
             continue;
         }
-        let resolved = match source_match::resolve_member_binding_group(
-            runtime_module,
-            &request.id,
-            &selector,
-            &exports_by_target,
-        ) {
-            Ok(resolved) => resolved,
-            Err(error) if keep_going => {
-                let message = format!("{error:#}");
-                for idx in member_indices {
-                    let member = &request.members[idx];
-                    diagnostics.push(SourceMatchDiagnostic {
-                        module_id: request.id.clone(),
-                        export_name: member.export_name.clone(),
-                        claim_origin: member.claim_origin.clone(),
-                        message: message.clone(),
-                    });
-                }
-                continue;
+        let cache_key = SourceMatchGroupCacheKey::new(selector.clone(), &exports_by_target);
+        let resolved = match source_match_group_cache.get(&cache_key) {
+            Some(resolved) => resolved.clone(),
+            None => {
+                let resolved = match source_match::resolve_member_binding_group(
+                    runtime_module,
+                    &request.id,
+                    &selector,
+                    &exports_by_target,
+                ) {
+                    Ok(resolved) => resolved,
+                    Err(error) if keep_going => {
+                        let message = format!("{error:#}");
+                        for idx in member_indices {
+                            let member = &request.members[idx];
+                            diagnostics.push(SourceMatchDiagnostic {
+                                module_id: request.id.clone(),
+                                export_name: member.export_name.clone(),
+                                claim_origin: member.claim_origin.clone(),
+                                message: message.clone(),
+                            });
+                        }
+                        continue;
+                    }
+                    Err(error) => return Err(error),
+                };
+                source_match_group_cache.insert(cache_key, resolved.clone());
+                resolved
             }
-            Err(error) => return Err(error),
         };
         for idx in member_indices {
             let member = &mut request.members[idx];
@@ -246,13 +281,12 @@ fn resolve_request_source_matches(
         }
     }
 
-    let mut source_match_cache = BTreeMap::new();
     for (idx, member) in request.members.iter_mut().enumerate() {
         if resolved_member_indices.contains(&idx) {
             continue;
         }
         if let Err(error) =
-            member.resolve_source_match(runtime_module, &request.id, &mut source_match_cache)
+            member.resolve_source_match(runtime_module, &request.id, source_match_cache)
         {
             if !keep_going {
                 return Err(error);
@@ -343,6 +377,22 @@ pub(super) struct ChunkPlanBuilder {
     /// canonical plan so later modules in the chunk can still be
     /// checked for independent selector and duplicate-claim failures.
     source_match_diagnostics: Vec<SourceMatchDiagnostic>,
+    /// Successful member-form `source_match` resolutions within this
+    /// chunk. Selector matching scans the same runtime chunk AST, and
+    /// many large migrations repeat exact selectors across logical
+    /// modules while converging duplicate ownership. Keeping successes
+    /// at chunk scope avoids re-running the structural matcher for
+    /// repeated selectors; failures still resolve live so diagnostics
+    /// stay anchored to the current module/export.
+    source_match_cache:
+        BTreeMap<spec::AnonymousStatementSelector, source_match::ResolvedMemberBinding>,
+    /// Successful grouped member-form source matches keyed by the
+    /// selector body and requested selector-local target bindings.
+    /// Export names are intentionally excluded: they only label
+    /// diagnostics/timings, while the resolved source bindings are a
+    /// function of the selector and target bindings.
+    source_match_group_cache:
+        BTreeMap<SourceMatchGroupCacheKey, BTreeMap<String, source_match::ResolvedMemberBinding>>,
     /// Anonymous statement selectors that did not resolve. In
     /// keep-going mode, unresolved anonymous statements are omitted
     /// from canonical ownership so later modules in the chunk can
@@ -368,6 +418,8 @@ impl ChunkPlanBuilder {
             catalogue_index_by_name: HashMap::new(),
             duplicate_binding_claims: Vec::new(),
             source_match_diagnostics: Vec::new(),
+            source_match_cache: BTreeMap::new(),
+            source_match_group_cache: BTreeMap::new(),
             anonymous_statement_diagnostics: Vec::new(),
             keep_going,
         }
@@ -391,6 +443,8 @@ impl ChunkPlanBuilder {
             ctx.runtime_module,
             self.keep_going,
             &mut self.source_match_diagnostics,
+            &mut self.source_match_cache,
+            &mut self.source_match_group_cache,
         )?;
         reject_duplicate_member_bindings("logical_module", &request.id, &request.members)?;
         let mut bindings = HashMap::<String, String>::new();


### PR DESCRIPTION
## Summary

This lifts successful member-form `source_match` resolution caching from one logical request to the whole chunk plan builder.

Two cache shapes are covered:

- exact member selectors keyed by the full `AnonymousStatementSelector`
- grouped member selectors keyed by the selector body plus requested target bindings

Failures are intentionally not cached so keep-going diagnostics stay anchored to the current module/export.

## Why

Large debundle migrations often repeat the same member-form selector across logical modules while duplicate ownership is being converged. Before this change, an exact selector repeated in a later logical module rescanned the same runtime chunk AST again because the cache was local to `resolve_request_source_matches`.

## Tests / validation

- `nix develop -c pre-commit run --files devinfra/js/debundle/lowering/materialize/plan_builder.rs devinfra/js/debundle/e2e/support.rs devinfra/js/debundle/e2e/cross_module_emission_test.rs`
- `nix develop -c bbr test //devinfra/js/debundle/e2e:cross_module_emission_test`
- Earlier focused run before reverting a discarded experiment also passed `//devinfra/js/debundle:source_match_test`.

The new e2e regression enables `DUCKTAPE_SOURCE_MATCH_TIMINGS=1` on a synthetic duplicate-claim fixture with two logical modules repeating the same member-form selector. It asserts the duplicate claim is still reported while the member `source_match` timing line appears once, proving the second selector is served from the chunk cache instead of invoking the resolver again.

## Downstream measurement

Using the broad Gaffer 660 dry-run shape with the current downstream tree:

- current `origin/devel`: 114.77s, exit 1, expected duplicate/source-match diagnostics
- cache-only patch: 116.93s, exit 1, same diagnostic class

With `DUCKTAPE_SOURCE_MATCH_TIMING_THRESHOLD_MS=1000`, neither run emitted per-selector timing lines, so this current downstream state does not show a stable full-run wall-time win. The patch is still a real bounded work-elimination improvement for repeated selectors, covered by the timing-count regression. I also tried a broader wildcard shape prefilter, but it worsened the broad run and is not included here.