### PR TITLE
debundle: rank read-off anchors by retained-source cost

### DIFF
--- a/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
+++ b/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
@@ -464,22 +464,22 @@ minimizer_expectation_case!(
     expected = "expected_match.js",
 );
 
-// Aspirational: an object that carries both a short discriminating key literal
-// and a very long string / template-literal value (shared verbatim across
-// siblings, so non-discriminating) should anchor on the short unique key and
-// hole everything else with OBJECT_PROPS. Today the minimizer drags the entire
-// long literal value into the selector as part of the retained anchor, even
-// though a much shorter sibling key already discriminates uniquely; the long
-// value is the largest node so it dominates the kept shape. This produces
-// rebuild-fragile, hundreds-of-lines selectors in the real spec (tool/command
-// definitions and feature-flag tables whose `description`/`prose` template
-// literals run for hundreds of lines while a one-token `name`/`id` key would
-// have sufficed).
+// An object that carries a very long string / template-literal value (shared
+// verbatim across siblings, so non-discriminating) alongside shorter unique
+// features must never anchor on the long value. The cost tiebreak ranks equally
+// selective+stable anchors by retained-source length, so the minimizer picks
+// the *shortest* discriminator and holes everything else with OBJECT_PROPS. Here
+// the shortest unique feature is `rank: 3` (siblings are rank 1/2), which beats
+// the longer-but-also-unique `id: "uniqueDiscriminatorId"`. Without this, the
+// long shared `prose` value (the largest node) would dominate the kept shape and
+// produce rebuild-fragile, hundreds-of-lines selectors in the real spec
+// (tool/command definitions and feature-flag tables whose `description`/`prose`
+// template literals run for hundreds of lines).
 minimizer_expectation_case!(
-    #[ignore = "literal-anchor minimizer retains the long template-literal value instead of anchoring on the short discriminating key"]
     minimizes_long_literal_value_anchor,
     fixture = "long_literal_value_anchor",
-    name = "object anchors on the short discriminating key, not the long shared literal value",
+    name =
+        "object anchors on the shortest discriminating feature, not the long shared literal value",
     module = "app/definitions",
     bindings = [("SelectedDefinition", "selectedDefinition")],
     expected = "expected_match.js",

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/long_literal_value_anchor/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/long_literal_value_anchor/expected_match.js
@@ -1,4 +1,5 @@
 const SelectedDefinition = {
-  id: "uniqueDiscriminatorId",
+  OBJECT_PROPS,
+  rank: 3,
   OBJECT_PROPS,
 };

--- a/devinfra/js/debundle/shape_index.rs
+++ b/devinfra/js/debundle/shape_index.rs
@@ -535,6 +535,15 @@ pub struct ScoredFeature {
     /// maximally selective (uniquely identifies its item).
     pub selectivity: usize,
     pub stability: Stability,
+    /// Retained-anchor cost: the source size this anchor forces the renderer to
+    /// pin verbatim (the literal value's character length, a key/member label's
+    /// length; `usize::MAX` for a structural skeleton, which pins no renderable
+    /// token and so must rank last on this key). Used as the ranking's third key
+    /// so that among equally selective+stable anchors a *short* renderable one
+    /// wins; a long literal value (a hundreds-of-lines template / string shared
+    /// across siblings) is a last-resort anchor, chosen only when nothing shorter
+    /// discriminates.
+    pub cost: usize,
 }
 
 /// Outcome of a read-off for one target item.
@@ -661,6 +670,7 @@ impl ShapeIndex {
             scored.push(ScoredFeature {
                 selectivity: self.posting(&f).len(),
                 stability: selector_feature_stability(feature),
+                cost: selector_feature_cost(feature),
                 feature: f,
             });
         }
@@ -680,6 +690,15 @@ impl ShapeIndex {
             scored.push(ScoredFeature {
                 selectivity: self.posting(&f).len(),
                 stability,
+                // A skeleton pins no concrete token — the renderer holes it away
+                // and keeps nothing, so it cannot serve as a retained anchor. It
+                // must therefore *lose* the cost tiebreak to any renderable value
+                // anchor of equal selectivity+stability (otherwise a skeleton
+                // would win and the render would hole the only discriminator,
+                // yielding a non-unique selector). It still wins on the
+                // higher-priority selectivity/stability keys when strictly
+                // better; only the cost tiebreak ranks it last.
+                cost: usize::MAX,
                 feature: f,
             });
         }
@@ -770,10 +789,38 @@ impl ShapeIndex {
 /// is distinctive enough to rank as a semantic anchor on stability ties.
 const SKELETON_NOISE_MULTIPLICITY: u32 = 4;
 
-/// Ranking key: most selective first (smallest posting list), then most stable.
-/// Wrapped in a comparable tuple; smaller sorts first.
-fn rank_key(f: &ScoredFeature) -> (usize, std::cmp::Reverse<Stability>) {
-    (f.selectivity, std::cmp::Reverse(f.stability))
+/// Ranking key: most selective first (smallest posting list), then most stable,
+/// then cheapest to retain (smallest pinned source size). The cost tiebreak is
+/// strictly subordinate to selectivity and stability, so it only orders anchors
+/// that are *already* equally discriminating and equally rebuild-stable: among
+/// those, a short anchor wins, and a long literal value is retained only when no
+/// shorter anchor discriminates. Wrapped in a comparable tuple; smaller sorts
+/// first.
+fn rank_key(f: &ScoredFeature) -> (usize, std::cmp::Reverse<Stability>, usize) {
+    (f.selectivity, std::cmp::Reverse(f.stability), f.cost)
+}
+
+/// Retained-anchor cost for an existing selector feature: the character length
+/// of the concrete source token the anchor pins. A long literal value (a
+/// shared template / string spanning hundreds of characters) therefore costs far
+/// more than a one-token discriminating key, so it loses the cost tiebreak to
+/// any equally selective+stable shorter anchor. Structural features (kinds,
+/// arities, import sources) pin nothing via a value span and cost `0`.
+fn selector_feature_cost(feature: &SelectorFeature) -> usize {
+    match feature {
+        SelectorFeature::StringLiteral(value) | SelectorFeature::NumberLiteral(value) => {
+            value.chars().count()
+        }
+        SelectorFeature::ObjectKey(label)
+        | SelectorFeature::ClassMember(label)
+        | SelectorFeature::MemberProperty(label)
+        | SelectorFeature::CallCallee(label) => label.chars().count(),
+        SelectorFeature::BoolLiteral(_) => 1,
+        SelectorFeature::TopLevelKind(_)
+        | SelectorFeature::VarKind(_)
+        | SelectorFeature::FunctionArity(_)
+        | SelectorFeature::ImportSource(_) => 0,
+    }
 }
 
 /// Whether `feature` is sound as an anchor under alpha-equivalent matching.


### PR DESCRIPTION
## Problem

Among equally selective and equally rebuild-stable anchors the read-off ranking had no tiebreak, so it could retain a long literal value — a template/string shared verbatim across siblings, hundreds of chars — when a one-token sibling key or short literal discriminated just as well. That produces rebuild-fragile, hundreds-of-lines selectors in the real spec (tool/command definitions and feature-flag tables whose `description`/`prose` template literals run long).

## Fix

Add a third ranking key: **retained-source cost** (character length of the concrete token the anchor pins). It is strictly subordinate to selectivity and stability, so it only orders anchors that *already* discriminate equally and rebuild equally — among those the shortest wins.

Structural skeletons pin no renderable token, so they rank **last** on cost (`usize::MAX`): a skeleton must never beat a renderable value anchor on the tiebreak, or the render would hole the only discriminator and yield a non-unique selector. (That exact regression showed up as `class_read_off_resolves_uniquely` returning `class ReadableName { CLASS_REST }` matching `[0,1,2]`; the `usize::MAX` skeleton cost fixes it.)

## Behavior

Unignores `minimizes_long_literal_value_anchor`. Its fixture gives `selectedDefinition` two unique discriminators — `id: "uniqueDiscriminatorId"` (21 chars) and `rank: 3` (1 char; siblings are rank 1/2) — sharing a long non-discriminating `prose` template. The minimizer now anchors on the **shortest** discriminator, `rank: 3`, and holes the rest with `OBJECT_PROPS`, never dragging the long shared value in.

`bazelisk test //devinfra/js/debundle/...` — all 116 tests pass, clippy clean.

https://claude.ai/code/session_01RYUAvJefa2eJRgZ7XBfqxA

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYUAvJefa2eJRgZ7XBfqxA)_