### PR TITLE
nix-attic-push: fallback to source build on substitution failure

### DIFF
--- a/.github/workflows/nix-attic-push.yml
+++ b/.github/workflows/nix-attic-push.yml
@@ -51,6 +51,14 @@ jobs:
             # still wins for the shared base; attic is only hit for paths it
             # alone has.
             extra-substituters = https://cache.allegedly.works/main
+            # Build from source if a substitution fails instead of hard-erroring.
+            # Required now that we pull from cache.allegedly.works/main: earlier
+            # runs were killed mid-upload, leaving dangling narinfos (present
+            # metadata, missing/partial NAR). Without fallback, nix aborts the
+            # whole job on the first such path ("could not be realised"); with
+            # it, nix rebuilds and watch-store re-pushes the good NAR, self-
+            # healing the cache.
+            fallback = true
 
       - name: Install Attic client
         run: nix profile install nixpkgs#attic-client


### PR DESCRIPTION
## Regression

The merged substitute-from-own-cache change (#2387) made `nix-attic-push` on devel fail in ~1 min (run `27809074891`):

```
error: some references of path '…-nixos-system-bazel-test-….' could not be realised
error: some substitutes for the outputs of derivation '…-nixos-system-bazel-test-….drv' failed
       (usually happens due to networking issues); try '--fallback' to build derivation from source
```

## Cause

Earlier runs were killed mid-upload (the 120-min timeouts), leaving **dangling entries** in `cache.allegedly.works/main`: a narinfo is present but the NAR behind it is missing/partial. Now that the job substitutes from `main`, nix finds the narinfo (auth is fine — it's a `200`), tries to download the NAR, fails, and — with no `--fallback` — aborts the whole job on the first such path. (If it were an auth/`401`, nix wouldn't find the path at all and would just build it; the `200`-then-failed-NAR is what makes it fatal.)

## Fix

Set `fallback = true` in the job's `extra_nix_config`. A failed substitution now builds from source instead of erroring; `watch-store` re-pushes the correct NAR, self-healing the dangling cache entry. This is also the right general posture now that the job pulls from a private cache that can be incomplete or transiently unavailable.

## Follow-up to

#2387 (substitute from own cache) + #2385 (pubkey SSOT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KmJwbYH1ZS4fuQ81fQoP6w)_