### PR TITLE
[codex] Default debundle run to keep-going

### DIFF
--- a/devinfra/js/debundle/cli/mod.rs
+++ b/devinfra/js/debundle/cli/mod.rs
@@ -491,7 +491,7 @@ pub fn run_debundle_cli(args: DebundleArgs) -> Result<()> {
     match args.command {
         DebundleCommand::Run(args) => {
             let dry_run = args.dry_run;
-            let keep_going = args.keep_going;
+            let keep_going = !args.fail_fast;
             let cli = args.resolve()?;
             run_transform_cli_with_options(
                 &cli,
@@ -1284,14 +1284,13 @@ mod tests {
                 "--spec",
                 "spec.yaml",
                 "--dry-run",
-                "--keep-going",
                 "--package-root",
                 "pkg=/tmp/pkg",
                 "--packages-root",
                 "/tmp/packages",
             ]);
             assert!(args.dry_run);
-            assert!(args.keep_going);
+            assert!(!args.fail_fast);
             let cli = args.resolve().expect("resolve cli");
             assert_eq!(
                 cli.spec_source,
@@ -1304,6 +1303,15 @@ mod tests {
                 Some(&PathBuf::from("/tmp/pkg"))
             );
             assert_eq!(cli.packages_root, Some(PathBuf::from("/tmp/packages")));
+        });
+    }
+
+    #[test]
+    fn parse_run_args_accepts_fail_fast_opt_out() {
+        js_ast::with_swc_globals(|| {
+            let args = parsed_run_args(&["debundle", "run", "--spec", "spec.yaml", "--fail-fast"]);
+            assert!(args.fail_fast);
+            assert!(!args.keep_going);
         });
     }
 

--- a/devinfra/js/debundle/docs/cli.md
+++ b/devinfra/js/debundle/docs/cli.md
@@ -39,10 +39,12 @@ checks and skips emitted-JS and accept-path report writes. A gate
 rejection still writes `owner_graph.json` plus the rejection evidence
 (`cycles.json` / `atomic_unit_conflicts.json`) under
 `reports/tree/<chunk>/`, so `gate list` / `gate describe` work on the
-rejection that was just reported. Add `--keep-going` to collect all
-supported diagnostics from a pass instead of stopping at the first one;
-currently this aggregates duplicate binding claims with module/export/origin
-evidence. There is no `debundle run --no-verify`.
+rejection that was just reported. Broad runs collect all supported diagnostics
+from a pass instead of stopping at the first one; currently this aggregates
+unresolved source-match selectors and duplicate binding claims with
+module/export/origin evidence. Use `--fail-fast` only when debugging the first
+failing selector or claim is more useful than the full diagnostic set. There is
+no `debundle run --no-verify`.
 
 Read-only commands (queries, listings, source slicing) take
 neither flag — they have no side effects.
@@ -69,9 +71,9 @@ with a list. Use the minified form to disambiguate.
 
 ### Pipeline
 
-| Command        | Mutates?                 | Function                                                                                                                                                                                                                                                                   |
-| -------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `debundle run` | yes (emits JS + reports) | Run the full transform pipeline: parse + facts + owner_graph + atomic_units + realizability gate + lower + emit. `--dry-run` runs pipeline checks without writing emitted JS or reports. `--keep-going` aggregates supported diagnostics such as duplicate binding claims. |
+| Command        | Mutates?                 | Function                                                                                                                                                                                                                                                                                                      |
+| -------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `debundle run` | yes (emits JS + reports) | Run the full transform pipeline: parse + facts + owner_graph + atomic_units + realizability gate + lower + emit. `--dry-run` runs pipeline checks without writing emitted JS or reports. Broad runs aggregate supported diagnostics by default; pass `--fail-fast` to stop at the first supported diagnostic. |
 
 ### Bindings
 

--- a/devinfra/js/debundle/docs/guide.md
+++ b/devinfra/js/debundle/docs/guide.md
@@ -75,11 +75,12 @@ spec first.
 Use `debundle run --dry-run` to run pipeline parse/facts/gate checks
 without writing emitted JS or reports.
 
-Add `--keep-going` during broad spec migrations to continue through supported
-diagnostic failures and report all findings from that pass. Today this
-aggregates duplicate binding claims during materialization plan building,
-including the chunk, binding, existing owner/export/origin, and competing
-owner/export/origin.
+Broad spec migrations continue through supported diagnostic failures by
+default and report all findings from that pass. Today this aggregates
+unresolved source-match selectors and duplicate binding claims during
+materialization plan building, including the chunk, binding, existing
+owner/export/origin, and competing owner/export/origin. Use `--fail-fast` only
+when the first failing selector or claim is the useful debugging target.
 
 ## Workflow: investigating a binding end-to-end
 

--- a/devinfra/js/debundle/e2e/cross_module_emission_test.rs
+++ b/devinfra/js/debundle/e2e/cross_module_emission_test.rs
@@ -571,15 +571,14 @@ export { existingHelper };
     );
 }
 
