### PR TITLE
haku/base: Tana actionability + curl fallback, env self-check, delegation lever

### DIFF
--- a/haku/base/instructions.md
+++ b/haku/base/instructions.md
@@ -38,6 +38,22 @@ an open-ended intelligence pointed at the operator's whole life. Each run:
   code, automation — not just the obvious one-line chore. Ask "what could a smart,
   well-equipped agent actually accomplish here?" and frame _that_.
 
+**Delegation to AI agents is a first-class, _growing_ lever — hunt for it
+deliberately.** The operator's standing preference (2026-06-25): he wants to
+maximally exploit the fact that, given the right tools and/or API keys, a capable
+agent can already take on a large and ever-expanding share of his work — and that
+surface only gets bigger over time. So make "what here could be handed to an agent?"
+a primary lens on _everything_ you see, not an afterthought on chores. For each
+candidate, think about **what would unlock it**: it may be doable today with what an
+executor already has (browser, code, research, the cluster, his read/write
+accounts), or it may just need a specific affordance — an API key, an MCP server, a
+service signup, a scoped credential. When a high-value task is blocked only on such
+an affordance, **say so in the item**: name the key/tool/service that would let an
+agent run it end-to-end, so the operator can decide to provision it. Maintain a
+running view of his delegatable backlog and what each piece needs in `memory/`
+(a delegation register), and grow it every run. Framing "this is now automatable,
+here's what it takes" is among the highest-value things you produce.
+
 The playbooks will always be a small subset of what's worth doing; invent passes
 they never anticipated, **building on your accumulated notes and past reasoning**.
 Look wherever your (read-only) access reaches.
@@ -255,12 +271,15 @@ change anything in. Outside it you have read-only diagnostics (the cluster-wide 
 infra-log grants above): you can look but never touch. The creds you can mount are
 read-only too, so the compute is for gathering, not acting on the world.
 
-**Your home has the `fastmcp` CLI** (in the agent-haku closure) for talking to MCP
-servers: `fastmcp list <url> --auth "$TOKEN"` and `fastmcp call <url> <tool>
-key=value … --auth "$TOKEN" --transport http`. That's how you reach bearer-gated MCP
-facades like `tana-mcp-ro` directly from your home — no pod, no JSON-RPC handshake
-(see _Hard rules_ and `playbooks/tana_review.md`). If `fastmcp` is not on your `PATH`,
-note the gap in your log and skip Tana for this run — it returns when the image rebuilds.
+**Your home _should_ have the `fastmcp` CLI** (in the agent-haku closure) for
+talking to MCP servers: `fastmcp list <url> --auth "$TOKEN"` and `fastmcp call <url>
+<tool> key=value … --auth "$TOKEN" --transport http` — the turnkey way to reach
+bearer-gated MCP facades like `tana-mcp-ro` directly from your home. **But don't
+assume it's there:** the web home sometimes comes up with the lean `.#devtools`
+closure (no `fastmcp`). If `fastmcp` is not on your `PATH`, **do not skip the source
+— fall back to `curl`** over MCP-HTTP (recipe in `playbooks/tana_review.md`) and
+**file an item** flagging the missing closure so the operator can fix the env (see
+_Environment self-check_). Working-but-degraded beats silently blind.
 
 If your runtime didn't already clone state for you, clone it yourself with the
 `haku-state-git-write` secret over the **public** `git.allegedly.works` host
@@ -278,7 +297,41 @@ git -C ~/haku-state config user.email haku@allegedly.works
 
 The repo may be **empty on the first run** (no seed) — if so, create the
 structure yourself: `items/`, `intake/processed/`, `log/`, `memory/`, and
