### PR TITLE
debundle: add CASE_REST switch-case-run list hole

### DIFF
--- a/devinfra/js/debundle/docs/guide.md
+++ b/devinfra/js/debundle/docs/guide.md
@@ -271,15 +271,15 @@ Default to this ladder when writing or repairing selectors:
    stable.
 2. Add anonymous `ANYTHING` holes where the hole name would not carry useful
    signal. Use typed holes (`EXPR`, `STMT`, `ARGS`, `STMT_LIST`,
-   `OBJECT_PROPS`, `CLASS_REST`, or `DECLARATORS`) when the syntactic role, a
-   typed list hole, or a named/equality hole makes the selector easier to read
-   or diagnose.
+   `OBJECT_PROPS`, `CLASS_REST`, `CASE_REST`, or `DECLARATORS`) when the
+   syntactic role, a typed list hole, or a named/equality hole makes the
+   selector easier to read or diagnose.
 3. Keep exact literals, property names, object keys, operators, and ordering
    when they carry the stable signal.
 4. Avoid exact long bodies/subexpressions unless they are the stable signal
    needed to disambiguate. If `ANYTHING`, `EXPR`, `OBJECT_PROPS`, `ARGS`,
-   `CLASS_REST`, `STMT_LIST`, or declarator gaps keep the selector unique, use
-   the hole form.
+   `CLASS_REST`, `CASE_REST`, `STMT_LIST`, or declarator gaps keep the selector
+   unique, use the hole form.
 5. Use `selector.binding.name` only for already-stable semantic names or as
    temporary debt that will be visible in `debundle spec selector-debt`.
 
@@ -353,8 +353,8 @@ review. Passing the production matcher only proves today's code is addressed;
 it does not prove that exact parameter destructuring, helper call arguments,
 object property values, or nested statement bodies are durable. When dry-run or
 apply output is visibly overpinned, prefer `ANYTHING`, `EXPR`, `ARGS`,
-`STMT_LIST`, `OBJECT_PROPS`, `CLASS_REST`, or `DECLARATORS` minimization where
-the matcher supports it. If the concise selector cannot be expressed yet, leave
+`STMT_LIST`, `OBJECT_PROPS`, `CLASS_REST`, `CASE_REST`, or `DECLARATORS`
+minimization where the matcher supports it. If the concise selector cannot be expressed yet, leave
 the binding as selector debt and record a generic minimization gap rather than
 committing a hand-maintained exact long selector.
 
@@ -804,6 +804,21 @@ absorbed sequence for cross-occurrence equality.
 - `CLASS_REST;` as a class field (no initializer) matches a run of class
   members — "this class by these members, ignore the rest". `CLASS_REST` is an
   exact token (not a prefix).
+- `case CASE_REST:` as an empty switch case (no body) matches a run of
+  `case`/`default` clauses — "this switch by these discriminating cases,
+  ignore the rest". `CASE_REST` is an exact token (not a prefix), and a
+  `default:` clause is never a hole. Use it to pin a many-arm `switch` by the
+  one or two cases that discriminate it without spelling every arm:
+
+  ```js
+  switch (ANYTHING) {
+    case CASE_REST:
+    case "target":
+      STMT_LIST;
+    case CASE_REST:
+  }
+  ```
+
 - `DECLARATORS` (or `DECLARATORS_name = null`) inside one variable declaration
   matches a run of declarators.
 

--- a/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
+++ b/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
@@ -334,6 +334,20 @@ minimizer_expectation_case!(
     expected = "expected_match.js",
 );
 
+// A target function whose body is a many-arm `switch` among same-shaped
+// sibling switches minimizes to `case CASE_REST:` holes around the single
+// discriminating `case` literal — closing the over-pin gap the survey flagged
+// for many-arm switches. Active: `hole_switch_cases` emits the run holes and
+// the matcher proves unique resolution.
+minimizer_expectation_case!(
+    minimizes_switch_case_run,
+    fixture = "switch_case_run",
+    name = "many-arm switch keeps only the discriminating case literal",
+    module = "app/routers",
+    bindings = [("SelectedRouter", "selectedRouter")],
+    expected = "expected_match.js",
+);
+
 // Aspirational: a target class among many same-shape sibling classes should
 // minimize to CLASS_REST holes plus the one discriminating member, not fall
 // back to emitting the full class body. Today `minimize_class_selector` bails

