### PR TITLE
debundle: statement-run holing + general co-occurrence grouping

### DIFF
--- a/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
+++ b/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
@@ -428,15 +428,14 @@ minimizer_expectation_case!(
     expected = "expected_match.js",
 );
 
-// Aspirational: a function whose body is a long run of sequential assignment
-// statements should minimize to STMT_LIST holes on both sides of the single
-// assignment whose right-hand side carries the discriminating literal. Today
-// the minimizer finds no sparse statement-level selector and bails (skips
-// rather than emitting a full-AST pin), so the flat sequence of writes is
-// never reduced to the one anchored assignment that uniquely identifies the
-// target among siblings sharing the same write-block shape.
+// A function whose body is a long run of sequential assignment statements
+// minimizes to STMT_LIST holes on both sides of the single assignment whose
+// right-hand side carries the discriminating literal. The assignment's LHS
+// receiver (`state`, a minified parameter) holes to `ANYTHING` while the stable
+// property name and discriminating RHS literal are kept, so the flat sequence of
+// writes reduces to the one anchored `ANYTHING.delta = "…"` assignment that
+// uniquely identifies the target among siblings sharing the write-block shape.
 minimizer_expectation_case!(
-    #[ignore = "statement minimizer bails instead of STMT_LIST + discriminating assignment"]
     minimizes_sequential_assignment_block,
     fixture = "sequential_assignment_block",
     name = "sequential assignment block keeps only the discriminating assignment",
@@ -734,6 +733,54 @@ fn minimizes_adjacent_accessor_group() {
             ],
             expected_match: include_str!(
                 "testdata/selector_minimizer_expectations/adjacent_accessor_group/expected_group_match.js"
+            ),
+        }],
+    });
+}
+
+// General co-occurrence grouping for non-function runs (readoff_minimization.md
+// item 5): four adjacent sibling *class* declarations, each individually
+// minimized to `class …Card { kind = "<unique>"; CLASS_REST }`, share the same
+// canonical selector shape and collapse into ONE binding_group whose
+// source_match is the consecutive run, instead of four standalone source_match
+// selectors. Exercises that the anti-unification grouping pass is no longer
+// function-specific: the same overlap-detection that merges DRY accessor hooks
+// now merges a sibling class-declaration cluster.
+#[test]
+fn minimizes_sibling_class_declaration_group() {
+    run_case(&MinimizedSelectorCase {
+        name: "adjacent sibling class declarations collapse into one binding_group",
+        source: include_str!(
+            "testdata/selector_minimizer_expectations/sibling_class_declaration_group/source.js"
+        ),
+        module: "app/cards",
+        bindings: &[
+            BindingCase {
+                export_name: "selectedAlphaCard",
+                runtime_name: "selectedAlphaCard",
+            },
+            BindingCase {
+                export_name: "selectedBetaCard",
+                runtime_name: "selectedBetaCard",
+            },
+            BindingCase {
+                export_name: "selectedGammaCard",
+                runtime_name: "selectedGammaCard",
+            },
+            BindingCase {
+                export_name: "selectedDeltaCard",
+                runtime_name: "selectedDeltaCard",
+            },
+        ],
+        outputs: &[SelectorOutputExpectation {
+            exports: &[
+                "selectedAlphaCard",
+                "selectedBetaCard",
+                "selectedGammaCard",
+                "selectedDeltaCard",
+            ],
+            expected_match: include_str!(
+                "testdata/selector_minimizer_expectations/sibling_class_declaration_group/expected_group_match.js"
             ),
         }],
     });

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/sibling_class_declaration_group/expected_group_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/sibling_class_declaration_group/expected_group_match.js
@@ -1,0 +1,16 @@
+class selectedAlphaCard {
+  kind = "uniqueAlphaCard";
+  CLASS_REST;
+}
+class selectedBetaCard {
+  kind = "uniqueBetaCard";
+  CLASS_REST;
+}
+class selectedGammaCard {
+  kind = "uniqueGammaCard";
+  CLASS_REST;
+}
+class selectedDeltaCard {
+  kind = "uniqueDeltaCard";
+  CLASS_REST;
+}

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/sibling_class_declaration_group/source.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/sibling_class_declaration_group/source.js
@@ -1,0 +1,39 @@
+// Four tiny sibling class declarations right after one another, each a
+// data-holder with a single discriminating `kind` field and an otherwise shared
+// shape. Each is individually discriminable (by its `kind` value), but they are
+// a DRY cluster: emitting four near-identical standalone source_match selectors
+// is wasteful. The general co-occurrence grouping trigger (not function-only)
+// collapses them into ONE binding_group whose source_match is the consecutive
+// run of the four `class …Card { kind = "…"; CLASS_REST }` declarations.
+class selectedAlphaCard {
+  kind = "uniqueAlphaCard";
+  render() {
+    return this.title;
+  }
+}
+class selectedBetaCard {
+  kind = "uniqueBetaCard";
+  render() {
+    return this.title;
+  }
+}
+class selectedGammaCard {
+  kind = "uniqueGammaCard";
+  render() {
+    return this.title;
+  }
+}
+class selectedDeltaCard {
+  kind = "uniqueDeltaCard";
+  render() {
+    return this.title;
+  }
+}
+
+class unrelatedWidget {
+  draw() {
+    return null;
+  }
+}
+
+export { selectedAlphaCard, selectedBetaCard, selectedGammaCard, selectedDeltaCard };

--- a/devinfra/js/debundle/plans/readoff_minimization.md
+++ b/devinfra/js/debundle/plans/readoff_minimization.md
@@ -124,7 +124,11 @@ Migrated to read-off as their primary path:
 
 - **Single-target function** (`minimize_function_selector` → `render_via_read_off`):
   reads off `minimal_anchor_set`, prefers the empty-kept structural scaffold when
-  it already discriminates, renders through the shared `render_with`.
+  it already discriminates, renders through the shared `render_with`. A body that
+  is a run of sequential assignment statements holes to `STMT_LIST` runs around
+  the one anchored assignment, whose LHS receiver (a minified parameter) holes to
+  `ANYTHING` while the stable property name and discriminating RHS literal stay
+  (the `hole_expr` `Expr::Assign` arm; `sequential_assignment_block`).
 - **Single-target object** (`try_object_read_off` → `hole_object_padded`):
   surrounds every kept prop with `OBJECT_PROPS` (leads, trails, **and**
   interleaves) so a discriminating `key: value` — or a minimal _key set_ — matches
@@ -180,12 +184,13 @@ the current (smaller, partly dogfood-applied) spec the whole chunk minimizes in
 `object_keys_over_pinned`, `long_literal_value_anchor`, `binding_group_partition`,
 `class_among_many_siblings`, `sibling_subclass_hierarchy`, `adjacent_accessor_group`,
 `interior_object_arg_holing` (unignored once the `Expr::Array` interior holing
-landed, #2289), and (unignored once the object key-set cover landed)
-`grouped_enum_objects`, `object_key_set_group`, `object_key_set_subset`. Ignored as
-aspirational (the named form not yet read-off-expressible):
-`sequential_assignment_block`, `deeply_nested_call_args`, `object_nested_value_dict`,
-`wide_destructure_block`, `single_target_class_whole_body`,
-`component_wide_destructure_whole_body`.
+landed, #2289), `sequential_assignment_block` (unignored once the `hole_expr`
+`Expr::Assign` arm landed), `sibling_class_declaration_group` (the general
+non-function co-occurrence group), and (unignored once the object key-set cover
+landed) `grouped_enum_objects`, `object_key_set_group`, `object_key_set_subset`.
+Ignored as aspirational (the named form not yet read-off-expressible):
+`deeply_nested_call_args`, `object_nested_value_dict`, `wide_destructure_block`,
+`single_target_class_whole_body`, `component_wide_destructure_whole_body`.
 
 ## Acceptance criteria
 
@@ -278,39 +283,33 @@ the landed architecture is in "Current state" above.
    resolution is something the chunk-wide read-off cannot express. Designing a
    per-slot anchor union proven through the binding-group matcher would let groups
    read off too — the last consumer of the keep-shallow cover and the gate for
-   items 6/7 below.
-4. **Statement runs** (`sequential_assignment_block`): `STMT_LIST` holes on both
-   sides of the one assignment whose RHS carries the discriminating literal.
-5. **General co-occurrence grouping → `binding_group`.** The shared-declaration
-   trigger (multi-declarator var) and adjacent same-shape function runs have
-   landed; the general co-occurrence trigger for non-function runs (statement runs,
-   sibling object/class declarations that are not a single var statement) is open.
-6. **Retire the keep-shallow group cover** once item 3 lands — removes
+   items 4/5 below.
+4. **Retire the keep-shallow group cover** once item 3 lands — removes
    `minimize_var_group_selector`'s escalation path, `collect_expr_anchors`, and
    `AnchorCandidates::{shallow_literals,deep_cover_tiers}`.
-7. **`selector_codemod.rs` by-form split + dedup** — the file is ~4.2k lines;
-   splitting by form enables parallel per-form fan-out (do after item 6 reshapes
+5. **`selector_codemod.rs` by-form split + dedup** — the file is ~4.2k lines;
+   splitting by form enables parallel per-form fan-out (do after item 4 reshapes
    the var path). Concrete dedup target: `try_object_read_off`, `try_var_read_off`,
    and `minimize_var_group_selector` each build a near-identical var `render_with`
    closure (iterate `var.decls`, `DECLARATORS_*` holes for non-target slots, holed
    target init); factor one shared slot-render helper parameterized by the
    per-slot init holing.
-8. **Language simplification** (see below) — emit anonymous `OBJECT_PROPS` /
+6. **Language simplification** (see below) — emit anonymous `OBJECT_PROPS` /
    `DECLARATORS` / `CLASS_REST` / `EXPR` / `STMT` as `ANYTHING`. Deferred until
    emission stabilizes (after the cover/keep-shallow paths fully retire), since it
    rewrites emitted selectors and touches many fixtures.
-9. **`deeply_nested_call_args` — callee/arg holing.** The var read-off drills to
+7. **`deeply_nested_call_args` — callee/arg holing.** The var read-off drills to
    the leaf but keeps bare-function callees pinned (`hole_callee` keeps a bare
    function reference) and holes dropped args to arity-exact `ANYTHING` rather than
    a variadic `ARGS` run-hole. Closing both is a cross-cutting `hole_callee` /
    `hole_args` policy change affecting all read-off paths; weigh against existing
    fixtures.
-10. **Dogfood-apply on gaffer-private (ongoing).** Run `synthesize-selectors
+8. **Dogfood-apply on gaffer-private (ongoing).** Run `synthesize-selectors
 --apply` on the real spec after each wave, review for over-pin, and PR the
-    beneficial minimized selectors. Operational PR rule: **revert any converted
-    selector whose `match` block is >40 lines AND has ≤2 holes** back to a name pin.
-    Keep pin-compatible (gaffer validates with a _pinned_ debundle release) and
-    regen the pipeline goldens. Each capability above re-applies here as it lands.
+   beneficial minimized selectors. Operational PR rule: **revert any converted
+   selector whose `match` block is >40 lines AND has ≤2 holes** back to a name pin.
+   Keep pin-compatible (gaffer validates with a _pinned_ debundle release) and
+   regen the pipeline goldens. Each capability above re-applies here as it lands.
 
 ## Orchestration & process notes
 

--- a/devinfra/js/debundle/selector_codemod.rs
+++ b/devinfra/js/debundle/selector_codemod.rs
@@ -540,7 +540,7 @@ pub struct SynthesizedTargetBinding {
 
 /// One synthesized selector together with the members it covers and the
 /// representative (first) declaration it was proven against. The anti-unification
-/// grouping pass ([`merge_adjacent_function_runs`]) operates on these: a
+/// grouping pass ([`merge_adjacent_same_shape_runs`]) operates on these: a
 /// single-declaration group may merge with adjacent same-shape neighbors into a
 /// run-based group whose `synthesized` spans several declarations.
 #[derive(Debug, Clone)]
@@ -715,11 +715,12 @@ fn rewrite_name_bindings_to_source_match(
         }
     }
 
-    // Anti-unification grouping (readoff_minimization.md item 7): collapse maximal
-    // runs of adjacent, same-shape single-target function declarations into one
-    // run-based binding_group. Multi-declarator var groups (already grouped by
-    // shared declaration) and lone groups pass through unchanged.
-    let prepared_groups = merge_adjacent_function_runs(index, synthesized_groups);
+    // Anti-unification grouping (readoff_minimization.md items 5 + 7): collapse
+    // maximal runs of adjacent, same-shape single-target declarations (any kind:
+    // function, class, var) into one run-based binding_group. Multi-declarator var
+    // groups (already grouped by shared declaration) and lone groups pass through
+    // unchanged.
+    let prepared_groups = merge_adjacent_same_shape_runs(index, synthesized_groups);
 
     // `Some(value)` replaces the member in place (singleton group rewrites to a
     // `source_match` member); `None` removes it (grouped members move into a
@@ -1084,29 +1085,33 @@ fn synthesize_simplest_selector_for_group(
 }
 
 // ===========================================================================
-// Anti-unification grouping (readoff_minimization.md item 7).
+// Anti-unification grouping (readoff_minimization.md items 5 + 7).
 //
 // `synthesize_simplest_selector_for_group` already groups members that share an
 // enclosing declaration (multi-declarator var statements). The second grouping
 // trigger — "minimal selectors overlap beyond a threshold" — collapses a run of
-// adjacent, near-identical *function* declarations whose individually-minimized
-// selectors share the bulk of their shape (e.g. four context-accessor hooks each
-// `function useX() { return ANYTHING.…; }`) into one run-based binding_group,
-// instead of N standalone source_match selectors.
+// adjacent, near-identical *single-target declarations* whose individually-
+// minimized selectors share the bulk of their shape into one run-based
+// binding_group, instead of N standalone source_match selectors. This started
+// function-only (four context-accessor hooks each `function useX() { return
+// ANYTHING.…; }`) and now generalizes to any single-target declaration kind:
+// sibling class declarations, statement-run functions, object/var declarations,
+// etc. — the same co-occurrence idea, not specialized to functions.
 //
-// The overlap test runs on the *minimized* selectors: same-purpose accessors
+// The overlap test runs on the *minimized* selectors: same-purpose siblings
 // collapse to the same minimal shape (`ANYTHING.<key>`), so two selectors are
 // "same shape" iff their canonical signatures — every identifier, member/key
 // name, and literal value blanked, leaving only structure ([`selector_shape_signature`])
-// — are equal. The merged run-selector is re-proven through the matcher gate; on
-// failure the run is emitted as individual selectors, never an unproven group.
+// — are equal. The merged run-selector is re-proven through the matcher gate
+// (kind-agnostic multi-statement alignment); on failure the run is emitted as
+// individual selectors, never an unproven group.
 // ===========================================================================
 
-/// Collapse maximal runs of adjacent, same-shape single-target function groups
-/// into one run-based binding_group. Other groups (multi-declarator var groups,
-/// classes, lone functions, anything whose merged run fails the matcher gate)
+/// Collapse maximal runs of adjacent, same-shape single-target declaration
+/// groups into one run-based binding_group. Other groups (multi-declarator var
+/// groups, lone declarations, anything whose merged run fails the matcher gate)
 /// pass through unchanged, preserving source order.
-fn merge_adjacent_function_runs(
+fn merge_adjacent_same_shape_runs(
     index: &ChunkSelectorIndex,
     groups: Vec<SynthesizedDeclGroup>,
 ) -> Vec<SynthesizedDeclGroup> {
@@ -1115,25 +1120,25 @@ fn merge_adjacent_function_runs(
     for group in groups {
         let extends_run = run
             .last()
-            .is_some_and(|prev| function_run_extends(index, prev, &group));
+            .is_some_and(|prev| same_shape_run_extends(index, prev, &group));
         if !extends_run {
-            flush_function_run(index, std::mem::take(&mut run), &mut merged);
+            flush_same_shape_run(index, std::mem::take(&mut run), &mut merged);
         }
         run.push(group);
     }
-    flush_function_run(index, run, &mut merged);
+    flush_same_shape_run(index, run, &mut merged);
     merged
 }
 
 /// Emit a candidate run: merge it into one binding_group when it holds ≥2 groups
 /// and the merged selector proves unique, else emit each group individually.
-fn flush_function_run(
+fn flush_same_shape_run(
     index: &ChunkSelectorIndex,
     run: Vec<SynthesizedDeclGroup>,
     out: &mut Vec<SynthesizedDeclGroup>,
 ) {
     if run.len() >= 2
-        && let Some(group) = merge_function_run(index, &run)
+        && let Some(group) = merge_same_shape_run(index, &run)
     {
         out.push(group);
         return;
@@ -1141,36 +1146,48 @@ fn flush_function_run(
     out.extend(run);
 }
 
-/// Whether `next` continues a function run started by `prev`: both are
-/// single-target function declarations, they are consecutive in source order,
-/// and their minimized selectors share the same canonical shape.
-fn function_run_extends(
+/// Whether `next` continues a same-shape run started by `prev`: both are
+/// single-target declaration groups of the same declaration kind, they are
+/// consecutive in source order, and their minimized selectors share the same
+/// canonical shape.
+fn same_shape_run_extends(
     index: &ChunkSelectorIndex,
     prev: &SynthesizedDeclGroup,
     next: &SynthesizedDeclGroup,
 ) -> bool {
-    is_single_function_group(index, prev)
-        && is_single_function_group(index, next)
-        && next.synthesized.body_idx == prev.synthesized.body_idx + 1
+    matches!(
+        (single_target_decl_kind(index, prev), single_target_decl_kind(index, next)),
+        (Some(prev_kind), Some(next_kind)) if prev_kind == next_kind
+    ) && next.synthesized.body_idx == prev.synthesized.body_idx + 1
         && same_selector_shape(
             &prev.synthesized.match_source,
             &next.synthesized.match_source,
         )
 }
 
-fn is_single_function_group(index: &ChunkSelectorIndex, group: &SynthesizedDeclGroup) -> bool {
-    group.members.len() == 1
-        && index
-            .decls
-            .get(group.decl_idx)
-            .is_some_and(|decl| decl.kind == IndexedDeclarationKind::Function)
+/// The declaration kind of a single-target (one-member) group, or `None` when
+/// the group covers multiple members (a multi-declarator var group, already
+/// grouped by its shared declaration) or its declaration index is unknown. A
+/// run only merges declarations of one kind so the concatenated selector stays a
+/// homogeneous sibling run. `Other`-kind declarations are excluded: their
+/// selector is an unmodeled verbatim statement, not a holed shape, so a
+/// shape-signature match would be coincidental rather than a true co-occurrence.
+fn single_target_decl_kind(
+    index: &ChunkSelectorIndex,
+    group: &SynthesizedDeclGroup,
+) -> Option<IndexedDeclarationKind> {
+    if group.members.len() != 1 {
+        return None;
+    }
+    let kind = index.decls.get(group.decl_idx)?.kind;
+    (kind != IndexedDeclarationKind::Other).then_some(kind)
 }
 
 /// Build one run-based binding_group from `run`: the source_match is the run's
 /// declarations concatenated in source order, `exports` maps every target. The
 /// merged selector is re-proven through the matcher gate; `None` (proof failed)
 /// leaves the run to be emitted individually.
-fn merge_function_run(
+fn merge_same_shape_run(
     index: &ChunkSelectorIndex,
     run: &[SynthesizedDeclGroup],
 ) -> Option<SynthesizedDeclGroup> {
@@ -1626,6 +1643,17 @@ fn hole_expr(expr: &Expr, kept: &BTreeSet<AnchorSpan>) -> Expr {
             holed.right = Box::new(hole_expr(&bin.right, kept));
             Expr::Bin(holed)
         }
+        // Assignment expression (`state.delta = "value"`): the dominant statement
+        // shape in sequential write-block bodies. Hole the LHS target's receiver
+        // (`state` → `ANYTHING`) while keeping the stable property name, and recurse
+        // into the RHS so a discriminating literal there is kept and everything else
+        // holed. The member property is preserved verbatim, mirroring `Expr::Member`.
+        Expr::Assign(assign) => {
+            let mut holed = assign.clone();
+            holed.left = hole_assign_target(&assign.left, kept);
+            holed.right = Box::new(hole_expr(&assign.right, kept));
+            Expr::Assign(holed)
+        }
         // Function/arrow-valued subexpressions (e.g. a `wrap(function(){…})` or
         // `useCallback((e) => {…})` initializer) carrying a kept anchor: hole the
         // params to `ANYTHING` and the body to `STMT_LIST` around the anchor, the
@@ -1653,6 +1681,23 @@ fn hole_expr(expr: &Expr, kept: &BTreeSet<AnchorSpan>) -> Expr {
         // Unmodeled shapes carrying a kept anchor: keep verbatim rather than
         // risk an unsound hole. Over-pinning here is a future refinement.
         _ => expr.clone(),
+    }
+}
+
+/// Hole an assignment target. A member target (`receiver.prop`) holes its
+/// receiver expression (a minified binding such as a function parameter) while
+/// keeping the stable property name, mirroring [`hole_expr`]'s `Expr::Member`
+/// arm. Bare-ident and pattern targets are kept verbatim — an ident assign
+/// target is itself a (usually minified) name with nothing to hole, and
+/// destructuring patterns are left intact rather than risk an unsound hole.
+fn hole_assign_target(target: &AssignTarget, kept: &BTreeSet<AnchorSpan>) -> AssignTarget {
+    match target {
+        AssignTarget::Simple(SimpleAssignTarget::Member(member)) => {
+            let mut holed = member.clone();
+            holed.obj = Box::new(hole_expr(&member.obj, kept));
+            AssignTarget::Simple(SimpleAssignTarget::Member(holed))
+        }
+        _ => target.clone(),
     }
 }
 


### PR DESCRIPTION
## Summary

Closes plan backlog **item 4** (statement runs) and **item 5** (general co-occurrence grouping) of `devinfra/js/debundle/plans/readoff_minimization.md`.

### Part A — statement-run holing (item 4)

A function body that is a long run of sequential assignment statements now minimizes to `STMT_LIST` holes on both sides of the single assignment whose RHS carries the discriminating literal.

The minimizer was *not* actually bailing (the `#[ignore]` reason was stale): it already produced the STMT_LIST runs and the discriminating string anchor, but kept the assignment **verbatim** (`state.delta = "…"`) because `hole_expr` had no `Expr::Assign` arm and fell through to `_ => expr.clone()`. Added an `Expr::Assign` arm plus a `hole_assign_target` helper that holes a member assign target's receiver (`state`, a minified parameter) to `ANYTHING` while keeping the stable property name, recursing into the RHS — mirroring the existing `Expr::Member` arm. Result: `ANYTHING.delta = "uniqueDiscriminatorValue"`, the rebuild-stable shape the fixture's `expected_match.js` already encoded (no re-baseline needed).

Un-ignored `sequential_assignment_block`.

### Part B — general co-occurrence grouping (item 5)

Generalized the adjacent same-shape run merge beyond function declarations. `merge_adjacent_function_runs` → `merge_adjacent_same_shape_runs`: it now collapses a run of adjacent **single-target declarations of one kind** (function, class, or var) whose individually-minimized selectors share a canonical `selector_shape_signature` into one `binding_group`, instead of N standalone selectors. The merge is gated by the kind-agnostic multi-statement matcher alignment (`find_matching_body_group_alignments`), so a run that fails to prove unique is emitted individually — never an unproven group. `Other`-kind (verbatim/unmodeled) declarations are excluded so a shape-signature match there can't be coincidental.

New synthetic fixture `sibling_class_declaration_group` (four adjacent sibling class declarations, each `class …Card { kind = "<unique>"; CLASS_REST }`) demonstrates the non-function path collapsing into one binding_group.

### Scope / coordination

- Edits localized to the statement-holing path (`hole_expr` / `hole_assign_target`) and the grouping path (`merge_adjacent_same_shape_runs` / `selector_shape_signature` area). `minimize_var_group_selector` untouched (parallel var lane).
- No changes to `selector_candidate_index.rs` / `shape_index.rs`.
- Generic synthetic fixture only.

### Testing

All 117 `//devinfra/js/debundle/...` tests pass on RBE; the expectation suite now has 20 active cases (5 still aspirational-ignored).

BAZEL_TEST_INVOCATIONS=buildbuddy:abb432c7-a856-4f5a-90c4-dea3e763d2b7

https://claude.ai/code/session_011YQabfZ5jVoFSETefd27Bg

---
_Generated by [Claude Code](https://claude.ai/code/session_011YQabfZ5jVoFSETefd27Bg)_