### PR TITLE
debundle: `synthesize-selectors --candidates N` — ranked candidate menu (M1)

### DIFF
--- a/devinfra/js/debundle/cli/mod.rs
+++ b/devinfra/js/debundle/cli/mod.rs
@@ -285,6 +285,12 @@ pub struct SelectorCodemodArgs {
     #[arg(long = "item")]
     pub items: Vec<String>,
 
+    /// Emit up to N ranked candidate selectors per item (a menu of alternative
+    /// anchors), not just the minimizer's single pick. Only affects
+    /// `synthesize-selectors`; the extras are reported as `alternatives`. Default 1.
+    #[arg(long = "candidates", default_value_t = 1)]
+    pub candidates: usize,
+
     /// Output format. Default `text` on tty, `json` on pipe.
     #[arg(long, value_enum)]
     pub format: Option<OutputFormat>,
@@ -762,6 +768,7 @@ fn run_selector_codemod_cmd(args: SelectorCodemodArgs) -> Result<()> {
         chunk: args.chunk,
         source_file: args.source_file,
         items: args.items,
+        candidates: args.candidates,
     })?;
     print_report(&report, format, render_selector_codemod_text)
         .context("writing selector-codemod output")

--- a/devinfra/js/debundle/e2e/selector_codemod_cli_test.rs
+++ b/devinfra/js/debundle/e2e/selector_codemod_cli_test.rs
@@ -1314,3 +1314,116 @@ fn apply_rewrites_anonymous_typed_holes_to_anything() {
         "named object-property holes should stay readable:\n{rewritten}"
     );
 }
+
+#[test]
+fn synthesize_selectors_candidates_reports_ranked_alternatives() {
+    let dir = tempfile::tempdir().unwrap();
+    let source = dir.path().join("chunks/app.js");
+    // `readSettings` is the only function, and both the `"settings-loaded"` string
+    // and the `424242` number each single it out — so the read-off menu has more
+    // than one proving anchor choice.
+    write_text_file(
+        &source,
+        concat!(
+            "function readSettings(store) {\n",
+            "  log(\"settings-loaded\");\n",
+            "  return store.get(424242);\n",
+            "}\n",
+            "export { readSettings };\n",
+        ),
+    );
+    let modules = dir.path().join("modules");
+    write_text_file(
+        &modules.join("app/settings.yaml"),
+        r#"members:
+  - name: ReadSettings
+    selector:
+      binding:
+        name: readSettings
+"#,
+    );
+
+    let out = run_synthesize_selectors(
+        &modules,
+        &[
+            "--source-file",
+            source.to_str().unwrap(),
+            "--item",
+            "app/settings:ReadSettings",
+            "--candidates",
+            "3",
+            "--format",
+            "json",
+        ],
+    );
+    let parsed = parse_stdout_json(&out);
+    let candidate = parsed["candidates"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|candidate| candidate["export_name"] == "ReadSettings")
+        .unwrap_or_else(|| panic!("no ReadSettings candidate: {parsed}"));
+    assert_eq!(candidate["candidate_count"], 1, "{parsed}");
+
+    // The menu surfaces alternative anchor choices beyond the minimizer's pick,
+    // each a distinct proving selector.
+    let alternatives = candidate["alternatives"].as_array().unwrap();
+    assert!(
+        !alternatives.is_empty(),
+        "expected a candidate menu: {parsed}"
+    );
+    for alternative in alternatives {
+        let match_source = alternative["match_source"].as_str().unwrap();
+        assert!(
+            match_source.contains("function ReadSettings"),
+            "each alternative is a function selector for the target: {match_source}"
+        );
+    }
+}
+
+#[test]
+fn synthesize_selectors_default_reports_no_alternatives() {
+    let dir = tempfile::tempdir().unwrap();
+    let source = dir.path().join("chunks/app.js");
+    write_text_file(
+        &source,
+        concat!(
+            "function readSettings(store) {\n",
+            "  log(\"settings-loaded\");\n",
+            "  return store.get(424242);\n",
+            "}\n",
+            "export { readSettings };\n",
+        ),
+    );
+    let modules = dir.path().join("modules");
+    write_text_file(
+        &modules.join("app/settings.yaml"),
+        r#"members:
+  - name: ReadSettings
+    selector:
+      binding:
+        name: readSettings
+"#,
+    );
+
+    // Without --candidates the report carries no `alternatives` (default = 1).
+    let out = run_synthesize_selectors(
+        &modules,
+        &[
+            "--source-file",
+            source.to_str().unwrap(),
+            "--item",
+            "app/settings:ReadSettings",
+            "--format",
+            "json",
+        ],
+    );
+    let parsed = parse_stdout_json(&out);
+    let candidate = parsed["candidates"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|candidate| candidate["export_name"] == "ReadSettings")
+        .unwrap_or_else(|| panic!("no ReadSettings candidate: {parsed}"));
+    assert!(candidate.get("alternatives").is_none(), "{parsed}");
+}

