### PR TITLE
debundle: catalog non-minimal patterns as disabled e2e cases

### DIFF
--- a/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
+++ b/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
@@ -443,6 +443,69 @@ minimizer_expectation_case!(
     expected = "expected_match.js",
 );
 
+// Aspirational: a large lookup dictionary whose VALUES are nested objects
+// (e.g. an id -> config map) should minimize to OBJECT_PROPS holes on both
+// sides of the one entry whose nested value carries the discriminating
+// literal, and that entry's own nested object should itself collapse to the
+// discriminating property plus an OBJECT_PROPS hole. This generalizes
+// `object_keys_over_pinned` (whose entry values are scalar string literals) to
+// the common nested-object-value case. Today the minimizer keeps every entry's
+// full nested object whole, over-pinning the entire dictionary where one
+// anchored nested property would resolve uniquely. Mirrors the real spec's
+// id->config maps (feature-flag / registry dicts) kept whole across ~50+
+// nested-object entries.
+minimizer_expectation_case!(
+    #[ignore = "nested-value-dict minimizer keeps all entries' full nested objects instead of OBJECT_PROPS around one anchored nested property"]
+    minimizes_object_nested_value_dict,
+    fixture = "object_nested_value_dict",
+    name = "nested-object-value dictionary keeps only the discriminating nested property",
+    module = "app/registries",
+    bindings = [("SelectedRegistry", "selectedRegistry")],
+    expected = "expected_match.js",
+);
+
+// Aspirational: an object that carries both a short discriminating key literal
+// and a very long string / template-literal value (shared verbatim across
+// siblings, so non-discriminating) should anchor on the short unique key and
+// hole everything else with OBJECT_PROPS. Today the minimizer drags the entire
+// long literal value into the selector as part of the retained anchor, even
+// though a much shorter sibling key already discriminates uniquely; the long
+// value is the largest node so it dominates the kept shape. This produces
+// rebuild-fragile, hundreds-of-lines selectors in the real spec (tool/command
+// definitions and feature-flag tables whose `description`/`prose` template
+// literals run for hundreds of lines while a one-token `name`/`id` key would
+// have sufficed).
+minimizer_expectation_case!(
+    #[ignore = "literal-anchor minimizer retains the long template-literal value instead of anchoring on the short discriminating key"]
+    minimizes_long_literal_value_anchor,
+    fixture = "long_literal_value_anchor",
+    name = "object anchors on the short discriminating key, not the long shared literal value",
+    module = "app/definitions",
+    bindings = [("SelectedDefinition", "selectedDefinition")],
+    expected = "expected_match.js",
+);
+
+// Aspirational: a function (commonly a UI component) whose body opens with a
+// wide object-destructuring binding (`const { a, b, c, ... } = props;`) should
+// minimize to OBJECT_PROPS holes around the single destructured property that
+// discriminates this target from its siblings, plus STMT_LIST holes for the
+// rest of the body. Today the minimizer keeps the entire wide destructuring
+// pattern whole — every destructured name — even when one anchored property
+// (and one body statement) would resolve uniquely, because the destructure
+// block is a single large node it retains intact rather than holing its
+// property run. Mirrors the real spec's React components whose 10-25-name
+// `{ ... } = e` prop destructure is kept verbatim at the top of an otherwise
+// holed body.
+minimizer_expectation_case!(
+    #[ignore = "wide-destructure minimizer keeps the entire destructuring pattern instead of OBJECT_PROPS around the one discriminating property"]
+    minimizes_wide_destructure_block,
+    fixture = "wide_destructure_block",
+    name = "wide destructuring block keeps only the discriminating destructured property",
+    module = "app/components",
+    bindings = [("SelectedComponent", "selectedComponent")],
+    expected = "expected_match.js",
+);
+
 // Re-baselined for the unified keep-shallow anchor policy: both outputs keep each
 // slot's direct shallow literals including object-property values. The group's
 // shared `enabled: true` and the standalone's `kind: "panel"` / `title: "Settings"`

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/long_literal_value_anchor/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/long_literal_value_anchor/expected_match.js
@@ -1,0 +1,4 @@
+const SelectedDefinition = {
+  id: "uniqueDiscriminatorId",
+  OBJECT_PROPS,
+};

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/long_literal_value_anchor/source.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/long_literal_value_anchor/source.js
@@ -1,0 +1,49 @@
+const selectedDefinition = {
+  id: "uniqueDiscriminatorId",
+  prose: `
+This is a long block of descriptive prose attached to the definition.
+It spans many lines and repeats boilerplate that is shared verbatim with
+every sibling definition in this module, so it carries no discriminating
+power on its own. A robust selector should never anchor on this value:
+it is large, brittle to edits, and identical across siblings. The short
+sibling key "id" already uniquely identifies this definition.
+More filler. More filler. More filler. More filler. More filler.
+Yet more filler so the value is unmistakably the largest node here.
+`,
+  enabled: true,
+  rank: 3,
+};
+
+const firstSiblingDefinition = {
+  id: "alphaId",
+  prose: `
+This is a long block of descriptive prose attached to the definition.
+It spans many lines and repeats boilerplate that is shared verbatim with
+every sibling definition in this module, so it carries no discriminating
+power on its own. A robust selector should never anchor on this value:
+it is large, brittle to edits, and identical across siblings. The short
+sibling key "id" already uniquely identifies this definition.
+More filler. More filler. More filler. More filler. More filler.
+Yet more filler so the value is unmistakably the largest node here.
+`,
+  enabled: true,
+  rank: 1,
+};
+
+const secondSiblingDefinition = {
+  id: "bravoId",
+  prose: `
+This is a long block of descriptive prose attached to the definition.
+It spans many lines and repeats boilerplate that is shared verbatim with
+every sibling definition in this module, so it carries no discriminating
+power on its own. A robust selector should never anchor on this value:
+it is large, brittle to edits, and identical across siblings. The short
+sibling key "id" already uniquely identifies this definition.
+More filler. More filler. More filler. More filler. More filler.
+Yet more filler so the value is unmistakably the largest node here.
+`,
+  enabled: false,
+  rank: 2,
+};
+
+export { selectedDefinition };

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/object_nested_value_dict/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/object_nested_value_dict/expected_match.js
@@ -1,0 +1,5 @@
+const SelectedRegistry = {
+  OBJECT_PROPS,
+  4: { audience: ["uniqueDiscriminatorAudience"], OBJECT_PROPS },
+  OBJECT_PROPS,
+};

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/object_nested_value_dict/source.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/object_nested_value_dict/source.js
@@ -1,0 +1,30 @@
+const selectedRegistry = {
+  0: { audience: ["alpha"], primed: true, retry: false },
+  1: { audience: ["beta"], primed: true, retry: true },
+  2: { audience: ["alpha", "beta"], retry: true },
+  3: { audience: ["gamma"], primed: true, retry: true },
+  4: { audience: ["uniqueDiscriminatorAudience"], primed: true, retry: true },
+  5: { audience: ["alpha"], primed: false, retry: true },
+  6: { audience: ["beta"], primed: true, retry: false },
+  7: { audience: ["gamma"], primed: true, retry: true },
+};
+
+const firstSiblingRegistry = {
+  0: { audience: ["alpha"], primed: true, retry: false },
+  1: { audience: ["beta"], primed: true, retry: true },
+  2: { audience: ["alpha", "beta"], retry: true },
+  3: { audience: ["gamma"], primed: true, retry: true },
+};
+
+const secondSiblingRegistry = {
+  5: { audience: ["alpha"], primed: false, retry: true },
+  6: { audience: ["beta"], primed: true, retry: false },
+  7: { audience: ["gamma"], primed: true, retry: true },
+};
+
+const thirdSiblingRegistry = {
+  0: { audience: ["alpha"], primed: true, retry: false },
+  4: { audience: ["beta"], primed: true, retry: true },
+};
+
+export { selectedRegistry };

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/wide_destructure_block/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/wide_destructure_block/expected_match.js
@@ -1,0 +1,4 @@
+function SelectedComponent(ANYTHING) {
+  const { OBJECT_PROPS, uniqueDiscriminatorProp } = ANYTHING;
+  STMT_LIST;
+}

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/wide_destructure_block/source.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/wide_destructure_block/source.js
@@ -1,0 +1,27 @@
+function selectedComponent(props) {
+  const { alpha, bravo, charlie, delta, echo, foxtrot, golf, hotel, india, uniqueDiscriminatorProp } = props;
+  const handle = makeHandle(alpha, bravo);
+  return render(handle, uniqueDiscriminatorProp);
+}
+
+function firstSiblingComponent(props) {
+  const { alpha, bravo, charlie, delta, echo, foxtrot, golf, hotel, india } = props;
+  const handle = makeHandle(alpha, bravo);
+  return render(handle, charlie);
+}
+
+function secondSiblingComponent(props) {
+  const { alpha, bravo, charlie, delta, echo, foxtrot, golf, hotel } = props;
+  const handle = makeHandle(alpha, delta);
+  return render(handle, echo);
+}
+
+function makeHandle(a, b) {
+  return [a, b];
+}
+
+function render(handle, value) {
+  return { handle, value };
+}
+
+export { selectedComponent };


