### PR TITLE
seaweedfs: bump filer memory limit (4.18+ idle regression, issue #9035)

### DIFF
--- a/cluster/k8s/seaweedfs/cluster/seaweed.yaml
+++ b/cluster/k8s/seaweedfs/cluster/seaweed.yaml
@@ -141,6 +141,11 @@ spec:
     # env-var binding (WEED_<key>, dot→underscore). CNPG auto-generates the
     # Secret seaweedfs-filer-db-app at cluster bootstrap.
     env:
+      # Soft heap ceiling ~90% of the memory limit below; see the sizing note
+      # at requests/limits. Go's GC (GOGC=100) otherwise ignores the cgroup
+      # limit and overshoots → kernel OOM-kill.
+      - name: GOMEMLIMIT
+        value: "700MiB"
       - name: WEED_POSTGRES2_USERNAME
         valueFrom:
           secretKeyRef:
@@ -152,15 +157,30 @@ spec:
             name: seaweedfs-filer-db-app
             key: password
     metricsPort: 9326
-    # QoS / eviction protection as on master (metadata gateway to postgres,
-    # ~172Mi observed). Singleton, so deliberately NO PodDisruptionBudget —
-    # a maxUnavailable:0 PDB on a 1-replica set would wedge node drains.
+    # QoS / eviction protection as on master. Singleton, so deliberately NO
+    # PodDisruptionBudget — a maxUnavailable:0 PDB on a 1-replica set would
+    # wedge node drains.
+    #
+    # Memory sizing: the filer is a metadata gateway to Postgres (postgres2
+    # backend — metadata lives in the DB, not in-pod), so steady-state is
+    # modest (~190Mi peak / ~136Mi current in our Mimir history). BUT the filer
+    # idle floor jumped in SeaweedFS 4.18+: per upstream
+    # https://github.com/seaweedfs/seaweedfs/issues/9035 the filer now uses
+    # 250–360Mi idle (vs 80–90Mi in 4.17), and that issue's reporter OOM-loops
+    # a 256Mi-limited filer every 3–5min. We run 4.29, and the old 256Mi
+    # *request* sat exactly on that regression's floor. Sized on data, same
+    # pattern as the s3 gateway below:
+    #   - request 384Mi: above the 360Mi reported idle ceiling, so kubelet
+    #     node-pressure eviction ranks it last.
+    #   - limit 768Mi: ~2× the reported idle ceiling, ~4× our observed peak.
+    #   - GOMEMLIMIT=700MiB (set in env above): soft ceiling so Go GCs harder
+    #     instead of being OOM-killed at the cap.
     priorityClassName: stateful-infra
     requests:
       cpu: 50m
-      memory: 256Mi
+      memory: 384Mi
     limits:
-      memory: 512Mi
+      memory: 768Mi
     nodeSelector:
       topology.kubernetes.io/zone: hil-ovh
 


### PR DESCRIPTION
## What

Bump the SeaweedFS **filer** from `request=256Mi / limit=512Mi` to `request=384Mi / limit=768Mi` and add `GOMEMLIMIT=700MiB`.

## Why

SeaweedFS 4.18+ raised the filer's idle memory floor to **250–360 MiB** (vs 80–90 MiB in 4.17) — see upstream [seaweedfs#9035](https://github.com/seaweedfs/seaweedfs/issues/9035), whose reporter OOM-loops a 256Mi-limited filer every 3–5 min. We run **4.29**, so the old **256Mi request sat exactly on that regression's floor**, and the 512Mi limit left little headroom above the reported 360Mi idle ceiling.

This is the same failure shape as the s3 gateway we just fixed (PR #2413), applied to the filer.

## Sizing (on data)

- Our Mimir history: filer peaks **~190Mi**, currently **~136Mi**.
- `request 384Mi`: above the 360Mi reported idle ceiling → kubelet ranks it last for node-pressure eviction.
- `limit 768Mi`: ~2× the reported idle ceiling, ~4× our observed peak.
- `GOMEMLIMIT=700MiB`: soft ceiling (~90% of limit) so Go's GC trades CPU to stay under the cap instead of being OOM-killed (GOGC=100 otherwise overshoots the cgroup limit).

## Risk

Low — singleton stateless-ish metadata gateway; the operator rolls the filer StatefulSet pod. No PDB by design (1 replica).