### PR TITLE
props: unify match_file_restriction matchability into one predicate

### DIFF
--- a/props/agents/grader/BUILD.bazel
+++ b/props/agents/grader/BUILD.bazel
@@ -156,6 +156,7 @@ py_test(
         "//props:conftest",
         "//props/db:database",
         "//props/db:models",
+        "//props/db:snapshots",
         "//props/testing/fixtures:runs",
         "@pypi//pytest",
         "@pypi//pytest_asyncio",  # keep

--- a/props/agents/grader/test_grading_edges_constraints.py
+++ b/props/agents/grader/test_grading_edges_constraints.py
@@ -12,7 +12,8 @@ import pytest
 import pytest_bazel
 from sqlalchemy.exc import IntegrityError
 
-from props.db.models import AgentRunStatus, GradingEdge
+from props.db.models import AgentRunStatus, GradingEdge, ReportedIssue, ReportedIssueOccurrence
+from props.db.snapshots import LocationAnchor
 from props.testing.fixtures.runs import make_fake_critic_run, make_fake_grader_run, make_reported_issues
 
 
@@ -178,6 +179,46 @@ def test_credit_sum_trigger_enforces_limit_fp(session, add_edge, fp_occurrence):
     with pytest.raises(Exception, match=r"Credit sum .* would exceed 1\.0"):
         session.commit()
     session.rollback()
+
+
+def test_edge_overlap_not_containment_is_gradeable(session, test_critic_run, test_grader_run, example_subtract_orm):
+    """Regression: an edge whose critique reports files OVERLAPPING but not CONTAINED in
+    a restricted occurrence's match_file_restriction must insert successfully.
+
+    train1's tp-001/occ-1 is restricted to {subtract.py}. A critic that reports the issue
+    on {subtract.py, add.py} overlaps the restriction (subtract.py) but is not contained in
+    it (add.py is extra). The matchability rule is OVERLAP, so the edge is valid. The old
+    enforce_edge_filter_scope trigger used CONTAINMENT and rejected such edges — the poison
+    pill that crash-looped the grader.
+    """
+    issue_id = "overlap-not-containment"
+    session.add(ReportedIssue(agent_run_id=test_critic_run.agent_run_id, issue_id=issue_id, rationale="overlap test"))
+    session.add(
+        ReportedIssueOccurrence(
+            agent_run_id=test_critic_run.agent_run_id,
+            reported_issue_id=issue_id,
+            # subtract.py is inside tp-001's restriction set; add.py is outside it.
+            locations=[
+                LocationAnchor(file="subtract.py", start_line=1, end_line=1),
+                LocationAnchor(file="add.py", start_line=1, end_line=1),
+            ],
+        )
+    )
+    session.flush()
+
+    session.add(
+        GradingEdge(
+            grader_run_id=test_grader_run.agent_run_id,
+            critique_run_id=test_critic_run.agent_run_id,
+            critique_issue_id=issue_id,
+            snapshot_slug=example_subtract_orm.snapshot_slug,
+            tp_id="tp-001",
+            tp_occurrence_id="occ-1",
+            credit=1.0,
+            rationale="Overlaps subtract.py (in restriction), plus add.py (outside)",
+        )
+    )
+    session.commit()
 
 
 if __name__ == "__main__":

--- a/props/agents/grader/test_matchable_occurrences.py
+++ b/props/agents/grader/test_matchable_occurrences.py
@@ -144,6 +144,23 @@ class TestMatchableOccurrences:
         # Single file should have fewer matchable occurrences
         assert single_file <= all_files, "Single file should have <= matchable occurrences than all files"
 
+    def test_restricted_tp_matched_when_files_overlap_not_contain(self, session, test_trivial_snapshot):
+        """A file-restricted TP is matchable when reported files OVERLAP the restriction set,
+        even if extra (out-of-set) files are also reported.
+
+        tp-001 is restricted to {subtract.py}. Reporting {subtract.py, add.py} overlaps the
+        restriction (subtract.py) while also touching add.py (outside it). The rule is OVERLAP,
+        so tp-001 must be matchable — the regression that crash-looped the grader.
+        """
+        result = session.execute(
+            text("""
+                SELECT tp_id FROM matchable_occurrences(:snapshot, ARRAY['subtract.py', 'add.py'])
+                WHERE tp_id IS NOT NULL
+            """),
+            {"snapshot": test_trivial_snapshot.slug},
+        ).fetchall()
+        assert "tp-001" in {row.tp_id for row in result}
+
     def test_empty_file_array_only_matches_unrestricted(self, session, test_trivial_snapshot):
         """Empty file array should only match unrestricted (NULL) occurrences."""
         result = session.execute(

--- a/props/db/migrations/versions/20260619000000_unify_matchability_predicate.py
+++ b/props/db/migrations/versions/20260619000000_unify_matchability_predicate.py
@@ -1,0 +1,240 @@
+"""Unify the match_file_restriction matchability rule into one predicate.
+
+The "matchability" rule — whether a critique issue may be graded against a GT
+TP/FP occurrence that carries a ``match_file_restriction`` — was implemented
+twice with divergent semantics:
+
+- ``matchable_occurrences()`` (used by the ``grading_pending`` view and workload
+  estimation) used OVERLAP: an occurrence is matchable if the restriction is NULL
+  or at least one reported file is in the restriction set.
+- ``check_edge_matches_filter_scope()`` (BEFORE INSERT/UPDATE trigger on
+  ``grading_edges``) used CONTAINMENT: it rejected an edge if ANY reported file
+  was outside the restriction set, i.e. it required all reported files ⊆ set.
+
+The documentation (ground_truth.md.mako, grading.md.mako, ground_truth_authoring.md)
+uniformly specifies OVERLAP ("only critiques touching at least one file in that
+set", "where the critique's files overlap"). The trigger's containment rule is the
+bug: a critic that reports a real issue plus an extra adjacent file gets the whole
+edge rejected, the grader retries to exhaustion, calls report_failure, exits 1, and
+the supervisor respawns it forever (poison pill / crash loop).
+
+Fix: introduce ONE canonical SQL predicate
+``occurrence_files_overlap(p_snapshot_slug, p_files_hash, p_files)`` expressing the
+overlap rule, and rewrite BOTH ``matchable_occurrences()`` and
+``check_edge_matches_filter_scope()`` to call it. Single source of truth.
+
+Revision ID: 20260619000000
+Revises: 20260608000000
+Create Date: 2026-06-19
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "20260619000000"
+down_revision: str | None = "20260608000000"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# --- Canonical matchability predicate (overlap rule) -------------------------
+# Returns TRUE if an occurrence with the given match_file_restriction file set
+# is matchable from the given reported files:
+#   - NULL restriction  -> unrestricted, always matchable
+#   - non-NULL          -> matchable iff at least one reported file is in the set
+OVERLAP_PREDICATE = """
+    CREATE OR REPLACE FUNCTION occurrence_files_overlap(
+        p_snapshot_slug VARCHAR,
+        p_files_hash VARCHAR,
+        p_files VARCHAR[]
+    ) RETURNS boolean
+    LANGUAGE sql STABLE
+    SET search_path = public
+    AS $$
+        SELECT p_files_hash IS NULL
+            OR EXISTS (
+                SELECT 1 FROM file_set_members fsm
+                WHERE fsm.snapshot_slug = p_snapshot_slug
+                  AND fsm.files_hash = p_files_hash
+                  AND fsm.file_path = ANY(p_files)
+            )
+    $$
+"""
+
+# Signature unchanged -> CREATE OR REPLACE keeps the grading_pending view (and any
+# other dependents) bound without a CASCADE drop.
+MATCHABLE_OCCURRENCES_UNIFIED = """
+    CREATE OR REPLACE FUNCTION matchable_occurrences(
+        p_snapshot_slug VARCHAR,
+        p_files VARCHAR[]
+    ) RETURNS TABLE (
+        tp_id VARCHAR,
+        tp_occurrence_id VARCHAR,
+        fp_id VARCHAR,
+        fp_occurrence_id VARCHAR
+    ) AS $$
+        SELECT tpo.tp_id, tpo.occurrence_id, NULL::VARCHAR, NULL::VARCHAR
+        FROM true_positive_occurrences tpo
+        WHERE tpo.snapshot_slug = p_snapshot_slug
+          AND occurrence_files_overlap(tpo.snapshot_slug, tpo.match_file_restriction, p_files)
+        UNION ALL
+        SELECT NULL, NULL, fpo.fp_id, fpo.occurrence_id
+        FROM false_positive_occurrences fpo
+        WHERE fpo.snapshot_slug = p_snapshot_slug
+          AND occurrence_files_overlap(fpo.snapshot_slug, fpo.match_file_restriction, p_files)
+    $$ LANGUAGE SQL STABLE
+"""
+
+# Trigger now enforces the SAME overlap rule: reject only when the restriction is
+# set and NONE of the critique's reported files fall inside it.
+CHECK_EDGE_FILTER_SCOPE_UNIFIED = """
+    CREATE OR REPLACE FUNCTION check_edge_matches_filter_scope() RETURNS trigger
+    LANGUAGE plpgsql
+    SET search_path = public
+    AS $$
+    DECLARE
+        filter_hash TEXT;
+        reported_files VARCHAR[];
+    BEGIN
+        IF NEW.tp_id IS NOT NULL THEN
+            SELECT match_file_restriction INTO filter_hash
+            FROM true_positive_occurrences
+            WHERE snapshot_slug = NEW.snapshot_slug
+              AND tp_id = NEW.tp_id
+              AND occurrence_id = NEW.tp_occurrence_id;
+        ELSE
+            SELECT match_file_restriction INTO filter_hash
+            FROM false_positive_occurrences
+            WHERE snapshot_slug = NEW.snapshot_slug
+              AND fp_id = NEW.fp_id
+              AND occurrence_id = NEW.fp_occurrence_id;
+        END IF;
+
+        IF filter_hash IS NULL THEN
+            RETURN NEW;
+        END IF;
+
+        -- Files this critique issue reported (reported_issue_occurrences.locations
+        -- is a JSONB array of {file, start_line?, end_line?}).
+        SELECT array_agg(DISTINCT loc->>'file')
+        INTO reported_files
+        FROM reported_issue_occurrences rio
+        CROSS JOIN LATERAL jsonb_array_elements(rio.locations) AS loc
+        WHERE rio.agent_run_id = NEW.critique_run_id
+          AND rio.reported_issue_id = NEW.critique_issue_id
+          AND loc->>'file' IS NOT NULL;
+
+        IF NOT occurrence_files_overlap(NEW.snapshot_slug, filter_hash, COALESCE(reported_files, ARRAY[]::VARCHAR[])) THEN
+            RAISE EXCEPTION 'Critique issue % reports no files overlapping target occurrence match_file_restriction scope (filter: %)',
+                NEW.critique_issue_id, filter_hash;
+        END IF;
+
+        RETURN NEW;
+    END;
+    $$
+"""
+
+# --- Original (buggy) definitions, restored on downgrade ---------------------
+MATCHABLE_OCCURRENCES_ORIGINAL = """
+    CREATE OR REPLACE FUNCTION matchable_occurrences(
+        p_snapshot_slug VARCHAR,
+        p_files VARCHAR[]
+    ) RETURNS TABLE (
+        tp_id VARCHAR,
+        tp_occurrence_id VARCHAR,
+        fp_id VARCHAR,
+        fp_occurrence_id VARCHAR
+    ) AS $$
+        SELECT tpo.tp_id, tpo.occurrence_id, NULL::VARCHAR, NULL::VARCHAR
+        FROM true_positive_occurrences tpo
+        WHERE tpo.snapshot_slug = p_snapshot_slug
+          AND (
+              tpo.match_file_restriction IS NULL
+              OR EXISTS (
+                  SELECT 1 FROM file_set_members fsm
+                  WHERE fsm.snapshot_slug = tpo.snapshot_slug
+                    AND fsm.files_hash = tpo.match_file_restriction
+                    AND fsm.file_path = ANY(p_files)
+              )
+          )
+        UNION ALL
+        SELECT NULL, NULL, fpo.fp_id, fpo.occurrence_id
+        FROM false_positive_occurrences fpo
+        WHERE fpo.snapshot_slug = p_snapshot_slug
+          AND (
+              fpo.match_file_restriction IS NULL
+              OR EXISTS (
+                  SELECT 1 FROM file_set_members fsm
+                  WHERE fsm.snapshot_slug = fpo.snapshot_slug
+                    AND fsm.files_hash = fpo.match_file_restriction
+                    AND fsm.file_path = ANY(p_files)
+              )
+          )
+    $$ LANGUAGE SQL STABLE
+"""
+
+CHECK_EDGE_FILTER_SCOPE_ORIGINAL = """
+    CREATE OR REPLACE FUNCTION check_edge_matches_filter_scope() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+    DECLARE
+        filter_hash TEXT;
+    BEGIN
+        IF NEW.tp_id IS NOT NULL THEN
+            SELECT match_file_restriction INTO filter_hash
+            FROM true_positive_occurrences
+            WHERE snapshot_slug = NEW.snapshot_slug
+              AND tp_id = NEW.tp_id
+              AND occurrence_id = NEW.tp_occurrence_id;
+        ELSE
+            SELECT match_file_restriction INTO filter_hash
+            FROM false_positive_occurrences
+            WHERE snapshot_slug = NEW.snapshot_slug
+              AND fp_id = NEW.fp_id
+              AND occurrence_id = NEW.fp_occurrence_id;
+        END IF;
+
+        IF filter_hash IS NULL THEN
+            RETURN NEW;
+        END IF;
+
+        IF EXISTS (
+            SELECT 1 FROM reported_issue_occurrences rio
+            CROSS JOIN LATERAL jsonb_array_elements(rio.locations) AS loc
+            WHERE rio.agent_run_id = NEW.critique_run_id
+              AND rio.reported_issue_id = NEW.critique_issue_id
+              AND loc->>'file' NOT IN (
+                  SELECT file_path FROM file_set_members
+                  WHERE snapshot_slug = NEW.snapshot_slug
+                    AND files_hash = filter_hash
+              )
+        ) THEN
+            RAISE EXCEPTION 'Critique issue % reports files outside target occurrence match_file_restriction scope (filter: %)',
+                NEW.critique_issue_id, filter_hash;
+        END IF;
+
+        RETURN NEW;
+    END;
+    $$
+"""
+
+
+def upgrade() -> None:
+    op.execute(OVERLAP_PREDICATE)
+    op.execute(MATCHABLE_OCCURRENCES_UNIFIED)
+    op.execute(CHECK_EDGE_FILTER_SCOPE_UNIFIED)
+    op.execute("""
+        COMMENT ON FUNCTION occurrence_files_overlap(VARCHAR, VARCHAR, VARCHAR[]) IS
+        'Canonical match_file_restriction matchability rule (OVERLAP).
+TRUE if p_files_hash IS NULL (unrestricted) or at least one of p_files is in the
+restriction file set. Single source of truth shared by matchable_occurrences()
+(grading_pending view, workload estimation) and the enforce_edge_filter_scope trigger.'
+    """)
+
+
+def downgrade() -> None:
+    op.execute(MATCHABLE_OCCURRENCES_ORIGINAL)
+    op.execute(CHECK_EDGE_FILTER_SCOPE_ORIGINAL)
+    op.execute("DROP FUNCTION IF EXISTS occurrence_files_overlap(VARCHAR, VARCHAR, VARCHAR[])")

--- a/props/orchestration/grader_supervisor.py
+++ b/props/orchestration/grader_supervisor.py
@@ -30,7 +30,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from collections import defaultdict
+from dataclasses import dataclass
 from types import TracebackType
 from typing import TYPE_CHECKING, Any
 
@@ -63,6 +65,26 @@ DEFAULT_RECONCILE_DEBOUNCE_S = 30.0
 # that crashed, a pod deleted out-of-band). 0 disables the loop.
 DEFAULT_PERIODIC_RECONCILE_S = 120.0
 
+# Crash-loop backoff: a grader that exits Failed is respawned, but only after an
+# exponentially growing quiet window keyed on how many times it has failed in a
+# row. Without this, a poison snapshot (e.g. an ungradeable critique) respawns a
+# fresh grader every reconcile and burns tokens unbounded.
+DEFAULT_BACKOFF_BASE_S = 120.0
+DEFAULT_BACKOFF_MAX_S = 3600.0
+# After this many consecutive failures the snapshot is quarantined: no respawn
+# until an operator intervenes (or the grader definition changes, which clears
+# the count). Surfaces a stuck snapshot instead of retrying forever.
+DEFAULT_MAX_CONSECUTIVE_FAILURES = 6
+
+
+@dataclass
+class _FailureState:
+    """Per-snapshot crash-loop accounting (monotonic clock)."""
+
+    consecutive: int
+    # Earliest monotonic time at which a respawn may be attempted.
+    respawn_not_before: float
+
 
 class GraderSupervisor:
     """Manages per-snapshot grader containers via reconciliation against the
@@ -85,6 +107,9 @@ class GraderSupervisor:
         *,
         reconcile_debounce_s: float = DEFAULT_RECONCILE_DEBOUNCE_S,
         periodic_reconcile_s: float = DEFAULT_PERIODIC_RECONCILE_S,
+        backoff_base_s: float = DEFAULT_BACKOFF_BASE_S,
+        backoff_max_s: float = DEFAULT_BACKOFF_MAX_S,
+        max_consecutive_failures: int = DEFAULT_MAX_CONSECUTIVE_FAILURES,
     ):
         self._registry = registry
         self._db_config = db_config
@@ -104,6 +129,11 @@ class GraderSupervisor:
         # Periodic backstop.
         self._periodic_reconcile_s = periodic_reconcile_s
         self._periodic_task: asyncio.Task[None] | None = None
+        # Crash-loop backoff state, keyed by snapshot.
+        self._backoff_base_s = backoff_base_s
+        self._backoff_max_s = backoff_max_s
+        self._max_consecutive_failures = max_consecutive_failures
+        self._failures: dict[SnapshotSlug, _FailureState] = {}
 
     async def __aenter__(self) -> GraderSupervisor:
         await self.start()
@@ -138,6 +168,9 @@ class GraderSupervisor:
             return
         notification = GraderDefinitionChangedNotification.model_validate_json(payload)
         logger.info(f"Grader definition changed: {notification.tag} -> {notification.digest}")
+        # A new grader image is a fresh attempt: clear crash-loop backoff so quarantined
+        # snapshots get re-graded (the new image may fix the failure).
+        self._failures.clear()
         # No restart flag: reconcile detects wrong-image graders from the API and
         # replaces them, so a tag move just schedules a normal reconcile.
         self._schedule_reconcile(trigger=f"grader_definition_changed:{notification.tag}")
@@ -221,8 +254,12 @@ class GraderSupervisor:
         for pod in pods:
             by_snapshot[pod.snapshot_slug].append(pod)
 
+        now = time.monotonic()
         handles_by_pod_name = {h.name: h for h in self._handles.values()}
         new_handles: dict[SnapshotSlug, AgentRunHandle] = {}
+        # Snapshots whose grader was observed Failed this cycle: never respawn them in
+        # the same reconcile that saw the crash, regardless of backoff window length.
+        failed_this_cycle: set[SnapshotSlug] = set()
         kept = adopted = reaped = spawned = 0
 
         for slug, plist in by_snapshot.items():
@@ -233,6 +270,17 @@ class GraderSupervisor:
             for pod in plist:
                 if keeper is not None and pod.name == keeper.name:
                     continue
+                # Terminal pods on the current image carry the crash-loop signal: a
+                # Failed exit feeds the backoff; a Succeeded exit clears it (a grader
+                # that finished its run proves the snapshot is gradeable again). A
+                # merely-Running pod is NOT proof of health — it may still crash — so
+                # it never resets the count.
+                if slug in desired and pod.image_ref == resolved.oci_ref:
+                    if pod.phase == "failed":
+                        self._record_failure(slug, now=now)
+                        failed_this_cycle.add(slug)
+                    elif pod.phase == "succeeded":
+                        self._failures.pop(slug, None)
                 await self._reap(pod, desired=desired, image=resolved, tracked=handles_by_pod_name)
                 reaped += 1
             if keeper is not None:
@@ -245,7 +293,7 @@ class GraderSupervisor:
                     adopted += 1
 
         for slug in desired:
-            if slug not in new_handles:
+            if slug not in new_handles and slug not in failed_this_cycle and self._may_spawn(slug, now=now):
                 handle = await self._spawn_grader(slug, image=resolved, trigger=trigger)
                 if handle is not None:
                     new_handles[slug] = handle
@@ -298,6 +346,35 @@ class GraderSupervisor:
             await handle.kill_and_delete()
         else:
             await self._registry.reap_grader_pod(pod, reason=reason)
+
+    # --- Crash-loop backoff ---
+
+    def _record_failure(self, slug: SnapshotSlug, *, now: float) -> None:
+        """Account a grader crash for ``slug`` and schedule its next respawn window."""
+        prev = self._failures.get(slug)
+        consecutive = (prev.consecutive if prev else 0) + 1
+        delay = min(self._backoff_base_s * 2 ** (consecutive - 1), self._backoff_max_s)
+        self._failures[slug] = _FailureState(consecutive=consecutive, respawn_not_before=now + delay)
+        if consecutive >= self._max_consecutive_failures:
+            logger.error(
+                "Grader for %s failed %d times in a row — quarantined, no respawn until the grader "
+                "definition changes or an operator clears it",
+                slug,
+                consecutive,
+            )
+        else:
+            logger.warning(
+                "Grader for %s failed (%d consecutive); backing off %.0fs before respawn", slug, consecutive, delay
+            )
+
+    def _may_spawn(self, slug: SnapshotSlug, *, now: float) -> bool:
+        """False while ``slug`` is quarantined or inside its crash-loop backoff window."""
+        state = self._failures.get(slug)
+        if state is None:
+            return True
+        if state.consecutive >= self._max_consecutive_failures:
+            return False
+        return now >= state.respawn_not_before
 
     # --- Internal helpers ---
 

--- a/props/orchestration/test_grader_supervisor.py
+++ b/props/orchestration/test_grader_supervisor.py
@@ -23,7 +23,11 @@ import pytest_bazel
 from props.core.ids import SnapshotSlug
 from props.orchestration.agent_registry import GraderPodInfo, ImageResolutionError, ResolvedImage
 from props.orchestration.executor import PodPhase
-from props.orchestration.grader_supervisor import GraderSupervisor
+from props.orchestration.grader_supervisor import (
+    DEFAULT_BACKOFF_BASE_S,
+    DEFAULT_MAX_CONSECUTIVE_FAILURES,
+    GraderSupervisor,
+)
 
 FAKE_IMAGE = ResolvedImage(digest="sha256:abc123", oci_ref="localhost:8000/grader@sha256:abc123")
 OLD_IMAGE = ResolvedImage(digest="sha256:old", oci_ref="localhost:8000/grader@sha256:old")
@@ -92,7 +96,12 @@ class FakeRegistry:
 
 
 def _make_supervisor(
-    snapshot_slugs: list[SnapshotSlug], *, image: ResolvedImage | None = FAKE_IMAGE, reconcile_debounce_s: float = 0.05
+    snapshot_slugs: list[SnapshotSlug],
+    *,
+    image: ResolvedImage | None = FAKE_IMAGE,
+    reconcile_debounce_s: float = 0.05,
+    backoff_base_s: float = DEFAULT_BACKOFF_BASE_S,
+    max_consecutive_failures: int = DEFAULT_MAX_CONSECUTIVE_FAILURES,
 ) -> tuple[GraderSupervisor, FakeRegistry]:
     registry = FakeRegistry(image=image)
 
@@ -112,6 +121,8 @@ def _make_supervisor(
         db=db,
         reconcile_debounce_s=reconcile_debounce_s,
         periodic_reconcile_s=0,  # no backstop loop in unit tests
+        backoff_base_s=backoff_base_s,
+        max_consecutive_failures=max_consecutive_failures,
     )
     return gs, registry
 
@@ -195,13 +206,59 @@ async def test_reconcile_replaces_wrong_image():
     assert next(iter(registry.pods.values())).image_ref == FAKE_IMAGE.oci_ref
 
 
-async def test_reconcile_reaps_terminal_pod_and_respawns():
-    """A crashed (Failed) grader is finalized/reaped and a fresh one spawned."""
+async def test_reconcile_reaps_terminal_pod_and_backs_off():
+    """A crashed (Failed) grader is finalized/reaped but NOT immediately respawned —
+    the first failure opens a backoff window to avoid a tight crash loop."""
     gs, registry = _make_supervisor([SNAP_A])
     registry.add_pod(SNAP_A, image_ref=FAKE_IMAGE.oci_ref, phase="failed")
     await gs.reconcile(trigger="periodic")
     assert len(registry.reaped) == 1
+    assert registry.spawned == []  # backed off, not respawned
+    assert gs._failures[SNAP_A].consecutive == 1
+
+
+async def test_reconcile_succeeded_pod_respawns_without_backoff():
+    """A grader that exited Succeeded is finalized and a fresh one spawned immediately —
+    success is not a crash, so it does not trigger backoff."""
+    gs, registry = _make_supervisor([SNAP_A])
+    registry.add_pod(SNAP_A, image_ref=FAKE_IMAGE.oci_ref, phase="succeeded")
+    await gs.reconcile(trigger="periodic")
+    assert len(registry.reaped) == 1
     assert registry.spawned == [SNAP_A]
+    assert SNAP_A not in gs._failures
+
+
+async def test_reconcile_respawns_after_backoff_window_elapses():
+    """Once the backoff window passes, a failed snapshot is respawned again."""
+    gs, registry = _make_supervisor([SNAP_A], backoff_base_s=0.0)
+    registry.add_pod(SNAP_A, image_ref=FAKE_IMAGE.oci_ref, phase="failed")
+    await gs.reconcile(trigger="periodic")  # records failure; window already elapsed (base 0)
+    assert registry.spawned == []
+    await gs.reconcile(trigger="periodic")  # window elapsed -> respawn
+    assert registry.spawned == [SNAP_A]
+
+
+async def test_reconcile_quarantines_after_max_consecutive_failures():
+    """After max consecutive failures the snapshot is quarantined: no further respawn."""
+    gs, registry = _make_supervisor([SNAP_A], backoff_base_s=0.0, max_consecutive_failures=3)
+    for _ in range(3):
+        registry.add_pod(SNAP_A, image_ref=FAKE_IMAGE.oci_ref, phase="failed")
+        await gs.reconcile(trigger="periodic")
+    assert gs._failures[SNAP_A].consecutive == 3
+    registry.spawned.clear()
+    await gs.reconcile(trigger="periodic")  # no pods present, but quarantined
+    assert registry.spawned == []
+
+
+async def test_succeeded_grader_clears_backoff():
+    """A snapshot whose grader later exits Succeeded has its failure count reset."""
+    gs, registry = _make_supervisor([SNAP_A], backoff_base_s=0.0)
+    registry.add_pod(SNAP_A, image_ref=FAKE_IMAGE.oci_ref, phase="failed")
+    await gs.reconcile(trigger="periodic")
+    assert SNAP_A in gs._failures
+    registry.add_pod(SNAP_A, image_ref=FAKE_IMAGE.oci_ref, phase="succeeded")
+    await gs.reconcile(trigger="periodic")
+    assert SNAP_A not in gs._failures
 
 
 async def test_reconcile_spawns_new_snapshot_only():

--- a/props/testing/fixtures/runs.py
+++ b/props/testing/fixtures/runs.py
@@ -20,10 +20,12 @@ from props.db.models import (
     AgentDefinition,
     AgentRun,
     AgentRunStatus,
+    FileSetMember,
     GradingEdge,
     ReportedIssue,
     ReportedIssueOccurrence,
     Snapshot,
+    TruePositiveOccurrenceORM,
 )
 from props.db.snapshots import LocationAnchor
 from props.testing.constants import DEFAULT_TEST_MODEL
@@ -108,6 +110,30 @@ def make_fake_grader_run(
     )
 
 
+def overlap_file_for_occurrence(
+    session: Session, snapshot_slug: SnapshotSlug, tp_id: str, occurrence_id: str, *, default: str = "subtract.py"
+) -> str:
+    """A reported-issue file that satisfies a TP occurrence's match_file_restriction.
+
+    The grading-edge trigger (and the grading_pending view) only credit a critique
+    against a restricted occurrence when the critique flagged a file overlapping the
+    restriction set. Fixtures that match restricted occurrences must therefore report
+    a file inside the restriction; for unrestricted occurrences any file works.
+    """
+    occ = session.get(TruePositiveOccurrenceORM, (snapshot_slug, tp_id, occurrence_id))
+    assert occ is not None, f"No TP occurrence {tp_id}/{occurrence_id} for {snapshot_slug}"
+    if occ.match_file_restriction is None:
+        return default
+    member = (
+        session.query(FileSetMember)
+        .filter_by(snapshot_slug=snapshot_slug, files_hash=occ.match_file_restriction)
+        .order_by(FileSetMember.file_path)
+        .first()
+    )
+    assert member is not None, f"Empty match_file_restriction file set for {tp_id}/{occurrence_id}"
+    return member.file_path
+
+
 def make_reported_issues(
     *, agent_run_id: UUID, issue_ids: list[str], session: Session, location_file: str | None = "subtract.py"
 ) -> list[ReportedIssue]:
@@ -146,18 +172,21 @@ def make_fake_critic_and_grader_run(
     session.flush()
 
     if credit > 0.0:
-        location_file = None if example.kind == ExampleKind.WHOLE_SNAPSHOT else "subtract.py"
-        for i in range(1, len(tp_occurrences) + 1):
+        for i, (tp_id, occ_id) in enumerate(tp_occurrences, start=1):
             issue_id = f"issue-{i:03d}"
             issue = ReportedIssue(agent_run_id=critic_run.agent_run_id, issue_id=issue_id, rationale=f"Test issue {i}")
             session.add(issue)
-            if location_file:
-                occ = ReportedIssueOccurrence(
-                    agent_run_id=critic_run.agent_run_id,
-                    reported_issue_id=issue_id,
-                    locations=[LocationAnchor(file=location_file, start_line=1, end_line=1)],
-                )
-                session.add(occ)
+            # Report a file overlapping this occurrence's match_file_restriction so the
+            # grading edge below is creditable (the trigger and grading_pending view both
+            # require overlap). A no-file/non-overlapping critique cannot match a
+            # restricted occurrence.
+            location_file = overlap_file_for_occurrence(session, example.snapshot_slug, tp_id, occ_id)
+            occ = ReportedIssueOccurrence(
+                agent_run_id=critic_run.agent_run_id,
+                reported_issue_id=issue_id,
+                locations=[LocationAnchor(file=location_file, start_line=1, end_line=1)],
+            )
+            session.add(occ)
 
         # Flush reported issues before adding grading edges (FK constraint)
         session.flush()
@@ -193,17 +222,20 @@ def make_fake_grader_run_with_credit(
     """Create grader run + grading_edge for a critic run using real TP occurrence IDs."""
     tp_id, occ_id = tp_occurrence
     issue_id = f"input-{input_idx}"
+    snapshot_slug = critic_run.critic_config().example.snapshot_slug
 
     issue = ReportedIssue(agent_run_id=critic_run.agent_run_id, issue_id=issue_id, rationale=f"Test issue {input_idx}")
     session.add(issue)
+    # Report a file overlapping the occurrence's match_file_restriction (see
+    # overlap_file_for_occurrence) so the grading edge below is creditable.
+    location_file = overlap_file_for_occurrence(session, snapshot_slug, tp_id, occ_id)
     occ = ReportedIssueOccurrence(
         agent_run_id=critic_run.agent_run_id,
         reported_issue_id=issue_id,
-        locations=[LocationAnchor(file="subtract.py", start_line=1, end_line=1)],
+        locations=[LocationAnchor(file=location_file, start_line=1, end_line=1)],
     )
     session.add(occ)
 
-    snapshot_slug = critic_run.critic_config().example.snapshot_slug
     grader_run = make_fake_grader_run(session=session, snapshot_slug=snapshot_slug, model=model)
     session.add(grader_run)
     session.flush()


### PR DESCRIPTION
## Problem

The props grader was crash-looping on snapshot `ducktape/2025-11-22-00` and burning GLM-4.6 tokens continuously (observed ~330M tokens/day on the z.ai account). Root cause: the **match_file_restriction "matchability" rule is implemented twice, with divergent semantics**, in `props/db/migrations/versions/20251228000000_complete_schema.py`:

| Implementation | Rule | Used by |
| --- | --- | --- |
| `matchable_occurrences()` | **OVERLAP** — matchable iff restriction is NULL or ≥1 reported file ∈ set | `grading_pending` view, workload estimation |
| `check_edge_matches_filter_scope()` trigger | **CONTAINMENT** — reject unless ALL reported files ⊆ set | `BEFORE INSERT/UPDATE` on `grading_edges` |

When a critic reports a real issue plus an extra adjacent file (e.g. `{stores.ts, RightSidebar.svelte}` against a TP restricted to `{stores.ts}`), the `grading_pending` view surfaces the edge (overlap) but the trigger **rejects the insert** (containment). The grader retries to exhaustion, calls `report_failure`, exits 1, and `grader_supervisor` respawns a fresh grader every reconcile — a poison-pill crash loop with no backoff.

`matchable_occurrences`' own comment even lists "Edge validation trigger" as a consumer of the same rule — so the trigger reimplementing a stricter rule is the bug. All docs (`ground_truth.md.mako`, `grading.md.mako`, `ground_truth_authoring.md`) uniformly specify **overlap**.

## Fix

- **Migration `20260619000000`** introduces one canonical predicate `occurrence_files_overlap(snapshot, files_hash, files)` and rewrites **both** `matchable_occurrences()` and `check_edge_matches_filter_scope()` to call it. `CREATE OR REPLACE`, signatures unchanged → `grading_pending` stays bound, no CASCADE. Downgrade restores the original (buggy) bodies.
- **No specimen data change** — overlap is canonical, so existing `match_file_restriction` sets are correct; the poison edges simply become gradeable.
- **Defense-in-depth:** `grader_supervisor` now applies per-snapshot exponential crash-loop backoff (base 120s, cap 1h) and **quarantines** a snapshot after 6 consecutive failures, so no future poison pill can respawn a grader every reconcile. A `Succeeded` exit or a grader-definition change clears the count.
- Regression tests: an overlap-but-not-containment edge is now gradeable (trigger + view paths); supervisor backoff/quarantine tests.

## Notes

- Once this deploys, `auto_migrate` applies the migration on boot and the live crash loop ends. No live DB hotfix was applied (per request), so the burn continues until deploy.
- Tests pass on RBE (`bbr`): `//props/orchestration:test_grader_supervisor`, `//props/agents/grader:{test_grading_edges_constraints,test_matchable_occurrences}`, `//props/db/migrations:test_migration_sequence`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)