### PR TITLE
haku/runtime: Agent Framework runtime (Runtime C) + Managed Agents scaffold (Runtime B)

### DIFF
--- a/devinfra/gazelle_python.yaml
+++ b/devinfra/gazelle_python.yaml
@@ -19,6 +19,7 @@ manifest:
     agent_framework_anthropic: agent_framework_anthropic
     agent_framework_claude: agent_framework_claude
     agent_framework_openai: agent_framework_openai
+    agent_framework_redis: agent_framework_redis
     agents: openai_agents
     aioboto3: aioboto3
     aiobotocore: aiobotocore
@@ -500,6 +501,8 @@ manifest:
     qrcode: qrcode
     qtpy: QtPy
     reaktiv: reaktiv
+    redis: redis
+    redisvl: redisvl
     referencing: referencing
     regex: regex
     requests: requests
@@ -546,7 +549,7 @@ manifest:
     sympy: sympy
     syrupy: syrupy
     tabulate: tabulate
-    takethetime: TakeTheTime
+    takethetime: takethetime
     tenacity: tenacity
     terminado: terminado
     testcontainers.arangodb: testcontainers
@@ -619,6 +622,7 @@ manifest:
     tzdata: tzdata
     tzlocal: tzlocal
     uc_micro: uc_micro_py
+    ulid: python_ulid
     uncalled_for: uncalled_for
     unidiff: unidiff
     unpaddedbase64: unpaddedbase64
@@ -654,4 +658,4 @@ manifest:
     zstandard: zstandard
   pip_repository:
     name: pypi
-integrity: ac3939c106bacca4bbb962ff3b327225cb158fe4cf0fb35f5fe92cd3886c2d7e
+integrity: 1674c0c8dd3285c56ac4acb34721dca759f6c1ec70b2d81b9cffd0d67d94f0ca

--- a/haku/PLAN.md
+++ b/haku/PLAN.md
@@ -428,7 +428,10 @@ vault env-var credential either way.
 Verdict: not the plan of record — the Claude Code CronJob keeps everything
 self-hosted and is fully specced above — but revisit if the
 client_credentials spike or scanner-image upkeep proves painful; scheduled
-deployments + vaults remove exactly those two work items.
+deployments + vaults remove exactly those two work items. A detailed migration
+design — a self-hosted worker in `haku-sandbox`, **one long-lived session woken
+by events** (not a session per run), and MCP auth via vaults — is being worked
+out in <plans/managed_agents.md>.
 
 ## MVP plan
 