--- a/devinfra/js/debundle/minimize/class.rs
+++ b/devinfra/js/debundle/minimize/class.rs
@@ -7,7 +7,7 @@ use source_match_holes::ANYTHING_HOLE_KEYWORD;
 use swc_common::{DUMMY_SP, Spanned};
 use swc_ecma_ast::*;
 
-use super::render_via_read_off;
+use super::{read_off_candidates, render_via_read_off};
 use crate::render::{
     AnchorSpan, anything_expr, anything_param, emit_selector, holed_block, ident_node,
     node_retains_any,
@@ -15,6 +15,32 @@ use crate::render::{
 use crate::{
     ChunkSelectorIndex, IndexedDeclaration, SpecializedSelector, SynthesizedTargetBinding,
 };
+
+/// The form-specific prune + codegen for a class-declaration selector: render the
+/// class holed down to the spans in `kept` (`extends` always holed to `ANYTHING`,
+/// member runs absorbed by `ANYTHING` class-member holes), named for the target
+/// export. Shared by the single-pick and `--candidates N` paths.
+fn class_render_with<'a>(
+    class: &'a Class,
+    target: &'a SynthesizedTargetBinding,
+) -> impl Fn(&BTreeSet<AnchorSpan>) -> Result<String> + 'a {
+    move |kept: &BTreeSet<AnchorSpan>| {
+        let mut holed_class = class.clone();
+        // A minified superclass identifier is alpha-wildcarded, so always hole
+        // `extends` to ANYTHING — it still discriminates "has a superclass" from a
+        // bare class without pinning the volatile name.
+        holed_class.super_class = class
+            .super_class
+            .as_ref()
+            .map(|_| Box::new(anything_expr()));
+        holed_class.body = hole_class_members(&class.body, kept);
+        emit_selector(ModuleItem::Stmt(Stmt::Decl(Decl::Class(ClassDecl {
+            ident: ident_node(&target.export_name),
+            declare: false,
+            class: Box::new(holed_class),
+        }))))
+    }
+}
 
 /// Minimal anchor cover for a single-target class: render the class keeping
 /// only members (and member-body statements) that carry a chosen anchor, with an
