### PR TITLE
nix-attic-push: substitute from the cache it pushes to

### DIFF
--- a/.github/workflows/nix-attic-push.yml
+++ b/.github/workflows/nix-attic-push.yml
@@ -13,7 +13,13 @@ jobs:
   nix-attic-push:
     name: Build & push to Attic
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    # 360 min (GitHub-hosted ceiling) so the first run after enabling
+    # extra-substituters (below) can do the one-time cold build of paths
+    # cache.nixos.org can't serve — notably the unfree CUDA stack
+    # (cuda-merged/ollama for wyrm2), a ~1.5h+ local build that caused the
+    # earlier 120-min timeouts — and push them. Once cached, later runs
+    # substitute them and finish quickly, so this can be lowered again.
+    timeout-minutes: 360
     steps:
       - name: Check out code
         uses: actions/checkout@v6
@@ -36,6 +42,15 @@ jobs:
             # needed so builtins.fetchClosure of the gaffer closure
             # (nix/packages/gaffer.nix) passes signature verification.
             extra-trusted-public-keys = ${{ steps.attic_keys.outputs.value }}
+            # Substitute from the main cache this job pushes to, so paths
+            # cache.nixos.org can't serve — notably the unfree CUDA stack
+            # (cuda-merged/ollama for the wyrm2 GPU host) — are pulled from a
+            # previous run instead of rebuilt locally every time. Auth is the
+            # ATTIC_TOKEN netrc written below (the CI token has main:pull). Attic
+            # advertises priority 41 < cache.nixos.org's 40, so the public cache
+            # still wins for the shared base; attic is only hit for paths it
+            # alone has.
+            extra-substituters = https://cache.allegedly.works/main
 
       - name: Install Attic client
         run: nix profile install nixpkgs#attic-client

--- a/cluster/k8s/agents/attic-jwt-rotation/rotators.json
+++ b/cluster/k8s/agents/attic-jwt-rotation/rotators.json
@@ -45,7 +45,7 @@
       "sops_file": "secrets/ci/attic-main-writer.sops.yaml",
       "sub": "ducktape-ci",
       "validity": "1 year",
-      "_pull_rationale": "gaffer:r is needed by the nix-attic-push workflow: evaluating flake outputs that reference nix/packages/gaffer.nix triggers builtins.fetchClosure against cache.allegedly.works/gaffer to substitute the private drivefs/drivectl closures bundled into NixOS/home configs.",
+      "_pull_rationale": "main:r is used by the nix-attic-push workflow as an extra substituter so paths cache.nixos.org can't serve (the unfree CUDA stack: cuda-merged/ollama for wyrm2) are pulled from a prior run instead of rebuilt locally. gaffer:r is needed because evaluating flake outputs that reference nix/packages/gaffer.nix triggers builtins.fetchClosure against cache.allegedly.works/gaffer to substitute the private drivefs/drivectl closures bundled into NixOS/home configs.",
       "pull": ["main", "gaffer"],
       "push": ["main"]
     },


### PR DESCRIPTION
## Root cause

With the keys fixed, the `nix-attic-push` job still timed out at 120 min — but not on download, upload, or HTTP/2 (both http2-on and http2-off runs died at exactly 120.3 min). The job log shows why:

```
04:27:09  building '…-libcublas-12.8.4.1-source.drv'...
04:28:21  building '…-cuda-merged-12.drv'...
04:28:21  building '…-ollama-0.21.1.drv'...
05:54:33  ##[error]The operation was canceled.
```

**~86 minutes with no output**, then the timeout. The job was stuck in one giant *local* build: the unfree CUDA stack (`libcublas` → `cuda-merged-12`) + `ollama` for the **wyrm2** GPU host. `cache.nixos.org` doesn't serve unfree-redistributable CUDA, so it's assembled locally **every run** — and that one host-specific tail exceeds the budget. The closure's shared base (correctly noted as mostly shared across hosts) flew by in the first ~30 min; this is not aggregate bloat, and per-host splitting wouldn't help (wyrm2's own job would still cold-build CUDA).

## Fix

Add `cache.allegedly.works/main` as an **extra substituter** — the cache this job already pushes to. Once the CUDA stack is built and pushed once, later runs pull it from the cache instead of rebuilding it.

- **Auth:** the existing `ATTIC_TOKEN` netrc. The CI writer token already carries `pull: [main, gaffer]` (per `rotators.json`), so no token change is needed. Its `_pull_rationale` — which previously only justified `gaffer:r` — is extended to record that `main:r` is now load-bearing (so it isn't later "cleaned up" as unused).
- **Priority:** attic advertises priority 41 < `cache.nixos.org`'s 40, so the public cache still wins for the shared base; attic is only hit for paths it alone has (the CUDA stack).

## Priming the cache (one-time)

Chicken-and-egg: CUDA isn't in the cache yet (every prior run was killed mid-build), so the **first** run still has to cold-build and push it. `timeout-minutes` is bumped `120 → 360` (the GitHub-hosted ceiling) so that first run can complete the cold build and prime the cache. Once primed, runs substitute it and finish quickly — this can be lowered again afterward.

## Builds on

The merged SSOT PR (#2385) — reuses `nix/attic-pubkeys.json` so the runner trusts the `main` signing key it now substitutes from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KmJwbYH1ZS4fuQ81fQoP6w)_