### PR TITLE
debundle: Wave 3 — number/bool features + object over-pin elimination

### DIFF
--- a/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
+++ b/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
@@ -363,15 +363,12 @@ minimizer_expectation_case!(
     expected = "expected_match.js",
 );
 
-// Aspirational: a large object literal that shares most keys with sibling
-// objects should minimize to OBJECT_PROPS holes on both sides of the single
-// discriminating key, so the selector survives key reordering. Today the
-// minimizer keeps the discriminating key but omits the trailing OBJECT_PROPS
-// hole, anchoring the key to the object's right edge. On the real
-// `infra/feature_flags.yaml` conversion the same retention path kept all ~50
-// keys (each held to ANYTHING) instead of holing the non-discriminating ones.
+// A large object literal that shares most keys with sibling objects minimizes
+// to OBJECT_PROPS holes on both sides of the single discriminating key, so the
+// selector survives key reordering. W3 routed the single-target object form
+// through the read-off shape index + padded-OBJECT_PROPS renderer, replacing the
+// old retention path that kept all ~50 keys (each held to ANYTHING).
 minimizer_expectation_case!(
-    #[ignore = "object minimizer retains all keys instead of OBJECT_PROPS + discriminator"]
     minimizes_object_keys_over_pinned,
     fixture = "object_keys_over_pinned",
     name = "large object keeps only the discriminating key value",

--- a/devinfra/js/debundle/plans/readoff_minimization.md
+++ b/devinfra/js/debundle/plans/readoff_minimization.md
@@ -209,3 +209,29 @@ each merge, and unignores E2E cases progressively. Build/test recipe: `bazelisk`
   `trace` object key, both 1 anchor); both gate-proven unique. W3 should extend
   the feature taxonomy to number/bool literals (drops the function cover
   fallback) and migrate var / class / object / group.
+- 2026-06-16: W3 built on `claude/debundle-readoff-object`. (a) **Feature
+  taxonomy extended to number/bool literals.** `SelectorFeature` gains
+  `NumberLiteral(String)` (canonical `f64`/BigInt decimal) and `BoolLiteral(bool)`;
+  `AstFeatureCollector` indexes them (never wildcarded, matcher discriminates by
+  `eq_ignore_span`, so the candidate set stays a sound match superset), scored
+  `Semantic`, rendered as kept literal spans by `readoff_render`. Soundness test
+  `number_and_bool_literal_features_keep_candidate_set_a_match_superset` asserts
+  the #2254 superset property still holds; matcher-backed read-off tests for
+  number and bool discriminators added. `call_argument_literal` (discriminator
+  `.bar` + `123`) now migrates to the function read-off (its fixture output is
+  unchanged — read-off renders the identical selector the cover did). (b)
+  **Single-target object migrated to read-off.** `try_single_object_read_off`
+  (single target binding, single declarator, object-literal init) reads the
+  minimal anchor set off the shape index and renders via `hole_object_padded`,
+  which always leads+trails with `OBJECT_PROPS` so the discriminating key:value
+  matches as an interior subsequence element (survives key reorder) rather than
+  anchoring to the object's right edge. Structural-only read-offs (empty kept
+  set) defer to the group path. Unignored `object_keys_over_pinned` (now
+  `OBJECT_PROPS, 10: "uniqueDiscriminatorLabel", OBJECT_PROPS`). `grouped_enum_objects`
+  stays ignored — it is a multi-declarator group, out of the single-target object
+  scope (W4/group wave). (c) W2 note #3: skeleton stability now demotes
+  high-multiplicity shapes (interned > 4×) to `Structural` so value anchors win
+  stability ties. Strangler-fig intact: var (single non-object + group), class,
+  group stay on the cover; the cover search is not deleted. All 116 debundle
+  tests green on RBE. Next wave: migrate var (non-object single) / class /
+  subclass / grouped-object forms, then delete the cover search.

