### PR TITLE
haku/base: tana_review playbook (read-only Tana via tana-mcp-ro)

### DIFF
--- a/haku/TODO.md
+++ b/haku/TODO.md
@@ -16,7 +16,8 @@ from `haku-sandbox`, plus an example playbook in `base/playbooks/`.
   Tana MCP, exposes only read tools (default-deny allowlist via the generic
   facade's `MCP_FACADE_TOOLS__ALLOW`), injects the Tana PAT server-side so
   callers never see it, and is gated by a static bearer `haku-tana-ro-token`
-  reflected into `haku-sandbox`. Remaining **Haku-side wiring (deferred)**:
+  reflected into `haku-sandbox`, and the `tana_review` playbook + the
+  `haku-tana-ro-token` credentials row are wired into `base/`. Remaining:
   - Decide how Haku reaches it: an in-cluster MCP client / `kubectl
 port-forward` from a sandbox pod using the reflected `haku-tana-ro-token`,
     vs. threading the Claude Code harness's MCP client to
@@ -27,15 +28,12 @@ port-forward` from a sandbox pod using the reflected `haku-tana-ro-token`,
     `toEntities: cluster`; no new CNP needed for that hop.
   - Confirm the read-only allowlist against the live `tools/list`; settle the
     `get_or_create_calendar_node` exclusion (it can create a daily node).
-  - Add a `tana` playbook — read recent daily/calendar notes + recently-edited
-    nodes (synthesized from `search_nodes` + calendar-node traversal) → stale
-    tasks, captured notes implying action — and a credentials-table row in
-    `base/instructions.md`.
-- **ducktape git history** — Haku already has the ducktape checkout and runs
-  `git log` for base-sync; add a `ducktape_git_review` playbook that scans
-  recent history (new TODO/FIXME, new `TODO.md`/`PLAN.md` entries,
-  follow-up-flagged commits, reverts, half-finished threads) → proposals. No
-  infra; playbook + `base/instructions.md` row only.
+  - **Future (PLAN north star):** retire the pod dance by wiring Tana into the
+    harness — expose `tana-mcp-ro` behind a bearer-gated route and give Haku
+    `mcp__tana_ro__*` tools natively (the `kubectl-local` stdio-MCP pattern, but
+    the facade is already HTTP so a `.mcp.json` `http` entry suffices), with the
+    bearer threaded from the reflected secret. Then `tana_review` drops its
+    connection section.
 - **Cluster Forgejo repos** — read access to `ducktape` and `gaffer-private`
   if/when they're migrated or mirrored to the cluster Forgejo: grant the `haku`
   Forgejo user read, add a repo-activity playbook (open PRs/issues/review

--- a/haku/base/instructions.md
+++ b/haku/base/instructions.md
@@ -117,6 +117,7 @@ can read exactly what you've been granted rather than guessing:
 | State repo (write)         | `haku-state-git-write`  | `username`, `password`, `repo_url`                |
 | Plaid Postgres (read-only) | `plaid-mcp-db-readonly` | `DATABASE_URL` (+ `username`/`password`/…)        |
 | Google read-only APIs      | `google-access-token`   | `access_token` (Gmail, Calendar, Drive, Tasks, …) |
+| Tana (read-only MCP)       | `haku-tana-ro-token`    | `token` (bearer for the `tana-mcp-ro` facade)     |
 
 More sources arrive the same way: a new read-only credential shows up as a
 secret in `haku-sandbox` and a row under `cluster/k8s/haku/`. Model calls go
@@ -213,6 +214,13 @@ below.
   even if attempted. Call the Gmail/Calendar REST APIs with
   `Authorization: Bearer $TOK`. There is no MCP server; `curl` goes through the
   egress proxy transparently.
+- **Tana: read-only MCP, from a `haku-sandbox` pod.** The operator's Tana
+  workspace is reachable only through the cluster-internal `tana-mcp-ro` facade,
+  which exposes read tools only (writes are hidden and rejected) and holds the
+  Tana PAT itself — you never see it. Reach it from a pod (command + `kubectl
+logs`, not `exec`/`port-forward`) carrying the `haku-tana-ro-token` bearer; the
+  facade is newly deployed, so confirm it's on your wire before relying on it. See
+  `playbooks/tana_review.md`.
 - Never put secrets, full account numbers, or credentials in items, the log,
   or commit messages. Reference transactions by date + merchant + amount, mail
   and events by subject/title + sender + date (never raw bodies, never the
@@ -286,7 +294,8 @@ rendered view** — there is no separate `items.md`. Keep it current every run:
 [`drive_activity`](playbooks/drive_activity.md),
 [`tasks`](playbooks/tasks.md),
 [`keep_notes`](playbooks/keep_notes.md),
-[`ducktape_git_review`](playbooks/ducktape_git_review.md)), **not a closed set**. Read them
+[`ducktape_git_review`](playbooks/ducktape_git_review.md),
+[`tana_review`](playbooks/tana_review.md)), **not a closed set**. Read them
 for the pattern, run the ones whose sources you have, and develop your own over
 time (record those in your `memory/`, not base). Some sources are designed but
 not yet wired — if a tool isn't on your wire, don't use it; note the gap in your

--- a/haku/base/playbooks/README.md
+++ b/haku/base/playbooks/README.md
@@ -17,6 +17,11 @@ products (Docs, Slides, …) are fair game the same way when the token carries t
 scope — if a call 403s, the scope isn't granted, so note the gap in your log and
 move on.
 
+[`tana_review`](tana_review.md) (read-only Tana via the cluster-internal
+`tana-mcp-ro` facade) is **newly deployed** — its `haku-tana-ro-token` secret and
+pod-based connection aren't paved yet, so confirm it's on your wire before relying
+on it (and record the working recipe in your `memory/`).
+
 Designed but **not yet wired** — the tools aren't on your wire; don't attempt
 them, just note the gap in your log if one appears: PostScanMail (unopened mail →
 open/discard), Grocy stock (expiring / below-minimum). Each is blocked until it

--- a/haku/base/playbooks/tana_review.md
+++ b/haku/base/playbooks/tana_review.md
@@ -1,0 +1,46 @@
+# tana_review (example)
+
+The operator's Tana workspace — daily notes, captured tasks, project nodes — is
+full of things they meant to do and never closed out. You can read it (read-only)
+through the `tana-mcp-ro` facade, which exposes only Tana's read tools
+(`search_nodes`, `read_node`, `get_children`, `open_node`, `list_tags`,
+`list_workspaces`, `get_tag_schema`); every write tool is hidden and rejected, and
+the Tana PAT stays server-side, so you never see it.
+
+## Reaching it
+
+`tana-mcp-ro` is cluster-internal
+(`tana-mcp-ro.tana-mcp.svc.cluster.local:8765/mcp`), so your home can't reach it —
+drive it from a `haku-sandbox` pod the way you query Plaid: bake the work into the
+pod's **command** and read results from `kubectl logs` (`exec`/`port-forward` don't
+work through the API gateway). Mount the bearer from the `haku-tana-ro-token` secret
+as an env var (`secretKeyRef`, so it never lands on a command line) and have the pod
+speak MCP over Streamable HTTP with `Authorization: Bearer $TOKEN` — e.g. a `python`
+pod running a small `fastmcp` client, or a script doing the JSON-RPC `initialize` →
+`tools/call` handshake.
+
+This connection isn't paved yet — `tana-mcp-ro` is newly deployed. On first use,
+confirm it's on your wire (the secret exists, the tools list is non-empty); if not,
+note the gap in your log and move on. Once you find a pod recipe that works, record
+it in `memory/` so later runs reuse it.
+
+## What to mine
+
+Resume from a bookmark in `memory/` (e.g. "tana: through 2026-06-18") and look at
+what's recent in the operator's graph:
+
+- **Recent daily notes** — walk the last ~1–2 weeks of daily/calendar nodes (find
+  them via `search_nodes`, then `get_children` to read them) for tasks the operator
+  jotted but never actioned: "follow up on X", "ask Y", half-captured ideas, items
+  with no owner or date.
+- **Recently-touched nodes** — `search_nodes` for what the operator edited lately; a
+  node they left open often implies intended next work, and is a window into what
+  they're focused on right now.
+- **Stale open tasks** — unchecked task nodes that have sat untouched, especially
+  ones implying a deadline or an easy win.
+
+Turn the worthwhile ones into items: `suggestion` for "do this", `prepared_prompt`
+where a full-access agent could carry it out (embed the node title + date + the
+desired outcome). Evidence in `body`: node title, date, a short quote — **never**
+dump raw node bodies. Skip anything already done elsewhere and anything you've filed
+before.


### PR DESCRIPTION
Adds the operator-framed `tana_review` example playbook (pulled from the facade PR #2373 so it could land on its own).

**What it does:** reads the operator's Tana workspace (recent daily/calendar notes, recently-touched nodes, stale open tasks) read-only through the cluster-internal `tana-mcp-ro` facade — driven from a `haku-sandbox` pod (command + `kubectl logs`, not `exec`/`port-forward`, which the API gateway doesn't proxy) with the reflected `haku-tana-ro-token` bearer. The connection isn't paved yet (facade newly deployed), so the playbook tells Haku to confirm reachability and record the working pod recipe in `memory/`.

**Wiring:** `instructions.md` (credentials row + Tana hard-rule bullet + playbook index) and `playbooks/README.md`. Trims `haku/TODO.md`: the playbook + creds row land here, the completed `ducktape_git_review` item is removed, and the remaining work is paving the pod connection — with a note that the **harness-MCP north star** (give Haku `mcp__tana_ro__*` natively) is the eventual replacement for the pod dance.

Docs-only; no Bazel target depends on `haku/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KgozbuL2YgSfcnFfe4h944

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgozbuL2YgSfcnFfe4h944)_