### PR TITLE
haku/tana_review: concrete, verified pod-connection recipe

### DIFF
--- a/haku/TODO.md
+++ b/haku/TODO.md
@@ -18,14 +18,14 @@ from `haku-sandbox`, plus an example playbook in `base/playbooks/`.
   callers never see it, and is gated by a static bearer `haku-tana-ro-token`
   reflected into `haku-sandbox`, and the `tana_review` playbook + the
   `haku-tana-ro-token` credentials row are wired into `base/`. Remaining:
-  - Decide how Haku reaches it: an in-cluster MCP client / `kubectl
-port-forward` from a sandbox pod using the reflected `haku-tana-ro-token`,
-    vs. threading the Claude Code harness's MCP client to
-    `tana-mcp-ro.tana-mcp.svc.cluster.local:8765/mcp` (needs the bearer wired
-    through the web env alongside the SOPS→kubectl path). The user prefers
-    starting simple (talk to it from a pod) over harness MCP wiring.
-  - Cluster-internal reach is already permitted by the `haku-sandbox` CCNP
-    `toEntities: cluster`; no new CNP needed for that hop.
+  - **Connection paved + verified:** a sandbox pod reaches
+    `tana-mcp-ro.tana-mcp.svc.cluster.local:8765` directly (the `.svc.cluster.local`
+    target is in the pod's injected `NO_PROXY`; the `haku-sandbox` CCNP already
+    permits `toEntities: cluster`) — confirmed live from `claude-sandbox`:
+    `GET /healthz` → 200, `POST /mcp` without the bearer → 401. The `tana_review`
+    playbook carries a stdlib `python:3-slim` MCP-client recipe (no `pip` in the
+    sandbox). Haku still needs one real run to confirm the **authenticated**
+    `tools/list` (needs its reflected bearer) and record the recipe in `memory/`.
   - Confirm the read-only allowlist against the live `tools/list`; settle the
     `get_or_create_calendar_node` exclusion (it can create a daily node).
   - **Future (PLAN north star):** retire the pod dance by wiring Tana into the

--- a/haku/base/playbooks/tana_review.md
+++ b/haku/base/playbooks/tana_review.md
@@ -9,20 +9,60 @@ the Tana PAT stays server-side, so you never see it.
 
 ## Reaching it
 
-`tana-mcp-ro` is cluster-internal
-(`tana-mcp-ro.tana-mcp.svc.cluster.local:8765/mcp`), so your home can't reach it —
-drive it from a `haku-sandbox` pod the way you query Plaid: bake the work into the
-pod's **command** and read results from `kubectl logs` (`exec`/`port-forward` don't
-work through the API gateway). Mount the bearer from the `haku-tana-ro-token` secret
-as an env var (`secretKeyRef`, so it never lands on a command line) and have the pod
-speak MCP over Streamable HTTP with `Authorization: Bearer $TOKEN` — e.g. a `python`
-pod running a small `fastmcp` client, or a script doing the JSON-RPC `initialize` →
-`tools/call` handshake.
+`tana-mcp-ro` is cluster-internal (`tana-mcp-ro.tana-mcp.svc.cluster.local:8765`),
+so your home can't reach it — drive it from a `haku-sandbox` pod the way you query
+Plaid: bake the work into the pod's **command** (or a ConfigMap-mounted script) and
+read results from `kubectl logs` (`exec`/`port-forward` don't work through the API
+gateway). **Verified** from a sandbox pod: `GET /healthz` → `200`, and `POST /mcp`
+without the bearer → `401` — the path and the bearer gate both work, you just need
+the token. Two things that save time:
 
