### PR TITLE
debundle: wire `--candidates N` menu to single-target var/object read-off + doc drift

### DIFF
--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -68,8 +68,10 @@ One-line status for each `plans/` design doc; this is the discovery index.
 - <plans/selector_authoring_agent.md> — **in progress.** Reframes selector choice as an
   agent task: the `debundle_stabilize` skill picks forward-compatible anchors; the
   minimizer is demoted to suggester + uniqueness oracle. Plan + skill landed (#2332);
-  the `match-selector` query + over-pin slack primitive landed (#2335). Open:
-  `--candidates N` and port-based evaluation.
+  **M1 read-only primitives complete** — `match-selector` query + over-pin slack
+  (#2335) and `synthesize-selectors --candidates N` ranked menu (#2339). Open: ground
+  the skill playbook with tested fixtures (M2), port-based evaluation (M3), and the
+  selector-authoring tooling gaps below.
 - <plans/adopt_names_via_bijection.md> — **not started.** Expose the `source_match`
   identifier bijection so one selector both locates a declaration and adopts
   readable names onto its params/locals/nested bindings.
@@ -269,6 +271,27 @@ reading source files. This is conditional on hitting that cost; not yet
 observed. (The `owner:<id>`-in-spec-notes framing that used to live here was
 stale — no such mechanism exists; `owner:N` ids are machine-generated graph
 keys and a `describe`/`show-source` input, not a spec authoring hint.)
+
+## Selector-authoring tooling gaps (M1 residue)
+
+The read-only authoring primitives landed (`match-selector` #2335,
+`synthesize-selectors --candidates N` #2339). Known gaps, each a follow-up:
+
+- **`--candidates N` menu for multi-declarator var binding groups.** The
+  ranked menu covers the function/class and single-target var/object read-off
+  forms (`read_off_candidates`, `try_var_read_off`, `try_object_read_off`). The
+  multi-target binding-group path (`try_var_group_read_off` + the keep-shallow
+  fallback) is tuple-shaped and still returns only the single pick;
+  `synthesize_specialized_selector_candidates` falls back to single for it.
+  Collecting a ranked tuple menu there is the remaining wiring.
+- **`match-selector` slack — structural run-holes not yet covered.** Slack drops
+  object properties, class members, block statements, and call/`new` args, and
+  holes value expressions. Still not attempted: **top-level context-statement**
+  drops (a member selector's context window — `STMT_LIST` at module top-level for
+  member-form selectors is unproven and was deliberately skipped) and
+  **destructure-pattern property** drops (object-pattern props in
+  `const { a, b } = …` selectors, the `ObjectPat` analogue of the object-literal
+  prop drop).
 
 ## Structural selector language
 

--- a/devinfra/js/debundle/e2e/selector_codemod_cli_test.rs
+++ b/devinfra/js/debundle/e2e/selector_codemod_cli_test.rs
@@ -1396,3 +1396,94 @@ fn synthesize_selectors_default_reports_no_alternatives() {
         .unwrap_or_else(|| panic!("no ReadSettings candidate: {parsed}"));
     assert!(candidate.get("alternatives").is_none(), "{parsed}");
 }
+
+#[test]
+fn synthesize_selectors_var_object_candidates_reports_value_anchor_menu() {
+    let dir = tempfile::tempdir().unwrap();
+    let source = dir.path().join("chunks/app.js");
+    // Two sibling object consts share the `{accent, surface}` key shape, so the
+    // keys never discriminate — only the globally-unique string values do. Each of
+    // `paletteConfig`'s two values singles its declarator out, so the var/object
+    // read-off menu has more than one proving value-anchor choice.
+    write_text_file(
+        &source,
+        concat!(
+            "const paletteConfig = {\n",
+            "  accent: \"palette-accent-7c1\",\n",
+            "  surface: \"palette-surface-3a9\",\n",
+            "};\n",
+            "const layoutConfig = {\n",
+            "  accent: \"layout-accent-002\",\n",
+            "  surface: \"layout-surface-118\",\n",
+            "};\n",
+            "export { paletteConfig, layoutConfig };\n",
+        ),
+    );
+    let modules = dir.path().join("modules");
+    write_text_file(
+        &modules.join("app/theme.yaml"),
+        r#"members:
+  - name: PaletteConfig
+    selector:
+      binding:
+        name: paletteConfig
+"#,
+    );
+
+    let out = run_synthesize_selectors(
+        &modules,
+        &[
+            "--source-file",
+            source.to_str().unwrap(),
+            "--item",
+            "app/theme:PaletteConfig",
+            "--candidates",
+            "3",
+            "--format",
+            "json",
+        ],
+    );
+    let parsed = parse_stdout_json(&out);
+    let candidate = parsed["candidates"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|candidate| candidate["export_name"] == "PaletteConfig")
+        .unwrap_or_else(|| panic!("no PaletteConfig candidate: {parsed}"));
+    assert_eq!(candidate["candidate_count"], 1, "{parsed}");
+
+    // The primary pins one unique value; the menu surfaces the slot's *other*
+    // discriminating value anchor, so the two together cover both `palette-…`
+    // strings — exercising the object read-off candidates path end-to-end.
+    let primary = candidate["match_source"].as_str().unwrap();
+    let alternatives = candidate["alternatives"].as_array().unwrap();
+    assert!(
+        !alternatives.is_empty(),
+        "expected an object-slot candidate menu: {parsed}"
+    );
+    let all_sources: Vec<&str> = std::iter::once(primary)
+        .chain(
+            alternatives
+                .iter()
+                .map(|alternative| alternative["match_source"].as_str().unwrap()),
+        )
+        .collect();
+    for source in &all_sources {
+        assert!(
+            source.contains("palette-"),
+            "each candidate pins a unique palette value: {source}"
+        );
+    }
+    assert!(
+        all_sources
+            .iter()
+            .any(|source| source.contains("palette-accent-7c1")),
+        "the menu surfaces the accent value anchor: {parsed}"
+    );
+    assert!(
+        all_sources
+            .iter()
+            .any(|source| source.contains("palette-surface-3a9")),
+        "the menu surfaces the surface value anchor: {parsed}"
+    );
+}

--- a/devinfra/js/debundle/minimize/group.rs
+++ b/devinfra/js/debundle/minimize/group.rs
@@ -8,8 +8,8 @@ use readoff_render::kept_spans_for_anchor_set;
 use swc_common::Spanned;
 use swc_ecma_ast::*;
 
-use super::object::{object_anchor_ranking, try_object_read_off};
-use super::var::try_var_read_off;
+use super::object::{object_anchor_ranking, try_object_read_off, try_object_read_off_candidates};
+use super::var::{try_var_read_off, try_var_read_off_candidates};
 use super::{hole_var_init_padded, render_var_slots, render_via_neighbor_context};
 use crate::regex_anchor::{accepted_regex_anchors, collect_regex_anchor_candidates};
 use crate::render::{
@@ -358,6 +358,56 @@ fn try_var_group_read_off(
         match_source: source,
         rewritten_holes,
     }))
+}
+
+/// Up to `limit` ranked candidate selectors for a `var` declaration — the
+/// `synthesize-selectors --candidates N` menu. A single-target object or non-object
+/// var slot returns its read-off menu; the multi-declarator binding-group and
+/// keep-shallow paths are not yet menu-aware and yield only the single pick
+/// (tracked in `TODO.md`). `limit == 1` reproduces [`minimize_var_group_selector`].
+pub(crate) fn minimize_var_group_selector_candidates(
+    index: &ChunkSelectorIndex,
+    var: &VarDecl,
+    decl: &IndexedDeclaration,
+    targets: &[SynthesizedTargetBinding],
+    limit: usize,
+) -> Result<Vec<SpecializedSelector>> {
+    let export_for = |runtime: &str| {
+        targets
+            .iter()
+            .find(|target| target.runtime_binding == runtime)
+            .map(|target| target.export_name.clone())
+    };
+    let target_slots: BTreeSet<usize> = var
+        .decls
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, declarator)| {
+            let name = single_ident_pat_name(&declarator.name)?;
+            export_for(name).map(|_| idx)
+        })
+        .collect();
+    if target_slots.len() != targets.len() {
+        return Ok(Vec::new());
+    }
+
+    let object = try_object_read_off_candidates(index, var, decl, targets, &target_slots, limit)?;
+    if !object.is_empty() {
+        return Ok(object);
+    }
+    if let [target] = targets
+        && target_slots.len() == 1
+    {
+        let slot = *target_slots.iter().next().expect("one target slot");
+        let var_candidates = try_var_read_off_candidates(index, var, decl, target, slot, limit)?;
+        if !var_candidates.is_empty() {
+            return Ok(var_candidates);
+        }
+    }
+    // Multi-target binding-group / keep-shallow: menu not yet wired — single pick.
+    Ok(minimize_var_group_selector(index, var, decl, targets)?
+        .into_iter()
+        .collect())
 }
 
 /// Minimal anchor cover for a `var`/`let`/`const` binding group: render the

