### PR TITLE
.gitattributes: drop now-redundant task.tsx diff override

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -83,9 +83,3 @@ x/k8s_old/** rules-lint-ignored=true
 # TODO: Delete legacy_* roles once all machines switch to Nix home-manager
 ansible/roles/legacy_*/** rules-lint-ignored=true
 tana/export/references/** rules-lint-ignored=true
-
-# haku/console/frontend/task.tsx carried a stray NUL byte (removed in this branch).
-# Force git to diff it as text so `bb remote` (CI) ships an applyable text patch
-# instead of a binary one against devel's still-binary copy. Redundant once devel's
-# copy is plain text (after this lands) — safe to drop then.
-haku/console/frontend/task.tsx diff


### PR DESCRIPTION
Follow-up cleanup to #2410.

That PR added a `haku/console/frontend/task.tsx diff` override to `.gitattributes` so `bb remote` (CI) would ship an applyable *text* patch for the file while `devel`'s copy still contained a stray NUL byte (which made git treat it as binary). Now that #2410 has merged, `devel`'s `task.tsx` is plain text (0 NUL bytes) and git diffs it as text on its own — so the override is redundant and is removed here.

No build/test targets are affected (it's a `.gitattributes`-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7wAM7sBZqCFvYi7L63H6H

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7wAM7sBZqCFvYi7L63H6H)_