### PR TITLE
debundle: trim dead import specifiers bundle-wide (lean entry, cascade export prune)

### DIFF
--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -344,6 +344,26 @@ rust_test(
 )
 
 rust_library(
+    name = "prune_dead_imports",
+    srcs = ["prune_dead_imports.rs"],
+    crate_root = "prune_dead_imports.rs",
+    edition = "2024",
+    deps = [
+        ":artifact",
+        "@crates//:swc_atoms",
+        "@crates//:swc_ecma_ast",
+        "@crates//:swc_ecma_visit",
+    ],
+)
+
+rust_test(
+    name = "prune_dead_imports_test",
+    crate = ":prune_dead_imports",
+    edition = "2024",
+    deps = [":js_ast"],
+)
+
+rust_library(
     name = "emit_harness",
     srcs = ["emit_harness.rs"],
     compile_data = ["//devinfra/js/debundle/live_proxy:harness_monitor.html"],
@@ -915,6 +935,7 @@ rust_library(
         ":lowering",
         ":output_layout",
         ":prepare_chunks",
+        ":prune_dead_imports",
         ":prune_module_exports",
         ":spec",
         ":spec_tree",

--- a/devinfra/js/debundle/e2e/chunk_rename_cross_module_test.rs
+++ b/devinfra/js/debundle/e2e/chunk_rename_cross_module_test.rs
@@ -79,13 +79,19 @@ export { a, b, c };
         &[" as cx", "const b = cx("],
     );
 
-    // The residual entry is unaffected by this test's contract,
-    // but pin that it also picked up the rename for parity with
-    // `chunk_renames_test`.
+    // The residual entry no longer references the vendor binding at all:
+    // its only use (`const b = cx()`) peeled into b_module, so the dead
+    // `import { f as getMobxGlobalState } from "./vendor.js"` is trimmed by
+    // `prune_dead_import_specifiers`. The rename still propagates to the live
+    // use (the b_module assertion above); the entry just no longer carries the
+    // now-unused vendor alias under either name.
     assert_module_source(
         &fixture.out_root,
         "static/app/entry.js",
-        &["getMobxGlobalState"],
-        &[" as cx", "cx()"],
+        &[
+            "import { b } from \"./modules/b_module.js\"",
+            "export { a, b, c }",
+        ],
+        &[" as cx", "cx()", "getMobxGlobalState", "vendor.js"],
     );
 }

--- a/devinfra/js/debundle/pipeline.rs
+++ b/devinfra/js/debundle/pipeline.rs
@@ -16,6 +16,7 @@ use lowering::{
     materialize_logical_modules,
 };
 use prepare_chunks::prepare_js_chunks;
+use prune_dead_imports::prune_dead_import_specifiers;
 use prune_module_exports::prune_unimported_module_exports;
 use spec::{MaterializeLogicalModulesConfig, TransformSpec};
 use spec_tree::{CompileSpecTreeOptions, compile_spec_tree};
@@ -347,6 +348,15 @@ pub fn run_transform_cli_with_options(
         spec.swap_vendor_chunks.output_manifest_path.as_deref(),
         &vendor_report,
     )?;
+
+    // Trim dead named import specifiers across the whole bundle (entry
+    // included): the lowerer over-imports residual/hub bindings the
+    // importing file never references. Runs immediately before the
+    // export prune so that dropping a dead import — which the
+    // name-based export prune would otherwise treat as a live consumer —
+    // cascades into dropping the now-unimported module exports. See
+    // prune_dead_imports.rs for the soundness argument.
+    prune_dead_import_specifiers(&mut artifact);
 
     // Drop dead named exports from emitted logical-module files: a
     // module-owned binding referenced nowhere outside its own module