--- a/devinfra/js/debundle/minimize/mod.rs
+++ b/devinfra/js/debundle/minimize/mod.rs
@@ -38,7 +38,7 @@ mod var;
 
 pub(crate) use class::{minimize_class_selector, minimize_class_selector_candidates};
 pub(crate) use function::{minimize_function_selector, minimize_function_selector_candidates};
-pub(crate) use group::minimize_var_group_selector;
+pub(crate) use group::{minimize_var_group_selector, minimize_var_group_selector_candidates};
 
 use std::collections::{BTreeMap, BTreeSet};
 

--- a/devinfra/js/debundle/minimize/object.rs
+++ b/devinfra/js/debundle/minimize/object.rs
@@ -130,18 +130,39 @@ pub(crate) fn try_object_read_off(
     targets: &[SynthesizedTargetBinding],
     target_slots: &BTreeSet<usize>,
 ) -> Result<Option<SpecializedSelector>> {
+    Ok(
+        try_object_read_off_candidates(index, var, decl, targets, target_slots, 1)?
+            .into_iter()
+            .next(),
+    )
+}
+
+/// Up to `limit` ranked read-off selectors for a single-target object declarator —
+/// the `synthesize-selectors --candidates N` menu. `limit == 1` reproduces
+/// [`try_object_read_off`] exactly (minimal anchor set, else the slot key-set
+/// cover). For `limit > 1`, once a primary read-off exists the menu is extended
+/// with the slot's individually-discriminating value anchors; an object that has
+/// no minimal/cover read-off offers no menu (matching the single-pick `None`).
+pub(crate) fn try_object_read_off_candidates(
+    index: &ChunkSelectorIndex,
+    var: &VarDecl,
+    decl: &IndexedDeclaration,
+    targets: &[SynthesizedTargetBinding],
+    target_slots: &BTreeSet<usize>,
+    limit: usize,
+) -> Result<Vec<SpecializedSelector>> {
     // Only the single-target case (one binding). A multi-target group needs the
     // tuple-resolving binding-group path; this owns the single object slot.
     let [target] = targets else {
-        return Ok(None);
+        return Ok(Vec::new());
     };
     if target_slots.len() != 1 {
-        return Ok(None);
+        return Ok(Vec::new());
     }
     let target_slot = *target_slots.iter().next().expect("one target slot");
     let declarator = &var.decls[target_slot];
     let Some(Expr::Object(object)) = declarator.init.as_deref() else {
-        return Ok(None);
+        return Ok(Vec::new());
     };
     let target_decl_span = declarator.span();
 
@@ -165,30 +186,70 @@ pub(crate) fn try_object_read_off(
         )
     };
 
