### PR TITLE
authentik: assign haku-dashboard + tandoor proxy providers to embedded outpost

### DIFF
--- a/cluster/k8s/authentik/app/blueprints/embedded-outpost.yaml
+++ b/cluster/k8s/authentik/app/blueprints/embedded-outpost.yaml
@@ -36,3 +36,5 @@ entries:
         - !Find [authentik_providers_proxy.proxyprovider, [name, adsb]]
         - !Find [authentik_providers_proxy.proxyprovider, [name, openhands]]
         - !Find [authentik_providers_proxy.proxyprovider, [name, fava]]
+        - !Find [authentik_providers_proxy.proxyprovider, [name, haku-dashboard]]
+        - !Find [authentik_providers_proxy.proxyprovider, [name, tandoor]]

--- a/cluster/validation/checks.py
+++ b/cluster/validation/checks.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 from collections import defaultdict
 from pathlib import Path
 
@@ -156,3 +157,111 @@ def check_blueprint_completeness(k8s_dir: Path) -> list[str]:
         ]
 
     return []
+
+
+@dataclasses.dataclass(frozen=True)
+class _BlueprintTag:
+    """An authentik blueprint custom YAML tag (e.g. !Find, !KeyOf) and its constructed argument.
+
+    Authentik blueprints use local `!`-tags that `yaml.SafeLoader` rejects; `_BlueprintLoader`
+    constructs them into these inert wrappers so the documents parse for static inspection.
+    """
+
+    tag: str
+    value: object
+
+
+class _BlueprintLoader(yaml.SafeLoader):
+    """SafeLoader that tolerates authentik's custom `!`-tags rather than erroring on them."""
+
+
+def _construct_blueprint_tag(loader: yaml.SafeLoader, tag_suffix: str, node: yaml.Node) -> _BlueprintTag:
+    # Construct the node's children by type — never re-dispatch this node's tag (would recurse forever).
+    if isinstance(node, yaml.ScalarNode):
+        value: object = loader.construct_scalar(node)
+    elif isinstance(node, yaml.SequenceNode):
+        value = loader.construct_sequence(node, deep=True)
+    elif isinstance(node, yaml.MappingNode):
+        value = loader.construct_mapping(node, deep=True)
+    else:
+        raise TypeError(f"unexpected YAML node type: {type(node)}")
+    return _BlueprintTag(tag_suffix, value)
+
+
+_BlueprintLoader.add_multi_constructor("!", _construct_blueprint_tag)
+
+
+def _outpost_provider_name(item: object, id_to_name: dict[str, str]) -> str | None:
+    """Resolve one outpost `providers` entry to its proxy-provider name.
+
+    Entries are `!KeyOf <blueprint-id>` (same-document reference) or
+    `!Find [authentik_providers_proxy.proxyprovider, [name, <name>]]`.
+    """
+    if not isinstance(item, _BlueprintTag):
+        return None
+    if item.tag == "KeyOf" and isinstance(item.value, str):
+        return id_to_name.get(item.value)
+    if item.tag == "Find" and isinstance(item.value, list) and len(item.value) == 2:
+        model, query = item.value
+        if (
+            model == "authentik_providers_proxy.proxyprovider"
+            and isinstance(query, list)
+            and len(query) == 2
+            and query[0] == "name"
+            and isinstance(query[1], str)
+        ):
+            return query[1]
+    return None
+
+
+def check_proxy_provider_outpost_assignment(k8s_dir: Path) -> list[str]:
+    """Every `present` authentik proxy provider must be assigned to an outpost.
+
+    A proxy provider that exists but is on no outpost has no host->backend mapping: the
+    embedded outpost doesn't recognise its `external_host` and 302s to the Authentik login
+    flow served *on that host*, so "Sign in with Google" builds the OAuth callback against
+    the wrong host and Google rejects it with `redirect_uri_mismatch`. This guards the
+    wiring that broke `haku.allegedly.works` (and, latently, `tandoor.allegedly.works`).
+    """
+    blueprints_dir = k8s_dir / "authentik" / "app" / "blueprints"
+    if not blueprints_dir.exists():
+        raise FileNotFoundError(f"Expected {blueprints_dir} to exist")
+
+    entries = [
+        entry
+        for path in sorted(blueprints_dir.glob("*.yaml"))
+        for doc in yaml.load_all(path.read_text(), Loader=_BlueprintLoader)
+        if isinstance(doc, dict)
+        for entry in doc.get("entries", [])
+        if isinstance(entry, dict)
+    ]
+
+    # Map blueprint id -> provider name (for !KeyOf), and collect present providers.
+    id_to_name: dict[str, str] = {}
+    present_providers: set[str] = set()
+    for entry in entries:
+        if entry.get("model") != "authentik_providers_proxy.proxyprovider":
+            continue
+        name = entry.get("identifiers", {}).get("name")
+        if not isinstance(name, str):
+            continue
+        if isinstance(entry.get("id"), str):
+            id_to_name[entry["id"]] = name
+        if entry.get("state", "present") == "present":
+            present_providers.add(name)
+
+    assigned: set[str] = set()
+    for entry in entries:
+        if entry.get("model") != "authentik_outposts.outpost" or entry.get("state", "present") != "present":
+            continue
+        for item in entry.get("attrs", {}).get("providers", []):
+            if (name := _outpost_provider_name(item, id_to_name)) is not None:
+                assigned.add(name)
+
+    return [
+        f"Authentik proxy provider '{name}' is defined but assigned to no outpost. Add it to the "
+        f"embedded outpost's providers in blueprints/embedded-outpost.yaml (see fava/haku-dashboard); "
+        f"otherwise its host 302s to a login flow served on itself and Google SSO fails with "
+        f"redirect_uri_mismatch."
+        for name in sorted(present_providers - assigned)
+    ]

