### PR TITLE
debundle: Wave 2 — read-off renderer + migrate function selectors

### DIFF
--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -140,6 +140,32 @@ rust_binary(
     ],
 )
 
+# Read-off selector renderer (W2): maps a read-off AnchorSet to the kept-span
+# set the existing selector_codemod prune machinery consumes. No second
+# serializer — rendering reuses the per-form render_with closure.
+rust_library(
+    name = "readoff_render",
+    srcs = ["readoff_render.rs"],
+    crate_root = "readoff_render.rs",
+    edition = "2024",
+    deps = [
+        ":selector_candidate_index",
+        ":shape_index",
+        "@crates//:swc_common",
+        "@crates//:swc_ecma_ast",
+        "@crates//:swc_ecma_visit",
+    ],
+)
+
+rust_test(
+    name = "readoff_render_test",
+    crate = ":readoff_render",
+    edition = "2024",
+    deps = [
+        ":js_ast",
+    ],
+)
+
 rust_library(
     name = "anonymous_resolution",
     srcs = ["anonymous_resolution.rs"],
@@ -559,7 +585,9 @@ rust_library(
     edition = "2024",
     deps = [
         ":js_ast",
+        ":readoff_render",
         ":selector_candidate_index",
+        ":shape_index",
         ":source_match",
         ":source_match_holes",
         ":spec",

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/nested_async_try/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/nested_async_try/expected_match.js
@@ -1,7 +1,7 @@
 async function SelectedLoader(ANYTHING, ANYTHING) {
   try {
     STMT_LIST;
-    await ANYTHING.fetch(ANYTHING, { includeMeta: true, OBJECT_PROPS });
+    await ANYTHING.fetch(ANYTHING, { OBJECT_PROPS, trace: ANYTHING });
     STMT_LIST;
   } catch (ANYTHING) {
     STMT_LIST;

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/sparse_function_body/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/sparse_function_body/expected_match.js
@@ -1,7 +1,4 @@
 function SelectedWorker(ANYTHING, ANYTHING, ANYTHING) {
-  STMT_LIST;
-  const marker = 123;
-  STMT_LIST;
-  ANYTHING.foo(ANYTHING, 123);
+  const transient = makeTransient(ANYTHING, ANYTHING.now());
   STMT_LIST;
 }

--- a/devinfra/js/debundle/plans/readoff_minimization.md
+++ b/devinfra/js/debundle/plans/readoff_minimization.md
@@ -190,3 +190,22 @@ each merge, and unignores E2E cases progressively. Build/test recipe: `bazelisk`
   `claude/debundle-shape-index`: Layer-1 shape index + read-off API + soundness
   test + benchmark, additive/behavior-preserving. OPT=1 share 100% on synthetic
   resolvable items; build linear. Ready for W2 (route forms through read-off).
+- 2026-06-16: W2 built on `claude/debundle-readoff-render`: production read-off
+  renderer (`readoff_render.rs`) maps a read-off `AnchorSet` to the kept-span
+  set the existing `selector_codemod` prune + swc-codegen machinery consumes (no
+  second serializer); skeleton/arity anchors pin via the holed scaffold (no kept
+  span). **Single-target function** migrated to read-off as its primary path:
+  `minimize_function_selector` reads off `minimal_anchor_set`, prefers the
+  structural empty-kept scaffold when it already discriminates, and renders
+  through the shared `render_with`. The cover search backs it as the
+  not-yet-expressible tail (chiefly _number/bool literal_ discriminators, which
+  the W1 feature taxonomy does not index — string literals only) and is **not
+  deleted** (strangler-fig). Var / class / object / group stay on the cover
+  (W3). Applied W1 hand-off note #1: greedy set-cover seeds `covered` from the
+  smallest relevant posting list (most-selective feature), not `0..N`, so
+  unresolvable items pay O(smallest posting) per step instead of O(N).
+  Equivalent-or-better fixture updates: `sparse_function_body` (2 anchors -> 1:
+  `Date.now()` member-property), `nested_async_try` (`includeMeta: true` ->
+  `trace` object key, both 1 anchor); both gate-proven unique. W3 should extend
+  the feature taxonomy to number/bool literals (drops the function cover
+  fallback) and migrate var / class / object / group.

--- a/devinfra/js/debundle/readoff_render.rs
+++ b/devinfra/js/debundle/readoff_render.rs
@@ -1,0 +1,324 @@
+//! Read-off selector renderer (W2 of the read-off minimization redesign; see
+//! `plans/readoff_minimization.md`).
+//!
+//! W1 built the [`ShapeIndex`] and its [`ShapeIndex::minimal_anchor_set`]
+//! read-off API, which returns the minimal [`AnchorSet`] — the smallest set of
+//! the target's own features whose posting-list intersection is the singleton
+//! `{target}`. W1's soundness test used a stand-in renderer; this is the
+//! production one.
+//!
+//! ## What it does
+//!
+//! It maps an [`AnchorSet`] to a **kept-span set** (`BTreeSet<AnchorSpan>`) over
+//! the target item's AST: the byte spans of exactly the concrete tokens the
+//! read-off chose to pin. That kept set is then handed to the *existing*
+//! `selector_codemod` AST-prune + swc-codegen machinery (`hole_stmts` /
+//! `hole_expr` / `hole_object` / `emit_selector` via the per-form `render_with`
+//! closure) — there is no second serializer. The matcher proves the result
+//! (gate 1), exactly as the cover path does.
+//!
+//! ## Skeleton / arity anchors (W1 hand-off note #2)
+//!
+//! When the discriminating feature is **structural** — a function/var skeleton,
+//! a member count, a param arity — it pins no literal, so it contributes **no
+//! kept span**. Structure is pinned by the holed scaffold itself: the function
+//! `render_with` emits one `ANYTHING` param per real param, so the rendered
+//! selector matches only that arity; the var scaffold pins `const`/`let`/`var`
+//! and the declarator shape. So a skeleton anchor is honored by rendering the
+//! scaffold with an empty (or value-only) kept set and letting the matcher pin
+//! the structure. Value-bearing anchors (string literals, object keys,
+//! member/method names, member-path callees) map to the spans of the tokens
+//! that exhibit them.
+//!
+//! ## Why a span set rather than a fresh AST
+//!
+//! The kept-span representation is exactly what every `selector_codemod` prune
+//! function already consumes (`node_retains_any`). Reusing it means the read-off
+//! path and the cover path render through identical code, so they cannot diverge
+//! on hole placement, codegen, or the matcher gate.
+
+use std::collections::BTreeSet;
+
+use selector_candidate_index::SelectorFeature;
+use shape_index::{AnchorSet, ShapeFeature};
+use swc_common::{Span, Spanned};
+use swc_ecma_ast::*;
+use swc_ecma_visit::{Visit, VisitWith};
+
+/// `(lo, hi)` byte offsets of a retained concrete token. Mirrors
+/// `selector_codemod::AnchorSpan` (the prune machinery's kept-span type).
+pub type AnchorSpan = (u32, u32);
+
+/// The value-bearing anchors a read-off can pin to concrete source tokens.
+/// Structural anchors (top-level kind, var kind, function arity, shape
+/// skeletons) carry no value and are pinned by the holed scaffold, so they are
+/// not collected here.
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+enum ValueAnchor {
+    StringLiteral(String),
+    ObjectKey(String),
+    ClassMember(String),
+    MemberProperty(String),
+    /// A member-path callee (`a.foo`); only `.`-containing labels reach here
+    /// (a bare-identifier callee is alpha-wildcarded and never an anchor).
+    CallCallee(String),
+}
+
+impl ValueAnchor {
+    /// The value-bearing anchors of an [`AnchorSet`]. Structural / skeleton
+    /// features yield nothing — the scaffold pins them.
+    fn from_anchor_set(anchor_set: &AnchorSet) -> BTreeSet<Self> {
+        anchor_set
+            .anchors
+            .iter()
+            .filter_map(|scored| match &scored.feature {
+                ShapeFeature::Selector(feature) => Self::from_selector_feature(feature),
+                ShapeFeature::Skeleton(_) => None,
+            })
+            .collect()
+    }
+
+    fn from_selector_feature(feature: &SelectorFeature) -> Option<Self> {
+        match feature {
+            SelectorFeature::StringLiteral(value) => Some(Self::StringLiteral(value.clone())),
+            SelectorFeature::ObjectKey(label) => Some(Self::ObjectKey(label.clone())),
+            SelectorFeature::ClassMember(label) => Some(Self::ClassMember(label.clone())),
+            SelectorFeature::MemberProperty(label) => Some(Self::MemberProperty(label.clone())),
+            SelectorFeature::CallCallee(label) => Some(Self::CallCallee(label.clone())),
+            SelectorFeature::TopLevelKind(_)
+            | SelectorFeature::VarKind(_)
+            | SelectorFeature::FunctionArity(_)
+            | SelectorFeature::ImportSource(_) => None,
+        }
+    }
+}
+
+/// Kept byte spans, in the target item, that exhibit the read-off's value
+/// anchors. Returned to the per-form `render_with` so the prune retains exactly
+/// those tokens and holes everything else.
+///
+/// A structural-only read-off (skeleton / arity / kind) yields an empty set:
+/// the holed scaffold alone discriminates, and the matcher proves it.
+pub fn kept_spans_for_anchor_set(
+    item: &ModuleItem,
+    anchor_set: &AnchorSet,
+) -> BTreeSet<AnchorSpan> {
+    let anchors = ValueAnchor::from_anchor_set(anchor_set);
+    let mut collector = SpanCollector {
+        anchors: &anchors,
+        kept: BTreeSet::new(),
+    };
+    item.visit_with(&mut collector);
+    collector.kept
+}
+
+/// Walks the target item collecting the byte span of every token that exhibits
+/// a chosen [`ValueAnchor`], mirroring the `SelectorCandidateIndex` feature
+/// taxonomy so the span-level pin matches the feature the read-off scored.
+struct SpanCollector<'a> {
+    anchors: &'a BTreeSet<ValueAnchor>,
+    kept: BTreeSet<AnchorSpan>,
+}
+
+impl SpanCollector<'_> {
+    fn keep(&mut self, span: Span) {
+        self.kept.insert((span.lo.0, span.hi.0));
+    }
+}
+
+impl Visit for SpanCollector<'_> {
+    fn visit_expr(&mut self, expr: &Expr) {
+        if let Expr::Lit(Lit::Str(str_)) = expr {
+            let value = str_.value.to_string_lossy().to_string();
+            if self.anchors.contains(&ValueAnchor::StringLiteral(value)) {
+                // Pin the literal node; the prune keeps it verbatim.
+                self.keep(str_.span);
+            }
+            return;
+        }
+        expr.visit_children_with(self);
+    }
+
+    fn visit_call_expr(&mut self, call: &CallExpr) {
+        if let Callee::Expr(callee) = &call.callee
+            && let Some(label) = member_callee_label(callee)
+            && self.anchors.contains(&ValueAnchor::CallCallee(label))
+        {
+            // Pin the callee member access; the prune keeps the property name
+            // and holes the receiver, yielding `ANYTHING.foo(...)`.
+            self.keep(callee.span());
+        }
+        call.visit_children_with(self);
+    }
+
+    fn visit_member_prop(&mut self, prop: &MemberProp) {
+        if let Some(label) = member_prop_label(prop)
+            && self.anchors.contains(&ValueAnchor::MemberProperty(label))
+        {
+            self.keep(prop.span());
+        }
+        prop.visit_children_with(self);
+    }
+
+    fn visit_object_lit(&mut self, object: &ObjectLit) {
+        for prop in &object.props {
+            if let Some((label, key_span)) = object_key_label_span(prop)
+                && self.anchors.contains(&ValueAnchor::ObjectKey(label))
+            {
+                self.keep(key_span);
+            }
+            prop.visit_with(self);
+        }
+    }
+
+    fn visit_class_member(&mut self, member: &ClassMember) {
+        if let Some((label, key_span)) = class_member_label_span(member)
+            && self.anchors.contains(&ValueAnchor::ClassMember(label))
+        {
+            self.keep(key_span);
+        }
+        member.visit_children_with(self);
+    }
+}
+
+/// `a.foo` for a member-access callee, mirroring `selector_candidate_index`'s
+/// `callee_label` for the member case (a bare identifier is never an anchor).
+fn member_callee_label(expr: &Expr) -> Option<String> {
+    let Expr::Member(member) = expr else {
+        return None;
+    };
+    let object = expr_label(&member.obj)?;
+    let prop = member_prop_label(&member.prop)?;
+    Some(format!("{object}.{prop}"))
+}
+
+fn expr_label(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Ident(ident) => Some(ident.sym.to_string()),
+        Expr::Member(member) => {
+            let object = expr_label(&member.obj)?;
+            let prop = member_prop_label(&member.prop)?;
+            Some(format!("{object}.{prop}"))
+        }
+        _ => None,
+    }
+}
+
+fn member_prop_label(prop: &MemberProp) -> Option<String> {
+    match prop {
+        MemberProp::Ident(ident) => Some(ident.sym.to_string()),
+        MemberProp::PrivateName(private) => Some(format!("#{}", private.name)),
+        MemberProp::Computed(_) => None,
+    }
+}
+
+fn object_key_label_span(prop: &PropOrSpread) -> Option<(String, Span)> {
+    let PropOrSpread::Prop(prop) = prop else {
+        return None;
+    };
+    match prop.as_ref() {
+        Prop::Shorthand(ident) => Some((ident.sym.to_string(), ident.span)),
+        Prop::KeyValue(kv) => prop_name_label_span(&kv.key),
+        Prop::Assign(assign) => Some((assign.key.sym.to_string(), assign.key.span)),
+        Prop::Getter(getter) => prop_name_label_span(&getter.key),
+        Prop::Setter(setter) => prop_name_label_span(&setter.key),
+        Prop::Method(method) => prop_name_label_span(&method.key),
+    }
+}
+
+fn class_member_label_span(member: &ClassMember) -> Option<(String, Span)> {
+    match member {
+        ClassMember::Constructor(ctor) => prop_name_label_span(&ctor.key),
+        ClassMember::Method(method) => prop_name_label_span(&method.key),
+        ClassMember::PrivateMethod(method) => {
+            Some((format!("#{}", method.key.name), method.key.span))
+        }
+        ClassMember::ClassProp(prop) => prop_name_label_span(&prop.key),
+        ClassMember::PrivateProp(prop) => Some((format!("#{}", prop.key.name), prop.key.span)),
+        ClassMember::AutoAccessor(_)
+        | ClassMember::StaticBlock(_)
+        | ClassMember::TsIndexSignature(_)
+        | ClassMember::Empty(_) => None,
+    }
+}
+
+fn prop_name_label_span(name: &PropName) -> Option<(String, Span)> {
+    match name {
+        PropName::Ident(ident) => Some((ident.sym.to_string(), ident.span)),
+        PropName::Str(str_) => Some((str_.value.to_string_lossy().to_string(), str_.span)),
+        PropName::Num(num) => Some((num.value.to_string(), num.span)),
+        PropName::BigInt(bigint) => Some((bigint.value.to_string(), bigint.span)),
+        PropName::Computed(_) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shape_index::ShapeIndex;
+
+    fn parse(source: &str) -> Module {
+        js_ast::with_swc_globals(|| js_ast::parse_js_module_ast("<test>", source).unwrap())
+    }
+
+    /// The substring of `source` covered by a kept span, for asserting which
+    /// token a kept anchor pins.
+    fn span_text<'a>(source: &'a str, span: &AnchorSpan) -> &'a str {
+        // swc byte positions are 1-based (BytePos 0 is the dummy sentinel).
+        &source[(span.0 - 1) as usize..(span.1 - 1) as usize]
+    }
+
+    #[test]
+    fn value_anchor_maps_to_the_token_span() {
+        // Item 0's unique string literal is the read-off anchor; the kept span
+        // must cover exactly that literal so the prune pins it.
+        let source = r#"const a = make("widget-token");
+const b = make("other-token");"#;
+        let module = parse(source);
+        let index = ShapeIndex::new(&module);
+        let anchor_set = index.minimal_anchor_set(0).unwrap();
+        let kept = kept_spans_for_anchor_set(&module.body[0], &anchor_set);
+        let pinned: Vec<&str> = kept.iter().map(|s| span_text(source, s)).collect();
+        assert_eq!(pinned, vec![r#""widget-token""#]);
+    }
+
+    #[test]
+    fn member_property_anchor_pins_the_property_name() {
+        // `.now` is unique to item 0 among the chunk, so the read-off pins the
+        // member property; the kept span covers the `now` accessor token.
+        let source = r#"const a = read(Date.now());
+const b = read(other());"#;
+        let module = parse(source);
+        let index = ShapeIndex::new(&module);
+        let anchor_set = index.minimal_anchor_set(0).unwrap();
+        let kept = kept_spans_for_anchor_set(&module.body[0], &anchor_set);
+        assert!(
+            kept.iter().any(|s| span_text(source, s) == "now"),
+            "expected a kept span covering `now`, got {:?}",
+            kept.iter()
+                .map(|s| span_text(source, s))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn structural_only_read_off_keeps_no_span() {
+        // The lone function is discriminated by its declaration kind / arity
+        // alone (a structural read-off), so no concrete token is pinned: the
+        // holed scaffold carries the whole pin.
+        let source = r#"function only(x) { return x; }
+const v = 1;"#;
+        let module = parse(source);
+        let index = ShapeIndex::new(&module);
+        let anchor_set = index.minimal_anchor_set(0).unwrap();
+        // The structural feature carries no value, so it maps to no kept span.
+        let kept = kept_spans_for_anchor_set(&module.body[0], &anchor_set);
+        assert!(
+            kept.is_empty(),
+            "structural read-off must pin no concrete token; got {:?}",
+            kept.iter()
+                .map(|s| span_text(source, s))
+                .collect::<Vec<_>>()
+        );
+    }
+}

--- a/devinfra/js/debundle/selector_codemod.rs
+++ b/devinfra/js/debundle/selector_codemod.rs
@@ -15,9 +15,11 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
+use readoff_render::kept_spans_for_anchor_set;
 use selector_candidate_index::SelectorCandidateIndex;
 use serde::Serialize;
 use serde_yaml::Value;
+use shape_index::ShapeIndex;
 use source_match::BodyIndexFilter;
 use spec::{SourceMatch, SourceMatchIdentifierMode};
 use spec_modules::{collect_module_files, is_module_yaml, module_path_from_file};
@@ -555,6 +557,10 @@ struct ChunkSelectorIndex {
     /// indices instead of the whole chunk. A pure prefilter — see
     /// [`matched_body_indices`].
     candidate_index: SelectorCandidateIndex,
+    /// Layer-1 read-off shape index (W2). Built once per chunk; the migrated
+    /// forms (single-target function and var) read their minimal anchor set off
+    /// it instead of running the cover search. The matcher stays the gate.
+    shape_index: ShapeIndex,
 }
 
 #[derive(Debug)]
@@ -900,12 +906,14 @@ impl ChunkSelectorIndex {
             decls.push(indexed);
         }
         let candidate_index = SelectorCandidateIndex::new(&parsed.module);
+        let shape_index = ShapeIndex::new(&parsed.module);
         Self {
             parsed,
             source,
             decls,
             binding_to_decl,
             candidate_index,
+            shape_index,
         }
     }
 }
@@ -1830,8 +1838,66 @@ fn minimize_function_selector(
             function: Box::new(holed),
         }))))
     };
+    // W2: single-target functions read their minimal anchor set off the shape
+    // index instead of running the cover search. The holed scaffold already
+    // pins the param arity (one `ANYTHING` per real param), so a structural /
+    // skeleton anchor needs no kept span; value anchors (string literals,
+    // member/method names, member-path callees) map to the spans of the tokens
+    // that exhibit them. The matcher proves the result (gate 1).
+    //
+    // Fallback: when the read-off cannot single out the target through its own
+    // features — chiefly because the discriminator is a *number/bool* literal,
+    // which the W1 feature taxonomy does not yet index (string literals only) —
+    // it returns `None` and we fall through to the cover search, which collects
+    // every literal kind. This keeps the migration honest (read-off is the
+    // primary path; the cover is the not-yet-expressible tail), not full-AST:
+    // the cover itself skips rather than dumping an untrimmed body. A later wave
+    // that extends the feature taxonomy can drop this fallback.
+    if let Some(selector) = render_via_read_off(index, decl, target, &render_with)? {
+        return Ok(Some(selector));
+    }
     let candidates = collect_stmt_list_anchors(&body.stmts);
     minimize_via_retention(index, decl, target, &candidates, &render_with)
+}
+
+/// Render a single-target selector via the W1 read-off API (W2).
+///
+/// Reads the minimal [`AnchorSet`] off the shape index, maps its value anchors
+/// to kept byte spans over the target item, and renders + proves through the
+/// supplied `render_with` (the same prune + codegen the cover path uses — no
+/// second serializer). Returns `None` when the read-off cannot single out the
+/// target (a genuine alpha-duplicate) or the rendered selector fails the matcher
+/// gate, so the caller falls back to current behavior (exact-or-skip; never a
+/// full-AST pin unless `--full-ast-fallback`).
+fn render_via_read_off(
+    index: &ChunkSelectorIndex,
+    decl: &IndexedDeclaration,
+    target: &SynthesizedTargetBinding,
+    render_with: &impl Fn(&BTreeSet<AnchorSpan>) -> Result<String>,
+) -> Result<Option<SpecializedSelector>> {
+    // Structural fast path (mirrors the cover's empty-competitors case): if the
+    // holed scaffold already pins enough — the declaration kind plus the param
+    // arity / declarator shape the scaffold renders for free — to resolve
+    // uniquely, keep no concrete token. This is the leanest, most rebuild-stable
+    // selector, so it is preferred over any value anchor the read-off would add.
+    let empty = BTreeSet::new();
+    if matched_body_indices(index, &target.export_name, &render_with(&empty)?)?
+        == BTreeSet::from([decl.body_idx])
+    {
+        return finish_minimized_selector(index, decl, target, render_with(&empty)?);
+    }
+
+    let Some(anchor_set) = index.shape_index.minimal_anchor_set(decl.body_idx) else {
+        return Ok(None);
+    };
+    let item = index
+        .parsed
+        .module
+        .body
+        .get(decl.body_idx)
+        .context("read-off body index no longer in module")?;
+    let kept = kept_spans_for_anchor_set(item, &anchor_set);
+    finish_minimized_selector(index, decl, target, render_with(&kept)?)
 }
 
 // ===========================================================================

--- a/devinfra/js/debundle/shape_index.rs
+++ b/devinfra/js/debundle/shape_index.rs
@@ -709,10 +709,19 @@ impl ShapeIndex {
         // Greedy set-cover tail: bounded to the target's own features. The
         // "universe" is the non-target items still in the running intersection;
         // each step takes the feature excluding the most of them.
-        let all_indices: BTreeSet<usize> = (0..self.items.len()).collect();
-        let mut covered = all_indices;
-        let mut chosen: Vec<ScoredFeature> = Vec::new();
+        //
+        // W1 hand-off note #1 (cheap perf fix): seed `covered` from the *smallest
+        // relevant posting list* — the most-selective feature, which is
+        // `scored.first()` since `scored` is sorted by ascending selectivity —
+        // rather than `0..N`. The final intersection is a subset of every chosen
+        // feature's posting list, so seeding from one of them (the target is in
+        // all of its own features' lists) loses nothing; it just bounds per-item
+        // cost to that list's size instead of the whole chunk, so unresolvable
+        // items pay O(smallest posting) per step rather than O(N).
         let mut remaining = scored;
+        let seed = remaining.first()?;
+        let mut covered: BTreeSet<usize> = self.posting(&seed.feature).clone();
+        let mut chosen: Vec<ScoredFeature> = vec![remaining.remove(0)];
 
         while covered.len() > 1 {
             let best = remaining


### PR DESCRIPTION
**Wave 2** of the read-off minimizer redesign. Builds the production renderer
(AnchorSet → `source_match`) and routes the **single-target function** form
through read-off, strangler-fig — var/class/object/group stay on the cover path
(Wave 3). Additive aside from the function-path wiring; the cover search is NOT
deleted (it's the fallback while forms migrate).

## Renderer (`readoff_render.rs`)
- `kept_spans_for_anchor_set` maps the read-off's value-bearing features
  (`StringLiteral`, `ObjectKey`, `ClassMember`, `MemberProperty`, member-path
  `CallCallee`) to the byte spans of the tokens that exhibit them — the same
  `kept: BTreeSet<AnchorSpan>` the existing `selector_codemod` prune consumes.
  **No second serializer:** rendering reuses the per-form `render_with` →
  `hole_stmts`/`hole_expr`/`hole_object` → `emit_selector` (swc codegen).
- **Skeleton/arity anchors (W1 note #2):** structural features carry no value and
  map to no kept span — the holed scaffold pins them. `render_via_read_off` tries
  the **empty-kept scaffold first**; if it already resolves uniquely, that's the
  leanest, most rebuild-stable selector and wins over any value anchor.

## Gate-1 + invariants
Every migrated emission is matcher-proven unique via
`finish_minimized_selector` → `prove_synthesized_selector`. Read-off `None` falls
back to the *current* behavior (skip/report), never a full-AST dump;
`--full-ast-fallback` stays off.

## Perf (W1 note #1)
`minimal_anchor_set`'s greedy tail seeds `covered` from the smallest relevant
posting list (most-selective feature), not `0..N` — per-step cost O(smallest
posting) instead of O(N), so unresolvable items no longer pay an O(N) allocation.

## Fixtures changed (equivalent-or-better, gate-proven unique, checked through swc)
- `sparse_function_body`: 2 anchors → **1** (stable `.now()` member-property,
  value-holed).
- `nested_async_try`: `includeMeta: true` (shared, value pinned) → `trace:
  ANYTHING` (unique key, value holed) — same count, more forward-compatible.
- `call_argument_literal`: **unchanged** — its number-literal discriminator isn't
  read-off-expressible yet (W1 taxonomy indexes string literals only), so it
  falls back to the cover with the identical selector.

## Validation
All **116** `//devinfra/js/debundle/...` tests pass on RBE; non-migrated forms'
outputs unchanged. Independently re-validated by the coordinator.

## Wave 3 hand-off
1. Extend the feature taxonomy to number/bool literals (keep it a sound match
   superset) → removes the function cover fallback.
2. Var migration needs read-off to model binding-group/declarator-slot tuple
   resolution.
3. Class/object over-pin elimination (`CLASS_REST`/`OBJECT_PROPS` + discriminator)
   + anti-unification grouping from posting co-occurrence; unignore the
   over-pin cases; then delete the cover and fold the empty-scaffold fast path.

https://claude.ai/code/session_01RYUAvJefa2eJRgZ7XBfqxA

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYUAvJefa2eJRgZ7XBfqxA)_