### PR TITLE
debundle: dedup CLI report dispatch + purity-reason construction

### DIFF
--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -160,33 +160,20 @@ propose`.
 ## Code refactor / dedup opportunities (2026-06-17 survey)
 
 Production-code (non-test) dedup/cleanup options surfaced by a codebase survey.
-Calibrated LOC estimates and risk; pick by (LOC saved × safety). The
-`minimize/` single-pick-layer collapse (function/class single-pick is the
-candidates read-off at limit 1) is already done.
+Calibrated by (LOC saved × safety). Done so far: the `minimize/` single-pick
+collapse (#2346), the CLI report-dispatch helper (`cli::emit_report`), and the
+`PurityReason` construction centralization (`PurityReason::new` +
+`Purity::from_reason_opt_detail`).
 
 **Safe, internal, no behavior change:**
 
-1. CLI common args via clap `#[command(flatten)]`. The `--modules` /
-   `--source-root` / `--format` fields repeat across 5+ `Args` structs in
-   <cli/mod.rs> (`SpecStatsArgs`, `SelectorDebtArgs`, `MatchSelectorArgs`,
-   `Bindings{Assign,Unassign}Args`, …). Factor a shared flattened struct.
-   ~80–120 LOC, low risk.
-2. CLI report dispatch helper. ~18 sites in <cli/mod.rs> repeat
-   `let format = OutputFormat::resolve(..); let report = run_*(..)?;
-print_report(&report, format, render_*)`. A `run_report_and_format`
-   helper collapses the triple. ~40–60 LOC (not the 200–300 an earlier
-   estimate claimed), low risk.
-3. `PurityReason { rule, span, source_location: None, detail: None }` literal
-   appears at 7 sites in <facts/purity_classification.rs> and
-   <purity/classifier.rs>; add a `Purity::not_pure(rule, span)` constructor.
-   ~20 LOC, trivial.
-4. `vendor/mod.rs` `validate_boundary_mapping_collisions` +
+1. `vendor/mod.rs` `validate_boundary_mapping_collisions` +
    `collect_boundary_mapping` both walk `module.body` export specifiers; merge
    into one pass. ~30 LOC, low risk.
 
 **Real value but needs design work / behavior-risk:**
 
