### PR TITLE
haku: dashboard/index.html is the single rendered view + reconcile base updates

### DIFF
--- a/haku/PLAN.md
+++ b/haku/PLAN.md
@@ -206,6 +206,10 @@ Properties this buys:
   path-scoped-write / protected-files / auto-merge apparatus entirely: there is
   nothing gated _inside_ state, so state needs no gate. Steering lives in state
   as part of `memory/` — guidance Haku maintains from intake, not instructions.
+  Operator base edits reach Haku by **reconciliation**: it pins the ducktape
+  commit it last synced (`memory/base-sync.md`), and each run diffs `haku/base`
+  since the pin and migrates its state to match (see _Adopting base updates_ in
+  the manual) — e.g. deleting a file the spec dropped.
 - **base is versioned in ducktape, not a stale seed.** In v0 the web home reads
   base from its ducktape checkout, so a playbook edit takes effect on the next
   run with no reseed. (In the later in-cluster path base is baked into the

--- a/haku/PLAN.md
+++ b/haku/PLAN.md
@@ -78,9 +78,10 @@ items under its own credentials. Each role:
   agent account or me) changed what, when, and why, with diffs. Provisioned by
   `tf/gitops/haku-state` (the `augur-evidence` pattern): the `haku` service
   user owns it, I review as Forgejo site-admin.
-- **Dashboard** — v0 is **just a view of git**. Starts as the
-  curator-maintained, value-sorted `items.md` rendered by Forgejo (zero UI
-  code), later a committed static page served via git-sync (see phase 2).
+- **Dashboard** — v0 is **just a view of git**. It is the value-sorted
+  `dashboard/index.html` Haku regenerates from its items, served read-only behind
+  Authentik by an nginx + git-sync Deployment (see phase 2). There is no separate
+  `items.md` — the HTML is the single rendered view.
   Exactly three affordances per item,
   all of which are commits: **hand off** (follow the handoff URL, mark
   `in_progress`), **archive** (flip to a terminal status), and **leave
@@ -116,7 +117,7 @@ class Item(BaseModel):
 
 Serialization: `items/<id>.yaml` in the `haku-state` repo, validated against
 `base/schema/item.json` at write time. Items stay machine-readable, not freeform
-notes — Haku regenerates the rendered `items.md` view from them; freeform
+notes — Haku regenerates the rendered dashboard view from them; freeform
 reasoning lives in `body`, the `log/`, and commit messages.
 
 Action tiers (the discriminated union — only these two; the earlier `ToolCalls`
@@ -126,7 +127,7 @@ tier was dropped):
   acknowledge.
 - **Tier 1 — `PreparedPrompt`**: the workhorse. Full prompt text embedding the
   evidence and desired outcome so the executor session needs no archaeology.
-  Rendered in `items.md` as a **handoff URL** — a `claude.ai/new?q=<prompt>`
+  Rendered on the dashboard as a **handoff URL** — a `claude.ai/new?q=<prompt>`
   deep link where the prompt fits in a URL, otherwise a link to the raw item
   file to copy from.
 
@@ -178,13 +179,13 @@ credential can write only the state repo**:
   entrypoint (`haku/claude_web_env/run.md`), not in base. There is **no
   `.mcp.json`** (v0 has no MCP servers — Plaid is `psql`, Google is REST).
 - **state** — the `haku-state` repo: Haku's _accumulated information_. `items/`,
