### PR TITLE
haku: tell Haku about its cluster diagnostics RBAC

### DIFF
--- a/cluster/k8s/agents/claude-rbac/README.md
+++ b/cluster/k8s/agents/claude-rbac/README.md
@@ -84,8 +84,9 @@ to give it general cluster diagnostics plus safe log reading. No Haku-specific r
 reuses the same three ClusterRoles:
 
 - **`cluster-diagnostics-reader`, cluster-wide** (added as a subject on the shared-rbac
-  ClusterRoleBinding). Secret-free: no `secrets`/`pods/log`/`configmaps`, so it preserves the
-  Ember invariant (Haku can fully use any secret it reads → it must read none here).
+  ClusterRoleBinding). Secret-free: no `secrets`/`pods/log`/`configmaps`, so it grants Haku no
+  readable credential material — it can see what's running and how it's wired, nothing it could
+  exfiltrate.
 - **Logs/configmaps in infrastructure namespaces only** (co-subjected on the per-namespace
   bindings): `flux-system`, `monitoring`, `kube-system`, `cnpg-system`, `cert-manager`,
   `local-path-storage`, `openebs`, `csi-proxmox`, `node-feature-discovery`,

--- a/cluster/k8s/agents/shared-rbac/clusterrolebinding-cluster-diagnostics-reader.yaml
+++ b/cluster/k8s/agents/shared-rbac/clusterrolebinding-cluster-diagnostics-reader.yaml
@@ -14,9 +14,8 @@ subjects:
     name: oidc-ksbx-groups:kubectl-sandbox-users
     apiGroup: rbac.authorization.k8s.io
   # Haku background agent: secret-free cluster-wide diagnostics. This class grants
-  # no secrets/pods-log/configmaps, so it preserves the Ember invariant (Haku reads
-  # no new credential material). Log/configmap reads are granted separately per
-  # infra namespace, not here.
+  # no secrets/pods-log/configmaps, so Haku reads no new credential material through
+  # it. Log/configmap reads are granted separately per infra namespace, not here.
   - kind: Group
     name: oidc-ksbx-groups:haku
     apiGroup: rbac.authorization.k8s.io

--- a/haku/PLAN.md
+++ b/haku/PLAN.md
@@ -330,11 +330,14 @@ k8s at runtime**. The model: tell Haku "to use service X, call facade Y
 - **`haku-sandbox` is a claude-sandbox-style sandbox.** The CronJob's
   ServiceAccount and the OIDC group `oidc-ksbx-groups:haku` get a Role with full
   CRUD **inside the `haku-sandbox` namespace** (pods/jobs/configmaps/secrets/…),
-  so Haku can run workloads and read the creds mounted to it — but **nothing
-  outside the namespace** (deliberately _not_ the broad `kubectl-sandbox-users`
-  diagnostics group). The perimeter is structural: namespace-scoped RBAC, the
-  dedicated mitmproxy egress allowlist, and a ResourceQuota/LimitRange — none
-  relying on the agent's restraint. The Ember invariant still holds: Haku can
+  so Haku can run workloads and read the creds mounted to it — but **write only
+  inside the namespace**. Beyond it Haku holds **read-only diagnostics**: it is a
+  subject on the `claude-rbac` reader ClusterRoles (`cluster-diagnostics-reader`
+  cluster-wide, plus `logs-configmaps-reader`/`namespace-diagnostics-reader` in
+  infrastructure namespaces only), which expose object status but **no secrets,
+  pod logs, or configmaps** outside the safe infra set. The perimeter is
+  structural: scoped RBAC, the dedicated mitmproxy egress allowlist, and a
+  ResourceQuota/LimitRange — none relying on the agent's restraint. The Ember invariant still holds: Haku can
   fully use any secret it can read, so **every credential reflected into
   `haku-sandbox` must be read-only/scoped** (the `plaid_ro` DSN, the read-only
   Google token, Haku's own git / LLM keys) — never a write-capable upstream token.

--- a/haku/PLAN.md
+++ b/haku/PLAN.md
@@ -337,8 +337,8 @@ k8s at runtime**. The model: tell Haku "to use service X, call facade Y
   infrastructure namespaces only), which expose object status but **no secrets,
   pod logs, or configmaps** outside the safe infra set. The perimeter is
   structural: scoped RBAC, the dedicated mitmproxy egress allowlist, and a