@@ -26,23 +52,6 @@ pub(crate) fn minimize_class_selector(
     decl: &IndexedDeclaration,
     target: &SynthesizedTargetBinding,
 ) -> Result<Option<SpecializedSelector>> {
-    let export = target.export_name.clone();
-    let render_with = |kept: &BTreeSet<AnchorSpan>| -> Result<String> {
-        let mut holed_class = class.clone();
-        // A minified superclass identifier is alpha-wildcarded, so always hole
-        // `extends` to ANYTHING — it still discriminates "has a superclass" from a
-        // bare class without pinning the volatile name.
-        holed_class.super_class = class
-            .super_class
-            .as_ref()
-            .map(|_| Box::new(anything_expr()));
-        holed_class.body = hole_class_members(&class.body, kept);
-        emit_selector(ModuleItem::Stmt(Stmt::Decl(Decl::Class(ClassDecl {
-            ident: ident_node(&export),
-            declare: false,
-            class: Box::new(holed_class),
-        }))))
-    };
     // Single-target classes read off their minimal anchor set the same way
     // functions and objects do: the holed scaffold pins the class kind plus
     // `extends ANYTHING`, and value anchors (a member name, a literal or callee
@@ -50,7 +59,25 @@ pub(crate) fn minimize_class_selector(
     // carrying them survive between `ANYTHING` class-member run holes. A class the read-off
     // cannot single out through its own value features returns `None` and is
     // reported as debt (never a full-AST pin).
-    render_via_read_off(index, decl, target, &render_with)
+    render_via_read_off(index, decl, target, &class_render_with(class, target))
+}
+
+/// Up to `limit` ranked candidate selectors for the class — the
+/// `synthesize-selectors --candidates N` menu. `limit == 1` is the single pick.
+pub(crate) fn minimize_class_selector_candidates(
+    index: &ChunkSelectorIndex,
+    class: &Class,
+    decl: &IndexedDeclaration,
+    target: &SynthesizedTargetBinding,
+    limit: usize,
+) -> Result<Vec<SpecializedSelector>> {
+    read_off_candidates(
+        index,
+        decl,
+        target,
+        &class_render_with(class, target),
+        limit,
+    )
 }
 
 /// A class-member run-absorber hole, emitted as an `ANYTHING;` no-init field. In

--- a/devinfra/js/debundle/minimize/function.rs
+++ b/devinfra/js/debundle/minimize/function.rs
@@ -5,11 +5,27 @@ use std::collections::BTreeSet;
 use anyhow::Result;
 use swc_ecma_ast::*;
 
-use super::render_via_read_off;
+use super::{read_off_candidates, render_via_read_off};
 use crate::render::{AnchorSpan, emit_selector, hole_function, ident_node};
 use crate::{
     ChunkSelectorIndex, IndexedDeclaration, SpecializedSelector, SynthesizedTargetBinding,
 };
+
+/// The form-specific prune + codegen for a function-declaration selector: render
+/// the function holed down to the spans in `kept`, named for the target export.
+/// Shared by the single-pick and `--candidates N` paths.
+fn function_render_with<'a>(
+    function: &'a Function,
+    target: &'a SynthesizedTargetBinding,
+) -> impl Fn(&BTreeSet<AnchorSpan>) -> Result<String> + 'a {
+    move |kept: &BTreeSet<AnchorSpan>| {
+        emit_selector(ModuleItem::Stmt(Stmt::Decl(Decl::Fn(FnDecl {
+            ident: ident_node(&target.export_name),
+            declare: false,
+            function: Box::new(hole_function(function, kept)),
+        }))))
+    }
+}
 
 pub(crate) fn minimize_function_selector(
     index: &ChunkSelectorIndex,
@@ -20,13 +36,6 @@ pub(crate) fn minimize_function_selector(
     if function.body.is_none() {
         return Ok(None);
     }
-    let render_with = |kept: &BTreeSet<AnchorSpan>| -> Result<String> {
-        emit_selector(ModuleItem::Stmt(Stmt::Decl(Decl::Fn(FnDecl {
-            ident: ident_node(&target.export_name),
-            declare: false,
-            function: Box::new(hole_function(function, kept)),
-        }))))
-    };
     // Single-target functions read their minimal anchor set off the shape index.
     // The holed scaffold already pins the param arity (one `ANYTHING` per real
     // param), so a structural / skeleton anchor needs no kept span; value anchors
@@ -34,5 +43,26 @@ pub(crate) fn minimize_function_selector(
     // to the spans of the tokens that exhibit them. The matcher proves the result
     // (gate 1); a target the read-off cannot single out returns `None` and is
     // reported as debt (never a full-AST pin).
-    render_via_read_off(index, decl, target, &render_with)
+    render_via_read_off(index, decl, target, &function_render_with(function, target))
+}
+
+/// Up to `limit` ranked candidate selectors for the function — the
+/// `synthesize-selectors --candidates N` menu. `limit == 1` is the single pick.
+pub(crate) fn minimize_function_selector_candidates(
+    index: &ChunkSelectorIndex,
+    function: &Function,
+    decl: &IndexedDeclaration,
+    target: &SynthesizedTargetBinding,
+    limit: usize,
+) -> Result<Vec<SpecializedSelector>> {
+    if function.body.is_none() {
+        return Ok(Vec::new());
+    }
+    read_off_candidates(
+        index,
+        decl,
+        target,
+        &function_render_with(function, target),
+        limit,
+    )
 }

--- a/devinfra/js/debundle/minimize/mod.rs
+++ b/devinfra/js/debundle/minimize/mod.rs
@@ -36,8 +36,8 @@ mod group;
 mod object;
 mod var;
 
-pub(crate) use class::minimize_class_selector;
-pub(crate) use function::minimize_function_selector;
+pub(crate) use class::{minimize_class_selector, minimize_class_selector_candidates};
+pub(crate) use function::{minimize_function_selector, minimize_function_selector_candidates};
 pub(crate) use group::minimize_var_group_selector;
 
 use std::collections::{BTreeMap, BTreeSet};
@@ -80,12 +80,45 @@ fn render_via_read_off(
     target: &SynthesizedTargetBinding,
     render_with: &impl Fn(&BTreeSet<AnchorSpan>) -> Result<String>,
 ) -> Result<Option<SpecializedSelector>> {
+    Ok(read_off_candidates(index, decl, target, render_with, 1)?
+        .into_iter()
+        .next())
+}
+
+/// Collect up to `limit` read-off selectors for the target, in the priority order
+/// [`render_via_read_off`] picks from — minimal anchor set → individually-
+/// discriminating value anchors → multi-feature value cover → bare scaffold →
+/// enclosing-context neighbor — each proven uniquely by the matcher (gate 1) and
+/// deduped by source. `limit == 1` reproduces [`render_via_read_off`] exactly (it
+/// stops at the first proving selector); `limit > 1` powers `synthesize-selectors
+/// --candidates N`, the ranked-candidate menu. Returns fewer than `limit` (or
+/// empty) when the target has no more proving anchors.
+fn read_off_candidates(
+    index: &ChunkSelectorIndex,
+    decl: &IndexedDeclaration,
+    target: &SynthesizedTargetBinding,
+    render_with: &impl Fn(&BTreeSet<AnchorSpan>) -> Result<String>,
+    limit: usize,
+) -> Result<Vec<SpecializedSelector>> {
     let item = index
         .parsed
         .module
         .body
         .get(decl.body_idx)
         .context("read-off body index no longer in module")?;
+
+    // Push a proven candidate unless its source duplicates one already kept;
+    // return true once `limit` is reached so the caller stops walking.
+    let collect = |selector: SpecializedSelector, out: &mut Vec<SpecializedSelector>| -> bool {
+        if !out
+            .iter()
+            .any(|kept| kept.match_source == selector.match_source)
+        {
+            out.push(selector);
+        }
+        out.len() >= limit
+    };
+    let mut out: Vec<SpecializedSelector> = Vec::new();
 
     // Primary read-off: the minimal anchor set. Keep it when its holed selector
     // proves uniquely — except the degenerate case of a single (OPT=1) feature that
@@ -100,8 +133,9 @@ fn render_via_read_off(
             && (!anchor_set.opt_one || kept.len() == 1)
             && let Some(selector) =
                 finish_minimized_selector(index, decl, target, render_with(&kept)?)?
+            && collect(selector, &mut out)
         {
-            return Ok(Some(selector));
+            return Ok(out);
         }
     }
 
@@ -125,8 +159,9 @@ fn render_via_read_off(
     value_kept.sort_by_key(BTreeSet::len);
     for kept in value_kept {
         if let Some(selector) = finish_minimized_selector(index, decl, target, render_with(&kept)?)?
+            && collect(selector, &mut out)
         {
-            return Ok(Some(selector));
+            return Ok(out);
         }
     }
 
@@ -142,21 +177,28 @@ fn render_via_read_off(
         if !kept.is_empty()
             && let Some(selector) =
                 finish_minimized_selector(index, decl, target, render_with(&kept)?)?
+            && collect(selector, &mut out)
         {
-            return Ok(Some(selector));
+            return Ok(out);
         }
     }
 
-    // Last resort: the bare structural scaffold, used only when it resolves
-    // uniquely (a purely structural discriminator — arity/shape — with no value
-    // anchor to keep). The scaffold is degenerate for `var`, so the var path skips
-    // this entirely and returns `None` for the keep-shallow path to handle.
+    // Bare structural scaffold, used only when it resolves uniquely (a purely
+    // structural discriminator — arity/shape — with no value anchor to keep). The
+    // scaffold is degenerate for `var`, so the var path skips this entirely and
+    // returns `None` for the keep-shallow path to handle. When the scaffold
+    // uniquely matches the read-off is done — it never falls through to neighbor
+    // context (mirroring the original early return), so stop here regardless of
+    // `limit`.
     let empty = BTreeSet::new();
     let scaffold = render_with(&empty)?;
     if matched_body_indices(index, &target.export_name, &scaffold)?
         == BTreeSet::from([decl.body_idx])
     {
-        return finish_minimized_selector(index, decl, target, scaffold);
+        if let Some(selector) = finish_minimized_selector(index, decl, target, scaffold)? {
+            collect(selector, &mut out);
+        }
+        return Ok(out);
     }
 
     // Enclosing-context anchoring (#2315): the target's own value anchors and the
@@ -164,7 +206,10 @@ fn render_via_read_off(
     // its stable neighbors — a 2-statement window pinning an adjacent declaration's
     // unique anchor + the target scaffold. `None` here leaves the target as residual
     // debt (never a full-AST pin).
-    render_via_neighbor_context(index, decl, target, &scaffold)
+    if let Some(selector) = render_via_neighbor_context(index, decl, target, &scaffold)? {
+        collect(selector, &mut out);
+    }
+    Ok(out)
 }
 
 fn finish_minimized_selector(

--- a/devinfra/js/debundle/selector_codemod.rs
+++ b/devinfra/js/debundle/selector_codemod.rs
@@ -45,7 +45,8 @@ mod render;
 pub mod match_selector;
 
 use crate::minimize::{
-    minimize_class_selector, minimize_function_selector, minimize_var_group_selector,
+    minimize_class_selector, minimize_class_selector_candidates, minimize_function_selector,
+    minimize_function_selector_candidates, minimize_var_group_selector,
 };
 use crate::render::holes_present;
 
@@ -84,6 +85,10 @@ pub struct SelectorCodemodConfig {
     pub chunk: Option<PathBuf>,
     pub source_file: Option<PathBuf>,
     pub items: Vec<String>,
+    /// Emit up to N ranked candidate selectors per synthesized item (a menu); the
+    /// extras beyond the primary pick are reported as `alternatives`. 1 = today's
+    /// single-pick behavior.
+    pub candidates: usize,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -92,6 +97,17 @@ pub enum SelectorCodemodAction {
     WouldChange,
     Changed,
     Skipped,
+}
+
+/// One alternative candidate selector for an item, beyond the minimizer's primary
+/// pick — the `synthesize-selectors --candidates N` menu. Each proves uniquely (it
+/// is a read-off candidate the matcher accepted), pinning a different anchor than
+/// the primary; the agent reads them as a menu to override an incidental pick.
+#[derive(Debug, Clone, Serialize)]
+pub struct SelectorAlternative {
+    pub match_source: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub rewritten_holes: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -113,6 +129,9 @@ pub struct SelectorCodemodCandidate {
     pub rewritten_holes: Vec<String>,
     #[serde(default, skip_serializing_if = "is_zero")]
     pub replacement_count: usize,
+    /// Extra ranked candidates beyond the primary, when `--candidates N > 1`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub alternatives: Vec<SelectorAlternative>,
     pub reason: Option<String>,
 }
 
@@ -215,6 +234,7 @@ fn run_selector_codemod_impl(config: &SelectorCodemodConfig) -> Result<SelectorC
                     minimize_synthesized_selectors: config.minimize_synthesized_selectors,
                     full_ast_fallback: config.full_ast_fallback,
                     apply: config.apply,
+                    candidates: config.candidates,
                 },
             )?;
             summary.members_scanned += outcomes.members_scanned;
@@ -323,6 +343,7 @@ fn rewrite_single_target_binding(
             candidate_count: None,
             rewritten_holes: Vec::new(),
             replacement_count: 0,
+            alternatives: Vec::new(),
             reason: Some("target_binding already present".to_string()),
         }));
     }
@@ -343,6 +364,7 @@ fn rewrite_single_target_binding(
                 candidate_count: None,
                 rewritten_holes: Vec::new(),
                 replacement_count: 0,
+                alternatives: Vec::new(),
                 reason: Some(format!("source_match did not parse: {err:#}")),
             }));
         }
