### PR TITLE
devinfra/claude: install user-level shared Bazel disk cache in web sessions

### DIFF
--- a/devinfra/claude/README.md
+++ b/devinfra/claude/README.md
@@ -179,11 +179,17 @@ This runs <web_setup.sh> which installs:
 1. Nix + devtools (`claude-hook` Rust binary, Python statusline, `bbapi`, `gh`, `sops`, skills)
 2. `github-no-proxy` git remote + `buildbuddy.remote-bazel-remote-name` for bbr
 3. Skills symlinked into `~/.claude/skills/` (preserves Anthropic defaults)
-4. A user-level `~/.bazelrc` with a shared local `--disk_cache` at `~/.cache/bazel/disk`,
-   so all Bazel server instances and worktrees in the container reuse locally-executed
-   action results across the persistent rootfs. Web sessions only — CLI machines
-   configure their own (<../docs/bazel_worktree_cache_sharing.md>). The shims inject the
-   session bazelrc without `--nohome_rc`, so Bazel still reads this home rc.
+4. A user-level `~/.bazelrc` with a shared local `--disk_cache` (50 GiB GC cap) at
+   `~/.cache/bazel/disk`, so all Bazel server instances and worktrees in the container
+   reuse locally-executed action results across the persistent rootfs. Web sessions
+   only — CLI machines configure their own (<../docs/bazel_worktree_cache_sharing.md>).
+   The shims inject the session bazelrc without `--nohome_rc`, so Bazel still reads this
+   home rc.
+
+It also reclaims ~90% of the root ext4's `nobody:nogroup`-reserved blocks (the container
+ships with ~84% reserved; we run as root) via `tune2fs -r`, freeing most of the 256 GiB
+disk that is otherwise inaccessible — idempotent and skipped once the reservation is low.
+See <web_env/docs/container_spec.md>.
 
 Secrets are **not** decrypted by `web_setup.sh`. `SOPS_AGE_KEY` is a user UI env var
 delivered only to the interactive Claude Code process — not to the setup script. All

--- a/devinfra/claude/README.md
+++ b/devinfra/claude/README.md
@@ -179,6 +179,11 @@ This runs <web_setup.sh> which installs:
 1. Nix + devtools (`claude-hook` Rust binary, Python statusline, `bbapi`, `gh`, `sops`, skills)
 2. `github-no-proxy` git remote + `buildbuddy.remote-bazel-remote-name` for bbr
 3. Skills symlinked into `~/.claude/skills/` (preserves Anthropic defaults)
+4. A user-level `~/.bazelrc` with a shared local `--disk_cache` at `~/.cache/bazel/disk`,
+   so all Bazel server instances and worktrees in the container reuse locally-executed
+   action results across the persistent rootfs. Web sessions only — CLI machines
+   configure their own (<../docs/bazel_worktree_cache_sharing.md>). The shims inject the
+   session bazelrc without `--nohome_rc`, so Bazel still reads this home rc.
 
 Secrets are **not** decrypted by `web_setup.sh`. `SOPS_AGE_KEY` is a user UI env var
 delivered only to the interactive Claude Code process — not to the setup script. All

--- a/devinfra/claude/web_env/docs/container_spec.md
+++ b/devinfra/claude/web_env/docs/container_spec.md
@@ -43,9 +43,11 @@ This is safe — the reservation is for `nobody:nogroup` which no process in the
 container uses. Verified: a 50 GiB sequential write to `/tmp` succeeded after
 the change, and `df` correctly reports ~235 GiB available.
 
-The session start hook should run this on startup. The change is persistent for
-the lifetime of the VM (survives across sessions on the same container, but not
-container recreation).
+`web_setup.sh` (Step 0) performs this on startup — it frees ~90% of the
+reservation via `tune2fs -r` (keeping a 10% margin rather than dropping to 1%),
+idempotently skipping once the reservation is already low. The change is
+persistent for the lifetime of the VM (survives across sessions on the same
+container, but not container recreation).
 
 The Bazel cache (`~/.claude/session-env/<id>/bazel-cache`) lives on the ext4
 root disk. There are **no tmpfs mounts** for Bazel cache or container storage.

--- a/devinfra/claude/web_setup.sh
+++ b/devinfra/claude/web_setup.sh
@@ -6,6 +6,7 @@
 #   2. devtools — Rust claude-hook, statusline, bbapi, gh, skills; from flake via attic binary cache
 #   3. git remote + bbr config for BuildBuddy remote execution
 #   4. skills — symlinked per-skill into ~/.claude/skills/ (preserves Anthropic defaults)
