### PR TITLE
airlock: don't blank-page when the OIDC callback fails or is reloaded

### DIFF
--- a/airlock/frontend/main.ts
+++ b/airlock/frontend/main.ts
@@ -3,9 +3,18 @@ import { mount } from "svelte";
 import App from "./App.svelte";
 import { isAuthCallback, handleAuthCallback } from "./auth.ts";
 
-// Handle OIDC callback before mounting the app.
+// Handle the OIDC callback before mounting the app. A failed or re-loaded
+// callback (single-use `code` already spent, PKCE state gone from sessionStorage)
+// must NOT block the mount — otherwise `#app` stays empty and the page is a blank
+// dead-end that reloading only re-breaks. On error, strip the stale code/state
+// from the URL and mount anyway; App re-initiates a clean login.
 if (isAuthCallback()) {
-  await handleAuthCallback();
+  try {
+    await handleAuthCallback();
+  } catch (e) {
+    console.error("OIDC callback failed; restarting login", e);
+    window.history.replaceState({}, "", "/");
+  }
 }
 
 const root = document.getElementById("app");


### PR DESCRIPTION
**Symptom:** `https://airlock.allegedly.works/auth/callback?code=…&state=…` renders a blank page, and reloading keeps it blank (operator can't log into the UI).

**Root cause:** `frontend/main.ts` did an unguarded top-level `await handleAuthCallback()` before `mount(App)`. `oidc-client-ts`'s `signinRedirectCallback()` throws whenever `/auth/callback` is re-loaded (the single-use `code` is spent and the PKCE state is gone from `sessionStorage`), or if a token exchange fails. On a throw, the `mount(App)` line never runs → `#app` stays empty → permanent blank dead-end that reloading only re-breaks on the stale `code`. (Pre-existing — image unchanged; it surfaced when an operator session expired and hit a fresh callback.)

**Fix:** guard the callback — on error, log it, strip the stale `code`/`state` from the URL (`replaceState` to `/`), and `mount(App)` regardless. App then re-initiates a clean PKCE login instead of dead-ending.

```js
if (isAuthCallback()) {
  try { await handleAuthCallback(); }
  catch (e) { console.error("OIDC callback failed; restarting login", e); window.history.replaceState({}, "", "/"); }
}
mount(App, { target: root });
```

Requires an airlock image rebuild + Flux redeploy to take effect. Operator workaround until then: open the bare `https://airlock.allegedly.works/` (not the callback URL) in a fresh window; clear the site's `sessionStorage` if it still dead-ends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFbZ5fLRn9XFQx7qV7vBP8)_