### PR TITLE
debundle: multi-feature interior cover for no-sparse-anchor bodies (#2289)

### DIFF
--- a/devinfra/js/debundle/plans/readoff_minimization.md
+++ b/devinfra/js/debundle/plans/readoff_minimization.md
@@ -98,7 +98,10 @@ keep-shallow path.
 **Layer 1 — shape index.** `shape_index.rs` builds the hash-consed Merkle DAG with
 alpha-leaf canonicalization, multi-granularity shape features, inverted posting
 lists, and `selective × stable` scoring; `minimal_anchor_set(item) -> AnchorSet`
-is the read-off API. Built on `selector_candidate_index.rs` (the prefilter
+is the read-off API, with `unique_value_anchor_candidates` (single discriminating
+value anchors, best-first) and `unique_value_anchor_cover` (a greedy multi-anchor
+cover over value-bearing features only) backing the renderer's robustness-anchor
+fallbacks. Built on `selector_candidate_index.rs` (the prefilter
 `SelectorCandidateIndex`), which it supersets, not forks. Soundness is gated by
 `shape_index_soundness_test.rs` (matcher-backed: the indexed candidate set is
 always a sound match superset) and a synthetic size-sweep + OPT-distribution
@@ -273,12 +276,22 @@ the landed architecture is in "Current state" above.
    holed selector proves (recovering `applyChange(ANYTHING) { STMT_LIST; ANYTHING.set("running"); }`
    instead of `class X { CLASS_REST }` when the _minimal_ anchor renders to a
    verbatim-kept statement that fails to prove). Closed fixtures:
-   `single_target_class_whole_body`, `component_wide_destructure_whole_body`. Still
-   open: the **multi-feature interior cover** for bodies where no _single_ value
-   anchor singles the target out among same-shape SIBLINGS (the candidate walk only
-   tries single-anchor sets); the real-spec deep multi-anchor cases bucketed "no
-   sparse selector" need a greedy subtree-granularity cover over the in-body anchor
-   set, not just the best-first single-anchor walk. Reclaims a further share of the
+   `single_target_class_whole_body`, `component_wide_destructure_whole_body`. The
+   **multi-feature interior cover** has now landed too:
+   `ShapeIndex::unique_value_anchor_cover` runs the same greedy set-cover as
+   `minimal_anchor_set` but restricted to _value-bearing_ features, so when no
+   _single_ value anchor singles the target out among same-shape SIBLINGS — each
+   value anchor individually shared with a different sibling — a greedy combination
+   of value anchors (each rendering a kept leaf) jointly resolves it. The renderer
+   walks it after the single-anchor candidates and before the degenerate scaffold,
+   so a body whose discriminator is a _set_ of deep leaves drills to those leaves
+   instead of dumping `class X { CLASS_REST }` / `const X = ANYTHING`. Unlike
+   `minimal_anchor_set` (which takes the globally most-excluding feature, possibly a
+   structural skeleton that renders nothing or a value whose only home is a verbatim
+   statement), every step of the value cover drills to a renderable token. Still
+   open: the genuine residual where even value combos cannot separate same-shape
+   siblings (alpha-only constructs, near-duplicate emitted helpers) — those need
+   enclosing-context anchoring or stay name-pinned. Reclaims a further share of the
    ~2,024 "no sparse selector" tail.
 2. **Wide destructure (`wide_destructure_block`).** A `const { …, x } = props`
    whose discriminator is a destructured property key (`x`) bails with "no sparse

--- a/devinfra/js/debundle/selector_codemod.rs
+++ b/devinfra/js/debundle/selector_codemod.rs
@@ -2220,6 +2220,23 @@ fn render_via_read_off(
         }
     }
 
+    // Multi-feature interior cover (#2289): no single value anchor singled the
+    // target out (every value anchor still shares same-shape siblings), but a
+    // *combination* of value anchors may — each individually shared with a
+    // different sibling. Greedy-cover over value-bearing features only, so each
+    // chosen anchor still renders a kept span, and emit the holed selector if it
+    // proves uniquely. This drills bodies whose discriminator is a *set* of deep
+    // leaves rather than one.
+    if let Some(anchor_set) = index.shape_index.unique_value_anchor_cover(decl.body_idx) {
+        let kept = kept_spans_for_anchor_set(item, &anchor_set);
+        if !kept.is_empty()
+            && let Some(selector) =
+                finish_minimized_selector(index, decl, target, render_with(&kept)?)?
+        {
+            return Ok(Some(selector));
+        }
+    }
+
     // Last resort: the bare structural scaffold, used only when it resolves
     // uniquely (a purely structural discriminator — arity/shape — with no value
     // anchor to keep). The scaffold is degenerate for `var`, so the var path skips
@@ -2704,6 +2721,9 @@ fn try_var_read_off(
     // holer keeps verbatim, leaving raw subtrees the matcher rejects) is recovered
     // here instead of collapsing to the degenerate `const X = ANYTHING` scaffold;
     // this drills a whole-body component initializer down to one anchored leaf.
+    // Finally the multi-feature interior cover (#2289): when no single value anchor
+    // is unique, a greedy cover over value-bearing features keeps the *set* of deep
+    // leaves that jointly single the slot out.
     let anchor_sets = index
         .shape_index
         .minimal_anchor_set(decl.body_idx)
@@ -2712,7 +2732,8 @@ fn try_var_read_off(
             index
                 .shape_index
                 .unique_value_anchor_candidates(decl.body_idx),
-        );
+        )
+        .chain(index.shape_index.unique_value_anchor_cover(decl.body_idx));
     for anchor_set in anchor_sets {
         let kept: BTreeSet<AnchorSpan> = kept_spans_for_anchor_set(item, &anchor_set)
             .into_iter()

--- a/devinfra/js/debundle/shape_index.rs
+++ b/devinfra/js/debundle/shape_index.rs
@@ -821,6 +821,74 @@ impl ShapeIndex {
             })
             .collect()
     }
