### PR TITLE
[codex] Skip source_match oracle for native selectors

### DIFF
--- a/devinfra/js/debundle/e2e/anonymous_statement_test.rs
+++ b/devinfra/js/debundle/e2e/anonymous_statement_test.rs
@@ -1055,6 +1055,38 @@ export { runtimeFormat };
 }
 
 #[test]
+fn exact_native_source_match_skips_legacy_resolver_timing() {
+    let fixture = run_fixture_with_env(
+        FixtureOpts::new(
+            r#"function runtimeFormat(value) {
+  return value.trim().toUpperCase();
+}
+console.log(runtimeFormat(" ok "));
+export { runtimeFormat };
+"#,
+            vec![logical_module(
+                "format",
+                &[Member::source_exact_target(
+                    "formatValue",
+                    "runtimeFormat",
+                    r#"function runtimeFormat(value) {
+  return value.trim().toUpperCase();
+}"#,
+                )],
+            )],
+        ),
+        &[("DUCKTAPE_SOURCE_MATCH_TIMINGS", "1")],
+    );
+
+    assert_entry_output(&fixture, "OK\n");
+    assert!(
+        !fixture.stderr.contains("[debundle source_match]"),
+        "native exact source_match should not call the legacy resolver\nstderr:\n{}",
+        fixture.stderr,
+    );
+}
+
+#[test]
 fn source_match_timing_preview_can_be_disabled() {
     let fixture = run_fixture_with_env(
         FixtureOpts::new(

--- a/devinfra/js/debundle/lowering/materialize/plan_builder.rs
+++ b/devinfra/js/debundle/lowering/materialize/plan_builder.rs
@@ -26,25 +26,13 @@ struct DuplicateBindingClaim {
 }
 
 #[derive(Debug, Clone)]
-struct SourceMatchDifferentialTarget {
+struct SourceMatchTargetInfo {
     target: SelectorTargetId,
     request_id: String,
-    module_path: String,
     export_name: String,
-    claim_origin: String,
     selector: spec::AnonymousStatementSelector,
     selector_key: String,
-}
-
-#[derive(Debug, Clone)]
-struct SourceMatchNativeAstDifferential {
-    module_id: String,
-    module_path: String,
-    export_name: String,
-    claim_origin: String,
-    selector: spec::AnonymousStatementSelector,
-    report: SourceMatchNativeDiffReport,
-    message: String,
+    group_assignment: Option<SourceMatchGroupAssignment>,
 }
 
 impl DuplicateBindingClaim {
@@ -64,12 +52,11 @@ impl DuplicateBindingClaim {
 // `selector_diagnostics` crate so writer and reader cannot drift.
 use selector_diagnostics::{
     DuplicateClaimReport, DuplicateClaimSiteReport, SelectorDiagnosticEntry,
-    SelectorDiagnosticsReport, SelectorNearestCandidate, SourceMatchNativeDiffOracle,
-    SourceMatchNativeDiffOutcome, SourceMatchNativeDiffReport,
+    SelectorDiagnosticsReport, SelectorNearestCandidate,
 };
 use selector_ir::{
-    ClaimOutcome, OwnerTerm, SelectorAtom, SelectorFact, SelectorFactStore, SelectorProgram,
-    SelectorTargetId, SolverResult, StringTerm,
+    ClaimOutcome, OwnerTerm, ResolvedClaim, SelectorAtom, SelectorFact, SelectorFactStore,
+    SelectorProgram, SelectorTargetId, StringTerm,
 };
 use selector_ir_lowering::{MemberSelectorLoweringContext, MemberSelectorProgramBuilder};
 
@@ -395,68 +382,6 @@ fn source_match_candidate_statement_ordinal(
     }
 }
 
-fn collect_source_match_native_ast_differentials(
-    program: &SelectorProgram,
-    result: &SolverResult,
-    facts: &SelectorFactStore,
-    targets: &[SourceMatchDifferentialTarget],
-    candidates_by_target: &BTreeMap<SelectorTargetId, Vec<source_match::MemberBindingMatch>>,
-    errors_by_target: &BTreeMap<SelectorTargetId, String>,
-    ordinal_by_binding: &BTreeMap<String, Option<StatementOrdinal>>,
-) -> Vec<SourceMatchNativeAstDifferential> {
-    let owner_by_ordinal = owner_by_statement_ordinal(facts);
-    targets
-        .iter()
-        .filter_map(|target| {
-            if program_has_source_match_candidate_atom(program, target.target, &target.selector_key)
-                || errors_by_target.contains_key(&target.target)
-            {
-                return None;
-            }
-            let [oracle_candidate] = candidates_by_target
-                .get(&target.target)
-                .map(Vec::as_slice)
-                .unwrap_or_default()
-            else {
-                return None;
-            };
-            let oracle_statement_ordinal = source_match_candidate_statement_ordinal_for_diff(
-                ordinal_by_binding,
-                oracle_candidate,
-            )?;
-            let oracle_owner = owner_by_ordinal.get(&oracle_statement_ordinal).copied();
-            let oracle = SourceMatchNativeDiffOracle {
-                body_index: oracle_candidate.body_idx,
-                statement_ordinal: oracle_statement_ordinal.0,
-                owner_id: oracle_owner.map(|owner| owner.0),
-                binding: oracle_candidate.binding.binding_name.clone(),
-            };
-            let outcome = result.outcome_for(target.target);
-            let native = source_match_native_diff_outcome(outcome);
-            let mismatch_kind =
-                source_match_native_diff_mismatch_kind(outcome, oracle_candidate, &oracle)?;
-            let report = SourceMatchNativeDiffReport {
-                mismatch_kind: mismatch_kind.to_string(),
-                oracle,
-                native,
-            };
-            Some(SourceMatchNativeAstDifferential {
-                module_id: target.request_id.clone(),
-                module_path: target.module_path.clone(),
-                export_name: target.export_name.clone(),
-                claim_origin: target.claim_origin.clone(),
-                selector: target.selector.clone(),
-                message: format!(
-                    "native AST source_match resolution diverged from legacy candidate oracle \
-                     for export `{}`: {}",
-                    target.export_name, mismatch_kind,
-                ),
-                report,
-            })
-        })
-        .collect()
-}
-
 fn program_has_source_match_candidate_atom(
     program: &SelectorProgram,
     target: SelectorTargetId,
@@ -476,121 +401,20 @@ fn program_has_source_match_candidate_atom(
     })
 }
 
-fn source_match_native_diff_mismatch_kind(
-    outcome: Option<&ClaimOutcome>,
-    oracle_candidate: &source_match::MemberBindingMatch,
-    oracle: &SourceMatchNativeDiffOracle,
-) -> Option<&'static str> {
-    let Some(ClaimOutcome::Unique { claim }) = outcome else {
-        return Some(match outcome {
-            Some(ClaimOutcome::NoMatch) => "native_no_match",
-            Some(ClaimOutcome::Ambiguous { .. }) => "native_ambiguous",
-            Some(ClaimOutcome::Duplicate { .. }) => "native_duplicate",
-            Some(ClaimOutcome::Unsupported { .. }) => "native_unsupported",
-            None => "native_missing_outcome",
-            Some(ClaimOutcome::Unique { .. }) => unreachable!(),
-        });
-    };
-    match claim.binding.as_deref() {
-        Some(binding) if binding != oracle_candidate.binding.binding_name => {
-            return Some("binding_mismatch");
-        }
-        None => return Some("native_missing_binding"),
-        _ => {}
-    }
-    if claim.statement_ordinal.0 != oracle.statement_ordinal {
-        return Some("ordinal_mismatch");
-    }
-    if oracle.owner_id.is_some_and(|owner| claim.owner.0 != owner) {
-        return Some("owner_mismatch");
-    }
-    None
-}
-
-fn source_match_candidate_statement_ordinal_for_diff(
-    by_binding: &BTreeMap<String, Option<StatementOrdinal>>,
-    candidate: &source_match::MemberBindingMatch,
-) -> Option<StatementOrdinal> {
-    by_binding
-        .get(&candidate.binding.binding_name)
-        .and_then(|ordinal| *ordinal)
-}
-
-fn source_match_native_diff_outcome(
-    outcome: Option<&ClaimOutcome>,
-) -> SourceMatchNativeDiffOutcome {
-    match outcome {
-        Some(ClaimOutcome::Unique { claim }) => SourceMatchNativeDiffOutcome {
-            kind: "unique".to_string(),
-            statement_ordinal: Some(claim.statement_ordinal.0),
-            owner_id: Some(claim.owner.0),
-            binding: claim.binding.clone(),
-            candidate_count: None,
-            message: None,
-        },
-        Some(ClaimOutcome::NoMatch) => SourceMatchNativeDiffOutcome {
-            kind: "no_match".to_string(),
-            statement_ordinal: None,
-            owner_id: None,
-            binding: None,
-            candidate_count: None,
-            message: None,
-        },
-        Some(ClaimOutcome::Ambiguous { candidates }) => SourceMatchNativeDiffOutcome {
-            kind: "ambiguous".to_string(),
-            statement_ordinal: None,
-            owner_id: None,
-            binding: None,
-            candidate_count: Some(candidates.len()),
-            message: None,
-        },
-        Some(ClaimOutcome::Duplicate {
-            owner,
-            conflicting_targets,
-        }) => SourceMatchNativeDiffOutcome {
-            kind: "duplicate".to_string(),
-            statement_ordinal: None,
-            owner_id: Some(owner.0),
-            binding: None,
-            candidate_count: Some(conflicting_targets.len()),
-            message: None,
-        },
-        Some(ClaimOutcome::Unsupported { message }) => SourceMatchNativeDiffOutcome {
-            kind: "unsupported".to_string(),
-            statement_ordinal: None,
-            owner_id: None,
-            binding: None,
-            candidate_count: None,
-            message: Some(message.clone()),
-        },
-        None => SourceMatchNativeDiffOutcome {
-            kind: "missing_outcome".to_string(),
-            statement_ordinal: None,
-            owner_id: None,
-            binding: None,
-            candidate_count: None,
-            message: None,
-        },
-    }
-}
-
-fn owner_by_statement_ordinal(facts: &SelectorFactStore) -> BTreeMap<StatementOrdinal, OwnerId> {
-    facts
-        .facts
-        .iter()
-        .filter_map(|fact| {
-            if let SelectorFact::Owner {
+fn solver_claim_is_import_specifier(facts: &SelectorFactStore, claim: &ResolvedClaim) -> bool {
+    facts.facts.iter().any(|fact| {
+        matches!(
+            fact,
+            SelectorFact::Owner {
                 owner,
                 statement_ordinal,
+                statement_kind,
                 ..
-            } = fact
-            {
-                Some((*statement_ordinal, *owner))
-            } else {
-                None
-            }
-        })
-        .collect()
+            } if *owner == claim.owner
+                && *statement_ordinal == claim.statement_ordinal
+                && statement_kind == "import"
+        )
+    })
 }
 
 #[derive(Debug, Clone)]
@@ -717,6 +541,32 @@ fn source_match_ambiguous_message(
         candidates
             .iter()
             .map(|candidate| candidate.binding.binding_name.as_str())
+            .collect::<Vec<_>>()
+            .join(", "),
+        selector.match_source,
+    ))
+}
+
+fn native_source_match_ambiguous_message(
+    request: &LogicalRequest,
+    member: &MemberRequest,
+    candidates: &[ResolvedClaim],
+) -> Option<String> {
+    let selector = member.source_match.as_ref()?;
+    Some(format!(
+        "logical_module {}: members[].selector.source_match for export `{}` is ambiguous in the \
+         native selector solver -- matched {} owners at statement ordinals {:?} (bindings: {}). \
+         Refine the selector. Source:\n{}",
+        request.id,
+        member.export_name,
+        candidates.len(),
+        candidates
+            .iter()
+            .map(|candidate| candidate.statement_ordinal.0)
+            .collect::<Vec<_>>(),
+        candidates
+            .iter()
+            .filter_map(|candidate| candidate.binding.as_deref())
             .collect::<Vec<_>>()
             .join(", "),
         selector.match_source,
@@ -1027,10 +877,6 @@ pub(super) struct ChunkPlanBuilder {
     /// canonical plan so later modules in the chunk can still be
     /// checked for independent selector and duplicate-claim failures.
     source_match_diagnostics: Vec<SourceMatchDiagnostic>,
-    /// Native AST lowering results that disagree with the legacy
-    /// `SourceMatchCandidate` oracle. These are non-fatal instrumentation
-    /// entries used while retiring the oracle.
-    source_match_native_ast_differentials: Vec<SourceMatchNativeAstDifferential>,
     /// Anonymous statement selectors that did not resolve. In
     /// keep-going mode, unresolved anonymous statements are omitted
     /// from canonical ownership so later modules in the chunk can
@@ -1057,7 +903,6 @@ impl ChunkPlanBuilder {
             catalogue_index_by_name: HashMap::new(),
             duplicate_binding_claims: Vec::new(),
             source_match_diagnostics: Vec::new(),
-            source_match_native_ast_differentials: Vec::new(),
             anonymous_statement_diagnostics: Vec::new(),
             keep_going,
         }
@@ -1315,7 +1160,7 @@ impl ChunkPlanBuilder {
             SourceMatchGroupCacheKey,
             Result<Vec<source_match::MemberBindingGroupMatch>, String>,
         >::new();
-        let mut source_match_diff_targets = Vec::<SourceMatchDifferentialTarget>::new();
+        let mut source_match_targets = Vec::<SourceMatchTargetInfo>::new();
         let mut pending_constraints = Vec::<(String, String, spec::MemberSelectorSpec)>::new();
         let source_match_ordinal_by_binding =
             source_match_candidate_statement_ordinals(owner_graph);
@@ -1349,89 +1194,14 @@ impl ChunkPlanBuilder {
                 }
                 if let Some(source_selector) = &member.source_match {
                     let selector_key = source_match::selector_key(source_selector);
-                    source_match_diff_targets.push(SourceMatchDifferentialTarget {
+                    source_match_targets.push(SourceMatchTargetInfo {
                         target,
                         request_id: request.id.clone(),
-                        module_path: request.target_path.clone(),
                         export_name: member.export_name.clone(),
-                        claim_origin: member.claim_origin.clone(),
                         selector: source_selector.clone(),
                         selector_key: selector_key.clone(),
+                        group_assignment: group_assignments.get(&member_index).cloned(),
                     });
-                    let candidates = if let Some(group) = group_assignments.get(&member_index) {
-                        let target_binding = source_selector.target_binding.as_deref().with_context(|| {
-                            format!(
-                                "logical_module {}: binding-group member `{}` unexpectedly has no \
-                                 target_binding",
-                                request.id, member.export_name,
-                            )
-                        })?;
-                        let cache_key = SourceMatchGroupCacheKey::new(
-                            group.selector.clone(),
-                            &group.exports_by_target,
-                        );
-                        let group_candidates =
-                            match source_match_group_candidate_cache.get(&cache_key) {
-                                Some(cached) => cached.clone(),
-                                None => {
-                                    let resolved = selector_resolver
-                                        .member_group_candidates(
-                                            &request.id,
-                                            &group.selector,
-                                            &group.exports_by_target,
-                                        )
-                                        .map_err(|error| format!("{error:#}"));
-                                    source_match_group_candidate_cache
-                                        .insert(cache_key, resolved.clone());
-                                    resolved
-                                }
-                            };
-                        group_candidates.map(|groups| {
-                            groups
-                                .into_iter()
-                                .filter_map(|group| group.bindings.get(target_binding).cloned())
-                                .collect::<Vec<_>>()
-                        })
-                    } else {
-                        match source_match_candidate_cache.get(source_selector) {
-                            Some(cached) => cached.clone(),
-                            None => {
-                                let resolved = selector_resolver
-                                    .member_candidates(
-                                        &request.id,
-                                        &member.export_name,
-                                        source_selector,
-                                    )
-                                    .map_err(|error| format!("{error:#}"));
-                                source_match_candidate_cache
-                                    .insert(source_selector.clone(), resolved.clone());
-                                resolved
-                            }
-                        }
-                    };
-                    match candidates {
-                        Ok(candidates) => {
-                            for candidate in &candidates {
-                                let statement_ordinal = source_match_candidate_statement_ordinal(
-                                    &source_match_ordinal_by_binding,
-                                    &request.id,
-                                    &member.export_name,
-                                    candidate,
-                                )?;
-                                facts.push(SelectorFact::SourceMatchCandidate {
-                                    chunk_id: chunk_id_interned,
-                                    selector_key: selector_key.clone(),
-                                    statement_ordinal,
-                                    binding: candidate.binding.binding_name.clone(),
-                                });
-                            }
-                            source_match_candidates.insert(target, candidates);
-                        }
-                        Err(error) if self.keep_going => {
-                            source_match_errors.insert(target, error);
-                        }
-                        Err(error) => bail!("{error}"),
-                    }
                 }
             }
         }
@@ -1439,18 +1209,94 @@ impl ChunkPlanBuilder {
             builder.lower_member_constraints_in_module(&logical_module, &export_name, &selector)?;
         }
         let program = builder.into_program()?;
+        let source_match_oracle_targets = source_match_targets
+            .iter()
+            .filter_map(|target| {
+                program_has_source_match_candidate_atom(
+                    &program,
+                    target.target,
+                    &target.selector_key,
+                )
+                .then_some(target.target)
+            })
+            .collect::<BTreeSet<_>>();
+        for target in &source_match_targets {
+            if !source_match_oracle_targets.contains(&target.target) {
+                continue;
+            }
+            let candidates = if let Some(group) = &target.group_assignment {
+                let target_binding =
+                    target.selector.target_binding.as_deref().with_context(|| {
+                        format!(
+                            "logical_module {}: binding-group member `{}` unexpectedly has no \
+                         target_binding",
+                            target.request_id, target.export_name,
+                        )
+                    })?;
+                let cache_key =
+                    SourceMatchGroupCacheKey::new(group.selector.clone(), &group.exports_by_target);
+                let group_candidates = match source_match_group_candidate_cache.get(&cache_key) {
+                    Some(cached) => cached.clone(),
+                    None => {
+                        let resolved = selector_resolver
+                            .member_group_candidates(
+                                &target.request_id,
+                                &group.selector,
+                                &group.exports_by_target,
+                            )
+                            .map_err(|error| format!("{error:#}"));
+                        source_match_group_candidate_cache.insert(cache_key, resolved.clone());
+                        resolved
+                    }
+                };
+                group_candidates.map(|groups| {
+                    groups
+                        .into_iter()
+                        .filter_map(|group| group.bindings.get(target_binding).cloned())
+                        .collect::<Vec<_>>()
+                })
+            } else {
+                match source_match_candidate_cache.get(&target.selector) {
+                    Some(cached) => cached.clone(),
+                    None => {
+                        let resolved = selector_resolver
+                            .member_candidates(
+                                &target.request_id,
+                                &target.export_name,
+                                &target.selector,
+                            )
+                            .map_err(|error| format!("{error:#}"));
+                        source_match_candidate_cache
+                            .insert(target.selector.clone(), resolved.clone());
+                        resolved
+                    }
+                }
+            };
+            match candidates {
+                Ok(candidates) => {
+                    for candidate in &candidates {
+                        let statement_ordinal = source_match_candidate_statement_ordinal(
+                            &source_match_ordinal_by_binding,
+                            &target.request_id,
+                            &target.export_name,
+                            candidate,
+                        )?;
+                        facts.push(SelectorFact::SourceMatchCandidate {
+                            chunk_id: chunk_id_interned,
+                            selector_key: target.selector_key.clone(),
+                            statement_ordinal,
+                            binding: candidate.binding.binding_name.clone(),
+                        });
+                    }
+                    source_match_candidates.insert(target.target, candidates);
+                }
+                Err(error) if self.keep_going => {
+                    source_match_errors.insert(target.target, error);
+                }
+                Err(error) => bail!("{error}"),
+            }
+        }
         let result = selector_ir_solver::solve(&program, &facts)?;
-        self.source_match_native_ast_differentials.extend(
-            collect_source_match_native_ast_differentials(
-                &program,
-                &result,
-                &facts,
-                &source_match_diff_targets,
-                &source_match_candidates,
-                &source_match_errors,
-                &source_match_ordinal_by_binding,
-            ),
-        );
 
         for (target, (index, member, group_assignment)) in deferred_targets {
             let request = &explicit_requests[index];
@@ -1463,7 +1309,7 @@ impl ChunkPlanBuilder {
                             request.id, member.export_name, claim.owner,
                         )
                     })?;
-                    if source_match_candidates
+                    let oracle_selects_import = source_match_candidates
                         .get(&target)
                         .and_then(|candidates| {
                             candidates.iter().find(|candidate| {
@@ -1479,8 +1325,11 @@ impl ChunkPlanBuilder {
                                 candidate.binding.kind,
                                 Some(BindingSourceKind::ImportSpecifier)
                             )
-                        })
-                    {
+                        });
+                    let native_selects_import = member.source_match.is_some()
+                        && !source_match_oracle_targets.contains(&target)
+                        && solver_claim_is_import_specifier(&facts, claim);
+                    if oracle_selects_import || native_selects_import {
                         self.claim_post_stage_a_imported_binding(
                             request,
                             &member,
@@ -1510,12 +1359,18 @@ impl ChunkPlanBuilder {
                         .get(&target)
                         .cloned()
                         .or_else(|| {
-                            source_match_resolution_error_message(
-                                selector_resolver,
-                                request,
-                                &member,
-                                group_assignment.as_ref(),
-                            )
+                            if member.source_match.is_some()
+                                && !source_match_oracle_targets.contains(&target)
+                            {
+                                source_match_no_match_message(request, &member)
+                            } else {
+                                source_match_resolution_error_message(
+                                    selector_resolver,
+                                    request,
+                                    &member,
+                                    group_assignment.as_ref(),
+                                )
+                            }
                         })
                         .or_else(|| source_match_no_match_message(request, &member))
                     {
@@ -1542,19 +1397,26 @@ impl ChunkPlanBuilder {
                     );
                 }
                 Some(ClaimOutcome::Ambiguous { candidates }) => {
-                    if let Some(message) = source_match_resolution_error_message(
-                        selector_resolver,
-                        request,
-                        &member,
-                        group_assignment.as_ref(),
-                    )
-                    .or_else(|| {
-                        source_match_ambiguous_message(
+                    let message = if member.source_match.is_some()
+                        && !source_match_oracle_targets.contains(&target)
+                    {
+                        native_source_match_ambiguous_message(request, &member, candidates)
+                    } else {
+                        source_match_resolution_error_message(
+                            selector_resolver,
                             request,
                             &member,
-                            source_match_candidates.get(&target).map(Vec::as_slice),
+                            group_assignment.as_ref(),
                         )
-                    }) {
+                        .or_else(|| {
+                            source_match_ambiguous_message(
+                                request,
+                                &member,
+                                source_match_candidates.get(&target).map(Vec::as_slice),
+                            )
+                        })
+                    };
+                    if let Some(message) = message {
                         if self.keep_going {
                             self.source_match_diagnostics
                                 .push(SourceMatchDiagnostic::new(
@@ -2924,37 +2786,9 @@ impl ChunkPlanBuilder {
                 source_match_hash: Some(source_match::selector_key(&diagnostic.selector)),
                 source_match_body_hash: Some(source_match::selector_body_key(&diagnostic.selector)),
                 duplicate_claim: None,
-                source_match_native_diff: None,
                 message: diagnostic.message.clone(),
                 recommended_next_action: recommended_source_match_action(&diagnostic.category)
                     .to_string(),
-            });
-        }
-        for diagnostic in &self.source_match_native_ast_differentials {
-            diagnostics.push(SelectorDiagnosticEntry {
-                category: "source_match_native_diff_mismatch".to_string(),
-                module_id: diagnostic.module_id.clone(),
-                module_path: Some(diagnostic.module_path.clone()),
-                export_name: Some(diagnostic.export_name.clone()),
-                selector_kind: source_match_selector_kind(&diagnostic.claim_origin).to_string(),
-                target_binding: diagnostic.selector.target_binding.clone(),
-                claim_origin: Some(diagnostic.claim_origin.clone()),
-                body_indices: vec![diagnostic.report.oracle.body_index],
-                first_mismatch: Some(diagnostic.report.mismatch_kind.clone()),
-                nearest_candidates: Vec::new(),
-                source_match_preview: Some(source_match::source_match_preview(
-                    &diagnostic.selector.match_source,
-                )),
-                source_match_hash: Some(source_match::selector_key(&diagnostic.selector)),
-                source_match_body_hash: Some(source_match::selector_body_key(&diagnostic.selector)),
-                duplicate_claim: None,
-                source_match_native_diff: Some(diagnostic.report.clone()),
-                message: diagnostic.message.clone(),
-                recommended_next_action:
-                    "Compare native AST selector lowering against the legacy source_match oracle, \
-                     then fix the native lowering before retiring SourceMatchCandidate for this \
-                     selector shape."
-                        .to_string(),
             });
         }
         for diagnostic in &self.anonymous_statement_diagnostics {
@@ -2976,7 +2810,6 @@ impl ChunkPlanBuilder {
                 source_match_hash: None,
                 source_match_body_hash: None,
                 duplicate_claim: None,
-                source_match_native_diff: None,
                 message: diagnostic.message.clone(),
                 recommended_next_action: recommended_source_match_action(category).to_string(),
             });
@@ -3002,7 +2835,6 @@ impl ChunkPlanBuilder {
                     existing: DuplicateClaimSiteReport::from(&duplicate.existing),
                     duplicate: DuplicateClaimSiteReport::from(&duplicate.duplicate),
                 }),
-                source_match_native_diff: None,
                 message: duplicate.render(),
                 recommended_next_action: "Move duplicate claims into one logical module, remove the duplicate member, or expose aliases from the same module."
                     .to_string(),
@@ -3069,215 +2901,5 @@ impl ChunkPlanBuilder {
             anonymous_ordinal_assignment: self.anonymous_ordinal_assignment,
             unmatched_spec_claims: self.unmatched_spec_claims,
         })
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use selector_ir::{ClaimKind, ClaimOrigin, ResolvedClaim, SolverClaim, VariableDomain};
-
-    fn selector() -> spec::AnonymousStatementSelector {
-        let mut selector = spec::AnonymousStatementSelector::exact("function selected() {}");
-        selector.target_binding = Some("selected".to_string());
-        selector
-    }
-
-    fn program_for_selector(
-        selector_key: &str,
-        include_candidate_atom: bool,
-    ) -> (SelectorProgram, SelectorTargetId) {
-        let mut program = SelectorProgram::default();
-        let owner = program.add_variable(VariableDomain::Owner, Some("@selected".to_string()));
-        let target = program.add_target(
-            analysis::ChunkId(7),
-            owner,
-            "static/app::diagnostics",
-            ClaimKind::Binding {
-                export_name: Some("selected".to_string()),
-            },
-            ClaimOrigin::MemberSelector,
-        );
-        if include_candidate_atom {
-            program.add_atom(SelectorAtom::SourceMatchCandidate {
-                owner: OwnerTerm::Var { id: owner },
-                selector_key: StringTerm::Const {
-                    value: selector_key.to_string(),
-                },
-            });
-        }
-        (program, target)
-    }
-
-    fn diff_target(
-        target: SelectorTargetId,
-        selector: &spec::AnonymousStatementSelector,
-    ) -> SourceMatchDifferentialTarget {
-        SourceMatchDifferentialTarget {
-            target,
-            request_id: "static/app::diagnostics".to_string(),
-            module_path: "diagnostics".to_string(),
-            export_name: "selected".to_string(),
-            claim_origin: "members[]".to_string(),
-            selector: selector.clone(),
-            selector_key: source_match::selector_key(selector),
-        }
-    }
-
-    fn candidate(binding: &str) -> source_match::MemberBindingMatch {
-        source_match::MemberBindingMatch {
-            body_idx: 0,
-            binding: source_match::ResolvedMemberBinding {
-                binding_name: binding.to_string(),
-                kind: None,
-            },
-        }
-    }
-
-    fn facts() -> SelectorFactStore {
-        let mut facts = SelectorFactStore::default();
-        facts.push(SelectorFact::Owner {
-            chunk_id: analysis::ChunkId(7),
-            owner: OwnerId(0),
-            statement_ordinal: StatementOrdinal(0),
-            statement_kind: "fn_decl".to_string(),
-        });
-        facts
-    }
-
-    fn candidates(
-        target: SelectorTargetId,
-        binding: &str,
-    ) -> BTreeMap<SelectorTargetId, Vec<source_match::MemberBindingMatch>> {
-        BTreeMap::from([(target, vec![candidate(binding)])])
-    }
-
-    fn ordinal_by_binding(binding: &str) -> BTreeMap<String, Option<StatementOrdinal>> {
-        BTreeMap::from([(binding.to_string(), Some(StatementOrdinal(0)))])
-    }
-
-    fn unique_result(target: SelectorTargetId, binding: &str) -> SolverResult {
-        SolverResult {
-            claims: vec![SolverClaim {
-                target,
-                outcome: ClaimOutcome::Unique {
-                    claim: ResolvedClaim {
-                        chunk_id: analysis::ChunkId(7),
-                        owner: OwnerId(0),
-                        statement_ordinal: StatementOrdinal(0),
-                        binding: Some(binding.to_string()),
-                        provenance: Vec::new(),
-                    },
-                },
-            }],
-        }
-    }
-
-    fn collect_with(
-        program: &SelectorProgram,
-        target: SelectorTargetId,
-        selector: &spec::AnonymousStatementSelector,
-        result: &SolverResult,
-        candidates: &BTreeMap<SelectorTargetId, Vec<source_match::MemberBindingMatch>>,
-        ordinal_by_binding: &BTreeMap<String, Option<StatementOrdinal>>,
-    ) -> Vec<SourceMatchNativeAstDifferential> {
-        collect_source_match_native_ast_differentials(
-            program,
-            result,
-            &facts(),
-            &[diff_target(target, selector)],
-            candidates,
-            &BTreeMap::new(),
-            ordinal_by_binding,
-        )
-    }
-
-    #[test]
-    fn native_source_match_diff_is_empty_for_matching_unique_resolution() {
-        let selector = selector();
-        let selector_key = source_match::selector_key(&selector);
-        let (program, target) = program_for_selector(&selector_key, false);
-        let result = unique_result(target, "oracleBinding");
-
-        let differentials = collect_with(
-            &program,
-            target,
-            &selector,
-            &result,
-            &candidates(target, "oracleBinding"),
-            &ordinal_by_binding("oracleBinding"),
-        );
-
-        assert!(differentials.is_empty(), "{differentials:#?}");
-    }
-
-    #[test]
-    fn native_source_match_diff_reports_binding_mismatch() {
-        let selector = selector();
-        let selector_key = source_match::selector_key(&selector);
-        let (program, target) = program_for_selector(&selector_key, false);
-        let result = unique_result(target, "nativeBinding");
-
-        let differentials = collect_with(
-            &program,
-            target,
-            &selector,
-            &result,
-            &candidates(target, "oracleBinding"),
-            &ordinal_by_binding("oracleBinding"),
-        );
-
-        assert_eq!(differentials.len(), 1);
-        assert_eq!(differentials[0].report.mismatch_kind, "binding_mismatch");
-        assert_eq!(differentials[0].report.oracle.binding, "oracleBinding");
-        assert_eq!(
-            differentials[0].report.native.binding.as_deref(),
-            Some("nativeBinding")
-        );
-    }
-
-    #[test]
-    fn native_source_match_diff_reports_native_no_match_against_oracle_unique() {
-        let selector = selector();
-        let selector_key = source_match::selector_key(&selector);
-        let (program, target) = program_for_selector(&selector_key, false);
-        let result = SolverResult {
-            claims: vec![SolverClaim {
-                target,
-                outcome: ClaimOutcome::NoMatch,
-            }],
-        };
-
-        let differentials = collect_with(
-            &program,
-            target,
-            &selector,
-            &result,
-            &candidates(target, "oracleBinding"),
-            &ordinal_by_binding("oracleBinding"),
-        );
-
-        assert_eq!(differentials.len(), 1);
-        assert_eq!(differentials[0].report.mismatch_kind, "native_no_match");
-        assert_eq!(differentials[0].report.native.kind, "no_match");
-    }
-
-    #[test]
-    fn native_source_match_diff_skips_oracle_fallback_source_match_candidate_atom() {
-        let selector = selector();
-        let selector_key = source_match::selector_key(&selector);
-        let (program, target) = program_for_selector(&selector_key, true);
-        let result = unique_result(target, "nativeBinding");
-
-        let differentials = collect_with(
-            &program,
-            target,
-            &selector,
-            &result,
-            &candidates(target, "oracleBinding"),
-            &ordinal_by_binding("oracleBinding"),
-        );
-
-        assert!(differentials.is_empty(), "{differentials:#?}");
     }
 }

--- a/devinfra/js/debundle/selector_diagnostics.rs
+++ b/devinfra/js/debundle/selector_diagnostics.rs
@@ -28,9 +28,6 @@
 //!   hole);
 //! - `duplicate_claim` — two selectors resolved to the same declaration
 //!   identity in the same chunk.
-//! - `source_match_native_diff_mismatch` — native AST lowering for a
-//!   `source_match` selector resolved differently than the legacy
-//!   `SourceMatchCandidate` oracle.
 //!
 //! The first three categories cover both member / binding-group `source_match`
 //! selectors and `anonymous_statements[].match` selectors;
@@ -80,8 +77,6 @@ pub struct SelectorDiagnosticEntry {
     pub source_match_hash: Option<String>,
     pub source_match_body_hash: Option<String>,
     pub duplicate_claim: Option<DuplicateClaimReport>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub source_match_native_diff: Option<SourceMatchNativeDiffReport>,
     pub message: String,
     pub recommended_next_action: String,
 }
@@ -110,29 +105,4 @@ pub struct DuplicateClaimSiteReport {
     pub module_id: String,
     pub export_name: Option<String>,
     pub claim_origin: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SourceMatchNativeDiffReport {
-    pub mismatch_kind: String,
-    pub oracle: SourceMatchNativeDiffOracle,
-    pub native: SourceMatchNativeDiffOutcome,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SourceMatchNativeDiffOracle {
-    pub body_index: usize,
-    pub statement_ordinal: usize,
-    pub owner_id: Option<usize>,
-    pub binding: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SourceMatchNativeDiffOutcome {
-    pub kind: String,
-    pub statement_ordinal: Option<usize>,
-    pub owner_id: Option<usize>,
-    pub binding: Option<String>,
-    pub candidate_count: Option<usize>,
-    pub message: Option<String>,
 }


### PR DESCRIPTION
## Summary

- Reorder global source_match resolution so selectors are lowered into the IR before legacy candidate enumeration.
- Call `ChunkResolver` only for targets whose lowered program still contains `SourceMatchCandidate`; native-covered selectors now go straight through the single solver pass over AST/owner facts.
- Remove the prior native/oracle differential compatibility shim and its JSON schema payload.
- Keep fallback oracle behavior for unsupported selector shapes while deriving native import-specifier routing and native no-match/ambiguous diagnostics from solver facts/results.

This is not the full deletion of `SourceMatchCandidate`; it is the production bridge removal for selector shapes already covered by native AST lowering.

## Validation

- `nix develop --command pre-commit run --files devinfra/js/debundle/e2e/anonymous_statement_test.rs devinfra/js/debundle/lowering/materialize/plan_builder.rs devinfra/js/debundle/selector_diagnostics.rs`
- `nix develop --command bazelisk test //devinfra/js/debundle:lowering_test //devinfra/js/debundle/e2e:anonymous_statement_test //devinfra/js/debundle/e2e:selector_diagnostics_report_test --config=rbe --remote_upload_local_results=false --remote_download_outputs=all --test_output=errors --cache_test_results=no`
  - BuildBuddy: https://app.buildbuddy.io/invocation/ac0aeaac-e80e-489d-a6f3-1e680ba68fb7
- Gaffer-private local override verification:
  - `nix develop -c bazelisk --output_base=/tmp/gaffer-tana-single-resolve build --experimental_convenience_symlinks=ignore --config=nolint --config=rbe --config=source-debundler --remote_upload_local_results=false --remote_download_outputs=all --override_module=ducktape=/tmp/ducktape-single-resolve-pass --override_module=ducktape_activitywatch=/tmp/ducktape-single-resolve-pass/third_party/activitywatch --override_module=ducktape_manifold_mcp_server=/tmp/ducktape-single-resolve-pass/third_party/manifold_mcp_server --override_module=ducktape_mcporter=/tmp/ducktape-single-resolve-pass/third_party/mcporter --override_module=ducktape_claude_web_env_environment_manager=/tmp/ducktape-single-resolve-pass/devinfra/claude/web_env/re/environment_manager/src //tana/re/web/78d928dca7:debundle`
  - BuildBuddy: https://app.buildbuddy.io/invocation/ff0a666f-fabc-44c3-819a-ab998ff1c030
  - Output had no `selector_diagnostics.json` files and no `source_match_native_diff` strings in `reports/tree`.