### PR TITLE
haku/base: record sync bookmarks as exact timestamps, not coarse dates

### DIFF
--- a/haku/base/instructions.md
+++ b/haku/base/instructions.md
@@ -285,7 +285,10 @@ Your home environment keeps nothing between runs; **`haku-state` is your only
 memory.** Keep whatever your future self needs under `memory/` and read it back
 when you orient. This is yours to structure and **does not need to be
 machine-readable** — prose is fine. Keep there: how far you've processed each
-source (a bookmark like "gmail: through 2026-06-18T07:00Z"), research notes, your
+source (a bookmark recorded as an **exact timestamp, not a coarse date** — e.g.
+`gmail: through 2026-06-18T07:03:12Z`, never `gmail: through 2026-06-18` — so the
+next run resumes exactly where you stopped, never re-scanning or skipping the rest
+of a day), research notes, your
 reasoning, and — first-class — your **model of the operator** (their context,
 preferences, constraints, risk tolerance, standing decisions, and the calibration
 learned from accept/reject/snooze; see _How you reason_). Maintaining that model

--- a/haku/base/playbooks/gmail_triage.md
+++ b/haku/base/playbooks/gmail_triage.md
@@ -1,7 +1,9 @@
 # gmail_triage (example)
 
 Read Gmail with the read-only token (see `../instructions.md` → _Hard rules_). List new
-mail since your bookmark (on the first run, a window like `newer_than:7d`):
+mail since your bookmark — resume precisely with `q=after:<epoch-seconds>`, since Gmail's
+`after:YYYY/MM/DD` is only date-granular and would re-scan or skip part of a day (on the
+first run, a window like `newer_than:7d`):
 `curl -s -H "Authorization: Bearer $TOK" 'https://gmail.googleapis.com/gmail/v1/users/me/messages?q=newer_than:7d'`,
 then fetch each with `.../messages/{id}?format=metadata` (use `format=full` only
 when you must read a body to judge it). Useful `q=` filters: `is:unread`,

--- a/haku/base/playbooks/tana_review.md
+++ b/haku/base/playbooks/tana_review.md
@@ -37,7 +37,8 @@ flips NotReady on a bad upstream, and the bearer must be the reflected one).
 
 ## What to mine
 
-Resume from a bookmark in `memory/` (e.g. "tana: through 2026-06-18") and look at
+Resume from a bookmark in `memory/` (e.g. "tana: through 2026-06-18T09:15:00Z" — an
+exact timestamp, not a coarse date) and look at
 what's recent in the operator's graph:
 
 - **Recent daily notes** — walk the last ~1–2 weeks of daily/calendar nodes (find


### PR DESCRIPTION
Haku records a **bookmark** per source — "how far processed" — so each run is an incremental update rather than a full rescan. Those bookmarks are sync high-watermarks, and writing one as a **coarse date** (e.g. `gmail: through 2026-06-18`) is ambiguous at the day boundary: the next run either re-scans the rest of that day (duplicate work) or skips it (missed items). This makes them **exact timestamps**.

- `instructions.md` — where bookmarks are defined, require an exact timestamp (not a coarse date), with the rationale and a counter-example.
- `playbooks/tana_review.md` — the example bookmark was a coarse date (`2026-06-18`); fixed to a timestamp.
- `playbooks/gmail_triage.md` — resume with `q=after:<epoch-seconds>`, since Gmail's `after:YYYY/MM/DD` is only date-granular and would otherwise re-scan or skip part of a day (Drive/Tana already use RFC3339 `modifiedTime`, so they honor the timestamp natively).

Docs-only change to Haku's base layer; no build or test targets affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7wAM7sBZqCFvYi7L63H6H

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7wAM7sBZqCFvYi7L63H6H)_