### PR TITLE
[codex] fix authentik jwt rotation identity mapping

### DIFF
--- a/cluster/docs/lessons_learned/2026_04_24_k8s_auth_through_mitm_proxy.md
+++ b/cluster/docs/lessons_learned/2026_04_24_k8s_auth_through_mitm_proxy.md
@@ -118,13 +118,15 @@ still use it.
 We already ran `kubectl-sandbox-mcp` for the interactive OAuth case — its
 `kubectl_sandbox_fixed_groups` scope mapping hardcodes
 `groups: ["kubectl-sandbox-users"]` on issued JWTs regardless of caller.
-The fix reuses that scope mapping on a new OIDC provider
-(`kubectl-sandbox-client-credentials`, `client_type = "confidential"`) with
+The non-interactive OIDC provider
+(`kubectl-sandbox-client-credentials`, `client_type = "confidential"`) uses
 a `client_credentials` grant so machine identities can mint JWTs without
-user consent. A 4th JWT issuer entry in the apiserver's
+user consent. Its current scope mapping is machine-specific: known principals
+map to explicit effective groups, while unknown principals receive no
+Kubernetes group. A 4th JWT issuer entry in the apiserver's
 `AuthenticationConfiguration` (`cluster/terraform/main/infrastructure.tf`)
-maps that provider's `groups` claim to the same
-`oidc-ksbx-groups:kubectl-sandbox-users` Group as every other sandbox path.
+maps that provider's `groups` claim through the stable
+`oidc-ksbx-groups:` prefix.
 
 **Zero RoleBinding edits.** Same constraint the cert migration enforced,
 same solution shape — map identity to Group at one layer, don't duplicate.
@@ -175,8 +177,9 @@ the already-minted JWT.
   mapping". Adding SA subjects to every binding (which the pre-2026-04-18
   token flow did) is a 30-binding surface that stops scaling.
 - **`kubectl-sandbox-mcp`'s `kubectl_sandbox_fixed_groups` scope mapping
-  is reusable** for any Authentik OAuth2 provider that wants to issue
-  sandbox-scoped JWTs. Don't rebuild it; attach it.
+  is reusable** for user-facing Authentik OAuth2 providers that should always
+  issue sandbox-scoped JWTs. Machine providers trusted by kube-apiserver should
+  instead use an explicit principal-to-groups allowlist.
 - **`mktemp` creates the file; `memfd_create` doesn't touch the filesystem
   at all.** The original latent crash (clobber-check against a zero-byte
   `mktemp` output) was masking the real network failure. Temp-file lifecycle
