### PR TITLE
nix: add gecko vm profile

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -5,11 +5,13 @@ keys:
   - &rugged-host age1ek24fa0hv54p3d8f08zrlgx69c7vsausadmgnxahurvtshhleegs3ys6n0
   - &atlas-host age1a23u3lugygtks3hhku9l3hsjc44y0eu7pv4q3r7n8u2k62uq3c9qmwh4ur
   - &iguana-host age1zemurrcedw7sme3hh793cv8u5zu8eeekn637zpkulxwuw8uav58srwcxzv
+  - &gecko-host age180y753h0vzxm8a3y3rd7c3zykhrat8xlajczuxuk7dz0h82cdf2s0slmw5
   # User keys (derived from ~/.ssh/id_ed25519 via ssh-to-age)
   - &wyrm2-agentydragon age12c2ef6ayydzvmz6k49pyyhtgu2g00nyynmht8y3laqvxn3wya4wselpc4s
   - &rugged-agentydragon age1qdgn0k59t7ghg3t4gg02g2ppnzp7uz0ddplup38y84hqslcsgsxq3v9tkz
   - &atlas-agentydragon age15hfg4r2zfc2zl6zarecpvykxjktw4zu3grlahz4397rstmhqpvtqjgf6yy
   - &iguana-agentydragon age1l325yz3v2mev3t896mzvmmkaatjc7z4d9kukvnjuslgwwd8zg9ss9pnsc7
+  - &gecko-agentydragon age1wjv755gsh9l02wm3wet48kjl6ju5ckk3jgllfpe8xmfauqqardgq7pt7ud
   # Claude agent key (Claude Code web sessions, private key in claude-sandbox k8s secret)
   - &claude-web age15gxxqn49sp8qhdya6utanzsxgzpfup63yfuht9yza4adpule4auqzsddj2
   # Haku agent key (Haku background-agent routine; private key in
@@ -99,6 +101,7 @@ creation_rules:
           - *rugged-agentydragon
           - *atlas-agentydragon
           - *iguana-agentydragon
+          - *gecko-agentydragon
 
   # Flux ntfy webhook: only the topic URL (address) is a capability/secret. The
   # ntfy message-template headers are non-secret presentation config, so keep
@@ -228,6 +231,12 @@ creation_rules:
           - *admin
           - *iguana-host
           - *iguana-agentydragon
+  - path_regex: secrets/hosts/gecko-attic\.yaml$
+    key_groups:
+      - age:
+          - *admin
+          - *gecko-host
+          - *gecko-agentydragon
 
   # --- Per-host secrets (admin + host) ---
   - path_regex: secrets/hosts/wyrm2-.*\.yaml$
@@ -250,6 +259,11 @@ creation_rules:
       - age:
           - *admin
           - *iguana-host
+  - path_regex: secrets/hosts/gecko-.*\.yaml$
+    key_groups:
+      - age:
+          - *admin
+          - *gecko-host
 
   # --- SSH keys (SOPS binary, admin + owning host's user key) ---
   - path_regex: ssh_keys/wyrm2-.*\.sops\.key$
@@ -276,6 +290,12 @@ creation_rules:
       - age:
           - *admin
           - *atlas-agentydragon
+  - path_regex: ssh_keys/gecko-.*\.sops\.key$
+    store_type: binary
+    key_groups:
+      - age:
+          - *admin
+          - *gecko-agentydragon
 
   # --- Per-user home-manager secrets (admin + user SSH key) ---
   - path_regex: secrets/home/wyrm2/.*\.yaml$
@@ -293,6 +313,11 @@ creation_rules:
       - age:
           - *admin
           - *atlas-agentydragon
+  - path_regex: secrets/home/gecko/.*\.yaml$
+    key_groups:
+      - age:
+          - *admin
+          - *gecko-agentydragon
 
   # --- Plaid API credentials (admin + all user keys) ---
   - path_regex: secrets/plaid\.sops\.yaml$
@@ -394,6 +419,7 @@ creation_rules:
           - *rugged-agentydragon
           - *atlas-agentydragon
           - *iguana-agentydragon
+          - *gecko-agentydragon
   # Claude web K8s bearer JWT (auto-rotated by the authentik-jwt-rotation CronJob)
   - path_regex: secrets/claude-web-k8s-jwt\.yaml$
     key_groups:
@@ -456,6 +482,7 @@ creation_rules:
           - *rugged-agentydragon
           - *atlas-agentydragon
           - *iguana-agentydragon
+          - *gecko-agentydragon
           - *claude-web
           - *codex-cloud-agent
           - *haku

--- a/cluster/k8s/user-agentydragon/atuin-user-password.sops.yaml
+++ b/cluster/k8s/user-agentydragon/atuin-user-password.sops.yaml
@@ -16,56 +16,65 @@ sops:
         - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHb0htS0NiRnlHWVB3RnF5
-            NW9SSUxHRmJRSEEvTTFrV3hSQThGQVBaSlFrCnBIb1ROZmFCTFBGNFEyS1NmNlBy
-            VDhvSEtlcEgvaHpEMi9UUzkzQ3VzWFEKLS0tIGVHRW9GS01iSWo3UUlBblFlOTAv
-            N3Q5S08rZXRsRng5VGVHdkZHdnUxejgKy4RrX1u4/x7/LT5YGd+eKGvY4+jMzHyn
-            p9TYPXJAlqpYoKsVtBuaJT6wvSqUYYOifiH8Wxf5gBSIT25nwROY4Q==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPdzN4VFhnNUkwUzlqQkx1
+            NFk5SXRZaGhZaHFuMVR3Y2V6SS82Z0wrWUFFCnpBWHh0WTd2Y3YrME8xejBtS2hw
+            SGk5YW8xNGI4ZHlCVmlwN1g2cWpYWTQKLS0tIEFvbi8yeGlBcHpXR2FiaWZkdk9N
+            MHZWbFlKY0NTMWpIdzFtRHp2b0l5UTgKXfvunfUc/IU3Xpquz3//pgawYDyhRRW4
+            r+BgzjiCN2pS1EIgNsaQhLMPmhSLMvJMPXviVyCxfCuLhOUT+at96A==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1nywlwepsyfxvyhqwkjquzz02nmus65gf6qewfjju4alym8f7se5qnua8na
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhTzBMOGcyVUdTcWRaajNt
-            ZGk4NFRqaE5jL1U5QlJRc3lNRWJyRG9JYTNNCk5McGsvTy9ISW5Cbm5LYU5ybkRr
-            RFNSZmYvc2pKakNZVnU5dW52eDNzZHcKLS0tIGd3aThmNnQwMmkwSzNVcC81WUVZ
-            Z2Y0TUJZNG9iUlBBYkRDMkt5U2M5TDAKBltFml2CMvZHK0kxglTCeP7Iq48pD7XH
-            GYfWESZlv+MQ1O/Rfv3HqbTyuvm5y5FKRZAlxQ0utfg4N0n6akIUsQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWY0NLMWJ6Y0kzbndQZXIx
+            SXNsaGNaeERVcjE3OFN3MENMKzVkLzBoQkFjClZyV3llbzA0MmE0UEpqelVvUzBU
+            TjA3azB5OForY3ZnYVpiVzYwU0I0U1EKLS0tIE1rTkFHWUtTZ09IMitON283Nzl0
+            dG1hVU5RY1Y5WTJrSCszWlNDZGQvOUkK5vneU/mjymQ4qkFVF7dhXI+3n0sVEpKP
+            faLrBCKo829raAdiH9rFHTevvzfojAX0Yf6PTQSOFtrINTM+D+dMaA==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age12c2ef6ayydzvmz6k49pyyhtgu2g00nyynmht8y3laqvxn3wya4wselpc4s
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpNDVkdnJWOUZYUGtSMVVV
-            Q2REL1VldFdhY0ZLdERna2RqYXk5VzlkSVVZCkVyZS92MjJpMkZDdm80M2w3TEtB
-            MzJyZnRYeG1uOVpiV25zQlpXWFVFdncKLS0tIEVQek5LdEh4d0l5aHlOQW5FZExZ
-            WmNkU2ppTWRNNVBqV3ZMUUp5bG5XZkUKlk4ITrlerwtJyn/E0U3EOsNk871JT5T5
-            HBIGY9FLNhi5S/UlFq3X674tPQy/wkVgUtUysPzokRdNrROvXSG5jw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6ejgyaks4MzE3YmhTZFZx
+            VHhYcTdycDd5WjdaS1R4Q1AydngvRG10ZlJFCit3QVZkSjkwdW0yQWQyak0yMVQ4
+            bVQ2eTk4MEFXeTlnc0Z2djZMeE96WVEKLS0tIEhQeTdJZTB1M1FGWXpWZ0V0ZVAr
+            S2NhT2RXR0NzZzFLaVlwbFF5OWMwSDgK8Tgkqwl3YCK6/FMLeusNiZGOMxHEop6d
+            u8r0S8M4nNmvx/fM5yY0THe/R8t4JJxRZZDN7ZjyEWM0ZiDXE/l26Q==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1qdgn0k59t7ghg3t4gg02g2ppnzp7uz0ddplup38y84hqslcsgsxq3v9tkz
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1RHJScklrVUVFYlgwSW1P
-            RXZYV01mNDhSN2crSnNXTmF6WVo3RHZtNjNVCjM3b2lERnlXcVR2NjMwWmlydHVl
-            OTN2aHc1NEpZYVNLUjNXNCszSk9heWsKLS0tIGlVd0VOZ2I5dUlyaU5XT0dmRDhC
-            UjhwbVVlRmRBcmsyR2xYV1VZbFQ2bHMKdIB6qipWBOg0KAdCQXlNrvr0/Q8XTM+n
-            q8T1BMqAFrP9mFMb1r1+6aI7S3xBUfh7jgGM8kKjVcqLE285r0KnwA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2OTdFZnFFd1U2eEY2aWla
+            T3hqb1grS0ZlSkdvY3dFcTBMeWhRNzBORlVnCkZGZXNvbWNoNDhwdXd6eW45N0ly
+            WmNhOEZUVUk4TEtnVmNnYUpMcG9MbE0KLS0tICt4OHB5RklxT01SR3Nxc2UvZkpr
+            QUErWlZiZ09FYWxnUHViRk1MSmpmV3cKs4fpuvQ3xBdiny6WRu6dsI/PxGZERADb
+            RVvCLsu+lGyAJRAFgcg0DvPHZH/EFy+8GO06qRGdO/AeVt34bxiHFg==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age15hfg4r2zfc2zl6zarecpvykxjktw4zu3grlahz4397rstmhqpvtqjgf6yy
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrR2NCVm1ueVBpYSttbkJ2
-            SGwxdnBBMC8zNUJYU2Y0bWhqS3RrUHk2ZDI0CmFSU1VFaGVmODhwNEtOYjlTS25m
-            cmIxUWhKcTVEZ1hxaU80RmNtUlQ0TlUKLS0tIDRVT0h2NHMyVlZueC9sYXlLd0gy
-            VnVrN1F2NVdjK1NIMlVUU0Z1NzBmam8K4Pxri7FG7vGDt/wkGcSFX3Bz7cQzC0Hs
-            gnQbK18QnnvYM31zp7QB+cRyHKValIoFSKaI5ct6YlNMXxPGhuMIzQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnUnZSN1BIQnRtUjVpajhp
+            UnJHN1lCdzVWSHJyY3FFR0xka1ZMYmlldUZzCng5NTdNdWVnY1FHdDBNZThkT1Zv
+            NGFTcENFNUtEVmdiT2xZaUZGTGdrMjgKLS0tIGhrQVZlRlVmTXJmYnN2T1IxY3Aw
+            Um5Tb0ZMS3pBN3hVMElPZjJlVWhZZlUKzElZyKYijMRmjMIA4UZGDgHbbA1sXqs4
+            bSPgK4WqedzO5CpQ6GoIA27m0mU7uMoLawS93JXuwfwkybjI0z9u7w==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1l325yz3v2mev3t896mzvmmkaatjc7z4d9kukvnjuslgwwd8zg9ss9pnsc7
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBieGR1dGNqVFdYYXRyNUY4
-            NEFEcjNDN2oyYzM3QkV5UW5ucTFHaGh0a2lBCllYaGJWMWNTMHNvYyt5dkFITmdz
-            WUpHUVZuZnpMOHhwaG0xeitXV0VwaW8KLS0tIGNqeUNSN2hpdE8zaHJ0REVzSU5L
-            Si8rb0NwZU9LVm9HMkVVYktpYXZJcFkKtwazvKDHmUrjZALYbZorYZF4ggh2xvJW
-            hjm+31gSwRBYy3Dq4ksAkC2eeqLG96NgRnjPY44amzFZUnEbb8IM5Q==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZZVhDL0xOb2h3alVaYlJi
+            WldrcVhaSGFIUjBXVjBtckRMQVZrekpYRFVvCisyNWxFYmw5dE1VT3VwSktFZlRM
+            amNRQU4zS0NlWVNkZmI1SUtsa1pSZkEKLS0tIGVzY0JjWi90Z3pGUXR4emhjNUJj
+            cXMwN250Uzc0OE9INGRDNWRhU05FWlkKE/yrW41amlouMHZRt/9ADmCpypI/f7+L
+            ZeVwmgcup2cstux2zTmYU68+QR6Ie4zQgw2GXb3Neze5MHtN/++z3A==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1wjv755gsh9l02wm3wet48kjl6ju5ckk3jgllfpe8xmfauqqardgq7pt7ud
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvSCtMaEJmVkxHYW5XKy9y
+            aWgzeUZNUERPa3ZKamp4V24ydk5EaHl0M25rCmdXUnBRMEptNmRjc09wRSsza2VM
+            U0Y3SzhmNjhXMVZtRzFBQWVidVNZZGcKLS0tIE5GUTFldmF2RUtmajM2NnBxRklk
+            QUdNV3BhWVVGV0s0cklsM2xQbFRSR00KgHlnlmP/43WpVgpf0YsDH/yGzh/4dRT6
+            wQ+BWfOXANh4kzstE6upwbT1YqdRE2StwpGE1i28z9qmlaFVidS9SQ==
             -----END AGE ENCRYPTED FILE-----
     lastmodified: "2026-04-19T04:59:07Z"
     mac: ENC[AES256_GCM,data:PdVx6pvRL8zCffUc25LHXy2N65UBHShk8PBteQmqmAq5yTTcMtkW7ZajvDMxPInNqL0+TdOSc3Ca5H/bd+AdoTP4kBR+NJ108+pjgVXXeMipwKHLCYyz09dgBQy+oOvhY/89K3c3aCd8w5Rl5NER3Sd9SpaCoEQPrA+dg5mMZ3A=,iv:ehd8z3lxef/LviiT4aaVnzIrEOBlhLx6FnAUcBB5m94=,tag:+HpW800KztMAPla2psjTZA==,type:str]

