### PR TITLE
debundle: trim completed/double-tracked items from TODO + automated_spec_workflows

### DIFF
--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -53,72 +53,40 @@ propose`.
 
 ### P0 — automation-first selector workflows
 
-1. **Forward-compatible minimized selector synthesis.** Implement the core
-   operation "given this binding, group, anonymous statement, or statement
-   range, emit the loosest readable selector that uniquely selects it." The
-   generated spec must both work for today's chunk and be likely to survive
-   future minified-bundle drift. Start from exact source slices, relax with
-   holes, prefer `ANYTHING` / `EXPR` / `OBJECT_PROPS` / `DECLARATORS` /
-   `CLASS_REST` / `ARGS` / `STMT_LIST` over long incidental code bodies, use
-   source indexes to count candidates cheaply, and verify the final selector
-   through the real resolver. Model this as a best-first or branch-and-bound
-   search over an AST-feature constraint lattice, not as string rewriting in a
-   fixed direction: exact source is a known-working upper bound, the loose hole
-   selector is a lower bound, and candidate selectors are subsets or
-   generalizations of target AST constraints. Maintain candidate match sets
-   with indexed bitsets, add or remove constraints by set operations, and avoid
-   full-matcher trial loops over every removable subtree. Binding groups should
-   use the same approach over `(declaration/range, target-slot mapping)` match
-   sets and should choose group vs repeated selectors by total selector cost.
-   The first indexed slice covers exact
-   function/class declaration recovery and multi-declarator `var`/`let`/
-   `const` groups selected from name-only members, with `DECLARATORS_*` gap
-   holes and uniqueness proof. Grow that into the general primitive for
-   new-spec bootstrap, old-spec stabilization, and version-port repair.
-2. **Shared source inventory/index.** Extract a reusable per-chunk index for
-   top-level statement identity, binding identity, stable literals/keys,
-   canonical fingerprints, source slices, and candidate-count queries. Use it
-   from `selector-debt`, `selector-codemod`, repair diagnostics, and future
-   port tooling rather than adding more per-command AST walks.
-3. **Patch-plan based bulk codemods.** Extend `debundle spec selector-codemod`
+1. **Forward-compatible minimized selector synthesis + shared source index.**
+   Owned by <plans/readoff_minimization.md>: the read-off AST-shape index
+   (`shape_index.rs`, superseting `selector_candidate_index.rs`),
+   function/object read-off, literal/regex anchors, and hole-based minimization
+   have landed; class/var/group migration, co-occurrence grouping, the
+   prove-gate perf fix, cover-search deletion, and whole-spec validation are in
+   that plan's backlog. Don't duplicate its design or status here.
+2. **Patch-plan based bulk codemods.** Extend `debundle spec selector-codemod`
    or add adjacent verbs so every broad rewrite can emit a dry-run patch plan,
-   preserve YAML comments where possible, apply with filters, and explain every
-   skipped candidate. High-value rewrite classes:
-   - make generated `name-only-source-match` selectors minimized when produced,
-     not only by later cleanup: replace unnecessary expression arguments,
-     object properties, class members, and statement ranges with `ANYTHING`,
-     typed holes, `OBJECT_PROPS`, `CLASS_REST`, or `STMT_LIST` while preserving
-     uniqueness;
-   - convert repeated member-form selectors over the same declaration context
-     into one `binding_groups` entry, including cases that do not start from
-     name-only inputs;
-   - merge multiple eligible generated selectors from the same declaration into
-     one `binding_groups` entry;
-   - convert unique literal-initializer bindings into structural selectors when
-     the source value is stable enough;
-   - source-aware reports or apply-safe rewrites for overpinned object literals
-     that can now use `ANYTHING` / `OBJECT_PROPS` around stable keys;
-   - grow selector synthesis from the declaration/binding index into a
-     trie/lattice of stable AST atoms: declaration kind, wrapper shape,
-     initializer kind, callee/member paths, object keys, literals, JSX tags,
-     class/function names, arity, and statement/declarator slots.
-4. **Selector diagnostics as machine-readable reports.** Emit a keep-going
+   apply with filters, and explain every skipped candidate. (Selector
+   minimization at synthesis time, unique-literal-initializer → structural
+   selectors, and over-pinned-object `OBJECT_PROPS` rewrites are done via the
+   read-off path; converting repeated member-form selectors into
+   `binding_groups` is the co-occurrence-grouping item in the read-off backlog.
+   The open work here is the dry-run / patch-plan / explain-every-skip
+   infrastructure that the rewrite classes pipe through.)
+3. **Selector diagnostics as machine-readable reports.** Emit a keep-going
    JSON report for unresolved selectors, ambiguous selectors, duplicate claims,
    and blocker comments. Include module path, export name, selector kind,
    target binding, first mismatch, nearest candidates, and recommended next
    action. This lets coordinators batch failures instead of scraping logs.
-5. **Spec repair from diagnostics.** Add a workflow that consumes the keep-going
+4. **Spec repair from diagnostics.** Add a workflow that consumes the keep-going
    report, proposes mechanically proven patch plans for no-match, ambiguous,
    duplicate-claim, and unsupported-selector cases, and leaves residual semantic
    decisions as explicit tasks.
-6. **Orthogonal CLI surface.** Converge new automation on the
+5. **Orthogonal CLI surface.** Converge new automation on the
    inventory/plan/apply/validate/explain model in
    <plans/automated_spec_workflows.md>. Avoid one-off command shapes that cannot
    pipe a dry-run plan into review, apply, validation, and repair.
-7. **Workflow latency budget.** Keep P0 reports and dry-run patch planners
-   fast enough for iterative agent use: parse/index each chunk once, stream
-   NDJSON as work is found, emit per-phase timings, and treat >60s runs as
-   urgent perf bugs unless they are deliberately offline.
+6. **Workflow latency budget.** Interactive commands target <10s on warmed
+   inputs; >60s is a blocker unless explicitly an offline/profile mode with
+   progress output and a resumable plan. The whole-spec minimize budget and the
+   measured real-chunk numbers live in <plans/readoff_minimization.md> (W4) and
+   <debug/selector_minimizer_dogfood.md>.
 
 ### P1 — broad workflow integration
 

--- a/devinfra/js/debundle/plans/automated_spec_workflows.md
+++ b/devinfra/js/debundle/plans/automated_spec_workflows.md
@@ -125,66 +125,24 @@ context window that distinguishes otherwise ambiguous candidates.
 
 ### Minimizer
 
-"Produce the loosest readable selector that uniquely selects this entity" should
-be a first-class operation. "Simplest" does not mean merely shortest, and it
-does not mean exact current-source reproduction; it means the lowest-cost
-selector that is expected to survive unrelated source drift while still
-matching only the target today. For a target binding, group, or anonymous
-statement, model minimization as a search over an AST-feature constraint
-lattice:
+"Produce the loosest readable selector that uniquely selects this entity" is a
+first-class operation. Its design and implementation now live in
+<readoff_minimization.md> (the read-off AST-shape index + a greedy set-cover over
+a `selective × stable` feature ranking, with the production matcher as the
+prove-gate); this section defers to that plan rather than restating the algorithm
+and drifting.
 
-1. Use exact source as the target AST and a known-working upper bound. Use the
-   loosest syntactically valid hole selector for the target kind as the lower
-   bound. The implementation may traverse from either side, but it should
-   reason about candidate selectors as constraint sets between those bounds.
-2. Index stable target features once per chunk. Features should include
-   declaration kind, arity, declarator slot, literal/key/operator/callee/member
-   shape, class member names, object-property keys, statement-kind sequence,
-   and small context-window anchors.
-3. Represent each feature or partial selector by its denotation: an efficient
-   bitset of candidate statements, declarations, declarators, ranges, or slot
-   mappings from the source inventory.
-4. Search for the lowest-cost selector whose denotation is unique. Adding a
-   constraint is set intersection; removing a constraint or replacing a subtree
-   with a hole is generalization. A best-first or branch-and-bound search can
-   use denotation size and remaining differentiating features as pruning
-   evidence.
-5. Use a cost model that prefers low-cost stable anchors that cut the candidate
-   set sharply, and assigns high cost to long exact function bodies, object
-   values, class bodies, anonymous statement runs, and nested expressions.
-6. Verify final candidates through the real selector resolver and emit the
-   lowest-cost unique selector plus structured rejected alternatives when useful
-   for diagnostics.
-
-Avoid an algorithm shaped like "try every subtree deletion and run the full
-matcher each time"; on large chunks that is roughly
-`O(selector_nodes * candidate_statements * matcher_cost)` per selector. The
-target shape is closer to `O(chunk_ast_size + feature_count + search_frontier *
-bitset_cost + proof_matcher_cost)` after the inventory is built, with the full
-matcher used as a verifier rather than the inner loop.
-
-Binding groups need the same treatment, but their candidate universe is
-declaration/range plus slot mapping rather than one statement. The inventory
-should index each top-level declaration or statement range with ordered
-bindings/declarators and stable range features. A group minimizer should
-maintain a bitset of possible `(declaration_or_range_id, target_slot_mapping)`
-tuples. Shared declaration constraints and per-target slot constraints are
-ordinary features in the same lattice. The cost model should compare one
-`binding_groups` selector against repeated member selectors: prefer the group
-when shared stable context makes it cheaper and more forward-compatible, but
-split the group if one huge selector would need long exact bodies or volatile
-initializers to be unique.
-
-Over-narrow selectors should be reported as debt even if they currently match.
-Examples include long function bodies where the signature plus a stable literal
-or call shape would suffice, object literals where only a few stable keys are
-needed, generated class bodies where `CLASS_REST` preserves the useful member
-shape, and anonymous statement blocks where `STMT_LIST` can ignore unrelated
-setup or cleanup statements.
-
-The minimizer should be deterministic. Greedy relaxation is acceptable for the
-first implementation when each accepted relaxation is revalidated, but the
-interfaces should allow a later branch-and-bound or trie-backed search.
+The product-vision intent this doc still owns: "simplest" means
+lowest-cost-forward-compatible, not shortest or exact-source — prefer low-cost
+stable anchors that cut the candidate set sharply, assign high cost to long exact
+function/object/class bodies, statement runs, and nested expressions, and
+**report over-narrow selectors as debt even when they currently match** (long
+function bodies where a signature + stable literal would suffice; object literals
+where a few stable keys suffice; class bodies where `CLASS_REST` keeps the useful
+member; anonymous blocks where `STMT_LIST` ignores setup/cleanup). Binding groups
+use the same cost model, comparing one `binding_groups` selector against repeated
+member selectors and splitting when one huge selector would need long exact
+bodies or volatile initializers to be unique.
 
 ### Patch Plans
 


### PR DESCRIPTION
Removes completed / double-tracked items from the debundle trackers (your "no
completed items in to-do lists" + don't-double-track principles). Docs-only.

**`TODO.md` P0 queue:**
- Merge the "forward-compatible minimized selector synthesis" + "shared source
  inventory/index" items into a single **pointer** to `plans/readoff_minimization.md`
  — both are built/owned there (`shape_index.rs` + `selector_candidate_index.rs`,
  function/object read-off, literal/regex anchors, hole minimization), with the
  remaining work (class/var/group migration, grouping, prove-gate perf,
  cover-deletion, whole-spec validation) in that plan's backlog.
- Drop the **done** sub-bullets from the patch-plan item (minimize-at-synthesis;
  unique-literal-initializer → structural — that was the just-deleted
  `literal_initializer_selector.md`; over-pinned-object `OBJECT_PROPS`); keep the
  open dry-run/patch-plan/explain infrastructure.
- Collapse the "workflow latency budget" item to a pointer (the read-off W4 item
  + `dogfood.md` own the real numbers). Renumbered 1–7 → 1–6.

**`plans/automated_spec_workflows.md`:** trim the "Minimizer" algorithm section
(duplicated the read-off plan) to a pointer, keeping the product-vision cost-model
+ over-pin-debt intent it still owns. (Its Milestones section already points at
the plan.)

Left untouched: the genuinely-open P0 #3–#5 / P1 / P2 items and the area sections
(diagnostics, repair, version-port, materialization, rename pipeline, corpus) —
real open work, not completed items.

https://claude.ai/code/session_01RYUAvJefa2eJRgZ7XBfqxA

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYUAvJefa2eJRgZ7XBfqxA)_