### PR TITLE
haku/base: ducktape_git_review example playbook

### DIFF
--- a/haku/base/instructions.md
+++ b/haku/base/instructions.md
@@ -284,7 +284,8 @@ rendered view** — there is no separate `items.md`. Keep it current every run:
 [`gmail_triage`](playbooks/gmail_triage.md),
 [`calendar_prep`](playbooks/calendar_prep.md),
 [`drive_activity`](playbooks/drive_activity.md),
-[`keep_notes`](playbooks/keep_notes.md)), **not a closed set**. Read them
+[`keep_notes`](playbooks/keep_notes.md),
+[`ducktape_git_review`](playbooks/ducktape_git_review.md)), **not a closed set**. Read them
 for the pattern, run the ones whose sources you have, and develop your own over
 time (record those in your `memory/`, not base). Some sources are designed but
 not yet wired — if a tool isn't on your wire, don't use it; note the gap in your

--- a/haku/base/playbooks/README.md
+++ b/haku/base/playbooks/README.md
@@ -9,8 +9,9 @@ read-only base).
 
 Available now: [`plaid_anomalies`](plaid_anomalies.md),
 [`gmail_triage`](gmail_triage.md), [`calendar_prep`](calendar_prep.md),
-[`drive_activity`](drive_activity.md), [`keep_notes`](keep_notes.md). The Google
-ones share the read-only Google token; other Google products (Docs, Tasks, …) are
+[`drive_activity`](drive_activity.md), [`keep_notes`](keep_notes.md), and
+[`ducktape_git_review`](ducktape_git_review.md) (your ducktape checkout — always
+reachable). The Google ones share the read-only Google token; other Google products (Docs, Tasks, …) are
 fair game the same way when the token carries their scope — if a call 403s, the
 scope isn't granted, so note the gap in your log and move on.
 

--- a/haku/base/playbooks/ducktape_git_review.md
+++ b/haku/base/playbooks/ducktape_git_review.md
@@ -1,0 +1,23 @@
+# ducktape_git_review (example)
+
+You have the **ducktape repo** checked out (your base lives in it, and you already
+`git log` it to adopt base updates). Its recent history is a rich source of
+follow-up work the operator may want surfaced. Look at roughly the last 1–2 weeks
+(`git -C <ducktape> log --since='2 weeks ago' --stat`, and `git log -p` where the
+diff matters), resuming from a bookmark in `memory/` so you don't relitigate:
+
+- **New `TODO`/`FIXME`/`XXX`** in code, and new entries in `TODO.md` / `PLAN.md` /
+  `plans/` — especially ones that read like the author meant to come back.
+- **Commits that flag their own follow-up** — "quick fix", "temporary", "stop-gap",
+  "revert once …", "will clean up", or a `CLEANUP(`/tombstone marker whose stated
+  condition now looks met.
+- **Reverts and immediate re-fixes** — something that broke and may still be fragile.
+- **Half-finished threads** — a feature whose commits trail off, a `plans/` doc
+  added but never tombstoned, a migration started but not carried across all callers.
+
+These rarely carry a deadline, so they're backlog-tier `value` unless something
+makes one urgent. File `suggestion` items for "worth doing", and `prepared_prompt`
+items where you can frame a concrete change for a full-access agent (name the files,
+the commit, and the desired end state). Put evidence in `body`: commit SHA(s), file
+paths, the line. Skip anything a later commit already resolved, and don't refile
+items you've filed before (check your dedup keys / `memory/`).


### PR DESCRIPTION
Standalone, infra-free example playbook for Haku.

Scan recent ducktape git history (new `TODO`/`FIXME`, new `TODO.md`/`PLAN.md`
entries, follow-up-flagged commits, reverts, half-finished threads) as a source
of proposal-worthy items. Haku already has the ducktape checkout and already
runs `git log` for base-sync, so this needs no infrastructure — it's purely a
new example playbook plus the instructions/README index entries.

Split out of #2373 (the Tana facade work) so it can land independently of the
still-in-design Tana read-only connection.

BAZEL_TEST_INVOCATIONS=none: docs-only — haku/base markdown; no Bazel target depends on haku/

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KgozbuL2YgSfcnFfe4h944)_