### PR TITLE
docs: kubectl exec works again post-#2376 — de-stale Haku notes + lessons-learned

### DIFF
--- a/cluster/docs/lessons_learned/2026_06_18_kubectl_exec_websocket_kubeapi_proxy.md
+++ b/cluster/docs/lessons_learned/2026_06_18_kubectl_exec_websocket_kubeapi_proxy.md
@@ -1,0 +1,47 @@
+# 2026-06-18 — kubectl exec/attach/port-forward broken through kubeapi.allegedly.works
+
+## Symptom
+
+`kubectl exec` / `attach` / `port-forward` against `kubeapi.allegedly.works` (the
+bearer-JWT TLS-terminate route Claude Code web sandboxes use) failed with an empty
+`Error from server:`. Ordinary verbs (`get`/`logs`/`apply`/`delete`) worked.
+
+With kubectl ≥1.31 (WebSocket-first exec) the verbose trace is `websocket: bad
+handshake (400)` → SPDY fallback also fails → empty error.
+
+## Root cause
+
+The `kubeapi-proxy` nginx (`cluster/k8s/kube-api-proxy/service.yaml`), which bridges
+the Cilium Gateway (TLS terminate) to the apiserver (HTTPS re-encrypt), was missing
+WebSocket-upgrade config. Default nginx proxies as HTTP/1.0 and drops the hop-by-hop
+`Upgrade`/`Connection` headers, so the apiserver received a plain `GET` to `/exec`
+and returned `400 "Upgrade request required"`. `kubectl logs` survived because it's a
+chunked HTTP response, not a connection upgrade.
+
+## How it was isolated (cluster-side, not Anthropic's egress)
+
+- The TLS cert for `kubeapi.allegedly.works` is issued by Anthropic's egress gateway
+  (a TLS-terminating MITM) — but it forwards fine; `get`/`logs`/`apply` all work.
+- A full-path exec probe returned `400` carrying an apiserver `Audit-Id` (only the
+  apiserver stamps that), with auth accepted → the request reached the apiserver
+  with the upgrade headers already stripped.
+- An in-cluster probe straight to `kubeapi-proxy.default.svc:8080` — bypassing both
+  the Anthropic egress and the Cilium Gateway — **still** returned `400 + Audit-Id`.
+  With only nginx in the path, nginx is the stripper.
+
+## Fix (PR #2376)
+
+Add to the nginx config: `proxy_http_version 1.1`, `proxy_set_header Upgrade
+$http_upgrade`, `proxy_set_header Connection $connection_upgrade`, and the
+`map $http_upgrade $connection_upgrade { default upgrade; '' close; }` block. Plus
+`reloader.stakater.com/auto: "true"` on the Deployment so the pods restart on the
+ConfigMap change (the config is mounted via `subPath`, which doesn't hot-reload).
+Verified: `kubectl exec` returns `101 Switching Protocols` and streams.
+
+## Takeaway
+
+Any nginx (or other L7 proxy) in front of the apiserver — or any WebSocket/SPDY
+backend — needs the explicit `proxy_http_version 1.1` + `Upgrade`/`Connection`
+directives. "Ordinary requests work but exec/attach/port-forward 400" — with an
+apiserver `Audit-Id` on the 400 — is the signature of an upstream proxy silently
+stripping the upgrade.

--- a/cluster/k8s/kube-api-proxy/README.md
+++ b/cluster/k8s/kube-api-proxy/README.md
@@ -70,3 +70,12 @@ kubeapi-https Service → apiserver :6443
 | `service.yaml`            | Wrapper Service + EndpointSlice with `appProtocol: https` for backend re-encryption    |
 | `kustomization.yaml`      | Flux kustomization root                                                                |
 | `flux-kustomization.yaml` | Flux Kustomization (no `dependsOn`)                                                    |
+
+## kubectl exec / WebSocket
+
+`kubectl exec`/`attach`/`port-forward` open an HTTP `Upgrade` (WebSocket, or SPDY
+on older clients). The `kubeapi-proxy` nginx must forward that upgrade
+(`proxy_http_version 1.1` together with the `Upgrade`/`Connection` headers — see
+`service.yaml`); otherwise the apiserver returns `400 "Upgrade request required"`.
+Root cause and isolation method for when this broke:
+<../../docs/lessons_learned/2026_06_18_kubectl_exec_websocket_kubeapi_proxy.md>.

--- a/haku/base/instructions.md
+++ b/haku/base/instructions.md
@@ -130,12 +130,12 @@ foothold — to run tools that aren't in your home, or to reach cluster-internal
 services your web home can't (the namespace's egress permits the cluster plus the
 allowlisted external hosts through its mitmproxy). That's how you query Plaid
 (see _Hard rules_). Mount the read-only secrets above into those pods as needed.
