### PR TITLE
haku/base: consolidate "Links as affordances"; per-pass item conformance

### DIFF
--- a/haku/base/instructions.md
+++ b/haku/base/instructions.md
@@ -346,7 +346,9 @@ below.
 - Never put secrets, full account numbers, or credentials in items, the log,
   or commit messages. Reference transactions by date + merchant + amount, mail
   and events by subject/title + sender + date (never raw bodies, never the
-  access token).
+  access token). **Exception:** a token embedded in a **URL** is fine when it's
+  the direct affordance (the console is operator-only behind Authentik — see
+  _Links as affordances_); this covers links only, not raw credentials in prose.
 - **You cannot change your own base.** To change this manual, the schema, or
   your config, the operator edits `haku/base/` in ducktape — it is not in your
   write scope.
@@ -401,23 +403,35 @@ Action kinds (only these two):
   and the evidence, and let it work out the how; don't shrink the ask to one
   mechanical step when the real win is bigger.
 
-**Interlink entities by their natural URL — inline, in the prose.** Where an item
-references an addressable entity, anchor the link on the natural words where it's
-mentioned, so it reads as prose: write "[Ivan's reply](…)", "[the failing CI run](…)",
-"[the COI request email](…)" as the link text — **not** a separate `**Links**:` block
-at the bottom. Link each entity once, at its first or most natural mention; fall back
-to a trailing list only for an entity that isn't named anywhere in the prose. The
-dashboard renders Markdown, so use `[text](url)` in `body` (and ``[`code`](url)``
-for file paths, which renders as a code-styled link); put plain URLs in
-`prepared_prompt` text. Natural URLs by source: **ducktape files** →
-`github.com/agentydragon/ducktape/blob/devel/<path>`; **GitHub PRs / commits / CI
-runs** → their `…/pull/<n>`, `…/commit/<sha>`, `…/actions/runs/<id>` URLs; **Gmail
-messages** → `mail.google.com/mail/u/0/#all/<messageId>`; **Tana nodes** → their Tana
-URL; **Drive files** → `drive.google.com/file/d/<fileId>/view` (the `id` /
-`webViewLink` comes free from the same `files.list`/`files.get` call you used to find
-the file — no excuse to skip it); **Calendar events** → their `htmlLink`. Plaid
-transactions have no public URL — keep referencing them by date + merchant + amount.
-Never put a secret or token in a URL (the hard rules already forbid this).
+**Links as affordances — give the operator the door, not directions to it.** A link
+that lands them one click from the thing or action beats a paragraph describing how to
+get there. So whenever you reference something addressable, link the most direct URL you
+can — **inline on the natural words** in the `body` (plain URLs in `prepared_prompt`
+text). The dashboard renders Markdown, so use `[text](url)` (and ``[`code`](url)`` for
+file paths, which renders as a code-styled link). Three kinds:
+
+- **Entities** → natural URL, anchored on the words where it's named ("[Ivan's
+  reply](…)", "[the refund PDF](…)") — **not** a trailing `**Links**:` block (fallback
+  only for an entity never named in prose); link each once, at its first or most natural
+  mention. By source: **ducktape files** → `github.com/agentydragon/ducktape/blob/devel/<path>`;
+  **GitHub PRs / commits / CI runs** → their `…/pull/<n>`, `…/commit/<sha>`,
+  `…/actions/runs/<id>` URLs; **Gmail messages** → `mail.google.com/mail/u/0/#all/<messageId>`;
+  **Tana nodes** → their Tana URL; **Drive files** → `drive.google.com/file/d/<fileId>/view`
+  (the `id` / `webViewLink` comes free from the same `files.list`/`files.get` call you
+  used to find the file — no excuse to skip it); **Calendar events** → their `htmlLink`.
+  Plaid transactions have no public URL — reference them by date + merchant + amount.
+- **Searches / views over a set** → when an item points at a _set_ the operator might
+  work through (an inbox cluster, a category of charges, a label), link the **search URL
+  that surfaces exactly that set**: Gmail `mail.google.com/mail/u/0/#search/<url-encoded
+query>` (e.g. one per cluster, `in:inbox from:(a.com OR b.com …)`).
+- **Actions / settings** → if you tell them to change a setting or do something on a
+  platform, **deep-link straight to that page** when you know it (`foobar.com/account/settings/<x>`)
+  instead of describing the click-path — one click beats five. Same for an executor in a
+  `prepared_prompt`.
+
+A URL **may include a token** if that's the direct path — the console is operator-only
+(behind Authentik) — but that's the only exception: never write a raw credential into an
+item's prose, the log, or a commit message (see _Hard rules_).
 
 **Attach operator action buttons (`actions[]`).** An item may carry an `actions`
 list — buttons the dashboard console renders as **click / un-click toggles**. The

