### PR TITLE
Add full-NixOS worker image for Haku Managed Agents

### DIFF
--- a/.github/workflows/haku-worker-image.yml
+++ b/.github/workflows/haku-worker-image.yml
@@ -1,0 +1,84 @@
+# Build the Haku Managed Agents self-hosted worker image (Runtime B) with Nix
+# and push it to GHCR.
+#
+# Unlike the Dockerfile images in container-images.yml (docker/build-push-action
+# via the ghcr-build-push composite), this is a Nix flake output: a full-NixOS
+# rootfs tarball (`.#haku-worker-image`), so it is `podman import`-ed and pushed
+# rather than buildx-built. Flux picks up the pushed `devel-<ts>-<sha7>` tag via
+# the haku-worker ImagePolicy (cluster/k8s/flux-image-automation-ghcr/).
+name: haku-worker image
+
+on:
+  push:
+    branches: [devel]
+    paths:
+      - "haku/runtime/managed_agent/**"
+      - "flake.nix"
+      - "nix/packages/anthropic-cli.nix"
+      - "nix/packages/fastmcp.nix"
+      - ".github/workflows/haku-worker-image.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-push:
+    name: Build & push haku-worker
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      IMAGE: ghcr.io/${{ github.repository_owner }}/haku-worker
+    steps:
+      - uses: actions/checkout@v6
+
+      # Attic trusted pubkeys (SSOT) — read with jq before Nix is installed,
+      # since extra_nix_config below is a static field.
+      - name: Load Attic trusted pubkeys
+        id: attic_keys
+        run: echo "value=$(jq -r 'join(" ")' nix/attic-pubkeys.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            experimental-features = nix-command flakes fetch-closure
+            netrc-file = /home/runner/.config/nix/netrc
+            extra-trusted-public-keys = ${{ steps.attic_keys.outputs.value }}
+            extra-substituters = https://cache.allegedly.works/main
+            fallback = true
+
+      - uses: ./.github/actions/setup-ci-secrets
+        with:
+          sops_age_key: ${{ secrets.SOPS_AGE_KEY }}
+
+      - name: Write Nix netrc for cache.allegedly.works
+        run: |
+          mkdir -p /home/runner/.config/nix
+          umask 077
+          printf 'machine cache.allegedly.works password %s\n' "$ATTIC_TOKEN" \
+            > /home/runner/.config/nix/netrc
+
+      - name: Build image
+        run: nix build .#haku-worker-image --print-build-logs
+
+      - name: Compute tag
+        id: meta
+        run: |
+          SHA="${{ github.sha }}"
+          echo "pin_tag=${GITHUB_REF_NAME}-$(date -u +%Y%m%d%H%M%S)-${SHA:0:7}" >> "$GITHUB_OUTPUT"
+
+      # Gate the push to devel so feature branches don't publish tags the Flux
+      # ImagePolicy would immediately deploy (matches push-images.yml).
+      - name: Import + push to GHCR
+        if: github.ref_name == 'devel'
+        run: |
+          echo "${{ github.token }}" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
+          # NixOS system.build.tarball is a flat rootfs tar.xz (not an OCI
+          # archive): import it, baking the systemd init as CMD, then push.
+          ref="$IMAGE:${{ steps.meta.outputs.pin_tag }}"
+          podman import --change 'CMD ["/init"]' result/tarball/*.tar.xz "$ref"
+          podman push "$ref"
+          echo "pushed \`$ref\`" >> "$GITHUB_STEP_SUMMARY"

--- a/cluster/k8s/flux-image-automation-ghcr/haku-worker-image-policy.yaml
+++ b/cluster/k8s/flux-image-automation-ghcr/haku-worker-image-policy.yaml
@@ -1,0 +1,14 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: haku-worker
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: haku-worker
+  filterTags:
+    # Tags pushed by CI: {branch}-YYYYMMDDHHMMSS-{sha7} — alphabetical == chronological
+    pattern: '^devel-\d{14}-[0-9a-f]{7}$'
+  policy:
+    alphabetical:
+      order: asc

--- a/cluster/k8s/flux-image-automation-ghcr/haku-worker-image-repository.yaml
+++ b/cluster/k8s/flux-image-automation-ghcr/haku-worker-image-repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: haku-worker
+  namespace: flux-system
+spec:
+  image: ghcr.io/agentydragon/haku-worker
+  interval: 5m

--- a/cluster/k8s/flux-image-automation-ghcr/kustomization.yaml
+++ b/cluster/k8s/flux-image-automation-ghcr/kustomization.yaml
@@ -51,6 +51,8 @@ resources:
   - grocy-mcp-oidc-server-image-policy.yaml
   - haku-console-image-repository.yaml
   - haku-console-image-policy.yaml
+  - haku-worker-image-repository.yaml
+  - haku-worker-image-policy.yaml
   # CLEANUP: remove kubernetes-mcp-server entries when upstream releases
   # the well-known 404 fallback (see third_party/kubernetes-mcp-server-pin.txt).
   - kubernetes-mcp-server-image-repository.yaml

--- a/cluster/k8s/flux-webhook/github-webhook-receiver.yaml
+++ b/cluster/k8s/flux-webhook/github-webhook-receiver.yaml
@@ -52,6 +52,9 @@ spec:
     - apiVersion: image.toolkit.fluxcd.io/v1beta2
       kind: ImageRepository
       name: haku-console
+    - apiVersion: image.toolkit.fluxcd.io/v1beta2
+      kind: ImageRepository
+      name: haku-worker
     # CLEANUP: remove when upstream releases the well-known 404 fallback.
     - apiVersion: image.toolkit.fluxcd.io/v1beta2
       kind: ImageRepository

--- a/cluster/k8s/haku/agent-worker/README.md
+++ b/cluster/k8s/haku/agent-worker/README.md
@@ -24,9 +24,9 @@ environment key exists. Nothing deploys until the operator activates it.
    value, created only via the Console — never the API.
 2. **Set the secret**: `sops cluster/k8s/haku/agent-worker/environment-key.sops.yaml`
    and replace the placeholder `environment_key` with the generated value.
-3. **Confirm the env wiring** in `deployment.yaml`: `ANTHROPIC_ENVIRONMENT_ID`,
-   `HAKU_GIT_HOST`, and `HAKU_DUCKTAPE_REPO_URL` (the last is a literal — adjust
-   if ducktape isn't public / not on `HAKU_GIT_HOST`).
+3. **Confirm the env wiring** in `deployment.yaml`: `ANTHROPIC_ENVIRONMENT_ID`
+   and `HAKU_GIT_HOST` (the haku-state Forgejo host). `HAKU_DUCKTAPE_REPO_URL` is
+   the public GitHub repo, cloned anonymously.
 4. **Activate**: set `suspend: false` in `flux-kustomization.yaml`, commit, push.
    Watch the Deployment — being the first systemd container here, verify it boots
    unprivileged (cgroup-v2 delegation, writable `/run`); tune the pod

--- a/cluster/k8s/haku/agent-worker/README.md
+++ b/cluster/k8s/haku/agent-worker/README.md
@@ -1,0 +1,35 @@
+# haku-worker — Managed Agents self-hosted worker (Runtime B)
+
+In-cluster worker for Haku on Anthropic Managed Agents. It long-polls
+Anthropic's work queue (`ant beta:worker poll`) and executes tool calls inside
+`haku-sandbox`. Design, trust split, and the control-plane provisioning live with
+the component: <../../../../haku/runtime/managed_agent/README.md>.
+
+The image is the full-NixOS `.#haku-worker-image` (systemd PID 1), built and
+pushed to `ghcr.io/agentydragon/haku-worker` by
+`.github/workflows/haku-worker-image.yml`; Flux tracks the tag via the
+`haku-worker` ImagePolicy.
+
+## Shipped suspended
+
+`flux-kustomization.yaml` has `suspend: true`. It is the first systemd-PID1 pod
+in the cluster (runs as root PID 1, unprivileged; the worker process drops to
+non-root `haku` via the systemd unit), and it can't authenticate until the
+environment key exists. Nothing deploys until the operator activates it.
+
+## Activation runbook
+
+1. **Generate the environment key** in the Console (Environments →
+   `haku-selfhosted` → _Generate environment key_). It is an `sk-ant-oat01-…`
+   value, created only via the Console — never the API.
+2. **Set the secret**: `sops cluster/k8s/haku/agent-worker/environment-key.sops.yaml`
+   and replace the placeholder `environment_key` with the generated value.
+3. **Confirm the env wiring** in `deployment.yaml`: `ANTHROPIC_ENVIRONMENT_ID`,
+   `HAKU_GIT_HOST`, and `HAKU_DUCKTAPE_REPO_URL` (the last is a literal — adjust
+   if ducktape isn't public / not on `HAKU_GIT_HOST`).
+4. **Activate**: set `suspend: false` in `flux-kustomization.yaml`, commit, push.
+   Watch the Deployment — being the first systemd container here, verify it boots
+   unprivileged (cgroup-v2 delegation, writable `/run`); tune the pod
+   `securityContext` if systemd needs an adjustment.
+5. **Smoke test**: `ant beta:deployments run --deployment-id depl_011DSrUoXuhoDWJoPyDuePqR`
+   (org `ANTHROPIC_API_KEY`, off the worker) and watch the session in the Console.

--- a/cluster/k8s/haku/agent-worker/deployment.yaml
+++ b/cluster/k8s/haku/agent-worker/deployment.yaml
@@ -1,0 +1,103 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: haku-worker
+  namespace: haku-sandbox
+  labels:
+    app.kubernetes.io/name: haku-worker
+  annotations:
+    description: "Anthropic Managed Agents self-hosted worker (Runtime B; ducktape haku/runtime/managed_agent). Long-polls Anthropic's work queue (`ant beta:worker poll`) and runs tool calls in-sandbox. The haku-sandbox perimeter (haku-mitmproxy egress, RBAC, ResourceQuota) is the fence; the worker holds only the environment key, never the org API key."
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: haku-worker
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: haku-worker
+    spec:
+      serviceAccountName: haku-worker
+      # The worker's `bash` tool runs `kubectl` with this SA's in-cluster token.
+      automountServiceAccountToken: true
+      enableServiceLinks: false
+      # NOTE — full-NixOS image: PID 1 is systemd (`/init`), which MUST run as
+      # root inside the container. The WORKER itself is non-root: the
+      # haku-worker systemd unit runs it as `User=haku` (uid 1000). So, unlike
+      # haku-console (a single runAsNonRoot process), this pod is not
+      # runAsNonRoot and does not drop all caps — systemd needs root +
+      # SETUID/SETGID to drop the worker to `haku`. It is still UNPRIVILEGED
+      # (no privileged, no added caps) and relies on cgroup-v2 (Talos).
+      # This is the FIRST systemd-PID1 pod in the cluster: the securityContext
+      # and the writable /run + cgroup needs below are best-effort and must be
+      # validated on first apply (that's why the Kustomization ships suspended).
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+        # /workspace emptyDir is chowned to the `users` group (gid 100, haku's
+        # primary group) so the non-root worker can write the git clones.
+        fsGroup: 100
+      containers:
+        - name: worker
+          image: ghcr.io/agentydragon/haku-worker:devel-00000000000000-0000000 # {"$imagepolicy": "flux-system:haku-worker"}
+          imagePullPolicy: Always
+          command: ["/init"] # boot systemd; the haku-worker unit runs the worker
+          env:
+            - name: ANTHROPIC_ENVIRONMENT_ID
+              value: env_015uqL9WAMSDytQEWWmLG9zF # haku-selfhosted environment (not secret)
+            - name: ANTHROPIC_ENVIRONMENT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: haku-environment-key
+                  key: environment_key
+            # haku-state clone (read+write) + the single git credential the
+            # entrypoint threads into ~/.netrc. Reuses the haku-console secret.
+            - name: HAKU_STATE_REPO_URL
+              valueFrom:
+                secretKeyRef:
+                  name: haku-state-git-write
+                  key: repo_url
+            - name: HAKU_GIT_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: haku-state-git-write
+                  key: username
+            - name: HAKU_GIT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: haku-state-git-write
+                  key: password
+            # Forgejo host for the .netrc machine line; must match the host in
+            # HAKU_STATE_REPO_URL. TODO(operator): confirm.
+            - name: HAKU_GIT_HOST
+              value: git.allegedly.works
+            # ducktape clone (read-only: haku/base + run.md, the live manual).
+            # TODO(operator): set the real URL. If ducktape is NOT on HAKU_GIT_HOST
+            # and is not public, entrypoint.sh's single-.netrc-host model needs a
+            # second credential/machine line.
+            - name: HAKU_DUCKTAPE_REPO_URL
+              value: https://github.com/agentydragon/ducktape
+          resources:
+            requests:
+              cpu: 200m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+          volumeMounts:
+            - name: workspace # git clones + agent workdir (entrypoint: /workspace)
+              mountPath: /workspace
+            - name: run # systemd PID 1 wants a writable tmpfs /run
+              mountPath: /run
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: workspace
+          emptyDir: {}
+        - name: run
+          emptyDir:
+            medium: Memory
+        - name: tmp
+          emptyDir: {}

--- a/cluster/k8s/haku/agent-worker/deployment.yaml
+++ b/cluster/k8s/haku/agent-worker/deployment.yaml
@@ -74,9 +74,8 @@ spec:
             - name: HAKU_GIT_HOST
               value: git.allegedly.works
             # ducktape clone (read-only: haku/base + run.md, the live manual).
-            # TODO(operator): set the real URL. If ducktape is NOT on HAKU_GIT_HOST
-            # and is not public, entrypoint.sh's single-.netrc-host model needs a
-            # second credential/machine line.
+            # Public GitHub repo — cloned anonymously over HTTPS, so the single
+            # .netrc entry (HAKU_GIT_HOST, for haku-state) is all the git auth needed.
             - name: HAKU_DUCKTAPE_REPO_URL
               value: https://github.com/agentydragon/ducktape
           resources:

--- a/cluster/k8s/haku/agent-worker/deployment.yaml
+++ b/cluster/k8s/haku/agent-worker/deployment.yaml
@@ -69,8 +69,9 @@ spec:
                 secretKeyRef:
                   name: haku-state-git-write
                   key: password
-            # Forgejo host for the .netrc machine line; must match the host in
-            # HAKU_STATE_REPO_URL. TODO(operator): confirm.
+            # In-cluster Forgejo host for the haku-state .netrc machine line
+            # (haku-state is git.allegedly.works/haku/haku-state). ducktape is on
+            # public GitHub (below), not the cluster Forgejo, so it needs no creds.
             - name: HAKU_GIT_HOST
               value: git.allegedly.works
             # ducktape clone (read-only: haku/base + run.md, the live manual).

--- a/cluster/k8s/haku/agent-worker/environment-key.sops.yaml
+++ b/cluster/k8s/haku/agent-worker/environment-key.sops.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: haku-environment-key
+    namespace: haku-sandbox
+    annotations:
+        description: 'Anthropic Managed Agents environment key (sk-ant-oat01-…) for the haku-selfhosted environment''s work queue. PLACEHOLDER — operator: generate in the Console (Environments → haku-selfhosted → Generate environment key) and `sops` this file to the real value before un-suspending the worker. Scoped to one environment''s queue; it cannot reach the control plane.'
+type: Opaque
+stringData:
+    environment_key: ENC[AES256_GCM,data:oeHx+1O02JqEtS2dfIEmnjqpc2v/GN79q7mfJYpi,iv:KKFBNqg8P8Fr8TDfTJzHFh4U8VnT02q7T2L6p05liMY=,tag:jEDpF03vWHvX+7o+DRRt6A==,type:str]
+sops:
+    age:
+        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFSnBUV0JzTlRZT0swRGZj
+            WHRkMGMrSFNGQitVL1FHTTN4T3dDQUU5WUc0ClBjMUluRDZoL0ZMRGY0QWFQOWRm
+            QWE1QThuYzdZUVdCYW9aK2Q0Z3BlcHMKLS0tIE43NFA4U2kvVEZEa2d0VUdVdFJq
+            OG1yTDI2YVJET1FUWW1pdjRqY0xoK2cKDKcCD8PO8x0aPxt78TwBg8GvPgBwuban
+            9xLVKKyP1wA5BmB6s8ZkW1k+KBELv52qrR5ASWQb36WRBWJFzgbvbA==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1nywlwepsyfxvyhqwkjquzz02nmus65gf6qewfjju4alym8f7se5qnua8na
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWUk1zK0dIbHg4Uzh5SXp4
+            SlNBVkVzU1lWY0JnUVpRTnNwNXZETjdHWEU4CkthQVpJVUJITTBtYTNMeHZFZjhn
+            WWdFdXVYb2srdGh5dlQzWnlrVTcxajQKLS0tIGhoQVo2UjVCdnplUVJqN1dOa0JF
+            dTJ0OTFGU0lYNW1jWjdpdDZ3MnhzdFEKHtaWjscgTldtko5J2kC1NfN+sCy5+8iR
+            R793Yh46uxv92guQPN0cjrFhuCE8lvUMW6aecf8bNuYK8tjFuwg2Vg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-06-23T06:12:22Z"
+    mac: ENC[AES256_GCM,data:fm4tUbrXZQ9aEDFcHHyrdApbsy6XofpvE/zhohYTvmYpNiEb3fz82vAsQLVgKYqN56cyQSrGh8Ye+LjSflKFjpjrgtHvrwMUR1YpKgvog6nk4FbPF+rOide0ZdyA6lvmDRztOLlo2RuE//MGzTaEx7tF7+QRR14Qvj6FLGoaFDo=,iv:lyyJi7C9hvxvqB5MWjFJJkCr3xK4sPic7x6qAA5pMP8=,tag:rfot8dnmfDptHES4hoZ7RQ==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.1

--- a/cluster/k8s/haku/agent-worker/flux-kustomization.yaml
+++ b/cluster/k8s/haku/agent-worker/flux-kustomization.yaml
@@ -1,0 +1,34 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: haku-agent-worker
+  namespace: flux-system
+spec:
+  # Shipped SUSPENDED: this is the first systemd-PID1 pod in the cluster and the
+  # worker can't authenticate until the operator generates the environment key
+  # (see environment-key.sops.yaml). Activate it with the runbook in README.md:
+  # generate + sops the env key, then flip `suspend: false`.
+  suspend: true
+  interval: 10m
+  retryInterval: 1m
+  timeout: 5m
+  path: ./cluster/k8s/haku/agent-worker
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age-cluster-secrets
+  healthChecks:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: haku-worker
+      namespace: haku-sandbox
+  dependsOn:
+    - name: haku-namespace
+    - name: haku-rbac
+    - name: haku-state # provides the haku-state-git-write secret in haku-sandbox
+    - name: haku-mitmproxy # injects the egress proxy + CA the worker imports

--- a/cluster/k8s/haku/agent-worker/kustomization.yaml
+++ b/cluster/k8s/haku/agent-worker/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - serviceaccount.yaml
+  - rolebinding.yaml
+  - environment-key.sops.yaml
+  - deployment.yaml

--- a/cluster/k8s/haku/agent-worker/rolebinding.yaml
+++ b/cluster/k8s/haku/agent-worker/rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: haku-worker-sandbox-admin
+  namespace: haku-sandbox
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: haku-sandbox-admin # defined in cluster/k8s/haku/rbac/role.yaml
+subjects:
+  - kind: ServiceAccount
+    name: haku-worker
+    namespace: haku-sandbox

--- a/cluster/k8s/haku/agent-worker/serviceaccount.yaml
+++ b/cluster/k8s/haku/agent-worker/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: haku-worker
+  namespace: haku-sandbox
+  annotations:
+    description: "In-cluster identity for the Haku Managed Agents worker (Runtime B; ducktape haku/runtime/managed_agent). The worker's `bash` tool calls `kubectl` with this SA token (the web home uses an OIDC JWT instead). Bound to haku-sandbox-admin for full CRUD in its own namespace; cluster-wide diagnostics read (the web home's cluster-diagnostics-reader) is a follow-up."

--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -202,6 +202,7 @@ resources:
   - haku/namespace/flux-kustomization.yaml
   - haku/rbac/flux-kustomization.yaml
   - haku/console/flux-kustomization.yaml
+  - haku/agent-worker/flux-kustomization.yaml # suspended; see the dir README to activate
 
   # --- matrix ---
   - matrix/namespace/flux-kustomization.yaml

--- a/flake.nix
+++ b/flake.nix
@@ -414,6 +414,11 @@
           # Build: nix build .#nix-rbe-nixos
           # Load:  docker import result/tarball/*.tar.xz nix-rbe-nixos
           nix-rbe-nixos = self.nixosConfigurations.nix-rbe-worker.config.system.build.tarball;
+          # Full-NixOS container image for the Haku Managed Agents self-hosted
+          # worker (Runtime B, haku/runtime/managed_agent).
+          # Build: nix build .#haku-worker-image
+          # Load:  docker import result/tarball/*.tar.xz haku-worker
+          haku-worker-image = self.nixosConfigurations.haku-worker.config.system.build.tarball;
           # Pre-built UEFI qcow2 VM images for Proxmox deployment.
           # Build: nix build .#wyrm2-image
           # Uses built-in system.build.images.qemu-efi (nixos-generators upstreamed in 25.05+).
@@ -530,6 +535,16 @@
           inherit system;
           modules = [
             ./x/nix_rbe_image/nixos.nix
+          ];
+        };
+
+        # Haku Managed Agents self-hosted worker (Runtime B). anthropic-cli and
+        # fastmcp are ducktape packages, passed in rather than re-derived.
+        haku-worker = nixpkgs.lib.nixosSystem {
+          inherit system;
+          specialArgs = { inherit (ducktapePkgs) anthropic-cli fastmcp; };
+          modules = [
+            ./haku/runtime/managed_agent/nixos.nix
           ];
         };
 

--- a/haku/TODO.md
+++ b/haku/TODO.md
@@ -72,43 +72,42 @@ facade** in front (the Authentik OAuth facade is auth, not tool filtering — se
   `kubectl_sandbox_fixed_groups` `else` default with an explicit SA→group map
   once the claude-sandbox JWT path has soaked (`tf/gitops/agent-machine-access`).
 
-## Managed Agents runtime (Runtime B) — remaining to go live
+## Managed Agents runtime (Runtime B) — operator activation to go live
 
-Runtime B (`runtime/managed_agent/`) is built and its control plane is
+Runtime B (`runtime/managed_agent/`) is built end-to-end and its control plane is
 provisioned (environment `env_015uqL9WAMSDytQEWWmLG9zF`, agent, vault +
 `tana-mcp-ro` credential, scheduled deployment `depl_011DSrUoXuhoDWJoPyDuePqR`;
-full IDs recorded on #2438). The worker is not yet deployed. Remaining:
+full IDs recorded on #2438). PR #2442 adds the worker image build+push and the
+k8s manifests (`cluster/k8s/haku/agent-worker/`, shipped **suspended**). What
+remains is operator activation (runbook in that dir's README):
 
-- **`haku-worker` Deployment** in `haku-sandbox`
-  (`cluster/k8s/haku/agent-worker/`, operator-owned): the worker image,
-  `serviceAccountName: haku`, non-root, behind `haku-mitmproxy`; env
-  `ANTHROPIC_ENVIRONMENT_ID` (the `env_…` above) + `ANTHROPIC_ENVIRONMENT_KEY`
-  and the `HAKU_{DUCKTAPE_REPO_URL,STATE_REPO_URL,GIT_HOST,GIT_USERNAME,GIT_PASSWORD}`
-  clone/push env (source creds — Plaid, Google, git — already reflected into
-  `haku-sandbox` from v0).
-- **`ANTHROPIC_ENVIRONMENT_KEY` secret** — generate in Console (Environments →
-  `haku-selfhosted` → "Generate environment key"), SOPS-encrypt under
-  `cluster/k8s/haku/…` to the **cluster/Flux** age key (not the `haku` key), Flux
-  → secret.
-- **Worker image** — built: `nix build .#haku-worker-image` (a full-NixOS
-  container, `runtime/managed_agent/nixos.nix`; systemd PID 1, runs unprivileged
-  on cgroup-v2/Talos with `command: ["/init"]`; tools `bash`/`git`/`kubectl`/
-  `postgresql`/`curl`/`jq`/`fastmcp` + `ant`). Remaining: a CI step to
-  `podman import` the rootfs tarball and push it to GHCR (no nix→GHCR automation
-  exists yet), then a Flux digest pin.
+- **Generate the environment key** in the Console (Environments →
+  `haku-selfhosted` → "Generate environment key") and `sops`
+  `cluster/k8s/haku/agent-worker/environment-key.sops.yaml` to the real value
+  (placeholder today, encrypted to the cluster/Flux age key).
+- **Finalize the worker env** in that `deployment.yaml`: `HAKU_GIT_HOST` and the
+  literal `HAKU_DUCKTAPE_REPO_URL` (adjust if ducktape isn't public / not on the
+  same host as haku-state — `entrypoint.sh` threads a single `.netrc` machine line).
+- **Activate + validate**: flip `suspend: false` on the Kustomization and watch
+  the Deployment — first systemd-PID1 pod in the cluster, so confirm it boots
+  unprivileged (cgroup-v2 delegation, writable `/run`) and tune the pod
+  `securityContext` if needed.
 - **Smoke test** — `ant beta:deployments run --deployment-id depl_011DSrUoXuhoDWJoPyDuePqR`,
   watch in the Console.
 
 Settled (not blockers):
 
+- **Image build + push** — `nix build .#haku-worker-image` (full-NixOS,
+  `runtime/managed_agent/nixos.nix`) → `.github/workflows/haku-worker-image.yml`
+  imports + pushes to `ghcr.io/agentydragon/haku-worker`; Flux tracks the tag via
+  the `haku-worker` ImagePolicy.
 - **Egress** — `api.anthropic.com` is on the `haku-mitmproxy` allowlist
   (`cluster/k8s/agents/haku-mitmproxy/cnp-haku-cloud-api-egress.yaml`); the worker
   reaches the work queue through the TLS-terminating proxy and trusts its CA via
-  the existing inject policy.
-- **SOPS identity** — the `&haku` age key already exists, but the in-cluster
-  worker needs no `SOPS_AGE_KEY`: it uses the `haku` ServiceAccount for `kubectl`
-  and reads creds from k8s secrets (only the web home decrypts the
-  public-`kubeapi` JWT via SOPS).
+  the inject policy (imported into the systemd unit).
+- **SOPS identity** — the in-cluster worker needs no `SOPS_AGE_KEY`: it uses its
+  `haku-worker` ServiceAccount for `kubectl` and reads creds from k8s secrets
+  (only the web home decrypts the public-`kubeapi` JWT via SOPS).
 
 ## Later (post-v0)
 

--- a/haku/TODO.md
+++ b/haku/TODO.md
@@ -90,9 +90,12 @@ full IDs recorded on #2438). The worker is not yet deployed. Remaining:
   `haku-selfhosted` → "Generate environment key"), SOPS-encrypt under
   `cluster/k8s/haku/…` to the **cluster/Flux** age key (not the `haku` key), Flux
   → secret.
-- **Worker image** (CI build) — `bash`/`git`/`kubectl`/`postgresql-client`/`curl`/
-  `fastmcp` + the `ant` CLI. Now that `ant` is packaged in nix (`anthropic-cli`),
-  prefer reusing the `.#agent-haku` closure + `ant` over a hand-rolled apt image.
+- **Worker image** — built: `nix build .#haku-worker-image` (a full-NixOS
+  container, `runtime/managed_agent/nixos.nix`; systemd PID 1, runs unprivileged
+  on cgroup-v2/Talos with `command: ["/init"]`; tools `bash`/`git`/`kubectl`/
+  `postgresql`/`curl`/`jq`/`fastmcp` + `ant`). Remaining: a CI step to
+  `podman import` the rootfs tarball and push it to GHCR (no nix→GHCR automation
+  exists yet), then a Flux digest pin.
 - **Smoke test** — `ant beta:deployments run --deployment-id depl_011DSrUoXuhoDWJoPyDuePqR`,
   watch in the Console.
 

--- a/haku/TODO.md
+++ b/haku/TODO.md
@@ -85,9 +85,6 @@ remains is operator activation (runbook in that dir's README):
   `haku-selfhosted` → "Generate environment key") and `sops`
   `cluster/k8s/haku/agent-worker/environment-key.sops.yaml` to the real value
   (placeholder today, encrypted to the cluster/Flux age key).
-- **Confirm `HAKU_GIT_HOST`** in that `deployment.yaml` (the haku-state Forgejo
-  host). `HAKU_DUCKTAPE_REPO_URL` is settled — the public GitHub repo, cloned
-  anonymously, so the single `.netrc` for haku-state is all the auth needed.
 - **Activate + validate**: flip `suspend: false` on the Kustomization and watch
   the Deployment — first systemd-PID1 pod in the cluster, so confirm it boots
   unprivileged (cgroup-v2 delegation, writable `/run`) and tune the pod
@@ -108,6 +105,11 @@ Settled (not blockers):
 - **SOPS identity** — the in-cluster worker needs no `SOPS_AGE_KEY`: it uses its
   `haku-worker` ServiceAccount for `kubectl` and reads creds from k8s secrets
   (only the web home decrypts the public-`kubeapi` JWT via SOPS).
+- **Git sources** — haku-state on the in-cluster Forgejo
+  (`git.allegedly.works/haku/haku-state`, single `.netrc` via `HAKU_GIT_HOST` +
+  the `haku-state-git-write` creds); ducktape on public GitHub (anonymous,
+  read-only) — it isn't mirrored to the cluster Forgejo yet (that migration is
+  the "Cluster Forgejo repos" item above).
 
 ## Later (post-v0)
 

--- a/haku/TODO.md
+++ b/haku/TODO.md
@@ -85,9 +85,9 @@ remains is operator activation (runbook in that dir's README):
   `haku-selfhosted` → "Generate environment key") and `sops`
   `cluster/k8s/haku/agent-worker/environment-key.sops.yaml` to the real value
   (placeholder today, encrypted to the cluster/Flux age key).
-- **Finalize the worker env** in that `deployment.yaml`: `HAKU_GIT_HOST` and the
-  literal `HAKU_DUCKTAPE_REPO_URL` (adjust if ducktape isn't public / not on the
-  same host as haku-state — `entrypoint.sh` threads a single `.netrc` machine line).
+- **Confirm `HAKU_GIT_HOST`** in that `deployment.yaml` (the haku-state Forgejo
+  host). `HAKU_DUCKTAPE_REPO_URL` is settled — the public GitHub repo, cloned
+  anonymously, so the single `.netrc` for haku-state is all the auth needed.
 - **Activate + validate**: flip `suspend: false` on the Kustomization and watch
   the Deployment — first systemd-PID1 pod in the cluster, so confirm it boots
   unprivileged (cgroup-v2 delegation, writable `/run`) and tune the pod

--- a/haku/runtime/managed_agent/README.md
+++ b/haku/runtime/managed_agent/README.md
@@ -28,6 +28,7 @@ later is the one thing that would reintroduce the SDK-version question.
 | `haku.deployment.yaml`  | scheduled-deployment wake trigger                                | control plane |
 | `provision.sh`          | one-shot: create environment/agent/vault/deployment via `ant`    | operator / CI |
 | `entrypoint.sh`         | clone ducktape + haku-state, then `ant beta:worker poll`         | `haku-worker` |
+| `nixos.nix`             | full-NixOS worker image (`nix build .#haku-worker-image`)        | CI / build    |
 
 ## Trust split — keep the org key off the worker
 
@@ -38,16 +39,22 @@ later is the one thing that would reintroduce the SDK-version question.
   org-scoped `ANTHROPIC_API_KEY`, run from CI / the operator laptop — **never**
   on the worker host.
 
-## Worker image (CI-only build)
+## Worker image (`nix build .#haku-worker-image`)
 
-A debian image with `bash`, `git`, `kubectl`, `postgresql-client`, `curl`,
-`ca-certificates`, `fastmcp`, and the **`ant` CLI** (Go binary from
-`github.com/anthropics/anthropic-cli/releases`), entrypoint `entrypoint.sh`.
-Built on CI (apt mirrors 403 in the Claude-web sandbox), pushed to GHCR, pinned
-by Flux — the standard <../../../cluster/docs/container-images.md> path. The
-fixed `ant` toolset is `bash/read/write/edit/glob/grep`; Haku reaches Plaid
-(`psql`), Google (`curl`), and the cluster (`kubectl`, in-cluster `haku` SA)
-through `bash`. Tana is a native `mcp_toolset` (Anthropic-side, vault auth).
+A full-NixOS container image (`nixos.nix`, systemd PID 1 — declaratively
+consistent with the rest of the fleet) carrying `bash`, `git`, `kubectl`,
+`postgresql` (`psql`), `curl`, `jq`, `cacert`, `fastmcp`, and the **`ant` CLI**
+(the `anthropic-cli` nix package). The `haku-worker` systemd unit runs
+`entrypoint.sh` as the non-root `haku` user. Build the rootfs tarball with
+`nix build .#haku-worker-image`; CI imports it (`podman import … --change 'CMD
+["/init"]'`) and pushes to GHCR, pinned by Flux — see
+<../../../cluster/docs/container-images.md>.
+
+Runs **unprivileged** on the cluster's cgroup-v2 (Talos) nodes — k8s boots it
+with `command: ["/init"]`; no `--privileged`, no extra caps. The fixed `ant`
+toolset is `bash/read/write/edit/glob/grep`; Haku reaches Plaid (`psql`),
+Google (`curl`), and the cluster (`kubectl`, in-cluster `haku` SA) through
+`bash`. Tana is a native `mcp_toolset` (Anthropic-side, vault auth).
 
 ## k8s wiring — operator-owned (follow-up)
 
@@ -70,6 +77,12 @@ ant beta:deployments run --deployment-id "$DEPL_ID"   # test one run, watch in C
 
 `ANTHROPIC_ENVIRONMENT_ID`, `ANTHROPIC_ENVIRONMENT_KEY`, `HAKU_DUCKTAPE_REPO_URL`,
 `HAKU_STATE_REPO_URL`, `HAKU_GIT_HOST`, `HAKU_GIT_USERNAME`, `HAKU_GIT_PASSWORD`.
+
+Set these on the pod (`envFrom` a Secret/ConfigMap); systemd PID 1 lifts them
+into the `haku-worker` unit via `ImportEnvironment=` (fallback: mount a Secret as
+an env file at `/etc/haku-worker/env`). Set the pod `fsGroup` to the `haku` gid
+so the `/workspace` emptyDir is writable, and layer the `haku-mitmproxy` CA into
+`/etc/ssl/certs/ca-certificates.crt` so HTTPS through the proxy validates.
 
 Beta-surface field/flag names (`agent_toolset_20260401`, `vault_ids`, the
 deployment schema) follow the `ant` docs as of 2026-06 — verify with

--- a/haku/runtime/managed_agent/README.md
+++ b/haku/runtime/managed_agent/README.md
@@ -56,13 +56,16 @@ toolset is `bash/read/write/edit/glob/grep`; Haku reaches Plaid (`psql`),
 Google (`curl`), and the cluster (`kubectl`, in-cluster `haku` SA) through
 `bash`. Tana is a native `mcp_toolset` (Anthropic-side, vault auth).
 
-## k8s wiring — operator-owned (follow-up)
+## k8s wiring
 
-The `haku-worker` Deployment, the `ANTHROPIC_ENVIRONMENT_KEY` secret, and the
-clone/git env live under `cluster/k8s/…/haku/` — see
-<../../plans/managed_agents.md> § "k8s wiring". The worker reuses Haku's existing
-`haku-sandbox` perimeter (`haku` SA + RBAC, `haku-mitmproxy` egress,
-ResourceQuota); none of it relies on agent restraint.
+The `haku-worker` Deployment, its `haku-worker` ServiceAccount (bound to
+`haku-sandbox-admin`), the `ANTHROPIC_ENVIRONMENT_KEY` secret stub, and the
+clone/git env live in <../../../cluster/k8s/haku/agent-worker/README.md> —
+shipped **suspended** (it's the first systemd-PID1 pod in the cluster and needs
+an operator-generated environment key; that dir's README is the activation
+runbook). The worker reuses Haku's `haku-sandbox` perimeter (`haku-sandbox-admin`
+RBAC, `haku-mitmproxy` egress + CA injection, ResourceQuota); none of it relies
+on agent restraint.
 
 ## Bring-up
 

--- a/haku/runtime/managed_agent/nixos.nix
+++ b/haku/runtime/managed_agent/nixos.nix
@@ -81,18 +81,21 @@ in
       ExecStart = "${entrypoint}/bin/haku-entrypoint";
       Restart = "always";
       RestartSec = 5;
-      # Base CA bundle for git/curl/ant. In-cluster these traverse
-      # haku-mitmproxy; its CA is layered into the pod's trust by the
-      # inject-haku-mitmproxy Kyverno policy (finalized with the k8s manifests).
-      Environment = "SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt GIT_SSL_CAINFO=/etc/ssl/certs/ca-certificates.crt";
-      # k8s sets the worker env on the container (envFrom secret/configMap); it
-      # lands in PID 1's (systemd) environment, and ImportEnvironment lifts the
-      # named vars into this unit (systemd >= 254; NixOS 25.11 ships newer).
-      # EnvironmentFile is an optional fallback: mount a secret as an env file.
+      # The worker's env arrives on the CONTAINER (PID 1 = systemd): the operator
+      # sets the ANTHROPIC_*/HAKU_* vars (envFrom secret/configMap), and the
+      # haku-sandbox Kyverno policy (inject-haku-mitmproxy) injects the egress
+      # proxy + its CA bundle (HTTP(S)_PROXY/NO_PROXY, SSL_CERT_FILE=/mitmproxy-ca/…
+      # and the CURL/REQUESTS/NODE variants). ImportEnvironment lifts all of them
+      # from PID 1's environment into this unit (systemd >= 254; NixOS 25.11 ships
+      # newer) — without the proxy/CA imports the worker wouldn't trust the
+      # mitmproxy CA and every proxied HTTPS call would fail. EnvironmentFile is
+      # an optional fallback: mount a secret as an env file.
       ImportEnvironment =
         "ANTHROPIC_ENVIRONMENT_ID ANTHROPIC_ENVIRONMENT_KEY "
         + "HAKU_DUCKTAPE_REPO_URL HAKU_STATE_REPO_URL "
