### PR TITLE
debundle: share owner-graph gate fixtures via support helpers

### DIFF
--- a/devinfra/js/debundle/e2e/bindings_assign_gate_cli_test.rs
+++ b/devinfra/js/debundle/e2e/bindings_assign_gate_cli_test.rs
@@ -14,9 +14,11 @@
 //! gate's reconstruction joins YAML members → owners by binding
 //! name, matching `gate_post_edit_partition`'s wire contract.
 
-use debundle_e2e_support::{debundler_path, write_text_file};
+use debundle_e2e_support::{
+    debundler_path, graph_with_acyclic_cross_module_read, write_atomic_unit_fixture,
+    write_text_file,
+};
 use std::fs;
-use std::path::{Path, PathBuf};
 use std::process::Command;
 
 /// Synthetic owner graph where alpha (owner:0) and beta (owner:1)
@@ -29,115 +31,9 @@ use std::process::Command;
 /// atom respected, realizable. A `bindings assign` that moves only
 /// `alpha` to a different module would split the atom; the gate
 /// must reject before any YAML is written.
-fn graph_with_atomic_unit() -> String {
-    serde_json::json!({
-        "chunk_id": "test/chunk",
-        "nodes": [
-            {
-                "id": "owner:0",
-                "statement_ordinal": 0,
-                "declared_bindings": [
-                    { "binding": "alpha", "export_name": "alpha" }
-                ],
-                "statement_kind": "var_decl",
-                "purity": { "kind": "pure" },
-                "destination": "home/atom"
-            },
-            {
-                "id": "owner:1",
-                "statement_ordinal": 1,
-                "declared_bindings": [
-                    { "binding": "beta", "export_name": "beta" }
-                ],
-                "statement_kind": "var_decl",
-                "purity": { "kind": "pure" },
-                "destination": "home/atom"
-            }
-        ],
-        "edges": [
-            {
-                "id": "owner_edge:0",
-                "source": "owner:0",
-                "target": "owner:1",
-                "edge_kind": "eager_rebind",
-                "binding": "beta",
-                "statement_ordinal": 0,
-                "constrains_init_order": true
-            },
-            {
-                "id": "owner_edge:1",
-                "source": "owner:1",
-                "target": "owner:0",
-                "edge_kind": "eager_rebind",
-                "binding": "alpha",
-                "statement_ordinal": 1,
-                "constrains_init_order": true
-            }
-        ],
-        "module_graph": { "nodes": [], "edges": [], "sccs": [] },
-        "atomic_graph": { "nodes": [], "edges": [] }
-    })
-    .to_string()
-}
-
 /// Synthetic owner graph with one acyclic cross-module read so a
 /// `bindings assign` between two existing modules is realizable.
 /// Used as the positive control.
