### PR TITLE
debundle: multi-target var binding-group read-off

### DIFF
--- a/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
+++ b/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
@@ -350,6 +350,30 @@ minimizer_expectation_case!(
     expected = "expected_match.js",
 );
 
+// Multi-target binding-group read-off (plan item 3): a group of sibling key-set
+// objects, two of them exported targets, each discriminated only by its own
+// uniquely-present key (`logViewer` / `alertChip`, values shared `theme.base`
+// member accesses holed to `ANYTHING`). The binding-group read-off reads each
+// target declarator slot's minimal anchor off the shape index + a slot-aware
+// greedy, restricts the kept spans to that slot, UNIONs them, and proves the
+// tuple through the binding-group matcher — so each slot pins only its
+// discriminating key with `OBJECT_PROPS` for the gaps and `DECLARATORS_AFTER` for
+// the non-target third declarator, instead of the keep-shallow path's over-pin
+// (which, with every value already a non-literal member access, would escalate to
+// keeping *every* key of both target objects). The per-slot declarator-tuple
+// resolution the chunk-wide read-off cannot express.
+minimizer_expectation_case!(
+    minimizes_binding_group_key_set_readoff,
+    fixture = "binding_group_key_set_readoff",
+    name = "multi-target group reads off each slot's discriminating key",
+    module = "app/badges",
+    bindings = [
+        ("ErrorBadge", "errorBadge"),
+        ("WarningBadge", "warningBadge")
+    ],
+    expected = "expected_match.js",
+);
+
 minimizer_expectation_case!(
     minimizes_nested_async_try,
     fixture = "nested_async_try",
@@ -640,14 +664,18 @@ minimizer_expectation_case!(
 );
 
 // Single vs group split after the var read-off migration: the multi-target group
-// (`SelectedPrimary`/`SelectedSecondary`) still uses the keep-shallow anchor policy
-// — both slots keep their direct shallow literals, including the shared
-// `enabled: true` over-pin (per-slot tuple resolution remains the cover's job). The
-// single-target `SelectedStandalone` now reads its minimal anchor off the shape
-// index: `kind: "panel"` alone discriminates it from `sameRouteDifferentKind`, so
-// the shared non-discriminating call arg `"settings"` holes to `ANYTHING` and the
-// redundant `title: "Settings"` collapses into `OBJECT_PROPS` — sparser and more
-// rebuild-robust than the keep-shallow over-pin.
+// (`SelectedPrimary`/`SelectedSecondary`) now reads off per-slot minimal anchors
+// (binding-group read-off, plan item 3). Each slot pins only what singles its own
+// declarator out within the statement: slot 0's `enabled: true` (vs
+// `unrelatedPrimary`'s `enabled: false`) is enough, so its `makeEntry` argument
+// holes to `ANYTHING`; slot 1 still needs `"secondary"` because `{ enabled: true }`
+// alone would also fit slot 0. The per-slot kept spans union and the binding-group
+// matcher proves the tuple — sparser than the keep-shallow path's "keep every
+// slot's shallow literals" (which pinned both `"primary"` and `"secondary"`). The
+// single-target `SelectedStandalone` reads its minimal anchor off the shape index:
+// `kind: "panel"` alone discriminates it from `sameRouteDifferentKind`, so the
+// shared non-discriminating call arg `"settings"` holes to `ANYTHING` and the
+// redundant `title: "Settings"` collapses into `OBJECT_PROPS`.
 #[test]
 fn minimizes_binding_group_partition() {
     run_case(&MinimizedSelectorCase {

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/binding_group_key_set_readoff/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/binding_group_key_set_readoff/expected_match.js
@@ -1,0 +1,3 @@
+const ErrorBadge = { OBJECT_PROPS, logViewer: ANYTHING, OBJECT_PROPS },
+  WarningBadge = { OBJECT_PROPS, alertChip: ANYTHING, OBJECT_PROPS },
+  DECLARATORS_AFTER = null;

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/binding_group_key_set_readoff/source.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/binding_group_key_set_readoff/source.js
@@ -1,0 +1,21 @@
+const errorBadge = {
+    diagnosticsSection: theme.base,
+    detailsToggle: theme.base,
+    logViewer: theme.base,
+  },
+  warningBadge = {
+    diagnosticsSection: theme.base,
+    detailsToggle: theme.base,
+    alertChip: theme.base,
+  },
+  unusedBadge = {
+    diagnosticsSection: theme.base,
+    detailsToggle: theme.base,
+  };
+
+const basePanelStyles = {
+  diagnosticsSection: theme.base,
+  detailsToggle: theme.base,
+};
+
+export { errorBadge, warningBadge };

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/binding_group_partition/expected_group_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/binding_group_partition/expected_group_match.js
@@ -1,3 +1,3 @@
-const SelectedPrimary = makeEntry("primary", { OBJECT_PROPS, enabled: true }),
+const SelectedPrimary = makeEntry(ANYTHING, { OBJECT_PROPS, enabled: true }),
   SelectedSecondary = makeEntry("secondary", { OBJECT_PROPS, enabled: true }),
   DECLARATORS_AFTER = null;

--- a/devinfra/js/debundle/plans/readoff_minimization.md
+++ b/devinfra/js/debundle/plans/readoff_minimization.md
@@ -163,11 +163,16 @@ stable-prefix/volatile-tail strings (trailing hex/digit runs).
 function/class anchor collectors) is **deleted**: single-target function, class,
 object, and var all route through the read-off, which subsumes it once W3 added
 number/bool features (its last reason to exist). A target the read-off cannot
-single out is reported as debt, never full-AST-pinned. The one cover that
-remains is the **multi-target var binding-group keep-shallow path**
+single out is reported as debt, never full-AST-pinned. Multi-target var binding
+groups also read off now (`try_var_group_read_off`, backlog item 3): each target
+declarator slot reads its minimal anchor off the shape index plus a slot-aware
+greedy (`slot_minimal_anchors`), the per-slot kept spans union, and the
+binding-group matcher proves the tuple. The **keep-shallow path**
 (`minimize_var_group_selector` + `collect_expr_anchors` +
-`AnchorCandidates::{shallow_literals,deep_cover_tiers}`), which does the per-slot
-tuple resolution the chunk-wide read-off cannot express.
+`AnchorCandidates::{shallow_literals,deep_cover_tiers}`) remains only as the
+**fallback** for groups whose per-slot single-binding view cannot single a slot
+out (a value shared across sibling statements that resolves only as a tuple);
+retiring it is gated as backlog item 6.
 
 **Measured perf.** Whole ~7 MB / ~4.5k-member chunk minimizes in **~13 s** with
 the prove-gate-via-index fast-path (#2280), down from ~110 s — **meets the ≤30 s
@@ -183,6 +188,7 @@ the current (smaller, partly dogfood-applied) spec the whole chunk minimizes in
 `binding_group_declarators`, `nested_async_try`, `class_body`, `switch_case_run`,
 `object_keys_over_pinned`, `long_literal_value_anchor`, `binding_group_partition`,
 `class_among_many_siblings`, `sibling_subclass_hierarchy`, `adjacent_accessor_group`,
+`binding_group_key_set_readoff` (multi-target group per-slot key read-off, item 3),
 `interior_object_arg_holing` (unignored once the `Expr::Array` interior holing
 landed, #2289), `sequential_assignment_block` (unignored once the `hole_expr`
 `Expr::Assign` arm landed), `sibling_class_declaration_group` (the general
@@ -278,15 +284,32 @@ the landed architecture is in "Current state" above.
    dicts — `object_nested_value_dict` — already minimize via the nested
    object/array holing recursion; the `ee({ coreMessage: …, type: … })`
    schema-object-call form folds into item 1.)
-3. **Multi-target var binding-group read-off.** Groups still use the keep-shallow
-   path (`minimize_var_group_selector`) because per-slot declarator-tuple
-   resolution is something the chunk-wide read-off cannot express. Designing a
-   per-slot anchor union proven through the binding-group matcher would let groups
-   read off too — the last consumer of the keep-shallow cover and the gate for
-   items 4/5 below.
-4. **Retire the keep-shallow group cover** once item 3 lands — removes
+3. **Multi-target var binding-group read-off — LANDED (keep-shallow retirement
+   still open, item 4).** `try_var_group_read_off` (in `selector_codemod.rs`) now
+   reads each target declarator slot's minimal anchor off the shape index
+   (restricted to the slot), extends it with a slot-aware greedy
+   (`slot_minimal_anchors`, reusing `cover_object_slot`'s `(target slot not yet
+resolved, total matches)` scoring via the single-binding matcher), UNIONs the
+   per-slot kept spans, renders through `render_var_group_readoff` (object slots →
+   padded `OBJECT_PROPS`, others → `hole_expr`), and proves the tuple through the
+   binding-group matcher (`prove_synthesized_selector`); the regex upgrade applies
+   across slots. The keep-shallow path (`minimize_var_group_selector`'s escalation
+   over `collect_expr_anchors` + `AnchorCandidates`) is **kept as the fallback**
+   for groups whose per-slot anchors cannot single a slot out (e.g.
+   `binding_group_declarators`, where a value shared with a sibling statement
+   resolves only as a tuple). E2E: `binding_group_key_set_readoff` (sparse
+   per-slot key read-off); `binding_group_partition`'s group output re-baselined
+   sparser. **Retiring the keep-shallow cover is still open as item 4** — gated on
+   migrating the remaining fallback-only groups (the value-shared-across-statements
+   tuples the per-slot single-binding view cannot resolve alone) onto a
+   tuple-aware read-off, or accepting them as debt.
+4. **Retire the keep-shallow group cover.** Item 3 landed the binding-group
+   read-off, but the keep-shallow path stays as the fallback for groups whose
+   per-slot single-binding view cannot single a slot out (a value shared across
+   sibling _statements_ resolves only as a tuple). Removing
    `minimize_var_group_selector`'s escalation path, `collect_expr_anchors`, and
-   `AnchorCandidates::{shallow_literals,deep_cover_tiers}`.
+   `AnchorCandidates::{shallow_literals,deep_cover_tiers}` is gated on a
+   tuple-aware read-off for those residual groups (or accepting them as debt).
 5. **`selector_codemod.rs` by-form split + dedup** — the file is ~4.2k lines;
    splitting by form enables parallel per-form fan-out (do after item 4 reshapes
    the var path). Concrete dedup target: `try_object_read_off`, `try_var_read_off`,

--- a/devinfra/js/debundle/selector_codemod.rs
+++ b/devinfra/js/debundle/selector_codemod.rs
@@ -1514,11 +1514,15 @@ fn synthesize_specialized_var_selector(
 // resolves uniquely (gate 1). A target the read-off cannot single out returns
 // `None` and is reported as debt — never a full-AST pin.
 //
-// Multi-target var binding groups still use a keep-shallow path
-// (`minimize_var_group_selector`): per-slot tuple resolution the chunk-wide
-// read-off cannot express. It keeps each slot's direct shallow literals,
-// escalating to structural/deeper anchors only until the group resolves to the
-// right declarators, proven through the binding-group matcher as a
+// Multi-target var binding groups read off per slot (`try_var_group_read_off`):
+// each target declarator slot reads its minimal anchor off the shape index
+// (restricted to the slot) plus a slot-aware greedy (`slot_minimal_anchors`),
+// the per-slot kept spans union, and the binding-group matcher proves the tuple.
+// A keep-shallow path (`minimize_var_group_selector`) remains as the fallback for
+// groups whose per-slot single-binding view cannot single a slot out (a value
+// shared across sibling statements that resolves only as a tuple): it keeps each
+// slot's direct shallow literals, escalating to structural/deeper anchors only
+// until the group resolves, proven through the binding-group matcher as a
 // resolves-uniquely oracle; it may over-pin rather than run an exact-minimum
 // cover (near-minimal is the accepted target).
 // ===========================================================================
@@ -2702,6 +2706,271 @@ fn try_var_read_off(
     }))
 }
 
+/// Render a binding-group selector for a read-off pass: keep the target
+/// declarators (each `export = <holed init>`), `DECLARATORS_*` holes for the
+/// non-target runs. Each kept slot's init is holed by its anchor set — an object
+/// init via [`hole_object_padded`] (interleaved `OBJECT_PROPS`, the key-set form
+/// `try_object_read_off` uses) and any other init via [`hole_expr`]. The optional
+/// `regex_anchors` post-pass swaps a kept volatile-tail literal for the
+/// `STR_LITERAL_MATCHING_RE` predicate across every slot.
+fn render_var_group_readoff(
+    var: &VarDecl,
+    target_slots: &BTreeSet<usize>,
+    export_for: &impl Fn(&str) -> Option<String>,
+    kept: &BTreeSet<AnchorSpan>,
+    regex_anchors: &BTreeMap<AnchorSpan, String>,
+) -> Result<String> {
+    let mut decls: Vec<VarDeclarator> = Vec::new();
+    let mut skipped_run = false;
+    let mut target_seen = 0usize;
+    for (idx, declarator) in var.decls.iter().enumerate() {
+        if !target_slots.contains(&idx) {
+            skipped_run = true;
+            continue;
+        }
+        if skipped_run {
+            decls.push(declarator_hole(declarator_hole_name(
+                target_seen,
+                target_slots.len(),
+            )));
+            skipped_run = false;
+        }
+        let name = single_ident_pat_name(&declarator.name)
+            .expect("target declarator is a plain identifier");
+        let mut holed = declarator.clone();
+        holed.name = named_pat(&export_for(name).expect("target declarator has an export"));
+        holed.init = declarator.init.as_ref().map(|init| {
+            let mut holed_init = match init.as_ref() {
+                Expr::Object(object) => Expr::Object(hole_object_padded(object, kept)),
+                other => hole_expr(other, kept),
+            };
+            if !regex_anchors.is_empty() {
+                holed_init.visit_mut_with(&mut RegexAnchorSubstitution {
+                    patterns: regex_anchors,
+                });
+            }
+            Box::new(holed_init)
+        });
+        decls.push(holed);
+        target_seen += 1;
+    }
+    if skipped_run {
+        decls.push(declarator_hole(declarator_hole_name(
+            target_seen,
+            target_slots.len(),
+        )));
+    }
+    let mut holed_var = var.clone();
+    holed_var.declare = false;
+    holed_var.decls = decls;
+    emit_selector(ModuleItem::Stmt(Stmt::Decl(Decl::Var(Box::new(holed_var)))))
+}
+
+/// Ranked candidate anchor spans for one binding-group slot, best-first. Object
+/// slots reuse the key-set ranking ([`object_anchor_ranking`]: direct values then
+/// keys); every other init ranks its direct shallow literals first (a meaningful,
+/// rebuild-stable value pin), then structural key/member presence, then deeper
+/// literals — the keep-shallow tier order, flattened into a single best-first
+/// list the per-slot greedy consumes.
+fn slot_anchor_ranking(declarator: &VarDeclarator) -> Vec<AnchorSpan> {
+    let Some(init) = declarator.init.as_deref() else {
+        return Vec::new();
+    };
+    if let Expr::Object(object) = init {
+        return object_anchor_ranking(object);
+    }
+    let mut candidates = AnchorCandidates::default();
+    collect_expr_anchors(init, 0, &mut candidates);
+    let mut ranked: Vec<AnchorSpan> = candidates.shallow_literals();
+    for tier in candidates.deep_cover_tiers() {
+        for span in tier {
+            if !ranked.contains(&span) {
+                ranked.push(span);
+            }
+        }
+    }
+    ranked
+}
+
+/// Per-slot minimal anchor set for a binding-group read-off: the smallest kept
+/// span subset (drawn from `ranked`) that makes the matcher resolve **this slot's
+/// own export binding** to its declarator, viewed as a single-target selector
+/// (every other target slot holed to `DECLARATORS_*`). This is the per-slot
+/// declarator-tuple resolution the chunk-wide `minimal_anchor_set` (which is
+/// per-statement and resolves by distinct body index) cannot express: it cannot
+/// see two sibling declarators of the *same* statement.
+///
+/// Reuses [`cover_object_slot`]'s slot-aware scoring — `(target slot not yet
+/// resolved, total matches)` via the single-binding-form matcher
+/// ([`matched_binding_candidates`]) — so an anchor that flips the target binding
+/// to the resolved one and rules out the most competitors wins. `seed` (the
+/// chunk-wide read-off spans restricted to this slot) is kept up front when
+/// non-empty: it is the index's already-ranked `selective × stable` choice, so
+/// the greedy only adds to it. Returns the kept spans for the slot, or `None`
+/// when the slot's own anchors cannot single it out (the caller then falls back
+/// to the keep-shallow group path).
+fn slot_minimal_anchors(
+    index: &ChunkSelectorIndex,
+    var: &VarDecl,
+    decl: &IndexedDeclaration,
+    slot: usize,
+    target: &SynthesizedTargetBinding,
+    seed: &BTreeSet<AnchorSpan>,
+    ranked: &[AnchorSpan],
+) -> Result<Option<BTreeSet<AnchorSpan>>> {
+    let export = target.export_name.as_str();
+    let runtime = target.runtime_binding.as_str();
+    let slot_decl_span = var.decls[slot].span();
+    // Single-target view of this slot: the slot is the lone target, every other
+    // declarator holes to a `DECLARATORS_*` run.
+    let only_this = BTreeSet::from([slot]);
+    let export_for = |name: &str| (name == runtime).then(|| export.to_string());
+    let no_regex = BTreeMap::new();
+    let render_slot = |kept: &BTreeSet<AnchorSpan>| -> Result<String> {
+        render_var_group_readoff(var, &only_this, &export_for, kept, &no_regex)
+    };
+    // The slot resolves when the single-binding matcher singles out exactly this
+    // declarator: one match, at the target statement, bound to the target slot's
+    // runtime name.
+    let slot_resolves = |kept: &BTreeSet<AnchorSpan>| -> Result<bool> {
+        let matches = matched_binding_candidates(index, export, &render_slot(kept)?)?;
+        let [m] = matches.as_slice() else {
+            return Ok(false);
+        };
+        Ok(m.body_idx == decl.body_idx && m.binding.binding_name == runtime)
+    };
+    let mut kept: BTreeSet<AnchorSpan> = seed.clone();
+    while !slot_resolves(&kept)? {
+        let mut best: Option<((bool, usize), AnchorSpan)> = None;
+        for &anchor in ranked.iter().take(MAX_MINIMIZER_ANCHORS) {
+            if kept.contains(&anchor) || !node_holds_anchor(slot_decl_span, anchor) {
+                continue;
+            }
+            let mut trial = kept.clone();
+            trial.insert(anchor);
+            let matches = matched_binding_candidates(index, export, &render_slot(&trial)?)?;
+            let target_unresolved = !matches.iter().any(|m| m.binding.binding_name == runtime);
+            let score = (target_unresolved, matches.len());
+            if best.is_none_or(|(best_score, _)| score < best_score) {
+                best = Some((score, anchor));
+            }
+        }
+        let Some((_, anchor)) = best else {
+            return Ok(None);
+        };
+        kept.insert(anchor);
+    }
+    Ok(Some(kept))
+}
+
+/// Multi-target binding-group read-off (the per-slot declarator-tuple resolution
+/// the chunk-wide read-off cannot express): for each target declarator slot read
+/// its minimal anchor off the shape index (restricted to that slot) and, when the
+/// chunk-wide set does not single the slot out within the statement, extend it
+/// with a slot-aware greedy ([`slot_minimal_anchors`]). UNION the per-slot kept
+/// spans, render the whole group through [`render_var_group_readoff`], and prove
+/// the tuple with [`prove_synthesized_selector`] (the binding-group matcher as the
+/// resolves-uniquely oracle). The regex-literal upgrade applies across all slots.
+///
+/// Returns `None` — caller falls back to the keep-shallow path — when any slot's
+/// own anchors cannot single it out or the unioned selector does not resolve the
+/// tuple uniquely.
+fn try_var_group_read_off(
+    index: &ChunkSelectorIndex,
+    var: &VarDecl,
+    decl: &IndexedDeclaration,
+    targets: &[SynthesizedTargetBinding],
+    target_slots: &BTreeSet<usize>,
+) -> Result<Option<SpecializedSelector>> {
+    let export_for = |runtime: &str| {
+        targets
+            .iter()
+            .find(|target| target.runtime_binding == runtime)
+            .map(|target| target.export_name.clone())
+    };
+    // Chunk-wide read-off anchors for the whole statement, mapped to byte spans;
+    // each slot's seed is the subset lying inside that declarator.
+    let chunk_kept: BTreeSet<AnchorSpan> = match index.shape_index.minimal_anchor_set(decl.body_idx)
+    {
+        Some(anchor_set) => {
+            let item = index
+                .parsed
+                .module
+                .body
+                .get(decl.body_idx)
+                .context("read-off body index no longer in module")?;
+            kept_spans_for_anchor_set(item, &anchor_set)
+        }
+        None => BTreeSet::new(),
+    };
+
+    let mut union: BTreeSet<AnchorSpan> = BTreeSet::new();
+    for &slot in target_slots {
+        let runtime = single_ident_pat_name(&var.decls[slot].name)
+            .expect("target declarator is a plain identifier");
+        let target = targets
+            .iter()
+            .find(|target| target.runtime_binding == runtime)
+            .expect("target slot has a target");
+        let slot_decl_span = var.decls[slot].span();
+        let seed: BTreeSet<AnchorSpan> = chunk_kept
+            .iter()
+            .copied()
+            .filter(|span| node_holds_anchor(slot_decl_span, *span))
+            .collect();
+        let ranked = slot_anchor_ranking(&var.decls[slot]);
+        let Some(slot_kept) = slot_minimal_anchors(index, var, decl, slot, target, &seed, &ranked)?
+        else {
+            return Ok(None);
+        };
+        union.extend(slot_kept);
+    }
+
+    let no_regex = BTreeMap::new();
+    // Prove the unioned tuple resolves uniquely through the binding-group matcher
+    // before offering the regex upgrade; on failure the caller falls back to the
+    // keep-shallow group path.
+    if prove_synthesized_selector(
+        index,
+        decl,
+        targets,
+        &render_var_group_readoff(var, target_slots, &export_for, &union, &no_regex)?,
+    )
+    .is_err()
+    {
+        return Ok(None);
+    }
+
+    // Regex-literal upgrade over the kept string literals of every target slot
+    // (shared policy with the keep-shallow path).
+    let mut regex_candidates: BTreeMap<AnchorSpan, String> = BTreeMap::new();
+    for &slot in target_slots {
+        if let Some(init) = &var.decls[slot].init {
+            regex_candidates.extend(collect_regex_anchor_candidates(init));
+        }
+    }
+    let render_with = |kept: &BTreeSet<AnchorSpan>,
+                       regex_anchors: &BTreeMap<AnchorSpan, String>|
+     -> Result<String> {
+        render_var_group_readoff(var, target_slots, &export_for, kept, regex_anchors)
+    };
+    let regex_anchors = accepted_regex_anchors(
+        index,
+        decl,
+        targets,
+        &regex_candidates,
+        &union,
+        &render_with,
+    )?;
+
+    let source = render_with(&union, &regex_anchors)?;
+    let rewritten_holes = holes_present(&source);
+    Ok(Some(SpecializedSelector {
+        match_source: source,
+        rewritten_holes,
+    }))
+}
+
 /// Minimal anchor cover for a `var`/`let`/`const` binding group: render the
 /// shared declaration keeping the target declarators (each `export = <holed
 /// init>`) with `DECLARATORS_*` holes for non-target runs, and pin just enough
@@ -2767,6 +3036,17 @@ fn minimize_var_group_selector(
             *target_slots.iter().next().expect("one target slot"),
         )?
     {
+        return Ok(Some(selector));
+    }
+
+    // Multi-target binding-group read-off: read each target declarator slot's
+    // minimal anchor off the shape index (restricted to that slot) plus a
+    // slot-aware greedy, UNION them, and prove the tuple through the binding-group
+    // matcher. This is the per-slot declarator-tuple resolution the chunk-wide
+    // read-off cannot express. On `None` (a slot the read-off cannot single out,
+    // or a non-resolving union) we fall through to the keep-shallow group path
+    // below — the same target is then handled exactly as before.
+    if let Some(selector) = try_var_group_read_off(index, var, decl, targets, &target_slots)? {
         return Ok(Some(selector));
     }
 


### PR DESCRIPTION
## Multi-target var binding-group read-off (backlog item 3)

Today `minimize_var_group_selector` routes SINGLE-target vars through the read-off but MULTI-target binding groups still use the keep-shallow path, which over-pins. This adds a read-off path for multi-target groups.

### What it does

`try_var_group_read_off` (in `selector_codemod.rs`):

- For each target declarator slot, reads its minimal anchor off the chunk-wide shape index (`minimal_anchor_set`), restricted to that slot's span, as a seed.
- Extends the seed with a slot-aware greedy (`slot_minimal_anchors`) that reuses `cover_object_slot`'s `(target slot not yet resolved, total matches)` scoring via the single-binding matcher — the per-slot view (others holed to `DECLARATORS_*`) the chunk-wide read-off (per-statement, resolves by distinct body index) cannot express.
- UNIONs the per-slot kept spans, renders the whole group through `render_var_group_readoff` (object slots → padded `OBJECT_PROPS` like `try_object_read_off`; other inits → `hole_expr`), and proves the tuple through the binding-group matcher (`prove_synthesized_selector`).
- Applies the regex-literal upgrade (`accepted_regex_anchors`) across the group's slots.

The **keep-shallow path is kept as the fallback** (not deleted — that retirement is backlog item 6, gated on this) for groups whose per-slot single-binding view cannot single a slot out (a value shared across sibling *statements* that resolves only as a tuple, e.g. `binding_group_declarators`).

### Fixtures

- **New**: `binding_group_key_set_readoff` — a multi-target group of sibling key-set objects (values all shared `theme.base` member accesses) reads off each slot's discriminating key (`logViewer` / `alertChip`) with `OBJECT_PROPS` gaps and `DECLARATORS_AFTER` for the non-target declarator, instead of the keep-shallow over-pin (which would escalate to keeping every key of both objects). Registered in `selector_minimizer_expectation_test.rs`; verified it fails on the wrong expected output (non-vacuous).
- **Re-baselined sparser**: `binding_group_partition` group output — slot 0's `makeEntry` call argument now holes to `ANYTHING` because `enabled: true` alone singles it out (vs `unrelatedPrimary`'s `enabled: false`), while slot 1 keeps `"secondary"`. Matcher-proven-unique, strictly sparser than the old both-args-pinned form.

Existing group fixtures (`binding_group_declarators`, `grouped_enum_objects`, `object_key_set_group`, `object_key_set_subset`) stay green and unchanged.

### Tests

`bazelisk test //devinfra/js/debundle/...` — 117 tests pass (BuildBuddy `5dfd3e88-f365-48f0-89f2-989b3a345038`).

https://claude.ai/code/session_011YQabfZ5jVoFSETefd27Bg

---
_Generated by [Claude Code](https://claude.ai/code/session_011YQabfZ5jVoFSETefd27Bg)_