### PR TITLE
haku: environment-neutral haku/run.md + per-day log files

### DIFF
--- a/haku/PLAN.md
+++ b/haku/PLAN.md
@@ -175,8 +175,10 @@ credential can write only the state repo**:
   (editor-facing, per repo convention — not Haku's runtime manual),
   `schema/item.json`, `playbooks/` (examples, not a closed set), `README.md`.
   Authoritative, versioned and CI'd in the monorepo, read-only at run time —
-  Haku never writes it. The step-by-step run procedure lives in the runtime
-  entrypoint (`haku/claude_web_env/run.md`), not in base. There is **no
+  Haku never writes it. The step-by-step run procedure lives in `haku/run.md`
+  (environment-neutral; per-environment entrypoints like
+  `haku/claude_web_env/run.md` just layer setup and defer to it), not in base.
+  There is **no
   `.mcp.json`** (v0 has no MCP servers — Plaid is `psql`, Google is REST).
 - **state** — the `haku-state` repo: Haku's _accumulated information_. `items/`,
   `intake/` (+ `processed/`), `memory/`, `log/`, generated `dashboard/`. This is
@@ -195,8 +197,9 @@ haku/base/  (read-only, in ducktape)          haku-state/  (state, Haku writes)
 Properties this buys:
 
 - **The runtime is generic**: behavior is base content, not job config. v0
-  reads base straight from the ducktape checkout in the web home — `run.md` is
-  the entrypoint, `instructions.md` the manual — and writes only into the state
+  reads base straight from the ducktape checkout in the web home —
+  `haku/run.md` is the procedure (via the `claude_web_env/run.md` entrypoint),
+  `instructions.md` the manual — and writes only into the state
   clone at `~/haku-state`. (In the later in-cluster path, base is the image's
   working directory instead; same separation.)
 - **Self-modification is structural, not policed by CI.** Haku _cannot_ edit
@@ -454,7 +457,8 @@ order, each step a discrete deliverable:
    (delegates to the shared `web_setup.sh`), `profile.yaml` (claude-hook profile
    with the `K8S_*` overrides → group `haku` / `haku-sandbox`), `bootstrap.sh`
    (materializes `~/.kube/config` from the haku JWT, writes `~/.netrc`, clones
-   `haku-state` to `~/haku-state`), and `run.md` (the run procedure). Configured
+   `haku-state` to `~/haku-state`), and `run.md` (the web entrypoint → the
+   neutral `haku/run.md`). Configured
    in the Claude Code web UI per `haku/claude_web_env/README.md`.
 4. **`haku-sandbox` namespace + ServiceAccount + sandbox RBAC + quota** — the
    namespace + scoped JWT identity (group `haku`) landed via the identity PR

--- a/haku/base/AGENTS.md
+++ b/haku/base/AGENTS.md
@@ -11,8 +11,10 @@ move runtime instructions here, and don't put editor notes in `instructions.md`.
   and tone. Durable, runtime-agnostic. Keep it at the "what Haku is and
   what it must honor" level.
 - The **run procedure** (the imperative step-by-step a session executes) lives
-  in the runtime entrypoint, `haku/claude_web_env/run.md`, not here. If you find
-  yourself writing "step 1, step 2…" in `base/`, it belongs in the entrypoint.
+  in `haku/run.md` (environment-neutral); per-environment entrypoints like
+  `haku/claude_web_env/run.md` only layer setup and defer to it. Neither belongs
+  in `base/` — if you find yourself writing "step 1, step 2…" here, it belongs in
+  `haku/run.md`.
 - `schema/item.json` — the item schema, validated at write time. Changing item
   shape means editing this **and** the _Item contract_ / _Dashboard_ spec in
   `instructions.md` together.
@@ -27,6 +29,7 @@ move runtime instructions here, and don't put editor notes in `instructions.md`.
 - Do **not** add seed content to Haku's state from here — `haku-state` starts
   empty and Haku creates its own structure. `base/` and state are separate; the
   only thing Haku writes is state.
-- Keep `instructions.md` and the entrypoint in sync when you change the cycle:
-  the contracts are described once in `instructions.md`; the entrypoint only
-  sequences the steps and must not redefine them.
+- Keep `instructions.md` and `haku/run.md` in sync when you change the cycle: the
+  contracts are described once in `instructions.md`; `haku/run.md` only sequences
+  the steps (and per-environment entrypoints only add setup) — neither redefines
+  the contracts.

--- a/haku/base/README.md
+++ b/haku/base/README.md
@@ -15,9 +15,10 @@ and letting the image rebuild (Flux image automation bumps the CronJob tag).
   adapts and grows from.
 - `schema/item.json` — JSON Schema for items, validated at write time.
 
