### PR TITLE
haku/base: require body and prompt to each stand alone

### DIFF
--- a/haku/base/instructions.md
+++ b/haku/base/instructions.md
@@ -403,6 +403,17 @@ Action kinds (only these two):
   and the evidence, and let it work out the how; don't shrink the ask to one
   mechanical step when the real win is bigger.
 
+**`body` and `prompt` each stand alone — neither may lean on the other.** They serve
+two audiences that never see each other's text. The **`body`** is what the operator
+reads on the console: it must convey the finding, the evidence, and what to do entirely
+on its own (the operator may never open the prompt). The **`prompt`** is what an
+executor agent reads: it must embed all its own evidence (ids, dates, amounts, links)
+and never refer back to the body. So don't split one thing across the boundary — e.g.
+don't bury an inbox-cleanup cluster table only in the `prompt` when the operator would
+want to see and click it; put it in the `body` too. Repetition between the two is
+expected and fine; a dangling cross-reference ("see the clusters above", "as the body
+explains") is not.
+
 **Links as affordances — give the operator the door, not directions to it.** A link
 that lands them one click from the thing or action beats a paragraph describing how to
 get there. So whenever you reference something addressable, link the most direct URL you

--- a/haku/base/schema/item.json
+++ b/haku/base/schema/item.json
@@ -21,7 +21,7 @@
     },
     "body": {
       "type": "string",
-      "description": "Rationale + evidence references (dates, merchants, amounts, item ids)"
+      "description": "Operator-facing rationale + evidence (dates, merchants, amounts, item ids); must stand alone \u2014 the operator may never open the prompt"
     },
     "value": {
       "type": "integer",
@@ -41,7 +41,9 @@
           "additionalProperties": false,
           "required": ["kind"],
           "properties": {
-            "kind": { "const": "suggestion" }
+            "kind": {
+              "const": "suggestion"
+            }
           }
         },
         {
@@ -49,10 +51,12 @@
           "additionalProperties": false,
           "required": ["kind", "prompt"],
           "properties": {
-            "kind": { "const": "prepared_prompt" },
+            "kind": {
+              "const": "prepared_prompt"
+            },
             "prompt": {
               "type": "string",
-              "description": "Self-contained prompt for an executor agent session"
+              "description": "Self-contained prompt for an executor agent session; embeds its own evidence and never refers back to the body"
             }
           }
         }
@@ -60,7 +64,7 @@
     },
     "source": {
       "type": "string",
-      "description": "What produced the item — a playbook name (e.g. plaid_anomalies) or a short tag for a self-directed finding"
+      "description": "What produced the item \u2014 a playbook name (e.g. plaid_anomalies) or a short tag for a self-directed finding"
     },
     "status": {
       "enum": ["open", "in_progress", "done", "rejected", "snoozed", "expired"]
@@ -76,7 +80,7 @@
     },
     "actions": {
       "type": "array",
-      "description": "Operator-facing buttons you attach to the item. The dashboard renders each as a click/un-click toggle; the click state is recorded by the console under clicks/<item-id>/<action-id> (NOT here). You reduce clicked actions on your next run — interpret the label/intent, do it, then clear the click. Include whatever fits: standard ones (snooze/reject/done) are just commands you interpret, plus item-specific ones.",
+      "description": "Operator-facing buttons you attach to the item. The dashboard renders each as a click/un-click toggle; the click state is recorded by the console under clicks/<item-id>/<action-id> (NOT here). You reduce clicked actions on your next run \u2014 interpret the label/intent, do it, then clear the click. Include whatever fits: standard ones (snooze/reject/done) are just commands you interpret, plus item-specific ones.",
       "items": {
         "oneOf": [
           {
@@ -84,8 +88,14 @@
             "additionalProperties": false,
             "required": ["id", "label", "kind", "intent"],
             "properties": {
-              "id": { "type": "string", "description": "Stable id within the item (used in the click path)" },
-              "label": { "type": "string", "description": "Button text shown to the operator" },
+              "id": {
+                "type": "string",
+                "description": "Stable id within the item (used in the click path)"
+              },
+              "label": {
+                "type": "string",
+                "description": "Button text shown to the operator"
+              },
               "kind": {
                 "const": "command",
                 "description": "A request you execute next run when clicked (toggle)"
@@ -101,8 +111,14 @@
             "additionalProperties": false,
             "required": ["id", "label", "kind", "prompt"],
             "properties": {
-              "id": { "type": "string", "description": "Stable id within the item (used in the click path)" },
-              "label": { "type": "string", "description": "Button text shown to the operator" },
+              "id": {
+                "type": "string",
+                "description": "Stable id within the item (used in the click path)"
+              },
+              "label": {
+                "type": "string",
+                "description": "Button text shown to the operator"
+              },
               "kind": {
                 "const": "claude_handoff",
                 "description": "A claude.ai/new deep-link rendered inline (no click state)"


### PR DESCRIPTION
Make Haku's two per-item artifacts independent.

An item's `body` (what the operator reads on the console) and its `prepared_prompt` (what an executor agent reads) serve two audiences that never see each other's text — but items had been splitting content across them (e.g. the inbox-cleanup cluster table lived only in the prompt, so the operator couldn't see or click it).

## What changed

**`instructions.md` (Item contract):** new rule — `body` and `prompt` each **stand alone**; neither may lean on the other. The `body` must convey the finding/evidence/action on its own (the operator may never open the prompt); the `prompt` must embed all its own evidence and never refer back to the body. Repetition between them is fine; dangling cross-references ("see the clusters above") are not.

**`schema/item.json`:** tightened the `body` and `prompt` field descriptions to say each must stand alone.

No structural schema change (descriptions only); pre-commit (prettier etc.) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJMNMdHtC2y3EVs4hmSZ2w

---
_Generated by [Claude Code](https://claude.ai/code/session_01TJMNMdHtC2y3EVs4hmSZ2w)_