### PR TITLE
haku: allow Anthropic work-queue egress for the managed_agent worker

### DIFF
--- a/cluster/k8s/agents/haku-mitmproxy/cnp-haku-cloud-api-egress.yaml
+++ b/cluster/k8s/agents/haku-mitmproxy/cnp-haku-cloud-api-egress.yaml
@@ -2,9 +2,10 @@
 # Additive with the operator's default-deny NetworkPolicy.
 #
 # The registry FQDNs (ghcr.io, *.githubusercontent.com, Docker Hub) cover
-# image-related pod egress; Gmail/Calendar reach Google's APIs. Plaid Postgres
-# is reached cluster-internally (not via this proxy) — see the `toEntities:
-# cluster` rule in ccnp-haku-proxy-egress.yaml.
+# image-related pod egress; Gmail/Calendar reach Google's APIs; the Managed
+# Agents self-hosted worker (haku/runtime/managed_agent) reaches Anthropic's work
+# queue at api.anthropic.com. Plaid Postgres is reached cluster-internally (not
+# via this proxy) — see the `toEntities: cluster` rule in ccnp-haku-proxy-egress.yaml.
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -48,6 +49,14 @@ spec:
         - matchName: pypi.org
         - matchName: files.pythonhosted.org
         - matchName: registry.npmjs.org
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+    # Managed Agents self-hosted worker (haku/runtime/managed_agent) long-polls
+    # Anthropic's work queue via `ant beta:worker poll`.
+    - toFQDNs:
+        - matchName: api.anthropic.com
       toPorts:
         - ports:
             - port: "443"

--- a/haku/TODO.md
+++ b/haku/TODO.md
@@ -72,10 +72,47 @@ facade** in front (the Authentik OAuth facade is auth, not tool filtering — se
   `kubectl_sandbox_fixed_groups` `else` default with an explicit SA→group map
   once the claude-sandbox JWT path has soaked (`tf/gitops/agent-machine-access`).
 
+## Managed Agents runtime (Runtime B) — remaining to go live
+
+Runtime B (`runtime/managed_agent/`) is built and its control plane is
+provisioned (environment `env_015uqL9WAMSDytQEWWmLG9zF`, agent, vault +
+`tana-mcp-ro` credential, scheduled deployment `depl_011DSrUoXuhoDWJoPyDuePqR`;
+full IDs recorded on #2438). The worker is not yet deployed. Remaining:
+
+- **`haku-worker` Deployment** in `haku-sandbox`
+  (`cluster/k8s/haku/agent-worker/`, operator-owned): the worker image,
+  `serviceAccountName: haku`, non-root, behind `haku-mitmproxy`; env
+  `ANTHROPIC_ENVIRONMENT_ID` (the `env_…` above) + `ANTHROPIC_ENVIRONMENT_KEY`
+  and the `HAKU_{DUCKTAPE_REPO_URL,STATE_REPO_URL,GIT_HOST,GIT_USERNAME,GIT_PASSWORD}`
+  clone/push env (source creds — Plaid, Google, git — already reflected into
+  `haku-sandbox` from v0).
+- **`ANTHROPIC_ENVIRONMENT_KEY` secret** — generate in Console (Environments →
+  `haku-selfhosted` → "Generate environment key"), SOPS-encrypt under
+  `cluster/k8s/haku/…` to the **cluster/Flux** age key (not the `haku` key), Flux
+  → secret.
+- **Worker image** (CI build) — `bash`/`git`/`kubectl`/`postgresql-client`/`curl`/
+  `fastmcp` + the `ant` CLI. Now that `ant` is packaged in nix (`anthropic-cli`),
+  prefer reusing the `.#agent-haku` closure + `ant` over a hand-rolled apt image.
+- **Smoke test** — `ant beta:deployments run --deployment-id depl_011DSrUoXuhoDWJoPyDuePqR`,
+  watch in the Console.
+
+Settled (not blockers):
+
+- **Egress** — `api.anthropic.com` is on the `haku-mitmproxy` allowlist
+  (`cluster/k8s/agents/haku-mitmproxy/cnp-haku-cloud-api-egress.yaml`); the worker
+  reaches the work queue through the TLS-terminating proxy and trusts its CA via
+  the existing inject policy.
+- **SOPS identity** — the `&haku` age key already exists, but the in-cluster
+  worker needs no `SOPS_AGE_KEY`: it uses the `haku` ServiceAccount for `kubectl`
+  and reads creds from k8s secrets (only the web home decrypts the
+  public-`kubeapi` JWT via SOPS).
+
 ## Later (post-v0)
 
-- **In-cluster runtime** — a `haku-scanner` image + Job/CronJob as an
-  alternative/complement to the Claude Code web home.
+- **In-cluster runtime** — realized as `runtime/agent` (Runtime C, MAF
+  self-hosted loop) and `runtime/managed_agent` (Runtime B, Managed Agents
+  self-hosted worker; remaining wiring above). The old `haku-scanner` image +
+  CronJob idea is superseded.
 - **haku-traces** — push Claude Code transcripts to a store separate from
   `haku-state` for replayability.
 - **tier-2 execution** — haku-owned execution behind stronger gating, only if


### PR DESCRIPTION
## Summary

Two managed_agent go-live items:

1. **Egress** — add `api.anthropic.com` to the `haku-mitmproxy` allowlist (`cnp-haku-cloud-api-egress.yaml`). Runtime B's self-hosted worker (`haku/runtime/managed_agent`) long-polls Anthropic's work queue via `ant beta:worker poll`; the allowlist previously covered only registries + Google APIs, so without this the worker can't reach the orchestration layer. It reaches the queue *through* the TLS-terminating proxy and trusts its CA via the existing inject policy.
2. **Docs** — record the remaining go-live items in `haku/TODO.md`: the `haku-worker` Deployment, the `ANTHROPIC_ENVIRONMENT_KEY` secret, and the worker image (now able to reuse the nix `.#agent-haku` closure + `ant`). Also marks egress (this change) and the existing `&haku` SOPS identity as settled non-blockers — the in-cluster worker uses the `haku` ServiceAccount + k8s-secret creds, so it needs no `SOPS_AGE_KEY` — and folds the superseded `haku-scanner` idea into the realized Runtime B/C entries.

## Verification

`kubeconform (cluster)` + the rest of pre-commit pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLiwoWexhunDUjGw1bGgJv

---
_Generated by [Claude Code](https://claude.ai/code/session_01JLiwoWexhunDUjGw1bGgJv)_