### PR TITLE
debundle: merge vendor boundary-mapping collect + validate into one pass

### DIFF
--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -161,19 +161,14 @@ propose`.
 
 Production-code (non-test) dedup/cleanup options surfaced by a codebase survey.
 Calibrated by (LOC saved × safety). Done so far: the `minimize/` single-pick
-collapse (#2346), the CLI report-dispatch helper (`cli::emit_report`), and the
+collapse (#2346), the CLI report-dispatch helper (`cli::emit_report`), the
 `PurityReason` construction centralization (`PurityReason::new` +
-`Purity::from_reason_opt_detail`).
-
-**Safe, internal, no behavior change:**
-
-1. `vendor/mod.rs` `validate_boundary_mapping_collisions` +
-   `collect_boundary_mapping` both walk `module.body` export specifiers; merge
-   into one pass. ~30 LOC, low risk.
+`Purity::from_reason_opt_detail`), and the `vendor/mod.rs` boundary-mapping
+collect+validate single-pass merge (`collect_and_validate_boundary_mapping`).
 
 **Real value but needs design work / behavior-risk:**
 
-2. Parameterize the per-form AST holing visitors (`render.rs` `hole_expr` /
+1. Parameterize the per-form AST holing visitors (`render.rs` `hole_expr` /
    `hole_stmt`, `minimize/class.rs` `hole_class_member`, etc.) behind a `Holer`
    trait or table to collapse repeated per-variant match clusters. ~150 LOC,
    medium risk (over-abstraction hazard; the per-form holing strategies differ

--- a/devinfra/js/debundle/vendor/mod.rs
+++ b/devinfra/js/debundle/vendor/mod.rs
@@ -34,24 +34,24 @@ pub use plan::{
 use spec::PartialSwapKind;
 pub use strip::ChunkStripStats;
 
-/// Bail when a boundary-mapping key (a vendor-LOCAL binding name) is
-/// itself a genuine export name of the vendor entry bound to a
-/// *different* local. The caller-side rewrite treats `import { k }` as
-/// "the caller spelled export `<mapping[k]>` by its vendor-local name" —
-/// but when the vendor really exports the name `k` (from another local),
-/// that import is legitimate and rewriting it would silently rebind the
-/// caller to the wrong value.
-fn validate_boundary_mapping_collisions(
+/// Collect the boundary-rename mapping (vendor-LOCAL binding name → the
+/// distinct, valid export name it is published under) and validate it against
+/// the entry's genuine exports — both in a single pass over `module.body`.
+///
+/// Validation bails when a mapping key (a vendor-LOCAL binding name) is itself a
+/// genuine export name of the vendor entry bound to a *different* local. The
+/// caller-side rewrite treats `import { k }` as "the caller spelled export
+/// `<mapping[k]>` by its vendor-local name" — but when the vendor really exports
+/// the name `k` (from another local), that import is legitimate and rewriting it
+/// would silently rebind the caller to the wrong value.
+fn collect_and_validate_boundary_mapping(
     module: &Module,
-    mapping: &BTreeMap<String, String>,
     chunk_path: &str,
-) -> Result<()> {
-    if mapping.is_empty() {
-        return Ok(());
-    }
-    // export name -> Some(local sym) when the export aliases a plain
-    // local binding; None when its local identity is not a local ident
-    // (forwarded `export … from`, string-literal orig).
+) -> Result<BTreeMap<String, String>> {
+    let mut mapping: BTreeMap<String, String> = BTreeMap::new();
+    // export name -> Some(local sym) when the export aliases a plain local
+    // binding; None when its local identity is not a local ident (forwarded
+    // `export … from`, string-literal orig).
     let mut export_locals: BTreeMap<String, Option<String>> = BTreeMap::new();
     for item in &module.body {
         match item {
@@ -69,6 +69,14 @@ fn validate_boundary_mapping_collisions(
                         (None, ModuleExportName::Ident(local)) => Some(local.sym.to_string()),
                         _ => None,
                     };
+                    // A boundary rename: a non-forwarded local binding published
+                    // under a different, valid identifier.
+                    if let Some(local_sym) = &local
+                        && exported != *local_sym
+                        && is_valid_identifier(&exported)
+                    {
+                        mapping.insert(local_sym.clone(), exported.clone());
+                    }
                     export_locals.insert(exported, local);
                 }
             }
@@ -94,37 +102,7 @@ fn validate_boundary_mapping_collisions(
             );
         }
     }
-    Ok(())
-}
-
-fn collect_boundary_mapping(module: &Module) -> BTreeMap<String, String> {
-    let mut mapping = BTreeMap::new();
-    for item in &module.body {
-        let ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(named)) = item else {
-            continue;
-        };
-        if named.src.is_some() || named.specifiers.is_empty() {
-            continue;
-        }
-        for specifier in &named.specifiers {
-            let ExportSpecifier::Named(named_specifier) = specifier else {
-                continue;
-            };
-            let ModuleExportName::Ident(local) = &named_specifier.orig else {
-                continue;
-            };
-            let exported_name = named_specifier
-                .exported
-                .as_ref()
-                .map(module_export_name)
-                .unwrap_or_else(|| local.sym.to_string());
-            if exported_name == local.sym.as_ref() || !is_valid_identifier(&exported_name) {
-                continue;
-            }
-            mapping.insert(local.sym.to_string(), exported_name);
-        }
-    }
-    mapping
+    Ok(mapping)
 }
 
 fn read_installed_package_metadata(

--- a/devinfra/js/debundle/vendor/plan.rs
+++ b/devinfra/js/debundle/vendor/plan.rs
@@ -53,10 +53,10 @@ use crate::wrappers::{
     plan_bundled_partial_swap_assets, set_diff, wrapper_output_path,
 };
 use crate::{
-    MaterializedOutputChunkIndex, collect_boundary_mapping, collect_default_export_object_keys,
-    collect_exported_names, is_valid_identifier, module_has_export_star,
-    read_installed_package_metadata, resolve_package_subpath, resolve_partial_swap_import_target,
-    validate_boundary_mapping_collisions, verified_default_alias_export_names,
+    MaterializedOutputChunkIndex, collect_and_validate_boundary_mapping,
+    collect_default_export_object_keys, collect_exported_names, is_valid_identifier,
+    module_has_export_star, read_installed_package_metadata, resolve_package_subpath,
+    resolve_partial_swap_import_target, verified_default_alias_export_names,
 };
 
 #[derive(Debug, Clone)]
@@ -649,8 +649,7 @@ fn plan_boundary_renames(
     }) {
         let chunk = &resolved_chunks[chunk_path.as_str()];
         let vendor_ast = vendor_entry_ast(artifact, "boundary_rename", chunk)?;
-        let mapping = collect_boundary_mapping(&vendor_ast.module);
-        validate_boundary_mapping_collisions(&vendor_ast.module, &mapping, chunk_path)?;
+        let mapping = collect_and_validate_boundary_mapping(&vendor_ast.module, chunk_path)?;
         plans.push(BoundaryRenamePlan {
             chunk_id: chunk.chunk_id,
             entry_file: chunk.entry_file.clone(),


### PR DESCRIPTION
Last clean "safe internal" item from the refactor survey.

`collect_boundary_mapping` and `validate_boundary_mapping_collisions` were always called back-to-back on the same module (the sole call site in `vendor/plan.rs`), each independently walking `module.body`'s export specifiers. This fuses them into `collect_and_validate_boundary_mapping`: one pass builds both the rename mapping (non-forwarded local → distinct valid export name) **and** the export-locals table, then runs the collision check and returns the mapping.

**Behavior is identical** — same two maps built (the `exported` value coincides with the mapping's export name exactly when the specifier's `orig` is an `Ident`, which is the only case the mapping populates), same collision `bail!`. The empty-mapping early-return becomes a no-op (the validation loop over empty keys does nothing).

Net **−23 LOC**. TODO updated (this was the last item under "Safe, internal").

Verified with `--noremote_accept_cached` (fresh clippy on the `vendor` crate + binary) and the **full debundle suite: 120/120 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011YQabfZ5jVoFSETefd27Bg)_