### PR TITLE
debundle: type the last two owner_for_binding callers

### DIFF
--- a/devinfra/js/debundle/e2e/BUILD.bazel
+++ b/devinfra/js/debundle/e2e/BUILD.bazel
@@ -64,7 +64,6 @@ _STANDARD_E2E_DEPS = [
         "naturalization_test",
         "naturalize_cross_scope_params_test",
         "object_plain_data_calls_test",
-        "pure_members_test",
         "url_rebase_test",
         "vendor_swap_test",
         "identifier_rename_queue_test",
@@ -88,7 +87,6 @@ _STANDARD_E2E_DEPS = [
         "duplicate_top_level_declaration_test",
         "at_init_promotion_nested_closure_test",
         "at_init_promotion_post_await_test",
-        "at_init_unresolved_callee_test",
         "hoisted_var_declaration_test",
         "export_default_purity_test",
         "auto_grown_export_alias_collision_test",
@@ -133,6 +131,8 @@ _STANDARD_E2E_DEPS = [
         "at_init_promotion_fndecl_direct_read_test",
         "at_init_cross_module_call_body_reads_test",
         "at_init_s_chain_dataflow_test",
+        "at_init_unresolved_callee_test",
+        "pure_members_test",
         "s_chain_dataflow_soundness_test",
     ]
 ]

--- a/devinfra/js/debundle/e2e/at_init_unresolved_callee_test.rs
+++ b/devinfra/js/debundle/e2e/at_init_unresolved_callee_test.rs
@@ -18,29 +18,8 @@
 //! gate-accepted-but-TDZ shapes below now close a constraining cycle
 //! and are rejected.
 
+use analysis::{DepKind, EdgeRoleReport, OwnerGraphReport};
 use debundle_e2e_support::*;
-use serde_json::Value;
-
-fn owner_for_binding(graph: &Value, binding: &str) -> String {
-    graph
-        .get("nodes")
-        .and_then(Value::as_array)
-        .and_then(|nodes| {
-            nodes.iter().find(|node| {
-                node.get("declared_bindings")
-                    .and_then(Value::as_array)
-                    .is_some_and(|bindings| {
-                        bindings
-                            .iter()
-                            .any(|b| b.get("binding").and_then(Value::as_str) == Some(binding))
-                    })
-            })
-        })
-        .and_then(|node| node.get("id"))
-        .and_then(Value::as_str)
-        .unwrap_or_else(|| panic!("no owner-graph node declares binding `{binding}`"))
-        .to_string()
-}
 
 /// `const g = readB; const r = g();` — the alias `g` is a VarDecl,
 /// not a function declaration, so the old promotion pass skipped the
@@ -157,21 +136,16 @@ export { later, tools, toolCopies, byName, ids, copiedIds, byId };
         )],
     ));
 
-    let graph: Value = read_json(&fixture.report_root.join("static/app/owner_graph.json"));
+    let graph: OwnerGraphReport =
+        read_json(&fixture.report_root.join("static/app/owner_graph.json"));
     let later_owner = owner_for_binding(&graph, "later");
     let promoted_to_later: Vec<_> = graph
-        .get("edges")
-        .and_then(Value::as_array)
-        .expect("owner graph edges array")
+        .edges
         .iter()
         .filter(|edge| {
-            edge.get("target").and_then(Value::as_str) == Some(later_owner.as_str())
-                && edge.get("edge_kind").and_then(Value::as_str) == Some("eager_use")
-                && edge
-                    .get("role")
-                    .and_then(|role| role.get("kind"))
-                    .and_then(Value::as_str)
-                    == Some("promoted_at_init")
+            edge.target == later_owner
+                && edge.edge_kind == DepKind::EagerUse
+                && matches!(edge.role, Some(EdgeRoleReport::PromotedAtInit { .. }))
         })
         .collect();
     assert!(
@@ -196,21 +170,16 @@ export { later };
         vec![logical_module("later_mod", &[Member::new("later")])],
     ));
 
-    let graph: Value = read_json(&fixture.report_root.join("static/app/owner_graph.json"));
+    let graph: OwnerGraphReport =
+        read_json(&fixture.report_root.join("static/app/owner_graph.json"));
     let later_owner = owner_for_binding(&graph, "later");
     let promoted_to_later: Vec<_> = graph
-        .get("edges")
-        .and_then(Value::as_array)
-        .expect("owner graph edges array")
+        .edges
         .iter()
         .filter(|edge| {
-            edge.get("target").and_then(Value::as_str) == Some(later_owner.as_str())
-                && edge.get("edge_kind").and_then(Value::as_str) == Some("eager_use")
-                && edge
-                    .get("role")
-                    .and_then(|role| role.get("kind"))
-                    .and_then(Value::as_str)
-                    == Some("promoted_at_init")
+            edge.target == later_owner
+                && edge.edge_kind == DepKind::EagerUse
+                && matches!(edge.role, Some(EdgeRoleReport::PromotedAtInit { .. }))
         })
         .collect();
     assert!(
@@ -237,21 +206,16 @@ export { later, document, button };
         vec![logical_module("later_mod", &[Member::new("later")])],
     ));
 