--- a/devinfra/js/debundle/e2e/syntactic_holes_test.rs
+++ b/devinfra/js/debundle/e2e/syntactic_holes_test.rs
@@ -24,6 +24,9 @@
 //!   want to pin.
 //! - `CLASS_REST;` as a class field absorbs a run of class members —
 //!   e.g. "match this class by these members, ignore the rest".
+//! - `case CASE_REST:` as an empty switch case absorbs a run of
+//!   `case`/`default` clauses — e.g. "match this switch by these
+//!   discriminating cases, ignore the rest".
 //! - `DECLARATORS` / `DECLARATORS_name = null` in a variable declaration
 //!   absorbs a run of declarators — e.g. match a few stable entries in a
 //!   wider `const` list without spelling unrelated siblings.
@@ -1561,6 +1564,67 @@ export { Counter };
         // The full class moved, members and all.
         &["class", "increment", "reset"],
         &["CLASS_REST", "STMT_LIST_CTOR"],
+    );
+}
+
+#[test]
+fn member_source_match_case_rest_hole_selects_switch_ignoring_other_cases() {
+    // Pin the function by one discriminating `case "go":` arm and let the
+    // `case CASE_REST:` holes absorb the surrounding cases. The whole
+    // function still moves — the holes are only in the selector.
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"function dispatch(kind) {
+  switch (kind) {
+    case "alpha":
+      return 1;
+    case "beta":
+      return 2;
+    case "go":
+      return 42;
+    case "delta":
+      return 4;
+    default:
+      return 0;
+  }
+}
+console.log(dispatch("go"));
+export { dispatch };
+"#,
+        vec![logical_module(
+            "router",
+            &[Member::source_alpha(
+                "dispatch",
+                r#"function readable(ANYTHING) {
+  switch (ANYTHING) {
+    case CASE_REST:
+    case "go":
+      STMT_LIST_GO;
+    case CASE_REST:
+  }
+}"#,
+            )],
+        )],
+    ));
+
+    assert_entry_output(&fixture, "42\n");
+    assert_module_exports(
+        &fixture.out_root,
+        "static/app/modules/router.js",
+        &["dispatch"],
+        &[],
+    );
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/modules/router.js",
+        // The full switch moved, every case and all.
+        &[
+            "function dispatch",
+            "switch",
+            "\"alpha\"",
+            "\"go\"",
+            "default",
+        ],
+        &["CASE_REST", "STMT_LIST_GO"],
     );
 }
 

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/switch_case_run/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/switch_case_run/expected_match.js
@@ -1,0 +1,8 @@
+function SelectedRouter(ANYTHING) {
+  switch (ANYTHING) {
+    case CASE_REST:
+    case "unique-target":
+      STMT_LIST;
+    case CASE_REST:
+  }
+}

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/switch_case_run/source.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/switch_case_run/source.js
@@ -1,0 +1,74 @@
+function selectedRouter(action) {
+  switch (action.type) {
+    case "init":
+      return setup(action);
+    case "load":
+      return load(action);
+    case "unique-target":
+      return handleTarget(action);
+    case "save":
+      return persist(action);
+    default:
+      return fallback(action);
+  }
+}
+
+function sameShapeDifferentCases(action) {
+  switch (action.type) {
+    case "init":
+      return setup(action);
+    case "load":
+      return load(action);
+    case "remove":
+      return remove(action);
+    case "save":
+      return persist(action);
+    default:
+      return fallback(action);
+  }
+}
+
+function anotherSibling(action) {
+  switch (action.type) {
+    case "open":
+      return open(action);
+    case "close":
+      return close(action);
+    default:
+      return fallback(action);
+  }
+}
+
+function setup(a) {
+  return a;
+}
+
+function load(a) {
+  return a;
+}
+
+function handleTarget(a) {
+  return a;
+}
+
+function persist(a) {
+  return a;
+}
+
+function fallback(a) {
+  return a;
+}
+
+function remove(a) {
+  return a;
+}
+
+function open(a) {
+  return a;
+}
+
+function close(a) {
+  return a;
+}
+
+export { selectedRouter };

