### PR TITLE
Remove git state validation from bbr, update bb to 5.0.387

### DIFF
--- a/.github/workflows/bazel-ci.yml
+++ b/.github/workflows/bazel-ci.yml
@@ -39,9 +39,11 @@ jobs:
         with:
           sops_age_key: ${{ secrets.SOPS_AGE_KEY }}
 
-      # bb remote's base resolution falls back to `git rev-parse <default-branch>`
-      # which needs a local ref. actions/checkout only creates remote tracking refs
-      # (origin/devel), not local branches, so create one for PR builds.
+      # bb remote's base resolution falls back to `git rev-parse <default-branch>@{upstream}`
+      # (and then the local `<default-branch>` ref) — both need a local branch. actions/checkout
+      # only creates remote-tracking refs (origin/devel), not local branches, so create one for
+      # PR builds. buildbuddy#11838 fixed the unpushed-local-commits case but still reads
+      # @{upstream}, which requires the local branch.
       - name: Create local ref for default branch
         if: github.event_name == 'pull_request'
         run: git branch "$GIT_REPO_DEFAULT_BRANCH" "origin/$GIT_REPO_DEFAULT_BRANCH"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,10 +126,6 @@ local-only runs that need the session config, use `bazelisk run //target -- ...`
 RBE-bound work (`bbr ...`) is unaffected because runner VMs don't use the session
 truststore.
 
-### Unpushed commits
-
-`bbr` aborts if local `devel` differs from `origin/devel`. Fix: `git push` first, or use a feature branch.
-
 ### Configuration layers
 
 | Layer   | Source                           | Contents                                                  |

--- a/devinfra/bbr.py
+++ b/devinfra/bbr.py
@@ -68,44 +68,6 @@ def _read_repo_config(repo_root: Path) -> RepoConfig:
     )
 
 
-def _validate_git_state(repo: pygit2.Repository) -> None:
-    """Abort if the default branch has unpushed commits.
-
-    bb remote selects the local HEAD as the base commit. If that commit
-    doesn't exist on the remote, the runner fails during git fetch.
-    """
-    if repo.head_is_detached:
-        return
-
-    current_branch = repo.head.shorthand
-
-    origin_head = repo.references.get("refs/remotes/origin/HEAD")
-    if origin_head is None:
-        # CI (actions/checkout) doesn't set origin/HEAD — skip validation.
-        return
-    default_branch = origin_head.resolve().shorthand.removeprefix("origin/")
-
-    if current_branch != default_branch:
-        return
-
-    try:
-        local_oid = repo.references[f"refs/heads/{default_branch}"].resolve().target
-    except KeyError:
-        return
-    try:
-        remote_oid = repo.references[f"refs/remotes/origin/{default_branch}"].resolve().target
-    except KeyError:
-        return
-
-    if local_oid != remote_oid:
-        print(
-            f"bbr: aborting — {default_branch} has unpushed commits (local {local_oid} != origin {remote_oid}).",
-            file=sys.stderr,
-        )
-        print("bbr: push first or use a feature branch.", file=sys.stderr)
-        sys.exit(1)
-
-
 def _find_bb() -> str:
     """Locate the bb binary on PATH."""
     if path := shutil.which("bb"):
@@ -247,7 +209,6 @@ def main() -> None:
         args.remove("--dry-run")
 
     repo = pygit2.Repository(".")
-    _validate_git_state(repo)
     cmd = build_command(repo, args)
 
     if dry_run:

