### PR TITLE
haku: read-only dashboard website behind Authentik (rungs 1+2)

### DIFF
--- a/cluster/k8s/authentik/app/blueprints/haku-dashboard-sso.yaml
+++ b/cluster/k8s/authentik/app/blueprints/haku-dashboard-sso.yaml
@@ -1,0 +1,40 @@
+version: 1
+metadata:
+  name: SSO - Haku dashboard
+  labels:
+    blueprints.goauthentik.io/description: "Haku dashboard proxy provider, application, and single-user access binding"
+
+entries:
+  - model: authentik_providers_proxy.proxyprovider
+    id: haku-dashboard-provider
+    state: present
+    identifiers:
+      name: haku-dashboard
+    attrs:
+      external_host: "https://haku.allegedly.works"
+      internal_host: "http://haku-dashboard.haku-sandbox.svc.cluster.local:8080"
+      mode: proxy
+      authentication_flow: !Find [authentik_flows.flow, [slug, default-authentication-flow]]
+      authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+      invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      access_token_validity: "hours=24"
+
+  - model: authentik_core.application
+    id: haku-dashboard-app
+    state: present
+    identifiers:
+      slug: haku-dashboard
+    attrs:
+      name: Haku
+      provider: !KeyOf haku-dashboard-provider
+      meta_description: "Haku's value-ranked item dashboard (read-only)"
+      meta_launch_url: "https://haku.allegedly.works"
+      open_in_new_tab: true
+
+  # Restrict access to the single user agentydragon (mirrors fava-sso).
+  - model: authentik_policies.policybinding
+    state: present
+    identifiers:
+      target: !KeyOf haku-dashboard-app
+      user: !Find [authentik_core.user, [username, agentydragon]]
+      order: 0

--- a/cluster/k8s/authentik/app/kustomization.yaml
+++ b/cluster/k8s/authentik/app/kustomization.yaml
@@ -32,4 +32,5 @@ configMapGenerator:
       - blueprints/claude-service-account.yaml
       - blueprints/openhands-sso.yaml
       - blueprints/fava-sso.yaml
+      - blueprints/haku-dashboard-sso.yaml
     namespace: authentik

--- a/cluster/k8s/authentik/proxy-routes/haku-dashboard-httproute.yaml
+++ b/cluster/k8s/authentik/proxy-routes/haku-dashboard-httproute.yaml
@@ -1,0 +1,18 @@
+# HTTPRoute for the Haku dashboard via the shared Authentik proxy outpost.
+# Traffic flows: Gateway -> outpost (auth, agentydragon-only) -> haku-dashboard backend.
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: haku-dashboard
+  namespace: authentik
+spec:
+  parentRefs:
+    - name: cluster-gateway
+      namespace: gateway-system
+  hostnames:
+    - "haku.allegedly.works"
+  rules:
+    - backendRefs:
+        - name: authentik-server
+          port: 80

--- a/cluster/k8s/authentik/proxy-routes/kustomization.yaml
+++ b/cluster/k8s/authentik/proxy-routes/kustomization.yaml
@@ -17,3 +17,4 @@ resources:
   - adsb-httproute.yaml
   - openhands-httproute.yaml
   - fava-httproute.yaml
+  - haku-dashboard-httproute.yaml