-#[test]
-fn keep_going_reports_source_match_failures_and_duplicate_claims_together() {
+fn source_match_and_duplicate_claims_fixture() -> FixtureOpts<'static> {
     let missing_selector = r#"function selectedFormatter(value) {
   return value.toLowerCase();
 }"#;
     let ambiguous_selector = r#"function repeatedHelper() {
   return "shared";
 }"#;
-    let opts = FixtureOpts::new(
+    FixtureOpts::new(
         r#"function renderCard(value) {
   return value.trim();
 }
@@ -607,9 +606,12 @@ export { renderCard, decoratePrimary, decorateSecondary };
                 &[Member::source_alpha("AmbiguousHelper", ambiguous_selector)],
             ),
         ],
-    );
+    )
+}
 
-    let rejected = run_keep_going_dry_run_rejection_fixture(opts);
+#[test]
+fn dry_run_defaults_to_collecting_source_match_failures_and_duplicate_claims_together() {
+    let rejected = run_dry_run_rejection_fixture(source_match_and_duplicate_claims_fixture());
     let stderr = rejected.stderr;
     for required in [
         "Source-match selector diagnostic report: 2 unresolved selector(s) found",
@@ -630,6 +632,35 @@ export { renderCard, decoratePrimary, decorateSecondary };
         assert!(
             stderr.contains(required),
             "stderr missing {required:?}\nstderr:\n{stderr}",
+        );
+    }
+}
+
+#[test]
+fn fail_fast_dry_run_stops_before_later_duplicate_claim_diagnostics() {
+    let rejected =
+        run_fail_fast_dry_run_rejection_fixture(source_match_and_duplicate_claims_fixture());
+    let stderr = rejected.stderr;
+    for required in [
+        "members[].selector.source_match",
+        "diagnostics/ambiguous",
+        "export `AmbiguousHelper`",
+        "is ambiguous",
+    ] {
+        assert!(
+            stderr.contains(required),
+            "stderr missing {required:?}\nstderr:\n{stderr}",
+        );
+    }
+    for absent in [
+        "Source-match selector diagnostic report:",
+        "Duplicate binding claim report:",
+        "duplicates/card",
+        "as `renderCardAgain`",
+    ] {
+        assert!(
+            !stderr.contains(absent),
+            "fail-fast stderr unexpectedly contained {absent:?}\nstderr:\n{stderr}",
         );
     }
 }

--- a/devinfra/js/debundle/e2e/support.rs
+++ b/devinfra/js/debundle/e2e/support.rs
@@ -942,8 +942,14 @@ pub fn run_dry_run_rejection_fixture(opts: FixtureOpts<'_>) -> RejectedFixture {
     run_rejection_fixture_with_args(opts, &["--dry-run"])
 }
 
-/// Like [`run_dry_run_rejection_fixture`] but asks the pipeline to continue
-/// through supported diagnostics and report all findings from the pass.
+/// Like [`run_dry_run_rejection_fixture`] but opts out of the default
+/// keep-going diagnostics and stops at the first supported failure.
+pub fn run_fail_fast_dry_run_rejection_fixture(opts: FixtureOpts<'_>) -> RejectedFixture {
+    run_rejection_fixture_with_args(opts, &["--dry-run", "--fail-fast"])
+}
+
+/// Compatibility spelling for tests that need to document the old explicit
+/// flag; keep-going is now the default for broad pipeline runs.
 pub fn run_keep_going_dry_run_rejection_fixture(opts: FixtureOpts<'_>) -> RejectedFixture {
     run_rejection_fixture_with_args(opts, &["--dry-run", "--keep-going"])
 }