--- a/devinfra/js/debundle/prune_dead_imports.rs
+++ b/devinfra/js/debundle/prune_dead_imports.rs
@@ -1,0 +1,680 @@
+//! Trim dead named import specifiers across the whole emitted bundle.
+//!
+//! The lowerer over-imports: an emitted file (the entry most of all)
+//! frequently carries `import { name } from "M"` specifiers for `name`s it
+//! never references — residual/hub bindings the per-module emit path imported
+//! defensively. A dead named import is doubly wasteful: it bloats the file, and
+//! because the name-based export prune (`prune_unimported_module_exports`)
+//! treats any imported name as "consumed", every dead import keeps a
+//! module-internal helper exported for no real consumer. Running this pass
+//! immediately before that one lets the export prune drop the now-unimported
+//! exports as a cascade.
+//!
+//! This is the bundle-wide post-emission analogue of
+//! `lowering::exports::trim_dead_named_specifiers` (which trims a single body
+//! during lowering); its reference collector mirrors that module's
+//! `TargetedRefCollector`. The two are deliberately copies: the lowering one is
+//! private to its crate and gated by a candidate set, while this one runs over
+//! the final artifact and collects the full referenced-sym set per file.
+//!
+//! Soundness (a violation breaks the rendered app):
+//! - Only ever removes named import *specifiers* or whole import *statements* —
+//!   never a binding declaration, an export, or a side-effecting statement.
+//! - Only `Named` specifiers are trimmed; `Default` and `Namespace` (`* as ns`)
+//!   are always kept (a namespace import can read any export by property).
+//! - A named specifier `import { orig as local } from "M"` is dead iff `local`
+//!   is referenced nowhere in the importing file's body (honoring shadowing)
+//!   AND `local` is not the `orig` of any local `export { … }` (re-export
+//!   shim — keep it so the import isn't orphaned).
+//! - Module evaluation/side effects are preserved: if trimming empties an
+//!   import that ORIGINALLY had named specifiers, the statement is dropped only
+//!   when the same target module `M` (resolved by path, not specifier string)
+//!   is still loaded by some other surviving import anywhere in the bundle;
+//!   otherwise it is converted to a bare side-effect import `import "M";`, with
+//!   exactly one bare import kept per such sole-loaded target. Imports that were
+//!   ORIGINALLY bare (`import "x";`) are never touched — the lowerer emits those
+//!   intentionally.
+
+use std::collections::HashSet;
+
+use artifact::{ChunkBundle, JsFile, join_module_path, module_path_dirname};
+use swc_atoms::Atom;
+use swc_ecma_ast::*;
+use swc_ecma_visit::{Visit, VisitWith};
+
+pub fn prune_dead_import_specifiers(bundle: &mut ChunkBundle) {
+    // PASS 1: per file, trim dead named specifiers in place. Records every
+    // import that originally had named specifiers and is now empty, keyed by
+    // (chunk, file, item) so later passes can locate it by stable index — PASS
+    // 1 only edits specifier vectors, never the ModuleItem list.
+    let mut emptied: Vec<EmptiedImport> = Vec::new();
+    for (chunk_index, chunk) in bundle.chunks.iter_mut().enumerate() {
+        for (file_index, file) in chunk.js.files.iter_mut().enumerate() {
+            let importer_abs = file_abs_path(file);
+            let Some(ast) = file.ast_mut() else {
+                continue;
+            };
+            let referenced = collect_referenced_syms(&ast.module);
+            let reexported = collect_local_reexport_origs(&ast.module);
+            for (item_index, item) in ast.module.body.iter_mut().enumerate() {
+                let ModuleItem::ModuleDecl(ModuleDecl::Import(import)) = item else {
+                    continue;
+                };
+                // Originally-bare imports exist solely to evaluate the target;
+                // never touch them.
+                let had_named = import
+                    .specifiers
+                    .iter()
+                    .any(|spec| matches!(spec, ImportSpecifier::Named(_)));
+                if !had_named {
+                    continue;
+                }
+                import.specifiers.retain(|spec| match spec {
+                    ImportSpecifier::Default(_) | ImportSpecifier::Namespace(_) => true,
+                    ImportSpecifier::Named(named) => {
+                        let local = &named.local.sym;
+                        referenced.contains(local) || reexported.contains(local)
+                    }
+                });
+                if import.specifiers.is_empty()
+                    && let Some(src) = import.src.value.as_str()
+                {
+                    emptied.push(EmptiedImport {
+                        chunk_index,
+                        file_index,
+                        item_index,
+                        target_abs: resolve_specifier(src, &importer_abs),
+                    });
+                }
+            }
+        }
+    }
+
+    if emptied.is_empty() {
+        return;
+    }
+
+    // PASS 2: resolved targets that, after PASS 1, are still loaded by some
+    // surviving import statement — one that kept ≥1 specifier or was originally
+    // bare. An emptied import whose target is in this set is redundant and can
+    // be dropped outright; otherwise the target is loaded only by emptied
+    // imports and exactly one must survive as a bare side-effect import.
+    let targets_with_surviving_load = collect_targets_with_surviving_load(bundle);
+
+    // PASS 3 decisions, computed before mutating bodies (item indices from PASS
+    // 1 stay valid only until the body is rebuilt). For each emptied import:
+    // drop it if the target is independently loaded, else keep the first
+    // occurrence per target as a bare import and drop the rest.
+    let mut kept_bare: HashSet<String> = HashSet::new();
+    let mut drop_items: HashSet<(usize, usize, usize)> = HashSet::new();
+    let mut bare_items: HashSet<(usize, usize, usize)> = HashSet::new();
+    for entry in &emptied {
+        let key = (entry.chunk_index, entry.file_index, entry.item_index);
+        if targets_with_surviving_load.contains(&entry.target_abs) {
+            drop_items.insert(key);
+        } else if kept_bare.insert(entry.target_abs.clone()) {
+            bare_items.insert(key);
+        } else {
+            drop_items.insert(key);
+        }
+    }
+
+    // PASS 3: rebuild each touched body, dropping the marked import ModuleItems
+    // and clearing specifiers on the kept-bare ones.
+    for (chunk_index, chunk) in bundle.chunks.iter_mut().enumerate() {
+        for (file_index, file) in chunk.js.files.iter_mut().enumerate() {
+            let Some(ast) = file.ast_mut() else {
+                continue;
+            };
+            let mut item_index = 0;
+            ast.module.body.retain_mut(|item| {
+                let key = (chunk_index, file_index, item_index);
+                item_index += 1;
+                if drop_items.contains(&key) {
+                    return false;
+                }
+                if bare_items.contains(&key)
+                    && let ModuleItem::ModuleDecl(ModuleDecl::Import(import)) = item
+                {
+                    import.specifiers.clear();
+                }
+                true
+            });
+        }
+    }
+}
+
+/// One import that originally had named specifiers and was left empty by
+/// PASS 1, located by stable (chunk, file, item) index for PASS 3.
+struct EmptiedImport {
+    chunk_index: usize,
+    file_index: usize,
+    item_index: usize,
+    target_abs: String,
+}
+
+/// Resolved target paths still loaded by an import that survives PASS 1 with at
+/// least one specifier, or that was originally bare. Such a target's module
+/// evaluation is already guaranteed, so an emptied import of it carries no
+/// side effect worth preserving.
+fn collect_targets_with_surviving_load(bundle: &ChunkBundle) -> HashSet<String> {
+    let mut targets = HashSet::new();
+    for chunk in &bundle.chunks {
+        for file in &chunk.js.files {
+            let importer_abs = file_abs_path(file);
+            let Some(ast) = file.ast() else {
+                continue;
+            };
+            for item in &ast.module.body {
+                let ModuleItem::ModuleDecl(ModuleDecl::Import(import)) = item else {
+                    continue;
+                };
+                // After PASS 1 a non-empty specifier list is a real load; an
+                // empty one is either an originally-bare import (a real load
+                // too) or an import PASS 1 just emptied (not yet a guaranteed
+                // load — its fate is decided against this very set).
+                let loads = !import.specifiers.is_empty();
+                if loads && let Some(src) = import.src.value.as_str() {
+                    targets.insert(resolve_specifier(src, &importer_abs));
+                }
+            }
+        }
+    }
+    targets
+}
+
+/// Local names re-exported by this body via `export { local … }` (no `from`).
+/// Such a name is the `orig` of a re-export shim whose import must be kept even
+/// when the local is otherwise unreferenced, or the export would be orphaned.
+fn collect_local_reexport_origs(module: &Module) -> HashSet<Atom> {
+    let mut origs = HashSet::new();
+    for item in &module.body {
+        let ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(named)) = item else {
+            continue;
+        };
+        if named.src.is_some() {
+            continue;
+        }
+        for spec in &named.specifiers {
+            if let ExportSpecifier::Named(n) = spec
+                && let ModuleExportName::Ident(ident) = &n.orig
+            {
+                origs.insert(ident.sym.clone());
+            }
+        }
+    }
+    origs
+}
+
+/// Output-tree-rooted path of a file: `<chunk_dir>/<file.path>`, where the
+/// chunk dir is the chunk's source path with the `.js` suffix dropped. Imports
+/// resolve against this same coordinate system (see `resolve_specifier`).
+fn file_abs_path(file: &JsFile) -> String {
+    let source_path = file.metadata.source_path.as_str();
+    let chunk_dir = source_path.strip_suffix(".js").unwrap_or(source_path);
+    join_module_path(&[chunk_dir, file.path.as_str()])
+}
+
+/// Resolve a relative module specifier against the importing file's absolute
+/// path, normalizing `.` / `..` so the result is directly comparable to a
+/// target file's `file_abs_path`.
+fn resolve_specifier(specifier: &str, importer_abs: &str) -> String {
+    let dir = module_path_dirname(importer_abs);
+    join_module_path(&[dir.as_str(), specifier])
+}
+
+/// Every symbol referenced (read) anywhere in a body, honoring shadowing.
+/// Mirrors `lowering::exports::TargetedRefCollector`'s binding/shadowing rules,
+/// but collects the full referenced set rather than tracking a candidate quota.
+fn collect_referenced_syms(module: &Module) -> HashSet<Atom> {
+    let mut collector = ReferencedSymCollector::default();
+    for item in &module.body {
+        item.visit_with(&mut collector);
+    }
+    collector.found
+}
+
+#[derive(Default)]
+struct ReferencedSymCollector {
+    found: HashSet<Atom>,
+    shadowed_scopes: Vec<HashSet<Atom>>,
+}
+
+impl ReferencedSymCollector {
+    fn is_shadowed(&self, name: &Atom) -> bool {
+        self.shadowed_scopes
+            .iter()
+            .rev()
+            .any(|scope| scope.contains(name))
+    }
+
+    fn with_shadowed_scope<F: FnOnce(&mut Self)>(&mut self, names: HashSet<Atom>, f: F) {
+        self.shadowed_scopes.push(names);
+        f(self);
+        self.shadowed_scopes.pop();
+    }
+}
+
+impl Visit for ReferencedSymCollector {
+    fn visit_ident(&mut self, node: &Ident) {
+        if !self.is_shadowed(&node.sym) {
+            self.found.insert(node.sym.clone());
+        }
+    }
+
+    // Binding sites are not references.
+    fn visit_binding_ident(&mut self, _node: &BindingIdent) {}
+
+    // Import binding sites (`import { x }`) are not references; the whole
+    // declaration is skipped so the specifier locals never count themselves.
+    fn visit_import_decl(&mut self, _node: &ImportDecl) {}
+
+    fn visit_function(&mut self, node: &Function) {
+        let shadowed = node
+            .params
+            .iter()
+            .flat_map(|param| param_pat_syms(&param.pat))
+            .collect();
+        self.with_shadowed_scope(shadowed, |collector| node.visit_children_with(collector));
+    }
+
+    fn visit_arrow_expr(&mut self, node: &ArrowExpr) {
+        let shadowed = node.params.iter().flat_map(param_pat_syms).collect();
+        self.with_shadowed_scope(shadowed, |collector| node.visit_children_with(collector));
+    }
+
+    fn visit_member_expr(&mut self, node: &MemberExpr) {
+        node.obj.visit_with(self);
+        // `.prop` is a property name, not a binding reference, unless computed.
+        if let MemberProp::Computed(computed) = &node.prop {
+            computed.expr.visit_with(self);
+        }
+    }
+
+    fn visit_prop_name(&mut self, node: &PropName) {
+        if let PropName::Computed(computed) = node {
+            computed.expr.visit_with(self);
+        }
+    }
+
+    // JSX element/attribute names are not value references to imports here.
+    fn visit_jsx_element_name(&mut self, _node: &JSXElementName) {}
+
+    fn visit_jsx_attr_name(&mut self, _node: &JSXAttrName) {}
+}
+
+/// Binding-identifier syms a parameter pattern introduces, used to shadow
+/// references inside the owning function/arrow body.
+fn param_pat_syms(pat: &Pat) -> Vec<Atom> {
+    let mut collector = PatBindingCollector::default();
+    pat.visit_with(&mut collector);
+    collector.syms
+}
+
+#[derive(Default)]
+struct PatBindingCollector {
+    syms: Vec<Atom>,
+}
+
+impl Visit for PatBindingCollector {
+    fn visit_binding_ident(&mut self, node: &BindingIdent) {
+        self.syms.push(node.id.sym.clone());
+    }
+
+    // `const { a: b }` binds `b`, not `a`; a computed key (`{ [k]: v }`) is an
+    // expression, not a binding, so don't descend into key positions.
+    fn visit_key_value_pat_prop(&mut self, node: &KeyValuePatProp) {
+        node.value.visit_with(self);
+    }
+
+    // Default-value expressions (`(a = expr) => …`) are evaluated in the outer
+    // scope and may reference imports, but they are not binding sites; only the
+    // bound name matters for shadowing, so skip the initializer.
+    fn visit_assign_pat(&mut self, node: &AssignPat) {
+        node.left.visit_with(self);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use artifact::{
+        ChunkAnalysisReport, ChunkArtifact, ChunkBundle, ChunkMetadata, ChunkTable, FileMetadata,
+        FileRole, JsChunk, JsFile, JsFileBody,
+    };
+    use js_ast::parse_js_module;
+
+    use super::*;
+
+    /// One chunk `c` (source path `c.js`), files laid out flat so a sibling's
+    /// `./mod.js` resolves to `c/mod.js`.
+    fn bundle(files: &[(&str, &str, FileRole)]) -> ChunkBundle {
+        let mut bundle = ChunkBundle {
+            chunks: Vec::new(),
+            chunk_table: ChunkTable::default(),
+        };
+        let chunk_id = bundle.chunk_table.intern("c".to_string());
+        let js_files = files
+            .iter()
+            .map(|(path, source, role)| {
+                let parsed = parse_js_module(&format!("c/{path}"), source).expect("parse");
+                JsFile {
+                    path: path.to_string(),
+                    body: JsFileBody::Ast(parsed),
+                    header_lines: Vec::new(),
+                    binding_comments: std::collections::BTreeMap::new(),
+                    leading_item_comments: std::collections::BTreeMap::new(),
+                    metadata: FileMetadata {
+                        chunk_id: "c".to_string(),
+                        chunk_file: path.to_string(),
+                        role: *role,
+                        source_path: "c.js".to_string(),
+                    },
+                }
+            })
+            .collect();
+        bundle.chunks.push(ChunkArtifact {
+            chunk_id,
+            js: JsChunk {
+                entry_file: "entry.js".to_string(),
+                files: js_files,
+                metadata: ChunkMetadata {
+                    source_path: "c.js".to_string(),
+                },
+            },
+            analysis: ChunkAnalysisReport {
+                chunk_id: "c".to_string(),
+                source_path: "c.js".to_string(),
+                parser: Default::default(),
+                entry_file: "entry.js".to_string(),
+                counts: Default::default(),
+                files: Vec::new(),
+                imports: Vec::new(),
+                export_aliases: Vec::new(),
+                unresolved_exports: Vec::new(),
+                kept_top_level_declarations: Vec::new(),
+            },
+        });
+        bundle
+    }
+
+    /// One `(source, local)` pair per surviving named import specifier in
+    /// `file_path`, sorted. `source` is the raw import specifier string.
+    fn named_imports(bundle: &ChunkBundle, file_path: &str) -> Vec<(String, String)> {
+        let file = bundle.chunks[0]
+            .js
+            .files
+            .iter()
+            .find(|f| f.path == file_path)
+            .expect("file");
+        let mut pairs = Vec::new();
+        for item in &file.ast().expect("ast").module.body {
+            if let ModuleItem::ModuleDecl(ModuleDecl::Import(import)) = item {
+                let src = import.src.value.as_str().expect("utf8 src").to_string();
+                for spec in &import.specifiers {
+                    if let ImportSpecifier::Named(named) = spec {
+                        pairs.push((src.clone(), named.local.sym.to_string()));
+                    }
+                }
+            }
+        }
+        pairs.sort();
+        pairs
+    }
+
+    /// Import statements in `file_path` as `(source, specifier_count)`, sorted —
+    /// lets a test assert a statement survives with zero specifiers (bare).
+    fn import_statements(bundle: &ChunkBundle, file_path: &str) -> Vec<(String, usize)> {
+        let file = bundle.chunks[0]
+            .js
+            .files
+            .iter()
+            .find(|f| f.path == file_path)
+            .expect("file");
+        let mut stmts = Vec::new();
+        for item in &file.ast().expect("ast").module.body {
+            if let ModuleItem::ModuleDecl(ModuleDecl::Import(import)) = item {
+                let src = import.src.value.as_str().expect("utf8 src").to_string();
+                stmts.push((src, import.specifiers.len()));
+            }
+        }
+        stmts.sort();
+        stmts
+    }
+
+    #[test]
+    fn drops_dead_named_specifier_keeps_used() {
+        js_ast::with_swc_globals(|| {
+            // The entry imports `{ used, dead }` but references only `used`;
+            // `mod.js` is also imported by a sibling, so the entry import is not
+            // emptied and simply loses the `dead` specifier.
+            let mut bundle = bundle(&[
+                (
+                    "entry.js",
+                    "import { used, dead } from \"./mod.js\";\nconsole.log(used);\n",
+                    FileRole::Entry,
+                ),
+                (
+                    "sib.js",
+                    "import { other } from \"./mod.js\";\nexport const useOther = () => other;\n",
+                    FileRole::Module,
+                ),
+                (
+                    "mod.js",
+                    "export const used = 1;\nexport const dead = 2;\nexport const other = 3;\n",
+                    FileRole::Module,
+                ),
+            ]);
+            prune_dead_import_specifiers(&mut bundle);
+            assert_eq!(
+                named_imports(&bundle, "entry.js"),
+                vec![("./mod.js".to_string(), "used".to_string())]
+            );
+        });
+    }
+
+    #[test]
+    fn drops_emptied_import_when_target_loaded_elsewhere() {
+        js_ast::with_swc_globals(|| {
+            // The entry's only specifier (`dead`) is unused, so the import
+            // empties. `mod.js` is still loaded (used) by a sibling, so the
+            // emptied entry import is dropped outright — not left bare.
+            let mut bundle = bundle(&[
+                (
+                    "entry.js",
+                    "import { dead } from \"./mod.js\";\nconsole.log(1);\n",
+                    FileRole::Entry,
+                ),
+                (
+                    "sib.js",
+                    "import { live } from \"./mod.js\";\nexport const useLive = () => live;\n",
+                    FileRole::Module,
+                ),
+                (
+                    "mod.js",
+                    "export const dead = 1;\nexport const live = 2;\n",
+                    FileRole::Module,
+                ),
+            ]);
+            prune_dead_import_specifiers(&mut bundle);
+            assert!(
+                import_statements(&bundle, "entry.js").is_empty(),
+                "emptied entry import of an elsewhere-loaded target should be dropped"
+            );
+        });
+    }
+
+    #[test]
+    fn converts_sole_loaded_emptied_import_to_bare() {
+        js_ast::with_swc_globals(|| {
+            // Nobody else loads `mod.js`, so emptying the entry's import must
+            // not drop the module evaluation: it becomes a bare `import
+            // "./mod.js";` (statement kept, zero specifiers).
+            let mut bundle = bundle(&[
+                (
+                    "entry.js",
+                    "import { dead } from \"./mod.js\";\nconsole.log(1);\n",
+                    FileRole::Entry,
+                ),
+                (
+                    "mod.js",
+                    "globalThis.__sideEffect = 1;\nexport const dead = 2;\n",
+                    FileRole::Module,
+                ),
+            ]);
+            prune_dead_import_specifiers(&mut bundle);
+            assert_eq!(
+                import_statements(&bundle, "entry.js"),
+                vec![("./mod.js".to_string(), 0)]
+            );
+        });
+    }
+
+    #[test]
+    fn keeps_exactly_one_bare_import_per_sole_loaded_target() {
+        js_ast::with_swc_globals(|| {
+            // Two emptied imports of the same sole-loaded target: keep exactly
+            // one bare import, drop the other.
+            let mut bundle = bundle(&[
+                (
+                    "entry.js",
+                    "import { a } from \"./mod.js\";\nimport { b } from \"./mod.js\";\nconsole.log(1);\n",
+                    FileRole::Entry,
+                ),
+                (
+                    "mod.js",
+                    "globalThis.__sideEffect = 1;\nexport const a = 1;\nexport const b = 2;\n",
+                    FileRole::Module,
+                ),
+            ]);
+            prune_dead_import_specifiers(&mut bundle);
+            assert_eq!(
+                import_statements(&bundle, "entry.js"),
+                vec![("./mod.js".to_string(), 0)]
+            );
+        });
+    }
+
+    #[test]
+    fn leaves_originally_bare_import_untouched() {
+        js_ast::with_swc_globals(|| {
+            // A side-effect-only import the lowerer emitted intentionally is
+            // never touched, even though it loads a target nothing else loads.
+            let mut bundle = bundle(&[(
+                "entry.js",
+                "import \"./x.js\";\nconsole.log(1);\n",
+                FileRole::Entry,
+            )]);
+            prune_dead_import_specifiers(&mut bundle);
+            assert_eq!(
+                import_statements(&bundle, "entry.js"),
+                vec![("./x.js".to_string(), 0)]
+            );
+        });
+    }
+
+    #[test]
+    fn never_trims_default_or_namespace_specifiers() {
+        js_ast::with_swc_globals(|| {
+            // Neither the default binding nor the namespace binding is
+            // referenced, yet both must survive (a namespace can read any
+            // export by property; a default is a single binding this pass
+            // doesn't reason about).
+            let mut bundle = bundle(&[
+                (
+                    "entry.js",
+                    "import def from \"./d.js\";\nimport * as ns from \"./n.js\";\nconsole.log(1);\n",
+                    FileRole::Entry,
+                ),
+                ("d.js", "export default 1;\n", FileRole::Module),
+                ("n.js", "export const k = 1;\n", FileRole::Module),
+            ]);
+            prune_dead_import_specifiers(&mut bundle);
+            let file = &bundle.chunks[0].js.files[0];
+            let mut defaults = Vec::new();
+            let mut namespaces = Vec::new();
+            for item in &file.ast().expect("ast").module.body {
+                if let ModuleItem::ModuleDecl(ModuleDecl::Import(import)) = item {
+                    for spec in &import.specifiers {
+                        match spec {
+                            ImportSpecifier::Default(d) => defaults.push(d.local.sym.to_string()),
+                            ImportSpecifier::Namespace(n) => {
+                                namespaces.push(n.local.sym.to_string())
+                            }
+                            ImportSpecifier::Named(_) => {}
+                        }
+                    }
+                }
+            }
+            assert_eq!(defaults, vec!["def".to_string()]);
+            assert_eq!(namespaces, vec!["ns".to_string()]);
+        });
+    }
+
+    #[test]
+    fn keeps_import_referenced_only_by_local_reexport() {
+        js_ast::with_swc_globals(|| {
+            // `a` is unused in the body but re-exported by a local
+            // `export { a }`; trimming the import would orphan the export, so
+            // the specifier is kept.
+            let mut bundle = bundle(&[(
+                "mod.js",
+                "import { x as a } from \"./v.js\";\nexport { a };\n",
+                FileRole::Module,
+            )]);
+            prune_dead_import_specifiers(&mut bundle);
+            assert_eq!(
+                named_imports(&bundle, "mod.js"),
+                vec![("./v.js".to_string(), "a".to_string())]
+            );
+        });
+    }
+
+    #[test]
+    fn shadowed_param_does_not_count_as_reference() {
+        js_ast::with_swc_globals(|| {
+            // The import `f` is shadowed by the arrow param `f`, so the body's
+            // `f()` refers to the param, not the import. The import is unused
+            // and dropped.
+            let mut bundle = bundle(&[
+                (
+                    "mod.js",
+                    "import { f } from \"./m.js\";\nexport const g = (f) => f();\n",
+                    FileRole::Module,
+                ),
+                ("m.js", "export const f = () => 1;\n", FileRole::Module),
+            ]);
+            prune_dead_import_specifiers(&mut bundle);
+            assert!(
+                named_imports(&bundle, "mod.js").is_empty(),
+                "shadowed import should be trimmed; the param is the only `f` reference"
+            );
+            // The whole import statement is gone (sole-loaded? no — nobody else
+            // loads m.js, so it becomes bare). Module evaluation is preserved.
+            assert_eq!(
+                import_statements(&bundle, "mod.js"),
+                vec![("./m.js".to_string(), 0)]
+            );
+        });
+    }
+
+    #[test]
+    fn unshadowed_use_outside_function_keeps_import() {
+        js_ast::with_swc_globals(|| {
+            // A param `f` shadows only inside its own function; a top-level
+            // reference to the imported `f` still counts and keeps the import.
+            let mut bundle = bundle(&[
+                (
+                    "mod.js",
+                    "import { f } from \"./m.js\";\nconst h = (f) => f();\nexport const top = f;\n",
+                    FileRole::Module,
+                ),
+                ("m.js", "export const f = 1;\n", FileRole::Module),
+            ]);
+            prune_dead_import_specifiers(&mut bundle);
+            assert_eq!(
+                named_imports(&bundle, "mod.js"),
+                vec![("./m.js".to_string(), "f".to_string())]
+            );
+        });
+    }
+}


### PR DESCRIPTION
## What

A post-emission pass `prune_dead_import_specifiers` (new `prune_dead_imports.rs`) that trims dead **named import specifiers** across the whole emitted bundle — the entry most of all — run immediately before `prune_unimported_module_exports`.

## Why

The lowerer over-imports. On the Tana web bundle ([gaffer-private#364](https://github.com/agentydragon/gaffer-private/pull/364)), `entry.js` was **382 KB / 1776 import statements**, of which ~9200 named imports were never referenced in the body and never re-exported — residual/hub bindings the per-module emit path pulled in defensively. Two costs:

- the entry is a 382 KB barrel of dead `import { … }`; and
- because the name-based export prune treats *any* imported name as "consumed", every dead entry import keeps a module-internal helper exported for no real consumer. `#2337` only dropped 48 exports because the dead imports were masking the rest.

## How

Three passes over the final `ChunkBundle`:

1. trim dead named import specifiers in every file (entry included) — a specifier is dead when its `local` is referenced nowhere in the body (AST walk, shadowing-aware) **and** is not the `orig` of a local `export { … }` (re-export shim, kept so the import isn't orphaned);
2. collect which resolved targets are still loaded by a surviving import;
3. drop an emptied import when its target is independently loaded, else keep exactly **one** bare `import "M";` per sole-loaded target.

Ordering this before the export prune makes that pass drop the now-unimported module exports as a **cascade**.

It's the bundle-wide post-emission analogue of `lowering::exports::trim_dead_named_specifiers` (which trims one body during lowering, gated to spec-claimed bindings).

**Soundness — specifier-only, cannot change execution:** the pass only ever removes named import *specifiers* or whole import *statements* — never a binding declaration, an export, or a side-effecting statement. `Default` and `* as ns` specifiers are always kept; module evaluation/side effects are preserved by the bare-import fallback; originally-bare `import "x";` is never touched.

## Impact (Tana web bundle, `tana/re/web/78d928dca7`)

|  | before | after |
| --- | --- | --- |
| `entry.js` | 382 KB, 1776 import stmts | **30 KB, 224** |
| module exports | 9018 | **4342** (−4676) |

## Tests / validation

- **9 unit tests** (`prune_dead_imports_test`): dead-spec trim while sibling-loaded import keeps its used name; emptied import dropped when target loaded elsewhere; emptied sole-loaded import → bare `import "M";`; exactly one bare per sole-loaded target; originally-bare untouched; `default` / `* as ns` never trimmed; re-export shim `import { x as a }; export { a };` kept; param-shadowed import dropped; unshadowed top-level use kept. `prune_module_exports` regression intact; clippy + rustfmt clean.
- `validate_emitted_exports` passes on the full Tana bundle.
- **Browser-load smoke `//tana/re/web:load_78d928dca7` PASSES** with this pass applied (built via `--override_module=ducktape=<local>`): the app still renders in headless Chromium — the aggressive elimination is sound.

After this releases, gaffer-private repins and the ~4700 holdouts leave the rename queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016vpknksSPe3PoneXhDogyx

---
_Generated by [Claude Code](https://claude.ai/code/session_016vpknksSPe3PoneXhDogyx)_