### PR TITLE
skills: adopt google-photos-link skill

### DIFF
--- a/skills/BUILD.bazel
+++ b/skills/BUILD.bazel
@@ -28,6 +28,7 @@ pkg_tar(
         "//skills/followups:followups_tar",
         "//skills/forensic_surgeon:forensic_surgeon_tar",
         "//skills/freecad:freecad_tar",
+        "//skills/google_photos_link:google_photos_link_tar",
         "//skills/ground_skill:ground_skill_tar",
         "//skills/info_gathering:info_gathering_tar",
         "//skills/knowledge_hygiene:knowledge_hygiene_tar",

--- a/skills/google_photos_link/BUILD.bazel
+++ b/skills/google_photos_link/BUILD.bazel
@@ -1,0 +1,9 @@
+load("//skills:defs.bzl", "skill_package")
+
+skill_package(
+    name = "google_photos_link",
+    srcs = [
+        "SKILL.md",
+        "scripts/fetch_google_photos.py",
+    ],
+)

--- a/skills/google_photos_link/SKILL.md
+++ b/skills/google_photos_link/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: google-photos-link
+description: >-
+  Access, download, and view images from a PUBLIC Google Photos share link —
+  either a short photos.app.goo.gl/XXXX link or a full
+  photos.google.com/share/ALBUM_ID?key=KEY link. Use this whenever the user
+  pastes a Google Photos link and asks you to view, open, download, describe, or
+  analyze the photos, OR when a Google Photos link appears and you need the
+  actual image content (web_fetch alone only returns album metadata, not the
+  pixels). Resolves the link, scrapes each photo's direct googleusercontent.com
+  URL, downloads at a chosen resolution, and leaves JPEGs on disk ready to open
+  with the view tool. Only works for link-shared (public) albums, not albums
+  shared privately to specific Google accounts.
+---
+
+# Google Photos Link Access
+
+## Why this skill exists
+
+A Google Photos share link does **not** point at an image file. It points at a
+JavaScript web app. Calling `web_fetch` on the link returns only the album
+_shell_: a title, an `og:image` thumbnail, and a list of links to per-photo
+pages. It does **not** give you the photos themselves. To actually see the
+images you have to walk one extra layer: open each photo's page, pull out its
+direct `lh3.googleusercontent.com` image URL, and download the bytes. This skill
+encodes that walk so you don't rediscover it each time.
+
+## Quickest path: run the script
+
+A tested helper does the whole walk. Prefer it over doing the steps by hand.
+
+```bash
+# Download viewable JPEGs (longest side 2048px) into ./photos/
+python3 scripts/fetch_google_photos.py "<share_url>" --out ./photos --width 2048
+
+# Then open them to actually look:
+#   view ./photos/photo_01.jpg   (etc.)
+```
+
+Other modes:
+
+```bash
+python3 scripts/fetch_google_photos.py "<url>" --original   # full-resolution originals (=d)
+python3 scripts/fetch_google_photos.py "<url>" --list       # print direct image URLs, download nothing
+```
+
+The script accepts the short link, the full album link, or a single-photo link.
+After it finishes, **view the downloaded files** — downloading is not the goal;
+seeing the images is. Report what you see.
+
+## What the link looks like (so you can sanity-check it)
+
+| Form         | Example                                                           |
+| ------------ | ----------------------------------------------------------------- |
+| Short        | `https://photos.app.goo.gl/C3aVzvb4GpZ9NA2e8`                     |
+| Full album   | `https://photos.google.com/share/AF1Qip…?key=RDdF…`               |
+| Single photo | `https://photos.google.com/share/AF1Qip…/photo/AF1Qip…?key=RDdF…` |
+
+The `key=` token is the share credential. If a link has no `key`, it is almost
+certainly a private album and this approach will hit a login wall.
+
+## The manual method (for debugging, or if the script breaks)
+
+Do this by hand only when the script fails and you need to see where.
+
+1. **Resolve the link.** `web_fetch` (or `curl -sL`) the share URL. The short
+   `goo.gl` link 302-redirects to `photos.google.com/share/<ALBUM_ID>?key=<KEY>`.
+   The returned HTML's `og:title` tells you the album name and photo count.
+
+2. **Collect photo IDs from the album page.** The album HTML contains one link
+   per photo of the form `/share/<ALBUM_ID>/photo/<PHOTO_ID>?key=<KEY>`. Extract
+   every `<PHOTO_ID>` and de-duplicate while preserving order:
+   `grep -oE '/photo/[A-Za-z0-9_-]+'`. (The album page does **not** contain the
+   full-size image URLs — only the cover, via `og:image`. That's why step 3 is
+   needed.)
+
+3. **Get each photo's direct image URL.** Fetch each photo page. Its HTML embeds
+   the real image at a thumbnail size, e.g.
+   `https://lh3.googleusercontent.com/pw/<TOKEN>=s250-k-no`. Grab the base
+   (everything before `=`):
+   `grep -oE 'https://lh3\.googleusercontent\.com/[A-Za-z0-9_/-]+' | head -1`.
+
+4. **Resize via the URL suffix, then download.** The `lh3` base URL is a
+   resizer. Append a suffix and `curl` the result:
+   - `=w2048-no` → longest side 2048px, aspect preserved, **no upscaling**
+     (`-no` is what prevents upscaling and extra server processing).
+   - `=w1280-no`, `=s1024`, `=w1920-h1080` → other size options.
+   - `=d` → the **original** bytes at full quality and native dimensions
+     (also the only way to pull the original of a video).
+
+5. **View the files.** Open each downloaded JPEG with the `view` tool and
+   describe / analyze as asked.
+
+## Picking a size
+
+- **Just viewing / describing:** `--width 2048` is plenty and keeps files small.
+- **Reading fine detail (text, engraving, small labels):** try `--width 4096`,
+  or `--original` to avoid re-compression artifacts. Note `=w{N}-no` never
+  upscales, so for an image whose original is smaller than N you'll get the
+  original size regardless.
+- **User wants the actual files to keep:** `--original`.
+
+## Limitations — know these before promising results
+
+- **Public link-shared albums only.** If the album was shared privately to
+  specific Google accounts (no `key=` in the URL), the pages return a sign-in
+  wall and there is nothing to scrape. Tell the user it needs to be shared "by
+  link" / "anyone with the link."
+- **Links can expire or be revoked.** The owner can turn off link sharing at any
+  time, after which the same URL stops working.
+- **Videos:** the per-photo page exposes a poster frame for stills easily; for
+  video, `=d` on the base may fetch the original file, but playback/streaming
+  variants are out of scope here.
+- **Consent interstitials:** in some regions Google serves a cookie-consent page
+  to non-browser clients. If the script returns 0 photos but the link works in a
+  browser, fall back to `curl -sL` with a browser `User-Agent` and inspect the
+  HTML, or have the user open it in an incognito window to confirm it's public.
+- **Respect privacy.** Only fetch links the user has supplied or clearly wants
+  opened. Don't enumerate or guess album/photo IDs.
+
+## Troubleshooting
+
+| Symptom                                        | Likely cause                                | Fix                                                                              |
+| ---------------------------------------------- | ------------------------------------------- | -------------------------------------------------------------------------------- |
+| "no photos found"                              | private album / missing `key`               | Confirm the link opens in an incognito window; ask owner to share by link        |
+| 0 photos but link works in browser             | consent page or odd UA handling             | Re-run with a browser `User-Agent`; inspect raw HTML for a redirect/consent form |
+| Downloaded file isn't a valid image            | grabbed an interstitial, not the image      | Check `file <name>`; re-extract the `lh3` base from the photo page               |
+| Image looks low-res                            | size suffix too small, or original is small | Use `--width 4096` or `--original`; remember `-no` won't upscale                 |
+| `Syntax error: "(" unexpected` in a shell loop | script ran under `/bin/sh`, not bash        | Use the Python helper, or write bash to a file and run `bash file.sh`            |

--- a/skills/google_photos_link/scripts/fetch_google_photos.py
+++ b/skills/google_photos_link/scripts/fetch_google_photos.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Download images from a PUBLIC Google Photos share link.
+
+Works with both forms of share URL:
+  - short:  https://photos.app.goo.gl/XXXXXXXX
+  - full:   https://photos.google.com/share/<ALBUM_ID>?key=<KEY>
+  - single: https://photos.google.com/share/<ALBUM_ID>/photo/<PHOTO_ID>?key=<KEY>
+
+Strategy (no API, no auth, stdlib only):
+  1. Follow the share link to the album page HTML.
+  2. Scrape the per-photo page paths (/share/<ALBUM>/photo/<PHOTO_ID>?key=<KEY>).
+  3. Open each photo page and scrape its lh3.googleusercontent.com base URL.
+  4. Append a size suffix to that base URL and download the bytes.
+
+Only works for albums shared by *link* (the URL carries a `key=` token). Albums
+shared privately to specific Google accounts return a login wall and cannot be
+read this way.
+
+Usage:
+  python3 fetch_google_photos.py "<share_url>" [--out DIR] [--width N | --original] [--list]
+
+Examples:
+  python3 fetch_google_photos.py "https://photos.app.goo.gl/abc123" --out ./photos --width 2048
+  python3 fetch_google_photos.py "<url>" --original          # full-resolution originals
+  python3 fetch_google_photos.py "<url>" --list              # print direct image URLs, download nothing
+"""
+
+import argparse
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36"
+HEADERS = {"User-Agent": UA, "Accept-Language": "en-US,en;q=0.9"}
+
+# An lh3 base URL: https://lh3.googleusercontent.com/pw/<token>   (token may contain - _ and /)
+# The size suffix begins at "=" (e.g. =s250-k-no), which is NOT in this class, so the
+# match naturally stops at the base.
+IMG_BASE_RE = re.compile(r"https://lh3\.googleusercontent\.com/[\w/-]+")
+PHOTO_ID_RE = re.compile(r"/photo/([\w-]+)")
+SHARE_ID_RE = re.compile(r"/share/([\w-]+)")
+KEY_RE = re.compile(r"[?&]key=([\w-]+)")
+
+
+def fetch(url: str, timeout: int = 30) -> tuple[str, str]:
+    """GET a URL (following redirects); return (decoded text, final resolved URL)."""
+    req = urllib.request.Request(url, headers=HEADERS)
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.read().decode("utf-8", errors="replace"), resp.geturl()
+
+
+def fetch_bytes(url: str, timeout: int = 60) -> bytes:
+    req = urllib.request.Request(url, headers=HEADERS)
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.read()
+
+
+def parse_album(share_url: str):
+    """Return (final_url, album_id, key, [photo_ids]) from an album OR single-photo URL."""
+    html, final_url = fetch(share_url)
+
+    album_id = None
+    m = SHARE_ID_RE.search(final_url) or SHARE_ID_RE.search(html)
+    if m:
+        album_id = m.group(1)
+
+    key = None
+    m = KEY_RE.search(final_url) or KEY_RE.search(html)
+    if m:
+        key = m.group(1)
+
+    # If the resolved URL is itself a single photo, just use that one id.
+    single = PHOTO_ID_RE.search(final_url)
+    if single:
+        return final_url, album_id, key, [single.group(1)]
+
+    # Otherwise scrape all photo ids from the album page, de-duped, order preserved.
+    ids, seen = [], set()
+    for pid in PHOTO_ID_RE.findall(html):
+        if pid not in seen:
+            seen.add(pid)
+            ids.append(pid)
+    return final_url, album_id, key, ids
+
+
+def photo_page_url(album_id: str, key: str | None, photo_id: str) -> str:
+    base = f"https://photos.google.com/share/{album_id}/photo/{photo_id}"
+    return f"{base}?key={key}" if key else base
+
+
+def base_image_url(photo_url: str):
+    """Open a photo page and return its bare lh3 base URL (no size suffix)."""
+    html, _ = fetch(photo_url)
+    m = IMG_BASE_RE.search(html)
+    return m.group(0) if m else None
+
+
+def sized(base: str, width: int | None, original: bool) -> str:
+    """Append the right size suffix to an lh3 base URL.
+
+    - original=True  -> '=d'      (downloads the original bytes, incl. video)
+    - width=N        -> '=wN'     (longest-dimension N, preserves aspect ratio)
+    The '-no' guard avoids server-side upscaling / extra processing for stills.
+    """
+    if original:
+        return base + "=d"
+    return base + f"=w{width}-no"
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Download images from a public Google Photos share link.")
+    ap.add_argument("url", help="Google Photos share link (short or full)")
+    ap.add_argument("--out", type=Path, default=Path("photos"), help="output directory")
+    ap.add_argument("--width", type=int, default=2048, help="longest-side pixels for viewable JPEGs")
+    ap.add_argument(
+        "--original", action="store_true", help="download full-resolution originals instead of resized JPEGs"
+    )
+    ap.add_argument("--list", action="store_true", help="print direct image URLs and exit without downloading")
+    args = ap.parse_args()
+
+    try:
+        final_url, album_id, key, photo_ids = parse_album(args.url)
+    except urllib.error.URLError as e:
+        sys.exit(f"ERROR: could not open share link: {e}")
+
+    if not photo_ids:
+        sys.exit(
+            "ERROR: no photos found. The link may be private, expired, or not a "
+            "link-shared album. Confirm it opens in an incognito browser window."
+        )
+
+    print(f"Resolved: {final_url}")
+    print(f"Album: {album_id or '(single photo)'}   Photos: {len(photo_ids)}")
+
+    args.out.mkdir(parents=True, exist_ok=True)
+    results = []
+    for i, pid in enumerate(photo_ids, 1):
+        purl = photo_page_url(album_id, key, pid) if album_id else final_url
+        base = base_image_url(purl)
+        if not base:
+            print(f"  [{i}/{len(photo_ids)}] {pid}: could not extract image URL (skipped)")
+            continue
+        img_url = sized(base, args.width, args.original)
+        results.append((i, pid, img_url))
+        if args.list:
+            print(img_url)
+            continue
+        ext = "jpg"  # =wN renders JPEG; =d originals keep their type but jpg is a safe default
+        dest = args.out / f"photo_{i:02d}.{ext}"
+        try:
+            data = fetch_bytes(img_url)
+            dest.write_bytes(data)
+            print(f"  [{i}/{len(photo_ids)}] {pid}: {len(data) // 1024} KB -> {dest}")
+        except urllib.error.URLError as e:
+            print(f"  [{i}/{len(photo_ids)}] {pid}: download failed ({e})")
+
+    if not args.list:
+        print(f"\nDone. {len(results)} image URL(s) resolved into {args.out}/")
+        print("View the files (e.g. with the `view` tool) to inspect them.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adopts the `google-photos-link` skill into the repo's `skills/` tree and wires it into the standard deployment flow.

## What
- `skills/google_photos_link/SKILL.md` — public Google Photos share-link image fetcher (resolves short/full share URLs, scrapes each photo's direct `googleusercontent.com` URL, downloads at a chosen resolution).
- `skills/google_photos_link/scripts/fetch_google_photos.py` — the stdlib-only helper the skill drives.
- `skills/google_photos_link/BUILD.bazel` — `skill_package(name, srcs)` packaging `SKILL.md` + the script (paths preserved).
- Registered `//skills/google_photos_link:google_photos_link_tar` in `//skills:all_skills_tar`.

Directory is snake_case (`google_photos_link`) per repo convention; the skill's invocation `name:` stays `google-photos-link` (same split as `info_gathering`/`info-gathering`).

## Adaptations to repo style
- `pathlib.Path` over `os.path`/`open`; `--out` parses directly as a `Path`.
- Fixed `fetch` return annotation (`-> tuple[str, str]`) and `photo_page_url` `key: str | None`.

## Verification
- `bbr build //skills:all_skills_tar //skills/google_photos_link:google_photos_link_tar` — tar contains `SKILL.md` + `scripts/fetch_google_photos.py`.
- `bbr test //skills/google_photos_link:google_photos_link_frontmatter_test` passed.
- `pre-commit` (ruff, ruff-format, buildifier, prettier) clean.

## Deploy
Skills auto-discover from the tarball (`nix/home/skills.nix` reads each dir). After this merges and CI publishes the new `all_skills_tar` release, bump the `skills-tar` flake input and run `home-manager switch` to land it in `~/.claude/skills/`.

No `allowed-tools` added.