### PR TITLE
devinfra/claude: export USER/HOME before home-manager activation

### DIFF
--- a/devinfra/claude/web_setup.sh
+++ b/devinfra/claude/web_setup.sh
@@ -213,6 +213,13 @@ if [ "$MODE" = "home-manager" ]; then
   # -b hm-backup: back up any pre-existing dotfiles (Anthropic-landed
   #   ~/.claude/settings.json etc.) instead of failing the activation.
   # nix run .#home-manager pins the HM CLI to our flake input (release-25.11).
+  #
+  # The init-script env does not reliably export USER, and the home-manager CLI
+  # runs under `set -u` (dies with "USER: unbound variable"). Export it (and
+  # guard HOME) so both the CLI and the impure claude-web eval see them.
+  export USER="${USER:-$(id -un)}"
+  export HOME="${HOME:-$(getent passwd "$USER" | cut -d: -f6)}"
+  log "Home Manager: USER=$USER HOME=$HOME"
   nix run --max-jobs auto "${FLAKE}#home-manager" -- switch \
     --impure -b hm-backup --max-jobs auto --flake "${FLAKE}#claude-web"
   log "Home Manager profile 'claude-web' activated."


### PR DESCRIPTION
## Summary

Follow-up fix to the home-manager install mode added in #2266.

Running `web_setup.sh` in `home-manager` mode failed during activation with:

```
/nix/store/.../home-manager/bin/home-manager: line 158: USER: unbound variable
```

The web init-script environment does not reliably export `USER`, and the
home-manager CLI runs under `set -u`, so it died before doing any work. The
`claude-web` profile also reads `getEnv "USER"`/`"HOME"` for
`home.username`/`home.homeDirectory`.

## Fix

Export `USER` (derived from `id -un`) and guard `HOME` in the home-manager
branch of `web_setup.sh`, before invoking `nix run .#home-manager -- switch`,
so both the CLI and the impure `claude-web` eval see them.

## Testing

- `bash -n devinfra/claude/web_setup.sh` (syntax) + `shfmt` pre-commit hook.
- No Bazel test targets cover `web_setup.sh`.

https://claude.ai/code/session_016tod3jXhBc9zprUytqcwt7

---
_Generated by [Claude Code](https://claude.ai/code/session_016tod3jXhBc9zprUytqcwt7)_