### PR TITLE
debundle: capture interior-holing feedback (plan item + e2e case)

### DIFF
--- a/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
+++ b/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
@@ -548,6 +548,26 @@ minimizer_expectation_case!(
     expected = "expected_match.js",
 );
 
+// Interior holing: a nested object literal inside a kept call argument should
+// hole its non-anchor properties to `OBJECT_PROPS`, the same way the single-target
+// object form already does at top level. The discriminator is one property
+// (`mode: "uniqueDiscriminatorMode"`); the rest are shared across siblings. Today
+// the minimizer holes the off-anchor receiver (`ctx.engine` -> `ANYTHING`) but
+// keeps the whole nested object verbatim instead of holing it. (Real-spec
+// analogue: `moveProcessedInboxAudioNodeToTarget` pins its entire move-options
+// object.) The read-off prunes off-anchor statements / call-chains / callbacks
+// already; the gap is holing INTO nested object/array literals within a kept
+// expression.
+minimizer_expectation_case!(
+    #[ignore = "nested object literal in a kept call arg pins every property; non-anchor props should hole to OBJECT_PROPS"]
+    minimizes_interior_object_arg_holing,
+    fixture = "interior_object_arg_holing",
+    name = "nested object in a kept call arg keeps only the discriminating property, OBJECT_PROPS for the rest",
+    module = "app/nodes",
+    bindings = [("SelectedMover", "selectedMover")],
+    expected = "expected_match.js",
+);
+
 // Re-baselined for the unified keep-shallow anchor policy: both outputs keep each
 // slot's direct shallow literals including object-property values. The group's
 // shared `enabled: true` and the standalone's `kind: "panel"` / `title: "Settings"`

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/interior_object_arg_holing/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/interior_object_arg_holing/expected_match.js
@@ -1,0 +1,3 @@
+function SelectedMover(ANYTHING) {
+  ANYTHING.run([{ OBJECT_PROPS, mode: "uniqueDiscriminatorMode", OBJECT_PROPS }]);
+}

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/interior_object_arg_holing/source.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/interior_object_arg_holing/source.js
@@ -1,0 +1,26 @@
+// The discriminating anchor (`mode: "uniqueDiscriminatorMode"`) is one property
+// of a nested object literal passed as a call argument; every other property is
+// shared across the siblings. Today the minimizer keeps the whole object
+// verbatim; it should hole the non-anchor properties to OBJECT_PROPS (interior
+// holing of a nested object within a kept statement).
+function selectedMover(ctx) {
+  ctx.engine.run([
+    {
+      source: ctx.node,
+      target: ctx.dest,
+      mode: "uniqueDiscriminatorMode",
+      silent: true,
+      retain: false,
+    },
+  ]);
+}
+
+function firstSiblingMover(ctx) {
+  ctx.engine.run([{ source: ctx.node, target: ctx.dest, mode: "alphaMode", silent: true, retain: false }]);
+}
+
+function secondSiblingMover(ctx) {
+  ctx.engine.run([{ source: ctx.node, target: ctx.dest, mode: "bravoMode", silent: true, retain: false }]);
+}
+
+export { selectedMover };

--- a/devinfra/js/debundle/plans/readoff_minimization.md
+++ b/devinfra/js/debundle/plans/readoff_minimization.md
@@ -204,6 +204,27 @@ non-minimal pattern catalog drives this and is encoded as disabled E2E cases.
    validated — whole chunk ~110s → ~13s, see W4 below.)**
 2. **Function** whole-body anchoring (~1,455 full + ~1,743 holed; biggest count) —
    anchor a deep unique literal/member, hole the rest (`sparse_function_body`).