--- a/flake.nix
+++ b/flake.nix
@@ -519,7 +519,7 @@
           };
         };
 
-        # Gecko - headless CLI-only VM (Proxmox) for Claude Code / Codex
+        # Gecko - headless CLI-only KubeVirt VM for Claude Code / Codex
         gecko = mkNixos {
           hostname = "gecko";
           username = "agentydragon";

--- a/nix/home/hosts/gecko.nix
+++ b/nix/home/hosts/gecko.nix
@@ -1,131 +1,29 @@
-# Gecko - headless CLI-only NixOS VM (Proxmox)
+# Gecko - headless KubeVirt VM for Claude Code / Codex.
 #
-# Runs Claude Code and OpenAI Codex. No GUI, no SOPS (yet).
-#
-# To apply: sudo nixos-rebuild switch --flake ~/code/ducktape#gecko
+# Bootstrap flow:
+# 1. Boot the generic bootstrap qcow2 from cluster/k8s/gecko.
+# 2. Ensure /home/agentydragon/.ssh/id_ed25519 exists.
+# 3. Switch to this profile:
+#    sudo nixos-rebuild switch --flake ~/code/ducktape#gecko
 {
   pkgs,
-  pkgsUnstable,
-  lib,
   ...
 }:
 {
   imports = [
-    ../modules/neovim.nix
-    ../modules/shell.nix
-    ../modules/tmux.nix
-    ../modules/solarized.nix
+    ../home.nix
+    ../modules/forgejo-ssh.nix
+    ../modules/github-ssh.nix
+    ../modules/kubeconfig.nix
+    ../modules/talosconfig.nix
   ];
 
-  home.username = "agentydragon";
-  home.homeDirectory = "/home/agentydragon";
+  ducktape.forgejoSsh.sopsFile = ../../../ssh_keys/gecko-forgejo.sops.key;
+  ducktape.githubSsh.sopsFile = ../../../ssh_keys/gecko-github.sops.key;
+
+  home.packages = [
+    pkgs.psmisc
+  ];
+
   home.stateVersion = "25.11";
-
-  programs.home-manager.enable = true;
-
-  nix.gc = {
-    automatic = true;
-    dates = "weekly";
-    options = "--delete-older-than 14d";
-  };
-
-  nix.settings = {
-    experimental-features = [
-      "nix-command"
-      "flakes"
-    ];
-  };
-
-  programs.git = {
-    enable = true;
-    lfs.enable = true;
-
-    ignores = [
-      ".aider*"
-      "__pycache__"
-      "*.sw[op]"
-      "**/.claude/settings.local.json"
-      "**/CLAUDE.local.md"
-      "oneoff__*"
-    ];
-
-    settings = {
-      user = {
-        name = "Rai";
-        email = "agentydragon@gmail.com";
-      };
-      core.autocrlf = false;
-      color.ui = "auto";
-      push.default = "upstream";
-      log = {
-        abbrevCommit = true;
-        decorate = "short";
-        date = "local";
-      };
-      format.pretty = "short";
-      advice = {
-        pushNonFastForward = false;
-        statusHints = false;
-        commitBeforeMerge = false;
-      };
-      clean.requireForce = true;
-      branch.autosetuprebase = "always";
-      rebase.autostash = true;
-      rebase.forkPoint = false;
-      rerere.enabled = true;
-      init.defaultBranch = "main";
-      merge.tool = "vimdiff";
-      credential.helper = "cache";
-      "url \"git@github.com:\"" = {
-        insteadOf = [
-          "https://github.com"
-          "https://github.com/"
-        ];
-      };
-    };
-  };
-
-  programs.gpg = {
-    enable = true;
-    settings = {
-      use-agent = true;
-      default-preference-list = "SHA512 SHA384 SHA256 AES256 AES192 AES ZLIB BZIP2 ZIP Uncompressed";
-      personal-cipher-preferences = "AES256 AES192 AES";
-      personal-digest-preferences = "SHA512 SHA384 SHA256";
-      fixed-list-mode = true;
-      keyid-format = "0xlong";
-      with-fingerprint = true;
-    };
-  };
-
-  services.gpg-agent = {
-    enable = true;
-    defaultCacheTtl = 28800;
-    maxCacheTtl = 86400;
-    pinentry.package = pkgs.pinentry-curses;
-  };
-
-  services.ssh-agent.enable = true;
-
-  # TODO: Provision API keys via SOPS (ANTHROPIC_API_KEY, OPENAI_API_KEY, etc.)
-  # Create secrets/home/gecko/ and add ducktape.sopsEnv entries.
-
-  home.packages = with pkgs; [
-    pkgsUnstable.claude-code
-    pkgsUnstable.codex
-
-    jq
-    yq
-    fd
-    ripgrep
-    fzf
-    htop
-    tree
-    pv
-    curl
-    wget
-    gh
-    direnv
-    git
-  ];
 }

--- a/nix/nixos/hosts/gecko/default.nix
+++ b/nix/nixos/hosts/gecko/default.nix
@@ -1,4 +1,4 @@
-# Gecko - headless CLI-only NixOS VM (Proxmox)
+# Gecko - headless CLI-only NixOS VM (KubeVirt)
 {
   pkgs,
   lib,
@@ -11,32 +11,46 @@ let
     wyrm2
     atlas
     rugged
+    gecko
   ];
 in
 {
   imports = [
     ../../modules/vm-hardware.nix
+    ../../modules/bazel
+    ../../modules/system-inspection-sudo.nix
   ];
+
+  # Passwordless sudo for read-only system inspection commands used by agents.
+  ducktape.systemInspectionSudo.enable = true;
 
   environment.systemPackages = with pkgs; [
     neovim
     tmux
     htop
+    btop
     ripgrep
+    fd
+    fzf
+    jq
+    yq
     tree
     pv
     strace
     lsof
+    sops
+    ssh-to-age
     home-manager
   ];
 
   users.users.${username} = {
     shell = pkgs.zsh;
     openssh.authorizedKeys.keys = sshKeys;
+    extraGroups = [ "systemd-journal" ];
   };
 
   users.users.root.openssh.authorizedKeys.keys = sshKeys;
   services.openssh.settings.PermitRootLogin = lib.mkForce "prohibit-password";
 
-  users.motd = "Gecko - headless CLI VM\n";
+  users.motd = "Gecko - headless KubeVirt agent VM\n";
 }

--- a/nix/ssh-keys.nix
+++ b/nix/ssh-keys.nix
@@ -10,4 +10,5 @@ in
   rugged = readKey "rugged-default.pub";
   rugged_wyrm = readKey "rugged-wyrm.pub";
   atlas = readKey "atlas-default.pub";
+  gecko = readKey "gecko-default.pub";
 }

--- a/secrets/buildbuddy.yaml
+++ b/secrets/buildbuddy.yaml
@@ -4,83 +4,92 @@ sops:
     - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2b2Q0WTlURFdydGtVMVQv
