### PR TITLE
haku: keep a deep backlog of items, not just a shortlist

### DIFF
--- a/haku/base/instructions.md
+++ b/haku/base/instructions.md
@@ -10,6 +10,16 @@ the good ones and either does them or hands them to an agent with more than
 read-only access. You never act on the world yourself — you find and frame the
 work, you don't do it.
 
+**Keep a deep backlog, not a shortlist.** It's valuable to have many items ready
+to pick up — including lower-urgency, longer-horizon, and contingent ones ("once
+X lands, consider Y") — so that whenever the operator clears current work there's
+always a ranked bench to draw from. `value` exists to **rank** the queue, not to
+gate what gets filed: there is no minimum score to file. Capture any genuine,
+non-duplicate opportunity the operator might plausibly want, let ranking sort it,
+and don't suppress a worthwhile idea just because it isn't top-of-list today. The
+only things that stay out are real noise — expected regulars and ideas already
+rejected (see _Item contract_ and the run procedure).
+
 Your scope is **not** a fixed set of checks. The playbooks are starting points,
 not boundaries — reason about what would make the operator's life better,
 **building on your accumulated notes and past reasoning** (not a fixed
@@ -211,16 +221,18 @@ Action kinds (only these two):
 ## `items.md` spec
 
 Regenerate fully on every scan. All `open` items, sorted by `value`
-descending. Keep it scannable, not overwhelming:
+descending. The backlog is meant to be **deep**, so keep `items.md` scannable by
+**tiering detail**, not by dropping items:
 
-- Top section **Up next**: a table of the top items (≤7) — `value`, `title`,
-  deadline if any, link to the item file.
-- Below, **Everything else** inside a `<details>` block: same table for the
-  remaining open items.
-- After the tables, one `### <title>` section per open item with `body` and,
-  for `prepared_prompt` items, the prompt in a fenced block plus a
-  `[hand off](https://claude.ai/new?q=<url-encoded prompt>)` link when the
-  encoded prompt stays under ~2000 characters.
+- **Up next**: a table of the top items (≤7) to act on now — `value`, `title`,
+  deadline if any, link to the item file. Below the table, one `### <title>`
+  section per **Up next** item with `body` and, for `prepared_prompt` items, the
+  prompt in a fenced block plus a `[hand off](https://claude.ai/new?q=<url-encoded prompt>)`
+  link when the encoded prompt stays under ~2000 characters.
+- **Backlog**: everything else, inside a `<details>` block — a single table
+  (same columns) covering **all** remaining open items, however many. No
+  per-item prose section here; the item file carries the detail. This is the
+  bench, and it's fine for it to be long.
 - Footer: counts by status and the timestamp of the last scan.
 
 ## Playbooks

--- a/haku/claude_web_env/run.md
+++ b/haku/claude_web_env/run.md
@@ -56,11 +56,16 @@ All paths below are relative to `~/haku-state`. Run this top to bottom:
    **examples**, not a closed set — run the ones whose sources you have, and
    reason freely beyond them, honoring the operator guidance in your `memory/`.
 4. **Write items**: new findings become `items/<id>.yaml` per the contract in the
-   manual. Update existing items when evidence changed; never duplicate a
+   manual. **Aim for a deep backlog** — file lower-urgency, longer-horizon, and
+   contingent opportunities too, not just the top few; there's no minimum `value`
+   to file. Update existing items when evidence changed; never duplicate a
    `dedup_key` that already exists in any status. Don't re-raise a rejected idea
    unless there is materially new evidence — and say what's new in `body`.
-5. **Curate**: re-score open items if context changed, set `status: expired` on
-   items past `deadline`, then regenerate `items.md` (spec in the manual).
+5. **Curate**: re-score open items if context changed and set `status: expired` on
+   items past `deadline` (or no longer possible). **Keep valid lower-priority
+   items `open` as the backlog** — don't drop or expire them just to shorten the
+   list; ranking and the `items.md` tiering keep it scannable. Then regenerate
+   `items.md` (spec in the manual).
 6. **Log**: append a run entry to `log/` — what you scanned, what you found, what
    you chose not to file and why (one line each). Compact old log content when it
    stops being useful; the log is yours to structure.


### PR DESCRIPTION
Shift Haku from "tight dashboard of the top few" toward maintaining a **deep,
value-ranked backlog** — lower-urgency, longer-horizon, and contingent items kept
ready so there's always a bench to pick up when current work clears.

**Changes (`haku/base/instructions.md`, `haku/claude_web_env/run.md`):**
- **Mandate:** keep a deep backlog, not a shortlist. `value` ranks the queue; it
  is **not** a filing threshold (no minimum score to file). Capture any genuine,
  non-duplicate opportunity and let ranking sort it; only real noise (expected
  regulars, already-rejected ideas) stays out.
- **`items.md` spec:** scale to a long backlog by **tiering detail** instead of
  dropping items — full prose sections only for the ≤7 "Up next"; a single
  (possibly long) "Backlog" table in a `<details>` block for everything else, so
  the dashboard stays scannable however deep the bench gets.
- **Run procedure (write/curate):** explicitly file lower-urgency/contingent
  items; keep valid lower-priority items `open` as the backlog rather than
  expiring them to shorten the list. Expire only genuinely perished items.

No schema change — this is purely how Haku fills and renders the existing queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFbZ5fLRn9XFQx7qV7vBP8)_