-  `intake/` (+ `processed/`), `memory/`, `log/`, generated `items.md`. This is
+  `intake/` (+ `processed/`), `memory/`, `log/`, generated `dashboard/`. This is
   the **only** thing Haku writes, and the only place it can.
 
 ```
 haku/base/  (read-only, in ducktape)          haku-state/  (state, Haku writes)
 ├── CLAUDE.md          # @AGENTS.md           ├── items/<id>.yaml
-├── AGENTS.md          # editor-facing        ├── items.md       # value-sorted view
+├── AGENTS.md          # editor-facing        ├── dashboard/     # rendered HTML view
 ├── instructions.md    # operating manual     ├── intake/        # freeform notes from me
 ├── playbooks/         # example playbooks     │   └── processed/ # + Haku's interpretation
 ├── schema/item.json   # JSON Schema          ├── memory/        # knowledge garden + bookmarks
@@ -212,7 +213,7 @@ Properties this buys:
   — the standard <../cluster/docs/container-images.md> flow.) State is **not
   seeded**: Terraform creates `haku-state` (`auto_init`) empty and Haku creates
   its own structure (`items/`, `intake/processed/`, `memory/`, `log/`,
-  `items.md`) on the first run.
+  `dashboard/`) on the first run.
 - **Schema lives in base** (`schema/item.json`). Haku validates items at write
   time against it; ducktape CI validates base. No second copy in state to drift.
 
@@ -483,8 +484,8 @@ cluster` (covers `plaid-mcp-db-ro:5432`, in-cluster LiteLLM, and
 
 Intake works from day one — I commit to `intake/` via the Forgejo web editor
 (phone included); the run reads unprocessed intake and folds guidance into
-`memory/`. Review and approval stay in Forgejo: the rendered `items.md` is the
-dashboard, approval = following an item's handoff URL.
+`memory/`. Review happens on the dashboard at `haku.allegedly.works`; approval =
+following an item's handoff URL, feedback = a Forgejo intake note.
 
 **The next source proves the filter-facade path.** Plaid used the
 scoped-credential trick; PostScanMail is the first HTTP MCP with no read-only
@@ -541,7 +542,7 @@ The web home already runs end to end, so phase 1 widens and sharpens the queue:
 
 ### Phase 2 — handoff polish (+ optional UI)
 
-- Better handoff: `claude.ai/new?q=` deep links in `items.md` where prompts
+- Better handoff: `claude.ai/new?q=` deep links on the dashboard where prompts
   fit; for longer prompts, a stable per-item URL whose content is
   one-click-copyable. Closing the loop stays manual at first (I flip
   `status` after the handoff session finishes).

--- a/haku/base/AGENTS.md
+++ b/haku/base/AGENTS.md
@@ -7,14 +7,14 @@ move runtime instructions here, and don't put editor notes in `instructions.md`.
 ## What lives where
 
 - `instructions.md` — Haku's operating manual: who it is, how it reasons, the
-  credential/perimeter model, hard rules, the item contract, the `items.md`
-  spec, and tone. Durable, runtime-agnostic. Keep it at the "what Haku is and
+  credential/perimeter model, hard rules, the item contract, the dashboard spec,
+  and tone. Durable, runtime-agnostic. Keep it at the "what Haku is and
   what it must honor" level.
 - The **run procedure** (the imperative step-by-step a session executes) lives
   in the runtime entrypoint, `haku/claude_web_env/run.md`, not here. If you find
   yourself writing "step 1, step 2…" in `base/`, it belongs in the entrypoint.
 - `schema/item.json` — the item schema, validated at write time. Changing item
-  shape means editing this **and** the _Item contract_ / `items.md` spec in
+  shape means editing this **and** the _Item contract_ / _Dashboard_ spec in
   `instructions.md` together.
 - `playbooks/` — **example** playbooks, explicitly not a closed set. When adding
   one, frame it as an example and keep it a pattern Haku adapts, not a mandate.

--- a/haku/base/README.md
+++ b/haku/base/README.md
@@ -7,8 +7,8 @@ writes here. Changing Haku's behaviour means editing this directory in ducktape
 and letting the image rebuild (Flux image automation bumps the CronJob tag).
 
 - `instructions.md` — Haku's operating manual: who it is, how it reasons, the
-  perimeter/credential model, hard rules, the item contract, the `items.md`
-  spec, and tone. Haku reads this as itself at run time.
+  perimeter/credential model, hard rules, the item contract, the dashboard spec,
+  and tone. Haku reads this as itself at run time.
 - `AGENTS.md` — instructions for agents that **edit** this directory (not
   Haku's runtime manual).
 - `playbooks/` — **example** playbooks (not a closed set); starting points Haku

--- a/haku/base/instructions.md
+++ b/haku/base/instructions.md
@@ -66,6 +66,26 @@ puts it at `~/haku-state` and sets up git auth); all paths in this manual are
 relative to that repo root. The operator reviews items in Forgejo and hands
 approved ones off to other agent sessions.
 
+## Adopting base updates
+
+Your base (`haku/base/` and the run entrypoint `haku/claude_web_env/run.md`) is
+versioned in ducktape and **changes over time** — the operator edits it to change
+how you work, and you can't edit it yourself (see _Hard rules_), so reconciling it
+each run is the only channel through which those edits reach you. You have the
+ducktape repo checked out, so adopt the changes yourself:
+
+- Keep a **pin of the ducktape commit you last reconciled against** in
+  `memory/base-sync.md` (the commit SHA plus a one-line note). On the first run
+  there's no pin yet — just record the current `HEAD`.
+- Each run, compare the ducktape checkout's `HEAD` to that pin. If it advanced,
+  read what changed in your contract —
+  `git -C <ducktape> log -p <pin>..HEAD -- haku/base haku/claude_web_env/run.md` —
+  and **migrate your state to match**: delete files the contract no longer uses
+  (e.g. a dropped `items.md`), rename/restructure directories, re-render the
+  dashboard, re-validate items against the schema, and fold any new guidance into
+  how you work. Then update the pin to `HEAD` and note in the `log/` what you
+  reconciled.
+
 ## Setup: discover credentials
 
 Everything you're allowed to touch is a Kubernetes Secret in your own namespace,

--- a/haku/base/instructions.md
+++ b/haku/base/instructions.md
@@ -54,12 +54,12 @@ failing test, confirm the gap), do it.
 
 This manual and `schema/item.json` are your **base** — read-only, baked into
 your image; you cannot change them at run time. Your **state** is the separate
