### PR TITLE
debundle: verify ANYTHING-vs-keyword redundancy (fix plan's ARGS claim) + proof tests

### DIFF
--- a/devinfra/js/debundle/e2e/syntactic_holes_test.rs
+++ b/devinfra/js/debundle/e2e/syntactic_holes_test.rs
@@ -2307,3 +2307,360 @@ export { actual };
         object_gap.stderr
     );
 }
+
+// ---------------------------------------------------------------------------
+// `ANYTHING`-vs-keyword redundancy proofs (de-risk "language simplification")
+//
+// `ANYTHING` is a *run-absorbing* list hole ONLY in the positions where the
+// matcher's list-hole detector predicate carries an `ANYTHING` fallback:
+// `OBJECT_PROPS` (`object_property_list_hole_name`), `DECLARATORS`
+// (`declarator_list_hole_name`), and `CLASS_REST` (`is_class_rest_hole`). In a
+// call/`new` argument position (`argument_list_hole_name` has no `ANYTHING`
+// fallback) and a block-statement position (`statement_list_hole_name` has no
+// `ANYTHING` fallback), a bare `ANYTHING` is a *single-node* hole — `EXPR`
+// resp. `STMT` — so it is NOT interchangeable with `ARGS` / `STMT_LIST`. A
+// `case CASE_REST:` clause has no `ANYTHING` spelling at all.
+//
+// The matched pairs below pin each claim against a representative subject.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn args_run_absorber_is_not_redundant_with_anything_single_arg() {
+    // Subject call has two arguments. `joinParts(ARGS)` absorbs the run and
+    // matches; `joinParts(ANYTHING)` is a single-expression hole, so it
+    // requires arity 1 and does NOT match a 2-argument call.
+    let subject = r#"function joinParts(...parts) {
+  return parts.join("|");
+}
+const actual = joinParts("alpha", "beta");
+console.log(actual);
+export { actual };
+"#;
+
+    // ARGS: run-absorber matches the two-arg call.
+    let with_args = run_fixture(FixtureOpts::new(
+        subject,
+        vec![logical_module(
+            "joined",
+            &[Member::source_alpha(
+                "joinedValue",
+                r#"const selectedValue = joinParts(ARGS);"#,
+            )],
+        )],
+    ));
+    assert_entry_output(&with_args, "alpha|beta\n");
+    assert_module_exports(
+        &with_args.out_root,
+        "static/app/modules/joined.js",
+        &["joinedValue"],
+        &["actual"],
+    );
+
+    // ANYTHING in the same position is a single EXPR: arity 1 != 2, no match.
+    expect_rejection_containing_all(
+        FixtureOpts::new(
+            subject,
+            vec![logical_module(
+                "joined",
+                &[Member::source_alpha(
+                    "joinedValue",
+                    r#"const selectedValue = joinParts(ANYTHING);"#,
+                )],
+            )],
+        ),
+        &[
+            "static/app::joined",
+            "did not match any top-level declaration",
+        ],
+    );
+}
+
+#[test]
+fn args_and_anything_agree_on_a_single_argument_call() {
+    // Companion to the inequivalence proof: when the subject call has exactly
+    // one argument, `ARGS` and `ANYTHING` are observationally identical (both
+    // match). The divergence is purely about run-vs-single arity, not about
+    // what a single argument matches.
+    let subject = r#"function wrap(value) {
+  return `[${value}]`;
+}
+const actual = wrap("solo");
+console.log(actual);
+export { actual };
+"#;
+
+    for selector in [
+        r#"const selectedValue = wrap(ARGS);"#,
+        r#"const selectedValue = wrap(ANYTHING);"#,
+    ] {
+        let fixture = run_fixture(FixtureOpts::new(
+            subject,
+            vec![logical_module(
+                "wrapped",
+                &[Member::source_alpha("wrappedValue", selector)],
+            )],
+        ));
+        assert_entry_output(&fixture, "[solo]\n");
+        assert_module_exports(
+            &fixture.out_root,
+            "static/app/modules/wrapped.js",
+            &["wrappedValue"],
+            &["actual"],
+        );
+    }
+}
+
+#[test]
+fn stmt_list_run_absorber_is_not_redundant_with_anything_single_stmt() {
+    // The `if` block has three statements. `{ STMT_LIST; }` absorbs the run
+    // and matches; `{ ANYTHING; }` is a single-statement hole (arity 1 != 3)
+    // and does NOT match.
+    let subject = r#"if (true) {
+  console.log("a");
+  console.log("b");
+  console.log("c");
+}
+const marker = "ready";
+export { marker };
+"#;
+
+    // STMT_LIST: run-absorber matches the three-statement block.
+    let with_stmt_list = run_fixture(FixtureOpts::new(
+        subject,
+        vec![logical_module_with_anon_alpha(
+            "init",
+            &[Member::new("marker")],
+            r#"if (true) {
+  STMT_LIST;
+}"#,
+        )],
+    ));
+    assert_entry_output(&with_stmt_list, "a\nb\nc\n");
+
+    // ANYTHING as a block statement is a single STMT: arity 1 != 3, no match.
+    expect_rejection_containing_all(
+        FixtureOpts::new(
+            subject,
+            vec![logical_module_with_anon_alpha(
+                "init",
+                &[Member::new("marker")],
+                r#"if (true) {
+  ANYTHING;
+}"#,
+            )],
+        ),
+        &["static/app::init", "did not match"],
+    );
+}
+
+#[test]
+fn stmt_and_anything_agree_on_a_single_statement_block() {
+    // Companion: a single-statement block is matched identically by a bare
+    // `STMT` and a bare `ANYTHING` (both single-node holes). So in the
+    // statement position `ANYTHING` is redundant with `STMT`, NOT `STMT_LIST`.
+    let subject = r#"if (true) {
+  console.log("only");
+}
+const marker = "ready";
+export { marker };
+"#;
+
+    for body in ["STMT;", "ANYTHING;"] {
+        let fixture = run_fixture(FixtureOpts::new(
+            subject,
+            vec![logical_module_with_anon_alpha(
+                "init",
+                &[Member::new("marker")],
+                &format!("if (true) {{\n  {body}\n}}"),
+            )],
+        ));
+        assert_entry_output(&fixture, "only\n");
+    }
+}
+
+#[test]
+fn case_rest_is_not_expressible_via_anything() {
+    // `case CASE_REST:` absorbs surrounding `case`/`default` clauses. There is
+    // no `ANYTHING` spelling for a switch-case-list hole: `is_case_rest_hole`
+    // matches only the literal `CASE_REST` test identifier. A bare `ANYTHING`
+    // statement is not a `case` clause, so attempting to use it to skip cases
+    // cannot parse into the case-list-hole shape — the keyword stays load-
+    // bearing. Here the `CASE_REST` form matches the multi-case switch.
+    let subject = r#"function dispatch(kind) {
+  switch (kind) {
+    case "alpha":
+      return 1;
+    case "go":
+      return 42;
+    default:
+      return 0;
+  }
+}
+console.log(dispatch("go"));
+export { dispatch };
+"#;
+
+    let with_case_rest = run_fixture(FixtureOpts::new(
+        subject,
+        vec![logical_module(
+            "router",
+            &[Member::source_alpha(
+                "dispatch",
+                r#"function readable(ANYTHING) {
+  switch (ANYTHING) {
+    case CASE_REST:
+    case "go":
+      STMT_LIST_GO;
+    case CASE_REST:
+  }
+}"#,
+            )],
+        )],
+    ));
+    assert_entry_output(&with_case_rest, "42\n");
+    assert_module_exports(
+        &with_case_rest.out_root,
+        "static/app/modules/router.js",
+        &["dispatch"],
+        &[],
+    );
+}
+
+#[test]
+fn object_props_and_anything_are_interchangeable_run_absorbers() {
+    // Positive redundancy proof: `OBJECT_PROPS_*` and `ANYTHING` shorthand are
+    // both run-absorbing property-list holes
+    // (`object_property_list_hole_name` carries the `ANYTHING` fallback), so
+    // they match the same object against the same gap.
+    let subject = r#"const actual = {
+  stable: 1,
+  generatedA: 2,
+  generatedB: 3,
+  tail: 4,
+};
+console.log(actual.stable + actual.tail);
+export { actual };
+"#;
+
+    for selector in [
+        r#"const readable = { stable: EXPR, OBJECT_PROPS_MID, tail: EXPR };"#,
+        r#"const readable = { stable: ANYTHING, ANYTHING, tail: ANYTHING };"#,
+    ] {
+        let fixture = run_fixture(FixtureOpts::new(
+            subject,
+            vec![logical_module(
+                "config",
+                &[Member::source_alpha_target(
+                    "config_object",
+                    "readable",
+                    selector,
+                )],
+            )],
+        ));
+        assert_entry_output(&fixture, "5\n");
+        assert_module_exports(
+            &fixture.out_root,
+            "static/app/modules/config.js",
+            &["config_object"],
+            &["actual"],
+        );
+    }
+}
+
+#[test]
+fn declarators_and_anything_are_interchangeable_run_absorbers() {
+    // Positive redundancy proof: `DECLARATORS_*` and `ANYTHING` declarator
+    // names are both run-absorbing declarator-list holes
+    // (`declarator_list_hole_name` carries the `ANYTHING` fallback), bracketing
+    // the same pinned declarator in the same wider `const` list.
+    let subject = r#"const runtimePrefix = "prefix",
+  runtimeTarget = makeTarget("value"),
+  runtimeSuffix = "suffix";
+function makeTarget(value) {
+  return `target:${value}`;
+}
+console.log(runtimePrefix, runtimeTarget, runtimeSuffix);
+export { runtimePrefix, runtimeTarget, runtimeSuffix, makeTarget };
+"#;
+
+    for selector in [
+        r#"const DECLARATORS_BEFORE = null,
+  Target = makeTarget("value"),
+  DECLARATORS_AFTER = null;"#,
+        r#"const ANYTHING = null,
+  Target = makeTarget("value"),
+  ANYTHING = null;"#,
+    ] {
+        let fixture = run_fixture(FixtureOpts::new(
+            subject,
+            vec![logical_module(
+                "target",
+                &[Member::source_exact_target(
+                    "SelectedTarget",
+                    "Target",
+                    selector,
+                )],
+            )],
+        ));
+        assert_entry_output(&fixture, "prefix target:value suffix\n");
+        assert_module_exports(
+            &fixture.out_root,
+            "static/app/modules/target.js",
+            &["SelectedTarget"],
+            &["runtimeTarget"],
+        );
+    }
+}
+
+#[test]
+fn class_rest_and_anything_are_interchangeable_run_absorbers() {
+    // Positive redundancy proof: `CLASS_REST;` and a no-init `ANYTHING;` class
+    // field are both run-absorbing class-member-list holes (`is_class_rest_hole`
+    // matches either keyword), bracketing the same pinned method.
+    let subject = r#"class Widget {
+  setup() {
+    return 0;
+  }
+  open() {
+    return 7;
+  }
+  close() {
+    return 3;
+  }
+}
+console.log(new Widget().open());
+export { Widget };
+"#;
+
+    for selector in [
+        r#"class K {
+  CLASS_REST;
+  open() {
+    STMT_LIST_O;
+  }
+  CLASS_REST;
+}"#,
+        r#"class K {
+  ANYTHING;
+  open() {
+    ANYTHING;
+  }
+  ANYTHING;
+}"#,
+    ] {
+        let fixture = run_fixture(FixtureOpts::new(
+            subject,
+            vec![logical_module(
+                "shapes",
+                &[Member::source_alpha("Widget", selector)],
+            )],
+        ));
+        assert_entry_output(&fixture, "7\n");
+        assert_module_exports(
+            &fixture.out_root,
+            "static/app/modules/shapes.js",
+            &["Widget"],
+            &[],
+        );
+    }
+}

