### PR TITLE
airlock/haku: add Tasks + Slides read scopes (skip Keep/Photos)

### DIFF
--- a/cluster/k8s/agents/airlock/config.yaml
+++ b/cluster/k8s/agents/airlock/config.yaml
@@ -47,9 +47,11 @@ oauth:
         - https://www.googleapis.com/auth/drive.readonly
         - https://www.googleapis.com/auth/drive.activity.readonly
         - https://www.googleapis.com/auth/calendar.readonly
+        - https://www.googleapis.com/auth/tasks.readonly
         - https://www.googleapis.com/auth/contacts.readonly
         - https://www.googleapis.com/auth/documents.readonly
         - https://www.googleapis.com/auth/spreadsheets.readonly
+        - https://www.googleapis.com/auth/presentations.readonly
         - https://www.googleapis.com/auth/youtube.readonly
       redirect_uri: https://airlock.allegedly.works/oauth/callback/google
       refresh_secret:

--- a/haku/TODO.md
+++ b/haku/TODO.md
@@ -44,12 +44,13 @@ port-forward` from a sandbox pod using the reflected `haku-tana-ro-token`,
   (currently suspended; see `cluster/` ActivityWatch). Useful for time-use
   patterns and "what changed in your routine" reasoning (e.g. cross-referencing
   CPAP weekend leakage with weekend activity).
-- **Google Keep scope** — add `keep.readonly` to the airlock
-  `google-access-token` grant so the `keep_notes` playbook works (today it 403s
-  and logs the gap). `drive.readonly` + `drive.activity.readonly` are already in
-  the grant (the `drive_activity` playbook works once the token is re-consented to
-  pick up the added scope). Other Google products (Docs, Tasks) light up the same
-  way as their scopes are added.
+- **Google scopes** — the airlock grant now carries Gmail, Calendar, Drive
+  (+ activity), Contacts, Docs, Sheets, Slides, Tasks, and YouTube read-only.
+  Re-consent at airlock's OAuth Providers page after adding scopes for the live
+  token to pick them up (the Drift row flags what's missing). Google **Keep** is
+  not pursuable on this account — its API is Workspace-only and this is a personal
+  Google account — so `keep_notes` stays an illustrative example only. Further
+  read-only Google scopes light up the same way as added.
 
 ## Read-only filter facades (sources designed, not yet wired)
 

--- a/haku/base/instructions.md
+++ b/haku/base/instructions.md
@@ -112,11 +112,11 @@ can read exactly what you've been granted rather than guessing:
 
 **Credentials you have today** (all in `haku-sandbox`, all read-only):
 
-| Purpose                      | Secret                  | Key fields                                 |
-| ---------------------------- | ----------------------- | ------------------------------------------ |
-| State repo (write)           | `haku-state-git-write`  | `username`, `password`, `repo_url`         |
-| Plaid Postgres (read-only)   | `plaid-mcp-db-readonly` | `DATABASE_URL` (+ `username`/`password`/…) |
-| Gmail + Calendar (read-only) | `google-access-token`   | `access_token`                             |
+| Purpose                    | Secret                  | Key fields                                        |
+| -------------------------- | ----------------------- | ------------------------------------------------- |
+| State repo (write)         | `haku-state-git-write`  | `username`, `password`, `repo_url`                |
+| Plaid Postgres (read-only) | `plaid-mcp-db-readonly` | `DATABASE_URL` (+ `username`/`password`/…)        |
+| Google read-only APIs      | `google-access-token`   | `access_token` (Gmail, Calendar, Drive, Tasks, …) |
 
 More sources arrive the same way: a new read-only credential shows up as a
 secret in `haku-sandbox` and a row under `cluster/k8s/haku/`. Model calls go
@@ -284,6 +284,7 @@ rendered view** — there is no separate `items.md`. Keep it current every run:
 [`gmail_triage`](playbooks/gmail_triage.md),
 [`calendar_prep`](playbooks/calendar_prep.md),
 [`drive_activity`](playbooks/drive_activity.md),
+[`tasks`](playbooks/tasks.md),
 [`keep_notes`](playbooks/keep_notes.md),
 [`ducktape_git_review`](playbooks/ducktape_git_review.md)), **not a closed set**. Read them
 for the pattern, run the ones whose sources you have, and develop your own over

--- a/haku/base/playbooks/README.md
+++ b/haku/base/playbooks/README.md
@@ -9,11 +9,13 @@ read-only base).
 
 Available now: [`plaid_anomalies`](plaid_anomalies.md),
 [`gmail_triage`](gmail_triage.md), [`calendar_prep`](calendar_prep.md),
-[`drive_activity`](drive_activity.md), [`keep_notes`](keep_notes.md), and
+[`drive_activity`](drive_activity.md), [`tasks`](tasks.md),
+[`keep_notes`](keep_notes.md), and
 [`ducktape_git_review`](ducktape_git_review.md) (your ducktape checkout — always
-reachable). The Google ones share the read-only Google token; other Google products (Docs, Tasks, …) are
-fair game the same way when the token carries their scope — if a call 403s, the
-scope isn't granted, so note the gap in your log and move on.
+reachable). The Google ones share the read-only Google token; other Google
+products (Docs, Slides, …) are fair game the same way when the token carries their
+scope — if a call 403s, the scope isn't granted, so note the gap in your log and
+move on.
 
 Designed but **not yet wired** — the tools aren't on your wire; don't attempt
 them, just note the gap in your log if one appears: PostScanMail (unopened mail →

--- a/haku/base/playbooks/tasks.md
+++ b/haku/base/playbooks/tasks.md
@@ -1,0 +1,18 @@
+# tasks (example)
+
+Scan Google Tasks for overdue and stale to-dos with the read-only Google token
+(see `../instructions.md` → _Hard rules_; same `$TOK`). List your task lists, then
+each list's open tasks:
+`curl -s -H "Authorization: Bearer $TOK" 'https://tasks.googleapis.com/tasks/v1/users/@me/lists'`,
+then `.../lists/{tasklistId}/tasks?showCompleted=false&showHidden=false`. Look for:
+
+- tasks past their `due` date (overdue)
+- tasks untouched for a long time (`updated` far in the past) — stale, worth
+  doing, rescheduling, or dropping
+- vague one-line captures that imply a real next step
+- things already done elsewhere that can just be closed
+
+A long tail of stale entries is itself a finding — prefer one item proposing a
+cleanup pass over one item per cruft task. File items referencing the task by
+title + list + `due`/`updated`. Needs the `tasks.readonly` scope; if a call
+returns 403, the scope isn't granted — note the gap in your log and move on.


### PR DESCRIPTION
Batches the two clean Google read scopes onto airlock's grant, per your picks
(skip Keep — Workspace-only on a personal account; skip Photos — Google removed
broad `photoslibrary.readonly` for general apps in 2025).

- **`config.yaml`:** add `tasks.readonly` and `presentations.readonly` to the
  `google` provider scopes (alongside the existing Gmail/Drive/Calendar/Contacts/
  Docs/Sheets/YouTube + the recently-added `drive.activity.readonly`).
- **New `tasks` playbook:** surface overdue/stale Google Tasks; explicitly
  suggests one cleanup-pass item for a long stale tail (the "bunch of stale
  entries" you mentioned) rather than one item per cruft task. Listed in
  `instructions.md` + `playbooks/README.md`.
- **Manual:** generalized the credential row to "Google read-only APIs".
- **`TODO.md`:** Tasks/Slides done; recorded that **Keep is not pursuable** on
  this account (Keep API is Workspace-only; personal Google account) — `keep_notes`
  stays an illustrative example only.

**Operator step:** re-consent at airlock's OAuth Providers page (Reconnect) so the
live token picks up `tasks.readonly` + `presentations.readonly`; the Drift row
will show them `missing` until then. (Batched with the pending
`drive.activity.readonly` re-consent, so it's one reconnect for all three.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFbZ5fLRn9XFQx7qV7vBP8)_