### PR TITLE
debundle: capture adjacent-accessor grouping feedback (plan + e2e)

### DIFF
--- a/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
+++ b/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
@@ -612,3 +612,55 @@ fn minimizes_binding_group_partition() {
         ],
     });
 }
+
+// Aspirational: a run of adjacent, near-identical accessor functions should
+// collapse into ONE binding_group (the source_match is the consecutive run of
+// the four `function …Accessor() { return ANYTHING.…; }` declarations, with
+// `exports` mapping each), rather than four standalone source_match selectors.
+// Today the grouping fires for some same-statement clusters but not for this
+// run, so the minimizer emits four individual outputs (the assertion below
+// expects one grouped output and fails). Real-spec analogue:
+// `app/state/accessors.yaml` `use{AppUser,NodeSpace,FocusService,CoreServices}`,
+// four adjacent context-accessor hooks each emitted as its own selector. The
+// grouping trigger (item 7: shared declaration OR minimal-selector overlap) must
+// cover adjacent same-shape function declarations with high selector overlap.
+#[ignore = "adjacent near-identical accessor functions emit N standalone selectors instead of one binding_group"]
+#[test]
+fn minimizes_adjacent_accessor_group() {
+    run_case(&MinimizedSelectorCase {
+        name: "adjacent near-identical accessor functions collapse into one binding_group",
+        source: include_str!(
+            "testdata/selector_minimizer_expectations/adjacent_accessor_group/source.js"
+        ),
+        module: "app/accessors",
+        bindings: &[
+            BindingCase {
+                export_name: "selectedAlphaAccessor",
+                runtime_name: "selectedAlphaAccessor",
+            },
+            BindingCase {
+                export_name: "selectedBetaAccessor",
+                runtime_name: "selectedBetaAccessor",
+            },
+            BindingCase {
+                export_name: "selectedGammaAccessor",
+                runtime_name: "selectedGammaAccessor",
+            },
+            BindingCase {
+                export_name: "selectedDeltaAccessor",
+                runtime_name: "selectedDeltaAccessor",
+            },
+        ],
+        outputs: &[SelectorOutputExpectation {
+            exports: &[
+                "selectedAlphaAccessor",
+                "selectedBetaAccessor",
+                "selectedGammaAccessor",
+                "selectedDeltaAccessor",
+            ],
+            expected_match: include_str!(
+                "testdata/selector_minimizer_expectations/adjacent_accessor_group/expected_group_match.js"
+            ),
+        }],
+    });
+}

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/adjacent_accessor_group/expected_group_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/adjacent_accessor_group/expected_group_match.js
@@ -1,0 +1,12 @@
+function selectedAlphaAccessor() {
+  return ANYTHING.services.alpha;
+}
+function selectedBetaAccessor() {
+  return ANYTHING.services.beta;
+}
+function selectedGammaAccessor() {
+  return ANYTHING.services.gamma;
+}
+function selectedDeltaAccessor() {
+  return ANYTHING.coreServices;
+}

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/adjacent_accessor_group/source.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/adjacent_accessor_group/source.js
@@ -1,0 +1,24 @@
+// Four tiny accessor functions declared right after one another, each a
+// one-liner that reads a different property off the same resolved context. Each
+// is individually discriminable (by its trailing property), but they are a DRY
+// cluster: emitting four near-identical standalone source_match selectors is
+// wasteful. They should collapse into ONE binding_group whose source_match is
+// the consecutive run of the four functions, with `exports` mapping each.
+function selectedAlphaAccessor() {
+  return resolveContext().services.alpha;
+}
+function selectedBetaAccessor() {
+  return resolveContext().services.beta;
+}
+function selectedGammaAccessor() {
+  return resolveContext().services.gamma;
+}
+function selectedDeltaAccessor() {
+  return resolveContext().coreServices;
+}
+
+function unrelatedHelper(value) {
+  return value * 2;
+}
+
+export { selectedAlphaAccessor, selectedBetaAccessor, selectedGammaAccessor, selectedDeltaAccessor };

--- a/devinfra/js/debundle/plans/readoff_minimization.md
+++ b/devinfra/js/debundle/plans/readoff_minimization.md
@@ -269,6 +269,16 @@ non-minimal pattern catalog drives this and is encoded as disabled E2E cases.
    and **var** migration (needs binding-group/declarator-slot tuple resolution).
 7. **Anti-unification grouping** from posting co-occurrence (shared declaration OR
    minimal-selector overlap threshold) → `binding_group`.
+   - **Adjacent same-shape function declarations (gaffer-dogfood feedback).**
+     `binding_group` already groups consecutive `function` declarations (the
+     `source_match` is the run of declarations, `exports` maps each), but the
+     trigger doesn't fire for runs of tiny near-identical accessors, which emit N
+     standalone selectors instead. Real example: `app/state/accessors.yaml`
+     `use{AppUser,NodeSpace,FocusService,CoreServices}` — four adjacent
+     `function useX() { return ANYTHING.nodeSpace.…; }` hooks, each its own
+     selector; they should collapse into one group (concise + DRY). The
+     minimal-selector-overlap trigger must catch a run of adjacent functions whose
+     selectors share the bulk of their shape. E2E: `adjacent_accessor_group`.
 8. **Delete the cover search** once all forms route through read-off
    (`minimize_via_retention`, `cover_competitors`, `min_set_cover`,
    `collect_*_anchors`) — shrinks `selector_codemod.rs` substantially.


### PR DESCRIPTION
Captures the adjacent-accessor grouping feedback from `app/state/accessors.yaml`. Docs + one disabled e2e.

Four adjacent near-identical context-accessor hooks — `use{AppUser,NodeSpace,FocusService,CoreServices}`, each `function useX() { return ANYTHING.nodeSpace.…; }` — were each emitted as a standalone `source_match` selector. They're a DRY cluster that should collapse into **one `binding_group`** (the `source_match` is the consecutive run of the function declarations, `exports` maps each — the format already used elsewhere in the spec, e.g. `messages.yaml`).

`binding_group` grouping already fires for some same-statement clusters, but the **minimal-selector-overlap trigger** doesn't catch runs of adjacent same-shape function declarations like this.

## Changes

- `adjacent_accessor_group` — disabled grouped-case e2e (modeled on `binding_group_partition`). Confirmed it reproduces the gap: the minimizer emits **4 individual** selectors, not 1 group.
- `plans/readoff_minimization.md` — sub-item under the anti-unification grouping backlog (item 7) for adjacent same-shape function runs, citing `accessors.yaml`.

`bazelisk test //devinfra/js/debundle/e2e:selector_minimizer_expectation_test` passes (new case is `#[ignore]`).

https://claude.ai/code/session_01RYUAvJefa2eJRgZ7XBfqxA

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYUAvJefa2eJRgZ7XBfqxA)_