### PR TITLE
[codex] Fix target-binding declarator holes

### DIFF
--- a/devinfra/js/debundle/e2e/support.rs
+++ b/devinfra/js/debundle/e2e/support.rs
@@ -202,6 +202,28 @@ impl Member {
         }
     }
 
+    /// Extract one binding from a matched declaration in exact identifier mode
+    /// by naming that binding as it appears in the selector source.
+    pub fn source_exact_target(
+        name: &'static str,
+        target_binding: impl Into<String>,
+        match_source: impl Into<String>,
+    ) -> Self {
+        Self {
+            name,
+            binding: None,
+            source_match: Some(FixtureSourceMatch {
+                identifiers: "exact",
+                target_binding: Some(target_binding.into()),
+                target_statement: None,
+                target_statements: None,
+                wildcard_string_literals: Vec::new(),
+                match_source: match_source.into(),
+            }),
+            comment: None,
+        }
+    }
+
     /// Attach an author comment to be emitted above the binding's owner
     /// statement in the lowered module body. See `spec::Member::comment`.
     pub fn with_comment(mut self, comment: impl Into<String>) -> Self {

--- a/devinfra/js/debundle/e2e/syntactic_holes_test.rs
+++ b/devinfra/js/debundle/e2e/syntactic_holes_test.rs
@@ -1041,6 +1041,45 @@ export { runtimePrefix, runtimeBuild, runtimeRead, runtimeSuffix };
 }
 
 #[test]