-**Drive these pods through their command + `kubectl logs`, not interactively:**
-`kubectl exec`, `attach`, and `port-forward` don't work through the API gateway
-(`kubeapi.allegedly.works`) — it doesn't proxy the streaming connection upgrade
-they need, so they fail with an empty `Error from server:`. Bake the work into
+**Drive these pods through their command + `kubectl logs`:** bake the work into
 the pod's command (or a ConfigMap-mounted script) and read the result from
-`kubectl logs`.
+`kubectl logs`. This keeps credentials off any command line and doesn't depend on
+a streaming connection. (`kubectl exec`/`attach`/`port-forward` work too — the
+`kubeapi-proxy` nginx forwards the WebSocket upgrade, `cluster/k8s/kube-api-proxy`
+— but command + logs is simplest.)
 Stay inside `haku-sandbox` — you have no access outside it; and the creds you can
 mount are read-only, so the compute is for gathering, not acting on the world.
 
@@ -193,20 +193,19 @@ below.
   the container's perimeter enforces this, these rules just describe it. Don't
   try to call mutating tools; they aren't on your wire.
 - **Plaid is read-only SQL, run from a `haku-sandbox` pod — via the pod's
-  command + `kubectl logs`, not `exec`.** The Plaid Postgres mirror is
-  cluster-internal — your home can't reach it, but a pod you launch in
-  `haku-sandbox` can (its egress allows the cluster). **`kubectl exec`,
-  `attach`, and `port-forward` do not work** through `kubeapi.allegedly.works`:
-  the API gateway proxies ordinary requests but not the streaming connection
-  upgrade those verbs need, so you get an empty `Error from server:`. So don't
-  start an idle pod and `exec` into it — make the query the pod's command and
-  read its logs. `kubectl apply` a short-lived `postgres`-image Pod
+  command + `kubectl logs`.** The Plaid Postgres mirror is cluster-internal —
+  your home can't reach it, but a pod you launch in `haku-sandbox` can (its
+  egress allows the cluster). Prefer the pod's command + `kubectl logs` over
+  `exec`: it keeps the DSN off any command line and doesn't depend on a streaming
+  connection. `kubectl apply` a short-lived `postgres`-image Pod
   (`restartPolicy: Never`) that pulls the DSN from the `plaid-mcp-db-readonly`
   secret as an env var (`secretKeyRef`, so no credential ever lands on a command
   line) and runs `psql "$DATABASE_URL" -c '<SELECT …>'` (or a heredoc) as its
   command; once it completes, `kubectl logs` the pod for the rows, then delete
