### PR TITLE
nix: single-source the attic cache trusted pubkeys

### DIFF
--- a/.github/workflows/nix-attic-push.yml
+++ b/.github/workflows/nix-attic-push.yml
@@ -18,6 +18,13 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v6
 
+      # Attic cache trusted pubkeys live in nix/attic-pubkeys.json (SSOT). Read
+      # them with jq (preinstalled) here, not in extra_nix_config below, because
+      # that field is static and Nix isn't installed yet at this point.
+      - name: Load Attic trusted pubkeys
+        id: attic_keys
+        run: echo "value=$(jq -r 'join(" ")' nix/attic-pubkeys.json)" >> "$GITHUB_OUTPUT"
+
       - name: Install Nix
         uses: cachix/install-nix-action@v31
         with:
@@ -25,7 +32,10 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes fetch-closure
             netrc-file = /home/runner/.config/nix/netrc
-            extra-trusted-public-keys = main:cy5xhwCNq/T7R55I9TaLv0z6SM6EipXvdFhqrbxC7nc= gaffer:Z8sM2kptUUDGk4ARVD/YkcpzWdMgmZX7nVLV5joK7r8=
+            # Trusted pubkeys from nix/attic-pubkeys.json (SSOT), loaded above —
+            # needed so builtins.fetchClosure of the gaffer closure
+            # (nix/packages/gaffer.nix) passes signature verification.
+            extra-trusted-public-keys = ${{ steps.attic_keys.outputs.value }}
 
       - name: Install Attic client
         run: nix profile install nixpkgs#attic-client

--- a/cluster/docs/nix_cache.md
+++ b/cluster/docs/nix_cache.md
@@ -12,10 +12,10 @@ metadata and a SeaweedFS S3 bucket for NAR chunk storage. Manifests in
 - **Caches** (private, priority 41, server-generated ED25519 keypairs):
   - `main` — ducktape CI's general-purpose cache (flake outputs)
   - `gaffer` — gaffer-private CI's cache (drivefs and friends)
-- **Trusted public keys** (consumer side, pinned in
-  `nix/nixos/modules/attic-substituter.nix`):
-  - `main:cy5xhwCNq/T7R55I9TaLv0z6SM6EipXvdFhqrbxC7nc=`
-  - `gaffer:Z8sM2kptUUDGk4ARVD/YkcpzWdMgmZX7nVLV5joK7r8=`
+- **Trusted public keys** (consumer side): single source of truth is
+  `nix/attic-pubkeys.json`, consumed by both
+  `nix/nixos/modules/attic-substituter.nix` and the `nix-attic-push` CI
+  workflow. Update that file on cluster rebuild (see Bootstrap below).
 
 Caches are created (and signing keypairs generated) by the bootstrap Job in
 `cluster/k8s/nix-cache/bootstrap/`. Re-running the Job is idempotent: GET the
