### PR TITLE
haku/base: gate the dashboard by actionability, not just value

### DIFF
--- a/haku/base/instructions.md
+++ b/haku/base/instructions.md
@@ -356,10 +356,30 @@ below.
 One file per item: `items/<id>.yaml` where `<id>` is a ULID you generate.
 Files must validate against `schema/item.json`. Statuses:
 
-- `open` — awaiting the operator. Only you create these.
-- `in_progress`, `done`, `rejected`, `snoozed` — set by the operator (you may
-  set them when intake says so).
+- `open` — awaiting the operator **and actionable now or soon**. Only you create these.
+- `snoozed` — deferred until a future date or condition (its **wake trigger**), and
+  hidden from the active dashboard. Set by the operator, **or by you** when an item
+  isn't yet actionable (its only next step is to wait) or to park a lower-priority
+  item; set `snoozed_until` to the wake date (the run procedure checks it each pass)
+  and note the trigger in your `memory/` watch-list.
+- `in_progress`, `done`, `rejected` — set by the operator (you may set them when
+  intake says so).
 - `expired` — set by you when `deadline` passes.
+
+**Gate by actionability, then rank by value.** The dashboard answers "what's worth
+doing now or soon" — not "here's a thing that exists." An item earns the **active
+queue only if the operator's next step is something to do now or in the near term**.
+If the next step is merely to **wait** — for a future date, a far-off deadline, or an
+external event outside their control — it is _not yet actionable_, however large the
+eventual payoff (a $4k refund you can only confirm next month; a passport that expires
+in four years). Don't surface those on the front page: either keep them as a dated
+entry in your `memory/` watch-list (no item needed), or, if they're substantial enough
+to be an item, file them `snoozed` from the start with `snoozed_until` set — never
+`open`. Value and actionability are independent axes: a high-value item can be
+not-yet-actionable, so never let a big payoff float a wait-item onto the front page. A
+future `deadline` does **not** by itself make an item a wait-item — the OpenAI tender
+has a hard deadline yet is intensely actionable now; the test is whether there's a
+useful next action in the near term, or only waiting.
 
 `value` is 0–100, ranking **impact against the operator's effort** — what tops
 the dashboard is high payoff for little of their time. Anchors: 90+ = money or a
@@ -418,13 +438,14 @@ operator's interface _to you_, not a privilege escalation.
 
 What the console renders (so you know what the operator sees):
 
-- All `open` items, ranked by `value`, **tiered** so the deep backlog stays scannable:
-  **Up next** (top ≤7) and a collapsible **Backlog**. Each task is a collapsible
-  `<details>` whose `<summary>` is a compact row (value, title, deadline, kind); the
-  full **`body` (Markdown→HTML)**, the action toggles, and the primary action button
-  live **only inside that task's expanded view**. A `prepared_prompt` item exposes a
-  `claude.ai/new?q=<url-encoded prompt>` deep-link (falling back to the item file once
-  the encoded prompt would exceed ~2000 characters).
+- All `open` items — your **actionable-now/soon** set; deferred `snoozed` items aren't
+  rendered (see the _Item contract_'s actionability gate) — ranked by `value`, **tiered**
+  so the deep backlog stays scannable: **Up next** (top ≤7) and a collapsible **Backlog**.
+  Each task is a collapsible `<details>` whose `<summary>` is a compact row (value, title,
+  deadline, kind); the full **`body` (Markdown→HTML)**, the action toggles, and the primary
+  action button live **only inside that task's expanded view**. A `prepared_prompt` item
+  exposes a `claude.ai/new?q=<url-encoded prompt>` deep-link (falling back to the item file
+  once the encoded prompt would exceed ~2000 characters).
 - The **`actions[]`** you attach (rendered as click/un-click toggles), a global
   **feedback** box, an **"Add intake note"** link to Forgejo, and a status +
   last-scan footer. The operator's clicks and feedback return to you as commits — the

--- a/haku/run.md
+++ b/haku/run.md
@@ -29,7 +29,9 @@ bottom:
 1. **Orient**: read your `memory/` (standing operator guidance, how far you got
    last time, prior notes), your most recent `log/` daily files, and all of
    `items/` (including terminal items — they encode what the operator already
-   decided).
+   decided). Check your `memory/` watch-list and your `snoozed`/deferred items for
+   **wake triggers that have now arrived** — things you parked for "later" because
+   they weren't yet actionable (see _Curate_ for promoting them).
 2. **Adopt base updates**: compare the ducktape checkout's `HEAD`
    (`git -C <ducktape> rev-parse HEAD`) to the pin in `memory/base-sync.md`. If it
    advanced, diff `haku/base` + `haku/run.md` since the pin, migrate your state to
