### PR TITLE
gecko: increase root disk template to 50Gi

### DIFF
--- a/cluster/k8s/gecko/app/virtualmachine.yaml
+++ b/cluster/k8s/gecko/app/virtualmachine.yaml
@@ -32,7 +32,7 @@ spec:
             - ReadWriteOnce
           resources:
             requests:
-              storage: 20Gi
+              storage: 50Gi
           storageClassName: local-path-ovh
           volumeMode: Filesystem
   template:


### PR DESCRIPTION
## Summary

- Increase Gecko's root DataVolume template request from `20Gi` to `50Gi`.

## Notes

This changes the VM template for newly created/recreated root DataVolumes. It does not resize the existing `gecko-root` PVC because `local-path-ovh` does not support PVC expansion and CDI rejects DataVolume spec updates after creation.

## Validation

- `kubectl kustomize cluster/k8s/gecko/app`
- `nix develop -c pre-commit run --files cluster/k8s/gecko/app/virtualmachine.yaml`