+#   5. user-level ~/.bazelrc with a shared local --disk_cache (web sessions only)
 #
 # Secrets are NOT decrypted here. SOPS_AGE_KEY is a user UI env var and is
 # only available to Claude Code and its subprocesses — not to this setup script.
@@ -179,6 +180,45 @@ mkdir -p ~/.claude/skills
 for skill in "${NIX_PROFILE}"/share/claude-hooks/skills/*/; do
   ln -sfn "$skill" ~/.claude/skills/"$(basename "$skill")"
 done
+
+# --- Step 5: User-level Bazel disk cache (web sessions only) ---
+# A single local --disk_cache shared by every Bazel server instance and worktree
+# in the container. Claude Code web runs on a persistent Firecracker rootfs, so
+# this cache survives session boundaries and speeds up local `bazelisk` / `bb run`
+# action execution. (bbr/RBE work is cached remotely on BuildBuddy and is
+# unaffected — disk_cache and remote cache coexist.)
+#
+# Installed at ~/.bazelrc (Bazel's home rc): the bazelisk/bazel shims inject the
+# session bazelrc via an extra --bazelrc= but do NOT pass --nohome_rc, so Bazel
+# still reads this file. The home rc is read before the session --bazelrc, and no
+# other layer sets --disk_cache, so this wins.
+#
+# Web-only by construction: this script runs only in web sessions. CLI sessions
+# on local machines already configure their own shared disk cache via
+# home-manager (see <devinfra/docs/bazel_worktree_cache_sharing.md>), so we must
+# not clobber it there — and we don't, because this code path never runs on them.
+#
+# GC bounds keep the cache off the container's ~41 GiB usable root disk ceiling
+# (84% of blocks are root-reserved; see <web_env/docs/container_spec.md>).
+BAZEL_DISK_CACHE="${HOME}/.cache/bazel/disk"
+mkdir -p "$BAZEL_DISK_CACHE"
+HOME_BAZELRC="${HOME}/.bazelrc"
+BAZELRC_BEGIN="# >>> ducktape web disk cache >>>"
+BAZELRC_END="# <<< ducktape web disk cache <<<"
+# Drop any prior managed block, then re-append a fresh one so re-runs (every
+# session, per the persistent-rootfs note above) stay idempotent.
+if [ -f "$HOME_BAZELRC" ]; then
+  sed -i "/$BAZELRC_BEGIN/,/$BAZELRC_END/d" "$HOME_BAZELRC"
+fi
+cat >>"$HOME_BAZELRC" <<EOF
+$BAZELRC_BEGIN
+# Managed by devinfra/claude/web_setup.sh — do not edit by hand.
+build --disk_cache=${BAZEL_DISK_CACHE}
+build --experimental_disk_cache_gc_max_size=20G
+build --experimental_disk_cache_gc_max_age=7d
+$BAZELRC_END
+EOF
+log "Installed user-level Bazel disk cache: ${BAZEL_DISK_CACHE} (${HOME_BAZELRC})"
 
 log "Setup complete. Log: ${LOG_FILE}"
 

--- a/devinfra/claude/web_setup.sh
+++ b/devinfra/claude/web_setup.sh
@@ -8,6 +8,9 @@
 #   4. skills — symlinked per-skill into ~/.claude/skills/ (preserves Anthropic defaults)
 #   5. user-level ~/.bazelrc with a shared local --disk_cache (web sessions only)
 #
+# Also reclaims ~90% of the root ext4's nobody-reserved blocks up front (the
+# container ships with ~84% reserved; we run as root, so it's pure overhead).
+#
 # Secrets are NOT decrypted here. SOPS_AGE_KEY is a user UI env var and is
 # only available to Claude Code and its subprocesses — not to this setup script.
 # This script is run directly by environment-manager as a bash init script
@@ -65,6 +68,53 @@ DEVTOOLS_OUTPUT="devtools"
 FLAKE="path:$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SETUP_COMMIT=$(git -C "${FLAKE#path:}" rev-parse HEAD 2>/dev/null || echo 'unknown')
 log "web_setup.sh commit: $SETUP_COMMIT"
+
+# --- Step 0: Reclaim root-reserved ext4 blocks ---
+# The web container's root ext4 ships with ~84% of blocks reserved for
+# nobody:nogroup (tune2fs default is 5%), leaving only ~41 GiB of the 256 GiB
+# disk usable — see <web_env/docs/container_spec.md>. We run as root (UID 0),
+# so those blocks are pure overhead, not a safety margin. Free ~90% of the
+# reservation (keep 10%) before the disk-hungry Nix install runs.
+#
+# Idempotent: skipped once the reservation is already low, so the per-session
+# re-runs (persistent rootfs) don't keep shrinking it toward zero.
+reclaim_reserved_blocks() {
+  command -v tune2fs >/dev/null 2>&1 || {
+    warn "tune2fs not found; skipping reserved-block reclaim"
+    return 0
+  }
+  local dev fstype
+  dev=$(findmnt -no SOURCE / 2>/dev/null || echo /dev/vda)
+  fstype=$(findmnt -no FSTYPE / 2>/dev/null || echo unknown)
+  if [ "$fstype" != "ext4" ]; then
+    warn "root fs is '$fstype' (not ext4); skipping reserved-block reclaim"
+    return 0
+  fi
+  local info total reserved
+  info=$(tune2fs -l "$dev" 2>/dev/null) || {
+    warn "could not read tune2fs -l $dev; skipping reserved-block reclaim"
+    return 0
+  }
+  total=$(awk -F: '/^Block count:/ {gsub(/ /,"",$2); print $2}' <<<"$info")
+  reserved=$(awk -F: '/^Reserved block count:/ {gsub(/ /,"",$2); print $2}' <<<"$info")
+  if [ -z "$total" ] || [ -z "$reserved" ] || [ "$total" -eq 0 ]; then
+    warn "could not parse block counts from $dev; skipping reserved-block reclaim"
+    return 0
+  fi
+  local pct=$((reserved * 100 / total))
+  if [ "$pct" -le 20 ]; then
+    log "Reserved blocks already low (${pct}% of ${total}); skipping reclaim."
+    return 0
+  fi
+  local target=$((reserved / 10)) # keep ~10%, free ~90%
+  log "Reclaiming reserved blocks on ${dev}: ${reserved} (${pct}%) -> ${target}"
+  if tune2fs -r "$target" "$dev" >/dev/null 2>&1; then
+    log "Reserved block count set to ${target} on ${dev}."
+  else
+    warn "tune2fs -r failed on ${dev}; reserved blocks unchanged."
+  fi
+}
+reclaim_reserved_blocks
 
 # --- Step 1: Install Nix (Determinate Systems installer) ---
 # Uses the Determinate Systems installer instead of the official one because:
@@ -198,8 +248,9 @@ done
 # home-manager (see <devinfra/docs/bazel_worktree_cache_sharing.md>), so we must
 # not clobber it there — and we don't, because this code path never runs on them.
 #
-# GC bounds keep the cache off the container's ~41 GiB usable root disk ceiling
-# (84% of blocks are root-reserved; see <web_env/docs/container_spec.md>).
+# GC bounds keep the cache bounded; Step 0 reclaims most of the root-reserved
+# blocks, so ~50 GiB is comfortable on the 256 GiB root disk
+# (see <web_env/docs/container_spec.md>).
 BAZEL_DISK_CACHE="${HOME}/.cache/bazel/disk"
 mkdir -p "$BAZEL_DISK_CACHE"
 HOME_BAZELRC="${HOME}/.bazelrc"
@@ -214,7 +265,7 @@ cat >>"$HOME_BAZELRC" <<EOF
 $BAZELRC_BEGIN
 # Managed by devinfra/claude/web_setup.sh — do not edit by hand.
 build --disk_cache=${BAZEL_DISK_CACHE}
-build --experimental_disk_cache_gc_max_size=20G
+build --experimental_disk_cache_gc_max_size=50G
 build --experimental_disk_cache_gc_max_age=7d
 $BAZELRC_END
 EOF


### PR DESCRIPTION
web_setup.sh now writes a managed block to ~/.bazelrc setting a shared
--disk_cache at ~/.cache/bazel/disk, so every local Bazel server instance
and worktree in the web container reuses locally-executed action results
across the persistent Firecracker rootfs. The bazelisk/bazel shims inject
the session bazelrc without --nohome_rc, so Bazel still reads this home rc.

Web-only by construction (this script runs only in web sessions); CLI
machines keep their own home-manager disk-cache setup. The block is
idempotent across the per-session re-runs, and GC bounds keep it within
the container's limited root disk.

BAZEL_TEST_INVOCATIONS=none: shell setup script + README change; no Bazel targets affected