### PR TITLE
debundle: enclosing-context anchoring for read-off residual (#2315)

### DIFF
--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -35,10 +35,10 @@ One-line status for each `plans/` design doc; this is the discovery index.
   key-set minimization, (adjacent-function + general) co-occurrence grouping,
   multi-target var binding-group read-off, whole-body interior holing (incl. the
   multi-feature value-anchor cover), wide destructure, callee/arg holing,
-  prove-gate-via-index, whole-spec perf validation (W4), and the branch-and-bound
-  cover deletion landed; keep-shallow group-cover retirement, by-form split,
-  language simplification, and the enclosing-context residual open. Holds its own
-  current-state + backlog.
+  enclosing-context residual anchoring, prove-gate-via-index, whole-spec perf
+  validation (W4), and the branch-and-bound cover deletion landed; keep-shallow
+  group-cover retirement, by-form split, and language simplification open. Holds
+  its own current-state + backlog.
 - <plans/readoff_algorithm_research.md> + <plans/readoff_research/> — **reference
   (complete).** Literature spike that gates the read-off design; durable, not a
   TODO.
@@ -64,11 +64,11 @@ propose`.
    function/object/class/var read-off, literal/regex anchors, hole-based
    minimization, multi-target var binding-group read-off, co-occurrence grouping,
    whole-body interior holing (incl. the multi-feature value-anchor cover), wide
-   destructure, callee/arg holing, the prove-gate perf fix, whole-spec validation,
-   and the branch-and-bound cover deletion have landed; keep-shallow group-cover
-   retirement, `selector_codemod.rs` by-form split, language simplification, and
-   the enclosing-context residual are in that plan's backlog. Don't duplicate its
-   design or status here.
+   destructure, callee/arg holing, enclosing-context residual anchoring, the
+   prove-gate perf fix, whole-spec validation, and the branch-and-bound cover
+   deletion have landed; keep-shallow group-cover retirement,
+   `selector_codemod.rs` by-form split, and language simplification are in that
+   plan's backlog. Don't duplicate its design or status here.
 2. **Patch-plan based bulk codemods.** Extend `debundle spec selector-codemod`
    or add adjacent verbs so every broad rewrite can emit a dry-run patch plan,
    apply with filters, and explain every skipped candidate. (Selector
@@ -266,14 +266,18 @@ Detailed workflow priorities live above and in
 implemented only when they unlock synthesis, stabilization, repair, or porting
 workflows, and must use generic synthetic fixtures.
 
-- **Contextual selectors.** Add readable `before` / `after` / `near`
-  anchors for cases where the selected statement or declaration is
-  helper-boilerplate that appears multiple times. This should replace
-  copied overlapping selector bodies and still reject ambiguous windows.
-  Decorator-helper neighborhoods are the motivating generic shape: a
-  helper declaration may be syntactically identical across many classes,
-  but it becomes unambiguous when selected near the class or decorator
-  calls whose property strings identify the target.
+- **Contextual selectors.** The disambiguation _capability_ for
+  helper-boilerplate that appears multiple times has landed (#2315): the
+  minimizer reads off a stable immediate neighbor's unique anchor and
+  emits a 2-statement-window `source_match` + `target_binding` rather than
+  a copied overlapping selector body (the matcher already rejects ambiguous
+  windows via the prove-gate). Decorator-helper neighborhoods — a helper
+  declaration syntactically identical across many classes, disambiguated by
+  an adjacent decorator call whose property strings identify the target —
+  are the motivating shape. Remaining: (a) readable `before` / `after` /
+  `near` _sugar_ so a hand-authored selector can express the same window
+  without spelling out both statements; (b) non-adjacent / enclosing-call-site
+  context (synthesis reads only the immediate ±1 neighbors today).
 - **Constrained hole matching.** Multi-hole selectors need cheap local
   constraints so authors can say that a hole appears only as a specific
   argument, callback body, object property value, or statement-list slot. This

--- a/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
+++ b/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
@@ -813,3 +813,46 @@ fn minimizes_sibling_class_declaration_group() {
         }],
     });
 }
+
+// Enclosing-context anchoring (#2315): an **alpha-only construct** — a target
+// `const selectedHelper = new Factory()` among same-shape `const X = new IDENT()`
+// siblings — has no value anchor of its own (the `new` callee alpha-canonicalizes,
+// the call has no stable args), so the target's read-off and keep-shallow paths
+// both fail. Rather than leaving it name-pinned, the var residual path pins a
+// **stable adjacent declaration** as context: a 2-statement window pairing the
+// immediately-preceding `defineSelected("gamma-unique-token")` call (holed to
+// `ANYTHING("gamma-unique-token")` — its minified callee dropped per #2318, only
+// the globally-unique string pinned) with the target's degenerate
+// `const SelectedHelper = ANYTHING` scaffold, `target_binding` picking the target
+// out. Exercises the
+// neighbor-*before*-target window (`target_binding` at needle index 1, routed
+// through the single-declarator-target matcher). Real-spec analogue: the alpha-only
+// `new ()` factories the read-off otherwise reports as residual debt.
+minimizer_expectation_case!(
+    anchors_alpha_only_construct_to_a_stable_neighbor,
+    fixture = "neighbor_context_alpha_construct",
+    name = "alpha-only `new` construct is anchored to its stable adjacent call",
+    module = "app/helpers",
+    bindings = [("SelectedHelper", "selectedHelper")],
+    expected = "expected_match.js",
+);
+
+// Enclosing-context anchoring (#2315): a **near-duplicate emitted helper** — a
+// target `function selectedHelper() { return wrap(); }` among byte-identical
+// `function X() { return wrap(); }` siblings (the `__decorate`-family shape) — has
+// no discriminating feature inside its own declaration, so even the bare
+// `function SelectedHelper() { STMT_LIST }` scaffold matches every sibling. The
+// function read-off (`render_via_read_off`) falls to the target's stable
+// neighbors: a 2-statement window pairing the holed scaffold with the
+// immediately-following `registerSelected("delta-unique-token")` call holed to
+// `ANYTHING("delta-unique-token")` (minified callee dropped per #2318, unique
+// string pinned), `target_binding` selecting the function. Closes the residual the
+// in-body value cover (#2289) explicitly left open.
+minimizer_expectation_case!(
+    anchors_duplicate_helper_to_a_stable_neighbor,
+    fixture = "neighbor_context_duplicate_helper",
+    name = "near-duplicate helper function is anchored to its stable adjacent call",
+    module = "app/helpers",
+    bindings = [("SelectedHelper", "selectedHelper")],
+    expected = "expected_match.js",
+);

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/neighbor_context_alpha_construct/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/neighbor_context_alpha_construct/expected_match.js
@@ -1,0 +1,2 @@
+ANYTHING("gamma-unique-token");
+const SelectedHelper = ANYTHING;

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/neighbor_context_alpha_construct/source.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/neighbor_context_alpha_construct/source.js
@@ -1,0 +1,6 @@
+const firstHelper = new Factory();
+defineSelected("gamma-unique-token");
+const selectedHelper = new Factory();
+const thirdHelper = new Factory();
+const fourthHelper = new Factory();
+export { selectedHelper };

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/neighbor_context_duplicate_helper/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/neighbor_context_duplicate_helper/expected_match.js
@@ -1,0 +1,4 @@
+function SelectedHelper() {
+  STMT_LIST;
+}
+ANYTHING("delta-unique-token");

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/neighbor_context_duplicate_helper/source.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/neighbor_context_duplicate_helper/source.js
@@ -1,0 +1,14 @@
+function firstHelper() {
+  return wrap();
+}
+function secondHelper() {
+  return wrap();
+}
+function selectedHelper() {
+  return wrap();
+}
+registerSelected("delta-unique-token");
+function fourthHelper() {
+  return wrap();
+}
+export { selectedHelper };

--- a/devinfra/js/debundle/minimize/group.rs
+++ b/devinfra/js/debundle/minimize/group.rs
@@ -10,7 +10,7 @@ use swc_ecma_ast::*;
 
 use super::object::{object_anchor_ranking, try_object_read_off};
 use super::var::try_var_read_off;
-use super::{hole_var_init_padded, render_var_slots};
+use super::{hole_var_init_padded, render_var_slots, render_via_neighbor_context};
 use crate::regex_anchor::{accepted_regex_anchors, collect_regex_anchor_candidates};
 use crate::render::{
     AnchorSpan, MAX_MINIMIZER_ANCHORS, hole_expr, holes_present, node_holds_anchor, span_key,
@@ -484,6 +484,17 @@ pub(crate) fn minimize_var_group_selector(
             }
         }
         if !resolves(&kept)? {
+            // Enclosing-context anchoring (#2315): the var's own anchors (read-off
+            // + keep-shallow) cannot single it out among same-shape siblings —
+            // an alpha-only initializer (`new ()`) or a near-duplicate emitted
+            // helper. For the single-target case, pin a stable adjacent declaration
+            // as context; the degenerate `const X = ANYTHING` scaffold is acceptable
+            // here because the neighbor carries the uniqueness. Multi-target group
+            // residuals stay as debt (tuple-aware context anchoring is future work).
+            if let [target] = targets {
+                let scaffold = render_with(&BTreeSet::new(), &no_regex)?;
+                return render_via_neighbor_context(index, decl, target, &scaffold);
+            }
             return Ok(None);
         }
     }

--- a/devinfra/js/debundle/minimize/mod.rs
+++ b/devinfra/js/debundle/minimize/mod.rs
@@ -46,8 +46,8 @@ use swc_ecma_visit::VisitMutWith;
 
 use crate::regex_anchor::RegexAnchorSubstitution;
 use crate::render::{
-    AnchorSpan, declarator_hole, emit_selector, hole_expr, hole_object_padded, holes_present,
-    named_pat,
+    AnchorSpan, declarator_hole, emit_selector, hole_expr, hole_object_padded, hole_stmt,
+    holes_present, named_pat,
 };
 use crate::{
     ChunkSelectorIndex, IndexedDeclaration, SpecializedSelector, SynthesizedTargetBinding,
@@ -140,12 +140,19 @@ fn render_via_read_off(
     // anchor to keep). The scaffold is degenerate for `var`, so the var path skips
     // this entirely and returns `None` for the keep-shallow path to handle.
     let empty = BTreeSet::new();
-    if matched_body_indices(index, &target.export_name, &render_with(&empty)?)?
+    let scaffold = render_with(&empty)?;
+    if matched_body_indices(index, &target.export_name, &scaffold)?
         == BTreeSet::from([decl.body_idx])
     {
-        return finish_minimized_selector(index, decl, target, render_with(&empty)?);
+        return finish_minimized_selector(index, decl, target, scaffold);
     }
-    Ok(None)
+
+    // Enclosing-context anchoring (#2315): the target's own value anchors and the
+    // bare scaffold all fail to single it out among same-shape siblings. Fall to
+    // its stable neighbors — a 2-statement window pinning an adjacent declaration's
+    // unique anchor + the target scaffold. `None` here leaves the target as residual
+    // debt (never a full-AST pin).
+    render_via_neighbor_context(index, decl, target, &scaffold)
 }
 
 fn finish_minimized_selector(
@@ -163,6 +170,73 @@ fn finish_minimized_selector(
         match_source: source,
         rewritten_holes,
     }))
+}
+
+/// Enclosing-context anchoring (#2315). The last resort before residual debt:
+/// when a target's own value anchors cannot separate it from same-shape siblings
+/// — alpha-only constructs (`new ()` with no stable args) or near-duplicate
+/// emitted helpers (the `__decorate` family) — pin a **stable adjacent
+/// declaration** as context. Emit a 2-statement window selector pairing the
+/// target's holed `target_scaffold` with an immediate neighbor holed to a
+/// globally-unique value anchor, ordered by their chunk adjacency, with
+/// `target_binding` picking the target out of the window. The matcher's
+/// contiguous member-window path resolves it and the prove-gate confirms
+/// uniqueness.
+///
+/// Returns `None` when no adjacent declaration carries a unique value anchor, or
+/// none of the windows prove — the target then stays name-pinned as residual
+/// debt, never a full-AST pin.
+fn render_via_neighbor_context(
+    index: &ChunkSelectorIndex,
+    decl: &IndexedDeclaration,
+    target: &SynthesizedTargetBinding,
+    target_scaffold: &str,
+) -> Result<Option<SpecializedSelector>> {
+    for candidate in index
+        .shape_index
+        .context_neighbor_anchor_candidates(decl.body_idx)
+    {
+        let Some(neighbor_item) = index.parsed.module.body.get(candidate.neighbor_body_idx) else {
+            continue;
+        };
+        let neighbor_kept = kept_spans_for_anchor_set(neighbor_item, &candidate.anchor_set);
+        if neighbor_kept.is_empty() {
+            continue;
+        }
+        let Some(neighbor_source) = render_context_neighbor(neighbor_item, &neighbor_kept)? else {
+            continue;
+        };
+        // Compose the window in chunk order so the matcher's contiguous member
+        // window aligns the neighbor and target to their real adjacency.
+        let (first, second) = if candidate.neighbor_body_idx < decl.body_idx {
+            (neighbor_source.as_str(), target_scaffold)
+        } else {
+            (target_scaffold, neighbor_source.as_str())
+        };
+        let window = format!("{}\n{}", first.trim_end(), second.trim_end());
+        if let Some(selector) = finish_minimized_selector(index, decl, target, window)? {
+            return Ok(Some(selector));
+        }
+    }
+    Ok(None)
+}
+
+/// Render an adjacent declaration as holed selector *context*: keep only the
+/// spans in `kept` (the neighbor's unique value anchor) and hole everything else,
+/// so the neighbor contributes a stable pin without dumping its full AST. Only
+/// plain statements are holed (the common adjacent-helper / config / call-site
+/// shape `hole_stmt` covers); a module declaration (import/export) yields `None`
+/// and the caller tries the other neighbor.
+fn render_context_neighbor(
+    item: &ModuleItem,
+    kept: &BTreeSet<AnchorSpan>,
+) -> Result<Option<String>> {
+    let ModuleItem::Stmt(stmt) = item else {
+        return Ok(None);
+    };
+    Ok(Some(emit_selector(ModuleItem::Stmt(hole_stmt(
+        stmt, kept,
+    )))?))
 }
 
 /// Per-slot initializer holing for the read-off var paths: an object init holes

--- a/devinfra/js/debundle/plans/readoff_minimization.md
+++ b/devinfra/js/debundle/plans/readoff_minimization.md
@@ -179,9 +179,13 @@ alpha-renameable binding, so it discriminates. Regex-over-string-literal anchors
 (`minimize_via_retention`, `cover_competitors`, `min_set_cover`, and the
 function/class anchor collectors) is **deleted**: single-target function, class,
 object, and var all route through the read-off, which subsumes it once W3 added
-number/bool features (its last reason to exist). A target the read-off cannot
-single out is reported as debt, never full-AST-pinned. Multi-target var binding
-groups also read off now (`try_var_group_read_off`, backlog item 2): each target
+number/bool features (its last reason to exist). A target whose own features
+cannot single it out falls last to **enclosing-context anchoring** (#2315,
+`render_via_neighbor_context`): a 2-statement window pinning a stable immediate
+neighbor's unique anchor alongside the target's holed scaffold, `target_binding`
+picking the target out. Only a target with no usable neighbor stays name-pinned
+as debt — never full-AST-pinned. Multi-target var binding
+groups also read off now (`try_var_group_read_off`, backlog item 1): each target
 declarator slot reads its minimal anchor off the shape index plus a slot-aware
 greedy (`slot_minimal_anchors`), the per-slot kept spans union, and the
 binding-group matcher proves the tuple. The **keep-shallow path**
@@ -189,7 +193,7 @@ binding-group matcher proves the tuple. The **keep-shallow path**
 `AnchorCandidates::{shallow_literals,deep_cover_tiers}`) remains only as the
 **fallback** for groups whose per-slot single-binding view cannot single a slot
 out (a value shared across sibling statements that resolves only as a tuple);
-retiring it is gated as backlog item 2.
+retiring it is gated as backlog item 1.
 
 **Measured perf.** Whole ~7 MB / ~4.5k-member chunk minimizes in **~13 s** with
 the prove-gate-via-index fast-path (#2280), down from ~110 s — **meets the ≤30 s
@@ -205,18 +209,20 @@ the current (smaller, partly dogfood-applied) spec the whole chunk minimizes in
 `binding_group_declarators`, `nested_async_try`, `class_body`, `switch_case_run`,
 `object_keys_over_pinned`, `long_literal_value_anchor`, `binding_group_partition`,
 `class_among_many_siblings`, `sibling_subclass_hierarchy`, `adjacent_accessor_group`,
-`binding_group_key_set_readoff` (multi-target group per-slot key read-off, item 2),
+`binding_group_key_set_readoff` (multi-target group per-slot key read-off, item 1),
 `interior_object_arg_holing` (unignored once the `Expr::Array` interior holing
 landed, #2289), `sequential_assignment_block` (`hole_expr` `Expr::Assign` arm),
 `sibling_class_declaration_group` (the general non-function co-occurrence group),
 `single_target_class_whole_body`, `component_wide_destructure_whole_body`
 (unignored once the robustness-anchor candidate-walk landed, #2289 item 1),
-`object_nested_value_dict`, and (unignored once the object key-set cover landed)
+`object_nested_value_dict`, (unignored once the object key-set cover landed)
 `grouped_enum_objects`, `object_key_set_group`, `object_key_set_subset`,
 (unignored once `hole_callee`/`hole_args` holed bare-function callees and
-non-anchor argument runs) `deeply_nested_call_args`, and (destructure-pattern-key
-`ObjectKey` anchors + `ObjectPat` holing, #2310) `wide_destructure_block`. Every
-catalogued expectation case is now active.
+non-anchor argument runs) `deeply_nested_call_args`, (destructure-pattern-key
+`ObjectKey` anchors + `ObjectPat` holing, #2310) `wide_destructure_block`, and
+(enclosing-context anchoring, #2315) `neighbor_context_alpha_construct`,
+`neighbor_context_duplicate_helper`. Every catalogued expectation case is now
+active.
 
 ## Acceptance criteria
 
@@ -256,9 +262,9 @@ serde); embedded/non-trailing volatility in regex anchors (future).
   the member is left as a name pin. These are **whole-body-only** members
   (uniqueness needs ~the entire body). Concentrated in `features` (955),
   `domains` (462), `app` (425). Recovering them is the hard, high-count tail:
-  needs **interior holing of whole bodies** (backlog item 1 — keep the body but
-  hole non-identifying subtrees so a fuller pin is at least less fragile / can be
-  emitted) and/or deeper anchoring. Biggest number, hardest; do not expect a
+  needs **interior holing of whole bodies** (landed — keeps the body but
+  holes non-identifying subtrees so a fuller pin is at least less fragile / can be
+  emitted) and/or deeper anchoring (enclosing-context, #2315). Biggest number, hardest; do not expect a
   clean compact selector for most.
 - **~200 (~9%) — convertible but >30 lines (filtered out of #360).** The minimizer
   _does_ synthesize a selector; it's just over the compact threshold. Shape mix:
@@ -266,9 +272,9 @@ serde); embedded/non-trailing volatility in regex anchors (future).
   These are the **achievable near-term wins**: the over-pin-reduction waves shrink
   them under the threshold so they ship as compact selectors —
   - var/object (the plurality) → wide object-destructure patterns now hole to
-    the discriminating key (landed, #2310); residual object-dict over-pin folds
-    into item 1's interior holing;
-  - function → **interior holing** within kept bodies (backlog item 1);
+    the discriminating key (landed, #2310); the remaining object-dict over-pin
+    folds into the landed interior holing;
+  - function → **interior holing** within kept bodies (landed);
   - a re-apply after each wave reconverts whatever now fits ≤30 lines.
 - 1 — `async` parse edge case (single; ignore).
 
@@ -283,17 +289,7 @@ real-spec sample (5,556 selectors); the non-minimal pattern catalog drives this
 and is encoded as disabled E2E cases. Completed items are removed, not annotated;
 the landed architecture is in "Current state" above.
 
-1. **Enclosing-context anchoring for the read-off residual (GitHub #2315).**
-   Interior holing of no-sparse-anchor bodies is complete (single-target
-   whole-body via the robustness-anchor candidate walk, and the multi-feature
-   `unique_value_anchor_cover` for same-shape-sibling bodies — see "Current state").
-   The genuine residual remains: bodies the read-off cannot separate from
-   same-shape siblings by any combination of their own value anchors (alpha-only
-   constructs like `new <minified>()`, near-duplicate emitted helpers like the
-   `__decorate` family). These have no discriminating feature _inside_ the
-   declaration, so they need **enclosing-context anchoring** (`before`/`after`/`near`
-   a stable neighbor) or stay name-pinned as accepted debt.
-2. **Retire the keep-shallow group cover.** The multi-target var binding-group
+1. **Retire the keep-shallow group cover.** The multi-target var binding-group
    read-off (`try_var_group_read_off`) landed, but the keep-shallow path
    (`minimize_var_group_selector`'s escalation over `collect_expr_anchors` +
    `AnchorCandidates`) stays as the fallback for groups whose per-slot
@@ -302,11 +298,11 @@ the landed architecture is in "Current state" above.
    Removing `minimize_var_group_selector`'s escalation path, `collect_expr_anchors`,
    and `AnchorCandidates::{shallow_literals,deep_cover_tiers}` is gated on a
    tuple-aware read-off for those residual groups (or accepting them as debt).
-3. **Language simplification** (see below) — emit anonymous `OBJECT_PROPS` /
+2. **Language simplification** (see below) — emit anonymous `OBJECT_PROPS` /
    `DECLARATORS` / `CLASS_REST` / `EXPR` / `STMT` as `ANYTHING`. Deferred until
    emission stabilizes (after the cover/keep-shallow paths fully retire), since it
    rewrites emitted selectors and touches many fixtures.
-4. **Dogfood-apply on gaffer-private (ongoing).** Run `synthesize-selectors
+3. **Dogfood-apply on gaffer-private (ongoing).** Run `synthesize-selectors
 --apply` on the real spec after each wave, review for over-pin, and PR the
    beneficial minimized selectors. Operational PR rule: **revert any converted
    selector whose `match` block is >40 lines AND has ≤2 holes** back to a name pin.

--- a/devinfra/js/debundle/render.rs
+++ b/devinfra/js/debundle/render.rs
@@ -429,7 +429,7 @@ fn hole_stmts(stmts: &[Stmt], kept: &BTreeSet<AnchorSpan>) -> Vec<Stmt> {
     out
 }
 
-fn hole_stmt(stmt: &Stmt, kept: &BTreeSet<AnchorSpan>) -> Stmt {
+pub(crate) fn hole_stmt(stmt: &Stmt, kept: &BTreeSet<AnchorSpan>) -> Stmt {
     match stmt {
         Stmt::Expr(expr_stmt) => {
             let mut holed = expr_stmt.clone();

--- a/devinfra/js/debundle/shape_index.rs
+++ b/devinfra/js/debundle/shape_index.rs
@@ -562,6 +562,17 @@ pub struct AnchorSet {
     pub opt_one: bool,
 }
 
+/// A stable anchor on a top-level *neighbor* of a residual target — the handle
+/// for enclosing-context anchoring (#2315). The `anchor_set` is one of the
+/// neighbor's individually-unique value anchors; pairing the neighbor (holed to
+/// that anchor) with the target's holed scaffold in a 2-statement window singles
+/// the target out even when its own features cannot.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ContextNeighborAnchor {
+    pub neighbor_body_idx: usize,
+    pub anchor_set: AnchorSet,
+}
+
 /// Per-item entry: the existing prefilter candidate plus this item's shape
 /// skeleton features.
 #[derive(Debug, Clone)]
@@ -889,6 +900,41 @@ impl ShapeIndex {
             },
         )
     }
+
+    /// Enclosing-context read-off (#2315): the disambiguating handles on a
+    /// target's **stable neighbors** when its own value features cannot separate
+    /// it from same-shape siblings (alpha-only constructs, near-duplicate emitted
+    /// helpers). For each immediate top-level neighbor (the declaration just
+    /// before and just after `body_idx`) it yields that neighbor's
+    /// individually-unique value anchors, best-first, as [`ContextNeighborAnchor`]s.
+    ///
+    /// A neighbor anchor whose posting list is the singleton `{neighbor}` pins a
+    /// token occurring in exactly one top-level item, so a 2-statement window
+    /// pairing the neighbor (holed to that anchor) with the target's holed
+    /// scaffold matches only where that unique neighbor sits adjacent to a
+    /// target-shaped statement — i.e. uniquely at the target. The renderer
+    /// composes and prove-gates the window; this method only reads the candidate
+    /// anchors off the index. Neighbors are bounded to the immediate ±1
+    /// declarations, so this stays a bounded read-off, never a chunk-wide search.
+    pub fn context_neighbor_anchor_candidates(
+        &self,
+        body_idx: usize,
+    ) -> Vec<ContextNeighborAnchor> {
+        let prev = body_idx.checked_sub(1);
+        let next = (body_idx + 1 < self.items.len()).then_some(body_idx + 1);
+        [prev, next]
+            .into_iter()
+            .flatten()
+            .flat_map(|neighbor_body_idx| {
+                self.unique_value_anchor_candidates(neighbor_body_idx)
+                    .into_iter()
+                    .map(move |anchor_set| ContextNeighborAnchor {
+                        neighbor_body_idx,
+                        anchor_set,
+                    })
+            })
+            .collect()
+    }
 }
 
 /// Whether a feature maps to a concrete kept token the renderer can pin (a
@@ -1211,6 +1257,56 @@ const c = emit("delta", "beta");"#,
             assert!(anchor_renders_a_value(&scored.feature), "{scored:?}");
         }
         assert!(index.read_off_resolves_uniquely(0, &cover));