--- a/devinfra/js/debundle/plans/readoff_minimization.md
+++ b/devinfra/js/debundle/plans/readoff_minimization.md
@@ -259,24 +259,91 @@ Lower priority / opportunistic:
 
 ## Language simplification: prefer `ANYTHING` where the context is unambiguous
 
-`ANYTHING` is already parse-position-polymorphic (see `source_match_holes.rs`):
-in an expression position it behaves like `EXPR`, as a bare expression statement
-like `STMT`, as a declarator name like `DECLARATORS`, as an object shorthand it
-absorbs `OBJECT_PROPS`, as an init-less class field like `CLASS_REST`, etc. So in
-any position where **only one kind of placeholder is syntactically legal**, the
-specific keyword (`OBJECT_PROPS`, `DECLARATORS`, `CLASS_REST`, `ARGS`, ...) is
-redundant with `ANYTHING`. Reducing to one placeholder where unambiguous cuts
-language surface and reader ambiguity.
+`ANYTHING` is parse-position-polymorphic (see `source_match_holes.rs`), but its
+behavior is **not** uniformly "the list hole legal here". Verified against the
+matcher (`source_match/matcher.rs`, `source_match/holes.rs`,
+`source_match/wildcard_idents.rs`), the decisive fact is:
 
-Do this **after** minimizer emission stabilizes (after migration + cover deletion),
-since it rewrites emitted selectors and touches many fixtures:
+> **`ANYTHING` is a run-absorbing list hole only in the positions where the
+> list-hole detector predicate carries an explicit `ANYTHING` fallback.** In
+> every other position a bare `ANYTHING` collapses to a _single-node_ hole
+> (`EXPR` / `STMT`) — or is not expressible at all.
 