@@ -366,6 +388,7 @@ fn rewrite_single_target_binding(
             candidate_count: None,
             rewritten_holes: Vec::new(),
             replacement_count: 0,
+            alternatives: Vec::new(),
             reason: Some(reason),
         }));
     };
@@ -403,6 +426,7 @@ fn rewrite_single_target_binding(
         candidate_count: None,
         rewritten_holes: Vec::new(),
         replacement_count: 0,
+        alternatives: Vec::new(),
         reason: None,
     }))
 }
@@ -462,6 +486,7 @@ fn rewrite_anything_holes(
                 candidate_count: None,
                 rewritten_holes: Vec::new(),
                 replacement_count: 0,
+                alternatives: Vec::new(),
                 reason: Some(format!("source_match did not parse: {err:#}")),
             }));
         }
@@ -504,6 +529,7 @@ fn rewrite_anything_holes(
         candidate_count: None,
         rewritten_holes,
         replacement_count,
+        alternatives: Vec::new(),
         reason: None,
     }))
 }
@@ -535,6 +561,7 @@ struct NameBindingRewriteOptions {
     minimize_synthesized_selectors: bool,
     full_ast_fallback: bool,
     apply: bool,
+    candidates: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -544,6 +571,7 @@ pub struct SynthesizedSelectorGroup {
     match_source: String,
     rewritten_holes: Vec<String>,
     candidate_count: usize,
+    alternatives: Vec<SelectorAlternative>,
 }
 
 #[derive(Debug, Clone)]
@@ -696,6 +724,7 @@ fn rewrite_name_bindings_to_source_match(
             &group_members,
             options.minimize_synthesized_selectors,
             options.full_ast_fallback,
+            options.candidates,
         ) {
             Ok(GroupSelectorOutcome::Synthesized(synthesized)) => {
                 synthesized_groups.push(SynthesizedDeclGroup {
@@ -1024,6 +1053,7 @@ fn synthesize_simplest_selector_for_group(
     members: &[NameBindingMember],
     minimize_synthesized_selectors: bool,
     full_ast_fallback: bool,
+    candidates_limit: usize,
 ) -> Result<GroupSelectorOutcome> {
     let decl = index
         .decls
@@ -1087,6 +1117,22 @@ fn synthesize_simplest_selector_for_group(
         ));
     };
 
+    // `--candidates N > 1`: collect the rest of the ranked read-off menu beyond the
+    // primary pick (deduped against it). Only meaningful for the minimized forms;
+    // the exact-fallback and the not-yet-covered object/var menus yield none.
+    let alternatives = if candidates_limit > 1 && minimize_synthesized_selectors {
+        synthesize_specialized_selector_candidates(index, item, decl, &targets, candidates_limit)?
+            .into_iter()
+            .map(|candidate| SelectorAlternative {
+                match_source: trim_selector_source_line_suffixes(&candidate.match_source),
+                rewritten_holes: candidate.rewritten_holes.into_iter().collect(),
+            })
+            .filter(|alternative| alternative.match_source != match_source)
+            .collect()
+    } else {
+        Vec::new()
+    };
+
     Ok(GroupSelectorOutcome::Synthesized(
         SynthesizedSelectorGroup {
             body_idx: decl.body_idx,
@@ -1094,6 +1140,7 @@ fn synthesize_simplest_selector_for_group(
             match_source,
             rewritten_holes: rewritten_holes.into_iter().collect(),
             candidate_count,
+            alternatives,
         },
     ))
 }
@@ -1230,6 +1277,7 @@ fn merge_same_shape_run(
             rewritten_holes: holes_present(&match_source).into_iter().collect(),
             match_source,
             candidate_count,
+            alternatives: Vec::new(),
         },
     })
 }
@@ -1462,6 +1510,44 @@ fn synthesize_specialized_selector(
             synthesize_specialized_var_selector(index, item, decl, targets)
         }
         IndexedDeclarationKind::Other => Ok(None),
+    }
+}
+
+/// Up to `limit` ranked candidate selectors for the item — the
+/// `synthesize-selectors --candidates N` menu. The function/class read-off forms
+/// return their full ranked walk; object/multi-declarator-var emit only the single
+/// pick for now (their menus are not yet wired through the var/object read-off).
+fn synthesize_specialized_selector_candidates(
+    index: &ChunkSelectorIndex,
+    item: &ModuleItem,
+    decl: &IndexedDeclaration,
+    targets: &[SynthesizedTargetBinding],
+    limit: usize,
+) -> Result<Vec<SpecializedSelector>> {
+    match decl.kind {
+        IndexedDeclarationKind::Function => {
+            let [target] = targets else {
+                return Ok(Vec::new());
+            };
+            let Some(Decl::Fn(function)) = item_decl(item) else {
+                return Ok(Vec::new());
+            };
+            minimize_function_selector_candidates(index, &function.function, decl, target, limit)
+        }
+        IndexedDeclarationKind::Class => {
+            let [target] = targets else {
+                return Ok(Vec::new());
+            };
+            let Some(Decl::Class(class_decl)) = item_decl(item) else {
+                return Ok(Vec::new());
+            };
+            minimize_class_selector_candidates(index, &class_decl.class, decl, target, limit)
+        }
+        IndexedDeclarationKind::Var | IndexedDeclarationKind::Other => {
+            Ok(synthesize_specialized_selector(index, item, decl, targets)?
+                .into_iter()
+                .collect())
+        }
     }
 }
 