-`haku-state` repo: it holds `items/`, `intake/`, `memory/`, `log/`, and
-`items.md`, and is the **only** thing you write. **This repo is yours** — tend it
+`haku-state` repo: it holds `items/`, `intake/`, `memory/`, `log/`, and the
+generated `dashboard/`, and is the **only** thing you write. **This repo is yours** — tend it
 like a knowledge garden: keep `memory/` and the log curated, prune what's stale,
 reorganize as it grows. Keep the **required structure** intact — the item files
-and `items.md` are the operator's interface (see _Item contract_ and _`items.md`
-spec_) — but everything else is yours to shape.
+and the rendered dashboard are the operator's interface (see _Item contract_ and
+_Dashboard_) — but everything else is yours to shape.
 
 Your runtime clones state for you and tells you where it lives (the web home
 puts it at `~/haku-state` and sets up git auth); all paths in this manual are
@@ -128,7 +128,7 @@ git -C ~/haku-state config user.email haku@allegedly.works
 
 The repo may be **empty on the first run** (no seed) — if so, create the
 structure yourself: `items/`, `intake/processed/`, `log/`, `memory/`, and
-`items.md`.
+`dashboard/`.
 
 ## Continuity — you are restarted from a clean home each run
 
@@ -152,7 +152,7 @@ fresh start. On the very first run, start each source from a sensible window
 Your runtime's entrypoint (for the web home, `haku/claude_web_env/run.md`) gives
 you the concrete step-by-step procedure each session. In outline it is always:
 orient from your state + memory → process `intake/` → reason across your sources
-→ write and curate `items/` and regenerate `items.md` → append to the `log/` →
+→ write and curate `items/` and regenerate the `dashboard/` → append to the `log/` →
 commit and push everything to `main`. The contracts those steps must honor are
 below.
 
@@ -218,43 +218,31 @@ Action kinds (only these two):
   archaeology. Write it as instructions to a capable agent with full access, not
   to you.
 
-## `items.md` spec
-
-Regenerate fully on every scan. All `open` items, sorted by `value`
-descending. The backlog is meant to be **deep**, so keep `items.md` scannable by
-**tiering detail**, not by dropping items:
-
-- **Up next**: a table of the top items (≤7) to act on now — `value`, `title`,
-  deadline if any, link to the item file. Below the table, one `### <title>`
-  section per **Up next** item with `body` and, for `prepared_prompt` items, the
-  prompt in a fenced block plus a `[hand off](https://claude.ai/new?q=<url-encoded prompt>)`
-  link when the encoded prompt stays under ~2000 characters.
-- **Backlog**: everything else, inside a `<details>` block — a single table
-  (same columns) covering **all** remaining open items, however many. No
-  per-item prose section here; the item file carries the detail. This is the
-  bench, and it's fine for it to be long.
-- Footer: counts by status and the timestamp of the last scan.
-
 ## Dashboard
 
-Your queue is published as a small **read-only website** at
+Your queue's rendered view is a small **read-only website** at
 `https://haku.allegedly.works`: an in-cluster nginx git-syncs your state repo and
-serves **only** its `dashboard/` directory, behind Authentik (operator-only). Keep
-that page current as part of every run:
+serves **only** its `dashboard/` directory, behind Authentik (operator-only). The
+`items/<id>.yaml` files are the data; `dashboard/index.html` is the **single
+rendered view** — there is no separate `items.md`. Keep it current every run:
 
 - Maintain `dashboard/index.html` with a **generator you author and keep in your
