### PR TITLE
debundle: key-set minimization for objects in var groups (#2290)

### DIFF
--- a/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
+++ b/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
@@ -377,6 +377,24 @@ minimizer_expectation_case!(
     expected = "expected_match.js",
 );
 
+// A target object inside a multi-declarator var group, discriminated purely by
+// its KEY SET (every value is a non-discriminating call, alpha-wildcarded),
+// minimizes to OBJECT_PROPS holes around the single rarest discriminating key
+// (`logSection`, which the same-shape sibling group lacks) plus DECLARATORS_AFTER
+// for the trailing helper declarator. Previously the group cover added every
+// object key at once (the coarse structural tier), keeping all keys held to
+// ANYTHING; the key-set greedy cover (#2290) adds keys rarest-first and stops at
+// the minimal discriminating subset. Real-spec analogues: CSS-styles dicts and
+// schema objects kept whole inside `var a={…},b={…},…` groups.
+minimizer_expectation_case!(
+    minimizes_object_keyset_group,
+    fixture = "object_keyset_group",
+    name = "key-set-discriminated object in a var group keeps only the rarest discriminating key",
+    module = "app/styles",
+    bindings = [("SelectedStyles", "selectedStyles")],
+    expected = "expected_match.js",
+);
+
 // A subclass among many sibling subclasses of a shared base minimizes to the
 // `extends` clause (superclass holed with ANYTHING) plus the single
 // discriminating class field, with CLASS_REST holes absorbing every other

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/object_keyset_group/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/object_keyset_group/expected_match.js
@@ -1,0 +1,6 @@
+var SelectedStyles = {
+    OBJECT_PROPS,
+    logSection: ANYTHING,
+    OBJECT_PROPS,
+  },
+  DECLARATORS_AFTER = null;

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/object_keyset_group/source.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/object_keyset_group/source.js
@@ -1,0 +1,17 @@
+var selectedStyles = {
+    diagnosticsSection: clsx(base),
+    detailsToggle: clsx(base),
+    details: clsx(base),
+    logSection: clsx(base),
+  },
+  styleHelper = register(theme);
+
+var siblingStyles = {
+    diagnosticsSection: clsx(base),
+    detailsToggle: clsx(base),
+    details: clsx(base),
+    footer: clsx(base),
+  },
+  otherHelper = register(theme);
+
+export { selectedStyles };

--- a/devinfra/js/debundle/plans/readoff_minimization.md
+++ b/devinfra/js/debundle/plans/readoff_minimization.md
@@ -155,11 +155,12 @@ Full scope table in <../debug/selector_minimizer_dogfood.md>.
 **E2E expectation suite** (`e2e/selector_minimizer_expectation_test.rs`). Active:
 `sparse_function_body`, `call_argument_literal`, `object_property_literals`,
 `binding_group_declarators`, `nested_async_try`, `class_body`, `switch_case_run`,
-`object_keys_over_pinned`, `long_literal_value_anchor`, `binding_group_partition`,
-and (unignored once the class read-off landed) `class_among_many_siblings`,
-`sibling_subclass_hierarchy`. Ignored as aspirational (the named form not yet
-read-off-expressible): `sequential_assignment_block`, `deeply_nested_call_args`,
-`grouped_enum_objects`, `object_nested_value_dict`, `wide_destructure_block`.
+`object_keys_over_pinned`, `object_keyset_group`, `long_literal_value_anchor`,
+`binding_group_partition`, and (unignored once the class read-off landed)
+`class_among_many_siblings`, `sibling_subclass_hierarchy`. Ignored as aspirational
+(the named form not yet read-off-expressible): `sequential_assignment_block`,
+`deeply_nested_call_args`, `grouped_enum_objects`, `object_nested_value_dict`,
+`wide_destructure_block`.
 
 ## Acceptance criteria
 
@@ -253,18 +254,25 @@ non-minimal pattern catalog drives this and is encoded as disabled E2E cases.
    single scalar), nested-value dicts (`object_nested_value_dict`), grouped
    objects (`grouped_enum_objects`: `DECLARATORS` + padded `OBJECT_PROPS`), wide
    destructure (`wide_destructure_block`).