-`dashboard/`.
+`dashboard/`. **But don't confuse a mid-bootstrap or incomplete checkout for a first
+run** — see _Environment self-check_.
+
+## Environment self-check — surface breakages as items
+
+The setup your entrypoint and this manual describe is a **contract about your
+environment**, and contracts break: a closure ships without a tool (`fastmcp`
+missing), a credential's scope is too narrow (Google Tasks/Drive-Activity 403),
+an egress host isn't allowlisted, a bootstrap step half-finished. When something
+the docs say should be available **isn't**, that is itself a finding the operator
+needs — and the operator only sees your **dashboard**, not your logs. So **don't
+bury breakages in the log: file an item** (a `prepared_prompt` proposing the
+ducktape/env fix, with the exact symptom as evidence), then **work around it for
+the current run** wherever you can (e.g. curl instead of `fastmcp`) rather than
+dropping the affected source. A logged-and-forgotten gap silently degrades you run
+after run — exactly how Tana went unscanned for weeks; an item gets it fixed.
+
+Concretely, each run sanity-check the capabilities you're about to rely on and
+reconcile them against this manual's promises:
+
+- **Tools on `PATH`** the docs assume (`fastmcp`, `kubectl`, `git`, `curl`, `psql`
+  via the pod path). Missing → item + fallback.
+- **Credentials present and adequately scoped** — the `haku-sandbox` secrets in the
+  table above resolve, and Google scopes cover what you call (a 403 is a scope/enablement
+  gap, **not** a network block; a timeout/refused is the network one). Persistent
+  403s on a documented source → item to widen the scope or enable the API.
+- **Egress reachability** for the hosts you need (state repo, `tana-mcp-ro`, Google
+  APIs, the cluster). A host that should work but is refused/blocked → item naming the
+  FQDN so the operator can add it to the allowlist.
+- **Bootstrap completed** — your state checkout is fully materialized (has commits,
+  expected dirs), not a partial clone (see _Continuity_).
+
+This is a **standing obligation**, not a one-off: the env will keep drifting, so keep
+checking and keep surfacing. Track known-open env breakages in `memory/` so you don't
+re-file the same one each run (update the item instead).
 
 ## Continuity — you are restarted from a clean home each run
 
@@ -343,12 +396,18 @@ below.
   even if attempted. Call the Gmail/Calendar REST APIs with
   `Authorization: Bearer $TOK`. There is no MCP server; `curl` goes through the
   egress proxy transparently.
-- **Tana: read-only MCP, via the `fastmcp` CLI.** The operator's Tana workspace is
-  reachable through the `tana-mcp-ro` facade, which exposes read tools only (writes
-  are hidden and rejected) and holds the Tana PAT itself — you never see it. It's
-  published at `https://tana-mcp-ro.allegedly.works/mcp` behind a static bearer, so
-  reach it **directly from your home** with `fastmcp` carrying the reflected
-  `haku-tana-ro-token` bearer — no pod needed. See `playbooks/tana_review.md`.
+- **Tana: read-only MCP — `fastmcp` if present, else `curl`. Never silently skip
+  it.** Tana is the operator's primary knowledge base and most likely to hold tasks
+  tracked nowhere else, so treat it as a must-scan source, not an optional one. The
+  `tana-mcp-ro` facade exposes read tools only (writes hidden and rejected) and holds
+  the Tana PAT server-side — you never see it. It's published at
+  `https://tana-mcp-ro.allegedly.works/mcp` behind a static bearer, reachable
+  **directly from your home**: with the `fastmcp` CLI carrying the reflected
+  `haku-tana-ro-token` bearer when it's on `PATH`, **or — when `fastmcp` is missing —
+  with plain `curl` over MCP-HTTP** (initialize → `notifications/initialized` →
+  `tools/call`; the recipe and field-tested gotchas are in `playbooks/tana_review.md`).
+  If `fastmcp` is absent, fall back to curl **and file an item** about the missing
+  closure (see _Environment self-check_) — don't drop the source.
 - Never put secrets, full account numbers, or credentials in items, the log,
   or commit messages. Reference transactions by date + merchant + amount, mail
   and events by subject/title + sender + date (never raw bodies, never the

--- a/haku/base/playbooks/README.md
+++ b/haku/base/playbooks/README.md
@@ -18,10 +18,16 @@ scope — if a call 403s, the scope isn't granted (or the API isn't enabled on t
 project), so note the gap in your log and move on.
 
 [`tana_review`](tana_review.md) reads the operator's Tana (read-only) via the
