### PR TITLE
nix-attic-push: fix claude-web eval error and keep drivefs out of main

### DIFF
--- a/cluster/docs/nix_cache.md
+++ b/cluster/docs/nix_cache.md
@@ -79,6 +79,50 @@ JWTs auto-rotated by the cluster (1-year validity, mint-on-staleness):
 Both files are encrypted with the CI age key, already on both repos as
 `SOPS_AGE_KEY` (synced by `tf/gitops/github-secrets-sync/main.tf`).
 
+## Private-binary isolation (drivefs)
+
+`drivefs` (the Google Drive binary) must stay in the restricted `gaffer` cache
+and **never** land in the broadly-readable `main` cache. The boundary that
+enforces this is the **narinfo**: each cache signs and serves its own narinfos,
+gated by per-cache JWT scope. `main` and `gaffer` physically share the one
+`attic` S3 bucket of content-addressed chunks, but chunks are useless without
+the gaffer narinfo (NAR hash → ordered chunk list), so narinfo scoping is the
+real access boundary even though chunk bytes coexist.
+
+The leak it guards against: `nix/home/modules/google-drive.nix`, when
+`services.google-drive.enable = true` (wyrm2, rugged), pulls `drivefs` via
+`builtins.fetchClosure` from `gaffer` into the local store **at eval time**. If a
+closure containing it were pushed to `main`, `drivefs`'s narinfo would land in
+`main`, pullable by anyone with `main:pull`.
+
+So `devinfra/ci/nix_attic_build_and_push.sh` builds every config with
+google-drive **forced off** before pushing to `main`:
+
+- NixOS hosts: `extendModules` injects
+  `home-manager.sharedModules += { services.google-drive.enable = mkForce false; }`,
+  probed per host (hosts without home-manager — e.g. `bootstrap`,
+  `nix-rbe-worker` — build as-is).
+- Home configs: `extendModules` injects `services.google-drive.enable = false`
+  (the standalone `claude-web` profile doesn't import the module and is skipped —
+  injecting an undeclared option errors, and a guard conditioned on `options`
+  recurses in the module fixpoint).
+
+With it off, `config = lib.mkIf cfg.enable {…}` never references `drivefs`, so it
+is never fetched and never enters a pushed closure. Real hosts deploy with
+google-drive **on**: `nixos-rebuild switch` pulls `drivefs` straight from
+`gaffer` (their reader JWT carries `--pull gaffer`) and rebuilds only the cheap
+home-manager generation diff.
+
+**Invariant:** any config that sets `services.google-drive.enable = true` must be
+covered by the CI override, or `drivefs` leaks into `main`. The NixOS loop forces
+it off generically (probe + `extendModules`), so new hosts are covered
+automatically; the only manual case is a home profile that _lacks_ the module.
+
+**Storage-layer follow-up (not done):** for defense-in-depth — so even a broad
+`attic`-bucket reader key (SeaweedFS `claude-reader`, which holds `Read:attic`)
+can't touch `drivefs` chunks — `gaffer` would need its **own S3 bucket** with
+separate credentials. The narinfo boundary above is the current line of defense.
+
 ## Pulling (NixOS Hosts)
 
 Substituter wiring is via `ducktape.attic-substituter.enable` in

--- a/devinfra/ci/nix_attic_build_and_push.sh
+++ b/devinfra/ci/nix_attic_build_and_push.sh
@@ -20,11 +20,35 @@ trap 'kill -TERM "$watcher_pid" 2>/dev/null || true; wait "$watcher_pid" 2>/dev/
 
 out_paths=$(mktemp)
 
-# NixOS configurations
+# NixOS configurations.
+#
+# Force services.google-drive off for each system's home-manager users so the
+# private gaffer `drivefs` closure is never pulled into a closure we push to the
+# broadly-readable `main` cache. Only the workstation hosts (wyrm2, rugged)
+# enable it; they pull drivefs straight from the restricted `gaffer` cache at
+# `nixos-rebuild switch` and rebuild only the cheap home-manager generation
+# diff. Keeping drivefs out of `main` is the whole point of the separate gaffer
+# cache — see cluster/docs/nix_cache.md "Private-binary isolation (drivefs)".
+#
+# Probe for home-manager rather than hardcoding a host list: hosts without it
+# (e.g. bootstrap) have no such option and are built as-is. A guard *inside* the
+# module — conditioning config on whether the option exists — is not possible:
+# referencing `options` triggers infinite recursion in the module fixpoint.
 for host in $(nix eval --json .#nixosConfigurations --apply builtins.attrNames | jq -r '.[]'); do
-  nix build --impure \
-    ".#nixosConfigurations.$host.config.system.build.toplevel" \
-    --no-link --print-out-paths >>"$out_paths"
+  if nix eval --impure ".#nixosConfigurations.$host.config.home-manager.users" \
+    --apply builtins.attrNames >/dev/null 2>&1; then
+    target="(flake.nixosConfigurations.$host.extendModules {
+      modules = [
+        { home-manager.sharedModules = [ ({ lib, ... }: { services.google-drive.enable = lib.mkForce false; }) ]; }
+      ];
+    }).config.system.build.toplevel"
+  else
+    target="flake.nixosConfigurations.$host.config.system.build.toplevel"
+  fi
+  nix build --impure --expr "
+    let flake = builtins.getFlake \"path:$(pwd)\";
+    in $target
+  " --no-link --print-out-paths >>"$out_paths"
 done
 
 # Home configurations: disable google-drive via extendModules so the private


### PR DESCRIPTION
Two fixes to `nix-attic-push`, both around the google-drive / gaffer wiring.

## 1. Fix the `claude-web` eval error (devel CI red)

`devinfra/ci/nix_attic_build_and_push.sh` injects `services.google-drive.enable = false` into every `homeConfiguration` via `extendModules` (to avoid fetching the private gaffer binary at eval). But `claude-web` is a minimal standalone profile that bypasses `mkHome` and never imports the google-drive module, so the injection failed every run with:

```
error: The option `services.google-drive' does not exist. Definition values: { enable = false; }
```

This turned `nix-attic-push` red on devel. Fix: skip the override for `claude-web` and build its `activationPackage` directly. A generic "only inject where the option exists" guard isn't possible — referencing `options` from a module's config triggers infinite recursion in the module fixpoint.

## 2. Keep `drivefs` out of the `main` cache

The NixOS build loop builds `wyrm2`/`rugged` with `services.google-drive.enable = true`, which pulls the private gaffer `drivefs` closure via `builtins.fetchClosure` into the local store. `attic watch-store` + the final push then republish it into the broadly-readable `main` cache, defeating the gaffer/main separation.

Fix: force google-drive off for each system's home-manager users before pushing (`extendModules` injecting `home-manager.sharedModules += { services.google-drive.enable = mkForce false; }`), probed per host so non-home-manager systems (`bootstrap`, `nix-rbe-worker`) build as-is. With it off, `config = lib.mkIf cfg.enable {…}` never references `drivefs`, so it's never fetched and never enters a pushed closure. Real hosts still deploy with google-drive **on** and pull `drivefs` straight from `gaffer` at `nixos-rebuild switch`.

Documents the isolation model in `cluster/docs/nix_cache.md` (narinfo boundary, shared-bucket caveat, the invariant, and a separate-bucket follow-up for storage-layer defense-in-depth).

## Verification

- Reproduced the `claude-web` failure, then confirmed `nix eval` of `claude-web` (plain) and `atlas` (with override) `activationPackage.drvPath` both succeed.
- Confirmed the home-manager probe classifies hosts correctly and the override flips `wyrm2`'s `services.google-drive.enable` from `true` → `false`.
- pre-commit (shfmt, markdownlint, prettier) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmJwbYH1ZS4fuQ81fQoP6w

---
_Generated by [Claude Code](https://claude.ai/code/session_01KmJwbYH1ZS4fuQ81fQoP6w)_