### PR TITLE
[codex] Add selector capability diagnostics

### DIFF
--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -37,10 +37,6 @@ old-spec selector-debt migration no longer needs special coordination.
    and blocker comments. Include module path, export name, selector kind,
    target binding, first mismatch, nearest candidates, and recommended next
    action. This lets coordinators batch failures instead of scraping logs.
-5. **Capability/version diagnostics for selector syntax.** Specs should fail
-   early when the pinned debundler lacks a selector feature they use. Unknown
-   hole names and unsupported selector fields should produce explicit
-   "unsupported selector capability" diagnostics, not generic no-match reports.
 
 ### P1 — improves agent throughput and reviewability
 

--- a/devinfra/js/debundle/docs/guide.md
+++ b/devinfra/js/debundle/docs/guide.md
@@ -606,6 +606,10 @@ matches both `foo(123)` and `foo(456)`, and `bar(EXPR, EXPR)` matches
 matches a call whose two arguments are identical. These are still structural
 selectors: surrounding syntax is exact after the identifier policy is applied,
 and ambiguous matches are rejected rather than resolved by source order.
+Reserved future selector spellings fail before matching with an explicit
+`unsupported selector capability` diagnostic. For example, `ANYTHING_FUTURE`
+is rejected early instead of falling through to a generic no-match report.
+Unknown `source_match` fields use the same diagnostic class.
 
 `ANYTHING` is universal anonymous sugar for positions where raw JavaScript can
 parse a plain identifier and the matcher already has a typed hole for that AST

--- a/devinfra/js/debundle/e2e/syntactic_holes_test.rs
+++ b/devinfra/js/debundle/e2e/syntactic_holes_test.rs
@@ -2137,3 +2137,70 @@ export { total };
         &["EXPR"],
     );
 }
+
+#[test]
+fn unsupported_reserved_hole_names_fail_before_generic_no_match() {
+    let universal = run_dry_run_rejection_fixture(FixtureOpts::new(
+        r#"const actual = computeTotal(1, 2);
+console.log(actual);
+export { actual };
+"#,
+        vec![logical_module(
+            "calc",
+            &[Member::source_alpha(
+                "total",
+                r#"const readable = ANYTHING_FUTURE;"#,
+            )],
+        )],
+    ));
+    assert!(
+        universal.stderr.contains("unsupported selector capability"),
+        "stderr:\n{}",
+        universal.stderr
+    );
+    assert!(
+        universal.stderr.contains("ANYTHING_FUTURE"),
+        "stderr:\n{}",
+        universal.stderr
+    );
+    assert!(
+        !universal
+            .stderr
+            .contains("did not match any top-level declaration"),
+        "stderr:\n{}",
+        universal.stderr
+    );
+
+    let object_gap = run_dry_run_rejection_fixture(FixtureOpts::new(
+        r#"const actual = { stable: 1, generated: 2, other: 3 };
+console.log(actual.stable + actual.other);
+export { actual };
+"#,
+        vec![logical_module(
+            "objects",
+            &[Member::source_alpha(
+                "selected",
+                r#"const readable = { stable: EXPR, ANYTHING_FUTURE, other: EXPR };"#,
+            )],
+        )],
+    ));
+    assert!(
+        object_gap
+            .stderr
+            .contains("unsupported selector capability"),
+        "stderr:\n{}",
+        object_gap.stderr
+    );
+    assert!(
+        object_gap.stderr.contains("ANYTHING_FUTURE"),
+        "stderr:\n{}",
+        object_gap.stderr
+    );
+    assert!(
+        !object_gap
+            .stderr
+            .contains("did not match any top-level declaration"),
+        "stderr:\n{}",
+        object_gap.stderr
+    );
+}

--- a/devinfra/js/debundle/source_match.rs
+++ b/devinfra/js/debundle/source_match.rs
@@ -274,6 +274,75 @@ fn first_error_line(error: &anyhow::Error) -> String {
     truncate_for_log(&line, 160)
 }
 
