### PR TITLE
debundle: robustness-anchor policy — prefer a value anchor over the bare scaffold

### DIFF
--- a/devinfra/js/debundle/e2e/selector_codemod_cli_test.rs
+++ b/devinfra/js/debundle/e2e/selector_codemod_cli_test.rs
@@ -755,9 +755,15 @@ fn synthesize_selectors_minimizes_function_body_by_default() {
         "{match_source}"
     );
     assert!(match_source.contains("STMT_LIST;"), "{match_source}");
+    // The body is holed down to a single anchored statement, not copied whole:
+    // `runtimeFormatter` is the only function in the chunk, so the bare scaffold
+    // alone would resolve — but the robustness-anchor policy keeps one
+    // discriminating value anchor (rather than the degenerate empty body) while
+    // still dropping the irrelevant statements (`trim().toUpperCase()`, the
+    // length `if`, `slice`) to `STMT_LIST`.
     assert!(
-        !match_source.contains("padEnd"),
-        "irrelevant function body should not be copied:\n{match_source}"
+        !match_source.contains("toUpperCase") && !match_source.contains("slice"),
+        "irrelevant function body statements should not be copied:\n{match_source}"
     );
 }
 

--- a/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
+++ b/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
@@ -295,6 +295,21 @@ minimizer_expectation_case!(
     expected = "expected_match.js",
 );
 
+// Robustness-anchor policy: a function that the bare scaffold alone would resolve
+// (it is the only arity-2 function in the chunk) still keeps its discriminating
+// value anchor (`"uniqueRobustnessToken"`) rather than emitting the degenerate
+// `function X(ANYTHING, ANYTHING) { STMT_LIST }`. The bare scaffold pins nothing
+// rebuild-stable and matches any arity-2 function a rebuild adds, so the read-off
+// prefers a holed-down value anchor when it has one.
+minimizer_expectation_case!(
+    minimizes_robustness_value_over_scaffold,
+    fixture = "robustness_value_over_scaffold",
+    name = "scaffold-resolvable function still keeps a discriminating value anchor",
+    module = "app/only",
+    bindings = [("SelectedOnly", "selectedOnly")],
+    expected = "expected_match.js",
+);
+
 // A single-target var initialized by a call wrapping a function expression
 // (`registerHandler(function (event) {…})`) drills into the function body via the
 // `hole_expr` `Expr::Fn` arm: the params hole to `ANYTHING`, the body to
