### PR TITLE
mitmproxy: allow PyPI + npm registry egress for both sandboxes

### DIFF
--- a/cluster/k8s/agents/haku-mitmproxy/cnp-haku-cloud-api-egress.yaml
+++ b/cluster/k8s/agents/haku-mitmproxy/cnp-haku-cloud-api-egress.yaml
@@ -40,6 +40,18 @@ spec:
         - ports:
             - port: "443"
               protocol: TCP
+    # Package registries for ad-hoc tooling installs inside sandbox pods
+    # (e.g. `pip install fastmcp`, `npx <mcp-server>`). PyPI: `pypi.org`
+    # (index/metadata) + `files.pythonhosted.org` (wheels/sdists); npm:
+    # `registry.npmjs.org`.
+    - toFQDNs:
+        - matchName: pypi.org
+        - matchName: files.pythonhosted.org
+        - matchName: registry.npmjs.org
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
     # Allow forwarding to any in-cluster Service. Sandbox workloads keep
     # mitmproxy in-path even when targeting cluster endpoints; NO_PROXY in the
     # inject policy still permits explicit bypass for Service FQDNs that already

--- a/cluster/k8s/agents/mitmproxy/cnp-cloud-api-egress.yaml
+++ b/cluster/k8s/agents/mitmproxy/cnp-cloud-api-egress.yaml
@@ -35,6 +35,18 @@ spec:
         - ports:
             - port: "443"
               protocol: TCP
+    # Package registries for ad-hoc tooling installs inside sandbox pods
+    # (e.g. `pip install fastmcp`, `npx <mcp-server>`). PyPI: `pypi.org`
+    # (index/metadata) + `files.pythonhosted.org` (wheels/sdists); npm:
+    # `registry.npmjs.org`.
+    - toFQDNs:
+        - matchName: pypi.org
+        - matchName: files.pythonhosted.org
+        - matchName: registry.npmjs.org
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
     # Allow forwarding to any in-cluster Service. Sandbox bench Jobs and
     # other workloads keep mitmproxy in-path even when targeting cluster
     # endpoints (e.g. `ollama.ollama:11434`); without this rule mitmproxy


### PR DESCRIPTION
Hole-punches package-registry FQDNs into the Cilium egress allowlist of **both** mitmproxy egress proxies, per the request to "allow things like pypi" in a separate PR:

- **`agents-mitmproxy`** (Claude sandbox) — `cnp-cloud-api-egress.yaml`
- **`haku-mitmproxy`** (Haku sandbox) — `cnp-haku-cloud-api-egress.yaml`

Each gains one new `toFQDNs` rule on :443:

| Host | Ecosystem | Purpose |
| --- | --- | --- |
| `pypi.org` | PyPI | index / metadata (`pip` simple + JSON API) |
| `files.pythonhosted.org` | PyPI | wheels / sdists |
| `registry.npmjs.org` | npm | `npm install` / `npx` |

### Why

Unblocks ad-hoc tooling installs inside sandbox pods without baking a custom image — most immediately `pip install fastmcp`, so the Haku `tana_review` recipe can use a turnkey MCP client instead of the hand-rolled stdlib JSON-RPC handshake.

### Scope / safety

The egress allowlist is enforced **solely** by each proxy's `CiliumNetworkPolicy` FQDN rules. mitmproxy intercepts every host and has no separate host filter (its only `--ignore-hosts` entry raw-tunnels `docker-ci`), so these two CNPs are the complete change — no deployment, README, or validation-test edits needed.

### Validation

- `pre-commit` (prettier, kubeconform cluster) — pass
- `//cluster/validation/...` (12 tests) — pass — [invocation `2db5e90b`](https://app.buildbuddy.io/invocation/2db5e90b-7204-4cec-b459-46a799c98ea9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KgozbuL2YgSfcnFfe4h944

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgozbuL2YgSfcnFfe4h944)_