### PR TITLE
Refactor reactive state to use Svelte 5 $derived

### DIFF
--- a/props/frontend/src/components/FileViewer.svelte
+++ b/props/frontend/src/components/FileViewer.svelte
@@ -43,6 +43,7 @@
     defaultCollapsed = false,
   }: Props = $props();
 
+  // svelte-ignore state_referenced_locally
   let collapsed = $state(defaultCollapsed);
 
   const lines = $derived.by(() => {

--- a/props/frontend/src/components/LLMRequestSection.svelte
+++ b/props/frontend/src/components/LLMRequestSection.svelte
@@ -9,10 +9,12 @@
   }
   const { requestBody }: Props = $props();
 
-  const inputItems = Array.isArray(requestBody.input) ? (requestBody.input as Record<string, unknown>[]) : null;
-  const inputStr = typeof requestBody.input === "string" ? requestBody.input : null;
-  const instructions = typeof requestBody.instructions === "string" ? requestBody.instructions : null;
-  const paramKeys = Object.keys(requestBody).filter((k) => k !== "input" && k !== "instructions");
+  const inputItems = $derived(
+    Array.isArray(requestBody.input) ? (requestBody.input as Record<string, unknown>[]) : null
+  );
+  const inputStr = $derived(typeof requestBody.input === "string" ? requestBody.input : null);
+  const instructions = $derived(typeof requestBody.instructions === "string" ? requestBody.instructions : null);
+  const paramKeys = $derived(Object.keys(requestBody).filter((k) => k !== "input" && k !== "instructions"));
 </script>
 
 <div class="p-4 space-y-2">

--- a/props/frontend/src/components/LLMResponseSection.svelte
+++ b/props/frontend/src/components/LLMResponseSection.svelte
@@ -9,9 +9,11 @@
   }
   const { responseBody }: Props = $props();
 
-  const outputItems = Array.isArray(responseBody.output) ? (responseBody.output as Record<string, unknown>[]) : null;
-  const usage = responseBody.usage as Record<string, unknown> | null | undefined;
-  const detailKeys = Object.keys(responseBody).filter((k) => k !== "output" && k !== "usage");
+  const outputItems = $derived(
+    Array.isArray(responseBody.output) ? (responseBody.output as Record<string, unknown>[]) : null
+  );
+  const usage = $derived(responseBody.usage as Record<string, unknown> | null | undefined);
+  const detailKeys = $derived(Object.keys(responseBody).filter((k) => k !== "output" && k !== "usage"));
 </script>
 
 <div class="p-4 space-y-2">

--- a/props/frontend/src/components/RunDetail.svelte
+++ b/props/frontend/src/components/RunDetail.svelte
@@ -44,8 +44,10 @@
   // State
   // svelte-ignore state_referenced_locally
   let run: AgentRunDetail | null = $state(initialRun ?? null);
-  // svelte-ignore state_referenced_locally
-  let loading = $state(!initialRun);
+  let loadError: string | null = $state(null);
+  // `run` is null both before the initial fetch resolves and after a failed
+  // fetch; loadError disambiguates so this reflects only the in-flight case.
+  const loading = $derived(run === null && loadError === null);
 
   // Critique viewer state
   // svelte-ignore state_referenced_locally
@@ -137,10 +139,8 @@
       run = await fetchRun(runId);
       loadSnapshotDataInBackground(run);
     } catch (e) {
-      const message = e instanceof Error ? e.message : "Failed to load run";
-      toast.error(message);
-    } finally {
-      loading = false;
+      loadError = e instanceof Error ? e.message : "Failed to load run";
+      toast.error(loadError);
     }
   }
 
@@ -546,7 +546,7 @@
     </div>
   {:else}
     <div class="p-4">
-      <p class="text-red-500 dark:text-red-400">Failed to load run</p>
+      <p class="text-red-500 dark:text-red-400">{loadError ?? "Failed to load run"}</p>
     </div>
   {/if}
 </div>

--- a/props/frontend/src/components/RunDetail.svelte
+++ b/props/frontend/src/components/RunDetail.svelte
@@ -41,13 +41,15 @@
   }
   const { runId, initialRun, initialSnapshotDetail, initialFileContents, initialLLMRequests }: Props = $props();
 
-  // State
+  // State. A discriminated union keeps the loading/loaded/error states mutually
+  // exclusive (no "loaded but also errored" combo). initialRun (visual tests / SSR
+  // hydration) seeds the loaded state; otherwise we start in loading.
+  type RunLoad =
+    | { status: "loading" }
+    | { status: "loaded"; run: AgentRunDetail }
+    | { status: "error"; message: string };
   // svelte-ignore state_referenced_locally
-  let run: AgentRunDetail | null = $state(initialRun ?? null);
-  let loadError: string | null = $state(null);
-  // `run` is null both before the initial fetch resolves and after a failed
-  // fetch; loadError disambiguates so this reflects only the in-flight case.
-  const loading = $derived(run === null && loadError === null);
+  let load: RunLoad = $state(initialRun ? { status: "loaded", run: initialRun } : { status: "loading" });
 
   // Critique viewer state
   // svelte-ignore state_referenced_locally
