### PR TITLE
haku-state: Forgejo repo + service user (renamed from haku-items)

### DIFF
--- a/cluster/k8s/forgejo/haku-state/flux-kustomization.yaml
+++ b/cluster/k8s/forgejo/haku-state/flux-kustomization.yaml
@@ -1,0 +1,27 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: haku-state
+  namespace: flux-system
+spec:
+  interval: 10m
+  retryInterval: 1m
+  timeout: 10m
+  path: ./cluster/k8s/forgejo/haku-state
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  # Wait for the Terraform apply (creates the Forgejo repo + service user + the
+  # haku-state-git-write Secret) so scan runs can depend on it.
+  healthChecks:
+    - apiVersion: infra.contrib.fluxcd.io/v1alpha2
+      kind: Terraform
+      name: haku-state
+      namespace: flux-system
+  dependsOn:
+    - name: forgejo # Forgejo API must be up (provider target)
+    - name: tofu-controller
+    - name: tofu-state-db
+    - name: haku-namespace # the git-creds Secret lands in the haku-sandbox namespace

--- a/cluster/k8s/forgejo/haku-state/kustomization.yaml
+++ b/cluster/k8s/forgejo/haku-state/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - terraform.yaml

--- a/cluster/k8s/forgejo/haku-state/terraform.yaml
+++ b/cluster/k8s/forgejo/haku-state/terraform.yaml
@@ -1,0 +1,36 @@
+apiVersion: infra.contrib.fluxcd.io/v1alpha2
+kind: Terraform
+metadata:
+  name: haku-state
+  namespace: flux-system
+spec:
+  interval: 15m
+  refreshBeforeApply: true
+  path: ./tf/gitops/haku-state
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+
+  # forgejo_collaborator.claude grants read to the claude agent account, so the
+  # forgejo-claude module (which provisions that user) must apply first.
+  dependsOn:
+    - name: forgejo-claude
+
+  serviceAccountName: tf-runner
+  approvePlan: "auto"
+
+  backendConfig:
+    customConfiguration: |
+      backend "pg" {
+        conn_str    = "postgres://tfstate@tofu-state-db-ovh-rw.tofu-state.svc:5432/tfstate?sslmode=disable"
+        schema_name = "haku_state"
+      }
+  runnerPodTemplate:
+    spec:
+      env:
+        - name: PGPASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: tofu-state-db-credentials
+              key: password

--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -187,6 +187,7 @@ resources:
   - forgejo/cpap-data/flux-kustomization.yaml
   - forgejo/claude/flux-kustomization.yaml
   - forgejo/agentydragon/flux-kustomization.yaml
+  - forgejo/haku-state/flux-kustomization.yaml
 
   # --- budget (Beancount ledger + exporter + Fava) ---
   - budget/namespace/flux-kustomization.yaml

--- a/tf/gitops/haku-state/BUILD.bazel
+++ b/tf/gitops/haku-state/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@rules_tf//tf:def.bzl", "tf_module", "tf_providers_versions")
+
+tf_providers_versions(
+    name = "providers",
+    providers = {
+        "forgejo": "svalabs/forgejo:~>1.5",
+        "kubernetes": "hashicorp/kubernetes:~>2.38",
+        "random": "hashicorp/random:~>3.7",
+    },
+    tf_version = "1.9.8",
+)
+
+tf_module(
+    name = "haku-state",
+    providers = [
+        "forgejo",
+        "kubernetes",
+        "random",
+    ],
+    providers_versions = ":providers",
+)