@@ -63,7 +63,8 @@ for cache in main gaffer; do
 done
 ```
 
-…and paste into `nix/nixos/modules/attic-substituter.nix` `trusted-public-keys`.
+…and paste into `nix/attic-pubkeys.json` (the single source of truth, read by
+both `nix/nixos/modules/attic-substituter.nix` and the `nix-attic-push` workflow).
 
 ## CI Push
 

--- a/cluster/k8s/nix-cache/bootstrap/bootstrap.sh
+++ b/cluster/k8s/nix-cache/bootstrap/bootstrap.sh
@@ -21,14 +21,15 @@
 # Public keys are NOT extracted by this script — fetch them from the
 # unauthenticated endpoint after the cache exists:
 #   curl https://cache.allegedly.works/<cache>/nix-cache-info
-# Paste the resulting `Trusted-Public-Key:` value into
-# nix/nixos/modules/attic-substituter.nix `trusted-public-keys`.
+# Paste each resulting `Trusted-Public-Key:` value into nix/attic-pubkeys.json
+# (the single source of truth, read by both nix/nixos/modules/attic-substituter.nix
+# and the nix-attic-push CI workflow).
 #
 # TODO: nice-to-have — auto-fetch the pubkey post-creation and push it
-# back into nix/nixos/modules/attic-substituter.nix via the
-# github-secrets-sync-pat PAT (same mechanism the rotator uses for SOPS
-# files). Today we just paste it once per cluster lifetime; the pubkey
-# only changes on full cluster rebuild, so the manual step is rare.
+# back into nix/attic-pubkeys.json via the github-secrets-sync-pat PAT
+# (same mechanism the rotator uses for SOPS files). Today we just paste it
+# once per cluster lifetime; the pubkey only changes on full cluster
+# rebuild, so the manual step is rare.
 #
 # To re-run after editing this script, the
 # `kustomize.toolkit.fluxcd.io/force: enabled` annotation on the Job tells

--- a/nix/attic-pubkeys.json
+++ b/nix/attic-pubkeys.json
@@ -1,0 +1,1 @@
+["main:owYQITaq2ixR/EnqKoIQAxgjalKKVqMemFwRMaUW53U=", "gaffer:78zVKxf5n254+14vXQeDKV2EHk1q2I9CrG6fLdwlQws="]

--- a/nix/nixos/modules/attic-substituter.nix
+++ b/nix/nixos/modules/attic-substituter.nix
@@ -47,21 +47,11 @@ in
         "https://cache.allegedly.works/main?priority=40"
         "https://cache.allegedly.works/gaffer?priority=40"
       ];
-      trusted-public-keys = [
-        # main + gaffer caches: created by the bootstrap Job in
-        # cluster/k8s/nix-cache/bootstrap/, signing keypairs live in attic's
-        # Postgres DB. Pubkeys captured via:
-        #   curl -sSf -H "Authorization: Bearer $JWT" \
-        #     https://cache.allegedly.works/_api/v1/cache-config/<cache> \
-        #     | jq -r .public_key
-        # ($JWT is an atticadm-minted admin token with `--pull '*'`.)
-        # TODO: nice-to-have — auto-fetch pubkeys post-creation and push
-        # them back into this file via the github-secrets-sync-pat PAT
-        # (same mechanism the rotator uses for SOPS files). Pubkeys only
-        # change on full cluster rebuild, so the manual step is rare.
-        "main:owYQITaq2ixR/EnqKoIQAxgjalKKVqMemFwRMaUW53U="
-        "gaffer:78zVKxf5n254+14vXQeDKV2EHk1q2I9CrG6fLdwlQws="
-      ];
+      # Trusted pubkeys for the main + gaffer caches. Single source of truth is
+      # nix/attic-pubkeys.json; the nix-attic-push CI workflow reads the same
+      # file. Provenance + rotation runbook (capture pubkeys on cluster rebuild):
+      # cluster/k8s/nix-cache/bootstrap/bootstrap.sh.
+      trusted-public-keys = builtins.fromJSON (builtins.readFile ../../attic-pubkeys.json);
       netrc-file = config.sops.templates."attic-netrc".path;
       connect-timeout = 5;
     };

--- a/plans/drivefs_private_cache.md
+++ b/plans/drivefs_private_cache.md
@@ -5,8 +5,8 @@
 The private-cache + JWT-rotation infra landed in commits
 `96c039b69..6ad34978d`:
 
-- `cache.allegedly.works/gaffer` cache exists (empty),
-  pubkey `gaffer:Z8sM2kptUUDGk4ARVD/YkcpzWdMgmZX7nVLV5joK7r8=`.
+- `cache.allegedly.works/gaffer` cache exists; trusted pubkey tracked in
+  `nix/attic-pubkeys.json` (SSOT).
 - Writer JWT for gaffer at `secrets/ci/attic-gaffer-writer.sops.yaml`,
   decryptable by the CI age key (already in gaffer-private's GHA secrets).
 - `nix/packages/gaffer.nix` ready to expose pins as `builtins.storePath`


### PR DESCRIPTION
## Problem

The `main`/`gaffer` attic cache public keys were hand-copied into **4 places**, and had already drifted into two inconsistent generations:

| Location | Held |
| --- | --- |
| `nix/nixos/modules/attic-substituter.nix` | current keys |
| `.github/workflows/nix-attic-push.yml` | **stale** keys |
| `cluster/docs/nix_cache.md` | **stale** keys |
| `plans/drivefs_private_cache.md` | **stale** gaffer key |

The bootstrap runbook (`cluster/k8s/nix-cache/bootstrap/bootstrap.sh`) only told you to update one of them, so the others drift on every rotation. (The stale workflow key is what breaks the `nix-attic-push` CI job: `builtins.fetchClosure` of the gaffer closure fails signature verification with "cannot add path … because it lacks a signature by a trusted key".)

## Fix

Consolidate to one source of truth: **`nix/attic-pubkeys.json`**.

- `attic-substituter.nix` reads it via `builtins.fromJSON (builtins.readFile ../../attic-pubkeys.json)`.
- `nix-attic-push.yml` reads it with `jq` in a pre-install step (jq rather than `nix eval`, because Nix isn't installed yet when `install-nix-action` consumes the value) and passes it as `extra-trusted-public-keys`. This also corrects the workflow's stale keys.
- `nix_cache.md` + `drivefs_private_cache.md` point at the file instead of copying values.
- `bootstrap.sh` runbook now says to paste rotated pubkeys into that one file.

On rotation you now edit **one** file; both consumers derive from it.

## Scope

SSOT consolidation only — **no `http2` change** and none of the other CI-diagnosis work from the parallel investigation. Independently reviewable and mergeable.

## Verification

- `jq -r 'join(" ")' nix/attic-pubkeys.json` → exact space-joined string for `extra-trusted-public-keys`.
- `nix eval --impure --expr 'builtins.fromJSON (builtins.readFile ./nix/attic-pubkeys.json)'` → the expected list.
- No literal key strings remain outside `nix/attic-pubkeys.json` (excluding frozen `props/specimens/` snapshots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KmJwbYH1ZS4fuQ81fQoP6w)_