@@ -59,12 +61,16 @@ bottom:
    `dedup_key` that already exists in any status. Don't re-raise a rejected idea
    unless there is materially new evidence — and say what's new in `body`.
 6. **Curate**: re-score open items if context changed and set `status: expired` on
-   items past `deadline` (or no longer possible). **Keep valid lower-priority
-   items `open` as the backlog** — don't drop or expire them just to shorten the
-   list; ranking and the dashboard's tiering keep it scannable. The dashboard console
-   renders the live site from `items/` on its own, so there's no page to regenerate
-   and no templates to maintain — the look lives in the console's bundle (see
-   _Dashboard_).
+   items past `deadline` (or no longer possible). **Promote** any `snoozed`/deferred
+   item or `memory/` watch-list follow-up whose **wake trigger** (its `snoozed_until`
+   date or a condition) has now arrived — flip it to `open` so it enters the dashboard
+   exactly when it becomes actionable. Conversely, anything you'd otherwise file whose
+   only next step is to wait goes to the watch-list or `snoozed` (with `snoozed_until`),
+   not `open` (per the manual's _Item contract_). **Keep valid lower-priority items
+   `open` as the backlog** — don't drop or expire them just to shorten the list;
+   ranking and the dashboard's tiering keep it scannable. The dashboard console renders
+   the live site from `items/` on its own, so there's no page to regenerate and no
+   templates to maintain — the look lives in the console's bundle (see _Dashboard_).
 7. **Log**: append a run entry to **today's daily log file** (`log/YYYY-MM-DD.md`
    — one file per day, never one monolithic journal) — what you scanned, what you
    found, what you chose not to file and why (one line each). Compact or prune old


### PR DESCRIPTION
## Why

Haku items whose only next step is to **wait** — a future date, a far-off deadline, an external event — were landing on the dashboard front page ranked by `value`. The motivating example: *"Verify the $4,292 Peak One refund landed by Jul 17"* — high `value`, so it floated to "Up next", but the only action *today* is to wait until mid-July. The front page should answer **"what's worth doing now or soon"**, not "here's a thing that exists that you can't act on yet."

Root cause: the dashboard had no **actionability gate** — it ranked by `value` alone, and `value` and actionability are independent axes (a high-value item can be not-yet-actionable).

## What changed

- **`instructions.md` (Item contract):** new principle — *gate by actionability, then rank by value*. An item earns the active queue only if the operator's next step is something to do now or soon; if the next step is just to wait, it goes to the `memory/` watch-list (no item needed) or `snoozed`, never `open`. Clarifies that a future `deadline` does **not** by itself make a wait-item (the OpenAI tender has a hard deadline yet is intensely actionable now). Broadens `snoozed` so Haku may file an item deferred-from-the-start, using the existing **`snoozed_until`** field as the machine-checkable wake date.
- **`instructions.md` (Dashboard):** integrated the gate into the current console spec — the console renders the `open` (actionable-now/soon) set; deferred `snoozed` items aren't rendered.
- **`run.md` (Orient / Curate):** every pass checks the watch-list + deferred items for **wake triggers** (`snoozed_until` / a condition) that have arrived and promotes them to `open`, so dormant follow-ups resurface exactly when they become actionable.

**No schema change** — uses the existing `snoozed` status + `snoozed_until` field (plus the `memory/` watch-list for lightweight, no-item follow-ups).

Rebased onto `devel`, so it sits on top of the `haku/console` web-app spec (the static `generate.py` / `index.html` model is gone); the actionability wording is expressed in console terms and is consistent with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJMNMdHtC2y3EVs4hmSZ2w