### PR TITLE
prettier: exclude secrets/haku-k8s-jwt.yaml (rotation-written)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -61,6 +61,7 @@ devinfra/js/debundle/peel/golden/**
 # entirely, which would also unblock cluster/k8s/flux-system, kustomization,
 # etc.) and drop these excludes.
 secrets/claude-web-k8s-jwt.yaml
+secrets/haku-k8s-jwt.yaml
 **/*.sops.yaml
 secrets/claude-web-attic.yaml
 secrets/hosts/*-attic.yaml


### PR DESCRIPTION
**Unblocks `devel`** — pre-commit is currently failing on every PR.

The `authentik-jwt-rotation` CronJob committed `secrets/haku-k8s-jwt.yaml` to
`devel` (commit `acd87dfa`) directly from inside the cluster, in sops's default
4-space indentation. The rotator container has no Node.js/prettier, so the file
isn't prettier-formatted; on the next CI run, pre-commit's prettier reformats it
(4-space → 2-space `sops:` block) and the **Pre-commit checks** job fails. The
encrypted payloads are untouched — it's purely an indentation reflow.

Its claude sibling `secrets/claude-web-k8s-jwt.yaml` is already in the
`.prettierignore` rotation-secrets block; the new haku rotation output was simply
never added. This adds it alongside.

(The pre-existing `TODO` in that block — have the rotator format with prettier,
or drop prettier-on-YAML entirely — still stands as the durable fix.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFbZ5fLRn9XFQx7qV7vBP8)_