-cluster-internal `tana-mcp-ro` facade — reached **directly from the web home**
-with the `fastmcp` CLI carrying the `haku-tana-ro-token` bearer (no pod). Confirm
-it's on your wire before relying on it and keep the working recipe in your
-`memory/`.
+cluster-internal `tana-mcp-ro` facade — reached **directly from the web home** with
+the `fastmcp` CLI carrying the `haku-tana-ro-token` bearer (no pod), or with plain
+`curl` over MCP-HTTP when `fastmcp` is missing (the playbook has both recipes). Tana
+is the operator's primary task store — a must-scan source, not optional; keep the
+working recipe in your `memory/`.
+
+[`delegation_scan`](delegation_scan.md) is the cross-source pass for the operator's
+top standing goal: find what a capable AI agent could take off his plate — today, or
+given one specific affordance (an API key, an MCP server, a credential) — and surface
+it ranked. Maintain a delegation register in `memory/` so it compounds.
 
 Designed but **not yet wired** — the tools aren't on your wire; don't attempt
 them, just note the gap in your log if one appears: PostScanMail (unopened mail →

--- a/haku/base/playbooks/delegation_scan.md
+++ b/haku/base/playbooks/delegation_scan.md
@@ -1,0 +1,55 @@
+# delegation_scan (example)
+
+A standing, cross-source pass whose single question is: **what here could a capable
+AI agent take off the operator's plate — now, or if given one specific affordance?**
+The operator wants to maximally exploit AI delegation, and treats the set of
+delegatable work as large and growing (see `instructions.md` → _How you reason_,
+the delegation-lever paragraph). This playbook is how you mine for it deliberately
+instead of only noticing it on obvious chores.
+
+## Inputs (triangulate — don't read one source)
+
+- **Tana** (`tana_review`) — his primary task store; usually the richest seam of
+  intentions he's tracked nowhere else. Pull open `#Task` nodes and recent daily
+  notes.
+- **Google Tasks** (`tasks`), **Gmail** (`gmail_triage`), **Calendar**
+  (`calendar_prep`), **Drive** (`drive_activity`) — explicit and latent to-dos.
+- **Your own `items/` and `memory/`** — existing open items that are really
+  "delegate this," and the delegation register you maintain (below).
+- **Your knowledge** — automatable angles he hasn't spotted (a service exists, an
+  API exists, an agent could just do it).
+
+## Triage each candidate
+
+For every task-shaped or problem-shaped thing, ask in order:
+
+1. **Already tracked / already done?** Cross-check before filing — much of this is in
+   Tana or a prior item. If tracked, **advance it** (do the research, draft the
+   artifact, compute the deadline), don't restate it. If a Tana checkbox is `[X]`,
+   it's done — skip it (the `is:todo` flag lies; read the checkbox).
+2. **Delegatable to an agent?** Could an executor with browser + code + research +
+   his accounts/cluster carry it out? If yes, it's a `prepared_prompt` — write the
+   outcome and embed the evidence.
+3. **What would unlock it?** Doable today, or blocked on one affordance — an **API
+   key**, an **MCP server**, a **service signup**, a **scoped credential**, a piece
+   of **automation worth building**? If blocked only on an affordance, **name it in
+   the item** so the operator can decide to provision it ("an agent could run this
+   end-to-end given a Plaid write token / a Calendar-write scope / a $X/mo service").
+4. **Value vs. his effort?** Rank per the contract. A task that becomes a
+   click-to-approve agent handoff is worth more than the same task done manually.
+
+## Group, don't spam
+
+Cluster related tasks into one well-framed item rather than one item per line — e.g.
+a change-of-address sweep, a subscription-cancellation sweep, or a "hand my NixOS /
+device backlog to a coding agent" bundle pointing at the relevant ducktape configs.
+The `prepared_prompt` enumerates the members with their evidence; the `body` shows
+the operator the list.
+
+## Keep a delegation register in `memory/`
+
+Maintain `memory/delegation.md` (or similar): the running backlog of delegatable
+work, what each piece needs to be runnable (already-possible vs. needs-key/tool/
+service), and what you've **learned about what he values** — every accept / reject /
+snooze / "was nothing" recalibrates which delegations are worth surfacing. Grow it
+each run; this is what makes the scan compound over time instead of restarting.

--- a/haku/base/playbooks/tana_review.md
+++ b/haku/base/playbooks/tana_review.md
@@ -92,36 +92,61 @@ operator decided against it), not `done`. Query the actionable set directly with
 Backlog **or** In progress). When you read an individual node, take its
 `**Task status**:` line as authoritative — ignore the checkbox glyph.
 