-        dWVWSEpmbk9SWG5McGtNcGRRTm84TXkvL0Y4CldVcGNzUFJpaDJJbmx6MGZnZWYv
-        L3NLYkFLMXFHYU9vRnI0L0xsT2FVSHcKLS0tIFRuQjVONUZrd1h6REpRQzlBVXFN
-        aVl0S2JFUEJoZTI1ZjIyRC9tbENuSWMK2usdSwpuZAPZ1AqC2CS4rgQxaxLpUXj8
-        V9fxT76pOOPA4pjP2nBvzG/e9CuCgnc3JHCy9jcLQrVk3MHhjEJmfQ==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqZ2hCMTB4Z2IrUTN1LzJ5
+        Ty8yS1ZxRGQ5ZGVzTkhJNjVzN0tNRWJVcnhRClM2dW9ia0dIOVFUU1hISDNVa3ds
+        blQ1UStJR01Obnc3Zk1RR0RlTDNZc0EKLS0tIHBBREljWGtaMnpmUWRwb28yS1I2
+        K05GWmVMNDNCdG1Ob25ySU9zTXBBNmsKEnH8z3IHmvP96WM/QxFR+QLYLVR6M8Tj
+        /KO0S4AIToxD92MsfxlO0pAc6EOyNA8R+riSoXM0gP0sm07hAoDBwQ==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age12c2ef6ayydzvmz6k49pyyhtgu2g00nyynmht8y3laqvxn3wya4wselpc4s
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSZWpxNm9ITXcyaVdsZi9n
-        YUxDc2VTVitCSGkyTmdSSEQ3akZQU3lyMFNFClUzTlUvRVlUNUN2Ym9wb0VQRDRU
-        MVY2UVZLYWhNaFh5RmVXT0lJV0w5MDgKLS0tIEJVWFQrTVZCWTdiUHpIU1U3a0hp
-        elJ1UHhwM2t5a3IrSlFrak0wZDZYQ28KtVm1Kzk2KBNLf8xnPmq7VBhRhx+1M3lE
-        ZjX2p11+rSW9KDY+iJF89roYLSr8Ow7KMyGvCkhD4vwhvZong3OpMQ==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBSjJZTGZoUlpqN3oyL0RR
+        MnUyNC9VWHphZFNvQjlzOFRPa3hMQy9Xa1ZnCjBKZk1yM3BxNTBVSkNQVmpKa0hJ
+        c0liakVjTTNJYjV2MlN6UjJma2lyRTAKLS0tIFJLNnFmOWxDdjQ3UUlYOHcxY1Fh
+        VGZMazhUSkxjMU45TlZpS1NkeW9RUlUKyVUo8PgWwtdZOV+yJ3eg4DD2nX4aTjiZ
+        kv1oOPuEjLIgmLNPiOCmsjZU9uFhmqAJf0YY4x8ifoOuYJqjZKqCYA==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age1qdgn0k59t7ghg3t4gg02g2ppnzp7uz0ddplup38y84hqslcsgsxq3v9tkz
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHYUlxTExSVVhrNlF3VUw4
-        Mzl0eUUxQUlQTWZ1dHBWK2h4ajkveWQwOXdnCk9GWnhuVE4rU3pBaXBsSnlqazRJ
-        V3hiTjRwVXhwdHBWWW5DUGplMDhzOW8KLS0tIFM2VGJZZFNLc2lkN3p3SVIvRGFt
-        MmxCV1lmcmdUNjNNM1pSL0R0WVlxWEEKGZhAmEIIiv1qK6DI/edzKcPboOiYNrvC
-        DHAzSfs8aQjpZ2ctZvyIM0s+sIR/7XHmGXCgHvMNvZlxMePiJRlUWQ==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwUk80b09McjVMUnpqNnV2
+        SDFSS2poVlFYNHFLTk1rVnRLS0lDMEFLSEM4CjVRVVozQlNiVmlIL1lsL1R6bUcr
+        RmFqTVo4T2dNdTJObDYvS1JjcldwRVkKLS0tIE9mandhRGtpSzFCRjYvd2Q0SmtX
+        TjB6NUhlSWJ3QjdyWXIrSnBGc3BmWnMKfVUOQpfjK3L2EETA+4Aqu0dX74rVtN1o
+        M1C7f/0r3w8M9Lh4U32s2210vukWrRhVaYPpTTeh942SCGfv6+bcGw==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age15hfg4r2zfc2zl6zarecpvykxjktw4zu3grlahz4397rstmhqpvtqjgf6yy
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAybzRlSmZmWmJhTE9oclJW
-        SGJlTVFYeGo4Y3RwOGVCMUQ0TnNHOWd3K0E4ClpuZjhsSzFya1FRbU1nSDBXZ3g2
-        bWNjbjJtdlhsamxaMzJxakRDUUNUZ2cKLS0tIFBndUVOdC93MWFHNm5rOGhmOGZV
-        V2dZRmtwejIwWFQ0S2VwS2RYSUd5MlUKO/Sh9ITvKlzeSvMLVmeW18Xv4rDwJ9NP
-        0CWiGBgSiRmZr56fN/SJr09hTkPd68TctjSTjm1Qm+EeV1dAtnuPcQ==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxYWRlUjdzaEI0NFM1MnBS
+        Yy8vdEdQanUreVd5NUdDUFd1UkI0akdoWUNFClFBWTVhWVh5VDl5Q1Z6bzRiQ1Fq
+        cGFDaHN1RVpMU3lLckhOOUQwdDVGMzAKLS0tIDNRTE5MZlJOV2djelc5QTM4N3Np
+        MG9YVW9GZ3B1dXF3US85QkZCYzcyNncK58tP5BBSA5mkVgr1kRWRhhNBJDww1PBj
+        hGOz3ExwpTzuReCFWHSSIz9Nh9Vyqp5Ih3xor6Nc379wRO/DSA4hkA==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age1l325yz3v2mev3t896mzvmmkaatjc7z4d9kukvnjuslgwwd8zg9ss9pnsc7
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDYk1NK1ArYytnd3gzRmhS
-        WXdXL2s5dHpuS29mOGVvVnBkL2ZyZnJBWTBvCmNYdXBWMXdGdzVrVTBOZWRDYXE0
-        NFpnSll0Mms2SThnK3piOXpuMjNtcTAKLS0tIC9iK2lUaXlwS3V5Qk41WkhxSXB0
-        eWhoMmR2cUxEa1Q1TjhGVUNrUnZBaHMKNy8ps9lCgEMFrht7XBnPC79CHfgtAX5k
-        rNpqfNK3iGl5MfcueFKTkzbET7Oos2CUxJtkMKKi/R3PkuTO2jVAMg==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA5QWJLYVA1T2NReTdpRkQ3
+        c0lQeDEwaCs5TmxZbDFRbVYxcXcreDhNL0I0CkgyT1FtSWJTOUh6b3BVMDU3ZlRq
+        SkgzRmU4N3RrQUVPNG5ueCthZDdyL1EKLS0tIFg4QzZpRWROZU1hZFA1WDdtVjJn
+        Vk9SSUFZTUEybnFSQmtNRFJoTkhCZ2cKisolRkZhcxyoMKx6PPoxDbgbhsLNPrNx
+        L12+QtGrSt1K2vNhXLbYlYvTy/c5lSs93cQgjKrosxk3zGfioMy9gQ==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1wjv755gsh9l02wm3wet48kjl6ju5ckk3jgllfpe8xmfauqqardgq7pt7ud
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmalNaTlRXZUVWMnJIUUJT
+        Q3N4aHp5eXhKL3RUMDZtTW94eFhiRlQwOWxNCnlHeFd4UmNDQU5PWVRiSloyRDRJ
+        S25KY2M4aHZ3dzVXZWdZMDVyRFdPUEkKLS0tIDdLQVFTZFkzSmhWQ2VGQTJzM01D
+        TVMyKzZHek1CUHprWVhPS1hvWjlyY1kKvzhTo6mb61Yt8UG+etpm0fF47CrijIpr
+        aCz2RZk+YdFQqAWv2KXH2RNtyecciqVFjQR6lnicxRpgSeOOYdxfMg==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age15gxxqn49sp8qhdya6utanzsxgzpfup63yfuht9yza4adpule4auqzsddj2
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjTHJXSzAyS2lsekVpbE1Z
-        SWh3L3R0Nk85SGY1cUp4dFJBcHZ2WUlwK3hVCldpNGlJc0hWR1g5UG5PU2lDb2du
-        S2Jnb2FvUi9SRTg1Yk1IODFnT2wzbmsKLS0tIEhPck5oM3FhMDI0a1dLc2pvZmMv
-        R29IaVhrYlB0OHdkbjhZc2tNdE9kUXcKSa6GCfZGr7bqM8yP3EwpyxbI0ip8rOpy
-        NIRSeELgSTxpk2sFJcTSzwXTeKRb+eH7ib3WNKNJ1KR5j4xA8+Gmtw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBERnU3dVNwZVRycHBHVXA0
+        VlQwN3pHYnovYXJJWHdVckxTT3hBT254OFM4CkIwdzFPblVUT3NOZ1BlL2hmeTdw
+        a0x1VHo1TWtBTGZNZTBoNUVpbnJrWW8KLS0tIEY5TDZPd3BnYndNaFVoaWQ3c3lz
+        UmdaZ1ltczVoM3Q4WHdSbnV5SDhBZFUKLqM1/yXKQ0WVjHkddxfP5CsQPzBww+rh
+        S/JbKBp0AgZli0mU04JTrf75Srpmyyg44GJKlgWfgpc6r18uS0MZyg==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age1hy7al8s2cxjhehgf93mnkfdv2plr579t9uhvtdaxlmh3rx0j2g7sludsex
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZdlh3Z3k0Nzg4N1UycVQx
-        eUpaNU52dE02eWdlcHZoMVR5bVc3UGluMUJJCjdaVWJoaGQ2dzVJWjRqdUlvbS9V
-        S0N0RzNBeHRmWWNlazhkcXpla0FXMEkKLS0tIE5HY2NqSG9ZdXZSRE5VWVBIaE8w
-        STlUUlpwQzg2aEVpQ0dOU2oyNTlJbE0KOd9KP1wuRCsY6+yzWNVkqIFg7FW1KsFX
-        VvsbJoijOO4fcBO7NYBGxG3a9Zrfg1An7qxZo7qieov0ZMEgkSIU4A==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2a2dmaVZNSE5ObEFhb3pX
+        ZTRkQTlRR29jaXpkOXBFNFU4d21paXFXQUVvClArZmExYkZSdWwyUGFvMmMyTUF5
+        UHFXWG05SXIxOVd0cnhLVUFzMU1NaFEKLS0tIEQ1cC83d1ppVnhZVVJaaDVzeGNv
+        bjEzajJRbk1NMlRsRnRUTTFtNmdURlEK74Tb5ohuh5tvnelRNIV9PLTGbL90h4GN
+        Ofg65HFRdmFXkQx/sXSMGz6ji9lQm4Vz4zlRGTRfUdZ1gWXaoWrgvg==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age1756xpy6yg7r8vdducm5cdn4cqt3m5qkcncxumsh8htlfdzpae4cq0c6gqf
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQbUNFS0xxYTMvYmp1Z1lF
-        N1ZxUUhCTGRIRmdKNWp2aEJsbVhnOFNESFcwClYrRmVBd2E4V0t4WXpnQkxlTnhK
-        TTFTS3VVcitzWXhtcXNSK2NvVU1lalEKLS0tIEhCaU45VDkwNHdhWEw2eUlzVVlu
-        VGZLU3JlTGFRTlNzdTRJd0p1a0ZMLzQK5GVMPGvHUUfID06MqqKCCZ4J+jU+Kiun
-        JAsmLu0T9V/pRciesEZ+k4B3D4oaNwq/qyLaCb4NT7JT67YxXueIMA==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1dGNyTzYrMGYzZXM4b2dN
+        eExDbjZuT3BSdmdCQlRMeXduSnpIWlRES1FBCkNMQ3dxeXFtZHdRWGVFL2c2U2or
+        UVA5WUw5SHMwOGNFcjMwMGhZTlg0QzgKLS0tIGlJcittTkVrNWNsUUkyWkNqYzd3
+        cExtV2hOb2pvVHNaRzl4T2dNU0x6TE0K5iQ405mi6seoBrqlEI5FK0v6YrcRMOyg
+        u2Q9Zqd5gxZHhzgS5RZ2+fRrWJWuMQFDlzlo7h5lIWUQh6w24lCefg==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age1zl5lv4g0lzd4pcwx9q4vvq0w4rpmkde5r68k4n2zu89urmnx9svs3c2mef
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNQ1JhU0doR3RIc2t5SjJz
-        ZGk4cWlPYnowcHpHSTJIckw4TXlOd0xKdlhJCkFQYkVOWnJpb3FySE9EazdUTmk2
-        aVFUV0tpTzE5SzhQV25kQ090MjF5OHcKLS0tIC9yRVRkUXlGUWpiR2xuWGhHc0dz
-        SzZSNjJNT3Y3c0l3M29HMnkxZzlIWlEK2DFR3hDChiyshd70pSJrWTVpMWXoRxAt
-        HnDX4G0gzoiP/yS6q5HU4mxTIqCXX+f8TBkcp5kx1ub0OI4KvtTxUw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBiaVRiSHJNK3VncjNwYnUv
+        YVFEYlNCZjJXeVkzK0hobmFMS0dsRXNSTmxVCjcvVGkyRmlxWWNBNGZsSDBVdzFP
+        VmIvbUlEaS9zeHp1WkZlZXk0d093bDAKLS0tIGhwdVg4SXh3Y3diQmNjVGpRSm56
+        ZlRqVEIxQ1lQeDBkQWNab2R3cjJSamcKcPYED+pBq8hc/tibcvTVlnSghAp14PGD
+        5jePjZ/xLgi+gcFzASkIyZxp0XOwYRlL5Hhv2NnbAeKHtuh+pKUobQ==
         -----END AGE ENCRYPTED FILE-----
   lastmodified: "2026-03-11T07:57:59Z"
   mac: ENC[AES256_GCM,data:EFPQ1auS7eiu0sXnSCOYwrQ1oVeNj+rMEEvGbZKATdn10XY/bZjAGI6qd4R/BZgariE1DABL6K2gWSM9dSlzx2w5ARN8leSnfQ6tfY8wld8MoJetoEwIY46U6hqB7CgMVH3d2bEpm3uX80VJys1siFLqdTBQbTrmAeXI2IvKKBg=,iv:sPFDzFDgKNgM0lGFf4Xay2T1cQFjyObIaVKHzJ7B9G8=,tag:6qIUhHLMB7ink/HGNF4DYQ==,type:str]

--- a/secrets/shared/atuin-key.yaml
+++ b/secrets/shared/atuin-key.yaml
@@ -9,56 +9,65 @@ sops:
     - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBKTXpSa2x1Q09OV1RlZ0pz
