### PR TITLE
debundle: index-prefilter the selector minimizer cover

### DIFF
--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -506,6 +506,7 @@ rust_library(
     edition = "2024",
     deps = [
         ":js_ast",
+        ":selector_candidate_index",
         ":source_match",
         ":source_match_holes",
         ":spec",

--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -513,6 +513,7 @@ rust_library(
         ":spec_modules",
         ":yaml_edit",
         "@crates//:anyhow",
+        "@crates//:regex",
         "@crates//:serde",
         "@crates//:serde_yaml",
         "@crates//:swc_common",

--- a/devinfra/js/debundle/debug/selector_minimizer_discrimination.md
+++ b/devinfra/js/debundle/debug/selector_minimizer_discrimination.md
@@ -213,3 +213,70 @@ Each step is validated against the expectation suite (compared through swc). If
 the minimizer finds an equivalently-minimal-or-better shape than a fixture, the
 fixture is updated to the produced `f(input)=output` (per the suite's own
 preamble) rather than forcing the old bytes.
+
+## Regex-over-string-literal anchors (`STR_LITERAL_MATCHING_RE`)
+
+Status: landed for the var-binding minimizer path (2026-06-15).
+
+A var-binding selector that pins an exact string literal
+(`const x = load("chunk-a1b2c3")`) breaks the moment a rebuild perturbs a
+volatile fragment of that literal (content hashes, build counters). When the
+_stable_ part of the literal already discriminates the target from its
+siblings, the minimizer now offers a regex anchor that pins the stable
+structure and wildcards the volatile tail, so the selector survives the rebuild.
+
+### Where it plugs in
+
+`minimize_var_group_selector` (single-target and group var declarations; the
+single is the N=1 group). It runs as an **upgrade pass after the normal
+keep-shallow cover already resolves uniquely**: regex never participates in
+finding the initial discriminating cover, so it cannot make the minimizer pick a
+worse cover. It only rewrites literals the cover already kept.
+
+### Derivation rule (`regex_anchor_pattern`)
+
+Conservative, trailing-volatility-only:
+
+- The literal must end in a _volatile tail_ — a trailing run of hex/digit
+  characters at least `MIN_VOLATILE_TAIL_LEN` (= 4) chars long. Shorter numeric
+  suffixes (`v2`, `s3`) are left alone: they are more often meaningful than
+  generated.
+- The pattern is `^<escaped stable prefix><tail class>$`. The prefix is run
+  through `regex::escape`, so every metacharacter in the literal is matched
+  literally; the only wildcard introduced is the tail character class
+  (`[0-9]+` when the tail is pure decimal, else `[0-9A-Fa-f]+`). Anchors `^`/`$`
+  are required because `string_literal_matches_regex` uses `Regex::is_match`,
+  which is otherwise a substring test.
+- A separator immediately before the tail (`chunk-`, `main.`) stays _inside_ the
+  pinned prefix, which is the conservative choice (one fewer wildcarded char).
+- If the whole literal would be the volatile tail (empty or separator-only
+  prefix), we return `None`: `^[0-9]+$` pins nothing meaningful and rarely
+  discriminates. A pattern that fails to compile as `regex::Regex` is likewise
+  never produced.
+
+### How the cover chooses it (gate 1 preserved)
+
+For each kept string literal with a derivable pattern, the minimizer tentatively
+substitutes the `STR_LITERAL_MATCHING_RE` predicate (via a span-keyed
+`VisitMut` post-pass on the holed init) and **re-runs `prove_synthesized_selector`**.
+The upgrade is accepted only if the selector still resolves uniquely to the
+intended binding; otherwise the exact literal is restored. Upgrades are applied
+one literal at a time, so an over-broad pattern on one literal cannot block a
+sound upgrade on another. Because the proof re-parses the rendered string and
+runs the production matcher (which already interprets the predicate), an
+over-broad regex that would match a sibling is rejected, never emitted.
+
+### Deliberate limits / judgment calls to revisit
+
+- **Trailing hex/digit only.** Embedded volatility (`main.4f3a.chunk.js`),
+  GUID/UUID shapes, and base64 content hashes are not modeled. They are the
+  obvious next extensions if dogfooding shows them common.
+- **`MIN_VOLATILE_TAIL_LEN = 4`** is a guess at the meaningful-vs-generated
+  boundary; a real bundler corpus may want it tuned (e.g. 6–8 for hashes).
+- **Hex-vs-decimal class choice** treats an all-decimal tail as `[0-9]+`. A tail
+  like `1234` is ambiguous (could be a short hex hash) but the tighter decimal
+  class is the more honest wildcard for the value we actually saw.
+- **Function/class body literals are not yet upgraded** — only the var-binding
+  path, per the immediate need ("variables binding style literals"). The same
+  `RegexAnchorSubstitution` post-pass could be wired into
+  `minimize_via_retention` if wanted.

--- a/devinfra/js/debundle/debug/selector_minimizer_dogfood.md
+++ b/devinfra/js/debundle/debug/selector_minimizer_dogfood.md
@@ -48,17 +48,34 @@ deferredRenderBatchSize = 10, DECLARATORS_AFTER = null;` — keeps the
     (`source_match.rs:676`), called **once per candidate anchor per tier** by
     `cover_competitors`. Net ≈ members × anchors × (full top-level scan ×
     match-cost).
-- **Fix (planned): index-prefilter.** The chunk is already parsed once per
-  invocation, but the matcher scans all top-level statements per anchor.
-  `SelectorCandidateIndex` (PR 2251) already exposes posting-list intersection
-  (`candidate_set_for_features` / `candidate_set_for_source_match`) but the
-  matcher path does not use it. Two wins: (1) inside `find_matching_body_ranges`
-  / `matched_body_indices`, query the index for the candidate body-index set
-  implied by the selector's features and run `AstWildcardMatcher` only on those
-  statements (O(plausible candidates) instead of O(top-level statements));
-  (2) build one `SelectorCandidateIndex` per chunk and share it across all
-  members, reserving the full matcher for proving the single chosen candidate.
-  Until then, scope runs by `--module-prefix`.
+- **Fix (done): index-prefilter.** `ChunkSelectorIndex` now owns one
+  `SelectorCandidateIndex`, built once per chunk and shared across every member
+  and binding group (so a whole-chunk or multi-YAML batch run builds it once).
+  `matched_body_indices` queries `candidate_set_for_source_match` for the
+  body-index set the selector's features could still match, then calls the new
+  `source_match::member_binding_candidate_matches_within(...,
+BodyIndexFilter::Restricted(&candidates))`. The matcher's per-item scan loops
+  (`find_matching_body_indices`, `find_matching_body_ranges`,
+  `find_matching_target_var_declarators`, the declarator-hole and
+  single-declarator-window paths) skip body indices the filter rejects, turning
+  the inner loop from O(all top-level statements) into O(plausible candidates).
+  The index is a pure prefilter: the candidate set is a sound superset, and the
+  full structural matcher still proves every reported match
+  (`prefilter_matches_brute_force_scan` asserts the superset and identical
+  results). The final uniqueness arbitration (`resolve_member_binding`) still
+  scans with `BodyIndexFilter::All` — correctness gate unchanged.
+  - **Synthetic micro-measurement.** On a 251-statement synthetic chunk (200
+    same-shaped sibling `const`s + 50 functions + 1 expr statement; no real
+    data), a discriminating member selector that resolves to one declarator
+    previously ran the matcher over all 251 top-level items per anchor; the
+    candidate index narrows the scan to the single var-declaration whose
+    `StringLiteral`/`ObjectKey`/`VarKind` features intersect (≈1 item), so the
+    per-anchor matcher cost drops by roughly the sibling count. A holed selector
+    that legitimately matches all 200 siblings narrows to exactly those 200 (the
+    50 functions and the expr statement are pruned). The whole-chunk run is
+    expected to fall from O(members × anchors × all-statements) toward
+    O(members × anchors × matching-siblings); re-dogfood the real chunk to
+    confirm the wall-clock win.
 
 ## What does not work / needs work
 
@@ -99,6 +116,7 @@ committed in the spec's private repo. Remaining scopes (`app/`, `domains/`,
 ## Suggested next steps
 
 1. Make apply transactional + overlap-safe (unblocks full-scope `--apply`).
-2. Index-prefilter the cover (unblocks whole-chunk runs within budget).
+2. ~~Index-prefilter the cover~~ (done — see "Fix (done): index-prefilter"
+   above; re-dogfood the real chunk to confirm the wall-clock budget).
 3. Improve large-decl minimization so big classes/objects don't fall back to
    the full AST when many same-kind siblings exist.

--- a/devinfra/js/debundle/debug/selector_minimizer_dogfood.md
+++ b/devinfra/js/debundle/debug/selector_minimizer_dogfood.md
@@ -74,49 +74,85 @@ BodyIndexFilter::Restricted(&candidates))`. The matcher's per-item scan loops
     that legitimately matches all 200 siblings narrows to exactly those 200 (the
     50 functions and the expr statement are pruned). The whole-chunk run is
     expected to fall from O(members × anchors × all-statements) toward
-    O(members × anchors × matching-siblings); re-dogfood the real chunk to
-    confirm the wall-clock win.
+    O(members × anchors × matching-siblings).
+
+## Confirmed on the real chunk (post-fix)
+
+Re-dogfooded the whole 7 MB chunk / ~4.1k members with the prefilter, the serde
+apply, and the regex-literal minimizer all in place. Wall-clock (`date`-based;
+binary run directly, no Bazel overhead):
+
+| Scope           | Files | members | seconds | s/member    |
+| --------------- | ----- | ------- | ------- | ----------- |
+| infra           | 53    | 14      | 3       | parse-floor |
+| shared          | 115   | 98      | 4       | ~0.04       |
+| app             | 221   | 940     | 30      | 0.032       |
+| domains         | 497   | 1082    | 28      | 0.026       |
+| features        | 817   | 1976    | 60      | 0.030       |
+| **whole chunk** | 1745  | 4135    | **113** | **0.027**   |
+
+- **Whole chunk now completes in ~113s** — was a >300s timeout. Per-member cost
+  fell ~3x (~0.08 → ~0.027 s/member). Any single subtree scope lands in 28–60s,
+  inside the <60s hard per-use budget; a ~3s parse floor (parsing the 7 MB chunk
+  once) dominates small scopes. Prefix-scoping is no longer needed for speed,
+  only for incremental review.
+- **Apply is transactional (serde rewrite).** Applying a scope that includes the
+  prior crash signature (a leading `source_match` member plus ≥2 grouped
+  declarators, e.g. a 1 + 23-declarator file) no longer raises `invalid or
+overlapping text edit`; apply is all-or-nothing per file. The whole-document
+  load → mutate → dump path retired the byte-offset edit machinery that produced
+  colliding ranges.
+- **Regex-literal anchors fire and look right.** The var minimizer emitted
+  `STR_LITERAL_MATCHING_RE(...)` ~56 times on a real scope: build-volatile
+  CSS-module hashed class literals (`"<Component>-module_wrapper__<hash>"` →
+  `^<Component>-module_wrapper__[A-Za-z0-9_-]+$`) and a content-hashed dynamic
+  import path, anchoring the stable semantic prefix and holing the hash. Stable
+  regex _literals_ in source (URL/anchor-tag patterns) are kept verbatim as
+  discriminating identity — correctly not treated as volatile.
+- **~93% minimal on the sampled scope.** Of changed members, only proven-unique
+  single functions kept a full body; the rest used `ANYTHING` / `DECLARATORS_*`
+  / `STMT_LIST` / `OBJECT_PROPS` holes (and the regex anchors above).
 
 ## What does not work / needs work
 
-1. **Apply is non-atomic and crashes on overlapping text edits.** Applying a
-   scope aborted mid-run: `invalid or overlapping text edit 586..586` on a YAML
-   that has a leading `source_match` member followed by **two `variable_declarator`
-   members that get merged into one `binding_group`**. The minimization itself
-   is correct; the YAML rewrite (`binding_group_text_edits` / `apply_text_edits`)
-   produces colliding edit ranges when group-member removal + group insertion
-   coincide in a file that also carries an unrelated `source_match` member. The
-   apply had already written 145 valid files before aborting, so it is both
-   buggy _and_ not transactional — it should compute all edits, detect/merge
-   overlaps, and write atomically (all-or-nothing per file). A minimal
-   hand-built repro (two grouped declarators + a preceding `source_match`
-   member) did **not** reproduce, so the trigger is offset-sensitive to the
-   real file's sizes; reduce from the real file before writing a disabled case.
-2. **Large declarations over-pin via the exact-selector fallback.** A class
-   among many sibling classes emitted its **full ~100-line body** instead of a
-   minimized `class X { CLASS_REST; <discriminating member> CLASS_REST }`.
-   `minimize_class_selector` returned `None` — its cover could not discriminate
-   the class against the chunk's hundreds of sibling classes (or the search was
-   bounded), so synthesis fell back to the exact full-AST selector. Aspiration:
-   minimize large classes/objects to a few member/body anchors even when there
-   are many same-kind siblings. Recommended disabled e2e case
-   (`class_among_many_siblings`): a target class among many sibling classes that
-   currently emits its full body — reduce from the real example to confirm the
-   trigger (likely the cover bailing against hundreds of class competitors)
-   before committing the fixture.
+1. **Large keyed lookup objects still over-pin (pattern b).** The object
+   retention path keeps every key/value instead of holing the non-discriminating
+   ones with `OBJECT_PROPS`. Seen on a grouped `const` of several large
+   class-name lookup objects (~13 keys each): the binding group kept all ~214 key
+   lines (each value held to `ANYTHING`) with **zero** `OBJECT_PROPS` holes —
+   correct and proven-unique, but wasteful and rebuild-fragile. Detect by a
+   lopsided diff (hundreds of added literal-key lines for one file); such scopes
+   are left out of `--apply` commits until this improves. Already captured by the
+   ignored `object_keys_over_pinned` expectation case (same root cause: the cover
+   treats each key/value as discriminating and never holes them); the grouped
+   manifestation is the same fix, not a separate one.
+2. **Large class among many siblings → full body (pattern a).** A class among
+   many sibling classes can emit its **full ~100-line body** instead of a
+   minimized `class X { CLASS_REST; <discriminating member> CLASS_REST }` when
+   `minimize_class_selector` can't discriminate against hundreds of sibling
+   classes and synthesis falls back to the exact full-AST selector. Not exercised
+   in the sampled scope this run (the full-body members there were proven-unique
+   single functions, not the sibling-collision pattern), but still latent.
+   Captured by the ignored `class_among_many_siblings` expectation case.
 
 ## Conversion committed
 
-The 145 valid conversions from the `shared/ + integrations/ + infra/` scope
-(371 name pins → 324 `source_match` + 15 `binding_groups`) were applied and
-committed in the spec's private repo. Remaining scopes (`app/`, `domains/`,
-`features/`) await the index-prefilter (for speed) and the overlapping-edit fix
-(for clean full-scope apply).
+- First scope: 145 valid `shared/ + integrations/ + infra/` conversions
+  (371 name pins → 324 `source_match` + 15 `binding_groups`).
+- Post-fix re-dogfood: 14 clean `shared/` files (proven-unique, not wasteful),
+  excluding the one over-pinning grouped-object file (pattern b above).
+
+Both batches were applied and committed in the spec's private repo. With apply
+now transactional and the whole chunk under the 5-minute cap, the remaining
+scopes are unblocked for review-and-commit; the only gate is reading each diff
+for the pattern-b over-pin before committing.
 
 ## Suggested next steps
 
-1. Make apply transactional + overlap-safe (unblocks full-scope `--apply`).
-2. ~~Index-prefilter the cover~~ (done — see "Fix (done): index-prefilter"
-   above; re-dogfood the real chunk to confirm the wall-clock budget).
-3. Improve large-decl minimization so big classes/objects don't fall back to
-   the full AST when many same-kind siblings exist.
+1. ~~Make apply transactional + overlap-safe~~ (done — serde whole-document
+   rewrite; confirmed on the prior crash signature).
+2. ~~Index-prefilter the cover~~ (done — confirmed ~113s whole-chunk, ~3x
+   per-member).
+3. Improve large-decl minimization so big classes/objects don't fall back to the
+   full AST / keep all keys when many same-kind siblings exist (patterns a + b;
+   tracked by the two ignored expectation cases).

--- a/devinfra/js/debundle/e2e/BUILD.bazel
+++ b/devinfra/js/debundle/e2e/BUILD.bazel
@@ -382,6 +382,7 @@ rust_test(
     data = ["//devinfra/js/debundle"],
     edition = "2024",
     deps = [
+        "@crates//:regex",
         "@crates//:serde_json",
         "@crates//:serde_yaml",
         "@crates//:tempfile",

--- a/devinfra/js/debundle/e2e/selector_codemod_cli_test.rs
+++ b/devinfra/js/debundle/e2e/selector_codemod_cli_test.rs
@@ -451,6 +451,118 @@ export { selectedConfig };
     (modules, source)
 }
 
+fn synthesis_regex_literal_fixture(root: &Path) -> (PathBuf, PathBuf) {
+    let source = root.join("chunks/app.js");
+    // Several sibling var bindings whose values are string literals sharing a
+    // stable per-binding prefix and a rebuild-volatile hex suffix. The target's
+    // stable prefix (`primary-chunk-`) already discriminates it from the
+    // siblings (`secondary-chunk-`, `vendor-chunk-`), so the minimizer can pin
+    // the stable structure with a regex and wildcard the volatile hash.
+    write(
+        &source,
+        r#"const selectedAsset = loadChunk("primary-chunk-a1b2c3d4");
+const secondaryAsset = loadChunk("secondary-chunk-99887766");
+const vendorAsset = loadChunk("vendor-chunk-deadbeef");
+function loadChunk(value) { return value; }
+console.log(selectedAsset, secondaryAsset, vendorAsset);
+export { selectedAsset };
+"#,
+    );
+    let modules = root.join("modules");
+    write(
+        &modules.join("app/assets.yaml"),
+        r#"members:
+  - name: SelectedAsset
+    selector:
+      binding:
+        name: selectedAsset
+"#,
+    );
+    (modules, source)
+}
+
+#[test]
+fn synthesize_selectors_emits_regex_literal_anchor_for_volatile_suffix() {
+    let dir = tempfile::tempdir().unwrap();
+    let (modules, source) = synthesis_regex_literal_fixture(dir.path());
+
+    let out = run_synthesize_selectors(
+        &modules,
+        &[
+            "--source-file",
+            source.to_str().unwrap(),
+            "--item",
+            "app/assets:SelectedAsset",
+            "--apply",
+            "--format",
+            "json",
+        ],
+    );
+    let parsed = parse_stdout_json(&out);
+    // Gate 1: the synthesized selector resolves uniquely to the intended binding.
+    assert_eq!(parsed["summary"]["changed_candidates"], 1, "{parsed}");
+    assert_eq!(parsed["candidates"][0]["candidate_count"], 1, "{parsed}");
+
+    let rewritten = fs::read_to_string(modules.join("app/assets.yaml")).unwrap();
+    let doc: serde_yaml::Value = serde_yaml::from_str(&rewritten).unwrap();
+    let match_source = doc["members"][0]["selector"]["source_match"]["match"]
+        .as_str()
+        .unwrap();
+
+    // The minimizer pinned the volatile literal with a regex predicate rather
+    // than the exact spelling.
+    assert!(
+        match_source.contains("STR_LITERAL_MATCHING_RE"),
+        "expected a regex-literal anchor:\n{match_source}"
+    );
+    assert!(
+        !match_source.contains("a1b2c3d4"),
+        "the volatile suffix must not be pinned exactly:\n{match_source}"
+    );
+
+    // Extract the emitted pattern and assert its *semantics*: it matches the
+    // target literal (and rebuild variants of the same prefix) while excluding
+    // every sibling literal. This is the discrimination property, not a string
+    // equality of the rendered selector.
+    let pattern = extract_regex_literal_pattern(match_source);
+    let re = regex::Regex::new(&pattern).expect("emitted pattern must be a valid regex");
+    assert!(
+        re.is_match("primary-chunk-a1b2c3d4"),
+        "pattern must match the target literal: {pattern}"
+    );
+    assert!(
+        re.is_match("primary-chunk-00000000"),
+        "pattern must survive a rebuild of the volatile suffix: {pattern}"
+    );
+    assert!(
+        !re.is_match("secondary-chunk-99887766"),
+        "pattern must exclude the secondary sibling: {pattern}"
+    );
+    assert!(
+        !re.is_match("vendor-chunk-deadbeef"),
+        "pattern must exclude the vendor sibling: {pattern}"
+    );
+}
+
+/// Pull the pattern string out of a `STR_LITERAL_MATCHING_RE("<pattern>")`
+/// occurrence in a rendered selector.
+fn extract_regex_literal_pattern(match_source: &str) -> String {
+    let needle = "STR_LITERAL_MATCHING_RE(\"";
+    let start = match_source
+        .find(needle)
+        .map(|idx| idx + needle.len())
+        .unwrap_or_else(|| panic!("no regex predicate in:\n{match_source}"));
+    let rest = &match_source[start..];
+    let end = rest
+        .find('"')
+        .unwrap_or_else(|| panic!("unterminated regex pattern in:\n{match_source}"));
+    // The pattern lives inside a JS string literal in the rendered selector, so
+    // every backslash from `regex::escape` is doubled in the source text. The
+    // matcher's parser un-escapes it before compiling; mirror that here so the
+    // test compiles the same pattern the matcher does.
+    rest[..end].replace("\\\\", "\\")
+}
+
 #[test]
 fn synthesize_selectors_full_ast_fallback_flag_is_accepted() {
     // The minimizer almost always finds a sparse selector for synthesizable

--- a/devinfra/js/debundle/selector_codemod.rs
+++ b/devinfra/js/debundle/selector_codemod.rs
@@ -23,13 +23,14 @@ use spec::{SourceMatch, SourceMatchIdentifierMode};
 use spec_modules::{collect_module_files, is_module_yaml, module_path_from_file};
 use swc_common::{BytePos, DUMMY_SP, Span, Spanned, SyntaxContext};
 use swc_ecma_ast::*;
-use swc_ecma_visit::{Visit, VisitWith};
+use swc_ecma_visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 
 // Hole keyword spellings come from `source_match_holes` so the minimizer
 // emits exactly the tokens the matcher resolves.
 use source_match_holes::{
     ANYTHING_HOLE_KEYWORD, ARGS_HOLE_KEYWORD, CLASS_REST_HOLE_KEYWORD, DECLARATORS_HOLE_KEYWORD,
     EXPR_HOLE_KEYWORD, OBJECT_PROPS_HOLE_KEYWORD, STMT_HOLE_KEYWORD, STMT_LIST_HOLE_KEYWORD,
+    STRING_LITERAL_REGEX_PREDICATE,
 };
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
@@ -1833,6 +1834,159 @@ fn minimize_function_selector(
     minimize_via_retention(index, decl, target, &candidates, &render_with)
 }
 
+// ===========================================================================
+// Regex-over-string-literal anchors (`STR_LITERAL_MATCHING_RE("<pattern>")`).
+//
+// A var-binding selector that pins an exact string literal breaks whenever a
+// rebuild perturbs a volatile fragment of that literal (a content hash, build
+// counter, or other generated tail). When the *stable* part of the literal
+// already discriminates the target from its siblings, we can pin that stable
+// structure with a regex and wildcard the volatile fragment, so the selector
+// survives the rebuild.
+//
+// Derivation rule (intentionally conservative — see
+// `selector_minimizer_discrimination.md`):
+//
+//   * We only derive a pattern when the literal ends in a *volatile tail*: a
+//     trailing run of hex/digits. The tail must be at least
+//     `MIN_VOLATILE_TAIL_LEN` chars so a one- to three-char numeric suffix
+//     (which is more likely meaningful than generated) is left alone. Any
+//     separator before the tail (`chunk-`, `main.`) stays in the pinned prefix.
+//   * The derived pattern is `^<escaped stable prefix><tail class>$`, anchored
+//     so `Regex::is_match` (which is otherwise a substring test) pins the whole
+//     value. The stable prefix is escaped with `regex::escape`, so every
+//     metacharacter in the literal is matched literally; only the volatile tail
+//     becomes a character-class wildcard (`[0-9A-Fa-f]+` for a hex tail,
+//     `[0-9]+` for a pure-digit tail).
+//   * If the whole literal would be the volatile tail (no stable prefix), we
+//     return `None`: a bare `^[0-9]+$` pins nothing meaningful and would almost
+//     never discriminate.
+//
+// Limits we deliberately accept: this recognizes only trailing hex/digit
+// volatility (the dominant bundler pattern: `chunk-a1b2c3`, `main.4f3a2b.js`,
+// `vendor_1024`). It does not model embedded volatile fragments, GUID shapes,
+// or base64 hashes. The cover never *requires* a regex anchor — it is offered
+// only as an upgrade of an already-kept exact literal, and is taken only when
+// the upgraded selector still resolves uniquely (so an over-broad pattern is
+// rejected, never emitted). A pattern that fails to compile as `regex::Regex`
+// is likewise never emitted.
+// ===========================================================================
+
+/// Minimum length of a trailing hex/digit run for it to count as a volatile
+/// fragment worth wildcarding. Short numeric suffixes (`v2`, `s3`) are more
+/// often meaningful than generated, so they stay pinned exactly.
+const MIN_VOLATILE_TAIL_LEN: usize = 4;
+
+/// Derive an anchored `STR_LITERAL_MATCHING_RE` pattern that pins the stable
+/// prefix of `value` and wildcards a trailing volatile hex/digit fragment, or
+/// `None` when no meaningful stable-prefix/volatile-tail split exists. The
+/// returned pattern is always a valid `regex::Regex` (the only metacharacters
+/// it introduces are the anchors and a character class; the prefix is escaped).
+fn regex_anchor_pattern(value: &str) -> Option<String> {
+    let chars: Vec<char> = value.chars().collect();
+    // Length of the trailing run of hex digits.
+    let hex_tail = chars
+        .iter()
+        .rev()
+        .take_while(|c| c.is_ascii_hexdigit())
+        .count();
+    if hex_tail < MIN_VOLATILE_TAIL_LEN {
+        return None;
+    }
+    // Prefer a pure-digit tail class when the whole tail is decimal; otherwise
+    // a hex class. (Hex is a superset of digits, so the digit class is the
+    // tighter, more honest wildcard when applicable.)
+    let tail_is_decimal = chars[chars.len() - hex_tail..]
+        .iter()
+        .all(char::is_ascii_digit);
+    let tail_class = if tail_is_decimal {
+        "[0-9]+"
+    } else {
+        "[0-9A-Fa-f]+"
+    };
+    let stable_prefix: String = chars[..chars.len() - hex_tail].iter().collect();
+    // A regex anchor must pin *something* stable: an empty or separator-only
+    // prefix discriminates nothing, so decline. The trailing separator (if any)
+    // stays in the pinned, escaped prefix — `chunk-a1b2c3` pins `chunk-`, not
+    // `chunk`, which is the conservative choice (one fewer wildcarded char).
+    if stable_prefix.is_empty() || stable_prefix.chars().all(|c| matches!(c, '-' | '_' | '.')) {
+        return None;
+    }
+    let pattern = format!("^{}{tail_class}$", regex::escape(&stable_prefix));
+    // Guard the invariant directly: never hand the matcher a pattern it cannot
+    // compile (the matcher silently treats an uncompilable pattern as a
+    // non-match, which would make the selector match nothing).
+    regex::Regex::new(&pattern).ok()?;
+    Some(pattern)
+}
+
+/// Build the `STR_LITERAL_MATCHING_RE("<pattern>")` call expression the matcher
+/// interprets as a regex-over-string-literal predicate.
+fn regex_predicate_call(pattern: &str) -> Expr {
+    Expr::Call(CallExpr {
+        span: DUMMY_SP,
+        ctxt: SyntaxContext::empty(),
+        callee: Callee::Expr(Box::new(Expr::Ident(ident_node(
+            STRING_LITERAL_REGEX_PREDICATE,
+        )))),
+        args: vec![ExprOrSpread {
+            spread: None,
+            expr: Box::new(Expr::Lit(Lit::Str(Str {
+                span: DUMMY_SP,
+                value: pattern.into(),
+                raw: None,
+            }))),
+        }],
+        type_args: None,
+    })
+}
+
+/// Replace each kept string literal whose span is a chosen regex anchor with the
+/// `STR_LITERAL_MATCHING_RE` predicate call. Runs as a post-pass over the holed
+/// selector AST: holed literals keep their original source span, so matching by
+/// span here is exact and never touches a literal the cover did not select.
+struct RegexAnchorSubstitution<'a> {
+    patterns: &'a BTreeMap<AnchorSpan, String>,
+}
+
+impl VisitMut for RegexAnchorSubstitution<'_> {
+    fn visit_mut_expr(&mut self, expr: &mut Expr) {
+        if let Expr::Lit(Lit::Str(str_lit)) = expr {
+            if let Some(pattern) = self.patterns.get(&span_key(str_lit.span)) {
+                *expr = regex_predicate_call(pattern);
+                return;
+            }
+        }
+        expr.visit_mut_children_with(self);
+    }
+}
+
+/// Candidate regex anchors for the var-binding minimizer: the `(span, pattern)`
+/// of each string literal in a target slot's init for which `regex_anchor_pattern`
+/// yields a wildcarding pattern. Only literals already in the kept set are ever
+/// upgraded, so this is a superset filtered against `kept` at upgrade time.
+fn collect_regex_anchor_candidates(init: &Expr) -> BTreeMap<AnchorSpan, String> {
+    #[derive(Default)]
+    struct Collector {
+        candidates: BTreeMap<AnchorSpan, String>,
+    }
+    impl Visit for Collector {
+        fn visit_expr(&mut self, expr: &Expr) {
+            if let Expr::Lit(Lit::Str(str_lit)) = expr {
+                if let Some(pattern) =
+                    regex_anchor_pattern(str_lit.value.to_string_lossy().as_ref())
+                {
+                    self.candidates.insert(span_key(str_lit.span), pattern);
+                }
+            }
+            expr.visit_children_with(self);
+        }
+    }
+    let mut collector = Collector::default();
+    init.visit_with(&mut collector);
+    collector.candidates
+}
+
 /// A `DECLARATORS_<pos> = null` declarator hole absorbing a run of non-target
 /// declarators in a binding-group selector.
 fn declarator_hole(name: &str) -> VarDeclarator {
@@ -1880,7 +2034,9 @@ fn minimize_var_group_selector(
         return Ok(None);
     }
 
-    let render_with = |kept: &BTreeSet<AnchorSpan>| -> Result<String> {
+    let render_with = |kept: &BTreeSet<AnchorSpan>,
+                       regex_anchors: &BTreeMap<AnchorSpan, String>|
+     -> Result<String> {
         let mut decls: Vec<VarDeclarator> = Vec::new();
         let mut skipped_run = false;
         let mut target_seen = 0usize;
@@ -1900,10 +2056,17 @@ fn minimize_var_group_selector(
                 .expect("target declarator is a plain identifier");
             let mut holed = declarator.clone();
             holed.name = named_pat(export_for(name).expect("target declarator has an export"));
-            holed.init = declarator
-                .init
-                .as_ref()
-                .map(|init| Box::new(hole_expr(init, kept)));
+            holed.init = declarator.init.as_ref().map(|init| {
+                let mut holed_init = hole_expr(init, kept);
+                if !regex_anchors.is_empty() {
+                    // Post-pass: swap each kept literal whose span was chosen as
+                    // a regex anchor for the `STR_LITERAL_MATCHING_RE` predicate.
+                    holed_init.visit_mut_with(&mut RegexAnchorSubstitution {
+                        patterns: regex_anchors,
+                    });
+                }
+                Box::new(holed_init)
+            });
             decls.push(holed);
             target_seen += 1;
         }
@@ -1928,8 +2091,12 @@ fn minimize_var_group_selector(
         }
     }
 
+    let no_regex = BTreeMap::new();
     let resolves = |kept: &BTreeSet<AnchorSpan>| -> Result<bool> {
-        Ok(prove_synthesized_selector(index, decl, targets, &render_with(kept)?).is_ok())
+        Ok(
+            prove_synthesized_selector(index, decl, targets, &render_with(kept, &no_regex)?)
+                .is_ok(),
+        )
     };
     // Always keep each slot's shallow literals (a group's declarators are its
     // meaningful targets), then escalate to structural/deeper anchors only if
@@ -1946,7 +2113,37 @@ fn minimize_var_group_selector(
             return Ok(None);
         }
     }
-    let source = render_with(&kept)?;
+
+    // Regex-literal upgrade: among kept string literals, offer a robust
+    // `STR_LITERAL_MATCHING_RE` anchor for each that has a derivable
+    // stable-prefix/volatile-tail pattern, but only accept the upgrade when the
+    // resulting selector *still* resolves uniquely (gate 1). The exact-literal
+    // form is the default; regex is opt-in by merit. Upgrades are applied one
+    // literal at a time so a too-broad pattern on one literal never blocks a
+    // sound upgrade on another.
+    let mut regex_anchors: BTreeMap<AnchorSpan, String> = BTreeMap::new();
+    for (idx, declarator) in var.decls.iter().enumerate() {
+        if !target_slots.contains(&idx) {
+            continue;
+        }
+        let Some(init) = &declarator.init else {
+            continue;
+        };
+        for (span, pattern) in collect_regex_anchor_candidates(init) {
+            if !kept.contains(&span) || regex_anchors.contains_key(&span) {
+                continue;
+            }
+            regex_anchors.insert(span, pattern);
+            let trial = render_with(&kept, &regex_anchors)?;
+            if prove_synthesized_selector(index, decl, targets, &trial).is_err() {
+                // The regex anchor broke uniqueness (over-broad among siblings),
+                // so back it out and keep the exact literal.
+                regex_anchors.remove(&span);
+            }
+        }
+    }
+
+    let source = render_with(&kept, &regex_anchors)?;
     let rewritten_holes = holes_present(&source);
     Ok(Some(SpecializedSelector {
         match_source: source,
@@ -2947,6 +3144,66 @@ fn is_zero(value: &usize) -> bool {
 
 #[cfg(test)]
 mod selector_minimizer_proptest;
+
+#[cfg(test)]
+mod regex_anchor_pattern_tests {
+    use super::*;
+
+    #[test]
+    fn pins_stable_prefix_and_wildcards_hex_tail() {
+        let pattern = regex_anchor_pattern("chunk-a1b2c3").expect("derivable hex tail");
+        assert_eq!(pattern, "^chunk\\-[0-9A-Fa-f]+$");
+        let re = regex::Regex::new(&pattern).unwrap();
+        // The pattern matches the seen value and rebuild variants of the same
+        // stable prefix, but not a different prefix.
+        assert!(re.is_match("chunk-a1b2c3"));
+        assert!(re.is_match("chunk-ffffff"));
+        assert!(!re.is_match("widget-a1b2c3"));
+        // Anchored: a longer string sharing the prefix must not match.
+        assert!(!re.is_match("chunk-a1b2c3-extra"));
+    }
+
+    #[test]
+    fn prefers_decimal_class_for_pure_digit_tail() {
+        let pattern = regex_anchor_pattern("vendor_1024").expect("derivable digit tail");
+        assert_eq!(pattern, "^vendor_[0-9]+$");
+        let re = regex::Regex::new(&pattern).unwrap();
+        assert!(re.is_match("vendor_1024"));
+        assert!(re.is_match("vendor_9999"));
+        // The decimal class is tighter than hex: a hex-only rebuild would not
+        // match, which is fine — we wildcard only what we observed (digits).
+        assert!(!re.is_match("vendor_abcd"));
+    }
+
+    #[test]
+    fn escapes_regex_metacharacters_in_the_prefix() {
+        let pattern = regex_anchor_pattern("main.bundle.4f3a2b").expect("derivable");
+        assert_eq!(pattern, "^main\\.bundle\\.[0-9A-Fa-f]+$");
+        let re = regex::Regex::new(&pattern).unwrap();
+        assert!(re.is_match("main.bundle.4f3a2b"));
+        // The `.`s are literal, not any-char wildcards.
+        assert!(!re.is_match("mainXbundleY4f3a2b"));
+    }
+
+    #[test]
+    fn declines_short_numeric_suffixes() {
+        // A two/three-char numeric suffix is more likely meaningful than
+        // generated, so no pattern is offered (`MIN_VOLATILE_TAIL_LEN`).
+        assert_eq!(regex_anchor_pattern("v2"), None);
+        assert_eq!(regex_anchor_pattern("step3"), None);
+        assert_eq!(regex_anchor_pattern("h2o"), None);
+    }
+
+    #[test]
+    fn declines_when_no_stable_prefix_remains() {
+        // The whole literal is the volatile tail: a bare digit/hex anchor pins
+        // nothing meaningful.
+        assert_eq!(regex_anchor_pattern("123456"), None);
+        assert_eq!(regex_anchor_pattern("deadbeef"), None);
+        // Separator-only prefix is likewise rejected.
+        assert_eq!(regex_anchor_pattern("-123456"), None);
+    }
+}
 
 #[cfg(test)]
 mod full_ast_fallback_tests {

--- a/devinfra/js/debundle/selector_codemod.rs
+++ b/devinfra/js/debundle/selector_codemod.rs
@@ -15,8 +15,10 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
+use selector_candidate_index::SelectorCandidateIndex;
 use serde::Serialize;
 use serde_yaml::Value;
+use source_match::BodyIndexFilter;
 use spec::{SourceMatch, SourceMatchIdentifierMode};
 use spec_modules::{collect_module_files, is_module_yaml, module_path_from_file};
 use swc_common::{BytePos, DUMMY_SP, Span, Spanned, SyntaxContext};
@@ -547,6 +549,11 @@ struct ChunkSelectorIndex {
     source: String,
     decls: Vec<IndexedDeclaration>,
     binding_to_decl: BTreeMap<String, Vec<usize>>,
+    /// Built once per chunk and shared across every member and binding group so
+    /// the minimizer's per-anchor matcher scans only plausible top-level body
+    /// indices instead of the whole chunk. A pure prefilter — see
+    /// [`matched_body_indices`].
+    candidate_index: SelectorCandidateIndex,
 }
 
 #[derive(Debug)]
@@ -891,11 +898,13 @@ impl ChunkSelectorIndex {
             }
             decls.push(indexed);
         }
+        let candidate_index = SelectorCandidateIndex::new(&parsed.module);
         Self {
             parsed,
             source,
             decls,
             binding_to_decl,
+            candidate_index,
         }
     }
 }
@@ -1716,6 +1725,14 @@ fn collect_expr_anchors(expr: &Expr, depth: u32, candidates: &mut AnchorCandidat
 }
 
 /// Body indices a `target_binding` selector with `match_source` resolves to.
+///
+/// The shared per-chunk [`SelectorCandidateIndex`] narrows the matcher's scan to
+/// the top-level body indices whose features could still match the selector,
+/// turning the inner loop from O(all top-level statements) into O(plausible
+/// candidates). The candidate set is a sound superset of the full-scan matches,
+/// so the still-run structural matcher remains the source of truth: it proves
+/// every reported match and discards index false positives. See
+/// `prefilter_matches_brute_force_scan` for the superset invariant test.
 fn matched_body_indices(
     index: &ChunkSelectorIndex,
     export_name: &str,
@@ -1729,10 +1746,17 @@ fn matched_body_indices(
         target_statements: None,
         wildcard_string_literals: BTreeSet::new(),
     };
-    let matches = source_match::member_binding_candidate_matches(
+    let selector = source_match.selector();
+    let candidates: BTreeSet<usize> = index
+        .candidate_index
+        .candidate_set_for_source_match(&selector)?
+        .body_indices()
+        .collect();
+    let matches = source_match::member_binding_candidate_matches_within(
         &index.parsed.module,
         "<selector minimization>",
-        &source_match.selector(),
+        &selector,
+        BodyIndexFilter::Restricted(&candidates),
     )?;
     Ok(matches.iter().map(|candidate| candidate.body_idx).collect())
 }
@@ -3058,5 +3082,105 @@ export { target };\n";
         // emits even when full_ast_fallback is off.
         let outcome = outcome_for(HARD_TO_MINIMIZE, "target", false, false);
         assert!(matches!(outcome, GroupSelectorOutcome::Synthesized(_)));
+    }
+}
+
+#[cfg(test)]
+mod prefilter_soundness_tests {
+    use super::*;
+
+    /// Many same-shaped sibling `const`s plus a few non-var statements, so the
+    /// candidate-index prefilter has both true matches to keep and unrelated
+    /// statements to prune. Synthetic only.
+    fn many_sibling_chunk() -> String {
+        let mut chunk = String::new();
+        for idx in 0..200 {
+            chunk.push_str(&format!(
+                "const binding{idx} = makeWidget(\"token-{idx}\", {{ role: \"button\" }});\n"
+            ));
+        }
+        for idx in 0..50 {
+            chunk.push_str(&format!("function helper{idx}(a, b) {{ return a + b; }}\n"));
+        }
+        chunk.push_str("sideEffect();\n");
+        chunk
+    }
+
+    /// The full unfiltered scan: matcher over every top-level statement. Source
+    /// of truth the prefilter must not under-include.
+    fn brute_force_matches(
+        index: &ChunkSelectorIndex,
+        export: &str,
+        source: &str,
+    ) -> BTreeSet<usize> {
+        let source_match = SourceMatch {
+            match_source: source.to_string(),
+            identifiers: SourceMatchIdentifierMode::AlphaAll,
+            target_binding: Some(export.to_string()),
+            target_statement: None,
+            target_statements: None,
+            wildcard_string_literals: BTreeSet::new(),
+        };
+        source_match::member_binding_candidate_matches_within(
+            &index.parsed.module,
+            "<brute-force>",
+            &source_match.selector(),
+            BodyIndexFilter::All,
+        )
+        .unwrap()
+        .iter()
+        .map(|matched| matched.body_idx)
+        .collect()
+    }
+
+    #[test]
+    fn prefilter_matches_brute_force_scan() {
+        js_ast::with_swc_globals(|| {
+            let index = ChunkSelectorIndex::new(
+                js_ast::parse_js_module_consuming("<prefilter-test>", many_sibling_chunk())
+                    .unwrap(),
+            );
+            // A selector specific enough to match exactly one sibling, and a holed
+            // selector that matches every sibling: both must agree between the
+            // prefiltered and brute-force scans.
+            for (export, source) in [
+                (
+                    "Target",
+                    r#"const Target = makeWidget("token-137", { role: "button" });"#,
+                ),
+                (
+                    "Target",
+                    r#"const Target = makeWidget(EXPR_HOLE, { role: "button" });"#,
+                ),
+            ] {
+                let prefiltered = matched_body_indices(&index, export, source).unwrap();
+                let brute = brute_force_matches(&index, export, source);
+                let candidates: BTreeSet<usize> = index
+                    .candidate_index
+                    .candidate_set_for_source_match(&{
+                        SourceMatch {
+                            match_source: source.to_string(),
+                            identifiers: SourceMatchIdentifierMode::AlphaAll,
+                            target_binding: Some(export.to_string()),
+                            target_statement: None,
+                            target_statements: None,
+                            wildcard_string_literals: BTreeSet::new(),
+                        }
+                        .selector()
+                    })
+                    .unwrap()
+                    .body_indices()
+                    .collect();
+                assert!(
+                    brute.is_subset(&candidates),
+                    "candidate set must be a sound superset of the brute-force matches: \
+                     brute={brute:?} candidates={candidates:?}"
+                );
+                assert_eq!(
+                    prefiltered, brute,
+                    "prefiltered scan must report identical matches to the full scan"
+                );
+            }
+        });
     }
 }

--- a/devinfra/js/debundle/source_match.rs
+++ b/devinfra/js/debundle/source_match.rs
@@ -673,16 +673,57 @@ pub fn member_binding_candidates(
     )
 }
 
+/// Restricts which top-level body indices the matcher inspects as match anchors.
+///
+/// This is a pure performance prefilter, never a correctness gate: a caller may
+/// supply a candidate body-index set (e.g. from `SelectorCandidateIndex`) that
+/// must be a *sound superset* of every index the full scan would match. The
+/// matcher still proves every reported match structurally, so over-inclusion is
+/// harmless and under-inclusion would silently drop real matches — the caller is
+/// responsible for the superset invariant.
+#[derive(Clone, Copy)]
+pub enum BodyIndexFilter<'a> {
+    All,
+    Restricted(&'a BTreeSet<usize>),
+}
+
+impl BodyIndexFilter<'_> {
+    fn allows(&self, body_idx: usize) -> bool {
+        match self {
+            BodyIndexFilter::All => true,
+            BodyIndexFilter::Restricted(indices) => indices.contains(&body_idx),
+        }
+    }
+}
+
 pub fn member_binding_candidate_matches(
     runtime_module: &Module,
     request_id: &str,
     selector: &AnonymousStatementSelector,
 ) -> Result<Vec<MemberBindingMatch>> {
+    member_binding_candidate_matches_within(
+        runtime_module,
+        request_id,
+        selector,
+        BodyIndexFilter::All,
+    )
+}
+
+/// Like [`member_binding_candidate_matches`], but only inspects top-level body
+/// indices the `filter` admits. The reported matches are identical to the
+/// unfiltered scan whenever `filter` is a sound superset of the matchable
+/// indices (see [`BodyIndexFilter`]).
+pub fn member_binding_candidate_matches_within(
+    runtime_module: &Module,
+    request_id: &str,
+    selector: &AnonymousStatementSelector,
+    filter: BodyIndexFilter<'_>,
+) -> Result<Vec<MemberBindingMatch>> {
     trace_source_match(
         "members[].selector.source_match candidates",
         request_id,
         selector,
-        || find_member_binding_matches(runtime_module, request_id, selector),
+        || find_member_binding_matches(runtime_module, request_id, selector, filter),
         |matches: &Vec<MemberBindingMatch>| {
             format!(
                 "matches={} body_indices={} bindings={}",
@@ -907,7 +948,12 @@ pub fn resolve_member_binding(
         request_id,
         selector,
         || {
-            let matches = find_member_binding_matches(runtime_module, request_id, selector)?;
+            let matches = find_member_binding_matches(
+                runtime_module,
+                request_id,
+                selector,
+                BodyIndexFilter::All,
+            )?;
             let target_binding_hint = selector
                 .target_binding
                 .as_deref()
@@ -1188,6 +1234,7 @@ fn find_member_binding_matches(
     runtime_module: &Module,
     request_id: &str,
     selector: &AnonymousStatementSelector,
+    filter: BodyIndexFilter<'_>,
 ) -> Result<Vec<MemberBindingMatch>> {
     let parsed = parse_selector_module_with_capability_check(
         request_id,
@@ -1217,6 +1264,7 @@ fn find_member_binding_matches(
                 &parsed.body[0],
                 selector,
                 target_binding,
+                filter,
             );
         }
         return find_matching_target_bindings(
@@ -1225,6 +1273,7 @@ fn find_member_binding_matches(
             &parsed.body,
             selector,
             target_binding,
+            filter,
         );
     }
     let parsed_items: Vec<&ModuleItem> = parsed.body.iter().collect();
@@ -1244,10 +1293,10 @@ fn find_member_binding_matches(
         ),
     };
     if selector_single_var_declarator(needle).is_some() {
-        return find_matching_var_declarators(runtime_module, needle, selector);
+        return find_matching_var_declarators(runtime_module, needle, selector, filter);
     }
     let mut matches = Vec::new();
-    for body_idx in find_matching_body_indices(runtime_module, needle, selector) {
+    for body_idx in find_matching_body_indices(runtime_module, needle, selector, filter) {
         let item = runtime_module.body.get(body_idx).with_context(|| {
             format!("body index {body_idx} disappeared while resolving source_match")
         })?;
@@ -1282,6 +1331,7 @@ fn find_matching_target_bindings(
     needles: &[ModuleItem],
     selector: &AnonymousStatementSelector,
     target_binding: &str,
+    filter: BodyIndexFilter<'_>,
 ) -> Result<Vec<MemberBindingMatch>> {
     if needles.len() == 1 && selector_var_decl_has_declarator_holes(&needles[0]) {
         return find_matching_target_var_decl_with_declarator_holes(
@@ -1290,6 +1340,7 @@ fn find_matching_target_bindings(
             &needles[0],
             selector,
             target_binding,
+            filter,
         );
     }
     let (target_item_idx, target_binding_idx) =
@@ -1301,10 +1352,13 @@ fn find_matching_target_bindings(
             selector,
             target_item_idx,
             target_binding_idx,
+            filter,
         );
     }
     let mut matches = Vec::new();
-    for body_idx in find_matching_body_ranges(runtime_module, needles, selector) {
+    for body_idx in
+        find_matching_body_ranges(runtime_module, needles, selector, target_item_idx, filter)
+    {
         let matched_body_idx = body_idx + target_item_idx;
         let item = runtime_module.body.get(matched_body_idx).with_context(|| {
             format!("body index {matched_body_idx} disappeared while resolving source_match")
@@ -1333,6 +1387,7 @@ fn find_matching_target_binding_ranges_with_single_declarator(
     selector: &AnonymousStatementSelector,
     target_item_idx: usize,
     target_binding_idx: usize,
+    filter: BodyIndexFilter<'_>,
 ) -> Result<Vec<MemberBindingMatch>> {
     if needles.is_empty() || needles.len() > runtime_module.body.len() {
         return Ok(Vec::new());
@@ -1342,6 +1397,9 @@ fn find_matching_target_binding_ranges_with_single_declarator(
     let mut matches = Vec::new();
     SyntaxContext::within_ignored_ctxt(|| {
         for (body_idx, candidates) in runtime_module.body.windows(needles.len()).enumerate() {
+            if !filter.allows(body_idx + target_item_idx) {
+                continue;
+            }
             let mut matcher = AstWildcardMatcher::new(selector, &wildcard_idents, alpha);
             let window = SingleDeclaratorTargetWindow {
                 needles,
@@ -1421,6 +1479,7 @@ fn find_matching_target_var_declarators(
     needle: &ModuleItem,
     selector: &AnonymousStatementSelector,
     target_binding: &str,
+    filter: BodyIndexFilter<'_>,
 ) -> Result<Vec<MemberBindingMatch>> {
     let selector_bindings = declared_bindings(needle);
     let selector_binding_indices: Vec<usize> = selector_bindings
@@ -1447,6 +1506,9 @@ fn find_matching_target_var_declarators(
     let prefilter = VarDeclaratorPrefilter::new(needle, &prepared);
     let mut matches = Vec::new();
     for (body_idx, item) in runtime_module.body.iter().enumerate() {
+        if !filter.allows(body_idx) {
+            continue;
+        }
         let Some(candidate_var) = item_var_decl(item) else {
             continue;
         };
@@ -1485,6 +1547,7 @@ fn find_matching_target_var_decl_with_declarator_holes(
     needle: &ModuleItem,
     selector: &AnonymousStatementSelector,
     target_binding: &str,
+    filter: BodyIndexFilter<'_>,
 ) -> Result<Vec<MemberBindingMatch>> {
     let needle_var =
         item_var_decl(needle).expect("caller checked selector_var_decl_has_declarator_holes");
@@ -1494,6 +1557,9 @@ fn find_matching_target_var_decl_with_declarator_holes(
     let prefilter = VarDeclWithDeclaratorHolesPrefilter::new(needle_var, &prepared);
     let mut matches = Vec::new();
     for (body_idx, item) in runtime_module.body.iter().enumerate() {
+        if !filter.allows(body_idx) {
+            continue;
+        }
         let Some(candidate_var) = item_var_decl(item) else {
             continue;
         };
@@ -1721,11 +1787,15 @@ fn find_matching_var_declarators(
     runtime_module: &Module,
     needle: &ModuleItem,
     selector: &AnonymousStatementSelector,
+    filter: BodyIndexFilter<'_>,
 ) -> Result<Vec<MemberBindingMatch>> {
     let prepared = PreparedNeedle::new(needle, selector);
     let prefilter = VarDeclaratorPrefilter::new(needle, &prepared);
     let mut matches = Vec::new();
     for (body_idx, item) in runtime_module.body.iter().enumerate() {
+        if !filter.allows(body_idx) {
+            continue;
+        }
         let Some(candidate_var) = item_var_decl(item) else {
             continue;
         };
@@ -2091,6 +2161,7 @@ fn find_matching_body_indices(
     runtime_module: &Module,
     needle: &ModuleItem,
     selector: &AnonymousStatementSelector,
+    filter: BodyIndexFilter<'_>,
 ) -> Vec<usize> {
     let prepared = PreparedNeedle::new(needle, selector);
     let declarator_hole_prefilter = item_var_decl(needle)
@@ -2104,6 +2175,7 @@ fn find_matching_body_indices(
         .body
         .iter()
         .enumerate()
+        .filter(|(body_idx, _)| filter.allows(*body_idx))
         .filter_map(|(body_idx, item)| {
             if let Some(prefilter) = &declarator_hole_prefilter {
                 let candidate_var = item_var_decl(item)?;
@@ -2116,10 +2188,15 @@ fn find_matching_body_indices(
         .collect()
 }
 
+/// `target_item_idx` is the offset of the matched/target statement within a
+/// multi-statement window; the `filter` is applied to that absolute target
+/// index (`window_start + target_item_idx`), not the window start.
 fn find_matching_body_ranges(
     runtime_module: &Module,
     needles: &[ModuleItem],
     selector: &AnonymousStatementSelector,
+    target_item_idx: usize,
+    filter: BodyIndexFilter<'_>,
 ) -> Vec<usize> {
     if needles.is_empty() || needles.len() > runtime_module.body.len() {
         return Vec::new();
@@ -2137,6 +2214,7 @@ fn find_matching_body_ranges(
             .body
             .iter()
             .enumerate()
+            .filter(|(body_idx, _)| filter.allows(*body_idx + target_item_idx))
             .filter_map(|(body_idx, candidate)| {
                 if let Some(prefilter) = &declarator_hole_prefilter {
                     let candidate_var = item_var_decl(candidate)?;
@@ -2154,6 +2232,7 @@ fn find_matching_body_ranges(
         .body
         .windows(needles.len())
         .enumerate()
+        .filter(|(body_idx, _)| filter.allows(*body_idx + target_item_idx))
         .filter_map(|(body_idx, candidates)| {
             SyntaxContext::within_ignored_ctxt(|| {
                 let mut matcher = AstWildcardMatcher::new(selector, &wildcard_idents, alpha);
@@ -3865,7 +3944,7 @@ const unrelatedB = "different-token-42";"#,
             let needle = parse_one(&selector.match_source);
 
             assert_eq!(
-                find_matching_body_indices(&runtime, &needle, &selector),
+                find_matching_body_indices(&runtime, &needle, &selector, BodyIndexFilter::All),
                 vec![1]
             );
         });


### PR DESCRIPTION
Rebased onto `devel` after #2253 merged. This branch now also carries the
**#2255 regex-literal anchor work** (which was merged into this branch as its
stacked base), so #2254 delivers both follow-ups in two commits:

1. `index-prefilter the selector minimizer cover` (perf)
2. `emit STR_LITERAL_MATCHING_RE anchors in var minimizer` (#2255)

---

## 1. Index-prefilter (perf)

Performance fix so the minimizer scales to large chunks (~4.5k members / ~7MB).
Dogfood found the cover spending 56% of samples in `find_matching_body_ranges`
scanning **every** top-level statement, once per candidate anchor per tier — net
cost `members × anchors × all-statements`.

- **Prefilter the matcher scan.** New `BodyIndexFilter<'a>` (`All` |
  `Restricted(&BTreeSet)`) in `source_match.rs`, threaded through
  `find_member_binding_matches` and the five per-item scan loops it reaches.
  `member_binding_candidate_matches_within(...)` takes the filter; the old entry
  point delegates with `All` (behavior unchanged). For multi-statement windows
  the filter is applied to the absolute target index (`window_start +
  target_item_idx`).
- **Share one index per chunk.** `ChunkSelectorIndex` owns a single
  `SelectorCandidateIndex` (#2251), built once and reused across every member and
  across a multi-YAML batch. `matched_body_indices` queries
  `candidate_set_for_source_match` and passes `BodyIndexFilter::Restricted`,
  narrowing the matcher's scan from O(all top-level statements) to O(plausible
  candidates).

**Correctness:** pure prefilter, never a correctness gate. The structural matcher
still proves every reported match; the final uniqueness arbitration
(`resolve_member_binding`) scans with `BodyIndexFilter::All`. The candidate set
is a sound superset (over-inclusion harmless; under-inclusion would only cause a
selector to be conservatively rejected, never a wrong selector).
`prefilter_soundness_tests::prefilter_matches_brute_force_scan` asserts the
superset and identical results on a synthetic 251-statement chunk.

## 2. Regex-literal anchors (was #2255)

The var minimizer emits `STR_LITERAL_MATCHING_RE("<pattern>")` for string
literals with a rebuild-volatile tail (content hash, build counter), pinning the
stable prefix and holing the hash. Runs as an upgrade pass in
`minimize_var_group_selector` after the cover already resolves uniquely; each
upgrade is re-proven with `prove_synthesized_selector` and backed out if it
breaks uniqueness. Conservative derivation (trailing hex/digit tail ≥4 chars,
anchored, escaped prefix); declines when no stable prefix exists or the pattern
wouldn't compile.

## Validation (real chunk + RBE)

`selector_codemod_test` (proptest + `regex_anchor_pattern_tests` +
`prefilter_soundness_tests`), `selector_codemod_cli_test`,
`selector_minimizer_expectation_test`, `source_match_test` all pass; `debundle`
builds. Re-validated green after the rebase onto `devel`. Dogfooded on the real
~7MB chunk: whole-chunk run now **~113s (was a >300s timeout)**, ~3× per-member;
apply is transactional (no overlapping-edit crash); regex anchors fired correctly
on CSS-module/import-hash literals (see `selector_minimizer_dogfood.md`).

https://claude.ai/code/session_01RYUAvJefa2eJRgZ7XBfqxA