### PR TITLE
Add home-manager install mode to Claude web setup

### DIFF
--- a/devinfra/claude/README.md
+++ b/devinfra/claude/README.md
@@ -180,6 +180,21 @@ This runs <web_setup.sh> which installs:
 2. `github-no-proxy` git remote + `buildbuddy.remote-bazel-remote-name` for bbr
 3. Skills symlinked into `~/.claude/skills/` (preserves Anthropic defaults)
 
+#### Install mode
+
+`web_setup.sh` supports two install modes, selected by the `DUCKTAPE_WEB_SETUP_MODE`
+env var (or a `--mode=<...>` arg):
+
+| Mode                          | How devtools + skills are installed                                                                                                                                                                       |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `profile` (default)           | `nix profile install .#devtools`, then per-skill symlinks into `~/.claude/skills/`.                                                                                                                       |
+| `home-manager` (experimental) | `home-manager switch --impure --flake .#claude-web`. Home Manager installs the same devtools and deploys Claude Code settings + skills through the shared HM skills module (<../../nix/home/skills.nix>). |
+
+The `home-manager` mode activates `homeConfigurations.claude-web` (defined in `flake.nix`,
+config at <../../nix/home/hosts/claude-web.nix>). It reuses the flake's `devToolPackages`
+list, so the two modes can't drift, and lets the web session pick up skills, plugins, MCP
+servers, and Claude settings from the same home-manager config the NixOS hosts use.
+
 Secrets are **not** decrypted by `web_setup.sh`. `SOPS_AGE_KEY` is a user UI env var
 delivered only to the interactive Claude Code process — not to the setup script. All
 decryption happens in the hook daemon via `startup_env_script` (`web_env.sh`) at

--- a/devinfra/claude/web_setup.sh
+++ b/devinfra/claude/web_setup.sh
@@ -7,6 +7,15 @@
 #   3. git remote + bbr config for BuildBuddy remote execution
 #   4. skills — symlinked per-skill into ~/.claude/skills/ (preserves Anthropic defaults)
 #
+# Install modes (DUCKTAPE_WEB_SETUP_MODE env var, or --mode=<...> arg):
+#   profile       (default) — `nix profile install .#devtools`, then manually
+#                  symlink skills into ~/.claude/skills/ (steps 2 + 4 above).
+#   home-manager  — `home-manager switch --flake .#claude-web`. Home Manager
+#                  installs the same devtools and deploys Claude Code settings +
+#                  skills through the shared HM skills module (nix/home/skills.nix),
+#                  so step 4 is owned by HM. See homeConfigurations.claude-web in
+#                  flake.nix and <nix/home/hosts/claude-web.nix>.
+#
 # Secrets are NOT decrypted here. SOPS_AGE_KEY is a user UI env var and is
 # only available to Claude Code and its subprocesses — not to this setup script.
 # This script is run directly by environment-manager as a bash init script
@@ -53,9 +62,21 @@ warn() {
 # Hook implementation is Rust-only. Keep parsing the old selector so stale web
 # UI env vars or setup args do not break session startup.
 HOOK_IMPL="rust"
+# Install mode: "profile" (nix profile install) or "home-manager".
+MODE="${DUCKTAPE_WEB_SETUP_MODE:-profile}"
 for arg in "$@"; do
-  case "$arg" in --impl=*) warn "Ignoring deprecated $arg; claude-hook is Rust-only" ;; esac
+  case "$arg" in
+    --impl=*) warn "Ignoring deprecated $arg; claude-hook is Rust-only" ;;
+    --mode=*) MODE="${arg#--mode=}" ;;
+  esac
 done
+case "$MODE" in
+  profile | home-manager) ;;
+  *)
+    warn "Unknown DUCKTAPE_WEB_SETUP_MODE='$MODE'; falling back to 'profile'"
+    MODE="profile"
+    ;;
+esac
 if [ -n "${DUCKTAPE_CLAUDE_HOOK_IMPL:-}" ] && [ "${DUCKTAPE_CLAUDE_HOOK_IMPL:-}" != "rust" ]; then
   warn "Ignoring deprecated DUCKTAPE_CLAUDE_HOOK_IMPL=$DUCKTAPE_CLAUDE_HOOK_IMPL; claude-hook is Rust-only"
 fi
