### PR TITLE
haku: fastmcp MCP-client closure (.#agent-haku) + bearer-gated tana-mcp-ro route + instructions

### DIFF
--- a/cluster/k8s/agents/tana-mcp-ro/deployment.yaml
+++ b/cluster/k8s/agents/tana-mcp-ro/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: tana-mcp-ro
   annotations:
-    description: "Cluster-internal read-only Tana MCP facade for background agents (haku). Exposes only read tools (config.yaml tools allowlist) and injects the full Tana PAT server-side, so callers never see it. Client auth is a static bearer (haku-tana-ro-token, reflected into haku-sandbox), not Authentik — there is no public HTTPRoute."
+    description: "Cluster-internal read-only Tana MCP facade for background agents (haku). Exposes only read tools (config.yaml tools allowlist) and injects the full Tana PAT server-side, so callers never see it. Client auth is a static bearer (haku-tana-ro-token, reflected into haku-sandbox), not Authentik. Exposed publicly via a bearer-gated HTTPRoute (tana-mcp-ro.allegedly.works, see httproute.yaml) so Haku's web home can reach it with fastmcp; the static bearer is the only gate."
     reloader.stakater.com/auto: "true"
     # CPU: VPA manages requests only — no CPU limit so fastmcp's ~6 CPU-second
     # import isn't throttled (see tana-mcp-facade for the full rationale).

--- a/cluster/k8s/agents/tana-mcp-ro/httproute.yaml
+++ b/cluster/k8s/agents/tana-mcp-ro/httproute.yaml
@@ -1,0 +1,27 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: tana-mcp-ro
+  namespace: tana-mcp
+  annotations:
+    description: >-
+      Public bearer-gated route to the read-only Tana MCP facade. The facade
+      enforces a static bearer (haku-tana-ro-token) and exposes read-only tools
+      only, with the Tana PAT injected server-side — the bearer is the only gate.
+      Exists so Haku's Claude Code web home can reach the facade directly via
+      `fastmcp call https://tana-mcp-ro.allegedly.works/mcp --auth <bearer>`; the
+      kube API gateway blocks port-forward/exec, so there is no cluster-internal
+      path from the home. Only :8765 is routed (metrics :9090 stays internal).
+spec:
+  parentRefs:
+    - name: cluster-gateway
+      namespace: gateway-system
+  hostnames:
+    - "tana-mcp-ro.allegedly.works"
+  rules:
+    - backendRefs:
+        - name: tana-mcp-ro
+          port: 8765
+      timeouts:
+        request: "60s"
+        backendRequest: "60s"

--- a/cluster/k8s/agents/tana-mcp-ro/kustomization.yaml
+++ b/cluster/k8s/agents/tana-mcp-ro/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - haku-tana-ro-token.sops.yaml
   - deployment.yaml
   - service.yaml
+  - httproute.yaml
 generatorOptions:
   # Stable ConfigMap name (the Deployment volume references it); the stakater
   # reloader annotation restarts the pod on config change.

--- a/devinfra/claude/README.md
+++ b/devinfra/claude/README.md
@@ -215,12 +215,12 @@ symlink bridge) vs. <claude_hook/profiles/web/home-manager.yaml> (`home-manager`
 `~/.nix-profile/bin` directly). In `home-manager` mode, point `DUCKTAPE_CLAUDE_HOOKS_PROFILE`
 at the `home-manager.yaml` sibling.
 
-**Which devtools closure** (orthogonal to install mode): in `profile` mode
-`web_setup.sh` installs `.#devtools` by default, or the flake output named by
-`DUCKTAPE_DEVTOOLS_OUTPUT`. Haku's <../../haku/claude_web_env/setup.sh> sets
-`DUCKTAPE_DEVTOOLS_OUTPUT=devtools-haku` to get `.#devtools-haku`, which adds the
-fastmcp MCP-client CLI (`fastmcp call <url> --auth <bearer>`) for talking to
-in-cluster MCP facades; Claude web uses the lean default.
+**Which flake output** (orthogonal to install mode): in `profile` mode
+`web_setup.sh` installs `.#devtools` by default, or the output named by
+`DUCKTAPE_WEB_SETUP_OUTPUT`. Haku's <../../haku/claude_web_env/setup.sh> sets
+`DUCKTAPE_WEB_SETUP_OUTPUT=agent-haku` to get `.#agent-haku`, which composes
+`.#devtools` and adds the fastmcp MCP-client CLI (`fastmcp call <url> --auth
+<bearer>`) for talking to in-cluster MCP facades; Claude web uses the lean default.
 
 Secrets are **not** decrypted by `web_setup.sh`. `SOPS_AGE_KEY` is a user UI env var
 delivered only to the interactive Claude Code process — not to the setup script. All

