### PR TITLE
debundle: interior holing of nested array literals within kept statements

### DIFF
--- a/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
+++ b/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
@@ -591,7 +591,6 @@ minimizer_expectation_case!(
 // already; the gap is holing INTO nested object/array literals within a kept
 // expression.
 minimizer_expectation_case!(
-    #[ignore = "nested object literal in a kept call arg pins every property; non-anchor props should hole to OBJECT_PROPS"]
     minimizes_interior_object_arg_holing,
     fixture = "interior_object_arg_holing",
     name = "nested object in a kept call arg keeps only the discriminating property, OBJECT_PROPS for the rest",

--- a/devinfra/js/debundle/plans/readoff_minimization.md
+++ b/devinfra/js/debundle/plans/readoff_minimization.md
@@ -167,10 +167,13 @@ the current (smaller, partly dogfood-applied) spec the whole chunk minimizes in
 `binding_group_declarators`, `nested_async_try`, `class_body`, `switch_case_run`,
 `object_keys_over_pinned`, `long_literal_value_anchor`, `binding_group_partition`,
 `class_among_many_siblings`, `sibling_subclass_hierarchy`, `adjacent_accessor_group`,
-and (unignored once the object key-set cover landed) `grouped_enum_objects`,
-`object_key_set_group`, `object_key_set_subset`. Ignored as aspirational (the named
-form not yet read-off-expressible): `sequential_assignment_block`,
-`deeply_nested_call_args`, `object_nested_value_dict`, `wide_destructure_block`.
+`interior_object_arg_holing` (unignored once the `Expr::Array` interior holing
+landed, #2289), and (unignored once the object key-set cover landed)
+`grouped_enum_objects`, `object_key_set_group`, `object_key_set_subset`. Ignored as
+aspirational (the named form not yet read-off-expressible):
+`sequential_assignment_block`, `deeply_nested_call_args`, `object_nested_value_dict`,
+`wide_destructure_block`, `single_target_class_whole_body`,
+`component_wide_destructure_whole_body`.
 
 ## Acceptance criteria
 
@@ -251,22 +254,38 @@ non-minimal pattern catalog drives this and is encoded as disabled E2E cases.
    _call-chain links_, and _callbacks_ when a sparse anchor exists: with a clean
    discriminator a `svc.fetchToken().then(…).catch(e => {…})` chain correctly
    minimizes to `ANYTHING.then((ANYTHING) => { <anchor> }).catch(ANYTHING)` (the
-   non-discriminating catch callback holes to `ANYTHING`). Two gaps remain:
-   - **Nested object / array literals inside a kept expression are pinned whole**
+   non-discriminating catch callback holes to `ANYTHING`). Two gaps:
+   - **Nested object / array literals inside a kept expression were pinned whole**
      rather than holed to `OBJECT_PROPS` / `ARGS` around the discriminating
-     element. Demonstrated by `interior_object_arg_holing`: the move-options object
-     in a kept `engine.run([{…}])` keeps every property instead of
-     `[{ OBJECT_PROPS, mode: "…", OBJECT_PROPS }]`. (Real-spec analogues:
-     `moveProcessedInboxAudioNodeToTarget`, the `Se({…})` command objects.) Fix:
-     extend the kept-span prune to recurse into object/array literals, holing
-     maximal non-anchor property/element runs the same way the top-level object
-     form does.
-   - **No-sparse-anchor bodies are kept verbatim** (the single-target / weak-anchor
+     element, e.g. the move-options object in a kept `engine.run([{…}])` keeping
+     every property instead of `[{ OBJECT_PROPS, mode: "…", OBJECT_PROPS }]`.
+     (Real-spec analogues: `moveProcessedInboxAudioNodeToTarget`, the `Se({…})`
+     command objects.) **Landed (#2289).** Object literals in a kept call arg
+     already holed (`hole_object` runs via `hole_expr`'s `Expr::Object` arm); the
+     only hole in the recursion was `Expr::Array`, which fell through to the
+     verbatim catch-all and froze any object nested in an array. `hole_expr` now
+     has an `Expr::Array` arm (`hole_array`) that recurses into each element
+     (non-anchor elements → `ANYTHING`, arity-exact since the matcher matches
+     array elements element-wise — no array list hole), so a nested object inside
+     `[…]` holes the same way a top-level call-arg object does.
+     `interior_object_arg_holing` unignored.
+   - **No-sparse-anchor bodies kept un-holed** (the single-target / weak-anchor
      family — `single_target_class_whole_body`, `component_wide_destructure_whole_body`,
      and function analogues like `redirectElectronAppWithCustomToken` keeping its
-     whole then+catch). Here uniqueness was proven by the full body, so nothing was
-     holed; the win is finding the minimal subtree set that still proves unique and
-     holing the rest (interior set-cover at subtree granularity).
+     whole then+catch). Still open, and **distinct from the nested-literal gap
+     above.** The two disabled fixtures have no same-shape sibling, so the read-off
+     never keeps the body to prove uniqueness: the structural fast path
+     (`render_via_read_off`) / keep-shallow var path emits a _vacuous_ selector
+     (`class X { CLASS_REST }`, `const X = ANYTHING`), not the real-spec "kept
+     verbatim". Closing them needs a **robustness-anchor policy** — keep a stable
+     deep value anchor (holed down) even when the bare scaffold already resolves,
+     which directly trades against the fast path's current "leanest scaffold
+     preferred" rationale — and, for the component case, `collect_expr_anchors` /
+     `hole_expr` recursion into function/arrow-valued initializers plus the var →
+     read-off migration (item 6). The "minimal subtree set that still proves
+     unique" framing degenerates to the empty set on a sibling-less fixture, so
+     the win there is robustness, not cardinality-minimality; the real-spec
+     cover-keeps-the-body case is the interior set-cover at subtree granularity.
 3. **Class** body among siblings (91 full + 268 holed; worst severity, ~1,151-line
    bodies) — `CLASS_REST` + discriminating member (`class_among_many_siblings`,
    `sibling_subclass_hierarchy`, `class_body`). **Landed.** `minimize_class_selector`

--- a/devinfra/js/debundle/selector_codemod.rs
+++ b/devinfra/js/debundle/selector_codemod.rs
@@ -1594,6 +1594,7 @@ fn hole_expr(expr: &Expr, kept: &BTreeSet<AnchorSpan>) -> Expr {
             Expr::New(holed)
         }
         Expr::Object(object) => Expr::Object(hole_object(object, kept)),
+        Expr::Array(array) => Expr::Array(hole_array(array, kept)),
         Expr::Await(await_expr) => {
             let mut holed = await_expr.clone();
             holed.arg = Box::new(hole_expr(&await_expr.arg, kept));
@@ -1649,6 +1650,29 @@ fn hole_args(args: &[ExprOrSpread], kept: &BTreeSet<AnchorSpan>) -> Vec<ExprOrSp
             holed
         })
         .collect()
+}
+
+/// Prune the elements of an array literal, holing each non-anchor element to
+/// `ANYTHING` (an arity-exact `EXPR` hole) and recursing into the ones that
+/// carry an anchor. The matcher matches array elements element-wise (no list
+/// hole for arrays), so the holed array keeps the same length; elisions and
+/// spreads are preserved verbatim, mirroring [`hole_args`].
+fn hole_array(array: &ArrayLit, kept: &BTreeSet<AnchorSpan>) -> ArrayLit {
+    let mut holed = array.clone();
+    holed.elems = array
+        .elems
+        .iter()
+        .map(|elem| {
+            elem.as_ref().map(|element| {
+                let mut holed_element = element.clone();
+                if element.spread.is_none() {
+                    holed_element.expr = Box::new(hole_expr(&element.expr, kept));
+                }
+                holed_element
+            })
+        })
+        .collect();
+    holed
 }
 
 fn hole_object(object: &ObjectLit, kept: &BTreeSet<AnchorSpan>) -> ObjectLit {
@@ -4224,5 +4248,89 @@ mod prefilter_soundness_tests {
                 "the distinct-token siblings must exercise the singleton fast-path"
             );
         });
+    }
+}
+
+#[cfg(test)]
+mod interior_holing_tests {
+    use super::*;
+
+    /// Round-trip `source` through swc parse + codegen so equality is on AST
+    /// shape, not incidental formatting.
+    fn normalize(source: &str) -> String {
+        js_ast::with_swc_globals(|| {
+            let module = js_ast::parse_js_module_ast("<interior-holing>", source).unwrap();
+            js_ast::emit_module_source(&module).unwrap()
+        })
+    }
+
+    /// Span of the first string literal whose value is `needle`.
+    fn string_literal_span(expr: &Expr, needle: &str) -> Span {
+        struct Find<'a> {
+            needle: &'a str,
+            found: Option<Span>,
+        }
+        impl Visit for Find<'_> {
+            fn visit_str(&mut self, str_: &Str) {
+                if self.found.is_none() && str_.value.to_string_lossy() == self.needle {
+                    self.found = Some(str_.span);
+                }
+            }
+        }
+        let mut find = Find {
+            needle,
+            found: None,
+        };
+        expr.visit_with(&mut find);
+        find.found.expect("needle literal present in expression")
+    }
+
+    /// Hole the single expression-statement in `source`, pinning the lone
+    /// `anchor` string literal as the kept span.
+    fn hole_statement_expr(source: &str, anchor: &str) -> String {
+        js_ast::with_swc_globals(|| {
+            let module = js_ast::parse_js_module_ast("<interior-holing>", source).unwrap();
+            let [ModuleItem::Stmt(Stmt::Expr(stmt))] = module.body.as_slice() else {
+                panic!("expected a single expression statement");
+            };
+            let kept = BTreeSet::from([span_key(string_literal_span(&stmt.expr, anchor))]);
+            emit_selector(ModuleItem::Stmt(Stmt::Expr(ExprStmt {
+                span: DUMMY_SP,
+                expr: Box::new(hole_expr(&stmt.expr, &kept)),
+            })))
+            .unwrap()
+        })
+    }
+
+    #[test]
+    fn holes_nested_object_inside_a_kept_array_argument() {
+        // The object nested in a kept `ANYTHING.run([{…}])` keeps only the anchor
+        // property, holing the rest to OBJECT_PROPS. Regression guard for the
+        // `Expr::Array` recursion: the array used to fall through `hole_expr`'s
+        // verbatim catch-all, so every property was pinned.
+        let holed = hole_statement_expr(
+            r#"ctx.engine.run([{ source: ctx.node, mode: "keepMe", silent: true }]);"#,
+            "keepMe",
+        );
+        assert_eq!(
+            normalize(&holed),
+            normalize(r#"ANYTHING.run([{ OBJECT_PROPS, mode: "keepMe", OBJECT_PROPS }]);"#),
+        );
+    }
+
+    #[test]
+    fn holes_non_anchor_array_elements_to_anything() {
+        // Array elements carrying no anchor hole to ANYTHING (arity-exact, since
+        // the matcher matches array elements element-wise); only the element
+        // holding the anchor is recursed into. The lone-prop object keeps its one
+        // anchor prop with no OBJECT_PROPS padding (nothing was dropped).
+        let holed = hole_statement_expr(
+            r#"render([first(), { mode: "keepMe" }, third()]);"#,
+            "keepMe",
+        );
+        assert_eq!(
+            normalize(&holed),
+            normalize(r#"render([ANYTHING, { mode: "keepMe" }, ANYTHING]);"#),
+        );
     }
 }


### PR DESCRIPTION
Closes gap 1 of issue #2289 (plan item 2b, "interior holing"): a nested
object/array literal inside a kept expression was pinned whole instead of
holing its non-anchor subtrees.

Object literals in a kept call argument already holed correctly (`hole_object`
runs via `hole_expr`'s `Expr::Object` arm — see `class_among_many_siblings`).
The single missing arm in the recursion was `Expr::Array`, which fell through
`hole_expr`'s verbatim catch-all, freezing any object nested inside an array:
`engine.run([{ source, target, mode: "X", silent, retain }])` kept every
property instead of `[{ OBJECT_PROPS, mode: "X", OBJECT_PROPS }]`.

`hole_expr` now has an `Expr::Array` arm (`hole_array`) that recurses into each
element — non-anchor elements hole to `ANYTHING` (arity-exact, since the matcher
matches array elements element-wise; there is no array list hole), elisions and
spreads pass through verbatim, mirroring `hole_args`. The prove-gate still backs
every read-off, so a hole that lost uniqueness would fall back, not ship.

Unignores the `interior_object_arg_holing` e2e expectation and adds focused
`hole_array` unit tests. Sharpens plan item 2b to record this landing and to
separate the still-open gap 2 (sibling-less whole-body cases —
`single_target_class_whole_body`, `component_wide_destructure_whole_body` — which
need a robustness-anchor policy and var->read-off migration, distinct from this
nested-literal recursion).

BAZEL_TEST_INVOCATIONS=buildbuddy:93fc6853-0bf4-474f-b7a2-91a83844662b

https://claude.ai/code/session_01G7bpGsgmYxwrWQSYCbzgj2