### PR TITLE
debundle: reprioritize trackers + remove completed items

### DIFF
--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -19,6 +19,29 @@ hold category-specific evidence:
 - <perf/> — measured performance notes. Update these from actual profiles
   before major matcher/index rewrites.
 
+**Current focus (2026-06-16 reprioritization).** The read-off **minimizer is
+complete** — every form migrated, interior holing + multi-feature value-anchor
+cover landed, the branch-and-bound cover deleted, the `render_var_slots` dedup
+done, and the enclosing-context residual handled; only a low-priority polish tail
+remains in <plans/readoff_minimization.md>. The active frontier has shifted to the
+**automation product flows**, in dispatch order:
+
+1. **Dogfood-apply on gaffer-private** — capture the landed minimizer wins on the
+   real spec (fragile name-pins → robust `source_match`, re-measure debt). Highest
+   value: it validates everything and is the reason the minimizer exists.
+2. **Spec repair from diagnostics (P0.3)** — build on the landed keep-going
+   diagnostics (#2302) to propose mechanically-proven patch plans.
+3. **Patch-plan / dry-run / explain infrastructure (P0.1)** — the apply-with-review
+   substrate the repair + bulk-codemod flows pipe through.
+4. **Version-port (P1.1) and new-app bootstrap (P1.2)** — the remaining
+   `automated_spec_workflows.md` milestones.
+5. **Excalidraw public live-browser smoke (P1.7)** — public-CI repro leverage,
+   independent of all the above.
+
+The minimizer polish tail (keep-shallow group-cover retirement, language
+simplification) is maintenance-priority — pick up opportunistically, not ahead of
+the frontier above.
+
 Prefer dispatching work in this order. Large downstream spec migrations should
 lean on tooling generated from this queue instead of hand-authored YAML.
 Interactive agent-facing commands should target under 10 seconds on warmed
@@ -30,15 +53,11 @@ progress output and a resumable or cacheable plan.
 
 One-line status for each `plans/` design doc; this is the discovery index.
 
-- <plans/readoff_minimization.md> — **active.** Read-off selector minimizer
-  (chunk-wide AST-shape index). Layer-1 index, function/object/class/var read-off,
-  key-set minimization, (adjacent-function + general) co-occurrence grouping,
-  multi-target var binding-group read-off, whole-body interior holing (incl. the
-  multi-feature value-anchor cover), wide destructure, callee/arg holing,
-  enclosing-context residual anchoring, prove-gate-via-index, whole-spec perf
-  validation (W4), and the branch-and-bound cover deletion landed; keep-shallow
-  group-cover retirement, by-form split, and language simplification open. Holds
-  its own current-state + backlog.
+- <plans/readoff_minimization.md> — **core complete.** Read-off selector
+  minimizer (chunk-wide AST-shape index); every form migrated and the cover
+  deleted. Open: dogfood value-capture (top priority) + a polish tail (keep-shallow
+  group-cover retirement, language simplification). Holds its own current-state +
+  backlog.
 - <plans/readoff_algorithm_research.md> + <plans/readoff_research/> — **reference
   (complete).** Literature spike that gates the read-off design; durable, not a
   TODO.
@@ -58,18 +77,7 @@ propose`.
 
 ### P0 — automation-first selector workflows
 
-1. **Forward-compatible minimized selector synthesis + shared source index.**
-   Owned by <plans/readoff_minimization.md>: the read-off AST-shape index
-   (`shape_index.rs`, superseting `selector_candidate_index.rs`),
-   function/object/class/var read-off, literal/regex anchors, hole-based
-   minimization, multi-target var binding-group read-off, co-occurrence grouping,
-   whole-body interior holing (incl. the multi-feature value-anchor cover), wide
-   destructure, callee/arg holing, enclosing-context residual anchoring, the
-   prove-gate perf fix, whole-spec validation, and the branch-and-bound cover
-   deletion have landed; keep-shallow group-cover retirement,
-   `selector_codemod.rs` by-form split, and language simplification are in that
-   plan's backlog. Don't duplicate its design or status here.
-2. **Patch-plan based bulk codemods.** Extend `debundle spec selector-codemod`
+1. **Patch-plan based bulk codemods.** Extend `debundle spec selector-codemod`
    or add adjacent verbs so every broad rewrite can emit a dry-run patch plan,
    apply with filters, and explain every skipped candidate. (Selector
    minimization at synthesis time, unique-literal-initializer → structural
@@ -78,25 +86,23 @@ propose`.
    `binding_groups` is the co-occurrence-grouping item in the read-off backlog.
    The open work here is the dry-run / patch-plan / explain-every-skip
    infrastructure that the rewrite classes pipe through.)