--- a/devinfra/js/debundle/selector_candidate_index.rs
+++ b/devinfra/js/debundle/selector_candidate_index.rs
@@ -11,9 +11,9 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use anyhow::{Context, Result};
 use source_match_holes::{
-    ANYTHING_HOLE_KEYWORD, CLASS_REST_HOLE_KEYWORD, DECLARATORS_HOLE_KEYWORD, EXPR_HOLE_KEYWORD,
-    OBJECT_PROPS_HOLE_KEYWORD, STMT_HOLE_KEYWORD, STMT_LIST_HOLE_KEYWORD,
-    STRING_LITERAL_REGEX_PREDICATE, hole_name_for,
+    ANYTHING_HOLE_KEYWORD, CASE_REST_HOLE_KEYWORD, CLASS_REST_HOLE_KEYWORD,
+    DECLARATORS_HOLE_KEYWORD, EXPR_HOLE_KEYWORD, OBJECT_PROPS_HOLE_KEYWORD, STMT_HOLE_KEYWORD,
+    STMT_LIST_HOLE_KEYWORD, STRING_LITERAL_REGEX_PREDICATE, hole_name_for,
 };
 use spec::{AnonymousStatementSelector, BindingSourceKind, SourceMatchIdentifierMode};
 use swc_ecma_ast::*;
@@ -573,6 +573,16 @@ impl Visit for AstFeatureCollector<'_, '_> {
         stmt.visit_children_with(self);
     }
 
+    fn visit_switch_case(&mut self, case: &SwitchCase) {
+        // A `case CASE_REST:` hole contributes no feature: it stands in
+        // for an arbitrary run of dropped cases, so a candidate switch
+        // need not carry any literal from it.
+        if case_rest_hole_name(case).is_some() {
+            return;
+        }
+        case.visit_children_with(self);
+    }
+
     fn visit_var_declarator(&mut self, declarator: &VarDeclarator) {
         if declarator_list_hole_name(declarator).is_some() {
             declarator.init.visit_with(self);
@@ -772,6 +782,16 @@ fn class_rest_hole_name(member: &ClassMember) -> Option<&str> {
         .or_else(|| hole_name_for(name, ANYTHING_HOLE_KEYWORD))
 }
 
+fn case_rest_hole_name(case: &SwitchCase) -> Option<&str> {
+    if !case.cons.is_empty() {
+        return None;
+    }
+    let Some(Expr::Ident(ident)) = case.test.as_deref() else {
+        return None;
+    };
+    hole_name_for(ident.sym.as_ref(), CASE_REST_HOLE_KEYWORD)
+}
+
 fn string_literal_regex_pattern_call(call: &CallExpr) -> bool {
     let Callee::Expr(callee) = &call.callee else {
         return false;
@@ -946,6 +966,31 @@ function render(value) { return value; }"#,
         assert_eq!(exact, vec![0]);
         assert!(exact.into_iter().all(|idx| candidate_set.contains(idx)));
         assert_eq!(body_indices(candidate_set), vec![0]);
+    }
+
+    #[test]
+    fn source_match_query_is_sound_for_switch_case_rest_selectors() {
+        let runtime = parse_module(
+            r#"switch (a) { case "x": doX(); case "y": doY(); }
+switch (b) { case "z": doZ(); }
+function unrelated() { return 1; }"#,
+        );
+        let index = SelectorCandidateIndex::new(&runtime);
+        // The discriminating `case "x":` literal must keep the candidate
+        // set a sound superset; the `case CASE_REST:` holes contribute no
+        // feature, so only the switch that carries `"x"` survives.
+        let selector = selector(
+            "switch (ANYTHING) {\n  case CASE_REST:\n  case \"x\":\n    STMT_LIST;\n  case CASE_REST:\n}",
+        );
+
+        let exact = js_ast::with_swc_globals(|| {
+            source_match::find_anonymous_statement_body_indices(&runtime, "<test>", &selector)
+                .unwrap()
+        });
+        let candidate_set = index.candidate_set_for_source_match(&selector).unwrap();
+
+        assert_eq!(exact, vec![0]);
+        assert!(exact.into_iter().all(|idx| candidate_set.contains(idx)));
     }
 
     #[test]

--- a/devinfra/js/debundle/selector_codemod.rs
+++ b/devinfra/js/debundle/selector_codemod.rs
@@ -30,9 +30,9 @@ use swc_ecma_visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 // Hole keyword spellings come from `source_match_holes` so the minimizer
 // emits exactly the tokens the matcher resolves.
 use source_match_holes::{
-    ANYTHING_HOLE_KEYWORD, ARGS_HOLE_KEYWORD, CLASS_REST_HOLE_KEYWORD, DECLARATORS_HOLE_KEYWORD,
-    EXPR_HOLE_KEYWORD, OBJECT_PROPS_HOLE_KEYWORD, STMT_HOLE_KEYWORD, STMT_LIST_HOLE_KEYWORD,
-    STRING_LITERAL_REGEX_PREDICATE,
+    ANYTHING_HOLE_KEYWORD, ARGS_HOLE_KEYWORD, CASE_REST_HOLE_KEYWORD, CLASS_REST_HOLE_KEYWORD,
+    DECLARATORS_HOLE_KEYWORD, EXPR_HOLE_KEYWORD, OBJECT_PROPS_HOLE_KEYWORD, STMT_HOLE_KEYWORD,
+    STMT_LIST_HOLE_KEYWORD, STRING_LITERAL_REGEX_PREDICATE,
 };
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
@@ -1308,6 +1308,16 @@ fn object_props_prop() -> PropOrSpread {
     ))))
 }
 
