### PR TITLE
[codex] Plan automated debundle spec workflows

### DIFF
--- a/devinfra/js/debundle/ARCHITECTURE_BACKLOG.md
+++ b/devinfra/js/debundle/ARCHITECTURE_BACKLOG.md
@@ -168,11 +168,18 @@ These files document the same project from multiple perspectives. Skimming them,
 
 ## Concerns to discuss before deciding
 
-### Gate simulator ↔ materializer import-order sharing (RESOLVED)
+### Entry-file universal-edge approximation
 
-The historical drift surface — the emitter placed phantom side-effect imports first in each emitted module while the simulator sorted ALL of a module's I-successors in one `linker_position` list, residual's missing universal entry imports, and the `usize::MAX` tie-break mismatch — is resolved: both sides now consume one shared ordering implementation, `esm_import_order::EsmImportOrder` (`sort_entry_imports` / `sort_module_imports`), built from the canonical `ChunkConstrainingEdgeSet`. The emitter renders the entry's per-plan import list (named imports for binding-owning plans, side-effect-only imports for binding-less plans) and each module's merged intra-chunk import list (binding + phantom + residual-entry, one sort) from it; the simulator (`realizability::EsmIGraph`) uses the same two sorts as DFS neighbor order, with residual fanning out to every I-graph module exactly as the emitted entry does. Do not reintroduce per-side ordering rules — encode any ordering requirement in `EsmImportOrder` so both sides inherit it.
-
-Remaining known approximation: the simulator roots at `partition.residual()` (the `anon_residual_sentinel` ≈ the entry file) and models its body as evaluating last. That is exact for the entry file in both `unassigned_mode`s; the `catchall_file` plan itself is an ordinary module and is modeled as one. Pass-2 candidate SCC enumeration still runs over the _real_ I-graph (no universal residual edges), so a module that eager-reads an entry-file binding when residual's own statements never reference that module forms no candidate SCC and is not checked — a narrow, pre-existing under-restriction (inline-mode-only: catchall chunks keep no TDZ-prone bindings in the entry file). Extending candidate enumeration with the universal entry edges would close it at the cost of much larger SCCs in the incremental planner path.
+The simulator and emitter now share import-ordering through
+`esm_import_order::EsmImportOrder`; keep it that way. The remaining
+approximation is narrower: pass-2 candidate SCC enumeration still runs over
+the real I-graph, without adding the entry-file residual module's universal
+edges. A module that eager-reads an entry-file binding when residual's own
+statements never reference that module can therefore avoid candidate SCC
+checking. This is a pre-existing inline-mode-only under-restriction; catchall
+chunks keep no TDZ-prone bindings in the entry file. Extending candidate
+enumeration with the universal entry edges would close it at the cost of much
+larger SCCs in the incremental planner path.
 
 ### `BindingId`/`BindingTable` interning (DECIDED 2026-06: defer, perf-triggered)
 

--- a/devinfra/js/debundle/CLI_DOGFOOD.md
+++ b/devinfra/js/debundle/CLI_DOGFOOD.md
@@ -22,6 +22,12 @@ The actual path now has a `+_repo_rules+` prefix:
 Generic usability follow-ups for the top-level planner commands.
 Corpus-specific paths and owner ids belong in the consuming repo.
 
+- **Orthogonal patch-plan workflow.** New spec automation should converge on
+  the inventory/plan/apply/validate/explain model in
+  <plans/automated_spec_workflows.md>. A dry-run that proposes edits should be
+  able to emit a stable plan artifact; apply should consume that artifact; repair
+  should consume validate diagnostics. Avoid adding isolated flags whose output
+  cannot feed the next command.
 - **Diagnostics toggle for `modules propose`.** `--limit` now bounds
   proposals and diagnostics and the `limits` summary reports totals
   when details are truncated, but there is still no explicit
@@ -41,5 +47,6 @@ Corpus-specific paths and owner ids belong in the consuming repo.
   module YAML with atomic-unit coverage, but it is not the only way to
   discover readable work: `atoms --readable-only` and `modules propose`
   may show graph-valid work even when no whole patch section is ready.
-  Docs and skill text should avoid implying that empty coverage output
-  means there is no landable work.
+  Docs and skill text should reserve "plan" for proposed edits that can be
+  reviewed/applied, and avoid implying that empty coverage output means there
+  is no landable work.

--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -5,60 +5,112 @@ once closed; this file is not a changelog.
 
 ## Current AI-worker priority queue (2026-06-14)
 
-This queue captures the highest-leverage debundle work from the
-large-spec stabilization pass. Prefer dispatching work in this order until the
-old-spec selector-debt migration no longer needs special coordination.
+This queue captures the active debundle tooling program. Treat this file as
+the current priority source of truth; detailed design for the automation-first
+direction lives in <plans/automated_spec_workflows.md>. Other tracking files
+hold category-specific evidence:
 
-### P0 — directly unlock large structural-selector peels
+- <CLI_DOGFOOD.md> — command UX and scripting-safety gaps found while running
+  real workflows.
+- <SELECTOR_BUGS.md> — selector matcher bugs and diagnostics gaps, with
+  generic/anonymized examples.
+- <ARCHITECTURE_BACKLOG.md> — deeper internal refactors, only urgent when they
+  block the active workflows here.
+- <perf/> — measured performance notes. Update these from actual profiles
+  before major matcher/index rewrites.
 