-## Incremental scan — resume from a bookmark
+### Always exclude trashed nodes
 
-`edited.since` takes a **milliseconds** epoch, so keep an exact bookmark in
-`memory/` (e.g. `tana: through 2026-06-25T20:30:00Z` → `1750883400000`) and only
-look at what changed:
+Every node in a `search_nodes` result carries an **`inTrash`** boolean. There is **no
+trash flag in the query DSL**, so `search_nodes` returns trashed nodes mixed in with
+live ones — **filter `inTrash === true` out client-side** before surfacing or filing
+anything. A trashed task the operator deleted is not relevant; surfacing it is the
+same class of error as surfacing a Done one. (Measured 2026-06-25: trashed `#Task`
+nodes still come back from the status-field query.)
 
-```jsonc
-// task nodes changed since the bookmark, still actionable:
-{"and":[{"hasType":"<taskTag>"},
-        {"or":[{"field":{"fieldId":"<statusF>","nodeId":"<backlog>"}},
-               {"field":{"fieldId":"<statusF>","nodeId":"<inProgress>"}}]},
-        {"edited":{"since": <bookmarkMs>}}]}
-```
+## Incremental scan — read EVERY change since the bookmark, not just tasks
 
-`created` only supports `{last: <days>}` (no `since`), so for brand-new nodes either
-`or:[{edited:{since:…}},{created:{last:N}}]` with `N` rounded up from the bookmark,
-or just rely on `edited.since` (creation stamps an edit). Bare `edited.since` across
-ALL nodes is noisy (daily-note churn easily hits the 100 cap) — always combine with
-`hasType` / status to narrow.
+Tana is the operator's primary brain; **a sweep must see all of it that changed since
+last time, across all node types** — not only `#Task`. Edits to meetings, projects,
+daily notes, company/person nodes, and free notes carry context that implies new tasks,
+problems worth solving, status updates on things you already track, and patterns worth
+suggesting. Missing edits = missing the operator's current reality.
 
-## What to mine
+Keep an **exact millisecond bookmark** in `memory/` (e.g. `tana: through
+2026-06-25T20:30:00Z` → `1750883400000`); `edited.since` takes ms. Each sweep, pull
+everything edited since it and **advance the bookmark to now** when done.
 
-- **Actionable tasks** — the Backlog/In-progress set above; the freshly-edited ones
-  are the operator's current focus, the stale ones are easy wins or things slipping.
-- **Recent daily notes** — walk the last ~1–2 weeks of daily/calendar nodes (find
-  via `search_nodes`, then `get_children`) for tasks jotted but never captured as
-  `#Task`: "follow up on X", "ask Y", half-formed ideas.
+**The hard constraint: `search_nodes` has NO pagination** (only `query`,
+`workspaceIds`, `limit`; no offset/cursor) **and `edited` has no upper bound** (only
+`since`/`last`, no range). So a single `{edited:{since}}` silently **truncates at the
+`limit` (~100)** — and Tana syncs Google Calendar as a stream of `#Meeting` nodes, so
+churn blows past 100 fast. To read the change set **completely**:
 
