### PR TITLE
seaweedfs: fix s3 gateway OOM loop — size memory on observed peak + GOMEMLIMIT

### DIFF
--- a/cluster/docs/lessons_learned/2026_06_19_seaweedfs_descheduler_dns_race_crashloop.md
+++ b/cluster/docs/lessons_learned/2026_06_19_seaweedfs_descheduler_dns_race_crashloop.md
@@ -134,6 +134,19 @@ victim) and below their memory request (kubelet node-pressure eviction ranks
 over-request pods first), and it deprioritizes them in the descheduler's QoS tiebreak.
 Same gap exists on every CNPG cluster — worth a cluster-wide convention.
 
+> **Follow-up (2026-06-19, later): the s3 `limit` from A. caused a self-OOM loop.**
+> PR #2402 set `limits.memory: 512Mi` on the s3 gateway. That is the upstream Helm
+> chart's _lightweight-gateway_ default, but our s3 is read-heavy (Mimir TSDB block
+> range-GETs dominate) and runs the in-process Iceberg REST catalog. Our own Mimir
+> history shows the **pre-limit** s3 pods peaked at ~1.7Gi under query/compaction
+> bursts, so the 512Mi cap hard-OOM-killed (exit 137) every ~10min in lockstep across
+> both replicas. Fix: request 512Mi (above ~400Mi steady-state), limit 2Gi (above the
+> ~1.7Gi peak), and `GOMEMLIMIT=1800MiB` so the runtime treats the cap as a soft
+> ceiling and GCs harder instead of dying — this is the "avoid
+> container-OOM-on-own-limit" caveat above, applied correctly. The chunk cache
+> (`-cacheCapacityMB`) is off by default, so s3 memory is load-driven, not a cappable
+> fixed footprint.
+
 ### B. PodDisruptionBudget for the raft/quorum sets (the real descheduler lever) — IMPLEMENTED
 
 The descheduler honors PDBs unconditionally. SeaweedFS master is a 3-node raft set →

--- a/cluster/k8s/seaweedfs/cluster/seaweed.yaml
+++ b/cluster/k8s/seaweedfs/cluster/seaweed.yaml
@@ -178,14 +178,35 @@ spec:
     annotations:
       reloader.stakater.com/auto: "true"
     metricsPort: 9327
-    # QoS / eviction protection (stateless gateway, low usage). No PDB: it is
-    # stateless and freely reschedulable, so descheduler moves are harmless.
+    # QoS / eviction protection. No PDB: it is stateless and freely
+    # reschedulable, so descheduler moves are harmless.
+    #
+    # Memory is load-driven, NOT a fixed footprint: it tracks concurrent
+    # in-flight transfers (our load is dominated by Mimir TSDB block range-GETs
+    # — verified via SeaweedFS_s3_request_total) plus the in-process Iceberg
+    # REST catalog. The in-memory chunk cache (-cacheCapacityMB) is off
+    # (default 0), so there is nothing to cap there. The upstream Helm chart's
+    # 128Mi/512Mi is sized for a *lightweight* gateway; ours is not. Mimir
+    # query/compaction bursts drove the pre-limit pods to ~1.7Gi peak (observed
+    # in our own Mimir history), so a 512Mi limit hard-OOM-looped the pod every
+    # ~10min (exit 137). Sizing, on data:
+    #   - request 512Mi: above steady-state (~400Mi) so kubelet node-pressure
+    #     eviction ranks it last (same logic as the volume servers above).
+    #   - limit 2Gi: comfortably above the observed ~1.7Gi burst peak.
+    #   - GOMEMLIMIT=1800MiB: soft ceiling ~90% of the limit. Go's GC otherwise
+    #     ignores the cgroup limit (GOGC=100 lets the heap overshoot before the
+    #     next GC → kernel OOM-kill). This makes the runtime trade CPU to stay
+    #     under the cap instead of dying — the "avoid container-OOM-on-own-limit"
+    #     caveat from the 2026_06_19 descheduler RCA, done properly for s3.
     priorityClassName: stateful-infra
+    env:
+      - name: GOMEMLIMIT
+        value: "1800MiB"
     requests:
       cpu: 50m
-      memory: 128Mi
-    limits:
       memory: 512Mi
+    limits:
+      memory: 2Gi
     # weed s3 defaults -ip.bind to localhost — kubelet's readiness probe from
     # outside the pod gets "connection refused". Bind to 0.0.0.0 so probes
     # (and the Service ClusterIP) reach the API.


### PR DESCRIPTION
## Problem

`seaweedfs-s3` has been crash-looping since PR #2402 landed today: both replicas **OOMKilled (exit 137)** every ~10 min in lockstep, 16 restarts in 5h. (The readiness `connection refused` is just the probe hitting a pod mid-restart, not the cause.)

PR #2402 ("protect stateful pods from descheduler eviction") set `limits.memory: 512Mi` on the s3 gateway — the **upstream Helm chart's lightweight-gateway default**. But our s3 isn't lightweight: it's read-heavy (load is dominated by **Mimir TSDB block range-GETs** — verified via `SeaweedFS_s3_request_total`) and runs the in-process **Iceberg REST catalog**.

## Data

From our **own Mimir history** (`container_memory_working_set_bytes`), the **pre-limit** s3 revision peaked at **~1.7 GiB** under query/compaction bursts; steady-state is ~400 MiB. The 512Mi cap is ~3–4× too small for real peak — the new pods aren't using less because they need less, they're killed before they can grow.

## What drives s3 memory

Load-proportional, **not a fixed footprint**: concurrent in-flight transfers + the Iceberg catalog. The in-memory chunk cache (`-cacheCapacityMB`) is **off by default** (and we don't set it), so there's nothing to cap there. With no `GOMEMLIMIT`, Go's GC ignores the cgroup limit (GOGC=100 lets the heap overshoot before the next GC) → kernel OOM-kill.

## Fix (sized on data)

| | before | after |
|---|---|---|
| request | 128Mi | **512Mi** (above ~400Mi steady-state → node-pressure ranks it last) |
| limit | 512Mi | **2Gi** (above the observed ~1.7Gi peak) |
| GOMEMLIMIT | — | **1800MiB** (soft ceiling ~90% of limit → Go GCs harder instead of hard-OOMing) |

Only the *request* reserves scheduling capacity; OVH workers are at 19–39% memory, so the 2Gi ceiling is comfortable.

Also adds an addendum to the `2026_06_19` descheduler RCA: its §A "optional limits, but avoid container-OOM-on-own-limit" caveat is exactly what bit s3.

## After merge

Reconcile the `seaweedfs` kustomization and confirm the s3 pods stop OOM-looping (restart count stabilizes, working set plateaus below 2Gi).