@@ -1799,6 +1885,7 @@ fn synthesized_candidate(input: SynthesizedCandidateInput<'_>) -> SelectorCodemo
         candidate_count: Some(input.synthesized.candidate_count),
         rewritten_holes: input.synthesized.rewritten_holes.clone(),
         replacement_count: input.synthesized.rewritten_holes.len(),
+        alternatives: input.synthesized.alternatives.clone(),
         reason: None,
     }
 }
@@ -1895,6 +1982,7 @@ fn skipped_candidate(
         candidate_count: None,
         rewritten_holes: Vec::new(),
         replacement_count: 0,
+        alternatives: Vec::new(),
         reason: Some(reason.into()),
     }
 }
@@ -2362,6 +2450,7 @@ mod full_ast_fallback_tests {
                 &members,
                 minimize,
                 full_ast_fallback,
+                1,
             )
             .unwrap()
         })
@@ -2410,13 +2499,14 @@ export { target };\n";
                 comment: None,
             }];
             let off =
-                synthesize_simplest_selector_for_group(&index, decl_idx, &members, true, false)
+                synthesize_simplest_selector_for_group(&index, decl_idx, &members, true, false, 1)
                     .unwrap();
             if let GroupSelectorOutcome::Skipped(reason) = &off {
                 assert!(reason.contains("no sparse selector"), "{reason}");
-                let on =
-                    synthesize_simplest_selector_for_group(&index, decl_idx, &members, true, true)
-                        .unwrap();
+                let on = synthesize_simplest_selector_for_group(
+                    &index, decl_idx, &members, true, true, 1,
+                )
+                .unwrap();
                 assert!(
                     matches!(on, GroupSelectorOutcome::Synthesized(_)),
                     "fallback on must emit where the default skipped"
@@ -2447,7 +2537,7 @@ export { target };\n";
                 comment: None,
             }];
             let GroupSelectorOutcome::Synthesized(group) =
