### PR TITLE
[codex] Add debundle selector diagnostics report

### DIFF
--- a/devinfra/js/debundle/e2e/BUILD.bazel
+++ b/devinfra/js/debundle/e2e/BUILD.bazel
@@ -104,6 +104,7 @@ _STANDARD_E2E_DEPS = [
         "namespace_aggregator_split_tdz_test",
         "pass_two_tdz_cut_diagnosis_test",
         "spec_comments_test",
+        "selector_diagnostics_report_test",
         "syntactic_holes_test",
     ]
 ]

--- a/devinfra/js/debundle/e2e/selector_diagnostics_report_test.rs
+++ b/devinfra/js/debundle/e2e/selector_diagnostics_report_test.rs
@@ -1,0 +1,150 @@
+use std::fs;
+
+use debundle_e2e_support::{
+    FixtureOpts, Member, logical_module, run_keep_going_dry_run_rejection_fixture,
+};
+use serde_json::Value;
+
+#[test]
+fn keep_going_writes_machine_readable_selector_diagnostics_report() {
+    let missing_selector = r#"function selectedFormatter(value) {
+  return value.toLowerCase();
+}"#;
+    let ambiguous_selector = r#"function repeatedHelper() {
+  return "shared";
+}"#;
+    let opts = FixtureOpts::new(
+        r#"function renderCard(value) {
+  return value.trim();
+}
+function decoratePrimary() {
+  return "shared";
+}
+function decorateSecondary() {
+  return "shared";
+}
+console.log(renderCard(" ok "), decoratePrimary(), decorateSecondary());
+export { renderCard, decoratePrimary, decorateSecondary };
+"#,
+        vec![
+            logical_module(
+                "diagnostics/missing",
+                &[Member::source_alpha("MissingFormatter", missing_selector)],
+            ),
+            logical_module("owners/card", &[Member::new("renderCard")]),
+            logical_module(
+                "duplicates/card",
+                &[Member::renamed("renderCardAgain", "renderCard")],
+            ),
+            logical_module(
+                "diagnostics/ambiguous",
+                &[Member::source_alpha("AmbiguousHelper", ambiguous_selector)],
+            ),
+        ],
+    );
+
+    let rejected = run_keep_going_dry_run_rejection_fixture(opts);
+    assert!(
+        rejected
+            .stderr
+            .contains("Source-match selector diagnostic report: 2 unresolved selector(s) found"),
+        "human source-match diagnostics must remain intact:\n{}",
+        rejected.stderr
+    );
+    assert!(
+        rejected
+            .stderr
+            .contains("Duplicate binding claim report: 1 duplicate claim(s) found"),
+        "human duplicate diagnostics must remain intact:\n{}",
+        rejected.stderr
+    );
+
+    let report_path = rejected
+        .report_root
+        .join("static")
+        .join("app")
+        .join("selector_diagnostics.json");
+    let report: Value = serde_json::from_str(
+        &fs::read_to_string(&report_path)
+            .unwrap_or_else(|error| panic!("read {}: {error}", report_path.display())),
+    )
+    .unwrap();
+    assert_eq!(report["chunk_id"], "static/app");
+    assert_eq!(report["counts"]["unresolved_selector"], 1);
+    assert_eq!(report["counts"]["ambiguous_selector"], 1);
+    assert_eq!(report["counts"]["duplicate_claim"], 1);
+
+    let diagnostics = report["diagnostics"]
+        .as_array()
+        .expect("diagnostics must be an array");
+    assert_eq!(diagnostics.len(), 3, "{report:#}");
+
+    let missing = find_entry(diagnostics, "unresolved_selector", "MissingFormatter");
+    assert_eq!(missing["module_path"], "diagnostics/missing");
+    assert_eq!(missing["selector_kind"], "members.source_match");
+    assert!(missing["target_binding"].is_null(), "{missing:#}");
+    assert!(
+        missing["source_match_preview"]
+            .as_str()
+            .unwrap()
+            .contains("selectedFormatter"),
+        "{missing:#}"
+    );
+    assert!(
+        missing["source_match_hash"].as_str().unwrap().len() >= 16,
+        "{missing:#}"
+    );
+    assert!(
+        missing["first_mismatch"]
+            .as_str()
+            .is_some_and(|s| !s.is_empty()),
+        "{missing:#}"
+    );
+    assert!(
+        missing["recommended_next_action"]
+            .as_str()
+            .unwrap()
+            .contains("nearest_candidates"),
+        "{missing:#}"
+    );
+
+    let ambiguous = find_entry(diagnostics, "ambiguous_selector", "AmbiguousHelper");
+    assert_eq!(ambiguous["module_path"], "diagnostics/ambiguous");
+    assert_eq!(ambiguous["body_indices"], serde_json::json!([1, 2]));
+    assert!(
+        ambiguous["message"].as_str().unwrap().contains("ambiguous"),
+        "{ambiguous:#}"
+    );
+    assert!(
+        ambiguous["recommended_next_action"]
+            .as_str()
+            .unwrap()
+            .contains("Refine the selector"),
+        "{ambiguous:#}"
+    );
+
+    let duplicate = diagnostics
+        .iter()
+        .find(|entry| entry["category"] == "duplicate_claim")
+        .expect("duplicate claim entry");
+    assert_eq!(duplicate["duplicate_claim"]["binding"], "renderCard");
+    let duplicate_sites = [
+        duplicate["duplicate_claim"]["existing"]["module_id"]
+            .as_str()
+            .unwrap(),
+        duplicate["duplicate_claim"]["duplicate"]["module_id"]
+            .as_str()
+            .unwrap(),
+    ];
+    assert!(duplicate_sites.contains(&"static/app::owners/card"));
+    assert!(duplicate_sites.contains(&"static/app::duplicates/card"));
+}
+
+fn find_entry<'a>(diagnostics: &'a [Value], category: &str, export_name: &str) -> &'a Value {
+    diagnostics
+        .iter()
+        .find(|entry| entry["category"] == category && entry["export_name"] == export_name)
+        .unwrap_or_else(|| {
+            panic!("missing {category} entry for export {export_name}: {diagnostics:#?}")
+        })
+}

