### PR TITLE
debundle: language simplification — emit ANYTHING for redundant object/class run-holes

### DIFF
--- a/devinfra/js/debundle/e2e/selector_codemod_cli_test.rs
+++ b/devinfra/js/debundle/e2e/selector_codemod_cli_test.rs
@@ -898,7 +898,8 @@ fn synthesize_selectors_minimizes_binding_group_to_needed_slot_anchors() {
 // object-bearing call (`makeConfig({…})`) reads its minimal anchor off the shape
 // index. Each entry's value (`computeValue("selected-beta")`) carries a globally
 // unique string, so the read-off pins ONE discriminating `key: value` and holes
-// every sibling key to `OBJECT_PROPS` — sparser than the keep-shallow "keep all
+// every sibling key to the object-property run hole (emitted as `ANYTHING`) —
+// sparser than the keep-shallow "keep all
 // keys" output and sparser than the {betaKey, gammaKey} key-set the B&B set-cover
 // would compute (a unique value beats a multi-key presence cover). It still
 // resolves uniquely to the intended binding. The min-cover guarantee still backs
@@ -931,9 +932,11 @@ fn synthesize_selectors_var_object_keys_resolve_uniquely() {
         .as_str()
         .unwrap();
     // One discriminating `key: value` with a globally-unique string value is the
-    // minimal read-off anchor; the rest collapse to `OBJECT_PROPS`.
+    // minimal read-off anchor; the rest collapse to the object-property run hole,
+    // emitted as `ANYTHING` (the run-absorber form the minimizer now prefers in
+    // object-property position).
     assert!(
-        match_source.contains("selected-") && match_source.matches("OBJECT_PROPS").count() >= 1,
+        match_source.contains("selected-") && match_source.matches("ANYTHING").count() >= 1,
         "a single discriminating value anchor should remain, rest holed:\n{match_source}"
     );
 }

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/binding_group_key_set_readoff/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/binding_group_key_set_readoff/expected_match.js
@@ -1,3 +1,3 @@
-const ErrorBadge = { OBJECT_PROPS, logViewer: ANYTHING, OBJECT_PROPS },
-  WarningBadge = { OBJECT_PROPS, alertChip: ANYTHING, OBJECT_PROPS },
+const ErrorBadge = { ANYTHING, logViewer: ANYTHING, ANYTHING },
+  WarningBadge = { ANYTHING, alertChip: ANYTHING, ANYTHING },
   DECLARATORS_AFTER = null;

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/binding_group_partition/expected_group_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/binding_group_partition/expected_group_match.js
@@ -1,3 +1,3 @@
-const SelectedPrimary = ANYTHING(ARGS, { OBJECT_PROPS, enabled: true }),
-  SelectedSecondary = ANYTHING("secondary", { OBJECT_PROPS, enabled: true }),
+const SelectedPrimary = ANYTHING(ARGS, { ANYTHING, enabled: true }),
+  SelectedSecondary = ANYTHING("secondary", { ANYTHING, enabled: true }),
   DECLARATORS_AFTER = null;

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/binding_group_partition/expected_standalone_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/binding_group_partition/expected_standalone_match.js
@@ -1,4 +1,4 @@
 const SelectedStandalone = ANYTHING(ARGS, {
   kind: "panel",
-  OBJECT_PROPS,
+  ANYTHING,
 });

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/class_among_many_siblings/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/class_among_many_siblings/expected_match.js
@@ -1,12 +1,12 @@
 class SelectedService {
-  CLASS_REST;
+  ANYTHING;
   async fetchSnapshot(ANYTHING) {
     const response = await ANYTHING.request({
-      OBJECT_PROPS,
+      ANYTHING,
       accept: "application/vnd.uniqueDiscriminator+json",
-      OBJECT_PROPS,
+      ANYTHING,
     });
     STMT_LIST;
   }
-  CLASS_REST;
+  ANYTHING;
 }

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/class_body/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/class_body/expected_match.js
@@ -1,8 +1,8 @@
 class SelectedWidget {
-  CLASS_REST;
+  ANYTHING;
   render(ANYTHING) {
     STMT_LIST;
     return ANYTHING.format("stable", ARGS);
   }
-  CLASS_REST;
+  ANYTHING;
 }

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/deeply_nested_call_args/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/deeply_nested_call_args/expected_match.js
@@ -2,7 +2,7 @@ const SelectedView = ANYTHING(
   ANYTHING(
     ANYTHING({
       mode: "uniqueDiscriminatorMode",
-      OBJECT_PROPS,
+      ANYTHING,
     }),
     ARGS
   )

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/grouped_enum_objects/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/grouped_enum_objects/expected_match.js
@@ -1,7 +1,7 @@
 const DECLARATORS_BEFORE = null,
   SelectedPalette = {
-    OBJECT_PROPS,
+    ANYTHING,
     accent: "uniqueDiscriminatorAccent",
-    OBJECT_PROPS,
+    ANYTHING,
   },
   DECLARATORS_AFTER = null;

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/interior_object_arg_holing/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/interior_object_arg_holing/expected_match.js
@@ -1,3 +1,3 @@
 function SelectedMover(ANYTHING) {
-  ANYTHING.run([{ OBJECT_PROPS, mode: "uniqueDiscriminatorMode", OBJECT_PROPS }]);
+  ANYTHING.run([{ ANYTHING, mode: "uniqueDiscriminatorMode", ANYTHING }]);
 }

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/long_literal_value_anchor/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/long_literal_value_anchor/expected_match.js
@@ -1,5 +1,5 @@
 const SelectedDefinition = {
-  OBJECT_PROPS,
+  ANYTHING,
   rank: 3,
-  OBJECT_PROPS,
+  ANYTHING,
 };

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/nested_async_try/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/nested_async_try/expected_match.js
@@ -1,7 +1,7 @@
 async function SelectedLoader(ANYTHING, ANYTHING) {
   try {
     STMT_LIST;
-    await ANYTHING.fetch(ARGS, { OBJECT_PROPS, trace: ANYTHING });
+    await ANYTHING.fetch(ARGS, { ANYTHING, trace: ANYTHING });
     STMT_LIST;
   } catch (ANYTHING) {
     STMT_LIST;

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/object_key_set_group/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/object_key_set_group/expected_match.js
@@ -1,6 +1,6 @@
 const ErrorPanelStyles = {
-    OBJECT_PROPS,
+    ANYTHING,
     logViewer: ANYTHING,
-    OBJECT_PROPS,
+    ANYTHING,
   },
   DECLARATORS_AFTER = null;

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/object_key_set_subset/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/object_key_set_subset/expected_match.js
@@ -1,7 +1,7 @@
 const TargetShape = {
-  OBJECT_PROPS,
+  ANYTHING,
   alpha: ANYTHING,
-  OBJECT_PROPS,
+  ANYTHING,
   delta: ANYTHING,
-  OBJECT_PROPS,
+  ANYTHING,
 };

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/object_keys_over_pinned/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/object_keys_over_pinned/expected_match.js
@@ -1,5 +1,5 @@
 const SelectedLabels = {
-  OBJECT_PROPS,
+  ANYTHING,
   10: "uniqueDiscriminatorLabel",
-  OBJECT_PROPS,
+  ANYTHING,
 };

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/object_nested_value_dict/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/object_nested_value_dict/expected_match.js
@@ -1,5 +1,5 @@
 const SelectedRegistry = {
-  OBJECT_PROPS,
-  4: { audience: ["uniqueDiscriminatorAudience"], OBJECT_PROPS },
-  OBJECT_PROPS,
+  ANYTHING,
+  4: { audience: ["uniqueDiscriminatorAudience"], ANYTHING },
+  ANYTHING,
 };

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/object_property_literals/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/object_property_literals/expected_match.js
@@ -1,4 +1,4 @@
 const SelectedConfig = ANYTHING({
-  OBJECT_PROPS,
+  ANYTHING,
   onClick: ANYTHING,
 });

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/sibling_class_declaration_group/expected_group_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/sibling_class_declaration_group/expected_group_match.js
@@ -1,16 +1,16 @@
 class selectedAlphaCard {
   kind = "uniqueAlphaCard";
-  CLASS_REST;
+  ANYTHING;
 }
 class selectedBetaCard {
   kind = "uniqueBetaCard";
-  CLASS_REST;
+  ANYTHING;
 }
 class selectedGammaCard {
   kind = "uniqueGammaCard";
-  CLASS_REST;
+  ANYTHING;
 }
 class selectedDeltaCard {
   kind = "uniqueDeltaCard";
-  CLASS_REST;
+  ANYTHING;
 }

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/sibling_subclass_hierarchy/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/sibling_subclass_hierarchy/expected_match.js
@@ -1,4 +1,4 @@
 class SelectedShape extends ANYTHING {
   kind = "uniqueDiscriminatorShape";
-  CLASS_REST;
+  ANYTHING;
 }

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/single_target_class_whole_body/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/single_target_class_whole_body/expected_match.js
@@ -1,8 +1,8 @@
 class SelectedRunner {
-  CLASS_REST;
+  ANYTHING;
   applyChange(ANYTHING) {
     STMT_LIST;
     ANYTHING.set("running");
   }
-  CLASS_REST;
+  ANYTHING;
 }

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/wide_destructure_block/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/wide_destructure_block/expected_match.js
@@ -1,4 +1,4 @@
 function SelectedComponent(ANYTHING) {
-  const { OBJECT_PROPS, uniqueDiscriminatorProp } = ANYTHING;
+  const { ANYTHING, uniqueDiscriminatorProp } = ANYTHING;
   STMT_LIST;
 }

--- a/devinfra/js/debundle/minimize/class.rs
+++ b/devinfra/js/debundle/minimize/class.rs
@@ -3,7 +3,7 @@
 use std::collections::BTreeSet;
 
 use anyhow::Result;
-use source_match_holes::CLASS_REST_HOLE_KEYWORD;
+use source_match_holes::ANYTHING_HOLE_KEYWORD;
 use swc_common::{DUMMY_SP, Spanned};
 use swc_ecma_ast::*;
 
@@ -17,8 +17,9 @@ use crate::{
 };
 
 /// Minimal anchor cover for a single-target class: render the class keeping
-/// only members (and member-body statements) that carry a chosen anchor, with
-/// `CLASS_REST` for dropped member runs, and cover sibling classes.
+/// only members (and member-body statements) that carry a chosen anchor, with an
+/// `ANYTHING` class-member run hole for dropped member runs, and cover sibling
+/// classes.
 pub(crate) fn minimize_class_selector(
     index: &ChunkSelectorIndex,
     class: &Class,
@@ -46,17 +47,22 @@ pub(crate) fn minimize_class_selector(
     // functions and objects do: the holed scaffold pins the class kind plus
     // `extends ANYTHING`, and value anchors (a member name, a literal or callee
     // inside a member body) map to their token spans so only the member runs
-    // carrying them survive between `CLASS_REST` holes. A class the read-off
+    // carrying them survive between `ANYTHING` class-member run holes. A class the read-off
     // cannot single out through its own value features returns `None` and is
     // reported as debt (never a full-AST pin).
     render_via_read_off(index, decl, target, &render_with)
 }
 
-/// A `CLASS_REST;` class-field hole that absorbs a run of dropped members.
+/// A class-member run-absorber hole, emitted as an `ANYTHING;` no-init field. In
+/// class-member position `ANYTHING` is a run-absorber identical to the
+/// (still-accepted) `CLASS_REST` keyword — `is_class_rest_hole` matches both — so
+/// we emit the shorter, position-polymorphic `ANYTHING` (the "prefer ANYTHING
+/// where the context is unambiguous" emission rule). Hand-written input selectors
+/// may still spell it `CLASS_REST`.
 fn class_rest_member() -> ClassMember {
     ClassMember::ClassProp(ClassProp {
         span: DUMMY_SP,
-        key: PropName::Ident(IdentName::new(CLASS_REST_HOLE_KEYWORD.into(), DUMMY_SP)),
+        key: PropName::Ident(IdentName::new(ANYTHING_HOLE_KEYWORD.into(), DUMMY_SP)),
         value: None,
         type_ann: None,
         is_static: false,

--- a/devinfra/js/debundle/minimize/mod.rs
+++ b/devinfra/js/debundle/minimize/mod.rs
@@ -3,9 +3,12 @@
 //! A selector is the target rendered with a *retention set*: the byte spans of
 //! the concrete tokens (literals, member/property names, callees, object keys)
 //! the selector pins. A node renders concretely iff a kept span lies inside it;
-//! every other position is holed — `ANYTHING` for a bare expression, and the
-//! run holes `STMT_LIST` / `OBJECT_PROPS` / `CLASS_REST` for dropped statement /
-//! object-property / class-member runs.
+//! every other position is holed — `ANYTHING` for a bare expression and for the
+//! object-property / class-member run holes (emitted as `ANYTHING`, the
+//! run-absorber form their detector predicates fall back to), and the
+//! load-bearing run holes `STMT_LIST` / `ARGS` / `CASE_REST` for dropped
+//! statement / argument / switch-case runs (where `ANYTHING` would collapse to
+//! an arity-exact single-node hole).
 //!
 //! Single targets (function, class, object, and non-object var) read their
 //! minimal anchor set off the chunk-wide shape index (`render_via_read_off` /

--- a/devinfra/js/debundle/plans/readoff_minimization.md
+++ b/devinfra/js/debundle/plans/readoff_minimization.md
@@ -173,11 +173,33 @@ exist in `source_match_holes.rs` and the matcher (`match_list_with_holes`):
 `STMT_LIST`, `ARGS`, `OBJECT_PROPS`, `DECLARATORS`, `CLASS_REST`, and `CASE_REST`
 (switch-case-run — closes the survey's inexpressible many-arm-`switch` shape).
 `OBJECT_PROPS` absorbs object-literal properties **and** destructure-pattern
-properties (`const { OBJECT_PROPS, x } = …`), where a shorthand pattern key is
+properties (`const { ANYTHING, x } = …`), where a shorthand pattern key is
 matched by exact spelling (the stable source property name) rather than as an
 alpha-renameable binding, so it discriminates. Regex-over-string-literal anchors
 (`STR_LITERAL_MATCHING_RE`) fire for stable-prefix/volatile-tail strings
 (trailing hex/digit runs).
+
+**Language simplification — `ANYTHING` for unambiguous run holes (landed).**
+`ANYTHING` is parse-position-polymorphic and is a run-absorber in exactly the
+positions whose list-hole detector predicate carries an `ANYTHING` fallback
+(`object_property_list_hole_name`, `object_pat_prop_list_hole_name`,
+`is_class_rest_hole`). The renderer therefore emits the anonymous object-property
+and class-member run holes as bare `ANYTHING` (`object_props_prop` /
+`object_props_pat_prop` in `render.rs`, `class_rest_member` in `minimize/class.rs`)
+instead of the `OBJECT_PROPS` / `CLASS_REST` keywords — sparser and one less
+keyword to read. Anonymous `EXPR` / `STMT` were already emitted as bare `ANYTHING`
+(`anything_expr`; `STMT_LIST` is the only statement-run hole). **Deviation:**
+`ARGS`, `STMT_LIST`, and `CASE_REST` stay load-bearing keywords — a bare `ANYTHING`
+in those positions collapses to an arity-exact single-node `EXPR`/`STMT` hole (or,
+for `CASE_REST`, has no spelling), so emitting `ANYTHING` there would be a
+correctness regression. `OBJECT_PROPS` / `CLASS_REST` / suffixed `DECLARATORS_*`
+remain accepted-but-not-emitted sugar: the matcher and `holes_present` still
+recognize them, so hand-written input selectors keep working, and the renderer
+never emits an anonymous `DECLARATORS` (it always carries a positional
+`_BEFORE`/`_BETWEEN`/`_AFTER` suffix). Equivalence is pinned by the matcher
+interchangeability tests in `syntactic_holes_test.rs`
+(`{object_props,declarators,class_rest}_and_anything_are_interchangeable_run_absorbers`)
+and the re-baselined `selector_minimizer_expectations` fixtures.
 
 **Strangler-fig boundary.** The matcher-driven branch-and-bound cover search
 (`minimize_via_retention`, `cover_competitors`, `min_set_cover`, and the
@@ -307,12 +329,9 @@ not annotated; the landed architecture is in "Current state" above.
    `AnchorCandidates`) stays as the fallback for groups whose per-slot
    single-binding view cannot single a slot out (a value shared across sibling
    _statements_ resolves only as a tuple, e.g. `binding_group_declarators`).
-   Removing it is gated on a tuple-aware read-off for those residual groups (or
-   accepting them as debt).
-3. **Language simplification** (see below) — emit anonymous `OBJECT_PROPS` /
-   `DECLARATORS` / `CLASS_REST` / `EXPR` / `STMT` as `ANYTHING`. Deferred until
-   emission stabilizes (after the keep-shallow path retires), since it rewrites
-   emitted selectors and touches many fixtures.
+   Removing `minimize_var_group_selector`'s escalation path, `collect_expr_anchors`,
+   and `AnchorCandidates::{shallow_literals,deep_cover_tiers}` is gated on a
+   tuple-aware read-off for those residual groups (or accepting them as debt).
 
 ## Orchestration & process notes
 
@@ -349,7 +368,11 @@ Lower priority / opportunistic:
   (currently trailing hex/digit only).
 - Skeleton-feature stability: refine further by multiplicity / depth.
 
-## Language simplification: prefer `ANYTHING` where the context is unambiguous
+## Reference: `ANYTHING` redundancy by hole position
+
+This is the matcher-behavior reference behind the landed "prefer `ANYTHING` where
+the context is unambiguous" emission (summarized under "Current state"): which
+keywords the renderer now emits as bare `ANYTHING` and which stay load-bearing.
 
 `ANYTHING` is parse-position-polymorphic (see `source_match_holes.rs`), but its
 behavior is **not** uniformly "the list hole legal here". Verified against the
@@ -397,38 +420,31 @@ ordered-subsequence `match_list_with_holes` path. `case CASE_REST:` has no
 | `STMT_LIST`    | **NO**                          | block statement                    | `ANYTHING;` stmt = single `STMT` (arity-exact), NOT a run-absorber. Diverges on length ≠ 1. Tests: `stmt_list_run_absorber_is_not_redundant_with_anything_single_stmt` (diverge), `stmt_and_anything_agree_on_a_single_statement_block` (agree).    |
 | `CASE_REST`    | **NO**                          | empty `switch` case clause         | No `ANYTHING` spelling exists for a case-list hole; the marker is a `case` clause, not an identifier expression. Test: `case_rest_is_not_expressible_via_anything`.                                                                                 |
 
-### Emission rule (the deferred change)
+### Emission rule (landed)
 
-Mechanical and unambiguous given the table — for the minimizer/renderer
-(`selector_codemod.rs` / `readoff_render.rs`), in position **P**:
+Mechanical and unambiguous given the table — the renderer (`render.rs` /
+`minimize/class.rs`), in position **P**:
 
-- **OBJECT_PROPS / DECLARATORS / CLASS_REST**: an _anonymous_ (unsuffixed) hole
-  in P may be emitted as `ANYTHING` instead of the keyword. A **named** list
-  hole (`OBJECT_PROPS_MID`, `DECLARATORS_AFTER`) carries a readability label and
-  is not equality-binding, so substituting `ANYTHING` is still semantically
-  safe but loses the label — keep the keyword when a suffix is present, or
-  accept the label loss as a deliberate readability tradeoff (decide at
-  emission time; the matcher accepts both).
-- **EXPR / STMT**: an _anonymous_ hole may be emitted as `ANYTHING`. A **named**
-  hole (`EXPR_LEFT`, `STMT_SETUP`) binds for cross-occurrence equality and is
-  **not** replaceable — `ANYTHING` is always anonymous (see `bind_expr` /
-  `bind_stmt`).
-- **ARGS / STMT_LIST / CASE_REST**: **never** emit `ANYTHING` in these
-  positions. `ARGS`/`STMT_LIST` would silently change a run-absorber into an
-  arity-exact single-node hole (a correctness regression), and `CASE_REST` has
-  no `ANYTHING` form. These keywords stay load-bearing.
+- **OBJECT_PROPS / CLASS_REST**: the _anonymous_ (unsuffixed) run-absorber hole
+  in P is emitted as `ANYTHING` (`object_props_prop` / `object_props_pat_prop` /
+  `class_rest_member`). The matcher still accepts the keyword spelling from
+  hand-written input selectors.
+- **DECLARATORS**: the renderer only ever emits the **suffixed** positional form
+  (`DECLARATORS_BEFORE`/`_BETWEEN`/`_AFTER`), which carries a readability label;
+  there is no anonymous `DECLARATORS` to convert, so the keyword stays in emitted
+  binding-group selectors.
+- **EXPR / STMT**: already emitted as bare `ANYTHING` (`anything_expr`; the only
+  statement-run hole is `STMT_LIST`). A **named** hole (`EXPR_LEFT`, `STMT_SETUP`)
+  binds for cross-occurrence equality and is **not** replaceable — but the
+  renderer never mints named single-node holes, so nothing to do.
+- **ARGS / STMT_LIST / CASE_REST**: **never** emitted as `ANYTHING`.
+  `ARGS`/`STMT_LIST` would silently change a run-absorber into an arity-exact
+  single-node hole (a correctness regression), and `CASE_REST` has no `ANYTHING`
+  form. These keywords stay load-bearing.
 
-Do this **after** minimizer emission stabilizes (after migration + cover
-deletion), since it rewrites emitted selectors and touches many fixtures:
-
-- The matcher already accepts `ANYTHING` in the redundant positions, so this is
-  an emission + fixture change, not a matcher change. Confirm equivalence
-  through swc; the prove-gate is unchanged.
-- Decide per keyword whether to deprecate/remove it once fully subsumed (affects
-  existing specs — needs a sweep) or keep it as accepted-but-not-emitted sugar.
-  `ARGS`, `STMT_LIST`, and `CASE_REST` are NOT subsumable and must be kept.
-  Default for the rest: keep accepting, stop emitting; revisit removal
-  separately.
+`OBJECT_PROPS` / `DECLARATORS` / `CLASS_REST` remain accepted-but-not-emitted
+sugar (matcher + `holes_present` still recognize them); a separate sweep could
+deprecate them later, but that is out of scope here.
 
 ### Matcher gap note
 

--- a/devinfra/js/debundle/readoff_render.rs
+++ b/devinfra/js/debundle/readoff_render.rs
@@ -194,7 +194,8 @@ impl Visit for SpanCollector<'_> {
         // A destructured property key is the same `ObjectKey` anchor as an
         // object-literal key (the stable source property name). Pin the key
         // token so the prune keeps it (and holes the rest of the pattern with
-        // `OBJECT_PROPS`), exactly as `visit_object_lit` does for literals.
+        // the object-property run hole), exactly as `visit_object_lit` does for
+        // literals.
         for prop in &pat.props {
             if let Some((label, key_span)) = object_pat_key_label_span(prop)
                 && self.anchors.contains(&ValueAnchor::ObjectKey(label))

--- a/devinfra/js/debundle/render.rs
+++ b/devinfra/js/debundle/render.rs
@@ -4,9 +4,12 @@
 //! the byte spans of the concrete tokens (literals, member/property names,
 //! callees, object keys) the selector pins. A node renders concretely iff a kept
 //! span lies inside it; every other position is holed — `ANYTHING` for a bare
-//! expression, and the run holes `STMT_LIST` / `OBJECT_PROPS` / `CASE_REST` for
-//! dropped statement / object-property / switch-case runs. These primitives are
-//! form-agnostic; the per-form minimizers (`crate::minimize`) drive them.
+//! expression and for the object-property / class-member run holes (whose
+//! detector predicates carry an `ANYTHING` fallback), and the load-bearing
+//! run holes `STMT_LIST` / `ARGS` / `CASE_REST` for dropped statement / argument
+//! / switch-case runs (where `ANYTHING` would collapse to an arity-exact
+//! single-node hole, so the keyword stays). These primitives are form-agnostic;
+//! the per-form minimizers (`crate::minimize`) drive them.
 
 use std::collections::BTreeSet;
 
@@ -50,10 +53,14 @@ fn stmt_list_stmt() -> Stmt {
     })
 }
 
+/// An object-property run-absorber hole, emitted as a bare `ANYTHING` shorthand
+/// property. In object-property position `ANYTHING` is a run-absorber identical to
+/// the (still-accepted) `OBJECT_PROPS` keyword — `object_property_list_hole_name`
+/// carries an `ANYTHING` fallback — so we emit the shorter, position-polymorphic
+/// `ANYTHING` (the "prefer ANYTHING where the context is unambiguous" emission
+/// rule). Hand-written input selectors may still spell it `OBJECT_PROPS`.
 fn object_props_prop() -> PropOrSpread {
-    PropOrSpread::Prop(Box::new(Prop::Shorthand(ident_node(
-        OBJECT_PROPS_HOLE_KEYWORD,
-    ))))
+    PropOrSpread::Prop(Box::new(Prop::Shorthand(ident_node(ANYTHING_HOLE_KEYWORD))))
 }
 
 /// An `ARGS` argument-list hole that absorbs a run of dropped (non-anchor)
@@ -294,14 +301,16 @@ fn hole_array(array: &ArrayLit, kept: &BTreeSet<AnchorSpan>) -> ArrayLit {
     holed
 }
 
-/// The `OBJECT_PROPS` destructure-pattern hole prop — a shorthand binding whose
-/// name is the keyword — absorbing a run of dropped destructured properties.
-/// The pattern analog of [`object_props_prop`].
+/// A destructure-pattern run-absorber hole — a shorthand binding whose name is
+/// `ANYTHING` — absorbing a run of dropped destructured properties. The pattern
+/// analog of [`object_props_prop`]; `object_pat_prop_list_hole_name` carries the
+/// same `ANYTHING` fallback as the object-literal position, so emitting the bare
+/// keyword is equivalent to the (still-accepted) `OBJECT_PROPS` spelling.
 fn object_props_pat_prop() -> ObjectPatProp {
     ObjectPatProp::Assign(AssignPatProp {
         span: DUMMY_SP,
         key: BindingIdent {
-            id: ident_node(OBJECT_PROPS_HOLE_KEYWORD),
+            id: ident_node(ANYTHING_HOLE_KEYWORD),
             type_ann: None,
         },
         value: None,
@@ -638,16 +647,17 @@ mod interior_holing_tests {
     #[test]
     fn holes_nested_object_inside_a_kept_array_argument() {
         // The object nested in a kept `ANYTHING.run([{…}])` keeps only the anchor
-        // property, holing the rest to OBJECT_PROPS. Regression guard for the
-        // `Expr::Array` recursion: the array used to fall through `hole_expr`'s
-        // verbatim catch-all, so every property was pinned.
+        // property, holing the rest to the object-property run hole (emitted as
+        // `ANYTHING`, the run-absorber form in object-property position).
+        // Regression guard for the `Expr::Array` recursion: the array used to fall
+        // through `hole_expr`'s verbatim catch-all, so every property was pinned.
         let holed = hole_statement_expr(
             r#"ctx.engine.run([{ source: ctx.node, mode: "keepMe", silent: true }]);"#,
             "keepMe",
         );
         assert_eq!(
             normalize(&holed),
-            normalize(r#"ANYTHING.run([{ OBJECT_PROPS, mode: "keepMe", OBJECT_PROPS }]);"#),
+            normalize(r#"ANYTHING.run([{ ANYTHING, mode: "keepMe", ANYTHING }]);"#),
         );
     }
 
@@ -667,5 +677,57 @@ mod interior_holing_tests {
             normalize(&holed),
             normalize(r#"ANYTHING([ANYTHING, { mode: "keepMe" }, ANYTHING]);"#),
         );
+    }
+
+    /// The object-property run hole is emitted as the bare `ANYTHING` keyword, not
+    /// `OBJECT_PROPS` — the run-absorber form the renderer now prefers in
+    /// object-property position (the matcher accepts both; equivalence is pinned by
+    /// `object_props_and_anything_are_interchangeable_run_absorbers` in
+    /// `syntactic_holes_test.rs`). Both the literal and destructure-pattern holes
+    /// are exercised; the padded key-set form interleaves the hole around the kept
+    /// discriminating key.
+    #[test]
+    fn object_property_run_holes_emit_anything() {
+        js_ast::with_swc_globals(|| {
+            let module = js_ast::parse_js_module_ast(
+                "<object-prop-hole>",
+                r#"const x = { drop_a: 1, keepMe: "v", drop_b: 2 };"#,
+            )
+            .unwrap();
+            let [ModuleItem::Stmt(Stmt::Decl(Decl::Var(var)))] = module.body.as_slice() else {
+                panic!("expected a single var declaration");
+            };
+            let Some(Expr::Object(object)) = var.decls[0].init.as_deref() else {
+                panic!("expected an object initializer");
+            };
+            let key_span = {
+                let PropOrSpread::Prop(prop) = &object.props[1] else {
+                    panic!("expected a key-value prop");
+                };
+                let Prop::KeyValue(kv) = prop.as_ref() else {
+                    panic!("expected a key-value prop");
+                };
+                kv.key.span()
+            };
+            let kept = BTreeSet::from([span_key(key_span)]);
+            let mut holed_decl = (**var).clone();
+            holed_decl.decls[0].init =
+                Some(Box::new(Expr::Object(hole_object_padded(object, &kept))));
+            let holed = emit_selector(ModuleItem::Stmt(Stmt::Decl(Decl::Var(Box::new(
+                holed_decl,
+            )))))
+            .unwrap();
+            assert!(
+                !holed.contains("OBJECT_PROPS"),
+                "object-property run hole must not emit OBJECT_PROPS:\n{holed}"
+            );
+            // The kept anchor is the `keepMe` key token; its value holes to
+            // `ANYTHING`, and the dropped sibling-prop runs on both sides become
+            // the object-property run hole, also emitted as `ANYTHING`.
+            assert_eq!(
+                normalize(&holed),
+                normalize(r#"const x = { ANYTHING, keepMe: ANYTHING, ANYTHING };"#),
+            );
+        });
     }
 }


### PR DESCRIPTION
## What

Stop the selector minimizer/renderer from emitting the redundant `OBJECT_PROPS` / `CLASS_REST` list-hole keywords and emit the shorter, position-polymorphic `ANYTHING` instead, per the "prefer `ANYTHING` where the context is unambiguous" rule in `plans/readoff_minimization.md`.

The matcher already accepts a bare `ANYTHING` as a run-absorber in every position whose list-hole detector predicate carries an `ANYTHING` fallback (`object_property_list_hole_name`, `object_pat_prop_list_hole_name`, `is_class_rest_hole`). **This is an emission + fixture change only — no matcher change.**

## Converted to `ANYTHING`

- `object_props_prop` / `object_props_pat_prop` (`render.rs`): object-literal and destructure-pattern run holes.
- `class_rest_member` (`minimize/class.rs`): dropped class-member run hole.

## Kept unchanged

- **`ARGS` / `STMT_LIST` / `CASE_REST`** stay load-bearing keywords — a bare `ANYTHING` in those positions collapses to an arity-exact single-node hole (or has no spelling for `CASE_REST`), which would be a correctness regression.
- **Suffixed `DECLARATORS_{BEFORE,BETWEEN,AFTER}`** keep their positional readability label; the renderer never emits an anonymous `DECLARATORS`.
- **`EXPR` / `STMT`** were already emitted as bare `ANYTHING`.
- `OBJECT_PROPS` / `CLASS_REST` / `DECLARATORS` remain accepted-but-not-emitted sugar (matcher + `holes_present` still recognize them), so hand-written input selectors keep working.

## Equivalence / tests

- All rewrites are swc-AST-equivalent. 19 `expected_*match.js` minimizer-output fixtures re-baselined (compared as ASTs by `normalize_selector`). Input-selector fixtures left intact (`anything_holes_fixture`, both `source.js` inputs).
- Added a focused `render.rs` test `object_property_run_holes_emit_anything`.
- Existing matcher interchangeability tests (`syntactic_holes_test.rs`) already pin `OBJECT_PROPS`/`CLASS_REST` ≡ `ANYTHING`.
- Folded the now-landed "Language simplification" plan section into "Current state".

Full `//devinfra/js/debundle/...` suite green (117 tests): `buildbuddy:30fcd84e-612d-42ba-886c-5cbe716811e0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YQabfZ5jVoFSETefd27Bg

---
_Generated by [Claude Code](https://claude.ai/code/session_011YQabfZ5jVoFSETefd27Bg)_