-- **Emit `ANYTHING`** from the minimizer/renderer in unambiguous positions instead
-  of the specific list hole; keep the specific keyword only where the position
-  genuinely admits more than one placeholder kind (document which).
-- The matcher already accepts `ANYTHING` in those positions, so this is an
-  emission + fixture change, not a matcher change. Confirm equivalence through
-  swc; the prove-gate is unchanged.
+The detector predicates and their `ANYTHING` handling:
+
+| Position            | Detector (in `holes.rs`)         | `ANYTHING` fallback?      | Slice router (`matcher.rs`)                 |
+| ------------------- | -------------------------------- | ------------------------- | ------------------------------------------- |
+| object property     | `object_property_list_hole_name` | **yes** (`.or_else`)      | `match_prop_or_spread_slice`                |
+| variable declarator | `declarator_list_hole_name`      | **yes** (`.or_else`)      | `match_var_declarator_slice_with_alignment` |
+| class member        | `is_class_rest_hole`             | **yes** (`\|\| ANYTHING`) | `match_class_member_slice`                  |
+| call/`new` argument | `argument_list_hole_name`        | **no**                    | `match_expr_or_spread_slice`                |
+| block statement     | `statement_list_hole_name`       | **no**                    | `match_stmt_slice`                          |
+| `switch` case       | `is_case_rest_hole`              | **no**                    | `match_switch_case_slice`                   |
+
+Why the single-node collapse happens for `ARGS`/`STMT_LIST`: the collector
+(`WildcardIdentCollector`) visits a bare `ANYTHING` argument via
+`visit_expr_or_spread`, finds no `argument_list_hole_name` match, recurses into
+the child expression, and registers it as an **expression** hole; likewise a bare
+`ANYTHING` expression-statement is registered as a **statement** hole (the
+`hole_name == ANYTHING` branch in `visit_stmt`, which is reached only _after_
+the `STMT_LIST` check fails). A single-node hole then routes through the
+length-exact `match_slice` path (arity must equal), never the
+ordered-subsequence `match_list_with_holes` path. `case CASE_REST:` has no
+`ANYTHING` spelling at all (`is_case_rest_hole` matches only the literal
+`CASE_REST` test ident; a bare `ANYTHING` statement is not a `case` clause).
+
+### Per-keyword redundancy table
+
+| Keyword        | Redundant with bare `ANYTHING`? | Unambiguous position               | Equivalence / inequivalence (evidence)                                                                                                                                                                                                              |
+| -------------- | ------------------------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `EXPR`         | **yes** (bare/anon form)        | any expression position            | `ANYTHING` ≡ `EXPR`; both anonymous single-expr (`bind_expr`). Tests: `member_source_match_anything_matches_expression_subtrees`, `single_node_hole_keeps_later_identifiers_aligned`. Named `EXPR_x` (cross-occurrence binding) is NOT replaceable. |
+| `STMT`         | **yes** (bare/anon form)        | bare expression-statement position | `ANYTHING;` ≡ `STMT;`; both anonymous single-stmt (`bind_stmt`). Test: `stmt_and_anything_agree_on_a_single_statement_block`. Named `STMT_x` is NOT replaceable.                                                                                    |
+| `OBJECT_PROPS` | **yes**                         | object-literal shorthand property  | run-absorber; `object_property_list_hole_name` has `ANYTHING` fallback. Test: `object_props_and_anything_are_interchangeable_run_absorbers` (+ existing `member_source_match_anything_object_property_hole_skips_arbitrary_key_values`).            |
+| `DECLARATORS`  | **yes**                         | variable declarator name           | run-absorber; `declarator_list_hole_name` has `ANYTHING` fallback. Test: `declarators_and_anything_are_interchangeable_run_absorbers` (+ existing `member_source_match_anything_declarator_*`).                                                     |
+| `CLASS_REST`   | **yes**                         | no-init class field                | run-absorber; `is_class_rest_hole` matches `CLASS_REST` or `ANYTHING`. Test: `class_rest_and_anything_are_interchangeable_run_absorbers` (+ existing `member_source_match_anything_class_member_*`).                                                |
+| `ARGS`         | **NO**                          | call/`new` argument                | `ANYTHING` arg = single `EXPR` (arity-exact), NOT a run-absorber. Diverges on arity ≠ 1. Tests: `args_run_absorber_is_not_redundant_with_anything_single_arg` (diverge), `args_and_anything_agree_on_a_single_argument_call` (agree at arity 1).    |
+| `STMT_LIST`    | **NO**                          | block statement                    | `ANYTHING;` stmt = single `STMT` (arity-exact), NOT a run-absorber. Diverges on length ≠ 1. Tests: `stmt_list_run_absorber_is_not_redundant_with_anything_single_stmt` (diverge), `stmt_and_anything_agree_on_a_single_statement_block` (agree).    |
+| `CASE_REST`    | **NO**                          | empty `switch` case clause         | No `ANYTHING` spelling exists for a case-list hole; the marker is a `case` clause, not an identifier expression. Test: `case_rest_is_not_expressible_via_anything`.                                                                                 |
+
+### Emission rule (the deferred change)
+
+Mechanical and unambiguous given the table — for the minimizer/renderer
+(`selector_codemod.rs` / `readoff_render.rs`), in position **P**:
+
+- **OBJECT_PROPS / DECLARATORS / CLASS_REST**: an _anonymous_ (unsuffixed) hole
+  in P may be emitted as `ANYTHING` instead of the keyword. A **named** list
+  hole (`OBJECT_PROPS_MID`, `DECLARATORS_AFTER`) carries a readability label and
+  is not equality-binding, so substituting `ANYTHING` is still semantically
+  safe but loses the label — keep the keyword when a suffix is present, or
+  accept the label loss as a deliberate readability tradeoff (decide at
+  emission time; the matcher accepts both).
+- **EXPR / STMT**: an _anonymous_ hole may be emitted as `ANYTHING`. A **named**
+  hole (`EXPR_LEFT`, `STMT_SETUP`) binds for cross-occurrence equality and is
+  **not** replaceable — `ANYTHING` is always anonymous (see `bind_expr` /
+  `bind_stmt`).
+- **ARGS / STMT_LIST / CASE_REST**: **never** emit `ANYTHING` in these
+  positions. `ARGS`/`STMT_LIST` would silently change a run-absorber into an
+  arity-exact single-node hole (a correctness regression), and `CASE_REST` has
+  no `ANYTHING` form. These keywords stay load-bearing.
+
+Do this **after** minimizer emission stabilizes (after migration + cover
+deletion), since it rewrites emitted selectors and touches many fixtures:
+
+- The matcher already accepts `ANYTHING` in the redundant positions, so this is
+  an emission + fixture change, not a matcher change. Confirm equivalence
+  through swc; the prove-gate is unchanged.
 - Decide per keyword whether to deprecate/remove it once fully subsumed (affects
   existing specs — needs a sweep) or keep it as accepted-but-not-emitted sugar.