-fn graph_with_acyclic_cross_module_read() -> String {
-    serde_json::json!({
-        "chunk_id": "test/chunk",
-        "nodes": [
-            {
-                "id": "owner:0",
-                "statement_ordinal": 0,
-                "declared_bindings": [
-                    { "binding": "alpha", "export_name": "alpha" }
-                ],
-                "statement_kind": "var_decl",
-                "purity": { "kind": "pure" },
-                "destination": "a"
-            },
-            {
-                "id": "owner:1",
-                "statement_ordinal": 1,
-                "declared_bindings": [
-                    { "binding": "beta", "export_name": "beta" }
-                ],
-                "statement_kind": "var_decl",
-                "purity": { "kind": "pure" },
-                "destination": "b"
-            }
-        ],
-        "edges": [
-            {
-                "id": "owner_edge:0",
-                "source": "owner:0",
-                "target": "owner:1",
-                "edge_kind": "eager_use",
-                "binding": "beta",
-                "statement_ordinal": 0,
-                "constrains_init_order": true
-            }
-        ],
-        "module_graph": { "nodes": [], "edges": [], "sccs": [] },
-        "atomic_graph": { "nodes": [], "edges": [] }
-    })
-    .to_string()
-}
-
-fn write_atomic_unit_fixture(root: &Path) -> (PathBuf, PathBuf) {
-    let modules = root.join("modules");
-    let graph = root.join("owner_graph.json");
-    write_text_file(&graph, &graph_with_atomic_unit());
-    // Pre-edit: alpha + beta co-located in one module — atom
-    // respected, realizable.
-    write_text_file(
-        &modules.join("home/atom.yaml"),
-        "members:\n  - selector: { binding: { name: alpha } }\n  - selector: { binding: { name: beta } }\n",
-    );
-    (modules, graph)
-}
-
 #[test]
 fn bindings_assign_rejects_split_of_known_atomic_unit() {
     let dir = tempfile::tempdir().unwrap();

--- a/devinfra/js/debundle/e2e/bindings_unassign_gate_cli_test.rs
+++ b/devinfra/js/debundle/e2e/bindings_unassign_gate_cli_test.rs
@@ -8,9 +8,8 @@
 //! `--modules` carry the same module-vs-binding assignments and the
 //! gate's reconstruction is unambiguous.
 
-use debundle_e2e_support::{debundler_path, write_text_file};
+use debundle_e2e_support::{debundler_path, write_atomic_unit_fixture, write_text_file};
 use std::fs;
-use std::path::{Path, PathBuf};
 use std::process::Command;
 
 /// Synthetic owner graph where alpha (owner:0) and beta (owner:1)
@@ -19,70 +18,6 @@ use std::process::Command;
 /// co-locate: any partition that places one in a different module
 /// (including "this one's home is residual, the other one isn't")
 /// splits the unit.
-fn graph_with_atomic_unit() -> String {
-    serde_json::json!({
-        "chunk_id": "test/chunk",
-        "nodes": [
-            {
-                "id": "owner:0",
-                "statement_ordinal": 0,
-                "declared_bindings": [
-                    { "binding": "alpha", "export_name": "alpha" }
-                ],
-                "statement_kind": "var_decl",
-                "purity": { "kind": "pure" },
-                "destination": "home/atom"
-            },
-            {
-                "id": "owner:1",
-                "statement_ordinal": 1,
-                "declared_bindings": [
-                    { "binding": "beta", "export_name": "beta" }
-                ],
-                "statement_kind": "var_decl",
-                "purity": { "kind": "pure" },
-                "destination": "home/atom"
-            }
-        ],
-        "edges": [
-            {
-                "id": "owner_edge:0",
-                "source": "owner:0",
-                "target": "owner:1",
-                "edge_kind": "eager_rebind",
-                "binding": "beta",
-                "statement_ordinal": 0,
-                "constrains_init_order": true
-            },
-            {
-                "id": "owner_edge:1",
-                "source": "owner:1",
-                "target": "owner:0",
-                "edge_kind": "eager_rebind",
-                "binding": "alpha",
-                "statement_ordinal": 1,
-                "constrains_init_order": true
-            }
-        ],
-        "module_graph": { "nodes": [], "edges": [], "sccs": [] },
-        "atomic_graph": { "nodes": [], "edges": [] }
-    })
-    .to_string()
-}
-
-fn write_atomic_unit_fixture(root: &Path) -> (PathBuf, PathBuf) {
-    let modules = root.join("modules");
-    let graph = root.join("owner_graph.json");
-    write_text_file(&graph, &graph_with_atomic_unit());
-    // Pre-edit: alpha + beta co-located in one module — atom
-    // respected, realizable.
-    write_text_file(
-        &modules.join("home/atom.yaml"),
-        "members:\n  - selector: { binding: { name: alpha } }\n  - selector: { binding: { name: beta } }\n",
-    );
-    (modules, graph)
-}
-
 #[test]
 fn bindings_unassign_rejects_atom_split_when_other_members_stay() {
     // Atomic unit {alpha, beta} co-located in `home/atom.yaml`.

--- a/devinfra/js/debundle/e2e/modules_gate_cli_test.rs
+++ b/devinfra/js/debundle/e2e/modules_gate_cli_test.rs
@@ -11,7 +11,7 @@
 //! the same `render_cycle_summary` text the pipeline prints when
 //! the materializer's gate rejects.
 
-use debundle_e2e_support::{debundler_path, write_text_file};
+use debundle_e2e_support::{debundler_path, graph_with_acyclic_cross_module_read, write_text_file};
 use std::process::Command;
 
 /// Synthetic owner graph with three owners (alpha, beta, gamma)
@@ -152,48 +152,6 @@ fn graph_with_mutual_cross_module_reads() -> String {
 /// the DAG `a → b`, realizable. Merging a + b drops the cross-module
 /// edge entirely (same-module). Deleting either one leaves a clean
 /// residual fallback with no cycle.
-fn graph_with_acyclic_cross_module_read() -> String {
-    serde_json::json!({
-        "chunk_id": "test/chunk",
-        "nodes": [
-            {
-                "id": "owner:0",
-                "statement_ordinal": 0,
-                "declared_bindings": [
-                    { "binding": "alpha", "export_name": "alpha" }
-                ],
-                "statement_kind": "var_decl",
-                "purity": { "kind": "pure" },
-                "destination": "a"
-            },
-            {
-                "id": "owner:1",
-                "statement_ordinal": 1,
-                "declared_bindings": [
-                    { "binding": "beta", "export_name": "beta" }
-                ],
-                "statement_kind": "var_decl",
-                "purity": { "kind": "pure" },
-                "destination": "b"
-            }
-        ],
-        "edges": [
-            {
-                "id": "owner_edge:0",
-                "source": "owner:0",
-                "target": "owner:1",
-                "edge_kind": "eager_use",
-                "binding": "beta",
-                "statement_ordinal": 0,
-                "constrains_init_order": true
-            }
-        ],
-        "module_graph": { "nodes": [], "edges": [], "sccs": [] },
-        "atomic_graph": { "nodes": [], "edges": [] }
-    })
-    .to_string()
-}
-
 #[test]
 fn modules_merge_rejects_when_merge_creates_cycle() {
     let dir = tempfile::tempdir().unwrap();

--- a/devinfra/js/debundle/e2e/support.rs
+++ b/devinfra/js/debundle/e2e/support.rs
@@ -1450,6 +1450,120 @@ pub fn chunk_rename(rename_to: &str, from_binding: &str) -> Value {
     })
 }
 
+/// Owner graph for a two-statement atomic unit: `alpha` and `beta` mutually
+/// `eager_rebind` each other and share destination `home/atom`, so the
+/// realizability gate must keep them co-located.
+pub fn graph_with_atomic_unit() -> String {
+    serde_json::json!({
+        "chunk_id": "test/chunk",
+        "nodes": [
+            {
+                "id": "owner:0",
+                "statement_ordinal": 0,
+                "declared_bindings": [
+                    { "binding": "alpha", "export_name": "alpha" }
+                ],
+                "statement_kind": "var_decl",
+                "purity": { "kind": "pure" },
+                "destination": "home/atom"
+            },
+            {
+                "id": "owner:1",
+                "statement_ordinal": 1,
+                "declared_bindings": [
+                    { "binding": "beta", "export_name": "beta" }
+                ],
+                "statement_kind": "var_decl",
+                "purity": { "kind": "pure" },
+                "destination": "home/atom"
+            }
+        ],
+        "edges": [
+            {
+                "id": "owner_edge:0",
+                "source": "owner:0",
+                "target": "owner:1",
+                "edge_kind": "eager_rebind",
+                "binding": "beta",
+                "statement_ordinal": 0,
+                "constrains_init_order": true
+            },
+            {
+                "id": "owner_edge:1",
+                "source": "owner:1",
+                "target": "owner:0",
+                "edge_kind": "eager_rebind",
+                "binding": "alpha",
+                "statement_ordinal": 1,
+                "constrains_init_order": true
+            }
+        ],
+        "module_graph": { "nodes": [], "edges": [], "sccs": [] },
+        "atomic_graph": { "nodes": [], "edges": [] }
+    })
+    .to_string()
+}
+
+/// Owner graph for an acyclic cross-module read: `alpha` (module `a`)
+/// `eager_use`s `beta` (module `b`) with no back edge, so the split is
+/// realizable.
+pub fn graph_with_acyclic_cross_module_read() -> String {
+    serde_json::json!({
+        "chunk_id": "test/chunk",
+        "nodes": [
+            {
+                "id": "owner:0",
+                "statement_ordinal": 0,
+                "declared_bindings": [
+                    { "binding": "alpha", "export_name": "alpha" }
+                ],
+                "statement_kind": "var_decl",
+                "purity": { "kind": "pure" },
+                "destination": "a"
+            },
+            {
+                "id": "owner:1",
+                "statement_ordinal": 1,
+                "declared_bindings": [
+                    { "binding": "beta", "export_name": "beta" }
+                ],
+                "statement_kind": "var_decl",
+                "purity": { "kind": "pure" },
+                "destination": "b"
+            }
+        ],
+        "edges": [
+            {
+                "id": "owner_edge:0",
+                "source": "owner:0",
+                "target": "owner:1",
+                "edge_kind": "eager_use",
+                "binding": "beta",
+                "statement_ordinal": 0,
+                "constrains_init_order": true
+            }
+        ],
+        "module_graph": { "nodes": [], "edges": [], "sccs": [] },
+        "atomic_graph": { "nodes": [], "edges": [] }
+    })
+    .to_string()
+}
+
+/// Write [`graph_with_atomic_unit`] plus a single module co-locating `alpha`
+/// and `beta`, returning `(modules_dir, owner_graph_path)`.
+pub fn write_atomic_unit_fixture(root: &Path) -> (PathBuf, PathBuf) {
+    let modules = root.join("modules");
+    let graph = root.join("owner_graph.json");
+    write_text_file(&graph, &graph_with_atomic_unit());
+    // Pre-edit: alpha + beta co-located in one module — atom
+    // respected, realizable.
+    write_text_file(
+        &modules.join("home/atom.yaml"),
+        "members:\n  - selector: { binding: { name: alpha } }\n  - selector: { binding: { name: beta } }\n",
+    );
+    (modules, graph)
+}
+
 pub fn write_yaml_file<T: Serialize + ?Sized>(path: &Path, value: &T) {
     fs::write(path, format!("{}\n", serde_yaml::to_string(value).unwrap())).unwrap();
 }


### PR DESCRIPTION
Next round of e2e test-setup consolidation (follows #2334, #2336).

Three byte-identical owner-graph fixtures were copy-pasted across the gate CLI tests; this lifts them into `debundle_e2e_support`:

| fixture | was duplicated in |
| --- | --- |
| `graph_with_atomic_unit` | `bindings_assign_gate` + `bindings_unassign_gate` |
| `write_atomic_unit_fixture` | `bindings_assign_gate` + `bindings_unassign_gate` |
| `graph_with_acyclic_cross_module_read` | `bindings_assign_gate` + `modules_gate` |

They're plain owner-graph JSON strings with no `:analysis` dependency, so they belong in `:support` alongside the other fixture builders. After the move, `graph_with_atomic_unit` is only reached *through* `write_atomic_unit_fixture`, so the gate files no longer import it directly (and their now-unused `std::path` imports were dropped).

**Deliberately left local:**
- `owner_for_binding` — needs `OwnerGraphReport` from `:analysis`, which the standard e2e tests intentionally keep out of their compile graph.
- The `edit_gate` fixture is a *different* `graph_with_atomic_unit_and_sources` (extra node + source locations), not a duplicate.
- `bindings_assign`/`comment` library tests keep their local `read`/`write` (they avoid the `:support` dep on purpose).

Net **−97 LOC**. No BUILD changes — all three consumers already depend on `:support`.

Verified with `--noremote_accept_cached` so clippy actually re-ran (catching two newly-unused imports, now removed): fresh build clean, all three tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011YQabfZ5jVoFSETefd27Bg)_