-        Z0VXU0ZtR25ib3NwWEJ6OEtNc1pRTXhyL0h3CkxVTmFiVFBabVBNRFZudlBjeUJm
-        T1Nyelp1M2pGekVqNGh0OEFaajdrVWcKLS0tIGZuVXQyRDd0Vm1EcUdKbWdXZmhK
-        bUZQL0pzeDZacEtQYWhudVdLOU96S3cKJ/6WOU3MuGTgsZZQX7lQQq6VaKvWRhrq
-        K5DaEr2fHE5ylhnQM40tNXstvolRnNeZbuIifLC4ufea/6F/VxwDBg==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSbXdUNWdTTXFIK0JISVpa
+        cHNoUVRkVUJ1eDdOTTlTcm9YVnZES08vOTBJCmR2YWZCQVFIYXFyYTFtaythcnFN
+        ZVBtTnRjdkhhOStaeENtRTVwUTBNekEKLS0tIGpGWDExbGhlL091UnV2Q1QwTGVp
+        L3FVZWxSTkxITXlpSnNtL0cxTUFtVWsKWGvpCWrxWOkHCzXPiVcjAAoKJkFmwOn0
+        E0WXApFm54J/jYVY6IPMPJouMDdVGWSOF0Nh/ZdKWNLEa1w//iSM0A==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age1tzq86mfj30su8hvw9e0y5zw9mg254frtk5s2mp48580uky8fdppsju42pp
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSByU2paMmY5cGpEbzM2ZUlt
-        aUNKQ1JmRkFEL2tGZVlueHdBK0hvQnRjNVFRCnVvZy9xYVlKUHJOa3hTVW1kdWIy
-        cUIrVk8ydGgrNHVWS3NoaGFrSUtYR2MKLS0tIC9BQWtDWG9xeEgzT3MvanZMcGR0
-        QUo5UC83cnppQ0gwMlVTRXptcHNOdTgKN6ZJdaJBeKBiZUwzwA14lnVfISyaDpHo
-        tAEhQhlcIT0BXBs+tHCf3pOiEvsph6+LllW2wvkJWgLtrkkwK9nGYQ==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVMHpIRE1yU2x4eGU2OGlG
+        Ukw5eElYRDJna20zTEV1d0lCUEpjR2NhdVVNCkltQjR6T3JjaUdmS2pMT21lRTlq
+        VUlDc1MrRUJqWHpxdHpYMHV4RFdveVkKLS0tIHg2ZU9MZE5KOUVzV2RuRU5hQUJO
+        a2REajBDRURJQnk4OXJHVDFUZld4YW8Kp39c3SPkmoQ2HuQXD7QdubrHm7jNPg9Z
+        9RGqWhhuipcFsrFscVmVuTRXeOERYqpD31fspDcxecRwwtMn1snDRQ==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age12c2ef6ayydzvmz6k49pyyhtgu2g00nyynmht8y3laqvxn3wya4wselpc4s
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB5Znp3Mm92UThHVW94dkdv
-        Smk1SjNFaVdOUVFBclNaS2M1OTd5MStFdkdBCjcrU1M5ajU1UHlUa29jajFRNGxq
-        Q2RhV1JmN1ZrM3NOWlhTbXBlUk9NYVUKLS0tIHYveXY0d1AyNzdEeUgxY2x0M0hl
-        OUJSTGx6N0hvSmZnSWMvUlpQR2VZUTgKp/9ctH4a9sUNpblt1ktQAjOy9IgBaikc
-        ShnWDAZDLvmDFA65VERjgMSLzDgkSv6tTk6IRvXqKKiAchj2HD5Vpw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQQW9HVDFERHkwd2RWQTZH
+        ZERZN0xTZTQ5Sjh1bXpOckY0TXo0Nk1aMGkwCk92U2RQazBwbzA0S0hWYlJRV3lY
+        cjhCWlkyODFLNVBqNm9KeTRVK29HMWcKLS0tIG1aQnovQzlIZERNcWpmVGcwNStF
+        REc4MGt6dVFUaU40L1IyQ2dPSDgvTDQKM+O4Y+rIfkHb5gIWKm0XHSRH7FCIh1n8
+        fBy/o1fT8SeA/Ai1nFipVuubfZNqr28OaNsYfUcg/VUwi/OWU5JYNQ==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age1qdgn0k59t7ghg3t4gg02g2ppnzp7uz0ddplup38y84hqslcsgsxq3v9tkz
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvK0VSakFiUmphVnlCcG1G
-        c3NGMzg0NWZHWUtxckZ1S2R0UnpPMVJ6aDBnCi9tT2tTeWhMcDM2QnozQnVudUor
-        Rk16ODFiQmVYSVlUSzEwak0vQW1EYWsKLS0tIFlTWEtwUTZxcFBHQUROYVIyVm5p
-        N3JEWDNlUUYzenJnOEFNZUt4RmNJSEEK+JABzJfq2xEp5YnhKjWJKiXYd2IbpRpM
-        YuxZoj1H7PQbHCn19M52FJbpFuGJFBgn+HMdPd/JWj1IaLQ4eYS04g==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3TUh5YmFIUC9Sc0JWSUlO
+        Y2VzeWtHYWw1YnNrTGJJZ0xxZmVkbjFtWURnCi9DOElHSVVqckxLeU9kQlpWbkls
+        cUxqeE9uNVg2V0VIczBVYmZqNGFpS1EKLS0tIGJMVlpTRU9FMGlPMUc1ZmR0endr
+        bXh6K2FEdGZZVnNzUjFuYlk1VC82bDAKiYA7Va8UTttegNe77QK3j5mbeefJzEpi
+        /9A4/tNveeB2eEKqbiV1lv1+OJuoQ2ZSKxlEreu7p3QZxJKzSNil9g==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age15hfg4r2zfc2zl6zarecpvykxjktw4zu3grlahz4397rstmhqpvtqjgf6yy
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmMnBuUTlzWVdmRmV2azBW
-        Q3FrL2lzZEZSR2pZaHA5d0N3azBtUHZudWtJCjFyRkdnTTNyN2xwY09TZ09uNERi
-        N0NIMnh5WFRtR3E0TDU2T0xXTTZQdGMKLS0tIEhZNmp6dk1id1VzM015OTBrTCtO
-        N2cvd25WNjgrUDN0KzBpWDFzV24rZGcKfQ5IAmkvKbmzDM9NEDzyjNMzzEBCRiXW
-        o0CV1i0zMwk9Bege5YyKTFn0/ZzcA43rbmlRwgOBhvUaTbvcwb1iDQ==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTbU1ON1JubVUxcTZFZGty
+        bkkxN3lrMEJYdDFlSzlXRUxaL3pDano1SjNRCnRPdEhobDZaKzBEckMvMzlhMnpR
+        UG5haUJBb0I3TzhQL3dQUlg5OE1RZDAKLS0tIDhwYTY1STJuKzM1RVFIdjdSQ3Zw
+        Sk1sc0MzRzUrWTZLays2M2htTC82T0UKjVj3aItkUDZqmn5fKT84KaKT62QRAHaA
+        Am9FlO6cCAicg1T2fGSeDqBMN67pFTY7qkprn2jmeRLNC3hLSzdkEQ==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age1l325yz3v2mev3t896mzvmmkaatjc7z4d9kukvnjuslgwwd8zg9ss9pnsc7
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1eHpDWmc3eUZKclV0aXhz
-        eG1laFQrTFh2M29sSHRSSHlSR3hwWlJzVEhNCkRzWTRZOS9QMlN3enJhQ2xqODNM
-        RGtHV2p4TzhQeGhaRjZpZWg4Q0JIR0EKLS0tIGR5TzFpbzFsQi9pcWI2bStrRDlo
-        WTUvRitDZnFQVUUwRkhpZ3RDbGxydncKhyEu6C2tqUta9qmiCZ+rmuLcmUfJOC4F
-        l8PagTx8cQw/BMUkJTNlG/BwbI48wcd0gs81+CFZ3UMdAiyVQopWhw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1OFBUNXhQUzZCR0dyU25k
+        aCsrRXhobEN4bWkxcTI3N1JHNnIxN21wWHlFClI1WEpFSENQMGpZa3lGNDVucmNJ
+        N2JlK29aWFBCK0tiK2x2TEppaStuNmcKLS0tIDVHL0c3L3FndUJPU2JuQnFueEU4
+        VXowc21rT3p1SE55ZjVIMmpkYUdLbHcKJaCk+V0502SV7gqkw0xkbf+al9olms8b
+        1z4UJ3K8safQ9XpF94tOa930jWNz0V+VuLv5bnMKZpr0xYJ9ew/JGQ==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1wjv755gsh9l02wm3wet48kjl6ju5ckk3jgllfpe8xmfauqqardgq7pt7ud
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsSnNlYnRNa0VOdVpTL25B
+        MUtLN1dCWlZWMU5DS0thMWlDUDN5dm4rNmhvCkhkeGY1bktsNjNoNDRmYldGRlFq
+        QzkvemRmQ2VBSE9xOTc5UE5xbUlLeG8KLS0tIGVlb0tIdWdXZFB4cHRLVlBLdVBH
+        b1BXNmdRRFZsMEsrSTV3dGtSdzdMMHMKkP7HTFy7a5LZoAuAf87zKhWRT9sh0mxc
+        nQSFn7xbrWuA4ClP0uLv/b4Ska1zNgu7yINdfb7HG3NNukYVHP/kXA==
         -----END AGE ENCRYPTED FILE-----
   lastmodified: "2026-05-29T10:38:10Z"
   mac: ENC[AES256_GCM,data:bp3MMQc9Dz6rV0Pyp3RKm7smXZwVQJ1Zj0AKJgQZeL+Pu9Z2pzIXs+ofsnQrddNypu19HcgrqIJwf+AFQAgGMaPQx1GmRNjaoOJmzx5BKiAYcSECfKocQrb5ec6x+p/S2hLvY2gIJX7AZvWYRoxEsHAARywsMRGB6Z8BZIujBQg=,iv:LuOrWVyiQBzr/ohScFhWbUgbhXmUUGze9Iw55o+lxLs=,tag:mI8SHQ6eXJXj4D3Y2Xg8LA==,type:str]

--- a/secrets/shared/habitify.yaml
+++ b/secrets/shared/habitify.yaml
@@ -4,56 +4,65 @@ sops:
     - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvYUNSZjFsUXA5U2V3UVlx