-  Default: keep accepting, stop emitting; revisit removal separately.
+  `ARGS`, `STMT_LIST`, and `CASE_REST` are NOT subsumable and must be kept.
+  Default for the rest: keep accepting, stop emitting; revisit removal
+  separately.
+
+### Matcher gap note
+
+No matcher change is needed or proposed. The asymmetry (list-hole fallback for
+`OBJECT_PROPS`/`DECLARATORS`/`CLASS_REST` but not `ARGS`/`STMT_LIST`/`CASE_REST`)
+is the _reason_ `ARGS`/`STMT_LIST`/`CASE_REST` are not droppable, not a bug to
+fix: making `ANYTHING` a run-absorber in argument/statement position would make
+it impossible to write a single-node `EXPR`/`STMT` hole anonymously there, since
+both spell as a lone `ANYTHING`. The two keyword families intentionally cover
+different cardinalities.


### PR DESCRIPTION
De-risks the language-simplification (`ANYTHING`) work by verifying — against the
matcher code, not doc comments — exactly which hole keywords a bare `ANYTHING`
can replace. **Found and fixed a real bug in the plan**: it previously claimed
`ARGS` was redundant with `ANYTHING`; it is not.

The decisive fact: `ANYTHING` is a run-absorbing list hole **only** where the
list-hole detector predicate carries an explicit `ANYTHING` fallback; elsewhere a
bare `ANYTHING` collapses to a single-node hole (`EXPR`/`STMT`).