-5. Parameterize the per-form AST holing visitors (`render.rs` `hole_expr` /
+2. Parameterize the per-form AST holing visitors (`render.rs` `hole_expr` /
    `hole_stmt`, `minimize/class.rs` `hole_class_member`, etc.) behind a `Holer`
    trait or table to collapse repeated per-variant match clusters. ~150 LOC,
    medium risk (over-abstraction hazard; the per-form holing strategies differ
@@ -195,6 +182,16 @@ print_report(&report, format, render_*)`. A `run_report_and_format`
 **Organization only (≈0 LOC removed, navigability win):** split the giant
 files by responsibility — <selector_codemod.rs> (2.8k), <peel/quotient.rs>
 (2.5k), <lowering/rename_ledger.rs> (1.7k).
+
+**Evaluated and declined:** CLI common args via clap `#[command(flatten)]`. The
+recurring flags (`--modules` / `--source-root` / `--format`) occur in
+incompatible combinations across the `Args` structs with inconsistent attrs
+(`source-root` carries `env` on some structs, not others; `MatchSelector` /
+`Describe` / `ShowSource` have no `--modules`), so there is no cohesive group to
+extract. Flattening `{modules, format}` would add `args.common.*` indirection
+for a semantically-incohesive bundle (input locator + output format) without a
+real clarity or LOC win. `peel`'s `CommonArgs` (`{graph, modules}`) stays as the
+one cohesive case.
 
 **Defer (high risk):** unifying the union-find / Tarjan-SCC / incremental
 cycle-detection between <peel/quotient.rs> and

--- a/devinfra/js/debundle/cli/mod.rs
+++ b/devinfra/js/debundle/cli/mod.rs
@@ -650,28 +650,42 @@ pub fn run_debundle_cli(args: DebundleArgs) -> Result<()> {
             ModulesNsCommand::Merge(m) => run_merge(m),
             ModulesNsCommand::Delete(d) => run_delete(d),
             ModulesNsCommand::Propose(p) => {
-                let format = OutputFormat::resolve(p.format);
                 let report = run_plan_work_report(&p)?;
-                print_report(&report, format, render_plan_work_text)
-                    .context("writing propose output")
+                emit_report(
+                    p.format,
+                    &report,
+                    render_plan_work_text,
+                    "writing propose output",
+                )
             }
             ModulesNsCommand::List(args) => run_modules_list(args),
         },
         DebundleCommand::Atoms(args) => {
-            let format = OutputFormat::resolve(args.format);
             let report = run_units_report(&args)?;
-            print_report(&report, format, render_units_text).context("writing atoms output")
+            emit_report(
+                args.format,
+                &report,
+                render_units_text,
+                "writing atoms output",
+            )
         }
         DebundleCommand::Coverage(args) => {
-            let format = OutputFormat::resolve(args.format);
             let report = run_patch_plan_report(&args)?;
-            print_report(&report, format, render_patch_plan_text).context("writing coverage output")
+            emit_report(
+                args.format,
+                &report,
+                render_patch_plan_text,
+                "writing coverage output",
+            )
         }
         DebundleCommand::GraphSummary(args) => {
-            let format = OutputFormat::resolve(args.format);
             let report = run_graph_summary_report(&args)?;
-            print_report(&report, format, render_graph_summary_text)
-                .context("writing graph-summary output")
+            emit_report(
+                args.format,
+                &report,
+                render_graph_summary_text,
+                "writing graph-summary output",
+            )
         }
         DebundleCommand::Describe(args) => run_describe(args),
         DebundleCommand::ShowSource(args) => run_show_source(args),
@@ -706,42 +720,63 @@ fn run_peel(args: PeelArgs) -> Result<()> {
     match args.command {
         PeelCommand::PlanWork(args) => {
             deprecation_notice("peel plan-work", "modules propose");
-            let format = OutputFormat::resolve(args.format);
             let report = run_plan_work_report(&args)?;
-            print_report(&report, format, render_plan_work_text).context("writing plan-work output")
+            emit_report(
+                args.format,
+                &report,
+                render_plan_work_text,
+                "writing plan-work output",
+            )
         }
         PeelCommand::Units(args) => {
             deprecation_notice("peel units", "atoms");
-            let format = OutputFormat::resolve(args.format);
             let report = run_units_report(&args)?;
-            print_report(&report, format, render_units_text).context("writing units output")
+            emit_report(
+                args.format,
+                &report,
+                render_units_text,
+                "writing units output",
+            )
         }
         PeelCommand::PatchPlan(args) => {
             deprecation_notice("peel patch-plan", "coverage");
-            let format = OutputFormat::resolve(args.format);
             let report = run_patch_plan_report(&args)?;
-            print_report(&report, format, render_patch_plan_text)
-                .context("writing patch-plan output")
+            emit_report(
+                args.format,
+                &report,
+                render_patch_plan_text,
+                "writing patch-plan output",
+            )
         }
         PeelCommand::Explain(args) => {
             deprecation_notice("peel explain", "describe <id>");
-            let format = OutputFormat::resolve(args.format);
             let report = run_explain_report(&args)?;
-            print_report(&report, format, render_explain_text).context("writing explain output")
+            emit_report(
+                args.format,
+                &report,
+                render_explain_text,
+                "writing explain output",
+            )
         }
         PeelCommand::SourceSlice(args) => {
             deprecation_notice("peel source-slice", "show-source <id>");
-            let format = OutputFormat::resolve(args.format);
             let report = run_source_slice_report(&args)?;
-            print_report(&report, format, render_source_slice_text)
-                .context("writing source-slice output")
+            emit_report(
+                args.format,
+                &report,
+                render_source_slice_text,
+                "writing source-slice output",
+            )
         }
         PeelCommand::GraphSummary(args) => {
             deprecation_notice("peel graph-summary", "graph-summary");
-            let format = OutputFormat::resolve(args.format);
             let report = run_graph_summary_report(&args)?;
-            print_report(&report, format, render_graph_summary_text)
-                .context("writing graph-summary output")
+            emit_report(
+                args.format,
+                &report,
+                render_graph_summary_text,
+                "writing graph-summary output",
+            )
         }
     }
 }
@@ -753,8 +788,22 @@ fn deprecation_notice(old: &str, new: &str) {
     );
 }
 
+/// Shared tail of every report subcommand: resolve `format` (tty-aware default),
+/// render `report`, and tag IO errors with `context`.
+fn emit_report<T, F>(
+    format: Option<OutputFormat>,
+    report: &T,
+    text_render: F,
+    context: &'static str,
+) -> Result<()>
+where
+    T: serde::Serialize,
+    F: FnOnce(&T, &mut String),
+{
+    print_report(report, OutputFormat::resolve(format), text_render).context(context)
+}
+
 fn run_selector_codemod_cmd(args: SelectorCodemodArgs) -> Result<()> {
-    let format = OutputFormat::resolve(args.format);
     let report = run_selector_codemod(&SelectorCodemodConfig {
         modules_root: args.modules_root,
         apply: args.apply,
@@ -770,12 +819,15 @@ fn run_selector_codemod_cmd(args: SelectorCodemodArgs) -> Result<()> {
         items: args.items,
         candidates: args.candidates,
     })?;
-    print_report(&report, format, render_selector_codemod_text)
-        .context("writing selector-codemod output")
+    emit_report(
+        args.format,
+        &report,
+        render_selector_codemod_text,
+        "writing selector-codemod output",
+    )
 }
 
 fn run_match_selector_cmd(args: MatchSelectorArgs) -> Result<()> {
-    let format = OutputFormat::resolve(args.format);
     let report = run_match_selector(&MatchSelectorConfig {
         source_file: args.source_file,
         source_root: args.source_root,
@@ -785,8 +837,12 @@ fn run_match_selector_cmd(args: MatchSelectorArgs) -> Result<()> {
         target_binding: args.target_binding,
         check_slack: !args.no_slack,
     })?;
-    print_report(&report, format, render_match_selector_text)
-        .context("writing match-selector output")
+    emit_report(
+        args.format,
+        &report,
+        render_match_selector_text,
+        "writing match-selector output",
+    )
 }
 
 /// Dispatch an `<id>` argument into a [`SelectionArgs`] populated with
@@ -872,7 +928,6 @@ fn resolve_id_as_module_path(id: &str, modules_root: &std::path::Path) -> Result
 }
 
 fn run_describe(args: DescribeArgs) -> Result<()> {
-    let format = OutputFormat::resolve(args.format);
     let selection = dispatch_id_selection(&args.id, &args.common.modules_root)?;
     let inner = ExplainArgs {
         common: args.common,
@@ -884,11 +939,15 @@ fn run_describe(args: DescribeArgs) -> Result<()> {
         format: None,
     };
     let report = run_explain_report(&inner)?;
-    print_report(&report, format, render_explain_text).context("writing describe output")
+    emit_report(
+        args.format,
+        &report,
+        render_explain_text,
+        "writing describe output",
+    )
 }
 
 fn run_show_source(args: ShowSourceArgs) -> Result<()> {
-    let format = OutputFormat::resolve(args.format);
     let selection = dispatch_id_selection(&args.id, &args.common.modules_root)?;
     let inner = SourceSliceArgs {
         common: args.common,
@@ -899,7 +958,12 @@ fn run_show_source(args: ShowSourceArgs) -> Result<()> {
         format: None,
     };
     let report = run_source_slice_report(&inner)?;
-    print_report(&report, format, render_source_slice_text).context("writing show-source output")
+    emit_report(
+        args.format,
+        &report,
+        render_source_slice_text,
+        "writing show-source output",
+    )
 }
 
 fn run_bindings_list_cmd(args: BindingsListNsArgs) -> Result<()> {
@@ -909,8 +973,12 @@ fn run_bindings_list_cmd(args: BindingsListNsArgs) -> Result<()> {
         orphan: args.orphan,
     };
     let report = run_bindings_list(&args.modules_root, &filters)?;
-    let format = OutputFormat::resolve(args.format);
-    print_report(&report, format, render_bindings_list_text).context("writing bindings list output")
+    emit_report(
+        args.format,
+        &report,
+        render_bindings_list_text,
+        "writing bindings list output",
+    )
 }
 
 fn render_bindings_list_text(report: &crate::binding::BindingsListReport, out: &mut String) {
@@ -1081,12 +1149,13 @@ fn run_modules_list(args: ModulesListArgs) -> Result<()> {
     }
     entries.sort_by(|a, b| a.path.cmp(&b.path));
     let report = ModulesListReport { modules: entries };
-    let format = OutputFormat::resolve(args.format);
     let with_anonymous = args.with_anonymous;
-    print_report(&report, format, |report, out| {
-        render_modules_list_text(report, out, with_anonymous)
-    })
-    .context("writing modules list output")
+    emit_report(
+        args.format,
+        &report,
+        |report, out| render_modules_list_text(report, out, with_anonymous),
+        "writing modules list output",
+    )
 }
 
 fn run_spec_stats_cmd(args: SpecStatsArgs) -> Result<()> {

--- a/devinfra/js/debundle/facts/mod.rs
+++ b/devinfra/js/debundle/facts/mod.rs
@@ -37,7 +37,7 @@ pub(crate) use swc_ecma_visit::{Visit, VisitWith};
 
 pub(crate) use crate::analysis_hints::{AnalysisHints, KnownEffect, LocalEffectPolicy};
 pub(crate) use crate::purity::{
-    ChunkCodeGraph, Purity, PurityReason, PurityRule, RedundantPureMemberHint, RedundantPurityHint,
+    ChunkCodeGraph, Purity, PurityRule, RedundantPureMemberHint, RedundantPurityHint,
     SHADOW_TRACKED_GLOBALS, class_has_static_observable, classify_expr_purity,
     classify_var_decl_purity, detect_redundant_pure_member_hints, detect_redundant_purity_hints,
 };

--- a/devinfra/js/debundle/facts/purity_classification.rs
+++ b/devinfra/js/debundle/facts/purity_classification.rs
@@ -35,14 +35,7 @@ pub(crate) fn item_purity(
                         graph,
                     ) =>
                 {
-                    Purity::NotPure {
-                        reasons: vec![PurityReason {
-                            rule: PurityRule::ClassStaticObservable,
-                            span: c.span,
-                            source_location: None,
-                            detail: None,
-                        }],
-                    }
+                    Purity::from_reason(PurityRule::ClassStaticObservable, c.span)
                 }
                 _ => Purity::Pure,
             },
@@ -73,14 +66,7 @@ pub(crate) fn item_purity(
                     graph,
                 ) =>
             {
-                Purity::NotPure {
-                    reasons: vec![PurityReason {
-                        rule: PurityRule::ClassStaticObservable,
-                        span: c.span,
-                        source_location: None,
-                        detail: None,
-                    }],
-                }
+                Purity::from_reason(PurityRule::ClassStaticObservable, c.span)
             }
             _ => Purity::Pure,
         },
@@ -94,14 +80,7 @@ pub(crate) fn item_purity(
                 graph,
             ),
             // Bare blocks, control flow, loops, etc. — soundness-first.
-            _ => Purity::NotPure {
-                reasons: vec![PurityReason {
-                    rule: PurityRule::BareControlFlow,
-                    span: item.span(),
-                    source_location: None,
-                    detail: None,
-                }],
-            },
+            _ => Purity::from_reason(PurityRule::BareControlFlow, item.span()),
         },
     }
 }