-        + "HAKU_GIT_HOST HAKU_GIT_USERNAME HAKU_GIT_PASSWORD";
+        + "HAKU_GIT_HOST HAKU_GIT_USERNAME HAKU_GIT_PASSWORD "
+        + "HTTP_PROXY HTTPS_PROXY NO_PROXY "
+        + "SSL_CERT_FILE CURL_CA_BUNDLE REQUESTS_CA_BUNDLE NODE_EXTRA_CA_CERTS";
       EnvironmentFile = "-/etc/haku-worker/env";
     };
   };

--- a/haku/runtime/managed_agent/nixos.nix
+++ b/haku/runtime/managed_agent/nixos.nix
@@ -1,0 +1,108 @@
+# Full-NixOS container image for the Haku Managed Agents self-hosted worker
+# (Runtime B, haku/runtime/managed_agent). systemd PID 1, declaratively
+# consistent with the rest of the fleet (wyrm2/rugged/nix-rbe-worker).
+#
+# Runs UNPRIVILEGED: on the cluster's cgroup-v2 nodes (Talos) systemd boots as
+# PID 1 in an ordinary non-root container — no --privileged, no extra caps. k8s
+# supervises the pod; systemd here just runs the one worker unit and gives it
+# journald + Restart. The real fence is the haku-sandbox perimeter (haku SA +
+# RBAC, mitmproxy egress), not anything inside the container.
+#
+# Build: nix build .#haku-worker-image
+# Load:  docker import result/tarball/*.tar.xz haku-worker
+# Run:   docker run --rm haku-worker /init      (k8s: command: ["/init"])
+{
+  modulesPath,
+  pkgs,
+  anthropic-cli,
+  fastmcp,
+  ...
+}:
+let
+  # Haku's runtime tool surface: what playbooks may assume on PATH. Lean by
+  # design (no dev/infra toolchain — no bazelisk/tofu/helm); the worker runs
+  # playbooks, it is not a dev box. Add here when a playbook needs a new tool,
+  # so the runtimes stay in deliberate sync.
+  workerTools = with pkgs; [
+    bashInteractive
+    coreutils
+    gnugrep
+    gnused
+    gawk
+    findutils
+    gnutar
+    gzip
+    which
+    less
+    jq
+    curl
+    openssl
+    cacert
+    git
+    kubectl
+    postgresql # psql (Plaid, reached cluster-internally)
+    fastmcp # in-cluster MCP facades (tana-mcp-ro, …)
+    anthropic-cli # `ant` — the worker poll loop
+  ];
+
+  # entrypoint.sh is the single source of truth (self-contained + runnable);
+  # bake it in with its shebang patched to the store bash.
+  entrypoint = pkgs.runCommand "haku-entrypoint" { } ''
+    install -Dm755 ${./entrypoint.sh} $out/bin/haku-entrypoint
+    patchShebangs $out/bin/haku-entrypoint
+  '';
+in
+{
+  imports = [ (modulesPath + "/virtualisation/docker-image.nix") ];
+
+  networking.hostName = "haku-worker";
+  networking.nftables.enable = false;
+  nixpkgs.config.allowUnfree = true; # anthropic-cli is unfree
+
+  # Non-root agent user (uid 1000). Set the pod's fsGroup to its primary group
+  # so a /workspace emptyDir mount stays writable.
+  users.users.haku = {
+    isNormalUser = true;
+    uid = 1000;
+    home = "/home/haku";
+    createHome = true;
+  };
+
+  # The worker unit: clone ducktape + haku-state, then long-poll Anthropic's
+  # self-hosted work queue (ant beta:worker poll). entrypoint.sh holds the body.
+  systemd.services.haku-worker = {
+    description = "Haku Managed Agents self-hosted worker";
+    wantedBy = [ "multi-user.target" ];
+    path = workerTools;
+    serviceConfig = {
+      Type = "exec";
+      User = "haku";
+      WorkingDirectory = "/workspace";
+      ExecStart = "${entrypoint}/bin/haku-entrypoint";
+      Restart = "always";
+      RestartSec = 5;
+      # Base CA bundle for git/curl/ant. In-cluster these traverse
+      # haku-mitmproxy; its CA is layered into the pod's trust by the
+      # inject-haku-mitmproxy Kyverno policy (finalized with the k8s manifests).
+      Environment = "SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt GIT_SSL_CAINFO=/etc/ssl/certs/ca-certificates.crt";
+      # k8s sets the worker env on the container (envFrom secret/configMap); it
+      # lands in PID 1's (systemd) environment, and ImportEnvironment lifts the
+      # named vars into this unit (systemd >= 254; NixOS 25.11 ships newer).
+      # EnvironmentFile is an optional fallback: mount a secret as an env file.
+      ImportEnvironment =
+        "ANTHROPIC_ENVIRONMENT_ID ANTHROPIC_ENVIRONMENT_KEY "
+        + "HAKU_DUCKTAPE_REPO_URL HAKU_STATE_REPO_URL "
+        + "HAKU_GIT_HOST HAKU_GIT_USERNAME HAKU_GIT_PASSWORD";
+      EnvironmentFile = "-/etc/haku-worker/env";
+    };
+  };
+
+  # /workspace: the git clones + agent workdir, writable by haku. In k8s this is
+  # normally an emptyDir (with the pod fsGroup above the mount is group-writable).
+  systemd.tmpfiles.rules = [ "d /workspace 0750 haku users -" ];
+
+  security.pki.certificateFiles = [ "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt" ];
+  environment.systemPackages = workerTools;
+
+  system.stateVersion = "25.11";
+}