| Keyword | Redundant w/ bare `ANYTHING`? | Why |
|---|---|---|
| `EXPR`, `STMT` | **yes** (anon only) | both route to the same single-node bind |
| `OBJECT_PROPS`, `DECLARATORS`, `CLASS_REST` | **yes** | detector has `.or_else(anything_hole_name)` → run-absorber |
| `ARGS`, `STMT_LIST` | **no** | no `ANYTHING` fallback → bare `ANYTHING` is a single `EXPR`/`STMT`, not a run |
| `CASE_REST` | **no** | no `ANYTHING` spelling in case position |

8 proof tests added to `e2e/syntactic_holes_test.rs` (e.g. `foo(ARGS)` matches a
2-arg call but `foo(ANYTHING)` does not; `OBJECT_PROPS`/`DECLARATORS`/`CLASS_REST`
≡ `ANYTHING` matched-pair proofs). The plan's Language-simplification section is
rewritten with the per-keyword table + a mechanical emission rule: emit `ANYTHING`
only for anonymous `EXPR`/`STMT`/`OBJECT_PROPS`/`DECLARATORS`/`CLASS_REST`; never
for `ARGS`/`STMT_LIST`/`CASE_REST` or named holes. No matcher/emission code touched
(the asymmetry is by design). Suite 116/116; rebased onto current `devel`.

https://claude.ai/code/session_01RYUAvJefa2eJRgZ7XBfqxA

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYUAvJefa2eJRgZ7XBfqxA)_