-                synthesize_simplest_selector_for_group(&index, decl_idx, &members, true, true)
+                synthesize_simplest_selector_for_group(&index, decl_idx, &members, true, true, 1)
                     .unwrap()
             else {
                 panic!("full_ast_fallback=true must not skip");
@@ -2620,8 +2710,10 @@ mod prefilter_soundness_tests {
                     comment: None,
                 }];
                 let GroupSelectorOutcome::Synthesized(group) =
-                    synthesize_simplest_selector_for_group(&index, decl_idx, &members, true, false)
-                        .unwrap()
+                    synthesize_simplest_selector_for_group(
+                        &index, decl_idx, &members, true, false, 1,
+                    )
+                    .unwrap()
                 else {
                     panic!("each distinct-token sibling must synthesize a selector");
                 };

--- a/devinfra/js/debundle/selector_minimizer_proptest.rs
+++ b/devinfra/js/debundle/selector_minimizer_proptest.rs
@@ -464,7 +464,7 @@ proptest! {
             // there is nothing to assert. `full_ast_fallback = true` keeps the
             // exact selector when minimization finds nothing sparse.
             let Ok(GroupSelectorOutcome::Synthesized(group)) =
-                synthesize_simplest_selector_for_group(&index, decl_idx, &members, true, true)
+                synthesize_simplest_selector_for_group(&index, decl_idx, &members, true, true, 1)
             else {
                 return Ok(());
             };


### PR DESCRIPTION
## What

The last M1 read-only primitive from the [selector-authoring plan](https://github.com/agentydragon/ducktape/blob/devel/devinfra/js/debundle/plans/selector_authoring_agent.md). The minimizer emits **one** selector per item — the cheapest unique anchor, which may be incidental (the `name`-key over `"running"` problem). `synthesize-selectors --candidates N` instead surfaces the **top-N ranked read-off candidates** so the agent can override an incidental pick with a purpose-bearing one.

```
debundle spec synthesize-selectors --modules … --source-file chunk.js \
  --item app/settings:ReadSettings --candidates 3 --format json
```

Each item's report candidate gains an `alternatives` list — the extra ranked selectors beyond the primary pick, each proven unique:

```json
{ "export_name": "ReadSettings", "candidate_count": 1,
  "alternatives": [ { "match_source": "function ReadSettings(ANYTHING) { … }", "rewritten_holes": [...] }, … ] }
```

## How

- **Refactor the read-off walk into `read_off_candidates(.., limit)`** (`minimize/mod.rs`): collects up to `limit` proving selectors in the same priority order the single-pick used (minimal anchor → individually-discriminating value anchors → multi-feature cover → bare scaffold → enclosing-context neighbor), deduped by source. `render_via_read_off` becomes `read_off_candidates(.., 1).next()` — **`limit == 1` reproduces today's behavior exactly**, so the default single-pick path is unchanged.
- **Per-form candidate variants** for function and class (the `render_via_read_off` forms), sharing a `render_with` factory with the single-pick path. Object / multi-declarator var emit only the single pick for now (their menus aren't wired through the var/object read-off yet — noted as follow-up).
- **`--candidates N` flag** threaded `synthesize-selectors` → config → synthesis; the extras beyond the primary surface as `alternatives` on the report candidate. Default `1` = unchanged output.

## Validation

- **All 119 `//devinfra/js/debundle/...` tests pass** — crucially the `selector_minimizer_expectation_test` (exact minimizer-output baselines) and the `selector_codemod` proptest, which prove the `limit == 1` refactor is behavior-preserving.
- New e2e: `--candidates 3` reports ranked `alternatives`; default reports none.
- Built/tested with `bazelisk` + system-Java truststore + RBE; clippy + rustfmt clean.

## Follow-ups

- Wire the menu through the object / multi-declarator-var read-off forms (currently single-pick only).
- The dry-run report still doesn't carry the *primary* selector's `match_source` (pre-existing — only `alternatives` show their text); surfacing the full N-item menu uniformly is a small follow-up.

With this, all three M1 primitives are landed (`match-selector` query+slack in #2335; `--candidates N` here). Remaining plan work: M3 port-based evaluation, and the gaffer dogfood wave (after a release-pin bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7wbQibmuz5nX9dTzT7PzU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7wbQibmuz5nX9dTzT7PzU)_