-1. **Bulk selector codemods beyond current apply mode.** Extend
-   `debundle spec selector-codemod` with more proven mechanical rewrites across
-   a spec. Remaining high-value targets:
+Prefer dispatching work in this order. Large downstream spec migrations should
+lean on tooling generated from this queue instead of hand-authored YAML.
+Interactive agent-facing commands should target under 10 seconds on warmed
+inputs for the largest known downstream specs. Anything over 60 seconds is a
+workflow blocker unless the command is explicitly an offline/profile mode with
+progress output and a resumable or cacheable plan.
+
+### P0 — automation-first selector workflows
+
+1. **Minimal selector synthesis.** Implement the core operation "given this
+   binding, group, anonymous statement, or statement range, emit the simplest
+   selector that uniquely selects it." Start from exact source slices, relax
+   with holes, use source indexes to count candidates cheaply, and verify the
+   final selector through the real resolver. This is the primitive for new-spec
+   bootstrap, old-spec stabilization, and version-port repair.
+2. **Shared source inventory/index.** Extract a reusable per-chunk index for
+   top-level statement identity, binding identity, stable literals/keys,
+   canonical fingerprints, source slices, and candidate-count queries. Use it
+   from `selector-debt`, `selector-codemod`, repair diagnostics, and future
+   port tooling rather than adding more per-command AST walks.
+3. **Patch-plan based bulk codemods.** Extend `debundle spec selector-codemod`
+   or add adjacent verbs so every broad rewrite can emit a dry-run patch plan,
+   preserve YAML comments where possible, apply with filters, and explain every
+   skipped candidate. High-value rewrite classes:
+   - minimize generated `name-only-source-match` selectors by replacing
+     unnecessary expression arguments, object properties, class members, and
+     statement ranges with `ANYTHING` / `OBJECT_PROPS` / `STMT_LIST` while
+     preserving uniqueness;
    - convert repeated member-form selectors over the same declaration context
      into one `binding_groups` entry;
-   - convert unique literal-initializer bindings into structural selectors
-     when the source value is stable enough;
+   - merge multiple eligible generated selectors from the same declaration into
+     one `binding_groups` entry;
    - source-aware reports or apply-safe rewrites for overpinned object literals
      that can now use `ANYTHING` / `OBJECT_PROPS` around stable keys.
-
-   Keep dry-run, path filters, JSON output, and an explanation for every
-   skipped candidate.
-
-2. **Selector diagnostics as machine-readable reports.** Emit a keep-going
+4. **Selector diagnostics as machine-readable reports.** Emit a keep-going
    JSON report for unresolved selectors, ambiguous selectors, duplicate claims,
    and blocker comments. Include module path, export name, selector kind,
    target binding, first mismatch, nearest candidates, and recommended next
    action. This lets coordinators batch failures instead of scraping logs.
+5. **Spec repair from diagnostics.** Add a workflow that consumes the keep-going
+   report, proposes mechanically proven patch plans for no-match, ambiguous,
+   duplicate-claim, and unsupported-selector cases, and leaves residual semantic
+   decisions as explicit tasks.
+6. **Orthogonal CLI surface.** Converge new automation on the
+   inventory/plan/apply/validate/explain model in
+   <plans/automated_spec_workflows.md>. Avoid one-off command shapes that cannot
+   pipe a dry-run plan into review, apply, validation, and repair.
+7. **Workflow latency budget.** Keep P0 reports and dry-run patch planners
+   fast enough for iterative agent use: parse/index each chunk once, stream
+   NDJSON as work is found, emit per-phase timings, and treat >60s runs as
+   urgent perf bugs unless they are deliberately offline.
 
-### P1 — improves agent throughput and reviewability
+### P1 — broad workflow integration
 
-1. **Selector-debt ranking improvements.** Extend `debundle spec selector-debt`
+1. **Version-port workflow.** Given v1 chunks + spec and v2 chunks, resolve v1
+   selectors to source identities/fingerprints, search v2 for matching
+   entities, apply confident selector repairs, and emit a residual report for
+   semantic drift.
+2. **New-app spec bootstrap.** Connect module proposals, naming output, and
+   selector synthesis so new debundle specs start with structural selectors and
+   an explicit debt/confidence report.
+3. **Selector-debt ranking improvements.** Extend `debundle spec selector-debt`
    with source-aware ranking for multi-statement windows, repeated selector
    bodies that can become binding groups, and "stable literal by value"
    candidates. Prefer output that can feed the P0 codemod dry-run.
-2. **Cross-module binding-group design.** Design a form for one matched source
+4. **Cross-module binding-group design.** Design a form for one matched source
    context to export bindings into different logical modules without duplicating
    the selector body.
-3. **Free-readable-identifier diagnostics.** When an `alpha_all` selector uses
+5. **Free-readable-identifier diagnostics.** When an `alpha_all` selector uses
    readable names that are free references rather than local binders, explain
    that they do not refer to previously exported symbols. Suggest grouping or
    holes.
-4. **Duplicate-claim identity.** Track claims by declaration identity instead
+6. **Duplicate-claim identity.** Track claims by declaration identity instead
    of only emitted/minified spelling; include declaration kind and source
    location in duplicate-claim diagnostics.
-5. **Public real-bundle smoke.** Build the Excalidraw live-browser smoke so
+7. **Public real-bundle smoke.** Build the Excalidraw live-browser smoke so
    private-corpus debundler issues can be reproduced and protected in public CI.
 
 ### P2 — pipeline performance and architecture cleanup
 