-        V3Z1cEZKNThnZjJ2K0Y2QUxLRDlhcktndFZNCkJ3OU9JeVZQdDlQZW5yeHhod09m
-        REc2ZUtBcUNtQjZoN0VDYjhzWUJtaUUKLS0tIC9hNFRpNmZLa3A1WmVpYWZEZUQx
-        NTBsL3RtZUQ0WE1yVERuNTg1dDR0NlkKBPwtUpYORg5GN7iNwcgPHzVqn1Qwc98T
-        BRR4WiuxQs8wQKI8nwNmS0DwS6EptCoJvhMURD1uZ0bUHExmchY+HQ==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmbzVLNzBmeENkc09zTjlH
+        WU0yaEdMNSs5SzZBNDQvUEJ6S2ZJVDg2QlRvCkJqcG01Y3VYckNFWnp5NnpzQjFZ
+        TExWL1o2dGtJY05UcHdpYVNkUVQyYzgKLS0tIEdQcTJkZ0VIeVBoa1BkQVhGQlVJ
+        YlJDSDU3cDNQY0F5MDdzVzMyd3RoQ00KMS5zwRzOd5KLoJEgUaQ52WQuTNPvTsuu
+        tVrR8Egy5MUSTYx3OECv5LkA4HfQvzEAnxri6CiAaXxti8rTW/lkrw==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age1tzq86mfj30su8hvw9e0y5zw9mg254frtk5s2mp48580uky8fdppsju42pp
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2Tm1YckFzWFFzN1RYZDE2
-        VEpwTFJ1UzJqVmFyNEhEb3VyQ2RneFVEY1d3CjRCa2c4bkRGQzZHMVNXNVJPdUJj
-        ZGZ3ZEpNWWV6aUY2N1NjbFRLQUkrNWcKLS0tIG5jTjBGb0pud3lUTmZ0cmttRFNv
-        ci94ZDBNeE5oOHliUk1sMndzRlNwQ1EKg+hPKKR7nGdaNe4YPYn8R04D13E9uySq
-        4sWdubNtR634rQ+uEMxIQtfdKvVuJVOANFHZxalyQmcOUBzR8wS+/A==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4TDZUemdJK1ZnZEVPaGIv
+        dXlVYk4yNzBoQ2R2UldXK0crcjFWWXlKYjFZCkFFVmlSZm5aTUhqSURGVkRpSEpR
+        WnVZZC9kM2hPWWlOQm0ydG4xOUVER0kKLS0tIHBpbGtYS0EzQXZiZnRpREozVWlS
+        TW0xN25rMDBxYVZub2FQLytuWGc3NDAKZAk2P30oEKlBQHTcaeXjxPNxgIAtYSS+
+        W7neGMjzmDUKlk9IjU48Ftk9oLZUz1I2s6vEusdPv7QJIy7AjWaE+g==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age12c2ef6ayydzvmz6k49pyyhtgu2g00nyynmht8y3laqvxn3wya4wselpc4s
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGL1dTQXZaNFEvbHpTVGtM
-        RVlIeWkzWTBMZFVzN2FCcWVBWW5jOFVWTUEwCmorNThneEFRWUdKZ3U5NGppV3hx
-        MnFsVXh5amZ4UUdOM2dmTnlYZ0E2Ym8KLS0tIFMvaGhWVWNjQWs3UDIxQ0lqeElJ
-        ZHdsVytqNm1QT0g1QU9xcnZ2aXJFZ3cKQIyfgJ17N7pTh85TKvYjmrlpV7x11qxz
-        o/udHwhVQ6Tz7oxt7a9dOOZlnmqv0skSYenUXkMM62KZWNiyOrwlmg==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSSmNxL1hLTHMrVWh5UU01
+        RTRZZmRiSXVZU1ZZa3dWTkZvMGRNQXhZYldJCmx6M1JIbFVVc1EzV2lUa2lyK1Yx
+        cmh5alN0NlBzWVF6WnRsRkcyVWdDSmsKLS0tIG8wS1dOQjZoR2pGZi9YVlFDcG1v
+        UUFHS2t1YzMyT1VDZXZCL0RwZ1BKaWMKb8VpO3lkGk2zzCQGESLMZS15wJrFHuq5
+        VDElIaO1k+I7JxYbCpGsY3k00DJiuq2QP581qjMHxVsjYp3+/5I3RA==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age1qdgn0k59t7ghg3t4gg02g2ppnzp7uz0ddplup38y84hqslcsgsxq3v9tkz
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJYXhuWXJXRHV6b0crNnZa
-        Q0V5MkNZYkRBWmJQS3Y3WDRJQ3RSaWhwVTBrCmhFeHR1VWZ0UVJISHVoZXQxZGIz
-        aWcrZUMzb3B4d29hS0N4VEVBSTNiNjQKLS0tIHVIOStjNDBZQWFHVXcxak8zQk11
-        dFlXYUFXblRFUlhBWnBrSGVuYko2R2sKxONQiYrH5qJBA8Qu5c4J6IB2+OTl/kvV
-        0Xi4JCeXOyxIgSp4n7da6av/ukVm5xWewd8B1SHh0XUqbbU8jrhKLw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBocmUvRXh4VzE0UVdVRW52
+        Z0U2MmQ5WmFJNllxYlZLMFNBRTBMY20xRGtBCnRrUS9tMGpJZEdCYTFnbTZwaXB1
+        WEptWVZPL1haNm53d1RTQlNMM0NBancKLS0tIDV1SEVYR1pCcHJoZE9TTGRHNVRt
+        bm16RVprUFJMZmM2MkcybW5LS0dLVjQKKrIMTW0R17ZJIXxveyZLo/78dJtyenF+
+        FJGW1HJ0dv5PYsgS53GfSaFbqRshaQAz1hjdLdAGc0gHqivykUywxQ==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age15hfg4r2zfc2zl6zarecpvykxjktw4zu3grlahz4397rstmhqpvtqjgf6yy
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGMmpQcEg1RTJpcWN2dkVU
-        Q21aOGZ2V0c0K1djMzB4YWluUU9hTkpHOUVzCnZvdTZEMC9wbDRIb01oWTAzRVI4
-        VXY3TG91bjV3T2dmK0pjTDZHTEs2MGsKLS0tIHYzcnNOQnordUVTVlVNSHJZWkxT
-        Rkx2YytJdDZjYmowMXhrV1lnY0x3VDgKyE/Q6GbaxTAXGZKE93FS7tdqjA5VMyxB
-        iSOZVSfM4G8vwNzfKNTfoc9zNR/0yOJspaHa3jN6C/2BuzPjDGkujQ==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAra2M4eW1rM0I0enpLbkh6
+        cVNqSXFONkF0SktHVkY5ZUwvTklMN2JEZm5VCklvR1ZqTDloT0poZ2FsRjlhZ0hH
+        RkFKZCswc0tzM2pzL3ZaWkF0dXVqR1EKLS0tIGlrOHdFbW5QOVF6aFgyRnFwZC9C
+        TExvU0FmNWQvSkRabmZxbGFSbVcxRVEK/YHUFil4CdcJvSKTtz6uySTBU2NyYRcq
+        MYJMblQzPH6mVzvPgDpOFHAzkMSGVkmywmiXk81Rito25HGrvgZU9g==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age1l325yz3v2mev3t896mzvmmkaatjc7z4d9kukvnjuslgwwd8zg9ss9pnsc7
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqMjRHc0tFc2RTUkQ3dC9y
-        VVRxcnFHdGdoNVZHZjNFV2FGVldCQm4yRVE0Cm5FblJNMWNCRE42b3paVnFMNE9m
-        YitWZnJReHArM3V5cVNRYmszVW1RMlkKLS0tIDJ0Mm5rSTRNMnBISlhqdmhjZkVS
-        MDgwa3hoYld1U2pxc1grS254Y09xblkKt/3Ap8X9lrhgI7M3RAPep/mawcBg/tcP
-        pVhMJQs88O3gMTr+BtapiewfgEBAYNiK7YmIZ2zGFlKq1IxvSqc0fw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHQVlUc3NFUzlOUWRZQzR5
+        SEZZZGVJU0ZLc1lEY3ozZ284aEJ2Z3huWldzCmdsTkVGZTNFMmJXNDQ1OHpHQTJ3
+        MnJHblhwYzlUQ25iR3pyWW5scFl4MWsKLS0tIDllTnFWdjlKODhpRWt6MHNrRTgr
+        NHBFTlIveGJDRHZTTmY4dWJ6cG94THcKuDW989VZZfq1W8wcva5ja7S/Ptpb0LEt
+        AMupoHOzLJyNe2nnd7CT9qr/CzWS1kvm75YNDzuTOwNNRUP1uts+qQ==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1wjv755gsh9l02wm3wet48kjl6ju5ckk3jgllfpe8xmfauqqardgq7pt7ud
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsVTRqalRMczNDS3I4Q3d6
+        NkZ1MmFWRmJ6R1NCVUo4TmJBVXgzbmdxUEhJClEzU29kN1dLTjI5UkhMdjRReHcr
+        aGVNRVo1RkJuMHkrWGNiQkMrSWViaVUKLS0tIHIxbitseUU4KzE4VCtCSjArb0Fv
+        Mjk3ZEFPdE1scitiMEVMaTJFZFA3WEEKI4GY1oDTWN2yz4iqZQ9cV/7uNsjd5gMs
+        4rKwhvbWXqv9d3tE1z61ZU6EA1CXO7LmkZtBGRBF7KxKhk06nWUgYw==
         -----END AGE ENCRYPTED FILE-----
   lastmodified: "2026-04-07T01:48:40Z"
   mac: ENC[AES256_GCM,data:0n9UGbquThsYKFWDrul59s+zc+OgTd5OKe+seHzI1M1GrenMs8ogj63eRYP6hCb2/QB7+HdsEad/2imJLlO0tdHc8J+/gmBazYBg0gkLwoS0rBIdq+XBwkC8x2VEo0qNv1wLHbqUz37at97spCswIBapr5O1uR8vb9LfWyn6yu0=,iv:sxSpciAvDFvr3pPuQQ7F6wI4TCcf8jKe9SYa1cEHWvY=,tag:eEVFV1YKZIupQ2yy4rAz3g==,type:str]

--- a/secrets/shared/huggingface.yaml
+++ b/secrets/shared/huggingface.yaml
@@ -4,56 +4,65 @@ sops:
     - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBkU0g4TG5BdC9paVk5aGR2