-    let graph: Value = read_json(&fixture.report_root.join("static/app/owner_graph.json"));
+    let graph: OwnerGraphReport =
+        read_json(&fixture.report_root.join("static/app/owner_graph.json"));
     let later_owner = owner_for_binding(&graph, "later");
     let promoted_to_later: Vec<_> = graph
-        .get("edges")
-        .and_then(Value::as_array)
-        .expect("owner graph edges array")
+        .edges
         .iter()
         .filter(|edge| {
-            edge.get("target").and_then(Value::as_str) == Some(later_owner.as_str())
-                && edge.get("edge_kind").and_then(Value::as_str) == Some("eager_use")
-                && edge
-                    .get("role")
-                    .and_then(|role| role.get("kind"))
-                    .and_then(Value::as_str)
-                    == Some("promoted_at_init")
+            edge.target == later_owner
+                && edge.edge_kind == DepKind::EagerUse
+                && matches!(edge.role, Some(EdgeRoleReport::PromotedAtInit { .. }))
         })
         .collect();
     assert!(

--- a/devinfra/js/debundle/e2e/pure_members_test.rs
+++ b/devinfra/js/debundle/e2e/pure_members_test.rs
@@ -14,35 +14,15 @@
 //! not re-verify; soundness shifts to the spec author. See
 //! AGENTS.md "Declared purity".
 
+use analysis::{DepKind, EdgeRoleReport, OwnerGraphReport};
 use debundle_e2e_support::*;
-use serde_json::{Value, json};
+use serde_json::json;
 
 const VENDOR_FILE: &[(&str, &str)] = &[(
     "static/app/vendor.js",
     "export function makePure(arg) { return arg; }\n\
      export function forwardRef(render) { return { render }; }\n",
 )];
-
-fn owner_for_binding(graph: &Value, binding: &str) -> String {
-    graph
-        .get("nodes")
-        .and_then(Value::as_array)
-        .and_then(|nodes| {
-            nodes.iter().find(|node| {
-                node.get("declared_bindings")
-                    .and_then(Value::as_array)
-                    .is_some_and(|bindings| {
-                        bindings
-                            .iter()
-                            .any(|b| b.get("binding").and_then(Value::as_str) == Some(binding))
-                    })
-            })
-        })
-        .and_then(|node| node.get("id"))
-        .and_then(Value::as_str)
-        .unwrap_or_else(|| panic!("no owner-graph node declares binding `{binding}`"))
-        .to_string()
-}
 
 /// Cycle-forcing fixture body parameterized by the per-case knobs.
 ///
@@ -200,23 +180,18 @@ export { component, later };
         .with_extra_files(VENDOR_FILE),
     );
 
-    let graph: Value = read_json(&fixture.report_root.join("static/app/owner_graph.json"));
+    let graph: OwnerGraphReport =
+        read_json(&fixture.report_root.join("static/app/owner_graph.json"));
     let component_owner = owner_for_binding(&graph, "component");
     let later_owner = owner_for_binding(&graph, "later");
     let promoted: Vec<_> = graph
-        .get("edges")
-        .and_then(Value::as_array)
-        .expect("owner graph edges array")
+        .edges
         .iter()
         .filter(|edge| {
-            edge.get("source").and_then(Value::as_str) == Some(component_owner.as_str())
-                && edge.get("target").and_then(Value::as_str) == Some(later_owner.as_str())
-                && edge.get("edge_kind").and_then(Value::as_str) == Some("eager_use")
-                && edge
-                    .get("role")
-                    .and_then(|role| role.get("kind"))
-                    .and_then(Value::as_str)
-                    == Some("promoted_at_init")
+            edge.source == component_owner
+                && edge.target == later_owner
+                && edge.edge_kind == DepKind::EagerUse
+                && matches!(edge.role, Some(EdgeRoleReport::PromotedAtInit { .. }))
         })
         .collect();
 


### PR DESCRIPTION
The logic refactor you asked for, finishing the `owner_for_binding` consolidation from #2340.

`at_init_unresolved_callee` and `pure_members` were the two tests still reading `owner_graph.json` as `serde_json::Value` and walking it by hand — a duplicate untyped `owner_for_binding` plus `Value`-based edge filters. This deserializes into the typed `OwnerGraphReport` instead, drops the local helpers (they now use the shared typed `owner_for_binding` from `:support`), and rewrites the edge filters against typed fields:

```rust
edge.target == owner
    && edge.edge_kind == DepKind::EagerUse
    && matches!(edge.role, Some(EdgeRoleReport::PromotedAtInit { .. }))
```

Both targets move to the `:analysis`-dep test list since they now name `analysis::` types directly. After this, **all five `owner_for_binding` callers share one typed helper and no `Value`-walking owner-graph code remains in the e2e suite.**

Net **−61 LOC**.

Verified with `--noremote_accept_cached` (clippy actually re-ran): both targets pass, and the full `//devinfra/js/debundle/e2e/...` suite (81 tests) is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011YQabfZ5jVoFSETefd27Bg)_