### PR TITLE
haku/console/frontend: submit feedback on Enter, Ctrl+Enter for newline

### DIFF
--- a/haku/console/frontend/feedback.tsx
+++ b/haku/console/frontend/feedback.tsx
@@ -1,5 +1,5 @@
-import { type FormEvent, useState } from "react";
-import { Button, Textarea } from "@mantine/core";
+import { type FormEvent, type KeyboardEvent, useState } from "react";
+import { Button, Text, Textarea } from "@mantine/core";
 
 import { sendFeedback } from "./client.ts";
 
@@ -25,12 +25,16 @@ interface FeedbackFormProps {
 // "Note to Haku" box and the per-item box. The Mantine Button's `loading` shows a
 // spinner and disables the form while the commit-push is in flight, so the operator
 // sees it land; a failure surfaces inline on the Textarea instead of being swallowed.
+//
+// Enter-to-send: the textarea's default (Enter inserts a newline) is inverted so the
+// common "type a line, hit Enter" sends without reaching for the mouse — the ↵ on the
+// button and the hint by it advertise this. A newline still needs Ctrl/Cmd+Enter (or
+// Shift+Enter).
 export function FeedbackForm({ minRows, placeholder, submitLabel, itemId }: FeedbackFormProps) {
   const [text, setText] = useState("");
   const [state, setState] = useState<SubmitState>({ status: "idle" });
 
-  function submit(event: FormEvent) {
-    event.preventDefault();
+  function send() {
     if (!text.trim() || state.status === "sending") return;
     setState({ status: "sending" });
     void sendFeedback(text, itemId)
@@ -43,9 +47,33 @@ export function FeedbackForm({ minRows, placeholder, submitLabel, itemId }: Feed
       });
   }
 
+  function onKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
+    if (event.key !== "Enter") return;
+    if (event.ctrlKey || event.metaKey) {
+      // Ctrl/Cmd+Enter inserts a newline at the caret (the browser default does not).
+      event.preventDefault();
+      const ta = event.currentTarget;
+      const start = ta.selectionStart ?? ta.value.length;
+      const end = ta.selectionEnd ?? ta.value.length;
+      ta.setRangeText("\n", start, end, "end");
+      setText(ta.value);
+      if (state.status !== "idle") setState({ status: "idle" });
+    } else if (!event.shiftKey) {
+      // Plain Enter sends; Shift+Enter falls through to the default newline.
+      event.preventDefault();
+      send();
+    }
+  }
+
   const sending = state.status === "sending";
   return (
-    <form onSubmit={submit} className="flex w-full flex-col items-start gap-2">
+    <form
+      onSubmit={(event: FormEvent) => {
+        event.preventDefault();
+        send();
+      }}
+      className="flex w-full flex-col items-start gap-2"
+    >
       <Textarea
         className="w-full"
         autosize
@@ -55,13 +83,29 @@ export function FeedbackForm({ minRows, placeholder, submitLabel, itemId }: Feed
           setText(event.currentTarget.value);
           if (state.status !== "idle") setState({ status: "idle" });
         }}
+        onKeyDown={onKeyDown}
         placeholder={placeholder}
         disabled={sending}
         error={state.status === "error" ? `Failed: ${state.message}` : undefined}
       />
-      <Button type="submit" color="teal" loading={sending} disabled={!text.trim()}>
-        {state.status === "sent" ? "Sent ✓" : submitLabel}
-      </Button>
+      <div className="flex items-center gap-3">
+        <Button
+          type="submit"
+          color="teal"
+          loading={sending}
+          disabled={!text.trim()}
+          rightSection={
+            <span aria-hidden="true" className="opacity-70">
+              ↵
+            </span>
+          }
+        >
+          {state.status === "sent" ? "Sent ✓" : submitLabel}
+        </Button>
+        <Text size="xs" c="dimmed">
+          Ctrl+Enter for newline
+        </Text>
+      </div>
     </form>
   );
 }


### PR DESCRIPTION
Follow-up to the haku console feedback work (#2410).

Makes the feedback boxes (global "Note to Haku" and per-item) submit on **Enter**, since the common case is a one-liner and reaching for the mouse is friction.

- **Enter** sends the note (the textarea's default Enter-inserts-newline is inverted).
- **Ctrl/Cmd+Enter** inserts a newline at the caret (via `setRangeText`, since browsers don't insert one by default for that chord); **Shift+Enter** also works via the browser default.
- **Discoverability**: the Send button shows a `↵` glyph to signal Enter-submits, with a dimmed "Ctrl+Enter for newline" hint beside it. (Put as an always-visible line rather than the placeholder, which would vanish the moment you start typing — exactly when you'd want the newline shortcut.)

Lives entirely in `feedback.tsx`, so both feedback boxes get it.

## Test

`bbr test //haku/console/...` green (`tsc_test` type-checks the new keydown handler under strict TS); `//haku/console/frontend:bundle` builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7wAM7sBZqCFvYi7L63H6H

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7wAM7sBZqCFvYi7L63H6H)_