+fn parse_selector_module_with_capability_check(
+    request_id: &str,
+    selector_kind: &str,
+    file_label: String,
+    match_source: &str,
+    parse_error_context: impl FnOnce() -> String,
+) -> Result<Module> {
+    let parsed =
+        js_ast::parse_js_module_ast(&file_label, match_source).with_context(parse_error_context)?;
+    validate_anything_holes(&parsed.body)?;
+    validate_selector_capabilities(request_id, selector_kind, match_source, &parsed)?;
+    Ok(parsed)
+}
+
+fn validate_selector_capabilities(
+    request_id: &str,
+    selector_kind: &str,
+    match_source: &str,
+    parsed: &Module,
+) -> Result<()> {
+    let mut collector = UnsupportedSelectorCapabilityCollector::default();
+    parsed.visit_with(&mut collector);
+    if collector.unsupported_holes.is_empty() {
+        return Ok(());
+    }
+
+    let holes = collector
+        .unsupported_holes
+        .iter()
+        .map(|hole| format!("`{hole}`"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    bail!(
+        "logical_module {request_id}: unsupported selector capability in {selector_kind}: \
+         hole name(s) {holes} are not supported by this debundler; upgrade the debundler or \
+         rewrite the selector with supported holes. Selector:\n{match_source}"
+    );
+}
+
+#[derive(Default)]
+struct UnsupportedSelectorCapabilityCollector {
+    unsupported_holes: BTreeSet<String>,
+}
+
+impl UnsupportedSelectorCapabilityCollector {
+    fn record_identifier(&mut self, name: &str) {
+        if unsupported_selector_hole_name(name).is_some() {
+            self.unsupported_holes.insert(name.to_string());
+        }
+    }
+}
+
+impl Visit for UnsupportedSelectorCapabilityCollector {
+    fn visit_ident(&mut self, ident: &Ident) {
+        self.record_identifier(ident.sym.as_ref());
+    }
+
+    fn visit_binding_ident(&mut self, ident: &BindingIdent) {
+        self.record_identifier(ident.id.sym.as_ref());
+    }
+
+    fn visit_prop_name(&mut self, name: &PropName) {
+        if let PropName::Ident(ident) = name {
+            self.record_identifier(ident.sym.as_ref());
+        }
+        name.visit_children_with(self);
+    }
+}
+
 pub fn source_match_preview(source: &str) -> String {
     let collapsed = source.split_whitespace().collect::<Vec<_>>().join(" ");
     truncate_for_log(&collapsed, 180)
@@ -455,16 +524,18 @@ pub fn source_match_declared_binding_names(
     request_id: &str,
     source_match: &SourceMatch,
 ) -> Result<Vec<String>> {
-    let parsed = parse_source_match_module_ast(
-        &format!("<binding group source_match in {request_id}>"),
+    let parsed = parse_selector_module_with_capability_check(
+        request_id,
+        "binding_groups[].source_match",
+        format!("<binding group source_match in {request_id}>"),
         &source_match.match_source,
-    )
-    .with_context(|| {
-        format!(
-            "logical_module {request_id}: binding_groups[].source_match did not parse as JS:\n{}",
-            source_match.match_source
-        )
-    })?;
+        || {
+            format!(
+                "logical_module {request_id}: binding_groups[].source_match did not parse as JS:\n{}",
+                source_match.match_source
+            )
+        },
+    )?;
     Ok(parsed
         .body
         .iter()
@@ -705,16 +776,18 @@ pub fn find_anonymous_statement_body_index_groups(
         request_id,
         selector,
         || {
-            let parsed = parse_source_match_module_ast(
-                &format!("<anonymous_statement match in {request_id}>"),
+            let parsed = parse_selector_module_with_capability_check(
+                request_id,
+                "anonymous_statements[].source_match",
+                format!("<anonymous_statement match in {request_id}>"),
                 &selector.match_source,
-            )
-            .with_context(|| {
-                format!(
-                    "logical_module {request_id}: anonymous_statements[].match did not parse as JS:\n{}",
-                    selector.match_source
-                )
-            })?;
+                || {
+                    format!(
+                        "logical_module {request_id}: anonymous_statements[].match did not parse as JS:\n{}",
+                        selector.match_source
+                    )
+                },
+            )?;
             let target_indices =
                 anonymous_selector_target_statement_indices(request_id, selector, &parsed.body)?;
             let mut groups = Vec::new();
@@ -762,16 +835,18 @@ pub fn source_match_body_debt(
     min_score: usize,
     limit: usize,
 ) -> Result<SourceMatchBodyDebt> {
-    let parsed = parse_source_match_module_ast(
-        &format!("<source_match debt in {request_id}>"),
+    let parsed = parse_selector_module_with_capability_check(
+        request_id,
+        "source_match",
+        format!("<source_match debt in {request_id}>"),
         &selector.match_source,
-    )
-    .with_context(|| {
-        format!(
-            "logical_module {request_id}: source_match did not parse as JS:\n{}",
-            selector.match_source
-        )
-    })?;
+        || {
+            format!(
+                "logical_module {request_id}: source_match did not parse as JS:\n{}",
+                selector.match_source
+            )
+        },
+    )?;
     let exact_groups = find_matching_body_group_alignments(runtime_module, &parsed.body, selector);
     let [needle] = parsed.body.as_slice() else {
         return Ok(SourceMatchBodyDebt {
@@ -935,16 +1010,18 @@ fn resolve_member_binding_group_impl(
              target_binding already set"
         );
     }
-    let parsed = parse_source_match_module_ast(
-        &format!("<binding group source_match in {request_id}>"),
+    let parsed = parse_selector_module_with_capability_check(
+        request_id,
+        "binding_groups[].source_match",
+        format!("<binding group source_match in {request_id}>"),
         &selector.match_source,
-    )
-    .with_context(|| {
-        format!(
-            "logical_module {request_id}: binding_groups[].source_match did not parse as JS:\n{}",
-            selector.match_source
-        )
-    })?;
+        || {
+            format!(
+                "logical_module {request_id}: binding_groups[].source_match did not parse as JS:\n{}",
+                selector.match_source
+            )
+        },
+    )?;
     if parsed.body.is_empty() {
         bail!(
             "logical_module {request_id}: binding_groups[].source_match parsed to zero \
@@ -1083,16 +1160,18 @@ fn find_member_binding_matches(
     request_id: &str,
     selector: &AnonymousStatementSelector,
 ) -> Result<Vec<MemberBindingMatch>> {
-    let parsed = parse_source_match_module_ast(
-        &format!("<member source_match in {request_id}>"),
+    let parsed = parse_selector_module_with_capability_check(
+        request_id,
+        "members[].selector.source_match",
+        format!("<member source_match in {request_id}>"),
         &selector.match_source,
-    )
-    .with_context(|| {
-        format!(
-            "logical_module {request_id}: members[].selector.source_match did not parse as JS:\n{}",
-            selector.match_source
-        )
-    })?;
+        || {
+            format!(
+                "logical_module {request_id}: members[].selector.source_match did not parse as JS:\n{}",
+                selector.match_source
+            )
+        },
+    )?;
     if let Some(target_binding) = &selector.target_binding {
         if parsed.body.is_empty() {
             bail!(
@@ -6077,6 +6156,11 @@ fn hole_name_for<'a>(name: &'a str, keyword: &str) -> Option<&'a str> {
 
 fn anything_hole_name(name: &str) -> Option<&str> {
     (name == ANYTHING_HOLE_KEYWORD).then_some(name)
+}
+
+fn unsupported_selector_hole_name(name: &str) -> Option<&str> {
+    let rest = name.strip_prefix(ANYTHING_HOLE_KEYWORD)?;
+    rest.starts_with('_').then_some(name)
 }
 
 /// Whether a hole name is the anonymous form: the bare keyword, or the

--- a/devinfra/js/debundle/spec.rs
+++ b/devinfra/js/debundle/spec.rs
@@ -826,8 +826,7 @@ impl fmt::Display for AnonymousStatementSelectorError {
 
 impl std::error::Error for AnonymousStatementSelectorError {}
 
-#[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq, Ord, PartialOrd)]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, Clone, Serialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct SourceMatch {
     #[serde(
         default,
@@ -862,6 +861,53 @@ pub struct SourceMatch {
     pub wildcard_string_literals: BTreeSet<String>,
     #[serde(rename = "match")]
     pub match_source: String,
+}
+
+#[derive(Deserialize)]
+struct SourceMatchWire {
+    #[serde(default)]
+    identifiers: SourceMatchIdentifierMode,
+    #[serde(default)]
+    target_binding: Option<String>,
+    #[serde(default)]
+    target_statement: Option<usize>,
+    #[serde(default)]
+    target_statements: Option<TargetStatements>,
+    #[serde(default)]
+    wildcard_string_literals: BTreeSet<String>,
+    #[serde(rename = "match")]
+    match_source: String,
+    #[serde(flatten)]
+    unsupported_fields: BTreeMap<String, serde::de::IgnoredAny>,
+}
+
+impl<'de> Deserialize<'de> for SourceMatch {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let wire = SourceMatchWire::deserialize(deserializer)?;
+        if !wire.unsupported_fields.is_empty() {
+            let fields = wire
+                .unsupported_fields
+                .keys()
+                .map(|field| format!("`{field}`"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Err(serde::de::Error::custom(format!(
+                "unsupported selector capability: source_match field(s) {fields} are not \
+                 supported by this debundler; upgrade the debundler or remove the field(s)"
+            )));
+        }
+        Ok(Self {
+            identifiers: wire.identifiers,
+            target_binding: wire.target_binding,
+            target_statement: wire.target_statement,
+            target_statements: wire.target_statements,
+            wildcard_string_literals: wire.wildcard_string_literals,
+            match_source: wire.match_source,
+        })
+    }
 }
 
 impl SourceMatch {
@@ -1259,6 +1305,27 @@ mod tests {
         assert!(
             !serialized.contains("admission_overrides"),
             "default overrides must not serialize: {serialized}"
+        );
+    }
+
+    #[test]
+    fn source_match_unknown_field_reports_unsupported_selector_capability() {
+        let error: serde_json::Error = serde_json::from_str::<SourceMatch>(
+            r#"{
+              "identifiers": "alpha_all",
+              "match": "const readable = 1;",
+              "object_props": true
+            }"#,
+        )
+        .unwrap_err();
+        let message = error.to_string();
+        assert!(
+            message.contains("unsupported selector capability"),
+            "unexpected error: {message}"
+        );
+        assert!(
+            message.contains("object_props"),
+            "unexpected error: {message}"
         );
     }
 }


### PR DESCRIPTION
## Summary

- fail `source_match` specs with unknown selector fields using an explicit `unsupported selector capability` diagnostic
- reject reserved unsupported universal-hole spellings such as `ANYTHING_FUTURE` immediately after selector JS parses, before generic no-match diagnostics
- preserve the merged #2229 `ANYTHING` / `OBJECT_PROPS` support while keeping targeted diagnostics for unsupported `ANYTHING` positions
- document the early capability diagnostic behavior and remove the completed P0 TODO queue item

## Validation

- `nix develop -c rustfmt devinfra/js/debundle/spec.rs devinfra/js/debundle/source_match.rs devinfra/js/debundle/e2e/syntactic_holes_test.rs`
- `nix develop -c bazelisk test //devinfra/js/debundle:spec_test //devinfra/js/debundle:source_match_test //devinfra/js/debundle/e2e:syntactic_holes_test`
- `nix develop -c pre-commit run --files devinfra/js/debundle/TODO.md devinfra/js/debundle/docs/guide.md devinfra/js/debundle/e2e/syntactic_holes_test.rs devinfra/js/debundle/source_match.rs devinfra/js/debundle/spec.rs`

BuildBuddy: https://app.buildbuddy.io/invocation/d7126570-38f3-4150-bdbc-10b45714c4f0