--- a/devinfra/js/debundle/readoff_render.rs
+++ b/devinfra/js/debundle/readoff_render.rs
@@ -56,6 +56,8 @@ pub type AnchorSpan = (u32, u32);
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
 enum ValueAnchor {
     StringLiteral(String),
+    NumberLiteral(String),
+    BoolLiteral(bool),
     ObjectKey(String),
     ClassMember(String),
     MemberProperty(String),
@@ -81,6 +83,8 @@ impl ValueAnchor {
     fn from_selector_feature(feature: &SelectorFeature) -> Option<Self> {
         match feature {
             SelectorFeature::StringLiteral(value) => Some(Self::StringLiteral(value.clone())),
+            SelectorFeature::NumberLiteral(value) => Some(Self::NumberLiteral(value.clone())),
+            SelectorFeature::BoolLiteral(value) => Some(Self::BoolLiteral(*value)),
             SelectorFeature::ObjectKey(label) => Some(Self::ObjectKey(label.clone())),
             SelectorFeature::ClassMember(label) => Some(Self::ClassMember(label.clone())),
             SelectorFeature::MemberProperty(label) => Some(Self::MemberProperty(label.clone())),
@@ -89,6 +93,22 @@ impl ValueAnchor {
             | SelectorFeature::VarKind(_)
             | SelectorFeature::FunctionArity(_)
             | SelectorFeature::ImportSource(_) => None,
+        }
+    }
+
+    /// Whether `lit` exhibits one of the value anchors, mapping each concrete
+    /// literal kind to the feature taxonomy the read-off scored.
+    fn matches_lit(anchors: &BTreeSet<ValueAnchor>, lit: &Lit) -> bool {
+        match lit {
+            Lit::Str(str_) => anchors.contains(&ValueAnchor::StringLiteral(
+                str_.value.to_string_lossy().into(),
+            )),
+            Lit::Num(num) => anchors.contains(&ValueAnchor::NumberLiteral(num.value.to_string())),
+            Lit::BigInt(bigint) => {
+                anchors.contains(&ValueAnchor::NumberLiteral(bigint.value.to_string()))
+            }
+            Lit::Bool(bool_) => anchors.contains(&ValueAnchor::BoolLiteral(bool_.value)),
+            Lit::Null(_) | Lit::Regex(_) | Lit::JSXText(_) => false,
         }
     }
 }
@@ -128,11 +148,10 @@ impl SpanCollector<'_> {
 
 impl Visit for SpanCollector<'_> {
     fn visit_expr(&mut self, expr: &Expr) {
-        if let Expr::Lit(Lit::Str(str_)) = expr {
-            let value = str_.value.to_string_lossy().to_string();
-            if self.anchors.contains(&ValueAnchor::StringLiteral(value)) {
+        if let Expr::Lit(lit) = expr {
+            if ValueAnchor::matches_lit(self.anchors, lit) {
                 // Pin the literal node; the prune keeps it verbatim.
-                self.keep(str_.span);
+                self.keep(lit.span());
             }
             return;
         }
@@ -266,6 +285,25 @@ mod tests {
     fn span_text<'a>(source: &'a str, span: &AnchorSpan) -> &'a str {
         // swc byte positions are 1-based (BytePos 0 is the dummy sentinel).
         &source[(span.0 - 1) as usize..(span.1 - 1) as usize]
+    }
+
+    #[test]
+    fn number_literal_anchor_maps_to_the_token_span() {
+        // The numeric argument is item 0's only discriminator; the read-off pins
+        // it and the kept span covers exactly that number literal.
+        let source = r#"const a = make(call(), 123);
+const b = make(call(), 456);"#;
+        let module = parse(source);
+        let index = ShapeIndex::new(&module);
+        let anchor_set = index.minimal_anchor_set(0).unwrap();
+        let kept = kept_spans_for_anchor_set(&module.body[0], &anchor_set);
+        assert!(
+            kept.iter().any(|s| span_text(source, s) == "123"),
+            "expected a kept span covering `123`, got {:?}",
+            kept.iter()
+                .map(|s| span_text(source, s))
+                .collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/devinfra/js/debundle/selector_candidate_index.rs
+++ b/devinfra/js/debundle/selector_candidate_index.rs
@@ -46,6 +46,12 @@ pub enum SelectorFeature {
     VarKind(VarKind),
     FunctionArity(usize),
     StringLiteral(String),
+    /// A numeric literal, keyed by its canonical `f64::to_string` form so the
+    /// index and matcher agree on identity (the matcher compares via
+    /// `eq_ignore_span`, which is value equality). BigInt literals reuse this
+    /// variant keyed by their decimal string.
+    NumberLiteral(String),
+    BoolLiteral(bool),
     ObjectKey(String),
     ClassMember(String),
     MemberProperty(String),
@@ -515,10 +521,32 @@ impl Visit for AstFeatureCollector<'_, '_> {
         if expr_hole_name(expr).is_some() {
             return;
         }
-        if let Expr::Lit(Lit::Str(str_)) = expr {
-            let value = str_.value.to_string_lossy().to_string();
-            if !self.string_literal_is_wildcard(&value) {
-                self.features.insert(SelectorFeature::StringLiteral(value));
+        if let Expr::Lit(lit) = expr {
+            match lit {
+                Lit::Str(str_) => {
+                    let value = str_.value.to_string_lossy().to_string();
+                    if !self.string_literal_is_wildcard(&value) {
+                        self.features.insert(SelectorFeature::StringLiteral(value));
+                    }
+                }
+                // Number / bool literals are never wildcarded or holed in place
+                // (only an `EXPR`/`ANYTHING` hole erases them, handled above),
+                // and the matcher discriminates them by value (`eq_ignore_span`),
+                // so indexing them keeps the candidate set a sound match superset
+                // while letting a numeric/bool discriminator narrow it.
+                Lit::Num(num) => {
+                    self.features
+                        .insert(SelectorFeature::NumberLiteral(num.value.to_string()));
+                }
+                Lit::BigInt(bigint) => {
+                    self.features
+                        .insert(SelectorFeature::NumberLiteral(bigint.value.to_string()));
+                }
+                Lit::Bool(bool_) => {
+                    self.features
+                        .insert(SelectorFeature::BoolLiteral(bool_.value));
+                }
+                Lit::Null(_) | Lit::Regex(_) | Lit::JSXText(_) => {}
             }
             return;
         }
@@ -991,6 +1019,56 @@ function unrelated() { return 1; }"#,
 
         assert_eq!(exact, vec![0]);
         assert!(exact.into_iter().all(|idx| candidate_set.contains(idx)));
+    }
+
+    #[test]
+    fn number_and_bool_literal_features_keep_candidate_set_a_match_superset() {
+        // The number/bool literal taxonomy extension must stay a sound prefilter:
+        // for every selector pinning a numeric or boolean discriminator, the
+        // candidate set must contain every body index the production matcher
+        // returns (it may contain extras, never miss a true match).
+        let runtime = parse_module(
+            r#"const alpha = make(123, { enabled: true });
+const beta = make(456, { enabled: true });
+const gamma = make(123, { enabled: false });
+const delta = make(123);"#,
+        );
+        let index = SelectorCandidateIndex::new(&runtime);
+
+        for selector_source in [
+            r#"const readable = make(123, ANYTHING);"#,
+            r#"const readable = make(456, ANYTHING);"#,
+            r#"const readable = make(ANYTHING, { enabled: true });"#,
+            r#"const readable = make(ANYTHING, { enabled: false });"#,
+            r#"const readable = make(123, { enabled: false });"#,
+        ] {
+            let selector = selector(selector_source);
+            let matched = js_ast::with_swc_globals(|| {
+                source_match::find_anonymous_statement_body_indices(&runtime, "<test>", &selector)
+                    .unwrap()
+            });
+            let candidate_set = index.candidate_set_for_source_match(&selector).unwrap();
+            assert!(
+                matched.iter().all(|idx| candidate_set.contains(*idx)),
+                "candidate set must be a match superset for {selector_source:?}: \
+                 matched={matched:?} candidates={:?}",
+                body_indices(candidate_set.clone())
+            );
+        }
+    }
+
+    #[test]
+    fn number_literal_feature_narrows_to_the_discriminating_item() {
+        // The numeric argument is the sole discriminator; indexing it lets the
+        // prefilter narrow to the single item carrying that value.
+        let runtime = parse_module(
+            r#"const alpha = make(call(), 123);
+const beta = make(call(), 456);"#,
+        );
+        let index = SelectorCandidateIndex::new(&runtime);
+        let only_123 =
+            index.candidate_set_for_feature(&SelectorFeature::NumberLiteral(123.0_f64.to_string()));
+        assert_eq!(body_indices(only_123), vec![0]);
     }
 
     #[test]

--- a/devinfra/js/debundle/selector_codemod.rs
+++ b/devinfra/js/debundle/selector_codemod.rs
@@ -1439,6 +1439,29 @@ fn hole_object(object: &ObjectLit, kept: &BTreeSet<AnchorSpan>) -> ObjectLit {
     holed
 }
 
+/// Hole an object literal for the read-off object form: keep only props
+/// carrying a kept anchor and **always** lead and trail with an `OBJECT_PROPS`
+/// hole, regardless of whether the kept prop sits at a source edge.
+///
+/// Unlike [`hole_object`] (which only emits a list hole where a run of props was
+/// actually dropped), this pads both edges unconditionally. Object properties
+/// are unordered enum/lookup entries: a key that is genuinely last in this build
+/// can move on a rebuild, so anchoring it to the object's right edge
+/// (`anchored_right` in the matcher) is fragile. Padding both sides matches the
+/// discriminating key as an interior subsequence element, surviving reorder.
+fn hole_object_padded(object: &ObjectLit, kept: &BTreeSet<AnchorSpan>) -> ObjectLit {
+    let mut props = vec![object_props_prop()];
+    for prop in &object.props {
+        if node_retains_any(prop.span(), kept) {
+            props.push(hole_prop(prop, kept));
+        }
+    }
+    props.push(object_props_prop());
+    let mut holed = object.clone();
+    holed.props = props;
+    holed
+}
+
 fn hole_prop(prop: &PropOrSpread, kept: &BTreeSet<AnchorSpan>) -> PropOrSpread {
     let PropOrSpread::Prop(inner) = prop else {
         return prop.clone();
@@ -2128,6 +2151,71 @@ fn declarator_hole(name: &str) -> VarDeclarator {
     }
 }
 
+/// Read off a minimal selector for a single-target `var`/`let`/`const` whose
+/// declarator value is an object literal (W3).
+///
+/// Applies only to the single-target, single-declarator-target object case (the
+/// general group path stays unmigrated). Reads the minimal [`AnchorSet`] off the
+/// shape index, maps its value anchors to kept byte spans over the object, and
+/// renders the object with [`hole_object_padded`] (both-edge `OBJECT_PROPS`) so
+/// the discriminating key:value survives key reordering. Returns `None` — so the
+/// caller falls back to the keep-shallow group path — when the target is not a
+/// single object declarator, the structural scaffold already resolves (let the
+/// group path keep its leaner all-holed form), the read-off cannot single out
+/// the target, or the rendered selector fails the matcher gate.
+fn try_single_object_read_off(
+    index: &ChunkSelectorIndex,
+    var: &VarDecl,
+    decl: &IndexedDeclaration,
+    targets: &[SynthesizedTargetBinding],
+    target_slots: &BTreeSet<usize>,
+) -> Result<Option<SpecializedSelector>> {
+    // Only the genuine single-declarator case: one target binding and one
+    // declarator in the whole var. A multi-declarator group (even with a single
+    // target slot) needs the `DECLARATORS_*` holes the group path renders, so it
+    // stays unmigrated (later wave).
+    let [target] = targets else {
+        return Ok(None);
+    };
+    if var.decls.len() != 1 || target_slots.len() != 1 {
+        return Ok(None);
+    }
+    let declarator = &var.decls[0];
+    let Some(Expr::Object(object)) = declarator.init.as_deref() else {
+        return Ok(None);
+    };
+
+    let render_with = |kept: &BTreeSet<AnchorSpan>| -> Result<String> {
+        let mut holed = declarator.clone();
+        holed.name = named_pat(&target.export_name);
+        holed.init = Some(Box::new(Expr::Object(hole_object_padded(object, kept))));
+        let mut holed_var = var.clone();
+        holed_var.declare = false;
+        holed_var.decls = vec![holed];
+        emit_selector(ModuleItem::Stmt(Stmt::Decl(Decl::Var(Box::new(holed_var)))))
+    };
+
+    let anchor_set = index.shape_index.minimal_anchor_set(decl.body_idx);
+    let Some(anchor_set) = anchor_set else {
+        return Ok(None);
+    };
+    let item = index
+        .parsed
+        .module
+        .body
+        .get(decl.body_idx)
+        .context("read-off body index no longer in module")?;
+    let kept = kept_spans_for_anchor_set(item, &anchor_set);
+    // A structural / skeleton-only read-off keeps no concrete object token: the
+    // padded scaffold would be `{ OBJECT_PROPS, OBJECT_PROPS }`, which pins
+    // nothing about the object and is no leaner than the group path's form.
+    // Defer to the group path so the migration only owns the value-anchored case.
+    if kept.is_empty() {
+        return Ok(None);
+    }
+    finish_minimized_selector(index, decl, target, render_with(&kept)?)
+}
+
 /// Minimal anchor cover for a `var`/`let`/`const` binding group: render the
 /// shared declaration keeping the target declarators (each `export = <holed
 /// init>`) with `DECLARATORS_*` holes for non-target runs, and pin just enough
@@ -2162,6 +2250,16 @@ fn minimize_var_group_selector(
         .collect();
     if target_slots.len() != targets.len() {
         return Ok(None);
+    }
+
+    // W3: single-target var whose value is an object literal reads its minimal
+    // selector off the shape index — `OBJECT_PROPS` holes around the
+    // discriminating key(s) instead of keeping every key (the
+    // `object_keys_over_pinned` over-pin). The matcher proves it (gate 1); on
+    // `None` we fall through to the keep-shallow group path below, so a target
+    // the read-off cannot single out is handled exactly as before.
+    if let Some(selector) = try_single_object_read_off(index, var, decl, targets, &target_slots)? {
+        return Ok(Some(selector));
     }
 
     let render_with = |kept: &BTreeSet<AnchorSpan>,

--- a/devinfra/js/debundle/shape_index.rs
+++ b/devinfra/js/debundle/shape_index.rs
@@ -666,11 +666,20 @@ impl ShapeIndex {
         }
         for &shape in &item.skeletons {
             let f = ShapeFeature::Skeleton(shape);
+            // W2 note #3: a shape skeleton interned many times across the chunk
+            // is structural noise (a common scaffold), not a stable anchor; one
+            // interned rarely is a distinctive shape worth pinning. Demote the
+            // common ones to `Structural` so a value-bearing semantic anchor
+            // (literal, key, member) wins the stability tiebreak when their
+            // selectivities are equal. Selectivity stays the primary key.
+            let stability = if self.interner.multiplicity(shape) > SKELETON_NOISE_MULTIPLICITY {
+                Stability::Structural
+            } else {
+                Stability::Semantic
+            };
             scored.push(ScoredFeature {
                 selectivity: self.posting(&f).len(),
-                // A shape skeleton seen on many items is structural noise; one
-                // seen rarely is a semantic shape worth pinning.
-                stability: Stability::Semantic,
+                stability,
                 feature: f,
             });
         }
@@ -755,6 +764,12 @@ impl ShapeIndex {
     }
 }
 
+/// Multiplicity above which a shape skeleton reads as structural noise rather
+/// than a distinctive anchor (W2 note #3). A shape interned more than this many
+/// times across the chunk is a common scaffold; one interned at most this often
+/// is distinctive enough to rank as a semantic anchor on stability ties.
+const SKELETON_NOISE_MULTIPLICITY: u32 = 4;
+
 /// Ranking key: most selective first (smallest posting list), then most stable.
 /// Wrapped in a comparable tuple; smaller sorts first.
 fn rank_key(f: &ScoredFeature) -> (usize, std::cmp::Reverse<Stability>) {
@@ -791,6 +806,10 @@ fn selector_feature_stability(feature: &SelectorFeature) -> Stability {
                 Stability::Semantic
             }
         }
+        // Number / bool literals are concrete semantic values (enum tags,
+        // discriminant codes, config flags); they survive rebuilds and
+        // discriminate well, so they rank as preferred anchors.
+        SelectorFeature::NumberLiteral(_) | SelectorFeature::BoolLiteral(_) => Stability::Semantic,
         SelectorFeature::ObjectKey(_)
         | SelectorFeature::ClassMember(_)
         | SelectorFeature::MemberProperty(_)

--- a/devinfra/js/debundle/shape_index_soundness_test.rs
+++ b/devinfra/js/debundle/shape_index_soundness_test.rs
@@ -38,6 +38,17 @@ fn render_selector(module: &Module, anchor: &AnchorSet) -> AnonymousStatementSel
             _ => None,
         })
         .collect();
+    // Number / bool literal anchors render verbatim (the matcher discriminates
+    // them by value), keyed by their canonical feature string.
+    let kept_numbers: BTreeSet<String> = anchor
+        .anchors
+        .iter()
+        .filter_map(|scored| match &scored.feature {
+            ShapeFeature::Selector(SelectorFeature::NumberLiteral(value)) => Some(value.clone()),
+            ShapeFeature::Selector(SelectorFeature::BoolLiteral(value)) => Some(value.to_string()),
+            _ => None,
+        })
+        .collect();
     let kept_keys: BTreeSet<String> = anchor
         .anchors
         .iter()
@@ -52,7 +63,7 @@ fn render_selector(module: &Module, anchor: &AnchorSet) -> AnonymousStatementSel
         })
         .collect();
 
-    let match_source = render_item(item, &kept_strings, &kept_keys);
+    let match_source = render_item(item, &kept_strings, &kept_numbers, &kept_keys);
     AnonymousStatementSelector {
         match_source,
         identifiers: SourceMatchIdentifierMode::AlphaAll,
@@ -66,6 +77,7 @@ fn render_selector(module: &Module, anchor: &AnchorSet) -> AnonymousStatementSel
 fn render_item(
     item: &ModuleItem,
     kept_strings: &BTreeSet<String>,
+    kept_numbers: &BTreeSet<String>,
     kept_keys: &BTreeSet<String>,
 ) -> String {
     match item {
@@ -78,7 +90,7 @@ fn render_item(
             let init = var.decls[0]
                 .init
                 .as_ref()
-                .map(|e| render_expr(e, kept_strings, kept_keys))
+                .map(|e| render_expr(e, kept_strings, kept_numbers, kept_keys))
                 .unwrap_or_else(|| "EXPR".to_string());
             format!("{kind} readable = {init};")
         }
@@ -115,6 +127,7 @@ fn render_item(
 fn render_expr(
     expr: &Expr,
     kept_strings: &BTreeSet<String>,
+    kept_numbers: &BTreeSet<String>,
     kept_keys: &BTreeSet<String>,
 ) -> String {
     match expr {
@@ -126,34 +139,45 @@ fn render_expr(
                 "EXPR".to_string()
             }
         }
+        Expr::Lit(Lit::Num(num)) if kept_numbers.contains(&num.value.to_string()) => {
+            num.value.to_string()
+        }
+        Expr::Lit(Lit::Bool(bool_)) if kept_numbers.contains(&bool_.value.to_string()) => {
+            bool_.value.to_string()
+        }
         Expr::Call(call) => {
             let callee = match &call.callee {
-                Callee::Expr(e) => render_expr(e, kept_strings, kept_keys),
+                Callee::Expr(e) => render_expr(e, kept_strings, kept_numbers, kept_keys),
                 _ => "EXPR".to_string(),
             };
             let args: Vec<String> = call
                 .args
                 .iter()
-                .map(|a| render_expr(&a.expr, kept_strings, kept_keys))
+                .map(|a| render_expr(&a.expr, kept_strings, kept_numbers, kept_keys))
                 .collect();
             format!("{callee}({})", args.join(", "))
         }
         Expr::Ident(_) => "EXPR".to_string(),
         Expr::Object(object) => {
-            // Keep a property when its key is an anchor, or when its value is a
-            // kept (anchored) string literal — pin the key:value so the kept
-            // literal survives into the selector.
+            // Keep a property when its key is an anchor, or when its value
+            // renders to a kept (anchored) scalar literal — pin the key:value so
+            // the kept literal survives into the selector.
             let props: Vec<String> = object
                 .props
                 .iter()
                 .filter_map(object_prop_kv)
-                .filter(|(key, value)| {
-                    kept_keys.contains(key)
-                        || value.as_ref().is_some_and(|v| kept_strings.contains(v))
-                })
-                .map(|(key, value)| match value {
-                    Some(v) if kept_strings.contains(&v) => format!("{key}: {v:?}"),
-                    _ => format!("{key}: EXPR"),
+                .filter_map(|(key, value)| {
+                    let rendered_value = value
+                        .as_ref()
+                        .map(|v| render_expr(v, kept_strings, kept_numbers, kept_keys));
+                    let value_anchored = rendered_value.as_deref().is_some_and(|v| v != "EXPR");
+                    if !kept_keys.contains(&key) && !value_anchored {
+                        return None;
+                    }
+                    Some(format!(
+                        "{key}: {}",
+                        rendered_value.unwrap_or_else(|| "EXPR".to_string())
+                    ))
                 })
                 .collect();
             // Lead and trail with list holes so kept props match as an ordered
@@ -178,20 +202,13 @@ fn class_member_name(member: &ClassMember) -> Option<String> {
     }
 }
 
-/// Key name plus, when the value is a string literal, its value.
-fn object_prop_kv(prop: &PropOrSpread) -> Option<(String, Option<String>)> {
+/// Key name plus the value expression (rendered by the caller).
+fn object_prop_kv(prop: &PropOrSpread) -> Option<(String, Option<&Expr>)> {
     let PropOrSpread::Prop(prop) = prop else {
         return None;
     };
     match prop.as_ref() {
-        Prop::KeyValue(kv) => {
-            let key = prop_name(&kv.key)?;
-            let value = match kv.value.as_ref() {
-                Expr::Lit(Lit::Str(str_)) => Some(str_.value.to_string_lossy().to_string()),
-                _ => None,
-            };
-            Some((key, value))
-        }
+        Prop::KeyValue(kv) => Some((prop_name(&kv.key)?, Some(kv.value.as_ref()))),
         Prop::Shorthand(ident) => Some((ident.sym.to_string(), None)),
         _ => None,
     }
@@ -320,6 +337,31 @@ const b = make("shared", "beta");"#,
             .all(|scored| scored.stability != Stability::Volatile),
         "read-off must prefer stable anchors when available"
     );
+}
+
+#[test]
+fn number_literal_discriminator_read_off_resolves_uniquely() {
+    // The only difference between the items is the numeric argument; with
+    // number-literal features the read-off pins it and resolves uniquely.
+    let module = parse(
+        r#"const a = make(call(), 123);
+const b = make(call(), 456);
+const c = make(call(), 789);"#,
+    );
+    for idx in 0..3 {
+        assert_read_off_resolves_uniquely(&module, idx);
+    }
+}
+
+#[test]
+fn bool_literal_discriminator_read_off_resolves_uniquely() {
+    // Items differ only in a boolean object-value; the bool literal anchor
+    // discriminates the `true` one from its `false` sibling.
+    let module = parse(
+        r#"const a = cfg({ flag: true });
+const b = cfg({ flag: false });"#,
+    );
+    assert_read_off_resolves_uniquely(&module, 0);
 }
 
 #[test]


### PR DESCRIPTION
**Wave 3 (part 1): object over-pin elimination + number/bool literal features.**
Rebased onto `devel` after #2261. Strangler-fig — var/class/group stay on the
cover path; cover not deleted.

## Number/bool literal features
`SelectorFeature` gains `NumberLiteral`/`BoolLiteral`; `AstFeatureCollector`
indexes all scalar literals. **Prefilter stays a sound match superset:** these
literals are never wildcarded and are only erased by an `EXPR`/`ANYTHING` hole
(which the collector early-returns on), so adding them can only *narrow*
candidate sets, never drop a true match. New test
`number_and_bool_literal_features_keep_candidate_set_a_match_superset` runs the
production matcher and asserts the superset property; plus a narrowing test and
matcher-backed read-off soundness tests. Side effect: `call_argument_literal`'s
numeric discriminator is now read-off-expressible (migrates to read-off;
identical output, no fixture change).

## Object form → read-off
`try_single_object_read_off` (single target binding + single declarator +
object-literal init) reads `minimal_anchor_set`, maps value anchors to kept
spans, and renders via a new `hole_object_padded` that **always** leads and
trails with `OBJECT_PROPS` — object props are unordered, so anchoring a key to
the right edge is fragile. Gate-1 proven via `prove_synthesized_selector`; `None`
falls back to the existing keep-shallow path, never a full-AST dump.

## Unignored
- **`object_keys_over_pinned` → active, green:** emits
  `const SelectedLabels = { OBJECT_PROPS, 10: "uniqueDiscriminatorLabel", OBJECT_PROPS };`.
- `grouped_enum_objects` stays ignored (multi-declarator group; later wave).

Also (W2 note #3): skeleton-feature stability demotes shapes interned >4× to
`Structural` so a value-bearing semantic anchor wins the stability tiebreak.

## Validation
116/116 `//devinfra/js/debundle/...` pass on RBE with lint (pre-rebase); the
rebase merged #2261's CASE_REST test alongside (no semantic overlap). Only fixture
change is removing `object_keys_over_pinned`'s `#[ignore]`.

## Next wave
var (non-object single declarator), class/subclass, grouped objects → read-off;
anti-unification grouping; then delete the cover search.

https://claude.ai/code/session_01RYUAvJefa2eJRgZ7XBfqxA

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYUAvJefa2eJRgZ7XBfqxA)_