### PR TITLE
haku: grant cluster diagnostics + safe-log RBAC

### DIFF
--- a/cluster/k8s/agents/claude-rbac/README.md
+++ b/cluster/k8s/agents/claude-rbac/README.md
@@ -76,6 +76,27 @@ bound via `shared-rbac/clusterrolebinding-cluster-diagnostics-reader.yaml`:
 Namespaced RoleBindings live in per-service `agent-rbac/` directories. Each is an independent
 Flux kustomization that depends only on the target namespace + `claude-rbac`.
 
+### 4. Haku background agent — diagnostics subset
+
+The Haku agent authenticates as group `oidc-ksbx-groups:haku` (see Authentication below) and,
+beyond its full-CRUD `haku-sandbox` Role, is **co-subjected** onto the existing reader bindings
+to give it general cluster diagnostics plus safe log reading. No Haku-specific roles exist — it
+reuses the same three ClusterRoles:
+
+- **`cluster-diagnostics-reader`, cluster-wide** (added as a subject on the shared-rbac
+  ClusterRoleBinding). Secret-free: no `secrets`/`pods/log`/`configmaps`, so it preserves the
+  Ember invariant (Haku can fully use any secret it reads → it must read none here).
+- **Logs/configmaps in infrastructure namespaces only** (co-subjected on the per-namespace
+  bindings): `flux-system`, `monitoring`, `kube-system`, `cnpg-system`, `cert-manager`,
+  `local-path-storage`, `openebs`, `csi-proxmox`, `node-feature-discovery`,
+  `nvidia-device-plugin`. These carry controller diagnostics, not user content. Haku is
+  deliberately **not** added to user-content/credential-bearing namespaces (`matrix`, `grocy`,
+  `authentik`, `props`, `langfuse`, `litellm`, `harbor`).
+
+This widens the original `haku-sandbox`-only perimeter (<../../../../haku/PLAN.md>) to read-only
+diagnostics; the structural fences (read-only verbs, no secret material, mitmproxy egress) are
+unchanged.
+
 @permissions.md
 
 ## Adding Agent RBAC for a New Service

--- a/cluster/k8s/agents/shared-rbac/clusterrolebinding-cluster-diagnostics-reader.yaml
+++ b/cluster/k8s/agents/shared-rbac/clusterrolebinding-cluster-diagnostics-reader.yaml
@@ -13,3 +13,10 @@ subjects:
   - kind: Group
     name: oidc-ksbx-groups:kubectl-sandbox-users
     apiGroup: rbac.authorization.k8s.io
+  # Haku background agent: secret-free cluster-wide diagnostics. This class grants
+  # no secrets/pods-log/configmaps, so it preserves the Ember invariant (Haku reads
+  # no new credential material). Log/configmap reads are granted separately per
+  # infra namespace, not here.
+  - kind: Group
+    name: oidc-ksbx-groups:haku
+    apiGroup: rbac.authorization.k8s.io

--- a/cluster/k8s/agents/shared-rbac/rolebinding-logs-configmaps-reader.yaml
+++ b/cluster/k8s/agents/shared-rbac/rolebinding-logs-configmaps-reader.yaml
@@ -14,3 +14,6 @@ subjects:
   - kind: Group
     name: oidc-ksbx-groups:kubectl-sandbox-users
     apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: oidc-ksbx-groups:haku
+    apiGroup: rbac.authorization.k8s.io

--- a/cluster/k8s/cert-manager/agent-rbac/rolebinding-namespace-diagnostics-reader.yaml
+++ b/cluster/k8s/cert-manager/agent-rbac/rolebinding-namespace-diagnostics-reader.yaml
@@ -11,3 +11,6 @@ subjects:
   - kind: Group
     name: oidc-ksbx-groups:kubectl-sandbox-users
     apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: oidc-ksbx-groups:haku
+    apiGroup: rbac.authorization.k8s.io

--- a/cluster/k8s/cnpg/agent-rbac/rolebinding-namespace-diagnostics-reader.yaml
+++ b/cluster/k8s/cnpg/agent-rbac/rolebinding-namespace-diagnostics-reader.yaml
@@ -11,3 +11,6 @@ subjects:
   - kind: Group
     name: oidc-ksbx-groups:kubectl-sandbox-users
     apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: oidc-ksbx-groups:haku
+    apiGroup: rbac.authorization.k8s.io

--- a/cluster/k8s/kube-system/agent-rbac/rolebinding-logs-configmaps-reader.yaml
+++ b/cluster/k8s/kube-system/agent-rbac/rolebinding-logs-configmaps-reader.yaml
@@ -14,3 +14,6 @@ subjects:
   - kind: Group
     name: oidc-ksbx-groups:kubectl-sandbox-users
     apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: oidc-ksbx-groups:haku
+    apiGroup: rbac.authorization.k8s.io

--- a/cluster/k8s/local-path-provisioner/agent-rbac/rolebinding-namespace-diagnostics-reader.yaml
+++ b/cluster/k8s/local-path-provisioner/agent-rbac/rolebinding-namespace-diagnostics-reader.yaml
@@ -11,3 +11,6 @@ subjects:
   - kind: Group
     name: oidc-ksbx-groups:kubectl-sandbox-users
     apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: oidc-ksbx-groups:haku
