### PR TITLE
tana-mcp-ro: add the missing config volume (fix #2379 Flux apply)

### DIFF
--- a/cluster/k8s/agents/tana-mcp-ro/deployment.yaml
+++ b/cluster/k8s/agents/tana-mcp-ro/deployment.yaml
@@ -89,3 +89,7 @@ spec:
               path: /healthz
               port: 8765
             periodSeconds: 20
+      volumes:
+        - name: config
+          configMap:
+            name: tana-mcp-ro-config


### PR DESCRIPTION
**Bug fix.** While verifying the `tana-mcp-ro` rollout I found its Flux Kustomization stuck `ReconciliationFailed`:

```
Deployment "tana-mcp-ro" is invalid: spec.template.spec.containers[0]
  .volumeMounts[0].name: Not found: "config"
```

#2379 added a `config` `volumeMount` (for the `config.yaml` mount) but no matching `volumes:` entry, so the kube-apiserver rejected the Deployment on server-side dry-run. Flux failed every reconcile of that revision and never rolled out — the pod kept running the prior env-based spec (still **healthy/serving**, just stuck on the old revision, so the `config.yaml` refactor wasn't applied).

Adds the missing `configMap` volume. Verified with `kustomize build` (volume now matches the volumeMount and resolves to the generated `tana-mcp-ro-config`).

**CI gap:** kubeconform and the cluster-validation suite validate per-resource schemas, not volume↔volumeMount consistency (a server-side check), so this passed CI on #2379. Worth a follow-up to add a server-dry-run / kube-linter step — noting, not doing here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KgozbuL2YgSfcnFfe4h944

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgozbuL2YgSfcnFfe4h944)_