### PR TITLE
[codex] Clarify debundle selector minimization guidance

### DIFF
--- a/devinfra/js/debundle/CLI_DOGFOOD.md
+++ b/devinfra/js/debundle/CLI_DOGFOOD.md
@@ -40,6 +40,14 @@ name-binding-to-source-match` showed that even one explicit
   top-level comment was dropped. Source-aware selector synthesis needs a
   text-preserving patch path for member selector replacement and
   binding-group/member collapse before broad generated patches are reviewable.
+- **Selector synthesis needs a minimization acceptance loop.** A generated
+  selector that exactly copies today's large function body, object literal,
+  argument list, or class body can match uniquely while still being fragile
+  spec debt. Dry-run/apply output should surface when a
+  candidate is long/exact and should either minimize it automatically with
+  `ANYTHING`, typed holes, `OBJECT_PROPS`, `CLASS_REST`, `STMT_LIST`, or
+  `DECLARATORS`, or emit a stable tooling-gap diagnostic that agents can route
+  instead of hand-maintaining the exact body.
 - **Orthogonal patch-plan workflow.** New spec automation should converge on
   the inventory/plan/apply/validate/explain model in
   <plans/automated_spec_workflows.md>. A dry-run that proposes edits should be

--- a/devinfra/js/debundle/docs/guide.md
+++ b/devinfra/js/debundle/docs/guide.md
@@ -255,6 +255,15 @@ literal, class body, or nested expression may be over-narrow and therefore
 fragile across the next minified-bundle version. Prefer the loosest readable
 selector that still proves uniqueness.
 
+A selector is done only when it satisfies both sides of that contract: it
+matches and claims the intended current declaration/statement, and it avoids
+pinning incidental bodies, argument lists, generated object values, or unrelated
+sibling declarations. Exact long synthesized selectors are intermediate
+evidence, not an acceptable endpoint, unless the exact source is itself the
+stable fingerprint being claimed. If a generated selector is only correct
+because it copied today's implementation body, minimize it with holes/stable
+anchors or route the shape back to Ducktape tooling before scaling the pattern.
+
 Default to this ladder when writing or repairing selectors:
 
 1. Use `selector.source_match` / `binding_groups` for the declaration,
@@ -298,8 +307,10 @@ For broad old-spec conversion passes, use an automation-first loop:
    bucket. Use `--item` for explicit export lists when available; current
    implementations prune item/module filters before scanning unrelated YAML.
 4. Apply only after the JSON summary shows a useful hit rate and bounded skip
-   reasons. After `--apply`, run `git diff --check`, the target regen/gate, and
-   another `selector-debt` summary to measure the debt delta.
+   reasons, and after spot-checking that the proposed selectors are concise
+   enough to be forward-compatible. After `--apply`, run `git diff --check`,
+   the target regen/gate, and another `selector-debt` summary to measure the
+   debt delta.
 5. Treat repeated skip reasons or oververbose generated selectors as Ducktape
    feature backlog. Do not land broad batches of exact long selectors merely
    because they pass today's uniqueness proof; add minimization tooling or a
@@ -336,6 +347,16 @@ detail whenever uniqueness is preserved. The report includes the matched
 top-level statement index, candidate count, group id, rewritten holes, files
 scanned, members scanned, and a structured skip reason for any item it cannot
 prove.
+
+Treat the generated `match:` body as a draft that still needs selector-quality
+review. Passing the production matcher only proves today's code is addressed;
+it does not prove that exact parameter destructuring, helper call arguments,
+object property values, or nested statement bodies are durable. When dry-run or
+apply output is visibly overpinned, prefer `ANYTHING`, `EXPR`, `ARGS`,
+`STMT_LIST`, `OBJECT_PROPS`, `CLASS_REST`, or `DECLARATORS` minimization where
+the matcher supports it. If the concise selector cannot be expressed yet, leave
+the binding as selector debt and record a generic minimization gap rather than
+committing a hand-maintained exact long selector.
 
 The first automated forms are intentionally narrow:
 

--- a/devinfra/js/debundle/skills/debundle_lane_worker/SKILL.md
+++ b/devinfra/js/debundle/skills/debundle_lane_worker/SKILL.md
@@ -54,10 +54,15 @@ The orchestrator or project adapter provides:
    to confirm the assigned bucket, then run
    `debundle spec synthesize-selectors` in dry-run JSON mode scoped with
    `--item`, `--module`, `--module-prefix`, or `--file`. Apply with `--apply`
-   only when the candidate count, skipped reasons, and file scope look
-   reviewable. After applying, run `git diff --check`, the adapter's
-   gate/regen command, and another `selector-debt` summary to report the debt
-   delta.
+   only when the candidate count, skipped reasons, file scope, and selector
+   shape look reviewable. A synthesized selector that copies an exact long
+   function body, object literal, argument list, class body, or nested
+   expression is not done merely because it resolves against the current chunk.
+   It must also avoid overpinning incidental implementation detail. Minimize it
+   with holes/stable anchors first, or route the shape to Ducktape
+   minimization/tooling before scaling the pattern. After applying, run
+   `git diff --check`, the adapter's gate/regen command, and another
+   `selector-debt` summary to report the debt delta.
 
    When hand-editing selectors is still necessary, follow
    `references/guide.md` "Workflow: authoring portable selectors": avoid
@@ -74,7 +79,11 @@ The orchestrator or project adapter provides:
    comma-list declaration, write a single-declarator `source_match` with
    `target_binding` and optional adjacent top-level context instead of spelling
    unrelated sibling declarators. Keep ambiguous structural matches rejecting
-   rather than source-order selected. Do not modify the upstream/source bundle.
+   rather than source-order selected. Do not turn an oververbose generated
+   selector into a manual maintenance burden by preserving exact incidental
+   bodies or generated object values; either minimize it or leave the binding as
+   explicit selector debt with a generic tooling blocker. Do not modify the
+   upstream/source bundle.
    After touching selectors, sanity-check the debt you added with
    `debundle spec selector-debt --modules <modules-dir> --min-score 70`; if
    your new members show up as high-score name-only selectors, reach for a

--- a/devinfra/js/debundle/skills/debundle_orchestrator/SKILL.md
+++ b/devinfra/js/debundle/skills/debundle_orchestrator/SKILL.md
@@ -41,8 +41,10 @@ Before dispatching work, collect:
   handled by `debundle spec synthesize-selectors` over hand-authored YAML, but
   do not treat exact long generated selectors as done merely because they match
   the current chunk. The selector program's target is current correctness plus
-  likely forward compatibility, so over-narrow synthesis output should become
-  Ducktape minimization work before it is scaled across many modules.
+  likely forward compatibility: selectors should avoid pinning incidental
+  bodies, argument lists, object values, and unrelated sibling declarations.
+  Over-narrow synthesis output should become Ducktape minimization work before
+  it is scaled across many modules.
 - Send seed clusters or reorg tasks to `debundle_lane_worker`.
 - Wake `debundle_architect` periodically or when module shape seems to drift.
 - Use `debundle_integrator` for merge trains of worker commits.
@@ -64,7 +66,8 @@ dispatch the integrator.
    Ducktape tooling work before asking humans or workers to hand-edit many
    selectors. A bucket is high quality only when its selectors are concise
    enough to avoid pinning incidental implementation detail; use holes and
-   stable anchors where uniqueness permits.
+   stable anchors where uniqueness permits. Do not dispatch work whose expected
+   output is a pile of manually maintained exact generated bodies.
 4. Ask intake for dispatchable seeds. Only `landable_today: true`
    proposals are directly dispatchable; `blocked_residual_dependency`
    rows need their closure grown (or manual co-location) before they

--- a/devinfra/js/debundle/skills/debundle_plan_work/SKILL.md
+++ b/devinfra/js/debundle/skills/debundle_plan_work/SKILL.md
@@ -43,10 +43,12 @@ bazelisk --output_base=/tmp/debundle-cli-bazel \
 - Treat selector quality as a forward-compatibility problem, not only a
   current-build problem. A synthesized selector that copies a long exact
   function body, object literal, class body, or nested expression can be
-  over-narrow even when it uniquely matches today's chunk. Prefer worker lanes
-  that use minimized selectors with holes and stable anchors, and route
-  oververbose synthesis output back to Ducktape tooling before scaling the
-  pattern across many modules.
+  over-narrow even when it uniquely matches today's chunk. A landable selector
+  should both match the current declaration and avoid pinning incidental
+  bodies, argument lists, object values, and unrelated siblings. Prefer worker
+  lanes that use minimized selectors with holes and stable anchors, and route
+  oververbose synthesis output back to Ducktape minimization/tooling before
+  scaling the pattern across many modules.
 - Use `coverage` and `atoms` when current YAML or atomic-unit closure is
   the question.
 - Use `describe` and `show-source` before recommending any assignment.
@@ -68,4 +70,6 @@ commands in all new docs, scripts, and reports.
 Selector planning should also record tooling gaps. If `synthesize-selectors`
 skips a large repeated shape, produces selectors that are too exact to be
 forward-compatible, or cannot express a concise stable anchor, recommend a
-Ducktape feature/fix before assigning many manual YAML edits.
+Ducktape feature/fix before assigning many manual YAML edits. Do not plan lanes
+whose work is simply to hand-transcribe exact long generated selectors; that is
+minimization backlog, not finished selector stabilization.

--- a/devinfra/js/debundle/skills/shared/workflow.md
+++ b/devinfra/js/debundle/skills/shared/workflow.md
@@ -53,6 +53,11 @@ enough stable anchors to be unique and leave unrelated structure behind
 Ambiguous structural selectors must remain failures; refine them with stable
 code shape, holes, or context instead of relying on source order or opaque
 hashes.
+Selector acceptance has two gates: it must match and claim the intended current
+code, and it must be concise enough not to overpin incidental bodies, arguments,
+generated object values, or unrelated sibling declarations. Exact long
+synthesized selectors satisfy only the first gate; treat them as drafts to
+minimize, not as finished work.
 
 To audit where a spec already carries this debt, run
 `debundle spec selector-debt --modules <modules-dir>`. It ranks name-only
@@ -82,7 +87,9 @@ manual YAML:
    fragile one-off selectors. Current uniqueness is only the first gate:
    selectors should also be likely to keep matching future minified-bundle
    versions, so prefer wildcard/hole forms over long incidental code whenever
-   uniqueness still holds.
+   uniqueness still holds. If no concise supported selector exists yet, leave
+   the binding as visible selector debt and record the generic tooling gap
+   rather than committing a manually maintained exact generated body.
 
 ## Round Loop
 


### PR DESCRIPTION
## Summary

- Clarify that synthesized `source_match` selectors are not done just because they match today's chunk.
- Add the two-part acceptance bar: selectors must match current code and avoid overpinning incidental bodies, arguments, generated object values, and unrelated siblings.
- Route oververbose synthesis output to minimization/tooling instead of broad manual exact-selector maintenance.
- Keep examples and guidance generic; no private source snippets included.

## Scope

Docs/skills only. This intentionally avoids `devinfra/js/debundle/TODO.md` and `devinfra/js/debundle/plans/automated_spec_workflows.md`, which are owned by PR #2244.

## Validation

- `git diff --check`
- `nix develop -c pre-commit run --files devinfra/js/debundle/CLI_DOGFOOD.md devinfra/js/debundle/docs/guide.md devinfra/js/debundle/skills/debundle_lane_worker/SKILL.md devinfra/js/debundle/skills/debundle_orchestrator/SKILL.md devinfra/js/debundle/skills/debundle_plan_work/SKILL.md devinfra/js/debundle/skills/shared/workflow.md`