### PR TITLE
Avoid cloning source-match declarators

### DIFF
--- a/devinfra/js/debundle/perf/proposer.md
+++ b/devinfra/js/debundle/perf/proposer.md
@@ -197,22 +197,41 @@ ducktape_version)` per chunk and skip lowering, codegen, and reports
 
 ### Member-form `source_match` selector resolution
 
-The Gaffer 660 migration loop still spends most of its broad
-`debundle run --dry-run --keep-going` wall time in member-form
-`source_match` selectors after the literal-initializer fast path
-(#2201) and selector aggregation (#2200/#2203).
+A 2026-06-14 downstream old-spec dry-run replay of a large private web
+corpus still showed material member-form `source_match` cost after the
+literal-initializer fast path (#2201) and selector aggregation
+(#2200/#2203). The replay used an optimized debundler, direct
+`debundle run --dry-run --keep-going`, `DUCKTAPE_SOURCE_MATCH_TIMINGS=1`,
+`DUCKTAPE_SOURCE_MATCH_TIMING_THRESHOLD_MS=50`, preview disabled, and:
 
-Current downstream profile snapshot, 2026-06-14, using the broad Gaffer
-660 command shape with `DUCKTAPE_SOURCE_MATCH_TIMINGS=1`,
-`DUCKTAPE_SOURCE_MATCH_TIMING_THRESHOLD_MS=100`, and preview disabled:
+```bash
+perf record -F 199 -e cpu-clock:u --call-graph dwarf,8192 \
+    -o /tmp/profile.data -- /tmp/run_debundle_direct.py
+```
 
-- wall: ~129s to the current aggregate duplicate-claim report;
-- timing lines: 129 `members[].selector.source_match` entries above
-  100ms;
-- representative early hot selectors: `hotkeyModifierSortOrder`
-  ~202ms, `compareHotkeyModifierOrder` ~258ms,
-  `composeNormalizedHotkey` ~423ms, plus many 120–250ms selectors
-  across bootstrap, panel, AI, search, and style modules.
+Baseline profile:
+
+- wall: 19.05s to the current aggregate duplicate-claim report;
+- timing lines: 80 `members[].selector.source_match` entries above
+  50ms, 5.765s summed, max 150ms;
+- sampled stacks: `source_match::find_member_binding_matches` 34.21%
+  children, with `source_match::module_item_for_single_var_declarator`
+  alone at 12.87% children.
+
+The clone-heavy single-declarator path has since been replaced with
+borrowed matching against the candidate declarator slice. Same replay:
+
+- wall: 12.64s;
+- timing lines: zero `members[].selector.source_match` entries above
+  50ms;
+- sampled stacks: `source_match::find_member_binding_matches` down to
+  17.11% children, and the synthetic `ModuleItem` clone helper is gone
+  from the profile.
+
+The remaining sampled `source_match` work is matcher/list-hole/string
+predicate logic: `match_var_declarator_slice_with_alignment`,
+`match_expr`, `StringLiteralPredicate::matches`, and body-group
+alignment.
 
 Two bounded per-declarator prefilter experiments were tried and rejected:
 
@@ -223,11 +242,11 @@ Two bounded per-declarator prefilter experiments were tried and rejected:
   cheap and tested, but broad run remained 128.955s with 129 timing
   lines, so it did not materially improve the real workload.
 
-Next credible implementation: add a shared per-chunk source-match
-candidate index/cache rather than more ad hoc per-selector filters. The
-index should be built once per chunk during materialization and reused
-across member/binding-group selectors. Candidate keys to try, with
-counters before changing semantics:
+Next credible implementation, if this path becomes material again: add a
+shared per-chunk source-match candidate index/cache rather than more ad
+hoc per-selector filters. The index should be built once per chunk
+during materialization and reused across member/binding-group selectors.
+Candidate keys to try, with counters before changing semantics:
 
 - top-level body kind + declaration kind + var kind/declarator count;
 - declared-binding count and, in exact identifier mode, declared-binding
@@ -238,7 +257,7 @@ counters before changing semantics:
   so repeated selector families do not reparse or rebuild matcher state.
 
 Treat a candidate-index PR as successful only if it shows a wall-time
-drop or a large reduction in timed selector count on the broad Gaffer
+drop or a large reduction in timed selector count on a broad downstream
 gate; isolated unit wins are not enough for this path.
 
 ### Materialize-stage hot-loop optimizations

--- a/devinfra/js/debundle/source_match.rs
+++ b/devinfra/js/debundle/source_match.rs
@@ -1103,8 +1103,7 @@ fn find_matching_target_var_declarators(
             if !prefilter.declarator_can_match(declarator) {
                 continue;
             }
-            let candidate_item = module_item_for_single_var_declarator(item, declarator);
-            if !prepared.matches(&candidate_item) {
+            if !prepared.matches_single_var_declarator(item, declarator) {
                 continue;
             }
             let declared = declared_bindings_for_var_declarator(declarator);
@@ -1369,8 +1368,7 @@ fn find_matching_var_declarators(
             if !prefilter.declarator_can_match(declarator) {
                 continue;
             }
-            let candidate_item = module_item_for_single_var_declarator(item, declarator);
-            if !prepared.matches(&candidate_item) {
+            if !prepared.matches_single_var_declarator(item, declarator) {
                 continue;
             }
             let declared = declared_bindings_for_var_declarator(declarator);
@@ -1645,34 +1643,6 @@ fn item_var_decl(item: &ModuleItem) -> Option<&VarDecl> {
             _ => None,
         },
         _ => None,
-    }
-}
-
-fn module_item_for_single_var_declarator(
-    source_item: &ModuleItem,
-    declarator: &VarDeclarator,
-) -> ModuleItem {
-    let (source_var, export_span) = match source_item {
-        ModuleItem::Stmt(Stmt::Decl(Decl::Var(var))) => (var.as_ref(), None),
-        ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(export)) => match &export.decl {
-            Decl::Var(var) => (var.as_ref(), Some(export.span)),
-            _ => unreachable!("item_var_decl already filtered source_item"),
-        },
-        _ => unreachable!("item_var_decl already filtered source_item"),
-    };
-    let var_decl = Decl::Var(Box::new(VarDecl {
-        span: source_var.span,
-        ctxt: source_var.ctxt,
-        kind: source_var.kind,
-        declare: source_var.declare,
-        decls: vec![declarator.clone()],
-    }));
-    match export_span {
-        Some(span) => ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
-            span,
-            decl: var_decl,
-        })),
-        None => ModuleItem::Stmt(Stmt::Decl(var_decl)),
     }
 }
 
@@ -3044,6 +3014,26 @@ impl<'a> PreparedNeedle<'a> {
         })
     }
 
+    fn matches_single_var_declarator(
+        &self,
+        candidate_item: &ModuleItem,
+        candidate_declarator: &VarDeclarator,
+    ) -> bool {
+        SyntaxContext::within_ignored_ctxt(|| {
+            let mut matcher = AstWildcardMatcher::new_with_string_literal_regexes(
+                self.selector,
+                &self.wildcard_idents,
+                &self.string_literal_regexes,
+                self.alpha,
+            );
+            matcher.match_single_var_declarator_item(
+                self.needle,
+                candidate_item,
+                candidate_declarator,
+            )
+        })
+    }
+
     fn var_declarator_alignment(
         &self,
         needle: &VarDecl,
@@ -3181,6 +3171,46 @@ mod tests {
 
     fn single_declarator_init(item: &ModuleItem) -> &Expr {
         single_declarator(item).init.as_deref().unwrap()
+    }
+
+    #[test]
+    fn prepared_needle_matches_borrowed_single_var_declarator() {
+        let plain_selector = selector(r#"const readable = makeValue("target-token");"#);
+        let needle = parse_one(&plain_selector.match_source);
+        let prepared = PreparedNeedle::new(&needle, &plain_selector);
+        let candidate = parse_one(
+            r#"const before = otherValue("other-token"),
+  minified = makeValue("target-token"),
+  after = otherValue("other-token");"#,
+        );
+        let candidate_var = item_var_decl(&candidate).unwrap();
+
+        assert!(!prepared.matches_single_var_declarator(&candidate, &candidate_var.decls[0]));
+        assert!(prepared.matches_single_var_declarator(&candidate, &candidate_var.decls[1]));
+        assert!(!prepared.matches_single_var_declarator(&candidate, &candidate_var.decls[2]));
+
+        let export_selector = selector(r#"export const readable = makeValue("target-token");"#);
+        let export_needle = parse_one(&export_selector.match_source);
+        let export_prepared = PreparedNeedle::new(&export_needle, &export_selector);
+        let export_candidate = parse_one(
+            r#"export const before = otherValue("other-token"),
+  minified = makeValue("target-token"),
+  after = otherValue("other-token");"#,
+        );
+        let export_candidate_var = item_var_decl(&export_candidate).unwrap();
+
+        assert!(
+            !export_prepared
+                .matches_single_var_declarator(&export_candidate, &export_candidate_var.decls[0])
+        );
+        assert!(
+            export_prepared
+                .matches_single_var_declarator(&export_candidate, &export_candidate_var.decls[1])
+        );
+        assert!(
+            !export_prepared
+                .matches_single_var_declarator(&export_candidate, &export_candidate_var.decls[2])
+        );
     }
 
     #[test]
@@ -3548,6 +3578,37 @@ impl<'a> AstWildcardMatcher<'a> {
         }
     }
 
+    fn match_single_var_declarator_item(
+        &mut self,
+        needle: &ModuleItem,
+        candidate_item: &ModuleItem,
+        candidate_declarator: &VarDeclarator,
+    ) -> bool {
+        match (needle, candidate_item) {
+            (
+                ModuleItem::Stmt(Stmt::Decl(Decl::Var(needle_var))),
+                ModuleItem::Stmt(Stmt::Decl(Decl::Var(candidate_var))),
+            ) => self.match_single_var_declarator_decl(
+                needle_var,
+                candidate_var,
+                candidate_declarator,
+            ),
+            (
+                ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(needle_export)),
+                ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(candidate_export)),
+            ) => match (&needle_export.decl, &candidate_export.decl) {
+                (Decl::Var(needle_var), Decl::Var(candidate_var)) => self
+                    .match_single_var_declarator_decl(
+                        needle_var,
+                        candidate_var,
+                        candidate_declarator,
+                    ),
+                _ => false,
+            },
+            _ => false,
+        }
+    }
+
     fn match_module_decl(&mut self, needle: &ModuleDecl, candidate: &ModuleDecl) -> bool {
         match (needle, candidate) {
             (ModuleDecl::Import(needle), ModuleDecl::Import(candidate)) => {
@@ -3646,6 +3707,23 @@ impl<'a> AstWildcardMatcher<'a> {
             && needle.declare == candidate.declare
             && self
                 .match_var_declarator_slice_with_alignment(&needle.decls, &candidate.decls)
+                .is_some()
+    }
+
+    fn match_single_var_declarator_decl(
+        &mut self,
+        needle: &VarDecl,
+        candidate: &VarDecl,
+        candidate_declarator: &VarDeclarator,
+    ) -> bool {
+        needle.kind == candidate.kind
+            && needle.declare == candidate.declare
+            && needle.decls.len() == 1
+            && self
+                .match_var_declarator_slice_with_alignment(
+                    &needle.decls,
+                    std::slice::from_ref(candidate_declarator),
+                )
                 .is_some()
     }
 


### PR DESCRIPTION
## Summary

- Avoid constructing a cloned synthetic `ModuleItem` for each candidate variable declarator during member-form `source_match` matching.
- Add a borrowed single-declarator matcher path that preserves the declaration/export wrapper checks while matching against `std::slice::from_ref(candidate_declarator)`.
- Record the sampled-stack before/after profile and remaining `source_match` follow-up in the debundle perf notes.

## Profile Evidence

Workload: downstream old-spec `debundle run --dry-run --keep-going` replay on a large private web corpus, using an optimized local debundler and source-match timing enabled. The replay still exits non-zero at the existing aggregate duplicate-claim report; timings compare the same path to that point.

Sampling command:

```bash
perf record -F 199 -e cpu-clock:u --call-graph dwarf,8192 \
  -o /tmp/gaffer78-profile-results-current/perf_cpu_clock.data \
  -- /tmp/run_gaffer78_debundle_direct.py