+    }
+
+    #[test]
+    fn context_neighbor_anchor_candidates_offer_adjacent_unique_value_anchors() {
+        // Three alpha-identical `const X = new IDENT()` helpers (bodies 0, 2, 3):
+        // none has a value anchor of its own (the `new` callee alpha-canonicalizes),
+        // so the middle one is a genuine residual — `minimal_anchor_set` cannot
+        // separate it. Its immediate neighbor (body 1) carries a globally-unique
+        // string, which the enclosing-context read-off offers as a disambiguating
+        // anchor on the neighbor.
+        let module = parse(
+            r#"const a = new Factory();
+mountSelected("beta-unique-token");
+const b = new Factory();
+const c = new Factory();"#,
+        );
+        let index = ShapeIndex::new(&module);
+        assert!(
+            index.minimal_anchor_set(2).is_none(),
+            "the middle helper must be a genuine residual (no own discriminator)"
+        );
+        let candidates = index.context_neighbor_anchor_candidates(2);
+        let unique_string =
+            ShapeFeature::Selector(SelectorFeature::StringLiteral("beta-unique-token".into()));
+        assert!(
+            candidates.iter().any(|candidate| {
+                candidate.neighbor_body_idx == 1
+                    && candidate
+                        .anchor_set
+                        .anchors
+                        .iter()
+                        .any(|scored| scored.feature == unique_string)
+            }),
+            "expected the adjacent unique string as a neighbor anchor, got {candidates:?}"
+        );
+    }
+
+    #[test]
+    fn context_neighbor_anchor_candidates_are_empty_without_a_stable_neighbor() {
+        // All four statements are alpha-identical residual helpers with no value
+        // anchor anywhere, so no neighbor can disambiguate: the read-off yields no
+        // context candidates and the caller leaves the target as name-pinned debt.
+        let module = parse(
+            r#"const a = new Factory();
+const b = new Factory();
+const c = new Factory();
+const d = new Factory();"#,
+        );
+        let index = ShapeIndex::new(&module);
+        assert!(index.context_neighbor_anchor_candidates(1).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Closes #2315.

## Problem

The in-body value cover (#2289) drills no-sparse-anchor bodies down to a value leaf (or a greedy combination of leaves), but it explicitly left open the genuine residual: bodies where even a combination of in-target value anchors cannot separate the target from same-shape siblings —

- **alpha-only constructs** (`new ()` with no stable args; every feature alpha-canonicalizes to the same shape across siblings), and
- **near-duplicate emitted helpers** (the `__decorate` family: byte-identical declarations differing only in minified callees).

These carry no discriminating feature *inside* the declaration, so the only handles are the declaration's stable **neighbors**.

## Approach

The matcher and emission path **already** support multi-statement member selectors with `target_binding` (contiguous member-window matching via `find_matching_body_ranges`; `member_with_source_match` already emits `identifiers: alpha_all` + `target_binding`). So this is a pure **synthesis** change — no matcher, candidate-index, or emission changes.

When a target's own value anchors (single → cover → bare scaffold) all fail to single it out, the read-off now falls to its stable immediate neighbors:

- `ShapeIndex::context_neighbor_anchor_candidates` reads off the individually-unique value anchors of the declarations just before/after the target (bounded ±1 — a bounded read-off, never a chunk-wide search).
- `render_via_neighbor_context` emits a 2-statement-window `source_match` pairing the neighbor (holed to that unique anchor) with the target's holed scaffold, ordered by chunk adjacency, with `target_binding` picking the target out.

A neighbor anchor whose posting list is a singleton pins a token occurring in exactly one top-level item, so the window matches only where that unique neighbor sits adjacent to a target-shaped statement — i.e. uniquely at the target. The production matcher's prove-gate confirms uniqueness. A target with no usable neighbor still stays name-pinned as debt — never full-AST-pinned.

Wired into both the function/class read-off (`render_via_read_off`) and the var residual (`minimize_var_group_selector`).

## Changes

- **`shape_index.rs`** — `ContextNeighborAnchor` + `context_neighbor_anchor_candidates`, plus unit tests (a residual with a stable neighbor yields the candidate; an all-residual chunk yields none).
- **`selector_codemod.rs`** — `render_via_neighbor_context` + `render_context_neighbor`; wired into the function/class and var residual paths.
- **E2E fixtures** — `neighbor_context_alpha_construct` (var/`new`, exercises the neighbor-*before* / single-declarator-target window) and `neighbor_context_duplicate_helper` (function, neighbor-*after*).
- Updated `plans/readoff_minimization.md` and `TODO.md`.

## Testing

- Both fixtures genuinely test the feature: on `devel` the residual is reported as debt (`changed_candidates == 0`), so the expectation test's `changed > 0` assertion fails without this change.
- Full debundle crate (RBE): **117/117 test targets pass**; 208-target crate build clean (incl. rustfmt). `pre-commit` clean.
- `BAZEL_TEST_INVOCATIONS` recorded in the commit.

## Follow-ups (noted in the plan)

Non-adjacent / enclosing-call-site context (only ±1 neighbors are read off today); jointly-but-not-individually-unique neighbor anchors; multi-target group residuals (the window resolves one `target_binding`, not a tuple); and readable `before`/`after`/`near` selector sugar for hand-authoring the same window.

https://claude.ai/code/session_01SNMPyQiPxhnnYRyqDDcJ1H

---
_Generated by [Claude Code](https://claude.ai/code/session_01SNMPyQiPxhnnYRyqDDcJ1H)_