### PR TITLE
haku: use recent Google Drive activity to orient on current work

### DIFF
--- a/haku/base/instructions.md
+++ b/haku/base/instructions.md
@@ -44,11 +44,18 @@ not to file) an item. Some illustrations of the _kind_ of reasoning expected
 - An email plus the calendar imply a routine appointment is overdue (e.g. a
   dental cleaning with no future booking) → prepare a prompt to schedule it.
 - A recurring spam pattern in Gmail → prepare a filter/rule prompt to kill it.
+- A burst of recent Google Drive edits on a project → orient on what the operator
+  is working on right now, cross-reference it with calendar and mail, and look for
+  where you could help (draft, summarize, research, prep the next step).
 
 The throughline: gather evidence from whatever you can read, think it through,
-and turn the worthwhile conclusions into well-framed items. When you can do
-quick research to make an item more actionable (identify the merchant, find the
-failing test, confirm the gap), do it.
+and turn the worthwhile conclusions into well-framed items. **Recent-activity
+signals are a window into what the operator is doing right now** — recent Google
+Drive edits (when you have Drive access), the calendar, and, once wired,
+ActivityWatch — so use them to orient on the current context and spot where help
+is welcome, not just to mine for discrete tasks. When you can do quick research
+to make an item more actionable (identify the merchant, find the failing test,
+confirm the gap), do it.
 
 ## base vs. state
 

--- a/haku/base/playbooks/calendar_prep.md
+++ b/haku/base/playbooks/calendar_prep.md
@@ -1,6 +1,6 @@
 # calendar_prep (example)
 
-Read Calendar with the read-only Google token (see `../AGENTS.md` → _Hard rules_)
+Read Calendar with the read-only Google token (see `../instructions.md` → _Hard rules_)
 over the next ~7–14 days:
 `curl -s -H "Authorization: Bearer $TOK" 'https://www.googleapis.com/calendar/v3/calendars/primary/events?timeMin=<now>&timeMax=<+14d>&singleEvents=true&orderBy=startTime'`.
 Look for:

--- a/haku/base/playbooks/drive_activity.md
+++ b/haku/base/playbooks/drive_activity.md
@@ -1,17 +1,24 @@
 # drive_activity (example)
 
-Scan recent Google Drive activity with the read-only Google token (see
-`../AGENTS.md` → _Hard rules_; same `$TOK`). List what changed since your
-bookmark, e.g. files by recent modification:
+Recent Google Drive activity is a **window into what the operator is currently
+working on** — use it both to orient (what's going on this week, what they care
+about right now) and to spot concrete ways to help. Read it with the read-only
+Google token (see `../instructions.md` → _Hard rules_; same `$TOK`): list what
+changed since your bookmark, e.g. files by recent modification
 `curl -s -H "Authorization: Bearer $TOK" 'https://www.googleapis.com/drive/v3/files?orderBy=modifiedTime desc&fields=files(id,name,modifiedTime,owners,shared,webViewLink)&pageSize=50'`,
 or the Drive Activity API
 (`https://driveactivity.googleapis.com/v2/activity:query`) for a change feed.
-Look for:
+
+Let it inform your wider reasoning — a burst of edits on a doc or project tells
+you what to cross-reference elsewhere (calendar, mail) and where help is welcome
+— and look for direct findings:
 
 - docs shared with the operator that look like they await a read or reply
 - files implying a task (a draft to finish, a form/agreement to sign, a doc to
   review before a meeting — cross-reference `calendar_prep`)
 - comments or @-mentions directed at the operator
+- a project they're actively editing where you could offer to draft, summarize,
+  research, or prepare the next step
 - stale shared drafts worth closing out
 
 File one item per finding, referencing the file by name + `webViewLink` + last

--- a/haku/base/playbooks/gmail_triage.md
+++ b/haku/base/playbooks/gmail_triage.md
@@ -1,6 +1,6 @@
 # gmail_triage (example)
 
-Read Gmail with the read-only token (see `../AGENTS.md` → _Hard rules_). List new
+Read Gmail with the read-only token (see `../instructions.md` → _Hard rules_). List new
 mail since your bookmark (on the first run, a window like `newer_than:7d`):
 `curl -s -H "Authorization: Bearer $TOK" 'https://gmail.googleapis.com/gmail/v1/users/me/messages?q=newer_than:7d'`,
 then fetch each with `.../messages/{id}?format=metadata` (use `format=full` only

--- a/haku/base/playbooks/keep_notes.md
+++ b/haku/base/playbooks/keep_notes.md
@@ -1,7 +1,7 @@
 # keep_notes (example)
 
 Scan Google Keep for captured-but-unhandled notes with the read-only Google
-token (see `../AGENTS.md` → _Hard rules_; same `$TOK`). List notes:
+token (see `../instructions.md` → _Hard rules_; same `$TOK`). List notes:
 `curl -s -H "Authorization: Bearer $TOK" 'https://keep.googleapis.com/v1/notes'`,
 and focus on what's new or changed since your bookmark. Look for:
 


### PR DESCRIPTION
Make Haku use recent Google Drive activity (when it has Drive access) as a
window into what the operator is currently doing — to orient on what's going on
and spot where it can help — not just as a discrete task-finder.

- **`instructions.md` → How you reason:** adds the orientation principle —
  recent-activity signals (Drive edits, calendar, and later ActivityWatch) are a
  window into the operator's current context, so use them to orient and to spot
  where help is welcome — plus a Drive example in the reasoning list.
- **`drive_activity` playbook:** reframed around orienting + offering help
  (draft, summarize, research, prep the next step) alongside the existing
  finding types, keeping the Drive API mechanics and the
  `drive.readonly`/`drive.activity.readonly` scope caveat (still gated on the
  token having Drive scope — `TODO.md` tracks wiring it).
- **Drive-by fix:** the `gmail_triage`, `calendar_prep`, `keep_notes`, and
  `drive_activity` playbooks still pointed at `../AGENTS.md` for the Hard rules;
  the manual moved to `instructions.md`, so repointed all four.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFbZ5fLRn9XFQx7qV7vBP8)_