--- a/haku/base/instructions.md
+++ b/haku/base/instructions.md
@@ -498,3 +498,11 @@ log. See [`playbooks/`](playbooks/README.md).
 
 Titles ≤80 chars, imperative ("Kill $14.99 Hooli subscription"). Bodies
 short: evidence, why it matters, what to do. No filler, no hedging stacks.
+
+**Rewrite items to current state — don't accrete patches.** When a later pass folds in
+new evidence, **rewrite the whole body to read as if written fresh today**: integrate
+the new information into the natural flow, re-order as needed, and **trim anything that's
+no longer needed or true**. Do **not** prepend/append a dated `**Update <date>:**` block
+or demote the prior text to `**Background**:` — the body is the current state, not a
+changelog (git holds the history; the dashboard shows the last-scan time). Structure
+(short headings, bullets) is fine; lazily layering each pass's edit on top is not.

--- a/haku/run.md
+++ b/haku/run.md
@@ -68,9 +68,14 @@ bottom:
    only next step is to wait goes to the watch-list or `snoozed` (with `snoozed_until`),
    not `open` (per the manual's _Item contract_). **Keep valid lower-priority items
    `open` as the backlog** — don't drop or expire them just to shorten the list;
-   ranking and the dashboard's tiering keep it scannable. The dashboard console renders
-   the live site from `items/` on its own, so there's no page to regenerate and no
-   templates to maintain — the look lives in the console's bundle (see _Dashboard_).
+   ranking and the dashboard's tiering keep it scannable. Also **bring user-facing items
+   into conformance with the manual** — the conventions evolve, so each pass check that
+   open items still follow the current contract (e.g. _Links as affordances_: inline
+   links, search/deep-link affordances; the actionability gate) and fix any that have
+   drifted, prioritising the top of the queue and any item you touch. The dashboard
+   console renders the live site from `items/` on its own, so there's no page to
+   regenerate and no templates to maintain — the look lives in the console's bundle (see
+   _Dashboard_).
 7. **Log**: append a run entry to **today's daily log file** (`log/YYYY-MM-DD.md`
    — one file per day, never one monolithic journal) — what you scanned, what you
    found, what you chose not to file and why (one line each). Compact or prune old


### PR DESCRIPTION
Item-writing conventions for Haku, prompted by operator feedback on real items (inbox-cleanup should carry the actual Gmail searches; settings advice should deep-link; an item that got a new paragraph stapled on top instead of being rewritten).

## What changed

**`instructions.md` — Links as affordances** (replaces the entity-only interlink paragraph). Throughline: *give the operator the shortest clickable path, not directions to it.* Three kinds:
- **Entities** → natural URL, inline on the words where named (Drive/Gmail/Tana/GitHub/Calendar; Drive id comes free from the API call).
- **Searches / views over a set** → link the search URL that surfaces the set, e.g. a Gmail `#search/<query>` per inbox cluster (`in:inbox from:(a.com OR b.com …)`).
- **Actions / settings** → deep-link straight to the page (`foobar.com/account/settings/<x>`) instead of describing the 5-click path.

**`instructions.md` — hard-rule carve-out.** A token embedded in a **URL** is now allowed when it's the direct affordance — the console is operator-only behind Authentik. Scoped to links only; raw credentials in prose/log/commits still forbidden.

**`instructions.md` (Tone) — rewrite items to current state, don't accrete patches.** When a later pass folds in new evidence, rewrite the whole body to read as if written fresh today (integrate, re-order, trim what's stale) — never prepend a dated `**Update <date>:**` block or demote prior text to `**Background**:`. The body is the current state; git holds the history.

**`run.md` (Curate).** Each pass, bring user-facing items into conformance with the manual as conventions evolve (inline/affordance links, the actionability gate, current-state rewrites) — fixing drift, prioritising the top of the queue and any item touched.

No schema change; pre-commit (prettier etc.) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJMNMdHtC2y3EVs4hmSZ2w