--- a/devinfra/claude/README.md
+++ b/devinfra/claude/README.md
@@ -215,6 +215,13 @@ symlink bridge) vs. <claude_hook/profiles/web/home-manager.yaml> (`home-manager`
 `~/.nix-profile/bin` directly). In `home-manager` mode, point `DUCKTAPE_CLAUDE_HOOKS_PROFILE`
 at the `home-manager.yaml` sibling.
 
+**Which devtools closure** (orthogonal to install mode): in `profile` mode
+`web_setup.sh` installs `.#devtools` by default, or the flake output named by
+`DUCKTAPE_DEVTOOLS_OUTPUT`. Haku's <../../haku/claude_web_env/setup.sh> sets
+`DUCKTAPE_DEVTOOLS_OUTPUT=devtools-haku` to get `.#devtools-haku`, which adds the
+fastmcp MCP-client CLI (`fastmcp call <url> --auth <bearer>`) for talking to
+in-cluster MCP facades; Claude web uses the lean default.
+
 Secrets are **not** decrypted by `web_setup.sh`. `SOPS_AGE_KEY` is a user UI env var
 delivered only to the interactive Claude Code process — not to the setup script. All
 decryption happens in the hook daemon via `startup_env_script` (`web_env.sh`) at

--- a/devinfra/claude/web_setup.sh
+++ b/devinfra/claude/web_setup.sh
@@ -83,11 +83,11 @@ case "$MODE" in
     MODE="profile"
     ;;
 esac
