### PR TITLE
nix: enable attic substituter for gecko

### DIFF
--- a/cluster/k8s/agents/attic-jwt-rotation/rotators.json
+++ b/cluster/k8s/agents/attic-jwt-rotation/rotators.json
@@ -33,6 +33,14 @@
       "push": []
     },
     {
+      "name": "gecko attic reader",
+      "sops_file": "secrets/hosts/gecko-attic.yaml",
+      "sub": "gecko",
+      "validity": "1 year",
+      "pull": ["main", "gaffer"],
+      "push": []
+    },
+    {
       "name": "claude-web attic reader",
       "sops_file": "secrets/claude-web-attic.yaml",
       "sub": "claude-web",

--- a/nix/nixos/hosts/gecko/default.nix
+++ b/nix/nixos/hosts/gecko/default.nix
@@ -19,7 +19,16 @@ in
     ../../modules/vm-hardware.nix
     ../../modules/bazel
     ../../modules/system-inspection-sudo.nix
+    ../../modules/attic-substituter.nix
   ];
+
+  # Pull substituter for cache.allegedly.works/{main,gaffer}. Reader JWT is
+  # auto-rotated by attic-jwt-rotation CronJob; the SOPS file is decryptable
+  # by the gecko host key + agentydragon user key.
+  ducktape.attic-substituter = {
+    enable = true;
+    sopsFile = ../../../../secrets/hosts/gecko-attic.yaml;
+  };
 
   # Passwordless sudo for read-only system inspection commands used by agents.
   ducktape.systemInspectionSudo.enable = true;

--- a/secrets/hosts/gecko-attic.yaml
+++ b/secrets/hosts/gecko-attic.yaml
@@ -1,0 +1,35 @@
+expires_unencrypted: "1970-01-01T00:00:00Z"
+attic_token: ENC[AES256_GCM,data:UlSXK1l4zXDbBaU=,iv:u6t4f4Gj0dH0kNRJJPycjAKBy93mQ7OqeYTlusxxPPQ=,tag:4kBZ6UkNbtuGTpy8oIWCng==,type:str]
+sops:
+    age:
+        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrSWZhM1dUQ21hdytzMnNm
+            c1dvalc3NzgvN3ljNGZJUWFVSCsvcnc2UVJVClBWN1FEby9xRGs5SnN5WVJDa2NG
+            UHRBVnlyWktTZVpQS1Vkc0g0cWxJdGcKLS0tIEhQanNLbWdPOC9UQWNoWmJabWZw
+            akF0UktZdzNTM1o3dXM2azlyTVBZbzAKDFLkemx4F0UJbdIOHxEv61kF+X84R/BE
+            zRC3riJV2o4K4CS6UR72YGl9SZ4n622jVsyJKNeUg3wHfnVEYuhXhg==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age180y753h0vzxm8a3y3rd7c3zykhrat8xlajczuxuk7dz0h82cdf2s0slmw5
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDNkNSS0NKSzY4UHlJTXJh
+            LzEvRlFzSnErNGNGbWxTV2Y2WEtGT0lOS3dzCkFyOVFlZEdUZGd0ZjVZcWt0cHk3
+            VXJKeDIwZWUzYlpJZ1FTeXFnMnZDc0EKLS0tIFhVOW9EVkF0TWF1TlJHNnUwTk8x
+            OVNLdkdVblo2ZHNBTVNWaVZKbmpPbm8K95JTPKIRK1+AIAm5HePh59OcTstho+gO
+            pza5V6q0kz7ikHuI9aPmRBhyd4TRRdSyX6jEZOKCeB1Gq58J5ULH+A==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1wjv755gsh9l02wm3wet48kjl6ju5ckk3jgllfpe8xmfauqqardgq7pt7ud
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA4aGZsYTFJRWRLSEpMQU5E
+            akx5eFUzWFA1TmVYUjZEL1lxMG44QzJ2NTFBCmt3eWgzWDdXbFJIYUJlUGo2aXZW
+            ZXVSSHJWVHQzSFBreUFKYnZqenJ1enMKLS0tIEJHb09ySXdKd3NRUXJjcUxWU24x
+            cGtCNHljTXZYM3ZhdGFRdlJhdzdqaGMKRjot0/eiRWLfhXQXYWcY9imqFWOVzL3L
+            iAX4F+y4YbCWfUVCWPWY9AiCeFvhRUqmsgiaoCl0Xzue6PxRHhTslA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-06-25T05:03:36Z"
+    mac: ENC[AES256_GCM,data:WaIxFWgrDekN17PLwUmkoScz8Ul05kPsFGMhikMMDBXx7Tz3qgTg6cJAeKes1td1KjoiFrM4cZJJ+rJYBiqXt6Now+Nk2dIy5mMhbgfVDiHBxf/dbS/iJpMO59nss2Ox8WmSEcQ3589oNZinPy01f8tsYxerOG3n35z2lF4tfo8=,iv:+PqUuJDrRjNWyFNqHqIazotfAr+kJlslQJfIaTdZZ8k=,tag:UdwExKo40CmhqoY5sadnxw==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.1


### PR DESCRIPTION
## Summary

- import the shared Attic substituter NixOS module in the Gecko profile
- add Gecko's per-host Attic reader token to the attic-jwt-rotation config
- add an expired SOPS-encrypted `secrets/hosts/gecko-attic.yaml` placeholder so Nix eval has a real path and the rotator can bootstrap a real token

## Validation

- pre-commit hooks passed during commit under the repo devshell
- `jq empty cluster/k8s/agents/attic-jwt-rotation/rotators.json`
- `sops filestatus secrets/hosts/gecko-attic.yaml`
- `nix eval --json .#nixosConfigurations.gecko.config.nix.settings.substituters`
- `nix eval --json .#nixosConfigurations.gecko.config.nix.settings.trusted-public-keys`
- `nix eval --raw .#nixosConfigurations.gecko.config.nix.settings.netrc-file`
- `nix eval --raw .#nixosConfigurations.gecko.config.system.build.toplevel.drvPath`