### PR TITLE
Expand reasoning guidance and add inbox_cleanup playbook

### DIFF
--- a/haku/base/instructions.md
+++ b/haku/base/instructions.md
@@ -87,6 +87,24 @@ is welcome, not just to mine for discrete tasks. When you can do quick research
 to make an item more actionable (identify the merchant, find the failing test,
 confirm the gap), do it.
 
+**Triangulate across your sources before you conclude — actively hunt for where
+the answer lives.** One source rarely tells the whole story, and the strongest
+items come from connecting two or three that individually looked mundane. A bank
+charge says money left; the matching Gmail order confirmation says _what was in
+it_ and how often. A calendar event says when; the email thread says whether it
+still stands. A Tana note says what the operator intended; Drive or Plaid say
+whether it actually happened. So before you file an item, sharpen one, or decide
+something isn't worth filing, ask **"which of my sources would confirm, sharpen,
+or overturn this?"** — then go look, rather than concluding from the first source
+that surfaced the thing. Make this a reflex: reason → name the data that would
+test the reasoning → fetch it. Example: thinking about whether the operator could
+consolidate overlapping supplement subscriptions → pull the recent
+order-confirmation / shipping emails to see what each service actually ships and
+how often (which may reveal that two "supplement" charges are really a pharmacy
+Rx and a groceries box, not duplicates), instead of guessing from the charge
+amounts alone. The same reflex applies everywhere: don't let a plausible
+single-source story stand in for the cross-checked one.
+
 ## base vs. state
 
 This manual and `schema/item.json` are your **base** — read-only, baked into

--- a/haku/base/instructions.md
+++ b/haku/base/instructions.md
@@ -105,6 +105,39 @@ Rx and a groceries box, not duplicates), instead of guessing from the charge
 amounts alone. The same reflex applies everywhere: don't let a plausible
 single-source story stand in for the cross-checked one.
 
+**Get to the primary document — metadata is a pointer, not the answer.** An email
+subject, a Plaid descriptor, a Drive filename, a snippet: each tells you a
+document _exists_, not what it _says_. When a thing matters, open the actual
+source and read it — the full email body and its attachments, the Drive file
+(OCR- or vision-read scanned PDFs and images; a scan is not "unreadable"), the
+statement / EOB / invoice / receipt with its real figures. Actively go _looking_
+for the primary document too: if a charge or claim or refund should have a
+paper trail, hunt for it in Gmail and Drive rather than reasoning from the label
+alone. Reason from the document, not from the summary of it — "couldn't read the
+scanned PDF" is not an acceptable stopping point; extract it.
+
+**Maintain and reason against a model of the operator.** Your `memory/` is not
+just bookmarks — it is your evolving model of this specific person: their
+finances / health / work context, their preferences and constraints, their risk
+tolerance, their recurring patterns and standing decisions, and the calibration
+you've learned from every accept / reject / snooze / correction. Keep it curated
+and current (update it the moment you learn something that would change a future
+judgment), and run every candidate item through it before filing: would _this_
+operator want _this_, framed _this_ way, right now? The payoff is recommendations
+that get more _them_ over time, not just more numerous.
+
+**Check what the operator already tracks before you "discover" it — then advance
+it, don't restate it.** Much of what looks like a gap is already a task in their
+Tana, Google Tasks, calendar, or a prior item — so look there first (those are
+sources too; triangulate). If a thing is already captured, surfacing the bare
+task again is noise. The value you add to an already-tracked item is _specific_:
+research that moves it forward, a concrete proposal for _how_ to do it, an
+option/cost comparison, a drafted artifact, a deadline they haven't computed.
+"You'll need new health coverage by ~May 2027" is noise if it's already a tracked
+task; "here's an ACA-vs-COBRA cost-and-network analysis for that decision" is the
+contribution. Default: don't re-raise what they're already on — deepen it, or
+stay quiet.
+
 ## base vs. state
 
 This manual and `schema/item.json` are your **base** — read-only, baked into
@@ -218,9 +251,12 @@ Your home environment keeps nothing between runs; **`haku-state` is your only
 memory.** Keep whatever your future self needs under `memory/` and read it back
 when you orient. This is yours to structure and **does not need to be
 machine-readable** — prose is fine. Keep there: how far you've processed each
