### PR TITLE
debundle: object key-set pin minimization (#2290)

### DIFF
--- a/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
+++ b/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
@@ -427,19 +427,51 @@ minimizer_expectation_case!(
     expected = "expected_match.js",
 );
 
-// Aspirational: a target object inside a multi-declarator group of sibling
-// enum/lookup objects should minimize to DECLARATORS holes around the target
-// declarator plus OBJECT_PROPS holes on both sides of the single discriminating
-// key. Today the minimizer keeps every sibling declarator's full object value
-// and every key of the target object, over-pinning a whole group of lookup
-// dicts where one declarator with one anchored key would resolve uniquely.
+// A target object inside a multi-declarator group of sibling enum/lookup objects
+// minimizes to DECLARATORS holes around the target declarator plus OBJECT_PROPS
+// holes on both sides of the single discriminating entry. The slot-aware
+// `cover_object_slot` greedy pins the entry whose value is globally unique
+// (`accent: "uniqueDiscriminatorAccent"`), resolving the binding to the right
+// declarator slot without keeping every sibling declarator's full object or every
+// key of the target object.
 minimizer_expectation_case!(
-    #[ignore = "group minimizer keeps all declarators and all keys instead of DECLARATORS + OBJECT_PROPS"]
     minimizes_grouped_enum_objects,
     fixture = "grouped_enum_objects",
     name = "grouped enum objects keep only the target declarator's discriminating key",
     module = "app/palettes",
     bindings = [("SelectedPalette", "selectedPalette")],
+    expected = "expected_match.js",
+);
+
+// Key-set minimization inside a multi-declarator group (#2290): when an object is
+// discriminated by its *key set* — every value already holed to ANYTHING (here
+// `theme.base` member accesses shared across all siblings) — the minimizer keeps
+// only the minimal discriminating key (`logViewer`, unique to the target slot)
+// with OBJECT_PROPS holes for the rest, and DECLARATORS holes for the sibling
+// declarators, instead of keeping every key of the target object. Mirrors the
+// real gaffer CSS-styles dicts (`{ diagnosticsSection: …, detailsToggle: …, … }`)
+// kept whole inside `DECLARATORS_BEFORE`/`_AFTER` groups.
+minimizer_expectation_case!(
+    minimizes_object_key_set_group,
+    fixture = "object_key_set_group",
+    name = "key-set object in a declarator group keeps only the discriminating key",
+    module = "app/styles",
+    bindings = [("ErrorPanelStyles", "errorPanelStyles")],
+    expected = "expected_match.js",
+);
+
+// Key-set minimization needing a *subset* of keys (#2290): no single key is
+// unique (each is shared with one sibling) but the pair `{ alpha, delta }`
+// discriminates the target. With every value holed to ANYTHING, the minimizer
+// keeps exactly those two non-adjacent keys, each surrounded by OBJECT_PROPS so
+// the key set matches as independent interior elements (surviving key reorder),
+// rather than keeping all four keys.
+minimizer_expectation_case!(
+    minimizes_object_key_set_subset,
+    fixture = "object_key_set_subset",
+    name = "key-set object keeps the minimal discriminating key subset",
+    module = "app/shapes",
+    bindings = [("TargetShape", "targetShape")],
     expected = "expected_match.js",
 );
 

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/object_key_set_group/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/object_key_set_group/expected_match.js
@@ -1,0 +1,6 @@
+const ErrorPanelStyles = {
+    OBJECT_PROPS,
+    logViewer: ANYTHING,
+    OBJECT_PROPS,
+  },
+  DECLARATORS_AFTER = null;

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/object_key_set_group/source.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/object_key_set_group/source.js
@@ -1,0 +1,17 @@
+const errorPanelStyles = {
+    diagnosticsSection: theme.base,
+    detailsToggle: theme.base,
+    logViewer: theme.base,
+  },
+  successPanelStyles = {
+    diagnosticsSection: theme.base,
+    detailsToggle: theme.base,
+    summaryCard: theme.base,
+  };
+
+const basePanelStyles = {
+  diagnosticsSection: theme.base,
+  detailsToggle: theme.base,
+};
+
+export { errorPanelStyles };

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/object_key_set_subset/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/object_key_set_subset/expected_match.js
@@ -1,0 +1,7 @@
+const TargetShape = {
+  OBJECT_PROPS,
+  alpha: ANYTHING,
+  OBJECT_PROPS,
+  delta: ANYTHING,
+  OBJECT_PROPS,
+};

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/object_key_set_subset/source.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/object_key_set_subset/source.js
@@ -1,0 +1,20 @@
+const targetShape = {
+  alpha: ref.shared,
+  beta: ref.shared,
+  gamma: ref.shared,
+  delta: ref.shared,
+};
+
+const firstSibling = {
+  alpha: ref.shared,
+  beta: ref.shared,
+  gamma: ref.shared,
+};
+
+const secondSibling = {
+  beta: ref.shared,
+  gamma: ref.shared,
+  delta: ref.shared,
+};
+
+export { targetShape };

--- a/devinfra/js/debundle/plans/readoff_minimization.md
+++ b/devinfra/js/debundle/plans/readoff_minimization.md
@@ -123,10 +123,16 @@ Migrated to read-off as their primary path:
 - **Single-target function** (`minimize_function_selector` → `render_via_read_off`):
   reads off `minimal_anchor_set`, prefers the empty-kept structural scaffold when
   it already discriminates, renders through the shared `render_with`.
-- **Single-target object** (`try_single_object_read_off` → `hole_object_padded`):
-  always leads+trails with `OBJECT_PROPS` so the discriminating `key: value`
-  matches as an interior subsequence element (survives key reorder), never
-  anchored to the object's right edge.
+- **Single-target object** (`try_object_read_off` → `hole_object_padded`):
+  surrounds every kept prop with `OBJECT_PROPS` (leads, trails, **and**
+  interleaves) so a discriminating `key: value` — or a minimal _key set_ — matches
+  as independent interior subsequence elements (survives key reorder and gaps),
+  never anchored to the object's right edge or assuming two kept keys stay
+  adjacent. Handles the object whether it stands alone or sits in a
+  multi-declarator group (one target slot, `DECLARATORS_*` holes for the rest):
+  reads its anchors off the shape index, then falls back to a slot-aware key-set
+  cover (`cover_object_slot`) that singles out the target declarator's own keys —
+  the per-slot view the chunk-wide read-off cannot see.
 - **Single-target class** (`minimize_class_selector` → `render_via_read_off`):
   holes `extends` to `ANYTHING` and keeps only the member runs carrying a chosen
   anchor between `CLASS_REST` holes; the value-over-name ranking key prefers a
@@ -156,10 +162,11 @@ Full scope table in <../debug/selector_minimizer_dogfood.md>.
 `sparse_function_body`, `call_argument_literal`, `object_property_literals`,
 `binding_group_declarators`, `nested_async_try`, `class_body`, `switch_case_run`,
 `object_keys_over_pinned`, `long_literal_value_anchor`, `binding_group_partition`,
-and (unignored once the class read-off landed) `class_among_many_siblings`,
-`sibling_subclass_hierarchy`. Ignored as aspirational (the named form not yet
+`class_among_many_siblings`, `sibling_subclass_hierarchy`, and (unignored once
+the object key-set cover landed) `grouped_enum_objects`, `object_key_set_group`,
+`object_key_set_subset`. Ignored as aspirational (the named form not yet
 read-off-expressible): `sequential_assignment_block`, `deeply_nested_call_args`,
-`grouped_enum_objects`, `object_nested_value_dict`, `wide_destructure_block`.
+`object_nested_value_dict`, `wide_destructure_block`.
 
 ## Acceptance criteria
 
@@ -250,21 +257,28 @@ non-minimal pattern catalog drives this and is encoded as disabled E2E cases.
    short discriminating key over the largest node (`long_literal_value_anchor`).
    **(Landed: #2281 — retained-source cost tiebreak; skeletons rank last on cost.)**
 5. **Object-dict family** — over-pinned keys (`object_keys_over_pinned`, done for
-   single scalar), nested-value dicts (`object_nested_value_dict`), grouped
-   objects (`grouped_enum_objects`: `DECLARATORS` + padded `OBJECT_PROPS`), wide
-   destructure (`wide_destructure_block`).
-   - **Key-set minimization (gaffer-dogfood feedback).** When an object is
-     discriminated by its _key set_ rather than any value — every value already
-     holed to `ANYTHING`, e.g. a CSS-styles dict
-     `{ diagnosticsSection: ANYTHING, detailsToggle: ANYTHING, … 11 keys }`, or a
-     schema object `ee({ coreMessage: …, type: …, … })` kept whole — the minimizer
-     keeps **every** key. It should keep only the **minimal key subset** whose
-     presence still discriminates the target from its siblings and collapse the
-     rest to `OBJECT_PROPS` (the key-set analogue of greedy set-cover: anchor on
-     the rarest discriminating keys, `OBJECT_PROPS` the common ones). Note these
-     over-pins surface inside multi-declarator var groups
-     (`DECLARATORS_BEFORE`/`_AFTER`), so the object key-set minimization must run
-     on the per-declarator object even when the statement is a declarator group.
+   single scalar), grouped objects (`grouped_enum_objects`: `DECLARATORS` + padded
+   `OBJECT_PROPS`, **landed** — see key-set below), and the still-open
+   nested-value dicts (`object_nested_value_dict`) and wide destructure
+   (`wide_destructure_block`).
+   - **Key-set minimization (gaffer-dogfood feedback). Landed (#2290).** When an
+     object is discriminated by its _key set_ rather than any value — every value
+     already holed to `ANYTHING`, e.g. a CSS-styles dict
+     `{ diagnosticsSection: ANYTHING, detailsToggle: ANYTHING, … 11 keys }` — the
+     minimizer used to keep **every** key. It now keeps only the **minimal key
+     subset** whose presence discriminates the target from its siblings and
+     collapses the rest to `OBJECT_PROPS` (the key-set analogue of greedy
+     set-cover: anchor the rarest discriminating keys, `OBJECT_PROPS` the common
+     ones). `hole_object_padded` interleaves `OBJECT_PROPS` between every kept prop
+     so a multi-key subset survives key reorder; `try_object_read_off` runs on the
+     per-declarator object even inside a `DECLARATORS_BEFORE`/`_AFTER` group, with
+     a slot-aware `cover_object_slot` greedy (scores by whether the _target
+     binding's_ slot resolves, since the matcher reports one alignment per body)
+     for the per-slot key sets the chunk-wide read-off cannot see. E2E:
+     `object_key_set_group`, `object_key_set_subset`, `grouped_enum_objects`.
+     Still open: the `ee({ coreMessage: …, type: …, … })` schema-object form is a
+     **call** kept whole (the no-sparse-anchor body family, item 2b), not the
+     object-literal-valued var this covers.
 6. **Statement runs** (`sequential_assignment_block`, `deeply_nested_call_args`)
    and **var** migration (needs binding-group/declarator-slot tuple resolution).
 7. **Anti-unification grouping** from posting co-occurrence (shared declaration OR

--- a/devinfra/js/debundle/selector_codemod.rs
+++ b/devinfra/js/debundle/selector_codemod.rs
@@ -1457,24 +1457,27 @@ fn hole_object(object: &ObjectLit, kept: &BTreeSet<AnchorSpan>) -> ObjectLit {
     holed
 }
 
-/// Hole an object literal for the read-off object form: keep only props
-/// carrying a kept anchor and **always** lead and trail with an `OBJECT_PROPS`
-/// hole, regardless of whether the kept prop sits at a source edge.
+/// Hole an object literal for the read-off object form: keep only props carrying
+/// a kept anchor, with an `OBJECT_PROPS` run hole before the first kept prop,
+/// after the last, and **between every pair** of kept props.
 ///
 /// Unlike [`hole_object`] (which only emits a list hole where a run of props was
-/// actually dropped), this pads both edges unconditionally. Object properties
-/// are unordered enum/lookup entries: a key that is genuinely last in this build
-/// can move on a rebuild, so anchoring it to the object's right edge
-/// (`anchored_right` in the matcher) is fragile. Padding both sides matches the
-/// discriminating key as an interior subsequence element, surviving reorder.
+/// actually dropped), this pads both edges and interleaves unconditionally.
+/// Object properties are unordered enum/lookup entries: a kept key can move on a
+/// rebuild, so anchoring one to the object's edge (`anchored_right` in the
+/// matcher) or assuming two kept keys stay adjacent is fragile. Surrounding every
+/// kept prop with `OBJECT_PROPS` matches each as an independent interior
+/// subsequence element, so a minimal *key set* survives key reorder and arbitrary
+/// gaps. With no kept prop this is a bare `{ OBJECT_PROPS }`; with one it is the
+/// padded single-key form (unchanged from the edge-padding behavior).
 fn hole_object_padded(object: &ObjectLit, kept: &BTreeSet<AnchorSpan>) -> ObjectLit {
     let mut props = vec![object_props_prop()];
     for prop in &object.props {
         if node_retains_any(prop.span(), kept) {
             props.push(hole_prop(prop, kept));
+            props.push(object_props_prop());
         }
     }
-    props.push(object_props_prop());
     let mut holed = object.clone();
     holed.props = props;
     holed
@@ -1838,7 +1841,8 @@ fn collect_expr_anchors(expr: &Expr, depth: u32, candidates: &mut AnchorCandidat
     }
 }
 
-/// Body indices a `target_binding` selector with `match_source` resolves to.
+/// Every `(body, binding-slot)` alignment a `target_binding` selector with
+/// `match_source` resolves to.
 ///
 /// The shared per-chunk [`SelectorCandidateIndex`] narrows the matcher's scan to
 /// the top-level body indices whose features could still match the selector,
@@ -1847,11 +1851,11 @@ fn collect_expr_anchors(expr: &Expr, depth: u32, candidates: &mut AnchorCandidat
 /// so the still-run structural matcher remains the source of truth: it proves
 /// every reported match and discards index false positives. See
 /// `prefilter_matches_brute_force_scan` for the superset invariant test.
-fn matched_body_indices(
+fn matched_binding_candidates(
     index: &ChunkSelectorIndex,
     export_name: &str,
     match_source: &str,
-) -> Result<BTreeSet<usize>> {
+) -> Result<Vec<source_match::MemberBindingMatch>> {
     let source_match = SourceMatch {
         match_source: match_source.to_string(),
         identifiers: SourceMatchIdentifierMode::AlphaAll,
@@ -1866,13 +1870,27 @@ fn matched_body_indices(
         .candidate_set_for_source_match(&selector)?
         .body_indices()
         .collect();
-    let matches = source_match::member_binding_candidate_matches_within(
+    source_match::member_binding_candidate_matches_within(
         &index.parsed.module,
         "<selector minimization>",
         &selector,
         BodyIndexFilter::Restricted(&candidates),
-    )?;
-    Ok(matches.iter().map(|candidate| candidate.body_idx).collect())
+    )
+}
+
+/// Distinct body indices the selector resolves to (slot alignments within one
+/// body collapse). Used by the body-index cover ([`cover_competitors`]).
+fn matched_body_indices(
+    index: &ChunkSelectorIndex,
+    export_name: &str,
+    match_source: &str,
+) -> Result<BTreeSet<usize>> {
+    Ok(
+        matched_binding_candidates(index, export_name, match_source)?
+            .iter()
+            .map(|candidate| candidate.body_idx)
+            .collect(),
+    )
 }
 
 fn holes_present(source: &str) -> BTreeSet<String> {
@@ -2169,69 +2187,193 @@ fn declarator_hole(name: &str) -> VarDeclarator {
     }
 }
 
-/// Read off a minimal selector for a single-target `var`/`let`/`const` whose
-/// declarator value is an object literal (W3).
+/// Ranked anchor spans for an object literal's key-set cover, best-first: each
+/// direct literal/template **value** (a value-level discriminator, tried first)
+/// then each **key** (the key-set discriminator). Value member accesses and
+/// nested expressions are intentionally excluded — a minified `.prop` is
+/// rebuild-volatile, so the cover pins the stable key and holes the value to
+/// `ANYTHING` rather than anchoring on a churning property name.
 ///
-/// Applies only to the single-target, single-declarator-target object case (the
-/// general group path stays unmigrated). Reads the minimal [`AnchorSet`] off the
-/// shape index, maps its value anchors to kept byte spans over the object, and
-/// renders the object with [`hole_object_padded`] (both-edge `OBJECT_PROPS`) so
-/// the discriminating key:value survives key reordering. Returns `None` — so the
-/// caller falls back to the keep-shallow group path — when the target is not a
-/// single object declarator, the structural scaffold already resolves (let the
-/// group path keep its leaner all-holed form), the read-off cannot single out
-/// the target, or the rendered selector fails the matcher gate.
-fn try_single_object_read_off(
+/// Within each class the order is source order; the cover's slot-resolution
+/// greedy ([`cover_object_slot`]) then picks the most discriminating anchor, so
+/// this ordering only breaks ties — preferring a unique value (`accent:
+/// "…Accent"`) over its equally-unique key (`accent: ANYTHING`) when both single
+/// out the slot.
+fn object_anchor_ranking(object: &ObjectLit) -> Vec<AnchorSpan> {
+    let key_value_props = || {
+        object.props.iter().filter_map(|prop| match prop {
+            PropOrSpread::Prop(prop) => match prop.as_ref() {
+                Prop::KeyValue(key_value) => Some(key_value),
+                _ => None,
+            },
+            PropOrSpread::Spread(_) => None,
+        })
+    };
+    let values = key_value_props()
+        .filter(|kv| matches!(kv.value.as_ref(), Expr::Lit(_) | Expr::Tpl(_)))
+        .map(|kv| span_key(kv.value.span()));
+    let keys = key_value_props().map(|kv| span_key(kv.key.span()));
+    values.chain(keys).collect()
+}
+
+/// Slot-aware minimal cover for a single-target object inside a `var` group: a
+/// greedy key-set set-cover that, at each step, adds the `ranked` anchor that best
+/// steers the selector toward resolving to the target binding's own declarator
+/// slot, until it proves unique. Unlike [`cover_competitors`] (which covers
+/// distinct body indices and so cannot see two sibling declarators of the *same*
+/// statement), this scores by whether the **target binding** is the one the
+/// selector resolves, then by the match count.
+///
+/// The matcher reports one alignment per body (the leftmost declarator the holed
+/// pattern fits), so a key shared with an *earlier* sibling slot
+/// (`blue: "#00f"`, also in `firstPalette`) resolves there, not to the target —
+/// hence the score's first key is "did the target slot resolve at all", which a
+/// key/value unique to the target slot (`accent`) flips true. Keeps adding the
+/// best anchor until the matcher's uniqueness proof passes, or the target's own
+/// anchors are exhausted (then `None`, and the caller keeps its keep-shallow
+/// form).
+fn cover_object_slot(
+    index: &ChunkSelectorIndex,
+    decl: &IndexedDeclaration,
+    target: &SynthesizedTargetBinding,
+    ranked: &[AnchorSpan],
+    render_with: &impl Fn(&BTreeSet<AnchorSpan>) -> Result<String>,
+) -> Result<Option<SpecializedSelector>> {
+    let targets = std::slice::from_ref(target);
+    let mut kept: BTreeSet<AnchorSpan> = BTreeSet::new();
+    while prove_synthesized_selector(index, decl, targets, &render_with(&kept)?).is_err() {
+        // Score a trial by `(target slot not yet resolved, total matches)`; a
+        // smaller score is better, so an anchor that makes the target binding the
+        // resolved one and rules out the most competitors wins.
+        let mut best: Option<((bool, usize), AnchorSpan)> = None;
+        for &anchor in ranked.iter().take(MAX_MINIMIZER_ANCHORS) {
+            if kept.contains(&anchor) {
+                continue;
+            }
+            let mut trial = kept.clone();
+            trial.insert(anchor);
+            let matches =
+                matched_binding_candidates(index, &target.export_name, &render_with(&trial)?)?;
+            let target_unresolved = !matches.iter().any(|m| {
+                m.body_idx == decl.body_idx && m.binding.binding_name == target.runtime_binding
+            });
+            let score = (target_unresolved, matches.len());
+            if best.is_none_or(|(best_score, _)| score < best_score) {
+                best = Some((score, anchor));
+            }
+        }
+        // No remaining anchor to add: the target's own keys/values cannot single
+        // out its slot. Defer to the caller.
+        let Some((_, anchor)) = best else {
+            return Ok(None);
+        };
+        kept.insert(anchor);
+    }
+    finish_minimized_selector(index, decl, target, render_with(&kept)?)
+}
+
+/// Read off a minimal selector for a single-target `var`/`let`/`const` whose
+/// target declarator value is an object literal (W3 + key-set minimization).
+///
+/// Handles the single-target object whether it stands alone or sits inside a
+/// multi-declarator group (one target slot, `DECLARATORS_*` holes for the rest).
+/// Two passes, both rendering through one slot-aware `render_with` that holes the
+/// object with [`hole_object_padded`] (interleaved `OBJECT_PROPS`) so the kept key
+/// subset survives key reorder:
+///
+///   1. **Read-off.** The chunk-wide shape index ranks the statement's own
+///      features by selective × stable, so a globally-rare discriminating
+///      key/value wins. Its kept spans are restricted to the target declarator (a
+///      group's anchor set may name a key carried only by a *sibling* declarator
+///      this selector holes away), and the matcher proves the restricted pin.
+///   2. **Cover fallback.** A matcher-driven minimal cover over the target
+///      object's own keys (and direct literal values) — the key-set analogue of
+///      greedy set-cover: anchor the rarest discriminating keys, `OBJECT_PROPS`
+///      the common ones. This is what singles out a target object inside a
+///      multi-declarator group, where the chunk-wide read-off cannot see the
+///      per-slot key sets.
+///
+/// Returns `None` — so the caller falls back to the keep-shallow group path —
+/// when the target is not a single object declarator or neither pass resolves it.
+fn try_object_read_off(
     index: &ChunkSelectorIndex,
     var: &VarDecl,
     decl: &IndexedDeclaration,
     targets: &[SynthesizedTargetBinding],
     target_slots: &BTreeSet<usize>,
 ) -> Result<Option<SpecializedSelector>> {
-    // Only the genuine single-declarator case: one target binding and one
-    // declarator in the whole var. A multi-declarator group (even with a single
-    // target slot) needs the `DECLARATORS_*` holes the group path renders, so it
-    // stays unmigrated (later wave).
+    // Only the single-target case (one binding). A multi-target group needs the
+    // tuple-resolving binding-group path; this owns the single object slot.
     let [target] = targets else {
         return Ok(None);
     };
-    if var.decls.len() != 1 || target_slots.len() != 1 {
+    if target_slots.len() != 1 {
         return Ok(None);
     }
-    let declarator = &var.decls[0];
+    let target_slot = *target_slots.iter().next().expect("one target slot");
+    let declarator = &var.decls[target_slot];
     let Some(Expr::Object(object)) = declarator.init.as_deref() else {
         return Ok(None);
     };
+    let target_decl_span = declarator.span();
 
+    // Slot-aware render: `DECLARATORS_*` holes for the non-target declarators
+    // (none when the target stands alone), the target's object holed to its kept
+    // keys padded + interleaved with `OBJECT_PROPS`.
     let render_with = |kept: &BTreeSet<AnchorSpan>| -> Result<String> {
-        let mut holed = declarator.clone();
-        holed.name = named_pat(&target.export_name);
-        holed.init = Some(Box::new(Expr::Object(hole_object_padded(object, kept))));
+        let mut decls: Vec<VarDeclarator> = Vec::new();
+        let mut skipped_run = false;
+        let mut target_seen = 0usize;
+        for (idx, other) in var.decls.iter().enumerate() {
+            if idx != target_slot {
+                skipped_run = true;
+                continue;
+            }
+            if skipped_run {
+                decls.push(declarator_hole(declarator_hole_name(target_seen, 1)));
+                skipped_run = false;
+            }
+            let mut holed = other.clone();
+            holed.name = named_pat(&target.export_name);
+            holed.init = Some(Box::new(Expr::Object(hole_object_padded(object, kept))));
+            decls.push(holed);
+            target_seen += 1;
+        }
+        if skipped_run {
+            decls.push(declarator_hole(declarator_hole_name(target_seen, 1)));
+        }
         let mut holed_var = var.clone();
         holed_var.declare = false;
-        holed_var.decls = vec![holed];
+        holed_var.decls = decls;
         emit_selector(ModuleItem::Stmt(Stmt::Decl(Decl::Var(Box::new(holed_var)))))
     };
 
-    let anchor_set = index.shape_index.minimal_anchor_set(decl.body_idx);
-    let Some(anchor_set) = anchor_set else {
-        return Ok(None);
-    };
-    let item = index
-        .parsed
-        .module
-        .body
-        .get(decl.body_idx)
-        .context("read-off body index no longer in module")?;
-    let kept = kept_spans_for_anchor_set(item, &anchor_set);
-    // A structural / skeleton-only read-off keeps no concrete object token: the
-    // padded scaffold would be `{ OBJECT_PROPS, OBJECT_PROPS }`, which pins
-    // nothing about the object and is no leaner than the group path's form.
-    // Defer to the group path so the migration only owns the value-anchored case.
-    if kept.is_empty() {
-        return Ok(None);
+    if let Some(anchor_set) = index.shape_index.minimal_anchor_set(decl.body_idx) {
+        let item = index
+            .parsed
+            .module
+            .body
+            .get(decl.body_idx)
+            .context("read-off body index no longer in module")?;
+        let kept: BTreeSet<AnchorSpan> = kept_spans_for_anchor_set(item, &anchor_set)
+            .into_iter()
+            .filter(|span| node_holds_anchor(target_decl_span, *span))
+            .collect();
+        if !kept.is_empty()
+            && let Some(selector) =
+                finish_minimized_selector(index, decl, target, render_with(&kept)?)?
+        {
+            return Ok(Some(selector));
+        }
     }
-    finish_minimized_selector(index, decl, target, render_with(&kept)?)
+
+    cover_object_slot(
+        index,
+        decl,
+        target,
+        &object_anchor_ranking(object),
+        &render_with,
+    )
 }
 
 /// Minimal anchor cover for a `var`/`let`/`const` binding group: render the
@@ -2270,13 +2412,15 @@ fn minimize_var_group_selector(
         return Ok(None);
     }
 
-    // W3: single-target var whose value is an object literal reads its minimal
-    // selector off the shape index — `OBJECT_PROPS` holes around the
-    // discriminating key(s) instead of keeping every key (the
-    // `object_keys_over_pinned` over-pin). The matcher proves it (gate 1); on
-    // `None` we fall through to the keep-shallow group path below, so a target
-    // the read-off cannot single out is handled exactly as before.
-    if let Some(selector) = try_single_object_read_off(index, var, decl, targets, &target_slots)? {
+    // W3 + key-set minimization: a single-target var whose target declarator is
+    // an object literal reads its minimal selector off the shape index, then
+    // (slot-aware) covers the target object's own keys — `OBJECT_PROPS` holes
+    // around the discriminating key subset instead of keeping every key (the
+    // `object_keys_over_pinned` / key-set group over-pin). Works whether the
+    // object stands alone or sits inside a multi-declarator group. The matcher
+    // proves it (gate 1); on `None` we fall through to the keep-shallow group path
+    // below, so a target neither pass can single out is handled exactly as before.
+    if let Some(selector) = try_object_read_off(index, var, decl, targets, &target_slots)? {
         return Ok(Some(selector));
     }
 


### PR DESCRIPTION
When an object is discriminated by its key set rather than any value
(every value already holed to ANYTHING — e.g. a CSS-styles dict), the
minimizer kept every key. It now keeps only the minimal discriminating
key subset and collapses the rest to OBJECT_PROPS.

- hole_object_padded interleaves OBJECT_PROPS between every kept prop
  (not just the edges), so a minimal key *set* matches as independent
  interior subsequence elements — surviving key reorder and gaps. This
  alone fixes single-declarator multi-key key-sets (the old edge-only
  padding required kept keys to stay adjacent, failing the matcher gate
  and falling back to keeping every key).
- try_object_read_off (was try_single_object_read_off) now handles the
  object whether it stands alone or sits in a multi-declarator group
  (one target slot, DECLARATORS_* holes for the rest) — the per-declarator
  case the issue flags. It reads anchors off the chunk-wide shape index
  first, then falls back to cover_object_slot: a slot-aware greedy that
  scores trials by whether the target binding's own declarator slot
  resolves (the matcher reports one alignment per body, so a key shared
  with an earlier sibling slot resolves there, not the target), then by
  match count. This is the per-slot key-set view the chunk-wide read-off
  cannot see.

Unignores grouped_enum_objects (now handled by the slot-aware cover) and
adds object_key_set_group / object_key_set_subset E2E cases. Full
debundle suite green.

BAZEL_TEST_INVOCATIONS=buildbuddy:dfedbf61-70f8-4ed6-a520-3b5470def980

https://claude.ai/code/session_01HDZjyEfG9ccZzAPEBbWN2w