### PR TITLE
[codex] debundle document declarator rest holes

### DIFF
--- a/devinfra/js/debundle/docs/guide.md
+++ b/devinfra/js/debundle/docs/guide.md
@@ -438,7 +438,12 @@ binding_groups:
 `DECLARATORS` and `DECLARATORS_*` absorb any run of declarators, including an
 empty run. The initializer is ignored; selectors commonly write `= null`
 because `const` declarations require an initializer. These pseudo-declarators
-are not exposed through `adopt_names`.
+are not exposed through `adopt_names`. This is the preferred pattern when a
+few adjacent constants or arrow-function helpers sit at the beginning, middle,
+or end of a larger declaration list: pin the declarators you want to export,
+put `DECLARATORS_BEFORE` and/or `DECLARATORS_AFTER` around the unrelated
+siblings, and use `adopt_names` or explicit `exports` only for the pinned
+selector-local names.
 
 For anonymous side-effect statements, prefer `source_match` when
 minified helper or class names drift, but keep selectors unique. If two

--- a/devinfra/js/debundle/e2e/syntactic_holes_test.rs
+++ b/devinfra/js/debundle/e2e/syntactic_holes_test.rs
@@ -676,6 +676,119 @@ export { selectedA, selectedB, laterC };
 }
 
 #[test]
+fn binding_group_declarator_holes_extract_adjacent_arrows_at_start_middle_and_end() {
+    let leading_fixture = run_fixture(FixtureOpts::new(
+        r#"const runtimeBuild = (value) => `build:${value}`,
+  runtimeRead = (value) => runtimeBuild(value).toUpperCase(),
+  runtimeTrailingHelper = () => "tail";
+console.log(runtimeRead("one"), runtimeTrailingHelper());
+export { runtimeBuild, runtimeRead, runtimeTrailingHelper };
+"#,
+        vec![logical_module_with_binding_groups(
+            "leading",
+            &[],
+            &[BindingGroup::source_alpha(
+                r#"const buildSelected = (value) => `build:${value}`,
+  readSelected = (value) => buildSelected(value).toUpperCase(),
+  DECLARATORS_AFTER = null;"#,
+                &[
+                    ("buildSelected", "buildValue"),
+                    ("readSelected", "readValue"),
+                ],
+            )],
+        )],
+    ));
+    assert_entry_output(&leading_fixture, "BUILD:ONE tail\n");
+    assert_module_exports(
+        &leading_fixture.out_root,
+        "static/app/modules/leading.js",
+        &["buildValue", "readValue"],
+        &["runtimeBuild", "runtimeRead", "runtimeTrailingHelper"],
+    );
+    assert_module_source(
+        &leading_fixture.out_root,
+        "static/app/modules/leading.js",
+        &["const buildValue", "const readValue"],
+        &["runtimeTrailingHelper", "DECLARATORS_AFTER"],
+    );
+
+    let middle_fixture = run_fixture(FixtureOpts::new(
+        r#"const runtimeLeadingHelper = () => "head",
+  runtimeBuild = (value) => `build:${value}`,
+  runtimeRead = (value) => runtimeBuild(value).toUpperCase(),
+  runtimeTrailingHelper = () => "tail";
+console.log(runtimeLeadingHelper(), runtimeRead("two"), runtimeTrailingHelper());
+export { runtimeLeadingHelper, runtimeBuild, runtimeRead, runtimeTrailingHelper };
+"#,
+        vec![logical_module_with_binding_groups(
+            "middle",
+            &[],
+            &[BindingGroup::source_alpha_adopt_all(
+                r#"const DECLARATORS_BEFORE = null,
+  buildSelected = (value) => `build:${value}`,
+  readSelected = (value) => buildSelected(value).toUpperCase(),
+  DECLARATORS_AFTER = null;"#,
+            )],
+        )],
+    ));
+    assert_entry_output(&middle_fixture, "head BUILD:TWO tail\n");
+    assert_module_exports(
+        &middle_fixture.out_root,
+        "static/app/modules/middle.js",
+        &["buildSelected", "readSelected"],
+        &[
+            "runtimeLeadingHelper",
+            "runtimeBuild",
+            "runtimeRead",
+            "runtimeTrailingHelper",
+        ],
+    );
+    assert_module_source(
+        &middle_fixture.out_root,
+        "static/app/modules/middle.js",
+        &["const buildSelected", "const readSelected"],
+        &[
+            "runtimeLeadingHelper",
+            "runtimeTrailingHelper",
+            "DECLARATORS_BEFORE",
+            "DECLARATORS_AFTER",
+        ],
+    );
+
+    let trailing_fixture = run_fixture(FixtureOpts::new(
+        r#"const runtimeLeadingHelper = () => "head",
+  runtimeBuild = (value) => `build:${value}`,
+  runtimeRead = (value) => runtimeBuild(value).toUpperCase();
+console.log(runtimeLeadingHelper(), runtimeRead("three"));
+export { runtimeLeadingHelper, runtimeBuild, runtimeRead };
+"#,
+        vec![logical_module_with_binding_groups(
+            "trailing",
+            &[],
+            &[BindingGroup::source_alpha_adopt_names(
+                r#"const DECLARATORS_BEFORE = null,
+  buildSelected = (value) => `build:${value}`,
+  readSelected = (value) => buildSelected(value).toUpperCase();"#,
+                &["buildSelected", "readSelected"],
+            )],
+        )],
+    ));
+    assert_entry_output(&trailing_fixture, "head BUILD:THREE\n");
+    assert_module_exports(
+        &trailing_fixture.out_root,
+        "static/app/modules/trailing.js",
+        &["buildSelected", "readSelected"],
+        &["runtimeLeadingHelper", "runtimeBuild", "runtimeRead"],
+    );
+    assert_module_source(
+        &trailing_fixture.out_root,
+        "static/app/modules/trailing.js",
+        &["const buildSelected", "const readSelected"],
+        &["runtimeLeadingHelper", "DECLARATORS_BEFORE"],
+    );
+}
+
+#[test]
 fn declarator_hole_miss_reports_best_anchored_var_decl_candidate() {
     let opts = FixtureOpts::new(
         r#"function operation(kind, value) {


### PR DESCRIPTION
## Summary
- Adds synthetic e2e coverage for using `DECLARATORS` rest holes to extract adjacent arrow-function declarators from larger `const` declarations.
- Covers selected declarator runs at the start, middle, and end of a declaration list, including explicit exports, `adopt_names: true`, and named `adopt_names` behavior.
- Updates the debundle guide to call out this as the intended source_match/binding_group pattern for mixed declaration lists.

Current `devel` already has the generic declarator-list matcher implementation; this PR keeps the scope to the missing old-spec ergonomics regression and docs.

## Tests
- `nix develop -c bazelisk --output_base=/tmp/bazel-ducktape-declarator-rest-holes test --config=rbe //devinfra/js/debundle/e2e:syntactic_holes_test`
  - BuildBuddy: https://app.buildbuddy.io/invocation/d9aa8b8c-d4c8-4fab-a1d6-2f83dd8234b3
- `nix develop -c pre-commit run --files devinfra/js/debundle/docs/guide.md devinfra/js/debundle/e2e/syntactic_holes_test.rs`

Fixtures are synthetic/generic; no downstream private snippets are included.