### PR TITLE
[codex] Optimize source_match literal selectors

### DIFF
--- a/devinfra/js/debundle/perf/BUILD.bazel
+++ b/devinfra/js/debundle/perf/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_rust//rust:defs.bzl", "rust_binary")
 load("//devinfra/python:defs.bzl", "py_binary", "py_library")
 
 py_library(
@@ -10,4 +11,17 @@ py_binary(
     name = "gen_synth_corpus_bin",
     main_module = "devinfra.js.debundle.perf.gen_synth_corpus",
     deps = [":gen_synth_corpus"],
+)
+
+rust_binary(
+    name = "source_match_decl_holes_profile",
+    srcs = ["source_match_decl_holes_profile.rs"],
+    crate_root = "source_match_decl_holes_profile.rs",
+    edition = "2024",
+    deps = [
+        "//devinfra/js/debundle:js_ast",
+        "//devinfra/js/debundle:source_match",
+        "//devinfra/js/debundle:spec",
+        "@crates//:anyhow",
+    ],
 )

--- a/devinfra/js/debundle/perf/source_match_decl_holes_profile.rs
+++ b/devinfra/js/debundle/perf/source_match_decl_holes_profile.rs
@@ -1,0 +1,204 @@
+//! Synthetic source_match workload for profiling declaration-hole selectors.
+//!
+//! The generated program is intentionally generic: many top-level `const`
+//! declarations, many declarators per declaration, and many selectors shaped
+//! like a direct CSS/literal sweep:
+//!
+//! ```js
+//! const DECLARATORS_BEFORE = null,
+//!   selected = STR_LITERAL_MATCHING_RE("^generic-token-123$"),
+//!   DECLARATORS_AFTER = null;
+//! ```
+//!
+//! Run through Bazel and a sampler, for example:
+//!
+//! ```bash
+//! bazelisk run //devinfra/js/debundle/perf:source_match_decl_holes_profile -- \
+//!   --mode binding-group --declarations 600 --declarators 10 --selectors 600 --repetitions 1
+//! ```
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::time::Instant;
+
+use spec::{AnonymousStatementSelector, SourceMatchIdentifierMode};
+
+#[derive(Debug)]
+struct Opts {
+    declarations: usize,
+    declarators: usize,
+    selectors: usize,
+    repetitions: usize,
+    mode: Mode,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Mode {
+    /// Select one pinned declarator by `target_binding`.
+    TargetBinding,
+    /// Omit `target_binding`, so matching the wider declaration produces
+    /// the same multi-binding ambiguity diagnostic shape as member-form
+    /// direct-selector sweeps.
+    Ambiguity,
+    /// Resolve through `binding_groups[].source_match` with one exported
+    /// target binding, the preferred spec shape for direct literal sweeps.
+    BindingGroup,
+}
+
+impl Default for Opts {
+    fn default() -> Self {
+        Self {
+            declarations: 600,
+            declarators: 10,
+            selectors: 600,
+            repetitions: 1,
+            mode: Mode::BindingGroup,
+        }
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    let opts = parse_opts()?;
+    js_ast::with_swc_globals(|| run(opts))
+}
+
+fn run(opts: Opts) -> anyhow::Result<()> {
+    if opts.declarations == 0 || opts.declarators == 0 || opts.selectors == 0 {
+        anyhow::bail!("declarations, declarators, and selectors must all be non-zero");
+    }
+    let runtime_source = runtime_source(&opts);
+    let runtime_module =
+        js_ast::parse_js_module_ast("<synthetic source_match profile>", &runtime_source)?;
+    let selectors = selectors(&opts);
+
+    let started = Instant::now();
+    let mut checksum = 0usize;
+    for _ in 0..opts.repetitions {
+        for (selector_idx, selector) in selectors.iter().enumerate() {
+            match opts.mode {
+                Mode::TargetBinding | Mode::Ambiguity => {
+                    let result = source_match::resolve_member_binding(
+                        &runtime_module,
+                        "synthetic/source_match_profile",
+                        &format!("export_{selector_idx}"),
+                        selector,
+                    );
+                    match (opts.mode, result) {
+                        (Mode::TargetBinding, Ok(resolved)) => {
+                            checksum = checksum.wrapping_add(resolved.binding_name.len());
+                        }
+                        (Mode::TargetBinding, Err(err)) => return Err(err),
+                        (Mode::Ambiguity, Ok(resolved)) => {
+                            checksum = checksum.wrapping_add(resolved.binding_name.len());
+                        }
+                        (Mode::Ambiguity, Err(err)) => {
+                            checksum = checksum.wrapping_add(err.to_string().len());
+                        }
+                        (Mode::BindingGroup, _) => unreachable!("outer match excludes this mode"),
+                    }
+                }
+                Mode::BindingGroup => {
+                    let resolved = source_match::resolve_member_binding_group(
+                        &runtime_module,
+                        "synthetic/source_match_profile",
+                        selector,
+                        &BTreeMap::from([("selected".to_string(), "selected".to_string())]),
+                    )?;
+                    checksum = checksum.wrapping_add(
+                        resolved
+                            .values()
+                            .map(|binding| binding.binding_name.len())
+                            .sum::<usize>(),
+                    );
+                }
+            }
+        }
+    }
+    let elapsed = started.elapsed();
+    println!(
+        "source_match_decl_holes_profile mode={:?} declarations={} declarators={} selectors={} repetitions={} elapsed_ms={} checksum={}",
+        opts.mode,
+        opts.declarations,
+        opts.declarators,
+        opts.selectors,
+        opts.repetitions,
+        elapsed.as_millis(),
+        checksum,
+    );
+    Ok(())
+}
+
+fn parse_opts() -> anyhow::Result<Opts> {
+    let mut opts = Opts::default();
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        let value = args
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("{arg} requires a value"))?;
+        match arg.as_str() {
+            "--declarations" => opts.declarations = parse_usize(&arg, &value)?,
+            "--declarators" => opts.declarators = parse_usize(&arg, &value)?,
+            "--selectors" => opts.selectors = parse_usize(&arg, &value)?,
+            "--repetitions" => opts.repetitions = parse_usize(&arg, &value)?,
+            "--mode" => {
+                opts.mode = match value.as_str() {
+                    "target-binding" => Mode::TargetBinding,
+                    "ambiguity" => Mode::Ambiguity,
+                    "binding-group" => Mode::BindingGroup,
+                    _ => anyhow::bail!(
+                        "--mode expects `target-binding`, `ambiguity`, or `binding-group`, got {value:?}"
+                    ),
+                };
+            }
+            _ => anyhow::bail!("unknown argument {arg}"),
+        }
+    }
+    Ok(opts)
+}
+
+fn parse_usize(arg: &str, value: &str) -> anyhow::Result<usize> {
+    value
+        .parse::<usize>()
+        .map_err(|err| anyhow::anyhow!("{arg} expects a usize, got {value:?}: {err}"))
+}
+
+fn runtime_source(opts: &Opts) -> String {
+    let mut source = String::new();
+    for decl_idx in 0..opts.declarations {
+        source.push_str("const ");
+        for declarator_idx in 0..opts.declarators {
+            if declarator_idx > 0 {
+                source.push_str(",\n  ");
+            }
+            source.push_str(&format!(
+                "runtime_{decl_idx}_{declarator_idx} = \"{}\"",
+                literal_for(decl_idx, declarator_idx),
+            ));
+        }
+        source.push_str(";\n");
+    }
+    source
+}
+
+fn selectors(opts: &Opts) -> Vec<AnonymousStatementSelector> {
+    (0..opts.selectors)
+        .map(|selector_idx| {
+            let decl_idx = selector_idx % opts.declarations;
+            let declarator_idx = (selector_idx / opts.declarations) % opts.declarators;
+            AnonymousStatementSelector {
+                match_source: format!(
+                    "const DECLARATORS_BEFORE = null,\n  selected = STR_LITERAL_MATCHING_RE(\"^{}$\"),\n  DECLARATORS_AFTER = null;",
+                    literal_for(decl_idx, declarator_idx),
+                ),
+                identifiers: SourceMatchIdentifierMode::AlphaAll,
+                target_binding: (opts.mode == Mode::TargetBinding).then(|| "selected".to_string()),
+                target_statement: None,
+                target_statements: None,
+                wildcard_string_literals: BTreeSet::new(),
+            }
+        })
+        .collect()
+}
+
+fn literal_for(decl_idx: usize, declarator_idx: usize) -> String {
+    format!("generic-token-{decl_idx:04}-{declarator_idx:02}")
+}

--- a/devinfra/js/debundle/perf/source_match_selector_profile.md
+++ b/devinfra/js/debundle/perf/source_match_selector_profile.md
@@ -1,0 +1,158 @@
+# source_match declaration-hole selector profile
+
+This note tracks stack-sample evidence for generic `source_match`
+selectors shaped like large direct literal sweeps. It intentionally uses
+only synthetic names and source.
+
+## Workload
+
+Target:
+
+```bash
+bazelisk run //devinfra/js/debundle/perf:source_match_decl_holes_profile -- \
+  --mode binding-group --declarations 600 --declarators 10 --selectors 600 --repetitions 1
+```
+
+The generated chunk contains many top-level `const` declarations, each
+with many string-literal declarators. Each selector is a one-declaration
+template with leading/trailing `DECLARATORS_*` holes and one pinned
+`STR_LITERAL_MATCHING_RE("^generic-token-...$")` declarator.
+
+Modes:
+
+- `binding-group`: calls `resolve_member_binding_group`, matching the
+  preferred `binding_groups[].source_match` shape.
+- `target-binding`: calls member-form `resolve_member_binding` with
+  `target_binding`, a comparable single-binding resolution path.
+- `ambiguity`: calls member-form `resolve_member_binding` without
+  `target_binding`, so matching the wider declaration produces the
+  multi-binding ambiguity diagnostic shape from direct-selector sweeps.
+
+## Profiles
+
+### Parent private-corpus signal
+
+A downstream CSS-direct validation run spent about 9 minutes CPU-bound
+before emitting hundreds of member-form `source_match` ambiguity
+diagnostics. The captured profile is not committed here because it
+belongs to a private corpus, but the stack-sample shape is relevant:
+
+```bash
+perf record -F 99 -g -p <debundle-pid> \
+  -o /tmp/debundle-css-direct.perf.data -- sleep 30
+```
+
+That run captured 2968 samples and was dominated by regex setup:
+`regex_automata::meta::strategy::new`,
+`regex_automata::nfa::thompson::compiler::*`,
+range-trie / alphabet byte-class construction, `regex_syntax::ast::parse`,
+and allocation/free around regex structures. The selectors all used
+`STR_LITERAL_MATCHING_RE(...)` in member-form selectors over
+multi-declarator top-level declarations. That pointed at repeated regex
+parse/compile during candidate matching, not just expensive regex search.
+
+### Generic before profile
+
+Command:
+
+```bash
+perf record -F 99 -g \
+  -o /tmp/ducktape-source-match-generic-before.perf.data -- \
+  bazel-bin/devinfra/js/debundle/perf/source_match_decl_holes_profile \
+    --declarations 60 --declarators 8 --selectors 60 --repetitions 1
+```
+
+Timing:
+
+```text
+source_match_decl_holes_profile declarations=60 declarators=8 selectors=60 repetitions=1 elapsed_ms=9580 checksum=710
+```
+
+An unprofiled `/usr/bin/time` run of the same command took
+`elapsed=14.78 user=11.10 sys=0.06`. The profile captured 944 samples.
+This pre-PR workload resolved one pinned declarator per selector; the
+same code path fed both member target-binding selectors and
+binding-group declarator-hole resolution.
+Top stacks included:
+
+- `regex_automata::hybrid::dfa::Lazy::add_state`
+- `regex_automata::nfa::thompson::backtrack::Config::new`
+- `regex_automata::util::alphabet::ByteClasses::set`
+- `regex_automata::nfa::thompson::compiler::Compiler::c_concat`
+- `regex_syntax::ast::parse::*`
+
+The generic profile reproduced the private-corpus signal: selector
+resolution was repeatedly compiling regexes while scanning declarations.
+
+### Optimization
+
+`source_match` now prepares regex predicates once per parsed selector
+needle and passes them through the wildcard matcher. For
+`DECLARATORS_*` variable-declaration selectors, it also builds a cheap
+prefilter from pinned direct string-literal predicates. Candidate
+declarations whose string-literal initializers cannot satisfy those
+predicates are rejected before recursive declarator-hole alignment.
+
+This covers both target-binding declarator-hole selectors and the
+member-form no-`target_binding` path that otherwise only reaches the
+"matched a multi-binding declaration" ambiguity diagnostic after a full
+AST match.
+
+### Generic after timings
+
+Same small workload, after the optimization:
+
+```text
+mode=Ambiguity     declarations=60 declarators=8 selectors=60 elapsed_ms=115 elapsed=0.12 user=0.11
+mode=TargetBinding declarations=60 declarators=8 selectors=60 elapsed_ms=144 elapsed=0.16 user=0.14
+mode=BindingGroup  declarations=60 declarators=8 selectors=60 elapsed_ms=151 elapsed=0.16 user=0.13
+```
+
+Scaled binding-group run:
+
+```text
+source_match_decl_holes_profile mode=BindingGroup declarations=600 declarators=10 selectors=600 repetitions=1 elapsed_ms=6267 checksum=7690
+elapsed=6.34 user=6.24 sys=0.00
+```
+
+### Generic binding-group after profile
+
+```bash
+perf record -F 99 -g \
+  -o /tmp/ducktape-source-match-binding-group-after.perf.data -- \
+  bazel-bin/devinfra/js/debundle/perf/source_match_decl_holes_profile \
+    --mode binding-group --declarations 600 --declarators 10 --selectors 600 --repetitions 1
+```
+
+Timing:
+
+```text
+source_match_decl_holes_profile mode=BindingGroup declarations=600 declarators=10 selectors=600 repetitions=1 elapsed_ms=6481 checksum=7690
+```
+
+The binding-group after profile captured 639 samples. Top stacks moved from regex
+compiler/setup to regex search and prefilter work:
+
+- `regex_automata::hybrid::search::find_fwd`
+- `regex_automata::hybrid::dfa::DFA::next_state_untagged_unchecked`
+- `regex_automata::meta::regex::Regex::search_half`
+- `source_match::StringLiteralPredicate::matches`
+- `source_match::VarDeclWithDeclaratorHolesPrefilter::var_decl_can_match`
+
+That is the intended shape: regexes are still used to test candidate
+string literals, but regex parse/compile setup is no longer on the hot
+path for every candidate AST comparison.
+
+## Remaining Work
+
+The next algorithmic step is a chunk-level source-match index keyed by
+top-level declaration kind and direct literal values/predicates. The
+current change keeps the public resolver API unchanged and still scans
+candidate declarations per distinct selector, but most candidates are
+rejected before recursive AST matching and regex compilation is hoisted
+out of that loop.
+
+Keep-going miss diagnostics can also do repeated nearest-candidate scans
+for selectors that truly miss. This PR targets the observed slow
+ambiguity path; miss-diagnostic caching/indexing should be handled as a
+follow-up if a profile shows `source_match_no_match_hint` dominating.

--- a/devinfra/js/debundle/source_match.rs
+++ b/devinfra/js/debundle/source_match.rs
@@ -1138,11 +1138,15 @@ fn find_matching_target_var_decl_with_declarator_holes(
     let (target_decl_idx, target_binding_idx) =
         selector_var_declarator_binding_location(needle_var, request_id, selector, target_binding)?;
     let prepared = PreparedNeedle::new(needle, selector);
+    let prefilter = VarDeclWithDeclaratorHolesPrefilter::new(needle_var, &prepared);
     let mut matches = Vec::new();
     for (body_idx, item) in runtime_module.body.iter().enumerate() {
         let Some(candidate_var) = item_var_decl(item) else {
             continue;
         };
+        if !prefilter.var_decl_can_match(candidate_var) {
+            continue;
+        }
         if !prepared.matches(item) {
             continue;
         }
@@ -1207,11 +1211,15 @@ fn resolve_member_binding_group_with_declarator_holes(
         })
         .collect::<Result<BTreeMap<_, _>>>()?;
     let prepared = PreparedNeedle::new(needle, selector);
+    let prefilter = VarDeclWithDeclaratorHolesPrefilter::new(needle_var, &prepared);
     let mut matches = Vec::new();
     for (body_idx, item) in runtime_module.body.iter().enumerate() {
         let Some(candidate_var) = item_var_decl(item) else {
             continue;
         };
+        if !prefilter.var_decl_can_match(candidate_var) {
+            continue;
+        }
         if !prepared.matches(item) {
             continue;
         }
@@ -1464,9 +1472,167 @@ impl VarDeclaratorPrefilter {
     }
 }
 
+/// Cheap candidate prefilter for variable declarations that use
+/// `DECLARATORS_*` list holes. The full matcher must still validate
+/// declaration structure and alpha bindings, but pinned direct string
+/// predicates are enough to reject most declarations before recursive
+/// list-hole alignment.
+struct VarDeclWithDeclaratorHolesPrefilter {
+    needle_kind: VarDeclKind,
+    pinned_literal_predicates: Vec<StringLiteralPredicate>,
+}
+
+impl VarDeclWithDeclaratorHolesPrefilter {
+    fn new(needle: &VarDecl, prepared: &PreparedNeedle<'_>) -> Self {
+        let pinned_literal_predicates = needle
+            .decls
+            .iter()
+            .filter(|declarator| declarator_list_hole_name(declarator).is_none())
+            .filter_map(|declarator| {
+                declarator.init.as_deref().and_then(|init| {
+                    string_literal_predicate_for_expr(
+                        init,
+                        prepared.selector,
+                        &prepared.string_literal_regexes,
+                    )
+                })
+            })
+            .collect();
+        Self {
+            needle_kind: needle.kind,
+            pinned_literal_predicates,
+        }
+    }
+
+    fn var_decl_can_match(&self, candidate: &VarDecl) -> bool {
+        if candidate.kind != self.needle_kind {
+            return false;
+        }
+        if self.pinned_literal_predicates.is_empty() {
+            return true;
+        }
+        let mut candidate_start = 0;
+        for predicate in &self.pinned_literal_predicates {
+            let Some(candidate_idx) = candidate
+                .decls
+                .iter()
+                .enumerate()
+                .skip(candidate_start)
+                .find_map(|(candidate_idx, declarator)| {
+                    declarator
+                        .init
+                        .as_deref()
+                        .and_then(string_literal_expr_value_ref)
+                        .is_some_and(|value| predicate.matches(value))
+                        .then_some(candidate_idx)
+                })
+            else {
+                return false;
+            };
+            candidate_start = candidate_idx + 1;
+        }
+        true
+    }
+}
+
+#[derive(Clone)]
+enum StringLiteralPredicate {
+    Exact(String),
+    Regex(Option<Regex>),
+}
+
+impl StringLiteralPredicate {
+    fn regex(pattern: String) -> Self {
+        Self::Regex(Regex::new(&pattern).ok())
+    }
+
+    fn matches(&self, candidate_value: &Wtf8Atom) -> bool {
+        match self {
+            Self::Exact(expected) => candidate_value.to_string_lossy().as_ref() == expected,
+            Self::Regex(compiled) => compiled
+                .as_ref()
+                .is_some_and(|regex| regex.is_match(candidate_value.to_string_lossy().as_ref())),
+        }
+    }
+}
+
+#[derive(Default)]
+struct CompiledStringLiteralRegexes {
+    patterns: BTreeMap<String, StringLiteralPredicate>,
+}
+
+impl CompiledStringLiteralRegexes {
+    fn for_module_item(needle: &ModuleItem) -> Self {
+        let mut collector = StringLiteralRegexPatternCollector::default();
+        needle.visit_with(&mut collector);
+        Self {
+            patterns: collector
+                .patterns
+                .into_iter()
+                .map(|pattern| (pattern.clone(), StringLiteralPredicate::regex(pattern)))
+                .collect(),
+        }
+    }
+
+    fn matches(&self, pattern: &str, candidate_value: &Wtf8Atom) -> bool {
+        self.patterns
+            .get(pattern)
+            .cloned()
+            .unwrap_or_else(|| StringLiteralPredicate::regex(pattern.to_string()))
+            .matches(candidate_value)
+    }
+
+    fn predicate(&self, pattern: &str) -> StringLiteralPredicate {
+        self.patterns
+            .get(pattern)
+            .cloned()
+            .unwrap_or_else(|| StringLiteralPredicate::regex(pattern.to_string()))
+    }
+}
+
+#[derive(Default)]
+struct StringLiteralRegexPatternCollector {
+    patterns: BTreeSet<String>,
+}
+
+impl Visit for StringLiteralRegexPatternCollector {
+    fn visit_expr(&mut self, expr: &Expr) {
+        if let Some(pattern) = string_literal_regex_pattern(expr) {
+            self.patterns.insert(pattern);
+            return;
+        }
+        expr.visit_children_with(self);
+    }
+}
+
+fn string_literal_predicate_for_expr(
+    expr: &Expr,
+    selector: &AnonymousStatementSelector,
+    string_literal_regexes: &CompiledStringLiteralRegexes,
+) -> Option<StringLiteralPredicate> {
+    if let Some(pattern) = string_literal_regex_pattern(expr) {
+        return Some(string_literal_regexes.predicate(&pattern));
+    }
+    let Expr::Lit(Lit::Str(str_)) = expr else {
+        return None;
+    };
+    let value = str_.value.to_string_lossy();
+    if selector.wildcard_string_literals.contains(value.as_ref()) {
+        return None;
+    }
+    Some(StringLiteralPredicate::Exact(value.to_string()))
+}
+
 fn string_literal_expr_value(expr: &Expr) -> Option<String> {
     match expr {
         Expr::Lit(Lit::Str(str_)) => Some(str_.value.to_string_lossy().to_string()),
+        _ => None,
+    }
+}
+
+fn string_literal_expr_value_ref(expr: &Expr) -> Option<&Wtf8Atom> {
+    match expr {
+        Expr::Lit(Lit::Str(str_)) => Some(&str_.value),
         _ => None,
     }
 }
@@ -1571,11 +1737,26 @@ fn find_matching_body_indices(
     selector: &AnonymousStatementSelector,
 ) -> Vec<usize> {
     let prepared = PreparedNeedle::new(needle, selector);
+    let declarator_hole_prefilter = item_var_decl(needle)
+        .filter(|var| {
+            var.decls
+                .iter()
+                .any(|declarator| declarator_list_hole_name(declarator).is_some())
+        })
+        .map(|var| VarDeclWithDeclaratorHolesPrefilter::new(var, &prepared));
     runtime_module
         .body
         .iter()
         .enumerate()
-        .filter_map(|(body_idx, item)| prepared.matches(item).then_some(body_idx))
+        .filter_map(|(body_idx, item)| {
+            if let Some(prefilter) = &declarator_hole_prefilter {
+                let candidate_var = item_var_decl(item)?;
+                if !prefilter.var_decl_can_match(candidate_var) {
+                    return None;
+                }
+            }
+            prepared.matches(item).then_some(body_idx)
+        })
         .collect()
 }
 
@@ -1589,11 +1770,26 @@ fn find_matching_body_ranges(
     }
     if let [needle] = needles {
         let prepared = PreparedNeedle::new(needle, selector);
+        let declarator_hole_prefilter = item_var_decl(needle)
+            .filter(|var| {
+                var.decls
+                    .iter()
+                    .any(|declarator| declarator_list_hole_name(declarator).is_some())
+            })
+            .map(|var| VarDeclWithDeclaratorHolesPrefilter::new(var, &prepared));
         return runtime_module
             .body
             .iter()
             .enumerate()
-            .filter_map(|(body_idx, candidate)| prepared.matches(candidate).then_some(body_idx))
+            .filter_map(|(body_idx, candidate)| {
+                if let Some(prefilter) = &declarator_hole_prefilter {
+                    let candidate_var = item_var_decl(candidate)?;
+                    if !prefilter.var_decl_can_match(candidate_var) {
+                        return None;
+                    }
+                }
+                prepared.matches(candidate).then_some(body_idx)
+            })
             .collect();
     }
     let wildcard_idents = wildcard_ident_names_for_module_items(needles);
@@ -2768,6 +2964,7 @@ struct PreparedNeedle<'a> {
     needle: &'a ModuleItem,
     selector: &'a AnonymousStatementSelector,
     wildcard_idents: WildcardIdents,
+    string_literal_regexes: CompiledStringLiteralRegexes,
     alpha: bool,
     /// Neither string-literal nor syntactic-hole wildcards/predicates
     /// present — the plain structural-equality fast path applies.
@@ -2781,6 +2978,7 @@ impl<'a> PreparedNeedle<'a> {
     fn new(needle: &'a ModuleItem, selector: &'a AnonymousStatementSelector) -> Self {
         SyntaxContext::within_ignored_ctxt(|| {
             let wildcard_idents = wildcard_ident_names(needle);
+            let string_literal_regexes = CompiledStringLiteralRegexes::for_module_item(needle);
             let alpha = selector.identifiers == SourceMatchIdentifierMode::AlphaAll;
             let no_wildcards =
                 selector.wildcard_string_literals.is_empty() && wildcard_idents.is_empty();
@@ -2793,6 +2991,7 @@ impl<'a> PreparedNeedle<'a> {
                 needle,
                 selector,
                 wildcard_idents,
+                string_literal_regexes,
                 alpha,
                 no_wildcards,
                 canonical_needle,
@@ -2835,8 +3034,13 @@ impl<'a> PreparedNeedle<'a> {
             // holes that absorb identifier-bearing subtrees don't desync the
             // identifiers after them — and it walks borrowed trees with no
             // per-comparison clone + canonicalize.
-            AstWildcardMatcher::new(self.selector, &self.wildcard_idents, self.alpha)
-                .match_module_item(self.needle, candidate)
+            AstWildcardMatcher::new_with_string_literal_regexes(
+                self.selector,
+                &self.wildcard_idents,
+                &self.string_literal_regexes,
+                self.alpha,
+            )
+            .match_module_item(self.needle, candidate)
         })
     }
 
@@ -2846,8 +3050,12 @@ impl<'a> PreparedNeedle<'a> {
         candidate: &VarDecl,
     ) -> Option<Vec<Option<usize>>> {
         SyntaxContext::within_ignored_ctxt(|| {
-            let mut matcher =
-                AstWildcardMatcher::new(self.selector, &self.wildcard_idents, self.alpha);
+            let mut matcher = AstWildcardMatcher::new_with_string_literal_regexes(
+                self.selector,
+                &self.wildcard_idents,
+                &self.string_literal_regexes,
+                self.alpha,
+            );
             matcher.match_var_declarator_slice_with_alignment(&needle.decls, &candidate.decls)
         })
     }
@@ -3029,6 +3237,59 @@ mod tests {
         assert!(!prepared.matches(&non_matching));
         assert!(!prepared.matches(&non_string));
     }
+
+    #[test]
+    fn declarator_hole_prefilter_uses_regex_string_literal_predicates() {
+        let selector = selector(
+            r#"const DECLARATORS_BEFORE = null,
+  readable = STR_LITERAL_MATCHING_RE("^generic-token-[0-9]+$"),
+  DECLARATORS_AFTER = null;"#,
+        );
+        let needle = parse_one(&selector.match_source);
+        let prepared = PreparedNeedle::new(&needle, &selector);
+        let prefilter =
+            VarDeclWithDeclaratorHolesPrefilter::new(item_var_decl(&needle).unwrap(), &prepared);
+
+        let matching = parse_one(
+            r#"const before = "other",
+  minified = "generic-token-42",
+  after = "other";"#,
+        );
+        let non_matching = parse_one(
+            r#"const before = "other",
+  minified = "different-token-42",
+  after = "other";"#,
+        );
+
+        assert!(prefilter.var_decl_can_match(item_var_decl(&matching).unwrap()));
+        assert!(!prefilter.var_decl_can_match(item_var_decl(&non_matching).unwrap()));
+    }
+
+    #[test]
+    fn declarator_hole_body_index_matching_prefilters_by_literal_predicate() {
+        js_ast::with_swc_globals(|| {
+            let runtime = js_ast::parse_js_module_ast(
+                "<test>",
+                r#"const unrelatedA = "generic-token-1";
+const before = "other",
+  minified = "generic-token-42",
+  after = "other";
+const unrelatedB = "different-token-42";"#,
+            )
+            .unwrap();
+            let selector = selector(
+                r#"const DECLARATORS_BEFORE = null,
+  readable = STR_LITERAL_MATCHING_RE("^generic-token-42$"),
+  DECLARATORS_AFTER = null;"#,
+            );
+            let needle = parse_one(&selector.match_source);
+
+            assert_eq!(
+                find_matching_body_indices(&runtime, &needle, &selector),
+                vec![1]
+            );
+        });
+    }
 }
 
 #[derive(Clone, Default)]
@@ -3047,6 +3308,7 @@ struct AlphaMatchScope {
 struct AstWildcardMatcher<'a> {
     selector: &'a AnonymousStatementSelector,
     wildcard_idents: &'a WildcardIdents,
+    string_literal_regexes: Option<&'a CompiledStringLiteralRegexes>,
     replacements: WildcardReplacements,
     /// Whether value/binding identifiers are alpha-renamable. When true,
     /// identifier equality is tracked as a bijection built incrementally
@@ -3093,9 +3355,33 @@ impl<'a> AstWildcardMatcher<'a> {
         wildcard_idents: &'a WildcardIdents,
         alpha: bool,
     ) -> Self {
+        Self::new_impl(selector, wildcard_idents, None, alpha)
+    }
+
+    fn new_with_string_literal_regexes(
+        selector: &'a AnonymousStatementSelector,
+        wildcard_idents: &'a WildcardIdents,
+        string_literal_regexes: &'a CompiledStringLiteralRegexes,
+        alpha: bool,
+    ) -> Self {
+        Self::new_impl(
+            selector,
+            wildcard_idents,
+            Some(string_literal_regexes),
+            alpha,
+        )
+    }
+
+    fn new_impl(
+        selector: &'a AnonymousStatementSelector,
+        wildcard_idents: &'a WildcardIdents,
+        string_literal_regexes: Option<&'a CompiledStringLiteralRegexes>,
+        alpha: bool,
+    ) -> Self {
         Self {
             selector,
             wildcard_idents,
+            string_literal_regexes,
             replacements: WildcardReplacements::default(),
             alpha,
             alpha_scopes: vec![AlphaMatchScope::default()],
@@ -3448,9 +3734,10 @@ impl<'a> AstWildcardMatcher<'a> {
     fn match_expr(&mut self, needle: &Expr, candidate: &Expr) -> bool {
         if let Some(pattern) = string_literal_regex_pattern(needle) {
             return match candidate {
-                Expr::Lit(Lit::Str(candidate)) => {
-                    string_literal_matches_regex(&pattern, &candidate.value)
-                }
+                Expr::Lit(Lit::Str(candidate)) => self.string_literal_regexes.map_or_else(
+                    || string_literal_matches_regex(&pattern, &candidate.value),
+                    |regexes| regexes.matches(&pattern, &candidate.value),
+                ),
                 _ => false,
             };
         }


### PR DESCRIPTION
## Summary

- Hoists `STR_LITERAL_MATCHING_RE(...)` regex compilation into prepared `source_match` selector state.
- Adds a declarator-hole prefilter that rejects variable declarations by pinned direct string/regex literal predicates before recursive AST alignment.
- Adds a generic profile workload and profile notes for declaration-hole literal selectors, including stack-sample evidence and before/after timings.

## Why

Large specs with hundreds of similar declaration-hole selectors were repeatedly compiling regexes while scanning candidate declarations. Profiles showed `regex_syntax` and `regex_automata` compiler/setup stacks dominating before useful diagnostics were produced.

## Validation

- `nix develop -c bazelisk test //devinfra/js/debundle:source_match_test //devinfra/js/debundle/perf:source_match_decl_holes_profile --remote_download_outputs=toplevel`
- `nix develop -c bazelisk test //devinfra/js/debundle/e2e:syntactic_holes_test`
- `git diff --check`
- Generic workload, 60 declarations x 8 declarators x 60 selectors: before `elapsed_ms=9580`; after binding-group mode `elapsed_ms=151`.
- Binding-group after profile: `/tmp/ducktape-source-match-binding-group-after.perf.data`, 639 samples, top stacks moved to regex search/predicate checks rather than regex compiler setup.