### PR TITLE
gecko: increase vm memory to 4Gi

### DIFF
--- a/cluster/k8s/gecko/app/virtualmachine.yaml
+++ b/cluster/k8s/gecko/app/virtualmachine.yaml
@@ -48,7 +48,7 @@ spec:
           cores: 1
         resources:
           requests:
-            memory: 2Gi
+            memory: 4Gi
         firmware:
           bootloader:
             efi:


### PR DESCRIPTION
## Summary

- Increase the Gecko KubeVirt VM memory request from 2Gi to 4Gi.

## Validation

- `kubectl kustomize cluster/k8s/gecko/app | rg -n "kind: VirtualMachine|memory: 4Gi|name: gecko"`
- `nix develop -c pre-commit run --files cluster/k8s/gecko/app/virtualmachine.yaml`
- Live VM template patched and VMI restarted; KubeVirt reports `guestCurrent=4Gi`.
- Public SSH smoke test after restart: `free -h` reports 3.8Gi total memory in the guest.