+    apiGroup: rbac.authorization.k8s.io

--- a/cluster/k8s/monitoring/agent-rbac/rolebinding-logs-configmaps-reader.yaml
+++ b/cluster/k8s/monitoring/agent-rbac/rolebinding-logs-configmaps-reader.yaml
@@ -14,3 +14,6 @@ subjects:
   - kind: Group
     name: oidc-ksbx-groups:kubectl-sandbox-users
     apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: oidc-ksbx-groups:haku
+    apiGroup: rbac.authorization.k8s.io

--- a/cluster/k8s/node-feature-discovery/agent-rbac/rolebinding-namespace-diagnostics-reader.yaml
+++ b/cluster/k8s/node-feature-discovery/agent-rbac/rolebinding-namespace-diagnostics-reader.yaml
@@ -11,3 +11,6 @@ subjects:
   - kind: Group
     name: oidc-ksbx-groups:kubectl-sandbox-users
     apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: oidc-ksbx-groups:haku
+    apiGroup: rbac.authorization.k8s.io

--- a/cluster/k8s/nvidia-device-plugin/agent-rbac/rolebinding-namespace-diagnostics-reader.yaml
+++ b/cluster/k8s/nvidia-device-plugin/agent-rbac/rolebinding-namespace-diagnostics-reader.yaml
@@ -11,3 +11,6 @@ subjects:
   - kind: Group
     name: oidc-ksbx-groups:kubectl-sandbox-users
     apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: oidc-ksbx-groups:haku
+    apiGroup: rbac.authorization.k8s.io

--- a/cluster/k8s/openebs-lvm/agent-rbac/rolebinding-namespace-diagnostics-reader.yaml
+++ b/cluster/k8s/openebs-lvm/agent-rbac/rolebinding-namespace-diagnostics-reader.yaml
@@ -11,3 +11,6 @@ subjects:
   - kind: Group
     name: oidc-ksbx-groups:kubectl-sandbox-users
     apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: oidc-ksbx-groups:haku
+    apiGroup: rbac.authorization.k8s.io

--- a/cluster/k8s/proxmox-csi/agent-rbac/rolebinding-namespace-diagnostics-reader.yaml
+++ b/cluster/k8s/proxmox-csi/agent-rbac/rolebinding-namespace-diagnostics-reader.yaml
@@ -11,3 +11,6 @@ subjects:
   - kind: Group
     name: oidc-ksbx-groups:kubectl-sandbox-users
     apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: oidc-ksbx-groups:haku
+    apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## What

Give the Haku background agent general cluster diagnostics and safe log reading by **co-subjecting its OIDC group `oidc-ksbx-groups:haku`** onto the existing `claude-rbac` reader bindings. The DRY core: **reuse the three existing ClusterRoles** (`cluster-diagnostics-reader`, `logs-configmaps-reader`, `namespace-diagnostics-reader`) — no Haku-specific roles.

| Grant | Where | Class |
|---|---|---|
| Cluster-wide diagnostics | `shared-rbac` ClusterRoleBinding | `cluster-diagnostics-reader` |
| Safe logs/configmaps | `flux-system`, `monitoring`, `kube-system`, `cnpg-system`, `cert-manager`, `local-path-storage`, `openebs`, `csi-proxmox`, `node-feature-discovery`, `nvidia-device-plugin` | `logs-configmaps-reader` / `namespace-diagnostics-reader` |

Deliberately **excluded** from Haku's log access (user content / credential-bearing): `matrix`, `grocy`, `authentik`, `props`, `langfuse`, `litellm`, `harbor`.

## Why it's safe

- **No new secret reachability** — the cluster-wide class grants no `secrets`/`pods/log`/`configmaps`, only object shape & status, so Haku gains no readable credential material — it can see what's running and how it's wired, nothing it could exfiltrate. cert-manager `Certificate`s / `ExternalSecret`s are config CRs, not key material.
- **Read-only** — all verbs are `get/list/watch`; the only mutating verb is the Kyverno-fenced Flux reconcile-annotation patch, inherited like Claude.
- **Logs stay curated** — risky classes are never cluster-wide; Haku only gets infra/controller namespaces, never user data.
- **Same proven tier** — exactly the classes already trusted cluster-wide for the interactive sandbox group.
- **Cheaply revocable** — each grant is one Flux-managed line.

This is a deliberate widening of the original `haku-sandbox`-only perimeter (`haku/PLAN.md`) to read-only diagnostics; documented in the `claude-rbac` README.

## Validation

Pre-commit passed, including `kubeconform` (manifest schema validation) and prettier/markdownlint. The full `bbr test //cluster/validation/...` suite could **not** run — both `bb` and `bazelisk` get a 403 fetching the Bazel binary from `releases.bazel.build` (environment proxy issue, unrelated to this change). CI will run the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS3Jh2wXqwQoLwu2ut2ppE