-        WTY2SnJFc0lObFJBbUhyV2RzdHpiWUd0NDNzCndjL3ZsR1ZsYmRXUGJaayswYWVZ
-        Z2hFZWNZQnpjTm1RaktlWG9UK1ZtUVEKLS0tIGg1TFptQVpxbkFpc1A4bWxWTHF4
-        bzFmeDZOUTNUZm0rbk40ellLWjV3WmMKk66QXMOvc+7dpbmn6C4bQKtj7IVmNs1H
-        yztZe2XHclBdK8tnWYcoi9ennah4MEOFtVzuUwhq2bzqmj1+jocBpQ==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2QTRZWDQvY1JvZ051aHZx
+        VWdjQTZveUNPT1VkVS9WSndWbDdEeUtXelRZCkVsZTB1RXplT2pNZFRodmJja1pU
+        MUJRd0xUbGRKMWg2VkxMTlBpU1VHVW8KLS0tICs4ajZEeEtvL2s0c2MvaGFHQTcr
+        M1NEL1RNUXYyRHMrZHlJSlJReHpZcjgK8g+DQB4pQfQUWut0ywud/jdJRPSw0rib
+        2Ic7fr9qLtfLHKZVI+u7v/MBskEuwbeMgiLRMQ+DlWpothl78UTxMg==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age1tzq86mfj30su8hvw9e0y5zw9mg254frtk5s2mp48580uky8fdppsju42pp
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDbWR1OElsYmZFeCsyaTJq
-        WUlVRUwyc3hHRjJmYnFLemN3U1h3RjQzZGlFCkpQTUtObkgxZnhVTWFpMktuUXo3
-        Y0wzNFlRZ3k4V3dvV3RnSkdDY3piS1EKLS0tIG1TZmFRbHVkMCtrUHNYMWVvOFov
-        VWptaDRCSDVsa3NpMm9hK3JjTnRXR0EKb5dEoe11JucRO5hvWCVfGlk6zE/f1CGj
-        uXQeHBLAv2OHnJ++uBa9bxG3/ybzTMYm6gy0M+AvxQ0gxExKF3zHhw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1YmN2VThUYmo4dDNFcTI2
+        bFNGWk9yVU9KQWdVckxKKzhPZjNaVnI5cFZNCnZCUFNFMkw5ekx4amRZdUw1Yk1u
+        WStMNWhROVdTbzFkK2NCWFN6dWduSTQKLS0tIFFmRW9EVlZ5Vlhsd3p0Wll4bTRa
+        M09xSHZDWFp0bmJNVmFCQUZjWFZjeVEK5rTC/HEsOequ12hayUdUFPdWVRJaXu33
+        EZ3yqJXaYt3u6gHNvZt/nBMRTer5i3nYMc8X6iQBrasKI1snuTPRyQ==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age12c2ef6ayydzvmz6k49pyyhtgu2g00nyynmht8y3laqvxn3wya4wselpc4s
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBKbEhEeWx5dldTQ0VQL3RH
-        WG1NTnArY0VCREI3TVQ4WWUrbkhCYUpWWWw0CnVLbVdHTHNrWlRwK0VOaytGUjBU
-        ZHRKU3h5QWw0MXhLNytwZ2ZpdGNoeW8KLS0tIE9jU2JsYW9SbzQ3MVdUQkQ4anFV
-        YU9DTnQwVEkyQzJ3eHVRN1JoZERBRGcKNgXw74yiOfYx1vtvtIu4gf8P6L3g62u3
-        XBuoJvrmzj2t2ZOQDH9in22PnABW6li3NZvWVs1SKQ7T2q40npBVBg==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnQUx0U290ZVgrK2NBWFBj
+        V3liOGhNbFBWQmJXRFJTNFJyeTZTNVZhY2wwCnlLQkJKMWtycGFWSytnL1pNNXpI
+        TXhzaGp1KytGV0NFTUt1bk92WDdIUkEKLS0tIEdsNWxKSDQ1N1Jxa2FlTmR6MXl5
+        TDRnOFZuTE1NTm1Ma2FiV013UzhQTjgK0FLDY0v0gKvZW4k+l5oo6nbcEqHVoJhi
+        ly5amqa8rZUcnEQZ1s8wcF33XGqxDaE3Gv4ttdcU4CrdLWE3m6dWaw==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age1qdgn0k59t7ghg3t4gg02g2ppnzp7uz0ddplup38y84hqslcsgsxq3v9tkz
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZcXZYVDZ1TGVuOGYzSHBw
-        UDBKMFBLeTFvWnFKNnEvdG01QW9UZHVoRFY4CmFzOUsvanN4T2wySUJWV1F6aHNO
-        anY1T0Q2U3hBVk1CemxZVlRpV3BJS0EKLS0tIFRwSUR2ZzJSOE1oSjZJb1lhWXhp
-        TjlGR0JwRWNoR3hOdENYem10MWNLdTgKhWyfFF1rYLcaD93q5rbMOOtYe73AB66z
-        39UtcUy5J/IyFGk5CTyNg4zqHwCd4ejed+GdYR09knejddJM1HTusQ==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB5MHhpQnU1RE51UXdiUE4r
+        V29rbnZpMDJoOXgxSVM0NkRDdUZEdFRkUzE0CkEweEZOdW1USWNqd0lZdi9LQ0Jx
+        ZDROMU9LWlZ0dExRZnJiUnVtNGRkUU0KLS0tIDA0RzhpZW1XcHY1bjZWalJKSXBk
+        OGlhNGltM1BmMk5lZk5rZDg1ejQ3cFEKSXjAOAwvoGybXOlHOBCMRHWAZBfDx8zE
+        4O57tsfadfHZribU+LnLzQ79RHUwwziJA6l6ATj5CvflZK3Q0pGEOw==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age15hfg4r2zfc2zl6zarecpvykxjktw4zu3grlahz4397rstmhqpvtqjgf6yy
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBidTVFdG05YUE5em9ZREFk
-        QU9QRkZZNkxBRS9TUUJtaEl6WjVQd01XYnd3CjZKY1Q0ekhVU1I3N29pRTVkdytT
-        OFZwZEZkY3ZVQy81OFVqVTBseW9QMEUKLS0tIE9tUnJJZkFtOGZjTk5kR0lnbUVJ
-        eDBxUmEwQlFpVVNYVGtjTXgvZ0tZYTAKZTCiMEKNS7XL5SOMbAIpqIgWJqZ3RqcT
-        UjkmExWc2GmdCXdjZ+IJluVj9NgmZtezh4HDBOZK7jfcLZeicSMvug==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwQjh1Mm84dnNNbDMxaDRU
+        N21RbkF6cnp4SUI3VExWNEwraXV3R0pjd2pZCk50QVV0VHZ6ZjhJTHpPb29uT0xG
+        SWNpWGhtZFpJcStIUVNkSGplTGNpNHcKLS0tIDdKT2MydlVjT1IwcmV5b2lFMXpp
+        ell4TXFjZC9ZL3h2bkE4ek8rNzNWTFkKibCRX1LeJ5WzliZq8mR46SaeUyc4YVy4
+        FoCDlkeh8I3yIge5QXB7pQT+p8zvBRIwPajRH14Nx/fLb0xUKE7CVQ==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age1l325yz3v2mev3t896mzvmmkaatjc7z4d9kukvnjuslgwwd8zg9ss9pnsc7
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArY1lsRGFlRHRXM2Q0YkZr
-        VkJ0UDlQTE5qQW8wQTl6RjRYclFyWlQ1VnhRCjNJSEVsODZLVVR1YjNLZWgyQTVS
-        aW9UUmozUlZTRzZsMGoxb2VvaW5oZmcKLS0tIEFCUGwzWCtpY1plNVRnZXNvenNI
-        d0o0dHppdHJVUm5KeVl6aVcxUGh4S2MKf1rt9J2pEzP+GQMWcV4zUaePrKKKCbR/
-        /CZaGl0zgawWImRIVLIf4YoZlHkh5j5DNqtS7vUs0+b46i1V/mYdAQ==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBiOXFZRmxoMGxqQWgzTFIw
+        K0wxOW1aR0RpYW11dHhXNGEzclRaNlRDMVV3CkF6RTFWR2gyK0tKeVpramRaR2ph
+        RW9VT3hiQ25SRTFqV2ZxNmtuN1RjQWsKLS0tIGRidUFOZ3M0ZUdaOVZvTi9pRnJi
+        Q2lzdHNRV2NrM0JxVm0ybmpDN2s5Q0EKI+LPqsQSKaqvdNbH8vvCFM2VVurf0AXT
+        OAM1yMtyt7WnHVvqrYV447ZwUra4/NHWoPRW25A33dMcwIY9V5L6Bw==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1wjv755gsh9l02wm3wet48kjl6ju5ckk3jgllfpe8xmfauqqardgq7pt7ud
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwZkdTT1VDVEh0WDFtdG9V
+        VlM4ZWZ4Qk5tK1Z6cklabk9lOHlRMCtlTnlZCnRqV0VFSWpFN2ErRjROL28reGFw
+        REQ2Z1VHcFVHbHNxNmg5YVJETTMvdkkKLS0tIFZUeDBuVkxjeHRSMStiUzlvd3B0
+        NDhoQlQzQTY5ZE1qMStURmJjV1NRS1UK5MW0nhKsEey52QkkspGBVmqHZAmkTTm5
+        9+JlRg7m0Txjj9ByAbK147PzICd29RJ/zhGom2cSZvCk5fTEd00k1Q==
         -----END AGE ENCRYPTED FILE-----
   lastmodified: "2026-04-07T01:44:22Z"
   mac: ENC[AES256_GCM,data:IFFn+o9RSrlAX7hqnZZzNfEs8LsuN6xJ08ROEg1xkBMOJmAro66PfsvkUPn3677bafEwXedYUpC2Ox2u5VHCFB6XPWoju3zI1uNlR+O5g8Mc0fVoJqzbRxJo0gxGetrUJgw9b5+v492r2yZIs+UAkoMjL4+zri3HnmYdmkRWzH4=,iv:1W4n3ujNUM/uGLAsqi7hEwDR0VdYmTLYUYN9S+6/xUs=,tag:JeC/mI1OBuHFPpXFIX6fFw==,type:str]

--- a/secrets/shared/kubeconfig.yaml
+++ b/secrets/shared/kubeconfig.yaml
@@ -4,56 +4,65 @@ sops:
     - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQWGNuMzliQi9LS20xSHlW
-        WmlndzZTcFRya3JOdzJOdHcyQ2FBTVNvM0NFClllUS9HQmpXUm9pMytVdnFvUjky
-        V1EyVzFCQlNBazUyMlE4OFlpODZtRXcKLS0tIFhWZStyY0JaRjNBOU5nMVoyN2xm
-        LzkxTS9jNFc3M2hReHZUTmE0NHpwb2MKaRdtE49iro1TZhHzV0RaXvwFuUzN5XC3
-        ZXyhQfiSn5/GvuBrHZloTs7+qspd9yV1xatxoWBoXbUr4sAIZE4wEg==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoUmI4NGJ2VUdPT2VlTDJa
+        blNwaXB4K0p3NCtZcmpNc0Q0WWNDSUxhcVVzCkMyREdoVnc1UmMvRThYL2drNDNs
+        cjAxTDNxZ0srdUxqbG83R3d5TVJhZ00KLS0tIG51SE1wbHJ5cmdma3Z2ZEl3ZWdl
+        QkgwOVdjd1VIbmVvNmpkRUpUaU5OLzAKpOLLWZ133ZZ8ZfAAoDDsxVqRYxWKKdMM
+        vfW49Jn15hNfF/SpStotEGzT2A7wpXtEZ+YHfbM74/vvil5l2nd2lA==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age1tzq86mfj30su8hvw9e0y5zw9mg254frtk5s2mp48580uky8fdppsju42pp
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA5L0hmaTlrSG96c1g3czdq
-        SXpXOG5DSHdmZHoxUGR1d1RRODFRb0lRMFhrCnp6SmkxUW1oVkxHNms5emtzZ1Vk
-        M0EzWmQ3ZVBqVUVsVzVRMmpmeHIyWUUKLS0tIGxWd2h3eW1aLzNuR0J5V1h6bEd5
-        ZzNPUWNqM3ZRMkNxN2JVT1FlcXpYeFEK8pjK4/N6sx8enHOoTtw2Gaek1c3xTDEG
-        fPiEK6rcxZ5ECmNWWJwTvc2P5OIZbIAaQGJLINVC3Ahi7eV7miKFUQ==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTVjFaVjh1RXZPL2ZzdWtH
+        c21zb1h5RitCRWhrTDFUbzk5ajIrVjd5Vng4CitMUi9EK0g2SUk5em44YW9STTVa
+        akZXajVyQTdIQ3VQcVJadGgrSDRmMEEKLS0tIHR1aGlZb1EzMXVOVkhyZG85bnVj
+        TGkwS0IyVHVZdGZtR0tjNTh0RHUzdGsKALTeR4N2rAqs/IU/z/E6WQqSsfNbnOvd
+        lsDexTCFCNEsi+kZqAqxKZtfDFqX5Y0zlg4BhR8k1AZ6020YKFx7mg==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age12c2ef6ayydzvmz6k49pyyhtgu2g00nyynmht8y3laqvxn3wya4wselpc4s
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3WDZVT3ltSkdLYmhCam5I
-        L2doT2kvOGVrUG9rcTVlejJiK2Q0RTNOVUFnCnl4eGNoRnc5YTlCVGhpbmZuK3dt
-        VThZTUI5alViaHlqbSswT1V3c2loS3cKLS0tIFNteWFaenhEdW4rdzU2ZjhmUnk0
-        c1NLZHVGQ2tYMHY2R05BdkRVbWFQRk0KwFhY+t/6uRaWZg8yyhmPGFfx+TRXox5M
-        ZZa+tE5ONR6pwbmedonq1vZWbhgMFT+mDZA3rE/qGwTf6SVaxOQ0Ow==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhL0JMbURndzAyeU5JVkxa
+        Rk5jbzBoQnZ5MVhTbTVuTFZBVWswcFQ0d1NNCk02WGlIMDl3a1FHbFlOMkdTSVNz
+        ZmxmQWZjdDVUWGpKQVNSazVnMmdKdEUKLS0tIHU0OWd4UU1iWTlpaWF5bm1FZlBZ
+        UUtOT1JKclEzQ0NVZkFHMjNldmRYNGMKPCf4N/oGCMOlNY8T3TgPurNZVr469Roj
+        /1ODlMxIL11mOyShzLF5eiDNN1GM7w5G3y1a/h6XOhNZhliDCw6+FQ==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age1qdgn0k59t7ghg3t4gg02g2ppnzp7uz0ddplup38y84hqslcsgsxq3v9tkz
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqTjNlMVpHaDhCam1jZmZz
-        OE1iSXlvUG53Q2xXeEtwOU03K3ZzRjJRNkdRCnhPVVNlY0tVSGxzL1B6cFA3bGFB
-        TWsxb1dGTmxqUTdHN1pvc0R1L0N4elEKLS0tIGJzV3UrZjNNN0dYWlRUNVVkRStk
-        UnBvRTBxc3d0OWNYTzJSSDVzNGQxN0kK2cbjz6+xnFL+Fc7z1psnus+Ckp3NGbUr
-        rrN79+ZnQx2JwwKuwbR/m4bW/jREWwHL1eJfUL0OBLaSZp5XwgK5bw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlTDQvbnRtckhqRWM3dlFB
+        MDQwM1pKMXRhbUU3QzJBVVkxL0hKOGxrRHhNClV5S1FJbVN4ZUpaUXlobnVhOHIz
+        a2dmVTVpOEhXSUN1alFoOVE5Ym9yK2sKLS0tIG1NMktSaTJxMGxEYmdMUVkrTjM1
+        MjJsMlVqTXJqR2xJUDdXQTZ2YWVNRmcK8ScJ9LY7/LyXbkUYPCj29++kMei+nBhv
+        5i8Eds81Z6rmNcDN7a5O4seUWxFKEq//v96Ijh3z/tTCpL91cedNSw==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age15hfg4r2zfc2zl6zarecpvykxjktw4zu3grlahz4397rstmhqpvtqjgf6yy
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBkcituOEI5d2hUbG5GWnds
-        VjdnWWpjYU4vMFl1anp5WW8yQ0lrOUtnSzFBCmk0RXduRWQrQ3hFQVZNcUVJc0JH
-        b2tmRHNUdmNySm1WTVJuOVJ6T3h6blEKLS0tIEVENnJxbUtpZ3U2VGplVVd5eHRM
-        U3NTUitoVHBvV3JCTDhFV081VzVDczAKYnS2VhwFlAepe/DVRksIP3EFbs+bvQTB
-        qb0sWd/65D+5E2+7/ail7nbUqHf3t7muTvNKKswcPoxXpMtmkcW65A==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1YXRHaGVBZkJWYXpDK1ZE
+        Y1cvRTJwRGpFaStnS1g3V0s5Y0s5ZlIxc2c4CkxoTzEvNVRXcmdTaUNLaElPYi9n
+        UmI4UFdvVUpSVXhjOWFZcXVmVHExd3cKLS0tIEE0bmh1cjlkWlRlaDNIcVBIL1dr
+        bE9pYmhaMlFjMktNMW9ydGY5L0FoQWsK9h1mr19UoOdKub71q5nMURM0+SQrHBJI
+        n1HZIFwA6LPqxck1pMN8UsyM2v0oE8g5AwRAFigbDParKLTOxZK4lg==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age1l325yz3v2mev3t896mzvmmkaatjc7z4d9kukvnjuslgwwd8zg9ss9pnsc7
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzVFloQUpPd0dJWjZJaGNO
-        dEhBVDArR3UwZHVQdm5BNmJNbUdjTzFLYWxRCkczYldyL3UxQlFmS0NPczhGbHdu
-        MHI5b2xiMkRLalh4YU5tR0JBMktGNTgKLS0tIG9iZzY1b1pnSFV3V1F1enlJV1g4
-        aXpCdDJYT1picVNPT1AxRlVQaStvNW8K3+yUBKmECSlMG6hRIxHzXpGmxy6ZIxYg
-        kOb9zhvIOUOUHGQz4Rf64qdkADs7pfDwN+Ve9dCv9CqX4G0CISgcBg==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNK3RiK3psOGJaY2FMOEJu
+        UnYrTXppSDFQR0NSZGREQmpZVUorRk1rVlZzCnJMMmVabjNGN2MremErSDFlMTRh
+        TXZiTVFHV0hTYlFHN1hEOXBlVWFLM2MKLS0tIGRyem1BSDhHOS9QVUVDcU5jWDBq
+        eXVlTW9heG4raG9HQ0JMTUN0TklGcDQKi94pHboy56PynfrGmMjOVFd8ZYedxWXk
+        MRbv2kzZTXF4d34hRFEyHLM3SaFFvQ/CGiin8ilK2dBbLlzs2JEdQQ==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1wjv755gsh9l02wm3wet48kjl6ju5ckk3jgllfpe8xmfauqqardgq7pt7ud
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIMXRYK0xxUFEydHNXMmpV
+        MzZlU3NnUVVTNUJ3a05SU0o2dWJRc3psangwCi8vSEJuZGxTR1p5c3djNXBkdFFs
+        YTROVEQ5dkZVVzR3eXpiWnpSYXQxN0kKLS0tIEVlVElNQUpEVlJFNlhRT0tDcGp6
+        MEFMZ3RPN3F5M25meFdwMkxWVE1JT2sKa+CHRstMF0+DEh9t1wC4Vqs+fo1s7mE2
+        pSgAkWQiw9BroTbX4/lgVcTWbk6amIRDFec8m2/BcRXHBDt1c6CBpg==
         -----END AGE ENCRYPTED FILE-----
   lastmodified: "2026-05-28T06:16:40Z"
   mac: ENC[AES256_GCM,data:2jgCSXslqsvfI9ZhJFFbhidhpTJN4Z8KcfZoV4LA6n7CI6Lr/pTIAPRZ7Ub5Z4ZEt05Uhgwbrp7NFVVLWvwPQGU0xEQBWz5Mr5zYMeQ3vf/le7+jbPSE8gOb0g0zweLYOpWeDu+OswyeRi6KpKnFsOadYcinqsSTEyzuqL6L3UU=,iv:xUeBXtJ7sKlChyQd0lv8iSCxGYUoMBUsQ5s2FGo3VcE=,tag:5WSR+3LU6+XQRffegmaSCQ==,type:str]