--- a/devinfra/js/debundle/pipeline.bzl
+++ b/devinfra/js/debundle/pipeline.bzl
@@ -53,6 +53,8 @@ def _debundle_pipeline_plan(ctx, out_root):
 
     # Each entry is a fully-rendered shell token (already quoted/escaped).
     argv = ["run"]
+    if ctx.attr.fail_fast:
+        argv.append("--fail-fast")
     if has_flat:
         argv += ["--spec", _shell_source_path(ctx.file.spec.path)]
     else:
@@ -140,6 +142,10 @@ _DEBUNDLE_PIPELINE_ATTRS = {
     "package_roots": attr.label_keyed_string_dict(
         allow_files = True,
         doc = "Vendor package roots: label of the package's `:dir` filegroup -> package name. The first file's dirname is passed as `--package-root <name>=<dir>`.",
+    ),
+    "fail_fast": attr.bool(
+        default = False,
+        doc = "Pass --fail-fast to debundle run for debugging; by default broad pipeline runs aggregate supported diagnostics.",
     ),
 }
 

--- a/devinfra/js/debundle/pipeline.rs
+++ b/devinfra/js/debundle/pipeline.rs
@@ -33,10 +33,19 @@ pub struct TransformCli {
     pub packages_root: Option<PathBuf>,
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TransformRunOptions {
     pub dry_run: bool,
     pub keep_going: bool,
+}
+
+impl Default for TransformRunOptions {
+    fn default() -> Self {
+        Self {
+            dry_run: false,
+            keep_going: true,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -77,11 +86,14 @@ pub struct TransformArgs {
     /// Run pipeline checks without writing emitted JS or reports.
     #[arg(long)]
     pub dry_run: bool,
-    /// Continue through supported spec-diagnostic failures and report all
-    /// findings from the pass. Currently aggregates materialization duplicate
-    /// binding claims plus member-form source_match misses and ambiguities.
+    /// Deprecated compatibility no-op: keep-going is now the default.
+    /// Use `--fail-fast` to stop at the first supported diagnostic instead.
     #[arg(long)]
     pub keep_going: bool,
+    /// Stop at the first supported diagnostic instead of collecting all
+    /// findings from the pass.
+    #[arg(long, conflicts_with = "keep_going")]
+    pub fail_fast: bool,
 }
 
 impl TransformArgs {


### PR DESCRIPTION
## Summary
- make `debundle run` use keep-going diagnostics by default
- add explicit `--fail-fast` opt-out while keeping `--keep-going` accepted as a compatibility no-op
- add `fail_fast` attr to `debundle_pipeline` so Bazel users can request the old debugging behavior
- update docs/guide wording and e2e coverage for default aggregation versus fail-fast

## Validation
- `nix develop -c bazelisk test //devinfra/js/debundle:cli_test //devinfra/js/debundle:pipeline_test //devinfra/js/debundle/e2e:cross_module_emission_test`
  - first post-rebase attempt hit transient GitHub 502 while downloading `uv` metadata before targets ran; retry passed
- `nix develop -c pre-commit run --files devinfra/js/debundle/cli/mod.rs devinfra/js/debundle/docs/cli.md devinfra/js/debundle/docs/guide.md devinfra/js/debundle/e2e/cross_module_emission_test.rs devinfra/js/debundle/e2e/support.rs devinfra/js/debundle/pipeline.bzl devinfra/js/debundle/pipeline.rs`
- `git diff --check -- devinfra/js/debundle/cli/mod.rs devinfra/js/debundle/docs/cli.md devinfra/js/debundle/docs/guide.md devinfra/js/debundle/e2e/cross_module_emission_test.rs devinfra/js/debundle/e2e/support.rs devinfra/js/debundle/pipeline.bzl devinfra/js/debundle/pipeline.rs`