### PR TITLE
nix-attic-push: only force google-drive off where it is enabled (fix bazel-test regression)

### DIFF
--- a/cluster/docs/nix_cache.md
+++ b/cluster/docs/nix_cache.md
@@ -95,17 +95,21 @@ The leak it guards against: `nix/home/modules/google-drive.nix`, when
 closure containing it were pushed to `main`, `drivefs`'s narinfo would land in
 `main`, pullable by anyone with `main:pull`.
 
-So `devinfra/ci/nix_attic_build_and_push.sh` builds every config with
-google-drive **forced off** before pushing to `main`:
+So `devinfra/ci/nix_attic_build_and_push.sh` forces google-drive **off** for any
+config that enables it before pushing to `main`, detected by reading the
+`services.google-drive.enable` bool (cheap; it does not fetch `drivefs`, which
+lives behind `config = lib.mkIf cfg.enable`):
 
-- NixOS hosts: `extendModules` injects
-  `home-manager.sharedModules += { services.google-drive.enable = mkForce false; }`,
-  probed per host (hosts without home-manager — e.g. `bootstrap`,
-  `nix-rbe-worker` — build as-is).
-- Home configs: `extendModules` injects `services.google-drive.enable = false`
-  (the standalone `claude-web` profile doesn't import the module and is skipped —
-  injecting an undeclared option errors, and a guard conditioned on `options`
-  recurses in the module fixpoint).
+- NixOS hosts: for each home-manager user reading `enable = true` (wyrm2,
+  rugged), `extendModules` injects
+  `home-manager.sharedModules += { services.google-drive.enable = mkForce false; }`.
+- Home configs: the same check on the config directly (none enable it today).
+
+Configs where the option is absent or false build as-is — they can't reference
+`drivefs`, and injecting an undeclared option would error. Crucially this covers
+configs that have **home-manager but not the google-drive module** (`bazel-test`'s
+`root` user; the standalone `claude-web` profile): the bool read errors → treated
+as not-enabled → built untouched.
 
 With it off, `config = lib.mkIf cfg.enable {…}` never references `drivefs`, so it
 is never fetched and never enters a pushed closure. Real hosts deploy with
@@ -113,10 +117,11 @@ google-drive **on**: `nixos-rebuild switch` pulls `drivefs` straight from
 `gaffer` (their reader JWT carries `--pull gaffer`) and rebuilds only the cheap
 home-manager generation diff.
 
-**Invariant:** any config that sets `services.google-drive.enable = true` must be
-covered by the CI override, or `drivefs` leaks into `main`. The NixOS loop forces
-it off generically (probe + `extendModules`), so new hosts are covered
-automatically; the only manual case is a home profile that _lacks_ the module.
+**Invariant:** the override targets exactly the configs whose
+`services.google-drive.enable` reads `true`, so a new google-drive host is covered
+automatically and a config that lacks the module is never mis-targeted (the bug
+that the earlier "force off everywhere with home-manager" approach hit on
+`bazel-test`).
 
 **Storage-layer follow-up (not done):** for defense-in-depth — so even a broad
 `attic`-bucket reader key (SeaweedFS `claude-reader`, which holds `Read:attic`)

--- a/devinfra/ci/nix_attic_build_and_push.sh
+++ b/devinfra/ci/nix_attic_build_and_push.sh
@@ -22,21 +22,29 @@ out_paths=$(mktemp)
 
 # NixOS configurations.
 #
-# Force services.google-drive off for each system's home-manager users so the
-# private gaffer `drivefs` closure is never pulled into a closure we push to the
-# broadly-readable `main` cache. Only the workstation hosts (wyrm2, rugged)
-# enable it; they pull drivefs straight from the restricted `gaffer` cache at
-# `nixos-rebuild switch` and rebuild only the cheap home-manager generation
-# diff. Keeping drivefs out of `main` is the whole point of the separate gaffer
-# cache — see cluster/docs/nix_cache.md "Private-binary isolation (drivefs)".
+# Force services.google-drive off for any home-manager user that has it ENABLED
+# (currently wyrm2, rugged) so the private gaffer `drivefs` closure never enters
+# a closure we push to the broadly-readable `main` cache. Those hosts pull
+# drivefs straight from the restricted `gaffer` cache at `nixos-rebuild switch`.
+# See cluster/docs/nix_cache.md "Private-binary isolation (drivefs)".
 #
