### PR TITLE
debundle: align single-query resolver tracking

### DIFF
--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -3,7 +3,7 @@
 Forward-looking gaps in the Rust debundler. Items are written to be removed
 once closed; this file is not a changelog.
 
-## Current AI-worker priority queue (2026-06-14)
+## Current AI-worker priority queue (2026-06-23)
 
 This queue captures the active debundle tooling program. Treat this file as
 the current priority source of truth; detailed design for the automation-first
@@ -24,39 +24,43 @@ records and scoped backlogs; when a plan's core work is complete, its remaining
 tail should be summarized here instead of leaving the plan looking like a second
 priority queue.
 
-**Current focus (2026-06-23 post-#2443).** PR #2439 landed on `devel` as
-`db25ef639` and closed the first global-solver bridge: `source_match` selectors
-now participate in the Ascent-backed selector solver. PR #2443 then lowered the
-exact single-statement subset onto native AST EDB facts. The remaining P0 is not
-a new solver choice. It is to remove the bridge shape that still feeds the
-solver pre-enumerated `SourceMatchCandidate` rows from `ChunkResolver`, and
-instead lower every supported `source_match` shape directly onto the native AST
-EDB facts already exposed by `chunk_facts.rs` /
-`SelectorFactStore::extend_chunk_facts`.
+**Current focus (2026-06-23 post-#2447).** PRs #2439, #2443, #2446, and
+#2447 moved `source_match` onto the Ascent-backed selector path, lowered the
+exact single-statement AST subset, stopped calling `ChunkResolver` for native
+selectors, and added native class-superclass constraints. The remaining P0 is
+to make every live selector form lower into one declarative Ascent/CSP-style
+constraint program. `SourceMatchCandidate` should shrink to the unsupported
+fallback set and then disappear.
 
 Dispatch work in this order:
 
-1. **Native AST EDB in the solver (P0.1).** Thread the full `ast_*` fact rows
-   through the Ascent rule library as queryable relations, with source spans and
-   fail-closed unsupported reporting.
-2. **`source_match` lowering parity (P0.2).** Compile JS-with-holes selectors,
-   binding groups, anonymous statements, holes, alpha matching, and regex
-   predicates into AST/owner facts. Keep `ChunkResolver` as the oracle until the
-   differential reaches zero. The mismatch-only parity surface is
-   `selector_diagnostics.json` entries with category
-   `source_match_native_diff_mismatch`.
-3. **Delete the candidate oracle (P0.3).** Replace `SourceMatchCandidate`
-   facts with native AST-shape constraints, and make no-match, ambiguous, and
-   duplicate-claim diagnostics projections of the solver result.
-4. **Derived relational predicates (P0.4).** Fold the remaining bridge
+1. **Alpha-all as query structure (P0.1).** Lower `identifiers: alpha_all` to
+   logic variables, equality, disequality / `all_different`, and scope facts.
+   Do not clone the procedural `selector_match::Bindings` matcher inside the
+   solver; alpha-renaming should fall out of the query.
+2. **Core hole predicates (P0.2).** Lower simple `ANYTHING` / `EXPR` / `STMT`
+   holes, regex string predicates, and then ordered run holes (`STMT_LIST`,
+   `OBJECT_PROPS`, `DECLARATORS`, `ARGS`, `CLASS_REST`, `CASE_REST`,
+   `ARRAY_ELEMENTS`) as native constraints. Preserve the fail-closed rule:
+   unsupported constructs stay on the oracle until their faithful encoding is
+   implemented.
+3. **Source-match surface pruning (P0.3).** Remove legacy `source_match`
+   options that no current downstream spec uses before nativeization hardens
+   them into the new IR. Current gaffer-private census: `target_statement`,
+   `target_statements`, and `wildcard_string_literals` are unused; verify and
+   delete Ducktape fixtures/helpers in a focused branch.
+4. **Delete the candidate oracle (P0.4).** Remove `SelectorAtom::SourceMatchCandidate`
+   / `SelectorFact::SourceMatchCandidate` once all retained selector forms lower
+   natively. No-match, ambiguity, unsupported, and duplicate-claim diagnostics
+   should be projections of solver results and categoricity / `all_different`.
+5. **Derived relational predicates (P0.5).** Fold the remaining bridge
    vocabulary (`cross_ref`, `reads_member`, `member_of_module`,
    `passed_to_call`, `makes_decorate_call`, `intrinsic_alias`) into IR atoms or
-   derived predicates over owner/reference + AST facts. Keep bridge tests as
-   parity tests until the bridge passes can be deleted.
+   derived predicates over owner/reference + AST facts.
 
 The minimizer polish tail and automation product flows remain valuable, but
-they should build on this native AST EDB resolver contract rather than harden
-today's candidate-oracle or late-bridge shape.
+they should build on this single constraint-program resolver contract rather
+than harden today's fallback oracle or late-bridge shape.
 
 Prefer dispatching work in this order. Large downstream spec migrations should
 lean on tooling generated from this queue instead of hand-authored YAML.
@@ -73,13 +77,14 @@ parallel dispatch queue.
 - <plans/selector_constraint_model.md> — **active (P0 global resolver).**
   Canonical plan for the selector model, Ascent solver choice, execution
   phases, verification gates, and Gaffer evidence queue. #2439 closed the
-  global-solver admission path for `source_match`; current top priority is
-  replacing the `SourceMatchCandidate` oracle with native AST EDB lowering. The
-  landed bridge primitives (`cross_ref`, `reads_member`, `member_of_module`,
-  `passed_to_call`, `makes_decorate_call`, `intrinsic_alias`) are useful
-  fact/selector vocabulary, but are bridge implementations until they fold into
-  derived predicates. See <debug/2026_06_19_p4_debt_worklist.md> for real-spec
-  evidence.
+  global-solver admission path for `source_match`; #2443/#2446/#2447 moved the
+  exact native subset out of the oracle. Current top priority is alpha-all and
+  hole lowering as one declarative query, plus pruning unused source-match
+  surface before carrying it forward. The landed bridge primitives (`cross_ref`,
+  `reads_member`, `member_of_module`, `passed_to_call`, `makes_decorate_call`,
+  `intrinsic_alias`) are useful fact/selector vocabulary, but are bridge
+  implementations until they fold into derived predicates. See
+  <debug/2026_06_19_p4_debt_worklist.md> for real-spec evidence.
 - <plans/automated_spec_workflows.md> — **active design, downstream of P0.**
   North-star for the inventory/plan/apply/validate CLI surface and the
   synthesize / stabilize / version-port / new-app-bootstrap flows. Foundational
@@ -96,22 +101,28 @@ parallel dispatch queue.
   planner design space + algorithm/analysis backlog behind `debundle modules
 propose`.
 
-### P0 — native AST EDB resolver cutover
+### P0 — single constraint-program resolver cutover
 
 Detailed design and gates live in <plans/selector_constraint_model.md>; keep
 this list as the dispatch summary, not a second plan.
 
-1. **Thread full AST facts into Ascent.** `chunk_facts.rs` already extracts
-   `ast_*` rows and `SelectorFactStore::extend_chunk_facts` already stores
-   them. Make the solver consume those rows as native AST-shape relations.
-2. **Lower `source_match` to those facts.** Replace JS-template matching with
-   IR atoms over AST/owner facts, while differentially checking against
-   `ChunkResolver` until selectors, binding groups, anonymous statements,
-   holes, alpha matching, and regex predicates are byte-for-byte equivalent.
-3. **Retire `SourceMatchCandidate`.** Delete the pre-enumerated candidate
-   oracle once the native lowering is equivalent, and route source-match
-   diagnostics through solver categoricity / `all_different`.
-4. **Fold bridge vocabulary into derived predicates.** Re-express the staged
+1. **Lower alpha-all declaratively.** Represent selector-local identifier
+   bindings/references as variables and constraints over facts, including
+   equality, disequality / `all_different`, and scope. This is the blocker for
+   current gaffer-private payoff: its Tana spec uses `identifiers: alpha_all`
+   for every `source_match`.
+2. **Lower the retained hole vocabulary.** Start with simple single-node holes
+   and regex string predicates, then add ordered run-hole placement for the
+   high-volume families (`STMT_LIST`, `DECLARATORS`, `OBJECT_PROPS`). Each
+   lowering must be faithful or fail closed.
+3. **Prune unused source-match options.** Remove `target_statement`,
+   `target_statements`, and `wildcard_string_literals` unless a fresh downstream
+   census finds real use. Also run a broader vestigial-feature audit before
+   nativeizing more rarely-used spec surface.
+4. **Retire `SourceMatchCandidate`.** Delete the pre-enumerated candidate
+   oracle once all retained selector forms lower natively, and route
+   source-match diagnostics through solver categoricity / `all_different`.
+5. **Fold bridge vocabulary into derived predicates.** Re-express the staged
    relational selectors as solver predicates over owner/reference + AST facts.
    Real-spec Gaffer work should supply missing predicates and diagnostics, not
    another permanent resolver layer.

--- a/devinfra/js/debundle/docs/selectors.md
+++ b/devinfra/js/debundle/docs/selectors.md
@@ -314,52 +314,12 @@ bindings. An explicit `exports` entry on the same group overrides the adopted
 public name for that selector-local binding. `comments` is keyed by
 selector-local binding name and emits like `members[].comment` after expansion.
 
-When the same source window should export bindings and move adjacent
-side-effect statements, put `target_statement` or `target_statements` on the
-binding group's `source_match`. Binding exports are still controlled by
-`exports` / `adopt_names`, while the selected statement indices are claimed as
-anonymous statements from the same structural match:
-
-```yaml
-binding_groups:
-  - source_match:
-      identifiers: alpha_all
-      target_statements: [1, 2]
-      match: |
-        let recordSlot, replaySlot;
-        true && (replaySlot = "replay");
-        false || (recordSlot = "record");
-    exports:
-      recordSlot: recordBridge
-      replaySlot: replayBridge
-```
-
-Decorator/property setup calls fit the same pattern. Use the class declaration
-as the binding context, keep durable property strings exact, and claim the
-decorator calls by index:
-
-```yaml
-binding_groups:
-  - source_match:
-      identifiers: alpha_all
-      target_statements: [1, 2]
-      match: |
-        class DecoratedModel {
-          CLASS_REST;
-          report() {
-            STMT_LIST;
-          }
-          CLASS_REST;
-        }
-        decorate(["observable"], DecoratedModel.prototype, "state");
-        decorate(["observable"], DecoratedModel.prototype, "title");
-    adopt_names: [DecoratedModel]
-```
-
-Under `alpha_all`, `decorate` and `DecoratedModel` are selector-local names:
-they only require a consistent structural correspondence inside this selector,
-so the runtime helper and class binding may be minified differently. The
-strings `"state"` and `"title"` remain exact anchors.
+Legacy binding-group `target_statement` / `target_statements` support can claim
+adjacent anonymous side-effect statements by source-order index from the same
+structural match. Do not use it for new specs: current downstream specs do not
+exercise it, it is slated for removal, and the single-query resolver should
+model anonymous side effects as their own distinguished selector targets rather
+than as indices into neighboring context.
 
 When a few useful bindings sit inside a larger `var`/`let`/`const` declaration
 list, use declarator-list holes instead of spelling unrelated siblings:
@@ -399,57 +359,22 @@ reject the spec as ambiguous rather than picking by source order.
 Refine the selector with an exact statement, a stable literal/property
 difference, or a deliberately small surrounding context.
 
-When the anonymous statement needs surrounding declarations for a unique
-structural match, include that context and set `target_statement` to the
-zero-based index of the statement to claim:
-
-```yaml
-anonymous_statements:
-  - source_match:
-      identifiers: alpha_all
-      target_statement: 1
-      match: |
-        const selectedLeft = "left",
-          selectedRight = "right";
-        console.log(`${selectedLeft}:${selectedRight}`);
-```
-
-Only the indexed statement is claimed; the surrounding context is used for
-matching and must be claimed separately if it should move with the anonymous
-statement.
-
-Use `target_statements` when one structural selector should claim several
-anonymous statements. It accepts either an explicit zero-based index list, or
-`all` to claim every non-hole top-level statement in the selector:
-
-```yaml
-anonymous_statements:
-  - source_match:
-      identifiers: alpha_all
-      target_statements: [1, 2]
-      match: |
-        const contextValue = "stable";
-        console.log("first side effect");
-        console.log("second side effect");
-
-  - source_match:
-      identifiers: alpha_all
-      target_statements: all
-      match: |
-        console.log("before");
-        STMT_LIST;
-        console.log("after");
-```
+Legacy `target_statement` / `target_statements` can claim one or more
+source-order indices from a larger `source_match` window. Do not introduce new
+uses. Current downstream specs do not use this surface, it is slated for
+removal, and source-order indexing is a weak fit for the solver model. Prefer a
+small selector whose distinguished target is the anonymous statement itself,
+using stable literals/properties or relation atoms to make that target unique.
 
 At top level in an anonymous-statement selector, `STMT_LIST;` absorbs a run of
-module-body statements that should be used only as skipped context. A
-`target_statement` or `target_statements` index must point at a pinned
-statement, not at the `STMT_LIST` hole.
+module-body statements that should be used only as skipped context. Treat
+top-level statement-list holes as a legacy compatibility surface until native
+run-hole lowering defines the retained form.
 
 Do not solve ambiguity with opaque hashes. A selector should be readable
 enough for a reviewer to audit and edit. When an anonymous statement needs
-nearby declarations to be unique, prefer `target_statement` over spreading
-duplicated boilerplate.
+nearby declarations to be unique, prefer a relation-shaped selector or a
+separate small structural selector over source-order indexing.
 
 ## Syntactic holes
 
@@ -560,9 +485,9 @@ absorbed sequence for cross-occurrence equality.
   ```
 
 - `STMT_LIST;` (or `STMT_LIST_name;`) in a block body matches any run of
-  statements, including none. At top level it is supported in
-  `anonymous_statements[].source_match` selectors that use `target_statement`
-  or `target_statements`.
+  statements, including none. Top-level `STMT_LIST` support for anonymous
+  statements is legacy compatibility surface pending native run-hole lowering;
+  avoid new selectors that require source-order indexing.
 - `OBJECT_PROPS` (or `OBJECT_PROPS_name`) in an object literal matches any run
   of key/value properties or spreads. Anonymous `ANYTHING` in the same
   shorthand-property position is equivalent. Use either form to pin only the

--- a/devinfra/js/debundle/plans/selector_constraint_model.md
+++ b/devinfra/js/debundle/plans/selector_constraint_model.md
@@ -1,18 +1,19 @@
 # Plan: selectors as one global constraint problem (relational spec model)
 
-**Current state (2026-06-22, after #2439).** Ascent remains the selected
+**Current state (2026-06-23, after #2447).** Ascent remains the selected
 production solver. PR #2439 landed on `devel` as `db25ef639` and closed the
 first global-solver bridge: `source_match` selectors now enter the global
-selector IR/solver instead of bypassing it. That bridge still feeds the solver
-`SourceMatchCandidate` rows enumerated by the fact-based `ChunkResolver`;
-`selector_ir_lowering.rs` lowers `source_match` to that candidate atom, and
-`plan_builder.rs` populates the rows by calling `ChunkResolver` candidate APIs.
+selector IR/solver instead of bypassing it. PR #2443 lowered exact
+single-statement selectors onto native AST facts. PR #2446 stopped asking
+`ChunkResolver` for candidate rows when a selector already lowers natively.
+PR #2447 added native `AstSuperClass` constraints for `class ... extends ...`
+matches.
 
-Full AST facts already exist in `chunk_facts.rs` and are appended by
-`SelectorFactStore::extend_chunk_facts`, but they are not yet the native solve
-path for `source_match`. The remaining P0 is to make Ascent consume those AST
-facts directly, lower `source_match` onto them with zero-differential parity,
-and then delete the candidate oracle.
+The bridge that remains is narrower: unsupported `source_match` shapes still
+lower to `SourceMatchCandidate`, and `plan_builder.rs` still asks
+`ChunkResolver` to enumerate rows for those fallback targets. The remaining P0
+is to lower every retained selector form into one declarative Ascent/CSP-style
+constraint program and then delete the candidate oracle.
 
 **Reframing.** The next architectural goal is not to grow more bridge
 vocabulary. It is to make the global constraint solve native over AST +
@@ -23,6 +24,13 @@ missing language/fact coverage; they should not add more long-lived
 anchor-first bridge architecture. The remaining-work index is
 <../debug/2026_06_19_p4_debt_worklist.md>, and the Gaffer-derived language
 evidence is summarized below.
+
+Put another way: debundle's selector YAML is only an authoring frontend. The
+engine contract should be "compile the spec into one query-shaped constraint
+model, run that model over the JS-derived fact store, and read back the relation
+`readable entity -> minified entity`." Datalog/CSP terminology is about using an
+efficient off-the-shelf solver for that model, not about adding a second
+resolver architecture.
 
 Extends the selector-authoring guidance in <../docs/selectors.md> and the
 `debundle_stabilize` skill — which fix _who_ chooses anchors (an agent, not the
@@ -39,18 +47,17 @@ Notation: `@Name` means "the binding/node pinned elsewhere in the spec as `Name`
 ## Goal
 
 Replace the remaining `SourceMatchCandidate` oracle with a Datalog/Ascent
-selector resolver that resolves every selector the `tana/re` spec depends on
-over an explicit relational model of the program (owner graph + AST facts).
-Parity must be **proven, not asserted**: a corpus-wide differential against the
-current `ChunkResolver` reaches zero disagreements, and the lowering is
-**fail-closed** — each construct compiles to atoms provably faithful to current
-`source_match` semantics, or it errors, never silently under-constraining. The
-design must stay **principled** — one general, faithful encoding per selector
-kind and hole, with no per-selector special cases, silent fallbacks, or hacks to
-force a hard construct through. If any construct, or the model itself, turns out
-not to admit such a faithful, principled encoding, we **abort and rethink the
-design** rather than push on with ugly hacks — an honest dead end beats a matcher
-we cannot trust.
+selector resolver that resolves every retained selector form over an explicit
+relational model of the program (owner graph + AST facts). Parity must be
+**proven, not asserted**: each construct compiles to atoms provably faithful to
+current `source_match` semantics, or it remains an explicit unsupported
+fallback while that construct is being implemented. The design must stay
+**principled** — one general, faithful encoding per selector kind and hole, with
+no per-selector special cases, silent fallbacks, or hacks to force a hard
+construct through. If any retained construct, or the model itself, turns out not
+to admit such a faithful, principled encoding, we **abort and rethink the
+design** rather than push on with ugly hacks — an honest dead end beats a
+matcher we cannot trust.
 
 Operationally, this means the Ducktape-side work leads with the engine contract:
 
@@ -59,8 +66,9 @@ Operationally, this means the Ducktape-side work leads with the engine contract:
 2. one fact store per chunk/component containing AST-shape facts,
    binding-resolution facts, owner/reference facts, and derived-predicate inputs,
    with the solver consuming the AST facts natively rather than candidate rows;
-3. one solve per connected selector component, with `@Name` as a shared logic
-   variable rather than a lookup into already-resolved members;
+3. one logical whole-spec solve, with `@Name` as a shared logic variable rather
+   than a lookup into already-resolved members; the engine may decompose
+   independent connected components internally without changing the model;
 4. one diagnostic/result projection for no-match, ambiguity, duplicate claims,
    unsupported constructs, and "which facts forced uniqueness";
 5. one resolved claim map consumed by the existing atomic-DAG / realizability /
@@ -111,9 +119,9 @@ Then:
   variable wherever one selector references another (`@Name`). That conjunction is
   one big pattern over `G`.
 - **`run` = find the homomorphisms of the whole-spec pattern into `G`, as one
-  solve** — a single CSP instance, not selector-by-selector resolution. (Evaluating a
-  conjunctive query _is_ finding homomorphisms into the structure; a CSP solver and a
-  pattern-matcher are the same thing here.)
+  solve** — a single logical CSP/query instance, not selector-by-selector
+  resolution. (Evaluating a conjunctive query _is_ finding homomorphisms into
+  the structure; a CSP solver and a pattern-matcher are the same thing here.)
 - **Validity = target-categoricity**: projected onto the distinguished variables, the
   solution set is a single tuple. Anchors may match in many places; only the
   **claimed** image must be forced. Per target: 0 solutions → `no-match`; ≥2 distinct
@@ -330,10 +338,13 @@ become roughly 5.
 ## Landing in the debundle binary
 
 This is not a side tool — it is the **resolution layer**: the code that maps
-each spec selector to its node on the chunk. After #2439, the global selector
-solver is on that path, but `source_match` still reaches it through
-`ChunkResolver`-enumerated candidate rows. Native AST EDB lowering makes the
-solver itself responsible for the shape match.
+each readable spec entity to its minified node on the chunk. After #2439, the
+global selector solver is on that path. After #2443/#2446/#2447, exact
+single-statement and superclass `source_match` forms lower to native AST
+constraints and no longer ask `ChunkResolver` for oracle rows. Unsupported
+`source_match` shapes still fall back through `ChunkResolver`-enumerated
+`SourceMatchCandidate` rows; the remaining cutover is to shrink that fallback
+set to zero for every retained selector form.
 
 The reference oracle is named in code: `source_match::SelectorResolver`, the
 trait `ChunkResolver` implements — `(parsed chunk, JS-template selector) →
@@ -355,8 +366,9 @@ EDB:
   `SourceMatchCandidate` oracle.
 
 The cutover is a consumer change: add native AST relations and shape rules to
-the Ascent solver, then delete the candidate-oracle projection once the
-differential is zero.
+the Ascent solver, delete each fallback shape after focused equivalence tests
+and corpus checks pass, then delete the candidate-oracle projection once every
+retained selector form resolves through the solver.
 
 ### It replaces several workflow parts, not just the matcher
 
@@ -451,9 +463,16 @@ The current `source_match` hole vocabulary maps four ways; only the first is a t
   `str_matches(node, "re")` (a builtin), not existence.
 - **ordered / positional** — multiple anchored runs implying a subsequence
   (`CLASS_REST; a(){} CLASS_REST; b(){}` ⇒ `a` before `b`), `DECLARATORS_BEFORE/AFTER`,
-  the `target_statement` index → **sibling-order atoms**, which are **T-variant**.
-  Permitted only via the `where:` escape hatch and flagged by `selector-debt` — a
-  stabilization target, not a default.
+  and any explicit source-order choice → **sibling-order atoms**, which are
+  **T-variant**. Permitted only via the `where:` escape hatch and flagged by
+  `selector-debt` — a stabilization target, not a default.
+
+Legacy `target_statement`, `target_statements`, and `wildcard_string_literals`
+are not current Tana/Gaffer requirements. Do not nativeize them by default:
+verify downstream absence, remove the authoring surface, and keep only a
+documented migration path if another consumer proves it needs them. For
+anonymous side effects, prefer one distinguished target per selector/query
+instead of an index into nearby context.
 
 So in the clean native form the surviving holes are exactly the existence qualifiers;
 regex becomes a first-class CQ construct, and order/position is
@@ -481,7 +500,7 @@ EDB; nothing is fundamentally inexpressible.
 | `STR_LITERAL_MATCHING_RE("re")`                                                              | filter atom `str_matches(node,"re")`                  | `str_lit(node,value)`                                  |
 | `identifiers: exact`                                                                         | name filter                                           | `name(node,spelling)`                                  |
 | `identifiers: alpha_all`                                                                     | identifier variable + scope                           | `resolves_to` (have it) + alpha-canonical ids          |
-| `target_binding` / `target_statement(s)`                                                     | choice of distinguished variable                      | —                                                      |
+| `target_binding`                                                                             | choice of distinguished variable                      | —                                                      |
 | `binding_groups` (adopt_names / exports)                                                     | mechanical per-target expansion (already done)        | —                                                      |
 | ordered / positional anchors                                                                 | child-index compare (`i < j`; adjacency `j == i + 1`) | `child` index column                                   |
 
@@ -500,12 +519,15 @@ Both are guarded twice: the lowering **errors** on any pattern whose faithful en
 implemented (no silent approximation), and the corpus differential flags any lowered query that
 disagrees with the matcher.
 
-**The two are not independent, and the dividing line is the _coupling_, not the hole count.** The
-run-hole routine does two things at once — (A)
-variable-length ordered-subsequence **placement** of the fixed segments around the holes, and (B)
-a **global bijective alpha-binding** constraint threaded through that placement (which is _why_ it
-backtracks — `place_segments` snapshots/restores `MatcherState{replacements, alpha_scopes}`). They
-encode very differently:
+**The two are coupled, and the native encoding must keep that coupling
+declarative.** The run-hole routine does two things at once — (A)
+variable-length ordered-subsequence **placement** of the fixed segments around
+the holes, and (B) a **global bijective alpha-binding** constraint threaded
+through that placement (which is _why_ it backtracks —
+`place_segments` snapshots/restores `MatcherState{replacements, alpha_scopes}`).
+In the endpoint, neither part is a procedural side table: placement choices and
+the identifier equalities/disequalities they induce are facts in the same
+solver model.
 
 - **(A) placement is cleanly Datalog-expressible — backtracking and all.** A list-with-holes is
   `[hole?, seg₁, hole, …, segₖ, hole?]`; "`segᵢ` matches starting at ordinal `p`" is the
@@ -518,26 +540,21 @@ encode very differently:
   `[STMT_LIST, const s = …, STMT_LIST]`, `infra/android.serializeNodeForNativeBridge` is
   `{OBJECT_PROPS, isTag: ANYTHING, OBJECT_PROPS}`. So the earlier "≤1 hole per list" intuition is
   **empirically false**; the chain-join handles interior links regardless.
-- **(B) the alpha bijection coupled with variable placement does _not_ map onto pure set-at-a-time
-  Datalog.** Per _fixed_ placement the bijection is clean (stratified negation: reject
-  `pair(n,s₁),pair(n,s₂),s₁≠s₂` or `pair(n₁,s),pair(n₂,s),n₁≠n₂`). But which pairs a placement
-  induces depends on _where_ segments land, so a global per-placement check must carry the
-  accumulated binding map along the chain — an unbounded value: either materialize combinatorially
-  many placement-tagged binding sets, or model a "binding-map lattice" whose merge can _fail_
-  (a failing merge is not a lattice join). Both leave the fragment Ascent evaluates efficiently.
-  This is the sharpened form of the alpha-scoping risk above.
+- **(B) alpha-all is the same query, not a matcher clone.** A placement induces
+  identifier-pair facts tagged with the placement id. Alpha bijection is then a
+  declarative rejection condition: reject any placement where one selector
+  identifier maps to two source identifiers, where two selector identifiers map
+  to the same source identifier, or where required `resolves_to` / scope facts
+  disagree. In Ascent terms this is ordinary
+  disequality/stratified-negation/all-different over placement-tagged rows. If
+  the row set gets too large, that is a profiling and encoding problem to solve
+  with better indexes or a different off-the-shelf solver, not a reason to
+  reintroduce a procedural `MatcherState` side resolver.
 
-**So we narrow on the coupling axis, not the hole-count axis.** In every corpus run-hole pattern
-the fixed landmarks between holes are structurally distinctive (`const s = ANYTHING && !0, …`, the
-prop name `isTag`, `return …`) and the alpha identifiers they carry are **fresh local
-declarations** or **anonymous `ANYTHING`** that never bind — no identifier's binding is decided by
-a variable-gap placement, so the bijection decomposes per-segment and stays the rung-2 conjunction.
-The principled encoding therefore lowers **placement** fully and keeps "an alpha-bound identifier
-whose binding would be decided by a variable-gap placement" **fail-closed** (loud `Unsupported`).
-The corpus-wide differential is what _proves_ the corpus never needs the forbidden coupling; if it
-ever flags a real selector that does, that is the go-back-to-the-drawing-board signal — pre-resolve
-the binding with scope facts independent of placement, or narrow the _selector_ language upstream so
-the pattern cannot be authored.
+So we narrow on the coupling axis, not the hole-count axis. The faithful
+encoding lowers **placement** and **alpha constraints** together. The only
+fail-closed cases should be forms whose required facts are not modeled yet, not
+forms that would be easier to handle by calling the old matcher.
 
 ## What the matcher cannot do that the query model can
 
@@ -624,40 +641,46 @@ So the vocabulary is proven expressible in the engine we picked — the gap to
 production is native consumption of the AST-facts EDB plus template→atoms
 lowering, not the solver's capability.
 
-## Closed by #2439
+## Closed so far
 
 - `source_match` selectors now enter the global selector IR/solver.
 - The materializer has a single Ascent-backed selector solve path for binding
   pins, staged relational selectors, and `source_match` claims.
+- Exact native `source_match` forms no longer call the legacy candidate oracle.
+- Exact single-statement shape and superclass constraints lower to native AST
+  facts.
 - Ascent remains the production solver choice; do not restart solver selection
   unless profiling proves the in-process path cannot meet the latency/memory
   target.
 
-## Remaining work (native AST EDB cutover)
+## Remaining work (single-model cutover)
 
 This is the detailed P0 queue; <../TODO.md> should only summarize it.
 
-- **G1 — native AST EDB ingestion.** Add Ascent relations and indexes for the
-  AST rows already emitted by `chunk_facts.rs` and imported by
-  `SelectorFactStore::extend_chunk_facts`: node kind, parent/child ordinal,
-  literals, identifier/property names, operators, regex, superclass, top-level
-  statement ordinal, and source-span/diagnostic payloads. Preserve the
-  fail-closed rule: unsupported constructs report `unsupported`, not a partial
-  fact set.
-- **G2 — `source_match` lowering parity.** Lower today's JS-with-holes selectors
-  and binding groups into native AST/owner IR atoms. Keep `ChunkResolver` as the
-  reference until the corpus differential is zero, including alpha matching,
-  run-hole placement, regex literal predicates, anonymous statements, exact
-  identifiers, target bindings, and binding groups. Mismatch-only native/oracle
-  parity rows are emitted as `source_match_native_diff_mismatch` entries in the
-  selector diagnostics report, so the cutover can shrink by selector shape
-  without changing production claims.
-- **G3 — candidate-oracle deletion.** Remove `SelectorAtom::SourceMatchCandidate`
-  / `SelectorFact::SourceMatchCandidate` from the production path after G2
-  parity. No-match, ambiguous, unsupported, and duplicate-claim diagnostics
-  should be projections of the native solver result, not `ChunkResolver`
-  side tables.
-- **G4 — relation/language fold-in.** Re-express `cross_ref`, `reads_member`,
+- **G1 — alpha-all as query constraints.** Lower `identifiers: alpha_all` to
+  identifier occurrence variables, `resolves_to`/scope facts, placement-tagged
+  equality and disequality rows, and `all_different`-style rejection rules. Do
+  not clone `MatcherState` or add a procedural alpha resolver.
+- **G2 — retained hole and predicate lowering.** Lower today's retained
+  JS-with-holes selectors and binding groups into native AST/owner IR atoms:
+  simple existential holes, regex string predicates, run-hole placement
+  (`STMT_LIST`, `ARGS`, `OBJECT_PROPS`, `DECLARATORS`, `CLASS_REST`,
+  `CASE_REST`), anonymous statements as distinguished targets, exact
+  identifiers, target bindings, and binding groups. Each construct either
+  compiles faithfully or reports `unsupported`.
+- **G3 — source-match surface pruning.** Remove unused authoring options before
+  nativeizing them. Current Gaffer/Tana census shows no use of
+  `target_statement`, `target_statements`, or `wildcard_string_literals`; verify
+  absence in a focused branch, delete the YAML/code/docs surface, and slate any
+  other vestigial debundle features that gaffer-private does not use for
+  removal rather than carrying them into the query model.
+- **G4 — candidate-oracle deletion.** Remove
+  `SelectorAtom::SourceMatchCandidate` / `SelectorFact::SourceMatchCandidate`
+  and the `ChunkResolver` pre-enumeration path after G1-G3 cover every retained
+  selector form. No-match, ambiguous, unsupported, and duplicate-claim
+  diagnostics should be projections of the native solver result, not
+  `ChunkResolver` side tables.
+- **G5 — relation/language fold-in.** Re-express `cross_ref`, `reads_member`,
   `member_of_module`, `passed_to_call`, `makes_decorate_call`,
   `intrinsic_alias`, and the Gaffer feature-request vocabulary as IR atoms or
   derived predicates over owner/reference + AST facts. The real-spec conversion
@@ -669,9 +692,11 @@ This is the detailed P0 queue; <../TODO.md> should only summarize it.
 - **Build/test gate**: build the changed debundler library and its consumers;
   run the changed area's tests with `--cache_test_results=no` and lint on for a
   final step.
-- **Resolver parity gate**: while both resolver paths exist, the global solve
-  and the current fact-based/staged resolver agree on every covered resolved
-  target, no-match, ambiguous match, duplicate claim, and unsupported construct.
+- **Resolver parity gate**: while fallback shapes still exist, the native solve
+  and the current fallback resolver agree on every covered resolved target,
+  no-match, ambiguous match, duplicate claim, and unsupported construct.
+  Compatibility checks live in focused tests/corpus gates; production should not
+  grow a permanent dual-resolver diagnostics stream.
 - **Real-spec conversion gate**: after converting a downstream selector from a
   name pin to a structural or relational selector, generated output stays
   byte-identical and the converted selector resolves to the same binding the
@@ -690,6 +715,14 @@ The 2026-06-22 `tana/re/web` stabilization dispatch on Gaffer
 `domains/ai` 17. Workers stopped where the current language required
 neighbor-borrowed context, long exact bodies, positional multi-declarator pins,
 or relation shapes visible in facts but awkward in the selector surface.
+
+The 2026-06-23 current-spec census found 5,583 `source_match` blocks across
+1,751 YAML files in the available `tana/re/web` spec, all using
+`identifiers: alpha_all`. The largest native-lowering blockers are hole forms:
+`ANYTHING`, `STMT_LIST`, `DECLARATORS`, `OBJECT_PROPS`, regex literal
+predicates, class-rest, and args/array-element runs. It found no uses of
+`target_statement`, `target_statements`, or `wildcard_string_literals`, so those
+are removal candidates, not P0 solver work.
 
 Use these as language/synthesis requirements for G5, not as independent
 resolver architecture:


### PR DESCRIPTION
## Summary
- update debundle TODO/priorities around one logical selector query / constraint model
- refresh selector constraint model plan after #2447 and make alpha-all a declarative query constraint, not a matcher clone
- mark unused source_match surfaces (`target_statement`, `target_statements`, `wildcard_string_literals`) as removal candidates and stop recommending `target_statement(s)` in selector docs

## Validation
- `git diff --check -- devinfra/js/debundle/TODO.md devinfra/js/debundle/plans/selector_constraint_model.md devinfra/js/debundle/docs/selectors.md`
- `nix develop --command pre-commit run --files devinfra/js/debundle/TODO.md devinfra/js/debundle/plans/selector_constraint_model.md devinfra/js/debundle/docs/selectors.md`