### PR TITLE
debundle: hoist typed owner_for_binding into support helpers

### DIFF
--- a/devinfra/js/debundle/e2e/BUILD.bazel
+++ b/devinfra/js/debundle/e2e/BUILD.bazel
@@ -13,6 +13,7 @@ rust_library(
     ],
     edition = "2024",
     deps = [
+        "//devinfra/js/debundle:analysis",
         "@crates//:serde",
         "@crates//:serde_json",
         "@crates//:serde_yaml",
@@ -25,9 +26,10 @@ rust_library(
 )
 
 # Standard e2e tests: shell out to the built debundler binary against
-# a fixture spec and assert on the emitted artifact tree. They do not
-# call into the `:analysis` Rust library — splitting that dep off
-# avoids dragging the library through every test's compile graph.
+# a fixture spec and assert on the emitted artifact tree. `:support`
+# depends on `:analysis` (for typed owner-graph helpers like
+# `owner_for_binding`), so it reaches every test transitively; tests that
+# name `analysis::` types directly still list `:analysis` themselves.
 _STANDARD_E2E_DEPS = [
     ":support",
     "@crates//:serde",

--- a/devinfra/js/debundle/e2e/at_init_cross_module_call_body_reads_test.rs
+++ b/devinfra/js/debundle/e2e/at_init_cross_module_call_body_reads_test.rs
@@ -59,21 +59,6 @@ console.log(triggerInit);
 export { iA, triggerInit, gR, crossModBinding };
 "#;
 
-fn owner_for_binding<'a>(graph: &'a OwnerGraphReport, binding: &str) -> &'a str {
-    let node = graph
-        .nodes
-        .iter()
-        .find(|node| node.declared_bindings.iter().any(|b| b.binding == binding))
-        .unwrap_or_else(|| {
-            panic!(
-                "no owner-graph node declares binding `{binding}`; \
-                 nodes: {:#?}",
-                graph.nodes,
-            )
-        });
-    node.id.as_str()
-}
-
 fn module_id_for<'a>(graph: &'a OwnerGraphReport, binding: &str) -> &'a str {
     let owner_id = owner_for_binding(graph, binding);
     let node = graph

--- a/devinfra/js/debundle/e2e/at_init_s_chain_dataflow_test.rs
+++ b/devinfra/js/debundle/e2e/at_init_s_chain_dataflow_test.rs
@@ -103,21 +103,6 @@ fn trusted_dataflow_opts<'a>(
     dataflow_opts(source, logical_modules).with_trusted_dataflow_summaries()
 }
 
-fn owner_for_binding<'a>(graph: &'a OwnerGraphReport, binding: &str) -> &'a str {
-    let node = graph
-        .nodes
-        .iter()
-        .find(|node| node.declared_bindings.iter().any(|b| b.binding == binding))
-        .unwrap_or_else(|| {
-            panic!(
-                "no owner-graph node declares binding `{binding}`; \
-                 nodes: {:#?}",
-                graph.nodes,
-            )
-        });
-    node.id.as_str()
-}
-
 fn sequenced_edges_between<'a>(
     graph: &'a OwnerGraphReport,
     a: &str,

--- a/devinfra/js/debundle/e2e/s_chain_dataflow_soundness_test.rs
+++ b/devinfra/js/debundle/e2e/s_chain_dataflow_soundness_test.rs
@@ -29,15 +29,6 @@ fn dataflow_opts<'a>(source: &'a str, logical_modules: Vec<LogicalModuleEntry>) 
     FixtureOpts::new(source, logical_modules).with_dataflow_aware_s_chain()
 }
 
-fn owner_for_binding<'a>(graph: &'a OwnerGraphReport, binding: &str) -> &'a str {
-    let node = graph
-        .nodes
-        .iter()
-        .find(|node| node.declared_bindings.iter().any(|b| b.binding == binding))
-        .unwrap_or_else(|| panic!("no owner-graph node declares binding `{binding}`"));
-    node.id.as_str()
-}
-
 fn owner_for_ordinal(graph: &OwnerGraphReport, ordinal: usize) -> &str {
     let node = graph
         .nodes

--- a/devinfra/js/debundle/e2e/support.rs
+++ b/devinfra/js/debundle/e2e/support.rs
@@ -3,6 +3,7 @@
 //! Drives the CLI through a YAML spec and asserts on the emitted file
 //! tree by reading files and re-running them under `node`.
 
+use analysis::OwnerGraphReport;
 use runfiles::{Runfiles, rlocation};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -1448,6 +1449,23 @@ pub fn chunk_rename(rename_to: &str, from_binding: &str) -> Value {
             },
         ],
     })
+}
+
+/// Owner-graph node id that declares `binding`, panicking (with the node dump)
+/// if none does.
+pub fn owner_for_binding<'a>(graph: &'a OwnerGraphReport, binding: &str) -> &'a str {
+    let node = graph
+        .nodes
+        .iter()
+        .find(|node| node.declared_bindings.iter().any(|b| b.binding == binding))
+        .unwrap_or_else(|| {
+            panic!(
+                "no owner-graph node declares binding `{binding}`; \
+                 nodes: {:#?}",
+                graph.nodes,
+            )
+        });
+    node.id.as_str()
 }
 
 /// Owner graph for a two-statement atomic unit: `alpha` and `beta` mutually


### PR DESCRIPTION
Stacked on #2338 (will retarget to `devel` once that merges).

`owner_for_binding(&OwnerGraphReport, binding) -> &str` was copy-pasted in three at-init / s-chain dataflow tests. This adds `:analysis` to the `:support` library so it can host the typed helper, and drops the three local copies (they reach it via the existing glob import).

Per your call, dragging `:analysis` into the e2e tests is fine: `:support` now pulls it into every e2e test's compile graph. Tests that name `analysis::` types directly keep their own `:analysis` dep; the obsolete "we deliberately keep analysis out" BUILD comment is updated.

**Left local on purpose:** the two `Value`-based `owner_for_binding` copies (`at_init_unresolved_callee`, `pure_members`) walk the owner graph as raw JSON for *edge* traversal as well, so they need `serde_json::Value`, not the typed report — converting them would be a logic rewrite, not a dedup.

Net **−19 LOC**.

Verified with `--noremote_accept_cached` (clippy actually re-ran): fresh build clean, and the full `//devinfra/js/debundle/e2e/...` suite (81 tests) passes with the new transitive `:analysis` dep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011YQabfZ5jVoFSETefd27Bg)_