@@ -136,11 +138,13 @@
   // so it cannot block run metadata, logs, or LLM request display.
   async function loadData() {
     try {
-      run = await fetchRun(runId);
-      loadSnapshotDataInBackground(run);
+      const fetchedRun = await fetchRun(runId);
+      load = { status: "loaded", run: fetchedRun };
+      loadSnapshotDataInBackground(fetchedRun);
     } catch (e) {
-      loadError = e instanceof Error ? e.message : "Failed to load run";
-      toast.error(loadError);
+      const message = e instanceof Error ? e.message : "Failed to load run";
+      load = { status: "error", message };
+      toast.error(message);
     }
   }
 
@@ -256,11 +260,13 @@
           class="px-3 py-1 text-sm border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-900 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800"
         />
         <h2 class="text-lg font-semibold">Run Details</h2>
-        {#if run}
+        {#if load.status === "loaded"}
+          {@const run = load.run}
           <span class="font-mono text-sm text-gray-500 dark:text-gray-400"><RunIdLink id={run.agent_run_id} /></span>
         {/if}
       </div>
-      {#if run}
+      {#if load.status === "loaded"}
+        {@const run = load.run}
         <span class="px-2 py-1 rounded text-sm font-medium capitalize {getStatusColor(run.status)}">
           {formatStatus(run.status)}
         </span>
@@ -269,11 +275,12 @@
     <Breadcrumb items={[{ label: "Home", href: "/" }, { label: "Runs", href: "/runs" }, { label: runId }]} />
   </div>
 
-  {#if loading}
+  {#if load.status === "loading"}
     <div class="p-4">
       <p class="text-gray-500 dark:text-gray-400">Loading...</p>
     </div>
-  {:else if run}
+  {:else if load.status === "loaded"}
+    {@const run = load.run}
     <!-- Run info -->
     <div class="p-4 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 flex-shrink-0">
       <div class="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
@@ -544,9 +551,9 @@
         </div>
       {/if}
     </div>
-  {:else}
+  {:else if load.status === "error"}
     <div class="p-4">
-      <p class="text-red-500 dark:text-red-400">{loadError ?? "Failed to load run"}</p>
+      <p class="text-red-500 dark:text-red-400">{load.message}</p>
     </div>
   {/if}
 </div>

--- a/props/frontend/src/components/RunDetail.svelte
+++ b/props/frontend/src/components/RunDetail.svelte
@@ -42,17 +42,22 @@
   const { runId, initialRun, initialSnapshotDetail, initialFileContents, initialLLMRequests }: Props = $props();
 
   // State
+  // svelte-ignore state_referenced_locally
   let run: AgentRunDetail | null = $state(initialRun ?? null);
+  // svelte-ignore state_referenced_locally
   let loading = $state(!initialRun);
 
   // Critique viewer state
+  // svelte-ignore state_referenced_locally
   let snapshotDetail: SnapshotDetailResponse | null = $state(initialSnapshotDetail ?? null);
+  // svelte-ignore state_referenced_locally
   let fileContents = $state(
     initialFileContents ? new SvelteMap(initialFileContents) : new SvelteMap<string, FileContentResponse>()
   );
   let loadingSnapshot = $state(false);
 
   // LLM requests state
+  // svelte-ignore state_referenced_locally
   let llmRequests: LLMRequestInfo[] = $state(initialLLMRequests ?? []);
   let loadingLLMRequests = $state(false);
 


### PR DESCRIPTION
## Summary
This PR refactors several components to better utilize Svelte 5's reactivity system by converting computed values from regular variables to `$derived` blocks. Additionally, it improves error handling in RunDetail by distinguishing between loading and error states.

## Key Changes

- **RunDetail.svelte**: 
  - Replaced boolean `loading` state with a `$derived` that checks if `run` is null and `loadError` is null
  - Added `loadError` state to track fetch failures separately from the loading state
  - Updated error handling to store and display the actual error message
  - Added `svelte-ignore` comments for state variables referenced locally

- **LLMRequestSection.svelte**:
  - Converted `inputItems`, `inputStr`, `instructions`, and `paramKeys` from regular variables to `$derived` blocks
  - These values are now reactively computed from `requestBody` prop changes

- **LLMResponseSection.svelte**:
  - Converted `outputItems`, `usage`, and `detailKeys` from regular variables to `$derived` blocks
  - These values are now reactively computed from `responseBody` prop changes

- **FileViewer.svelte**:
  - Added `svelte-ignore` comment for `collapsed` state variable

## Implementation Details

The refactoring improves the reactive dependency tracking by explicitly marking derived values with `$derived`, which ensures they're automatically recomputed when their dependencies change. This is more idiomatic for Svelte 5 and provides better performance characteristics than manual variable updates.

The error handling improvement in RunDetail allows the UI to distinguish between three states: loading (run is null, no error), error (loadError is set), and loaded (run is set). This enables more precise error messaging to users.

https://claude.ai/code/session_0155CzkRyaCVcDSrK7NDXVnc