@@ -116,8 +137,6 @@ ls -la
 # first so `install` re-evaluates `.#devtools` against the current flake.
 #
 # See <devinfra/claude/docs/web-setup-debug.md> ("Pin drift on persistent rootfs").
-nix profile remove devtools 2>/dev/null || true
-nix profile remove devtools-rust 2>/dev/null || true
 # TODO: `attic login` against cache.allegedly.works/{main,gaffer} before this
 # install so devtools (and any gaffer-built closures pulled transitively) hit
 # the private cache instead of building from source. The reader JWT is in
@@ -133,13 +152,38 @@ nix profile remove devtools-rust 2>/dev/null || true
 # sops decrypt into web_setup.sh directly using SOPS_AGE_KEY. Today the
 # install path falls back to building from source if main isn't reachable
 # anonymously — slow but works.
-nix profile install --max-jobs auto "${FLAKE}#${DEVTOOLS_OUTPUT}"
-log "Dev tools installed (impl=$HOOK_IMPL)."
+log "Install mode: $MODE"
+if [ "$MODE" = "home-manager" ]; then
+  # Home Manager installs the same devtools (homeConfigurations.claude-web reuses
+  # the flake's devToolPackages list) and deploys skills + Claude Code settings
+  # itself, so the standalone skill symlink in step 4 is skipped below.
+  #
+  # --impure: claude-web reads home.username/homeDirectory from $USER/$HOME.
+  # -b hm-backup: back up any pre-existing dotfiles (Anthropic-landed
+  #   ~/.claude/settings.json etc.) instead of failing the activation.
+  # nix run .#home-manager pins the HM CLI to our flake input (release-25.11).
+  nix run --max-jobs auto "${FLAKE}#home-manager" -- switch \
+    --impure -b hm-backup --max-jobs auto --flake "${FLAKE}#claude-web"
+  log "Home Manager profile 'claude-web' activated."
+  # home.packages land in the Nix user profile. Determinate/XDG-base-dir Nix may
+  # site it under ~/.local/state instead of ~/.nix-profile; pick whichever has bin/.
+  NIX_PROFILE="${HOME}/.nix-profile"
+  if [ ! -d "${NIX_PROFILE}/bin" ] && [ -d "${HOME}/.local/state/nix/profiles/profile/bin" ]; then
+    NIX_PROFILE="${HOME}/.local/state/nix/profiles/profile"
+  fi
+else
+  # CRITICAL: remove first so install re-evaluates against the current flake
+  # (see the "Pin drift on persistent rootfs" comment in the CRITICAL note above).
+  nix profile remove devtools 2>/dev/null || true
+  nix profile remove devtools-rust 2>/dev/null || true
+  NIX_PROFILE="/nix/var/nix/profiles/default"
+  nix profile install --max-jobs auto "${FLAKE}#${DEVTOOLS_OUTPUT}"
+  log "Dev tools installed (impl=$HOOK_IMPL)."
+fi
 
 # Symlink all Nix-installed binaries into /usr/local/bin so they're on PATH.
 # Claude Code is launched directly (not via login shell), so the Nix profile bin
 # is not in PATH when hooks run. /usr/local/bin is always in PATH.
