### PR TITLE
debundle: dogfood-apply survey + two over-pin expectation cases

### DIFF
--- a/devinfra/js/debundle/debug/perf/2026_06_17_dogfood_apply_whole_spec/command.sh
+++ b/devinfra/js/debundle/debug/perf/2026_06_17_dogfood_apply_whole_spec/command.sh
@@ -1,0 +1,9 @@
+# Rerunner: whole-spec synthesize-selectors under callgrind (Ir-only, no cache-sim).
+# Run from a built `-c opt` debundle binary; gaffer spec + upstream snapshot as input.
+BIN=bazel-bin/devinfra/js/debundle/debundle
+GSPEC=../../../gaffer-private/tana/re/web/78d928dca7/spec
+SROOT=../../../gaffer-private/tana/upstream/web/snapshots/78d928dca7
+valgrind --tool=callgrind --callgrind-out-file=callgrind.whole.out \
+  --cache-sim=no --branch-sim=no --dump-instr=no --collect-jumps=no \
+  "$BIN" spec synthesize-selectors --modules "$GSPEC/modules" \
+  --source-root "$SROOT" --chunk static/index-DI2GynTv.js --format json >/dev/null

--- a/devinfra/js/debundle/debug/selector_minimizer_dogfood.md
+++ b/devinfra/js/debundle/debug/selector_minimizer_dogfood.md
@@ -1,12 +1,82 @@
 # Dogfood: read-off minimizer on the real tana/re spec
 
 Real-chunk measurements of the read-off `synthesize-selectors` minimizer against
-the ~7 MB minified chunk / ~4.5k name-pin members. Earlier search-era and
-migration-phase findings (conversion rates, the apply-crash fix, the over-pin
-shapes) are superseded: the over-pin patterns are now tracked as the disabled E2E
-expectation cases, and next steps live in the plan backlog
+the ~7 MB minified chunk (`static/index-DI2GynTv.js`). Earlier search-era and
+migration-phase findings (the apply-crash fix, the original over-pin shapes) are
+superseded; next steps live in the plan backlog
 (<../plans/readoff_minimization.md>). What remains here is the load-bearing perf