-    if let Some(anchor_set) = index.shape_index.minimal_anchor_set(decl.body_idx) {
-        let item = index
-            .parsed
-            .module
-            .body
-            .get(decl.body_idx)
-            .context("read-off body index no longer in module")?;
-        let kept: BTreeSet<AnchorSpan> = kept_spans_for_anchor_set(item, &anchor_set)
+    let item = index
+        .parsed
+        .module
+        .body
+        .get(decl.body_idx)
+        .context("read-off body index no longer in module")?;
+    let kept_in_slot = |anchor_set: &shape_index::AnchorSet| -> BTreeSet<AnchorSpan> {
+        kept_spans_for_anchor_set(item, anchor_set)
             .into_iter()
             .filter(|span| node_holds_anchor(target_decl_span, *span))
-            .collect();
+            .collect()
+    };
+    let collect = |selector: SpecializedSelector, out: &mut Vec<SpecializedSelector>| -> bool {
+        if !out
+            .iter()
+            .any(|kept| kept.match_source == selector.match_source)
+        {
+            out.push(selector);
+        }
+        out.len() >= limit
+    };
+    let mut out: Vec<SpecializedSelector> = Vec::new();
+
+    // Single pick (limit == 1): the minimal anchor set, else the slot key-set cover.
+    if let Some(anchor_set) = index.shape_index.minimal_anchor_set(decl.body_idx) {
+        let kept = kept_in_slot(&anchor_set);
         if !kept.is_empty()
             && let Some(selector) =
                 finish_minimized_selector(index, decl, target, render_with(&kept)?)?
+            && collect(selector, &mut out)
         {
-            return Ok(Some(selector));
+            return Ok(out);
         }
     }
-
-    cover_object_slot(
+    if let Some(selector) = cover_object_slot(
         index,
         decl,
         target,
         &object_anchor_ranking(object),
         &render_with,
-    )
+    )? && collect(selector, &mut out)
+    {
+        return Ok(out);
+    }
+
+    // No minimal/cover read-off ⇒ no menu (the single pick is `None`).
+    if out.is_empty() {
+        return Ok(out);
+    }
+
+    // Menu extras: the slot's individually-discriminating value anchors.
+    for anchor_set in index
+        .shape_index
+        .unique_value_anchor_candidates(decl.body_idx)
+    {
+        let kept = kept_in_slot(&anchor_set);
+        if kept.is_empty() {
+            continue;
+        }
+        if let Some(selector) = finish_minimized_selector(index, decl, target, render_with(&kept)?)?
+            && collect(selector, &mut out)
+        {
+            return Ok(out);
+        }
+    }
+    Ok(out)
 }