--- a/cluster/k8s/haku/dashboard/deployment.yaml
+++ b/cluster/k8s/haku/dashboard/deployment.yaml
@@ -1,0 +1,150 @@
+# Read-only Haku dashboard: a git-sync sidecar keeps /data a shallow checkout of
+# haku-state, and nginx serves only its dashboard/ directory (the self-contained
+# index.html Haku regenerates each run). Access is gated by Authentik
+# (agentydragon-only) via the proxy outpost — nginx has no native auth. Modelled
+# on cluster/k8s/budget/app (Fava + ledger-sync).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: haku-dashboard
+  namespace: haku-sandbox
+  labels:
+    app.kubernetes.io/name: haku-dashboard
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: haku-dashboard
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: haku-dashboard
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101 # nginx-unprivileged uid; git-sync runs as the same uid
+        runAsGroup: 101
+        fsGroup: 101
+      initContainers:
+        # One-time clone so /data exists before nginx starts.
+        - name: state-sync-init
+          image: docker.io/alpine/git:2.52.0@sha256:4a0e72d49596a1f5d3701aeedafdadc5c0da4062be4657c7bdc4017387f591cc
+          command: ["sh", "/scripts/sync.sh", "once"]
+          env:
+            - name: GIT_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: haku-state-git-write
+                  key: username
+            - name: GIT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: haku-state-git-write
+                  key: password
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: tmp # git writes its global config under $HOME (/tmp); rootfs is read-only
+              mountPath: /tmp
+            - name: scripts
+              mountPath: /scripts
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+      containers:
+        - name: state-sync
+          image: docker.io/alpine/git:2.52.0@sha256:4a0e72d49596a1f5d3701aeedafdadc5c0da4062be4657c7bdc4017387f591cc
+          command: ["sh", "/scripts/sync.sh"]
+          env:
+            - name: GIT_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: haku-state-git-write
+                  key: username
+            - name: GIT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: haku-state-git-write
+                  key: password
+            - name: SYNC_PERIOD
+              value: "300"
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: tmp
+              mountPath: /tmp
+            - name: scripts
+              mountPath: /scripts
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 50m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+        - name: nginx
+          image: nginxinc/nginx-unprivileged:1.27-alpine
+          ports:
+            - name: http
+              containerPort: 8080
+          volumeMounts:
+            - name: data
+              mountPath: /data
+              readOnly: true
+            - name: nginx-conf
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: default.conf
+              readOnly: true
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+            - name: nginx-run
+              mountPath: /var/run
+            - name: tmp
+              mountPath: /tmp
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+      volumes:
+        - name: data
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}
+        - name: scripts
+          configMap:
+            name: haku-dashboard-sync
+        - name: nginx-conf
+          configMap:
+            name: haku-dashboard-nginx

--- a/cluster/k8s/haku/dashboard/flux-kustomization.yaml
+++ b/cluster/k8s/haku/dashboard/flux-kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: haku-dashboard
+  namespace: flux-system
+spec:
+  interval: 10m
+  retryInterval: 1m
+  timeout: 5m
+  path: ./cluster/k8s/haku/dashboard
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  dependsOn:
+    - name: haku-namespace
+    - name: haku-state # provisions haku-state-git-write in the haku-sandbox namespace
+    - name: gateway
+    - name: authentik

--- a/cluster/k8s/haku/dashboard/kustomization.yaml
+++ b/cluster/k8s/haku/dashboard/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+
+configMapGenerator:
+  - name: haku-dashboard-sync
+    namespace: haku-sandbox
+    files:
+      - sync/sync.sh
+  - name: haku-dashboard-nginx
+    namespace: haku-sandbox
+    files:
+      - nginx/default.conf

--- a/cluster/k8s/haku/dashboard/nginx/default.conf
+++ b/cluster/k8s/haku/dashboard/nginx/default.conf
@@ -1,0 +1,13 @@
+# Serve ONLY haku-state's dashboard/ directory — never the rest of the repo
+# (items/, intake/, memory/, log/, .git). Haku publishes exactly what it writes
+# under dashboard/.
+server {
+    listen 8080;
+    server_name _;
+    root /data/dashboard;
+    index index.html;
+    autoindex off;
+    location / {
+        try_files $uri $uri/ =404;
+    }
+}

--- a/cluster/k8s/haku/dashboard/service.yaml
+++ b/cluster/k8s/haku/dashboard/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: haku-dashboard
+  namespace: haku-sandbox
+  labels:
+    app.kubernetes.io/name: haku-dashboard
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: haku-dashboard
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP

--- a/cluster/k8s/haku/dashboard/sync/sync.sh
+++ b/cluster/k8s/haku/dashboard/sync/sync.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Keep /data a shallow checkout of haku-state so nginx can serve dashboard/.
+# Read-only use of the haku git credential (the repo's own creds, delivered as
+# the haku-state-git-write Secret; the budget Fava app reuses repo creds for its
+# read-only sync the same way). Arg "once" syncs once and exits (init
+# container); default loops.
+set -eu
+
+REPO="http://forgejo-http.forgejo:3000/haku/haku-state.git"
+DIR=/data
+export HOME=/tmp
+
+git config --global --replace-all credential.helper \
+  '!f() { printf "username=%s\npassword=%s\n" "$GIT_USERNAME" "$GIT_PASSWORD"; }; f'
+git config --global safe.directory "$DIR"
+
+sync() {
+  if [ -e "$DIR/.git" ]; then
+    git -C "$DIR" fetch --depth 1 origin HEAD
+    git -C "$DIR" reset --hard FETCH_HEAD
+  else
+    git clone --depth 1 "$REPO" "$DIR"
+  fi
+}
+
+sync
+[ "${1:-loop}" = "once" ] && exit 0
+
+while true; do
+  sleep "${SYNC_PERIOD:-300}"
+  sync
+done

--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -200,6 +200,7 @@ resources:
   # --- haku (personal background agent; see haku/PLAN.md) ---
   - haku/namespace/flux-kustomization.yaml
   - haku/rbac/flux-kustomization.yaml
+  - haku/dashboard/flux-kustomization.yaml
 
   # --- matrix ---
   - matrix/namespace/flux-kustomization.yaml

--- a/haku/PLAN.md
+++ b/haku/PLAN.md
@@ -545,13 +545,14 @@ The web home already runs end to end, so phase 1 widens and sharpens the queue:
   fit; for longer prompts, a stable per-item URL whose content is
   one-click-copyable. Closing the loop stays manual at first (I flip
   `status` after the handoff session finishes).
-- Dashboard ladder — **v0 is decided: the Forgejo web editor**, rendered
-  `items.md` as the view. Escalate a rung only when the current one
-  demonstrably hurts:
-  1. **Committed static page**: haku-regenerated `dashboard/index.html` in
-     the repo, served by a static container + git-sync sidecar behind
-     Authentik (the augur evidence-sync pattern). Affordances are plain
-     links: handoff URLs, Forgejo web-editor deep links for archive/feedback.
+- Dashboard ladder — escalate a rung only when the current one demonstrably
+  hurts:
+  1. **Committed static page (DONE):** Haku regenerates `dashboard/index.html`
+     in its state via a generator it authors and keeps under `dashboard/`; an
+     nginx + git-sync Deployment (`cluster/k8s/haku/dashboard/`, modelled on the
+     budget/Fava app) serves only that directory at `haku.allegedly.works` behind
+     Authentik (agentydragon-only). Affordances are plain links: `claude.ai/new?q=`
+     handoff buttons and a Forgejo new-file deep link for adding intake notes.
   2. **Pretty dashboard, still no backend**: a real web app (Svelte) whose
      build reads the repo from a git-sync volume and renders client-side;
      archive/feedback buttons call the Forgejo API with my Authentik session.

--- a/haku/base/instructions.md
+++ b/haku/base/instructions.md
@@ -235,6 +235,30 @@ descending. The backlog is meant to be **deep**, so keep `items.md` scannable by
   bench, and it's fine for it to be long.
 - Footer: counts by status and the timestamp of the last scan.
 
+## Dashboard
+
+Your queue is published as a small **read-only website** at
+`https://haku.allegedly.works`: an in-cluster nginx git-syncs your state repo and
+serves **only** its `dashboard/` directory, behind Authentik (operator-only). Keep
+that page current as part of every run:
+
+- Maintain `dashboard/index.html` with a **generator you author and keep in your
+  state** (e.g. `dashboard/generate.py`). It reads your items and renders a
+  self-contained HTML page. Treat the generator as part of your knowledge garden —
+  version it in the repo and improve it over time.
+- **Run the generator whenever items change** and commit the regenerated
+  `dashboard/index.html` alongside `items.md`, so the published page always matches
+  the queue. You may wire it as a git pre-commit hook in your state repo so it
+  can't drift from the items.
+- Mirror `items.md`: value-sorted **Up next** plus a collapsible backlog. For
+  every `prepared_prompt` item, render its `claude.ai/new?q=<url-encoded prompt>`
+  deep link as a button. Include a standing **"Add intake note"** link to
+  Forgejo's new-file editor — `https://git.allegedly.works/haku/haku-state/_new/main/intake/`
+  — so the operator can drop feedback without leaving the page.
+- Only `dashboard/` is web-served. Put only publishable content there, don't rely
+  on anything outside it being visible, and never include secrets (the item rules
+  already forbid this).
+
 ## Playbooks
 
 `playbooks/` holds **example** playbooks — concrete starting points