-3. **Selector diagnostics as machine-readable reports.** The keep-going JSON
-   report (`debundle spec validate --keep-going --format text|json|ndjson`)
-   classifies unresolved, ambiguous, and duplicate-claim selector failures with
-   module path, export name, selector kind, target binding, first mismatch,
-   nearest candidates, and recommended next action; the shared contract lives in
-   `selector_diagnostics.rs`. Still open: emit structured entries for
-   anonymous-statement `source_match` failures and blocker comments (today the
-   report carries them only as a `coverage_notes` gap), and add the
+2. **Selector diagnostics — remaining extensions.** The keep-going JSON report
+   (`debundle spec validate --keep-going --format text|json|ndjson`) landed
+   (#2302; shared contract in `selector_diagnostics.rs`) and classifies
+   unresolved / ambiguous / duplicate-claim failures with full provenance. Still
+   open: structured entries for anonymous-statement `source_match` failures and
+   blocker comments (today carried only as a `coverage_notes` gap), and the
    free-readable-identifier class (P1.5) so `alpha_all` readable names that are
    free references rather than local binders are reported, not silently dropped.
-4. **Spec repair from diagnostics.** Add a workflow that consumes the keep-going
+3. **Spec repair from diagnostics.** Add a workflow that consumes the keep-going
    report, proposes mechanically proven patch plans for no-match, ambiguous,
    duplicate-claim, and unsupported-selector cases, and leaves residual semantic
    decisions as explicit tasks.
-5. **Orthogonal CLI surface.** Converge new automation on the
+4. **Orthogonal CLI surface.** Converge new automation on the
    inventory/plan/apply/validate/explain model in
    <plans/automated_spec_workflows.md>. Avoid one-off command shapes that cannot
    pipe a dry-run plan into review, apply, validation, and repair.
-6. **Workflow latency budget.** Interactive commands target <10s on warmed
+5. **Workflow latency budget.** Interactive commands target <10s on warmed
    inputs; >60s is a blocker unless explicitly an offline/profile mode with
    progress output and a resumable plan. The whole-spec minimize budget and the
    measured real-chunk numbers live in <plans/readoff_minimization.md> (W4) and

--- a/devinfra/js/debundle/plans/readoff_minimization.md
+++ b/devinfra/js/debundle/plans/readoff_minimization.md
@@ -1,9 +1,13 @@
 # Plan: read-off selector minimization
 
-Status: active. The agreed target architecture for the debundle selector
-minimizer — a single chunk-wide AST-shape index that selectors are **read off**
-rather than searched. This doc is the current state plus the open backlog; it is
-not a changelog. Sibling planning docs are indexed from <../TODO.md>.
+Status: **core complete** — every form (function/class/object/var + multi-target
+group) is migrated, interior holing + multi-feature value-anchor cover landed, the
+branch-and-bound cover is deleted, and the `render_var_slots` dedup is done. What
+remains is **dogfood value-capture** (apply to the real spec) plus a low-priority
+polish tail. The architecture is a single chunk-wide AST-shape index that
+selectors are **read off** rather than searched. This doc is the current state
+plus the open backlog; it is not a changelog. Sibling planning docs are indexed
+from <../TODO.md>; the cross-program priority is in <../TODO.md>'s "Current focus".
 
 ## Motivation
 
@@ -284,30 +288,31 @@ body interior holing + anchoring). Re-measure this split after each wave lands.
 
 ## Backlog (open only)
 
-Severity-ordered minimality work. Counts are members in a representative
-real-spec sample (5,556 selectors); the non-minimal pattern catalog drives this
-and is encoded as disabled E2E cases. Completed items are removed, not annotated;
-the landed architecture is in "Current state" above.
+Priority-ordered. With the minimizer core complete, **value-capture leads**;
+the rest is a maintenance-priority polish tail. Counts are members in a
+representative real-spec sample (5,556 selectors). Completed items are removed,
+not annotated; the landed architecture is in "Current state" above.
 
