### PR TITLE
debundle: minimize wide object-destructure bindings (#2310)

### DIFF
--- a/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
+++ b/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
@@ -584,7 +584,6 @@ minimizer_expectation_case!(
 // `{ ... } = e` prop destructure is kept verbatim at the top of an otherwise
 // holed body.
 minimizer_expectation_case!(
-    #[ignore = "the discriminator is a destructure-pattern property key (`uniqueDiscriminatorProp`), which the candidate index does not collect, and holing an `ObjectPat` (keep one property + OBJECT_PROPS) is not yet implemented; the read-off bails with no sparse selector. Needs destructure-pattern-key anchor indexing + pattern holing."]
     minimizes_wide_destructure_block,
     fixture = "wide_destructure_block",
     name = "wide destructuring block keeps only the discriminating destructured property",

--- a/devinfra/js/debundle/plans/readoff_minimization.md
+++ b/devinfra/js/debundle/plans/readoff_minimization.md
@@ -115,9 +115,11 @@ O(smallest posting) per step, not O(N).
 **Feature taxonomy.** `SelectorFeature` indexes string, **number, and boolean**
 literals (number/bool canonicalized and scored `Semantic`; never wildcarded — the
 matcher discriminates by `eq_ignore_span`, so the candidate set stays a sound
-match superset), object keys, member/method/callee names, and bounded-depth
-skeletons. High-multiplicity skeletons (interned >4×) demote to `Structural` so
-value anchors win stability ties.
+match superset), object keys (object-literal **and** destructure-pattern
+property keys — the stable source property name, not the minified local
+binding), member/method/callee names, and bounded-depth skeletons.
+High-multiplicity skeletons (interned >4×) demote to `Structural` so value
+anchors win stability ties.
 
 **Layer 2 — read-off renderer + migrated forms.** `readoff_render.rs`
 (`kept_spans_for_anchor_set`) maps a read-off `AnchorSet` to the kept-span set the
@@ -131,7 +133,11 @@ Migrated to read-off as their primary path:
   is a run of sequential assignment statements holes to `STMT_LIST` runs around
   the one anchored assignment, whose LHS receiver (a minified parameter) holes to
   `ANYTHING` while the stable property name and discriminating RHS literal stay
-  (the `hole_expr` `Expr::Assign` arm; `sequential_assignment_block`).
+  (the `hole_expr` `Expr::Assign` arm; `sequential_assignment_block`). A body
+  opening with a wide object-destructure (`const { …, x } = props`) whose
+  discriminator is a destructured property key holes the pattern to
+  `{ OBJECT_PROPS, x }` (keep the anchored key, absorb the rest) and the RHS to
+  `ANYTHING` (`hole_object_pat`; `wide_destructure_block`).
 - **Single-target object** (`try_object_read_off` → `hole_object_padded`):
   surrounds every kept prop with `OBJECT_PROPS` (leads, trails, **and**
   interleaves) so a discriminating `key: value` — or a minimal _key set_ — matches
@@ -162,8 +168,12 @@ Migrated to read-off as their primary path:
 exist in `source_match_holes.rs` and the matcher (`match_list_with_holes`):
 `STMT_LIST`, `ARGS`, `OBJECT_PROPS`, `DECLARATORS`, `CLASS_REST`, and `CASE_REST`
 (switch-case-run — closes the survey's inexpressible many-arm-`switch` shape).
-Regex-over-string-literal anchors (`STR_LITERAL_MATCHING_RE`) fire for
-stable-prefix/volatile-tail strings (trailing hex/digit runs).
+`OBJECT_PROPS` absorbs object-literal properties **and** destructure-pattern
+properties (`const { OBJECT_PROPS, x } = …`), where a shorthand pattern key is
+matched by exact spelling (the stable source property name) rather than as an
+alpha-renameable binding, so it discriminates. Regex-over-string-literal anchors
+(`STR_LITERAL_MATCHING_RE`) fire for stable-prefix/volatile-tail strings
+(trailing hex/digit runs).
 
 **Strangler-fig boundary.** The matcher-driven branch-and-bound cover search
 (`minimize_via_retention`, `cover_competitors`, `min_set_cover`, and the
@@ -171,7 +181,7 @@ function/class anchor collectors) is **deleted**: single-target function, class,
 object, and var all route through the read-off, which subsumes it once W3 added
 number/bool features (its last reason to exist). A target the read-off cannot
 single out is reported as debt, never full-AST-pinned. Multi-target var binding
-groups also read off now (`try_var_group_read_off`, backlog item 3): each target
+groups also read off now (`try_var_group_read_off`, backlog item 2): each target
 declarator slot reads its minimal anchor off the shape index plus a slot-aware
 greedy (`slot_minimal_anchors`), the per-slot kept spans union, and the
 binding-group matcher proves the tuple. The **keep-shallow path**
@@ -179,7 +189,7 @@ binding-group matcher proves the tuple. The **keep-shallow path**
 `AnchorCandidates::{shallow_literals,deep_cover_tiers}`) remains only as the
 **fallback** for groups whose per-slot single-binding view cannot single a slot
 out (a value shared across sibling statements that resolves only as a tuple);
-retiring it is gated as backlog item 3.
+retiring it is gated as backlog item 2.
 
 **Measured perf.** Whole ~7 MB / ~4.5k-member chunk minimizes in **~13 s** with
 the prove-gate-via-index fast-path (#2280), down from ~110 s — **meets the ≤30 s
@@ -195,17 +205,18 @@ the current (smaller, partly dogfood-applied) spec the whole chunk minimizes in
 `binding_group_declarators`, `nested_async_try`, `class_body`, `switch_case_run`,
 `object_keys_over_pinned`, `long_literal_value_anchor`, `binding_group_partition`,
 `class_among_many_siblings`, `sibling_subclass_hierarchy`, `adjacent_accessor_group`,
-`binding_group_key_set_readoff` (multi-target group per-slot key read-off, item 3),
+`binding_group_key_set_readoff` (multi-target group per-slot key read-off, item 2),
 `interior_object_arg_holing` (unignored once the `Expr::Array` interior holing
 landed, #2289), `sequential_assignment_block` (`hole_expr` `Expr::Assign` arm),
 `sibling_class_declaration_group` (the general non-function co-occurrence group),
 `single_target_class_whole_body`, `component_wide_destructure_whole_body`
 (unignored once the robustness-anchor candidate-walk landed, #2289 item 1),
 `object_nested_value_dict`, and (unignored once the object key-set cover landed)
-`grouped_enum_objects`, `object_key_set_group`, `object_key_set_subset`, and
+`grouped_enum_objects`, `object_key_set_group`, `object_key_set_subset`,
 (unignored once `hole_callee`/`hole_args` holed bare-function callees and
-non-anchor argument runs) `deeply_nested_call_args`. Ignored as aspirational (the
-named form not yet read-off-expressible): `wide_destructure_block`.
+non-anchor argument runs) `deeply_nested_call_args`, and (destructure-pattern-key
+`ObjectKey` anchors + `ObjectPat` holing, #2310) `wide_destructure_block`. Every
+catalogued expectation case is now active.
 
 ## Acceptance criteria
 
@@ -254,7 +265,9 @@ serde); embedded/non-trailing volatility in regex anchors (future).
   **~55% var/object, ~42% function, ~3% class**; median ~35 lines, tail to ~700.
   These are the **achievable near-term wins**: the over-pin-reduction waves shrink
   them under the threshold so they ship as compact selectors —
-  - var/object (the plurality) → the remaining object-dict forms (backlog item 2);
+  - var/object (the plurality) → wide object-destructure patterns now hole to
+    the discriminating key (landed, #2310); residual object-dict over-pin folds
+    into item 1's interior holing;
   - function → **interior holing** within kept bodies (backlog item 1);
   - a re-apply after each wave reconverts whatever now fits ≤30 lines.
 - 1 — `async` parse edge case (single; ignore).
@@ -280,16 +293,7 @@ the landed architecture is in "Current state" above.
    `__decorate` family). These have no discriminating feature _inside_ the
    declaration, so they need **enclosing-context anchoring** (`before`/`after`/`near`
    a stable neighbor) or stay name-pinned as accepted debt.
-2. **Wide destructure (`wide_destructure_block`).** A `const { …, x } = props`
-   whose discriminator is a destructured property key (`x`) bails with "no sparse
-   selector": the candidate index does not collect destructure-pattern property
-   keys as anchors, and holing an `ObjectPat` (keep one property + `OBJECT_PROPS`,
-   hole the RHS) is not implemented (`hole_expr` is expression-only). Needs
-   destructure-pattern-key anchor indexing plus pattern holing. (Nested-value
-   dicts — `object_nested_value_dict` — already minimize via the nested
-   object/array holing recursion; the `ee({ coreMessage: …, type: … })`
-   schema-object-call form folds into item 1.)
-3. **Retire the keep-shallow group cover.** The multi-target var binding-group
+2. **Retire the keep-shallow group cover.** The multi-target var binding-group
    read-off (`try_var_group_read_off`) landed, but the keep-shallow path
    (`minimize_var_group_selector`'s escalation over `collect_expr_anchors` +
    `AnchorCandidates`) stays as the fallback for groups whose per-slot
@@ -298,18 +302,18 @@ the landed architecture is in "Current state" above.
    Removing `minimize_var_group_selector`'s escalation path, `collect_expr_anchors`,
    and `AnchorCandidates::{shallow_literals,deep_cover_tiers}` is gated on a
    tuple-aware read-off for those residual groups (or accepting them as debt).
-4. **`selector_codemod.rs` by-form split + dedup** — the file is ~4.2k lines;
-   splitting by form enables parallel per-form fan-out (do after item 3 reshapes
+3. **`selector_codemod.rs` by-form split + dedup** — the file is ~4.2k lines;
+   splitting by form enables parallel per-form fan-out (do after item 2 reshapes
    the var path). Concrete dedup target: `try_object_read_off`, `try_var_read_off`,
    and `minimize_var_group_selector` each build a near-identical var `render_with`
    closure (iterate `var.decls`, `DECLARATORS_*` holes for non-target slots, holed
    target init); factor one shared slot-render helper parameterized by the
    per-slot init holing.
-5. **Language simplification** (see below) — emit anonymous `OBJECT_PROPS` /
+4. **Language simplification** (see below) — emit anonymous `OBJECT_PROPS` /
    `DECLARATORS` / `CLASS_REST` / `EXPR` / `STMT` as `ANYTHING`. Deferred until
    emission stabilizes (after the cover/keep-shallow paths fully retire), since it
    rewrites emitted selectors and touches many fixtures.
-6. **Dogfood-apply on gaffer-private (ongoing).** Run `synthesize-selectors
+5. **Dogfood-apply on gaffer-private (ongoing).** Run `synthesize-selectors
 --apply` on the real spec after each wave, review for over-pin, and PR the
    beneficial minimized selectors. Operational PR rule: **revert any converted
    selector whose `match` block is >40 lines AND has ≤2 holes** back to a name pin.

--- a/devinfra/js/debundle/readoff_render.rs
+++ b/devinfra/js/debundle/readoff_render.rs
@@ -190,6 +190,21 @@ impl Visit for SpanCollector<'_> {
         }
     }
 
+    fn visit_object_pat(&mut self, pat: &ObjectPat) {
+        // A destructured property key is the same `ObjectKey` anchor as an
+        // object-literal key (the stable source property name). Pin the key
+        // token so the prune keeps it (and holes the rest of the pattern with
+        // `OBJECT_PROPS`), exactly as `visit_object_lit` does for literals.
+        for prop in &pat.props {
+            if let Some((label, key_span)) = object_pat_key_label_span(prop)
+                && self.anchors.contains(&ValueAnchor::ObjectKey(label))
+            {
+                self.keep(key_span);
+            }
+            prop.visit_with(self);
+        }
+    }
+
     fn visit_class_member(&mut self, member: &ClassMember) {
         if let Some((label, key_span)) = class_member_label_span(member)
             && self.anchors.contains(&ValueAnchor::ClassMember(label))
@@ -242,6 +257,14 @@ fn object_key_label_span(prop: &PropOrSpread) -> Option<(String, Span)> {
         Prop::Getter(getter) => prop_name_label_span(&getter.key),
         Prop::Setter(setter) => prop_name_label_span(&setter.key),
         Prop::Method(method) => prop_name_label_span(&method.key),
+    }
+}
+
+fn object_pat_key_label_span(prop: &ObjectPatProp) -> Option<(String, Span)> {
+    match prop {
+        ObjectPatProp::KeyValue(kv) => prop_name_label_span(&kv.key),
+        ObjectPatProp::Assign(assign) => Some((assign.key.id.sym.to_string(), assign.key.id.span)),
+        ObjectPatProp::Rest(_) => None,
     }
 }
 

--- a/devinfra/js/debundle/selector_candidate_index.rs
+++ b/devinfra/js/debundle/selector_candidate_index.rs
@@ -613,6 +613,20 @@ impl Visit for AstFeatureCollector<'_, '_> {
         }
     }
 
+    fn visit_object_pat_prop(&mut self, prop: &ObjectPatProp) {
+        // A destructured property key (`const { …, foo } = obj`, or
+        // `{ foo: localBinding }`) is the source object's stable property name —
+        // the matcher matches it exactly, exactly like an object-literal key —
+        // not the (minified) local binding it introduces. Index it as the same
+        // `ObjectKey` feature so a wide-destructure discriminator can be read off
+        // and pinned. The minified binding itself is alpha-volatile and never a
+        // feature.
+        if let Some(label) = object_pat_key_label(prop) {
+            self.features.insert(SelectorFeature::ObjectKey(label));
+        }
+        prop.visit_children_with(self);
+    }
+
     fn visit_class_member(&mut self, member: &ClassMember) {
         if class_rest_hole_name(member).is_some() {
             return;
@@ -911,6 +925,22 @@ fn object_key_label(prop: &PropOrSpread) -> Option<String> {
         Prop::Setter(prop) => prop_name_label(&prop.key),
         Prop::Method(prop) => prop_name_label(&prop.key),
         _ => None,
+    }
+}
+
+/// The stable property-name label of a destructure-pattern property, or `None`
+/// for the `OBJECT_PROPS`/`ANYTHING` list hole, a rest element, or a computed
+/// key. Mirrors [`object_key_label`] for the object-pattern case.
+fn object_pat_key_label(prop: &ObjectPatProp) -> Option<String> {
+    match prop {
+        ObjectPatProp::KeyValue(kv) => prop_name_label(&kv.key),
+        ObjectPatProp::Assign(assign)
+            if hole_name_for(assign.key.id.sym.as_ref(), OBJECT_PROPS_HOLE_KEYWORD).is_none()
+                && hole_name_for(assign.key.id.sym.as_ref(), ANYTHING_HOLE_KEYWORD).is_none() =>
+        {
+            Some(assign.key.id.sym.to_string())
+        }
+        ObjectPatProp::Assign(_) | ObjectPatProp::Rest(_) => None,
     }
 }
 

--- a/devinfra/js/debundle/selector_codemod.rs
+++ b/devinfra/js/debundle/selector_codemod.rs
@@ -1803,6 +1803,58 @@ fn hole_array(array: &ArrayLit, kept: &BTreeSet<AnchorSpan>) -> ArrayLit {
     holed
 }
 
+/// The `OBJECT_PROPS` destructure-pattern hole prop — a shorthand binding whose
+/// name is the keyword — absorbing a run of dropped destructured properties.
+/// The pattern analog of [`object_props_prop`].
+fn object_props_pat_prop() -> ObjectPatProp {
+    ObjectPatProp::Assign(AssignPatProp {
+        span: DUMMY_SP,
+        key: BindingIdent {
+            id: ident_node(OBJECT_PROPS_HOLE_KEYWORD),
+            type_ann: None,
+        },
+        value: None,
+    })
+}
+
+/// Prune a binding pattern into selector form. An object destructuring pattern
+/// (`const { …, x } = e`) holes down to the props carrying a kept anchor (a
+/// discriminating destructured key) via [`hole_object_pat`]; every other
+/// pattern is kept verbatim — a bare minified binding name is already
+/// alpha-wildcarded by the matcher, so there is nothing to hole.
+fn hole_pat(pat: &Pat, kept: &BTreeSet<AnchorSpan>) -> Pat {
+    match pat {
+        Pat::Object(object) => Pat::Object(hole_object_pat(object, kept)),
+        _ => pat.clone(),
+    }
+}
+
+/// Hole a destructuring object pattern: keep only the props carrying a kept
+/// anchor (the discriminating destructured key), dropping every other run into
+/// an `OBJECT_PROPS` hole. The pattern analog of [`hole_object`]; a kept prop is
+/// retained verbatim (its bound local is alpha-wildcarded by the matcher).
+fn hole_object_pat(object: &ObjectPat, kept: &BTreeSet<AnchorSpan>) -> ObjectPat {
+    let mut props = Vec::new();
+    let mut dropped_run = false;
+    for prop in &object.props {
+        if node_retains_any(prop.span(), kept) {
+            if dropped_run {
+                props.push(object_props_pat_prop());
+                dropped_run = false;
+            }
+            props.push(prop.clone());
+        } else {
+            dropped_run = true;
+        }
+    }
+    if dropped_run {
+        props.push(object_props_pat_prop());
+    }
+    let mut holed = object.clone();
+    holed.props = props;
+    holed
+}
+
 fn hole_object(object: &ObjectLit, kept: &BTreeSet<AnchorSpan>) -> ObjectLit {
     let mut props = Vec::new();
     let mut dropped_run = false;
@@ -1906,6 +1958,7 @@ fn hole_stmt(stmt: &Stmt, kept: &BTreeSet<AnchorSpan>) -> Stmt {
         Stmt::Decl(Decl::Var(var)) => {
             let mut holed = (**var).clone();
             for declarator in &mut holed.decls {
+                declarator.name = hole_pat(&declarator.name, kept);
                 if let Some(init) = &declarator.init {
                     declarator.init = Some(Box::new(hole_expr(init, kept)));
                 }

--- a/devinfra/js/debundle/source_match/holes.rs
+++ b/devinfra/js/debundle/source_match/holes.rs
@@ -124,6 +124,23 @@ pub(crate) fn object_property_list_hole_name(prop_or_spread: &PropOrSpread) -> O
         .or_else(|| anything_hole_name(ident.sym.as_ref()))
 }
 
+/// The name of an object-**pattern** property-list hole (`OBJECT_PROPS` /
+/// `OBJECT_PROPS_*`) if `prop` is one. Mirrors [`object_property_list_hole_name`]
+/// for destructuring patterns: the hole is written as a shorthand binding
+/// (`const { OBJECT_PROPS, x } = …`), parsed as an `ObjectPatProp::Assign` with
+/// no default, and absorbs a run of destructured properties. Anonymous
+/// `ANYTHING` is the sugar form.
+pub(crate) fn object_pat_prop_list_hole_name(prop: &ObjectPatProp) -> Option<&str> {
+    let ObjectPatProp::Assign(assign) = prop else {
+        return None;
+    };
+    if assign.value.is_some() {
+        return None;
+    }
+    let name = assign.key.id.sym.as_ref();
+    hole_name_for(name, OBJECT_PROPS_HOLE_KEYWORD).or_else(|| anything_hole_name(name))
+}
+
 pub(crate) fn anything_hole_name(name: &str) -> Option<&str> {
     (name == ANYTHING_HOLE_KEYWORD).then_some(name)
 }

--- a/devinfra/js/debundle/source_match/matcher.rs
+++ b/devinfra/js/debundle/source_match/matcher.rs
@@ -857,11 +857,7 @@ impl<'a> AstWildcardMatcher<'a> {
             (Pat::Object(needle), Pat::Object(candidate)) => {
                 needle.optional == candidate.optional
                     && needle.type_ann.eq_ignore_span(&candidate.type_ann)
-                    && self.match_slice(
-                        &needle.props,
-                        &candidate.props,
-                        Self::match_object_pat_prop,
-                    )
+                    && self.match_object_pat_prop_slice(&needle.props, &candidate.props)
             }
             (Pat::Assign(needle), Pat::Assign(candidate)) => {
                 self.match_assign_pat(needle, candidate)
@@ -883,6 +879,32 @@ impl<'a> AstWildcardMatcher<'a> {
             && self.match_expr(&needle.right, &candidate.right)
     }
 
+    /// Match a destructuring object-pattern property list. An `OBJECT_PROPS`
+    /// hole (`const { OBJECT_PROPS, x } = …`) splits the needle into fixed
+    /// segments matched as an ordered subsequence with gaps (see
+    /// [`Self::match_list_with_holes`]); with no hole this is an exact
+    /// element-wise match. Mirrors [`Self::match_prop_or_spread_slice`] for the
+    /// object-literal case.
+    fn match_object_pat_prop_slice(
+        &mut self,
+        needle: &[ObjectPatProp],
+        candidate: &[ObjectPatProp],
+    ) -> bool {
+        if needle
+            .iter()
+            .any(|prop| object_pat_prop_list_hole_name(prop).is_some())
+        {
+            self.match_list_with_holes(
+                needle,
+                candidate,
+                |prop| object_pat_prop_list_hole_name(prop).is_some(),
+                Self::match_object_pat_prop,
+            )
+        } else {
+            self.match_slice(needle, candidate, Self::match_object_pat_prop)
+        }
+    }
+
     fn match_object_pat_prop(&mut self, needle: &ObjectPatProp, candidate: &ObjectPatProp) -> bool {
         match (needle, candidate) {
             (ObjectPatProp::KeyValue(needle), ObjectPatProp::KeyValue(candidate)) => {
@@ -896,7 +918,17 @@ impl<'a> AstWildcardMatcher<'a> {
                 self.match_assign_pat_against_key_value_pat(needle, candidate)
             }
             (ObjectPatProp::Assign(needle), ObjectPatProp::Assign(candidate)) => {
-                self.match_binding_binding_ident(&needle.key, &candidate.key)
+                // A shorthand destructure key is a stable source property name:
+                // it matches by exact spelling, like a KeyValue pattern key
+                // (`match_prop_name_exact`), an object-literal key, and the
+                // KeyValue↔Assign cross-forms below — never as an
+                // alpha-renameable binding. `match_binding_binding_ident` then
+                // registers the introduced local in the alpha scope so later
+                // references resolve. Without the exact-spelling gate a wide
+                // `{ OBJECT_PROPS, foo }` selector would alpha-bind `foo` to any
+                // sibling's property and stop discriminating.
+                needle.key.id.sym == candidate.key.id.sym
+                    && self.match_binding_binding_ident(&needle.key, &candidate.key)
                     && self.match_option_box_expr(&needle.value, &candidate.value)
             }
             (ObjectPatProp::Rest(needle), ObjectPatProp::Rest(candidate)) => {
@@ -925,11 +957,7 @@ impl<'a> AstWildcardMatcher<'a> {
             (Pat::Object(needle), Pat::Object(candidate)) => {
                 needle.optional == candidate.optional
                     && needle.type_ann.eq_ignore_span(&candidate.type_ann)
-                    && self.match_slice(
-                        &needle.props,
-                        &candidate.props,
-                        Self::match_ref_object_pat_prop,
-                    )
+                    && self.match_ref_object_pat_prop_slice(&needle.props, &candidate.props)
             }
             (Pat::Assign(needle), Pat::Assign(candidate)) => {
                 self.match_ref_assign_pat(needle, candidate)
@@ -959,6 +987,28 @@ impl<'a> AstWildcardMatcher<'a> {
             && self.match_expr(&needle.right, &candidate.right)
     }
 
+    /// Reference-position analog of [`Self::match_object_pat_prop_slice`] (an
+    /// assignment-target destructure such as `({ OBJECT_PROPS, x } = …)`).
+    fn match_ref_object_pat_prop_slice(
+        &mut self,
+        needle: &[ObjectPatProp],
+        candidate: &[ObjectPatProp],
+    ) -> bool {
+        if needle
+            .iter()
+            .any(|prop| object_pat_prop_list_hole_name(prop).is_some())
+        {
+            self.match_list_with_holes(
+                needle,
+                candidate,
+                |prop| object_pat_prop_list_hole_name(prop).is_some(),
+                Self::match_ref_object_pat_prop,
+            )
+        } else {
+            self.match_slice(needle, candidate, Self::match_ref_object_pat_prop)
+        }
+    }
+
     fn match_ref_object_pat_prop(
         &mut self,
         needle: &ObjectPatProp,
@@ -976,7 +1026,10 @@ impl<'a> AstWildcardMatcher<'a> {
                 self.match_assign_pat_against_key_value_ref_pat(needle, candidate)
             }
             (ObjectPatProp::Assign(needle), ObjectPatProp::Assign(candidate)) => {
-                self.match_binding_ident_as_ref(&needle.key, &candidate.key)
+                // The destructure key is a stable property name (exact spelling);
+                // see the binding-position note in `match_object_pat_prop`.
+                needle.key.id.sym == candidate.key.id.sym
+                    && self.match_binding_ident_as_ref(&needle.key, &candidate.key)
                     && self.match_option_box_expr(&needle.value, &candidate.value)
             }
             (ObjectPatProp::Rest(needle), ObjectPatProp::Rest(candidate)) => {

--- a/devinfra/js/debundle/source_match/parse_validate.rs
+++ b/devinfra/js/debundle/source_match/parse_validate.rs
@@ -69,6 +69,17 @@ impl Visit for UnsupportedAnythingCollector {
         pat.visit_children_with(self);
     }
 
+    fn visit_object_pat_prop(&mut self, prop: &ObjectPatProp) {
+        // `{ ANYTHING }` / `{ OBJECT_PROPS }` is the destructure-pattern
+        // property-list hole (the pattern analog of the object-literal
+        // `OBJECT_PROPS` hole), so the shorthand `ANYTHING` here is supported
+        // sugar, not a stray `ANYTHING` binding identifier.
+        if object_pat_prop_list_hole_name(prop).is_some() {
+            return;
+        }
+        prop.visit_children_with(self);
+    }
+
     fn visit_class_member(&mut self, member: &ClassMember) {
         if is_anything_class_rest_hole(member) {
             return;

--- a/devinfra/js/debundle/source_match/tests.rs
+++ b/devinfra/js/debundle/source_match/tests.rs
@@ -170,6 +170,51 @@ fn prepared_needle_matches_via_table() {
 }"#,
             expected: false,
         },
+        // `OBJECT_PROPS` in a destructure pattern absorbs the other destructured
+        // properties; the kept shorthand key matches by exact spelling.
+        MatchCase {
+            intent: "OBJECT_PROPS pattern hole keeps a discriminating destructure key",
+            selector_src: r#"function readable(ANYTHING) {
+  const { OBJECT_PROPS, target } = ANYTHING;
+  STMT_LIST
+}"#,
+            subject_src: r#"function m(p) {
+  const { a, b, c, target } = p;
+  return use(target);
+}"#,
+            expected: true,
+        },
+        // The destructure key is the stable property name (exact spelling), so a
+        // wide destructure lacking it does not match — without exact-key matching
+        // the shorthand key would alpha-bind to any sibling property and stop
+        // discriminating.
+        MatchCase {
+            intent: "destructure-key pattern hole discriminates on the exact key name",
+            selector_src: r#"function readable(ANYTHING) {
+  const { OBJECT_PROPS, target } = ANYTHING;
+  STMT_LIST
+}"#,
+            subject_src: r#"function m(p) {
+  const { a, b, c } = p;
+  return use(a);
+}"#,
+            expected: false,
+        },
+        // A KeyValue destructure (`{ key: minifiedBinding }`, the realistic
+        // minified form) discriminates on the exact key through the same pattern
+        // list-hole routing, while the bound local stays alpha-renameable.
+        MatchCase {
+            intent: "OBJECT_PROPS pattern hole keeps a KeyValue destructure key, binding stays alpha",
+            selector_src: r#"function readable(ANYTHING) {
+  const { OBJECT_PROPS, target: bound } = ANYTHING;
+  STMT_LIST
+}"#,
+            subject_src: r#"function m(p) {
+  const { a: x, target: y } = p;
+  return use(y);
+}"#,
+            expected: true,
+        },
     ]);
 }
 

--- a/devinfra/js/debundle/source_match/wildcard_idents.rs
+++ b/devinfra/js/debundle/source_match/wildcard_idents.rs
@@ -160,4 +160,19 @@ impl Visit for WildcardIdentCollector {
         }
         prop_or_spread.visit_children_with(self);
     }
+
+    fn visit_object_pat_prop(&mut self, prop: &ObjectPatProp) {
+        // An `OBJECT_PROPS` hole in destructure-pattern position
+        // (`const { OBJECT_PROPS, x } = …`). Routed to the same
+        // ordered-subsequence property matching as the object-literal hole; the
+        // shorthand-binding token must not be alpha-canonicalized as a real
+        // binding.
+        if let Some(hole_name) = object_pat_prop_list_hole_name(prop) {
+            self.idents
+                .object_property_lists
+                .insert(hole_name.to_string());
+            return;
+        }
+        prop.visit_children_with(self);
+    }
 }

--- a/devinfra/js/debundle/source_match_holes.rs
+++ b/devinfra/js/debundle/source_match_holes.rs
@@ -18,7 +18,8 @@
 //! `CASE_REST`, and `DECLARATORS` are variable-length list holes: `ARGS`
 //! absorbs a run of call/new arguments, `STMT_LIST` absorbs a run of block
 //! statements (or top-level anonymous selector statements), `OBJECT_PROPS`
-//! absorbs a run of object literal properties/spreads, `CLASS_REST` absorbs a
+//! absorbs a run of object literal properties/spreads (or destructured
+//! properties in an object binding/assignment pattern), `CLASS_REST` absorbs a
 //! run of class members, `CASE_REST` absorbs a run of `case`/`default`
 //! clauses inside one `switch` statement, and `DECLARATORS` absorbs a run of
 //! variable declarators inside one `var`/`let`/`const` declaration.
@@ -37,7 +38,8 @@
 //! position it behaves like `EXPR`; as a bare expression statement it behaves
 //! like `STMT`; as a variable declarator name it behaves like `DECLARATORS`;
 //! as a non-declarator binding pattern it matches any pattern; as an
-//! object-literal shorthand property it absorbs object properties/spreads; as
+//! object-literal shorthand property — or a destructure-pattern shorthand
+//! property — it absorbs object/destructured properties/spreads; as
 //! a class field with no initializer it behaves like `CLASS_REST`. Use the
 //! typed spellings when a named hole is helpful or when the position would
 //! otherwise be ambiguous. `STMT_LIST` must be checked before `STMT`, since


### PR DESCRIPTION
A binding whose discriminator is a destructured property key
(`function C(props) { const { …, x } = props; … }`) previously bailed
with "no sparse selector": the candidate/shape index did not collect
destructure-pattern keys as anchors, and the renderer could not hole an
ObjectPat. Both gaps are closed.

Producer:
- selector_candidate_index: collect ObjectPat property keys as the same
  stable `ObjectKey` feature as object-literal keys (shorthand and
  KeyValue), so the read-off can pick a destructured key as the anchor.
- readoff_render: pin the destructure-key span for an `ObjectKey` anchor.
- selector_codemod: hole an ObjectPat declarator name — keep the anchored
  property, absorb the rest into `OBJECT_PROPS`, hole the RHS to ANYTHING.

Matcher (prove-gate):
- holes/matcher: route object-pattern props through `match_list_with_holes`
  when an `OBJECT_PROPS` hole is present (binding and assignment-target
  positions).
- matcher: match a shorthand `(Assign, Assign)` destructure key by exact
  spelling (the stable source property name), consistent with the KeyValue
  and cross-form paths, so a `{ OBJECT_PROPS, x }` selector discriminates
  instead of alpha-binding `x` to any sibling property.
- wildcard_idents/parse_validate: recognize and allow the pattern-position
  `OBJECT_PROPS`/`ANYTHING` list hole.

Unignores the `wide_destructure_block` e2e fixture
(`function C(ANYTHING) { const { OBJECT_PROPS, x } = ANYTHING; STMT_LIST; }`)
and clears backlog item 2 in plans/readoff_minimization.md.

BAZEL_TEST_INVOCATIONS=buildbuddy:01c5d146-c8bf-49f1-a961-31cf610f99e2,buildbuddy:aff72943-2cec-4d9d-a0b6-bbf6ff358422

https://claude.ai/code/session_01UHpMEZhSoC1xDvHW8baZeQ