+   2b. **Interior holing — hole non-anchor subtrees within kept statements
+   (gaffer-dogfood feedback).** The read-off already prunes off-anchor _statements_,
+   _call-chain links_, and _callbacks_ when a sparse anchor exists: with a clean
+   discriminator a `svc.fetchToken().then(…).catch(e => {…})` chain correctly
+   minimizes to `ANYTHING.then((ANYTHING) => { <anchor> }).catch(ANYTHING)` (the
+   non-discriminating catch callback holes to `ANYTHING`). Two gaps remain:
+   - **Nested object / array literals inside a kept expression are pinned whole**
+     rather than holed to `OBJECT_PROPS` / `ARGS` around the discriminating
+     element. Demonstrated by `interior_object_arg_holing`: the move-options object
+     in a kept `engine.run([{…}])` keeps every property instead of
+     `[{ OBJECT_PROPS, mode: "…", OBJECT_PROPS }]`. (Real-spec analogues:
+     `moveProcessedInboxAudioNodeToTarget`, the `Se({…})` command objects.) Fix:
+     extend the kept-span prune to recurse into object/array literals, holing
+     maximal non-anchor property/element runs the same way the top-level object
+     form does.
+   - **No-sparse-anchor bodies are kept verbatim** (the single-target / weak-anchor
+     family — `single_target_class_whole_body`, `component_wide_destructure_whole_body`,
+     and function analogues like `redirectElectronAppWithCustomToken` keeping its
+     whole then+catch). Here uniqueness was proven by the full body, so nothing was
+     holed; the win is finding the minimal subtree set that still proves unique and
+     holing the rest (interior set-cover at subtree granularity).
 3. **Class** body among siblings (91 full + 268 holed; worst severity, ~1,151-line
    bodies) — `CLASS_REST` + discriminating member (`class_among_many_siblings`,
    `sibling_subclass_hierarchy`, `class_body`). **Landed.** `minimize_class_selector`


### PR DESCRIPTION
Captures your minimal-selector feedback from reviewing the converted gaffer selectors. Docs + one disabled e2e case.

## Finding

The read-off **already** prunes off-anchor statements, call-chain links, and callbacks when a sparse anchor exists — e.g. a `svc.fetchToken().then(…).catch(e => {…})` chain with a clean discriminator correctly minimizes to `ANYTHING.then((ANYTHING) => { <anchor> }).catch(ANYTHING)` (the non-discriminating catch callback **does** hole to `ANYTHING`; verified against a synthetic reproduction).

Two gaps remain, both in your examples:

1. **Nested object / array literals inside a kept expression are pinned whole** instead of holing to `OBJECT_PROPS` / `ARGS` around the discriminating element. New disabled e2e case `interior_object_arg_holing` reproduces it: `engine.run([{ source, target, mode: "uniqueDiscriminatorMode", silent, retain }])` keeps every property today; it should be `[{ OBJECT_PROPS, mode: "uniqueDiscriminatorMode", OBJECT_PROPS }]`. (Real-spec analogues: `moveProcessedInboxAudioNodeToTarget`, the `Se({…})` command objects, the `addTagCommand` declarator group.)
2. **No-sparse-anchor bodies are kept verbatim** — the single-target / weak-anchor family (`redirectElectronAppWithCustomToken` keeping its whole then+catch, `summarizeWorkspaceBootTimings` keeping the whole loop body, `executeSingleMoveOperation`'s giant ternary). Uniqueness was proven by the full body, so nothing was holed; the win is finding the minimal subtree set that still proves unique and holing the rest. Same family as the existing `single_target_class_whole_body` / `component_wide_destructure_whole_body` cases.

## Changes

- `plans/readoff_minimization.md`: new backlog item **2b (interior holing)** distinguishing the two gaps and what already works.
- `interior_object_arg_holing` — anonymized `#[ignore]` expectation case for gap (1); confirmed it over-pins today (kept all 5 props).

`bazelisk test //devinfra/js/debundle/e2e:selector_minimizer_expectation_test` passes (new case is `#[ignore]`).

https://claude.ai/code/session_01RYUAvJefa2eJRgZ7XBfqxA

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYUAvJefa2eJRgZ7XBfqxA)_