### PR TITLE
debundle: resolve source_match selectors in the global solver

### DIFF
--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -1055,6 +1055,7 @@ rust_library(
     deps = [
         ":analysis",
         ":selector_ir",
+        ":source_match",
         ":spec",
     ],
 )
@@ -1065,6 +1066,7 @@ rust_test(
     edition = "2024",
     deps = [
         ":selector_ir",
+        ":source_match",
         ":spec",
     ],
 )

--- a/devinfra/js/debundle/lowering/materialize/mod.rs
+++ b/devinfra/js/debundle/lowering/materialize/mod.rs
@@ -181,7 +181,6 @@ pub(super) fn materialize_logical_chunk(
     // by the corpus differential, <debug/2026_06_18_per_chunk_gate_real_source.md>).
     let selector_resolver = source_match::ChunkResolver::new(&runtime_ast.module);
     let explicit_request_ctx = ExplicitRequestContext {
-        runtime_module: &runtime_ast.module,
         selector_resolver: &selector_resolver,
         declaration_by_name: &declaration_by_name,
         chunk_top_level_mark,
@@ -199,7 +198,6 @@ pub(super) fn materialize_logical_chunk(
             &mut imported_from_by_src,
         )?;
     }
-    drop(imported_binding_resolver);
     builder.drop_explicit_request_scratch();
     builder.pull_destructure_siblings(&destructure_siblings, chunk_top_level_mark)?;
     builder.adopt_bindings_of_claimed_anonymous_statements(&declarations);
@@ -283,9 +281,8 @@ pub(super) fn materialize_logical_chunk(
         fact_analysis: analysis,
         owner_graph_and_units: precomputed,
     } = stage_one;
-    // Global selector resolution: `add_explicit_request` left relational members
-    // unclaimed because their target bindings are only knowable once Stage A has
-    // produced the owner graph. Compile all resolved binding anchors plus all
+    // Global selector resolution: `add_explicit_request` left deferred selector
+    // members unclaimed. Compile binding anchors, source_match candidates, and
     // relational selectors into one IR program and run one Ascent solver pass over
     // the owner graph + chunk AST relation facts.
     let import_sources: HashMap<String, String> = runtime_import_facts
@@ -298,12 +295,18 @@ pub(super) fn materialize_logical_chunk(
             &precomputed.owner_graph,
             &runtime_ast.module,
             &import_sources,
+            &selector_resolver,
+            &runtime_import_facts,
+            &mut imported_binding_resolver,
+            &mut imported_from_by_src,
             chunk_top_level_mark,
             chunk_id,
+            &target_file,
             chunk_id_interned,
             &declaration_by_name,
         )
     })?;
+    drop(imported_binding_resolver);
     time_phase!(timings, "fold_rebind_atomic_units", {
         apply_stage_one_a5(&mut builder, &precomputed);
     });

