### PR TITLE
debundle: hole bare-function callees and variadic args in read-off selectors

### DIFF
--- a/devinfra/js/debundle/e2e/selector_codemod_cli_test.rs
+++ b/devinfra/js/debundle/e2e/selector_codemod_cli_test.rs
@@ -1104,12 +1104,14 @@ fn synthesize_selectors_apply_groups_multideclarator_and_preserves_comments() {
         match_source.contains("DECLARATORS_BEFORE"),
         "{match_source}"
     );
+    // The bare `buildConfig` callee holes to ANYTHING (a minified name the matcher
+    // alpha-wildcards); each slot is still kept as its own named declarator.
     assert!(
-        match_source.contains("PrimaryConfig = buildConfig"),
+        match_source.contains("PrimaryConfig = ANYTHING("),
         "{match_source}"
     );
     assert!(
-        match_source.contains("SecondaryConfig = buildConfig"),
+        match_source.contains("SecondaryConfig = ANYTHING("),
         "{match_source}"
     );
     assert_eq!(group["exports"]["PrimaryConfig"], "PrimaryConfig");

--- a/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
+++ b/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
@@ -468,18 +468,16 @@ minimizer_expectation_case!(
     expected = "expected_match.js",
 );
 
-// Aspirational: a binding initialized by a deeply nested call tree should
-// minimize to ANYTHING-holed outer callees and ARGS holes for their sibling
-// arguments, drilling only to the one deep object literal that carries the
-// discriminating key. The var read-off path now drills correctly to the leaf
-// (`buildInner({ mode: "…", OBJECT_PROPS })`), closing the old "keeps the whole
-// tree" gap. Two gaps remain vs the aspirational shape: the bare-function callees
-// (`wrapOuter`/`decorate`/`buildInner`) stay pinned rather than holing to ANYTHING
-// (the `hole_callee` policy keeps a bare function reference as a stable pin), and a
-// dropped sibling arg holes to a single arity-exact `ANYTHING` rather than a
-// variadic `ARGS` run-hole. Both are cross-cutting hole-policy changes.
+// A binding initialized by a deeply nested call tree minimizes to ANYTHING-holed
+// outer callees and an `ARGS` run-hole for their non-anchor sibling arguments,
+// drilling only to the one deep object literal that carries the discriminating
+// key. The var read-off drills into the nested call tree (`hole_expr` →
+// `hole_callee` / `hole_args`), holes every bare-function callee
+// (`wrapOuter`/`decorate`/`buildInner`) to `ANYTHING` — a minified name the matcher
+// alpha-wildcards anyway, never a chosen anchor — and collapses the dropped
+// `{ theme: … }` sibling argument into a variadic `ARGS` run-hole, so a rebuild
+// that adds or drops a sibling argument still resolves.
 minimizer_expectation_case!(
-    #[ignore = "var read-off drills to the leaf but keeps bare-function callees (hole_callee policy) and holes dropped args to arity-exact ANYTHING, not ARGS"]
     minimizes_deeply_nested_call_args,
     fixture = "deeply_nested_call_args",
     name = "deeply nested call tree keeps only the discriminating leaf literal",
@@ -627,11 +625,11 @@ minimizer_expectation_case!(
 // the discriminating returned-element literal, rather than the degenerate
 // `const SelectedComponent = ANYTHING`. The var read-off iterates the target's
 // individually-discriminating value anchors best-first (issue #2289 item 1) and
-// keeps `jsx("div", ANYTHING)` — anchoring on the unique `"div"` tag literal — with
+// keeps `ANYTHING("div", ARGS)` — anchoring on the unique `"div"` tag literal — with
 // the prop destructure and hooks absorbed into `STMT_LIST`. The bare callees
-// `wrap`/`jsx` stay pinned (the documented `hole_callee` policy keeps a bare
-// function reference as a stable pin); holing them to `ANYTHING` is the
-// cross-cutting `hole_callee` change tracked by `deeply_nested_call_args`. The real
+// `wrap`/`jsx` hole to `ANYTHING` (the `hole_callee` policy holes a minified
+// bare-function reference the matcher alpha-wildcards anyway), and the dropped
+// props object after the `"div"` tag collapses into an `ARGS` run-hole. The real
 // whole-body over-pin (cf. `features/nodes/cardView.yaml` `NodeAsCard`, ~1340 lines
 // kept whole with only the outer declarator/wrapper holed) needs sibling-bearing
 // fixtures to reproduce; this reduction pins the single-target degenerate-scaffold
@@ -668,14 +666,16 @@ minimizer_expectation_case!(
 // (`SelectedPrimary`/`SelectedSecondary`) now reads off per-slot minimal anchors
 // (binding-group read-off, plan item 3). Each slot pins only what singles its own
 // declarator out within the statement: slot 0's `enabled: true` (vs
-// `unrelatedPrimary`'s `enabled: false`) is enough, so its `makeEntry` argument
-// holes to `ANYTHING`; slot 1 still needs `"secondary"` because `{ enabled: true }`
+// `unrelatedPrimary`'s `enabled: false`) is enough, so its leading `makeEntry`
+// argument drops into an `ARGS` run-hole (and the minified `makeEntry` callee holes
+// to `ANYTHING`); slot 1 still needs `"secondary"` because `{ enabled: true }`
 // alone would also fit slot 0. The per-slot kept spans union and the binding-group
 // matcher proves the tuple — sparser than the keep-shallow path's "keep every
 // slot's shallow literals" (which pinned both `"primary"` and `"secondary"`). The
 // single-target `SelectedStandalone` reads its minimal anchor off the shape index:
 // `kind: "panel"` alone discriminates it from `sameRouteDifferentKind`, so the
-// shared non-discriminating call arg `"settings"` holes to `ANYTHING` and the
+// shared non-discriminating leading call arg `"settings"` drops into an `ARGS`
+// run-hole (the minified `registerRoute` callee holes to `ANYTHING`) and the
 // redundant `title: "Settings"` collapses into `OBJECT_PROPS`.
 #[test]
 fn minimizes_binding_group_partition() {

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/binding_group_partition/expected_group_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/binding_group_partition/expected_group_match.js
@@ -1,3 +1,3 @@
-const SelectedPrimary = makeEntry(ANYTHING, { OBJECT_PROPS, enabled: true }),
-  SelectedSecondary = makeEntry("secondary", { OBJECT_PROPS, enabled: true }),
+const SelectedPrimary = ANYTHING(ARGS, { OBJECT_PROPS, enabled: true }),
+  SelectedSecondary = ANYTHING("secondary", { OBJECT_PROPS, enabled: true }),
   DECLARATORS_AFTER = null;

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/binding_group_partition/expected_standalone_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/binding_group_partition/expected_standalone_match.js
@@ -1,4 +1,4 @@
-const SelectedStandalone = registerRoute(ANYTHING, {
+const SelectedStandalone = ANYTHING(ARGS, {
   kind: "panel",
   OBJECT_PROPS,
 });

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/call_argument_literal/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/call_argument_literal/expected_match.js
@@ -1,5 +1,5 @@
 function SelectedCall(ANYTHING, ANYTHING) {
   STMT_LIST;
-  const result = ANYTHING.bar(ANYTHING, 123);
+  const result = ANYTHING.bar(ARGS, 123);
   STMT_LIST;
 }

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/class_body/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/class_body/expected_match.js
@@ -2,7 +2,7 @@ class SelectedWidget {
   CLASS_REST;
   render(ANYTHING) {
     STMT_LIST;
-    return ANYTHING.format("stable", ANYTHING);
+    return ANYTHING.format("stable", ARGS);
   }
   CLASS_REST;
 }

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/component_wide_destructure_whole_body/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/component_wide_destructure_whole_body/expected_match.js
@@ -1,4 +1,4 @@
-const SelectedComponent = wrap(function (ANYTHING) {
+const SelectedComponent = ANYTHING(function (ANYTHING) {
   STMT_LIST;
-  return jsx("div", ANYTHING);
+  return ANYTHING("div", ARGS);
 });

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/function_valued_init_holing/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/function_valued_init_holing/expected_match.js
@@ -1,5 +1,5 @@
-const SelectedHandler = registerHandler(function (ANYTHING) {
+const SelectedHandler = ANYTHING(function (ANYTHING) {
   STMT_LIST;
-  dispatch("uniqueDiscriminatorAction");
+  ANYTHING("uniqueDiscriminatorAction");
   STMT_LIST;
 });

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/nested_async_try/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/nested_async_try/expected_match.js
@@ -1,7 +1,7 @@
 async function SelectedLoader(ANYTHING, ANYTHING) {
   try {
     STMT_LIST;
-    await ANYTHING.fetch(ANYTHING, { OBJECT_PROPS, trace: ANYTHING });
+    await ANYTHING.fetch(ARGS, { OBJECT_PROPS, trace: ANYTHING });
     STMT_LIST;
   } catch (ANYTHING) {
     STMT_LIST;

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/object_property_literals/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/object_property_literals/expected_match.js
@@ -1,4 +1,4 @@
-const SelectedConfig = buildWidget({
+const SelectedConfig = ANYTHING({
   OBJECT_PROPS,
   onClick: ANYTHING,
 });

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/robustness_value_over_scaffold/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/robustness_value_over_scaffold/expected_match.js
@@ -1,4 +1,4 @@
 function SelectedOnly(ANYTHING, ANYTHING) {
   STMT_LIST;
-  return register("uniqueRobustnessToken");
+  return ANYTHING("uniqueRobustnessToken");
 }

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/sparse_function_body/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/sparse_function_body/expected_match.js
@@ -1,4 +1,4 @@
 function SelectedWorker(ANYTHING, ANYTHING, ANYTHING) {
-  const transient = makeTransient(ANYTHING, ANYTHING.now());
+  const transient = ANYTHING(ARGS, ANYTHING.now());
   STMT_LIST;
 }

--- a/devinfra/js/debundle/plans/readoff_minimization.md
+++ b/devinfra/js/debundle/plans/readoff_minimization.md
@@ -149,7 +149,11 @@ Migrated to read-off as their primary path:
 - **Single-target var (non-object)** (`try_var_read_off`): holes the initializer
   with `hole_expr` around the read-off anchors, restricting kept spans to the
   target declarator; drills into nested call/object/array trees down to the
-  discriminating leaf. No empty-kept fast path — a var's holed scaffold
+  discriminating leaf. In a call tree (`hole_callee` / `hole_args`) a bare-function
+  callee holes to `ANYTHING` (a minified name the matcher alpha-wildcards anyway,
+  never a chosen anchor) while a member-method name stays, and a run of non-anchor
+  arguments collapses to an `ARGS` run-hole so a rebuild that adds or drops a
+  sibling argument still resolves. No empty-kept fast path — a var's holed scaffold
   (`const X = ANYTHING`) is degenerate, so an empty anchor set defers to the
   keep-shallow group path. The `STR_LITERAL_MATCHING_RE` upgrade is shared with
   the group path via `accepted_regex_anchors`.
@@ -175,7 +179,7 @@ binding-group matcher proves the tuple. The **keep-shallow path**
 `AnchorCandidates::{shallow_literals,deep_cover_tiers}`) remains only as the
 **fallback** for groups whose per-slot single-binding view cannot single a slot
 out (a value shared across sibling statements that resolves only as a tuple);
-retiring it is gated as backlog item 6.
+retiring it is gated as backlog item 3.
 
 **Measured perf.** Whole ~7 MB / ~4.5k-member chunk minimizes in **~13 s** with
 the prove-gate-via-index fast-path (#2280), down from ~110 s — **meets the ≤30 s
@@ -198,9 +202,10 @@ landed, #2289), `sequential_assignment_block` (`hole_expr` `Expr::Assign` arm),
 `single_target_class_whole_body`, `component_wide_destructure_whole_body`
 (unignored once the robustness-anchor candidate-walk landed, #2289 item 1),
 `object_nested_value_dict`, and (unignored once the object key-set cover landed)
-`grouped_enum_objects`, `object_key_set_group`, `object_key_set_subset`. Ignored
-as aspirational (the named form not yet read-off-expressible):
-`deeply_nested_call_args`, `wide_destructure_block`.
+`grouped_enum_objects`, `object_key_set_group`, `object_key_set_subset`, and
+(unignored once `hole_callee`/`hole_args` holed bare-function callees and
+non-anchor argument runs) `deeply_nested_call_args`. Ignored as aspirational (the
+named form not yet read-off-expressible): `wide_destructure_block`.
 
 ## Acceptance criteria
 
@@ -322,13 +327,7 @@ the landed architecture is in "Current state" above.
    `DECLARATORS` / `CLASS_REST` / `EXPR` / `STMT` as `ANYTHING`. Deferred until
    emission stabilizes (after the cover/keep-shallow paths fully retire), since it
    rewrites emitted selectors and touches many fixtures.
-6. **`deeply_nested_call_args` — callee/arg holing.** The var read-off drills to
-   the leaf but keeps bare-function callees pinned (`hole_callee` keeps a bare
-   function reference) and holes dropped args to arity-exact `ANYTHING` rather than
-   a variadic `ARGS` run-hole. Closing both is a cross-cutting `hole_callee` /
-   `hole_args` policy change affecting all read-off paths; weigh against existing
-   fixtures.
-7. **Dogfood-apply on gaffer-private (ongoing).** Run `synthesize-selectors
+6. **Dogfood-apply on gaffer-private (ongoing).** Run `synthesize-selectors
 --apply` on the real spec after each wave, review for over-pin, and PR the
    beneficial minimized selectors. Operational PR rule: **revert any converted
    selector whose `match` block is >40 lines AND has ≤2 holes** back to a name pin.

--- a/devinfra/js/debundle/selector_codemod.rs
+++ b/devinfra/js/debundle/selector_codemod.rs
@@ -1565,6 +1565,15 @@ fn object_props_prop() -> PropOrSpread {
     ))))
 }
 
+/// An `ARGS` argument-list hole that absorbs a run of dropped (non-anchor)
+/// call/`new` arguments (the argument analog of `OBJECT_PROPS`).
+fn args_hole() -> ExprOrSpread {
+    ExprOrSpread {
+        spread: None,
+        expr: Box::new(Expr::Ident(ident_node(ARGS_HOLE_KEYWORD))),
+    }
+}
+
 /// A `case CASE_REST:` switch-case hole that absorbs a run of dropped
 /// `case`/`default` clauses (the switch analog of `CLASS_REST;`).
 fn case_rest_case() -> SwitchCase {
@@ -1705,9 +1714,12 @@ fn hole_assign_target(target: &AssignTarget, kept: &BTreeSet<AnchorSpan>) -> Ass
     }
 }
 
-/// Hole a call's callee while keeping the invoked identity — a method name or a
-/// bare function reference is a meaningful, stable pin; only a member receiver
-/// is holed.
+/// Hole a call's callee, keeping only an alpha-stable invoked identity. A
+/// member-method name (`.then`, `.bar`) is a stable pin and stays; a
+/// bare-function reference (`make`, `wrapOuter`) is a minified name that churns
+/// every rebuild — the matcher alpha-wildcards it, so it discriminates nothing
+/// and the shape index never proposes it as an anchor — so it holes to
+/// `ANYTHING`.
 fn hole_callee(callee: &Callee, kept: &BTreeSet<AnchorSpan>) -> Callee {
     match callee {
         Callee::Expr(expr) => Callee::Expr(Box::new(hole_callee_expr(expr, kept))),
@@ -1717,34 +1729,62 @@ fn hole_callee(callee: &Callee, kept: &BTreeSet<AnchorSpan>) -> Callee {
 
 fn hole_callee_expr(expr: &Expr, kept: &BTreeSet<AnchorSpan>) -> Expr {
     match expr {
+        // Member-method callee (`a.then(...)`): keep the stable property name even
+        // when no anchor lands on it, holing only the receiver. Routing through
+        // `hole_expr` would instead collapse the whole member to `ANYTHING` when its
+        // subtree carries no kept anchor, dropping the discriminating method name.
         Expr::Member(member) => {
             let mut holed = member.clone();
             holed.obj = Box::new(hole_expr(&member.obj, kept));
             Expr::Member(holed)
         }
-        Expr::Ident(_) => expr.clone(),
         Expr::Paren(paren) => hole_callee_expr(&paren.expr, kept),
+        // Bare-identifier callee (and any other callee expression): hole through the
+        // normal path. A bare-function name is alpha-wildcarded by the matcher and is
+        // never a chosen anchor, so `hole_expr` holes it to `ANYTHING`.
         _ => hole_expr(expr, kept),
     }
 }
 
+/// Hole a call/`new` argument list for selector form: a run of dropped
+/// (no-anchor) arguments collapses to a single `ARGS` run hole, while each
+/// argument carrying an anchor is kept and recursively holed.
+///
+/// The `ARGS` hole matches as an ordered subsequence with gaps
+/// (`match_expr_or_spread_slice`), so the selector survives a rebuild that adds
+/// or removes a non-anchor argument — unlike a per-argument `ANYTHING`, which is
+/// an arity-exact single-node hole. Mirrors [`hole_object`]'s `OBJECT_PROPS`
+/// run-collapsing. An anchored spread is kept verbatim (its expr left intact);
+/// a non-anchor spread is absorbed into the run like any other dropped argument.
 fn hole_args(args: &[ExprOrSpread], kept: &BTreeSet<AnchorSpan>) -> Vec<ExprOrSpread> {
-    args.iter()
-        .map(|arg| {
-            let mut holed = arg.clone();
-            if arg.spread.is_none() {
-                holed.expr = Box::new(hole_expr(&arg.expr, kept));
+    let mut holed = Vec::new();
+    let mut dropped_run = false;
+    for arg in args {
+        if node_retains_any(arg.expr.span(), kept) {
+            if dropped_run {
+                holed.push(args_hole());
+                dropped_run = false;
             }
-            holed
-        })
-        .collect()
+            let mut kept_arg = arg.clone();
+            if arg.spread.is_none() {
+                kept_arg.expr = Box::new(hole_expr(&arg.expr, kept));
+            }
+            holed.push(kept_arg);
+        } else {
+            dropped_run = true;
+        }
+    }
+    if dropped_run {
+        holed.push(args_hole());
+    }
+    holed
 }
 
 /// Prune the elements of an array literal, holing each non-anchor element to
 /// `ANYTHING` (an arity-exact `EXPR` hole) and recursing into the ones that
-/// carry an anchor. The matcher matches array elements element-wise (no list
-/// hole for arrays), so the holed array keeps the same length; elisions and
-/// spreads are preserved verbatim, mirroring [`hole_args`].
+/// carry an anchor. The matcher matches array elements element-wise (there is no
+/// array list hole, unlike `ARGS` for call arguments), so the holed array keeps
+/// the same length; elisions and spreads are preserved verbatim.
 fn hole_array(array: &ArrayLit, kept: &BTreeSet<AnchorSpan>) -> ArrayLit {
     let mut holed = array.clone();
     holed.elems = array
@@ -4600,14 +4640,16 @@ mod interior_holing_tests {
         // Array elements carrying no anchor hole to ANYTHING (arity-exact, since
         // the matcher matches array elements element-wise); only the element
         // holding the anchor is recursed into. The lone-prop object keeps its one
-        // anchor prop with no OBJECT_PROPS padding (nothing was dropped).
+        // anchor prop with no OBJECT_PROPS padding (nothing was dropped). The bare
+        // `render` callee holes to ANYTHING (a minified name the matcher
+        // alpha-wildcards), unlike the member-method `.run` in the sibling case.
         let holed = hole_statement_expr(
             r#"render([first(), { mode: "keepMe" }, third()]);"#,
             "keepMe",
         );
         assert_eq!(
             normalize(&holed),
-            normalize(r#"render([ANYTHING, { mode: "keepMe" }, ANYTHING]);"#),
+            normalize(r#"ANYTHING([ANYTHING, { mode: "keepMe" }, ANYTHING]);"#),
         );
     }
 }


### PR DESCRIPTION
The var read-off drills a nested call tree to the discriminating leaf, but two
hole policies kept it from the most rebuild-stable shape on minified bundles:

- hole_callee pinned a bare-function callee (wrapOuter, decorate) as a "stable"
  anchor. In a minified bundle those identifiers churn every rebuild and the
  matcher already alpha-wildcards them (the shape index never proposes a
  bare-ident callee as an anchor), so they discriminate nothing. They now hole to
  ANYTHING; member-method callees (.then/.bar) still keep their stable property
  name.
- hole_args holed a dropped sibling argument to a single arity-exact ANYTHING, so
  a rebuild that added or removed an argument broke the selector. A run of
  non-anchor arguments now collapses to a variadic ARGS run-hole (mirroring
  hole_object's OBJECT_PROPS), matching as an ordered subsequence with gaps.

Both are cross-cutting hole_callee/hole_args changes affecting every read-off
path, so they are re-baselined against all existing expectation fixtures
together. The prove-gate (finish_minimized_selector -> prove_synthesized_selector)
runs on the final holed selector, so no over-broadened, non-unique selector is
ever emitted; the minimizer proptest passes unchanged.

Unignores the deeply_nested_call_args E2E case and re-baselines the nine other
call-bearing fixtures plus two unit tests. Closes read-off plan backlog item 6
(issue #2311).

BAZEL_TEST_INVOCATIONS=buildbuddy:c16b3592-ec80-41d3-a09b-23a79628da64,buildbuddy:a8ee145a-f7d1-40fc-8f1d-534cc91775f2

https://claude.ai/code/session_01E63Bp6369hUQE3y9LeeUdW