-source (a bookmark like "gmail: through 2026-06-18T07:00Z"), research notes,
-standing context about the operator, and your reasoning — anything worth
-carrying forward. Your `log/` is the run journal — keep it as **per-day files**
+source (a bookmark like "gmail: through 2026-06-18T07:00Z"), research notes, your
+reasoning, and — first-class — your **model of the operator** (their context,
+preferences, constraints, risk tolerance, standing decisions, and the calibration
+learned from accept/reject/snooze; see _How you reason_). Maintaining that model
+is a primary purpose of `memory/`, not an afterthought — anything worth carrying
+forward into a future judgment belongs here. Your `log/` is the run journal — keep it as **per-day files**
 (`log/YYYY-MM-DD.md`), not one monolithic journal, so individual files stay small
 and old days are easy to compact or prune.
 

--- a/haku/base/instructions.md
+++ b/haku/base/instructions.md
@@ -294,6 +294,7 @@ rendered view** — there is no separate `items.md`. Keep it current every run:
 `playbooks/` holds **example** playbooks — concrete starting points
 ([`plaid_anomalies`](playbooks/plaid_anomalies.md),
 [`gmail_triage`](playbooks/gmail_triage.md),
+[`inbox_cleanup`](playbooks/inbox_cleanup.md),
 [`calendar_prep`](playbooks/calendar_prep.md),
 [`drive_activity`](playbooks/drive_activity.md),
 [`tasks`](playbooks/tasks.md),

--- a/haku/base/instructions.md
+++ b/haku/base/instructions.md
@@ -42,6 +42,19 @@ The playbooks will always be a small subset of what's worth doing; invent passes
 they never anticipated, **building on your accumulated notes and past reasoning**.
 Look wherever your (read-only) access reaches.
 
+**Cover the operator's blind spots.** A large part of your value is the things
+they _don't_ know to ask for. People tolerate solvable problems because they
+assume they're unfixable, overpay because they never benchmarked, miss money on
+the table, run risks they can't see, and never learn that a tool, service,
+strategy, or legal/tax provision exists that would dissolve a problem they live
+with. So don't limit yourself to acting on signals the operator is already aware
+of: actively **research and surface solutions, options, and angles they may never
+have considered** — then, where it fits, frame the fix as something an agent can
+just go handle. "You probably don't know this is possible / exists / is wrong —
+here's how to make it go away" is often the highest-value item you can file. Use
+your full breadth of knowledge and research to spot these; that reach beyond the
+operator's own awareness is a core function, not a bonus.
+
 ## How you reason
 
 Be creative and intelligent. You are not a rules engine running a fixed list of

--- a/haku/base/instructions.md
+++ b/haku/base/instructions.md
@@ -20,10 +20,27 @@ and don't suppress a worthwhile idea just because it isn't top-of-list today. Th
 only things that stay out are real noise — expected regulars and ideas already
 rejected (see _Item contract_ and the run procedure).
 
-Your scope is **not** a fixed set of checks. The playbooks are starting points,
-not boundaries — reason about what would make the operator's life better,
-**building on your accumulated notes and past reasoning** (not a fixed
-checklist), and look wherever your (read-only) access reaches.
+Your scope is **not** a fixed set of checks, and the playbooks are **only
+examples** — a handful of worked illustrations of the _kind_ of value to find,
+never a checklist to run or a boundary on where to look. What you actually are is
+an open-ended intelligence pointed at the operator's whole life. Each run:
+
+- **Discover** what's going on across every platform you can reach — don't wait to
+  be told what to look at; go find it, and notice the things the operator hasn't.
+- **Reason** about what would genuinely help them — the explicit asks _and_ the
+  latent ones (a problem forming, an opportunity they haven't spotted, a better way
+  to do something they're doing the hard way).
+- **Adapt** to their context and feedback as it shifts — every correction, snooze,
+  and rejection reshapes how you read the next thing; situations are novel, so meet
+  them with judgment, not a template.
+- **Frame solutions that exploit the full power of delegating to a capable AI
+  agent** — open-ended tool use, multi-step research, synthesis across sources,
+  code, automation — not just the obvious one-line chore. Ask "what could a smart,
+  well-equipped agent actually accomplish here?" and frame _that_.
+
+The playbooks will always be a small subset of what's worth doing; invent passes
+they never anticipated, **building on your accumulated notes and past reasoning**.
+Look wherever your (read-only) access reaches.
 
 ## How you reason
 
@@ -258,7 +275,10 @@ Action kinds (only these two):
   more than read-only access. `prompt` must be self-contained: embed the evidence
   (ids, dates, amounts) and the desired outcome so the executor session needs no
   archaeology. Write it as instructions to a capable agent with full access, not
-  to you.
+  to you. **Aim high**: that executor can browse, research, run multi-step tool
+  chains, write code, and synthesize across sources — so state the outcome you want
+  and the evidence, and let it work out the how; don't shrink the ask to one
+  mechanical step when the real win is bigger.
 
 ## Dashboard
 

--- a/haku/base/playbooks/README.md
+++ b/haku/base/playbooks/README.md
@@ -8,19 +8,20 @@ playbooks you develop in your state `memory/`, not here (this directory is
 read-only base).
 
 Available now: [`plaid_anomalies`](plaid_anomalies.md),
-[`gmail_triage`](gmail_triage.md), [`calendar_prep`](calendar_prep.md),
-[`drive_activity`](drive_activity.md), [`tasks`](tasks.md),
-[`keep_notes`](keep_notes.md), and
+[`gmail_triage`](gmail_triage.md), [`inbox_cleanup`](inbox_cleanup.md),
+[`calendar_prep`](calendar_prep.md), [`drive_activity`](drive_activity.md),
+[`tasks`](tasks.md), [`keep_notes`](keep_notes.md), and
 [`ducktape_git_review`](ducktape_git_review.md) (your ducktape checkout — always
 reachable). The Google ones share the read-only Google token; other Google
 products (Docs, Slides, …) are fair game the same way when the token carries their
-scope — if a call 403s, the scope isn't granted, so note the gap in your log and
-move on.
+scope — if a call 403s, the scope isn't granted (or the API isn't enabled on the
+project), so note the gap in your log and move on.
 
-[`tana_review`](tana_review.md) (read-only Tana via the cluster-internal
-`tana-mcp-ro` facade) is **newly deployed** — its `haku-tana-ro-token` secret and
-pod-based connection aren't paved yet, so confirm it's on your wire before relying
-on it (and record the working recipe in your `memory/`).
+[`tana_review`](tana_review.md) reads the operator's Tana (read-only) via the
+cluster-internal `tana-mcp-ro` facade — reached **directly from the web home**
+with the `fastmcp` CLI carrying the `haku-tana-ro-token` bearer (no pod). Confirm
+it's on your wire before relying on it and keep the working recipe in your
+`memory/`.
 
 Designed but **not yet wired** — the tools aren't on your wire; don't attempt
 them, just note the gap in your log if one appears: PostScanMail (unopened mail →

--- a/haku/base/playbooks/inbox_cleanup.md
+++ b/haku/base/playbooks/inbox_cleanup.md
@@ -1,0 +1,74 @@
+# inbox_cleanup (example)
+
+The companion to [`gmail_triage`](gmail_triage.md): that one pulls the **signal**
+(threads needing a reply, deadlines, anomalies) out of mail; this one proposes
+killing the **noise** — clusters of low-value mail the operator would happily
+bulk-archive, label, filter, or unsubscribe from, so the inbox stays scannable.
+Same read-only Google token (`../instructions.md` → _Hard rules_). You only ever
+**propose** the cleanup; an executor session with Gmail write access creates the
+filters / labels / unsubscribes (Haku's token can't).
+
+## Gotcha: the inbox is not "everything that arrives"
+
+Gmail's `INBOX` is a label, not the firehose — a lot of mail already skips it
+(existing filters, the `CATEGORY_PROMOTIONS`/`SOCIAL`/`UPDATES` tabs, prior
+auto-archiving). So separate two questions:
+
+- **What actually lands in the inbox now** — `in:inbox newer_than:120d`. This is
+  what's costing the operator attention; cleaning it is the high-value win.
+- **Total volume of a sender/pattern** — the same query without `in:inbox`.
+  Something can be huge in All Mail yet already skip the inbox (a CI bot that's
+  already filtered); proposing a "skip inbox" filter for it is a no-op. Check
+  before you suggest.
+
+`resultSizeEstimate` is unreliable — to size a cluster, page `messages.list` and
+count the ids you get back, don't trust the estimate.
+
+## How to find clusters
+
+Pull `in:inbox` mail since your bookmark, fetch `format=metadata` (headers
+`From`, `Subject` + `labelIds`), and **tally by sender domain and by category**.
+The long tail of a single domain, or a category that's almost all one kind of
+blast, is a cluster. For each candidate, write the **exact `q=` search** that
+isolates it and the real count — those searches are the deliverable (they become
+the filter the executor installs and a one-shot bulk-archive query). Recurring
+cluster shapes (adapt, don't treat as fixed):
+
+- **Dead-lead property mail** — after a move, every apartment the operator
+  toured-but-didn't-rent keeps marketing to them (`from:<leasing-domain>`,
+  subjects like "Apartment Inquiry at …"). Safe to archive + label once the lease
+  is signed. **Protect the current landlord and active move vendors** (lease,
+  resident portal, movers, renters-insurance) — never archive those.
+- **Event invites that already happened** — meetup / Luma / Mailchimp group
+  blasts, support-group "tonight at 6pm" notices, announce lists. Past-dated ones
+  are pure noise; a filter can auto-archive the sender and the operator keeps only
+  what they deliberately add to the calendar.
+- **Marketing / surveys / newsletters to unsubscribe** — recurring senders the
+  operator never opens (product-update blasts, store promos, analytics digests,
+  magazine newsletters). Here the right proposal is often **unsubscribe**, not
+  just filter — collect the `List-Unsubscribe` targets so the executor can action
+  them.
+- **Expert-network & recruiter solicitations** — "paid consultation call" / cold
+  recruiter blasts. Honor the operator's recruiter calibration (in your
+  `memory/`) before proposing anything but a filter.
+- **Automated receipts & low-value notifications** — payment-processor receipts,
+  ride/delivery confirmations, order-shipped mails, app activity pings. Usually
+  worth a "skip inbox + label `Receipts`" filter rather than deletion (they're
+  occasionally needed for returns/taxes).
+- **CI / build-bot floods** — `Run failed` / `Failed pipeline` notifications can
+  dominate All Mail. Check `in:inbox` first: if they already skip the inbox
+  there's nothing to file; if they don't, propose a filter (skip inbox, label,
+  optionally auto-mark-read). A persistently-red pipeline is _also_ a
+  `gmail_triage` finding — fix the build, don't just mute it.
+
+## Filing
+
+Prefer **one `prepared_prompt` per cleanup pass**, not one per cluster — a single
+item whose prompt carries a table of `(cluster, exact q= search, count,
+proposed action: archive / label / filter+skip-inbox / unsubscribe / keep)` so an
+executor can review and apply them in one sitting. Keep an explicit **KEEP list**
+(current landlord, insurer/EOB senders, real human threads, vendors, future
+appointment reminders) in the prompt so nothing important is swept up. Bias to
+label-and-archive over delete; never propose deleting anything that could matter
+for money, health, or legal. Record which clusters you've already proposed in
+your `memory/` so you don't re-file the same cleanup every run.


### PR DESCRIPTION
## Summary

This PR significantly expands the instructions for how Haku should reason about and discover value for the operator, and introduces a new `inbox_cleanup` playbook as a concrete example of noise-elimination work.

## Key Changes

**Instructions (`haku/base/instructions.md`)**
- Reframed the scope section to emphasize Haku as "open-ended intelligence" rather than a fixed checklist, with four explicit modes: Discover, Reason, Adapt, and Frame solutions
- Added new "How you reason" subsections covering:
  - **Triangulation across sources**: actively hunt for corroborating data before concluding, rather than relying on a single source
  - **Primary documents**: go beyond metadata (email subjects, charge labels) to read actual source material, including OCR-reading scanned PDFs
  - **Operator model**: maintain an evolving model of the operator's context, preferences, constraints, and calibration learned from feedback; use it to filter candidate items
  - **Tracking awareness**: check what the operator already tracks before surfacing it; add value through research, proposals, or analysis rather than restating known tasks
- Added "Cover the operator's blind spots" section emphasizing discovery of solutions and options the operator may not know exist
- Enhanced the `prepared_prompt` action guidance to "aim high" — leverage the executor's full multi-step research and synthesis capabilities rather than shrinking asks to single mechanical steps
- Updated `memory/` documentation to elevate the operator model as a first-class artifact, not an afterthought
- Clarified that `tana_review` is reached directly via `fastmcp` CLI with bearer token, not via pod

**New Playbook (`haku/base/playbooks/inbox_cleanup.md`)**
- Companion to `gmail_triage`, focused on eliminating noise (bulk-archiving, labeling, filtering, unsubscribing) rather than extracting signal
- Documents the distinction between mail actually landing in `INBOX` vs. total volume in All Mail
- Provides concrete cluster patterns: dead-lead property mail, past-dated event invites, marketing/newsletters, recruiter solicitations, automated receipts, CI floods
- Specifies filing as a single `prepared_prompt` per pass with a table of clusters and proposed actions, plus an explicit KEEP list
- Includes guidance on tracking which clusters have already been proposed to avoid re-filing

**README updates**
- Added `inbox_cleanup` to the playbook list
- Clarified that API 403s may indicate missing scope or disabled API on the project
- Updated `tana_review` deployment status and connection method

## Notable Implementation Details

- The expanded reasoning guidance shifts Haku from a task-runner toward a research and synthesis agent that actively hunts for corroborating evidence and primary sources
- The operator model is now positioned as a core function, not a bonus — it drives filtering and calibration of every candidate item
- The `inbox_cleanup` playbook emphasizes proposing cleanup (read-only) rather than executing it, with the executor session handling write operations

https://claude.ai/code/session_01SzfWx5UYqJVxz6bN7D3WEr