### PR TITLE
debundle: var read-off migration + branch-and-bound cover deletion

### DIFF
--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -31,9 +31,11 @@ progress output and a resumable or cacheable plan.
 One-line status for each `plans/` design doc; this is the discovery index.
 
 - <plans/readoff_minimization.md> — **active.** Read-off selector minimizer
-  (chunk-wide AST-shape index). Layer-1 index + function/object read-off landed;
-  var/class/group migration, co-occurrence grouping, cover-search deletion, and
-  whole-spec validation open. Holds its own current-state + backlog.
+  (chunk-wide AST-shape index). Layer-1 index, function/object/class read-off,
+  key-set minimization, adjacent-function grouping, prove-gate-via-index, and
+  whole-spec perf validation (W4) landed; var migration, general co-occurrence
+  grouping, whole-body interior holing, and cover-search deletion open. Holds its
+  own current-state + backlog.
 - <plans/readoff_algorithm_research.md> + <plans/readoff_research/> — **reference
   (complete).** Literature spike that gates the read-off design; durable, not a
   TODO.
@@ -56,10 +58,11 @@ propose`.
 1. **Forward-compatible minimized selector synthesis + shared source index.**
    Owned by <plans/readoff_minimization.md>: the read-off AST-shape index
    (`shape_index.rs`, superseting `selector_candidate_index.rs`),
-   function/object read-off, literal/regex anchors, and hole-based minimization
-   have landed; class/var/group migration, co-occurrence grouping, the
-   prove-gate perf fix, cover-search deletion, and whole-spec validation are in
-   that plan's backlog. Don't duplicate its design or status here.
+   function/object/class read-off, literal/regex anchors, hole-based
+   minimization, the prove-gate perf fix, and whole-spec validation have landed;
+   var migration, general co-occurrence grouping, whole-body interior holing, and
+   cover-search deletion are in that plan's backlog. Don't duplicate its design or
+   status here.
 2. **Patch-plan based bulk codemods.** Extend `debundle spec selector-codemod`
    or add adjacent verbs so every broad rewrite can emit a dry-run patch plan,
    apply with filters, and explain every skipped candidate. (Selector

--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -31,11 +31,11 @@ progress output and a resumable or cacheable plan.
 One-line status for each `plans/` design doc; this is the discovery index.
 
 - <plans/readoff_minimization.md> — **active.** Read-off selector minimizer
-  (chunk-wide AST-shape index). Layer-1 index, function/object/class read-off,
-  key-set minimization, adjacent-function grouping, prove-gate-via-index, and
-  whole-spec perf validation (W4) landed; var migration, general co-occurrence
-  grouping, whole-body interior holing, and cover-search deletion open. Holds its
-  own current-state + backlog.
+  (chunk-wide AST-shape index). Layer-1 index, function/object/class/var read-off,
+  key-set minimization, adjacent-function grouping, prove-gate-via-index,
+  whole-spec perf validation (W4), and the branch-and-bound cover deletion landed;
+  multi-target var binding-group read-off, general co-occurrence grouping, and
+  whole-body interior holing open. Holds its own current-state + backlog.
 - <plans/readoff_algorithm_research.md> + <plans/readoff_research/> — **reference
   (complete).** Literature spike that gates the read-off design; durable, not a
   TODO.
@@ -58,11 +58,11 @@ propose`.
 1. **Forward-compatible minimized selector synthesis + shared source index.**
    Owned by <plans/readoff_minimization.md>: the read-off AST-shape index
    (`shape_index.rs`, superseting `selector_candidate_index.rs`),
-   function/object/class read-off, literal/regex anchors, hole-based
-   minimization, the prove-gate perf fix, and whole-spec validation have landed;
-   var migration, general co-occurrence grouping, whole-body interior holing, and
-   cover-search deletion are in that plan's backlog. Don't duplicate its design or
-   status here.
+   function/object/class/var read-off, literal/regex anchors, hole-based
+   minimization, the prove-gate perf fix, whole-spec validation, and the
+   branch-and-bound cover deletion have landed; multi-target var binding-group
+   read-off, general co-occurrence grouping, and whole-body interior holing are in
+   that plan's backlog. Don't duplicate its design or status here.
 2. **Patch-plan based bulk codemods.** Extend `debundle spec selector-codemod`
    or add adjacent verbs so every broad rewrite can emit a dry-run patch plan,
    apply with filters, and explain every skipped candidate. (Selector

--- a/devinfra/js/debundle/e2e/selector_codemod_cli_test.rs
+++ b/devinfra/js/debundle/e2e/selector_codemod_cli_test.rs
@@ -888,12 +888,16 @@ fn synthesize_selectors_minimizes_binding_group_to_needed_slot_anchors() {
     );
 }
 