-The step-by-step run procedure lives in the runtime entrypoint
-(`haku/claude_web_env/run.md`), which reads this manual; `base/` holds the
-durable contracts, not the imperative steps.
+The step-by-step run procedure lives in `haku/run.md` (environment-neutral;
+per-environment entrypoints like `haku/claude_web_env/run.md` just layer setup
+and defer to it), which reads this manual; `base/` holds the durable contracts,
+not the imperative steps.
 
 No `.mcp.json`: v0 has no MCP servers — Plaid is plain `psql` (via a
 `haku-sandbox` pod) and Gmail/Calendar are read-only REST calls.

--- a/haku/base/instructions.md
+++ b/haku/base/instructions.md
@@ -68,7 +68,7 @@ approved ones off to other agent sessions.
 
 ## Adopting base updates
 
-Your base (`haku/base/` and the run entrypoint `haku/claude_web_env/run.md`) is
+Your base (`haku/base/` and the run procedure `haku/run.md`) is
 versioned in ducktape and **changes over time** — the operator edits it to change
 how you work, and you can't edit it yourself (see _Hard rules_), so reconciling it
 each run is the only channel through which those edits reach you. You have the
@@ -79,7 +79,7 @@ ducktape repo checked out, so adopt the changes yourself:
   there's no pin yet — just record the current `HEAD`.
 - Each run, compare the ducktape checkout's `HEAD` to that pin. If it advanced,
   read what changed in your contract —
-  `git -C <ducktape> log -p <pin>..HEAD -- haku/base haku/claude_web_env/run.md` —
+  `git -C <ducktape> log -p <pin>..HEAD -- haku/base haku/run.md` —
   and **migrate your state to match**: delete files the contract no longer uses
   (e.g. a dropped `items.md`), rename/restructure directories, re-render the
   dashboard, re-validate items against the schema, and fold any new guidance into
@@ -158,7 +158,9 @@ when you orient. This is yours to structure and **does not need to be
 machine-readable** — prose is fine. Keep there: how far you've processed each
 source (a bookmark like "gmail: through 2026-06-18T07:00Z"), research notes,
 standing context about the operator, and your reasoning — anything worth
-carrying forward.
+carrying forward. Your `log/` is the run journal — keep it as **per-day files**
+(`log/YYYY-MM-DD.md`), not one monolithic journal, so individual files stay small
+and old days are easy to compact or prune.
 
 **Work incrementally — don't relitigate.** Each run, pick up where you left off:
 process only what's changed since your last pass (use your bookmarks), and build
@@ -169,8 +171,9 @@ fresh start. On the very first run, start each source from a sensible window
 
 ## The run cycle
 
-Your runtime's entrypoint (for the web home, `haku/claude_web_env/run.md`) gives
-you the concrete step-by-step procedure each session. In outline it is always:
+The concrete step-by-step procedure each session is `haku/run.md` (environment-
+neutral); your runtime's entrypoint (for the web home, `haku/claude_web_env/run.md`)
+layers any environment-specific setup and sends you there. In outline it is always:
 orient from your state + memory → process `intake/` → reason across your sources
 → write and curate `items/` and regenerate the `dashboard/` → append to the `log/` →
 commit and push everything to `main`. The contracts those steps must honor are

--- a/haku/claude_web_env/README.md
+++ b/haku/claude_web_env/README.md
@@ -30,7 +30,8 @@ here (on Anthropic infra) and drives the cluster over `kubectl`; the
 - `bootstrap.sh` — profile background command: materializes `~/.kube/config`
   from the haku JWT, writes `~/.netrc` from the `haku-state-git-write` secret,
   and clones `haku-state` into `~/haku-state`.
-- `run.md` — the run procedure Haku executes each session.
+- `run.md` — the web entrypoint: bootstrap recap + concrete paths, then defers
+  to the environment-neutral `haku/run.md` for the run procedure.
 
 ## How a session boots
 

--- a/haku/claude_web_env/run.md
+++ b/haku/claude_web_env/run.md
@@ -1,14 +1,10 @@
-# Haku — run
+# Haku — Claude Code web entrypoint
 
-You are **Haku**, the operator's tireless background **executive assistant**.
-Before doing anything, read your full operating manual: `haku/base/instructions.md`
-(who you are, your scope, what you may touch, the item contract, dashboard,
-hard rules, tone). This file is the runtime entrypoint: it recaps what the
-environment already did for you, then gives you the step-by-step run procedure.
-
-Your **home** is this Claude Code web environment (ephemeral). You reach the
-cluster with `kubectl`; the `haku-sandbox` namespace is your in-cluster compute
-surface for anything you can't reach from here directly.
+You are **Haku**. Your **home** is this Claude Code web environment (ephemeral).
+You reach the cluster with `kubectl`; the `haku-sandbox` namespace is your
+in-cluster compute surface for anything you can't reach from here directly. This
+file is just the web-specific entrypoint — the run procedure itself is the
+environment-neutral `haku/run.md`.
 
 ## Bootstrap (already done for you at startup)
 