-1. Add `debundle run --reports=<list>` so dry-run/spec-check workflows can skip
+1. Use actual profiles to prioritize selector matching/index work. The expected
+   direction is one parse/index per chunk, prepared selector reuse, inverted
+   indexes for stable anchors, and memoized selector-body resolution; validate
+   each major change in <perf/>.
+2. Add `debundle run --reports=<list>` so dry-run/spec-check workflows can skip
    expensive reports they do not need.
-2. Add chunk-level incremental rebuilds keyed by upstream bytes, spec slice,
+3. Add chunk-level incremental rebuilds keyed by upstream bytes, spec slice,
    and Ducktape version.
-3. Add an AST-hash SWC codegen cache for unchanged post-lowering modules.
-4. Replace `JsChunk::{get_file,get_file_mut,remove_file}` linear scans with a
+4. Add an AST-hash SWC codegen cache for unchanged post-lowering modules.
+5. Replace `JsChunk::{get_file,get_file_mut,remove_file}` linear scans with a
    path-keyed index if fresh profiles show chunk file lookup hot.
-5. Move `split_entry_body` to a draining/move-based implementation if fresh
+6. Move `split_entry_body` to a draining/move-based implementation if fresh
    profiles show retained-statement cloning hot.
 
 ## Excalidraw live-browser smoke
@@ -176,54 +228,12 @@ observed. (The `owner:<id>`-in-spec-notes framing that used to live here was
 stale — no such mechanism exists; `owner:N` ids are machine-generated graph
 keys and a `describe`/`show-source` input, not a spec authoring hint.)
 
-## Completed-plan follow-ups
-
-- **Peel proposer contraction cleanup.** The quotient-contraction
-  proposer and lazy-priority-queue greedy driver are implemented and
-  documented in <docs/peel_proposer.md>. Remaining cleanup is narrow:
-  retire the hidden full-scan greedy reference only after the lazy-PQ
-  path has had release-cycle confidence, and add a diagnostic-only seed
-  rejection mode only if spec authors need a focused debugging surface.
-- **Chunk IR / schedule split remains deferred.** The completed IR cleanup plan
-  left one deliberately deferred refactor: split the "everything about chunk K
-  under partition P" state into a pure `ChunkIR` plus a `Schedule` only if a
-  downstream consumer actually needs one half without the other. If this happens,
-  move the `owner_report_ids_by_binding` cache to its report-only consumer and
-  have peelability build directly from `(ir, partition)`.
-- **Inter-cell cycle policing at assignment/render time.** The exact gate does
-  not reject mutually-cyclic residual cells itself; `peel/factorize.rs` reports
-  them as `BlockedResidualDependency`. If that is insufficient for
-  `bindings assign`, add a render-time cell-DAG / proposal-shape check rather
-  than reintroducing a realizability-gate rule.
-- **Proptest coverage for the gate differential harness.** Migrate
-  `peel/gate_differential_test.rs` from its deterministic xorshift sweep to
-  proptest strategies, matching the condensation-order and `RenameLedger`
-  proptest suites.
-- **Materialize-into-emit.** Let lowered outputs feed `write_js_tree` /
-  harness emission directly, dropping the `materialize_logical_modules`
-  bundle round-trip and post-materialize index rebuild. Details live in
-  <ARCHITECTURE_BACKLOG.md>.
-- **Post-strip consumer scan retirement.** Retire
-  `vendor/mod.rs::validate_partial_swap_consumers` only after construction
-  paths consult `VendorResolutionPlan` and e2e fixtures pin synthesized
-  consumer-directive shapes that fail without the scan. Details live in
-  <ARCHITECTURE_BACKLOG.md>.
-- **Program facts unification.** Fold
-  `program_analysis.rs::analyze_program_shallow` into the full program-facts
-  path, or derive it from that path, so the two top-level fact walks cannot
-  drift. Also tracked in <CODE_REVIEW.md>.
-- **Sanitization-era test cleanup.** Clean up the remaining small fixture debt:
-  consolidate the `logical_module_with_*` helpers in `e2e/support.rs`, remove
-  the hardcoded entry path from
-  `assert_generated_module_after_entry_script`, and replace brittle
-  whitespace OR-chain assertions. Also tracked in <CODE_REVIEW.md>.
-
 ## Structural selector language
 
-`source_match` and same-module `binding_groups` exist, but the selector
-language still needs more shape when porting real minified bundles. Keep
-new features generic and backed by synthetic e2e fixtures; do not encode
-private corpus details in Ducktape.
+Detailed workflow priorities live above and in
+<plans/automated_spec_workflows.md>. Remaining selector-language gaps should be
+implemented only when they unlock synthesis, stabilization, repair, or porting
+workflows, and must use generic synthetic fixtures.
 
 - **Contextual selectors.** Add readable `before` / `after` / `near`
   anchors for cases where the selected statement or declaration is
@@ -238,45 +248,10 @@ private corpus details in Ducktape.
   argument, callback body, object property value, or statement-list slot. This
   should avoid scanning unrelated subtrees while preserving the current rule
   that ambiguous matches are hard errors.
