### PR TITLE
[codex] Prune selector synthesis scans

### DIFF
--- a/devinfra/js/debundle/e2e/selector_codemod_cli_test.rs
+++ b/devinfra/js/debundle/e2e/selector_codemod_cli_test.rs
@@ -218,6 +218,19 @@ export { runtimePrimary, runtimeSecondary, runtimeFormatter };
         name: runtimeFormatter
 "#,
     );
+    write(
+        &modules.join("ignored/noisy.yaml"),
+        r#"members:
+  - name: NoisyOne
+    selector:
+      binding:
+        name: noisyOne
+  - name: NoisyTwo
+    selector:
+      binding:
+        name: noisyTwo
+"#,
+    );
     (modules, source)
 }
 
@@ -275,7 +288,9 @@ fn dry_run_reports_single_binding_rewrite_without_writing() {
     assert_eq!(parsed["action"], "dry_run", "{parsed}");
     assert_eq!(parsed["rewrite"], "single_target_binding", "{parsed}");
     assert_eq!(parsed["summary"]["dry_run"], true, "{parsed}");
+    assert_eq!(parsed["summary"]["files_scanned"], 1, "{parsed}");
     assert_eq!(parsed["summary"]["modules_scanned"], 1, "{parsed}");
+    assert_eq!(parsed["summary"]["members_scanned"], 3, "{parsed}");
     assert_eq!(parsed["summary"]["source_match_members"], 3, "{parsed}");
     assert_eq!(parsed["summary"]["changed_candidates"], 1, "{parsed}");
     assert_eq!(parsed["summary"]["skipped_candidates"], 2, "{parsed}");
@@ -393,6 +408,9 @@ fn synthesize_selectors_dry_run_reports_grouped_unique_evidence() {
         "{parsed}"
     );
     assert_eq!(parsed["action"], "dry_run", "{parsed}");
+    assert_eq!(parsed["summary"]["files_scanned"], 1, "{parsed}");
+    assert_eq!(parsed["summary"]["modules_scanned"], 1, "{parsed}");
+    assert_eq!(parsed["summary"]["members_scanned"], 2, "{parsed}");
     assert_eq!(parsed["summary"]["name_binding_members"], 2, "{parsed}");
     assert_eq!(parsed["summary"]["synthesized_groups"], 1, "{parsed}");
     assert_eq!(parsed["summary"]["changed_candidates"], 2, "{parsed}");
@@ -437,6 +455,41 @@ fn synthesize_selectors_command_alias_uses_name_binding_rewrite() {
     );
     assert_eq!(parsed["summary"]["changed_candidates"], 1, "{parsed}");
     assert_eq!(parsed["candidates"][0]["target_binding"], "FormatValue");
+    assert_eq!(parsed["summary"]["files_scanned"], 1, "{parsed}");
+    assert_eq!(parsed["summary"]["modules_scanned"], 1, "{parsed}");
+    assert_eq!(parsed["summary"]["members_scanned"], 3, "{parsed}");
+}
+
+#[test]
+fn synthesize_selectors_module_prefix_limits_file_scan() {
+    let dir = tempfile::tempdir().unwrap();
+    let (modules, source) = synthesis_fixture(dir.path());
+
+    let out = run_synthesize_selectors(
+        &modules,
+        &[
+            "--source-file",
+            source.to_str().unwrap(),
+            "--module-prefix",
+            "app",
+            "--format",
+            "json",
+        ],
+    );
+    let parsed = parse_stdout_json(&out);
+    assert_eq!(parsed["summary"]["files_scanned"], 1, "{parsed}");
+    assert_eq!(parsed["summary"]["modules_scanned"], 1, "{parsed}");
+    assert_eq!(parsed["summary"]["members_scanned"], 3, "{parsed}");
+    assert_eq!(parsed["summary"]["name_binding_members"], 3, "{parsed}");
+    assert_eq!(parsed["summary"]["changed_candidates"], 3, "{parsed}");
+    assert!(
+        parsed["candidates"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|candidate| candidate["module"] == "app/config"),
+        "{parsed}"
+    );
 }
 
 #[test]
