### PR TITLE
debundle: wire `--candidates N` menu to the binding-group read-off (M1 complete)

### DIFF
--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -69,9 +69,9 @@ One-line status for each `plans/` design doc; this is the discovery index.
   agent task: the `debundle_stabilize` skill picks forward-compatible anchors; the
   minimizer is demoted to suggester + uniqueness oracle. Plan + skill landed (#2332);
   **M1 read-only primitives complete** — `match-selector` query + over-pin slack
-  (#2335) and `synthesize-selectors --candidates N` ranked menu (#2339). Open: ground
-  the skill playbook with tested fixtures (M2), port-based evaluation (M3), and the
-  selector-authoring tooling gaps below.
+  (value + structural, #2335/#2345) and `synthesize-selectors --candidates N` ranked
+  menu across all read-off forms (#2339 + binding-group menu). Open: ground the skill
+  playbook with tested fixtures (M2) and port-based evaluation (M3).
 - <plans/adopt_names_via_bijection.md> — **not started.** Expose the `source_match`
   identifier bijection so one selector both locates a declaration and adopts
   readable names onto its params/locals/nested bindings.
@@ -271,19 +271,6 @@ reading source files. This is conditional on hitting that cost; not yet
 observed. (The `owner:<id>`-in-spec-notes framing that used to live here was
 stale — no such mechanism exists; `owner:N` ids are machine-generated graph
 keys and a `describe`/`show-source` input, not a spec authoring hint.)
-
-## Selector-authoring tooling gaps (M1 residue)
-
-The read-only authoring primitives landed (`match-selector` #2335,
-`synthesize-selectors --candidates N` #2339). Known gaps, each a follow-up:
-
-- **`--candidates N` menu for multi-declarator var binding groups.** The
-  ranked menu covers the function/class and single-target var/object read-off
-  forms (`read_off_candidates`, `try_var_read_off`, `try_object_read_off`). The
-  multi-target binding-group path (`try_var_group_read_off` + the keep-shallow
-  fallback) is tuple-shaped and still returns only the single pick;
-  `synthesize_specialized_selector_candidates` falls back to single for it.
-  Collecting a ranked tuple menu there is the remaining wiring.
 
 ## Structural selector language
 

--- a/devinfra/js/debundle/e2e/selector_codemod_cli_test.rs
+++ b/devinfra/js/debundle/e2e/selector_codemod_cli_test.rs
@@ -1487,3 +1487,79 @@ fn synthesize_selectors_var_object_candidates_reports_value_anchor_menu() {
         "the menu surfaces the surface value anchor: {parsed}"
     );
 }
+
+#[test]
+fn synthesize_selectors_binding_group_candidates_offers_keep_shallow_alternative() {
+    let dir = tempfile::tempdir().unwrap();
+    let source = dir.path().join("chunks/app.js");
+    // A two-declarator binding group (both targets in one `const`). Each slot's
+    // leading string is globally unique, so the sparse union-minimal tuple pins
+    // just those strings (holing the numeric args via ARGS), while the keep-shallow
+    // tuple keeps every shallow literal — two genuinely different group selectors.
+    write_text_file(
+        &source,
+        concat!(
+            "const widgetA = buildWidget(\"alpha-tag\", 11, 22),\n",
+            "  widgetB = buildWidget(\"beta-tag\", 33, 44);\n",
+            "export { widgetA, widgetB };\n",
+        ),
+    );
+    let modules = dir.path().join("modules");
+    write_text_file(
+        &modules.join("app/widgets.yaml"),
+        r#"members:
+  - name: WidgetA
+    selector:
+      binding:
+        name: widgetA
+  - name: WidgetB
+    selector:
+      binding:
+        name: widgetB
+"#,
+    );
+
+    let out = run_synthesize_selectors(
+        &modules,
+        &[
+            "--source-file",
+            source.to_str().unwrap(),
+            "--item",
+            "app/widgets:WidgetA",
+            "--item",
+            "app/widgets:WidgetB",
+            "--candidates",
+            "2",
+            "--format",
+            "json",
+        ],
+    );
+    let parsed = parse_stdout_json(&out);
+    // The two members share a declaration, so they synthesize as one binding group;
+    // its candidate carries the keep-shallow tuple as a ranked alternative.
+    let candidate = parsed["candidates"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|candidate| {
+            candidate
+                .get("alternatives")
+                .and_then(|alternatives| alternatives.as_array())
+                .is_some_and(|alternatives| !alternatives.is_empty())
+        })
+        .unwrap_or_else(|| panic!("no binding-group candidate with a menu: {parsed}"));
+    let primary = candidate["match_source"].as_str().unwrap();
+    // Each alternative is a distinct group selector binding both targets (the
+    // keep-shallow tuple keeps the numeric args the union-minimal primary holes).
+    for alternative in candidate["alternatives"].as_array().unwrap() {
+        let alt = alternative["match_source"].as_str().unwrap();
+        assert_ne!(
+            alt, primary,
+            "alternative must differ from the primary: {candidate}"
+        );
+        assert!(
+            alt.contains("WidgetA") && alt.contains("WidgetB"),
+            "each alternative is a group selector for both targets: {alt}"
+        );
+    }
+}

--- a/devinfra/js/debundle/minimize/group.rs
+++ b/devinfra/js/debundle/minimize/group.rs
@@ -362,9 +362,10 @@ fn try_var_group_read_off(
 
 /// Up to `limit` ranked candidate selectors for a `var` declaration — the
 /// `synthesize-selectors --candidates N` menu. A single-target object or non-object
-/// var slot returns its read-off menu; the multi-declarator binding-group and
-/// keep-shallow paths are not yet menu-aware and yield only the single pick
-/// (tracked in `TODO.md`). `limit == 1` reproduces [`minimize_var_group_selector`].
+/// var slot returns its read-off menu; a multi-declarator binding group returns the
+/// sparse union-minimal tuple plus the keep-shallow tuple as a robustness
+/// alternative ([`group_read_off_candidates`]). `limit == 1` reproduces
+/// [`minimize_var_group_selector`].
 pub(crate) fn minimize_var_group_selector_candidates(
     index: &ChunkSelectorIndex,
     var: &VarDecl,
@@ -404,10 +405,39 @@ pub(crate) fn minimize_var_group_selector_candidates(
             return Ok(var_candidates);
         }
     }
-    // Multi-target binding-group / keep-shallow: menu not yet wired — single pick.
-    Ok(minimize_var_group_selector(index, var, decl, targets)?
-        .into_iter()
-        .collect())
+    // Multi-target binding-group (and the single-target case that fell through the
+    // object / non-object read-off menus): the sparse union-minimal tuple, then the
+    // keep-shallow tuple as a robustness alternative.
+    group_read_off_candidates(index, var, decl, targets, &target_slots, limit)
+}
+
+/// Up to `limit` ranked binding-group selectors: the sparse union-minimal tuple
+/// ([`try_var_group_read_off`]) first, then the keep-shallow tuple
+/// ([`keep_shallow_group_selector`]) as a robustness alternative, deduped by
+/// source. `limit == 1` reproduces the single pick [`minimize_var_group_selector`]
+/// returns for the group / fell-through path (group read-off, else keep-shallow).
+fn group_read_off_candidates(
+    index: &ChunkSelectorIndex,
+    var: &VarDecl,
+    decl: &IndexedDeclaration,
+    targets: &[SynthesizedTargetBinding],
+    target_slots: &BTreeSet<usize>,
+    limit: usize,
+) -> Result<Vec<SpecializedSelector>> {
+    let mut out: Vec<SpecializedSelector> = Vec::new();
+    if let Some(selector) = try_var_group_read_off(index, var, decl, targets, target_slots)? {
+        out.push(selector);
+    }
+    if out.len() < limit
+        && let Some(selector) =
+            keep_shallow_group_selector(index, var, decl, targets, target_slots)?
+        && !out
+            .iter()
+            .any(|kept| kept.match_source == selector.match_source)
+    {
+        out.push(selector);
+    }
+    Ok(out)
 }
 
 /// Minimal anchor cover for a `var`/`let`/`const` binding group: render the
@@ -489,16 +519,39 @@ pub(crate) fn minimize_var_group_selector(
         return Ok(Some(selector));
     }
 
-    // Keep-shallow render via the shared var-slot renderer. Unlike the read-off
-    // paths, the keep-shallow path holes every init (objects included) through
-    // plain [`hole_expr`] — an object init holes via [`hole_object`] (list hole
-    // only where a run dropped), not the padded key-set form.
+    // Keep-shallow cover (with enclosing-context fallback): the robustness path
+    // when no read-off form singled the group out.
+    keep_shallow_group_selector(index, var, decl, targets, &target_slots)
+}
+
+/// Keep-shallow cover for a binding group: keep each target slot's shallow
+/// literal anchors, escalating to structural / deeper tiers only if the group
+/// does not yet resolve uniquely to the right bindings. Unlike the read-off
+/// paths, it holes every init (objects included) through plain [`hole_expr`] (an
+/// object init holes via `hole_object` — list hole only where a run dropped — not
+/// the padded key-set form). The robustness-favoring counterpart to the sparse
+/// [`try_var_group_read_off`]; for a single target that no anchor set singles out,
+/// falls back to enclosing-context anchoring. Returns `None` for a multi-target
+/// residual no cover resolves.
+fn keep_shallow_group_selector(
+    index: &ChunkSelectorIndex,
+    var: &VarDecl,
+    decl: &IndexedDeclaration,
+    targets: &[SynthesizedTargetBinding],
+    target_slots: &BTreeSet<usize>,
+) -> Result<Option<SpecializedSelector>> {
+    let export_for = |runtime: &str| {
+        targets
+            .iter()
+            .find(|target| target.runtime_binding == runtime)
+            .map(|target| target.export_name.clone())
+    };
     let render_with = |kept: &BTreeSet<AnchorSpan>,
                        regex_anchors: &BTreeMap<AnchorSpan, String>|
      -> Result<String> {
         render_var_slots(
             var,
-            &target_slots,
+            target_slots,
             &export_for,
             kept,
             regex_anchors,

--- a/devinfra/js/debundle/plans/selector_authoring_agent.md
+++ b/devinfra/js/debundle/plans/selector_authoring_agent.md
@@ -178,8 +178,9 @@ reads them as a menu to override an incidental anchor with a purpose-bearing one
 read-off walk now collects the top-N proving anchor sets (`read_off_candidates`, with
 `limit == 1` reproducing the single pick); the extras beyond the primary surface as
 `alternatives` on each report candidate, and the primary's own `match_source` is now in
-the report too. Covers the function/class and single-target var/object read-off forms;
-the multi-declarator binding-group menu is still single-pick (tracked in `TODO.md`).
+the report too. Covers every read-off form: function/class, single-target var/object
+(each with its value-anchor extras), and the multi-declarator binding group (the sparse
+union-minimal tuple plus the keep-shallow tuple as a robustness alternative).
 
 Both commands follow the
 [automated spec workflows](automated_spec_workflows.md) contract: `--format
@@ -292,10 +293,10 @@ way it dispatches naming/extraction lanes.
 ## Open questions / milestones
 
 - **M1 — read-only primitives — complete.** `match-selector` (hypothesis-test probe +
-  over-pin slack, value + structural, now incl. top-level context-statement and
-  destructure-pattern-property drops) **landed** (#2335); `synthesize-selectors
---candidates N` (the ranked-candidate menu) **landed** (#2339). Residue tracked in
-  `TODO.md`: the candidates menu for multi-declarator var groups.
+  over-pin slack, value + structural incl. top-level context-statement and
+  destructure-pattern-property drops) **landed** (#2335/#2345); `synthesize-selectors
+--candidates N` (the ranked-candidate menu, across every read-off form incl. the
+  binding-group tuple) **landed** (#2339 + binding-group menu). No residue.
 - **M2 — the skill.** Loop + playbook + anonymized fixtures. The `debundle_stabilize`
   skill **landed** (#2332); grounding its playbook entries with tested fixtures is
   still open.


### PR DESCRIPTION
## What

The last M1 residue from the [selector-authoring plan](https://github.com/agentydragon/ducktape/blob/devel/devinfra/js/debundle/plans/selector_authoring_agent.md): the multi-declarator var **binding-group** path was still single-pick, while function/class and single-target var/object read-off forms all had a ranked `synthesize-selectors --candidates N` menu (#2339, #2341). This wires the group path too.

## How

- **Extract** the keep-shallow cover tail of `minimize_var_group_selector` into `keep_shallow_group_selector` (behavior-preserving — the single-pick path now calls it as its final fallback).
- **Add `group_read_off_candidates(.., limit)`**: the sparse union-minimal tuple (`try_var_group_read_off`) as the primary, then the keep-shallow tuple as a robustness alternative, deduped by source. **`limit == 1` reproduces exactly what `minimize_var_group_selector` picks** (group read-off, else keep-shallow), so default synthesize output is unchanged.
- **Route** the multi-target group (and the single-target case that fell through the object/non-object read-off menus) through `group_read_off_candidates` instead of collapsing to the single pick.

The two tuples are genuinely different anchor choices — sparse value pins vs. keep-every-shallow-literal, plus distinct holers for object slots — so the agent gets a real **sparse-vs-robust** menu for groups, not a cosmetic duplicate (it dedups to one when they coincide).

## Validation

- New e2e `synthesize_selectors_binding_group_candidates_offers_keep_shallow_alternative`: a two-declarator group (`const widgetA = buildWidget("alpha-tag", 11, 22), widgetB = …`) reports the keep-shallow tuple as a ranked alternative binding **both** targets.
- **All 120 `//devinfra/js/debundle/...` tests pass** — including the `selector_minimizer_expectation_test` baselines and the `selector_codemod` proptest that gate the `limit == 1` behavior, confirming the extraction + routing is behavior-preserving.
- Built/tested with `bazelisk` + system-Java truststore + RBE; clippy + rustfmt clean.

With this, **every M1 read-only primitive is fully landed — no residue.** `match-selector` (query + value/structural slack) across #2335/#2345; `synthesize-selectors --candidates N` across every read-off form via #2339/#2341 and this PR. Remaining plan work is M2 (ground the `debundle_stabilize` skill with tested fixtures) and M3 (port-based evaluation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7wbQibmuz5nX9dTzT7PzU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7wbQibmuz5nX9dTzT7PzU)_