-Turn the worthwhile ones into items: `suggestion` for "do this", `prepared_prompt`
-where a full-access agent could carry it out (embed the node title + date + the
-desired outcome). Evidence in `body`: node title, date, a short quote — **never**
-dump raw node bodies. Skip anything whose `Task status` is Done/Cancelled, anything
-already tracked, and anything you've filed before.
+1. Scope to the operator's workspace(s) with `workspaceIds`.
+2. Run `{edited:{since:<ms>}}` (+ `created:{last:N}` for brand-new nodes — `created`
+   has no `since`). If it returns **fewer than `limit`**, that's the complete set.
+3. If it **hits the cap**, it's truncated — **narrow and re-run per supertag**:
+   `and:[{hasType:<tag>},{edited:{since}}]` for each tag from `list_tags`, since a
+   single tag rarely exceeds 100. Cover untagged/daily churn via the date nodes
+   directly (`get_children` on the recent `#Day`/Week nodes).
+4. Keep the **bookmark cadence tight enough** that a window never exceeds the cap; if
+   one tag ever caps anyway, sweep more often (smaller windows). Log if you suspect
+   truncation so a gap is visible rather than silent.
+
+Always drop `inTrash` nodes (above). `#Meeting`/`#Day` nodes are mostly routine
+calendar syncs — skim, don't dwell, unless one implies something (a note like "…for
+insurance fighting" on a meeting is a real signal).
+
+## What to mine — reason beyond tasks
+
+- **Actionable `#Task`s** (Backlog/In-progress, not trashed): freshly-edited = current
+  focus; stale = easy wins or things slipping.
+- **Everything else that changed** — read it for: (a) **status updates** on things you
+  already track (close/advance the matching item); (b) **latent tasks** jotted in
+  daily notes/projects but never made `#Task`s ("follow up on X", "ask Y"); (c)
+  **problems** implied by a note that an agent could solve; (d) **patterns in how the
+  operator uses Tana** worth suggesting (e.g. recurring manual steps to automate, a
+  messy area to restructure) — surface those as `suggestion` items too.
+
+Turn the worthwhile ones into items: `suggestion` for "do this / here's an idea",
+`prepared_prompt` where a full-access agent could carry it out (embed the node title +
+date + desired outcome). Evidence in `body`: node title, date, a short quote — **never**
+dump raw node bodies. Skip anything trashed, anything whose `Task status` is
+Done/Cancelled, anything already tracked, and anything you've filed before.

--- a/haku/base/playbooks/tana_review.md
+++ b/haku/base/playbooks/tana_review.md
@@ -35,24 +35,93 @@ Read tools only — `search_nodes`, `read_node`, `get_children`, `open_node`,
 `list` is empty or a call 401s, note the gap in your log and move on (the facade
 flips NotReady on a bad upstream, and the bearer must be the reflected one).
 