-  ResourceQuota/LimitRange — none relying on the agent's restraint. The Ember invariant still holds: Haku can
-  fully use any secret it can read, so **every credential reflected into
+  ResourceQuota/LimitRange — none relying on the agent's restraint. Because Haku
+  can fully use any secret it can read, **every credential reflected into
   `haku-sandbox` must be read-only/scoped** (the `plaid_ro` DSN, the read-only
   Google token, Haku's own git / LLM keys) — never a write-capable upstream token.
 - **Credential discovery.** v0 does this ad-hoc per `instructions.md`: Haku

--- a/haku/base/instructions.md
+++ b/haku/base/instructions.md
@@ -68,6 +68,14 @@ not to file) an item. Some illustrations of the _kind_ of reasoning expected
   file a `prepared_prompt` to cancel it.
 - An email says CI is red on one of the operator's repos → look at the GitHub
   repo, read the failing job, and prepare a prompt for an agent to fix it.
+- The **cluster** is one of your standing sources — you have read-only
+  diagnostics over it (see _Setup: discover credentials_). Sweep it each run for
+  high-value infra work: a Flux Kustomization or HelmRelease stuck not-ready, a
+  pod CrashLooping, a certificate near expiry, a resource with no requests/limits,
+  a drifted or risky config. Read its status/events/(infra-namespace) logs, work
+  out the cause, and file a `prepared_prompt` proposing the **declarative fix to
+  the cluster infra in ducktape** — surfacing improvements the operator hasn't
+  noticed counts as much as fixing outright breakage.
 - CPAP data shows leakage concentrated on weekends → reason about what differs
   (different bed, alcohol, mask fit) and suggest a routine change or a thing to
   check.
@@ -196,7 +204,9 @@ What that yields today:
   `get/list/watch` of object shape and status across the whole cluster (nodes,
   pods, events, deployments, Flux/HelmReleases, certificates, metrics, …). It
   grants **no secrets, no pod logs, no configmaps** — so you can see what's
-  running and how it's wired, but read no credential material through it.
+  running and how it's wired, but read no credential material through it. Use it:
+  the cluster is a standing source to sweep for high-value infra items (see _How
+  you reason_), not just for diagnosing things you were already pointed at.
 - **Pod logs + configmaps in infrastructure namespaces only** — via the
   `logs-configmaps-reader` / `namespace-diagnostics-reader` ClusterRoles, bound
   per-namespace in each service's `agent-rbac/` dir: `flux-system`, `monitoring`,

--- a/haku/base/instructions.md
+++ b/haku/base/instructions.md
@@ -181,15 +181,37 @@ Everything you're allowed to touch is a Kubernetes Secret in your own namespace,
 `kubectl get secret <name> -o jsonpath='{.data.<field>}' | base64 -d`.
 
 You also have the **ducktape repo** checked out (this manual lives in it), so you
-can read exactly what you've been granted rather than guessing:
+can read exactly what you've been granted rather than guessing. Your cluster
+identity is the OIDC group `oidc-ksbx-groups:haku`; **discover your full perimeter
+by finding every binding that subjects it** instead of trusting this list:
+`git -C <ducktape> grep -rl 'oidc-ksbx-groups:haku' cluster/k8s` enumerates them,
+and each binding's `roleRef` names the (Cluster)Role whose `rules` spell out the
+exact resources and verbs (the readers live in `cluster/k8s/agents/claude-rbac/`).
+What that yields today:
 
-- `cluster/k8s/haku/rbac/` — your Role (`haku-sandbox-admin`) and its bindings:
-  the resources/verbs you hold in `haku-sandbox`. That is your perimeter; if
-  something isn't granted there, you can't do it.
+- `cluster/k8s/haku/rbac/` — your `haku-sandbox-admin` Role: **full CRUD inside
+  `haku-sandbox`**. This is the only namespace you can write to.
+- **Cluster-wide read-only diagnostics** — you're a subject on the
+  `cluster-diagnostics-reader` ClusterRole (`cluster/k8s/agents/shared-rbac/`):
+  `get/list/watch` of object shape and status across the whole cluster (nodes,
+  pods, events, deployments, Flux/HelmReleases, certificates, metrics, …). It
+  grants **no secrets, no pod logs, no configmaps** — so you can see what's
+  running and how it's wired, but read no credential material through it.
+- **Pod logs + configmaps in infrastructure namespaces only** — via the
+  `logs-configmaps-reader` / `namespace-diagnostics-reader` ClusterRoles, bound
+  per-namespace in each service's `agent-rbac/` dir: `flux-system`, `monitoring`,
+  `kube-system`, `cnpg-system`, `cert-manager`, and the storage/device-plugin
+  namespaces (`local-path-storage`, `openebs`, `csi-proxmox`,
+  `node-feature-discovery`, `nvidia-device-plugin`). You **cannot** read logs or
+  configmaps in app namespaces that carry user content (matrix, grocy, authentik,
+  props, langfuse, litellm, harbor) — diagnose those from object status + events.
 - the secret sources reflected into `haku-sandbox` (e.g.
   `cluster/k8s/agents/plaid-mcp/db` for Plaid, `cluster/k8s/agents/airlock` for
   the Google token) — read these to learn what credential each secret carries
   and how it's scoped (all of yours are read-only by construction).
