### PR TITLE
nix: add the Anthropic CLI (ant) to the devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -272,6 +272,9 @@
       # Packages NOT needed on RBE workers (large, only for local/infra use).
       # Excluded from rbeToolPackages to keep the RBE image small.
       localOnlyPackages = [
+        # Anthropic CLI (`ant`): Claude API / Managed Agents control plane, for
+        # running `ant beta:*` (haku/runtime/managed_agent). Not needed on RBE.
+        ducktapePkgs.anthropic-cli
         pkgs.rustfmt # 1GB (pulls full rustc via RPATH)
         pkgs.ansible # 650MB
         # llvm-addr2line: drop-in for GNU addr2line used by `perf report` for

--- a/nix/packages/anthropic-cli.nix
+++ b/nix/packages/anthropic-cli.nix
@@ -1,0 +1,42 @@
+# Anthropic CLI (`ant`): the Claude API / Managed Agents control-plane CLI.
+# Not in nixpkgs (and `pkgs.ant` is Apache Ant), so we vendor the upstream
+# statically-linked release binary. Used by haku/runtime/managed_agent
+# (`ant beta:{environments,agents,vaults,deployments,worker} ...`).
+{
+  lib,
+  pkgs,
+}:
+pkgs.stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "anthropic-cli";
+  version = "1.12.1";
+
+  src = pkgs.fetchurl {
+    url = "https://github.com/anthropics/anthropic-cli/releases/download/v${finalAttrs.version}/ant_${finalAttrs.version}_linux_amd64.tar.gz";
+    hash = "sha256-cgXlUsZ4UhmKAVLPEADhybq3AHXcALVm/KkZnjHZxQk=";
+  };
+
+  # Tarball holds `ant` plus completions/ and man/ at the root; the binary is
+  # statically linked, so no autoPatchelf is needed.
+  dontUnpack = true;
+  nativeBuildInputs = [ pkgs.installShellFiles ];
+
+  installPhase = ''
+    runHook preInstall
+    tar xzf "$src"
+    install -Dm755 ant "$out/bin/ant"
+    installShellCompletion --cmd ant \
+      --bash completions/ant.bash \
+      --fish completions/ant.fish \
+      --zsh completions/ant.zsh
+    install -Dm644 man/man1/ant.1.gz "$out/share/man/man1/ant.1.gz"
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Anthropic CLI (ant) — Claude API and Managed Agents control plane";
+    homepage = "https://github.com/anthropics/anthropic-cli";
+    license = lib.licenses.unfree;
+    mainProgram = "ant";
+    platforms = [ "x86_64-linux" ];
+  };
+})

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -315,6 +315,9 @@ rec {
   litert-lm = pkgs.callPackage ./litert-lm.nix { };
   prettier = pkgs.callPackage ./prettier/prettier.nix { };
   kubernetes-mcp-server = pkgs.callPackage ./kubernetes-mcp-server.nix { };
+  # Anthropic CLI (`ant`): Claude API / Managed Agents control plane. Not in
+  # nixpkgs; vendored static release binary. Used by haku/runtime/managed_agent.
+  anthropic-cli = pkgs.callPackage ./anthropic-cli.nix { };
   # fastmcp's client CLI (`fastmcp call|list <url> --auth <bearer>`) exposed as a
   # standalone app for agent closures (flake.nix `.#agent-haku`). The library
   # is consumed by the `ducktape` wheel above via `python3Packages.fastmcp`; this


### PR DESCRIPTION
## Summary

Adds the **Anthropic CLI (`ant`)** to the Nix devshell.

It isn't in nixpkgs (and `pkgs.ant` is **Apache Ant**, a name clash), so this vendors the upstream **statically-linked** release binary as `nix/packages/anthropic-cli.nix` (v1.12.1) and wires it into `localOnlyPackages`.

That placement puts `ant` in:
- the **devShell** (`nix develop` / direnv),
- `.#devtools` (Claude Code web), and
- `.#agent-haku`,

but **excludes it from the RBE worker image** (`rbetools`), where `ant` has no use.

The tarball's shell completions and manpage are installed too. Used by `haku/runtime/managed_agent` for the Managed Agents control plane (`ant beta:{environments,agents,vaults,deployments,worker} …`).

## Verification

- `nix build .#anthropic-cli` succeeds; `ant version` → `1.12.1`.
- `nix eval .#devShells.x86_64-linux.default.drvPath` evaluates with `ant` wired in.
- `nixfmt` + `statix` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLiwoWexhunDUjGw1bGgJv

---
_Generated by [Claude Code](https://claude.ai/code/session_01JLiwoWexhunDUjGw1bGgJv)_