-  it. (`kubectl run --env` can't pull from a secret, hence the manifest.) The
-  role is read-only — `SELECT` is all that works — no MCP server.
+  it. (`kubectl run --env` can't pull from a secret, hence the manifest.
+  `kubectl exec` works too now, though command-and-logs is simplest.) The role is
+  read-only — `SELECT` is all that works
+  — no MCP server.
 - **Gmail & Calendar: read-only via Google's REST API.** Get the token:
   `TOK=$(kubectl get secret google-access-token -o jsonpath='{.data.access_token}' | base64 -d)`
   — airlock's access token, whose scopes are all `.readonly`, so a write fails

--- a/haku/claude_web_env/run.md
+++ b/haku/claude_web_env/run.md
@@ -20,18 +20,11 @@ environment-neutral `haku/run.md`.
   ducktape repo you have checked out (`cluster/k8s/haku/rbac/` = your perimeter).
   See the credential table in `haku/base/instructions.md`.
 - Cluster-internal data (e.g. Plaid Postgres) isn't reachable from here — run a
-  pod **in `haku-sandbox`** to query it, as the manual describes. **Gotcha:**
-  `kubectl exec`/`attach` (and `kubectl run -i`) fail: the proxy in front of
-  `kubeapi.allegedly.works` rejects HTTP connection upgrades. kubectl 1.34 tries a
-  WebSocket upgrade first and gets `websocket: bad handshake (400)`, then falls back
-  to SPDY, which also fails — surfacing as an empty `Error from server:` (forcing
-  either protocol via `KUBECTL_REMOTE_COMMAND_WEBSOCKETS` doesn't help).
-  `kubectl logs`/`get`/`apply`/`delete` are fine. So make the SQL
-  the pod's **command** and read results from logs: put the SQL in a `ConfigMap`,
-  run a `postgres:16` pod whose command is `psql "$DATABASE_URL" -f /sql/q.sql`
-  (DSN via `envFrom` the `plaid-mcp-db-readonly` secret, never on the command
-  line), `restartPolicy: Never`, poll `.status.phase` until `Succeeded`, then
-  `kubectl logs` it. Delete the pod after (20-pod quota).
+  pod **in `haku-sandbox`** to query it, as the manual describes (pod command +
+  `kubectl logs`, DSN from a secret via `secretKeyRef`). `kubectl exec`/`attach`/
+  `port-forward` work too — the `kubeapi-proxy` nginx forwards the WebSocket
+  upgrade (`cluster/k8s/kube-api-proxy`); they were briefly broken until that was
+  added. Clean up pods after (20-pod quota).
 
 ## Then run
 


### PR DESCRIPTION
Docs follow-up to #2376 (merged + verified — `kubectl exec` through
`kubeapi.allegedly.works` now works). Several docs still claimed exec is broken;
this corrects them and records the root cause.

## What's stale

While #2376 was in flight, the "`kubectl exec`/`attach`/`port-forward` don't work
through the gateway, drive pods via command + `kubectl logs`" guidance got baked
into the Haku base manual (`haku/base/instructions.md`, two places) and the web
entrypoint (`haku/claude_web_env/run.md`). With the nginx fix deployed, exec works,
so those "exec doesn't work / empty `Error from server:`" claims are now false.

## Changes

- **`haku/base/instructions.md`** ×2 and **`haku/claude_web_env/run.md`**: drop the
  false "exec doesn't work" rationale. Kept the command + `kubectl logs` recipe as
  the recommended pattern (it keeps the DSN off any command line and doesn't depend
  on streaming), and noted that `kubectl exec`/`attach`/`port-forward` also work now
  (the `kubeapi-proxy` nginx forwards the WebSocket upgrade).
- **New `cluster/docs/lessons_learned/2026_06_18_kubectl_exec_websocket_kubeapi_proxy.md`**:
  symptom, root cause (nginx stripping the `Upgrade`/`Connection` headers), the
  in-cluster isolation method (probe straight to `kubeapi-proxy.default.svc:8080`
  that still 400'd with an apiserver `Audit-Id` → nginx, not the egress), the #2376
  fix, and the general takeaway.
- **`cluster/k8s/kube-api-proxy/README.md`**: brief "kubectl exec / WebSocket"
  section pointing at the config requirement + the lessons doc.

Docs-only; `instructions.md` rebuilds the `haku-scanner` image on merge (standard
base-edit path), but there's no behavior change beyond the corrected guidance.
`pre-commit` (prettier + markdownlint + kubeconform) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJgMq6mcsAMrPAUJ1frmKC

---
_Generated by [Claude Code](https://claude.ai/code/session_01SJgMq6mcsAMrPAUJ1frmKC)_