### PR TITLE
[codex] Trim selector synthesis source whitespace

### DIFF
--- a/devinfra/js/debundle/e2e/selector_codemod_cli_test.rs
+++ b/devinfra/js/debundle/e2e/selector_codemod_cli_test.rs
@@ -26,6 +26,14 @@ fn write(path: &Path, body: &str) {
     fs::write(path, body).unwrap();
 }
 
+fn assert_no_trailing_whitespace(text: &str) {
+    assert!(
+        text.lines()
+            .all(|line| !line.ends_with(' ') && !line.ends_with('\t')),
+        "rewritten YAML contains trailing whitespace:\n{text}"
+    );
+}
+
 fn run_codemod(modules: &Path, extra: &[&str]) -> std::process::Output {
     let mut args = vec![
         "spec",
@@ -179,23 +187,24 @@ fn synthesis_fixture(root: &Path) -> (PathBuf, PathBuf) {
     let source = root.join("chunks/app.js");
     write(
         &source,
-        r#"const beforeConfig = helper("before"),
-  runtimePrimary = buildConfig({ stable: "primary", generated: "ignore-a" }),
-  middleConfig = helper("middle"),
-  runtimeSecondary = buildConfig({ stable: "secondary", generated: "ignore-b" }),
-  afterConfig = helper("after");
-function runtimeFormatter(value) {
-  return value.trim().toUpperCase();
-}
-function helper(value) {
-  return value;
-}
-function buildConfig(value) {
-  return value;
-}
-console.log(runtimePrimary, runtimeSecondary, runtimeFormatter(" ok "));
-export { runtimePrimary, runtimeSecondary, runtimeFormatter };
-"#,
+        concat!(
+            "const beforeConfig = helper(\"before\"),\n",
+            "  runtimePrimary = buildConfig({ stable: \"primary\", generated: \"ignore-a\" }),  \n",
+            "  middleConfig = helper(\"middle\"),\n",
+            "  runtimeSecondary = buildConfig({ stable: \"secondary\", generated: \"ignore-b\" }),\t\n",
+            "  afterConfig = helper(\"after\");\n",
+            "function runtimeFormatter(value) {\n",
+            "  return value.trim().toUpperCase();\n",
+            "}\n",
+            "function helper(value) {\n",
+            "  return value;\n",
+            "}\n",
+            "function buildConfig(value) {\n",
+            "  return value;\n",
+            "}\n",
+            "console.log(runtimePrimary, runtimeSecondary, runtimeFormatter(\" ok \"));\n",
+            "export { runtimePrimary, runtimeSecondary, runtimeFormatter };\n",
+        ),
     );
     let modules = root.join("modules");
     let module = modules.join("app/config.yaml");
@@ -238,16 +247,17 @@ fn synthesis_single_member_text_fixture(root: &Path) -> (PathBuf, PathBuf) {
     let source = root.join("chunks/app.js");
     write(
         &source,
-        r#"function runtimeFormatter(value) {
-  const trimmed = value.trim();
-
-  return trimmed.toUpperCase();
-}
-function untouchedBinding() {
-  return "still name-only";
-}
-export { runtimeFormatter, untouchedBinding };
-"#,
+        concat!(
+            "function runtimeFormatter(value) {\n",
+            "  const trimmed = value.trim();  \n",
+            "  \t\n",
+            "  return trimmed.toUpperCase(); \t\n",
+            "}\n",
+            "function untouchedBinding() {\n",
+            "  return \"still name-only\";\n",
+            "}\n",
+            "export { runtimeFormatter, untouchedBinding };\n",
+        ),
     );
     let modules = root.join("modules");
     let module = modules.join("app/bootstrap.yaml");
@@ -384,10 +394,7 @@ anonymous_statements:
       initializeRuntime();
 "#
     );
-    assert!(
-        rewritten.lines().all(|line| !line.ends_with(' ')),
-        "rewritten YAML contains trailing whitespace:\n{rewritten}"
-    );
+    assert_no_trailing_whitespace(&rewritten);
 }
 
 #[test]
@@ -528,8 +535,9 @@ fn synthesize_selectors_apply_groups_multideclarator_and_preserves_comments() {
     assert_eq!(parsed["summary"]["changed_candidates"], 3, "{parsed}");
 
     let module = modules.join("app/config.yaml");
-    let doc: serde_yaml::Value =
-        serde_yaml::from_str(&fs::read_to_string(module).unwrap()).unwrap();
+    let rewritten = fs::read_to_string(module).unwrap();
+    assert_no_trailing_whitespace(&rewritten);
+    let doc: serde_yaml::Value = serde_yaml::from_str(&rewritten).unwrap();
     let members = doc["members"].as_sequence().unwrap();
     assert_eq!(members.len(), 1, "{doc:?}");
     assert_eq!(members[0]["name"], "FormatValue");

--- a/devinfra/js/debundle/selector_codemod.rs
+++ b/devinfra/js/debundle/selector_codemod.rs
@@ -1027,7 +1027,7 @@ fn synthesize_simplest_selector_for_group(
             runtime_binding: member.binding_name.clone(),
         })
         .collect::<Vec<_>>();
-    let (match_source, rewritten_holes) = match decl.kind {
+    let (mut match_source, rewritten_holes) = match decl.kind {
         IndexedDeclarationKind::Var => render_var_group_selector(index, item, decl, &targets)?,
         IndexedDeclarationKind::Function | IndexedDeclarationKind::Class => {
             let target = targets
@@ -1050,6 +1050,9 @@ fn synthesize_simplest_selector_for_group(
             bail!("unsupported declaration kind for selector synthesis")
         }
     };
+    // Normalize before proving uniqueness, so generated YAML is diff-clean
+    // while semantically significant whitespace changes still fail matching.
+    match_source = trim_selector_source_line_suffixes(&match_source);
 
     let mut candidate_count = None;
     if targets.len() > 1 {
@@ -1314,6 +1317,14 @@ fn span_offsets(index: &ChunkSelectorIndex, span: Span) -> Result<(usize, usize)
 
 fn span_item_like_semicolon(source: &str) -> bool {
     source.starts_with("const ") || source.starts_with("let ") || source.starts_with("var ")
+}
+
+fn trim_selector_source_line_suffixes(source: &str) -> String {
+    source
+        .split('\n')
+        .map(|line| line.trim_end_matches([' ', '\t']))
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 fn replace_ident_span_text(


### PR DESCRIPTION
## Summary

- Normalize trailing spaces/tabs from synthesized selector source lines before proving selector uniqueness.
- Keep semantic safety by running the production source-match proof against the normalized selector text before apply can write it.
- Extend generic selector-codemod e2e coverage with synthetic JS source lines that contain trailing spaces, tabs, and whitespace-only lines, covering both simple member replacement and grouped binding output.

## Root Cause

#2240 stopped the YAML renderer from adding indentation to truly empty source lines, but selector synthesis still copied trailing spaces/tabs from non-empty JS source lines into `source_match.match`. Those copied suffixes made generated YAML fail `git diff --check` even though the selector itself parsed and matched.

## Validation

- `git diff --check`
- `nix develop -c rustfmt devinfra/js/debundle/selector_codemod.rs devinfra/js/debundle/e2e/selector_codemod_cli_test.rs`
- `nix develop -c bbr test //devinfra/js/debundle/e2e:selector_codemod_cli_test`
- `env SKIP=no-commit-to-branch nix develop -c pre-commit run --files devinfra/js/debundle/selector_codemod.rs devinfra/js/debundle/e2e/selector_codemod_cli_test.rs`
- commit hook under `nix develop -c git commit ...` passed