### PR TITLE
haku/console: fix CrashLoopBackOff from a K8s service-link env collision

### DIFF
--- a/cluster/k8s/haku/console/deployment.yaml
+++ b/cluster/k8s/haku/console/deployment.yaml
@@ -26,6 +26,10 @@ spec:
         app.kubernetes.io/name: haku-console
     spec:
       automountServiceAccountToken: false
+      # Don't inject the kubelet's {SVCNAME}_* service-link env vars: the haku-console
+      # Service's HAKU_CONSOLE_PORT=tcp://<clusterIP>:8080 collides with the app's
+      # HAKU_CONSOLE_ settings prefix (it parsed into the port:int field → crash).
+      enableServiceLinks: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/haku/console/app.py
+++ b/haku/console/app.py
@@ -104,7 +104,10 @@ def main() -> None:
         branch=settings.branch,
     )
     app = create_app(settings, git_state=git_state)
-    uvicorn.run(app, host=settings.host, port=settings.port, log_level="info")
+    # host/port are fixed, not env-driven: under the HAKU_CONSOLE_ prefix a `port`
+    # setting would read the kubelet's HAKU_CONSOLE_PORT service-link var (a URL),
+    # not an int. The deployment also disables service links (enableServiceLinks: false).
+    uvicorn.run(app, host="0.0.0.0", port=8080, log_level="info")
 
 
 if __name__ == "__main__":

--- a/haku/console/config.py
+++ b/haku/console/config.py
@@ -22,9 +22,6 @@ class Settings(BaseSettings):
     clone_dir: Path = Path("/data/haku-state")
     pull_interval_s: float = 45.0
 
-    host: str = "0.0.0.0"
-    port: int = 8080
-
     # Directory holding the built React SPA (index.html + assets), served same-origin.
     # Unset in tests (the API runs without a UI); set to the bundled dir in the image.
     static_dir: Path | None = None


### PR DESCRIPTION
## Incident

After #2401 merged, `haku.allegedly.works` returned **Bad Gateway** (`dial tcp <clusterIP>:8080: connect: operation not permitted`). The `haku-console` pod was in **CrashLoopBackOff** on the new image — crashing on startup, so the Service had no endpoints and Authentik's proxy failed.

## Root cause

A Kubernetes **service-link env-var collision**. Crash traceback:

```
pydantic_core.ValidationError: 1 validation error for Settings
port
  Input should be a valid integer, unable to parse string as an integer
  [input_value='tcp://10.104.50.188:8080']
```

Because a Service is named `haku-console`, the kubelet auto-injects the Docker-link var `HAKU_CONSOLE_PORT=tcp://<clusterIP>:8080`. The app's `Settings(env_prefix="HAKU_CONSOLE_")` read that into its `port: int` field → `Settings()` raised → uvicorn never started.

Latent since the `port` field existed; it surfaced now because the post-merge `Recreate` rollout recreated the pod **while the Service already existed**, so the service-link var got injected this time.

## Fix

- **`deployment.yaml`: `enableServiceLinks: false`** — stops all `{SVCNAME}_*` injection. This heals the **current** image immediately on merge (no rebuild): Flux applies the manifest, the pod restarts, `port` falls back to `8080`.
- **`config.py` / `app.py`** — drop the env-driven `host`/`port` settings and bind `0.0.0.0:8080` directly, so the collision can't recur regardless of the manifest setting (defense-in-depth; takes effect on the next image build).

## Validation

`bbr test //haku/console/...` green (mypy + pytest); `kubeconform` passes the manifest. On merge, Flux reconciles the Deployment and the pod should come up Ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpaCuKQ6A8fGMRmYnZr3ZU

---
_Generated by [Claude Code](https://claude.ai/code/session_01QpaCuKQ6A8fGMRmYnZr3ZU)_