### PR TITLE
haku/runtime/managed_agent: fix ant CLI flags in provision.sh

### DIFF
--- a/haku/runtime/managed_agent/provision.sh
+++ b/haku/runtime/managed_agent/provision.sh
@@ -21,7 +21,7 @@ echo "agent: $AGENT_ID"
 # Vault for MCP credentials. tana-mcp-ro is gated by the static bearer Haku
 # already has reflected into haku-sandbox (haku-tana-ro-token); pipe it via
 # stdin, never argv. Anthropic injects it at egress; the pod never sees it.
-VAULT_ID=$(ant beta:vaults create --name haku-mcp --transform id -r)
+VAULT_ID=$(ant beta:vaults create --display-name haku-mcp --transform id -r)
 echo "vault: $VAULT_ID"
 TANA_TOKEN=$(kubectl -n haku-sandbox get secret haku-tana-ro-token -o jsonpath='{.data.token}' | base64 -d)
 ant beta:vaults:credentials create --vault-id "$VAULT_ID" >/dev/null <<YAML
@@ -35,7 +35,7 @@ echo "  -> tana-mcp-ro credential stored in vault $VAULT_ID"
 
 # Scheduled deployment = the wake trigger (one fresh session per fire).
 DEPL_ID=$(ant beta:deployments create \
-  --agent "$AGENT_ID" --environment-id "$ENV_ID" --vault-ids "[$VAULT_ID]" \
+  --agent "$AGENT_ID" --environment-id "$ENV_ID" --vault-id "$VAULT_ID" \
   --transform id -r <"$here/haku.deployment.yaml")
 echo "deployment: $DEPL_ID"
 


### PR DESCRIPTION
## Summary

Fixes two wrong `ant` CLI flags in `haku/runtime/managed_agent/provision.sh`, surfaced when running it for real (env + agent created fine; the vault step then errored with `flag provided but not defined: -name`). Both corrected against the actual CLI (**`ant` v1.12.1 `--help`**):

- **Vault** — `ant beta:vaults create` takes `--display-name`, not `--name`.
- **Deployment** — `ant beta:deployments create` takes `--vault-id` (singular, repeatable), not `--vault-ids`. `--agent` / `--environment-id` were already correct.

Everything else matches the CLI as-is: the environment/agent creates (stdin YAML), and the credential create (`ant beta:vaults:credentials create --vault-id … ` + stdin `auth:` body — `beta:vaults:credentials` is a real resource with `--vault-id` / `--auth` / `--display-name`).

## Verification

Downloaded `ant` 1.12.1 and confirmed each subcommand's flags via `--help` (vault `--display-name`; deployment `--vault-id`; credential `--vault-id`/`--auth`). Auth itself already works — `provision.sh` created `env_…` and `agent_…` successfully before hitting the vault flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLiwoWexhunDUjGw1bGgJv

---
_Generated by [Claude Code](https://claude.ai/code/session_01JLiwoWexhunDUjGw1bGgJv)_