### PR TITLE
debundle: activate object_nested_value_dict; scope wide_destructure follow-up

### DIFF
--- a/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
+++ b/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
@@ -513,19 +513,15 @@ minimizer_expectation_case!(
     expected = "expected_match.js",
 );
 
-// Aspirational: a large lookup dictionary whose VALUES are nested objects
-// (e.g. an id -> config map) should minimize to OBJECT_PROPS holes on both
-// sides of the one entry whose nested value carries the discriminating
-// literal, and that entry's own nested object should itself collapse to the
-// discriminating property plus an OBJECT_PROPS hole. This generalizes
-// `object_keys_over_pinned` (whose entry values are scalar string literals) to
-// the common nested-object-value case. Today the minimizer keeps every entry's
-// full nested object whole, over-pinning the entire dictionary where one
-// anchored nested property would resolve uniquely. Mirrors the real spec's
-// id->config maps (feature-flag / registry dicts) kept whole across ~50+
-// nested-object entries.
+// A large lookup dictionary whose VALUES are nested objects (e.g. an id -> config
+// map) minimizes to OBJECT_PROPS holes on both sides of the one entry whose nested
+// value carries the discriminating literal, and that entry's own nested object
+// itself collapses to the discriminating property plus OBJECT_PROPS. Generalizes
+// `object_keys_over_pinned` (scalar entry values) to the nested-object-value case;
+// handled by the read-off drilling through the nested object/array holing
+// (`hole_object` / `hole_array` recursion). Mirrors the real spec's id->config
+// maps (feature-flag / registry dicts) otherwise kept whole across ~50+ entries.
 minimizer_expectation_case!(
-    #[ignore = "nested-value-dict minimizer keeps all entries' full nested objects instead of OBJECT_PROPS around one anchored nested property"]
     minimizes_object_nested_value_dict,
     fixture = "object_nested_value_dict",
     name = "nested-object-value dictionary keeps only the discriminating nested property",
@@ -567,7 +563,7 @@ minimizer_expectation_case!(
 // `{ ... } = e` prop destructure is kept verbatim at the top of an otherwise
 // holed body.
 minimizer_expectation_case!(
-    #[ignore = "wide-destructure minimizer keeps the entire destructuring pattern instead of OBJECT_PROPS around the one discriminating property"]
+    #[ignore = "the discriminator is a destructure-pattern property key (`uniqueDiscriminatorProp`), which the candidate index does not collect, and holing an `ObjectPat` (keep one property + OBJECT_PROPS) is not yet implemented; the read-off bails with no sparse selector. Needs destructure-pattern-key anchor indexing + pattern holing."]
     minimizes_wide_destructure_block,
     fixture = "wide_destructure_block",
     name = "wide destructuring block keeps only the discriminating destructured property",

--- a/devinfra/js/debundle/plans/readoff_minimization.md
+++ b/devinfra/js/debundle/plans/readoff_minimization.md
@@ -264,11 +264,15 @@ the landed architecture is in "Current state" above.
    anchors, then add interior set-cover at subtree granularity. Reclaims a
    meaningful share of the ~2,024 "no sparse selector" tail, not just the ~200
    bulky-convertible.
-2. **Object-dict family — remaining forms.** Nested-value dicts
-   (`object_nested_value_dict`: hole all but one anchored nested property) and wide
-   destructure (`wide_destructure_block`: `OBJECT_PROPS` around the one
-   discriminating destructured property). The `ee({ coreMessage: …, type: … })`
-   schema-object-call form is a call kept whole — folds into item 1.
+2. **Wide destructure (`wide_destructure_block`).** A `const { …, x } = props`
+   whose discriminator is a destructured property key (`x`) bails with "no sparse
+   selector": the candidate index does not collect destructure-pattern property
+   keys as anchors, and holing an `ObjectPat` (keep one property + `OBJECT_PROPS`,
+   hole the RHS) is not implemented (`hole_expr` is expression-only). Needs
+   destructure-pattern-key anchor indexing plus pattern holing. (Nested-value
+   dicts — `object_nested_value_dict` — already minimize via the nested
+   object/array holing recursion; the `ee({ coreMessage: …, type: … })`
+   schema-object-call form folds into item 1.)
 3. **Multi-target var binding-group read-off.** Groups still use the keep-shallow
    path (`minimize_var_group_selector`) because per-slot declarator-tuple
    resolution is something the chunk-wide read-off cannot express. Designing a
@@ -284,8 +288,13 @@ the landed architecture is in "Current state" above.
 6. **Retire the keep-shallow group cover** once item 3 lands — removes
    `minimize_var_group_selector`'s escalation path, `collect_expr_anchors`, and
    `AnchorCandidates::{shallow_literals,deep_cover_tiers}`.
-7. **`selector_codemod.rs` by-form split** — the file is ~4.2k lines; splitting by
-   form enables parallel per-form fan-out (do after item 6 reshapes the var path).
+7. **`selector_codemod.rs` by-form split + dedup** — the file is ~4.2k lines;
+   splitting by form enables parallel per-form fan-out (do after item 6 reshapes
+   the var path). Concrete dedup target: `try_object_read_off`, `try_var_read_off`,
+   and `minimize_var_group_selector` each build a near-identical var `render_with`
+   closure (iterate `var.decls`, `DECLARATORS_*` holes for non-target slots, holed
+   target init); factor one shared slot-render helper parameterized by the
+   per-slot init holing.
 8. **Language simplification** (see below) — emit anonymous `OBJECT_PROPS` /
    `DECLARATORS` / `CLASS_REST` / `EXPR` / `STMT` as `ANYTHING`. Deferred until
    emission stabilizes (after the cover/keep-shallow paths fully retire), since it


### PR DESCRIPTION
## Summary

Object-dict family (plan backlog item 2).

- **`object_nested_value_dict` now passes — unignored.** The nested-object-value dictionary (id→config map) minimizes to `OBJECT_PROPS` around the one entry whose nested value carries the discriminating literal, that entry's nested object itself collapsing to the discriminating property + `OBJECT_PROPS`. No code change needed — the cumulative var read-off + nested object/array interior holing (`hole_object` / `hole_array` recursion) already handles it; it just needed enabling.
- **`wide_destructure_block` stays ignored, with a precise reason.** Its discriminator is a destructure-pattern property key (`uniqueDiscriminatorProp`); the read-off bails ("no sparse selector") because the candidate index doesn't collect destructure-pattern keys as anchors and holing an `ObjectPat` (keep one property + `OBJECT_PROPS`, hole the RHS) isn't implemented (`hole_expr` is expression-only). Plan item 2 now scopes that follow-up.
- **Dedup target recorded** in plan item 7: the three near-identical var `render_with` closures (`try_object_read_off` / `try_var_read_off` / `minimize_var_group_selector`) should factor into one shared slot-render helper (deferred to the by-form split, after the active var-path lanes land).

## Testing

`bazelisk test //devinfra/js/debundle/...` — 117/117 pass (RBE).

https://claude.ai/code/session_011YQabfZ5jVoFSETefd27Bg

---
_Generated by [Claude Code](https://claude.ai/code/session_011YQabfZ5jVoFSETefd27Bg)_