### PR TITLE
glm-5.2: wire new z.ai model into litellm, props, and z-claude alias

### DIFF
--- a/cluster/k8s/litellm/app/generate_litellm.py
+++ b/cluster/k8s/litellm/app/generate_litellm.py
@@ -48,7 +48,16 @@ _MODELS: list[tuple[str, list[tuple[str, int | None]]]] = [
 # in favor of this one.
 _ZAI_ANTHROPIC_BASE = "https://api.z.ai/api/anthropic"
 # Full GLM matrix z.ai serves on the Anthropic endpoint (per /api/anthropic/v1/models, 2026-06).
-_ZAI_ANTHROPIC_MODELS: list[str] = ["glm-4.5", "glm-4.5-air", "glm-4.6", "glm-4.7", "glm-5", "glm-5-turbo", "glm-5.1"]
+_ZAI_ANTHROPIC_MODELS: list[str] = [
+    "glm-4.5",
+    "glm-4.5-air",
+    "glm-4.6",
+    "glm-4.7",
+    "glm-5",
+    "glm-5-turbo",
+    "glm-5.1",
+    "glm-5.2",
+]
 
 
 def _zai_anthropic_entries() -> Iterator[dict]:

--- a/cluster/k8s/litellm/app/proxy-config.yaml
+++ b/cluster/k8s/litellm/app/proxy-config.yaml
@@ -164,6 +164,14 @@ model_list:
     model_info:
       mode: chat
       supports_function_calling: true
+  - model_name: glm-5.2-anthropic
+    litellm_params:
+      model: anthropic/glm-5.2
+      api_base: https://api.z.ai/api/anthropic
+      api_key: os.environ/ZAI_API_KEY
+    model_info:
+      mode: chat
+      supports_function_calling: true
 litellm_settings:
   drop_params: true
   callbacks:

--- a/cluster/k8s/props/app/config.toml
+++ b/cluster/k8s/props/app/config.toml
@@ -134,3 +134,17 @@ output_usd_per_1m_tokens = 1.74
 context_window_tokens = 200000
 max_output_tokens = 131072
 max_parallel_agents = 8
+
+# glm-5.2 (released 2026-06-17) ships a 1M-token context window, unlike the
+# 200k of earlier GLM models. Pricing left at the uniform family guardrail above.
+[[models]]
+name = "glm-5.2"
+upstream = "litellm"
+upstream_model = "glm-5.2-anthropic"
+api_shape = "anthropic"
+input_usd_per_1m_tokens = 0.39
+cached_input_usd_per_1m_tokens = 0.39
+output_usd_per_1m_tokens = 1.74
+context_window_tokens = 1000000
+max_output_tokens = 131072
+max_parallel_agents = 8

--- a/docs/zai_api.md
+++ b/docs/zai_api.md
@@ -173,7 +173,7 @@ Z.ai's gateway registers routes for many provider prefixes (`/api/v1/`, `/api/v2
 
 ## Available Models
 
-As of 2026-05-08:
+As of 2026-06-19:
 
 | Model ID      | Display Name |
 | ------------- | ------------ |
@@ -184,6 +184,10 @@ As of 2026-05-08:
 | `glm-5`       | GLM-5        |
 | `glm-5-turbo` | GLM-5-Turbo  |
 | `glm-5.1`     | GLM-5.1      |
+| `glm-5.2`     | GLM-5.2      |
+
+`glm-5.2` (released 2026-06-17) ships a 1M-token context window, up from the 200k
+of the earlier GLM-4.x / 5.x models.
 
 ## Prompt Caching
 
@@ -400,7 +404,7 @@ Notes:
 
 - **Claude Code** (`z-claude` alias): works via the Anthropic-compatible endpoint.
   Sets `ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic`, `ANTHROPIC_AUTH_TOKEN=$ZAI_API_KEY`,
-  `ANTHROPIC_MODEL=glm-5.1`.
+  `ANTHROPIC_MODEL=glm-5.2`.
 
 - **Codex CLI**: not compatible — requires OpenAI Responses API which Z.ai does not expose.
   `wire_api = "chat"` (Chat Completions mode) was deprecated in Codex ~2026-04-21 and is no

--- a/nix/home/home.nix
+++ b/nix/home/home.nix
@@ -298,7 +298,7 @@ in
         exec env \
           ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic \
           ANTHROPIC_AUTH_TOKEN="$ZAI_API_KEY" \
-          ANTHROPIC_MODEL=glm-5.1 \
+          ANTHROPIC_MODEL=glm-5.2 \
           claude --disallowed-tools "WebFetch WebSearch" \
           "$@"
       '')


### PR DESCRIPTION
## What

z.ai released **GLM-5.2** (2026-06-17), a 1M-token-context model. This wires it in everywhere the GLM family is configured and points the `z-claude` alias at it.

- **litellm** (`cluster/k8s/litellm/app`): add `glm-5.2` to the z.ai Anthropic model matrix in `generate_litellm.py`; regenerated `proxy-config.yaml` gains the `glm-5.2-anthropic` entry.
- **props** (`cluster/k8s/props/app/config.toml`): new `glm-5.2` model routed via `glm-5.2-anthropic`, `context_window_tokens = 1_000_000` (the rest of the family is 200k).
- **z-claude alias** (`nix/home/home.nix`): `ANTHROPIC_MODEL` `glm-5.1` → `glm-5.2`.
- **docs/zai_api.md**: add `glm-5.2` to the model table + a 1M-context note, and update the alias example.

## Verification

- Confirmed `glm-5.2` is live on z.ai's `/api/anthropic/v1/models` (`id: glm-5.2`, created 2026-06-17).
- `bazelisk test //cluster/k8s/litellm/app:test_generate_litellm` → **PASSED** (generator/`proxy-config.yaml` parity + lint).
- `pre-commit run --files …` → all hooks pass.

## Left unchanged (deliberate single-model pins — happy to bump any on request)

- props `grader_model = "glm-4.6"`
- kagent default `model: glm-5.1`
- loom gym baselines (`glm-4.5`) and `agent_core` live-test defaults (`glm-4.6`)

These are deliberate version/baseline selections rather than "make the model available" wiring, so I left them as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4qb4U6sVbxJkHxbS63NDW)_