-1. **Retire the keep-shallow group cover.** The multi-target var binding-group
-   read-off (`try_var_group_read_off`) landed, but the keep-shallow path
-   (`minimize_var_group_selector`'s escalation over `collect_expr_anchors` +
+1. **Dogfood-apply on gaffer-private (ongoing — top priority).** Run
+   `synthesize-selectors --apply` on the real spec to convert the now-large set of
+   fragile name-pins into robust `source_match` selectors, review for over-pin, and
+   PR the beneficial ones; re-measure the fragile-pin debt. This is why the
+   minimizer exists, and it validates every landed capability. Operational PR rule:
+   **revert any converted selector whose `match` block is >40 lines AND has ≤2
+   holes** back to a name pin. Keep pin-compatible (gaffer validates with a _pinned_
+   debundle release) and regen the pipeline goldens.
+2. **Retire the keep-shallow group cover** (cleanup). The multi-target var
+   binding-group read-off (`try_var_group_read_off`) landed, but the keep-shallow
+   path (`minimize_var_group_selector`'s escalation over `collect_expr_anchors` +
    `AnchorCandidates`) stays as the fallback for groups whose per-slot
    single-binding view cannot single a slot out (a value shared across sibling
    _statements_ resolves only as a tuple, e.g. `binding_group_declarators`).
-   Removing `minimize_var_group_selector`'s escalation path, `collect_expr_anchors`,
-   and `AnchorCandidates::{shallow_literals,deep_cover_tiers}` is gated on a
-   tuple-aware read-off for those residual groups (or accepting them as debt).
-2. **Language simplification** (see below) — emit anonymous `OBJECT_PROPS` /
+   Removing it is gated on a tuple-aware read-off for those residual groups (or
+   accepting them as debt).
+3. **Language simplification** (see below) — emit anonymous `OBJECT_PROPS` /
    `DECLARATORS` / `CLASS_REST` / `EXPR` / `STMT` as `ANYTHING`. Deferred until
-   emission stabilizes (after the cover/keep-shallow paths fully retire), since it
-   rewrites emitted selectors and touches many fixtures.
-3. **Dogfood-apply on gaffer-private (ongoing).** Run `synthesize-selectors
---apply` on the real spec after each wave, review for over-pin, and PR the
-   beneficial minimized selectors. Operational PR rule: **revert any converted
-   selector whose `match` block is >40 lines AND has ≤2 holes** back to a name pin.
-   Keep pin-compatible (gaffer validates with a _pinned_ debundle release) and
-   regen the pipeline goldens. Each capability above re-applies here as it lands.
+   emission stabilizes (after the keep-shallow path retires), since it rewrites
+   emitted selectors and touches many fixtures.
 
 ## Orchestration & process notes
 


### PR DESCRIPTION
## Summary

Doc-only tracker reprioritization + completed-item cleanup, after the read-off minimizer reached core-complete (the `render_var_slots` dedup #2322 was the last piece).

- **Reprioritized** `TODO.md` and `plans/readoff_minimization.md`: the minimizer is done; the active frontier is the **automation product flows** — dogfood-apply (value capture, top), spec-repair on the keep-going diagnostics, patch-plan/dry-run/explain infra, version-port + new-app bootstrap, and the Excalidraw public smoke. The minimizer polish tail (keep-shallow retirement, language simplification, enclosing-context residual #2315) drops to maintenance-priority.
- **Removed completed items** from `TODO.md`: dropped the complete P0.1 (minimizer), renumbered the P0 queue, trimmed P0.2 (diagnostics) to its open extensions, and simplified the plan-index line to "core complete" + open tail.
- Readoff backlog reordered so dogfood value-capture leads.

## Issue housekeeping (already done)
- Closed **#2310** (#2321), **#2311** (#2318), **#2312** (dedup #2322; by-form split dropped — file now 2667 lines).
- Open: **#2315** (enclosing-context residual).

No code change.

https://claude.ai/code/session_011YQabfZ5jVoFSETefd27Bg

---
_Generated by [Claude Code](https://claude.ai/code/session_011YQabfZ5jVoFSETefd27Bg)_