-// Re-baselined for the unified keep-shallow policy: single-target vars now route
-// through the group path, whose structural-tier escalation keeps the whole
-// object-key tier rather than running the exact-minimum set-cover B&B. The
-// min-cover guarantee still holds for function bodies (via `minimize_via_retention`
-// → `cover_competitors` → `min_set_cover`); this var case keeps all keys and
-// still resolves uniquely to the intended binding.
+// After the var read-off migration, a single-target var initialized by an
+// object-bearing call (`makeConfig({…})`) reads its minimal anchor off the shape
+// index. Each entry's value (`computeValue("selected-beta")`) carries a globally
+// unique string, so the read-off pins ONE discriminating `key: value` and holes
+// every sibling key to `OBJECT_PROPS` — sparser than the keep-shallow "keep all
+// keys" output and sparser than the {betaKey, gammaKey} key-set the B&B set-cover
+// would compute (a unique value beats a multi-key presence cover). It still
+// resolves uniquely to the intended binding. The min-cover guarantee still backs
+// function bodies via `minimize_via_retention` → `cover_competitors` →
+// `min_set_cover`.
 #[test]
 fn synthesize_selectors_var_object_keys_resolve_uniquely() {
     let dir = tempfile::tempdir().unwrap();
@@ -920,9 +924,11 @@ fn synthesize_selectors_var_object_keys_resolve_uniquely() {
     let match_source = doc["members"][0]["selector"]["source_match"]["match"]
         .as_str()
         .unwrap();
+    // One discriminating `key: value` with a globally-unique string value is the
+    // minimal read-off anchor; the rest collapse to `OBJECT_PROPS`.
     assert!(
-        match_source.contains("betaKey:") && match_source.contains("gammaKey:"),
-        "the discriminating keys should remain:\n{match_source}"
+        match_source.contains("selected-") && match_source.matches("OBJECT_PROPS").count() >= 1,
+        "a single discriminating value anchor should remain, rest holed:\n{match_source}"
     );
 }
 

--- a/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
+++ b/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
@@ -295,10 +295,15 @@ minimizer_expectation_case!(
     expected = "expected_match.js",
 );
 
+// A single-target var initialized by an object-bearing call (`buildWidget({…})`)
+// routes through the var read-off path (`try_var_read_off` → `hole_expr` →
+// `hole_object`). The read-off picks the uniquely-present `onClick` key (held to
+// `ANYTHING`) as the sole minimal discriminator — sparser than keeping the
+// `kind`/`mode` value pair the siblings also carry.
 minimizer_expectation_case!(
     minimizes_object_property_literals,
     fixture = "object_property_literals",
-    name = "object literal keeps minimal key value anchors",
+    name = "object-in-call var keeps only the uniquely-present key",
     module = "app/config",
     bindings = [("SelectedConfig", "selectedConfig")],
     expected = "expected_match.js",
@@ -414,11 +419,15 @@ minimizer_expectation_case!(
 // Aspirational: a binding initialized by a deeply nested call tree should
 // minimize to ANYTHING-holed outer callees and ARGS holes for their sibling
 // arguments, drilling only to the one deep object literal that carries the
-// discriminating key. Today the minimizer keeps the entire nested call/object
-// tree whole, over-pinning every wrapper call and every transient argument
-// instead of holing the path down to the single discriminating leaf.
+// discriminating key. The var read-off path now drills correctly to the leaf
+// (`buildInner({ mode: "…", OBJECT_PROPS })`), closing the old "keeps the whole
+// tree" gap. Two gaps remain vs the aspirational shape: the bare-function callees
+// (`wrapOuter`/`decorate`/`buildInner`) stay pinned rather than holing to ANYTHING
+// (the `hole_callee` policy keeps a bare function reference as a stable pin), and a
+// dropped sibling arg holes to a single arity-exact `ANYTHING` rather than a
+// variadic `ARGS` run-hole. Both are cross-cutting hole-policy changes.
 minimizer_expectation_case!(
-    #[ignore = "nested-call minimizer keeps whole tree instead of holing wrappers down to the leaf"]
+    #[ignore = "var read-off drills to the leaf but keeps bare-function callees (hole_callee policy) and holes dropped args to arity-exact ANYTHING, not ARGS"]
     minimizes_deeply_nested_call_args,
     fixture = "deeply_nested_call_args",
     name = "deeply nested call tree keeps only the discriminating leaf literal",
@@ -606,12 +615,15 @@ minimizer_expectation_case!(
     expected = "expected_match.js",
 );
 
-// Re-baselined for the unified keep-shallow anchor policy: both outputs keep each
-// slot's direct shallow literals including object-property values. The group's
-// shared `enabled: true` and the standalone's `kind: "panel"` / `title: "Settings"`
-// / call arg `"settings"` are over-pinned versus the old `ANYTHING` holes. The
-// design note accepts this occasional over-pin as the price of one policy across
-// single (N=1 group) and multi-target group paths.
+// Single vs group split after the var read-off migration: the multi-target group
+// (`SelectedPrimary`/`SelectedSecondary`) still uses the keep-shallow anchor policy
+// — both slots keep their direct shallow literals, including the shared
+// `enabled: true` over-pin (per-slot tuple resolution remains the cover's job). The
+// single-target `SelectedStandalone` now reads its minimal anchor off the shape
+// index: `kind: "panel"` alone discriminates it from `sameRouteDifferentKind`, so
+// the shared non-discriminating call arg `"settings"` holes to `ANYTHING` and the
+// redundant `title: "Settings"` collapses into `OBJECT_PROPS` — sparser and more
+// rebuild-robust than the keep-shallow over-pin.
 #[test]
 fn minimizes_binding_group_partition() {
     run_case(&MinimizedSelectorCase {

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/binding_group_partition/expected_standalone_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/binding_group_partition/expected_standalone_match.js
@@ -1,5 +1,4 @@
-const SelectedStandalone = registerRoute("settings", {
+const SelectedStandalone = registerRoute(ANYTHING, {
   kind: "panel",
   OBJECT_PROPS,
-  title: "Settings",
 });

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/object_property_literals/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/object_property_literals/expected_match.js
@@ -1,6 +1,4 @@
 const SelectedConfig = buildWidget({
-  kind: "primary",
   OBJECT_PROPS,
-  mode: "compact",
-  OBJECT_PROPS,
+  onClick: ANYTHING,
 });

--- a/devinfra/js/debundle/plans/readoff_minimization.md
+++ b/devinfra/js/debundle/plans/readoff_minimization.md
@@ -90,8 +90,10 @@ The literature spike (<readoff_algorithm_research.md> + five strand reports in
 
 ## Current state (on `devel`)
 
-The three-layer index and the read-off path for the first two forms are built and
-behavior-preserving; the bespoke cover search still backs the unmigrated forms.
+The three-layer index and the read-off path back every single-target form
+(function, class, object, var); the branch-and-bound cover search they replaced is
+deleted. The only remaining bespoke cover is the multi-target var binding-group
+keep-shallow path.
 
 **Layer 1 — shape index.** `shape_index.rs` builds the hash-consed Merkle DAG with
 alpha-leaf canonicalization, multi-granularity shape features, inverted posting
@@ -137,6 +139,13 @@ Migrated to read-off as their primary path:
   holes `extends` to `ANYTHING` and keeps only the member runs carrying a chosen
   anchor between `CLASS_REST` holes; the value-over-name ranking key prefers a
   member's value literal/key over a bare member name.
+- **Single-target var (non-object)** (`try_var_read_off`): holes the initializer
+  with `hole_expr` around the read-off anchors, restricting kept spans to the
+  target declarator; drills into nested call/object/array trees down to the
+  discriminating leaf. No empty-kept fast path — a var's holed scaffold
+  (`const X = ANYTHING`) is degenerate, so an empty anchor set defers to the
+  keep-shallow group path. The `STR_LITERAL_MATCHING_RE` upgrade is shared with
+  the group path via `accepted_regex_anchors`.
 
 **Selector language features the read-off renderer pins through.** All list holes
 exist in `source_match_holes.rs` and the matcher (`match_list_with_holes`):
@@ -216,7 +225,7 @@ serde); embedded/non-trailing volatility in regex anchors (future).
   the member is left as a name pin. These are **whole-body-only** members
   (uniqueness needs ~the entire body). Concentrated in `features` (955),
   `domains` (462), `app` (425). Recovering them is the hard, high-count tail:
-  needs **interior holing of whole bodies** (item 2b gap 2 — keep the body but
+  needs **interior holing of whole bodies** (backlog item 1 — keep the body but
   hole non-identifying subtrees so a fuller pin is at least less fragile / can be
   emitted) and/or deeper anchoring. Biggest number, hardest; do not expect a
   clean compact selector for most.
@@ -225,9 +234,8 @@ serde); embedded/non-trailing volatility in regex anchors (future).
   **~55% var/object, ~42% function, ~3% class**; median ~35 lines, tail to ~700.
   These are the **achievable near-term wins**: the over-pin-reduction waves shrink
   them under the threshold so they ship as compact selectors —
-  - var/object (the plurality) → **interior object/array holing** (item 2b gap 1)
-    - **key-set minimization** + the object-dict family (item 5);
-  - function → **interior holing** within kept bodies (item 2b);
+  - var/object (the plurality) → the remaining object-dict forms (backlog item 2);
+  - function → **interior holing** within kept bodies (backlog item 1);
   - a re-apply after each wave reconverts whatever now fits ≤30 lines.
 - 1 — `async` parse edge case (single; ignore).
 
@@ -237,183 +245,60 @@ body interior holing + anchoring). Re-measure this split after each wave lands.
 
 ## Backlog (open only)
 
-Agreed order (interleave perf-first, then severity-ordered minimality). Counts
-are members in a representative real-spec sample (5,556 selectors); the
-non-minimal pattern catalog drives this and is encoded as disabled E2E cases.
+Severity-ordered minimality work. Counts are members in a representative
+real-spec sample (5,556 selectors); the non-minimal pattern catalog drives this
+and is encoded as disabled E2E cases. Completed items are removed, not annotated;
+the landed architecture is in "Current state" above.
 
-1. **Perf — prove-gate via index.** Whole-chunk minimize is ~110s, almost all of
-   it the per-member full-matcher proof (`prove_synthesized_selector` →
-   `resolve_member_binding`) — read-off made synthesis cheap but the prove-gate is
-   the bottleneck, unchanged from the 113s search baseline. Fix: the index is a
-   **sound superset**, so when the selector's anchor-feature posting-list
-   intersection is the singleton `{target}` that _is_ a uniqueness proof — skip
-   the matcher; full matcher only for non-singleton cases. Collapses per-member
-   cost for the `OPT=1` majority toward the ≤10s target. **(Landed: #2280;
-   validated — whole chunk ~110s → ~13s, see W4 below.)**
-2. **Function** whole-body anchoring (~1,455 full + ~1,743 holed; biggest count) —
-   anchor a deep unique literal/member, hole the rest (`sparse_function_body`).
-   2b. **Interior holing — hole non-anchor subtrees within kept statements
-   (gaffer-dogfood feedback).** The read-off already prunes off-anchor _statements_,
-   _call-chain links_, and _callbacks_ when a sparse anchor exists: with a clean
-   discriminator a `svc.fetchToken().then(…).catch(e => {…})` chain correctly
-   minimizes to `ANYTHING.then((ANYTHING) => { <anchor> }).catch(ANYTHING)` (the
-   non-discriminating catch callback holes to `ANYTHING`). Two gaps:
-   - **Nested object / array literals inside a kept expression were pinned whole**
-     rather than holed to `OBJECT_PROPS` / `ARGS` around the discriminating
-     element, e.g. the move-options object in a kept `engine.run([{…}])` keeping
-     every property instead of `[{ OBJECT_PROPS, mode: "…", OBJECT_PROPS }]`.
-     (Real-spec analogues: `moveProcessedInboxAudioNodeToTarget`, the `Se({…})`
-     command objects.) **Landed (#2289).** Object literals in a kept call arg
-     already holed (`hole_object` runs via `hole_expr`'s `Expr::Object` arm); the
-     only hole in the recursion was `Expr::Array`, which fell through to the
-     verbatim catch-all and froze any object nested in an array. `hole_expr` now
-     has an `Expr::Array` arm (`hole_array`) that recurses into each element
-     (non-anchor elements → `ANYTHING`, arity-exact since the matcher matches
-     array elements element-wise — no array list hole), so a nested object inside
-     `[…]` holes the same way a top-level call-arg object does.
-     `interior_object_arg_holing` unignored.
-   - **No-sparse-anchor bodies kept un-holed** (the single-target / weak-anchor
-     family — `single_target_class_whole_body`, `component_wide_destructure_whole_body`,
-     and function analogues like `redirectElectronAppWithCustomToken` keeping its
-     whole then+catch). Still open, and **distinct from the nested-literal gap
-     above.** The two disabled fixtures have no same-shape sibling, so the read-off
-     never keeps the body to prove uniqueness: the structural fast path
-     (`render_via_read_off`) / keep-shallow var path emits a _vacuous_ selector
-     (`class X { CLASS_REST }`, `const X = ANYTHING`), not the real-spec "kept
-     verbatim". Closing them needs a **robustness-anchor policy** — keep a stable
-     deep value anchor (holed down) even when the bare scaffold already resolves,
-     which directly trades against the fast path's current "leanest scaffold
-     preferred" rationale — and, for the component case, `collect_expr_anchors` /
-     `hole_expr` recursion into function/arrow-valued initializers plus the var →
-     read-off migration (item 6). The "minimal subtree set that still proves
-     unique" framing degenerates to the empty set on a sibling-less fixture, so
-     the win there is robustness, not cardinality-minimality; the real-spec
-     cover-keeps-the-body case is the interior set-cover at subtree granularity.
-3. **Class** body among siblings (91 full + 268 holed; worst severity, ~1,151-line
-   bodies) — `CLASS_REST` + discriminating member (`class_among_many_siblings`,
-   `sibling_subclass_hierarchy`, `class_body`). **Landed.** `minimize_class_selector`
-   routes single-target classes through `render_via_read_off`, holing `extends` to
-   `ANYTHING` (the superclass identifier is alpha-volatile) and falling back to
-   the cover search when the read-off cannot single the class out. Two design
-   points that made it work:
-   - **Value-over-name ranking.** The read-off's third ranking key (above `cost`,
-     below selectivity/stability) prefers a semantic **value** anchor (literal,
-     object key) over a bare **name/reference** (class-member / member-property
-     name) over a **structural** feature. So among equally selective anchors the
-     subclass pins `kind = "uniqueDiscriminatorShape"` rather than the equally
-     selective `area` method name, and the many-siblings class pins the unique
-     `accept:` string — the value survives a rebuild where a renamed method would
-     not. (The earlier WIP predated this key and the now-merged `cost` key, so it
-     anchored on whatever was shortest/structural.)
-   - **Selectivity still dominates.** A genuinely unique member _name_ (a sole
-     `dispose`/`constructor`) is strictly more selective than a value pair, so the
-     ranking can't override it — `class_body`'s fixture was tightened so all
-     siblings share the constructor/render/dispose shape and the only discriminator
-     is the `format`+`"stable"` body pair, which is what the case is meant to test.
-4. **Long-literal-value anchor** (~25; extreme severity, clean fix) — prefer a
-   short discriminating key over the largest node (`long_literal_value_anchor`).
-   **(Landed: #2281 — retained-source cost tiebreak; skeletons rank last on cost.)**
-5. **Object-dict family** — over-pinned keys (`object_keys_over_pinned`, done for
-   single scalar), grouped objects (`grouped_enum_objects`: `DECLARATORS` + padded
-   `OBJECT_PROPS`, **landed** — see key-set below), and the still-open
-   nested-value dicts (`object_nested_value_dict`) and wide destructure
-   (`wide_destructure_block`).
-   - **Key-set minimization (gaffer-dogfood feedback). Landed (#2290).** When an
-     object is discriminated by its _key set_ rather than any value — every value
-     already holed to `ANYTHING`, e.g. a CSS-styles dict
-     `{ diagnosticsSection: ANYTHING, detailsToggle: ANYTHING, … 11 keys }` — the
-     minimizer used to keep **every** key. It now keeps only the **minimal key
-     subset** whose presence discriminates the target from its siblings and
-     collapses the rest to `OBJECT_PROPS` (the key-set analogue of greedy
-     set-cover: anchor the rarest discriminating keys, `OBJECT_PROPS` the common
-     ones). `hole_object_padded` interleaves `OBJECT_PROPS` between every kept prop
-     so a multi-key subset survives key reorder; `try_object_read_off` runs on the
-     per-declarator object even inside a `DECLARATORS_BEFORE`/`_AFTER` group, with
-     a slot-aware `cover_object_slot` greedy (scores by whether the _target
-     binding's_ slot resolves, since the matcher reports one alignment per body)
-     for the per-slot key sets the chunk-wide read-off cannot see. E2E:
-     `object_key_set_group`, `object_key_set_subset`, `grouped_enum_objects`.
-     Still open: the `ee({ coreMessage: …, type: …, … })` schema-object form is a
-     **call** kept whole (the no-sparse-anchor body family, item 2b), not the
-     object-literal-valued var this covers.
-6. **Var migration.** Single-target `var`/`let`/`const` now reads off the shape
-   index (`try_var_read_off`, objects via `try_object_read_off`), mirroring
-   function/class. **Landed.** This drilled `deeply_nested_call_args` down to the
-   discriminating leaf (still ignored: bare-function callees stay pinned and
-   dropped args hole to arity-exact `ANYTHING`, not `ARGS` — cross-cutting
-   `hole_callee`/`hole_args` policy). Still open: **multi-target binding groups**
-   (per-slot declarator-tuple resolution; they keep the keep-shallow path) and
-   **statement runs** (`sequential_assignment_block`).
-7. **Anti-unification grouping** from posting co-occurrence (shared declaration OR
-   minimal-selector overlap threshold) → `binding_group`. The shared-declaration
-   trigger (multi-declarator var) and the adjacent-function sub-item below have
+1. **Interior holing of no-sparse-anchor bodies (the dominant lever; GitHub
+   #2289).** When uniqueness was proven by the full body, nothing is holed. Two sub-cases: (a) sibling-less single targets emit a _vacuous_ selector
+   (`class X { CLASS_REST }`, `const X = ANYTHING`) — disabled fixtures
+   `single_target_class_whole_body`, `component_wide_destructure_whole_body`;
+   (b) real-spec bodies with a genuine deep unique anchor the renderer can't
+   interleave holes down to (`nr_name === "HAS IMAGE"`, `n.BundleInstaller`),
+   wrongly bucketed "no sparse selector". Closing needs a **robustness-anchor
+   policy** (keep a holed-down deep value anchor even when the bare scaffold
+   already resolves — trades against the current "leanest scaffold preferred" fast
+   path) plus interior set-cover at subtree granularity. Reclaims a meaningful
+   share of the ~2,024 "no sparse selector" tail, not just the ~200 bulky-convertible.
+2. **Object-dict family — remaining forms.** Nested-value dicts
+   (`object_nested_value_dict`: hole all but one anchored nested property) and wide
+   destructure (`wide_destructure_block`: `OBJECT_PROPS` around the one
+   discriminating destructured property). The `ee({ coreMessage: …, type: … })`
+   schema-object-call form is a call kept whole — folds into item 1.
+3. **Multi-target var binding-group read-off.** Groups still use the keep-shallow
+   path (`minimize_var_group_selector`) because per-slot declarator-tuple
+   resolution is something the chunk-wide read-off cannot express. Designing a
+   per-slot anchor union proven through the binding-group matcher would let groups
+   read off too — the last consumer of the keep-shallow cover and the gate for
+   items 6/7 below.
+4. **Statement runs** (`sequential_assignment_block`): `STMT_LIST` holes on both
+   sides of the one assignment whose RHS carries the discriminating literal.
+5. **General co-occurrence grouping → `binding_group`.** The shared-declaration
+   trigger (multi-declarator var) and adjacent same-shape function runs have
    landed; the general co-occurrence trigger for non-function runs (statement runs,
-   sibling object/class declarations that are not a single var statement) is still
-   open.
-   - **Adjacent same-shape function declarations (gaffer-dogfood feedback).**
-     **Landed.** `merge_adjacent_function_runs` (in `selector_codemod.rs`) collapses
-     a maximal run of adjacent single-target function declarations whose
-     individually-minimized selectors share the same canonical shape into one
-     run-based `binding_group` (the `source_match` is the run of declarations,
-     `exports` maps each), instead of N standalone selectors. The minimal-selector
-     overlap is realized as exact canonical-shape equality computed on the
-     _minimized_ selectors: each accessor minimizes to its single discriminating
-     member with the shared receiver chain holed to `ANYTHING`, so a DRY cluster
-     collapses to one shape once every identifier / member-key / literal leaf is
-     blanked (`selector_shape_signature`). The merged run-selector is re-proven
-     through the matcher gate; on proof failure the run is emitted individually.
-     E2E: `adjacent_accessor_group`. Real-spec analogue: `app/state/accessors.yaml`
-     `use{AppUser,NodeSpace,FocusService,CoreServices}`.
-8. **Delete the cover search.** The branch-and-bound cover (`minimize_via_retention`,
-   `cover_competitors`, `min_set_cover`, the function/class anchor collectors,
-   `AnchorCandidates::tiers`) is **deleted** — read-off subsumed it once W3 added
-   number/bool features (−305 lines). Remaining cover: the multi-target var
-   binding-group keep-shallow path, retired only once group read-off (item 6) lands.
-9. **`selector_codemod.rs` refactor** — the cover deletion reshaped the file
-   (~4.2k lines); a by-form split is still open and enables parallel per-form
-   fan-out.
-10. **Language simplification** (see below).
-11. **W4 — whole-spec validation:** **hard budget met** — whole chunk ~13s after
-    #2280 (was ~110s), every sub-scope ≤8s; ≤10s ideal narrowly missed. Measured
-    and recorded in the dogfood note.
-12. **Perf — close the ≤10s ideal (index-build cost).** With the prove-gate cheap,
-    the remaining cost is dominated by the **index build**, not parsing or the
-    per-member proof. callgrind on the real chunk (see
-    <../debug/selector_minimizer_perf.md>) attributes the top self-cost to
-    `Ord::cmp` on `SelectorFeature` / `ShapeFeature` / `ShapeNode` (String-label
-    `memcmp`) inside the `BTreeMap`/`BTreeSet` build, plus ~30% allocator churn
-    (`malloc`/`free`/`malloc_consolidate`) from the many small posting-list nodes.
-    Targets, highest-leverage first: (a) **intern feature labels to integer IDs**
-    so feature comparison is an int compare, not `memcmp` on Strings; (b) swap the
-    posting-list `BTreeMap`/`BTreeSet` for a hashed map (`FxHashMap`/`FxHashSet`)
-    where ordered iteration isn't required; (c) reserve/amortise allocations in
-    `SelectorCandidateIndex::new` / `ShapeIndex::with_extractor`. Any one likely
-    recovers the last ~3s. **(Landed: #2291 — did (b)+(c) with
-    `roaring::RoaringBitmap` posting lists (the standard inverted-index structure,
-    `CandidateSet`) keyed by `FxHashMap` inverted indices + hash-cons table; (a)
-    interning was not needed. Measured: ≈1.8× faster index build / 4.5× faster
-    read-off on the synthetic sweep; real-chunk same-spec whole-chunk ~8.2s → ~7.3s
-    median (roaring's per-container overhead keeps RSS flat with the baseline on
-    this selective-heavy chunk — a bespoke sorted `Vec<u32>` would be ~21 MB leaner
-    but non-standard). Identical posting contents / `OPT=1` distribution; soundness
-    stays gated by `shape_index_soundness_test.rs`. See
-    <../debug/selector_minimizer_perf.md>.)**
-13. **Dogfood-apply on gaffer-private (in progress).** Run `synthesize-selectors
---apply` on the real spec, review for over-pin, and PR the beneficial minimized
-    selectors (fragile minified-name pins → forward-compatible `source_match`). On
-    the first apply ~79% of conversions were sparse/beneficial and ~21% over-pinned
-    (187 fully verbatim); the operational PR rule is **revert any converted selector
-    whose `match` block is >40 lines AND has ≤2 holes** back to a name pin (a
-    900-line verbatim pin is no less fragile than a 1-line minified-name pin, just
-    bigger). The over-pin patterns feed the disabled E2E cases
-    (`single_target_class_whole_body`, `component_wide_destructure_whole_body`, and
-    the existing `object_nested_value_dict` / `long_literal_value_anchor`, now
-    confirmed live on the real spec). Re-applies as each later wave lands; keep
-    pin-compatible and regen pipeline goldens.
-
-Each capability re-applies to gaffer-private as it lands (review diffs for
-over-pin; gaffer validates with a _pinned_ debundle release, so spec PRs must
-regen the pipeline goldens and stay pin-compatible).
+   sibling object/class declarations that are not a single var statement) is open.
+6. **Retire the keep-shallow group cover** once item 3 lands — removes
+   `minimize_var_group_selector`'s escalation path, `collect_expr_anchors`, and
+   `AnchorCandidates::{shallow_literals,deep_cover_tiers}`.
+7. **`selector_codemod.rs` by-form split** — the file is ~4.2k lines; splitting by
+   form enables parallel per-form fan-out (do after item 6 reshapes the var path).
+8. **Language simplification** (see below) — emit anonymous `OBJECT_PROPS` /
+   `DECLARATORS` / `CLASS_REST` / `EXPR` / `STMT` as `ANYTHING`. Deferred until
+   emission stabilizes (after the cover/keep-shallow paths fully retire), since it
+   rewrites emitted selectors and touches many fixtures.
+9. **`deeply_nested_call_args` — callee/arg holing.** The var read-off drills to
+   the leaf but keeps bare-function callees pinned (`hole_callee` keeps a bare
+   function reference) and holes dropped args to arity-exact `ANYTHING` rather than
+   a variadic `ARGS` run-hole. Closing both is a cross-cutting `hole_callee` /
+   `hole_args` policy change affecting all read-off paths; weigh against existing
+   fixtures.
+10. **Dogfood-apply on gaffer-private (ongoing).** Run `synthesize-selectors
+--apply` on the real spec after each wave, review for over-pin, and PR the
+    beneficial minimized selectors. Operational PR rule: **revert any converted
+    selector whose `match` block is >40 lines AND has ≤2 holes** back to a name pin.
+    Keep pin-compatible (gaffer validates with a _pinned_ debundle release) and
+    regen the pipeline goldens. Each capability above re-applies here as it lands.
 
 ## Orchestration & process notes
 

--- a/devinfra/js/debundle/plans/readoff_minimization.md
+++ b/devinfra/js/debundle/plans/readoff_minimization.md
@@ -145,13 +145,16 @@ exist in `source_match_holes.rs` and the matcher (`match_list_with_holes`):
 Regex-over-string-literal anchors (`STR_LITERAL_MATCHING_RE`) fire for
 stable-prefix/volatile-tail strings (trailing hex/digit runs).
 
-**Strangler-fig boundary.** The cover search (`minimize_via_retention`,
-`cover_competitors`, the B&B `min_set_cover`, `collect_*_anchors`) is **not
-deleted**; it backs single-target var (non-object) and the binding-group /
-multi-declarator paths, plus any tail a read-off cannot yet single out (including
-single-target classes whose own value features don't discriminate).
-`selector_codemod.rs` is ~3.7k lines and shrinks substantially once the cover is
-removed.
+**Strangler-fig boundary.** The matcher-driven branch-and-bound cover search
+(`minimize_via_retention`, `cover_competitors`, `min_set_cover`, and the
+function/class anchor collectors) is **deleted**: single-target function, class,
+object, and var all route through the read-off, which subsumes it once W3 added
+number/bool features (its last reason to exist). A target the read-off cannot
+single out is reported as debt, never full-AST-pinned. The one cover that
+remains is the **multi-target var binding-group keep-shallow path**
+(`minimize_var_group_selector` + `collect_expr_anchors` +
+`AnchorCandidates::{shallow_literals,deep_cover_tiers}`), which does the per-slot
+tuple resolution the chunk-wide read-off cannot express.
 
 **Measured perf.** Whole ~7 MB / ~4.5k-member chunk minimizes in **~13 s** with
 the prove-gate-via-index fast-path (#2280), down from ~110 s — **meets the ≤30 s
@@ -333,8 +336,14 @@ non-minimal pattern catalog drives this and is encoded as disabled E2E cases.
      Still open: the `ee({ coreMessage: …, type: …, … })` schema-object form is a
      **call** kept whole (the no-sparse-anchor body family, item 2b), not the
      object-literal-valued var this covers.
-6. **Statement runs** (`sequential_assignment_block`, `deeply_nested_call_args`)
-   and **var** migration (needs binding-group/declarator-slot tuple resolution).
+6. **Var migration.** Single-target `var`/`let`/`const` now reads off the shape
+   index (`try_var_read_off`, objects via `try_object_read_off`), mirroring
+   function/class. **Landed.** This drilled `deeply_nested_call_args` down to the
+   discriminating leaf (still ignored: bare-function callees stay pinned and
+   dropped args hole to arity-exact `ANYTHING`, not `ARGS` — cross-cutting
+   `hole_callee`/`hole_args` policy). Still open: **multi-target binding groups**
+   (per-slot declarator-tuple resolution; they keep the keep-shallow path) and
+   **statement runs** (`sequential_assignment_block`).
 7. **Anti-unification grouping** from posting co-occurrence (shared declaration OR
    minimal-selector overlap threshold) → `binding_group`. The shared-declaration
    trigger (multi-declarator var) and the adjacent-function sub-item below have
@@ -355,11 +364,14 @@ non-minimal pattern catalog drives this and is encoded as disabled E2E cases.
      through the matcher gate; on proof failure the run is emitted individually.
      E2E: `adjacent_accessor_group`. Real-spec analogue: `app/state/accessors.yaml`
      `use{AppUser,NodeSpace,FocusService,CoreServices}`.
-8. **Delete the cover search** once all forms route through read-off
-   (`minimize_via_retention`, `cover_competitors`, `min_set_cover`,
-   `collect_*_anchors`) — shrinks `selector_codemod.rs` substantially.
-9. **`selector_codemod.rs` refactor** — after cover deletion (deletion reshapes
-   the file; splitting by form earlier also enables parallel per-form fan-out).
+8. **Delete the cover search.** The branch-and-bound cover (`minimize_via_retention`,
+   `cover_competitors`, `min_set_cover`, the function/class anchor collectors,
+   `AnchorCandidates::tiers`) is **deleted** — read-off subsumed it once W3 added
+   number/bool features (−305 lines). Remaining cover: the multi-target var
+   binding-group keep-shallow path, retired only once group read-off (item 6) lands.
+9. **`selector_codemod.rs` refactor** — the cover deletion reshaped the file
+   (~4.2k lines); a by-form split is still open and enables parallel per-form
+   fan-out.
 10. **Language simplification** (see below).
 11. **W4 — whole-spec validation:** **hard budget met** — whole chunk ~13s after
     #2280 (was ~110s), every sub-scope ≤8s; ≤10s ideal narrowly missed. Measured

--- a/devinfra/js/debundle/selector_codemod.rs
+++ b/devinfra/js/debundle/selector_codemod.rs
@@ -1480,7 +1480,7 @@ fn synthesize_specialized_var_selector(
 }
 
 // ===========================================================================
-// Retention-driven selector minimizer.
+// Selector minimizer (read-off based).
 //
 // A selector is the target rendered with a *retention set*: the byte spans of
 // the concrete tokens (literals, member/property names, callees, object keys)
@@ -1489,19 +1489,21 @@ fn synthesize_specialized_var_selector(
 // run holes `STMT_LIST` / `OBJECT_PROPS` / `CLASS_REST` for dropped statement /
 // object-property / class-member runs.
 //
-// Anchor selection favors keeping shallow literals (direct values/args), then
-// escalates by tier (structural key/member presence, then deeper literals).
-// Function and class single targets resolve through a matcher-driven minimum
-// set cover (`cover_competitors` + `min_set_cover` B&B): each anchor's exclusion
-// set is computed by the production matcher, so discrimination is exact and the
-// cover is minimum-cardinality. Var declarations (single and multi-target
-// groups) share one keep-shallow-then-escalate path (`minimize_var_group_selector`,
-// the single declarator being its N=1 case), proven through the binding-group
-// matcher used as a resolves-uniquely oracle; it keeps each slot's direct shallow
-// literals and may over-pin rather than run an exact-minimum cover. Either way the
-// chosen union is rendered once and proven by the matcher. This is a mechanical
-// first pass — it finds *a* robust pin for the routine cases, not necessarily the
-// most semantically meaningful one.
+// Single targets (function, class, object, and non-object var) read their
+// minimal anchor set off the chunk-wide shape index (`render_via_read_off` /
+// `try_object_read_off` / `try_var_read_off`): the index ranks each candidate
+// feature by selective × stable, so the chosen anchors are sparse and
+// rebuild-robust, and the production matcher proves the rendered selector
+// resolves uniquely (gate 1). A target the read-off cannot single out returns
+// `None` and is reported as debt — never a full-AST pin.
+//
+// Multi-target var binding groups still use a keep-shallow path
+// (`minimize_var_group_selector`): per-slot tuple resolution the chunk-wide
+// read-off cannot express. It keeps each slot's direct shallow literals,
+// escalating to structural/deeper anchors only until the group resolves to the
+// right declarators, proven through the binding-group matcher as a
+// resolves-uniquely oracle; it may over-pin rather than run an exact-minimum
+// cover (near-minimal is the accepted target).
 // ===========================================================================
 
 /// `(lo, hi)` byte offsets of a retained concrete token.
@@ -1879,47 +1881,6 @@ struct AnchorCandidates {
 const SHALLOW_LITERAL_DEPTH: u32 = 1;
 
 impl AnchorCandidates {
-    /// Anchor tiers, most-preferred first:
-    /// 1. shallow literals (direct values/args), by ascending call depth;
-    /// 2. structural key/member presence;
-    /// 3. deeper literals (buried in nested calls).
-    ///
-    /// Structural presence sits above deep literals because pinning a key's
-    /// existence is leaner and more rebuild-robust than pinning a volatile
-    /// computed value (`stableKey: ANYTHING` over `stableKey: mk("x")`).
-    fn tiers(&self) -> Vec<Vec<AnchorSpan>> {
-        let literal_tier = |depth: u32| -> Vec<AnchorSpan> {
-            self.literals
-                .iter()
-                .filter(|(_, anchor_depth)| *anchor_depth == depth)
-                .map(|(span, _)| *span)
-                .collect()
-        };
-        let mut tiers = Vec::new();
-        let Some(max_depth) = self.literals.iter().map(|(_, depth)| *depth).max() else {
-            if !self.structural.is_empty() {
-                tiers.push(self.structural.clone());
-            }
-            return tiers;
-        };
-        for depth in 0..=max_depth.min(SHALLOW_LITERAL_DEPTH) {
-            let tier = literal_tier(depth);
-            if !tier.is_empty() {
-                tiers.push(tier);
-            }
-        }
-        if !self.structural.is_empty() {
-            tiers.push(self.structural.clone());
-        }
-        for depth in (SHALLOW_LITERAL_DEPTH + 1)..=max_depth {
-            let tier = literal_tier(depth);
-            if !tier.is_empty() {
-                tiers.push(tier);
-            }
-        }
-        tiers
-    }
-
     /// Shallow literal anchors — direct values/args worth keeping as meaningful
     /// per-slot pins even when structure alone would already discriminate. This
     /// includes object-property values (`kind: "primary"`): the unified anchor
@@ -1958,77 +1919,10 @@ impl AnchorCandidates {
     }
 }
 
-fn collect_stmt_list_anchors(stmts: &[Stmt]) -> AnchorCandidates {
-    let mut candidates = AnchorCandidates::default();
-    for stmt in stmts {
-        collect_stmt_anchors(stmt, &mut candidates);
-    }
-    candidates
-}
-
-fn collect_stmt_anchors(stmt: &Stmt, candidates: &mut AnchorCandidates) {
-    match stmt {
-        Stmt::Expr(expr_stmt) => collect_expr_anchors(&expr_stmt.expr, 0, candidates),
-        Stmt::Return(ret) => {
-            if let Some(arg) = &ret.arg {
-                collect_expr_anchors(arg, 0, candidates);
-            }
-        }
-        Stmt::Throw(throw) => collect_expr_anchors(&throw.arg, 0, candidates),
-        Stmt::Decl(Decl::Var(var)) => {
-            for declarator in &var.decls {
-                if let Some(init) = &declarator.init {
-                    collect_expr_anchors(init, 0, candidates);
-                }
-            }
-        }
-        Stmt::If(if_stmt) => {
-            collect_expr_anchors(&if_stmt.test, 0, candidates);
-            collect_block_anchors(&if_stmt.cons, candidates);
-        }
-        Stmt::Try(try_stmt) => {
-            for stmt in &try_stmt.block.stmts {
-                collect_stmt_anchors(stmt, candidates);
-            }
-        }
-        Stmt::Block(block) => {
-            for stmt in &block.stmts {
-                collect_stmt_anchors(stmt, candidates);
-            }
-        }
-        Stmt::Switch(switch) => {
-            collect_expr_anchors(&switch.discriminant, 0, candidates);
-            for case in &switch.cases {
-                // A case test literal (`case "x":`) is the discriminating
-                // landmark that the `CASE_REST` hole keeps; collect it as a
-                // shallow literal so the cover can retain it.
-                if let Some(test) = &case.test {
-                    collect_expr_anchors(test, 0, candidates);
-                }
-                for stmt in &case.cons {
-                    collect_stmt_anchors(stmt, candidates);
-                }
-            }
-        }
-        _ => {}
-    }
-}
-
-fn collect_block_anchors(stmt: &Stmt, candidates: &mut AnchorCandidates) {
-    match stmt {
-        Stmt::Block(block) => {
-            for stmt in &block.stmts {
-                collect_stmt_anchors(stmt, candidates);
-            }
-        }
-        _ => collect_stmt_anchors(stmt, candidates),
-    }
-}
-
-/// `depth` counts enclosing call/new levels, so the tiered cover can prefer
-/// shallower literal anchors. Object-property values (`kind: "primary"`) are
-/// collected at the enclosing depth like any other literal; the unified
-/// keep-shallow policy retains them rather than treating them as incidental.
+/// `depth` counts enclosing call/new levels, so the keep-shallow group path can
+/// prefer shallower literal anchors. Object-property values (`kind: "primary"`)
+/// are collected at the enclosing depth like any other literal; the keep-shallow
+/// policy retains them rather than treating them as incidental.
 fn collect_expr_anchors(expr: &Expr, depth: u32, candidates: &mut AnchorCandidates) {
     match expr {
         Expr::Lit(_) | Expr::Tpl(_) => {
@@ -2119,7 +2013,8 @@ fn matched_binding_candidates(
 }
 
 /// Distinct body indices the selector resolves to (slot alignments within one
-/// body collapse). Used by the body-index cover ([`cover_competitors`]).
+/// body collapse). Used by the read-off structural fast path
+/// ([`render_via_read_off`]).
 fn matched_body_indices(
     index: &ChunkSelectorIndex,
     export_name: &str,
@@ -2149,37 +2044,6 @@ fn holes_present(source: &str) -> BTreeSet<String> {
     holes
 }
 
-/// Minimal anchor cover for a single-target declaration. `render_with` renders
-/// the declaration's selector given a kept-anchor set, and `candidates` are its
-/// concrete anchors. Competitors are exactly the items the maximally-holed
-/// selector still matches; the tiered cover picks the fewest anchors that rule
-/// them out, and the chosen selector is rendered and proven once.
-fn minimize_via_retention(
-    index: &ChunkSelectorIndex,
-    decl: &IndexedDeclaration,
-    target: &SynthesizedTargetBinding,
-    candidates: &AnchorCandidates,
-    render_with: &impl Fn(&BTreeSet<AnchorSpan>) -> Result<String>,
-) -> Result<Option<SpecializedSelector>> {
-    let empty = BTreeSet::new();
-    let mut competitors = matched_body_indices(index, &target.export_name, &render_with(&empty)?)?;
-    competitors.remove(&decl.body_idx);
-    if competitors.is_empty() {
-        return finish_minimized_selector(index, decl, target, render_with(&empty)?);
-    }
-    let Some(chosen) = cover_competitors(
-        index,
-        target,
-        &competitors,
-        &candidates.tiers(),
-        render_with,
-    )?
-    else {
-        return Ok(None);
-    };
-    finish_minimized_selector(index, decl, target, render_with(&chosen)?)
-}
-
 fn minimize_function_selector(
     index: &ChunkSelectorIndex,
     function: &Function,
@@ -2201,26 +2065,14 @@ fn minimize_function_selector(
             function: Box::new(holed),
         }))))
     };
-    // W2: single-target functions read their minimal anchor set off the shape
-    // index instead of running the cover search. The holed scaffold already
-    // pins the param arity (one `ANYTHING` per real param), so a structural /
-    // skeleton anchor needs no kept span; value anchors (string literals,
-    // member/method names, member-path callees) map to the spans of the tokens
-    // that exhibit them. The matcher proves the result (gate 1).
-    //
-    // Fallback: when the read-off cannot single out the target through its own
-    // features — chiefly because the discriminator is a *number/bool* literal,
-    // which the W1 feature taxonomy does not yet index (string literals only) —
-    // it returns `None` and we fall through to the cover search, which collects
-    // every literal kind. This keeps the migration honest (read-off is the
-    // primary path; the cover is the not-yet-expressible tail), not full-AST:
-    // the cover itself skips rather than dumping an untrimmed body. A later wave
-    // that extends the feature taxonomy can drop this fallback.
-    if let Some(selector) = render_via_read_off(index, decl, target, &render_with)? {
-        return Ok(Some(selector));
-    }
-    let candidates = collect_stmt_list_anchors(&body.stmts);
-    minimize_via_retention(index, decl, target, &candidates, &render_with)
+    // Single-target functions read their minimal anchor set off the shape index.
+    // The holed scaffold already pins the param arity (one `ANYTHING` per real
+    // param), so a structural / skeleton anchor needs no kept span; value anchors
+    // (string/number/bool literals, member/method names, member-path callees) map
+    // to the spans of the tokens that exhibit them. The matcher proves the result
+    // (gate 1); a target the read-off cannot single out returns `None` and is
+    // reported as debt (never a full-AST pin).
+    render_via_read_off(index, decl, target, &render_with)
 }
 
 /// Render a single-target selector via the W1 read-off API (W2).
@@ -2490,10 +2342,10 @@ fn object_anchor_ranking(object: &ObjectLit) -> Vec<AnchorSpan> {
 /// Slot-aware minimal cover for a single-target object inside a `var` group: a
 /// greedy key-set set-cover that, at each step, adds the `ranked` anchor that best
 /// steers the selector toward resolving to the target binding's own declarator
-/// slot, until it proves unique. Unlike [`cover_competitors`] (which covers
-/// distinct body indices and so cannot see two sibling declarators of the *same*
-/// statement), this scores by whether the **target binding** is the one the
-/// selector resolves, then by the match count.
+/// slot, until it proves unique. The chunk-wide read-off resolves by distinct
+/// body index and so cannot see two sibling declarators of the *same* statement;
+/// this scores by whether the **target binding** is the one the selector
+/// resolves, then by the match count.
 ///
 /// The matcher reports one alignment per body (the leftmost declarator the holed
 /// pattern fits), so a key shared with an *earlier* sibling slot
@@ -2961,14 +2813,10 @@ fn minimize_class_selector(
     // functions and objects do: the holed scaffold pins the class kind plus
     // `extends ANYTHING`, and value anchors (a member name, a literal or callee
     // inside a member body) map to their token spans so only the member runs
-    // carrying them survive between `CLASS_REST` holes. Fall back to the tiered
-    // cover search when the read-off cannot single the class out through its own
-    // value features.
-    if let Some(selector) = render_via_read_off(index, decl, target, &render_with)? {
-        return Ok(Some(selector));
-    }
-    let candidates = collect_class_anchors(class);
-    minimize_via_retention(index, decl, target, &candidates, &render_with)
+    // carrying them survive between `CLASS_REST` holes. A class the read-off
+    // cannot single out through its own value features returns `None` and is
+    // reported as debt (never a full-AST pin).
+    render_via_read_off(index, decl, target, &render_with)
 }
 
 fn anything_param() -> Param {
@@ -3062,159 +2910,6 @@ fn emit_selector(item: ModuleItem) -> Result<String> {
         body: vec![item],
         shebang: None,
     })
-}
-
-fn collect_class_anchors(class: &Class) -> AnchorCandidates {
-    let mut candidates = AnchorCandidates::default();
-    for member in &class.body {
-        if let Some(span) = class_member_name_span(member) {
-            candidates.structural.push(span_key(span));
-        }
-        match member {
-            ClassMember::Method(m) => collect_block_stmt_anchors(&m.function.body, &mut candidates),
-            ClassMember::PrivateMethod(m) => {
-                collect_block_stmt_anchors(&m.function.body, &mut candidates)
-            }
-            ClassMember::Constructor(ctor) => {
-                collect_block_stmt_anchors(&ctor.body, &mut candidates)
-            }
-            ClassMember::ClassProp(prop) => {
-                if let Some(value) = &prop.value {
-                    collect_expr_anchors(value, 0, &mut candidates);
-                }
-            }
-            _ => {}
-        }
-    }
-    candidates
-}
-
-fn collect_block_stmt_anchors(body: &Option<BlockStmt>, candidates: &mut AnchorCandidates) {
-    if let Some(block) = body {
-        for stmt in &block.stmts {
-            collect_stmt_anchors(stmt, candidates);
-        }
-    }
-}
-
-fn class_member_name_span(member: &ClassMember) -> Option<Span> {
-    let prop_name_span = |name: &PropName| match name {
-        PropName::Ident(ident) => Some(ident.span),
-        _ => None,
-    };
-    match member {
-        ClassMember::Method(m) => prop_name_span(&m.key),
-        ClassMember::ClassProp(prop) => prop_name_span(&prop.key),
-        _ => None,
-    }
-}
-
-/// Tiered minimum set cover. Tiers are tried most-preferred first; within a
-/// tier, the matcher gives each anchor's exclusion set and a minimum-cardinality
-/// cover (branch-and-bound) clears as many still-uncovered competitors as the
-/// tier can, leaving the rest to later tiers. Tier order encodes meaning
-/// preference; minimum cardinality within a tier avoids greedy over-pinning.
-/// The final selector is proven once by the caller. Returns `None` if even all
-/// anchors together cannot single out the target.
-fn cover_competitors(
-    index: &ChunkSelectorIndex,
-    target: &SynthesizedTargetBinding,
-    competitors: &BTreeSet<usize>,
-    tiers: &[Vec<AnchorSpan>],
-    render_with: &impl Fn(&BTreeSet<AnchorSpan>) -> Result<String>,
-) -> Result<Option<BTreeSet<AnchorSpan>>> {
-    let mut uncovered = competitors.clone();
-    let mut chosen = BTreeSet::new();
-    for tier in tiers {
-        if uncovered.is_empty() {
-            break;
-        }
-        let mut exclusions: Vec<(AnchorSpan, BTreeSet<usize>)> = Vec::new();
-        for &anchor in tier.iter().take(MAX_MINIMIZER_ANCHORS) {
-            let survivors = matched_body_indices(
-                index,
-                &target.export_name,
-                &render_with(&BTreeSet::from([anchor]))?,
-            )?;
-            let excluded: BTreeSet<usize> = uncovered.difference(&survivors).copied().collect();
-            if !excluded.is_empty() {
-                exclusions.push((anchor, excluded));
-            }
-        }
-        let coverable: BTreeSet<usize> = exclusions
-            .iter()
-            .flat_map(|(_, excluded)| excluded.iter().copied())
-            .collect();
-        if coverable.is_empty() {
-            continue;
-        }
-        for anchor in min_set_cover(&exclusions, &coverable) {
-            chosen.insert(anchor);
-        }
-        uncovered = uncovered.difference(&coverable).copied().collect();
-    }
-    if uncovered.is_empty() {
-        Ok(Some(chosen))
-    } else {
-        Ok(None)
-    }
-}
-
-/// Minimum-cardinality set cover of `universe` by `sets` (each an anchor and the
-/// competitors it excludes). Branch-and-bound on the least-coverable element;
-/// `universe` is the union of all sets, so a cover always exists. Instances are
-/// tiny (anchors and competitors are per-chunk), so exhaustive search with
-/// best-length pruning stays well within budget and avoids greedy over-pinning.
-fn min_set_cover(
-    sets: &[(AnchorSpan, BTreeSet<usize>)],
-    universe: &BTreeSet<usize>,
-) -> Vec<AnchorSpan> {
-    let mut best: Option<Vec<AnchorSpan>> = None;
-    let mut chosen: Vec<AnchorSpan> = Vec::new();
-    min_set_cover_search(sets, universe.clone(), &mut chosen, &mut best);
-    best.unwrap_or_default()
-}
-
-fn min_set_cover_search(
-    sets: &[(AnchorSpan, BTreeSet<usize>)],
-    remaining: BTreeSet<usize>,
-    chosen: &mut Vec<AnchorSpan>,
-    best: &mut Option<Vec<AnchorSpan>>,
-) {
-    if remaining.is_empty() {
-        if best.as_ref().is_none_or(|found| chosen.len() < found.len()) {
-            *best = Some(chosen.clone());
-        }
-        return;
-    }
-    if best
-        .as_ref()
-        .is_some_and(|found| chosen.len() + 1 >= found.len())
-    {
-        return;
-    }
-    // Branch on the still-uncovered competitor that the fewest anchors exclude:
-    // every cover must include one of those anchors, which keeps the tree narrow.
-    let Some(pivot) = remaining.iter().copied().min_by_key(|competitor| {
-        sets.iter()
-            .filter(|(_, excluded)| excluded.contains(competitor))
-            .count()
-    }) else {
-        return;
-    };
-    for (anchor, excluded) in sets {
-        if chosen.contains(anchor) || !excluded.contains(&pivot) {
-            continue;
-        }
-        chosen.push(*anchor);
-        min_set_cover_search(
-            sets,
-            remaining.difference(excluded).copied().collect(),
-            chosen,
-            best,
-        );
-        chosen.pop();
-    }
 }
 
 fn finish_minimized_selector(

--- a/devinfra/js/debundle/selector_codemod.rs
+++ b/devinfra/js/debundle/selector_codemod.rs
@@ -2416,6 +2416,37 @@ fn collect_regex_anchor_candidates(init: &Expr) -> BTreeMap<AnchorSpan, String> 
     collector.candidates
 }
 
+/// Among kept string literals (`candidates` = span → derivable volatile-tail
+/// pattern), accept each `STR_LITERAL_MATCHING_RE` upgrade iff the upgraded
+/// selector *still* resolves uniquely (gate 1). The exact-literal form is the
+/// default; regex is opt-in by merit. Upgrades are applied one literal at a time
+/// so a too-broad pattern on one literal never blocks a sound upgrade on another.
+/// Shared by the read-off single-target var path and the keep-shallow group path.
+fn accepted_regex_anchors(
+    index: &ChunkSelectorIndex,
+    decl: &IndexedDeclaration,
+    targets: &[SynthesizedTargetBinding],
+    candidates: &BTreeMap<AnchorSpan, String>,
+    kept: &BTreeSet<AnchorSpan>,
+    render_with: &impl Fn(&BTreeSet<AnchorSpan>, &BTreeMap<AnchorSpan, String>) -> Result<String>,
+) -> Result<BTreeMap<AnchorSpan, String>> {
+    let mut regex_anchors: BTreeMap<AnchorSpan, String> = BTreeMap::new();
+    for (&span, pattern) in candidates {
+        if !kept.contains(&span) {
+            continue;
+        }
+        regex_anchors.insert(span, pattern.clone());
+        if prove_synthesized_selector(index, decl, targets, &render_with(kept, &regex_anchors)?)
+            .is_err()
+        {
+            // The regex anchor broke uniqueness (over-broad among siblings), so
+            // back it out and keep the exact literal.
+            regex_anchors.remove(&span);
+        }
+    }
+    Ok(regex_anchors)
+}
+
 /// A `DECLARATORS_<pos> = null` declarator hole absorbing a run of non-target
 /// declarators in a binding-group selector.
 fn declarator_hole(name: &str) -> VarDeclarator {
@@ -2616,6 +2647,120 @@ fn try_object_read_off(
     )
 }
 
+/// Read off a minimal selector for a single-target `var`/`let`/`const` whose
+/// target declarator value is **not** an object literal (objects route through
+/// [`try_object_read_off`]). Mirrors [`render_via_read_off`] (function/class) but
+/// slot-aware: holes non-target declarators to `DECLARATORS_*`, holes the target
+/// init with [`hole_expr`] around the read-off anchors, and restricts the kept
+/// spans to the target declarator so a group's chunk-wide anchor set never pins a
+/// span carried only by a sibling this selector holes away.
+///
+/// Deviation from the function/class read-off: there is no empty-kept structural
+/// fast path. A var's maximally-holed scaffold is the *degenerate* `const X =
+/// ANYTHING`, which pins nothing meaningful and would match any wrapped-const a
+/// rebuild adds (criterion 2). A var selector must keep a discriminating value
+/// anchor, so an empty anchor set yields `None` and the caller falls back to the
+/// keep-shallow group path.
+///
+/// Returns `None` — caller falls back — when the target is an object declarator,
+/// the read-off has no anchor set, every anchor lies outside the target slot, or
+/// the rendered selector fails the matcher gate.
+fn try_var_read_off(
+    index: &ChunkSelectorIndex,
+    var: &VarDecl,
+    decl: &IndexedDeclaration,
+    target: &SynthesizedTargetBinding,
+    target_slot: usize,
+) -> Result<Option<SpecializedSelector>> {
+    let declarator = &var.decls[target_slot];
+    let Some(init) = declarator.init.as_deref() else {
+        return Ok(None);
+    };
+    // Objects are `try_object_read_off`'s domain (padded `OBJECT_PROPS` + the
+    // slot-aware key-set cover); this owns every other initializer shape.
+    if matches!(init, Expr::Object(_)) {
+        return Ok(None);
+    }
+    let target_decl_span = declarator.span();
+    let targets = std::slice::from_ref(target);
+
+    let render_with = |kept: &BTreeSet<AnchorSpan>,
+                       regex_anchors: &BTreeMap<AnchorSpan, String>|
+     -> Result<String> {
+        let mut decls: Vec<VarDeclarator> = Vec::new();
+        let mut skipped_run = false;
+        let mut target_seen = 0usize;
+        for (idx, other) in var.decls.iter().enumerate() {
+            if idx != target_slot {
+                skipped_run = true;
+                continue;
+            }
+            if skipped_run {
+                decls.push(declarator_hole(declarator_hole_name(target_seen, 1)));
+                skipped_run = false;
+            }
+            let mut holed = other.clone();
+            holed.name = named_pat(&target.export_name);
+            let mut holed_init = hole_expr(init, kept);
+            if !regex_anchors.is_empty() {
+                holed_init.visit_mut_with(&mut RegexAnchorSubstitution {
+                    patterns: regex_anchors,
+                });
+            }
+            holed.init = Some(Box::new(holed_init));
+            decls.push(holed);
+            target_seen += 1;
+        }
+        if skipped_run {
+            decls.push(declarator_hole(declarator_hole_name(target_seen, 1)));
+        }
+        let mut holed_var = var.clone();
+        holed_var.declare = false;
+        holed_var.decls = decls;
+        emit_selector(ModuleItem::Stmt(Stmt::Decl(Decl::Var(Box::new(holed_var)))))
+    };
+
+    let Some(anchor_set) = index.shape_index.minimal_anchor_set(decl.body_idx) else {
+        return Ok(None);
+    };
+    let item = index
+        .parsed
+        .module
+        .body
+        .get(decl.body_idx)
+        .context("read-off body index no longer in module")?;
+    let kept: BTreeSet<AnchorSpan> = kept_spans_for_anchor_set(item, &anchor_set)
+        .into_iter()
+        .filter(|span| node_holds_anchor(target_decl_span, *span))
+        .collect();
+    if kept.is_empty() {
+        return Ok(None);
+    }
+    let no_regex = BTreeMap::new();
+    // Prove the read-off resolves uniquely before offering the regex upgrade; on
+    // failure the caller falls back to the keep-shallow group path.
+    if prove_synthesized_selector(index, decl, targets, &render_with(&kept, &no_regex)?).is_err() {
+        return Ok(None);
+    }
+    // Preserve the keep-shallow path's regex-literal upgrade: among kept string
+    // literals, swap a volatile-suffix value for a `STR_LITERAL_MATCHING_RE`
+    // anchor when the upgraded selector still resolves uniquely.
+    let regex_anchors = accepted_regex_anchors(
+        index,
+        decl,
+        targets,
+        &collect_regex_anchor_candidates(init),
+        &kept,
+        &render_with,
+    )?;
+    let source = render_with(&kept, &regex_anchors)?;
+    let rewritten_holes = holes_present(&source);
+    Ok(Some(SpecializedSelector {
+        match_source: source,
+        rewritten_holes,
+    }))
+}
+
 /// Minimal anchor cover for a `var`/`let`/`const` binding group: render the
 /// shared declaration keeping the target declarators (each `export = <holed
 /// init>`) with `DECLARATORS_*` holes for non-target runs, and pin just enough
@@ -2661,6 +2806,26 @@ fn minimize_var_group_selector(
     // proves it (gate 1); on `None` we fall through to the keep-shallow group path
     // below, so a target neither pass can single out is handled exactly as before.
     if let Some(selector) = try_object_read_off(index, var, decl, targets, &target_slots)? {
+        return Ok(Some(selector));
+    }
+
+    // W2 read-off for the single-target non-object var (mirroring function/class):
+    // read the sparse `selective × stable` anchor off the shape index and hole the
+    // initializer down to it, instead of the keep-shallow path's "keep every
+    // shallow literal" over-pin. On `None` (no anchor set, anchors outside the
+    // target slot, or not uniquely resolved) we fall through to the keep-shallow
+    // group path below; multi-target groups always use that path — the read-off is
+    // single-target (per-slot tuple resolution is still the cover's job).
+    if let [target] = targets
+        && target_slots.len() == 1
+        && let Some(selector) = try_var_read_off(
+            index,
+            var,
+            decl,
+            target,
+            *target_slots.iter().next().expect("one target slot"),
+        )?
+    {
         return Ok(Some(selector));
     }
 
@@ -2744,34 +2909,19 @@ fn minimize_var_group_selector(
         }
     }
 
-    // Regex-literal upgrade: among kept string literals, offer a robust
-    // `STR_LITERAL_MATCHING_RE` anchor for each that has a derivable
-    // stable-prefix/volatile-tail pattern, but only accept the upgrade when the
-    // resulting selector *still* resolves uniquely (gate 1). The exact-literal
-    // form is the default; regex is opt-in by merit. Upgrades are applied one
-    // literal at a time so a too-broad pattern on one literal never blocks a
-    // sound upgrade on another.
-    let mut regex_anchors: BTreeMap<AnchorSpan, String> = BTreeMap::new();
+    // Regex-literal upgrade over the kept string literals of every target slot
+    // (shared with the read-off path).
+    let mut regex_candidates: BTreeMap<AnchorSpan, String> = BTreeMap::new();
     for (idx, declarator) in var.decls.iter().enumerate() {
         if !target_slots.contains(&idx) {
             continue;
         }
-        let Some(init) = &declarator.init else {
-            continue;
-        };
-        for (span, pattern) in collect_regex_anchor_candidates(init) {
-            if !kept.contains(&span) || regex_anchors.contains_key(&span) {
-                continue;
-            }
-            regex_anchors.insert(span, pattern);
-            let trial = render_with(&kept, &regex_anchors)?;
-            if prove_synthesized_selector(index, decl, targets, &trial).is_err() {
-                // The regex anchor broke uniqueness (over-broad among siblings),
-                // so back it out and keep the exact literal.
-                regex_anchors.remove(&span);
-            }
+        if let Some(init) = &declarator.init {
+            regex_candidates.extend(collect_regex_anchor_candidates(init));
         }
     }
+    let regex_anchors =
+        accepted_regex_anchors(index, decl, targets, &regex_candidates, &kept, &render_with)?;
 
     let source = render_with(&kept, &regex_anchors)?;
     let rewritten_holes = holes_present(&source);


### PR DESCRIPTION
## Summary

Continues the read-off selector-minimizer program (`plans/readoff_minimization.md`). Migrates the last single-target form (`var`) onto the read-off path, then removes the branch-and-bound cover search it (together with the earlier function/class/object migrations) made dead.

## Changes

- **Single-target `var` read-off** (`16c5f029`). `var`/`let`/`const` now read their minimal selector off the shape index (`try_var_read_off`), mirroring function/class; objects keep the dedicated padded/key-set path. Holes the initializer with `hole_expr` around the selective×stable anchors and restricts kept spans to the target declarator. No empty-kept structural fast path (a var's holed scaffold is the degenerate `const X = ANYTHING`). The `STR_LITERAL_MATCHING_RE` regex-anchor upgrade is preserved across both paths via a new shared `accepted_regex_anchors` helper.

- **Delete the B&B cover** (`9a596c2a`, −305 lines). With function/class/object/var all on the read-off, the matcher-driven minimum-set-cover fallback is dead — it existed mainly for number/bool-literal discriminators the early feature taxonomy didn't index, and W3 added those features. Verified by disabling it under a flag (whole selector suite stays green, incl. the `123` number literal, class value-discrimination cases, and `switch_case_run`) and by the full 116-test debundle tree. Removed: `minimize_via_retention`, `cover_competitors`, `min_set_cover`/`min_set_cover_search`, the function/class anchor collectors, `AnchorCandidates::tiers()`. Function/class minimizers now return the read-off result directly; an unsingle-out-able target is reported as debt, never full-AST-pinned.

- **Docs** (`63ed282b`, `f4c2532b`). Refresh the `TODO.md` plan-index and `plans/readoff_minimization.md` to current state.

## Effects on existing fixtures (all matcher-proven unique, sparser)

- `object_property_literals`: object-in-call var picks the uniquely-present `onClick` key alone.
- `binding_group_partition` standalone: holes the shared `"settings"` arg + redundant `title`, keeps only `kind: "panel"` (the multi-target group still uses keep-shallow).
- `deeply_nested_call_args`: now drills to the discriminating leaf (kept ignored — bare-function callees + arity-exact arg holes are separate `hole_callee`/`hole_args` policy).

## Retained, deliberately

The multi-target var **binding-group** keep-shallow path (per-slot declarator-tuple resolution the chunk-wide read-off can't express). It's the last blocker for fully retiring the keep-shallow machinery and the `selector_codemod.rs` by-form refactor.

## Testing

`bazelisk test //devinfra/js/debundle/...` — 116/116 pass (RBE).

## Follow-up

Removing the cover means members the read-off can't single out on the real gaffer-private spec become reported name-pin debt rather than cover-pinned. This is aligned with the minimizer's report-don't-dump contract, but should be confirmed by the dogfood re-apply (`plans/readoff_minimization.md` item 13).

https://claude.ai/code/session_011YQabfZ5jVoFSETefd27Bg

---
_Generated by [Claude Code](https://claude.ai/code/session_011YQabfZ5jVoFSETefd27Bg)_