--- a/devinfra/js/debundle/purity/classifier.rs
+++ b/devinfra/js/debundle/purity/classifier.rs
@@ -463,14 +463,7 @@ fn classify_member_purity(
         (Expr::Ident(o), MemberProp::Ident(p)) => Some(format!("{}.{}", o.sym, p.sym)),
         _ => None,
     };
-    Purity::NotPure {
-        reasons: vec![PurityReason {
-            rule: PurityRule::UnknownMember,
-            span: member.span,
-            source_location: None,
-            detail,
-        }],
-    }
+    Purity::from_reason_opt_detail(PurityRule::UnknownMember, member.span, detail)
 }
 
 pub(crate) fn classify_call_purity(
@@ -775,14 +768,7 @@ fn classify_callee_call(
         return Purity::Pure;
     }
     let detail = callee_summary(callee_expr);
-    Purity::NotPure {
-        reasons: vec![PurityReason {
-            rule: PurityRule::UnknownCall,
-            span: call_span,
-            source_location: None,
-            detail,
-        }],
-    }
+    Purity::from_reason_opt_detail(PurityRule::UnknownCall, call_span, detail)
 }
 
 fn callee_summary(callee_expr: &Expr) -> Option<String> {

--- a/devinfra/js/debundle/purity/purity_type.rs
+++ b/devinfra/js/debundle/purity/purity_type.rs
@@ -99,24 +99,33 @@ impl Purity {
     }
 
     pub(crate) fn from_reason(rule: PurityRule, span: Span) -> Self {
-        Purity::NotPure {
-            reasons: vec![PurityReason {
-                rule,
-                span,
-                source_location: None,
-                detail: None,
-            }],
-        }
+        Self::from_reason_opt_detail(rule, span, None)
     }
 
     pub(crate) fn from_reason_with_detail(rule: PurityRule, span: Span, detail: String) -> Self {
+        Self::from_reason_opt_detail(rule, span, Some(detail))
+    }
+
+    pub(crate) fn from_reason_opt_detail(
+        rule: PurityRule,
+        span: Span,
+        detail: Option<String>,
+    ) -> Self {
         Purity::NotPure {
-            reasons: vec![PurityReason {
-                rule,
-                span,
-                source_location: None,
-                detail: Some(detail),
-            }],
+            reasons: vec![PurityReason::new(rule, span, detail)],
+        }
+    }
+}
+
+impl PurityReason {
+    /// A reason with `source_location` left unresolved: the classifier fills only
+    /// `span`; `resolve_reason_locations` populates `source_location` later.
+    pub(crate) fn new(rule: PurityRule, span: Span, detail: Option<String>) -> Self {
+        Self {
+            rule,
+            span,
+            source_location: None,
+            detail,
         }
     }
 }