-measurement that backs the W4 budget item.
+measurement that backs the W4 budget item, plus the current dogfood-apply survey
+(below) that drives the next over-pin-reduction wave.
+
+## Dogfood-apply survey (2026-06-17, post enclosing-context + interior-cover)
+
+Whole-spec `synthesize-selectors --apply` (`-c opt` binary, gaffer
+`tana/re/web/78d928dca7` spec, the unmodified name-pinned spec). Measures what the
+**current** minimizer — with the post-#2291 capabilities landed
+(#2310 wide-destructure, #2315 enclosing-context anchoring, #2318 callee/arg
+holing, #2289 interior cover, #2306 multi-target binding-group read-off) — does on
+the real spec, and where it still over-pins.
+
+| metric                                   | value           |
+| ---------------------------------------- | --------------- |
+| modules / members scanned                | 1745 / 5903     |
+| fragile `binding.name` members           | 2227            |
+| **converted** (`would_change`)           | **1104 (~50%)** |
+| selectors emitted (incl. binding groups) | 1013            |
+| skipped (no sparse selector)             | 1123            |
+| wall (`--apply`, whole spec, `-c opt`)   | **13.1 s**      |
+
+The **~50% conversion** is a large jump from the ~9%-convertible the plan recorded
+at gaffer `main` after #360 (then: ~91% "no sparse selector"). The
+enclosing-context anchoring (#2315) and interior cover (#2289) recover most of the
+previously-skipped whole-body-only tail — but they are also where the new over-pin
+debt comes from (below). The ~1123 still-skipped are the residual hard tail.
+
+### Converted-selector size distribution (1013 emitted)
+
+`match`-block line count: min 1, median 13, mean 27.4, max 904.
+
+| ≤10 | 11–20 | 21–40 | 41–100 | >100 |
+| --- | ----- | ----- | ------ | ---- |
+| 414 | 251   | 191   | 117    | 40   |
+
+Two-thirds (656/1013) land ≤20 lines — compact, robust selectors. The >40-line tail
+(157) is where the over-pin lives.
+
+### Over-pin survey (operational rule: `match` >40 lines AND ≤2 holes)
+
+**62 hard over-pins** (a further 95 are >40 lines but well-holed, kept). Classified
+by shape:
+
+| n   | shape                                                                    |
+| --- | ------------------------------------------------------------------------ |
+| 46  | **neighbor-context anchoring pins the whole neighbor declaration**       |
+| 11  | function / class whole-body (interior cover found no compact anchor)     |
+| 2   | **class-expression-valued `const X = class {…}` pinned whole (0 holes)** |
+| 2   | object-literal whole / async-generator parse edge                        |
+
+The two **bolded** shapes are clean, fixable gaps with no existing coverage, so
+each is captured as a new ignored expectation case in
+`e2e/selector_minimizer_expectation_test.rs` (anonymized minimal reproductions):
+
+- **`neighbor_context_whole_function_neighbor`** — #2315 picks the right stable
+  neighbor but, when it is a function _declaration_ (not a single call statement),
+  pins its body verbatim instead of running it back through the per-form read-off.
+  Dominant shape (46/62). Real analogues: the `SubscriptionFlow` /
+  `nodeDisplayName` wrappers whose preceding ~40-line component function is kept
+  whole; the largest is `features/search/popoverState.yaml::$rt` at **904 lines /
+  1 hole**.
+- **`class_expression_const_whole_body`** — `try_var_read_off`'s `hole_expr` has no
+  `Expr::Class` arm, so a class-expression initializer never reaches the class
+  read-off (CLASS*REST holing). The equivalent class \_declaration* minimizes
+  correctly (control verified). Real analogues:
+  `integrations/google/api/client.yaml::GoogleApiClient` (314 lines, 0 holes) and
+  `features/search/state.yaml::SearchState` (300 lines, 0 holes).
+
+The 11 function/class whole-body cases are the known structural tail the interior
+cover (#2289) explicitly leaves open (uniqueness genuinely needs ~the whole body);
+they are not new gaps. Per the operational rule, the 62 hard over-pins revert to
+name pins in the dogfood-apply PR; the well-holed >40-line conversions ship.
 
 ## Read-off minimizer real-chunk perf (2026-06-16, post prove-gate-via-index)
 

--- a/devinfra/js/debundle/debug/selector_minimizer_perf.md
+++ b/devinfra/js/debundle/debug/selector_minimizer_perf.md
@@ -134,3 +134,65 @@ posting lists are size 1–2 (selective features dominate), where roaring's
 per-container overhead costs ~21 MB more RSS than a `Vec<u32>` would — an
 acceptable price for the standard structure (footprint stays flat vs the BTree
 baseline; see the dogfood note).
+
+## Re-profile after enclosing-context + interior cover (2026-06-17)
+
+Same callgrind method (Ir-only, no cache-sim), but on the **whole-spec
+`--apply`** run with the post-#2291 capabilities landed (#2315
+enclosing-context anchoring, #2289 interior cover, #2306 multi-target
+binding-group read-off). Reproducer:
+<perf/2026_06_17_dogfood_apply_whole_spec/command.sh>. Total **99.3B Ir**;
+wall **13.1 s** — a regression from the ~7 s #2291 recorded, because the new
+capabilities now **convert ~1104 members (~50%)** instead of the ~200 then
+convertible, and each conversion drives the prove-gate matcher (often several
+times: neighbor windows, group tuples, interior covers).
+
+**The bottleneck has moved off the shape index (#2291 fixed it) and onto the
+prove-gate MATCHER.** Inclusive cost:
+
+| Ir % (incl.) | function                                                |
+| ------------ | ------------------------------------------------------- |
+| 96.0         | `rewrite_name_bindings_to_source_match` (whole convert) |
+| **58.4**     | `find_member_binding_matches` (the prove-gate matcher)  |
+| **8.4**      | `AstWildcardMatcher::restore` (backtrack undo)          |
+| **5.6**      | `AstWildcardMatcher::snapshot` (backtrack save)         |
+| 3.3          | `AstWildcardMatcher::with_alpha_scope` (scope push/pop) |
+
+`snapshot` + `restore` + `with_alpha_scope` ≈ **17% of the whole run is pure
+backtracking bookkeeping**, and it is the **same `BTreeMap` pattern #2291 fixed
+one layer up**: `AlphaMatchScope` (`source_match/matcher.rs`) holds two
+`BTreeMap<Atom, Atom>` (forward/backward alpha-binding maps), and the matcher keeps
+a `Vec<AlphaMatchScope>` stack that it `clone()`s on `snapshot` and drops/swaps on
+`restore` for every backtrack. Top self-cost confirms it — allocator churn ~30%
+(`_int_free` 9.3%, `malloc` 6.8%, `_int_malloc` 5.6%, `free` 4.4%, …) and
+`BTreeMap`/`BTreeSet` ops ~21% (`IntoIter::dying_next` 5.6%, `Drop` 4.3%,
+`from_iter` 4.1%, `Iter::next` 2.4%, `clone_subtree` 1.3%, …), almost all of it
+the alpha-scope clone/drop. Parsing is ~2% (`next_token` 0.79%); the shape index /
+read-off no longer registers near the top.
+
+The new conversion paths are what call the matcher so much:
+`find_member_binding_matches` callers include `synthesized_candidate` (the
+prove-gate, 1075×), `minimize_var_group_selector` (1272×),
+`try_var_read_off` (577×), `render_via_neighbor_context` (497×, the #2315 path),
+and `resolve_member_binding_group_with_declarator_holes` (379×).
+
+### Improvement targets (ranked)
+
+1. **Journaled (undo-log) `AlphaMatchScope`, not clone-on-snapshot.** Record the
+   keys inserted into `forward`/`backward` since the last `snapshot`; on `restore`
+   pop exactly those, instead of cloning the whole map and swapping it back. Makes
+   snapshot/restore O(Δbindings) rather than O(scope size) and removes the
+   `clone_subtree` / `dying_next` / `Drop` churn — directly attacks the ~14%
+   snapshot+restore and a large share of the ~30% allocator churn. Highest-leverage
+   and self-contained, exactly mirroring the #2291 win one layer down.
+2. **`FxHashMap<Atom, Atom>` for `forward`/`backward`.** Ordered iteration is never
+   needed for a forward/backward lookup; hashing removes the remaining
+   `Atom: Ord::cmp` and BTree rebalance on every bind.
+3. **Cut redundant prove-gate calls in the neighbor / group paths.** The #2315
+   window search (497×) and the keep-shallow group escalation (1272×) re-run the
+   full matcher per candidate window/tuple; restricting each to the candidate-index
+   posting intersection first (as the single-target read-off already does, #2280)
+   would prune most failing matches before the matcher walks them.
+
+(1)+(2) are the read-off→matcher analogue of #2291 and should recover the
+regression to at or below the ≤10 s ideal even with the higher conversion count.

--- a/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
+++ b/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
@@ -856,3 +856,54 @@ minimizer_expectation_case!(
     bindings = [("SelectedHelper", "selectedHelper")],
     expected = "expected_match.js",
 );
+
+// IGNORED (dogfood over-pin, 2026-06-17): enclosing-context anchoring (#2315)
+// picks the right stable neighbor but, when that neighbor is a **function
+// declaration** rather than a single call statement, pins the neighbor's body
+// VERBATIM instead of holing it down to its own discriminating anchor. Here the
+// near-duplicate target `selectedHelper` (bare scaffold matches `firstHelper`)
+// is correctly anchored to the following `neighborWithToken` declaration, but the
+// emitted selector keeps all three of the neighbor's body statements
+// (`const prepared = …`, the discriminating `emit("neighbor-unique-token")`, and
+// `cleanup(prepared)`) plus its parameter list. The target shape is the neighbor
+// minimized as if it were a standalone function read-off: hole the name/params,
+// `STMT_LIST` the non-discriminating statements, and keep only the unique
+// `ANYTHING("neighbor-unique-token")` anchor (callee dropped per #2318). The
+// neighbor branch of `render_via_neighbor_context` needs to run the neighbor
+// declaration back through the per-form read-off before pinning it. Dominant
+// dogfood over-pin shape: 46/62 of the gaffer `78d928dca7` >40-line, ≤2-hole
+// conversions are this "neighbor declaration kept whole" pattern (e.g. the real
+// `SubscriptionFlow`/`nodeDisplayName` wrappers whose preceding ~40-line component
+// function is pinned verbatim).
+minimizer_expectation_case!(
+    #[ignore = "neighbor-context anchoring pins the whole neighbor function declaration instead of holing it to its anchor"]
+    minimizes_neighbor_context_whole_function_neighbor,
+    fixture = "neighbor_context_whole_function_neighbor",
+    name = "neighbor function declaration is holed to its discriminating anchor, not pinned whole",
+    module = "app/helpers",
+    bindings = [("SelectedHelper", "selectedHelper")],
+    expected = "expected_match.js",
+);
+
+// IGNORED (dogfood over-pin, 2026-06-17): a class-EXPRESSION-valued `const`
+// (`const X = class { … }`) is pinned whole because the var read-off
+// (`try_var_read_off` → `hole_expr`) has no `Expr::Class` arm, so the class
+// initializer never routes through the class read-off (CLASS_REST member holing).
+// The equivalent class DECLARATION minimizes correctly today — control:
+// `class selectedStore { status = "idle"; run(){…} describe(){…} }` emits
+// `class SelectedStore { status = "idle"; ANYTHING; }` — so the gap is purely the
+// expression form failing to reach `minimize_class_selector`'s read-off. The
+// target shape wraps that same class read-off output back in the `const … = class`
+// initializer. Real-spec analogue: the 0-hole whole-body giants
+// `integrations/google/api/client.yaml::GoogleApiClient` (314 lines) and
+// `features/search/state.yaml::SearchState` (300 lines), both `const X = class {…}`
+// kept verbatim with zero holes.
+minimizer_expectation_case!(
+    #[ignore = "class-expression-valued const is pinned whole; not routed through the class read-off"]
+    minimizes_class_expression_const_whole_body,
+    fixture = "class_expression_const_whole_body",
+    name = "class-expression const keeps only one discriminating member, not the whole class body",
+    module = "app/stores",
+    bindings = [("SelectedStore", "selectedStore")],
+    expected = "expected_match.js",
+);

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/class_expression_const_whole_body/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/class_expression_const_whole_body/expected_match.js
@@ -1,0 +1,4 @@
+const SelectedStore = class {
+  status = "idle";
+  ANYTHING;
+};

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/class_expression_const_whole_body/source.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/class_expression_const_whole_body/source.js
@@ -1,0 +1,10 @@
+const selectedStore = class {
+  status = "idle";
+  run() {
+    return base(this);
+  }
+  describe() {
+    return tag("unique-store-token");
+  }
+};
+export { selectedStore };

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/neighbor_context_whole_function_neighbor/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/neighbor_context_whole_function_neighbor/expected_match.js
@@ -1,0 +1,8 @@
+function SelectedHelper() {
+  STMT_LIST;
+}
+function ANYTHING(ANYTHING) {
+  STMT_LIST;
+  ANYTHING("neighbor-unique-token");
+  STMT_LIST;
+}

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/neighbor_context_whole_function_neighbor/source.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/neighbor_context_whole_function_neighbor/source.js
@@ -1,0 +1,12 @@
+function firstHelper() {
+  return wrap();
+}
+function selectedHelper() {
+  return wrap();
+}
+function neighborWithToken(input) {
+  const prepared = normalize(input);
+  emit("neighbor-unique-token");
+  cleanup(prepared);
+}
+export { selectedHelper };

--- a/devinfra/js/debundle/plans/readoff_minimization.md
+++ b/devinfra/js/debundle/plans/readoff_minimization.md
@@ -255,8 +255,11 @@ landed, #2289), `sequential_assignment_block` (`hole_expr` `Expr::Assign` arm),
 non-anchor argument runs) `deeply_nested_call_args`, (destructure-pattern-key
 `ObjectKey` anchors + `ObjectPat` holing, #2310) `wide_destructure_block`, and
 (enclosing-context anchoring, #2315) `neighbor_context_alpha_construct`,
-`neighbor_context_duplicate_helper`. Every catalogued expectation case is now
-active.
+`neighbor_context_duplicate_helper`. **Ignored** (over-pins the 2026-06-17 dogfood
+survey surfaced, no fix yet): `neighbor_context_whole_function_neighbor` (#2315
+pins a function-declaration neighbor whole instead of holing it) and
+`class_expression_const_whole_body` (`const X = class {…}` not routed through the
+class read-off). See backlog items 3–4.
 
 ## Acceptance criteria
 
@@ -284,37 +287,30 @@ active.
 adversarial tail cases (near-minimal is fine); preserving YAML comments (out via
 serde); embedded/non-trailing volatility in regex anchors (future).
 
-## Remaining minified-pin debt (measured, gaffer `main` after #360)
+## Remaining minified-pin debt (measured, gaffer `78d928dca7`, 2026-06-17)
 
-`spec selector-debt` on the converted spec: **5,108 robust `source_match`** vs
-**2,226 still-fragile name-only** pins (~70% converted). Re-running the minimizer
-(`synthesize-selectors`, dry) over the 2,226 splits the debt by _why_ it remains
-— the prioritization input for the waves below:
+`spec selector-debt`: **5,108 robust `source_match`** vs **2,226 still-fragile
+name-only** pins. A whole-spec `synthesize-selectors --apply` (current minimizer,
+all post-#2291 capabilities) now **converts 1,104 of the 2,227 name-pins (~50%)** —
+a large jump from the ~9%-convertible recorded at gaffer `main` after #360, because
+#2310/#2315/#2289/#2306 recover most of the previously skipped whole-body-only
+tail. Full survey + size distribution in <../debug/selector_minimizer_dogfood.md>.
+The split is now:
 
-- **~2,024 (~91%) — "no sparse selector" (minimizer skips).** No compact
-  discriminating anchor set resolves uniquely, so with `--full-ast-fallback` off
-  the member is left as a name pin. These are **whole-body-only** members
-  (uniqueness needs ~the entire body). Concentrated in `features` (955),
-  `domains` (462), `app` (425). Recovering them is the hard, high-count tail:
-  needs **interior holing of whole bodies** (landed — keeps the body but
-  holes non-identifying subtrees so a fuller pin is at least less fragile / can be
-  emitted) and/or deeper anchoring (enclosing-context, #2315). Biggest number, hardest; do not expect a
-  clean compact selector for most.
-- **~200 (~9%) — convertible but >30 lines (filtered out of #360).** The minimizer
-  _does_ synthesize a selector; it's just over the compact threshold. Shape mix:
-  **~55% var/object, ~42% function, ~3% class**; median ~35 lines, tail to ~700.
-  These are the **achievable near-term wins**: the over-pin-reduction waves shrink
-  them under the threshold so they ship as compact selectors —
-  - var/object (the plurality) → wide object-destructure patterns now hole to
-    the discriminating key (landed, #2310); the remaining object-dict over-pin
-    folds into the landed interior holing;
-  - function → **interior holing** within kept bodies (landed);
-  - a re-apply after each wave reconverts whatever now fits ≤30 lines.
-- 1 — `async` parse edge case (single; ignore).
+- **1,123 still skipped ("no sparse selector").** The residual structural tail —
+  uniqueness genuinely needs ~the whole body and the interior cover (#2289) finds
+  no compact anchor. The hardest, highest-count remainder.
+- **1,104 converted, of which 62 over-pin** (`match` >40 lines AND ≤2 holes;
+  another 95 are >40 lines but well-holed and ship). The 62 break down as **46
+  neighbor-context "neighbor declaration kept whole" (backlog 3), 11 function/class
+  whole-body (no compact anchor — the skip tail by another name), 2
+  class-expression `const X = class {…}` kept whole (backlog 4), 2 misc**. The two
+  named shapes are clean fixable gaps captured as ignored E2E cases.
 
-**Takeaway:** the ~200 bulky-convertible are the cheap recovery (over-pin waves,
-mostly object-shaped); the ~2,024 no-sparse are the structural long tail (whole-
-body interior holing + anchoring). Re-measure this split after each wave lands.
+**Takeaway:** the conversion rate is now high; the new debt is **over-pin**, not
+non-conversion. The 62 hard over-pins concentrate in two fixable shapes (backlog
+3–4); fixing those plus the matcher-perf item (backlog 5) is the next wave.
+Re-measure after each lands.
 
 ## Backlog (open only)
 
@@ -340,6 +336,36 @@ not annotated; the landed architecture is in "Current state" above.
    Removing `minimize_var_group_selector`'s escalation path, `collect_expr_anchors`,
    and `AnchorCandidates::{shallow_literals,deep_cover_tiers}` is gated on a
    tuple-aware read-off for those residual groups (or accepting them as debt).
+3. **Hole the neighbor declaration in enclosing-context anchoring** (#2315 follow-up;
+   dominant dogfood over-pin, 46/62). When `render_via_neighbor_context` anchors a
+   near-duplicate / empty-scaffold target to a stable neighbor that is itself a
+   **function or class declaration**, it pins the neighbor's body verbatim instead
+   of running the neighbor back through the per-form read-off (hole the
+   name/params, keep only its discriminating value anchor). The 2-statement-window
+   anchoring already works for call-statement neighbors
+   (`neighbor_context_duplicate_helper`); this extends the same holing to
+   declaration neighbors. Ignored E2E:
+   `neighbor_context_whole_function_neighbor`. Real analogues: the
+   `SubscriptionFlow` / `nodeDisplayName` wrappers (preceding component kept
+   whole); largest `features/search/popoverState.yaml::$rt` at 904 lines.
+4. **Route class-expression initializers through the class read-off.**
+   `try_var_read_off`'s `hole_expr` has no `Expr::Class` arm, so
+   `const X = class {…}` is pinned whole (0 holes) while the equivalent class
+   _declaration_ minimizes via `minimize_class_selector` (CLASS_REST holing). Add a
+   `hole_expr` `Expr::Class` arm (or detect a class-expression-valued declarator and
+   dispatch to the class read-off, wrapping its output back in the `const … = class`
+   initializer). Ignored E2E: `class_expression_const_whole_body`. Real analogues:
+   `GoogleApiClient` (314 lines), `SearchState` (300 lines), both 0-hole.
+5. **Journaled `AlphaMatchScope` + cheaper prove-gate fan-out** (perf). The whole-spec
+   apply regressed to ~13 s (from ~7 s) because the new conversion paths run the
+   prove-gate matcher far more (it is now **58% inclusive** of the run), and
+   `AstWildcardMatcher::{snapshot,restore,with_alpha_scope}` ≈ **17%** is the
+   `BTreeMap<Atom,Atom>` alpha-scope being cloned/dropped per backtrack — the same
+   pattern #2291 fixed for the shape index, one layer down. Replace clone-on-snapshot
+   with an undo-log (pop the keys added since the snapshot), switch `forward`/`backward`
+   to `FxHashMap`, and prune the neighbor/group prove-gate fan-out by the
+   candidate-index intersection. Full profile:
+   <../debug/selector_minimizer_perf.md>.
 
 ## Orchestration & process notes
 


### PR DESCRIPTION
## What

Dogfooded the current `spec synthesize-selectors` minimizer against the whole real
gaffer `tana/re/web/78d928dca7` spec (the ~7 MB `index-DI2GynTv` chunk), measured
what it does, and captured the residual over-pin shapes as anonymized **ignored**
expectation cases.

## Findings

Whole-spec `--apply` (`-c opt`):

| metric | value |
| --- | --- |
| fragile `binding.name` members | 2227 |
| **converted** | **1104 (~50%)** |
| skipped (no sparse selector) | 1123 |
| wall | 13.1 s |

The ~50% conversion is a big jump from the ~9%-convertible recorded after gaffer
#360 — the post-#2291 capabilities (#2310/#2315/#2289/#2306) recover most of the
previously-skipped whole-body tail. But the new paths also introduced over-pin
debt: **62 of the 1104 conversions are >40-line, ≤2-hole selectors**, concentrated
in two clean, fixable shapes with no existing coverage.

## Two new ignored expectation cases

Both are minimal anonymized reproductions, verified to fail today and to pass once
the gap closes (per the file's "document target behavior" contract):

- **`neighbor_context_whole_function_neighbor`** (dominant, 46/62) — enclosing-context
  anchoring (#2315) picks the right stable neighbor but, when it is a function
  _declaration_, pins its body verbatim instead of running it back through the
  per-form read-off. Real analogues: the `SubscriptionFlow`/`nodeDisplayName`
  wrappers; the largest is a 904-line / 1-hole selector.
- **`class_expression_const_whole_body`** — `const X = class {…}` is pinned whole
  (0 holes) because `try_var_read_off`'s `hole_expr` has no `Expr::Class` arm, so the
  class initializer never reaches the class read-off. The equivalent class
  _declaration_ minimizes correctly (control verified). Real analogues:
  `GoogleApiClient` (314 lines), `SearchState` (300 lines).

## Profiling (real profiler)

`perf` is unavailable in the container, so re-profiled the whole-spec apply under
**callgrind**. Wall regressed to ~13 s (from the ~7 s #2291 recorded) because the
new paths convert ~5× more members, each driving the prove-gate matcher — which is
now **58% inclusive** of the run. ~17% is `AstWildcardMatcher::{snapshot,restore,
with_alpha_scope}` cloning/dropping `AlphaMatchScope`'s `BTreeMap<Atom,Atom>` per
backtrack — the **same pattern #2291 fixed for the shape index, one layer down**.
Ranked fixes (journaled undo-log snapshot, `FxHashMap` scope, prune prove-gate
fan-out) recorded as backlog item 5.

## Files

- 2 new fixtures + ignored cases in `e2e/selector_minimizer_expectation_test.rs`
- `debug/selector_minimizer_dogfood.md` — fresh survey
- `debug/selector_minimizer_perf.md` — callgrind re-profile + targets
- `plans/readoff_minimization.md` — refreshed debt + backlog items 3–5
- `debug/perf/.../command.sh` — profile reproducer

The active expectation suite stays green; the two new cases are `#[ignore]`d.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016vpknksSPe3PoneXhDogyx)_