### PR TITLE
[codex] Avoid whitespace-only selector YAML lines

### DIFF
--- a/devinfra/js/debundle/e2e/selector_codemod_cli_test.rs
+++ b/devinfra/js/debundle/e2e/selector_codemod_cli_test.rs
@@ -226,7 +226,9 @@ fn synthesis_single_member_text_fixture(root: &Path) -> (PathBuf, PathBuf) {
     write(
         &source,
         r#"function runtimeFormatter(value) {
-  return value.trim().toUpperCase();
+  const trimmed = value.trim();
+
+  return trimmed.toUpperCase();
 }
 function untouchedBinding() {
   return "still name-only";
@@ -358,12 +360,18 @@ members:
         target_binding: FormatValue
         match: |-
           function FormatValue(value) {
-            return value.trim().toUpperCase();
+            const trimmed = value.trim();
+
+            return trimmed.toUpperCase();
           }
 anonymous_statements:
   - match: |
       initializeRuntime();
 "#
+    );
+    assert!(
+        rewritten.lines().all(|line| !line.ends_with(' ')),
+        "rewritten YAML contains trailing whitespace:\n{rewritten}"
     );
 }
 

--- a/devinfra/js/debundle/selector_codemod.rs
+++ b/devinfra/js/debundle/selector_codemod.rs
@@ -1679,8 +1679,10 @@ fn render_yaml_sequence_items(items: &[Value], indent: &str) -> Result<String> {
 
 fn push_literal_block(out: &mut String, text: &str, indent: &str) {
     for line in text.split('\n') {
-        out.push_str(indent);
-        out.push_str(line);
+        if !line.is_empty() {
+            out.push_str(indent);
+            out.push_str(line);
+        }
         out.push('\n');
     }
 }


### PR DESCRIPTION
## Summary

- Avoid emitting indentation-only lines when selector-codemod renders synthesized `source_match.match` literal blocks.
- Extend the generic selector-synthesis apply fixture with a blank line inside the synthesized function body.
- Assert the rewritten generic YAML has no trailing-space lines.

## Root Cause

#2237's text-preserving apply path rendered each literal-block source line by writing the YAML indentation and then the line contents. For blank source lines, that produced a YAML line containing only indentation spaces. The YAML parsed correctly, but `git diff --check` reported trailing whitespace in downstream dogfood output.

## Validation

- `nix develop -c rustfmt devinfra/js/debundle/selector_codemod.rs devinfra/js/debundle/e2e/selector_codemod_cli_test.rs`
- `git diff --check`
- `nix develop -c bbr test //devinfra/js/debundle/e2e:selector_codemod_cli_test`
- `env SKIP=no-commit-to-branch nix develop -c pre-commit run --files devinfra/js/debundle/selector_codemod.rs devinfra/js/debundle/e2e/selector_codemod_cli_test.rs`
- commit hook under `nix develop -c git commit ...` passed