@@ -576,7 +591,7 @@ minimizer_expectation_case!(
 // here needs sibling-bearing fixtures; this reduction instead pins down the
 // degenerate-scaffold half of the gap. See plan item 2b.
 minimizer_expectation_case!(
-    #[ignore = "single-target class with no sibling emits a degenerate `class X { CLASS_REST }` scaffold instead of CLASS_REST + one anchored member"]
+    #[ignore = "discriminating value lives in a class method body, which the candidate index does not yet collect, so the read-off falls back to the degenerate scaffold; needs candidate-index anchor deepening on top of the robustness-anchor policy"]
     minimizes_single_target_class_whole_body,
     fixture = "single_target_class_whole_body",
     name = "single-target class keeps only one discriminating member, not the whole body",

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/robustness_value_over_scaffold/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/robustness_value_over_scaffold/expected_match.js
@@ -1,0 +1,4 @@
+function SelectedOnly(ANYTHING, ANYTHING) {
+  STMT_LIST;
+  return register("uniqueRobustnessToken");
+}

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/robustness_value_over_scaffold/source.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/robustness_value_over_scaffold/source.js
@@ -1,0 +1,19 @@
+function selectedOnly(a, b) {
+  setup(a);
+  return register("uniqueRobustnessToken");
+}
+
+function helperOne(x) {
+  return x + 1;
+}
+
+function helperTwo(y) {
+  return y + 2;
+}
+
+function setup(value) {}
+function register(token) {
+  return token;
+}
+
+export { selectedOnly };

--- a/devinfra/js/debundle/plans/readoff_minimization.md
+++ b/devinfra/js/debundle/plans/readoff_minimization.md
@@ -250,17 +250,20 @@ real-spec sample (5,556 selectors); the non-minimal pattern catalog drives this
 and is encoded as disabled E2E cases. Completed items are removed, not annotated;
 the landed architecture is in "Current state" above.
 
-1. **Interior holing of no-sparse-anchor bodies (the dominant lever; GitHub
-   #2289).** When uniqueness was proven by the full body, nothing is holed. Two sub-cases: (a) sibling-less single targets emit a _vacuous_ selector
-   (`class X { CLASS_REST }`, `const X = ANYTHING`) — disabled fixtures
-   `single_target_class_whole_body`, `component_wide_destructure_whole_body`;
-   (b) real-spec bodies with a genuine deep unique anchor the renderer can't
-   interleave holes down to (`nr_name === "HAS IMAGE"`, `n.BundleInstaller`),
-   wrongly bucketed "no sparse selector". Closing needs a **robustness-anchor
-   policy** (keep a holed-down deep value anchor even when the bare scaffold
-   already resolves — trades against the current "leanest scaffold preferred" fast
-   path) plus interior set-cover at subtree granularity. Reclaims a meaningful
-   share of the ~2,024 "no sparse selector" tail, not just the ~200 bulky-convertible.
+1. **Candidate-index anchor deepening for no-sparse-anchor bodies (the dominant
+   lever; GitHub #2289).** Two render-side pieces have landed: `hole_expr` recurses
+   into function/arrow-valued subexpressions (#2301), and the **robustness-anchor
+   policy** keeps a holed-down value anchor instead of the degenerate bare scaffold
+   when one is available (#2303). The remaining blocker is that the candidate index
+   does **not collect anchors inside class method bodies or function-expression
+   bodies**, so for the whole-body cases the read-off has no value anchor to prefer
+   and still falls back to the scaffold (disabled fixtures
+   `single_target_class_whole_body`, `component_wide_destructure_whole_body`; and
+   real-spec deep anchors like `nr_name === "HAS IMAGE"`, `n.BundleInstaller`
+   wrongly bucketed "no sparse selector"). Deepen the index to collect those deep
+   anchors, then add interior set-cover at subtree granularity. Reclaims a
+   meaningful share of the ~2,024 "no sparse selector" tail, not just the ~200
+   bulky-convertible.
 2. **Object-dict family — remaining forms.** Nested-value dicts
    (`object_nested_value_dict`: hole all but one anchored nested property) and wide
    destructure (`wide_destructure_block`: `OBJECT_PROPS` around the one

--- a/devinfra/js/debundle/selector_codemod.rs
+++ b/devinfra/js/debundle/selector_codemod.rs
@@ -2107,44 +2107,56 @@ fn minimize_function_selector(
     render_via_read_off(index, decl, target, &render_with)
 }
 
-/// Render a single-target selector via the W1 read-off API (W2).
+/// Render a single-target selector via the read-off API.
 ///
 /// Reads the minimal [`AnchorSet`] off the shape index, maps its value anchors
 /// to kept byte spans over the target item, and renders + proves through the
-/// supplied `render_with` (the same prune + codegen the cover path uses — no
-/// second serializer). Returns `None` when the read-off cannot single out the
-/// target (a genuine alpha-duplicate) or the rendered selector fails the matcher
-/// gate, so the caller falls back to current behavior (exact-or-skip; never a
-/// full-AST pin unless `--full-ast-fallback`).
+/// supplied `render_with` (the same prune + codegen — no second serializer).
+///
+/// **Robustness-anchor policy.** A holed-down *value* anchor is preferred over
+/// the bare structural scaffold even when the scaffold alone would resolve. A
+/// scaffold that pins only declaration kind + arity (`class X { CLASS_REST }`,
+/// `function f(ANYTHING) { STMT_LIST }`, `const X = ANYTHING`) is a degenerate
+/// selector: it pins nothing rebuild-stable and matches any same-shape sibling a
+/// rebuild adds. So the read-off keeps its chosen value anchor when it has one,
+/// and falls back to the bare scaffold only when the target has no renderable
+/// value anchor — `minimal_anchor_set` chose a purely structural skeleton (empty
+/// kept spans) because nothing but shape discriminates — or the value anchor
+/// fails to prove. Returns `None` when neither route singles the target out (a
+/// genuine alpha-duplicate); the caller reports it as debt, never a full-AST pin.
 fn render_via_read_off(
     index: &ChunkSelectorIndex,
     decl: &IndexedDeclaration,
     target: &SynthesizedTargetBinding,
     render_with: &impl Fn(&BTreeSet<AnchorSpan>) -> Result<String>,
 ) -> Result<Option<SpecializedSelector>> {
-    // Structural fast path (mirrors the cover's empty-competitors case): if the
-    // holed scaffold already pins enough — the declaration kind plus the param
-    // arity / declarator shape the scaffold renders for free — to resolve
-    // uniquely, keep no concrete token. This is the leanest, most rebuild-stable
-    // selector, so it is preferred over any value anchor the read-off would add.
+    if let Some(anchor_set) = index.shape_index.minimal_anchor_set(decl.body_idx) {
+        let item = index
+            .parsed
+            .module
+            .body
+            .get(decl.body_idx)
+            .context("read-off body index no longer in module")?;
+        let kept = kept_spans_for_anchor_set(item, &anchor_set);
+        if !kept.is_empty()
+            && let Some(selector) =
+                finish_minimized_selector(index, decl, target, render_with(&kept)?)?
+        {
+            return Ok(Some(selector));
+        }
+    }
+
+    // Fallback: the bare structural scaffold, used only when it resolves uniquely
+    // (a purely structural discriminator — arity/shape — with no value anchor to
+    // keep). The scaffold itself is degenerate for `var`, so the var path skips
+    // this entirely and returns `None` for the keep-shallow path to handle.
     let empty = BTreeSet::new();
     if matched_body_indices(index, &target.export_name, &render_with(&empty)?)?
         == BTreeSet::from([decl.body_idx])
     {
         return finish_minimized_selector(index, decl, target, render_with(&empty)?);
     }
-
-    let Some(anchor_set) = index.shape_index.minimal_anchor_set(decl.body_idx) else {
-        return Ok(None);
-    };
-    let item = index
-        .parsed
-        .module
-        .body
-        .get(decl.body_idx)
-        .context("read-off body index no longer in module")?;
-    let kept = kept_spans_for_anchor_set(item, &anchor_set);
-    finish_minimized_selector(index, decl, target, render_with(&kept)?)
+    Ok(None)
 }
 
 // ===========================================================================


### PR DESCRIPTION
## Summary

Render-side half of issue #2289 gap 2. `render_via_read_off` used to take an empty-scaffold fast path: if `function X(ANYTHING) { STMT_LIST }` / `class X { CLASS_REST }` already resolved uniquely, it emitted that and kept no concrete token. That is a **degenerate selector** — it pins nothing rebuild-stable and matches any same-shape sibling a rebuild adds (criterion 5).

This reverses the priority: read the minimal anchor set off the shape index first and keep its **value anchor**; fall back to the bare scaffold only when the target has no renderable value anchor (a purely structural skeleton → empty kept spans) or that anchor fails to prove.

## Changes

- `render_via_read_off`: value-anchor-first, scaffold-fallback.
- New e2e `robustness_value_over_scaffold`: a function the bare scaffold alone would resolve (the only arity-2 function) now keeps its discriminating `"uniqueRobustnessToken"` anchor.
- Re-baselined `synthesize_selectors_minimizes_function_body_by_default` (the only function in its chunk): asserts the body is holed to one anchored statement rather than fully emptied — the intended robustness behavior.

## Known follow-up (the two whole-body disabled fixtures stay ignored)

`single_target_class_whole_body` and `component_wide_destructure_whole_body` still produce the degenerate scaffold because their discriminating values live **inside class method bodies / function-expression bodies**, which the candidate index does not yet collect — so the read-off has no value anchor to prefer there. Closing them needs **candidate-index anchor deepening** on top of this policy. Their ignore reasons are updated to name that follow-up.

## Testing

`bazelisk test //devinfra/js/debundle/...` — 116/116 pass (RBE).

Branches from `devel` (after #2300 + #2301).

https://claude.ai/code/session_011YQabfZ5jVoFSETefd27Bg

---
_Generated by [Claude Code](https://claude.ai/code/session_011YQabfZ5jVoFSETefd27Bg)_