--- a/haku/claude_web_env/run.md
+++ b/haku/claude_web_env/run.md
@@ -65,14 +65,16 @@ All paths below are relative to `~/haku-state`. Run this top to bottom:
    items past `deadline` (or no longer possible). **Keep valid lower-priority
    items `open` as the backlog** — don't drop or expire them just to shorten the
    list; ranking and the `items.md` tiering keep it scannable. Then regenerate
-   `items.md` (spec in the manual).
+   `items.md`, and run your dashboard generator to refresh `dashboard/index.html`
+   (both per the manual — see _`items.md` spec_ and _Dashboard_).
 6. **Log**: append a run entry to `log/` — what you scanned, what you found, what
    you chose not to file and why (one line each). Compact old log content when it
    stops being useful; the log is yours to structure.
 7. **Commit and push**: directly to `main`, one commit per logical change
-   (intake processing, new/updated items + regenerated `items.md`, log,
-   `memory/`). Push **everything** before you finish — your state is your only
-   memory. Message format: `scan: <summary>` / `intake: <summary>` /
+   (intake processing, new/updated items + regenerated `items.md` +
+   `dashboard/index.html`, log, `memory/`). Push **everything** before you finish
+   — your state is your only memory, and pushing is what updates the published
+   dashboard. Message format: `scan: <summary>` / `intake: <summary>` /
    `log: <summary>`.
 
 Then stop — the operator reviews the items in Forgejo and hands off approved


### PR DESCRIPTION
Publishes Haku's queue as a small **read-only website** at `haku.allegedly.works`,
gated by Authentik to the **agentydragon** user, with a Forgejo deep link for
adding intake notes (no backend yet — rungs 1 + 2 of the dashboard ladder).

### K8s (`cluster/k8s/haku/dashboard/`, modelled on the budget/Fava app)
- **Deployment:** an `alpine/git` sidecar (+ init) shallow-syncs `haku-state`
  into an `emptyDir` every 5 min; `nginx-unprivileged` serves **only** that
  checkout's `dashboard/` directory — never the rest of the repo or `.git`.
  Reuses the existing `haku-state-git-write` Secret read-only (the budget app
  reuses its repo creds the same way). Hardened: non-root, read-only rootfs,
  dropped caps.
- **Service** + **flux-kustomization** (`dependsOn` haku-namespace, haku-state,
  gateway, authentik), wired into the root kustomization.
- **Authentik blueprint** (`haku-dashboard-sso.yaml`): proxy provider +
  application + a single-user policy binding to `agentydragon` (mirrors
  `fava-sso`). **HTTPRoute** on `haku.allegedly.works` → shared outpost.
  `*.allegedly.works` is wildcard, so no DNS/cert work.

### Haku manual (`base/instructions.md` + `run.md`)
Haku maintains `dashboard/index.html` via a **generator it authors and keeps
under `dashboard/`** in its state, runs it whenever items change, and commits the
result — pushing is what updates the live site. The page mirrors `items.md` (Up
next + collapsible backlog), renders each `prepared_prompt`'s `claude.ai/new?q=`
deep link as a button, and includes a standing Forgejo new-file link for intake
notes. PLAN dashboard ladder rung 1 marked done.

### Notes
- No custom backend / writes yet (rung 3) — intake submission is the zero-backend
  Forgejo new-file link, per your ask.
- nginx serves an empty dir until Haku's next run writes `dashboard/index.html`
  (404 until then) — expected on first deploy.
- Independent of the deep-backlog PR (#2367); both touch `run.md`'s curate step,
  so whichever merges second needs a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFbZ5fLRn9XFQx7qV7vBP8)_