@@ -522,6 +575,8 @@ fn apply_adds_target_binding_and_honors_module_prefix_filter() {
     let parsed = parse_stdout_json(&out);
     assert_eq!(parsed["action"], "applied", "{parsed}");
     assert_eq!(parsed["summary"]["dry_run"], false, "{parsed}");
+    assert_eq!(parsed["summary"]["files_scanned"], 1, "{parsed}");
+    assert_eq!(parsed["summary"]["modules_scanned"], 1, "{parsed}");
     assert_eq!(parsed["summary"]["changed_candidates"], 1, "{parsed}");
     assert_eq!(
         parsed["summary"]["files_written"].as_array().unwrap().len(),
@@ -569,6 +624,8 @@ fn apply_single_target_binding_preserves_comments_and_local_text() {
         ],
     );
     let parsed = parse_stdout_json(&out);
+    assert_eq!(parsed["summary"]["files_scanned"], 1, "{parsed}");
+    assert_eq!(parsed["summary"]["modules_scanned"], 1, "{parsed}");
     assert_eq!(parsed["summary"]["changed_candidates"], 1, "{parsed}");
     assert_eq!(parsed["summary"]["skipped_candidates"], 1, "{parsed}");
 

--- a/devinfra/js/debundle/selector_codemod.rs
+++ b/devinfra/js/debundle/selector_codemod.rs
@@ -18,7 +18,7 @@ use anyhow::{Context, Result, bail};
 use serde::Serialize;
 use serde_yaml::Value;
 use spec::{SourceMatch, SourceMatchIdentifierMode};
-use spec_modules::{collect_module_files, module_path_from_file};
+use spec_modules::{collect_module_files, is_module_yaml, module_path_from_file};
 use swc_common::{BytePos, Span, Spanned};
 use swc_ecma_ast::*;
 use swc_ecma_visit::{Visit, VisitWith};
@@ -120,22 +120,28 @@ pub fn run_selector_codemod(config: &SelectorCodemodConfig) -> Result<SelectorCo
 }
 
 fn run_selector_codemod_impl(config: &SelectorCodemodConfig) -> Result<SelectorCodemodReport> {
-    let synthesis_index = (config.rewrite == SelectorCodemodRewrite::NameBindingToSourceMatch)
-        .then(|| load_synthesis_index(config))
-        .transpose()?;
     let selected_items = config
         .items
         .iter()
         .map(|item| parse_synthesis_item(item))
         .collect::<Result<BTreeSet<_>>>()?;
-    let files = collect_module_files(&config.modules_root)
-        .with_context(|| format!("walking {}", config.modules_root.display()))?;
+    let selected_item_exports = selected_item_exports_by_module(&selected_items);
     let selected_files = config
         .files
         .iter()
         .map(|path| resolve_file_filter(&config.modules_root, path))
         .collect::<BTreeSet<_>>();
     let selected_modules = config.modules.iter().cloned().collect::<BTreeSet<_>>();
+    let files = collect_candidate_module_files(
+        config,
+        &selected_files,
+        &selected_modules,
+        &selected_item_exports,
+    )
+    .with_context(|| format!("selecting files under {}", config.modules_root.display()))?;
+    let synthesis_index = (config.rewrite == SelectorCodemodRewrite::NameBindingToSourceMatch)
+        .then(|| load_synthesis_index(config))
+        .transpose()?;
 
     let mut candidates = Vec::new();
     let mut summary = SelectorCodemodSummary {
@@ -173,6 +179,10 @@ fn run_selector_codemod_impl(config: &SelectorCodemodConfig) -> Result<SelectorC
             continue;
         };
         if config.rewrite == SelectorCodemodRewrite::NameBindingToSourceMatch {
+            let selected_exports = selected_item_exports.get(&module);
+            if !selected_item_exports.is_empty() && selected_exports.is_none() {
+                continue;
+            }
             let outcomes = rewrite_name_bindings_to_source_match(
                 &module,
                 &file,
@@ -180,15 +190,12 @@ fn run_selector_codemod_impl(config: &SelectorCodemodConfig) -> Result<SelectorC
                 synthesis_index
                     .as_ref()
                     .expect("source-aware rewrite loaded synthesis index"),
-                &selected_items,
+                selected_exports,
                 &original_text,
                 config.apply,
             )?;
             text_edits.extend(outcomes.text_edits);
-            summary.members_scanned += root
-                .get(yk("members"))
-                .and_then(Value::as_sequence)
-                .map_or(0, Vec::len);
+            summary.members_scanned += outcomes.members_scanned;
             summary.name_binding_members += outcomes.members_seen;
             summary.synthesized_groups += outcomes.groups_changed;
             for candidate in outcomes.candidates {
@@ -554,6 +561,7 @@ struct SynthesisItem {
 #[derive(Debug)]
 struct NameBindingRewriteOutcomes {
     candidates: Vec<SelectorCodemodCandidate>,
+    members_scanned: usize,
     members_seen: usize,
     groups_changed: usize,
     text_edits: Vec<TextEdit>,
@@ -624,13 +632,14 @@ fn rewrite_name_bindings_to_source_match(
     file: &Path,
     root: &mut serde_yaml::Mapping,
     index: &ChunkSelectorIndex,
-    selected_items: &BTreeSet<SynthesisItem>,
+    selected_exports: Option<&BTreeSet<String>>,
     source_text: &str,
     apply: bool,
 ) -> Result<NameBindingRewriteOutcomes> {
     let Some(Value::Sequence(members)) = root.get_mut(yk("members")) else {
         return Ok(NameBindingRewriteOutcomes {
             candidates: Vec::new(),
+            members_scanned: 0,
             members_seen: 0,
             groups_changed: 0,
             text_edits: Vec::new(),
@@ -638,20 +647,26 @@ fn rewrite_name_bindings_to_source_match(
     };
     let mut candidates = Vec::new();
     let mut grouped: BTreeMap<usize, Vec<NameBindingMember>> = BTreeMap::new();
+    let mut remaining_exports = selected_exports.cloned();
+    let mut members_scanned = 0;
     let mut members_seen = 0;
 
     for (member_index, member) in members.iter().enumerate() {
+        if remaining_exports.as_ref().is_some_and(BTreeSet::is_empty) {
+            break;
+        }
+        members_scanned += 1;
         let export_name = mapping_get(member, "name").and_then(value_as_string);
         let Some(export_name) = export_name else {
             continue;
         };
-        if !selected_items.is_empty()
-            && !selected_items.contains(&SynthesisItem {
-                module: module.to_string(),
-                export_name: export_name.clone(),
-            })
-        {
-            continue;
+        if let Some(selected_exports) = selected_exports {
+            if !selected_exports.contains(&export_name) {
+                continue;
+            }
+            if let Some(remaining_exports) = &mut remaining_exports {
+                remaining_exports.remove(&export_name);
+            }
         }
         let Some(binding_name) =
             mapping_get_path(member, &["selector", "binding", "name"]).and_then(value_as_string)
@@ -793,6 +808,7 @@ fn rewrite_name_bindings_to_source_match(
 
     Ok(NameBindingRewriteOutcomes {
         candidates,
+        members_scanned,
         members_seen,
         groups_changed,
         text_edits,
@@ -828,6 +844,95 @@ fn parse_synthesis_item(raw: &str) -> Result<SynthesisItem> {
         module: module.to_string(),
         export_name: export_name.to_string(),
     })
+}
+
+fn selected_item_exports_by_module(
+    selected_items: &BTreeSet<SynthesisItem>,
+) -> BTreeMap<String, BTreeSet<String>> {
+    let mut by_module: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for item in selected_items {
+        by_module
+            .entry(item.module.clone())
+            .or_default()
+            .insert(item.export_name.clone());
+    }
+    by_module
+}
+
+fn collect_candidate_module_files(
+    config: &SelectorCodemodConfig,
+    selected_files: &BTreeSet<PathBuf>,
+    selected_modules: &BTreeSet<String>,
+    selected_item_exports: &BTreeMap<String, BTreeSet<String>>,
+) -> Result<Vec<PathBuf>> {
+    let has_explicit_module_filters = !selected_files.is_empty()
+        || !selected_modules.is_empty()
+        || !config.module_prefixes.is_empty();
+    if !has_explicit_module_filters && selected_item_exports.is_empty() {
+        return collect_module_files(&config.modules_root);
+    }
+
+    let mut candidates = BTreeSet::new();
+    for file in selected_files {
+        add_existing_module_file(&mut candidates, file);
+    }
+    for module in selected_modules {
+        add_existing_module_file(
+            &mut candidates,
+            &module_file_path(&config.modules_root, module),
+        );
+    }
+    for module in selected_item_exports.keys() {
+        add_existing_module_file(
+            &mut candidates,
+            &module_file_path(&config.modules_root, module),
+        );
+    }
+    if selected_item_exports.is_empty() {
+        for prefix in &config.module_prefixes {
+            add_module_prefix_files(&mut candidates, &config.modules_root, prefix)?;
+        }
+    }
+
+    Ok(candidates
+        .into_iter()
+        .filter(|file| {
+            let module = module_path_from_file(file, &config.modules_root);
+            module_selected(
+                file,
+                &module,
+                selected_files,
+                selected_modules,
+                &config.module_prefixes,
+            ) && (selected_item_exports.is_empty() || selected_item_exports.contains_key(&module))
+        })
+        .collect())
+}
+
+fn module_file_path(modules_root: &Path, module: &str) -> PathBuf {
+    modules_root.join(format!("{module}.yaml"))
+}
+
+fn add_existing_module_file(candidates: &mut BTreeSet<PathBuf>, path: &Path) {
+    if path.is_file() && is_module_yaml(path) {
+        candidates.insert(path.to_path_buf());
+    }
+}
+
+fn add_module_prefix_files(
+    candidates: &mut BTreeSet<PathBuf>,
+    modules_root: &Path,
+    prefix: &str,
+) -> Result<()> {
+    if prefix.is_empty() {
+        return Ok(());
+    }
+    add_existing_module_file(candidates, &module_file_path(modules_root, prefix));
+    let dir = modules_root.join(prefix);
+    if dir.is_dir() {
+        candidates.extend(collect_module_files(&dir)?);
+    }
+    Ok(())
 }
 
 impl ChunkSelectorIndex {
@@ -947,7 +1052,53 @@ fn synthesize_simplest_selector_for_group(
     };
 
     let mut candidate_count = None;
-    for target in &targets {
+    if targets.len() > 1 {
+        let selector = SourceMatch {
+            match_source: match_source.clone(),
+            identifiers: SourceMatchIdentifierMode::AlphaAll,
+            target_binding: None,
+            target_statement: None,
+            target_statements: None,
+            wildcard_string_literals: BTreeSet::new(),
+        }
+        .selector();
+        let exports_by_target = targets
+            .iter()
+            .map(|target| (target.export_name.clone(), target.export_name.clone()))
+            .collect::<BTreeMap<_, _>>();
+        let matched = source_match::resolve_member_binding_group_match(
+            &index.parsed.module,
+            "<selector synthesis>",
+            &selector,
+            &exports_by_target,
+        )?;
+        if matched.body_idx != decl.body_idx {
+            bail!(
+                "synthesized selector matched body index {} instead of intended {}",
+                matched.body_idx,
+                decl.body_idx
+            );
+        }
+        for target in &targets {
+            let binding = matched.bindings.get(&target.export_name).with_context(|| {
+                format!(
+                    "synthesized selector target `{}` did not resolve a binding",
+                    target.export_name
+                )
+            })?;
+            if binding.binding_name != target.runtime_binding {
+                bail!(
+                    "synthesized selector target `{}` resolved `{}` instead of intended `{}`",
+                    target.export_name,
+                    binding.binding_name,
+                    target.runtime_binding
+                );
+            }
+        }
+        candidate_count = Some(1);
+    }
+
+    if let [target] = targets.as_slice() {
         let source_match = SourceMatch {
             match_source: match_source.clone(),
             identifiers: SourceMatchIdentifierMode::AlphaAll,
@@ -957,47 +1108,38 @@ fn synthesize_simplest_selector_for_group(
             wildcard_string_literals: BTreeSet::new(),
         };
         let selector = source_match.selector();
-        let body_debt = source_match::source_match_body_debt(
+        let matches = source_match::member_binding_candidate_matches(
             &index.parsed.module,
             "<selector synthesis>",
             &selector,
-            0,
-            0,
         )?;
-        let groups = body_debt.exact_groups;
-        let current_count = groups.len();
+        let current_count = matches.len();
         if candidate_count
             .replace(current_count)
             .is_some_and(|prior| prior != current_count)
         {
             bail!("selector candidate count changed across target bindings");
         }
-        let [single_group] = groups.as_slice() else {
+        let [candidate] = matches.as_slice() else {
             bail!("synthesized selector matched {current_count} candidate declaration groups");
         };
-        if !single_group.contains(&Some(decl.body_idx)) {
-            bail!("synthesized selector matched a different declaration group: {single_group:?}");
-        }
-        let candidates = source_match::member_binding_candidates(
-            &index.parsed.module,
-            "<selector synthesis>",
-            &selector,
-        )?;
-        let [candidate] = candidates.as_slice() else {
+        if candidate.body_idx != decl.body_idx {
             bail!(
-                "synthesized selector target `{}` resolved to {} candidate binding(s)",
-                target.export_name,
-                candidates.len()
+                "synthesized selector matched body index {} instead of intended {}",
+                candidate.body_idx,
+                decl.body_idx
             );
         };
-        if candidate.binding_name != target.runtime_binding {
+        if candidate.binding.binding_name != target.runtime_binding {
             bail!(
                 "synthesized selector target `{}` resolved `{}` instead of intended `{}`",
                 target.export_name,
-                candidate.binding_name,
+                candidate.binding.binding_name,
                 target.runtime_binding
             );
         }
+    } else if targets.is_empty() {
+        bail!("selector synthesis group has no targets");
     }
 
     Ok(SynthesizedSelectorGroup {

--- a/devinfra/js/debundle/source_match.rs
+++ b/devinfra/js/debundle/source_match.rs
@@ -515,9 +515,15 @@ pub struct SourceMatchBodyDebt {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
-struct MemberBindingMatch {
-    body_idx: usize,
-    binding: ResolvedMemberBinding,
+pub struct MemberBindingMatch {
+    pub body_idx: usize,
+    pub binding: ResolvedMemberBinding,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ResolvedMemberBindingGroup {
+    pub body_idx: usize,
+    pub bindings: BTreeMap<String, ResolvedMemberBinding>,
 }
 
 pub fn source_match_declared_binding_names(
@@ -690,7 +696,20 @@ pub fn member_binding_candidates(
     request_id: &str,
     selector: &AnonymousStatementSelector,
 ) -> Result<Vec<ResolvedMemberBinding>> {
-    let matches = trace_source_match(
+    Ok(
+        member_binding_candidate_matches(runtime_module, request_id, selector)?
+            .into_iter()
+            .map(|matched| matched.binding)
+            .collect(),
+    )
+}
+
+pub fn member_binding_candidate_matches(
+    runtime_module: &Module,
+    request_id: &str,
+    selector: &AnonymousStatementSelector,
+) -> Result<Vec<MemberBindingMatch>> {
+    trace_source_match(
         "members[].selector.source_match candidates",
         request_id,
         selector,
@@ -707,8 +726,7 @@ pub fn member_binding_candidates(
                 )
             )
         },
-    )?;
-    Ok(matches.into_iter().map(|matched| matched.binding).collect())
+    )
 }
 
 pub fn resolve_anonymous_statement_body_index(
@@ -972,6 +990,23 @@ pub fn resolve_member_binding_group(
     selector: &AnonymousStatementSelector,
     exports_by_target: &BTreeMap<String, String>,
 ) -> Result<BTreeMap<String, ResolvedMemberBinding>> {
+    Ok(
+        resolve_member_binding_group_match(
+            runtime_module,
+            request_id,
+            selector,
+            exports_by_target,
+        )?
+        .bindings,
+    )
+}
+
+pub fn resolve_member_binding_group_match(
+    runtime_module: &Module,
+    request_id: &str,
+    selector: &AnonymousStatementSelector,
+    exports_by_target: &BTreeMap<String, String>,
+) -> Result<ResolvedMemberBindingGroup> {
     trace_source_match(
         "binding_groups[].source_match",
         request_id,
@@ -987,9 +1022,10 @@ pub fn resolve_member_binding_group(
         |resolved| {
             format!(
                 "targets={} bindings={}",
-                resolved.len(),
+                resolved.bindings.len(),
                 render_timing_names(
                     resolved
+                        .bindings
                         .values()
                         .map(|matched| matched.binding_name.as_str())
                 )
@@ -1003,7 +1039,7 @@ fn resolve_member_binding_group_impl(
     request_id: &str,
     selector: &AnonymousStatementSelector,
     exports_by_target: &BTreeMap<String, String>,
-) -> Result<BTreeMap<String, ResolvedMemberBinding>> {
+) -> Result<ResolvedMemberBindingGroup> {
     if selector.target_binding.is_some() {
         bail!(
             "logical_module {request_id}: binding group resolver received a selector with \
@@ -1031,15 +1067,36 @@ fn resolve_member_binding_group_impl(
     }
     if parsed.body.len() == 1 && selector_single_var_declarator(&parsed.body[0]).is_some() {
         let mut resolved = BTreeMap::new();
+        let mut matched_body_idx = None;
         for (target_binding, export_name) in exports_by_target {
             let mut selector = selector.clone();
             selector.target_binding = Some(target_binding.clone());
-            resolved.insert(
-                target_binding.clone(),
-                resolve_member_binding(runtime_module, request_id, export_name, &selector)?,
-            );
+            let matches = member_binding_candidate_matches(runtime_module, request_id, &selector)?;
+            let [matched] = matches.as_slice() else {
+                bail!(
+                    "logical_module {request_id}: binding_groups[].source_match target_binding \
+                     `{target_binding}` for export `{export_name}` resolved to {} candidate \
+                     binding(s). Refine the selector. Source:\n{match_source}",
+                    matches.len(),
+                    match_source = selector.match_source,
+                );
+            };
+            if matched_body_idx
+                .replace(matched.body_idx)
+                .is_some_and(|prior| prior != matched.body_idx)
+            {
+                bail!(
+                    "logical_module {request_id}: binding_groups[].source_match targets \
+                     resolved to different body indices. Refine the selector. Source:\n{match_source}",
+                    match_source = selector.match_source,
+                );
+            }
+            resolved.insert(target_binding.clone(), matched.binding.clone());
         }
-        return Ok(resolved);
+        return Ok(ResolvedMemberBindingGroup {
+            body_idx: matched_body_idx.unwrap_or(0),
+            bindings: resolved,
+        });
     }
     if parsed.body.len() == 1 && selector_var_decl_has_declarator_holes(&parsed.body[0]) {
         return resolve_member_binding_group_with_declarator_holes(
@@ -1118,7 +1175,10 @@ fn resolve_member_binding_group_impl(
         };
         resolved.insert(target_binding, binding.clone());
     }
-    Ok(resolved)
+    Ok(ResolvedMemberBindingGroup {
+        body_idx: alignment.iter().flatten().copied().next().unwrap_or(0),
+        bindings: resolved,
+    })
 }
 
 fn selector_binding_location(
@@ -1528,7 +1588,7 @@ fn resolve_member_binding_group_with_declarator_holes(
     needle: &ModuleItem,
     selector: &AnonymousStatementSelector,
     exports_by_target: &BTreeMap<String, String>,
-) -> Result<BTreeMap<String, ResolvedMemberBinding>> {
+) -> Result<ResolvedMemberBindingGroup> {
     let needle_var =
         item_var_decl(needle).expect("caller checked selector_var_decl_has_declarator_holes");
     let target_locations = exports_by_target
@@ -1595,7 +1655,10 @@ fn resolve_member_binding_group_with_declarator_holes(
         matches.push((body_idx, resolved));
     }
     match matches.as_slice() {
-        [(_, resolved)] => Ok(resolved.clone()),
+        [(body_idx, resolved)] => Ok(ResolvedMemberBindingGroup {
+            body_idx: *body_idx,
+            bindings: resolved.clone(),
+        }),
         [] => {
             let target_hint = exports_by_target
                 .iter()


### PR DESCRIPTION
## Summary

Fix `debundle spec synthesize-selectors` / source-aware selector codemod filtering so explicit filters are applied before broad module traversal and before unnecessary candidate work.

Root cause: source-aware synthesis collected every module YAML up front, then applied `--item` inside the per-file member loop. That made a single `--item module:export` dry run still report the whole spec in `files_scanned` / `members_scanned`. Synthesis also used `source_match_body_debt(..., 0, 0)` just to prove exact matches, which paid unlimited near-miss scoring, and multi-target groups verified one target at a time.

Changes:

- Build a candidate module-file set from `--file`, `--module`, `--module-prefix`, and item-derived modules before reading YAML files.
- For `--item` synthesis, visit only matching modules and count members actually inspected; stop early once all requested exports in that module have been found.
- Expose source-match candidate matches with body indices and a grouped binding resolver result, then use those in synthesis to avoid selector-debt near-miss scoring and to verify multi-target var groups in one matcher pass.
- Add synthetic e2e assertions that item/file/module-prefix filtered runs do not scan unrelated fixture module files/members.

## Validation

- `nix develop -c bazelisk test //devinfra/js/debundle:source_match_test //devinfra/js/debundle/e2e:selector_codemod_cli_test`
- `nix develop -c pre-commit run --files devinfra/js/debundle/source_match.rs devinfra/js/debundle/selector_codemod.rs devinfra/js/debundle/e2e/selector_codemod_cli_test.rs`

Dogfood timing on clean gaffer-private old spec `528778fff` using the patched binary, JSON dry runs only:

- Single item `app/bootstrap/initBundle:FeatureFlag`: `2.34s`, `files_scanned=1`, `modules_scanned=1`, `members_scanned=128`, `name_binding_members=1`.
- 263 explicit `--item app/bootstrap/initBundle:*` batch: `9.51s`, `files_scanned=1`, `modules_scanned=1`, `members_scanned=697`, `name_binding_members=263`.
- Broad `--module-prefix app/bootstrap`: `24.66s`, `files_scanned=31`, `modules_scanned=31`, `members_scanned=791`, `name_binding_members=730`; this no longer scans the whole spec or times out at 30s, but it remains above the <10s budget for broad no-item prefix runs on that large module set.