### PR TITLE
debundle: expand native source_match lowering for Tana selectors

### DIFF
--- a/devinfra/js/debundle/e2e/anonymous_statement_test.rs
+++ b/devinfra/js/debundle/e2e/anonymous_statement_test.rs
@@ -695,7 +695,7 @@ export { runtimeBinding, siblingBinding, Existing };
 }
 
 #[test]
-fn source_match_timing_env_reports_member_selector_resolution() {
+fn multi_statement_native_source_match_skips_legacy_resolver_timing() {
     let fixture = run_fixture_with_env(
         FixtureOpts::new(
             r#"const runtimePrefix = "OK:";
@@ -721,23 +721,11 @@ function formatValue(value) {
     );
 
     assert_entry_output(&fixture, "OK:OK\n");
-    for required in [
-        "[debundle source_match]",
-        "request=static/app::format",
-        "kind=members[].selector.source_match export=`formatValue`",
-        "selector_key=",
-        "body_key=",
-        "body_indices=[1]",
-        "binding=runtimeFormat",
-        "target_binding=`formatValue`",
-        "selector=const prefix = \"OK:\"; function formatValue(value) { return prefix + value.trim().toUpperCase(); }",
-    ] {
-        assert!(
-            fixture.stderr.contains(required),
-            "stderr missing {required:?}\nstderr:\n{}",
-            fixture.stderr,
-        );
-    }
+    assert!(
+        !fixture.stderr.contains("[debundle source_match]"),
+        "native multi-statement source_match should not call the legacy resolver\nstderr:\n{}",
+        fixture.stderr,
+    );
 }
 
 #[test]
@@ -840,7 +828,7 @@ export { RuntimeWidget };
 }
 
 #[test]
-fn source_match_timing_preview_can_be_disabled() {
+fn multi_statement_native_source_match_ignores_legacy_timing_preview_env() {
     let fixture = run_fixture_with_env(
         FixtureOpts::new(
             r#"const runtimePrefix = "ok:";
@@ -869,25 +857,9 @@ function normalizeValue(value) {
     );
 
     assert_entry_output(&fixture, "ok:ok\n");
-    for required in [
-        "[debundle source_match]",
-        "request=static/app::normalize",
-        "kind=members[].selector.source_match export=`normalizeValue`",
-        "selector_key=",
-        "body_key=",
-        "body_indices=[1]",
-        "binding=runtimeNormalize",
-        "target_binding=`normalizeValue`",
-    ] {
-        assert!(
-            fixture.stderr.contains(required),
-            "stderr missing {required:?}\nstderr:\n{}",
-            fixture.stderr,
-        );
-    }
     assert!(
-        !fixture.stderr.contains("function normalizeValue"),
-        "timing preview should be hidden when DUCKTAPE_SOURCE_MATCH_TIMING_PREVIEW=0\nstderr:\n{}",
+        !fixture.stderr.contains("[debundle source_match]"),
+        "native multi-statement source_match should not call the legacy resolver\nstderr:\n{}",
         fixture.stderr,
     );
 }

--- a/devinfra/js/debundle/e2e/syntactic_holes_test.rs
+++ b/devinfra/js/debundle/e2e/syntactic_holes_test.rs
@@ -1017,6 +1017,54 @@ STMT_LIST_TAIL;"#,
 }
 
 #[test]
+fn binding_group_source_match_range_with_internal_stmt_list_hole_stays_native() {
+    let fixture = run_fixture_with_env(
+        FixtureOpts::new(
+            r#"const runtimeFirst = "alpha";
+const ignoredMiddle = "middle";
+function runtimeSecond() {
+  return `${runtimeFirst}:beta`;
+}
+console.log(runtimeSecond(), ignoredMiddle);
+export { runtimeFirst, ignoredMiddle, runtimeSecond };
+"#,
+            vec![logical_module_with_binding_groups(
+                "selected/gapped-range",
+                &[],
+                &[BindingGroup::source_alpha(
+                    r#"const first = "alpha";
+STMT_LIST_MIDDLE;
+function second() {
+  return `${first}:beta`;
+}"#,
+                    &[("first", "first"), ("second", "second")],
+                )],
+            )],
+        ),
+        &[("DUCKTAPE_SOURCE_MATCH_TIMINGS", "1")],
+    );
+    assert!(
+        !fixture.stderr.contains("[debundle source_match]"),
+        "native binding_group source_match with internal STMT_LIST should not call the legacy resolver\nstderr:\n{}",
+        fixture.stderr
+    );
+
+    assert_entry_output(&fixture, "alpha:beta middle\n");
+    assert_module_exports(
+        &fixture.out_root,
+        "static/app/modules/selected/gapped-range.js",
+        &["first", "second"],
+        &["ignoredMiddle"],
+    );
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/modules/selected/gapped-range.js",
+        &["const first", "function second", "alpha"],
+        &["ignoredMiddle", "STMT_LIST"],
+    );
+}
+
+#[test]
 fn binding_group_source_match_range_matches_exported_const_declarations() {
     let fixture = run_fixture(FixtureOpts::new(
         r#"export const runtimeFirstClassName = "Widget-module_first__exp1";

--- a/devinfra/js/debundle/e2e/syntactic_holes_test.rs
+++ b/devinfra/js/debundle/e2e/syntactic_holes_test.rs
@@ -913,8 +913,9 @@ const styles = { first: firstClassName, second: secondClassName };"#,
 
 #[test]
 fn binding_group_source_match_range_ignores_comments_and_exports_subset() {
-    let fixture = run_fixture(FixtureOpts::new(
-        r#"const runtimeFirstClassName = "Widget-module_first__c0m";
+    let fixture = run_fixture_with_env(
+        FixtureOpts::new(
+            r#"const runtimeFirstClassName = "Widget-module_first__c0m";
 // Deliberately between declarations; comments should not become selector anchors.
 const runtimeSecondClassName = "Widget-module_second__m3nt";
 /* Another ignored comment before the aggregate object. */
@@ -925,17 +926,24 @@ const runtimeStyles = {
 console.log(runtimeStyles.first, runtimeStyles.second);
 export { runtimeFirstClassName, runtimeSecondClassName, runtimeStyles };
 "#,
-        vec![logical_module_with_binding_groups(
-            "styles/commented-widget",
-            &[],
-            &[BindingGroup::source_alpha(
-                r#"const firstClassName = STR_LITERAL_MATCHING_RE("^Widget-module_first__[A-Za-z0-9_-]+$");
+            vec![logical_module_with_binding_groups(
+                "styles/commented-widget",
+                &[],
+                &[BindingGroup::source_alpha(
+                    r#"const firstClassName = STR_LITERAL_MATCHING_RE("^Widget-module_first__[A-Za-z0-9_-]+$");
 const secondClassName = STR_LITERAL_MATCHING_RE("^Widget-module_second__[A-Za-z0-9_-]+$");
 const styles = { first: firstClassName, second: secondClassName };"#,
-                &[("styles", "styles")],
+                    &[("styles", "styles")],
+                )],
             )],
-        )],
-    ));
+        ),
+        &[("DUCKTAPE_SOURCE_MATCH_TIMINGS", "1")],
+    );
+    assert!(
+        !fixture.stderr.contains("[debundle source_match]"),
+        "native multi-statement binding_group source_match should not call the legacy resolver\nstderr:\n{}",
+        fixture.stderr
+    );
 
     assert_entry_output(
         &fixture,

--- a/devinfra/js/debundle/e2e/syntactic_holes_test.rs
+++ b/devinfra/js/debundle/e2e/syntactic_holes_test.rs
@@ -967,6 +967,56 @@ const styles = { first: firstClassName, second: secondClassName };"#,
 }
 
 #[test]
+fn binding_group_source_match_range_with_outer_stmt_list_holes_stays_native() {
+    let fixture = run_fixture_with_env(
+        FixtureOpts::new(
+            r#"const ignoredBefore = "before";
+const runtimeFirst = "alpha";
+function runtimeSecond() {
+  return `${runtimeFirst}:beta`;
+}
+const ignoredAfter = "after";
+console.log(runtimeSecond(), ignoredBefore, ignoredAfter);
+export { ignoredBefore, runtimeFirst, runtimeSecond, ignoredAfter };
+"#,
+            vec![logical_module_with_binding_groups(
+                "selected/range",
+                &[],
+                &[BindingGroup::source_alpha(
+                    r#"STMT_LIST_HEAD;
+const first = "alpha";
+function second() {
+  return `${first}:beta`;
+}
+STMT_LIST_TAIL;"#,
+                    &[("first", "first"), ("second", "second")],
+                )],
+            )],
+        ),
+        &[("DUCKTAPE_SOURCE_MATCH_TIMINGS", "1")],
+    );
+    assert!(
+        !fixture.stderr.contains("[debundle source_match]"),
+        "native binding_group source_match with outer STMT_LIST holes should not call the legacy resolver\nstderr:\n{}",
+        fixture.stderr
+    );
+
+    assert_entry_output(&fixture, "alpha:beta before after\n");
+    assert_module_exports(
+        &fixture.out_root,
+        "static/app/modules/selected/range.js",
+        &["first", "second"],
+        &["ignoredBefore", "ignoredAfter"],
+    );
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/modules/selected/range.js",
+        &["const first", "function second", "alpha"],
+        &["ignoredBefore", "ignoredAfter", "STMT_LIST"],
+    );
+}
+
+#[test]
 fn binding_group_source_match_range_matches_exported_const_declarations() {
     let fixture = run_fixture(FixtureOpts::new(
         r#"export const runtimeFirstClassName = "Widget-module_first__exp1";

--- a/devinfra/js/debundle/selector_ir.rs
+++ b/devinfra/js/debundle/selector_ir.rs
@@ -232,6 +232,10 @@ pub enum SelectorAtom {
         ordinal: OrdinalTerm,
         offset: i32,
     },
+    OrdinalBefore {
+        before: OrdinalTerm,
+        after: OrdinalTerm,
+    },
     ReadsMember {
         owner: OwnerTerm,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -498,6 +502,10 @@ impl SelectorProgram {
             SelectorAtom::OrdinalOffset { base, ordinal, .. } => {
                 self.validate_ordinal_term(base, "ordinal_offset.base")?;
                 self.validate_ordinal_term(ordinal, "ordinal_offset.ordinal")
+            }
+            SelectorAtom::OrdinalBefore { before, after } => {
+                self.validate_ordinal_term(before, "ordinal_before.before")?;
+                self.validate_ordinal_term(after, "ordinal_before.after")
             }
             SelectorAtom::ReadsMember {
                 owner,

--- a/devinfra/js/debundle/selector_ir.rs
+++ b/devinfra/js/debundle/selector_ir.rs
@@ -227,6 +227,11 @@ pub enum SelectorAtom {
         node: NodeTerm,
         ordinal: OrdinalTerm,
     },
+    OrdinalOffset {
+        base: OrdinalTerm,
+        ordinal: OrdinalTerm,
+        offset: i32,
+    },
     ReadsMember {
         owner: OwnerTerm,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -489,6 +494,10 @@ impl SelectorProgram {
             SelectorAtom::AstTopLevel { node, ordinal } => {
                 self.validate_node_term(node, "ast_top_level.node")?;
                 self.validate_ordinal_term(ordinal, "ast_top_level.ordinal")
+            }
+            SelectorAtom::OrdinalOffset { base, ordinal, .. } => {
+                self.validate_ordinal_term(base, "ordinal_offset.base")?;
+                self.validate_ordinal_term(ordinal, "ordinal_offset.ordinal")
             }
             SelectorAtom::ReadsMember {
                 owner,

--- a/devinfra/js/debundle/selector_ir.rs
+++ b/devinfra/js/debundle/selector_ir.rs
@@ -208,6 +208,12 @@ pub enum SelectorAtom {
         node: NodeTerm,
         value: StringTerm,
     },
+    AstBareProperty {
+        node: NodeTerm,
+        key: StringTerm,
+        identifier: StringTerm,
+        is_binding: bool,
+    },
     AstOperator {
         node: NodeTerm,
         value: StringTerm,
@@ -457,6 +463,16 @@ impl SelectorProgram {
             | SelectorAtom::AstOperator { node, value } => {
                 self.validate_node_term(node, "ast_label.node")?;
                 self.validate_string_term(value, "ast_label.value")
+            }
+            SelectorAtom::AstBareProperty {
+                node,
+                key,
+                identifier,
+                ..
+            } => {
+                self.validate_node_term(node, "ast_bare_property.node")?;
+                self.validate_string_term(key, "ast_bare_property.key")?;
+                self.validate_string_term(identifier, "ast_bare_property.identifier")
             }
             SelectorAtom::AstBoolLiteral { node, .. } => {
                 self.validate_node_term(node, "ast_bool_literal.node")
@@ -804,6 +820,13 @@ pub enum SelectorFact {
         node: NodeId,
         value: String,
     },
+    AstBareProperty {
+        chunk_id: ChunkId,
+        node: NodeId,
+        key: String,
+        identifier: String,
+        is_binding: bool,
+    },
     AstOperator {
         chunk_id: ChunkId,
         node: NodeId,
@@ -880,6 +903,7 @@ impl SelectorFact {
             Self::AstBoolLiteral { .. } => "ast_bool_literal",
             Self::AstIdentifierName { .. } => "ast_identifier_name",
             Self::AstPropertyName { .. } => "ast_property_name",
+            Self::AstBareProperty { .. } => "ast_bare_property",
             Self::AstOperator { .. } => "ast_operator",
             Self::AstRegexLiteral { .. } => "ast_regex_literal",
             Self::AstSuperClass { .. } => "ast_super_class",
@@ -1002,6 +1026,7 @@ impl SelectorFactStore {
                         value: value.clone(),
                     }),
             );
+        self.extend_ast_bare_property_facts(chunk_id, facts);
         self.facts.extend(
             facts
                 .operator
@@ -1037,6 +1062,112 @@ impl SelectorFactStore {
                     statement_ordinal: StatementOrdinal(*statement_ordinal),
                 }
             }));
+    }
+
+    fn extend_ast_bare_property_facts(&mut self, chunk_id: ChunkId, facts: &ChunkFacts) {
+        let node_kind: BTreeMap<NodeId, NodeKind> = facts.node_kind.iter().copied().collect();
+        let ident_name: BTreeMap<NodeId, &str> = facts
+            .ident_name
+            .iter()
+            .map(|(node, name)| (*node, name.as_str()))
+            .collect();
+        let prop_name: BTreeMap<NodeId, &str> = facts
+            .prop_name
+            .iter()
+            .map(|(node, name)| (*node, name.as_str()))
+            .collect();
+        let mut children_by_parent = BTreeMap::<NodeId, Vec<(u32, NodeId)>>::new();
+        for (parent, index, child) in &facts.child {
+            children_by_parent
+                .entry(*parent)
+                .or_default()
+                .push((*index, *child));
+        }
+        for children in children_by_parent.values_mut() {
+            children.sort_by_key(|(index, _child)| *index);
+        }
+
+        for (node, kind) in &node_kind {
+            match kind {
+                NodeKind::Shorthand => {
+                    if let Some(name) = ident_name.get(node).copied() {
+                        self.facts.push(SelectorFact::AstBareProperty {
+                            chunk_id,
+                            node: *node,
+                            key: name.to_string(),
+                            identifier: name.to_string(),
+                            is_binding: false,
+                        });
+                    }
+                }
+                NodeKind::KeyValue => {
+                    let Some(children) = children_by_parent.get(node) else {
+                        continue;
+                    };
+                    let [(_, key), (_, value)] = children.as_slice() else {
+                        continue;
+                    };
+                    if node_kind.get(value) != Some(&NodeKind::Ident) {
+                        continue;
+                    }
+                    if let Some((key, identifier)) = prop_name
+                        .get(key)
+                        .zip(ident_name.get(value))
+                        .map(|(k, i)| (*k, *i))
+                    {
+                        self.facts.push(SelectorFact::AstBareProperty {
+                            chunk_id,
+                            node: *node,
+                            key: key.to_string(),
+                            identifier: identifier.to_string(),
+                            is_binding: false,
+                        });
+                    }
+                }
+                NodeKind::PatAssign => {
+                    if children_by_parent
+                        .get(node)
+                        .is_some_and(|children| !children.is_empty())
+                    {
+                        continue;
+                    }
+                    if let Some(name) = ident_name.get(node).copied() {
+                        self.facts.push(SelectorFact::AstBareProperty {
+                            chunk_id,
+                            node: *node,
+                            key: name.to_string(),
+                            identifier: name.to_string(),
+                            is_binding: true,
+                        });
+                    }
+                }
+                NodeKind::PatKeyValue => {
+                    let Some(children) = children_by_parent.get(node) else {
+                        continue;
+                    };
+                    let [(_, key), (_, value)] = children.as_slice() else {
+                        continue;
+                    };
+                    if node_kind.get(value) != Some(&NodeKind::BindingIdent) {
+                        continue;
+                    }
+                    if let Some((key, identifier)) = prop_name
+                        .get(key)
+                        .zip(ident_name.get(value))
+                        .map(|(k, i)| (*k, *i))
+                    {
+                        self.facts.push(SelectorFact::AstBareProperty {
+                            chunk_id,
+                            node: *node,
+                            key: key.to_string(),
+                            identifier: identifier.to_string(),
+                            is_binding: true,
+                        });
+                    }
+                }
+                _ => {}
+            }
+        }
     }
 }
 
@@ -1178,6 +1309,31 @@ mod tests {
             chunk_id: ChunkId(7),
             node: 1,
             statement_ordinal: StatementOrdinal(4),
+        }));
+    }
+
+    #[test]
+    fn imports_bare_property_chunk_facts() {
+        let mut chunk = ChunkFacts::default();
+        chunk.node_kind.push((1, NodeKind::Object));
+        chunk.node_kind.push((2, NodeKind::KeyValue));
+        chunk.node_kind.push((3, NodeKind::PropName));
+        chunk.node_kind.push((4, NodeKind::Ident));
+        chunk.child.push((1, 0, 2));
+        chunk.child.push((2, 0, 3));
+        chunk.child.push((2, 1, 4));
+        chunk.prop_name.push((3, "stable".to_string()));
+        chunk.ident_name.push((4, "runtimeValue".to_string()));
+
+        let mut store = SelectorFactStore::default();
+        store.extend_chunk_facts(ChunkId(7), &chunk);
+
+        assert!(store.facts.contains(&SelectorFact::AstBareProperty {
+            chunk_id: ChunkId(7),
+            node: 2,
+            key: "stable".to_string(),
+            identifier: "runtimeValue".to_string(),
+            is_binding: false,
         }));
     }
 

--- a/devinfra/js/debundle/selector_ir_lowering.rs
+++ b/devinfra/js/debundle/selector_ir_lowering.rs
@@ -1477,10 +1477,37 @@ fn native_single_node_hole_roots(
             continue;
         }
         if selector_hole_name(name) && !native_child_list_hole_name(name) {
+            if native_contextual_anything_prop_child_list_carrier(
+                *node,
+                name,
+                &node_kind,
+                &parent_by_child,
+                &child_counts,
+            ) {
+                continue;
+            }
             return None;
         }
     }
     Some(roots)
+}
+
+fn native_contextual_anything_prop_child_list_carrier(
+    node: NodeId,
+    name: &str,
+    node_kind: &BTreeMap<NodeId, NodeKind>,
+    parent_by_child: &BTreeMap<NodeId, (NodeId, u32)>,
+    child_counts: &BTreeMap<NodeId, u32>,
+) -> bool {
+    if hole_name_for(name, ANYTHING_HOLE_KEYWORD).is_none() {
+        return false;
+    }
+    let Some((parent, index)) = parent_by_child.get(&node).copied() else {
+        return false;
+    };
+    index == 0
+        && node_kind.get(&parent) == Some(&NodeKind::ClassProp)
+        && child_counts.get(&parent).copied().unwrap_or(0) == 1
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1516,6 +1543,14 @@ fn classify_native_single_node_hole(
     if kind == Some(NodeKind::BindingIdent) && hole_name_for(name, ANYTHING_HOLE_KEYWORD).is_some()
     {
         return Some(HoleClassification::Supported { root: node });
+    }
+
+    if hole_name_for(name, ANYTHING_HOLE_KEYWORD).is_some()
+        && (kind == Some(NodeKind::Shorthand)
+            || (kind == Some(NodeKind::PatAssign)
+                && child_counts.get(&node).copied().unwrap_or(0) == 0))
+    {
+        return Some(HoleClassification::NotHole);
     }
 
     if native_child_list_hole_name(name) {
@@ -1697,7 +1732,7 @@ fn native_child_list_patterns(
         );
     }
 
-    if valid_child_list_nodes == child_list_hole_nodes {
+    if child_list_hole_nodes.is_subset(&valid_child_list_nodes) {
         Some(patterns)
     } else {
         None
@@ -1821,6 +1856,7 @@ fn object_props_carrier_ident(
             if node_kind.get(&node) == Some(&NodeKind::Shorthand)
                 && ident_name.get(&node).is_some_and(|name| {
                     labeled_hole_name_for(name, OBJECT_PROPS_HOLE_KEYWORD).is_some()
+                        || hole_name_for(name, ANYTHING_HOLE_KEYWORD).is_some()
                 })
             {
                 Some(node)
@@ -1833,6 +1869,7 @@ fn object_props_carrier_ident(
                 && children_by_parent.get(&node).is_none_or(Vec::is_empty)
                 && ident_name.get(&node).is_some_and(|name| {
                     labeled_hole_name_for(name, OBJECT_PROPS_HOLE_KEYWORD).is_some()
+                        || hole_name_for(name, ANYTHING_HOLE_KEYWORD).is_some()
                 })
             {
                 Some(node)
@@ -3287,6 +3324,90 @@ mod tests {
     }
 
     #[test]
+    fn source_match_with_anything_object_props_hole_lowers_natively() {
+        let selector =
+            AnonymousStatementSelector::exact("const actual = { stable: 1, ANYTHING, tail: 2 };");
+        let lowered = lower_member_selector(
+            &context(),
+            "Widget",
+            &MemberSelectorSpec::SourceMatch(selector),
+        )
+        .unwrap();
+
+        assert!(
+            !lowered
+                .program
+                .atoms
+                .iter()
+                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
+        );
+        assert!(lowered.program.atoms.iter().any(|atom| matches!(
+            atom,
+            SelectorAtom::AstChildListPattern {
+                start_index: 0,
+                anchored_left: true,
+                anchored_right: true,
+                segments,
+                ..
+            } if segments.len() == 2
+                && segments[0].len() == 1
+                && segments[1].len() == 1
+        )));
+        assert!(
+            !lowered.program.atoms.iter().any(|atom| matches!(
+                atom,
+                SelectorAtom::AstIdentifierName {
+                    value: StringTerm::Const { value },
+                    ..
+                } if value == "ANYTHING"
+            )),
+            "ANYTHING object-property shorthand is run-hole syntax, not an identifier constraint"
+        );
+    }
+
+    #[test]
+    fn source_match_with_anything_object_pattern_props_hole_lowers_natively() {
+        let selector =
+            AnonymousStatementSelector::exact("const { stable, ANYTHING, tail } = actual;");
+        let lowered = lower_member_selector(
+            &context(),
+            "Widget",
+            &MemberSelectorSpec::SourceMatch(selector),
+        )
+        .unwrap();
+
+        assert!(
+            !lowered
+                .program
+                .atoms
+                .iter()
+                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
+        );
+        assert!(lowered.program.atoms.iter().any(|atom| matches!(
+            atom,
+            SelectorAtom::AstChildListPattern {
+                start_index: 0,
+                anchored_left: true,
+                anchored_right: true,
+                segments,
+                ..
+            } if segments.len() == 2
+                && segments[0].len() == 1
+                && segments[1].len() == 1
+        )));
+        assert!(
+            !lowered.program.atoms.iter().any(|atom| matches!(
+                atom,
+                SelectorAtom::AstIdentifierName {
+                    value: StringTerm::Const { value },
+                    ..
+                } if value == "ANYTHING"
+            )),
+            "ANYTHING object-pattern shorthand is run-hole syntax, not an identifier constraint"
+        );
+    }
+
+    #[test]
     fn source_match_with_declarators_lowers_to_native_child_list_pattern() {
         let selector = AnonymousStatementSelector::exact(
             "const DECLARATORS_BEFORE = null, picked = make(), DECLARATORS_AFTER = null;",
@@ -3324,6 +3445,47 @@ mod tests {
                 } if value.starts_with(DECLARATORS_HOLE_KEYWORD)
             )),
             "DECLARATORS labels are hole syntax, not identifier constraints"
+        );
+    }
+
+    #[test]
+    fn source_match_with_anything_declarators_lowers_to_native_child_list_pattern() {
+        let selector = AnonymousStatementSelector::exact(
+            "const ANYTHING = null, picked = make(), ANYTHING = null;",
+        );
+        let lowered = lower_member_selector(
+            &context(),
+            "Widget",
+            &MemberSelectorSpec::SourceMatch(selector),
+        )
+        .unwrap();
+
+        assert!(
+            !lowered
+                .program
+                .atoms
+                .iter()
+                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
+        );
+        assert!(lowered.program.atoms.iter().any(|atom| matches!(
+            atom,
+            SelectorAtom::AstChildListPattern {
+                start_index: 0,
+                anchored_left: false,
+                anchored_right: false,
+                segments,
+                ..
+            } if segments.len() == 1 && segments[0].len() == 1
+        )));
+        assert!(
+            !lowered.program.atoms.iter().any(|atom| matches!(
+                atom,
+                SelectorAtom::AstIdentifierName {
+                    value: StringTerm::Const { value },
+                    ..
+                } if value == "ANYTHING"
+            )),
+            "ANYTHING declarators are run-hole syntax, not identifier constraints"
         );
     }
 
@@ -3420,6 +3582,47 @@ mod tests {
                 "bare CLASS_REST class selector must not constrain class child count"
             );
         }
+    }
+
+    #[test]
+    fn source_match_with_anything_class_rest_lowers_to_native_child_list_pattern() {
+        let selector = AnonymousStatementSelector::exact(
+            "class Widget { ANYTHING; render() { return 1; } ANYTHING; }",
+        );
+        let lowered = lower_member_selector(
+            &context(),
+            "Widget",
+            &MemberSelectorSpec::SourceMatch(selector),
+        )
+        .unwrap();
+
+        assert!(
+            !lowered
+                .program
+                .atoms
+                .iter()
+                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
+        );
+        assert!(lowered.program.atoms.iter().any(|atom| matches!(
+            atom,
+            SelectorAtom::AstChildListPattern {
+                start_index: 0,
+                anchored_left: false,
+                anchored_right: false,
+                segments,
+                ..
+            } if segments.len() == 1 && segments[0].len() == 1
+        )));
+        assert!(
+            !lowered.program.atoms.iter().any(|atom| matches!(
+                atom,
+                SelectorAtom::AstPropertyName {
+                    value: StringTerm::Const { value },
+                    ..
+                } if value == "ANYTHING"
+            )),
+            "ANYTHING class members are run-hole syntax, not property-name constraints"
+        );
     }
 
     #[test]

--- a/devinfra/js/debundle/selector_ir_lowering.rs
+++ b/devinfra/js/debundle/selector_ir_lowering.rs
@@ -1513,6 +1513,11 @@ fn classify_native_single_node_hole(
         return Some(HoleClassification::Supported { root: node });
     }
 
+    if kind == Some(NodeKind::BindingIdent) && hole_name_for(name, ANYTHING_HOLE_KEYWORD).is_some()
+    {
+        return Some(HoleClassification::Supported { root: node });
+    }
+
     if native_child_list_hole_name(name) {
         return Some(HoleClassification::NotHole);
     }
@@ -2923,6 +2928,83 @@ mod tests {
                 segments,
                 ..
             } if segments.len() == 1
+        )));
+    }
+
+    #[test]
+    fn source_match_with_anything_binding_params_lowers_natively() {
+        let mut selector = AnonymousStatementSelector::exact(
+            "function readable(ANYTHING, ANYTHING) { return 1; }",
+        );
+        selector.identifiers = SourceMatchIdentifierMode::AlphaAll;
+        let lowered = lower_member_selector(
+            &context(),
+            "Widget",
+            &MemberSelectorSpec::SourceMatch(selector),
+        )
+        .unwrap();
+
+        assert!(
+            !lowered
+                .program
+                .atoms
+                .iter()
+                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
+        );
+        assert!(
+            !lowered.program.atoms.iter().any(|atom| matches!(
+                atom,
+                SelectorAtom::AstIdentifierName {
+                    value: StringTerm::Const { value },
+                    ..
+                } if value == "ANYTHING"
+            )),
+            "ANYTHING binding params are hole syntax, not identifier constraints"
+        );
+        let target_owner = lowered.program.targets[lowered.target.0].owner;
+        assert!(lowered.program.atoms.iter().any(|atom| matches!(
+            atom,
+            SelectorAtom::OwnerDeclaresBinding {
+                owner: OwnerTerm::Var { id },
+                binding: StringTerm::Var { .. },
+            } if *id == target_owner
+        )));
+    }
+
+    #[test]
+    fn source_match_with_anything_object_pattern_value_lowers_natively() {
+        let selector =
+            AnonymousStatementSelector::exact("const { stable: ANYTHING } = readInput();");
+        let lowered = lower_member_selector(
+            &context(),
+            "Widget",
+            &MemberSelectorSpec::SourceMatch(selector),
+        )
+        .unwrap();
+
+        assert!(
+            !lowered
+                .program
+                .atoms
+                .iter()
+                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
+        );
+        assert!(
+            !lowered.program.atoms.iter().any(|atom| matches!(
+                atom,
+                SelectorAtom::AstIdentifierName {
+                    value: StringTerm::Const { value },
+                    ..
+                } if value == "ANYTHING"
+            )),
+            "ANYTHING pattern values are hole syntax, not identifier constraints"
+        );
+        assert!(lowered.program.atoms.iter().any(|atom| matches!(
+            atom,
+            SelectorAtom::AstPropertyName {
+                value: StringTerm::Const { value },
+                ..
+            } if value == "stable"
         )));
     }
 

--- a/devinfra/js/debundle/selector_ir_lowering.rs
+++ b/devinfra/js/debundle/selector_ir_lowering.rs
@@ -1644,7 +1644,6 @@ fn native_child_list_patterns(
             .map(|(_index, child)| *child)
             .collect::<Vec<_>>();
         let mut hole_positions = BTreeSet::new();
-        let mut allow_all_hole_pattern = false;
         for (index, child) in children.iter().enumerate() {
             if let Some(ident) = native_child_list_carrier_ident(
                 parent_kind,
@@ -1656,9 +1655,6 @@ fn native_child_list_patterns(
             ) {
                 hole_positions.insert(index);
                 valid_child_list_nodes.insert(ident);
-                if matches!(parent_kind, NodeKind::Object | NodeKind::ObjectPat) {
-                    allow_all_hole_pattern = true;
-                }
                 collect_native_child_list_subtree(*child, &children_by_parent, skipped_nodes);
             }
         }
@@ -1682,7 +1678,7 @@ fn native_child_list_patterns(
 
         let (segments, anchored_left, anchored_right) =
             child_list_segments(&children, &hole_positions);
-        if segments.is_empty() && !allow_all_hole_pattern {
+        if segments.is_empty() && !native_all_hole_child_list_pattern_supported(parent_kind) {
             return None;
         }
         patterns.insert(
@@ -1701,6 +1697,23 @@ fn native_child_list_patterns(
     } else {
         None
     }
+}
+
+fn native_all_hole_child_list_pattern_supported(parent_kind: NodeKind) -> bool {
+    matches!(
+        parent_kind,
+        NodeKind::Block
+            | NodeKind::SwitchCase
+            | NodeKind::Array
+            | NodeKind::VarDecl
+            | NodeKind::Class
+            | NodeKind::Object
+            | NodeKind::ObjectPat
+            | NodeKind::Call
+            | NodeKind::New
+            | NodeKind::OptCall
+            | NodeKind::Switch
+    )
 }
 
 fn single_declarator_segment(
@@ -2674,6 +2687,60 @@ mod tests {
     }
 
     #[test]
+    fn source_match_with_all_stmt_list_lowers_natively_without_block_arity() {
+        let selector = AnonymousStatementSelector::exact("function readable() { STMT_LIST_BODY; }");
+        let lowered = lower_member_selector(
+            &context(),
+            "Widget",
+            &MemberSelectorSpec::SourceMatch(selector),
+        )
+        .unwrap();
+
+        assert!(
+            !lowered
+                .program
+                .atoms
+                .iter()
+                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
+        );
+        assert!(
+            !lowered.program.atoms.iter().any(|atom| matches!(
+                atom,
+                SelectorAtom::AstIdentifierName {
+                    value: StringTerm::Const { value },
+                    ..
+                } if value == "STMT_LIST_BODY"
+            )),
+            "STMT_LIST labels are hole syntax, not identifier constraints"
+        );
+        let block_nodes = lowered
+            .program
+            .atoms
+            .iter()
+            .filter_map(|atom| match atom {
+                SelectorAtom::AstKind {
+                    node: NodeTerm::Var { id },
+                    node_kind,
+                } if *node_kind == NodeKind::Block => Some(*id),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert!(!block_nodes.is_empty());
+        for block_node in block_nodes {
+            assert!(
+                !lowered.program.atoms.iter().any(|atom| matches!(
+                    atom,
+                    SelectorAtom::AstChildCount {
+                        node: NodeTerm::Var { id },
+                        ..
+                    } if *id == block_node
+                )),
+                "bare STMT_LIST block selector must not constrain block child count"
+            );
+        }
+    }
+
+    #[test]
     fn exact_source_match_with_argument_run_holes_lowers_to_native_child_list_pattern() {
         let selector = AnonymousStatementSelector::exact(
             r#"const selectedValue = joinParts("stable", ARGS_BEFORE, importantValue, ARGS_AFTER);"#,
@@ -2722,6 +2789,61 @@ mod tests {
             )),
             "ARGS labels are hole syntax, not identifier constraints"
         );
+    }
+
+    #[test]
+    fn exact_source_match_with_all_argument_run_hole_lowers_natively_without_call_arity() {
+        let selector =
+            AnonymousStatementSelector::exact(r#"const selectedValue = joinParts(ARGS);"#);
+        let lowered = lower_member_selector(
+            &context(),
+            "Widget",
+            &MemberSelectorSpec::SourceMatch(selector),
+        )
+        .unwrap();
+
+        assert!(
+            !lowered
+                .program
+                .atoms
+                .iter()
+                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
+        );
+        assert!(
+            !lowered.program.atoms.iter().any(|atom| matches!(
+                atom,
+                SelectorAtom::AstIdentifierName {
+                    value: StringTerm::Const { value },
+                    ..
+                } if value == "ARGS"
+            )),
+            "ARGS is hole syntax, not an identifier constraint"
+        );
+        let call_nodes = lowered
+            .program
+            .atoms
+            .iter()
+            .filter_map(|atom| match atom {
+                SelectorAtom::AstKind {
+                    node: NodeTerm::Var { id },
+                    node_kind,
+                } if *node_kind == NodeKind::Call => Some(*id),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert!(!call_nodes.is_empty());
+        for call_node in call_nodes {
+            assert!(
+                !lowered.program.atoms.iter().any(|atom| matches!(
+                    atom,
+                    SelectorAtom::AstChildCount {
+                        node: NodeTerm::Var { id },
+                        ..
+                    } if *id == call_node
+                )),
+                "bare ARGS call selector must not constrain call child count"
+            );
+        }
     }
 
     #[test]
@@ -3162,6 +3284,60 @@ mod tests {
             )),
             "CLASS_REST labels are hole syntax, not property-name constraints"
         );
+    }
+
+    #[test]
+    fn source_match_with_all_class_rest_lowers_natively_without_class_arity() {
+        let selector = AnonymousStatementSelector::exact("class Widget { CLASS_REST; }");
+        let lowered = lower_member_selector(
+            &context(),
+            "Widget",
+            &MemberSelectorSpec::SourceMatch(selector),
+        )
+        .unwrap();
+
+        assert!(
+            !lowered
+                .program
+                .atoms
+                .iter()
+                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
+        );
+        assert!(
+            !lowered.program.atoms.iter().any(|atom| matches!(
+                atom,
+                SelectorAtom::AstPropertyName {
+                    value: StringTerm::Const { value },
+                    ..
+                } if value == "CLASS_REST"
+            )),
+            "CLASS_REST is hole syntax, not a property-name constraint"
+        );
+        let class_nodes = lowered
+            .program
+            .atoms
+            .iter()
+            .filter_map(|atom| match atom {
+                SelectorAtom::AstKind {
+                    node: NodeTerm::Var { id },
+                    node_kind,
+                } if *node_kind == NodeKind::Class => Some(*id),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert!(!class_nodes.is_empty());
+        for class_node in class_nodes {
+            assert!(
+                !lowered.program.atoms.iter().any(|atom| matches!(
+                    atom,
+                    SelectorAtom::AstChildCount {
+                        node: NodeTerm::Var { id },
+                        ..
+                    } if *id == class_node
+                )),
+                "bare CLASS_REST class selector must not constrain class child count"
+            );
+        }
     }
 
     #[test]

--- a/devinfra/js/debundle/selector_ir_lowering.rs
+++ b/devinfra/js/debundle/selector_ir_lowering.rs
@@ -410,11 +410,6 @@ impl MemberSelectorProgramBuilder {
         else {
             return Ok(false);
         };
-        if selector.identifiers == SourceMatchIdentifierMode::AlphaAll
-            && !native_alpha_source_match_supported(&facts, &skipped_nodes)
-        {
-            return Ok(false);
-        }
         let bare_properties = if selector.identifiers == SourceMatchIdentifierMode::AlphaAll {
             native_bare_property_selectors(&facts, &skipped_nodes)
         } else {
@@ -559,11 +554,6 @@ impl MemberSelectorProgramBuilder {
         else {
             return Ok(false);
         };
-        if selector.identifiers == SourceMatchIdentifierMode::AlphaAll
-            && !native_alpha_source_match_supported(&facts, &skipped_nodes)
-        {
-            return Ok(false);
-        }
         let bare_properties = if selector.identifiers == SourceMatchIdentifierMode::AlphaAll {
             native_bare_property_selectors(&facts, &skipped_nodes)
         } else {
@@ -1099,25 +1089,6 @@ fn introduces_alpha_scope(kind: NodeKind) -> bool {
             | NodeKind::Setter
             | NodeKind::Catch
     )
-}
-
-fn native_alpha_source_match_supported(
-    facts: &ChunkFacts,
-    skipped_nodes: &BTreeSet<NodeId>,
-) -> bool {
-    let [(_root, _ordinal)] = facts.top_level.as_slice() else {
-        return false;
-    };
-
-    if facts
-        .node_kind
-        .iter()
-        .any(|(node, kind)| !skipped_nodes.contains(node) && *kind == NodeKind::AssignProp)
-    {
-        return false;
-    }
-
-    true
 }
 
 fn native_target_binding_node(
@@ -3271,6 +3242,34 @@ mod tests {
             atom,
             SelectorAtom::AstKind {
                 node_kind: NodeKind::Seq,
+                ..
+            }
+        )));
+    }
+
+    #[test]
+    fn alpha_all_source_match_assign_property_lowers_natively() {
+        let mut selector =
+            AnonymousStatementSelector::exact("const selected = { stable = fallbackValue };");
+        selector.identifiers = SourceMatchIdentifierMode::AlphaAll;
+        let lowered = lower_member_selector(
+            &context(),
+            "Widget",
+            &MemberSelectorSpec::SourceMatch(selector),
+        )
+        .unwrap();
+
+        assert!(
+            !lowered
+                .program
+                .atoms
+                .iter()
+                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
+        );
+        assert!(lowered.program.atoms.iter().any(|atom| matches!(
+            atom,
+            SelectorAtom::AstKind {
+                node_kind: NodeKind::AssignProp,
                 ..
             }
         )));

--- a/devinfra/js/debundle/selector_ir_lowering.rs
+++ b/devinfra/js/debundle/selector_ir_lowering.rs
@@ -401,7 +401,7 @@ impl MemberSelectorProgramBuilder {
         else {
             return Ok(false);
         };
-        if parsed.body.len() > 1 && native_module_stmt_list_hole_roots(&facts) {
+        if parsed.body.len() > 1 && !native_module_stmt_list_hole_roots(&facts).is_empty() {
             return Ok(false);
         }
         let regex_predicates = native_string_literal_regex_predicates(&facts);
@@ -559,6 +559,48 @@ impl MemberSelectorProgramBuilder {
         Ok(true)
     }
 
+    fn lower_native_top_level_fixed_sequence(
+        &mut self,
+        logical_module: &str,
+        variable_label: &str,
+        node_vars: &BTreeMap<NodeId, SelectorVariableId>,
+        top_level_roots: &[NodeId],
+    ) -> Result<(), SelectorIrLoweringError> {
+        let mut ordinals = Vec::new();
+        for (index, root) in top_level_roots.iter().enumerate() {
+            let Some(root) = node_vars.get(root).copied() else {
+                continue;
+            };
+            let ordinal = self.program.add_variable(
+                VariableDomain::StatementOrdinal,
+                Some(format!(
+                    "{logical_module}::{variable_label}.sequence.ordinal.{index}"
+                )),
+            );
+            self.program.add_atom(SelectorAtom::AstTopLevel {
+                node: node_term(root),
+                ordinal: OrdinalTerm::Var { id: ordinal },
+            });
+            ordinals.push(ordinal);
+        }
+        let Some(base_ordinal) = ordinals.first().copied() else {
+            return Ok(());
+        };
+        for (index, ordinal) in ordinals.iter().enumerate() {
+            let offset =
+                i32::try_from(index).map_err(|_| SelectorIrLoweringError::Unsupported {
+                    selector_kind: "source_match",
+                    reason: "multi-statement source_match sequence exceeds solver i32 range",
+                })?;
+            self.program.add_atom(SelectorAtom::OrdinalOffset {
+                base: OrdinalTerm::Var { id: base_ordinal },
+                ordinal: OrdinalTerm::Var { id: *ordinal },
+                offset,
+            });
+        }
+        Ok(())
+    }
+
     fn lower_native_top_level_window(
         &mut self,
         logical_module: &str,
@@ -622,7 +664,7 @@ impl MemberSelectorProgramBuilder {
         }) else {
             return Ok(false);
         };
-        if parsed.body.len() != 1 {
+        if parsed.body.is_empty() {
             return Ok(false);
         }
         let Ok(facts) =
@@ -630,6 +672,9 @@ impl MemberSelectorProgramBuilder {
         else {
             return Ok(false);
         };
+        if !native_module_stmt_list_hole_roots(&facts).is_empty() {
+            return Ok(false);
+        }
         let regex_predicates = native_string_literal_regex_predicates(&facts);
         let Some(hole_roots) =
             native_single_node_hole_roots(&facts, &regex_predicates.consumed_nodes)
@@ -647,9 +692,14 @@ impl MemberSelectorProgramBuilder {
         } else {
             BTreeMap::new()
         };
-        let [(root_node, _ordinal)] = facts.top_level.as_slice() else {
+        if facts.top_level.len() != parsed.body.len() {
             return Ok(false);
-        };
+        }
+        let top_level_roots = facts
+            .top_level
+            .iter()
+            .map(|(root, _ordinal)| *root)
+            .collect::<Vec<_>>();
 
         let mut target_binding_nodes = BTreeMap::<String, NodeId>::new();
         for target_binding in exports_by_target.keys() {
@@ -673,9 +723,31 @@ impl MemberSelectorProgramBuilder {
                 ),
             );
         }
-        let Some(root) = node_vars.get(root_node).copied() else {
+        let root_by_target_binding = {
+            let index = AlphaIdentifierIndex::new(&facts);
+            target_binding_nodes
+                .iter()
+                .map(|(target_binding, target_binding_node)| {
+                    native_top_level_root_containing_node(
+                        &index,
+                        &top_level_roots,
+                        *target_binding_node,
+                    )
+                    .map(|root| (target_binding.clone(), root))
+                })
+                .collect::<Option<BTreeMap<_, _>>>()
+        };
+        let Some(root_by_target_binding) = root_by_target_binding else {
             return Ok(false);
         };
+        if top_level_roots.len() > 1 {
+            self.lower_native_top_level_fixed_sequence(
+                logical_module,
+                "binding_group.source_match",
+                &node_vars,
+                &top_level_roots,
+            )?;
+        }
 
         let alpha_identifier_vars = if selector.identifiers == SourceMatchIdentifierMode::AlphaAll {
             self.lower_alpha_identifier_variables(logical_module, &facts, &skipped_nodes)
@@ -685,6 +757,11 @@ impl MemberSelectorProgramBuilder {
         let mut exact_identifier_projection_vars = BTreeMap::new();
         for (target_binding, export_name) in exports_by_target {
             let owner = self.owner_for_local_export(logical_module, export_name);
+            let root = root_by_target_binding
+                .get(target_binding)
+                .and_then(|root| node_vars.get(root))
+                .copied()
+                .expect("target binding roots were collected for every export");
             self.program.add_atom(SelectorAtom::OwnerTopLevelRoot {
                 owner: owner_term(owner),
                 root: node_term(root),
@@ -1241,11 +1318,16 @@ fn native_node_contains(index: &AlphaIdentifierIndex, root: NodeId, target: Node
         .any(|child| native_node_contains(index, *child, target))
 }
 
-fn native_module_stmt_list_hole_roots(facts: &ChunkFacts) -> bool {
+fn native_module_stmt_list_hole_roots(facts: &ChunkFacts) -> BTreeSet<NodeId> {
     let index = AlphaIdentifierIndex::new(facts);
-    facts.top_level.iter().any(|(root, _ordinal)| {
-        index.node_kind.get(root) == Some(&NodeKind::ExprStmt)
-            && index.children_by_parent.get(root).is_some_and(|children| {
+    facts
+        .top_level
+        .iter()
+        .filter_map(|(root, _ordinal)| {
+            if index.node_kind.get(root) != Some(&NodeKind::ExprStmt) {
+                return None;
+            }
+            let is_hole = index.children_by_parent.get(root).is_some_and(|children| {
                 let [child] = children.as_slice() else {
                     return false;
                 };
@@ -1253,8 +1335,10 @@ fn native_module_stmt_list_hole_roots(facts: &ChunkFacts) -> bool {
                     && index.ident_name.get(child).is_some_and(|name| {
                         labeled_hole_name_for(name, STMT_LIST_HOLE_KEYWORD).is_some()
                     })
-            })
-    })
+            });
+            is_hole.then_some(*root)
+        })
+        .collect()
 }
 
 fn native_single_declared_binding_node(
@@ -2928,6 +3012,90 @@ mod tests {
             })
             .collect::<BTreeSet<_>>();
         assert_eq!(projected_bindings.len(), 2);
+    }
+
+    #[test]
+    fn multi_statement_binding_group_source_match_lowers_to_native_sequence() {
+        let mut group_selector = AnonymousStatementSelector::exact(
+            r#"const first = makeFirst();
+function second() {
+    return first.value;
+}"#,
+        );
+        group_selector.identifiers = SourceMatchIdentifierMode::AlphaAll;
+        let mut first_selector = group_selector.clone();
+        first_selector.target_binding = Some("first".to_string());
+        let mut second_selector = group_selector.clone();
+        second_selector.target_binding = Some("second".to_string());
+
+        let mut builder = MemberSelectorProgramBuilder::new(context());
+        let first_target = builder
+            .declare_member_target_in_module(
+                "runtime/widgets",
+                "First",
+                &MemberSelectorSpec::SourceMatch(first_selector),
+            )
+            .unwrap();
+        let second_target = builder
+            .declare_member_target_in_module(
+                "runtime/widgets",
+                "Second",
+                &MemberSelectorSpec::SourceMatch(second_selector),
+            )
+            .unwrap();
+        assert!(
+            builder
+                .try_lower_native_source_match_group(
+                    "runtime/widgets",
+                    &group_selector,
+                    &BTreeMap::from([
+                        ("first".to_string(), "First".to_string()),
+                        ("second".to_string(), "Second".to_string()),
+                    ]),
+                )
+                .unwrap()
+        );
+        let program = builder.into_program().unwrap();
+
+        assert!(
+            !program
+                .atoms
+                .iter()
+                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. })),
+            "multi-statement binding_groups should stay in native IR"
+        );
+        let first_owner = program.targets[first_target.0].owner;
+        let second_owner = program.targets[second_target.0].owner;
+        let roots = program
+            .atoms
+            .iter()
+            .filter_map(|atom| match atom {
+                SelectorAtom::OwnerTopLevelRoot {
+                    owner: OwnerTerm::Var { id },
+                    root: NodeTerm::Var { id: root },
+                } if *id == first_owner || *id == second_owner => Some(*root),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(roots.len(), 2);
+        assert_ne!(roots[0], roots[1]);
+        assert_eq!(
+            program
+                .atoms
+                .iter()
+                .filter(|atom| matches!(atom, SelectorAtom::AstTopLevel { .. }))
+                .count(),
+            2
+        );
+        let offsets = program
+            .atoms
+            .iter()
+            .filter_map(|atom| match atom {
+                SelectorAtom::OrdinalOffset { offset, .. } => Some(*offset),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(offsets, vec![0, 1]);
     }
 
     #[test]

--- a/devinfra/js/debundle/selector_ir_lowering.rs
+++ b/devinfra/js/debundle/selector_ir_lowering.rs
@@ -1109,18 +1109,6 @@ fn native_alpha_source_match_supported(
         return false;
     };
 
-    // Alpha variable scopes are modeled for simple single-scope selectors.
-    // Nested function/arrow/catch scopes need a native notion of scoped
-    // alpha-renaming before they can safely avoid the legacy matcher.
-    let scope_count = facts
-        .node_kind
-        .iter()
-        .filter(|(node, kind)| !skipped_nodes.contains(node) && introduces_alpha_scope(*kind))
-        .count();
-    if scope_count > 1 {
-        return false;
-    }
-
     if facts
         .node_kind
         .iter()
@@ -3289,18 +3277,24 @@ mod tests {
     }
 
     #[test]
-    fn alpha_all_source_match_nested_scope_stays_oracle_only() {
+    fn alpha_all_source_match_nested_scope_lowers_natively() {
         let mut selector =
             AnonymousStatementSelector::exact("function a(xs) { return xs.map((x) => x.id); }");
         selector.identifiers = SourceMatchIdentifierMode::AlphaAll;
         let lowered = lower_member_selector(
             &context(),
             "Widget",
-            &MemberSelectorSpec::SourceMatch(selector.clone()),
+            &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
 
-        assert_source_match_oracle_only(&lowered, &selector);
+        assert!(
+            !lowered
+                .program
+                .atoms
+                .iter()
+                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
+        );
     }
 
     #[test]

--- a/devinfra/js/debundle/selector_ir_lowering.rs
+++ b/devinfra/js/debundle/selector_ir_lowering.rs
@@ -672,9 +672,12 @@ impl MemberSelectorProgramBuilder {
         else {
             return Ok(false);
         };
-        if !native_module_stmt_list_hole_roots(&facts).is_empty() {
+        let module_stmt_list_hole_roots = native_module_stmt_list_hole_roots(&facts);
+        let Some(top_level_roots) =
+            native_single_pinned_top_level_segment(&facts, &module_stmt_list_hole_roots)
+        else {
             return Ok(false);
-        }
+        };
         let regex_predicates = native_string_literal_regex_predicates(&facts);
         let Some(hole_roots) =
             native_single_node_hole_roots(&facts, &regex_predicates.consumed_nodes)
@@ -682,6 +685,10 @@ impl MemberSelectorProgramBuilder {
             return Ok(false);
         };
         let mut skipped_nodes = native_hole_subtree_nodes(&facts, &hole_roots);
+        skipped_nodes.extend(native_hole_subtree_nodes(
+            &facts,
+            &module_stmt_list_hole_roots,
+        ));
         skipped_nodes.extend(regex_predicates.consumed_nodes.iter().copied());
         let Some(child_list_patterns) = native_child_list_patterns(&facts, &mut skipped_nodes)
         else {
@@ -695,11 +702,6 @@ impl MemberSelectorProgramBuilder {
         if facts.top_level.len() != parsed.body.len() {
             return Ok(false);
         }
-        let top_level_roots = facts
-            .top_level
-            .iter()
-            .map(|(root, _ordinal)| *root)
-            .collect::<Vec<_>>();
 
         let mut target_binding_nodes = BTreeMap::<String, NodeId>::new();
         for target_binding in exports_by_target.keys() {
@@ -1341,6 +1343,29 @@ fn native_module_stmt_list_hole_roots(facts: &ChunkFacts) -> BTreeSet<NodeId> {
         .collect()
 }
 
+fn native_single_pinned_top_level_segment(
+    facts: &ChunkFacts,
+    module_stmt_list_hole_roots: &BTreeSet<NodeId>,
+) -> Option<Vec<NodeId>> {
+    let mut roots = Vec::new();
+    let mut saw_pinned_root = false;
+    let mut saw_trailing_hole = false;
+    for (root, _ordinal) in &facts.top_level {
+        if module_stmt_list_hole_roots.contains(root) {
+            if saw_pinned_root {
+                saw_trailing_hole = true;
+            }
+            continue;
+        }
+        if saw_trailing_hole {
+            return None;
+        }
+        saw_pinned_root = true;
+        roots.push(*root);
+    }
+    if roots.is_empty() { None } else { Some(roots) }
+}
+
 fn native_single_declared_binding_node(
     facts: &ChunkFacts,
     skipped_nodes: &BTreeSet<NodeId>,
@@ -1978,7 +2003,7 @@ fn native_child_list_patterns(
     let child_list_idents = ident_name
         .iter()
         .filter_map(|(node, name)| {
-            if native_child_list_hole_name(name) {
+            if !skipped_nodes.contains(node) && native_child_list_hole_name(name) {
                 Some(*node)
             } else {
                 None
@@ -1989,7 +2014,7 @@ fn native_child_list_patterns(
         .prop_name
         .iter()
         .filter_map(|(node, name)| {
-            if native_child_list_hole_name(name) {
+            if !skipped_nodes.contains(node) && native_child_list_hole_name(name) {
                 Some(*node)
             } else {
                 None
@@ -3096,6 +3121,106 @@ function second() {
             })
             .collect::<Vec<_>>();
         assert_eq!(offsets, vec![0, 1]);
+    }
+
+    #[test]
+    fn binding_group_source_match_with_outer_stmt_list_holes_lowers_to_native_sequence() {
+        let mut group_selector = AnonymousStatementSelector::exact(
+            r#"STMT_LIST_HEAD;
+const first = makeFirst();
+function second() {
+    return first.value;
+}
+STMT_LIST_TAIL;"#,
+        );
+        group_selector.identifiers = SourceMatchIdentifierMode::AlphaAll;
+        let mut first_selector = group_selector.clone();
+        first_selector.target_binding = Some("first".to_string());
+        let mut second_selector = group_selector.clone();
+        second_selector.target_binding = Some("second".to_string());
+
+        let mut builder = MemberSelectorProgramBuilder::new(context());
+        builder
+            .declare_member_target_in_module(
+                "runtime/widgets",
+                "First",
+                &MemberSelectorSpec::SourceMatch(first_selector),
+            )
+            .unwrap();
+        builder
+            .declare_member_target_in_module(
+                "runtime/widgets",
+                "Second",
+                &MemberSelectorSpec::SourceMatch(second_selector),
+            )
+            .unwrap();
+        assert!(
+            builder
+                .try_lower_native_source_match_group(
+                    "runtime/widgets",
+                    &group_selector,
+                    &BTreeMap::from([
+                        ("first".to_string(), "First".to_string()),
+                        ("second".to_string(), "Second".to_string()),
+                    ]),
+                )
+                .unwrap()
+        );
+        let program = builder.into_program().unwrap();
+
+        assert!(
+            !program
+                .atoms
+                .iter()
+                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. })),
+            "outer module-level STMT_LIST holes should not force the group oracle"
+        );
+        assert_eq!(
+            program
+                .atoms
+                .iter()
+                .filter(|atom| matches!(atom, SelectorAtom::AstTopLevel { .. }))
+                .count(),
+            2,
+            "only pinned top-level statements should get top-level ordinal constraints"
+        );
+        assert!(
+            !program.atoms.iter().any(|atom| matches!(
+                atom,
+                SelectorAtom::AstIdentifierName {
+                    value: StringTerm::Const { value },
+                    ..
+                } if value.starts_with(STMT_LIST_HOLE_KEYWORD)
+            )),
+            "module-level STMT_LIST labels are hole syntax, not identifier constraints"
+        );
+    }
+
+    #[test]
+    fn binding_group_source_match_with_internal_stmt_list_hole_stays_oracle_only() {
+        let mut group_selector = AnonymousStatementSelector::exact(
+            r#"const first = makeFirst();
+STMT_LIST_MIDDLE;
+function second() {
+    return first.value;
+}"#,
+        );
+        group_selector.identifiers = SourceMatchIdentifierMode::AlphaAll;
+        let mut builder = MemberSelectorProgramBuilder::new(context());
+
+        assert!(
+            !builder
+                .try_lower_native_source_match_group(
+                    "runtime/widgets",
+                    &group_selector,
+                    &BTreeMap::from([
+                        ("first".to_string(), "First".to_string()),
+                        ("second".to_string(), "Second".to_string()),
+                    ]),
+                )
+                .unwrap(),
+            "internal top-level STMT_LIST needs ordered-subsequence ordinal support"
+        );
     }
 
     #[test]

--- a/devinfra/js/debundle/selector_ir_lowering.rs
+++ b/devinfra/js/debundle/selector_ir_lowering.rs
@@ -565,7 +565,7 @@ impl MemberSelectorProgramBuilder {
         variable_label: &str,
         node_vars: &BTreeMap<NodeId, SelectorVariableId>,
         top_level_roots: &[NodeId],
-    ) -> Result<(), SelectorIrLoweringError> {
+    ) -> Result<Vec<SelectorVariableId>, SelectorIrLoweringError> {
         let mut ordinals = Vec::new();
         for (index, root) in top_level_roots.iter().enumerate() {
             let Some(root) = node_vars.get(root).copied() else {
@@ -584,7 +584,7 @@ impl MemberSelectorProgramBuilder {
             ordinals.push(ordinal);
         }
         let Some(base_ordinal) = ordinals.first().copied() else {
-            return Ok(());
+            return Ok(ordinals);
         };
         for (index, ordinal) in ordinals.iter().enumerate() {
             let offset =
@@ -598,7 +598,7 @@ impl MemberSelectorProgramBuilder {
                 offset,
             });
         }
-        Ok(())
+        Ok(ordinals)
     }
 
     fn lower_native_top_level_window(
@@ -673,11 +673,16 @@ impl MemberSelectorProgramBuilder {
             return Ok(false);
         };
         let module_stmt_list_hole_roots = native_module_stmt_list_hole_roots(&facts);
-        let Some(top_level_roots) =
-            native_single_pinned_top_level_segment(&facts, &module_stmt_list_hole_roots)
-        else {
+        let top_level_segments =
+            native_pinned_top_level_segments(&facts, &module_stmt_list_hole_roots);
+        if top_level_segments.is_empty() {
             return Ok(false);
-        };
+        }
+        let top_level_roots = top_level_segments
+            .iter()
+            .flatten()
+            .copied()
+            .collect::<Vec<_>>();
         let regex_predicates = native_string_literal_regex_predicates(&facts);
         let Some(hole_roots) =
             native_single_node_hole_roots(&facts, &regex_predicates.consumed_nodes)
@@ -742,13 +747,28 @@ impl MemberSelectorProgramBuilder {
         let Some(root_by_target_binding) = root_by_target_binding else {
             return Ok(false);
         };
-        if top_level_roots.len() > 1 {
-            self.lower_native_top_level_fixed_sequence(
-                logical_module,
-                "binding_group.source_match",
-                &node_vars,
-                &top_level_roots,
-            )?;
+        if top_level_segments.len() > 1 || top_level_roots.len() > 1 {
+            let mut previous_segment_last = None;
+            for (segment_index, segment_roots) in top_level_segments.iter().enumerate() {
+                let ordinals = self.lower_native_top_level_fixed_sequence(
+                    logical_module,
+                    &format!("binding_group.source_match.segment.{segment_index}"),
+                    &node_vars,
+                    segment_roots,
+                )?;
+                let Some(segment_first) = ordinals.first().copied() else {
+                    continue;
+                };
+                if let Some(previous_segment_last) = previous_segment_last {
+                    self.program.add_atom(SelectorAtom::OrdinalBefore {
+                        before: OrdinalTerm::Var {
+                            id: previous_segment_last,
+                        },
+                        after: OrdinalTerm::Var { id: segment_first },
+                    });
+                }
+                previous_segment_last = ordinals.last().copied();
+            }
         }
 
         let alpha_identifier_vars = if selector.identifiers == SourceMatchIdentifierMode::AlphaAll {
@@ -1343,27 +1363,25 @@ fn native_module_stmt_list_hole_roots(facts: &ChunkFacts) -> BTreeSet<NodeId> {
         .collect()
 }
 
-fn native_single_pinned_top_level_segment(
+fn native_pinned_top_level_segments(
     facts: &ChunkFacts,
     module_stmt_list_hole_roots: &BTreeSet<NodeId>,
-) -> Option<Vec<NodeId>> {
-    let mut roots = Vec::new();
-    let mut saw_pinned_root = false;
-    let mut saw_trailing_hole = false;
+) -> Vec<Vec<NodeId>> {
+    let mut segments = Vec::new();
+    let mut current_segment = Vec::new();
     for (root, _ordinal) in &facts.top_level {
         if module_stmt_list_hole_roots.contains(root) {
-            if saw_pinned_root {
-                saw_trailing_hole = true;
+            if !current_segment.is_empty() {
+                segments.push(std::mem::take(&mut current_segment));
             }
             continue;
         }
-        if saw_trailing_hole {
-            return None;
-        }
-        saw_pinned_root = true;
-        roots.push(*root);
+        current_segment.push(*root);
     }
-    if roots.is_empty() { None } else { Some(roots) }
+    if !current_segment.is_empty() {
+        segments.push(current_segment);
+    }
+    segments
 }
 
 fn native_single_declared_binding_node(
@@ -3197,7 +3215,7 @@ STMT_LIST_TAIL;"#,
     }
 
     #[test]
-    fn binding_group_source_match_with_internal_stmt_list_hole_stays_oracle_only() {
+    fn binding_group_source_match_with_internal_stmt_list_hole_lowers_to_native_sequence() {
         let mut group_selector = AnonymousStatementSelector::exact(
             r#"const first = makeFirst();
 STMT_LIST_MIDDLE;
@@ -3206,10 +3224,29 @@ function second() {
 }"#,
         );
         group_selector.identifiers = SourceMatchIdentifierMode::AlphaAll;
+        let mut first_selector = group_selector.clone();
+        first_selector.target_binding = Some("first".to_string());
+        let mut second_selector = group_selector.clone();
+        second_selector.target_binding = Some("second".to_string());
+
         let mut builder = MemberSelectorProgramBuilder::new(context());
+        builder
+            .declare_member_target_in_module(
+                "runtime/widgets",
+                "First",
+                &MemberSelectorSpec::SourceMatch(first_selector),
+            )
+            .unwrap();
+        builder
+            .declare_member_target_in_module(
+                "runtime/widgets",
+                "Second",
+                &MemberSelectorSpec::SourceMatch(second_selector),
+            )
+            .unwrap();
 
         assert!(
-            !builder
+            builder
                 .try_lower_native_source_match_group(
                     "runtime/widgets",
                     &group_selector,
@@ -3219,8 +3256,24 @@ function second() {
                     ]),
                 )
                 .unwrap(),
-            "internal top-level STMT_LIST needs ordered-subsequence ordinal support"
+            "internal top-level STMT_LIST should lower to an ordinal-before constraint"
         );
+        let program = builder.into_program().unwrap();
+
+        assert!(
+            !program
+                .atoms
+                .iter()
+                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. })),
+            "internal module-level STMT_LIST holes should not force the group oracle"
+        );
+        assert!(program.atoms.iter().any(|atom| matches!(
+            atom,
+            SelectorAtom::OrdinalBefore {
+                before: OrdinalTerm::Var { .. },
+                after: OrdinalTerm::Var { .. },
+            }
+        )));
     }
 
     #[test]

--- a/devinfra/js/debundle/selector_ir_lowering.rs
+++ b/devinfra/js/debundle/selector_ir_lowering.rs
@@ -73,6 +73,7 @@ struct NativeAstFactLowering<'a> {
     alpha_identifier_vars: &'a BTreeMap<NodeId, SelectorVariableId>,
     exact_identifier_projection_vars: &'a BTreeMap<NodeId, SelectorVariableId>,
     child_list_patterns: &'a BTreeMap<NodeId, NativeChildListPattern>,
+    bare_properties: &'a BTreeMap<NodeId, NativeBarePropertySelector>,
     regex_predicates: &'a NativeRegexPredicateIndex,
 }
 
@@ -414,6 +415,11 @@ impl MemberSelectorProgramBuilder {
         {
             return Ok(false);
         }
+        let bare_properties = if selector.identifiers == SourceMatchIdentifierMode::AlphaAll {
+            native_bare_property_selectors(&facts, &skipped_nodes)
+        } else {
+            BTreeMap::new()
+        };
         let [(root_node, _ordinal)] = facts.top_level.as_slice() else {
             return Ok(false);
         };
@@ -510,6 +516,7 @@ impl MemberSelectorProgramBuilder {
             alpha_identifier_vars: &alpha_identifier_vars,
             exact_identifier_projection_vars: &exact_identifier_projection_vars,
             child_list_patterns: &child_list_patterns,
+            bare_properties: &bare_properties,
             regex_predicates: &regex_predicates,
         });
         Ok(true)
@@ -557,6 +564,11 @@ impl MemberSelectorProgramBuilder {
         {
             return Ok(false);
         }
+        let bare_properties = if selector.identifiers == SourceMatchIdentifierMode::AlphaAll {
+            native_bare_property_selectors(&facts, &skipped_nodes)
+        } else {
+            BTreeMap::new()
+        };
         let [(root_node, _ordinal)] = facts.top_level.as_slice() else {
             return Ok(false);
         };
@@ -639,6 +651,7 @@ impl MemberSelectorProgramBuilder {
             alpha_identifier_vars: &alpha_identifier_vars,
             exact_identifier_projection_vars: &exact_identifier_projection_vars,
             child_list_patterns: &child_list_patterns,
+            bare_properties: &bare_properties,
             regex_predicates: &regex_predicates,
         });
         Ok(true)
@@ -654,11 +667,21 @@ impl MemberSelectorProgramBuilder {
             alpha_identifier_vars,
             exact_identifier_projection_vars,
             child_list_patterns,
+            bare_properties,
             regex_predicates,
         } = lowering;
+        let bare_property_structural_nodes = bare_properties
+            .values()
+            .flat_map(|property| property.structural_skip_nodes.iter().copied())
+            .collect::<BTreeSet<_>>();
+        let structurally_skipped_node = |node: &NodeId| {
+            skipped_nodes.contains(node)
+                || bare_properties.contains_key(node)
+                || bare_property_structural_nodes.contains(node)
+        };
         let mut wildcard_string_vars = BTreeMap::<String, SelectorVariableId>::new();
         for (_node, token) in &facts.str_wildcard {
-            if skipped_nodes.contains(_node) {
+            if structurally_skipped_node(_node) {
                 continue;
             }
             wildcard_string_vars
@@ -673,7 +696,7 @@ impl MemberSelectorProgramBuilder {
         let wildcard_string_by_node: BTreeMap<NodeId, SelectorVariableId> = facts
             .str_wildcard
             .iter()
-            .filter(|(node, _token)| !skipped_nodes.contains(node))
+            .filter(|(node, _token)| !structurally_skipped_node(node))
             .filter_map(|(node, token)| wildcard_string_vars.get(token).map(|var| (*node, *var)))
             .collect();
         let mut child_counts: BTreeMap<NodeId, u32> =
@@ -688,6 +711,22 @@ impl MemberSelectorProgramBuilder {
             let Some(node_var) = node_vars.get(node).copied() else {
                 continue;
             };
+            if let Some(property) = bare_properties.get(node) {
+                let identifier = alpha_identifier_vars
+                    .get(&property.identifier_node)
+                    .copied()
+                    .expect("bare property identifier should have an alpha variable");
+                self.program.add_atom(SelectorAtom::AstBareProperty {
+                    node: node_term(node_var),
+                    key: const_str(&property.key),
+                    identifier: string_term(identifier),
+                    is_binding: property.is_binding,
+                });
+                continue;
+            }
+            if bare_property_structural_nodes.contains(node) {
+                continue;
+            }
             if let Some(pattern) = regex_predicates.pattern_by_call.get(node) {
                 self.program
                     .add_atom(SelectorAtom::AstStringLiteralMatchingRegex {
@@ -709,6 +748,9 @@ impl MemberSelectorProgramBuilder {
         }
         for (parent, index, child) in &facts.child {
             if skipped_nodes.contains(parent) {
+                continue;
+            }
+            if bare_properties.contains_key(parent) {
                 continue;
             }
             if regex_predicates.pattern_by_call.contains_key(parent) {
@@ -757,7 +799,7 @@ impl MemberSelectorProgramBuilder {
             });
         }
         for (class_node, super_class) in &facts.super_class {
-            if skipped_nodes.contains(class_node) {
+            if structurally_skipped_node(class_node) {
                 continue;
             }
             let (Some(class_node), Some(super_class)) =
@@ -771,7 +813,7 @@ impl MemberSelectorProgramBuilder {
             });
         }
         for (node, value) in &facts.str_lit {
-            if skipped_nodes.contains(node) {
+            if structurally_skipped_node(node) {
                 continue;
             }
             if let Some(wildcard_string_var) = wildcard_string_by_node.get(node).copied() {
@@ -788,7 +830,7 @@ impl MemberSelectorProgramBuilder {
             }
         }
         for (node, value) in &facts.num_lit {
-            if skipped_nodes.contains(node) {
+            if structurally_skipped_node(node) {
                 continue;
             }
             self.add_ast_string_label(node_vars, *node, value, |node, value| {
@@ -796,7 +838,7 @@ impl MemberSelectorProgramBuilder {
             });
         }
         for (node, value) in &facts.bool_lit {
-            if skipped_nodes.contains(node) {
+            if structurally_skipped_node(node) {
                 continue;
             }
             if let Some(node) = node_vars.get(node).copied() {
@@ -807,7 +849,7 @@ impl MemberSelectorProgramBuilder {
             }
         }
         for (node, value) in &facts.ident_name {
-            if skipped_nodes.contains(node) {
+            if structurally_skipped_node(node) {
                 continue;
             }
             match identifier_mode {
@@ -840,7 +882,7 @@ impl MemberSelectorProgramBuilder {
             }
         }
         for (node, value) in &facts.prop_name {
-            if skipped_nodes.contains(node) {
+            if structurally_skipped_node(node) {
                 continue;
             }
             self.add_ast_string_label(node_vars, *node, value, |node, value| {
@@ -848,7 +890,7 @@ impl MemberSelectorProgramBuilder {
             });
         }
         for (node, value) in &facts.operator {
-            if skipped_nodes.contains(node) {
+            if structurally_skipped_node(node) {
                 continue;
             }
             self.add_ast_string_label(node_vars, *node, value, |node, value| {
@@ -856,7 +898,7 @@ impl MemberSelectorProgramBuilder {
             });
         }
         for (node, pattern, flags) in &facts.regex {
-            if skipped_nodes.contains(node) {
+            if structurally_skipped_node(node) {
                 continue;
             }
             if let Some(node) = node_vars.get(node).copied() {
@@ -911,7 +953,7 @@ impl MemberSelectorProgramBuilder {
         let mut result = BTreeMap::new();
         let kind = index.node_kind.get(&node).copied();
         if let (Some(kind), Some(name)) = (kind, index.ident_name.get(&node)) {
-            let identifier = if kind == NodeKind::BindingIdent {
+            let identifier = if matches!(kind, NodeKind::BindingIdent | NodeKind::PatAssign) {
                 self.alpha_binding_identifier(logical_module, state, name)
             } else {
                 self.alpha_reference_identifier(logical_module, state, name)
@@ -1063,14 +1105,9 @@ fn native_alpha_source_match_supported(
     facts: &ChunkFacts,
     skipped_nodes: &BTreeSet<NodeId>,
 ) -> bool {
-    let index = AlphaIdentifierIndex::new(facts);
     let [(_root, _ordinal)] = facts.top_level.as_slice() else {
         return false;
     };
-
-    if native_alpha_has_explicit_same_name_property(&index, skipped_nodes) {
-        return false;
-    }
 
     // Alpha variable scopes are modeled for simple single-scope selectors.
     // Nested function/arrow/catch scopes need a native notion of scoped
@@ -1085,43 +1122,12 @@ fn native_alpha_source_match_supported(
     }
 
     if facts.node_kind.iter().any(|(node, kind)| {
-        !skipped_nodes.contains(node)
-            && matches!(
-                kind,
-                NodeKind::Seq | NodeKind::Shorthand | NodeKind::AssignProp
-            )
+        !skipped_nodes.contains(node) && matches!(kind, NodeKind::Seq | NodeKind::AssignProp)
     }) {
         return false;
     }
 
     true
-}
-
-fn native_alpha_has_explicit_same_name_property(
-    index: &AlphaIdentifierIndex,
-    skipped_nodes: &BTreeSet<NodeId>,
-) -> bool {
-    index.node_kind.iter().any(|(node, kind)| {
-        if skipped_nodes.contains(node)
-            || !matches!(kind, NodeKind::KeyValue | NodeKind::PatKeyValue)
-        {
-            return false;
-        }
-        let Some(children) = index.children_by_parent.get(node) else {
-            return false;
-        };
-        let Some(key) = children.first() else {
-            return false;
-        };
-        let Some(value) = children.get(1) else {
-            return false;
-        };
-        index
-            .prop_name
-            .get(key)
-            .zip(index.ident_name.get(value))
-            .is_some_and(|(key, value)| key == value)
-    })
 }
 
 fn native_target_binding_node(
@@ -1372,6 +1378,152 @@ struct NativeChildListPattern {
 struct NativeRegexPredicateIndex {
     pattern_by_call: BTreeMap<NodeId, String>,
     consumed_nodes: BTreeSet<NodeId>,
+}
+
+#[derive(Debug, Clone)]
+struct NativeBarePropertySelector {
+    key: String,
+    identifier_node: NodeId,
+    is_binding: bool,
+    structural_skip_nodes: BTreeSet<NodeId>,
+}
+
+fn native_bare_property_selectors(
+    facts: &ChunkFacts,
+    skipped_nodes: &BTreeSet<NodeId>,
+) -> BTreeMap<NodeId, NativeBarePropertySelector> {
+    let index = AlphaIdentifierIndex::new(facts);
+    let mut result = BTreeMap::new();
+    for (node, kind) in &index.node_kind {
+        if skipped_nodes.contains(node) {
+            continue;
+        }
+        let property = match kind {
+            NodeKind::Shorthand => {
+                let Some(name) = index.ident_name.get(node) else {
+                    continue;
+                };
+                if selector_hole_name(name) {
+                    continue;
+                }
+                NativeBarePropertySelector {
+                    key: name.clone(),
+                    identifier_node: *node,
+                    is_binding: false,
+                    structural_skip_nodes: BTreeSet::new(),
+                }
+            }
+            NodeKind::KeyValue => {
+                let Some(children) = index.children_by_parent.get(node) else {
+                    continue;
+                };
+                let Some((key_node, value_node)) =
+                    children.first().copied().zip(children.get(1).copied())
+                else {
+                    continue;
+                };
+                if skipped_nodes.contains(&key_node) || skipped_nodes.contains(&value_node) {
+                    continue;
+                }
+                if index.node_kind.get(&value_node) != Some(&NodeKind::Ident) {
+                    continue;
+                }
+                let Some(key) = index.prop_name.get(&key_node) else {
+                    continue;
+                };
+                let Some(identifier) = index.ident_name.get(&value_node) else {
+                    continue;
+                };
+                if selector_hole_name(key) || selector_hole_name(identifier) {
+                    continue;
+                }
+                NativeBarePropertySelector {
+                    key: key.clone(),
+                    identifier_node: value_node,
+                    is_binding: false,
+                    structural_skip_nodes: native_bare_property_structural_skip_nodes(
+                        &index,
+                        &[key_node, value_node],
+                    ),
+                }
+            }
+            NodeKind::PatAssign => {
+                if index
+                    .children_by_parent
+                    .get(node)
+                    .is_some_and(|children| !children.is_empty())
+                {
+                    continue;
+                }
+                let Some(name) = index.ident_name.get(node) else {
+                    continue;
+                };
+                if selector_hole_name(name) {
+                    continue;
+                }
+                NativeBarePropertySelector {
+                    key: name.clone(),
+                    identifier_node: *node,
+                    is_binding: true,
+                    structural_skip_nodes: BTreeSet::new(),
+                }
+            }
+            NodeKind::PatKeyValue => {
+                let Some(children) = index.children_by_parent.get(node) else {
+                    continue;
+                };
+                let Some((key_node, value_node)) =
+                    children.first().copied().zip(children.get(1).copied())
+                else {
+                    continue;
+                };
+                if skipped_nodes.contains(&key_node) || skipped_nodes.contains(&value_node) {
+                    continue;
+                }
+                if index.node_kind.get(&value_node) != Some(&NodeKind::BindingIdent) {
+                    continue;
+                }
+                let Some(key) = index.prop_name.get(&key_node) else {
+                    continue;
+                };
+                let Some(identifier) = index.ident_name.get(&value_node) else {
+                    continue;
+                };
+                if selector_hole_name(key) || selector_hole_name(identifier) {
+                    continue;
+                }
+                NativeBarePropertySelector {
+                    key: key.clone(),
+                    identifier_node: value_node,
+                    is_binding: true,
+                    structural_skip_nodes: native_bare_property_structural_skip_nodes(
+                        &index,
+                        &[key_node, value_node],
+                    ),
+                }
+            }
+            _ => continue,
+        };
+        result.insert(*node, property);
+    }
+    result
+}
+
+fn native_bare_property_structural_skip_nodes(
+    index: &AlphaIdentifierIndex,
+    roots: &[NodeId],
+) -> BTreeSet<NodeId> {
+    let mut skipped = BTreeSet::new();
+    let mut stack = roots.to_vec();
+    while let Some(node) = stack.pop() {
+        if !skipped.insert(node) {
+            continue;
+        }
+        if let Some(children) = index.children_by_parent.get(&node) {
+            stack.extend(children.iter().copied());
+        }
+    }
+    skipped
 }
 
 fn native_string_literal_regex_predicates(facts: &ChunkFacts) -> NativeRegexPredicateIndex {
@@ -3046,17 +3198,63 @@ mod tests {
     }
 
     #[test]
-    fn alpha_all_source_match_explicit_same_name_property_stays_oracle_only() {
+    fn alpha_all_source_match_bare_object_property_lowers_natively() {
         let mut selector = AnonymousStatementSelector::exact("function a(x) { return { x: x }; }");
         selector.identifiers = SourceMatchIdentifierMode::AlphaAll;
         let lowered = lower_member_selector(
             &context(),
             "Widget",
-            &MemberSelectorSpec::SourceMatch(selector.clone()),
+            &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
 
-        assert_source_match_oracle_only(&lowered, &selector);
+        assert!(
+            !lowered
+                .program
+                .atoms
+                .iter()
+                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
+        );
+        assert!(lowered.program.atoms.iter().any(|atom| matches!(
+            atom,
+            SelectorAtom::AstBareProperty {
+                key: StringTerm::Const { value },
+                identifier: StringTerm::Var { .. },
+                is_binding: false,
+                ..
+            } if value == "x"
+        )));
+    }
+
+    #[test]
+    fn alpha_all_source_match_bare_object_pattern_property_lowers_natively() {
+        let mut selector = AnonymousStatementSelector::exact(
+            "function a(input) { const { stable } = input; return stable; }",
+        );
+        selector.identifiers = SourceMatchIdentifierMode::AlphaAll;
+        let lowered = lower_member_selector(
+            &context(),
+            "Widget",
+            &MemberSelectorSpec::SourceMatch(selector),
+        )
+        .unwrap();
+
+        assert!(
+            !lowered
+                .program
+                .atoms
+                .iter()
+                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
+        );
+        assert!(lowered.program.atoms.iter().any(|atom| matches!(
+            atom,
+            SelectorAtom::AstBareProperty {
+                key: StringTerm::Const { value },
+                identifier: StringTerm::Var { .. },
+                is_binding: true,
+                ..
+            } if value == "stable"
+        )));
     }
 
     #[test]

--- a/devinfra/js/debundle/selector_ir_lowering.rs
+++ b/devinfra/js/debundle/selector_ir_lowering.rs
@@ -10,7 +10,7 @@ use std::fmt;
 use analysis::{ChunkId, StatementKind};
 use chunk_facts::{ChunkFacts, NodeId, NodeKind};
 use selector_ir::{
-    ClaimKind, ClaimOrigin, NodeTerm, OwnerTerm, RelationalPrimitive, SelectorAtom,
+    ClaimKind, ClaimOrigin, NodeTerm, OrdinalTerm, OwnerTerm, RelationalPrimitive, SelectorAtom,
     SelectorProgram, SelectorTargetId, SelectorVariableId, StringTerm, VariableDomain,
 };
 use source_match_holes::{
@@ -390,7 +390,10 @@ impl MemberSelectorProgramBuilder {
         }) else {
             return Ok(false);
         };
-        if parsed.body.len() != 1 {
+        if parsed.body.is_empty() {
+            return Ok(false);
+        }
+        if parsed.body.len() > 1 && selector.target_binding.is_none() {
             return Ok(false);
         }
         let Ok(facts) =
@@ -398,6 +401,9 @@ impl MemberSelectorProgramBuilder {
         else {
             return Ok(false);
         };
+        if parsed.body.len() > 1 && native_module_stmt_list_hole_roots(&facts) {
+            return Ok(false);
+        }
         let regex_predicates = native_string_literal_regex_predicates(&facts);
         let Some(hole_roots) =
             native_single_node_hole_roots(&facts, &regex_predicates.consumed_nodes)
@@ -415,9 +421,14 @@ impl MemberSelectorProgramBuilder {
         } else {
             BTreeMap::new()
         };
-        let [(root_node, _ordinal)] = facts.top_level.as_slice() else {
+        if facts.top_level.len() != parsed.body.len() {
             return Ok(false);
-        };
+        }
+        let top_level_roots = facts
+            .top_level
+            .iter()
+            .map(|(root, _ordinal)| *root)
+            .collect::<Vec<_>>();
         let target_binding_node = match &selector.target_binding {
             Some(target_binding) => {
                 let Some(target_binding_node) =
@@ -435,6 +446,29 @@ impl MemberSelectorProgramBuilder {
             }
             _ => None,
         };
+        let target_root_node =
+            if let Some((_target_binding, target_binding_node)) = target_binding_node {
+                let index = AlphaIdentifierIndex::new(&facts);
+                let Some(root) = native_top_level_root_containing_node(
+                    &index,
+                    &top_level_roots,
+                    target_binding_node,
+                ) else {
+                    return Ok(false);
+                };
+                root
+            } else {
+                let [root] = top_level_roots.as_slice() else {
+                    return Ok(false);
+                };
+                *root
+            };
+        let Some(target_root_index) = top_level_roots
+            .iter()
+            .position(|root| *root == target_root_node)
+        else {
+            return Ok(false);
+        };
 
         let mut node_vars = BTreeMap::<NodeId, SelectorVariableId>::new();
         for (node, _kind) in &facts.node_kind {
@@ -446,13 +480,21 @@ impl MemberSelectorProgramBuilder {
                 ),
             );
         }
-        let Some(root) = node_vars.get(root_node).copied() else {
+        let Some(root) = node_vars.get(&target_root_node).copied() else {
             return Ok(false);
         };
         self.program.add_atom(SelectorAtom::OwnerTopLevelRoot {
             owner: owner_term(owner),
             root: node_term(root),
         });
+        if top_level_roots.len() > 1 {
+            self.lower_native_top_level_window(
+                logical_module,
+                &node_vars,
+                &top_level_roots,
+                target_root_index,
+            )?;
+        }
         let alpha_identifier_vars = if selector.identifiers == SourceMatchIdentifierMode::AlphaAll {
             self.lower_alpha_identifier_variables(logical_module, &facts, &skipped_nodes)
         } else {
@@ -515,6 +557,52 @@ impl MemberSelectorProgramBuilder {
             regex_predicates: &regex_predicates,
         });
         Ok(true)
+    }
+
+    fn lower_native_top_level_window(
+        &mut self,
+        logical_module: &str,
+        node_vars: &BTreeMap<NodeId, SelectorVariableId>,
+        top_level_roots: &[NodeId],
+        target_root_index: usize,
+    ) -> Result<(), SelectorIrLoweringError> {
+        let target_ordinal = self.program.add_variable(
+            VariableDomain::StatementOrdinal,
+            Some(format!(
+                "{logical_module}::source_match.window.target_ordinal"
+            )),
+        );
+        for (index, root) in top_level_roots.iter().enumerate() {
+            let Some(root) = node_vars.get(root).copied() else {
+                continue;
+            };
+            let ordinal = if index == target_root_index {
+                target_ordinal
+            } else {
+                self.program.add_variable(
+                    VariableDomain::StatementOrdinal,
+                    Some(format!(
+                        "{logical_module}::source_match.window.ordinal.{index}"
+                    )),
+                )
+            };
+            self.program.add_atom(SelectorAtom::AstTopLevel {
+                node: node_term(root),
+                ordinal: OrdinalTerm::Var { id: ordinal },
+            });
+            let offset = i32::try_from(index)
+                .and_then(|index| i32::try_from(target_root_index).map(|target| index - target))
+                .map_err(|_| SelectorIrLoweringError::Unsupported {
+                    selector_kind: "source_match",
+                    reason: "multi-statement source_match window exceeds solver i32 range",
+                })?;
+            self.program.add_atom(SelectorAtom::OrdinalOffset {
+                base: OrdinalTerm::Var { id: target_ordinal },
+                ordinal: OrdinalTerm::Var { id: ordinal },
+                offset,
+            });
+        }
+        Ok(())
     }
 
     pub fn try_lower_native_source_match_group(
@@ -920,12 +1008,22 @@ impl MemberSelectorProgramBuilder {
         facts: &ChunkFacts,
         skipped_nodes: &BTreeSet<NodeId>,
     ) -> BTreeMap<NodeId, SelectorVariableId> {
-        let [(root, _ordinal)] = facts.top_level.as_slice() else {
+        if facts.top_level.is_empty() {
             return BTreeMap::new();
-        };
+        }
         let index = AlphaIdentifierIndex::new(facts);
         let mut state = AlphaIdentifierState::default();
-        self.lower_alpha_identifier_node(logical_module, &index, skipped_nodes, &mut state, *root)
+        let mut result = BTreeMap::new();
+        for (root, _ordinal) in &facts.top_level {
+            result.extend(self.lower_alpha_identifier_node(
+                logical_module,
+                &index,
+                skipped_nodes,
+                &mut state,
+                *root,
+            ));
+        }
+        result
     }
 
     fn lower_alpha_identifier_node(
@@ -1096,11 +1194,15 @@ fn native_target_binding_node(
     skipped_nodes: &BTreeSet<NodeId>,
     target_binding: &str,
 ) -> Option<NodeId> {
-    let [(root, _ordinal)] = facts.top_level.as_slice() else {
+    if facts.top_level.is_empty() {
         return None;
-    };
+    }
     let index = AlphaIdentifierIndex::new(facts);
-    let declared_nodes = native_declared_binding_nodes(&index, skipped_nodes, *root);
+    let declared_nodes = facts
+        .top_level
+        .iter()
+        .flat_map(|(root, _ordinal)| native_declared_binding_nodes(&index, skipped_nodes, *root))
+        .collect::<Vec<_>>();
     let matches = declared_nodes
         .into_iter()
         .filter(|node| index.ident_name.get(node).map(String::as_str) == Some(target_binding))
@@ -1109,6 +1211,50 @@ fn native_target_binding_node(
         return None;
     };
     Some(*node)
+}
+
+fn native_top_level_root_containing_node(
+    index: &AlphaIdentifierIndex,
+    top_level_roots: &[NodeId],
+    target: NodeId,
+) -> Option<NodeId> {
+    let roots = top_level_roots
+        .iter()
+        .copied()
+        .filter(|root| native_node_contains(index, *root, target))
+        .collect::<Vec<_>>();
+    let [root] = roots.as_slice() else {
+        return None;
+    };
+    Some(*root)
+}
+
+fn native_node_contains(index: &AlphaIdentifierIndex, root: NodeId, target: NodeId) -> bool {
+    if root == target {
+        return true;
+    }
+    index
+        .children_by_parent
+        .get(&root)
+        .into_iter()
+        .flatten()
+        .any(|child| native_node_contains(index, *child, target))
+}
+
+fn native_module_stmt_list_hole_roots(facts: &ChunkFacts) -> bool {
+    let index = AlphaIdentifierIndex::new(facts);
+    facts.top_level.iter().any(|(root, _ordinal)| {
+        index.node_kind.get(root) == Some(&NodeKind::ExprStmt)
+            && index.children_by_parent.get(root).is_some_and(|children| {
+                let [child] = children.as_slice() else {
+                    return false;
+                };
+                index.node_kind.get(child) == Some(&NodeKind::Ident)
+                    && index.ident_name.get(child).is_some_and(|name| {
+                        labeled_hole_name_for(name, STMT_LIST_HOLE_KEYWORD).is_some()
+                    })
+            })
+    })
 }
 
 fn native_single_declared_binding_node(
@@ -2356,6 +2502,48 @@ mod tests {
                 .atoms
                 .iter()
                 .any(|atom| matches!(atom, SelectorAtom::AstSuperClass { .. }))
+        );
+    }
+
+    #[test]
+    fn multi_statement_source_match_lowers_to_native_window_constraints() {
+        let mut selector = AnonymousStatementSelector::exact(
+            "function helper(value) { return value + 1; }\nconst selected = makeThing();",
+        );
+        selector.target_binding = Some("selected".to_string());
+        let lowered = lower_member_selector(
+            &context(),
+            "Widget",
+            &MemberSelectorSpec::SourceMatch(selector),
+        )
+        .unwrap();
+
+        assert!(
+            !lowered
+                .program
+                .atoms
+                .iter()
+                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. })),
+            "fixed-window member source_match selectors should stay in native IR"
+        );
+        let offsets = lowered
+            .program
+            .atoms
+            .iter()
+            .filter_map(|atom| match atom {
+                SelectorAtom::OrdinalOffset { offset, .. } => Some(*offset),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(offsets, vec![-1, 0]);
+        assert_eq!(
+            lowered
+                .program
+                .atoms
+                .iter()
+                .filter(|atom| matches!(atom, SelectorAtom::AstTopLevel { .. }))
+                .count(),
+            2
         );
     }
 

--- a/devinfra/js/debundle/selector_ir_lowering.rs
+++ b/devinfra/js/debundle/selector_ir_lowering.rs
@@ -419,11 +419,6 @@ impl MemberSelectorProgramBuilder {
         };
         let target_binding_node = match &selector.target_binding {
             Some(target_binding) => {
-                if selector.identifiers == SourceMatchIdentifierMode::AlphaAll
-                    && native_declared_binding_count(&facts, &skipped_nodes) != Some(1)
-                {
-                    return Ok(false);
-                }
                 let Some(target_binding_node) =
                     native_target_binding_node(&facts, &skipped_nodes, target_binding)
                 else {
@@ -1162,17 +1157,6 @@ fn native_single_declared_binding_node(
         return None;
     };
     Some(*node)
-}
-
-fn native_declared_binding_count(
-    facts: &ChunkFacts,
-    skipped_nodes: &BTreeSet<NodeId>,
-) -> Option<usize> {
-    let [(root, _ordinal)] = facts.top_level.as_slice() else {
-        return None;
-    };
-    let index = AlphaIdentifierIndex::new(facts);
-    Some(native_declared_binding_nodes(&index, skipped_nodes, *root).len())
 }
 
 fn native_declared_binding_nodes(
@@ -2470,6 +2454,48 @@ mod tests {
                 binding: StringTerm::Var { .. },
             } if *id == target_owner
         )));
+    }
+
+    #[test]
+    fn alpha_all_target_binding_in_multideclarator_lowers_natively() {
+        let mut selector = AnonymousStatementSelector::exact(
+            r#"const first = build("left"), second = build("right");"#,
+        );
+        selector.identifiers = SourceMatchIdentifierMode::AlphaAll;
+        selector.target_binding = Some("second".to_string());
+        let lowered = lower_member_selector(
+            &context(),
+            "Selected",
+            &MemberSelectorSpec::SourceMatch(selector),
+        )
+        .unwrap();
+
+        assert!(
+            !lowered
+                .program
+                .atoms
+                .iter()
+                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. })),
+            "alpha_all source_match with target_binding in a multi-declarator should stay native",
+        );
+        let target_owner = lowered.program.targets[lowered.target.0].owner;
+        let projected_bindings = lowered
+            .program
+            .atoms
+            .iter()
+            .filter_map(|atom| match atom {
+                SelectorAtom::OwnerDeclaresBinding {
+                    owner: OwnerTerm::Var { id },
+                    binding: StringTerm::Var { id: binding },
+                } if *id == target_owner => Some(*binding),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            projected_bindings.len(),
+            1,
+            "target owner should project exactly one declared binding variable",
+        );
     }
 
     #[test]

--- a/devinfra/js/debundle/selector_ir_lowering.rs
+++ b/devinfra/js/debundle/selector_ir_lowering.rs
@@ -1121,9 +1121,11 @@ fn native_alpha_source_match_supported(
         return false;
     }
 
-    if facts.node_kind.iter().any(|(node, kind)| {
-        !skipped_nodes.contains(node) && matches!(kind, NodeKind::Seq | NodeKind::AssignProp)
-    }) {
+    if facts
+        .node_kind
+        .iter()
+        .any(|(node, kind)| !skipped_nodes.contains(node) && *kind == NodeKind::AssignProp)
+    {
         return false;
     }
 
@@ -3254,6 +3256,35 @@ mod tests {
                 is_binding: true,
                 ..
             } if value == "stable"
+        )));
+    }
+
+    #[test]
+    fn alpha_all_source_match_sequence_expression_lowers_natively() {
+        let mut selector = AnonymousStatementSelector::exact(
+            "function a(target, decorators) { return (applyDecorators(target, decorators), target); }",
+        );
+        selector.identifiers = SourceMatchIdentifierMode::AlphaAll;
+        let lowered = lower_member_selector(
+            &context(),
+            "Widget",
+            &MemberSelectorSpec::SourceMatch(selector),
+        )
+        .unwrap();
+
+        assert!(
+            !lowered
+                .program
+                .atoms
+                .iter()
+                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
+        );
+        assert!(lowered.program.atoms.iter().any(|atom| matches!(
+            atom,
+            SelectorAtom::AstKind {
+                node_kind: NodeKind::Seq,
+                ..
+            }
         )));
     }
 

--- a/devinfra/js/debundle/selector_ir_solver.rs
+++ b/devinfra/js/debundle/selector_ir_solver.rs
@@ -4183,6 +4183,50 @@ function candidateRight() {
     }
 
     #[test]
+    fn solves_alpha_all_target_binding_in_multideclarator() {
+        let mut selector = AnonymousStatementSelector::exact(
+            r#"const first = build("left"), second = build("right");"#,
+        );
+        selector.identifiers = spec::SourceMatchIdentifierMode::AlphaAll;
+        selector.target_binding = Some("second".to_string());
+        let lowered = lower_member_selector(
+            &MemberSelectorLoweringContext::new(ChunkId(0), "runtime/target"),
+            "Target",
+            &MemberSelectorSpec::SourceMatch(selector),
+        )
+        .unwrap();
+        assert!(
+            !lowered
+                .program
+                .atoms
+                .iter()
+                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
+        );
+        let facts = fact_store_from_analyzed_source(
+            r#"
+const runtimeFirst = build("left"), runtimeSecond = build("right");
+const otherFirst = build("left"), otherSecond = build("wrong");
+"#,
+        );
+
+        let result = solve(&lowered.program, &facts).unwrap();
+        let owner = owner_for_binding(&facts, "runtimeSecond");
+
+        assert_eq!(
+            result.outcome_for(lowered.target),
+            Some(&ClaimOutcome::Unique {
+                claim: ResolvedClaim {
+                    chunk_id: ChunkId(0),
+                    owner,
+                    statement_ordinal: statement_ordinal_for_owner(&facts, owner),
+                    binding: Some("runtimeSecond".to_string()),
+                    provenance: Vec::new(),
+                },
+            })
+        );
+    }
+
+    #[test]
     fn solves_lowered_exact_source_match_projects_target_binding() {
         let mut selector =
             AnonymousStatementSelector::exact(r#"const Target = makeTarget("value");"#);

--- a/devinfra/js/debundle/selector_ir_solver.rs
+++ b/devinfra/js/debundle/selector_ir_solver.rs
@@ -188,6 +188,7 @@ ascent! {
     relation ast_bool_literal(u32, bool); // node, value
     relation ast_identifier_name(u32, String); // node, value
     relation ast_property_name(u32, String); // node, value
+    relation ast_bare_property(u32, String, String, bool); // property node, key, identifier, is_binding
     relation ast_operator(u32, String); // node, operator
     relation ast_regex_literal(u32, String, String); // node, pattern, flags
     relation ast_super_class(u32, u32); // class node, super-class expression node
@@ -369,6 +370,7 @@ ascent! {
     relation required_ast_bool_literal(usize, usize, bool);
     relation required_ast_identifier_name(usize, usize, String);
     relation required_ast_property_name(usize, usize, String);
+    relation required_ast_bare_property(usize, usize, String, String, bool);
     relation required_ast_operator(usize, usize, String);
     relation required_ast_regex_literal(usize, usize, String, String);
     relation required_ast_top_level_ordinal(usize, usize, usize);
@@ -426,6 +428,12 @@ ascent! {
         ast_property_name(node, actual),
         if actual == value;
     node_constraint_support(*constraint, *var, *node) <--
+        required_ast_bare_property(constraint, var, key, identifier, is_binding),
+        ast_bare_property(node, actual_key, actual_identifier, actual_is_binding),
+        if actual_key == key,
+        if actual_identifier == identifier,
+        if actual_is_binding == is_binding;
+    node_constraint_support(*constraint, *var, *node) <--
         required_ast_operator(constraint, var, value),
         ast_operator(node, actual),
         if actual == value;
@@ -462,6 +470,7 @@ ascent! {
     relation required_owner_top_level_root(usize, usize, usize);
     relation required_ast_string_literal_var(usize, usize, usize);
     relation required_ast_identifier_name_var(usize, usize, usize);
+    relation required_ast_bare_property_var(usize, usize, String, usize, bool);
     relation required_owner_declares_binding_var(usize, usize, usize);
 
     relation binary_constraint_edge(usize, usize, usize, usize, usize);
@@ -515,6 +524,11 @@ ascent! {
     node_string_constraint_edge(*constraint, *node_var, *node, *string_var, value.clone()) <--
         required_ast_identifier_name_var(constraint, node_var, string_var),
         ast_identifier_name(node, value);
+    node_string_constraint_edge(*constraint, *node_var, *node, *string_var, value.clone()) <--
+        required_ast_bare_property_var(constraint, node_var, key, string_var, is_binding),
+        ast_bare_property(node, actual_key, value, actual_is_binding),
+        if actual_key == key,
+        if actual_is_binding == is_binding;
 
     relation owner_node_constraint_edge(usize, usize, usize, usize, u32);
     owner_node_constraint_edge(*constraint, *owner_var, *owner, *node_var, *node) <--
@@ -749,6 +763,11 @@ pub fn solve(
     for (node, value) in &fact_index.ast_property_names {
         ascent.ast_property_name.push((*node, value.clone()));
     }
+    for (node, key, identifier, is_binding) in &fact_index.ast_bare_properties {
+        ascent
+            .ast_bare_property
+            .push((*node, key.clone(), identifier.clone(), *is_binding));
+    }
     for (node, value) in &fact_index.ast_operators {
         ascent.ast_operator.push((*node, value.clone()));
     }
@@ -977,6 +996,19 @@ pub fn solve(
                     value.clone(),
                 ));
             }
+            NodeUnaryConstraintKind::BareProperty {
+                key,
+                identifier,
+                is_binding,
+            } => {
+                ascent.required_ast_bare_property.push((
+                    constraint.id,
+                    constraint.variable.0,
+                    key.clone(),
+                    identifier.clone(),
+                    *is_binding,
+                ));
+            }
             NodeUnaryConstraintKind::Operator { value } => {
                 ascent.required_ast_operator.push((
                     constraint.id,
@@ -1110,19 +1142,28 @@ pub fn solve(
         }
     }
     for constraint in &support.node_string_constraints {
-        match constraint.kind {
-            NodeStringConstraintKind::AstStringLiteral => {
+        match &constraint.kind {
+            NodeStringConstraintKind::StringLiteral => {
                 ascent.required_ast_string_literal_var.push((
                     constraint.id,
                     constraint.node.0,
                     constraint.string.0,
                 ));
             }
-            NodeStringConstraintKind::AstIdentifierName => {
+            NodeStringConstraintKind::IdentifierName => {
                 ascent.required_ast_identifier_name_var.push((
                     constraint.id,
                     constraint.node.0,
                     constraint.string.0,
+                ));
+            }
+            NodeStringConstraintKind::BareProperty { key, is_binding } => {
+                ascent.required_ast_bare_property_var.push((
+                    constraint.id,
+                    constraint.node.0,
+                    key.clone(),
+                    constraint.string.0,
+                    *is_binding,
                 ));
             }
         }
@@ -1541,11 +1582,9 @@ impl ProgramSupport {
                 SelectorAtom::AstStringLiteral {
                     node: NodeTerm::Var { id: node },
                     value: StringTerm::Var { id: string },
-                } => support.add_node_string(
-                    *node,
-                    *string,
-                    NodeStringConstraintKind::AstStringLiteral,
-                ),
+                } => {
+                    support.add_node_string(*node, *string, NodeStringConstraintKind::StringLiteral)
+                }
                 SelectorAtom::AstStringLiteralMatchingRegex {
                     node,
                     pattern: StringTerm::Const { value },
@@ -1593,7 +1632,7 @@ impl ProgramSupport {
                 } => support.add_node_string(
                     *node,
                     *string,
-                    NodeStringConstraintKind::AstIdentifierName,
+                    NodeStringConstraintKind::IdentifierName,
                 ),
                 SelectorAtom::AstPropertyName {
                     node,
@@ -1605,6 +1644,12 @@ impl ProgramSupport {
                     },
                     "ast_property_name",
                 ),
+                SelectorAtom::AstBareProperty {
+                    node,
+                    key,
+                    identifier,
+                    is_binding,
+                } => support.add_ast_bare_property(node, key, identifier, *is_binding),
                 SelectorAtom::AstOperator {
                     node,
                     value: StringTerm::Const { value },
@@ -2186,6 +2231,43 @@ impl ProgramSupport {
         }
     }
 
+    fn add_ast_bare_property(
+        &mut self,
+        node: &NodeTerm,
+        key: &StringTerm,
+        identifier: &StringTerm,
+        is_binding: bool,
+    ) {
+        let StringTerm::Const { value: key } = key else {
+            self.unsupported_atoms
+                .push("unsupported variable ast_bare_property.key".to_string());
+            return;
+        };
+        match (node, identifier) {
+            (NodeTerm::Var { id: node }, StringTerm::Var { id: identifier }) => self
+                .add_node_string(
+                    *node,
+                    *identifier,
+                    NodeStringConstraintKind::BareProperty {
+                        key: key.clone(),
+                        is_binding,
+                    },
+                ),
+            (NodeTerm::Var { id: node }, StringTerm::Const { value: identifier }) => self
+                .add_node_unary(
+                    *node,
+                    NodeUnaryConstraintKind::BareProperty {
+                        key: key.clone(),
+                        identifier: identifier.clone(),
+                        is_binding,
+                    },
+                ),
+            (NodeTerm::Const { .. }, _) => self
+                .unsupported_atoms
+                .push("unsupported constant-only ast_bare_property assertion".to_string()),
+        }
+    }
+
     fn add_ast_top_level(&mut self, node: &NodeTerm, ordinal: &OrdinalTerm) {
         match (node, ordinal) {
             (NodeTerm::Var { id: node }, OrdinalTerm::Const { ordinal }) => self.add_node_unary(
@@ -2673,21 +2755,59 @@ struct NodeUnaryConstraint {
 
 #[derive(Debug, Clone)]
 enum NodeUnaryConstraintKind {
-    Kind { node_kind: String },
-    ChildCount { count: u32 },
-    ChildParent { index: u32, child: u32 },
-    ChildChild { parent: u32, index: u32 },
-    SuperClassClass { super_class: u32 },
-    SuperClassSuper { class_node: u32 },
-    StringLiteral { value: String },
-    StringLiteralMatchingRegex { pattern: String },
-    NumberLiteral { value: String },
-    BoolLiteral { value: bool },
-    IdentifierName { value: String },
-    PropertyName { value: String },
-    Operator { value: String },
-    RegexLiteral { pattern: String, flags: String },
-    TopLevelOrdinal { ordinal: StatementOrdinal },
+    Kind {
+        node_kind: String,
+    },
+    ChildCount {
+        count: u32,
+    },
+    ChildParent {
+        index: u32,
+        child: u32,
+    },
+    ChildChild {
+        parent: u32,
+        index: u32,
+    },
+    SuperClassClass {
+        super_class: u32,
+    },
+    SuperClassSuper {
+        class_node: u32,
+    },
+    StringLiteral {
+        value: String,
+    },
+    StringLiteralMatchingRegex {
+        pattern: String,
+    },
+    NumberLiteral {
+        value: String,
+    },
+    BoolLiteral {
+        value: bool,
+    },
+    IdentifierName {
+        value: String,
+    },
+    PropertyName {
+        value: String,
+    },
+    BareProperty {
+        key: String,
+        identifier: String,
+        is_binding: bool,
+    },
+    Operator {
+        value: String,
+    },
+    RegexLiteral {
+        pattern: String,
+        flags: String,
+    },
+    TopLevelOrdinal {
+        ordinal: StatementOrdinal,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -2801,10 +2921,11 @@ struct NodeStringConstraint {
     kind: NodeStringConstraintKind,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 enum NodeStringConstraintKind {
-    AstStringLiteral,
-    AstIdentifierName,
+    StringLiteral,
+    IdentifierName,
+    BareProperty { key: String, is_binding: bool },
 }
 
 #[derive(Debug, Clone)]
@@ -2863,6 +2984,7 @@ fn atom_kind(atom: &SelectorAtom) -> &'static str {
         SelectorAtom::AstBoolLiteral { .. } => "ast_bool_literal",
         SelectorAtom::AstIdentifierName { .. } => "ast_identifier_name",
         SelectorAtom::AstPropertyName { .. } => "ast_property_name",
+        SelectorAtom::AstBareProperty { .. } => "ast_bare_property",
         SelectorAtom::AstOperator { .. } => "ast_operator",
         SelectorAtom::AstRegexLiteral { .. } => "ast_regex_literal",
         SelectorAtom::AstTopLevel { .. } => "ast_top_level",
@@ -2909,6 +3031,7 @@ struct FactIndex {
     ast_bool_literals: Vec<(u32, bool)>,
     ast_identifier_names: Vec<(u32, String)>,
     ast_property_names: Vec<(u32, String)>,
+    ast_bare_properties: Vec<(u32, String, String, bool)>,
     ast_operators: Vec<(u32, String)>,
     ast_regex_literals: Vec<(u32, String, String)>,
     ast_super_classes: Vec<(u32, u32)>,
@@ -3092,6 +3215,21 @@ impl FactIndex {
                 SelectorFact::AstPropertyName { node, value, .. } => {
                     index.all_nodes.insert(*node);
                     index.ast_property_names.push((*node, value.clone()));
+                }
+                SelectorFact::AstBareProperty {
+                    node,
+                    key,
+                    identifier,
+                    is_binding,
+                    ..
+                } => {
+                    index.all_nodes.insert(*node);
+                    index.ast_bare_properties.push((
+                        *node,
+                        key.clone(),
+                        identifier.clone(),
+                        *is_binding,
+                    ));
                 }
                 SelectorFact::AstOperator { node, value, .. } => {
                     index.all_nodes.insert(*node);
@@ -4115,6 +4253,101 @@ function good() { return good; }
             r#"
 function bad() { return bad; }
 function good() { return other; }
+"#,
+        );
+
+        let result = solve(&lowered.program, &facts).unwrap();
+        let owner = owner_for_binding(&facts, "good");
+
+        assert_eq!(
+            result.outcome_for(lowered.target),
+            Some(&ClaimOutcome::Unique {
+                claim: ResolvedClaim {
+                    chunk_id: ChunkId(0),
+                    owner,
+                    statement_ordinal: statement_ordinal_for_owner(&facts, owner),
+                    binding: Some("good".to_string()),
+                    provenance: Vec::new(),
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn solves_alpha_all_source_match_object_shorthand_against_explicit_property() {
+        let mut selector =
+            AnonymousStatementSelector::exact("function selected(stable) { return { stable }; }");
+        selector.identifiers = spec::SourceMatchIdentifierMode::AlphaAll;
+        let lowered = lower_member_selector(
+            &MemberSelectorLoweringContext::new(ChunkId(0), "runtime/target"),
+            "Target",
+            &MemberSelectorSpec::SourceMatch(selector),
+        )
+        .unwrap();
+        assert!(
+            !lowered
+                .program
+                .atoms
+                .iter()
+                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
+        );
+        let facts = fact_store_from_analyzed_source(
+            r#"
+function wrongKey(runtimeStable) {
+  return { other: runtimeStable };
+}
+function good(runtimeStable) {
+  return { stable: runtimeStable };
+}
+"#,
+        );
+
+        let result = solve(&lowered.program, &facts).unwrap();
+        let owner = owner_for_binding(&facts, "good");
+
+        assert_eq!(
+            result.outcome_for(lowered.target),
+            Some(&ClaimOutcome::Unique {
+                claim: ResolvedClaim {
+                    chunk_id: ChunkId(0),
+                    owner,
+                    statement_ordinal: statement_ordinal_for_owner(&facts, owner),
+                    binding: Some("good".to_string()),
+                    provenance: Vec::new(),
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn solves_alpha_all_source_match_object_pattern_shorthand_against_explicit_property() {
+        let mut selector = AnonymousStatementSelector::exact(
+            "function selected(input) { const { stable } = input; return stable; }",
+        );
+        selector.identifiers = spec::SourceMatchIdentifierMode::AlphaAll;
+        let lowered = lower_member_selector(
+            &MemberSelectorLoweringContext::new(ChunkId(0), "runtime/target"),
+            "Target",
+            &MemberSelectorSpec::SourceMatch(selector),
+        )
+        .unwrap();
+        assert!(
+            !lowered
+                .program
+                .atoms
+                .iter()
+                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
+        );
+        let facts = fact_store_from_analyzed_source(
+            r#"
+function wrongKey(input) {
+  const { other: runtimeStable } = input;
+  return runtimeStable;
+}
+function good(input) {
+  const { stable: runtimeStable } = input;
+  return runtimeStable;
+}
 "#,
         );
 

--- a/devinfra/js/debundle/selector_ir_solver.rs
+++ b/devinfra/js/debundle/selector_ir_solver.rs
@@ -37,6 +37,37 @@ fn optional_edge_kind_matches(expected: &Option<String>, actual: &str) -> bool {
         .is_none_or(|expected| expected == actual)
 }
 
+fn top_level_ordinal_offset_rows(
+    ast_top_levels: &[(u32, StatementOrdinal)],
+    required_offsets: &BTreeSet<i32>,
+) -> Vec<(usize, usize, i32)> {
+    if required_offsets.is_empty() {
+        return Vec::new();
+    }
+    let ordinals = ast_top_levels
+        .iter()
+        .map(|(_node, ordinal)| ordinal.0)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let mut rows = Vec::new();
+    for (base_index, base) in ordinals.iter().enumerate() {
+        for offset in required_offsets {
+            let Some(target_index) = (base_index as isize).checked_add(*offset as isize) else {
+                continue;
+            };
+            if target_index < 0 {
+                continue;
+            }
+            let Some(ordinal) = ordinals.get(target_index as usize) else {
+                continue;
+            };
+            rows.push((*base, *ordinal, *offset));
+        }
+    }
+    rows
+}
+
 type AssignmentRow = Vec<(usize, AssignmentValue)>;
 type EqualityCheck = (usize, usize, EqualityConstraintKind);
 type EqualityCheckSchedule = Vec<(usize, Vec<EqualityCheck>)>;
@@ -194,6 +225,7 @@ ascent! {
     relation ast_super_class(u32, u32); // class node, super-class expression node
     relation ast_top_level(u32, usize); // root node, statement ordinal
     relation ast_string_literal_regex_match(u32, String); // string literal node, pattern
+    relation ordinal_offset(usize, usize, i32); // base statement ordinal, target statement ordinal, body-order offset
 
     relation owner_statement_ordinal(usize, usize);
     owner_statement_ordinal(*owner, *ordinal) <--
@@ -467,6 +499,7 @@ ascent! {
     relation required_ast_child(usize, usize, usize, u32);
     relation required_ast_super_class(usize, usize, usize);
     relation required_ast_top_level(usize, usize, usize);
+    relation required_ordinal_offset(usize, usize, usize, i32);
     relation required_owner_top_level_root(usize, usize, usize);
     relation required_ast_string_literal_var(usize, usize, usize);
     relation required_ast_identifier_name_var(usize, usize, usize);
@@ -516,6 +549,11 @@ ascent! {
     node_ordinal_constraint_edge(*constraint, *node_var, *node, *ordinal_var, *ordinal) <--
         required_ast_top_level(constraint, node_var, ordinal_var),
         ast_top_level(node, ordinal);
+
+    relation ordinal_ordinal_constraint_edge(usize, usize, usize, usize, usize);
+    ordinal_ordinal_constraint_edge(*constraint, *base_var, *base, *ordinal_var, *ordinal) <--
+        required_ordinal_offset(constraint, base_var, ordinal_var, offset),
+        ordinal_offset(base, ordinal, offset);
 
     relation node_string_constraint_edge(usize, usize, u32, usize, String);
     node_string_constraint_edge(*constraint, *node_var, *node, *string_var, value.clone()) <--
@@ -586,6 +624,14 @@ ascent! {
         if let Some(row) = assignment_row_2(
             *node_var,
             AssignmentValue::AstNode(*node),
+            *ordinal_var,
+            AssignmentValue::StatementOrdinal(*ordinal),
+        );
+    atom_assignment(*constraint, row) <--
+        ordinal_ordinal_constraint_edge(constraint, base_var, base, ordinal_var, ordinal),
+        if let Some(row) = assignment_row_2(
+            *base_var,
+            AssignmentValue::StatementOrdinal(*base),
             *ordinal_var,
             AssignmentValue::StatementOrdinal(*ordinal),
         );
@@ -781,6 +827,12 @@ pub fn solve(
     }
     for (node, ordinal) in &fact_index.ast_top_levels {
         ascent.ast_top_level.push((*node, ordinal.0));
+    }
+    for (base, ordinal, offset) in top_level_ordinal_offset_rows(
+        &fact_index.ast_top_levels,
+        &support.required_ordinal_offsets(),
+    ) {
+        ascent.ordinal_offset.push((base, ordinal, offset));
     }
     for constraint in &support.node_list_constraints {
         for row in child_list_assignment_rows(constraint, &fact_index) {
@@ -1141,6 +1193,18 @@ pub fn solve(
             )),
         }
     }
+    for constraint in &support.ordinal_ordinal_constraints {
+        match constraint.kind {
+            OrdinalOrdinalConstraintKind::Offset { offset } => {
+                ascent.required_ordinal_offset.push((
+                    constraint.id,
+                    constraint.base.0,
+                    constraint.ordinal.0,
+                    offset,
+                ));
+            }
+        }
+    }
     for constraint in &support.node_string_constraints {
         match &constraint.kind {
             NodeStringConstraintKind::StringLiteral => {
@@ -1429,6 +1493,7 @@ struct ProgramSupport {
     node_node_constraints: Vec<NodeNodeConstraint>,
     node_list_constraints: Vec<NodeListConstraint>,
     node_ordinal_constraints: Vec<NodeOrdinalConstraint>,
+    ordinal_ordinal_constraints: Vec<OrdinalOrdinalConstraint>,
     node_string_constraints: Vec<NodeStringConstraint>,
     owner_string_constraints: Vec<OwnerStringConstraint>,
     equality_constraints: Vec<EqualityConstraint>,
@@ -1675,6 +1740,11 @@ impl ProgramSupport {
                 SelectorAtom::AstTopLevel { node, ordinal } => {
                     support.add_ast_top_level(node, ordinal)
                 }
+                SelectorAtom::OrdinalOffset {
+                    base,
+                    ordinal,
+                    offset,
+                } => support.add_ordinal_offset(base, ordinal, *offset),
                 SelectorAtom::ReadsMember {
                     owner: OwnerTerm::Var { id },
                     object: None,
@@ -1987,6 +2057,25 @@ impl ProgramSupport {
         self.constraints_by_var.entry(ordinal).or_default().push(id);
     }
 
+    fn add_ordinal_ordinal(
+        &mut self,
+        base: SelectorVariableId,
+        ordinal: SelectorVariableId,
+        kind: OrdinalOrdinalConstraintKind,
+    ) {
+        let id = self.next_constraint_id;
+        self.next_constraint_id += 1;
+        self.ordinal_ordinal_constraints
+            .push(OrdinalOrdinalConstraint {
+                id,
+                base,
+                ordinal,
+                kind,
+            });
+        self.constraints_by_var.entry(base).or_default().push(id);
+        self.constraints_by_var.entry(ordinal).or_default().push(id);
+    }
+
     fn add_node_string(
         &mut self,
         node: SelectorVariableId,
@@ -2287,6 +2376,23 @@ impl ProgramSupport {
         }
     }
 
+    fn add_ordinal_offset(&mut self, base: &OrdinalTerm, ordinal: &OrdinalTerm, offset: i32) {
+        match (base, ordinal) {
+            (OrdinalTerm::Var { id: base }, OrdinalTerm::Var { id: ordinal }) => self
+                .add_ordinal_ordinal(
+                    *base,
+                    *ordinal,
+                    OrdinalOrdinalConstraintKind::Offset { offset },
+                ),
+            (OrdinalTerm::Const { .. }, OrdinalTerm::Const { .. }) => self
+                .unsupported_atoms
+                .push("unsupported constant-only ordinal_offset assertion".to_string()),
+            _ => self
+                .unsupported_atoms
+                .push("unsupported mixed constant/variable ordinal_offset assertion".to_string()),
+        }
+    }
+
     fn string_literal_regex_patterns(&self) -> BTreeSet<String> {
         self.node_unary_constraints
             .iter()
@@ -2295,6 +2401,15 @@ impl ProgramSupport {
                     Some(pattern.clone())
                 }
                 _ => None,
+            })
+            .collect()
+    }
+
+    fn required_ordinal_offsets(&self) -> BTreeSet<i32> {
+        self.ordinal_ordinal_constraints
+            .iter()
+            .map(|constraint| match constraint.kind {
+                OrdinalOrdinalConstraintKind::Offset { offset } => offset,
             })
             .collect()
     }
@@ -2558,6 +2673,10 @@ impl ProgramSupport {
             variables.insert(constraint.node.0);
             variables.insert(constraint.ordinal.0);
         }
+        if let Some(constraint) = self.ordinal_ordinal_constraints.iter().find(|c| c.id == id) {
+            variables.insert(constraint.base.0);
+            variables.insert(constraint.ordinal.0);
+        }
         if let Some(constraint) = self.node_string_constraints.iter().find(|c| c.id == id) {
             variables.insert(constraint.node.0);
             variables.insert(constraint.string.0);
@@ -2635,6 +2754,10 @@ impl ProgramSupport {
                 .any(|constraint| constraint.id == id)
             || self
                 .node_ordinal_constraints
+                .iter()
+                .any(|constraint| constraint.id == id)
+            || self
+                .ordinal_ordinal_constraints
                 .iter()
                 .any(|constraint| constraint.id == id)
         {
@@ -2914,6 +3037,19 @@ enum NodeOrdinalConstraintKind {
 }
 
 #[derive(Debug, Clone)]
+struct OrdinalOrdinalConstraint {
+    id: usize,
+    base: SelectorVariableId,
+    ordinal: SelectorVariableId,
+    kind: OrdinalOrdinalConstraintKind,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum OrdinalOrdinalConstraintKind {
+    Offset { offset: i32 },
+}
+
+#[derive(Debug, Clone)]
 struct NodeStringConstraint {
     id: usize,
     node: SelectorVariableId,
@@ -2988,6 +3124,7 @@ fn atom_kind(atom: &SelectorAtom) -> &'static str {
         SelectorAtom::AstOperator { .. } => "ast_operator",
         SelectorAtom::AstRegexLiteral { .. } => "ast_regex_literal",
         SelectorAtom::AstTopLevel { .. } => "ast_top_level",
+        SelectorAtom::OrdinalOffset { .. } => "ordinal_offset",
         SelectorAtom::ReadsMember { .. } => "reads_member",
         SelectorAtom::ReadsMemberOfOwner { .. } => "reads_member_of_owner",
         SelectorAtom::ConsumesModuleMember { .. } => "consumes_module_member",
@@ -3547,6 +3684,136 @@ mod tests {
         let result = solve(&program, &facts).unwrap();
 
         assert_eq!(result.outcome_for(target), Some(&ClaimOutcome::NoMatch));
+    }
+
+    #[test]
+    fn ordinal_offset_requires_adjacent_statement_window() {
+        let mut program = SelectorProgram::default();
+        let owner_var = program.add_variable(VariableDomain::Owner, Some("@Target".to_string()));
+        let helper_node = program.add_variable(
+            VariableDomain::AstNode,
+            Some("source_match.helper".to_string()),
+        );
+        let target_node = program.add_variable(
+            VariableDomain::AstNode,
+            Some("source_match.target".to_string()),
+        );
+        let helper_ordinal = program.add_variable(
+            VariableDomain::StatementOrdinal,
+            Some("source_match.helper.ordinal".to_string()),
+        );
+        let target_ordinal = program.add_variable(
+            VariableDomain::StatementOrdinal,
+            Some("source_match.target.ordinal".to_string()),
+        );
+        let target = program.add_target(
+            ChunkId(0),
+            owner_var,
+            "runtime/widgets",
+            ClaimKind::Binding {
+                export_name: Some("Target".to_string()),
+            },
+            ClaimOrigin::MemberSelector,
+        );
+        program.add_atom(SelectorAtom::OwnerDeclaresBinding {
+            owner: OwnerTerm::Var { id: owner_var },
+            binding: StringTerm::Const {
+                value: "selected".to_string(),
+            },
+        });
+        program.add_atom(SelectorAtom::OwnerStatementOrdinal {
+            owner: OwnerTerm::Var { id: owner_var },
+            ordinal: OrdinalTerm::Var { id: target_ordinal },
+        });
+        program.add_atom(SelectorAtom::AstTopLevel {
+            node: NodeTerm::Var { id: helper_node },
+            ordinal: OrdinalTerm::Var { id: helper_ordinal },
+        });
+        program.add_atom(SelectorAtom::AstTopLevel {
+            node: NodeTerm::Var { id: target_node },
+            ordinal: OrdinalTerm::Var { id: target_ordinal },
+        });
+        program.add_atom(SelectorAtom::AstKind {
+            node: NodeTerm::Var { id: helper_node },
+            node_kind: chunk_facts::NodeKind::FnDecl,
+        });
+        program.add_atom(SelectorAtom::AstKind {
+            node: NodeTerm::Var { id: target_node },
+            node_kind: chunk_facts::NodeKind::VarDecl,
+        });
+        program.add_atom(SelectorAtom::OrdinalOffset {
+            base: OrdinalTerm::Var { id: target_ordinal },
+            ordinal: OrdinalTerm::Var { id: helper_ordinal },
+            offset: -1,
+        });
+        let adjacent = SelectorFactStore {
+            facts: vec![
+                owner(1, 1, "fn_decl"),
+                owner(2, 2, "var_decl"),
+                declared(2, "selected"),
+                SelectorFact::AstTopLevel {
+                    chunk_id: ChunkId(0),
+                    node: 10,
+                    statement_ordinal: StatementOrdinal(1),
+                },
+                SelectorFact::AstTopLevel {
+                    chunk_id: ChunkId(0),
+                    node: 20,
+                    statement_ordinal: StatementOrdinal(2),
+                },
+                SelectorFact::AstKind {
+                    chunk_id: ChunkId(0),
+                    node: 10,
+                    node_kind: chunk_facts::NodeKind::FnDecl,
+                },
+                SelectorFact::AstKind {
+                    chunk_id: ChunkId(0),
+                    node: 20,
+                    node_kind: chunk_facts::NodeKind::VarDecl,
+                },
+            ],
+        };
+        let gapped = SelectorFactStore {
+            facts: vec![
+                owner(1, 1, "fn_decl"),
+                owner(2, 3, "var_decl"),
+                declared(2, "selected"),
+                SelectorFact::AstTopLevel {
+                    chunk_id: ChunkId(0),
+                    node: 10,
+                    statement_ordinal: StatementOrdinal(1),
+                },
+                SelectorFact::AstTopLevel {
+                    chunk_id: ChunkId(0),
+                    node: 20,
+                    statement_ordinal: StatementOrdinal(3),
+                },
+                SelectorFact::AstTopLevel {
+                    chunk_id: ChunkId(0),
+                    node: 15,
+                    statement_ordinal: StatementOrdinal(2),
+                },
+                SelectorFact::AstKind {
+                    chunk_id: ChunkId(0),
+                    node: 10,
+                    node_kind: chunk_facts::NodeKind::FnDecl,
+                },
+                SelectorFact::AstKind {
+                    chunk_id: ChunkId(0),
+                    node: 20,
+                    node_kind: chunk_facts::NodeKind::VarDecl,
+                },
+            ],
+        };
+
+        assert!(matches!(
+            solve(&program, &adjacent).unwrap().outcome_for(target),
+            Some(ClaimOutcome::Unique { claim }) if claim.owner == OwnerId(2)
+        ));
+        assert_eq!(
+            solve(&program, &gapped).unwrap().outcome_for(target),
+            Some(&ClaimOutcome::NoMatch)
+        );
     }
 
     #[test]
@@ -4593,6 +4860,67 @@ const wrongCallee = makeOther("value");
                     provenance: Vec::new(),
                 },
             })
+        );
+    }
+
+    #[test]
+    fn solves_lowered_multi_statement_source_match_window_natively() {
+        let mut selector = AnonymousStatementSelector::exact(
+            "function helper(value) { return value + 1; }\nconst selected = makeThing();",
+        );
+        selector.target_binding = Some("selected".to_string());
+        let lowered = lower_member_selector(
+            &MemberSelectorLoweringContext::new(ChunkId(0), "runtime/widgets"),
+            "Widget",
+            &MemberSelectorSpec::SourceMatch(selector),
+        )
+        .unwrap();
+        assert!(
+            !lowered
+                .program
+                .atoms
+                .iter()
+                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
+        );
+
+        let adjacent = fact_store_from_analyzed_source(
+            r#"
+function helper(value) {
+  return value + 1;
+}
+const selected = makeThing();
+const other = makeThing();
+"#,
+        );
+        let gapped = fact_store_from_analyzed_source(
+            r#"
+function helper(value) {
+  return value + 1;
+}
+const gap = 0;
+const selected = makeThing();
+"#,
+        );
+
+        let result = solve(&lowered.program, &adjacent).unwrap();
+        let owner = owner_for_binding(&adjacent, "selected");
+        assert_eq!(
+            result.outcome_for(lowered.target),
+            Some(&ClaimOutcome::Unique {
+                claim: ResolvedClaim {
+                    chunk_id: ChunkId(0),
+                    owner,
+                    statement_ordinal: statement_ordinal_for_owner(&adjacent, owner),
+                    binding: Some("selected".to_string()),
+                    provenance: Vec::new(),
+                },
+            })
+        );
+        assert_eq!(
+            solve(&lowered.program, &gapped)
+                .unwrap()
+                .outcome_for(lowered.target),
+            Some(&ClaimOutcome::NoMatch)
         );
     }
 

--- a/devinfra/js/debundle/selector_ir_solver.rs
+++ b/devinfra/js/debundle/selector_ir_solver.rs
@@ -4416,6 +4416,48 @@ function good(target, decorators) {
     }
 
     #[test]
+    fn solves_alpha_all_source_match_assign_property() {
+        let mut selector =
+            AnonymousStatementSelector::exact(r#"const selected = { stable = "ok" };"#);
+        selector.identifiers = spec::SourceMatchIdentifierMode::AlphaAll;
+        let lowered = lower_member_selector(
+            &MemberSelectorLoweringContext::new(ChunkId(0), "runtime/target"),
+            "Target",
+            &MemberSelectorSpec::SourceMatch(selector),
+        )
+        .unwrap();
+        assert!(
+            !lowered
+                .program
+                .atoms
+                .iter()
+                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
+        );
+        let facts = fact_store_from_analyzed_source(
+            r#"
+const bad = { runtimeStable = "wrong" };
+const good = { runtimeStable = "ok" };
+"#,
+        );
+
+        let result = solve(&lowered.program, &facts).unwrap();
+        let owner = owner_for_binding(&facts, "good");
+
+        assert_eq!(
+            result.outcome_for(lowered.target),
+            Some(&ClaimOutcome::Unique {
+                claim: ResolvedClaim {
+                    chunk_id: ChunkId(0),
+                    owner,
+                    statement_ordinal: statement_ordinal_for_owner(&facts, owner),
+                    binding: Some("good".to_string()),
+                    provenance: Vec::new(),
+                },
+            })
+        );
+    }
+
+    #[test]
     fn solves_lowered_alpha_all_source_match_projects_target_binding() {
         let mut selector =
             AnonymousStatementSelector::exact(r#"function second() { return make("right"); }"#);

--- a/devinfra/js/debundle/selector_ir_solver.rs
+++ b/devinfra/js/debundle/selector_ir_solver.rs
@@ -173,6 +173,13 @@ fn assignment_satisfies_equality(
     match kind {
         EqualityConstraintKind::Equal => left == right,
         EqualityConstraintKind::NotEqual => left != right,
+        EqualityConstraintKind::OrdinalBefore => matches!(
+            (left, right),
+            (
+                AssignmentValue::StatementOrdinal(left),
+                AssignmentValue::StatementOrdinal(right),
+            ) if left < right
+        ),
     }
 }
 
@@ -1745,6 +1752,9 @@ impl ProgramSupport {
                     ordinal,
                     offset,
                 } => support.add_ordinal_offset(base, ordinal, *offset),
+                SelectorAtom::OrdinalBefore { before, after } => {
+                    support.add_ordinal_before(before, after)
+                }
                 SelectorAtom::ReadsMember {
                     owner: OwnerTerm::Var { id },
                     object: None,
@@ -2390,6 +2400,20 @@ impl ProgramSupport {
             _ => self
                 .unsupported_atoms
                 .push("unsupported mixed constant/variable ordinal_offset assertion".to_string()),
+        }
+    }
+
+    fn add_ordinal_before(&mut self, before: &OrdinalTerm, after: &OrdinalTerm) {
+        match (before, after) {
+            (OrdinalTerm::Var { id: before }, OrdinalTerm::Var { id: after }) => {
+                self.add_equality(*before, *after, EqualityConstraintKind::OrdinalBefore)
+            }
+            (OrdinalTerm::Const { .. }, OrdinalTerm::Const { .. }) => self
+                .unsupported_atoms
+                .push("unsupported constant-only ordinal_before assertion".to_string()),
+            _ => self
+                .unsupported_atoms
+                .push("unsupported mixed constant/variable ordinal_before assertion".to_string()),
         }
     }
 
@@ -3089,6 +3113,7 @@ struct EqualityConstraint {
 enum EqualityConstraintKind {
     Equal,
     NotEqual,
+    OrdinalBefore,
 }
 
 fn optional_const_string(value: &Option<StringTerm>) -> Option<Option<String>> {
@@ -3125,6 +3150,7 @@ fn atom_kind(atom: &SelectorAtom) -> &'static str {
         SelectorAtom::AstRegexLiteral { .. } => "ast_regex_literal",
         SelectorAtom::AstTopLevel { .. } => "ast_top_level",
         SelectorAtom::OrdinalOffset { .. } => "ordinal_offset",
+        SelectorAtom::OrdinalBefore { .. } => "ordinal_before",
         SelectorAtom::ReadsMember { .. } => "reads_member",
         SelectorAtom::ReadsMemberOfOwner { .. } => "reads_member_of_owner",
         SelectorAtom::ConsumesModuleMember { .. } => "consumes_module_member",
@@ -3812,6 +3838,102 @@ mod tests {
         ));
         assert_eq!(
             solve(&program, &gapped).unwrap().outcome_for(target),
+            Some(&ClaimOutcome::NoMatch)
+        );
+    }
+
+    #[test]
+    fn ordinal_before_requires_ordered_top_level_roots() {
+        let mut program = SelectorProgram::default();
+        let owner_var = program.add_variable(VariableDomain::Owner, Some("@Target".to_string()));
+        let first_node = program.add_variable(
+            VariableDomain::AstNode,
+            Some("source_match.first".to_string()),
+        );
+        let second_node = program.add_variable(
+            VariableDomain::AstNode,
+            Some("source_match.second".to_string()),
+        );
+        let first_ordinal = program.add_variable(
+            VariableDomain::StatementOrdinal,
+            Some("source_match.first.ordinal".to_string()),
+        );
+        let second_ordinal = program.add_variable(
+            VariableDomain::StatementOrdinal,
+            Some("source_match.second.ordinal".to_string()),
+        );
+        let target = program.add_target(
+            ChunkId(0),
+            owner_var,
+            "runtime/widgets",
+            ClaimKind::Binding {
+                export_name: Some("Target".to_string()),
+            },
+            ClaimOrigin::MemberSelector,
+        );
+        program.add_atom(SelectorAtom::OwnerDeclaresBinding {
+            owner: OwnerTerm::Var { id: owner_var },
+            binding: StringTerm::Const {
+                value: "selected".to_string(),
+            },
+        });
+        program.add_atom(SelectorAtom::OwnerTopLevelRoot {
+            owner: OwnerTerm::Var { id: owner_var },
+            root: NodeTerm::Var { id: second_node },
+        });
+        program.add_atom(SelectorAtom::AstTopLevel {
+            node: NodeTerm::Var { id: first_node },
+            ordinal: OrdinalTerm::Var { id: first_ordinal },
+        });
+        program.add_atom(SelectorAtom::AstTopLevel {
+            node: NodeTerm::Var { id: second_node },
+            ordinal: OrdinalTerm::Var { id: second_ordinal },
+        });
+        program.add_atom(SelectorAtom::OrdinalBefore {
+            before: OrdinalTerm::Var { id: first_ordinal },
+            after: OrdinalTerm::Var { id: second_ordinal },
+        });
+        program.add_atom(SelectorAtom::AstKind {
+            node: NodeTerm::Var { id: first_node },
+            node_kind: chunk_facts::NodeKind::VarDecl,
+        });
+        program.add_atom(SelectorAtom::AstKind {
+            node: NodeTerm::Var { id: second_node },
+            node_kind: chunk_facts::NodeKind::VarDecl,
+        });
+        let facts = |first_ordinal, second_ordinal| SelectorFactStore {
+            facts: vec![
+                owner(2, second_ordinal, "var_decl"),
+                declared(2, "selected"),
+                SelectorFact::AstTopLevel {
+                    chunk_id: ChunkId(0),
+                    node: 10,
+                    statement_ordinal: StatementOrdinal(first_ordinal),
+                },
+                SelectorFact::AstTopLevel {
+                    chunk_id: ChunkId(0),
+                    node: 20,
+                    statement_ordinal: StatementOrdinal(second_ordinal),
+                },
+                SelectorFact::AstKind {
+                    chunk_id: ChunkId(0),
+                    node: 10,
+                    node_kind: chunk_facts::NodeKind::VarDecl,
+                },
+                SelectorFact::AstKind {
+                    chunk_id: ChunkId(0),
+                    node: 20,
+                    node_kind: chunk_facts::NodeKind::VarDecl,
+                },
+            ],
+        };
+
+        assert!(matches!(
+            solve(&program, &facts(1, 3)).unwrap().outcome_for(target),
+            Some(ClaimOutcome::Unique { claim }) if claim.owner == OwnerId(2)
+        ));
+        assert_eq!(
+            solve(&program, &facts(3, 1)).unwrap().outcome_for(target),
             Some(&ClaimOutcome::NoMatch)
         );
     }

--- a/devinfra/js/debundle/selector_ir_solver.rs
+++ b/devinfra/js/debundle/selector_ir_solver.rs
@@ -4369,6 +4369,53 @@ function good(input) {
     }
 
     #[test]
+    fn solves_alpha_all_source_match_sequence_expression() {
+        let mut selector = AnonymousStatementSelector::exact(
+            "function selected(target, decorators) { return (applyDecorators(target, decorators), target); }",
+        );
+        selector.identifiers = spec::SourceMatchIdentifierMode::AlphaAll;
+        let lowered = lower_member_selector(
+            &MemberSelectorLoweringContext::new(ChunkId(0), "runtime/target"),
+            "Target",
+            &MemberSelectorSpec::SourceMatch(selector),
+        )
+        .unwrap();
+        assert!(
+            !lowered
+                .program
+                .atoms
+                .iter()
+                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
+        );
+        let facts = fact_store_from_analyzed_source(
+            r#"
+function bad(target, decorators) {
+  return (applyDecorators(target, decorators), decorators);
+}
+function good(target, decorators) {
+  return (applyDecorators(target, decorators), target);
+}
+"#,
+        );
+
+        let result = solve(&lowered.program, &facts).unwrap();
+        let owner = owner_for_binding(&facts, "good");
+
+        assert_eq!(
+            result.outcome_for(lowered.target),
+            Some(&ClaimOutcome::Unique {
+                claim: ResolvedClaim {
+                    chunk_id: ChunkId(0),
+                    owner,
+                    statement_ordinal: statement_ordinal_for_owner(&facts, owner),
+                    binding: Some("good".to_string()),
+                    provenance: Vec::new(),
+                },
+            })
+        );
+    }
+
+    #[test]
     fn solves_lowered_alpha_all_source_match_projects_target_binding() {
         let mut selector =
             AnonymousStatementSelector::exact(r#"function second() { return make("right"); }"#);


### PR DESCRIPTION
## Summary

Moves several high-volume `source_match` shapes from the legacy `SourceMatchCandidate` oracle path into native selector IR lowering / the single solver path:

- lower `alpha_all` `target_binding` selectors in multi-declarator statements natively
- lower all-hole child-list selectors such as whole `STMT_LIST`, `ARGS`, and `CLASS_REST` regions without constraining arity
- lower `ANYTHING` binding-pattern holes natively for params/destructuring-style patterns
- lower contextual `ANYTHING` list-hole sugar for object props, object patterns, declarators, and class-rest carriers
- lower bare object/object-pattern property alpha forms natively via an `ast_bare_property` relation, so shorthand and `{ key: ident }` / `{ key: binding }` forms meet inside the solver instead of using the legacy matcher
- lower `alpha_all` sequence-expression source matches natively, keeping comma-expression structure in the solver rather than falling back to the legacy matcher
- lower nested alpha scopes natively, including sibling callback-scope fixtures
- remove the remaining native alpha support predicate/gate, including `AssignProp`; alpha source_match now fails only through the concrete parse, hole, target-binding, or structural lowering paths
- lower fixed-window multi-statement member `source_match` selectors natively by introducing an ordinal-offset constraint over top-level body order
- lower contiguous multi-statement `binding_groups[].source_match` ranges natively, anchoring each export owner to the top-level root containing its selector-local target binding
- admit leading/trailing module-level `STMT_LIST` holes around a contiguous binding-group range without falling back to the group candidate oracle
- admit internal module-level `STMT_LIST` gaps in binding-group ranges by lowering each pinned segment plus an ordinal-before constraint, still without invoking the group candidate oracle

This keeps the movement toward one query/solver model: these selectors now produce AST/owner/ordinal constraints directly instead of asking `ChunkResolver` to pre-enumerate candidate rows.

## Validation

- `nix --offline develop --command pre-commit run --files devinfra/js/debundle/selector_ir.rs devinfra/js/debundle/selector_ir_lowering.rs devinfra/js/debundle/selector_ir_solver.rs devinfra/js/debundle/e2e/anonymous_statement_test.rs`
- `nix --offline develop --command bbr test //devinfra/js/debundle:selector_ir_lowering_test //devinfra/js/debundle:selector_ir_solver_test //devinfra/js/debundle/e2e:anonymous_statement_test`
- For the binding-group range follow-up: `nix --offline develop --command pre-commit run --files devinfra/js/debundle/selector_ir_lowering.rs devinfra/js/debundle/e2e/syntactic_holes_test.rs`
- For the binding-group range follow-up: `nix --offline develop --command bbr test //devinfra/js/debundle:selector_ir_lowering_test //devinfra/js/debundle/e2e:syntactic_holes_test`
- For the binding-group range follow-up: `nix --offline develop --command bbr test //devinfra/js/debundle:selector_ir_solver_test //devinfra/js/debundle/e2e:anonymous_statement_test`
- For the outer `STMT_LIST` binding-group follow-up: `nix --offline develop --command pre-commit run --files devinfra/js/debundle/selector_ir_lowering.rs devinfra/js/debundle/e2e/syntactic_holes_test.rs`
- For the outer `STMT_LIST` binding-group follow-up: `nix --offline develop --command bbr test //devinfra/js/debundle:selector_ir_lowering_test //devinfra/js/debundle/e2e:syntactic_holes_test`
- For the internal `STMT_LIST` binding-group follow-up: `nix --offline develop --command pre-commit run --files devinfra/js/debundle/selector_ir.rs devinfra/js/debundle/selector_ir_lowering.rs devinfra/js/debundle/selector_ir_solver.rs devinfra/js/debundle/e2e/syntactic_holes_test.rs`
- For the internal `STMT_LIST` binding-group follow-up: `nix --offline develop --command bbr test //devinfra/js/debundle:selector_ir_lowering_test //devinfra/js/debundle:selector_ir_solver_test //devinfra/js/debundle/e2e:syntactic_holes_test`
- Earlier on this branch: `nix --offline develop --command bbr test //devinfra/js/debundle/e2e:syntactic_holes_test //devinfra/js/debundle/e2e:anonymous_statement_test`
- Earlier on this branch: `nix --offline develop --command bbr test //devinfra/js/debundle/e2e:binding_group_adopt_names_test`

## Gaffer-private check

Attempted the documented source-debundler validation:

`nix --offline develop --command bazelisk build //tana/re/web/78d928dca7:debundle --config=nolint --config=rbe --config=source-debundler --override_module=ducktape=/tmp/ducktape-global-anonymous --remote_download_outputs=minimal`

Current result: the run reached `Running debundle pipeline for //tana/re/web/78d928dca7:debundle`, then the remote action was killed for resource exhaustion after about 31.5 minutes.

That run was started before the final solver constraint-ordering patch in `0385f95942`, so the gaffer-private full validation is still unproven. I did not see a debundle correctness failure from gaffer-private; the remaining issue is solver/runtime scalability on the full Tana target.
