### PR TITLE
nix-attic-push: skip google-drive override for claude-web home config

### DIFF
--- a/devinfra/ci/nix_attic_build_and_push.sh
+++ b/devinfra/ci/nix_attic_build_and_push.sh
@@ -27,14 +27,25 @@ for host in $(nix eval --json .#nixosConfigurations --apply builtins.attrNames |
     --no-link --print-out-paths >>"$out_paths"
 done
 
-# Home configurations (google-drive disabled via extendModules so the private
-# gaffer-private binary is never fetched at eval time)
+# Home configurations: disable google-drive via extendModules so the private
+# gaffer-private binary is never fetched at eval time.
+#
+# claude-web is a minimal standalone profile that does NOT import the
+# google-drive module, so injecting the option there fails with "The option
+# services.google-drive does not exist". Skip the override for it. (A generic
+# guard on whether the option exists is not possible: referencing `options`
+# from a module's config triggers infinite recursion in the module fixpoint.)
 for host in $(nix eval --impure --json .#homeConfigurations --apply builtins.attrNames | jq -r '.[]'); do
+  if [ "$host" = claude-web ]; then
+    target="flake.homeConfigurations.$host.activationPackage"
+  else
+    target="(flake.homeConfigurations.$host.extendModules {
+      modules = [ { services.google-drive.enable = false; } ];
+    }).activationPackage"
+  fi
   nix build --impure --expr "
     let flake = builtins.getFlake \"path:$(pwd)\";
-    in (flake.homeConfigurations.$host.extendModules {
-      modules = [{ services.google-drive.enable = false; }];
-    }).activationPackage
+    in $target
   " --no-link --print-out-paths >>"$out_paths"
 done
 


### PR DESCRIPTION
The CI build script injects `services.google-drive.enable = false` into every
homeConfiguration via extendModules (so the private gaffer-private drivefs
binary is never fetched at eval time). claude-web is a minimal standalone
profile that does NOT import the google-drive module, so that injection failed
every run with "The option `services.google-drive' does not exist" — turning
nix-attic-push red on devel.

Skip the override for claude-web and build its activationPackage directly. A
generic guard (inject only where the option exists) isn't possible: referencing
`options` from a module's config triggers infinite recursion in the module
fixpoint.

Verified locally: `nix eval` of claude-web (plain) and atlas (with the override)
activationPackage drvPaths both succeed.

BAZEL_TEST_INVOCATIONS=none: CI shell-script change; no Bazel targets affected (verified via local nix eval of the affected home configs)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KmJwbYH1ZS4fuQ81fQoP6w