@@ -190,8 +193,9 @@ s_client -connect <host>:443 | openssl x509 -noout -issuer`. If the
 ## References
 
 - Fix commit: (this branch, claude/fix-kubectl-auth-4qjkm)
-- Pre-existing Authentik scope mapping:
-  `tf/gitops/agent-machine-access/main.tf` `kubectl_sandbox_fixed_groups`
+- Authentik scope mappings:
+  `tf/gitops/agent-machine-access/main.tf` `kubectl_sandbox_fixed_groups`,
+  `kubectl_machine_groups`
 - Apiserver `AuthenticationConfiguration`:
   `cluster/terraform/main/infrastructure.tf`
 - Gateway API routes: `cluster/k8s/kube-api-proxy/`

--- a/cluster/k8s/TODO.md
+++ b/cluster/k8s/TODO.md
@@ -153,3 +153,10 @@ Options to consider:
 - [ ] Configure a fallback substituter on wyrm2 (e.g. `cache.nixos.org`
       ahead of `cache.allegedly.works`, or as a fallback) so a degraded
       attic doesn't block local rebuilds.
+
+## Slim down `authentik-jwt-rotation` image
+
+- [ ] 2026-06-18: Revisit `authentik-jwt-rotation` image contents. It still
+      bundles shell tools like `curl`/`git`; consider moving to the standard
+      Python image pattern with `pygit2` and certifi/CA-certs, matching the
+      other pygit2-based images, and remove the extra package cruft.

--- a/cluster/k8s/agents/authentik-jwt-rotation/BUILD.bazel
+++ b/cluster/k8s/agents/authentik-jwt-rotation/BUILD.bazel
@@ -24,6 +24,8 @@ py_test(
     imports = ["."],
     deps = [
         ":rotate",
+        "@pypi//pydantic",
+        "@pypi//pytest",
         "@pypi//pytest_bazel",
     ],
 )

--- a/cluster/k8s/agents/authentik-jwt-rotation/README.md
+++ b/cluster/k8s/agents/authentik-jwt-rotation/README.md
@@ -4,11 +4,11 @@ Hourly CronJob that mints Authentik `client_credentials` JWTs and commits them
 SOPS-encrypted to `secrets/`. One job rotates every token in
 <rotations.yaml>:
 
-| Rotation         | Provider                             | Output                                 | Notes                |
-| ---------------- | ------------------------------------ | -------------------------------------- | -------------------- |
-| `claude-web-k8s` | `kubectl-sandbox-client-credentials` | `secrets/claude-web-k8s-jwt.yaml`      | group check          |
-| `haku-k8s`       | `kubectl-sandbox-client-credentials` | `secrets/haku-k8s-jwt.yaml`            | group check (`haku`) |
-| `alloy-otlp`     | `alloy-otlp-client-credentials`      | `secrets/alloy-otlp-bearer-token.yaml` | proxy exchange       |
+| Rotation         | Provider                             | Output                                 | Notes                                 |
+| ---------------- | ------------------------------------ | -------------------------------------- | ------------------------------------- |
+| `claude-web-k8s` | `kubectl-sandbox-client-credentials` | `secrets/claude-web-k8s-jwt.yaml`      | provider secret; group check          |
+| `haku-k8s`       | `kubectl-sandbox-client-credentials` | `secrets/haku-k8s-jwt.yaml`            | user/password app-token; group `haku` |
+| `alloy-otlp`     | `alloy-otlp-client-credentials`      | `secrets/alloy-otlp-bearer-token.yaml` | provider secret; proxy exchange       |
 
 `rotate.py` reads each output's unencrypted-by-suffix `expires_unencrypted`
 field (no decryption, no in-cluster age key), skips entries with more than
@@ -18,10 +18,17 @@ cycle in a single combined commit. The freshness stamp is the final token's own
 rotation self-heals on the next hourly run.
 
 Each rotation's `credentials_dir` points at a mounted `*-client-credentials`
-secret (`client_id` + `client_secret`, plus `proxy_client_id` when
-`exchange_scopes` is set). Consumers read the committed JWT via
+secret. The default `credential_mode` reads `client_id` + `client_secret`;
+`credential_mode: user_password` reads `client_id` + `username` + `password`
+for Authentik service-account app-password grants. `proxy_client_id` is also
+read when `exchange_scopes` is set. Consumers read the committed JWT via
 <../../../../devinfra/k8s/kubeconfig.py> (k8s token) or the Alloy OTLP bearer
 flow.
+
+`claude-web-k8s` and `haku-k8s` deliberately share the same
+`kubectl-sandbox-client-credentials` issuer/audience that kube-apiserver trusts.
+Their effective Kubernetes RBAC comes from the provider's explicit Authentik
+machine-principal allowlist, not from adding more apiserver issuer entries.
 
 The image bakes `rotate.py` (Python interpreter via `py_image_layer`), the
 `sops` binary, and `git` + `ca-certificates`. The per-deployment YAML list rides

--- a/cluster/k8s/agents/authentik-jwt-rotation/flux-kustomization.yaml
+++ b/cluster/k8s/agents/authentik-jwt-rotation/flux-kustomization.yaml
@@ -12,4 +12,5 @@ spec:
     name: flux-system
   dependsOn:
     - name: github-secrets-sync-secrets
+    - name: agent-machine-access-tf
   timeout: 2m

--- a/cluster/k8s/agents/authentik-jwt-rotation/rotate.py
+++ b/cluster/k8s/agents/authentik-jwt-rotation/rotate.py
@@ -27,7 +27,7 @@ import os
 import subprocess
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 import httpx
 import typer
@@ -39,13 +39,19 @@ logger = logging.getLogger(__name__)
 AUTH_BASE = "https://auth.allegedly.works"
 TOKEN_URL = f"{AUTH_BASE}/application/o/token/"
 
+CredentialMode = Literal["client_secret", "user_password"]
+
 
 class Rotation(BaseModel):
     name: str = Field(description="Human-readable name for logs and the commit message")
     provider_slug: str = Field(description="Authentik provider slug; pins the expected source-JWT issuer")
     scopes: str = Field(description="OAuth scopes for the client_credentials mint")
+    credential_mode: CredentialMode = Field(
+        default="client_secret",
+        description="How to authenticate to the token endpoint: provider client_secret or service-account username/password",
+    )
     credentials_dir: Path = Field(
-        description="Mounted secret dir holding client_id + client_secret (+ proxy_client_id when exchanging)"
+        description="Mounted secret dir holding client credentials (+ proxy_client_id when exchanging)"
     )
     sops_file: Path = Field(description="Repo-relative path to the encrypted output file")
     token_field: str = Field(description="YAML field name under which the token is written")
@@ -95,10 +101,18 @@ def remaining_hours(sops_file: Path) -> float | None:
     return None
 
 
-def mint_jwt(client: httpx.Client, rotation: Rotation, client_id: str, client_secret: str) -> str:
-    resp = client.post(
-        TOKEN_URL, auth=(client_id, client_secret), data={"grant_type": "client_credentials", "scope": rotation.scopes}
-    )
+def mint_jwt(client: httpx.Client, rotation: Rotation) -> str:
+    client_id = (rotation.credentials_dir / "client_id").read_text().strip()
+    data = {"grant_type": "client_credentials", "scope": rotation.scopes}
+
+    if rotation.credential_mode == "client_secret":
+        client_secret = (rotation.credentials_dir / "client_secret").read_text().strip()
+        resp = client.post(TOKEN_URL, auth=(client_id, client_secret), data=data)
+    else:
+        username = (rotation.credentials_dir / "username").read_text().strip()
+        password = (rotation.credentials_dir / "password").read_text().strip()
+        resp = client.post(TOKEN_URL, data={**data, "client_id": client_id, "username": username, "password": password})
+
     resp.raise_for_status()
     token: str | None = resp.json().get("access_token")
     if not token:
@@ -136,10 +150,7 @@ def rotate_one(client: httpx.Client, rotation: Rotation, config: Config) -> bool
         return False
     logger.info("%s: rotating (remaining=%s)", rotation.name, "none" if remaining is None else f"{remaining:.0f}h")
 
-    client_id = (rotation.credentials_dir / "client_id").read_text().strip()
-    client_secret = (rotation.credentials_dir / "client_secret").read_text().strip()
-
-    source_jwt = mint_jwt(client, rotation, client_id, client_secret)
+    source_jwt = mint_jwt(client, rotation)
     source_payload = jwt_payload(source_jwt)
     if source_payload.get("iss") != rotation.expected_issuer:
         raise RuntimeError(

--- a/cluster/k8s/agents/authentik-jwt-rotation/rotations.yaml
+++ b/cluster/k8s/agents/authentik-jwt-rotation/rotations.yaml
@@ -13,6 +13,7 @@ rotations:
   - name: haku-k8s
     provider_slug: kubectl-sandbox-client-credentials
     scopes: openid profile email groups
+    credential_mode: user_password
     expected_group: haku
     credentials_dir: /var/run/secrets/authentik/haku-k8s
     sops_file: secrets/haku-k8s-jwt.yaml

--- a/cluster/k8s/agents/authentik-jwt-rotation/test_rotate.py
+++ b/cluster/k8s/agents/authentik-jwt-rotation/test_rotate.py
@@ -3,13 +3,35 @@ import json
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
+import pytest
 import pytest_bazel
-from rotate import Config, Rotation, jwt_payload, remaining_hours
+from pydantic import ValidationError
+from rotate import Config, Rotation, jwt_payload, mint_jwt, remaining_hours
 
 
 def _make_jwt(claims: dict) -> str:
     body = base64.urlsafe_b64encode(json.dumps(claims).encode()).rstrip(b"=").decode()
     return f"header.{body}.sig"
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict):
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        pass
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class _RecordingClient:
+    def __init__(self):
+        self.calls: list[tuple[str, dict]] = []
+
+    def post(self, url: str, **kwargs) -> _FakeResponse:
+        self.calls.append((url, kwargs))
+        return _FakeResponse({"access_token": "minted.jwt"})
 
 
 def test_jwt_payload_decodes_unpadded_base64url():
@@ -67,7 +89,81 @@ def test_config_parses_exchange_and_group_fields():
     (rotation,) = config.rotations
     assert rotation.exchange_scopes == "openid profile email ak_proxy"
     assert rotation.expected_group is None
+    assert rotation.credential_mode == "client_secret"
     assert config.rotate_below_hours == 24
+
+
+def test_config_rejects_unknown_credential_mode():
+    with pytest.raises(ValidationError, match="credential_mode"):
+        Config.model_validate(
+            {
+                "rotations": [
+                    {
+                        "name": "haku-k8s",
+                        "provider_slug": "kubectl-sandbox-client-credentials",
+                        "scopes": "openid profile email groups",
+                        "credential_mode": "strip-suffix",
+                        "credentials_dir": "/var/run/secrets/authentik/haku-k8s",
+                        "sops_file": "secrets/haku-k8s-jwt.yaml",
+                        "token_field": "jwt",
+                    }
+                ]
+            }
+        )
+
+
+def test_mint_jwt_default_mode_uses_provider_client_secret(tmp_path: Path):
+    creds = tmp_path / "creds"
+    creds.mkdir()
+    (creds / "client_id").write_text("provider-client\n")
+    (creds / "client_secret").write_text("provider-secret\n")
+    rotation = Rotation(
+        name="claude-web-k8s",
+        provider_slug="kubectl-sandbox-client-credentials",
+        scopes="openid profile email groups",
+        credentials_dir=creds,
+        sops_file=Path("secrets/claude-web-k8s-jwt.yaml"),
+        token_field="jwt",
+    )
+
+    client = _RecordingClient()
+    assert mint_jwt(client, rotation) == "minted.jwt"
+
+    [(url, kwargs)] = client.calls
+    assert url == "https://auth.allegedly.works/application/o/token/"
+    assert kwargs["auth"] == ("provider-client", "provider-secret")
+    assert kwargs["data"] == {"grant_type": "client_credentials", "scope": "openid profile email groups"}
+
+
+def test_mint_jwt_user_password_mode_uses_form_credentials(tmp_path: Path):
+    creds = tmp_path / "creds"
+    creds.mkdir()
+    (creds / "client_id").write_text("provider-client\n")
+    (creds / "username").write_text("haku-k8s\n")
+    (creds / "password").write_text("app-password\n")
+    rotation = Rotation(
+        name="haku-k8s",
+        provider_slug="kubectl-sandbox-client-credentials",
+        scopes="openid profile email groups",
+        credential_mode="user_password",
+        credentials_dir=creds,
+        sops_file=Path("secrets/haku-k8s-jwt.yaml"),
+        token_field="jwt",
+    )
+
+    client = _RecordingClient()
+    assert mint_jwt(client, rotation) == "minted.jwt"
+
+    [(url, kwargs)] = client.calls
+    assert url == "https://auth.allegedly.works/application/o/token/"
+    assert "auth" not in kwargs
+    assert kwargs["data"] == {
+        "grant_type": "client_credentials",
+        "scope": "openid profile email groups",
+        "client_id": "provider-client",
+        "username": "haku-k8s",
+        "password": "app-password",
+    }
 
 
 if __name__ == "__main__":

--- a/cluster/k8s/agents/claude-rbac/README.md
+++ b/cluster/k8s/agents/claude-rbac/README.md
@@ -101,6 +101,12 @@ OIDC users who log into the `kubectl-sandbox-mcp` Authentik application
 `kubectl_sandbox_fixed_groups` scope mapping, so the RBAC below applies
 unchanged.
 
+Machine JWTs from the `kubectl-sandbox-client-credentials` provider use a
+separate explicit Authentik allowlist for effective groups. The normal provider
+client-credentials principal maps to `kubectl-sandbox-users`; the `haku-k8s`
+service account maps to `haku`; unknown machine principals receive no Kubernetes
+RBAC group.
+
 Laptops run their own admin kubeconfig (deployed by home-manager from
 `secrets/shared/kubeconfig.yaml`) with cluster-admin-level access; it's
 not governed by this sandbox RBAC. See
@@ -110,8 +116,8 @@ egress proxy eats client certs).
 
 ## Kubeconfig Provisioning
 
-The JWT is minted by the `authentik-jwt-rotation` CronJob via Authentik's
-`kubectl-sandbox-client-credentials` OAuth2 provider and committed
+The Claude web JWT is minted by the `authentik-jwt-rotation` CronJob via
+Authentik's `kubectl-sandbox-client-credentials` OAuth2 provider and committed
 SOPS-encrypted to `secrets/claude-web-k8s-jwt.yaml`. At session start,
 <devinfra/k8s/kubeconfig.py> decrypts it and builds a kubeconfig
 with `user.token` auth pointing at `https://kubeapi.allegedly.works`