--- a/haku/plans/managed_agents.md
+++ b/haku/plans/managed_agents.md
@@ -1,0 +1,230 @@
+# Plan: Haku on Anthropic Managed Agents (self-hosted sandbox)
+
+Status: **design / exploring** — not yet decided over the Claude Code web home.
+Expands the _Alternative runtime: Anthropic Managed Agents_ section of
+<../PLAN.md> from a paragraph into a concrete migration design, and is an
+alternative to the deferred in-cluster `haku-scanner` runtime (<../TODO.md> →
+_Later_). Delete or tombstone once Haku's runtime is decided.
+
+## Why
+
+v0 runs Haku as a **manually-started, ephemeral Claude Code web session** on
+Anthropic infra (`haku/runtime/claude_web_env/`). Two wants motivate moving off it:
+
+1. **Trigger Haku on events / on demand** (a push to `haku-state`, a schedule, a
+   button) — without a human opening a web session.
+2. **Don't re-read everything on every wake.** A fresh session re-bootstraps the
+   environment and re-loads the operating manual as cold context each time.
+
+Anthropic **Managed Agents** (public beta, `managed-agents-2026-04-01`) is
+phase-1-as-a-service: Anthropic runs the agent loop; you supply a persisted,
+versioned **agent** config and an **environment**, and drive **sessions** over an
+event stream. Its **self-hosted sandbox** (`config.type: "self_hosted"`) is the
+bring-your-own-container variant: the loop stays at Anthropic, but tool execution
+(`bash`, file ops, code) runs in a **worker you run in `haku-sandbox`**, polling
+Anthropic's work queue outbound-only. That is exactly Haku's posture today (a
+read-only container behind the mitmproxy egress), so the fit is unusually close.
+
+This **removes two specced-but-unbuilt work items**: the MCP
+`client_credentials` / facade-JWT spike (replaced by **vaults**, below), and the
+`haku-scanner` image / CronJob upkeep (replaced by the worker image plus a
+supervisor). It **gives up** in-cluster LiteLLM/Langfuse attribution and the
+`haku-traces` transcript store — the loop and its traces live at Anthropic (see
+_Tradeoffs_).
+
+## Runtime model: one long-lived session + wake events
+
+The design we want (not a session-per-run):
+
+- The **supervisor** keeps **exactly one live Haku session** and holds it open.
+  On a trigger it sends a `user.message` event — _"do a scan per `run.md`"_ —
+  into that session. Events queue and process in order, so a wake that arrives
+  mid-run is picked up next. The agent **retains its loaded base manual and
+  recent reasoning across wakes**, so a wake is an incremental nudge, not a cold
+  re-read. This is the literal answer to want (2).
+- **Idle is cheap.** Session-runtime billing accrues only while a session is
+  `running`; an idle session waiting for the next wake does not (verify — see
+  _Open questions_). Token cost is paid per wake (cached history), not per idle
+  minute.
+- **Context stays bounded.** Managed Agents sessions auto-**compact** history near
+  the context limit, so a long-lived session doesn't blow the window.
+- **`haku-state` is still the system of record.** The warm session is an
+  optimization, not memory. If it terminates or compacts, a fresh session just
+  re-orients from `haku-state` (its `memory/` bookmarks + `items/` + `log/`) — as
+  today. Losing the session never loses memory. So the supervisor may recreate
+  the session at will, and the agent's own incremental-scan discipline
+  (bookmarks) already means "only look at what's new" independent of session
+  warmth.
+
+```
+trigger (push / cron / button)
+        │
+        ▼
+   supervisor ──holds──▶ one Haku session ◀──loop runs at──▶ Anthropic
+   (holds API key)        │  events: user.message in,            orchestration
+   - 1 live session       │  agent.* / tool_use out
+   - reconnect SSE        ▼
+   - recreate on death   worker pod in haku-sandbox  ── bash/kubectl/psql/curl/git
+                          (holds ANTHROPIC_ENVIRONMENT_KEY only)   ▲
+                          bootstrap.sh: kubeconfig + clone state ──┘
+```
+
+### Triggers funnel into the supervisor
+
+All paths end in "send a wake message to the current session (creating one if
+none is live)" — **not** `sessions.create()` per event:
+
+- **Schedule** — the supervisor's own timer. (A Managed Agents _scheduled
+  deployment_ fires a **new** session per tick, which is the cold, session-per-run
+  shape we're explicitly avoiding — so the schedule lives in the supervisor, not a
+  deployment.)
+- **Git events** — a Forgejo webhook on `haku-state` (and/or ducktape base
+  changes) → an HTTP endpoint on the supervisor → wake. Anthropic's own webhooks
+  are Anthropic→you _notifications_, not GitHub→you _triggers_; the receiver is
+  ordinary code on our side.
+- **On demand** — a button / small CLI → the same wake endpoint.
+
+## MCP servers + vaults (the "nicely handled auth" path)
+
+Haku's sources today are reached ad hoc: Plaid over `psql` (in-cluster pod),
+Gmail/Calendar over REST `curl`, Tana over the `fastmcp` CLI to the bearer-gated
+`tana-mcp-ro` facade. There is no `.mcp.json`. The PLAN north star (<../TODO.md>)
+is to give Haku **native MCP tools**.
+
+Managed Agents does this cleanly, and its **vaults** are precisely the
+headless-MCP-auth mechanism the PLAN's _MCP auth provisioning_ spike was for:
+
+- **Declare servers on the agent** — `mcp_servers: [{type:"url", name, url}]` plus
+  a `tools: [{type:"mcp_toolset", mcp_server_name}]` entry. No auth on the agent.
+- **Auth lives in a vault** — `mcp_oauth` (OAuth with **auto-refresh**) or
+  `static_bearer`, keyed by the MCP server URL. Attach via `vault_ids` on the
+  session. Anthropic injects the credential **at egress**, so the sandbox never
+  sees it, and refreshes OAuth tokens itself. This is the "nicely handled auth for
+  remote MCP servers" — and it deletes the `client_credentials` + JWT-rotation +
+  "does the facade accept service-account JWTs" spike.
+
+Candidate servers to wire (each already has or could expose a gated public route):
+`tana-mcp-ro` (`static_bearer` from `haku-tana-ro-token`, or upgrade to its
+Authentik OIDC mode → `mcp_oauth`, which the TODO already wants), `grocy_mcp`,
+PostScanMail, the Google Workspace MCP, Manifold — the `cluster/k8s/agents/*-mcp`
+fleet, optionally fronted by the `mcp_infra` compositor as a single endpoint.
+
+### Two caveats that shape the source split
+
+1. **MCP runs on Anthropic's orchestration layer, not in the worker.** In a
+   self-hosted sandbox only `bash`/file/code execution moves to your container;
+   `mcp_toolset` calls originate from Anthropic's side. So a vault-backed MCP
+   server must be **reachable from Anthropic at a public, gated URL** (as
+   `tana-mcp-ro.allegedly.works` already is). Sources that stay loopback-only
+   in-cluster can't be vault-backed `mcp_toolset`s — the worker reaches them via
+   `bash`/`fastmcp`/`psql` as today (no vault, manual auth). **Per source: public
+   gated facade + vault (nice auth) vs. in-cluster + bash (worker-reached).**
+2. **`environment_variable` vault credentials are _not_ supported in self-hosted**
+   (egress is yours, so there's nowhere for Anthropic to substitute the secret).
+   That's fine: the secrets Haku's **bash** tools need — the `haku` kubeconfig/JWT,
+   the Plaid `plaid-mcp-db-readonly` DSN, the `google-access-token`, the
+   `haku-state-git-write` creds — stay materialized **in-container from
+   `haku-sandbox` k8s secrets at bootstrap**, exactly as `bootstrap.sh` does now.
+
+Clean rule: **MCP auth → vaults; everything bash reaches → in-container k8s
+secrets.**
+
+## Component mapping
+
+| Today (Claude Code web)                                                        | Self-hosted Managed Agent                                                                                                                                                      |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Session start hook + `web_setup.sh` provisions the env                         | A **worker image** running `EnvironmentWorker` (Python/Go SDK) or `ant beta:worker poll` in `haku-sandbox`                                                                     |
+| `haku/runtime/claude_web_env/bootstrap.sh` (kubeconfig, `.netrc`, clone state) | **Same script** as the worker entrypoint — self-hosted does _not_ auto-mount repos, so our existing bootstrap _is_ the mount                                                   |
+| `Execute haku/runtime/claude_web_env/run.md` prompt                            | A `user.message` wake event                                                                                                                                                    |
+| `--dangerously-skip-permissions` (Pod = trust boundary)                        | `permission_policy: always_allow` (same reasoning)                                                                                                                             |
+| Cluster access via `kubeapi.allegedly.works` proxy                             | **Direct in-cluster access** (worker runs in `haku-sandbox`)                                                                                                                   |
+| Claude Code native tools (mostly bash)                                         | `agent_toolset_20260401` (bash/read/write/edit/glob/grep) + `mcp_toolset`s                                                                                                     |
+| `haku-state` git repo as durable memory                                        | unchanged                                                                                                                                                                      |
+| base read from the ducktape checkout, reconciled via `memory/base-sync`        | unchanged — worker clones ducktape; agent `system` is a thin pointer ("read the manual + run procedure, then run") so base stays single-sourced and reconciliation still works |
+
+The worker pod keeps the Ember posture intact: non-root, behind the existing
+dedicated `haku-mitmproxy` egress, scoped `haku-sandbox` RBAC, ResourceQuota —
+none of it relying on agent restraint. Egress is ours in self-hosted, which the
+`haku-mitmproxy` + CCNP already enforce.
+
+## Artifacts to build
+
+First-cut, copy-pasteable drafts of every item below are in
+<managed_agents_artifacts.md>.
+
+1. **`haku.agent.yaml`** (control plane, version-controlled, applied via `ant
+beta:agents create|update`): `model: claude-opus-4-8`, thin pointer `system`,
+   `tools: [agent_toolset_20260401, mcp_toolset…]`, `mcp_servers: […]`,
+   `permission_policy: always_allow`.
+2. **`haku.environment.yaml`**: `config: {type: self_hosted}`.
+3. **Worker image** (Bazel `oci_image`, the standard
+   <../../cluster/docs/container-images.md> path): Python 3.13, `git`, `kubectl`,
+   postgres client, `curl`, `fastmcp`, `/bin/bash`, the `anthropic` SDK. Entrypoint
+   reuses `bootstrap.sh`, then runs `EnvironmentWorker(...).run()`.
+4. **Supervisor** (small service): holds the control-plane API key, maintains one
+   live session, reconnects the SSE stream losslessly (history `events.list` +
+   dedupe; break only on terminated / idle-with-terminal-stop_reason), recreates
+   the session on death, and exposes the wake endpoint (HTTP for the webhook +
+   internal timer for the schedule).
+5. **k8s** in `cluster/k8s/haku/`: a `haku-worker` Deployment and a
+   `haku-supervisor` Deployment, an `ANTHROPIC_ENVIRONMENT_KEY` secret (worker
+   only) and an API-key secret (supervisor only — keep the org-scoped API key
+   **off** the worker host so agent tool calls can't read it), and a Forgejo
+   webhook → supervisor route.
+6. **Vault(s)**: one vault holding the MCP credentials (`tana-mcp-ro` bearer/OAuth,
+   then others as wired); referenced by `vault_ids` on session create.
+
+## Effort
+
+A working v1 is **a few focused days**; robustness + per-source MCP exposure is
+the longer tail. Reused vs. new:
+
+- **Reused, near-zero change**: `bootstrap.sh`, the `haku-mitmproxy` egress, the
+  `haku-sandbox` RBAC/quota, `haku-state`, the base manual + run procedure, the
+  incremental-scan discipline. Haku's actual logic doesn't change.
+- **New**: worker image + entrypoint (~½–1d, repo already builds `oci_image`s),
+  `haku.{agent,environment}.yaml` + env key (~½d), the supervisor with robust
+  reconnect (~1–2d — the bulk), the Forgejo webhook route (~½d), and per-MCP
+  vault + public gated facade wiring (incremental, ~½d per source).
+
+## Tradeoffs vs. the self-hosted Claude Code path
+
+- **Lose**: in-cluster LiteLLM attribution / budget / kill-switch and Langfuse
+  traces (the loop runs at Anthropic). Kill-switch becomes "archive the agent /
+  revoke the environment key"; budget becomes Anthropic workspace limits;
+  per-run replay becomes the Console session trace (below) — optionally the
+  supervisor can still mirror transcripts to `haku-traces`.
+- **Gain**: no scheduled-CronJob / scanner-image bespoke runtime, no
+  `client_credentials` MCP-auth spike (vaults), warm-session wakeups, and a
+  first-class Console UI.
+
+## Observability
+
+The Anthropic **Console** (`platform.claude.com/workspaces/default/sessions`)
+renders each session as a chronological, chat-style trace — messages, thinking,
+every `tool_use` + `tool_result`, per-step token usage — live and after the
+fact. It works for self-hosted too: tool I/O round-trips through Anthropic's
+orchestration layer, so it appears in the trace even though execution is on our
+worker. This is the managed-agents equivalent of the claude.ai/code session view
+we watch Haku in today, and arguably better for an unattended agent. Aggregate
+token/cost lives in Console → Logs and the Usage & Cost Admin API.
+
+## Open questions / to verify
+
+- **Idle billing**: confirm an idle long-lived session accrues no
+  session-runtime cost (only tokens per wake). Drives whether warm-session is
+  actually cheap.
+- **Workdir persistence across wakes**: does a self-hosted worker's `/workspace`
+  survive across turns of one long-lived session? Haku tolerates either way
+  (state is in git), but it affects whether re-clone is needed per wake.
+- **MCP vaults on self-hosted**: confirm `mcp_oauth`/`static_bearer` vault creds
+  work with `config.type: self_hosted` (strongly implied — MCP runs Anthropic-side
+  and vaults are offered as the self-hosted workaround for env-var creds — but
+  verify on `tana-mcp-ro`).
+- **Which facades to expose publicly** (gated) for vault-backed `mcp_toolset` vs.
+  keep loopback-only and reach via worker `bash`/`fastmcp`. Per source.
+- **Attribution**: accept the loss of LiteLLM/Langfuse, or have the supervisor
+  push session transcripts to `haku-traces`? Console trace + Admin usage API may
+  suffice.
+- **Beta surface**: Managed Agents + self-hosted are public beta; the
+  `EnvironmentWorker` helper is Python/Go/TS only (use Python). Pin SDK versions.

--- a/haku/plans/managed_agents_artifacts.md
+++ b/haku/plans/managed_agents_artifacts.md
@@ -1,0 +1,335 @@
+# Artifact drafts: Haku on Managed Agents (self-hosted)
+
+First-cut, copy-pasteable drafts of the artifacts in the
+[migration plan](managed_agents.md) (its "Artifacts to build" section).
+**Status: partially superseded.** The component landed in
+[`haku/runtime/managed_agent/`](../runtime/managed_agent/README.md) using an
+**ant-all-the-way** approach (no `anthropic` Python SDK — see that README for
+why). The control-plane YAML (§§1–3) and the vault wiring (§3) carry over; the
+SDK worker (§4) is replaced by `ant beta:worker poll`, and the Python supervisor
+(§5) is **deferred** in favor of a scheduled deployment (`haku.deployment.yaml`).
+Field names flagged for verification are not fully pinned in the skill docs —
+confirm against `ant <cmd> --help` before relying on them.
+
+Naming below assumes: base manual baked into the worker image at `/opt/haku`
+(the PLAN's image model — base ships by image rebuild, reconciliation is against
+the image's pinned version); `haku-state` cloned at runtime to
+`/workspace/haku-state`; agent working dir `/workspace`.
+
+## 1. Environment (`haku.environment.yaml`)
+
+```yaml
+name: haku-selfhosted
+config:
+  type: self_hosted
+```
+
+```sh
+ENV_ID=$(ant beta:environments create < haku.environment.yaml --transform id -r)
+# Generate the environment key in Console (Environments → this env → "Generate
+# environment key"); it is the worker's only Anthropic credential.
+```
+
+## 2. Agent (`haku.agent.yaml`)
+
+Thin `system` (a pointer to the baked manual — behavior stays single-sourced in
+`haku/base/`); the full toolset auto-allowed (the Pod is the trust boundary); one
+`mcp_toolset` for `tana-mcp-ro` to start.
+
+```yaml
+name: haku
+model: claude-opus-4-8
+system: |
+  You are Haku, the operator's tireless background executive assistant. The
+  worker has bootstrapped your home: your operating manual is baked at
+  /opt/haku/base/instructions.md and your run procedure at /opt/haku/run.md;
+  your haku-state checkout (your only memory and write surface) is at
+  /workspace/haku-state, with ~/.kube/config and git auth already in place.
+  Read the manual and the run procedure, then execute the run procedure end to
+  end. Each user message is a wake: do one scan pass, commit and push your
+  state, then stop and wait for the next wake.
+tools:
+  - type: agent_toolset_20260401
+    default_config:
+      enabled: true
+      permission_policy:
+        type: always_allow
+  - type: mcp_toolset
+    mcp_server_name: tana-ro
+mcp_servers:
+  - type: url
+    name: tana-ro
+    url: https://tana-mcp-ro.allegedly.works/mcp
+```
+
+```sh
+AGENT_ID=$(ant beta:agents create < haku.agent.yaml --transform id -r)
+# Iterate later with: ant beta:agents update --agent-id "$AGENT_ID" --version N < haku.agent.yaml
+```
+
+## 3. Vault + the `tana-mcp-ro` credential
+
+One vault holds MCP creds; `tana-mcp-ro` is gated by the static bearer Haku
+already has reflected into `haku-sandbox` (`haku-tana-ro-token`). The token is
+piped via stdin (never on argv).
+
+```sh
+VAULT_ID=$(ant beta:vaults create --name haku-mcp --transform id -r)
+
+TANA_TOKEN=$(kubectl -n haku-sandbox get secret haku-tana-ro-token \
+  -o jsonpath='{.data.token}' | base64 -d)
+
+# static_bearer credential keyed by the MCP server URL. (verify: exact field
+# names — the skill documents mcp_oauth in full but only names static_bearer.)
+ant beta:vaults:credentials create --vault-id "$VAULT_ID" <<YAML
+display_name: tana-mcp-ro (read-only)
+auth:
+  type: static_bearer
+  mcp_server_url: https://tana-mcp-ro.allegedly.works/mcp
+  token: ${TANA_TOKEN}
+YAML
+```
+
+The vault is attached per session via `vault_ids` (see the supervisor). Upgrading
+`tana-mcp-ro` to its Authentik OIDC mode later swaps this for an `mcp_oauth`
+credential (auto-refresh), which is what the <../TODO.md> Tana entry wants.
+
+## 4. Worker image
+
+Image contents (becomes a Bazel `oci_image` per
+<../../cluster/docs/container-images.md>; shown as a Dockerfile for clarity):
+
+```dockerfile
+# Runs in haku-sandbox as non-root, behind haku-mitmproxy egress.
+FROM python:3.13-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      git curl ca-certificates postgresql-client bash \
+ && rm -rf /var/lib/apt/lists/*
+# kubectl + fastmcp (fastmcp is in the agent-haku Nix closure today; pin both)
+COPY --from=bitnami/kubectl:latest /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/kubectl
+RUN pip install --no-cache-dir anthropic fastmcp
+# Baked base (PLAN image model) + the kubeconfig helper + the worker.
+COPY haku/base /opt/haku/base
+COPY haku/run.md /opt/haku/run.md
+COPY devinfra/k8s/kubeconfig.py /opt/haku/kubeconfig.py
+COPY haku/managed_agents/entrypoint.sh /opt/haku/entrypoint.sh
+COPY haku/managed_agents/worker.py /opt/haku/worker.py
+USER 1000
+WORKDIR /workspace
+ENTRYPOINT ["/opt/haku/entrypoint.sh"]
+```
+
+`entrypoint.sh` — the same bootstrap steps as
+`haku/runtime/claude_web_env/bootstrap.sh`, retargeted to `/workspace` (factor the shared
+logic into one script when this lands):
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+state_dir=/workspace/haku-state
+ns=haku-sandbox
+
+# 1. kubeconfig from the haku JWT (K8S_* env set on the Deployment).
+python3 /opt/haku/kubeconfig.py --write "$HOME/.kube/config"
+
+# 2. git auth for the state repo, off any command line.
+u=$(kubectl -n "$ns" get secret haku-state-git-write -o jsonpath='{.data.username}' | base64 -d)
+p=$(kubectl -n "$ns" get secret haku-state-git-write -o jsonpath='{.data.password}' | base64 -d)
+umask 077
+printf 'machine git.allegedly.works login %s password %s\n' "$u" "$p" >"$HOME/.netrc"
+
+# 3. clone or fast-forward state.
+if [ -d "$state_dir/.git" ]; then
+  git -C "$state_dir" pull --ff-only || true
+else
+  git clone https://git.allegedly.works/haku/haku-state.git "$state_dir"
+fi
+git -C "$state_dir" config user.name haku
+git -C "$state_dir" config user.email haku@allegedly.works
+
+exec python3 /opt/haku/worker.py
+```
+
+`worker.py` — the always-on self-hosted worker (the loop runs at Anthropic; this
+just executes tool calls in the Pod):
+
+```python
+import asyncio
+import os
+
+from anthropic import AsyncAnthropic
+from anthropic.lib.environments import EnvironmentWorker
+
+
+async def main() -> None:
+    environment_key = os.environ["ANTHROPIC_ENVIRONMENT_KEY"]
+    environment_id = os.environ["ANTHROPIC_ENVIRONMENT_ID"]
+    async with AsyncAnthropic(auth_token=environment_key) as client:
+        await EnvironmentWorker(
+            client,
+            environment_id=environment_id,
+            environment_key=environment_key,
+            workdir="/workspace",
+        ).run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+## 5. Supervisor (`supervisor.py`)
+
+Owns **exactly one live session**, exposes a wake endpoint (Forgejo webhook +
+manual), runs the schedule, and keeps a lossless event stream so it knows when a
+session died. Skeleton — the load-bearing control flow, not production-hardened:
+
+```python
+import asyncio
+import contextlib
+import os
+
+from anthropic import AsyncAnthropic
+from fastapi import FastAPI
+
+AGENT_ID = os.environ["HAKU_AGENT_ID"]
+ENV_ID = os.environ["HAKU_ENVIRONMENT_ID"]
+VAULT_ID = os.environ["HAKU_VAULT_ID"]
+WAKE = "Wake: do one scan pass per the run procedure, then commit, push, and stop."
+
+client = AsyncAnthropic()  # ANTHROPIC_API_KEY — the control-plane key, worker never sees it
+app = FastAPI()
+_lock = asyncio.Lock()
+_session_id: str | None = None
+
+
+async def _live(session_id: str | None) -> bool:
+    if session_id is None:
+        return False
+    s = await client.beta.sessions.retrieve(session_id)
+    return s.status != "terminated"
+
+
+async def ensure_session() -> str:
+    """Return a live session id, creating one (warm, long-lived) if needed."""
+    global _session_id
+    async with _lock:
+        if not await _live(_session_id):
+            session = await client.beta.sessions.create(
+                agent=AGENT_ID, environment_id=ENV_ID, vault_ids=[VAULT_ID],
+            )
+            _session_id = session.id
+            asyncio.create_task(_consume(session.id))  # tail its stream until terminal
+        return _session_id
+
+
+async def wake(text: str = WAKE) -> None:
+    session_id = await ensure_session()
+    await client.beta.sessions.events.send(
+        session_id=session_id,
+        events=[{"type": "user.message", "content": [{"type": "text", "text": text}]}],
+    )
+
+
+async def _consume(session_id: str) -> None:
+    """Lossless tail: history first (dedupe), then live stream; mark dead on terminal."""
+    global _session_id
+    seen: set[str] = set()
+    async with client.beta.sessions.events.stream(session_id=session_id) as stream:
+        async for event in client.beta.sessions.events.list(session_id=session_id):
+            seen.add(event.id)
+        async for event in stream:
+            if event.id not in seen:
+                seen.add(event.id)
+                # TODO: optionally mirror transcript to haku-traces here.
+            if event.type == "session.status_terminated":
+                break
+            if event.type == "session.status_idle" and event.stop_reason.type != "requires_action":
+                # idle-and-done — keep the session warm for the next wake; don't break the stream
+                continue
+    if _session_id == session_id:
+        _session_id = None  # next wake recreates; haku-state carries memory forward
+
+
+@app.post("/wake")
+async def http_wake() -> dict[str, str]:
+    # Forgejo push webhook + manual trigger land here. (Add HMAC verification.)
+    await wake()
+    return {"status": "woken"}
+
+
+async def _scheduler(period_s: float = 3600.0) -> None:
+    while True:
+        await asyncio.sleep(period_s)
+        await wake()
+
+
+@app.on_event("startup")
+async def _startup() -> None:
+    app.state.scheduler = asyncio.create_task(_scheduler())
+
+
+@app.on_event("shutdown")
+async def _shutdown() -> None:
+    app.state.scheduler.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await app.state.scheduler
+```
+
+Notes: a real version needs SSE reconnect-on-drop (re-run the history+stream
+overlap), the post-idle status-write race guard before any cleanup, and webhook
+HMAC verification — all documented patterns. The idle handler deliberately
+**keeps the stream open** so the session stays warm; it only drops `_session_id`
+on a true terminal so the next wake recreates and re-orients from `haku-state`.
+
+## 6. k8s wiring (`cluster/k8s/haku/`)
+
+Two Deployments in `haku-sandbox`, secrets split by trust:
+
+- **`haku-worker`** — the worker image; mounts only `ANTHROPIC_ENVIRONMENT_KEY`
+  (+ `ANTHROPIC_ENVIRONMENT_ID`) and the `K8S_*` env the existing profile uses to
+  materialize the haku JWT kubeconfig. Non-root, behind `haku-mitmproxy`, scoped
+  RBAC + quota — unchanged perimeter.
+- **`haku-supervisor`** — the supervisor; mounts the org-scoped
+  `ANTHROPIC_API_KEY` (**kept off the worker host** so agent tool calls can't read
+  it) and `HAKU_{AGENT,ENVIRONMENT,VAULT}_ID`. Exposes `/wake`; a Forgejo webhook
+  on `haku-state` and a manual button both POST it.
+
+Worker Deployment, abbreviated:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: haku-worker
+  namespace: haku-sandbox
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: haku-worker } }
+  template:
+    metadata: { labels: { app: haku-worker } }
+    spec:
+      serviceAccountName: haku
+      securityContext: { runAsNonRoot: true, runAsUser: 1000 }
+      containers:
+        - name: worker
+          image: ghcr.io/agentydragon/haku-worker # Flux image automation pins the tag
+          env:
+            - { name: K8S_JWT_SOPS_PATH, value: secrets/haku-k8s-jwt.yaml }
+            - { name: K8S_USER, value: haku }
+            - { name: K8S_NAMESPACE, value: haku-sandbox }
+            - name: ANTHROPIC_ENVIRONMENT_KEY
+              valueFrom: { secretKeyRef: { name: haku-anthropic-env-key, key: key } }
+            - name: ANTHROPIC_ENVIRONMENT_ID
+              valueFrom: { secretKeyRef: { name: haku-anthropic-env-key, key: environment_id } }
+```
+
+## Wire-up order
+
+1. `ant beta:environments create` → `ENV_ID`; generate the environment key.
+2. `ant beta:vaults create` + the `tana-mcp-ro` credential → `VAULT_ID`.
+3. `ant beta:agents create` → `AGENT_ID`.
+4. Build + push the worker image; deploy `haku-worker` (env key + `ENV_ID`).
+5. Deploy `haku-supervisor` (API key + the three IDs); point a Forgejo webhook at
+   `/wake`.
+6. `POST /wake` once by hand → watch the session live in Console
+   (`platform.claude.com/workspaces/default/sessions`).

--- a/haku/plans/runtime_c_artifacts.md
+++ b/haku/plans/runtime_c_artifacts.md
@@ -1,0 +1,246 @@
+# Artifact drafts: Haku on a provider-agnostic loop (Runtime C)
+
+Status: **sketches**, not landed code. Companion to
+[runtime_options.md](runtime_options.md) (Runtime C); pairs with
+[managed_agents_artifacts.md](managed_agents_artifacts.md) (Runtime B) so both
+runtimes are equally concrete before choosing. Framework shown: **Pydantic AI**
+on the in-cluster **LiteLLM**. Graduates into a real `haku/runtime/agent/` component once
+chosen. Kwarg/import names marked _(verify)_ move between Pydantic AI 1.x
+releases — pin a version and check.
+
+**Shape vs Runtime B:** there is no Anthropic-run loop and no separate worker —
+the agent loop runs in **your** process, so B's "worker + supervisor + session"
+collapse into **one** in-cluster service. MCP auth is in-process (pass the bearer
+header straight to the client; no vault, no public-facade requirement — the
+in-cluster loop can reach in-cluster MCP servers directly). The model goes
+through LiteLLM, so the provider is a config knob and only LiteLLM holds provider
+keys.
+
+## 1. The agent (`haku_agent.py`)
+
+```python
+import asyncio
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+import httpx
+from pydantic_ai import Agent, RunContext
+from pydantic_ai.mcp import MCPServerStreamableHTTP
+from pydantic_ai.models.fallback import FallbackModel
+from pydantic_ai.models.openai import OpenAIModel        # (verify import path across 1.x)
+from pydantic_ai.providers.openai import OpenAIProvider
+
+
+# Model layer: route through in-cluster LiteLLM (OpenAI-compatible /v1). The model
+# string is whatever LiteLLM registers (an alias or "provider/model"); swapping it
+# picks the provider. Only LiteLLM holds Anthropic/OpenAI/Z.AI keys.
+def litellm_model(name: str) -> OpenAIModel:
+    return OpenAIModel(
+        name,
+        provider=OpenAIProvider(
+            base_url="http://litellm.litellm.svc.cluster.local/v1",  # (verify Service)
+            api_key=os.environ["LITELLM_API_KEY"],                   # Haku's scoped virtual key
+        ),
+    )
+
+
+model = FallbackModel(
+    litellm_model("anthropic/claude-opus-4-8"),
+    litellm_model("zai/glm-4.6"),
+)
+
+
+@dataclass
+class Deps:
+    state_repo: Path
+    http: httpx.AsyncClient
+
+
+tana = MCPServerStreamableHTTP(
+    "https://tana-mcp-ro.allegedly.works/mcp",            # or the in-cluster Service
+    headers={"Authorization": f"Bearer {os.environ['TANA_RO_TOKEN']}"},
+)
+
+haku = Agent(
+    model,
+    deps_type=Deps,
+    toolsets=[tana],            # (verify: toolsets= vs mcp_servers= for your version)
+    instrument=True,            # native OTel → Langfuse (configure OTLP exporter via env)
+    system_prompt=(
+        "You are Haku, the operator's background executive assistant. Your manual "
+        "is at /opt/haku/base/instructions.md and your run procedure at "
+        "/opt/haku/run.md; your haku-state checkout (your only memory and write "
+        "surface) is at /workspace/haku-state, kubeconfig and git auth in place. "
+        "Read the manual and the run procedure, then execute one scan pass."
+    ),
+)
+
+
+@haku.tool
+async def run_command(ctx: RunContext[Deps], command: str) -> str:
+    """Run a shell command (kubectl/psql/git/curl/fastmcp). The Pod is the trust
+    boundary, so commands run unsandboxed; everything reachable is read-only."""
+    proc = await asyncio.create_subprocess_shell(
+        command,
+        cwd=ctx.deps.state_repo,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+    out, _ = await proc.communicate()
+    return out.decode()[-20000:]    # tail, to keep tool results bounded
+```
+
+`bash` + the Tana MCP toolset cover Haku's surface today; add more MCP toolsets
+(grocy, postscanmail, google) the same way, or keep reaching them via `bash`/curl
+as now. Note this is the C advantage over B: no vault and no public-facade
+requirement — an in-cluster loop can call an in-cluster MCP Service directly.
+
+## 2. The supervisor / wake endpoint (`supervisor.py`)
+
+No session to keep alive or reconnect (the loop is in-process), so "wake" is just
+`agent.run()` under a lock.
+
+```python
+import asyncio
+import contextlib
+from pathlib import Path
+
+import httpx
+from fastapi import FastAPI
+
+from haku_agent import Deps, haku
+
+STATE = Path("/workspace/haku-state")
+app = FastAPI()
+_lock = asyncio.Lock()
+WAKE = "Wake: do one scan pass per the run procedure, then commit, push, and stop."
+
+
+async def wake(text: str = WAKE) -> None:
+    async with _lock:                       # serialize: one scan at a time
+        async with httpx.AsyncClient() as http, haku:   # `async with haku` opens MCP conns (verify)
+            await haku.run(text, deps=Deps(state_repo=STATE, http=http))
+    # haku-state git IS the durable memory — nothing else to persist. To keep a
+    # warm conversation instead, store result.all_messages() and pass it as
+    # message_history= on the next wake.
+
+
+@app.post("/wake")
+async def http_wake() -> dict[str, str]:
+    asyncio.create_task(wake())             # ack fast; run in the background
+    return {"status": "woken"}
+
+
+async def _scheduler(period_s: float = 3600.0) -> None:
+    while True:
+        await asyncio.sleep(period_s)
+        await wake()
+
+
+@app.on_event("startup")
+async def _startup() -> None:
+    app.state.sched = asyncio.create_task(_scheduler())
+
+
+@app.on_event("shutdown")
+async def _shutdown() -> None:
+    app.state.sched.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await app.state.sched
+```
+
+Crash-survivability here is "re-orient from `haku-state` on restart" (cheap, since
+the scan is incremental via bookmarks). If you want true checkpointed resume of an
+in-flight run, that's the point where **Dapr Agents** or a Pydantic AI
+durable-execution integration (DBOS/Temporal) would slot in instead of this
+hand-rolled loop.
+
+## 3. Container + entrypoint
+
+Runtime B's image minus the Anthropic worker: bake base, reuse `bootstrap.sh`
+(kubeconfig + clone state), then run uvicorn.
+
+```dockerfile
+FROM python:3.13-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      git curl ca-certificates postgresql-client bash \
+ && rm -rf /var/lib/apt/lists/*
+COPY --from=bitnami/kubectl:latest /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/kubectl
+RUN pip install --no-cache-dir pydantic-ai fastapi uvicorn httpx fastmcp
+COPY haku/base /opt/haku/base
+COPY haku/run.md /opt/haku/run.md
+COPY devinfra/k8s/kubeconfig.py /opt/haku/kubeconfig.py
+COPY haku/runtime/agent/entrypoint.sh /opt/haku/entrypoint.sh
+COPY haku/runtime/agent/haku_agent.py /opt/haku/haku_agent.py
+COPY haku/runtime/agent/supervisor.py /opt/haku/supervisor.py
+USER 1000
+WORKDIR /workspace
+ENTRYPOINT ["/opt/haku/entrypoint.sh"]
+```
+
+`entrypoint.sh` is the same bootstrap as Runtime B (materialize kubeconfig from
+the JWT, write `~/.netrc`, clone `haku-state` to `/workspace/haku-state`), then:
+
+```bash
+exec uvicorn supervisor:app --host 0.0.0.0 --port 8080
+```
+
+## 4. k8s wiring (`cluster/k8s/haku/`)
+
+A single `haku-agent` Deployment (no worker/supervisor split), in `haku-sandbox`,
+non-root, behind `haku-mitmproxy`, scoped RBAC — same perimeter as today.
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: haku-agent
+  namespace: haku-sandbox
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: haku-agent } }
+  template:
+    metadata: { labels: { app: haku-agent } }
+    spec:
+      serviceAccountName: haku
+      securityContext: { runAsNonRoot: true, runAsUser: 1000 }
+      containers:
+        - name: agent
+          image: ghcr.io/agentydragon/haku-agent # Flux image automation pins the tag
+          env:
+            - { name: K8S_JWT_SOPS_PATH, value: secrets/haku-k8s-jwt.yaml }
+            - { name: K8S_USER, value: haku }
+            - { name: K8S_NAMESPACE, value: haku-sandbox }
+            - name: LITELLM_API_KEY
+              valueFrom: { secretKeyRef: { name: haku-litellm-key, key: key } }
+            - name: TANA_RO_TOKEN
+              valueFrom: { secretKeyRef: { name: haku-tana-ro-token, key: token } }
+            # OTEL_EXPORTER_OTLP_* → Langfuse; provider keys live in LiteLLM, not here.
+```
+
+Plus a `Service` and a Forgejo webhook on `haku-state` → `POST /wake`.
+
+## What's different from Runtime B
+
+- **One process, not three** — no Anthropic loop, no worker, no session supervisor.
+- **MCP auth in-process** — bearer header straight to the client; no vault, no
+  public-facade requirement; in-cluster MCP Services reachable directly.
+- **Provider is a config knob** (LiteLLM); attribution + traces via
+  LiteLLM + Langfuse (the keys never leave LiteLLM).
+- **No Console** — observe in Langfuse.
+- **Crash-resume** = re-orient from `haku-state` (or adopt Dapr/durable-exec for
+  true checkpointing).
+
+## Open questions / verify
+
+- Pydantic AI 1.x specifics: `toolsets=` vs `mcp_servers=`, the MCP lifecycle
+  context manager (`async with haku` vs `run_mcp_servers()`), and the
+  `OpenAIModel`/`OpenAIProvider` import paths. Pin a version.
+- The in-cluster LiteLLM Service DNS, and that Haku's virtual key is registered
+  for the model strings used (`anthropic/...`, `zai/glm-...`).
+- Warm `message_history` (cost: re-send history each wake, mostly cache-read) vs.
+  stateless re-orient (cost: re-read `haku-state` each wake; cheap — git is
+  incremental via bookmarks). Default to stateless; git is the memory.
+- Read-only stays structural (mitmproxy egress + read-only creds + scoped RBAC) —
+  unchanged from today; the loop owning provider keys doesn't widen Haku's reach.

--- a/haku/plans/runtime_options.md
+++ b/haku/plans/runtime_options.md
@@ -1,0 +1,138 @@
+# Haku runtime options: A / B / C
+
+Status: **design / exploring**. Three candidate runtimes for Haku beyond the v0
+Claude Code web home. This is the "which runtime" comparison; the detailed design
+of Runtime B is in [managed_agents.md](managed_agents.md) (+ its
+[artifact drafts](managed_agents_artifacts.md)). Delete or tombstone once the
+runtime is chosen.
+
+## The two layers of lock-in
+
+Lock-in has two independent layers: **who runs the agent loop**, and **which
+model provider you pay**. They're separable, and the second is already solved —
+the in-cluster **LiteLLM** proxy decouples the model layer (one endpoint →
+Anthropic / OpenAI / Z.AI-GLM, with budgets, kill-switch, and Langfuse traces).
+So the runtimes differ mostly in the **loop layer**, and "no provider lock-in"
+means: self-host the loop **and** route models through LiteLLM.
+
+## Runtime A — Claude Code web routine
+
+Anthropic-managed Claude Code in the cloud; **routines** fire on a schedule, a
+GitHub event, or an API call. This is essentially v0-plus-triggers (today Haku is
+a manual web session).
+
+- **Pros:** ~zero ops, the mature Claude Code harness, the Console session view.
+- **Cons:** Anthropic-managed container **only** (no BYOC); full lock-in (loop +
+  infra + model all Anthropic); in-cluster access only via the public
+  `kubeapi.allegedly.works` proxy (as today); subscription/seat billing.
+
+### Runtime A variant — self-hosted Claude Code (Agent SDK)
+
+The **Claude Agent SDK** (`claude-agent-sdk`, formerly `claude-code-sdk`) is a
+client-side driver that subprocess-spawns the `claude` CLI binary: the same
+Claude Code harness as A, but **the loop runs in your process**, so it could run
+in `haku-sandbox` (BYOC) rather than Anthropic's cloud. It is **not** Managed
+Agents (B) — the Agent SDK runs the loop locally around the CLI, whereas B runs
+the loop server-side at Anthropic. The CLI honors `ANTHROPIC_BASE_URL` and
+`ANTHROPIC_AUTH_TOKEN`, so its model leg can point at LiteLLM's Anthropic-format
+passthrough — but the harness stays Anthropic-request-shaped (prompt-caching
+fidelity, beta param shapes, OAuth/subscription auth), so routing to a
+non-Anthropic provider through LiteLLM is lossy and the subscription benefit
+doesn't survive. Net: it collapses to "A's harness in front of LiteLLM →
+Anthropic" — self-hosted infra, same model lock-in — which is why it's a variant
+of A, not a peer of C.
+
+## Runtime B — Anthropic Managed Agents (self-hosted sandbox)
+
+Loop at Anthropic; tools execute in **your** worker in `haku-sandbox`; **vaults**
+handle MCP auth; one long-lived session woken by events; Console session trace.
+Full detail: [managed_agents.md](managed_agents.md).
+
+- **Pros:** hosted loop (nothing to maintain); vaults remove the
+  `client_credentials` MCP-auth spike; BYOC keeps tools/data/egress in-cluster;
+  Console UI.
+- **Cons:** Anthropic **API-rate** billing (the cost gripe); model is
+  effectively Anthropic-only (the harness assumes Anthropic platform surfaces —
+  see below); gives up in-cluster LiteLLM/Langfuse attribution; you run a worker
+  fleet.
+
+## Runtime C — provider-agnostic self-hosted loop
+
+**You own the loop** (an off-the-shelf neutral framework), route models through
+in-cluster LiteLLM → {Anthropic, OpenAI, Z.AI/GLM}, do MCP auth yourself, and
+send traces to your existing Langfuse. This is essentially the PLAN's original
+self-hosted vision (LiteLLM + Langfuse were always in it), with a multi-provider
+framework as the loop instead of Claude Code.
+
+- **Pros:** no provider lock-in (per-call provider choice; cheap GLM coding plans
+  answer the API-rate gripe); restores LiteLLM/Langfuse attribution; fully
+  self-hosted including the loop.
+- **Cons:** you own the loop (tools, context management, retries, MCP plumbing —
+  though the frameworks give most of this); no vaults (MCP auth is yours); no
+  Console (lean on Langfuse).
+
+Framework shortlist, all on the LiteLLM keystone:
+
+- **Pydantic AI** — cleanest fit for this repo (typed Python, FastAPI-native,
+  MCP client, native OTel→Langfuse, DBOS/Temporal durable-exec options).
+- **Dapr Agents** — `DurableAgent` on Dapr Workflows: checkpointed, **crash- and
+  restart-survivable** wakeups; k8s-native. Best if durable wakeups dominate.
+  (Provider wiring for Anthropic/GLM goes via `DaprChatClient`/components —
+  verify.)
+- **LangGraph or Microsoft Agent Framework** — durable, resumable sessions
+  (checkpointer/threads), heavier abstraction.
+
+Concrete drafts (Pydantic AI agent + supervisor + k8s wiring):
+[runtime_c_artifacts.md](runtime_c_artifacts.md).
+
+## What Runtime C gives up — the Anthropic surfaces
+
+The Claude harness isn't a thin `/v1/messages` client; it assumes Anthropic
+platform surfaces a neutral framework (and LiteLLM) don't reimplement:
+server-side tools (web search/fetch/code-execution), the Files API, Batches,
+`count_tokens`, prompt-caching fidelity/portability, subscription/OAuth auth, and
+the beta param shapes (effort, compaction, task budgets, fallbacks). **For Haku
+this barely matters** — its tools are all client-side already (bash + the MCP
+servers), so it never needed Anthropic's server tools, Files, or batches. Prompt
+caching still works on the Anthropic _leg_ (framework → LiteLLM → Anthropic
+honors `cache_control`); it just isn't portable across OpenAI/GLM.
+
+## The subscription paradox
+
+The Max/Pro **subscription** benefit and **provider-agnosticism** are mutually
+exclusive within one runtime: the subscription is Anthropic OAuth + Anthropic
+inference, i.e. itself a form of lock-in. So it's either "cheap via the Max plan,
+Anthropic-locked" (A/B) **or** "provider-agnostic, pay each provider directly,
+incl. cheap GLM" (C). You can run both as separate Haku runtimes; you can't
+collapse them into one.
+
+## Comparison
+
+| Axis                         | A: Claude Code web routine  | B: Managed Agents (self-hosted) | C: provider-agnostic loop                |
+| ---------------------------- | --------------------------- | ------------------------------- | ---------------------------------------- |
+| Runs the loop                | Anthropic                   | Anthropic                       | you (framework)                          |
+| Tools execute                | Anthropic container         | your worker (`haku-sandbox`)    | your process (`haku-sandbox`)            |
+| Model providers              | Anthropic only              | Anthropic only                  | any (LiteLLM: Anthropic/OpenAI/GLM)      |
+| Provider lock-in             | full                        | model-locked                    | none                                     |
+| Billing                      | subscription / seats        | API rates + session runtime     | per-provider (cheap GLM option)          |
+| In-cluster access            | via `kubeapi` proxy         | direct                          | direct                                   |
+| MCP auth                     | native                      | vaults (managed)                | you wire it                              |
+| Triggers                     | routines (sched/GitHub/API) | you wire (webhook → session)    | you wire (webhook → loop)                |
+| Wakeup model                 | new session per routine     | long-lived session + events     | framework persistence / re-init from git |
+| Observability                | Console                     | Console                         | Langfuse (existing)                      |
+| LiteLLM/Langfuse attribution | no                          | no                              | yes                                      |
+| Ops burden                   | ~none                       | run a worker fleet              | run loop + worker                        |
+
+## Recommendation
+
+- **C** if provider-agnosticism and reusing the existing LiteLLM/Langfuse is the
+  priority (it is, per the lock-in concern) — framework = **Pydantic AI**, or
+  **Dapr Agents** if crash-survivable k8s wakeups dominate.
+- **B** if you'd rather not maintain a loop and will accept Anthropic
+  model-lock + API rates in exchange for hosted infra, vaults, and the Console.
+- **A** is the zero-ops / manual stopgap (≈ today plus triggers).
+
+Haku's `haku-state` git memory means the warm "wake session" is an
+**optimization** in every runtime — losing it just re-orients from `haku-state` —
+so C's "re-instantiate per wake" is both cheap and robust, and the choice between
+B and C is really hosted-convenience-with-lock-in vs. self-hosted-and-portable.

--- a/haku/runtime/agent/AGENTS.md
+++ b/haku/runtime/agent/AGENTS.md
@@ -1,0 +1,1 @@
+@README.md

--- a/haku/runtime/agent/BUILD.bazel
+++ b/haku/runtime/agent/BUILD.bazel
@@ -1,0 +1,105 @@
+load("//devinfra/python:defs.bzl", "py_binary", "py_library", "py_test")
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "config",
+    srcs = ["config.py"],
+    deps = [
+        "@pypi//pydantic",
+        "@pypi//pydantic_settings",
+    ],
+)
+
+py_library(
+    name = "bootstrap",
+    srcs = ["bootstrap.py"],
+    deps = [
+        ":config",
+        "@pypi//pygit2",
+    ],
+)
+
+py_library(
+    name = "agent",
+    srcs = ["agent.py"],
+    deps = [
+        ":config",
+        "@pypi//httpx",
+        # agent_framework core's __init__ references the openai/anthropic/claude stub
+        # modules, so all four packages must be present even though we import only
+        # core + openai (see skills/info_gathering/evals/.../agent_framework/BUILD.bazel).
+        "@pypi//agent_framework_anthropic",
+        "@pypi//agent_framework_claude",
+        "@pypi//agent_framework_core",
+        "@pypi//agent_framework_openai",
+        "@pypi//agent_framework_redis",
+    ],
+)
+
+py_library(
+    name = "main",
+    srcs = ["main.py"],
+    deps = [
+        ":agent",
+        ":bootstrap",
+        ":config",
+    ],
+)
+
+py_binary(
+    name = "scan",
+    main_module = "haku.runtime.agent.main",
+    deps = [":main"],
+)
+
+py_library(
+    name = "supervisor",
+    srcs = ["supervisor.py"],
+    deps = [
+        ":agent",
+        ":bootstrap",
+        ":config",
+        "@pypi//agent_framework_anthropic",
+        "@pypi//agent_framework_claude",
+        "@pypi//agent_framework_core",
+        "@pypi//agent_framework_openai",
+        "@pypi//apscheduler",
+        "@pypi//fastapi",
+        "@pypi//uvicorn",
+    ],
+)
+
+py_binary(
+    name = "serve",
+    main_module = "haku.runtime.agent.supervisor",
+    deps = [":supervisor"],
+)
+
+py_test(
+    name = "test_agent",
+    srcs = ["test_agent.py"],
+    deps = [
+        ":agent",
+        ":config",
+        "//:conftest",
+        # agent_framework's stub __init__ chains into the openai/anthropic/claude stubs,
+        # so mypy needs all four present to resolve `from agent_framework import ...`.
+        "@pypi//agent_framework_anthropic",
+        "@pypi//agent_framework_claude",
+        "@pypi//agent_framework_core",
+        "@pypi//agent_framework_openai",
+        "@pypi//pytest_asyncio",  # keep: pytest plugin (auto async mode), not a direct import
+        "@pypi//pytest_bazel",
+    ],
+)
+
+py_test(
+    name = "test_bootstrap",
+    srcs = ["test_bootstrap.py"],
+    deps = [
+        ":bootstrap",
+        "@pypi//pygit2",
+        "@pypi//pytest_bazel",
+    ],
+)

--- a/haku/runtime/agent/CLAUDE.md
+++ b/haku/runtime/agent/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/haku/runtime/agent/PLAN.md
+++ b/haku/runtime/agent/PLAN.md
@@ -1,0 +1,112 @@
+# haku/runtime/agent — deployment plan
+
+Status: the **runtime is feature-complete and green** — agent (`:scan`), supervisor
+(`:serve`, warm session, `/wake`, scheduler), unit tests, Valkey durable history
+(`RedisHistoryProvider`), `SummarizationStrategy` compaction, and startup cloning of
+ducktape and haku-state (`bootstrap.py`). What remains is **deployment**: the loop/tools
+split below, the two images, and the operator-owned k8s perimeter. Some steps are blocked
+in the Claude-web sandbox (apt and Go-SDK 403) and must run on CI / a full-network
+machine.
+
+## Execution model: loop and tools containers (`pods/exec`)
+
+One Pod in `haku-sandbox`, two containers sharing an `emptyDir` at `/workspace`:
+
+- **loop** — the `:serve` image: MAF agent and supervisor (`/wake`, scheduler). Lean,
+  like `haku/console` (debian-slim, Python, pygit2, **no apt**). Clones ducktape and
+  haku-state (pygit2, `bootstrap.py`) onto `/workspace`. `run_command` execs into the
+  tools container. **Buildable in this sandbox** (no apt — a `rules_py` `oci_image` like
+  the console).
+- **tools** — sidecar: the `trixie_haku_agent` apt image (git, curl, ca-certificates,
+  postgresql-client), a kubectl static binary, and the `fastmcp` CLI, kept alive with
+  `sleep infinity`. Mounts the same `/workspace`; its shell `git` / `kubectl` / `psql` /
+  `fastmcp` operate on the checkout. **CI-only build** (apt 403 in this sandbox).
+
+`run_command(cmd)` execs `sh -lc <cmd>` (cwd = the haku-state checkout) in the tools
+container of its own Pod via the k8s `pods/exec` API: the sync `kubernetes` client's
+`stream(connect_get_namespaced_pod_exec, …, STDOUT_CHANNEL / STDERR_CHANNEL)` wrapped in
+`asyncio.to_thread` (the `cluster/network_readiness.py` pattern), capturing
+stdout+stderr, tail-capped. Own Pod name via the downward API (`HAKU_POD_NAME`),
+container `tools`.
+
+### Auth / RBAC — mostly already exists
+
+Haku already has a k8s identity: the `haku-k8s` machine principal maps to group `haku`,
+which holds a **full-CRUD `haku-sandbox` Role** plus cluster-diagnostics read (see
+`cluster/k8s/agents/claude-rbac`). The sandbox Role pattern includes `pods/exec` and
+`pods/attach` (verify the `haku-sandbox` Role lists it), so exec into the sidecar (same
+namespace) is **already within Haku's perimeter — no new RBAC**. The loop authenticates
+with the `haku-k8s` JWT, building its kubeconfig via `devinfra/k8s/kubeconfig.py` (the
+mechanism the console/web session already uses), targeting `kubeapi.allegedly.works`.
+
+### Shared state and creds
+
+`/workspace` (`emptyDir`) holds the ducktape and haku-state checkouts, mounted in both
+containers. `bootstrap.py` (loop) clones onto it via pygit2. The `~/.netrc` it writes
+must land where the tools container's shell `git` reads it, so write `/workspace/.netrc`
+and set `HOME=/workspace` (or `GIT_CONFIG`) on the tools container — a small
+`bootstrap.py` tweak from the current `~/.netrc`.
+
+## Images
+
+- **loop** (`//haku/runtime/agent:image`, **buildable here**): a `rules_py` `oci_image` on
+  `@debian_*_slim`, like `haku/console` — the `:serve` `py_image_layer`, no apt, no baked
+  manual (cloned at startup); entrypoint runs `:serve`.
+- **tools** (CI-only): the apt manifest is written (<trixie_haku_agent.yaml>); its lock
+  and image build where apt resolves. An `apt.install` whose `.lock.json` is missing
+  breaks MODULE.bazel eval, so this is not committed yet.
+
+Turnkey tools-image wiring where apt resolves — add to MODULE.bazel's `apt` extension
+(and the name to `use_repo(apt, …)`):
+
+```
+apt.install(
+    name = "trixie_haku_agent",
+    lock = "//haku/runtime/agent:trixie_haku_agent.lock.json",
+    manifest = "//haku/runtime/agent:trixie_haku_agent.yaml",
+)
+```
+
+Then `bazel run @trixie_haku_agent//:lock`, add an `oci_image` modeled on
+`finance/beancount_export` (base `@debian_trixie_slim_linux_amd64`, the
+`"@trixie_haku_agent//:flat"` apt layer, a kubectl static binary, fastmcp; command `sleep
+infinity`), and `bbr build` then GHCR push plus Flux.
+
+## k8s wiring (`cluster/k8s/haku/runtime/agent/`) — operator-owned
+
+- **Deployment** `haku-agent` in `haku-sandbox`: two containers (loop, tools) sharing an
+  `emptyDir` at `/workspace`, non-root, behind `haku-mitmproxy`.
+- **haku-k8s kubeconfig** mounted in the loop (the existing JWT secret) so `run_command`
+  can exec — reuses the existing `haku` RBAC.
+- **Valkey** with **AOF (`appendonly yes`, `everysec`) on a PVC** for durable history;
+  `HAKU_REDIS_URL` points at its Service. (Or reuse an existing durable Valkey.)
+- **Secrets**: `HAKU_REDIS_URL`, the LiteLLM virtual key, `haku-state-git-write`, the
+  `haku-k8s` JWT, each source's MCP token.
+- **Trigger**: Forgejo webhook on `haku-state` to `POST /wake` (plus optional
+  `HAKU_WAKE_INTERVAL_SECONDS` tick).
+
+### Open decisions (yours)
+
+1. **Exec auth path**: the `haku-k8s` JWT via the `kubeapi` proxy (reuses existing wiring)
+   vs. an in-cluster ServiceAccount bound to the `haku` perimeter (no public hop, new RBAC
+   subjecting).
+2. **Egress**: the existing `haku-sandbox` mitmproxy policy, or additions for what the
+   tools container reaches.
+3. **Model**: `HAKU_MODEL` and the virtual-key budget (summarization can use a cheaper
+   `HAKU_SUMMARIZE_MODEL`).
+4. **Valkey**: dedicated vs. reuse; AOF; PVC size.
+
+## Code changes for the split (from today's in-process `run_command`)
+
+- `agent.py`: `run_command` becomes a k8s `pods/exec` into the tools container (sync exec
+  in `asyncio.to_thread`, output cap as today).
+- `config.py`: `HAKU_POD_NAME`, tools container name, namespace, kubeconfig path, netrc
+  path.
+- `bootstrap.py`: write `~/.netrc` onto the shared `/workspace`.
+- `BUILD.bazel`: the loop `oci_image` (buildable here) now; the tools image on CI.
+
+## Blocked in this sandbox (need CI / a full-network machine)
+
+- The tools image apt layer — debian repos (snapshot.debian.org) 403.
+- `bazel run //devinfra:gazelle_python_manifest.update` — Go SDK (go.dev) 403; the Redis
+  lockfile add needs this run elsewhere, else the manifest-sync CI test may go red.

--- a/haku/runtime/agent/README.md
+++ b/haku/runtime/agent/README.md
@@ -1,0 +1,46 @@
+# haku/runtime/agent — Haku's Agent Framework runtime
+
+Runtime C from <../../plans/runtime_options.md>: a provider-agnostic, self-hosted agent
+loop for Haku, built on **Microsoft Agent Framework**. Separate component from
+`haku/console/` (the dashboard) — different image, dependencies, and git write
+identity.
+
+- **Model** via the in-cluster **LiteLLM** proxy (OpenAI-compatible), so the provider
+  (Anthropic / OpenAI / Z.AI-GLM) is a LiteLLM config knob (`HAKU_MODEL`), not code.
+  Only LiteLLM holds provider keys.
+- **Tools**: a `run_command` shell tool (the Pod is the trust boundary — see
+  <../../PLAN.md>) plus remote MCP toolsets (Tana to start). Bearer auth rides a
+  pre-built `http_client` because `MCPStreamableHTTPTool` ignores `headers=`.
+- **Behavior** is `haku/base/` + `haku/run.md` from the **ducktape clone** (the agent
+  clones ducktape + haku-state at startup via pygit2; see `bootstrap.py`), read at
+  runtime — so it stays single-sourced and live-editable, no image rebuild to change it.
+- **Persistent threads + compaction**: history persists across restarts in
+  **Valkey/Redis** via `RedisHistoryProvider` (keyed by `HAKU_SESSION_ID`) when
+  `HAKU_REDIS_URL` is set — otherwise in-memory. `SummarizationStrategy` keeps the
+  instruction prefix and, once history fills (`HAKU_SUMMARIZE_TARGET_COUNT` +
+  `HAKU_SUMMARIZE_THRESHOLD` groups), LLM-summarizes the oldest turns into a running
+  summary (using `HAKU_SUMMARIZE_MODEL` if set, else `HAKU_MODEL`) rather than dropping
+  them; `HAKU_REDIS_MAX_MESSAGES` bounds the stored list.
+  git (`haku-state`) remains the durable memory, so a lost cache just re-orients.
+  (`agent-framework-redis` is pinned to `1.0.0b260402`, the newest beta whose core floor
+  keeps `agent-framework-core` at 1.0.0.)
+
+`main.py` (`:scan`) runs one scan — manual or scheduled. `supervisor.py` (`:serve`) is
+the long-lived service: it holds one warm `AgentSession` (so the manual + run procedure
+aren't re-read each wake), exposes `POST /wake` + `GET /healthz`, and self-wakes every
+`HAKU_WAKE_INTERVAL_SECONDS` (0 disables). The `oci_image` and k8s wiring are the
+remaining increments.
+
+## Build / run
+
+```bash
+bbr build //haku/runtime/agent:scan
+```
+
+Config is `HAKU_*` env (see `config.py`): `HAKU_MODEL`, `HAKU_LITELLM_BASE_URL`,
+`HAKU_LITELLM_API_KEY`, the clone config (`HAKU_DUCKTAPE_REPO_URL`,
+`HAKU_STATE_REPO_URL`, `HAKU_GIT_HOST` / `HAKU_GIT_USERNAME` / `HAKU_GIT_PASSWORD`), and
+optional `HAKU_REDIS_URL`, `HAKU_TANA_RO_TOKEN`, `HAKU_SESSION_ID`,
+`HAKU_WAKE_INTERVAL_SECONDS`.
+
+Design + tradeoffs vs. the other runtimes: <../../plans/runtime_options.md>.

--- a/haku/runtime/agent/agent.py
+++ b/haku/runtime/agent/agent.py
@@ -1,0 +1,161 @@
+"""Assemble Haku's Microsoft Agent Framework agent and run one scan pass.
+
+Runtime C (see <../../plans/runtime_options.md>): the agent loop runs here, in-process
+and provider-agnostic. Model calls go through the in-cluster LiteLLM proxy
+(OpenAI-compatible), so the provider (Anthropic / OpenAI / Z.AI-GLM) is a LiteLLM
+config knob (`HAKU_MODEL`), not code. Tools are a `run_command` shell tool (the Pod
+is the trust boundary — see <../../PLAN.md>) plus remote MCP toolsets (Tana to start).
+Behavior is `haku/base/` + `haku/run.md` from the ducktape clone (bootstrap.py clones it
+at startup), read at runtime, so it stays single-sourced and live-editable. Session
+history persists in Valkey/Redis
+(`RedisHistoryProvider`) when `HAKU_REDIS_URL` is set, else in-memory;
+`SummarizationStrategy` keeps the instruction prefix and, once history fills,
+LLM-summarizes the oldest turns into a running summary rather than dropping them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from pathlib import Path
+
+import httpx
+from agent_framework import (
+    Agent,
+    AgentSession,
+    FunctionInvocationConfiguration,
+    FunctionTool,
+    InMemoryHistoryProvider,
+    MCPStreamableHTTPTool,
+    SummarizationStrategy,
+)
+from agent_framework.openai import OpenAIChatCompletionClient
+from agent_framework_redis import RedisHistoryProvider
+
+from haku.runtime.agent.config import Settings
+
+# Tail tool output so a chatty command can't blow the context window.
+_MAX_TOOL_OUTPUT = 20_000
+
+WAKE = "Wake: execute one scan pass per the run procedure, then commit, push, and stop."
+
+
+async def _run_command(command: str, *, cwd: Path) -> str:
+    proc = await asyncio.create_subprocess_shell(
+        command, cwd=cwd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT
+    )
+    out, _ = await proc.communicate()
+    return out.decode(errors="replace")[-_MAX_TOOL_OUTPUT:]
+
+
+def _run_command_tool(settings: Settings) -> FunctionTool:
+    async def run_command(command: str) -> str:
+        return await _run_command(command, cwd=settings.state_dir)
+
+    return FunctionTool(
+        name="run_command",
+        description=(
+            "Run a shell command (kubectl, psql, git, curl, fastmcp, …) from the haku-state "
+            "checkout. The Pod is the trust boundary (mitmproxy egress + read-only creds + scoped "
+            "RBAC), so everything reachable is read-only except haku-state. Returns combined "
+            "stdout+stderr, tail-truncated."
+        ),
+        func=run_command,
+    )
+
+
+def _instructions(settings: Settings) -> str:
+    return (
+        "You are Haku, the operator's tireless background executive assistant. The ducktape repo "
+        f"is checked out at {settings.ducktape_dir}: your operating manual is at "
+        f"{settings.ducktape_dir}/haku/base/instructions.md and your run procedure at "
+        f"{settings.ducktape_dir}/haku/run.md. Your haku-state checkout — your only memory and "
+        f"write surface — is at {settings.state_dir}, with git auth already in place. Read the "
+        "manual and the run procedure with your tools, then execute the run procedure end to end: "
+        "orient, process intake, scan your sources, write and curate items, append to the log, "
+        "then commit and push. Each user message is a wake."
+    )
+
+
+def build_mcp_tools(settings: Settings) -> list[MCPStreamableHTTPTool]:
+    tools: list[MCPStreamableHTTPTool] = []
+    if settings.tana_ro_token:
+        # Bearer auth rides a pre-built http_client; the `headers=` kwarg is ignored in
+        # later releases. Verify http_client against the pinned 1.0.0 before wiring Tana
+        # for real — in-repo MCPStreamableHTTPTool usage so far is name+url only.
+        tools.append(
+            MCPStreamableHTTPTool(
+                name="tana_ro",
+                url="https://tana-mcp-ro.allegedly.works/mcp",
+                http_client=httpx.AsyncClient(
+                    headers={"Authorization": f"Bearer {settings.tana_ro_token}"}, follow_redirects=True
+                ),
+            )
+        )
+    return tools
+
+
+def build_client(settings: Settings, *, model: str | None = None) -> OpenAIChatCompletionClient:
+    return OpenAIChatCompletionClient(
+        model=model or settings.model,
+        api_key=settings.litellm_api_key,
+        base_url=settings.litellm_base_url,
+        # Surface tool errors back to the model (it reads and retries) rather than aborting; raise
+        # the inner roundtrip cap well past any realistic scan burst.
+        function_invocation_configuration=FunctionInvocationConfiguration(
+            include_detailed_errors=True, max_iterations=1000
+        ),
+    )
+
+
+def build_history_provider(settings: Settings) -> InMemoryHistoryProvider | RedisHistoryProvider:
+    """Durable session history in Valkey/Redis when HAKU_REDIS_URL is set, else in-memory.
+
+    The same session id keys the same Redis list, so history survives pod restarts; git
+    (haku-state) remains the durable memory regardless."""
+    if settings.redis_url:
+        return RedisHistoryProvider(redis_url=settings.redis_url, max_messages=settings.redis_max_messages)
+    return InMemoryHistoryProvider()
+
+
+async def aclose_history(history: InMemoryHistoryProvider | RedisHistoryProvider) -> None:
+    """Release the Redis connection; in-memory history needs no teardown."""
+    if isinstance(history, RedisHistoryProvider):
+        await history.aclose()
+
+
+def build_agent(
+    settings: Settings, mcp_tools: list[MCPStreamableHTTPTool], history: InMemoryHistoryProvider | RedisHistoryProvider
+) -> Agent:
+    client = build_client(settings)
+    # Summarize with a cheaper model when HAKU_SUMMARIZE_MODEL is set, else reuse the client.
+    summarizer = build_client(settings, model=settings.summarize_model) if settings.summarize_model else client
+    tools: list[FunctionTool | MCPStreamableHTTPTool] = [_run_command_tool(settings), *mcp_tools]
+    return Agent(
+        client=client,
+        name="haku",
+        instructions=_instructions(settings),
+        tools=tools,
+        context_providers=[history],
+        # Keep the (cached) instruction prefix, append turns, and once history grows past
+        # target+threshold groups, LLM-summarize the oldest into a running summary and
+        # continue — rather than hard-dropping old turns.
+        compaction_strategy=SummarizationStrategy(
+            client=summarizer, target_count=settings.summarize_target_count, threshold=settings.summarize_threshold
+        ),
+    )
+
+
+async def run_scan(settings: Settings, *, message: str = WAKE) -> str:
+    """Run one scan pass, resuming the persisted thread for `settings.session_id`."""
+    mcp_tools = build_mcp_tools(settings)
+    history = build_history_provider(settings)
+    try:
+        async with contextlib.AsyncExitStack() as stack:
+            for tool in mcp_tools:
+                await stack.enter_async_context(tool)
+            agent = build_agent(settings, mcp_tools, history)
+            response = await agent.run(message, session=AgentSession(session_id=settings.session_id))
+        return response.text or ""
+    finally:
+        await aclose_history(history)

--- a/haku/runtime/agent/bootstrap.py
+++ b/haku/runtime/agent/bootstrap.py
@@ -1,0 +1,59 @@
+"""Startup bootstrap: write git creds, then clone/refresh ducktape (context) and
+haku-state (memory) so the agent has both checked out before its first wake.
+
+Clones via pygit2 (hermetic — no git binary needed, like the console). A `~/.netrc` is
+written from the same creds so the agent's own shell `git` commits/pushes (via
+run_command) authenticate too. `*_repo_url = None` skips that clone (the dir is assumed
+already present, e.g. in tests or a pre-seeded volume).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pygit2
+
+from haku.runtime.agent.config import Settings
+
+logger = logging.getLogger(__name__)
+
+
+def write_netrc(*, host: str, username: str, password: str, path: Path) -> None:
+    path.write_text(f"machine {host}\n  login {username}\n  password {password}\n")
+    path.chmod(0o600)
+
+
+def clone_or_refresh(repo_url: str, dest: Path, *, callbacks: pygit2.RemoteCallbacks, depth: int = 0) -> None:
+    """Clone `repo_url` into `dest`, or fetch + hard-reset an existing clone to origin."""
+    if (dest / ".git").exists():
+        repo = pygit2.Repository(str(dest))
+        branch = repo.head.shorthand
+        repo.remotes["origin"].fetch(callbacks=callbacks)
+        repo.reset(repo.lookup_reference(f"refs/remotes/origin/{branch}").target, pygit2.enums.ResetMode.HARD)
+    else:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        pygit2.clone_repository(repo_url, str(dest), callbacks=callbacks, depth=depth)
+    logger.info("ready: %s", dest)
+
+
+def bootstrap(settings: Settings) -> None:
+    """Clone/refresh ducktape + haku-state and write git creds. Synchronous (libgit2 is
+    blocking); call via `asyncio.to_thread` from async startup."""
+    creds: pygit2.UserPass | None = None
+    if settings.git_username and settings.git_password:
+        creds = pygit2.UserPass(settings.git_username, settings.git_password)
+        if settings.git_host:
+            write_netrc(
+                host=settings.git_host,
+                username=settings.git_username,
+                password=settings.git_password,
+                path=Path.home() / ".netrc",
+            )
+    callbacks = pygit2.RemoteCallbacks(credentials=creds)
+    if settings.ducktape_repo_url:
+        clone_or_refresh(
+            settings.ducktape_repo_url, settings.ducktape_dir, callbacks=callbacks, depth=settings.ducktape_clone_depth
+        )
+    if settings.state_repo_url:
+        clone_or_refresh(settings.state_repo_url, settings.state_dir, callbacks=callbacks)

--- a/haku/runtime/agent/config.py
+++ b/haku/runtime/agent/config.py
@@ -1,0 +1,47 @@
+"""Runtime configuration for Haku's Agent Framework runtime (env: HAKU_*)."""
+
+from pathlib import Path
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Haku AF runtime settings, sourced from HAKU_* environment variables."""
+
+    model_config = SettingsConfigDict(env_prefix="HAKU_", protected_namespaces=())
+
+    model: str = Field(description="LiteLLM model id, e.g. 'anthropic/claude-opus-4-8' or 'zai/glm-4.6'.")
+    litellm_base_url: str = Field(description="In-cluster LiteLLM OpenAI-compatible base URL (ends in /v1).")
+    litellm_api_key: str = Field(description="Haku's scoped LiteLLM virtual key.")
+    tana_ro_token: str | None = Field(default=None, description="Bearer for tana-mcp-ro; omit to run without Tana.")
+    # Repos cloned at startup so the agent has them as context. ducktape holds the
+    # manual/run-procedure/playbooks + the codebase; haku-state is Haku's memory + write
+    # surface. *_repo_url None skips the clone (the dir is assumed already present).
+    ducktape_repo_url: str | None = Field(default=None, description="ducktape git URL to clone for context.")
+    ducktape_dir: Path = Field(default=Path("/workspace/ducktape"), description="ducktape checkout (manual + code).")
+    ducktape_clone_depth: int = Field(default=1, description="Shallow-clone depth for ducktape; 0 = full history.")
+    state_repo_url: str | None = Field(default=None, description="haku-state git URL to clone; None assumes present.")
+    state_dir: Path = Field(default=Path("/workspace/haku-state"), description="haku-state checkout (Haku's memory).")
+    git_host: str | None = Field(default=None, description="Host for the ~/.netrc git-creds entry (haku-state push).")
+    git_username: str | None = Field(default=None, description="Git username for git_host.")
+    git_password: str | None = Field(default=None, description="Git password/token for git_host.")
+    session_id: str = Field(default="haku-main", description="Stable session id; the same id resumes the thread.")
+    summarize_target_count: int = Field(
+        default=20, description="Compaction: message groups to keep after LLM summarization."
+    )
+    summarize_threshold: int = Field(
+        default=10, description="Compaction: summarize once group count exceeds target + this."
+    )
+    summarize_model: str | None = Field(
+        default=None, description="LiteLLM model for SummarizationStrategy; None reuses HAKU_MODEL."
+    )
+    host: str = Field(default="0.0.0.0", description="Supervisor HTTP bind host.")
+    port: int = Field(default=8080, description="Supervisor HTTP bind port.")
+    wake_interval_seconds: int = Field(default=0, description="Scheduler wake interval in seconds; 0 disables it.")
+    redis_url: str | None = Field(
+        default=None, description="Valkey/Redis URL for durable session history; None = in-memory."
+    )
+    redis_max_messages: int = Field(
+        default=500, description="Max messages retained per session in Redis (auto-trims oldest)."
+    )

--- a/haku/runtime/agent/main.py
+++ b/haku/runtime/agent/main.py
@@ -1,0 +1,33 @@
+"""One-shot Haku scan on the persisted thread (resumes by session id).
+
+The event-driven supervisor (a long-lived FastAPI process holding the agent with a
+`/wake` endpoint + scheduler) is the next increment; this binary runs a single scan,
+suitable for a manual trigger or a scheduled job. History persists across runs via
+`FileHistoryProvider` keyed by the stable session id, so each run resumes the warm
+thread rather than re-reading everything cold.
+"""
+
+import asyncio
+import logging
+
+from haku.runtime.agent.agent import run_scan
+from haku.runtime.agent.bootstrap import bootstrap
+from haku.runtime.agent.config import Settings
+
+logger = logging.getLogger(__name__)
+
+
+async def _amain() -> None:
+    settings = Settings()
+    await asyncio.to_thread(bootstrap, settings)
+    text = await run_scan(settings)
+    logger.info("scan complete: %s", text[:1000])
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+    asyncio.run(_amain())
+
+
+if __name__ == "__main__":
+    main()

--- a/haku/runtime/agent/supervisor.py
+++ b/haku/runtime/agent/supervisor.py
@@ -1,0 +1,104 @@
+"""Long-lived Haku supervisor: one warm Agent Framework session, woken by events.
+
+A single in-process `AgentSession` stays warm across wakes for the pod's lifetime, so
+the manual + run procedure the agent reads on the first wake stay in context and aren't
+re-read each wake (the expensive part); `SlidingWindowStrategy` bounds the history. When
+`HAKU_REDIS_URL` is set, session history persists in Valkey keyed by the session id, so
+it survives pod restarts too; otherwise a restart re-orients from haku-state (git is the
+durable memory regardless). Wakes fire from a scheduler tick or `POST /wake`, one at a
+time.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+
+import uvicorn
+from agent_framework import Agent, AgentSession
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.interval import IntervalTrigger
+from fastapi import FastAPI
+
+from haku.runtime.agent.agent import WAKE, aclose_history, build_agent, build_history_provider, build_mcp_tools
+from haku.runtime.agent.bootstrap import bootstrap
+from haku.runtime.agent.config import Settings
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class HakuRuntime:
+    """The warm agent + its single long-lived session, serialized by a one-wake lock."""
+
+    agent: Agent
+    session: AgentSession
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+    async def wake(self, message: str = WAKE) -> str:
+        async with self.lock:
+            logger.info("wake: running one scan pass")
+            response = await self.agent.run(message, session=self.session)
+            text = response.text or ""
+            logger.info("wake complete: %s", text[:500])
+            return text
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    settings = Settings()
+    await asyncio.to_thread(bootstrap, settings)
+    mcp_tools = build_mcp_tools(settings)
+    history = build_history_provider(settings)
+    async with contextlib.AsyncExitStack() as stack:
+        # Open the remote MCP toolsets once, for the app's lifetime, rather than per wake.
+        for tool in mcp_tools:
+            await stack.enter_async_context(tool)
+        runtime = HakuRuntime(
+            agent=build_agent(settings, mcp_tools, history), session=AgentSession(session_id=settings.session_id)
+        )
+        app.state.runtime = runtime
+
+        scheduler = AsyncIOScheduler()
+        if settings.wake_interval_seconds > 0:
+            # coalesce + max_instances=1: never pile up or overlap scheduled wakes.
+            scheduler.add_job(
+                runtime.wake, IntervalTrigger(seconds=settings.wake_interval_seconds), max_instances=1, coalesce=True
+            )
+            scheduler.start()
+            logger.info("scheduler started: wake every %ds", settings.wake_interval_seconds)
+        try:
+            yield
+        finally:
+            if scheduler.running:
+                scheduler.shutdown(wait=False)
+            await aclose_history(history)
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(title="haku-agent", lifespan=lifespan)
+
+    @app.post("/wake")
+    async def wake() -> dict[str, str]:
+        runtime: HakuRuntime = app.state.runtime
+        return {"result": await runtime.wake()}
+
+    @app.get("/healthz")
+    async def healthz() -> dict[str, str]:
+        return {"status": "ok"}
+
+    return app
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+    settings = Settings()
+    uvicorn.run(create_app(), host=settings.host, port=settings.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/haku/runtime/agent/test_agent.py
+++ b/haku/runtime/agent/test_agent.py
@@ -1,0 +1,45 @@
+"""Unit tests for the Haku agent assembly — pure logic, no network or LLM."""
+
+from pathlib import Path
+
+import pytest_bazel
+from agent_framework import InMemoryHistoryProvider
+
+from haku.runtime.agent.agent import _run_command, aclose_history, build_history_provider, build_mcp_tools
+from haku.runtime.agent.config import Settings
+
+
+def _settings(*, tana_ro_token: str | None = None, redis_url: str | None = None) -> Settings:
+    return Settings(
+        model="prov/model",
+        litellm_base_url="http://litellm/v1",
+        litellm_api_key="k",
+        tana_ro_token=tana_ro_token,
+        redis_url=redis_url,
+    )
+
+
+def test_build_mcp_tools_omits_tana_without_token() -> None:
+    assert build_mcp_tools(_settings()) == []
+
+
+def test_build_mcp_tools_includes_tana_with_token() -> None:
+    assert [tool.name for tool in build_mcp_tools(_settings(tana_ro_token="secret"))] == ["tana_ro"]
+
+
+def test_history_provider_in_memory_without_redis_url() -> None:
+    assert isinstance(build_history_provider(_settings()), InMemoryHistoryProvider)
+
+
+async def test_history_provider_redis_with_url() -> None:
+    history = build_history_provider(_settings(redis_url="redis://localhost:6379"))
+    assert not isinstance(history, InMemoryHistoryProvider)
+    await aclose_history(history)
+
+
+async def test_run_command_returns_combined_output(tmp_path: Path) -> None:
+    assert (await _run_command("echo hi", cwd=tmp_path)).strip() == "hi"
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/haku/runtime/agent/test_bootstrap.py
+++ b/haku/runtime/agent/test_bootstrap.py
@@ -1,0 +1,38 @@
+"""Tests for the startup bootstrap (netrc write + pygit2 clone/refresh)."""
+
+from pathlib import Path
+
+import pygit2
+import pytest_bazel
+
+from haku.runtime.agent.bootstrap import clone_or_refresh, write_netrc
+
+
+def test_write_netrc_format_and_mode(tmp_path: Path) -> None:
+    netrc = tmp_path / ".netrc"
+    write_netrc(host="git.example", username="u", password="p", path=netrc)
+    assert netrc.read_text() == "machine git.example\n  login u\n  password p\n"
+    assert (netrc.stat().st_mode & 0o777) == 0o600
+
+
+def test_clone_then_refresh(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    repo = pygit2.init_repository(str(src), initial_head="main")
+    (src / "f.txt").write_text("hello")
+    repo.index.add("f.txt")
+    repo.index.write()
+    sig = pygit2.Signature("t", "t@example")
+    repo.create_commit("refs/heads/main", sig, sig, "init", repo.index.write_tree(), [])
+
+    dest = tmp_path / "dest"
+    callbacks = pygit2.RemoteCallbacks()
+    clone_or_refresh(str(src), dest, callbacks=callbacks)
+    assert (dest / "f.txt").read_text() == "hello"
+
+    # Second call refreshes the existing clone (fetch + hard-reset path), still clean.
+    clone_or_refresh(str(src), dest, callbacks=callbacks)
+    assert (dest / "f.txt").read_text() == "hello"
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/haku/runtime/agent/trixie_haku_agent.yaml
+++ b/haku/runtime/agent/trixie_haku_agent.yaml
@@ -1,0 +1,30 @@
+# Deb packages for the Haku agent (haku/runtime/agent) image, on debian:trixie-slim.
+#
+# Haku's `run_command` shell tool uses these to reach sources and write haku-state:
+#   - git (+ ca-certificates) to clone/commit/push haku-state and hit HTTPS endpoints
+#   - curl for REST APIs (Gmail/Calendar/Drive/PostScanMail)
+#   - postgresql-client (psql) for the Plaid ledger
+# Python + the app come from the rules_py image layers (not apt). The fastmcp MCP-client
+# CLI comes from the `agent-haku` Python devshell output, not apt. kubectl is NOT in
+# trixie main — if the shell route needs `kubectl`, add it from an upstream static
+# binary (cf. loom/gym's docker CLI), not here.
+#
+# Regenerate the lock after any change. NOTE: this needs the apt index over the network,
+# which is 403 in the Claude-web sandbox — run it on CI / a full-network machine:
+#   bazel run @trixie_haku_agent//:lock
+version: 1
+
+sources:
+  - channel: trixie main
+    url: https://snapshot.debian.org/archive/debian/20260301T000000Z
+  - channel: trixie-security main
+    url: https://snapshot.debian.org/archive/debian-security/20260301T000000Z
+
+archs:
+  - "amd64"
+
+packages:
+  - "ca-certificates"
+  - "git"
+  - "curl"
+  - "postgresql-client"

--- a/haku/runtime/managed_agent/AGENTS.md
+++ b/haku/runtime/managed_agent/AGENTS.md
@@ -1,0 +1,1 @@
+@README.md

--- a/haku/runtime/managed_agent/CLAUDE.md
+++ b/haku/runtime/managed_agent/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/haku/runtime/managed_agent/README.md
+++ b/haku/runtime/managed_agent/README.md
@@ -1,0 +1,76 @@
+# haku/runtime/managed_agent — Haku on Anthropic Managed Agents (self-hosted)
+
+Runtime B from <../../plans/runtime_options.md>: Anthropic runs the agent loop;
+tool execution runs in a worker **you** run in `haku-sandbox` (self-hosted
+sandbox, `config.type: self_hosted`). Full design + tradeoffs:
+<../../plans/managed_agents.md> (+ <../../plans/managed_agents_artifacts.md>).
+
+## "ant-all-the-way" — no `anthropic` Python SDK
+
+This component uses **only the `ant` CLI**, no `anthropic` Python SDK. Why: the
+SDK's self-hosted worker (`EnvironmentWorker`) and session APIs need
+`anthropic>=0.103`, but `agent-framework-anthropic` (used by Runtime C and the
+skill/grocy evals) hard-pins `anthropic==0.80.0` in the shared lockfile. The
+`ant` binary carries its own deps, so leaning on it sidesteps the conflict
+entirely — no lockfile bump, no second pip version, Runtime C untouched.
+
+The cost: the **warm-session supervisor is deferred**. The wake trigger is a
+scheduled deployment that fires a fresh session each tick; `haku-state` (git) is
+the durable memory, so a cold session just re-orients. Adding a warm supervisor
+later is the one thing that would reintroduce the SDK-version question.
+
+## Pieces
+
+| File                    | Role                                                             | Runs on       |
+| ----------------------- | ---------------------------------------------------------------- | ------------- |
+| `haku.environment.yaml` | self-hosted environment (`ant beta:environments create`)         | control plane |
+| `haku.agent.yaml`       | agent: thin `system` pointer, fixed toolset + tana `mcp_toolset` | control plane |
+| `haku.deployment.yaml`  | scheduled-deployment wake trigger                                | control plane |
+| `provision.sh`          | one-shot: create environment/agent/vault/deployment via `ant`    | operator / CI |
+| `entrypoint.sh`         | clone ducktape + haku-state, then `ant beta:worker poll`         | `haku-worker` |
+
+## Trust split — keep the org key off the worker
+
+- **Worker pod** (`haku-sandbox`): only `ANTHROPIC_ENVIRONMENT_KEY`
+  (`sk-ant-oat01-…`, one environment's work queue). A prompt-injected tool call
+  can't reach the control plane.
+- **Provisioning** (`provision.sh`, deployment management, `…:work stats`): the
+  org-scoped `ANTHROPIC_API_KEY`, run from CI / the operator laptop — **never**
+  on the worker host.
+
+## Worker image (CI-only build)
+
+A debian image with `bash`, `git`, `kubectl`, `postgresql-client`, `curl`,
+`ca-certificates`, `fastmcp`, and the **`ant` CLI** (Go binary from
+`github.com/anthropics/anthropic-cli/releases`), entrypoint `entrypoint.sh`.
+Built on CI (apt mirrors 403 in the Claude-web sandbox), pushed to GHCR, pinned
+by Flux — the standard <../../../cluster/docs/container-images.md> path. The
+fixed `ant` toolset is `bash/read/write/edit/glob/grep`; Haku reaches Plaid
+(`psql`), Google (`curl`), and the cluster (`kubectl`, in-cluster `haku` SA)
+through `bash`. Tana is a native `mcp_toolset` (Anthropic-side, vault auth).
+
+## k8s wiring — operator-owned (follow-up)
+
+The `haku-worker` Deployment, the `ANTHROPIC_ENVIRONMENT_KEY` secret, and the
+clone/git env live under `cluster/k8s/…/haku/` — see
+<../../plans/managed_agents.md> § "k8s wiring". The worker reuses Haku's existing
+`haku-sandbox` perimeter (`haku` SA + RBAC, `haku-mitmproxy` egress,
+ResourceQuota); none of it relies on agent restraint.
+
+## Bring-up
+
+```sh
+./provision.sh                                   # org ANTHROPIC_API_KEY, outside the worker
+# generate the environment key in the Console -> ANTHROPIC_ENVIRONMENT_KEY secret
+# deploy haku-worker (env key + the HAKU_* clone/git env) in haku-sandbox
+ant beta:deployments run --deployment-id "$DEPL_ID"   # test one run, watch in Console
+```
+
+## Worker env
+
+`ANTHROPIC_ENVIRONMENT_ID`, `ANTHROPIC_ENVIRONMENT_KEY`, `HAKU_DUCKTAPE_REPO_URL`,
+`HAKU_STATE_REPO_URL`, `HAKU_GIT_HOST`, `HAKU_GIT_USERNAME`, `HAKU_GIT_PASSWORD`.
+
+Beta-surface field/flag names (`agent_toolset_20260401`, `vault_ids`, the
+deployment schema) follow the `ant` docs as of 2026-06 — verify with
+`ant <cmd> --help`.

--- a/haku/runtime/managed_agent/entrypoint.sh
+++ b/haku/runtime/managed_agent/entrypoint.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# haku-worker entrypoint (runs in haku-sandbox): clone Haku's home into the agent
+# workdir, then long-poll Anthropic's self-hosted work queue with the fixed `ant`
+# toolset. The pod holds ONLY the environment key (sk-ant-oat01-...), never the
+# org-scoped API key — so a prompt-injected tool call can't reach the control plane.
+set -euo pipefail
+
+workspace=/workspace
+ducktape_dir="$workspace/ducktape"
+state_dir="$workspace/haku-state"
+
+# git auth for the Forgejo host, off any command line.
+umask 077
+printf 'machine %s login %s password %s\n' \
+  "$HAKU_GIT_HOST" "$HAKU_GIT_USERNAME" "$HAKU_GIT_PASSWORD" >"$HOME/.netrc"
+
+clone_or_pull() { # <url> <dest>
+  if [ -d "$2/.git" ]; then
+    git -C "$2" pull --ff-only
+  else
+    git clone --depth 1 "$1" "$2"
+  fi
+}
+
+# Behavior: ducktape's haku/base + haku/run.md, read at runtime (live-editable —
+# no image rebuild to change the manual).
+clone_or_pull "$HAKU_DUCKTAPE_REPO_URL" "$ducktape_dir"
+# Memory + the only write surface.
+clone_or_pull "$HAKU_STATE_REPO_URL" "$state_dir"
+git -C "$state_dir" config user.name haku
+git -C "$state_dir" config user.email haku@allegedly.works
+
+# kubectl uses the pod's haku ServiceAccount token automatically (in-cluster);
+# no kubeconfig to materialize, unlike the Claude Code web home.
+exec ant beta:worker poll \
+  --environment-id "$ANTHROPIC_ENVIRONMENT_ID" \
+  --workdir "$workspace"

--- a/haku/runtime/managed_agent/haku.agent.yaml
+++ b/haku/runtime/managed_agent/haku.agent.yaml
@@ -1,0 +1,33 @@
+# Haku's Managed Agents agent (control plane; version-controlled, applied via
+# `ant beta:agents {create,update}`). The `system` prompt is a thin pointer —
+# behavior stays single-sourced in haku/base + haku/run.md, which the worker
+# clones into the agent workdir at startup (see entrypoint.sh).
+name: haku
+model: claude-opus-4-8
+system: |
+  You are Haku, the operator's tireless background executive assistant. A worker
+  in your haku-sandbox namespace has cloned your home into the agent workdir:
+  your operating manual is at /workspace/ducktape/haku/base/instructions.md and
+  your run procedure at /workspace/ducktape/haku/run.md; your haku-state checkout
+  — your only memory and write surface — is at /workspace/haku-state, with git
+  auth and in-cluster kubectl already in place.
+
+  Read the manual and the run procedure, then execute the run procedure end to
+  end. Each user message is a wake: do one scan pass, commit and push haku-state,
+  then stop and wait for the next wake.
+tools:
+  # Fixed built-in toolset, supplied by the `ant` worker in the pod. The Pod is
+  # the trust boundary (Ember posture), so everything is auto-allowed.
+  - type: agent_toolset_20260401
+    default_config:
+      enabled: true
+      permission_policy:
+        type: always_allow
+  # Tana (read-only) as a native MCP tool; auth is injected at Anthropic's egress
+  # from the vault credential (provision.sh), so the pod never sees the token.
+  - type: mcp_toolset
+    mcp_server_name: tana-ro
+mcp_servers:
+  - type: url
+    name: tana-ro
+    url: https://tana-mcp-ro.allegedly.works/mcp

--- a/haku/runtime/managed_agent/haku.deployment.yaml
+++ b/haku/runtime/managed_agent/haku.deployment.yaml
@@ -1,0 +1,17 @@
+# The wake trigger: a scheduled deployment fires one fresh session per tick.
+# (The warm-session supervisor is a deferred optimization — haku-state is the
+# durable memory, so a cold session just re-orients.) provision.sh injects the
+# resolved --agent / --environment-id / --vault-ids; the static parts live here.
+# Verify flag/field names against `ant beta:deployments create --help`.
+name: haku-scan
+initial_events:
+  - type: user.message
+    content:
+      - type: text
+        text: "Wake: do one scan pass per the run procedure, then commit, push, and stop."
+# Tune the cadence to taste; start sparse and test on demand with
+# `ant beta:deployments run --deployment-id <id>` before trusting the schedule.
+schedule:
+  type: cron
+  expression: "0 */6 * * *"
+  timezone: America/Los_Angeles

--- a/haku/runtime/managed_agent/haku.environment.yaml
+++ b/haku/runtime/managed_agent/haku.environment.yaml
@@ -1,0 +1,8 @@
+# Haku's self-hosted Managed Agents environment. The agent loop runs at
+# Anthropic; tool execution (the fixed bash/read/write/edit/glob/grep set) runs
+# in the haku-worker pod in haku-sandbox. `{type: self_hosted}` is the entire
+# config — egress, hardening, and networking are ours (haku-mitmproxy + CCNP).
+#   ant beta:environments create < haku.environment.yaml
+name: haku-selfhosted
+config:
+  type: self_hosted

--- a/haku/runtime/managed_agent/provision.sh
+++ b/haku/runtime/managed_agent/provision.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Provision Haku's Managed Agents control plane via the `ant` CLI.
+#
+# Run from OUTSIDE the worker host (operator laptop / CI) authenticated with an
+# org-scoped ANTHROPIC_API_KEY (or `ant auth login` profile) — NEVER on the
+# worker pod, which holds only the environment key so agent tool calls can't
+# reach the control plane. First-time create only; iterate later with
+# `ant beta:agents update --agent-id <id> --version <n> < haku.agent.yaml`.
+set -euo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+ENV_ID=$(ant beta:environments create --transform id -r <"$here/haku.environment.yaml")
+echo "environment: $ENV_ID"
+echo "  -> generate its environment key in the Console (Environments -> haku-selfhosted"
+echo "     -> 'Generate environment key') and store it as the ANTHROPIC_ENVIRONMENT_KEY"
+echo "     secret on the haku-worker Deployment (it is never created via the API)."
+
+AGENT_ID=$(ant beta:agents create --transform id -r <"$here/haku.agent.yaml")
+echo "agent: $AGENT_ID"
+
+# Vault for MCP credentials. tana-mcp-ro is gated by the static bearer Haku
+# already has reflected into haku-sandbox (haku-tana-ro-token); pipe it via
+# stdin, never argv. Anthropic injects it at egress; the pod never sees it.
+VAULT_ID=$(ant beta:vaults create --name haku-mcp --transform id -r)
+echo "vault: $VAULT_ID"
+TANA_TOKEN=$(kubectl -n haku-sandbox get secret haku-tana-ro-token -o jsonpath='{.data.token}' | base64 -d)
+ant beta:vaults:credentials create --vault-id "$VAULT_ID" >/dev/null <<YAML
+display_name: tana-mcp-ro (read-only)
+auth:
+  type: static_bearer
+  mcp_server_url: https://tana-mcp-ro.allegedly.works/mcp
+  token: ${TANA_TOKEN}
+YAML
+echo "  -> tana-mcp-ro credential stored in vault $VAULT_ID"
+
+# Scheduled deployment = the wake trigger (one fresh session per fire).
+DEPL_ID=$(ant beta:deployments create \
+  --agent "$AGENT_ID" --environment-id "$ENV_ID" --vault-ids "[$VAULT_ID]" \
+  --transform id -r <"$here/haku.deployment.yaml")
+echo "deployment: $DEPL_ID"
+
+echo
+echo "Record these IDs. Test one run on demand (works even before the schedule):"
+echo "  ant beta:deployments run --deployment-id $DEPL_ID"
+echo "Watch it live in the Console: platform.claude.com/workspaces/default/sessions"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,6 +213,10 @@ dependencies = [
     "agent-framework-openai>=1.0",
     "agent-framework-anthropic>=1.0.0b260402",
     "agent-framework-claude>=1.0.0b260402",
+    # haku/runtime/agent — durable session history (RedisHistoryProvider) over Valkey. Pinned to
+    # the newest agent-framework-redis beta whose core floor is >=1.0.0,<2, so adding it
+    # does NOT bump agent-framework-core off 1.0.0 (b260409+ require core >=1.0.1).
+    "agent-framework-redis==1.0.0b260402",
     "langgraph>=0.2",
     "langchain-mcp-adapters>=0.1",
     "langchain-openai>=0.3",

--- a/requirements_bazel.txt
+++ b/requirements_bazel.txt
@@ -20,9 +20,14 @@ agent-framework-core==1.0.0 \
     #   agent-framework-anthropic
     #   agent-framework-claude
     #   agent-framework-openai
+    #   agent-framework-redis
 agent-framework-openai==1.0.0 \
     --hash=sha256:229179103f43125b30715bda98bc4b3316af3b303d8cd8034a54e3c3f94c28d5 \
     --hash=sha256:57303177a876528442b23825a97f05a20c49440c0ff65e0c2fb447d058babc42
+    # via ducktape (pyproject.toml)
+agent-framework-redis==1.0.0b260402 \
+    --hash=sha256:1e0744fb6c11ba98e57e33c8f33c3e752bf8f4e3dc790b999f1ebc79645835b9 \
+    --hash=sha256:9b842225bceb50186c655a54534e9c68f253bad790792296cd6efd573a42c949
     # via ducktape (pyproject.toml)
 aioboto3==15.5.0 \
     --hash=sha256:cc880c4d6a8481dd7e05da89f41c384dbd841454fc1998ae25ca9c39201437a6 \
@@ -2603,7 +2608,9 @@ jsonpatch==1.33 \
 jsonpath-ng==1.8.0 \
     --hash=sha256:54252968134b5e549ea5b872f1df1168bd7defe1a52fed5a358c194e1943ddc3 \
     --hash=sha256:b8dde192f8af58d646fc031fac9c99fe4d00326afc4148f1f043c601a8cfe138
-    # via inspect-ai
+    # via
+    #   inspect-ai
+    #   redisvl
 jsonpointer==3.0.0 \
     --hash=sha256:13e088adc14fca8b6aa8177c044e12701e6ad4b28ff10e65f2267a90109c9942 \
     --hash=sha256:2b2d729f2091522d61c3b31f82e11870f60b68f43fbc705cb76bf4b832af59ef
@@ -3413,6 +3420,7 @@ ml-dtypes==0.5.4 \
     # via
     #   jax
     #   jaxlib
+    #   redisvl
 mmh3==5.2.1 \
     --hash=sha256:022aa1a528604e6c83d0a7705fdef0b5355d897a9e0fa3a8d26709ceaa06965d \
     --hash=sha256:0634581290e6714c068f4aa24020acf7880927d1f0084fa753d9799ae9610082 \
@@ -3912,6 +3920,7 @@ numpy==2.4.2 \
     --hash=sha256:fd49860271d52127d61197bb50b64f58454e9f578cb4b2c001a6de8b1f50b0b1
     # via
     #   ducktape (pyproject.toml)
+    #   agent-framework-redis
     #   arch
     #   asyncvnc
     #   chromadb
@@ -3930,6 +3939,7 @@ numpy==2.4.2 \
     #   pandas-stubs
     #   patsy
     #   plotnine
+    #   redisvl
     #   scipy
     #   statsmodels
     #   types-networkx
@@ -5285,6 +5295,7 @@ pydantic[email]==2.12.5 \
     #   pydantic-ai-slim
     #   pydantic-graph
     #   pydantic-settings
+    #   redisvl
 pydantic-ai-slim[anthropic, fastmcp, openai]==1.70.0 \
     --hash=sha256:162907092a562b3160d9ef0418d317ec941c5c0e6dd6e0aa0dbb53b5a5cd3450 \
     --hash=sha256:3df0c0e92f72c35e546d24795bce1f4d38f81da2d10addd2e9f255b2d2c83c91
@@ -5732,6 +5743,10 @@ python-socks[asyncio]==2.8.1 \
     --hash=sha256:28232739c4988064e725cdbcd15be194743dd23f1c910f784163365b9d7be035 \
     --hash=sha256:698daa9616d46dddaffe65b87db222f2902177a2d2b2c0b9a9361df607ab3687
     # via aiohttp-socks
+python-ulid==3.1.0 \
+    --hash=sha256:e2cdc979c8c877029b4b7a38a6fba3bc4578e4f109a308419ff4d3ccf0a46619 \
+    --hash=sha256:ff0410a598bc5f6b01b602851a3296ede6f91389f913a5d5f8c496003836f636
+    # via redisvl
 pytimeparse==1.1.8 \
     --hash=sha256:04b7be6cc8bd9f5647a6325444926c3ac34ee6bc7e69da4367ba282f076036bd \
     --hash=sha256:e86136477be924d7e670646a98561957e8ca7308d44841e21f5ddea757556a0a
@@ -5826,6 +5841,7 @@ pyyaml==6.0.3 \
     #   kubernetes-asyncio
     #   langchain-core
     #   pre-commit
+    #   redisvl
     #   uvicorn
 pyzmq==27.1.0 \
     --hash=sha256:01c0e07d558b06a60773744ea6251f769cd79a41a97d11b8bf4ab8f034b0424d \
@@ -5936,6 +5952,16 @@ reaktiv==0.21.3 \
     --hash=sha256:1fd3ec8c8f0ebeaa84b3bd7db7ede84201b0f4c2c882dadca75642d0f158f04f \
     --hash=sha256:c9e12ca28e969ac34909e40f7a60107e3379ba97bb60950883577890b85b1283
     # via ducktape (pyproject.toml)
+redis==7.1.1 \
+    --hash=sha256:a2814b2bda15b39dad11391cc48edac4697214a8a5a4bd10abe936ab4892eb43 \
+    --hash=sha256:f77817f16071c2950492c67d40b771fa493eb3fccc630a424a10976dbb794b7a
+    # via
+    #   agent-framework-redis
+    #   redisvl
+redisvl==0.15.0 \
+    --hash=sha256:0e382e9b6cd8378dfe1515b18f92d125cfba905f6f3c5fe9b8904b3ca840d1ca \
+    --hash=sha256:aff716b9a9c4aef9c81de9a12d9939a0170ff3b3a1fe9d4164e94b131a754290
+    # via agent-framework-redis
 referencing==0.37.0 \
     --hash=sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231 \
     --hash=sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8
@@ -6708,6 +6734,7 @@ tenacity==9.1.4 \
     #   inspect-ai
     #   instructor
     #   langchain-core
+    #   redisvl
 terminado==0.18.1 \
     --hash=sha256:a4468e1b37bb318f8a86514f65814e1afc977cf29b3992a4500d9dd305dcceb0 \
     --hash=sha256:de09f2c4b85de4765f7714688fff57d3e75bad1f909b589fde880460c753fd2e


### PR DESCRIPTION
## Summary

Lands both new Haku runtimes (the `haku/runtime/` reorg landed in #2434). #2436 merged into this branch rather than `devel`, so this PR carries **both** Runtime C and the Runtime B scaffold; they squash-land together.

**Runtime C — `haku/runtime/agent/`** — provider-agnostic, self-hosted agent loop on **Microsoft Agent Framework**, models via in-cluster **LiteLLM**: agent loop (`:scan`) + supervisor (`:serve`: warm `AgentSession`, `POST /wake`, scheduler), Valkey durable history (`RedisHistoryProvider`), `SummarizationStrategy` compaction, ducktape + haku-state startup clone. Deps: `agent-framework-redis`, `redis`, `redisvl`, `python-ulid` (+ lockfile) and the regenerated `devinfra/gazelle_python.yaml`.

**Runtime B — `haku/runtime/managed_agent/`** (from #2436) — Anthropic **Managed Agents**, self-hosted sandbox, "ant-all-the-way" (only the `ant` CLI, no `anthropic` Python SDK): control-plane YAML + `provision.sh` + `entrypoint.sh` (worker = `ant beta:worker poll`). Warm-session supervisor deferred. Bring-up steps are in `haku/runtime/managed_agent/README.md` (and were detailed on #2436).

**Design docs** — `haku/plans/`: `runtime_options.md` (A/B/C + the self-hosted Agent-SDK variant), `managed_agents.md` + artifact drafts, `runtime_c_artifacts.md`.

## Verification

`bbr test //haku/runtime/agent/...` passes on RBE; the gazelle manifest was regenerated so `//devinfra:gazelle_python_manifest.test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLiwoWexhunDUjGw1bGgJv