### PR TITLE
haku: read access to the BuildBuddy API key

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -444,6 +444,7 @@ creation_rules:
           - *iguana-agentydragon
           - *claude-web
           - *codex-cloud-agent
+          - *haku
           - *ci
   # Hetzner Robot webservice credentials (admin + all user keys)
   - path_regex: secrets/hetzner-robot\.sops\.yaml$

--- a/secrets/buildbuddy.yaml
+++ b/secrets/buildbuddy.yaml
@@ -4,74 +4,83 @@ sops:
     - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPYllhbkZlVCtEVXJuWlRR
-        Z0FPa2o2Q2pseXp1R05pQ0d3MjBrUlBFQ2x3CkJUdmovUWtBbFJCZWtIWTlOUnda
-        eldzMyt3K0NTYXBEd2xjaFMxZDF5b00KLS0tIHdOazUwRlFTQTlXcmJRaDhPK2VH
-        cncwNmNlcjVJbm9vMXgrWjdpS0gvbEkKvFTtQQWW6y3QYHyRdx3osBhpLbkvGlkv
-        IrjNNDzLtPPpKeZ56oX5GNoyLrnReX68aKHYOUcYOS6breluTOZGVA==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2b2Q0WTlURFdydGtVMVQv
+        dWVWSEpmbk9SWG5McGtNcGRRTm84TXkvL0Y4CldVcGNzUFJpaDJJbmx6MGZnZWYv
+        L3NLYkFLMXFHYU9vRnI0L0xsT2FVSHcKLS0tIFRuQjVONUZrd1h6REpRQzlBVXFN
+        aVl0S2JFUEJoZTI1ZjIyRC9tbENuSWMK2usdSwpuZAPZ1AqC2CS4rgQxaxLpUXj8
+        V9fxT76pOOPA4pjP2nBvzG/e9CuCgnc3JHCy9jcLQrVk3MHhjEJmfQ==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age12c2ef6ayydzvmz6k49pyyhtgu2g00nyynmht8y3laqvxn3wya4wselpc4s
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYWk9wWlQ3MENoWDlzT0dz
-        RlJBQUpMZS9xbHhnVXZid1ZDZ05HakhpNXc4CkZqMzd6ZzhlOVJML2lFc29NWFF0
-        MDBnR0J5NmM5S25Rc2Q2UGZzNGVNTjQKLS0tIFZrcFBpMDNyQjQ5Uzc3ZzdaVGZ6
-        Ymg5V0ozSWY2eENIWExNTGdjSXBOS1kKij2TqxtmaDqxqidN4M0qMxw2AmexD6Gi
-        5nsc6d+qQuO5hpnyIJ1fgxYmGOsocq1s3/p3ox/qebXDThdHVkLqQA==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSZWpxNm9ITXcyaVdsZi9n
+        YUxDc2VTVitCSGkyTmdSSEQ3akZQU3lyMFNFClUzTlUvRVlUNUN2Ym9wb0VQRDRU
+        MVY2UVZLYWhNaFh5RmVXT0lJV0w5MDgKLS0tIEJVWFQrTVZCWTdiUHpIU1U3a0hp
+        elJ1UHhwM2t5a3IrSlFrak0wZDZYQ28KtVm1Kzk2KBNLf8xnPmq7VBhRhx+1M3lE
+        ZjX2p11+rSW9KDY+iJF89roYLSr8Ow7KMyGvCkhD4vwhvZong3OpMQ==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age1qdgn0k59t7ghg3t4gg02g2ppnzp7uz0ddplup38y84hqslcsgsxq3v9tkz
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRT0VGOVc3WVVHeHNoNi9G
-        eW9zeWlEWEZRZldiMk1VOXFaTnVubmhQOFRrCldLVElubWZEV0pBZzZwQ05iNFdZ
-        aElFVGl0dEp0Zjk2SkF0V3R4NXlvVXcKLS0tIFV4bkY4YVQrMVVHQnk5d1JaUFRv
-        S08yKzlTUUx2ZnlveXVmSzU4NTBROWcKK5A4Ou5mo2Sa6BjvN3R5ZpB1YCtwerN4
-        BrJ67GQ/0gAq68LdLxxWgWzQWMPDcw7OEQMo6MFoJt8uxOLiVPRchg==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHYUlxTExSVVhrNlF3VUw4
+        Mzl0eUUxQUlQTWZ1dHBWK2h4ajkveWQwOXdnCk9GWnhuVE4rU3pBaXBsSnlqazRJ
+        V3hiTjRwVXhwdHBWWW5DUGplMDhzOW8KLS0tIFM2VGJZZFNLc2lkN3p3SVIvRGFt
+        MmxCV1lmcmdUNjNNM1pSL0R0WVlxWEEKGZhAmEIIiv1qK6DI/edzKcPboOiYNrvC
+        DHAzSfs8aQjpZ2ctZvyIM0s+sIR/7XHmGXCgHvMNvZlxMePiJRlUWQ==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age15hfg4r2zfc2zl6zarecpvykxjktw4zu3grlahz4397rstmhqpvtqjgf6yy
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3TGFLWStvNEVua2p1WDBw
-        ZmFLTVIxSFY4WHZRbm5xUld3cWFNVDg4MWdVCnhVSjd3a0JTVjZzTjlSSFgzYTdK
-        TWlUajRNaURidFc0WVJ5b1lTbkE0UGcKLS0tIDNsRjd0aWNKVk10Kzh0dkRGUCtD
-        aExaTlc1cHBRa09YRzZ1aDZCK2NId28KSkEZNCAqIwORhlGvOc1USpOHSXPtU/ET
-        NsSeQFP2N7L1yysd8ObaFkN7qFJ3cxqYq4X8p5gkeB3OwRZoC6s6YQ==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAybzRlSmZmWmJhTE9oclJW
+        SGJlTVFYeGo4Y3RwOGVCMUQ0TnNHOWd3K0E4ClpuZjhsSzFya1FRbU1nSDBXZ3g2
+        bWNjbjJtdlhsamxaMzJxakRDUUNUZ2cKLS0tIFBndUVOdC93MWFHNm5rOGhmOGZV
+        V2dZRmtwejIwWFQ0S2VwS2RYSUd5MlUKO/Sh9ITvKlzeSvMLVmeW18Xv4rDwJ9NP
+        0CWiGBgSiRmZr56fN/SJr09hTkPd68TctjSTjm1Qm+EeV1dAtnuPcQ==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age1l325yz3v2mev3t896mzvmmkaatjc7z4d9kukvnjuslgwwd8zg9ss9pnsc7
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZOVZNK2lodWpXd1gyMTFq
-        RVQ0bWxnRC9IMktXTzlwenJvTkp4MWc0ZmhzCkI3eHU0OXhiV0p0MGhVdG5Rc1Ew
-        NVdEKzhJY1lWZ2Jmb1RhRlVNUnR6ZlEKLS0tIE9UdGlHT0dBWjZ4dGVKZ3MvdTUv
-        ZHhFMWlYOVhmVjlqKzB3Q20rVjVnc1EKnXeZikBF9dWBnxninsLseVMg5c/07oE3
-        dGapoHVGGZit4tmTg826QMqs71c41lM62qOBD7T3WGChUvud6ltZ3g==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDYk1NK1ArYytnd3gzRmhS
+        WXdXL2s5dHpuS29mOGVvVnBkL2ZyZnJBWTBvCmNYdXBWMXdGdzVrVTBOZWRDYXE0
+        NFpnSll0Mms2SThnK3piOXpuMjNtcTAKLS0tIC9iK2lUaXlwS3V5Qk41WkhxSXB0
+        eWhoMmR2cUxEa1Q1TjhGVUNrUnZBaHMKNy8ps9lCgEMFrht7XBnPC79CHfgtAX5k
+        rNpqfNK3iGl5MfcueFKTkzbET7Oos2CUxJtkMKKi/R3PkuTO2jVAMg==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age15gxxqn49sp8qhdya6utanzsxgzpfup63yfuht9yza4adpule4auqzsddj2
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBTmp3ZURVclIwM2t3dUZI
-        b0E2K3BnR0NGcUZIbHFkTENTU3RiK3ZrV2hFCno4MUYvVjhxbjVkR3FyOVllWFlh
-        dGt2NERMTXNDYU4wSXRYNU1janlMS28KLS0tIFRxc3ZmdHVyTklOcFdPdDNoTStx
-        WlNzS3NDYTlKRFpBbmJVeEpZbHFuTG8KDNR1JxyZ/FWIf7hETv7KdFuHyIRQz+A5
-        415Cvx8FjpIvs+Kgi7OO/aTUbWM31AlaW9FETQCWwEGkPTeZommScg==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjTHJXSzAyS2lsekVpbE1Z
+        SWh3L3R0Nk85SGY1cUp4dFJBcHZ2WUlwK3hVCldpNGlJc0hWR1g5UG5PU2lDb2du
+        S2Jnb2FvUi9SRTg1Yk1IODFnT2wzbmsKLS0tIEhPck5oM3FhMDI0a1dLc2pvZmMv
+        R29IaVhrYlB0OHdkbjhZc2tNdE9kUXcKSa6GCfZGr7bqM8yP3EwpyxbI0ip8rOpy
+        NIRSeELgSTxpk2sFJcTSzwXTeKRb+eH7ib3WNKNJ1KR5j4xA8+Gmtw==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age1hy7al8s2cxjhehgf93mnkfdv2plr579t9uhvtdaxlmh3rx0j2g7sludsex
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaZFMrRUFUS3ZNRm1aTGI3
-        aDcwWWh6K0NOY3pHbUtvVVNCQlZ1S1Mvb0VRCmVpbmFrYjJxakpiMWM1OWtoTmp5
-        L0tDQm0wQnZMcnc3K2RGZ1NjYjFVTEkKLS0tIEVWSkNLN0ZmOEhyS2szMjk5TEJW
-        RUd6MjFYZFhwendBc2JyQ1NNS2V4K28K8T71TUYfpnJjtN1CdiUoxJZXLtFWL9EG
-        6HEbV3y6HOXN/7ACQZTyJU+Wc7ZfHmVChL/2ymJ8ME9u5OCNnQ3YWQ==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZdlh3Z3k0Nzg4N1UycVQx
+        eUpaNU52dE02eWdlcHZoMVR5bVc3UGluMUJJCjdaVWJoaGQ2dzVJWjRqdUlvbS9V
+        S0N0RzNBeHRmWWNlazhkcXpla0FXMEkKLS0tIE5HY2NqSG9ZdXZSRE5VWVBIaE8w
+        STlUUlpwQzg2aEVpQ0dOU2oyNTlJbE0KOd9KP1wuRCsY6+yzWNVkqIFg7FW1KsFX
+        VvsbJoijOO4fcBO7NYBGxG3a9Zrfg1An7qxZo7qieov0ZMEgkSIU4A==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1756xpy6yg7r8vdducm5cdn4cqt3m5qkcncxumsh8htlfdzpae4cq0c6gqf
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQbUNFS0xxYTMvYmp1Z1lF
+        N1ZxUUhCTGRIRmdKNWp2aEJsbVhnOFNESFcwClYrRmVBd2E4V0t4WXpnQkxlTnhK
+        TTFTS3VVcitzWXhtcXNSK2NvVU1lalEKLS0tIEhCaU45VDkwNHdhWEw2eUlzVVlu
+        VGZLU3JlTGFRTlNzdTRJd0p1a0ZMLzQK5GVMPGvHUUfID06MqqKCCZ4J+jU+Kiun
+        JAsmLu0T9V/pRciesEZ+k4B3D4oaNwq/qyLaCb4NT7JT67YxXueIMA==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age1zl5lv4g0lzd4pcwx9q4vvq0w4rpmkde5r68k4n2zu89urmnx9svs3c2mef
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBycElXUFNGWFdUSktMTW1l
-        dmFXM0p0eVh4Q3NFeW1rUUhjaW9OZEhrMmdFCkcwaW1hOHVnSkFhTXdZTVdKQ3Bp
-        aWoyV2RJazNpS2pGdk1WcmQxWUpOK2sKLS0tIHBPK0dXdG11U1R0ZzZXMG9DQzRB
-        d2pUUG1icUxadlJ4R2VBSVNha2NWRU0KjSAiBNp4yAqHpYL5brCRYvS8/UoNfAo+
-        B+t8XrEEmX8/8Yml3wPj1EFoawuRh/+ZKzCOlxAA78qUMcCt7WYPMw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNQ1JhU0doR3RIc2t5SjJz
+        ZGk4cWlPYnowcHpHSTJIckw4TXlOd0xKdlhJCkFQYkVOWnJpb3FySE9EazdUTmk2
+        aVFUV0tpTzE5SzhQV25kQ090MjF5OHcKLS0tIC9yRVRkUXlGUWpiR2xuWGhHc0dz
+        SzZSNjJNT3Y3c0l3M29HMnkxZzlIWlEK2DFR3hDChiyshd70pSJrWTVpMWXoRxAt
+        HnDX4G0gzoiP/yS6q5HU4mxTIqCXX+f8TBkcp5kx1ub0OI4KvtTxUw==
         -----END AGE ENCRYPTED FILE-----
   lastmodified: "2026-03-11T07:57:59Z"
   mac: ENC[AES256_GCM,data:EFPQ1auS7eiu0sXnSCOYwrQ1oVeNj+rMEEvGbZKATdn10XY/bZjAGI6qd4R/BZgariE1DABL6K2gWSM9dSlzx2w5ARN8leSnfQ6tfY8wld8MoJetoEwIY46U6hqB7CgMVH3d2bEpm3uX80VJys1siFLqdTBQbTrmAeXI2IvKKBg=,iv:sPFDzFDgKNgM0lGFf4Xay2T1cQFjyObIaVKHzJ7B9G8=,tag:6qIUhHLMB7ink/HGNF4DYQ==,type:str]


### PR DESCRIPTION
## Summary

Add the `haku` age recipient to `secrets/buildbuddy.yaml` so the Haku routine can decrypt `buildbuddy_api_key` with its own key — same pattern as `claude-web` and `codex-cloud-agent`.

- `.sops.yaml`: `*haku` added to the `secrets/buildbuddy\.yaml` creation rule.
- `secrets/buildbuddy.yaml`: re-encrypted (`sops updatekeys`) — now 9 recipients including `haku` (`age1756xpy6…`). Verified it still decrypts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFbZ5fLRn9XFQx7qV7vBP8)_