### PR TITLE
haku-worker: replace ant poll loop with Python SDK worker.py

### DIFF
--- a/cluster/k8s/haku/agent-worker/deployment.yaml
+++ b/cluster/k8s/haku/agent-worker/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: haku-worker
   annotations:
-    description: "Anthropic Managed Agents self-hosted worker (Runtime B; ducktape haku/runtime/managed_agent/self_hosted). Long-polls Anthropic's work queue (`ant beta:worker poll`) and runs tool calls in-sandbox. The haku-sandbox perimeter (haku-mitmproxy egress, RBAC, ResourceQuota) is the fence; the worker holds only the environment key, never the org API key."
+    description: "Anthropic Managed Agents self-hosted worker (Runtime B; ducktape haku/runtime/managed_agent/self_hosted). Long-polls Anthropic's work queue (worker.py on the anthropic Python SDK) and runs tool calls in-sandbox. The haku-sandbox perimeter (haku-mitmproxy egress, RBAC, ResourceQuota) is the fence; the worker holds only the environment key, never the org API key."
 spec:
   replicas: 1
   strategy:
@@ -51,12 +51,6 @@ spec:
             # login shell k8s won't set it, so pin it to haku's home.
             - name: HOME
               value: /home/haku
-            # Verbose ant worker logging (global --debug). Currently ON while we
-            # diagnose sessions stalling at "idle" (worker claims work but tool
-            # results never post — suspected mitmproxy interference with the
-            # session-tool-runner stream). Set to "" or remove to disable.
-            - name: ANT_DEBUG
-              value: "1"
             - name: ANTHROPIC_ENVIRONMENT_ID
               value: env_015uqL9WAMSDytQEWWmLG9zF # haku-selfhosted environment (not secret)
             - name: ANTHROPIC_ENVIRONMENT_KEY

--- a/flake.nix
+++ b/flake.nix
@@ -557,11 +557,13 @@
           ];
         };
 
-        # Haku Managed Agents self-hosted worker (Runtime B). anthropic-cli and
-        # fastmcp are ducktape packages, passed in rather than re-derived.
+        # Haku Managed Agents self-hosted worker (Runtime B). fastmcp is a
+        # ducktape package, passed in rather than re-derived. The poll loop is
+        # worker.py on the anthropic Python SDK now, not `ant` (the anthropic-cli
+        # package stays available in the devshell); see nixos.nix.
         haku-worker = nixpkgs.lib.nixosSystem {
           inherit system;
-          specialArgs = { inherit (ducktapePkgs) anthropic-cli fastmcp; };
+          specialArgs = { inherit (ducktapePkgs) fastmcp; };
           modules = [
             ./haku/runtime/managed_agent/self_hosted/nixos.nix
           ];

--- a/haku/runtime/managed_agent/self_hosted/BUILD.bazel
+++ b/haku/runtime/managed_agent/self_hosted/BUILD.bazel
@@ -1,0 +1,8 @@
+# worker.py is intentionally NOT a Bazel target. It runs only inside the
+# haku-worker NixOS image, against the anthropic Python SDK ≥0.111 (the Managed
+# Agents worker lib), pinned in nixos.nix. The repo's shared Bazel lockfile is
+# held at anthropic 0.80 by agent-framework-anthropic's hard pin
+# (anthropic<0.80.1), which predates that lib — so a py_library here would fail
+# the mypy aspect on `import anthropic.lib.environments`. It's a baked script
+# like entrypoint.sh; ruff still lints it via pre-commit.
+# gazelle:exclude worker.py

--- a/haku/runtime/managed_agent/self_hosted/README.md
+++ b/haku/runtime/managed_agent/self_hosted/README.md
@@ -6,26 +6,35 @@ sandbox, `config.type: self_hosted`). The Anthropic-hosted-sandbox alternative i
 the sibling <../anthropic_hosted/README.md>. Full design + tradeoffs:
 <../../../plans/managed_agents.md> (+ <../../../plans/managed_agents_artifacts.md>).
 
