### PR TITLE
nix/home: fix infinite recursion from enableGui in imports

### DIFF
--- a/nix/home/home.nix
+++ b/nix/home/home.nix
@@ -84,8 +84,6 @@ in
     ./modules/sops-env.nix
     ./services/activitywatch.nix
     ./opencode
-  ]
-  ++ lib.optionals enableGui [
     ./modules/gnome-shell-keybindings.nix
     ./modules/flameshot-screenshots.nix
   ];

--- a/nix/home/modules/flameshot-screenshots.nix
+++ b/nix/home/modules/flameshot-screenshots.nix
@@ -1,7 +1,12 @@
 # Flameshot screenshot configuration
 # Configures Flameshot as the default screenshot tool with Print Screen key
-{ pkgs, ... }:
 {
+  pkgs,
+  lib,
+  enableGui,
+  ...
+}:
+lib.mkIf enableGui {
   xdg.autostart = {
     enable = true;
     entries = [

--- a/nix/home/modules/gnome-shell-keybindings.nix
+++ b/nix/home/modules/gnome-shell-keybindings.nix
@@ -11,11 +11,11 @@
 # References:
 #   https://github.com/pop-os/shell/blob/master_noble/scripts/configure.sh
 #   https://github.com/pop-os/shell/blob/master_noble/schemas/org.gnome.shell.extensions.pop-shell.gschema.xml
-{ lib, ... }:
+{ lib, enableGui, ... }:
 let
   emptyStrArray = lib.hm.gvariant.mkEmptyArray lib.hm.gvariant.type.string;
 in
-{
+lib.mkIf enableGui {
   dconf.settings = {
     # Pop Shell extension preferences and keybinding overrides.
     # Strip arrow key variants from focus (we use Super+Arrow for workspaces


### PR DESCRIPTION
## Problem

The "Nix Attic push" GitHub Actions workflow has been failing on **every** devel commit since `e2ce15a` ("home: gate dconf settings on GUI profiles"), with:

```
error: infinite recursion encountered
… while evaluating the module argument `enableGui' in nix/home/home.nix
```

## Root cause

`e2ce15a` added `lib.optionals enableGui [ ./modules/gnome-shell-keybindings.nix ./modules/flameshot-screenshots.nix ]` to the **`imports`** list in `nix/home/home.nix`. You can't use a module argument (`enableGui`, resolved via `_module.args`, which requires `config`) inside `imports` — `imports` must be evaluated *before* `config` is built. Hence infinite recursion.

## Fix

Import both GUI-only modules **unconditionally** and gate their content with `lib.mkIf enableGui` inside each module (the standard NixOS/home-manager pattern for conditional-on-config imports).

## Test

`pre-commit` (nixfmt/statix) passes. The Nix eval that the Attic-push workflow performs no longer hits the recursion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCfbKCVsZu48PcLmqmUeBE

---
_Generated by [Claude Code](https://claude.ai/code/session_01XCfbKCVsZu48PcLmqmUeBE)_