-- **Object-literal property holes.** Add a structural `source_match` list hole
-  for object literal properties, likely anonymous `OBJECT_PROPS` /
-  labeled `OBJECT_PROPS_name` shorthand entries inside an object literal. The
-  goal is to pin stable anchors such as
-  `{ requiredKey: EXPR, OBJECT_PROPS, anotherKey: EXPR }` without spelling every
-  unrelated key/value property or replacing the whole object with `EXPR`.
 - **Cross-module binding groups.** Current `binding_groups` export
   multiple bindings into one logical module. Add or design a form for
   one matched declaration context whose bindings should land in
   different modules, without repeating the whole source selector.
-- **Selector debt reporting.** Shipped as `debundle spec selector-debt`:
-  ranks name-only selectors by how minified the bound name looks, groups
-  `source_match` bodies copied verbatim across members / anonymous
-  statements / binding groups, and (via `--against`) diffs minified
-  bindings across two spec versions. A first **source-aware** slice exists
-  behind `--source-file` or `--source-root --chunk`: it parses the current
-  chunk and flags structural selectors that match exactly one top-level
-  statement today but have high-scoring non-matching sibling statements; it
-  also reports repeated selector bodies that resolve to the same exact body
-  indices and suggests `binding_groups` replacements for repeated member-form
-  `source_match` selectors over one multi-declarator variable declaration.
-  No-match diagnostics for `DECLARATORS_*` selectors now call out missing
-  before / between / after pseudo-declarator holes and explain the
-  `target_binding` versus `binding_groups` choice.
-- **Selector codemod apply mode.** Shipped as
-  `debundle spec selector-codemod`: dry-run-by-default, JSON-capable,
-  filterable application of the safe single-binding `target_binding` rewrite.
-  Remaining work: add an apply-mode rewrite for the existing source-aware
-  `binding_groups` suggestions, preserving member comments/export names while
-  deleting the repeated member-form selectors atomically.
-- **Selector debt remaining work.** Rank multi-statement windows, consider
-  owner-graph context where useful, and produce richer edit-distance
-  diagnostics for non-declarator selector shapes than the current
-  first-mismatch score/reason.
-- **Selector linting.** The report now exists (`spec selector-debt`); the
-  next step is an opt-in warning or gate that fails when a name-only
-  selector over an autogenerated/minified source scores above a threshold,
-  with an explicit escape hatch for cases where the name is genuinely
-  stable or no better structural handle exists.
 - **Matcher core cleanup.** Factor anonymous-statement and member-binding
   `source_match` resolution through a shared parse/canonicalize/window
   matcher before adding more selector variants.

--- a/devinfra/js/debundle/perf/source_match_selector_profile.md
+++ b/devinfra/js/debundle/perf/source_match_selector_profile.md
@@ -4,6 +4,15 @@ This note tracks stack-sample evidence for generic `source_match`
 selectors shaped like large direct literal sweeps. It intentionally uses
 only synthetic names and source.
 
+## Budget
+
+Selector-heavy agent workflows should be interactive: under 10 seconds on
+warmed inputs is the target, and sustained runs over 60 seconds on the largest
+known downstream specs are priority performance bugs unless the command is
+explicitly marked as an offline/profile mode. New matcher/index work should
+show either lower wall time or a material drop in timed selector resolutions on
+a broad workload, not only a microbenchmark win.
+
 ## Workload
 
 Target:

--- a/devinfra/js/debundle/plans/automated_spec_workflows.md
+++ b/devinfra/js/debundle/plans/automated_spec_workflows.md
@@ -1,0 +1,498 @@
+# Automated Debundle Spec Workflows
+
+## Goal
+
+Make debundle specs cheap to create, stabilize, and port across minified bundle
+versions. The target user is an agent operating on a large real-world bundle:
+the agent should spend most of its time reviewing ranked patch plans and
+blockers, not hand-authoring fragile selectors one binding at a time.
+
+This plan covers three product flows:
+
+1. Given one or more minified JavaScript chunks, produce a minimal spec that
+   emits readable, reviewable logical modules.
+2. Given an existing partially unstable spec, replace fragile selectors with
+   stable structural selectors in large batches.
+3. Given version 1 chunks plus spec and version 2 chunks, update the spec to
+   version 2 and present the remaining repair work as structured diagnostics.
+
+Keep all examples and fixtures generic. Do not copy private downstream bundle
+source into Ducktape tests.
+
+## Desired Agent Workflow
+
+An efficient agent loop should look like this:
+
+1. Build an indexed source inventory for each chunk once.
+2. Ask debundle for ranked worklists: unstable selectors, unresolved selectors,
+   ambiguous selectors, repeated selector bodies, and likely grouping
+   opportunities.
+3. Ask debundle to synthesize a patch plan for a whole bucket, with dry-run
+   JSON/NDJSON explaining every applied and skipped candidate.
+4. Apply the safe subset, preserving YAML comments and producing small
+   deterministic diffs.
+5. Run the keep-going validation report, not just the first failing selector.
+6. Repeat until the residual report is small enough for manual review.
+
+The important interface is the patch plan, not a single CLI command name. Every
+bulk command should support path/module filters, `--apply`, stable JSON output,
+and a reason for every skipped candidate.
+
+## CLI Design Principles
+
+Design commands around orthogonal operations, not one command per historical
+rewrite:
+
+- **inventory/report** commands read source/spec state and emit facts;
+- **plan** commands turn facts plus intent into proposed edits;
+- **apply** commands apply a previously emitted plan deterministically;
+- **validate** commands check current state and emit keep-going diagnostics;
+- **explain/show** commands inspect one target or failure in human-readable
+  detail.
+
+The same filters and output contracts should work everywhere they make sense:
+`--module`, `--module-prefix`, `--file`, `--chunk`, `--source-root`,
+`--format text|json|ndjson`, `--limit`, `--apply`, and `--plan-out` should not
+mean subtly different things between commands. Prefer a small set of
+composable verbs over a growing pile of bespoke flags whose behavior cannot be
+piped into the next step.
+
+Patch plans should be reusable artifacts: a dry-run plan can be reviewed,
+filtered, applied later, or fed into a repair command. If a command cannot emit
+a stable plan for an edit, it should remain a diagnostic/report command until
+the edit model is clear.
+
+## Core Data Model
+
+### Source Inventory
+
+Build a reusable per-chunk index from the parsed SWC module:
+
+- top-level statement identity: body index, span, declaration kind, exported
+  bindings, anonymous-statement eligibility;
+- binding identity: current minified name, declaration span, declarator span,
+  initializer shape, literal values, class/function metadata;
+- canonical AST fingerprints for statements, declarations, declarators,
+  object properties, call expressions, class members, and statement lists;
+- inverted indexes for stable anchors: string/number/boolean/null literals,
+  property keys, object keys, member names, operators, callee/member shapes,
+  declaration kind, arity, and statement/declarator count;
+- source slices and byte ranges needed for YAML selector emission;
+- cheap candidate-count queries for "would this relaxed selector still be
+  unique?"
+
+This index should be shared by `selector-debt`, `selector-codemod`, selector
+resolution diagnostics, spec repair, and version-port tooling. Avoid separate
+per-command AST walks that drift semantically.
+
+### Selector Candidates
+
+Candidate generation should produce multiple selector forms for the same target
+and let a ranker choose:
+
+- exact structural `source_match`;
+- minimized structural `source_match` with `ANYTHING`, `OBJECT_PROPS`,
+  `DECLARATORS`, `CLASS_REST`, `ARGS`, and `STMT_LIST` holes;
+- `binding_groups` when one source context exports multiple bindings;
+- literal-initializer selectors when a top-level binding is uniquely
+  initialized to a stable literal;
+- regex string-literal anchors for generated class/style names or other stable
+  prefix/suffix families;
+- contextual windows when a selected statement is generic but nearby stable
+  anchors make the window unique;
+- anonymous-statement and statement-list selectors for side-effect blocks.
+
+Selectors should be ranked by a cost model that rewards uniqueness, stability,
+small readable source, grouped exports, exact stable literals/keys, and fewer
+unneeded pinned generated details.
+
+### Minimizer
+
+"Produce the simplest selector that uniquely selects this entity" should be a
+first-class operation. For a target binding, group, or anonymous statement:
+
+1. Start from an exact source slice known to select the desired entity.
+2. Generate relaxations by replacing low-signal subtrees with holes and by
+   shrinking context windows.
+3. Use source-inventory indexes to cheaply count possible matches before
+   invoking the full matcher.
+4. Verify final candidates through the real selector resolver.
+5. Emit the lowest-cost unique selector and structured rejected alternatives
+   when useful for diagnostics.
+
+The minimizer should be deterministic. Greedy relaxation is acceptable for the
+first implementation when each accepted relaxation is revalidated, but the
+interfaces should allow a later branch-and-bound or trie-backed search.
+
+### Patch Plans
+
+Bulk tools should produce a machine-readable plan before mutating YAML:
+
+- target module path and member/group/anonymous-statement location;
+- current selector summary and proposed selector summary;
+- edit kind: replace selector, create binding group, merge members, add hole,
+  add target binding, add diagnostic comment, or leave unchanged;
+- proof: uniqueness result, body indices, target binding, grouped exports, and
+  source-inventory anchors used;
+- skip reason with the next useful action.
+
+Apply mode should preserve comments and ordering where possible. If a rewrite
+needs to delete repeated member-form selectors and create one group, comments
+from the deleted members must be retained or moved into the group/export rows.
+
+## High-Level CLI Shape
+
+Exact names can change, but the command surface should stay consistent and
+orthogonal:
+
+- `debundle spec inventory --modules ... --source-root ... --format ndjson`
+  emits source/spec facts: bindings, anonymous statements, current selectors,
+  debt buckets, grouping opportunities, source fingerprints, and stable anchors.
+- `debundle spec plan selectors --targets <targets.json> --source-root ...`
+  emits a patch plan that creates or replaces selectors for explicit bindings,
+  groups, anonymous statements, or statement ranges.
+- `debundle spec plan stabilize --modules ... --source-root ...`
+  emits a patch plan for eligible fragile selectors across an existing spec.
+- `debundle spec plan repair --diagnostics <report.json> --source-root ...`
+  emits a patch plan for unresolved, ambiguous, duplicate-claim, or unsupported
+  selector failures.
+- `debundle spec plan port --from-modules ... --from-source-root ... --to-source-root ...`
+  emits a patch plan carrying a spec across bundle versions plus residual
+  semantic tasks.
+- `debundle spec apply-plan --plan <plan.json> --modules ...`
+  applies a reviewed plan, preserving comments/order where the edit type
+  supports it and refusing stale plans whose inputs no longer match.
+- `debundle spec validate --keep-going --format json`
+  reports all selector/spec failures in one pass with enough source identity to
+  feed `plan repair`.
+- Existing focused commands such as `selector-debt` and `selector-codemod` can
+  remain as aliases or transitional frontends, but new work should converge on
+  the inventory/plan/apply/validate model.
+
+Prefer extending existing commands when that keeps the UX coherent. Add new
+verbs when overloading an existing command would make the mode hard to explain.
+
+## Flow 1: New Chunks to Readable Spec
+
+The bootstrap flow should combine existing debundle planning with selector
+synthesis:
+
+1. Run module/factor proposals and naming passes to identify candidate logical
+   modules and export names.
+2. For each proposed binding cluster, synthesize a selector or binding group.
+3. Prefer grouped declaration contexts over repeated member-form selectors.
+4. Use the minimizer to remove irrelevant initializer arguments, object
+   properties, class members, and statement ranges while preserving uniqueness.
+5. Emit an initial spec plus a report of low-confidence names, unaddressable
+   anonymous statements, and selectors that needed high-cost context.
+
+This should make new-app specs start structurally stable instead of beginning
+with a large name-only debt pile.
+
+## Flow 2: Stabilize an Existing Spec
+
+The stabilization flow is the current large-spec migration case:
+
+1. Inventory debt with `selector-debt` and bucket by mechanical rewrite class.
+2. Apply broad buckets first: class declarations, function declarations,
+   literal-initialized constants, multi-declarator groups, style/string regex
+   anchors, object-literal anchors, and anonymous statement lists.
+3. For each bucket, generate a patch plan and apply only candidates with a
+   uniqueness proof.
+4. Record precise YAML comments for candidates that cannot yet be stabilized,
+   including the missing selector feature or ambiguity reason.
+5. Track debt metrics after each batch: name-only count, repeated selectors,
+   unresolved selectors, ambiguous selectors, and slow selector families.
+
+The output should be large reviewable PRs grouped by rewrite class, not tiny
+hand-authored module-by-module edits.
+
+## Flow 3: Port Version 1 Spec to Version 2 Chunks
+
+The port flow should treat v1 selectors as evidence, not as immutable text:
+
+1. Resolve v1 spec against v1 chunks and store source identities and canonical
+   fingerprints for every selected binding/group/anonymous statement.
+2. Resolve the same selectors against v2 chunks in keep-going mode.
+3. For failures, search v2 source inventory for candidates with matching
+   fingerprints, stable literals, property keys, call/class shape, and nearby
+   context.
+4. Synthesize minimized replacement selectors for confident matches.
+5. Surface residual cases as repair tasks: zero match, ambiguous match, moved
+   module boundary, changed API shape, or missing selector feature.
+
+The command should make it obvious which changes are mechanical and which need
+human or reverse-engineering review.
+
+## Repair Workflow
+
+For a selector that does not match anything:
+
+1. Classify the failure: parse/schema error, unsupported hole, free readable
+   identifier, no top-level candidate, local subtree mismatch, literal mismatch,
+   or context-window mismatch.
+2. Show nearest candidate statements using canonical AST distance and stable
+   anchor overlap.
+3. Try mechanical relaxations: replace volatile subtrees with holes, shrink or
+   expand the statement window, use literal/regex anchors, or group bindings.
+4. Emit a candidate patch only if the repaired selector is unique.
+
+For an ambiguous selector:
+
+1. List candidate source identities and the anchors they share.
+2. Suggest the smallest differentiating stable anchor: literal, key, class
+   member, call shape, adjacent statement, or declaration kind.
+3. If no stable differentiator exists, report that the selector must remain
+   intentionally more specific or use a different ownership boundary.
+
+For duplicate claims:
+
+1. Report duplicate identity by declaration/declarator, not only minified name.
+2. Identify whether the right rewrite is binding-group collapse,
+   cross-module-group support, or a real ownership conflict.
+
+## Performance Plan
+
+Large specs should not require pairwise scans of every selector against every
+statement. Prioritize:
+
+- parse each chunk once per command invocation;
+- prepare each distinct selector body once;
+- cache canonical AST fingerprints and hole-normalized forms;
+- use inverted indexes to retrieve candidate statements by stable anchors
+  before full structural matching;
+- memoize selector-body resolution keyed by chunk hash, normalized selector,
+  target binding/statement, and Ducktape version;
+- keep timing reports grouped by selector key and body key so slow families
+  point to one fix.
+
+Actual stack-sample profiles should continue to update `perf/` notes before
+major matcher rewrites.
+
+### Scale Model
+
+Use these symbols when designing and reviewing algorithms:
+
+- `C`: chunks in the spec run;
+- `N`: top-level statements in a chunk;
+- `B`: top-level declared bindings/declarators in a chunk;
+- `A`: stable anchors in a chunk, such as literals, keys, member names, call
+  shapes, declaration kinds, and arities;
+- `E`: AST nodes in a chunk;
+- `S`: selectors or selector targets being processed;
+- `L`: average selector AST size;
+- `K`: candidate statements after indexed filtering.
+
+The Tana-scale target is thousands of YAML modules and thousands of selectors;
+the current migration has roughly 8.5k fragile selector bindings before broad
+peels. Agent-facing workflows should be designed for warmed runs under 10s and
+must treat sustained runs over 60s as blocking performance bugs unless the mode
+is explicitly offline/profile-oriented.
+
+Expected warmed runtime budgets on Tana-scale inputs:
+
+| Operation                                                   |       Target |  Hard concern |
+| ----------------------------------------------------------- | -----------: | ------------: |
+| Build source inventory for one large chunk                  |         1-3s |          >10s |
+| Emit selector debt/inventory report for the current spec    |         <10s |          >60s |
+| Classify name-only function/class/declarator rewrite bucket |          <5s |          >30s |
+| Plan a broad mechanical stabilization bucket                |         <10s |          >60s |
+| Minimize one ordinary selector context                      |     10-100ms |           >1s |
+| Validate selectors in keep-going mode after a batch         |         <10s |          >60s |
+| Deep nearest-candidate repair search                        | offline mode | no silent run |
+
+If a command cannot meet the interactive budget, it should stream progress,
+write resumable intermediate plans, and label itself as offline/profile mode.
+
+### Source Inventory Data Structures
+
+Build one dense per-chunk inventory:
+
+- `Vec<StatementRecord>` indexed by top-level body index. Each record stores
+  span, declaration kind, export wrapper kind, declared binding ids, anonymous
+  owner identity, cheap structural fingerprints, and stable anchor ids.
+- `Vec<BindingRecord>` indexed by dense binding id. Each record stores current
+  minified name, declaration/declarator statement id, declarator index, kind,
+  initializer summary, exported spec names, and source slice ranges.
+- `HashMap<Atom, AnchorId>` or an intern table for stable anchors. Anchor atoms
+  should use compact owned forms such as `Wtf8Atom`/interned strings for string
+  literals and property names; avoid allocating normalized strings per query.
+- Inverted postings from `AnchorId` to dense candidate sets. For Tana-scale
+  chunks, a sorted `Vec<StatementId>` is usually compact; for high-frequency
+  anchors, promote to a dense `Vec<u64>` bitset. The query interface should hide
+  the representation and expose cheap intersection/count/iterate operations.
+- Direct maps for exact lookups: binding name -> binding ids, literal
+  initializer -> declarator ids, normalized selector body -> prepared selector,
+  source fingerprint -> statement ids.
+
+Index construction should be `O(E + A)` per chunk with memory linear in AST
+size plus postings. It should parse source once and avoid command-specific AST
+walks. For a single large chunk, the expected warmed inventory build should be
+low single-digit seconds in optimized Rust; if it is not, profile construction
+before adding consumers.
+
+### Indexed Matching
+
+Selector resolution should be two-stage:
+
+1. Compile the selector once into a `PreparedSelector` containing its AST,
+   hole descriptors, required declaration kind, required binding count,
+   required stable anchors, literal predicates, and normalized cache key.
+2. Use the inventory to obtain a candidate set by intersecting the most
+   selective required anchors before running the full structural matcher.
+
+Expected query cost:
+
+- prepare selector: `O(L)`, once per distinct normalized selector body;
+- candidate retrieval: `O(p * W)` for bitset intersections or
+  `O(sum postings)` for sparse lists, where `p` is required anchor count and
+  `W = ceil(N / 64)`;
+- full matcher: `O(K * L)` in the common case, with `K` intended to be small.
+
+The implementation should refuse accidental `O(S * N * L)` behavior in bulk
+commands. A diagnostic fallback may scan all `N` statements only when the
+indexed candidate set is empty and the command is explicitly trying to explain
+a failure; that fallback must be timed and reported.
+
+### Minimal Selector Synthesis
+
+For one target entity:
+
+1. Start with an exact source slice and verify it selects the target.
+2. Build a relaxation graph where each edge replaces one low-signal subtree or
+   list region with a hole, shrinks a context window, or changes a literal to a
+   constrained literal/regex form.
+3. Score candidates by stability and readability:
+   - low cost: stable literals, object keys, property names, declaration kind,
+     arity, grouped exports;
+   - high cost: generated identifiers, long copied function bodies, unrelated
+     arguments, large object property lists, broad statement windows;
+   - invalid: non-unique selectors, selectors that target the wrong binding, or
+     selectors whose proof depends only on minified spelling.
+4. Use indexed candidate counts as the inner loop. Only run the full matcher on
+   candidates whose indexed count is nonzero and below a configurable cap.
+5. Stop when no relaxation lowers cost while preserving uniqueness, or use
+   best-first/branch-and-bound when greedy choices are too local.
+
+A greedy first implementation can be `O(R * (indexed_count + K * L))`, where
+`R` is the number of relaxations tried. Keep `R` bounded by generating
+coarse-grained relaxations first: whole argument list, whole object-property
+suffix, whole class-rest, whole statement-list window, then finer child holes
+only when needed. For bulk synthesis, group targets by exact source context so
+one relaxation search can emit a `binding_groups` selector for many exports.
+
+### Bulk Stabilization
+
+Stabilizing an existing spec should operate by buckets:
+
+- exact name-only function/class/declarator candidates via binding-name index:
+  `O(S + B)` to classify, then one uniqueness proof per candidate;
+- literal-initialized constants via literal initializer index:
+  `O(B)` index build plus `O(1)` lookup per candidate value;
+- repeated selector bodies via normalized body hash:
+  `O(S * L)` normalization and `O(S log S)` or hash grouping;
+- repeated declarator-context selectors into binding groups:
+  group by resolved statement id and declarator set, then emit one edit per
+  group;
+- overpinned objects/classes/functions:
+  synthesize once per unique source context, then fan out to all members using
+  that context.
+
+The critical rule is to dedupe before expensive matching. A spec with 8.5k
+fragile selectors should not do 8.5k independent parse/prepare scans if many
+selectors share context or rewrite class.
+
+### Repair And Porting Search
+
+No-match and version-port repair should use top-k retrieval rather than scanning
+every statement:
+
+1. Extract anchors and fingerprints from the failing v1 selector or selected
+   v1 source identity.
+2. Retrieve candidate statement ids from high-value anchors first: stable
+   string literals, object keys, property names, declaration kind, arity, and
+   structural fingerprint prefix.
+3. Score candidates by weighted anchor overlap and AST edit distance on the
+   small retrieved set.
+4. Run selector synthesis/minimization only for the top candidates.
+
+Expected cost per failed selector should be near `O(sum selective postings +
+K log K + K * diff_cost)`, with `K` capped. A full `O(N * diff_cost)` nearest
+candidate scan is acceptable only as an explicit deep diagnostic mode.
+
+### Patch Application And Caching
+
+Patch planning and application should be deterministic:
+
+- include input hashes for source chunks, modules files, selector bodies, and
+  Ducktape version in patch-plan metadata;
+- refuse apply when the input hash no longer matches, unless the caller asks to
+  rebase/recompute the plan;
+- cache inventory and prepared selector data by chunk hash and Ducktape
+  version within a process, and leave room for a future on-disk cache;
+- stream NDJSON plan rows as soon as they are known so long runs remain useful
+  and interruptible.
+
+## Implementation Milestones
+
+### Milestone 0: Consolidate Current Tooling
+
+- Keep the existing `selector-codemod` source-backed name-only conversion as
+  the first concrete synthesis slice.
+- Ensure dry-run/apply reports are stable and contain enough data to feed a
+  later batch planner.
+- Document current limitations: no comment-preserving group collapse yet, no
+  global minimizer yet.
+
+### Milestone 1: Source Inventory and Minimal Selector Synthesis
+
+- Extract the current per-command source index into a shared module.
+- Add explicit target input: binding names, export names, body indices,
+  declarator indices, and anonymous statement IDs.
+- Generate exact structural selectors for functions, classes,
+  single-declarator variables, multi-declarator variables, and anonymous
+  top-level statements.
+- Verify each generated selector through the real resolver.
+
+### Milestone 2: Minimization and Grouping
+
+- Add hole relaxation for expressions, arguments, object properties,
+  declarators, class bodies, and statement lists.
+- Collapse repeated member selectors into `binding_groups`, preserving comments
+  and export names.
+- Batch multiple targets from the same declaration/context into one selector
+  when possible.
+
+### Milestone 3: Repair Reports and Patch Plans
+
+- Add keep-going JSON validation with structured selector failures.
+- Implement nearest-candidate and smallest-differentiator diagnostics.
+- Let `repair` consume diagnostics and emit/apply patch plans for mechanically
+  proven cases.
+
+### Milestone 4: Version-Port Workflow
+
+- Persist or recompute v1 source identities and fingerprints.
+- Match v1-selected entities into v2 chunks using source inventory search.
+- Apply confident selector repairs and emit residual tasks for semantic drift.
+
+### Milestone 5: New-App Bootstrap
+
+- Feed module proposals, naming output, and selector synthesis into an initial
+  spec generator.
+- Produce a reviewable spec plus confidence/debt reports for the first human
+  pass.
+
+## Success Metrics
+
+- A large existing spec can remove hundreds or thousands of fragile selectors
+  per PR, grouped by rewrite class.
+- Generated selectors are unique by construction and validated by the existing
+  resolver.
+- Manual YAML editing becomes the fallback for semantic decisions, not the
+  normal path for mechanical selector conversion.
+- Keep-going diagnostics surface the full repair backlog in one run.
+- Selector matching time is dominated by the few genuinely complex selectors,
+  not repeated reparsing or avoidable quadratic scans.
+- New downstream debundle specs start with structural selectors and an explicit
+  debt report.


