### PR TITLE
debundle: record W4 perf validation (whole chunk ~110s → ~13s)

### DIFF
--- a/devinfra/js/debundle/debug/selector_minimizer_dogfood.md
+++ b/devinfra/js/debundle/debug/selector_minimizer_dogfood.md
@@ -8,66 +8,68 @@ expectation cases, and next steps live in the plan backlog
 (<../plans/readoff_minimization.md>). What remains here is the load-bearing perf
 measurement that backs the W4 budget item.
 
-## Read-off minimizer real-chunk perf (2026-06-16)
+## Read-off minimizer real-chunk perf (2026-06-16, post prove-gate-via-index)
 
 W4 perf acceptance measurement of the **current read-off minimizer** (shape-index
 `minimal_anchor_set` + `kept_spans_for_anchor_set`, the default minimization path;
-no `--no-minimize`). Dry run (no `--apply`), `name-binding-to-source-match`
-rewrite, binary run directly (no Bazel overhead), wall-clock via `time.perf_counter`,
-peak RSS via `getrusage(RUSAGE_CHILDREN)` on a fresh child per scope. Members
-counted as `name_binding_members` (the members the minimizer actually processes).
+no `--no-minimize`), **with the prove-gate-via-index fast-path (#2280)**. Dry run
+(no `--apply`), `name-binding-to-source-match` rewrite, **`-c opt` binary** run
+directly (no Bazel overhead), wall-clock via `time.perf_counter`, peak RSS via
+`getrusage(RUSAGE_CHILDREN)` on a fresh child per scope. Members counted as
+`name_binding_members` (the members the minimizer actually processes). Chunk:
+`static/index-DI2GynTv.js`.
 
-| Scope           | Files | members | seconds     | s/member  | peak RSS    |
-| --------------- | ----- | ------- | ----------- | --------- | ----------- |
-| infra           | 53    | 155     | 6.5         | 0.042     | ~253 MB     |
-| integrations    | 42    | 51      | 4.1         | 0.080     | ~253 MB     |
-| shared          | 115   | 247     | 8.7         | 0.035     | ~253 MB     |
-| app             | 221   | 940     | 27.0        | 0.029     | ~253 MB     |
-| domains         | 497   | 1082    | 27.0        | 0.025     | ~253 MB     |
-| features        | 817   | 1976    | 57.6        | 0.029     | ~253 MB     |
-| **whole chunk** | 1745  | 4451    | **107–112** | **0.024** | **~253 MB** |
+| Scope           | members | seconds       | peak RSS    |
+| --------------- | ------- | ------------- | ----------- |
+| infra           | 155     | 2.0           | ~242 MB     |
+| integrations    | 106     | 2.9           | ~242 MB     |
+| shared          | 247     | 1.8           | ~242 MB     |
+| app             | 940     | 4.0           | ~242 MB     |
+| domains         | 1082    | 3.8           | ~242 MB     |
+| features        | 1976    | 7.5           | ~242 MB     |
+| **whole chunk** | 4506    | **13.0–13.6** | **~243 MB** |
 
-(Whole-chunk timed twice: 106.6s and 112.5s — stable around ~110s. Peak RSS is
-flat at ~253 MB across every scope: the parsed 7 MB AST + indices dominate and the
+(Whole-chunk timed twice: 13.0s and 13.6s — stable around ~13s. Peak RSS is flat
+at ~242 MB across every scope: the parsed 7 MB AST + indices dominate and the
 per-member work allocates little, so memory is not scope-sensitive.)
 
-- **Index/parse floor ≈ 3.3s.** A scope whose prefix matches zero files (0 members
-  processed) still pays ~3.3s — parse the chunk once, build the candidate index and
-  the read-off shape index. This one-time cost dominates small scopes and is the
-  floor every invocation pays.
-- **Per-member cost is ~linear and ~constant** at ~0.024–0.04 s/member once the
-  parse floor is amortised. Whole chunk = floor + members × ~0.024s.
+- **Index/parse floor ≈ 1.2s.** A scope whose prefix matches zero files (0 members
+  processed) pays ~1.2s — parse the chunk once, build the candidate index and the
+  read-off shape index. This one-time cost dominates the small scopes.
+- **Per-member cost ≈ 0.0027 s/member** on the whole chunk
+  (`(13.3 − 1.2) / 4506`), down from ~0.024 s/member before #2280 — a ~9× drop.
+  Whole chunk = floor + members × ~0.0027s.
 
 ### Budget verdict
 
-- **Misses the ≤10s ideal and the ≤30s hard budget on the whole chunk by a wide
-  margin** (~110s — ~3.7× over the 30s cap, ~11× over the 10s ideal).
-- **Sub-scopes do meet budget** except the largest: `infra`/`integrations`/
-  `shared`/`app`/`domains` ≤30s; `features` (~58s, ~2k members) is the only single
-  subtree over the hard cap. Scope-at-a-time review stays in budget except for the
-  largest subtree; the whole-chunk acceptance criterion is not met.
+- **Meets the ≤30s hard budget on the whole chunk with margin** (~13s, ~2.3× under
+  the cap) and **narrowly misses the ≤10s ideal** (~13s vs 10s).
+- **Every sub-scope is well within budget**: the largest single subtree
+  (`features`, ~2k members) is ~7.5s, and scope-at-a-time review is effectively
+  instant. The whole-chunk hard-budget acceptance criterion is now met; closing the
+  last ~3s to the ideal would come from the parse/index floor or batching the
+  residual non-singleton proofs.
 
 ### Where the time goes
 
 The read-off layer makes the **selector choice** cheap (shape-index anchor set, no
-full-AST scan), but it does not remove the per-member **uniqueness proof**:
-`synthesize_simplest_selector_for_group` still calls `prove_synthesized_selector`
-(`source_match::resolve_member_binding{,_group_match}` — the production matcher)
-for every emitted selector, over the candidate-index-filtered AST. So the split is
-**~3.3s one-time build** + **~0.024 s/member prove-gate**, the prove-gate
-accounting for essentially all ~107s of per-member time on the whole chunk.
+full-AST scan). The prove-gate-via-index fast-path (#2280) then collapses the
+per-member **uniqueness proof**: `prove_synthesized_selector` restricts the
+production matcher to the candidate-index posting-list intersection, so for the
+singleton-provable majority (the `OPT=1` common case) the matcher inspects a single
+item instead of scanning the matching siblings. The split is now **~1.2s one-time
+build** + **~0.0027 s/member**, so neither phase dominates and the whole chunk lands
+near the parse/index floor plus cheap per-member work.
 
 ### Comparison to prior numbers
 
-- **vs. the 113s search-based baseline:** whole-chunk wall-clock is **unchanged**
-  (~110s vs 113s). Read-off made the _selector-synthesis_ phase cheaper, but the
-  prove-gate (full matcher, once per member) was already the bottleneck and is
-  untouched, so total wall-clock did not move. **The read-off work optimised the
-  cheap half; the prove-gate is now the entire cost.**
-- **vs. the synthetic `OPT=1` = 100% prediction:** the candidate-index prefilter
-  collapses each _matcher call_ from O(all top-level statements) to O(matching
-  siblings) — that holds — but it does not eliminate the once-per-member proof:
-  residual ~0.024 s/member × ~4.5k ≈ 107s still dominates. Hitting budget needs the
-  proof itself amortised/batched across members, or the prove-gate restricted to a
-  cheaper equivalence check the read-off shape index can discharge for the common
-  single-proven-unique case (the planned "prove-gate via index" fix).
+- **vs. the ~110s pre-#2280 read-off baseline** (and the ~113s search-era baseline):
+  whole-chunk wall-clock drops from **~110s to ~13s (~8.5×)**. Before #2280 the
+  prove-gate (full matcher, once per member) was essentially the entire cost
+  (~0.024 s/member × ~4.5k ≈ 107s); restricting it to the index intersection removed
+  that bottleneck, which is where the speedup comes from. `features` alone went
+  57.6s → 7.5s, `app`/`domains` 27s → ~4s.
+- **vs. the synthetic `OPT=1` = 100% prediction:** now borne out on the real chunk —
+  the candidate-index intersection is a singleton `{target}` for the overwhelming
+  majority of members, so the matcher proves uniqueness by inspecting one item and
+  the residual per-member cost is negligible.

--- a/devinfra/js/debundle/plans/readoff_minimization.md
+++ b/devinfra/js/debundle/plans/readoff_minimization.md
@@ -147,9 +147,10 @@ single-target classes whose own value features don't discriminate).
 `selector_codemod.rs` is ~3.7k lines and shrinks substantially once the cover is
 removed.
 
-**Measured perf.** Whole ~7 MB / ~4k-member spec minimizes in ~113 s today
-(pre-read-off baseline). The `≤10s` ideal is validated only on the synthetic
-sweep so far; the real-chunk size-sweep is W4 (backlog).
+**Measured perf.** Whole ~7 MB / ~4.5k-member chunk minimizes in **~13 s** with
+the prove-gate-via-index fast-path (#2280), down from ~110 s — **meets the ≤30 s
+hard budget**, narrowly over the ≤10 s ideal (per-member ~0.0027 s, ~9× cheaper).
+Full scope table in <../debug/selector_minimizer_dogfood.md>.
 
 **E2E expectation suite** (`e2e/selector_minimizer_expectation_test.rs`). Active:
 `sparse_function_body`, `call_argument_literal`, `object_property_literals`,
@@ -199,7 +200,8 @@ non-minimal pattern catalog drives this and is encoded as disabled E2E cases.
    **sound superset**, so when the selector's anchor-feature posting-list
    intersection is the singleton `{target}` that _is_ a uniqueness proof — skip
    the matcher; full matcher only for non-singleton cases. Collapses per-member
-   cost for the `OPT=1` majority toward the ≤10s target. **(Landed: #2280.)**
+   cost for the `OPT=1` majority toward the ≤10s target. **(Landed: #2280;
+   validated — whole chunk ~110s → ~13s, see W4 below.)**
 2. **Function** whole-body anchoring (~1,455 full + ~1,743 holed; biggest count) —
    anchor a deep unique literal/member, hole the rest (`sparse_function_body`).
 3. **Class** body among siblings (91 full + 268 holed; worst severity, ~1,151-line
@@ -240,8 +242,10 @@ non-minimal pattern catalog drives this and is encoded as disabled E2E cases.
 9. **`selector_codemod.rs` refactor** — after cover deletion (deletion reshapes
    the file; splitting by form earlier also enables parallel per-form fan-out).
 10. **Language simplification** (see below).
-11. **W4 — whole-spec validation:** ≤10/30 s + real-chunk size-sweep; refresh the
-    dogfood note (current real-chunk baseline ~110s recorded there).
+11. **W4 — whole-spec validation:** **hard budget met** — whole chunk ~13s after
+    #2280 (was ~110s), every sub-scope ≤8s; ≤10s ideal narrowly missed. Measured
+    and recorded in the dogfood note. Remaining: close the last ~3s to the ideal
+    (parse/index floor or batching residual non-singleton proofs) if desired.
 
 Each capability re-applies to gaffer-private as it lands (review diffs for
 over-pin; gaffer validates with a _pinned_ debundle release, so spec PRs must


### PR DESCRIPTION
Re-measured the read-off `synthesize-selectors` minimizer on the real `tana/re` chunk with the prove-gate-via-index fast-path (#2280) and an `-c opt` binary, validating the W4 perf budget.

## Result — whole chunk ~110s → ~13s (~8.5×)

| Scope | members | baseline | now |
| --- | --- | --- | --- |
| infra | 155 | 6.5s | 2.0s |
| integrations | 106 | 4.1s | 2.9s |
| shared | 247 | 8.7s | 1.8s |
| app | 940 | 27.0s | 4.0s |
| domains | 1082 | 27.0s | 3.8s |
| features | 1976 | 57.6s | 7.5s |
| **whole chunk** | 4506 | **~110s** | **13.0/13.6s** |

Per-member cost ~0.0027s (was ~0.024s, ~9×). Parse/index floor ~1.2s. Peak RSS flat ~242 MB.

## Verdict

- **Meets the ≤30s hard budget** with margin (~2.3× under).
- **Narrowly misses the ≤10s ideal** (~13s). Closing the last ~3s would come from the parse/index floor or batching the residual non-singleton proofs.

Before #2280 the per-member full-matcher proof was essentially the entire cost (~0.024 s/member × ~4.5k ≈ 107s); restricting it to the candidate-index posting-list intersection (singleton ⇒ uniqueness proof for the `OPT=1` majority) removed that bottleneck — the synthetic `OPT=1`=100% prediction now borne out on the real chunk.

Docs only: updates the dogfood note with the post-#2280 scope table and the plan's W4 item / perf line.

https://claude.ai/code/session_01RYUAvJefa2eJRgZ7XBfqxA

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYUAvJefa2eJRgZ7XBfqxA)_