```

Baseline:

- wall: 19.05s
- `members[].selector.source_match` timing lines above 50ms: 80, summed 5.765s, max 150ms
- sampled stack: `source_match::find_member_binding_matches` 34.21% children
- sampled stack: `source_match::module_item_for_single_var_declarator` 12.87% children

After this change:

- wall: 12.64s
- `members[].selector.source_match` timing lines above 50ms: 0
- sampled stack: `source_match::find_member_binding_matches` 17.11% children
- `module_item_for_single_var_declarator` is removed and absent from the profile

Remaining sampled `source_match` work is matcher/list-hole/string-predicate logic, especially `match_var_declarator_slice_with_alignment`, `match_expr`, and `StringLiteralPredicate::matches`.

## Validation

- `nix develop --command bazelisk test //devinfra/js/debundle:source_match_test --config=nolint` (BuildBuddy invocation `fc52b377-7c39-41a2-b670-3f95b407fe7a`)
- `nix develop --command bazelisk test //devinfra/js/debundle:source_match_test //devinfra/js/debundle/e2e:syntactic_holes_test //devinfra/js/debundle/e2e:anonymous_statement_test --config=nolint` (BuildBuddy invocation `48742b2e-1710-4d57-a46c-8712baa9e3f7`)
- Downstream replay rebuilt with this Ducktape override and reached the same expected duplicate-claim failure boundary before after-profile collection.
