### PR TITLE
debundle: emit plain DECLARATORS (drop positional run-hole suffixes)

### DIFF
--- a/devinfra/js/debundle/e2e/selector_codemod_cli_test.rs
+++ b/devinfra/js/debundle/e2e/selector_codemod_cli_test.rs
@@ -853,7 +853,7 @@ fn synthesize_selectors_minimizes_binding_group_to_needed_slot_anchors() {
         );
         // Re-baselined: the unified group path reports holes via the canonical
         // `holes_present` extractor, which records the bare `DECLARATORS` keyword
-        // (the match source below still emits the specific `DECLARATORS_BETWEEN`).
+        // (the match source below still emits a `DECLARATORS` gap declarator).
         assert!(
             candidate["rewritten_holes"]
                 .as_array()
@@ -874,7 +874,7 @@ fn synthesize_selectors_minimizes_binding_group_to_needed_slot_anchors() {
     // literal in either target slot, the group escalates to the whole structural
     // (object-key) tier, so both slots keep their `stableX`/`volatileX` keys
     // rather than the exact-minimum `stableX` alone. The skipped middle
-    // declarator still collapses to a `DECLARATORS_BETWEEN` gap and each slot
+    // declarator still collapses to a `DECLARATORS` gap and each slot
     // keeps its discriminating stable key.
     assert!(
         match_source.contains("stableA:"),
@@ -885,7 +885,7 @@ fn synthesize_selectors_minimizes_binding_group_to_needed_slot_anchors() {
         "slot B stable key should remain to distinguish it from the skipped declarator:\n{match_source}"
     );
     assert!(
-        match_source.contains("DECLARATORS_BETWEEN"),
+        match_source.contains("DECLARATORS"),
         "irrelevant middle declarator should become a gap:\n{match_source}"
     );
     assert!(
@@ -982,7 +982,7 @@ fn synthesize_selectors_dry_run_reports_grouped_unique_evidence() {
         assert_eq!(candidate["candidate_count"], 1, "{candidate}");
         // Re-baselined: the unified group path reports holes via the canonical
         // `holes_present` extractor, which records the bare `DECLARATORS` keyword
-        // (the match source still emits the specific `DECLARATORS_BEFORE` gap).
+        // (the match source still emits a leading `DECLARATORS` gap declarator).
         assert!(
             candidate["rewritten_holes"]
                 .as_array()
@@ -1103,10 +1103,7 @@ fn synthesize_selectors_apply_groups_multideclarator_and_preserves_comments() {
     assert_eq!(groups.len(), 1, "{doc:?}");
     let group = &groups[0];
     let match_source = group["source_match"]["match"].as_str().unwrap();
-    assert!(
-        match_source.contains("DECLARATORS_BEFORE"),
-        "{match_source}"
-    );
+    assert!(match_source.contains("DECLARATORS"), "{match_source}");
     // The bare `buildConfig` callee holes to ANYTHING (a minified name the matcher
     // alpha-wildcards); each slot is still kept as its own named declarator.
     assert!(

--- a/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
+++ b/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
@@ -357,7 +357,7 @@ minimizer_expectation_case!(
 // target declarator slot's minimal anchor off the shape index + a slot-aware
 // greedy, restricts the kept spans to that slot, UNIONs them, and proves the
 // tuple through the binding-group matcher — so each slot pins only its
-// discriminating key with `OBJECT_PROPS` for the gaps and `DECLARATORS_AFTER` for
+// discriminating key with `OBJECT_PROPS` for the gaps and a `DECLARATORS` gap for
 // the non-target third declarator, instead of the keep-shallow path's over-pin
 // (which, with every value already a non-literal member access, would escalate to
 // keeping *every* key of both target objects). The per-slot declarator-tuple
@@ -509,7 +509,7 @@ minimizer_expectation_case!(
 // with OBJECT_PROPS holes for the rest, and DECLARATORS holes for the sibling
 // declarators, instead of keeping every key of the target object. Mirrors the
 // real gaffer CSS-styles dicts (`{ diagnosticsSection: …, detailsToggle: …, … }`)
-// kept whole inside `DECLARATORS_BEFORE`/`_AFTER` groups.
+// kept whole inside `DECLARATORS`-bracketed groups.
 minimizer_expectation_case!(
     minimizes_object_key_set_group,
     fixture = "object_key_set_group",

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/binding_group_declarators/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/binding_group_declarators/expected_match.js
@@ -1,4 +1,4 @@
 const SelectedLimit = 15,
-  DECLARATORS_BETWEEN = null,
+  DECLARATORS = null,
   SelectedThreshold = 0.3,
-  DECLARATORS_AFTER = null;
+  DECLARATORS = null;

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/binding_group_key_set_readoff/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/binding_group_key_set_readoff/expected_match.js
@@ -1,3 +1,3 @@
 const ErrorBadge = { ANYTHING, logViewer: ANYTHING, ANYTHING },
   WarningBadge = { ANYTHING, alertChip: ANYTHING, ANYTHING },
-  DECLARATORS_AFTER = null;
+  DECLARATORS = null;

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/binding_group_partition/expected_group_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/binding_group_partition/expected_group_match.js
@@ -1,3 +1,3 @@
 const SelectedPrimary = ANYTHING(ARGS, { ANYTHING, enabled: true }),
   SelectedSecondary = ANYTHING("secondary", { ANYTHING, enabled: true }),
-  DECLARATORS_AFTER = null;
+  DECLARATORS = null;

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/grouped_enum_objects/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/grouped_enum_objects/expected_match.js
@@ -1,7 +1,7 @@
-const DECLARATORS_BEFORE = null,
+const DECLARATORS = null,
   SelectedPalette = {
     ANYTHING,
     accent: "uniqueDiscriminatorAccent",
     ANYTHING,
   },
-  DECLARATORS_AFTER = null;
+  DECLARATORS = null;

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/object_key_set_group/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/object_key_set_group/expected_match.js
@@ -3,4 +3,4 @@ const ErrorPanelStyles = {
     logViewer: ANYTHING,
     ANYTHING,
   },
-  DECLARATORS_AFTER = null;
+  DECLARATORS = null;

--- a/devinfra/js/debundle/minimize/mod.rs
+++ b/devinfra/js/debundle/minimize/mod.rs
@@ -275,17 +275,13 @@ fn render_var_slots(
 ) -> Result<String> {
     let mut decls: Vec<VarDeclarator> = Vec::new();
     let mut skipped_run = false;
-    let mut target_seen = 0usize;
     for (idx, declarator) in var.decls.iter().enumerate() {
         if !target_slots.contains(&idx) {
             skipped_run = true;
             continue;
         }
         if skipped_run {
-            decls.push(declarator_hole(declarator_hole_name(
-                target_seen,
-                target_slots.len(),
-            )));
+            decls.push(declarator_hole(declarator_hole_name()));
             skipped_run = false;
         }
         let name = single_ident_pat_name(&declarator.name)
@@ -302,13 +298,9 @@ fn render_var_slots(
             Box::new(holed_init)
         });
         decls.push(holed);
-        target_seen += 1;
     }
     if skipped_run {
-        decls.push(declarator_hole(declarator_hole_name(
-            target_seen,
-            target_slots.len(),
-        )));
+        decls.push(declarator_hole(declarator_hole_name()));
     }
     let mut holed_var = var.clone();
     holed_var.declare = false;

--- a/devinfra/js/debundle/plans/readoff_minimization.md
+++ b/devinfra/js/debundle/plans/readoff_minimization.md
@@ -192,14 +192,22 @@ keyword to read. Anonymous `EXPR` / `STMT` were already emitted as bare `ANYTHIN
 `ARGS`, `STMT_LIST`, and `CASE_REST` stay load-bearing keywords — a bare `ANYTHING`
 in those positions collapses to an arity-exact single-node `EXPR`/`STMT` hole (or,
 for `CASE_REST`, has no spelling), so emitting `ANYTHING` there would be a
-correctness regression. `OBJECT_PROPS` / `CLASS_REST` / suffixed `DECLARATORS_*`
-remain accepted-but-not-emitted sugar: the matcher and `holes_present` still
-recognize them, so hand-written input selectors keep working, and the renderer
-never emits an anonymous `DECLARATORS` (it always carries a positional
-`_BEFORE`/`_BETWEEN`/`_AFTER` suffix). Equivalence is pinned by the matcher
-interchangeability tests in `syntactic_holes_test.rs`
+correctness regression. Declarator-run gaps now render as **plain `DECLARATORS`**
+(the positional `_BEFORE`/`_BETWEEN`/`_AFTER` suffix was readability-only — the
+matcher checks `declarator_list_hole_name(..).is_some()` and never reads the
+suffix — so it was dropped; the parser tolerates duplicate-named declarator holes,
+so a both-sides gap renders `const DECLARATORS = null, …, DECLARATORS = null`).
+`OBJECT_PROPS` / `CLASS_REST` / suffixed `DECLARATORS_*` remain
+accepted-but-not-emitted sugar: the matcher and `holes_present` still recognize
+them, so hand-written input selectors keep working. Equivalence is pinned by the
+matcher interchangeability tests in `syntactic_holes_test.rs`
 (`{object_props,declarators,class_rest}_and_anything_are_interchangeable_run_absorbers`)
-and the re-baselined `selector_minimizer_expectations` fixtures.
+and the re-baselined `selector_minimizer_expectations` fixtures. **Follow-up
+(GitHub #2327, gated on the dogfood re-apply):** drop these redundant keywords
+from the _accepted_ set too — a breaking change requiring every downstream
+selector (gaffer-private, pinned release) to be migrated first, then the keywords
+
+- matcher branches + interchangeability tests removed and the pin bumped.
 
 **Strangler-fig boundary.** The matcher-driven branch-and-bound cover search
 (`minimize_via_retention`, `cover_competitors`, `min_set_cover`, and the
@@ -442,9 +450,10 @@ Mechanical and unambiguous given the table — the renderer (`render.rs` /
   single-node hole (a correctness regression), and `CASE_REST` has no `ANYTHING`
   form. These keywords stay load-bearing.
 
-`OBJECT_PROPS` / `DECLARATORS` / `CLASS_REST` remain accepted-but-not-emitted
-sugar (matcher + `holes_present` still recognize them); a separate sweep could
-deprecate them later, but that is out of scope here.
+`OBJECT_PROPS` / `CLASS_REST` / suffixed `DECLARATORS_*` remain
+accepted-but-not-emitted sugar (matcher + `holes_present` still recognize them;
+the minimizer emits `ANYTHING` and plain `DECLARATORS`). Dropping them from the
+accepted set is tracked as #2327, gated on the dogfood migration.
 
 ### Matcher gap note
 

--- a/devinfra/js/debundle/selector_codemod.rs
+++ b/devinfra/js/debundle/selector_codemod.rs
@@ -1588,14 +1588,13 @@ fn render_var_group_selector(
     let mut parts = Vec::new();
     let mut holes = Vec::new();
     let mut skipped_run = 0usize;
-    let mut target_seen = 0usize;
     for (idx, declarator) in var.decls.iter().enumerate() {
         if !target_decl_indices.contains(&idx) {
             skipped_run += 1;
             continue;
         }
         if skipped_run > 0 {
-            let hole = declarator_hole_name(target_seen, target_decl_indices.len());
+            let hole = declarator_hole_name();
             parts.push(format!("{hole} = null"));
             holes.push(hole.to_string());
             skipped_run = 0;
@@ -1612,10 +1611,9 @@ fn render_var_group_selector(
             runtime_name,
             export_name,
         )?);
-        target_seen += 1;
     }
     if skipped_run > 0 {
-        let hole = declarator_hole_name(target_seen, target_decl_indices.len());
+        let hole = declarator_hole_name();
         parts.push(format!("{hole} = null"));
         holes.push(hole.to_string());
     }
@@ -1628,12 +1626,12 @@ fn render_var_group_selector(
     ))
 }
 
-fn declarator_hole_name(target_seen: usize, target_count: usize) -> &'static str {
-    match (target_seen, target_count) {
-        (0, _) => "DECLARATORS_BEFORE",
-        (seen, total) if seen == total => "DECLARATORS_AFTER",
-        _ => "DECLARATORS_BETWEEN",
-    }
+/// The declarator-run hole for a binding-group selector. The matcher treats every
+/// `DECLARATORS` / `DECLARATORS_*` run hole identically — the positional suffix is
+/// not equality-binding (only used in human-facing hint text) — so the renderer
+/// always emits the plain keyword. (Suffixed forms remain accepted on input.)
+fn declarator_hole_name() -> &'static str {
+    DECLARATORS_HOLE_KEYWORD
 }
 
 fn render_var_declarator_selector(


### PR DESCRIPTION
## Summary

Answers your "why the varied `DECLARATORS_{BEFORE,BETWEEN,AFTER}` suffixes?" — they're not load-bearing. The matcher only ever checks `declarator_list_hole_name(..).is_some()` (a boolean "is this a run-hole?"); the suffix is **never matched or equality-bound**, only used in human-facing `hints.rs` text. So the renderer now emits the plain `DECLARATORS` keyword for every declarator-run gap, and the `target_seen` bookkeeping that existed only to pick the suffix is gone.

The parser tolerates duplicate-named declarator holes (the existing `const ANYTHING = null, …, ANYTHING = null` interchangeability test already relies on this), so a both-sides gap renders `const DECLARATORS = null, …, DECLARATORS = null` — empirically confirmed by the re-baselined two-gap fixtures `binding_group_declarators` and `grouped_enum_objects`.

## Non-breaking
Matcher unchanged — suffixed `DECLARATORS_*` stay **accepted on input**, so existing hand-written/downstream selectors keep working.

## Changes
- `selector_codemod.rs`: `declarator_hole_name()` → returns plain `DECLARATORS`; removed `target_seen` tracking in both group renderers.
- Re-baselined 5 `expected_*.js` fixtures + 2 cli-test output assertions; fixed stale comments; updated the plan's language-simplification section.

## Follow-up
Dropping the redundant run-hole keywords (`OBJECT_PROPS` / `CLASS_REST` / suffixed `DECLARATORS_*`) from the **accepted** set entirely is the breaking, dogfood-gated change tracked in **#2327**.

## Testing
`bazelisk test //devinfra/js/debundle/...` — 117/117 pass (RBE).

https://claude.ai/code/session_011YQabfZ5jVoFSETefd27Bg

---
_Generated by [Claude Code](https://claude.ai/code/session_011YQabfZ5jVoFSETefd27Bg)_