### PR DESCRIPTION
Two of the three requested safe internal refactors; the third (CLI common-args flatten) was evaluated and intentionally declined.

**1. CLI report-dispatch helper.** Added `cli::emit_report(format, &report, render, context)` — the shared tail (`OutputFormat::resolve` + `print_report` + `.context`) of every report subcommand — and routed the 16 report dispatch sites through it. The five sites that branch on the *resolved* format (ndjson early-returns, `print_*_outcome` JSON printers) keep their explicit `resolve`.

**2. `PurityReason` construction centralization.** Added `PurityReason::new` (the `source_location: None` default now lives in one place) and `Purity::from_reason_opt_detail`; existing `from_reason` / `from_reason_with_detail` delegate to it. Replaced the five raw `Purity::NotPure { reasons: vec[PurityReason { .. }] }` literals in `facts/purity_classification.rs` and `purity/classifier.rs` with the constructors; dropped the now-unused `PurityReason` import in `facts/mod.rs`.

**3. CLI common-args flatten — declined (recorded in TODO).** There's no cohesive group to extract: `--modules` / `--source-root` / `--format` recur in incompatible combinations with inconsistent attrs (`source-root` carries `env` on some structs, not others; `MatchSelector`/`Describe`/`ShowSource` have no `--modules`). Flattening `{modules, format}` would add `args.common.*` indirection for a semantically-incohesive bundle (input locator + output format) with no real clarity/LOC win. `peel`'s `CommonArgs` (`{graph, modules}`) remains the one cohesive case. TODO updated to mark the two done items and record this as evaluated-and-declined.

Verified with `--noremote_accept_cached` (fresh clippy on `analysis` + the binary — the `analysis` crate's clippy is where an earlier unused-import slipped past a cached binary build) and the **full debundle suite: 120/120 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011YQabfZ5jVoFSETefd27Bg)_