--- a/devinfra/js/debundle/lowering/materialize/plan_builder.rs
+++ b/devinfra/js/debundle/lowering/materialize/plan_builder.rs
@@ -201,6 +201,10 @@ fn resolve_anchor<'a>(
 fn member_selector_spec_for_global_solver(
     member: &MemberRequest,
 ) -> Option<spec::MemberSelectorSpec> {
+    if let Some(selector) = &member.source_match {
+        return Some(spec::MemberSelectorSpec::SourceMatch(selector.clone()));
+    }
+
     if let Some(relational) = &member.relational {
         return Some(match relational {
             RelationalSelector::CrossRef(target) => {
@@ -393,6 +397,86 @@ fn render_source_match_diagnostics(diagnostics: &[SourceMatchDiagnostic]) -> Str
     report
 }
 
+fn source_match_no_match_message(
+    request: &LogicalRequest,
+    member: &MemberRequest,
+) -> Option<String> {
+    let selector = member.source_match.as_ref()?;
+    let target_binding_hint = selector
+        .target_binding
+        .as_deref()
+        .map(|target| format!(" target_binding `{target}`"))
+        .unwrap_or_default();
+    Some(format!(
+        "logical_module {}: members[].selector.source_match for export `{}`{} did not match any \
+         top-level declaration in the chunk. Selector:\n{}",
+        request.id, member.export_name, target_binding_hint, selector.match_source,
+    ))
+}
+
+fn source_match_ambiguous_message(
+    request: &LogicalRequest,
+    member: &MemberRequest,
+    candidates: Option<&[source_match::MemberBindingMatch]>,
+) -> Option<String> {
+    let selector = member.source_match.as_ref()?;
+    let candidates = candidates?;
+    let target_binding_hint = selector
+        .target_binding
+        .as_deref()
+        .map(|target| format!(" target_binding `{target}`"))
+        .unwrap_or_default();
+    Some(format!(
+        "logical_module {}: members[].selector.source_match for export `{}`{} is ambiguous -- \
+         matched {} top-level statements at body indices {:?} (bindings: {}). Refine the \
+         selector. Source:\n{}",
+        request.id,
+        member.export_name,
+        target_binding_hint,
+        candidates.len(),
+        candidates
+            .iter()
+            .map(|candidate| candidate.body_idx)
+            .collect::<Vec<_>>(),
+        candidates
+            .iter()
+            .map(|candidate| candidate.binding.binding_name.as_str())
+            .collect::<Vec<_>>()
+            .join(", "),
+        selector.match_source,
+    ))
+}
+
+fn source_match_resolution_error_message(
+    selector_resolver: &dyn source_match::SelectorResolver,
+    request: &LogicalRequest,
+    member: &MemberRequest,
+    group_assignment: Option<&SourceMatchGroupAssignment>,
+) -> Option<String> {
+    let selector = member.source_match.as_ref()?;
+    if let Some(group) = group_assignment {
+        let member_error = selector_resolver
+            .resolve_member_with_label(
+                &request.id,
+                &member.export_name,
+                selector,
+                "binding_groups[].source_match",
+            )
+            .err()
+            .map(|error| format!("{error:#}"));
+        return member_error.or_else(|| {
+            selector_resolver
+                .resolve_member_group(&request.id, &group.selector, &group.exports_by_target)
+                .err()
+                .map(|error| format!("{error:#}"))
+        });
+    }
+    selector_resolver
+        .resolve_member(&request.id, &member.export_name, selector)
+        .err()
+        .map(|error| format!("{error:#}"))
+}
+
 struct SourceMatchReportDetails {
     body_indices: Vec<usize>,
     first_mismatch: Option<String>,
@@ -479,26 +563,6 @@ fn source_match_selector_kind(claim_origin: &str) -> &'static str {
     }
 }
 
-fn module_path_from_id(module_id: &str) -> Option<String> {
-    module_id.split_once("::").map(|(_, path)| path.to_string())
-}
-
-fn render_anonymous_statement_diagnostics(diagnostics: &[AnonymousStatementDiagnostic]) -> String {
-    let mut diagnostics = diagnostics.iter().collect::<Vec<_>>();
-    diagnostics.sort_by(|a, b| a.module_id.cmp(&b.module_id));
-    let mut report = format!(
-        "Anonymous statement selector diagnostic report: {} unresolved selector(s) found. \
-         Under --keep-going, anonymous statements with unresolved selectors are skipped from \
-         canonical ownership so the rest of the chunk can still be checked.",
-        diagnostics.len()
-    );
-    for diagnostic in &diagnostics {
-        report.push_str("\n- ");
-        report.push_str(&diagnostic.render());
-    }
-    report
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 struct SourceMatchGroupCacheKey {
     selector: spec::AnonymousStatementSelector,
@@ -518,49 +582,15 @@ impl SourceMatchGroupCacheKey {
     }
 }
 
-/// Output of `ChunkPlanBuilder::finalize`: everything downstream
-/// `lower_chunk` + the chunk-report builder need from the plan
-/// construction phase.
-pub(super) struct ChunkPlan {
-    pub(super) module_plans: Vec<ModulePlan>,
-    pub(super) binding_assignment: HashMap<Id, usize>,
-    pub(super) bindings_catalogue: HashMap<Id, BindingKind>,
-    pub(super) anonymous_ordinal_assignment: BTreeMap<usize, usize>,
-    pub(super) unmatched_spec_claims: Vec<crate::UnmatchedSpecClaim>,
+#[derive(Debug, Clone)]
+struct SourceMatchGroupAssignment {
+    selector: spec::AnonymousStatementSelector,
+    exports_by_target: BTreeMap<String, String>,
 }
 
-/// Per-explicit-request inputs the builder reads but does not own.
-pub(super) struct ExplicitRequestContext<'a> {
-    pub(super) runtime_module: &'a Module,
-    /// The selector resolver, built once for this chunk (see
-    /// `materialize_chunk`) and shared across every request's member and
-    /// binding-group `source_match` resolution. Carrying the resolver rather
-    /// than rebuilding it per request is what keeps a fact-based resolver's
-    /// per-chunk EDB construction off the hot path.
-    pub(super) selector_resolver: &'a dyn source_match::SelectorResolver,
-    pub(super) declaration_by_name: &'a HashMap<Id, usize>,
-    pub(super) chunk_top_level_mark: swc_common::Mark,
-    pub(super) target_dir: &'a str,
-    pub(super) chunk_id: &'a str,
-    pub(super) target_file: &'a str,
-    pub(super) runtime_import_facts: &'a RuntimeImportFacts,
-}
-
-fn resolve_request_source_matches(
-    request: &mut LogicalRequest,
-    resolver: &dyn source_match::SelectorResolver,
-    runtime_module: &Module,
-    keep_going: bool,
-    diagnostics: &mut Vec<SourceMatchDiagnostic>,
-    source_match_cache: &mut BTreeMap<
-        spec::AnonymousStatementSelector,
-        source_match::ResolvedMemberBinding,
-    >,
-    source_match_group_cache: &mut BTreeMap<
-        SourceMatchGroupCacheKey,
-        BTreeMap<String, source_match::ResolvedMemberBinding>,
-    >,
-) -> Result<()> {
+fn source_match_group_assignments(
+    request: &LogicalRequest,
+) -> BTreeMap<usize, SourceMatchGroupAssignment> {
     let mut grouped_by_selector: BTreeMap<spec::AnonymousStatementSelector, Vec<usize>> =
         BTreeMap::new();
     for (idx, member) in request.members.iter().enumerate() {
@@ -578,7 +608,7 @@ fn resolve_request_source_matches(
             .push(idx);
     }
 
-    let mut resolved_member_indices = BTreeSet::new();
+    let mut assignments = BTreeMap::new();
     for (selector, member_indices) in grouped_by_selector {
         if member_indices.len() < 2 {
             continue;
@@ -602,86 +632,62 @@ fn resolve_request_source_matches(
         if has_duplicate_target {
             continue;
         }
-        let cache_key = SourceMatchGroupCacheKey::new(selector.clone(), &exports_by_target);
-        let resolved = match source_match_group_cache.get(&cache_key) {
-            Some(resolved) => resolved.clone(),
-            None => {
-                let resolved = match resolver
-                    .resolve_member_group(&request.id, &selector, &exports_by_target)
-                    .map(|group| group.bindings)
-                {
-                    Ok(resolved) => resolved,
-                    Err(error) if keep_going => {
-                        let message = format!("{error:#}");
-                        let module_id = request.id.clone();
-                        let module_path = request.target_path.clone();
-                        for idx in member_indices {
-                            let member = &request.members[idx];
-                            diagnostics.push(SourceMatchDiagnostic::new(
-                                runtime_module,
-                                &module_id,
-                                &module_path,
-                                member,
-                                message.clone(),
-                            ));
-                        }
-                        continue;
-                    }
-                    Err(error) => return Err(error),
-                };
-                source_match_group_cache.insert(cache_key, resolved.clone());
-                resolved
-            }
+        let assignment = SourceMatchGroupAssignment {
+            selector,
+            exports_by_target,
         };
         for idx in member_indices {
-            let member = &mut request.members[idx];
-            let target_binding = member
-                .source_match
-                .as_ref()
-                .and_then(|selector| selector.target_binding.as_ref())
-                .expect("grouped selectors always have target_binding");
-            let resolved = resolved.get(target_binding).with_context(|| {
-                format!("binding group resolver did not return target_binding `{target_binding}`")
-            })?;
-            apply_resolved_member_binding(member, resolved.clone());
-            resolved_member_indices.insert(idx);
+            assignments.insert(idx, assignment.clone());
         }
     }
-
-    let module_id = request.id.clone();
-    let module_path = request.target_path.clone();
-    for (idx, member) in request.members.iter_mut().enumerate() {
-        if resolved_member_indices.contains(&idx) {
-            continue;
-        }
-        if let Err(error) = member.resolve_source_match(resolver, &request.id, source_match_cache) {
-            if !keep_going {
-                return Err(error);
-            }
-            diagnostics.push(SourceMatchDiagnostic::new(
-                runtime_module,
-                &module_id,
-                &module_path,
-                member,
-                format!("{error:#}"),
-            ));
-        }
-    }
-    if keep_going {
-        request
-            .members
-            .retain(|member| member.source_match.is_none());
-    }
-    Ok(())
+    assignments
 }
 
-fn apply_resolved_member_binding(
-    member: &mut MemberRequest,
-    resolved: source_match::ResolvedMemberBinding,
-) {
-    member.binding = resolved.binding_name;
-    member.is_import_specifier = matches!(resolved.kind, Some(BindingSourceKind::ImportSpecifier));
-    member.source_match = None;
+fn module_path_from_id(module_id: &str) -> Option<String> {
+    module_id.split_once("::").map(|(_, path)| path.to_string())
+}
+
+fn render_anonymous_statement_diagnostics(diagnostics: &[AnonymousStatementDiagnostic]) -> String {
+    let mut diagnostics = diagnostics.iter().collect::<Vec<_>>();
+    diagnostics.sort_by(|a, b| a.module_id.cmp(&b.module_id));
+    let mut report = format!(
+        "Anonymous statement selector diagnostic report: {} unresolved selector(s) found. \
+         Under --keep-going, anonymous statements with unresolved selectors are skipped from \
+         canonical ownership so the rest of the chunk can still be checked.",
+        diagnostics.len()
+    );
+    for diagnostic in &diagnostics {
+        report.push_str("\n- ");
+        report.push_str(&diagnostic.render());
+    }
+    report
+}
+
+/// Output of `ChunkPlanBuilder::finalize`: everything downstream
+/// `lower_chunk` + the chunk-report builder need from the plan
+/// construction phase.
+pub(super) struct ChunkPlan {
+    pub(super) module_plans: Vec<ModulePlan>,
+    pub(super) binding_assignment: HashMap<Id, usize>,
+    pub(super) bindings_catalogue: HashMap<Id, BindingKind>,
+    pub(super) anonymous_ordinal_assignment: BTreeMap<usize, usize>,
+    pub(super) unmatched_spec_claims: Vec<crate::UnmatchedSpecClaim>,
+}
+
+/// Per-explicit-request inputs the builder reads but does not own.
+pub(super) struct ExplicitRequestContext<'a> {
+    /// The selector resolver, built once for this chunk (see
+    /// `materialize_chunk`) and shared across anonymous statement resolution and
+    /// the global selector pass. Carrying the resolver rather than rebuilding it
+    /// per request is what keeps a fact-based resolver's per-chunk EDB
+    /// construction off the hot path.
+    pub(super) selector_resolver: &'a dyn source_match::SelectorResolver,
+    pub(super) declaration_by_name: &'a HashMap<Id, usize>,
+    pub(super) chunk_top_level_mark: swc_common::Mark,
+    pub(super) target_dir: &'a str,
+    pub(super) chunk_id: &'a str,
+    pub(super) target_file: &'a str,
+    pub(super) runtime_import_facts: &'a RuntimeImportFacts,
 }
 
 /// Builds a `ChunkPlan` from spec requests and chunk AST analysis.
@@ -745,22 +751,6 @@ pub(super) struct ChunkPlanBuilder {
     /// canonical plan so later modules in the chunk can still be
     /// checked for independent selector and duplicate-claim failures.
     source_match_diagnostics: Vec<SourceMatchDiagnostic>,
-    /// Successful member-form `source_match` resolutions within this
-    /// chunk. Selector matching scans the same runtime chunk AST, and
-    /// many large migrations repeat exact selectors across logical
-    /// modules while converging duplicate ownership. Keeping successes
-    /// at chunk scope avoids re-running the structural matcher for
-    /// repeated selectors; failures still resolve live so diagnostics
-    /// stay anchored to the current module/export.
-    source_match_cache:
-        BTreeMap<spec::AnonymousStatementSelector, source_match::ResolvedMemberBinding>,
-    /// Successful grouped member-form source matches keyed by the
-    /// selector body and requested selector-local target bindings.
-    /// Export names are intentionally excluded: they only label
-    /// diagnostics/timings, while the resolved source bindings are a
-    /// function of the selector and target bindings.
-    source_match_group_cache:
-        BTreeMap<SourceMatchGroupCacheKey, BTreeMap<String, source_match::ResolvedMemberBinding>>,
     /// Anonymous statement selectors that did not resolve. In
     /// keep-going mode, unresolved anonymous statements are omitted
     /// from canonical ownership so later modules in the chunk can
@@ -787,8 +777,6 @@ impl ChunkPlanBuilder {
             catalogue_index_by_name: HashMap::new(),
             duplicate_binding_claims: Vec::new(),
             source_match_diagnostics: Vec::new(),
-            source_match_cache: BTreeMap::new(),
-            source_match_group_cache: BTreeMap::new(),
             anonymous_statement_diagnostics: Vec::new(),
             keep_going,
         }
@@ -807,15 +795,6 @@ impl ChunkPlanBuilder {
         imported_binding_resolver: &mut ArtifactSourceImportResolutionCache<'_>,
         imported_from_by_src: &mut BTreeMap<String, String>,
     ) -> Result<()> {
-        resolve_request_source_matches(
-            request,
-            ctx.selector_resolver,
-            ctx.runtime_module,
-            self.keep_going,
-            &mut self.source_match_diagnostics,
-            &mut self.source_match_cache,
-            &mut self.source_match_group_cache,
-        )?;
         reject_duplicate_member_bindings("logical_module", &request.id, &request.members)?;
         let mut bindings = HashMap::<String, String>::new();
         let anonymous_statement_claims = resolve_anonymous_statement_ordinals(
@@ -865,11 +844,10 @@ impl ChunkPlanBuilder {
         let module_id = ModuleId(LogicalModuleIndex(index));
         let mut duplicate_bindings = BTreeSet::<String>::new();
         for member in &request.members {
-            // Relational members resolve against the chunk's owner graph and AST
-            // relation facts, which are only available after Stage A. The global
-            // selector pass claims them later; until then their `binding` is
-            // empty, so they contribute nothing here.
-            if member.is_relational() {
+            // Deferred selector members resolve in the global selector pass after
+            // Stage A has produced the owner graph and selector fact store. Until
+            // then their `binding` is empty, so they contribute nothing here.
+            if member.is_relational() || member.source_match.is_some() {
                 continue;
             }
             if let Some(existing_kind) = self.catalogue_index_by_name.get(member.binding.as_str()) {
@@ -921,9 +899,6 @@ impl ChunkPlanBuilder {
                         claim_origin: Some(member.claim_origin.clone()),
                     },
                 };
-                if !self.keep_going {
-                    bail!("{}", render_duplicate_binding_claims(&[duplicate]));
-                }
                 self.duplicate_binding_claims.push(duplicate);
                 duplicate_bindings.insert(member.binding.clone());
                 continue;
@@ -984,7 +959,7 @@ impl ChunkPlanBuilder {
         let binding_comments: BTreeMap<String, String> = request
             .members
             .iter()
-            .filter(|member| !member.is_relational())
+            .filter(|member| !member.is_relational() && member.source_match.is_none())
             .filter(|member| !duplicate_bindings.contains(member.binding.as_str()))
             .filter_map(|member| {
                 member
@@ -996,7 +971,7 @@ impl ChunkPlanBuilder {
         let binding_claim_origins: BTreeMap<String, String> = request
             .members
             .iter()
-            .filter(|member| !member.is_relational())
+            .filter(|member| !member.is_relational() && member.source_match.is_none())
             .filter(|member| !duplicate_bindings.contains(member.binding.as_str()))
             .map(|member| (member.binding.clone(), member.claim_origin.clone()))
             .collect();
@@ -1022,15 +997,20 @@ impl ChunkPlanBuilder {
         owner_graph: &analysis::OwnerGraph,
         module: &swc_ecma_ast::Module,
         import_sources: &HashMap<String, String>,
+        selector_resolver: &dyn source_match::SelectorResolver,
+        runtime_import_facts: &RuntimeImportFacts,
+        imported_binding_resolver: &mut ArtifactSourceImportResolutionCache<'_>,
+        imported_from_by_src: &mut BTreeMap<String, String>,
         chunk_top_level_mark: swc_common::Mark,
         chunk_id: &str,
+        target_file: &str,
         chunk_id_interned: ChunkId,
         declaration_by_name: &HashMap<Id, usize>,
     ) -> Result<()> {
         if explicit_requests
             .iter()
             .flat_map(|request| &request.members)
-            .all(|member| !member.is_relational())
+            .all(|member| !member.is_relational() && member.source_match.is_none())
         {
             return Ok(());
         }
@@ -1039,10 +1019,27 @@ impl ChunkPlanBuilder {
             chunk_id_interned,
             chunk_id,
         ));
-        let mut relational_targets = BTreeMap::<SelectorTargetId, (usize, MemberRequest)>::new();
+        let mut deferred_targets = BTreeMap::<
+            SelectorTargetId,
+            (usize, MemberRequest, Option<SourceMatchGroupAssignment>),
+        >::new();
+        let mut source_match_candidates =
+            BTreeMap::<SelectorTargetId, Vec<source_match::MemberBindingMatch>>::new();
+        let mut source_match_errors = BTreeMap::<SelectorTargetId, String>::new();
+        let mut source_match_candidate_cache = BTreeMap::<
+            spec::AnonymousStatementSelector,
+            Result<Vec<source_match::MemberBindingMatch>, String>,
+        >::new();
+        let mut source_match_group_candidate_cache = BTreeMap::<
+            SourceMatchGroupCacheKey,
+            Result<Vec<source_match::MemberBindingGroupMatch>, String>,
+        >::new();
         let mut pending_constraints = Vec::<(String, String, spec::MemberSelectorSpec)>::new();
+        let mut facts =
+            selector_fact_store_for_chunk(chunk_id_interned, owner_graph, module, import_sources);
         for (index, request) in explicit_requests.iter().enumerate() {
-            for member in &request.members {
+            let group_assignments = source_match_group_assignments(request);
+            for (member_index, member) in request.members.iter().enumerate() {
                 let Some(selector) = member_selector_spec_for_global_solver(member) else {
                     continue;
                 };
@@ -1056,8 +1053,91 @@ impl ChunkPlanBuilder {
                     member.export_name.clone(),
                     selector,
                 ));
-                if member.is_relational() {
-                    relational_targets.insert(target, (index, member.clone()));
+                if member.is_relational() || member.source_match.is_some() {
+                    deferred_targets.insert(
+                        target,
+                        (
+                            index,
+                            member.clone(),
+                            group_assignments.get(&member_index).cloned(),
+                        ),
+                    );
+                }
+                if let Some(source_selector) = &member.source_match {
+                    let selector_key = source_match::selector_key(source_selector);
+                    let candidates = if let Some(group) = group_assignments.get(&member_index) {
+                        let target_binding = source_selector.target_binding.as_deref().with_context(|| {
+                            format!(
+                                "logical_module {}: binding-group member `{}` unexpectedly has no \
+                                 target_binding",
+                                request.id, member.export_name,
+                            )
+                        })?;
+                        let cache_key = SourceMatchGroupCacheKey::new(
+                            group.selector.clone(),
+                            &group.exports_by_target,
+                        );
+                        let group_candidates =
+                            match source_match_group_candidate_cache.get(&cache_key) {
+                                Some(cached) => cached.clone(),
+                                None => {
+                                    let resolved = selector_resolver
+                                        .member_group_candidates(
+                                            &request.id,
+                                            &group.selector,
+                                            &group.exports_by_target,
+                                        )
+                                        .map_err(|error| format!("{error:#}"));
+                                    source_match_group_candidate_cache
+                                        .insert(cache_key, resolved.clone());
+                                    resolved
+                                }
+                            };
+                        group_candidates.map(|groups| {
+                            groups
+                                .into_iter()
+                                .filter_map(|group| group.bindings.get(target_binding).cloned())
+                                .collect::<Vec<_>>()
+                        })
+                    } else {
+                        match source_match_candidate_cache.get(source_selector) {
+                            Some(cached) => cached.clone(),
+                            None => {
+                                let resolved = selector_resolver
+                                    .member_candidates(
+                                        &request.id,
+                                        &member.export_name,
+                                        source_selector,
+                                    )
+                                    .map_err(|error| format!("{error:#}"));
+                                source_match_candidate_cache
+                                    .insert(source_selector.clone(), resolved.clone());
+                                resolved
+                            }
+                        }
+                    };
+                    match candidates {
+                        Ok(candidates) => {
+                            for candidate in &candidates {
+                                facts.push(SelectorFact::SourceMatchCandidate {
+                                    chunk_id: chunk_id_interned,
+                                    selector_key: selector_key.clone(),
+                                    statement_ordinal: StatementOrdinal(
+                                        js_ast::statement_ordinal_for_body_index(
+                                            &module.body,
+                                            candidate.body_idx,
+                                        ),
+                                    ),
+                                    binding: candidate.binding.binding_name.clone(),
+                                });
+                            }
+                            source_match_candidates.insert(target, candidates);
+                        }
+                        Err(error) if self.keep_going => {
+                            source_match_errors.insert(target, error);
+                        }
+                        Err(error) => bail!("{error}"),
+                    }
                 }
             }
         }
@@ -1065,11 +1145,9 @@ impl ChunkPlanBuilder {
             builder.lower_member_constraints_in_module(&logical_module, &export_name, &selector)?;
         }
         let program = builder.into_program()?;
-        let facts =
-            selector_fact_store_for_chunk(chunk_id_interned, owner_graph, module, import_sources);
         let result = selector_ir_solver::solve(&program, &facts)?;
 
-        for (target, (index, member)) in relational_targets {
+        for (target, (index, member, group_assignment)) in deferred_targets {
             let request = &explicit_requests[index];
             match result.outcome_for(target) {
                 Some(ClaimOutcome::Unique { claim }) => {
@@ -1080,6 +1158,38 @@ impl ChunkPlanBuilder {
                             request.id, member.export_name, claim.owner,
                         )
                     })?;
+                    if source_match_candidates
+                        .get(&target)
+                        .and_then(|candidates| {
+                            candidates.iter().find(|candidate| {
+                                candidate.binding.binding_name == binding
+                                    && StatementOrdinal(js_ast::statement_ordinal_for_body_index(
+                                        &module.body,
+                                        candidate.body_idx,
+                                    )) == claim.statement_ordinal
+                            })
+                        })
+                        .is_some_and(|candidate| {
+                            matches!(
+                                candidate.binding.kind,
+                                Some(BindingSourceKind::ImportSpecifier)
+                            )
+                        })
+                    {
+                        self.claim_post_stage_a_imported_binding(
+                            request,
+                            &member,
+                            binding,
+                            index,
+                            chunk_top_level_mark,
+                            chunk_id,
+                            target_file,
+                            runtime_import_facts,
+                            imported_binding_resolver,
+                            imported_from_by_src,
+                        )?;
+                        continue;
+                    }
                     self.claim_post_stage_a_binding(
                         request,
                         &member,
@@ -1091,6 +1201,32 @@ impl ChunkPlanBuilder {
                     )?;
                 }
                 Some(ClaimOutcome::NoMatch) => {
+                    if let Some(message) = source_match_errors
+                        .get(&target)
+                        .cloned()
+                        .or_else(|| {
+                            source_match_resolution_error_message(
+                                selector_resolver,
+                                request,
+                                &member,
+                                group_assignment.as_ref(),
+                            )
+                        })
+                        .or_else(|| source_match_no_match_message(request, &member))
+                    {
+                        if self.keep_going {
+                            self.source_match_diagnostics
+                                .push(SourceMatchDiagnostic::new(
+                                    module,
+                                    &request.id,
+                                    &request.target_path,
+                                    &member,
+                                    message,
+                                ));
+                            continue;
+                        }
+                        bail!("{message}");
+                    }
                     bail!(
                         "logical_module {}: global selector solver found no match for relational \
                          member `{}` ({}): {:?}",
@@ -1101,6 +1237,32 @@ impl ChunkPlanBuilder {
                     );
                 }
                 Some(ClaimOutcome::Ambiguous { candidates }) => {
+                    if let Some(message) = source_match_resolution_error_message(
+                        selector_resolver,
+                        request,
+                        &member,
+                        group_assignment.as_ref(),
+                    )
+                    .or_else(|| {
+                        source_match_ambiguous_message(
+                            request,
+                            &member,
+                            source_match_candidates.get(&target).map(Vec::as_slice),
+                        )
+                    }) {
+                        if self.keep_going {
+                            self.source_match_diagnostics
+                                .push(SourceMatchDiagnostic::new(
+                                    module,
+                                    &request.id,
+                                    &request.target_path,
+                                    &member,
+                                    message,
+                                ));
+                            continue;
+                        }
+                        bail!("{message}");
+                    }
                     bail!(
                         "logical_module {}: global selector solver found {} candidates for \
                          relational member `{}` ({}): {:?}",
@@ -1906,6 +2068,87 @@ impl ChunkPlanBuilder {
     /// residual plan when the pre-Stage-A sweep ran, before this pass knew its
     /// identity.
     #[allow(clippy::too_many_arguments)]
+    fn claim_post_stage_a_imported_binding(
+        &mut self,
+        request: &LogicalRequest,
+        member: &MemberRequest,
+        binding: &str,
+        index: usize,
+        chunk_top_level_mark: swc_common::Mark,
+        chunk_id: &str,
+        target_file: &str,
+        runtime_import_facts: &RuntimeImportFacts,
+        imported_binding_resolver: &mut ArtifactSourceImportResolutionCache<'_>,
+        imported_from_by_src: &mut BTreeMap<String, String>,
+    ) -> Result<()> {
+        if let Some(existing_kind) = self.catalogue_index_by_name.get(binding) {
+            let duplicate =
+                self.duplicate_claim_for(existing_kind, binding, chunk_id, request, member);
+            if !self.keep_going {
+                bail!("{}", render_duplicate_binding_claims(&[duplicate]));
+            }
+            self.duplicate_binding_claims.push(duplicate);
+            return Ok(());
+        }
+        let (imported_name, imported_from) = resolve_imported_binding(
+            imported_binding_resolver,
+            runtime_import_facts,
+            chunk_id,
+            target_file,
+            binding,
+            imported_from_by_src,
+        )?;
+        let kind = BindingKind::Imported {
+            imported_name: imported_name.into(),
+            imported_from,
+            re_exporter: ModuleId(LogicalModuleIndex(index)),
+            public_name: member.export_name.as_str().into(),
+        };
+        self.catalogue_index_by_name
+            .insert(binding.to_string(), kind.clone());
+        self.bindings_catalogue
+            .insert(top_level_id(binding, chunk_top_level_mark), kind);
+        Ok(())
+    }
+
+    fn same_module_duplicate_source_binding_report(
+        &self,
+        existing_kind: &BindingKind,
+        binding: &str,
+        index: usize,
+        request: &LogicalRequest,
+        member: &MemberRequest,
+    ) -> Option<String> {
+        member.source_match.as_ref()?;
+        let BindingKind::Owned {
+            module: ModuleId(LogicalModuleIndex(owner_index)),
+        } = existing_kind
+        else {
+            return None;
+        };
+        if *owner_index != index {
+            return None;
+        }
+        let plan = self.module_plans.get(index)?;
+        let existing_export = plan.bindings.get(binding)?;
+        let existing_origin = plan
+            .binding_claim_origins
+            .get(binding)
+            .map(String::as_str)
+            .unwrap_or("<unknown origin>");
+        Some(format!(
+            "logical_module {} has duplicate source binding claims:\n- source binding `{}` \
+             claimed 2 times:\n  - export `{}` ({})\n  - export `{}` ({})",
+            request.id,
+            binding,
+            existing_export,
+            existing_origin,
+            member.export_name,
+            member.claim_origin,
+        ))
+    }
+
+    #[allow(clippy::too_many_arguments)]
     fn claim_post_stage_a_binding(
         &mut self,
         request: &LogicalRequest,
@@ -1932,6 +2175,15 @@ impl ChunkPlanBuilder {
         }
         let module_id = ModuleId(LogicalModuleIndex(index));
         if let Some(existing_kind) = self.catalogue_index_by_name.get(binding) {
+            if let Some(report) = self.same_module_duplicate_source_binding_report(
+                existing_kind,
+                binding,
+                index,
+                request,
+                member,
+            ) {
+                bail!("{report}");
+            }
             let duplicate =
                 self.duplicate_claim_for(existing_kind, binding, chunk_id, request, member);
             if !self.keep_going {

--- a/devinfra/js/debundle/lowering/plans.rs
+++ b/devinfra/js/debundle/lowering/plans.rs
@@ -162,30 +162,6 @@ impl MemberRequest {
         }
     }
 
-    pub(super) fn resolve_source_match(
-        &mut self,
-        resolver: &dyn source_match::SelectorResolver,
-        request_id: &str,
-        cache: &mut BTreeMap<spec::AnonymousStatementSelector, source_match::ResolvedMemberBinding>,
-    ) -> Result<()> {
-        let Some(selector) = self.source_match.clone() else {
-            return Ok(());
-        };
-        let resolved = match cache.get(&selector) {
-            Some(resolved) => resolved.clone(),
-            None => {
-                let resolved = resolver.resolve_member(request_id, &self.export_name, &selector)?;
-                cache.insert(selector, resolved.clone());
-                resolved
-            }
-        };
-        self.binding = resolved.binding_name;
-        self.is_import_specifier =
-            matches!(resolved.kind, Some(BindingSourceKind::ImportSpecifier));
-        self.source_match = None;
-        Ok(())
-    }
-
     /// Extend `hints` with this member's spec-level trust assertions
     /// (purity, pure_members, effect). Spec annotations carried on any
     /// member form (logical-module member, chunk_renames member)

--- a/devinfra/js/debundle/selector_ir.rs
+++ b/devinfra/js/debundle/selector_ir.rs
@@ -1,9 +1,8 @@
 //! Engine-facing selector IR and fact-store contract for the global selector
 //! solver.
 //!
-//! This module is intentionally additive. It gives `source_match` lowering,
-//! relational selector lowering, the Ascent solver, and materialization one
-//! shared vocabulary without changing the current resolver path.
+//! This module gives `source_match` lowering, relational selector lowering, the
+//! Ascent solver, and materialization one shared vocabulary.
 
 use std::collections::BTreeMap;
 use std::error::Error;
@@ -246,6 +245,10 @@ pub enum SelectorAtom {
         owner: OwnerTerm,
         property: StringTerm,
         referenced_by: OwnerTerm,
+    },
+    SourceMatchCandidate {
+        owner: OwnerTerm,
+        selector_key: StringTerm,
     },
     Equal {
         left: SelectorVariableId,
@@ -499,6 +502,13 @@ impl SelectorProgram {
                 self.validate_owner_term(owner, "intrinsic_alias.owner")?;
                 self.validate_string_term(property, "intrinsic_alias.property")?;
                 self.validate_owner_term(referenced_by, "intrinsic_alias.referenced_by")
+            }
+            SelectorAtom::SourceMatchCandidate {
+                owner,
+                selector_key,
+            } => {
+                self.validate_owner_term(owner, "source_match_candidate.owner")?;
+                self.validate_string_term(selector_key, "source_match_candidate.selector_key")
             }
             SelectorAtom::Equal { left, right } | SelectorAtom::NotEqual { left, right } => {
                 let left_domain = self.require_variable(*left, "equality.left")?;
@@ -779,6 +789,12 @@ pub enum SelectorFact {
         binding: String,
         property: String,
     },
+    SourceMatchCandidate {
+        chunk_id: ChunkId,
+        selector_key: String,
+        statement_ordinal: StatementOrdinal,
+        binding: String,
+    },
 }
 
 impl SelectorFact {
@@ -804,6 +820,7 @@ impl SelectorFact {
             Self::CallArgumentUse { .. } => "call_argument_use",
             Self::DecorateCallUse { .. } => "decorate_call_use",
             Self::IntrinsicAliasUse { .. } => "intrinsic_alias_use",
+            Self::SourceMatchCandidate { .. } => "source_match_candidate",
         }
     }
 }

--- a/devinfra/js/debundle/selector_ir_lowering.rs
+++ b/devinfra/js/debundle/selector_ir_lowering.rs
@@ -1,9 +1,7 @@
 //! Lower existing debundle selector specs into the global selector IR.
 //!
-//! Binding selectors and the current relational selector primitives lower into
-//! one joint program. Raw `source_match` AST patterns still fail closed here;
-//! the materializer cutover feeds already resolved source matches into the
-//! joint solver as binding constraints until AST-pattern lowering lands.
+//! Binding selectors, `source_match` selectors, and the current relational
+//! selector primitives lower into one joint program.
 
 use std::collections::BTreeMap;
 use std::error::Error;
@@ -95,13 +93,6 @@ impl MemberSelectorProgramBuilder {
         export_name: &str,
         selector: &MemberSelectorSpec,
     ) -> Result<SelectorTargetId, SelectorIrLoweringError> {
-        if matches!(selector, MemberSelectorSpec::SourceMatch(_)) {
-            return Err(SelectorIrLoweringError::unsupported(
-                selector.selector_kind_label(),
-                "source_match requires AST-pattern lowering and differential parity",
-            ));
-        }
-
         let logical_module = logical_module.into();
         let owner = self.owner_for_local_export(&logical_module, export_name);
         self.targeted_owners
@@ -131,12 +122,6 @@ impl MemberSelectorProgramBuilder {
         export_name: &str,
         selector: &MemberSelectorSpec,
     ) -> Result<(), SelectorIrLoweringError> {
-        if matches!(selector, MemberSelectorSpec::SourceMatch(_)) {
-            return Err(SelectorIrLoweringError::unsupported(
-                selector.selector_kind_label(),
-                "source_match requires AST-pattern lowering and differential parity",
-            ));
-        }
         let owner = self.owner_for_local_export(logical_module, export_name);
         self.lower_selector_atoms(logical_module, owner, selector)
     }
@@ -206,7 +191,13 @@ impl MemberSelectorProgramBuilder {
     ) -> Result<(), SelectorIrLoweringError> {
         match selector {
             MemberSelectorSpec::Binding(binding) => self.lower_binding_selector(owner, binding),
-            MemberSelectorSpec::SourceMatch(_) => unreachable!("source_match rejected earlier"),
+            MemberSelectorSpec::SourceMatch(selector) => {
+                self.program.add_atom(SelectorAtom::SourceMatchCandidate {
+                    owner: owner_term(owner),
+                    selector_key: const_str(&source_match::selector_key(selector)),
+                });
+                Ok(())
+            }
             MemberSelectorSpec::CrossRef(target) => {
                 let anchor = self.owner_for_global_export(&target.anchor)?;
                 match target.relation {
@@ -524,21 +515,24 @@ mod tests {
     }
 
     #[test]
-    fn source_match_fails_closed_until_ast_lowering_lands() {
-        let error = lower_member_selector(
+    fn lowers_source_match_candidate_constraint() {
+        let selector = AnonymousStatementSelector::exact("const a = 1;");
+        let lowered = lower_member_selector(
             &context(),
             "Widget",
-            &MemberSelectorSpec::SourceMatch(AnonymousStatementSelector::exact("const a = 1;")),
+            &MemberSelectorSpec::SourceMatch(selector.clone()),
         )
-        .unwrap_err();
+        .unwrap();
 
-        assert_eq!(
-            error,
-            SelectorIrLoweringError::Unsupported {
-                selector_kind: "source_match",
-                reason: "source_match requires AST-pattern lowering and differential parity",
-            }
-        );
+        let target_owner = lowered.program.targets[lowered.target.0].owner;
+        assert_eq!(lowered.program.atoms.len(), 1);
+        assert!(matches!(
+            &lowered.program.atoms[0],
+            SelectorAtom::SourceMatchCandidate {
+                owner: OwnerTerm::Var { id },
+                selector_key: StringTerm::Const { value },
+            } if *id == target_owner && value == &source_match::selector_key(&selector)
+        ));
     }
 
     #[test]

--- a/devinfra/js/debundle/selector_ir_solver.rs
+++ b/devinfra/js/debundle/selector_ir_solver.rs
@@ -3,8 +3,9 @@
 //! The solver runs one Ascent derivation over the lowered selector constraints
 //! plus chunk-level owner/fact-store relations, then projects target claims from
 //! the derived candidate sets. It supports binding/name/kind constraints and
-//! the current relational selector primitives. Unsupported atoms remain explicit
-//! `ClaimOutcome::Unsupported` rows instead of being ignored or approximated.
+//! `source_match` candidate constraints, and the current relational selector
+//! primitives. Unsupported atoms remain explicit `ClaimOutcome::Unsupported` rows
+//! instead of being ignored or approximated.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
@@ -47,6 +48,7 @@ ascent! {
     relation call_arg_from(String, String, String, u32); // argument, callee object, member, index
     relation decorate_call(String, String, Option<String>); // callee, class binding, member
     relation intrinsic_alias(String, String); // binding, Object property
+    relation source_match_candidate(String, usize, String); // selector key, owner, matched binding
 
     relation name_owner(String, usize);
     name_owner(binding.clone(), *owner) <-- declares(owner, binding);
@@ -119,6 +121,7 @@ ascent! {
     relation required_passed_to_call(usize, usize, String, Option<u32>);
     relation required_passed_to_call_from_binding(usize, usize, String, String, Option<u32>);
     relation required_makes_decorate_call_for_binding(usize, usize, String, Option<String>);
+    relation required_source_match_candidate(usize, usize, String);
 
     relation constraint_support(usize, usize, usize); // constraint id, variable id, owner
     constraint_support(*constraint, *var, *owner) <--
@@ -173,6 +176,10 @@ ascent! {
         declares(owner, _declared),
         if actual_class_anchor == class_anchor,
         if optional_string_matches(member, actual_member);
+    constraint_support(*constraint, *var, *owner) <--
+        required_source_match_candidate(constraint, var, selector_key),
+        source_match_candidate(selector_key, owner, _binding),
+        owner_fact(owner, _ordinal, _kind);
 
     relation required_references_owner(usize, usize, usize);
     relation required_aliases_owner(usize, usize, usize);
@@ -278,6 +285,11 @@ pub fn solve(
             .intrinsic_alias
             .push((binding.clone(), property.clone()));
     }
+    for (selector_key, owner, binding) in &fact_index.source_match_candidates {
+        ascent
+            .source_match_candidate
+            .push((selector_key.clone(), owner.0, binding.clone()));
+    }
     for constraint in &support.unary_constraints {
         match &constraint.kind {
             UnaryConstraintKind::Binding { binding } => ascent.required_binding.push((
@@ -353,6 +365,13 @@ pub fn solve(
                 class_anchor.clone(),
                 member.clone(),
             )),
+            UnaryConstraintKind::SourceMatchCandidate { selector_key } => {
+                ascent.required_source_match_candidate.push((
+                    constraint.id,
+                    constraint.variable.0,
+                    selector_key.clone(),
+                ));
+            }
         }
     }
     for constraint in &support.binary_constraints {
@@ -554,10 +573,18 @@ fn classify_candidates(
     facts: &FactIndex,
     support: &ProgramSupport,
 ) -> ClaimOutcome {
-    let claims: Vec<ResolvedClaim> = candidates
-        .into_iter()
-        .filter_map(|owner| resolved_claim(target, owner, facts, support))
-        .collect();
+    let claims: Vec<ResolvedClaim> =
+        if let Some(selector_key) = support.source_match_selector_for(target.owner) {
+            candidates
+                .into_iter()
+                .flat_map(|owner| resolved_source_match_claims(target, owner, facts, &selector_key))
+                .collect()
+        } else {
+            candidates
+                .into_iter()
+                .filter_map(|owner| resolved_claim(target, owner, facts, support))
+                .collect()
+        };
     match claims.as_slice() {
         [] => ClaimOutcome::NoMatch,
         [claim] => ClaimOutcome::Unique {
@@ -565,6 +592,28 @@ fn classify_candidates(
         },
         _ => ClaimOutcome::Ambiguous { candidates: claims },
     }
+}
+
+fn resolved_source_match_claims(
+    target: &SelectorTarget,
+    owner: OwnerId,
+    facts: &FactIndex,
+    selector_key: &str,
+) -> Vec<ResolvedClaim> {
+    let Some(statement_ordinal) = facts.statement_ordinal_by_owner.get(&owner).copied() else {
+        return Vec::new();
+    };
+    facts
+        .source_match_bindings_for_owner(selector_key, owner)
+        .into_iter()
+        .map(|binding| ResolvedClaim {
+            chunk_id: target.chunk_id,
+            owner,
+            statement_ordinal,
+            binding: Some(binding),
+            provenance: Vec::new(),
+        })
+        .collect()
 }
 
 fn resolved_claim(
@@ -579,9 +628,14 @@ fn resolved_claim(
         owner,
         statement_ordinal,
         binding: support.binding_constraint_for(target.owner).or_else(|| {
-            facts
-                .single_binding_for_owner(owner)
-                .map(ToString::to_string)
+            support
+                .source_match_selector_for(target.owner)
+                .and_then(|selector_key| facts.source_match_binding_for_owner(&selector_key, owner))
+                .or_else(|| {
+                    facts
+                        .single_binding_for_owner(owner)
+                        .map(ToString::to_string)
+                })
         }),
         provenance: Vec::new(),
     })
@@ -812,6 +866,15 @@ impl ProgramSupport {
                         property: value.clone(),
                     },
                 ),
+                SelectorAtom::SourceMatchCandidate {
+                    owner: OwnerTerm::Var { id },
+                    selector_key: StringTerm::Const { value },
+                } => support.add_unary(
+                    *id,
+                    UnaryConstraintKind::SourceMatchCandidate {
+                        selector_key: value.clone(),
+                    },
+                ),
                 unsupported => support.unsupported_atoms.push(format!(
                     "unsupported selector atom `{}`",
                     atom_kind(unsupported)
@@ -877,6 +940,25 @@ impl ProgramSupport {
             })
             .next()
     }
+
+    fn source_match_selector_for(&self, variable: SelectorVariableId) -> Option<String> {
+        self.unary_constraints_by_var
+            .get(&variable)?
+            .iter()
+            .filter_map(|constraint_id| {
+                let constraint = self
+                    .unary_constraints
+                    .iter()
+                    .find(|constraint| constraint.id == *constraint_id)?;
+                match &constraint.kind {
+                    UnaryConstraintKind::SourceMatchCandidate { selector_key } => {
+                        Some(selector_key.clone())
+                    }
+                    _ => None,
+                }
+            })
+            .next()
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -924,6 +1006,9 @@ enum UnaryConstraintKind {
     MakesDecorateCallForBinding {
         class_anchor: String,
         member: Option<String>,
+    },
+    SourceMatchCandidate {
+        selector_key: String,
     },
 }
 
@@ -989,6 +1074,7 @@ fn atom_kind(atom: &SelectorAtom) -> &'static str {
         SelectorAtom::MakesDecorateCall { .. } => "makes_decorate_call",
         SelectorAtom::MakesDecorateCallForOwner { .. } => "makes_decorate_call_for_owner",
         SelectorAtom::IntrinsicAlias { .. } => "intrinsic_alias",
+        SelectorAtom::SourceMatchCandidate { .. } => "source_match_candidate",
         SelectorAtom::Equal { .. } => "equal",
         SelectorAtom::NotEqual { .. } => "not_equal",
     }
@@ -1011,6 +1097,7 @@ struct FactIndex {
     call_arguments_from: Vec<(String, String, String, usize)>,
     decorate_calls: Vec<(String, String, Option<String>)>,
     intrinsic_aliases: Vec<(String, String)>,
+    source_match_candidates: Vec<(String, OwnerId, String)>,
 }
 
 impl FactIndex {
@@ -1135,6 +1222,20 @@ impl FactIndex {
                         .intrinsic_aliases
                         .push((binding.clone(), property.clone()));
                 }
+                SelectorFact::SourceMatchCandidate {
+                    selector_key,
+                    statement_ordinal,
+                    binding,
+                    ..
+                } => {
+                    if let Some(owner) = index.owner_by_statement_ordinal.get(statement_ordinal) {
+                        index.source_match_candidates.push((
+                            selector_key.clone(),
+                            *owner,
+                            binding.clone(),
+                        ));
+                    }
+                }
                 _ => {}
             }
         }
@@ -1148,6 +1249,33 @@ impl FactIndex {
             return None;
         }
         Some(binding)
+    }
+
+    fn source_match_binding_for_owner(&self, selector_key: &str, owner: OwnerId) -> Option<String> {
+        let mut matches = self
+            .source_match_candidates
+            .iter()
+            .filter(|(candidate_key, candidate_owner, _binding)| {
+                candidate_key == selector_key && *candidate_owner == owner
+            })
+            .map(|(_key, _owner, binding)| binding.clone());
+        let binding = matches.next()?;
+        if matches.next().is_some() {
+            return None;
+        }
+        Some(binding)
+    }
+
+    fn source_match_bindings_for_owner(&self, selector_key: &str, owner: OwnerId) -> Vec<String> {
+        self.source_match_candidates
+            .iter()
+            .filter(|(candidate_key, candidate_owner, _binding)| {
+                candidate_key == selector_key && *candidate_owner == owner
+            })
+            .map(|(_key, _owner, binding)| binding.clone())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect()
     }
 }
 

--- a/devinfra/js/debundle/source_match/datalog_resolver.rs
+++ b/devinfra/js/debundle/source_match/datalog_resolver.rs
@@ -641,13 +641,13 @@ fn resolve_anonymous_multi(
 /// DECLARATORS_GAP = null, b = …, DECLARATORS_AFTER = null;`): one plain
 /// (un-prebound) declarator alignment per candidate owner yields every target's
 /// declarator at once.
-fn resolve_group_declarator_holes(
+fn group_matches_declarator_holes(
     chunk: &ChunkResolver,
     needle: &ModuleItem,
     request_id: &str,
     selector: &AnonymousStatementSelector,
     exports_by_target: &BTreeMap<String, String>,
-) -> Result<ResolvedMemberBindingGroup> {
+) -> Result<Vec<MemberBindingGroupMatch>> {
     let needle_var = item_var_decl(needle).ok_or_else(|| {
         anyhow::anyhow!(
             "datalog resolver: declarator-hole group needle is not a variable declaration"
@@ -666,7 +666,7 @@ fn resolve_group_declarator_holes(
     let mode = selector_mode(selector);
     selector_match::var_declarator_alignment_indexed(&needle_index, &needle_index, mode, None)
         .map_err(|unsupported| anyhow::anyhow!("datalog resolver: {}", unsupported.reason))?;
-    let mut matches: Vec<(usize, BTreeMap<String, ResolvedMemberBinding>)> = Vec::new();
+    let mut matches: Vec<MemberBindingGroupMatch> = Vec::new();
     // No prebind here (the alignment runs un-prebound), so an exact-mode needle may
     // require its pinned-declarator identifier spellings; `DECLARATORS`-hole
     // declarator idents are absorbed and excluded by `needle_required_tokens`.
@@ -702,24 +702,24 @@ fn resolve_group_declarator_holes(
             else {
                 bail!("datalog resolver: target `{target}` binding index out of range");
             };
-            resolved.insert(target.clone(), binding);
+            resolved.insert(target.clone(), MemberBindingMatch { body_idx, binding });
         }
-        matches.push((body_idx, resolved));
+        matches.push(MemberBindingGroupMatch { bindings: resolved });
     }
-    one_group_match(matches, request_id)
+    Ok(matches)
 }
 
 /// Binding-group branch 1 — a single-statement single-declarator needle: match
 /// the declarator across every owner's declarators (a target inside a
 /// multi-declarator owner is found), reading each target's binding from the one
 /// matched declarator.
-fn resolve_group_single_declarator(
+fn group_matches_single_declarator(
     chunk: &ChunkResolver,
     needle: &ModuleItem,
     request_id: &str,
     selector: &AnonymousStatementSelector,
     exports_by_target: &BTreeMap<String, String>,
-) -> Result<ResolvedMemberBindingGroup> {
+) -> Result<Vec<MemberBindingGroupMatch>> {
     let declared = declared_bindings(needle);
     let target_binding_indices: BTreeMap<String, usize> = exports_by_target
         .keys()
@@ -749,7 +749,7 @@ fn resolve_group_single_declarator(
     let mode = selector_mode(selector);
     selector_match::matches_indexed(&needle_index, &needle_index, mode)
         .map_err(|unsupported| anyhow::anyhow!("datalog resolver: {}", unsupported.reason))?;
-    let mut matches: Vec<(usize, BTreeMap<String, ResolvedMemberBinding>)> = Vec::new();
+    let mut matches: Vec<MemberBindingGroupMatch> = Vec::new();
     // No prebind (the declarator match is un-prebound); an exact-mode needle may
     // require its identifier spellings.
     for subject_idx in chunk.candidate_declarators(&needle_index, mode, true) {
@@ -773,23 +773,29 @@ fn resolve_group_single_declarator(
             let Some(binding) = declarator_bindings.get(*target_binding_idx) else {
                 bail!("datalog resolver: target `{target}` binding index out of range");
             };
-            resolved.insert(target.clone(), binding.clone());
+            resolved.insert(
+                target.clone(),
+                MemberBindingMatch {
+                    body_idx: subject.body_idx,
+                    binding: binding.clone(),
+                },
+            );
         }
-        matches.push((subject.body_idx, resolved));
+        matches.push(MemberBindingGroupMatch { bindings: resolved });
     }
-    one_group_match(matches, request_id)
+    Ok(matches)
 }
 
 /// Binding-group branch 3 — a general (multi-statement or non-var) needle: a
 /// single top-level sequence alignment supplies every target's owner statement,
 /// read by declared-binding index.
-fn resolve_group_general(
+fn group_matches_general(
     chunk: &ChunkResolver,
     needles: &[ModuleItem],
     request_id: &str,
     selector: &AnonymousStatementSelector,
     exports_by_target: &BTreeMap<String, String>,
-) -> Result<ResolvedMemberBindingGroup> {
+) -> Result<Vec<MemberBindingGroupMatch>> {
     let target_locations: BTreeMap<String, (usize, usize)> = exports_by_target
         .keys()
         .map(|target| {
@@ -812,48 +818,55 @@ fn resolve_group_general(
         selector_mode(selector),
     )
     .map_err(|unsupported| anyhow::anyhow!("datalog resolver: {}", unsupported.reason))?;
-    let alignment = match alignments.as_slice() {
-        [single] => single,
-        [] => bail!(
-            "logical_module {request_id}: binding_groups[].source_match did not match any \
-             top-level declaration range"
-        ),
-        multiple => bail!(
-            "logical_module {request_id}: binding_groups[].source_match is ambiguous — {} ranges",
-            multiple.len(),
-        ),
-    };
-    let mut resolved = BTreeMap::new();
-    for (target, (target_item_idx, target_binding_idx)) in &target_locations {
-        let Some(Some(body_idx)) = alignment.get(*target_item_idx) else {
-            bail!(
-                "logical_module {request_id}: binding_groups[].source_match target_binding \
-                 `{target}` was matched by a STMT_LIST hole, not a pinned statement"
+    let mut matches = Vec::new();
+    for alignment in alignments {
+        let mut resolved = BTreeMap::new();
+        for (target, (target_item_idx, target_binding_idx)) in &target_locations {
+            let Some(Some(body_idx)) = alignment.get(*target_item_idx) else {
+                bail!(
+                    "logical_module {request_id}: binding_groups[].source_match target_binding \
+                     `{target}` was matched by a STMT_LIST hole, not a pinned statement"
+                );
+            };
+            let Some(binding) = declared_bindings(&chunk.module.body[*body_idx])
+                .into_iter()
+                .nth(*target_binding_idx)
+            else {
+                bail!("datalog resolver: target `{target}` binding index out of range");
+            };
+            resolved.insert(
+                target.clone(),
+                MemberBindingMatch {
+                    body_idx: *body_idx,
+                    binding,
+                },
             );
-        };
-        let Some(binding) = declared_bindings(&chunk.module.body[*body_idx])
-            .into_iter()
-            .nth(*target_binding_idx)
-        else {
-            bail!("datalog resolver: target `{target}` binding index out of range");
-        };
-        resolved.insert(target.clone(), binding);
+        }
+        matches.push(MemberBindingGroupMatch { bindings: resolved });
     }
-    Ok(ResolvedMemberBindingGroup {
-        body_idx: alignment.iter().flatten().copied().next().unwrap_or(0),
-        bindings: resolved,
-    })
+    Ok(matches)
 }
 
 /// Owner-level categoricity for the per-owner group branches: exactly one owner
 /// must match (production rejects zero or several).
 fn one_group_match(
-    mut matches: Vec<(usize, BTreeMap<String, ResolvedMemberBinding>)>,
+    mut matches: Vec<MemberBindingGroupMatch>,
     request_id: &str,
 ) -> Result<ResolvedMemberBindingGroup> {
     match matches.len() {
         1 => {
-            let (body_idx, bindings) = matches.remove(0);
+            let match_ = matches.remove(0);
+            let body_idx = match_
+                .bindings
+                .values()
+                .map(|binding| binding.body_idx)
+                .min()
+                .unwrap_or(0);
+            let bindings = match_
+                .bindings
+                .into_iter()
+                .map(|(target, matched)| (target, matched.binding))
+                .collect();
             Ok(ResolvedMemberBindingGroup { body_idx, bindings })
         }
         0 => bail!(
@@ -931,12 +944,7 @@ fn member_matches_single_statement(
 }
 
 impl ChunkResolver<'_> {
-    /// The non-categorical member match list. Shares the per-path match collection
-    /// with [`SelectorResolver::resolve_member`]; the only difference is this
-    /// returns the whole list (each carrying `body_idx` + binding) instead of
-    /// collapsing to the unique winner. Used by cross-source consumers that
-    /// aggregate matches before deciding uniqueness (the CLI edit gate).
-    pub fn member_candidates(
+    fn collect_member_candidates(
         &self,
         request_id: &str,
         selector: &AnonymousStatementSelector,
@@ -956,21 +964,94 @@ impl ChunkResolver<'_> {
         member_matches_single_statement(self, needle, request_id, selector)
     }
 
-    /// Member-level categoricity: exactly one candidate must match (production
-    /// rejects zero or several). The single place the `[single]/[]/multiple`
-    /// collapse lives, mirroring [`one_group_match`]. On zero/several it produces
-    /// the diagnostic the keep-going report and the failing-run stderr surface:
-    /// the `target_binding` hint, the selector source echo, the matched body
-    /// indices + bindings (ambiguous), and the scored near-miss candidate framing
-    /// (no-match) — the fact-path equivalent of the deleted matcher's
-    /// `resolve_member_binding` bail. `body_idx` is otherwise discarded; only the
-    /// claimed binding is the categorical answer.
+    /// The non-categorical member match list. Shares the per-path match collection
+    /// with [`SelectorResolver::resolve_member`]; the only difference is this
+    /// returns the whole list (each carrying `body_idx` + binding) instead of
+    /// collapsing to the unique winner. Used by cross-source consumers that
+    /// aggregate matches before deciding uniqueness (the CLI edit gate).
+    pub fn member_candidates(
+        &self,
+        request_id: &str,
+        selector: &AnonymousStatementSelector,
+    ) -> Result<Vec<MemberBindingMatch>> {
+        self.collect_member_candidates(request_id, selector)
+    }
+
+    fn member_candidates_with_timing(
+        &self,
+        request_id: &str,
+        export_name: &str,
+        selector: &AnonymousStatementSelector,
+    ) -> Result<Vec<MemberBindingMatch>> {
+        let (matches, elapsed) =
+            time_source_match(|| self.collect_member_candidates(request_id, selector));
+        let matches = matches?;
+        if source_match_timings_enabled() {
+            let body_indices: Vec<usize> = matches.iter().map(|m| m.body_idx).collect();
+            let binding = match matches.as_slice() {
+                [single] => single.binding.binding_name.as_str(),
+                _ => "<unresolved>",
+            };
+            emit_source_match_timing(
+                &format!("members[].selector.source_match export=`{export_name}`"),
+                request_id,
+                selector,
+                elapsed,
+                &format!("body_indices={body_indices:?} binding={binding}"),
+            );
+        }
+        Ok(matches)
+    }
+
+    fn member_group_candidates_impl(
+        &self,
+        request_id: &str,
+        selector: &AnonymousStatementSelector,
+        exports_by_target: &BTreeMap<String, String>,
+    ) -> Result<Vec<MemberBindingGroupMatch>> {
+        if selector.target_binding.is_some() {
+            bail!(
+                "datalog resolver: binding-group selector for {request_id} unexpectedly has \
+                 target_binding set"
+            );
+        }
+        let needles = parse_needles(request_id, selector)?;
+        let [first, ..] = needles.as_slice() else {
+            bail!(
+                "logical_module {request_id}: binding_groups[].source_match parsed to zero \
+                 statements"
+            );
+        };
+        // Branch order mirrors `resolve_member_group`: single-declarator before
+        // declarator-holes, then the general sequence path.
+        if needles.len() == 1 && selector_single_var_declarator(first).is_some() {
+            return group_matches_single_declarator(
+                self,
+                first,
+                request_id,
+                selector,
+                exports_by_target,
+            );
+        }
+        if needles.len() == 1 && selector_var_decl_has_declarator_holes(first) {
+            return group_matches_declarator_holes(
+                self,
+                first,
+                request_id,
+                selector,
+                exports_by_target,
+            );
+        }
+        group_matches_general(self, &needles, request_id, selector, exports_by_target)
+    }
+
     fn collapse_member_match(
         &self,
         matches: Vec<MemberBindingMatch>,
         request_id: &str,
         export_name: &str,
         selector: &AnonymousStatementSelector,
+        selector_label: &'static str,
     ) -> Result<ResolvedMemberBinding> {
         let target_binding_hint = selector
             .target_binding
@@ -984,16 +1065,15 @@ impl ChunkResolver<'_> {
                 let hint =
                     fact_source_match_no_match_hint(self.module, selector).unwrap_or_default();
                 bail!(
-                    "logical_module {request_id}: members[].selector.source_match for export \
-                     `{export_name}`{target_binding_hint} did not match any top-level declaration \
-                     in the chunk. Selector:\n{match_source}{hint}"
+                    "logical_module {request_id}: {selector_label} for export `{export_name}`\
+                     {target_binding_hint} did not match any top-level declaration in the chunk. \
+                     Selector:\n{match_source}{hint}"
                 )
             }
             multiple => bail!(
-                "logical_module {request_id}: members[].selector.source_match for export \
-                 `{export_name}`{target_binding_hint} is ambiguous — matched {} top-level \
-                 statements at body indices {:?} (bindings: {}). Refine the selector. \
-                 Source:\n{match_source}",
+                "logical_module {request_id}: {selector_label} for export `{export_name}`\
+                 {target_binding_hint} is ambiguous — matched {} top-level statements at body \
+                 indices {:?} (bindings: {}). Refine the selector. Source:\n{match_source}",
                 multiple.len(),
                 multiple.iter().map(|m| m.body_idx).collect::<Vec<_>>(),
                 multiple
@@ -1007,11 +1087,12 @@ impl ChunkResolver<'_> {
 }
 
 impl SelectorResolver for ChunkResolver<'_> {
-    fn resolve_member(
+    fn resolve_member_with_label(
         &self,
         request_id: &str,
         export_name: &str,
         selector: &AnonymousStatementSelector,
+        selector_label: &'static str,
     ) -> Result<ResolvedMemberBinding> {
         let needles = parse_needles(request_id, selector)?;
         let (matches, elapsed) = time_source_match(|| match needles.as_slice() {
@@ -1038,14 +1119,32 @@ impl SelectorResolver for ChunkResolver<'_> {
                 _ => "<unresolved>",
             };
             emit_source_match_timing(
-                &format!("members[].selector.source_match export=`{export_name}`"),
+                &format!("{selector_label} export=`{export_name}`"),
                 request_id,
                 selector,
                 elapsed,
                 &format!("body_indices={body_indices:?} binding={binding}"),
             );
         }
-        self.collapse_member_match(matches, request_id, export_name, selector)
+        self.collapse_member_match(matches, request_id, export_name, selector, selector_label)
+    }
+
+    fn member_candidates(
+        &self,
+        request_id: &str,
+        export_name: &str,
+        selector: &AnonymousStatementSelector,
+    ) -> Result<Vec<MemberBindingMatch>> {
+        self.member_candidates_with_timing(request_id, export_name, selector)
+    }
+
+    fn member_group_candidates(
+        &self,
+        request_id: &str,
+        selector: &AnonymousStatementSelector,
+        exports_by_target: &BTreeMap<String, String>,
+    ) -> Result<Vec<MemberBindingGroupMatch>> {
+        self.member_group_candidates_impl(request_id, selector, exports_by_target)
     }
 
     fn resolve_member_group(
@@ -1070,24 +1169,33 @@ impl SelectorResolver for ChunkResolver<'_> {
         // Branch order: single-declarator before declarator-holes (a lone hole
         // declarator is single-declarator too), then the general sequence path.
         if needles.len() == 1 && selector_single_var_declarator(first).is_some() {
-            return resolve_group_single_declarator(
-                self,
-                first,
+            return one_group_match(
+                group_matches_single_declarator(
+                    self,
+                    first,
+                    request_id,
+                    selector,
+                    exports_by_target,
+                )?,
                 request_id,
-                selector,
-                exports_by_target,
             );
         }
         if needles.len() == 1 && selector_var_decl_has_declarator_holes(first) {
-            return resolve_group_declarator_holes(
-                self,
-                first,
+            return one_group_match(
+                group_matches_declarator_holes(
+                    self,
+                    first,
+                    request_id,
+                    selector,
+                    exports_by_target,
+                )?,
                 request_id,
-                selector,
-                exports_by_target,
             );
         }
-        resolve_group_general(self, &needles, request_id, selector, exports_by_target)
+        one_group_match(
+            group_matches_general(self, &needles, request_id, selector, exports_by_target)?,
+            request_id,
+        )
     }
 
     fn resolve_anonymous_groups(

--- a/devinfra/js/debundle/source_match/mod.rs
+++ b/devinfra/js/debundle/source_match/mod.rs
@@ -82,6 +82,6 @@ pub(crate) use fact_near_miss::fact_source_match_no_match_hint;
 pub use resolver::SelectorResolver;
 pub use timing::{selector_body_key, selector_key, source_match_preview};
 pub use types::{
-    BindingGroupMemberSelector, MemberBindingMatch, ResolvedMemberBinding,
+    BindingGroupMemberSelector, MemberBindingGroupMatch, MemberBindingMatch, ResolvedMemberBinding,
     ResolvedMemberBindingGroup, SourceMatchBodyDebt, SourceMatchNearMiss,
 };

--- a/devinfra/js/debundle/source_match/resolver.rs
+++ b/devinfra/js/debundle/source_match/resolver.rs
@@ -27,7 +27,47 @@ pub trait SelectorResolver {
         request_id: &str,
         export_name: &str,
         selector: &AnonymousStatementSelector,
+    ) -> Result<ResolvedMemberBinding> {
+        self.resolve_member_with_label(
+            request_id,
+            export_name,
+            selector,
+            "members[].selector.source_match",
+        )
+    }
+
+    /// Resolve a member-shaped selector while rendering diagnostics under a
+    /// caller-provided spec path. Binding-group diagnostics use this to preserve
+    /// the same near-miss detail as member selectors without lying about origin.
+    fn resolve_member_with_label(
+        &self,
+        request_id: &str,
+        export_name: &str,
+        selector: &AnonymousStatementSelector,
+        selector_label: &'static str,
     ) -> Result<ResolvedMemberBinding>;
+
+    /// Enumerate every candidate a single-member `source_match` selector matches
+    /// without collapsing to unique/no-match/ambiguous. The global selector solver
+    /// consumes these rows as EDB facts, then performs final claim classification
+    /// together with the rest of the selector program.
+    fn member_candidates(
+        &self,
+        request_id: &str,
+        export_name: &str,
+        selector: &AnonymousStatementSelector,
+    ) -> Result<Vec<MemberBindingMatch>>;
+
+    /// Enumerate every candidate alignment for a binding-group `source_match`
+    /// selector without collapsing to unique/no-match/ambiguous. Each candidate
+    /// carries per-target body indices so the global selector solver can claim
+    /// the actual owner of every exported binding.
+    fn member_group_candidates(
+        &self,
+        request_id: &str,
+        selector: &AnonymousStatementSelector,
+        exports_by_target: &BTreeMap<String, String>,
+    ) -> Result<Vec<MemberBindingGroupMatch>>;
 
     /// Resolve a binding-group `source_match` selector to its per-target
     /// bindings (selector-local target binding → matched binding).

--- a/devinfra/js/debundle/source_match/types.rs
+++ b/devinfra/js/debundle/source_match/types.rs
@@ -27,6 +27,11 @@ pub struct MemberBindingMatch {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
+pub struct MemberBindingGroupMatch {
+    pub bindings: BTreeMap<String, MemberBindingMatch>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ResolvedMemberBindingGroup {
     pub body_idx: usize,
     pub bindings: BTreeMap<String, ResolvedMemberBinding>,


### PR DESCRIPTION
## Summary
- Lower `source_match` selectors into the selector IR as source-match candidate constraints instead of resolving them before Stage A.
- Feed member and binding-group `source_match` candidate facts into the single Ascent solver pass, preserving binding-group shared alignment and per-target owner locations.
- Keep rich resolver diagnostics/timing for source_match failures while moving successful claims to the post-Stage-A global selector claiming path, including imported binding claims.

## Notes
- Follow-up to the now-merged #2433 relational selector cutover.
- Same-module source_match duplicate reports keep the existing duplicate source-binding wording; cross-module duplicates still use the normal duplicate binding claim report.

## Tests
- `git diff --check origin/devel..HEAD`
- `nix develop --command rustfmt devinfra/js/debundle/selector_ir.rs devinfra/js/debundle/selector_ir_lowering.rs devinfra/js/debundle/selector_ir_solver.rs devinfra/js/debundle/source_match/datalog_resolver.rs devinfra/js/debundle/source_match/resolver.rs devinfra/js/debundle/source_match/types.rs devinfra/js/debundle/source_match/mod.rs devinfra/js/debundle/lowering/materialize/mod.rs devinfra/js/debundle/lowering/materialize/plan_builder.rs devinfra/js/debundle/lowering/plans.rs`
- `nix develop --command buildifier devinfra/js/debundle/BUILD.bazel`
- `nix develop --command bazelisk --output_base=/tmp/ducktape-global-solver-g4-bazel test //devinfra/js/debundle:source_match_test //devinfra/js/debundle:selector_ir_test //devinfra/js/debundle:selector_ir_lowering_test //devinfra/js/debundle:selector_ir_solver_test //devinfra/js/debundle/e2e:cross_ref_lowering_test //devinfra/js/debundle/e2e:reads_member_lowering_test //devinfra/js/debundle/e2e:member_of_module_lowering_test //devinfra/js/debundle/e2e:passed_to_call_lowering_test //devinfra/js/debundle/e2e:makes_decorate_call_lowering_test //devinfra/js/debundle/e2e:intrinsic_alias_lowering_test //devinfra/js/debundle/e2e:anonymous_statement_test //devinfra/js/debundle/e2e:syntactic_holes_test //devinfra/js/debundle/e2e:cross_module_emission_test //devinfra/js/debundle/e2e:selector_diagnostics_report_test //devinfra/js/debundle/e2e:spec_validate_cli_test //devinfra/js/debundle/e2e:module_merge_test`

BuildBuddy invocation for the rebased full focused run: `f2036ec4-e0cf-43c4-9683-0deb178a4b23`.