### PR TITLE
authentik: assign haku-dashboard + tandoor proxy providers to embedded outpost

### DIFF
--- a/cluster/k8s/authentik/app/blueprints/embedded-outpost.yaml
+++ b/cluster/k8s/authentik/app/blueprints/embedded-outpost.yaml
@@ -36,3 +36,5 @@ entries:
         - !Find [authentik_providers_proxy.proxyprovider, [name, adsb]]
         - !Find [authentik_providers_proxy.proxyprovider, [name, openhands]]
         - !Find [authentik_providers_proxy.proxyprovider, [name, fava]]
+        - !Find [authentik_providers_proxy.proxyprovider, [name, haku-dashboard]]
+        - !Find [authentik_providers_proxy.proxyprovider, [name, tandoor]]


### PR DESCRIPTION
## Problem

`haku.allegedly.works` returned a Google **`Error 400: redirect_uri_mismatch`** on sign-in.

Root cause: the `haku-dashboard` proxy provider and its HTTPRoute existed, but the provider was never added to the **embedded outpost's `providers` list** in `cluster/k8s/authentik/app/blueprints/embedded-outpost.yaml`.

With no provider assigned for the host, the embedded outpost doesn't recognize `haku.allegedly.works` and `302`s to the Authentik login flow served **on the haku host itself** (relative `/flows/-/default/authentication/`) instead of `/outpost.goauthentik.io/start`. "Sign in with Google" then builds the OAuth source callback as `https://haku.allegedly.works/source/oauth/callback/google/`, which isn't a registered redirect URI in Google (only `auth.allegedly.works` is) — hence the mismatch.

Confirmed by tracing redirects:

| host | first redirect |
| --- | --- |
| `fava` (works) | `https://fava.allegedly.works/outpost.goauthentik.io/start?rd=…` |
| `haku` (broken) | `/flows/-/default/authentication/?next=/` (relative — stays on the host) |

## Change

Add `haku-dashboard` to the embedded outpost (the fix), plus `tandoor`, which was found to be broken identically (live app, same relative-redirect symptom). `kagent` is unaffected — it intentionally uses its own dedicated `kagent-outpost`.

## Deployment note

Once merged, Flux updates the `authentik-sso-blueprints` ConfigMap and the blueprint reconciler assigns the providers to the outpost (can take up to ~60 min, or restart `authentik-server` to apply immediately).

A separate, stacked PR adds a regression check that fails when any proxy provider is assigned to no outpost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MtvmeLBt1cVenHMC8m5XfA

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtvmeLBt1cVenHMC8m5XfA)_