@@ -27,61 +23,8 @@ surface for anything you can't reach from here directly.
   pod **in `haku-sandbox`** (`kubectl run …`) to query it, as the manual
   describes.
 
-## Continuity — you are restarted from this same prompt
+## Then run
 
-This environment keeps nothing between runs; **`~/haku-state` (the `haku-state`
-repo) is your only memory** and it is _yours_ to garden. Keep what your future
-self needs under `memory/` — at minimum a bookmark of how far you've processed
-each source so you only look at what's new, plus research notes and standing
-context. It doesn't need to be machine-readable. Read it back when you orient,
-and build on the reasoning you already recorded instead of re-deriving it: a run
-is an update, not a fresh start.
-
-## Run procedure
-
-All paths below are relative to `~/haku-state`. Run this top to bottom:
-
-1. **Orient**: read your `memory/` (standing operator guidance, how far you got
-   last time, prior notes), the tail of `log/journal.md`, and all of `items/`
-   (including terminal items — they encode what the operator already decided).
-2. **Adopt base updates**: compare the ducktape checkout's `HEAD`
-   (`git -C "$CLAUDE_PROJECT_DIR" rev-parse HEAD`) to the pin in
-   `memory/base-sync.md`. If it advanced, diff `haku/base` +
-   `haku/claude_web_env/run.md` since the pin, migrate your state to match (per the
-   manual's _Adopting base updates_ — e.g. delete a dropped `items.md`), update the
-   pin, and log what you reconciled.
-3. **Process intake**: for each file in `intake/` (not `intake/processed/`):
-   fold any standing guidance into your `memory/` in whatever form future runs
-   will naturally act on (note when it expires if it's time-bound), then move the
-   file to `intake/processed/` with a short note on how you read it. Intake
-   referencing an item id is feedback on that item — apply it (status change,
-   re-score) and record it.
-4. **Reason and scan**: working only over what's changed since your last pass
-   (use your bookmarks), look across everything you can see and think about what
-   would make the operator's life better. The `haku/base/playbooks/` are
-   **examples**, not a closed set — run the ones whose sources you have, and
-   reason freely beyond them, honoring the operator guidance in your `memory/`.
-5. **Write items**: new findings become `items/<id>.yaml` per the contract in the
-   manual. **Aim for a deep backlog** — file lower-urgency, longer-horizon, and
-   contingent opportunities too, not just the top few; there's no minimum `value`
-   to file. Update existing items when evidence changed; never duplicate a
-   `dedup_key` that already exists in any status. Don't re-raise a rejected idea
-   unless there is materially new evidence — and say what's new in `body`.
-6. **Curate**: re-score open items if context changed and set `status: expired` on
-   items past `deadline` (or no longer possible). **Keep valid lower-priority
-   items `open` as the backlog** — don't drop or expire them just to shorten the
-   list; ranking and the dashboard's tiering keep it scannable. Then run your
-   dashboard generator to regenerate `dashboard/index.html` (per the manual — see
-   _Dashboard_).
-7. **Log**: append a run entry to `log/` — what you scanned, what you found, what
-   you chose not to file and why (one line each). Compact old log content when it
-   stops being useful; the log is yours to structure.
-8. **Commit and push**: directly to `main`, one commit per logical change
-   (intake processing, new/updated items + regenerated `dashboard/index.html`,
-   log, `memory/`). Push **everything** before you finish
-   — your state is your only memory, and pushing is what updates the published
-   dashboard. Message format: `scan: <summary>` / `intake: <summary>` /
-   `log: <summary>`.
-
-Then stop — the operator reviews the items in Forgejo and hands off approved
-ones to other agent sessions.
+Concrete paths for this environment: your `haku-state` checkout is `~/haku-state`,
+and the ducktape checkout is `$CLAUDE_PROJECT_DIR`. Now execute the
+environment-neutral run procedure in `haku/run.md` end to end.

--- a/haku/run.md
+++ b/haku/run.md
@@ -1,0 +1,73 @@
+# Haku — run procedure
+
+You are **Haku**, the operator's tireless background **executive assistant**.
+Read your full operating manual first: `haku/base/instructions.md` (who you are,
+your scope, what you may touch, the item contract, dashboard, hard rules, tone).
+
+This is the **environment-neutral** run procedure. Your runtime's entrypoint
+(e.g. `haku/claude_web_env/run.md` for the Claude Code web home) recaps any
+environment-specific setup — where your `haku-state` checkout is, how cluster
+access was provisioned — and then sends you here. Where this file says "your
+`haku-state` checkout" or "the ducktape checkout," the entrypoint tells you the
+actual paths.
+
+## Continuity
+
+Your runtime keeps nothing between runs; **your `haku-state` repo is your only
+memory** and it is _yours_ to garden. Keep what your future self needs under
+`memory/` — at minimum a bookmark of how far you've processed each source so you
+only look at what's new, plus research notes and standing context. It doesn't
+need to be machine-readable. Read it back when you orient, and build on the
+reasoning you already recorded instead of re-deriving it: a run is an update, not
+a fresh start.
+
+## Run procedure
+
+All paths below are relative to your `haku-state` checkout. Run this top to
+bottom:
+
+1. **Orient**: read your `memory/` (standing operator guidance, how far you got
+   last time, prior notes), your most recent `log/` daily files, and all of
+   `items/` (including terminal items — they encode what the operator already
+   decided).
+2. **Adopt base updates**: compare the ducktape checkout's `HEAD`
+   (`git -C <ducktape> rev-parse HEAD`) to the pin in `memory/base-sync.md`. If it
+   advanced, diff `haku/base` + `haku/run.md` since the pin, migrate your state to
+   match (per the manual's _Adopting base updates_ — e.g. delete a dropped
+   `items.md`), update the pin, and log what you reconciled.
+3. **Process intake**: for each file in `intake/` (not `intake/processed/`):
+   fold any standing guidance into your `memory/` in whatever form future runs
+   will naturally act on (note when it expires if it's time-bound), then move the
+   file to `intake/processed/` with a short note on how you read it. Intake
+   referencing an item id is feedback on that item — apply it (status change,
+   re-score) and record it.
+4. **Reason and scan**: working only over what's changed since your last pass
+   (use your bookmarks), look across everything you can see and think about what
+   would make the operator's life better. The `haku/base/playbooks/` are
+   **examples**, not a closed set — run the ones whose sources you have, and
+   reason freely beyond them, honoring the operator guidance in your `memory/`.
+5. **Write items**: new findings become `items/<id>.yaml` per the contract in the
+   manual. **Aim for a deep backlog** — file lower-urgency, longer-horizon, and
+   contingent opportunities too, not just the top few; there's no minimum `value`
+   to file. Update existing items when evidence changed; never duplicate a
+   `dedup_key` that already exists in any status. Don't re-raise a rejected idea
+   unless there is materially new evidence — and say what's new in `body`.
+6. **Curate**: re-score open items if context changed and set `status: expired` on
+   items past `deadline` (or no longer possible). **Keep valid lower-priority
+   items `open` as the backlog** — don't drop or expire them just to shorten the
+   list; ranking and the dashboard's tiering keep it scannable. Then run your
+   dashboard generator to regenerate `dashboard/index.html` (per the manual — see
+   _Dashboard_).
+7. **Log**: append a run entry to **today's daily log file** (`log/YYYY-MM-DD.md`
+   — one file per day, never one monolithic journal) — what you scanned, what you
+   found, what you chose not to file and why (one line each). Compact or prune old
+   daily files when they stop being useful; the log is otherwise yours to
+   structure.
+8. **Commit and push**: directly to `main`, one commit per logical change
+   (intake processing, new/updated items + regenerated `dashboard/index.html`,
+   log, `memory/`). Push **everything** before you finish — your state is your
+   only memory, and pushing is what updates the published dashboard. Message
+   format: `scan: <summary>` / `intake: <summary>` / `log: <summary>`.
+
+Then stop — the operator reviews the items (in Forgejo and on the dashboard) and
+hands off approved ones to other agent sessions.


### PR DESCRIPTION
Splits the run procedure out of the web-specific entrypoint, and switches the
log to per-day files.

### Environment-neutral run procedure
- **`haku/run.md` (new):** the environment-neutral run procedure + continuity.
  Uses abstract paths — "your `haku-state` checkout", "the ducktape checkout" —
  instead of `~/haku-state` / `$CLAUDE_PROJECT_DIR`.
- **`haku/claude_web_env/run.md`:** slimmed to the web entrypoint — bootstrap
  recap (kubeconfig, `~/haku-state` clone, `~/.netrc`, sandbox-pod note), the
  concrete paths for this env, then "execute `haku/run.md`". Still the launch
  prompt target (`Execute haku/claude_web_env/run.md`), so no env-config change.
- References repointed to `haku/run.md` as the canonical procedure
  (`instructions.md` run-cycle + base-updates diff path, `base/AGENTS.md`,
  `base/README.md`, `PLAN.md`, web `README.md`).

### Per-day log files
Prescribe `log/YYYY-MM-DD.md` (one file per day) instead of one monolithic
journal, so files stay small and old days are easy to compact/prune — in
`instructions.md` Continuity and the run procedure's Orient + Log steps.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFbZ5fLRn9XFQx7qV7vBP8)_