-# Which flake devtools output to `nix profile install`. Default is the lean
-# `.#devtools` (Claude web). Haku sets DUCKTAPE_DEVTOOLS_OUTPUT=devtools-haku
-# (in haku/claude_web_env/setup.sh) to get `.#devtools-haku`, which adds the
-# fastmcp MCP-client CLI. Only honored in `profile` install mode.
-DEVTOOLS_OUTPUT="${DUCKTAPE_DEVTOOLS_OUTPUT:-devtools}"
+# Which flake output to `nix profile install`. Default is the lean `.#devtools`
+# (Claude web). Haku sets DUCKTAPE_WEB_SETUP_OUTPUT=agent-haku (in
+# haku/claude_web_env/setup.sh) to get `.#agent-haku`, which composes `.#devtools`
+# and adds the fastmcp MCP-client CLI. Only honored in `profile` install mode.
+WEB_SETUP_OUTPUT="${DUCKTAPE_WEB_SETUP_OUTPUT:-devtools}"
 
 FLAKE="path:$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SETUP_COMMIT=$(git -C "${FLAKE#path:}" rev-parse HEAD 2>/dev/null || echo 'unknown')
@@ -236,16 +236,14 @@ if [ "$MODE" = "home-manager" ]; then
   fi
 else
   # CRITICAL: remove first so install re-evaluates against the current flake
-  # (see the "Pin drift on persistent rootfs" comment in the CRITICAL note above).
-  # Remove every known devtools variant first (by attr name) so install
-  # re-evaluates against the current flake (see the "Pin drift" note above) and
-  # so switching DUCKTAPE_DEVTOOLS_OUTPUT never leaves two devtools closures
-  # fighting over PATH.
+  # (see the "Pin drift on persistent rootfs" comment in the CRITICAL note
+  # above). Remove every known output variant (by attr name) so switching
+  # DUCKTAPE_WEB_SETUP_OUTPUT never leaves two closures fighting over PATH.
   nix profile remove devtools 2>/dev/null || true
   nix profile remove devtools-rust 2>/dev/null || true
-  nix profile remove devtools-haku 2>/dev/null || true
+  nix profile remove agent-haku 2>/dev/null || true
   NIX_PROFILE="/nix/var/nix/profiles/default"
-  nix profile install --max-jobs auto "${FLAKE}#${DEVTOOLS_OUTPUT}"
+  nix profile install --max-jobs auto "${FLAKE}#${WEB_SETUP_OUTPUT}"
   log "Dev tools installed (impl=$HOOK_IMPL)."
 fi
 

--- a/devinfra/claude/web_setup.sh
+++ b/devinfra/claude/web_setup.sh
@@ -83,7 +83,11 @@ case "$MODE" in
     MODE="profile"
     ;;
 esac
-DEVTOOLS_OUTPUT="devtools"
+# Which flake devtools output to `nix profile install`. Default is the lean
+# `.#devtools` (Claude web). Haku sets DUCKTAPE_DEVTOOLS_OUTPUT=devtools-haku
+# (in haku/claude_web_env/setup.sh) to get `.#devtools-haku`, which adds the
+# fastmcp MCP-client CLI. Only honored in `profile` install mode.
+DEVTOOLS_OUTPUT="${DUCKTAPE_DEVTOOLS_OUTPUT:-devtools}"
 
 FLAKE="path:$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SETUP_COMMIT=$(git -C "${FLAKE#path:}" rev-parse HEAD 2>/dev/null || echo 'unknown')
@@ -233,8 +237,13 @@ if [ "$MODE" = "home-manager" ]; then
 else
   # CRITICAL: remove first so install re-evaluates against the current flake
   # (see the "Pin drift on persistent rootfs" comment in the CRITICAL note above).
+  # Remove every known devtools variant first (by attr name) so install
+  # re-evaluates against the current flake (see the "Pin drift" note above) and
+  # so switching DUCKTAPE_DEVTOOLS_OUTPUT never leaves two devtools closures
+  # fighting over PATH.
   nix profile remove devtools 2>/dev/null || true
   nix profile remove devtools-rust 2>/dev/null || true
+  nix profile remove devtools-haku 2>/dev/null || true
   NIX_PROFILE="/nix/var/nix/profiles/default"
   nix profile install --max-jobs auto "${FLAKE}#${DEVTOOLS_OUTPUT}"
   log "Dev tools installed (impl=$HOOK_IMPL)."

--- a/flake.nix
+++ b/flake.nix
@@ -377,6 +377,17 @@
             name = "ducktape-rbetools";
             paths = devToolPackages;
           };
+          # Haku's devtools: the shared closure plus a turnkey MCP-client CLI
+          # (the fastmcp `call`/`list` commands, with `--auth <bearer>`), so the
+          # background agent can talk to in-cluster MCP facades (tana-mcp-ro)
+          # without a runtime `pip install` or a hand-rolled JSON-RPC handshake.
+          # Claude web's `.#devtools` stays lean — no fastmcp Python dep tree.
+          # Installed by web_setup.sh when DUCKTAPE_DEVTOOLS_OUTPUT=devtools-haku
+          # (set by haku/claude_web_env/setup.sh).
+          devtools-haku = pkgs.symlinkJoin {
+            name = "ducktape-devtools-haku";
+            paths = devToolPackages ++ localOnlyPackages ++ [ ducktapePkgs.fastmcp ];
+          };
           # home-manager CLI, pinned to our flake input (release-25.11). Used by
           # web_setup.sh's home-manager install mode so activation does not pull
           # an unpinned home-manager from the registry:

--- a/flake.nix
+++ b/flake.nix
@@ -377,16 +377,20 @@
             name = "ducktape-rbetools";
             paths = devToolPackages;
           };