-> **As-built drift:** the sections below describe the original design (systemd
-> PID 1, `/init`, GitHub clone). The worker as actually brought up runs the nix
-> closure **directly** (non-root, no systemd), bakes `/bin/bash`, clones ducktape
-> from the in-cluster Forgejo mirror, and is gated only by the upstream
-> empty-tool-result deadlock. See <debug/self_hosted_worker_bringup.md> for the
-> as-built runtime, the fix chain, and open issues.
+The bring-up RCA — the fix chain, diagnostics, and open issues — is in
+<debug/self_hosted_worker_bringup.md>.
 
-## "ant-all-the-way" — no `anthropic` Python SDK
+## The worker is `worker.py` on the anthropic Python SDK (not `ant`)
 
-This component uses **only the `ant` CLI**, no `anthropic` Python SDK. Why: the
-SDK's self-hosted worker (`EnvironmentWorker`) and session APIs need
-`anthropic>=0.103`, but `agent-framework-anthropic` (used by Runtime C and the
-skill/grocy evals) hard-pins `anthropic==0.80.0` in the shared lockfile. The
-`ant` binary carries its own deps, so leaning on it sidesteps the conflict
-entirely — no lockfile bump, no second pip version, Runtime C untouched.
+The poll loop is `worker.py`, built on the official `anthropic` Python SDK's
+`EnvironmentWorker`. It replaced `ant beta:worker poll` (the Go CLI) because the
+Go SDK's session tool runner posts an **empty text block** for empty tool output,
+which the API 400s — deadlocking the session
+([anthropic-sdk-go#377](https://github.com/anthropics/anthropic-sdk-go/issues/377)).
+The Python session runner guards that exact case (`"(no output)"`), so the
+Python worker sidesteps the deadlock. The Go-vs-Python source evidence is in the
+RCA.
 
-The cost: the **warm-session supervisor is deferred**. The wake trigger is a
-scheduled deployment that fires a fresh session each tick; `haku-state` (git) is
-the durable memory, so a cold session just re-orients. Adding a warm supervisor
-later is the one thing that would reintroduce the SDK-version question.
+**Why the SDK is pinned in `nixos.nix`, not the shared Bazel lockfile:** the
+worker lib (`anthropic.lib.environments`) needs `anthropic>=0.111`, but
+`agent-framework-anthropic` (used by `haku/runtime/agent`) hard-pins
+`anthropic<0.80.1` on every release to date — an irreconcilable lockfile
+conflict. So the worker closure gets `anthropic` 0.111 via a `python3` override
+in `nixos.nix`, and `worker.py` is a baked script excluded from Bazel (see the
+local `BUILD.bazel`) — independent of the repo lockfile, Runtime C untouched.
+
+The **control plane** still uses `ant` (`provision.sh`,
+`ant beta:deployments run`, `…:work stats`) — only the in-pod poll loop moved to
+Python. The `anthropic-cli` package stays in the devshell.
+
+The **warm-session supervisor is deferred**: the wake trigger is a scheduled
+deployment that fires a fresh session each tick; `haku-state` (git) is the
+durable memory, so a cold session just re-orients.
 
 ## Pieces
 
@@ -35,45 +44,46 @@ later is the one thing that would reintroduce the SDK-version question.
 | `haku.agent.yaml`       | agent: thin `system` pointer, fixed toolset + tana `mcp_toolset` | control plane |
 | `haku.deployment.yaml`  | scheduled-deployment wake trigger                                | control plane |
 | `provision.sh`          | one-shot: create environment/agent/vault/deployment via `ant`    | operator / CI |
-| `entrypoint.sh`         | clone ducktape + haku-state, then `ant beta:worker poll`         | `haku-worker` |
+| `entrypoint.sh`         | clone ducktape + haku-state, then exec `haku-worker`             | `haku-worker` |
+| `worker.py`             | the poll loop (anthropic Python SDK `EnvironmentWorker`)         | `haku-worker` |
 | `nixos.nix`             | full-NixOS worker image (`nix build .#haku-worker-image`)        | CI / build    |
 
 ## Trust split — keep the org key off the worker
 
 - **Worker pod** (`haku-sandbox`): only `ANTHROPIC_ENVIRONMENT_KEY`
-  (`sk-ant-oat01-…`, one environment's work queue). A prompt-injected tool call
-  can't reach the control plane.
+  (`sk-ant-oat01-…`, one environment's work queue). The worker authenticates
+  every call with a Bearer sub-client derived from it; a prompt-injected tool
+  call can't reach the control plane.
 - **Provisioning** (`provision.sh`, deployment management, `…:work stats`): the
   org-scoped `ANTHROPIC_API_KEY`, run from CI / the operator laptop — **never**
   on the worker host.
 
 ## Worker image (`nix build .#haku-worker-image`)
 
-A full-NixOS container image (`nixos.nix`, systemd PID 1 — declaratively
-consistent with the rest of the fleet) carrying `bash`, `git`, `kubectl`,
-`postgresql` (`psql`), `curl`, `jq`, `cacert`, `fastmcp`, and the **`ant` CLI**
-(the `anthropic-cli` nix package). The `haku-worker` systemd unit runs
-`entrypoint.sh` as the non-root `haku` user. Build the rootfs tarball with
-`nix build .#haku-worker-image`; CI imports it (`podman import … --change 'CMD
-["/init"]'`) and pushes to GHCR, pinned by Flux — see
-<../../../../cluster/docs/container-images.md>.
+A full-NixOS rootfs (`nixos.nix`, declaratively consistent with the fleet)
+carrying `bash`, `git`, `kubectl`, `postgresql` (`psql`), `curl`, `jq`, `cacert`,
+`fastmcp`, and `haku-worker` (the pinned `python3` + `anthropic` 0.111 running
+`worker.py`). We do **not** boot it: booting systemd PID 1 in an unprivileged
+container can't mount the API filesystems, so the pod runs the closure
+**directly** — k8s execs `/sw/bin/haku-worker-run` (a wrapper that puts the tool
+closure on PATH and execs `entrypoint.sh`) as the non-root `haku` uid with all
+caps dropped. Build the uncompressed rootfs tarball with `nix build
+.#haku-worker-image`; CI imports it (`podman import`) and pushes to GHCR, pinned
+by Flux — see <../../../../cluster/docs/container-images.md>.
 
-Runs **unprivileged** on the cluster's cgroup-v2 (Talos) nodes — k8s boots it
-with `command: ["/init"]`; no `--privileged`, no extra caps. The fixed `ant`
-toolset is `bash/read/write/edit/glob/grep`; Haku reaches Plaid (`psql`),
-Google (`curl`), and the cluster (`kubectl`, in-cluster `haku` SA) through
-`bash`. Tana is a native `mcp_toolset` (Anthropic-side, vault auth).
+The fixed toolset is `agent_toolset_20260401` (`bash/read/write/edit/glob/grep`);
+Haku reaches Plaid (`psql`), Google (`curl`), and the cluster (`kubectl`,
+in-cluster `haku` SA) through `bash`. Tana is a native `mcp_toolset`
+(Anthropic-side, vault auth).
 
 ## k8s wiring
 
 The `haku-worker` Deployment, its `haku-worker` ServiceAccount (bound to
 `haku-sandbox-admin`), the `ANTHROPIC_ENVIRONMENT_KEY` secret stub, and the
-clone/git env live in <../../../../cluster/k8s/haku/agent-worker/README.md> —
-shipped **suspended** (it's the first systemd-PID1 pod in the cluster and needs
-an operator-generated environment key; that dir's README is the activation
-runbook). The worker reuses Haku's `haku-sandbox` perimeter (`haku-sandbox-admin`
-RBAC, `haku-mitmproxy` egress + CA injection, ResourceQuota); none of it relies
-on agent restraint.
+clone/git env live in <../../../../cluster/k8s/haku/agent-worker/README.md> (that
+dir's README is the activation runbook). The worker reuses Haku's `haku-sandbox`
+perimeter (`haku-sandbox-admin` RBAC, `haku-mitmproxy` egress + CA injection,
+ResourceQuota); none of it relies on agent restraint.
 
 ## Bring-up
 
@@ -89,11 +99,11 @@ ant beta:deployments run --deployment-id "$DEPL_ID"   # test one run, watch in C
 `ANTHROPIC_ENVIRONMENT_ID`, `ANTHROPIC_ENVIRONMENT_KEY`, `HAKU_DUCKTAPE_REPO_URL`,
 `HAKU_STATE_REPO_URL`, `HAKU_GIT_HOST`, `HAKU_GIT_USERNAME`, `HAKU_GIT_PASSWORD`.
 
-Set these on the pod (`envFrom` a Secret/ConfigMap); systemd PID 1 lifts them
-into the `haku-worker` unit via `ImportEnvironment=` (fallback: mount a Secret as
-an env file at `/etc/haku-worker/env`). Set the pod `fsGroup` to the `haku` gid
-so the `/workspace` emptyDir is writable, and layer the `haku-mitmproxy` CA into
-`/etc/ssl/certs/ca-certificates.crt` so HTTPS through the proxy validates.
+The pod runs the closure directly (no systemd), so the Deployment's `env` lands
+straight in the entry process — plus the `HTTP(S)_PROXY`/`SSL_CERT_FILE` the
+`haku-sandbox` Kyverno policy injects for mitmproxy egress (httpx honors both via
+`trust_env`). Set the pod `fsGroup` to the `haku` gid so the `/workspace`
+emptyDir is writable.
 
 Beta-surface field/flag names (`agent_toolset_20260401`, `vault_ids`, the
 deployment schema) follow the `ant` docs as of 2026-06 — verify with

--- a/haku/runtime/managed_agent/self_hosted/debug/self_hosted_worker_bringup.md
+++ b/haku/runtime/managed_agent/self_hosted/debug/self_hosted_worker_bringup.md
@@ -96,9 +96,11 @@ empty-output command, masked by the agent's `2>/dev/null | head`.
 
 ## Diagnostic recipes
 
-- **Worker debug logs:** `ANT_DEBUG=1` on the Deployment → `ant --debug`. Look for
-  `claimed work`, `executing tool`, `dispatched tool … posted=true/false`, and
-  `tool result send hit permanent 4xx`.
+- **Worker debug logs:** the Python `worker.py` logs to stderr at `INFO`
+  (`kubectl logs deploy/haku-worker -n haku-sandbox`); the SDK's
+  `EnvironmentWorker` logs poll/claim/dispatch under the `anthropic` logger.
+  (Historical, on the old `ant` worker: `ANT_DEBUG=1` → `ant --debug`, whose
+  `tool result send hit permanent 4xx` line was the empty-output tell.)
 - **Session timeline (control plane, org key):**
   `ant beta:sessions:events list <sid>` — `agent.tool_use` vs `user.tool_result`
   (match on `tool_use_id`); an unmatched `tool_use` is the stuck one. `is_error`
@@ -114,7 +116,7 @@ empty-output command, masked by the agent's `2>/dev/null | head`.
 
 - `haku.agent.yaml` model is **Sonnet** (`TEMP(debugging)`); restore
   `claude-opus-4-8` and re-pin the deployment.
-- `ANT_DEBUG=1` in the worker Deployment; set to `""` once stable.
+- ~~`ANT_DEBUG=1`~~ — gone with the `ant` worker; `worker.py` logs at `INFO`.
 - mitmproxy `ignore_hosts` is a keeper, but has a `TODO` to tighten (currently
   passes all of `api.anthropic.com`).
 
@@ -131,19 +133,47 @@ pty` + `TERM=dumb` runner, `[output truncated]`, native `glob`/`grep`) and **no
 Implication for "switch to the SDK that runs Claude Code": there isn't one. The
 Managed Agents **SDK** `EnvironmentWorker` (Python/TS/Go) is _also_ an
 independent reimplementation of the same `agent_toolset_20260401` — not Claude
-Code. So switching SDKs does **not** buy Claude Code's harness. The only real
-"switch" options:
+Code. So switching SDKs does **not** buy Claude Code's harness. But the toolsets
+are **hand-rolled per language and not consistent with each other**, and that is
+the lever: the empty-output→400 guard exists in the **Python and TypeScript**
+SDKs but **not** the Go one.
 
-- **Go SDK `EnvironmentWorker`** — a different impl of the toolset that _might_
-  guard the empty-result case better (the API requires `content.text` ≥ 1, so a
-  correct worker must send a placeholder; check the SDK source before betting on
-  it). Avoids the Python lockfile conflict, but means building/maintaining a
-  custom Go worker instead of the stock `ant` CLI.
-- **Python SDK `EnvironmentWorker`** — reopens the `anthropic` 0.103-vs-0.80
-  lockfile conflict that motivated "ant-all-the-way"; avoid.
+## Resolution (2026-06-25): switch the worker to the Python SDK
 
-Neither is Claude Code. Recommended: stay on `ant`, mitigate triggers, and report
-the empty-result→400 deadlock upstream.
+We replaced `ant` (Go) with `worker.py` on the official **anthropic Python SDK**.
+The empty-result deadlock is **Go-specific**, confirmed in source (repos cloned
+in `~/code`):
+
+- **Go (buggy):** `anthropic-sdk-go tools/agenttoolset/agenttoolset.go:145
+textResult(s)` → `BetaTextBlockParam{Text: s}`, no empty guard → the 400.
+- **Python (guarded):** `anthropic-sdk-python
+src/anthropic/lib/tools/_beta_session_runner.py:235` bridges a tool's string
+  result with `content or "(no output)"` (and the block-list path / final
+  fallback likewise default to `"(no output)"`). So an empty tool result becomes
+  `(no output)` — no 400, no deadlock. The TS SDK guards it too.
+
+Why not just bump the **Bazel** lockfile to a guarded `anthropic`: we can't.
+`agent-framework-anthropic` (used by `haku/runtime/agent`) hard-pins
+`anthropic<0.80.1,>=0.80.0` on **every** release through the latest
+(`1.0.0b260618`, checked 2026-06-25) — and the Managed Agents worker lib
+(`anthropic.lib.environments`) only landed ~0.111. So the worker's `anthropic`
+0.111 is pinned **independently in `nixos.nix`** (a `python3` override on the
+worker closure only), and `worker.py` is a baked script excluded from Bazel —
+not in the shared lockfile. See `nixos.nix` + `worker.py` + the local
+`BUILD.bazel`.
+
+The Go artifacts are **kept** for possible future use: the `anthropic-cli`
+package stays in `nix/packages/` and the devshell (just no longer baked into the
+worker image), and the upstream issue
+[anthropic-sdk-go#377](https://github.com/anthropics/anthropic-sdk-go/issues/377)
+tracks a Go-side fix. If `#377` lands and the Bazel-lockfile pin ever frees up,
+revisiting a Go worker (or re-unifying on the SDK lockfile) is open.
+
+Tiers we considered but didn't need: reimplementing the toolset against the SDK
+worker protocol (the `tools=` factory hook accepts custom `BetaTool`s — useful
+only for Claude-Code-grade behavior like spill-large-output-to-file, which the
+stock toolset lacks), or a from-scratch poll/heartbeat/lease loop (heavy; the
+protocol is beta and churning — `worker.go` is ~526 LOC of lease subtlety).
 
 ## Current state & next steps (as of 2026-06-23)
 

--- a/haku/runtime/managed_agent/self_hosted/entrypoint.sh
+++ b/haku/runtime/managed_agent/self_hosted/entrypoint.sh
@@ -25,9 +25,10 @@ clone_or_pull() { # <url> <dest> [extra git clone flags...]
 # Behavior: ducktape's haku/base + haku/run.md, read at runtime (live-editable —
 # no image rebuild to change the manual). NOT --depth 1: the run procedure's
 # base-sync diffs HEAD against the last-reconciled commit (`git log <pin>..HEAD`),
-# which needs that commit present. A week of history covers the wake cadence;
-# a `git log` that reaches past the pin just errors empty (and an empty tool
-# result currently deadlocks the session — ant posts "" and the API 400s it).
+# which needs that commit present. A week of history covers the wake cadence.
+# (A `git log` that reaches past the pin errors with empty output; the Python
+# worker turns empty tool output into "(no output)" rather than deadlocking on
+# it the way `ant` did — see worker.py / anthropic-sdk-go#377.)
 clone_or_pull "$HAKU_DUCKTAPE_REPO_URL" "$ducktape_dir" --shallow-since="1 week ago"
 # Memory + the only write surface.
 clone_or_pull "$HAKU_STATE_REPO_URL" "$state_dir" --depth 1
@@ -37,10 +38,8 @@ git -C "$state_dir" config user.email haku@allegedly.works
 # kubectl uses the pod's haku ServiceAccount token automatically (in-cluster);
 # no kubeconfig to materialize, unlike the Claude Code web home.
 #
-# ANT_DEBUG (set in the Deployment manifest) toggles ant's verbose logging: the
-# global --debug flag must precede the subcommand. Empty/unset = off. Useful for
-# diagnosing the worker's session-tool-runner stream (claim vs result-submission)
-# — e.g. when sessions stall at "idle" behind the mitmproxy egress.
-exec ant ${ANT_DEBUG:+--debug} beta:worker poll \
-  --environment-id "$ANTHROPIC_ENVIRONMENT_ID" \
-  --workdir "$workspace"
+# Long-poll the self-hosted work queue (worker.py on the anthropic Python SDK,
+# baked into the image as `haku-worker`). ANTHROPIC_ENVIRONMENT_ID/_KEY come from
+# the Deployment env; the workdir holds the git clones above.
+export ANTHROPIC_WORKDIR="$workspace"
+exec haku-worker

--- a/haku/runtime/managed_agent/self_hosted/nixos.nix
+++ b/haku/runtime/managed_agent/self_hosted/nixos.nix
@@ -1,7 +1,14 @@
 # NixOS-closure container image for the Haku Managed Agents self-hosted worker
 # (Runtime B, haku/runtime/managed_agent). We build a full-NixOS rootfs (so the
-# whole tool closure — bash/git/kubectl/ant/psql/… — is consistent with the rest
+# whole tool closure — bash/git/kubectl/psql/… — is consistent with the rest
 # of the fleet) but we do NOT boot it: the pod runs the worker process directly.
+#
+# The poll loop is `worker.py` on the official anthropic Python SDK, NOT `ant`
+# (the Go CLI): the Go SDK deadlocks a session on empty tool output
+# (anthropic-sdk-go#377); the Python session runner guards that case. The SDK
+# can't ride the Bazel lockfile (agent-framework-anthropic hard-pins anthropic
+# to 0.80.0, while the worker lib needs ≥0.111), so it's pinned independently in
+# the override below — see <debug/self_hosted_worker_bringup.md>.
 #
 # Runs UNPRIVILEGED and as NON-ROOT: k8s execs `/sw/bin/haku-worker-run` (the
 # wrapper below, on the stable system-path) as uid 1000 (`haku`) with all caps
@@ -17,7 +24,6 @@
 {
   modulesPath,
   pkgs,
-  anthropic-cli,
   fastmcp,
   ...
 }:
@@ -45,8 +51,40 @@ let
     kubectl
     postgresql # psql (Plaid, reached cluster-internally)
     fastmcp # in-cluster MCP facades (tana-mcp-ro, …)
-    anthropic-cli # `ant` — the worker poll loop
   ];
+
+  # anthropic Python SDK ≥0.111 (the Managed Agents worker lib). nixpkgs ships
+  # 0.75 and the repo's Bazel lockfile is held at 0.80 by agent-framework, so
+  # pin it here for the worker closure only: bump the version + sdist, and add
+  # docstring-parser (a runtime dep new since the nixpkgs derivation's 0.75).
+  pythonWithAnthropic =
+    let
+      python = pkgs.python3.override {
+        self = python;
+        packageOverrides = _pyfinal: pyprev: {
+          anthropic = pyprev.anthropic.overridePythonAttrs (old: rec {
+            version = "0.111.0";
+            src = pyprev.fetchPypi {
+              pname = "anthropic";
+              inherit version;
+              hash = "sha256-OcvaCsF6bUI+W/YJgRvWmybt32KZ16RoEm4FvHEc6CY=";
+            };
+            dependencies = (old.dependencies or [ ]) ++ [ pyprev.docstring-parser ];
+            doCheck = false;
+          });
+        };
+      };
+    in
+    python.withPackages (ps: [ ps.anthropic ]);
+
+  # worker.py is the single source of truth (self-contained + runnable on the
+  # SDK). The `haku-worker` command runs it under the pinned interpreter; the
+  # entrypoint execs it like it used to exec `ant beta:worker poll`.
+  haku-worker = pkgs.writeShellApplication {
+    name = "haku-worker";
+    runtimeInputs = [ pythonWithAnthropic ];
+    text = ''exec python ${./worker.py} "$@"'';
+  };
 
   # entrypoint.sh is the single source of truth (self-contained + runnable);
   # bake it in with its shebang patched to the store bash.
@@ -70,7 +108,6 @@ in
 
   networking.hostName = "haku-worker";
   networking.nftables.enable = false;
-  nixpkgs.config.allowUnfree = true; # anthropic-cli is unfree
 
   # Non-root agent user (uid 1000). The pod runs the worker as this uid via
   # securityContext.runAsUser. createHome gives a writable /home/haku in the
@@ -90,7 +127,10 @@ in
   };
 
   security.pki.certificateFiles = [ "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt" ];
-  environment.systemPackages = workerTools ++ [ haku-worker-run ];
+  environment.systemPackages = workerTools ++ [
+    haku-worker-run
+    haku-worker
+  ];
 
   system.stateVersion = "25.11";
 }

--- a/haku/runtime/managed_agent/self_hosted/worker.py
+++ b/haku/runtime/managed_agent/self_hosted/worker.py
@@ -1,0 +1,70 @@
+"""Haku self-hosted Managed Agents worker (Runtime B).
+
+Replaces ``ant beta:worker poll``: long-polls Anthropic's self-hosted work queue
+for the haku-selfhosted environment and services each claimed session's tool
+calls locally with the built-in ``agent_toolset_20260401`` (bash/read/write/
+edit/glob/grep), bound to the workspace.
+
+Why the Python SDK instead of ``ant`` (the Go CLI): the Go SDK's session tool
+runner posts an empty text block when a tool produces empty output, which the
+API rejects with 400 "minimum string length is 1" — deadlocking the session
+(anthropic-sdk-go#377). The Python SDK's session runner guards that exact case
+(substitutes "(no output)"), so this worker sidesteps the deadlock. See
+<debug/self_hosted_worker_bringup.md>.
+
+Credentials: the pod holds ONLY ``ANTHROPIC_ENVIRONMENT_KEY`` (sk-ant-oat01-…),
+never the org API key. The worker authenticates every poll/session/heartbeat
+call with a Bearer sub-client the SDK derives from the environment key, so a
+prompt-injected tool call can't reach the control plane.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+
+from anthropic import AsyncAnthropic
+from anthropic.lib.environments import MANAGED_AGENTS_BETA
+from anthropic.lib.tools.agent_toolset import beta_agent_toolset_20260401
+
+logger = logging.getLogger(__name__)
+
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise SystemExit(f"missing required environment variable {name}")
+    return value
+
+
+async def async_main() -> None:
+    environment_id = _require_env("ANTHROPIC_ENVIRONMENT_ID")
+    environment_key = _require_env("ANTHROPIC_ENVIRONMENT_KEY")
+    workdir = os.environ.get("ANTHROPIC_WORKDIR", "/workspace")
+
+    # The environment key is the worker's only credential. Passing it as
+    # auth_token satisfies the client constructor (no org X-Api-Key is present,
+    # by design); the worker re-derives a Bearer sub-client from it per call.
+    client = AsyncAnthropic(auth_token=environment_key)
+
+    worker = client.beta.environments.work.worker(
+        environment_id=environment_id,
+        environment_key=environment_key,
+        workdir=workdir,
+        tools=lambda env: list(beta_agent_toolset_20260401(env)),
+        # Gates Sessions access to the self-hosted environment; the SDK threads
+        # it through every poll/session/heartbeat call.
+        extra_headers={"anthropic-beta": MANAGED_AGENTS_BETA},
+    )
+    logger.info("polling environment %s (workdir %s)", environment_id, workdir)
+    await worker.run()  # long-poll loop; returns only on cancellation
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+    asyncio.run(async_main())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Replace the in-pod `ant beta:worker poll` (Go) with `worker.py` on the official **anthropic Python SDK** `EnvironmentWorker`.

## Why

`ant` deadlocks a Managed Agents session on **empty tool output**: the Go SDK's session runner posts an empty text block, the API 400s it (`minimum string length is 1`), and the worker never retries — the session hangs forever ([anthropic-sdk-go#377](https://github.com/anthropics/anthropic-sdk-go/issues/377), filed by us). The bug is **Go-specific**: the Python (and TS) SDK session runner guards the exact case (`_to_session_content` → `"(no output)"`). Verified in source; see the RCA.

## How

- `worker.py` — the poll loop (`EnvironmentWorker` + `beta_agent_toolset_20260401`), auth'd by the environment key alone (no org API key on the pod).
- **Can't use the shared Bazel lockfile:** `agent-framework-anthropic` hard-pins `anthropic<0.80.1` on *every* release through the latest, while the worker lib needs `≥0.111`. So anthropic 0.111 is pinned via a `python3` override in `nixos.nix` for the worker closure only, and `worker.py` is a baked script excluded from Bazel (local `BUILD.bazel`). Runtime C untouched.
- Control-plane provisioning still uses `ant`; the `anthropic-cli` package stays in the devshell (Go artifacts kept).
- Drops `ANT_DEBUG` (worker now logs via stdlib).
- Refreshes the README/RCA to as-built (also corrects pre-existing systemd-PID1 drift).

## Validation

Local: image builds; `anthropic` 0.111 + `anthropic.lib.environments` import in the closure; the empty-output guard is present; `worker.py` loads under the pinned interpreter and exits cleanly on missing env. ruff + full pre-commit pass.

**In-cluster live test is gated on merge** — the image CI and Flux ImagePolicy are `devel`-only, so the pod can't roll to this until it lands on `devel`. After merge: CI pushes the image, Flux bumps the tag (~5m), then `ant beta:deployments run` a wake and watch `kubectl logs deploy/haku-worker -n haku-sandbox` for a clean claim→tool→result with no 400.