### PR TITLE
debundle: hoist shared e2e test setup into support helpers

### DIFF
--- a/devinfra/js/debundle/e2e/chunk_renames_test.rs
+++ b/devinfra/js/debundle/e2e/chunk_renames_test.rs
@@ -32,22 +32,11 @@
 //! unowned decls share `ResidualEntry` ownership; no cycle.
 
 use debundle_e2e_support::*;
-use serde_json::{Value, json};
+use serde_json::json;
 
 /// Build a `chunk_renames` spec entry that renames a single residual
 /// binding to a new export name. All tests in this file rename a
 /// single binding; the helper hides the wire shape.
-fn chunk_rename(rename_to: &str, from_binding: &str) -> Value {
-    json!({
-        "members": [
-            {
-                "name": rename_to,
-                "selector": { "binding": { "name": from_binding } },
-            },
-        ],
-    })
-}
-
 #[test]
 fn chunk_renames_renames_residual_bindings_in_entry() {
     // S1 (orphan-S):       console.log("before")

--- a/devinfra/js/debundle/e2e/cli_mutation_outcome_test.rs
+++ b/devinfra/js/debundle/e2e/cli_mutation_outcome_test.rs
@@ -22,7 +22,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use debundle_e2e_support::{debundler_path, write_text_file};
+use debundle_e2e_support::{debundler_path, parse_stdout_json, write_text_file};
 use serde_json::Value;
 
 fn run_debundle(args: &[&str]) -> std::process::Output {
@@ -30,16 +30,6 @@ fn run_debundle(args: &[&str]) -> std::process::Output {
         .args(args)
         .output()
         .expect("spawn debundle")
-}
-
-fn parse_stdout_json(out: &std::process::Output) -> Value {
-    serde_json::from_slice(&out.stdout).unwrap_or_else(|err| {
-        panic!(
-            "stdout is not JSON ({err})\nstdout:\n{}\nstderr:\n{}",
-            String::from_utf8_lossy(&out.stdout),
-            String::from_utf8_lossy(&out.stderr),
-        )
-    })
 }
 
 fn owner_node(id: &str, ordinal: usize, binding: &str, destination: &str) -> Value {

--- a/devinfra/js/debundle/e2e/module_merge_test.rs
+++ b/devinfra/js/debundle/e2e/module_merge_test.rs
@@ -7,17 +7,9 @@ use std::path::Path;
 use std::process::Command;
 
 use debundle_cli::module::merge_modules;
-use debundle_e2e_support::debundler_path;
+use debundle_e2e_support::{debundler_path, write_file};
 use serde_yaml::Value;
 use tempfile::TempDir;
-
-fn write(root: &Path, rel: &str, body: &str) {
-    let path = root.join(rel);
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).unwrap();
-    }
-    fs::write(path, body).unwrap();
-}
 
 fn member_names(doc: &Value) -> Vec<String> {
     doc["members"]
@@ -38,17 +30,17 @@ fn merges_two_sources_into_target_and_deletes_sources() {
     let dir = TempDir::new().unwrap();
     let root = dir.path();
 
-    write(
+    write_file(
         root,
         "ui/target.yaml",
         "members:\n  - selector: { binding: { name: alpha } }\n",
     );
-    write(
+    write_file(
         root,
         "ui/src1.yaml",
         "members:\n  - selector: { binding: { name: bravo } }\n",
     );
-    write(
+    write_file(
         root,
         "ui/src2.yaml",
         "members:\n  - selector: { binding: { name: charlie } }\n",
@@ -84,17 +76,17 @@ fn duplicate_member_name_across_sources_errors_and_keeps_sources() {
     let dir = TempDir::new().unwrap();
     let root = dir.path();
 
-    write(
+    write_file(
         root,
         "target.yaml",
         "members:\n  - selector: { binding: { name: keep } }\n",
     );
-    write(
+    write_file(
         root,
         "a.yaml",
         "members:\n  - selector: { binding: { name: collide } }\n",
     );
-    write(
+    write_file(
         root,
         "b.yaml",
         "members:\n  - selector: { binding: { name: collide } }\n",
@@ -122,12 +114,12 @@ fn duplicate_member_name_across_sources_errors_and_keeps_sources() {
 fn modules_merge_new_subcommand_path_works_through_binary() {
     let dir = TempDir::new().unwrap();
     let root = dir.path();
-    write(
+    write_file(
         root,
         "target.yaml",
         "members:\n  - selector: { binding: { name: a } }\n",
     );
-    write(
+    write_file(
         root,
         "src.yaml",
         "members:\n  - selector: { binding: { name: b } }\n",
@@ -164,7 +156,7 @@ fn modules_merge_can_create_missing_target_through_binary() {
     let dir = TempDir::new().unwrap();
     let root = dir.path();
     let src_body = "members:\n  - selector: { binding: { name: a } }\n";
-    write(root, "src.yaml", src_body);
+    write_file(root, "src.yaml", src_body);
 
     let dry_run = Command::new(debundler_path())
         .args([
@@ -223,8 +215,8 @@ fn modules_merge_dry_run_does_not_modify_files() {
     let root = dir.path();
     let src_body = "members:\n  - selector: { binding: { name: b } }\n";
     let target_body = "members:\n  - selector: { binding: { name: a } }\n";
-    write(root, "target.yaml", target_body);
-    write(root, "src.yaml", src_body);
+    write_file(root, "target.yaml", target_body);
+    write_file(root, "src.yaml", src_body);
 
     let out = Command::new(debundler_path())
         .args([
@@ -260,12 +252,12 @@ fn modules_merge_dry_run_does_not_modify_files() {
 fn deprecated_module_merge_alias_still_works_with_warning() {
     let dir = TempDir::new().unwrap();
     let root = dir.path();
-    write(
+    write_file(
         root,
         "target.yaml",
         "members:\n  - selector: { binding: { name: a } }\n",
     );
-    write(
+    write_file(
         root,
         "src.yaml",
         "members:\n  - selector: { binding: { name: b } }\n",
@@ -301,12 +293,12 @@ fn merge_carries_binding_groups_into_target() {
     // owners on the next `debundle run`.
     let dir = TempDir::new().unwrap();
     let root = dir.path();
-    write(
+    write_file(
         root,
         "target.yaml",
         "members:\n  - selector: { binding: { name: a } }\n",
     );
-    write(
+    write_file(
         root,
         "src.yaml",
         "binding_groups:\n  - source_match:\n      match: 'const x = 1;'\n    exports: { x: ExportedX }\nmembers: []\n",
@@ -334,17 +326,17 @@ fn merge_concatenates_module_comments_with_divider() {
     // `--- from <source>:` divider.
     let dir = TempDir::new().unwrap();
     let root = dir.path();
-    write(
+    write_file(
         root,
         "target.yaml",
         "comment: target overview\nmembers:\n  - selector: { binding: { name: a } }\n",
     );
-    write(
+    write_file(
         root,
         "src1.yaml",
         "comment: src1 notes\nmembers:\n  - selector: { binding: { name: b } }\n",
     );
-    write(
+    write_file(
         root,
         "src2.yaml",
         "members:\n  - selector: { binding: { name: c } }\n",
@@ -373,12 +365,12 @@ fn merge_concatenates_module_comments_with_divider() {
 fn merge_into_uncommented_target_adopts_source_comment_with_divider() {
     let dir = TempDir::new().unwrap();
     let root = dir.path();
-    write(
+    write_file(
         root,
         "target.yaml",
         "members:\n  - selector: { binding: { name: a } }\n",
     );
-    write(
+    write_file(
         root,
         "src.yaml",
         "comment: src notes\nmembers:\n  - selector: { binding: { name: b } }\n",

--- a/devinfra/js/debundle/e2e/modules_delete_cli_test.rs
+++ b/devinfra/js/debundle/e2e/modules_delete_cli_test.rs
@@ -6,26 +6,17 @@
 //! clap wiring and the env-var plumbing are covered too.
 
 use std::fs;
-use std::path::Path;
 use std::process::Command;
 
 use debundle_cli::module::delete_modules;
-use debundle_e2e_support::debundler_path;
+use debundle_e2e_support::{debundler_path, write_file};
 use tempfile::TempDir;
-
-fn write(root: &Path, rel: &str, body: &str) {
-    let path = root.join(rel);
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).unwrap();
-    }
-    fs::write(path, body).unwrap();
-}
 
 #[test]
 fn delete_empty_module_succeeds() {
     let dir = TempDir::new().unwrap();
     let root = dir.path();
-    write(root, "ui/empty.yaml", "members: []\n");
+    write_file(root, "ui/empty.yaml", "members: []\n");
 
     let out = Command::new(debundler_path())
         .args([
@@ -59,7 +50,7 @@ fn delete_non_empty_module_without_force_refuses() {
     let dir = TempDir::new().unwrap();
     let root = dir.path();
     let body = "members:\n  - selector: { binding: { name: a } }\n";
-    write(root, "ui/full.yaml", body);
+    write_file(root, "ui/full.yaml", body);
 
     let out = Command::new(debundler_path())
         .args([
@@ -86,7 +77,7 @@ fn delete_non_empty_module_without_force_refuses() {
 fn delete_non_empty_module_with_force_succeeds() {
     let dir = TempDir::new().unwrap();
     let root = dir.path();
-    write(
+    write_file(
         root,
         "ui/full.yaml",
         "members:\n  - selector: { binding: { name: a } }\n",
@@ -118,9 +109,9 @@ fn delete_non_empty_module_with_force_succeeds() {
 fn delete_multiple_atomic_all_succeed() {
     let dir = TempDir::new().unwrap();
     let root = dir.path();
-    write(root, "a.yaml", "members: []\n");
-    write(root, "b.yaml", "members: []\n");
-    write(root, "c.yaml", "members: []\n");
+    write_file(root, "a.yaml", "members: []\n");
+    write_file(root, "b.yaml", "members: []\n");
+    write_file(root, "c.yaml", "members: []\n");
 
     let out = Command::new(debundler_path())
         .args([
@@ -156,7 +147,7 @@ fn dry_run_prints_verdict_without_deleting() {
     let dir = TempDir::new().unwrap();
     let root = dir.path();
     let body = "members: []\n";
-    write(root, "ui/empty.yaml", body);
+    write_file(root, "ui/empty.yaml", body);
 
     let out = Command::new(debundler_path())
         .args([
@@ -222,9 +213,9 @@ fn batch_with_one_non_empty_refuses_atomically() {
     let root = dir.path();
     let empty_body = "members: []\n";
     let full_body = "members:\n  - selector: { binding: { name: a } }\n";
-    write(root, "x.yaml", empty_body);
-    write(root, "y.yaml", full_body);
-    write(root, "z.yaml", empty_body);
+    write_file(root, "x.yaml", empty_body);
+    write_file(root, "y.yaml", full_body);
+    write_file(root, "z.yaml", empty_body);
 
     let out = Command::new(debundler_path())
         .args([
@@ -251,8 +242,8 @@ fn batch_with_one_non_empty_refuses_atomically() {
 fn delete_modules_library_call_deletes_then_reports() {
     let dir = TempDir::new().unwrap();
     let root = dir.path();
-    write(root, "a.yaml", "members: []\n");
-    write(root, "b.yaml", "members: []\n");
+    write_file(root, "a.yaml", "members: []\n");
+    write_file(root, "b.yaml", "members: []\n");
     let abs = [root.join("a.yaml"), root.join("b.yaml")];
 
     let summary = delete_modules(&abs, false).unwrap();
@@ -267,7 +258,7 @@ fn delete_modules_library_call_deletes_then_reports() {
 fn delete_modules_library_dry_run_leaves_files_in_place() {
     let dir = TempDir::new().unwrap();
     let root = dir.path();
-    write(root, "a.yaml", "members: []\n");
+    write_file(root, "a.yaml", "members: []\n");
     let abs = [root.join("a.yaml")];
 
     let summary = delete_modules(&abs, true).unwrap();

--- a/devinfra/js/debundle/e2e/rename_shadowed_inner_binding_test.rs
+++ b/devinfra/js/debundle/e2e/rename_shadowed_inner_binding_test.rs
@@ -13,18 +13,6 @@
 //! purity classifier (#1714).
 
 use debundle_e2e_support::*;
-use serde_json::{Value, json};
-
-fn chunk_rename(rename_to: &str, from_binding: &str) -> Value {
-    json!({
-        "members": [
-            {
-                "name": rename_to,
-                "selector": { "binding": { "name": from_binding } },
-            },
-        ],
-    })
-}
 
 /// Renaming top-level `a` -> `b` must leave the inner function's own `var a`
 /// (which shadows the top-level `a`) untouched. The rename target `b` already

--- a/devinfra/js/debundle/e2e/rename_shorthand_destructure_test.rs
+++ b/devinfra/js/debundle/e2e/rename_shorthand_destructure_test.rs
@@ -10,19 +10,7 @@
 //! `obj.readable` instead.
 
 use debundle_e2e_support::*;
-use serde_json::{Value, json};
 use std::fs;
-
-fn chunk_rename(rename_to: &str, from_binding: &str) -> Value {
-    json!({
-        "members": [
-            {
-                "name": rename_to,
-                "selector": { "binding": { "name": from_binding } },
-            },
-        ],
-    })
-}
 
 /// Both shorthand positions in one source: the destructure pattern
 /// declaring `a` and an object-literal shorthand read of `a`. A

--- a/devinfra/js/debundle/e2e/rename_target_capture_test.rs
+++ b/devinfra/js/debundle/e2e/rename_target_capture_test.rs
@@ -6,18 +6,6 @@
 //! instead of emitting a miscompiled body.
 
 use debundle_e2e_support::*;
-use serde_json::{Value, json};
-
-fn chunk_rename(rename_to: &str, from_binding: &str) -> Value {
-    json!({
-        "members": [
-            {
-                "name": rename_to,
-                "selector": { "binding": { "name": from_binding } },
-            },
-        ],
-    })
-}
 
 /// `chunk_renames` path: the rename applies to entry's body, where a
 /// nested function binds the target name and reads the source binding.

--- a/devinfra/js/debundle/e2e/selector_codemod_cli_test.rs
+++ b/devinfra/js/debundle/e2e/selector_codemod_cli_test.rs
@@ -4,9 +4,9 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use serde_json::Value;
-
-use debundle_e2e_support::{debundler_path, write_text_file};
+use debundle_e2e_support::{
+    debundler_path, parse_stdout_json, run_synthesize_selectors, write_text_file,
+};
 
 fn assert_no_trailing_whitespace(text: &str) {
     assert!(
@@ -35,37 +35,6 @@ fn run_codemod(modules: &Path, extra: &[&str]) -> std::process::Output {
         String::from_utf8_lossy(&out.stderr)
     );
     out
-}
-
-fn run_synthesize_selectors(modules: &Path, extra: &[&str]) -> std::process::Output {
-    let mut args = vec![
-        "spec",
-        "synthesize-selectors",
-        "--modules",
-        modules.to_str().unwrap(),
-    ];
-    args.extend_from_slice(extra);
-    let out = Command::new(debundler_path())
-        .args(&args)
-        .output()
-        .expect("spawn debundle");
-    assert!(
-        out.status.success(),
-        "non-zero exit\nstdout:\n{}\nstderr:\n{}",
-        String::from_utf8_lossy(&out.stdout),
-        String::from_utf8_lossy(&out.stderr)
-    );
-    out
-}
-
-fn parse_stdout_json(out: &std::process::Output) -> Value {
-    serde_json::from_slice(&out.stdout).unwrap_or_else(|err| {
-        panic!(
-            "stdout is not JSON ({err})\nstdout:\n{}\nstderr:\n{}",
-            String::from_utf8_lossy(&out.stdout),
-            String::from_utf8_lossy(&out.stderr),
-        )
-    })
 }
 
 fn fixture(modules: &Path) -> (PathBuf, PathBuf) {

--- a/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
+++ b/devinfra/js/debundle/e2e/selector_minimizer_expectation_test.rs
@@ -9,11 +9,8 @@
 use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
-use serde_json::Value;
-
-use debundle_e2e_support::{debundler_path, write_text_file};
+use debundle_e2e_support::{parse_stdout_json, run_synthesize_selectors, write_text_file};
 
 struct MinimizedSelectorCase {
     name: &'static str,
@@ -37,37 +34,6 @@ struct SelectorOutputExpectation {
 struct SelectorOutput {
     exports: BTreeSet<String>,
     match_source: String,
-}
-
-fn run_synthesize_selectors(modules: &Path, extra: &[&str]) -> std::process::Output {
-    let mut args = vec![
-        "spec",
-        "synthesize-selectors",
-        "--modules",
-        modules.to_str().unwrap(),
-    ];
-    args.extend_from_slice(extra);
-    let out = Command::new(debundler_path())
-        .args(&args)
-        .output()
-        .expect("spawn debundle");
-    assert!(
-        out.status.success(),
-        "non-zero exit\nstdout:\n{}\nstderr:\n{}",
-        String::from_utf8_lossy(&out.stdout),
-        String::from_utf8_lossy(&out.stderr)
-    );
-    out
-}
-
-fn parse_stdout_json(out: &std::process::Output) -> Value {
-    serde_json::from_slice(&out.stdout).unwrap_or_else(|err| {
-        panic!(
-            "stdout is not JSON ({err})\nstdout:\n{}\nstderr:\n{}",
-            String::from_utf8_lossy(&out.stdout),
-            String::from_utf8_lossy(&out.stderr),
-        )
-    })
 }
 
 fn write_case(root: &Path, case: &MinimizedSelectorCase) -> (PathBuf, PathBuf) {

--- a/devinfra/js/debundle/e2e/support.rs
+++ b/devinfra/js/debundle/e2e/support.rs
@@ -1395,6 +1395,61 @@ pub fn write_text_file(path: &Path, content: &str) {
     fs::write(path, content).unwrap();
 }
 
+/// Write `body` to `root`-relative path `rel`, creating parent dirs. The
+/// root-relative convenience over [`write_text_file`] for CLI tests that
+/// scatter several fixture files under one temp root.
+pub fn write_file(root: &Path, rel: &str, body: &str) {
+    write_text_file(&root.join(rel), body);
+}
+
+/// Parse a CLI invocation's stdout as JSON, panicking with both stdio streams
+/// on failure so a non-JSON (e.g. error) stdout is legible in the test log.
+pub fn parse_stdout_json(out: &std::process::Output) -> Value {
+    serde_json::from_slice(&out.stdout).unwrap_or_else(|err| {
+        panic!(
+            "stdout is not JSON ({err})\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr),
+        )
+    })
+}
+
+/// Run `debundle spec synthesize-selectors --modules <dir> [extra...]`, asserting
+/// success and returning the raw output for the caller to parse.
+pub fn run_synthesize_selectors(modules: &Path, extra: &[&str]) -> std::process::Output {
+    let mut args = vec![
+        "spec",
+        "synthesize-selectors",
+        "--modules",
+        modules.to_str().unwrap(),
+    ];
+    args.extend_from_slice(extra);
+    let out = Command::new(debundler_path())
+        .args(&args)
+        .output()
+        .expect("spawn debundle");
+    assert!(
+        out.status.success(),
+        "non-zero exit\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    out
+}
+
+/// A single-member chunk-renames spec mapping the binding `from_binding` to the
+/// exported name `rename_to`.
+pub fn chunk_rename(rename_to: &str, from_binding: &str) -> Value {
+    serde_json::json!({
+        "members": [
+            {
+                "name": rename_to,
+                "selector": { "binding": { "name": from_binding } },
+            },
+        ],
+    })
+}
+
 pub fn write_yaml_file<T: Serialize + ?Sized>(path: &Path, value: &T) {
     fs::write(path, format!("{}\n", serde_yaml::to_string(value).unwrap())).unwrap();
 }


### PR DESCRIPTION
Follow-up to #2334. Continues consolidating duplicated e2e test setup into `debundle_e2e_support`, calling everything by the canonical names the module defines.

Four local helpers that were copy-pasted across tests are pulled up into `support.rs`:

| helper | was duplicated in |
| --- | --- |
| `parse_stdout_json` | 3 selector/mutation tests (byte-identical) |
| `run_synthesize_selectors` | the 2 selector tests (byte-identical) |
| `chunk_rename` | the 4 `rename_*` tests (byte-identical) |
| `write_file(root, rel, body)` | `module_merge` + `modules_delete` CLI tests (root-relative wrapper over `write_text_file`) |

**Deliberately left alone:**
- `owner_for_binding` — needs `OwnerGraphReport` from the `:analysis` library, which the standard e2e tests intentionally keep out of their compile graph (per the `BUILD.bazel` comment). Hosting it in `:support` would drag `:analysis` into every test.
- `bindings_assign` / `comment` CLI tests keep their own local `write`/`read`: they call the library directly and don't depend on `:support` (which carries the debundle-binary + node data deps), so staying lean is the right call.
- **Fixture bodies** — I checked for shareable fixture content (JS bundles, YAML specs) and found none worth centralizing; each fixture is semantically unique to its test scenario, so sharing them would couple unrelated tests to the same literal.

Net **−79 LOC**. No `BUILD.bazel` changes needed — every consumer already depended on `:support`.

Verified: full `//devinfra/js/debundle/e2e/...` builds (rustfmt + clippy `-D warnings` aspects) and all tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011YQabfZ5jVoFSETefd27Bg)_