### PR TITLE
[codex] Lower superclass source_match selectors natively

### DIFF
--- a/devinfra/js/debundle/e2e/anonymous_statement_test.rs
+++ b/devinfra/js/debundle/e2e/anonymous_statement_test.rs
@@ -1087,6 +1087,42 @@ export { runtimeFormat };
 }
 
 #[test]
+fn exact_native_source_match_with_extends_skips_legacy_resolver_timing() {
+    let fixture = run_fixture_with_env(
+        FixtureOpts::new(
+            r#"class RuntimeWidget extends Object {
+  label() {
+    return "runtime";
+  }
+}
+console.log(new RuntimeWidget().label());
+export { RuntimeWidget };
+"#,
+            vec![logical_module(
+                "widget",
+                &[Member::source_exact_target(
+                    "runtimeWidget",
+                    "RuntimeWidget",
+                    r#"class RuntimeWidget extends Object {
+  label() {
+    return "runtime";
+  }
+}"#,
+                )],
+            )],
+        ),
+        &[("DUCKTAPE_SOURCE_MATCH_TIMINGS", "1")],
+    );
+
+    assert_entry_output(&fixture, "runtime\n");
+    assert!(
+        !fixture.stderr.contains("[debundle source_match]"),
+        "native exact source_match with extends should not call the legacy resolver\nstderr:\n{}",
+        fixture.stderr,
+    );
+}
+
+#[test]
 fn source_match_timing_preview_can_be_disabled() {
     let fixture = run_fixture_with_env(
         FixtureOpts::new(

--- a/devinfra/js/debundle/selector_ir.rs
+++ b/devinfra/js/debundle/selector_ir.rs
@@ -165,6 +165,10 @@ pub enum SelectorAtom {
         index: u32,
         child: NodeTerm,
     },
+    AstSuperClass {
+        class_node: NodeTerm,
+        super_class: NodeTerm,
+    },
     AstChildCount {
         node: NodeTerm,
         count: u32,
@@ -395,6 +399,13 @@ impl SelectorProgram {
             SelectorAtom::AstChild { parent, child, .. } => {
                 self.validate_node_term(parent, "ast_child.parent")?;
                 self.validate_node_term(child, "ast_child.child")
+            }
+            SelectorAtom::AstSuperClass {
+                class_node,
+                super_class,
+            } => {
+                self.validate_node_term(class_node, "ast_super_class.class_node")?;
+                self.validate_node_term(super_class, "ast_super_class.super_class")
             }
             SelectorAtom::AstChildCount { node, .. } => {
                 self.validate_node_term(node, "ast_child_count.node")

--- a/devinfra/js/debundle/selector_ir_lowering.rs
+++ b/devinfra/js/debundle/selector_ir_lowering.rs
@@ -351,9 +351,6 @@ impl MemberSelectorProgramBuilder {
         else {
             return Ok(false);
         };
-        if !facts.super_class.is_empty() {
-            return Ok(false);
-        }
         let [(root_node, _ordinal)] = facts.top_level.as_slice() else {
             return Ok(false);
         };
@@ -441,6 +438,17 @@ impl MemberSelectorProgramBuilder {
                 parent: node_term(*parent),
                 index: *index,
                 child: node_term(*child),
+            });
+        }
+        for (class_node, super_class) in &facts.super_class {
+            let (Some(class_node), Some(super_class)) =
+                (node_vars.get(class_node), node_vars.get(super_class))
+            else {
+                continue;
+            };
+            self.program.add_atom(SelectorAtom::AstSuperClass {
+                class_node: node_term(*class_node),
+                super_class: node_term(*super_class),
             });
         }
         for (node, value) in &facts.str_lit {
@@ -831,6 +839,32 @@ mod tests {
                 .atoms
                 .iter()
                 .any(|atom| matches!(atom, SelectorAtom::AstChild { .. }))
+        );
+    }
+
+    #[test]
+    fn exact_source_match_with_superclass_lowers_to_native_ast_constraint() {
+        let selector = AnonymousStatementSelector::exact("class Widget extends BaseWidget {}");
+        let lowered = lower_member_selector(
+            &context(),
+            "Widget",
+            &MemberSelectorSpec::SourceMatch(selector),
+        )
+        .unwrap();
+
+        assert!(
+            !lowered
+                .program
+                .atoms
+                .iter()
+                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
+        );
+        assert!(
+            lowered
+                .program
+                .atoms
+                .iter()
+                .any(|atom| matches!(atom, SelectorAtom::AstSuperClass { .. }))
         );
     }
 

--- a/devinfra/js/debundle/selector_ir_solver.rs
+++ b/devinfra/js/debundle/selector_ir_solver.rs
@@ -213,6 +213,8 @@ ascent! {
     relation required_ast_child_count(usize, usize, u32);
     relation required_ast_child_parent(usize, usize, u32, u32);
     relation required_ast_child_child(usize, usize, u32, u32);
+    relation required_ast_super_class_class(usize, usize, u32);
+    relation required_ast_super_class_super(usize, usize, u32);
     relation required_ast_string_literal(usize, usize, String);
     relation required_ast_number_literal(usize, usize, String);
     relation required_ast_bool_literal(usize, usize, bool);
@@ -242,6 +244,14 @@ ascent! {
         ast_child(actual_parent, actual_index, child),
         if actual_parent == parent,
         if actual_index == index;
+    node_constraint_support(*constraint, *var, *class_node) <--
+        required_ast_super_class_class(constraint, var, super_class),
+        ast_super_class(class_node, actual_super_class),
+        if actual_super_class == super_class;
+    node_constraint_support(*constraint, *var, *super_class) <--
+        required_ast_super_class_super(constraint, var, class_node),
+        ast_super_class(actual_class_node, super_class),
+        if actual_class_node == class_node;
     node_constraint_support(*constraint, *var, *node) <--
         required_ast_string_literal(constraint, var, value),
         ast_string_literal(node, actual),
@@ -294,6 +304,7 @@ ascent! {
     relation required_intrinsic_alias(usize, usize, usize, String);
     relation required_owner_statement_ordinal_var(usize, usize, usize);
     relation required_ast_child(usize, usize, usize, u32);
+    relation required_ast_super_class(usize, usize, usize);
     relation required_ast_top_level(usize, usize, usize);
     relation required_owner_top_level_root(usize, usize, usize);
     relation required_ast_string_literal_var(usize, usize, usize);
@@ -333,6 +344,9 @@ ascent! {
         required_ast_child(constraint, parent_var, child_var, index),
         ast_child(parent, actual_index, child),
         if actual_index == index;
+    node_node_constraint_edge(*constraint, *class_var, *class_node, *super_var, *super_class) <--
+        required_ast_super_class(constraint, class_var, super_var),
+        ast_super_class(class_node, super_class);
 
     relation node_ordinal_constraint_edge(usize, usize, u32, usize, usize);
     node_ordinal_constraint_edge(*constraint, *node_var, *node, *ordinal_var, *ordinal) <--
@@ -584,6 +598,20 @@ pub fn solve(
                     *index,
                 ));
             }
+            NodeUnaryConstraintKind::SuperClassClass { super_class } => {
+                ascent.required_ast_super_class_class.push((
+                    constraint.id,
+                    constraint.variable.0,
+                    *super_class,
+                ));
+            }
+            NodeUnaryConstraintKind::SuperClassSuper { class_node } => {
+                ascent.required_ast_super_class_super.push((
+                    constraint.id,
+                    constraint.variable.0,
+                    *class_node,
+                ));
+            }
             NodeUnaryConstraintKind::StringLiteral { value } => {
                 ascent.required_ast_string_literal.push((
                     constraint.id,
@@ -727,6 +755,11 @@ pub fn solve(
                 constraint.left.0,
                 constraint.right.0,
                 index,
+            )),
+            NodeNodeConstraintKind::AstSuperClass => ascent.required_ast_super_class.push((
+                constraint.id,
+                constraint.left.0,
+                constraint.right.0,
             )),
         }
     }
@@ -1405,6 +1438,10 @@ impl ProgramSupport {
                     index,
                     child,
                 } => support.add_ast_child(parent, *index, child),
+                SelectorAtom::AstSuperClass {
+                    class_node,
+                    super_class,
+                } => support.add_ast_super_class(class_node, super_class),
                 SelectorAtom::AstStringLiteral {
                     node,
                     value: StringTerm::Const { value },
@@ -1816,6 +1853,37 @@ impl ProgramSupport {
         }
     }
 
+    fn add_ast_super_class(&mut self, class_node: &NodeTerm, super_class: &NodeTerm) {
+        match (class_node, super_class) {
+            (NodeTerm::Var { id: class_node }, NodeTerm::Var { id: super_class }) => {
+                self.add_node_node(
+                    *class_node,
+                    *super_class,
+                    NodeNodeConstraintKind::AstSuperClass,
+                );
+            }
+            (NodeTerm::Var { id: class_node }, NodeTerm::Const { node: super_class }) => {
+                self.add_node_unary(
+                    *class_node,
+                    NodeUnaryConstraintKind::SuperClassClass {
+                        super_class: *super_class,
+                    },
+                );
+            }
+            (NodeTerm::Const { node: class_node }, NodeTerm::Var { id: super_class }) => {
+                self.add_node_unary(
+                    *super_class,
+                    NodeUnaryConstraintKind::SuperClassSuper {
+                        class_node: *class_node,
+                    },
+                );
+            }
+            _ => self
+                .unsupported_atoms
+                .push("unsupported constant-only ast_super_class assertion".to_string()),
+        }
+    }
+
     fn add_node_label(
         &mut self,
         node: &NodeTerm,
@@ -1960,6 +2028,8 @@ enum NodeUnaryConstraintKind {
     ChildCount { count: u32 },
     ChildParent { index: u32, child: u32 },
     ChildChild { parent: u32, index: u32 },
+    SuperClassClass { super_class: u32 },
+    SuperClassSuper { class_node: u32 },
     StringLiteral { value: String },
     NumberLiteral { value: String },
     BoolLiteral { value: bool },
@@ -2034,6 +2104,7 @@ struct NodeNodeConstraint {
 #[derive(Debug, Clone, Copy)]
 enum NodeNodeConstraintKind {
     AstChild { index: u32 },
+    AstSuperClass,
 }
 
 #[derive(Debug, Clone)]
@@ -2081,6 +2152,7 @@ fn atom_kind(atom: &SelectorAtom) -> &'static str {
         SelectorAtom::OwnerAliasesOwner { .. } => "owner_aliases_owner",
         SelectorAtom::AstKind { .. } => "ast_kind",
         SelectorAtom::AstChild { .. } => "ast_child",
+        SelectorAtom::AstSuperClass { .. } => "ast_super_class",
         SelectorAtom::AstChildCount { .. } => "ast_child_count",
         SelectorAtom::AstStringLiteral { .. } => "ast_string_literal",
         SelectorAtom::AstNumberLiteral { .. } => "ast_number_literal",


### PR DESCRIPTION
## Summary

- Add `AstSuperClass` as a selector IR atom over the existing superclass fact relation.
- Teach the Ascent selector solver to satisfy superclass node-node and constant-node constraints.
- Stop exact single-statement `source_match` lowering from falling back to the legacy oracle solely because the selector contains `extends`.
- Add synthetic coverage proving class-extends exact source matches lower natively and skip legacy resolver timing output.

This is another fallback class removed from the path toward one native solver pass; `SourceMatchCandidate` remains only for selector shapes not yet lowered natively.

## Validation

- `nix develop --command rustfmt devinfra/js/debundle/selector_ir.rs devinfra/js/debundle/selector_ir_lowering.rs devinfra/js/debundle/selector_ir_solver.rs devinfra/js/debundle/e2e/anonymous_statement_test.rs`
- `nix develop --command bazelisk test //devinfra/js/debundle:selector_ir_test //devinfra/js/debundle:selector_ir_lowering_test //devinfra/js/debundle:selector_ir_solver_test //devinfra/js/debundle/e2e:anonymous_statement_test --config=rbe --remote_upload_local_results=false --remote_download_outputs=all --test_output=errors --cache_test_results=no`
  - BuildBuddy: https://app.buildbuddy.io/invocation/8b6bf814-d211-4585-9a53-30867bab6360
- `nix develop --command pre-commit run --files devinfra/js/debundle/e2e/anonymous_statement_test.rs devinfra/js/debundle/selector_ir.rs devinfra/js/debundle/selector_ir_lowering.rs devinfra/js/debundle/selector_ir_solver.rs`
- Gaffer-private local override verification:
  - `nix develop -c bazelisk --output_base=/tmp/gaffer-tana-native-superclass build --experimental_convenience_symlinks=ignore --config=nolint --config=rbe --config=source-debundler --remote_upload_local_results=false --remote_download_outputs=all --override_module=ducktape=/tmp/ducktape-native-superclass --override_module=ducktape_activitywatch=/tmp/ducktape-native-superclass/third_party/activitywatch --override_module=ducktape_manifold_mcp_server=/tmp/ducktape-native-superclass/third_party/manifold_mcp_server --override_module=ducktape_mcporter=/tmp/ducktape-native-superclass/third_party/mcporter --override_module=ducktape_claude_web_env_environment_manager=/tmp/ducktape-native-superclass/devinfra/claude/web_env/re/environment_manager/src //tana/re/web/78d928dca7:debundle`
  - BuildBuddy: https://app.buildbuddy.io/invocation/b390f520-1f90-4d12-9a49-9a221b1230a4
  - Output had no `selector_diagnostics.json` files and no `source_match_native_diff` strings in `reports/tree`.