### PR TITLE
haku: fix fastmcp/Tana closure clobber, simplify bootstrap signal, widen egress

### DIFF
--- a/cluster/k8s/agents/haku-mitmproxy/cnp-haku-cloud-api-egress.yaml
+++ b/cluster/k8s/agents/haku-mitmproxy/cnp-haku-cloud-api-egress.yaml
@@ -37,6 +37,11 @@ spec:
         - matchName: index.docker.io
         - matchName: gmail.googleapis.com
         - matchName: www.googleapis.com
+        # Google Tasks API — Haku reads the operator's task list (the Tasks
+        # playbook). www.googleapis.com covers Calendar/Drive; Tasks is on its
+        # own host. (A 403 here is a token-scope gap, not this allowlist — but
+        # the host must still be reachable once the scope is granted.)
+        - matchName: tasks.googleapis.com
       toPorts:
         - ports:
             - port: "443"
@@ -49,6 +54,18 @@ spec:
         - matchName: pypi.org
         - matchName: files.pythonhosted.org
         - matchName: registry.npmjs.org
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+    # Nix binary cache + channels — so Haku runtimes that install/refresh their
+    # Nix closure (e.g. the agent-haku devtools/fastmcp install) hit the public
+    # cache instead of building from source. cache.nixos.org serves nars;
+    # nixos.org redirects channel/installer fetches.
+    - toFQDNs:
+        - matchName: cache.nixos.org
+        - matchName: nixos.org
+        - matchName: channels.nixos.org
       toPorts:
         - ports:
             - port: "443"

--- a/devinfra/claude/web_setup.sh
+++ b/devinfra/claude/web_setup.sh
@@ -88,6 +88,18 @@ esac
 # haku/runtime/claude_web_env/setup.sh) to get `.#agent-haku`, which composes `.#devtools`
 # and adds the fastmcp MCP-client CLI. Only honored in `profile` install mode.
 WEB_SETUP_OUTPUT="${DUCKTAPE_WEB_SETUP_OUTPUT:-devtools}"
