### PR TITLE
home: gate dconf settings on GUI profiles

### DIFF
--- a/nix/home/home.nix
+++ b/nix/home/home.nix
@@ -76,9 +76,7 @@ in
     ./programs/gemini-cli.nix
     ./gemini_cli.nix
     ./shell/oh-my-posh.nix
-    ./modules/gnome-shell-keybindings.nix
     ./modules/gnome-custom-keybindings.nix
-    ./modules/flameshot-screenshots.nix
     ./modules/attic.nix
     ./modules/atuin.nix
     ./modules/buildbuddy.nix
@@ -86,6 +84,10 @@ in
     ./modules/sops-env.nix
     ./services/activitywatch.nix
     ./opencode
+  ]
+  ++ lib.optionals enableGui [
+    ./modules/gnome-shell-keybindings.nix
+    ./modules/flameshot-screenshots.nix
   ];
   ducktape.sopsEnv = {
     HF_TOKEN = {
@@ -379,19 +381,23 @@ in
 
   fonts.fontconfig.enable = enableGui;
 
-  home.activation.fixMimeApps = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-    run ${pkgs.xdg-utils}/bin/xdg-mime default google-chrome.desktop text/html
-    run ${pkgs.xdg-utils}/bin/xdg-mime default org.gnome.Evince.desktop application/pdf
-    run ${pkgs.xdg-utils}/bin/xdg-mime default remote-viewer.desktop application/x-virt-viewer
-  '';
+  home.activation.fixMimeApps = lib.mkIf enableGui (
+    lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      run ${pkgs.xdg-utils}/bin/xdg-mime default google-chrome.desktop text/html
+      run ${pkgs.xdg-utils}/bin/xdg-mime default org.gnome.Evince.desktop application/pdf
+      run ${pkgs.xdg-utils}/bin/xdg-mime default remote-viewer.desktop application/x-virt-viewer
+    ''
+  );
 
-  ducktape.gnomeCustomKeybindings.terminal = {
+  ducktape.gnomeCustomKeybindings.terminal = lib.mkIf enableGui {
     name = "Launch Terminal";
     command = "xdg-terminal-exec";
     binding = "<Primary><Alt>t";
   };
 
-  xdg.configFile."xdg-terminals.list".text = "org.gnome.Terminal.desktop\n";
+  xdg.configFile."xdg-terminals.list" = lib.mkIf enableGui {
+    text = "org.gnome.Terminal.desktop\n";
+  };
 
   xdg.dataFile."themes/Ducktape Shell/gnome-shell/gnome-shell.css" = lib.mkIf enableGui {
     text = ''
@@ -416,7 +422,7 @@ in
     '';
   };
 
-  xdg.autostart = {
+  xdg.autostart = lib.mkIf enableGui {
     enable = true;
     entries = [
       (pkgs.writeText "syncthing-gtk.desktop" ''
@@ -432,7 +438,7 @@ in
     ];
   };
 
-  dconf = {
+  dconf = lib.mkIf enableGui {
     enable = true;
     settings = {
       "org/gnome/desktop/wm/preferences" = {

--- a/nix/home/modules/gnome-custom-keybindings.nix
+++ b/nix/home/modules/gnome-custom-keybindings.nix
@@ -9,7 +9,12 @@
 #
 # This module collects all declarations and generates both the individual
 # dconf keybinding entries and the registry list that GNOME requires.
-{ lib, config, ... }:
+{
+  lib,
+  config,
+  enableGui,
+  ...
+}:
 let
   cfg = config.ducktape.gnomeCustomKeybindings;
   mediaKeys = "org/gnome/settings-daemon/plugins/media-keys";
@@ -28,15 +33,17 @@ in
     default = { };
   };
 
-  config.dconf.settings = {
-    ${mediaKeys} = {
-      custom-keybindings = map (n: "/${mediaKeys}/custom-keybindings/${n}/") (builtins.attrNames cfg);
-    };
-  }
-  // lib.mapAttrs' (
-    name: value:
-    lib.nameValuePair "${mediaKeys}/custom-keybindings/${name}" {
-      inherit (value) name command binding;
+  config = lib.mkIf enableGui {
+    dconf.settings = {
+      ${mediaKeys} = {
+        custom-keybindings = map (n: "/${mediaKeys}/custom-keybindings/${n}/") (builtins.attrNames cfg);
+      };
     }
-  ) cfg;
+    // lib.mapAttrs' (
+      name: value:
+      lib.nameValuePair "${mediaKeys}/custom-keybindings/${name}" {
+        inherit (value) name command binding;
+      }
+    ) cfg;
+  };
 }


### PR DESCRIPTION
## Summary

- Gate shared GNOME/dconf Home Manager config behind `enableGui`.
- Keep the `ducktape.gnomeCustomKeybindings` option import available for all hosts, while only emitting dconf settings on GUI hosts.
- Prevent headless Gecko from running the Home Manager `dconfSettings` activation step that fails without a dconf service.

## Validation

- `nix develop -c pre-commit run --files nix/home/home.nix nix/home/modules/gnome-custom-keybindings.nix`
- `nix eval --json .#nixosConfigurations.gecko.config.home-manager.users.agentydragon.dconf.settings` -> `{}`
- `nix eval --json --impure --expr 'let flake = builtins.getFlake (toString ./.); cfg = flake.nixosConfigurations.gecko.config.home-manager.users.agentydragon; in builtins.hasAttr "dconfSettings" cfg.home.activation'` -> `false`
- `nix eval --json .#nixosConfigurations.rugged.config.home-manager.users.agentydragon.dconf.settings` still returns GNOME settings