### PR TITLE
debundle: dedup e2e test helpers onto support.rs

### DIFF
--- a/devinfra/js/debundle/e2e/BUILD.bazel
+++ b/devinfra/js/debundle/e2e/BUILD.bazel
@@ -210,6 +210,7 @@ rust_test(
     data = ["//devinfra/js/debundle"],
     edition = "2024",
     deps = [
+        ":support",
         "//devinfra/js/debundle:cli",
         "@crates//:serde_yaml",
         "@crates//:tempfile",
@@ -226,6 +227,7 @@ rust_test(
     data = ["//devinfra/js/debundle"],
     edition = "2024",
     deps = [
+        ":support",
         "//devinfra/js/debundle:cli",
         "@crates//:tempfile",
     ],
@@ -241,6 +243,7 @@ rust_test(
     data = ["//devinfra/js/debundle"],
     edition = "2024",
     deps = [
+        ":support",
         "@crates//:serde_json",
         "@crates//:tempfile",
     ],
@@ -257,6 +260,7 @@ rust_test(
     data = ["//devinfra/js/debundle"],
     edition = "2024",
     deps = [
+        ":support",
         "@crates//:serde_json",
         "@crates//:tempfile",
     ],
@@ -272,6 +276,7 @@ rust_test(
     data = ["//devinfra/js/debundle"],
     edition = "2024",
     deps = [
+        ":support",
         "@crates//:serde_json",
         "@crates//:tempfile",
     ],
@@ -289,6 +294,7 @@ rust_test(
     data = ["//devinfra/js/debundle"],
     edition = "2024",
     deps = [
+        ":support",
         "@crates//:serde_json",
         "@crates//:tempfile",
     ],
@@ -306,6 +312,7 @@ rust_test(
     data = ["//devinfra/js/debundle"],
     edition = "2024",
     deps = [
+        ":support",
         "@crates//:serde_json",
         "@crates//:tempfile",
     ],
@@ -335,6 +342,7 @@ rust_test(
     crate_root = "top_level_query_cli_test.rs",
     edition = "2024",
     deps = [
+        ":support",
         "//devinfra/js/debundle:analysis",
         "//devinfra/js/debundle:peel",
         "//devinfra/js/debundle:report_fixtures",
@@ -354,6 +362,7 @@ rust_test(
     data = ["//devinfra/js/debundle"],
     edition = "2024",
     deps = [
+        ":support",
         "@crates//:serde_json",
         "@crates//:tempfile",
     ],
@@ -369,6 +378,7 @@ rust_test(
     data = ["//devinfra/js/debundle"],
     edition = "2024",
     deps = [
+        ":support",
         "@crates//:serde_json",
         "@crates//:tempfile",
     ],
@@ -436,6 +446,7 @@ rust_test(
     data = ["//devinfra/js/debundle"],
     edition = "2024",
     deps = [
+        ":support",
         "@crates//:serde_json",
         "@crates//:tempfile",
     ],
@@ -461,6 +472,7 @@ rust_test(
     crate_root = "binding_name_resolution_cli_test.rs",
     edition = "2024",
     deps = [
+        ":support",
         "//devinfra/js/debundle:analysis",
         "//devinfra/js/debundle:peel",
         "//devinfra/js/debundle:report_fixtures",

--- a/devinfra/js/debundle/e2e/binding_name_resolution_cli_test.rs
+++ b/devinfra/js/debundle/e2e/binding_name_resolution_cli_test.rs
@@ -18,19 +18,13 @@ use analysis::{
     OwnerGraphNodeReport, OwnerGraphQuotientReport, OwnerGraphReport, Purity, QuotientEdgeReport,
     QuotientSccReport, SourceLocation, StatementKind, StatementOrdinal,
 };
+use debundle_e2e_support::write_text_file as write;
 use peel::{
     CommonArgs, ExplainArgs, SelectionArgs, SourceSliceArgs, resolve_binding_owners,
     run_explain_report, run_source_slice_report,
 };
 use report_fixtures::{module_entry, module_ref};
 use tempfile::TempDir;
-
-fn write(path: &Path, body: &str) {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).unwrap();
-    }
-    fs::write(path, body).unwrap();
-}
 
 fn member(binding: &str, export: &str) -> BindingReport {
     BindingReport {

--- a/devinfra/js/debundle/e2e/bindings_assign_gate_cli_test.rs
+++ b/devinfra/js/debundle/e2e/bindings_assign_gate_cli_test.rs
@@ -14,23 +14,10 @@
 //! gate's reconstruction joins YAML members → owners by binding
 //! name, matching `gate_post_edit_partition`'s wire contract.
 
+use debundle_e2e_support::{debundler_path as debundle_binary, write_text_file as write};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-
-fn debundle_binary() -> PathBuf {
-    let runfiles_path = std::env::var("RUNFILES_DIR")
-        .or_else(|_| std::env::var("TEST_SRCDIR"))
-        .expect("runfiles env var");
-    Path::new(&runfiles_path).join("_main/devinfra/js/debundle/debundle")
-}
-
-fn write(path: &Path, body: &str) {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).unwrap();
-    }
-    fs::write(path, body).unwrap();
-}
 
 /// Synthetic owner graph where alpha (owner:0) and beta (owner:1)
 /// form an atomic unit via a mutual `eager_rebind` edge. Per

--- a/devinfra/js/debundle/e2e/bindings_unassign_gate_cli_test.rs
+++ b/devinfra/js/debundle/e2e/bindings_unassign_gate_cli_test.rs
@@ -8,23 +8,10 @@
 //! `--modules` carry the same module-vs-binding assignments and the
 //! gate's reconstruction is unambiguous.
 
+use debundle_e2e_support::{debundler_path as debundle_binary, write_text_file as write};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-
-fn debundle_binary() -> PathBuf {
-    let runfiles_path = std::env::var("RUNFILES_DIR")
-        .or_else(|_| std::env::var("TEST_SRCDIR"))
-        .expect("runfiles env var");
-    Path::new(&runfiles_path).join("_main/devinfra/js/debundle/debundle")
-}
-
-fn write(path: &Path, body: &str) {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).unwrap();
-    }
-    fs::write(path, body).unwrap();
-}
 
 /// Synthetic owner graph where alpha (owner:0) and beta (owner:1)
 /// form an atomic unit via mutual `eager_rebind` edges (matching the

--- a/devinfra/js/debundle/e2e/cli_mutation_outcome_test.rs
+++ b/devinfra/js/debundle/e2e/cli_mutation_outcome_test.rs
@@ -22,21 +22,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use debundle_e2e_support::{debundler_path as debundle_binary, write_text_file as write};
 use serde_json::Value;
-
-fn debundle_binary() -> PathBuf {
-    let runfiles_path = std::env::var("RUNFILES_DIR")
-        .or_else(|_| std::env::var("TEST_SRCDIR"))
-        .expect("runfiles env var");
-    Path::new(&runfiles_path).join("_main/devinfra/js/debundle/debundle")
-}
-
-fn write(path: &Path, body: &str) {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).unwrap();
-    }
-    fs::write(path, body).unwrap();
-}
 
 fn run_debundle(args: &[&str]) -> std::process::Output {
     Command::new(debundle_binary())

--- a/devinfra/js/debundle/e2e/edit_gate_source_match_cli_test.rs
+++ b/devinfra/js/debundle/e2e/edit_gate_source_match_cli_test.rs
@@ -13,23 +13,10 @@
 //! `owner_graph.json` + source-file fixtures, mirroring
 //! `bindings_unassign_gate_cli_test.rs`.
 
+use debundle_e2e_support::{debundler_path as debundle_binary, write_text_file as write};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-
-fn debundle_binary() -> PathBuf {
-    let runfiles_path = std::env::var("RUNFILES_DIR")
-        .or_else(|_| std::env::var("TEST_SRCDIR"))
-        .expect("runfiles env var");
-    Path::new(&runfiles_path).join("_main/devinfra/js/debundle/debundle")
-}
-
-fn write(path: &Path, body: &str) {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).unwrap();
-    }
-    fs::write(path, body).unwrap();
-}
 
 /// Synthetic owner graph where alpha (owner:0) and beta (owner:1)
 /// form an atomic unit via mutual `eager_rebind` edges, plus an

--- a/devinfra/js/debundle/e2e/module_merge_test.rs
+++ b/devinfra/js/debundle/e2e/module_merge_test.rs
@@ -7,15 +7,9 @@ use std::path::Path;
 use std::process::Command;
 
 use debundle_cli::module::merge_modules;
+use debundle_e2e_support::debundler_path as debundle_binary;
 use serde_yaml::Value;
 use tempfile::TempDir;
-
-fn debundle_binary() -> std::path::PathBuf {
-    let runfiles_path = std::env::var("RUNFILES_DIR")
-        .or_else(|_| std::env::var("TEST_SRCDIR"))
-        .expect("runfiles env var");
-    Path::new(&runfiles_path).join("_main/devinfra/js/debundle/debundle")
-}
 
 fn write(root: &Path, rel: &str, body: &str) {
     let path = root.join(rel);

--- a/devinfra/js/debundle/e2e/modules_delete_cli_test.rs
+++ b/devinfra/js/debundle/e2e/modules_delete_cli_test.rs
@@ -6,18 +6,12 @@
 //! clap wiring and the env-var plumbing are covered too.
 
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
 
 use debundle_cli::module::delete_modules;
+use debundle_e2e_support::debundler_path as debundle_binary;
 use tempfile::TempDir;
-
-fn debundle_binary() -> PathBuf {
-    let runfiles_path = std::env::var("RUNFILES_DIR")
-        .or_else(|_| std::env::var("TEST_SRCDIR"))
-        .expect("runfiles env var");
-    Path::new(&runfiles_path).join("_main/devinfra/js/debundle/debundle")
-}
 
 fn write(root: &Path, rel: &str, body: &str) {
     let path = root.join(rel);

--- a/devinfra/js/debundle/e2e/modules_gate_cli_test.rs
+++ b/devinfra/js/debundle/e2e/modules_gate_cli_test.rs
@@ -11,23 +11,8 @@
 //! the same `render_cycle_summary` text the pipeline prints when
 //! the materializer's gate rejects.
 
-use std::fs;
-use std::path::{Path, PathBuf};
+use debundle_e2e_support::{debundler_path as debundle_binary, write_text_file as write};
 use std::process::Command;
-
-fn debundle_binary() -> PathBuf {
-    let runfiles_path = std::env::var("RUNFILES_DIR")
-        .or_else(|_| std::env::var("TEST_SRCDIR"))
-        .expect("runfiles env var");
-    Path::new(&runfiles_path).join("_main/devinfra/js/debundle/debundle")
-}
-
-fn write(path: &Path, body: &str) {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).unwrap();
-    }
-    fs::write(path, body).unwrap();
-}
 
 /// Synthetic owner graph with three owners (alpha, beta, gamma)
 /// and a DAG of constraining eager-use edges that, when alpha and

--- a/devinfra/js/debundle/e2e/modules_list_cli_test.rs
+++ b/devinfra/js/debundle/e2e/modules_list_cli_test.rs
@@ -1,32 +1,9 @@
 //! End-to-end exercise of `debundle modules list`'s filters by
 //! shelling out to the built binary against a tiny modules fixture.
 
-use std::fs;
-use std::path::{Path, PathBuf};
+use debundle_e2e_support::{debundler_path as debundle_binary, write_text_file as write};
+use std::path::Path;
 use std::process::Command;
-
-fn debundle_binary() -> PathBuf {
-    // Test data declared in BUILD.bazel adds the debundle binary at
-    // this runfiles path. The runfiles helper is overkill for a
-    // single binary; reach for it directly via the env var.
-    let runfiles_path = std::env::var("RUNFILES_DIR")
-        .or_else(|_| std::env::var("TEST_SRCDIR"))
-        .expect("runfiles env var");
-    let candidate = Path::new(&runfiles_path).join("_main/devinfra/js/debundle/debundle");
-    assert!(
-        candidate.exists(),
-        "debundle binary not at {}",
-        candidate.display()
-    );
-    candidate
-}
-
-fn write(path: &Path, body: &str) {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).unwrap();
-    }
-    fs::write(path, body).unwrap();
-}
 
 fn setup_modules_fixture(root: &Path) {
     write(

--- a/devinfra/js/debundle/e2e/scc_cluster_cli_test.rs
+++ b/devinfra/js/debundle/e2e/scc_cluster_cli_test.rs
@@ -1,23 +1,9 @@
 //! E2e for `debundle scc` and `debundle cluster` against a synthetic
 //! owner-graph fixture.
 
+use debundle_e2e_support::{debundler_path as debundle_binary, write_text_file as write};
 use std::fs;
-use std::path::{Path, PathBuf};
 use std::process::Command;
-
-fn debundle_binary() -> PathBuf {
-    let runfiles_path = std::env::var("RUNFILES_DIR")
-        .or_else(|_| std::env::var("TEST_SRCDIR"))
-        .expect("runfiles env var");
-    Path::new(&runfiles_path).join("_main/devinfra/js/debundle/debundle")
-}
-
-fn write(path: &Path, body: &str) {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).unwrap();
-    }
-    fs::write(path, body).unwrap();
-}
 
 /// Build a small owner_graph.json with a 2-module SCC + a singleton.
 fn synthetic_graph_json() -> String {

--- a/devinfra/js/debundle/e2e/spec_stats_cli_test.rs
+++ b/devinfra/js/debundle/e2e/spec_stats_cli_test.rs
@@ -1,29 +1,9 @@
 //! End-to-end exercise of `debundle spec stats` by shelling out to the
 //! built binary against tiny modules-tree fixtures.
 
-use std::fs;
-use std::path::{Path, PathBuf};
+use debundle_e2e_support::{debundler_path as debundle_binary, write_text_file as write};
+use std::path::Path;
 use std::process::Command;
-
-fn debundle_binary() -> PathBuf {
-    let runfiles_path = std::env::var("RUNFILES_DIR")
-        .or_else(|_| std::env::var("TEST_SRCDIR"))
-        .expect("runfiles env var");
-    let candidate = Path::new(&runfiles_path).join("_main/devinfra/js/debundle/debundle");
-    assert!(
-        candidate.exists(),
-        "debundle binary not at {}",
-        candidate.display()
-    );
-    candidate
-}
-
-fn write(path: &Path, body: &str) {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).unwrap();
-    }
-    fs::write(path, body).unwrap();
-}
 
 fn run_stats(modules: &Path, extra: &[&str]) -> std::process::Output {
     let mut args = vec!["spec", "stats", "--modules", modules.to_str().unwrap()];

--- a/devinfra/js/debundle/e2e/top_level_query_cli_test.rs
+++ b/devinfra/js/debundle/e2e/top_level_query_cli_test.rs
@@ -5,14 +5,12 @@
 //! Calls the library entry points directly (no binary execution) so
 //! the test runs in-process and stays fast.
 
-use std::fs;
-use std::path::Path;
-
 use analysis::{
     AtomicGraphReport, AtomicUnitReport, BindingReport, DepKind, ModuleEntry, OwnerGraphEdgeReport,
     OwnerGraphNodeReport, OwnerGraphQuotientReport, OwnerGraphReport, Purity, QuotientSccReport,
     SourceLocation, StatementKind, StatementOrdinal,
 };
+use debundle_e2e_support::write_text_file as write;
 use peel::plan::PatchPlanStatus;
 use peel::{
     CommonArgs, ExplainArgs, GraphSummaryArgs, PatchPlanArgs, PlanWorkArgs, SelectionArgs,
@@ -21,13 +19,6 @@ use peel::{
 };
 use report_fixtures::{module_ref, module_table};
 use tempfile::TempDir;
-
-fn write(path: &Path, body: &str) {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).unwrap();
-    }
-    fs::write(path, body).unwrap();
-}
 
 fn member(binding: &str, export: &str) -> BindingReport {
     BindingReport {


### PR DESCRIPTION
## Summary

Dedup: 12 e2e test files hand-rolled their own `debundle_binary()` (4 cosmetic variants — return-type spelling, an `.exists()` assert, a comment — **all resolving the same `_main/devinfra/js/debundle/debundle` runfile**) and/or the 2-arg `write(path, body)` helper, duplicating the canonical `debundle_e2e_support::{debundler_path, write_text_file}` that already exist in `support.rs`.

Replace the local copies with `use … as` aliases (call sites unchanged), wire the `:support` dep into each target, and trim the now-orphaned `std::fs` / `std::path` imports. **No behavior change** — `DEBUNDLER_RLOCATION` is the same path the env-var copies used, and `write_text_file` is byte-identical to the 2-arg `write`.

**−139 net lines** across 13 files (12 tests + BUILD); `support.rs` untouched.

## Excluded / follow-up
- `selector_codemod_cli_test` and `selector_minimizer_expectation_test` — left out because they're touched by the in-flight #2325 (avoid a merge-conflict); easy follow-up once that lands.
- The 3-arg `write(root, rel, body)` variant in a few other files is a different API, not consolidated here.

## Testing

`bazelisk test //devinfra/js/debundle/e2e/...` — 80/80 pass (RBE).

https://claude.ai/code/session_011YQabfZ5jVoFSETefd27Bg

---
_Generated by [Claude Code](https://claude.ai/code/session_011YQabfZ5jVoFSETefd27Bg)_