+
+The RBAC files are the source of truth, not this prose: when unsure whether you
+can do something, grep for your group and read the referenced role.
 
 **Credentials you have today** (all in `haku-sandbox`, all read-only):
 
@@ -218,8 +240,10 @@ the pod's command (or a ConfigMap-mounted script) and read the result from
 a streaming connection. (`kubectl exec`/`attach`/`port-forward` work too — the
 `kubeapi-proxy` nginx forwards the WebSocket upgrade, `cluster/k8s/kube-api-proxy`
 — but command + logs is simplest.)
-Stay inside `haku-sandbox` — you have no access outside it; and the creds you can
-mount are read-only, so the compute is for gathering, not acting on the world.
+**Write only inside `haku-sandbox`** — it's the one namespace you can create or
+change anything in. Outside it you have read-only diagnostics (the cluster-wide +
+infra-log grants above): you can look but never touch. The creds you can mount are
+read-only too, so the compute is for gathering, not acting on the world.
 
 **Your home has the `fastmcp` CLI** (in the agent-haku closure) for talking to MCP
 servers: `fastmcp list <url> --auth "$TOKEN"` and `fastmcp call <url> <tool>

--- a/haku/claude_web_env/run.md
+++ b/haku/claude_web_env/run.md
@@ -16,9 +16,12 @@ environment-neutral `haku/run.md`.
   for `git.allegedly.works`, so you can `git -C ~/haku-state pull/commit/push`
   with no credentials to manage. (If `~/haku-state` is somehow missing, re-run
   `haku/claude_web_env/bootstrap.sh`.)
-- Discover your other credentials from `haku-sandbox` secrets and from the
-  ducktape repo you have checked out (`cluster/k8s/haku/rbac/` = your perimeter).
-  See the credential table in `haku/base/instructions.md`.
+- Discover your other credentials from `haku-sandbox` secrets and your full
+  cluster perimeter from the ducktape repo you have checked out — grep
+  `oidc-ksbx-groups:haku` under `cluster/k8s` for every binding (write CRUD in
+  `haku-sandbox`, plus cluster-wide read-only diagnostics and infra-namespace
+  logs). See the credential table and perimeter discovery in
+  `haku/base/instructions.md`.
 - Cluster-internal data (e.g. Plaid Postgres) isn't reachable from here — run a
   pod **in `haku-sandbox`** to query it, as the manual describes (pod command +
   `kubectl logs`, DSN from a secret via `secretKeyRef`). `kubectl exec`/`attach`/


### PR DESCRIPTION
Rebased onto `origin/devel` after #2405 merged. Three commits:

1. **Tell Haku about its cluster diagnostics RBAC** — updates Haku's runtime manual (`haku/base/instructions.md`) so it knows its real perimeter and **discovers it from the RBAC files** (`git grep oidc-ksbx-groups:haku` across `cluster/k8s`, read the referenced `claude-rbac` ClusterRoles). Fixes the stale "no access outside `haku-sandbox`" claim in `instructions.md`, `claude_web_env/run.md`, and `haku/PLAN.md`.
2. **Treat the cluster as a standing source** — "How you reason" now tells Haku to sweep the cluster each run for high-value infra work (stuck Flux/HelmReleases, CrashLoops, expiring certs, missing resource limits, risky/drifted config) and file `prepared_prompt`s proposing the **declarative fix to the cluster infra in ducktape**.
3. **Drop the "Ember invariant" jargon** from `claude-rbac/README.md` and the ClusterRoleBinding comment. #2405 merged *before* this cleanup landed, so the phrase is currently live in devel — this PR removes it (plain-language reword, same meaning).

## Why discovery-first

The manual defers to the RBAC files as source of truth, so Haku stays accurate even as bindings change — no drift between prose and the actual grant.

## Notes

Now independent of #2405 (which is merged). Doc + tiny doc-string cleanup; pre-commit (prettier) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS3Jh2wXqwQoLwu2ut2ppE