### PR TITLE
[codex] debundle add string literal regex selectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1087,6 +1087,7 @@ dependencies = [
  "prometheus",
  "proptest",
  "rayon",
+ "regex",
  "relative-path",
  "reqwest 0.12.28",
  "rig-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ relative-path = "^2.0.1"
 lol_html = "^2.8.1"
 humantime = "^2.3.0"
 rayon = "^1.12.0"
+regex = "^1.12.3"
 # debundle property-based test suites (test-only consumer; single
 # [dependencies] section because crate_universe pins one root manifest)
 proptest = "^1.6.0"

--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -40,6 +40,7 @@ rust_library(
         ":js_ast",
         ":spec",
         "@crates//:anyhow",
+        "@crates//:regex",
         "@crates//:swc_atoms",
         "@crates//:swc_common",
         "@crates//:swc_ecma_ast",

--- a/devinfra/js/debundle/docs/guide.md
+++ b/devinfra/js/debundle/docs/guide.md
@@ -537,6 +537,25 @@ matches a call whose two arguments are identical. These are still structural
 selectors: surrounding syntax is exact after the identifier policy is applied,
 and ambiguous matches are rejected rather than resolved by source order.
 
+For string literals with stable shape but unstable suffixes, use
+`STR_LITERAL_MATCHING_RE("...")` in expression position:
+
+```yaml
+members:
+  - selector:
+      source_match:
+        identifiers: alpha_all
+        match: |
+          const selectedStyle = STR_LITERAL_MATCHING_RE("^WidgetShell-[0-9]+$");
+    name: widgetShellStyle
+```
+
+This matches a string literal AST node, not arbitrary source text. The pattern
+uses Rust `regex` syntax against the decoded string literal value, so it is
+unanchored unless you write `^` / `$`. Escape the regex as a JavaScript string
+inside the selector source; for example, write `"\\d+"` when the regex should
+see `\d+`.
+
 Variable-length **list holes** absorb a contiguous run rather than a single
 node. Their optional suffixes are labels for readability; they do not bind the
 absorbed sequence for cross-occurrence equality.

--- a/devinfra/js/debundle/e2e/syntactic_holes_test.rs
+++ b/devinfra/js/debundle/e2e/syntactic_holes_test.rs
@@ -209,6 +209,82 @@ export { actual };
 }
 
 #[test]
+fn member_source_match_string_literal_regex_predicate_matches_string_literal_value() {
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"const runtimeStyle = "WidgetShell-42";
+console.log(runtimeStyle);
+export { runtimeStyle };
+"#,
+        vec![logical_module(
+            "styles/shell",
+            &[Member::source_alpha(
+                "shellStyle",
+                r#"const readableStyle = STR_LITERAL_MATCHING_RE("^WidgetShell-[0-9]+$");"#,
+            )],
+        )],
+    ));
+
+    assert_entry_output(&fixture, "WidgetShell-42\n");
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/modules/styles/shell.js",
+        &["const shellStyle = \"WidgetShell-42\""],
+        &["STR_LITERAL_MATCHING_RE"],
+    );
+}
+
+#[test]
+fn member_source_match_string_literal_regex_predicate_rejects_non_matching_literal() {
+    expect_rejection_containing_all(
+        FixtureOpts::new(
+            r#"const runtimeStyle = "PanelShell-42";
+console.log(runtimeStyle);
+export { runtimeStyle };
+"#,
+            vec![logical_module(
+                "styles/shell",
+                &[Member::source_alpha(
+                    "shellStyle",
+                    r#"const readableStyle = STR_LITERAL_MATCHING_RE("^WidgetShell-[0-9]+$");"#,
+                )],
+            )],
+        ),
+        &[
+            "styles/shell",
+            "did not match any top-level declaration",
+            "STR_LITERAL_MATCHING_RE",
+            "WidgetShell",
+        ],
+    );
+}
+
+#[test]
+fn member_source_match_string_literal_regex_predicate_rejects_ambiguous_literals() {
+    expect_rejection_containing_all(
+        FixtureOpts::new(
+            r#"const runtimePrimaryStyle = "WidgetShell-1";
+const runtimeSecondaryStyle = "WidgetShell-2";
+console.log(runtimePrimaryStyle, runtimeSecondaryStyle);
+export { runtimePrimaryStyle, runtimeSecondaryStyle };
+"#,
+            vec![logical_module(
+                "styles/shell",
+                &[Member::source_alpha(
+                    "shellStyle",
+                    r#"const readableStyle = STR_LITERAL_MATCHING_RE("^WidgetShell-[0-9]+$");"#,
+                )],
+            )],
+        ),
+        &[
+            "styles/shell",
+            "ambiguous",
+            "STR_LITERAL_MATCHING_RE",
+            "WidgetShell",
+        ],
+    );
+}
+
+#[test]
 fn member_source_match_many_expr_holes_match_positionally() {
     let fixture = run_fixture(FixtureOpts::new(
         r#"const actual = [
@@ -330,6 +406,40 @@ export { first, second };
             r#"var second_value = Number.parseInt("4", 10)"#,
         ],
         &[],
+    );
+}
+
+#[test]
+fn binding_group_source_match_string_literal_regex_predicates_match_each_target_binding() {
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"const runtimePrimary = "Token-primary-101",
+  runtimeSecondary = "Token-secondary-202";
+console.log(`${runtimePrimary}:${runtimeSecondary}`);
+export { runtimePrimary, runtimeSecondary };
+"#,
+        vec![logical_module_with_binding_groups(
+            "styles/tokens",
+            &[],
+            &[BindingGroup::source_alpha(
+                r#"const primaryToken = STR_LITERAL_MATCHING_RE("^Token-primary-[0-9]+$"),
+  secondaryToken = STR_LITERAL_MATCHING_RE("^Token-secondary-[0-9]+$");"#,
+                &[
+                    ("primaryToken", "primaryStyleToken"),
+                    ("secondaryToken", "secondaryStyleToken"),
+                ],
+            )],
+        )],
+    ));
+
+    assert_entry_output(&fixture, "Token-primary-101:Token-secondary-202\n");
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/modules/styles/tokens.js",
+        &[
+            "const primaryStyleToken = \"Token-primary-101\"",
+            "secondaryStyleToken = \"Token-secondary-202\"",
+        ],
+        &["STR_LITERAL_MATCHING_RE"],
     );
 }
 

