### PR TITLE
debundle: consolidate the unrealizable-SCC report types

### DIFF
--- a/devinfra/js/debundle/ARCHITECTURE_BACKLOG.md
+++ b/devinfra/js/debundle/ARCHITECTURE_BACKLOG.md
@@ -82,6 +82,8 @@ OwnerGraphReport       // reports/schema.rs (the JSON view of the typed OwnerGra
 
 Six distinct types in the orbit of "stuff a chunk analysis produced" (after the `ChunkAnalysis`/`ChunkAnalysisReport` split). A reader still can't tell from the name alone which one carries which data without grepping. Some of this is unavoidable (the JSON-wire / typed-IR split is real), but the layering of `ChunkAnalysis` → `ChunkFactorization` → `FactorizationReport` could plausibly collapse to two: an IR with optional partition state + a derive-to-report adapter.
 
+**Verdict (2026-06, do not attempt):** the proposed two-layer shape — an IR with optional partition state plus a derive-to-report adapter — is already the shape in practice. `ChunkAnalysis` is the partition-free IR; `ChunkFactorization` is that IR plus applied partition state; `FactorizationReport` is the derive-to-report adapter (`validate()`). Collapsing the `Arc<ChunkAnalysis>` boundary inside `ChunkFactorization` (folding the wrapper into a single partition-optional IR type) is a large, risky change touching the materializer/emitter path for no behavior gain, so it is deliberately left alone. The naming-clarity nit (`ChunkFactorization` vs `ChunkAnalysis`) survives in "Name overloading" below.
+
 ### `pub(crate)` on internals is broad
 
 `OwnerGraph` fields are private, but `RealizabilityIndex` holds
@@ -96,7 +98,6 @@ makes invalid operations impossible.
 Watch out for:
 
 - **`ChunkFactorization` vs `ChunkAnalysis`**: both are per-chunk IR; the difference is whether the partition is applied. Could be `ChunkAnalysis` (no partition) vs `FactorizedChunk` (partition applied) and the meaning would be more obvious.
-- **`SccDiagnosis` (`realizability/mod.rs`, renamed from `UnrealizableScc` in `3dbaf1037`)** vs **`CycleReport` (`validation.rs:38`)** vs **`QuotientSccReport` (`reports/schema.rs:174`)** vs **`AtomicUnitConflict` (`factor_assembly.rs:42`)** — four representations of "the spec is unrealizable, here's why" with subtly different fields. `SccDiagnosis` carries `constraining_owner_edges`; `CycleReport` carries `cut` (a minimum cut) + `evidence`; `QuotientSccReport` carries `module_edge_ids` + `constraining_module_edge_ids`. Two of these contain the same data ("the modules in the SCC + the edges in the SCC"), with the cut/evidence/min decoration added by the validator. The right shape is one core type with optional decorations, not four parallel structs.
 
 ## Algorithmic clarity (realizability gate, atom detection)
 

