### PR TITLE
devinfra/claude: make claude-web a standalone minimal home-manager profile

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -416,20 +416,19 @@
         };
 
         # Claude Code web session — headless standalone profile installed by
-        # web_setup.sh's home-manager mode. Portable across the web container's
-        # user (home.username/homeDirectory read from the env), so it must be
-        # built/activated with --impure:
+        # web_setup.sh's home-manager mode. Independent of the shared host
+        # structure: it only needs the devtools list and the skills args.
+        # Portable across the web container's user (home.username/homeDirectory
+        # read from the env), so it must be built/activated with --impure:
         #   home-manager switch --impure --flake .#claude-web
         claude-web = home-manager.lib.homeManagerConfiguration {
           inherit pkgs;
           modules = [
             ./nix/home/hosts/claude-web.nix
             {
-              _module.args = hmCommonArgs // {
-                enableGui = false;
-                isNixOS = false;
-                isK8sWorker = false;
+              _module.args = {
                 webDevTools = devToolPackages;
+                inherit (hmCommonArgs) sharedSkillsArgs;
               };
             }
           ];

--- a/nix/home/hosts/claude-web.nix
+++ b/nix/home/hosts/claude-web.nix
@@ -1,34 +1,39 @@
-# Claude Code web session — standalone home-manager profile.
+# Claude Code web session — standalone, minimal home-manager profile.
 #
-# Headless, non-NixOS. This is the home-manager counterpart to the
-# `nix profile install .#devtools` + manual skill-symlink path in
-# <devinfra/claude/web_setup.sh>: it installs the same devtools and deploys
-# Claude Code settings + skills through the shared home-manager skills module
-# (../skills.nix, via the ../claude_code module).
+# Deliberately independent of the shared nix/home host structure (it does NOT
+# import home.nix or the claude_code module). It contains only what
+# web_setup.sh's home-manager mode explicitly needs:
+#   - the devtools (same list the .#devtools profile install ships)
+#   - direnv + nix-direnv
+#   - skill deployment into ~/.claude/skills via the shared skills module
+#
+# The Claude Code CLI itself is provided by Anthropic in the web session, so it
+# is not installed here (and the nixpkgs build downloads the binary from
+# downloads.claude.ai, which 403s in the web container anyway).
 #
 # Portable across whatever user the web container runs as: home.username and
 # home.homeDirectory are read from the environment, so activation needs
-# --impure (same as the atlas profile):
+# --impure:
 #
 #   home-manager switch --impure --flake .#claude-web
 {
   pkgs,
-  lib,
   webDevTools,
+  sharedSkillsArgs,
   ...
 }:
 let
   envUser = builtins.getEnv "USER";
   envHome = builtins.getEnv "HOME";
+  user = if envUser != "" then envUser else "user";
+
+  # The reason this profile exists: deploy skills to ~/.claude/skills via the
+  # shared home-manager skills module.
+  mkSkills = import ../skills.nix sharedSkillsArgs;
 in
 {
-  imports = [
-    ../claude_code
-  ];
-
-  home.username = if envUser != "" then envUser else "user";
-  home.homeDirectory =
-    if envHome != "" then envHome else "/home/${if envUser != "" then envUser else "user"}";
+  home.username = user;
+  home.homeDirectory = if envHome != "" then envHome else "/home/${user}";
   home.stateVersion = "25.11";
 
   programs.home-manager.enable = true;
@@ -54,4 +59,6 @@ in
   # bbr, bbapi, gh, sops, kubectl, …). Reuses the flake's devToolPackages list
   # so the two install paths can never drift.
   home.packages = webDevTools;
+
+  home.file = mkSkills { prefix = ".claude"; };
 }


### PR DESCRIPTION
## Summary

Follow-up to the home-manager web-setup mode (#2266, #2267). Reworks the
`claude-web` profile to be **standalone and minimal** instead of inheriting the
shared `nix/home` host structure.

`claude-web.nix` previously imported the `claude_code` module, which dragged in
a lot of incidental config (settings.json, plugins, MCP servers, permissions,
sandbox config) plus the `claude-code` package — whose nixpkgs build downloads
the binary from `downloads.claude.ai`, which **403s inside the web container**.
That forced `package = null` / `mcpServers = {}` workarounds.

## Change

`claude-web.nix` no longer imports `home.nix` or the `claude_code` module. It
contains only what `web_setup.sh`'s home-manager mode explicitly needs:

- the devtools (the flake's `devToolPackages` list — same as `.#devtools`)
- direnv + nix-direnv (bash hook)
- skill deployment to `~/.claude/skills` via the shared `nix/home/skills.nix`
  module

The Claude Code CLI itself is **not** installed — the web session already
provides Anthropic's `claude` on `PATH`. The flake's `claude-web` definition now
passes only `webDevTools` + `sharedSkillsArgs` instead of the full
`hmCommonArgs`.

## Testing

Built `.#homeConfigurations.claude-web.activationPackage` in a Claude web session
(the environment that previously failed):

- ✅ builds clean — no `claude.drv`, no 403
- ✅ 35 skills deployed to `~/.claude/skills/`
- ✅ no `settings.json` (minimal profile)
- ✅ no `claude` binary in the HM profile
- ✅ devtools (`claude-hook`, `bbr`, `gh`, `sops`) + direnv hook in `.bashrc` present

https://claude.ai/code/session_016tod3jXhBc9zprUytqcwt7