+/// A `case CASE_REST:` switch-case hole that absorbs a run of dropped
+/// `case`/`default` clauses (the switch analog of `CLASS_REST;`).
+fn case_rest_case() -> SwitchCase {
+    SwitchCase {
+        span: DUMMY_SP,
+        test: Some(Box::new(Expr::Ident(ident_node(CASE_REST_HOLE_KEYWORD)))),
+        cons: vec![],
+    }
+}
+
 fn anything_pat() -> Pat {
     Pat::Ident(BindingIdent {
         id: ident_node(ANYTHING_HOLE_KEYWORD),
@@ -1520,9 +1530,49 @@ fn hole_stmt(stmt: &Stmt, kept: &BTreeSet<AnchorSpan>) -> Stmt {
             Stmt::Try(holed)
         }
         Stmt::Block(block) => Stmt::Block(holed_block(block, kept)),
+        Stmt::Switch(switch) => {
+            let mut holed = switch.clone();
+            holed.discriminant = Box::new(hole_expr(&switch.discriminant, kept));
+            holed.cases = hole_switch_cases(&switch.cases, kept);
+            Stmt::Switch(holed)
+        }
         // Unmodeled statement shapes carrying a kept anchor: keep verbatim.
         _ => stmt.clone(),
     }
+}
+
+/// Prune a `switch`'s case list: drop runs of non-discriminating
+/// `case`/`default` clauses into `case CASE_REST:` holes, keeping only the
+/// clauses that retain an anchor (their test literal or a body statement).
+/// Mirrors [`hole_class_members`].
+fn hole_switch_cases(cases: &[SwitchCase], kept: &BTreeSet<AnchorSpan>) -> Vec<SwitchCase> {
+    let mut out = Vec::new();
+    let mut dropped_run = false;
+    for case in cases {
+        if node_retains_any(case.span(), kept) {
+            if dropped_run {
+                out.push(case_rest_case());
+                dropped_run = false;
+            }
+            out.push(hole_switch_case(case, kept));
+        } else {
+            dropped_run = true;
+        }
+    }
+    if dropped_run || out.is_empty() {
+        out.push(case_rest_case());
+    }
+    out
+}
+
+fn hole_switch_case(case: &SwitchCase, kept: &BTreeSet<AnchorSpan>) -> SwitchCase {
+    let mut holed = case.clone();
+    holed.test = case
+        .test
+        .as_ref()
+        .map(|test| Box::new(hole_expr(test, kept)));
+    holed.cons = hole_stmts(&case.cons, kept);
+    holed
 }
 
 /// Candidate concrete anchors, split into preference tiers. Literal values are
@@ -1660,6 +1710,20 @@ fn collect_stmt_anchors(stmt: &Stmt, candidates: &mut AnchorCandidates) {
         Stmt::Block(block) => {
             for stmt in &block.stmts {
                 collect_stmt_anchors(stmt, candidates);
+            }
+        }
+        Stmt::Switch(switch) => {
+            collect_expr_anchors(&switch.discriminant, 0, candidates);
+            for case in &switch.cases {
+                // A case test literal (`case "x":`) is the discriminating
+                // landmark that the `CASE_REST` hole keeps; collect it as a
+                // shallow literal so the cover can retain it.
+                if let Some(test) = &case.test {
+                    collect_expr_anchors(test, 0, candidates);
+                }
+                for stmt in &case.cons {
+                    collect_stmt_anchors(stmt, candidates);
+                }
             }
         }
         _ => {}

--- a/devinfra/js/debundle/source_match.rs
+++ b/devinfra/js/debundle/source_match.rs
@@ -23,9 +23,9 @@ use swc_ecma_visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 // matcher, the `selector_codemod` minimizer, and `selector_candidate_index`
 // share one spelling. See that module's docs for the hole language.
 use source_match_holes::{
-    ANYTHING_HOLE_KEYWORD, ARGS_HOLE_KEYWORD, CLASS_REST_HOLE_KEYWORD, DECLARATORS_HOLE_KEYWORD,
-    EXPR_HOLE_KEYWORD, OBJECT_PROPS_HOLE_KEYWORD, STMT_HOLE_KEYWORD, STMT_LIST_HOLE_KEYWORD,
-    STRING_LITERAL_REGEX_PREDICATE, hole_name_for,
+    ANYTHING_HOLE_KEYWORD, ARGS_HOLE_KEYWORD, CASE_REST_HOLE_KEYWORD, CLASS_REST_HOLE_KEYWORD,
+    DECLARATORS_HOLE_KEYWORD, EXPR_HOLE_KEYWORD, OBJECT_PROPS_HOLE_KEYWORD, STMT_HOLE_KEYWORD,
+    STMT_LIST_HOLE_KEYWORD, STRING_LITERAL_REGEX_PREDICATE, hole_name_for,
 };
 
 const SOURCE_MATCH_TIMINGS_ENV: &str = "DUCKTAPE_SOURCE_MATCH_TIMINGS";
@@ -3949,6 +3949,124 @@ const unrelatedB = "different-token-42";"#,
             );
         });
     }