-# Probe for home-manager rather than hardcoding a host list: hosts without it
-# (e.g. bootstrap) have no such option and are built as-is. A guard *inside* the
-# module — conditioning config on whether the option exists — is not possible:
-# referencing `options` triggers infinite recursion in the module fixpoint.
+# Detect by reading the enable bool per HM user — cheap, and it does not fetch
+# drivefs (that lives behind `config = lib.mkIf cfg.enable`). Hosts where the
+# option is absent (e.g. bazel-test's `root` user has home-manager but not the
+# google-drive module) or false are built as-is: they can't leak drivefs, and
+# injecting an undeclared option would error. Reading the bool this way avoids
+# the infinite recursion an in-module options-existence guard would cause.
 for host in $(nix eval --json .#nixosConfigurations --apply builtins.attrNames | jq -r '.[]'); do
-  if nix eval --impure ".#nixosConfigurations.$host.config.home-manager.users" \
-    --apply builtins.attrNames >/dev/null 2>&1; then
+  override=
+  for u in $(nix eval --impure --json ".#nixosConfigurations.$host.config.home-manager.users" \
+    --apply builtins.attrNames 2>/dev/null | jq -r '.[]' 2>/dev/null); do
+    if [ "$(nix eval --impure \
+      ".#nixosConfigurations.$host.config.home-manager.users.$u.services.google-drive.enable" \
+      2>/dev/null)" = true ]; then
+      override=1
+    fi
+  done
+  if [ -n "$override" ]; then
     target="(flake.nixosConfigurations.$host.extendModules {
       modules = [
         { home-manager.sharedModules = [ ({ lib, ... }: { services.google-drive.enable = lib.mkForce false; }) ]; }
@@ -51,21 +59,17 @@ for host in $(nix eval --json .#nixosConfigurations --apply builtins.attrNames |
   " --no-link --print-out-paths >>"$out_paths"
 done
 
-# Home configurations: disable google-drive via extendModules so the private
-# gaffer-private binary is never fetched at eval time.
-#
-# claude-web is a minimal standalone profile that does NOT import the
-# google-drive module, so injecting the option there fails with "The option
-# services.google-drive does not exist". Skip the override for it. (A generic
-# guard on whether the option exists is not possible: referencing `options`
-# from a module's config triggers infinite recursion in the module fixpoint.)
+# Home configurations — same rule: force google-drive off only where a config
+# actually enables it (none today). The standalone claude-web profile doesn't
+# import the module, so the option read errors and it is built as-is.
 for host in $(nix eval --impure --json .#homeConfigurations --apply builtins.attrNames | jq -r '.[]'); do
-  if [ "$host" = claude-web ]; then
-    target="flake.homeConfigurations.$host.activationPackage"
-  else
+  if [ "$(nix eval --impure \
+    ".#homeConfigurations.$host.config.services.google-drive.enable" 2>/dev/null)" = true ]; then
     target="(flake.homeConfigurations.$host.extendModules {
-      modules = [ { services.google-drive.enable = false; } ];
+      modules = [ ({ lib, ... }: { services.google-drive.enable = lib.mkForce false; }) ];
     }).activationPackage"
+  else
+    target="flake.homeConfigurations.$host.activationPackage"
   fi
   nix build --impure --expr "
     let flake = builtins.getFlake \"path:$(pwd)\";


### PR DESCRIPTION
## Regression fix

The previous change (#2399) forced `services.google-drive.enable` off for **every** home-manager user of **every** NixOS system. But `bazel-test` has home-manager (`home-manager.users.root`) *without* the google-drive module, so injecting that option there failed the same way `claude-web` did:

```
The option services.google-drive does not exist. Definition values:
  { enable = { _type="override"; content=false; priority=50; } }   ← lib.mkForce false
```

`bazel-test` is built first (alphabetical), so the post-merge `nix-attic-push` run on devel went red in ~54s.

## Fix

Force google-drive off **only for configs that actually enable it**, detected by reading the `services.google-drive.enable` bool per home-manager user — cheap, and it does **not** fetch `drivefs` (that lives behind `config = lib.mkIf cfg.enable`). Configs where the option is absent (`bazel-test`'s `root` user, `claude-web`) or `false` build as-is: they can't leak `drivefs`, and this drops the brittle `claude-web` name-skip. Only `wyrm2`/`rugged` (which read `enable = true`) get the `mkForce false` override.

This is more correct than the old "force off everywhere with home-manager" approach — a host that doesn't enable google-drive can't leak `drivefs` in the first place, and a config lacking the module is never mis-targeted.

## Verification (local `nix eval`)

- Override selection: exactly `wyrm2` + `rugged` for NixOS; **none** for home configs.
- `bazel-test` now evaluates its `system.build.toplevel.drvPath` cleanly with no google-drive error (the regression).
- `wyrm2`/`rugged` still get `enable` forced `false` (drivefs stays out of `main`).

Doc updated in `cluster/docs/nix_cache.md` to describe the read-the-bool detection and the bazel-test case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmJwbYH1ZS4fuQ81fQoP6w

---
_Generated by [Claude Code](https://claude.ai/code/session_01KmJwbYH1ZS4fuQ81fQoP6w)_