-  state** (e.g. `dashboard/generate.py`). It reads your items and renders a
+  state** (e.g. `dashboard/generate.py`) that reads `items/` and renders a
   self-contained HTML page. Treat the generator as part of your knowledge garden —
-  version it in the repo and improve it over time.
-- **Run the generator whenever items change** and commit the regenerated
-  `dashboard/index.html` alongside `items.md`, so the published page always matches
-  the queue. You may wire it as a git pre-commit hook in your state repo so it
-  can't drift from the items.
-- Mirror `items.md`: value-sorted **Up next** plus a collapsible backlog. For
-  every `prepared_prompt` item, render its `claude.ai/new?q=<url-encoded prompt>`
-  deep link as a button. Include a standing **"Add intake note"** link to
-  Forgejo's new-file editor — `https://git.allegedly.works/haku/haku-state/_new/main/intake/`
-  — so the operator can drop feedback without leaving the page.
+  version it and improve it over time. Run it whenever items change and commit the
+  result (you may wire it as a git pre-commit hook so it can't drift from the
+  items); pushing is what updates the live site.
+- Render all `open` items, sorted by `value` descending, scannable by **tiering**
+  the deep backlog rather than dropping items:
+  - **Up next**: the top items (≤7) to act on now, each with its `body` and — for
+    `prepared_prompt` items — a `claude.ai/new?q=<url-encoded prompt>` deep-link
+    button (fall back to a link to the item file when the encoded prompt would
+    exceed ~2000 characters).
+  - **Backlog**: everything else in a collapsible `<details>` block — a compact
+    list/table of all remaining open items, however long.
+  - A standing **"Add intake note"** link to Forgejo's new-file editor,
+    `https://git.allegedly.works/haku/haku-state/_new/main/intake/`, plus a footer
+    with counts by status and the last-scan time.
 - Only `dashboard/` is web-served. Put only publishable content there, don't rely
   on anything outside it being visible, and never include secrets (the item rules
   already forbid this).

--- a/haku/claude_web_env/run.md
+++ b/haku/claude_web_env/run.md
@@ -2,7 +2,7 @@
 
 You are **Haku**, the operator's tireless background **executive assistant**.
 Before doing anything, read your full operating manual: `haku/base/instructions.md`
