### PR TITLE
precommit: drop cluster-validate from ducktape pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -192,12 +192,14 @@ repos:
         files: "pyproject\\.toml$"
         exclude: "^pyproject\\.toml$"
 
-      # Pre-commit file validations (tf-centralization, filenames, cluster, frozen-specimens)
+      # Pre-commit file validations (filenames, frozen-specimens). These are
+      # git-diff-based checks with no static repo-state equivalent. Cluster
+      # validation moved to the Bazel test //cluster/validation:test_* targets.
       - id: ducktape-precommit
         name: ducktape pre-commit
         entry: ducktape-precommit
         language: system
-        pass_filenames: true
+        pass_filenames: false
         always_run: true
         stages: [pre-commit]
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -183,7 +183,6 @@ py_wheel(
 py_package(
     name = "ducktape_git_hooks_pkg",
     packages = [
-        "cluster.validation",
         "devinfra",
         "devinfra.precommit",
         "devinfra.precommit.enforce_bazel_tests",

--- a/cluster/AGENTS.md
+++ b/cluster/AGENTS.md
@@ -151,7 +151,8 @@ README, transcluded here:
 
 Layer 1 (CRD operators) → Layer 2 (secrets with ESO) → Layer 3 (app with HelmRelease).
 Each layer's `flux-kustomization.yaml` has `dependsOn` on previous.
-Violations detected by pre-commit (`validate_kustomizations.py`).
+Violations are caught by the Bazel test `//cluster/validation:test_crd_layering`
+(part of the `//cluster/validation:test_*` suite that validates the cluster in CI).
 
 - Flat example: `k8s/scanner/` — single flux-kustomization, all manifests at root
 - Grouped example: `k8s/langfuse/{namespace,secrets,db,app}/` — multi-layer with dependsOn

--- a/cluster/docs/troubleshooting.md
+++ b/cluster/docs/troubleshooting.md
@@ -412,9 +412,9 @@ some `cluster/k8s/.../flux-kustomization.yaml` reference in
 tracked tree. Fix the reference (or recommit the missing directory), then
 all the queued-up downstream changes apply at once.
 
-A pre-commit `cluster-validate` check that catches dangling resource
-references in `cluster/k8s/kustomization.yaml` would prevent this class of
-silent wedge entirely.
+The Bazel test `//cluster/validation:test_cluster_integration` catches dangling
+resource references in `cluster/k8s/kustomization.yaml` (its orphaned-files and
+dependency checks), preventing this class of silent wedge from reaching `devel`.
 
 ## Quick Reference
 

--- a/cluster/validation/test_cluster_integration.py
+++ b/cluster/validation/test_cluster_integration.py
@@ -5,9 +5,9 @@ Tests that parse the cluster kustomization tree and check structural invariants
 blueprint completeness). All kustomizations are built with kustomize to validate
 they render correctly and to provide build results for resource-level checks.
 
-TODO: These checks duplicate validate_cluster (run via pre-commit). Consolidate by
-enforcing affected bazel tests pass before commit (PR #819 WIP), then remove the
-validate_cluster pre-commit hook and use this test as the single source of truth.
+These Bazel tests are the single source of truth for cluster validation; the
+former `cluster-validate` pre-commit hook was removed in favor of running them
+(and the sibling `test_*.py` targets) in CI.
 """
 
 from __future__ import annotations

--- a/devinfra/docs/linting.md
+++ b/devinfra/docs/linting.md
@@ -96,17 +96,17 @@ All hooks respect `.gitattributes` and `.pre-commit-config.yaml` exclusions.
 
 Key hooks in `.pre-commit-config.yaml`:
 
-| Hook                 | Source                       | Purpose                  |
-| -------------------- | ---------------------------- | ------------------------ |
-| `ruff-check`         | astral-sh/ruff-pre-commit    | Python linting           |
-| `ruff-format`        | astral-sh/ruff-pre-commit    | Python formatting        |
-| `buildifier`         | keith/pre-commit-buildifier  | Starlark formatting      |
-| `buildifier-lint`    | keith/pre-commit-buildifier  | Starlark linting         |
-| `ducktape-precommit` | local (system)               | Validations              |
-| `prettier`           | local (node)                 | JS/TS/MD/YAML formatting |
-| `rustfmt`            | local (system)               | Rust formatting          |
-| `nixfmt`             | local (static binary)        | Nix formatting           |
-| `markdownlint-cli2`  | DavidAnson/markdownlint-cli2 | Markdown linting         |
+| Hook                 | Source                       | Purpose                           |
+| -------------------- | ---------------------------- | --------------------------------- |
+| `ruff-check`         | astral-sh/ruff-pre-commit    | Python linting                    |
+| `ruff-format`        | astral-sh/ruff-pre-commit    | Python formatting                 |
+| `buildifier`         | keith/pre-commit-buildifier  | Starlark formatting               |
+| `buildifier-lint`    | keith/pre-commit-buildifier  | Starlark linting                  |
+| `ducktape-precommit` | local (system)               | Filename + frozen-specimen checks |
+| `prettier`           | local (node)                 | JS/TS/MD/YAML formatting          |
+| `rustfmt`            | local (system)               | Rust formatting                   |
+| `nixfmt`             | local (static binary)        | Nix formatting                    |
+| `markdownlint-cli2`  | DavidAnson/markdownlint-cli2 | Markdown linting                  |
 
 Cluster-specific hooks run only on `cluster/` files:
 
@@ -115,6 +115,10 @@ Cluster-specific hooks run only on `cluster/` files:
 - `tflint` - Terraform linting
 
 Terraform validation and linting are also covered by Bazel `tf_module` test targets (`rules_tf`).
+
+Cluster structural validation (kustomize builds, CRD layering, orphaned files, Flux
+dependencies, health checks, blueprint completeness) runs as the
+`//cluster/validation:test_*` Bazel test suite, not as a pre-commit hook.
 
 ## Version Management
 

--- a/devinfra/precommit/BUILD.bazel
+++ b/devinfra/precommit/BUILD.bazel
@@ -105,7 +105,6 @@ py_library(
         ":commit_tag",
         ":filename_conventions",
         ":frozen_specimens",
-        "//cluster/validation:validate_all",
         "//devinfra:pytest_main",
         "//devinfra/precommit/enforce_bazel_tests",
         "//util:otel",

--- a/devinfra/precommit/git_hook.py
+++ b/devinfra/precommit/git_hook.py
@@ -1,7 +1,7 @@
 """Git hook entry points for pre-commit framework.
 
 Installed as separate console scripts via the claude-hooks wheel:
-- ducktape-precommit: file validations (filenames, cluster, frozen-specimens)
+- ducktape-precommit: file validations (filenames, frozen-specimens)
 - ducktape-pytest-main-check: verify test files have pytest_bazel.main() entry points
 - ducktape-prepare-commit-msg: block amending already-pushed commits
 - ducktape-commit-msg: enforce BAZEL_TEST_INVOCATIONS= tag
@@ -22,7 +22,6 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.trace import StatusCode
 
-from cluster.validation.validate_all import validate as validate_cluster
 from devinfra.precommit.commit_tag import TestTagError, check_commit_message
 from devinfra.precommit.enforce_bazel_tests.enforce_bazel_tests import run as enforce_bazel_tests_run
 from devinfra.precommit.filename_conventions import check_filename_conventions
@@ -40,12 +39,6 @@ def _is_ignored(repo: pygit2.Repository, path: str) -> bool:
     return any(repo.get_attr(path, a) in (True, "true") for a in _IGNORE_ATTRS)
 
 
-def is_cluster_validated(p: Path) -> bool:
-    if p.is_relative_to("cluster/k8s") and p.suffix in (".yaml", ".yml"):
-        return True
-    return p.is_relative_to("cluster/terraform") and "cilium" in p.parts
-
-
 async def run_pytest_main_check(files: list[Path], repo_root: Path, bazel_index: BazelPyTestIndex) -> str | None:
     """Check that test files have pytest_bazel.main() calls."""
     if not files:
@@ -61,20 +54,6 @@ async def run_pytest_main_check(files: list[Path], repo_root: Path, bazel_index:
     failed = [r for r in results if not r.passed]
     if failed:
         return "\n".join(f"{r.file_path}: {r.reason}" for r in failed)
-    return None
-
-
-async def run_cluster_validate(files: list[Path], repo_root: Path) -> str | None:
-    if not any(is_cluster_validated(f) for f in files):
-        return None
-    # Pre-commit only flags orphans introduced by this commit — unstaged YAML
-    # left on disk by a parallel agent shouldn't fail an unrelated diff.
-    orphan_candidates = {(repo_root / f).resolve() for f in files}
-    errors = await validate_cluster(
-        repo_root / "cluster/k8s", skip_flux_build=True, orphan_candidates=orphan_candidates
-    )
-    if errors:
-        return "\n".join(f"  {e.strip()}" for e in errors)
     return None
 
 
@@ -120,16 +99,13 @@ def _setup_tracing(repo: pygit2.Repository) -> None:
 # ---------------------------------------------------------------------------
 
 
-async def _run_pre_commit(argv: list[str]) -> int:
+async def _run_pre_commit() -> int:
     repo = pygit2.Repository(".")
-    repo_root = Path(repo.workdir)
     _setup_tracing(repo)
 
     with tracer.start_as_current_span("precommit"):
         head_tree, all_deltas = _staged_deltas(repo)
         deltas = [d for d in all_deltas if not _is_ignored(repo, d.new_file.path)]
-
-        files = [Path(f) for f in argv] if argv else get_all_files(repo)
 
         async def _traced(name: str, coro: Awaitable[str | None]) -> tuple[str, str | None]:
             with tracer.start_as_current_span(name):
@@ -138,11 +114,10 @@ async def _run_pre_commit(argv: list[str]) -> int:
                     trace.get_current_span().set_status(StatusCode.ERROR, error[:200])
                 return (name, error)
 
-        print(f"Validating {len(files)} files...")
+        print(f"Validating {len(deltas)} changed files...")
         results = list(
             await asyncio.gather(
                 _traced("filename-conventions", run_filename_convention_check(deltas, head_tree)),
-                _traced("cluster-validate", run_cluster_validate(files, repo_root)),
                 _traced("frozen-specimens", run_frozen_specimens_check(deltas, head_tree)),
             )
         )
@@ -225,7 +200,7 @@ def _run_commit_msg(argv: list[str]) -> int:
 
 
 def main_pre_commit() -> int:
-    return asyncio.run(_run_pre_commit(sys.argv[1:]))
+    return asyncio.run(_run_pre_commit())
 
 
 def main_pytest_main_check() -> int:


### PR DESCRIPTION
## Summary

Removes the `cluster-validate` check from the `ducktape-precommit` hook. Cluster
structural validation is already fully covered by the `//cluster/validation:test_*`
Bazel test suite (`test_cluster_integration`, `test_crd_layering`, `test_dependencies`,
`test_health_checks`, ...), which runs in CI. The pre-commit version was a
fast-but-partial duplicate (staged files only, `skip_flux_build=True`); the Bazel suite
is now the single source of truth.

## Changes

- **`devinfra/precommit/git_hook.py`** — drop the `validate_cluster` import,
  `is_cluster_validated()`, `run_cluster_validate()`, and the gather entry. The two
  remaining checks (`filename-conventions`, `frozen-specimens`) read git deltas directly,
  so the now-unused `argv`/`files`/`repo_root` plumbing is removed and the docstring updated.
- **`.pre-commit-config.yaml`** — fix the stale `tf-centralization` comment, document why
  the remaining checks stay as a git hook, and set `pass_filenames: false`.
- **`devinfra/precommit/BUILD.bazel`** — drop the now-unused `//cluster/validation:validate_all` dep.
- **`BUILD.bazel`** — drop `cluster.validation` from the git-hooks wheel `packages`.
- **Docs** — `cluster/AGENTS.md` kustomization-layering note pointed at a stale
  `validate_kustomizations.py` (now only exists in frozen specimens); it now points at
  `//cluster/validation:test_crd_layering`. `cluster/docs/troubleshooting.md` and
  `devinfra/docs/linting.md` now describe cluster validation as a Bazel test.
  `cluster/validation/test_cluster_integration.py` loses its obsolete "remove the
  pre-commit hook" TODO.

## Trade-off

Local commits touching `cluster/k8s/` no longer get instant validation feedback —
issues now surface at `bbr test` / CI time instead. This is intentional.

## Verification

- `bbr test //devinfra/precommit:test_git_hook //cluster/validation:test_cluster_integration //cluster/validation:test_crd_layering` → all 3 PASS
- `bbr build //:ducktape_git_hooks_wheel` → clean (confirms dep/package removals)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012t8FrkP91xENEovBGKXyxb

---
_Generated by [Claude Code](https://claude.ai/code/session_012t8FrkP91xENEovBGKXyxb)_