### PR TITLE
cluster: decommission openclaw operator + clean up leftover objects

### DIFF
--- a/cluster/docs/plan.md
+++ b/cluster/docs/plan.md
@@ -37,8 +37,17 @@ and would **not** come back just because `atlas`/`wyrm2` returns.
 - **kagent**: `kagent-{crds,db,secrets}` — parked 2026-05-08; too fragile (sessions die on
   large MCP outputs, z.ai error 1261). Resources deleted. See <../k8s/agents/kagent/TODO.md>.
 - **Matrix**: `matrix`, `matrix-{db,secrets,namespace}` — parked.
-- **OpenClaw**: `openclaw-{gateway,operator,sandbox}` (+ their `-namespace`/`-secrets`) —
-  experimental, parked.
+- **OpenClaw**: `openclaw-{gateway,operator,sandbox}` (+ their `-namespace`/`-secrets`,
+  `gateway-agent-rbac`) — experimental, parked. **Cluster objects deleted 2026-06-19**:
+  the `openclaw-{operator,mitmproxy}` namespaces (operator Deployment/HelmRelease/pod) and
+  the `openclaw-operator-manager-{role,binding}` ClusterRole/ClusterRoleBinding. The
+  operator was already broken before teardown — its HelmChart had no artifact and the
+  operator image `ghcr.io/openclaw-rocks/openclaw-operator:v0.11.1` was in
+  `ImagePullBackOff` — so it sat firing `FluxHelmReleaseNotReady` /
+  `KubeDeploymentReplicasMismatch`. **To revive: fix the operator HelmChart/image pull
+  first, then un-suspend the kustomizations** (the git manifests are intact). The
+  `authentik/openclaw` HTTPRoute is left in place (owned by the active authentik
+  proxy-routes kustomization, backend is the authentik outpost) and will 502 until revived.
 - **OpenHands**: `openhands`, `openhands-{namespace,secrets,sandboxes}` — experimental, not
   currently used.
 - **Tandoor**: `tandoor`, `tandoor-{db,namespace}` — using Grocy instead.

--- a/cluster/k8s/agents/openclaw/gateway-agent-rbac/flux-kustomization.yaml
+++ b/cluster/k8s/agents/openclaw/gateway-agent-rbac/flux-kustomization.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     description: Agent RBAC for openclaw-gateway namespace. Lightweight — only RoleBindings. Depends on namespace existing + gateway for the openclaw-reader Role.
 spec:
+  suspend: true
   interval: 10m
   path: ./cluster/k8s/agents/openclaw/gateway-agent-rbac
   prune: true


### PR DESCRIPTION
## What

OpenClaw is parked (all kustomizations suspended), but the operator was still firing two alerts because its HelmRelease was broken: the HelmChart had no artifact and the operator image \`ghcr.io/openclaw-rocks/openclaw-operator:v0.11.1\` sat in \`ImagePullBackOff\`. This decommissions the leftover objects and parks the last un-suspended openclaw kustomization.

## Changes

- **Suspend** the straggler \`openclaw-gateway-agent-rbac\` kustomization (the other six openclaw kustomizations were already \`suspend: true\`).
- **Deleted live leftover objects** out-of-band (suspended kustomizations won't recreate them):
  - \`openclaw-{operator,mitmproxy}\` namespaces
  - \`openclaw-operator\` HelmRelease — \`helm uninstall\` also swept the operator Deployment + \`openclaw-operator-manager-{role,binding}\` ClusterRole/ClusterRoleBinding
- **Documented** the teardown + revival prerequisite in \`plan.md\` (fix the operator HelmChart/image pull first, then un-suspend; git manifests are intact).

## Safety check (nothing else depends on the deleted objects)

| Check | Result |
|---|---|
| ClusterRoleBinding subjects | Bound only the operator's own SA |
| mitmproxy CA-bundle configmap | Passive reflector copy (1 of 80), source elsewhere |
| ESO openclaw stores | Zero consumers; reference gateway/sandbox (not deleted) namespaces |
| CNPs in other namespaces | None reference openclaw |
| \`authentik/openclaw\` HTTPRoute | Backends the authentik outpost, not an openclaw Service — left in place |

## Alerts resolved

\`FluxHelmReleaseNotReady\` and \`KubeDeploymentReplicasMismatch\` (both \`ns=openclaw-operator\`).