+### Fallback: drive the facade with `curl` when `fastmcp` is missing
+
+`fastmcp` is the convenience wrapper, **not** the only way in. If it isn't on your
+`PATH` (e.g. the web home came up with the lean `.#devtools` instead of
+`.#agent-haku`), **do not skip Tana** — it's the operator's most important source.
+The facade is plain MCP-over-HTTP behind the same bearer, so reach it with `curl`:
+do an `initialize` (capture the `Mcp-Session-Id` response header), send
+`notifications/initialized`, then `tools/call`. Responses come back as SSE
+(`data: {…}` lines). A minimal one-call-per-invocation helper (fresh handshake each
+time, stateless-friendly):
+
+```bash
+TOK=$(kubectl -n haku-sandbox get secret haku-tana-ro-token -o jsonpath='{.data.token}' | base64 -d)
+URL=https://tana-mcp-ro.allegedly.works/mcp
+H=(-H "Authorization: Bearer $TOK" -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream")
+SID=$(curl -sS -D - -o /dev/null "${H[@]}" -X POST "$URL" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"haku","version":"0"}}}' \
+  | awk 'tolower($1)=="mcp-session-id:"{print $2}' | tr -d '\r')
+curl -sS "${H[@]}" -H "Mcp-Session-Id: $SID" -X POST "$URL" \
+  -d '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}' >/dev/null
+curl -sS "${H[@]}" -H "Mcp-Session-Id: $SID" -X POST "$URL" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"search_nodes","arguments":{"query":{"and":[{"hasType":"<taskTagId>"},{"or":[{"field":{"fieldId":"<statusFieldId>","nodeId":"<backlogId>"}},{"field":{"fieldId":"<statusFieldId>","nodeId":"<inProgressId>"}}]}]},"limit":100}}}' \
+  | sed 's/^data: //' | grep -E '^\{' | tail -1
+```
+
+`search_nodes` takes a top-level `query` (and `limit`, max ~100) — **no
+`workspaceId`**; the structured query DSL is in the tool's own `description`. Link
+Tana nodes in items as `https://app.tana.inc?nodeid=<nodeId>`. **Surface the
+`fastmcp` gap itself as an item** (see _Environment self-check_) so the operator can
+fix the closure — curl keeps you working meanwhile, but the root cause should reach
+the dashboard.
+
+## Determining whether a task is actually open — use the `Task status` field, NOT the checkbox or `is:todo`
+
+**Both `is:'todo'/'done'` and the markdown `[ ]/[X]` checkbox are unreliable
+truth sources for a `#Task`** — they cost real reconciliation errors (filing/keeping
+items for work the operator had already finished). Measured on this graph
+(2026-06-25): `is:todo` returned 27 nodes of which **26 were actually done**, and it
+**missed** genuinely-open tasks entirely; the checkbox is binary so it conflates
+**Done** and **Cancelled** (and any other terminal state) into one `[X]`.
+
+The real source of truth is the `#Task` supertag's **`Task status`** field, an enum.
+Discover its field id and option ids with `get_tag_schema` on the task tag (ids are
+**workspace-specific** — never hardcode; re-read the schema). On this graph today:
+
+- Field **`Task status`** = `1McjTPZczhYk`, options: **Backlog** `Prpt16bEROhy`
+  (default), **In progress** `nwX-Fo55la66`, **Done** `BWHY3xGsWmOJ`, **Cancelled**
+  `6ruvnDPXXUBF`.
+
+**Actionable = `Task status` ∈ {Backlog, In progress}. Treat Done AND Cancelled as
+closed** — never surface them, and reconcile any existing item against them: a Tana
+**Done** → mark the item `done`; a Tana **Cancelled** → mark it `rejected` (the
+operator decided against it), not `done`. Query the actionable set directly with the
+`field` operator (the curl example above): `hasType:<taskTag>` AND (`field` status =
+Backlog **or** In progress). When you read an individual node, take its
+`**Task status**:` line as authoritative — ignore the checkbox glyph.
+
+## Incremental scan — resume from a bookmark
+
+`edited.since` takes a **milliseconds** epoch, so keep an exact bookmark in
+`memory/` (e.g. `tana: through 2026-06-25T20:30:00Z` → `1750883400000`) and only
+look at what changed:
+
+```jsonc
+// task nodes changed since the bookmark, still actionable:
+{"and":[{"hasType":"<taskTag>"},
+        {"or":[{"field":{"fieldId":"<statusF>","nodeId":"<backlog>"}},
+               {"field":{"fieldId":"<statusF>","nodeId":"<inProgress>"}}]},
+        {"edited":{"since": <bookmarkMs>}}]}
+```
+
+`created` only supports `{last: <days>}` (no `since`), so for brand-new nodes either
+`or:[{edited:{since:…}},{created:{last:N}}]` with `N` rounded up from the bookmark,
+or just rely on `edited.since` (creation stamps an edit). Bare `edited.since` across
+ALL nodes is noisy (daily-note churn easily hits the 100 cap) — always combine with
+`hasType` / status to narrow.
+
 ## What to mine
 
-Resume from a bookmark in `memory/` (e.g. "tana: through 2026-06-18T09:15:00Z" — an
-exact timestamp, not a coarse date) and look at
-what's recent in the operator's graph:
-
+- **Actionable tasks** — the Backlog/In-progress set above; the freshly-edited ones
+  are the operator's current focus, the stale ones are easy wins or things slipping.
 - **Recent daily notes** — walk the last ~1–2 weeks of daily/calendar nodes (find
-  them via `search_nodes`, then `get_children` to read them) for tasks the operator
-  jotted but never actioned: "follow up on X", "ask Y", half-captured ideas, items
-  with no owner or date.
-- **Recently-touched nodes** — `search_nodes` for what the operator edited lately; a
-  node they left open often implies intended next work, and is a window into what
-  they're focused on right now.
-- **Stale open tasks** — unchecked task nodes that have sat untouched, especially
-  ones implying a deadline or an easy win.
+  via `search_nodes`, then `get_children`) for tasks jotted but never captured as
+  `#Task`: "follow up on X", "ask Y", half-formed ideas.
 
 Turn the worthwhile ones into items: `suggestion` for "do this", `prepared_prompt`
 where a full-access agent could carry it out (embed the node title + date + the
 desired outcome). Evidence in `body`: node title, date, a short quote — **never**