--- a/secrets/shared/talosconfig.yaml
+++ b/secrets/shared/talosconfig.yaml
@@ -4,56 +4,65 @@ sops:
     - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA5STdLdjdmZEh2TThQSTBH
-        MDR1bHFZdEF3Y1huZHBXeGp4MDlxN1dZQUdnCkt3dG1EbUhZRzc4VnNPeEhJNVM2
-        NXovMnczblZtajNNUjB2SFphc1BhZU0KLS0tIC93RU1BU2VsVS9FME5MNTVBem5O
-        dnAxcFBMSndKU0hLK0FPc2VxU2t0V0kKH3a/FKQqq/cZyXrl0WGADBCcsYqbE0J7
-        WfOn1nIWDMmU1Zzr6qHD593Me3FvcugWfWOqIrrKRF9AUISN7QbqOA==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUcXFzNTc4UEJub0xVb3pI
+        ekEzdWp6UWhPbkJQeFZqRU1kWGFQanBROEVVCkZCOVlRRDUwaytCUkt1NkFjZUoz
+        OHFKWjdiTGVCeURUYVlRZmE2OUJZbkUKLS0tIGczM1ljUDhBMmNOTUpidnZhMWY0
+        M3Z3Kzd6dnBIQUNTZHJJUXkvamJEOTAKhgqyg4VNAkPbNGMBgg2XAp8ESGnTpiy6
+        IQ/UCYmltpAjgjCcaUAjSgraqOKkanQnZW6OteDSDLC22qWI9DTALg==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age1tzq86mfj30su8hvw9e0y5zw9mg254frtk5s2mp48580uky8fdppsju42pp
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMWVZ1ZHQ5RkhqbzJFTUZ3
-        U215am1qMUNwR0J2bWxHVGlPZGdlOUJJVkZRCkRRK05QRFdJZUQ1cjBuNDhWdUg2
-        VlRuWUk3b2hDMG9GbnZmTHlNSm5xREUKLS0tIE0yOGs0ZTdHV004aVZ0MTZQc0xk
-        TDNMaWpVdk9BSEd1VGJCbFpnUFdXVkUK8Kb/S6O+ZdMAKm/V2TSdw7rANeLhwEBK
-        T3a13RXR19Wz55xoEKYFtq549vh9HtRqT+HG5RftdjqIQFSxrzphqg==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzNEVrL2RVbkhaYkxJb3VN
+        TStCYmFORjVrYlRTdDVhdDFnUllTNUpwS1dBCm9iOGtSQnlWQUpXVVRaclE3cGtZ
+        eWdtcWhLdmJ1WmZuRW9wU1JIdldaYTgKLS0tIEpkVjBsTFdvSTA3TldySUtwam1V
+        bHZ0MUtlaXFrdTFPSzN4KzczSEtkVHMKWtlM3fwdbidav4jI7ioPgB7E0D951pkS
+        PXIHPZMxlGzyZZlpx6ZATAqHHlLt5f+O1GsN7oQtFBWhXKzkf5AZMA==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age12c2ef6ayydzvmz6k49pyyhtgu2g00nyynmht8y3laqvxn3wya4wselpc4s
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrVDNrTEpvb0kvOWc1dTRx
-        bnVsSitjbG1teXRkaE55blJTUjlJOWQyZ3pRCkF3R1FPUVRUdGdvWko2SlU1MEN5
-        aWwzVVgvZ0lpWDJ2bzAveENESmlud3MKLS0tIFZLQzkrU3lDTExVakVENGNDUjFy
-        NEY5YTQ4NnBsOGhKN1BFWXRTYVo5OUEKyc0rKatxtfE7sM110r97P6LyUEF7MCXf
-        sMEnZ5ELvtrgypMWb1LuUB5KFy+a15o2VKPpsrSaRqvUGY1HmjpU7A==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRaTBjT011ei9ZdnFFbHBC
+        dkxkZDJiTW9QenhqaXFBQ1Z5cVFVRDh6eFJvCjVFR2RzYTBXY0FDd3FKRDFkUy9O
+        d1FhUE50Qis4ZG5YUUNkSWo0TUNZMWsKLS0tIFFtL2luSitnbmQzSjY0cW5uT2ha
+        K1NDNWNwdHM1UGdyYkthTEMySHN2OEUK4F7bPZhbBiZOtDbVlxJ3xRRw67j2Jsq4
+        i6vXyOoQxyPnNlF2jn+GQH9gLB03QQV2UjrV3kJqlcmU9juArS5ixg==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age1qdgn0k59t7ghg3t4gg02g2ppnzp7uz0ddplup38y84hqslcsgsxq3v9tkz
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA4Rng0eVZKeUZDU0M2UGV6
-        K1oySk1YcGM3SEN4YnN1R2RZRzZkdTVlV0ZvCjYyenl4cUdodjJvZCtoZUNHSWlS
-        blR3TDQwTm1sMCtvdDhZRlpBRjNPVDgKLS0tIEtMeWhwUmNBRXk0L0YvVHdXM1VD
-        OStMdDg4eUZxS1pydHBONDAxV3VOblUK7Tg/+Fi6vLf/xJS6L8eQtLnso9QyB5kG
-        gKm9pJQtSd6qwF9FIdlNdATxnEHszgGx7TYm8i/vw5y5vY0CkyhZDw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoZ2R3dDlJWkdnYnplWjlz
+        TVE5WWxDUmsyR0FDaVQvb1lEMHVZSzZrbVRBCldrZit1Zk9mVFE3cXNIeld0SnNw
+        M0Q4ZHZqbCtHTHJObHVyaGZsUW9SWUEKLS0tIDZhNURuSlM1cExuY2trb0M3amFE
+        LzJlWG11Vzg3YjJCMmM1cXErOFJ2R0kKKmfsBBOdkniuDUIURlQ/ixybpZ9rv4hX
+        DsTTFsrAcs2xK0dFVnOhEDvrQps8tnfmWEvxDcrZ4Ag08wPztx2vuw==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age15hfg4r2zfc2zl6zarecpvykxjktw4zu3grlahz4397rstmhqpvtqjgf6yy
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNcThsSU1DbEFyZzgxQngy
-        V2l4THFPb1BMcm5LWmxYQkYzR05iZ0RJZzFFCjdPTkY5b0pnRWpiUWNsaSsvZGxL
-        aUs0dDYrWjJGWVhEWnhYSUxKOWhSemMKLS0tIFVGQ3RaaHdSRWJjTUUzckhpUkxh
-        eUw4NXVBeXUwSzBYWU9aTStpaXV5OTgKSVtqMQZZg0DPeTmKGfYQSYg3SyqqqP04
-        cV1TvppryDmjEivmEQuUV5cjCTrl4zd/nSoo5trjAD5w8Fh0EBuW2Q==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxb09qaFZnY1UxSnF3ZVVt
+        ekNaaFI2ZXlyWUltSURreDBGdE1mZFRhUjFBCkFNRks1MDRjV2FsYlpKa1U2YTRP
+        V1ArNlliOG9lWXJadFpScXVqTHNKVk0KLS0tIDVnNndFdUNOQm5xUWpzRW9xbG50
+        YWloaHF5NXRiSzlLVS8vWGJTUXRuUW8KMiaL2SRmlQVy8bcd3q7YR45irkRAQvn5
+        jRLD/zJWBCKvot488lZ48xrNkvXMXMTrABOg7DiEl7iQNg4MtLG0Lw==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age1l325yz3v2mev3t896mzvmmkaatjc7z4d9kukvnjuslgwwd8zg9ss9pnsc7
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsR0l0cTdhaHFaSXltS0py
-        eGU4YXoyMGFmVWVNdDlZQ0ZoM0drU0U5VmpRCnU3NXZYWDBWUEdjUmg1ZTRZZUJE
-        akpwa0pLclBsUFN6YmhwRnFXMXljVTgKLS0tIEpSNklSQXdhWnJwdnRNS1MvdGJw
-        U0NGbVRIUlVjWGN0R0U3cmdXNStKY1UKaHs8HB7g8p+rlHuW2H4AF+z2VdtqGNH7
-        5pZWqEpb8x8IrA0SO8zRmSs0X8ZsB0NV6Oy95N0jdxZQmoNmuvvBKQ==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwOWpDSm1YZXNOS1dkaGdJ
+        UzZOZWRuNnpQeGY4bnhOMGEybUtpZjV2dERjCnBLejhTaUJzQXBRR3drcUxZUnln
+        QU1maUtHb1RMRHJMT0ROOGVBTWRHMTQKLS0tIEFKRDZoL0hZZzgvZXZHeVVEa3VY
+        bzZRVFdXM092WkpLVFUwWmRWNWZGeEUKvNR/jGkmArzi2So7c/6z/ReuYEcjGMqS
+        vyFebpKFaL3UgiOmz3cblAZWpEGoVUB/XIMFxmgi87CFd+eRk1TeYQ==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1wjv755gsh9l02wm3wet48kjl6ju5ckk3jgllfpe8xmfauqqardgq7pt7ud
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA0K2lrOG5lZnlLN0V2MVhl
+        NDBOUUtLQm8ya1dwQVNRNlpnV2pOelhZT1FnClJaamRKNWJTbzZOdkJRZlA0ME9a
+        cVNzeHVaMlMvNFJVdlB3dlVseSt6NXMKLS0tIDV2NDAzb2ViVmxFcTlhVW5PSnRL
+        VjRUR2thV0RlWUhjSy9reWtHOE9OTE0KeLScZCSXC9BC8+GeKS/ZJuRlHgWTpFFT
+        nSb2qm5ngFeYA1PtPFYBfcJ39qr9zpH1uOPjoWjDD7pJsuK5GC+oMw==
         -----END AGE ENCRYPTED FILE-----
   lastmodified: "2026-05-28T06:16:40Z"
   mac: ENC[AES256_GCM,data:dTq/Wo3UlERMZuDcmUKjGX8jf1DwDeOXTbK+Y813eyHWuZ69qMM8ybotZXWHt0ImlJdbFPGFgno3JOIZ71IRX4boelQCnWbJIMrBz479uaMBTyVdM2gD2FyytSaTlEmWsltRW6Vlurur9u5GubgSTpWDjbtAjfPq6eSDz3Jw6pU=,iv:Zodbi7kiYi3emLj4k9l+K2NTGVvyt43wBxIG1qQeyuU=,tag:uHpO/i1oIHHIATgn70UPJQ==,type:str]

