### PR TITLE
debundle: `spec match-selector` — selector query + holing-slack probe (M1)

### DIFF
--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -613,6 +613,7 @@ rust_test(
 rust_library(
     name = "selector_codemod",
     srcs = [
+        "match_selector.rs",
         "minimize/class.rs",
         "minimize/function.rs",
         "minimize/group.rs",

--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -65,6 +65,11 @@ One-line status for each `plans/` design doc; this is the discovery index.
   inventory/plan/apply/validate CLI surface and the synthesize / stabilize /
   version-port / new-app-bootstrap flows. Foundational milestones realized by the
   read-off work; repair-report, version-port, and bootstrap flows not started.
+- <plans/selector_authoring_agent.md> — **in progress.** Reframes selector choice as an
+  agent task: the `debundle_stabilize` skill picks forward-compatible anchors; the
+  minimizer is demoted to suggester + uniqueness oracle. Plan + skill landed (#2332);
+  the `match-selector` query + over-pin slack primitive landed (#2335). Open:
+  `--candidates N` and port-based evaluation.
 - <plans/adopt_names_via_bijection.md> — **not started.** Expose the `source_match`
   identifier bijection so one selector both locates a declaration and adopts
   readable names onto its params/locals/nested bindings.

--- a/devinfra/js/debundle/cli/mod.rs
+++ b/devinfra/js/debundle/cli/mod.rs
@@ -33,6 +33,9 @@ use peel::{
     run_source_slice_report, run_units_report,
 };
 use pipeline::{TransformArgs, TransformRunOptions, run_transform_cli_with_options};
+use selector_codemod::match_selector::{
+    MatchSelectorConfig, render_match_selector_text, run_match_selector,
+};
 use selector_codemod::{
     SelectorCodemodConfig, SelectorCodemodRewrite, render_selector_codemod_text,
     run_selector_codemod,
@@ -41,6 +44,7 @@ use selector_debt::{
     SelectorDebtReport, SourceAwareSelectorDebtConfig, compute_selector_debt_with_source,
     populate_name_only_module_groups, render_selector_debt_text,
 };
+use spec::SourceMatchIdentifierMode;
 use spec_modules::{collect_module_files, module_path_from_file};
 use spec_stats::{SpecStats, compute_spec_stats, render_spec_stats_text};
 
@@ -125,6 +129,11 @@ enum SpecNsCommand {
     /// Synthesize structural selectors for selected name-only members.
     #[command(name = "synthesize-selectors")]
     SynthesizeSelectors(SelectorCodemodArgs),
+    /// Resolve a candidate `source_match` against a chunk and report what it
+    /// binds: the matching items, and whether it pins a unique target. The
+    /// interactive prove-gate probe for authoring forward-compatible selectors.
+    #[command(name = "match-selector")]
+    MatchSelector(MatchSelectorArgs),
     /// Keep-going selector validation: report every selector problem
     /// (no-match, ambiguous, duplicate-claim, resolution error) in one
     /// machine-readable pass.
@@ -274,6 +283,58 @@ pub struct SelectorCodemodArgs {
     /// Restrict source-aware rewrites to module:export items.
     #[arg(long = "item")]
     pub items: Vec<String>,
+
+    /// Output format. Default `text` on tty, `json` on pipe.
+    #[arg(long, value_enum)]
+    pub format: Option<OutputFormat>,
+}
+
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub enum SourceMatchIdentifierModeArg {
+    /// Match identifiers literally (the selector's spelling must match).
+    Exact,
+    /// Treat binding/value identifiers as alpha-renamable placeholders — the
+    /// authoring norm for selectors that survive minifier renames.
+    AlphaAll,
+}
+
+impl From<SourceMatchIdentifierModeArg> for SourceMatchIdentifierMode {
+    fn from(value: SourceMatchIdentifierModeArg) -> Self {
+        match value {
+            SourceMatchIdentifierModeArg::Exact => Self::Exact,
+            SourceMatchIdentifierModeArg::AlphaAll => Self::AlphaAll,
+        }
+    }
+}
+
+/// Args for `debundle spec match-selector`.
+#[derive(Debug, ClapArgs)]
+pub struct MatchSelectorArgs {
+    /// Direct source JS file to resolve the selector against.
+    #[arg(long = "source-file")]
+    pub source_file: Option<PathBuf>,
+
+    /// Source root used with `--chunk`.
+    #[arg(long = "source-root", env = "DEBUNDLE_SOURCE_ROOT")]
+    pub source_root: Option<PathBuf>,
+
+    /// Chunk path relative to `--source-root`, e.g. `static/index.js`.
+    #[arg(long = "chunk")]
+    pub chunk: Option<PathBuf>,
+
+    /// The candidate `source_match` `match` text to test.
+    #[arg(long = "match")]
+    pub match_source: String,
+
+    /// Identifier policy for the candidate selector.
+    #[arg(long = "identifiers", value_enum, default_value_t = SourceMatchIdentifierModeArg::AlphaAll)]
+    pub identifiers: SourceMatchIdentifierModeArg,
+
+    /// Selector-local binding to claim (sets `target_binding`) when the match
+    /// declares more than one binding.
+    #[arg(long = "target-binding")]
+    pub target_binding: Option<String>,
 
     /// Output format. Default `text` on tty, `json` on pipe.
     #[arg(long, value_enum)]
@@ -612,6 +673,7 @@ pub fn run_debundle_cli(args: DebundleArgs) -> Result<()> {
                 s.rewrite = SelectorCodemodRewriteArg::NameBindingToSourceMatch;
                 run_selector_codemod_cmd(s)
             }
+            SpecNsCommand::MatchSelector(s) => run_match_selector_cmd(s),
             SpecNsCommand::Validate(v) => {
                 run_validate_cmd(v).context("running keep-going selector validation")
             }
@@ -697,6 +759,20 @@ fn run_selector_codemod_cmd(args: SelectorCodemodArgs) -> Result<()> {
     })?;
     print_report(&report, format, render_selector_codemod_text)
         .context("writing selector-codemod output")
+}
+
+fn run_match_selector_cmd(args: MatchSelectorArgs) -> Result<()> {
+    let format = OutputFormat::resolve(args.format);
+    let report = run_match_selector(&MatchSelectorConfig {
+        source_file: args.source_file,
+        source_root: args.source_root,
+        chunk: args.chunk,
+        match_source: args.match_source,
+        identifiers: args.identifiers.into(),
+        target_binding: args.target_binding,
+    })?;
+    print_report(&report, format, render_match_selector_text)
+        .context("writing match-selector output")
 }
 
 /// Dispatch an `<id>` argument into a [`SelectionArgs`] populated with

--- a/devinfra/js/debundle/cli/mod.rs
+++ b/devinfra/js/debundle/cli/mod.rs
@@ -130,8 +130,9 @@ enum SpecNsCommand {
     #[command(name = "synthesize-selectors")]
     SynthesizeSelectors(SelectorCodemodArgs),
     /// Resolve a candidate `source_match` against a chunk and report what it
-    /// binds: the matching items, and whether it pins a unique target. The
-    /// interactive prove-gate probe for authoring forward-compatible selectors.
+    /// binds: the matching items, whether it pins a unique target, and (unless
+    /// `--no-slack`) which kept values could be holed further without losing
+    /// uniqueness. The interactive prove-gate probe for selector authoring.
     #[command(name = "match-selector")]
     MatchSelector(MatchSelectorArgs),
     /// Keep-going selector validation: report every selector problem
@@ -335,6 +336,11 @@ pub struct MatchSelectorArgs {
     /// declares more than one binding.
     #[arg(long = "target-binding")]
     pub target_binding: Option<String>,
+
+    /// Skip holing-slack analysis (report matches only). Slack is computed by
+    /// default when the selector pins a unique target.
+    #[arg(long = "no-slack")]
+    pub no_slack: bool,
 
     /// Output format. Default `text` on tty, `json` on pipe.
     #[arg(long, value_enum)]
@@ -770,6 +776,7 @@ fn run_match_selector_cmd(args: MatchSelectorArgs) -> Result<()> {
         match_source: args.match_source,
         identifiers: args.identifiers.into(),
         target_binding: args.target_binding,
+        check_slack: !args.no_slack,
     })?;
     print_report(&report, format, render_match_selector_text)
         .context("writing match-selector output")

--- a/devinfra/js/debundle/e2e/BUILD.bazel
+++ b/devinfra/js/debundle/e2e/BUILD.bazel
@@ -400,6 +400,20 @@ rust_test(
     ],
 )
 
+# `debundle spec match-selector`: the prove-gate probe resolving a candidate
+# source_match against a chunk and reporting matches + uniqueness verdict.
+rust_test(
+    name = "match_selector_cli_test",
+    srcs = ["match_selector_cli_test.rs"],
+    crate_root = "match_selector_cli_test.rs",
+    data = ["//devinfra/js/debundle"],
+    edition = "2024",
+    deps = [
+        "@crates//:serde_json",
+        "@crates//:tempfile",
+    ],
+)
+
 # Ignored target-behavior examples for recursive selector minimization.
 # Each case can be unignored independently as that selector shape lands.
 rust_test(

--- a/devinfra/js/debundle/e2e/BUILD.bazel
+++ b/devinfra/js/debundle/e2e/BUILD.bazel
@@ -401,7 +401,8 @@ rust_test(
 )
 
 # `debundle spec match-selector`: the prove-gate probe resolving a candidate
-# source_match against a chunk and reporting matches + uniqueness verdict.
+# source_match against a chunk and reporting matches, uniqueness verdict, and
+# holing slack (which kept values could be holed further).
 rust_test(
     name = "match_selector_cli_test",
     srcs = ["match_selector_cli_test.rs"],

--- a/devinfra/js/debundle/e2e/match_selector_cli_test.rs
+++ b/devinfra/js/debundle/e2e/match_selector_cli_test.rs
@@ -60,10 +60,17 @@ fn match_selector(source: &Path, match_source: &str, extra: &[&str]) -> Value {
 }
 
 // leftPanel and rightPanel differ only by their string argument; widgetConfig is
-// the lone `makeWidget` call.
+// the lone `makeWidget` call; errorState is the lone object literal; computeTotal
+// is the lone function declaration.
 const CHUNK: &str = r#"const leftPanel = renderPanel("left");
 const widgetConfig = makeWidget("widget", 3, theme);
 const rightPanel = renderPanel("right");
+const errorState = { kind: "error", code: 500, retry: false };
+function computeTotal(items) {
+  const base = items.length;
+  const tax = base * 2;
+  return base + tax;
+}
 "#;
 
 fn fixture() -> (tempfile::TempDir, PathBuf) {
@@ -135,9 +142,12 @@ fn over_pinned_selector_reports_holeable_slack() {
     assert!(!slack.is_empty(), "expected over-pin slack, got {report}");
     for relaxation in slack {
         let relaxed = relaxation["relaxed_match"].as_str().unwrap();
+        // Every slack variant keeps the discriminating `makeWidget` callee; the
+        // arguments were the unnecessary precision (holed to ANYTHING or dropped
+        // via ARGS).
         assert!(
-            relaxed.contains("makeWidget") && relaxed.contains("ANYTHING"),
-            "relaxed selector should keep the makeWidget anchor and add a hole: {relaxed}"
+            relaxed.contains("makeWidget"),
+            "relaxed selector should keep the makeWidget anchor: {relaxed}"
         );
     }
 }
@@ -169,4 +179,50 @@ fn no_slack_flag_skips_slack_analysis() {
     assert_eq!(report["unique"], Value::Bool(true));
     // With --no-slack the field is omitted even though the selector is unique.
     assert!(report.get("slack").is_none());
+}
+
+#[test]
+fn slack_drops_an_unneeded_object_property() {
+    let (_dir, source) = fixture();
+    // errorState is the only object literal, so any one of its keys alone pins
+    // it — the others are droppable kvps, not just holeable values.
+    let report = match_selector(
+        &source,
+        "const e = { kind: \"error\", code: 500, retry: false };",
+        &["--target-binding", "e"],
+    );
+    assert_eq!(report["unique"], Value::Bool(true));
+    assert_eq!(report["matches"][0]["binding_name"], "errorState");
+    let slack = report["slack"].as_array().unwrap();
+    // A property-drop relaxation removes the `code` kvp entirely (key and value),
+    // which value-holing alone could never do.
+    assert!(
+        slack.iter().any(|relaxation| !relaxation["relaxed_match"]
+            .as_str()
+            .unwrap()
+            .contains("code")),
+        "expected a relaxation that drops the `code` property: {report}"
+    );
+}
+
+#[test]
+fn slack_drops_a_statement_from_an_over_pinned_body() {
+    let (_dir, source) = fixture();
+    // computeTotal is the only function, so its body statements are not needed
+    // for uniqueness and collapse to STMT_LIST runs.
+    let report = match_selector(
+        &source,
+        "function f(items) { const base = items.length; const tax = base * 2; return base + tax; }",
+        &["--target-binding", "f"],
+    );
+    assert_eq!(report["unique"], Value::Bool(true));
+    assert_eq!(report["matches"][0]["binding_name"], "computeTotal");
+    let slack = report["slack"].as_array().unwrap();
+    assert!(
+        slack.iter().any(|relaxation| relaxation["relaxed_match"]
+            .as_str()
+            .unwrap()
+            .contains("STMT_LIST")),
+        "expected a relaxation that drops a body statement: {report}"
+    );
 }

--- a/devinfra/js/debundle/e2e/match_selector_cli_test.rs
+++ b/devinfra/js/debundle/e2e/match_selector_cli_test.rs
@@ -1,6 +1,7 @@
 //! End-to-end coverage for `debundle spec match-selector`: the prove-gate probe
 //! that resolves a candidate `source_match` against a chunk and reports what it
-//! binds and whether it is unique.
+//! binds, whether it is unique, and (by default) how much further it could be
+//! holed.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -58,8 +59,10 @@ fn match_selector(source: &Path, match_source: &str, extra: &[&str]) -> Value {
     })
 }
 
+// leftPanel and rightPanel differ only by their string argument; widgetConfig is
+// the lone `makeWidget` call.
 const CHUNK: &str = r#"const leftPanel = renderPanel("left");
-const widgetConfig = { kind: "widget", label: "Primary" };
+const widgetConfig = makeWidget("widget", 3, theme);
 const rightPanel = renderPanel("right");
 "#;
 
@@ -75,7 +78,7 @@ fn unique_match_reports_the_bound_target() {
     let (_dir, source) = fixture();
     let report = match_selector(
         &source,
-        "const w = { kind: \"widget\", ANYTHING };",
+        "const w = makeWidget(\"widget\", 3, theme);",
         &["--target-binding", "w"],
     );
     assert_eq!(report["unique"], Value::Bool(true));
@@ -95,6 +98,8 @@ fn no_match_is_not_unique() {
     );
     assert_eq!(report["unique"], Value::Bool(false));
     assert!(report["matches"].as_array().unwrap().is_empty());
+    // Slack is undefined for a non-unique selector.
+    assert!(report.get("slack").is_none());
 }
 
 #[test]
@@ -106,10 +111,62 @@ fn ambiguous_match_lists_every_candidate_in_body_order() {
         &["--target-binding", "p"],
     );
     assert_eq!(report["unique"], Value::Bool(false));
-    let matches = report["matches"].as_array().unwrap();
-    let names: Vec<&str> = matches
+    let names: Vec<&str> = report["matches"]
+        .as_array()
+        .unwrap()
         .iter()
         .map(|matched| matched["binding_name"].as_str().unwrap())
         .collect();
     assert_eq!(names, vec!["leftPanel", "rightPanel"]);
+}
+
+#[test]
+fn over_pinned_selector_reports_holeable_slack() {
+    let (_dir, source) = fixture();
+    // The callee + arity already single out the one `makeWidget` call, so the
+    // pinned literal arguments are unnecessary precision.
+    let report = match_selector(
+        &source,
+        "const w = makeWidget(\"widget\", 3, theme);",
+        &["--target-binding", "w"],
+    );
+    assert_eq!(report["unique"], Value::Bool(true));
+    let slack = report["slack"].as_array().unwrap();
+    assert!(!slack.is_empty(), "expected over-pin slack, got {report}");
+    for relaxation in slack {
+        let relaxed = relaxation["relaxed_match"].as_str().unwrap();
+        assert!(
+            relaxed.contains("makeWidget") && relaxed.contains("ANYTHING"),
+            "relaxed selector should keep the makeWidget anchor and add a hole: {relaxed}"
+        );
+    }
+}
+
+#[test]
+fn minimally_pinned_selector_reports_empty_slack() {
+    let (_dir, source) = fixture();
+    // The "left" literal is the only thing distinguishing leftPanel from
+    // rightPanel; holing it would make the selector ambiguous, so there is no
+    // slack to report.
+    let report = match_selector(
+        &source,
+        "const p = renderPanel(\"left\");",
+        &["--target-binding", "p"],
+    );
+    assert_eq!(report["unique"], Value::Bool(true));
+    assert_eq!(report["matches"][0]["binding_name"], "leftPanel");
+    assert!(report["slack"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn no_slack_flag_skips_slack_analysis() {
+    let (_dir, source) = fixture();
+    let report = match_selector(
+        &source,
+        "const w = makeWidget(\"widget\", 3, theme);",
+        &["--target-binding", "w", "--no-slack"],
+    );
+    assert_eq!(report["unique"], Value::Bool(true));
+    // With --no-slack the field is omitted even though the selector is unique.
+    assert!(report.get("slack").is_none());
 }

--- a/devinfra/js/debundle/e2e/match_selector_cli_test.rs
+++ b/devinfra/js/debundle/e2e/match_selector_cli_test.rs
@@ -1,0 +1,115 @@
+//! End-to-end coverage for `debundle spec match-selector`: the prove-gate probe
+//! that resolves a candidate `source_match` against a chunk and reports what it
+//! binds and whether it is unique.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+fn debundle_binary() -> PathBuf {
+    let runfiles_path = std::env::var("RUNFILES_DIR")
+        .or_else(|_| std::env::var("TEST_SRCDIR"))
+        .expect("runfiles env var");
+    let candidate = Path::new(&runfiles_path).join("_main/devinfra/js/debundle/debundle");
+    assert!(
+        candidate.exists(),
+        "debundle binary not at {}",
+        candidate.display()
+    );
+    candidate
+}
+
+fn write(path: &Path, body: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, body).unwrap();
+}
+
+fn match_selector(source: &Path, match_source: &str, extra: &[&str]) -> Value {
+    let mut args = vec![
+        "spec",
+        "match-selector",
+        "--source-file",
+        source.to_str().unwrap(),
+        "--match",
+        match_source,
+        "--format",
+        "json",
+    ];
+    args.extend_from_slice(extra);
+    let out = Command::new(debundle_binary())
+        .args(&args)
+        .output()
+        .expect("spawn debundle");
+    assert!(
+        out.status.success(),
+        "non-zero exit\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    serde_json::from_slice(&out.stdout).unwrap_or_else(|err| {
+        panic!(
+            "stdout is not JSON ({err}):\n{}",
+            String::from_utf8_lossy(&out.stdout)
+        )
+    })
+}
+
+const CHUNK: &str = r#"const leftPanel = renderPanel("left");
+const widgetConfig = { kind: "widget", label: "Primary" };
+const rightPanel = renderPanel("right");
+"#;
+
+fn fixture() -> (tempfile::TempDir, PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let source = dir.path().join("app.js");
+    write(&source, CHUNK);
+    (dir, source)
+}
+
+#[test]
+fn unique_match_reports_the_bound_target() {
+    let (_dir, source) = fixture();
+    let report = match_selector(
+        &source,
+        "const w = { kind: \"widget\", ANYTHING };",
+        &["--target-binding", "w"],
+    );
+    assert_eq!(report["unique"], Value::Bool(true));
+    let matches = report["matches"].as_array().unwrap();
+    assert_eq!(matches.len(), 1);
+    assert_eq!(matches[0]["body_index"], 1);
+    assert_eq!(matches[0]["binding_name"], "widgetConfig");
+}
+
+#[test]
+fn no_match_is_not_unique() {
+    let (_dir, source) = fixture();
+    let report = match_selector(
+        &source,
+        "const w = { kind: \"missing\" };",
+        &["--target-binding", "w"],
+    );
+    assert_eq!(report["unique"], Value::Bool(false));
+    assert!(report["matches"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn ambiguous_match_lists_every_candidate_in_body_order() {
+    let (_dir, source) = fixture();
+    let report = match_selector(
+        &source,
+        "const p = renderPanel(ANYTHING);",
+        &["--target-binding", "p"],
+    );
+    assert_eq!(report["unique"], Value::Bool(false));
+    let matches = report["matches"].as_array().unwrap();
+    let names: Vec<&str> = matches
+        .iter()
+        .map(|matched| matched["binding_name"].as_str().unwrap())
+        .collect();
+    assert_eq!(names, vec!["leftPanel", "rightPanel"]);
+}

--- a/devinfra/js/debundle/match_selector.rs
+++ b/devinfra/js/debundle/match_selector.rs
@@ -1,12 +1,23 @@
 //! `debundle spec match-selector`: resolve a candidate `source_match` against a
-//! chunk and report what it binds.
+//! chunk and report what it binds — and, when it pins a unique target, how much
+//! further it could be holed.
 //!
 //! The interactive prove-gate probe behind the selector-authoring loop
 //! (`plans/selector_authoring_agent.md`): the agent forms an anchor hypothesis,
 //! writes a candidate `match`, and asks "does this resolve to the singleton I
-//! mean, and is it the right one?" before committing the selector to YAML. The
-//! batch minimizer answers the same question with a boolean gate; this exposes
-//! it as a probe that returns the matched handles instead.
+//! mean, and the right one — and did I over-pin it?" before committing the
+//! selector to YAML. Matching and slack share the same parse + baseline resolve,
+//! so they are answered together.
+//!
+//! **Slack** is the mechanical half of "report over-narrow selectors as debt even
+//! when they match": each entry is a kept value-expression that could be holed to
+//! `ANYTHING` while still pinning the same unique target. It is a _heuristic_ for
+//! which pins to revisit, never a verdict — a zero-slack selector can still be
+//! anchored on an incidental key, and the agent still judges whether the
+//! surviving anchor is the right one. Scope: expression-value relaxations (the
+//! dominant over-pin — a pinned literal, argument, or property value); structural
+//! run-hole relaxations (dropping whole properties / members / statements) are a
+//! future extension.
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
@@ -14,6 +25,8 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result, bail};
 use serde::Serialize;
 use spec::{SourceMatch, SourceMatchIdentifierMode};
+use swc_ecma_ast::{Expr, Module};
+use swc_ecma_visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 
 pub struct MatchSelectorConfig {
     pub source_file: Option<PathBuf>,
@@ -22,6 +35,8 @@ pub struct MatchSelectorConfig {
     pub match_source: String,
     pub identifiers: SourceMatchIdentifierMode,
     pub target_binding: Option<String>,
+    /// Also compute holing slack when the selector pins a unique target.
+    pub check_slack: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -33,11 +48,23 @@ pub struct MatchSelectorMatch {
 }
 
 #[derive(Debug, Clone, Serialize)]
+pub struct SlackRelaxation {
+    /// A strictly looser selector — the input with one kept value holed to
+    /// `ANYTHING` — that still resolves to the same unique target.
+    pub relaxed_match: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
 pub struct MatchSelectorReport {
     /// The headline verdict: exactly one item matched, so the selector is a
     /// valid (unique) pin. Zero or several matches both make it unusable.
     pub unique: bool,
     pub matches: Vec<MatchSelectorMatch>,
+    /// Kept value-expressions that could be holed to `ANYTHING` without losing
+    /// uniqueness — a non-empty list flags a likely over-pin. `None` when the
+    /// selector is not unique (slack is undefined) or `--no-slack` skipped it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub slack: Option<Vec<SlackRelaxation>>,
 }
 
 /// Resolve the chunk path from the `--source-file` / `--source-root` + `--chunk`
@@ -71,31 +98,137 @@ fn run_match_selector_impl(config: &MatchSelectorConfig) -> Result<MatchSelector
         .with_context(|| format!("reading source file {}", source_file.display()))?;
     let parsed = js_ast::parse_js_module_consuming(&source_file.display().to_string(), source)
         .with_context(|| format!("parsing source file {}", source_file.display()))?;
-    let selector = SourceMatch {
-        match_source: config.match_source.clone(),
-        identifiers: config.identifiers,
-        target_binding: config.target_binding.clone(),
-        target_statement: None,
-        target_statements: None,
-        wildcard_string_literals: BTreeSet::new(),
-    }
-    .selector();
-    let mut matches: Vec<MatchSelectorMatch> = source_match::member_binding_candidate_matches(
-        &parsed.module,
-        "<match-selector>",
-        &selector,
-    )?
-    .into_iter()
-    .map(|matched| MatchSelectorMatch {
-        body_index: matched.body_idx,
-        binding_name: matched.binding.binding_name,
-    })
-    .collect();
+
+    let resolve = |match_source: String| -> Result<Vec<source_match::MemberBindingMatch>> {
+        let selector = SourceMatch {
+            match_source,
+            identifiers: config.identifiers,
+            target_binding: config.target_binding.clone(),
+            target_statement: None,
+            target_statements: None,
+            wildcard_string_literals: BTreeSet::new(),
+        }
+        .selector();
+        source_match::member_binding_candidate_matches(
+            &parsed.module,
+            "<match-selector>",
+            &selector,
+        )
+    };
+
+    let baseline = resolve(config.match_source.clone())?;
+    let mut matches: Vec<MatchSelectorMatch> = baseline
+        .iter()
+        .map(|matched| MatchSelectorMatch {
+            body_index: matched.body_idx,
+            binding_name: matched.binding.binding_name.clone(),
+        })
+        .collect();
     matches.sort_by_key(|matched| matched.body_index);
+
+    let unique = matches.len() == 1;
+    let slack = match (unique, config.check_slack) {
+        (true, true) => Some(compute_slack(
+            &config.match_source,
+            baseline[0].body_idx,
+            &baseline[0].binding.binding_name,
+            &resolve,
+        )?),
+        _ => None,
+    };
+
     Ok(MatchSelectorReport {
-        unique: matches.len() == 1,
+        unique,
         matches,
+        slack,
     })
+}
+
+/// For each kept value-expression in the selector, try holing it to `ANYTHING`
+/// and keep the relaxation if the selector still resolves to the same unique
+/// `(body_idx, binding_name)` target.
+fn compute_slack(
+    match_source: &str,
+    target_body_idx: usize,
+    target_binding_name: &str,
+    resolve: &impl Fn(String) -> Result<Vec<source_match::MemberBindingMatch>>,
+) -> Result<Vec<SlackRelaxation>> {
+    let mut selector_module =
+        js_ast::parse_js_module_consuming("<match-selector slack>", match_source.to_string())
+            .with_context(|| "parsing the candidate selector for slack analysis")?
+            .module;
+    js_ast::strip_parens(&mut selector_module);
+
+    let mut slack = Vec::new();
+    for index in 0..count_holeable_exprs(&selector_module) {
+        let mut relaxed = selector_module.clone();
+        hole_nth_expr(&mut relaxed, index);
+        let relaxed_match = js_ast::emit_module_source(&relaxed)?;
+        if let [only] = resolve(relaxed_match.clone())?.as_slice() {
+            if only.body_idx == target_body_idx && only.binding.binding_name == target_binding_name
+            {
+                slack.push(SlackRelaxation { relaxed_match });
+            }
+        }
+    }
+    Ok(slack)
+}
+
+/// A value expression that holing to `ANYTHING` would relax. Bare identifiers are
+/// excluded: under `alpha_all` they are already alpha-wildcards (and a hole
+/// keyword is itself an identifier), so holing one removes no real anchor.
+fn is_holeable(expr: &Expr) -> bool {
+    !matches!(expr, Expr::Ident(_) | Expr::Invalid(_))
+}
+
+fn count_holeable_exprs(module: &Module) -> usize {
+    struct Counter {
+        count: usize,
+    }
+    impl Visit for Counter {
+        fn visit_expr(&mut self, expr: &Expr) {
+            if is_holeable(expr) {
+                self.count += 1;
+            }
+            expr.visit_children_with(self);
+        }
+    }
+    let mut counter = Counter { count: 0 };
+    module.visit_with(&mut counter);
+    counter.count
+}
+
+/// Replace the `target`-th holeable expression (pre-order) with `ANYTHING`. The
+/// pre-order walk matches [`count_holeable_exprs`], so index `i` names the same
+/// node across the count and hole passes.
+fn hole_nth_expr(module: &mut Module, target: usize) {
+    struct Holer {
+        target: usize,
+        seen: usize,
+        done: bool,
+    }
+    impl VisitMut for Holer {
+        fn visit_mut_expr(&mut self, expr: &mut Expr) {
+            if self.done {
+                return;
+            }
+            if is_holeable(expr) {
+                if self.seen == self.target {
+                    *expr = crate::render::anything_expr();
+                    self.done = true;
+                    return;
+                }
+                self.seen += 1;
+            }
+            expr.visit_mut_children_with(self);
+        }
+    }
+    let mut holer = Holer {
+        target,
+        seen: 0,
+        done: false,
+    };
+    module.visit_mut_with(&mut holer);
 }
 
 pub fn render_match_selector_text(report: &MatchSelectorReport, out: &mut String) {
@@ -112,5 +245,24 @@ pub fn render_match_selector_text(report: &MatchSelectorReport, out: &mut String
             "  body[{}] -> {}",
             matched.body_index, matched.binding_name
         );
+    }
+    match &report.slack {
+        None => {}
+        Some(slack) if slack.is_empty() => {
+            let _ = writeln!(out, "slack: none (no kept value is holeable)");
+        }
+        Some(slack) => {
+            let _ = writeln!(
+                out,
+                "slack: {} holeable value(s) — likely over-pin",
+                slack.len()
+            );
+            for (i, relaxation) in slack.iter().enumerate() {
+                let _ = writeln!(out, "  [{i}] still unique after holing one value:");
+                for line in relaxation.relaxed_match.lines() {
+                    let _ = writeln!(out, "        {line}");
+                }
+            }
+        }
     }
 }

--- a/devinfra/js/debundle/match_selector.rs
+++ b/devinfra/js/debundle/match_selector.rs
@@ -10,23 +10,37 @@
 //! so they are answered together.
 //!
 //! **Slack** is the mechanical half of "report over-narrow selectors as debt even
-//! when they match": each entry is a kept value-expression that could be holed to
-//! `ANYTHING` while still pinning the same unique target. It is a _heuristic_ for
-//! which pins to revisit, never a verdict — a zero-slack selector can still be
-//! anchored on an incidental key, and the agent still judges whether the
-//! surviving anchor is the right one. Scope: expression-value relaxations (the
-//! dominant over-pin — a pinned literal, argument, or property value); structural
-//! run-hole relaxations (dropping whole properties / members / statements) are a
-//! future extension.
+//! when they match": each entry is a strictly looser variant of the selector —
+//! one kept thing holed — that still pins the same unique target. It is a
+//! _heuristic_ for which pins to revisit, never a verdict: a zero-slack selector
+//! can still be anchored on an incidental key, and the agent still judges whether
+//! the surviving anchors are the right ones.
+//!
+//! Slack tries one relaxation at a time, of these kinds: hole a value expression
+//! (literal / argument / property value) to `ANYTHING`; drop an object property,
+//! a class member, a block statement, or a call/`new` argument via the matching
+//! run-hole. Not yet covered: dropping top-level context statements and
+//! destructure-pattern properties.
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
 use serde::Serialize;
+use source_match_holes::{
+    ANYTHING_HOLE_KEYWORD, ARGS_HOLE_KEYWORD, CASE_REST_HOLE_KEYWORD, CLASS_REST_HOLE_KEYWORD,
+    DECLARATORS_HOLE_KEYWORD, EXPR_HOLE_KEYWORD, OBJECT_PROPS_HOLE_KEYWORD, STMT_HOLE_KEYWORD,
+    STMT_LIST_HOLE_KEYWORD,
+};
 use spec::{SourceMatch, SourceMatchIdentifierMode};
-use swc_ecma_ast::{Expr, Module};
-use swc_ecma_visit::{Visit, VisitMut, VisitMutWith, VisitWith};
+use swc_common::DUMMY_SP;
+use swc_ecma_ast::{
+    BlockStmt, CallExpr, Class, ClassMember, ClassProp, Expr, ExprOrSpread, ExprStmt, IdentName,
+    Module, NewExpr, ObjectLit, Prop, PropName, PropOrSpread, Stmt,
+};
+use swc_ecma_visit::{VisitMut, VisitMutWith};
+
+use crate::render::{anything_expr, ident_node};
 
 pub struct MatchSelectorConfig {
     pub source_file: Option<PathBuf>,
@@ -49,8 +63,8 @@ pub struct MatchSelectorMatch {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct SlackRelaxation {
-    /// A strictly looser selector — the input with one kept value holed to
-    /// `ANYTHING` — that still resolves to the same unique target.
+    /// A strictly looser selector — the input with one kept thing holed — that
+    /// still resolves to the same unique target.
     pub relaxed_match: String,
 }
 
@@ -60,9 +74,9 @@ pub struct MatchSelectorReport {
     /// valid (unique) pin. Zero or several matches both make it unusable.
     pub unique: bool,
     pub matches: Vec<MatchSelectorMatch>,
-    /// Kept value-expressions that could be holed to `ANYTHING` without losing
-    /// uniqueness — a non-empty list flags a likely over-pin. `None` when the
-    /// selector is not unique (slack is undefined) or `--no-slack` skipped it.
+    /// Looser variants that still pin the same unique target — a non-empty list
+    /// flags a likely over-pin. `None` when the selector is not unique (slack is
+    /// undefined) or `--no-slack` skipped it.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub slack: Option<Vec<SlackRelaxation>>,
 }
@@ -144,9 +158,8 @@ fn run_match_selector_impl(config: &MatchSelectorConfig) -> Result<MatchSelector
     })
 }
 
-/// For each kept value-expression in the selector, try holing it to `ANYTHING`
-/// and keep the relaxation if the selector still resolves to the same unique
-/// `(body_idx, binding_name)` target.
+/// Try every single-edit relaxation of the selector; keep the ones that still
+/// resolve to the same unique `(body_idx, binding_name)` target.
 fn compute_slack(
     match_source: &str,
     target_body_idx: usize,
@@ -158,12 +171,15 @@ fn compute_slack(
             .with_context(|| "parsing the candidate selector for slack analysis")?
             .module;
     js_ast::strip_parens(&mut selector_module);
+    let baseline_emit = js_ast::emit_module_source(&selector_module)?;
 
+    let mut seen = BTreeSet::new();
     let mut slack = Vec::new();
-    for index in 0..count_holeable_exprs(&selector_module) {
-        let mut relaxed = selector_module.clone();
-        hole_nth_expr(&mut relaxed, index);
+    for relaxed in enumerate_relaxations(&selector_module) {
         let relaxed_match = js_ast::emit_module_source(&relaxed)?;
+        if relaxed_match == baseline_emit || !seen.insert(relaxed_match.clone()) {
+            continue;
+        }
         if let [only] = resolve(relaxed_match.clone())?.as_slice() {
             if only.body_idx == target_body_idx && only.binding.binding_name == target_binding_name
             {
@@ -174,61 +190,229 @@ fn compute_slack(
     Ok(slack)
 }
 
-/// A value expression that holing to `ANYTHING` would relax. Bare identifiers are
-/// excluded: under `alpha_all` they are already alpha-wildcards (and a hole
-/// keyword is itself an identifier), so holing one removes no real anchor.
-fn is_holeable(expr: &Expr) -> bool {
-    !matches!(expr, Expr::Ident(_) | Expr::Invalid(_))
+/// The single-edit relaxation kinds. Each holes one kept element so the resulting
+/// selector is a strict superset of the original.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Relaxation {
+    /// Hole a kept value expression to `ANYTHING`.
+    HoleExpr,
+    /// Drop an object-literal property (absorbed by an `ANYTHING` run-hole).
+    DropObjectProp,
+    /// Drop a class member (absorbed by a `CLASS_REST` field).
+    DropClassMember,
+    /// Drop a statement inside a block body (absorbed by `STMT_LIST`).
+    DropStatement,
+    /// Drop a call/`new` argument (absorbed by `ARGS`).
+    DropCallArg,
 }
 
-fn count_holeable_exprs(module: &Module) -> usize {
-    struct Counter {
-        count: usize,
-    }
-    impl Visit for Counter {
-        fn visit_expr(&mut self, expr: &Expr) {
-            if is_holeable(expr) {
-                self.count += 1;
-            }
-            expr.visit_children_with(self);
+const RELAXATIONS: [Relaxation; 5] = [
+    Relaxation::HoleExpr,
+    Relaxation::DropObjectProp,
+    Relaxation::DropClassMember,
+    Relaxation::DropStatement,
+    Relaxation::DropCallArg,
+];
+
+/// Produce every selector with exactly one element holed, across all relaxation
+/// kinds. Each kind is counted (a dry run with an out-of-range target) and then
+/// applied once per index.
+fn enumerate_relaxations(selector: &Module) -> Vec<Module> {
+    let mut out = Vec::new();
+    for kind in RELAXATIONS {
+        let total = apply_relaxation(&mut selector.clone(), kind, usize::MAX);
+        for index in 0..total {
+            let mut relaxed = selector.clone();
+            apply_relaxation(&mut relaxed, kind, index);
+            out.push(relaxed);
         }
     }
-    let mut counter = Counter { count: 0 };
-    module.visit_with(&mut counter);
-    counter.count
+    out
 }
 
-/// Replace the `target`-th holeable expression (pre-order) with `ANYTHING`. The
-/// pre-order walk matches [`count_holeable_exprs`], so index `i` names the same
-/// node across the count and hole passes.
-fn hole_nth_expr(module: &mut Module, target: usize) {
-    struct Holer {
-        target: usize,
-        seen: usize,
-        done: bool,
-    }
-    impl VisitMut for Holer {
-        fn visit_mut_expr(&mut self, expr: &mut Expr) {
-            if self.done {
-                return;
-            }
-            if is_holeable(expr) {
-                if self.seen == self.target {
-                    *expr = crate::render::anything_expr();
-                    self.done = true;
-                    return;
-                }
-                self.seen += 1;
-            }
-            expr.visit_mut_children_with(self);
-        }
-    }
-    let mut holer = Holer {
+/// Apply the `target`-th relaxation of `kind` (pre-order) to `module`, returning
+/// the number of relaxation sites of that kind. With `target == usize::MAX` it
+/// edits nothing and just counts.
+fn apply_relaxation(module: &mut Module, kind: Relaxation, target: usize) -> usize {
+    let mut relaxer = Relaxer {
+        kind,
         target,
         seen: 0,
         done: false,
     };
-    module.visit_mut_with(&mut holer);
+    module.visit_mut_with(&mut relaxer);
+    relaxer.seen
+}
+
+struct Relaxer {
+    kind: Relaxation,
+    target: usize,
+    seen: usize,
+    done: bool,
+}
+
+impl Relaxer {
+    /// Count this site; replace it (returning true) when it is the target index.
+    fn take(&mut self, droppable: bool) -> bool {
+        if self.done || !droppable {
+            return false;
+        }
+        if self.seen == self.target {
+            self.done = true;
+            return true;
+        }
+        self.seen += 1;
+        false
+    }
+}
+
+impl VisitMut for Relaxer {
+    fn visit_mut_expr(&mut self, expr: &mut Expr) {
+        if self.kind == Relaxation::HoleExpr && self.take(is_holeable_expr(expr)) {
+            *expr = anything_expr();
+            return;
+        }
+        expr.visit_mut_children_with(self);
+    }
+
+    fn visit_mut_object_lit(&mut self, object: &mut ObjectLit) {
+        if self.kind == Relaxation::DropObjectProp {
+            for prop in object.props.iter_mut() {
+                if self.take(is_droppable_prop(prop)) {
+                    *prop = object_props_hole();
+                    break;
+                }
+            }
+        }
+        object.visit_mut_children_with(self);
+    }
+
+    fn visit_mut_class(&mut self, class: &mut Class) {
+        if self.kind == Relaxation::DropClassMember {
+            for member in class.body.iter_mut() {
+                if self.take(is_droppable_member(member)) {
+                    *member = class_member_hole();
+                    break;
+                }
+            }
+        }
+        class.visit_mut_children_with(self);
+    }
+
+    fn visit_mut_block_stmt(&mut self, block: &mut BlockStmt) {
+        if self.kind == Relaxation::DropStatement {
+            for stmt in block.stmts.iter_mut() {
+                if self.take(is_droppable_stmt(stmt)) {
+                    *stmt = stmt_list_hole();
+                    break;
+                }
+            }
+        }
+        block.visit_mut_children_with(self);
+    }
+
+    fn visit_mut_call_expr(&mut self, call: &mut CallExpr) {
+        if self.kind == Relaxation::DropCallArg {
+            for arg in call.args.iter_mut() {
+                if self.take(is_droppable_arg(arg)) {
+                    *arg = args_hole();
+                    break;
+                }
+            }
+        }
+        call.visit_mut_children_with(self);
+    }
+
+    fn visit_mut_new_expr(&mut self, new_expr: &mut NewExpr) {
+        if self.kind == Relaxation::DropCallArg {
+            if let Some(args) = new_expr.args.as_mut() {
+                for arg in args.iter_mut() {
+                    if self.take(is_droppable_arg(arg)) {
+                        *arg = args_hole();
+                        break;
+                    }
+                }
+            }
+        }
+        new_expr.visit_mut_children_with(self);
+    }
+}
+
+/// A value expression worth holing. Bare identifiers are excluded: under
+/// `alpha_all` they are already alpha-wildcards (and a hole keyword is itself an
+/// identifier), so holing one removes no real anchor.
+fn is_holeable_expr(expr: &Expr) -> bool {
+    !matches!(expr, Expr::Ident(_) | Expr::Invalid(_))
+}
+
+fn is_droppable_prop(prop: &PropOrSpread) -> bool {
+    !matches!(prop, PropOrSpread::Prop(boxed)
+        if matches!(boxed.as_ref(), Prop::Shorthand(ident) if is_hole_keyword(&ident.sym)))
+}
+
+fn is_droppable_member(member: &ClassMember) -> bool {
+    !matches!(member, ClassMember::ClassProp(prop)
+        if prop.value.is_none()
+            && matches!(&prop.key, PropName::Ident(key) if is_hole_keyword(&key.sym)))
+}
+
+fn is_droppable_stmt(stmt: &Stmt) -> bool {
+    !matches!(stmt, Stmt::Expr(expr_stmt)
+        if matches!(expr_stmt.expr.as_ref(), Expr::Ident(ident) if is_hole_keyword(&ident.sym)))
+}
+
+fn is_droppable_arg(arg: &ExprOrSpread) -> bool {
+    !matches!(arg.expr.as_ref(), Expr::Ident(ident) if is_hole_keyword(&ident.sym))
+}
+
+/// Whether an identifier name is one of the selector hole keywords, so we never
+/// "drop" a hole the relaxer (or the input) already wrote.
+fn is_hole_keyword(name: &str) -> bool {
+    name == ANYTHING_HOLE_KEYWORD
+        || name == EXPR_HOLE_KEYWORD
+        || name == STMT_HOLE_KEYWORD
+        || name == STMT_LIST_HOLE_KEYWORD
+        || name == ARGS_HOLE_KEYWORD
+        || name == OBJECT_PROPS_HOLE_KEYWORD
+        || name == CLASS_REST_HOLE_KEYWORD
+        || name == CASE_REST_HOLE_KEYWORD
+        || name == DECLARATORS_HOLE_KEYWORD
+}
+
+fn object_props_hole() -> PropOrSpread {
+    PropOrSpread::Prop(Box::new(Prop::Shorthand(ident_node(ANYTHING_HOLE_KEYWORD))))
+}
+
+fn args_hole() -> ExprOrSpread {
+    ExprOrSpread {
+        spread: None,
+        expr: Box::new(Expr::Ident(ident_node(ARGS_HOLE_KEYWORD))),
+    }
+}
+
+fn stmt_list_hole() -> Stmt {
+    Stmt::Expr(ExprStmt {
+        span: DUMMY_SP,
+        expr: Box::new(Expr::Ident(ident_node(STMT_LIST_HOLE_KEYWORD))),
+    })
+}
+
+fn class_member_hole() -> ClassMember {
+    ClassMember::ClassProp(ClassProp {
+        span: DUMMY_SP,
+        key: PropName::Ident(IdentName::new(ANYTHING_HOLE_KEYWORD.into(), DUMMY_SP)),
+        value: None,
+        type_ann: None,
+        is_static: false,
+        decorators: vec![],
+        accessibility: None,
+        is_abstract: false,
+        is_optional: false,
+        is_override: false,
+        readonly: false,
+        declare: false,
+        definite: false,
+    })
 }
 
 pub fn render_match_selector_text(report: &MatchSelectorReport, out: &mut String) {
@@ -249,16 +433,16 @@ pub fn render_match_selector_text(report: &MatchSelectorReport, out: &mut String
     match &report.slack {
         None => {}
         Some(slack) if slack.is_empty() => {
-            let _ = writeln!(out, "slack: none (no kept value is holeable)");
+            let _ = writeln!(out, "slack: none (nothing further is holeable)");
         }
         Some(slack) => {
             let _ = writeln!(
                 out,
-                "slack: {} holeable value(s) — likely over-pin",
+                "slack: {} looser variant(s) still unique — likely over-pin",
                 slack.len()
             );
             for (i, relaxation) in slack.iter().enumerate() {
-                let _ = writeln!(out, "  [{i}] still unique after holing one value:");
+                let _ = writeln!(out, "  [{i}]");
                 for line in relaxation.relaxed_match.lines() {
                     let _ = writeln!(out, "        {line}");
                 }

--- a/devinfra/js/debundle/match_selector.rs
+++ b/devinfra/js/debundle/match_selector.rs
@@ -1,0 +1,116 @@
+//! `debundle spec match-selector`: resolve a candidate `source_match` against a
+//! chunk and report what it binds.
+//!
+//! The interactive prove-gate probe behind the selector-authoring loop
+//! (`plans/selector_authoring_agent.md`): the agent forms an anchor hypothesis,
+//! writes a candidate `match`, and asks "does this resolve to the singleton I
+//! mean, and is it the right one?" before committing the selector to YAML. The
+//! batch minimizer answers the same question with a boolean gate; this exposes
+//! it as a probe that returns the matched handles instead.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use serde::Serialize;
+use spec::{SourceMatch, SourceMatchIdentifierMode};
+
+pub struct MatchSelectorConfig {
+    pub source_file: Option<PathBuf>,
+    pub source_root: Option<PathBuf>,
+    pub chunk: Option<PathBuf>,
+    pub match_source: String,
+    pub identifiers: SourceMatchIdentifierMode,
+    pub target_binding: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MatchSelectorMatch {
+    /// Top-level statement index the selector matched in the chunk.
+    pub body_index: usize,
+    /// Runtime (minified) name of the binding the selector would claim.
+    pub binding_name: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MatchSelectorReport {
+    /// The headline verdict: exactly one item matched, so the selector is a
+    /// valid (unique) pin. Zero or several matches both make it unusable.
+    pub unique: bool,
+    pub matches: Vec<MatchSelectorMatch>,
+}
+
+/// Resolve the chunk path from the `--source-file` / `--source-root` + `--chunk`
+/// flag combination shared by the source-aware selector commands.
+pub(crate) fn resolve_chunk_source_file(
+    source_file: Option<&Path>,
+    source_root: Option<&Path>,
+    chunk: Option<&Path>,
+) -> Result<PathBuf> {
+    match (source_file, source_root, chunk) {
+        (Some(source_file), _, None) => Ok(source_file.to_path_buf()),
+        (None, Some(source_root), Some(chunk)) => Ok(source_root.join(chunk)),
+        (Some(_), _, Some(_)) => {
+            bail!("use either --source-file or --source-root with --chunk, not both")
+        }
+        _ => bail!("a source chunk is required: pass --source-file or --source-root + --chunk"),
+    }
+}
+
+pub fn run_match_selector(config: &MatchSelectorConfig) -> Result<MatchSelectorReport> {
+    js_ast::with_swc_globals(|| run_match_selector_impl(config))
+}
+
+fn run_match_selector_impl(config: &MatchSelectorConfig) -> Result<MatchSelectorReport> {
+    let source_file = resolve_chunk_source_file(
+        config.source_file.as_deref(),
+        config.source_root.as_deref(),
+        config.chunk.as_deref(),
+    )?;
+    let source = std::fs::read_to_string(&source_file)
+        .with_context(|| format!("reading source file {}", source_file.display()))?;
+    let parsed = js_ast::parse_js_module_consuming(&source_file.display().to_string(), source)
+        .with_context(|| format!("parsing source file {}", source_file.display()))?;
+    let selector = SourceMatch {
+        match_source: config.match_source.clone(),
+        identifiers: config.identifiers,
+        target_binding: config.target_binding.clone(),
+        target_statement: None,
+        target_statements: None,
+        wildcard_string_literals: BTreeSet::new(),
+    }
+    .selector();
+    let mut matches: Vec<MatchSelectorMatch> = source_match::member_binding_candidate_matches(
+        &parsed.module,
+        "<match-selector>",
+        &selector,
+    )?
+    .into_iter()
+    .map(|matched| MatchSelectorMatch {
+        body_index: matched.body_idx,
+        binding_name: matched.binding.binding_name,
+    })
+    .collect();
+    matches.sort_by_key(|matched| matched.body_index);
+    Ok(MatchSelectorReport {
+        unique: matches.len() == 1,
+        matches,
+    })
+}
+
+pub fn render_match_selector_text(report: &MatchSelectorReport, out: &mut String) {
+    use std::fmt::Write;
+    let verdict = match report.matches.len() {
+        1 => "unique",
+        0 => "no-match",
+        _ => "ambiguous",
+    };
+    let _ = writeln!(out, "{verdict} ({} match(es))", report.matches.len());
+    for matched in &report.matches {
+        let _ = writeln!(
+            out,
+            "  body[{}] -> {}",
+            matched.body_index, matched.binding_name
+        );
+    }
+}

--- a/devinfra/js/debundle/plans/selector_authoring_agent.md
+++ b/devinfra/js/debundle/plans/selector_authoring_agent.md
@@ -1,13 +1,16 @@
 # Plan: agent-authored forward-compatible selectors
 
-Status: **design**. Reframes the selector-choice half of
+Status: **in progress**. The plan and the `debundle_stabilize` skill (M2) landed in
+#2332; the `match-selector` query + over-pin slack primitive (M1) landed in #2335.
+Remaining: `synthesize-selectors --candidates N` (M1) and port-based evaluation (M3).
+Reframes the selector-choice half of
 [automated spec workflows](automated_spec_workflows.md). That doc's mechanical
 `selective × stable × cost` ranker
 ([read-off minimization](readoff_minimization.md)) stays — but demoted from
 decision-maker to **suggester + uniqueness oracle**. The decision of **which**
-anchor a selector pins moves to an agent (a new `debundle_*` skill). Validity stays
-mechanically gated; forward-compatibility is an agent judgment, sanity-checked after
-the fact against real bundle versions.
+anchor a selector pins moves to an agent (the `debundle_stabilize` skill). Validity
+stays mechanically gated; forward-compatibility is an agent judgment, sanity-checked
+after the fact against real bundle versions.
 
 ## Why a cost model can't author forward-compatible selectors
 
@@ -78,7 +81,8 @@ Two mechanical signals **bound** that search without defining it:
   and complete — every name-pin is debt.
 - **Holing slack is a heuristic for over-pin.** A `source_match` that pins more than it
   needs — an anchor that could be holed further and still resolve uniquely — is a
-  _candidate_ for rework (the `selector-slack` query below). But slack is only a smell:
+  _candidate_ for rework (`match-selector` reports this slack; see below). But slack is
+  only a smell:
   a zero-slack selector can still be pinned on an incidental anchor (the `name`-key case
   has no slack and is still wrong), and a selector with slack can be perfectly readable.
   The agent uses it to **prioritize**, never to decide.
@@ -139,43 +143,41 @@ query feed the next.
 - `debundle spec synthesize-selectors` — the minimizer's single chosen selector.
 - keep-going spec validation — all selector failures in one pass.
 
-### New: `match-selector` (the hypothesis-test primitive)
+### Landed: `match-selector` (hypothesis-test probe + over-pin slack) — #2335
 
-Give it a candidate `source_match` (inline or a spec member) and a chunk; get back
-**what it resolves to**: the set of matching item/binding ids, the count, the
-uniqueness verdict, and the binding it would bind. This is the interactive
-counterpart to the batch minimizer — it lets the agent ask "if I anchor on X, is the
-match set the singleton I mean, and is it the right singleton?" and chain the
-returned ids into `show-source`. The matcher already exists internally (the
-prove-gate); this exposes it as a standalone probe that returns handles instead of a
-boolean.
+Give it a candidate `source_match` and a chunk; get back **what it resolves to** — the
+matching item/binding ids, the uniqueness verdict, and the binding it would bind — and,
+when the selector pins a unique target, its **slack**. The interactive counterpart to
+the batch minimizer: the agent asks "if I anchor on X, is the match set the singleton I
+mean, the right one — and did I over-pin it?" and chains the returned ids into
+`show-source`. The matcher already exists internally (the prove-gate); this exposes it
+as a probe that returns handles instead of a boolean.
 
-### New: `synthesize-selectors --candidates N`
+**Slack** is the mechanical half of "report over-narrow selectors as debt even when
+they match" (the [automated spec workflows](automated_spec_workflows.md) goal). It
+walks the selector AST and, for each pinned place, tries replacing it with the matching
+wildcard / run-hole — value-holing (`ANYTHING`) plus structural drops of an object
+property, class member, block statement, or call/`new` argument — keeping the
+relaxation iff the same unique target still resolves. Matching and slack share the
+parse + baseline resolve, so they are answered together (`--no-slack` skips slack for a
+fast match-only check). A non-empty slack list is a **where to look next** heuristic,
+never a verdict: high slack flags a likely over-pin, but the agent still judges whether
+the surviving anchors are right (a zero-slack selector can still be pinned on an
+incidental key). It reports only; relaxing a pin is an authoring decision, run back
+through `match-selector`. _(This subsumes the separately-planned `selector-slack`
+command — query and slack are the same authoring question.)_ Not yet covered:
+top-level context-statement drops and destructure-pattern property drops.
+
+### Planned: `synthesize-selectors --candidates N`
 
 Emit the top-N ranked candidates per item (each with its uniqueness proof, cost, and
 the concrete anchors it pins), not just the one minimal pick. The agent reads them as
 a menu — accept one, or use them to locate a better semantic anchor the ranker
-undervalued.
+undervalued. The remaining M1 piece: it needs the read-off walk to collect rather than
+short-circuit at the first proving anchor set, plus a multi-selector-per-item report
+shape.
 
-### New: `selector-slack` (the over-pin heuristic)
-
-Given an existing spec (or a module filter), report per selector whether any
-currently-kept anchor could be **holed further** — replaced with `ANYTHING` /
-`STMT_LIST` / `OBJECT_PROPS` / `CLASS_REST`, or tightened to a
-`STR_LITERAL_MATCHING_RE` stable-prefix anchor — while the selector still resolves to
-the same unique target. This is the minimizer's relaxation step run _against a
-hand-written selector_ instead of from scratch: every relaxation that preserves
-uniqueness counts as slack, and the slack set is what the selector over-pins.
-
-It is the mechanical half of "report over-narrow selectors as debt even when they
-match" (the [automated spec workflows](automated_spec_workflows.md) goal). Output is a
-list ranked most-slack-first that the agent reads as a **where to look next** heuristic,
-never a verdict: high slack flags a likely over-pin, but the agent still judges whether
-the surviving anchor is the right one (a zero-slack selector can still be pinned on an
-incidental key). Reports slack only; it never rewrites — relaxing the pin is an
-authoring decision, run back through `match-selector` and the prove-gate.
-
-All three new commands follow the
+Both commands follow the
 [automated spec workflows](automated_spec_workflows.md) contract: `--format
 json|ndjson`, the shared `--module` / `--source-root` filters, stable output, and a
 reason for every rejected candidate.
@@ -274,9 +276,9 @@ way it dispatches naming/extraction lanes.
   three product flows. This plan amends only its selector-choice assumption: the cost
   model ranks and proves; it does not decide. The "report over-narrow selectors as
   debt even when they match" goal stays, but is reframed: mechanically it is only the
-  `selector-slack` heuristic (which selectors _could_ be holed further), and judging
-  which flagged selectors are genuinely debt is the agent's call, not a worklist the
-  substrate hands over.
+  slack heuristic `match-selector` reports (which selectors _could_ be holed further),
+  and judging which flagged selectors are genuinely debt is the agent's call, not a
+  worklist the substrate hands over.
 - [read-off minimization](readoff_minimization.md) stays as the suggester/prover
   implementation. Its remaining over-pin backlog (e.g. value-over-key preference, the
   `single_target_class_whole_body` outcome) is no longer a blocker for spec quality —
@@ -285,11 +287,12 @@ way it dispatches naming/extraction lanes.
 
 ## Open questions / milestones
 
-- **M1 — read-only primitives: `match-selector`, `synthesize-selectors --candidates N`,
-  `selector-slack`.** The loop is not useful without the hypothesis-test probe and the
-  candidate menu; `selector-slack` feeds the prioritization heuristic for what to
-  revisit.
-- **M2 — the skill.** Loop + playbook + anonymized fixtures, grounded/tested.
+- **M1 — read-only primitives.** `match-selector` (hypothesis-test probe + over-pin
+  slack, value + structural) **landed** (#2335). Remaining: `synthesize-selectors
+--candidates N` (the ranked-candidate menu).
+- **M2 — the skill.** Loop + playbook + anonymized fixtures. The `debundle_stabilize`
+  skill **landed** (#2332); grounding its playbook entries with tested fixtures is
+  still open.
 - **M3 — port-based evaluation.** Run the two-version dogfood pair as a held-out eval
   of the skill's instructions; version-port emits a per-selector survived/broke
   verdict attributed to anchor kind; feed a stability scorecard back into the

--- a/devinfra/js/debundle/selector_codemod.rs
+++ b/devinfra/js/debundle/selector_codemod.rs
@@ -40,6 +40,10 @@ mod minimize;
 mod regex_anchor;
 mod render;
 
+// Read-only agent-facing selector query primitives (M1 of the
+// selector-authoring plan), sharing this crate's source loading + prove-gate.
+pub mod match_selector;
+
 use crate::minimize::{
     minimize_class_selector, minimize_function_selector, minimize_var_group_selector,
 };

--- a/devinfra/js/debundle/skills/debundle_stabilize/SKILL.md
+++ b/devinfra/js/debundle/skills/debundle_stabilize/SKILL.md
@@ -70,8 +70,10 @@ This census is complete for name pins but blind to the other failure mode: a
 selector that is _already_ `source_match` yet pinned on an incidental anchor (the
 `{ name: ANYTHING }` shape). No command enumerates those — judging whether a pin is
 forward-stable is the same intelligence as authoring it, so you find them by reading
-source. The planned `selector-slack` probe (see Background) will at least flag
-over-specified selectors as a starting heuristic.
+source. `match-selector` (used in the loop below) reports **slack** as a starting
+heuristic — kept things that could be holed further without losing uniqueness — but a
+clean (zero-slack) selector can still be pinned on the wrong anchor, so slack only
+prioritizes; it never decides.
 
 ## The loop (per member, or per cohesive cluster)
 
@@ -91,11 +93,13 @@ over-specified selectors as a starting heuristic.
    member YAML — by hand, or by taking `synthesize-selectors --apply` output and
    tightening it onto the anchor you picked.
 
-4. **Prove it.** Run `debundle spec validate` (keep-going): it resolves every
-   selector and reports `no-match`, `ambiguous`, and `duplicate-claim`. Your edit
-   must resolve uniquely. This is today's way to answer "does my anchor actually
-   single this out?"; the planned `match-selector` probe (see Background) will make
-   it a faster inline check.
+4. **Prove it.** Test the candidate with
+   `debundle spec match-selector --source-file <chunk> --match '<selector>'
+--target-binding <name>`: it reports whether the selector resolves **uniquely** to
+   the binding you mean, and its **slack** — the kept things you could still hole
+   without losing uniqueness (i.e. whether you over-pinned). For a whole-spec sweep,
+   `debundle spec validate` (keep-going) resolves every selector and reports
+   `no-match` / `ambiguous` / `duplicate-claim`.
 
 5. **Group** adjacent or cohesive bindings that share a declaration context into a
    `binding_group` rather than emitting N overlapping member selectors.
@@ -166,10 +170,10 @@ authority.
 ## Background
 
 The design rationale (why anchor choice is an agent judgment rather than a cost
-term), the verifiability asymmetry, and the planned affordances that will speed
-this loop up — `match-selector` (probe "what does this candidate selector match?"),
-`synthesize-selectors --candidates N` (a menu of ranked candidates rather than one),
-and `selector-slack` (flags existing selectors that could be holed further without
-losing uniqueness — a heuristic for which pins to revisit) — live in the
-`selector_authoring_agent` plan under `devinfra/js/debundle/plans/`. The two-bundle-version dogfood pair is the eventual
-scorecard for whether these instructions actually produce durable selectors.
+term) and the verifiability asymmetry live in the `selector_authoring_agent` plan
+under `devinfra/js/debundle/plans/`. `match-selector` (which probes "what does this
+candidate match?" and reports over-pin slack in one shot) has landed; the one planned
+affordance still to come is `synthesize-selectors --candidates N` (a menu of ranked
+candidates rather than the minimizer's single pick). The two-bundle-version dogfood
+pair is the eventual scorecard for whether these instructions actually produce
+durable selectors.


### PR DESCRIPTION
## What

The interactive prove-gate probe from the [selector-authoring plan](https://github.com/agentydragon/ducktape/blob/devel/devinfra/js/debundle/plans/selector_authoring_agent.md) (M1). `debundle spec match-selector` resolves a candidate `source_match` against a chunk and answers, in one shot, the two questions the authoring loop asks of a hypothesis:

1. **What does it bind?** — the matching top-level items (body index + bound runtime binding) and whether it pins a **unique** target.
2. **Did I over-pin it?** — **slack**: strictly looser variants of the selector that still pin the *same* unique target.

```
debundle spec match-selector \
  --source-file chunk.js \
  --match 'const w = makeWidget("widget", 3, theme);' \
  --target-binding w --format json
```

Query and slack share the same parse + baseline resolve, so they are computed together (`--no-slack` skips slack for a fast match-only check).

## Slack = "what could be holed further"

Slack walks the selector AST and, for each pinned place, tries replacing it with the appropriate wildcard / run-hole, keeping the relaxation only if the selector **still resolves to the same unique target**. One relaxation at a time:

- hole a value expression (literal / argument / property value) → `ANYTHING`;
- drop an object-literal property → `ANYTHING` run-hole;
- drop a class member → `CLASS_REST` field;
- drop a block statement → `STMT_LIST`;
- drop a call/`new` argument → `ARGS`.

A non-empty slack list flags a likely over-pin. It is a **heuristic** for which pins to revisit, never a verdict — a zero-slack selector can still be anchored on an incidental key, and the agent still judges whether the surviving anchors are the right ones. (This is the mechanical half of automated-spec-workflows' "report over-narrow selectors as debt even when they match".)

_Not yet covered:_ top-level context-statement drops and destructure-pattern property drops.

## How it's built

- New `selector_codemod::match_selector` module, reusing the crate's source loading and the production matcher (`source_match::member_binding_candidate_matches`) as the prove-gate — no new matching engine.
- Slack relaxations are a single unified single-edit enumerator (`Relaxation` kinds + a pre-order `Relaxer`); variants are deduped by emitted source.
- Wired as `debundle spec match-selector` with `--source-file` / `--source-root` + `--chunk`, `--match`, `--identifiers exact|alpha-all`, `--target-binding`, `--no-slack`, `--format`.

## Validation

- e2e (`e2e/match_selector_cli_test.rs`): unique / no-match / ambiguous verdicts; over-pinned reports slack; minimally-pinned reports empty slack; `--no-slack` omits it; object-property-drop and statement-drop relaxations.
- Built/tested with `bazelisk` + system-Java truststore + RBE; clippy + rustfmt clean.

## Follow-ups

- The third M1 primitive, `synthesize-selectors --candidates N` (a menu of the top-N ranked anchor choices), is deferred to its own PR — it needs the read-off walk to collect rather than short-circuit at the first proving anchor set, plus a multi-selector-per-item report shape.
- The plan doc (#2332) still lists `match-selector` and `selector-slack` as separate affordances; will sync it to reflect the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7wbQibmuz5nX9dTzT7PzU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7wbQibmuz5nX9dTzT7PzU)_