--- a/devinfra/js/debundle/minimize/var.rs
+++ b/devinfra/js/debundle/minimize/var.rs
@@ -40,14 +40,34 @@ pub(crate) fn try_var_read_off(
     target: &SynthesizedTargetBinding,
     target_slot: usize,
 ) -> Result<Option<SpecializedSelector>> {
+    Ok(
+        try_var_read_off_candidates(index, var, decl, target, target_slot, 1)?
+            .into_iter()
+            .next(),
+    )
+}
+
+/// Up to `limit` ranked read-off selectors for a single-target non-object var, in
+/// the same priority order [`try_var_read_off`] picks from (minimal anchor →
+/// individually-discriminating value anchors → multi-feature cover), each proven
+/// uniquely and deduped by source. `limit == 1` reproduces [`try_var_read_off`]
+/// exactly; `limit > 1` powers the `synthesize-selectors --candidates N` menu.
+pub(crate) fn try_var_read_off_candidates(
+    index: &ChunkSelectorIndex,
+    var: &VarDecl,
+    decl: &IndexedDeclaration,
+    target: &SynthesizedTargetBinding,
+    target_slot: usize,
+    limit: usize,
+) -> Result<Vec<SpecializedSelector>> {
     let declarator = &var.decls[target_slot];
     let Some(init) = declarator.init.as_deref() else {
-        return Ok(None);
+        return Ok(Vec::new());
     };
     // Objects are `try_object_read_off`'s domain (padded `OBJECT_PROPS` + the
     // slot-aware key-set cover); this owns every other initializer shape.
     if matches!(init, Expr::Object(_)) {
-        return Ok(None);
+        return Ok(Vec::new());
     }
     let target_decl_span = declarator.span();
     let targets = std::slice::from_ref(target);
@@ -98,6 +118,7 @@ pub(crate) fn try_var_read_off(
                 .unique_value_anchor_candidates(decl.body_idx),
         )
         .chain(index.shape_index.unique_value_anchor_cover(decl.body_idx));
+    let mut out: Vec<SpecializedSelector> = Vec::new();
     for anchor_set in anchor_sets {
         let kept: BTreeSet<AnchorSpan> = kept_spans_for_anchor_set(item, &anchor_set)
             .into_iter()
@@ -124,11 +145,17 @@ pub(crate) fn try_var_read_off(
             &render_with,
         )?;
         let source = render_with(&kept, &regex_anchors)?;
+        if out.iter().any(|kept| kept.match_source == source) {
+            continue;
+        }
         let rewritten_holes = holes_present(&source);
-        return Ok(Some(SpecializedSelector {
+        out.push(SpecializedSelector {
             match_source: source,
             rewritten_holes,
-        }));
+        });
+        if out.len() >= limit {
+            break;
+        }
     }
-    Ok(None)
+    Ok(out)
 }