-   - **Key-set minimization (gaffer-dogfood feedback).** When an object is
-     discriminated by its _key set_ rather than any value — every value already
-     holed to `ANYTHING`, e.g. a CSS-styles dict
-     `{ diagnosticsSection: ANYTHING, detailsToggle: ANYTHING, … 11 keys }`, or a
-     schema object `ee({ coreMessage: …, type: …, … })` kept whole — the minimizer
-     keeps **every** key. It should keep only the **minimal key subset** whose
-     presence still discriminates the target from its siblings and collapse the
-     rest to `OBJECT_PROPS` (the key-set analogue of greedy set-cover: anchor on
-     the rarest discriminating keys, `OBJECT_PROPS` the common ones). Note these
-     over-pins surface inside multi-declarator var groups
-     (`DECLARATORS_BEFORE`/`_AFTER`), so the object key-set minimization must run
-     on the per-declarator object even when the statement is a declarator group.
+   - **Key-set minimization (gaffer-dogfood feedback). Landed (#2290).** When an
+     object is discriminated by its _key set_ rather than any value — every value
+     already holed to `ANYTHING`, e.g. a CSS-styles dict
+     `{ diagnosticsSection: ANYTHING, detailsToggle: ANYTHING, … 11 keys }` — the
+     minimizer kept **every** key. The single-declarator object form already
+     handled this via `minimal_anchor_set` (object keys are scored features, so
+     greedy set-cover already covers them); the gap was the **multi-declarator var
+     group** cover, which added every object key at once (the coarse `structural`
+     tier). `minimize_var_group_selector` now runs a key-set greedy cover
+     (`ranked_object_key_anchors_for_slots` → `ShapeIndex::selector_feature_selectivity`)
+     before that tier: it adds each target slot's object keys one at a time
+     rarest-first, re-proving with the matcher oracle, and stops at the minimal
+     discriminating subset; direct object-literal inits render through
+     `hole_object_padded` so the kept keys are interior `OBJECT_PROPS` subsequence
+     elements (survive reorder). E2E `object_keyset_group`. Still open:
+     value-discriminated grouped objects keeping all _value_ literals
+     (`grouped_enum_objects` — a value-vs-key anchor-preference question, distinct
+     from the key-set case) and `ee({ … })`-style schema objects passed as a call
+     argument rather than a direct init.
 6. **Statement runs** (`sequential_assignment_block`, `deeply_nested_call_args`)
    and **var** migration (needs binding-group/declarator-slot tuple resolution).
 7. **Anti-unification grouping** from posting co-occurrence (shared declaration OR

--- a/devinfra/js/debundle/readoff_render.rs
+++ b/devinfra/js/debundle/readoff_render.rs
@@ -231,7 +231,11 @@ fn member_prop_label(prop: &MemberProp) -> Option<String> {
     }
 }
 
-fn object_key_label_span(prop: &PropOrSpread) -> Option<(String, Span)> {
+/// The key label and its source span for an object property, mirroring
+/// `selector_candidate_index::object_key_label` (same labeling) plus the span.
+/// Reused by the var-group key-set cover to enumerate a declarator object's
+/// keys; spreads and computed keys carry no stable label and yield `None`.
+pub fn object_key_label_span(prop: &PropOrSpread) -> Option<(String, Span)> {
     let PropOrSpread::Prop(prop) = prop else {
         return None;
     };

--- a/devinfra/js/debundle/selector_codemod.rs
+++ b/devinfra/js/debundle/selector_codemod.rs
@@ -15,8 +15,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
-use readoff_render::kept_spans_for_anchor_set;
-use selector_candidate_index::SelectorCandidateIndex;
+use readoff_render::{kept_spans_for_anchor_set, object_key_label_span};
+use selector_candidate_index::{SelectorCandidateIndex, SelectorFeature};
 use serde::Serialize;
 use serde_yaml::Value;
 use shape_index::ShapeIndex;
@@ -2234,6 +2234,42 @@ fn try_single_object_read_off(
     finish_minimized_selector(index, decl, target, render_with(&kept)?)
 }
 
+/// Object-key anchor spans of every target slot whose init is a direct object
+/// literal, ranked rarest-first: chunk-wide key selectivity ascending, then
+/// shorter key label, then source order. The var-group key-set cover adds these
+/// to the matcher-proven anchor set one at a time, so an object discriminated by
+/// its key *set* (every value non-discriminating) keeps only the minimal
+/// discriminating subset — the rarest keys — with `OBJECT_PROPS` for the rest,
+/// instead of every key. Mirrors the single-declarator object read-off
+/// ([`try_single_object_read_off`]), which the group path cannot use directly
+/// because per-declarator scoping needs the group matcher oracle.
+fn ranked_object_key_anchors_for_slots(
+    index: &ChunkSelectorIndex,
+    var: &VarDecl,
+    target_slots: &BTreeSet<usize>,
+) -> Vec<AnchorSpan> {
+    let mut ranked: Vec<(usize, usize, AnchorSpan)> = Vec::new();
+    for (idx, declarator) in var.decls.iter().enumerate() {
+        if !target_slots.contains(&idx) {
+            continue;
+        }
+        let Some(Expr::Object(object)) = declarator.init.as_deref() else {
+            continue;
+        };
+        for prop in &object.props {
+            let Some((label, span)) = object_key_label_span(prop) else {
+                continue;
+            };
+            let selectivity = index
+                .shape_index
+                .selector_feature_selectivity(&SelectorFeature::ObjectKey(label.clone()));
+            ranked.push((selectivity, label.chars().count(), span_key(span)));
+        }
+    }
+    ranked.sort();
+    ranked.into_iter().map(|(_, _, span)| span).collect()
+}
+
 /// Minimal anchor cover for a `var`/`let`/`const` binding group: render the
 /// shared declaration keeping the target declarators (each `export = <holed
 /// init>`) with `DECLARATORS_*` holes for non-target runs, and pin just enough
@@ -2303,7 +2339,15 @@ fn minimize_var_group_selector(
             let mut holed = declarator.clone();
             holed.name = named_pat(export_for(name).expect("target declarator has an export"));
             holed.init = declarator.init.as_ref().map(|init| {
-                let mut holed_init = hole_expr(init, kept);
+                // A direct object-literal init holes through the padded form
+                // (leading + trailing `OBJECT_PROPS`) so a kept key matches as an
+                // interior subsequence element and survives key reorder — the same
+                // treatment the single-declarator object read-off applies via
+                // `hole_object_padded`. Other inits use the run-padding `hole_expr`.
+                let mut holed_init = match init.as_ref() {
+                    Expr::Object(object) => Expr::Object(hole_object_padded(object, kept)),
+                    _ => hole_expr(init, kept),
+                };
                 if !regex_anchors.is_empty() {
                     // Post-pass: swap each kept literal whose span was chosen as
                     // a regex anchor for the `STR_LITERAL_MATCHING_RE` predicate.
@@ -2348,16 +2392,32 @@ fn minimize_var_group_selector(
     // meaningful targets), then escalate to structural/deeper anchors only if
     // the group does not yet resolve uniquely to the right bindings.
     let mut kept: BTreeSet<AnchorSpan> = candidates.shallow_literals().into_iter().collect();
-    if !resolves(&kept)? {
-        for tier in candidates.deep_cover_tiers() {
-            kept.extend(tier);
+    let mut resolved = resolves(&kept)?;
+    // Key-set minimization (#2290): when shallow values do not discriminate, add
+    // target-slot object keys one at a time rarest-first (greedy set-cover)
+    // before the coarse all-keys structural tier, so an object identified by its
+    // key set keeps only the minimal discriminating subset (`OBJECT_PROPS` the
+    // common ones) instead of every key. The matcher oracle proves each addition.
+    if !resolved {
+        for key_span in ranked_object_key_anchors_for_slots(index, var, &target_slots) {
+            kept.insert(key_span);
             if resolves(&kept)? {
+                resolved = true;
                 break;
             }
         }
-        if !resolves(&kept)? {
-            return Ok(None);
+    }
+    if !resolved {
+        for tier in candidates.deep_cover_tiers() {
+            kept.extend(tier);
+            if resolves(&kept)? {
+                resolved = true;
+                break;
+            }
         }
+    }
+    if !resolved {
+        return Ok(None);
     }
 
     // Regex-literal upgrade: among kept string literals, offer a robust
@@ -3602,6 +3662,90 @@ export { target };\n";
         // emits even when full_ast_fallback is off.
         let outcome = outcome_for(HARD_TO_MINIMIZE, "target", false, false);
         assert!(matches!(outcome, GroupSelectorOutcome::Synthesized(_)));
+    }
+}
+
+#[cfg(test)]
+mod var_group_keyset_cover_tests {
+    use super::*;
+
+    /// Minimize the group selector for `runtime` and return its match source,
+    /// asserting it resolves uniquely back to the intended declaration.
+    fn minimized_match(source: &str, runtime: &str, export: &str) -> String {
+        js_ast::with_swc_globals(|| {
+            let parsed =
+                js_ast::parse_js_module_consuming("<keyset-test>", source.to_string()).unwrap();
+            let index = ChunkSelectorIndex::new(parsed);
+            let decl_idx = *index
+                .binding_to_decl
+                .get(runtime)
+                .and_then(|decls| decls.first())
+                .expect("chunk declares the target binding");
+            let members = [NameBindingMember {
+                member_index: 0,
+                export_name: export.to_string(),
+                binding_name: runtime.to_string(),
+                comment: None,
+            }];
+            let GroupSelectorOutcome::Synthesized(group) =
+                synthesize_simplest_selector_for_group(&index, decl_idx, &members, true, false)
+                    .unwrap()
+            else {
+                panic!("key-set group must synthesize a minimized selector");
+            };
+            assert_eq!(
+                matched_body_indices(&index, export, &group.match_source).unwrap(),
+                BTreeSet::from([group.body_idx]),
+                "minimized selector must resolve uniquely: {}",
+                group.match_source
+            );
+            group.match_source
+        })
+    }
+
+    #[test]
+    fn keeps_only_the_rarest_key_in_a_declarator_group() {
+        // `selectedStyles` shares three keys with the same-shape sibling group and
+        // differs only by `logSection`; every value is a non-discriminating call.
+        // The greedy cover keeps just `logSection`, OBJECT_PROPS the shared keys,
+        // and holes the trailing helper declarator with DECLARATORS_AFTER.
+        let source = "\
+var selectedStyles = { diagnosticsSection: clsx(base), detailsToggle: clsx(base), details: clsx(base), logSection: clsx(base) }, styleHelper = register(theme);\n\
+var siblingStyles = { diagnosticsSection: clsx(base), detailsToggle: clsx(base), details: clsx(base), footer: clsx(base) }, otherHelper = register(theme);\n\
+export { selectedStyles };\n";
+        let match_source = minimized_match(source, "selectedStyles", "SelectedStyles");
+        assert!(match_source.contains("logSection"), "{match_source}");
+        assert!(match_source.contains("OBJECT_PROPS"), "{match_source}");
+        assert!(match_source.contains("DECLARATORS_AFTER"), "{match_source}");
+        // The shared keys (`details` also covers `detailsToggle`) are holed, not
+        // pinned — the over-pin this fix removes.
+        for shared in ["diagnosticsSection", "details"] {
+            assert!(
+                !match_source.contains(shared),
+                "kept shared key `{shared}`: {match_source}"
+            );
+        }
+    }
+
+    #[test]
+    fn keeps_a_minimal_two_key_cover_when_no_single_key_is_unique() {
+        // No single key is unique to the target: `alpha` is absent from sibOne and
+        // `beta` from sibTwo, so the greedy cover must keep both; `gamma`/`delta`
+        // are shared across all three groups and stay holed.
+        let source = "\
+var selectedThing = { alpha: r0, beta: r1, gamma: r2, delta: r3 }, helperA = build(shared);\n\
+var sibOne = { beta: r1, gamma: r2, delta: r3, extraX: r8 }, helperB = build(shared);\n\
+var sibTwo = { alpha: r0, gamma: r2, delta: r3, extraY: r9 }, helperC = build(shared);\n\
+export { selectedThing };\n";
+        let match_source = minimized_match(source, "selectedThing", "SelectedThing");
+        assert!(match_source.contains("alpha"), "{match_source}");
+        assert!(match_source.contains("beta"), "{match_source}");
+        for shared in ["gamma", "delta"] {
+            assert!(
+                !match_source.contains(shared),
+                "kept shared key `{shared}`: {match_source}"
+            );
+        }
     }
 }
 

--- a/devinfra/js/debundle/shape_index.rs
+++ b/devinfra/js/debundle/shape_index.rs
@@ -646,6 +646,14 @@ impl ShapeIndex {
         self.postings.get(feature).unwrap_or(&EMPTY)
     }
 
+    /// Chunk-wide selectivity of a selector feature: the number of top-level
+    /// items whose shape exhibits it (smaller = rarer = more discriminating).
+    /// Used by the var-group key-set cover to rank object keys rarest-first
+    /// before adding them to the matcher-proven anchor set.
+    pub fn selector_feature_selectivity(&self, feature: &SelectorFeature) -> usize {
+        self.posting(&ShapeFeature::Selector(feature.clone())).len()
+    }
+
     /// Every feature exhibited by `body_idx` that is sound to use as an anchor
     /// under alpha-equivalent matching (the mode the read-off minimizer emits),
     /// each scored with its index-wide selectivity and stability. The read-off


### PR DESCRIPTION
Closes #2290.

## Problem

When a target object inside a multi-declarator `var` group is discriminated purely by its **key set** (every value already holed to `ANYTHING`), the group cover added *every* object key at once through the coarse `structural` tier, keeping all keys held to `ANYTHING`.

## Finding

Built the CLI and reproduced it. The **single-declarator** object form *already* minimized key-sets correctly via `minimal_anchor_set` (object keys are scored features, so greedy set-cover already covers them) — confirmed for both a single rare key and a true 2-key cover. The actual gap was only the **multi-declarator var group** path: a target keeping all 4 keys when only `logSection` discriminated it from a same-shape sibling group.

## Fix

Isolated to the group path:

- **`shape_index.rs`** — `selector_feature_selectivity` (chunk-wide posting-list size) to rank keys by rarity.
- **`readoff_render.rs`** — exposed `object_key_label_span` for reuse.
- **`selector_codemod.rs`** — `minimize_var_group_selector` now runs a **greedy key-set set-cover** (`ranked_object_key_anchors_for_slots`) before the structural tier: it adds each target slot's object keys **rarest-first**, re-proving with the matcher oracle, and stops at the minimal discriminating subset. Direct object-literal inits render through `hole_object_padded` so kept keys match as interior `OBJECT_PROPS` subsequence elements and survive key reorder.
- **`plans/readoff_minimization.md`** — marked the sub-item landed.

Result on the reproduced case:

```js
var SelectedStyles = {
    OBJECT_PROPS,
    logSection: ANYTHING,
    OBJECT_PROPS
}, DECLARATORS_AFTER = null;
```

(was: all 4 keys held to `ANYTHING`).

## Tests

- New active E2E `object_keyset_group` (single rarest key in a var group).
- Unit tests in `selector_codemod.rs` for the single-key and true 2-key covers, each asserting unique resolution via the matcher.
- All 116 `//devinfra/js/debundle/...` tests pass; pre-commit (rustfmt / prettier / ducktape hooks) clean.

## Out of scope (distinct, still-open object-dict items, noted in the plan)

- Value-discriminated grouped objects keeping all *value* literals (`grouped_enum_objects` — a value-vs-key anchor-preference question).
- `ee({ … })`-style schema objects passed as a call argument rather than a direct init.

https://claude.ai/code/session_013ikMhehN17gsq2JaAZF2WJ

---
_Generated by [Claude Code](https://claude.ai/code/session_013ikMhehN17gsq2JaAZF2WJ)_