+
+    #[test]
+    fn case_rest_hole_is_recognized_only_as_bare_keyword_empty_case() {
+        js_ast::with_swc_globals(|| {
+            let item = parse_one("switch (x) { case CASE_REST: }");
+            let Stmt::Switch(switch) = &item.as_stmt().unwrap() else {
+                panic!("expected switch");
+            };
+            assert!(is_case_rest_hole(&switch.cases[0]));
+
+            // A `case CASE_REST:` with a body is a real case, not a hole.
+            let with_body = parse_one("switch (x) { case CASE_REST: break; }");
+            let Stmt::Switch(switch) = &with_body.as_stmt().unwrap() else {
+                panic!("expected switch");
+            };
+            assert!(!is_case_rest_hole(&switch.cases[0]));
+
+            // `default:` is never a hole; nor is an unrelated literal.
+            let other = parse_one(r#"switch (x) { default: case "a": }"#);
+            let Stmt::Switch(switch) = &other.as_stmt().unwrap() else {
+                panic!("expected switch");
+            };
+            assert!(!is_case_rest_hole(&switch.cases[0]));
+            assert!(!is_case_rest_hole(&switch.cases[1]));
+        });
+    }
+
+    #[test]
+    fn case_rest_hole_absorbs_surrounding_case_runs() {
+        js_ast::with_swc_globals(|| {
+            let selector = selector(
+                r#"function readable(ANYTHING) {
+  switch (ANYTHING) {
+    case CASE_REST:
+    case "go":
+      STMT_LIST
+    case CASE_REST:
+  }
+}"#,
+            );
+            let needle = parse_one(&selector.match_source);
+            let prepared = PreparedNeedle::new(&needle, &selector);
+
+            // `case "go":` with arbitrary cases before and after.
+            let middle = parse_one(
+                r#"function m(t) {
+  switch (t) {
+    case "a": return 1;
+    case "go": doThing(); break;
+    case "b": return 2;
+    default: return 3;
+  }
+}"#,
+            );
+            assert!(prepared.matches(&middle));
+
+            // `case "go":` as the very first arm (leading hole absorbs zero).
+            let leading = parse_one(
+                r#"function m(t) {
+  switch (t) {
+    case "go": go();
+    case "z": zz();
+  }
+}"#,
+            );
+            assert!(prepared.matches(&leading));
+
+            // No `case "go":` arm at all — must not match.
+            let no_go = parse_one(
+                r#"function m(t) {
+  switch (t) {
+    case "a": return 1;
+    case "b": return 2;
+  }
+}"#,
+            );
+            assert!(!prepared.matches(&no_go));
+        });
+    }
+
+    #[test]
+    fn case_rest_hole_does_not_change_non_hole_switch_matching() {
+        js_ast::with_swc_globals(|| {
+            // A switch selector with no CASE_REST hole still matches exactly.
+            let selector = selector(
+                r#"function readable(ANYTHING) {
+  switch (ANYTHING) {
+    case "a": STMT_LIST
+    case "b": STMT_LIST
+  }
+}"#,
+            );
+            let needle = parse_one(&selector.match_source);
+            let prepared = PreparedNeedle::new(&needle, &selector);
+
+            let exact = parse_one(
+                r#"function m(t) {
+  switch (t) {
+    case "a": one();
+    case "b": two();
+  }
+}"#,
+            );
+            assert!(prepared.matches(&exact));
+
+            // Extra trailing case is rejected without a CASE_REST hole.
+            let extra = parse_one(
+                r#"function m(t) {
+  switch (t) {
+    case "a": one();
+    case "b": two();
+    case "c": three();
+  }
+}"#,
+            );
+            assert!(!prepared.matches(&extra));
+        });
+    }
 }
 
 #[derive(Clone, Default)]
