### PR TITLE
debundle: DRY repeated anyhow error-context messages (no behavior change)

### DIFF
--- a/devinfra/js/debundle/anonymous_resolution.rs
+++ b/devinfra/js/debundle/anonymous_resolution.rs
@@ -93,12 +93,8 @@ fn resolve_member_selector_claims_in_globals(
 
     let mut parsed_by_source = BTreeMap::new();
     for source_path in &source_paths {
-        let resolved =
-            resolve_source_file(source_path, source_root, owner_graph_path, modules_root)?;
-        let source = fs::read_to_string(&resolved)
-            .with_context(|| format!("reading source file {}", resolved.display()))?;
-        let parsed = js_ast::parse_js_module(source_path, &source)
-            .with_context(|| format!("parsing source file {}", resolved.display()))?;
+        let parsed =
+            read_and_parse_source(source_path, source_root, owner_graph_path, modules_root)?;
         parsed_by_source.insert(source_path.clone(), parsed);
     }
 
@@ -206,12 +202,8 @@ fn addressable_anonymous_statement_owner_ids_in_globals(
 
     let mut out = BTreeSet::<String>::new();
     for source_path in &source_paths {
-        let resolved =
-            resolve_source_file(source_path, source_root, owner_graph_path, modules_root)?;
-        let source = fs::read_to_string(&resolved)
-            .with_context(|| format!("reading source file {}", resolved.display()))?;
-        let parsed = js_ast::parse_js_module(source_path, &source)
-            .with_context(|| format!("parsing source file {}", resolved.display()))?;
+        let parsed =
+            read_and_parse_source(source_path, source_root, owner_graph_path, modules_root)?;
         let unique_body_indices: BTreeSet<usize> = SyntaxContext::within_ignored_ctxt(|| {
             parsed
                 .module
@@ -286,12 +278,8 @@ fn resolve_anonymous_statement_claims_in_globals(
 
     let mut parsed_by_source = BTreeMap::new();
     for source_path in &source_paths {
-        let resolved =
-            resolve_source_file(source_path, source_root, owner_graph_path, modules_root)?;
-        let source = fs::read_to_string(&resolved)
-            .with_context(|| format!("reading source file {}", resolved.display()))?;
-        let parsed = js_ast::parse_js_module(source_path, &source)
-            .with_context(|| format!("parsing source file {}", resolved.display()))?;
+        let parsed =
+            read_and_parse_source(source_path, source_root, owner_graph_path, modules_root)?;
         parsed_by_source.insert(source_path.clone(), parsed);
     }
 
@@ -348,6 +336,22 @@ fn resolve_anonymous_statement_claims_in_globals(
     }
 
     Ok(out)
+}
+
+/// Resolve `source_path` to a file on disk, read it, and parse it as a JS
+/// module. The resolve/read/parse trio every selector-claim resolver in this
+/// module repeats; the read and parse error contexts name the resolved file.
+fn read_and_parse_source(
+    source_path: &str,
+    source_root: Option<&Path>,
+    owner_graph_path: &Path,
+    modules_root: &Path,
+) -> Result<js_ast::ParsedJsModule> {
+    let resolved = resolve_source_file(source_path, source_root, owner_graph_path, modules_root)?;
+    let source = fs::read_to_string(&resolved)
+        .with_context(|| format!("reading source file {}", resolved.display()))?;
+    js_ast::parse_js_module(source_path, &source)
+        .with_context(|| format!("parsing source file {}", resolved.display()))
 }
 
 fn resolve_source_file(

--- a/devinfra/js/debundle/cli/edit_gate.rs
+++ b/devinfra/js/debundle/cli/edit_gate.rs
@@ -349,11 +349,7 @@ pub fn gate_post_edit_partition(
     source_root: Option<&Path>,
     post_spec: &PostEditSpec,
 ) -> Result<()> {
-    let owner_graph_report: OwnerGraphReport = serde_json::from_str(
-        &fs::read_to_string(owner_graph_path)
-            .with_context(|| format!("reading {}", owner_graph_path.display()))?,
-    )
-    .with_context(|| format!("parsing owner graph {}", owner_graph_path.display()))?;
+    let owner_graph_report = crate::load_owner_graph_report(owner_graph_path)?;
 
     // The gate algorithm walks edges + partition, not declared sets.
     // Pass `&[]` for facts — `from_report` leaves `declared` empty,

--- a/devinfra/js/debundle/cli/gate.rs
+++ b/devinfra/js/debundle/cli/gate.rs
@@ -191,10 +191,7 @@ fn load_cycles(common: &GateCommonArgs) -> Result<Vec<BlockingSccEntry>> {
 }
 
 fn load_graph(common: &GateCommonArgs) -> Result<OwnerGraphReport> {
-    let text = std::fs::read_to_string(&common.owner_graph_path)
-        .with_context(|| format!("reading {}", common.owner_graph_path.display()))?;
-    serde_json::from_str(&text)
-        .with_context(|| format!("parsing owner graph {}", common.owner_graph_path.display()))
+    crate::load_owner_graph_report(&common.owner_graph_path)
 }
 
 fn run_list(args: GateListArgs) -> Result<()> {

--- a/devinfra/js/debundle/cli/mod.rs
+++ b/devinfra/js/debundle/cli/mod.rs
@@ -42,6 +42,16 @@ use selector_debt::{
 use spec_modules::{collect_module_files, module_path_from_file};
 use spec_stats::{SpecStats, compute_spec_stats, render_spec_stats_text};
 
+/// Read and JSON-parse an `owner_graph.json` into an [`OwnerGraphReport`],
+/// the load every `cli` verb that takes `--graph` shares.
+pub(crate) fn load_owner_graph_report(
+    path: &std::path::Path,
+) -> Result<analysis::OwnerGraphReport> {
+    let text =
+        std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    serde_json::from_str(&text).with_context(|| format!("parsing owner graph {}", path.display()))
+}
+
 #[derive(Debug, Parser)]
 #[command(
     name = "debundle",

--- a/devinfra/js/debundle/cli/scc_cluster.rs
+++ b/devinfra/js/debundle/cli/scc_cluster.rs
@@ -99,16 +99,7 @@ pub struct ClusterReport {
 }
 
 pub fn run_scc(args: SccArgs) -> Result<()> {
-    let graph: analysis::OwnerGraphReport = serde_json::from_str(
-        &std::fs::read_to_string(&args.common.owner_graph_path)
-            .with_context(|| format!("reading {}", args.common.owner_graph_path.display()))?,
-    )
-    .with_context(|| {
-        format!(
-            "parsing owner graph {}",
-            args.common.owner_graph_path.display()
-        )
-    })?;
+    let graph = crate::load_owner_graph_report(&args.common.owner_graph_path)?;
     // If a binding was supplied, find its owner -> destination module
     // first; we restrict SCCs to ones containing that destination.
     // Uses the shared `resolve_binding_owners` helper so minified and
@@ -192,10 +183,7 @@ fn render_scc_text(report: &SccReport, out: &mut String) {
 
 pub fn run_cluster(args: ClusterArgs) -> Result<()> {
     let sym = args.resolve_sym()?;
-    let graph: analysis::OwnerGraphReport = serde_json::from_str(
-        &std::fs::read_to_string(&args.common.owner_graph_path)
-            .with_context(|| format!("reading {}", args.common.owner_graph_path.display()))?,
-    )?;
+    let graph = crate::load_owner_graph_report(&args.common.owner_graph_path)?;
     // Use the shared `resolve_binding_owners` helper (same code path
     // `describe` / `show-source` / `scc --binding` use), so minified
     // and readable names both work.

--- a/devinfra/js/debundle/source_match/binding_resolution.rs
+++ b/devinfra/js/debundle/source_match/binding_resolution.rs
@@ -9,12 +9,7 @@ pub fn source_match_declared_binding_names(
         "binding_groups[].source_match",
         format!("<binding group source_match in {request_id}>"),
         &source_match.match_source,
-        || {
-            format!(
-                "logical_module {request_id}: binding_groups[].source_match did not parse as JS:\n{}",
-                source_match.match_source
-            )
-        },
+        "binding_groups[].source_match",
     )?;
     Ok(parsed
         .body
@@ -281,12 +276,7 @@ pub fn find_anonymous_statement_body_index_groups(
                 "anonymous_statements[].source_match",
                 format!("<anonymous_statement match in {request_id}>"),
                 &selector.match_source,
-                || {
-                    format!(
-                        "logical_module {request_id}: anonymous_statements[].match did not parse as JS:\n{}",
-                        selector.match_source
-                    )
-                },
+                "anonymous_statements[].match",
             )?;
             let target_indices =
                 anonymous_selector_target_statement_indices(request_id, selector, &parsed.body)?;
@@ -340,12 +330,7 @@ pub fn source_match_body_debt(
         "source_match",
         format!("<source_match debt in {request_id}>"),
         &selector.match_source,
-        || {
-            format!(
-                "logical_module {request_id}: source_match did not parse as JS:\n{}",
-                selector.match_source
-            )
-        },
+        "source_match",
     )?;
     let exact_groups = find_matching_body_group_alignments(runtime_module, &parsed.body, selector);
     let [needle] = parsed.body.as_slice() else {
@@ -538,12 +523,7 @@ pub(crate) fn resolve_member_binding_group_impl(
         "binding_groups[].source_match",
         format!("<binding group source_match in {request_id}>"),
         &selector.match_source,
-        || {
-            format!(
-                "logical_module {request_id}: binding_groups[].source_match did not parse as JS:\n{}",
-                selector.match_source
-            )
-        },
+        "binding_groups[].source_match",
     )?;
     if parsed.body.is_empty() {
         bail!(
@@ -647,9 +627,7 @@ pub(crate) fn resolve_member_binding_group_impl(
             );
         };
         let matched_body_idx = *matched_body_idx;
-        let item = runtime_module.body.get(matched_body_idx).with_context(|| {
-            format!("body index {matched_body_idx} disappeared while resolving source_match")
-        })?;
+        let item = require_body_item(runtime_module, matched_body_idx)?;
         let declared = declared_bindings(item);
         let Some(binding) = declared.get(target_binding_idx) else {
             bail!(

--- a/devinfra/js/debundle/source_match/body_search.rs
+++ b/devinfra/js/debundle/source_match/body_search.rs
@@ -1,5 +1,16 @@
 use super::*;
 
+/// Fetch the runtime-module top-level item a matcher resolved to. The
+/// index always comes from a window/alignment computed against
+/// `runtime_module.body` itself, so a miss is an internal invariant
+/// break, not a user error.
+pub(crate) fn require_body_item(runtime_module: &Module, body_idx: usize) -> Result<&ModuleItem> {
+    runtime_module
+        .body
+        .get(body_idx)
+        .with_context(|| format!("body index {body_idx} disappeared while resolving source_match"))
+}
+
 pub(crate) fn find_matching_body_indices(
     runtime_module: &Module,
     needle: &ModuleItem,

--- a/devinfra/js/debundle/source_match/parse_validate.rs
+++ b/devinfra/js/debundle/source_match/parse_validate.rs
@@ -149,10 +149,14 @@ pub(crate) fn parse_selector_module_with_capability_check(
     selector_kind: &str,
     file_label: String,
     match_source: &str,
-    parse_error_context: impl FnOnce() -> String,
+    // Field path used only in the "did not parse as JS" message; usually
+    // equals `selector_kind`, but a few callers name the narrower `.match`
+    // sub-field whose source actually failed to parse.
+    parse_label: &str,
 ) -> Result<Module> {
-    let parsed =
-        js_ast::parse_js_module_ast(&file_label, match_source).with_context(parse_error_context)?;
+    let parsed = js_ast::parse_js_module_ast(&file_label, match_source).with_context(|| {
+        format!("logical_module {request_id}: {parse_label} did not parse as JS:\n{match_source}")
+    })?;
     validate_anything_holes(&parsed.body)?;
     validate_selector_capabilities(request_id, selector_kind, match_source, &parsed)?;
     Ok(parsed)

--- a/devinfra/js/debundle/source_match/target_matching.rs
+++ b/devinfra/js/debundle/source_match/target_matching.rs
@@ -1,5 +1,39 @@
 use super::*;
 
+/// `target_binding` names a binding the selector source never declares.
+/// Shared by the statement-level, declarator-level, and single-needle
+/// target-binding location resolvers, which all reject this case identically.
+fn target_binding_not_declared(
+    request_id: &str,
+    selector: &AnonymousStatementSelector,
+    target_binding: &str,
+) -> anyhow::Error {
+    anyhow::anyhow!(
+        "logical_module {request_id}: members[].selector.source_match target_binding \
+         `{target_binding}` is not declared by the selector source:\n{match_source}",
+        match_source = selector.match_source,
+    )
+}
+
+/// `target_binding` is declared more than once in the selector source.
+/// `index_kind` names what the reported `indices` count (e.g.
+/// `"statement/binding"`, `"declared-binding"`, `"declarator/binding"`), the
+/// only detail that varies between the resolvers.
+fn target_binding_ambiguous(
+    request_id: &str,
+    selector: &AnonymousStatementSelector,
+    target_binding: &str,
+    index_kind: &str,
+    indices: impl std::fmt::Debug,
+) -> anyhow::Error {
+    anyhow::anyhow!(
+        "logical_module {request_id}: members[].selector.source_match target_binding \
+         `{target_binding}` is ambiguous within the selector source at {index_kind} \
+         indices {indices:?}. Refine the selector source:\n{match_source}",
+        match_source = selector.match_source,
+    )
+}
+
 pub(crate) fn selector_binding_location(
     needles: &[ModuleItem],
     request_id: &str,
@@ -19,18 +53,18 @@ pub(crate) fn selector_binding_location(
         .collect();
     match selector_binding_locations.as_slice() {
         [single] => Ok(*single),
-        [] => bail!(
-            "logical_module {request_id}: members[].selector.source_match target_binding \
-             `{target_binding}` is not declared by the selector source:\n{match_source}",
-            match_source = selector.match_source,
-        ),
-        multiple => bail!(
-            "logical_module {request_id}: members[].selector.source_match target_binding \
-             `{target_binding}` is ambiguous within the selector source at statement/binding \
-             indices {:?}. Refine the selector source:\n{match_source}",
+        [] => Err(target_binding_not_declared(
+            request_id,
+            selector,
+            target_binding,
+        )),
+        multiple => Err(target_binding_ambiguous(
+            request_id,
+            selector,
+            target_binding,
+            "statement/binding",
             multiple,
-            match_source = selector.match_source,
-        ),
+        )),
     }
 }
 
@@ -45,12 +79,7 @@ pub(crate) fn find_member_binding_matches(
         "members[].selector.source_match",
         format!("<member source_match in {request_id}>"),
         &selector.match_source,
-        || {
-            format!(
-                "logical_module {request_id}: members[].selector.source_match did not parse as JS:\n{}",
-                selector.match_source
-            )
-        },
+        "members[].selector.source_match",
     )?;
     if let Some(target_binding) = &selector.target_binding {
         if parsed.body.is_empty() {
@@ -101,9 +130,7 @@ pub(crate) fn find_member_binding_matches(
     }
     let mut matches = Vec::new();
     for body_idx in find_matching_body_indices(runtime_module, needle, selector, filter) {
-        let item = runtime_module.body.get(body_idx).with_context(|| {
-            format!("body index {body_idx} disappeared while resolving source_match")
-        })?;
+        let item = require_body_item(runtime_module, body_idx)?;
         let declared = declared_bindings(item);
         match declared.as_slice() {
             [single] => matches.push(MemberBindingMatch {
@@ -164,9 +191,7 @@ pub(crate) fn find_matching_target_bindings(
         find_matching_body_ranges(runtime_module, needles, selector, target_item_idx, filter)
     {
         let matched_body_idx = body_idx + target_item_idx;
-        let item = runtime_module.body.get(matched_body_idx).with_context(|| {
-            format!("body index {matched_body_idx} disappeared while resolving source_match")
-        })?;
+        let item = require_body_item(runtime_module, matched_body_idx)?;
         let declared = declared_bindings(item);
         let Some(binding) = declared.get(target_binding_idx) else {
             bail!(
@@ -293,18 +318,22 @@ pub(crate) fn find_matching_target_var_declarators(
         .collect();
     let target_binding_idx = match selector_binding_indices.as_slice() {
         [single] => *single,
-        [] => bail!(
-            "logical_module {request_id}: members[].selector.source_match target_binding \
-             `{target_binding}` is not declared by the selector source:\n{match_source}",
-            match_source = selector.match_source,
-        ),
-        multiple => bail!(
-            "logical_module {request_id}: members[].selector.source_match target_binding \
-             `{target_binding}` is ambiguous within the selector source at declared-binding \
-             indices {:?}. Refine the selector source:\n{match_source}",
-            multiple,
-            match_source = selector.match_source,
-        ),
+        [] => {
+            return Err(target_binding_not_declared(
+                request_id,
+                selector,
+                target_binding,
+            ));
+        }
+        multiple => {
+            return Err(target_binding_ambiguous(
+                request_id,
+                selector,
+                target_binding,
+                "declared-binding",
+                multiple,
+            ));
+        }
     };
     let prepared = PreparedNeedle::new(needle, selector);
     let prefilter = VarDeclaratorPrefilter::new(needle, &prepared);
@@ -551,18 +580,18 @@ pub(crate) fn selector_var_declarator_binding_location(
         .collect::<Vec<_>>();
     match selector_binding_locations.as_slice() {
         [single] => Ok(*single),
-        [] => bail!(
-            "logical_module {request_id}: members[].selector.source_match target_binding \
-             `{target_binding}` is not declared by the selector source:\n{match_source}",
-            match_source = selector.match_source,
-        ),
-        multiple => bail!(
-            "logical_module {request_id}: members[].selector.source_match target_binding \
-             `{target_binding}` is ambiguous within the selector source at declarator/binding \
-             indices {:?}. Refine the selector source:\n{match_source}",
+        [] => Err(target_binding_not_declared(
+            request_id,
+            selector,
+            target_binding,
+        )),
+        multiple => Err(target_binding_ambiguous(
+            request_id,
+            selector,
+            target_binding,
+            "declarator/binding",
             multiple,
-            match_source = selector.match_source,
-        ),
+        )),
     }
 }
 


### PR DESCRIPTION
DRYs repeated `anyhow` error-context message shapes across debundle (the
`anonymous_statement.rs`-style repetition you flagged), applied broadly.
**Behavior-preserving** — error text stays equally specific, just sourced from
shared helpers. Net-negative (9 files, +134/−117).

Shared helpers introduced:
- `parse_selector_module_with_capability_check` (`source_match/parse_validate.rs`)
  — dropped the redundant `parse_error_context` closure param (5 call sites
  rebuilt the same string from args the fn already had) for a `parse_label`.
- `require_body_item` (`source_match/body_search.rs`) — the 3 identical
  `"body index N disappeared while resolving source_match"` guards.
- `target_binding_not_declared` / `target_binding_ambiguous`
  (`source_match/target_matching.rs`) — the not-declared/ambiguous pair copied
  across 3 resolvers (index-noun parameterized).
- `read_and_parse_source` (`anonymous_resolution.rs`) — the resolve→read→parse
  trio in 3 selector-claim resolvers.
- `load_owner_graph_report` (`cli/mod.rs`) — read + JSON-parse-context shared by
  scc/cluster/gate/edit_gate (one site gains the parse context it previously
  lacked — strictly more specific).

Deliberately left alone (judged not worth collapsing, with reasons): per-command
`"writing X output"` one-liners, the `Value`/`&mut Value`-split member-index
messages, and peel's separate owner-graph loaders. The four minimizer files
(`selector_codemod`/`readoff_render`/`shape_index`/`selector_candidate_index`)
were left untouched for a parallel agent / follow-up.

All error substrings the tests assert on are reproduced exactly. Full
`//devinfra/js/debundle/...` suite **116/116 green** on RBE (rebased onto current
`devel`; re-validated).

https://claude.ai/code/session_01RYUAvJefa2eJRgZ7XBfqxA

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYUAvJefa2eJRgZ7XBfqxA)_