### PR TITLE
debundle: add disabled e2e cases for over-pin shapes from the real spec

### DIFF
--- a/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
+++ b/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
@@ -366,6 +366,72 @@ minimizer_expectation_case!(
     expected = "expected_match.js",
 );
 
+// Aspirational: a subclass among many sibling subclasses of a shared base
+// should minimize to the `extends` clause (superclass holed with ANYTHING)
+// plus the single discriminating class field, with CLASS_REST holes absorbing
+// every other member. Today the minimizer dumps the whole class body (every
+// field and method) rather than anchoring on the one field literal that
+// distinguishes this subclass from its siblings, mirroring large blocks of
+// sibling subclass declarations kept whole in the real spec.
+minimizer_expectation_case!(
+    #[ignore = "subclass minimizer keeps full body instead of extends + discriminating field"]
+    minimizes_sibling_subclass_hierarchy,
+    fixture = "sibling_subclass_hierarchy",
+    name = "subclass among siblings keeps only the discriminating field initializer",
+    module = "app/shapes",
+    bindings = [("SelectedShape", "selectedShape")],
+    expected = "expected_match.js",
+);
+
+// Aspirational: a function whose body is a long run of sequential assignment
+// statements should minimize to STMT_LIST holes on both sides of the single
+// assignment whose right-hand side carries the discriminating literal. Today
+// the minimizer finds no sparse statement-level selector and bails (skips
+// rather than emitting a full-AST pin), so the flat sequence of writes is
+// never reduced to the one anchored assignment that uniquely identifies the
+// target among siblings sharing the same write-block shape.
+minimizer_expectation_case!(
+    #[ignore = "statement minimizer bails instead of STMT_LIST + discriminating assignment"]
+    minimizes_sequential_assignment_block,
+    fixture = "sequential_assignment_block",
+    name = "sequential assignment block keeps only the discriminating assignment",
+    module = "app/reducers",
+    bindings = [("SelectedReducer", "selectedReducer")],
+    expected = "expected_match.js",
+);
+
+// Aspirational: a binding initialized by a deeply nested call tree should
+// minimize to ANYTHING-holed outer callees and ARGS holes for their sibling
+// arguments, drilling only to the one deep object literal that carries the
+// discriminating key. Today the minimizer keeps the entire nested call/object
+// tree whole, over-pinning every wrapper call and every transient argument
+// instead of holing the path down to the single discriminating leaf.
+minimizer_expectation_case!(
+    #[ignore = "nested-call minimizer keeps whole tree instead of holing wrappers down to the leaf"]
+    minimizes_deeply_nested_call_args,
+    fixture = "deeply_nested_call_args",
+    name = "deeply nested call tree keeps only the discriminating leaf literal",
+    module = "app/views",
+    bindings = [("SelectedView", "selectedView")],
+    expected = "expected_match.js",
+);
+
+// Aspirational: a target object inside a multi-declarator group of sibling
+// enum/lookup objects should minimize to DECLARATORS holes around the target
+// declarator plus OBJECT_PROPS holes on both sides of the single discriminating
+// key. Today the minimizer keeps every sibling declarator's full object value
+// and every key of the target object, over-pinning a whole group of lookup
+// dicts where one declarator with one anchored key would resolve uniquely.
+minimizer_expectation_case!(
+    #[ignore = "group minimizer keeps all declarators and all keys instead of DECLARATORS + OBJECT_PROPS"]
+    minimizes_grouped_enum_objects,
+    fixture = "grouped_enum_objects",
+    name = "grouped enum objects keep only the target declarator's discriminating key",
+    module = "app/palettes",
+    bindings = [("SelectedPalette", "selectedPalette")],
+    expected = "expected_match.js",
+);
+
 // Re-baselined for the unified keep-shallow anchor policy: both outputs keep each
 // slot's direct shallow literals including object-property values. The group's
 // shared `enabled: true` and the standalone's `kind: "panel"` / `title: "Settings"`

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/deeply_nested_call_args/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/deeply_nested_call_args/expected_match.js
@@ -1,0 +1,9 @@
+const SelectedView = ANYTHING(
+  ANYTHING(
+    ANYTHING({
+      mode: "uniqueDiscriminatorMode",
+      OBJECT_PROPS,
+    }),
+    ARGS
+  )
+);

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/deeply_nested_call_args/source.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/deeply_nested_call_args/source.js
@@ -1,0 +1,47 @@
+const selectedView = wrapOuter(
+  decorate(
+    buildInner({
+      mode: "uniqueDiscriminatorMode",
+      payload: computePayload(Date.now()),
+    }),
+    { theme: "light" }
+  )
+);
+
+const firstSiblingView = wrapOuter(
+  decorate(
+    buildInner({
+      mode: "compact",
+      payload: computePayload(Date.now()),
+    }),
+    { theme: "light" }
+  )
+);
+
+const secondSiblingView = wrapOuter(
+  decorate(
+    buildInner({
+      mode: "wide",
+      payload: computePayload(Math.random()),
+    }),
+    { theme: "dark" }
+  )
+);
+
+function wrapOuter(value) {
+  return value;
+}
+
+function decorate(value, options) {
+  return { value, options };
+}
+
+function buildInner(config) {
+  return config;
+}
+
+function computePayload(value) {
+  return value;
+}
+
+export { selectedView };

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/grouped_enum_objects/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/grouped_enum_objects/expected_match.js
@@ -1,0 +1,7 @@
+const DECLARATORS_BEFORE = null,
+  SelectedPalette = {
+    OBJECT_PROPS,
+    accent: "uniqueDiscriminatorAccent",
+    OBJECT_PROPS,
+  },
+  DECLARATORS_AFTER = null;

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/grouped_enum_objects/source.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/grouped_enum_objects/source.js
@@ -1,0 +1,22 @@
+const firstPalette = {
+    red: "#f00",
+    green: "#0f0",
+    blue: "#00f",
+  },
+  selectedPalette = {
+    red: "#f00",
+    green: "#0f0",
+    blue: "#00f",
+    accent: "uniqueDiscriminatorAccent",
+  },
+  thirdPalette = {
+    red: "#f00",
+    cyan: "#0ff",
+  };
+
+const otherFirstPalette = {
+  red: "#f00",
+  green: "#0f0",
+};
+
+export { selectedPalette };

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/sequential_assignment_block/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/sequential_assignment_block/expected_match.js
@@ -1,0 +1,5 @@
+function SelectedReducer(ANYTHING, ANYTHING) {
+  STMT_LIST;
+  ANYTHING.delta = "uniqueDiscriminatorValue";
+  STMT_LIST;
+}

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/sequential_assignment_block/source.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/sequential_assignment_block/source.js
@@ -1,0 +1,28 @@
+function selectedReducer(state, data) {
+  state.alpha = data.alpha;
+  state.bravo = data.bravo;
+  state.charlie = data.charlie;
+  state.delta = "uniqueDiscriminatorValue";
+  state.echo = data.echo;
+  state.foxtrot = data.foxtrot;
+  return state;
+}
+
+function firstSiblingReducer(state, data) {
+  state.alpha = data.alpha;
+  state.bravo = data.bravo;
+  state.charlie = data.charlie;
+  state.delta = "alpha";
+  state.echo = data.echo;
+  return state;
+}
+
+function secondSiblingReducer(state, data) {
+  state.alpha = data.alpha;
+  state.bravo = data.bravo;
+  state.echo = data.echo;
+  state.foxtrot = data.foxtrot;
+  return state;
+}
+
+export { selectedReducer };

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/sibling_subclass_hierarchy/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/sibling_subclass_hierarchy/expected_match.js
@@ -1,0 +1,5 @@
+class SelectedShape extends ANYTHING {
+  CLASS_REST;
+  kind = "uniqueDiscriminatorShape";
+  CLASS_REST;
+}

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/sibling_subclass_hierarchy/source.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/sibling_subclass_hierarchy/source.js
@@ -1,0 +1,35 @@
+class baseShape {
+  area() {
+    return 0;
+  }
+}
+
+class roundShape extends baseShape {
+  kind = "round";
+  area() {
+    return this.radius * this.radius * 3;
+  }
+}
+
+class selectedShape extends baseShape {
+  kind = "uniqueDiscriminatorShape";
+  area() {
+    return this.side * this.side;
+  }
+}
+
+class wideShape extends baseShape {
+  kind = "wide";
+  area() {
+    return this.width * this.height;
+  }
+}
+
+class tallShape extends baseShape {
+  kind = "tall";
+  area() {
+    return this.width * this.height;
+  }
+}
+
+export { selectedShape };