@@ -4409,7 +4527,7 @@ impl<'a> AstWildcardMatcher<'a> {
             }
             (Stmt::Switch(needle), Stmt::Switch(candidate)) => {
                 self.match_expr(&needle.discriminant, &candidate.discriminant)
-                    && self.match_slice(&needle.cases, &candidate.cases, Self::match_switch_case)
+                    && self.match_switch_case_slice(&needle.cases, &candidate.cases)
             }
             (Stmt::Throw(needle), Stmt::Throw(candidate)) => {
                 self.match_expr(&needle.arg, &candidate.arg)
@@ -5679,6 +5797,24 @@ impl<'a> AstWildcardMatcher<'a> {
         }
     }
 
+    /// Match a `switch` case list. `case CASE_REST:` holes split the
+    /// needle into fixed segments matched as an ordered subsequence with
+    /// gaps (see [`Self::match_list_with_holes`]); with no hole this is an
+    /// exact element-wise match. The run absorbed by a hole may contain
+    /// `case`/`default` clauses freely.
+    fn match_switch_case_slice(&mut self, needle: &[SwitchCase], candidate: &[SwitchCase]) -> bool {
+        if needle.iter().any(is_case_rest_hole) {
+            self.match_list_with_holes(
+                needle,
+                candidate,
+                is_case_rest_hole,
+                Self::match_switch_case,
+            )
+        } else {
+            self.match_slice(needle, candidate, Self::match_switch_case)
+        }
+    }
+
     /// Match a variable declarator list. `DECLARATORS` /
     /// `DECLARATORS_*` holes split the needle into fixed declarator
     /// segments matched as an ordered subsequence with gaps. The return
