### PR TITLE
Avoid string allocation in source-match predicates

### DIFF
--- a/devinfra/js/debundle/perf/proposer.md
+++ b/devinfra/js/debundle/perf/proposer.md
@@ -233,6 +233,25 @@ predicate logic: `match_var_declarator_slice_with_alignment`,
 `match_expr`, `StringLiteralPredicate::matches`, and body-group
 alignment.
 
+Follow-up replay on the same corpus with source-match timing threshold
+set to 0 showed 761 total source-match resolutions, with member
+selectors accounting for nearly all residual selector wall:
+
+- post-clone-fix baseline: 2.508s summed `source_match` timing, 2.384s
+  of that in 345 member selectors; sampled
+  `StringLiteralPredicate::matches` at 2.18% children;
+- exact string literal predicates changed from lossy string allocation
+  to direct `Wtf8Atom` comparison: 2.149s summed `source_match` timing,
+  2.107s in the same 345 member selectors; sampled
+  `StringLiteralPredicate::matches` at 1.90% children.
+
+A shared per-chunk candidate index keyed by declaration kind and
+export/non-export wrapper was also tried after the clone fix and
+rejected: it increased summed threshold-0 `source_match` timing from
+2.508s to 2.648s on this replay. Do not revive that exact index shape
+without new counters showing top-level scan overhead, rather than
+matcher recursion, is the bottleneck.
+
 Two bounded per-declarator prefilter experiments were tried and rejected:
 
 - nested string-literal multiset prefilter for single-declarator

--- a/devinfra/js/debundle/source_match.rs
+++ b/devinfra/js/debundle/source_match.rs
@@ -1535,7 +1535,7 @@ impl VarDeclWithDeclaratorHolesPrefilter {
 
 #[derive(Clone)]
 enum StringLiteralPredicate {
-    Exact(String),
+    Exact(Wtf8Atom),
     Regex(Option<Regex>),
 }
 
@@ -1546,7 +1546,7 @@ impl StringLiteralPredicate {
 
     fn matches(&self, candidate_value: &Wtf8Atom) -> bool {
         match self {
-            Self::Exact(expected) => candidate_value.to_string_lossy().as_ref() == expected,
+            Self::Exact(expected) => candidate_value == expected,
             Self::Regex(compiled) => compiled
                 .as_ref()
                 .is_some_and(|regex| regex.is_match(candidate_value.to_string_lossy().as_ref())),
@@ -1614,11 +1614,14 @@ fn string_literal_predicate_for_expr(
     let Expr::Lit(Lit::Str(str_)) = expr else {
         return None;
     };
-    let value = str_.value.to_string_lossy();
-    if selector.wildcard_string_literals.contains(value.as_ref()) {
+    let value = &str_.value;
+    if selector
+        .wildcard_string_literals
+        .contains(value.to_string_lossy().as_ref())
+    {
         return None;
     }
-    Some(StringLiteralPredicate::Exact(value.to_string()))
+    Some(StringLiteralPredicate::Exact(value.clone()))
 }
 
 fn string_literal_expr_value(expr: &Expr) -> Option<String> {


### PR DESCRIPTION
## Summary

- Store exact source-match string literal predicates as `Wtf8Atom` instead of `String`.
- Compare exact candidate string literals directly as atoms, avoiding `to_string_lossy()` allocation on each exact predicate match.
- Update the debundle perf notes with the measured follow-up result and the rejected declaration-kind candidate-index experiment.

## Profile Evidence

This builds on #2222 (`Avoid cloning source-match declarators`) and uses the same downstream old-spec `debundle run --dry-run --keep-going` replay on a large private web corpus. The replay still exits non-zero at the existing aggregate duplicate-claim report; timing compares the path to that boundary.

Timing command:

```bash
DUCKTAPE_SOURCE_MATCH_TIMING_THRESHOLD_MS=0 \
  /usr/bin/time -v /tmp/run_gaffer78_debundle_direct.py
```

Post-#2222 baseline:

- wall: 15.62s in the threshold-0 timing replay
- total source_match timing: 761 resolutions, 2.508s summed, max 41ms
- member selectors: 345 resolutions, 2.384s summed
- sampled stack: `source_match::StringLiteralPredicate::matches` 2.18% children

After this change:

- wall: 12.49s in the threshold-0 timing replay
- total source_match timing: 761 resolutions, 2.149s summed, max 33ms
- member selectors: 345 resolutions, 2.107s summed
- sampled stack: `source_match::StringLiteralPredicate::matches` 1.90% children

The sampled profile was captured with:

```bash
perf record -F 199 -e cpu-clock:u --call-graph dwarf,8192 \
  -o /tmp/gaffer78-profile-results-wtf8/perf_cpu_clock.data \
  -- /tmp/run_gaffer78_debundle_direct.py
```

I also tried the next larger candidate-index shape from the perf notes: a shared per-chunk index keyed by variable declaration kind and export/non-export wrapper. That experiment was rejected because it increased threshold-0 source_match timing from 2.508s to 2.648s on this replay.

## Validation

- `nix develop --command bazelisk test //devinfra/js/debundle:source_match_test --config=nolint` after rebasing onto current `origin/devel` (BuildBuddy invocation `23767fbb-3299-4058-adcb-419c636bf694`)
- `nix develop --command bazelisk test //devinfra/js/debundle:source_match_test //devinfra/js/debundle/e2e:syntactic_holes_test //devinfra/js/debundle/e2e:anonymous_statement_test --config=nolint` before the clean rebase onto `origin/devel` (BuildBuddy invocation `8907f4b4-6fce-455b-aec7-50e537659a05`)
- Downstream replay rebuilt with this Ducktape override and reached the same expected duplicate-claim failure boundary before timing/profile collection.