+fn member_source_match_anything_declarator_can_bracket_capitalized_target_binding() {
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"const beforeTarget = "before",
+  runtimeTarget = makeTarget("value"),
+  afterTarget = "after";
+function makeTarget(value) {
+  return `target:${value}`;
+}
+console.log(beforeTarget, runtimeTarget, afterTarget);
+export { beforeTarget, runtimeTarget, afterTarget, makeTarget };
+"#,
+        vec![logical_module(
+            "target",
+            &[Member::source_exact_target(
+                "SelectedTarget",
+                "Target",
+                r#"const ANYTHING = null,
+  Target = makeTarget("value"),
+  ANYTHING = null;"#,
+            )],
+        )],
+    ));
+
+    assert_entry_output(&fixture, "before target:value after\n");
+    assert_module_exports(
+        &fixture.out_root,
+        "static/app/modules/target.js",
+        &["SelectedTarget"],
+        &["runtimeTarget"],
+    );
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/modules/target.js",
+        &["const SelectedTarget", "makeTarget"],
+        &["beforeTarget", "afterTarget", "ANYTHING"],
+    );
+}
+
+#[test]
 fn binding_group_declarator_holes_extract_multiple_bindings_and_skip_holes_for_adopt_names() {
     let fixture = run_fixture(FixtureOpts::new(
         r#"const runtimePrefix = "prefix",

--- a/devinfra/js/debundle/source_match.rs
+++ b/devinfra/js/debundle/source_match.rs
@@ -1471,10 +1471,21 @@ fn find_matching_target_var_decl_with_declarator_holes(
         if !prefilter.var_decl_can_match(candidate_var) {
             continue;
         }
-        if !prepared.matches(item) {
-            continue;
-        }
-        let Some(alignment) = prepared.var_declarator_alignment(needle_var, candidate_var) else {
+        let Some(alignment) = target_binding_candidate_names(candidate_var, target_binding_idx)
+            .into_iter()
+            .find_map(|candidate_binding| {
+                if !prepared.matches_with_prebound_binding(item, target_binding, &candidate_binding)
+                {
+                    return None;
+                }
+                prepared.var_declarator_alignment_with_prebound_binding(
+                    needle_var,
+                    candidate_var,
+                    target_binding,
+                    &candidate_binding,
+                )
+            })
+        else {
             continue;
         };
         let Some(Some(candidate_decl_idx)) = alignment.get(target_decl_idx) else {
@@ -2025,6 +2036,21 @@ fn declared_bindings_for_var_declarator(declarator: &VarDeclarator) -> Vec<Resol
         .map(|binding_name| ResolvedMemberBinding {
             binding_name,
             kind: Some(BindingSourceKind::VariableDeclarator),
+        })
+        .collect()
+}
+
+fn target_binding_candidate_names(
+    candidate_var: &VarDecl,
+    target_binding_idx: usize,
+) -> Vec<String> {
+    candidate_var
+        .decls
+        .iter()
+        .filter_map(|declarator| {
+            declared_bindings_for_var_declarator(declarator)
+                .get(target_binding_idx)
+                .map(|binding| binding.binding_name.clone())
         })
         .collect()
 }
@@ -3487,6 +3513,24 @@ impl<'a> PreparedNeedle<'a> {
         })
     }
 
+    fn matches_with_prebound_binding(
+        &self,
+        candidate: &ModuleItem,
+        selector_binding: &str,
+        candidate_binding: &str,
+    ) -> bool {
+        SyntaxContext::within_ignored_ctxt(|| {
+            let mut matcher = AstWildcardMatcher::new_with_string_literal_regexes(
+                self.selector,
+                &self.wildcard_idents,
+                &self.string_literal_regexes,
+                self.alpha,
+            );
+            matcher.prebind_alpha_sym(selector_binding, candidate_binding)
+                && matcher.match_module_item(self.needle, candidate)
+        })
+    }
+
     fn var_declarator_alignment(
         &self,
         needle: &VarDecl,
@@ -3499,6 +3543,27 @@ impl<'a> PreparedNeedle<'a> {
                 &self.string_literal_regexes,
                 self.alpha,
             );
+            matcher.match_var_declarator_slice_with_alignment(&needle.decls, &candidate.decls)
+        })
+    }
+
+    fn var_declarator_alignment_with_prebound_binding(
+        &self,
+        needle: &VarDecl,
+        candidate: &VarDecl,
+        selector_binding: &str,
+        candidate_binding: &str,
+    ) -> Option<Vec<Option<usize>>> {
+        SyntaxContext::within_ignored_ctxt(|| {
+            let mut matcher = AstWildcardMatcher::new_with_string_literal_regexes(
+                self.selector,
+                &self.wildcard_idents,
+                &self.string_literal_regexes,
+                self.alpha,
+            );
+            if !matcher.prebind_alpha_sym(selector_binding, candidate_binding) {
+                return None;
+            }
             matcher.match_var_declarator_slice_with_alignment(&needle.decls, &candidate.decls)
         })
     }
@@ -3885,10 +3950,6 @@ impl<'a> AstWildcardMatcher<'a> {
     /// consult the visible lexical scope stack, then create a mapping in
     /// the current scope if neither side is known yet.
     fn match_sym(&mut self, needle: &Atom, candidate: &Atom) -> bool {
-        if !self.alpha {
-            return needle == candidate;
-        }
-
         for scope in self.alpha_scopes.iter().rev() {
             if let Some(mapped) = scope.forward.get(needle) {
                 return mapped == candidate;
@@ -3897,6 +3958,9 @@ impl<'a> AstWildcardMatcher<'a> {
                 return false;
             }
         }
+        if !self.alpha {
+            return needle == candidate;
+        }
         self.bind_alpha_sym_in_current_scope(needle, candidate)
     }
 
@@ -3904,10 +3968,24 @@ impl<'a> AstWildcardMatcher<'a> {
     /// allowed to shadow an outer binding with the same spelling, so only
     /// the current lexical frame is consulted before creating the pair.
     fn match_binding_sym(&mut self, needle: &Atom, candidate: &Atom) -> bool {
+        let scope = self
+            .alpha_scopes
+            .last()
+            .expect("alpha matcher always has a root scope");
+        if let Some(mapped) = scope.forward.get(needle) {
+            return mapped == candidate;
+        }
+        if scope.backward.contains_key(candidate) {
+            return false;
+        }
         if !self.alpha {
             return needle == candidate;
         }
         self.bind_alpha_sym_in_current_scope(needle, candidate)
+    }
+
+    fn prebind_alpha_sym(&mut self, needle: &str, candidate: &str) -> bool {
+        self.bind_alpha_sym_in_current_scope(&Atom::from(needle), &Atom::from(candidate))
     }
 
     fn bind_alpha_sym_in_current_scope(&mut self, needle: &Atom, candidate: &Atom) -> bool {


### PR DESCRIPTION
## Summary
- Fix member `source_match` target-binding resolution for var declarations with declarator-list holes so exact-mode selectors can bind the selector-local `target_binding` name to the matched runtime declarator.
- Add a generic e2e regression for `const ANYTHING = null, Target = ..., ANYTHING = null;` bracketing a capitalized selector-local target binding while the runtime binding has a different name.
- Add an exact-mode target-binding fixture helper for e2e tests.

## Validation
- `nix develop -c bazelisk test //devinfra/js/debundle/e2e:syntactic_holes_test //devinfra/js/debundle/e2e:selector_codemod_cli_test`
- `nix develop -c pre-commit run --files devinfra/js/debundle/source_match.rs devinfra/js/debundle/e2e/support.rs devinfra/js/debundle/e2e/syntactic_holes_test.rs`

Draft because this is a tooling-lane fix and may want review alongside the recently merged selector-codemod preservation change.