### PR DESCRIPTION
Adds four **anonymized, synthetic, disabled** (`#[ignore]`) expectation cases
capturing distinct over-pinning shapes found by surveying the real tana/re spec
(longest `match:` blocks first; 2,651 selectors ranked). They give the read-off
minimizer (Wave 3) concrete targets to unignore as capabilities land. **No
tana-specific content** — every fixture uses neutral synthetic tokens
(`palette/shape/reducer/view`, color hexes, `uniqueDiscriminator*`); the real
spec was read for motivation only.

New shapes (distinct from the existing `object_keys_over_pinned` /
`class_among_many_siblings`):

| Case | Shape | Current minimizer | Aspiration |
|---|---|---|---|
| `sibling_subclass_hierarchy` | subclass among siblings of a shared base, one discriminating field | keeps the full class body | `extends ANYTHING` + field + `CLASS_REST` |
| `sequential_assignment_block` | function body = run of `this.x = …` writes | **bails** (no sparse selector) | `STMT_LIST` + discriminating assignment + `STMT_LIST` |
| `deeply_nested_call_args` | binding from a deeply nested call/JSX tree | keeps the whole nested tree | `ANYTHING(…({key, OBJECT_PROPS}), ARGS)` holing down to the leaf |
| `grouped_enum_objects` | target object in a multi-declarator group of sibling lookup objects | keeps every declarator + every key | `DECLARATORS` holes + `OBJECT_PROPS`/key/`OBJECT_PROPS` |

Each current-vs-aspiration contrast was confirmed by running the current
`synthesize-selectors` on the synthetic fixture. Suite builds green (the 4 new
cases stay `#[ignore]` — they compile/parse via swc but don't run). Fixtures
auto-wire through the existing `compile_data` glob; no BUILD change.

(Deliberately skipped: many-arm `switch` functions — not expressible with the
current hole vocabulary, no case-run list hole.)

https://claude.ai/code/session_01RYUAvJefa2eJRgZ7XBfqxA

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYUAvJefa2eJRgZ7XBfqxA)_