### PR TITLE
haku web env: prefix setup command with ducktape/

### DIFF
--- a/haku/claude_web_env/README.md
+++ b/haku/claude_web_env/README.md
@@ -6,7 +6,9 @@ here (on Anthropic infra) and drives the cluster over `kubectl`; the
 
 ## Environment settings (when creating the web environment)
 
-- **Setup script:** `bash haku/claude_web_env/setup.sh`
+- **Setup script:** `bash ducktape/haku/claude_web_env/setup.sh` — the setup
+  command runs from the parent of the repo checkout, so it needs the `ducktape/`
+  prefix (same as the shared `bash ducktape/devinfra/claude/web_setup.sh`).
 - **Environment variables:**
   - `DUCKTAPE_CLAUDE_HOOKS_PROFILE=haku/claude_web_env/profile.yaml`
   - `SOPS_AGE_KEY=<the haku age key>` — decrypt it from

--- a/haku/claude_web_env/setup.sh
+++ b/haku/claude_web_env/setup.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # Environment setup script for Haku's Claude Code web "home".
 #
-# Wire it as the web environment's setup script:
-#   bash haku/claude_web_env/setup.sh
+# Wire it as the web environment's setup script (the setup command runs from the
+# parent of the repo checkout, hence the ducktape/ prefix):
+#   bash ducktape/haku/claude_web_env/setup.sh
 # paired with these environment settings:
 #   DUCKTAPE_CLAUDE_HOOKS_PROFILE=haku/claude_web_env/profile.yaml
 #   SOPS_AGE_KEY=<the haku age key from secrets/haku-age-key.sops.yaml>


### PR DESCRIPTION
The Claude Code web **setup command** runs from the parent of the repo
checkout, so the documented `bash haku/claude_web_env/setup.sh` fails with
`No such file or directory`. Use the `ducktape/` prefix, matching the shared
`bash ducktape/devinfra/claude/web_setup.sh`.

Fixed in `haku/claude_web_env/README.md` and `setup.sh`'s usage comment. The
`DUCKTAPE_CLAUDE_HOOKS_PROFILE` env var stays unprefixed — the hook resolves it
against the project dir, not the setup command's cwd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFbZ5fLRn9XFQx7qV7vBP8)_