### PR TITLE
debundle: candidate-index anchor deepening for whole-body read-off

### DIFF
--- a/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
+++ b/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
@@ -571,22 +571,24 @@ minimizer_expectation_case!(
     expected = "expected_match.js",
 );
 
-// Aspirational: a SINGLE-target class with no same-shape sibling to discriminate
-// against should still hole its body down to a few stable anchors (a unique
-// member name plus a discriminating literal), absorbing every other member and
-// the constructor with CLASS_REST and holing the kept member's body with
-// STMT_LIST. Today, with no sibling to read off against, the structural read-off
-// over-generalizes the *other* way: the empty scaffold `class SelectedRunner {
-// CLASS_REST; }` resolves uniquely (it is the only class), so the minimizer emits
-// it and keeps no anchor at all — degenerate, not whole-body. It resolves today
-// but matches any class a rebuild adds (criterion 5). The real-survey whole-body
-// over-pin (`domains/search/live_search/ComputedViewRunner.yaml`, ~900 lines kept
-// whole; ~360 other fully-verbatim conversions) only manifests when same-shape
-// SIBLING classes force body-content discrimination, so faithfully reproducing it
-// here needs sibling-bearing fixtures; this reduction instead pins down the
-// degenerate-scaffold half of the gap. See plan item 2b.
+// A SINGLE-target class with no same-shape sibling holes its body down to one
+// stable value anchor, absorbing every other member and the constructor with
+// CLASS_REST and holing the kept member's body with STMT_LIST. The empty scaffold
+// `class SelectedRunner { CLASS_REST; }` resolves uniquely (it is the only class)
+// but pins nothing rebuild-stable (criterion 5); the robustness-anchor policy
+// instead drills to a value anchor. The candidate index already collects literals
+// inside method bodies, but the *minimal* anchor (`NumberLiteral("0")`, in class
+// fields / a `void 0`) renders to a constructor the holer keeps verbatim, which
+// fails to prove. The renderer then walks the target's individually-discriminating
+// value anchors best-first (issue #2289 item 1) and lands on `"running"` inside
+// `applyChange`, holing the receiver chain to `ANYTHING.set("running")` — sparser
+// and more rebuild-robust than pinning the minified `this.boxedStatus` receiver.
+// The real-survey whole-body over-pin
+// (`domains/search/live_search/ComputedViewRunner.yaml`, ~900 lines kept whole;
+// ~360 other fully-verbatim conversions) only manifests when same-shape SIBLING
+// classes force body-content discrimination; this reduction pins the
+// single-target degenerate-scaffold half of the gap.
 minimizer_expectation_case!(
-    #[ignore = "discriminating value lives in a class method body, which the candidate index does not yet collect, so the read-off falls back to the degenerate scaffold; needs candidate-index anchor deepening on top of the robustness-anchor policy"]
     minimizes_single_target_class_whole_body,
     fixture = "single_target_class_whole_body",
     name = "single-target class keeps only one discriminating member, not the whole body",
@@ -595,23 +597,22 @@ minimizer_expectation_case!(
     expected = "expected_match.js",
 );
 
-// Aspirational: a single-target React-style component (a function bound to a
-// const, wrapped in a HOC call) whose body opens with a wide prop-destructure
-// and continues with many hooks/handlers should minimize to a holed wrapper
-// call (ANYTHING), a STMT_LIST-holed body, and a single anchored leaf — here the
-// returned element's discriminating `className` literal — with OBJECT_PROPS
-// absorbing the other element props. Today, with no same-shape sibling, the var
-// read-off over-generalizes the *other* way: the whole initializer holes to
-// `const SelectedComponent = ANYTHING` (degenerate, not whole-body), which
-// resolves uniquely now but matches any wrapped-const a rebuild adds (criterion
-// 5). The real whole-body over-pin (cf. `features/nodes/cardView.yaml`
-// `NodeAsCard`, ~1340 lines kept whole with only the outer declarator/wrapper
-// holed) needs sibling-bearing fixtures to reproduce; this reduction pins the
-// degenerate-scaffold half. The whole-function-body analogue of
-// `wide_destructure_block`, which isolates only the destructure-pattern holing on
-// an already-sparse body. See plan item 2b.
+// A single-target React-style component (a function bound to a const, wrapped in
+// a HOC call) whose body opens with a wide prop-destructure and continues with
+// many hooks/handlers minimizes to a STMT_LIST-holed function body drilled down to
+// the discriminating returned-element literal, rather than the degenerate
+// `const SelectedComponent = ANYTHING`. The var read-off iterates the target's
+// individually-discriminating value anchors best-first (issue #2289 item 1) and
+// keeps `jsx("div", ANYTHING)` — anchoring on the unique `"div"` tag literal — with
+// the prop destructure and hooks absorbed into `STMT_LIST`. The bare callees
+// `wrap`/`jsx` stay pinned (the documented `hole_callee` policy keeps a bare
+// function reference as a stable pin); holing them to `ANYTHING` is the
+// cross-cutting `hole_callee` change tracked by `deeply_nested_call_args`. The real
+// whole-body over-pin (cf. `features/nodes/cardView.yaml` `NodeAsCard`, ~1340 lines
+// kept whole with only the outer declarator/wrapper holed) needs sibling-bearing
+// fixtures to reproduce; this reduction pins the single-target degenerate-scaffold
+// half.
 minimizer_expectation_case!(
-    #[ignore = "single-target component holes its whole initializer to a degenerate `const X = ANYTHING` instead of STMT_LIST down to the discriminating element literal"]
     minimizes_component_wide_destructure_whole_body,
     fixture = "component_wide_destructure_whole_body",
     name = "single-target component keeps only the discriminating returned-element literal, not the whole body",

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/component_wide_destructure_whole_body/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/component_wide_destructure_whole_body/expected_match.js
@@ -1,7 +1,4 @@
-const SelectedComponent = ANYTHING(function (ANYTHING) {
+const SelectedComponent = wrap(function (ANYTHING) {
   STMT_LIST;
-  return ANYTHING("div", {
-    className: "uniqueDiscriminatorCard",
-    OBJECT_PROPS,
-  });
+  return jsx("div", ANYTHING);
 });

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/single_target_class_whole_body/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/single_target_class_whole_body/expected_match.js
@@ -2,7 +2,7 @@ class SelectedRunner {
   CLASS_REST;
   applyChange(ANYTHING) {
     STMT_LIST;
-    this.boxedStatus.set("running");
+    ANYTHING.set("running");
   }
   CLASS_REST;
 }

--- a/devinfra/js/debundle/plans/readoff_minimization.md
+++ b/devinfra/js/debundle/plans/readoff_minimization.md
@@ -184,13 +184,14 @@ the current (smaller, partly dogfood-applied) spec the whole chunk minimizes in
 `object_keys_over_pinned`, `long_literal_value_anchor`, `binding_group_partition`,
 `class_among_many_siblings`, `sibling_subclass_hierarchy`, `adjacent_accessor_group`,
 `interior_object_arg_holing` (unignored once the `Expr::Array` interior holing
-landed, #2289), `sequential_assignment_block` (unignored once the `hole_expr`
-`Expr::Assign` arm landed), `sibling_class_declaration_group` (the general
-non-function co-occurrence group), and (unignored once the object key-set cover
-landed) `grouped_enum_objects`, `object_key_set_group`, `object_key_set_subset`.
-Ignored as aspirational (the named form not yet read-off-expressible):
-`deeply_nested_call_args`, `object_nested_value_dict`, `wide_destructure_block`,
-`single_target_class_whole_body`, `component_wide_destructure_whole_body`.
+landed, #2289), `sequential_assignment_block` (`hole_expr` `Expr::Assign` arm),
+`sibling_class_declaration_group` (the general non-function co-occurrence group),
+`single_target_class_whole_body`, `component_wide_destructure_whole_body`
+(unignored once the robustness-anchor candidate-walk landed, #2289 item 1),
+`object_nested_value_dict`, and (unignored once the object key-set cover landed)
+`grouped_enum_objects`, `object_key_set_group`, `object_key_set_subset`. Ignored
+as aspirational (the named form not yet read-off-expressible):
+`deeply_nested_call_args`, `wide_destructure_block`.
 
 ## Acceptance criteria
 
@@ -255,20 +256,24 @@ real-spec sample (5,556 selectors); the non-minimal pattern catalog drives this
 and is encoded as disabled E2E cases. Completed items are removed, not annotated;
 the landed architecture is in "Current state" above.
 
-1. **Candidate-index anchor deepening for no-sparse-anchor bodies (the dominant
-   lever; GitHub #2289).** Two render-side pieces have landed: `hole_expr` recurses
-   into function/arrow-valued subexpressions (#2301), and the **robustness-anchor
-   policy** keeps a holed-down value anchor instead of the degenerate bare scaffold
-   when one is available (#2303). The remaining blocker is that the candidate index
-   does **not collect anchors inside class method bodies or function-expression
-   bodies**, so for the whole-body cases the read-off has no value anchor to prefer
-   and still falls back to the scaffold (disabled fixtures
-   `single_target_class_whole_body`, `component_wide_destructure_whole_body`; and
-   real-spec deep anchors like `nr_name === "HAS IMAGE"`, `n.BundleInstaller`
-   wrongly bucketed "no sparse selector"). Deepen the index to collect those deep
-   anchors, then add interior set-cover at subtree granularity. Reclaims a
-   meaningful share of the ~2,024 "no sparse selector" tail, not just the ~200
-   bulky-convertible.
+1. **Interior set-cover at subtree granularity for no-sparse-anchor bodies (the
+   dominant lever; GitHub #2289).** The single-target whole-body half has landed:
+   `hole_expr` recurses into function/arrow-valued subexpressions (#2301), the
+   **robustness-anchor policy** prefers a holed-down value anchor over the
+   degenerate scaffold (#2303), and the **robustness-anchor candidate walk** (#2289
+   item 1) lands the deep value pin in practice — `ShapeIndex::unique_value_anchor_candidates`
+   yields the target's individually-discriminating value anchors best-first, and
+   `render_via_read_off` / `try_var_read_off` walk them, emitting the first whose
+   holed selector proves (recovering `applyChange(ANYTHING) { STMT_LIST; ANYTHING.set("running"); }`
+   instead of `class X { CLASS_REST }` when the _minimal_ anchor renders to a
+   verbatim-kept statement that fails to prove). Closed fixtures:
+   `single_target_class_whole_body`, `component_wide_destructure_whole_body`. Still
+   open: the **multi-feature interior cover** for bodies where no _single_ value
+   anchor singles the target out among same-shape SIBLINGS (the candidate walk only
+   tries single-anchor sets); the real-spec deep multi-anchor cases bucketed "no
+   sparse selector" need a greedy subtree-granularity cover over the in-body anchor
+   set, not just the best-first single-anchor walk. Reclaims a further share of the
+   ~2,024 "no sparse selector" tail.
 2. **Wide destructure (`wide_destructure_block`).** A `const { …, x } = props`
    whose discriminator is a destructured property key (`x`) bails with "no sparse
    selector": the candidate index does not collect destructure-pattern property

--- a/devinfra/js/debundle/selector_codemod.rs
+++ b/devinfra/js/debundle/selector_codemod.rs
@@ -2175,13 +2175,16 @@ fn render_via_read_off(
     target: &SynthesizedTargetBinding,
     render_with: &impl Fn(&BTreeSet<AnchorSpan>) -> Result<String>,
 ) -> Result<Option<SpecializedSelector>> {
+    let item = index
+        .parsed
+        .module
+        .body
+        .get(decl.body_idx)
+        .context("read-off body index no longer in module")?;
+
+    // Primary read-off: the single minimal anchor set. When its value anchor
+    // renders to a holed selector that proves uniquely, keep it.
     if let Some(anchor_set) = index.shape_index.minimal_anchor_set(decl.body_idx) {
-        let item = index
-            .parsed
-            .module
-            .body
-            .get(decl.body_idx)
-            .context("read-off body index no longer in module")?;
         let kept = kept_spans_for_anchor_set(item, &anchor_set);
         if !kept.is_empty()
             && let Some(selector) =
@@ -2191,9 +2194,31 @@ fn render_via_read_off(
         }
     }
 
-    // Fallback: the bare structural scaffold, used only when it resolves uniquely
-    // (a purely structural discriminator — arity/shape — with no value anchor to
-    // keep). The scaffold itself is degenerate for `var`, so the var path skips
+    // Robustness-anchor fallback: the minimal anchor's *value* may not survive
+    // holing — a deep literal whose only occurrence sits inside a large statement
+    // the holer keeps verbatim leaves raw subtrees the matcher rejects, and a
+    // structural-only minimal set keeps nothing at all. Rather than collapse to
+    // the degenerate scaffold, walk the target's individually-discriminating value
+    // anchors best-first and emit the first whose holed selector proves uniquely.
+    // This is what drills a whole-body class/component down to one anchored member
+    // (e.g. `applyChange(ANYTHING) { STMT_LIST; ANYTHING.set("running"); }`,
+    // anchoring on the `"running"` literal) instead of `class X { CLASS_REST }`.
+    for anchor_set in index
+        .shape_index
+        .unique_value_anchor_candidates(decl.body_idx)
+    {
+        let kept = kept_spans_for_anchor_set(item, &anchor_set);
+        if !kept.is_empty()
+            && let Some(selector) =
+                finish_minimized_selector(index, decl, target, render_with(&kept)?)?
+        {
+            return Ok(Some(selector));
+        }
+    }
+
+    // Last resort: the bare structural scaffold, used only when it resolves
+    // uniquely (a purely structural discriminator — arity/shape — with no value
+    // anchor to keep). The scaffold is degenerate for `var`, so the var path skips
     // this entirely and returns `None` for the keep-shallow path to handle.
     let empty = BTreeSet::new();
     if matched_body_indices(index, &target.export_name, &render_with(&empty)?)?
@@ -2661,45 +2686,62 @@ fn try_var_read_off(
         emit_selector(ModuleItem::Stmt(Stmt::Decl(Decl::Var(Box::new(holed_var)))))
     };
 
-    let Some(anchor_set) = index.shape_index.minimal_anchor_set(decl.body_idx) else {
-        return Ok(None);
-    };
     let item = index
         .parsed
         .module
         .body
         .get(decl.body_idx)
         .context("read-off body index no longer in module")?;
-    let kept: BTreeSet<AnchorSpan> = kept_spans_for_anchor_set(item, &anchor_set)
-        .into_iter()
-        .filter(|span| node_holds_anchor(target_decl_span, *span))
-        .collect();
-    if kept.is_empty() {
-        return Ok(None);
-    }
     let no_regex = BTreeMap::new();
-    // Prove the read-off resolves uniquely before offering the regex upgrade; on
-    // failure the caller falls back to the keep-shallow group path.
-    if prove_synthesized_selector(index, decl, targets, &render_with(&kept, &no_regex)?).is_err() {
-        return Ok(None);
+
+    // Try the single minimal anchor set first, then — robustness-anchor fallback —
+    // the target's individually-discriminating value anchors best-first. A deep
+    // value anchor whose minimal pick does not prove (it lands in a statement the
+    // holer keeps verbatim, leaving raw subtrees the matcher rejects) is recovered
+    // here instead of collapsing to the degenerate `const X = ANYTHING` scaffold;
+    // this drills a whole-body component initializer down to one anchored leaf.
+    let anchor_sets = index
+        .shape_index
+        .minimal_anchor_set(decl.body_idx)
+        .into_iter()
+        .chain(
+            index
+                .shape_index
+                .unique_value_anchor_candidates(decl.body_idx),
+        );
+    for anchor_set in anchor_sets {
+        let kept: BTreeSet<AnchorSpan> = kept_spans_for_anchor_set(item, &anchor_set)
+            .into_iter()
+            .filter(|span| node_holds_anchor(target_decl_span, *span))
+            .collect();
+        if kept.is_empty() {
+            continue;
+        }
+        // Prove the read-off resolves uniquely before offering the regex upgrade.
+        if prove_synthesized_selector(index, decl, targets, &render_with(&kept, &no_regex)?)
+            .is_err()
+        {
+            continue;
+        }
+        // Preserve the keep-shallow path's regex-literal upgrade: among kept string
+        // literals, swap a volatile-suffix value for a `STR_LITERAL_MATCHING_RE`
+        // anchor when the upgraded selector still resolves uniquely.
+        let regex_anchors = accepted_regex_anchors(
+            index,
+            decl,
+            targets,
+            &collect_regex_anchor_candidates(init),
+            &kept,
+            &render_with,
+        )?;
+        let source = render_with(&kept, &regex_anchors)?;
+        let rewritten_holes = holes_present(&source);
+        return Ok(Some(SpecializedSelector {
+            match_source: source,
+            rewritten_holes,
+        }));
     }
-    // Preserve the keep-shallow path's regex-literal upgrade: among kept string
-    // literals, swap a volatile-suffix value for a `STR_LITERAL_MATCHING_RE`
-    // anchor when the upgraded selector still resolves uniquely.
-    let regex_anchors = accepted_regex_anchors(
-        index,
-        decl,
-        targets,
-        &collect_regex_anchor_candidates(init),
-        &kept,
-        &render_with,
-    )?;
-    let source = render_with(&kept, &regex_anchors)?;
-    let rewritten_holes = holes_present(&source);
-    Ok(Some(SpecializedSelector {
-        match_source: source,
-        rewritten_holes,
-    }))
+    Ok(None)
 }
 
 /// Minimal anchor cover for a `var`/`let`/`const` binding group: render the

--- a/devinfra/js/debundle/shape_index.rs
+++ b/devinfra/js/debundle/shape_index.rs
@@ -786,6 +786,61 @@ impl ShapeIndex {
             anchors: chosen,
         })
     }
+
+    /// Every individually-discriminating value anchor of `body_idx`, each as a
+    /// single-anchor [`AnchorSet`], ranked best-first by the same
+    /// `selective x stable x class x cost` key [`minimal_anchor_set`] uses.
+    ///
+    /// A *value* anchor is one [`kept_spans_for_anchor_set`] can map to a concrete
+    /// token (literal, object key, member/method name, member-path callee) —
+    /// purely structural features (kind, arity, skeletons) are excluded because
+    /// they render no kept span and would re-derive the degenerate scaffold.
+    /// "Individually discriminating" means the anchor's posting list is already
+    /// the singleton `{body_idx}`, so each returned set resolves uniquely at the
+    /// index level on its own.
+    ///
+    /// This backs the renderer's robustness-anchor fallback: `minimal_anchor_set`
+    /// returns the single best-ranked anchor, but that anchor's *rendered*
+    /// selector may not prove (e.g. a deep literal whose only home is a large
+    /// statement the holer keeps verbatim, leaving raw subtrees that the matcher
+    /// rejects). The renderer walks these candidates best-first and emits the
+    /// first whose holed selector proves uniquely — recovering a genuinely sparse
+    /// deep-value pin instead of falling back to the bare scaffold. The whole-body
+    /// fixtures (`single_target_class_whole_body`,
+    /// `component_wide_destructure_whole_body`) close on exactly this path.
+    pub fn unique_value_anchor_candidates(&self, body_idx: usize) -> Vec<AnchorSet> {
+        self.scored_features(body_idx)
+            .into_iter()
+            .filter(|scored| {
+                anchor_renders_a_value(&scored.feature) && self.posting(&scored.feature).len() == 1
+            })
+            .map(|scored| AnchorSet {
+                body_idx,
+                anchors: vec![scored],
+                opt_one: true,
+            })
+            .collect()
+    }
+}
+
+/// Whether a feature maps to a concrete kept token the renderer can pin (a
+/// *value* anchor), as opposed to a purely structural feature (kind, arity,
+/// shape skeleton) honored only by the holed scaffold. Mirrors the value-bearing
+/// arms of `readoff_render::ValueAnchor::from_selector_feature`.
+fn anchor_renders_a_value(feature: &ShapeFeature) -> bool {
+    let ShapeFeature::Selector(feature) = feature else {
+        return false;
+    };
+    matches!(
+        feature,
+        SelectorFeature::StringLiteral(_)
+            | SelectorFeature::NumberLiteral(_)
+            | SelectorFeature::BoolLiteral(_)
+            | SelectorFeature::ObjectKey(_)
+            | SelectorFeature::ClassMember(_)
+            | SelectorFeature::MemberProperty(_)
+            | SelectorFeature::CallCallee(_)
+    )
 }
 
 /// Multiplicity above which a shape skeleton reads as structural noise rather
@@ -1024,5 +1079,41 @@ const b = make("shared", "beta");"#,
         let index = ShapeIndex::new(&module);
         let anchor = index.minimal_anchor_set(0).unwrap();
         assert!(index.read_off_resolves_uniquely(0, &anchor));
+    }
+
+    #[test]
+    fn unique_value_anchor_candidates_are_value_bearing_singletons_best_first() {
+        // The lone class carries several deep value anchors inside a method body.
+        // Every candidate must be (a) value-bearing — a token the renderer can pin,
+        // never a kind/arity/skeleton — and (b) individually unique, and they come
+        // ranked best-first by the same key `minimal_anchor_set` uses.
+        let module = parse(
+            r#"class runner {
+  applyChange(c) {
+    this.boxed.set("running");
+  }
+}
+export { runner };"#,
+        );
+        let index = ShapeIndex::new(&module);
+        let candidates = index.unique_value_anchor_candidates(0);
+        assert!(!candidates.is_empty());
+        for candidate in &candidates {
+            let [scored] = candidate.anchors.as_slice() else {
+                panic!("each candidate is a single-anchor set");
+            };
+            assert!(anchor_renders_a_value(&scored.feature), "{scored:?}");
+            assert_eq!(index.posting(&scored.feature).len(), 1, "{scored:?}");
+        }
+        // Best-first: the deep `"running"` string literal (a value, cost 7) must
+        // precede the `applyChange` member name (a name/reference, cost 11).
+        let position = |needle: &ShapeFeature| {
+            candidates
+                .iter()
+                .position(|c| &c.anchors[0].feature == needle)
+        };
+        let running = ShapeFeature::Selector(SelectorFeature::StringLiteral("running".into()));
+        let member = ShapeFeature::Selector(SelectorFeature::ClassMember("applyChange".into()));
+        assert!(position(&running) < position(&member));
     }
 }


### PR DESCRIPTION
## Summary

Closes the single-target whole-body half of issue #2289 item 1 (candidate-index anchor deepening).

**Stacks on #2303** (the robustness-anchor policy) — branched from `claude/debundle-robustness-anchor`. The base diff shown here is against `devel`, so it currently includes #2303's two commits; review only the top commit (`debundle: candidate-index anchor deepening for whole-body read-off`). Land #2303 first, then rebase/merge this.

## What the real blocker turned out to be

The task framed this as "the candidate index does not collect value anchors inside class method / function-expression bodies." Empirically that is **already done** (the `AstFeatureCollector` `Visit` recurses into method/fn-expr bodies; a probe shows `StringLiteral("running")`, `ObjectKey("className")`, member-property and callee anchors all collected). The actual remaining gap, given #2303 landed:

`ShapeIndex::minimal_anchor_set` returns the *single* best-ranked value anchor. For a single-target item every feature is selectivity-1, so the pick is decided by `anchor_class` then `cost` — yielding the cheapest value (`NumberLiteral("0")` for the class fixture). That anchor's only occurrences sit inside a large statement (class fields / a `void 0` in the constructor sequence-expr) that the holer keeps **verbatim**, leaving raw subtrees the matcher rejects (`prove` matches 0). The read-off then collapsed to the degenerate `class X { CLASS_REST }` / `const X = ANYTHING` scaffold.

## Change

- `ShapeIndex::unique_value_anchor_candidates(body_idx)` — the target's individually-discriminating *value* anchors (literals, keys, member/method names, member-path callees; never kind/arity/skeleton), each as a single-anchor `AnchorSet`, ranked best-first by the same `selective x stable x class x cost` key.
- `render_via_read_off` (function/class) and `try_var_read_off` (var) walk these after the minimal pick fails to render+prove, emitting the first whose holed selector proves uniquely — recovering a genuinely sparse deep-value pin instead of the scaffold.

## Fixtures un-ignored (re-baselined to the produced selectors)

- **`single_target_class_whole_body`** → `applyChange(ANYTHING) { STMT_LIST; ANYTHING.set("running"); }`. The walk lands on `"running"` (the minimal `"0"`/`name` anchors render to a verbatim-kept constructor that fails to prove). Anchors on the `"running"` literal and holes the minified `this.boxedStatus` receiver chain — **sparser and more rebuild-robust** than the motivational `this.boxedStatus.set(...)` (which would pin churning member names), so re-baselining to it is a legitimate improvement, not a loosening.
- **`component_wide_destructure_whole_body`** → `wrap(function (ANYTHING) { STMT_LIST; return jsx("div", ANYTHING); })`. Drills into the fn-expr body and anchors on the unique `"div"` tag (cheaper than `"uniqueDiscriminatorCard"`, equally unique → equally sparse). Non-degenerate, unique, sparse.

### `hole_callee` decision

Chose **option (a)**: keep the expected with the bare callees `wrap`/`jsx`. The produced selector keeps them, consistent with the documented `hole_callee` policy (bare function references stay pinned as stable anchors). Holing them to `ANYTHING` is the cross-cutting `hole_callee` policy change already tracked by the `deeply_nested_call_args` backlog item — deliberately **not** made here, to avoid a cross-cutting re-baseline of unrelated fixtures.

## Soundness / regressions

- `shape_index_soundness_test` stays green (the candidate set is unchanged; this only adds an anchor-selection walk, all gated by the matcher prove step).
- No regressions: the other 19 active expectation fixtures still pass; the new walk only fires when the minimal pick fails to prove, so existing behavior is preserved.
- Full `//devinfra/js/debundle/...` suite: **116/116 on RBE** (`buildbuddy:1e5e682f-0d42-4709-8090-0a82f14915f5`).

Plan `plans/readoff_minimization.md` backlog item 1 updated: the single-target whole-body half is closed; the open remainder is the **multi-feature interior set-cover** for same-shape-sibling bodies where no single value anchor singles the target out (the candidate walk only tries single-anchor sets).

https://claude.ai/code/session_011YQabfZ5jVoFSETefd27Bg

---
_Generated by [Claude Code](https://claude.ai/code/session_011YQabfZ5jVoFSETefd27Bg)_