--- a/devinfra/docs/bb_remote_internals.md
+++ b/devinfra/docs/bb_remote_internals.md
@@ -143,8 +143,19 @@ When `--run_from_branch` and `--run_from_commit` are both empty (auto mode):
    - If HEAD is ahead (unpushed commits): falls through to default branch
 4. **Fallback** (branch doesn't exist remotely, or has unpushed commits):
    - `branch = defaultBranch` (e.g., `devel`)
-   - `commit = git rev-parse devel` — uses the **local** ref, not
-     `origin/devel`
+   - `commit = git rev-parse devel@{upstream}` — the **remote-tracking** commit
+     (e.g. `origin/devel`), so an unpushed local `devel` tip is never used as
+     the base; the unpushed commits are sent as patches instead. Falls back to
+     `git rev-parse devel` (the **local** ref) only when `devel` has no upstream
+     configured.
+   - Resolving `@{upstream}` requires a **local** `devel` branch with tracking
+     config. A normal clone has this; a CI checkout that creates only
+     `origin/devel` (no local branch) does not — see Gotchas below.
+   - **Deviation from older `bb`:** before [buildbuddy#11838][bb11838] the
+     fallback was just `git rev-parse devel` (local ref), which broke when local
+     `devel` had unpushed commits. Our pinned `bb` (≥ 5.0.387) includes the fix.
+
+[bb11838]: https://github.com/buildbuddy-io/buildbuddy/pull/11838
 
 ### Phase 3: Generate patches (`generatePatches`, line 514)
 
@@ -165,19 +176,27 @@ with `git apply`. Result: workspace matches your local working tree.
 
 ### Scenario matrix
 
-| Scenario                                   | Base branch       | Base commit                 | Patches contain                  |
-| ------------------------------------------ | ----------------- | --------------------------- | -------------------------------- |
-| Local branch, pushed, HEAD on remote       | `feature-x`       | HEAD SHA                    | uncommitted changes only         |
-| Local branch, pushed, HEAD ahead of remote | `devel` (default) | local `git rev-parse devel` | all branch commits + uncommitted |
-| Local branch, not pushed                   | `devel` (default) | local `git rev-parse devel` | all branch commits + uncommitted |
-| Detached HEAD, ref exists remotely         | detached ref      | ref SHA                     | uncommitted changes only         |
-| Detached HEAD, ref not on remote           | `devel` (default) | local `git rev-parse devel` | everything since devel           |
+| Scenario                                   | Base branch       | Base commit                       | Patches contain                  |
+| ------------------------------------------ | ----------------- | --------------------------------- | -------------------------------- |
+| Local branch, pushed, HEAD on remote       | `feature-x`       | HEAD SHA                          | uncommitted changes only         |
+| Local branch, pushed, HEAD ahead of remote | `devel` (default) | `devel@{upstream}` (origin/devel) | all branch commits + uncommitted |
+| Local branch, not pushed                   | `devel` (default) | `devel@{upstream}` (origin/devel) | all branch commits + uncommitted |
+| Detached HEAD, ref exists remotely         | detached ref      | ref SHA                           | uncommitted changes only         |
+| Detached HEAD, ref not on remote           | `devel` (default) | `devel@{upstream}` (origin/devel) | everything since devel           |
+
+(The fallback rows assume a local `devel` branch with an upstream — a normal
+clone. With no local `devel` it falls back to `git rev-parse devel`, which also
+fails if absent: that is the CI case the `bazel-ci.yml` workaround handles.)
 
 ### Gotchas
 
-- **Local devel ref used, not origin/devel**: If your local `devel` is behind
-  `origin/devel`, the base commit may not exist on the remote → runner clone
-  fails. Run `git fetch` first.
+- **Fallback base is `origin/devel` via `@{upstream}`**: the fallback resolves
+  `devel@{upstream}` (the remote-tracking commit), so unpushed commits on a local
+  `devel` are sent as patches rather than used as the base. This needs a **local**
+  `devel` branch with tracking config. A CI checkout (`actions/checkout`) creates
+  only `origin/devel`, not a local branch, so `@{upstream}` (and the `git rev-parse
+devel` fallback) both fail — `bazel-ci.yml` creates a local `devel` ref for PR
+  builds. If `origin/devel` itself is stale, `git fetch` first.
 - **`--run_from_commit` disables patches**: When set, the runner checks out
   exactly that commit. Patches are only generated when BOTH `--run_from_branch`
   and `--run_from_commit` are empty. Do NOT use `--run_from_commit` in wrapper

--- a/devinfra/test_bbr.py
+++ b/devinfra/test_bbr.py
@@ -14,15 +14,7 @@ import pygit2
 import pytest
 import pytest_bazel
 
-from devinfra.bbr import (
-    RepoConfig,
-    _bazelrc_args,
-    _env_args,
-    _read_repo_config,
-    _validate_git_state,
-    build_command,
-    find_verb_index,
-)
+from devinfra.bbr import RepoConfig, _bazelrc_args, _env_args, _read_repo_config, build_command, find_verb_index
 
 BB = "/usr/bin/bb"
 IMAGE = "ghcr.io/test/rbe@sha256:deadbeef"
@@ -86,42 +78,6 @@ class TestReadRepoConfig:
         assert result.bazel_args == ["--config=rbe"]
         assert result.runner_exec_properties == {}
         assert result.container_image is None
-
-
-class TestValidateGitState:
-    def test_detached_head_skips(self, tmp_path: Path) -> None:
-        repo = _make_repo(tmp_path)
-        repo.set_head(repo.head.target)
-        _validate_git_state(repo)
-
-    def test_feature_branch_skips(self, tmp_path: Path) -> None:
-        repo = _make_repo(tmp_path)
-        repo.references.create("refs/heads/my-feature", repo.head.target)
-        repo.set_head("refs/heads/my-feature")
-        _validate_git_state(repo)
-
-    def test_default_branch_unpushed_aborts(self, tmp_path: Path) -> None:
-        repo = _make_repo(tmp_path)
-        sig = pygit2.Signature("test", "test@test.com")
-        tree = repo.TreeBuilder().write()
-        new_oid = repo.create_commit("refs/heads/devel", sig, sig, "second", tree, [repo.head.target])
-        repo.set_head("refs/heads/devel")
-        assert repo.references["refs/heads/devel"].resolve().target == new_oid
-        with pytest.raises(SystemExit):
-            _validate_git_state(repo)
-
-    def test_default_branch_up_to_date_passes(self, tmp_path: Path) -> None:
-        repo = _make_repo(tmp_path)
-        _validate_git_state(repo)
-
-    def test_missing_origin_head_skips(self, tmp_path: Path) -> None:
-        """Without refs/remotes/origin/HEAD (e.g. CI), validation is skipped."""
-        repo = pygit2.init_repository(str(tmp_path / "bare"))
-        sig = pygit2.Signature("test", "test@test.com")
-        tree = repo.TreeBuilder().write()
-        repo.create_commit("refs/heads/devel", sig, sig, "init", tree, [])
-        repo.set_head("refs/heads/devel")
-        _validate_git_state(repo)
 
 
 class TestFindVerbIndex:

--- a/nix/artifact-pins.json
+++ b/nix/artifact-pins.json
@@ -5,8 +5,8 @@
       "sha256": "lWZoDmuApuj0xhgvK3raYFeUAIPjVKcH3pkSZlTsKdg="
     },
     "bb": {
-      "url": "https://github.com/buildbuddy-io/bazel/releases/download/5.0.339/bazel-5.0.339-linux-x86_64",
-      "sha256": "TgfSB1u2oIO519Ew320bvQGBBurJ9hp8xmdyM7QEXCE="
+      "url": "https://github.com/buildbuddy-io/bazel/releases/download/5.0.387/bazel-5.0.387-linux-x86_64",
+      "sha256": "zV9vs+sjVRB7pRkN8WeTdxJWZJtlPEMqsA2qDum3c0A="
     },
     "bbapi": {
       "url": "https://github.com/agentydragon/ducktape/releases/download/bbapi-8171b6d7c834/bbapi",

--- a/nix/packages/bb.nix
+++ b/nix/packages/bb.nix
@@ -5,7 +5,7 @@
 }:
 pkgs.stdenv.mkDerivation {
   pname = "bb";
-  version = "5.0.339";
+  version = "5.0.387";
   src = artifacts.bb;
   dontUnpack = true;
   nativeBuildInputs = [ pkgs.makeWrapper ];

--- a/x/nix_rbe_image/TODO.md
+++ b/x/nix_rbe_image/TODO.md
@@ -13,34 +13,6 @@
 - Removed permanently: QEMU, dosfstools, mtools, fuse3, fuse,
   gobject-introspection, cairo.dev, dbus.dev (unused)
 
-## `bb remote` Auto-Detection / git sync Issues
-
-### Unpushed commit breaks auto-detect
-
-When there are unpushed local commits, `bb remote` (without `--run_from_commit`
-or `--run_from_branch`) tries to use the local HEAD SHA as the base commit. The
-runner then does `git fetch --depth=1 origin <sha>` which fails with
-`upload-pack: not our ref` because the commit doesn't exist on the remote.
-
-Patches are only generated when both `--run_from_branch` and `--run_from_commit`
-are empty, so the workarounds drop local diffs:
-
-- `--run_from_branch=devel` / `--run_from_commit=origin/devel` work but silently
-  drop all local diffs (same footgun).
-
-This makes local iteration painful — you either push every change or lose your
-diff. There should be a better workflow.
-
-**Questions to investigate** (the `getBaseBranchAndCommit` / patch-generation
-flow in `remotebazel.go`):
-
-- How exactly does `getBaseBranchAndCommit` auto-detect? It should fall back to
-  the default branch when the local commit isn't pushed. Why isn't it?
-- Does it check if the commit exists on the remote before using it?
-- Is the issue that the local branch tracks a remote branch, so bb assumes the
-  commit is pushed?
-- What's the intended workflow for developing with unpushed commits?
-
 ## shiboken6 / PySide6
 
 - `ezdxf[draw]` → `pyside6` → `shiboken6`/`pyside6-addons` fails to install on `bb remote`


### PR DESCRIPTION
## Summary

Remove the `_validate_git_state()` function from bbr that was aborting when the default branch had unpushed commits. This validation is no longer needed because bb 5.0.387+ (buildbuddy#11838) now correctly handles unpushed commits by using `git rev-parse <branch>@{upstream}` to resolve the remote-tracking commit as the base, sending unpushed local commits as patches instead.

## Key Changes

- **Remove git state validation**: Delete `_validate_git_state()` function and its call from `main()` in `devinfra/bbr.py`
- **Remove related tests**: Delete `TestValidateGitState` class from `devinfra/test_bbr.py`
- **Update bb version**: Bump pinned bb from 5.0.339 to 5.0.387 in `nix/artifact-pins.json` and `nix/packages/bb.nix`
- **Update documentation**: 
  - Clarify in `devinfra/docs/bb_remote_internals.md` that fallback base resolution now uses `devel@{upstream}` (remote-tracking ref) instead of local `devel`
  - Update scenario matrix to reflect the new behavior
  - Add gotchas section explaining the requirement for a local branch with tracking config
  - Add reference to buildbuddy#11838 fix
- **Update CI workflow**: Clarify in `.github/workflows/bazel-ci.yml` why a local default branch ref is still needed (for `@{upstream}` resolution)
- **Update AGENTS.md**: Remove the "Unpushed commits" section documenting the old abort behavior

## Implementation Details

The old validation would abort if a user had unpushed commits on the default branch, forcing them to either push or switch to a feature branch. With bb 5.0.387+, the base resolution intelligently falls back to the remote-tracking branch (`origin/devel` via `@{upstream}`), allowing unpushed commits to be sent as patches. This enables a better local development workflow without losing diffs.

The CI workaround of creating a local default branch ref is still needed because `@{upstream}` requires a local branch with tracking configuration, which `actions/checkout` doesn't create by default.

https://claude.ai/code/session_012MbHQhecrkLFUdY3ztRMnJ