### PR TITLE
haku: propagate convention changes to all open items on base adoption

### DIFF
--- a/haku/run.md
+++ b/haku/run.md
@@ -36,7 +36,13 @@ bottom:
    (`git -C <ducktape> rev-parse HEAD`) to the pin in `memory/base-sync.md`. If it
    advanced, diff `haku/base` + `haku/run.md` since the pin, migrate your state to
    match (per the manual's _Adopting base updates_ — e.g. delete a dropped
-   `items.md`), update the pin, and log what you reconciled.
+   `items.md`), update the pin, and log what you reconciled. **For each commit that
+   changes an item convention** (how bodies are written, link formatting, actionability
+   rules, tone, the item contract) — as opposed to structural migrations (deleted files,
+   renamed directories) — **note it as a retroactive obligation to apply to every open
+   item in Step 6.** Commit-message migration notes are examples of what the author
+   happened to fix; they are not an exhaustive list of where the new convention applies.
+   The diff is the spec; your open items are the scope.
 3. **Process intake**: for each file in `intake/` (not `intake/processed/`):
    fold any standing guidance into your `memory/` in whatever form future runs
    will naturally act on (note when it expires if it's time-bound), then move the
@@ -72,7 +78,11 @@ bottom:
    into conformance with the manual** — the conventions evolve, so each pass check that
    open items still follow the current contract (e.g. _Links as affordances_: inline
    links, search/deep-link affordances; the actionability gate) and fix any that have
-   drifted, prioritising the top of the queue and any item you touch. The dashboard
+   drifted, prioritising the top of the queue and any item you touch. **When a base
+   update was adopted this run, the conformance sweep is mandatory and must cover every
+   open item** — not only those you touched for other reasons. For each convention change
+   noted in Step 2, read every open item and apply the new convention wherever it
+   applies; don't stop at the examples named in the commit message. The dashboard
    console renders the live site from `items/` on its own, so there's no page to
    regenerate and no templates to maintain — the look lives in the console's bundle (see
    _Dashboard_).


### PR DESCRIPTION
## What

Two small additions to `haku/run.md` that close a gap in how base-update
convention changes get applied to the existing item backlog.

### The bug

When adopting commits #2408/#2409 (Links as affordances, rewrite-not-accrete),
Haku read the commit-message migration notes as an exhaustive list of items to
fix, and rewrote only the 3 items the notes named — leaving the
`peak-one-refund-and-escalating-charge` item with bare Drive file names instead
of `[text](drive.google.com/file/d/<id>/view)` inline links, in violation of
the convention the same run had just adopted.

### Root cause

Step 6 already said to "bring user-facing items into conformance with the
manual" and to "prioritise the top of the queue and any item you touch," but
there was nothing connecting Step 2 (base adoption) to Step 6 (conformance
sweep) that made the sweep mandatory and full-queue when a convention changed.
The instructions also didn't make clear that commit-message migration notes are
examples, not a closed list.

### Fix

**Step 2** — after diffing the pin range, now explicitly notes
convention-changing commits as retroactive obligations for Step 6, and states
that commit-message notes are examples while the diff is the spec.

**Step 6** — adds: when a base update was adopted this run, the conformance
sweep is mandatory and must cover every open item, not only those touched for
other reasons.

## Diff

Changes are confined to `haku/run.md`. No schema, no other files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01756KeUv3of51NQBr3MFaqu)_