--- a/ssh_keys/gecko-default.pub
+++ b/ssh_keys/gecko-default.pub
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIF96KlodDZw8VpolPW65U1wKwU2Efht57zsG0uEY7Fwv agentydragon@gecko

--- a/ssh_keys/gecko-forgejo.pub
+++ b/ssh_keys/gecko-forgejo.pub
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG5apm/WgL+EWRaJ5m0PBrMtAOAcnZK0zgYPiPb94q6v agentydragon@gecko-forgejo

--- a/ssh_keys/gecko-forgejo.sops.key
+++ b/ssh_keys/gecko-forgejo.sops.key
@@ -1,0 +1,18 @@
+{
+	"data": "ENC[AES256_GCM,data:QQqhkaqCBHjgecLnkW907tSpxRJ7jeageleU/zOijMF91+75Gp1GSnhTzRshymhGiVLslteJaofFZgzoT5qrQ6q5mYM73FL6UhnvmUTn1uLmtnNd36Alyj12FNCet6KPAXYo13tzpSaSFXi7YD++tkX/LuZ+pxEAwaEDBxDf70LlpKRc784R4barIO0iuc1hcv0F+hZ7iixoTYl4f4dYv15Qzb/PG1e7gZk+kbNLbdnDNG4TpkifyYUbO+I7yvp1VTo5D9orE9OTOXT0QNyMACPOJffUVzAb2dUcJSugiXj9wjMMpoCdrITYxstn+1vneOHuqwfmVMaitx1WVYhK/sQMygNe1YIuz+Lzai2aPuSVLowSnDJ0FPJ6t0YqqtOqzCQqdaSP53YC0d2elO+PByQJecyqwBB7TgUCWsrnsD7X/b1pTYwKNvn6NRK3yC+PD6PyFr+74tvDRQg2SrRymy0aC0gqWMgDIS7j3RNlC5e9rY/flt98RS5DzSAzvu/0I917Paq4b8dwxVX0aJucXRk9CVmzd2v3wisO52L3vHVvZ+E=,iv:ZHIA7AC+W8p52n23nFPe/y0Hqw1aXEpZXM0pgCPAUYw=,tag:XnIBACn7dXrrW+5q1fSiuw==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"recipient": "age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSN0cralNTcmJTN2xOeUYx\nQkU2SWpBd0xMeWZmVkg0aVdKSHM1bkYxYldRCjltN0pwSU5DbkJXTEVwQVEzRStE\nSmkxazhrWXA4Y0poUXVOSXpPK3VqK1UKLS0tIG1JMkg3a25Nd2N4VW5seG5rVTlF\nN2phdHE4amlsdURleXJnVWl1RGVFYUEKQZM2wjATFcShKyYMcJqw6WE6Zqr8ydqw\nnbhRYBdB/LZdlB1at7JXzhZl+g4Qf4GgETpGJMq9w0KpmMJE7ELNPw==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1wjv755gsh9l02wm3wet48kjl6ju5ckk3jgllfpe8xmfauqqardgq7pt7ud",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlc2p4TDNRbS9qZXNMbUlN\nOUxwWE1iREVMYUxoRVAvaGFNR1BrckFSMVU0Ci9SVHg4WkN2NGg4RDZMT05PYXVF\nM2hCYUhlSlp4UktZVmtjQlB1ekthbncKLS0tIEVzd2V1MU1KQi91VkhzS1RHdFRE\nYnJHSUdCYjFwTHNVTzRTK1BSN2M3bEEKWJIz9wMxsxWR598r5iNJsaQStKlUnPNF\nb9DCy87/rHgPiyqG0jzwgJzaE2ysrQSDYXYvn2kPQiKXncqg+QvIOA==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2026-06-25T03:47:05Z",
+		"mac": "ENC[AES256_GCM,data:M9eUEE85EXz0wfF7VovefgIv+mHuoNcmggQaHvtVvjcBdmXRD9dH5Tz/KHiyo/IG6uS49sud0aTr8x8Pb0NhUcoCCmcOQ2+x1uHq7sUrbADmfp1F3uNUSVbrYrqk+3ZGCbRN/rn2/Ex4qKC9f+qv1UyGRmssGeAirVdKdFgS0qQ=,iv:bhA53CQGAQW4iXpYXy4zJI9oX5n5Rm8Qlp30szPq8xQ=,tag:qgaF17186s6tBI6NsOG8aw==,type:str]",
+		"version": "3.12.1"
+	}
+}

--- a/ssh_keys/gecko-github.pub
+++ b/ssh_keys/gecko-github.pub
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBq5RiEMGquENqIFJ+V5HYUoh0nBC9Yqq8ObJvuUVu+A agentydragon@gecko-github

--- a/ssh_keys/gecko-github.sops.key
+++ b/ssh_keys/gecko-github.sops.key
@@ -1,0 +1,18 @@
+{
+	"data": "ENC[AES256_GCM,data:g2AQxenyfq4LRk9YS4qFaeYe2hRoS8KI6cMD3aZHIw2iqDF/eXskQF1MEMl5voCfhTeoVYT901uMbb77zbuXj1A8dkyVV/qkqUaommv+K1cvuDPwGwQrP4GvL5gCObkBDmIUmak9fIiZMuikTFJkj8ivOvm0zhhWIHLaifXS8I7BSB2pwYVSIcGQSRaFpE5mHj6pr2QK4xRhFNbY8ls1/vS0TQ0ZhTcUUADcdTrNUyQQDpkEzhP532JY13Wu13zDZ9gHf3dtt4p4qasyNY+a0Tbqpk54NYHZHR6rTV5UBIZAvsVheqTpXhlENWvn/n1rB30QGUssJXLaYPAOiaOo5vpfID4mGE3bJBGTTCM5jlDdtOvQQYXbWb+zS3F98ePlNQx4/3P1mCU7yaJdSHD5aS769Y4QhDB0pTE1TAHsyRK5K/CkkL+e/ql6Oe/2b0VLT/A4dmY0N5Kd4sF9sNByTxkzsQ9r+pg9tcDDfv9/ZsxUKqCC8iXmezWMzOw+z9fvuKoFy5F4hbkTgxDGiltb2ZxM9xkVkHjLCmwaeUvxYheoscs=,iv:Mk66BN6daZz/qQolRUiyeQ4YfzyyMmFvjjHyLy5LVb8=,tag:RbeosO2Zs4mLg38JSDYecw==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"recipient": "age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLMzBRSG9VMm5IcDRCRk5P\ncmMvR3RpM3QraytYVUhEY01TUGtJb3dMdDJFCnNiNUtkL1RRbEtNdzJoZkwxeitP\nckNCVjRyNkFZdnY1K0pHTXNoRmUwY3MKLS0tIFk1RmtTbkgweDAzVE1ZUkVhNnMv\nU29UQzVmbVY1SEtjTzduOVhXR1V6VzQKidqBnYlf/sb7KfiNUJq17dooUdb6A/QB\ndvn0RkNm0C8D3TQEBtk4QUp4kFChC/Z0hLUXn230JSxTGSlcBTV+3g==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1wjv755gsh9l02wm3wet48kjl6ju5ckk3jgllfpe8xmfauqqardgq7pt7ud",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4c0Y1bFhPWVlPMGFXQnVn\nV1Z1Ym5HazNtVVBMTXBySGZXeU00MUVYOVVZCkxYVjA1MUQvOVVvMERsOEprU0hL\nQytFQ2lKZ0ZnaTlhWXEwTE1Qd1oxMDAKLS0tIHdndmdDaXQyTU8xY3BEUmoyS2Jh\neTBxU2FhZm13aWxXUjhYM3BPL2RNM2MKsVqgwsbkkCmsOX0XhF3xdyKdAwnww43z\nCmp6FpREnU7KSDztaBpsmub5bOjmAjK/Dv7I15pMOIa+/6DVfo3tbw==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2026-06-25T03:47:05Z",
+		"mac": "ENC[AES256_GCM,data:RnEZV9CTWLUcJtkZ+8BuH8oBYRcpKlGJ5dbKLWQjWBcZTevHzym+zpfRjWZrXuYZsB/g3Xi5gisqAaKXYhjVFlEpjSVPizmuCPfxccZTjEvriPPJ5kQOp8RmeuXpJWc6hBqe3ad8FryLo/pzeaEq1x6bFj13iu3Wxt6uAE9uLuI=,iv:JwVDSGwj3vIErU3fPK/mDsabsAaGJmNwhOuKCcp517E=,tag:xpqCDkdHRWjw+NgDToWguA==,type:str]",
+		"version": "3.12.1"
+	}
+}


### PR DESCRIPTION
## Summary

- turn Gecko from a minimal post-bootstrap placeholder into a real headless KubeVirt NixOS profile
- import the shared Home Manager dotfiles setup plus Forgejo/GitHub SSH, kubeconfig, and talosconfig modules
- add Gecko SOPS recipients and encrypted Gecko Forgejo/GitHub SSH key material
- re-encrypt the shared SOPS files that the Gecko profile needs during Home Manager activation

## Validation

- pre-commit hooks passed during commit under the repo devshell
- `nix eval --raw .#nixosConfigurations.gecko.config.system.build.toplevel.drvPath`
- `nix eval --raw .#nixosConfigurations.gecko.config.home-manager.users.agentydragon.home.activationPackage.drvPath`
- SOPS decrypt smoke test for the re-encrypted shared secrets

A full Gecko toplevel realization was attempted, but this environment hit external network resets fetching Go modules for `sops-install-secrets` from `proxy.golang.org`; the focused eval checks passed.