--- a/devinfra/js/debundle/factor_assembly.rs
+++ b/devinfra/js/debundle/factor_assembly.rs
@@ -33,11 +33,11 @@ pub struct ConflictingClaim {
 /// more distinct destinations — unrealizable by construction.
 ///
 /// Atom-level (binding members claimed across distinct destinations),
-/// not SCC-level. The module-quotient-SCC counterpart is
-/// `SccDiagnosis` (gate crate); the two share the
-/// "unrealizable, here's why" framing but operate on different
-/// domains (atomic unit membership vs. inter-module constraining
-/// cycles) and intentionally remain separate types.
+/// not SCC-level — the atom-level sibling of the module-quotient-SCC
+/// shape [`crate::reports::SccCore`]. Both carry the "unrealizable,
+/// here's why" framing, but this one's domain is owners in an atomic
+/// unit rather than modules in an SCC, so it does not reuse that core
+/// and stays a separate type.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize)]
 pub struct AtomicUnitConflict {
     /// Members sorted by `OwnerId`.

--- a/devinfra/js/debundle/peel/quotient.rs
+++ b/devinfra/js/debundle/peel/quotient.rs
@@ -1004,7 +1004,7 @@ impl QuotientGraph {
         let partition = self.realizability_index.partition();
         let mut cycles: Vec<CycleClassSet> = Vec::new();
         for scc in &verdict.unrealizable_sccs {
-            let modules_in_scc: BTreeSet<ModuleId> = scc.modules.iter().copied().collect();
+            let modules_in_scc: BTreeSet<ModuleId> = scc.core.modules.iter().copied().collect();
             let mut owner_ids: BTreeSet<String> = BTreeSet::new();
             let mut class_set: BTreeSet<ClassId> = BTreeSet::new();
             for (owner_idx, owner_id_str) in self.owner_ids.iter().enumerate() {
@@ -1161,7 +1161,7 @@ impl QuotientGraph {
         for scc in &verdict.unrealizable_sccs {
             let mut owner_ids: BTreeSet<String> = BTreeSet::new();
             let mut class_set: BTreeSet<ClassId> = BTreeSet::new();
-            for module in &scc.modules {
+            for module in &scc.core.modules {
                 let Some(idxs) = module_to_owners.get(module) else {
                     continue;
                 };
@@ -2394,7 +2394,7 @@ pub fn build_seed_quotient(
             // Walk owners; bucket those whose current partition
             // assignment falls in this SCC's module set.
             let modules_in_scc: BTreeSet<analysis::ModuleId> =
-                scc.modules.iter().copied().collect();
+                scc.core.modules.iter().copied().collect();
             let mut owners: BTreeSet<String> = BTreeSet::new();
             let mut class_set: BTreeSet<ClassId> = BTreeSet::new();
             for (owner_idx, owner_id) in q.owner_ids.iter().enumerate() {

--- a/devinfra/js/debundle/peel/quotient_integration_test.rs
+++ b/devinfra/js/debundle/peel/quotient_integration_test.rs
@@ -1132,8 +1132,9 @@ fn normalize_verdict(verdict: RealizabilityVerdict) -> NormalizedVerdict {
         .unrealizable_sccs
         .into_iter()
         .map(|scc| {
-            let modules: Vec<analysis::ModuleId> = scc.modules.into_iter().collect();
+            let modules: Vec<analysis::ModuleId> = scc.core.modules.into_iter().collect();
             let edges: Vec<usize> = scc
+                .core
                 .constraining_owner_edges
                 .into_iter()
                 .map(|e| e.0)

--- a/devinfra/js/debundle/realizability/incremental_quotient.rs
+++ b/devinfra/js/debundle/realizability/incremental_quotient.rs
@@ -10,6 +10,7 @@ use analysis::OwnerId;
 use analysis::graph::{OwnerEdge, OwnerEdgeId, OwnerGraph};
 use analysis::ids::ModuleId;
 use analysis::partition::Partition;
+use analysis::reports::SccCore;
 
 use crate::rollback_graph::{GraphMark, RollbackDiGraph};
 
@@ -800,8 +801,10 @@ impl IncrementalQuotient {
             let constraining_owner_edges = self.constraining_edges_inside(&modules);
             reported.insert(modules.clone());
             verdict.unrealizable_sccs.push(SccDiagnosis {
-                modules,
-                constraining_owner_edges,
+                core: SccCore {
+                    modules,
+                    constraining_owner_edges,
+                },
                 rejection: SccRejection::MutualConstrainingCycle,
             });
         }
@@ -830,8 +833,10 @@ impl IncrementalQuotient {
                 }
                 let constraining_owner_edges = self.tdz_constraining_edges(&tdz_pairs, None);
                 verdict.unrealizable_sccs.push(SccDiagnosis {
-                    modules,
-                    constraining_owner_edges,
+                    core: SccCore {
+                        modules,
+                        constraining_owner_edges,
+                    },
                     rejection: SccRejection::EsmEvaluationTdz,
                 });
             }
@@ -858,8 +863,10 @@ impl IncrementalQuotient {
             let constraining_owner_edges = self.constraining_edges_inside(&constraining_modules);
             reported.insert(constraining_modules.clone());
             verdict.unrealizable_sccs.push(SccDiagnosis {
-                modules: constraining_modules,
-                constraining_owner_edges,
+                core: SccCore {
+                    modules: constraining_modules,
+                    constraining_owner_edges,
+                },
                 rejection: SccRejection::MutualConstrainingCycle,
             });
         }
@@ -882,8 +889,10 @@ impl IncrementalQuotient {
                 if !tdz_pairs.is_empty() {
                     let constraining_owner_edges = self.tdz_constraining_edges(&tdz_pairs, None);
                     verdict.unrealizable_sccs.push(SccDiagnosis {
-                        modules: i_modules,
-                        constraining_owner_edges,
+                        core: SccCore {
+                            modules: i_modules,
+                            constraining_owner_edges,
+                        },
                         rejection: SccRejection::EsmEvaluationTdz,
                     });
                 }
@@ -927,8 +936,10 @@ impl IncrementalQuotient {
                 self.constraining_edges_inside_with_overlay(&constraining_modules, overlay);
             reported.insert(constraining_modules.clone());
             verdict.unrealizable_sccs.push(SccDiagnosis {
-                modules: constraining_modules,
-                constraining_owner_edges,
+                core: SccCore {
+                    modules: constraining_modules,
+                    constraining_owner_edges,
+                },
                 rejection: SccRejection::MutualConstrainingCycle,
             });
         }
@@ -945,8 +956,10 @@ impl IncrementalQuotient {
                     let constraining_owner_edges =
                         self.tdz_constraining_edges(&tdz_pairs, Some(overlay));
                     verdict.unrealizable_sccs.push(SccDiagnosis {
-                        modules: i_modules,
-                        constraining_owner_edges,
+                        core: SccCore {
+                            modules: i_modules,
+                            constraining_owner_edges,
+                        },
                         rejection: SccRejection::EsmEvaluationTdz,
                     });
                 }

--- a/devinfra/js/debundle/realizability/mod.rs
+++ b/devinfra/js/debundle/realizability/mod.rs
@@ -42,6 +42,7 @@ use analysis::OwnerId;
 use analysis::graph::{OwnerEdgeId, OwnerGraph, chunk_constraining_module_edges};
 use analysis::ids::ModuleId;
 use analysis::partition::Partition;
+use analysis::reports::SccCore;
 
 mod condensation_order;
 #[cfg(test)]
@@ -59,33 +60,25 @@ use incremental_quotient::{IncrementalQuotient, JournalEntry, QuotientOverlay};
 /// [`RealizabilityVerdict`] violates clause 3 (multi-module SCC in
 /// the constraining-edge subgraph of the quotient).
 ///
-/// This is the **primitive** shape: typed `ModuleId`s and typed
-/// `OwnerEdgeId` evidence, no rendering. Downstream projection types
-/// derive their fields from this:
+/// This is the in-memory consumer of the shared [`SccCore`] shape
+/// (typed `ModuleId`s + `OwnerEdgeId` evidence, no rendering) plus one
+/// decoration — `rejection`. The exact edge set in `core` depends on
+/// `rejection`:
 ///
-/// - [`crate::validation::CycleReport`] — validator's rendered
-///   projection: stringified module names + `evidence` and FAS `cut`
-///   decorations.
-/// - [`analysis::reports::schema::QuotientSccReport`] — wire-format
-///   projection: stringified module ids + edge ids. Covers every
-///   SCC of the dep graph (including realizable single-module ones),
-///   not only the offending diagnoses listed here.
+/// - [`SccRejection::MutualConstrainingCycle`]: every constraining
+///   cross-module owner edge whose endpoints both fall inside
+///   `core.modules`.
+/// - [`SccRejection::EsmEvaluationTdz`]: only the owner edges backing
+///   the constraining `(from, to)` pairs whose simulated post-order
+///   check failed — the surgical set whose removal (by co-locating the
+///   binding pair) lifts the violation.
+///
+/// [`SccCore`] documents the rendered/wire projections of the same
+/// shape ([`crate::validation::CycleReport`],
+/// [`analysis::reports::schema::QuotientSccReport`]).
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct SccDiagnosis {
-    /// Modules participating in the cycle.
-    pub modules: BTreeSet<ModuleId>,
-    /// Constraining owner-edge evidence the rejection is composed of,
-    /// in stable `OwnerEdgeId` order. The exact edge set depends on
-    /// `rejection`:
-    ///
-    /// - [`SccRejection::MutualConstrainingCycle`]: every constraining
-    ///   cross-module owner edge whose endpoints both fall inside
-    ///   `modules`.
-    /// - [`SccRejection::EsmEvaluationTdz`]: only the owner edges
-    ///   backing the constraining `(from, to)` pairs whose simulated
-    ///   post-order check failed — the surgical set whose removal
-    ///   (by co-locating the binding pair) lifts the violation.
-    pub constraining_owner_edges: Vec<OwnerEdgeId>,
+    pub core: SccCore,
     /// Which gate pass rejected this SCC.
     pub rejection: SccRejection,
 }
@@ -137,7 +130,7 @@ impl RealizabilityVerdict {
     pub fn modules_in_unrealizable_sccs(&self) -> BTreeSet<ModuleId> {
         let mut out = BTreeSet::new();
         for scc in &self.unrealizable_sccs {
-            for &m in &scc.modules {
+            for &m in &scc.core.modules {
                 out.insert(m);
             }
         }
@@ -221,8 +214,10 @@ pub fn check_realizability(
         owner_edges.sort();
         reported.insert(modules.clone());
         verdict.unrealizable_sccs.push(SccDiagnosis {
-            modules,
-            constraining_owner_edges: owner_edges,
+            core: SccCore {
+                modules,
+                constraining_owner_edges: owner_edges,
+            },
             rejection: SccRejection::MutualConstrainingCycle,
         });
     }
@@ -289,8 +284,10 @@ pub fn check_realizability(
             }
             owner_edges.sort();
             verdict.unrealizable_sccs.push(SccDiagnosis {
-                modules,
-                constraining_owner_edges: owner_edges,
+                core: SccCore {
+                    modules,
+                    constraining_owner_edges: owner_edges,
+                },
                 rejection: SccRejection::EsmEvaluationTdz,
             });
         }
@@ -322,7 +319,7 @@ pub fn check_realizability_touching(
         unrealizable_sccs: full
             .unrealizable_sccs
             .into_iter()
-            .filter(|scc| scc.modules.contains(&module))
+            .filter(|scc| scc.core.modules.contains(&module))
             .collect(),
         cross_rebinds: full
             .cross_rebinds

--- a/devinfra/js/debundle/realizability/tests.rs
+++ b/devinfra/js/debundle/realizability/tests.rs
@@ -80,7 +80,7 @@ fn constraining_cycle_across_two_modules_is_unrealizable() {
         verdict
             .unrealizable_sccs
             .iter()
-            .all(|scc| !scc.constraining_owner_edges.is_empty()),
+            .all(|scc| !scc.core.constraining_owner_edges.is_empty()),
         "every SCC must carry owner-edge evidence"
     );
 }
@@ -832,8 +832,9 @@ fn normalize_verdict(verdict: RealizabilityVerdict) -> NormalizedVerdict {
         .unrealizable_sccs
         .into_iter()
         .map(|scc| {
-            let modules: Vec<ModuleId> = scc.modules.into_iter().collect();
+            let modules: Vec<ModuleId> = scc.core.modules.into_iter().collect();
             let edges: Vec<usize> = scc
+                .core
                 .constraining_owner_edges
                 .into_iter()
                 .map(|edge| edge.0)
@@ -857,7 +858,7 @@ fn filter_verdict_touching(
         unrealizable_sccs: verdict
             .unrealizable_sccs
             .iter()
-            .filter(|scc| scc.modules.contains(&module))
+            .filter(|scc| scc.core.modules.contains(&module))
             .cloned()
             .collect(),
         cross_rebinds: verdict

--- a/devinfra/js/debundle/reports/mod.rs
+++ b/devinfra/js/debundle/reports/mod.rs
@@ -1,8 +1,38 @@
 pub mod schema;
 
-use crate::graph::OwnerId;
+use std::collections::BTreeSet;
+
+use crate::graph::{OwnerEdgeId, OwnerId};
 use crate::ids::{LogicalModuleIndex, ModuleId};
 use crate::reports::schema::ModuleKey;
+
+/// The shared "modules in the SCC + the edges in the SCC" shape — the
+/// one core carried, in different encodings, by every type describing
+/// an unrealizable / cyclic module-quotient SCC:
+///
+/// - `gate::realizability::SccDiagnosis` — the in-memory primitive:
+///   this core plus an `SccRejection` decoration. Carries it verbatim.
+/// - `gate::validation::CycleReport` — the validator's rendered
+///   projection: module names stringified to `ModulePath`, plus FAS
+///   `cut` / `lazy_closure` decorations.
+/// - [`schema::QuotientSccReport`] — the wire projection: wire-stable
+///   string ids in place of typed [`ModuleId`] / [`OwnerEdgeId`],
+///   covering every dep-graph SCC (not only the unrealizable ones).
+///
+/// The rendered/wire projections re-encode these two fields with their
+/// own id spelling and decorations, so they point here rather than
+/// re-describing the shape. [`crate::factor_assembly::AtomicUnitConflict`]
+/// is the atom-level sibling — same "unrealizable, here's why" framing
+/// but a different domain (owners in an atomic unit, not modules in an
+/// SCC), so it does not reuse this core.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct SccCore {
+    /// Modules participating in the cycle.
+    pub modules: BTreeSet<ModuleId>,
+    /// Constraining cross-module owner-edge evidence backing the SCC,
+    /// in stable [`OwnerEdgeId`] order.
+    pub constraining_owner_edges: Vec<OwnerEdgeId>,
+}
 
 pub fn owner_key(id: OwnerId) -> String {
     format!("owner:{}", id.0)

--- a/devinfra/js/debundle/reports/schema.rs
+++ b/devinfra/js/debundle/reports/schema.rs
@@ -188,13 +188,13 @@ pub struct QuotientEdgeReport {
     pub constrains_init_order: bool,
 }
 
-/// Wire-format projection of one quotient SCC. The in-memory
-/// primitive for **unrealizable** SCCs is
-/// `SccDiagnosis` (gate crate); this shape covers **every**
-/// SCC the dep graph turns up (single-module non-self-loops are
-/// filtered out at the builder), with `realizable` distinguishing the
-/// offending ones, and uses wire-stable string ids (`module_key`,
-/// `quotient_edge:N`) instead of typed `ModuleId` / `OwnerEdgeId`.
+/// Wire-format projection of the shared [`super::SccCore`] shape
+/// ("modules in the SCC + edges in the SCC"). Deviation from that
+/// in-memory core: this shape covers **every** SCC the dep graph turns
+/// up (single-module non-self-loops are filtered out at the builder),
+/// with `realizable` distinguishing the offending ones, and uses
+/// wire-stable string ids (`module_key`, `quotient_edge:N`) instead of
+/// typed `ModuleId` / `OwnerEdgeId`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QuotientSccReport {
     pub id: String,

--- a/devinfra/js/debundle/validation.rs
+++ b/devinfra/js/debundle/validation.rs
@@ -39,11 +39,12 @@ pub struct FactorizationReport {
     pub cross_rebinds: Vec<String>,
 }
 
-/// Validator's rendered projection of one unrealizable SCC. The
-/// in-memory primitive is [`crate::realizability::SccDiagnosis`]
-/// (typed `ModuleId`s + `OwnerEdgeId` evidence); this shape
-/// stringifies the module names and decorates the diagnosis with the
-/// `cut` / `lazy_closure` rows the bail-message renderer consumes.
+/// Validator's rendered projection of one unrealizable SCC. The shared
+/// "modules in the SCC + edges in the SCC" core is
+/// [`analysis::reports::SccCore`]; the in-memory primitive that carries
+/// it is [`crate::realizability::SccDiagnosis`]. This shape stringifies
+/// the module names and decorates the diagnosis with the `cut` /
+/// `lazy_closure` rows the bail-message renderer consumes.
 #[derive(Debug, Clone, Serialize)]
 pub struct CycleReport {
     pub modules: Vec<ModulePath>,
@@ -373,7 +374,7 @@ pub fn validate_factorization(
                     compute_realizability_cut(
                         owner_graph,
                         partition,
-                        &diagnosis.constraining_owner_edges,
+                        &diagnosis.core.constraining_owner_edges,
                         module_path,
                         &from_binding_by_ordinal,
                     ),
@@ -386,21 +387,27 @@ pub fn validate_factorization(
                     cycle_edges_for(
                         owner_graph,
                         partition,
-                        diagnosis.constraining_owner_edges.iter().copied(),
+                        diagnosis.core.constraining_owner_edges.iter().copied(),
                         module_path,
                         &from_binding_by_ordinal,
                     ),
                     lazy_closure_edges(
                         owner_graph,
                         partition,
-                        &diagnosis.modules,
+                        &diagnosis.core.modules,
                         module_path,
                         &from_binding_by_ordinal,
                     ),
                 ),
             };
             CycleReport {
-                modules: diagnosis.modules.iter().copied().map(module_path).collect(),
+                modules: diagnosis
+                    .core
+                    .modules
+                    .iter()
+                    .copied()
+                    .map(module_path)
+                    .collect(),
                 cut,
                 lazy_closure,
             }


### PR DESCRIPTION
## What

Consolidates the four parallel "spec is unrealizable, here's the SCC and why" structs (ARCHITECTURE_BACKLOG "Name overloading") toward **one core type with optional decorations** instead of four structs re-describing the same shape four different ways.

- New core type **`analysis::reports::SccCore`** carries the shared in-memory shape: `modules: BTreeSet<ModuleId>` + `constraining_owner_edges: Vec<OwnerEdgeId>` ("the modules in the SCC + the edges in the SCC").
- **`SccDiagnosis`** (gate, `realizability/mod.rs`) now embeds `SccCore` (`core: SccCore` + its one decoration `rejection: SccRejection`), instead of carrying `modules`/`constraining_owner_edges` inline.
- **`CycleReport`** (`validation.rs`), **`QuotientSccReport`** (`reports/schema.rs`), and **`AtomicUnitConflict`** (`factor_assembly.rs`) keep their distinct wire/render encodings but point their docs at `SccCore` as the canonical shape rather than re-describing it. `AtomicUnitConflict` stays a separate type (atom-level / owners-in-a-unit domain, not modules-in-an-SCC) with a doc pointer naming it the atom-level sibling.

## Behavior-preserving / no wire-JSON change

`SccCore` and `SccDiagnosis` are **in-memory only** — neither derives `Serialize` (verified `SccDiagnosis` still has none). The only changes to the three serialized projection types are **doc comments**; no field or `serde` attribute changed, so `owner_graph.json` / `cycles.json` / `atomic_unit_conflicts.json` and the frozen `props/specimens` snapshot stay byte-identical. The full `//devinfra/js/debundle/...` suite (including report-fixture / wire-format / specimen tests) is green.

## Secondary (assessment only, no code change)

Recorded the `ChunkFactorization` Encapsulation verdict in ARCHITECTURE_BACKLOG: the proposed two-layer IR/adapter shape already matches reality (`ChunkAnalysis` = partition-free IR, `ChunkFactorization` = IR + applied partition, `FactorizationReport` = derive-to-report adapter); collapsing the `Arc<ChunkAnalysis>` boundary is large/risky for no behavior gain, so it is deliberately left alone. The resolved "Name overloading" SCC-cluster item is removed from the backlog.

## Test

`bazelisk test //devinfra/js/debundle/...` — 117 tests pass.
BuildBuddy invocation: https://app.buildbuddy.io/invocation/49917d1d-ca44-4aa2-b5e9-32637acb83b3

https://claude.ai/code/session_011YQabfZ5jVoFSETefd27Bg

---
_Generated by [Claude Code](https://claude.ai/code/session_011YQabfZ5jVoFSETefd27Bg)_