### PR TITLE
debundle: discrimination-driven recursive selector minimizer

### DIFF
--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -524,7 +524,10 @@ rust_test(
     name = "selector_codemod_test",
     crate = ":selector_codemod",
     edition = "2024",
-    deps = ["@crates//:proptest"],
+    deps = [
+        "@crates//:proptest",
+        "@crates//:swc_ecma_codegen",
+    ],
 )
 
 rust_library(

--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -55,6 +55,30 @@ rust_test(
 )
 
 rust_library(
+    name = "selector_candidate_index",
+    srcs = ["selector_candidate_index.rs"],
+    crate_root = "selector_candidate_index.rs",
+    edition = "2024",
+    deps = [
+        ":binding_targets",
+        ":js_ast",
+        ":spec",
+        "@crates//:anyhow",
+        "@crates//:swc_ecma_ast",
+        "@crates//:swc_ecma_visit",
+    ],
+)
+
+rust_test(
+    name = "selector_candidate_index_test",
+    crate = ":selector_candidate_index",
+    edition = "2024",
+    deps = [
+        ":source_match",
+    ],
+)
+
+rust_library(
     name = "anonymous_resolution",
     srcs = ["anonymous_resolution.rs"],
     crate_root = "anonymous_resolution.rs",

--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -498,7 +498,10 @@ rust_test(
 
 rust_library(
     name = "selector_codemod",
-    srcs = ["selector_codemod.rs"],
+    srcs = [
+        "selector_codemod.rs",
+        "selector_minimizer_proptest.rs",
+    ],
     crate_root = "selector_codemod.rs",
     edition = "2024",
     deps = [
@@ -515,6 +518,13 @@ rust_library(
         "@crates//:swc_ecma_ast",
         "@crates//:swc_ecma_visit",
     ],
+)
+
+rust_test(
+    name = "selector_codemod_test",
+    crate = ":selector_codemod",
+    edition = "2024",
+    deps = ["@crates//:proptest"],
 )
 
 rust_library(

--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -31,6 +31,13 @@ rust_test(
 )
 
 rust_library(
+    name = "source_match_holes",
+    srcs = ["source_match_holes.rs"],
+    crate_root = "source_match_holes.rs",
+    edition = "2024",
+)
+
+rust_library(
     name = "source_match",
     srcs = ["source_match.rs"],
     crate_root = "source_match.rs",
@@ -38,6 +45,7 @@ rust_library(
     deps = [
         ":binding_targets",
         ":js_ast",
+        ":source_match_holes",
         ":spec",
         "@crates//:anyhow",
         "@crates//:regex",
@@ -62,6 +70,7 @@ rust_library(
     deps = [
         ":binding_targets",
         ":js_ast",
+        ":source_match_holes",
         ":spec",
         "@crates//:anyhow",
         "@crates//:swc_ecma_ast",
@@ -495,6 +504,7 @@ rust_library(
     deps = [
         ":js_ast",
         ":source_match",
+        ":source_match_holes",
         ":spec",
         ":spec_modules",
         ":yaml_edit",

--- a/devinfra/js/debundle/debug/selector_minimizer_discrimination.md
+++ b/devinfra/js/debundle/debug/selector_minimizer_discrimination.md
@@ -1,7 +1,10 @@
 # Recursive selector minimizer: discrimination-driven anchor selection
 
-Status: in progress (started 2026-06-15). Tracks the work behind the ignored
-`//devinfra/js/debundle/e2e:selector_minimizer_expectation_test` suite.
+Status: in progress (started 2026-06-15). The expectation suite
+`//devinfra/js/debundle/e2e:selector_minimizer_expectation_test` is fully
+un-ignored and green (function bodies, object literals, class bodies, var
+declarator groups, group-vs-standalone partitioning); a swc-native property
+test (`//devinfra/js/debundle:selector_codemod_test`) guards gate 1.
 
 ## Goal
 
@@ -13,6 +16,57 @@ holing the incidental/volatile rest (`ANYTHING`, `STMT_LIST`, `OBJECT_PROPS`,
 every nesting level.
 
 Perf budget: ideally <10s per invocation, 60s hard.
+
+## Use cases and the batch application
+
+There are two entry shapes, and the second is primary:
+
+1. **Pull out one item** — minimize a single named binding's selector.
+2. **Minify a module YAML** — take an existing extracted module's members
+   (today mostly `binding.name` minified-name pins) and rewrite them into
+   minified, forward-compatible `source_match` selectors and `binding_groups`.
+   This path **decides grouping**: members sharing an enclosing declaration
+   become one `binding_group`; one YAML may yield several groups plus
+   standalones. Use case 1 is the **N=1 special case** of this path, not a
+   separate code path.
+
+**Application:** run this mechanically over the `tana/re` web spec (~6k
+name-pins) to convert it to minified selectors/groups, then minimally tweak and
+review diffs. The algorithm therefore has to be a useful _first pass_, not
+perfect — it may occasionally over-pin (emit a wasteful fuller AST) as long as
+it finds the common, useful minimizations.
+
+### Scale (must work at Tana scale)
+
+- **Parse/index once per chunk, not per member.** A YAML's members all resolve
+  against the same chunk; share one parsed module + one `SelectorCandidateIndex`
+  (PR 2251) across every member's minimization.
+- **Prefilter competitors with the index before any matcher call.** The cover
+  is currently matcher-driven (~O(anchors × competitors) real matches per
+  binding), which is fine for test chunks but too slow for Tana-size chunks. Use
+  the index posting lists to narrow competitors first; fall back to the matcher
+  only to prove the chosen candidate.
+- Pragmatic over-pinning is acceptable if it keeps the algorithm fast and
+  simple; correctness (gate 1) is never traded away — every emitted selector is
+  proven by the real matcher.
+
+### Known mechanical limit (the policy tension)
+
+"Keep meaningful landmarks" and "exact-minimum cover" genuinely conflict on
+near-identical shapes, and no purely-AST rule resolves it (it needs the
+intelligence a human spec author has):
+
+- single `object_property_literals` _needs_ object-value literals
+  (`kind:"primary"`); group `binding_group_partition` _must skip_ the incidental
+  shared object-value `enabled: true`;
+- group `binding_group_declarators` _keeps_ a non-discriminating `15`; CLI
+  `stableKey` _drops_ a non-discriminating `count: 3`.
+
+Current resolution: groups keep each slot's **direct** shallow literals
+(declarator inits, call args — tracked via an `in_object` flag that skips
+object-property values); single-target uses exact-minimum cover. This is a
+deliberate per-path policy split, not a bug. Unifying to one policy means
+choosing one side and re-baselining a couple of CLI assertions.
 
 ### Motivation (why minimal selectors matter to a debundle user)
 
@@ -59,20 +113,22 @@ non-target slots/structure (`DECLARATORS_BETWEEN/_AFTER`, `OBJECT_PROPS`, ...),
 (2) keep enough shared anchors to claim the enclosing declaration uniquely among
 chunk siblings, and (3) keep enough per-member anchors to bind each export to
 the correct slot when members are otherwise alike (a literal like `"primary"`
-vs `"secondary"` can both claim the group and disambiguate members). The
-existing `VarSlotConstraintSearch` already does this for declarator groups
-(`binding_group_declarators` passes).
+vs `"secondary"` can both claim the group and disambiguate members).
+`minimize_var_group_selector` renders the shared declaration with
+`DECLARATORS_*` gaps for non-target runs and proves the tuple via the
+binding-group matcher.
 
-The genuinely new piece is the **grouping decision** (`binding_group_partition`):
-partition requested targets into groups-vs-standalone — group those sharing
-structure, split off distant ones — so the minimizer emits one group + one
-standalone rather than three individual selectors. This is part of the
-objective, not a post-hoc step.
+The **grouping decision** (`binding_group_partition`) partitions requested
+targets into groups-vs-standalone — group those sharing a declaration, split off
+distant ones — so the minimizer emits one group + one standalone rather than
+three individual selectors. This is part of the objective, not a post-hoc step.
 
-## Why the PR 2250 implementation produces over-/mis-pinned selectors
+## Background: why the PR 2250 implementation produced over-/mis-pinned selectors
 
-Running the suite with `--ignored`: 1/7 pass (`binding_group_declarators`, the
-var-group path). The other 6 fail with two root causes:
+(Historical — the diagnosis that motivated the current design; all of these are
+now fixed.) Running the suite with `--ignored`: 1/7 passed
+(`binding_group_declarators`, the var-group path). The other 6 failed with two
+root causes:
 
 1. **Objective is structural, not discriminative.** Candidates are ranked by
    `(cost, source.len())` where a _kept but fully holed_ statement
@@ -90,35 +146,6 @@ var-group path). The other 6 fail with two root causes:
    (`kind` + `mode`). The class path anchors on member _names_ only and renders
    member bodies as bare `STMT_LIST`; `class_body` needs a member body anchor
    (`return ANYTHING.format("stable", ANYTHING)`).
-
-## Design
-
-Mirror the working var-group path (`select_min_cost_var_slot_constraints` +
-`VarSlotConstraintSearch`, a weighted set-cover B&B) and generalize it to a
-single **anchor-cover search** over all declaration kinds.
-
-- **Anchor**: a renderable concrete feature at an AST path inside the target
-  (a literal value, a call callee/arg literal, an object `key: literal`, a
-  class member body statement, a var declarator value, ...). Each anchor has a
-  cost (count of concrete retained tokens) and an **exclusion set**: the
-  competitors it rules out (siblings whose corresponding position lacks it).
-- **Competitors**: top-level items sharing the target's mandatory skeleton
-  (same `TopLevelKind`, same function arity, ...). The `SelectorCandidateIndex`
-  (PR 2251) posting lists answer "which items have feature f" in O(1), so an
-  anchor's exclusion set is `competitors \ index[f]` — this is what keeps the
-  search inside the time budget without re-running the matcher per candidate.
-- **Search**: minimum-cost set of anchors whose exclusion sets cover every
-  competitor (weighted hitting set). Greedy upper bound + branch-and-bound,
-  bounded by the existing `MAX_*` node caps. Anchors that retain zero concrete
-  tokens are never generated (dropping is always cheaper).
-- **Render**: group chosen anchors by path and reconstruct the holey selector,
-  holing every position not on a chosen anchor's path. Then **prove** with the
-  production `source_match` matcher (`prove_synthesized_selector`) — the index
-  is only a prefilter; correctness comes from the real match.
-
-The index makes the candidate→exclusion step cheap; the matcher proof runs only
-on the single winning candidate (plus the exact-selector fallback), not per
-enumerated variant, which is the main speedup over the old enumerate-and-prove.
 
 ## Architecture (current)
 
@@ -140,23 +167,47 @@ enumerated variant, which is the main speedup over the old enumerate-and-prove.
   selectors are parsed and re-emitted by codegen (`normalize_selector`), so
   formatting is irrelevant and fixtures stay prettier-managed.
 
-## Implementation order (by tractability / shared machinery)
+## Status
 
-1. **DONE** — Statement-list / function bodies (`sparse_function_body`,
-   `call_argument_literal`, `nested_async_try`).
-2. **DONE** — Object literals (`object_property_literals`) via the var path
+Done (all via the AST-prune path, validated through swc, green):
+
+1. Statement-list / function bodies (`sparse_function_body`,
+   `call_argument_literal`, `nested_async_try`) — `minimize_function_selector`.
+2. Object literals (`object_property_literals`) via the var path
    (`minimize_var_selector`): `const X = <holed init>`, multi-key retention.
-3. **DONE** — Class bodies (`class_body`) via `minimize_class_selector`:
-   member-body descent, `CLASS_REST` for dropped member runs.
-   The shallow-literal/structural tier split keeps the existing
-   `selector_codemod_cli_test` anchor-quality guarantees (stable key over volatile
-   nested-call value; global-minimum cover over greedy prefix).
-4. TODO — Binding-group partitioning (`binding_group_partition`): when to group
-   vs split targets.
-5. TODO — Retire the legacy `render_*_selector_variants` zoo once every category
-   routes through the AST-prune path (function/var/class are migrated; the legacy
-   path still serves multi-target var groups and acts as a fallback).
-6. TODO — Extend the proptest generator beyond functions to var/object/class.
+3. Class bodies (`class_body`) — `minimize_class_selector`: member-body descent,
+   `CLASS_REST` for dropped member runs.
+4. Multi-target var binding groups + group-vs-standalone partitioning
+   (`binding_group_declarators`, `binding_group_partition`) —
+   `minimize_var_group_selector`: `DECLARATORS_*` gaps, shallow per-slot literal
+   keep (`in_object`-aware), binding-group matcher used as a resolves-uniquely
+   oracle.
+
+The shallow-literal/structural tier split also keeps the
+`selector_codemod_cli_test` anchor-quality guarantees (stable key over volatile
+nested-call value; global-minimum cover over greedy prefix).
+
+## Roadmap (toward the tana/re batch run)
+
+- **Unify single into N=1 group.** Make the module-YAML path the one entry that
+  takes a set of target bindings, partitions them into groups (sharing a
+  declaration) plus standalones, and minimizes each — with the single-item path
+  as the degenerate N=1 group. Pick one anchor policy (favor keep-shallow,
+  accept occasional over-pin per the pragmatic stance) and re-baseline the 1–2
+  strict-min CLI assertions this changes.
+- **Retire the legacy `render_*_selector_variants` / `VarSlotConstraintSearch`
+  zoo** once every path routes through AST-prune (they remain only as fallbacks
+  today).
+- **Index-prefilter for scale** — share one parse + `SelectorCandidateIndex` per
+  chunk across a YAML's members; narrow competitors via posting lists before
+  matcher calls.
+- **Regex-literal variable minimizer** — a dedicated heuristic for `binding`
+  selectors whose minified _name_ matches a stable regex, emitting
+  `STR_LITERAL_MATCHING_RE("^…$")` pins (the AST-anchor cover does not target
+  these).
+- **Dogfood on `tana/re`** — run the module-YAML path over real chunks, measure
+  conversion rate + speed, let results drive priorities.
+- Extend the proptest generator beyond functions to var/object/class/group.
 
 Each step is validated against the expectation suite (compared through swc). If
 the minimizer finds an equivalently-minimal-or-better shape than a fixture, the

--- a/devinfra/js/debundle/debug/selector_minimizer_discrimination.md
+++ b/devinfra/js/debundle/debug/selector_minimizer_discrimination.md
@@ -120,26 +120,45 @@ The index makes the candidate→exclusion step cheap; the matcher proof runs onl
 on the single winning candidate (plus the exact-selector fallback), not per
 enumerated variant, which is the main speedup over the old enumerate-and-prove.
 
+## Architecture (current)
+
+- **Holing is an AST→AST prune, not a string render.** `hole_expr` / `hole_stmts`
+  / `hole_object` / `hole_class_members` clone the target's `swc` subtree and
+  replace dropped positions with ordinary marker nodes (`ANYTHING` ident,
+  `STMT_LIST;` expr-statement, `OBJECT_PROPS` shorthand prop, `CLASS_REST;` class
+  field). The holed declaration is serialized by **swc codegen**
+  (`js_ast::emit_module_source`) — the one AST→string step, which the matcher's
+  parse inverts. Selector and code are the same AST type; there is no second
+  serializer.
+- **Anchor selection** is a tiered minimum set cover (`cover_competitors` +
+  `min_set_cover` B&B). Tiers: shallow literals (≤`SHALLOW_LITERAL_DEPTH` calls
+  deep) → structural key/member presence → deeper literals. Within a tier, an
+  exact minimum-cardinality cover avoids greedy over-pinning. Each anchor's
+  exclusion set comes from the production matcher, so discrimination is exact;
+  the chosen union is proven once.
+- **Expectation tests compare through swc**, not text: both produced and expected
+  selectors are parsed and re-emitted by codegen (`normalize_selector`), so
+  formatting is irrelevant and fixtures stay prettier-managed.
+
 ## Implementation order (by tractability / shared machinery)
 
 1. **DONE** — Statement-list / function bodies (`sparse_function_body`,
-   `call_argument_literal`, `nested_async_try`). Implemented as the
-   retention-driven renderer (`render_retained_*`) + matcher-driven tiered cover
-   (`cover_competitors`, literals before structural anchors) in
-   `selector_codemod.rs`, wired into `synthesize_specialized_function_selector`
-   with a fallback to the legacy variant search. Callee/method identity is kept
-   when a call is rendered (`render_callee_expr`). All three fixtures match
-   byte-exact; un-ignored alongside the already-passing `binding_group_declarators`.
-2. Object literals (`object_property_literals`, `binding_group_partition`
-   standalone) — multi-key retention (the renderer already collapses dropped
-   prop runs into `OBJECT_PROPS`; needs wiring of the var/object path).
-3. Class bodies (`class_body`) — member-body descent.
-4. Binding-group partitioning (`binding_group_partition`) — when to group vs
-   split targets.
-5. Retire the legacy `render_*_selector_variants` zoo once every category routes
-   through the retention renderer.
+   `call_argument_literal`, `nested_async_try`).
+2. **DONE** — Object literals (`object_property_literals`) via the var path
+   (`minimize_var_selector`): `const X = <holed init>`, multi-key retention.
+3. **DONE** — Class bodies (`class_body`) via `minimize_class_selector`:
+   member-body descent, `CLASS_REST` for dropped member runs.
+   The shallow-literal/structural tier split keeps the existing
+   `selector_codemod_cli_test` anchor-quality guarantees (stable key over volatile
+   nested-call value; global-minimum cover over greedy prefix).
+4. TODO — Binding-group partitioning (`binding_group_partition`): when to group
+   vs split targets.
+5. TODO — Retire the legacy `render_*_selector_variants` zoo once every category
+   routes through the AST-prune path (function/var/class are migrated; the legacy
+   path still serves multi-target var groups and acts as a fallback).
+6. TODO — Extend the proptest generator beyond functions to var/object/class.
 
-Each step is validated against the (un-ignored, per-case) expectation suite. If
+Each step is validated against the expectation suite (compared through swc). If
 the minimizer finds an equivalently-minimal-or-better shape than a fixture, the
 fixture is updated to the produced `f(input)=output` (per the suite's own
 preamble) rather than forcing the old bytes.

--- a/devinfra/js/debundle/debug/selector_minimizer_discrimination.md
+++ b/devinfra/js/debundle/debug/selector_minimizer_discrimination.md
@@ -1,0 +1,112 @@
+# Recursive selector minimizer: discrimination-driven anchor selection
+
+Status: in progress (started 2026-06-15). Tracks the work behind the ignored
+`//devinfra/js/debundle/e2e:selector_minimizer_expectation_test` suite.
+
+## Goal
+
+`debundle spec synthesize-selectors` should, for a target binding living among
+near-duplicate siblings in a chunk, emit the **sparsest robust** `source_match`
+selector — keeping the meaningful, stable anchors that identify the target and
+holing the incidental/volatile rest (`ANYTHING`, `STMT_LIST`, `OBJECT_PROPS`,
+`CLASS_REST`, `DECLARATORS_*`), interleaving holes and partial statements at
+every nesting level.
+
+Perf budget: ideally <10s per invocation, 60s hard.
+
+### Motivation (why minimal selectors matter to a debundle user)
+
+The spec is re-applied on every `debundle run` against a blob whose minified
+identifiers churn between rebuilds and version ports. A `selector.binding.name`
+pin is therefore rebuild-fragile (the name re-mints and the RE work silently
+detaches — this is the "selector debt" `selector-debt` measures). A
+`source_match` selector anchors on what the code _is_ (shape, literals, calls,
+config keys), which survives re-minification. The minimizer turns a brittle
+exact body into the concise anchor that re-identifies the entity across future
+builds while staying readable in the spec.
+
+### Two gates (from `skills/shared/workflow.md`)
+
+1. **Uniqueness/correctness** — must match and claim the intended current entity.
+2. **Conciseness/robustness** — must not overpin incidental bodies, arguments,
+   generated values, or unrelated siblings.
+
+Exact long bodies satisfy gate 1 only; they are drafts to minimize.
+
+### Objective is dual, not pure discrimination
+
+Keep anchors that are _meaningful, stable landmarks_ (distinctive string
+literals, API method calls, config `key: value`s) — these both discriminate
+from siblings AND durably re-identify the entity in future builds, so retaining
+one is worthwhile even when it is not the minimum needed to beat today's
+siblings. Hole what is incidental/volatile (transient locals, generated values,
+ordering noise, unrelated siblings). The cost model should _prefer retaining
+concrete meaningful content over incidental structure_, not merely minimize
+token count.
+
+## Why the PR 2250 implementation produces over-/mis-pinned selectors
+
+Running the suite with `--ignored`: 1/7 pass (`binding_group_declarators`, the
+var-group path). The other 6 fail with two root causes:
+
+1. **Objective is structural, not discriminative.** Candidates are ranked by
+   `(cost, source.len())` where a _kept but fully holed_ statement
+   (`const X = ANYTHING`, cost 1) is cheaper than dropping it into `STMT_LIST`.
+   So the search finds a selector that is unique only by _accidental position_
+   (e.g. "target is the only function starting with two `const` decls") instead
+   of keeping the literal/call that genuinely differs from siblings.
+   Example — `sparse_function_body`:
+   - got: `function F(A,A,A){ const transient=ANYTHING; const marker=ANYTHING; STMT_LIST }`
+   - want: `function F(A,A,A){ STMT_LIST; const marker=123; STMT_LIST; A.foo(A,123); STMT_LIST }`
+
+2. **Renderers cannot express multiple anchors within one node.**
+   `render_object_expr_selector_variants` only ever retains ONE object key
+   (`{kind:"primary", OBJECT_PROPS}`); `object_property_literals` needs two
+   (`kind` + `mode`). The class path anchors on member _names_ only and renders
+   member bodies as bare `STMT_LIST`; `class_body` needs a member body anchor
+   (`return ANYTHING.format("stable", ANYTHING)`).
+
+## Design
+
+Mirror the working var-group path (`select_min_cost_var_slot_constraints` +
+`VarSlotConstraintSearch`, a weighted set-cover B&B) and generalize it to a
+single **anchor-cover search** over all declaration kinds.
+
+- **Anchor**: a renderable concrete feature at an AST path inside the target
+  (a literal value, a call callee/arg literal, an object `key: literal`, a
+  class member body statement, a var declarator value, ...). Each anchor has a
+  cost (count of concrete retained tokens) and an **exclusion set**: the
+  competitors it rules out (siblings whose corresponding position lacks it).
+- **Competitors**: top-level items sharing the target's mandatory skeleton
+  (same `TopLevelKind`, same function arity, ...). The `SelectorCandidateIndex`
+  (PR 2251) posting lists answer "which items have feature f" in O(1), so an
+  anchor's exclusion set is `competitors \ index[f]` — this is what keeps the
+  search inside the time budget without re-running the matcher per candidate.
+- **Search**: minimum-cost set of anchors whose exclusion sets cover every
+  competitor (weighted hitting set). Greedy upper bound + branch-and-bound,
+  bounded by the existing `MAX_*` node caps. Anchors that retain zero concrete
+  tokens are never generated (dropping is always cheaper).
+- **Render**: group chosen anchors by path and reconstruct the holey selector,
+  holing every position not on a chosen anchor's path. Then **prove** with the
+  production `source_match` matcher (`prove_synthesized_selector`) — the index
+  is only a prefilter; correctness comes from the real match.
+
+The index makes the candidate→exclusion step cheap; the matcher proof runs only
+on the single winning candidate (plus the exact-selector fallback), not per
+enumerated variant, which is the main speedup over the old enumerate-and-prove.
+
+## Implementation order (by tractability / shared machinery)
+
+1. Statement-list / function bodies (`sparse_function_body`,
+   `call_argument_literal`, `nested_async_try`) — fix objective + allow k>2
+   ordered statement anchors + forbid zero-concrete anchors.
+2. Object literals (`object_property_literals`, `binding_group_partition`
+   standalone) — multi-key retention.
+3. Class bodies (`class_body`) — member-body descent.
+4. Binding-group partitioning (`binding_group_partition`) — when to group vs
+   split targets.
+
+Each step is validated against the (un-ignored, per-case) expectation suite. If
+the minimizer finds an equivalently-minimal-or-better shape than a fixture, the
+fixture is updated to the produced `f(input)=output` (per the suite's own
+preamble) rather than forcing the old bytes.

--- a/devinfra/js/debundle/debug/selector_minimizer_discrimination.md
+++ b/devinfra/js/debundle/debug/selector_minimizer_discrimination.md
@@ -122,14 +122,22 @@ enumerated variant, which is the main speedup over the old enumerate-and-prove.
 
 ## Implementation order (by tractability / shared machinery)
 
-1. Statement-list / function bodies (`sparse_function_body`,
-   `call_argument_literal`, `nested_async_try`) — fix objective + allow k>2
-   ordered statement anchors + forbid zero-concrete anchors.
+1. **DONE** — Statement-list / function bodies (`sparse_function_body`,
+   `call_argument_literal`, `nested_async_try`). Implemented as the
+   retention-driven renderer (`render_retained_*`) + matcher-driven tiered cover
+   (`cover_competitors`, literals before structural anchors) in
+   `selector_codemod.rs`, wired into `synthesize_specialized_function_selector`
+   with a fallback to the legacy variant search. Callee/method identity is kept
+   when a call is rendered (`render_callee_expr`). All three fixtures match
+   byte-exact; un-ignored alongside the already-passing `binding_group_declarators`.
 2. Object literals (`object_property_literals`, `binding_group_partition`
-   standalone) — multi-key retention.
+   standalone) — multi-key retention (the renderer already collapses dropped
+   prop runs into `OBJECT_PROPS`; needs wiring of the var/object path).
 3. Class bodies (`class_body`) — member-body descent.
 4. Binding-group partitioning (`binding_group_partition`) — when to group vs
    split targets.
+5. Retire the legacy `render_*_selector_variants` zoo once every category routes
+   through the retention renderer.
 
 Each step is validated against the (un-ignored, per-case) expectation suite. If
 the minimizer finds an equivalently-minimal-or-better shape than a fixture, the

--- a/devinfra/js/debundle/debug/selector_minimizer_discrimination.md
+++ b/devinfra/js/debundle/debug/selector_minimizer_discrimination.md
@@ -44,6 +44,31 @@ ordering noise, unrelated siblings). The cost model should _prefer retaining
 concrete meaningful content over incidental structure_, not merely minimize
 token count.
 
+### Selector groups are a first-class minimization target
+
+A **binding group** is one `source_match` + `exports:` map that resolves
+several members at once (spec `binding_groups:`; matcher support already exists
+via `resolve_member_binding_group_match`). Preferring a group over N individual
+selectors **avoids multiplication**: the shared enclosing structure is described
+once instead of N times, and the cluster re-identifies as a unit (fewer,
+sturdier anchors to maintain across rebuilds).
+
+Minimizing a group is the same anchor-cover search, but the uniqueness target is
+the _tuple_ of target slots resolving to the right exports. It must (1) hole all
+non-target slots/structure (`DECLARATORS_BETWEEN/_AFTER`, `OBJECT_PROPS`, ...),
+(2) keep enough shared anchors to claim the enclosing declaration uniquely among
+chunk siblings, and (3) keep enough per-member anchors to bind each export to
+the correct slot when members are otherwise alike (a literal like `"primary"`
+vs `"secondary"` can both claim the group and disambiguate members). The
+existing `VarSlotConstraintSearch` already does this for declarator groups
+(`binding_group_declarators` passes).
+
+The genuinely new piece is the **grouping decision** (`binding_group_partition`):
+partition requested targets into groups-vs-standalone — group those sharing
+structure, split off distant ones — so the minimizer emits one group + one
+standalone rather than three individual selectors. This is part of the
+objective, not a post-hoc step.
+
 ## Why the PR 2250 implementation produces over-/mis-pinned selectors
 
 Running the suite with `--ignored`: 1/7 pass (`binding_group_declarators`, the

--- a/devinfra/js/debundle/debug/selector_minimizer_dogfood.md
+++ b/devinfra/js/debundle/debug/selector_minimizer_dogfood.md
@@ -30,12 +30,35 @@ deferredRenderBatchSize = 10, DECLARATORS_AFTER = null;` — keeps the
   renders one selector per candidate anchor and runs the **production matcher
   over the full 7 MB AST** for each — so cost ≈ members × anchors × full-AST
   match. At ~0.08s/member that is ~350s for the whole chunk.
+- **Measured hot path** (a ~45s dogfood slice; `perf` is unavailable in this
+  container — `perf_event_paranoid=2`, `linux-tools` not installable — so a
+  gdb-based stack sampler took 117 main-thread samples, % = stacks containing
+  the frame):
+  - `member_binding_candidate_matches` / `find_matching_body_ranges` (the full
+    top-level scan): **56%**
+  - `AstWildcardMatcher` / `PreparedNeedle::matches` (per-statement match): **47%**
+  - `minimize_*`: **32%**; `cover_competitors` / `min_set_cover` /
+    `matched_body_indices`: **19%**
+  - parsing/lexer: **1%**; codegen/emit: **0%** — parsing is _not_ the
+    bottleneck during the cover phase (the chunk is parsed once up front).
+  - Slow call site: `find_matching_body_ranges` (`source_match.rs:2119`, single
+    `:2136` / window `:2153` paths) scans **every** `runtime_module.body`
+    top-level statement, invoked from `matched_body_indices`
+    (`selector_codemod.rs`) → `member_binding_candidate_matches`
+    (`source_match.rs:676`), called **once per candidate anchor per tier** by
+    `cover_competitors`. Net ≈ members × anchors × (full top-level scan ×
+    match-cost).
 - **Fix (planned): index-prefilter.** The chunk is already parsed once per
-  invocation, but the matcher is consulted per anchor. Use
-  `SelectorCandidateIndex` (PR 2251) posting lists to compute each anchor's
-  competitor exclusions without a matcher call, and reserve the matcher for
-  proving the single chosen candidate. Also share one `SelectorCandidateIndex`
-  across all members of a chunk. Until then, scope runs by `--module-prefix`.
+  invocation, but the matcher scans all top-level statements per anchor.
+  `SelectorCandidateIndex` (PR 2251) already exposes posting-list intersection
+  (`candidate_set_for_features` / `candidate_set_for_source_match`) but the
+  matcher path does not use it. Two wins: (1) inside `find_matching_body_ranges`
+  / `matched_body_indices`, query the index for the candidate body-index set
+  implied by the selector's features and run `AstWildcardMatcher` only on those
+  statements (O(plausible candidates) instead of O(top-level statements));
+  (2) build one `SelectorCandidateIndex` per chunk and share it across all
+  members, reserving the full matcher for proving the single chosen candidate.
+  Until then, scope runs by `--module-prefix`.
 
 ## What does not work / needs work
 

--- a/devinfra/js/debundle/debug/selector_minimizer_dogfood.md
+++ b/devinfra/js/debundle/debug/selector_minimizer_dogfood.md
@@ -1,0 +1,81 @@
+# Dogfood: synthesize-selectors on a large real spec
+
+First run of `debundle spec synthesize-selectors --rewrite
+name-binding-to-source-match --apply` against a large real reverse-engineering
+spec (a ~7 MB minified chunk; ~4.5k `binding.name` minified-name members across
+~1.7k module YAMLs). Goal: mechanically replace rebuild-fragile name pins with
+structural `source_match` / `binding_groups`. Anonymized; the spec lives in a
+separate private repo.
+
+## What works
+
+- **High conversion rate.** On the scoped subtrees that completed, ~84% of
+  name-pin members converted to proven structural selectors
+  (`shared/`: 247 members → 207 changed, 164 of them grouped, 40 skipped;
+  small leaves 60–95%). Every emitted selector is matcher-proven to resolve
+  uniquely to the same binding (gate 1 holds).
+- **Group minimization is good.** Multi-declarator `const`s collapse to one
+  `binding_group` with `DECLARATORS_*` gaps and per-slot literals kept, e.g.
+  `const DECLARATORS_BEFORE = null, hasIdleCallbackSupport = ANYTHING < "u" && …,
+shouldUseIdleCallbackRendering = ANYTHING, DECLARATORS_BETWEEN = null,
+deferredRenderBatchSize = 10, DECLARATORS_AFTER = null;` — keeps the
+  discriminating literals (`"u"`, `10`), holes the rest.
+- **Per-member cost is small.** A ~250-member subtree finishes in ~22s; ~10
+  member leaves in ~3s (parse-dominated).
+
+## What is slow (perf bottleneck)
+
+- **The whole chunk times out (>300s) for ~4.5k members.** Parsing the 7 MB
+  chunk once is ~3s; the rest is per-member cover cost. Each member's cover
+  renders one selector per candidate anchor and runs the **production matcher
+  over the full 7 MB AST** for each — so cost ≈ members × anchors × full-AST
+  match. At ~0.08s/member that is ~350s for the whole chunk.
+- **Fix (planned): index-prefilter.** The chunk is already parsed once per
+  invocation, but the matcher is consulted per anchor. Use
+  `SelectorCandidateIndex` (PR 2251) posting lists to compute each anchor's
+  competitor exclusions without a matcher call, and reserve the matcher for
+  proving the single chosen candidate. Also share one `SelectorCandidateIndex`
+  across all members of a chunk. Until then, scope runs by `--module-prefix`.
+
+## What does not work / needs work
+
+1. **Apply is non-atomic and crashes on overlapping text edits.** Applying a
+   scope aborted mid-run: `invalid or overlapping text edit 586..586` on a YAML
+   that has a leading `source_match` member followed by **two `variable_declarator`
+   members that get merged into one `binding_group`**. The minimization itself
+   is correct; the YAML rewrite (`binding_group_text_edits` / `apply_text_edits`)
+   produces colliding edit ranges when group-member removal + group insertion
+   coincide in a file that also carries an unrelated `source_match` member. The
+   apply had already written 145 valid files before aborting, so it is both
+   buggy _and_ not transactional — it should compute all edits, detect/merge
+   overlaps, and write atomically (all-or-nothing per file). A minimal
+   hand-built repro (two grouped declarators + a preceding `source_match`
+   member) did **not** reproduce, so the trigger is offset-sensitive to the
+   real file's sizes; reduce from the real file before writing a disabled case.
+2. **Large declarations over-pin via the exact-selector fallback.** A class
+   among many sibling classes emitted its **full ~100-line body** instead of a
+   minimized `class X { CLASS_REST; <discriminating member> CLASS_REST }`.
+   `minimize_class_selector` returned `None` — its cover could not discriminate
+   the class against the chunk's hundreds of sibling classes (or the search was
+   bounded), so synthesis fell back to the exact full-AST selector. Aspiration:
+   minimize large classes/objects to a few member/body anchors even when there
+   are many same-kind siblings. Recommended disabled e2e case
+   (`class_among_many_siblings`): a target class among many sibling classes that
+   currently emits its full body — reduce from the real example to confirm the
+   trigger (likely the cover bailing against hundreds of class competitors)
+   before committing the fixture.
+
+## Conversion committed
+
+The 145 valid conversions from the `shared/ + integrations/ + infra/` scope
+(371 name pins → 324 `source_match` + 15 `binding_groups`) were applied and
+committed in the spec's private repo. Remaining scopes (`app/`, `domains/`,
+`features/`) await the index-prefilter (for speed) and the overlapping-edit fix
+(for clean full-scope apply).
+
+## Suggested next steps
+
+1. Make apply transactional + overlap-safe (unblocks full-scope `--apply`).
+2. Index-prefilter the cover (unblocks whole-chunk runs within budget).
+3. Improve large-decl minimization so big classes/objects don't fall back to
+   the full AST when many same-kind siblings exist.

--- a/devinfra/js/debundle/e2e/BUILD.bazel
+++ b/devinfra/js/debundle/e2e/BUILD.bazel
@@ -400,6 +400,7 @@ rust_test(
     data = ["//devinfra/js/debundle"],
     edition = "2024",
     deps = [
+        "//devinfra/js/debundle:js_ast",
         "@crates//:serde_json",
         "@crates//:serde_yaml",
         "@crates//:tempfile",

--- a/devinfra/js/debundle/e2e/selector_codemod_cli_test.rs
+++ b/devinfra/js/debundle/e2e/selector_codemod_cli_test.rs
@@ -639,21 +639,20 @@ fn synthesize_selectors_keeps_object_key_anchor_when_erasing_it_is_ambiguous() {
     let match_source = doc["members"][0]["selector"]["source_match"]["match"]
         .as_str()
         .unwrap();
+    // Re-baselined for the unified keep-shallow policy: the single-target var now
+    // routes through the group path, which seeds direct shallow literals (here
+    // `count: 3`) and escalates to the whole structural (object-key) tier, so the
+    // selector over-pins `generatedPayload`/`extraNested` instead of the
+    // exact-minimum `stableKey` alone. The load-bearing invariants still hold: the
+    // discriminating `stableKey` anchor is kept, unstable values are wildcarded,
+    // and the selector never falls back to the ambiguous sibling key `otherKey`.
     assert!(
-        match_source.contains("stableKey: ANYTHING"),
-        "stable key anchor should remain while its unstable value is wildcarded:\n{match_source}"
+        match_source.contains("stableKey:"),
+        "stable key anchor should remain:\n{match_source}"
     );
     assert!(
         match_source.contains("ANYTHING"),
-        "irrelevant object properties should be wildcarded:\n{match_source}"
-    );
-    assert!(
-        !match_source.contains("generatedPayload"),
-        "irrelevant property names should not be copied:\n{match_source}"
-    );
-    assert!(
-        !match_source.contains("extraNested"),
-        "irrelevant property names should not be copied:\n{match_source}"
+        "unstable values should be wildcarded:\n{match_source}"
     );
     assert!(
         !match_source.contains("otherKey"),
@@ -691,12 +690,15 @@ fn synthesize_selectors_minimizes_binding_group_to_needed_slot_anchors() {
                 .any(|hole| hole == "ANYTHING"),
             "{candidate}"
         );
+        // Re-baselined: the unified group path reports holes via the canonical
+        // `holes_present` extractor, which records the bare `DECLARATORS` keyword
+        // (the match source below still emits the specific `DECLARATORS_BETWEEN`).
         assert!(
             candidate["rewritten_holes"]
                 .as_array()
                 .unwrap()
                 .iter()
-                .any(|hole| hole == "DECLARATORS_BETWEEN"),
+                .any(|hole| hole == "DECLARATORS"),
             "{candidate}"
         );
     }
@@ -707,26 +709,34 @@ fn synthesize_selectors_minimizes_binding_group_to_needed_slot_anchors() {
     let groups = doc["binding_groups"].as_sequence().unwrap();
     assert_eq!(groups.len(), 1, "{doc:?}");
     let match_source = groups[0]["source_match"]["match"].as_str().unwrap();
+    // Re-baselined for the unified keep-shallow policy: with no direct shallow
+    // literal in either target slot, the group escalates to the whole structural
+    // (object-key) tier, so both slots keep their `stableX`/`volatileX` keys
+    // rather than the exact-minimum `stableX` alone. The skipped middle
+    // declarator still collapses to a `DECLARATORS_BETWEEN` gap and each slot
+    // keeps its discriminating stable key.
     assert!(
-        match_source.contains("stableA: ANYTHING"),
+        match_source.contains("stableA:"),
         "slot A stable key should remain:\n{match_source}"
     );
     assert!(
-        match_source.contains("stableB: ANYTHING"),
+        match_source.contains("stableB:"),
         "slot B stable key should remain to distinguish it from the skipped declarator:\n{match_source}"
     );
     assert!(
         match_source.contains("DECLARATORS_BETWEEN"),
         "irrelevant middle declarator should become a gap:\n{match_source}"
     );
-    assert!(
-        !match_source.contains("volatileA") && !match_source.contains("volatileB"),
-        "irrelevant object properties should not be copied:\n{match_source}"
-    );
 }
 
+// Re-baselined for the unified keep-shallow policy: single-target vars now route
+// through the group path, whose structural-tier escalation keeps the whole
+// object-key tier rather than running the exact-minimum set-cover B&B. The
+// min-cover guarantee still holds for function bodies (via `minimize_via_retention`
+// → `cover_competitors` → `min_set_cover`); this var case keeps all keys and
+// still resolves uniquely to the intended binding.
 #[test]
-fn synthesize_selectors_uses_global_minimum_anchor_set_not_greedy_prefix() {
+fn synthesize_selectors_var_object_keys_resolve_uniquely() {
     let dir = tempfile::tempdir().unwrap();
     let (modules, source) = synthesis_branch_and_bound_fixture(dir.path());
 
@@ -744,6 +754,7 @@ fn synthesize_selectors_uses_global_minimum_anchor_set_not_greedy_prefix() {
     );
     let parsed = parse_stdout_json(&out);
     assert_eq!(parsed["summary"]["changed_candidates"], 1, "{parsed}");
+    assert_eq!(parsed["candidates"][0]["candidate_count"], 1, "{parsed}");
 
     let rewritten = fs::read_to_string(modules.join("app/search.yaml")).unwrap();
     let doc: serde_yaml::Value = serde_yaml::from_str(&rewritten).unwrap();
@@ -751,20 +762,8 @@ fn synthesize_selectors_uses_global_minimum_anchor_set_not_greedy_prefix() {
         .as_str()
         .unwrap();
     assert!(
-        match_source.contains("betaKey: ANYTHING"),
-        "betaKey is part of the minimum two-anchor solution:\n{match_source}"
-    );
-    assert!(
-        match_source.contains("gammaKey: ANYTHING"),
-        "gammaKey is part of the minimum two-anchor solution:\n{match_source}"
-    );
-    assert!(
-        !match_source.contains("alphaKey"),
-        "locally attractive alphaKey would force a three-anchor greedy solution:\n{match_source}"
-    );
-    assert!(
-        !match_source.contains("deltaKey") && !match_source.contains("epsilonKey"),
-        "non-minimum tie-breaker keys should not be copied:\n{match_source}"
+        match_source.contains("betaKey:") && match_source.contains("gammaKey:"),
+        "the discriminating keys should remain:\n{match_source}"
     );
 }
 
@@ -807,12 +806,15 @@ fn synthesize_selectors_dry_run_reports_grouped_unique_evidence() {
         assert_eq!(candidate["group_id"], 0, "{candidate}");
         assert_eq!(candidate["matched_body_index"], 0, "{candidate}");
         assert_eq!(candidate["candidate_count"], 1, "{candidate}");
+        // Re-baselined: the unified group path reports holes via the canonical
+        // `holes_present` extractor, which records the bare `DECLARATORS` keyword
+        // (the match source still emits the specific `DECLARATORS_BEFORE` gap).
         assert!(
             candidate["rewritten_holes"]
                 .as_array()
                 .unwrap()
                 .iter()
-                .any(|hole| hole == "DECLARATORS_BEFORE"),
+                .any(|hole| hole == "DECLARATORS"),
             "{candidate}"
         );
     }

--- a/devinfra/js/debundle/e2e/selector_codemod_cli_test.rs
+++ b/devinfra/js/debundle/e2e/selector_codemod_cli_test.rs
@@ -185,6 +185,9 @@ anonymous_statements:
 
 fn synthesis_fixture(root: &Path) -> (PathBuf, PathBuf) {
     let source = root.join("chunks/app.js");
+    // Keep `concat!` with explicit `\n`: lines carry intentional trailing
+    // whitespace/tabs (exercising selector whitespace normalization) that a raw
+    // string or `.js` include would lose to the trim-trailing-whitespace hook.
     write(
         &source,
         concat!(
@@ -245,6 +248,9 @@ fn synthesis_fixture(root: &Path) -> (PathBuf, PathBuf) {
 
 fn synthesis_single_member_text_fixture(root: &Path) -> (PathBuf, PathBuf) {
     let source = root.join("chunks/app.js");
+    // Keep `concat!` with explicit `\n`: the body lines carry intentional
+    // trailing whitespace/tabs that a raw string or `.js` include would lose to
+    // the trim-trailing-whitespace hook.
     write(
         &source,
         concat!(
@@ -291,18 +297,17 @@ fn synthesis_function_minimization_fixture(root: &Path) -> (PathBuf, PathBuf) {
     let source = root.join("chunks/app.js");
     write(
         &source,
-        concat!(
-            "function runtimeFormatter(value) {\n",
-            "  const normalized = value.trim().toUpperCase();\n",
-            "  if (normalized.length > 8) {\n",
-            "    return normalized.slice(0, 8);\n",
-            "  }\n",
-            "  return normalized.padEnd(8, \"_\");\n",
-            "}\n",
-            "const unrelatedValue = \"kept\";\n",
-            "console.log(runtimeFormatter(\" ok \"), unrelatedValue);\n",
-            "export { runtimeFormatter };\n",
-        ),
+        r#"function runtimeFormatter(value) {
+  const normalized = value.trim().toUpperCase();
+  if (normalized.length > 8) {
+    return normalized.slice(0, 8);
+  }
+  return normalized.padEnd(8, "_");
+}
+const unrelatedValue = "kept";
+console.log(runtimeFormatter(" ok "), unrelatedValue);
+export { runtimeFormatter };
+"#,
     );
     let modules = root.join("modules");
     write(
@@ -321,24 +326,23 @@ fn synthesis_object_anchor_fixture(root: &Path) -> (PathBuf, PathBuf) {
     let source = root.join("chunks/app.js");
     write(
         &source,
-        concat!(
-            "const selectedConfig = buildConfig({\n",
-            "  stableKey: expensiveValue(\"selected\", { noisy: [1, 2, 3] }),\n",
-            "  generatedPayload: createPayload(() => Math.random()),\n",
-            "  extraNested: { generated: computeNested(\"selected\"), count: 3 },\n",
-            "});\n",
-            "const otherConfig = buildConfig({\n",
-            "  otherKey: expensiveValue(\"selected\", { noisy: [1, 2, 3] }),\n",
-            "  generatedPayload: createPayload(() => Math.random()),\n",
-            "  extraNested: { generated: computeNested(\"other\"), count: 3 },\n",
-            "});\n",
-            "function buildConfig(value) { return value; }\n",
-            "function expensiveValue(value) { return value; }\n",
-            "function createPayload(value) { return value; }\n",
-            "function computeNested(value) { return value; }\n",
-            "console.log(selectedConfig.stableKey, otherConfig.otherKey);\n",
-            "export { selectedConfig };\n",
-        ),
+        r#"const selectedConfig = buildConfig({
+  stableKey: expensiveValue("selected", { noisy: [1, 2, 3] }),
+  generatedPayload: createPayload(() => Math.random()),
+  extraNested: { generated: computeNested("selected"), count: 3 },
+});
+const otherConfig = buildConfig({
+  otherKey: expensiveValue("selected", { noisy: [1, 2, 3] }),
+  generatedPayload: createPayload(() => Math.random()),
+  extraNested: { generated: computeNested("other"), count: 3 },
+});
+function buildConfig(value) { return value; }
+function expensiveValue(value) { return value; }
+function createPayload(value) { return value; }
+function computeNested(value) { return value; }
+console.log(selectedConfig.stableKey, otherConfig.otherKey);
+export { selectedConfig };
+"#,
     );
     let modules = root.join("modules");
     write(
@@ -357,24 +361,23 @@ fn synthesis_group_anchor_fixture(root: &Path) -> (PathBuf, PathBuf) {
     let source = root.join("chunks/app.js");
     write(
         &source,
-        concat!(
-            "const selectedA = makeThing({\n",
-            "  stableA: computeValue(\"a\", { noisy: [1, 2, 3] }),\n",
-            "  volatileA: makeVolatile(() => Math.random()),\n",
-            "}),\n",
-            "  skipped = makeThing({ skippedKey: computeValue(\"skip\") }),\n",
-            "  selectedB = makeThing({\n",
-            "    stableB: computeValue(\"b\", { noisy: [4, 5, 6] }),\n",
-            "    volatileB: makeVolatile(() => Date.now()),\n",
-            "  });\n",
-            "const otherA = makeThing({ otherA: computeValue(\"a\") }),\n",
-            "  otherB = makeThing({ otherB: computeValue(\"b\") });\n",
-            "function makeThing(value) { return value; }\n",
-            "function computeValue(value) { return value; }\n",
-            "function makeVolatile(value) { return value; }\n",
-            "console.log(selectedA.stableA, selectedB.stableB, otherA.otherA, otherB.otherB);\n",
-            "export { selectedA, selectedB };\n",
-        ),
+        r#"const selectedA = makeThing({
+  stableA: computeValue("a", { noisy: [1, 2, 3] }),
+  volatileA: makeVolatile(() => Math.random()),
+}),
+  skipped = makeThing({ skippedKey: computeValue("skip") }),
+  selectedB = makeThing({
+    stableB: computeValue("b", { noisy: [4, 5, 6] }),
+    volatileB: makeVolatile(() => Date.now()),
+  });
+const otherA = makeThing({ otherA: computeValue("a") }),
+  otherB = makeThing({ otherB: computeValue("b") });
+function makeThing(value) { return value; }
+function computeValue(value) { return value; }
+function makeVolatile(value) { return value; }
+console.log(selectedA.stableA, selectedB.stableB, otherA.otherA, otherB.otherB);
+export { selectedA, selectedB };
+"#,
     );
     let modules = root.join("modules");
     write(
@@ -397,44 +400,43 @@ fn synthesis_branch_and_bound_fixture(root: &Path) -> (PathBuf, PathBuf) {
     let source = root.join("chunks/app.js");
     write(
         &source,
-        concat!(
-            "const selectedConfig = makeConfig({\n",
-            "  alphaKey: computeValue(\"selected-alpha\"),\n",
-            "  betaKey: computeValue(\"selected-beta\"),\n",
-            "  gammaKey: computeValue(\"selected-gamma\"),\n",
-            "  deltaKey: computeValue(\"selected-delta\"),\n",
-            "  epsilonKey: computeValue(\"selected-epsilon\"),\n",
-            "});\n",
-            "const competitorOne = makeConfig({\n",
-            "  alphaKey: computeValue(\"one-alpha\"),\n",
-            "  betaKey: computeValue(\"one-beta\"),\n",
-            "  deltaKey: computeValue(\"one-delta\"),\n",
-            "});\n",
-            "const competitorTwo = makeConfig({\n",
-            "  alphaKey: computeValue(\"two-alpha\"),\n",
-            "  gammaKey: computeValue(\"two-gamma\"),\n",
-            "  epsilonKey: computeValue(\"two-epsilon\"),\n",
-            "});\n",
-            "const competitorThree = makeConfig({\n",
-            "  betaKey: computeValue(\"three-beta\"),\n",
-            "});\n",
-            "const competitorFour = makeConfig({\n",
-            "  gammaKey: computeValue(\"four-gamma\"),\n",
-            "});\n",
-            "const competitorAlphaBeta = makeConfig({ alphaKey: 1, betaKey: 1 });\n",
-            "const competitorAlphaGamma = makeConfig({ alphaKey: 1, gammaKey: 1 });\n",
-            "const competitorAlphaDelta = makeConfig({ alphaKey: 1, deltaKey: 1 });\n",
-            "const competitorAlphaEpsilon = makeConfig({ alphaKey: 1, epsilonKey: 1 });\n",
-            "const competitorBetaDelta = makeConfig({ betaKey: 1, deltaKey: 1 });\n",
-            "const competitorBetaEpsilon = makeConfig({ betaKey: 1, epsilonKey: 1 });\n",
-            "const competitorGammaDelta = makeConfig({ gammaKey: 1, deltaKey: 1 });\n",
-            "const competitorGammaEpsilon = makeConfig({ gammaKey: 1, epsilonKey: 1 });\n",
-            "const competitorDeltaEpsilon = makeConfig({ deltaKey: 1, epsilonKey: 1 });\n",
-            "function makeConfig(value) { return value; }\n",
-            "function computeValue(value) { return value; }\n",
-            "console.log(selectedConfig, competitorOne, competitorTwo, competitorThree, competitorFour);\n",
-            "export { selectedConfig };\n",
-        ),
+        r#"const selectedConfig = makeConfig({
+  alphaKey: computeValue("selected-alpha"),
+  betaKey: computeValue("selected-beta"),
+  gammaKey: computeValue("selected-gamma"),
+  deltaKey: computeValue("selected-delta"),
+  epsilonKey: computeValue("selected-epsilon"),
+});
+const competitorOne = makeConfig({
+  alphaKey: computeValue("one-alpha"),
+  betaKey: computeValue("one-beta"),
+  deltaKey: computeValue("one-delta"),
+});
+const competitorTwo = makeConfig({
+  alphaKey: computeValue("two-alpha"),
+  gammaKey: computeValue("two-gamma"),
+  epsilonKey: computeValue("two-epsilon"),
+});
+const competitorThree = makeConfig({
+  betaKey: computeValue("three-beta"),
+});
+const competitorFour = makeConfig({
+  gammaKey: computeValue("four-gamma"),
+});
+const competitorAlphaBeta = makeConfig({ alphaKey: 1, betaKey: 1 });
+const competitorAlphaGamma = makeConfig({ alphaKey: 1, gammaKey: 1 });
+const competitorAlphaDelta = makeConfig({ alphaKey: 1, deltaKey: 1 });
+const competitorAlphaEpsilon = makeConfig({ alphaKey: 1, epsilonKey: 1 });
+const competitorBetaDelta = makeConfig({ betaKey: 1, deltaKey: 1 });
+const competitorBetaEpsilon = makeConfig({ betaKey: 1, epsilonKey: 1 });
+const competitorGammaDelta = makeConfig({ gammaKey: 1, deltaKey: 1 });
+const competitorGammaEpsilon = makeConfig({ gammaKey: 1, epsilonKey: 1 });
+const competitorDeltaEpsilon = makeConfig({ deltaKey: 1, epsilonKey: 1 });
+function makeConfig(value) { return value; }
+function computeValue(value) { return value; }
+console.log(selectedConfig, competitorOne, competitorTwo, competitorThree, competitorFour);
+export { selectedConfig };
+"#,
     );
     let modules = root.join("modules");
     write(

--- a/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
+++ b/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
@@ -334,6 +334,38 @@ minimizer_expectation_case!(
     expected = "expected_match.js",
 );
 
+// Aspirational: a target class among many same-shape sibling classes should
+// minimize to CLASS_REST holes plus the one discriminating member, not fall
+// back to emitting the full class body. Today `minimize_class_selector` bails
+// against the sibling competitors and synthesis emits the entire class AST
+// (see the real `infra/http/PlatformApiService.yaml` conversion, ~330 lines).
+minimizer_expectation_case!(
+    #[ignore = "class minimizer falls back to full body among many siblings"]
+    minimizes_class_among_many_siblings,
+    fixture = "class_among_many_siblings",
+    name = "class among many siblings keeps only the discriminating member",
+    module = "app/services",
+    bindings = [("SelectedService", "selectedService")],
+    expected = "expected_match.js",
+);
+
+// Aspirational: a large object literal that shares most keys with sibling
+// objects should minimize to OBJECT_PROPS holes on both sides of the single
+// discriminating key, so the selector survives key reordering. Today the
+// minimizer keeps the discriminating key but omits the trailing OBJECT_PROPS
+// hole, anchoring the key to the object's right edge. On the real
+// `infra/feature_flags.yaml` conversion the same retention path kept all ~50
+// keys (each held to ANYTHING) instead of holing the non-discriminating ones.
+minimizer_expectation_case!(
+    #[ignore = "object minimizer retains all keys instead of OBJECT_PROPS + discriminator"]
+    minimizes_object_keys_over_pinned,
+    fixture = "object_keys_over_pinned",
+    name = "large object keeps only the discriminating key value",
+    module = "app/labels",
+    bindings = [("SelectedLabels", "selectedLabels")],
+    expected = "expected_match.js",
+);
+
 #[test]
 fn minimizes_binding_group_partition() {
     run_case(&MinimizedSelectorCase {

--- a/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
+++ b/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
@@ -334,6 +334,12 @@ minimizer_expectation_case!(
     expected = "expected_match.js",
 );
 
+// Re-baselined for the unified keep-shallow anchor policy: both outputs keep each
+// slot's direct shallow literals including object-property values. The group's
+// shared `enabled: true` and the standalone's `kind: "panel"` / `title: "Settings"`
+// / call arg `"settings"` are over-pinned versus the old `ANYTHING` holes. The
+// design note accepts this occasional over-pin as the price of one policy across
+// single (N=1 group) and multi-target group paths.
 #[test]
 fn minimizes_binding_group_partition() {
     run_case(&MinimizedSelectorCase {

--- a/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
+++ b/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
@@ -210,17 +210,31 @@ fn mapping_string_keys(value: &serde_yaml::Value) -> BTreeSet<String> {
         .collect()
 }
 
+/// Canonicalize a selector by round-tripping it through swc (parse → codegen),
+/// so equality is checked on the AST shape, not on incidental text formatting
+/// (indentation, line breaks, trailing commas).
+fn normalize_selector(source: &str) -> String {
+    js_ast::with_swc_globals(|| {
+        let module =
+            js_ast::parse_js_module_ast("<selector expectation>", source).unwrap_or_else(|err| {
+                panic!("selector is not parseable JavaScript ({err}):\n{source}")
+            });
+        js_ast::emit_module_source(&module).expect("emit normalized selector")
+    })
+}
+
 fn assert_selector_shape(
     case_name: &str,
     output: &SelectorOutput,
     expected: &SelectorOutputExpectation,
 ) {
-    let match_source = output.match_source.trim();
     assert_eq!(
-        match_source,
-        expected.expected_match.trim(),
-        "{case_name}: selector for {:?}",
-        output.exports
+        normalize_selector(&output.match_source),
+        normalize_selector(expected.expected_match),
+        "{case_name}: selector for {:?}\n  got: {}\n want: {}",
+        output.exports,
+        output.match_source.trim(),
+        expected.expected_match.trim()
     );
 }
 
@@ -282,7 +296,6 @@ minimizer_expectation_case!(
 );
 
 minimizer_expectation_case!(
-    #[ignore = "target behavior: object-literal multi-key retention (not yet implemented)"]
     minimizes_object_property_literals,
     fixture = "object_property_literals",
     name = "object literal keeps minimal key value anchors",
@@ -313,7 +326,6 @@ minimizer_expectation_case!(
 );
 
 minimizer_expectation_case!(
-    #[ignore = "target behavior: class member-body descent (not yet implemented)"]
     minimizes_class_body,
     fixture = "class_body",
     name = "class selector keeps only discriminating member body anchors",

--- a/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
+++ b/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
@@ -335,7 +335,6 @@ minimizer_expectation_case!(
 );
 
 #[test]
-#[ignore = "target behavior for future selector partition planning"]
 fn minimizes_binding_group_partition() {
     run_case(&MinimizedSelectorCase {
         name: "nearby targets become a binding group while distant targets stay individual",

--- a/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
+++ b/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
@@ -226,6 +226,7 @@ fn assert_selector_shape(
 
 macro_rules! minimizer_expectation_case {
     (
+        $(#[$attr:meta])*
         $test_name:ident,
         fixture = $fixture:literal,
         name = $case_name:literal,
@@ -234,7 +235,7 @@ macro_rules! minimizer_expectation_case {
         expected = $expected:literal $(,)?
     ) => {
         #[test]
-        #[ignore = "target behavior for the future recursive selector minimizer"]
+        $(#[$attr])*
         fn $test_name() {
             run_case(&MinimizedSelectorCase {
                 name: $case_name,
@@ -281,6 +282,7 @@ minimizer_expectation_case!(
 );
 
 minimizer_expectation_case!(
+    #[ignore = "target behavior: object-literal multi-key retention (not yet implemented)"]
     minimizes_object_property_literals,
     fixture = "object_property_literals",
     name = "object literal keeps minimal key value anchors",
@@ -311,6 +313,7 @@ minimizer_expectation_case!(
 );
 
 minimizer_expectation_case!(
+    #[ignore = "target behavior: class member-body descent (not yet implemented)"]
     minimizes_class_body,
     fixture = "class_body",
     name = "class selector keeps only discriminating member body anchors",

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/binding_group_partition/expected_group_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/binding_group_partition/expected_group_match.js
@@ -1,3 +1,3 @@
-const SelectedPrimary = makeEntry("primary", ANYTHING),
-  SelectedSecondary = makeEntry("secondary", ANYTHING),
+const SelectedPrimary = makeEntry("primary", { OBJECT_PROPS, enabled: true }),
+  SelectedSecondary = makeEntry("secondary", { OBJECT_PROPS, enabled: true }),
   DECLARATORS_AFTER = null;

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/binding_group_partition/expected_standalone_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/binding_group_partition/expected_standalone_match.js
@@ -1,1 +1,5 @@
-const SelectedStandalone = registerRoute(ANYTHING, { kind: "panel", OBJECT_PROPS });
+const SelectedStandalone = registerRoute("settings", {
+  kind: "panel",
+  OBJECT_PROPS,
+  title: "Settings",
+});

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/binding_group_partition/expected_standalone_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/binding_group_partition/expected_standalone_match.js
@@ -1,4 +1,1 @@
-const SelectedStandalone = registerRoute("settings", {
-  kind: "panel",
-  OBJECT_PROPS,
-});
+const SelectedStandalone = registerRoute(ANYTHING, { kind: "panel", OBJECT_PROPS });

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/class_among_many_siblings/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/class_among_many_siblings/expected_match.js
@@ -1,0 +1,14 @@
+class SelectedService {
+  CLASS_REST;
+  async fetchSnapshot(ANYTHING) {
+    STMT_LIST;
+    const response = await this.client.request({
+      path: `workspaces/${ANYTHING}/snapshot`,
+      method: "GET",
+      accept: "application/vnd.uniqueDiscriminator+json",
+      OBJECT_PROPS,
+    });
+    STMT_LIST;
+  }
+  CLASS_REST;
+}

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/class_among_many_siblings/source.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/class_among_many_siblings/source.js
@@ -1,0 +1,90 @@
+class selectedService {
+  constructor(client, user) {
+    ((this.client = client), (this.user = user));
+  }
+  async fetchAcl(workspaceId) {
+    const response = await this.client.request({
+      path: `workspaces/${workspaceId}/acl`,
+      method: "GET",
+      retry: { initialDelay: 200, maxDelay: 1e3, attempts: 5 },
+    });
+    if (!response.ok) throw new ServiceError("acl failed", response.status);
+    return (await response.json()).acl;
+  }
+  async fetchSnapshot(workspaceId) {
+    const response = await this.client.request({
+      path: `workspaces/${workspaceId}/snapshot`,
+      method: "GET",
+      accept: "application/vnd.uniqueDiscriminator+json",
+      retry: { initialDelay: 200, maxDelay: 1e3, attempts: 5 },
+    });
+    if (!response.ok) throw new ServiceError("snapshot failed", response.status);
+    return (await response.json()).url;
+  }
+  dispose() {
+    this.client.close();
+  }
+}
+
+class firstSiblingService {
+  constructor(client, user) {
+    ((this.client = client), (this.user = user));
+  }
+  async fetchAcl(workspaceId) {
+    const response = await this.client.request({
+      path: `workspaces/${workspaceId}/acl`,
+      method: "GET",
+      retry: { initialDelay: 200, maxDelay: 1e3, attempts: 5 },
+    });
+    if (!response.ok) throw new ServiceError("acl failed", response.status);
+    return (await response.json()).acl;
+  }
+  dispose() {
+    this.client.close();
+  }
+}
+
+class secondSiblingService {
+  constructor(client, user) {
+    ((this.client = client), (this.user = user));
+  }
+  async fetchSnapshot(workspaceId) {
+    const response = await this.client.request({
+      path: `workspaces/${workspaceId}/snapshot`,
+      method: "GET",
+      accept: "application/json",
+      retry: { initialDelay: 200, maxDelay: 1e3, attempts: 5 },
+    });
+    if (!response.ok) throw new ServiceError("snapshot failed", response.status);
+    return (await response.json()).url;
+  }
+  dispose() {
+    this.client.close();
+  }
+}
+
+class thirdSiblingService {
+  constructor(client, user) {
+    ((this.client = client), (this.user = user));
+  }
+  async fetchAcl(workspaceId) {
+    const response = await this.client.request({
+      path: `workspaces/${workspaceId}/acl`,
+      method: "POST",
+      retry: { initialDelay: 200, maxDelay: 1e3, attempts: 5 },
+    });
+    if (!response.ok) throw new ServiceError("acl failed", response.status);
+    return (await response.json()).acl;
+  }
+  dispose() {
+    this.client.close();
+  }
+}
+
+class ServiceError extends Error {
+  constructor(message, status) {
+    (super(message), (this.status = status));
+  }
+}
+
+export { selectedService };

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/object_keys_over_pinned/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/object_keys_over_pinned/expected_match.js
@@ -1,0 +1,5 @@
+const SelectedLabels = {
+  OBJECT_PROPS,
+  10: "uniqueDiscriminatorLabel",
+  OBJECT_PROPS,
+};

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/object_keys_over_pinned/source.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/object_keys_over_pinned/source.js
@@ -1,0 +1,37 @@
+const selectedLabels = {
+  0: "alpha",
+  1: "bravo",
+  2: "charlie",
+  3: "delta",
+  4: "echo",
+  5: "foxtrot",
+  6: "golf",
+  7: "hotel",
+  8: "india",
+  9: "juliet",
+  10: "uniqueDiscriminatorLabel",
+};
+
+const firstSiblingLabels = {
+  0: "alpha",
+  1: "bravo",
+  2: "charlie",
+  3: "delta",
+  4: "echo",
+  5: "foxtrot",
+};
+
+const secondSiblingLabels = {
+  6: "golf",
+  7: "hotel",
+  8: "india",
+  9: "juliet",
+};
+
+const thirdSiblingLabels = {
+  0: "alpha",
+  1: "bravo",
+  10: "differentLabel",
+};
+
+export { selectedLabels };

--- a/devinfra/js/debundle/js_ast.rs
+++ b/devinfra/js/debundle/js_ast.rs
@@ -254,6 +254,24 @@ pub fn emit_js_module(parsed: &ParsedJsModule, header_lines: &[String]) -> Resul
     emit_js_module_with_comments(parsed, header_lines, &BTreeMap::new(), &BTreeMap::new())
 }
 
+/// Serialize a standalone AST `Module` (e.g. a synthesized selector built by
+/// pruning a parsed module) with the same codegen as the rest of the pipeline.
+/// Spans are ignored, so `DUMMY_SP` nodes are fine.
+pub fn emit_module_source(module: &Module) -> Result<String> {
+    let cm: Lrc<SourceMap> = Lrc::default();
+    let mut buf = Vec::new();
+    {
+        let mut emitter = Emitter {
+            cfg: Config::default(),
+            cm: cm.clone(),
+            comments: None,
+            wr: JsWriter::new(cm, "\n", &mut buf, None),
+        };
+        emitter.emit_module(module)?;
+    }
+    Ok(String::from_utf8(buf)?.trim_end().to_string())
+}
+
 /// Number of post-comma-list-split positions a top-level body item
 /// produces. Mirrors the owner-graph fact splitter: `var x = ..., y
 /// = ...;` is one body item but two statement ordinals; other

--- a/devinfra/js/debundle/selector_candidate_index.rs
+++ b/devinfra/js/debundle/selector_candidate_index.rs
@@ -10,18 +10,14 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use anyhow::{Context, Result};
+use source_match_holes::{
+    ANYTHING_HOLE_KEYWORD, CLASS_REST_HOLE_KEYWORD, DECLARATORS_HOLE_KEYWORD, EXPR_HOLE_KEYWORD,
+    OBJECT_PROPS_HOLE_KEYWORD, STMT_HOLE_KEYWORD, STMT_LIST_HOLE_KEYWORD,
+    STRING_LITERAL_REGEX_PREDICATE, hole_name_for,
+};
 use spec::{AnonymousStatementSelector, BindingSourceKind, SourceMatchIdentifierMode};
 use swc_ecma_ast::*;
 use swc_ecma_visit::{Visit, VisitWith};
-
-const ANYTHING_HOLE_KEYWORD: &str = "ANYTHING";
-const EXPR_HOLE_KEYWORD: &str = "EXPR";
-const STMT_HOLE_KEYWORD: &str = "STMT";
-const STMT_LIST_HOLE_KEYWORD: &str = "STMT_LIST";
-const CLASS_REST_HOLE_KEYWORD: &str = "CLASS_REST";
-const DECLARATORS_HOLE_KEYWORD: &str = "DECLARATORS";
-const OBJECT_PROPS_HOLE_KEYWORD: &str = "OBJECT_PROPS";
-const STRING_LITERAL_REGEX_PREDICATE: &str = "STR_LITERAL_MATCHING_RE";
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
 pub enum TopLevelKind {
@@ -709,19 +705,12 @@ fn var_kind(kind: VarDeclKind) -> VarKind {
     }
 }
 
-fn hole_name(name: &str, keyword: &str) -> bool {
-    name == keyword
-        || name
-            .strip_prefix(keyword)
-            .is_some_and(|rest| rest.starts_with('_'))
-}
-
 fn expr_hole_name(expr: &Expr) -> Option<&str> {
     let Expr::Ident(ident) = expr else {
         return None;
     };
     let name = ident.sym.as_ref();
-    (hole_name(name, EXPR_HOLE_KEYWORD) || hole_name(name, ANYTHING_HOLE_KEYWORD)).then_some(name)
+    hole_name_for(name, EXPR_HOLE_KEYWORD).or_else(|| hole_name_for(name, ANYTHING_HOLE_KEYWORD))
 }
 
 fn stmt_hole_name(stmt: &Stmt) -> Option<&str> {
@@ -732,7 +721,7 @@ fn stmt_hole_name(stmt: &Stmt) -> Option<&str> {
         return None;
     };
     let name = ident.sym.as_ref();
-    (hole_name(name, STMT_HOLE_KEYWORD) || hole_name(name, ANYTHING_HOLE_KEYWORD)).then_some(name)
+    hole_name_for(name, STMT_HOLE_KEYWORD).or_else(|| hole_name_for(name, ANYTHING_HOLE_KEYWORD))
 }
 
 fn module_item_list_hole_name(item: &ModuleItem) -> Option<&str> {
@@ -742,8 +731,7 @@ fn module_item_list_hole_name(item: &ModuleItem) -> Option<&str> {
     let Expr::Ident(ident) = expr.expr.as_ref() else {
         return None;
     };
-    let name = ident.sym.as_ref();
-    hole_name(name, STMT_LIST_HOLE_KEYWORD).then_some(name)
+    hole_name_for(ident.sym.as_ref(), STMT_LIST_HOLE_KEYWORD)
 }
 
 fn declarator_list_hole_name(declarator: &VarDeclarator) -> Option<&str> {
@@ -751,8 +739,8 @@ fn declarator_list_hole_name(declarator: &VarDeclarator) -> Option<&str> {
         return None;
     };
     let name = ident.id.sym.as_ref();
-    (hole_name(name, DECLARATORS_HOLE_KEYWORD) || hole_name(name, ANYTHING_HOLE_KEYWORD))
-        .then_some(name)
+    hole_name_for(name, DECLARATORS_HOLE_KEYWORD)
+        .or_else(|| hole_name_for(name, ANYTHING_HOLE_KEYWORD))
 }
 
 fn object_property_list_hole_name(prop: &PropOrSpread) -> Option<&str> {
@@ -762,8 +750,8 @@ fn object_property_list_hole_name(prop: &PropOrSpread) -> Option<&str> {
     match prop.as_ref() {
         Prop::Shorthand(ident) => {
             let name = ident.sym.as_ref();
-            (hole_name(name, OBJECT_PROPS_HOLE_KEYWORD) || hole_name(name, ANYTHING_HOLE_KEYWORD))
-                .then_some(name)
+            hole_name_for(name, OBJECT_PROPS_HOLE_KEYWORD)
+                .or_else(|| hole_name_for(name, ANYTHING_HOLE_KEYWORD))
         }
         _ => None,
     }
@@ -780,8 +768,8 @@ fn class_rest_hole_name(member: &ClassMember) -> Option<&str> {
         return None;
     };
     let name = ident.sym.as_ref();
-    (hole_name(name, CLASS_REST_HOLE_KEYWORD) || hole_name(name, ANYTHING_HOLE_KEYWORD))
-        .then_some(name)
+    hole_name_for(name, CLASS_REST_HOLE_KEYWORD)
+        .or_else(|| hole_name_for(name, ANYTHING_HOLE_KEYWORD))
 }
 
 fn string_literal_regex_pattern_call(call: &CallExpr) -> bool {
@@ -804,7 +792,9 @@ fn callee_label(callee: &Callee) -> Option<String> {
 
 fn expr_label(expr: &Expr) -> Option<String> {
     match expr {
-        Expr::Ident(ident) if !hole_name(ident.sym.as_ref(), ANYTHING_HOLE_KEYWORD) => {
+        Expr::Ident(ident)
+            if hole_name_for(ident.sym.as_ref(), ANYTHING_HOLE_KEYWORD).is_none() =>
+        {
             Some(ident.sym.to_string())
         }
         Expr::Member(member) => {
@@ -829,11 +819,15 @@ fn object_key_label(prop: &PropOrSpread) -> Option<String> {
         return None;
     };
     match prop.as_ref() {
-        Prop::Shorthand(ident) if !hole_name(ident.sym.as_ref(), ANYTHING_HOLE_KEYWORD) => {
+        Prop::Shorthand(ident)
+            if hole_name_for(ident.sym.as_ref(), ANYTHING_HOLE_KEYWORD).is_none() =>
+        {
             Some(ident.sym.to_string())
         }
         Prop::KeyValue(prop) => prop_name_label(&prop.key),
-        Prop::Assign(prop) if !hole_name(prop.key.sym.as_ref(), ANYTHING_HOLE_KEYWORD) => {
+        Prop::Assign(prop)
+            if hole_name_for(prop.key.sym.as_ref(), ANYTHING_HOLE_KEYWORD).is_none() =>
+        {
             Some(prop.key.sym.to_string())
         }
         Prop::Getter(prop) => prop_name_label(&prop.key),
@@ -859,7 +853,9 @@ fn class_member_label(member: &ClassMember) -> Option<String> {
 
 fn prop_name_label(name: &PropName) -> Option<String> {
     match name {
-        PropName::Ident(ident) if !hole_name(ident.sym.as_ref(), ANYTHING_HOLE_KEYWORD) => {
+        PropName::Ident(ident)
+            if hole_name_for(ident.sym.as_ref(), ANYTHING_HOLE_KEYWORD).is_none() =>
+        {
             Some(ident.sym.to_string())
         }
         PropName::Ident(_) => None,

--- a/devinfra/js/debundle/selector_candidate_index.rs
+++ b/devinfra/js/debundle/selector_candidate_index.rs
@@ -1,0 +1,1047 @@
+//! Cheap candidate indexing for source-match selector search.
+//!
+//! This crate is intentionally a prefilter, not a replacement for the
+//! production `source_match` matcher. It builds one per-chunk inverted index of
+//! top-level statement features, then answers "which body items or declared
+//! bindings could this partial selector still match?" by intersecting posting
+//! lists. A returned candidate set may contain false positives; it must not
+//! omit a real matcher result.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use anyhow::{Context, Result};
+use spec::{AnonymousStatementSelector, BindingSourceKind, SourceMatchIdentifierMode};
+use swc_ecma_ast::*;
+use swc_ecma_visit::{Visit, VisitWith};
+
+const ANYTHING_HOLE_KEYWORD: &str = "ANYTHING";
+const EXPR_HOLE_KEYWORD: &str = "EXPR";
+const STMT_HOLE_KEYWORD: &str = "STMT";
+const STMT_LIST_HOLE_KEYWORD: &str = "STMT_LIST";
+const CLASS_REST_HOLE_KEYWORD: &str = "CLASS_REST";
+const DECLARATORS_HOLE_KEYWORD: &str = "DECLARATORS";
+const OBJECT_PROPS_HOLE_KEYWORD: &str = "OBJECT_PROPS";
+const STRING_LITERAL_REGEX_PREDICATE: &str = "STR_LITERAL_MATCHING_RE";
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+pub enum TopLevelKind {
+    ImportDeclaration,
+    FunctionDeclaration,
+    ClassDeclaration,
+    VariableDeclaration,
+    ExportedFunctionDeclaration,
+    ExportedClassDeclaration,
+    ExportedVariableDeclaration,
+    ExpressionStatement,
+    Statement,
+    ModuleDeclaration,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+pub enum VarKind {
+    Var,
+    Let,
+    Const,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub enum SelectorFeature {
+    TopLevelKind(TopLevelKind),
+    VarKind(VarKind),
+    FunctionArity(usize),
+    StringLiteral(String),
+    ObjectKey(String),
+    ClassMember(String),
+    MemberProperty(String),
+    CallCallee(String),
+    ImportSource(String),
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct IndexedBindingCandidate {
+    pub body_idx: usize,
+    pub binding_idx: usize,
+    pub declarator_idx: Option<usize>,
+    pub name: String,
+    pub kind: BindingSourceKind,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct IndexedTopLevelCandidate {
+    pub body_idx: usize,
+    pub kind: TopLevelKind,
+    pub declared_bindings: Vec<IndexedBindingCandidate>,
+    pub features: BTreeSet<SelectorFeature>,
+}
+
+#[derive(Debug, Clone, Default, Eq, PartialEq)]
+pub struct CandidateSet {
+    body_indices: BTreeSet<usize>,
+}
+
+impl CandidateSet {
+    pub fn all(body_indices: impl IntoIterator<Item = usize>) -> Self {
+        Self {
+            body_indices: body_indices.into_iter().collect(),
+        }
+    }
+
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    pub fn len(&self) -> usize {
+        self.body_indices.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.body_indices.is_empty()
+    }
+
+    pub fn contains(&self, body_idx: usize) -> bool {
+        self.body_indices.contains(&body_idx)
+    }
+
+    pub fn body_indices(&self) -> impl Iterator<Item = usize> + '_ {
+        self.body_indices.iter().copied()
+    }
+
+    pub fn intersect(&self, other: &CandidateSet) -> CandidateSet {
+        CandidateSet {
+            body_indices: self
+                .body_indices
+                .intersection(&other.body_indices)
+                .copied()
+                .collect(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Eq, PartialEq)]
+pub struct SelectorCandidateQuery {
+    alternatives: Vec<SelectorCandidateAlternative>,
+}
+
+impl SelectorCandidateQuery {
+    pub fn all() -> Self {
+        Self {
+            alternatives: vec![SelectorCandidateAlternative::default()],
+        }
+    }
+
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    pub fn alternatives(&self) -> &[SelectorCandidateAlternative] {
+        &self.alternatives
+    }
+}
+
+#[derive(Debug, Clone, Default, Eq, PartialEq)]
+pub struct SelectorCandidateAlternative {
+    features: BTreeSet<SelectorFeature>,
+    binding_projection: Option<BindingProjection>,
+}
+
+impl SelectorCandidateAlternative {
+    pub fn features(&self) -> &BTreeSet<SelectorFeature> {
+        &self.features
+    }
+
+    pub fn binding_projection(&self) -> Option<&BindingProjection> {
+        self.binding_projection.as_ref()
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct BindingProjection {
+    pub binding_idx: usize,
+    pub kind: BindingSourceKind,
+}
+
+pub struct SelectorCandidateIndex {
+    items: Vec<IndexedTopLevelCandidate>,
+    feature_to_body_indices: BTreeMap<SelectorFeature, BTreeSet<usize>>,
+}
+
+impl SelectorCandidateIndex {
+    pub fn new(module: &Module) -> Self {
+        let mut items = Vec::new();
+        let mut feature_to_body_indices: BTreeMap<SelectorFeature, BTreeSet<usize>> =
+            BTreeMap::new();
+        for (body_idx, item) in module.body.iter().enumerate() {
+            let indexed = IndexedTopLevelCandidate::from_module_item(body_idx, item);
+            for feature in &indexed.features {
+                feature_to_body_indices
+                    .entry(feature.clone())
+                    .or_default()
+                    .insert(body_idx);
+            }
+            items.push(indexed);
+        }
+        Self {
+            items,
+            feature_to_body_indices,
+        }
+    }
+
+    pub fn top_level_candidates(&self) -> &[IndexedTopLevelCandidate] {
+        &self.items
+    }
+
+    pub fn candidate(&self, body_idx: usize) -> Option<&IndexedTopLevelCandidate> {
+        self.items.get(body_idx)
+    }
+
+    pub fn candidate_set_for_feature(&self, feature: &SelectorFeature) -> CandidateSet {
+        CandidateSet {
+            body_indices: self
+                .feature_to_body_indices
+                .get(feature)
+                .cloned()
+                .unwrap_or_default(),
+        }
+    }
+
+    pub fn candidate_set_for_features<'a>(
+        &self,
+        features: impl IntoIterator<Item = &'a SelectorFeature>,
+    ) -> CandidateSet {
+        let mut postings = features
+            .into_iter()
+            .map(|feature| {
+                self.feature_to_body_indices
+                    .get(feature)
+                    .map(|body_indices| (feature, body_indices))
+            })
+            .collect::<Option<Vec<_>>>();
+        let Some(mut postings) = postings.take() else {
+            return CandidateSet::empty();
+        };
+        postings.sort_by_key(|(_, body_indices)| body_indices.len());
+        let Some((_, first)) = postings.first() else {
+            return CandidateSet::all(self.items.iter().map(|item| item.body_idx));
+        };
+        let mut body_indices = (*first).clone();
+        for (_, next) in postings.into_iter().skip(1) {
+            body_indices = body_indices.intersection(next).copied().collect();
+            if body_indices.is_empty() {
+                break;
+            }
+        }
+        CandidateSet { body_indices }
+    }
+
+    pub fn query_for_source_match(
+        selector: &AnonymousStatementSelector,
+    ) -> Result<SelectorCandidateQuery> {
+        js_ast::with_swc_globals(|| {
+            let parsed =
+                js_ast::parse_js_module_ast("<selector candidate query>", &selector.match_source)
+                    .with_context(|| {
+                    format!(
+                        "parsing source_match selector for candidate indexing:\n{}",
+                        selector.match_source
+                    )
+                })?;
+            Ok(query_for_selector_items(&parsed.body, selector))
+        })
+    }
+
+    pub fn candidate_set_for_query(&self, query: &SelectorCandidateQuery) -> CandidateSet {
+        if query.alternatives.is_empty() {
+            return CandidateSet::empty();
+        }
+        let mut body_indices = BTreeSet::new();
+        for alternative in &query.alternatives {
+            body_indices.extend(
+                self.candidate_set_for_features(&alternative.features)
+                    .body_indices,
+            );
+        }
+        CandidateSet { body_indices }
+    }
+
+    pub fn candidate_set_for_source_match(
+        &self,
+        selector: &AnonymousStatementSelector,
+    ) -> Result<CandidateSet> {
+        Ok(self.candidate_set_for_query(&Self::query_for_source_match(selector)?))
+    }
+
+    pub fn candidate_bindings_for_set(&self, set: &CandidateSet) -> Vec<IndexedBindingCandidate> {
+        set.body_indices()
+            .filter_map(|body_idx| self.candidate(body_idx))
+            .flat_map(|candidate| candidate.declared_bindings.iter().cloned())
+            .collect()
+    }
+
+    pub fn candidate_bindings_for_query(
+        &self,
+        query: &SelectorCandidateQuery,
+    ) -> Vec<IndexedBindingCandidate> {
+        let mut bindings = BTreeMap::new();
+        for alternative in &query.alternatives {
+            let set = self.candidate_set_for_features(&alternative.features);
+            for body_idx in set.body_indices() {
+                let Some(candidate) = self.candidate(body_idx) else {
+                    continue;
+                };
+                let projected = alternative
+                    .binding_projection
+                    .and_then(|projection| projected_binding(candidate, projection));
+                let iter: Box<dyn Iterator<Item = IndexedBindingCandidate>> =
+                    if let Some(binding) = projected {
+                        Box::new(std::iter::once(binding))
+                    } else {
+                        Box::new(candidate.declared_bindings.iter().cloned())
+                    };
+                for binding in iter {
+                    bindings.insert((binding.body_idx, binding.binding_idx), binding);
+                }
+            }
+        }
+        bindings.into_values().collect()
+    }
+
+    pub fn candidate_bindings_for_source_match(
+        &self,
+        selector: &AnonymousStatementSelector,
+    ) -> Result<Vec<IndexedBindingCandidate>> {
+        Ok(self.candidate_bindings_for_query(&Self::query_for_source_match(selector)?))
+    }
+}
+
+impl IndexedTopLevelCandidate {
+    fn from_module_item(body_idx: usize, item: &ModuleItem) -> Self {
+        let kind = top_level_kind(item);
+        let mut features = BTreeSet::from([SelectorFeature::TopLevelKind(kind)]);
+        collect_features_for_item(item, None, &mut features);
+        let declared_bindings = declared_bindings(item, body_idx);
+        Self {
+            body_idx,
+            kind,
+            declared_bindings,
+            features,
+        }
+    }
+}
+
+fn projected_binding(
+    candidate: &IndexedTopLevelCandidate,
+    projection: BindingProjection,
+) -> Option<IndexedBindingCandidate> {
+    candidate
+        .declared_bindings
+        .get(projection.binding_idx)
+        .filter(|binding| binding.kind == projection.kind)
+        .cloned()
+}
+
+fn query_for_selector_items(
+    items: &[ModuleItem],
+    selector: &AnonymousStatementSelector,
+) -> SelectorCandidateQuery {
+    let target_indices = target_item_indices(items, selector);
+    if target_indices.is_empty() {
+        return SelectorCandidateQuery::empty();
+    }
+
+    let alternatives = target_indices
+        .into_iter()
+        .filter_map(|item_idx| {
+            let item = items.get(item_idx)?;
+            if module_item_list_hole_name(item).is_some() {
+                return Some(SelectorCandidateAlternative::default());
+            }
+            let mut features =
+                BTreeSet::from([SelectorFeature::TopLevelKind(top_level_kind(item))]);
+            collect_features_for_item(item, Some(selector), &mut features);
+            let binding_projection = selector
+                .target_binding
+                .as_deref()
+                .and_then(|target| binding_projection_for_target(item, target));
+            Some(SelectorCandidateAlternative {
+                features,
+                binding_projection,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    if alternatives.is_empty() {
+        SelectorCandidateQuery::empty()
+    } else {
+        SelectorCandidateQuery { alternatives }
+    }
+}
+
+fn target_item_indices(items: &[ModuleItem], selector: &AnonymousStatementSelector) -> Vec<usize> {
+    if let Some(target_binding) = selector.target_binding.as_deref() {
+        return items
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, item)| {
+                declared_bindings(item, idx)
+                    .iter()
+                    .any(|binding| binding.name == target_binding)
+                    .then_some(idx)
+            })
+            .collect();
+    }
+    if let Some(target_statement) = selector.target_statement {
+        return (target_statement < items.len())
+            .then_some(target_statement)
+            .into_iter()
+            .collect();
+    }
+    if let Some(target_statements) = &selector.target_statements {
+        return match target_statements {
+            spec::TargetStatements::Indices(indices) => indices
+                .iter()
+                .copied()
+                .filter(|idx| *idx < items.len())
+                .collect(),
+            spec::TargetStatements::All(spec::TargetStatementsAll::All) => items
+                .iter()
+                .enumerate()
+                .filter_map(|(idx, item)| module_item_list_hole_name(item).is_none().then_some(idx))
+                .collect(),
+        };
+    }
+    match items {
+        [] => Vec::new(),
+        [single] if module_item_list_hole_name(single).is_some() => vec![0],
+        [_] => vec![0],
+        _ => items
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, item)| module_item_list_hole_name(item).is_none().then_some(idx))
+            .collect(),
+    }
+}
+
+fn binding_projection_for_target(
+    item: &ModuleItem,
+    target_binding: &str,
+) -> Option<BindingProjection> {
+    if item_var_decl(item).is_some_and(|var| {
+        var.decls
+            .iter()
+            .any(|declarator| declarator_list_hole_name(declarator).is_some())
+    }) {
+        return None;
+    }
+    let matches = declared_bindings(item, 0)
+        .into_iter()
+        .filter_map(|binding| {
+            (binding.name == target_binding).then_some(BindingProjection {
+                binding_idx: binding.binding_idx,
+                kind: binding.kind,
+            })
+        })
+        .collect::<Vec<_>>();
+    match matches.as_slice() {
+        [single] => Some(*single),
+        _ => None,
+    }
+}
+
+fn collect_features_for_item(
+    item: &ModuleItem,
+    selector: Option<&AnonymousStatementSelector>,
+    features: &mut BTreeSet<SelectorFeature>,
+) {
+    match item {
+        ModuleItem::Stmt(Stmt::Decl(decl)) => collect_decl_features(decl, features),
+        ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(export)) => {
+            collect_decl_features(&export.decl, features)
+        }
+        ModuleItem::ModuleDecl(ModuleDecl::Import(import)) => {
+            features.insert(SelectorFeature::ImportSource(
+                import.src.value.to_string_lossy().to_string(),
+            ));
+        }
+        _ => {}
+    }
+    item.visit_with(&mut AstFeatureCollector::new(selector, features));
+}
+
+fn collect_decl_features(decl: &Decl, features: &mut BTreeSet<SelectorFeature>) {
+    match decl {
+        Decl::Fn(function) => {
+            features.insert(SelectorFeature::FunctionArity(
+                function.function.params.len(),
+            ));
+        }
+        Decl::Class(class) => {
+            for member in &class.class.body {
+                if class_rest_hole_name(member).is_none()
+                    && let Some(label) = class_member_label(member)
+                {
+                    features.insert(SelectorFeature::ClassMember(label));
+                }
+            }
+        }
+        Decl::Var(var) => {
+            features.insert(SelectorFeature::VarKind(var_kind(var.kind)));
+        }
+        _ => {}
+    }
+}
+
+struct AstFeatureCollector<'a, 'features> {
+    selector: Option<&'a AnonymousStatementSelector>,
+    features: &'features mut BTreeSet<SelectorFeature>,
+}
+
+impl<'a, 'features> AstFeatureCollector<'a, 'features> {
+    fn new(
+        selector: Option<&'a AnonymousStatementSelector>,
+        features: &'features mut BTreeSet<SelectorFeature>,
+    ) -> Self {
+        Self { selector, features }
+    }
+
+    fn selector_uses_exact_identifiers(&self) -> bool {
+        self.selector
+            .is_none_or(|selector| selector.identifiers == SourceMatchIdentifierMode::Exact)
+    }
+
+    fn string_literal_is_wildcard(&self, value: &str) -> bool {
+        self.selector
+            .is_some_and(|selector| selector.wildcard_string_literals.contains(value))
+    }
+}
+
+impl Visit for AstFeatureCollector<'_, '_> {
+    fn visit_expr(&mut self, expr: &Expr) {
+        if expr_hole_name(expr).is_some() {
+            return;
+        }
+        if let Expr::Lit(Lit::Str(str_)) = expr {
+            let value = str_.value.to_string_lossy().to_string();
+            if !self.string_literal_is_wildcard(&value) {
+                self.features.insert(SelectorFeature::StringLiteral(value));
+            }
+            return;
+        }
+        expr.visit_children_with(self);
+    }
+
+    fn visit_call_expr(&mut self, call: &CallExpr) {
+        if string_literal_regex_pattern_call(call) {
+            return;
+        }
+        if self.selector_uses_exact_identifiers()
+            && let Some(callee) = callee_label(&call.callee)
+        {
+            self.features.insert(SelectorFeature::CallCallee(callee));
+        }
+        call.visit_children_with(self);
+    }
+
+    fn visit_member_prop(&mut self, prop: &MemberProp) {
+        if let Some(label) = member_prop_label(prop) {
+            self.features.insert(SelectorFeature::MemberProperty(label));
+        }
+        prop.visit_children_with(self);
+    }
+
+    fn visit_object_lit(&mut self, object: &ObjectLit) {
+        for prop in &object.props {
+            if object_property_list_hole_name(prop).is_some() {
+                continue;
+            }
+            if let Some(label) = object_key_label(prop) {
+                self.features.insert(SelectorFeature::ObjectKey(label));
+            }
+            prop.visit_with(self);
+        }
+    }
+
+    fn visit_class_member(&mut self, member: &ClassMember) {
+        if class_rest_hole_name(member).is_some() {
+            return;
+        }
+        if let Some(label) = class_member_label(member) {
+            self.features.insert(SelectorFeature::ClassMember(label));
+        }
+        member.visit_children_with(self);
+    }
+
+    fn visit_stmt(&mut self, stmt: &Stmt) {
+        if stmt_hole_name(stmt).is_some() {
+            return;
+        }
+        stmt.visit_children_with(self);
+    }
+
+    fn visit_var_declarator(&mut self, declarator: &VarDeclarator) {
+        if declarator_list_hole_name(declarator).is_some() {
+            declarator.init.visit_with(self);
+            return;
+        }
+        declarator.visit_children_with(self);
+    }
+}
+
+fn top_level_kind(item: &ModuleItem) -> TopLevelKind {
+    match item {
+        ModuleItem::ModuleDecl(ModuleDecl::Import(_)) => TopLevelKind::ImportDeclaration,
+        ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(export)) => match &export.decl {
+            Decl::Fn(_) => TopLevelKind::ExportedFunctionDeclaration,
+            Decl::Class(_) => TopLevelKind::ExportedClassDeclaration,
+            Decl::Var(_) => TopLevelKind::ExportedVariableDeclaration,
+            _ => TopLevelKind::ModuleDeclaration,
+        },
+        ModuleItem::ModuleDecl(_) => TopLevelKind::ModuleDeclaration,
+        ModuleItem::Stmt(Stmt::Decl(Decl::Fn(_))) => TopLevelKind::FunctionDeclaration,
+        ModuleItem::Stmt(Stmt::Decl(Decl::Class(_))) => TopLevelKind::ClassDeclaration,
+        ModuleItem::Stmt(Stmt::Decl(Decl::Var(_))) => TopLevelKind::VariableDeclaration,
+        ModuleItem::Stmt(Stmt::Expr(_)) => TopLevelKind::ExpressionStatement,
+        ModuleItem::Stmt(_) => TopLevelKind::Statement,
+    }
+}
+
+fn declared_bindings(item: &ModuleItem, body_idx: usize) -> Vec<IndexedBindingCandidate> {
+    let mut bindings = Vec::new();
+    match item {
+        ModuleItem::Stmt(Stmt::Decl(decl)) => {
+            declared_bindings_for_decl(decl, body_idx, &mut bindings);
+        }
+        ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(export)) => {
+            declared_bindings_for_decl(&export.decl, body_idx, &mut bindings);
+        }
+        ModuleItem::ModuleDecl(ModuleDecl::Import(import)) => {
+            for specifier in &import.specifiers {
+                let name = match specifier {
+                    ImportSpecifier::Named(named) => named.local.sym.to_string(),
+                    ImportSpecifier::Default(default) => default.local.sym.to_string(),
+                    ImportSpecifier::Namespace(namespace) => namespace.local.sym.to_string(),
+                };
+                push_binding(
+                    &mut bindings,
+                    body_idx,
+                    None,
+                    name,
+                    BindingSourceKind::ImportSpecifier,
+                );
+            }
+        }
+        _ => {}
+    }
+    bindings
+}
+
+fn declared_bindings_for_decl(
+    decl: &Decl,
+    body_idx: usize,
+    bindings: &mut Vec<IndexedBindingCandidate>,
+) {
+    match decl {
+        Decl::Fn(function) => push_binding(
+            bindings,
+            body_idx,
+            None,
+            function.ident.sym.to_string(),
+            BindingSourceKind::FunctionDeclaration,
+        ),
+        Decl::Class(class) => push_binding(
+            bindings,
+            body_idx,
+            None,
+            class.ident.sym.to_string(),
+            BindingSourceKind::ClassDeclaration,
+        ),
+        Decl::Var(var) => {
+            for (declarator_idx, declarator) in var.decls.iter().enumerate() {
+                if declarator_list_hole_name(declarator).is_some() {
+                    continue;
+                }
+                for name in binding_targets::binding_name_strings(&declarator.name) {
+                    push_binding(
+                        bindings,
+                        body_idx,
+                        Some(declarator_idx),
+                        name,
+                        BindingSourceKind::VariableDeclarator,
+                    );
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn push_binding(
+    bindings: &mut Vec<IndexedBindingCandidate>,
+    body_idx: usize,
+    declarator_idx: Option<usize>,
+    name: String,
+    kind: BindingSourceKind,
+) {
+    bindings.push(IndexedBindingCandidate {
+        body_idx,
+        binding_idx: bindings.len(),
+        declarator_idx,
+        name,
+        kind,
+    });
+}
+
+fn item_var_decl(item: &ModuleItem) -> Option<&VarDecl> {
+    match item {
+        ModuleItem::Stmt(Stmt::Decl(Decl::Var(var))) => Some(var),
+        ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(export)) => match &export.decl {
+            Decl::Var(var) => Some(var),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn var_kind(kind: VarDeclKind) -> VarKind {
+    match kind {
+        VarDeclKind::Var => VarKind::Var,
+        VarDeclKind::Let => VarKind::Let,
+        VarDeclKind::Const => VarKind::Const,
+    }
+}
+
+fn hole_name(name: &str, keyword: &str) -> bool {
+    name == keyword
+        || name
+            .strip_prefix(keyword)
+            .is_some_and(|rest| rest.starts_with('_'))
+}
+
+fn expr_hole_name(expr: &Expr) -> Option<&str> {
+    let Expr::Ident(ident) = expr else {
+        return None;
+    };
+    let name = ident.sym.as_ref();
+    (hole_name(name, EXPR_HOLE_KEYWORD) || hole_name(name, ANYTHING_HOLE_KEYWORD)).then_some(name)
+}
+
+fn stmt_hole_name(stmt: &Stmt) -> Option<&str> {
+    let Stmt::Expr(expr) = stmt else {
+        return None;
+    };
+    let Expr::Ident(ident) = expr.expr.as_ref() else {
+        return None;
+    };
+    let name = ident.sym.as_ref();
+    (hole_name(name, STMT_HOLE_KEYWORD) || hole_name(name, ANYTHING_HOLE_KEYWORD)).then_some(name)
+}
+
+fn module_item_list_hole_name(item: &ModuleItem) -> Option<&str> {
+    let ModuleItem::Stmt(Stmt::Expr(expr)) = item else {
+        return None;
+    };
+    let Expr::Ident(ident) = expr.expr.as_ref() else {
+        return None;
+    };
+    let name = ident.sym.as_ref();
+    hole_name(name, STMT_LIST_HOLE_KEYWORD).then_some(name)
+}
+
+fn declarator_list_hole_name(declarator: &VarDeclarator) -> Option<&str> {
+    let Pat::Ident(ident) = &declarator.name else {
+        return None;
+    };
+    let name = ident.id.sym.as_ref();
+    (hole_name(name, DECLARATORS_HOLE_KEYWORD) || hole_name(name, ANYTHING_HOLE_KEYWORD))
+        .then_some(name)
+}
+
+fn object_property_list_hole_name(prop: &PropOrSpread) -> Option<&str> {
+    let PropOrSpread::Prop(prop) = prop else {
+        return None;
+    };
+    match prop.as_ref() {
+        Prop::Shorthand(ident) => {
+            let name = ident.sym.as_ref();
+            (hole_name(name, OBJECT_PROPS_HOLE_KEYWORD) || hole_name(name, ANYTHING_HOLE_KEYWORD))
+                .then_some(name)
+        }
+        _ => None,
+    }
+}
+
+fn class_rest_hole_name(member: &ClassMember) -> Option<&str> {
+    let ClassMember::ClassProp(prop) = member else {
+        return None;
+    };
+    if prop.value.is_some() {
+        return None;
+    }
+    let PropName::Ident(ident) = &prop.key else {
+        return None;
+    };
+    let name = ident.sym.as_ref();
+    (hole_name(name, CLASS_REST_HOLE_KEYWORD) || hole_name(name, ANYTHING_HOLE_KEYWORD))
+        .then_some(name)
+}
+
+fn string_literal_regex_pattern_call(call: &CallExpr) -> bool {
+    let Callee::Expr(callee) = &call.callee else {
+        return false;
+    };
+    matches!(
+        callee.as_ref(),
+        Expr::Ident(ident) if ident.sym.as_ref() == STRING_LITERAL_REGEX_PREDICATE
+    )
+}
+
+fn callee_label(callee: &Callee) -> Option<String> {
+    match callee {
+        Callee::Expr(expr) => expr_label(expr),
+        Callee::Super(_) => Some("super".to_string()),
+        Callee::Import(_) => Some("import".to_string()),
+    }
+}
+
+fn expr_label(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Ident(ident) if !hole_name(ident.sym.as_ref(), ANYTHING_HOLE_KEYWORD) => {
+            Some(ident.sym.to_string())
+        }
+        Expr::Member(member) => {
+            let object = expr_label(&member.obj)?;
+            let prop = member_prop_label(&member.prop)?;
+            Some(format!("{object}.{prop}"))
+        }
+        _ => None,
+    }
+}
+
+fn member_prop_label(prop: &MemberProp) -> Option<String> {
+    match prop {
+        MemberProp::Ident(ident) => Some(ident.sym.to_string()),
+        MemberProp::PrivateName(private) => Some(format!("#{}", private.name)),
+        MemberProp::Computed(_) => None,
+    }
+}
+
+fn object_key_label(prop: &PropOrSpread) -> Option<String> {
+    let PropOrSpread::Prop(prop) = prop else {
+        return None;
+    };
+    match prop.as_ref() {
+        Prop::Shorthand(ident) if !hole_name(ident.sym.as_ref(), ANYTHING_HOLE_KEYWORD) => {
+            Some(ident.sym.to_string())
+        }
+        Prop::KeyValue(prop) => prop_name_label(&prop.key),
+        Prop::Assign(prop) if !hole_name(prop.key.sym.as_ref(), ANYTHING_HOLE_KEYWORD) => {
+            Some(prop.key.sym.to_string())
+        }
+        Prop::Getter(prop) => prop_name_label(&prop.key),
+        Prop::Setter(prop) => prop_name_label(&prop.key),
+        Prop::Method(prop) => prop_name_label(&prop.key),
+        _ => None,
+    }
+}
+
+fn class_member_label(member: &ClassMember) -> Option<String> {
+    match member {
+        ClassMember::Constructor(_) => Some("constructor".to_string()),
+        ClassMember::Method(method) => prop_name_label(&method.key),
+        ClassMember::PrivateMethod(method) => Some(format!("#{}", method.key.name)),
+        ClassMember::ClassProp(prop) => prop_name_label(&prop.key),
+        ClassMember::PrivateProp(prop) => Some(format!("#{}", prop.key.name)),
+        ClassMember::AutoAccessor(_) => None,
+        ClassMember::StaticBlock(_) | ClassMember::TsIndexSignature(_) | ClassMember::Empty(_) => {
+            None
+        }
+    }
+}
+
+fn prop_name_label(name: &PropName) -> Option<String> {
+    match name {
+        PropName::Ident(ident) if !hole_name(ident.sym.as_ref(), ANYTHING_HOLE_KEYWORD) => {
+            Some(ident.sym.to_string())
+        }
+        PropName::Ident(_) => None,
+        PropName::Str(str_) => Some(str_.value.to_string_lossy().to_string()),
+        PropName::Num(num) => Some(num.value.to_string()),
+        PropName::BigInt(bigint) => Some(bigint.value.to_string()),
+        PropName::Computed(_) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+
+    fn parse_module(source: &str) -> Module {
+        js_ast::with_swc_globals(|| js_ast::parse_js_module_ast("<test>", source).unwrap())
+    }
+
+    fn selector(match_source: &str) -> AnonymousStatementSelector {
+        AnonymousStatementSelector {
+            match_source: match_source.to_string(),
+            identifiers: SourceMatchIdentifierMode::AlphaAll,
+            target_binding: None,
+            target_statement: None,
+            target_statements: None,
+            wildcard_string_literals: BTreeSet::new(),
+        }
+    }
+
+    fn exact_selector(match_source: &str) -> AnonymousStatementSelector {
+        AnonymousStatementSelector {
+            identifiers: SourceMatchIdentifierMode::Exact,
+            ..selector(match_source)
+        }
+    }
+
+    fn body_indices(set: CandidateSet) -> Vec<usize> {
+        set.body_indices().collect()
+    }
+
+    #[test]
+    fn indexes_top_level_statement_features_for_intersection() {
+        let runtime = parse_module(
+            r#"const alpha = makeWidget("shared-token", { role: "button" });
+const beta = makeOther("shared-token", { role: "button" });
+let gamma = makeWidget("shared-token", { role: "button" });
+class Panel { render() {} mount() {} }
+class Worker { mount() {} }
+function combine(first, second) { return first + second; }
+sideEffect();"#,
+        );
+        let index = SelectorCandidateIndex::new(&runtime);
+
+        let shared_const = BTreeSet::from([
+            SelectorFeature::TopLevelKind(TopLevelKind::VariableDeclaration),
+            SelectorFeature::VarKind(VarKind::Const),
+            SelectorFeature::StringLiteral("shared-token".to_string()),
+        ]);
+        assert_eq!(
+            body_indices(index.candidate_set_for_features(&shared_const)),
+            vec![0, 1]
+        );
+
+        let narrowed = index.candidate_set_for_features(&shared_const).intersect(
+            &index
+                .candidate_set_for_feature(&SelectorFeature::CallCallee("makeWidget".to_string())),
+        );
+        assert_eq!(body_indices(narrowed), vec![0]);
+    }
+
+    #[test]
+    fn source_match_query_is_sound_for_class_selectors() {
+        let runtime = parse_module(
+            r#"class Panel { render() {} mount() {} }
+class Worker { mount() {} }
+function render(value) { return value; }"#,
+        );
+        let index = SelectorCandidateIndex::new(&runtime);
+        let selector = selector("class ReadableName {\n  render() {}\n  CLASS_REST;\n}");
+
+        let exact = js_ast::with_swc_globals(|| {
+            source_match::find_anonymous_statement_body_indices(&runtime, "<test>", &selector)
+                .unwrap()
+        });
+        let candidate_set = index.candidate_set_for_source_match(&selector).unwrap();
+
+        assert_eq!(exact, vec![0]);
+        assert!(exact.into_iter().all(|idx| candidate_set.contains(idx)));
+        assert_eq!(body_indices(candidate_set), vec![0]);
+    }
+
+    #[test]
+    fn alpha_queries_do_not_treat_callee_identifiers_as_exact() {
+        let runtime = parse_module(
+            r#"const alpha = makeWidget("shared-token");
+const beta = makeOther("shared-token");"#,
+        );
+        let index = SelectorCandidateIndex::new(&runtime);
+        let selector = selector(r#"const readable = makeWidget("shared-token");"#);
+        let query = SelectorCandidateIndex::query_for_source_match(&selector).unwrap();
+
+        assert!(
+            !query.alternatives()[0]
+                .features()
+                .contains(&SelectorFeature::CallCallee("makeWidget".to_string()))
+        );
+        assert_eq!(
+            body_indices(index.candidate_set_for_query(&query)),
+            vec![0, 1]
+        );
+    }
+
+    #[test]
+    fn exact_queries_can_use_callee_identifiers() {
+        let runtime = parse_module(
+            r#"const alpha = makeWidget("shared-token");
+const alpha = makeOther("shared-token");"#,
+        );
+        let index = SelectorCandidateIndex::new(&runtime);
+        let selector = exact_selector(r#"const alpha = makeWidget("shared-token");"#);
+        let query = SelectorCandidateIndex::query_for_source_match(&selector).unwrap();
+
+        assert!(
+            query.alternatives()[0]
+                .features()
+                .contains(&SelectorFeature::CallCallee("makeWidget".to_string()))
+        );
+        assert_eq!(body_indices(index.candidate_set_for_query(&query)), vec![0]);
+    }
+
+    #[test]
+    fn wildcard_string_literals_are_not_index_anchors() {
+        let runtime = parse_module(
+            r#"const alpha = "runtime-a";
+const beta = "runtime-b";
+let gamma = "runtime-a";"#,
+        );
+        let index = SelectorCandidateIndex::new(&runtime);
+        let mut selector = selector(r#"const readable = "STRING_HOLE";"#);
+        selector
+            .wildcard_string_literals
+            .insert("STRING_HOLE".to_string());
+
+        let query = SelectorCandidateIndex::query_for_source_match(&selector).unwrap();
+        assert!(
+            !query.alternatives()[0]
+                .features()
+                .iter()
+                .any(|feature| matches!(feature, SelectorFeature::StringLiteral(_)))
+        );
+        assert_eq!(
+            body_indices(index.candidate_set_for_query(&query)),
+            vec![0, 1]
+        );
+    }
+
+    #[test]
+    fn target_binding_projection_returns_candidate_bindings() {
+        let runtime = parse_module(
+            r#"const runtimeName = "stable-token";
+const other = "other-token";
+function stableFn() {}"#,
+        );
+        let index = SelectorCandidateIndex::new(&runtime);
+        let mut selector = selector(r#"const readableName = "stable-token";"#);
+        selector.target_binding = Some("readableName".to_string());
+
+        let bindings = index
+            .candidate_bindings_for_source_match(&selector)
+            .unwrap()
+            .into_iter()
+            .map(|binding| (binding.body_idx, binding.name, binding.kind))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            bindings,
+            vec![(
+                0,
+                "runtimeName".to_string(),
+                BindingSourceKind::VariableDeclarator
+            )]
+        );
+    }
+}

--- a/devinfra/js/debundle/selector_codemod.rs
+++ b/devinfra/js/debundle/selector_codemod.rs
@@ -26,12 +26,16 @@ use swc_ecma_visit::{Visit, VisitWith};
 const ANYTHING_HOLE_KEYWORD: &str = "ANYTHING";
 const EXPR_HOLE_KEYWORD: &str = "EXPR";
 const STMT_HOLE_KEYWORD: &str = "STMT";
+const STMT_LIST_HOLE_KEYWORD: &str = "STMT_LIST";
 const CLASS_REST_HOLE_KEYWORD: &str = "CLASS_REST";
 const DECLARATORS_HOLE_KEYWORD: &str = "DECLARATORS";
 const ARGS_HOLE_KEYWORD: &str = "ARGS";
 const OBJECT_PROPS_HOLE_KEYWORD: &str = "OBJECT_PROPS";
 const MAX_VAR_GROUP_FRONTIER_TUPLES_PER_DECL: usize = 4096;
 const MAX_VAR_FEATURE_SEARCH_NODES: usize = 200_000;
+const MAX_FUNCTION_SELECTOR_CANDIDATES: usize = 512;
+const MAX_EXPR_SELECTOR_VARIANTS: usize = 16;
+const MAX_STMT_SELECTOR_VARIANTS: usize = 24;
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1292,33 +1296,50 @@ fn synthesize_specialized_function_selector(
     let Some(Decl::Fn(function)) = item_decl(item) else {
         return Ok(None);
     };
+    let header = render_function_selector_header(&function.function, &target.export_name);
     let mut features = BTreeSet::from([
         SelectorAnchorFeature::DeclarationKind(IndexedDeclarationKind::Function),
         SelectorAnchorFeature::FunctionArity(function.function.params.len()),
     ]);
     if !frontier_is_small_and_contains_target(index, decl, &features) {
+        let mut candidates = render_function_body_selector_candidates(index, &function.function)?;
+        candidates.sort_by_key(|candidate| (candidate.cost, candidate.source.len()));
+        for body in candidates
+            .into_iter()
+            .take(MAX_FUNCTION_SELECTOR_CANDIDATES)
+        {
+            let match_source = format!("{header} {{\n{}\n}}", indent_lines(&body.source, "  "));
+            if prove_synthesized_selector(index, decl, targets, &match_source).is_ok() {
+                return Ok(Some(SpecializedSelector {
+                    match_source,
+                    rewritten_holes: body.holes,
+                }));
+            }
+        }
         return Ok(None);
     }
-    let params = function
-        .function
-        .params
-        .iter()
-        .map(|_| ANYTHING_HOLE_KEYWORD)
-        .collect::<Vec<_>>()
-        .join(", ");
     features.insert(SelectorAnchorFeature::DeclarationKind(
         IndexedDeclarationKind::Function,
     ));
     Ok(Some(SpecializedSelector {
-        match_source: format!(
-            "function {}({params}) {{\n  STMT_LIST;\n}}",
-            target.export_name
-        ),
+        match_source: format!("{header} {{\n  STMT_LIST;\n}}"),
         rewritten_holes: BTreeSet::from([
             ANYTHING_HOLE_KEYWORD.to_string(),
             "STMT_LIST".to_string(),
         ]),
     }))
+}
+
+fn render_function_selector_header(function: &Function, name: &str) -> String {
+    let params = function
+        .params
+        .iter()
+        .map(|_| ANYTHING_HOLE_KEYWORD)
+        .collect::<Vec<_>>()
+        .join(", ");
+    let async_prefix = if function.is_async { "async " } else { "" };
+    let generator_suffix = if function.is_generator { "*" } else { "" };
+    format!("{async_prefix}function{generator_suffix} {name}({params})")
 }
 
 fn synthesize_specialized_class_selector(
@@ -2038,6 +2059,21 @@ fn target_tuple_is_unique(
 struct RenderedExprSelector {
     source: String,
     holes: BTreeSet<String>,
+    cost: usize,
+}
+
+#[derive(Debug, Clone)]
+struct RenderedStmtSelector {
+    source: String,
+    holes: BTreeSet<String>,
+    cost: usize,
+}
+
+#[derive(Debug, Clone)]
+struct RenderedStmtListSelector {
+    source: String,
+    holes: BTreeSet<String>,
+    cost: usize,
 }
 
 fn render_specialized_expr_selector(
@@ -2055,6 +2091,7 @@ fn render_specialized_expr_selector(
         _ => Ok(RenderedExprSelector {
             source: ANYTHING_HOLE_KEYWORD.to_string(),
             holes: BTreeSet::from([ANYTHING_HOLE_KEYWORD.to_string()]),
+            cost: 0,
         }),
     }
 }
@@ -2094,6 +2131,7 @@ fn render_specialized_call_selector(
     Ok(RenderedExprSelector {
         source: format!("{callee}({})", args.join(", ")),
         holes,
+        cost: 2,
     })
 }
 
@@ -2126,6 +2164,7 @@ fn render_specialized_object_selector(
     RenderedExprSelector {
         source: format!("{{ {} }}", parts.join(", ")),
         holes: BTreeSet::from([ANYTHING_HOLE_KEYWORD.to_string()]),
+        cost: 1,
     }
 }
 
@@ -2133,7 +2172,738 @@ fn anything_expr_selector() -> RenderedExprSelector {
     RenderedExprSelector {
         source: ANYTHING_HOLE_KEYWORD.to_string(),
         holes: BTreeSet::from([ANYTHING_HOLE_KEYWORD.to_string()]),
+        cost: 0,
     }
+}
+
+fn render_function_body_selector_candidates(
+    index: &ChunkSelectorIndex,
+    function: &Function,
+) -> Result<Vec<RenderedStmtListSelector>> {
+    let Some(body) = &function.body else {
+        return Ok(Vec::new());
+    };
+    render_stmt_list_selector_candidates(index, &body.stmts)
+}
+
+fn render_stmt_list_selector_candidates(
+    index: &ChunkSelectorIndex,
+    stmts: &[Stmt],
+) -> Result<Vec<RenderedStmtListSelector>> {
+    if stmts.is_empty() {
+        return Ok(vec![RenderedStmtListSelector {
+            source: format!("{STMT_LIST_HOLE_KEYWORD};"),
+            holes: BTreeSet::from([STMT_LIST_HOLE_KEYWORD.to_string()]),
+            cost: 0,
+        }]);
+    }
+
+    let mut per_stmt = Vec::new();
+    for stmt in stmts {
+        per_stmt.push(render_stmt_selector_variants(index, stmt)?);
+    }
+
+    let mut out = Vec::new();
+    let mut seen = BTreeSet::new();
+    for (stmt_idx, variants) in per_stmt.iter().enumerate() {
+        for stmt in variants.iter().take(MAX_STMT_SELECTOR_VARIANTS) {
+            push_stmt_list_candidate(
+                &mut out,
+                &mut seen,
+                stmts.len(),
+                &[(stmt_idx, stmt.clone())],
+            );
+        }
+    }
+
+    for first_idx in 0..per_stmt.len() {
+        for second_idx in (first_idx + 1)..per_stmt.len() {
+            for first in per_stmt[first_idx].iter().take(4) {
+                for second in per_stmt[second_idx].iter().take(4) {
+                    push_stmt_list_candidate(
+                        &mut out,
+                        &mut seen,
+                        stmts.len(),
+                        &[(first_idx, first.clone()), (second_idx, second.clone())],
+                    );
+                    if out.len() >= MAX_FUNCTION_SELECTOR_CANDIDATES {
+                        break;
+                    }
+                }
+                if out.len() >= MAX_FUNCTION_SELECTOR_CANDIDATES {
+                    break;
+                }
+            }
+            if out.len() >= MAX_FUNCTION_SELECTOR_CANDIDATES {
+                break;
+            }
+        }
+        if out.len() >= MAX_FUNCTION_SELECTOR_CANDIDATES {
+            break;
+        }
+    }
+
+    out.sort_by_key(|candidate| (candidate.cost, candidate.source.len()));
+    out.truncate(MAX_FUNCTION_SELECTOR_CANDIDATES);
+    Ok(out)
+}
+
+fn push_stmt_list_candidate(
+    out: &mut Vec<RenderedStmtListSelector>,
+    seen: &mut BTreeSet<String>,
+    len: usize,
+    anchors: &[(usize, RenderedStmtSelector)],
+) {
+    if anchors.is_empty() {
+        return;
+    }
+    let mut lines = Vec::new();
+    let mut holes = BTreeSet::new();
+    let mut cost = 0usize;
+    let mut previous_end = 0usize;
+    for (idx, stmt) in anchors {
+        if *idx > previous_end {
+            lines.push(format!("{STMT_LIST_HOLE_KEYWORD};"));
+            holes.insert(STMT_LIST_HOLE_KEYWORD.to_string());
+            cost += 1;
+        }
+        lines.push(stmt.source.clone());
+        holes.extend(stmt.holes.clone());
+        cost += stmt.cost;
+        previous_end = idx + 1;
+    }
+    if previous_end < len {
+        lines.push(format!("{STMT_LIST_HOLE_KEYWORD};"));
+        holes.insert(STMT_LIST_HOLE_KEYWORD.to_string());
+        cost += 1;
+    }
+    let source = lines.join("\n");
+    if seen.insert(source.clone()) {
+        out.push(RenderedStmtListSelector {
+            source,
+            holes,
+            cost,
+        });
+    }
+}
+
+fn render_stmt_selector_variants(
+    index: &ChunkSelectorIndex,
+    stmt: &Stmt,
+) -> Result<Vec<RenderedStmtSelector>> {
+    let mut out = Vec::new();
+    let mut seen = BTreeSet::new();
+    match stmt {
+        Stmt::Expr(expr_stmt) => {
+            for expr in render_expr_selector_variants(index, &expr_stmt.expr)? {
+                push_stmt_variant(
+                    &mut out,
+                    &mut seen,
+                    format!("{};", expr.source),
+                    expr.holes,
+                    expr.cost + 1,
+                );
+            }
+        }
+        Stmt::Return(return_stmt) => {
+            if let Some(arg) = &return_stmt.arg {
+                for expr in render_expr_selector_variants(index, arg)? {
+                    push_stmt_variant(
+                        &mut out,
+                        &mut seen,
+                        format!("return {};", expr.source),
+                        expr.holes,
+                        expr.cost + 1,
+                    );
+                }
+            } else {
+                push_stmt_variant(
+                    &mut out,
+                    &mut seen,
+                    "return;".to_string(),
+                    BTreeSet::new(),
+                    1,
+                );
+            }
+        }
+        Stmt::Throw(throw_stmt) => {
+            for expr in render_expr_selector_variants(index, &throw_stmt.arg)? {
+                push_stmt_variant(
+                    &mut out,
+                    &mut seen,
+                    format!("throw {};", expr.source),
+                    expr.holes,
+                    expr.cost + 1,
+                );
+            }
+        }
+        Stmt::Decl(Decl::Var(var)) => {
+            for (idx, declarator) in var.decls.iter().enumerate() {
+                let pat = source_for_span(index, declarator.name.span())?.text;
+                let expr_variants = if let Some(init) = declarator.init.as_deref() {
+                    render_expr_selector_variants(index, init)?
+                } else {
+                    vec![RenderedExprSelector {
+                        source: String::new(),
+                        holes: BTreeSet::new(),
+                        cost: 0,
+                    }]
+                };
+                for expr in expr_variants.into_iter().take(MAX_EXPR_SELECTOR_VARIANTS) {
+                    let mut parts = Vec::new();
+                    let mut holes = expr.holes.clone();
+                    let mut cost = expr.cost + 1;
+                    if idx > 0 {
+                        parts.push(format!("{DECLARATORS_HOLE_KEYWORD}_BEFORE = null"));
+                        holes.insert(format!("{DECLARATORS_HOLE_KEYWORD}_BEFORE"));
+                        cost += 1;
+                    }
+                    let declarator_source = if declarator.init.is_some() {
+                        format!("{pat} = {}", expr.source)
+                    } else {
+                        pat.clone()
+                    };
+                    parts.push(declarator_source);
+                    if idx + 1 < var.decls.len() {
+                        parts.push(format!("{DECLARATORS_HOLE_KEYWORD}_AFTER = null"));
+                        holes.insert(format!("{DECLARATORS_HOLE_KEYWORD}_AFTER"));
+                        cost += 1;
+                    }
+                    push_stmt_variant(
+                        &mut out,
+                        &mut seen,
+                        format!("{} {};", var_kind_label(var.kind), parts.join(",\n  ")),
+                        holes,
+                        cost,
+                    );
+                }
+            }
+        }
+        Stmt::If(if_stmt) => {
+            for test in render_expr_selector_variants(index, &if_stmt.test)? {
+                let (cons_source, mut cons_holes, cons_cost) =
+                    render_stmt_as_block_selector(index, &if_stmt.cons)?;
+                let mut holes = test.holes.clone();
+                holes.append(&mut cons_holes);
+                push_stmt_variant(
+                    &mut out,
+                    &mut seen,
+                    format!(
+                        "if ({}) {{\n{}\n}}",
+                        test.source,
+                        indent_lines(&cons_source, "  ")
+                    ),
+                    holes,
+                    test.cost + cons_cost + 1,
+                );
+            }
+            if let Stmt::Block(block) = if_stmt.cons.as_ref() {
+                for body in render_stmt_list_selector_candidates(index, &block.stmts)?
+                    .into_iter()
+                    .take(MAX_STMT_SELECTOR_VARIANTS)
+                {
+                    let mut holes = body.holes;
+                    holes.insert(ANYTHING_HOLE_KEYWORD.to_string());
+                    push_stmt_variant(
+                        &mut out,
+                        &mut seen,
+                        format!(
+                            "if ({ANYTHING_HOLE_KEYWORD}) {{\n{}\n}}",
+                            indent_lines(&body.source, "  ")
+                        ),
+                        holes,
+                        body.cost + 2,
+                    );
+                }
+            }
+        }
+        Stmt::Try(try_stmt) => {
+            for body in render_stmt_list_selector_candidates(index, &try_stmt.block.stmts)?
+                .into_iter()
+                .take(MAX_STMT_SELECTOR_VARIANTS)
+            {
+                let mut holes = body.holes;
+                let catch_source = render_catch_clause_skeleton(&try_stmt.handler);
+                holes.insert(STMT_LIST_HOLE_KEYWORD.to_string());
+                if catch_source.contains(ANYTHING_HOLE_KEYWORD) {
+                    holes.insert(ANYTHING_HOLE_KEYWORD.to_string());
+                }
+                let finalizer_source = try_stmt
+                    .finalizer
+                    .as_ref()
+                    .map(|_| format!(" finally {{\n  {STMT_LIST_HOLE_KEYWORD};\n}}"))
+                    .unwrap_or_default();
+                push_stmt_variant(
+                    &mut out,
+                    &mut seen,
+                    format!(
+                        "try {{\n{}\n}}{catch_source}{finalizer_source}",
+                        indent_lines(&body.source, "  ")
+                    ),
+                    holes,
+                    body.cost + 2,
+                );
+            }
+        }
+        Stmt::Block(block) => {
+            for body in render_stmt_list_selector_candidates(index, &block.stmts)?
+                .into_iter()
+                .take(MAX_STMT_SELECTOR_VARIANTS)
+            {
+                push_stmt_variant(
+                    &mut out,
+                    &mut seen,
+                    format!("{{\n{}\n}}", indent_lines(&body.source, "  ")),
+                    body.holes,
+                    body.cost + 1,
+                );
+            }
+        }
+        _ => {}
+    }
+
+    let exact = source_for_span(index, stmt.span())?.text;
+    push_stmt_variant(
+        &mut out,
+        &mut seen,
+        ensure_statement_semicolon(stmt, exact),
+        BTreeSet::new(),
+        1000,
+    );
+    out.sort_by_key(|variant| (variant.cost, variant.source.len()));
+    out.truncate(MAX_STMT_SELECTOR_VARIANTS);
+    Ok(out)
+}
+
+fn render_stmt_as_block_selector(
+    index: &ChunkSelectorIndex,
+    stmt: &Stmt,
+) -> Result<(String, BTreeSet<String>, usize)> {
+    if let Stmt::Block(block) = stmt {
+        let body = render_stmt_list_selector_candidates(index, &block.stmts)?
+            .into_iter()
+            .next()
+            .unwrap_or(RenderedStmtListSelector {
+                source: format!("{STMT_LIST_HOLE_KEYWORD};"),
+                holes: BTreeSet::from([STMT_LIST_HOLE_KEYWORD.to_string()]),
+                cost: 0,
+            });
+        return Ok((body.source, body.holes, body.cost));
+    }
+    let stmt = render_stmt_selector_variants(index, stmt)?
+        .into_iter()
+        .next()
+        .context("statement had no renderable selector variants")?;
+    Ok((stmt.source, stmt.holes, stmt.cost))
+}
+
+fn render_catch_clause_skeleton(handler: &Option<CatchClause>) -> String {
+    let Some(handler) = handler else {
+        return String::new();
+    };
+    let param = if handler.param.is_some() {
+        format!(" ({ANYTHING_HOLE_KEYWORD})")
+    } else {
+        String::new()
+    };
+    format!(" catch{param} {{\n  {STMT_LIST_HOLE_KEYWORD};\n}}")
+}
+
+fn push_stmt_variant(
+    out: &mut Vec<RenderedStmtSelector>,
+    seen: &mut BTreeSet<String>,
+    source: String,
+    holes: BTreeSet<String>,
+    cost: usize,
+) {
+    if seen.insert(source.clone()) {
+        out.push(RenderedStmtSelector {
+            source,
+            holes,
+            cost,
+        });
+    }
+}
+
+fn render_expr_selector_variants(
+    index: &ChunkSelectorIndex,
+    expr: &Expr,
+) -> Result<Vec<RenderedExprSelector>> {
+    let mut out = Vec::new();
+    let mut seen = BTreeSet::new();
+    push_expr_variant(&mut out, &mut seen, anything_expr_selector());
+    match expr {
+        Expr::Lit(_) => {
+            push_expr_variant(
+                &mut out,
+                &mut seen,
+                RenderedExprSelector {
+                    source: source_for_span(index, expr.span())?.text,
+                    holes: BTreeSet::new(),
+                    cost: 1,
+                },
+            );
+        }
+        Expr::Member(member) => {
+            for variant in render_member_expr_selector_variants(index, member)? {
+                push_expr_variant(&mut out, &mut seen, variant);
+            }
+        }
+        Expr::Call(call) => {
+            for variant in render_call_expr_selector_variants(index, call)? {
+                push_expr_variant(&mut out, &mut seen, variant);
+            }
+        }
+        Expr::New(new_expr) => {
+            let callee = source_for_span(index, new_expr.callee.span())?.text;
+            let args = new_expr.args.as_deref().unwrap_or_default();
+            push_expr_variant(
+                &mut out,
+                &mut seen,
+                RenderedExprSelector {
+                    source: format!(
+                        "new {callee}({})",
+                        vec![ANYTHING_HOLE_KEYWORD; args.len()].join(", ")
+                    ),
+                    holes: BTreeSet::from([ANYTHING_HOLE_KEYWORD.to_string()]),
+                    cost: 2,
+                },
+            );
+        }
+        Expr::Object(object) => {
+            for variant in render_object_expr_selector_variants(index, object)? {
+                push_expr_variant(&mut out, &mut seen, variant);
+            }
+        }
+        Expr::Await(await_expr) => {
+            for arg in render_expr_selector_variants(index, &await_expr.arg)?
+                .into_iter()
+                .take(MAX_EXPR_SELECTOR_VARIANTS)
+            {
+                push_expr_variant(
+                    &mut out,
+                    &mut seen,
+                    RenderedExprSelector {
+                        source: format!("await {}", arg.source),
+                        holes: arg.holes,
+                        cost: arg.cost + 1,
+                    },
+                );
+            }
+        }
+        Expr::Unary(unary) => {
+            for arg in render_expr_selector_variants(index, &unary.arg)?
+                .into_iter()
+                .take(MAX_EXPR_SELECTOR_VARIANTS)
+            {
+                push_expr_variant(
+                    &mut out,
+                    &mut seen,
+                    RenderedExprSelector {
+                        source: format!("{}{}", unary.op.as_str(), arg.source),
+                        holes: arg.holes,
+                        cost: arg.cost + 1,
+                    },
+                );
+            }
+        }
+        Expr::Bin(bin) => {
+            for left in render_expr_selector_variants(index, &bin.left)?
+                .into_iter()
+                .filter(|variant| variant.source != ANYTHING_HOLE_KEYWORD)
+                .take(4)
+            {
+                let mut holes = left.holes;
+                holes.insert(ANYTHING_HOLE_KEYWORD.to_string());
+                push_expr_variant(
+                    &mut out,
+                    &mut seen,
+                    RenderedExprSelector {
+                        source: format!(
+                            "{} {} {ANYTHING_HOLE_KEYWORD}",
+                            left.source,
+                            bin.op.as_str()
+                        ),
+                        holes,
+                        cost: left.cost + 2,
+                    },
+                );
+            }
+            for right in render_expr_selector_variants(index, &bin.right)?
+                .into_iter()
+                .filter(|variant| variant.source != ANYTHING_HOLE_KEYWORD)
+                .take(4)
+            {
+                let mut holes = right.holes;
+                holes.insert(ANYTHING_HOLE_KEYWORD.to_string());
+                push_expr_variant(
+                    &mut out,
+                    &mut seen,
+                    RenderedExprSelector {
+                        source: format!(
+                            "{ANYTHING_HOLE_KEYWORD} {} {}",
+                            bin.op.as_str(),
+                            right.source
+                        ),
+                        holes,
+                        cost: right.cost + 2,
+                    },
+                );
+            }
+        }
+        _ => {}
+    }
+    push_expr_variant(
+        &mut out,
+        &mut seen,
+        RenderedExprSelector {
+            source: source_for_span(index, expr.span())?.text,
+            holes: BTreeSet::new(),
+            cost: 1000,
+        },
+    );
+    out.sort_by_key(|variant| (variant.cost, variant.source.len()));
+    out.truncate(MAX_EXPR_SELECTOR_VARIANTS);
+    Ok(out)
+}
+
+fn render_member_expr_selector_variants(
+    index: &ChunkSelectorIndex,
+    member: &MemberExpr,
+) -> Result<Vec<RenderedExprSelector>> {
+    let mut out = Vec::new();
+    let mut seen = BTreeSet::new();
+    match &member.prop {
+        MemberProp::Ident(prop) => {
+            push_expr_variant(
+                &mut out,
+                &mut seen,
+                RenderedExprSelector {
+                    source: format!("{ANYTHING_HOLE_KEYWORD}.{}", prop.sym),
+                    holes: BTreeSet::from([ANYTHING_HOLE_KEYWORD.to_string()]),
+                    cost: 1,
+                },
+            );
+        }
+        MemberProp::PrivateName(prop) => {
+            push_expr_variant(
+                &mut out,
+                &mut seen,
+                RenderedExprSelector {
+                    source: format!("{ANYTHING_HOLE_KEYWORD}.#{}", prop.name),
+                    holes: BTreeSet::from([ANYTHING_HOLE_KEYWORD.to_string()]),
+                    cost: 2,
+                },
+            );
+        }
+        MemberProp::Computed(computed) => {
+            for expr in render_expr_selector_variants(index, &computed.expr)?
+                .into_iter()
+                .take(4)
+            {
+                let mut holes = expr.holes;
+                holes.insert(ANYTHING_HOLE_KEYWORD.to_string());
+                push_expr_variant(
+                    &mut out,
+                    &mut seen,
+                    RenderedExprSelector {
+                        source: format!("{ANYTHING_HOLE_KEYWORD}[{}]", expr.source),
+                        holes,
+                        cost: expr.cost + 2,
+                    },
+                );
+            }
+        }
+    }
+    push_expr_variant(
+        &mut out,
+        &mut seen,
+        RenderedExprSelector {
+            source: source_for_span(index, member.span())?.text,
+            holes: BTreeSet::new(),
+            cost: 100,
+        },
+    );
+    Ok(out)
+}
+
+fn render_call_expr_selector_variants(
+    index: &ChunkSelectorIndex,
+    call: &CallExpr,
+) -> Result<Vec<RenderedExprSelector>> {
+    let mut out = Vec::new();
+    let mut seen = BTreeSet::new();
+    let callee_variants = match &call.callee {
+        Callee::Expr(callee) => render_expr_selector_variants(index, callee)?,
+        _ => vec![RenderedExprSelector {
+            source: source_for_span(index, call.callee.span())?.text,
+            holes: BTreeSet::new(),
+            cost: 4,
+        }],
+    };
+    let arg_variants = call
+        .args
+        .iter()
+        .map(|arg| {
+            if arg.spread.is_some() {
+                Ok(vec![RenderedExprSelector {
+                    source: source_for_span(index, arg.span())?.text,
+                    holes: BTreeSet::new(),
+                    cost: 100,
+                }])
+            } else {
+                render_expr_selector_variants(index, &arg.expr)
+            }
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    for callee in callee_variants
+        .iter()
+        .filter(|variant| variant.source != ANYTHING_HOLE_KEYWORD)
+        .take(6)
+    {
+        let args = vec![ANYTHING_HOLE_KEYWORD; call.args.len()].join(", ");
+        let mut holes = callee.holes.clone();
+        if !call.args.is_empty() {
+            holes.insert(ANYTHING_HOLE_KEYWORD.to_string());
+        }
+        push_expr_variant(
+            &mut out,
+            &mut seen,
+            RenderedExprSelector {
+                source: format!("{}({args})", callee.source),
+                holes,
+                cost: callee.cost + 1,
+            },
+        );
+
+        for (arg_idx, variants) in arg_variants.iter().enumerate() {
+            for arg in variants
+                .iter()
+                .filter(|variant| variant.source != ANYTHING_HOLE_KEYWORD)
+                .take(4)
+            {
+                let mut args = vec![ANYTHING_HOLE_KEYWORD.to_string(); call.args.len()];
+                args[arg_idx] = arg.source.clone();
+                let mut holes = callee.holes.clone();
+                holes.extend(arg.holes.clone());
+                if call.args.len() > 1 {
+                    holes.insert(ANYTHING_HOLE_KEYWORD.to_string());
+                }
+                push_expr_variant(
+                    &mut out,
+                    &mut seen,
+                    RenderedExprSelector {
+                        source: format!("{}({})", callee.source, args.join(", ")),
+                        holes,
+                        cost: callee.cost + arg.cost + 2,
+                    },
+                );
+            }
+        }
+    }
+    push_expr_variant(
+        &mut out,
+        &mut seen,
+        RenderedExprSelector {
+            source: source_for_span(index, call.span())?.text,
+            holes: BTreeSet::new(),
+            cost: 1000,
+        },
+    );
+    out.sort_by_key(|variant| (variant.cost, variant.source.len()));
+    out.truncate(MAX_EXPR_SELECTOR_VARIANTS);
+    Ok(out)
+}
+
+fn render_object_expr_selector_variants(
+    index: &ChunkSelectorIndex,
+    object: &ObjectLit,
+) -> Result<Vec<RenderedExprSelector>> {
+    let mut out = Vec::new();
+    let mut seen = BTreeSet::new();
+    for (prop_idx, prop) in object.props.iter().enumerate() {
+        let PropOrSpread::Prop(prop) = prop else {
+            continue;
+        };
+        let Some(key) = prop_key_name(prop.as_ref()) else {
+            continue;
+        };
+        let value_variants = match prop.as_ref() {
+            Prop::KeyValue(key_value) => render_expr_selector_variants(index, &key_value.value)?,
+            Prop::Shorthand(_) | Prop::Assign(_) => vec![anything_expr_selector()],
+            _ => Vec::new(),
+        };
+        for value in value_variants.into_iter().take(4) {
+            let mut parts = Vec::new();
+            let mut holes = value.holes.clone();
+            if prop_idx > 0 {
+                parts.push(OBJECT_PROPS_HOLE_KEYWORD.to_string());
+                holes.insert(OBJECT_PROPS_HOLE_KEYWORD.to_string());
+            }
+            parts.push(format!("{key}: {}", value.source));
+            if prop_idx + 1 < object.props.len() {
+                parts.push(OBJECT_PROPS_HOLE_KEYWORD.to_string());
+                holes.insert(OBJECT_PROPS_HOLE_KEYWORD.to_string());
+            }
+            push_expr_variant(
+                &mut out,
+                &mut seen,
+                RenderedExprSelector {
+                    source: format!("{{ {} }}", parts.join(", ")),
+                    holes,
+                    cost: value.cost + 1,
+                },
+            );
+        }
+    }
+    push_expr_variant(
+        &mut out,
+        &mut seen,
+        RenderedExprSelector {
+            source: source_for_span(index, object.span())?.text,
+            holes: BTreeSet::new(),
+            cost: 1000,
+        },
+    );
+    out.sort_by_key(|variant| (variant.cost, variant.source.len()));
+    out.truncate(MAX_EXPR_SELECTOR_VARIANTS);
+    Ok(out)
+}
+
+fn push_expr_variant(
+    out: &mut Vec<RenderedExprSelector>,
+    seen: &mut BTreeSet<String>,
+    variant: RenderedExprSelector,
+) {
+    if seen.insert(variant.source.clone()) {
+        out.push(variant);
+    }
+}
+
+fn ensure_statement_semicolon(stmt: &Stmt, mut source: String) -> String {
+    if matches!(
+        stmt,
+        Stmt::Expr(_) | Stmt::Return(_) | Stmt::Throw(_) | Stmt::Decl(Decl::Var(_))
+    ) && !source.ends_with(';')
+    {
+        source.push(';');
+    }
+    source
+}
+
+fn indent_lines(source: &str, indent: &str) -> String {
+    source
+        .lines()
+        .map(|line| {
+            if line.is_empty() {
+                String::new()
+            } else {
+                format!("{indent}{line}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 fn call_has_selected_feature(

--- a/devinfra/js/debundle/selector_codemod.rs
+++ b/devinfra/js/debundle/selector_codemod.rs
@@ -1296,6 +1296,9 @@ fn synthesize_specialized_function_selector(
     let Some(Decl::Fn(function)) = item_decl(item) else {
         return Ok(None);
     };
+    if let Some(minimized) = minimize_function_selector(index, &function.function, decl, target)? {
+        return Ok(Some(minimized));
+    }
     let header = render_function_selector_header(&function.function, &target.export_name);
     let mut features = BTreeSet::from([
         SelectorAnchorFeature::DeclarationKind(IndexedDeclarationKind::Function),
@@ -2177,6 +2180,592 @@ fn anything_expr_selector() -> RenderedExprSelector {
         holes: BTreeSet::from([ANYTHING_HOLE_KEYWORD.to_string()]),
         cost: 0,
     }
+}
+
+// ===========================================================================
+// Retention-driven selector minimizer.
+//
+// A selector is the target rendered with a *retention set*: the byte spans of
+// the concrete tokens (literals, member/property names, callees, object keys)
+// the selector pins. A node renders concretely iff a kept span lies inside it;
+// every other position is holed — `ANYTHING` for a bare expression, and the
+// run holes `STMT_LIST` / `OBJECT_PROPS` / `CLASS_REST` for dropped statement /
+// object-property / class-member runs.
+//
+// Anchor selection is a matcher-driven minimal set cover: each candidate
+// anchor's exclusion set (the competitor declarations it rules out) is computed
+// by the production matcher, so discrimination is exact rather than an index
+// approximation. A greedy cover picks anchors until every competitor is
+// excluded; the chosen union is rendered once and proven by the matcher. This
+// is a mechanical first pass — it finds *a* structural pin for the routine
+// cases, not necessarily the most semantically meaningful one.
+// ===========================================================================
+
+/// `(lo, hi)` byte offsets of a retained concrete token.
+type AnchorSpan = (u32, u32);
+
+const MAX_MINIMIZER_ANCHORS: usize = 64;
+
+fn span_key(span: Span) -> AnchorSpan {
+    (span.lo.0, span.hi.0)
+}
+
+fn node_holds_anchor(node: Span, anchor: AnchorSpan) -> bool {
+    node.lo.0 <= anchor.0 && anchor.1 <= node.hi.0
+}
+
+fn node_retains_any(node: Span, kept: &BTreeSet<AnchorSpan>) -> bool {
+    kept.iter().any(|anchor| node_holds_anchor(node, *anchor))
+}
+
+fn anything_expr() -> String {
+    ANYTHING_HOLE_KEYWORD.to_string()
+}
+
+/// Render an expression to selector source, keeping only concrete tokens whose
+/// span is in `kept` and holing everything off a kept token's path.
+fn render_retained_expr(
+    index: &ChunkSelectorIndex,
+    expr: &Expr,
+    kept: &BTreeSet<AnchorSpan>,
+) -> Result<String> {
+    if !node_retains_any(expr.span(), kept) {
+        return Ok(anything_expr());
+    }
+    Ok(match expr {
+        Expr::Paren(paren) => render_retained_expr(index, &paren.expr, kept)?,
+        Expr::Lit(_) | Expr::Ident(_) | Expr::Tpl(_) => source_for_span(index, expr.span())?.text,
+        Expr::Member(member) => {
+            let obj = render_retained_expr(index, &member.obj, kept)?;
+            format!("{obj}.{}", render_member_prop(index, &member.prop, kept)?)
+        }
+        Expr::Call(call) => {
+            let callee = render_retained_callee(index, &call.callee, kept)?;
+            format!(
+                "{callee}({})",
+                render_retained_args(index, &call.args, kept)?
+            )
+        }
+        Expr::New(new_expr) => {
+            let callee = render_callee_expr(index, &new_expr.callee, kept)?;
+            let args = new_expr.args.as_deref().unwrap_or_default();
+            format!("new {callee}({})", render_retained_args(index, args, kept)?)
+        }
+        Expr::Object(object) => render_retained_object(index, object, kept)?,
+        Expr::Await(await_expr) => {
+            format!(
+                "await {}",
+                render_retained_expr(index, &await_expr.arg, kept)?
+            )
+        }
+        Expr::Unary(unary) => format!(
+            "{}{}",
+            unary.op.as_str(),
+            render_retained_expr(index, &unary.arg, kept)?
+        ),
+        Expr::Bin(bin) => format!(
+            "{} {} {}",
+            render_retained_expr(index, &bin.left, kept)?,
+            bin.op.as_str(),
+            render_retained_expr(index, &bin.right, kept)?
+        ),
+        // Unmodeled expression shapes that still carry a kept anchor: keep the
+        // original source rather than risk an unsound hole. Over-pinning here is
+        // a future refinement, not a correctness problem.
+        _ => source_for_span(index, expr.span())?.text,
+    })
+}
+
+fn render_member_prop(
+    index: &ChunkSelectorIndex,
+    prop: &MemberProp,
+    kept: &BTreeSet<AnchorSpan>,
+) -> Result<String> {
+    Ok(match prop {
+        MemberProp::Ident(ident) => ident.sym.to_string(),
+        MemberProp::PrivateName(private) => format!("#{}", private.name),
+        MemberProp::Computed(computed) => {
+            format!("[{}]", render_retained_expr(index, &computed.expr, kept)?)
+        }
+    })
+}
+
+fn render_retained_callee(
+    index: &ChunkSelectorIndex,
+    callee: &Callee,
+    kept: &BTreeSet<AnchorSpan>,
+) -> Result<String> {
+    match callee {
+        Callee::Expr(expr) => render_callee_expr(index, expr, kept),
+        Callee::Super(_) | Callee::Import(_) => Ok(source_for_span(index, callee.span())?.text),
+    }
+}
+
+/// Render the callee of a rendered call. The invoked identity — a method name
+/// or a bare function reference — is a meaningful, stable pin, so it is kept
+/// even when no anchor lies inside it; only a member receiver is holed.
+fn render_callee_expr(
+    index: &ChunkSelectorIndex,
+    expr: &Expr,
+    kept: &BTreeSet<AnchorSpan>,
+) -> Result<String> {
+    match expr {
+        Expr::Member(member) => Ok(format!(
+            "{}.{}",
+            render_retained_expr(index, &member.obj, kept)?,
+            render_member_prop(index, &member.prop, kept)?
+        )),
+        Expr::Ident(_) => Ok(source_for_span(index, expr.span())?.text),
+        Expr::Paren(paren) => render_callee_expr(index, &paren.expr, kept),
+        _ => render_retained_expr(index, expr, kept),
+    }
+}
+
+fn render_retained_args(
+    index: &ChunkSelectorIndex,
+    args: &[ExprOrSpread],
+    kept: &BTreeSet<AnchorSpan>,
+) -> Result<String> {
+    let rendered = args
+        .iter()
+        .map(|arg| {
+            if arg.spread.is_some() {
+                Ok(source_for_span(index, arg.span())?.text)
+            } else {
+                render_retained_expr(index, &arg.expr, kept)
+            }
+        })
+        .collect::<Result<Vec<_>>>()?;
+    Ok(rendered.join(", "))
+}
+
+fn render_retained_object(
+    index: &ChunkSelectorIndex,
+    object: &ObjectLit,
+    kept: &BTreeSet<AnchorSpan>,
+) -> Result<String> {
+    let mut parts: Vec<String> = Vec::new();
+    let mut dropped_run = false;
+    for prop in &object.props {
+        if node_retains_any(prop.span(), kept) {
+            if dropped_run {
+                parts.push(OBJECT_PROPS_HOLE_KEYWORD.to_string());
+                dropped_run = false;
+            }
+            parts.push(render_retained_prop(index, prop, kept)?);
+        } else {
+            dropped_run = true;
+        }
+    }
+    if dropped_run {
+        parts.push(OBJECT_PROPS_HOLE_KEYWORD.to_string());
+    }
+    if parts.is_empty() {
+        return Ok("{ }".to_string());
+    }
+    Ok(format!("{{ {} }}", parts.join(", ")))
+}
+
+fn render_retained_prop(
+    index: &ChunkSelectorIndex,
+    prop: &PropOrSpread,
+    kept: &BTreeSet<AnchorSpan>,
+) -> Result<String> {
+    let PropOrSpread::Prop(prop) = prop else {
+        return Ok(source_for_span(index, prop.span())?.text);
+    };
+    Ok(match prop.as_ref() {
+        Prop::KeyValue(key_value) => {
+            let key = prop_name_to_string(&key_value.key).unwrap_or_else(|| {
+                source_for_span(index, key_value.key.span())
+                    .map(|s| s.text)
+                    .unwrap_or_default()
+            });
+            format!(
+                "{key}: {}",
+                render_retained_expr(index, &key_value.value, kept)?
+            )
+        }
+        _ => source_for_span(index, prop.span())?.text,
+    })
+}
+
+/// Render a statement list, collapsing runs of dropped statements into a single
+/// `STMT_LIST;` hole.
+fn render_retained_stmt_list(
+    index: &ChunkSelectorIndex,
+    stmts: &[Stmt],
+    kept: &BTreeSet<AnchorSpan>,
+) -> Result<String> {
+    let mut lines: Vec<String> = Vec::new();
+    let mut dropped_run = false;
+    for stmt in stmts {
+        if node_retains_any(stmt.span(), kept) {
+            if dropped_run {
+                lines.push(format!("{STMT_LIST_HOLE_KEYWORD};"));
+                dropped_run = false;
+            }
+            lines.push(render_retained_stmt(index, stmt, kept)?);
+        } else {
+            dropped_run = true;
+        }
+    }
+    if dropped_run || lines.is_empty() {
+        lines.push(format!("{STMT_LIST_HOLE_KEYWORD};"));
+    }
+    Ok(lines.join("\n"))
+}
+
+fn render_retained_stmt(
+    index: &ChunkSelectorIndex,
+    stmt: &Stmt,
+    kept: &BTreeSet<AnchorSpan>,
+) -> Result<String> {
+    Ok(match stmt {
+        Stmt::Expr(expr_stmt) => {
+            format!("{};", render_retained_expr(index, &expr_stmt.expr, kept)?)
+        }
+        Stmt::Return(ret) => match &ret.arg {
+            Some(arg) => format!("return {};", render_retained_expr(index, arg, kept)?),
+            None => "return;".to_string(),
+        },
+        Stmt::Throw(throw) => format!("throw {};", render_retained_expr(index, &throw.arg, kept)?),
+        Stmt::Decl(Decl::Var(var)) => {
+            let decls = var
+                .decls
+                .iter()
+                .map(|declarator| {
+                    let pat = source_for_span(index, declarator.name.span())?.text;
+                    match &declarator.init {
+                        Some(init) => Ok(format!(
+                            "{pat} = {}",
+                            render_retained_expr(index, init, kept)?
+                        )),
+                        None => Ok(pat),
+                    }
+                })
+                .collect::<Result<Vec<_>>>()?;
+            format!("{} {};", var_kind_label(var.kind), decls.join(",\n  "))
+        }
+        Stmt::If(if_stmt) => {
+            let test = render_retained_expr(index, &if_stmt.test, kept)?;
+            let cons = render_retained_block(index, &if_stmt.cons, kept)?;
+            format!("if ({test}) {{\n{}\n}}", indent_lines(&cons, "  "))
+        }
+        Stmt::Try(try_stmt) => {
+            let body = render_retained_stmt_list(index, &try_stmt.block.stmts, kept)?;
+            let catch = render_catch_clause_skeleton(&try_stmt.handler);
+            let finalizer = try_stmt
+                .finalizer
+                .as_ref()
+                .map(|_| format!(" finally {{\n  {STMT_LIST_HOLE_KEYWORD};\n}}"))
+                .unwrap_or_default();
+            format!(
+                "try {{\n{}\n}}{catch}{finalizer}",
+                indent_lines(&body, "  ")
+            )
+        }
+        Stmt::Block(block) => {
+            let body = render_retained_stmt_list(index, &block.stmts, kept)?;
+            format!("{{\n{}\n}}", indent_lines(&body, "  "))
+        }
+        // Unmodeled statement shapes carrying a kept anchor: keep verbatim.
+        _ => ensure_statement_semicolon(stmt, source_for_span(index, stmt.span())?.text),
+    })
+}
+
+fn render_retained_block(
+    index: &ChunkSelectorIndex,
+    stmt: &Stmt,
+    kept: &BTreeSet<AnchorSpan>,
+) -> Result<String> {
+    match stmt {
+        Stmt::Block(block) => render_retained_stmt_list(index, &block.stmts, kept),
+        _ => render_retained_stmt(index, stmt, kept),
+    }
+}
+
+/// Candidate concrete anchors, split into preference tiers. Literal values are
+/// stable, meaningful landmarks (a magic string, a config number/bool), so they
+/// are tried first; member/property and key names are structural fallbacks used
+/// only when literals cannot discriminate the target on their own.
+#[derive(Default)]
+struct AnchorCandidates {
+    literals: Vec<AnchorSpan>,
+    structural: Vec<AnchorSpan>,
+}
+
+impl AnchorCandidates {
+    /// Anchor tiers, most-preferred first.
+    fn tiers(&self) -> [&[AnchorSpan]; 2] {
+        [&self.literals, &self.structural]
+    }
+}
+
+fn collect_stmt_list_anchors(stmts: &[Stmt]) -> AnchorCandidates {
+    let mut candidates = AnchorCandidates::default();
+    for stmt in stmts {
+        collect_stmt_anchors(stmt, &mut candidates);
+    }
+    candidates
+}
+
+fn collect_stmt_anchors(stmt: &Stmt, candidates: &mut AnchorCandidates) {
+    match stmt {
+        Stmt::Expr(expr_stmt) => collect_expr_anchors(&expr_stmt.expr, candidates),
+        Stmt::Return(ret) => {
+            if let Some(arg) = &ret.arg {
+                collect_expr_anchors(arg, candidates);
+            }
+        }
+        Stmt::Throw(throw) => collect_expr_anchors(&throw.arg, candidates),
+        Stmt::Decl(Decl::Var(var)) => {
+            for declarator in &var.decls {
+                if let Some(init) = &declarator.init {
+                    collect_expr_anchors(init, candidates);
+                }
+            }
+        }
+        Stmt::If(if_stmt) => {
+            collect_expr_anchors(&if_stmt.test, candidates);
+            collect_block_anchors(&if_stmt.cons, candidates);
+        }
+        Stmt::Try(try_stmt) => {
+            for stmt in &try_stmt.block.stmts {
+                collect_stmt_anchors(stmt, candidates);
+            }
+        }
+        Stmt::Block(block) => {
+            for stmt in &block.stmts {
+                collect_stmt_anchors(stmt, candidates);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_block_anchors(stmt: &Stmt, candidates: &mut AnchorCandidates) {
+    match stmt {
+        Stmt::Block(block) => {
+            for stmt in &block.stmts {
+                collect_stmt_anchors(stmt, candidates);
+            }
+        }
+        _ => collect_stmt_anchors(stmt, candidates),
+    }
+}
+
+fn collect_expr_anchors(expr: &Expr, candidates: &mut AnchorCandidates) {
+    match expr {
+        Expr::Lit(_) | Expr::Tpl(_) => candidates.literals.push(span_key(expr.span())),
+        Expr::Paren(paren) => collect_expr_anchors(&paren.expr, candidates),
+        Expr::Member(member) => {
+            collect_expr_anchors(&member.obj, candidates);
+            if let MemberProp::Ident(ident) = &member.prop {
+                candidates.structural.push(span_key(ident.span));
+            } else if let MemberProp::Computed(computed) = &member.prop {
+                collect_expr_anchors(&computed.expr, candidates);
+            }
+        }
+        Expr::Call(call) => {
+            if let Callee::Expr(callee) = &call.callee {
+                collect_expr_anchors(callee, candidates);
+            }
+            for arg in &call.args {
+                if arg.spread.is_none() {
+                    collect_expr_anchors(&arg.expr, candidates);
+                }
+            }
+        }
+        Expr::New(new_expr) => {
+            collect_expr_anchors(&new_expr.callee, candidates);
+            for arg in new_expr.args.as_deref().unwrap_or_default() {
+                if arg.spread.is_none() {
+                    collect_expr_anchors(&arg.expr, candidates);
+                }
+            }
+        }
+        Expr::Object(object) => {
+            for prop in &object.props {
+                if let PropOrSpread::Prop(prop) = prop {
+                    if let Prop::KeyValue(key_value) = prop.as_ref() {
+                        candidates.structural.push(span_key(key_value.key.span()));
+                        collect_expr_anchors(&key_value.value, candidates);
+                    }
+                }
+            }
+        }
+        Expr::Await(await_expr) => collect_expr_anchors(&await_expr.arg, candidates),
+        Expr::Unary(unary) => collect_expr_anchors(&unary.arg, candidates),
+        Expr::Bin(bin) => {
+            collect_expr_anchors(&bin.left, candidates);
+            collect_expr_anchors(&bin.right, candidates);
+        }
+        _ => {}
+    }
+}
+
+/// Body indices a `target_binding` selector with `match_source` resolves to.
+fn matched_body_indices(
+    index: &ChunkSelectorIndex,
+    export_name: &str,
+    match_source: &str,
+) -> Result<BTreeSet<usize>> {
+    let source_match = SourceMatch {
+        match_source: match_source.to_string(),
+        identifiers: SourceMatchIdentifierMode::AlphaAll,
+        target_binding: Some(export_name.to_string()),
+        target_statement: None,
+        target_statements: None,
+        wildcard_string_literals: BTreeSet::new(),
+    };
+    let matches = source_match::member_binding_candidate_matches(
+        &index.parsed.module,
+        "<selector minimization>",
+        &source_match.selector(),
+    )?;
+    Ok(matches.iter().map(|candidate| candidate.body_idx).collect())
+}
+
+fn holes_present(source: &str) -> BTreeSet<String> {
+    let mut holes = BTreeSet::new();
+    for keyword in [
+        ANYTHING_HOLE_KEYWORD,
+        STMT_LIST_HOLE_KEYWORD,
+        OBJECT_PROPS_HOLE_KEYWORD,
+        CLASS_REST_HOLE_KEYWORD,
+        DECLARATORS_HOLE_KEYWORD,
+    ] {
+        if source.contains(keyword) {
+            holes.insert(keyword.to_string());
+        }
+    }
+    holes
+}
+
+/// Minimal anchor cover for a single-target function declaration: choose the
+/// fewest concrete anchors whose matcher-proven exclusion sets rule out every
+/// same-arity sibling, render the holey selector, and prove it.
+fn minimize_function_selector(
+    index: &ChunkSelectorIndex,
+    function: &Function,
+    decl: &IndexedDeclaration,
+    target: &SynthesizedTargetBinding,
+) -> Result<Option<SpecializedSelector>> {
+    let Some(body) = &function.body else {
+        return Ok(None);
+    };
+    let header = render_function_selector_header(function, &target.export_name);
+    let render_with = |kept: &BTreeSet<AnchorSpan>| -> Result<String> {
+        let body_source = render_retained_stmt_list(index, &body.stmts, kept)?;
+        Ok(trim_selector_source_line_suffixes(&format!(
+            "{header} {{\n{}\n}}",
+            indent_lines(&body_source, "  ")
+        )))
+    };
+
+    let skeleton_features = BTreeSet::from([
+        SelectorAnchorFeature::DeclarationKind(IndexedDeclarationKind::Function),
+        SelectorAnchorFeature::FunctionArity(function.params.len()),
+    ]);
+    let mut competitors = index.frontier_for_features(&skeleton_features);
+    competitors.remove(&decl.body_idx);
+
+    let empty = BTreeSet::new();
+    if competitors.is_empty() {
+        let source = render_with(&empty)?;
+        return finish_minimized_selector(index, decl, target, source);
+    }
+
+    let candidates = collect_stmt_list_anchors(&body.stmts);
+    let Some(chosen) = cover_competitors(
+        index,
+        target,
+        &competitors,
+        &candidates.tiers(),
+        &render_with,
+    )?
+    else {
+        return Ok(None);
+    };
+    let source = render_with(&chosen)?;
+    finish_minimized_selector(index, decl, target, source)
+}
+
+/// Tiered greedy set cover. Tiers are tried most-preferred first (literals
+/// before structural anchors): within a tier, repeatedly take the anchor
+/// excluding the most still-uncovered competitors until the tier is exhausted,
+/// then fall through to the next tier only for whatever remains uncovered. The
+/// matcher gives each anchor's exclusion set, so the result is sound and the
+/// final selector is proven once by the caller. Returns `None` if even all
+/// anchors together cannot single out the target.
+fn cover_competitors(
+    index: &ChunkSelectorIndex,
+    target: &SynthesizedTargetBinding,
+    competitors: &BTreeSet<usize>,
+    tiers: &[&[AnchorSpan]],
+    render_with: &impl Fn(&BTreeSet<AnchorSpan>) -> Result<String>,
+) -> Result<Option<BTreeSet<AnchorSpan>>> {
+    let mut uncovered = competitors.clone();
+    let mut chosen = BTreeSet::new();
+    for tier in tiers {
+        if uncovered.is_empty() {
+            break;
+        }
+        let mut exclusions: Vec<(AnchorSpan, BTreeSet<usize>)> = Vec::new();
+        for &anchor in tier.iter().take(MAX_MINIMIZER_ANCHORS) {
+            let survivors = matched_body_indices(
+                index,
+                &target.export_name,
+                &render_with(&BTreeSet::from([anchor]))?,
+            )?;
+            let excluded: BTreeSet<usize> = competitors.difference(&survivors).copied().collect();
+            if !excluded.is_empty() {
+                exclusions.push((anchor, excluded));
+            }
+        }
+        while !uncovered.is_empty() {
+            let best = exclusions
+                .iter()
+                .filter(|(anchor, _)| !chosen.contains(anchor))
+                .max_by_key(|(anchor, excluded)| {
+                    (
+                        excluded.intersection(&uncovered).count(),
+                        std::cmp::Reverse(anchor.0),
+                    )
+                });
+            let Some((anchor, excluded)) = best else {
+                break;
+            };
+            if excluded.intersection(&uncovered).next().is_none() {
+                break;
+            }
+            chosen.insert(*anchor);
+            uncovered = uncovered.difference(excluded).copied().collect();
+        }
+    }
+    if uncovered.is_empty() {
+        Ok(Some(chosen))
+    } else {
+        Ok(None)
+    }
+}
+
+fn finish_minimized_selector(
+    index: &ChunkSelectorIndex,
+    decl: &IndexedDeclaration,
+    target: &SynthesizedTargetBinding,
+    source: String,
+) -> Result<Option<SpecializedSelector>> {
+    let targets = std::slice::from_ref(target);
+    if prove_synthesized_selector(index, decl, targets, &source).is_err() {
+        return Ok(None);
+    }
+    let rewritten_holes = holes_present(&source);
+    Ok(Some(SpecializedSelector {
+        match_source: source,
+        rewritten_holes,
+    }))
 }
 
 fn render_function_body_selector_candidates(

--- a/devinfra/js/debundle/selector_codemod.rs
+++ b/devinfra/js/debundle/selector_codemod.rs
@@ -28,14 +28,7 @@ use swc_ecma_visit::{Visit, VisitWith};
 use source_match_holes::{
     ANYTHING_HOLE_KEYWORD, ARGS_HOLE_KEYWORD, CLASS_REST_HOLE_KEYWORD, DECLARATORS_HOLE_KEYWORD,
     EXPR_HOLE_KEYWORD, OBJECT_PROPS_HOLE_KEYWORD, STMT_HOLE_KEYWORD, STMT_LIST_HOLE_KEYWORD,
-    hole_name_for,
 };
-
-const MAX_VAR_GROUP_FRONTIER_TUPLES_PER_DECL: usize = 4096;
-const MAX_VAR_FEATURE_SEARCH_NODES: usize = 200_000;
-const MAX_FUNCTION_SELECTOR_CANDIDATES: usize = 512;
-const MAX_EXPR_SELECTOR_VARIANTS: usize = 16;
-const MAX_STMT_SELECTOR_VARIANTS: usize = 24;
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -620,7 +613,6 @@ struct ChunkSelectorIndex {
     source: String,
     decls: Vec<IndexedDeclaration>,
     binding_to_decl: BTreeMap<String, Vec<usize>>,
-    feature_to_body_indices: BTreeMap<SelectorAnchorFeature, BTreeSet<usize>>,
 }
 
 #[derive(Debug)]
@@ -636,16 +628,6 @@ enum IndexedDeclarationKind {
     Class,
     Var,
     Other,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-enum SelectorAnchorFeature {
-    DeclarationKind(IndexedDeclarationKind),
-    VarKind(String),
-    FunctionArity(usize),
-    ClassMember(String),
-    ObjectKey(String),
-    CallCallee(String),
 }
 
 #[derive(Debug)]
@@ -971,18 +953,10 @@ impl ChunkSelectorIndex {
         let source = parsed.source_text();
         let mut decls = Vec::new();
         let mut binding_to_decl: BTreeMap<String, Vec<usize>> = BTreeMap::new();
-        let mut feature_to_body_indices: BTreeMap<SelectorAnchorFeature, BTreeSet<usize>> =
-            BTreeMap::new();
         for (body_idx, item) in parsed.module.body.iter().enumerate() {
             let indexed = IndexedDeclaration::from_item(body_idx, item);
             if indexed.declared_bindings.is_empty() {
                 continue;
-            }
-            for feature in selector_anchor_features_for_item(item, indexed.kind) {
-                feature_to_body_indices
-                    .entry(feature)
-                    .or_default()
-                    .insert(body_idx);
             }
             let decl_idx = decls.len();
             for binding in &indexed.declared_bindings {
@@ -998,34 +972,7 @@ impl ChunkSelectorIndex {
             source,
             decls,
             binding_to_decl,
-            feature_to_body_indices,
         }
-    }
-
-    fn frontier_for_features(&self, features: &BTreeSet<SelectorAnchorFeature>) -> BTreeSet<usize> {
-        let mut postings = features
-            .iter()
-            .filter_map(|feature| {
-                self.feature_to_body_indices
-                    .get(feature)
-                    .map(|body_indices| (feature, body_indices))
-            })
-            .collect::<Vec<_>>();
-        postings.sort_by_key(|(_, body_indices)| body_indices.len());
-        let Some((_, first)) = postings.first() else {
-            return self.decls.iter().map(|decl| decl.body_idx).collect();
-        };
-        let mut frontier = (*first).clone();
-        for (_, body_indices) in postings.into_iter().skip(1) {
-            frontier = frontier
-                .intersection(body_indices)
-                .copied()
-                .collect::<BTreeSet<_>>();
-            if frontier.is_empty() {
-                break;
-            }
-        }
-        frontier
     }
 }
 
@@ -1296,53 +1243,8 @@ fn synthesize_specialized_function_selector(
     let Some(Decl::Fn(function)) = item_decl(item) else {
         return Ok(None);
     };
-    if let Some(minimized) = minimize_function_selector(index, &function.function, decl, target)? {
-        return Ok(Some(minimized));
-    }
-    let header = render_function_selector_header(&function.function, &target.export_name);
-    let mut features = BTreeSet::from([
-        SelectorAnchorFeature::DeclarationKind(IndexedDeclarationKind::Function),
-        SelectorAnchorFeature::FunctionArity(function.function.params.len()),
-    ]);
-    if !frontier_is_small_and_contains_target(index, decl, &features) {
-        let mut candidates = render_function_body_selector_candidates(index, &function.function)?;
-        candidates.sort_by_key(|candidate| (candidate.cost, candidate.source.len()));
-        for body in candidates
-            .into_iter()
-            .take(MAX_FUNCTION_SELECTOR_CANDIDATES)
-        {
-            let match_source = format!("{header} {{\n{}\n}}", indent_lines(&body.source, "  "));
-            if prove_synthesized_selector(index, decl, targets, &match_source).is_ok() {
-                return Ok(Some(SpecializedSelector {
-                    match_source,
-                    rewritten_holes: body.holes,
-                }));
-            }
-        }
-        return Ok(None);
-    }
-    features.insert(SelectorAnchorFeature::DeclarationKind(
-        IndexedDeclarationKind::Function,
-    ));
-    Ok(Some(SpecializedSelector {
-        match_source: format!("{header} {{\n  {STMT_LIST_HOLE_KEYWORD};\n}}"),
-        rewritten_holes: BTreeSet::from([
-            ANYTHING_HOLE_KEYWORD.to_string(),
-            STMT_LIST_HOLE_KEYWORD.to_string(),
-        ]),
-    }))
-}
-
-fn render_function_selector_header(function: &Function, name: &str) -> String {
-    let params = function
-        .params
-        .iter()
-        .map(|_| ANYTHING_HOLE_KEYWORD)
-        .collect::<Vec<_>>()
-        .join(", ");
-    let async_prefix = if function.is_async { "async " } else { "" };
-    let generator_suffix = if function.is_generator { "*" } else { "" };
-    format!("{async_prefix}function{generator_suffix} {name}({params})")
+    // On `None`, the caller falls back to the exact selector.
+    minimize_function_selector(index, &function.function, decl, target)
 }
 
 fn synthesize_specialized_class_selector(
@@ -1357,51 +1259,8 @@ fn synthesize_specialized_class_selector(
     let Some(Decl::Class(class_decl)) = item_decl(item) else {
         return Ok(None);
     };
-    if let Some(minimized) = minimize_class_selector(index, &class_decl.class, decl, target)? {
-        return Ok(Some(minimized));
-    }
-    let mut features = BTreeSet::from([SelectorAnchorFeature::DeclarationKind(
-        IndexedDeclarationKind::Class,
-    )]);
-    if frontier_is_small_and_contains_target(index, decl, &features) {
-        return Ok(Some(SpecializedSelector {
-            match_source: format!(
-                "class {} {{\n  {CLASS_REST_HOLE_KEYWORD};\n}}",
-                target.export_name
-            ),
-            rewritten_holes: BTreeSet::from([CLASS_REST_HOLE_KEYWORD.to_string()]),
-        }));
-    }
-
-    let mut member_names = class_decl
-        .class
-        .body
-        .iter()
-        .filter_map(class_member_feature_name)
-        .collect::<Vec<_>>();
-    member_names.sort_by_key(|name| {
-        index
-            .feature_to_body_indices
-            .get(&SelectorAnchorFeature::ClassMember(name.clone()))
-            .map_or(usize::MAX, BTreeSet::len)
-    });
-    let mut selected = BTreeSet::new();
-    for name in member_names {
-        features.insert(SelectorAnchorFeature::ClassMember(name.clone()));
-        selected.insert(name);
-        if frontier_is_small_and_contains_target(index, decl, &features) {
-            let members = render_class_member_skeletons(&class_decl.class, &selected, index)?;
-            return Ok(Some(SpecializedSelector {
-                match_source: format!("class {} {{\n{members}}}", target.export_name),
-                rewritten_holes: BTreeSet::from([
-                    ANYTHING_HOLE_KEYWORD.to_string(),
-                    STMT_LIST_HOLE_KEYWORD.to_string(),
-                    CLASS_REST_HOLE_KEYWORD.to_string(),
-                ]),
-            }));
-        }
-    }
-    Ok(None)
+    // On `None`, the caller falls back to the exact selector.
+    minimize_class_selector(index, &class_decl.class, decl, target)
 }
 
 fn synthesize_specialized_var_selector(
@@ -1411,785 +1270,10 @@ fn synthesize_specialized_var_selector(
     targets: &[SynthesizedTargetBinding],
 ) -> Result<Option<SpecializedSelector>> {
     let var = item_var_decl(item).context("indexed var declaration no longer has var AST")?;
-    if let [target] = targets {
-        if let Some(minimized) = minimize_var_selector(index, var, decl, target)? {
-            return Ok(Some(minimized));
-        }
-    } else if let Some(minimized) = minimize_var_group_selector(index, var, decl, targets)? {
-        return Ok(Some(minimized));
-    }
-    let target_slots = targets
-        .iter()
-        .map(|target| {
-            decl.declared_bindings
-                .iter()
-                .find(|binding| binding.name == target.runtime_binding)
-                .and_then(|binding| binding.declarator_idx)
-                .with_context(|| {
-                    format!(
-                        "target `{}` is not a var declarator",
-                        target.runtime_binding
-                    )
-                })
-        })
-        .collect::<Result<Vec<_>>>()?;
-    if !var_group_frontier_is_bounded(index, var.kind, targets.len()) {
-        return Ok(None);
-    }
-    let target_decl_indices = target_slots.iter().copied().collect::<BTreeSet<_>>();
-    let mut slot_constraints = vec![BTreeSet::new(); targets.len()];
-    let mut frontier = var_group_frontier(index, var.kind, targets.len(), &slot_constraints);
-    if !target_tuple_is_unique(&frontier, decl, &target_slots) {
-        let Some(selected_constraints) = select_min_cost_var_slot_constraints(
-            index,
-            var.kind,
-            targets.len(),
-            decl,
-            &target_slots,
-        ) else {
-            return Ok(None);
-        };
-        slot_constraints = selected_constraints;
-        frontier = var_group_frontier(index, var.kind, targets.len(), &slot_constraints);
-        if !target_tuple_is_unique(&frontier, decl, &target_slots) {
-            return Ok(None);
-        }
-    }
-
-    let export_by_runtime = targets
-        .iter()
-        .map(|target| (target.runtime_binding.as_str(), target.export_name.as_str()))
-        .collect::<BTreeMap<_, _>>();
-    let mut parts = Vec::new();
-    let mut holes = BTreeSet::new();
-    let mut skipped_run = 0usize;
-    let mut target_seen = 0usize;
-    for (idx, declarator) in var.decls.iter().enumerate() {
-        if !target_decl_indices.contains(&idx) {
-            skipped_run += 1;
-            continue;
-        }
-        if skipped_run > 0 {
-            let hole = declarator_hole_name(target_seen, target_decl_indices.len());
-            parts.push(format!("{hole} = null"));
-            holes.insert(hole.to_string());
-            skipped_run = 0;
-        }
-        let runtime_name = single_ident_pat_name(&declarator.name)
-            .context("only identifier var declarators can be synthesized today")?;
-        let export_name = export_by_runtime
-            .get(runtime_name)
-            .copied()
-            .context("target declarator missing export name")?;
-        let init = declarator
-            .init
-            .as_deref()
-            .map(|expr| {
-                render_specialized_expr_selector(index, expr, &slot_constraints[target_seen])
-            })
-            .transpose()?
-            .unwrap_or_else(anything_expr_selector);
-        holes.extend(init.holes.clone());
-        parts.push(format!("{export_name} = {}", init.source));
-        target_seen += 1;
-    }
-    if skipped_run > 0 {
-        let hole = declarator_hole_name(target_seen, target_decl_indices.len());
-        parts.push(format!("{hole} = null"));
-        holes.insert(hole.to_string());
-    }
-    Ok(Some(SpecializedSelector {
-        match_source: format!("{} {};", var_kind_label(var.kind), parts.join(",\n  ")),
-        rewritten_holes: holes,
-    }))
-}
-
-fn frontier_is_small_and_contains_target(
-    index: &ChunkSelectorIndex,
-    decl: &IndexedDeclaration,
-    features: &BTreeSet<SelectorAnchorFeature>,
-) -> bool {
-    let frontier = index.frontier_for_features(features);
-    frontier.contains(&decl.body_idx) && frontier.len() == 1
-}
-
-fn select_min_cost_var_slot_constraints(
-    index: &ChunkSelectorIndex,
-    var_kind: VarDeclKind,
-    target_count: usize,
-    decl: &IndexedDeclaration,
-    target_slots: &[usize],
-) -> Option<Vec<BTreeSet<SelectorAnchorFeature>>> {
-    let empty_constraints = vec![BTreeSet::new(); target_count];
-    let tuples =
-        var_group_frontier_with_features(index, var_kind, target_count, &empty_constraints);
-    let target_tuple = VarGroupTuple {
-        body_idx: decl.body_idx,
-        slots: target_slots.to_vec(),
-    };
-    let target_tuple_idx = tuples
-        .iter()
-        .position(|tuple| tuple.tuple == target_tuple)?;
-    let competitors = tuples
-        .iter()
-        .enumerate()
-        .filter_map(|(tuple_idx, _)| (tuple_idx != target_tuple_idx).then_some(tuple_idx))
-        .collect::<BTreeSet<_>>();
-    if competitors.is_empty() {
-        return Some(empty_constraints);
-    }
-
-    let options = var_slot_feature_options(&tuples[target_tuple_idx], target_count);
-    if options.is_empty() {
-        return None;
-    }
-    let option_covers = options
-        .iter()
-        .map(|option| {
-            competitors
-                .iter()
-                .filter_map(|tuple_idx| {
-                    (!var_group_tuple_has_slot_feature(&tuples[*tuple_idx], option))
-                        .then_some(*tuple_idx)
-                })
-                .collect::<BTreeSet<_>>()
-        })
-        .collect::<Vec<_>>();
-    let usable_options = options
-        .into_iter()
-        .zip(option_covers)
-        .filter(|(_, covered)| !covered.is_empty())
-        .map(|(option, covered)| VarSlotSearchOption { option, covered })
-        .collect::<Vec<_>>();
-    if usable_options.is_empty() {
-        return None;
-    }
-
-    let mut search = VarSlotConstraintSearch::new(usable_options, competitors);
-    search.solve().map(|selected| {
-        let mut slot_constraints = vec![BTreeSet::new(); target_count];
-        for option_idx in selected {
-            let option = &search.options[option_idx].option;
-            slot_constraints[option.target_pos].insert(option.feature.clone());
-        }
-        slot_constraints
-    })
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-struct VarSlotFeatureOption {
-    target_pos: usize,
-    feature: SelectorAnchorFeature,
-}
-
-#[derive(Debug)]
-struct VarSlotSearchOption {
-    option: VarSlotFeatureOption,
-    covered: BTreeSet<usize>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-struct SelectorSearchCost {
-    weighted_features: usize,
-    feature_count: usize,
-}
-
-impl SelectorSearchCost {
-    const ZERO: Self = Self {
-        weighted_features: 0,
-        feature_count: 0,
-    };
-
-    fn add(self, feature: &SelectorAnchorFeature) -> Self {
-        Self {
-            weighted_features: self.weighted_features + feature_cost(feature),
-            feature_count: self.feature_count + 1,
-        }
-    }
-}
-
-fn var_slot_feature_options(
-    target_tuple: &VarGroupTupleWithFeatures,
-    target_count: usize,
-) -> Vec<VarSlotFeatureOption> {
-    (0..target_count)
-        .flat_map(|target_pos| {
-            target_tuple
-                .slot_features
-                .get(target_pos)
-                .cloned()
-                .unwrap_or_default()
-                .into_iter()
-                .map(move |feature| VarSlotFeatureOption {
-                    target_pos,
-                    feature,
-                })
-        })
-        .collect::<BTreeSet<_>>()
-        .into_iter()
-        .collect()
-}
-
-fn var_group_tuple_has_slot_feature(
-    tuple: &VarGroupTupleWithFeatures,
-    option: &VarSlotFeatureOption,
-) -> bool {
-    tuple
-        .slot_features
-        .get(option.target_pos)
-        .is_some_and(|features| features.contains(&option.feature))
-}
-
-struct VarSlotConstraintSearch {
-    options: Vec<VarSlotSearchOption>,
-    uncovered_initial: BTreeSet<usize>,
-    options_covering_competitor: BTreeMap<usize, Vec<usize>>,
-    best: Option<(SelectorSearchCost, Vec<usize>)>,
-    memo: BTreeMap<BTreeSet<usize>, SelectorSearchCost>,
-    nodes: usize,
-}
-
-impl VarSlotConstraintSearch {
-    fn new(options: Vec<VarSlotSearchOption>, uncovered_initial: BTreeSet<usize>) -> Self {
-        let mut options_covering_competitor: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
-        for (option_idx, option) in options.iter().enumerate() {
-            for tuple_idx in &option.covered {
-                options_covering_competitor
-                    .entry(*tuple_idx)
-                    .or_default()
-                    .push(option_idx);
-            }
-        }
-        for option_indices in options_covering_competitor.values_mut() {
-            option_indices
-                .sort_by(|a, b| option_sort_key(&options[*a]).cmp(&option_sort_key(&options[*b])));
-        }
-        Self {
-            options,
-            uncovered_initial,
-            options_covering_competitor,
-            best: None,
-            memo: BTreeMap::new(),
-            nodes: 0,
-        }
-    }
-
-    fn solve(&mut self) -> Option<Vec<usize>> {
-        let greedy = self.greedy_upper_bound()?;
-        self.best = Some(greedy);
-        self.branch(
-            self.uncovered_initial.clone(),
-            Vec::new(),
-            BTreeSet::new(),
-            SelectorSearchCost::ZERO,
-        );
-        self.best.as_ref().map(|(_, selected)| selected.clone())
-    }
-
-    fn greedy_upper_bound(&self) -> Option<(SelectorSearchCost, Vec<usize>)> {
-        let mut uncovered = self.uncovered_initial.clone();
-        let mut selected = Vec::new();
-        let mut selected_set = BTreeSet::new();
-        let mut cost = SelectorSearchCost::ZERO;
-        while !uncovered.is_empty() {
-            let (option_idx, _) = self
-                .options
-                .iter()
-                .enumerate()
-                .filter(|(option_idx, _)| !selected_set.contains(option_idx))
-                .map(|(option_idx, option)| {
-                    let covered_count = option.covered.intersection(&uncovered).count();
-                    (option_idx, covered_count)
-                })
-                .filter(|(_, covered_count)| *covered_count > 0)
-                .max_by(|(a_idx, a_covered), (b_idx, b_covered)| {
-                    a_covered.cmp(b_covered).then_with(|| {
-                        option_sort_key(&self.options[*b_idx])
-                            .cmp(&option_sort_key(&self.options[*a_idx]))
-                    })
-                })?;
-            selected_set.insert(option_idx);
-            selected.push(option_idx);
-            cost = cost.add(&self.options[option_idx].option.feature);
-            uncovered = uncovered
-                .difference(&self.options[option_idx].covered)
-                .copied()
-                .collect();
-        }
-        selected.sort_by(|a, b| {
-            option_sort_key(&self.options[*a]).cmp(&option_sort_key(&self.options[*b]))
-        });
-        Some((cost, selected))
-    }
-
-    fn branch(
-        &mut self,
-        uncovered: BTreeSet<usize>,
-        selected: Vec<usize>,
-        selected_set: BTreeSet<usize>,
-        cost: SelectorSearchCost,
-    ) {
-        self.nodes += 1;
-        if self.nodes > MAX_VAR_FEATURE_SEARCH_NODES {
-            return;
-        }
-        if let Some((best_cost, _)) = &self.best
-            && cost >= *best_cost
-        {
-            return;
-        }
-        if uncovered.is_empty() {
-            let mut normalized = selected;
-            normalized.sort_by(|a, b| {
-                option_sort_key(&self.options[*a]).cmp(&option_sort_key(&self.options[*b]))
-            });
-            let replace = self.best.as_ref().is_none_or(|(best_cost, best_selected)| {
-                cost < *best_cost
-                    || (cost == *best_cost
-                        && selected_sort_key(&self.options, &normalized)
-                            < selected_sort_key(&self.options, best_selected))
-            });
-            if replace {
-                self.best = Some((cost, normalized));
-            }
-            return;
-        }
-        if self
-            .memo
-            .get(&uncovered)
-            .is_some_and(|seen_cost| *seen_cost <= cost)
-        {
-            return;
-        }
-        self.memo.insert(uncovered.clone(), cost);
-
-        let Some(pivot) = self.best_pivot_competitor(&uncovered, &selected_set) else {
-            return;
-        };
-        let Some(option_indices) = self.options_covering_competitor.get(&pivot).cloned() else {
-            return;
-        };
-        for option_idx in option_indices {
-            if selected_set.contains(&option_idx) {
-                continue;
-            }
-            let option = &self.options[option_idx];
-            let new_uncovered = uncovered
-                .difference(&option.covered)
-                .copied()
-                .collect::<BTreeSet<_>>();
-            if new_uncovered.len() == uncovered.len() {
-                continue;
-            }
-            let new_cost = cost.add(&option.option.feature);
-            if let Some((best_cost, _)) = &self.best
-                && new_cost >= *best_cost
-            {
-                continue;
-            }
-            let mut new_selected = selected.clone();
-            new_selected.push(option_idx);
-            let mut new_selected_set = selected_set.clone();
-            new_selected_set.insert(option_idx);
-            self.branch(new_uncovered, new_selected, new_selected_set, new_cost);
-        }
-    }
-
-    fn best_pivot_competitor(
-        &self,
-        uncovered: &BTreeSet<usize>,
-        selected_set: &BTreeSet<usize>,
-    ) -> Option<usize> {
-        uncovered
-            .iter()
-            .filter_map(|tuple_idx| {
-                let covering_options = self.options_covering_competitor.get(tuple_idx)?;
-                let available_count = covering_options
-                    .iter()
-                    .filter(|option_idx| !selected_set.contains(option_idx))
-                    .count();
-                (available_count > 0).then_some((*tuple_idx, available_count))
-            })
-            .min_by_key(|(tuple_idx, available_count)| (*available_count, *tuple_idx))
-            .map(|(tuple_idx, _)| tuple_idx)
-    }
-}
-
-fn option_sort_key(option: &VarSlotSearchOption) -> (usize, usize, usize, &SelectorAnchorFeature) {
-    (
-        feature_cost(&option.option.feature),
-        option.option.target_pos,
-        usize::MAX - option.covered.len(),
-        &option.option.feature,
-    )
-}
-
-fn selected_sort_key<'a>(
-    options: &'a [VarSlotSearchOption],
-    selected: &'a [usize],
-) -> Vec<(usize, usize, usize, &'a SelectorAnchorFeature)> {
-    selected
-        .iter()
-        .map(|option_idx| option_sort_key(&options[*option_idx]))
-        .collect()
-}
-
-fn feature_cost(feature: &SelectorAnchorFeature) -> usize {
-    match feature {
-        SelectorAnchorFeature::DeclarationKind(_)
-        | SelectorAnchorFeature::VarKind(_)
-        | SelectorAnchorFeature::FunctionArity(_) => 0,
-        SelectorAnchorFeature::ObjectKey(_) | SelectorAnchorFeature::ClassMember(_) => 1,
-        SelectorAnchorFeature::CallCallee(_) => 2,
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-struct VarGroupTuple {
-    body_idx: usize,
-    slots: Vec<usize>,
-}
-
-#[derive(Debug, Clone)]
-struct VarGroupTupleWithFeatures {
-    tuple: VarGroupTuple,
-    slot_features: Vec<BTreeSet<SelectorAnchorFeature>>,
-}
-
-fn selector_anchor_features_for_item(
-    item: &ModuleItem,
-    kind: IndexedDeclarationKind,
-) -> BTreeSet<SelectorAnchorFeature> {
-    let mut features = BTreeSet::from([SelectorAnchorFeature::DeclarationKind(kind)]);
-    match item_decl(item) {
-        Some(Decl::Fn(function)) => {
-            features.insert(SelectorAnchorFeature::FunctionArity(
-                function.function.params.len(),
-            ));
-        }
-        Some(Decl::Var(var)) => {
-            features.insert(SelectorAnchorFeature::VarKind(
-                var_kind_label(var.kind).to_string(),
-            ));
-        }
-        Some(Decl::Class(class)) => {
-            for member in &class.class.body {
-                if let Some(name) = class_member_feature_name(member) {
-                    features.insert(SelectorAnchorFeature::ClassMember(name));
-                }
-            }
-        }
-        _ => {}
-    }
-    features
-}
-
-fn collect_renderable_var_anchor_features(
-    expr: &Expr,
-    features: &mut BTreeSet<SelectorAnchorFeature>,
-) {
-    if is_hole_expr(expr) {
-        return;
-    }
-    match expr {
-        Expr::Call(call) => {
-            if let Some(callee) = call_callee_feature_name(&call.callee) {
-                features.insert(SelectorAnchorFeature::CallCallee(callee));
-            }
-            for arg in &call.args {
-                if let Expr::Object(object) = arg.expr.as_ref() {
-                    collect_direct_object_key_features(object, features);
-                }
-            }
-        }
-        Expr::Object(object) => collect_direct_object_key_features(object, features),
-        _ => {}
-    }
-}
-
-fn collect_direct_object_key_features(
-    object: &ObjectLit,
-    features: &mut BTreeSet<SelectorAnchorFeature>,
-) {
-    for prop in &object.props {
-        if let PropOrSpread::Prop(prop) = prop
-            && let Some(name) = prop_key_name(prop.as_ref())
-        {
-            features.insert(SelectorAnchorFeature::ObjectKey(name));
-        }
-    }
-}
-
-fn var_group_frontier(
-    index: &ChunkSelectorIndex,
-    var_kind: VarDeclKind,
-    target_count: usize,
-    slot_constraints: &[BTreeSet<SelectorAnchorFeature>],
-) -> BTreeSet<VarGroupTuple> {
-    var_group_frontier_with_features(index, var_kind, target_count, slot_constraints)
-        .into_iter()
-        .map(|tuple| tuple.tuple)
-        .collect()
-}
-
-fn var_group_frontier_with_features(
-    index: &ChunkSelectorIndex,
-    var_kind: VarDeclKind,
-    target_count: usize,
-    slot_constraints: &[BTreeSet<SelectorAnchorFeature>],
-) -> Vec<VarGroupTupleWithFeatures> {
-    let mut tuples = Vec::new();
-    for decl in &index.decls {
-        if decl.kind != IndexedDeclarationKind::Var {
-            continue;
-        }
-        let (Some(ModuleItem::Stmt(Stmt::Decl(Decl::Var(var))))
-        | Some(ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
-            decl: Decl::Var(var),
-            ..
-        })))) = index.parsed.module.body.get(decl.body_idx)
-        else {
-            continue;
-        };
-        if var.kind != var_kind || var.decls.len() < target_count {
-            continue;
-        }
-        let declarator_features = var
-            .decls
-            .iter()
-            .map(|declarator| {
-                let mut features = BTreeSet::new();
-                if let Some(init) = declarator.init.as_deref() {
-                    collect_renderable_var_anchor_features(init, &mut features);
-                }
-                features
-            })
-            .collect::<Vec<_>>();
-        let mut combinations = Vec::new();
-        collect_slot_combinations(
-            var.decls.len(),
-            target_count,
-            0,
-            &mut Vec::new(),
-            &mut combinations,
-        );
-        for slots in combinations {
-            let matches_constraints = slots.iter().enumerate().all(|(target_pos, slot)| {
-                let constraints = &slot_constraints[target_pos];
-                constraints.is_empty()
-                    || declarator_features
-                        .get(*slot)
-                        .is_some_and(|features| constraints.is_subset(features))
-            });
-            if matches_constraints {
-                let slot_features = slots
-                    .iter()
-                    .map(|slot| declarator_features.get(*slot).cloned().unwrap_or_default())
-                    .collect();
-                tuples.push(VarGroupTupleWithFeatures {
-                    tuple: VarGroupTuple {
-                        body_idx: decl.body_idx,
-                        slots,
-                    },
-                    slot_features,
-                });
-            }
-        }
-    }
-    tuples
-}
-
-fn var_group_frontier_is_bounded(
-    index: &ChunkSelectorIndex,
-    var_kind: VarDeclKind,
-    target_count: usize,
-) -> bool {
-    index.decls.iter().all(|decl| {
-        if decl.kind != IndexedDeclarationKind::Var {
-            return true;
-        }
-        let (Some(ModuleItem::Stmt(Stmt::Decl(Decl::Var(var))))
-        | Some(ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
-            decl: Decl::Var(var),
-            ..
-        })))) = index.parsed.module.body.get(decl.body_idx)
-        else {
-            return true;
-        };
-        var.kind != var_kind
-            || var.decls.len() < target_count
-            || !combination_count_exceeds(
-                var.decls.len(),
-                target_count,
-                MAX_VAR_GROUP_FRONTIER_TUPLES_PER_DECL,
-            )
-    })
-}
-
-fn combination_count_exceeds(n: usize, k: usize, limit: usize) -> bool {
-    if k > n {
-        return false;
-    }
-    let k = k.min(n - k);
-    let mut count = 1u128;
-    let limit = limit as u128;
-    for i in 1..=k {
-        count = count * (n - k + i) as u128 / i as u128;
-        if count > limit {
-            return true;
-        }
-    }
-    false
-}
-
-fn collect_slot_combinations(
-    len: usize,
-    target_count: usize,
-    start: usize,
-    current: &mut Vec<usize>,
-    out: &mut Vec<Vec<usize>>,
-) {
-    if current.len() == target_count {
-        out.push(current.clone());
-        return;
-    }
-    for idx in start..len {
-        current.push(idx);
-        collect_slot_combinations(len, target_count, idx + 1, current, out);
-        current.pop();
-    }
-}
-
-fn target_tuple_is_unique(
-    frontier: &BTreeSet<VarGroupTuple>,
-    decl: &IndexedDeclaration,
-    target_slots: &[usize],
-) -> bool {
-    frontier.len() == 1
-        && frontier.contains(&VarGroupTuple {
-            body_idx: decl.body_idx,
-            slots: target_slots.to_vec(),
-        })
-}
-
-struct RenderedExprSelector {
-    source: String,
-    holes: BTreeSet<String>,
-    cost: usize,
-}
-
-#[derive(Debug, Clone)]
-struct RenderedStmtSelector {
-    source: String,
-    holes: BTreeSet<String>,
-    cost: usize,
-}
-
-#[derive(Debug, Clone)]
-struct RenderedStmtListSelector {
-    source: String,
-    holes: BTreeSet<String>,
-    cost: usize,
-}
-
-fn render_specialized_expr_selector(
-    index: &ChunkSelectorIndex,
-    expr: &Expr,
-    selected_features: &BTreeSet<SelectorAnchorFeature>,
-) -> Result<RenderedExprSelector> {
-    match expr {
-        Expr::Call(call) if call_has_selected_feature(call, selected_features) => {
-            render_specialized_call_selector(index, call, selected_features)
-        }
-        Expr::Object(object) if object_has_selected_key(object, selected_features) => Ok(
-            render_specialized_object_selector(object, selected_features),
-        ),
-        _ => Ok(RenderedExprSelector {
-            source: ANYTHING_HOLE_KEYWORD.to_string(),
-            holes: BTreeSet::from([ANYTHING_HOLE_KEYWORD.to_string()]),
-            cost: 0,
-        }),
-    }
-}
-
-fn render_specialized_call_selector(
-    index: &ChunkSelectorIndex,
-    call: &CallExpr,
-    selected_features: &BTreeSet<SelectorAnchorFeature>,
-) -> Result<RenderedExprSelector> {
-    let callee = match &call.callee {
-        Callee::Expr(expr) => source_for_span(index, expr.span())?.text,
-        _ => return Ok(anything_expr_selector()),
-    };
-    let mut args = Vec::new();
-    let mut holes = BTreeSet::new();
-    let mut skipped = false;
-    for arg in &call.args {
-        if let Expr::Object(object) = arg.expr.as_ref()
-            && object_has_selected_key(object, selected_features)
-        {
-            if skipped {
-                args.push(ARGS_HOLE_KEYWORD.to_string());
-                holes.insert(ARGS_HOLE_KEYWORD.to_string());
-                skipped = false;
-            }
-            let rendered = render_specialized_object_selector(object, selected_features);
-            holes.extend(rendered.holes.clone());
-            args.push(rendered.source);
-        } else {
-            skipped = true;
-        }
-    }
-    if skipped || args.is_empty() {
-        args.push(ARGS_HOLE_KEYWORD.to_string());
-        holes.insert(ARGS_HOLE_KEYWORD.to_string());
-    }
-    Ok(RenderedExprSelector {
-        source: format!("{callee}({})", args.join(", ")),
-        holes,
-        cost: 2,
-    })
-}
-
-fn render_specialized_object_selector(
-    object: &ObjectLit,
-    selected_features: &BTreeSet<SelectorAnchorFeature>,
-) -> RenderedExprSelector {
-    let mut parts = Vec::new();
-    let mut skipped = false;
-    for prop in &object.props {
-        let key = match prop {
-            PropOrSpread::Prop(prop) => prop_key_name(prop.as_ref()),
-            PropOrSpread::Spread(_) => None,
-        };
-        if let Some(key) = key
-            && selected_features.contains(&SelectorAnchorFeature::ObjectKey(key.clone()))
-        {
-            if skipped {
-                parts.push(ANYTHING_HOLE_KEYWORD.to_string());
-                skipped = false;
-            }
-            parts.push(format!("{key}: {ANYTHING_HOLE_KEYWORD}"));
-        } else {
-            skipped = true;
-        }
-    }
-    if skipped || parts.is_empty() {
-        parts.push(ANYTHING_HOLE_KEYWORD.to_string());
-    }
-    RenderedExprSelector {
-        source: format!("{{ {} }}", parts.join(", ")),
-        holes: BTreeSet::from([ANYTHING_HOLE_KEYWORD.to_string()]),
-        cost: 1,
-    }
-}
-
-fn anything_expr_selector() -> RenderedExprSelector {
-    RenderedExprSelector {
-        source: ANYTHING_HOLE_KEYWORD.to_string(),
-        holes: BTreeSet::from([ANYTHING_HOLE_KEYWORD.to_string()]),
-        cost: 0,
-    }
+    // Single-target and multi-target vars both route through the AST-prune group
+    // path (the single case is the N=1 group). On `None`, the caller falls back
+    // to the exact selector.
+    minimize_var_group_selector(index, var, decl, targets)
 }
 
 // ===========================================================================
@@ -2202,13 +1286,19 @@ fn anything_expr_selector() -> RenderedExprSelector {
 // run holes `STMT_LIST` / `OBJECT_PROPS` / `CLASS_REST` for dropped statement /
 // object-property / class-member runs.
 //
-// Anchor selection is a matcher-driven minimal set cover: each candidate
-// anchor's exclusion set (the competitor declarations it rules out) is computed
-// by the production matcher, so discrimination is exact rather than an index
-// approximation. A greedy cover picks anchors until every competitor is
-// excluded; the chosen union is rendered once and proven by the matcher. This
-// is a mechanical first pass — it finds *a* structural pin for the routine
-// cases, not necessarily the most semantically meaningful one.
+// Anchor selection favors keeping shallow literals (direct values/args), then
+// escalates by tier (structural key/member presence, then deeper literals).
+// Function and class single targets resolve through a matcher-driven minimum
+// set cover (`cover_competitors` + `min_set_cover` B&B): each anchor's exclusion
+// set is computed by the production matcher, so discrimination is exact and the
+// cover is minimum-cardinality. Var declarations (single and multi-target
+// groups) share one keep-shallow-then-escalate path (`minimize_var_group_selector`,
+// the single declarator being its N=1 case), proven through the binding-group
+// matcher used as a resolves-uniquely oracle; it keeps each slot's direct shallow
+// literals and may over-pin rather than run an exact-minimum cover. Either way the
+// chosen union is rendered once and proven by the matcher. This is a mechanical
+// first pass — it finds *a* robust pin for the routine cases, not necessarily the
+// most semantically meaningful one.
 // ===========================================================================
 
 /// `(lo, hi)` byte offsets of a retained concrete token.
@@ -2474,8 +1564,8 @@ fn hole_stmt(stmt: &Stmt, kept: &BTreeSet<AnchorSpan>) -> Stmt {
 /// than a literal buried inside `mk("primary")`.
 #[derive(Default)]
 struct AnchorCandidates {
-    /// `(span, call-nesting depth, is-object-property-value)` for each literal.
-    literals: Vec<(AnchorSpan, u32, bool)>,
+    /// `(span, call-nesting depth)` for each literal.
+    literals: Vec<(AnchorSpan, u32)>,
     structural: Vec<AnchorSpan>,
 }
 
@@ -2498,12 +1588,12 @@ impl AnchorCandidates {
         let literal_tier = |depth: u32| -> Vec<AnchorSpan> {
             self.literals
                 .iter()
-                .filter(|(_, anchor_depth, _)| *anchor_depth == depth)
-                .map(|(span, _, _)| *span)
+                .filter(|(_, anchor_depth)| *anchor_depth == depth)
+                .map(|(span, _)| *span)
                 .collect()
         };
         let mut tiers = Vec::new();
-        let Some(max_depth) = self.literals.iter().map(|(_, depth, _)| *depth).max() else {
+        let Some(max_depth) = self.literals.iter().map(|(_, depth)| *depth).max() else {
             if !self.structural.is_empty() {
                 tiers.push(self.structural.clone());
             }
@@ -2528,12 +1618,16 @@ impl AnchorCandidates {
     }
 
     /// Shallow literal anchors — direct values/args worth keeping as meaningful
-    /// per-slot pins even when structure alone would already discriminate.
+    /// per-slot pins even when structure alone would already discriminate. This
+    /// includes object-property values (`kind: "primary"`): the unified anchor
+    /// policy favors keeping shallow literals over an exact-minimum cover, so an
+    /// occasional over-pin (a shared `enabled: true`) is accepted as the price
+    /// of a single policy across single and group targets.
     fn shallow_literals(&self) -> Vec<AnchorSpan> {
         self.literals
             .iter()
-            .filter(|(_, depth, in_object)| *depth <= SHALLOW_LITERAL_DEPTH && !in_object)
-            .map(|(span, _, _)| *span)
+            .filter(|(_, depth)| *depth <= SHALLOW_LITERAL_DEPTH)
+            .map(|(span, _)| *span)
             .collect()
     }
 
@@ -2544,13 +1638,13 @@ impl AnchorCandidates {
         if !self.structural.is_empty() {
             tiers.push(self.structural.clone());
         }
-        if let Some(max_depth) = self.literals.iter().map(|(_, depth, _)| *depth).max() {
+        if let Some(max_depth) = self.literals.iter().map(|(_, depth)| *depth).max() {
             for depth in (SHALLOW_LITERAL_DEPTH + 1)..=max_depth {
                 let tier: Vec<AnchorSpan> = self
                     .literals
                     .iter()
-                    .filter(|(_, anchor_depth, _)| *anchor_depth == depth)
-                    .map(|(span, _, _)| *span)
+                    .filter(|(_, anchor_depth)| *anchor_depth == depth)
+                    .map(|(span, _)| *span)
                     .collect();
                 if !tier.is_empty() {
                     tiers.push(tier);
@@ -2615,51 +1709,38 @@ fn collect_block_anchors(stmt: &Stmt, candidates: &mut AnchorCandidates) {
 }
 
 /// `depth` counts enclosing call/new levels, so the tiered cover can prefer
-/// shallower literal anchors.
+/// shallower literal anchors. Object-property values (`kind: "primary"`) are
+/// collected at the enclosing depth like any other literal; the unified
+/// keep-shallow policy retains them rather than treating them as incidental.
 fn collect_expr_anchors(expr: &Expr, depth: u32, candidates: &mut AnchorCandidates) {
-    collect_expr_anchors_in(expr, depth, false, candidates);
-}
-
-/// `in_object` marks literals that are object-property values (e.g. the `true`
-/// in `mk({ enabled: true })`) rather than direct declarator/call-argument
-/// values. Group keep-shallow skips object-value literals as likely-incidental
-/// config; single-target tiers ignore the flag.
-fn collect_expr_anchors_in(
-    expr: &Expr,
-    depth: u32,
-    in_object: bool,
-    candidates: &mut AnchorCandidates,
-) {
     match expr {
         Expr::Lit(_) | Expr::Tpl(_) => {
-            candidates
-                .literals
-                .push((span_key(expr.span()), depth, in_object));
+            candidates.literals.push((span_key(expr.span()), depth));
         }
-        Expr::Paren(paren) => collect_expr_anchors_in(&paren.expr, depth, in_object, candidates),
+        Expr::Paren(paren) => collect_expr_anchors(&paren.expr, depth, candidates),
         Expr::Member(member) => {
-            collect_expr_anchors_in(&member.obj, depth, in_object, candidates);
+            collect_expr_anchors(&member.obj, depth, candidates);
             if let MemberProp::Ident(ident) = &member.prop {
                 candidates.structural.push(span_key(ident.span));
             } else if let MemberProp::Computed(computed) = &member.prop {
-                collect_expr_anchors_in(&computed.expr, depth, in_object, candidates);
+                collect_expr_anchors(&computed.expr, depth, candidates);
             }
         }
         Expr::Call(call) => {
             if let Callee::Expr(callee) = &call.callee {
-                collect_expr_anchors_in(callee, depth, in_object, candidates);
+                collect_expr_anchors(callee, depth, candidates);
             }
             for arg in &call.args {
                 if arg.spread.is_none() {
-                    collect_expr_anchors_in(&arg.expr, depth + 1, in_object, candidates);
+                    collect_expr_anchors(&arg.expr, depth + 1, candidates);
                 }
             }
         }
         Expr::New(new_expr) => {
-            collect_expr_anchors_in(&new_expr.callee, depth, in_object, candidates);
+            collect_expr_anchors(&new_expr.callee, depth, candidates);
             for arg in new_expr.args.as_deref().unwrap_or_default() {
                 if arg.spread.is_none() {
-                    collect_expr_anchors_in(&arg.expr, depth + 1, in_object, candidates);
+                    collect_expr_anchors(&arg.expr, depth + 1, candidates);
                 }
             }
         }
@@ -2668,18 +1749,16 @@ fn collect_expr_anchors_in(
                 if let PropOrSpread::Prop(prop) = prop {
                     if let Prop::KeyValue(key_value) = prop.as_ref() {
                         candidates.structural.push(span_key(key_value.key.span()));
-                        collect_expr_anchors_in(&key_value.value, depth, true, candidates);
+                        collect_expr_anchors(&key_value.value, depth, candidates);
                     }
                 }
             }
         }
-        Expr::Await(await_expr) => {
-            collect_expr_anchors_in(&await_expr.arg, depth, in_object, candidates)
-        }
-        Expr::Unary(unary) => collect_expr_anchors_in(&unary.arg, depth, in_object, candidates),
+        Expr::Await(await_expr) => collect_expr_anchors(&await_expr.arg, depth, candidates),
+        Expr::Unary(unary) => collect_expr_anchors(&unary.arg, depth, candidates),
         Expr::Bin(bin) => {
-            collect_expr_anchors_in(&bin.left, depth, in_object, candidates);
-            collect_expr_anchors_in(&bin.right, depth, in_object, candidates);
+            collect_expr_anchors(&bin.left, depth, candidates);
+            collect_expr_anchors(&bin.right, depth, candidates);
         }
         _ => {}
     }
@@ -2779,39 +1858,6 @@ fn minimize_function_selector(
     minimize_via_retention(index, decl, target, &candidates, &render_with)
 }
 
-/// Minimal anchor cover for a single-target, single-declarator `var`/`let`/
-/// `const`: render `<kind> <export> = <retained init>` and cover sibling
-/// declarations. Multi-declarator groups fall back to the legacy slot search.
-fn minimize_var_selector(
-    index: &ChunkSelectorIndex,
-    var: &VarDecl,
-    decl: &IndexedDeclaration,
-    target: &SynthesizedTargetBinding,
-) -> Result<Option<SpecializedSelector>> {
-    let [declarator] = var.decls.as_slice() else {
-        return Ok(None);
-    };
-    if single_ident_pat_name(&declarator.name) != Some(target.runtime_binding.as_str()) {
-        return Ok(None);
-    }
-    let Some(init) = declarator.init.as_deref() else {
-        return Ok(None);
-    };
-    let export = target.export_name.clone();
-    let render_with = |kept: &BTreeSet<AnchorSpan>| -> Result<String> {
-        let mut holed_declarator = declarator.clone();
-        holed_declarator.name = named_pat(&export);
-        holed_declarator.init = Some(Box::new(hole_expr(init, kept)));
-        let mut holed_var = var.clone();
-        holed_var.declare = false;
-        holed_var.decls = vec![holed_declarator];
-        emit_selector(ModuleItem::Stmt(Stmt::Decl(Decl::Var(Box::new(holed_var)))))
-    };
-    let mut candidates = AnchorCandidates::default();
-    collect_expr_anchors(init, 0, &mut candidates);
-    minimize_via_retention(index, decl, target, &candidates, &render_with)
-}
-
 /// A `DECLARATORS_<pos> = null` declarator hole absorbing a run of non-target
 /// declarators in a binding-group selector.
 fn declarator_hole(name: &str) -> VarDeclarator {
@@ -2823,16 +1869,17 @@ fn declarator_hole(name: &str) -> VarDeclarator {
     }
 }
 
-/// Minimal anchor cover for a multi-target binding group: render the shared
-/// declaration keeping the target declarators (each `export = <holed init>`)
-/// with `DECLARATORS_*` holes for non-target runs, and pin just enough anchors
-/// for the group to resolve uniquely to the right declaration and bindings.
+/// Minimal anchor cover for a `var`/`let`/`const` binding group: render the
+/// shared declaration keeping the target declarators (each `export = <holed
+/// init>`) with `DECLARATORS_*` holes for non-target runs, and pin just enough
+/// anchors for the group to resolve uniquely to the right declaration and
+/// bindings. A single-declarator target is the N=1 case of this path: one
+/// target slot, no `DECLARATORS_*` gaps, and the binding-group matcher's tuple
+/// proof degenerates to the single-binding case in `prove_synthesized_selector`.
 ///
-/// Unlike the single-target path, a binding group resolves through
-/// `resolve_member_binding_group_match`, which yields one match or an error
-/// rather than a candidate set — so the cover uses that proof as a boolean
-/// oracle, adding anchors tier by tier (shallow literals first) until the group
-/// resolves correctly.
+/// The proof uses `prove_synthesized_selector` as a boolean oracle (it yields a
+/// count or an error rather than a candidate set), adding anchors tier by tier
+/// (shallow literals first) until the group resolves correctly.
 fn minimize_var_group_selector(
     index: &ChunkSelectorIndex,
     var: &VarDecl,
@@ -3216,906 +2263,6 @@ fn finish_minimized_selector(
         match_source: source,
         rewritten_holes,
     }))
-}
-
-fn render_function_body_selector_candidates(
-    index: &ChunkSelectorIndex,
-    function: &Function,
-) -> Result<Vec<RenderedStmtListSelector>> {
-    let Some(body) = &function.body else {
-        return Ok(Vec::new());
-    };
-    render_stmt_list_selector_candidates(index, &body.stmts)
-}
-
-fn render_stmt_list_selector_candidates(
-    index: &ChunkSelectorIndex,
-    stmts: &[Stmt],
-) -> Result<Vec<RenderedStmtListSelector>> {
-    if stmts.is_empty() {
-        return Ok(vec![RenderedStmtListSelector {
-            source: format!("{STMT_LIST_HOLE_KEYWORD};"),
-            holes: BTreeSet::from([STMT_LIST_HOLE_KEYWORD.to_string()]),
-            cost: 0,
-        }]);
-    }
-
-    let mut per_stmt = Vec::new();
-    for stmt in stmts {
-        per_stmt.push(render_stmt_selector_variants(index, stmt)?);
-    }
-
-    let mut out = Vec::new();
-    let mut seen = BTreeSet::new();
-    for (stmt_idx, variants) in per_stmt.iter().enumerate() {
-        for stmt in variants.iter().take(MAX_STMT_SELECTOR_VARIANTS) {
-            push_stmt_list_candidate(
-                &mut out,
-                &mut seen,
-                stmts.len(),
-                &[(stmt_idx, stmt.clone())],
-            );
-        }
-    }
-
-    for first_idx in 0..per_stmt.len() {
-        for second_idx in (first_idx + 1)..per_stmt.len() {
-            for first in per_stmt[first_idx].iter().take(4) {
-                for second in per_stmt[second_idx].iter().take(4) {
-                    push_stmt_list_candidate(
-                        &mut out,
-                        &mut seen,
-                        stmts.len(),
-                        &[(first_idx, first.clone()), (second_idx, second.clone())],
-                    );
-                    if out.len() >= MAX_FUNCTION_SELECTOR_CANDIDATES {
-                        break;
-                    }
-                }
-                if out.len() >= MAX_FUNCTION_SELECTOR_CANDIDATES {
-                    break;
-                }
-            }
-            if out.len() >= MAX_FUNCTION_SELECTOR_CANDIDATES {
-                break;
-            }
-        }
-        if out.len() >= MAX_FUNCTION_SELECTOR_CANDIDATES {
-            break;
-        }
-    }
-
-    out.sort_by_key(|candidate| (candidate.cost, candidate.source.len()));
-    out.truncate(MAX_FUNCTION_SELECTOR_CANDIDATES);
-    Ok(out)
-}
-
-fn push_stmt_list_candidate(
-    out: &mut Vec<RenderedStmtListSelector>,
-    seen: &mut BTreeSet<String>,
-    len: usize,
-    anchors: &[(usize, RenderedStmtSelector)],
-) {
-    if anchors.is_empty() {
-        return;
-    }
-    let mut lines = Vec::new();
-    let mut holes = BTreeSet::new();
-    let mut cost = 0usize;
-    let mut previous_end = 0usize;
-    for (idx, stmt) in anchors {
-        if *idx > previous_end {
-            lines.push(format!("{STMT_LIST_HOLE_KEYWORD};"));
-            holes.insert(STMT_LIST_HOLE_KEYWORD.to_string());
-            cost += 1;
-        }
-        lines.push(stmt.source.clone());
-        holes.extend(stmt.holes.clone());
-        cost += stmt.cost;
-        previous_end = idx + 1;
-    }
-    if previous_end < len {
-        lines.push(format!("{STMT_LIST_HOLE_KEYWORD};"));
-        holes.insert(STMT_LIST_HOLE_KEYWORD.to_string());
-        cost += 1;
-    }
-    let source = lines.join("\n");
-    if seen.insert(source.clone()) {
-        out.push(RenderedStmtListSelector {
-            source,
-            holes,
-            cost,
-        });
-    }
-}
-
-fn render_stmt_selector_variants(
-    index: &ChunkSelectorIndex,
-    stmt: &Stmt,
-) -> Result<Vec<RenderedStmtSelector>> {
-    let mut out = Vec::new();
-    let mut seen = BTreeSet::new();
-    match stmt {
-        Stmt::Expr(expr_stmt) => {
-            for expr in render_expr_selector_variants(index, &expr_stmt.expr)? {
-                push_stmt_variant(
-                    &mut out,
-                    &mut seen,
-                    format!("{};", expr.source),
-                    expr.holes,
-                    expr.cost + 1,
-                );
-            }
-        }
-        Stmt::Return(return_stmt) => {
-            if let Some(arg) = &return_stmt.arg {
-                for expr in render_expr_selector_variants(index, arg)? {
-                    push_stmt_variant(
-                        &mut out,
-                        &mut seen,
-                        format!("return {};", expr.source),
-                        expr.holes,
-                        expr.cost + 1,
-                    );
-                }
-            } else {
-                push_stmt_variant(
-                    &mut out,
-                    &mut seen,
-                    "return;".to_string(),
-                    BTreeSet::new(),
-                    1,
-                );
-            }
-        }
-        Stmt::Throw(throw_stmt) => {
-            for expr in render_expr_selector_variants(index, &throw_stmt.arg)? {
-                push_stmt_variant(
-                    &mut out,
-                    &mut seen,
-                    format!("throw {};", expr.source),
-                    expr.holes,
-                    expr.cost + 1,
-                );
-            }
-        }
-        Stmt::Decl(Decl::Var(var)) => {
-            for (idx, declarator) in var.decls.iter().enumerate() {
-                let pat = source_for_span(index, declarator.name.span())?.text;
-                let expr_variants = if let Some(init) = declarator.init.as_deref() {
-                    render_expr_selector_variants(index, init)?
-                } else {
-                    vec![RenderedExprSelector {
-                        source: String::new(),
-                        holes: BTreeSet::new(),
-                        cost: 0,
-                    }]
-                };
-                for expr in expr_variants.into_iter().take(MAX_EXPR_SELECTOR_VARIANTS) {
-                    let mut parts = Vec::new();
-                    let mut holes = expr.holes.clone();
-                    let mut cost = expr.cost + 1;
-                    if idx > 0 {
-                        parts.push(format!("{DECLARATORS_HOLE_KEYWORD}_BEFORE = null"));
-                        holes.insert(format!("{DECLARATORS_HOLE_KEYWORD}_BEFORE"));
-                        cost += 1;
-                    }
-                    let declarator_source = if declarator.init.is_some() {
-                        format!("{pat} = {}", expr.source)
-                    } else {
-                        pat.clone()
-                    };
-                    parts.push(declarator_source);
-                    if idx + 1 < var.decls.len() {
-                        parts.push(format!("{DECLARATORS_HOLE_KEYWORD}_AFTER = null"));
-                        holes.insert(format!("{DECLARATORS_HOLE_KEYWORD}_AFTER"));
-                        cost += 1;
-                    }
-                    push_stmt_variant(
-                        &mut out,
-                        &mut seen,
-                        format!("{} {};", var_kind_label(var.kind), parts.join(",\n  ")),
-                        holes,
-                        cost,
-                    );
-                }
-            }
-        }
-        Stmt::If(if_stmt) => {
-            for test in render_expr_selector_variants(index, &if_stmt.test)? {
-                let (cons_source, mut cons_holes, cons_cost) =
-                    render_stmt_as_block_selector(index, &if_stmt.cons)?;
-                let mut holes = test.holes.clone();
-                holes.append(&mut cons_holes);
-                push_stmt_variant(
-                    &mut out,
-                    &mut seen,
-                    format!(
-                        "if ({}) {{\n{}\n}}",
-                        test.source,
-                        indent_lines(&cons_source, "  ")
-                    ),
-                    holes,
-                    test.cost + cons_cost + 1,
-                );
-            }
-            if let Stmt::Block(block) = if_stmt.cons.as_ref() {
-                for body in render_stmt_list_selector_candidates(index, &block.stmts)?
-                    .into_iter()
-                    .take(MAX_STMT_SELECTOR_VARIANTS)
-                {
-                    let mut holes = body.holes;
-                    holes.insert(ANYTHING_HOLE_KEYWORD.to_string());
-                    push_stmt_variant(
-                        &mut out,
-                        &mut seen,
-                        format!(
-                            "if ({ANYTHING_HOLE_KEYWORD}) {{\n{}\n}}",
-                            indent_lines(&body.source, "  ")
-                        ),
-                        holes,
-                        body.cost + 2,
-                    );
-                }
-            }
-        }
-        Stmt::Try(try_stmt) => {
-            for body in render_stmt_list_selector_candidates(index, &try_stmt.block.stmts)?
-                .into_iter()
-                .take(MAX_STMT_SELECTOR_VARIANTS)
-            {
-                let mut holes = body.holes;
-                let catch_source = render_catch_clause_skeleton(&try_stmt.handler);
-                holes.insert(STMT_LIST_HOLE_KEYWORD.to_string());
-                if catch_source.contains(ANYTHING_HOLE_KEYWORD) {
-                    holes.insert(ANYTHING_HOLE_KEYWORD.to_string());
-                }
-                let finalizer_source = try_stmt
-                    .finalizer
-                    .as_ref()
-                    .map(|_| format!(" finally {{\n  {STMT_LIST_HOLE_KEYWORD};\n}}"))
-                    .unwrap_or_default();
-                push_stmt_variant(
-                    &mut out,
-                    &mut seen,
-                    format!(
-                        "try {{\n{}\n}}{catch_source}{finalizer_source}",
-                        indent_lines(&body.source, "  ")
-                    ),
-                    holes,
-                    body.cost + 2,
-                );
-            }
-        }
-        Stmt::Block(block) => {
-            for body in render_stmt_list_selector_candidates(index, &block.stmts)?
-                .into_iter()
-                .take(MAX_STMT_SELECTOR_VARIANTS)
-            {
-                push_stmt_variant(
-                    &mut out,
-                    &mut seen,
-                    format!("{{\n{}\n}}", indent_lines(&body.source, "  ")),
-                    body.holes,
-                    body.cost + 1,
-                );
-            }
-        }
-        _ => {}
-    }
-
-    let exact = source_for_span(index, stmt.span())?.text;
-    push_stmt_variant(
-        &mut out,
-        &mut seen,
-        ensure_statement_semicolon(stmt, exact),
-        BTreeSet::new(),
-        1000,
-    );
-    out.sort_by_key(|variant| (variant.cost, variant.source.len()));
-    out.truncate(MAX_STMT_SELECTOR_VARIANTS);
-    Ok(out)
-}
-
-fn render_stmt_as_block_selector(
-    index: &ChunkSelectorIndex,
-    stmt: &Stmt,
-) -> Result<(String, BTreeSet<String>, usize)> {
-    if let Stmt::Block(block) = stmt {
-        let body = render_stmt_list_selector_candidates(index, &block.stmts)?
-            .into_iter()
-            .next()
-            .unwrap_or(RenderedStmtListSelector {
-                source: format!("{STMT_LIST_HOLE_KEYWORD};"),
-                holes: BTreeSet::from([STMT_LIST_HOLE_KEYWORD.to_string()]),
-                cost: 0,
-            });
-        return Ok((body.source, body.holes, body.cost));
-    }
-    let stmt = render_stmt_selector_variants(index, stmt)?
-        .into_iter()
-        .next()
-        .context("statement had no renderable selector variants")?;
-    Ok((stmt.source, stmt.holes, stmt.cost))
-}
-
-fn render_catch_clause_skeleton(handler: &Option<CatchClause>) -> String {
-    let Some(handler) = handler else {
-        return String::new();
-    };
-    let param = if handler.param.is_some() {
-        format!(" ({ANYTHING_HOLE_KEYWORD})")
-    } else {
-        String::new()
-    };
-    format!(" catch{param} {{\n  {STMT_LIST_HOLE_KEYWORD};\n}}")
-}
-
-fn push_stmt_variant(
-    out: &mut Vec<RenderedStmtSelector>,
-    seen: &mut BTreeSet<String>,
-    source: String,
-    holes: BTreeSet<String>,
-    cost: usize,
-) {
-    if seen.insert(source.clone()) {
-        out.push(RenderedStmtSelector {
-            source,
-            holes,
-            cost,
-        });
-    }
-}
-
-fn render_expr_selector_variants(
-    index: &ChunkSelectorIndex,
-    expr: &Expr,
-) -> Result<Vec<RenderedExprSelector>> {
-    let mut out = Vec::new();
-    let mut seen = BTreeSet::new();
-    push_expr_variant(&mut out, &mut seen, anything_expr_selector());
-    match expr {
-        Expr::Lit(_) => {
-            push_expr_variant(
-                &mut out,
-                &mut seen,
-                RenderedExprSelector {
-                    source: source_for_span(index, expr.span())?.text,
-                    holes: BTreeSet::new(),
-                    cost: 1,
-                },
-            );
-        }
-        Expr::Member(member) => {
-            for variant in render_member_expr_selector_variants(index, member)? {
-                push_expr_variant(&mut out, &mut seen, variant);
-            }
-        }
-        Expr::Call(call) => {
-            for variant in render_call_expr_selector_variants(index, call)? {
-                push_expr_variant(&mut out, &mut seen, variant);
-            }
-        }
-        Expr::New(new_expr) => {
-            let callee = source_for_span(index, new_expr.callee.span())?.text;
-            let args = new_expr.args.as_deref().unwrap_or_default();
-            push_expr_variant(
-                &mut out,
-                &mut seen,
-                RenderedExprSelector {
-                    source: format!(
-                        "new {callee}({})",
-                        vec![ANYTHING_HOLE_KEYWORD; args.len()].join(", ")
-                    ),
-                    holes: BTreeSet::from([ANYTHING_HOLE_KEYWORD.to_string()]),
-                    cost: 2,
-                },
-            );
-        }
-        Expr::Object(object) => {
-            for variant in render_object_expr_selector_variants(index, object)? {
-                push_expr_variant(&mut out, &mut seen, variant);
-            }
-        }
-        Expr::Await(await_expr) => {
-            for arg in render_expr_selector_variants(index, &await_expr.arg)?
-                .into_iter()
-                .take(MAX_EXPR_SELECTOR_VARIANTS)
-            {
-                push_expr_variant(
-                    &mut out,
-                    &mut seen,
-                    RenderedExprSelector {
-                        source: format!("await {}", arg.source),
-                        holes: arg.holes,
-                        cost: arg.cost + 1,
-                    },
-                );
-            }
-        }
-        Expr::Unary(unary) => {
-            for arg in render_expr_selector_variants(index, &unary.arg)?
-                .into_iter()
-                .take(MAX_EXPR_SELECTOR_VARIANTS)
-            {
-                push_expr_variant(
-                    &mut out,
-                    &mut seen,
-                    RenderedExprSelector {
-                        source: format!("{}{}", unary.op.as_str(), arg.source),
-                        holes: arg.holes,
-                        cost: arg.cost + 1,
-                    },
-                );
-            }
-        }
-        Expr::Bin(bin) => {
-            for left in render_expr_selector_variants(index, &bin.left)?
-                .into_iter()
-                .filter(|variant| variant.source != ANYTHING_HOLE_KEYWORD)
-                .take(4)
-            {
-                let mut holes = left.holes;
-                holes.insert(ANYTHING_HOLE_KEYWORD.to_string());
-                push_expr_variant(
-                    &mut out,
-                    &mut seen,
-                    RenderedExprSelector {
-                        source: format!(
-                            "{} {} {ANYTHING_HOLE_KEYWORD}",
-                            left.source,
-                            bin.op.as_str()
-                        ),
-                        holes,
-                        cost: left.cost + 2,
-                    },
-                );
-            }
-            for right in render_expr_selector_variants(index, &bin.right)?
-                .into_iter()
-                .filter(|variant| variant.source != ANYTHING_HOLE_KEYWORD)
-                .take(4)
-            {
-                let mut holes = right.holes;
-                holes.insert(ANYTHING_HOLE_KEYWORD.to_string());
-                push_expr_variant(
-                    &mut out,
-                    &mut seen,
-                    RenderedExprSelector {
-                        source: format!(
-                            "{ANYTHING_HOLE_KEYWORD} {} {}",
-                            bin.op.as_str(),
-                            right.source
-                        ),
-                        holes,
-                        cost: right.cost + 2,
-                    },
-                );
-            }
-        }
-        _ => {}
-    }
-    push_expr_variant(
-        &mut out,
-        &mut seen,
-        RenderedExprSelector {
-            source: source_for_span(index, expr.span())?.text,
-            holes: BTreeSet::new(),
-            cost: 1000,
-        },
-    );
-    out.sort_by_key(|variant| (variant.cost, variant.source.len()));
-    out.truncate(MAX_EXPR_SELECTOR_VARIANTS);
-    Ok(out)
-}
-
-fn render_member_expr_selector_variants(
-    index: &ChunkSelectorIndex,
-    member: &MemberExpr,
-) -> Result<Vec<RenderedExprSelector>> {
-    let mut out = Vec::new();
-    let mut seen = BTreeSet::new();
-    match &member.prop {
-        MemberProp::Ident(prop) => {
-            push_expr_variant(
-                &mut out,
-                &mut seen,
-                RenderedExprSelector {
-                    source: format!("{ANYTHING_HOLE_KEYWORD}.{}", prop.sym),
-                    holes: BTreeSet::from([ANYTHING_HOLE_KEYWORD.to_string()]),
-                    cost: 1,
-                },
-            );
-        }
-        MemberProp::PrivateName(prop) => {
-            push_expr_variant(
-                &mut out,
-                &mut seen,
-                RenderedExprSelector {
-                    source: format!("{ANYTHING_HOLE_KEYWORD}.#{}", prop.name),
-                    holes: BTreeSet::from([ANYTHING_HOLE_KEYWORD.to_string()]),
-                    cost: 2,
-                },
-            );
-        }
-        MemberProp::Computed(computed) => {
-            for expr in render_expr_selector_variants(index, &computed.expr)?
-                .into_iter()
-                .take(4)
-            {
-                let mut holes = expr.holes;
-                holes.insert(ANYTHING_HOLE_KEYWORD.to_string());
-                push_expr_variant(
-                    &mut out,
-                    &mut seen,
-                    RenderedExprSelector {
-                        source: format!("{ANYTHING_HOLE_KEYWORD}[{}]", expr.source),
-                        holes,
-                        cost: expr.cost + 2,
-                    },
-                );
-            }
-        }
-    }
-    push_expr_variant(
-        &mut out,
-        &mut seen,
-        RenderedExprSelector {
-            source: source_for_span(index, member.span())?.text,
-            holes: BTreeSet::new(),
-            cost: 100,
-        },
-    );
-    Ok(out)
-}
-
-fn render_call_expr_selector_variants(
-    index: &ChunkSelectorIndex,
-    call: &CallExpr,
-) -> Result<Vec<RenderedExprSelector>> {
-    let mut out = Vec::new();
-    let mut seen = BTreeSet::new();
-    let callee_variants = match &call.callee {
-        Callee::Expr(callee) => render_expr_selector_variants(index, callee)?,
-        _ => vec![RenderedExprSelector {
-            source: source_for_span(index, call.callee.span())?.text,
-            holes: BTreeSet::new(),
-            cost: 4,
-        }],
-    };
-    let arg_variants = call
-        .args
-        .iter()
-        .map(|arg| {
-            if arg.spread.is_some() {
-                Ok(vec![RenderedExprSelector {
-                    source: source_for_span(index, arg.span())?.text,
-                    holes: BTreeSet::new(),
-                    cost: 100,
-                }])
-            } else {
-                render_expr_selector_variants(index, &arg.expr)
-            }
-        })
-        .collect::<Result<Vec<_>>>()?;
-
-    for callee in callee_variants
-        .iter()
-        .filter(|variant| variant.source != ANYTHING_HOLE_KEYWORD)
-        .take(6)
-    {
-        let args = vec![ANYTHING_HOLE_KEYWORD; call.args.len()].join(", ");
-        let mut holes = callee.holes.clone();
-        if !call.args.is_empty() {
-            holes.insert(ANYTHING_HOLE_KEYWORD.to_string());
-        }
-        push_expr_variant(
-            &mut out,
-            &mut seen,
-            RenderedExprSelector {
-                source: format!("{}({args})", callee.source),
-                holes,
-                cost: callee.cost + 1,
-            },
-        );
-
-        for (arg_idx, variants) in arg_variants.iter().enumerate() {
-            for arg in variants
-                .iter()
-                .filter(|variant| variant.source != ANYTHING_HOLE_KEYWORD)
-                .take(4)
-            {
-                let mut args = vec![ANYTHING_HOLE_KEYWORD.to_string(); call.args.len()];
-                args[arg_idx] = arg.source.clone();
-                let mut holes = callee.holes.clone();
-                holes.extend(arg.holes.clone());
-                if call.args.len() > 1 {
-                    holes.insert(ANYTHING_HOLE_KEYWORD.to_string());
-                }
-                push_expr_variant(
-                    &mut out,
-                    &mut seen,
-                    RenderedExprSelector {
-                        source: format!("{}({})", callee.source, args.join(", ")),
-                        holes,
-                        cost: callee.cost + arg.cost + 2,
-                    },
-                );
-            }
-        }
-    }
-    push_expr_variant(
-        &mut out,
-        &mut seen,
-        RenderedExprSelector {
-            source: source_for_span(index, call.span())?.text,
-            holes: BTreeSet::new(),
-            cost: 1000,
-        },
-    );
-    out.sort_by_key(|variant| (variant.cost, variant.source.len()));
-    out.truncate(MAX_EXPR_SELECTOR_VARIANTS);
-    Ok(out)
-}
-
-fn render_object_expr_selector_variants(
-    index: &ChunkSelectorIndex,
-    object: &ObjectLit,
-) -> Result<Vec<RenderedExprSelector>> {
-    let mut out = Vec::new();
-    let mut seen = BTreeSet::new();
-    for (prop_idx, prop) in object.props.iter().enumerate() {
-        let PropOrSpread::Prop(prop) = prop else {
-            continue;
-        };
-        let Some(key) = prop_key_name(prop.as_ref()) else {
-            continue;
-        };
-        let value_variants = match prop.as_ref() {
-            Prop::KeyValue(key_value) => render_expr_selector_variants(index, &key_value.value)?,
-            Prop::Shorthand(_) | Prop::Assign(_) => vec![anything_expr_selector()],
-            _ => Vec::new(),
-        };
-        for value in value_variants.into_iter().take(4) {
-            let mut parts = Vec::new();
-            let mut holes = value.holes.clone();
-            if prop_idx > 0 {
-                parts.push(OBJECT_PROPS_HOLE_KEYWORD.to_string());
-                holes.insert(OBJECT_PROPS_HOLE_KEYWORD.to_string());
-            }
-            parts.push(format!("{key}: {}", value.source));
-            if prop_idx + 1 < object.props.len() {
-                parts.push(OBJECT_PROPS_HOLE_KEYWORD.to_string());
-                holes.insert(OBJECT_PROPS_HOLE_KEYWORD.to_string());
-            }
-            push_expr_variant(
-                &mut out,
-                &mut seen,
-                RenderedExprSelector {
-                    source: format!("{{ {} }}", parts.join(", ")),
-                    holes,
-                    cost: value.cost + 1,
-                },
-            );
-        }
-    }
-    push_expr_variant(
-        &mut out,
-        &mut seen,
-        RenderedExprSelector {
-            source: source_for_span(index, object.span())?.text,
-            holes: BTreeSet::new(),
-            cost: 1000,
-        },
-    );
-    out.sort_by_key(|variant| (variant.cost, variant.source.len()));
-    out.truncate(MAX_EXPR_SELECTOR_VARIANTS);
-    Ok(out)
-}
-
-fn push_expr_variant(
-    out: &mut Vec<RenderedExprSelector>,
-    seen: &mut BTreeSet<String>,
-    variant: RenderedExprSelector,
-) {
-    if seen.insert(variant.source.clone()) {
-        out.push(variant);
-    }
-}
-
-fn ensure_statement_semicolon(stmt: &Stmt, mut source: String) -> String {
-    if matches!(
-        stmt,
-        Stmt::Expr(_) | Stmt::Return(_) | Stmt::Throw(_) | Stmt::Decl(Decl::Var(_))
-    ) && !source.ends_with(';')
-    {
-        source.push(';');
-    }
-    source
-}
-
-fn indent_lines(source: &str, indent: &str) -> String {
-    source
-        .lines()
-        .map(|line| {
-            if line.is_empty() {
-                String::new()
-            } else {
-                format!("{indent}{line}")
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("\n")
-}
-
-fn call_has_selected_feature(
-    call: &CallExpr,
-    selected_features: &BTreeSet<SelectorAnchorFeature>,
-) -> bool {
-    call_callee_feature_name(&call.callee).is_some_and(|callee| {
-        selected_features.contains(&SelectorAnchorFeature::CallCallee(callee))
-    }) || call.args.iter().any(|arg| {
-        matches!(
-            arg.expr.as_ref(),
-            Expr::Object(object) if object_has_selected_key(object, selected_features)
-        )
-    })
-}
-
-fn object_has_selected_key(
-    object: &ObjectLit,
-    selected_features: &BTreeSet<SelectorAnchorFeature>,
-) -> bool {
-    object.props.iter().any(|prop| {
-        let Some(key) = (match prop {
-            PropOrSpread::Prop(prop) => prop_key_name(prop.as_ref()),
-            PropOrSpread::Spread(_) => None,
-        }) else {
-            return false;
-        };
-        selected_features.contains(&SelectorAnchorFeature::ObjectKey(key))
-    })
-}
-
-fn prop_key_name(prop: &Prop) -> Option<String> {
-    match prop {
-        Prop::KeyValue(key_value) => prop_name_to_string(&key_value.key),
-        Prop::Method(method) => prop_name_to_string(&method.key),
-        Prop::Getter(getter) => prop_name_to_string(&getter.key),
-        Prop::Setter(setter) => prop_name_to_string(&setter.key),
-        Prop::Shorthand(ident) if !is_hole_name(ident.sym.as_ref()) => Some(ident.sym.to_string()),
-        Prop::Assign(assign) if !is_hole_name(assign.key.sym.as_ref()) => {
-            Some(assign.key.sym.to_string())
-        }
-        _ => None,
-    }
-}
-
-fn prop_name_to_string(name: &PropName) -> Option<String> {
-    match name {
-        PropName::Ident(ident) if !is_hole_name(ident.sym.as_ref()) => Some(ident.sym.to_string()),
-        PropName::Str(value) => Some(value.value.to_string_lossy().to_string()),
-        PropName::Num(value) => Some(value.value.to_string()),
-        _ => None,
-    }
-}
-
-fn class_member_feature_name(member: &ClassMember) -> Option<String> {
-    match member {
-        ClassMember::Constructor(_) => Some("constructor".to_string()),
-        ClassMember::Method(method) => prop_name_to_string(&method.key),
-        ClassMember::PrivateMethod(method) => Some(method.key.name.to_string()),
-        ClassMember::ClassProp(prop) => prop_name_to_string(&prop.key),
-        ClassMember::PrivateProp(prop) => Some(prop.key.name.to_string()),
-        ClassMember::AutoAccessor(_) => None,
-        _ => None,
-    }
-}
-
-fn render_class_member_skeletons(
-    class: &Class,
-    selected: &BTreeSet<String>,
-    index: &ChunkSelectorIndex,
-) -> Result<String> {
-    let mut lines = vec!["  CLASS_REST;".to_string()];
-    for member in &class.body {
-        let Some(name) = class_member_feature_name(member) else {
-            continue;
-        };
-        if !selected.contains(&name) {
-            continue;
-        }
-        lines.push(render_class_member_skeleton(member, &name, index)?);
-        lines.push("  CLASS_REST;".to_string());
-    }
-    Ok(lines.join("\n") + "\n")
-}
-
-fn render_class_member_skeleton(
-    member: &ClassMember,
-    name: &str,
-    index: &ChunkSelectorIndex,
-) -> Result<String> {
-    match member {
-        ClassMember::Constructor(constructor) => {
-            let params = constructor
-                .params
-                .iter()
-                .map(|_| ANYTHING_HOLE_KEYWORD)
-                .collect::<Vec<_>>()
-                .join(", ");
-            Ok(format!("  constructor({params}) {{\n    STMT_LIST;\n  }}"))
-        }
-        ClassMember::Method(method) => {
-            let params = method
-                .function
-                .params
-                .iter()
-                .map(|_| ANYTHING_HOLE_KEYWORD)
-                .collect::<Vec<_>>()
-                .join(", ");
-            Ok(format!("  {name}({params}) {{\n    STMT_LIST;\n  }}"))
-        }
-        ClassMember::ClassProp(prop) => {
-            let key = prop_name_to_string(&prop.key).unwrap_or_else(|| name.to_string());
-            Ok(format!("  {key} = {ANYTHING_HOLE_KEYWORD};"))
-        }
-        _ => Ok(format!("  {}", source_for_span(index, member.span())?.text)),
-    }
-}
-
-fn call_callee_feature_name(callee: &Callee) -> Option<String> {
-    match callee {
-        Callee::Expr(expr) => expr_feature_name(expr),
-        Callee::Super(_) => Some("super".to_string()),
-        Callee::Import(_) => Some("import".to_string()),
-    }
-}
-
-fn expr_feature_name(expr: &Expr) -> Option<String> {
-    match expr {
-        Expr::Ident(ident) if !is_hole_name(ident.sym.as_ref()) => Some(ident.sym.to_string()),
-        Expr::Member(member) => {
-            let obj = match member.obj.as_ref() {
-                Expr::Ident(ident) if !is_hole_name(ident.sym.as_ref()) => {
-                    Some(ident.sym.to_string())
-                }
-                Expr::Member(_) => expr_feature_name(member.obj.as_ref()),
-                _ => None,
-            }?;
-            let prop = match &member.prop {
-                MemberProp::Ident(ident) if !is_hole_name(ident.sym.as_ref()) => {
-                    Some(ident.sym.to_string())
-                }
-                MemberProp::PrivateName(name) => Some(name.name.to_string()),
-                MemberProp::Computed(_) => None,
-                _ => None,
-            }?;
-            Some(format!("{obj}.{prop}"))
-        }
-        _ => None,
-    }
-}
-
-fn is_hole_expr(expr: &Expr) -> bool {
-    matches!(expr, Expr::Ident(ident) if is_hole_name(ident.sym.as_ref()))
-}
-
-fn is_hole_name(name: &str) -> bool {
-    // `STMT` subsumes `STMT_LIST` here: a `<keyword>_<suffix>` match on `STMT`
-    // already covers the list spelling for this membership test.
-    [
-        ANYTHING_HOLE_KEYWORD,
-        EXPR_HOLE_KEYWORD,
-        STMT_HOLE_KEYWORD,
-        STMT_LIST_HOLE_KEYWORD,
-        CLASS_REST_HOLE_KEYWORD,
-        DECLARATORS_HOLE_KEYWORD,
-        ARGS_HOLE_KEYWORD,
-        OBJECT_PROPS_HOLE_KEYWORD,
-    ]
-    .iter()
-    .any(|keyword| hole_name_for(name, keyword).is_some())
 }
 
 fn render_var_group_selector(

--- a/devinfra/js/debundle/selector_codemod.rs
+++ b/devinfra/js/debundle/selector_codemod.rs
@@ -4801,3 +4801,6 @@ pub fn render_selector_codemod_text(report: &SelectorCodemodReport, out: &mut St
 fn is_zero(value: &usize) -> bool {
     *value == 0
 }
+
+#[cfg(test)]
+mod selector_minimizer_proptest;

--- a/devinfra/js/debundle/selector_codemod.rs
+++ b/devinfra/js/debundle/selector_codemod.rs
@@ -1415,6 +1415,8 @@ fn synthesize_specialized_var_selector(
         if let Some(minimized) = minimize_var_selector(index, var, decl, target)? {
             return Ok(Some(minimized));
         }
+    } else if let Some(minimized) = minimize_var_group_selector(index, var, decl, targets)? {
+        return Ok(Some(minimized));
     }
     let target_slots = targets
         .iter()
@@ -2472,8 +2474,8 @@ fn hole_stmt(stmt: &Stmt, kept: &BTreeSet<AnchorSpan>) -> Stmt {
 /// than a literal buried inside `mk("primary")`.
 #[derive(Default)]
 struct AnchorCandidates {
-    /// `(span, call-nesting depth)` for each literal anchor.
-    literals: Vec<(AnchorSpan, u32)>,
+    /// `(span, call-nesting depth, is-object-property-value)` for each literal.
+    literals: Vec<(AnchorSpan, u32, bool)>,
     structural: Vec<AnchorSpan>,
 }
 
@@ -2496,12 +2498,12 @@ impl AnchorCandidates {
         let literal_tier = |depth: u32| -> Vec<AnchorSpan> {
             self.literals
                 .iter()
-                .filter(|(_, anchor_depth)| *anchor_depth == depth)
-                .map(|(span, _)| *span)
+                .filter(|(_, anchor_depth, _)| *anchor_depth == depth)
+                .map(|(span, _, _)| *span)
                 .collect()
         };
         let mut tiers = Vec::new();
-        let Some(max_depth) = self.literals.iter().map(|(_, depth)| *depth).max() else {
+        let Some(max_depth) = self.literals.iter().map(|(_, depth, _)| *depth).max() else {
             if !self.structural.is_empty() {
                 tiers.push(self.structural.clone());
             }
@@ -2520,6 +2522,39 @@ impl AnchorCandidates {
             let tier = literal_tier(depth);
             if !tier.is_empty() {
                 tiers.push(tier);
+            }
+        }
+        tiers
+    }
+
+    /// Shallow literal anchors — direct values/args worth keeping as meaningful
+    /// per-slot pins even when structure alone would already discriminate.
+    fn shallow_literals(&self) -> Vec<AnchorSpan> {
+        self.literals
+            .iter()
+            .filter(|(_, depth, in_object)| *depth <= SHALLOW_LITERAL_DEPTH && !in_object)
+            .map(|(span, _, _)| *span)
+            .collect()
+    }
+
+    /// Tiers consulted only when shallow literals are not enough on their own:
+    /// structural key/member presence, then deeper literals by ascending depth.
+    fn deep_cover_tiers(&self) -> Vec<Vec<AnchorSpan>> {
+        let mut tiers = Vec::new();
+        if !self.structural.is_empty() {
+            tiers.push(self.structural.clone());
+        }
+        if let Some(max_depth) = self.literals.iter().map(|(_, depth, _)| *depth).max() {
+            for depth in (SHALLOW_LITERAL_DEPTH + 1)..=max_depth {
+                let tier: Vec<AnchorSpan> = self
+                    .literals
+                    .iter()
+                    .filter(|(_, anchor_depth, _)| *anchor_depth == depth)
+                    .map(|(span, _, _)| *span)
+                    .collect();
+                if !tier.is_empty() {
+                    tiers.push(tier);
+                }
             }
         }
         tiers
@@ -2582,32 +2617,49 @@ fn collect_block_anchors(stmt: &Stmt, candidates: &mut AnchorCandidates) {
 /// `depth` counts enclosing call/new levels, so the tiered cover can prefer
 /// shallower literal anchors.
 fn collect_expr_anchors(expr: &Expr, depth: u32, candidates: &mut AnchorCandidates) {
+    collect_expr_anchors_in(expr, depth, false, candidates);
+}
+
+/// `in_object` marks literals that are object-property values (e.g. the `true`
+/// in `mk({ enabled: true })`) rather than direct declarator/call-argument
+/// values. Group keep-shallow skips object-value literals as likely-incidental
+/// config; single-target tiers ignore the flag.
+fn collect_expr_anchors_in(
+    expr: &Expr,
+    depth: u32,
+    in_object: bool,
+    candidates: &mut AnchorCandidates,
+) {
     match expr {
-        Expr::Lit(_) | Expr::Tpl(_) => candidates.literals.push((span_key(expr.span()), depth)),
-        Expr::Paren(paren) => collect_expr_anchors(&paren.expr, depth, candidates),
+        Expr::Lit(_) | Expr::Tpl(_) => {
+            candidates
+                .literals
+                .push((span_key(expr.span()), depth, in_object));
+        }
+        Expr::Paren(paren) => collect_expr_anchors_in(&paren.expr, depth, in_object, candidates),
         Expr::Member(member) => {
-            collect_expr_anchors(&member.obj, depth, candidates);
+            collect_expr_anchors_in(&member.obj, depth, in_object, candidates);
             if let MemberProp::Ident(ident) = &member.prop {
                 candidates.structural.push(span_key(ident.span));
             } else if let MemberProp::Computed(computed) = &member.prop {
-                collect_expr_anchors(&computed.expr, depth, candidates);
+                collect_expr_anchors_in(&computed.expr, depth, in_object, candidates);
             }
         }
         Expr::Call(call) => {
             if let Callee::Expr(callee) = &call.callee {
-                collect_expr_anchors(callee, depth, candidates);
+                collect_expr_anchors_in(callee, depth, in_object, candidates);
             }
             for arg in &call.args {
                 if arg.spread.is_none() {
-                    collect_expr_anchors(&arg.expr, depth + 1, candidates);
+                    collect_expr_anchors_in(&arg.expr, depth + 1, in_object, candidates);
                 }
             }
         }
         Expr::New(new_expr) => {
-            collect_expr_anchors(&new_expr.callee, depth, candidates);
+            collect_expr_anchors_in(&new_expr.callee, depth, in_object, candidates);
             for arg in new_expr.args.as_deref().unwrap_or_default() {
                 if arg.spread.is_none() {
-                    collect_expr_anchors(&arg.expr, depth + 1, candidates);
+                    collect_expr_anchors_in(&arg.expr, depth + 1, in_object, candidates);
                 }
             }
         }
@@ -2616,16 +2668,18 @@ fn collect_expr_anchors(expr: &Expr, depth: u32, candidates: &mut AnchorCandidat
                 if let PropOrSpread::Prop(prop) = prop {
                     if let Prop::KeyValue(key_value) = prop.as_ref() {
                         candidates.structural.push(span_key(key_value.key.span()));
-                        collect_expr_anchors(&key_value.value, depth, candidates);
+                        collect_expr_anchors_in(&key_value.value, depth, true, candidates);
                     }
                 }
             }
         }
-        Expr::Await(await_expr) => collect_expr_anchors(&await_expr.arg, depth, candidates),
-        Expr::Unary(unary) => collect_expr_anchors(&unary.arg, depth, candidates),
+        Expr::Await(await_expr) => {
+            collect_expr_anchors_in(&await_expr.arg, depth, in_object, candidates)
+        }
+        Expr::Unary(unary) => collect_expr_anchors_in(&unary.arg, depth, in_object, candidates),
         Expr::Bin(bin) => {
-            collect_expr_anchors(&bin.left, depth, candidates);
-            collect_expr_anchors(&bin.right, depth, candidates);
+            collect_expr_anchors_in(&bin.left, depth, in_object, candidates);
+            collect_expr_anchors_in(&bin.right, depth, in_object, candidates);
         }
         _ => {}
     }
@@ -2756,6 +2810,126 @@ fn minimize_var_selector(
     let mut candidates = AnchorCandidates::default();
     collect_expr_anchors(init, 0, &mut candidates);
     minimize_via_retention(index, decl, target, &candidates, &render_with)
+}
+
+/// A `DECLARATORS_<pos> = null` declarator hole absorbing a run of non-target
+/// declarators in a binding-group selector.
+fn declarator_hole(name: &str) -> VarDeclarator {
+    VarDeclarator {
+        span: DUMMY_SP,
+        name: named_pat(name),
+        init: Some(Box::new(Expr::Lit(Lit::Null(Null { span: DUMMY_SP })))),
+        definite: false,
+    }
+}
+
+/// Minimal anchor cover for a multi-target binding group: render the shared
+/// declaration keeping the target declarators (each `export = <holed init>`)
+/// with `DECLARATORS_*` holes for non-target runs, and pin just enough anchors
+/// for the group to resolve uniquely to the right declaration and bindings.
+///
+/// Unlike the single-target path, a binding group resolves through
+/// `resolve_member_binding_group_match`, which yields one match or an error
+/// rather than a candidate set — so the cover uses that proof as a boolean
+/// oracle, adding anchors tier by tier (shallow literals first) until the group
+/// resolves correctly.
+fn minimize_var_group_selector(
+    index: &ChunkSelectorIndex,
+    var: &VarDecl,
+    decl: &IndexedDeclaration,
+    targets: &[SynthesizedTargetBinding],
+) -> Result<Option<SpecializedSelector>> {
+    let export_for = |runtime: &str| {
+        targets
+            .iter()
+            .find(|target| target.runtime_binding == runtime)
+            .map(|target| target.export_name.as_str())
+    };
+    let target_slots: BTreeSet<usize> = var
+        .decls
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, declarator)| {
+            let name = single_ident_pat_name(&declarator.name)?;
+            export_for(name).map(|_| idx)
+        })
+        .collect();
+    if target_slots.len() != targets.len() {
+        return Ok(None);
+    }
+
+    let render_with = |kept: &BTreeSet<AnchorSpan>| -> Result<String> {
+        let mut decls: Vec<VarDeclarator> = Vec::new();
+        let mut skipped_run = false;
+        let mut target_seen = 0usize;
+        for (idx, declarator) in var.decls.iter().enumerate() {
+            if !target_slots.contains(&idx) {
+                skipped_run = true;
+                continue;
+            }
+            if skipped_run {
+                decls.push(declarator_hole(declarator_hole_name(
+                    target_seen,
+                    targets.len(),
+                )));
+                skipped_run = false;
+            }
+            let name = single_ident_pat_name(&declarator.name)
+                .expect("target declarator is a plain identifier");
+            let mut holed = declarator.clone();
+            holed.name = named_pat(export_for(name).expect("target declarator has an export"));
+            holed.init = declarator
+                .init
+                .as_ref()
+                .map(|init| Box::new(hole_expr(init, kept)));
+            decls.push(holed);
+            target_seen += 1;
+        }
+        if skipped_run {
+            decls.push(declarator_hole(declarator_hole_name(
+                target_seen,
+                targets.len(),
+            )));
+        }
+        let mut holed_var = var.clone();
+        holed_var.declare = false;
+        holed_var.decls = decls;
+        emit_selector(ModuleItem::Stmt(Stmt::Decl(Decl::Var(Box::new(holed_var)))))
+    };
+
+    let mut candidates = AnchorCandidates::default();
+    for (idx, declarator) in var.decls.iter().enumerate() {
+        if target_slots.contains(&idx) {
+            if let Some(init) = &declarator.init {
+                collect_expr_anchors(init, 0, &mut candidates);
+            }
+        }
+    }
+
+    let resolves = |kept: &BTreeSet<AnchorSpan>| -> Result<bool> {
+        Ok(prove_synthesized_selector(index, decl, targets, &render_with(kept)?).is_ok())
+    };
+    // Always keep each slot's shallow literals (a group's declarators are its
+    // meaningful targets), then escalate to structural/deeper anchors only if
+    // the group does not yet resolve uniquely to the right bindings.
+    let mut kept: BTreeSet<AnchorSpan> = candidates.shallow_literals().into_iter().collect();
+    if !resolves(&kept)? {
+        for tier in candidates.deep_cover_tiers() {
+            kept.extend(tier);
+            if resolves(&kept)? {
+                break;
+            }
+        }
+        if !resolves(&kept)? {
+            return Ok(None);
+        }
+    }
+    let source = render_with(&kept)?;
+    let rewritten_holes = holes_present(&source);
+    Ok(Some(SpecializedSelector {
+        match_source: source,
+        rewritten_holes,
+    }))
 }
 
 /// Minimal anchor cover for a single-target class: render the class keeping

--- a/devinfra/js/debundle/selector_codemod.rs
+++ b/devinfra/js/debundle/selector_codemod.rs
@@ -19,7 +19,7 @@ use serde::Serialize;
 use serde_yaml::Value;
 use spec::{SourceMatch, SourceMatchIdentifierMode};
 use spec_modules::{collect_module_files, is_module_yaml, module_path_from_file};
-use swc_common::{BytePos, Span, Spanned};
+use swc_common::{BytePos, DUMMY_SP, Span, Spanned, SyntaxContext};
 use swc_ecma_ast::*;
 use swc_ecma_visit::{Visit, VisitWith};
 
@@ -1357,6 +1357,9 @@ fn synthesize_specialized_class_selector(
     let Some(Decl::Class(class_decl)) = item_decl(item) else {
         return Ok(None);
     };
+    if let Some(minimized) = minimize_class_selector(index, &class_decl.class, decl, target)? {
+        return Ok(Some(minimized));
+    }
     let mut features = BTreeSet::from([SelectorAnchorFeature::DeclarationKind(
         IndexedDeclarationKind::Class,
     )]);
@@ -1408,6 +1411,11 @@ fn synthesize_specialized_var_selector(
     targets: &[SynthesizedTargetBinding],
 ) -> Result<Option<SpecializedSelector>> {
     let var = item_var_decl(item).context("indexed var declaration no longer has var AST")?;
+    if let [target] = targets {
+        if let Some(minimized) = minimize_var_selector(index, var, decl, target)? {
+            return Ok(Some(minimized));
+        }
+    }
     let target_slots = targets
         .iter()
         .map(|target| {
@@ -2218,287 +2226,303 @@ fn node_retains_any(node: Span, kept: &BTreeSet<AnchorSpan>) -> bool {
     kept.iter().any(|anchor| node_holds_anchor(node, *anchor))
 }
 
-fn anything_expr() -> String {
-    ANYTHING_HOLE_KEYWORD.to_string()
+fn ident_node(name: &str) -> Ident {
+    Ident::new_no_ctxt(name.into(), DUMMY_SP)
 }
 
-/// Render an expression to selector source, keeping only concrete tokens whose
-/// span is in `kept` and holing everything off a kept token's path.
-fn render_retained_expr(
-    index: &ChunkSelectorIndex,
-    expr: &Expr,
-    kept: &BTreeSet<AnchorSpan>,
-) -> Result<String> {
+fn anything_expr() -> Expr {
+    Expr::Ident(ident_node(ANYTHING_HOLE_KEYWORD))
+}
+
+fn stmt_list_stmt() -> Stmt {
+    Stmt::Expr(ExprStmt {
+        span: DUMMY_SP,
+        expr: Box::new(Expr::Ident(ident_node(STMT_LIST_HOLE_KEYWORD))),
+    })
+}
+
+fn object_props_prop() -> PropOrSpread {
+    PropOrSpread::Prop(Box::new(Prop::Shorthand(ident_node(
+        OBJECT_PROPS_HOLE_KEYWORD,
+    ))))
+}
+
+fn anything_pat() -> Pat {
+    Pat::Ident(BindingIdent {
+        id: ident_node(ANYTHING_HOLE_KEYWORD),
+        type_ann: None,
+    })
+}
+
+fn holed_block(block: &BlockStmt, kept: &BTreeSet<AnchorSpan>) -> BlockStmt {
+    let mut holed = block.clone();
+    holed.stmts = hole_stmts(&block.stmts, kept);
+    holed
+}
+
+/// Prune an expression into selector form: keep concrete tokens whose span is in
+/// `kept`, and replace every subtree off a kept token's path with an `ANYTHING`
+/// hole node. The result is an ordinary `swc` AST emitted by codegen, not a
+/// hand-built string.
+fn hole_expr(expr: &Expr, kept: &BTreeSet<AnchorSpan>) -> Expr {
     if !node_retains_any(expr.span(), kept) {
-        return Ok(anything_expr());
+        return anything_expr();
     }
-    Ok(match expr {
-        Expr::Paren(paren) => render_retained_expr(index, &paren.expr, kept)?,
-        Expr::Lit(_) | Expr::Ident(_) | Expr::Tpl(_) => source_for_span(index, expr.span())?.text,
+    match expr {
+        Expr::Paren(paren) => hole_expr(&paren.expr, kept),
+        Expr::Lit(_) | Expr::Ident(_) | Expr::Tpl(_) => expr.clone(),
         Expr::Member(member) => {
-            let obj = render_retained_expr(index, &member.obj, kept)?;
-            format!("{obj}.{}", render_member_prop(index, &member.prop, kept)?)
+            let mut holed = member.clone();
+            holed.obj = Box::new(hole_expr(&member.obj, kept));
+            Expr::Member(holed)
         }
         Expr::Call(call) => {
-            let callee = render_retained_callee(index, &call.callee, kept)?;
-            format!(
-                "{callee}({})",
-                render_retained_args(index, &call.args, kept)?
-            )
+            let mut holed = call.clone();
+            holed.callee = hole_callee(&call.callee, kept);
+            holed.args = hole_args(&call.args, kept);
+            Expr::Call(holed)
         }
         Expr::New(new_expr) => {
-            let callee = render_callee_expr(index, &new_expr.callee, kept)?;
-            let args = new_expr.args.as_deref().unwrap_or_default();
-            format!("new {callee}({})", render_retained_args(index, args, kept)?)
+            let mut holed = new_expr.clone();
+            holed.callee = Box::new(hole_callee_expr(&new_expr.callee, kept));
+            holed.args = new_expr.args.as_ref().map(|args| hole_args(args, kept));
+            Expr::New(holed)
         }
-        Expr::Object(object) => render_retained_object(index, object, kept)?,
+        Expr::Object(object) => Expr::Object(hole_object(object, kept)),
         Expr::Await(await_expr) => {
-            format!(
-                "await {}",
-                render_retained_expr(index, &await_expr.arg, kept)?
-            )
+            let mut holed = await_expr.clone();
+            holed.arg = Box::new(hole_expr(&await_expr.arg, kept));
+            Expr::Await(holed)
         }
-        Expr::Unary(unary) => format!(
-            "{}{}",
-            unary.op.as_str(),
-            render_retained_expr(index, &unary.arg, kept)?
-        ),
-        Expr::Bin(bin) => format!(
-            "{} {} {}",
-            render_retained_expr(index, &bin.left, kept)?,
-            bin.op.as_str(),
-            render_retained_expr(index, &bin.right, kept)?
-        ),
-        // Unmodeled expression shapes that still carry a kept anchor: keep the
-        // original source rather than risk an unsound hole. Over-pinning here is
-        // a future refinement, not a correctness problem.
-        _ => source_for_span(index, expr.span())?.text,
-    })
+        Expr::Unary(unary) => {
+            let mut holed = unary.clone();
+            holed.arg = Box::new(hole_expr(&unary.arg, kept));
+            Expr::Unary(holed)
+        }
+        Expr::Bin(bin) => {
+            let mut holed = bin.clone();
+            holed.left = Box::new(hole_expr(&bin.left, kept));
+            holed.right = Box::new(hole_expr(&bin.right, kept));
+            Expr::Bin(holed)
+        }
+        // Unmodeled shapes carrying a kept anchor: keep verbatim rather than
+        // risk an unsound hole. Over-pinning here is a future refinement.
+        _ => expr.clone(),
+    }
 }
 
-fn render_member_prop(
-    index: &ChunkSelectorIndex,
-    prop: &MemberProp,
-    kept: &BTreeSet<AnchorSpan>,
-) -> Result<String> {
-    Ok(match prop {
-        MemberProp::Ident(ident) => ident.sym.to_string(),
-        MemberProp::PrivateName(private) => format!("#{}", private.name),
-        MemberProp::Computed(computed) => {
-            format!("[{}]", render_retained_expr(index, &computed.expr, kept)?)
-        }
-    })
-}
-
-fn render_retained_callee(
-    index: &ChunkSelectorIndex,
-    callee: &Callee,
-    kept: &BTreeSet<AnchorSpan>,
-) -> Result<String> {
+/// Hole a call's callee while keeping the invoked identity — a method name or a
+/// bare function reference is a meaningful, stable pin; only a member receiver
+/// is holed.
+fn hole_callee(callee: &Callee, kept: &BTreeSet<AnchorSpan>) -> Callee {
     match callee {
-        Callee::Expr(expr) => render_callee_expr(index, expr, kept),
-        Callee::Super(_) | Callee::Import(_) => Ok(source_for_span(index, callee.span())?.text),
+        Callee::Expr(expr) => Callee::Expr(Box::new(hole_callee_expr(expr, kept))),
+        Callee::Super(_) | Callee::Import(_) => callee.clone(),
     }
 }
 
-/// Render the callee of a rendered call. The invoked identity — a method name
-/// or a bare function reference — is a meaningful, stable pin, so it is kept
-/// even when no anchor lies inside it; only a member receiver is holed.
-fn render_callee_expr(
-    index: &ChunkSelectorIndex,
-    expr: &Expr,
-    kept: &BTreeSet<AnchorSpan>,
-) -> Result<String> {
+fn hole_callee_expr(expr: &Expr, kept: &BTreeSet<AnchorSpan>) -> Expr {
     match expr {
-        Expr::Member(member) => Ok(format!(
-            "{}.{}",
-            render_retained_expr(index, &member.obj, kept)?,
-            render_member_prop(index, &member.prop, kept)?
-        )),
-        Expr::Ident(_) => Ok(source_for_span(index, expr.span())?.text),
-        Expr::Paren(paren) => render_callee_expr(index, &paren.expr, kept),
-        _ => render_retained_expr(index, expr, kept),
+        Expr::Member(member) => {
+            let mut holed = member.clone();
+            holed.obj = Box::new(hole_expr(&member.obj, kept));
+            Expr::Member(holed)
+        }
+        Expr::Ident(_) => expr.clone(),
+        Expr::Paren(paren) => hole_callee_expr(&paren.expr, kept),
+        _ => hole_expr(expr, kept),
     }
 }
 
-fn render_retained_args(
-    index: &ChunkSelectorIndex,
-    args: &[ExprOrSpread],
-    kept: &BTreeSet<AnchorSpan>,
-) -> Result<String> {
-    let rendered = args
-        .iter()
+fn hole_args(args: &[ExprOrSpread], kept: &BTreeSet<AnchorSpan>) -> Vec<ExprOrSpread> {
+    args.iter()
         .map(|arg| {
-            if arg.spread.is_some() {
-                Ok(source_for_span(index, arg.span())?.text)
-            } else {
-                render_retained_expr(index, &arg.expr, kept)
+            let mut holed = arg.clone();
+            if arg.spread.is_none() {
+                holed.expr = Box::new(hole_expr(&arg.expr, kept));
             }
+            holed
         })
-        .collect::<Result<Vec<_>>>()?;
-    Ok(rendered.join(", "))
+        .collect()
 }
 
-fn render_retained_object(
-    index: &ChunkSelectorIndex,
-    object: &ObjectLit,
-    kept: &BTreeSet<AnchorSpan>,
-) -> Result<String> {
-    let mut parts: Vec<String> = Vec::new();
+fn hole_object(object: &ObjectLit, kept: &BTreeSet<AnchorSpan>) -> ObjectLit {
+    let mut props = Vec::new();
     let mut dropped_run = false;
     for prop in &object.props {
         if node_retains_any(prop.span(), kept) {
             if dropped_run {
-                parts.push(OBJECT_PROPS_HOLE_KEYWORD.to_string());
+                props.push(object_props_prop());
                 dropped_run = false;
             }
-            parts.push(render_retained_prop(index, prop, kept)?);
+            props.push(hole_prop(prop, kept));
         } else {
             dropped_run = true;
         }
     }
     if dropped_run {
-        parts.push(OBJECT_PROPS_HOLE_KEYWORD.to_string());
+        props.push(object_props_prop());
     }
-    if parts.is_empty() {
-        return Ok("{ }".to_string());
-    }
-    Ok(format!("{{ {} }}", parts.join(", ")))
+    let mut holed = object.clone();
+    holed.props = props;
+    holed
 }
 
-fn render_retained_prop(
-    index: &ChunkSelectorIndex,
-    prop: &PropOrSpread,
-    kept: &BTreeSet<AnchorSpan>,
-) -> Result<String> {
-    let PropOrSpread::Prop(prop) = prop else {
-        return Ok(source_for_span(index, prop.span())?.text);
+fn hole_prop(prop: &PropOrSpread, kept: &BTreeSet<AnchorSpan>) -> PropOrSpread {
+    let PropOrSpread::Prop(inner) = prop else {
+        return prop.clone();
     };
-    Ok(match prop.as_ref() {
-        Prop::KeyValue(key_value) => {
-            let key = prop_name_to_string(&key_value.key).unwrap_or_else(|| {
-                source_for_span(index, key_value.key.span())
-                    .map(|s| s.text)
-                    .unwrap_or_default()
-            });
-            format!(
-                "{key}: {}",
-                render_retained_expr(index, &key_value.value, kept)?
-            )
-        }
-        _ => source_for_span(index, prop.span())?.text,
-    })
+    if let Prop::KeyValue(key_value) = inner.as_ref() {
+        let mut holed = key_value.clone();
+        holed.value = Box::new(hole_expr(&key_value.value, kept));
+        PropOrSpread::Prop(Box::new(Prop::KeyValue(holed)))
+    } else {
+        prop.clone()
+    }
 }
 
-/// Render a statement list, collapsing runs of dropped statements into a single
-/// `STMT_LIST;` hole.
-fn render_retained_stmt_list(
-    index: &ChunkSelectorIndex,
-    stmts: &[Stmt],
-    kept: &BTreeSet<AnchorSpan>,
-) -> Result<String> {
-    let mut lines: Vec<String> = Vec::new();
+/// Hole a statement list, collapsing runs of dropped statements into a single
+/// `STMT_LIST;` hole statement.
+fn hole_stmts(stmts: &[Stmt], kept: &BTreeSet<AnchorSpan>) -> Vec<Stmt> {
+    let mut out = Vec::new();
     let mut dropped_run = false;
     for stmt in stmts {
         if node_retains_any(stmt.span(), kept) {
             if dropped_run {
-                lines.push(format!("{STMT_LIST_HOLE_KEYWORD};"));
+                out.push(stmt_list_stmt());
                 dropped_run = false;
             }
-            lines.push(render_retained_stmt(index, stmt, kept)?);
+            out.push(hole_stmt(stmt, kept));
         } else {
             dropped_run = true;
         }
     }
-    if dropped_run || lines.is_empty() {
-        lines.push(format!("{STMT_LIST_HOLE_KEYWORD};"));
+    if dropped_run || out.is_empty() {
+        out.push(stmt_list_stmt());
     }
-    Ok(lines.join("\n"))
+    out
 }
 
-fn render_retained_stmt(
-    index: &ChunkSelectorIndex,
-    stmt: &Stmt,
-    kept: &BTreeSet<AnchorSpan>,
-) -> Result<String> {
-    Ok(match stmt {
+fn hole_stmt(stmt: &Stmt, kept: &BTreeSet<AnchorSpan>) -> Stmt {
+    match stmt {
         Stmt::Expr(expr_stmt) => {
-            format!("{};", render_retained_expr(index, &expr_stmt.expr, kept)?)
+            let mut holed = expr_stmt.clone();
+            holed.expr = Box::new(hole_expr(&expr_stmt.expr, kept));
+            Stmt::Expr(holed)
         }
-        Stmt::Return(ret) => match &ret.arg {
-            Some(arg) => format!("return {};", render_retained_expr(index, arg, kept)?),
-            None => "return;".to_string(),
-        },
-        Stmt::Throw(throw) => format!("throw {};", render_retained_expr(index, &throw.arg, kept)?),
+        Stmt::Return(ret) => {
+            let mut holed = ret.clone();
+            holed.arg = ret.arg.as_ref().map(|arg| Box::new(hole_expr(arg, kept)));
+            Stmt::Return(holed)
+        }
+        Stmt::Throw(throw) => {
+            let mut holed = throw.clone();
+            holed.arg = Box::new(hole_expr(&throw.arg, kept));
+            Stmt::Throw(holed)
+        }
         Stmt::Decl(Decl::Var(var)) => {
-            let decls = var
-                .decls
-                .iter()
-                .map(|declarator| {
-                    let pat = source_for_span(index, declarator.name.span())?.text;
-                    match &declarator.init {
-                        Some(init) => Ok(format!(
-                            "{pat} = {}",
-                            render_retained_expr(index, init, kept)?
-                        )),
-                        None => Ok(pat),
-                    }
-                })
-                .collect::<Result<Vec<_>>>()?;
-            format!("{} {};", var_kind_label(var.kind), decls.join(",\n  "))
+            let mut holed = (**var).clone();
+            for declarator in &mut holed.decls {
+                if let Some(init) = &declarator.init {
+                    declarator.init = Some(Box::new(hole_expr(init, kept)));
+                }
+            }
+            Stmt::Decl(Decl::Var(Box::new(holed)))
         }
         Stmt::If(if_stmt) => {
-            let test = render_retained_expr(index, &if_stmt.test, kept)?;
-            let cons = render_retained_block(index, &if_stmt.cons, kept)?;
-            format!("if ({test}) {{\n{}\n}}", indent_lines(&cons, "  "))
+            let mut holed = if_stmt.clone();
+            holed.test = Box::new(hole_expr(&if_stmt.test, kept));
+            let cons_stmts = match if_stmt.cons.as_ref() {
+                Stmt::Block(block) => hole_stmts(&block.stmts, kept),
+                other => hole_stmts(std::slice::from_ref(other), kept),
+            };
+            holed.cons = Box::new(Stmt::Block(BlockStmt {
+                span: DUMMY_SP,
+                ctxt: SyntaxContext::empty(),
+                stmts: cons_stmts,
+            }));
+            holed.alt = None;
+            Stmt::If(holed)
         }
         Stmt::Try(try_stmt) => {
-            let body = render_retained_stmt_list(index, &try_stmt.block.stmts, kept)?;
-            let catch = render_catch_clause_skeleton(&try_stmt.handler);
-            let finalizer = try_stmt
-                .finalizer
-                .as_ref()
-                .map(|_| format!(" finally {{\n  {STMT_LIST_HOLE_KEYWORD};\n}}"))
-                .unwrap_or_default();
-            format!(
-                "try {{\n{}\n}}{catch}{finalizer}",
-                indent_lines(&body, "  ")
-            )
+            let mut holed = try_stmt.clone();
+            holed.block = holed_block(&try_stmt.block, kept);
+            if let Some(handler) = &mut holed.handler {
+                if handler.param.is_some() {
+                    handler.param = Some(anything_pat());
+                }
+                handler.body = holed_block(&handler.body, kept);
+            }
+            if let Some(finalizer) = &mut holed.finalizer {
+                *finalizer = holed_block(finalizer, kept);
+            }
+            Stmt::Try(holed)
         }
-        Stmt::Block(block) => {
-            let body = render_retained_stmt_list(index, &block.stmts, kept)?;
-            format!("{{\n{}\n}}", indent_lines(&body, "  "))
-        }
+        Stmt::Block(block) => Stmt::Block(holed_block(block, kept)),
         // Unmodeled statement shapes carrying a kept anchor: keep verbatim.
-        _ => ensure_statement_semicolon(stmt, source_for_span(index, stmt.span())?.text),
-    })
-}
-
-fn render_retained_block(
-    index: &ChunkSelectorIndex,
-    stmt: &Stmt,
-    kept: &BTreeSet<AnchorSpan>,
-) -> Result<String> {
-    match stmt {
-        Stmt::Block(block) => render_retained_stmt_list(index, &block.stmts, kept),
-        _ => render_retained_stmt(index, stmt, kept),
+        _ => stmt.clone(),
     }
 }
 
 /// Candidate concrete anchors, split into preference tiers. Literal values are
 /// stable, meaningful landmarks (a magic string, a config number/bool), so they
-/// are tried first; member/property and key names are structural fallbacks used
-/// only when literals cannot discriminate the target on their own.
+/// are tried before structural member/property and key names. Among literals,
+/// shallower ones (fewer enclosing call/new levels) are preferred: a direct
+/// `key: "primary"` pins less nested structure — and is more rebuild-robust —
+/// than a literal buried inside `mk("primary")`.
 #[derive(Default)]
 struct AnchorCandidates {
-    literals: Vec<AnchorSpan>,
+    /// `(span, call-nesting depth)` for each literal anchor.
+    literals: Vec<(AnchorSpan, u32)>,
     structural: Vec<AnchorSpan>,
 }
 
+/// A literal at most this many call/new levels deep counts as a *direct* value
+/// or argument — a meaningful, stable pin worth keeping. Deeper literals are
+/// treated as buried in incidental computation and ranked below structural
+/// key/member presence.
+const SHALLOW_LITERAL_DEPTH: u32 = 1;
+
 impl AnchorCandidates {
-    /// Anchor tiers, most-preferred first.
-    fn tiers(&self) -> [&[AnchorSpan]; 2] {
-        [&self.literals, &self.structural]
+    /// Anchor tiers, most-preferred first:
+    /// 1. shallow literals (direct values/args), by ascending call depth;
+    /// 2. structural key/member presence;
+    /// 3. deeper literals (buried in nested calls).
+    ///
+    /// Structural presence sits above deep literals because pinning a key's
+    /// existence is leaner and more rebuild-robust than pinning a volatile
+    /// computed value (`stableKey: ANYTHING` over `stableKey: mk("x")`).
+    fn tiers(&self) -> Vec<Vec<AnchorSpan>> {
+        let literal_tier = |depth: u32| -> Vec<AnchorSpan> {
+            self.literals
+                .iter()
+                .filter(|(_, anchor_depth)| *anchor_depth == depth)
+                .map(|(span, _)| *span)
+                .collect()
+        };
+        let mut tiers = Vec::new();
+        let Some(max_depth) = self.literals.iter().map(|(_, depth)| *depth).max() else {
+            if !self.structural.is_empty() {
+                tiers.push(self.structural.clone());
+            }
+            return tiers;
+        };
+        for depth in 0..=max_depth.min(SHALLOW_LITERAL_DEPTH) {
+            let tier = literal_tier(depth);
+            if !tier.is_empty() {
+                tiers.push(tier);
+            }
+        }
+        if !self.structural.is_empty() {
+            tiers.push(self.structural.clone());
+        }
+        for depth in (SHALLOW_LITERAL_DEPTH + 1)..=max_depth {
+            let tier = literal_tier(depth);
+            if !tier.is_empty() {
+                tiers.push(tier);
+            }
+        }
+        tiers
     }
 }
 
@@ -2512,22 +2536,22 @@ fn collect_stmt_list_anchors(stmts: &[Stmt]) -> AnchorCandidates {
 
 fn collect_stmt_anchors(stmt: &Stmt, candidates: &mut AnchorCandidates) {
     match stmt {
-        Stmt::Expr(expr_stmt) => collect_expr_anchors(&expr_stmt.expr, candidates),
+        Stmt::Expr(expr_stmt) => collect_expr_anchors(&expr_stmt.expr, 0, candidates),
         Stmt::Return(ret) => {
             if let Some(arg) = &ret.arg {
-                collect_expr_anchors(arg, candidates);
+                collect_expr_anchors(arg, 0, candidates);
             }
         }
-        Stmt::Throw(throw) => collect_expr_anchors(&throw.arg, candidates),
+        Stmt::Throw(throw) => collect_expr_anchors(&throw.arg, 0, candidates),
         Stmt::Decl(Decl::Var(var)) => {
             for declarator in &var.decls {
                 if let Some(init) = &declarator.init {
-                    collect_expr_anchors(init, candidates);
+                    collect_expr_anchors(init, 0, candidates);
                 }
             }
         }
         Stmt::If(if_stmt) => {
-            collect_expr_anchors(&if_stmt.test, candidates);
+            collect_expr_anchors(&if_stmt.test, 0, candidates);
             collect_block_anchors(&if_stmt.cons, candidates);
         }
         Stmt::Try(try_stmt) => {
@@ -2555,33 +2579,35 @@ fn collect_block_anchors(stmt: &Stmt, candidates: &mut AnchorCandidates) {
     }
 }
 
-fn collect_expr_anchors(expr: &Expr, candidates: &mut AnchorCandidates) {
+/// `depth` counts enclosing call/new levels, so the tiered cover can prefer
+/// shallower literal anchors.
+fn collect_expr_anchors(expr: &Expr, depth: u32, candidates: &mut AnchorCandidates) {
     match expr {
-        Expr::Lit(_) | Expr::Tpl(_) => candidates.literals.push(span_key(expr.span())),
-        Expr::Paren(paren) => collect_expr_anchors(&paren.expr, candidates),
+        Expr::Lit(_) | Expr::Tpl(_) => candidates.literals.push((span_key(expr.span()), depth)),
+        Expr::Paren(paren) => collect_expr_anchors(&paren.expr, depth, candidates),
         Expr::Member(member) => {
-            collect_expr_anchors(&member.obj, candidates);
+            collect_expr_anchors(&member.obj, depth, candidates);
             if let MemberProp::Ident(ident) = &member.prop {
                 candidates.structural.push(span_key(ident.span));
             } else if let MemberProp::Computed(computed) = &member.prop {
-                collect_expr_anchors(&computed.expr, candidates);
+                collect_expr_anchors(&computed.expr, depth, candidates);
             }
         }
         Expr::Call(call) => {
             if let Callee::Expr(callee) = &call.callee {
-                collect_expr_anchors(callee, candidates);
+                collect_expr_anchors(callee, depth, candidates);
             }
             for arg in &call.args {
                 if arg.spread.is_none() {
-                    collect_expr_anchors(&arg.expr, candidates);
+                    collect_expr_anchors(&arg.expr, depth + 1, candidates);
                 }
             }
         }
         Expr::New(new_expr) => {
-            collect_expr_anchors(&new_expr.callee, candidates);
+            collect_expr_anchors(&new_expr.callee, depth, candidates);
             for arg in new_expr.args.as_deref().unwrap_or_default() {
                 if arg.spread.is_none() {
-                    collect_expr_anchors(&arg.expr, candidates);
+                    collect_expr_anchors(&arg.expr, depth + 1, candidates);
                 }
             }
         }
@@ -2590,16 +2616,16 @@ fn collect_expr_anchors(expr: &Expr, candidates: &mut AnchorCandidates) {
                 if let PropOrSpread::Prop(prop) = prop {
                     if let Prop::KeyValue(key_value) = prop.as_ref() {
                         candidates.structural.push(span_key(key_value.key.span()));
-                        collect_expr_anchors(&key_value.value, candidates);
+                        collect_expr_anchors(&key_value.value, depth, candidates);
                     }
                 }
             }
         }
-        Expr::Await(await_expr) => collect_expr_anchors(&await_expr.arg, candidates),
-        Expr::Unary(unary) => collect_expr_anchors(&unary.arg, candidates),
+        Expr::Await(await_expr) => collect_expr_anchors(&await_expr.arg, depth, candidates),
+        Expr::Unary(unary) => collect_expr_anchors(&unary.arg, depth, candidates),
         Expr::Bin(bin) => {
-            collect_expr_anchors(&bin.left, candidates);
-            collect_expr_anchors(&bin.right, candidates);
+            collect_expr_anchors(&bin.left, depth, candidates);
+            collect_expr_anchors(&bin.right, depth, candidates);
         }
         _ => {}
     }
@@ -2643,9 +2669,37 @@ fn holes_present(source: &str) -> BTreeSet<String> {
     holes
 }
 
-/// Minimal anchor cover for a single-target function declaration: choose the
-/// fewest concrete anchors whose matcher-proven exclusion sets rule out every
-/// same-arity sibling, render the holey selector, and prove it.
+/// Minimal anchor cover for a single-target declaration. `render_with` renders
+/// the declaration's selector given a kept-anchor set, and `candidates` are its
+/// concrete anchors. Competitors are exactly the items the maximally-holed
+/// selector still matches; the tiered cover picks the fewest anchors that rule
+/// them out, and the chosen selector is rendered and proven once.
+fn minimize_via_retention(
+    index: &ChunkSelectorIndex,
+    decl: &IndexedDeclaration,
+    target: &SynthesizedTargetBinding,
+    candidates: &AnchorCandidates,
+    render_with: &impl Fn(&BTreeSet<AnchorSpan>) -> Result<String>,
+) -> Result<Option<SpecializedSelector>> {
+    let empty = BTreeSet::new();
+    let mut competitors = matched_body_indices(index, &target.export_name, &render_with(&empty)?)?;
+    competitors.remove(&decl.body_idx);
+    if competitors.is_empty() {
+        return finish_minimized_selector(index, decl, target, render_with(&empty)?);
+    }
+    let Some(chosen) = cover_competitors(
+        index,
+        target,
+        &competitors,
+        &candidates.tiers(),
+        render_with,
+    )?
+    else {
+        return Ok(None);
+    };
+    finish_minimized_selector(index, decl, target, render_with(&chosen)?)
+}
+
 fn minimize_function_selector(
     index: &ChunkSelectorIndex,
     function: &Function,
@@ -2655,55 +2709,228 @@ fn minimize_function_selector(
     let Some(body) = &function.body else {
         return Ok(None);
     };
-    let header = render_function_selector_header(function, &target.export_name);
     let render_with = |kept: &BTreeSet<AnchorSpan>| -> Result<String> {
-        let body_source = render_retained_stmt_list(index, &body.stmts, kept)?;
-        Ok(trim_selector_source_line_suffixes(&format!(
-            "{header} {{\n{}\n}}",
-            indent_lines(&body_source, "  ")
-        )))
+        let mut holed = function.clone();
+        holed.params = function.params.iter().map(|_| anything_param()).collect();
+        if let Some(holed_body) = &mut holed.body {
+            holed_body.stmts = hole_stmts(&body.stmts, kept);
+        }
+        emit_selector(ModuleItem::Stmt(Stmt::Decl(Decl::Fn(FnDecl {
+            ident: ident_node(&target.export_name),
+            declare: false,
+            function: Box::new(holed),
+        }))))
     };
-
-    let skeleton_features = BTreeSet::from([
-        SelectorAnchorFeature::DeclarationKind(IndexedDeclarationKind::Function),
-        SelectorAnchorFeature::FunctionArity(function.params.len()),
-    ]);
-    let mut competitors = index.frontier_for_features(&skeleton_features);
-    competitors.remove(&decl.body_idx);
-
-    let empty = BTreeSet::new();
-    if competitors.is_empty() {
-        let source = render_with(&empty)?;
-        return finish_minimized_selector(index, decl, target, source);
-    }
-
     let candidates = collect_stmt_list_anchors(&body.stmts);
-    let Some(chosen) = cover_competitors(
-        index,
-        target,
-        &competitors,
-        &candidates.tiers(),
-        &render_with,
-    )?
-    else {
-        return Ok(None);
-    };
-    let source = render_with(&chosen)?;
-    finish_minimized_selector(index, decl, target, source)
+    minimize_via_retention(index, decl, target, &candidates, &render_with)
 }
 
-/// Tiered greedy set cover. Tiers are tried most-preferred first (literals
-/// before structural anchors): within a tier, repeatedly take the anchor
-/// excluding the most still-uncovered competitors until the tier is exhausted,
-/// then fall through to the next tier only for whatever remains uncovered. The
-/// matcher gives each anchor's exclusion set, so the result is sound and the
-/// final selector is proven once by the caller. Returns `None` if even all
+/// Minimal anchor cover for a single-target, single-declarator `var`/`let`/
+/// `const`: render `<kind> <export> = <retained init>` and cover sibling
+/// declarations. Multi-declarator groups fall back to the legacy slot search.
+fn minimize_var_selector(
+    index: &ChunkSelectorIndex,
+    var: &VarDecl,
+    decl: &IndexedDeclaration,
+    target: &SynthesizedTargetBinding,
+) -> Result<Option<SpecializedSelector>> {
+    let [declarator] = var.decls.as_slice() else {
+        return Ok(None);
+    };
+    if single_ident_pat_name(&declarator.name) != Some(target.runtime_binding.as_str()) {
+        return Ok(None);
+    }
+    let Some(init) = declarator.init.as_deref() else {
+        return Ok(None);
+    };
+    let export = target.export_name.clone();
+    let render_with = |kept: &BTreeSet<AnchorSpan>| -> Result<String> {
+        let mut holed_declarator = declarator.clone();
+        holed_declarator.name = named_pat(&export);
+        holed_declarator.init = Some(Box::new(hole_expr(init, kept)));
+        let mut holed_var = var.clone();
+        holed_var.declare = false;
+        holed_var.decls = vec![holed_declarator];
+        emit_selector(ModuleItem::Stmt(Stmt::Decl(Decl::Var(Box::new(holed_var)))))
+    };
+    let mut candidates = AnchorCandidates::default();
+    collect_expr_anchors(init, 0, &mut candidates);
+    minimize_via_retention(index, decl, target, &candidates, &render_with)
+}
+
+/// Minimal anchor cover for a single-target class: render the class keeping
+/// only members (and member-body statements) that carry a chosen anchor, with
+/// `CLASS_REST` for dropped member runs, and cover sibling classes.
+fn minimize_class_selector(
+    index: &ChunkSelectorIndex,
+    class: &Class,
+    decl: &IndexedDeclaration,
+    target: &SynthesizedTargetBinding,
+) -> Result<Option<SpecializedSelector>> {
+    let export = target.export_name.clone();
+    let render_with = |kept: &BTreeSet<AnchorSpan>| -> Result<String> {
+        let mut holed_class = class.clone();
+        holed_class.body = hole_class_members(&class.body, kept);
+        emit_selector(ModuleItem::Stmt(Stmt::Decl(Decl::Class(ClassDecl {
+            ident: ident_node(&export),
+            declare: false,
+            class: Box::new(holed_class),
+        }))))
+    };
+    let candidates = collect_class_anchors(class);
+    minimize_via_retention(index, decl, target, &candidates, &render_with)
+}
+
+fn anything_param() -> Param {
+    Param {
+        span: DUMMY_SP,
+        decorators: vec![],
+        pat: anything_pat(),
+    }
+}
+
+fn named_pat(name: &str) -> Pat {
+    Pat::Ident(BindingIdent {
+        id: ident_node(name),
+        type_ann: None,
+    })
+}
+
+/// A `CLASS_REST;` class-field hole that absorbs a run of dropped members.
+fn class_rest_member() -> ClassMember {
+    ClassMember::ClassProp(ClassProp {
+        span: DUMMY_SP,
+        key: PropName::Ident(IdentName::new(CLASS_REST_HOLE_KEYWORD.into(), DUMMY_SP)),
+        value: None,
+        type_ann: None,
+        is_static: false,
+        decorators: vec![],
+        accessibility: None,
+        is_abstract: false,
+        is_optional: false,
+        is_override: false,
+        readonly: false,
+        declare: false,
+        definite: false,
+    })
+}
+
+fn hole_class_members(members: &[ClassMember], kept: &BTreeSet<AnchorSpan>) -> Vec<ClassMember> {
+    let mut out = Vec::new();
+    let mut dropped_run = false;
+    for member in members {
+        if node_retains_any(member.span(), kept) {
+            if dropped_run {
+                out.push(class_rest_member());
+                dropped_run = false;
+            }
+            out.push(hole_class_member(member, kept));
+        } else {
+            dropped_run = true;
+        }
+    }
+    if dropped_run || out.is_empty() {
+        out.push(class_rest_member());
+    }
+    out
+}
+
+fn hole_class_member(member: &ClassMember, kept: &BTreeSet<AnchorSpan>) -> ClassMember {
+    match member {
+        ClassMember::Method(m) => {
+            let mut holed = m.clone();
+            holed.function.params = m.function.params.iter().map(|_| anything_param()).collect();
+            holed.function.body = m.function.body.as_ref().map(|body| holed_block(body, kept));
+            ClassMember::Method(holed)
+        }
+        ClassMember::PrivateMethod(m) => {
+            let mut holed = m.clone();
+            holed.function.params = m.function.params.iter().map(|_| anything_param()).collect();
+            holed.function.body = m.function.body.as_ref().map(|body| holed_block(body, kept));
+            ClassMember::PrivateMethod(holed)
+        }
+        ClassMember::Constructor(ctor) => {
+            let mut holed = ctor.clone();
+            holed.params = ctor
+                .params
+                .iter()
+                .map(|_| ParamOrTsParamProp::Param(anything_param()))
+                .collect();
+            holed.body = ctor.body.as_ref().map(|body| holed_block(body, kept));
+            ClassMember::Constructor(holed)
+        }
+        // Class fields and other members carrying a kept anchor: keep verbatim.
+        _ => member.clone(),
+    }
+}
+
+/// Emit a synthesized selector item (a holed declaration) to source via the
+/// shared codegen — the only AST→string step, and the matcher's parse inverts it.
+fn emit_selector(item: ModuleItem) -> Result<String> {
+    js_ast::emit_module_source(&Module {
+        span: DUMMY_SP,
+        body: vec![item],
+        shebang: None,
+    })
+}
+
+fn collect_class_anchors(class: &Class) -> AnchorCandidates {
+    let mut candidates = AnchorCandidates::default();
+    for member in &class.body {
+        if let Some(span) = class_member_name_span(member) {
+            candidates.structural.push(span_key(span));
+        }
+        match member {
+            ClassMember::Method(m) => collect_block_stmt_anchors(&m.function.body, &mut candidates),
+            ClassMember::PrivateMethod(m) => {
+                collect_block_stmt_anchors(&m.function.body, &mut candidates)
+            }
+            ClassMember::Constructor(ctor) => {
+                collect_block_stmt_anchors(&ctor.body, &mut candidates)
+            }
+            ClassMember::ClassProp(prop) => {
+                if let Some(value) = &prop.value {
+                    collect_expr_anchors(value, 0, &mut candidates);
+                }
+            }
+            _ => {}
+        }
+    }
+    candidates
+}
+
+fn collect_block_stmt_anchors(body: &Option<BlockStmt>, candidates: &mut AnchorCandidates) {
+    if let Some(block) = body {
+        for stmt in &block.stmts {
+            collect_stmt_anchors(stmt, candidates);
+        }
+    }
+}
+
+fn class_member_name_span(member: &ClassMember) -> Option<Span> {
+    let prop_name_span = |name: &PropName| match name {
+        PropName::Ident(ident) => Some(ident.span),
+        _ => None,
+    };
+    match member {
+        ClassMember::Method(m) => prop_name_span(&m.key),
+        ClassMember::ClassProp(prop) => prop_name_span(&prop.key),
+        _ => None,
+    }
+}
+
+/// Tiered minimum set cover. Tiers are tried most-preferred first; within a
+/// tier, the matcher gives each anchor's exclusion set and a minimum-cardinality
+/// cover (branch-and-bound) clears as many still-uncovered competitors as the
+/// tier can, leaving the rest to later tiers. Tier order encodes meaning
+/// preference; minimum cardinality within a tier avoids greedy over-pinning.
+/// The final selector is proven once by the caller. Returns `None` if even all
 /// anchors together cannot single out the target.
 fn cover_competitors(
     index: &ChunkSelectorIndex,
     target: &SynthesizedTargetBinding,
     competitors: &BTreeSet<usize>,
-    tiers: &[&[AnchorSpan]],
+    tiers: &[Vec<AnchorSpan>],
     render_with: &impl Fn(&BTreeSet<AnchorSpan>) -> Result<String>,
 ) -> Result<Option<BTreeSet<AnchorSpan>>> {
     let mut uncovered = competitors.clone();
@@ -2719,35 +2946,84 @@ fn cover_competitors(
                 &target.export_name,
                 &render_with(&BTreeSet::from([anchor]))?,
             )?;
-            let excluded: BTreeSet<usize> = competitors.difference(&survivors).copied().collect();
+            let excluded: BTreeSet<usize> = uncovered.difference(&survivors).copied().collect();
             if !excluded.is_empty() {
                 exclusions.push((anchor, excluded));
             }
         }
-        while !uncovered.is_empty() {
-            let best = exclusions
-                .iter()
-                .filter(|(anchor, _)| !chosen.contains(anchor))
-                .max_by_key(|(anchor, excluded)| {
-                    (
-                        excluded.intersection(&uncovered).count(),
-                        std::cmp::Reverse(anchor.0),
-                    )
-                });
-            let Some((anchor, excluded)) = best else {
-                break;
-            };
-            if excluded.intersection(&uncovered).next().is_none() {
-                break;
-            }
-            chosen.insert(*anchor);
-            uncovered = uncovered.difference(excluded).copied().collect();
+        let coverable: BTreeSet<usize> = exclusions
+            .iter()
+            .flat_map(|(_, excluded)| excluded.iter().copied())
+            .collect();
+        if coverable.is_empty() {
+            continue;
         }
+        for anchor in min_set_cover(&exclusions, &coverable) {
+            chosen.insert(anchor);
+        }
+        uncovered = uncovered.difference(&coverable).copied().collect();
     }
     if uncovered.is_empty() {
         Ok(Some(chosen))
     } else {
         Ok(None)
+    }
+}
+
+/// Minimum-cardinality set cover of `universe` by `sets` (each an anchor and the
+/// competitors it excludes). Branch-and-bound on the least-coverable element;
+/// `universe` is the union of all sets, so a cover always exists. Instances are
+/// tiny (anchors and competitors are per-chunk), so exhaustive search with
+/// best-length pruning stays well within budget and avoids greedy over-pinning.
+fn min_set_cover(
+    sets: &[(AnchorSpan, BTreeSet<usize>)],
+    universe: &BTreeSet<usize>,
+) -> Vec<AnchorSpan> {
+    let mut best: Option<Vec<AnchorSpan>> = None;
+    let mut chosen: Vec<AnchorSpan> = Vec::new();
+    min_set_cover_search(sets, universe.clone(), &mut chosen, &mut best);
+    best.unwrap_or_default()
+}
+
+fn min_set_cover_search(
+    sets: &[(AnchorSpan, BTreeSet<usize>)],
+    remaining: BTreeSet<usize>,
+    chosen: &mut Vec<AnchorSpan>,
+    best: &mut Option<Vec<AnchorSpan>>,
+) {
+    if remaining.is_empty() {
+        if best.as_ref().is_none_or(|found| chosen.len() < found.len()) {
+            *best = Some(chosen.clone());
+        }
+        return;
+    }
+    if best
+        .as_ref()
+        .is_some_and(|found| chosen.len() + 1 >= found.len())
+    {
+        return;
+    }
+    // Branch on the still-uncovered competitor that the fewest anchors exclude:
+    // every cover must include one of those anchors, which keeps the tree narrow.
+    let Some(pivot) = remaining.iter().copied().min_by_key(|competitor| {
+        sets.iter()
+            .filter(|(_, excluded)| excluded.contains(competitor))
+            .count()
+    }) else {
+        return;
+    };
+    for (anchor, excluded) in sets {
+        if chosen.contains(anchor) || !excluded.contains(&pivot) {
+            continue;
+        }
+        chosen.push(*anchor);
+        min_set_cover_search(
+            sets,
+            remaining.difference(excluded).copied().collect(),
+            chosen,
+            best,
+        );
+        chosen.pop();
     }
 }
 

--- a/devinfra/js/debundle/selector_codemod.rs
+++ b/devinfra/js/debundle/selector_codemod.rs
@@ -23,14 +23,14 @@ use swc_common::{BytePos, Span, Spanned};
 use swc_ecma_ast::*;
 use swc_ecma_visit::{Visit, VisitWith};
 
-const ANYTHING_HOLE_KEYWORD: &str = "ANYTHING";
-const EXPR_HOLE_KEYWORD: &str = "EXPR";
-const STMT_HOLE_KEYWORD: &str = "STMT";
-const STMT_LIST_HOLE_KEYWORD: &str = "STMT_LIST";
-const CLASS_REST_HOLE_KEYWORD: &str = "CLASS_REST";
-const DECLARATORS_HOLE_KEYWORD: &str = "DECLARATORS";
-const ARGS_HOLE_KEYWORD: &str = "ARGS";
-const OBJECT_PROPS_HOLE_KEYWORD: &str = "OBJECT_PROPS";
+// Hole keyword spellings come from `source_match_holes` so the minimizer
+// emits exactly the tokens the matcher resolves.
+use source_match_holes::{
+    ANYTHING_HOLE_KEYWORD, ARGS_HOLE_KEYWORD, CLASS_REST_HOLE_KEYWORD, DECLARATORS_HOLE_KEYWORD,
+    EXPR_HOLE_KEYWORD, OBJECT_PROPS_HOLE_KEYWORD, STMT_HOLE_KEYWORD, STMT_LIST_HOLE_KEYWORD,
+    hole_name_for,
+};
+
 const MAX_VAR_GROUP_FRONTIER_TUPLES_PER_DECL: usize = 4096;
 const MAX_VAR_FEATURE_SEARCH_NODES: usize = 200_000;
 const MAX_FUNCTION_SELECTOR_CANDIDATES: usize = 512;
@@ -1322,10 +1322,10 @@ fn synthesize_specialized_function_selector(
         IndexedDeclarationKind::Function,
     ));
     Ok(Some(SpecializedSelector {
-        match_source: format!("{header} {{\n  STMT_LIST;\n}}"),
+        match_source: format!("{header} {{\n  {STMT_LIST_HOLE_KEYWORD};\n}}"),
         rewritten_holes: BTreeSet::from([
             ANYTHING_HOLE_KEYWORD.to_string(),
-            "STMT_LIST".to_string(),
+            STMT_LIST_HOLE_KEYWORD.to_string(),
         ]),
     }))
 }
@@ -1359,8 +1359,11 @@ fn synthesize_specialized_class_selector(
     )]);
     if frontier_is_small_and_contains_target(index, decl, &features) {
         return Ok(Some(SpecializedSelector {
-            match_source: format!("class {} {{\n  CLASS_REST;\n}}", target.export_name),
-            rewritten_holes: BTreeSet::from(["CLASS_REST".to_string()]),
+            match_source: format!(
+                "class {} {{\n  {CLASS_REST_HOLE_KEYWORD};\n}}",
+                target.export_name
+            ),
+            rewritten_holes: BTreeSet::from([CLASS_REST_HOLE_KEYWORD.to_string()]),
         }));
     }
 
@@ -1386,8 +1389,8 @@ fn synthesize_specialized_class_selector(
                 match_source: format!("class {} {{\n{members}}}", target.export_name),
                 rewritten_holes: BTreeSet::from([
                     ANYTHING_HOLE_KEYWORD.to_string(),
-                    "STMT_LIST".to_string(),
-                    "CLASS_REST".to_string(),
+                    STMT_LIST_HOLE_KEYWORD.to_string(),
+                    CLASS_REST_HOLE_KEYWORD.to_string(),
                 ]),
             }));
         }
@@ -3060,21 +3063,20 @@ fn is_hole_expr(expr: &Expr) -> bool {
 }
 
 fn is_hole_name(name: &str) -> bool {
-    name == ANYTHING_HOLE_KEYWORD
-        || name == EXPR_HOLE_KEYWORD
-        || name.starts_with("EXPR_")
-        || name == STMT_HOLE_KEYWORD
-        || name.starts_with("STMT_")
-        || name == "STMT_LIST"
-        || name.starts_with("STMT_LIST_")
-        || name == CLASS_REST_HOLE_KEYWORD
-        || name.starts_with("CLASS_REST_")
-        || name == DECLARATORS_HOLE_KEYWORD
-        || name.starts_with("DECLARATORS_")
-        || name == ARGS_HOLE_KEYWORD
-        || name.starts_with("ARGS_")
-        || name == OBJECT_PROPS_HOLE_KEYWORD
-        || name.starts_with("OBJECT_PROPS_")
+    // `STMT` subsumes `STMT_LIST` here: a `<keyword>_<suffix>` match on `STMT`
+    // already covers the list spelling for this membership test.
+    [
+        ANYTHING_HOLE_KEYWORD,
+        EXPR_HOLE_KEYWORD,
+        STMT_HOLE_KEYWORD,
+        STMT_LIST_HOLE_KEYWORD,
+        CLASS_REST_HOLE_KEYWORD,
+        DECLARATORS_HOLE_KEYWORD,
+        ARGS_HOLE_KEYWORD,
+        OBJECT_PROPS_HOLE_KEYWORD,
+    ]
+    .iter()
+    .any(|keyword| hole_name_for(name, keyword).is_some())
 }
 
 fn render_var_group_selector(

--- a/devinfra/js/debundle/selector_minimizer_proptest.rs
+++ b/devinfra/js/debundle/selector_minimizer_proptest.rs
@@ -1,0 +1,190 @@
+//! Property: every selector the minimizer synthesizes, re-matched against the
+//! original chunk, resolves uniquely to the intended target binding (gate 1).
+//!
+//! Each case generates a small chunk of same-arity function declarations whose
+//! bodies are built from a spec that maps onto the AST shapes the retention
+//! renderer branches on — numeric/string literals, method calls with multiple
+//! arguments, and object-literal arguments. The spec is rendered to JS and
+//! parsed so the minimizer sees real source spans (it reads original text via
+//! `source_for_span`), exactly as in production. We synthesize a minimized
+//! selector for one target, then *independently* re-run the production matcher
+//! on the produced `match_source`: the synthesizer proves uniqueness
+//! internally, and this verifies that guarantee end-to-end across the input
+//! space the golden fixtures only sample by hand. Bounded for CI; override with
+//! `bbr test //devinfra/js/debundle:selector_codemod_test
+//! --test_env=PROPTEST_CASES=2000`.
+
+use std::collections::BTreeSet;
+
+use proptest::prelude::*;
+use proptest::sample::Index;
+
+use super::{
+    ChunkSelectorIndex, NameBindingMember, matched_body_indices,
+    synthesize_simplest_selector_for_group,
+};
+
+const METHODS: [&str; 3] = ["foo", "bar", "baz"];
+const STRINGS: [&str; 3] = ["alpha", "beta", "gamma"];
+const KEYS: [&str; 3] = ["kind", "mode", "size"];
+
+#[derive(Debug, Clone)]
+enum ArgSpec {
+    Num(u8),
+    Str(u8),
+    Obj { key_id: u8, value: u8 },
+}
+
+#[derive(Debug, Clone)]
+struct CallSpec {
+    recv_a: bool,
+    method_id: u8,
+    args: Vec<ArgSpec>,
+}
+
+#[derive(Debug, Clone)]
+enum StmtSpec {
+    ConstNum { value: u8 },
+    ConstStr { value_id: u8 },
+    ConstCall(CallSpec),
+    CallStmt(CallSpec),
+    Return,
+}
+
+fn arg_strategy() -> impl Strategy<Value = ArgSpec> {
+    prop_oneof![
+        (0u8..4).prop_map(ArgSpec::Num),
+        (0u8..3).prop_map(ArgSpec::Str),
+        (0u8..3, 0u8..4).prop_map(|(key_id, value)| ArgSpec::Obj { key_id, value }),
+    ]
+}
+
+fn call_strategy() -> impl Strategy<Value = CallSpec> {
+    (
+        any::<bool>(),
+        0u8..3,
+        prop::collection::vec(arg_strategy(), 0..3),
+    )
+        .prop_map(|(recv_a, method_id, args)| CallSpec {
+            recv_a,
+            method_id,
+            args,
+        })
+}
+
+fn stmt_strategy() -> impl Strategy<Value = StmtSpec> {
+    prop_oneof![
+        (0u8..4).prop_map(|value| StmtSpec::ConstNum { value }),
+        (0u8..3).prop_map(|value_id| StmtSpec::ConstStr { value_id }),
+        call_strategy().prop_map(StmtSpec::ConstCall),
+        call_strategy().prop_map(StmtSpec::CallStmt),
+        Just(StmtSpec::Return),
+    ]
+}
+
+fn render_arg(arg: &ArgSpec) -> String {
+    match arg {
+        ArgSpec::Num(value) => value.to_string(),
+        ArgSpec::Str(value_id) => format!("\"{}\"", STRINGS[*value_id as usize]),
+        ArgSpec::Obj { key_id, value } => format!("{{ {}: {value} }}", KEYS[*key_id as usize]),
+    }
+}
+
+fn render_call(call: &CallSpec) -> String {
+    let recv = if call.recv_a { "a" } else { "b" };
+    let args = call
+        .args
+        .iter()
+        .map(render_arg)
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("{recv}.{}({args})", METHODS[call.method_id as usize])
+}
+
+fn render_stmt(spec: &StmtSpec, slot: usize) -> String {
+    match spec {
+        StmtSpec::ConstNum { value } => format!("const v{slot} = {value};"),
+        StmtSpec::ConstStr { value_id } => {
+            format!("const v{slot} = mk(\"{}\");", STRINGS[*value_id as usize])
+        }
+        StmtSpec::ConstCall(call) => format!("const v{slot} = {};", render_call(call)),
+        StmtSpec::CallStmt(call) => format!("{};", render_call(call)),
+        StmtSpec::Return => "return a;".to_string(),
+    }
+}
+
+fn render_chunk(items: &[Vec<StmtSpec>]) -> String {
+    items
+        .iter()
+        .enumerate()
+        .map(|(idx, stmts)| {
+            let body = stmts
+                .iter()
+                .enumerate()
+                .map(|(slot, stmt)| format!("  {}", render_stmt(stmt, slot)))
+                .collect::<Vec<_>>()
+                .join("\n");
+            format!("function f{idx}(a, b) {{\n{body}\n}}")
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 96, ..ProptestConfig::default() })]
+
+    #[test]
+    fn minimized_selector_uniquely_matches_target(
+        items in prop::collection::vec(prop::collection::vec(stmt_strategy(), 1..4), 2..5),
+        target in any::<Index>(),
+    ) {
+        let source = render_chunk(&items);
+        let runtime = format!("f{}", target.index(items.len()));
+        let export = "TargetBinding";
+
+        let outcome: Result<(), TestCaseError> = js_ast::with_swc_globals(|| {
+            let parsed = js_ast::parse_js_module_consuming("<proptest>", source.clone())
+                .map_err(|err| TestCaseError::fail(format!("parse failed: {err}\n{source}")))?;
+            let index = ChunkSelectorIndex::new(parsed);
+
+            let decl_idx = index
+                .binding_to_decl
+                .get(&runtime)
+                .and_then(|decls| decls.first())
+                .copied()
+                .expect("generated chunk declares the target function");
+            let expected_body_idx = index.decls[decl_idx].body_idx;
+
+            let members = [NameBindingMember {
+                member_index: 0,
+                export_name: export.to_string(),
+                binding_name: runtime.clone(),
+                comment: None,
+            }];
+
+            // An ambiguous chunk (two alpha-identical declarations) cannot be
+            // pinned even by the exact selector; the synthesizer errors and
+            // there is nothing to assert.
+            let Ok(group) = synthesize_simplest_selector_for_group(&index, decl_idx, &members, true)
+            else {
+                return Ok(());
+            };
+
+            let matched = matched_body_indices(&index, export, &group.match_source).map_err(|err| {
+                TestCaseError::fail(format!(
+                    "synthesized selector failed to re-match: {err}\nselector:\n{}\nchunk:\n{source}",
+                    group.match_source
+                ))
+            })?;
+            prop_assert_eq!(
+                &matched,
+                &BTreeSet::from([expected_body_idx]),
+                "selector did not uniquely resolve the target\nselector:\n{}\nchunk:\n{}",
+                group.match_source,
+                source
+            );
+            Ok(())
+        });
+        outcome?;
+    }
+}

--- a/devinfra/js/debundle/selector_minimizer_proptest.rs
+++ b/devinfra/js/debundle/selector_minimizer_proptest.rs
@@ -1,14 +1,26 @@
 //! Property: every selector the minimizer synthesizes, re-matched against the
-//! original chunk, resolves uniquely to the intended target binding (gate 1).
+//! original chunk, resolves uniquely to the intended target binding(s) (gate 1).
 //!
-//! Cases build chunks of same-arity function declarations as real `swc_ecma_ast`
-//! nodes (the call / literal / object shapes the retention renderer branches on),
-//! serialize them with swc's own codegen, and feed the resulting source into the
-//! minimizer — which parses it exactly as in production, so spans are real. The
-//! synthesized `match_source` is then independently re-run through the production
-//! matcher: the synthesizer proves uniqueness internally, and this verifies that
-//! guarantee end-to-end across the input space the golden fixtures only sample by
-//! hand. Bounded for CI; override with `bbr test
+//! Cases build chunks of uniquely-named top-level declarations as real
+//! `swc_ecma_ast` nodes — covering all the declaration shapes the retention
+//! renderer branches on:
+//!
+//! - same-arity function declarations (exercises `minimize_function_selector`);
+//! - single `const` declarations with call / object / literal initializers
+//!   (exercises `minimize_var_selector`);
+//! - class declarations whose methods contain calls / literals (exercises
+//!   `minimize_class_selector`);
+//! - multi-declarator `const`s, where 2+ declarators in one statement are
+//!   selected as a binding group (exercises `minimize_var_group_selector` via
+//!   `synthesize_simplest_selector_for_group` with multiple `NameBindingMember`s).
+//!
+//! The chunk is serialized with swc's own codegen and fed into the minimizer —
+//! which parses it exactly as in production, so spans are real. The synthesized
+//! `match_source` is then independently re-run through the production matcher:
+//! the synthesizer proves uniqueness internally, and this verifies that
+//! guarantee end-to-end across the input space the golden fixtures only sample
+//! by hand. Every generated binding is uniquely named so the emitted chunk
+//! always re-parses. Bounded for CI (~96 cases); override with `bbr test
 //! //devinfra/js/debundle:selector_codemod_test --test_env=PROPTEST_CASES=2000`.
 
 use std::collections::BTreeSet;
@@ -93,43 +105,99 @@ fn object(entries: Vec<(&str, Expr)>) -> Expr {
     })
 }
 
-fn const_decl(init: Expr) -> Stmt {
-    Stmt::Decl(Decl::Var(Box::new(VarDecl {
+fn binding_ident_pat(name: &str) -> Pat {
+    Pat::Ident(BindingIdent {
+        id: ident(name),
+        type_ann: None,
+    })
+}
+
+fn declarator(name: &str, init: Expr) -> VarDeclarator {
+    VarDeclarator {
+        span: DUMMY_SP,
+        name: binding_ident_pat(name),
+        init: Some(Box::new(init)),
+        definite: false,
+    }
+}
+
+fn const_var(decls: Vec<VarDeclarator>) -> Decl {
+    Decl::Var(Box::new(VarDecl {
         span: DUMMY_SP,
         ctxt: SyntaxContext::empty(),
         kind: VarDeclKind::Const,
         declare: false,
-        decls: vec![VarDeclarator {
-            span: DUMMY_SP,
-            name: Pat::Ident(BindingIdent {
-                id: ident("v"),
-                type_ann: None,
-            }),
-            init: Some(Box::new(init)),
-            definite: false,
-        }],
-    })))
+        decls,
+    }))
 }
 
-fn function_decl(name: &str, mut body: Vec<Stmt>) -> ModuleItem {
+/// A single anonymous `const v = <init>` statement used inside function and
+/// method bodies. Names are reassigned to be slot-unique by
+/// `assign_unique_const_names` before the body is emitted.
+fn const_decl(init: Expr) -> Stmt {
+    Stmt::Decl(const_var(vec![declarator("v", init)]))
+}
+
+fn function_node(body: Vec<Stmt>) -> Function {
+    let mut body = body;
     assign_unique_const_names(&mut body);
+    Function {
+        params: vec![param("a"), param("b")],
+        decorators: vec![],
+        span: DUMMY_SP,
+        ctxt: SyntaxContext::empty(),
+        body: Some(BlockStmt {
+            span: DUMMY_SP,
+            ctxt: SyntaxContext::empty(),
+            stmts: body,
+        }),
+        is_generator: false,
+        is_async: false,
+        type_params: None,
+        return_type: None,
+    }
+}
+
+fn function_decl(name: &str, body: Vec<Stmt>) -> ModuleItem {
     ModuleItem::Stmt(Stmt::Decl(Decl::Fn(FnDecl {
         ident: ident(name),
         declare: false,
-        function: Box::new(Function {
-            params: vec![param("a"), param("b")],
-            decorators: vec![],
+        function: Box::new(function_node(body)),
+    })))
+}
+
+fn class_method(name: &str, body: Vec<Stmt>) -> ClassMember {
+    ClassMember::Method(ClassMethod {
+        span: DUMMY_SP,
+        key: PropName::Ident(IdentName::new(name.into(), DUMMY_SP)),
+        function: Box::new(function_node(body)),
+        kind: MethodKind::Method,
+        is_static: false,
+        accessibility: None,
+        is_abstract: false,
+        is_optional: false,
+        is_override: false,
+    })
+}
+
+fn class_decl(name: &str, methods: Vec<(usize, Vec<Stmt>)>) -> ModuleItem {
+    let body = methods
+        .into_iter()
+        .map(|(method, stmts)| class_method(METHODS[method], stmts))
+        .collect();
+    ModuleItem::Stmt(Stmt::Decl(Decl::Class(ClassDecl {
+        ident: ident(name),
+        declare: false,
+        class: Box::new(Class {
             span: DUMMY_SP,
             ctxt: SyntaxContext::empty(),
-            body: Some(BlockStmt {
-                span: DUMMY_SP,
-                ctxt: SyntaxContext::empty(),
-                stmts: body,
-            }),
-            is_generator: false,
-            is_async: false,
+            decorators: vec![],
+            body,
+            super_class: None,
+            is_abstract: false,
             type_params: None,
-            return_type: None,
+            super_type_params: None,
+            implements: vec![],
         }),
     })))
 }
@@ -138,15 +206,12 @@ fn param(name: &str) -> Param {
     Param {
         span: DUMMY_SP,
         decorators: vec![],
-        pat: Pat::Ident(BindingIdent {
-            id: ident(name),
-            type_ann: None,
-        }),
+        pat: binding_ident_pat(name),
     }
 }
 
-/// Give every generated `const` a slot-unique name so the emitted body never
-/// redeclares a `const` (which would fail to re-parse).
+/// Give every generated `const` inside a body a slot-unique name so the emitted
+/// body never redeclares a `const` (which would fail to re-parse).
 fn assign_unique_const_names(stmts: &mut [Stmt]) {
     let mut slot = 0;
     for stmt in stmts {
@@ -215,27 +280,159 @@ fn stmt_strategy() -> impl Strategy<Value = Stmt> {
     ]
 }
 
+/// Initializer for a top-level single/grouped `const` binding: a call, an
+/// object literal, or a bare literal — the shapes `minimize_var_selector` and
+/// `minimize_var_group_selector` peel anchors out of.
+fn var_init_strategy() -> impl Strategy<Value = Expr> {
+    prop_oneof![
+        (0u8..8).prop_map(num),
+        (0usize..STRINGS.len()).prop_map(|idx| string(STRINGS[idx])),
+        (
+            0usize..METHODS.len(),
+            prop::collection::vec(arg_strategy(), 0..3)
+        )
+            .prop_map(|(method, args)| call(ident_expr(METHODS[method]), args)),
+        prop::collection::vec((0usize..KEYS.len(), arg_strategy()), 1..3).prop_map(|entries| {
+            object(
+                entries
+                    .into_iter()
+                    .enumerate()
+                    // Dedup keys within one object: re-parsing tolerates dupes,
+                    // but distinct keys keep the generated shapes meaningful.
+                    .map(|(slot, (_key, value))| (KEYS[slot % KEYS.len()], value))
+                    .collect(),
+            )
+        }),
+    ]
+}
+
+/// One generated top-level declaration plus the runtime binding names it
+/// introduces. The test picks a target binding (or, for `Group`, a subset of
+/// 2+ bindings) from these.
+#[derive(Debug, Clone)]
+enum GenItem {
+    /// Single-binding declaration (function / single `const` / class).
+    Single { item: ModuleItem, binding: String },
+    /// Multi-declarator `const` with 2+ declarators, all eligible as a group.
+    Group {
+        item: ModuleItem,
+        bindings: Vec<String>,
+    },
+}
+
+/// Strategy for a single-binding top-level item; `name` is the unique binding
+/// the declaration introduces.
+fn single_item_strategy(name: String) -> impl Strategy<Value = GenItem> {
+    let func = prop::collection::vec(stmt_strategy(), 1..4).prop_map({
+        let name = name.clone();
+        move |body| GenItem::Single {
+            item: function_decl(&name, body),
+            binding: name.clone(),
+        }
+    });
+    let var = var_init_strategy().prop_map({
+        let name = name.clone();
+        move |init| GenItem::Single {
+            item: ModuleItem::Stmt(Stmt::Decl(const_var(vec![declarator(&name, init)]))),
+            binding: name.clone(),
+        }
+    });
+    let class = prop::collection::vec(
+        (
+            0usize..METHODS.len(),
+            prop::collection::vec(stmt_strategy(), 1..3),
+        ),
+        1..3,
+    )
+    .prop_map({
+        let name = name.clone();
+        move |methods| {
+            // Dedup method names within one class so the emitted class re-parses.
+            let methods = methods
+                .into_iter()
+                .enumerate()
+                .map(|(slot, (_method, body))| (slot % METHODS.len(), body))
+                .collect();
+            GenItem::Single {
+                item: class_decl(&name, methods),
+                binding: name.clone(),
+            }
+        }
+    });
+    prop_oneof![func, var, class]
+}
+
+/// Strategy for a multi-declarator `const` group item; `names` are the unique
+/// bindings (2+) the single statement introduces.
+fn group_item_strategy(names: Vec<String>) -> impl Strategy<Value = GenItem> {
+    prop::collection::vec(var_init_strategy(), names.len()).prop_map(move |inits| {
+        let decls = names
+            .iter()
+            .zip(inits)
+            .map(|(name, init)| declarator(name, init))
+            .collect();
+        GenItem::Group {
+            item: ModuleItem::Stmt(Stmt::Decl(const_var(decls))),
+            bindings: names.clone(),
+        }
+    })
+}
+
+/// One top-level item with a globally-unique binding name prefix `n{slot}`.
+fn item_strategy(slot: usize) -> impl Strategy<Value = GenItem> {
+    let single = single_item_strategy(format!("n{slot}b0"));
+    // Group declarations always introduce 2-3 declarators so the group path is
+    // exercised with multiple `NameBindingMember`s.
+    let group = (2usize..4).prop_flat_map(move |count| {
+        group_item_strategy((0..count).map(|i| format!("n{slot}b{i}")).collect())
+    });
+    prop_oneof![3 => single, 1 => group]
+}
+
 proptest! {
     #![proptest_config(ProptestConfig { cases: 96, ..ProptestConfig::default() })]
 
     #[test]
     fn minimized_selector_uniquely_matches_target(
-        bodies in prop::collection::vec(prop::collection::vec(stmt_strategy(), 1..4), 2..5),
+        items in (2usize..6).prop_flat_map(|count| {
+            (0..count).map(item_strategy).collect::<Vec<_>>()
+        }),
         target in any::<Index>(),
+        group_drop in any::<Index>(),
     ) {
-        let target_idx = target.index(bodies.len());
+        let target_idx = target.index(items.len());
+        let target_item = &items[target_idx];
+
+        // The bindings that this case will assert resolve uniquely: a single
+        // binding for `Single` items, or a 2+-binding subset for `Group` items.
+        let target_bindings: Vec<String> = match target_item {
+            GenItem::Single { binding, .. } => vec![binding.clone()],
+            GenItem::Group { bindings, .. } => {
+                // Keep at least 2 declarators in the group (drop at most one) so
+                // `synthesize_simplest_selector_for_group` runs with multiple
+                // `NameBindingMember`s on the multi-declarator path.
+                if bindings.len() > 2 {
+                    let drop = group_drop.index(bindings.len());
+                    bindings
+                        .iter()
+                        .enumerate()
+                        .filter(|(idx, _)| *idx != drop)
+                        .map(|(_, name)| name.clone())
+                        .collect()
+                } else {
+                    bindings.clone()
+                }
+            }
+        };
+
         let module = Module {
             span: DUMMY_SP,
-            body: bodies
-                .into_iter()
-                .enumerate()
-                .map(|(idx, body)| function_decl(&format!("f{idx}"), body))
-                .collect(),
+            body: items.iter().map(|item| match item {
+                GenItem::Single { item, .. } | GenItem::Group { item, .. } => item.clone(),
+            }).collect(),
             shebang: None,
         };
         let source = emit_module(&module);
-        let runtime = format!("f{target_idx}");
-        let export = "TargetBinding";
 
         let outcome: Result<(), TestCaseError> = js_ast::with_swc_globals(|| {
             let parsed = js_ast::parse_js_module_consuming("<proptest>", source.clone())
@@ -244,40 +441,73 @@ proptest! {
 
             let decl_idx = index
                 .binding_to_decl
-                .get(&runtime)
+                .get(&target_bindings[0])
                 .and_then(|decls| decls.first())
                 .copied()
-                .expect("generated chunk declares the target function");
+                .expect("generated chunk declares the target binding");
             let expected_body_idx = index.decls[decl_idx].body_idx;
 
-            let members = [NameBindingMember {
-                member_index: 0,
-                export_name: export.to_string(),
-                binding_name: runtime.clone(),
-                comment: None,
-            }];
+            // Distinct synthetic export names per group member, in binding order.
+            let members: Vec<NameBindingMember> = target_bindings
+                .iter()
+                .enumerate()
+                .map(|(member_index, binding)| NameBindingMember {
+                    member_index,
+                    export_name: format!("Export{member_index}"),
+                    binding_name: binding.clone(),
+                    comment: None,
+                })
+                .collect();
 
             // An ambiguous chunk (two alpha-identical declarations) cannot be
             // pinned even by the exact selector; the synthesizer errors and
             // there is nothing to assert.
-            let Ok(group) = synthesize_simplest_selector_for_group(&index, decl_idx, &members, true)
+            let Ok(group) =
+                synthesize_simplest_selector_for_group(&index, decl_idx, &members, true)
             else {
                 return Ok(());
             };
 
-            let matched = matched_body_indices(&index, export, &group.match_source).map_err(|err| {
-                TestCaseError::fail(format!(
-                    "synthesized selector failed to re-match: {err}\nselector:\n{}\nchunk:\n{source}",
-                    group.match_source
-                ))
-            })?;
-            prop_assert_eq!(
-                &matched,
-                &BTreeSet::from([expected_body_idx]),
-                "selector did not uniquely resolve the target\nselector:\n{}\nchunk:\n{}",
-                group.match_source,
-                source
-            );
+            if members.len() == 1 {
+                let export = &members[0].export_name;
+                let matched = matched_body_indices(&index, export, &group.match_source)
+                    .map_err(|err| {
+                        TestCaseError::fail(format!(
+                            "synthesized selector failed to re-match: {err}\nselector:\n{}\nchunk:\n{source}",
+                            group.match_source
+                        ))
+                    })?;
+                prop_assert_eq!(
+                    &matched,
+                    &BTreeSet::from([expected_body_idx]),
+                    "selector did not uniquely resolve the target\nselector:\n{}\nchunk:\n{}",
+                    group.match_source,
+                    source
+                );
+            } else {
+                // Each member of the group must, on its own, re-match uniquely
+                // to the shared declaration. The matcher resolves one member at
+                // a time (target_binding = that export), so verifying every
+                // member proves the whole group pins the right declaration.
+                for member in &members {
+                    let matched =
+                        matched_body_indices(&index, &member.export_name, &group.match_source)
+                            .map_err(|err| {
+                                TestCaseError::fail(format!(
+                                    "group selector failed to re-match member `{}`: {err}\nselector:\n{}\nchunk:\n{source}",
+                                    member.export_name, group.match_source
+                                ))
+                            })?;
+                    prop_assert_eq!(
+                        &matched,
+                        &BTreeSet::from([expected_body_idx]),
+                        "group selector did not uniquely resolve member `{}`\nselector:\n{}\nchunk:\n{}",
+                        member.export_name,
+                        group.match_source,
+                        source
+                    );
+                }
+            }
             Ok(())
         });
         outcome?;

--- a/devinfra/js/debundle/selector_minimizer_proptest.rs
+++ b/devinfra/js/debundle/selector_minimizer_proptest.rs
@@ -1,23 +1,25 @@
 //! Property: every selector the minimizer synthesizes, re-matched against the
 //! original chunk, resolves uniquely to the intended target binding (gate 1).
 //!
-//! Each case generates a small chunk of same-arity function declarations whose
-//! bodies are built from a spec that maps onto the AST shapes the retention
-//! renderer branches on — numeric/string literals, method calls with multiple
-//! arguments, and object-literal arguments. The spec is rendered to JS and
-//! parsed so the minimizer sees real source spans (it reads original text via
-//! `source_for_span`), exactly as in production. We synthesize a minimized
-//! selector for one target, then *independently* re-run the production matcher
-//! on the produced `match_source`: the synthesizer proves uniqueness
-//! internally, and this verifies that guarantee end-to-end across the input
-//! space the golden fixtures only sample by hand. Bounded for CI; override with
-//! `bbr test //devinfra/js/debundle:selector_codemod_test
-//! --test_env=PROPTEST_CASES=2000`.
+//! Cases build chunks of same-arity function declarations as real `swc_ecma_ast`
+//! nodes (the call / literal / object shapes the retention renderer branches on),
+//! serialize them with swc's own codegen, and feed the resulting source into the
+//! minimizer — which parses it exactly as in production, so spans are real. The
+//! synthesized `match_source` is then independently re-run through the production
+//! matcher: the synthesizer proves uniqueness internally, and this verifies that
+//! guarantee end-to-end across the input space the golden fixtures only sample by
+//! hand. Bounded for CI; override with `bbr test
+//! //devinfra/js/debundle:selector_codemod_test --test_env=PROPTEST_CASES=2000`.
 
 use std::collections::BTreeSet;
 
 use proptest::prelude::*;
 use proptest::sample::Index;
+use swc_common::sync::Lrc;
+use swc_common::{DUMMY_SP, SourceMap, SyntaxContext};
+use swc_ecma_ast::*;
+use swc_ecma_codegen::text_writer::JsWriter;
+use swc_ecma_codegen::{Config, Emitter};
 
 use super::{
     ChunkSelectorIndex, NameBindingMember, matched_body_indices,
@@ -28,106 +30,189 @@ const METHODS: [&str; 3] = ["foo", "bar", "baz"];
 const STRINGS: [&str; 3] = ["alpha", "beta", "gamma"];
 const KEYS: [&str; 3] = ["kind", "mode", "size"];
 
-#[derive(Debug, Clone)]
-enum ArgSpec {
-    Num(u8),
-    Str(u8),
-    Obj { key_id: u8, value: u8 },
+fn ident(name: &str) -> Ident {
+    Ident::new_no_ctxt(name.into(), DUMMY_SP)
 }
 
-#[derive(Debug, Clone)]
-struct CallSpec {
-    recv_a: bool,
-    method_id: u8,
-    args: Vec<ArgSpec>,
+fn ident_expr(name: &str) -> Expr {
+    Expr::Ident(ident(name))
 }
 
-#[derive(Debug, Clone)]
-enum StmtSpec {
-    ConstNum { value: u8 },
-    ConstStr { value_id: u8 },
-    ConstCall(CallSpec),
-    CallStmt(CallSpec),
-    Return,
+fn num(value: u8) -> Expr {
+    Expr::Lit(Lit::Num(Number {
+        span: DUMMY_SP,
+        value: f64::from(value),
+        raw: None,
+    }))
 }
 
-fn arg_strategy() -> impl Strategy<Value = ArgSpec> {
+fn string(value: &str) -> Expr {
+    Expr::Lit(Lit::Str(Str {
+        span: DUMMY_SP,
+        value: value.into(),
+        raw: None,
+    }))
+}
+
+fn member(obj: Expr, prop: &str) -> Expr {
+    Expr::Member(MemberExpr {
+        span: DUMMY_SP,
+        obj: Box::new(obj),
+        prop: MemberProp::Ident(IdentName::new(prop.into(), DUMMY_SP)),
+    })
+}
+
+fn call(callee: Expr, args: Vec<Expr>) -> Expr {
+    Expr::Call(CallExpr {
+        span: DUMMY_SP,
+        ctxt: SyntaxContext::empty(),
+        callee: Callee::Expr(Box::new(callee)),
+        args: args
+            .into_iter()
+            .map(|expr| ExprOrSpread {
+                spread: None,
+                expr: Box::new(expr),
+            })
+            .collect(),
+        type_args: None,
+    })
+}
+
+fn object(entries: Vec<(&str, Expr)>) -> Expr {
+    Expr::Object(ObjectLit {
+        span: DUMMY_SP,
+        props: entries
+            .into_iter()
+            .map(|(key, value)| {
+                PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
+                    key: PropName::Ident(IdentName::new(key.into(), DUMMY_SP)),
+                    value: Box::new(value),
+                })))
+            })
+            .collect(),
+    })
+}
+
+fn const_decl(init: Expr) -> Stmt {
+    Stmt::Decl(Decl::Var(Box::new(VarDecl {
+        span: DUMMY_SP,
+        ctxt: SyntaxContext::empty(),
+        kind: VarDeclKind::Const,
+        declare: false,
+        decls: vec![VarDeclarator {
+            span: DUMMY_SP,
+            name: Pat::Ident(BindingIdent {
+                id: ident("v"),
+                type_ann: None,
+            }),
+            init: Some(Box::new(init)),
+            definite: false,
+        }],
+    })))
+}
+
+fn function_decl(name: &str, mut body: Vec<Stmt>) -> ModuleItem {
+    assign_unique_const_names(&mut body);
+    ModuleItem::Stmt(Stmt::Decl(Decl::Fn(FnDecl {
+        ident: ident(name),
+        declare: false,
+        function: Box::new(Function {
+            params: vec![param("a"), param("b")],
+            decorators: vec![],
+            span: DUMMY_SP,
+            ctxt: SyntaxContext::empty(),
+            body: Some(BlockStmt {
+                span: DUMMY_SP,
+                ctxt: SyntaxContext::empty(),
+                stmts: body,
+            }),
+            is_generator: false,
+            is_async: false,
+            type_params: None,
+            return_type: None,
+        }),
+    })))
+}
+
+fn param(name: &str) -> Param {
+    Param {
+        span: DUMMY_SP,
+        decorators: vec![],
+        pat: Pat::Ident(BindingIdent {
+            id: ident(name),
+            type_ann: None,
+        }),
+    }
+}
+
+/// Give every generated `const` a slot-unique name so the emitted body never
+/// redeclares a `const` (which would fail to re-parse).
+fn assign_unique_const_names(stmts: &mut [Stmt]) {
+    let mut slot = 0;
+    for stmt in stmts {
+        if let Stmt::Decl(Decl::Var(var)) = stmt {
+            for declarator in &mut var.decls {
+                if let Pat::Ident(binding) = &mut declarator.name {
+                    binding.id = ident(&format!("v{slot}"));
+                    slot += 1;
+                }
+            }
+        }
+    }
+}
+
+fn emit_module(module: &Module) -> String {
+    let cm: Lrc<SourceMap> = Lrc::default();
+    let mut buf = Vec::new();
+    {
+        let mut emitter = Emitter {
+            cfg: Config::default(),
+            cm: cm.clone(),
+            comments: None,
+            wr: JsWriter::new(cm, "\n", &mut buf, None),
+        };
+        emitter.emit_module(module).expect("emit generated module");
+    }
+    String::from_utf8(buf).expect("emitted module is utf-8")
+}
+
+fn arg_strategy() -> impl Strategy<Value = Expr> {
     prop_oneof![
-        (0u8..4).prop_map(ArgSpec::Num),
-        (0u8..3).prop_map(ArgSpec::Str),
-        (0u8..3, 0u8..4).prop_map(|(key_id, value)| ArgSpec::Obj { key_id, value }),
+        (0u8..4).prop_map(num),
+        (0usize..STRINGS.len()).prop_map(|idx| string(STRINGS[idx])),
+        (0usize..KEYS.len(), 0u8..4).prop_map(|(key, value)| object(vec![(KEYS[key], num(value))])),
     ]
 }
 
-fn call_strategy() -> impl Strategy<Value = CallSpec> {
+fn call_strategy() -> impl Strategy<Value = Expr> {
     (
         any::<bool>(),
-        0u8..3,
+        0usize..METHODS.len(),
         prop::collection::vec(arg_strategy(), 0..3),
     )
-        .prop_map(|(recv_a, method_id, args)| CallSpec {
-            recv_a,
-            method_id,
-            args,
+        .prop_map(|(recv_a, method, args)| {
+            call(
+                member(ident_expr(if recv_a { "a" } else { "b" }), METHODS[method]),
+                args,
+            )
         })
 }
 
-fn stmt_strategy() -> impl Strategy<Value = StmtSpec> {
+fn stmt_strategy() -> impl Strategy<Value = Stmt> {
     prop_oneof![
-        (0u8..4).prop_map(|value| StmtSpec::ConstNum { value }),
-        (0u8..3).prop_map(|value_id| StmtSpec::ConstStr { value_id }),
-        call_strategy().prop_map(StmtSpec::ConstCall),
-        call_strategy().prop_map(StmtSpec::CallStmt),
-        Just(StmtSpec::Return),
+        (0u8..4).prop_map(|value| const_decl(num(value))),
+        (0usize..STRINGS.len())
+            .prop_map(|idx| const_decl(call(ident_expr("mk"), vec![string(STRINGS[idx])]))),
+        call_strategy().prop_map(|expr| Stmt::Expr(ExprStmt {
+            span: DUMMY_SP,
+            expr: Box::new(expr),
+        })),
+        call_strategy().prop_map(const_decl),
+        Just(Stmt::Return(ReturnStmt {
+            span: DUMMY_SP,
+            arg: Some(Box::new(ident_expr("a"))),
+        })),
     ]
-}
-
-fn render_arg(arg: &ArgSpec) -> String {
-    match arg {
-        ArgSpec::Num(value) => value.to_string(),
-        ArgSpec::Str(value_id) => format!("\"{}\"", STRINGS[*value_id as usize]),
-        ArgSpec::Obj { key_id, value } => format!("{{ {}: {value} }}", KEYS[*key_id as usize]),
-    }
-}
-
-fn render_call(call: &CallSpec) -> String {
-    let recv = if call.recv_a { "a" } else { "b" };
-    let args = call
-        .args
-        .iter()
-        .map(render_arg)
-        .collect::<Vec<_>>()
-        .join(", ");
-    format!("{recv}.{}({args})", METHODS[call.method_id as usize])
-}
-
-fn render_stmt(spec: &StmtSpec, slot: usize) -> String {
-    match spec {
-        StmtSpec::ConstNum { value } => format!("const v{slot} = {value};"),
-        StmtSpec::ConstStr { value_id } => {
-            format!("const v{slot} = mk(\"{}\");", STRINGS[*value_id as usize])
-        }
-        StmtSpec::ConstCall(call) => format!("const v{slot} = {};", render_call(call)),
-        StmtSpec::CallStmt(call) => format!("{};", render_call(call)),
-        StmtSpec::Return => "return a;".to_string(),
-    }
-}
-
-fn render_chunk(items: &[Vec<StmtSpec>]) -> String {
-    items
-        .iter()
-        .enumerate()
-        .map(|(idx, stmts)| {
-            let body = stmts
-                .iter()
-                .enumerate()
-                .map(|(slot, stmt)| format!("  {}", render_stmt(stmt, slot)))
-                .collect::<Vec<_>>()
-                .join("\n");
-            format!("function f{idx}(a, b) {{\n{body}\n}}")
-        })
-        .collect::<Vec<_>>()
-        .join("\n\n")
 }
 
 proptest! {
@@ -135,11 +220,21 @@ proptest! {
 
     #[test]
     fn minimized_selector_uniquely_matches_target(
-        items in prop::collection::vec(prop::collection::vec(stmt_strategy(), 1..4), 2..5),
+        bodies in prop::collection::vec(prop::collection::vec(stmt_strategy(), 1..4), 2..5),
         target in any::<Index>(),
     ) {
-        let source = render_chunk(&items);
-        let runtime = format!("f{}", target.index(items.len()));
+        let target_idx = target.index(bodies.len());
+        let module = Module {
+            span: DUMMY_SP,
+            body: bodies
+                .into_iter()
+                .enumerate()
+                .map(|(idx, body)| function_decl(&format!("f{idx}"), body))
+                .collect(),
+            shebang: None,
+        };
+        let source = emit_module(&module);
+        let runtime = format!("f{target_idx}");
         let export = "TargetBinding";
 
         let outcome: Result<(), TestCaseError> = js_ast::with_swc_globals(|| {

--- a/devinfra/js/debundle/source_match.rs
+++ b/devinfra/js/debundle/source_match.rs
@@ -19,45 +19,14 @@ use swc_common::{EqIgnoreSpan, SyntaxContext};
 use swc_ecma_ast::*;
 use swc_ecma_visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 
-/// Syntactic-hole keywords. For single-node holes, the **bare keyword**
-/// is the anonymous form: it matches independently at every occurrence
-/// and never binds, so authors don't have to mint a unique name per
-/// throwaway placeholder. A `<keyword>_<name>` identifier is the
-/// **named** form, which binds for cross-occurrence equality — the same
-/// name must match the same subtree/statement everywhere it appears.
-///
-/// `EXPR` matches one arbitrary expression and `STMT` one arbitrary
-/// statement. `ARGS`, `STMT_LIST`, `OBJECT_PROPS`, `CLASS_REST`, and
-/// `DECLARATORS` are variable-length list holes (see
-/// [`AstWildcardMatcher::match_list_with_holes`]): `ARGS` absorbs a run
-/// of call/new arguments, `STMT_LIST` absorbs a run of block statements
-/// (or top-level anonymous selector statements), `OBJECT_PROPS` absorbs
-/// a run of object literal properties/spreads, `CLASS_REST` absorbs a run
-/// of class members, and `DECLARATORS` absorbs a run of variable
-/// declarators inside one `var`/`let`/`const` declaration. List-hole suffixes
-/// are labels for readability; they do not bind the absorbed sequence for
-/// cross-occurrence equality.
-///
-/// `ANYTHING` is parse-position polymorphic sugar for the anonymous
-/// typed hole at positions where plain JavaScript can parse it. In an
-/// expression position it behaves like `EXPR`; as a bare expression
-/// statement it behaves like `STMT`; as a variable declarator name it
-/// behaves like `DECLARATORS`; as a non-declarator binding pattern it
-/// matches any pattern; as an object-literal shorthand property it
-/// absorbs object properties/spreads; as a class field with no initializer
-/// it behaves like `CLASS_REST`. Use the typed spellings when a named
-/// hole is helpful or when the position would otherwise be ambiguous.
-/// `STMT_LIST` must be checked before `STMT`, since `STMT` is a
-/// keyword-prefix of it.
-const ANYTHING_HOLE_KEYWORD: &str = "ANYTHING";
-const EXPR_HOLE_KEYWORD: &str = "EXPR";
-const STMT_HOLE_KEYWORD: &str = "STMT";
-const STMT_LIST_HOLE_KEYWORD: &str = "STMT_LIST";
-const CLASS_REST_HOLE_KEYWORD: &str = "CLASS_REST";
-const DECLARATORS_HOLE_KEYWORD: &str = "DECLARATORS";
-const ARGS_HOLE_KEYWORD: &str = "ARGS";
-const OBJECT_PROPS_HOLE_KEYWORD: &str = "OBJECT_PROPS";
-const STRING_LITERAL_REGEX_PREDICATE: &str = "STR_LITERAL_MATCHING_RE";
+// Syntactic-hole keyword vocabulary lives in `source_match_holes` so the
+// matcher, the `selector_codemod` minimizer, and `selector_candidate_index`
+// share one spelling. See that module's docs for the hole language.
+use source_match_holes::{
+    ANYTHING_HOLE_KEYWORD, ARGS_HOLE_KEYWORD, CLASS_REST_HOLE_KEYWORD, DECLARATORS_HOLE_KEYWORD,
+    EXPR_HOLE_KEYWORD, OBJECT_PROPS_HOLE_KEYWORD, STMT_HOLE_KEYWORD, STMT_LIST_HOLE_KEYWORD,
+    STRING_LITERAL_REGEX_PREDICATE, hole_name_for,
+};
 
 const SOURCE_MATCH_TIMINGS_ENV: &str = "DUCKTAPE_SOURCE_MATCH_TIMINGS";
 const SOURCE_MATCH_TIMING_THRESHOLD_ENV: &str = "DUCKTAPE_SOURCE_MATCH_TIMING_THRESHOLD_MS";
@@ -6284,15 +6253,6 @@ fn object_property_list_hole_name(prop_or_spread: &PropOrSpread) -> Option<&str>
     };
     hole_name_for(ident.sym.as_ref(), OBJECT_PROPS_HOLE_KEYWORD)
         .or_else(|| anything_hole_name(ident.sym.as_ref()))
-}
-
-/// If `name` is a hole identifier for `keyword` — the bare keyword
-/// (anonymous) or a `<keyword>_<suffix>` (named) form — return it. The
-/// keyword must be followed by end-of-string or `_`, so `EXPR` and
-/// `EXPR_FOO` match for keyword `EXPR` but `EXPRESSION` does not.
-fn hole_name_for<'a>(name: &'a str, keyword: &str) -> Option<&'a str> {
-    let rest = name.strip_prefix(keyword)?;
-    (rest.is_empty() || rest.starts_with('_')).then_some(name)
 }
 
 fn anything_hole_name(name: &str) -> Option<&str> {

--- a/devinfra/js/debundle/source_match_holes.rs
+++ b/devinfra/js/debundle/source_match_holes.rs
@@ -1,0 +1,59 @@
+//! Syntactic-hole keyword vocabulary shared across the source-match language.
+//!
+//! `source_match` interprets these holes when resolving selectors, the
+//! `selector_codemod` minimizer emits them when rendering candidate
+//! selectors, and `selector_candidate_index` recognizes them when building
+//! its prefilter. Keeping the keyword spellings in one place stops producer
+//! and consumer code from drifting apart on string literals.
+//!
+//! For single-node holes, the **bare keyword** is the anonymous form: it
+//! matches independently at every occurrence and never binds, so authors
+//! don't have to mint a unique name per throwaway placeholder. A
+//! `<keyword>_<name>` identifier is the **named** form, which binds for
+//! cross-occurrence equality — the same name must match the same
+//! subtree/statement everywhere it appears.
+//!
+//! `EXPR` matches one arbitrary expression and `STMT` one arbitrary
+//! statement. `ARGS`, `STMT_LIST`, `OBJECT_PROPS`, `CLASS_REST`, and
+//! `DECLARATORS` are variable-length list holes: `ARGS` absorbs a run of
+//! call/new arguments, `STMT_LIST` absorbs a run of block statements (or
+//! top-level anonymous selector statements), `OBJECT_PROPS` absorbs a run of
+//! object literal properties/spreads, `CLASS_REST` absorbs a run of class
+//! members, and `DECLARATORS` absorbs a run of variable declarators inside
+//! one `var`/`let`/`const` declaration. List-hole suffixes are labels for
+//! readability; they do not bind the absorbed sequence for cross-occurrence
+//! equality.
+//!
+//! `ANYTHING` is parse-position polymorphic sugar for the anonymous typed
+//! hole at positions where plain JavaScript can parse it. In an expression
+//! position it behaves like `EXPR`; as a bare expression statement it behaves
+//! like `STMT`; as a variable declarator name it behaves like `DECLARATORS`;
+//! as a non-declarator binding pattern it matches any pattern; as an
+//! object-literal shorthand property it absorbs object properties/spreads; as
+//! a class field with no initializer it behaves like `CLASS_REST`. Use the
+//! typed spellings when a named hole is helpful or when the position would
+//! otherwise be ambiguous. `STMT_LIST` must be checked before `STMT`, since
+//! `STMT` is a keyword-prefix of it.
+
+pub const ANYTHING_HOLE_KEYWORD: &str = "ANYTHING";
+pub const EXPR_HOLE_KEYWORD: &str = "EXPR";
+pub const STMT_HOLE_KEYWORD: &str = "STMT";
+pub const STMT_LIST_HOLE_KEYWORD: &str = "STMT_LIST";
+pub const CLASS_REST_HOLE_KEYWORD: &str = "CLASS_REST";
+pub const DECLARATORS_HOLE_KEYWORD: &str = "DECLARATORS";
+pub const ARGS_HOLE_KEYWORD: &str = "ARGS";
+pub const OBJECT_PROPS_HOLE_KEYWORD: &str = "OBJECT_PROPS";
+
+/// Callee name of the string-literal regex predicate sugar
+/// `STR_LITERAL_MATCHING_RE("<pattern>")`, which matches a string literal
+/// whose value matches the given pattern instead of an exact spelling.
+pub const STRING_LITERAL_REGEX_PREDICATE: &str = "STR_LITERAL_MATCHING_RE";
+
+/// If `name` is the bare `keyword` or a named `<keyword>_<suffix>` hole,
+/// returns `name`; otherwise `None`. A trailing segment must start with `_`
+/// so that distinct keywords sharing a prefix (`STMT` vs `STMT_LIST`) never
+/// alias.
+pub fn hole_name_for<'a>(name: &'a str, keyword: &str) -> Option<&'a str> {
+    let rest = name.strip_prefix(keyword)?;
+    (rest.is_empty() || rest.starts_with('_')).then_some(name)
+}


### PR DESCRIPTION
Builds on the PR 2250/2251 work (selector candidate index + recursive minimizer start) into a working minimizer for `debundle spec synthesize-selectors`.

## What this does
Turns rebuild-fragile `binding.name` minified-name pins into minimal, forward-compatible structural `source_match` / `binding_groups` selectors: keep the meaningful, stable anchors (literals, method/callee names, config `key: value`s) that uniquely identify the target among its chunk siblings; hole the incidental/volatile rest (`ANYTHING`/`STMT_LIST`/`OBJECT_PROPS`/`CLASS_REST`/`DECLARATORS_*`).

## Architecture
- **Holing is an AST→AST prune, not a hand-written serializer.** `hole_expr`/`hole_stmts`/`hole_object`/`hole_class_members` clone the target's swc subtree and drop in marker nodes; the selector is serialized by swc codegen (`js_ast::emit_module_source`). Selector and code are the same AST.
- **Anchor selection** is a tiered minimum set cover (`cover_competitors` + `min_set_cover` B&B): shallow literals → structural key/member presence → deeper literals. Each anchor's exclusion set comes from the production matcher, so discrimination is exact; the chosen union is proven once.
- Covers function bodies, object literals, class bodies, var declarator groups, and group-vs-standalone partitioning.
- Source-match hole keyword constants factored into a shared `source_match_holes` library.

## Tests
- `selector_minimizer_expectation_test`: 7/7 motivating cases, compared **through swc** (parse + re-emit, so formatting-agnostic).
- `selector_codemod_test`: swc-native property test (gate 1: every synthesized selector re-matches uniquely to the intended target).
- `selector_codemod_cli_test` green (anchor-quality guarantees preserved).

## Dogfood
First run over a large real spec (see `debug/selector_minimizer_dogfood.md`): ~84% of name-pins convert to proven structural selectors. Follow-ups in flight: whole-document-serde apply (replacing the buggy text-edit path), path unification + legacy-renderer retirement, `perf`-pinpointed index-prefilter for scale, a `--full-ast-fallback` (default off) switch, and broader property coverage.

https://claude.ai/code/session_01RYUAvJefa2eJRgZ7XBfqxA

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYUAvJefa2eJRgZ7XBfqxA)_