### PR TITLE
debundle: record selector synthesis dogfood blockers

### DIFF
--- a/devinfra/js/debundle/CLI_DOGFOOD.md
+++ b/devinfra/js/debundle/CLI_DOGFOOD.md
@@ -22,6 +22,24 @@ The actual path now has a `+_repo_rules+` prefix:
 Generic usability follow-ups for the top-level planner commands.
 Corpus-specific paths and owner ids belong in the consuming repo.
 
+- **Selector synthesis filters apply too late.** A downstream large-spec
+  dogfood run of `debundle spec synthesize-selectors --rewrite
+name-binding-to-source-match` showed that even one explicit
+  `--item module:export` scanned every module file and member in the spec:
+  `files_scanned=1745`, `modules_scanned=1745`, `members_scanned=6692`,
+  `name_binding_members=1`, `elapsed=3.43s`. Scoped `--module-prefix` dry runs
+  timed out at 30s CPU-bound. Explicit item batches were useful but still paid
+  full-scan cost: top-100 items took 16.37s for 75 candidate changes; top-200
+  took 31.38s for 157 candidate changes. Apply item/file/module filters before
+  full YAML traversal and before source candidate generation where possible.
+- **Selector synthesis apply emits non-reviewable YAML churn.** The same
+  downstream dogfood run applied a top-100 item batch with 75 changed
+  candidates. Selector correctness looked promising, but the YAML application
+  path rewrote unrelated text: 13 files changed with 7331 insertions and 4273
+  deletions, one large module accounted for most churn, and an unrelated
+  top-level comment was dropped. Source-aware selector synthesis needs a
+  text-preserving patch path for member selector replacement and
+  binding-group/member collapse before broad generated patches are reviewable.
 - **Orthogonal patch-plan workflow.** New spec automation should converge on
   the inventory/plan/apply/validate/explain model in
   <plans/automated_spec_workflows.md>. A dry-run that proposes edits should be

--- a/devinfra/js/debundle/perf/source_match_selector_profile.md
+++ b/devinfra/js/debundle/perf/source_match_selector_profile.md
@@ -165,3 +165,31 @@ Keep-going miss diagnostics can also do repeated nearest-candidate scans
 for selectors that truly miss. This PR targets the observed slow
 ambiguity path; miss-diagnostic caching/indexing should be handled as a
 follow-up if a profile shows `source_match_no_match_hint` dominating.
+
+### Selector Synthesis Dogfood: Filter Latency
+
+A downstream large-spec run of `debundle spec synthesize-selectors --rewrite
+name-binding-to-source-match` on a single 6.9 MiB / 204k-line chunk showed the
+next performance blocker is command-level filtering and plan application, not
+only the inner declaration-hole matcher. No private source text is reproduced
+here.
+
+Observed timings from an optimized merged binary:
+
+| Scope                    | Elapsed | Candidate changes | Notes                                       |
+| ------------------------ | ------: | ----------------: | ------------------------------------------- |
+| one explicit `--item`    |   3.43s |                 0 | still scanned 1745 files / 6692 members     |
+| `--module-prefix` subset |    >30s |                 - | timed out CPU-bound before producing output |
+| top-100 explicit items   |  16.37s |                75 | still scanned 1745 files / 6692 members     |
+| top-200 explicit items   |  31.38s |               157 | still scanned 1745 files / 6692 members     |
+
+The source-aware selector synthesis path is productive, but broad dogfood is
+blocked until item/file/module filters prune YAML traversal and candidate
+generation earlier. The acceptance target for this workload is:
+
+- one explicit `--item` should be close to source parse + one module file scan,
+  not a full spec scan;
+- top-100 explicit items should stay within the interactive budget on warmed
+  inputs, ideally under 10s;
+- broad runs should stream progress or declare themselves offline/profile mode
+  if they cannot meet the budget.


### PR DESCRIPTION
## Summary

- record downstream selector-synthesis dogfood measurements showing late filtering costs
- record the current YAML-apply churn blocker that makes broad generated patches hard to review
- keep examples generic: this documents metrics and workflow gaps without embedding downstream source snippets

## Validation

- `git diff --check`
- `nix develop -c pre-commit run --files devinfra/js/debundle/CLI_DOGFOOD.md devinfra/js/debundle/perf/source_match_selector_profile.md`