### PR TITLE
debundle: resolve simple anonymous selectors globally

### DIFF
--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -1067,6 +1067,7 @@ rust_library(
 
 rust_test(
     name = "selector_ir_lowering_test",
+    size = "small",
     crate = ":selector_ir_lowering",
     edition = "2024",
     deps = [
@@ -1090,6 +1091,7 @@ rust_library(
 
 rust_test(
     name = "selector_ir_solver_test",
+    size = "small",
     crate = ":selector_ir_solver",
     edition = "2024",
     deps = [

--- a/devinfra/js/debundle/e2e/BUILD.bazel
+++ b/devinfra/js/debundle/e2e/BUILD.bazel
@@ -25,118 +25,821 @@ rust_library(
     ],
 )
 
-# Standard e2e tests: shell out to the built debundler binary against
-# a fixture spec and assert on the emitted artifact tree. `:support`
-# depends on `:analysis` (for typed owner-graph helpers like
-# `owner_for_binding`), so it reaches every test transitively; tests that
-# name `analysis::` types directly still list `:analysis` themselves.
-_STANDARD_E2E_DEPS = [
-    ":support",
-    "@crates//:serde",
-    "@crates//:serde_json",
-    "@crates//:serde_yaml",
-    "@crates//:swc_common",
-    "@crates//:swc_ecma_ast",
-    "@crates//:swc_ecma_parser",
-    "@crates//:tempfile",
-    "@rules_rust//tools/runfiles",
-]
+rust_test(
+    name = "chunk_admission_test",
+    srcs = ["chunk_admission_test.rs"],
+    crate_root = "chunk_admission_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
 
-[
-    rust_test(
-        name = name,
-        srcs = ["{}.rs".format(name)],
-        crate_root = "{}.rs".format(name),
-        data = [
-            "//devinfra/js/debundle",
-            "@nodejs_linux_amd64//:bin/node",
-        ],
-        edition = "2024",
-        deps = _STANDARD_E2E_DEPS,
-    )
-    for name in [
-        "anonymous_statement_test",
-        "binding_group_adopt_names_test",
-        "chunk_admission_test",
-        "comma_list_owner_split_test",
-        "lowering_test",
-        "mini_factors_test",
-        "naturalization_test",
-        "naturalize_cross_scope_params_test",
-        "object_plain_data_calls_test",
-        "url_rebase_test",
-        "vendor_swap_test",
-        "identifier_rename_queue_test",
-        "sibling_declarator_steal_test",
-        "chunk_rename_cross_module_test",
-        "chunk_renames_test",
-        "rename_shadowed_inner_binding_test",
-        "rename_shorthand_destructure_test",
-        "rename_target_capture_test",
-        "member_comment_rename_test",
-        "export_local_heuristic_remap_test",
-        "missing_binding_member_test",
-        "residual_member_rename_test",
-        "source_order_emit_test",
-        "cross_module_emission_test",
-        "purity_test",
-        "import_coalescing_test",
-        "object_literal_import_collapse_test",
-        "object_literal_return_shorthand_drops_import_test",
-        "duplicate_export_test",
-        "duplicate_top_level_declaration_test",
-        "at_init_promotion_nested_closure_test",
-        "at_init_promotion_post_await_test",
-        "hoisted_var_declaration_test",
-        "export_default_purity_test",
-        "auto_grown_export_alias_collision_test",
-        "reserved_word_mint_test",
-        "runtime_tdz_on_imported_class_test",
-        "accepted_spec_runs_under_node_test",
-        "gate_rejection_scopes_to_bad_scc_test",
-        "lemma_one_linker_post_order_test",
-        "lemma_two_rescued_asymmetric_cycle_test",
-        "lemma_three_at_init_read_test",
-        "lemma_four_lazy_read_cycle_test",
-        "lemma_five_side_effect_order_test",
-        "asymmetric_non_residual_cycle_test",
-        "mediator_reaches_asymmetric_cycle_test",
-        "namespace_aggregator_split_tdz_test",
-        "pass_two_tdz_cut_diagnosis_test",
-        "spec_comments_test",
-        "selector_diagnostics_report_test",
-        "spec_validate_cli_test",
-        "syntactic_holes_test",
-        "cross_ref_lowering_test",
-    ]
-]
+rust_test(
+    name = "comma_list_owner_split_test",
+    srcs = ["comma_list_owner_split_test.rs"],
+    crate_root = "comma_list_owner_split_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
+
+rust_test(
+    name = "lowering_test",
+    srcs = ["lowering_test.rs"],
+    crate_root = "lowering_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
+
+rust_test(
+    name = "mini_factors_test",
+    srcs = ["mini_factors_test.rs"],
+    crate_root = "mini_factors_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
+
+rust_test(
+    name = "naturalization_test",
+    srcs = ["naturalization_test.rs"],
+    crate_root = "naturalization_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
+
+rust_test(
+    name = "naturalize_cross_scope_params_test",
+    srcs = ["naturalize_cross_scope_params_test.rs"],
+    crate_root = "naturalize_cross_scope_params_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
+
+rust_test(
+    name = "object_plain_data_calls_test",
+    srcs = ["object_plain_data_calls_test.rs"],
+    crate_root = "object_plain_data_calls_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
+
+rust_test(
+    name = "url_rebase_test",
+    srcs = ["url_rebase_test.rs"],
+    crate_root = "url_rebase_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
+
+rust_test(
+    name = "vendor_swap_test",
+    srcs = ["vendor_swap_test.rs"],
+    crate_root = "vendor_swap_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [
+        ":support",
+        "@crates//:serde_json",
+        "@crates//:tempfile",
+    ],
+)
+
+rust_test(
+    name = "identifier_rename_queue_test",
+    srcs = ["identifier_rename_queue_test.rs"],
+    crate_root = "identifier_rename_queue_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [
+        ":support",
+        "@crates//:serde_json",
+    ],
+)
+
+rust_test(
+    name = "chunk_rename_cross_module_test",
+    srcs = ["chunk_rename_cross_module_test.rs"],
+    crate_root = "chunk_rename_cross_module_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [
+        ":support",
+        "@crates//:serde_json",
+    ],
+)
+
+rust_test(
+    name = "chunk_renames_test",
+    srcs = ["chunk_renames_test.rs"],
+    crate_root = "chunk_renames_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [
+        ":support",
+        "@crates//:serde_json",
+    ],
+)
+
+rust_test(
+    name = "rename_shadowed_inner_binding_test",
+    srcs = ["rename_shadowed_inner_binding_test.rs"],
+    crate_root = "rename_shadowed_inner_binding_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
+
+rust_test(
+    name = "rename_shorthand_destructure_test",
+    srcs = ["rename_shorthand_destructure_test.rs"],
+    crate_root = "rename_shorthand_destructure_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
+
+rust_test(
+    name = "rename_target_capture_test",
+    srcs = ["rename_target_capture_test.rs"],
+    crate_root = "rename_target_capture_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
+
+rust_test(
+    name = "member_comment_rename_test",
+    srcs = ["member_comment_rename_test.rs"],
+    crate_root = "member_comment_rename_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
+
+rust_test(
+    name = "export_local_heuristic_remap_test",
+    srcs = ["export_local_heuristic_remap_test.rs"],
+    crate_root = "export_local_heuristic_remap_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
+
+rust_test(
+    name = "missing_binding_member_test",
+    srcs = ["missing_binding_member_test.rs"],
+    crate_root = "missing_binding_member_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [
+        ":support",
+        "@crates//:serde_json",
+    ],
+)
+
+rust_test(
+    name = "residual_member_rename_test",
+    srcs = ["residual_member_rename_test.rs"],
+    crate_root = "residual_member_rename_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
+
+rust_test(
+    name = "source_order_emit_test",
+    srcs = ["source_order_emit_test.rs"],
+    crate_root = "source_order_emit_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
+
+rust_test(
+    name = "purity_test",
+    srcs = ["purity_test.rs"],
+    crate_root = "purity_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [
+        ":support",
+        "@crates//:serde_json",
+    ],
+)
+
+rust_test(
+    name = "object_literal_import_collapse_test",
+    srcs = ["object_literal_import_collapse_test.rs"],
+    crate_root = "object_literal_import_collapse_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
+
+rust_test(
+    name = "object_literal_return_shorthand_drops_import_test",
+    srcs = ["object_literal_return_shorthand_drops_import_test.rs"],
+    crate_root = "object_literal_return_shorthand_drops_import_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
+
+rust_test(
+    name = "duplicate_export_test",
+    srcs = ["duplicate_export_test.rs"],
+    crate_root = "duplicate_export_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
+
+rust_test(
+    name = "at_init_promotion_nested_closure_test",
+    srcs = ["at_init_promotion_nested_closure_test.rs"],
+    crate_root = "at_init_promotion_nested_closure_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
+
+rust_test(
+    name = "at_init_promotion_post_await_test",
+    srcs = ["at_init_promotion_post_await_test.rs"],
+    crate_root = "at_init_promotion_post_await_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
+
+rust_test(
+    name = "hoisted_var_declaration_test",
+    srcs = ["hoisted_var_declaration_test.rs"],
+    crate_root = "hoisted_var_declaration_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
+
+rust_test(
+    name = "export_default_purity_test",
+    srcs = ["export_default_purity_test.rs"],
+    crate_root = "export_default_purity_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
+
+rust_test(
+    name = "auto_grown_export_alias_collision_test",
+    srcs = ["auto_grown_export_alias_collision_test.rs"],
+    crate_root = "auto_grown_export_alias_collision_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
+
+rust_test(
+    name = "reserved_word_mint_test",
+    srcs = ["reserved_word_mint_test.rs"],
+    crate_root = "reserved_word_mint_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [
+        ":support",
+        "@crates//:swc_ecma_ast",
+    ],
+)
+
+rust_test(
+    name = "runtime_tdz_on_imported_class_test",
+    srcs = ["runtime_tdz_on_imported_class_test.rs"],
+    crate_root = "runtime_tdz_on_imported_class_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
+
+rust_test(
+    name = "accepted_spec_runs_under_node_test",
+    srcs = ["accepted_spec_runs_under_node_test.rs"],
+    crate_root = "accepted_spec_runs_under_node_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
+
+rust_test(
+    name = "gate_rejection_scopes_to_bad_scc_test",
+    srcs = ["gate_rejection_scopes_to_bad_scc_test.rs"],
+    crate_root = "gate_rejection_scopes_to_bad_scc_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [
+        ":support",
+        "@crates//:serde_json",
+    ],
+)
+
+rust_test(
+    name = "lemma_one_linker_post_order_test",
+    srcs = ["lemma_one_linker_post_order_test.rs"],
+    crate_root = "lemma_one_linker_post_order_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
+
+rust_test(
+    name = "lemma_two_rescued_asymmetric_cycle_test",
+    srcs = ["lemma_two_rescued_asymmetric_cycle_test.rs"],
+    crate_root = "lemma_two_rescued_asymmetric_cycle_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
+
+rust_test(
+    name = "lemma_three_at_init_read_test",
+    srcs = ["lemma_three_at_init_read_test.rs"],
+    crate_root = "lemma_three_at_init_read_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
+
+rust_test(
+    name = "lemma_four_lazy_read_cycle_test",
+    srcs = ["lemma_four_lazy_read_cycle_test.rs"],
+    crate_root = "lemma_four_lazy_read_cycle_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
+
+rust_test(
+    name = "lemma_five_side_effect_order_test",
+    srcs = ["lemma_five_side_effect_order_test.rs"],
+    crate_root = "lemma_five_side_effect_order_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
+
+rust_test(
+    name = "asymmetric_non_residual_cycle_test",
+    srcs = ["asymmetric_non_residual_cycle_test.rs"],
+    crate_root = "asymmetric_non_residual_cycle_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
+
+rust_test(
+    name = "mediator_reaches_asymmetric_cycle_test",
+    srcs = ["mediator_reaches_asymmetric_cycle_test.rs"],
+    crate_root = "mediator_reaches_asymmetric_cycle_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
+
+rust_test(
+    name = "namespace_aggregator_split_tdz_test",
+    srcs = ["namespace_aggregator_split_tdz_test.rs"],
+    crate_root = "namespace_aggregator_split_tdz_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
+
+rust_test(
+    name = "pass_two_tdz_cut_diagnosis_test",
+    srcs = ["pass_two_tdz_cut_diagnosis_test.rs"],
+    crate_root = "pass_two_tdz_cut_diagnosis_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [
+        ":support",
+        "@crates//:serde_json",
+    ],
+)
+
+rust_test(
+    name = "cross_ref_lowering_test",
+    srcs = ["cross_ref_lowering_test.rs"],
+    crate_root = "cross_ref_lowering_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
+
+rust_test(
+    name = "anonymous_statement_test",
+    size = "small",
+    srcs = ["anonymous_statement_test.rs"],
+    crate_root = "anonymous_statement_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
+
+rust_test(
+    name = "binding_group_adopt_names_test",
+    size = "small",
+    srcs = ["binding_group_adopt_names_test.rs"],
+    crate_root = "binding_group_adopt_names_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
+
+rust_test(
+    name = "cross_module_emission_test",
+    size = "small",
+    srcs = ["cross_module_emission_test.rs"],
+    crate_root = "cross_module_emission_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [
+        ":support",
+        "@crates//:serde_json",
+    ],
+)
+
+rust_test(
+    name = "duplicate_top_level_declaration_test",
+    size = "small",
+    srcs = ["duplicate_top_level_declaration_test.rs"],
+    crate_root = "duplicate_top_level_declaration_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
+
+rust_test(
+    name = "import_coalescing_test",
+    size = "small",
+    srcs = ["import_coalescing_test.rs"],
+    crate_root = "import_coalescing_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [
+        ":support",
+        "@crates//:serde_json",
+        "@crates//:swc_ecma_ast",
+    ],
+)
+
+rust_test(
+    name = "selector_diagnostics_report_test",
+    size = "small",
+    srcs = ["selector_diagnostics_report_test.rs"],
+    crate_root = "selector_diagnostics_report_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [
+        ":support",
+        "@crates//:serde_json",
+    ],
+)
+
+rust_test(
+    name = "sibling_declarator_steal_test",
+    size = "small",
+    srcs = ["sibling_declarator_steal_test.rs"],
+    crate_root = "sibling_declarator_steal_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [
+        ":support",
+        "@crates//:serde_json",
+    ],
+)
+
+rust_test(
+    name = "spec_comments_test",
+    size = "small",
+    srcs = ["spec_comments_test.rs"],
+    crate_root = "spec_comments_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
+
+rust_test(
+    name = "spec_validate_cli_test",
+    size = "small",
+    srcs = ["spec_validate_cli_test.rs"],
+    crate_root = "spec_validate_cli_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [
+        ":support",
+        "@crates//:serde_json",
+    ],
+)
+
+rust_test(
+    name = "syntactic_holes_test",
+    size = "small",
+    srcs = ["syntactic_holes_test.rs"],
+    crate_root = "syntactic_holes_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
 
 # E2E tests that also inspect the in-process analysis types
 # (`OwnerGraphReport`, `BindingReport`, etc.) emitted alongside the
 # debundler's text output. These need a direct dep on `:analysis`.
-[
-    rust_test(
-        name = name,
-        srcs = ["{}.rs".format(name)],
-        crate_root = "{}.rs".format(name),
-        data = [
-            "//devinfra/js/debundle",
-            "@nodejs_linux_amd64//:bin/node",
-        ],
-        edition = "2024",
-        deps = _STANDARD_E2E_DEPS + ["//devinfra/js/debundle:analysis"],
-    )
-    for name in [
-        "realizability_test",
-        "owner_graph_purity_reason_test",
-        "at_init_promotion_fndecl_direct_read_test",
-        "at_init_cross_module_call_body_reads_test",
-        "at_init_s_chain_dataflow_test",
-        "at_init_unresolved_callee_test",
-        "pure_members_test",
-        "s_chain_dataflow_soundness_test",
-    ]
-]
+rust_test(
+    name = "realizability_test",
+    srcs = ["realizability_test.rs"],
+    crate_root = "realizability_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [
+        ":support",
+        "//devinfra/js/debundle:analysis",
+        "@crates//:serde_json",
+    ],
+)
+
+rust_test(
+    name = "owner_graph_purity_reason_test",
+    srcs = ["owner_graph_purity_reason_test.rs"],
+    crate_root = "owner_graph_purity_reason_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [
+        ":support",
+        "//devinfra/js/debundle:analysis",
+        "@crates//:serde_json",
+    ],
+)
+
+rust_test(
+    name = "at_init_promotion_fndecl_direct_read_test",
+    srcs = ["at_init_promotion_fndecl_direct_read_test.rs"],
+    crate_root = "at_init_promotion_fndecl_direct_read_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [
+        ":support",
+        "//devinfra/js/debundle:analysis",
+    ],
+)
+
+rust_test(
+    name = "at_init_cross_module_call_body_reads_test",
+    srcs = ["at_init_cross_module_call_body_reads_test.rs"],
+    crate_root = "at_init_cross_module_call_body_reads_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [
+        ":support",
+        "//devinfra/js/debundle:analysis",
+    ],
+)
+
+rust_test(
+    name = "at_init_s_chain_dataflow_test",
+    srcs = ["at_init_s_chain_dataflow_test.rs"],
+    crate_root = "at_init_s_chain_dataflow_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [
+        ":support",
+        "//devinfra/js/debundle:analysis",
+    ],
+)
+
+rust_test(
+    name = "at_init_unresolved_callee_test",
+    srcs = ["at_init_unresolved_callee_test.rs"],
+    crate_root = "at_init_unresolved_callee_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [
+        ":support",
+        "//devinfra/js/debundle:analysis",
+    ],
+)
+
+rust_test(
+    name = "pure_members_test",
+    srcs = ["pure_members_test.rs"],
+    crate_root = "pure_members_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [
+        ":support",
+        "//devinfra/js/debundle:analysis",
+        "@crates//:serde_json",
+    ],
+)
+
+rust_test(
+    name = "s_chain_dataflow_soundness_test",
+    srcs = ["s_chain_dataflow_soundness_test.rs"],
+    crate_root = "s_chain_dataflow_soundness_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [
+        ":support",
+        "//devinfra/js/debundle:analysis",
+    ],
+)
 
 # Node-differential sweep: drives the real pipeline per fixture, then
 # compares the gate simulator's predicted evaluation post-order
@@ -152,9 +855,12 @@ rust_test(
         "@nodejs_linux_amd64//:bin/node",
     ],
     edition = "2024",
-    deps = _STANDARD_E2E_DEPS + [
+    deps = [
+        ":support",
         "//devinfra/js/debundle:analysis",
         "//devinfra/js/debundle:gate",
+        "@crates//:swc_common",
+        "@crates//:swc_ecma_parser",
     ],
 )
 
@@ -162,6 +868,7 @@ rust_test(
 # directly alongside the standard fixture pipeline.
 rust_test(
     name = "peel_factorize_landability_test",
+    size = "small",
     srcs = ["peel_factorize_landability_test.rs"],
     crate_root = "peel_factorize_landability_test.rs",
     data = [
@@ -174,9 +881,7 @@ rust_test(
         "//devinfra/js/debundle:analysis",
         "//devinfra/js/debundle:peel",
         "//devinfra/js/debundle:spec",
-        "@crates//:serde",
         "@crates//:serde_json",
-        "@rules_rust//tools/runfiles",
     ],
 )
 
@@ -184,6 +889,7 @@ rust_test(
 # into the extension of their target active module.
 rust_test(
     name = "peel_factorize_extend_anonymous_test",
+    size = "small",
     srcs = ["peel_factorize_extend_anonymous_test.rs"],
     crate_root = "peel_factorize_extend_anonymous_test.rs",
     data = [
@@ -196,9 +902,6 @@ rust_test(
         "//devinfra/js/debundle:analysis",
         "//devinfra/js/debundle:peel",
         "//devinfra/js/debundle:spec",
-        "@crates//:serde",
-        "@crates//:serde_json",
-        "@rules_rust//tools/runfiles",
     ],
 )
 
@@ -410,7 +1113,6 @@ rust_test(
     edition = "2024",
     deps = [
         ":support",
-        "@crates//:serde_json",
         "@crates//:tempfile",
     ],
 )
@@ -426,7 +1128,6 @@ rust_test(
     edition = "2024",
     deps = [
         ":support",
-        "@crates//:serde_json",
         "@crates//:tempfile",
     ],
 )
@@ -495,7 +1196,6 @@ rust_test(
         "//devinfra/js/debundle:analysis",
         "//devinfra/js/debundle:peel",
         "//devinfra/js/debundle:report_fixtures",
-        "//devinfra/js/debundle:spec",
         "@crates//:serde_json",
         "@crates//:tempfile",
     ],
@@ -537,6 +1237,7 @@ rust_test(
 # explicit `--apply` mutation of member-form source_match selectors.
 rust_test(
     name = "selector_codemod_cli_test",
+    size = "small",
     srcs = ["selector_codemod_cli_test.rs"],
     crate_root = "selector_codemod_cli_test.rs",
     data = ["//devinfra/js/debundle"],
@@ -544,7 +1245,6 @@ rust_test(
     deps = [
         ":support",
         "@crates//:regex",
-        "@crates//:serde_json",
         "@crates//:serde_yaml",
         "@crates//:tempfile",
     ],
@@ -579,7 +1279,6 @@ rust_test(
     deps = [
         ":support",
         "//devinfra/js/debundle:js_ast",
-        "@crates//:serde_json",
         "@crates//:serde_yaml",
         "@crates//:tempfile",
     ],
@@ -600,7 +1299,10 @@ rust_test(
         "@nodejs_linux_amd64//:bin/node",
     ],
     edition = "2024",
-    deps = _STANDARD_E2E_DEPS,
+    deps = [
+        ":support",
+        "@crates//:serde_json",
+    ],
 )
 
 # `debundle scc` filters + `debundle cluster` neighbors against a
@@ -642,7 +1344,6 @@ rust_test(
         "//devinfra/js/debundle:analysis",
         "//devinfra/js/debundle:peel",
         "//devinfra/js/debundle:report_fixtures",
-        "//devinfra/js/debundle:spec",
         "@crates//:serde_json",
         "@crates//:tempfile",
     ],

--- a/devinfra/js/debundle/e2e/anonymous_statement_test.rs
+++ b/devinfra/js/debundle/e2e/anonymous_statement_test.rs
@@ -931,25 +931,33 @@ export { runtimeLocalPart, runtimeDomain, runtimeAddress, duplicateLocalPart };
 
 #[test]
 fn binding_group_source_match_extracts_multiple_bindings_from_multideclarator() {
-    let fixture = run_fixture(FixtureOpts::new(
-        r#"let runtimeA = 100,
+    let fixture = run_fixture_with_env(
+        FixtureOpts::new(
+            r#"let runtimeA = 100,
   runtimeB = null,
   runtimeC = `${runtimeA}:${runtimeB === null}:bar`;
 const Existing = "existing";
 console.log(runtimeA, runtimeB === null, runtimeC, Existing);
 export { runtimeA, runtimeB, runtimeC, Existing };
 "#,
-        vec![logical_module_with_binding_groups(
-            "selected_values",
-            &[],
-            &[BindingGroup::source_alpha(
-                r#"let a = 100,
+            vec![logical_module_with_binding_groups(
+                "selected_values",
+                &[],
+                &[BindingGroup::source_alpha(
+                    r#"let a = 100,
   b = null,
   c = `${a}:${b === null}:bar`;"#,
-                &[("a", "NameA"), ("b", "NameB"), ("c", "NameC")],
+                    &[("a", "NameA"), ("b", "NameB"), ("c", "NameC")],
+                )],
             )],
-        )],
-    ));
+        ),
+        &[("DUCKTAPE_SOURCE_MATCH_TIMINGS", "1")],
+    );
+    assert!(
+        !fixture.stderr.contains("[debundle source_match]"),
+        "native binding_group source_match should not call the legacy resolver\nstderr:\n{}",
+        fixture.stderr
+    );
 
     let mut exports =
         list_module_exports(&fixture.out_root, "static/app/modules/selected_values.js");
@@ -1011,8 +1019,8 @@ export { siblingBinding, runtimeBinding, Existing };
     );
     assert_entry_output(&fixture, "selected other existing\n");
     assert!(
-        fixture.stderr.contains("[debundle source_match]"),
-        "var-declaration target_binding source_match remains on the legacy resolver until open-list constraints are native\nstderr:\n{}",
+        !fixture.stderr.contains("[debundle source_match]"),
+        "var-declaration target_binding source_match should stay on the native global solver path\nstderr:\n{}",
         fixture.stderr,
     );
 }

--- a/devinfra/js/debundle/e2e/cross_module_emission_test.rs
+++ b/devinfra/js/debundle/e2e/cross_module_emission_test.rs
@@ -424,7 +424,7 @@ export { RuntimeCatalog };
 }
 
 #[test]
-fn repeated_source_match_selectors_reuse_chunk_cache_across_modules() {
+fn repeated_source_match_selectors_use_native_solver_across_modules() {
     let class_selector = r#"class K {
   CLASS_REST;
   label() {
@@ -488,8 +488,8 @@ export { RuntimeCatalog };
         })
         .count();
     assert_eq!(
-        timing_lines, 1,
-        "CLASS_REST selectors should reuse one cached legacy resolution across modules\nstderr:\n{stderr}",
+        timing_lines, 0,
+        "CLASS_REST selectors should stay in the global solver instead of falling back to legacy source_match resolution\nstderr:\n{stderr}",
     );
 }
 

--- a/devinfra/js/debundle/lowering/anonymous.rs
+++ b/devinfra/js/debundle/lowering/anonymous.rs
@@ -6,6 +6,7 @@
 //! `eq_ignore_span` compare the source-level identifier shape.
 
 use super::*;
+use crate::plans::AnonymousStatementRequest;
 
 #[derive(Debug, Clone)]
 pub(super) struct ResolvedAnonymousStatement {
@@ -53,39 +54,33 @@ fn one_anonymous_group(
     }
 }
 
-/// Resolve every anonymous statement entry on `request` to a pre-split body
-/// index in the chunk's top-level body, via the selector resolver seam. The
-/// resolver requires exactly one match per entry — a 0-match or ambiguous-match
-/// selector is a spec error.
-pub(super) fn resolve_anonymous_statement_ordinals(
-    request: &LogicalRequest,
+pub(super) fn resolve_anonymous_statement_request(
+    request_id: &str,
+    statement: &AnonymousStatementRequest,
     resolver: &dyn source_match::SelectorResolver,
     keep_going: bool,
     diagnostics: &mut Vec<AnonymousStatementDiagnostic>,
 ) -> Result<Vec<ResolvedAnonymousStatement>> {
-    let mut resolved = Vec::new();
-    for statement in &request.anonymous_statements {
-        let ordinals = match resolver
-            .resolve_anonymous_groups(&request.id, &statement.selector)
-            .and_then(|groups| one_anonymous_group(&request.id, &statement.selector, groups))
-        {
-            Ok(ordinals) => ordinals,
-            Err(error) if keep_going => {
-                diagnostics.push(AnonymousStatementDiagnostic {
-                    module_id: request.id.clone(),
-                    selector: statement.selector.clone(),
-                    message: format!("{error:#}"),
-                });
-                continue;
-            }
-            Err(error) => return Err(error),
-        };
-        for ordinal in ordinals {
-            resolved.push(ResolvedAnonymousStatement {
-                ordinal,
-                comment: statement.comment.clone(),
+    let ordinals = match resolver
+        .resolve_anonymous_groups(request_id, &statement.selector)
+        .and_then(|groups| one_anonymous_group(request_id, &statement.selector, groups))
+    {
+        Ok(ordinals) => ordinals,
+        Err(error) if keep_going => {
+            diagnostics.push(AnonymousStatementDiagnostic {
+                module_id: request_id.to_string(),
+                selector: statement.selector.clone(),
+                message: format!("{error:#}"),
             });
+            return Ok(Vec::new());
         }
-    }
-    Ok(resolved)
+        Err(error) => return Err(error),
+    };
+    Ok(ordinals
+        .into_iter()
+        .map(|ordinal| ResolvedAnonymousStatement {
+            ordinal,
+            comment: statement.comment.clone(),
+        })
+        .collect())
 }

--- a/devinfra/js/debundle/lowering/exports.rs
+++ b/devinfra/js/debundle/lowering/exports.rs
@@ -204,7 +204,7 @@ pub(super) fn reject_duplicate_member_bindings(
 ) -> Result<()> {
     let mut by_binding = BTreeMap::<String, Vec<&MemberRequest>>::new();
     for member in members {
-        if member.binding.is_empty() {
+        if member.resolves_after_stage_a() {
             continue;
         }
         by_binding

--- a/devinfra/js/debundle/lowering/materialize/mod.rs
+++ b/devinfra/js/debundle/lowering/materialize/mod.rs
@@ -173,15 +173,14 @@ pub(super) fn materialize_logical_chunk(
     let mut imported_binding_resolver =
         ArtifactSourceImportResolutionCache::new(artifact, artifact_indexes);
     let mut imported_from_by_src = BTreeMap::<String, String>::new();
-    // One selector resolver for the whole chunk, shared across every request's
-    // member and binding-group resolution (built once — see the seam contract in
+    // One selector resolver for the whole chunk, shared by global-selector
+    // fallback facts (built once — see the seam contract in
     // `source_match::SelectorResolver`). The fact-based `ChunkResolver` is the
     // production resolver: it builds the chunk's EDB once and resolves every
     // selector against it, at parity with the former hand-rolled matcher (proven
     // by the corpus differential, <debug/2026_06_18_per_chunk_gate_real_source.md>).
     let selector_resolver = source_match::ChunkResolver::new(&runtime_ast.module);
     let explicit_request_ctx = ExplicitRequestContext {
-        selector_resolver: &selector_resolver,
         declaration_by_name: &declaration_by_name,
         chunk_top_level_mark,
         target_dir,
@@ -200,7 +199,6 @@ pub(super) fn materialize_logical_chunk(
     }
     builder.drop_explicit_request_scratch();
     builder.pull_destructure_siblings(&destructure_siblings, chunk_top_level_mark)?;
-    builder.adopt_bindings_of_claimed_anonymous_statements(&declarations);
     builder.add_residual_sweep(
         residual_request.as_ref(),
         chunk_unassigned_mode.catchall_file_target(),
@@ -306,6 +304,7 @@ pub(super) fn materialize_logical_chunk(
             &declaration_by_name,
         )
     })?;
+    builder.adopt_bindings_of_claimed_anonymous_statements(&declarations);
     drop(imported_binding_resolver);
     time_phase!(timings, "fold_rebind_atomic_units", {
         apply_stage_one_a5(&mut builder, &precomputed);

--- a/devinfra/js/debundle/lowering/materialize/plan_builder.rs
+++ b/devinfra/js/debundle/lowering/materialize/plan_builder.rs
@@ -6,7 +6,7 @@
 
 use super::super::ordinal::body_index_for_statement_ordinal;
 use super::*;
-use crate::plans::RelationalSelector;
+use crate::plans::{AnonymousStatementRequest, RelationalSelector};
 use analysis::StatementOrdinal;
 use anyhow::anyhow;
 
@@ -33,6 +33,13 @@ struct SourceMatchTargetInfo {
     selector: spec::AnonymousStatementSelector,
     selector_key: String,
     group_assignment: Option<SourceMatchGroupAssignment>,
+}
+
+#[derive(Debug, Clone)]
+struct AnonymousStatementTargetInfo {
+    target: SelectorTargetId,
+    request_index: usize,
+    statement: AnonymousStatementRequest,
 }
 
 impl DuplicateBindingClaim {
@@ -128,7 +135,7 @@ fn resolved_anchor_bindings(
     let mut anchor_binding: HashMap<String, Option<String>> = HashMap::new();
     for request in explicit_requests {
         for member in &request.members {
-            if member.binding.is_empty() {
+            if member.resolves_after_stage_a() {
                 continue;
             }
             anchor_binding
@@ -242,7 +249,7 @@ fn member_selector_spec_for_global_solver(
         });
     }
 
-    if member.binding.is_empty() || member.is_import_specifier {
+    if member.resolves_after_stage_a() || member.is_import_specifier {
         return None;
     }
     Some(spec::MemberSelectorSpec::Binding(spec::BindingSelector {
@@ -759,6 +766,30 @@ fn render_anonymous_statement_diagnostics(diagnostics: &[AnonymousStatementDiagn
     report
 }
 
+fn anonymous_statement_no_match_message(
+    request: &LogicalRequest,
+    statement: &AnonymousStatementRequest,
+) -> String {
+    format!(
+        "logical_module {}: anonymous_statements[].match did not match any top-level statement \
+         group in the chunk. Selector:\n{}",
+        request.id, statement.selector.match_source,
+    )
+}
+
+fn anonymous_statement_ambiguous_message(
+    request: &LogicalRequest,
+    statement: &AnonymousStatementRequest,
+    candidate_count: usize,
+    body_indices: &[usize],
+) -> String {
+    format!(
+        "logical_module {}: anonymous_statements[].match is ambiguous -- matched {} top-level \
+         statement groups at body indices {:?}. Refine the selector. Source:\n{}",
+        request.id, candidate_count, body_indices, statement.selector.match_source,
+    )
+}
+
 /// Output of `ChunkPlanBuilder::finalize`: everything downstream
 /// `lower_chunk` + the chunk-report builder need from the plan
 /// construction phase.
@@ -772,12 +803,6 @@ pub(super) struct ChunkPlan {
 
 /// Per-explicit-request inputs the builder reads but does not own.
 pub(super) struct ExplicitRequestContext<'a> {
-    /// The selector resolver, built once for this chunk (see
-    /// `materialize_chunk`) and shared across anonymous statement resolution and
-    /// the global selector pass. Carrying the resolver rather than rebuilding it
-    /// per request is what keeps a fact-based resolver's per-chunk EDB
-    /// construction off the hot path.
-    pub(super) selector_resolver: &'a dyn source_match::SelectorResolver,
     pub(super) declaration_by_name: &'a HashMap<Id, usize>,
     pub(super) chunk_top_level_mark: swc_common::Mark,
     pub(super) target_dir: &'a str,
@@ -879,10 +904,12 @@ impl ChunkPlanBuilder {
     }
 
     /// Process one explicit (non-residual) logical-module request:
-    /// resolve its anonymous-statement matches, claim each named
-    /// member, and append a `ModulePlan`. Duplicate-claim detection
-    /// across all explicit requests is keyed by binding-name via the
-    /// builder's `catalogue_index_by_name` scratch index.
+    /// claim each pre-Stage-A named member, and append a `ModulePlan`.
+    /// Solver-resolved members and anonymous statement selectors are left
+    /// unclaimed until `resolve_and_claim_global_selectors` runs over Stage A
+    /// facts. Duplicate-claim detection across all explicit requests is keyed
+    /// by binding-name via the builder's `catalogue_index_by_name` scratch
+    /// index.
     pub(super) fn add_explicit_request(
         &mut self,
         index: usize,
@@ -893,49 +920,6 @@ impl ChunkPlanBuilder {
     ) -> Result<()> {
         reject_duplicate_member_bindings("logical_module", &request.id, &request.members)?;
         let mut bindings = HashMap::<String, String>::new();
-        let anonymous_statement_claims = resolve_anonymous_statement_ordinals(
-            request,
-            ctx.selector_resolver,
-            self.keep_going,
-            &mut self.anonymous_statement_diagnostics,
-        )?;
-        for claim in &anonymous_statement_claims {
-            if let Some(existing) = self
-                .anonymous_ordinal_assignment
-                .get(&claim.ordinal)
-                .copied()
-            {
-                let existing_id: String = self
-                    .module_plans
-                    .get(existing)
-                    .map(|plan: &ModulePlan| plan.id.clone())
-                    .unwrap_or_else(|| format!("<plan#{existing}>"));
-                bail!(
-                    "anonymous_statements[].match in module {} also matches the \
-                     top-level statement at ordinal {} already claimed by module {}; \
-                     each anonymous statement may belong to at most one logical \
-                     module.",
-                    request.id,
-                    claim.ordinal,
-                    existing_id,
-                );
-            }
-            self.anonymous_ordinal_assignment
-                .insert(claim.ordinal, index);
-        }
-        let anonymous_statement_ordinals: Vec<usize> = anonymous_statement_claims
-            .iter()
-            .map(|claim| claim.ordinal)
-            .collect();
-        let anonymous_statement_comments: BTreeMap<usize, String> = anonymous_statement_claims
-            .iter()
-            .filter_map(|claim| {
-                claim
-                    .comment
-                    .as_ref()
-                    .map(|comment| (claim.ordinal, comment.clone()))
-            })
-            .collect();
         let dest_target_file = target_file_for_request(ctx.target_dir, &request.target_path)?;
         let module_id = ModuleId(LogicalModuleIndex(index));
         let mut duplicate_bindings = BTreeSet::<String>::new();
@@ -943,7 +927,7 @@ impl ChunkPlanBuilder {
             // Deferred selector members resolve in the global selector pass after
             // Stage A has produced the owner graph and selector fact store. Until
             // then their `binding` is empty, so they contribute nothing here.
-            if member.is_relational() || member.source_match.is_some() {
+            if member.resolves_after_stage_a() {
                 continue;
             }
             if let Some(existing_kind) = self.catalogue_index_by_name.get(member.binding.as_str()) {
@@ -1055,7 +1039,7 @@ impl ChunkPlanBuilder {
         let binding_comments: BTreeMap<String, String> = request
             .members
             .iter()
-            .filter(|member| !member.is_relational() && member.source_match.is_none())
+            .filter(|member| !member.resolves_after_stage_a())
             .filter(|member| !duplicate_bindings.contains(member.binding.as_str()))
             .filter_map(|member| {
                 member
@@ -1067,7 +1051,7 @@ impl ChunkPlanBuilder {
         let binding_claim_origins: BTreeMap<String, String> = request
             .members
             .iter()
-            .filter(|member| !member.is_relational() && member.source_match.is_none())
+            .filter(|member| !member.resolves_after_stage_a())
             .filter(|member| !duplicate_bindings.contains(member.binding.as_str()))
             .map(|member| (member.binding.clone(), member.claim_origin.clone()))
             .collect();
@@ -1077,13 +1061,99 @@ impl ChunkPlanBuilder {
             target_path: request.target_path.clone(),
             explicit: true,
             bindings,
-            anonymous_statement_ordinals,
-            anonymous_statement_comments,
+            anonymous_statement_ordinals: Vec::new(),
+            anonymous_statement_comments: BTreeMap::new(),
             comment: request.comment.clone(),
             binding_comments,
             binding_claim_origins,
         });
         Ok(())
+    }
+
+    fn claim_anonymous_statement(
+        &mut self,
+        module_index: usize,
+        request_id: &str,
+        claim: &ResolvedAnonymousStatement,
+    ) -> Result<()> {
+        if let Some(existing) = self
+            .anonymous_ordinal_assignment
+            .get(&claim.ordinal)
+            .copied()
+        {
+            let existing_id: String = self
+                .module_plans
+                .get(existing)
+                .map(|plan: &ModulePlan| plan.id.clone())
+                .unwrap_or_else(|| format!("<plan#{existing}>"));
+            bail!(
+                "anonymous_statements[].match in module {} also matches the top-level \
+                 statement at body index {} already claimed by module {}; each anonymous \
+                 statement may belong to at most one logical module.",
+                request_id,
+                claim.ordinal,
+                existing_id,
+            );
+        }
+        self.anonymous_ordinal_assignment
+            .insert(claim.ordinal, module_index);
+        let plan = self.module_plans.get_mut(module_index).with_context(|| {
+            format!(
+                "logical_module {request_id}: anonymous statement resolved before its module plan existed"
+            )
+        })?;
+        plan.anonymous_statement_ordinals.push(claim.ordinal);
+        plan.anonymous_statement_ordinals.sort_unstable();
+        plan.anonymous_statement_ordinals.dedup();
+        if let Some(comment) = &claim.comment {
+            plan.anonymous_statement_comments
+                .insert(claim.ordinal, comment.clone());
+        }
+        Ok(())
+    }
+
+    fn claim_anonymous_statement_from_solver(
+        &mut self,
+        module: &swc_ecma_ast::Module,
+        module_index: usize,
+        request_id: &str,
+        statement: &AnonymousStatementRequest,
+        claim: &ResolvedClaim,
+    ) -> Result<()> {
+        let body_index = body_index_for_statement_ordinal(&module.body, claim.statement_ordinal.0)
+            .with_context(|| {
+                format!(
+                    "logical_module {request_id}: global selector solver resolved anonymous \
+                     statement to post-split ordinal {} which has no source body item",
+                    claim.statement_ordinal.0,
+                )
+            })?;
+        self.claim_anonymous_statement(
+            module_index,
+            request_id,
+            &ResolvedAnonymousStatement {
+                ordinal: body_index,
+                comment: statement.comment.clone(),
+            },
+        )
+    }
+
+    fn record_anonymous_statement_failure_or_bail(
+        &mut self,
+        request: &LogicalRequest,
+        statement: &AnonymousStatementRequest,
+        message: String,
+    ) -> Result<()> {
+        if self.keep_going {
+            self.anonymous_statement_diagnostics
+                .push(AnonymousStatementDiagnostic {
+                    module_id: request.id.clone(),
+                    selector: statement.selector.clone(),
+                    message,
+                });
+            return Ok(());
+        }
+        bail!("{message}")
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1103,11 +1173,14 @@ impl ChunkPlanBuilder {
         chunk_id_interned: ChunkId,
         declaration_by_name: &HashMap<Id, usize>,
     ) -> Result<()> {
-        if explicit_requests
+        let has_deferred_members = explicit_requests
             .iter()
             .flat_map(|request| &request.members)
-            .all(|member| !member.is_relational() && member.source_match.is_none())
-        {
+            .any(MemberRequest::resolves_after_stage_a);
+        let has_anonymous_statements = explicit_requests
+            .iter()
+            .any(|request| !request.anonymous_statements.is_empty());
+        if !has_deferred_members && !has_anonymous_statements {
             return Ok(());
         }
 
@@ -1131,47 +1204,75 @@ impl ChunkPlanBuilder {
             Result<Vec<source_match::MemberBindingGroupMatch>, String>,
         >::new();
         let mut source_match_targets = Vec::<SourceMatchTargetInfo>::new();
+        let mut anonymous_statement_targets = Vec::<AnonymousStatementTargetInfo>::new();
         let mut pending_constraints = Vec::<(String, String, spec::MemberSelectorSpec)>::new();
-        let source_match_ordinal_by_binding =
-            source_match_candidate_statement_ordinals(owner_graph);
-        let mut facts =
-            selector_fact_store_for_chunk(chunk_id_interned, owner_graph, module, import_sources)?;
-        for (index, request) in explicit_requests.iter().enumerate() {
-            let group_assignments = source_match_group_assignments(request);
-            for (member_index, member) in request.members.iter().enumerate() {
-                let Some(selector) = member_selector_spec_for_global_solver(member) else {
-                    continue;
-                };
-                let target = builder.declare_member_target_in_module(
-                    &request.id,
-                    &member.export_name,
-                    &selector,
-                )?;
-                pending_constraints.push((
-                    request.id.clone(),
-                    member.export_name.clone(),
-                    selector,
-                ));
-                if member.is_relational() || member.source_match.is_some() {
-                    deferred_targets.insert(
-                        target,
-                        (
-                            index,
-                            member.clone(),
-                            group_assignments.get(&member_index).cloned(),
-                        ),
-                    );
+        if has_deferred_members {
+            for (index, request) in explicit_requests.iter().enumerate() {
+                let group_assignments = source_match_group_assignments(request);
+                for (member_index, member) in request.members.iter().enumerate() {
+                    let Some(selector) = member_selector_spec_for_global_solver(member) else {
+                        continue;
+                    };
+                    let target = builder.declare_member_target_in_module(
+                        &request.id,
+                        &member.export_name,
+                        &selector,
+                    )?;
+                    pending_constraints.push((
+                        request.id.clone(),
+                        member.export_name.clone(),
+                        selector,
+                    ));
+                    if member.resolves_after_stage_a() {
+                        deferred_targets.insert(
+                            target,
+                            (
+                                index,
+                                member.clone(),
+                                group_assignments.get(&member_index).cloned(),
+                            ),
+                        );
+                    }
+                    if let Some(source_selector) = &member.source_match {
+                        let selector_key = source_match::selector_key(source_selector);
+                        source_match_targets.push(SourceMatchTargetInfo {
+                            target,
+                            request_id: request.id.clone(),
+                            export_name: member.export_name.clone(),
+                            selector: source_selector.clone(),
+                            selector_key: selector_key.clone(),
+                            group_assignment: group_assignments.get(&member_index).cloned(),
+                        });
+                    }
                 }
-                if let Some(source_selector) = &member.source_match {
-                    let selector_key = source_match::selector_key(source_selector);
-                    source_match_targets.push(SourceMatchTargetInfo {
-                        target,
-                        request_id: request.id.clone(),
-                        export_name: member.export_name.clone(),
-                        selector: source_selector.clone(),
-                        selector_key: selector_key.clone(),
-                        group_assignment: group_assignments.get(&member_index).cloned(),
-                    });
+            }
+        }
+        for (request_index, request) in explicit_requests.iter().enumerate() {
+            for (statement_index, statement) in request.anonymous_statements.iter().enumerate() {
+                match builder.declare_native_anonymous_statement_target_in_module(
+                    &request.id,
+                    statement_index,
+                    &statement.selector,
+                )? {
+                    Some(target) => {
+                        anonymous_statement_targets.push(AnonymousStatementTargetInfo {
+                            target,
+                            request_index,
+                            statement: statement.clone(),
+                        })
+                    }
+                    None => {
+                        let claims = resolve_anonymous_statement_request(
+                            &request.id,
+                            statement,
+                            selector_resolver,
+                            self.keep_going,
+                            &mut self.anonymous_statement_diagnostics,
+                        )?;
+                        for claim in claims {
+                            self.claim_anonymous_statement(request_index, &request.id, &claim)?;
+                        }
+                    }
                 }
             }
         }
@@ -1179,6 +1280,13 @@ impl ChunkPlanBuilder {
             builder.lower_member_constraints_in_module(&logical_module, &export_name, &selector)?;
         }
         let program = builder.into_program()?;
+        if program.targets.is_empty() {
+            return Ok(());
+        }
+        let source_match_ordinal_by_binding =
+            source_match_candidate_statement_ordinals(owner_graph);
+        let mut facts =
+            selector_fact_store_for_chunk(chunk_id_interned, owner_graph, module, import_sources)?;
         let source_match_oracle_targets = source_match_targets
             .iter()
             .filter_map(|target| {
@@ -1368,7 +1476,7 @@ impl ChunkPlanBuilder {
                         bail!("{message}");
                     }
                     bail!(
-                        "logical_module {}: global selector solver found no match for relational \
+                        "logical_module {}: global selector solver found no match for selector \
                          member `{}` ({}): {:?}",
                         request.id,
                         member.export_name,
@@ -1422,7 +1530,7 @@ impl ChunkPlanBuilder {
                     }
                     bail!(
                         "logical_module {}: global selector solver found {} candidates for \
-                         relational member `{}` ({}): {:?}",
+                         selector member `{}` ({}): {:?}",
                         request.id,
                         candidates.len(),
                         member.export_name,
@@ -1435,7 +1543,7 @@ impl ChunkPlanBuilder {
                     conflicting_targets,
                 }) => {
                     bail!(
-                        "logical_module {}: global selector solver assigned relational member `{}` \
+                        "logical_module {}: global selector solver assigned selector member `{}` \
                          to duplicate owner {:?} shared by targets {:?}",
                         request.id,
                         member.export_name,
@@ -1445,7 +1553,7 @@ impl ChunkPlanBuilder {
                 }
                 Some(ClaimOutcome::Unsupported { message }) => {
                     bail!(
-                        "logical_module {}: global selector solver does not support relational \
+                        "logical_module {}: global selector solver does not support selector \
                          member `{}` ({}): {}",
                         request.id,
                         member.export_name,
@@ -1456,10 +1564,81 @@ impl ChunkPlanBuilder {
                 None => {
                     bail!(
                         "logical_module {}: global selector solver returned no outcome for \
-                         relational member `{}` ({})",
+                         selector member `{}` ({})",
                         request.id,
                         member.export_name,
                         member.claim_origin,
+                    );
+                }
+            }
+        }
+        for info in anonymous_statement_targets {
+            let request = &explicit_requests[info.request_index];
+            match result.outcome_for(info.target) {
+                Some(ClaimOutcome::Unique { claim }) => {
+                    self.claim_anonymous_statement_from_solver(
+                        module,
+                        info.request_index,
+                        &request.id,
+                        &info.statement,
+                        claim,
+                    )?;
+                }
+                Some(ClaimOutcome::NoMatch) => {
+                    self.record_anonymous_statement_failure_or_bail(
+                        request,
+                        &info.statement,
+                        anonymous_statement_no_match_message(request, &info.statement),
+                    )?;
+                    continue;
+                }
+                Some(ClaimOutcome::Ambiguous { candidates }) => {
+                    let body_indices = candidates
+                        .iter()
+                        .filter_map(|candidate| {
+                            body_index_for_statement_ordinal(
+                                &module.body,
+                                candidate.statement_ordinal.0,
+                            )
+                        })
+                        .collect::<Vec<_>>();
+                    self.record_anonymous_statement_failure_or_bail(
+                        request,
+                        &info.statement,
+                        anonymous_statement_ambiguous_message(
+                            request,
+                            &info.statement,
+                            candidates.len(),
+                            &body_indices,
+                        ),
+                    )?;
+                    continue;
+                }
+                Some(ClaimOutcome::Duplicate {
+                    owner,
+                    conflicting_targets,
+                }) => {
+                    bail!(
+                        "logical_module {}: global selector solver assigned anonymous statement \
+                         to duplicate owner {:?} shared by targets {:?}",
+                        request.id,
+                        owner,
+                        conflicting_targets,
+                    );
+                }
+                Some(ClaimOutcome::Unsupported { message }) => {
+                    bail!(
+                        "logical_module {}: global selector solver does not support anonymous \
+                         statement selector: {}",
+                        request.id,
+                        message,
+                    );
+                }
+                None => {
+                    bail!(
+                        "logical_module {}: global selector solver returned no outcome for \
+                         anonymous statement selector",
+                        request.id,
                     );
                 }
             }
@@ -2445,11 +2624,10 @@ impl ChunkPlanBuilder {
     /// block-hoisted `var` inside a claimed `try` statement) belong
     /// to the module that claims the statement: the declaration is
     /// emitted there, so binding ownership, exports, and
-    /// cross-module import wiring must follow it. Runs before the
-    /// residual sweep so the sweep doesn't route these bindings to
-    /// the catchall while their declaring statement lives elsewhere
-    /// (which emitted an `export { name }` whose declaration is in a
-    /// different file — a SyntaxError at load).
+    /// cross-module import wiring must follow it. Runs after global
+    /// selector resolution; bindings already swept into residual are
+    /// moved out so the residual file does not export declarations
+    /// emitted in another module.
     pub(super) fn adopt_bindings_of_claimed_anonymous_statements(
         &mut self,
         declarations: &[TopLevelDecl],
@@ -2460,8 +2638,13 @@ impl ChunkPlanBuilder {
             };
             let module = ModuleId(LogicalModuleIndex(plan_index));
             for (name, id) in &decl.bindings {
-                if self.binding_assignment.contains_key(id) {
-                    continue;
+                if let Some(existing) = self.binding_assignment.get(id).copied() {
+                    if Some(existing) != self.residual_plan_index {
+                        continue;
+                    }
+                    if let Some(residual_index) = self.residual_plan_index {
+                        self.module_plans[residual_index].bindings.remove(name);
+                    }
                 }
                 self.binding_assignment.insert(id.clone(), plan_index);
                 self.module_plans[plan_index]

--- a/devinfra/js/debundle/lowering/materialize/plan_builder.rs
+++ b/devinfra/js/debundle/lowering/materialize/plan_builder.rs
@@ -527,8 +527,10 @@ fn native_source_match_no_match_message(
         .unwrap_or_default();
     Some(format!(
         "logical_module {}: members[].selector.source_match for export `{}`{} did not produce a \
-         valid global selector assignment. The selector may have no matching source declaration, \
-         or the joint constraints may reject all otherwise matching declarations. Selector:\n{}",
+         valid global selector assignment for any top-level declaration accepted by the global \
+         selector solver. The selector did not match any top-level declaration under the joint \
+         constraints; it may have no matching source declaration, or the joint constraints may \
+         reject all otherwise matching declarations. Selector:\n{}",
         request.id, member.export_name, target_binding_hint, selector.match_source,
     ))
 }
@@ -609,12 +611,18 @@ fn native_source_match_ambiguous_message(
     candidates: &[ResolvedClaim],
 ) -> Option<String> {
     let selector = member.source_match.as_ref()?;
+    let target_binding_hint = selector
+        .target_binding
+        .as_deref()
+        .map(|target| format!(" target_binding `{target}`"))
+        .unwrap_or_default();
     Some(format!(
-        "logical_module {}: members[].selector.source_match for export `{}` is ambiguous in the \
+        "logical_module {}: members[].selector.source_match for export `{}`{} is ambiguous in the \
          native selector solver -- matched {} owners at statement ordinals {:?} (bindings: {}). \
          Refine the selector. Source:\n{}",
         request.id,
         member.export_name,
+        target_binding_hint,
         candidates.len(),
         candidates
             .iter()
@@ -639,6 +647,10 @@ fn first_relevant_error_line(message: &str) -> Option<String> {
 fn classify_source_match_failure(message: &str) -> &'static str {
     if message.contains(" is ambiguous") {
         "ambiguous_selector"
+    } else if message.contains("valid global selector assignment")
+        || message.contains("global selector solver")
+    {
+        "selector_resolution_error"
     } else if message.contains("did not match any") {
         "unresolved_selector"
     } else {
@@ -1206,6 +1218,9 @@ impl ChunkPlanBuilder {
         let mut source_match_targets = Vec::<SourceMatchTargetInfo>::new();
         let mut anonymous_statement_targets = Vec::<AnonymousStatementTargetInfo>::new();
         let mut pending_constraints = Vec::<(String, String, spec::MemberSelectorSpec)>::new();
+        let mut pending_source_match_groups = Vec::<(String, SourceMatchGroupAssignment)>::new();
+        let mut pending_source_match_group_keys =
+            BTreeSet::<(String, SourceMatchGroupCacheKey)>::new();
         if has_deferred_members {
             for (index, request) in explicit_requests.iter().enumerate() {
                 let group_assignments = source_match_group_assignments(request);
@@ -1218,20 +1233,28 @@ impl ChunkPlanBuilder {
                         &member.export_name,
                         &selector,
                     )?;
-                    pending_constraints.push((
-                        request.id.clone(),
-                        member.export_name.clone(),
-                        selector,
-                    ));
-                    if member.resolves_after_stage_a() {
-                        deferred_targets.insert(
-                            target,
-                            (
-                                index,
-                                member.clone(),
-                                group_assignments.get(&member_index).cloned(),
+                    let group_assignment = group_assignments.get(&member_index).cloned();
+                    if let Some(group) = &group_assignment {
+                        let key = (
+                            request.id.clone(),
+                            SourceMatchGroupCacheKey::new(
+                                group.selector.clone(),
+                                &group.exports_by_target,
                             ),
                         );
+                        if pending_source_match_group_keys.insert(key) {
+                            pending_source_match_groups.push((request.id.clone(), group.clone()));
+                        }
+                    } else {
+                        pending_constraints.push((
+                            request.id.clone(),
+                            member.export_name.clone(),
+                            selector,
+                        ));
+                    }
+                    if member.resolves_after_stage_a() {
+                        deferred_targets
+                            .insert(target, (index, member.clone(), group_assignment.clone()));
                     }
                     if let Some(source_selector) = &member.source_match {
                         let selector_key = source_match::selector_key(source_selector);
@@ -1241,7 +1264,7 @@ impl ChunkPlanBuilder {
                             export_name: member.export_name.clone(),
                             selector: source_selector.clone(),
                             selector_key: selector_key.clone(),
-                            group_assignment: group_assignments.get(&member_index).cloned(),
+                            group_assignment,
                         });
                     }
                 }
@@ -1274,6 +1297,24 @@ impl ChunkPlanBuilder {
                         }
                     }
                 }
+            }
+        }
+        for (logical_module, group) in pending_source_match_groups {
+            if builder.try_lower_native_source_match_group(
+                &logical_module,
+                &group.selector,
+                &group.exports_by_target,
+            )? {
+                continue;
+            }
+            for (target_binding, export_name) in group.exports_by_target {
+                let mut selector = group.selector.clone();
+                selector.target_binding = Some(target_binding);
+                builder.lower_member_constraints_in_module(
+                    &logical_module,
+                    &export_name,
+                    &spec::MemberSelectorSpec::SourceMatch(selector),
+                )?;
             }
         }
         for (logical_module, export_name, selector) in pending_constraints {

--- a/devinfra/js/debundle/lowering/mod.rs
+++ b/devinfra/js/debundle/lowering/mod.rs
@@ -61,7 +61,9 @@ mod util;
 mod vendor_imports;
 mod visitors;
 
-use anonymous::{AnonymousStatementDiagnostic, resolve_anonymous_statement_ordinals};
+use anonymous::{
+    AnonymousStatementDiagnostic, ResolvedAnonymousStatement, resolve_anonymous_statement_request,
+};
 use body_facts::{ModuleBodyFacts, collect_module_body_facts};
 use chunk_ast::{
     ChunkAstAnalysis, TopLevelDecl, analyze_chunk_ast, binding_ids, binding_names, declaration_ids,

--- a/devinfra/js/debundle/lowering/plans.rs
+++ b/devinfra/js/debundle/lowering/plans.rs
@@ -114,10 +114,14 @@ pub(super) struct MemberRequest {
 }
 
 impl MemberRequest {
-    /// Whether this member is pinned by a relational selector (and so resolves in a
-    /// post-Stage-A pass, with an empty `binding` until then).
-    pub(super) fn is_relational(&self) -> bool {
-        self.relational.is_some()
+    /// Whether this member's binding is intentionally unknown until Stage A
+    /// facts are available and the global selector solver runs.
+    ///
+    /// Request lowering canonicalizes every non-name member selector into this
+    /// shape. Callers should route on that semantic state instead of re-spelling
+    /// individual selector forms such as `source_match` versus the relation enum.
+    pub(super) fn resolves_after_stage_a(&self) -> bool {
+        self.binding.is_empty()
     }
 
     pub(super) fn cross_ref(&self) -> Option<&spec::CrossRefTarget> {
@@ -335,9 +339,9 @@ pub(super) fn build_members(
         .map(|m| {
             let selected = m.selector.selected()?;
             let kind_label = selected.selector_kind_label();
-            // A relational / source-match member's public export name can't default
-            // to a binding name — the binding isn't known until the selector
-            // resolves — so `name:` is required. The kind label colors the message.
+            // A solver-resolved member's public export name can't default to a
+            // binding name — the binding isn't known until the selector resolves
+            // — so `name:` is required. The kind label colors the message.
             let require_name = || {
                 m.name.clone().ok_or_else(|| {
                     anyhow::anyhow!(

--- a/devinfra/js/debundle/selector_ir_lowering.rs
+++ b/devinfra/js/debundle/selector_ir_lowering.rs
@@ -138,6 +138,36 @@ impl MemberSelectorProgramBuilder {
         ))
     }
 
+    pub fn declare_native_anonymous_statement_target_in_module(
+        &mut self,
+        logical_module: impl Into<String>,
+        statement_index: usize,
+        selector: &AnonymousStatementSelector,
+    ) -> Result<Option<SelectorTargetId>, SelectorIrLoweringError> {
+        if !native_anonymous_source_match_supported(selector) {
+            return Ok(None);
+        }
+        let logical_module = logical_module.into();
+        let owner = self.program.add_variable(
+            VariableDomain::Owner,
+            Some(format!(
+                "{logical_module}::anonymous_statement.{statement_index}"
+            )),
+        );
+        if !self.try_lower_native_source_match(&logical_module, owner, selector)? {
+            return Ok(None);
+        }
+        Ok(Some(self.program.add_target(
+            self.context.chunk_id,
+            owner,
+            logical_module,
+            ClaimKind::AnonymousStatement,
+            ClaimOrigin::AnonymousStatement {
+                index: statement_index,
+            },
+        )))
+    }
+
     pub fn lower_member_constraints_in_module(
         &mut self,
         logical_module: &str,
@@ -1196,6 +1226,16 @@ impl AlphaIdentifierState {
 #[derive(Default)]
 struct AlphaIdentifierFrame {
     by_name: BTreeMap<String, SelectorVariableId>,
+}
+
+fn native_anonymous_source_match_supported(selector: &AnonymousStatementSelector) -> bool {
+    // Keep alpha and multi-statement anonymous selectors on the existing
+    // resolver path until the native solver has bounded support for those
+    // broader patterns.
+    selector.identifiers == SourceMatchIdentifierMode::Exact
+        && selector.target_binding.is_none()
+        && selector.wildcard_string_literals.is_empty()
+        && !selector.match_source.contains('\n')
 }
 
 fn owner_term(owner: SelectorVariableId) -> OwnerTerm {

--- a/devinfra/js/debundle/selector_ir_lowering.rs
+++ b/devinfra/js/debundle/selector_ir_lowering.rs
@@ -410,7 +410,7 @@ impl MemberSelectorProgramBuilder {
             return Ok(false);
         };
         if selector.identifiers == SourceMatchIdentifierMode::AlphaAll
-            && !native_alpha_source_match_supported(&facts, &skipped_nodes, &child_list_patterns)
+            && !native_alpha_source_match_supported(&facts, &skipped_nodes)
         {
             return Ok(false);
         }
@@ -506,6 +506,135 @@ impl MemberSelectorProgramBuilder {
             }
             (None, _) => {}
         }
+        self.lower_native_ast_facts(NativeAstFactLowering {
+            logical_module,
+            facts: &facts,
+            node_vars: &node_vars,
+            skipped_nodes: &skipped_nodes,
+            identifier_mode: selector.identifiers,
+            alpha_identifier_vars: &alpha_identifier_vars,
+            exact_identifier_projection_vars: &exact_identifier_projection_vars,
+            child_list_patterns: &child_list_patterns,
+            regex_predicates: &regex_predicates,
+        });
+        Ok(true)
+    }
+
+    pub fn try_lower_native_source_match_group(
+        &mut self,
+        logical_module: &str,
+        selector: &AnonymousStatementSelector,
+        exports_by_target: &BTreeMap<String, String>,
+    ) -> Result<bool, SelectorIrLoweringError> {
+        if selector.target_binding.is_some() || exports_by_target.is_empty() {
+            return Ok(false);
+        }
+        let Ok(parsed) = js_ast::with_swc_globals(|| {
+            js_ast::parse_js_module_ast(
+                &format!("<selector ir binding_group source_match in {logical_module}>"),
+                &selector.match_source,
+            )
+        }) else {
+            return Ok(false);
+        };
+        if parsed.body.len() != 1 {
+            return Ok(false);
+        }
+        let Ok(facts) =
+            chunk_facts::extract_facts_needle(&parsed.body, &selector.wildcard_string_literals)
+        else {
+            return Ok(false);
+        };
+        let regex_predicates = native_string_literal_regex_predicates(&facts);
+        let Some(hole_roots) =
+            native_single_node_hole_roots(&facts, &regex_predicates.consumed_nodes)
+        else {
+            return Ok(false);
+        };
+        let mut skipped_nodes = native_hole_subtree_nodes(&facts, &hole_roots);
+        skipped_nodes.extend(regex_predicates.consumed_nodes.iter().copied());
+        let Some(child_list_patterns) = native_child_list_patterns(&facts, &mut skipped_nodes)
+        else {
+            return Ok(false);
+        };
+        if selector.identifiers == SourceMatchIdentifierMode::AlphaAll
+            && !native_alpha_source_match_supported(&facts, &skipped_nodes)
+        {
+            return Ok(false);
+        }
+        let [(root_node, _ordinal)] = facts.top_level.as_slice() else {
+            return Ok(false);
+        };
+
+        let mut target_binding_nodes = BTreeMap::<String, NodeId>::new();
+        for target_binding in exports_by_target.keys() {
+            let Some(target_binding_node) =
+                native_target_binding_node(&facts, &skipped_nodes, target_binding)
+            else {
+                return Ok(false);
+            };
+            target_binding_nodes.insert(target_binding.clone(), target_binding_node);
+        }
+
+        let mut node_vars = BTreeMap::<NodeId, SelectorVariableId>::new();
+        for (node, _kind) in &facts.node_kind {
+            node_vars.insert(
+                *node,
+                self.program.add_variable(
+                    VariableDomain::AstNode,
+                    Some(format!(
+                        "{logical_module}::binding_group.source_match.node{node}"
+                    )),
+                ),
+            );
+        }
+        let Some(root) = node_vars.get(root_node).copied() else {
+            return Ok(false);
+        };
+
+        let alpha_identifier_vars = if selector.identifiers == SourceMatchIdentifierMode::AlphaAll {
+            self.lower_alpha_identifier_variables(logical_module, &facts, &skipped_nodes)
+        } else {
+            BTreeMap::new()
+        };
+        let mut exact_identifier_projection_vars = BTreeMap::new();
+        for (target_binding, export_name) in exports_by_target {
+            let owner = self.owner_for_local_export(logical_module, export_name);
+            self.program.add_atom(SelectorAtom::OwnerTopLevelRoot {
+                owner: owner_term(owner),
+                root: node_term(root),
+            });
+            let target_binding_node = target_binding_nodes
+                .get(target_binding)
+                .copied()
+                .expect("target binding nodes were collected for every export");
+            match selector.identifiers {
+                SourceMatchIdentifierMode::Exact => {
+                    let binding_var = self.program.add_variable(
+                        VariableDomain::String,
+                        Some(format!(
+                            "{logical_module}::binding_group.source_match.target_binding.{target_binding}"
+                        )),
+                    );
+                    exact_identifier_projection_vars.insert(target_binding_node, binding_var);
+                    self.program.add_atom(SelectorAtom::OwnerDeclaresBinding {
+                        owner: owner_term(owner),
+                        binding: string_term(binding_var),
+                    });
+                }
+                SourceMatchIdentifierMode::AlphaAll => {
+                    let binding_var = alpha_identifier_vars
+                        .get(&target_binding_node)
+                        .copied()
+                        .expect("alpha_all target binding node should have an identifier variable");
+                    self.program.add_atom(SelectorAtom::OwnerDeclaresBinding {
+                        owner: owner_term(owner),
+                        binding: string_term(binding_var),
+                    });
+                }
+            }
+        }
+
         self.lower_native_ast_facts(NativeAstFactLowering {
             logical_module,
             facts: &facts,
@@ -938,7 +1067,6 @@ fn introduces_alpha_scope(kind: NodeKind) -> bool {
 fn native_alpha_source_match_supported(
     facts: &ChunkFacts,
     skipped_nodes: &BTreeSet<NodeId>,
-    child_list_patterns: &BTreeMap<NodeId, NativeChildListPattern>,
 ) -> bool {
     let index = AlphaIdentifierIndex::new(facts);
     let [(_root, _ordinal)] = facts.top_level.as_slice() else {
@@ -946,14 +1074,6 @@ fn native_alpha_source_match_supported(
     };
 
     if native_alpha_has_explicit_same_name_property(&index, skipped_nodes) {
-        return false;
-    }
-
-    // Syntactic holes and open child-list patterns still rely on the legacy
-    // matcher's structural semantics. Keep alpha native lowering to complete
-    // no-hole shapes until these constraints are represented directly in the
-    // solver.
-    if !skipped_nodes.is_empty() || !child_list_patterns.is_empty() {
         return false;
     }
 
@@ -979,12 +1099,7 @@ fn native_alpha_source_match_supported(
         return false;
     }
 
-    !child_list_patterns.iter().any(|(parent, _pattern)| {
-        matches!(
-            index.node_kind.get(parent).copied(),
-            Some(NodeKind::Call | NodeKind::New)
-        )
-    })
+    true
 }
 
 fn native_alpha_has_explicit_same_name_property(
@@ -1229,13 +1344,7 @@ struct AlphaIdentifierFrame {
 }
 
 fn native_anonymous_source_match_supported(selector: &AnonymousStatementSelector) -> bool {
-    // Keep alpha and multi-statement anonymous selectors on the existing
-    // resolver path until the native solver has bounded support for those
-    // broader patterns.
-    selector.identifiers == SourceMatchIdentifierMode::Exact
-        && selector.target_binding.is_none()
-        && selector.wildcard_string_literals.is_empty()
-        && !selector.match_source.contains('\n')
+    selector.target_binding.is_none()
 }
 
 fn owner_term(owner: SelectorVariableId) -> OwnerTerm {
@@ -2364,33 +2473,138 @@ mod tests {
     }
 
     #[test]
-    fn alpha_all_var_decl_without_target_binding_stays_oracle_only() {
-        let mut selector =
-            AnonymousStatementSelector::exact(r#"const readable = { kind: "selected" };"#);
-        selector.identifiers = SourceMatchIdentifierMode::AlphaAll;
-        let lowered = lower_member_selector(
-            &context(),
-            "Widget",
-            &MemberSelectorSpec::SourceMatch(selector.clone()),
-        )
-        .unwrap();
+    fn alpha_all_binding_group_source_match_lowers_to_one_shared_root() {
+        let mut group_selector = AnonymousStatementSelector::exact(
+            r#"const first = build("a"), second = build(first);"#,
+        );
+        group_selector.identifiers = SourceMatchIdentifierMode::AlphaAll;
+        let mut first_selector = group_selector.clone();
+        first_selector.target_binding = Some("first".to_string());
+        let mut second_selector = group_selector.clone();
+        second_selector.target_binding = Some("second".to_string());
 
-        assert_source_match_oracle_only(&lowered, &selector);
+        let mut builder = MemberSelectorProgramBuilder::new(context());
+        let first_target = builder
+            .declare_member_target_in_module(
+                "runtime/widgets",
+                "First",
+                &MemberSelectorSpec::SourceMatch(first_selector),
+            )
+            .unwrap();
+        let second_target = builder
+            .declare_member_target_in_module(
+                "runtime/widgets",
+                "Second",
+                &MemberSelectorSpec::SourceMatch(second_selector),
+            )
+            .unwrap();
+        assert!(
+            builder
+                .try_lower_native_source_match_group(
+                    "runtime/widgets",
+                    &group_selector,
+                    &BTreeMap::from([
+                        ("first".to_string(), "First".to_string()),
+                        ("second".to_string(), "Second".to_string()),
+                    ]),
+                )
+                .unwrap()
+        );
+        let program = builder.into_program().unwrap();
+
+        assert!(
+            !program
+                .atoms
+                .iter()
+                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
+        );
+        let first_owner = program.targets[first_target.0].owner;
+        let second_owner = program.targets[second_target.0].owner;
+        let shared_roots = program
+            .atoms
+            .iter()
+            .filter_map(|atom| match atom {
+                SelectorAtom::OwnerTopLevelRoot {
+                    owner: OwnerTerm::Var { id },
+                    root: NodeTerm::Var { id: root },
+                } if *id == first_owner || *id == second_owner => Some(*root),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(shared_roots.len(), 2);
+        assert_eq!(shared_roots[0], shared_roots[1]);
+
+        let projected_bindings = program
+            .atoms
+            .iter()
+            .filter_map(|atom| match atom {
+                SelectorAtom::OwnerDeclaresBinding {
+                    owner: OwnerTerm::Var { id },
+                    binding: StringTerm::Var { id: binding },
+                } if *id == first_owner || *id == second_owner => Some(*binding),
+                _ => None,
+            })
+            .collect::<BTreeSet<_>>();
+        assert_eq!(projected_bindings.len(), 2);
     }
 
     #[test]
-    fn alpha_all_single_declarator_source_match_stays_oracle_only() {
+    fn alpha_all_var_decl_without_target_binding_lowers_natively() {
         let mut selector =
             AnonymousStatementSelector::exact(r#"const readable = { kind: "selected" };"#);
         selector.identifiers = SourceMatchIdentifierMode::AlphaAll;
         let lowered = lower_member_selector(
             &context(),
             "Widget",
-            &MemberSelectorSpec::SourceMatch(selector.clone()),
+            &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
 
-        assert_source_match_oracle_only(&lowered, &selector);
+        let target_owner = lowered.program.targets[lowered.target.0].owner;
+        assert!(
+            !lowered
+                .program
+                .atoms
+                .iter()
+                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
+        );
+        assert!(lowered.program.atoms.iter().any(|atom| matches!(
+            atom,
+            SelectorAtom::OwnerDeclaresBinding {
+                owner: OwnerTerm::Var { id },
+                binding: StringTerm::Var { .. },
+            } if *id == target_owner
+        )));
+    }
+
+    #[test]
+    fn alpha_all_single_declarator_source_match_lowers_natively() {
+        let mut selector =
+            AnonymousStatementSelector::exact(r#"const readable = { kind: "selected" };"#);
+        selector.identifiers = SourceMatchIdentifierMode::AlphaAll;
+        let lowered = lower_member_selector(
+            &context(),
+            "Widget",
+            &MemberSelectorSpec::SourceMatch(selector),
+        )
+        .unwrap();
+
+        assert!(
+            !lowered
+                .program
+                .atoms
+                .iter()
+                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
+        );
+        assert!(lowered.program.atoms.iter().any(|atom| matches!(
+            atom,
+            SelectorAtom::AstChildListPattern {
+                anchored_left: false,
+                anchored_right: false,
+                segments,
+                ..
+            } if segments.len() == 1
+        )));
     }
 
     #[test]
@@ -2535,17 +2749,33 @@ mod tests {
     }
 
     #[test]
-    fn alpha_all_source_match_with_argument_run_hole_stays_oracle_only() {
+    fn alpha_all_source_match_with_argument_run_hole_lowers_natively() {
         let mut selector = AnonymousStatementSelector::exact("const a = foo(ARGS, b);");
         selector.identifiers = SourceMatchIdentifierMode::AlphaAll;
         let lowered = lower_member_selector(
             &context(),
             "Widget",
-            &MemberSelectorSpec::SourceMatch(selector.clone()),
+            &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
 
-        assert_source_match_oracle_only(&lowered, &selector);
+        assert!(
+            !lowered
+                .program
+                .atoms
+                .iter()
+                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
+        );
+        assert!(lowered.program.atoms.iter().any(|atom| matches!(
+            atom,
+            SelectorAtom::AstChildListPattern {
+                start_index: 1,
+                anchored_left: false,
+                anchored_right: true,
+                segments,
+                ..
+            } if segments.len() == 1
+        )));
     }
 
     #[test]

--- a/devinfra/js/debundle/selector_ir_solver.rs
+++ b/devinfra/js/debundle/selector_ir_solver.rs
@@ -17,7 +17,7 @@ use regex::Regex;
 use selector_ir::{
     ClaimKind, ClaimOutcome, NodeTerm, OrdinalTerm, OwnerTerm, ResolvedClaim, SelectorAtom,
     SelectorFact, SelectorFactStore, SelectorProgram, SelectorProgramError, SelectorTarget,
-    SelectorVariableId, SolverClaim, SolverResult, StringTerm, VariableDomain,
+    SelectorVariableId, SolverClaim, SolverResult, StringTerm,
 };
 
 fn optional_u32_matches(expected: &Option<u32>, actual: u32) -> bool {
@@ -38,6 +38,8 @@ fn optional_edge_kind_matches(expected: &Option<String>, actual: &str) -> bool {
 }
 
 type AssignmentRow = Vec<(usize, AssignmentValue)>;
+type EqualityCheck = (usize, usize, EqualityConstraintKind);
+type EqualityCheckSchedule = Vec<(usize, Vec<EqualityCheck>)>;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 enum AssignmentValue {
@@ -86,6 +88,28 @@ fn merge_assignment_bindings(mut row: AssignmentRow) -> Option<AssignmentRow> {
     Some(merged)
 }
 
+fn project_assignment_row(row: &AssignmentRow, live_variables: &[usize]) -> Option<AssignmentRow> {
+    Some(
+        row.iter()
+            .filter(|(var, _value)| live_variables.binary_search(var).is_ok())
+            .cloned()
+            .collect(),
+    )
+}
+
+fn connect_variables(variables: BTreeSet<usize>, adjacency: &mut BTreeMap<usize, BTreeSet<usize>>) {
+    let Some(first) = variables.first().copied() else {
+        return;
+    };
+    for variable in &variables {
+        adjacency.entry(*variable).or_default();
+    }
+    for variable in variables {
+        adjacency.entry(first).or_default().insert(variable);
+        adjacency.entry(variable).or_default().insert(first);
+    }
+}
+
 fn assignment_owner(row: &AssignmentRow, variable: usize) -> Option<usize> {
     row.iter().find_map(|(var, value)| {
         if *var != variable {
@@ -96,6 +120,38 @@ fn assignment_owner(row: &AssignmentRow, variable: usize) -> Option<usize> {
             _ => None,
         }
     })
+}
+
+fn assignment_value(row: &AssignmentRow, variable: usize) -> Option<&AssignmentValue> {
+    row.iter()
+        .find_map(|(var, value)| (*var == variable).then_some(value))
+}
+
+fn assignment_satisfies_equality(
+    row: &AssignmentRow,
+    left_var: usize,
+    right_var: usize,
+    kind: EqualityConstraintKind,
+) -> bool {
+    let Some(left) = assignment_value(row, left_var) else {
+        return false;
+    };
+    let Some(right) = assignment_value(row, right_var) else {
+        return false;
+    };
+    match kind {
+        EqualityConstraintKind::Equal => left == right,
+        EqualityConstraintKind::NotEqual => left != right,
+    }
+}
+
+fn assignment_satisfies_equalities(
+    row: &AssignmentRow,
+    checks: &[(usize, usize, EqualityConstraintKind)],
+) -> bool {
+    checks
+        .iter()
+        .all(|(left, right, kind)| assignment_satisfies_equality(row, *left, *right, *kind))
 }
 
 fn assignment_string(row: &AssignmentRow, variable: usize) -> Option<String> {
@@ -470,15 +526,13 @@ ascent! {
         required_owner_declares_binding_var(constraint, owner_var, string_var),
         declares(owner, binding);
 
-    relation variable_value_domain(usize, AssignmentValue);
-    relation target_owner_var(usize);
-    relation target_binding_projection_var(usize, usize);
-    relation target_binding_projection_const(usize, String);
-    relation required_equal(usize, usize, usize);
-    relation required_not_equal(usize, usize, usize);
+    relation project_owner_after_step(usize, usize);
+    relation project_binding_var_after_step(usize, usize, usize);
+    relation project_binding_const_after_step(usize, usize, String);
     relation constraint_order(usize, usize);
-    relation constraint_count(usize);
     relation child_list_assignment(usize, AssignmentRow);
+    relation equality_checks_after_step(usize, Vec<EqualityCheck>);
+    relation live_variables_after_step(usize, Vec<usize>);
 
     relation atom_assignment(usize, AssignmentRow);
     atom_assignment(*constraint, row.clone()) <--
@@ -545,57 +599,38 @@ ascent! {
             *string_var,
             AssignmentValue::String(binding.clone()),
         );
-    atom_assignment(*constraint, row) <--
-        required_equal(constraint, left_var, right_var),
-        variable_value_domain(left_var, value),
-        variable_value_domain(right_var, value),
-        if let Some(row) = assignment_row_2(
-            *left_var,
-            value.clone(),
-            *right_var,
-            value.clone(),
-        );
-    atom_assignment(*constraint, row) <--
-        required_not_equal(constraint, left_var, right_var),
-        variable_value_domain(left_var, left_value),
-        variable_value_domain(right_var, right_value),
-        if left_value != right_value,
-        if let Some(row) = assignment_row_2(
-            *left_var,
-            left_value.clone(),
-            *right_var,
-            right_value.clone(),
-        );
 
     relation partial_assignment(usize, AssignmentRow);
     partial_assignment(0, Vec::new());
-    partial_assignment(*step + 1, merged_row) <--
+    relation stepped_assignment(usize, AssignmentRow);
+    stepped_assignment(*step + 1, merged_row.clone()) <--
         partial_assignment(step, row),
         constraint_order(step, constraint),
         atom_assignment(constraint, constraint_row),
-        if let Some(merged_row) = merge_assignment_rows(row, constraint_row);
+        if let Some(merged_row) = merge_assignment_rows(row, constraint_row),
+        equality_checks_after_step((*step + 1), equality_checks),
+        if assignment_satisfies_equalities(&merged_row, equality_checks);
 
-    relation complete_assignment(AssignmentRow);
-    complete_assignment(row.clone()) <--
-        partial_assignment(step, row),
-        constraint_count(required),
-        if *step == *required;
+    partial_assignment(*step, projected_row) <--
+        stepped_assignment(step, row),
+        live_variables_after_step(step, live_variables),
+        if let Some(projected_row) = project_assignment_row(row, live_variables);
 
     relation solution_owner(usize, usize);
     solution_owner(*target_var, owner) <--
-        target_owner_var(target_var),
-        complete_assignment(row),
+        project_owner_after_step(step, target_var),
+        stepped_assignment(step, row),
         if let Some(owner) = assignment_owner(row, *target_var);
 
     relation solution_target_binding(usize, usize, String);
     solution_target_binding(*target_var, owner, binding.clone()) <--
-        target_binding_projection_var(target_var, binding_var),
-        complete_assignment(row),
+        project_binding_var_after_step(step, target_var, binding_var),
+        stepped_assignment(step, row),
         if let Some(owner) = assignment_owner(row, *target_var),
         if let Some(binding) = assignment_string(row, *binding_var);
     solution_target_binding(*target_var, owner, binding.clone()) <--
-        target_binding_projection_const(target_var, binding),
-        complete_assignment(row),
+        project_binding_const_after_step(step, target_var, binding),
+        stepped_assignment(step, row),
         if let Some(owner) = assignment_owner(row, *target_var);
 }
 
@@ -728,61 +763,47 @@ pub fn solve(
     for (node, ordinal) in &fact_index.ast_top_levels {
         ascent.ast_top_level.push((*node, ordinal.0));
     }
-    for variable in &program.variables {
-        match variable.domain {
-            VariableDomain::Owner => {
-                for owner in &fact_index.all_owners {
-                    ascent
-                        .variable_value_domain
-                        .push((variable.id.0, AssignmentValue::Owner(owner.0)));
-                }
-            }
-            VariableDomain::AstNode => {
-                for node in &fact_index.all_nodes {
-                    ascent
-                        .variable_value_domain
-                        .push((variable.id.0, AssignmentValue::AstNode(*node)));
-                }
-            }
-            VariableDomain::StatementOrdinal => {
-                for ordinal in &fact_index.all_statement_ordinals {
-                    ascent
-                        .variable_value_domain
-                        .push((variable.id.0, AssignmentValue::StatementOrdinal(ordinal.0)));
-                }
-            }
-            VariableDomain::String => {
-                for value in &fact_index.all_strings {
-                    ascent
-                        .variable_value_domain
-                        .push((variable.id.0, AssignmentValue::String(value.clone())));
-                }
-            }
-        }
-    }
-    for target in &program.targets {
-        ascent.target_owner_var.push((target.owner.0,));
-    }
-    for (owner, binding) in &support.target_binding_projection_by_owner {
-        match binding {
-            TargetBindingProjection::Const(value) => ascent
-                .target_binding_projection_const
-                .push((owner.0, value.clone())),
-            TargetBindingProjection::Var(binding) => ascent
-                .target_binding_projection_var
-                .push((owner.0, binding.0)),
-        }
-    }
     for constraint in &support.node_list_constraints {
         for row in child_list_assignment_rows(constraint, &fact_index) {
             ascent.child_list_assignment.push((constraint.id, row));
         }
     }
     let constraint_ids = support.constraint_ids();
+    for (step, equality_checks) in support.equality_checks_by_step(&constraint_ids) {
+        ascent
+            .equality_checks_after_step
+            .push((step, equality_checks));
+    }
+    let target_projection_steps =
+        support.target_projection_steps(&constraint_ids, &program.targets);
+    for target in &program.targets {
+        let Some(step) = target_projection_steps.get(&target.owner).copied() else {
+            continue;
+        };
+        ascent.project_owner_after_step.push((step, target.owner.0));
+        if let Some(binding) = support
+            .target_binding_projection_by_owner
+            .get(&target.owner)
+        {
+            match binding {
+                TargetBindingProjection::Const(value) => ascent
+                    .project_binding_const_after_step
+                    .push((step, target.owner.0, value.clone())),
+                TargetBindingProjection::Var(binding) => ascent
+                    .project_binding_var_after_step
+                    .push((step, target.owner.0, binding.0)),
+            }
+        }
+    }
+    for (step, live_variables) in support.live_variables_by_step(&constraint_ids, &program.targets)
+    {
+        ascent
+            .live_variables_after_step
+            .push((step, live_variables));
+    }
     for (step, constraint) in constraint_ids.iter().enumerate() {
         ascent.constraint_order.push((step, *constraint));
     }
-    ascent.constraint_count.push((constraint_ids.len(),));
     for constraint in &support.unary_constraints {
         match &constraint.kind {
             UnaryConstraintKind::Binding { binding } => ascent.required_binding.push((
@@ -1113,22 +1134,6 @@ pub fn solve(
                     constraint.id,
                     constraint.owner.0,
                     constraint.string.0,
-                ));
-            }
-        }
-    }
-    for constraint in &support.equality_constraints {
-        match constraint.kind {
-            EqualityConstraintKind::Equal => {
-                ascent
-                    .required_equal
-                    .push((constraint.id, constraint.left.0, constraint.right.0));
-            }
-            EqualityConstraintKind::NotEqual => {
-                ascent.required_not_equal.push((
-                    constraint.id,
-                    constraint.left.0,
-                    constraint.right.0,
                 ));
             }
         }
@@ -2238,8 +2243,370 @@ impl ProgramSupport {
             .next()
     }
 
+    fn live_variables_by_step(
+        &self,
+        constraint_ids: &[usize],
+        targets: &[SelectorTarget],
+    ) -> Vec<(usize, Vec<usize>)> {
+        let constraint_variables = constraint_ids
+            .iter()
+            .map(|id| self.variables_for_constraint(*id))
+            .collect::<Vec<_>>();
+        let equality_check_steps = self.equality_check_steps(constraint_ids);
+        let target_projection_steps = self.target_projection_steps(constraint_ids, targets);
+        let mut future_live = BTreeSet::<usize>::new();
+        let mut by_step = BTreeMap::<usize, Vec<usize>>::new();
+        by_step.insert(
+            constraint_ids.len(),
+            self.with_future_scheduled_variables(
+                constraint_ids.len(),
+                &future_live,
+                &equality_check_steps,
+                &target_projection_steps,
+            ),
+        );
+        for (idx, variables) in constraint_variables.iter().enumerate().rev() {
+            for variable in variables {
+                future_live.insert(*variable);
+            }
+            by_step.insert(
+                idx,
+                self.with_future_scheduled_variables(
+                    idx,
+                    &future_live,
+                    &equality_check_steps,
+                    &target_projection_steps,
+                ),
+            );
+        }
+        (1..=constraint_ids.len())
+            .map(|step| (step, by_step.get(&step).cloned().unwrap_or_default()))
+            .collect()
+    }
+
+    fn with_future_scheduled_variables(
+        &self,
+        step: usize,
+        live: &BTreeSet<usize>,
+        equality_check_steps: &BTreeMap<usize, usize>,
+        target_projection_steps: &BTreeMap<SelectorVariableId, usize>,
+    ) -> Vec<usize> {
+        let mut live = live.clone();
+        for constraint in &self.equality_constraints {
+            if equality_check_steps
+                .get(&constraint.id)
+                .is_some_and(|check_step| *check_step > step)
+            {
+                live.insert(constraint.left.0);
+                live.insert(constraint.right.0);
+            }
+        }
+        for (owner, projection_step) in target_projection_steps {
+            if *projection_step > step {
+                live.insert(owner.0);
+                if let Some(TargetBindingProjection::Var(binding)) =
+                    self.target_binding_projection_by_owner.get(owner)
+                {
+                    live.insert(binding.0);
+                }
+            }
+        }
+        live.into_iter().collect()
+    }
+
+    fn target_projection_steps(
+        &self,
+        constraint_ids: &[usize],
+        targets: &[SelectorTarget],
+    ) -> BTreeMap<SelectorVariableId, usize> {
+        let components = self.variable_components(constraint_ids);
+        let variable_last_steps = self.variable_last_constraint_steps(constraint_ids);
+        let equality_check_steps = self.equality_check_steps(constraint_ids);
+        targets
+            .iter()
+            .filter_map(|target| {
+                let component = components.get(&target.owner.0)?;
+                let mut projection_step = component
+                    .iter()
+                    .filter_map(|variable| variable_last_steps.get(variable).copied())
+                    .max()
+                    .unwrap_or(0);
+                for constraint in &self.equality_constraints {
+                    if component.contains(&constraint.left.0)
+                        || component.contains(&constraint.right.0)
+                    {
+                        projection_step = projection_step.max(
+                            equality_check_steps
+                                .get(&constraint.id)
+                                .copied()
+                                .unwrap_or(0),
+                        );
+                    }
+                }
+                (projection_step > 0).then_some((target.owner, projection_step))
+            })
+            .collect()
+    }
+
+    fn variable_components(&self, constraint_ids: &[usize]) -> BTreeMap<usize, BTreeSet<usize>> {
+        let mut adjacency = BTreeMap::<usize, BTreeSet<usize>>::new();
+        for constraint_id in constraint_ids {
+            connect_variables(
+                self.variables_for_constraint(*constraint_id),
+                &mut adjacency,
+            );
+        }
+        for constraint in &self.equality_constraints {
+            connect_variables(
+                [constraint.left.0, constraint.right.0]
+                    .into_iter()
+                    .collect(),
+                &mut adjacency,
+            );
+        }
+
+        let mut components = BTreeMap::<usize, BTreeSet<usize>>::new();
+        let mut visited = BTreeSet::<usize>::new();
+        for variable in adjacency.keys().copied().collect::<Vec<_>>() {
+            if visited.contains(&variable) {
+                continue;
+            }
+            let mut component = BTreeSet::<usize>::new();
+            let mut stack = vec![variable];
+            visited.insert(variable);
+            while let Some(current) = stack.pop() {
+                component.insert(current);
+                for neighbor in adjacency.get(&current).into_iter().flatten() {
+                    if visited.insert(*neighbor) {
+                        stack.push(*neighbor);
+                    }
+                }
+            }
+            for member in &component {
+                components.insert(*member, component.clone());
+            }
+        }
+        components
+    }
+
+    fn equality_checks_by_step(&self, constraint_ids: &[usize]) -> EqualityCheckSchedule {
+        let equality_check_steps = self.equality_check_steps(constraint_ids);
+        (1..=constraint_ids.len())
+            .map(|step| {
+                let checks = self
+                    .equality_constraints
+                    .iter()
+                    .filter(|constraint| {
+                        equality_check_steps
+                            .get(&constraint.id)
+                            .is_some_and(|check_step| *check_step == step)
+                    })
+                    .map(|constraint| (constraint.left.0, constraint.right.0, constraint.kind))
+                    .collect();
+                (step, checks)
+            })
+            .collect()
+    }
+
+    fn equality_check_steps(&self, constraint_ids: &[usize]) -> BTreeMap<usize, usize> {
+        let variable_last_steps = self.variable_last_constraint_steps(constraint_ids);
+        let final_step = constraint_ids.len();
+        self.equality_constraints
+            .iter()
+            .filter_map(|constraint| {
+                let check_step = variable_last_steps
+                    .get(&constraint.left.0)
+                    .copied()
+                    .unwrap_or(final_step)
+                    .max(
+                        variable_last_steps
+                            .get(&constraint.right.0)
+                            .copied()
+                            .unwrap_or(final_step),
+                    );
+                (check_step > 0).then_some((constraint.id, check_step))
+            })
+            .collect()
+    }
+
+    fn variable_last_constraint_steps(&self, constraint_ids: &[usize]) -> BTreeMap<usize, usize> {
+        let mut last_steps = BTreeMap::<usize, usize>::new();
+        for (idx, constraint_id) in constraint_ids.iter().enumerate() {
+            for variable in self.variables_for_constraint(*constraint_id) {
+                last_steps.insert(variable, idx + 1);
+            }
+        }
+        last_steps
+    }
+
+    fn variables_for_constraint(&self, id: usize) -> BTreeSet<usize> {
+        let mut variables = BTreeSet::new();
+        if let Some(constraint) = self.unary_constraints.iter().find(|c| c.id == id) {
+            variables.insert(constraint.variable.0);
+        }
+        if let Some(constraint) = self.node_unary_constraints.iter().find(|c| c.id == id) {
+            variables.insert(constraint.variable.0);
+        }
+        if let Some(constraint) = self.ordinal_unary_constraints.iter().find(|c| c.id == id) {
+            variables.insert(constraint.variable.0);
+        }
+        if let Some(constraint) = self.binary_constraints.iter().find(|c| c.id == id) {
+            variables.insert(constraint.left.0);
+            variables.insert(constraint.right.0);
+        }
+        if let Some(constraint) = self.owner_ordinal_constraints.iter().find(|c| c.id == id) {
+            variables.insert(constraint.owner.0);
+            variables.insert(constraint.ordinal.0);
+        }
+        if let Some(constraint) = self.owner_node_constraints.iter().find(|c| c.id == id) {
+            variables.insert(constraint.owner.0);
+            variables.insert(constraint.node.0);
+        }
+        if let Some(constraint) = self.node_node_constraints.iter().find(|c| c.id == id) {
+            variables.insert(constraint.left.0);
+            variables.insert(constraint.right.0);
+        }
+        if let Some(constraint) = self.node_list_constraints.iter().find(|c| c.id == id) {
+            variables.insert(constraint.parent.0);
+            for child in constraint.segments.iter().flatten() {
+                variables.insert(child.0);
+            }
+        }
+        if let Some(constraint) = self.node_ordinal_constraints.iter().find(|c| c.id == id) {
+            variables.insert(constraint.node.0);
+            variables.insert(constraint.ordinal.0);
+        }
+        if let Some(constraint) = self.node_string_constraints.iter().find(|c| c.id == id) {
+            variables.insert(constraint.node.0);
+            variables.insert(constraint.string.0);
+        }
+        if let Some(constraint) = self.owner_string_constraints.iter().find(|c| c.id == id) {
+            variables.insert(constraint.owner.0);
+            variables.insert(constraint.string.0);
+        }
+        variables
+    }
+
     fn constraint_ids(&self) -> Vec<usize> {
-        (0..self.next_constraint_id).collect()
+        let equality_ids = self
+            .equality_constraints
+            .iter()
+            .map(|constraint| constraint.id)
+            .collect::<BTreeSet<_>>();
+        let mut remaining = (0..self.next_constraint_id)
+            .filter(|id| !equality_ids.contains(id))
+            .collect::<BTreeSet<_>>();
+        let variables_by_constraint = remaining
+            .iter()
+            .map(|id| (*id, self.variables_for_constraint(*id)))
+            .collect::<BTreeMap<_, _>>();
+        let mut ordered = Vec::with_capacity(remaining.len());
+        let mut bound = BTreeSet::<usize>::new();
+
+        while !remaining.is_empty() {
+            let has_connected = !bound.is_empty()
+                && remaining.iter().any(|id| {
+                    variables_by_constraint
+                        .get(id)
+                        .is_some_and(|variables| !variables.is_disjoint(&bound))
+                });
+            if !bound.is_empty() && !has_connected {
+                bound.clear();
+            }
+
+            let Some(chosen) = remaining
+                .iter()
+                .min_by_key(|id| {
+                    let variables = variables_by_constraint.get(id).expect("constraint vars");
+                    let connected = bound.is_empty() || !variables.is_disjoint(&bound);
+                    let new_variables = variables.difference(&bound).count();
+                    (
+                        usize::from(!connected),
+                        self.constraint_order_rank(**id),
+                        new_variables,
+                        variables.len(),
+                        **id,
+                    )
+                })
+                .copied()
+            else {
+                break;
+            };
+            remaining.remove(&chosen);
+            if let Some(variables) = variables_by_constraint.get(&chosen) {
+                bound.extend(variables.iter().copied());
+            }
+            ordered.push(chosen);
+        }
+
+        ordered
+    }
+
+    fn constraint_order_rank(&self, id: usize) -> usize {
+        if self
+            .owner_node_constraints
+            .iter()
+            .any(|constraint| constraint.id == id)
+            || self
+                .owner_ordinal_constraints
+                .iter()
+                .any(|constraint| constraint.id == id)
+            || self
+                .node_ordinal_constraints
+                .iter()
+                .any(|constraint| constraint.id == id)
+        {
+            return 0;
+        }
+        if self
+            .binary_constraints
+            .iter()
+            .any(|constraint| constraint.id == id)
+            || self
+                .node_node_constraints
+                .iter()
+                .any(|constraint| constraint.id == id)
+            || self
+                .node_list_constraints
+                .iter()
+                .any(|constraint| constraint.id == id)
+        {
+            return 1;
+        }
+        if self
+            .unary_constraints
+            .iter()
+            .any(|constraint| constraint.id == id)
+            || self
+                .owner_string_constraints
+                .iter()
+                .any(|constraint| constraint.id == id)
+            || self
+                .node_string_constraints
+                .iter()
+                .any(|constraint| constraint.id == id)
+        {
+            return 2;
+        }
+        if let Some(constraint) = self
+            .node_unary_constraints
+            .iter()
+            .find(|constraint| constraint.id == id)
+        {
+            return match &constraint.kind {
+                NodeUnaryConstraintKind::Kind { .. }
+                | NodeUnaryConstraintKind::ChildCount { .. } => 4,
+                _ => 3,
+            };
+        }
+        if self
+            .ordinal_unary_constraints
+            .iter()
+            .any(|constraint| constraint.id == id)
+        {
+            return 3;
+        }
+        5
     }
 }
 
@@ -2461,7 +2828,7 @@ struct EqualityConstraint {
     kind: EqualityConstraintKind,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 enum EqualityConstraintKind {
     Equal,
     NotEqual,
@@ -2517,8 +2884,6 @@ fn atom_kind(atom: &SelectorAtom) -> &'static str {
 struct FactIndex {
     all_owners: BTreeSet<OwnerId>,
     all_nodes: BTreeSet<u32>,
-    all_statement_ordinals: BTreeSet<StatementOrdinal>,
-    all_strings: BTreeSet<String>,
     owner_facts: Vec<(OwnerId, StatementOrdinal, String)>,
     statement_ordinal_by_owner: BTreeMap<OwnerId, StatementOrdinal>,
     owner_by_statement_ordinal: BTreeMap<StatementOrdinal, OwnerId>,
@@ -2571,7 +2936,6 @@ impl FactIndex {
                 index
                     .owner_by_statement_ordinal
                     .insert(*statement_ordinal, *owner);
-                index.all_statement_ordinals.insert(*statement_ordinal);
             }
         }
 
@@ -2585,7 +2949,6 @@ impl FactIndex {
                     ..
                 } => {
                     index.declared_bindings.push((*owner, binding.clone()));
-                    index.all_strings.insert(binding.clone());
                     index
                         .owner_bindings
                         .entry(*owner)
@@ -2708,7 +3071,6 @@ impl FactIndex {
                 }
                 SelectorFact::AstStringLiteral { node, value, .. } => {
                     index.all_nodes.insert(*node);
-                    index.all_strings.insert(value.clone());
                     index.ast_string_literals.push((*node, value.clone()));
                 }
                 SelectorFact::AstStringWildcard { node, token, .. } => {
@@ -2725,7 +3087,6 @@ impl FactIndex {
                 }
                 SelectorFact::AstIdentifierName { node, value, .. } => {
                     index.all_nodes.insert(*node);
-                    index.all_strings.insert(value.clone());
                     index.ast_identifier_names.push((*node, value.clone()));
                 }
                 SelectorFact::AstPropertyName { node, value, .. } => {
@@ -2762,7 +3123,6 @@ impl FactIndex {
                     ..
                 } => {
                     index.all_nodes.insert(*node);
-                    index.all_statement_ordinals.insert(*statement_ordinal);
                     index.ast_top_levels.push((*node, *statement_ordinal));
                 }
             }


### PR DESCRIPTION
Stacked on #2456.

Summary:
- route simple exact anonymous statement selectors through the global selector solver
- keep alpha/multiline anonymous selectors on the existing resolver fallback until native support is bounded
- move anonymous binding adoption after global selector resolution so residual ownership is pruned when needed
- replace remaining selector-deferred checks with `MemberRequest::resolves_after_stage_a()`

Validation:
- `nix --offline develop --command pre-commit run --files devinfra/js/debundle/lowering/anonymous.rs devinfra/js/debundle/lowering/exports.rs devinfra/js/debundle/lowering/materialize/mod.rs devinfra/js/debundle/lowering/materialize/plan_builder.rs devinfra/js/debundle/lowering/mod.rs devinfra/js/debundle/lowering/plans.rs devinfra/js/debundle/selector_ir_lowering.rs`
- `nix --offline develop --command bbr test //devinfra/js/debundle:selector_ir_lowering_test //devinfra/js/debundle:selector_ir_solver_test //devinfra/js/debundle/e2e:anonymous_statement_test //devinfra/js/debundle/e2e:syntactic_holes_test //devinfra/js/debundle/e2e:selector_diagnostics_report_test` (Bazel invocation f2e5d1ad-1c7f-44d1-8521-15e83a786b36)