--- a/cluster/validation/test_cluster_integration.py
+++ b/cluster/validation/test_cluster_integration.py
@@ -22,6 +22,7 @@ import yaml
 from cluster.validation.checks import (
     check_goldilocks_explicit_decision,
     check_goldilocks_namespace_labels,
+    check_proxy_provider_outpost_assignment,
     find_orphaned_files,
 )
 from cluster.validation.cluster import ParsedCluster, parse_cluster
@@ -153,6 +154,17 @@ def test_blueprint_completeness(k8s_dir: Path) -> None:
     assert not unlisted, "Add to authentik-sso-blueprints files list: " + ", ".join(
         f"blueprints/{name}" for name in unlisted
     )
+
+
+def test_proxy_providers_assigned_to_outpost(k8s_dir: Path) -> None:
+    """Every present authentik proxy provider must be assigned to an outpost.
+
+    An unassigned proxy provider (HTTPRoute present, but not on the embedded outpost)
+    302s to a login flow served on its own host, breaking Google SSO with
+    redirect_uri_mismatch — the haku.allegedly.works failure mode.
+    """
+    errors = check_proxy_provider_outpost_assignment(k8s_dir)
+    assert not errors, "\n".join(errors)
 
 
 if __name__ == "__main__":

--- a/cluster/validation/validate_all.py
+++ b/cluster/validation/validate_all.py
@@ -14,11 +14,13 @@ Checks:
 8. Helm template rendering: Cilium values files render without errors (Bazel test only,
    enable in pre-commit with DUCKTAPE_HELM_VALIDATE=1)
 9. Blueprint completeness: All authentik blueprint files must be listed in configMapGenerator
-10. Goldilocks explicit decision: Namespaces with workloads must explicitly set goldilocks enabled label
-11. Image automation <-> webhook: every ImageRepository is listed in the GitHub webhook
+10. Proxy provider outpost assignment: every present authentik proxy provider must be assigned to an
+    outpost, else its host 302s to a login flow served on itself and Google SSO redirect_uri_mismatch
+11. Goldilocks explicit decision: Namespaces with workloads must explicitly set goldilocks enabled label
+12. Image automation <-> webhook: every ImageRepository is listed in the GitHub webhook
     receiver (so pushes reconcile immediately, not just on the 5m poll), and every ImagePolicy
     references a defined ImageRepository
-12. Terraform backends: tofu-controller Terraform CRs must not store state in Kubernetes Secrets
+13. Terraform backends: tofu-controller Terraform CRs must not store state in Kubernetes Secrets
 
 See AGENTS.md section "Flux Kustomization Layering" for CRD layering details.
 """
@@ -34,6 +36,7 @@ from cluster.validation.checks import (
     check_duplicate_external_secrets,
     check_goldilocks_explicit_decision,
     check_goldilocks_namespace_labels,
+    check_proxy_provider_outpost_assignment,
     find_orphaned_files,
 )
 from cluster.validation.cluster import parse_cluster
@@ -84,6 +87,7 @@ async def validate(
 
     errors.extend(find_orphaned_files(cluster, root, candidates=orphan_candidates))
     errors.extend(check_blueprint_completeness(root))
+    errors.extend(check_proxy_provider_outpost_assignment(root))
     errors.extend(check_goldilocks_namespace_labels(cluster))
     errors.extend(check_goldilocks_explicit_decision(cluster))
     errors.extend(validate_dependencies(cluster, root))


### PR DESCRIPTION
## Problem

`haku.allegedly.works` returned a Google **`Error 400: redirect_uri_mismatch`** on sign-in.

Root cause: the `haku-dashboard` proxy provider and its HTTPRoute existed, but the provider was never added to the **embedded outpost's `providers` list** in `cluster/k8s/authentik/app/blueprints/embedded-outpost.yaml`.

With no provider assigned for the host, the embedded outpost doesn't recognize `haku.allegedly.works` and `302`s to the Authentik login flow served **on the haku host itself** (relative `/flows/-/default/authentication/`) instead of `/outpost.goauthentik.io/start`. "Sign in with Google" then builds the OAuth source callback as `https://haku.allegedly.works/source/oauth/callback/google/`, which isn't a registered redirect URI in Google (only `auth.allegedly.works` is) — hence the mismatch.

Confirmed by tracing redirects:

| host | first redirect |
| --- | --- |
| `fava` (works) | `https://fava.allegedly.works/outpost.goauthentik.io/start?rd=…` |
| `haku` (broken) | `/flows/-/default/authentication/?next=/` (relative — stays on the host) |

## Changes

- **Add `haku-dashboard` to the embedded outpost** — the fix for the reported error.
- **Add `tandoor`** — found to be broken identically (live app, same relative-redirect symptom). `kagent` is unaffected: it intentionally uses its own dedicated `kagent-outpost`.
- **Add a regression check** `check_proxy_provider_outpost_assignment` (in `cluster/validation/checks.py`, wired into `validate_all.py` and `test_cluster_integration.py`) that fails when any `present` proxy provider is assigned to no outpost, so this wiring gap can't recur.

## Verification

`bbr test //cluster/validation/...` — all 12 tests pass and the mypy/ruff lint aspect passes.

## Deployment note

Once merged, Flux updates the `authentik-sso-blueprints` ConfigMap and the blueprint reconciler assigns the providers to the outpost (can take up to ~60 min, or restart `authentik-server` to apply immediately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MtvmeLBt1cVenHMC8m5XfA

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtvmeLBt1cVenHMC8m5XfA)_