### PR TITLE
debundle: prune completed items from TODO.md

### DIFF
--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -26,16 +26,13 @@ done, and the enclosing-context residual handled; only a low-priority polish tai
 remains in <plans/readoff_minimization.md>. The active frontier has shifted to the
 **automation product flows**, in dispatch order:
 
-1. **Dogfood-apply on gaffer-private** — capture the landed minimizer wins on the
-   real spec (fragile name-pins → robust `source_match`, re-measure debt). Highest
-   value: it validates everything and is the reason the minimizer exists.
-2. **Spec repair from diagnostics (P0.3)** — build on the landed keep-going
+1. **Spec repair from diagnostics (P0.3)** — build on the landed keep-going
    diagnostics (#2302) to propose mechanically-proven patch plans.
-3. **Patch-plan / dry-run / explain infrastructure (P0.1)** — the apply-with-review
+2. **Patch-plan / dry-run / explain infrastructure (P0.1)** — the apply-with-review
    substrate the repair + bulk-codemod flows pipe through.
-4. **Version-port (P1.1) and new-app bootstrap (P1.2)** — the remaining
+3. **Version-port (P1.1) and new-app bootstrap (P1.2)** — the remaining
    `automated_spec_workflows.md` milestones.
-5. **Excalidraw public live-browser smoke (P1.7)** — public-CI repro leverage,
+4. **Excalidraw public live-browser smoke (P1.7)** — public-CI repro leverage,
    independent of all the above.
 
 The minimizer polish tail (keep-shallow group-cover retirement, language
@@ -55,9 +52,9 @@ One-line status for each `plans/` design doc; this is the discovery index.
 
 - <plans/readoff_minimization.md> — **core complete.** Read-off selector
   minimizer (chunk-wide AST-shape index); every form migrated and the cover
-  deleted. Open: dogfood value-capture (top priority) + a polish tail (keep-shallow
-  group-cover retirement, language simplification). Holds its own current-state +
-  backlog.
+  deleted. Dogfood value-capture done (stabilization lanes, rounds 1–3). Open: a
+  polish tail (keep-shallow group-cover retirement, language simplification). Holds
+  its own current-state + backlog.
 - <plans/readoff_algorithm_research.md> + <plans/readoff_research/> — **reference
   (complete).** Literature spike that gates the read-off design; durable, not a
   TODO.
@@ -73,12 +70,11 @@ One-line status for each `plans/` design doc; this is the discovery index.
   menu across all read-off forms (#2339 + binding-group menu). Open: ground the skill
   playbook with tested fixtures (M2) and port-based evaluation (M3).
 - <plans/selector_constraint_model.md> + <plans/selector_resolver_endpoint.md> — **active
-  (P4 expressivity).** The fact-based resolver is the sole selector resolver and the
-  X1–X3 relational primitives (`cross_ref` / `reads_member` / `member_of_module`) are in
-  place. Remaining: the real-spec **conversions** (delegators → `cross_ref`, codegen
-  helpers → `reads_member`, empty-classes → `member_of_module`), X4/X5
-  (counting/uniqueness + one global solve), and push-to-zero — see
-  <debug/2026_06_19_p4_debt_worklist.md>.
+  (P4 expressivity).** The fact-based resolver + the full X1–X3 relational primitive
+  suite (`cross_ref` / `reads_member` / `member_of_module`) plus `passed_to_call` /
+  `makes_decorate_call` / `intrinsic_alias` landed in #2398. Remaining: X4/X5
+  (counting/uniqueness + one global solve) and the real-spec push-to-zero conversions
+  (underway via the stabilization lanes) — see <debug/2026_06_19_p4_debt_worklist.md>.
 - <plans/adopt_names_via_bijection.md> — **not started.** Expose the `source_match`
   identifier bijection so one selector both locates a declaration and adopts
   readable names onto its params/locals/nested bindings.
@@ -150,34 +146,14 @@ propose`.
 
 ### P2 — pipeline performance and architecture cleanup
 
-1. **Selector matching was the measured hot path — fixed 2026-06-21**
-   (<perf/fact_resolver.md>). The fact-based `ChunkResolver` → `selector_match`
-   homomorphism was ~92% of a source_match-selector `run`/`validate` and ≈O(n²) in
-   selector count (4x selectors → ~15x wall; 40k statements breached the 60s
-   blocker). Both fixes landed, behavior-preserving (byte-identical output, 132
-   suite + e2e green): (a) the per-needle `unsupported_needle_construct` re-check
-   is hoisted out of the candidate loop (`matches_prepared` /
-   `var_declarator_alignment_prepared`, called after a one-time probe); (b) the
-   per-chunk token postings index now also keys on identifier spellings
-   (`Token::Ident` / `subject_tokens`), and an exact-mode no-prebind needle
-   requires its identifiers (`needle_required_tokens`), pruning the candidate scan
-   for the identifier-only `const NAME = …;` shape that pinned no literal token —
-   the source of the quadratic. Result: 10k 4.25s→0.45s, 40k 80.3s→2.76s; scaling
-   exponent ≈2.1 → ≈1.3 (quadratic gone), both interactive (<10s) and blocker
-   (<60s) budgets met at 40k. `chunk_facts` EDB extraction and `selector_solve`
-   (Ascent) were confirmed not hot; items #5/#6 (`JsChunk` scans,
-   `split_entry_body` clone) were checked and are not hot. Follow-up (optional):
-   the third profile lever (intern identifier atoms to drop the `__memcmp` exact-id
-   compares) is now largely subsumed by the shrunken candidate set; re-measure on a
-   real (non-synthetic) chunk before pursuing it.
-2. Add `debundle run --reports=<list>` so dry-run/spec-check workflows can skip
+1. Add `debundle run --reports=<list>` so dry-run/spec-check workflows can skip
    expensive reports they do not need.
-3. Add chunk-level incremental rebuilds keyed by upstream bytes, spec slice,
+2. Add chunk-level incremental rebuilds keyed by upstream bytes, spec slice,
    and Ducktape version.
-4. Add an AST-hash SWC codegen cache for unchanged post-lowering modules.
-5. Replace `JsChunk::{get_file,get_file_mut,remove_file}` linear scans with a
+3. Add an AST-hash SWC codegen cache for unchanged post-lowering modules.
+4. Replace `JsChunk::{get_file,get_file_mut,remove_file}` linear scans with a
    path-keyed index if fresh profiles show chunk file lookup hot.
-6. Move `split_entry_body` to a draining/move-based implementation if fresh
+5. Move `split_entry_body` to a draining/move-based implementation if fresh
    profiles show retained-statement cloning hot.
 
 ## Code refactor / dedup opportunities (2026-06-17 survey)


### PR DESCRIPTION
`devinfra/js/debundle/TODO.md` is "written to be removed once closed; this file is not a changelog", but it still carried completed work after #2398 merged. This prunes it (−41/+17):

- **Drop the landed 2026-06-21 selector-matching perf-fix entry** (P2 #1) — a multi-paragraph changelog entry for the `ChunkResolver`/`selector_match` quadratic fix that shipped in #2398; renumber the remaining P2 items.
- **Drop the "Dogfood-apply on gaffer-private" frontier item** — done via the stabilization lanes (rounds 1–3: fragile name-pins → `source_match`, debt re-measured); renumber the dispatch list.
- **Refresh two plan-index lines** to reflect #2398 landing: `readoff_minimization` dogfood value-capture is done; the fact-based resolver + the full X1–X3 / `passed_to_call` / `makes_decorate_call` / `intrinsic_alias` suite landed (only X4/X5 + the real-spec push-to-zero conversions remain).

No code changes; docs-only. Pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYRJift7ufbrfsdXTZDyaS

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYRJift7ufbrfsdXTZDyaS)_