--- a/devinfra/js/debundle/plans/selector_authoring_agent.md
+++ b/devinfra/js/debundle/plans/selector_authoring_agent.md
@@ -1,9 +1,10 @@
 # Plan: agent-authored forward-compatible selectors
 
 Status: **in progress**. The plan and the `debundle_stabilize` skill (M2) landed in
-#2332; the `match-selector` query + over-pin slack primitive (M1) landed in #2335.
-Remaining: `synthesize-selectors --candidates N` (M1) and port-based evaluation (M3).
-Reframes the selector-choice half of
+#2332; **M1 (read-only primitives) is complete** — `match-selector` (query + over-pin
+slack) in #2335, `synthesize-selectors --candidates N` (ranked menu) in #2339.
+Remaining: grounding the skill's playbook with tested fixtures (M2) and port-based
+evaluation (M3). Reframes the selector-choice half of
 [automated spec workflows](automated_spec_workflows.md). That doc's mechanical
 `selective × stable × cost` ranker
 ([read-off minimization](readoff_minimization.md)) stays — but demoted from
@@ -168,14 +169,15 @@ through `match-selector`. _(This subsumes the separately-planned `selector-slack
 command — query and slack are the same authoring question.)_ Not yet covered:
 top-level context-statement drops and destructure-pattern property drops.
 
-### Planned: `synthesize-selectors --candidates N`
+### Landed: `synthesize-selectors --candidates N` — #2339
 
-Emit the top-N ranked candidates per item (each with its uniqueness proof, cost, and
-the concrete anchors it pins), not just the one minimal pick. The agent reads them as
-a menu — accept one, or use them to locate a better semantic anchor the ranker
-undervalued. The remaining M1 piece: it needs the read-off walk to collect rather than
-short-circuit at the first proving anchor set, plus a multi-selector-per-item report
-shape.
+Emit the top-N ranked candidates per item, not just the one minimal pick — the agent
+reads them as a menu to override an incidental anchor with a purpose-bearing one. The
+read-off walk now collects the top-N proving anchor sets (`read_off_candidates`, with
+`limit == 1` reproducing the single pick); the extras beyond the primary surface as
+`alternatives` on each report candidate, and the primary's own `match_source` is now in
+the report too. Covers the function/class and single-target var/object read-off forms;
+the multi-declarator binding-group menu is still single-pick (tracked in `TODO.md`).
 
 Both commands follow the
 [automated spec workflows](automated_spec_workflows.md) contract: `--format
@@ -287,9 +289,11 @@ way it dispatches naming/extraction lanes.
 
 ## Open questions / milestones
 
-- **M1 — read-only primitives.** `match-selector` (hypothesis-test probe + over-pin
-  slack, value + structural) **landed** (#2335). Remaining: `synthesize-selectors
---candidates N` (the ranked-candidate menu).
+- **M1 — read-only primitives — complete.** `match-selector` (hypothesis-test probe +
+  over-pin slack, value + structural) **landed** (#2335); `synthesize-selectors
+--candidates N` (the ranked-candidate menu) **landed** (#2339). Residue tracked in
+  `TODO.md`: the candidates menu for multi-declarator var groups, and slack for
+  top-level context statements / destructure-pattern properties.
 - **M2 — the skill.** Loop + playbook + anonymized fixtures. The `debundle_stabilize`
   skill **landed** (#2332); grounding its playbook entries with tested fixtures is
   still open.

--- a/devinfra/js/debundle/selector_codemod.rs
+++ b/devinfra/js/debundle/selector_codemod.rs
@@ -47,6 +47,7 @@ pub mod match_selector;
 use crate::minimize::{
     minimize_class_selector, minimize_class_selector_candidates, minimize_function_selector,
     minimize_function_selector_candidates, minimize_var_group_selector,
+    minimize_var_group_selector_candidates,
 };
 use crate::render::holes_present;
 
@@ -125,6 +126,12 @@ pub struct SelectorCodemodCandidate {
     pub matched_body_index: Option<usize>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub candidate_count: Option<usize>,
+    /// The synthesized primary selector's `match` source (synthesize-selectors
+    /// only); `None` for non-synthesizing rewrites and skips. Makes the proposed
+    /// selector visible in dry-run, and completes the `--candidates` menu (the
+    /// primary here, the rest in `alternatives`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub match_source: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub rewritten_holes: Vec<String>,
     #[serde(default, skip_serializing_if = "is_zero")]
@@ -341,6 +348,7 @@ fn rewrite_single_target_binding(
             group_id: None,
             matched_body_index: None,
             candidate_count: None,
+            match_source: None,
             rewritten_holes: Vec::new(),
             replacement_count: 0,
             alternatives: Vec::new(),
@@ -362,6 +370,7 @@ fn rewrite_single_target_binding(
                 group_id: None,
                 matched_body_index: None,
                 candidate_count: None,
+                match_source: None,
                 rewritten_holes: Vec::new(),
                 replacement_count: 0,
                 alternatives: Vec::new(),
@@ -386,6 +395,7 @@ fn rewrite_single_target_binding(
             group_id: None,
             matched_body_index: None,
             candidate_count: None,
+            match_source: None,
             rewritten_holes: Vec::new(),
             replacement_count: 0,
             alternatives: Vec::new(),
@@ -424,6 +434,7 @@ fn rewrite_single_target_binding(
         group_id: None,
         matched_body_index: None,
         candidate_count: None,
+        match_source: None,
         rewritten_holes: Vec::new(),
         replacement_count: 0,
         alternatives: Vec::new(),
@@ -484,6 +495,7 @@ fn rewrite_anything_holes(
                 group_id: None,
                 matched_body_index: None,
                 candidate_count: None,
+                match_source: None,
                 rewritten_holes: Vec::new(),
                 replacement_count: 0,
                 alternatives: Vec::new(),
@@ -527,6 +539,7 @@ fn rewrite_anything_holes(
         group_id: None,
         matched_body_index: None,
         candidate_count: None,
+        match_source: None,
         rewritten_holes,
         replacement_count,
         alternatives: Vec::new(),
@@ -1543,7 +1556,12 @@ fn synthesize_specialized_selector_candidates(
             };
             minimize_class_selector_candidates(index, &class_decl.class, decl, target, limit)
         }
-        IndexedDeclarationKind::Var | IndexedDeclarationKind::Other => {
+        IndexedDeclarationKind::Var => {
+            let var =
+                item_var_decl(item).context("indexed var declaration no longer has var AST")?;
+            minimize_var_group_selector_candidates(index, var, decl, targets, limit)
+        }
+        IndexedDeclarationKind::Other => {
             Ok(synthesize_specialized_selector(index, item, decl, targets)?
                 .into_iter()
                 .collect())
@@ -1883,6 +1901,7 @@ fn synthesized_candidate(input: SynthesizedCandidateInput<'_>) -> SelectorCodemo
         group_id: Some(input.group_id),
         matched_body_index: Some(input.synthesized.body_idx),
         candidate_count: Some(input.synthesized.candidate_count),
+        match_source: Some(input.synthesized.match_source.clone()),
         rewritten_holes: input.synthesized.rewritten_holes.clone(),
         replacement_count: input.synthesized.rewritten_holes.len(),
         alternatives: input.synthesized.alternatives.clone(),
@@ -1980,6 +1999,7 @@ fn skipped_candidate(
         group_id: None,
         matched_body_index: None,
         candidate_count: None,
+        match_source: None,
         rewritten_holes: Vec::new(),
         replacement_count: 0,
         alternatives: Vec::new(),

--- a/devinfra/js/debundle/skills/debundle_stabilize/SKILL.md
+++ b/devinfra/js/debundle/skills/debundle_stabilize/SKILL.md
@@ -87,7 +87,9 @@ prioritizes; it never decides.
    Read it as a _suggestion_. If it anchored on something incidental (a bare
    number, a generic key with the value holed, pure positional/structural shape),
    discard the anchor and keep looking — the proof that it is unique today says
-   nothing about tomorrow.
+   nothing about tomorrow. Add `--candidates N` to get a ranked **menu** of
+   alternative anchor choices (in `alternatives`) instead of the single pick, then
+   choose the most purpose-bearing one.
 
 3. **Choose a purpose anchor** (rubric below) and write the `source_match` into the
    member YAML — by hand, or by taking `synthesize-selectors --apply` output and


### PR DESCRIPTION
## What

Follow-ups stacked on the `synthesize-selectors --candidates N` menu (#2339, now merged). #2339 wired the ranked menu through the function/class read-off forms only; the object / multi-declarator-var forms emitted just the single pick, and the dry-run report didn't surface the primary selector's `match_source`. This closes those gaps for the single-target var/object case and records the rest as tracked residue.

## How

- **Var/object candidates menu.** `synthesize_specialized_selector_candidates` now dispatches the `Var` arm to a new `minimize_var_group_selector_candidates`, which collects the single-target object and non-object read-off menus (`try_object_read_off_candidates` / `try_var_read_off_candidates`, both `limit`-bounded with `limit == 1` reproducing the single pick exactly). The multi-declarator binding-group and keep-shallow paths stay single-pick for now (tracked in `TODO.md`).
- **Primary `match_source` in the report.** `SelectorCodemodCandidate` gains an optional `match_source`, so the synthesized primary selector is visible in dry-run and the `--candidates` menu is complete (primary here + the rest in `alternatives`).
- **Doc drift.** The plan, the `TODO.md` plan-index line, and the `debundle_stabilize` skill now mark **M1 (read-only primitives) complete** and point at the `--candidates N` menu.
- **TODO gaps.** A new "Selector-authoring tooling gaps (M1 residue)" section records the two known residues: the candidates menu for multi-declarator var binding groups, and `match-selector` slack for top-level context-statement drops and destructure-pattern property drops.

## Validation

- New e2e `synthesize_selectors_var_object_candidates_reports_value_anchor_menu`: two sibling object consts share a `{accent, surface}` key shape so only the globally-unique string values discriminate — the primary pins one value, the menu surfaces the other, and the two together cover both.
- **All 120 `//devinfra/js/debundle/...` tests pass** — the `selector_minimizer_expectation_test` baselines and the `selector_codemod` proptest confirm the `limit == 1` path stays behavior-preserving.
- Built/tested with `bazelisk` + system-Java truststore + RBE; clippy + rustfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7wbQibmuz5nX9dTzT7PzU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7wbQibmuz5nX9dTzT7PzU)_