### PR TITLE
haku manual: drive sandbox pods via command + kubectl logs, not exec

### DIFF
--- a/haku/base/instructions.md
+++ b/haku/base/instructions.md
@@ -93,6 +93,12 @@ foothold — to run tools that aren't in your home, or to reach cluster-internal
 services your web home can't (the namespace's egress permits the cluster plus the
 allowlisted external hosts through its mitmproxy). That's how you query Plaid
 (see _Hard rules_). Mount the read-only secrets above into those pods as needed.
+**Drive these pods through their command + `kubectl logs`, not interactively:**
+`kubectl exec`, `attach`, and `port-forward` don't work through the API gateway
+(`kubeapi.allegedly.works`) — it doesn't proxy the streaming connection upgrade
+they need, so they fail with an empty `Error from server:`. Bake the work into
+the pod's command (or a ConfigMap-mounted script) and read the result from
+`kubectl logs`.
 Stay inside `haku-sandbox` — you have no access outside it; and the creds you can
 mount are read-only, so the compute is for gathering, not acting on the world.
 
@@ -146,13 +152,21 @@ below.
   source — is read-only. You have no credential to write anything but state;
   the container's perimeter enforces this, these rules just describe it. Don't
   try to call mutating tools; they aren't on your wire.
-- **Plaid is read-only SQL, run from a `haku-sandbox` pod.** The Plaid Postgres
-  mirror is cluster-internal — your home can't reach it, but a pod you launch in
-  `haku-sandbox` can (its egress allows the cluster). `kubectl run` a short-lived
-  `postgres`-image pod that reads the DSN from the `plaid-mcp-db-readonly` secret
-  (reflected into `haku-sandbox`) and runs your `SELECT`s, then capture its
-  output. The role is read-only — `SELECT` is all that works — no MCP server, no
-  creds on a command line.
+- **Plaid is read-only SQL, run from a `haku-sandbox` pod — via the pod's
+  command + `kubectl logs`, not `exec`.** The Plaid Postgres mirror is
+  cluster-internal — your home can't reach it, but a pod you launch in
+  `haku-sandbox` can (its egress allows the cluster). **`kubectl exec`,
+  `attach`, and `port-forward` do not work** through `kubeapi.allegedly.works`:
+  the API gateway proxies ordinary requests but not the streaming connection
+  upgrade those verbs need, so you get an empty `Error from server:`. So don't
+  start an idle pod and `exec` into it — make the query the pod's command and
+  read its logs. `kubectl apply` a short-lived `postgres`-image Pod
+  (`restartPolicy: Never`) that pulls the DSN from the `plaid-mcp-db-readonly`
+  secret as an env var (`secretKeyRef`, so no credential ever lands on a command
+  line) and runs `psql "$DATABASE_URL" -c '<SELECT …>'` (or a heredoc) as its
+  command; once it completes, `kubectl logs` the pod for the rows, then delete
+  it. (`kubectl run --env` can't pull from a secret, hence the manifest.) The
+  role is read-only — `SELECT` is all that works — no MCP server.
 - **Gmail & Calendar: read-only via Google's REST API.** Get the token:
   `TOK=$(kubectl get secret google-access-token -o jsonpath='{.data.access_token}' | base64 -d)`
   — airlock's access token, whose scopes are all `.readonly`, so a write fails

--- a/haku/base/playbooks/plaid_anomalies.md
+++ b/haku/base/playbooks/plaid_anomalies.md
@@ -1,10 +1,12 @@
 # plaid_anomalies (example)
 
 Financial transactions live in the Plaid Postgres mirror. Query it by launching a
-`psql` pod in `haku-sandbox` (see `../AGENTS.md` → _Hard rules_; your home can't
-reach the DB directly), using the read-only DSN from the `plaid-mcp-db-readonly`
-secret. The role is read-only, so `psql` can only `SELECT`. `\dt` to orient on the
-schema, then look at roughly the last 60 days for:
+`postgres`-image pod in `haku-sandbox` whose **command is your `psql` query**, then
+read the rows from `kubectl logs` — `exec`/`port-forward` don't work through the API
+gateway (see `../instructions.md` → _Hard rules_; your home can't reach the DB
+directly). The DSN comes from the `plaid-mcp-db-readonly` secret as an env var, and
+the role is read-only, so `psql` can only `SELECT`. Query `information_schema` (or
+`\dt`) first to orient on the schema, then look at roughly the last 60 days for:
 
 - duplicate charges (same merchant, amount, close dates)
 - new recurring merchants (a subscription you may not know you have)


### PR DESCRIPTION
From a Haku run: `kubectl exec` through `kubeapi.allegedly.works` fails with an
empty `Error from server:`, so the manual's "exec into a psql pod" approach
doesn't work. Haku worked around it by making the SQL the pod's command and
reading `kubectl logs` — which is the correct pattern.

**Root cause:** `exec`/`attach`/`port-forward` need an HTTP connection upgrade
(SPDY or WebSocket) for their streaming session. The API is reached through the
Cilium/Envoy Gateway (`kubeapi.allegedly.works`), which proxies ordinary
requests but not that upgrade — hence the empty server error.

**Changes (`haku/base/`):**
- Plaid hard rule in `instructions.md`: rewritten to the working pattern — a
  `restartPolicy: Never` Pod whose command runs `psql "$DATABASE_URL" -c '…'`
  (DSN from the `plaid-mcp-db-readonly` secret via `secretKeyRef`, so no creds
  on a command line), then `kubectl logs` for the rows. Explicit
  "no exec/attach/port-forward through the gateway" caveat.
- Compute-sandbox section: same caveat generally — drive sandbox pods via their
  command + `kubectl logs`.
- `plaid_anomalies.md`: recipe updated to match, and fixed a stale
  `../AGENTS.md` → `../instructions.md` reference.

Not addressed here (separate, larger question): whether to make `exec` actually
work through the gateway (enabling WebSocket-exec end-to-end), vs. treating it
as a permanent constraint. Happy to investigate if you want it tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFbZ5fLRn9XFQx7qV7vBP8)_