+
+    /// A greedy **multi**-anchor cover restricted to *value-bearing* features —
+    /// the multi-feature analogue of [`unique_value_anchor_candidates`]. When no
+    /// single value anchor is individually unique (every value anchor's posting
+    /// list still holds same-shape siblings), the target may still be singled out
+    /// by a *combination* of value anchors, each individually shared with a
+    /// different sibling. This runs the same greedy set-cover as
+    /// [`minimal_anchor_set`], but over value-bearing features only, so every
+    /// chosen anchor renders a concrete kept token and the result is a genuinely
+    /// sparse multi-leaf pin rather than the degenerate scaffold.
+    ///
+    /// It differs from [`minimal_anchor_set`] in exactly the way the renderer
+    /// needs: that method takes the globally most-excluding feature at each step
+    /// *regardless of whether it renders a kept span*, so its cover can include a
+    /// structural skeleton (kept nothing) or land on a value whose only home is a
+    /// statement the holer keeps verbatim, leaving raw subtrees the matcher
+    /// rejects. Restricting the cover to value anchors guarantees every step
+    /// drills to a renderable leaf, so the holed selector keeps only the
+    /// discriminating tokens.
+    ///
+    /// Returns `None` when value anchors alone cannot reach the singleton
+    /// `{body_idx}`, and (deliberately) for the single-anchor case — a lone unique
+    /// value anchor is [`unique_value_anchor_candidates`]'s domain, which the
+    /// renderer walks first; this method only contributes the genuinely
+    /// multi-anchor covers that walk cannot produce.
+    pub fn unique_value_anchor_cover(&self, body_idx: usize) -> Option<AnchorSet> {
+        if body_idx >= self.items.len() {
+            return None;
+        }
+        let mut remaining: Vec<ScoredFeature> = self
+            .scored_features(body_idx)
+            .into_iter()
+            .filter(|scored| anchor_renders_a_value(&scored.feature))
+            .collect();
+        let seed = remaining.first()?;
+        let mut covered = self.posting(&seed.feature).clone();
+        let mut chosen: Vec<ScoredFeature> = vec![remaining.remove(0)];
+        let mut scratch = CandidateSet::empty();
+
+        while covered.len() > 1 {
+            // The value feature that shrinks the candidate set the most; ranked by
+            // intersection size only, ties broken toward the better-ranked feature.
+            let (best_i, best_len) = remaining
+                .iter()
+                .enumerate()
+                .map(|(i, f)| (i, covered.intersection_len(self.posting(&f.feature))))
+                .min_by(|(ai, a), (bi, b)| a.cmp(b).then(ai.cmp(bi)))?;
+            // No remaining value anchor makes progress: value anchors alone cannot
+            // single the target out. Leave the residual to structural paths.
+            if best_len == covered.len() {
+                return None;
+            }
+            covered.intersect_into(self.posting(&remaining[best_i].feature), &mut scratch);
+            std::mem::swap(&mut covered, &mut scratch);
+            chosen.push(remaining.remove(best_i));
+        }
+
+        // A single-anchor cover means the seed value anchor was already unique —
+        // that is the single-anchor candidates' job, walked first by the renderer.
+        // Yield only the genuinely multi-anchor covers.
+        (chosen.len() >= 2 && covered.len() == 1 && covered.contains(body_idx)).then_some(
+            AnchorSet {
+                body_idx,
+                opt_one: false,
+                anchors: chosen,
+            },
+        )
+    }
 }
 
 /// Whether a feature maps to a concrete kept token the renderer can pin (a
