### PR TITLE
Centralize Attic cache pubkeys in nix/attic-pubkeys.json

### DIFF
--- a/cluster/k8s/nix-cache/app/server.toml
+++ b/cluster/k8s/nix-cache/app/server.toml
@@ -4,7 +4,14 @@ listen = "[::]:8080"
 type = "s3"
 region = "us-east-1"
 bucket = "attic"
-endpoint = "http://seaweedfs-s3.seaweedfs.svc:8333"
+# Public S3 gateway (not the internal seaweedfs-s3.svc). attic presigns
+# single-chunk NAR downloads against this endpoint via a 307 redirect; the host
+# must be resolvable by external clients (CI), so it can't be a .svc name.
+# Multi-chunk NARs stream through attic regardless. attic's own chunk I/O also
+# routes here (through the gateway). Requires the `attic` identity on the
+# public-s3 config (cluster/k8s/seaweedfs/public-s3/s3-config-externalsecret.yaml)
+# so SeaweedFS validates the presigned URLs and attic's reads/writes.
+endpoint = "https://s3.allegedly.works"
 # Credentials sourced from AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY env vars.
 
 [database]

--- a/cluster/k8s/seaweedfs/public-s3/s3-config-externalsecret.yaml
+++ b/cluster/k8s/seaweedfs/public-s3/s3-config-externalsecret.yaml
@@ -7,10 +7,14 @@ metadata:
     description: >-
       Renders the consolidated public S3 gateway config from the credential
       Secrets: drivefs-artifacts (writer + reader), vm-images (ci-writer +
-      cdi-reader), and claude (cross-bucket read; write only to loom-gym).
-      Intentionally excludes admin and all in-cluster-only tenants. SeaweedFS
-      scopes actions per identity, so co-hosting these on one public gateway
-      does not let one identity's credentials reach another's buckets.
+      cdi-reader), claude (cross-bucket read; write only to loom-gym), and
+      attic (read/write to the attic nix-cache bucket). attic is here so the
+      nix cache can point its storage endpoint at s3.allegedly.works: presigned
+      single-chunk NAR download URLs then resolve for external clients (CI),
+      and attic's own chunk I/O routes through this gateway. Intentionally
+      excludes admin and all in-cluster-only tenants. SeaweedFS scopes actions
+      per identity, so co-hosting these on one public gateway does not let one
+      identity's credentials reach another's buckets.
 spec:
   refreshInterval: 1m
   secretStoreRef:
@@ -38,7 +42,10 @@ spec:
              "actions":["Read:vm-images","List:vm-images"]},
             {"name":"claude-reader",
              "credentials":[{"accessKey":"{{ .claudeReaderAccessKey }}","secretKey":"{{ .claudeReaderSecretKey }}"}],
-             "actions":["Read:attic","List:attic","Read:drivefs-artifacts","List:drivefs-artifacts","Read:vm-images","List:vm-images","Read:augur-assets","List:augur-assets","Read:listing-monitor-captures","List:listing-monitor-captures","Read:wayback-archive","List:wayback-archive","Read:loom-gym","Write:loom-gym","List:loom-gym","Tagging:loom-gym"]}
+             "actions":["Read:attic","List:attic","Read:drivefs-artifacts","List:drivefs-artifacts","Read:vm-images","List:vm-images","Read:augur-assets","List:augur-assets","Read:listing-monitor-captures","List:listing-monitor-captures","Read:wayback-archive","List:wayback-archive","Read:loom-gym","Write:loom-gym","List:loom-gym","Tagging:loom-gym"]},
+            {"name":"attic",
+             "credentials":[{"accessKey":"{{ .accessKey }}","secretKey":"{{ .secretKey }}"}],
+             "actions":["Read:attic","Write:attic","List:attic","Tagging:attic"]}
           ]}
   dataFrom:
     - extract:
@@ -47,3 +54,8 @@ spec:
         key: vm-images-s3-credentials
     - extract:
         key: claude-reader-s3-credentials
+    # attic's own SeaweedFS identity (generic accessKey/secretKey keys, no
+    # collision with the prefixed keys above). Lets public-s3 validate the
+    # presigned NAR URLs attic signs with this key.
+    - extract:
+        key: s3-identity-attic


### PR DESCRIPTION
Consolidates the Attic cache trusted public keys into a single source of truth (`nix/attic-pubkeys.json`) that is consumed by both the NixOS substituter configuration and the CI workflow, eliminating duplication and improving maintainability.

## Key Changes

- **Created `nix/attic-pubkeys.json`**: New file containing the trusted public keys for both `main` and `gaffer` caches in JSON array format
- **Updated `nix-attic-push` CI workflow**: Modified to read pubkeys from the JSON file and dynamically inject them into Nix configuration, rather than hardcoding them
  - Added step to load and parse pubkeys with `jq`
  - Replaced hardcoded `extra-trusted-public-keys` with dynamic value from the JSON file
  - Added extensive comments explaining HTTP/2 workaround for cache.nixos.org NAR fetch failures
- **Updated `nix/nixos/modules/attic-substituter.nix`**: Changed to read pubkeys from the JSON file using `builtins.readFile` and `builtins.fromJSON`, replacing the previously hardcoded list
- **Updated S3 gateway configuration**: Modified `cluster/k8s/seaweedfs/public-s3/s3-config-externalsecret.yaml` to add `attic` identity with read/write permissions to the attic bucket, and updated `cluster/k8s/nix-cache/app/server.toml` to use the public S3 gateway endpoint (`https://s3.allegedly.works`) instead of internal service DNS
- **Updated documentation**: Modified bootstrap script comments, nix_cache.md, and drivefs_private_cache.md to reference the new JSON file as the single source of truth for pubkey management

## Implementation Details

The JSON file serves as the canonical source for cache pubkeys, eliminating the need to manually update multiple configuration files during cluster rebuilds. The CI workflow reads this file at runtime, while the NixOS module reads it at evaluation time. Documentation has been updated to clarify the pubkey rotation runbook and point to the bootstrap Job for capture procedures.

https://claude.ai/code/session_01KmJwbYH1ZS4fuQ81fQoP6w