### PR TITLE
airlock: request drive.activity.readonly on the Google grant

### DIFF
--- a/cluster/k8s/agents/airlock/config.yaml
+++ b/cluster/k8s/agents/airlock/config.yaml
@@ -45,6 +45,7 @@ oauth:
       scopes:
         - https://www.googleapis.com/auth/gmail.readonly
         - https://www.googleapis.com/auth/drive.readonly
+        - https://www.googleapis.com/auth/drive.activity.readonly
         - https://www.googleapis.com/auth/calendar.readonly
         - https://www.googleapis.com/auth/contacts.readonly
         - https://www.googleapis.com/auth/documents.readonly

--- a/haku/TODO.md
+++ b/haku/TODO.md
@@ -22,11 +22,12 @@ from `haku-sandbox`, plus an example playbook in `base/playbooks/`.
   (currently suspended; see `cluster/` ActivityWatch). Useful for time-use
   patterns and "what changed in your routine" reasoning (e.g. cross-referencing
   CPAP weekend leakage with weekend activity).
-- **Google Drive + Keep scopes** — add `drive.readonly`
-  (+ `drive.activity.readonly`) and `keep.readonly` to the airlock
-  `google-access-token` grant so the `drive_activity` / `keep_notes` playbooks
-  work (today they 403 and log the gap). Other Google products (Docs, Tasks)
-  light up the same way as their scopes are added.
+- **Google Keep scope** — add `keep.readonly` to the airlock
+  `google-access-token` grant so the `keep_notes` playbook works (today it 403s
+  and logs the gap). `drive.readonly` + `drive.activity.readonly` are already in
+  the grant (the `drive_activity` playbook works once the token is re-consented to
+  pick up the added scope). Other Google products (Docs, Tasks) light up the same
+  way as their scopes are added.
 
 ## Read-only filter facades (sources designed, not yet wired)
 


### PR DESCRIPTION
Adds `https://www.googleapis.com/auth/drive.activity.readonly` to airlock's
`google` OAuth provider scopes (in `cluster/k8s/agents/airlock/config.yaml`),
alongside the existing `drive.readonly`. This lets the `google-access-token`
(mirrored into `haku-sandbox`) drive Haku's `drive_activity` playbook via the
Drive Activity API, on top of the plain Drive read it already has.

**Operator step:** the existing token was issued under the old scope set, so it
needs a **one-time re-consent** through airlock's Google OAuth flow
(`https://airlock.allegedly.works/oauth/callback/google`) to pick up the added
scope; until then the Activity API will 403 and Haku logs the gap (as the
playbook already handles).

Also updates `haku/TODO.md`: `drive.readonly` + `drive.activity.readonly` are now
in the grant; `keep.readonly` remains the open scope item.

No egress change needed — Haku calls `driveactivity.googleapis.com` from its web
home, already covered by the `*.googleapis.com` allowlist; airlock only does the
token exchange.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFbZ5fLRn9XFQx7qV7vBP8)_