### PR TITLE
[codex] debundle cover binding group declaration ranges

### DIFF
--- a/devinfra/js/debundle/docs/guide.md
+++ b/devinfra/js/debundle/docs/guide.md
@@ -350,6 +350,25 @@ binding_groups:
       address: Primary address shown to operators.
 ```
 
+The `match` may also be a contiguous range of top-level declarations. This is
+useful when related constants are declared separately and a later object ties
+them together:
+
+```yaml
+binding_groups:
+  - source_match:
+      identifiers: alpha_all
+      match: |
+        const firstClassName = STR_LITERAL_MATCHING_RE("^Widget-module_first__[A-Za-z0-9_-]+$");
+        const secondClassName = STR_LITERAL_MATCHING_RE("^Widget-module_second__[A-Za-z0-9_-]+$");
+        const styles = { first: firstClassName, second: secondClassName };
+    adopt_names: true
+```
+
+Under `alpha_all`, the selector-local `firstClassName` and `secondClassName`
+names carry across the range, so the object initializer can refer to the
+matched runtime bindings without spelling their minified names.
+
 When the selector source already uses the desired public names, use
 `adopt_names` instead of repeating identity entries under `exports`:
 

--- a/devinfra/js/debundle/e2e/syntactic_holes_test.rs
+++ b/devinfra/js/debundle/e2e/syntactic_holes_test.rs
@@ -444,6 +444,62 @@ export { runtimePrimary, runtimeSecondary };
 }
 
 #[test]
+fn binding_group_source_match_string_literal_regex_range_exports_style_object() {
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"const runtimeFirstClassName = "Widget-module_first__a1B-2";
+const runtimeSecondClassName = "Widget-module_second__Z9_x";
+const runtimeStyles = {
+  first: runtimeFirstClassName,
+  second: runtimeSecondClassName,
+};
+console.log(runtimeStyles.first, runtimeStyles.second);
+export { runtimeFirstClassName, runtimeSecondClassName, runtimeStyles };
+"#,
+        vec![logical_module_with_binding_groups(
+            "styles/widget",
+            &[],
+            &[BindingGroup::source_alpha(
+                r#"const firstClassName = STR_LITERAL_MATCHING_RE("^Widget-module_first__[A-Za-z0-9_-]+$");
+const secondClassName = STR_LITERAL_MATCHING_RE("^Widget-module_second__[A-Za-z0-9_-]+$");
+const styles = { first: firstClassName, second: secondClassName };"#,
+                &[
+                    ("firstClassName", "firstClassName"),
+                    ("secondClassName", "secondClassName"),
+                    ("styles", "styles"),
+                ],
+            )],
+        )],
+    ));
+
+    assert_entry_output(
+        &fixture,
+        "Widget-module_first__a1B-2 Widget-module_second__Z9_x\n",
+    );
+    assert_module_exports(
+        &fixture.out_root,
+        "static/app/modules/styles/widget.js",
+        &["firstClassName", "secondClassName", "styles"],
+        &[
+            "runtimeFirstClassName",
+            "runtimeSecondClassName",
+            "runtimeStyles",
+        ],
+    );
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/modules/styles/widget.js",
+        &[
+            r#"const firstClassName = "Widget-module_first__a1B-2""#,
+            r#"const secondClassName = "Widget-module_second__Z9_x""#,
+            "const styles = {",
+            "first: firstClassName",
+            "second: secondClassName",
+        ],
+        &["STR_LITERAL_MATCHING_RE"],
+    );
+}
+
+#[test]
 fn binding_group_comments_emit_for_each_target_binding() {
     let fixture = run_fixture(FixtureOpts::new(
         r#"var first = 1 + 2, second = Number.parseInt("4", 10);


### PR DESCRIPTION
## Summary
- Adds a synthetic e2e regression for a `binding_groups[].source_match` range that exports two regex-matched class-name constants plus a style object tying them together.
- Documents that `binding_groups` may match a contiguous top-level declaration range and that `alpha_all` carries selector-local names across the range.

Investigation result: current `devel` already supports this shape after the recent string-literal regex and range-matching work. The first local run reproduced only an over-strict test assertion against provenance comments, not a matching failure. This PR pins the generic old-spec ergonomics shape so it does not regress.

## Tests
- `nix develop -c bazelisk --output_base=/tmp/bazel-ducktape-binding-group-ranges-rebased test --config=rbe //devinfra/js/debundle/e2e:syntactic_holes_test`
  - BuildBuddy: https://app.buildbuddy.io/invocation/43112876-5ea3-4e44-be63-b0735142dcfe
- `nix develop -c pre-commit run --files devinfra/js/debundle/docs/guide.md devinfra/js/debundle/e2e/syntactic_holes_test.rs`

Fixtures are synthetic/generic; no downstream private snippets are included.