--- a/cluster/terraform/main/infrastructure.tf
+++ b/cluster/terraform/main/infrastructure.tf
@@ -124,9 +124,9 @@ locals {
       },
       # kubectl-sandbox-client-credentials: machine-to-machine OIDC for
       # write_kubeconfig.py / authentik-jwt-rotation CronJob. Non-interactive
-      # client_credentials grant; same fixed-groups scope mapping as
-      # kubectl-sandbox-mcp, so issued tokens always carry
-      # groups: ["kubectl-sandbox-users"].
+      # client_credentials grant; Authentik maps known machine principals to
+      # their effective groups while kube-apiserver keeps trusting one stable
+      # issuer/audience.
       {
         issuer = {
           url       = "https://auth.${var.cluster_domain}/application/o/kubectl-sandbox-client-credentials/"

--- a/tf/gitops/agent-machine-access/main.tf
+++ b/tf/gitops/agent-machine-access/main.tf
@@ -738,14 +738,24 @@ resource "authentik_property_mapping_provider_scope" "kubectl_sandbox_fixed_grou
     # Overrides the user's real groups with a fixed sandbox-only group.
     # The kubectl-sandbox-mcp application authenticates users via consent,
     # but the issued token only carries this group — no privilege escalation.
-    #
-    # Per-SA fixed groups (no real-group passthrough). The haku service
-    # account gets a read-only haku identity; everyone else keeps the
-    # sandbox group. kube-apiserver maps these via the oidc-ksbx-groups:
-    # prefix.
-    if request.user.username == "haku-k8s":
-        return {"groups": ["haku"]}
     return {"groups": ["kubectl-sandbox-users"]}
+  EXPR
+}
+
+## Machine-client scope mapping for kubectl-sandbox-client-credentials.
+## This provider is trusted by kube-apiserver, so keep the effective groups as
+## an explicit allowlist of known machine principals. Unknown users get no
+## Kubernetes RBAC group instead of falling back to sandbox.
+resource "authentik_property_mapping_provider_scope" "kubectl_machine_groups" {
+  name       = "kubectl-client-credentials-machine-groups"
+  scope_name = "groups"
+  expression = <<-EXPR
+    username = request.user.username
+    if username == "ak-kubectl-sandbox-client-credentials-client_credentials":
+        return {"groups": ["kubectl-sandbox-users"]}
+    if username == "haku-k8s":
+        return {"groups": ["haku"]}
+    return {"groups": []}
   EXPR
 }
 
@@ -773,11 +783,9 @@ resource "authentik_policy_binding" "kubectl_sandbox_scoped_users" {
 # ============================================================================
 # Non-interactive sibling of kubectl-sandbox-mcp: confidential OAuth2 client
 # using `client_credentials` grant, so a CronJob can mint JWTs without a
-# browser. Reuses the same `kubectl_sandbox_fixed_groups` scope mapping —
-# issued tokens always carry `groups: ["kubectl-sandbox-users"]`, which
-# kube-apiserver's AuthenticationConfiguration maps to the existing K8s
-# Group subject (`oidc-ksbx-groups:kubectl-sandbox-users`) that every
-# sandbox RoleBinding already binds. Zero new RBAC.
+# browser. Reuses the same kube-apiserver trusted issuer/audience for every
+# machine identity; the provider's machine-only scope mapping is an explicit
+# principal-to-groups allowlist.
 #
 # Consumer: cluster/k8s/agents/authentik-jwt-rotation/ CronJob. It runs
 # biweekly, exchanges client_id + client_secret for a JWT, commits the JWT
@@ -804,7 +812,7 @@ resource "authentik_provider_oauth2" "kubectl_sandbox_client_credentials" {
     data.authentik_property_mapping_provider_scope.openid.id,
     data.authentik_property_mapping_provider_scope.email.id,
     data.authentik_property_mapping_provider_scope.profile.id,
-    authentik_property_mapping_provider_scope.kubectl_sandbox_fixed_groups.id,
+    authentik_property_mapping_provider_scope.kubectl_machine_groups.id,
   ]
 
   # client_credentials doesn't redirect, so allowed_redirect_uris is omitted.
@@ -814,29 +822,13 @@ resource "authentik_application" "kubectl_sandbox_client_credentials" {
   name              = "kubectl-sandbox-client-credentials"
   slug              = "kubectl-sandbox-client-credentials"
   protocol_provider = authentik_provider_oauth2.kubectl_sandbox_client_credentials.id
-  meta_description  = "Machine-to-machine kubectl access for Claude Code (client_credentials → JWT with fixed sandbox group)"
-}
-
-# Service account user for the client_credentials grant. Authentik resolves
-# the issued token's `preferred_username`/subject to this user; the fixed
-# groups scope mapping overrides whatever groups the user actually has.
-resource "authentik_user" "kubectl_sandbox_client_credentials" {
-  username = "kubectl-sandbox-client-credentials"
-  name     = "kubectl-sandbox client_credentials service account"
-  type     = "service_account"
-  path     = "goauthentik.io/service-accounts"
-}
-
-resource "authentik_policy_binding" "kubectl_sandbox_client_credentials" {
-  target = authentik_application.kubectl_sandbox_client_credentials.uuid
-  user   = authentik_user.kubectl_sandbox_client_credentials.id
-  order  = 0
+  meta_description  = "Machine-to-machine kubectl access with explicit Authentik principal-to-group mapping"
 }
 
 # Authentik auto-creates an internal service account for client_credentials
 # grants (username: ak-<slug>-client_credentials). The client_credentials flow
-# authenticates as THIS user, not the TF-managed one above. Without a policy
-# binding for it, the grant is rejected with invalid_grant.
+# authenticates as this user. Without a policy binding for it, the grant is
+# rejected with invalid_grant.
 data "authentik_user" "kubectl_sandbox_cc_auto" {
   username = "ak-kubectl-sandbox-client-credentials-client_credentials"
 }
@@ -844,7 +836,7 @@ data "authentik_user" "kubectl_sandbox_cc_auto" {
 resource "authentik_policy_binding" "kubectl_sandbox_cc_auto_user" {
   target = authentik_application.kubectl_sandbox_client_credentials.uuid
   user   = data.authentik_user.kubectl_sandbox_cc_auto.pk
-  order  = 1
+  order  = 0
 }
 
 # K8s Secret holding the client_id + client_secret. Lives in agents-infra
@@ -873,20 +865,18 @@ resource "kubernetes_secret" "kubectl_sandbox_client_credentials" {
 # kubectl-sandbox-client-credentials OAuth2 provider — no dedicated provider,
 # so no kube-apiserver issuer entry and no cluster bootstrap. Instead of a
 # provider-level client_secret, the authentik-jwt-rotation CronJob authenticates
-# as the haku-k8s service account using that SA's app-password token (an
-# `authentik_token`) paired with the shared provider's client_id. Authentik
-# issues a token FOR the haku-k8s SA, and the shared kubectl_sandbox_fixed_groups
-# scope mapping evaluates with request.user = haku-k8s, returning
-# groups: ["haku"] (every other caller still gets kubectl-sandbox-users). The
-# apiserver maps that claim to oidc-ksbx-groups:haku — read-only access to the
-# haku namespace, isolated from the sandbox group.
+# as the haku-k8s service account using that SA's app-password token paired with
+# the shared provider's client_id. Authentik issues a token FOR the haku-k8s SA,
+# and the provider's machine-only scope mapping emits groups: ["haku"] only for
+# that exact username. Unknown machine principals receive no Kubernetes group.
+# The apiserver maps that claim to oidc-ksbx-groups:haku — read-only access to
+# the haku namespace, isolated from the sandbox group.
 #
 # Consumer: cluster/k8s/agents/authentik-jwt-rotation/ CronJob (the haku-k8s
-# rotations.yaml entry). It exchanges client_id + the SA token (as
-# client_secret) for a JWT and commits it SOPS-encrypted to
-# secrets/haku-k8s-jwt.yaml.
+# rotations.yaml entry). It exchanges client_id + username + app-password for a
+# JWT and commits it SOPS-encrypted to secrets/haku-k8s-jwt.yaml.
 
-# Service account whose identity the issued JWT carries. The shared scope
+# Service account whose identity the issued JWT carries. The machine scope
 # mapping branches on this username (haku-k8s) to emit groups: ["haku"].
 resource "authentik_user" "haku_k8s" {
   username = "haku-k8s"
@@ -895,13 +885,13 @@ resource "authentik_user" "haku_k8s" {
   path     = "goauthentik.io/service-accounts"
 }
 
-# App-password token for the haku-k8s SA, used as the client_secret in the
-# client_credentials exchange against the shared provider's client_id. Mirrors
-# the agent_sa_token / claude_api SA-token pattern (intent = "api").
+# App-password token for the haku-k8s SA, used as the password in the
+# client_credentials username/password exchange against the shared provider's
+# client_id.
 resource "authentik_token" "haku_k8s" {
   identifier   = "haku-k8s-client-credentials"
   user         = authentik_user.haku_k8s.id
-  intent       = "api"
+  intent       = "app_password"
   expiring     = false
   retrieve_key = true
   description  = "client_credentials app-password for Haku's k8s JWT rotation"
@@ -916,8 +906,8 @@ resource "authentik_policy_binding" "haku_k8s_client_credentials" {
   order  = 2
 }
 
-# K8s Secret holding the shared provider's client_id + the haku-k8s SA token
-# (used as client_secret). Lives in agents-infra (where the authentik-jwt-rotation
+# K8s Secret holding the shared provider's client_id + the haku-k8s username
+# and app-password. Lives in agents-infra (where the authentik-jwt-rotation
 # CronJob runs) and is the only place this credential exists outside Authentik
 # — the minted JWT lives SOPS-encrypted in secrets/haku-k8s-jwt.yaml.
 resource "kubernetes_secret" "haku_client_credentials" {
@@ -925,12 +915,13 @@ resource "kubernetes_secret" "haku_client_credentials" {
     name      = "haku-client-credentials"
     namespace = "agents-infra"
     annotations = {
-      description = "client_id (shared kubectl-sandbox-client-credentials provider) + the haku-k8s SA app-password (client_secret), authenticating the haku-k8s service account so its JWT carries groups: [\"haku\"] (mounted by authentik-jwt-rotation CronJob)"
+      description = "client_id (shared kubectl-sandbox-client-credentials provider) + haku-k8s username/app-password, authenticating the haku-k8s service account so its JWT carries groups: [\"haku\"] (mounted by authentik-jwt-rotation CronJob)"
     }
   }
 
   data = {
-    client_id     = authentik_provider_oauth2.kubectl_sandbox_client_credentials.client_id
-    client_secret = authentik_token.haku_k8s.key
+    client_id = authentik_provider_oauth2.kubectl_sandbox_client_credentials.client_id
+    username  = authentik_user.haku_k8s.username
+    password  = authentik_token.haku_k8s.key
   }
 }


### PR DESCRIPTION
## Summary

- make `authentik-jwt-rotation` depend on `agent-machine-access-tf`
- split public fixed-sandbox Authentik groups mapping from the machine client-credentials mapping
- map only the two known machine principals to effective Kubernetes groups, with unknown principals receiving no groups
- switch Haku rotation to Authentik username/app-password client-credentials and update rotator support/tests/docs
- record follow-up to slim the rotator image in `cluster/k8s/TODO.md`

## Validation

- `bbr test //cluster/k8s/agents/authentik-jwt-rotation:test_rotate`
- `bbr build //tf/gitops/agent-machine-access:agent-machine-access`
- `nix develop -c pre-commit run --files ...`