--- a/devinfra/js/debundle/source_match.rs
+++ b/devinfra/js/debundle/source_match.rs
@@ -9,6 +9,7 @@ use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, bail};
+use regex::Regex;
 use spec::{
     AnonymousStatementSelector, BindingGroup, BindingGroupAdoptNames, BindingSourceKind,
     SourceMatch, SourceMatchIdentifierMode, TargetStatements, TargetStatementsAll,
@@ -43,6 +44,7 @@ const STMT_LIST_HOLE_KEYWORD: &str = "STMT_LIST";
 const CLASS_REST_HOLE_KEYWORD: &str = "CLASS_REST";
 const DECLARATORS_HOLE_KEYWORD: &str = "DECLARATORS";
 const ARGS_HOLE_KEYWORD: &str = "ARGS";
+const STRING_LITERAL_REGEX_PREDICATE: &str = "STR_LITERAL_MATCHING_RE";
 
 const SOURCE_MATCH_TIMINGS_ENV: &str = "DUCKTAPE_SOURCE_MATCH_TIMINGS";
 const SOURCE_MATCH_TIMING_THRESHOLD_ENV: &str = "DUCKTAPE_SOURCE_MATCH_TIMING_THRESHOLD_MS";
@@ -2045,6 +2047,9 @@ fn render_var_declarator_label(declarator: &VarDeclarator) -> String {
 }
 
 fn expr_shape_label(expr: &Expr) -> String {
+    if string_literal_regex_pattern(expr).is_some() {
+        return format!("{STRING_LITERAL_REGEX_PREDICATE}(...)");
+    }
     match expr {
         Expr::Ident(ident) => ident.sym.to_string(),
         Expr::Lit(lit) => lit_shape_label(lit),
@@ -2764,8 +2769,8 @@ struct PreparedNeedle<'a> {
     selector: &'a AnonymousStatementSelector,
     wildcard_idents: WildcardIdents,
     alpha: bool,
-    /// Neither string-literal nor syntactic-hole wildcards present —
-    /// the plain structural-equality fast path applies.
+    /// Neither string-literal nor syntactic-hole wildcards/predicates
+    /// present — the plain structural-equality fast path applies.
     no_wildcards: bool,
     /// The needle pre-canonicalized once for the no-wildcard alpha
     /// path (`None` otherwise).
@@ -2966,6 +2971,10 @@ mod tests {
         &var.decls[0]
     }
 
+    fn single_declarator_init(item: &ModuleItem) -> &Expr {
+        single_declarator(item).init.as_deref().unwrap()
+    }
+
     #[test]
     fn var_declarator_prefilter_uses_string_literal_in_alpha_mode() {
         let selector = selector(r#"const readableName = "stable-css-class";"#);
@@ -2989,6 +2998,36 @@ mod tests {
         let candidate = parse_one(r#"const minifiedName = "runtime-css-class";"#);
 
         assert!(prefilter.declarator_can_match(single_declarator(&candidate)));
+    }
+
+    #[test]
+    fn string_literal_regex_predicate_recognizes_only_direct_string_pattern_calls() {
+        let selector = parse_one(r#"const readable = STR_LITERAL_MATCHING_RE("^Card-[0-9]+$");"#);
+        assert_eq!(
+            string_literal_regex_pattern(single_declarator_init(&selector)).as_deref(),
+            Some("^Card-[0-9]+$"),
+        );
+
+        let non_string_arg = parse_one(r#"const readable = STR_LITERAL_MATCHING_RE(pattern);"#);
+        assert!(string_literal_regex_pattern(single_declarator_init(&non_string_arg)).is_none());
+
+        let two_args = parse_one(r#"const readable = STR_LITERAL_MATCHING_RE("Card", "Panel");"#);
+        assert!(string_literal_regex_pattern(single_declarator_init(&two_args)).is_none());
+    }
+
+    #[test]
+    fn string_literal_regex_predicate_matches_string_literal_ast_nodes() {
+        let selector = selector(r#"const readable = STR_LITERAL_MATCHING_RE("^Card-[0-9]+$");"#);
+        let needle = parse_one(&selector.match_source);
+        let prepared = PreparedNeedle::new(&needle, &selector);
+        let matching = parse_one(r#"const minified = "Card-42";"#);
+        let non_matching = parse_one(r#"const minified = "Panel-42";"#);
+        let non_string = parse_one(r#"const minified = makeCardName();"#);
+
+        assert!(!prepared.no_wildcards);
+        assert!(prepared.matches(&matching));
+        assert!(!prepared.matches(&non_matching));
+        assert!(!prepared.matches(&non_string));
     }
 }
 
@@ -3407,6 +3446,14 @@ impl<'a> AstWildcardMatcher<'a> {
     }
 
     fn match_expr(&mut self, needle: &Expr, candidate: &Expr) -> bool {
+        if let Some(pattern) = string_literal_regex_pattern(needle) {
+            return match candidate {
+                Expr::Lit(Lit::Str(candidate)) => {
+                    string_literal_matches_regex(&pattern, &candidate.value)
+                }
+                _ => false,
+            };
+        }
         if let Some(hole_name) = expression_hole_name(needle)
             && self.wildcard_idents.expressions.contains(hole_name)
         {
@@ -4977,6 +5024,12 @@ struct WildcardIdents {
     /// `ARGS` argument-list hole names. These are pseudo-arguments and
     /// must route to ordered-subsequence argument matching.
     argument_lists: BTreeSet<String>,
+    /// Whether the selector contains any `STR_LITERAL_MATCHING_RE(...)`
+    /// expression predicate. This is not an identifier hole, but it
+    /// changes expression shape (`CallExpr` in the selector,
+    /// `Lit::Str` in the candidate), so the selector still needs the
+    /// wildcard matcher.
+    string_literal_regex_present: bool,
     /// Whether the selector contains any `CLASS_REST` class-member
     /// hole. The marker is a class field key (an `IdentName`, not an
     /// `Ident`), so it survives alpha-canonicalization without being
@@ -4995,6 +5048,7 @@ impl WildcardIdents {
             && self.statement_lists.is_empty()
             && self.declarator_lists.is_empty()
             && self.argument_lists.is_empty()
+            && !self.string_literal_regex_present
             && !self.class_rest_present
     }
 }
@@ -5020,6 +5074,10 @@ struct WildcardIdentCollector {
 
 impl Visit for WildcardIdentCollector {
     fn visit_expr(&mut self, expr: &Expr) {
+        if string_literal_regex_pattern(expr).is_some() {
+            self.idents.string_literal_regex_present = true;
+            return;
+        }
         if let Some(hole_name) = expression_hole_name(expr) {
             self.idents.expressions.insert(hole_name.to_string());
             return;
@@ -5073,6 +5131,33 @@ fn expression_hole_name(expr: &Expr) -> Option<&str> {
         return None;
     };
     hole_name_for(ident.sym.as_ref(), EXPR_HOLE_KEYWORD)
+}
+
+fn string_literal_regex_pattern(expr: &Expr) -> Option<String> {
+    let Expr::Call(call) = expr else {
+        return None;
+    };
+    if call.args.len() != 1 || call.args[0].spread.is_some() {
+        return None;
+    }
+    let Callee::Expr(callee) = &call.callee else {
+        return None;
+    };
+    let Expr::Ident(callee) = callee.as_ref() else {
+        return None;
+    };
+    if callee.sym.as_ref() != STRING_LITERAL_REGEX_PREDICATE {
+        return None;
+    }
+    let Expr::Lit(Lit::Str(pattern)) = call.args[0].expr.as_ref() else {
+        return None;
+    };
+    Some(pattern.value.to_string_lossy().to_string())
+}
+
+fn string_literal_matches_regex(pattern: &str, candidate_value: &Wtf8Atom) -> bool {
+    Regex::new(pattern)
+        .is_ok_and(|regex| regex.is_match(candidate_value.to_string_lossy().as_ref()))
 }
 
 fn statement_hole_name(stmt: &Stmt) -> Option<&str> {


### PR DESCRIPTION
## Summary
- Adds `STR_LITERAL_MATCHING_RE("...")` as a `source_match` expression predicate for matching string literal AST nodes by Rust regex.
- Covers member `source_match` success, no-match, ambiguity, and binding-group exports using synthetic generic fixtures.
- Documents regex anchoring and escaping semantics in the debundle guide.

## Tests
- `nix develop -c bazelisk --output_base=/tmp/bazel-ducktape-string-literal-regex-rebased test --config=rbe //devinfra/js/debundle:source_match_test //devinfra/js/debundle/e2e:syntactic_holes_test`
  - BuildBuddy: https://app.buildbuddy.io/invocation/f13e50b5-aa2b-47c5-8fe5-9fdef8ad0512
- `nix develop -c pre-commit run --files Cargo.toml Cargo.lock devinfra/js/debundle/BUILD.bazel devinfra/js/debundle/docs/guide.md devinfra/js/debundle/e2e/syntactic_holes_test.rs devinfra/js/debundle/source_match.rs`

Fixtures are synthetic/generic; no downstream private snippets are included.