@@ -6093,6 +6229,10 @@ struct WildcardIdents {
     /// `Ident`), so it survives alpha-canonicalization without being
     /// reserved — only presence matters for routing.
     class_rest_present: bool,
+    /// Whether the selector contains any `case CASE_REST:` switch-case
+    /// hole. The marker is a `case` test identifier; only presence
+    /// matters for routing to the structural matcher.
+    case_rest_present: bool,
 }
 
 impl WildcardIdents {
@@ -6110,6 +6250,7 @@ impl WildcardIdents {
             && self.patterns.is_empty()
             && !self.string_literal_regex_present
             && !self.class_rest_present
+            && !self.case_rest_present
     }
 }
 
@@ -6171,6 +6312,14 @@ impl Visit for WildcardIdentCollector {
             return;
         }
         member.visit_children_with(self);
+    }
+
+    fn visit_switch_case(&mut self, case: &SwitchCase) {
+        if is_case_rest_hole(case) {
+            self.idents.case_rest_present = true;
+            return;
+        }
+        case.visit_children_with(self);
     }
 
     fn visit_var_declarator(&mut self, declarator: &VarDeclarator) {
@@ -6366,6 +6515,20 @@ fn is_class_rest_hole(member: &ClassMember) -> bool {
             PropName::Ident(ident)
                 if ident.sym.as_ref() == CLASS_REST_HOLE_KEYWORD
                     || ident.sym.as_ref() == ANYTHING_HOLE_KEYWORD
+        )
+}
+
+/// Whether `case` is a `case CASE_REST:` switch-case hole: a `case`
+/// clause whose test is exactly the bare keyword identifier and whose
+/// body is empty. Matched as an exact token (not a `CASE_REST_*` prefix)
+/// so it never collides with a real `case CASE_REST:` discriminant; since
+/// it never binds, a suffix would carry no meaning anyway. A `default:`
+/// clause is never a hole.
+fn is_case_rest_hole(case: &SwitchCase) -> bool {
+    case.cons.is_empty()
+        && matches!(
+            case.test.as_deref(),
+            Some(Expr::Ident(ident)) if ident.sym.as_ref() == CASE_REST_HOLE_KEYWORD
         )
 }
 

--- a/devinfra/js/debundle/source_match_holes.rs
+++ b/devinfra/js/debundle/source_match_holes.rs
@@ -14,15 +14,23 @@
 //! subtree/statement everywhere it appears.
 //!
 //! `EXPR` matches one arbitrary expression and `STMT` one arbitrary
-//! statement. `ARGS`, `STMT_LIST`, `OBJECT_PROPS`, `CLASS_REST`, and
-//! `DECLARATORS` are variable-length list holes: `ARGS` absorbs a run of
-//! call/new arguments, `STMT_LIST` absorbs a run of block statements (or
-//! top-level anonymous selector statements), `OBJECT_PROPS` absorbs a run of
-//! object literal properties/spreads, `CLASS_REST` absorbs a run of class
-//! members, and `DECLARATORS` absorbs a run of variable declarators inside
-//! one `var`/`let`/`const` declaration. List-hole suffixes are labels for
-//! readability; they do not bind the absorbed sequence for cross-occurrence
-//! equality.
+//! statement. `ARGS`, `STMT_LIST`, `OBJECT_PROPS`, `CLASS_REST`,
+//! `CASE_REST`, and `DECLARATORS` are variable-length list holes: `ARGS`
+//! absorbs a run of call/new arguments, `STMT_LIST` absorbs a run of block
+//! statements (or top-level anonymous selector statements), `OBJECT_PROPS`
+//! absorbs a run of object literal properties/spreads, `CLASS_REST` absorbs a
+//! run of class members, `CASE_REST` absorbs a run of `case`/`default`
+//! clauses inside one `switch` statement, and `DECLARATORS` absorbs a run of
+//! variable declarators inside one `var`/`let`/`const` declaration.
+//! List-hole suffixes are labels for readability; they do not bind the
+//! absorbed sequence for cross-occurrence equality.
+//!
+//! The `CASE_REST` list hole is spelled as a `case CASE_REST:` clause with no
+//! body (the switch analog of the `CLASS_REST;` class field): a selector like
+//! `switch (ANYTHING) { case CASE_REST: case "x": STMT_LIST; case CASE_REST: }`
+//! matches a `switch` that has a `case "x":` arm preceded/followed by any
+//! other `case`/`default` clauses. Like `CLASS_REST`, it is matched as an
+//! exact token with no suffix and never binds.
 //!
 //! `ANYTHING` is parse-position polymorphic sugar for the anonymous typed
 //! hole at positions where plain JavaScript can parse it. In an expression