+# Self-heal the Haku web home. DUCKTAPE_WEB_SETUP_OUTPUT=agent-haku is set inside
+# haku/runtime/claude_web_env/setup.sh (the init-script path), but the Setup-hook
+# path (web_setup_hook.sh → this script) and resume-cached sessions run WITHOUT it
+# — so they would reinstall the lean .#devtools and clobber the .#agent-haku
+# (fastmcp) the init script installed, silently breaking Haku's Tana access. The
+# hooks profile IS visible on both paths (UI env var), so when it's Haku's profile
+# and no explicit output was requested, default to agent-haku. (Explicit
+# DUCKTAPE_WEB_SETUP_OUTPUT always wins.)
+if [ -z "${DUCKTAPE_WEB_SETUP_OUTPUT:-}" ] && [[ "${DUCKTAPE_CLAUDE_HOOKS_PROFILE:-}" == *haku* ]]; then
+  WEB_SETUP_OUTPUT=agent-haku
+  log "Haku profile detected (DUCKTAPE_CLAUDE_HOOKS_PROFILE=$DUCKTAPE_CLAUDE_HOOKS_PROFILE); defaulting WEB_SETUP_OUTPUT=agent-haku"
+fi
 
 FLAKE="path:$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SETUP_COMMIT=$(git -C "${FLAKE#path:}" rev-parse HEAD 2>/dev/null || echo 'unknown')
@@ -250,6 +262,15 @@ fi
 # Symlink all Nix-installed binaries into /usr/local/bin so they're on PATH.
 # Claude Code is launched directly (not via login shell), so the Nix profile bin
 # is not in PATH when hooks run. /usr/local/bin is always in PATH.
+#
+# First prune any dangling /usr/local/bin symlinks left by a PREVIOUS install of a
+# different output: switching agent-haku→devtools (or vice versa) removes binaries
+# (e.g. fastmcp) from the profile, but the old symlink lingers and masquerades as
+# present (`which fastmcp` resolves to a broken link). Drop links whose target is
+# gone before re-bridging the current profile.
+for link in /usr/local/bin/*; do
+  [ -L "$link" ] && [ ! -e "$link" ] && rm -f "$link"
+done
 for bin in "${NIX_PROFILE}"/bin/*; do
   ln -sfn "$bin" /usr/local/bin/"$(basename "$bin")"
 done

--- a/haku/runtime/claude_web_env/README.md
+++ b/haku/runtime/claude_web_env/README.md
@@ -18,9 +18,12 @@ here (on Anthropic infra) and drives the cluster over `kubectl`; the
 - **Allowed domains:** the [default allowed domains](https://code.claude.com/docs/en/claude-code-on-the-web#default-allowed-domains)
   plus:
   - `*.anthropic.com`
-  - `*.allegedly.works` — the cluster (kube API, Forgejo, LiteLLM, …)
-  - `*.googleapis.com` — Gmail/Calendar read-only REST
+  - `*.allegedly.works` — the cluster (kube API, Forgejo, LiteLLM, `tana-mcp-ro`, …)
+  - `*.googleapis.com` — Gmail/Calendar/Tasks read-only REST
   - `*.buildbuddy.io` — RBE/remote cache (only if Haku runs `bbr`)
+  - `nixos.org`, `cache.nixos.org` — Nix channels + binary cache, so the
+    `.#agent-haku` install (and any Nix/pre-commit work) pulls from the cache
+    instead of failing (observed: `nixos.org` 403 without this).
 
 ## Files
 
@@ -48,3 +51,22 @@ here (on Anthropic infra) and drives the cluster over `kubectl`; the
 
 Depends on `secrets/haku-k8s-jwt.yaml` existing (minted by the
 `authentik-jwt-rotation` CronJob) — that JWT is what the kubeconfig is built from.
+
+## Gotcha: the Setup hook can clobber `.#agent-haku` (fastmcp/Tana)
+
+`web_setup.sh` runs **twice** per fresh session: once as the init script (via
+`setup.sh`, which sets `DUCKTAPE_WEB_SETUP_OUTPUT=agent-haku` → installs fastmcp)
+and once as the **Setup hook** (`web_setup_hook.sh` → `web_setup.sh`), which does
+**not** carry that env var. The Setup-hook run was defaulting to `.#devtools` and
+running `nix profile remove agent-haku`, **wiping fastmcp** and leaving a dangling
+`/usr/local/bin/fastmcp` — so Haku lost Tana access (it fell back to "skip Tana").
+On `resume-cached` sessions only the Setup hook runs, so agent-haku never installed
+at all.
+
+Fix (in `devinfra/claude/web_setup.sh`): when `DUCKTAPE_WEB_SETUP_OUTPUT` is unset
+but `DUCKTAPE_CLAUDE_HOOKS_PROFILE` points at a Haku profile, it now defaults to
+`agent-haku` — so **both** paths install fastmcp consistently — and it prunes
+dangling `/usr/local/bin` symlinks before re-bridging. Setting
+`DUCKTAPE_WEB_SETUP_OUTPUT=agent-haku` as a web-UI env var is an equally valid
+explicit override. (Tana also has a `curl` fallback in the base instructions, so a
+missing fastmcp degrades rather than blinds — but the closure should be present.)

--- a/haku/runtime/claude_web_env/bootstrap.sh
+++ b/haku/runtime/claude_web_env/bootstrap.sh
@@ -7,7 +7,13 @@
 #   2. Read the haku-state-git-write secret from haku-sandbox and write a
 #      ~/.netrc so git needs no inline credentials.
 #   3. Clone (or fast-forward) haku-state into ~/haku-state — outside the
-#      ducktape checkout, so there's no collision.
+#      ducktape checkout, so there's no collision. The clone runs into a temp dir
+#      and is atomically swapped into place, so ~/haku-state never exists
+#      half-populated (it's absent until the clone completes). An early echo +
+#      the daemon's "Task [bootstrap] exited" message (bg stdout is surfaced to
+#      the agent) keep an agent that starts before this finishes from mistaking
+#      an absent checkout for a first run (the bug that produced duplicate items
+#      on the 8th run).
 set -euo pipefail
 
 state_dir="$HOME/haku-state"
@@ -24,7 +30,19 @@ printf 'machine git.allegedly.works login %s password %s\n' "$u" "$p" >~/.netrc
 if [ -d "$state_dir/.git" ]; then
   git -C "$state_dir" pull --ff-only || true
 else
-  git clone https://git.allegedly.works/haku/haku-state.git "$state_dir"
+  # Clone into a temp dir and atomically swap it into place, so ~/haku-state is
+  # NEVER half-populated — it simply doesn't exist until the clone completes.
+  # Announce on stdout: this runs as a background command, and the hook daemon
+  # surfaces bg stdout (and a "Task [bootstrap] exited N." mailbox message) to the
+  # agent as a system message on its next tool call (devinfra/claude/claude_hook/
+  # bg_command.rs + main.rs drain). So the agent gets an explicit "still cloning"
+  # signal here and an explicit completion signal when this task exits — it must
+  # not mistake an absent ~/haku-state for a first run.
+  echo "haku-state: cloning in the background (pid $$). ~/haku-state is populated via atomic swap only when this completes — it is NOT ready until the 'Task [bootstrap] exited' message arrives (or until ~/haku-state/items exists)."
+  tmp_dir="$HOME/haku-state.cloning"
+  rm -rf "$tmp_dir"
+  git clone https://git.allegedly.works/haku/haku-state.git "$tmp_dir"
+  mv "$tmp_dir" "$state_dir"
 fi
 git -C "$state_dir" config user.name haku
 git -C "$state_dir" config user.email haku@allegedly.works

--- a/haku/runtime/claude_web_env/run.md
+++ b/haku/runtime/claude_web_env/run.md
@@ -29,6 +29,36 @@ environment-neutral `haku/run.md`.
   upgrade (`cluster/k8s/kube-api-proxy`); they were briefly broken until that was
   added. Clean up pods after (20-pod quota).
 
+## First: wait for bootstrap to finish (avoid the false "first run")
+
+`bootstrap.sh` runs as a **background** profile command, so when your session
+starts it may **not have finished cloning** `~/haku-state` yet. The clone lands via
+an **atomic swap**, so `~/haku-state` is never half-populated — it simply **doesn't
+exist** until the clone completes. Two signals tell you it's still running, both
+surfaced to you as system messages (the hook daemon drains background-command
+stdout + lifecycle messages on each tool call): bootstrap's own
+`haku-state: cloning in the background (pid …) — NOT ready yet` line, and the
+daemon's `Task [bootstrap] exited 0.` once it finishes. **Until you've seen the
+exit message (or confirmed `~/haku-state/items` exists), do not treat the absent/
+empty checkout as a first run** — orienting too early and concluding "first run"
+creates duplicates of items that already exist on the remote. Before Step 1, block
+until the clone is actually complete:
+
+```bash
+for i in $(seq 1 60); do
+  if git -C ~/haku-state rev-parse HEAD >/dev/null 2>&1 && [ -d ~/haku-state/items ]; then
+    echo "haku-state ready at $(git -C ~/haku-state rev-parse --short HEAD)"; break
+  fi
+  echo "waiting for bootstrap clone… ($i)"; sleep 5
+done
+git -C ~/haku-state pull --ff-only || true
+```
+
+If it's still not ready after the wait, re-run
+`haku/runtime/claude_web_env/bootstrap.sh` yourself and check the output. Only treat
+the state as a genuine first run if, after a **completed** clone, the **remote** has
+no commits — never on the strength of a local checkout that might still be filling in.
+
 ## Then run
 
 Concrete paths for this environment: your `haku-state` checkout is `~/haku-state`,


### PR DESCRIPTION
## Problem

Haku's recurring "Tana unreachable" was never a network/token problem — Tana is fully reachable. The cause: `fastmcp` kept disappearing from the web home's PATH.

## Root cause (confirmed from `/tmp/web-setup.log` + `nix profile list`)

`web_setup.sh` runs **twice** per fresh session:
1. **init script** (via `haku/runtime/claude_web_env/setup.sh`) sets `DUCKTAPE_WEB_SETUP_OUTPUT=agent-haku` → installs `.#agent-haku` **with fastmcp**.
2. **Setup hook** (`web_setup_hook.sh` → `web_setup.sh`) re-runs **without** that env var → defaults to `.#devtools`, runs `nix profile remove agent-haku` → **wipes fastmcp**, leaving a dangling `/usr/local/bin/fastmcp`.

On `resume-cached` sessions only the Setup hook runs, so `agent-haku` never installs at all. Haku's old instruction then said "skip Tana if no fastmcp" → its most important source was silently dropped for weeks.

## Changes

- **`web_setup.sh`**: when `DUCKTAPE_WEB_SETUP_OUTPUT` is unset but the hooks profile is Haku's, default to `agent-haku` — so both paths (and resume-cached) install fastmcp consistently. Also prune dangling `/usr/local/bin` symlinks before re-bridging.
- **`bootstrap.sh`**: clone via temp dir + atomic swap (so `~/haku-state` is never half-populated), and echo a *factual* "cloning in background (pid …), not ready until exit" line — the hook daemon surfaces bg stdout + the `Task [bootstrap] exited` message to the agent. No hardcoded "this is not a first run" claim (the script can't know that).
- **`cnp-haku-cloud-api-egress.yaml`**: allow `tasks.googleapis.com` (Google Tasks) and the Nix cache/channels (`cache.nixos.org`, `nixos.org`, `channels.nixos.org`).
- **README**: document the clobber gotcha + the self-heal; add `nixos.org`/`cache.nixos.org` to the web env's allowed-domains.

## Operator follow-up (web UI, not in repo)

In the Haku Claude-web environment, add `nixos.org` + `cache.nixos.org` to Allowed Domains (observed `nixos.org` 403). Optionally set `DUCKTAPE_WEB_SETUP_OUTPUT=agent-haku` as an explicit env var (the profile-inference fix already covers it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCfbKCVsZu48PcLmqmUeBE

---
_Generated by [Claude Code](https://claude.ai/code/session_01XCfbKCVsZu48PcLmqmUeBE)_