### PR TITLE
[codex] Fix Forgejo agentydragon Terraform key source

### DIFF
--- a/tf/gitops/forgejo-agentydragon/main.tf
+++ b/tf/gitops/forgejo-agentydragon/main.tf
@@ -22,23 +22,18 @@ data "forgejo_user" "agentydragon" {
 }
 
 locals {
-  # Forgejo stores only the key type + key data. Keep comments in the .pub
-  # files for humans, but strip them here to avoid provider normalization churn.
+  # Public keys are duplicated from ssh_keys/*-forgejo.pub because tofu-controller
+  # executes only this Terraform module path, so file() cannot read repo-root files.
   public_keys = {
-    atlas  = "${path.module}/../../../ssh_keys/atlas-forgejo.pub"
-    iguana = "${path.module}/../../../ssh_keys/iguana-forgejo.pub"
-    rugged = "${path.module}/../../../ssh_keys/rugged-forgejo.pub"
-    wyrm2  = "${path.module}/../../../ssh_keys/wyrm2-forgejo.pub"
-  }
-
-  pubkey = {
-    for host, path in local.public_keys :
-    host => join(" ", slice(split(" ", trimspace(file(path))), 0, 2))
+    atlas  = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG6/fkFmt/yOWY0s+PHulmGoTh8kll0WHoL8NXWluTn/"
+    iguana = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMZZ91cQfULMM/rcBcYGaJ4HSiGeD8/G140ElIToYvIV"
+    rugged = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILlk0/g/0s5plFxzC8V/G8IHlTmlX+0ZYqIPr5+Tglcp"
+    wyrm2  = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKp26ICwuhnkiPNqhFjly2k/iW5vs7n5Rq27imnrpK/e"
   }
 }
 
 resource "forgejo_ssh_key" "host" {
-  for_each = local.pubkey
+  for_each = local.public_keys
 
   user  = data.forgejo_user.agentydragon.login
   key   = each.value


### PR DESCRIPTION
## Summary

- Inline the `agentydragon` Forgejo public keys inside `tf/gitops/forgejo-agentydragon` instead of reading repo-root `ssh_keys/*.pub` files with `file()`.
- Fixes the live tofu-controller failure where the runner executes only the Terraform module path and cannot see `../../../ssh_keys/*-forgejo.pub`.

## Live failure observed

`forgejo-agentydragon` failed planning with:

```text
Invalid value for "path" parameter: no file exists at "./../../../ssh_keys/atlas-forgejo.pub"
```

Same failure occurred for `atlas`, `iguana`, `rugged`, and `wyrm2`.

## Validation

- `tofu fmt tf/gitops/forgejo-agentydragon`
- `pre-commit run --files tf/gitops/forgejo-agentydragon/main.tf`
- `bbr build //tf/gitops/forgejo-agentydragon:forgejo-agentydragon`

Note: local `bbr` mirrored from the shared stale local `devel` branch rather than the refreshed remote-tracking ref, so the remote runner patch was larger than this branch. The checked local branch diff against current `origin/devel` is one file: `tf/gitops/forgejo-agentydragon/main.tf`.