@@ -1115,5 +1183,51 @@ export { runner };"#,
         let running = ShapeFeature::Selector(SelectorFeature::StringLiteral("running".into()));
         let member = ShapeFeature::Selector(SelectorFeature::ClassMember("applyChange".into()));
         assert!(position(&running) < position(&member));
+    }
+
+    #[test]
+    fn unique_value_anchor_cover_combines_value_anchors_when_no_single_one_is_unique() {
+        // Three same-shape const-bound calls. No single string literal singles the
+        // target (item 0) out: `"alpha"` is shared with item 1, `"beta"` with
+        // item 2. Only the *combination* {alpha, beta} resolves to item 0 — and
+        // both anchors are value-bearing, so the cover is renderable end to end.
+        let module = parse(
+            r#"const a = emit("alpha", "beta");
+const b = emit("alpha", "gamma");
+const c = emit("delta", "beta");"#,
+        );
+        let index = ShapeIndex::new(&module);
+
+        // Precondition: no single value anchor is individually unique, so the
+        // single-anchor candidates walk yields nothing.
+        assert!(index.unique_value_anchor_candidates(0).is_empty());
+
+        let cover = index
+            .unique_value_anchor_cover(0)
+            .expect("a multi-value-anchor cover resolves item 0");
+        assert!(cover.anchors.len() >= 2, "{cover:?}");
+        assert!(!cover.opt_one);
+        for scored in &cover.anchors {
+            assert!(anchor_renders_a_value(&scored.feature), "{scored:?}");
+        }
+        assert!(index.read_off_resolves_uniquely(0, &cover));
+    }
+
+    #[test]
+    fn unique_value_anchor_cover_declines_the_single_anchor_case() {
+        // The lone class has a unique value anchor (`"running"`); a single-anchor
+        // cover is the candidates walk's domain, so this method declines it rather
+        // than duplicate that path.
+        let module = parse(
+            r#"class runner {
+  applyChange(c) {
+    this.boxed.set("running");
+  }
+}
+export { runner };"#,
+        );
+        let index = ShapeIndex::new(&module);
+        assert!(!index.unique_value_anchor_candidates(0).is_empty());
+        assert!(index.unique_value_anchor_cover(0).is_none());
     }
 }


### PR DESCRIPTION
When no single value anchor singles a target out among same-shape siblings
(each value anchor individually shared with a different sibling), the read-off
robustness fallback previously had nothing to offer and collapsed to the
degenerate scaffold (`class X { CLASS_REST }` / `const X = ANYTHING`).

Add `ShapeIndex::unique_value_anchor_cover`: the same greedy set-cover as
`minimal_anchor_set` but restricted to value-bearing features, so every chosen
anchor renders a concrete kept token and a *combination* of deep leaves jointly
resolves the target. The renderer (`render_via_read_off`, `try_var_read_off`)
walks it after the single-anchor candidates and before the scaffold, drilling
bodies whose discriminator is a *set* of leaves rather than one.

BAZEL_TEST_INVOCATIONS=buildbuddy:396ac1b9-39b5-4c5d-8327-7ce6555d4531,buildbuddy:f30bf627-31c8-4265-9629-c3bf23cbaa3c