### PR DESCRIPTION
## Summary

Introduces a declarative NixOS-based container image for the Haku Managed Agents self-hosted worker (Runtime B), replacing the previous Debian-based approach. The worker runs as an unprivileged systemd container on the cluster's cgroup-v2 nodes.

## Key Changes

- **New `haku/runtime/managed_agent/nixos.nix`**: Full NixOS container configuration with:
  - Systemd PID 1 (consistent with the rest of the fleet)
  - Non-root `haku` user (uid 1000) for unprivileged execution
  - `haku-worker` systemd unit that runs `entrypoint.sh` with automatic restart
  - Curated tool surface: `bash`, `git`, `kubectl`, `postgresql`, `curl`, `jq`, `cacert`, `fastmcp`, and `anthropic-cli`
  - Environment variable import from k8s pod config via `ImportEnvironment=`
  - `/workspace` directory for git clones and agent workdir

- **Updated `flake.nix`**: 
  - Added `haku-worker` NixOS configuration
  - Exposed `haku-worker-image` output for building the rootfs tarball
  - Passes `anthropic-cli` and `fastmcp` from ducktape packages

- **Updated `haku/runtime/managed_agent/README.md`**: 
  - Documented the new NixOS-based image build process (`nix build .#haku-worker-image`)
  - Clarified unprivileged execution model and k8s integration
  - Added environment variable setup instructions for pod configuration

- **Updated `haku/TODO.md`**: 
  - Marked worker image as built
  - Noted remaining CI step (podman import and GHCR push) and Flux digest pin

## Implementation Details

The worker runs unprivileged on Talos nodes with no `--privileged` flag or extra capabilities. The security boundary is enforced by the haku-sandbox perimeter (service account + RBAC, mitmproxy egress), not container privileges. The systemd unit imports environment variables from the k8s pod, with an optional fallback to `/etc/haku-worker/env`. The pod's `fsGroup` should be set to the `haku` group (gid 1000) to ensure `/workspace` emptyDir mounts remain writable.

https://claude.ai/code/session_01JLiwoWexhunDUjGw1bGgJv