-(who you are, your scope, what you may touch, the item contract, `items.md` spec,
+(who you are, your scope, what you may touch, the item contract, dashboard,
 hard rules, tone). This file is the runtime entrypoint: it recaps what the
 environment already did for you, then gives you the step-by-step run procedure.
 
@@ -64,15 +64,15 @@ All paths below are relative to `~/haku-state`. Run this top to bottom:
 5. **Curate**: re-score open items if context changed and set `status: expired` on
    items past `deadline` (or no longer possible). **Keep valid lower-priority
    items `open` as the backlog** — don't drop or expire them just to shorten the
-   list; ranking and the `items.md` tiering keep it scannable. Then regenerate
-   `items.md`, and run your dashboard generator to refresh `dashboard/index.html`
-   (both per the manual — see _`items.md` spec_ and _Dashboard_).
+   list; ranking and the dashboard's tiering keep it scannable. Then run your
+   dashboard generator to regenerate `dashboard/index.html` (per the manual — see
+   _Dashboard_).
 6. **Log**: append a run entry to `log/` — what you scanned, what you found, what
    you chose not to file and why (one line each). Compact old log content when it
    stops being useful; the log is yours to structure.
 7. **Commit and push**: directly to `main`, one commit per logical change
-   (intake processing, new/updated items + regenerated `items.md` +
-   `dashboard/index.html`, log, `memory/`). Push **everything** before you finish
+   (intake processing, new/updated items + regenerated `dashboard/index.html`,
+   log, `memory/`). Push **everything** before you finish
    — your state is your only memory, and pushing is what updates the published
    dashboard. Message format: `scan: <summary>` / `intake: <summary>` /
    `log: <summary>`.

--- a/haku/claude_web_env/run.md
+++ b/haku/claude_web_env/run.md
@@ -44,33 +44,39 @@ All paths below are relative to `~/haku-state`. Run this top to bottom:
 1. **Orient**: read your `memory/` (standing operator guidance, how far you got
    last time, prior notes), the tail of `log/journal.md`, and all of `items/`
    (including terminal items — they encode what the operator already decided).
-2. **Process intake**: for each file in `intake/` (not `intake/processed/`):
+2. **Adopt base updates**: compare the ducktape checkout's `HEAD`
+   (`git -C "$CLAUDE_PROJECT_DIR" rev-parse HEAD`) to the pin in
+   `memory/base-sync.md`. If it advanced, diff `haku/base` +
+   `haku/claude_web_env/run.md` since the pin, migrate your state to match (per the
+   manual's _Adopting base updates_ — e.g. delete a dropped `items.md`), update the
+   pin, and log what you reconciled.
+3. **Process intake**: for each file in `intake/` (not `intake/processed/`):
    fold any standing guidance into your `memory/` in whatever form future runs
    will naturally act on (note when it expires if it's time-bound), then move the
    file to `intake/processed/` with a short note on how you read it. Intake
    referencing an item id is feedback on that item — apply it (status change,
    re-score) and record it.
-3. **Reason and scan**: working only over what's changed since your last pass
+4. **Reason and scan**: working only over what's changed since your last pass
    (use your bookmarks), look across everything you can see and think about what
    would make the operator's life better. The `haku/base/playbooks/` are
    **examples**, not a closed set — run the ones whose sources you have, and
    reason freely beyond them, honoring the operator guidance in your `memory/`.
-4. **Write items**: new findings become `items/<id>.yaml` per the contract in the
+5. **Write items**: new findings become `items/<id>.yaml` per the contract in the
    manual. **Aim for a deep backlog** — file lower-urgency, longer-horizon, and
    contingent opportunities too, not just the top few; there's no minimum `value`
    to file. Update existing items when evidence changed; never duplicate a
    `dedup_key` that already exists in any status. Don't re-raise a rejected idea
    unless there is materially new evidence — and say what's new in `body`.
-5. **Curate**: re-score open items if context changed and set `status: expired` on
+6. **Curate**: re-score open items if context changed and set `status: expired` on
    items past `deadline` (or no longer possible). **Keep valid lower-priority
    items `open` as the backlog** — don't drop or expire them just to shorten the
    list; ranking and the dashboard's tiering keep it scannable. Then run your
    dashboard generator to regenerate `dashboard/index.html` (per the manual — see
    _Dashboard_).
-6. **Log**: append a run entry to `log/` — what you scanned, what you found, what
+7. **Log**: append a run entry to `log/` — what you scanned, what you found, what
    you chose not to file and why (one line each). Compact old log content when it
    stops being useful; the log is yours to structure.
-7. **Commit and push**: directly to `main`, one commit per logical change
+8. **Commit and push**: directly to `main`, one commit per logical change
    (intake processing, new/updated items + regenerated `dashboard/index.html`,
    log, `memory/`). Push **everything** before you finish
    — your state is your only memory, and pushing is what updates the published


### PR DESCRIPTION
Two related changes to how Haku's base→state evolution works.

### 1. Drop `items.md` — `dashboard/index.html` is the single rendered view
Haku generates `dashboard/index.html` as the rendered queue view, so a separate
value-sorted `items.md` is redundant. The item YAMLs (`items/`) stay the data.
- `instructions.md`: removed the `items.md` spec; folded its rendering detail (Up
  next + collapsible backlog, `claude.ai/new?q=` deep-link buttons, intake link,
  status-count footer) into the Dashboard section. State structure / clone-fallback
  / run-cycle list `dashboard/` instead of `items.md`.
- `run.md`: curate step regenerates `dashboard/index.html` only.
- `base/AGENTS.md`, `base/README.md`, `PLAN.md`: references repointed.

### 2. Reconcile base updates via a last-synced commit pin
Base (`haku/base/` + `run.md`) evolves in ducktape, but nothing told Haku to
migrate state shaped by older instructions — so a dropped `items.md` would linger.
Now Haku pins the ducktape commit it last reconciled against in
`memory/base-sync.md`, and **each run** compares the checkout's `HEAD` to the pin;
if it advanced, it diffs `haku/base` + `run.md` since the pin and migrates its
state to match (delete dropped files like `items.md`, restructure, re-render the
dashboard, re-validate items), then updates the pin and logs it.
- `instructions.md`: new "Adopting base updates" section.
- `run.md`: new step 2 "Adopt base updates" (rest renumbered).
- `PLAN.md`: notes the reconciliation channel under the base/state split.

Docs-only — no code/manifest change. The two are bundled because they touch the
same files and #2 is literally how #1 propagates to Haku's live state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)