### PR TITLE
debundle: extract peel::print_ndjson_list to dedup CLI NDJSON preamble

### DIFF
--- a/devinfra/js/debundle/cli/gate.rs
+++ b/devinfra/js/debundle/cli/gate.rs
@@ -207,10 +207,7 @@ fn run_list(args: GateListArgs) -> Result<()> {
             .collect(),
     };
     let format = peel::OutputFormat::resolve(args.format);
-    if format == peel::OutputFormat::Ndjson {
-        for entry in &report.blocking_sccs {
-            println!("{}", serde_json::to_string(entry)?);
-        }
+    if peel::print_ndjson_list(&report.blocking_sccs, format)? {
         return Ok(());
     }
     peel::print_report(&report, format, render_list_text).context("writing gate list output")
@@ -319,10 +316,7 @@ fn run_cut(args: GateIdArgs) -> Result<()> {
         cut: entry.cut.clone(),
     };
     let format = peel::OutputFormat::resolve(args.format);
-    if format == peel::OutputFormat::Ndjson {
-        for edge in &report.cut {
-            println!("{}", serde_json::to_string(edge)?);
-        }
+    if peel::print_ndjson_list(&report.cut, format)? {
         return Ok(());
     }
     peel::print_report(&report, format, render_cut_text).context("writing gate cut output")

--- a/devinfra/js/debundle/cli/scc_cluster.rs
+++ b/devinfra/js/debundle/cli/scc_cluster.rs
@@ -3,7 +3,10 @@
 
 use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
-use peel::{CommonArgs as PeelCommonArgs, OutputFormat, print_report, resolve_binding_owners};
+use peel::{
+    CommonArgs as PeelCommonArgs, OutputFormat, print_ndjson_list, print_report,
+    resolve_binding_owners,
+};
 
 /// Args for `debundle scc`.
 #[derive(Debug, ClapArgs)]
@@ -155,10 +158,7 @@ pub fn run_scc(args: SccArgs) -> Result<()> {
     }
     let report = SccReport { sccs: entries };
     let format = OutputFormat::resolve(args.format);
-    if format == OutputFormat::Ndjson {
-        for entry in &report.sccs {
-            println!("{}", serde_json::to_string(entry)?);
-        }
+    if print_ndjson_list(&report.sccs, format)? {
         return Ok(());
     }
     print_report(&report, format, render_scc_text).context("writing scc output")

--- a/devinfra/js/debundle/peel/mod.rs
+++ b/devinfra/js/debundle/peel/mod.rs
@@ -5,7 +5,7 @@ pub mod quotient;
 pub use plan::{
     CommonArgs, ExplainArgs, ExplainReport, GraphSummaryArgs, GraphSummaryReport, OutputFormat,
     PatchPlanArgs, PatchPlanReport, PeelArgs, PeelCommand, PlanWorkArgs, PlanWorkReport,
-    SelectionArgs, SourceSliceArgs, SourceSliceReport, UnitsArgs, UnitsReport, print_report,
-    resolve_binding_owners, run_explain_report, run_graph_summary_report, run_patch_plan_report,
-    run_plan_work_report, run_source_slice_report, run_units_report,
+    SelectionArgs, SourceSliceArgs, SourceSliceReport, UnitsArgs, UnitsReport, print_ndjson_list,
+    print_report, resolve_binding_owners, run_explain_report, run_graph_summary_report,
+    run_patch_plan_report, run_plan_work_report, run_source_slice_report, run_units_report,
 };

--- a/devinfra/js/debundle/peel/plan.rs
+++ b/devinfra/js/debundle/peel/plan.rs
@@ -531,6 +531,20 @@ where
     }
 }
 
+/// For a command whose primary output is an array: when `format` is `Ndjson`,
+/// emit one compact JSON line per item and return `true` (the caller should
+/// stop). Otherwise emit nothing and return `false`, so the caller falls through
+/// to [`print_report`] for the text/json rendering of the whole report.
+pub fn print_ndjson_list<T: Serialize>(items: &[T], format: OutputFormat) -> Result<bool> {
+    if format != OutputFormat::Ndjson {
+        return Ok(false);
+    }
+    for item in items {
+        println!("{}", serde_json::to_string(item)?);
+    }
+    Ok(true)
+}
+
 pub fn run_plan_work_report(args: &PlanWorkArgs) -> Result<PlanWorkReport> {
     let mut report = analyze_peel_factorize(&PeelFactorizeOptions {
         owner_graph_path: args.common.owner_graph_path.clone(),


### PR DESCRIPTION
## Summary

Small CLI cleanup. Three commands (`gate` list, `gate` cut, `scc`) repeated the same NDJSON-list preamble before `print_report`:

```rust
let format = OutputFormat::resolve(args.format);
if format == OutputFormat::Ndjson {
    for x in &report.<list> { println!("{}", serde_json::to_string(x)?); }
    return Ok(());
}
print_report(&report, format, render_text)...
```

Extract `peel::print_ndjson_list(items, format) -> Result<bool>` (emit one compact JSON line per item when `Ndjson`, returning whether the caller should stop) and replace the three copies with `if peel::print_ndjson_list(&report.<list>, format)? { return Ok(()); }`.

The `selector-debt` and `validate` commands keep their bespoke NDJSON emitters (they emit multiple sections, not a single list).

## Testing

`bazelisk test //devinfra/js/debundle/...` — 117/117 pass (RBE).

https://claude.ai/code/session_011YQabfZ5jVoFSETefd27Bg

---
_Generated by [Claude Code](https://claude.ai/code/session_011YQabfZ5jVoFSETefd27Bg)_