--- a/tf/gitops/haku-state/main.tf
+++ b/tf/gitops/haku-state/main.tf
@@ -1,0 +1,80 @@
+# Forgejo repo + service user for Haku, the personal background agent
+# (see haku/PLAN.md).
+#
+# Provisions a private `haku/haku-state` repo owned by a dedicated `haku`
+# service user (full read/write on its own repo; scan runs commit+push items,
+# intake, steering, and log as this user), plus a read-only grant for the
+# `claude` agent account. A Kubernetes Secret in the `haku-sandbox` namespace
+# carries the git credentials, consumed by in-cluster scan runs. Mirrors
+# tf/gitops/augur-evidence. The repo starts empty (auto_init only) — no seed.
+
+data "kubernetes_secret" "forgejo_admin" {
+  metadata {
+    name      = "forgejo-admin-password"
+    namespace = "forgejo"
+  }
+}
+
+provider "forgejo" {
+  host     = var.forgejo_url
+  username = data.kubernetes_secret.forgejo_admin.data["username"]
+  password = data.kubernetes_secret.forgejo_admin.data["password"]
+}
+
+resource "random_password" "haku" {
+  length  = 48
+  special = false
+}
+
+resource "forgejo_user" "haku" {
+  login                = "haku"
+  email                = "haku@allegedly.works"
+  password             = random_password.haku.result
+  must_change_password = false
+  visibility           = "private"
+}
+
+resource "forgejo_repository" "state" {
+  owner          = forgejo_user.haku.login
+  name           = "haku-state"
+  description    = "Haku's state: item queue, intake, steering, and log. See haku/PLAN.md."
+  private        = true
+  default_branch = "main"
+  # Initial commit so `main` exists for branch protection. No content seed.
+  auto_init = true
+}
+
+# Block force-pushes (and branch deletion) on main. Forgejo rejects force-push
+# on any protected branch by default — there is no separate "force push" toggle
+# — so protecting `main` is what disallows it. enable_push keeps Haku's ordinary
+# commits working; without it, protecting the branch would require PRs, which v0
+# doesn't want.
+resource "forgejo_branch_protection" "state_main" {
+  repository_id = forgejo_repository.state.id
+  branch_name   = "main"
+  enable_push   = true
+}
+
+# Read-only access for the claude agent account (user provisioned by
+# tf/gitops/forgejo-claude; until it exists this resource fails and the
+# Terraform CR retries on its interval).
+resource "forgejo_collaborator" "claude" {
+  repository_id = forgejo_repository.state.id
+  user          = "claude"
+  permission    = "read"
+}
+
+# Write credentials for scan runs, delivered to the haku-sandbox namespace so
+# the in-cluster scanner can clone/commit/push state.
+resource "kubernetes_secret" "haku_state_git_write" {
+  metadata {
+    name      = "haku-state-git-write"
+    namespace = "haku-sandbox"
+  }
+
+  data = {
+    username = forgejo_user.haku.login
+    password = random_password.haku.result
+    repo_url = "http://forgejo-http.forgejo:3000/${forgejo_user.haku.login}/${forgejo_repository.state.name}.git"
+  }
+}

--- a/tf/gitops/haku-state/terraform.tf
+++ b/tf/gitops/haku-state/terraform.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    forgejo = {
+      source  = "svalabs/forgejo"
+      version = "~> 1.5"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.38"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.7"
+    }
+  }
+
+  # Placeholder; the actual backend (pg, tofu-state) is injected by the Terraform
+  # CR's backendConfig.customConfiguration (see cluster/k8s/forgejo/haku-state).
+  backend "kubernetes" {
+    secret_suffix = "haku-state"
+    namespace     = "flux-system"
+  }
+}

--- a/tf/gitops/haku-state/variables.tf
+++ b/tf/gitops/haku-state/variables.tf
@@ -1,0 +1,5 @@
+variable "forgejo_url" {
+  description = "Forgejo internal cluster API URL"
+  type        = string
+  default     = "http://forgejo-http.forgejo:3000"
+}


### PR DESCRIPTION
## Summary

Split Haku's **state repo provisioning** out of the item-store PR (#2355) and rename `haku-items` → `haku-state`.

## Changes

- **`tf/gitops/haku-state`** — a private `haku/haku-state` Forgejo repo owned by the dedicated `haku` service user, a read-only collaborator grant for the `claude` agent account, and force-push protection on `main`. **No content seed** — `auto_init` only (so `main` exists for branch protection).
- **Git credential in `haku-sandbox`** — the `haku-state-git-write` Secret (username/password/repo_url for the `haku` user) now lands in the `haku-sandbox` namespace so the in-cluster scanner has the Forgejo credentials.
- **`cluster/k8s/forgejo/haku-state`** — Terraform CR (`schema_name: haku_state`, `dependsOn: forgejo-claude`) + flux-kustomization (health-gated on the apply), wired into the root kustomization.

## Notes

- Renames throughout: repo `haku-items`→`haku-state`, tf module + state schema, the git-write secret.
- Depends on the `haku-sandbox` namespace (already on `devel`) for the secret target.
- #2355 is reduced to just `haku/base` (the seed files are dropped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFbZ5fLRn9XFQx7qV7vBP8)_