### PR TITLE
debundle: interior holing of function/arrow-valued subexpressions

### DIFF
--- a/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
+++ b/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
@@ -295,6 +295,20 @@ minimizer_expectation_case!(
     expected = "expected_match.js",
 );
 
+// A single-target var initialized by a call wrapping a function expression
+// (`registerHandler(function (event) {…})`) drills into the function body via the
+// `hole_expr` `Expr::Fn` arm: the params hole to `ANYTHING`, the body to
+// `STMT_LIST` runs around the one statement carrying the discriminating string,
+// instead of pinning the whole callback verbatim.
+minimizer_expectation_case!(
+    minimizes_function_valued_init_holing,
+    fixture = "function_valued_init_holing",
+    name = "function-valued var init holes the callback body around the anchor",
+    module = "app/handlers",
+    bindings = [("SelectedHandler", "selectedHandler")],
+    expected = "expected_match.js",
+);
+
 // A single-target var initialized by an object-bearing call (`buildWidget({…})`)
 // routes through the var read-off path (`try_var_read_off` → `hole_expr` →
 // `hole_object`). The read-off picks the uniquely-present `onClick` key (held to

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/function_valued_init_holing/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/function_valued_init_holing/expected_match.js
@@ -1,0 +1,5 @@
+const SelectedHandler = registerHandler(function (ANYTHING) {
+  STMT_LIST;
+  dispatch("uniqueDiscriminatorAction");
+  STMT_LIST;
+});

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/function_valued_init_holing/source.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/function_valued_init_holing/source.js
@@ -1,0 +1,26 @@
+const selectedHandler = registerHandler(function (event) {
+  logEvent(event);
+  dispatch("uniqueDiscriminatorAction");
+  cleanup(event);
+});
+
+const firstOtherHandler = registerHandler(function (event) {
+  logEvent(event);
+  dispatch("alphaAction");
+  cleanup(event);
+});
+
+const secondOtherHandler = registerHandler(function (event) {
+  logEvent(event);
+  dispatch("betaAction");
+  cleanup(event);
+});
+
+function registerHandler(fn) {
+  return fn;
+}
+function logEvent(e) {}
+function dispatch(action) {}
+function cleanup(e) {}
+
+export { selectedHandler };

--- a/devinfra/js/debundle/selector_codemod.rs
+++ b/devinfra/js/debundle/selector_codemod.rs
@@ -1567,6 +1567,19 @@ fn holed_block(block: &BlockStmt, kept: &BTreeSet<AnchorSpan>) -> BlockStmt {
     holed
 }
 
+/// Hole a function for selector form: every parameter to an `ANYTHING` pattern
+/// (pinning arity, not names) and the body's statements to `STMT_LIST` runs
+/// around the kept anchors. Used both for top-level function selectors and for
+/// function-valued subexpressions reached through [`hole_expr`].
+fn hole_function(function: &Function, kept: &BTreeSet<AnchorSpan>) -> Function {
+    let mut holed = function.clone();
+    holed.params = function.params.iter().map(|_| anything_param()).collect();
+    if let Some(body) = &function.body {
+        holed.body = Some(holed_block(body, kept));
+    }
+    holed
+}
+
 /// Prune an expression into selector form: keep concrete tokens whose span is in
 /// `kept`, and replace every subtree off a kept token's path with an `ANYTHING`
 /// hole node. The result is an ordinary `swc` AST emitted by codegen, not a