-NIX_PROFILE="/nix/var/nix/profiles/default"
 for bin in "${NIX_PROFILE}"/bin/*; do
   ln -sfn "$bin" /usr/local/bin/"$(basename "$bin")"
 done
@@ -174,11 +218,17 @@ log "Set buildbuddy.remote-bazel-remote-name=github-no-proxy"
 # --- Step 4: Symlink skills into ~/.claude/skills/ ---
 # Per-skill symlinks instead of replacing the directory, so Anthropic's
 # pre-landed default skills are preserved.
-log "Deploying skills to ~/.claude/skills/..."
-mkdir -p ~/.claude/skills
-for skill in "${NIX_PROFILE}"/share/claude-hooks/skills/*/; do
-  ln -sfn "$skill" ~/.claude/skills/"$(basename "$skill")"
-done
+# Skipped in home-manager mode: the claude-web profile deploys skills via the
+# shared HM skills module (nix/home/skills.nix).
+if [ "$MODE" = "home-manager" ]; then
+  log "Skills deployed by Home Manager (claude-web profile); skipping manual symlink."
+else
+  log "Deploying skills to ~/.claude/skills/..."
+  mkdir -p ~/.claude/skills
+  for skill in "${NIX_PROFILE}"/share/claude-hooks/skills/*/; do
+    ln -sfn "$skill" ~/.claude/skills/"$(basename "$skill")"
+  done
+fi
 
 log "Setup complete. Log: ${LOG_FILE}"
 

--- a/flake.nix
+++ b/flake.nix
@@ -372,6 +372,11 @@
             name = "ducktape-rbetools";
             paths = devToolPackages;
           };
+          # home-manager CLI, pinned to our flake input (release-25.11). Used by
+          # web_setup.sh's home-manager install mode so activation does not pull
+          # an unpinned home-manager from the registry:
+          #   nix run .#home-manager -- switch --impure --flake .#claude-web
+          inherit (home-manager.packages.${system}) home-manager;
           # NixOS container tarball for docker import.
           # Build: nix build .#bazel-test-docker
           # Load:  docker import result ducktape-nixos-bazel
@@ -408,6 +413,26 @@
           enableGui = true;
           isNixOS = false;
 
+        };
+
+        # Claude Code web session — headless standalone profile installed by
+        # web_setup.sh's home-manager mode. Portable across the web container's
+        # user (home.username/homeDirectory read from the env), so it must be
+        # built/activated with --impure:
+        #   home-manager switch --impure --flake .#claude-web
+        claude-web = home-manager.lib.homeManagerConfiguration {
+          inherit pkgs;
+          modules = [
+            ./nix/home/hosts/claude-web.nix
+            {
+              _module.args = hmCommonArgs // {
+                enableGui = false;
+                isNixOS = false;
+                isK8sWorker = false;
+                webDevTools = devToolPackages;
+              };
+            }
+          ];
         };
       };
 

--- a/nix/README.md
+++ b/nix/README.md
@@ -37,9 +37,12 @@ These are the current standalone `homeConfigurations` exposed by the flake:
 ```bash
 home-manager switch --flake ~/code/ducktape#nixos-vm
 home-manager switch --impure --flake ~/code/ducktape#atlas
+home-manager switch --impure --flake ~/code/ducktape#claude-web
 ```
 
 Note: `atlas` needs `--impure` because it uses nixGL on a non-NixOS system.
+`claude-web` needs `--impure` because it reads `home.username`/`home.homeDirectory`
+from `$USER`/`$HOME` so the same profile works for whatever user the web container runs as.
 
 ## Available Hosts
 
@@ -55,10 +58,11 @@ Note: `atlas` needs `--impure` because it uses nixGL on a non-NixOS system.
 
 ### Home-Manager Configs (`homeConfigurations`)
 
-| Host       | OS       | Description                     |
-| ---------- | -------- | ------------------------------- |
-| `atlas`    | Proxmox  | Proxmox VE host home config     |
-| `nixos-vm` | NixOS VM | Simplified standalone HM config |
+| Host         | OS        | Description                                                                                                                          |
+| ------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `atlas`      | Proxmox   | Proxmox VE host home config                                                                                                          |
+| `nixos-vm`   | NixOS VM  | Simplified standalone HM config                                                                                                      |
+| `claude-web` | Web (any) | Headless Claude Code web-session profile; installed by `web_setup.sh` (home-manager mode). Reads `$USER`/`$HOME` → needs `--impure`. |
 
 ## Common Commands
 

--- a/nix/home/hosts/claude-web.nix
+++ b/nix/home/hosts/claude-web.nix
@@ -1,0 +1,51 @@
+# Claude Code web session — standalone home-manager profile.
+#
+# Headless, non-NixOS. This is the home-manager counterpart to the
+# `nix profile install .#devtools` + manual skill-symlink path in
+# <devinfra/claude/web_setup.sh>: it installs the same devtools and deploys
+# Claude Code settings + skills through the shared home-manager skills module
+# (../skills.nix, via the ../claude_code module).
+#
+# Portable across whatever user the web container runs as: home.username and
+# home.homeDirectory are read from the environment, so activation needs
+# --impure (same as the atlas profile):
+#
+#   home-manager switch --impure --flake .#claude-web
+{
+  pkgs,
+  lib,
+  webDevTools,
+  ...
+}:
+let
+  envUser = builtins.getEnv "USER";
+  envHome = builtins.getEnv "HOME";
+in
+{
+  imports = [
+    ../claude_code
+  ];
+
+  home.username = if envUser != "" then envUser else "user";
+  home.homeDirectory =
+    if envHome != "" then envHome else "/home/${if envUser != "" then envUser else "user"}";
+  home.stateVersion = "25.11";
+
+  programs.home-manager.enable = true;
+  targets.genericLinux.enable = true;
+
+  nix.package = pkgs.nix;
+  nix.settings.experimental-features = [
+    "nix-command"
+    "flakes"
+  ];
+
+  # Same toolset the .#devtools profile install ships (claude-hook, statusline,
+  # bbr, bbapi, gh, sops, kubectl, …). Reuses the flake's devToolPackages list
+  # so the two install paths can never drift.
+  home.packages = webDevTools ++ [
+    pkgs.jq
+    pkgs.ripgrep
+    pkgs.fd
+  ];
+}

--- a/nix/home/hosts/claude-web.nix
+++ b/nix/home/hosts/claude-web.nix
@@ -40,12 +40,18 @@ in
     "flakes"
   ];
 
+  # direnv + nix-direnv with the bash hook wired in (programs.bash.enable is
+  # required for home-manager to emit the hook into the shell rc) so `cd`ing into
+  # the repo activates the .envrc devshell.
+  programs.bash.enable = true;
+  programs.direnv = {
+    enable = true;
+    enableBashIntegration = true;
+    nix-direnv.enable = true;
+  };
+
   # Same toolset the .#devtools profile install ships (claude-hook, statusline,
   # bbr, bbapi, gh, sops, kubectl, …). Reuses the flake's devToolPackages list
   # so the two install paths can never drift.
-  home.packages = webDevTools ++ [
-    pkgs.jq
-    pkgs.ripgrep
-    pkgs.fd
-  ];
+  home.packages = webDevTools;
 }


### PR DESCRIPTION
## Summary

Adds an alternative installation mode to `web_setup.sh` that uses Home Manager instead of `nix profile install` for setting up Claude Code web sessions. This allows the web session to leverage the same home-manager configuration infrastructure used by NixOS hosts, ensuring consistency in devtools, skills, plugins, and Claude settings across deployment targets.

## Key Changes

- **New install mode selection**: `web_setup.sh` now accepts `DUCKTAPE_WEB_SETUP_MODE` env var or `--mode=<...>` argument to choose between `profile` (default) and `home-manager` modes
- **Home Manager profile**: Added `homeConfigurations.claude-web` in `flake.nix` with corresponding config at `nix/home/hosts/claude-web.nix`
- **Portable user handling**: The `claude-web` profile reads `home.username` and `home.homeDirectory` from `$USER` and `$HOME` environment variables (requires `--impure`), making it work across any user the web container runs as
- **Shared devtools list**: Both install modes use the same `devToolPackages` list from the flake, preventing drift between installation paths
- **Conditional skill deployment**: In home-manager mode, skills are deployed by Home Manager via the shared `nix/home/skills.nix` module; in profile mode, they're manually symlinked as before
- **Documentation**: Updated `devinfra/claude/README.md` and `nix/README.md` with install mode details and usage instructions

## Implementation Details

- The home-manager mode runs `nix run .#home-manager -- switch --impure --flake .#claude-web`, pinning the Home Manager CLI to the flake's release-25.11 input
- Handles both standard (`~/.nix-profile`) and Determinate/XDG-base-dir Nix profile locations (`~/.local/state/nix/profiles/profile`)
- Maintains backward compatibility: profile mode remains the default and works unchanged
- The `claude-web` profile imports the shared `../claude_code` home-manager module, reusing skills, plugins, and Claude Code settings configuration

https://claude.ai/code/session_016tod3jXhBc9zprUytqcwt7