--- a/devinfra/js/debundle/lowering/materialize/mod.rs
+++ b/devinfra/js/debundle/lowering/materialize/mod.rs
@@ -14,7 +14,9 @@ use super::util::{render_atomic_unit_cause_guidance, target_file_for_request};
 use super::*;
 use crate::time_phase;
 use js_ast::statement_ordinal_for_body_index;
-use output_layout::{ATOMIC_UNIT_CONFLICTS_REPORT, CYCLES_REPORT, OWNER_GRAPH_REPORT};
+use output_layout::{
+    ATOMIC_UNIT_CONFLICTS_REPORT, CYCLES_REPORT, OWNER_GRAPH_REPORT, SELECTOR_DIAGNOSTICS_REPORT,
+};
 
 /// Per-chunk inputs that identify the chunk and where its outputs
 /// should land. Bundled into `MaterializeLogicalChunkInputs::context`.
@@ -271,6 +273,18 @@ pub(super) fn materialize_logical_chunk(
     if matches!(chunk_unassigned_mode, UnassignedMode::MiniFactors) {
         time_phase!(timings, "synthesize_mini_factor_plans", {
             builder.synthesize_mini_factors(&precomputed, &runtime_ast.module.body, target_dir)
+        })?;
+    }
+    if let Some(report) = builder.selector_diagnostics_report(chunk_id)
+        && let Some(report_out_dir) = report_emission.rejection_dir()
+    {
+        time_phase!(timings, "write_selector_diagnostics_report", {
+            write_chunk_report_json(
+                report_out_dir,
+                chunk_id,
+                SELECTOR_DIAGNOSTICS_REPORT,
+                &report,
+            )
         })?;
     }
     // Plan construction is finished — consume the builder and use

--- a/devinfra/js/debundle/lowering/materialize/plan_builder.rs
+++ b/devinfra/js/debundle/lowering/materialize/plan_builder.rs
@@ -39,6 +39,67 @@ impl DuplicateBindingClaim {
     }
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct SelectorDiagnosticsReport {
+    pub chunk_id: String,
+    pub counts: BTreeMap<String, usize>,
+    pub diagnostics: Vec<SelectorDiagnosticEntry>,
+    pub coverage_notes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct SelectorDiagnosticEntry {
+    pub category: String,
+    pub module_id: String,
+    pub module_path: Option<String>,
+    pub export_name: Option<String>,
+    pub selector_kind: String,
+    pub target_binding: Option<String>,
+    pub claim_origin: Option<String>,
+    pub body_indices: Vec<usize>,
+    pub first_mismatch: Option<String>,
+    pub nearest_candidates: Vec<SelectorNearestCandidate>,
+    pub source_match_preview: Option<String>,
+    pub source_match_hash: Option<String>,
+    pub source_match_body_hash: Option<String>,
+    pub duplicate_claim: Option<DuplicateClaimReport>,
+    pub message: String,
+    pub recommended_next_action: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct SelectorNearestCandidate {
+    pub body_index: usize,
+    pub declared_bindings: Vec<String>,
+    pub score: usize,
+    pub first_mismatch: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct DuplicateClaimReport {
+    pub chunk_id: String,
+    pub binding: String,
+    pub existing: DuplicateClaimSiteReport,
+    pub duplicate: DuplicateClaimSiteReport,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct DuplicateClaimSiteReport {
+    pub module_id: String,
+    pub export_name: Option<String>,
+    pub claim_origin: Option<String>,
+}
+
+impl From<&DuplicateClaimSite> for DuplicateClaimSiteReport {
+    fn from(site: &DuplicateClaimSite) -> Self {
+        Self {
+            module_id: site.module_id.clone(),
+            export_name: site.export_name.clone(),
+            claim_origin: site.claim_origin.clone(),
+        }
+    }
+}
+
 fn render_duplicate_claim_site(site: &DuplicateClaimSite) -> String {
     let export = site
         .export_name
@@ -83,12 +144,48 @@ fn render_duplicate_binding_claims(duplicates: &[DuplicateBindingClaim]) -> Stri
 #[derive(Debug, Clone)]
 struct SourceMatchDiagnostic {
     module_id: String,
+    module_path: String,
     export_name: String,
     claim_origin: String,
+    selector: spec::AnonymousStatementSelector,
     message: String,
+    category: String,
+    body_indices: Vec<usize>,
+    first_mismatch: Option<String>,
+    nearest_candidates: Vec<SelectorNearestCandidate>,
 }
 
 impl SourceMatchDiagnostic {
+    fn new(
+        runtime_module: &Module,
+        module_id: &str,
+        module_path: &str,
+        member: &MemberRequest,
+        message: String,
+    ) -> Self {
+        let selector = member
+            .source_match
+            .clone()
+            .expect("source_match diagnostic requires unresolved selector");
+        let SourceMatchReportDetails {
+            body_indices,
+            first_mismatch,
+            nearest_candidates,
+        } = source_match_report_details(runtime_module, module_id, &selector, &message);
+        Self {
+            module_id: module_id.to_string(),
+            module_path: module_path.to_string(),
+            export_name: member.export_name.clone(),
+            claim_origin: member.claim_origin.clone(),
+            selector,
+            category: classify_source_match_failure(&message).to_string(),
+            body_indices,
+            first_mismatch,
+            nearest_candidates,
+            message,
+        }
+    }
+
     fn render(&self) -> String {
         format!(
             "module {} as `{}` ({}): {}",
@@ -122,6 +219,96 @@ fn render_source_match_diagnostics(diagnostics: &[SourceMatchDiagnostic]) -> Str
         report.push_str(&diagnostic.render());
     }
     report
+}
+
+struct SourceMatchReportDetails {
+    body_indices: Vec<usize>,
+    first_mismatch: Option<String>,
+    nearest_candidates: Vec<SelectorNearestCandidate>,
+}
+
+fn source_match_report_details(
+    runtime_module: &Module,
+    request_id: &str,
+    selector: &spec::AnonymousStatementSelector,
+    message: &str,
+) -> SourceMatchReportDetails {
+    match source_match::source_match_body_debt(runtime_module, request_id, selector, 1, 3) {
+        Ok(debt) => {
+            let body_indices = debt
+                .exact_groups
+                .iter()
+                .flat_map(|group| group.iter().flatten().copied())
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect::<Vec<_>>();
+            let nearest_candidates = debt
+                .near_misses
+                .into_iter()
+                .map(|candidate| SelectorNearestCandidate {
+                    body_index: candidate.body_idx,
+                    declared_bindings: candidate.declared_bindings,
+                    score: candidate.score,
+                    first_mismatch: candidate.reason,
+                })
+                .collect::<Vec<_>>();
+            let first_mismatch = nearest_candidates
+                .first()
+                .map(|candidate| candidate.first_mismatch.clone())
+                .or_else(|| first_relevant_error_line(message));
+            SourceMatchReportDetails {
+                body_indices,
+                first_mismatch,
+                nearest_candidates,
+            }
+        }
+        Err(error) => SourceMatchReportDetails {
+            body_indices: Vec::new(),
+            first_mismatch: Some(format!("failed to analyze nearest candidates: {error:#}")),
+            nearest_candidates: Vec::new(),
+        },
+    }
+}
+
+fn first_relevant_error_line(message: &str) -> Option<String> {
+    message
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .map(|line| line.trim().to_string())
+}
+
+fn classify_source_match_failure(message: &str) -> &'static str {
+    if message.contains("ambiguous") {
+        "ambiguous_selector"
+    } else if message.contains("did not match any") {
+        "unresolved_selector"
+    } else {
+        "selector_resolution_error"
+    }
+}
+
+fn recommended_source_match_action(category: &str) -> &'static str {
+    match category {
+        "ambiguous_selector" => {
+            "Refine the selector, add target_binding when selecting one binding from a matched declaration, or narrow the matched source context."
+        }
+        "unresolved_selector" => {
+            "Update the selector source to match the current chunk or inspect nearest_candidates before applying a mechanical rewrite."
+        }
+        _ => "Inspect the selector error and update the spec syntax or selector source.",
+    }
+}
+
+fn source_match_selector_kind(claim_origin: &str) -> &'static str {
+    if claim_origin.starts_with("binding_groups[]") {
+        "binding_groups.source_match"
+    } else {
+        "members.source_match"
+    }
+}
+
+fn module_path_from_id(module_id: &str) -> Option<String> {
+    module_id.split_once("::").map(|(_, path)| path.to_string())
 }
 
 fn render_anonymous_statement_diagnostics(diagnostics: &[AnonymousStatementDiagnostic]) -> String {
@@ -249,14 +436,17 @@ fn resolve_request_source_matches(
                     Ok(resolved) => resolved,
                     Err(error) if keep_going => {
                         let message = format!("{error:#}");
+                        let module_id = request.id.clone();
+                        let module_path = request.target_path.clone();
                         for idx in member_indices {
                             let member = &request.members[idx];
-                            diagnostics.push(SourceMatchDiagnostic {
-                                module_id: request.id.clone(),
-                                export_name: member.export_name.clone(),
-                                claim_origin: member.claim_origin.clone(),
-                                message: message.clone(),
-                            });
+                            diagnostics.push(SourceMatchDiagnostic::new(
+                                runtime_module,
+                                &module_id,
+                                &module_path,
+                                member,
+                                message.clone(),
+                            ));
                         }
                         continue;
                     }
@@ -281,6 +471,8 @@ fn resolve_request_source_matches(
         }
     }
 
+    let module_id = request.id.clone();
+    let module_path = request.target_path.clone();
     for (idx, member) in request.members.iter_mut().enumerate() {
         if resolved_member_indices.contains(&idx) {
             continue;
@@ -291,12 +483,13 @@ fn resolve_request_source_matches(
             if !keep_going {
                 return Err(error);
             }
-            diagnostics.push(SourceMatchDiagnostic {
-                module_id: request.id.clone(),
-                export_name: member.export_name.clone(),
-                claim_origin: member.claim_origin.clone(),
-                message: format!("{error:#}"),
-            });
+            diagnostics.push(SourceMatchDiagnostic::new(
+                runtime_module,
+                &module_id,
+                &module_path,
+                member,
+                format!("{error:#}"),
+            ));
         }
     }
     if keep_going {
@@ -1010,6 +1203,92 @@ impl ChunkPlanBuilder {
     /// existing claims count as "swept" (and hence still foldable).
     pub(super) fn residual_plan_index(&self) -> Option<usize> {
         self.residual_plan_index
+    }
+
+    pub(super) fn selector_diagnostics_report(
+        &self,
+        chunk_id: &str,
+    ) -> Option<SelectorDiagnosticsReport> {
+        let mut diagnostics = Vec::new();
+        for diagnostic in &self.source_match_diagnostics {
+            diagnostics.push(SelectorDiagnosticEntry {
+                category: diagnostic.category.clone(),
+                module_id: diagnostic.module_id.clone(),
+                module_path: Some(diagnostic.module_path.clone()),
+                export_name: Some(diagnostic.export_name.clone()),
+                selector_kind: source_match_selector_kind(&diagnostic.claim_origin).to_string(),
+                target_binding: diagnostic.selector.target_binding.clone(),
+                claim_origin: Some(diagnostic.claim_origin.clone()),
+                body_indices: diagnostic.body_indices.clone(),
+                first_mismatch: diagnostic.first_mismatch.clone(),
+                nearest_candidates: diagnostic.nearest_candidates.clone(),
+                source_match_preview: Some(source_match::source_match_preview(
+                    &diagnostic.selector.match_source,
+                )),
+                source_match_hash: Some(source_match::selector_key(&diagnostic.selector)),
+                source_match_body_hash: Some(source_match::selector_body_key(&diagnostic.selector)),
+                duplicate_claim: None,
+                message: diagnostic.message.clone(),
+                recommended_next_action: recommended_source_match_action(&diagnostic.category)
+                    .to_string(),
+            });
+        }
+        for duplicate in &self.duplicate_binding_claims {
+            diagnostics.push(SelectorDiagnosticEntry {
+                category: "duplicate_claim".to_string(),
+                module_id: duplicate.duplicate.module_id.clone(),
+                module_path: module_path_from_id(&duplicate.duplicate.module_id),
+                export_name: duplicate.duplicate.export_name.clone(),
+                selector_kind: "duplicate_claim".to_string(),
+                target_binding: None,
+                claim_origin: duplicate.duplicate.claim_origin.clone(),
+                body_indices: Vec::new(),
+                first_mismatch: None,
+                nearest_candidates: Vec::new(),
+                source_match_preview: None,
+                source_match_hash: None,
+                source_match_body_hash: None,
+                duplicate_claim: Some(DuplicateClaimReport {
+                    chunk_id: duplicate.chunk_id.clone(),
+                    binding: duplicate.binding.clone(),
+                    existing: DuplicateClaimSiteReport::from(&duplicate.existing),
+                    duplicate: DuplicateClaimSiteReport::from(&duplicate.duplicate),
+                }),
+                message: duplicate.render(),
+                recommended_next_action: "Move duplicate claims into one logical module, remove the duplicate member, or expose aliases from the same module."
+                    .to_string(),
+            });
+        }
+        if diagnostics.is_empty() {
+            return None;
+        }
+        diagnostics.sort_by(|a, b| {
+            (
+                a.category.as_str(),
+                a.module_id.as_str(),
+                a.export_name.as_deref().unwrap_or_default(),
+                a.selector_kind.as_str(),
+            )
+                .cmp(&(
+                    b.category.as_str(),
+                    b.module_id.as_str(),
+                    b.export_name.as_deref().unwrap_or_default(),
+                    b.selector_kind.as_str(),
+                ))
+        });
+        let mut counts = BTreeMap::new();
+        for diagnostic in &diagnostics {
+            *counts.entry(diagnostic.category.clone()).or_insert(0) += 1;
+        }
+        Some(SelectorDiagnosticsReport {
+            chunk_id: chunk_id.to_string(),
+            counts,
+            diagnostics,
+            coverage_notes: vec![
+                "TODO: anonymous_statement source_match failures and blocker-comment diagnostics still need normalized JSON entries."
+                    .to_string(),
+            ],
+        })
     }
 
     pub(super) fn finalize(self) -> Result<ChunkPlan> {

--- a/devinfra/js/debundle/output_layout.rs
+++ b/devinfra/js/debundle/output_layout.rs
@@ -17,6 +17,7 @@ pub const MODULES_REPORT: &str = "modules.json";
 pub const OWNER_GRAPH_REPORT: &str = "owner_graph.json";
 pub const CYCLES_REPORT: &str = "cycles.json";
 pub const ATOMIC_UNIT_CONFLICTS_REPORT: &str = "atomic_unit_conflicts.json";
+pub const SELECTOR_DIAGNOSTICS_REPORT: &str = "selector_diagnostics.json";
 pub const INDEX_REPORT: &str = "index.json";
 
 #[derive(Debug, Clone)]

--- a/devinfra/js/debundle/source_match.rs
+++ b/devinfra/js/debundle/source_match.rs
@@ -125,7 +125,7 @@ fn first_error_line(error: &anyhow::Error) -> String {
     truncate_for_log(&line, 160)
 }
 
-fn source_match_preview(source: &str) -> String {
+pub fn source_match_preview(source: &str) -> String {
     let collapsed = source.split_whitespace().collect::<Vec<_>>().join(" ");
     truncate_for_log(&collapsed, 180)
 }
@@ -135,8 +135,8 @@ fn source_match_timing_selector_details(
     config: &SourceMatchTimingConfig,
 ) -> String {
     let mut fields = vec![
-        format!("selector_key={}", selector_timing_key(selector)),
-        format!("body_key={}", selector_body_timing_key(selector)),
+        format!("selector_key={}", selector_key(selector)),
+        format!("body_key={}", selector_body_key(selector)),
     ];
     if let Some(target_binding) = selector.target_binding.as_deref() {
         fields.push(format!("target_binding=`{target_binding}`"));
@@ -156,7 +156,7 @@ fn source_match_timing_selector_details(
     fields.join(" ")
 }
 
-fn selector_body_timing_key(selector: &AnonymousStatementSelector) -> String {
+pub fn selector_body_key(selector: &AnonymousStatementSelector) -> String {
     let mut state = Fnv1a64::new();
     state.update(b"body");
     state.update(format!("{:?}", selector.identifiers).as_bytes());
@@ -165,7 +165,7 @@ fn selector_body_timing_key(selector: &AnonymousStatementSelector) -> String {
     format!("{:016x}", state.finish())
 }
 
-fn selector_timing_key(selector: &AnonymousStatementSelector) -> String {
+pub fn selector_key(selector: &AnonymousStatementSelector) -> String {
     let mut state = Fnv1a64::new();
     state.update(b"selector");
     state.update(format!("{:?}", selector.identifiers).as_bytes());


### PR DESCRIPTION
## Summary

- Add `reports/tree/<chunk>/selector_diagnostics.json` for keep-going selector failures.
- Include machine-readable entries for member-form `source_match` unresolved/ambiguous failures and duplicate binding claims.
- Preserve the existing human stderr diagnostics and add a focused black-box e2e fixture.

## Notes

The report currently includes a `coverage_notes` TODO for anonymous statement selector failures and blocker-comment diagnostics. Those remain in human diagnostics but are not yet normalized into this JSON schema.

## Validation

- `git diff --check origin/devel...HEAD`
- `nix develop -c pre-commit run --files devinfra/js/debundle/e2e/BUILD.bazel devinfra/js/debundle/e2e/selector_diagnostics_report_test.rs devinfra/js/debundle/lowering/materialize/mod.rs devinfra/js/debundle/lowering/materialize/plan_builder.rs devinfra/js/debundle/output_layout.rs devinfra/js/debundle/source_match.rs`
- `nix develop -c bazelisk test //devinfra/js/debundle/e2e:selector_diagnostics_report_test //devinfra/js/debundle/e2e:cross_module_emission_test //devinfra/js/debundle/e2e:anonymous_statement_test`

BuildBuddy invocation: https://app.buildbuddy.io/invocation/757078bf-2b8e-411a-b44f-281b9cbe9456