-dump raw node bodies. Skip anything already done elsewhere and anything you've filed
-before.
+dump raw node bodies. Skip anything whose `Task status` is Done/Cancelled, anything
+already tracked, and anything you've filed before.

--- a/haku/run.md
+++ b/haku/run.md
@@ -26,12 +26,25 @@ a fresh start.
 All paths below are relative to your `haku-state` checkout. Run this top to
 bottom:
 
-1. **Orient**: read your `memory/` (standing operator guidance, how far you got
-   last time, prior notes), your most recent `log/` daily files, and all of
-   `items/` (including terminal items — they encode what the operator already
-   decided). Check your `memory/` watch-list and your `snoozed`/deferred items for
-   **wake triggers that have now arrived** — things you parked for "later" because
-   they weren't yet actionable (see _Curate_ for promoting them).
+1. **Orient — fully, before you dig**: read your `memory/` (standing operator
+   guidance, how far you got last time, prior notes), your most recent `log/` daily
+   files, and **all** of `items/` (including terminal items — they encode what the
+   operator already decided). **Finish this before you scan or file anything**: load
+   every existing item's `dedup_key` into mind first, so you advance/update what's
+   already there instead of creating duplicates (the failure mode is filing a "new"
+   tender-offer or move item that already exists). Check your `memory/` watch-list and
+   your `snoozed`/deferred items for **wake triggers that have now arrived** — things
+   you parked for "later" because they weren't yet actionable (see _Curate_ for
+   promoting them).
+   **Confirm this isn't a false first run:** if `items/` looks empty, verify the state
+   repo is genuinely seedless (the **remote** has no commits) rather than a partial or
+   mid-bootstrap checkout — re-pull / wait for the clone to finish before concluding
+   it's the first run (your entrypoint's bootstrap may still be running). Treating an
+   incomplete checkout as a fresh start is how duplicates and lost history happen.
+   Then run a quick **environment self-check** (per `instructions.md` → _Environment
+   self-check_): confirm the tools, credentials, and egress this run will rely on are
+   actually present, and **file an item** for any documented capability that's broken
+   (then work around it for this run) rather than silently degrading.
 2. **Adopt base updates**: compare the ducktape checkout's `HEAD`
    (`git -C <ducktape> rev-parse HEAD`) to the pin in `memory/base-sync.md`. If it
    advanced, diff `haku/base` + `haku/run.md` since the pin, migrate your state to


### PR DESCRIPTION
Hardens Haku's runtime behavior after the 8th run mis-scanned Tana, mistook a mid-clone checkout for a first run, and surfaced tasks the operator had already completed.

## Tana

- **Must-scan source, with a `curl` fallback.** The `tana-mcp-ro` facade is plain MCP-over-HTTP; reach it with `fastmcp` when present, else `curl` (recipe in `tana_review.md`). Never silently skip Tana.
- **Actionability from the `#Task` `Task status` field**, not the `is:todo` flag or the `[ ]/[X]` checkbox — both proven unreliable on the live graph (`is:todo` returned 27 nodes of which **26 were actually done**, and missed genuinely-open ones; the checkbox conflates **Done** and **Cancelled**). Backlog/In-progress = actionable; a Tana **Done** → mark the item `done`, a Tana **Cancelled** → mark it `rejected`. Field/option ids via `get_tag_schema` (workspace-specific).
- **Incremental scan** via `edited.since` (milliseconds epoch) from a `memory/` bookmark.

## Other base changes

- **Environment self-check**: surface broken documented capabilities (missing tool, narrow scope, blocked egress) as **items** — the operator sees the dashboard, not logs — then work around them for the run.
- **Delegation lever**: the operator's standing goal is to maximize AI delegation; hunt for it deliberately and, when a task is blocked only on an affordance (API key, MCP server, credential), name it. New `delegation_scan` playbook.
- **`run.md` Step 1**: orient fully and load all `dedup_key`s before scanning/filing; verify a *genuine* first run (remote has no commits) vs. an incomplete checkout; run the env self-check.

Note: docs reference the curl fallback / env-self-check that also appear in the companion web-runtime PR, but the two are independent and merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCfbKCVsZu48PcLmqmUeBE

---
_Generated by [Claude Code](https://claude.ai/code/session_01XCfbKCVsZu48PcLmqmUeBE)_