### PR DESCRIPTION
Three new **anonymized, disabled** (`#[ignore]`) expectation cases capturing
non-minimal patterns surfaced by running the current minimizer over a
representative real-spec sample (5,556 synthesized selectors across all six
subtrees). They give the next minimizer waves concrete targets. No tana data —
synthetic fixtures only; e2e test + testdata only (append-only).

New cases:
- **`object_nested_value_dict`** — id→nested-object lookup dict; aspires to
  `OBJECT_PROPS` around the one entry whose nested value carries the
  discriminator (generalizes `object_keys_over_pinned` to nested values).
- **`long_literal_value_anchor`** — object with a short discriminating `id` key +
  a long shared template literal; aspires to anchor on `id: "..."` + `OBJECT_PROPS`,
  **not** the long literal (the largest node should not dominate the kept shape
  when a short sibling key already discriminates).
- **`wide_destructure_block`** — function opening with a wide `{...} = props`
  destructure; aspires to `const { OBJECT_PROPS, <discriminator> } = ANYTHING;`
  + `STMT_LIST`.

Frequency-ranked catalog (the prioritization driver) is in the task report; the
whole-function-body pattern (rank 1) is intentionally **not** re-fixtured here —
it's owned by the in-flight sparse-function-anchor work.

Suite green (the 3 new cases compile + register, stay ignored). Rebased onto
current `devel`.

https://claude.ai/code/session_01RYUAvJefa2eJRgZ7XBfqxA

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYUAvJefa2eJRgZ7XBfqxA)_