### PR TITLE
devinfra/claude: purge dead DUCKTAPE_CLAUDE_HOOK_IMPL env var

### DIFF
--- a/devinfra/claude/web_setup.sh
+++ b/devinfra/claude/web_setup.sh
@@ -65,8 +65,8 @@ warn() {
   log "WARNING: $*" >&2
 }
 
-# Hook implementation is Rust-only. Keep parsing the old selector so stale web
-# UI env vars or setup args do not break session startup.
+# Hook implementation is Rust-only. Keep parsing the old --impl setup arg so a
+# stale value does not break session startup.
 HOOK_IMPL="rust"
 # Install mode: "profile" (nix profile install) or "home-manager".
 MODE="${DUCKTAPE_WEB_SETUP_MODE:-profile}"
@@ -83,9 +83,6 @@ case "$MODE" in
     MODE="profile"
     ;;
 esac
-if [ -n "${DUCKTAPE_CLAUDE_HOOK_IMPL:-}" ] && [ "${DUCKTAPE_CLAUDE_HOOK_IMPL:-}" != "rust" ]; then
-  warn "Ignoring deprecated DUCKTAPE_CLAUDE_HOOK_IMPL=$DUCKTAPE_CLAUDE_HOOK_IMPL; claude-hook is Rust-only"
-fi
 DEVTOOLS_OUTPUT="devtools"
 
 FLAKE="path:$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"

--- a/devinfra/claude/web_setup_hook.sh
+++ b/devinfra/claude/web_setup_hook.sh
@@ -10,9 +10,7 @@
 #
 # Unlike the init_script invocation of web_setup.sh (which runs BEFORE claude
 # and does not see user-UI env vars), this Setup hook fires as a subprocess of
-# `claude` and inherits the full user-UI env. `claude-hook` is Rust-only now;
-# web_setup.sh still logs any stale DUCKTAPE_CLAUDE_HOOK_IMPL value but always
-# installs the Rust hook implementation.
+# `claude` and inherits the full user-UI env.
 #
 # No-ops on CLI sessions (CLAUDE_CODE_REMOTE unset) — web_setup.sh is
 # web-only (Nix flake install, git remote, etc.) and must not run on NixOS.
@@ -34,7 +32,7 @@ exec >>"$LOG_FILE" 2>&1
 # Logged verbatim so we can observe what (if anything) Setup hooks receive.
 STDIN_DATA=$(cat)
 echo "[$(date -Iseconds)] web_setup_hook.sh: cwd=$(pwd) BASH_SOURCE=${BASH_SOURCE[0]}"
-echo "[$(date -Iseconds)] web_setup_hook.sh: CLAUDE_CODE_REMOTE=${CLAUDE_CODE_REMOTE:-<unset>} IS_SANDBOX=${IS_SANDBOX:-<unset>} DUCKTAPE_CLAUDE_HOOK_IMPL=${DUCKTAPE_CLAUDE_HOOK_IMPL:-<unset>}"
+echo "[$(date -Iseconds)] web_setup_hook.sh: CLAUDE_CODE_REMOTE=${CLAUDE_CODE_REMOTE:-<unset>} IS_SANDBOX=${IS_SANDBOX:-<unset>}"
 echo "[$(date -Iseconds)] web_setup_hook.sh: stdin=${STDIN_DATA:-(empty)}"
 
 if [ -z "${CLAUDE_CODE_REMOTE:-}" ]; then


### PR DESCRIPTION
The hook is Rust-only; nothing reads `DUCKTAPE_CLAUDE_HOOK_IMPL` to select an
implementation anymore. The only remaining references just reacted to it:
`web_setup.sh` warned on a non-`rust` value and `web_setup_hook.sh` logged it.

This drops both references and tidies the now-stale comment in `web_setup.sh`
that mentioned "stale web UI env vars". The unrelated `--impl` setup-arg
compatibility shim (and the always-`"rust"` `HOOK_IMPL` local that feeds a log
line) are left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFbZ5fLRn9XFQx7qV7vBP8)_