-This connection isn't paved yet — `tana-mcp-ro` is newly deployed. On first use,
-confirm it's on your wire (the secret exists, the tools list is non-empty); if not,
-note the gap in your log and move on. Once you find a pod recipe that works, record
-it in `memory/` so later runs reuse it.
+- The endpoint is under `.svc.cluster.local`, which your pod's injected `NO_PROXY`
+  already covers, so the call goes **direct**, not through the mitmproxy.
+- You can't `pip install` in the sandbox (egress allowlist), so use a stock
+  `python:3-slim` image with a **stdlib** client — not `fastmcp`.
+
+Mount the bearer from `haku-tana-ro-token` as an env var (`secretKeyRef`, so it
+never lands on a command line), then speak Streamable-HTTP MCP: `initialize` (keep
+the `Mcp-Session-Id` response header), `notifications/initialized`, then `tools/list`
+/ `tools/call` — responses may be SSE, so read the `data:` line:
+
+```python
+import json, os, urllib.request
+
+BASE = "http://tana-mcp-ro.tana-mcp.svc.cluster.local:8765/mcp"
+HDR = {"Authorization": f"Bearer {os.environ['TANA_RO_TOKEN']}",
+       "Content-Type": "application/json",
+       "Accept": "application/json, text/event-stream"}
+sid = {}
+
+def rpc(method, params=None, notify=False):
+    msg = {"jsonrpc": "2.0", "method": method}
+    if not notify:
+        msg["id"] = 1
+    if params:
+        msg["params"] = params
+    headers = dict(HDR, **({"Mcp-Session-Id": sid["v"]} if sid else {}))
+    req = urllib.request.Request(BASE, method="POST", headers=headers, data=json.dumps(msg).encode())
+    with urllib.request.urlopen(req, timeout=30) as r:
+        if r.headers.get("Mcp-Session-Id"):
+            sid["v"] = r.headers["Mcp-Session-Id"]
+        ctype, raw = r.headers.get("Content-Type", ""), r.read().decode()
+    if notify:
+        return None
+    if "text/event-stream" in ctype:  # SSE: the JSON-RPC response is the data: line
+        raw = next(line[5:] for line in raw.splitlines() if line.startswith("data:"))
+    return json.loads(raw)
+
+rpc("initialize", {"protocolVersion": "2025-06-18", "capabilities": {},
+                   "clientInfo": {"name": "haku", "version": "0"}})
+rpc("notifications/initialized", notify=True)
+print([t["name"] for t in rpc("tools/list")["result"]["tools"]])
+```
+
+Then add `tools/call` for `search_nodes` etc. The reach and bearer gate are
+confirmed; verify the authenticated `tools/list` on your first run, and record the
+working pod recipe in `memory/` so later runs reuse it.
 
 ## What to mine
 


### PR DESCRIPTION
Makes Haku able to actually create a pod that talks to `tana-mcp-ro` — replaces the vague "use fastmcp or a JSON-RPC handshake" note in the `tana_review` playbook with a concrete, **verified** recipe.

**Verified live** from a `claude-sandbox` pod (same sandbox constraints as `haku-sandbox`):

```
1) GET  /healthz          -> (200, b'{"ok":true}')
2) POST /mcp (no auth)    -> (401, b'{"error":"unauthorized"}')
3) POST /mcp (wrong tok)  -> (401, b'{"error":"unauthorized"}')
```

So a sandbox pod reaches `tana-mcp-ro.tana-mcp.svc.cluster.local:8765` directly (the `.svc.cluster.local` target is in the pod's auto-injected `NO_PROXY`, so it bypasses the mitmproxy), the facade is up, and the static-bearer gate works. Also separately verified: no `CiliumNetworkPolicy` blocks ingress to `tana-mcp`, and the `haku-sandbox` CCNP already allows `toEntities: cluster`.

**Recipe** is stdlib-only on `python:3-slim` (the sandbox egress allowlist blocks `pip install`, so no `fastmcp`): it does the Streamable-HTTP MCP handshake (`initialize` → keep `Mcp-Session-Id` → `notifications/initialized` → `tools/list`), handling SSE responses, with the bearer mounted from `haku-tana-ro-token` via `secretKeyRef`.

The authenticated `tools/list` still needs Haku's reflected bearer (which this `claude-web` session can't read), so the playbook says to confirm it on the first real run and record the working recipe in `memory/`. `haku/TODO.md` updated to mark the connection paved + verified.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KgozbuL2YgSfcnFfe4h944

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgozbuL2YgSfcnFfe4h944)_