-          # Haku's devtools: the shared closure plus a turnkey MCP-client CLI
-          # (the fastmcp `call`/`list` commands, with `--auth <bearer>`), so the
-          # background agent can talk to in-cluster MCP facades (tana-mcp-ro)
-          # without a runtime `pip install` or a hand-rolled JSON-RPC handshake.
-          # Claude web's `.#devtools` stays lean — no fastmcp Python dep tree.
-          # Installed by web_setup.sh when DUCKTAPE_DEVTOOLS_OUTPUT=devtools-haku
-          # (set by haku/claude_web_env/setup.sh).
-          devtools-haku = pkgs.symlinkJoin {
-            name = "ducktape-devtools-haku";
-            paths = devToolPackages ++ localOnlyPackages ++ [ ducktapePkgs.fastmcp ];
+          # Haku's agent closure: the single shared `.#devtools` plus a turnkey
+          # MCP-client CLI (the fastmcp `call`/`list` commands, with
+          # `--auth <bearer>`), so the background agent can talk to in-cluster
+          # MCP facades (tana-mcp-ro) without a runtime `pip install` or a
+          # hand-rolled JSON-RPC handshake. This is NOT a devtools fork — it
+          # composes the one `.#devtools` and adds fastmcp on top. Installed by
+          # web_setup.sh when DUCKTAPE_WEB_SETUP_OUTPUT=agent-haku (set in
+          # haku/claude_web_env/setup.sh).
+          agent-haku = pkgs.symlinkJoin {
+            name = "ducktape-agent-haku";
+            paths = [
+              self.packages.${system}.devtools
+              ducktapePkgs.fastmcp
+            ];
           };
           # home-manager CLI, pinned to our flake input (release-25.11). Used by
           # web_setup.sh's home-manager install mode so activation does not pull

--- a/haku/TODO.md
+++ b/haku/TODO.md
@@ -18,12 +18,18 @@ from `haku-sandbox`, plus an example playbook in `base/playbooks/`.
   callers never see it, and is gated by a static bearer `haku-tana-ro-token`
   reflected into `haku-sandbox`, and the `tana_review` playbook + the
   `haku-tana-ro-token` credentials row are wired into `base/`. Remaining:
-  - Decide how Haku reaches it: an in-cluster MCP client / `kubectl
-port-forward` from a sandbox pod using the reflected `haku-tana-ro-token`,
-    vs. threading the Claude Code harness's MCP client to
-    `tana-mcp-ro.tana-mcp.svc.cluster.local:8765/mcp` (needs the bearer wired
-    through the web env alongside the SOPS→kubectl path). The user prefers
-    starting simple (talk to it from a pod) over harness MCP wiring.
+  - **MCP client: done** — Haku's devtools closure now bakes in the fastmcp CLI
+    (flake `.#devtools-haku`), so the client is turnkey:
+    `fastmcp call <url> <tool> key=value --auth <bearer> --transport http`
+    (and `fastmcp list <url> --auth <bearer>`) — no runtime `pip install` or
+    hand-rolled JSON-RPC handshake.
+  - Decide how Haku reaches the facade with that client: `kubectl port-forward`
+    to `tana-mcp-ro` from the web home + `fastmcp call http://localhost:PORT/mcp`
+    (needs a port-forward RoleBinding for group `haku` in the `tana-mcp` ns —
+    Haku is admin only in `haku-sandbox`), vs. exposing `tana-mcp-ro` behind a
+    bearer-gated `*.allegedly.works` route so the web home reaches it directly
+    (the PLAN north star below). Read the bearer from the reflected
+    `haku-tana-ro-token` secret in `haku-sandbox` either way.
   - Cluster-internal reach is already permitted by the `haku-sandbox` CCNP
     `toEntities: cluster`; no new CNP needed for that hop.
   - Confirm the read-only allowlist against the live `tools/list`; settle the

--- a/haku/TODO.md
+++ b/haku/TODO.md
@@ -11,35 +11,20 @@ from `haku-sandbox`, plus an example playbook in `base/playbooks/`.
 - **CPAP data** — read-only access to daily summaries / AHI / compliance (see
   `cpap/`; WebDAV + EDF). Land scoped read creds as a `haku-sandbox` secret and
   add a `cpap` playbook (compliance dips, AHI spikes, mask-leak trends).
-- **Tana workspace** — read-only Tana access. The cluster-internal read-only
-  facade is **built**: `tana-mcp-ro` (in the `tana-mcp` namespace) fronts the
-  Tana MCP, exposes only read tools (default-deny allowlist via the generic
-  facade's `MCP_FACADE_TOOLS__ALLOW`), injects the Tana PAT server-side so
-  callers never see it, and is gated by a static bearer `haku-tana-ro-token`
-  reflected into `haku-sandbox`, and the `tana_review` playbook + the
-  `haku-tana-ro-token` credentials row are wired into `base/`. Remaining:
-  - **MCP client: done** — Haku's devtools closure now bakes in the fastmcp CLI
-    (flake `.#devtools-haku`), so the client is turnkey:
-    `fastmcp call <url> <tool> key=value --auth <bearer> --transport http`
-    (and `fastmcp list <url> --auth <bearer>`) — no runtime `pip install` or
-    hand-rolled JSON-RPC handshake.
-  - Decide how Haku reaches the facade with that client: `kubectl port-forward`
-    to `tana-mcp-ro` from the web home + `fastmcp call http://localhost:PORT/mcp`
-    (needs a port-forward RoleBinding for group `haku` in the `tana-mcp` ns —
-    Haku is admin only in `haku-sandbox`), vs. exposing `tana-mcp-ro` behind a
-    bearer-gated `*.allegedly.works` route so the web home reaches it directly
-    (the PLAN north star below). Read the bearer from the reflected
-    `haku-tana-ro-token` secret in `haku-sandbox` either way.
-  - Cluster-internal reach is already permitted by the `haku-sandbox` CCNP
-    `toEntities: cluster`; no new CNP needed for that hop.
+- **Tana workspace** — read-only Tana access. **Built + wired:** the `tana-mcp-ro`
+  facade (in `tana-mcp`) fronts the Tana MCP, exposes only read tools (default-deny
+  allowlist via `MCP_FACADE_TOOLS__ALLOW`), injects the Tana PAT server-side
+  (callers never see it), and is gated by the static bearer `haku-tana-ro-token`
+  (reflected into `haku-sandbox`). It's published at the bearer-gated route
+  `tana-mcp-ro.allegedly.works`, Haku's closure carries the `fastmcp` client, and
+  the `tana_review` playbook + the `haku-tana-ro-token` credentials row use it.
+  Remaining:
   - Confirm the read-only allowlist against the live `tools/list`; settle the
     `get_or_create_calendar_node` exclusion (it can create a daily node).
-  - **Future (PLAN north star):** retire the pod dance by wiring Tana into the
-    harness — expose `tana-mcp-ro` behind a bearer-gated route and give Haku
-    `mcp__tana_ro__*` tools natively (the `kubectl-local` stdio-MCP pattern, but
-    the facade is already HTTP so a `.mcp.json` `http` entry suffices), with the
-    bearer threaded from the reflected secret. Then `tana_review` drops its
-    connection section.
+  - **Future (PLAN north star):** give Haku `mcp__tana_ro__*` tools natively via a
+    `.mcp.json` `http` entry to the route (bearer threaded from the reflected
+    secret), so `tana_review` can drop its connection section and the explicit
+    `fastmcp` step entirely.
 - **Cluster Forgejo repos** — read access to `ducktape` and `gaffer-private`
   if/when they're migrated or mirrored to the cluster Forgejo: grant the `haku`
   Forgejo user read, add a repo-activity playbook (open PRs/issues/review

--- a/haku/TODO.md
+++ b/haku/TODO.md
@@ -21,6 +21,14 @@ from `haku-sandbox`, plus an example playbook in `base/playbooks/`.
   Remaining:
   - Confirm the read-only allowlist against the live `tools/list`; settle the
     `get_or_create_calendar_node` exclusion (it can create a daily node).
+  - **Consider stronger auth for the public route (if/when feasible):** it's gated
+    only by the long-lived static bearer today. The same facade image already
+    supports Authentik OIDC — the read-write `tana-mcp-facade` runs that way
+    (`MCP_FACADE_AUTH__OIDC_*`, group-enforced, Valkey OAuth state) — which buys
+    short-lived tokens, central revocation, and audit, with Haku using
+    `fastmcp --auth oauth` so no read token ever touches a command line. Read-only
+    tools + the server-side PAT keep the blast radius small, so this is hardening,
+    not a blocker.
   - **Future (PLAN north star):** give Haku `mcp__tana_ro__*` tools natively via a
     `.mcp.json` `http` entry to the route (bearer threaded from the reflected
     secret), so `tana_review` can drop its connection section and the explicit

--- a/haku/base/instructions.md
+++ b/haku/base/instructions.md
@@ -140,6 +140,12 @@ a streaming connection. (`kubectl exec`/`attach`/`port-forward` work too — the
 Stay inside `haku-sandbox` — you have no access outside it; and the creds you can
 mount are read-only, so the compute is for gathering, not acting on the world.
 
+**Your home has the `fastmcp` CLI** (in the agent-haku closure) for talking to MCP
+servers: `fastmcp list <url> --auth "$TOKEN"` and `fastmcp call <url> <tool>
+key=value … --auth "$TOKEN" --transport http`. That's how you reach bearer-gated MCP
+facades like `tana-mcp-ro` directly from your home — no pod, no JSON-RPC handshake
+(see _Hard rules_ and `playbooks/tana_review.md`).
+
 If your runtime didn't already clone state for you, clone it yourself with the
 `haku-state-git-write` secret over the **public** `git.allegedly.works` host
 (your home runs on Anthropic infra and can't resolve the cluster-internal
@@ -213,13 +219,12 @@ below.
   even if attempted. Call the Gmail/Calendar REST APIs with
   `Authorization: Bearer $TOK`. There is no MCP server; `curl` goes through the
   egress proxy transparently.
-- **Tana: read-only MCP, from a `haku-sandbox` pod.** The operator's Tana
-  workspace is reachable only through the cluster-internal `tana-mcp-ro` facade,
-  which exposes read tools only (writes are hidden and rejected) and holds the
-  Tana PAT itself — you never see it. Reach it from a pod (command + `kubectl
-logs`, not `exec`/`port-forward`) carrying the `haku-tana-ro-token` bearer; the
-  facade is newly deployed, so confirm it's on your wire before relying on it. See
-  `playbooks/tana_review.md`.
+- **Tana: read-only MCP, via the `fastmcp` CLI.** The operator's Tana workspace is
+  reachable through the `tana-mcp-ro` facade, which exposes read tools only (writes
+  are hidden and rejected) and holds the Tana PAT itself — you never see it. It's
+  published at `https://tana-mcp-ro.allegedly.works/mcp` behind a static bearer, so
+  reach it **directly from your home** with `fastmcp` carrying the reflected
+  `haku-tana-ro-token` bearer — no pod needed. See `playbooks/tana_review.md`.
 - Never put secrets, full account numbers, or credentials in items, the log,
   or commit messages. Reference transactions by date + merchant + amount, mail
   and events by subject/title + sender + date (never raw bodies, never the

--- a/haku/base/playbooks/tana_review.md
+++ b/haku/base/playbooks/tana_review.md
@@ -9,20 +9,31 @@ the Tana PAT stays server-side, so you never see it.
 
 ## Reaching it
 
-`tana-mcp-ro` is cluster-internal
-(`tana-mcp-ro.tana-mcp.svc.cluster.local:8765/mcp`), so your home can't reach it —
-drive it from a `haku-sandbox` pod the way you query Plaid: bake the work into the
-pod's **command** and read results from `kubectl logs` (`exec`/`port-forward` don't
-work through the API gateway). Mount the bearer from the `haku-tana-ro-token` secret
-as an env var (`secretKeyRef`, so it never lands on a command line) and have the pod
-speak MCP over Streamable HTTP with `Authorization: Bearer $TOKEN` — e.g. a `python`
-pod running a small `fastmcp` client, or a script doing the JSON-RPC `initialize` →
-`tools/call` handshake.
+`tana-mcp-ro` is exposed at `https://tana-mcp-ro.allegedly.works/mcp`, gated by a
+static bearer. Your home has the `fastmcp` CLI (baked into the agent-haku closure —
+see `haku/claude_web_env/`), so talk to it **directly** — no pod, no JSON-RPC
+handshake. Read the bearer from the reflected `haku-tana-ro-token` secret into a
+shell variable (reference `"$TOKEN"`, never the literal, so the secret stays out of
+your transcript), then list and call:
 
-This connection isn't paved yet — `tana-mcp-ro` is newly deployed. On first use,
-confirm it's on your wire (the secret exists, the tools list is non-empty); if not,
-note the gap in your log and move on. Once you find a pod recipe that works, record
-it in `memory/` so later runs reuse it.
+```bash
+TOKEN=$(kubectl -n haku-sandbox get secret haku-tana-ro-token \
+  -o jsonpath='{.data.token}' | base64 -d)
+URL=https://tana-mcp-ro.allegedly.works/mcp
+
+# What's exposed, with each tool's argument schema:
+fastmcp list "$URL" --auth "$TOKEN" --transport http --input-schema
+
+# Call a tool — args are key=value pairs per the schema above (or
+# --input-json '{…}' for nested); add --json for machine-readable output:
+fastmcp call "$URL" search_nodes query="follow up" --auth "$TOKEN" --transport http
+fastmcp call "$URL" read_node nodeId="<id>" --auth "$TOKEN" --transport http
+```
+
+Read tools only — `search_nodes`, `read_node`, `get_children`, `open_node`,
+`list_tags`, `list_workspaces`, `get_tag_schema`; writes are hidden and rejected. If
+`list` is empty or a call 401s, note the gap in your log and move on (the facade
+flips NotReady on a bad upstream, and the bearer must be the reflected one).
 
 ## What to mine
 

--- a/haku/claude_web_env/README.md
+++ b/haku/claude_web_env/README.md
@@ -24,7 +24,9 @@ here (on Anthropic infra) and drives the cluster over `kubectl`; the
 
 ## Files
 
-- `setup.sh` — environment setup script; delegates to `devinfra/claude/web_setup.sh`.
+- `setup.sh` — environment setup script; delegates to `devinfra/claude/web_setup.sh`,
+  setting `DUCKTAPE_DEVTOOLS_OUTPUT=devtools-haku` so Haku's closure includes the
+  fastmcp MCP-client CLI (`fastmcp call <url> --auth <bearer>`) for `tana-mcp-ro`.
 - `profile.yaml` — the claude-hook profile. Sets the `K8S_*` overrides (→ group
   `haku` / `haku-sandbox`) and runs `bootstrap.sh` as its background command.
 - `bootstrap.sh` — profile background command: materializes `~/.kube/config`
@@ -35,8 +37,9 @@ here (on Anthropic infra) and drives the cluster over `kubectl`; the
 
 ## How a session boots
 
-1. `setup.sh` (env creation) → shared web setup: devtools, claude-hook daemon,
-   certs, git remotes.
+1. `setup.sh` (env creation) → shared web setup: devtools (the `devtools-haku`
+   variant, which adds the fastmcp MCP-client CLI), claude-hook daemon, certs,
+   git remotes.
 2. `profile.yaml` runs `bootstrap.sh` (each session start): it materializes
    `~/.kube/config` from the SOPS-encrypted haku JWT, then — with cluster access
    in hand — writes `~/.netrc` and clones `haku-state` into `~/haku-state`.

--- a/haku/claude_web_env/README.md
+++ b/haku/claude_web_env/README.md
@@ -25,8 +25,9 @@ here (on Anthropic infra) and drives the cluster over `kubectl`; the
 ## Files
 
 - `setup.sh` — environment setup script; delegates to `devinfra/claude/web_setup.sh`,
-  setting `DUCKTAPE_DEVTOOLS_OUTPUT=devtools-haku` so Haku's closure includes the
-  fastmcp MCP-client CLI (`fastmcp call <url> --auth <bearer>`) for `tana-mcp-ro`.
+  setting `DUCKTAPE_WEB_SETUP_OUTPUT=agent-haku` so Haku installs `.#agent-haku`
+  (the shared `.#devtools` plus the fastmcp MCP-client CLI, `fastmcp call <url>
+--auth <bearer>`) for `tana-mcp-ro`.
 - `profile.yaml` — the claude-hook profile. Sets the `K8S_*` overrides (→ group
   `haku` / `haku-sandbox`) and runs `bootstrap.sh` as its background command.
 - `bootstrap.sh` — profile background command: materializes `~/.kube/config`
@@ -37,8 +38,8 @@ here (on Anthropic infra) and drives the cluster over `kubectl`; the
 
 ## How a session boots
 
-1. `setup.sh` (env creation) → shared web setup: devtools (the `devtools-haku`
-   variant, which adds the fastmcp MCP-client CLI), claude-hook daemon, certs,
+1. `setup.sh` (env creation) → shared web setup installing `.#agent-haku`
+   (`.#devtools` plus the fastmcp MCP-client CLI), claude-hook daemon, certs,
    git remotes.
 2. `profile.yaml` runs `bootstrap.sh` (each session start): it materializes
    `~/.kube/config` from the SOPS-encrypted haku JWT, then — with cluster access

--- a/haku/claude_web_env/setup.sh
+++ b/haku/claude_web_env/setup.sh
@@ -13,4 +13,9 @@
 # Haku comes up as group `haku` against the `haku-sandbox` namespace.
 set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# Install Haku's devtools closure (.#devtools-haku), which adds the fastmcp
+# MCP-client CLI on top of the shared devtools — so Haku can talk to in-cluster
+# MCP facades (tana-mcp-ro) turnkey-ly via `fastmcp call <url> --auth <bearer>`,
+# no runtime pip install. Claude web installs the lean default `.#devtools`.
+export DUCKTAPE_DEVTOOLS_OUTPUT=devtools-haku
 exec bash "${repo_root}/devinfra/claude/web_setup.sh"

--- a/haku/claude_web_env/setup.sh
+++ b/haku/claude_web_env/setup.sh
@@ -13,9 +13,10 @@
 # Haku comes up as group `haku` against the `haku-sandbox` namespace.
 set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-# Install Haku's devtools closure (.#devtools-haku), which adds the fastmcp
-# MCP-client CLI on top of the shared devtools — so Haku can talk to in-cluster
-# MCP facades (tana-mcp-ro) turnkey-ly via `fastmcp call <url> --auth <bearer>`,
-# no runtime pip install. Claude web installs the lean default `.#devtools`.
-export DUCKTAPE_DEVTOOLS_OUTPUT=devtools-haku
+# Install Haku's agent closure (.#agent-haku), which composes the shared
+# `.#devtools` and adds the fastmcp MCP-client CLI — so Haku can talk to
+# in-cluster MCP facades (tana-mcp-ro) turnkey-ly via
+# `fastmcp call <url> --auth <bearer>`, no runtime pip install. Claude web
+# installs the lean default `.#devtools`.
+export DUCKTAPE_WEB_SETUP_OUTPUT=agent-haku
 exec bash "${repo_root}/devinfra/claude/web_setup.sh"

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -315,6 +315,11 @@ rec {
   litert-lm = pkgs.callPackage ./litert-lm.nix { };
   prettier = pkgs.callPackage ./prettier/prettier.nix { };
   kubernetes-mcp-server = pkgs.callPackage ./kubernetes-mcp-server.nix { };
+  # fastmcp's client CLI (`fastmcp call|list <url> --auth <bearer>`) exposed as a
+  # standalone app for agent closures (flake.nix `.#devtools-haku`). The library
+  # is consumed by the `ducktape` wheel above via `python3Packages.fastmcp`; this
+  # re-exposes its console script (fastmcp 3.x, pinned in fastmcp.nix) as an app.
+  fastmcp = python3Packages.toPythonApplication python3Packages.fastmcp;
   bebas-neue-font = pkgs.callPackage ./bebas-neue-font.nix { };
   bb = pkgs.callPackage ./bb.nix { inherit artifacts; };
   telegram-desktop = pkgs.callPackage ./telegram-desktop.nix { };

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -316,7 +316,7 @@ rec {
   prettier = pkgs.callPackage ./prettier/prettier.nix { };
   kubernetes-mcp-server = pkgs.callPackage ./kubernetes-mcp-server.nix { };
   # fastmcp's client CLI (`fastmcp call|list <url> --auth <bearer>`) exposed as a
-  # standalone app for agent closures (flake.nix `.#devtools-haku`). The library
+  # standalone app for agent closures (flake.nix `.#agent-haku`). The library
   # is consumed by the `ducktape` wheel above via `python3Packages.fastmcp`; this
   # re-exposes its console script (fastmcp 3.x, pinned in fastmcp.nix) as an app.
   fastmcp = python3Packages.toPythonApplication python3Packages.fastmcp;


### PR DESCRIPTION
Gives Haku a turnkey MCP client and a working path to the read-only Tana facade. **Supersedes #2382** (the pod / JSON-RPC-handshake recipe).

### 1. `.#agent-haku` closure (no devtools fork)

Haku installed the *same* `.#devtools` as the Claude web agent. Now `web_setup.sh` honors `DUCKTAPE_WEB_SETUP_OUTPUT` (default `devtools`), and Haku's `setup.sh` sets it to `agent-haku` — a new output that **composes** the single `.#devtools` (`self.packages.${system}.devtools`) and adds the `fastmcp` client on top. `.#devtools` is untouched; there is no `devtools-*` variant.

`fastmcp` v3.1.0 (already vendored for the `ducktape` wheel) is exposed as a top-level package; its CLI is a complete MCP client:

```
fastmcp list <url> --auth <BEARER> --transport http
fastmcp call <url> <tool> key=value … --auth <BEARER> --transport http
```

### 2. Bearer-gated route to tana-mcp-ro

New `HTTPRoute` (modeled on `tana-mcp-facade`) publishes the read-only facade at **`tana-mcp-ro.allegedly.works`**. The facade's static bearer (`haku-tana-ro-token`) is the only gate; read-only tools only, Tana PAT injected server-side, metrics `:9090` stays internal. This lets Haku's web home reach it **directly** — no pod, no port-forward.

⚠️ **Exposure note:** this puts the read-only Tana facade on the public internet behind a single static bearer (per your call). Defense-in-depth (Authentik in front) remains an option — flagged for review.

### 3. Haku instructions explain fastmcp

- `instructions.md`: the home carries the `fastmcp` CLI for MCP servers; the Tana hard rule points at the route.
- `playbooks/tana_review.md`: working recipe — read the reflected bearer into a var, then `fastmcp list|call https://tana-mcp-ro.allegedly.works/mcp --auth "$TOKEN"`.
- `haku/TODO.md`: pruned — client / reach / recipe are done; only the live `tools/list` allowlist check + the native-harness-tools north star remain.

### Verified

- `nix build .#agent-haku` — `fastmcp`, `bazelisk`, `kubectl`, `claude-hook`, `sops` coexist; `fastmcp` runs from the joined closure.
- `//cluster/validation/...` 12 tests pass ([invocation `a96d6b37`](https://app.buildbuddy.io/invocation/a96d6b37-9e18-4f94-b6d6-92b4f9f4bc1f)).
- pre-commit (nixfmt, shfmt, prettier, kubeconform) — pass.

### Not live-verifiable from this session

The authenticated `fastmcp call` against the route needs the route reconciled (post-merge) and Haku's reflected bearer (this `claude-web` session can't read it). The facade's bearer gate + reachability were verified earlier (#2382's probe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KgozbuL2YgSfcnFfe4h944