### PR TITLE
Enable verbose output for pre-commit checks

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -67,7 +67,7 @@ jobs:
           # Unset NODE_OPTIONS to avoid global-agent requirement in pre-commit's
           # isolated node environments (markdownlint-cli2 hook uses npm)
           unset NODE_OPTIONS
-          pre-commit run --all-files --show-diff-on-failure
+          pre-commit run --all-files --show-diff-on-failure -v
 
       # ============================================================================
       # CACHE SAVES


### PR DESCRIPTION
## Summary
Add verbose flag to the pre-commit run command in the CI workflow to provide more detailed output during pre-commit hook execution.

## Changes
- Added `-v` (verbose) flag to `pre-commit run` command in the pre-commit workflow

## Details
This change enables verbose output when running pre-commit hooks in CI, which will help with debugging and understanding what each hook is doing during the validation process. The verbose flag provides more detailed information about hook execution without changing the actual validation logic.

https://claude.ai/code/session_012t8FrkP91xENEovBGKXyxb