### PR TITLE
haku-worker: auto-allow the Tana RO mcp_toolset

### DIFF
--- a/haku/runtime/managed_agent/self_hosted/haku.agent.yaml
+++ b/haku/runtime/managed_agent/self_hosted/haku.agent.yaml
@@ -29,8 +29,15 @@ tools:
         type: always_allow
   # Tana (read-only) as a native MCP tool; auth is injected at Anthropic's egress
   # from the vault credential (provision.sh), so the pod never sees the token.
+  # Auto-allow like the bash toolset: it's the read-only Tana facade and the pod
+  # is the trust boundary — without this the mcp_toolset defaults to always_ask,
+  # which parks an unattended scan on the first Tana call awaiting approval.
   - type: mcp_toolset
     mcp_server_name: tana-ro
+    default_config:
+      enabled: true
+      permission_policy:
+        type: always_allow
 mcp_servers:
   - type: url
     name: tana-ro


### PR DESCRIPTION
The `agent_toolset_20260401` is `always_allow`, but the `tana-ro` `mcp_toolset` had no `permission_policy`, so it defaulted to `always_ask`. The first live scan (after the Python-worker switch landed) ran 37 bash/read tools fine, then **parked awaiting approval** on the Tana `list_workspaces` call. It's the read-only Tana facade and the pod is the trust boundary, so auto-allow it like the bash toolset. Applied live via `ant beta:agents update` + deployment re-pin.