### PR TITLE
haku/runtime/managed_agent: Managed Agents scaffold (Runtime B)

### DIFF
--- a/haku/runtime/managed_agent/AGENTS.md
+++ b/haku/runtime/managed_agent/AGENTS.md
@@ -1,0 +1,1 @@
+@README.md

--- a/haku/runtime/managed_agent/CLAUDE.md
+++ b/haku/runtime/managed_agent/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/haku/runtime/managed_agent/README.md
+++ b/haku/runtime/managed_agent/README.md
@@ -1,0 +1,76 @@
+# haku/runtime/managed_agent — Haku on Anthropic Managed Agents (self-hosted)
+
+Runtime B from <../../plans/runtime_options.md>: Anthropic runs the agent loop;
+tool execution runs in a worker **you** run in `haku-sandbox` (self-hosted
+sandbox, `config.type: self_hosted`). Full design + tradeoffs:
+<../../plans/managed_agents.md> (+ <../../plans/managed_agents_artifacts.md>).
+
+## "ant-all-the-way" — no `anthropic` Python SDK
+
+This component uses **only the `ant` CLI**, no `anthropic` Python SDK. Why: the
+SDK's self-hosted worker (`EnvironmentWorker`) and session APIs need
+`anthropic>=0.103`, but `agent-framework-anthropic` (used by Runtime C and the
+skill/grocy evals) hard-pins `anthropic==0.80.0` in the shared lockfile. The
+`ant` binary carries its own deps, so leaning on it sidesteps the conflict
+entirely — no lockfile bump, no second pip version, Runtime C untouched.
+
+The cost: the **warm-session supervisor is deferred**. The wake trigger is a
+scheduled deployment that fires a fresh session each tick; `haku-state` (git) is
+the durable memory, so a cold session just re-orients. Adding a warm supervisor
+later is the one thing that would reintroduce the SDK-version question.
+
+## Pieces
+
+| File                    | Role                                                             | Runs on       |
+| ----------------------- | ---------------------------------------------------------------- | ------------- |
+| `haku.environment.yaml` | self-hosted environment (`ant beta:environments create`)         | control plane |
+| `haku.agent.yaml`       | agent: thin `system` pointer, fixed toolset + tana `mcp_toolset` | control plane |
+| `haku.deployment.yaml`  | scheduled-deployment wake trigger                                | control plane |
+| `provision.sh`          | one-shot: create environment/agent/vault/deployment via `ant`    | operator / CI |
+| `entrypoint.sh`         | clone ducktape + haku-state, then `ant beta:worker poll`         | `haku-worker` |
+
+## Trust split — keep the org key off the worker
+
+- **Worker pod** (`haku-sandbox`): only `ANTHROPIC_ENVIRONMENT_KEY`
+  (`sk-ant-oat01-…`, one environment's work queue). A prompt-injected tool call
+  can't reach the control plane.
+- **Provisioning** (`provision.sh`, deployment management, `…:work stats`): the
+  org-scoped `ANTHROPIC_API_KEY`, run from CI / the operator laptop — **never**
+  on the worker host.
+
+## Worker image (CI-only build)
+
+A debian image with `bash`, `git`, `kubectl`, `postgresql-client`, `curl`,
+`ca-certificates`, `fastmcp`, and the **`ant` CLI** (Go binary from
+`github.com/anthropics/anthropic-cli/releases`), entrypoint `entrypoint.sh`.
+Built on CI (apt mirrors 403 in the Claude-web sandbox), pushed to GHCR, pinned
+by Flux — the standard <../../../cluster/docs/container-images.md> path. The
+fixed `ant` toolset is `bash/read/write/edit/glob/grep`; Haku reaches Plaid
+(`psql`), Google (`curl`), and the cluster (`kubectl`, in-cluster `haku` SA)
+through `bash`. Tana is a native `mcp_toolset` (Anthropic-side, vault auth).
+
+## k8s wiring — operator-owned (follow-up)
+
+The `haku-worker` Deployment, the `ANTHROPIC_ENVIRONMENT_KEY` secret, and the
+clone/git env live under `cluster/k8s/…/haku/` — see
+<../../plans/managed_agents.md> § "k8s wiring". The worker reuses Haku's existing
+`haku-sandbox` perimeter (`haku` SA + RBAC, `haku-mitmproxy` egress,
+ResourceQuota); none of it relies on agent restraint.
+
+## Bring-up
+
+```sh
+./provision.sh                                   # org ANTHROPIC_API_KEY, outside the worker
+# generate the environment key in the Console -> ANTHROPIC_ENVIRONMENT_KEY secret
+# deploy haku-worker (env key + the HAKU_* clone/git env) in haku-sandbox
+ant beta:deployments run --deployment-id "$DEPL_ID"   # test one run, watch in Console
+```
+
+## Worker env
+
+`ANTHROPIC_ENVIRONMENT_ID`, `ANTHROPIC_ENVIRONMENT_KEY`, `HAKU_DUCKTAPE_REPO_URL`,
+`HAKU_STATE_REPO_URL`, `HAKU_GIT_HOST`, `HAKU_GIT_USERNAME`, `HAKU_GIT_PASSWORD`.
+
+Beta-surface field/flag names (`agent_toolset_20260401`, `vault_ids`, the
+deployment schema) follow the `ant` docs as of 2026-06 — verify with
+`ant <cmd> --help`.

--- a/haku/runtime/managed_agent/entrypoint.sh
+++ b/haku/runtime/managed_agent/entrypoint.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# haku-worker entrypoint (runs in haku-sandbox): clone Haku's home into the agent
+# workdir, then long-poll Anthropic's self-hosted work queue with the fixed `ant`
+# toolset. The pod holds ONLY the environment key (sk-ant-oat01-...), never the
+# org-scoped API key — so a prompt-injected tool call can't reach the control plane.
+set -euo pipefail
+
+workspace=/workspace
+ducktape_dir="$workspace/ducktape"
+state_dir="$workspace/haku-state"
+
+# git auth for the Forgejo host, off any command line.
+umask 077
+printf 'machine %s login %s password %s\n' \
+  "$HAKU_GIT_HOST" "$HAKU_GIT_USERNAME" "$HAKU_GIT_PASSWORD" >"$HOME/.netrc"
+
+clone_or_pull() { # <url> <dest>
+  if [ -d "$2/.git" ]; then
+    git -C "$2" pull --ff-only
+  else
+    git clone --depth 1 "$1" "$2"
+  fi
+}
+
+# Behavior: ducktape's haku/base + haku/run.md, read at runtime (live-editable —
+# no image rebuild to change the manual).
+clone_or_pull "$HAKU_DUCKTAPE_REPO_URL" "$ducktape_dir"
+# Memory + the only write surface.
+clone_or_pull "$HAKU_STATE_REPO_URL" "$state_dir"
+git -C "$state_dir" config user.name haku
+git -C "$state_dir" config user.email haku@allegedly.works
+
+# kubectl uses the pod's haku ServiceAccount token automatically (in-cluster);
+# no kubeconfig to materialize, unlike the Claude Code web home.
+exec ant beta:worker poll \
+  --environment-id "$ANTHROPIC_ENVIRONMENT_ID" \
+  --workdir "$workspace"

--- a/haku/runtime/managed_agent/haku.agent.yaml
+++ b/haku/runtime/managed_agent/haku.agent.yaml
@@ -1,0 +1,33 @@
+# Haku's Managed Agents agent (control plane; version-controlled, applied via
+# `ant beta:agents {create,update}`). The `system` prompt is a thin pointer —
+# behavior stays single-sourced in haku/base + haku/run.md, which the worker
+# clones into the agent workdir at startup (see entrypoint.sh).
+name: haku
+model: claude-opus-4-8
+system: |
+  You are Haku, the operator's tireless background executive assistant. A worker
+  in your haku-sandbox namespace has cloned your home into the agent workdir:
+  your operating manual is at /workspace/ducktape/haku/base/instructions.md and
+  your run procedure at /workspace/ducktape/haku/run.md; your haku-state checkout
+  — your only memory and write surface — is at /workspace/haku-state, with git
+  auth and in-cluster kubectl already in place.
+
+  Read the manual and the run procedure, then execute the run procedure end to
+  end. Each user message is a wake: do one scan pass, commit and push haku-state,
+  then stop and wait for the next wake.
+tools:
+  # Fixed built-in toolset, supplied by the `ant` worker in the pod. The Pod is
+  # the trust boundary (Ember posture), so everything is auto-allowed.
+  - type: agent_toolset_20260401
+    default_config:
+      enabled: true
+      permission_policy:
+        type: always_allow
+  # Tana (read-only) as a native MCP tool; auth is injected at Anthropic's egress
+  # from the vault credential (provision.sh), so the pod never sees the token.
+  - type: mcp_toolset
+    mcp_server_name: tana-ro
+mcp_servers:
+  - type: url
+    name: tana-ro
+    url: https://tana-mcp-ro.allegedly.works/mcp

--- a/haku/runtime/managed_agent/haku.deployment.yaml
+++ b/haku/runtime/managed_agent/haku.deployment.yaml
@@ -1,0 +1,17 @@
+# The wake trigger: a scheduled deployment fires one fresh session per tick.
+# (The warm-session supervisor is a deferred optimization — haku-state is the
+# durable memory, so a cold session just re-orients.) provision.sh injects the
+# resolved --agent / --environment-id / --vault-ids; the static parts live here.
+# Verify flag/field names against `ant beta:deployments create --help`.
+name: haku-scan
+initial_events:
+  - type: user.message
+    content:
+      - type: text
+        text: "Wake: do one scan pass per the run procedure, then commit, push, and stop."
+# Tune the cadence to taste; start sparse and test on demand with
+# `ant beta:deployments run --deployment-id <id>` before trusting the schedule.
+schedule:
+  type: cron
+  expression: "0 */6 * * *"
+  timezone: America/Los_Angeles

--- a/haku/runtime/managed_agent/haku.environment.yaml
+++ b/haku/runtime/managed_agent/haku.environment.yaml
@@ -1,0 +1,8 @@
+# Haku's self-hosted Managed Agents environment. The agent loop runs at
+# Anthropic; tool execution (the fixed bash/read/write/edit/glob/grep set) runs
+# in the haku-worker pod in haku-sandbox. `{type: self_hosted}` is the entire
+# config — egress, hardening, and networking are ours (haku-mitmproxy + CCNP).
+#   ant beta:environments create < haku.environment.yaml
+name: haku-selfhosted
+config:
+  type: self_hosted

--- a/haku/runtime/managed_agent/provision.sh
+++ b/haku/runtime/managed_agent/provision.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Provision Haku's Managed Agents control plane via the `ant` CLI.
+#
+# Run from OUTSIDE the worker host (operator laptop / CI) authenticated with an
+# org-scoped ANTHROPIC_API_KEY (or `ant auth login` profile) — NEVER on the
+# worker pod, which holds only the environment key so agent tool calls can't
+# reach the control plane. First-time create only; iterate later with
+# `ant beta:agents update --agent-id <id> --version <n> < haku.agent.yaml`.
+set -euo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+ENV_ID=$(ant beta:environments create --transform id -r <"$here/haku.environment.yaml")
+echo "environment: $ENV_ID"
+echo "  -> generate its environment key in the Console (Environments -> haku-selfhosted"
+echo "     -> 'Generate environment key') and store it as the ANTHROPIC_ENVIRONMENT_KEY"
+echo "     secret on the haku-worker Deployment (it is never created via the API)."
+
+AGENT_ID=$(ant beta:agents create --transform id -r <"$here/haku.agent.yaml")
+echo "agent: $AGENT_ID"
+
+# Vault for MCP credentials. tana-mcp-ro is gated by the static bearer Haku
+# already has reflected into haku-sandbox (haku-tana-ro-token); pipe it via
+# stdin, never argv. Anthropic injects it at egress; the pod never sees it.
+VAULT_ID=$(ant beta:vaults create --name haku-mcp --transform id -r)
+echo "vault: $VAULT_ID"
+TANA_TOKEN=$(kubectl -n haku-sandbox get secret haku-tana-ro-token -o jsonpath='{.data.token}' | base64 -d)
+ant beta:vaults:credentials create --vault-id "$VAULT_ID" >/dev/null <<YAML
+display_name: tana-mcp-ro (read-only)
+auth:
+  type: static_bearer
+  mcp_server_url: https://tana-mcp-ro.allegedly.works/mcp
+  token: ${TANA_TOKEN}
+YAML
+echo "  -> tana-mcp-ro credential stored in vault $VAULT_ID"
+
+# Scheduled deployment = the wake trigger (one fresh session per fire).
+DEPL_ID=$(ant beta:deployments create \
+  --agent "$AGENT_ID" --environment-id "$ENV_ID" --vault-ids "[$VAULT_ID]" \
+  --transform id -r <"$here/haku.deployment.yaml")
+echo "deployment: $DEPL_ID"
+
+echo
+echo "Record these IDs. Test one run on demand (works even before the schedule):"
+echo "  ant beta:deployments run --deployment-id $DEPL_ID"
+echo "Watch it live in the Console: platform.claude.com/workspaces/default/sessions"


### PR DESCRIPTION
## Stack

**Stacked on #2435** (which is stacked on #2434). Top of the 3-PR split of #2432.

> Base is `claude/haku-runtime-agent`; the diff below is only this PR's changes. Retarget down the stack as the lower PRs merge.

## Summary

**Runtime B** — Anthropic **Managed Agents**, self-hosted sandbox (`config.type: self_hosted`): Anthropic runs the loop, tool execution runs in a worker in `haku-sandbox`.

**"ant-all-the-way"** — only the `ant` CLI, no `anthropic` Python SDK. The SDK's `EnvironmentWorker` + `beta.sessions` need `anthropic>=0.103`, but `agent-framework-anthropic` (used by Runtime C and the skill/grocy evals) hard-pins `anthropic==0.80.0` in the shared lockfile; the `ant` binary carries its own deps, so this needs no lockfile change and leaves Runtime C untouched. The warm-session supervisor is **deferred** in favor of a scheduled deployment (`haku-state` is the durable memory, so a cold session per wake just re-orients).

Files: `haku.environment.yaml` / `haku.agent.yaml` / `haku.deployment.yaml` (control plane), `provision.sh` (create environment/agent/vault/deployment), `entrypoint.sh` (worker = `ant beta:worker poll`).

## Bring-up

1. **Provision the control plane** (org-scoped `ANTHROPIC_API_KEY`, run from the operator laptop / CI — never on the worker):
   ```sh
   ./haku/runtime/managed_agent/provision.sh
   ```
   Creates the environment, agent, vault (+ tana-mcp-ro credential), and scheduled deployment; prints `ENV_ID` / `AGENT_ID` / `VAULT_ID` / `DEPL_ID`.
2. **Generate the environment key** in the Console (Environments → `haku-selfhosted` → "Generate environment key") → store as the `ANTHROPIC_ENVIRONMENT_KEY` secret for the worker. Never created via the API.
3. **Build + push the worker image** (CI): debian + `git`/`kubectl`/`postgresql-client`/`curl`/`fastmcp` + the `ant` Go binary, entrypoint `entrypoint.sh`.
4. **Deploy `haku-worker`** in `haku-sandbox` (env key + the `HAKU_*` clone/git env). _k8s wiring is a follow-up._
5. **Test one run** and watch in the Console:
   ```sh
   ant beta:deployments run --deployment-id "$DEPL_ID"
   ```

## Follow-ups (not in this PR)

- **Worker image** (apt + `ant` binary) — CI-only build (apt mirrors 403 in the Claude-web sandbox).
- **k8s wiring** — operator-owned `haku-worker` Deployment + `ANTHROPIC_ENVIRONMENT_KEY` secret under `cluster/k8s/haku/`, reusing the existing `haku-sandbox` perimeter (`haku` SA + RBAC, `haku-mitmproxy` egress, ResourceQuota).
- **Warm-session supervisor** (reopens the anthropic-SDK-version question).

## Caveats

`ant` beta CLI field/flag names (`agent_toolset_20260401`, `--vault-ids`, the deployment schema) follow the docs as of 2026-06 — **verify with `ant <cmd> --help`** at bring-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLiwoWexhunDUjGw1bGgJv

---
_Generated by [Claude Code](https://claude.ai/code/session_01JLiwoWexhunDUjGw1bGgJv)_