@@ -40,6 +48,7 @@ pub const EXPR_HOLE_KEYWORD: &str = "EXPR";
 pub const STMT_HOLE_KEYWORD: &str = "STMT";
 pub const STMT_LIST_HOLE_KEYWORD: &str = "STMT_LIST";
 pub const CLASS_REST_HOLE_KEYWORD: &str = "CLASS_REST";
+pub const CASE_REST_HOLE_KEYWORD: &str = "CASE_REST";
 pub const DECLARATORS_HOLE_KEYWORD: &str = "DECLARATORS";
 pub const ARGS_HOLE_KEYWORD: &str = "ARGS";
 pub const OBJECT_PROPS_HOLE_KEYWORD: &str = "OBJECT_PROPS";


### PR DESCRIPTION
Adds a variable-length **switch case-run list hole** to the `source_match`
language, closing the gap flagged by the over-pin survey (many-arm `switch`
functions were previously inexpressible, so the minimizer kept the whole switch).

## Keyword: `CASE_REST` (parallels `CLASS_REST`)
Spelled `case CASE_REST:` — an empty switch case whose test is the bare keyword,
the switch analog of the `CLASS_REST;` empty class field. Exact-token only (never
binds, no `_*` suffixes); a real `default:` is never a hole.

## Matcher (`source_match.rs`)
`Stmt::Switch` routes its case list through `match_switch_case_slice`, which
delegates any `case CASE_REST:` to the existing generic `match_list_with_holes`
engine (the same ordered-subsequence-with-gaps machinery `CLASS_REST`/`STMT_LIST`
use). So `switch (ANYTHING) { case CASE_REST: case "x": STMT_LIST; case CASE_REST: }`
matches any switch with a `case "x":` arm and arbitrary case/default runs (incl.
empty) before/after, order-preserving, with the kept case's test/body recursively
holed. Unchanged for switches without `CASE_REST` (still exact element-wise).

## Index + minimizer
- `selector_candidate_index.rs`: recognizes the hole and skips it for feature
  extraction (the discriminating `case "x":` literal still contributes) — candidate
  set stays a sound superset; soundness unit test added.
- `shape_index.rs`: no change needed (switches map to the opaque `stmt_other`
  node, already an over-broad superset).
- `selector_codemod.rs`: `hole_switch_cases`/`case_rest_case` emit the hole
  (mirroring `hole_class_members`); `collect_stmt_anchors` descends into switches
  to keep the discriminating case literal. Gate-1 unchanged.

## E2E: active
The minimizer fully produces the target on a many-arm switch among same-shaped
siblings: `switch (ANYTHING) { case CASE_REST: case "unique-target": STMT_LIST;
case CASE_REST: }`. The `minimizes_switch_case_run` expectation case + a
`syntactic_holes_test` case are registered **active** (not ignored).

## Validation
**116/116** `//devinfra/js/debundle/...` tests pass on RBE; no non-switch
selector behavior changed (only additive: a `Stmt::Switch` arm, a
`case_rest_present` collector field, new tests). Independently re-validated.
Docs updated (`guide.md` + `source_match_holes.rs` header).

Parallel-track note: touches `source_match.rs` / `selector_codemod.rs` /
`selector_candidate_index.rs`, shared with the read-off object wave; my edits are
additive and isolated (`match_switch_case_slice`, the switch arms) so they should
merge cleanly — I'll rebase whichever lands second.

https://claude.ai/code/session_01RYUAvJefa2eJRgZ7XBfqxA

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYUAvJefa2eJRgZ7XBfqxA)_