### PR TITLE
gatus: enable /metrics endpoint to fix TargetDown

### DIFF
--- a/cluster/k8s/gatus/app/config.yaml
+++ b/cluster/k8s/gatus/app/config.yaml
@@ -1,3 +1,10 @@
+# Expose the Prometheus /metrics endpoint on the web port. The gatus
+# ServiceMonitor (k8s/gatus/servicemonitor/) scrapes /metrics; without this
+# gatus never registers that handler, so the scrape 404s and
+# TargetDown{service=gatus} fires (gatus itself stays healthy — the readiness
+# probe hits /health, which always serves).
+metrics: true
+
 security:
   oidc:
     issuer-url: https://auth.allegedly.works/application/o/gatus/


### PR DESCRIPTION
## Problem

`TargetDown{service=gatus, namespace=gatus}` has been firing since **2026-06-11** (100% of gatus scrape targets down).

The `gatus-servicemonitor` scrapes `/metrics`, but the gatus config never set `metrics: true`, so gatus never registered that handler — every scrape 404'd. The pod itself was healthy the whole time (readiness probe hits `/health`, which always serves), so this was **monitoring-only**: gatus's uptime checks kept working, we just got no Prometheus metrics from it.

## Fix

Set `metrics: true` at the top of `cluster/k8s/gatus/app/config.yaml`. Gatus then exposes the Prometheus endpoint on the existing web port (8080). The NetworkPolicy already allows the `monitoring` namespace to scrape 8080, so no other change is needed.

## Verification

- Confirmed gatus pod is `1/1 Ready` and serving `/health`.
- Confirmed `gatus-ingress` NetworkPolicy permits `monitoring` → gatus:8080.
- After merge + reconcile, the ServiceMonitor scrape should succeed and `TargetDown{service=gatus}` should clear.