### PR TITLE
kube-api-proxy: support WebSocket/SPDY upgrades (fix kubectl exec/attach/port-forward)

### DIFF
--- a/cluster/k8s/kube-api-proxy/service.yaml
+++ b/cluster/k8s/kube-api-proxy/service.yaml
@@ -17,6 +17,14 @@ data:
     events { worker_connections 128; }
     http {
       access_log /dev/stderr;
+      # kubectl exec/attach/port-forward open an HTTP Upgrade (WebSocket/SPDY) to
+      # the apiserver. By default nginx proxies as HTTP/1.0 and strips the hop-by-hop
+      # Upgrade/Connection headers, so the apiserver receives a plain GET to /exec and
+      # returns 400 "Upgrade request required". The map + directives below fix that.
+      map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      close;
+      }
       server {
         listen 8080;
         location / {
@@ -29,6 +37,10 @@ data:
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
           # Pass through all headers including Authorization
           proxy_pass_request_headers on;
+          # WebSocket/SPDY upgrade for kubectl exec/attach/port-forward:
+          proxy_http_version 1.1;
+          proxy_set_header Upgrade $http_upgrade;
+          proxy_set_header Connection $connection_upgrade;
           proxy_read_timeout 300s;
           proxy_send_timeout 300s;
         }
@@ -41,6 +53,8 @@ metadata:
   name: kubeapi-proxy
   namespace: default
   annotations:
+    # Restart pods when kubeapi-proxy-config changes (subPath mounts don't hot-reload).
+    reloader.stakater.com/auto: "true"
     description: |
       nginx reverse proxy: HTTP 8080 → HTTPS kubernetes.default.svc:443.
       Bridges the gap between Cilium Gateway (TLS terminate) and the

--- a/haku/claude_web_env/run.md
+++ b/haku/claude_web_env/run.md
@@ -24,8 +24,15 @@ surface for anything you can't reach from here directly.
   ducktape repo you have checked out (`cluster/k8s/haku/rbac/` = your perimeter).
   See the credential table in `haku/base/instructions.md`.
 - Cluster-internal data (e.g. Plaid Postgres) isn't reachable from here — run a
-  pod **in `haku-sandbox`** (`kubectl run …`) to query it, as the manual
-  describes.
+  pod **in `haku-sandbox`** to query it, as the manual describes. **Gotcha:**
+  `kubectl exec`/`attach` (and `kubectl run -i`) fail with an empty
+  `Error from server:` — the L7 proxy in front of `kubeapi.allegedly.works` drops
+  the exec stream; `kubectl logs`/`get`/`apply`/`delete` are fine. So make the SQL
+  the pod's **command** and read results from logs: put the SQL in a `ConfigMap`,
+  run a `postgres:16` pod whose command is `psql "$DATABASE_URL" -f /sql/q.sql`
+  (DSN via `envFrom` the `plaid-mcp-db-readonly` secret, never on the command
+  line), `restartPolicy: Never`, poll `.status.phase` until `Succeeded`, then
+  `kubectl logs` it. Delete the pod after (20-pod quota).
 
 ## Continuity — you are restarted from this same prompt
 

--- a/haku/claude_web_env/run.md
+++ b/haku/claude_web_env/run.md
@@ -25,9 +25,12 @@ surface for anything you can't reach from here directly.
   See the credential table in `haku/base/instructions.md`.
 - Cluster-internal data (e.g. Plaid Postgres) isn't reachable from here — run a
   pod **in `haku-sandbox`** to query it, as the manual describes. **Gotcha:**
-  `kubectl exec`/`attach` (and `kubectl run -i`) fail with an empty
-  `Error from server:` — the L7 proxy in front of `kubeapi.allegedly.works` drops
-  the exec stream; `kubectl logs`/`get`/`apply`/`delete` are fine. So make the SQL
+  `kubectl exec`/`attach` (and `kubectl run -i`) fail: the proxy in front of
+  `kubeapi.allegedly.works` rejects HTTP connection upgrades. kubectl 1.34 tries a
+  WebSocket upgrade first and gets `websocket: bad handshake (400)`, then falls back
+  to SPDY, which also fails — surfacing as an empty `Error from server:` (forcing
+  either protocol via `KUBECTL_REMOTE_COMMAND_WEBSOCKETS` doesn't help).
+  `kubectl logs`/`get`/`apply`/`delete` are fine. So make the SQL
   the pod's **command** and read results from logs: put the SQL in a `ConfigMap`,
   run a `postgres:16` pod whose command is `psql "$DATABASE_URL" -f /sql/q.sql`
   (DSN via `envFrom` the `plaid-mcp-db-readonly` secret, never on the command


### PR DESCRIPTION
## Problem

`kubectl exec` / `attach` / `port-forward` fail through `kubeapi.allegedly.works`
(the route Claude Code web sandboxes use) with an empty `Error from server:`.
With kubectl 1.34 (WebSocket-first since 1.31) the verbose trace is:

```
RemoteCommand fallback: unable to upgrade streaming request: websocket: bad handshake (400 Bad Request)
```

→ kubectl falls back to SPDY → that also fails → empty `Error from server:`.
Plain `get`/`logs`/`apply` work fine, so it's specifically the HTTP `Upgrade`
path that breaks.

## Root cause

The `kubeapi-proxy` nginx (`cluster/k8s/kube-api-proxy/service.yaml`) is missing
WebSocket-upgrade configuration. Its `location /` had `proxy_pass` but no
`proxy_http_version 1.1` and no `Upgrade`/`Connection` set-headers, so nginx
proxies to the apiserver as HTTP/1.0 and **strips the hop-by-hop `Upgrade` /
`Connection` headers**. The apiserver then receives a plain `GET` to `/exec` and
returns `400 "Upgrade request required"`. (`kubectl logs` survives because it's a
chunked HTTP response, not an upgrade.)

## How it was isolated (it's cluster-side, not the egress proxy)

1. The TLS cert for `kubeapi.allegedly.works` is `CN=*.allegedly.works` issued by
   `O=Anthropic; CN=Egress Gateway SDS Issuing CA` — confirming Anthropic's egress
   is a TLS-terminating MITM (as the route docs note) — but it forwards fine
   (`get`/`logs`/`apply` work; it speaks both HTTP/1.1 and HTTP/2).
2. A full-path WebSocket-upgrade probe to `/exec` returns `400` carrying an
   apiserver `Audit-Id` (only kube-apiserver stamps that) with auth accepted — so
   the request reaches the apiserver with the upgrade headers already stripped.
3. An **in-cluster** probe straight to `kubeapi-proxy.default.svc:8080` —
   bypassing *both* Anthropic's egress *and* the Cilium Gateway — **still** returns
   `400` + `Audit-Id`. With only nginx in the path, nginx is provably the stripper.

## Fix

- Add `proxy_http_version 1.1`, `proxy_set_header Upgrade $http_upgrade`, and
  `proxy_set_header Connection $connection_upgrade` (with the standard
  `map $http_upgrade $connection_upgrade` block) — the textbook nginx WebSocket
  config. This covers SPDY too (same `Upgrade` mechanism).
- Add `reloader.stakater.com/auto: "true"` to the Deployment so the pods restart
  on the ConfigMap change (the config is mounted via `subPath`, which does **not**
  hot-reload).

`pre-commit` (incl. `kubeconform`) passes.

## Verification

I can't apply this to the live cluster from the sandbox (RBAC is `haku-sandbox`
only). After merge + Flux reconcile (Reloader will roll the `kubeapi-proxy`
pods), `kubectl exec` against `kubeapi.allegedly.works` should return `101
Switching Protocols` and stream. Evidence above shows nginx is the sole stripper
(the egress/Cilium forward the upgrade as far as nginx), so this should be
sufficient; if anything remained, the next suspect would be Cilium's Envoy
websocket config.

## Also in this branch

Two `haku/claude_web_env/run.md` commits documenting this exact failure and the
`kubectl logs`-capture workaround Haku uses for Plaid queries in the meantime.
Those notes can be trimmed once exec is confirmed working post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJgMq6mcsAMrPAUJ1frmKC

---
_Generated by [Claude Code](https://claude.ai/code/session_01SJgMq6mcsAMrPAUJ1frmKC)_