### PR TITLE
debundle: capture read-off minimization algorithm research

### DIFF
--- a/devinfra/js/debundle/plans/readoff_algorithm_research.md
+++ b/devinfra/js/debundle/plans/readoff_algorithm_research.md
@@ -1,0 +1,200 @@
+# Research: the read-off minimization algorithm (de-risking spike)
+
+Status: complete (2026-06-16). Inputs: five independent literature strands
+(term indexing; tree automata & bottom-up tree pattern matching;
+anti-unification / LGG; subtree mining & tree compression; minimal keys /
+teaching-set / set-cover). The five full strand reports with citations live in
+<readoff_research/>. This note is the synthesis + recommendation that gates
+Wave 1 of <readoff_minimization.md>. It pressure-tests the "read off, not
+search, in O(M+N)" thesis and tells us what is safe to build now vs. what must
+stay behind a swappable interface.
+
+## Problem, restated formally
+
+Chunk parses to a JS AST. Items `I` = top-level statements / declared bindings.
+A selector is a tree pattern in the `source_match` hole language `L` (typed
+holes `EXPR`/`STMT`, variadic list holes `ARGS`/`STMT_LIST`/`OBJECT_PROPS`/
+`DECLARATORS`/`CLASS_REST`, `ANYTHING`, and the `STR_LITERAL_MATCHING_RE`
+predicate), matched by structural tree matching modulo holes and
+alpha-equivalence (minified identifiers are wildcards; stable
+literals/keys/exported names are concrete). For a target `t` we want the
+**minimal, stability-biased selector matching exactly `{t}`**, plus a principled
+**grouping** of targets whose selectors would largely overlap.
+
+## What the literature settles
+
+### 1. The data structure is solved and genuinely O(N): hash-consed Merkle DAG
+
+Bottom-up **hash-consing** (`id(node) = H(kind ‖ child-ids)`) assigns every
+distinct subtree shape a canonical id in one pass; equal shapes collapse and
+share automatically; subtree equality becomes O(1) id comparison. Linear-time,
+textbook: Downey–Sethi–Tarjan, "Variations on the Common Subexpression Problem,"
+JACM 1980. Merkle/Git/Hashlife are the same construction in practice.
+
+- **Alpha-equivalence falls out** by canonicalizing identifier leaves to a
+  wildcard sentinel (or De Bruijn index for binding-aware) _before_ hashing, so
+  renamed-isomorphic subtrees hash equal. Crucially this makes equality =
+  identity, which keeps us in **regular tree language** territory and avoids the
+  non-regular `f(t,t)` trap (see §2).
+- **Free byproduct:** per-shape multiplicity (collision count) is exactly the
+  **selectivity** signal, and feeds the **stability** signal — computed in O(N).
+- **AVOID** frequent/discriminative subtree mining (FREQT/TreeMiner/gSpan+CORK):
+  output-exponential, NP-hard, and solves a _global corpus_ feature-selection
+  problem, not our _per-target_ one-witness query. Confirmed by the
+  subtree-mining strand.
+
+### 2. Matching/verification is O(N) given the index; the exponential is only in preprocessing and is avoidable
+
+"All hole-patterns matching a fixed subtree `s`" is a **regular tree language**
+`L_s`, linear in `|s|` (Comon et al., _Tree Automata Techniques and
+Applications_). Bottom-up **match-set automata** (Hoffmann–O'Donnell, "Pattern
+Matching in Trees," JACM 1982; the BURS/instruction-selection lineage,
+Chase POPL'87, Cai–Paige–Tarjan TCS'92) match all indexed patterns in **O(N)**
+at the subject pass via table lookups. The minimal distinguisher is, in theory,
+the regular-language difference `L_t \ ⋃_{u≠t} L_u`. The exponential lives in
+preprocessing / the product over many items — and is **avoided** by (i)
+hash-consing + alpha-normalizing first (equality = identity ⇒ stay regular,
+dodge `f(t,t)`), and (ii) using one shared automaton / posting-list index rather
+than materializing pairwise differences. Term indexing (Sekar–Ramakrishnan–
+Voronkov, _Handbook of Automated Reasoning_ ch. 26) frames this as an
+**imperfect index**: cheap candidate retrieval + an exact verification step.
+**Schulz fingerprint indexing (IJCAR 2012)** is the closest prior art to our
+index — fixed-length feature vectors coded `{symbol, A=var, B=below-var,
+N=absent}` with sound compatibility tables, stored as a constant-depth trie so
+retrieval is **leaf-union, not per-coordinate intersection** (a concrete
+improvement over a naive "intersect posting lists" design).
+
+Takeaway: our production matcher is the **verification oracle / prove-gate**;
+the index narrows candidates. No index choice can yield a wrong selector.
+
+### 3. The minimization is NOT a free read-off — it is Minimum Set Cover (and that is fine)
+
+This is the load-bearing finding. "Smallest feature subset whose posting-list
+intersection is `{t}`" reduces **exactly** to Minimum Set Cover over the
+non-target items (feature `f` "covers" the non-targets it excludes). Equivalent,
+under the same reduction, to **minimum key / unique-column-combination**
+(Lucchesi–Osborn, JCSS 1978: NP-complete), **minimum teaching set / specifying
+set / witness set** (Goldman–Kearns 1995), and the one-target **Minimum Test
+Cover** (Garey–Johnson [SP6]).
+
+- NP-hard; **W[2]-complete** in solution size; not approximable below
+  `(1−ε)ln n` unless P=NP (Feige JACM'98; Dinur–Steurer STOC'14).
+- **Greedy "most-selective-first"** (repeatedly take the feature excluding the
+  most still-included non-targets) gives `H(d) ≤ 1 + ln d` (`d` = max
+  non-targets one feature excludes), tight worst case `ln n − ln ln n + Θ(1)`
+  (Slavík'97), and is **essentially the best any poly-time algorithm achieves**.
+- **The common case is a true read-off.** Real selectivity is Zipfian, so a
+  single highly selective+stable feature usually has posting list `{t}` already
+  ⇒ `OPT=1` ⇒ greedy returns it in step 1 in **O(target)**. The search domain is
+  intrinsically bounded by the target's own `≤d` features (`2^d`), **never the
+  corpus** — so "bounded, not unbounded search" is rigorous.
+- **Exact tail, if ever wanted:** `O*(2^d)` subset-DP, or UCC/minimal-hitting-set
+  enumerators (Ducc, HyUCC, HPIValid; Fredman–Khachiyan quasi-poly) — keep in
+  reserve; greedy is the default.
+
+So the user's "mostly minimal / gets close, never dump the full AST" is **not a
+compromise — it is the theoretically correct target.** Pure read-off holds for
+the Zipfian majority (`OPT=1`); the tail is bounded greedy set-cover.
+
+### 4. Grouping is solved and linear: anti-unification / LGG
+
+The common pattern of several sibling targets is the **least general
+generalization** (Plotkin 1970, Reynolds 1970): first-order syntactic AU is
+_unitary_ (one canonical answer up to renaming) and **linear-time**; the n-ary
+version is the order-independent lattice meet — concrete where all siblings
+agree, holes where they diverge. Co-occurrence in posting lists detects the
+overlap cheaply (no search). Caveat: **variadic** AST children need
+**unranked/hedge anti-unification** (Kutsia–Levy–Villaret), which is _finitary_
+(a small candidate set, not one). The "distinguish one from the rest" half is
+NOT AU — that is the §3 set-cover problem (version-space G-boundary descent).
+
+## The one real lock-in fork: variable-length list holes
+
+Every strand flags the same break point. Hash-consing, match-set automata,
+fingerprint/term indexing, and first-order AU **all assume fixed arity**. A hole
+absorbing a 0..k-child run (`ARGS`, `STMT_LIST`, `OBJECT_PROPS`, `DECLARATORS`,
+`CLASS_REST`) has no native fixed-arity encoding. Options:
+
+- **(a) Cons-spine binarization + bounded-depth skeletons.** Encode child lists
+  as right-leaning cons spines so a list hole is a wildcard over the spine tail;
+  hash only the top `d` levels (variadic frontier = one wildcard child). Keeps
+  everything in the ranked-tree / hash-cons / greedy world. Lowest lock-in,
+  slight expressivity loss on deep list-body matching.
+- **(b) Unranked / hedge automata** (TATA ch. 8) — native variadic holes
+  (regular language over child-state sequences), principled but heavier and a
+  bigger architectural commitment.
+- **(c) Schulz `B`-code sampling** — "this position may exist in an instance";
+  cheap but models one variable absorbing a fixed subtree, not a variadic run.
+
+**Recommendation: (a), behind a `shape-feature-extraction` + `matcher-verify`
+interface.** It preserves O(N) build + greedy read-off, matches how the existing
+matcher already handles list holes, and the interface lets us swap to (b) hedge
+automata later _iff_ deep list-body matching proves load-bearing. This is the
+lock-in mitigation: **no arity assumption is baked into the index/greedy core**;
+it lives only in feature extraction + verification, both swappable.
+
+## Recommended architecture (three layers, each grounded in solved prior art)
+
+1. **Canonicalization + shape index (O(N), low regret — build now).**
+   Hash-consed Merkle DAG with alpha-leaf canonicalization; multi-granularity
+   shape features (shallow literals, object keys, member/callee names,
+   bounded-depth skeletons); inverted posting lists; per-shape selectivity +
+   stability scores. Supersets the existing `SelectorCandidateIndex` (#2251),
+   which is already a partial path-index — extend it, don't fork it.
+2. **Read-off minimization (greedy set-cover, two-key ranking).** For a target,
+   scan its `≤d` features ranked by **selective × stable**; if the top feature's
+   posting list is `{t}`, emit it (the `OPT=1` read-off); else greedy set-cover
+   over its features until the intersection is `{t}`. The production matcher
+   proves the result (imperfect-index + exact-filter). Never an unbounded scan;
+   never a full-AST dump.
+3. **Grouping (n-ary anti-unification).** When targets share an enclosing
+   declaration OR their minimal selectors overlap beyond a threshold (the agreed
+   trigger), emit the LGG as a `binding_group`; hedge-AU for variadic children.
+
+## Lock-in analysis (what's safe now vs. swappable)
+
+- **Safe to build now (low regret):** hash-cons Merkle index + alpha-leaf
+  canonicalization + inverted posting lists + greedy set-cover read-off + LGG
+  grouping. All textbook, O(N) / O(target), independently validated; greedy is
+  provably near-optimal so we are not betting on a heuristic that a better
+  poly-time algorithm could embarrass.
+- **Behind a swappable interface:** (i) the feature taxonomy (which
+  shapes/granularities), (ii) the **list-hole encoding** (cons-spine now; hedge
+  automata later), (iii) the exact-vs-greedy **tail solver** (greedy now;
+  UCC/hitting-set enumerator later if provable minimality is ever required).
+- **Invariant regardless of choices:** the production matcher is the correctness
+  gate, so no design decision can emit a selector that doesn't resolve uniquely.
+
+## Perf expectation & the validating experiment
+
+Build O(N) (one hash-cons pass); per-target O(d) in the `OPT=1` majority,
+O(d · posting) greedy tail; total ≈ O(N + M) for the common case. The ≤10s
+aspiration is consistent; the costs to watch are the per-emitted-selector
+prove-gate and the greedy tail. **Validating experiment for Wave 1** (before
+committing to the full migration): build the hash-cons index over the real
+~7MB chunk, measure (i) build time + memory, (ii) the distribution of `OPT` /
+read-off depth `d` across items (validates the Zipfian `OPT=1`-majority
+assumption), and (iii) per-target read-off time — a size-sweep confirming the
+near-linear slope. If `OPT=1` is _not_ the majority, the tail greedy cost
+dominates and we revisit before building the full minimizer.
+
+## Key sources
+
+- Hash-consing / min-DAG: Downey, Sethi, Tarjan, JACM 27(4), 1980.
+- Tree pattern matching / automata: Hoffmann & O'Donnell, JACM 29(1), 1982;
+  Chase, POPL 1987; Cai–Paige–Tarjan, TCS 106, 1992; Comon et al., TATA (2008).
+- Term indexing: Sekar, Ramakrishnan & Voronkov, Handbook of Automated Reasoning
+  ch. 26, 2001; McCune, JAR 9(2), 1992 (discrimination/path); Graf, RTA 1995
+  (substitution trees); Schulz, IJCAR 2012 (fingerprint indexing).
+- Anti-unification: Plotkin (1970), Reynolds (1970); Cerna & Kutsia survey,
+  IJCAI 2023; Kutsia–Levy–Villaret (unranked/hedge AU), JAR 2014.
+- Minimality core: Karp (1972); Lucchesi & Osborn, JCSS 1978 (keys NP-complete);
+  Feige, JACM 1998 & Dinur–Steurer, STOC 2014 (`ln n` inapproximability);
+  Chvátal, MOR 1979 & Slavík, 1997 (greedy bounds); Goldman & Kearns, JCSS 1995
+  (teaching dimension); Birnick et al., PVLDB 2020 (UCC ≡ hitting-set).
+
+## Decision needed before Wave 1
+
+Confirm the **list-hole encoding** (recommend (a) cons-spine + bounded-depth
+skeletons behind a swappable interface) and the green light to dispatch Wave 1
+(build layer 1 + run the validating experiment) on this design.

--- a/devinfra/js/debundle/plans/readoff_research/01_anti_unification_lgg.md
+++ b/devinfra/js/debundle/plans/readoff_research/01_anti_unification_lgg.md
@@ -1,0 +1,155 @@
+# Anti-unification / LGG for group patterns and distinguishing structure
+
+Research-spike strand (2026-06-16). Verbatim sub-agent report. Synthesis and
+recommendation live in <../readoff_algorithm_research.md>.
+
+## Scope and bottom line
+
+Anti-unification (AU) — equivalently, **least general generalization (lgg)** /
+most specific generalization (msg) — is exactly the right tool for problem
+**(a)**: computing the common pattern of a group of sibling terms. It is a
+mature, well-understood operation: for first-order syntactic terms it is
+_unitary_ (a single canonical answer), unique up to renaming, and computable in
+linear time. Problem **(b)** — producing a _minimal distinguishing_ pattern that
+matches `t` but none of a set `S` of others — is **not** what classical AU
+computes, and it is **not** a clean, single-answer problem: it is a
+discrimination/concept-learning problem whose minimal-size variants are
+set-cover/NP-hard-flavored.
+
+## 1. Plotkin (1970) and Reynolds (1970): first-order lgg
+
+In 1970, **Gordon Plotkin** and **John Reynolds** independently gave equivalent
+procedures for generalizing first-order terms. AU is the **dual of Robinson's
+unification** (1965), hence "anti-unification."
+
+- Plotkin, G. D. (1970). _A Note on Inductive Generalization._ Machine
+  Intelligence 5, pp. 153–163. (Follow-up: Machine Intelligence 6, 1971,
+  pp. 101–124.)
+- Reynolds, J. C. (1970). _Transformational systems and the algebraic structure
+  of atomic formulas._ Machine Intelligence 5, pp. 135–151.
+
+Key facts (established):
+
+- For any two first-order terms, the lgg exists, is a single term, and is
+  **unique up to variable renaming**. First-order syntactic AU is **unitary**.
+- Algorithm: walk both terms in parallel; where heads agree, recurse; where they
+  disagree, install a variable — _reusing the same variable for repeated
+  identical disagreement pairs_ (`f(a,a)` vs `f(b,b)` → `f(X,X)`, not `f(X,Y)`).
+- **Complexity:** linear-size output; modern formulations compute the lgg in
+  **linear time**; naive non-sharing is at worst quadratic.
+
+Sources: Wikipedia "Anti-unification (computer science)"; Cerna & Kutsia IJCAI
+2023 survey (arXiv:2302.00277); Galitsky CEUR Vol-2529.
+
+## 2. Anti-unification of a SET of n terms — the "common group pattern"
+
+Pairwise lgg is the lattice meet under the subsumption order; the lgg of a set is
+the order-independent fold `lgg(t1, lgg(t2, …))`. Result: concrete where **all**
+n terms agree, fresh variable where they **disagree** (same variable reused for
+recurring disagreement tuples) — "the common skeleton with holes punched where
+the siblings differ." Complexity ≈ **O(n · |term|)** for the syntactic case.
+
+**Caveat for ASTs:** list/sequence children of varying _length_ are not
+first-order-syntactic (arity differs). Those need **unranked / hedge
+anti-unification** (Kutsia, Levy, Villaret, _Anti-unification for Unranked Terms
+and Hedges_, JAR 2014), which can be **finitary** (several incomparable
+generalizations), so for variadic AST children you may get a small candidate set,
+not one. Dedicated n-ary "anti-combination" (ILP 2020) beats naive iteration.
+
+## 3. Higher-order / E-anti-unification and the Cerna–Kutsia survey
+
+Cerna, D. M. & Kutsia, T. (2023), _Anti-unification and Generalization: A
+Survey_, IJCAI 2023, arXiv:2302.00277. Categorizes AU by generalization type —
+_unitary / finitary / infinitary / nullary_ — and by theory (syntactic vs
+equational/E-generalization), order (first- vs higher-order), and added structure
+(ordered, nominal, sorted, constraint-based).
+
+- **Higher-order pattern AU is unitary and linear-time** (Baumgartner, Kutsia,
+  Levy, Villaret, JAR 58(2):293–310, 2017). Unrestricted higher-order AU is
+  unitary-or-nullary (arXiv:2207.08918).
+- **E-anti-unification** ranges unitary→infinitary/nullary, theory-dependent.
+- **Nominal AU** (binders / α-equivalence) is unitary–finitary (arXiv:2504.21097).
+
+For plain AST selector grouping we stay in the **unitary, linear-time
+first-order** world. Reach for E-/higher-order/unranked only for algebraic laws
+or variadic/binding structure (accepting finitary answers + higher cost).
+
+## 4. AU as the dual of unification; the lattice of generalizations
+
+Terms are quasi-ordered by subsumption (`t ≤ u` iff `tσ = u`). Unification = least
+upper bound (mgu, specialize); anti-unification = greatest lower bound (lgg,
+generalize). First-order terms form a lattice; lgg/mgu are meet/join. This is why
+the n-ary lgg is well-defined and order-independent. Generalization _type_ = the
+cardinality of the minimal complete set of generalizations.
+
+## 5. KEY QUESTION: most-specific generalization of {t} that excludes a set S
+
+**Honest answer: a different, non-clean problem; minimal-size versions are
+NP-hard, set-cover-flavored.** AU only generalizes; it has no "must not match
+these." This is a _discrimination_ problem:
+
+- **(a) Version spaces / candidate elimination (Mitchell 1977/1982).** Maintains
+  the S-boundary (maximally specific) and G-boundary (maximally general). Your
+  "most specific generalization of `{t}` not generalizing any `s∈S`" lives near
+  the **G-boundary**, which is generally a _set_ (can be exponentially many).
+- **(b) ILP / Golem / inverse resolution.** RLGG with negatives as consistency
+  constraints; **plain RLGG clause length grows O(mⁿ)**; Golem only polynomial
+  under **ij-determinacy**. Direct evidence "generalize-while-excluding" is hard
+  in general.
+- **(c) Contrast-set / minimal-distinguishing pattern mining** (most on-point):
+  Ting & Bailey, _Mining Minimal Contrast Subgraph Patterns_, SDM 2006 (minimal
+  hypergraph transversal core); minimal distinguishing subgraphs/subsequences
+  (Ramamohanarao/Bailey); survey arXiv:2209.13556.
+
+**Complexity verdict:** minimal distinguishing pattern is **NP-hard /
+set-cover-flavored**. Two sources: (i) matching/subgraph-iso (polynomial for
+_trees_, which helps us) and (ii) **minimizing** = minimal hypergraph transversal
+/ minimum set cover (NP-hard, log-approximable). No clean unitary
+"most-specific distinguishing generalization" exists.
+
+**Practical mapping (`t` = target sibling, `S` = others):**
+
+1. Specialize from the top (G-boundary descent): start most-general, add concrete
+   constraints from `t` until it stops matching every `s∈S`.
+2. Each concrete feature "kills" a subset of negatives; choosing the **fewest** =
+   **minimum set cover** over `S` ⇒ greedy set-cover (O(log|S|)-approx) is the
+   standard, defensible engineering answer.
+3. Enumerating _all_ maximally-general distinguishers = G-boundary / minimal
+   transversal; bound it (top-k, size cap).
+
+## Synthesis
+
+For **grouping** use first-order syntactic **lgg / anti-unification** (Plotkin
+1970, Reynolds 1970): unitary, linear-time, order-independent lattice meet —
+"shared structure concrete, divergence as variables." Variadic children →
+unranked/hedge AU (finitary). For **distinguishing** one declaration from the
+rest, AU is insufficient and there is no canonical operator: it is a
+discrimination problem (version-space G-boundary; ILP/Golem RLGG O(mⁿ); contrast
+mining → minimum set cover, NP-hard). Recommended: greedy top-down specialization
+with a set-cover heuristic, not an exact lgg-style operator.
+
+### Caveats on sourcing
+
+Plotkin 1970 / Reynolds 1970 are pre-digital Machine Intelligence volumes;
+titles/venues verified via the survey and secondary sources. Linear-time
+first-order lgg firmly established for higher-order _pattern_ generalization
+(Baumgartner et al. 2017, verified); naive non-sharing is quadratic. NP-hardness
+of _minimal_ distinguishing patterns well-supported for graphs (subgraph-iso +
+minimal-transversal/set-cover); for **trees/ASTs**, matching is polynomial, so
+the residual hardness is the minimization (set cover).
+
+### Primary URLs
+
+- Cerna & Kutsia survey: https://arxiv.org/abs/2302.00277 ·
+  https://www.ijcai.org/proceedings/2023/0736.pdf
+- Higher-order pattern AU linear time:
+  https://link.springer.com/article/10.1007/s10817-016-9383-3 ·
+  https://pmc.ncbi.nlm.nih.gov/articles/PMC6109779/
+- Wikipedia (CS): https://en.wikipedia.org/wiki/Anti-unification_(computer_science)
+- Golem / ILP: https://en.wikipedia.org/wiki/Golem_(ILP) ·
+  https://arxiv.org/pdf/2008.07912
+- Version spaces (Mitchell): https://en.wikipedia.org/wiki/Version_space_learning
+- Minimal contrast subgraphs (Ting & Bailey 2006):
+  https://people.eng.unimelb.edu.au/baileyj/papers/siampaper.pdf
+- Contrast pattern mining survey: https://arxiv.org/pdf/2209.13556
+- Unranked/hedge AU: https://link.springer.com/article/10.1007/s10817-013-9285-6

--- a/devinfra/js/debundle/plans/readoff_research/02_subtree_mining_and_tree_compression.md
+++ b/devinfra/js/debundle/plans/readoff_research/02_subtree_mining_and_tree_compression.md
@@ -1,0 +1,145 @@
+# Subtree mining vs. canonical subtree fingerprinting
+
+Research-spike strand (2026-06-16). Verbatim sub-agent report. Synthesis in
+<../readoff_algorithm_research.md>.
+
+**Bottom line.** For "read off one minimal distinguishing pattern per target in
+O(target size), with compact posting lists and cheap dedup of identical subtree
+shapes":
+
+- **AVOID** frequent/discriminative subtree (and subgraph) mining — a global,
+  output-exponential, NP-hard-flavored enumeration/selection problem,
+  mis-aligned with the local per-target task.
+- **USE** bottom-up Merkle-style hash-consing / minimal-DAG compression — a
+  textbook O(N) construction assigning every distinct subtree shape a canonical
+  id (equal shapes share a posting list automatically), composes with
+  alpha-equivalence canonicalization, exactly right for "bounded-depth shape
+  skeleton hashed to a feature."
+
+## PART A — Frequent and discriminative subtree mining (TOO HEAVY)
+
+### A1. Frequent subtree mining
+
+**FREQT** (Asai et al., 2002/2004) mines frequent labeled ordered tree patterns
+via levelwise rightmost-extension. **TreeMiner** (Zaki, KDD 2002; TKDE 2005)
+mines frequent embedded ordered subtrees with scope-lists.
+
+Why heavy:
+
+- **Support test NP-complete in general** (subgraph-isomorphism instance);
+  polynomial only for ordered trees.
+- **Combinatorial explosion**: exponentially more frequent subtrees than maximal
+  ones.
+- **No output-polynomial enumeration in general** (unless P=NP); none for
+  maximal frequent tree mining even for rooted unordered bounded-height trees.
+
+### A2. Discriminative / contrast subtree (subgraph) mining — wrong frame
+
+**gSpan** (Yan & Han, ICDM 2002) min-DFS-code canonical labeling. **CORK**
+(Thoma et al., SDM 2009/2010) submodular discriminativeness + greedy (1−1/e),
+folded into gSpan. Applications to ASTs/CFGs (arXiv:2308.11161).
+
+Why wrong for us:
+
+1. Solves a **global** problem (jointly discriminate across the whole labeled
+   corpus), not per-target one-witness.
+2. Pays the full frequent-mining pass first (inherits A1 cost).
+3. "Minimal distinguishing pattern" ≠ "discriminative feature set."
+4. The (1−1/e) guarantee approximates an NP-hard global optimum — irrelevant
+   overhead for a single existence witness.
+
+## PART B — Tree compression and canonical subtree fingerprints (USE)
+
+### B3. DAG compression / hash-consing / CSE — the right primitive
+
+- **Downey, Sethi, Tarjan, "Variations on the Common Subexpression Problem,"
+  JACM 27(4):758–771, 1980** — congruence-closure / CSE, basis of hash-consing.
+- Mechanism: build nodes bottom-up; a node equals an existing one iff label +
+  child-_ids_ match → return that id, else mint fresh. Identical shapes collapse.
+- **Linear time:** minimal DAG of a tree computable in O(n); one bottom-up pass.
+- **Merkle phrasing:** `id = hash(label, child-ids)`; equal subtrees hash equal
+  (Git object model / Hashlife).
+- Scope note: minimal DAG shares only **complete rooted-subtree** repeats;
+  top-trees/grammars (B4) also exploit internal/partial repeats.
+
+Answers to the three key questions:
+
+- **O(N) canonical ids so equal shapes share a posting list?** Yes — hash-cons /
+  minimal-DAG, one bottom-up pass.
+- **Cheap alpha-equivalence (minified ids as wildcards)?** Yes — canonicalize
+  leaves before hashing (replace identifiers with a wildcard/De-Bruijn token);
+  renamed-isomorphic subtrees hash equal. A single `IDENT` sentinel suffices if
+  binders don't matter (O(N)).
+- **Variable-length list holes?** Partially — the weak spot. A Merkle id hashes a
+  _fixed_ child sequence, so `[a,b,c]` and `[a,b,c,d]` don't collapse.
+  Mitigations: (a) **bounded-depth shape skeletons** (hash top d levels, variadic
+  frontier = one wildcard child) — the "shape feature" we want; (b) tree-grammar
+  / top-tree representations for genuine variadic list-body matching.
+
+### B4. Top-tree compression and tree grammars — more than needed
+
+- **Top-tree compression** (Bille, Gørtz, Landau, Weimann, Inf. Comput. 2015 /
+  ICALP 2013): exploits internal repeats, can be exponentially smaller than DAG,
+  O(log n) navigation.
+- **SLCF tree grammars / TreeRePair** (Lohrey, Maneth, Mennicke): minimal SLCF
+  grammars smaller than minimal DAGs but **computing the minimal grammar is
+  NP-hard**; TreeRePair is a linear-time heuristic.
+
+Do their canonical-form ideas help fingerprints? Marginally and not for free: the
+internal DAG still rests on hash-consing; the extra power is partial/spine
+repeats (the list-hole problem). But optimal grammars are NP-hard, heuristics are
+**not canonical** (no stable equality token), and top-trees give canonical
+_navigation_, not a canonical _equality token_. Reach for them only if list-hole
+matching is load-bearing.
+
+### B5. Merkle / structural hashing in practice
+
+Git (Merkle DAG of content-addressed objects); compiler CSE/value-numbering
+(Downey–Sethi–Tarjan congruence closure); Hashlife (canonical ids for repeated
+quadtree subpatterns). Grounds "bounded-depth shape skeleton → feature": hash the
+top d levels (labels + child ids, identifiers wildcarded), emit the digest as the
+posting-list key. O(N), content-addressed, free dedup.
+
+## Final verdict
+
+| Technique                                                                    | Use?                                                 | Why                                                                                                                                               |
+| ---------------------------------------------------------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Hash-consing / minimal-DAG / Merkle hashing (Downey–Sethi–Tarjan 1980)       | **USE — core primitive**                             | O(N) canonical id per shape; equal shapes share posting list; alpha-equivalence via leaf-wildcarding; bounded-depth skeleton = the shape feature. |
+| Alpha-equivalence canonicalization (leaf-wildcarding; De-Bruijn for binders) | **USE — leaf step on top of hash-consing**           | Linear-ish; collapses minified/renamed identifiers.                                                                                               |
+| Top-tree / SLCF grammars (TreeRePair)                                        | **MAYBE — only if variadic list holes load-bearing** | Exploit internal/spine repeats DAG misses, but optimal NP-hard, heuristics non-canonical, give navigation not a stable equality token.            |
+| Frequent subtree mining (FREQT, TreeMiner)                                   | **AVOID**                                            | Output-exponential; NP-complete support test off ordered-tree case.                                                                               |
+| Discriminative/contrast subtree mining (gSpan+CORK)                          | **AVOID**                                            | Global NP-hard feature-selection; requires full frequent-mining pass; mis-framed for per-target one-witness.                                      |
+
+**One-line recommendation:** build the shape index with bottom-up Merkle
+hash-consing (O(N)), canonicalize identifier leaves to wildcards for
+alpha-equivalence, answer "minimal distinguishing pattern per target" as a query
+against per-shape posting lists. Keep tree-grammar/top-tree compression in
+reserve solely for variable-length list-hole matching; stay away from
+frequent/discriminative mining.
+
+## Sources
+
+- Frequent subtree mining: https://en.wikipedia.org/wiki/Frequent_subtree_mining ;
+  complexity https://arxiv.org/html/2602.03436 ;
+  https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4085724/
+- TreeMiner (Zaki) TKDE 2005: http://www.cs.rpi.edu/~zaki/PaperDir/TKDE05-treeminer.pdf ;
+  https://dl.acm.org/doi/10.1109/TKDE.2005.125
+- FREQT: https://globals.ieice.org/en_transactions/information/10.1587/e87-d_12_2754/_p ;
+  https://link.springer.com/chapter/10.1007/3-540-45681-3_1
+- gSpan: http://protocols.netlab.uky.edu/~liuj/teaching/CS685_s19/ref-gSpan.pdf
+- CORK / discriminative subgraph mining: https://www.dbs.ifi.lmu.de/Publikationen/Papers/SAM2010.pdf ;
+  https://sites.cs.ucsb.edu/~xyan/papers/sdm09_submodular.pdf ;
+  survey https://link.springer.com/chapter/10.1007/978-3-642-40837-3_4
+- Downey, Sethi, Tarjan JACM 1980: https://dl.acm.org/doi/10.1145/322217.322228
+- Hash-consing / O(n) tree hashing: https://arxiv.org/pdf/1109.0784 ;
+  https://www.baeldung.com/cs/hashing-tree ; https://arxiv.org/pdf/2105.01344
+- Alpha-equivalent hash-consing (thinnings / De Bruijn):
+  https://www.philipzucker.com/thin_hash_cons_codebruijn/
+- Top-tree compression: https://www2.compute.dtu.dk/~phbi/files/publications/2013tcwttC.pdf ;
+  https://www.sciencedirect.com/science/article/pii/S0890540114001643 ;
+  https://arxiv.org/pdf/1506.04499
+- Grammar-based tree compression / TreeRePair:
+  https://link.springer.com/chapter/10.1007/978-3-319-21500-6_3 ;
+  https://arxiv.org/pdf/1007.5406
+- Merkle/structural hashing in practice: https://en.wikipedia.org/wiki/Merkle_tree ;
+  https://en.wikipedia.org/wiki/Hashlife

--- a/devinfra/js/debundle/plans/readoff_research/03_tree_automata_and_pattern_matching.md
+++ b/devinfra/js/debundle/plans/readoff_research/03_tree_automata_and_pattern_matching.md
@@ -1,0 +1,183 @@
+# Tree automata & bottom-up tree pattern matching
+
+Research-spike strand (2026-06-16). Verbatim sub-agent report. Synthesis in
+<../readoff_algorithm_research.md>.
+
+## 1. Hoffmann & O'Donnell (JACM 1982): bottom-up tree pattern matching
+
+Christoph M. Hoffmann, Michael J. O'Donnell, "Pattern Matching in Trees," JACM
+29(1):68–95, 1982. DOI 10.1145/322290.322295.
+
+- Patterns are trees over a ranked alphabet with a wildcard `v`; "simple
+  patterns" are **linear** (no repeated-variable equality constraint).
+- Central object: the **match set** at a subject node = the set of pattern
+  subtrees matching there. Computed bottom-up: at node `f` with children labeled
+  match sets `m_1..m_k`, `table_f(m_1,…,m_k) → m`. A pattern matches at a node iff
+  its root subpattern is in that node's match set.
+- This is a **deterministic bottom-up tree automaton** whose states are match
+  sets.
+- **Matching:** O(n) table lookups for a subject of n nodes — **linear in the
+  subject, independent of pattern-set size at match time.**
+- **Preprocessing can be exponential** in the size/number of patterns (number of
+  subsumption-closed match sets; per-operator table indexed by tuples of states).
+- **Read-off:** at each node read its match-set label / a precomputed bitvector
+  of which patterns fire — O(1) per (node, pattern), no re-traversal.
+
+Follow-up taming the blow-up (not eliminating it):
+
+- Chase, "An Improvement to Bottom-up Tree Pattern Matching," POPL 1987 —
+  compresses transition tables; worst case stays exponential.
+- Cai, Paige, Tarjan, "More Efficient Bottom-up Multi-pattern Matching in
+  Trees," TCS 106(1):21–60, 1992 — asymptotic improvements, ~10× on hardest
+  instances; no polynomial worst-case guarantee.
+
+Industrial application — **instruction selection / BURS**: Pelegrí-Llopart &
+Graham (POPL 1988); Proebsting, "BURS Automata Generation," TOPLAS 1995; survey
+Hjort Blindell arXiv:1306.4898.
+
+Mapping:
+
+- _AST subtrees:_ direct; subject pass labels every node in O(N).
+- _Alpha-equivalence:_ a single wildcard `v` for "any identifier leaf" is
+  Hoffmann–O'Donnell's variable — native, linear. **Non-linear** matching (two
+  holes must bind the _same_ identifier) is harder (Ramesh & Ramakrishnan,
+  "Nonlinear Pattern Matching in Trees," JACM 39(2):295–316, 1992); fix by
+  linear match + equality post-check, or canonicalize identifiers first (§4).
+- _Variable-length list holes:_ the real impedance mismatch — Hoffmann–O'Donnell
+  is over a **ranked** alphabet. Need **unranked/hedge automata** (§2) or
+  cons-spine binarization.
+- _Minimality / stable-anchor bias:_ not addressed — the automaton tells you
+  _which_ patterns match, not _which is minimal_ (that is §3).
+
+## 2. TATA — Tree Automata Techniques and Applications (Comon et al., 2008)
+
+Free book; mirrors at eecs.harvard.edu and pages.di.unipi.it.
+
+Chapter 1 essentials:
+
+- **Recognizable = regular tree languages**, recognized by finite tree automata
+  (bottom-up or top-down).
+- **Determinization:** every NFTA has an equivalent DFTA via subset construction,
+  **worst-case exponential** in #states. Deterministic top-down is strictly
+  weaker — rely on bottom-up determinism.
+- **Closure:** under union, intersection, complement, hence **difference**.
+  Complement needs a complete deterministic automaton (⇒ determinization blow-up
+  if input is nondeterministic).
+- **Emptiness:** decidable by reachability fixpoint in **linear time O(|A|)**;
+  PTIME for DFTAs. Pumping lemma holds.
+- **Equivalence/inclusion:** decidable but **DEXPTIME-complete** in general
+  (PSPACE-complete for finite languages).
+- **Unranked extension (Chapter 8 / hedge automata):** the principled home for
+  `ARGS`/`STMT_LIST` — child-state sequences described by a regular language, so
+  a "list hole" becomes a regex over child states.
+
+Corroborating text-extractable sources: Lammich TUM notes; "An Efficient Finite
+Tree Automata Library" arXiv:1204.3240; congruence perspective arXiv:2104.11453.
+
+## 3. Is "all hole-patterns matching subtree s" a regular tree language? Minimal distinguisher = language difference?
+
+**Yes, `L_s` is regular — caveat on the hole language.** For a fixed subject `s`
+and **linear patterns**, the set of patterns matching `s` is a regular tree
+language `L_s` over `Σ ∪ {v}`: roughly `s` with any antichain of complete
+subtrees replaced by `v`. Recognizable by a DFTA with O(|s|) states, built in
+linear time. (The Hoffmann–O'Donnell match set at `s`'s root is a finite
+description of `L_s ∩ indexed-patterns`.) Finitely many equivalence classes =
+the Myhill–Nerode/congruence property.
+
+**Caveat — nonlinearity.** If holes must bind equal subtrees (`f(x,x)`), the set
+of matched _ground terms_ is **not regular** (pumping lemma). Fix: canonicalize
+(hash-cons / alpha-normalize, §4) so equality = identity, staying regular.
+
+**Minimal distinguisher as language difference:**
+
+```
+Distinguishers(t) = L_t \ ⋃_{u ≠ t, u indexed} L_u
+```
+
+regular (closed under ∩, complement). "Minimal" = the minimum-cost member under
+a preference order (fewest concrete nodes / most wildcards, stability-biased) —
+a weighted-emptiness / best-tree DP over the automaton (polynomial in its size).
+"Is `{t}` distinguished only by the fully-concrete pattern?" is an
+emptiness/inclusion check.
+
+**Where the blow-up lives:** each `L_s` is linear in `|s|`; the **product /
+intersection over many indexed `u`** is O(∏|L_u|) — exponential in the number of
+indexed items if done monolithically (same explosion as the match-set universe).
+Equivalence/inclusion underlying "unique distinguisher" is DEXPTIME-complete in
+the worst case (polynomial for the deterministic linear-hole automata in
+practice). **Mitigation:** don't materialize the global product — reuse one
+shared match-set automaton, turning "distinguish t from everyone" into membership
+queries against a single automaton, not k pairwise differences.
+
+## 4. Bottom-up subtree hashing / Merkle identity / hash-consing / DAG compression
+
+Hash-consing: bottom-up `id(node)=H(op ‖ child-ids)`; structurally identical
+subtrees collapse; subtree equality = O(1) id comparison; whole tree becomes a
+maximally-shared DAG. Merkle phrasing identical. Linear-time foundation: Downey,
+Sethi, Tarjan, JACM 1980 (O(n log n) general congruence closure; linear special
+cases incl. bottom-up subtree identity).
+
+Beyond rooted-subtree sharing: top-tree compression (Bille et al., Inf. Comput.
+2015; arXiv:1304.5702) exploits internal repeats, can beat DAG exponentially,
+O(log n) navigation.
+
+Mapping:
+
+- AST subtrees / equal shapes share one id: exactly hash-consing, O(N).
+- Alpha-equivalence: fold into the digest (normalize minified ids to a canonical
+  token / De Bruijn) ⇒ alpha-equivalent subtrees hash-cons to the same id in
+  O(N), and **restores regularity** for §3 (equality-of-holes = identity-of-ids).
+- List holes: hash-cons over the same binarized cons-spine the matcher uses.
+- Minimality / stable anchors: hashing gives **per-shape frequency** for free
+  (count collisions per id) — the stable-anchor / selectivity signal; weight the
+  §3 cost function by these counts.
+
+## 5. XML/XPath twig-query indexing (brief analog)
+
+TwigStack (Bruno, Koudas, Srivastava, SIGMOD 2002): stack-chains encoding
+partial path matches; I/O- and CPU-optimal for ancestor-descendant twigs; weak on
+parent-child (spurious intermediate results). Index-accelerated variants
+(TwigX-Guide, C-Tree). **Borrow:** holistic stack-based linear composition for
+list holes; region/Dewey encoding for O(1) ancestor/depth tests. **Don't import**
+the parent-child intermediate-result pathology (axis semantics we don't have).
+
+## Bottom line on the O(N) aspiration
+
+- **Per-subject matching is genuinely O(N)** (match-set lookups; hash-cons
+  identity), given the tables/automata.
+- **The exponential lives entirely in preprocessing** (match-set universe;
+  equivalently the intersection/complement product over items; DEXPTIME
+  equivalence worst case).
+- **It need not kill O(N) if** you (i) hash-cons/alpha-normalize first (equality
+  = identity ⇒ regular), (ii) use one shared deterministic match-set automaton
+  instead of k pairwise differences, (iii) use hedge automata or principled
+  binarization for list holes. The exponential is then bounded by pattern/index
+  structure, paid once, far below worst case in practice; the subject pass and
+  per-target read-off stay linear.
+
+## Sources
+
+- Hoffmann & O'Donnell JACM 1982: https://doi.org/10.1145/322290.322295
+- Chase POPL 1987: https://dl.acm.org/doi/10.1145/41625.41640
+- Cai, Paige, Tarjan TCS 1992: https://scholarsmine.mst.edu/math_stat_facwork/106/
+- Ramesh & Ramakrishnan, Nonlinear Pattern Matching, JACM 1992:
+  https://doi.org/10.1145/128749.128752
+- BURS: Proebsting TOPLAS 1995 https://dl.acm.org/doi/10.1145/203095.203098 ;
+  survey https://arxiv.org/pdf/1306.4898
+- TATA: http://tata.gforge.inria.fr/ ;
+  https://www.eecs.harvard.edu/~shieber/Projects/Transducers/Papers/comon-tata.pdf
+- Tree-automata facts: https://www21.in.tum.de/~lammich/2015_SS_Automata2/slides/handout.pdf ;
+  https://arxiv.org/pdf/1204.3240 ; https://arxiv.org/pdf/2104.11453
+- Downey, Sethi, Tarjan JACM 1980: https://dl.acm.org/doi/10.1145/322217.322228
+- Hash-consing: https://en.wikipedia.org/wiki/Hash_consing ; https://arxiv.org/pdf/2509.20534
+- Top-tree compression: https://arxiv.org/abs/1304.5702 ;
+  https://www.sciencedirect.com/science/article/pii/S0890540114001643
+- XML twig: https://www.ijert.org/xml-twig-pattern-matching-algorithms-and-query-processing
+
+**Verification caveats:** TATA PDF mirrors are image-encoded (structural/
+complexity claims corroborated via Lammich notes, the FTA-library paper, the
+congruence-perspective paper, not direct quotation). The Hoffmann–O'Donnell
+exponential-preprocessing characterization is established (motivation for Chase
+1987 / Cai–Paige–Tarjan 1992). The "`L_s` regular / minimal distinguisher =
+language difference" framing in §3 is sound synthesis built on the closure-and-
+emptiness machinery + match-set-as-DFTA equivalence, not a single cited theorem.

--- a/devinfra/js/debundle/plans/readoff_research/04_term_indexing.md
+++ b/devinfra/js/debundle/plans/readoff_research/04_term_indexing.md
@@ -1,0 +1,194 @@
+# Term indexing for structural retrieval and minimal distinguishing patterns
+
+Research-spike strand (2026-06-16). Verbatim sub-agent report. Synthesis in
+<../readoff_algorithm_research.md>. Headline: **no term index solves the
+minimal-distinguishing-pattern problem directly** — that is an
+anti-unification / minimal-feature-cover problem; the indexes serve as the fast
+candidate-pruning + verification oracle.
+
+## 1. The canonical survey (Sekar, Ramakrishnan, Voronkov 2001)
+
+R. Sekar, I. V. Ramakrishnan, A. Voronkov, "Term Indexing," ch. 26 in _Handbook
+of Automated Reasoning_, 2001, pp. 1853–1964.
+
+Model: maintain indexed term set `L`; answer queries about query term `t`. Four
+retrieval operations by substitution relation:
+
+- **Retrieve unifiable** — indexed `s` with `∃θ. sθ = tθ`.
+- **Retrieve instances** — indexed `s` that are instances of the query
+  (`∃θ. tθ = s`); query more general.
+- **Retrieve generalizations** — indexed `s` that are generalizations of the
+  query (`∃θ. sθ = t`); entries more general (forward subsumption/rewriting).
+- **Retrieve variants** — `s` equal to `t` up to renaming.
+
+"Find the smallest pattern matching exactly one stored term" is
+generalization-flavored (a pattern `p` such that exactly one stored AST is an
+instance of `p`) ⇒ **retrieve-instances of `p`** is the relevant primitive.
+
+**Perfect vs. non-perfect (imperfect) indexing:** a perfect index returns
+exactly the matching set; an imperfect index returns a **candidate superset**
+filtered by an exact test — exactly the inverted-index situation (posting-list
+intersection gives candidates; confirm with a real match). Fingerprint indexing
+is explicitly non-perfect.
+
+## 2. Discrimination trees & path indexing
+
+McCune, "Experiments with discrimination-tree indexing and path indexing for term
+retrieval," JAR 9(2):147–167, 1992.
+
+**Discrimination tree** = trie over the **preorder (flattened) symbol string**;
+all variables collapsed to one wildcard `*`; shared prefixes share trie paths.
+
+- Build: O(|t|) per term, O(Σ|t|) total.
+- Retrieve generalizations (ground query): descend the matching edge **and** the
+  `*` edge — near O(|t|) in practice, the strong direction (E uses perfect
+  discrimination trees for forward rewriting).
+- Retrieve instances/unifiable (query has variables): a query wildcard matches
+  any stored subtree → branching multiplies; the weak direction (Graf & Meyer on
+  unifier retrieval).
+- Worst case exponential in branching but proportional to consistent trie paths.
+
+**Path indexing** (same paper): inverted index keyed by **root-to-position symbol
+paths** (`f.1.g.1`) → posting list of terms containing that path; retrieval
+intersects/unions posting lists. **The closest classical analog to our inverted
+feature index.** Build O(Σ|t|); inherently non-perfect (verify candidates). The
+trade-off (vs. fingerprinting) is the per-coordinate **intersection**.
+
+## 3. Substitution trees (Graf, RTA 1995)
+
+Nodes labeled with **substitutions**; the term at a leaf = composition of
+substitutions along the path. Shares common _instantiation_ structure (not just
+symbol prefixes) → **most compact** of the classical trio; supports all four
+relations. Price: backtracking substitution state; insertion computes a
+generalization (msg/anti-unifier) to decide splits — adjacent to, but not, a
+distinguishing-pattern computation. Higher-order extension: Pientka, TOCL 2009.
+
+## 4. Fingerprint indexing (Schulz, IJCAR 2012) — closest analog to our tool
+
+S. Schulz, "Fingerprint Indexing for Paramodulation and Rewriting," IJCAR 2012,
+LNAI 7364, pp. 477–483.
+
+**General fingerprint feature function.** Fix sample positions. For term `t`,
+position `p`, `gfpf(t,p) ∈ F ⊎ {A, B, N}`:
+
+- `A` if `p ∈ pos(t)` and `t|_p` is a **variable**;
+- `top(t|_p)` (the function symbol) if `p ∈ pos(t)` and `t|_p` is **not** a
+  variable;
+- `B` if `p = q.r` with `q ∈ pos(t)` and `t|_q` a variable (position lies
+  **strictly below** a variable — could exist in an instance);
+- `N` otherwise (position **cannot exist** in `t` or any instance).
+
+A fingerprint is the length-`n` vector over the fixed positions — **constant
+length, independent of term size.**
+
+**Compatibility (the pruning core), verbatim from Fig. 1** (`f₁,f₂` distinct
+symbols):
+
+Unification compatibility (symmetric):
+
+|        | f₁  | f₂  | A   | B   | N   |
+| ------ | --- | --- | --- | --- | --- |
+| **f₁** | Y   | N   | Y   | Y   | N   |
+| **f₂** | N   | Y   | Y   | Y   | N   |
+| **A**  | Y   | Y   | Y   | Y   | N   |
+| **B**  | Y   | Y   | Y   | Y   | Y   |
+| **N**  | N   | N   | N   | Y   | Y   |
+
+Matching compatibility (match `s` onto `t`; asymmetric, rows = `s`, cols = `t`):
+
+|        | f₁  | f₂  | A   | B   | N   |
+| ------ | --- | --- | --- | --- | --- |
+| **f₁** | Y   | N   | N   | N   | N   |
+| **f₂** | N   | Y   | N   | N   | N   |
+| **A**  | Y   | Y   | Y   | N   | N   |
+| **B**  | Y   | Y   | Y   | Y   | Y   |
+| **N**  | N   | N   | N   | N   | Y   |
+
+Two distinct concrete symbols at one position (`f₁` vs `f₂`) are never
+compatible — the prune. **Soundness (Thm 1):** incompatible fingerprints ⇒ not
+unifiable / does not match. Compatibility is a **necessary condition** (never
+drops a true match; over-approximates).
+
+**Organization & cost:** fingerprints partition terms into disjoint classes; the
+index is a **constant-depth trie of depth `n`**; query descends every
+compatible edge and **unions** reached leaves. Build O(n·|L|); query O(n) +
+candidates. **Key advantage vs. posting-list intersection:** each term sits at
+exactly one leaf, so retrieval **unions compatible leaves** — _no per-coordinate
+intersection_ (Schulz §3 contrasts coordinate/path indexing explicitly).
+
+**Mapping:** our "inverted feature index, intersect posting lists" is the
+coordinate/path formulation; Schulz's fixed-length sampled vector + trie replaces
+intersection with one descent + union, with sound `A/B/N` compatibility tables we
+can adopt wholesale. Break points: alpha-equivalence (handled — see §"breaks"),
+and variadic list holes (the `B` code only models one variable absorbing a fixed
+subtree).
+
+## 5. Code trees and context/abstraction trees
+
+**Code trees** (Voronkov, JAR 1995; Riazanov & Voronkov, JELIA 2000): a
+discrimination tree compiled into matching-VM instructions; faster execution
+model, same asymptotic retrieval semantics. **Context trees** (Ganzinger,
+Nieuwenhuis, Nivela, JAR 2004) generalize substitution trees with **context
+variables (holes)** — the closest classical idea to "list holes" — but still
+index for the four standard relations, not minimality.
+
+## 6. Do these indexes read off the minimal distinguishing pattern? NO.
+
+Every structure answers _membership/relation_ queries. With retrieve-instances
+you can **verify** a candidate `p` ("does exactly one stored term match `p`?")
+efficiently — an excellent **oracle**. But none **searches** the pattern space or
+**reads off** the minimal distinguisher in linear preprocessing.
+
+Why it's separate: "most general pattern matching exactly one stored term" is an
+**anti-unification-lattice + minimum-feature-cover** problem — among
+generalizations of `x`, find a maximal one whose instance-set ∩ stored-set =
+`{x}`. Generalizing increases coverage monotonically ⇒ a **minimum-cover /
+hitting-set** optimization. Studied as **minimal distinguishing patterns** and
+**teaching / distinguishing sets** (Wang & Bailey KAIS; "Distinguishing Pattern
+Languages with Membership Examples," 2017; teaching dimension, Goldman & Kearns
+1995). Minimization is **NP-hard** (set cover); greedy ln(n)-approximation
+(Chvátal 1979) in practice — the index makes each greedy step cheap but does not
+remove the minimization.
+
+**Precise relationship:** (1) build the inverted feature index (path/coordinate
+or Schulz fingerprint trie) — **linear preprocessing**; (2) it gives posting
+lists + a fast retrieve-instances oracle (literature fully supports this); (3)
+"smallest feature subset whose intersection is `{x}`" is **minimum set cover** —
+NP-hard — use greedy over posting lists. The index is the pruning/verification
+oracle; the minimality is layered on top and is set-cover-hard.
+
+## Where the analogy breaks (explicit)
+
+- **Variable-length list holes.** All five structures assume **fixed-arity**
+  symbols. A variadic hole has no native encoding; closer to tree/word automata
+  with gap symbols / unranked tree indexing (hedge automata). Schulz's `B` code
+  partially models "this fixed position may exist in an instance," not a variadic
+  run.
+- **Alpha-equivalence.** Indexes collapse variables to one wildcard (`*`) or
+  `A`/`B` codes — already alpha-invariant at the leaf level. The break appears
+  only if you must track _binding/sharing_ (same variable in two positions);
+  substitution/context trees recover some of this at extra cost.
+- **The minimality objective.** Not an indexing property at all.
+
+## Key URLs
+
+- Handbook ch. 26: https://dl.acm.org/doi/10.5555/778522.778535
+- McCune JAR 1992: https://link.springer.com/article/10.1007/BF00245458
+- Graf RTA 1995: https://link.springer.com/chapter/10.1007/3-540-59200-8_52
+- Schulz fingerprint PDF:
+  http://wwwlehre.dhbw-stuttgart.de/~sschulz/PAPERS/schulz_fp-index.pdf
+- Riazanov–Voronkov code trees:
+  https://link.springer.com/chapter/10.1007/3-540-40006-0_15
+- Ganzinger–Nieuwenhuis–Nivela context trees:
+  https://link.springer.com/article/10.1023/B:JARS.0000029963.64213.ac
+- Mining minimal distinguishing patterns:
+  http://people.eng.unimelb.edu.au/baileyj/papers/KIS.pdf
+- Teaching dimension: https://en.wikipedia.org/wiki/Teaching_dimension
+- Anti-unification linear-time: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6109779/
+
+**Confidence:** the Schulz `gfpf` definition, both compatibility tables, and the
+"union not intersection" advantage are quoted from the primary PDF (high
+confidence). The Handbook taxonomy and Graf/McCune/Voronkov/context-tree
+attributions are confirmed via publisher pages. The part-6 NP-hardness/set-cover
+framing is reasoning from the problem structure + distinguishing-pattern/teaching-
+dimension literature, not a verbatim theorem from a single indexing paper.

--- a/devinfra/js/debundle/plans/readoff_research/05_minimal_keys_and_distinguishing_sets.md
+++ b/devinfra/js/debundle/plans/readoff_research/05_minimal_keys_and_distinguishing_sets.md
@@ -1,0 +1,135 @@
+# The combinatorial core: "smallest feature set whose posting-list intersection is {target}"
+
+Research-spike strand (2026-06-16). Verbatim sub-agent report. Synthesis in
+<../readoff_algorithm_research.md>.
+
+## 0. The reduction that ties everything together
+
+Fix target `t` and a set of features (each a posting list = items having it).
+Keep only features whose posting list **contains** `t`. The intersection of
+chosen lists is `{t}` iff, for **every non-target** `x`, at least one chosen
+feature **excludes** `x`. This is exactly **Minimum Set Cover**, dualized:
+
+- Universe `U` = non-targets (size `n`).
+- Feature `f` ↦ `cover(f)` = the non-targets it excludes.
+- A subcollection covers `U` ⟺ its posting-list intersection is `{t}`.
+
+Parameters: `n` = #non-targets; `d` = max non-targets one feature excludes
+(largest set); `f` = max #features excluding any one non-target (frequency).
+
+## 1. Minimal unique column combinations / minimal keys (UCC discovery)
+
+- **Minimum-cardinality key is NP-complete** (decision: key of size ≤ k?):
+  Lucchesi & Osborn, "Candidate keys for relations," JCSS 17(2):270–279, 1978 —
+  also "is an attribute prime?" NP-complete; gives an **output-polynomial**
+  all-keys enumeration.
+- **#minimal keys can be exponential** (counting #P-hard): GORDIAN, Sismanis et
+  al., VLDB 2006.
+- **= minimal transversals (hitting sets) of the difference-set hypergraph**
+  (Mannila & Räihä, JCSS 1986; DAM 1992; DKE 1994).
+- **Transversal-hypergraph complexity:** Eiter & Gottlob, SIAM J. Comput.
+  24(6):1278–1304, 1995; enumeration in **quasi-polynomial total time
+  N^{o(log N)}** (Fredman & Khachiyan, J. Algorithms 21(3):618–628, 1996);
+  output-polynomial is the famous open problem.
+- **Modern equivalence:** Birnick et al., "Hitting Set Enumeration with Partial
+  Information for UCC Discovery," PVLDB 13(11):2270–2283, 2020 (HPIValid):
+  minimal-UCC discovery ≡ minimal-hitting-set enumeration of the difference-set
+  hypergraph under parsimonious reductions.
+- **Practical algorithms:** Ducc (PVLDB 2013), DFD (CIKM 2014), HyUCC (BTW 2017,
+  hybrid sampling + lattice validation — scales far beyond Ducc/DFD/GORDIAN).
+- **Parameterized:** bounded-size UCC detection is **W[2]-complete** in solution
+  size (Bläsius, Friedrich, Schirneck, arXiv:2103.13331).
+
+## 2. Minimum Set Cover and Minimum Test Cover
+
+- **Set Cover NP-hard** — Karp's 21 (1972).
+- **Greedy H-approximation:** Johnson (JCSS 1974), Lovász (Discrete Math. 1975),
+  Chvátal (Math. OR 4(3):233–235, 1979, weighted). Guarantee cost ≤
+  `H(s)·OPT ≤ (1 + ln s)·OPT`, `s` = largest set size.
+- **`(1−o(1)) ln n` inapproximable:** Feige, JACM 45(4):634–652, 1998.
+  Tightened to **`(1−ε) ln n` NP-hard ∀ε>0 under P≠NP:** Dinur & Steurer, STOC 2014. So greedy's `ln n` is essentially optimal.
+- **Minimum Test Cover / Test Collection** — Garey & Johnson [SP6], NP-complete;
+  set cover over the `~m(m−1)/2` pairs to separate. De Bontridder et al., Math.
+  Prog. B 98:477–491, 2003: greedy `O(log m)`, `O(log k)` for tests of size ≤ k,
+  APX-hard. **Our problem is the one-target special case** — only every `{t,x}`
+  pair, i.e. cover every non-target `x` — collapsing to plain set cover (with the
+  `OPT=1` shortcut).
+- **Frequency-`f` bound:** every element in ≤ `f` sets ⇒ LP-rounding / primal-dual
+  gives an **`f`-approximation** (generalizes vertex cover, `f=2`): Hochbaum,
+  SIAM J. Comput. 11(3):555–556, 1982; Vazirani, _Approximation Algorithms_,
+  ch. 14–15.
+
+## 3. Teaching dimension / minimal distinguishing sets
+
+- **Teaching dimension:** Goldman & Kearns, "On the Complexity of Teaching,"
+  COLT 1991 / JCSS 50(1):20–31, 1995. A **teaching set** = sample on which the
+  target is the _unique_ consistent concept — "smallest feature set making the
+  target unique." Co-originated: Shinohara & Miyano, New Generation Computing 8(4), 1991.
+- **Vocabulary equivalence:** minimal teaching set = specifying set = witness set
+  = key = discriminant (Kushilevitz, Linial, Rabinovich, Saks, JCTA 73(2), 1996).
+- **Minimum teaching set is NP-hard** by reduction from Set Cover
+  (Shinohara–Miyano; Goldman–Kummer; recursive TD NP-hard, arXiv:2307.09792).
+- **Combinatorial ancestor — separating systems:** Katona, J. Comb. Theory
+  1(2):174–194, 1966 (origin Rényi 1961). Modern identifying/discriminating codes
+  descend from this.
+
+## 4. Greedy behavior in practice
+
+- **Right guarantee is `H_d`, not `H_n`** (Chvátal/Lovász): `H(d) = ln d + O(1)`,
+  `d` = max non-targets one feature excludes. If no feature is very selective `d`
+  is small ⇒ small constant (`H(7) ≈ 2.59`).
+- **Exact worst case `ln n − ln ln n + Θ(1)`** (Slavík, STOC 1996 / J. Algorithms
+  25(2):237–254, 1997); greedy essentially optimal given §2 inapproximability.
+- **`OPT=1` trivial and common:** a single feature excluding all non-targets ⇒
+  greedy returns it in step 1, optimal.
+- **Why typical instances are easy:** Zipf/Heaps term-frequency power laws
+  (Manning, Raghavan, Schütze, _IR_, 2008) ⇒ usually some highly selective
+  feature ⇒ small `OPT`. The IR/DB **"most-selective-first"** heuristic _is_ the
+  greedy max-coverage rule under the §0 duality (System R, Selinger et al. SIGMOD
+  1979).
+- **`f`-bound lever:** few features per non-target ⇒ small-constant `f`-approx;
+  operative bound `min(H_d, f)`.
+- **Bounded VC-dimension lever:** Brönnimann & Goodrich, DCG 14(4):463–479, 1995
+  give `O(d·log(d·c))` (so `O(log c)` for constant VC-dim, beating `ln n` when
+  OPT `c ≪ n`); Clarkson–Varadarajan / shallow-cell-complexity line. Caveat:
+  whether _our_ exclusion system has bounded VC-dim is data-dependent.
+
+## 5. Bounded vs unbounded search; FPT and output-sensitivity
+
+- **W[2]-complete in solution size `k`** (Downey & Fellows 1999) — not FPT in `k`
+  unless the W-hierarchy collapses.
+- **FPT in universe size `n`:** exact in **`O*(2^n)`** subset-DP
+  (`OPT(T)=1+min_i OPT(T\S_i)`; Fomin & Kratsch 2010; inclusion–exclusion
+  Björklund–Husfeldt–Koivisto 2006). When #non-targets-to-exclude is small, FPT in
+  _that_ parameter.
+- **Search bounded by the target's own `d` features:** any usable feature must
+  contain `t`, so a minimal distinguishing set ⊆ those `d` features — domain
+  `2^d`, **never the whole corpus** (attribute-lattice bound for keys). Choosing
+  the minimum subset is still set cover (`O*(2^d)` exact / `H_d`-approx).
+- **Output-sensitive enumeration of all minimal distinguishing sets** =
+  transversal-hypergraph enumeration, quasi-poly (Fredman–Khachiyan 1996);
+  UCC ≡ hitting-set (JCSS 2021).
+
+## Bottom line
+
+- **Minimal-distinguishing-feature-set NP-hard?** **Yes** — exactly Minimum Set
+  Cover over non-targets (= one-target Test Cover = minimum teaching set =
+  minimum key). NP-hard (Karp 1972 / Lucchesi–Osborn 1978); **W[2]-complete** in
+  solution size; not approximable below `(1−ε) ln n` unless P=NP (Dinur–Steurer
+  2014).
+- **Best practical guarantee:** greedy `ln n` (rank by selectivity, take the
+  feature excluding the most still-included non-targets) ⇒ `H(d) ≤ 1 + ln d`,
+  tight `ln n − ln ln n + Θ(1)` (Slavík 1997) — essentially optimal for any
+  poly-time algorithm. Instance levers: `f`-approx; `O(log OPT)` under bounded
+  VC-dim.
+- **Why typical instances are easy:** Zipfian selectivity ⇒ a single selective
+  feature drives `OPT=1` (greedy finds it in step 1); search bounded by the
+  target's own `d` features, never an unbounded scan; exact optimum reachable in
+  `O*(2^{#non-targets})` or `O*(2^d)` when small.
+
+**Caveats:** the Garey–Johnson [SP6] pointer and the exact test-cover greedy
+constant are secondary-sourced; the set-cover-over-rival-pairs reduction, the
+IR-duality framing, and "bounded by `d` posting lists" are sound synthesis. All
+complexity constants (Lucchesi–Osborn, Feige, Dinur–Steurer, Slavík,
+Chvátal/Lovász, Fredman–Khachiyan, W[2]-completeness) independently re-verified
+against primary indexes (DBLP, ScienceDirect, JACM/STOC records).

--- a/devinfra/js/debundle/plans/readoff_research/README.md
+++ b/devinfra/js/debundle/plans/readoff_research/README.md
@@ -1,0 +1,21 @@
+# Read-off minimization: research spike (2026-06-16)
+
+De-risking literature survey for the read-off selector-minimizer redesign,
+requested to avoid committing to an algorithm that can't reach the efficient one.
+Five independent strands, each a verbatim sub-agent report with verified
+citations. The synthesis + recommendation + lock-in analysis is one level up in
+<../readoff_algorithm_research.md>; the redesign plan is <../readoff_minimization.md>.
+
+| Strand                             | File                                         | Verdict                                                                                    |
+| ---------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| Anti-unification / LGG             | <01_anti_unification_lgg.md>                 | Grouping = first-order LGG (unitary, linear). Distinguishing ≠ AU → set-cover.             |
+| Subtree mining & tree compression  | <02_subtree_mining_and_tree_compression.md>  | USE hash-cons/Merkle min-DAG (O(N)); AVOID frequent/discriminative mining.                 |
+| Tree automata & pattern matching   | <03_tree_automata_and_pattern_matching.md>   | Match-set automata: O(N) match, exponential only in preprocessing (avoidable).             |
+| Term indexing                      | <04_term_indexing.md>                        | Schulz fingerprint trie (union, not intersection). No index reads off minimality.          |
+| Minimal keys / distinguishing sets | <05_minimal_keys_and_distinguishing_sets.md> | Minimality ≡ Minimum Set Cover / teaching set: NP-hard; greedy ln n optimal; OPT=1 common. |
+
+Convergent conclusion: **hash-consed Merkle shape index (O(N)) + greedy
+set-cover read-off (true read-off when OPT=1, the Zipfian majority) + LGG
+grouping**, with the production matcher as verification oracle. The single
+lock-in fork is the **variable-length list-hole encoding** (recommend cons-spine
+plus bounded-depth skeletons behind a swappable interface).


### PR DESCRIPTION
De-risking literature spike for the read-off minimizer redesign (requested
before committing to an index design that can't reach the efficient one). Five
independent strands, each a cited report under
`devinfra/js/debundle/plans/readoff_research/`, plus a synthesis with the
recommended three-layer architecture and lock-in analysis in
`plans/readoff_algorithm_research.md`.

**Convergent conclusion** (five strands agree):

- **Index** = bottom-up **hash-consed Merkle DAG** (Downey–Sethi–Tarjan 1980),
  O(N); canonical id per shape, alpha-equivalence by leaf-wildcarding (which
  keeps us in *regular tree language* territory), per-shape frequency for free.
  Frequent/discriminative subtree mining is explicitly the **wrong** (global,
  output-exponential, NP-hard) frame.
- **Minimality** = the smallest distinguishing feature set is **exactly Minimum
  Set Cover** = minimum key/UCC = minimum teaching set: NP-hard, W[2]-complete,
  inapproximable below `(1−ε)ln n`. **Greedy "most-selective-first" is `≈ln d`
  and essentially optimal**, and Zipfian selectivity makes `OPT=1` (a true
  one-feature read-off) the common case. So "mostly minimal / gets close" is the
  theoretically correct target, not a compromise.
- **Grouping** = first-order **anti-unification / LGG** (Plotkin–Reynolds 1970):
  unitary, linear; hedge-AU for variadic children.
- The production matcher stays the **verification oracle** (imperfect-index +
  exact filter, per term-indexing theory).

**Single lock-in fork:** variable-length list holes break the fixed-arity
assumption everywhere. Recommendation: **cons-spine binarization + bounded-depth
skeletons behind a swappable feature-extraction/matcher-verify interface**, so
the index/greedy core bakes in no arity assumption and we can swap to hedge
automata later iff list-body matching proves load-bearing.

Docs-only; gates Wave 1 of `plans/readoff_minimization.md`.

https://claude.ai/code/session_01RYUAvJefa2eJRgZ7XBfqxA

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYUAvJefa2eJRgZ7XBfqxA)_