### PR TITLE
debundle: thread native AST facts into selector solver

### DIFF
--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -24,38 +24,35 @@ records and scoped backlogs; when a plan's core work is complete, its remaining
 tail should be summarized here instead of leaving the plan looking like a second
 priority queue.
 
-**Current focus (2026-06-22 global-solve reframing).** The read-off minimizer
-and fact-based `source_match` resolver are complete enough to stop scaling the
-staged resolver shape. The active frontier is now the **global selector
-constraint solver**: compile every selector in a chunk/spec component into one
-query over the source facts, solve shared `@Name` variables together, enforce
-target categoricity + `all_different` inside the solve, then feed the resolved
-claims to the existing atomic/realizability gate.
+**Current focus (2026-06-22 post-#2439).** PR #2439 landed on `devel` as
+`db25ef639` and closed the first global-solver bridge: `source_match` selectors
+now participate in the Ascent-backed selector solver. The remaining P0 is not a
+new solver choice. It is to remove the bridge shape that still feeds the solver
+pre-enumerated `SourceMatchCandidate` rows from `ChunkResolver`, and instead
+lower `source_match` directly onto the native AST EDB facts already exposed by
+`chunk_facts.rs` / `SelectorFactStore::extend_chunk_facts`.
 
 Dispatch work in this order:
 
-1. **Global selector IR and fact schema (P0.1).** Define the engine-facing
-   atom set for targets, clause-local variables, shape atoms, relational atoms,
-   and derived predicates. This is the contract all authoring syntax lowers to.
-2. **`source_match` lowering parity (P0.2).** Lower today's JS-with-holes
-   selectors into the same IR while keeping the current fact-based resolver as
-   the oracle until a differential reaches zero.
-3. **Shared `@Name` variables (P0.3).** Replace the production-only
-   anchor-first bridge with solver-owned target symbols so relation selectors
-   do not depend on already-resolved members.
-4. **Counting/uniqueness in the solve (P0.4).** Make no-match, ambiguous, and
-   duplicate-claim diagnostics projections of the solver result, not a mix of
-   per-selector checks and post-hoc duplicate detection.
-5. **Materializer integration (P0.5).** Build facts once, solve the selector
-   component once, and let `materialize` consume a resolved claim map. Keep the
-   owner graph, atomic unit, module DAG, and JS realization gates downstream.
-6. **Language/synthesis work as solver vocabulary (P0.6).** Add only language
-   features that lower to the global IR or expose facts it already needs. Use
-   the Gaffer evidence queue in <plans/selector_constraint_model.md>.
+1. **Native AST EDB in the solver (P0.1).** Thread the full `ast_*` fact rows
+   through the Ascent rule library as queryable relations, with source spans and
+   fail-closed unsupported reporting.
+2. **`source_match` lowering parity (P0.2).** Compile JS-with-holes selectors,
+   binding groups, anonymous statements, holes, alpha matching, and regex
+   predicates into AST/owner facts. Keep `ChunkResolver` as the oracle until the
+   differential reaches zero.
+3. **Delete the candidate oracle (P0.3).** Replace `SourceMatchCandidate`
+   facts with native AST-shape constraints, and make no-match, ambiguous, and
+   duplicate-claim diagnostics projections of the solver result.
+4. **Derived relational predicates (P0.4).** Fold the remaining bridge
+   vocabulary (`cross_ref`, `reads_member`, `member_of_module`,
+   `passed_to_call`, `makes_decorate_call`, `intrinsic_alias`) into IR atoms or
+   derived predicates over owner/reference + AST facts. Keep bridge tests as
+   parity tests until the bridge passes can be deleted.
 
 The minimizer polish tail and automation product flows remain valuable, but
-they should build on the global resolver contract rather than harden today's
-per-selector/late-pass shape.
+they should build on this native AST EDB resolver contract rather than harden
+today's candidate-oracle or late-bridge shape.
 
 Prefer dispatching work in this order. Large downstream spec migrations should
 lean on tooling generated from this queue instead of hand-authored YAML.
@@ -71,13 +68,13 @@ parallel dispatch queue.
 
 - <plans/selector_constraint_model.md> — **active (P0 global resolver).**
   Canonical plan for the selector model, Ascent solver choice, execution
-  phases, verification gates, and Gaffer evidence queue. Current top priority:
-  replace per-selector and per-relational-family resolution with one
-  whole-spec/component constraint solve over AST + owner-graph facts. The
+  phases, verification gates, and Gaffer evidence queue. #2439 closed the
+  global-solver admission path for `source_match`; current top priority is
+  replacing the `SourceMatchCandidate` oracle with native AST EDB lowering. The
   landed bridge primitives (`cross_ref`, `reads_member`, `member_of_module`,
   `passed_to_call`, `makes_decorate_call`, `intrinsic_alias`) are useful
   fact/selector vocabulary, but are bridge implementations until they fold into
-  the global IR. See <debug/2026_06_19_p4_debt_worklist.md> for real-spec
+  derived predicates. See <debug/2026_06_19_p4_debt_worklist.md> for real-spec
   evidence.
 - <plans/automated_spec_workflows.md> — **active design, downstream of P0.**
   North-star for the inventory/plan/apply/validate CLI surface and the
@@ -95,42 +92,25 @@ parallel dispatch queue.
   planner design space + algorithm/analysis backlog behind `debundle modules
 propose`.
 
-### P0 — global selector constraint resolver
+### P0 — native AST EDB resolver cutover
 
-1. **Global selector IR and fact schema.** Define the normalized atom/rule
-   representation for shape constraints, relational constraints, target
-   variables, local holes, derived predicates, and selector diagnostics. The IR
-   is the single contract for `run`, `validate`, `match-selector`,
-   `selector-debt`, and synthesis.
-2. **Fact extraction boundary.** Expose the AST facts currently used by
-   `ChunkResolver` and the owner/reference facts currently used by
-   `selector_solve` through one chunk fact store. Preserve the fail-closed rule:
-   unmodeled AST constructs or relations must report `unsupported`, not silently
-   drop facts.
-3. **Lower `source_match` to IR with differential parity.** Compile existing
-   JS-with-holes selectors and binding groups into query atoms. Keep the current
-   resolver as the reference until the corpus differential is zero, including
-   alpha matching, run holes, regex literal predicates, anonymous statements,
-   and binding groups.
-4. **Make `@Name` a solver variable.** Carry spec target symbols through the
-   solve instead of resolving relation anchors from already-claimed members.
-   This removes anchor-first ordering and allows mutually constraining selector
-   clusters.
-5. **Categoricity and `all_different`.** Return per-target no-match /
-   ambiguous / unique outcomes and duplicate claims from one solve result. The
-   keep-going report should become a projection of this result.
-6. **Materializer claim-map integration.** Replace
-   `add_explicit_request`-then-late-pass claiming with "solve selectors, then
-   consume resolved claims." The atomic unit, module DAG, cycle, and JS
-   realization gates stay downstream and unchanged.
-7. **Fold relational bridge passes into derived predicates.** Re-express
-   `cross_ref`, `reads_member`, `member_of_module`, `passed_to_call`,
-   `makes_decorate_call`, and `intrinsic_alias` as selector IR / derived
-   predicates. Keep the existing bridge tests as parity tests until the bridge
-   passes can be deleted.
-8. **Real-spec dogfood as evidence, not architecture.** Continue Gaffer
-   selector stabilization only where it produces language/fact/diagnostic
-   requirements for the global solver or proves the new resolver byte-identical.
+Detailed design and gates live in <plans/selector_constraint_model.md>; keep
+this list as the dispatch summary, not a second plan.
+
+1. **Thread full AST facts into Ascent.** `chunk_facts.rs` already extracts
+   `ast_*` rows and `SelectorFactStore::extend_chunk_facts` already stores
+   them. Make the solver consume those rows as native AST-shape relations.
+2. **Lower `source_match` to those facts.** Replace JS-template matching with
+   IR atoms over AST/owner facts, while differentially checking against
+   `ChunkResolver` until selectors, binding groups, anonymous statements,
+   holes, alpha matching, and regex predicates are byte-for-byte equivalent.
+3. **Retire `SourceMatchCandidate`.** Delete the pre-enumerated candidate
+   oracle once the native lowering is equivalent, and route source-match
+   diagnostics through solver categoricity / `all_different`.
+4. **Fold bridge vocabulary into derived predicates.** Re-express the staged
+   relational selectors as solver predicates over owner/reference + AST facts.
+   Real-spec Gaffer work should supply missing predicates and diagnostics, not
+   another permanent resolver layer.
 
 ### P1 — automation product flows over the solver
 

--- a/devinfra/js/debundle/lowering/materialize/plan_builder.rs
+++ b/devinfra/js/debundle/lowering/materialize/plan_builder.rs
@@ -8,6 +8,7 @@ use super::super::ordinal::body_index_for_statement_ordinal;
 use super::*;
 use crate::plans::RelationalSelector;
 use analysis::StatementOrdinal;
+use anyhow::anyhow;
 
 #[derive(Debug, Clone)]
 struct DuplicateClaimSite {
@@ -242,8 +243,17 @@ fn selector_fact_store_for_chunk(
     owner_graph: &analysis::OwnerGraph,
     module: &swc_ecma_ast::Module,
     import_sources: &HashMap<String, String>,
-) -> SelectorFactStore {
+) -> Result<SelectorFactStore> {
     let mut store = SelectorFactStore::default();
+    let ast_facts = chunk_facts::extract_facts(module).map_err(|unsupported| {
+        anyhow!(
+            "chunk {:?}: selector AST fact extraction failed at {}; global selector solving needs \
+             a complete AST EDB",
+            chunk_id,
+            unsupported.context,
+        )
+    })?;
+    store.extend_chunk_facts(chunk_id, &ast_facts);
     for node in owner_graph.iter_nodes() {
         store.push(SelectorFact::Owner {
             chunk_id,
@@ -314,7 +324,7 @@ fn selector_fact_store_for_chunk(
             property: alias.property,
         });
     }
-    store
+    Ok(store)
 }
 
 #[derive(Debug, Clone)]
@@ -1036,7 +1046,7 @@ impl ChunkPlanBuilder {
         >::new();
         let mut pending_constraints = Vec::<(String, String, spec::MemberSelectorSpec)>::new();
         let mut facts =
-            selector_fact_store_for_chunk(chunk_id_interned, owner_graph, module, import_sources);
+            selector_fact_store_for_chunk(chunk_id_interned, owner_graph, module, import_sources)?;
         for (index, request) in explicit_requests.iter().enumerate() {
             let group_assignments = source_match_group_assignments(request);
             for (member_index, member) in request.members.iter().enumerate() {

--- a/devinfra/js/debundle/plans/selector_constraint_model.md
+++ b/devinfra/js/debundle/plans/selector_constraint_model.md
@@ -1,24 +1,28 @@
 # Plan: selectors as one global constraint problem (relational spec model)
 
-**Current state (2026-06-22).** The hand-rolled matcher is retired: the fact-based
-`ChunkResolver` is the **sole** `source_match` resolver
-(`AstWildcardMatcher` / `AstWildcardResolver` / `DifferentialResolver` deleted).
-Re-homing the existing selector language onto the relational AST-facts substrate
-— proven by a full-corpus differential against the old matcher — is done; that
-parity was the equivalence gate, not new power. The relational bridge primitives
-(`cross_ref`, `reads_member`, `member_of_module`, `passed_to_call`,
-`makes_decorate_call`, `intrinsic_alias`) have landed as staged materializer
-passes.
+**Current state (2026-06-22, after #2439).** Ascent remains the selected
+production solver. PR #2439 landed on `devel` as `db25ef639` and closed the
+first global-solver bridge: `source_match` selectors now enter the global
+selector IR/solver instead of bypassing it. That bridge still feeds the solver
+`SourceMatchCandidate` rows enumerated by the fact-based `ChunkResolver`;
+`selector_ir_lowering.rs` lowers `source_match` to that candidate atom, and
+`plan_builder.rs` populates the rows by calling `ChunkResolver` candidate APIs.
 
-**Reframing.** The next architectural goal is not "do more per-selector
-conversions, then eventually solve globally." It is to make the global
-constraint solve the resolver itself: compile every selector form into one
-selector IR over AST + owner-graph facts, solve shared `@Name` variables and
-`all_different` together, and hand materialization a resolved claim map. Real
-spec conversions are dogfood and evidence for missing language/fact coverage;
-they should not add more long-lived anchor-first bridge architecture. The
-remaining-work index is <../debug/2026_06_19_p4_debt_worklist.md>, and the
-Gaffer-derived language evidence is summarized below.
+Full AST facts already exist in `chunk_facts.rs` and are appended by
+`SelectorFactStore::extend_chunk_facts`, but they are not yet the native solve
+path for `source_match`. The remaining P0 is to make Ascent consume those AST
+facts directly, lower `source_match` onto them with zero-differential parity,
+and then delete the candidate oracle.
+
+**Reframing.** The next architectural goal is not to grow more bridge
+vocabulary. It is to make the global constraint solve native over AST +
+owner/reference facts: compile every selector form into one selector IR, solve
+shared `@Name` variables and `all_different` together, and hand materialization
+a resolved claim map. Real spec conversions are dogfood and evidence for
+missing language/fact coverage; they should not add more long-lived
+anchor-first bridge architecture. The remaining-work index is
+<../debug/2026_06_19_p4_debt_worklist.md>, and the Gaffer-derived language
+evidence is summarized below.
 
 Extends the selector-authoring guidance in <../docs/selectors.md> and the
 `debundle_stabilize` skill — which fix _who_ chooses anchors (an agent, not the
@@ -34,24 +38,27 @@ Notation: `@Name` means "the binding/node pinned elsewhere in the spec as `Name`
 
 ## Goal
 
-Replace the hand-rolled JS↔JS template matcher with a Datalog-based selector resolver that
-resolves every selector the `tana/re` spec depends on, over an explicit relational model of the
-program (owner graph + AST facts) rather than ad-hoc AST walking. Parity must be **proven, not
-asserted**: a corpus-wide differential against the current matcher reaches zero disagreements, and
-the lowering is **fail-closed** — each construct compiles to atoms provably faithful to the
-matcher's semantics, or it errors, never silently under-constraining. The design must stay
-**principled** — one general, faithful encoding per selector kind and hole, with no per-selector
-special cases, silent fallbacks, or hacks to force a hard construct through. If any construct, or
-the model itself, turns out not to admit such a faithful, principled encoding, we **abort and
-rethink the design** rather than push on with ugly hacks — an honest dead end beats a matcher we
-cannot trust.
+Replace the remaining `SourceMatchCandidate` oracle with a Datalog/Ascent
+selector resolver that resolves every selector the `tana/re` spec depends on
+over an explicit relational model of the program (owner graph + AST facts).
+Parity must be **proven, not asserted**: a corpus-wide differential against the
+current `ChunkResolver` reaches zero disagreements, and the lowering is
+**fail-closed** — each construct compiles to atoms provably faithful to current
+`source_match` semantics, or it errors, never silently under-constraining. The
+design must stay **principled** — one general, faithful encoding per selector
+kind and hole, with no per-selector special cases, silent fallbacks, or hacks to
+force a hard construct through. If any construct, or the model itself, turns out
+not to admit such a faithful, principled encoding, we **abort and rethink the
+design** rather than push on with ugly hacks — an honest dead end beats a matcher
+we cannot trust.
 
 Operationally, this means the Ducktape-side work leads with the engine contract:
 
 1. one engine-facing selector IR shared by `run`, `validate`,
    `match-selector`, `selector-debt`, synthesis, and repair;
 2. one fact store per chunk/component containing AST-shape facts,
-   binding-resolution facts, owner/reference facts, and derived-predicate inputs;
+   binding-resolution facts, owner/reference facts, and derived-predicate inputs,
+   with the solver consuming the AST facts natively rather than candidate rows;
 3. one solve per connected selector component, with `@Name` as a shared logic
    variable rather than a lookup into already-resolved members;
 4. one diagnostic/result projection for no-match, ambiguity, duplicate claims,
@@ -215,9 +222,12 @@ str_lit(node, "…").   num_lit(node, 5).   operator(node, "+").
 resolves_to(use, def).   member_of_module(binding, module).
 ```
 
-Most of this already exists as the owner/reference graph; the work is to _expose_ it as
-queryable relations. `resolves_to` is the only genuinely new, genuinely semantic
-relation — the one minification preserves while names churn.
+The AST projection already exists in `chunk_facts.rs` and
+`SelectorFactStore::extend_chunk_facts`; the owner/reference facts already feed
+the selector solver. The open work is to make the Ascent rule library consume
+the AST rows directly instead of only consuming `SourceMatchCandidate` rows
+pre-enumerated by `ChunkResolver`. `resolves_to` remains the genuinely semantic
+edge — the one minification preserves while names churn.
 
 **Derived predicates — a rule library, not engine primitives.** `calls`, `alias`, a
 decorator application, etc. are rules over AST shape + `resolves_to`:
@@ -272,10 +282,12 @@ initial batch resolver.
 class with _exactly_ these members"; "the _only_ class with method m" as a writable
 anchor) — stratified negation / aggregation; categoricity as a _check_ is plain
 counting. Variable-length holes need recursion. Most cases — literal + `resolves_to`
-anchors — are plain positive CQ. New code is the AST→atoms lowering plus the EDB extractor — a
-fail-closed recursive walk (not a `swc_ecma_visit::Visit`, whose no-op defaults would silently skip
-an un-overridden node type): an unmodeled construct raises a loud `Unsupported`, never projecting a
-silently-incomplete fact set that would match wrongly.
+anchors — are plain positive CQ. New code is AST→atoms lowering plus native
+solver ingestion of the existing EDB extractor. That extractor is a fail-closed
+recursive walk (not a `swc_ecma_visit::Visit`, whose no-op defaults would
+silently skip an un-overridden node type): an unmodeled construct raises a loud
+`Unsupported`, never projecting a silently-incomplete fact set that would match
+wrongly.
 
 ## Scale and performance
 
@@ -317,34 +329,44 @@ become roughly 5.
 
 ## Landing in the debundle binary
 
-This is not a side tool — it is the **resolution layer**: the code that maps each spec selector to
-its node on the chunk. The fact-based `ChunkResolver` is that layer behind every caller;
-`binding_resolution.rs` is the shared binding-extraction the resolver reuses.
+This is not a side tool — it is the **resolution layer**: the code that maps
+each spec selector to its node on the chunk. After #2439, the global selector
+solver is on that path, but `source_match` still reaches it through
+`ChunkResolver`-enumerated candidate rows. Native AST EDB lowering makes the
+solver itself responsible for the shape match.
 
-The resolver is named in code: `source_match::SelectorResolver`, the trait `ChunkResolver`
-implements — `(parsed chunk, JS-template selector) → unique {claimed binding | body-index group}`,
-with no-match / ambiguous as the only failure modes.
+The reference oracle is named in code: `source_match::SelectorResolver`, the
+trait `ChunkResolver` implements — `(parsed chunk, JS-template selector) →
+unique {claimed binding | body-index group}`, with no-match / ambiguous as the
+only failure modes.
 
 ### EDB from analysis the pipeline already does
 
-The pipeline already parses the chunk (`js_ast`), computes binding resolution and the
-owner/reference graph (`program_analysis`, `facts/`, `graph/`, emitted as
-`owner_graph.json`), and builds the candidate index. Those _are_ the EDB: `resolves_to`
+The pipeline already parses the chunk (`js_ast`), computes binding resolution
+and the owner/reference graph (`program_analysis`, `facts/`, `graph/`, emitted
+as `owner_graph.json`), and extracts `chunk_facts.rs` AST rows. Those are the
+EDB:
 
-- module membership + ordinal/purity from the owner graph (proven), AST
-  `child`/`kind`/`str_lit`/`prop_name` from the parsed tree (phase 2), label posting lists
-  from the candidate index. EDB construction is a re-projection of existing analysis,
-  slotted after analysis and before materialization.
+- module membership + ordinal/purity from the owner graph;
+- owner/reference rows already consumed by `selector_ir_solver.rs`;
+- AST `kind` / `child` / literal / identifier / property / operator /
+  top-level rows already stored by `SelectorFactStore::extend_chunk_facts`;
+- label posting lists still used by `ChunkResolver` as the current
+  `SourceMatchCandidate` oracle.
+
+The cutover is a consumer change: add native AST relations and shape rules to
+the Ascent solver, then delete the candidate-oracle projection once the
+differential is zero.
 
 ### It replaces several workflow parts, not just the matcher
 
-| Today                                                                       | Becomes                                                                                                                                  |
-| --------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `lowering/materialize/plan_builder.rs` resolves each selector individually  | one `solve(spec, edb)`; the plan consumes per-target bindings                                                                            |
-| `validate` no-match / ambiguous / duplicate-claim (per-selector + post-hoc) | solver categoricity (no-match / ambiguous) + `all_different` (duplicate-claim) in one keep-going pass                                    |
-| `match_selector.rs` resolves one candidate                                  | single-query solve over the EDB; gains probing of **relational/cross-ref** candidates, not just local shapes                             |
-| `selector_codemod.rs` prove-gate (candidate-index uniqueness)               | solver categoricity; the minimizer's search space grows to relational atoms — it can now _propose_ the cross-ref selectors that now skip |
-| `selector_debt.rs` source-aware near-ambiguous / repeated-body scan         | solver reports per target **which atoms forced uniqueness, tagged invariant/variant**, and the categoricity margin                       |
+| Today                                                                                             | Becomes                                                                                                                                  |
+| ------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `lowering/materialize/plan_builder.rs` still asks `ChunkResolver` for `SourceMatchCandidate` rows | one native `solve(spec, edb)` over AST + owner/reference facts; the plan consumes per-target bindings                                    |
+| `validate` no-match / ambiguous / duplicate-claim (per-selector + post-hoc)                       | solver categoricity (no-match / ambiguous) + `all_different` (duplicate-claim) in one keep-going pass                                    |
+| `match_selector.rs` resolves one candidate                                                        | single-query solve over the EDB; gains probing of **relational/cross-ref** candidates, not just local shapes                             |
+| `selector_codemod.rs` prove-gate (candidate-index uniqueness)                                     | solver categoricity; the minimizer's search space grows to relational atoms — it can now _propose_ the cross-ref selectors that now skip |
+| `selector_debt.rs` source-aware near-ambiguous / repeated-body scan                               | solver reports per target **which atoms forced uniqueness, tagged invariant/variant**, and the categoricity margin                       |
 
 The cycle/atomic gate (`gate.rs`, `realizability/`, `atomic_units.rs`) and emit run
 **downstream of resolution on the resolved ownership** — unchanged, as are the module
@@ -599,36 +621,46 @@ re-minification-proof identity anchor.
 `selector_query_examples.rs` (`selector_query_examples_test`): cross-ref joins, a disequality
 `all_different`, stratified negation (`!rel`), recursive transitive closure, `count` aggregation
 with a uniqueness guard, and an AST-literal-∧-import-edge join all resolve to the expected owners.
-So the vocabulary is proven expressible in the engine we picked — the gap to production is the
-phase-2 AST-facts EDB and the template→atoms lowering, not the solver's capability.
+So the vocabulary is proven expressible in the engine we picked — the gap to
+production is native consumption of the AST-facts EDB plus template→atoms
+lowering, not the solver's capability.
 
-## Remaining work (global-solve cutover)
+## Closed by #2439
 
-Everything that reproduces the old selector language is done at the current
-bridge layer. The remaining work is to make this model the production resolver:
+- `source_match` selectors now enter the global selector IR/solver.
+- The materializer has a single Ascent-backed selector solve path for binding
+  pins, staged relational selectors, and `source_match` claims.
+- Ascent remains the production solver choice; do not restart solver selection
+  unless profiling proves the in-process path cannot meet the latency/memory
+  target.
 
-- **G1 — IR and fact-store contract.** Specify the normalized selector atom set,
-  target variables, clause-local variables, derived predicates, source spans,
-  and diagnostic payloads. This is the shared contract for `run`, `validate`,
-  `match-selector`, `selector-debt`, synthesis, and repair.
-- **G2 — `source_match` parity lowering.** Lower today's JS-with-holes selectors
-  and binding groups into IR atoms. Keep the fact-based `ChunkResolver` as the
-  oracle until the corpus differential is zero, including alpha matching,
-  run-hole placement, regex literal predicates, anonymous statements, and
-  binding groups.
-- **G3 — shared-variable solve.** Join AST facts, binding-resolution facts, and
-  owner/reference facts into one solve per connected selector component.
-  `@Name` becomes a shared target variable; no-match / ambiguous / unique and
-  `all_different` duplicate claims are result projections.
-- **G4 — materializer cutover.** Replace staged per-selector claiming plus late
-  relational passes with a solver-produced claim map. The owner graph,
-  atomic-DAG, module-DAG, and emit gates stay downstream.
-- **G5 — relation/language fold-in.** Re-express `cross_ref`, `reads_member`,
+## Remaining work (native AST EDB cutover)
+
+This is the detailed P0 queue; <../TODO.md> should only summarize it.
+
+- **G1 — native AST EDB ingestion.** Add Ascent relations and indexes for the
+  AST rows already emitted by `chunk_facts.rs` and imported by
+  `SelectorFactStore::extend_chunk_facts`: node kind, parent/child ordinal,
+  literals, identifier/property names, operators, regex, superclass, top-level
+  statement ordinal, and source-span/diagnostic payloads. Preserve the
+  fail-closed rule: unsupported constructs report `unsupported`, not a partial
+  fact set.
+- **G2 — `source_match` lowering parity.** Lower today's JS-with-holes selectors
+  and binding groups into native AST/owner IR atoms. Keep `ChunkResolver` as the
+  reference until the corpus differential is zero, including alpha matching,
+  run-hole placement, regex literal predicates, anonymous statements, exact
+  identifiers, target bindings, and binding groups.
+- **G3 — candidate-oracle deletion.** Remove `SelectorAtom::SourceMatchCandidate`
+  / `SelectorFact::SourceMatchCandidate` from the production path after G2
+  parity. No-match, ambiguous, unsupported, and duplicate-claim diagnostics
+  should be projections of the native solver result, not `ChunkResolver`
+  side tables.
+- **G4 — relation/language fold-in.** Re-express `cross_ref`, `reads_member`,
   `member_of_module`, `passed_to_call`, `makes_decorate_call`,
   `intrinsic_alias`, and the Gaffer feature-request vocabulary as IR atoms or
-  derived predicates. The real-spec conversion worklist in
-  <../debug/2026_06_19_p4_debt_worklist.md> is evidence and dogfood for this,
-  not a reason to add more permanent bridge passes.
+  derived predicates over owner/reference + AST facts. The real-spec conversion
+  worklist in <../debug/2026_06_19_p4_debt_worklist.md> is evidence and dogfood
+  for this, not a reason to add more permanent bridge passes.
 
 ## Execution contract
 

--- a/devinfra/js/debundle/selector_ir_solver.rs
+++ b/devinfra/js/debundle/selector_ir_solver.rs
@@ -14,9 +14,9 @@ use std::fmt;
 use analysis::{OwnerId, StatementOrdinal};
 use ascent::ascent;
 use selector_ir::{
-    ClaimOutcome, OwnerTerm, ResolvedClaim, SelectorAtom, SelectorFact, SelectorFactStore,
-    SelectorProgram, SelectorProgramError, SelectorTarget, SelectorTargetId, SelectorVariableId,
-    SolverClaim, SolverResult, StringTerm, VariableDomain,
+    ClaimOutcome, NodeTerm, OrdinalTerm, OwnerTerm, ResolvedClaim, SelectorAtom, SelectorFact,
+    SelectorFactStore, SelectorProgram, SelectorProgramError, SelectorTarget, SelectorTargetId,
+    SelectorVariableId, SolverClaim, SolverResult, StringTerm, VariableDomain,
 };
 
 fn optional_u32_matches(expected: &Option<u32>, actual: u32) -> bool {
@@ -49,6 +49,27 @@ ascent! {
     relation decorate_call(String, String, Option<String>); // callee, class binding, member
     relation intrinsic_alias(String, String); // binding, Object property
     relation source_match_candidate(String, usize, String); // selector key, owner, matched binding
+    relation ast_kind(u32, String); // AST node, node kind tag
+    relation ast_child(u32, u32, u32); // parent, child index, child
+    relation ast_string_literal(u32, String); // node, value
+    relation ast_string_wildcard(u32, String); // needle node, wildcard token
+    relation ast_number_literal(u32, String); // node, value
+    relation ast_bool_literal(u32, bool); // node, value
+    relation ast_identifier_name(u32, String); // node, value
+    relation ast_property_name(u32, String); // node, value
+    relation ast_operator(u32, String); // node, operator
+    relation ast_regex_literal(u32, String, String); // node, pattern, flags
+    relation ast_super_class(u32, u32); // class node, super-class expression node
+    relation ast_top_level(u32, usize); // root node, statement ordinal
+
+    relation owner_statement_ordinal(usize, usize);
+    owner_statement_ordinal(*owner, *ordinal) <--
+        owner_fact(owner, ordinal, _kind);
+
+    relation owner_top_level_root(usize, u32);
+    owner_top_level_root(*owner, *node) <--
+        owner_fact(owner, ordinal, _kind),
+        ast_top_level(node, ordinal);
 
     relation name_owner(String, usize);
     name_owner(binding.clone(), *owner) <-- declares(owner, binding);
@@ -122,6 +143,7 @@ ascent! {
     relation required_passed_to_call_from_binding(usize, usize, String, String, Option<u32>);
     relation required_makes_decorate_call_for_binding(usize, usize, String, Option<String>);
     relation required_source_match_candidate(usize, usize, String);
+    relation required_owner_statement_ordinal(usize, usize, usize);
 
     relation constraint_support(usize, usize, usize); // constraint id, variable id, owner
     constraint_support(*constraint, *var, *owner) <--
@@ -180,6 +202,83 @@ ascent! {
         required_source_match_candidate(constraint, var, selector_key),
         source_match_candidate(selector_key, owner, _binding),
         owner_fact(owner, _ordinal, _kind);
+    constraint_support(*constraint, *var, *owner) <--
+        required_owner_statement_ordinal(constraint, var, ordinal),
+        owner_statement_ordinal(owner, actual_ordinal),
+        if actual_ordinal == ordinal;
+
+    relation required_statement_ordinal_for_owner(usize, usize, usize);
+    relation required_ast_kind(usize, usize, String);
+    relation required_ast_child_parent(usize, usize, u32, u32);
+    relation required_ast_child_child(usize, usize, u32, u32);
+    relation required_ast_string_literal(usize, usize, String);
+    relation required_ast_number_literal(usize, usize, String);
+    relation required_ast_bool_literal(usize, usize, bool);
+    relation required_ast_identifier_name(usize, usize, String);
+    relation required_ast_property_name(usize, usize, String);
+    relation required_ast_operator(usize, usize, String);
+    relation required_ast_regex_literal(usize, usize, String, String);
+    relation required_ast_top_level_ordinal(usize, usize, usize);
+    relation required_ast_top_level_node(usize, usize, u32);
+
+    relation node_constraint_support(usize, usize, u32); // constraint id, variable id, AST node
+    node_constraint_support(*constraint, *var, *node) <--
+        required_ast_kind(constraint, var, node_kind),
+        ast_kind(node, actual),
+        if actual == node_kind;
+    node_constraint_support(*constraint, *var, *parent) <--
+        required_ast_child_parent(constraint, var, index, child),
+        ast_child(parent, actual_index, actual_child),
+        if actual_index == index,
+        if actual_child == child;
+    node_constraint_support(*constraint, *var, *child) <--
+        required_ast_child_child(constraint, var, parent, index),
+        ast_child(actual_parent, actual_index, child),
+        if actual_parent == parent,
+        if actual_index == index;
+    node_constraint_support(*constraint, *var, *node) <--
+        required_ast_string_literal(constraint, var, value),
+        ast_string_literal(node, actual),
+        if actual == value;
+    node_constraint_support(*constraint, *var, *node) <--
+        required_ast_number_literal(constraint, var, value),
+        ast_number_literal(node, actual),
+        if actual == value;
+    node_constraint_support(*constraint, *var, *node) <--
+        required_ast_bool_literal(constraint, var, value),
+        ast_bool_literal(node, actual),
+        if actual == value;
+    node_constraint_support(*constraint, *var, *node) <--
+        required_ast_identifier_name(constraint, var, value),
+        ast_identifier_name(node, actual),
+        if actual == value;
+    node_constraint_support(*constraint, *var, *node) <--
+        required_ast_property_name(constraint, var, value),
+        ast_property_name(node, actual),
+        if actual == value;
+    node_constraint_support(*constraint, *var, *node) <--
+        required_ast_operator(constraint, var, value),
+        ast_operator(node, actual),
+        if actual == value;
+    node_constraint_support(*constraint, *var, *node) <--
+        required_ast_regex_literal(constraint, var, pattern, flags),
+        ast_regex_literal(node, actual_pattern, actual_flags),
+        if actual_pattern == pattern,
+        if actual_flags == flags;
+    node_constraint_support(*constraint, *var, *node) <--
+        required_ast_top_level_ordinal(constraint, var, ordinal),
+        ast_top_level(node, actual_ordinal),
+        if actual_ordinal == ordinal;
+
+    relation ordinal_constraint_support(usize, usize, usize); // constraint id, variable id, ordinal
+    ordinal_constraint_support(*constraint, *var, *ordinal) <--
+        required_statement_ordinal_for_owner(constraint, var, owner),
+        owner_statement_ordinal(actual_owner, ordinal),
+        if actual_owner == owner;
+    ordinal_constraint_support(*constraint, *var, *ordinal) <--
+        required_ast_top_level_node(constraint, var, node),
+        ast_top_level(actual_node, ordinal),
+        if actual_node == node;
 
     relation required_references_owner(usize, usize, usize);
     relation required_aliases_owner(usize, usize, usize);
@@ -187,6 +286,10 @@ ascent! {
     relation required_passed_to_call_of_owner(usize, usize, usize, String, Option<u32>);
     relation required_makes_decorate_call_for_owner(usize, usize, usize, Option<String>);
     relation required_intrinsic_alias(usize, usize, usize, String);
+    relation required_owner_statement_ordinal_var(usize, usize, usize);
+    relation required_ast_child(usize, usize, usize, u32);
+    relation required_ast_top_level(usize, usize, usize);
+    relation required_owner_top_level_root(usize, usize, usize);
 
     relation binary_constraint_edge(usize, usize, usize, usize, usize);
     binary_constraint_edge(*constraint, *left_var, *left_owner, *right_var, *right_owner) <--
@@ -212,6 +315,27 @@ ascent! {
         required_intrinsic_alias(constraint, left_var, right_var, property),
         intrinsic_alias_referenced_by_edge(left_owner, actual_property, right_owner),
         if actual_property == property;
+
+    relation owner_ordinal_constraint_edge(usize, usize, usize, usize, usize);
+    owner_ordinal_constraint_edge(*constraint, *owner_var, *owner, *ordinal_var, *ordinal) <--
+        required_owner_statement_ordinal_var(constraint, owner_var, ordinal_var),
+        owner_statement_ordinal(owner, ordinal);
+
+    relation node_node_constraint_edge(usize, usize, u32, usize, u32);
+    node_node_constraint_edge(*constraint, *parent_var, *parent, *child_var, *child) <--
+        required_ast_child(constraint, parent_var, child_var, index),
+        ast_child(parent, actual_index, child),
+        if actual_index == index;
+
+    relation node_ordinal_constraint_edge(usize, usize, u32, usize, usize);
+    node_ordinal_constraint_edge(*constraint, *node_var, *node, *ordinal_var, *ordinal) <--
+        required_ast_top_level(constraint, node_var, ordinal_var),
+        ast_top_level(node, ordinal);
+
+    relation owner_node_constraint_edge(usize, usize, usize, usize, u32);
+    owner_node_constraint_edge(*constraint, *owner_var, *owner, *node_var, *node) <--
+        required_owner_top_level_root(constraint, owner_var, node_var),
+        owner_top_level_root(owner, node);
 }
 
 /// Solve the supported selector IR fragment against a selector fact store.
@@ -289,6 +413,44 @@ pub fn solve(
         ascent
             .source_match_candidate
             .push((selector_key.clone(), owner.0, binding.clone()));
+    }
+    for (node, node_kind) in &fact_index.ast_kinds {
+        ascent.ast_kind.push((*node, node_kind.clone()));
+    }
+    for (parent, index, child) in &fact_index.ast_children {
+        ascent.ast_child.push((*parent, *index, *child));
+    }
+    for (node, value) in &fact_index.ast_string_literals {
+        ascent.ast_string_literal.push((*node, value.clone()));
+    }
+    for (node, value) in &fact_index.ast_string_wildcards {
+        ascent.ast_string_wildcard.push((*node, value.clone()));
+    }
+    for (node, value) in &fact_index.ast_number_literals {
+        ascent.ast_number_literal.push((*node, value.clone()));
+    }
+    for (node, value) in &fact_index.ast_bool_literals {
+        ascent.ast_bool_literal.push((*node, *value));
+    }
+    for (node, value) in &fact_index.ast_identifier_names {
+        ascent.ast_identifier_name.push((*node, value.clone()));
+    }
+    for (node, value) in &fact_index.ast_property_names {
+        ascent.ast_property_name.push((*node, value.clone()));
+    }
+    for (node, value) in &fact_index.ast_operators {
+        ascent.ast_operator.push((*node, value.clone()));
+    }
+    for (node, pattern, flags) in &fact_index.ast_regex_literals {
+        ascent
+            .ast_regex_literal
+            .push((*node, pattern.clone(), flags.clone()));
+    }
+    for (class_node, super_class) in &fact_index.ast_super_classes {
+        ascent.ast_super_class.push((*class_node, *super_class));
+    }
+    for (node, ordinal) in &fact_index.ast_top_levels {
+        ascent.ast_top_level.push((*node, ordinal.0));
     }
     for constraint in &support.unary_constraints {
         match &constraint.kind {
@@ -372,6 +534,113 @@ pub fn solve(
                     selector_key.clone(),
                 ));
             }
+            UnaryConstraintKind::OwnerStatementOrdinal { ordinal } => {
+                ascent.required_owner_statement_ordinal.push((
+                    constraint.id,
+                    constraint.variable.0,
+                    ordinal.0,
+                ));
+            }
+        }
+    }
+    for constraint in &support.node_unary_constraints {
+        match &constraint.kind {
+            NodeUnaryConstraintKind::Kind { node_kind } => ascent.required_ast_kind.push((
+                constraint.id,
+                constraint.variable.0,
+                node_kind.clone(),
+            )),
+            NodeUnaryConstraintKind::ChildParent { index, child } => {
+                ascent.required_ast_child_parent.push((
+                    constraint.id,
+                    constraint.variable.0,
+                    *index,
+                    *child,
+                ));
+            }
+            NodeUnaryConstraintKind::ChildChild { parent, index } => {
+                ascent.required_ast_child_child.push((
+                    constraint.id,
+                    constraint.variable.0,
+                    *parent,
+                    *index,
+                ));
+            }
+            NodeUnaryConstraintKind::StringLiteral { value } => {
+                ascent.required_ast_string_literal.push((
+                    constraint.id,
+                    constraint.variable.0,
+                    value.clone(),
+                ));
+            }
+            NodeUnaryConstraintKind::NumberLiteral { value } => {
+                ascent.required_ast_number_literal.push((
+                    constraint.id,
+                    constraint.variable.0,
+                    value.clone(),
+                ));
+            }
+            NodeUnaryConstraintKind::BoolLiteral { value } => {
+                ascent.required_ast_bool_literal.push((
+                    constraint.id,
+                    constraint.variable.0,
+                    *value,
+                ));
+            }
+            NodeUnaryConstraintKind::IdentifierName { value } => {
+                ascent.required_ast_identifier_name.push((
+                    constraint.id,
+                    constraint.variable.0,
+                    value.clone(),
+                ));
+            }
+            NodeUnaryConstraintKind::PropertyName { value } => {
+                ascent.required_ast_property_name.push((
+                    constraint.id,
+                    constraint.variable.0,
+                    value.clone(),
+                ));
+            }
+            NodeUnaryConstraintKind::Operator { value } => {
+                ascent.required_ast_operator.push((
+                    constraint.id,
+                    constraint.variable.0,
+                    value.clone(),
+                ));
+            }
+            NodeUnaryConstraintKind::RegexLiteral { pattern, flags } => {
+                ascent.required_ast_regex_literal.push((
+                    constraint.id,
+                    constraint.variable.0,
+                    pattern.clone(),
+                    flags.clone(),
+                ));
+            }
+            NodeUnaryConstraintKind::TopLevelOrdinal { ordinal } => {
+                ascent.required_ast_top_level_ordinal.push((
+                    constraint.id,
+                    constraint.variable.0,
+                    ordinal.0,
+                ));
+            }
+        }
+    }
+    for constraint in &support.ordinal_unary_constraints {
+        match &constraint.kind {
+            OrdinalUnaryConstraintKind::OwnerStatementOrdinal { owner } => {
+                ascent.required_statement_ordinal_for_owner.push((
+                    constraint.id,
+                    constraint.variable.0,
+                    owner.0,
+                ));
+            }
+            OrdinalUnaryConstraintKind::AstTopLevelNode { node } => {
+                ascent.required_ast_top_level_node.push((
+                    constraint.id,
+                    constraint.variable.0,
+                    *node,
+                ));
+            }
         }
     }
     for constraint in &support.binary_constraints {
@@ -422,12 +691,55 @@ pub fn solve(
             }
         }
     }
+    for constraint in &support.owner_ordinal_constraints {
+        match constraint.kind {
+            OwnerOrdinalConstraintKind::OwnerStatementOrdinal => {
+                ascent.required_owner_statement_ordinal_var.push((
+                    constraint.id,
+                    constraint.owner.0,
+                    constraint.ordinal.0,
+                ));
+            }
+        }
+    }
+    for constraint in &support.node_node_constraints {
+        match constraint.kind {
+            NodeNodeConstraintKind::AstChild { index } => ascent.required_ast_child.push((
+                constraint.id,
+                constraint.left.0,
+                constraint.right.0,
+                index,
+            )),
+        }
+    }
+    for constraint in &support.node_ordinal_constraints {
+        match constraint.kind {
+            NodeOrdinalConstraintKind::AstTopLevel => ascent.required_ast_top_level.push((
+                constraint.id,
+                constraint.node.0,
+                constraint.ordinal.0,
+            )),
+        }
+    }
     ascent.run();
 
     let unary_supports = group_unary_supports(ascent.constraint_support);
+    let node_unary_supports = group_node_unary_supports(ascent.node_constraint_support);
+    let ordinal_unary_supports = group_ordinal_unary_supports(ascent.ordinal_constraint_support);
     let binary_edges = group_binary_edges(ascent.binary_constraint_edge);
-    let candidates =
-        solve_candidate_sets(program, &support, &fact_index, unary_supports, binary_edges);
+    let owner_ordinal_edges = group_owner_ordinal_edges(ascent.owner_ordinal_constraint_edge);
+    let node_node_edges = group_node_node_edges(ascent.node_node_constraint_edge);
+    let node_ordinal_edges = group_node_ordinal_edges(ascent.node_ordinal_constraint_edge);
+    let derived_support = DerivedSupport {
+        owner_unary: unary_supports,
+        node_unary: node_unary_supports,
+        ordinal_unary: ordinal_unary_supports,
+        owner_owner: binary_edges,
+        owner_ordinal: owner_ordinal_edges,
+        node_node: node_node_edges,
+        node_ordinal: node_ordinal_edges,
+    };
+    let candidates = solve_candidate_sets(program, &support, &fact_index, derived_support);
 
     let mut claims = Vec::new();
     for target in &program.targets {
@@ -439,7 +751,11 @@ pub fn solve(
             continue;
         }
 
-        let candidates = candidates.get(&target.owner).cloned().unwrap_or_default();
+        let candidates = candidates
+            .owners
+            .get(&target.owner)
+            .cloned()
+            .unwrap_or_default();
         let outcome = classify_candidates(target, candidates, &fact_index, &support);
         claims.push(SolverClaim {
             target: target.id,
@@ -491,52 +807,164 @@ fn group_binary_edges(
     grouped
 }
 
+fn group_node_unary_supports(rows: Vec<(usize, usize, u32)>) -> BTreeMap<usize, BTreeSet<u32>> {
+    let mut grouped = BTreeMap::new();
+    for (constraint, _var, node) in rows {
+        grouped
+            .entry(constraint)
+            .or_insert_with(BTreeSet::new)
+            .insert(node);
+    }
+    grouped
+}
+
+fn group_ordinal_unary_supports(
+    rows: Vec<(usize, usize, usize)>,
+) -> BTreeMap<usize, BTreeSet<StatementOrdinal>> {
+    let mut grouped = BTreeMap::new();
+    for (constraint, _var, ordinal) in rows {
+        grouped
+            .entry(constraint)
+            .or_insert_with(BTreeSet::new)
+            .insert(StatementOrdinal(ordinal));
+    }
+    grouped
+}
+
+fn group_owner_ordinal_edges(
+    rows: Vec<(usize, usize, usize, usize, usize)>,
+) -> BTreeMap<usize, BTreeSet<(OwnerId, StatementOrdinal)>> {
+    let mut grouped = BTreeMap::new();
+    for (constraint, _owner_var, owner, _ordinal_var, ordinal) in rows {
+        grouped
+            .entry(constraint)
+            .or_insert_with(BTreeSet::new)
+            .insert((OwnerId(owner), StatementOrdinal(ordinal)));
+    }
+    grouped
+}
+
+fn group_node_node_edges(
+    rows: Vec<(usize, usize, u32, usize, u32)>,
+) -> BTreeMap<usize, BTreeSet<(u32, u32)>> {
+    let mut grouped = BTreeMap::new();
+    for (constraint, _left_var, left, _right_var, right) in rows {
+        grouped
+            .entry(constraint)
+            .or_insert_with(BTreeSet::new)
+            .insert((left, right));
+    }
+    grouped
+}
+
+fn group_node_ordinal_edges(
+    rows: Vec<(usize, usize, u32, usize, usize)>,
+) -> BTreeMap<usize, BTreeSet<(u32, StatementOrdinal)>> {
+    let mut grouped = BTreeMap::new();
+    for (constraint, _node_var, node, _ordinal_var, ordinal) in rows {
+        grouped
+            .entry(constraint)
+            .or_insert_with(BTreeSet::new)
+            .insert((node, StatementOrdinal(ordinal)));
+    }
+    grouped
+}
+
+#[derive(Debug, Default)]
+struct CandidateSets {
+    owners: BTreeMap<SelectorVariableId, BTreeSet<OwnerId>>,
+    nodes: BTreeMap<SelectorVariableId, BTreeSet<u32>>,
+    ordinals: BTreeMap<SelectorVariableId, BTreeSet<StatementOrdinal>>,
+}
+
+struct DerivedSupport {
+    owner_unary: BTreeMap<usize, BTreeSet<OwnerId>>,
+    node_unary: BTreeMap<usize, BTreeSet<u32>>,
+    ordinal_unary: BTreeMap<usize, BTreeSet<StatementOrdinal>>,
+    owner_owner: BTreeMap<usize, BTreeSet<(OwnerId, OwnerId)>>,
+    owner_ordinal: BTreeMap<usize, BTreeSet<(OwnerId, StatementOrdinal)>>,
+    node_node: BTreeMap<usize, BTreeSet<(u32, u32)>>,
+    node_ordinal: BTreeMap<usize, BTreeSet<(u32, StatementOrdinal)>>,
+}
+
 fn solve_candidate_sets(
     program: &SelectorProgram,
     support: &ProgramSupport,
     facts: &FactIndex,
-    unary_supports: BTreeMap<usize, BTreeSet<OwnerId>>,
-    binary_edges: BTreeMap<usize, BTreeSet<(OwnerId, OwnerId)>>,
-) -> BTreeMap<SelectorVariableId, BTreeSet<OwnerId>> {
-    let mut candidates = BTreeMap::new();
+    derived: DerivedSupport,
+) -> CandidateSets {
+    let mut candidates = CandidateSets::default();
     for variable in &program.variables {
-        if variable.domain == VariableDomain::Owner {
-            candidates.insert(variable.id, facts.all_owners.clone());
+        match variable.domain {
+            VariableDomain::Owner => {
+                candidates
+                    .owners
+                    .insert(variable.id, facts.all_owners.clone());
+            }
+            VariableDomain::AstNode => {
+                candidates
+                    .nodes
+                    .insert(variable.id, facts.all_nodes.clone());
+            }
+            VariableDomain::StatementOrdinal => {
+                candidates
+                    .ordinals
+                    .insert(variable.id, facts.all_statement_ordinals.clone());
+            }
+            VariableDomain::String => {}
         }
     }
 
     for (variable, constraints) in &support.unary_constraints_by_var {
-        let mut intersection: Option<BTreeSet<OwnerId>> = None;
-        for constraint in constraints {
-            let supported = unary_supports.get(constraint).cloned().unwrap_or_default();
-            intersection = Some(match intersection {
-                Some(existing) => existing.intersection(&supported).copied().collect(),
-                None => supported,
-            });
-        }
-        if let Some(intersection) = intersection {
-            candidates.insert(*variable, intersection);
-        }
+        intersect_constraints(
+            &mut candidates.owners,
+            *variable,
+            constraints,
+            &derived.owner_unary,
+        );
+    }
+    for (variable, constraints) in &support.node_unary_constraints_by_var {
+        intersect_constraints(
+            &mut candidates.nodes,
+            *variable,
+            constraints,
+            &derived.node_unary,
+        );
+    }
+    for (variable, constraints) in &support.ordinal_unary_constraints_by_var {
+        intersect_constraints(
+            &mut candidates.ordinals,
+            *variable,
+            constraints,
+            &derived.ordinal_unary,
+        );
     }
 
     let mut changed = true;
     while changed {
         changed = false;
         for constraint in &support.binary_constraints {
-            let edges = binary_edges
+            let edges = derived
+                .owner_owner
                 .get(&constraint.id)
                 .cloned()
                 .unwrap_or_default();
             let left_current = candidates
+                .owners
                 .get(&constraint.left)
                 .cloned()
                 .unwrap_or_default();
             let right_current = candidates
+                .owners
                 .get(&constraint.right)
                 .cloned()
                 .unwrap_or_default();
 
-            let left_allowed: BTreeSet<OwnerId> = edges
+            // Owner-owner selector edges are directional: the left side is the
+            // selector target, while the right side is an anchor target. A failed
+            // dependent selector must not erase the anchor's own independent
+            // claim; AST/internal variables below remain bidirectional.
+            let left_allowed: BTreeSet<_> = edges
                 .iter()
                 .filter(|(left, right)| {
                     left_current.contains(left) && right_current.contains(right)
@@ -544,7 +972,105 @@ fn solve_candidate_sets(
                 .map(|(left, _right)| *left)
                 .collect();
 
-            if intersect_candidate_set(&mut candidates, constraint.left, left_allowed) {
+            if intersect_candidate_set(&mut candidates.owners, constraint.left, left_allowed) {
+                changed = true;
+            }
+        }
+        for constraint in &support.owner_ordinal_constraints {
+            let edges = derived
+                .owner_ordinal
+                .get(&constraint.id)
+                .cloned()
+                .unwrap_or_default();
+            let owner_current = candidates
+                .owners
+                .get(&constraint.owner)
+                .cloned()
+                .unwrap_or_default();
+            let ordinal_current = candidates
+                .ordinals
+                .get(&constraint.ordinal)
+                .cloned()
+                .unwrap_or_default();
+            let (owner_allowed, ordinal_allowed): (BTreeSet<_>, BTreeSet<_>) = edges
+                .iter()
+                .filter(|(owner, ordinal)| {
+                    owner_current.contains(owner) && ordinal_current.contains(ordinal)
+                })
+                .map(|(owner, ordinal)| (*owner, *ordinal))
+                .unzip();
+            if intersect_candidate_set(&mut candidates.owners, constraint.owner, owner_allowed) {
+                changed = true;
+            }
+            if intersect_candidate_set(
+                &mut candidates.ordinals,
+                constraint.ordinal,
+                ordinal_allowed,
+            ) {
+                changed = true;
+            }
+        }
+        for constraint in &support.node_node_constraints {
+            let edges = derived
+                .node_node
+                .get(&constraint.id)
+                .cloned()
+                .unwrap_or_default();
+            let left_current = candidates
+                .nodes
+                .get(&constraint.left)
+                .cloned()
+                .unwrap_or_default();
+            let right_current = candidates
+                .nodes
+                .get(&constraint.right)
+                .cloned()
+                .unwrap_or_default();
+            let (left_allowed, right_allowed): (BTreeSet<_>, BTreeSet<_>) = edges
+                .iter()
+                .filter(|(left, right)| {
+                    left_current.contains(left) && right_current.contains(right)
+                })
+                .map(|(left, right)| (*left, *right))
+                .unzip();
+            if intersect_candidate_set(&mut candidates.nodes, constraint.left, left_allowed) {
+                changed = true;
+            }
+            if intersect_candidate_set(&mut candidates.nodes, constraint.right, right_allowed) {
+                changed = true;
+            }
+        }
+        for constraint in &support.node_ordinal_constraints {
+            let edges = derived
+                .node_ordinal
+                .get(&constraint.id)
+                .cloned()
+                .unwrap_or_default();
+            let node_current = candidates
+                .nodes
+                .get(&constraint.node)
+                .cloned()
+                .unwrap_or_default();
+            let ordinal_current = candidates
+                .ordinals
+                .get(&constraint.ordinal)
+                .cloned()
+                .unwrap_or_default();
+            let (node_allowed, ordinal_allowed): (BTreeSet<_>, BTreeSet<_>) = edges
+                .iter()
+                .filter(|(node, ordinal)| {
+                    node_current.contains(node) && ordinal_current.contains(ordinal)
+                })
+                .map(|(node, ordinal)| (*node, *ordinal))
+                .unzip();
+            if intersect_candidate_set(&mut candidates.nodes, constraint.node, node_allowed) {
+                changed = true;
+            }
+            if intersect_candidate_set(
+                &mut candidates.ordinals,
+                constraint.ordinal,
+                ordinal_allowed,
+            ) {
                 changed = true;
             }
         }
@@ -553,10 +1079,29 @@ fn solve_candidate_sets(
     candidates
 }
 
-fn intersect_candidate_set(
-    candidates: &mut BTreeMap<SelectorVariableId, BTreeSet<OwnerId>>,
+fn intersect_constraints<T: Copy + Ord>(
+    candidates: &mut BTreeMap<SelectorVariableId, BTreeSet<T>>,
     variable: SelectorVariableId,
-    allowed: BTreeSet<OwnerId>,
+    constraints: &[usize],
+    supports: &BTreeMap<usize, BTreeSet<T>>,
+) {
+    let mut intersection: Option<BTreeSet<T>> = None;
+    for constraint in constraints {
+        let supported = supports.get(constraint).cloned().unwrap_or_default();
+        intersection = Some(match intersection {
+            Some(existing) => existing.intersection(&supported).copied().collect(),
+            None => supported,
+        });
+    }
+    if let Some(intersection) = intersection {
+        candidates.insert(variable, intersection);
+    }
+}
+
+fn intersect_candidate_set<T: Copy + Ord>(
+    candidates: &mut BTreeMap<SelectorVariableId, BTreeSet<T>>,
+    variable: SelectorVariableId,
+    allowed: BTreeSet<T>,
 ) -> bool {
     let current = candidates.entry(variable).or_default();
     let next = current.intersection(&allowed).copied().collect();
@@ -675,8 +1220,15 @@ fn apply_all_different(program: &SelectorProgram, result: &mut SolverResult) {
 struct ProgramSupport {
     next_constraint_id: usize,
     unary_constraints: Vec<UnaryConstraint>,
+    node_unary_constraints: Vec<NodeUnaryConstraint>,
+    ordinal_unary_constraints: Vec<OrdinalUnaryConstraint>,
     binary_constraints: Vec<BinaryConstraint>,
+    owner_ordinal_constraints: Vec<OwnerOrdinalConstraint>,
+    node_node_constraints: Vec<NodeNodeConstraint>,
+    node_ordinal_constraints: Vec<NodeOrdinalConstraint>,
     unary_constraints_by_var: BTreeMap<SelectorVariableId, Vec<usize>>,
+    node_unary_constraints_by_var: BTreeMap<SelectorVariableId, Vec<usize>>,
+    ordinal_unary_constraints_by_var: BTreeMap<SelectorVariableId, Vec<usize>>,
     constraints_by_var: BTreeMap<SelectorVariableId, Vec<usize>>,
     unsupported_atoms: Vec<String>,
 }
@@ -714,6 +1266,9 @@ impl ProgramSupport {
                         statement_kind: value.clone(),
                     },
                 ),
+                SelectorAtom::OwnerStatementOrdinal { owner, ordinal } => {
+                    support.add_owner_statement_ordinal(owner, ordinal)
+                }
                 SelectorAtom::OwnerReferencesBinding {
                     owner: OwnerTerm::Var { id },
                     binding: StringTerm::Const { value },
@@ -738,6 +1293,92 @@ impl ProgramSupport {
                     owner: OwnerTerm::Var { id: owner },
                     aliased: OwnerTerm::Var { id: aliased },
                 } => support.add_binary(*owner, *aliased, BinaryConstraintKind::AliasesOwner),
+                SelectorAtom::AstKind { node, node_kind } => match node {
+                    NodeTerm::Var { id } => support.add_node_unary(
+                        *id,
+                        NodeUnaryConstraintKind::Kind {
+                            node_kind: node_kind.as_tag().to_string(),
+                        },
+                    ),
+                    NodeTerm::Const { .. } => support
+                        .unsupported_atoms
+                        .push("unsupported constant-only ast_kind assertion".to_string()),
+                },
+                SelectorAtom::AstChild {
+                    parent,
+                    index,
+                    child,
+                } => support.add_ast_child(parent, *index, child),
+                SelectorAtom::AstStringLiteral {
+                    node,
+                    value: StringTerm::Const { value },
+                } => support.add_node_label(
+                    node,
+                    NodeUnaryConstraintKind::StringLiteral {
+                        value: value.clone(),
+                    },
+                    "ast_string_literal",
+                ),
+                SelectorAtom::AstNumberLiteral {
+                    node,
+                    value: StringTerm::Const { value },
+                } => support.add_node_label(
+                    node,
+                    NodeUnaryConstraintKind::NumberLiteral {
+                        value: value.clone(),
+                    },
+                    "ast_number_literal",
+                ),
+                SelectorAtom::AstBoolLiteral { node, value } => support.add_node_label(
+                    node,
+                    NodeUnaryConstraintKind::BoolLiteral { value: *value },
+                    "ast_bool_literal",
+                ),
+                SelectorAtom::AstIdentifierName {
+                    node,
+                    value: StringTerm::Const { value },
+                } => support.add_node_label(
+                    node,
+                    NodeUnaryConstraintKind::IdentifierName {
+                        value: value.clone(),
+                    },
+                    "ast_identifier_name",
+                ),
+                SelectorAtom::AstPropertyName {
+                    node,
+                    value: StringTerm::Const { value },
+                } => support.add_node_label(
+                    node,
+                    NodeUnaryConstraintKind::PropertyName {
+                        value: value.clone(),
+                    },
+                    "ast_property_name",
+                ),
+                SelectorAtom::AstOperator {
+                    node,
+                    value: StringTerm::Const { value },
+                } => support.add_node_label(
+                    node,
+                    NodeUnaryConstraintKind::Operator {
+                        value: value.clone(),
+                    },
+                    "ast_operator",
+                ),
+                SelectorAtom::AstRegexLiteral {
+                    node,
+                    pattern: StringTerm::Const { value: pattern },
+                    flags: StringTerm::Const { value: flags },
+                } => support.add_node_label(
+                    node,
+                    NodeUnaryConstraintKind::RegexLiteral {
+                        pattern: pattern.clone(),
+                        flags: flags.clone(),
+                    },
+                    "ast_regex_literal",
+                ),
+                SelectorAtom::AstTopLevel { node, ordinal } => {
+                    support.add_ast_top_level(node, ordinal)
+                }
                 SelectorAtom::ReadsMember {
                     owner: OwnerTerm::Var { id },
                     object: None,
@@ -917,6 +1558,175 @@ impl ProgramSupport {
         self.constraints_by_var.entry(right).or_default().push(id);
     }
 
+    fn add_node_unary(&mut self, variable: SelectorVariableId, kind: NodeUnaryConstraintKind) {
+        let id = self.next_constraint_id;
+        self.next_constraint_id += 1;
+        self.node_unary_constraints
+            .push(NodeUnaryConstraint { id, variable, kind });
+        self.node_unary_constraints_by_var
+            .entry(variable)
+            .or_default()
+            .push(id);
+        self.constraints_by_var
+            .entry(variable)
+            .or_default()
+            .push(id);
+    }
+
+    fn add_ordinal_unary(
+        &mut self,
+        variable: SelectorVariableId,
+        kind: OrdinalUnaryConstraintKind,
+    ) {
+        let id = self.next_constraint_id;
+        self.next_constraint_id += 1;
+        self.ordinal_unary_constraints
+            .push(OrdinalUnaryConstraint { id, variable, kind });
+        self.ordinal_unary_constraints_by_var
+            .entry(variable)
+            .or_default()
+            .push(id);
+        self.constraints_by_var
+            .entry(variable)
+            .or_default()
+            .push(id);
+    }
+
+    fn add_owner_ordinal(
+        &mut self,
+        owner: SelectorVariableId,
+        ordinal: SelectorVariableId,
+        kind: OwnerOrdinalConstraintKind,
+    ) {
+        let id = self.next_constraint_id;
+        self.next_constraint_id += 1;
+        self.owner_ordinal_constraints.push(OwnerOrdinalConstraint {
+            id,
+            owner,
+            ordinal,
+            kind,
+        });
+        self.constraints_by_var.entry(owner).or_default().push(id);
+        self.constraints_by_var.entry(ordinal).or_default().push(id);
+    }
+
+    fn add_node_node(
+        &mut self,
+        left: SelectorVariableId,
+        right: SelectorVariableId,
+        kind: NodeNodeConstraintKind,
+    ) {
+        let id = self.next_constraint_id;
+        self.next_constraint_id += 1;
+        self.node_node_constraints.push(NodeNodeConstraint {
+            id,
+            left,
+            right,
+            kind,
+        });
+        self.constraints_by_var.entry(left).or_default().push(id);
+        self.constraints_by_var.entry(right).or_default().push(id);
+    }
+
+    fn add_node_ordinal(
+        &mut self,
+        node: SelectorVariableId,
+        ordinal: SelectorVariableId,
+        kind: NodeOrdinalConstraintKind,
+    ) {
+        let id = self.next_constraint_id;
+        self.next_constraint_id += 1;
+        self.node_ordinal_constraints.push(NodeOrdinalConstraint {
+            id,
+            node,
+            ordinal,
+            kind,
+        });
+        self.constraints_by_var.entry(node).or_default().push(id);
+        self.constraints_by_var.entry(ordinal).or_default().push(id);
+    }
+
+    fn add_owner_statement_ordinal(&mut self, owner: &OwnerTerm, ordinal: &OrdinalTerm) {
+        match (owner, ordinal) {
+            (OwnerTerm::Var { id: owner }, OrdinalTerm::Const { ordinal }) => self.add_unary(
+                *owner,
+                UnaryConstraintKind::OwnerStatementOrdinal { ordinal: *ordinal },
+            ),
+            (OwnerTerm::Var { id: owner }, OrdinalTerm::Var { id: ordinal }) => self
+                .add_owner_ordinal(
+                    *owner,
+                    *ordinal,
+                    OwnerOrdinalConstraintKind::OwnerStatementOrdinal,
+                ),
+            (OwnerTerm::Const { owner }, OrdinalTerm::Var { id: ordinal }) => self
+                .add_ordinal_unary(
+                    *ordinal,
+                    OrdinalUnaryConstraintKind::OwnerStatementOrdinal { owner: *owner },
+                ),
+            _ => self
+                .unsupported_atoms
+                .push("unsupported constant-only owner_statement_ordinal assertion".to_string()),
+        }
+    }
+
+    fn add_ast_child(&mut self, parent: &NodeTerm, index: u32, child: &NodeTerm) {
+        match (parent, child) {
+            (NodeTerm::Var { id: parent }, NodeTerm::Var { id: child }) => {
+                self.add_node_node(*parent, *child, NodeNodeConstraintKind::AstChild { index });
+            }
+            (NodeTerm::Var { id: parent }, NodeTerm::Const { node: child }) => self.add_node_unary(
+                *parent,
+                NodeUnaryConstraintKind::ChildParent {
+                    index,
+                    child: *child,
+                },
+            ),
+            (NodeTerm::Const { node: parent }, NodeTerm::Var { id: child }) => self.add_node_unary(
+                *child,
+                NodeUnaryConstraintKind::ChildChild {
+                    parent: *parent,
+                    index,
+                },
+            ),
+            _ => self
+                .unsupported_atoms
+                .push("unsupported constant-only ast_child assertion".to_string()),
+        }
+    }
+
+    fn add_node_label(
+        &mut self,
+        node: &NodeTerm,
+        kind: NodeUnaryConstraintKind,
+        relation: &'static str,
+    ) {
+        match node {
+            NodeTerm::Var { id } => self.add_node_unary(*id, kind),
+            NodeTerm::Const { .. } => self
+                .unsupported_atoms
+                .push(format!("unsupported constant-only {relation} assertion")),
+        }
+    }
+
+    fn add_ast_top_level(&mut self, node: &NodeTerm, ordinal: &OrdinalTerm) {
+        match (node, ordinal) {
+            (NodeTerm::Var { id: node }, OrdinalTerm::Const { ordinal }) => self.add_node_unary(
+                *node,
+                NodeUnaryConstraintKind::TopLevelOrdinal { ordinal: *ordinal },
+            ),
+            (NodeTerm::Var { id: node }, OrdinalTerm::Var { id: ordinal }) => {
+                self.add_node_ordinal(*node, *ordinal, NodeOrdinalConstraintKind::AstTopLevel)
+            }
+            (NodeTerm::Const { node }, OrdinalTerm::Var { id: ordinal }) => self.add_ordinal_unary(
+                *ordinal,
+                OrdinalUnaryConstraintKind::AstTopLevelNode { node: *node },
+            ),
+            _ => self
+                .unsupported_atoms
+                .push("unsupported constant-only ast_top_level assertion".to_string()),
+        }
+    }
+
     fn unsupported_reason_for_target(&self, target: &SelectorTarget) -> Option<String> {
         if !self.constraints_by_var.contains_key(&target.owner) {
             return Some("target owner variable has no selector constraints".to_string());
@@ -1010,6 +1820,44 @@ enum UnaryConstraintKind {
     SourceMatchCandidate {
         selector_key: String,
     },
+    OwnerStatementOrdinal {
+        ordinal: StatementOrdinal,
+    },
+}
+
+#[derive(Debug, Clone)]
+struct NodeUnaryConstraint {
+    id: usize,
+    variable: SelectorVariableId,
+    kind: NodeUnaryConstraintKind,
+}
+
+#[derive(Debug, Clone)]
+enum NodeUnaryConstraintKind {
+    Kind { node_kind: String },
+    ChildParent { index: u32, child: u32 },
+    ChildChild { parent: u32, index: u32 },
+    StringLiteral { value: String },
+    NumberLiteral { value: String },
+    BoolLiteral { value: bool },
+    IdentifierName { value: String },
+    PropertyName { value: String },
+    Operator { value: String },
+    RegexLiteral { pattern: String, flags: String },
+    TopLevelOrdinal { ordinal: StatementOrdinal },
+}
+
+#[derive(Debug, Clone)]
+struct OrdinalUnaryConstraint {
+    id: usize,
+    variable: SelectorVariableId,
+    kind: OrdinalUnaryConstraintKind,
+}
+
+#[derive(Debug, Clone)]
+enum OrdinalUnaryConstraintKind {
+    OwnerStatementOrdinal { owner: OwnerId },
+    AstTopLevelNode { node: u32 },
 }
 
 #[derive(Debug, Clone)]
@@ -1037,6 +1885,45 @@ enum BinaryConstraintKind {
     IntrinsicAlias {
         property: String,
     },
+}
+
+#[derive(Debug, Clone)]
+struct OwnerOrdinalConstraint {
+    id: usize,
+    owner: SelectorVariableId,
+    ordinal: SelectorVariableId,
+    kind: OwnerOrdinalConstraintKind,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum OwnerOrdinalConstraintKind {
+    OwnerStatementOrdinal,
+}
+
+#[derive(Debug, Clone)]
+struct NodeNodeConstraint {
+    id: usize,
+    left: SelectorVariableId,
+    right: SelectorVariableId,
+    kind: NodeNodeConstraintKind,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum NodeNodeConstraintKind {
+    AstChild { index: u32 },
+}
+
+#[derive(Debug, Clone)]
+struct NodeOrdinalConstraint {
+    id: usize,
+    node: SelectorVariableId,
+    ordinal: SelectorVariableId,
+    kind: NodeOrdinalConstraintKind,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum NodeOrdinalConstraintKind {
+    AstTopLevel,
 }
 
 fn optional_const_string(value: &Option<StringTerm>) -> Option<Option<String>> {
@@ -1083,6 +1970,8 @@ fn atom_kind(atom: &SelectorAtom) -> &'static str {
 #[derive(Debug, Default)]
 struct FactIndex {
     all_owners: BTreeSet<OwnerId>,
+    all_nodes: BTreeSet<u32>,
+    all_statement_ordinals: BTreeSet<StatementOrdinal>,
     owner_facts: Vec<(OwnerId, StatementOrdinal, String)>,
     statement_ordinal_by_owner: BTreeMap<OwnerId, StatementOrdinal>,
     owner_by_statement_ordinal: BTreeMap<StatementOrdinal, OwnerId>,
@@ -1098,6 +1987,18 @@ struct FactIndex {
     decorate_calls: Vec<(String, String, Option<String>)>,
     intrinsic_aliases: Vec<(String, String)>,
     source_match_candidates: Vec<(String, OwnerId, String)>,
+    ast_kinds: Vec<(u32, String)>,
+    ast_children: Vec<(u32, u32, u32)>,
+    ast_string_literals: Vec<(u32, String)>,
+    ast_string_wildcards: Vec<(u32, String)>,
+    ast_number_literals: Vec<(u32, String)>,
+    ast_bool_literals: Vec<(u32, bool)>,
+    ast_identifier_names: Vec<(u32, String)>,
+    ast_property_names: Vec<(u32, String)>,
+    ast_operators: Vec<(u32, String)>,
+    ast_regex_literals: Vec<(u32, String, String)>,
+    ast_super_classes: Vec<(u32, u32)>,
+    ast_top_levels: Vec<(u32, StatementOrdinal)>,
 }
 
 impl FactIndex {
@@ -1121,6 +2022,7 @@ impl FactIndex {
                 index
                     .owner_by_statement_ordinal
                     .insert(*statement_ordinal, *owner);
+                index.all_statement_ordinals.insert(*statement_ordinal);
             }
         }
 
@@ -1236,7 +2138,81 @@ impl FactIndex {
                         ));
                     }
                 }
-                _ => {}
+                SelectorFact::AstKind {
+                    node, node_kind, ..
+                } => {
+                    index.all_nodes.insert(*node);
+                    index
+                        .ast_kinds
+                        .push((*node, node_kind.as_tag().to_string()));
+                }
+                SelectorFact::AstChild {
+                    parent,
+                    index: child_index,
+                    child,
+                    ..
+                } => {
+                    index.all_nodes.insert(*parent);
+                    index.all_nodes.insert(*child);
+                    index.ast_children.push((*parent, *child_index, *child));
+                }
+                SelectorFact::AstStringLiteral { node, value, .. } => {
+                    index.all_nodes.insert(*node);
+                    index.ast_string_literals.push((*node, value.clone()));
+                }
+                SelectorFact::AstStringWildcard { node, token, .. } => {
+                    index.all_nodes.insert(*node);
+                    index.ast_string_wildcards.push((*node, token.clone()));
+                }
+                SelectorFact::AstNumberLiteral { node, value, .. } => {
+                    index.all_nodes.insert(*node);
+                    index.ast_number_literals.push((*node, value.clone()));
+                }
+                SelectorFact::AstBoolLiteral { node, value, .. } => {
+                    index.all_nodes.insert(*node);
+                    index.ast_bool_literals.push((*node, *value));
+                }
+                SelectorFact::AstIdentifierName { node, value, .. } => {
+                    index.all_nodes.insert(*node);
+                    index.ast_identifier_names.push((*node, value.clone()));
+                }
+                SelectorFact::AstPropertyName { node, value, .. } => {
+                    index.all_nodes.insert(*node);
+                    index.ast_property_names.push((*node, value.clone()));
+                }
+                SelectorFact::AstOperator { node, value, .. } => {
+                    index.all_nodes.insert(*node);
+                    index.ast_operators.push((*node, value.clone()));
+                }
+                SelectorFact::AstRegexLiteral {
+                    node,
+                    pattern,
+                    flags,
+                    ..
+                } => {
+                    index.all_nodes.insert(*node);
+                    index
+                        .ast_regex_literals
+                        .push((*node, pattern.clone(), flags.clone()));
+                }
+                SelectorFact::AstSuperClass {
+                    class_node,
+                    super_class,
+                    ..
+                } => {
+                    index.all_nodes.insert(*class_node);
+                    index.all_nodes.insert(*super_class);
+                    index.ast_super_classes.push((*class_node, *super_class));
+                }
+                SelectorFact::AstTopLevel {
+                    node,
+                    statement_ordinal,
+                    ..
+                } => {
+                    index.all_nodes.insert(*node);
+                    index.all_statement_ordinals.insert(*statement_ordinal);
+                    index.ast_top_levels.push((*node, *statement_ordinal));
+                }
             }
         }
         index
@@ -1502,6 +2478,102 @@ mod tests {
     }
 
     #[test]
+    fn ast_atoms_prune_owner_candidates_through_statement_root() {
+        let mut program = SelectorProgram::default();
+        let target_owner = program.add_variable(VariableDomain::Owner, Some("@Target".to_string()));
+        let ordinal = program.add_variable(
+            VariableDomain::StatementOrdinal,
+            Some("target.ordinal".to_string()),
+        );
+        let root = program.add_variable(VariableDomain::AstNode, Some("target.root".to_string()));
+        let binding_node =
+            program.add_variable(VariableDomain::AstNode, Some("target.binding".to_string()));
+        let target = program.add_target(
+            ChunkId(0),
+            target_owner,
+            "runtime/target",
+            ClaimKind::Binding {
+                export_name: Some("Target".to_string()),
+            },
+            ClaimOrigin::MemberSelector,
+        );
+        program.add_atom(SelectorAtom::OwnerStatementOrdinal {
+            owner: OwnerTerm::Var { id: target_owner },
+            ordinal: selector_ir::OrdinalTerm::Var { id: ordinal },
+        });
+        program.add_atom(SelectorAtom::AstTopLevel {
+            node: selector_ir::NodeTerm::Var { id: root },
+            ordinal: selector_ir::OrdinalTerm::Var { id: ordinal },
+        });
+        program.add_atom(SelectorAtom::AstChild {
+            parent: selector_ir::NodeTerm::Var { id: root },
+            index: 0,
+            child: selector_ir::NodeTerm::Var { id: binding_node },
+        });
+        program.add_atom(SelectorAtom::AstIdentifierName {
+            node: selector_ir::NodeTerm::Var { id: binding_node },
+            value: StringTerm::Const {
+                value: "b".to_string(),
+            },
+        });
+        let facts = SelectorFactStore {
+            facts: vec![
+                owner(1, 1, "var_decl"),
+                declared(1, "a"),
+                owner(2, 2, "var_decl"),
+                declared(2, "b"),
+                SelectorFact::AstTopLevel {
+                    chunk_id: ChunkId(0),
+                    node: 10,
+                    statement_ordinal: StatementOrdinal(1),
+                },
+                SelectorFact::AstChild {
+                    chunk_id: ChunkId(0),
+                    parent: 10,
+                    index: 0,
+                    child: 11,
+                },
+                SelectorFact::AstIdentifierName {
+                    chunk_id: ChunkId(0),
+                    node: 11,
+                    value: "a".to_string(),
+                },
+                SelectorFact::AstTopLevel {
+                    chunk_id: ChunkId(0),
+                    node: 20,
+                    statement_ordinal: StatementOrdinal(2),
+                },
+                SelectorFact::AstChild {
+                    chunk_id: ChunkId(0),
+                    parent: 20,
+                    index: 0,
+                    child: 21,
+                },
+                SelectorFact::AstIdentifierName {
+                    chunk_id: ChunkId(0),
+                    node: 21,
+                    value: "b".to_string(),
+                },
+            ],
+        };
+
+        let result = solve(&program, &facts).unwrap();
+
+        assert_eq!(
+            result.outcome_for(target),
+            Some(&ClaimOutcome::Unique {
+                claim: ResolvedClaim {
+                    chunk_id: ChunkId(0),
+                    owner: OwnerId(2),
+                    statement_ordinal: StatementOrdinal(2),
+                    binding: Some("b".to_string()),
+                    provenance: Vec::new(),
+                },
+            })
+        );
+    }
+
+    #[test]
     fn solves_cross_ref_anchor_in_one_program() {
         let mut builder = MemberSelectorProgramBuilder::new(MemberSelectorLoweringContext::new(
             ChunkId(0),
@@ -1546,6 +2618,71 @@ mod tests {
             result.outcome_for(delegator),
             Some(ClaimOutcome::Unique { claim }) if claim.owner == OwnerId(2)
         ));
+    }
+
+    #[test]
+    fn missing_dependent_owner_relation_does_not_poison_anchor_claim() {
+        let mut builder = MemberSelectorProgramBuilder::new(MemberSelectorLoweringContext::new(
+            ChunkId(0),
+            "runtime/widgets",
+        ));
+        let class = builder
+            .lower_member_selector("DecoratedClass", &binding_selector("C", None))
+            .unwrap();
+        let helper = builder
+            .lower_member_selector(
+                "decorateClassMember",
+                &MemberSelectorSpec::MakesDecorateCall(MakesDecorateCallTarget {
+                    class: "DecoratedClass".to_string(),
+                    member: None,
+                    kind: None,
+                }),
+            )
+            .unwrap();
+        let alias = builder
+            .lower_member_selector(
+                "defineProp",
+                &MemberSelectorSpec::IntrinsicAlias(IntrinsicAliasTarget {
+                    property: "defineProperty".to_string(),
+                    referenced_by: "decorateClassMember".to_string(),
+                }),
+            )
+            .unwrap();
+        let program = builder.into_program().unwrap();
+        let facts = SelectorFactStore {
+            facts: vec![
+                owner(1, 1, "class_decl"),
+                declared(1, "C"),
+                owner(2, 2, "var_decl"),
+                declared(2, "d"),
+                owner(3, 3, "var_decl"),
+                declared(3, "p"),
+                SelectorFact::DecorateCallUse {
+                    chunk_id: ChunkId(0),
+                    callee: "d".to_string(),
+                    class_anchor: "C".to_string(),
+                    member: None,
+                },
+                SelectorFact::OwnerReferencesBinding {
+                    chunk_id: ChunkId(0),
+                    owner: OwnerId(2),
+                    binding: "p".to_string(),
+                    edge_kind: "eager_use".to_string(),
+                },
+            ],
+        };
+
+        let result = solve(&program, &facts).unwrap();
+
+        assert!(matches!(
+            result.outcome_for(class),
+            Some(ClaimOutcome::Unique { claim }) if claim.owner == OwnerId(1)
+        ));
+        assert!(matches!(
+            result.outcome_for(helper),
+            Some(ClaimOutcome::Unique { claim }) if claim.owner == OwnerId(2)
+        ));
+        assert_eq!(result.outcome_for(alias), Some(&ClaimOutcome::NoMatch));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Thread `chunk_facts::extract_facts` into the selector fact store used by materialization, failing closed when AST EDB projection is incomplete.
- Teach `selector_ir_solver` to ingest AST EDB rows into Ascent and propagate owner, AST-node, and statement-ordinal constraints together.
- Add regressions proving AST atoms can prune owner candidates through `owner -> ordinal -> top-level root -> child identifier` without `SourceMatchCandidate` rows, and that missing dependent relational selectors do not erase their anchor target's own claim.
- Consolidate `TODO.md` / `plans/selector_constraint_model.md` after #2439: Ascent remains the solver, #2439 closed solver admission for `source_match`, and the remaining P0 is native AST lowering plus candidate-oracle deletion.

## Notes

This does not delete `SourceMatchCandidate` yet. It lands the native AST EDB ingestion and solver-domain foundation needed for the next parity-lowering step.

## Tests

- `nix develop -c bazelisk test //devinfra/js/debundle:selector_ir_solver_test`
- `nix develop -c bazelisk test //devinfra/js/debundle/e2e:intrinsic_alias_lowering_test`
- `nix develop -c bazelisk test //devinfra/js/debundle:lowering_test`
- `nix develop -c pre-commit run --files devinfra/js/debundle/selector_ir_solver.rs`