@@ -1612,6 +1625,30 @@ fn hole_expr(expr: &Expr, kept: &BTreeSet<AnchorSpan>) -> Expr {
             holed.left = Box::new(hole_expr(&bin.left, kept));
             holed.right = Box::new(hole_expr(&bin.right, kept));
             Expr::Bin(holed)
+        }
+        // Function/arrow-valued subexpressions (e.g. a `wrap(function(){…})` or
+        // `useCallback((e) => {…})` initializer) carrying a kept anchor: hole the
+        // params to `ANYTHING` and the body to `STMT_LIST` around the anchor, the
+        // same interior holing the top-level function selector does. A callback
+        // with no kept anchor never reaches here — the leading `node_retains_any`
+        // guard already collapsed it to `ANYTHING`.
+        Expr::Fn(fn_expr) => {
+            let mut holed = fn_expr.clone();
+            holed.function = Box::new(hole_function(&fn_expr.function, kept));
+            Expr::Fn(holed)
+        }
+        Expr::Arrow(arrow) => {
+            let mut holed = arrow.clone();
+            holed.params = arrow.params.iter().map(|_| anything_pat()).collect();
+            holed.body = Box::new(match arrow.body.as_ref() {
+                BlockStmtOrExpr::BlockStmt(block) => {
+                    BlockStmtOrExpr::BlockStmt(holed_block(block, kept))
+                }
+                BlockStmtOrExpr::Expr(expr) => {
+                    BlockStmtOrExpr::Expr(Box::new(hole_expr(expr, kept)))
+                }
+            });
+            Expr::Arrow(holed)
         }
         // Unmodeled shapes carrying a kept anchor: keep verbatim rather than
         // risk an unsound hole. Over-pinning here is a future refinement.
@@ -2050,19 +2087,14 @@ fn minimize_function_selector(
     decl: &IndexedDeclaration,
     target: &SynthesizedTargetBinding,
 ) -> Result<Option<SpecializedSelector>> {
-    let Some(body) = &function.body else {
+    if function.body.is_none() {
         return Ok(None);
-    };
+    }
     let render_with = |kept: &BTreeSet<AnchorSpan>| -> Result<String> {
-        let mut holed = function.clone();
-        holed.params = function.params.iter().map(|_| anything_param()).collect();
-        if let Some(holed_body) = &mut holed.body {
-            holed_body.stmts = hole_stmts(&body.stmts, kept);
-        }
         emit_selector(ModuleItem::Stmt(Stmt::Decl(Decl::Fn(FnDecl {
             ident: ident_node(&target.export_name),
             declare: false,
-            function: Box::new(holed),
+            function: Box::new(hole_function(function, kept)),
         }))))
     };
     // Single-target functions read their minimal anchor set off the shape index.


### PR DESCRIPTION
## Summary

First step of issue #2289 (interior holing). Extends the read-off's interior holing — which already recurses into nested objects (#2289) and arrays (#2296) — to **function and arrow expressions** reached through `hole_expr`.

A `const x = registerHandler(function (event) { …; dispatch("UNIQUE"); … })` now holes the callback body to `STMT_LIST` runs around the discriminating statement (params → `ANYTHING`) instead of pinning the whole function verbatim. A callback with no kept anchor still collapses to `ANYTHING` via the existing `node_retains_any` guard.

## Changes

- New `hole_expr` `Expr::Fn` / `Expr::Arrow` arms.
- Factor the top-level function body holing into a shared `hole_function` helper (params → `ANYTHING`, body via `holed_block`), reused by `minimize_function_selector` and the new arms.
- New e2e fixture `function_valued_init_holing`.

## Scope

This is the cleanly-separable part of #2289 **gap 2**. The remaining piece — the **no-sparse-anchor robustness-anchor policy** (keep a holed-down deep value anchor even when the bare scaffold already resolves, overriding the leanest-scaffold fast path on sibling-less targets like `single_target_class_whole_body` / `component_wide_destructure_whole_body`) — flips the lean-vs-robust tradeoff across all function/class selectors, so it's left as a follow-up decision.

## Testing

`bazelisk test //devinfra/js/debundle/...` — 116/116 pass (RBE).

Branches from `devel` (after the merged #2300 var read-off work).

https://claude.ai/code/session_011YQabfZ5jVoFSETefd27Bg

---
_Generated by [Claude Code](https://claude.ai/code/session_011YQabfZ5jVoFSETefd27Bg)_