### PR TITLE
debundle: index-build perf — sorted Vec<u32> postings + FxHashMap (#2291)

### DIFF
--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -73,6 +73,7 @@ rust_library(
         ":source_match_holes",
         ":spec",
         "@crates//:anyhow",
+        "@crates//:rustc-hash",
         "@crates//:swc_ecma_ast",
         "@crates//:swc_ecma_visit",
     ],
@@ -98,6 +99,7 @@ rust_library(
     deps = [
         ":js_ast",
         ":selector_candidate_index",
+        "@crates//:rustc-hash",
         "@crates//:swc_ecma_ast",
     ],
 )

--- a/devinfra/js/debundle/debug/selector_minimizer_dogfood.md
+++ b/devinfra/js/debundle/debug/selector_minimizer_dogfood.md
@@ -73,3 +73,27 @@ near the parse/index floor plus cheap per-member work.
   the candidate-index intersection is a singleton `{target}` for the overwhelming
   majority of members, so the matcher proves uniqueness by inspecting one item and
   the residual per-member cost is negligible.
+
+## Index-build perf (#2291, posting lists as sorted `Vec<u32>` + `FxHashMap`)
+
+Same `-c opt` whole-chunk dry-run as above, on the **current** spec (the
+dogfood-apply backlog has since converted ~half the name-pins, so the spec now
+reports **2,227** `name_binding_members`, not the 4,506 of the table above —
+fewer members to minimize, so even the unmodified binary is already under the
+≤10s ideal). To isolate the data-structure change from the spec-size change,
+both binaries were built `-c opt` and run back-to-back on this same spec
+(`static/index-DI2GynTv.js`, `time.perf_counter` × 3, `RUSAGE_CHILDREN`):
+
+| binary                           | whole chunk (median) | best  | peak RSS |
+| -------------------------------- | -------------------- | ----- | -------- |
+| before (`BTreeMap`/`BTreeSet`)   | 8.2 s                | 7.4 s | ~243 MB  |
+| after (`FxHashMap`/sorted `Vec`) | 7.0 s                | 6.6 s | ~222 MB  |
+
+≈ **15% wall-clock** and **~21 MB peak RSS** off the whole chunk (the smaller
+`Vec<u32>` posting lists replace the many small `BTreeSet` nodes). The largest
+single scope (`features`, 1,037 members both runs) drops 4.0 s → 3.7 s best. The
+isolated index-build + read-off lever is larger (≈1.9× build / 3.7× read-off on
+the synthetic sweep — see <selector_minimizer_perf.md>); on the real chunk the
+fixed swc parse of the 7 MB chunk and the per-member render/prove work dilute it,
+but both phases the change touches got materially cheaper and the ≤10s ideal is
+met with margin.

--- a/devinfra/js/debundle/debug/selector_minimizer_perf.md
+++ b/devinfra/js/debundle/debug/selector_minimizer_perf.md
@@ -88,3 +88,39 @@ only ~6% on `app` — #2280 did its job. What dominates is:
 
 Any one of (1)–(2) should recover the last ~3s to the ≤10s ideal; (1) is the
 highest-leverage and most self-contained.
+
+## Resolution (#2291): sorted `Vec<u32>` posting lists + `FxHashMap`
+
+Landed targets **(1)**, **(3)**, and **(4)** — the self-contained data-structure
+swap, no feature-label interning needed:
+
+- **Posting lists / candidate sets are now ascending-sorted `Vec<u32>`**
+  (`CandidateSet` in `selector_candidate_index.rs`), built in one pass via
+  `push_ascending` (body indices arrive in order, so no per-element insert/sort).
+  Intersection is a two-pointer linear merge into a **reused scratch buffer**;
+  the greedy read-off ranks candidate features by `intersection_len` (count-only,
+  no allocation) and materializes only the winner. This removes the
+  `BTreeMap::Iter::next` / `IntoIter::dying_next` / `Drop` / `from_iter` cost and
+  most of the small-node allocator churn.
+- **The inverted indices are `FxHashMap`** (`feature_to_body_indices`,
+  `ShapeIndex::postings`, and the `ShapeInterner` hash-cons table `by_node`) —
+  ordered iteration was never needed, so hashing removes the `SelectorFeature` /
+  `ShapeFeature` / `ShapeNode` `Ord::cmp` (String-label `memcmp`) and the
+  tree-rebalance cost from every build insert and lookup.
+
+The feature taxonomy and posting-list **contents** are unchanged (same
+`distinct_shapes` / `posting_entries`, same `OPT=1` distribution), so the read-off
+results are identical — only the representation is faster. Soundness stays gated
+by `shape_index_soundness_test.rs`.
+
+**Measured.** Synthetic `shape_index_bench` (isolated index-build + read-off
+lever), `-c opt`:
+
+| N    | build before | build after | read-off before | read-off after |
+| ---- | ------------ | ----------- | --------------- | -------------- |
+| 200  | 0.0067 ms/it | 0.0038      | 1.61 µs/it      | 0.72           |
+| 1000 | 0.0069 ms/it | 0.0039      | 3.26 µs/it      | 1.06           |
+| 4000 | 0.0081 ms/it | 0.0042      | 8.82 µs/it      | 2.41           |
+
+≈ **1.9× faster index build** and **3.7× faster read-off** at N=4000. Real-chunk
+same-spec whole-chunk wall-clock and peak RSS in <selector_minimizer_dogfood.md>.

--- a/devinfra/js/debundle/plans/readoff_minimization.md
+++ b/devinfra/js/debundle/plans/readoff_minimization.md
@@ -150,7 +150,11 @@ removed.
 **Measured perf.** Whole ~7 MB / ~4.5k-member chunk minimizes in **~13 s** with
 the prove-gate-via-index fast-path (#2280), down from ~110 s — **meets the ≤30 s
 hard budget**, narrowly over the ≤10 s ideal (per-member ~0.0027 s, ~9× cheaper).
-Full scope table in <../debug/selector_minimizer_dogfood.md>.
+Full scope table in <../debug/selector_minimizer_dogfood.md>. #2291 then closed
+the index-build cost (posting lists as sorted `Vec<u32>` + `FxHashMap` inverted
+indices): ≈1.9× faster build / 3.7× faster read-off on the synthetic sweep, and on
+the current (smaller, partly dogfood-applied) spec the whole chunk minimizes in
+**~7 s**, comfortably under the ≤10 s ideal.
 
 **E2E expectation suite** (`e2e/selector_minimizer_expectation_test.rs`). Active:
 `sparse_function_body`, `call_argument_literal`, `object_property_literals`,
@@ -300,7 +304,15 @@ non-minimal pattern catalog drives this and is encoded as disabled E2E cases.
     posting-list `BTreeMap`/`BTreeSet` for a hashed map (`FxHashMap`/`FxHashSet`)
     where ordered iteration isn't required; (c) reserve/amortise allocations in
     `SelectorCandidateIndex::new` / `ShapeIndex::with_extractor`. Any one likely
-    recovers the last ~3s.
+    recovers the last ~3s. **(Landed: #2291 — did (b)+(c) plus sorted-`Vec<u32>`
+    posting lists with reused-scratch linear-merge intersection; (a) interning was
+    not needed. Posting lists/candidate sets are now ascending-sorted `Vec<u32>`
+    (`CandidateSet`), the inverted indices + hash-cons table are `FxHashMap`.
+    Measured: ≈1.9× faster index build / 3.7× faster read-off on the synthetic
+    sweep; real-chunk same-spec whole-chunk ~8.2s → ~7.0s median with ~21 MB less
+    peak RSS. Identical posting contents / `OPT=1` distribution; soundness stays
+    gated by `shape_index_soundness_test.rs`. See
+    <../debug/selector_minimizer_perf.md>.)**
 13. **Dogfood-apply on gaffer-private (in progress).** Run `synthesize-selectors
 --apply` on the real spec, review for over-pin, and PR the beneficial minimized
     selectors (fragile minified-name pins → forward-compatible `source_match`). On

--- a/devinfra/js/debundle/selector_candidate_index.rs
+++ b/devinfra/js/debundle/selector_candidate_index.rs
@@ -7,9 +7,11 @@
 //! lists. A returned candidate set may contain false positives; it must not
 //! omit a real matcher result.
 
+use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
 
 use anyhow::{Context, Result};
+use rustc_hash::FxHashMap;
 use source_match_holes::{
     ANYTHING_HOLE_KEYWORD, CASE_REST_HOLE_KEYWORD, CLASS_REST_HOLE_KEYWORD,
     DECLARATORS_HOLE_KEYWORD, EXPR_HOLE_KEYWORD, OBJECT_PROPS_HOLE_KEYWORD, STMT_HOLE_KEYWORD,
@@ -19,7 +21,7 @@ use spec::{AnonymousStatementSelector, BindingSourceKind, SourceMatchIdentifierM
 use swc_ecma_ast::*;
 use swc_ecma_visit::{Visit, VisitWith};
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum TopLevelKind {
     ImportDeclaration,
     FunctionDeclaration,
@@ -33,14 +35,14 @@ pub enum TopLevelKind {
     ModuleDeclaration,
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum VarKind {
     Var,
     Let,
     Const,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum SelectorFeature {
     TopLevelKind(TopLevelKind),
     VarKind(VarKind),
@@ -76,20 +78,50 @@ pub struct IndexedTopLevelCandidate {
     pub features: BTreeSet<SelectorFeature>,
 }
 
+/// A set of top-level body indices, stored as an ascending-sorted, de-duplicated
+/// `Vec<u32>`. Body indices are dense small integers `0..N`, so a sorted vector
+/// makes intersection a linear two-pointer merge (no per-element allocation or
+/// ordered-tree traversal) and keeps the whole set in one contiguous allocation —
+/// the index-build perf lever for whole-chunk minimize (issue #2291).
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
 pub struct CandidateSet {
-    body_indices: BTreeSet<usize>,
+    body_indices: Vec<u32>,
 }
 
 impl CandidateSet {
+    /// The empty set as a `const`, so callers can hand out a `&'static` empty
+    /// posting list without allocating.
+    pub const EMPTY: CandidateSet = CandidateSet {
+        body_indices: Vec::new(),
+    };
+
     pub fn all(body_indices: impl IntoIterator<Item = usize>) -> Self {
-        Self {
-            body_indices: body_indices.into_iter().collect(),
-        }
+        Self::from_unsorted(body_indices.into_iter().map(|idx| idx as u32).collect())
     }
 
     pub fn empty() -> Self {
         Self::default()
+    }
+
+    /// Build from possibly-unsorted, possibly-duplicated indices.
+    fn from_unsorted(mut body_indices: Vec<u32>) -> Self {
+        body_indices.sort_unstable();
+        body_indices.dedup();
+        Self { body_indices }
+    }
+
+    /// Append a body index that is strictly greater than every index appended so
+    /// far. The index builders walk body items in order, so each posting list is
+    /// produced already ascending and unique — this keeps the invariant without a
+    /// trailing sort. Cheaper than `BTreeSet::insert` (no node allocation).
+    pub fn push_ascending(&mut self, body_idx: usize) {
+        debug_assert!(
+            self.body_indices
+                .last()
+                .is_none_or(|&last| (body_idx as u32) > last),
+            "push_ascending requires strictly increasing indices"
+        );
+        self.body_indices.push(body_idx as u32);
     }
 
     pub fn len(&self) -> usize {
@@ -101,22 +133,69 @@ impl CandidateSet {
     }
 
     pub fn contains(&self, body_idx: usize) -> bool {
-        self.body_indices.contains(&body_idx)
+        u32::try_from(body_idx).is_ok_and(|idx| self.body_indices.binary_search(&idx).is_ok())
     }
 
     pub fn body_indices(&self) -> impl Iterator<Item = usize> + '_ {
-        self.body_indices.iter().copied()
+        self.body_indices.iter().map(|&idx| idx as usize)
     }
 
     pub fn intersect(&self, other: &CandidateSet) -> CandidateSet {
-        CandidateSet {
-            body_indices: self
-                .body_indices
-                .intersection(&other.body_indices)
-                .copied()
-                .collect(),
+        let mut out = CandidateSet::empty();
+        self.intersect_into(other, &mut out);
+        out
+    }
+
+    /// Intersect into a reusable buffer (cleared first), so a per-member loop can
+    /// keep one scratch set instead of allocating a fresh one each step.
+    pub fn intersect_into(&self, other: &CandidateSet, out: &mut CandidateSet) {
+        sorted_intersect_into(
+            &self.body_indices,
+            &other.body_indices,
+            &mut out.body_indices,
+        );
+    }
+
+    /// Size of the intersection without materializing it — for ranking candidate
+    /// features by how much they shrink the working set.
+    pub fn intersection_len(&self, other: &CandidateSet) -> usize {
+        sorted_intersection_len(&self.body_indices, &other.body_indices)
+    }
+}
+
+/// Two-pointer intersection of two ascending-sorted slices into `out` (cleared
+/// first). Result stays ascending-sorted and de-duplicated.
+fn sorted_intersect_into(a: &[u32], b: &[u32], out: &mut Vec<u32>) {
+    out.clear();
+    let (mut i, mut j) = (0, 0);
+    while i < a.len() && j < b.len() {
+        match a[i].cmp(&b[j]) {
+            Ordering::Less => i += 1,
+            Ordering::Greater => j += 1,
+            Ordering::Equal => {
+                out.push(a[i]);
+                i += 1;
+                j += 1;
+            }
         }
     }
+}
+
+/// Count of common elements in two ascending-sorted slices, without allocating.
+fn sorted_intersection_len(a: &[u32], b: &[u32]) -> usize {
+    let (mut i, mut j, mut count) = (0, 0, 0);
+    while i < a.len() && j < b.len() {
+        match a[i].cmp(&b[j]) {
+            Ordering::Less => i += 1,
+            Ordering::Greater => j += 1,
+            Ordering::Equal => {
+                count += 1;
+                i += 1;
+                j += 1;
+            }
+        }
+    }
+    count
 }
 
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
@@ -164,21 +243,21 @@ pub struct BindingProjection {
 
 pub struct SelectorCandidateIndex {
     items: Vec<IndexedTopLevelCandidate>,
-    feature_to_body_indices: BTreeMap<SelectorFeature, BTreeSet<usize>>,
+    feature_to_body_indices: FxHashMap<SelectorFeature, CandidateSet>,
 }
 
 impl SelectorCandidateIndex {
     pub fn new(module: &Module) -> Self {
-        let mut items = Vec::new();
-        let mut feature_to_body_indices: BTreeMap<SelectorFeature, BTreeSet<usize>> =
-            BTreeMap::new();
+        let mut items = Vec::with_capacity(module.body.len());
+        let mut feature_to_body_indices: FxHashMap<SelectorFeature, CandidateSet> =
+            FxHashMap::default();
         for (body_idx, item) in module.body.iter().enumerate() {
             let indexed = IndexedTopLevelCandidate::from_module_item(body_idx, item);
             for feature in &indexed.features {
                 feature_to_body_indices
                     .entry(feature.clone())
                     .or_default()
-                    .insert(body_idx);
+                    .push_ascending(body_idx);
             }
             items.push(indexed);
         }
@@ -197,42 +276,40 @@ impl SelectorCandidateIndex {
     }
 
     pub fn candidate_set_for_feature(&self, feature: &SelectorFeature) -> CandidateSet {
-        CandidateSet {
-            body_indices: self
-                .feature_to_body_indices
-                .get(feature)
-                .cloned()
-                .unwrap_or_default(),
-        }
+        self.feature_to_body_indices
+            .get(feature)
+            .cloned()
+            .unwrap_or_default()
     }
 
     pub fn candidate_set_for_features<'a>(
         &self,
         features: impl IntoIterator<Item = &'a SelectorFeature>,
     ) -> CandidateSet {
-        let mut postings = features
+        // A feature absent from the index has an empty posting list, so the whole
+        // intersection is empty; no features at all means every item qualifies.
+        let postings: Option<Vec<&CandidateSet>> = features
             .into_iter()
-            .map(|feature| {
-                self.feature_to_body_indices
-                    .get(feature)
-                    .map(|body_indices| (feature, body_indices))
-            })
-            .collect::<Option<Vec<_>>>();
-        let Some(mut postings) = postings.take() else {
+            .map(|feature| self.feature_to_body_indices.get(feature))
+            .collect();
+        let Some(mut postings) = postings else {
             return CandidateSet::empty();
         };
-        postings.sort_by_key(|(_, body_indices)| body_indices.len());
-        let Some((_, first)) = postings.first() else {
+        postings.sort_by_key(|posting| posting.len());
+        let Some((first, rest)) = postings.split_first() else {
             return CandidateSet::all(self.items.iter().map(|item| item.body_idx));
         };
-        let mut body_indices = (*first).clone();
-        for (_, next) in postings.into_iter().skip(1) {
-            body_indices = body_indices.intersection(next).copied().collect();
-            if body_indices.is_empty() {
+        // Intersect smallest-first into a reused scratch buffer.
+        let mut acc = (*first).clone();
+        let mut scratch = CandidateSet::empty();
+        for next in rest.iter().copied() {
+            acc.intersect_into(next, &mut scratch);
+            std::mem::swap(&mut acc, &mut scratch);
+            if acc.is_empty() {
                 break;
             }
         }
-        CandidateSet { body_indices }
+        acc
     }
 
     pub fn query_for_source_match(
@@ -255,14 +332,16 @@ impl SelectorCandidateIndex {
         if query.alternatives.is_empty() {
             return CandidateSet::empty();
         }
-        let mut body_indices = BTreeSet::new();
+        // Union the per-alternative candidate sets.
+        let mut merged = Vec::new();
         for alternative in &query.alternatives {
-            body_indices.extend(
-                self.candidate_set_for_features(&alternative.features)
+            merged.extend_from_slice(
+                &self
+                    .candidate_set_for_features(&alternative.features)
                     .body_indices,
             );
         }
-        CandidateSet { body_indices }
+        CandidateSet::from_unsorted(merged)
     }
 
     pub fn candidate_set_for_source_match(

--- a/devinfra/js/debundle/shape_index.rs
+++ b/devinfra/js/debundle/shape_index.rs
@@ -44,9 +44,12 @@
 //! the opaque feature set the extractor emits, so a later wave can swap in a
 //! hedge-automaton extractor without touching them.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 
-use selector_candidate_index::{IndexedTopLevelCandidate, SelectorCandidateIndex, SelectorFeature};
+use rustc_hash::FxHashMap;
+use selector_candidate_index::{
+    CandidateSet, IndexedTopLevelCandidate, SelectorCandidateIndex, SelectorFeature,
+};
 use swc_ecma_ast::*;
 
 /// Canonical identity of an alpha-equivalent subtree shape. Two subtrees share
@@ -124,7 +127,7 @@ struct ShapeNode {
 /// whole DAG is O(N) in chunk size.
 #[derive(Debug, Default)]
 pub struct ShapeInterner {
-    by_node: BTreeMap<ShapeNode, ShapeId>,
+    by_node: FxHashMap<ShapeNode, ShapeId>,
     /// Per-shape multiplicity across everything interned so far. The collision
     /// count is exactly the per-shape selectivity signal (free byproduct).
     multiplicity: Vec<u32>,
@@ -521,7 +524,7 @@ fn prop_name_string(name: &PropName) -> Option<String> {
 /// [`SelectorFeature`]s (literals, keys, member/callee names, kinds) or a
 /// bounded-depth shape skeleton id. Tagging them in one enum lets the greedy
 /// cover rank heterogeneous features uniformly by `(selectivity, stability)`.
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum ShapeFeature {
     Selector(SelectorFeature),
     Skeleton(ShapeId),
@@ -573,8 +576,10 @@ pub struct ShapeIndex {
     items: Vec<ShapeIndexedItem>,
     interner: ShapeInterner,
     /// feature -> set of item body indices exhibiting it (inverted index).
-    /// Covers both selector features and shape skeletons.
-    postings: BTreeMap<ShapeFeature, BTreeSet<usize>>,
+    /// Covers both selector features and shape skeletons. Hashed (no ordered
+    /// iteration needed) with sorted-`Vec` posting lists for cheap build +
+    /// intersection (issue #2291).
+    postings: FxHashMap<ShapeFeature, CandidateSet>,
 }
 
 impl ShapeIndex {
@@ -585,7 +590,7 @@ impl ShapeIndex {
     pub fn with_extractor(module: &Module, extractor: &dyn ShapeFeatureExtractor) -> Self {
         let prefilter = SelectorCandidateIndex::new(module);
         let mut interner = ShapeInterner::default();
-        let mut postings: BTreeMap<ShapeFeature, BTreeSet<usize>> = BTreeMap::new();
+        let mut postings: FxHashMap<ShapeFeature, CandidateSet> = FxHashMap::default();
         let mut items = Vec::with_capacity(module.body.len());
 
         for (body_idx, module_item) in module.body.iter().enumerate() {
@@ -597,14 +602,14 @@ impl ShapeIndex {
                 postings
                     .entry(ShapeFeature::Selector(feature.clone()))
                     .or_default()
-                    .insert(body_idx);
+                    .push_ascending(body_idx);
             }
             let skeletons = extractor.shape_features(module_item, &mut interner);
             for &shape in &skeletons {
                 postings
                     .entry(ShapeFeature::Skeleton(shape))
                     .or_default()
-                    .insert(body_idx);
+                    .push_ascending(body_idx);
             }
             items.push(ShapeIndexedItem {
                 candidate,
@@ -641,8 +646,8 @@ impl ShapeIndex {
         self.items.get(body_idx).map(|item| &item.candidate)
     }
 
-    fn posting(&self, feature: &ShapeFeature) -> &BTreeSet<usize> {
-        static EMPTY: BTreeSet<usize> = BTreeSet::new();
+    fn posting(&self, feature: &ShapeFeature) -> &CandidateSet {
+        static EMPTY: CandidateSet = CandidateSet::EMPTY;
         self.postings.get(feature).unwrap_or(&EMPTY)
     }
 
@@ -726,7 +731,7 @@ impl ShapeIndex {
         if let Some(top) = scored.first()
             && self.posting(&top.feature).len() == 1
         {
-            debug_assert!(self.posting(&top.feature).contains(&body_idx));
+            debug_assert!(self.posting(&top.feature).contains(body_idx));
             return Some(AnchorSet {
                 body_idx,
                 anchors: vec![top.clone()],
@@ -748,34 +753,31 @@ impl ShapeIndex {
         // items pay O(smallest posting) per step rather than O(N).
         let mut remaining = scored;
         let seed = remaining.first()?;
-        let mut covered: BTreeSet<usize> = self.posting(&seed.feature).clone();
+        let mut covered = self.posting(&seed.feature).clone();
         let mut chosen: Vec<ScoredFeature> = vec![remaining.remove(0)];
+        let mut scratch = CandidateSet::empty();
 
         while covered.len() > 1 {
-            let best = remaining
+            // The feature that shrinks the candidate set the most; ranked by
+            // intersection size only (no allocation), ties broken toward the
+            // better-ranked feature (lower index). Only the winner is then
+            // materialized, into the reused scratch buffer.
+            let (best_i, best_len) = remaining
                 .iter()
                 .enumerate()
-                .map(|(i, f)| {
-                    let next: BTreeSet<usize> = covered
-                        .intersection(self.posting(&f.feature))
-                        .copied()
-                        .collect();
-                    (i, next)
-                })
-                // The feature that shrinks the candidate set the most; ties
-                // broken toward the better-ranked feature (lower index).
-                .min_by(|(ai, a), (bi, b)| a.len().cmp(&b.len()).then(ai.cmp(bi)))?;
-            let (best_i, next_covered) = best;
+                .map(|(i, f)| (i, covered.intersection_len(self.posting(&f.feature))))
+                .min_by(|(ai, a), (bi, b)| a.cmp(b).then(ai.cmp(bi)))?;
             // No feature makes progress: the target is not separable by its own
             // features. Report "unminimizable" rather than loop forever.
-            if next_covered.len() == covered.len() {
+            if best_len == covered.len() {
                 return None;
             }
-            covered = next_covered;
+            covered.intersect_into(self.posting(&remaining[best_i].feature), &mut scratch);
+            std::mem::swap(&mut covered, &mut scratch);
             chosen.push(remaining.remove(best_i));
         }
 
-        (covered == BTreeSet::from([body_idx])).then_some(AnchorSet {
+        (covered.len() == 1 && covered.contains(body_idx)).then_some(AnchorSet {
             body_idx,
             opt_one: chosen.len() == 1,
             anchors: chosen,
@@ -999,14 +1001,11 @@ const c = other("third-token");"#,
         /// exactly `{body_idx}` (the index-level uniqueness check; the matcher
         /// is the production gate, exercised in the integration test crate).
         fn read_off_resolves_uniquely(&self, body_idx: usize, anchor: &AnchorSet) -> bool {
-            let mut covered: BTreeSet<usize> = (0..self.items.len()).collect();
+            let mut covered = CandidateSet::all(0..self.items.len());
             for scored in &anchor.anchors {
-                covered = covered
-                    .intersection(self.posting(&scored.feature))
-                    .copied()
-                    .collect();
+                covered = covered.intersect(self.posting(&scored.feature));
             }
-            covered == BTreeSet::from([body_idx])
+            covered.len() == 1 && covered.contains(body_idx)
         }
     }
 


### PR DESCRIPTION
Whole-chunk selector minimize spent its remaining time in the index build,
not parsing or the prove-gate (callgrind: BTreeMap/BTreeSet traversal +
small-node allocator churn + String-label Ord::cmp). Swap the index data
structures, no behavior change:

- Posting lists / candidate sets are ascending-sorted Vec<u32> (CandidateSet),
  built in one pass via push_ascending; intersection is a two-pointer linear
  merge into a reused scratch buffer. The greedy read-off ranks features by
  intersection_len (count-only) and materializes only the winner.
- The inverted indices and the shape hash-cons table are FxHashMap (ordered
  iteration was never needed), removing the feature/ShapeNode Ord::cmp cost.

Posting contents and the OPT=1 distribution are unchanged, so read-off results
are identical; soundness stays gated by shape_index_soundness_test.rs. All 83
affected debundle rust_test targets pass.

Measured: ~1.9x faster index build / ~3.7x faster read-off on the synthetic
shape_index_bench; real-chunk same-spec whole-chunk ~8.2s -> ~7.0s median with
~21 MB less peak RSS, comfortably under the <=10s ideal (plan backlog item 12).

https://claude.ai/code/session_01C6qHhDd6YqwWsUGfMBPnGt