### PR TITLE
debundle: hole sequence/ternary exprs so seq-constructor anchors pin by content

### DIFF
--- a/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
+++ b/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
@@ -215,10 +215,14 @@ fn mapping_string_keys(value: &serde_yaml::Value) -> BTreeSet<String> {
 /// (indentation, line breaks, trailing commas).
 fn normalize_selector(source: &str) -> String {
     js_ast::with_swc_globals(|| {
-        let module =
-            js_ast::parse_js_module_ast("<selector expectation>", source).unwrap_or_else(|err| {
+        let mut module = js_ast::parse_js_module_ast("<selector expectation>", source)
+            .unwrap_or_else(|err| {
                 panic!("selector is not parseable JavaScript ({err}):\n{source}")
             });
+        // Compare paren-insensitively: the renderer drops redundant parens, prettier
+        // re-adds them to the expected fixture, and the matcher itself sees through
+        // parens — so canonicalize both sides before comparing.
+        js_ast::strip_parens(&mut module);
         js_ast::emit_module_source(&module).expect("emit normalized selector")
     })
 }
@@ -593,17 +597,20 @@ minimizer_expectation_case!(
 );
 
 // A SINGLE-target class with no same-shape sibling holes its body down to one
-// stable value anchor, absorbing every other member and the constructor with
-// CLASS_REST and holing the kept member's body with STMT_LIST. The empty scaffold
-// `class SelectedRunner { CLASS_REST; }` resolves uniquely (it is the only class)
-// but pins nothing rebuild-stable (criterion 5); the robustness-anchor policy
-// instead drills to a value anchor. The candidate index already collects literals
-// inside method bodies, but the *minimal* anchor (`NumberLiteral("0")`, in class
-// fields / a `void 0`) renders to a constructor the holer keeps verbatim, which
-// fails to prove. The renderer then walks the target's individually-discriminating
-// value anchors best-first (issue #2289 item 1) and lands on `"running"` inside
-// `applyChange`, holing the receiver chain to `ANYTHING.set("running")` — sparser
-// and more rebuild-robust than pinning the minified `this.boxedStatus` receiver.
+// stable value anchor, absorbing the other members with CLASS_REST. The empty
+// scaffold `class SelectedRunner { CLASS_REST; }` resolves uniquely (it is the only
+// class) but pins nothing rebuild-stable (criterion 5); the robustness-anchor
+// policy instead drills to a value anchor. The *minimal* anchor is
+// `NumberLiteral("0")` — but `0` occurs three times in the body (the two `= 0`
+// fields and the `void 0` inside the constructor's sequence), so pinning it keeps
+// all three sites and drags in unrelated members. The read-off's span preference
+// therefore defers that multi-occurrence anchor and walks the single-occurrence
+// value anchors best-first, landing on the cheapest one — the `name` object key in
+// the constructor's `boxedStatus = box(…, { name: … })` — holing the receiver, the
+// `box` callee, the `"stopped"` argument, the value, and every other sequence
+// element. The constructor body holes through the `hole_expr` sequence/ternary arms
+// (the same arms that fix `class_sequence_constructor_body`); before they landed
+// `0` rendered to a verbatim constructor the matcher rejected, masking this choice.
 // The real-survey whole-body over-pin
 // (`domains/search/live_search/ComputedViewRunner.yaml`, ~900 lines kept whole;
 // ~360 other fully-verbatim conversions) only manifests when same-shape SIBLING
@@ -908,27 +915,19 @@ minimizer_expectation_case!(
     expected = "expected_match.js",
 );
 
-// IGNORED (dogfood over-pin, 2026-06-17): a class whose only discriminating
-// content lives inside its constructor's **sequence-expression** body
-// (`constructor(...) { (super(a), this.x = b, this.label = "token"); }`) over-pins
-// to enclosing-context anchoring instead of pinning that own anchor. `hole_expr`
-// (render.rs) has no `Expr::Seq` arm, so a comma-sequence falls to its
-// `_ => expr.clone()` "unmodeled shape" fallback: the read-off cannot hole the
-// sequence down to the discriminating `this.label = "selected-error-token"`
-// assignment, so every value-anchor candidate keeps the sequence verbatim (raw
-// sibling subtrees the prove-gate rejects), the bare scaffold is ambiguous among
-// same-shape sibling error classes, and the class falls to
-// `render_via_neighbor_context` — which pins the unrelated preceding
-// `serializeState` neighbor whole and holes the whole class body to `ANYTHING`.
-// Control: the identical class written with plain statement assignments (no
-// sequence) already minimizes to
-// `constructor(ANYTHING, ANYTHING, ANYTHING) { STMT_LIST; ANYTHING.label = "selected-error-token"; }`
-// with no neighbor, so the gap is purely the sequence-expression form never
-// reaching a holer. Fix: an `Expr::Seq` arm in `hole_expr` (hole each non-anchor
-// element to `ANYTHING`, recurse into the anchored one), exactly parallel to the
-// missing `Expr::Class` arm behind `class_expression_const_whole_body`.
+// A class whose only discriminating content sits inside its constructor's
+// **sequence (comma) expression** body
+// (`constructor(...) { (super(a), this.x = b, this.label = "token"); }`) pins by
+// that own anchor, not via a neighbor. `hole_expr`'s `Expr::Seq` arm holes each
+// non-anchor element to `ANYTHING` and recurses into the anchored one, and the
+// matcher sees through the source's `(a, b, c)` parens, so the read-off keeps the
+// discriminating `this.label = "selected-error-token"` (holed to
+// `ANYTHING.label = "selected-error-token"`). Without those two pieces the
+// sequence stayed verbatim (raw sibling subtrees the prove-gate rejects), the bare
+// scaffold was ambiguous among same-shape sibling error classes, and the class
+// fell to `render_via_neighbor_context`, pinning the unrelated preceding
+// `serializeState` neighbor whole — the over-pin this case originally captured.
 minimizer_expectation_case!(
-    #[ignore = "class anchor inside a constructor sequence-expression body over-pins to neighbor context; hole_expr has no Expr::Seq arm"]
     minimizes_class_sequence_constructor_body,
     fixture = "class_sequence_constructor_body",
     name = "class anchor inside a constructor sequence expression is holed in place, not pinned via a neighbor",

--- a/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/single_target_class_whole_body/expected_match.js
+++ b/devinfra/js/debundle/e2e/testdata/selector_minimizer_expectations/single_target_class_whole_body/expected_match.js
@@ -1,8 +1,14 @@
 class SelectedRunner {
-  ANYTHING;
-  applyChange(ANYTHING) {
-    STMT_LIST;
-    ANYTHING.set("running");
+  constructor(ANYTHING, ANYTHING, ANYTHING, ANYTHING) {
+    (ANYTHING,
+      ANYTHING,
+      ANYTHING,
+      ANYTHING,
+      ANYTHING,
+      (ANYTHING.boxedStatus = ANYTHING(ARGS, { name: ANYTHING })),
+      ANYTHING,
+      ANYTHING,
+      ANYTHING);
   }
   ANYTHING;
 }

--- a/devinfra/js/debundle/js_ast.rs
+++ b/devinfra/js/debundle/js_ast.rs
@@ -5,7 +5,7 @@ use swc_atoms::Atom;
 use swc_common::comments::{Comment, CommentKind, Comments, SingleThreadedComments};
 use swc_common::sync::Lrc;
 use swc_common::{BytePos, DUMMY_SP, FileName, GLOBALS, Globals, Mark, SourceMap, Spanned};
-use swc_ecma_ast::{Decl, Module, ModuleDecl, ModuleItem, Pat, Stmt, Str};
+use swc_ecma_ast::{Decl, Expr, Module, ModuleDecl, ModuleItem, Pat, Stmt, Str};
 use swc_ecma_codegen::text_writer::JsWriter;
 use swc_ecma_codegen::{Config, Emitter};
 use swc_ecma_parser::{Parser, StringInput, Syntax, TsSyntax, lexer::Lexer};
@@ -270,6 +270,24 @@ pub fn emit_module_source(module: &Module) -> Result<String> {
         emitter.emit_module(module)?;
     }
     Ok(String::from_utf8(buf)?.trim_end().to_string())
+}
+
+/// Strip every `(expr)` parenthesization, replacing it with its inner expression.
+/// Parens are syntactically insignificant grouping, so removing them canonicalizes
+/// an AST: two expressions that differ only in redundant parens emit identically
+/// after this pass. Mirrors the source-match matcher, which sees through parens on
+/// both sides — use it to compare selector shapes paren-insensitively.
+pub fn strip_parens(module: &mut Module) {
+    struct ParenStripper;
+    impl swc_ecma_visit::VisitMut for ParenStripper {
+        fn visit_mut_expr(&mut self, expr: &mut Expr) {
+            expr.visit_mut_children_with(self);
+            if let Expr::Paren(paren) = expr {
+                *expr = (*paren.expr).clone();
+            }
+        }
+    }
+    module.visit_mut_with(&mut ParenStripper);
 }
 
 /// Number of post-comma-list-split positions a top-level body item

--- a/devinfra/js/debundle/minimize/mod.rs
+++ b/devinfra/js/debundle/minimize/mod.rs
@@ -87,11 +87,17 @@ fn render_via_read_off(
         .get(decl.body_idx)
         .context("read-off body index no longer in module")?;
 
-    // Primary read-off: the single minimal anchor set. When its value anchor
-    // renders to a holed selector that proves uniquely, keep it.
+    // Primary read-off: the minimal anchor set. Keep it when its holed selector
+    // proves uniquely — except the degenerate case of a single (OPT=1) feature that
+    // occurs *several times* in the target (e.g. the literal `0`, which also hides
+    // inside `void 0`): pinning it keeps every occurrence and drags in unrelated
+    // members, so a multi-occurrence single anchor defers to the value-anchor walk
+    // below, which prefers a single-occurrence leaf. A genuine multi-feature cover
+    // (`!opt_one`) legitimately keeps several spans and is taken here.
     if let Some(anchor_set) = index.shape_index.minimal_anchor_set(decl.body_idx) {
         let kept = kept_spans_for_anchor_set(item, &anchor_set);
         if !kept.is_empty()
+            && (!anchor_set.opt_one || kept.len() == 1)
             && let Some(selector) =
                 finish_minimized_selector(index, decl, target, render_with(&kept)?)?
         {
@@ -99,23 +105,26 @@ fn render_via_read_off(
         }
     }
 
-    // Robustness-anchor fallback: the minimal anchor's *value* may not survive
-    // holing — a deep literal whose only occurrence sits inside a large statement
-    // the holer keeps verbatim leaves raw subtrees the matcher rejects, and a
-    // structural-only minimal set keeps nothing at all. Rather than collapse to
-    // the degenerate scaffold, walk the target's individually-discriminating value
-    // anchors best-first and emit the first whose holed selector proves uniquely.
-    // This is what drills a whole-body class/component down to one anchored member
-    // (e.g. `applyChange(ANYTHING) { STMT_LIST; ANYTHING.set("running"); }`,
-    // anchoring on the `"running"` literal) instead of `class X { CLASS_REST }`.
-    for anchor_set in index
+    // Robustness-anchor fallback: walk the target's individually-discriminating
+    // value anchors, preferring those that pin the *fewest* source spans (a
+    // single-occurrence leaf over a literal repeated across the body), then by the
+    // shape index's rank (stable sort keeps the rank order within a span count).
+    // Emit the first whose holed selector proves uniquely. The minimal anchor's
+    // value may not survive holing (a deep literal whose only home is a large
+    // statement the holer keeps verbatim leaves raw subtrees the matcher rejects),
+    // so this is also where a whole-body class/component drills down to one anchored
+    // member (e.g. `applyChange(ANYTHING) { STMT_LIST; ANYTHING.set("running"); }`)
+    // instead of `class X { CLASS_REST }`.
+    let mut value_kept: Vec<BTreeSet<AnchorSpan>> = index
         .shape_index
         .unique_value_anchor_candidates(decl.body_idx)
-    {
-        let kept = kept_spans_for_anchor_set(item, &anchor_set);
-        if !kept.is_empty()
-            && let Some(selector) =
-                finish_minimized_selector(index, decl, target, render_with(&kept)?)?
+        .into_iter()
+        .map(|anchor_set| kept_spans_for_anchor_set(item, &anchor_set))
+        .filter(|kept| !kept.is_empty())
+        .collect();
+    value_kept.sort_by_key(BTreeSet::len);
+    for kept in value_kept {
+        if let Some(selector) = finish_minimized_selector(index, decl, target, render_with(&kept)?)?
         {
             return Ok(Some(selector));
         }

--- a/devinfra/js/debundle/render.rs
+++ b/devinfra/js/debundle/render.rs
@@ -138,6 +138,24 @@ pub(crate) fn hole_expr(expr: &Expr, kept: &BTreeSet<AnchorSpan>) -> Expr {
         }
         Expr::Object(object) => Expr::Object(hole_object(object, kept)),
         Expr::Array(array) => Expr::Array(hole_array(array, kept)),
+        // Sequence (comma) expression (`(super(a), this.x = b, this.label = "tok")`):
+        // hole each element the way [`hole_array`] holes array elements — a non-anchor
+        // element collapses to `ANYTHING` through the leading guard, the anchored one
+        // recurses. A discriminating leaf buried in a comma-sequence (e.g. an error
+        // subclass whose entire constructor body is one sequence statement) is holed in
+        // place rather than kept verbatim; keeping it verbatim leaves raw sibling
+        // subtrees the matcher rejects, forcing the read-off all the way to
+        // enclosing-context anchoring. Arity-exact (no run hole), mirroring the array
+        // path.
+        Expr::Seq(seq) => {
+            let mut holed = seq.clone();
+            holed.exprs = seq
+                .exprs
+                .iter()
+                .map(|element| Box::new(hole_expr(element, kept)))
+                .collect();
+            Expr::Seq(holed)
+        }
         Expr::Await(await_expr) => {
             let mut holed = await_expr.clone();
             holed.arg = Box::new(hole_expr(&await_expr.arg, kept));
@@ -153,6 +171,18 @@ pub(crate) fn hole_expr(expr: &Expr, kept: &BTreeSet<AnchorSpan>) -> Expr {
             holed.left = Box::new(hole_expr(&bin.left, kept));
             holed.right = Box::new(hole_expr(&bin.right, kept));
             Expr::Bin(holed)
+        }
+        // Conditional (ternary) `test ? cons : alt`: hole each branch so a
+        // discriminating leaf in one branch is kept and the rest collapses to
+        // `ANYTHING`, instead of pinning the whole ternary verbatim (which keeps raw
+        // sibling subtrees). Reached e.g. when a kept anchor sits inside a
+        // `x ? new Y(x) : void 0` initializer in a holed sequence element.
+        Expr::Cond(cond) => {
+            let mut holed = cond.clone();
+            holed.test = Box::new(hole_expr(&cond.test, kept));
+            holed.cons = Box::new(hole_expr(&cond.cons, kept));
+            holed.alt = Box::new(hole_expr(&cond.alt, kept));
+            Expr::Cond(holed)
         }
         // Assignment expression (`state.delta = "value"`): the dominant statement
         // shape in sequential write-block bodies. Hole the LHS target's receiver

--- a/devinfra/js/debundle/source_match/matcher.rs
+++ b/devinfra/js/debundle/source_match/matcher.rs
@@ -510,6 +510,19 @@ impl<'a> AstWildcardMatcher<'a> {
     }
 
     fn match_expr(&mut self, needle: &Expr, candidate: &Expr) -> bool {
+        // Parentheses are syntactically insignificant grouping; see through them on
+        // either side. The renderer drops redundant parens when holing (`hole_expr`'s
+        // `Expr::Paren` arm), so a holed needle — e.g. a holed comma sequence, whose
+        // source form is the parenthesized `(a, b, c)` — must still match the
+        // parenthesized source expression; hand-written selectors may likewise include
+        // or omit them. Strict superset of the former paren-vs-paren-only arm, and it
+        // keeps selectors robust to a rebuild adding or dropping redundant parens.
+        if let Expr::Paren(needle) = needle {
+            return self.match_expr(&needle.expr, candidate);
+        }
+        if let Expr::Paren(candidate) = candidate {
+            return self.match_expr(needle, &candidate.expr);
+        }
         if let Some(pattern) = string_literal_regex_pattern(needle) {
             return match candidate {
                 Expr::Lit(Lit::Str(candidate)) => self.string_literal_regexes.map_or_else(
@@ -612,9 +625,6 @@ impl<'a> AstWildcardMatcher<'a> {
             }
             (Expr::Await(needle), Expr::Await(candidate)) => {
                 self.match_expr(&needle.arg, &candidate.arg)
-            }
-            (Expr::Paren(needle), Expr::Paren(candidate)) => {
-                self.match_expr(&needle.expr, &candidate.expr)
             }
             (Expr::JSXElement(needle), Expr::JSXElement(candidate)) => {
                 self.match_jsx_element(needle, candidate)


### PR DESCRIPTION
## What

Implements the `Expr::Seq` arm that the ignored `class_sequence_constructor_body`
expectation (added in #2330) was filed against, plus the supporting pieces needed
to make a sequence-expression-bodied target actually pin by its **own content**
instead of an unrelated neighbor.

The motivating over-pin: an error subclass whose entire constructor body is one
parenthesized comma sequence —

```js
class PlatformError extends Error {
  constructor(e, t, r) {
    (super(e), (this.statusCode = t), (this.extras = r), (this.name = "PlatformError"));
  }
}
```

— was pinned via the preceding (unrelated) declaration kept whole, with the class
body stubbed to `ANYTHING`, because the discriminating `this.name = "…"` anchor
sat inside a sequence `hole_expr` couldn't hole.

## Changes

- **`render.rs`** — add `Expr::Seq` and `Expr::Cond` arms to `hole_expr`. A
  comma-sequence and a ternary now hole each element/branch around the kept anchor
  instead of falling to the `_ => clone` verbatim fallback (which left raw subtrees
  the matcher rejects). Arity-exact, mirroring the array path.
- **`source_match/matcher.rs`** — see through parens on either side in
  `match_expr`. The renderer drops redundant parens when holing, so a holed comma
  sequence (source form `(a, b, c)`) must still match the parenthesized source.
  Strict superset of the former paren-vs-paren-only arm; also makes selectors
  robust to a rebuild adding/dropping redundant parens.
- **`minimize/mod.rs`** — prefer value anchors that pin the **fewest** source
  spans. A single OPT=1 feature occurring several times in the body (the literal
  `0`, also hiding in `void 0`) would pin every occurrence and drag in unrelated
  members; defer it and walk single-occurrence anchors first.
- **`js_ast.rs`** — add `strip_parens`, used by the expectation test to compare
  selector shapes paren-insensitively (matching the matcher).

## Fixtures

- **Unignores `class_sequence_constructor_body`** — now pins
  `ANYTHING.label = "selected-error-token"` inside the constructor sequence, no
  neighbor.
- **Updates `single_target_class_whole_body`** — now drills to the constructor's
  `boxedStatus = box(…, { name: … })` member rather than failing to hole the
  constructor and falling back to `applyChange`. (It anchors the `name` object key;
  see note below.)

## Validation

- All **117 `//devinfra/js/debundle/...` tests pass** (matcher units, selector
  minimizer proptest, syntactic holes, full expectation suite).
- `nix develop` pre-commit clean.
- Built/tested with `bazelisk` + system-Java truststore + RBE.

## Note / possible follow-up

`single_target_class_whole_body` now anchors the `name` object key (value holed)
rather than the old `"running"` string value. Both are class-0 anchors per the
ranking design, and it's a clean single-member pin, but a key with its value holed
is a weaker discriminator than a string value. This is a `cost`-tiebreak artifact
amplified by the fixture's trivial siblings (in a real chunk `{ name: … }` would
not be unique). Making the ranking prefer literal **values** over object **keys**
is a separate, broader change not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7wbQibmuz5nX9dTzT7PzU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7wbQibmuz5nX9dTzT7PzU)_