### PR TITLE
debundle: keep-going machine-readable selector diagnostics

### DIFF
--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -192,6 +192,16 @@ rust_library(
 )
 
 rust_library(
+    name = "selector_diagnostics",
+    srcs = ["selector_diagnostics.rs"],
+    crate_root = "selector_diagnostics.rs",
+    edition = "2024",
+    deps = [
+        "@crates//:serde",
+    ],
+)
+
+rust_library(
     name = "artifact",
     srcs = ["artifact.rs"],
     crate_root = "artifact.rs",
@@ -783,6 +793,7 @@ rust_library(
         ":js_ast",
         ":output_layout",
         ":program_analysis",
+        ":selector_diagnostics",
         ":source_match",
         ":spec",
         ":stage_one",
@@ -908,6 +919,7 @@ rust_library(
         "cli/module.rs",
         "cli/outcome.rs",
         "cli/scc_cluster.rs",
+        "cli/validate.rs",
         "cli/yaml_edit.rs",
     ],
     crate_name = "debundle_cli",
@@ -923,6 +935,7 @@ rust_library(
         ":pipeline",
         ":selector_codemod",
         ":selector_debt",
+        ":selector_diagnostics",
         ":source_match",
         ":spec",
         ":spec_modules",
@@ -933,6 +946,7 @@ rust_library(
         "@crates//:serde_json",
         "@crates//:serde_yaml",
         "@crates//:swc_atoms",
+        "@crates//:tempfile",
     ],
 )
 

--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -72,11 +72,16 @@ propose`.
    `binding_groups` is the co-occurrence-grouping item in the read-off backlog.
    The open work here is the dry-run / patch-plan / explain-every-skip
    infrastructure that the rewrite classes pipe through.)
-3. **Selector diagnostics as machine-readable reports.** Emit a keep-going
-   JSON report for unresolved selectors, ambiguous selectors, duplicate claims,
-   and blocker comments. Include module path, export name, selector kind,
-   target binding, first mismatch, nearest candidates, and recommended next
-   action. This lets coordinators batch failures instead of scraping logs.
+3. **Selector diagnostics as machine-readable reports.** The keep-going JSON
+   report (`debundle spec validate --keep-going --format text|json|ndjson`)
+   classifies unresolved, ambiguous, and duplicate-claim selector failures with
+   module path, export name, selector kind, target binding, first mismatch,
+   nearest candidates, and recommended next action; the shared contract lives in
+   `selector_diagnostics.rs`. Still open: emit structured entries for
+   anonymous-statement `source_match` failures and blocker comments (today the
+   report carries them only as a `coverage_notes` gap), and add the
+   free-readable-identifier class (P1.5) so `alpha_all` readable names that are
+   free references rather than local binders are reported, not silently dropped.
 4. **Spec repair from diagnostics.** Add a workflow that consumes the keep-going
    report, proposes mechanically proven patch plans for no-match, ambiguous,
    duplicate-claim, and unsupported-selector cases, and leaves residual semantic

--- a/devinfra/js/debundle/cli/mod.rs
+++ b/devinfra/js/debundle/cli/mod.rs
@@ -5,6 +5,7 @@ pub mod gate;
 pub mod module;
 pub mod outcome;
 pub mod scc_cluster;
+pub mod validate;
 pub mod yaml_edit;
 
 use std::path::PathBuf;
@@ -21,6 +22,7 @@ use crate::gate::{GateArgs, run_gate_cli};
 use crate::module::{DeleteArgs, MergeArgs, ModuleArgs, run_delete, run_merge, run_module_cli};
 use crate::outcome::{emit_gate_rejection_json, print_outcome_json};
 use crate::scc_cluster::{ClusterArgs, SccArgs, run_cluster, run_scc};
+use crate::validate::{ValidateArgs, run_validate_cmd};
 use anyhow::{Context, Result, bail};
 use clap::{Args as ClapArgs, Parser, Subcommand};
 use peel::factorize::DEFAULT_SIZE_CAP_LINES;
@@ -123,6 +125,10 @@ enum SpecNsCommand {
     /// Synthesize structural selectors for selected name-only members.
     #[command(name = "synthesize-selectors")]
     SynthesizeSelectors(SelectorCodemodArgs),
+    /// Keep-going selector validation: report every selector problem
+    /// (no-match, ambiguous, duplicate-claim, resolution error) in one
+    /// machine-readable pass.
+    Validate(ValidateArgs),
 }
 
 /// Args for `debundle spec stats`. Source is the on-disk modules tree;
@@ -549,6 +555,7 @@ pub fn run_debundle_cli(args: DebundleArgs) -> Result<()> {
                 TransformRunOptions {
                     dry_run,
                     keep_going,
+                    report_dir_override: None,
                 },
             )?;
             if dry_run {
@@ -604,6 +611,9 @@ pub fn run_debundle_cli(args: DebundleArgs) -> Result<()> {
             SpecNsCommand::SynthesizeSelectors(mut s) => {
                 s.rewrite = SelectorCodemodRewriteArg::NameBindingToSourceMatch;
                 run_selector_codemod_cmd(s)
+            }
+            SpecNsCommand::Validate(v) => {
+                run_validate_cmd(v).context("running keep-going selector validation")
             }
         },
         // Don't wrap with a generic context — `gate` subcommands

--- a/devinfra/js/debundle/cli/validate.rs
+++ b/devinfra/js/debundle/cli/validate.rs
@@ -1,0 +1,218 @@
+//! `debundle spec validate --keep-going` — one keep-going pass over every
+//! selector in a spec that emits a machine-readable report of every selector
+//! problem instead of stopping at the first failing selector.
+//!
+//! The keep-going classification itself lives in the materialize pass
+//! (`lowering::materialize::plan_builder`), which already writes a per-chunk
+//! `selector_diagnostics.json` under [`ReportEmission::OnRejection`]. This
+//! verb is a thin frontend: it runs the dry-run keep-going pipeline with
+//! reports forced into a capture directory, reads the per-chunk reports back
+//! through the shared [`SelectorDiagnosticsReport`] contract, and re-emits a
+//! combined report on stdout in the standard `--format text|json|ndjson`
+//! convention.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use clap::Args as ClapArgs;
+use output_layout::SELECTOR_DIAGNOSTICS_REPORT;
+use peel::{OutputFormat, print_report};
+use pipeline::{TransformArgs, TransformRunOptions, run_transform_cli_with_options};
+use selector_diagnostics::SelectorDiagnosticsReport;
+use serde::Serialize;
+
+/// Args for `debundle spec validate`. The spec source and package-root flags
+/// mirror `debundle run` (`--spec` / `--tree-config` + roots) so the same
+/// inputs validate and run.
+#[derive(Debug, ClapArgs)]
+pub struct ValidateArgs {
+    // The flattened `--spec` / `--tree-config` / `--package-root` / `--keep-going`
+    // / `--fail-fast` flags. Keep-going is the default; pass `--fail-fast` to
+    // stop at the first supported failure instead of collecting every problem.
+    #[command(flatten)]
+    pub transform: TransformArgs,
+
+    /// Output format. Default `text` on tty, `json` on pipe. `ndjson` emits one
+    /// JSON object per diagnostic plus a final `summary` line.
+    #[arg(long, value_enum)]
+    pub format: Option<OutputFormat>,
+}
+
+/// Combined keep-going report across every chunk the spec materializes.
+#[derive(Debug, Serialize)]
+pub struct ValidateReport {
+    /// Per-failure-class totals summed across all chunks.
+    pub counts: std::collections::BTreeMap<String, usize>,
+    /// Total selector problems found.
+    pub total: usize,
+    /// Per-chunk reports, sorted by chunk id. A chunk with no selector
+    /// problems contributes no entry.
+    pub chunks: Vec<SelectorDiagnosticsReport>,
+}
+
+pub fn run_validate_cmd(args: ValidateArgs) -> Result<()> {
+    let format = OutputFormat::resolve(args.format);
+    let keep_going = !args.transform.fail_fast;
+    let cli = args.transform.resolve()?;
+
+    // Force reports into a private capture dir: dry-run + a report dir makes
+    // the materialize pass emit `selector_diagnostics.json` per chunk on
+    // rejection, independent of how the spec configures `report_out_dir`.
+    let capture = tempfile::tempdir().context("creating selector-diagnostics capture dir")?;
+    // The keep-going pass writes the per-chunk diagnostics *and then* fails the
+    // pipeline at the end with the collected findings — that rejection is the
+    // contract for `debundle run`. `validate` treats the findings as data, not a
+    // tool failure: when the run produced reports, we emit them and exit zero;
+    // only a run that errored *without* producing any report is a real failure
+    // (bad spec path, parse error, …).
+    let pass = run_transform_cli_with_options(
+        &cli,
+        TransformRunOptions {
+            dry_run: true,
+            keep_going,
+            report_dir_override: Some(capture.path().to_path_buf()),
+        },
+    );
+
+    let mut chunks = collect_chunk_reports(capture.path())?;
+    if let Err(error) = pass
+        && chunks.is_empty()
+    {
+        return Err(error).context("running keep-going validation pass");
+    }
+    chunks.sort_by(|a, b| a.chunk_id.cmp(&b.chunk_id));
+
+    let mut counts = std::collections::BTreeMap::new();
+    for chunk in &chunks {
+        for (category, count) in &chunk.counts {
+            *counts.entry(category.clone()).or_insert(0) += count;
+        }
+    }
+    let total = counts.values().sum();
+    let report = ValidateReport {
+        counts,
+        total,
+        chunks,
+    };
+
+    if format == OutputFormat::Ndjson {
+        emit_validate_ndjson(&report)?;
+        return Ok(());
+    }
+    print_report(&report, format, render_validate_text).context("writing validate output")
+}
+
+/// Recursively gather every `selector_diagnostics.json` under the capture
+/// directory. The materialize pass nests each report at
+/// `<capture>/<chunk_id parts>/selector_diagnostics.json`.
+fn collect_chunk_reports(capture: &Path) -> Result<Vec<SelectorDiagnosticsReport>> {
+    let mut reports = Vec::new();
+    collect_chunk_reports_into(capture, &mut reports)?;
+    Ok(reports)
+}
+
+fn collect_chunk_reports_into(
+    dir: &Path,
+    reports: &mut Vec<SelectorDiagnosticsReport>,
+) -> Result<()> {
+    if !dir.is_dir() {
+        return Ok(());
+    }
+    let mut entries = std::fs::read_dir(dir)
+        .with_context(|| format!("reading {}", dir.display()))?
+        .collect::<std::io::Result<Vec<_>>>()
+        .with_context(|| format!("reading {}", dir.display()))?;
+    entries.sort_by_key(std::fs::DirEntry::path);
+    for entry in entries {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_chunk_reports_into(&path, reports)?;
+        } else if path.file_name().and_then(|name| name.to_str())
+            == Some(SELECTOR_DIAGNOSTICS_REPORT)
+        {
+            let text = std::fs::read_to_string(&path)
+                .with_context(|| format!("reading {}", path.display()))?;
+            reports.push(
+                serde_json::from_str(&text)
+                    .with_context(|| format!("parsing selector diagnostics {}", path.display()))?,
+            );
+        }
+    }
+    Ok(())
+}
+
+fn render_validate_text(report: &ValidateReport, buf: &mut String) {
+    use std::fmt::Write;
+
+    if report.total == 0 {
+        buf.push_str("No selector problems found.");
+        return;
+    }
+    let summary = report
+        .counts
+        .iter()
+        .map(|(category, count)| format!("{category}={count}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let _ = writeln!(
+        buf,
+        "{} selector problem(s) across {} chunk(s): {summary}",
+        report.total,
+        report.chunks.len(),
+    );
+    for chunk in &report.chunks {
+        let _ = writeln!(buf, "\nchunk {}:", chunk.chunk_id);
+        for diagnostic in &chunk.diagnostics {
+            let export = diagnostic.export_name.as_deref().unwrap_or("-");
+            let module = diagnostic
+                .module_path
+                .as_deref()
+                .unwrap_or(&diagnostic.module_id);
+            let _ = writeln!(
+                buf,
+                "  [{}] {module} as `{export}` ({}): {}",
+                diagnostic.category, diagnostic.selector_kind, diagnostic.message,
+            );
+            let _ = writeln!(buf, "    -> {}", diagnostic.recommended_next_action);
+        }
+    }
+}
+
+/// One JSON object per diagnostic tagged with its chunk, then a final
+/// `summary` line — the streaming shape `jq -c` consumers dispatch on.
+fn emit_validate_ndjson(report: &ValidateReport) -> Result<()> {
+    #[derive(Serialize)]
+    struct DiagnosticLine<'a> {
+        section: &'a str,
+        chunk_id: &'a str,
+        #[serde(flatten)]
+        diagnostic: &'a selector_diagnostics::SelectorDiagnosticEntry,
+    }
+    #[derive(Serialize)]
+    struct SummaryLine<'a> {
+        section: &'a str,
+        total: usize,
+        counts: &'a std::collections::BTreeMap<String, usize>,
+    }
+    for chunk in &report.chunks {
+        for diagnostic in &chunk.diagnostics {
+            println!(
+                "{}",
+                serde_json::to_string(&DiagnosticLine {
+                    section: "diagnostic",
+                    chunk_id: &chunk.chunk_id,
+                    diagnostic,
+                })?
+            );
+        }
+    }
+    println!(
+        "{}",
+        serde_json::to_string(&SummaryLine {
+            section: "summary",
+            total: report.total,
+            counts: &report.counts,
+        })?
+    );
+    Ok(())
+}

--- a/devinfra/js/debundle/e2e/BUILD.bazel
+++ b/devinfra/js/debundle/e2e/BUILD.bazel
@@ -105,6 +105,7 @@ _STANDARD_E2E_DEPS = [
         "pass_two_tdz_cut_diagnosis_test",
         "spec_comments_test",
         "selector_diagnostics_report_test",
+        "spec_validate_cli_test",
         "syntactic_holes_test",
     ]
 ]

--- a/devinfra/js/debundle/e2e/spec_validate_cli_test.rs
+++ b/devinfra/js/debundle/e2e/spec_validate_cli_test.rs
@@ -1,0 +1,183 @@
+//! End-to-end exercise of `debundle spec validate --keep-going` by shelling
+//! out to the built binary. The keep-going classification itself is pinned by
+//! `selector_diagnostics_report_test`; this test pins the CLI verb: that one
+//! pass surfaces every failure class on stdout in each `--format`.
+
+use debundle_e2e_support::{
+    FixtureOpts, Member, logical_module, run_spec_validate, write_validate_fixture_spec,
+};
+use serde_json::Value;
+
+/// One fixture exercising every covered failure class at once:
+/// - `unresolved_selector`: a `source_match` whose body matches nothing;
+/// - `ambiguous_selector`: a `source_match` matching two identical helpers;
+/// - `duplicate_claim`: two members resolving to the same declaration.
+fn mixed_failure_fixture() -> FixtureOpts<'static> {
+    let missing_selector = r#"function selectedFormatter(value) {
+  return value.toLowerCase();
+}"#;
+    let ambiguous_selector = r#"function repeatedHelper() {
+  return "shared";
+}"#;
+    FixtureOpts::new(
+        r#"function renderCard(value) {
+  return value.trim();
+}
+function decoratePrimary() {
+  return "shared";
+}
+function decorateSecondary() {
+  return "shared";
+}
+console.log(renderCard(" ok "), decoratePrimary(), decorateSecondary());
+export { renderCard, decoratePrimary, decorateSecondary };
+"#,
+        vec![
+            logical_module(
+                "diagnostics/missing",
+                &[Member::source_alpha("MissingFormatter", missing_selector)],
+            ),
+            logical_module("owners/card", &[Member::new("renderCard")]),
+            logical_module(
+                "duplicates/card",
+                &[Member::renamed("renderCardAgain", "renderCard")],
+            ),
+            logical_module(
+                "diagnostics/ambiguous",
+                &[Member::source_alpha("AmbiguousHelper", ambiguous_selector)],
+            ),
+        ],
+    )
+}
+
+#[test]
+fn validate_json_reports_every_failure_class_in_one_pass() {
+    let fixture = write_validate_fixture_spec(mixed_failure_fixture());
+    let out = run_spec_validate(&fixture.spec_path, &["--format", "json"]);
+    assert!(
+        out.status.success(),
+        "spec validate exited non-zero: stderr={}",
+        out.stderr
+    );
+
+    let report: Value = serde_json::from_str(&out.stdout)
+        .unwrap_or_else(|err| panic!("parse validate json: {err}\nstdout:\n{}", out.stdout));
+
+    assert_eq!(report["total"], 3, "{report:#}");
+    assert_eq!(report["counts"]["unresolved_selector"], 1, "{report:#}");
+    assert_eq!(report["counts"]["ambiguous_selector"], 1, "{report:#}");
+    assert_eq!(report["counts"]["duplicate_claim"], 1, "{report:#}");
+
+    let chunks = report["chunks"].as_array().expect("chunks array");
+    let chunk = chunks
+        .iter()
+        .find(|chunk| chunk["chunk_id"] == "static/app")
+        .expect("static/app chunk report");
+    let diagnostics = chunk["diagnostics"].as_array().expect("diagnostics array");
+    assert_eq!(diagnostics.len(), 3, "{chunk:#}");
+
+    let missing = find_entry(diagnostics, "unresolved_selector", "MissingFormatter");
+    assert_eq!(missing["module_path"], "diagnostics/missing");
+    assert_eq!(missing["selector_kind"], "members.source_match");
+    assert!(
+        missing["recommended_next_action"]
+            .as_str()
+            .unwrap()
+            .contains("nearest_candidates"),
+        "{missing:#}"
+    );
+
+    let ambiguous = find_entry(diagnostics, "ambiguous_selector", "AmbiguousHelper");
+    assert_eq!(ambiguous["body_indices"], serde_json::json!([1, 2]));
+
+    let duplicate = diagnostics
+        .iter()
+        .find(|entry| entry["category"] == "duplicate_claim")
+        .expect("duplicate claim entry");
+    assert_eq!(duplicate["duplicate_claim"]["binding"], "renderCard");
+}
+
+#[test]
+fn validate_ndjson_streams_one_object_per_diagnostic_plus_summary() {
+    let fixture = write_validate_fixture_spec(mixed_failure_fixture());
+    let out = run_spec_validate(&fixture.spec_path, &["--format", "ndjson"]);
+    assert!(out.status.success(), "stderr={}", out.stderr);
+
+    let lines: Vec<&str> = out.stdout.trim_end().split('\n').collect();
+    // 3 diagnostics + 1 summary line.
+    assert_eq!(lines.len(), 4, "stdout:\n{}", out.stdout);
+
+    let parsed: Vec<Value> = lines
+        .iter()
+        .map(|line| serde_json::from_str(line).expect("each ndjson line is valid json"))
+        .collect();
+    let summary = parsed.last().unwrap();
+    assert_eq!(summary["section"], "summary");
+    assert_eq!(summary["total"], 3);
+
+    for line in &parsed[..3] {
+        assert_eq!(line["section"], "diagnostic");
+        assert_eq!(line["chunk_id"], "static/app");
+        assert!(line["category"].is_string(), "{line:#}");
+    }
+}
+
+#[test]
+fn validate_text_summarizes_counts_and_per_chunk_findings() {
+    let fixture = write_validate_fixture_spec(mixed_failure_fixture());
+    let out = run_spec_validate(&fixture.spec_path, &["--format", "text"]);
+    assert!(out.status.success(), "stderr={}", out.stderr);
+
+    let stdout = out.stdout;
+    assert!(
+        stdout.contains("3 selector problem(s)"),
+        "missing total line:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("chunk static/app:"),
+        "missing chunk header:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("[unresolved_selector]") && stdout.contains("[ambiguous_selector]"),
+        "missing classified findings:\n{stdout}"
+    );
+}
+
+#[test]
+fn validate_clean_spec_reports_no_problems() {
+    let opts = FixtureOpts::new(
+        r#"function renderCard(value) {
+  return value.trim();
+}
+console.log(renderCard(" ok "));
+export { renderCard };
+"#,
+        vec![logical_module("owners/card", &[Member::new("renderCard")])],
+    );
+    let fixture = write_validate_fixture_spec(opts);
+
+    let json = run_spec_validate(&fixture.spec_path, &["--format", "json"]);
+    assert!(json.status.success(), "stderr={}", json.stderr);
+    let report: Value = serde_json::from_str(&json.stdout).unwrap();
+    assert_eq!(report["total"], 0, "{report:#}");
+    assert!(
+        report["chunks"].as_array().unwrap().is_empty(),
+        "{report:#}"
+    );
+
+    let text = run_spec_validate(&fixture.spec_path, &["--format", "text"]);
+    assert!(
+        text.stdout.contains("No selector problems found"),
+        "{}",
+        text.stdout
+    );
+}
+
+fn find_entry<'a>(diagnostics: &'a [Value], category: &str, export_name: &str) -> &'a Value {
+    diagnostics
+        .iter()
+        .find(|entry| entry["category"] == category && entry["export_name"] == export_name)
+        .unwrap_or_else(|| {
+            panic!("missing {category} entry for export {export_name}: {diagnostics:#?}")
+        })
+}

--- a/devinfra/js/debundle/e2e/support.rs
+++ b/devinfra/js/debundle/e2e/support.rs
@@ -1012,6 +1012,49 @@ fn run_rejection_fixture_with_args_and_env(
     }
 }
 
+/// A written transform spec ready to feed to a `debundle` subcommand other
+/// than `run` (e.g. `spec validate`). The held [`TempDir`] keeps the spec,
+/// source snapshot, and js-list alive for the duration of the test.
+pub struct ValidateFixture {
+    pub spec_path: PathBuf,
+    _root: TempDir,
+}
+
+/// Materialize `opts` into an on-disk transform spec without running the
+/// pipeline. Lets a CLI test point `debundle spec validate --spec <path>` at
+/// exactly the same fixture shape the keep-going materialize tests build.
+pub fn write_validate_fixture_spec(opts: FixtureOpts<'_>) -> ValidateFixture {
+    let setup = setup_fixture(&opts);
+    let spec_path = setup.root.path().join("transform_spec.yaml");
+    let spec = build_spec(&opts, &setup);
+    write_yaml_file(&spec_path, &spec);
+    ValidateFixture {
+        spec_path,
+        _root: setup.root,
+    }
+}
+
+/// Run `debundle spec validate --spec <path> <extra_args>` and return its
+/// captured stdio + exit status.
+pub fn run_spec_validate(spec_path: &Path, extra_args: &[&str]) -> CommandResult {
+    let bin = debundler_path();
+    let mut command = Command::new(&bin);
+    command
+        .arg("spec")
+        .arg("validate")
+        .arg("--spec")
+        .arg(spec_path);
+    command.args(extra_args);
+    let output = command
+        .output()
+        .unwrap_or_else(|e| panic!("spawn debundler {}: {e}", bin.display()));
+    CommandResult {
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        status: output.status,
+    }
+}
+
 pub fn assert_entry_output(fixture: &Fixture, expected_stdout: &str) {
     assert_node_output(&fixture.entry_path, expected_stdout, "");
 }

--- a/devinfra/js/debundle/lowering/materialize/plan_builder.rs
+++ b/devinfra/js/debundle/lowering/materialize/plan_builder.rs
@@ -39,56 +39,13 @@ impl DuplicateBindingClaim {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
-pub(super) struct SelectorDiagnosticsReport {
-    pub chunk_id: String,
-    pub counts: BTreeMap<String, usize>,
-    pub diagnostics: Vec<SelectorDiagnosticEntry>,
-    pub coverage_notes: Vec<String>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub(super) struct SelectorDiagnosticEntry {
-    pub category: String,
-    pub module_id: String,
-    pub module_path: Option<String>,
-    pub export_name: Option<String>,
-    pub selector_kind: String,
-    pub target_binding: Option<String>,
-    pub claim_origin: Option<String>,
-    pub body_indices: Vec<usize>,
-    pub first_mismatch: Option<String>,
-    pub nearest_candidates: Vec<SelectorNearestCandidate>,
-    pub source_match_preview: Option<String>,
-    pub source_match_hash: Option<String>,
-    pub source_match_body_hash: Option<String>,
-    pub duplicate_claim: Option<DuplicateClaimReport>,
-    pub message: String,
-    pub recommended_next_action: String,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub(super) struct SelectorNearestCandidate {
-    pub body_index: usize,
-    pub declared_bindings: Vec<String>,
-    pub score: usize,
-    pub first_mismatch: String,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub(super) struct DuplicateClaimReport {
-    pub chunk_id: String,
-    pub binding: String,
-    pub existing: DuplicateClaimSiteReport,
-    pub duplicate: DuplicateClaimSiteReport,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub(super) struct DuplicateClaimSiteReport {
-    pub module_id: String,
-    pub export_name: Option<String>,
-    pub claim_origin: Option<String>,
-}
+// The serialized report shape is the debundler-owned JSON contract shared
+// with the `debundle spec validate --keep-going` reader; it lives in the
+// `selector_diagnostics` crate so writer and reader cannot drift.
+use selector_diagnostics::{
+    DuplicateClaimReport, DuplicateClaimSiteReport, SelectorDiagnosticEntry,
+    SelectorDiagnosticsReport, SelectorNearestCandidate,
+};
 
 impl From<&DuplicateClaimSite> for DuplicateClaimSiteReport {
     fn from(site: &DuplicateClaimSite) -> Self {

--- a/devinfra/js/debundle/pipeline.rs
+++ b/devinfra/js/debundle/pipeline.rs
@@ -33,10 +33,15 @@ pub struct TransformCli {
     pub packages_root: Option<PathBuf>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TransformRunOptions {
     pub dry_run: bool,
     pub keep_going: bool,
+    /// Force per-chunk reports (owner graph, selector diagnostics, …) to this
+    /// directory, overriding the spec's `materialize_logical_modules.report_out_dir`.
+    /// Used by `debundle spec validate --keep-going` to capture the keep-going
+    /// selector diagnostics regardless of how the spec configures reporting.
+    pub report_dir_override: Option<PathBuf>,
 }
 
 impl Default for TransformRunOptions {
@@ -44,6 +49,7 @@ impl Default for TransformRunOptions {
         Self {
             dry_run: false,
             keep_going: true,
+            report_dir_override: None,
         }
     }
 }
@@ -238,6 +244,9 @@ pub fn run_transform_cli_with_options(
             report_out_dir,
             target_dir,
         } = spec.materialize_logical_modules.clone();
+        // `validate --keep-going` forces reports to its own capture dir even
+        // when the spec leaves `report_out_dir` unset; otherwise honor the spec.
+        let report_out_dir = options.report_dir_override.clone().or(report_out_dir);
         // `materialize_logical_modules` derives its own per-run indexes
         // internally (it prunes chunks first); the pipeline indexes are
         // not consumed here, but the artifact mutates, so the update
@@ -905,6 +914,7 @@ mod tests {
                 TransformRunOptions {
                     dry_run: true,
                     keep_going: false,
+                    report_dir_override: None,
                 },
             )?;
 

--- a/devinfra/js/debundle/selector_diagnostics.rs
+++ b/devinfra/js/debundle/selector_diagnostics.rs
@@ -1,0 +1,101 @@
+//! Machine-readable keep-going selector diagnostics.
+//!
+//! The materialize keep-going pass classifies every selector problem it
+//! finds while building a chunk plan and emits a per-chunk
+//! [`SelectorDiagnosticsReport`] instead of stopping at the first failing
+//! selector. These types are the stable, debundler-owned JSON contract for
+//! that report.
+//!
+//! Two consumers share these types so the on-disk shape can never drift
+//! between writer and reader:
+//!
+//! - the producer ([`crate::lowering::materialize::plan_builder`]) builds a
+//!   report from its internal diagnostic state and serializes it to
+//!   `selector_diagnostics.json` per chunk;
+//! - the `debundle spec validate --keep-going` CLI verb
+//!   ([`crate::cli::validate`]) runs the keep-going dry-run pass, reads those
+//!   per-chunk reports back, and re-emits a combined report on stdout in the
+//!   shared `--format text|json|ndjson` convention.
+//!
+//! Failure taxonomy ([`SelectorDiagnosticEntry::category`]):
+//!
+//! - `unresolved_selector` — a `source_match` selector matched zero
+//!   top-level candidates (no-match);
+//! - `ambiguous_selector` — a `source_match` selector matched more than one
+//!   candidate without a differentiating `target_binding`;
+//! - `selector_resolution_error` — the selector failed to resolve for a
+//!   reason other than no-match / ambiguity (parse / schema / unsupported
+//!   hole);
+//! - `duplicate_claim` — two selectors resolved to the same declaration
+//!   identity in the same chunk.
+//!
+//! Not yet classified here (deferred to the free-readable-identifier work in
+//! `TODO.md` P1.5): `alpha_all` readable names that are free references
+//! rather than local binders.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Per-chunk keep-going selector diagnostics. The producer writes `None`
+/// when a chunk has no selector problems, so a present report always
+/// carries at least one diagnostic.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SelectorDiagnosticsReport {
+    pub chunk_id: String,
+    /// Failure-class histogram keyed by [`SelectorDiagnosticEntry::category`].
+    pub counts: BTreeMap<String, usize>,
+    pub diagnostics: Vec<SelectorDiagnosticEntry>,
+    /// Known gaps in the taxonomy (classes not yet emitted as structured
+    /// entries), carried so a coordinator sees what the report does *not*
+    /// cover.
+    pub coverage_notes: Vec<String>,
+}
+
+/// One classified selector failure with enough source identity to feed a
+/// later repair flow.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SelectorDiagnosticEntry {
+    pub category: String,
+    pub module_id: String,
+    pub module_path: Option<String>,
+    pub export_name: Option<String>,
+    pub selector_kind: String,
+    pub target_binding: Option<String>,
+    pub claim_origin: Option<String>,
+    pub body_indices: Vec<usize>,
+    pub first_mismatch: Option<String>,
+    pub nearest_candidates: Vec<SelectorNearestCandidate>,
+    pub source_match_preview: Option<String>,
+    pub source_match_hash: Option<String>,
+    pub source_match_body_hash: Option<String>,
+    pub duplicate_claim: Option<DuplicateClaimReport>,
+    pub message: String,
+    pub recommended_next_action: String,
+}
+
+/// A near-miss top-level statement scored against an unresolved selector,
+/// cheapest-distance first.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SelectorNearestCandidate {
+    pub body_index: usize,
+    pub declared_bindings: Vec<String>,
+    pub score: usize,
+    pub first_mismatch: String,
+}
+
+/// Two selectors resolving to the same declaration identity in one chunk.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DuplicateClaimReport {
+    pub chunk_id: String,
+    pub binding: String,
+    pub existing: DuplicateClaimSiteReport,
+    pub duplicate: DuplicateClaimSiteReport,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DuplicateClaimSiteReport {
+    pub module_id: String,
+    pub export_name: Option<String>,
+    pub claim_origin: Option<String>,
+}


### PR DESCRIPTION
## What

Adds `debundle spec validate --keep-going --format text|json|ndjson` — a thin CLI verb over the existing keep-going materialize pass that classifies **every** selector problem in one pass and emits a combined, machine-readable report on stdout, so a coordinator can batch failures instead of scraping logs.

This is the first half of `plans/automated_spec_workflows.md` Milestone 3 (TODO P0.3): the structured keep-going report, surfaced through the orthogonal `validate` verb in the established `--format` convention.

## Failure taxonomy

Each diagnostic carries `module_path`, `export_name`, `selector_kind`, `target_binding`, `body_indices`, `first_mismatch`, `nearest_candidates`, `source_match_preview`/`hash`, `message`, and `recommended_next_action`. Classes:

- `unresolved_selector` — `source_match` matched zero candidates (no-match);
- `ambiguous_selector` — `source_match` matched >1 candidate without a differentiating `target_binding`;
- `duplicate_claim` — two selectors resolve the same declaration identity in one chunk;
- `selector_resolution_error` — parse / schema / unsupported-hole resolution failure.

## Design

- The keep-going classification already lived in the materialize pass (`lowering/materialize/plan_builder.rs`), which writes a per-chunk `selector_diagnostics.json` under `ReportEmission::OnRejection`. The new verb runs that dry-run pass into a private capture dir (via a new `TransformRunOptions.report_dir_override`), reads the per-chunk reports back, and re-emits a combined report. Stays **out** of `selector_codemod.rs`.
- The serialized report shape moves into a new leaf crate `selector_diagnostics.rs` (`Serialize` + `Deserialize`) so the materialize-side writer and the CLI-side reader share one contract and cannot drift; `plan_builder.rs` imports those types instead of defining its own `pub(super)` copies. No selector-resolution logic changed.
- `validate` treats findings as data, not a tool failure: a run that produced reports exits zero with the report on stdout; only a run that errored *without* any report (bad spec path, parse error) propagates the error.

## Fixtures / tests

`e2e/spec_validate_cli_test.rs` drives the built binary against synthetic fixtures:

- one mixed fixture surfacing unresolved + ambiguous + duplicate-claim in a single pass, asserted across `--format json`, `ndjson` (one object per diagnostic + a `summary` line), and `text`;
- a clean spec that reports `total: 0` / "No selector problems found".

The pre-existing `selector_diagnostics_report_test.rs` (which pins the report *content* via the side-output path) still passes against the shared types.

## Deferred (TODO P0.3)

- Structured entries for anonymous-statement `source_match` failures and blocker comments (today carried as a `coverage_notes` gap).
- The free-readable-identifier class (P1.5): `alpha_all` readable names that are free references rather than local binders.

## Test

`bazelisk test //devinfra/js/debundle/...` — 117/117 pass (`BAZEL_TEST_INVOCATIONS=buildbuddy:c63e781f-d08d-482a-8a7e-43eddd08cff5`).

https://claude.ai/code/session_011YQabfZ5jVoFSETefd27Bg

---
_Generated by [Claude Code](https://claude.ai/code/session_011YQabfZ5jVoFSETefd27Bg)_