### PR DESCRIPTION
## Summary

Adds an automation-first project plan for debundle spec authoring, stabilization, and version porting.

- Introduces `plans/automated_spec_workflows.md` covering new-spec bootstrap, old-spec stabilization, and v1-to-v2 repair workflows.
- Defines an orthogonal CLI model around inventory, plan, apply, validate, and explain operations.
- Adds concrete algorithm/data-structure guidance for source inventories, selector candidate indexes, minimization, repair search, patch plans, caching, and expected complexity.
- Reprioritizes `TODO.md` around minimal selector synthesis, shared source indexing, patch-plan bulk codemods, keep-going diagnostics, repair, and workflow latency budgets.
- Trims completed/shipped selector-planning history from active TODOs and reframes tracking docs so detailed evidence lives in the right backlog.

## Validation

- `nix develop -c pre-commit run --files devinfra/js/debundle/ARCHITECTURE_BACKLOG.md devinfra/js/debundle/CLI_DOGFOOD.md devinfra/js/debundle/TODO.md devinfra/js/debundle/plans/automated_spec_workflows.md devinfra/js/debundle/perf/source_match_selector_profile.md devinfra/js/debundle/cli/mod.rs devinfra/js/debundle/docs/cli.md devinfra/js/debundle/e2e/selector_codemod_cli_test.rs devinfra/js/debundle/selector_codemod.rs`
- `git diff --cached --check`

Note: this PR is docs/tracking only. The overlapping selector synthesis implementation is already in #2234, so I did not include local duplicate codemod changes here.