### PR TITLE
debundle: fail closed on non-native source_match

### DIFF
--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -24,13 +24,15 @@ records and scoped backlogs; when a plan's core work is complete, its remaining
 tail should be summarized here instead of leaving the plan looking like a second
 priority queue.
 
-**Current focus (2026-06-23 post-#2447).** PRs #2439, #2443, #2446, and
-#2447 moved `source_match` onto the Ascent-backed selector path, lowered the
-exact single-statement AST subset, stopped calling `ChunkResolver` for native
-selectors, and added native class-superclass constraints. The remaining P0 is
-to make every live selector form lower into one declarative Ascent/CSP-style
-constraint program. `SourceMatchCandidate` should shrink to the unsupported
-fallback set and then disappear.
+**Current focus (2026-06-25).** PRs #2439, #2443, #2446, and #2447 moved
+`source_match` onto the Ascent-backed selector path, lowered the exact
+single-statement AST subset, stopped calling `ChunkResolver` for native
+selectors, and added native class-superclass constraints. Current work deletes
+the `SourceMatchCandidate` schema, member/group candidate-oracle injection, and
+production anonymous-statement `ChunkResolver` fallback. The remaining P0 is to
+make every retained selector form lower faithfully into one declarative
+Ascent/CSP-style constraint program; unsupported forms now fail closed instead
+of taking a production procedural fallback.
 
 Dispatch work in this order:
 
@@ -42,18 +44,14 @@ Dispatch work in this order:
    holes, regex string predicates, and then ordered run holes (`STMT_LIST`,
    `OBJECT_PROPS`, `DECLARATORS`, `ARGS`, `CLASS_REST`, `CASE_REST`,
    `ARRAY_ELEMENTS`) as native constraints. Preserve the fail-closed rule:
-   unsupported constructs stay on the oracle until their faithful encoding is
+   unsupported constructs report `unsupported` until their faithful encoding is
    implemented.
 3. **Source-match surface pruning (P0.3).** Remove legacy `source_match`
    options that no current downstream spec uses before nativeization hardens
    them into the new IR. `target_statement` / `target_statements` have been
    removed; the remaining gaffer-private census follow-up is
    `wildcard_string_literals`.
-4. **Delete the candidate oracle (P0.4).** Remove `SelectorAtom::SourceMatchCandidate`
-   / `SelectorFact::SourceMatchCandidate` once all retained selector forms lower
-   natively. No-match, ambiguity, unsupported, and duplicate-claim diagnostics
-   should be projections of solver results and categoricity / `all_different`.
-5. **Derived relational predicates (P0.5).** Fold the remaining bridge
+4. **Derived relational predicates (P0.4).** Fold the remaining bridge
    vocabulary (`cross_ref`, `reads_member`, `member_of_module`,
    `passed_to_call`, `makes_decorate_call`, `intrinsic_alias`) into IR atoms or
    derived predicates over owner/reference + AST facts.
@@ -118,10 +116,7 @@ this list as the dispatch summary, not a second plan.
 3. **Prune unused source-match options.** Finish the
    `wildcard_string_literals` census/removal decision, and run a broader
    vestigial-feature audit before nativeizing more rarely-used spec surface.
-4. **Retire `SourceMatchCandidate`.** Delete the pre-enumerated candidate
-   oracle once all retained selector forms lower natively, and route
-   source-match diagnostics through solver categoricity / `all_different`.
-5. **Fold bridge vocabulary into derived predicates.** Re-express the staged
+4. **Fold bridge vocabulary into derived predicates.** Re-express the staged
    relational selectors as solver predicates over owner/reference + AST facts.
    Real-spec Gaffer work should supply missing predicates and diagnostics, not
    another permanent resolver layer.

--- a/devinfra/js/debundle/lowering/anonymous.rs
+++ b/devinfra/js/debundle/lowering/anonymous.rs
@@ -1,12 +1,7 @@
-//! Resolve `anonymous_statements[]` selectors on a spec
-//! `LogicalRequest` to pre-split body ordinals in the runtime
-//! module. Match equality ignores both `Span` and `SyntaxContext`
-//! because needle and runtime are parsed in different `resolver`
-//! passes; SWC's `SyntaxContext::within_ignored_ctxt` makes
-//! `eq_ignore_span` compare the source-level identifier shape.
-
-use super::*;
-use crate::plans::AnonymousStatementRequest;
+//! Shared materialization state for `anonymous_statements[]` claims and
+//! diagnostics. Selector matching is handled by the global selector IR solver;
+//! this module only carries resolved ordinals into the planner and renders
+//! keep-going failures.
 
 #[derive(Debug, Clone)]
 pub(super) struct ResolvedAnonymousStatement {
@@ -25,62 +20,4 @@ impl AnonymousStatementDiagnostic {
     pub(super) fn render(&self) -> String {
         format!("module {}: {}", self.module_id, self.message)
     }
-}
-
-/// Categorical reduction of the seam's matched groups to one group's body
-/// indices: an `anonymous_statements[]` entry must match exactly one top-level
-/// group (mirrors the former `source_match::resolve_anonymous_statement_body_indices`,
-/// now reached through the resolver seam so the matcher flip carries this path too).
-fn one_anonymous_group(
-    request_id: &str,
-    selector: &spec::AnonymousStatementSelector,
-    groups: Vec<Vec<usize>>,
-) -> Result<Vec<usize>> {
-    match groups.as_slice() {
-        [single] => Ok(single.clone()),
-        [] => bail!(
-            "logical_module {request_id}: anonymous_statements[].match did not match any \
-             top-level statement group in the chunk. Selector:\n{match_source}",
-            match_source = selector.match_source,
-        ),
-        multiple => bail!(
-            "logical_module {request_id}: anonymous_statements[].match is ambiguous — \
-             matched {} top-level statement groups at body indices {:?}. Refine the selector. \
-             Source:\n{match_source}",
-            multiple.len(),
-            multiple,
-            match_source = selector.match_source,
-        ),
-    }
-}
-
-pub(super) fn resolve_anonymous_statement_request(
-    request_id: &str,
-    statement: &AnonymousStatementRequest,
-    resolver: &dyn source_match::SelectorResolver,
-    keep_going: bool,
-    diagnostics: &mut Vec<AnonymousStatementDiagnostic>,
-) -> Result<Vec<ResolvedAnonymousStatement>> {
-    let ordinals = match resolver
-        .resolve_anonymous_groups(request_id, &statement.selector)
-        .and_then(|groups| one_anonymous_group(request_id, &statement.selector, groups))
-    {
-        Ok(ordinals) => ordinals,
-        Err(error) if keep_going => {
-            diagnostics.push(AnonymousStatementDiagnostic {
-                module_id: request_id.to_string(),
-                selector: statement.selector.clone(),
-                message: format!("{error:#}"),
-            });
-            return Ok(Vec::new());
-        }
-        Err(error) => return Err(error),
-    };
-    Ok(ordinals
-        .into_iter()
-        .map(|ordinal| ResolvedAnonymousStatement {
-            ordinal,
-            comment: statement.comment.clone(),
-        })
-        .collect())
 }

--- a/devinfra/js/debundle/lowering/materialize/mod.rs
+++ b/devinfra/js/debundle/lowering/materialize/mod.rs
@@ -14,6 +14,8 @@ mod passed_to_call;
 mod plan_builder;
 mod reads_member;
 
+use std::io::Write;
+
 pub(super) use apply::apply_materialized_logical_chunks;
 use plan_builder::{ChunkPlan, ChunkPlanBuilder, ExplicitRequestContext};
 
@@ -25,6 +27,27 @@ use js_ast::statement_ordinal_for_body_index;
 use output_layout::{
     ATOMIC_UNIT_CONFLICTS_REPORT, CYCLES_REPORT, OWNER_GRAPH_REPORT, SELECTOR_DIAGNOSTICS_REPORT,
 };
+
+const DEBUNDLE_PROGRESS_ENV: &str = "DUCKTAPE_DEBUNDLE_PROGRESS";
+
+fn debundle_progress_enabled() -> bool {
+    std::env::var(DEBUNDLE_PROGRESS_ENV)
+        .ok()
+        .is_some_and(|raw| {
+            !matches!(
+                raw.to_ascii_lowercase().as_str(),
+                "" | "0" | "false" | "off" | "no"
+            )
+        })
+}
+
+fn emit_debundle_progress(chunk_id: &str, phase: &str, state: &str) {
+    if !debundle_progress_enabled() {
+        return;
+    }
+    eprintln!("[debundle progress] chunk={chunk_id} phase={phase} state={state}");
+    let _ = std::io::stderr().flush();
+}
 
 /// Per-chunk inputs that identify the chunk and where its outputs
 /// should land. Bundled into `MaterializeLogicalChunkInputs::context`.
@@ -115,6 +138,7 @@ pub(super) fn materialize_logical_chunk(
         .chunk_table
         .get(chunk_id)
         .with_context(|| format!("materialize_logical_modules unknown chunk: {chunk_id}"))?;
+    emit_debundle_progress(chunk_id, "materialize_logical_chunk", "start");
     let chunk_started = Instant::now();
     let mut timings = PhaseTimings::default();
     let target_file = time_phase!(timings, "resolve_entry", {
@@ -173,13 +197,6 @@ pub(super) fn materialize_logical_chunk(
     let mut imported_binding_resolver =
         ArtifactSourceImportResolutionCache::new(artifact, artifact_indexes);
     let mut imported_from_by_src = BTreeMap::<String, String>::new();
-    // One selector resolver for the whole chunk, shared by global-selector
-    // fallback facts (built once — see the seam contract in
-    // `source_match::SelectorResolver`). The fact-based `ChunkResolver` is the
-    // production resolver: it builds the chunk's EDB once and resolves every
-    // selector against it, at parity with the former hand-rolled matcher (proven
-    // by the corpus differential, <debug/2026_06_18_per_chunk_gate_real_source.md>).
-    let selector_resolver = source_match::ChunkResolver::new(&runtime_ast.module);
     let explicit_request_ctx = ExplicitRequestContext {
         declaration_by_name: &declaration_by_name,
         chunk_top_level_mark,
@@ -265,7 +282,8 @@ pub(super) fn materialize_logical_chunk(
         None => DynamicImportTarget::External,
     };
     let stage_one = time_phase!(timings, "compute_stage_one_analysis", {
-        compute_stage_one_analysis(
+        emit_debundle_progress(chunk_id, "compute_stage_one_analysis", "start");
+        let stage_one = compute_stage_one_analysis(
             chunk_id,
             &runtime_ast.module,
             &analysis_hints,
@@ -273,14 +291,16 @@ pub(super) fn materialize_logical_chunk(
             |span| line_index.line_range_for_span(span),
             owner_graph_options,
             &resolve_dynamic_import,
-        )?
+        )?;
+        emit_debundle_progress(chunk_id, "compute_stage_one_analysis", "end");
+        stage_one
     });
     let StageOneAnalysis {
         fact_analysis: analysis,
         owner_graph_and_units: precomputed,
     } = stage_one;
     // Global selector resolution: `add_explicit_request` left deferred selector
-    // members unclaimed. Compile binding anchors, source_match candidates, and
+    // members unclaimed. Compile binding anchors, source_match constraints, and
     // relational selectors into one IR program and run one Ascent solver pass over
     // the owner graph + chunk AST relation facts.
     let import_sources: HashMap<String, String> = runtime_import_facts
@@ -288,12 +308,12 @@ pub(super) fn materialize_logical_chunk(
         .map(|(local, src)| (local.to_string(), src.to_string()))
         .collect();
     time_phase!(timings, "resolve_global_selector_members", {
-        builder.resolve_and_claim_global_selectors(
+        emit_debundle_progress(chunk_id, "resolve_global_selector_members", "start");
+        let result = builder.resolve_and_claim_global_selectors(
             &explicit_requests,
             &precomputed.owner_graph,
             &runtime_ast.module,
             &import_sources,
-            &selector_resolver,
             &runtime_import_facts,
             &mut imported_binding_resolver,
             &mut imported_from_by_src,
@@ -302,7 +322,9 @@ pub(super) fn materialize_logical_chunk(
             &target_file,
             chunk_id_interned,
             &declaration_by_name,
-        )
+        );
+        emit_debundle_progress(chunk_id, "resolve_global_selector_members", "end");
+        result
     })?;
     builder.adopt_bindings_of_claimed_anonymous_statements(&declarations);
     drop(imported_binding_resolver);

--- a/devinfra/js/debundle/lowering/materialize/plan_builder.rs
+++ b/devinfra/js/debundle/lowering/materialize/plan_builder.rs
@@ -26,16 +26,6 @@ struct DuplicateBindingClaim {
 }
 
 #[derive(Debug, Clone)]
-struct SourceMatchTargetInfo {
-    target: SelectorTargetId,
-    request_id: String,
-    export_name: String,
-    selector: spec::AnonymousStatementSelector,
-    selector_key: String,
-    group_assignment: Option<SourceMatchGroupAssignment>,
-}
-
-#[derive(Debug, Clone)]
 struct AnonymousStatementTargetInfo {
     target: SelectorTargetId,
     request_index: usize,
@@ -61,10 +51,7 @@ use selector_diagnostics::{
     DuplicateClaimReport, DuplicateClaimSiteReport, SelectorDiagnosticEntry,
     SelectorDiagnosticsReport,
 };
-use selector_ir::{
-    ClaimOutcome, OwnerTerm, ResolvedClaim, SelectorAtom, SelectorFact, SelectorFactStore,
-    SelectorProgram, SelectorTargetId, StringTerm,
-};
+use selector_ir::{ClaimOutcome, ResolvedClaim, SelectorFact, SelectorFactStore, SelectorTargetId};
 use selector_ir_lowering::{MemberSelectorLoweringContext, MemberSelectorProgramBuilder};
 
 impl From<&DuplicateClaimSite> for DuplicateClaimSiteReport {
@@ -347,67 +334,6 @@ fn selector_fact_store_for_chunk(
     Ok(store)
 }
 
-fn source_match_candidate_statement_ordinals(
-    owner_graph: &analysis::OwnerGraph,
-) -> BTreeMap<String, Option<StatementOrdinal>> {
-    let mut by_binding = BTreeMap::new();
-    for node in owner_graph.iter_nodes() {
-        for binding in &node.declared {
-            by_binding
-                .entry(binding.0.as_str().to_string())
-                .and_modify(|existing| {
-                    if *existing != Some(node.statement_ordinal) {
-                        *existing = None;
-                    }
-                })
-                .or_insert(Some(node.statement_ordinal));
-        }
-    }
-    by_binding
-}
-
-fn source_match_candidate_statement_ordinal(
-    by_binding: &BTreeMap<String, Option<StatementOrdinal>>,
-    request_id: &str,
-    export_name: &str,
-    candidate: &source_match::MemberBindingMatch,
-) -> Result<StatementOrdinal> {
-    match by_binding.get(&candidate.binding.binding_name) {
-        Some(Some(statement_ordinal)) => Ok(*statement_ordinal),
-        Some(None) => Err(anyhow!(
-            "logical_module {request_id}: source_match candidate for member `{export_name}` \
-             matched binding `{}` but that binding is declared by multiple owner-graph nodes",
-            candidate.binding.binding_name,
-        )),
-        None => Err(anyhow!(
-            "logical_module {request_id}: source_match candidate for member `{export_name}` \
-             matched binding `{}` at body index {}, but that binding does not appear in the \
-             owner graph",
-            candidate.binding.binding_name,
-            candidate.body_idx,
-        )),
-    }
-}
-
-fn program_has_source_match_candidate_atom(
-    program: &SelectorProgram,
-    target: SelectorTargetId,
-    selector_key: &str,
-) -> bool {
-    let Some(target_owner) = program.targets.get(target.0).map(|target| target.owner) else {
-        return false;
-    };
-    program.atoms.iter().any(|atom| {
-        matches!(
-            atom,
-            SelectorAtom::SourceMatchCandidate {
-                owner: OwnerTerm::Var { id },
-                selector_key: StringTerm::Const { value },
-            } if *id == target_owner && value == selector_key
-        )
-    })
-}
-
 fn solver_claim_is_import_specifier(facts: &SelectorFactStore, claim: &ResolvedClaim) -> bool {
     facts.facts.iter().any(|fact| {
         matches!(
@@ -498,23 +424,6 @@ fn render_source_match_diagnostics(diagnostics: &[SourceMatchDiagnostic]) -> Str
     report
 }
 
-fn source_match_no_match_message(
-    request: &LogicalRequest,
-    member: &MemberRequest,
-) -> Option<String> {
-    let selector = member.source_match.as_ref()?;
-    let target_binding_hint = selector
-        .target_binding
-        .as_deref()
-        .map(|target| format!(" target_binding `{target}`"))
-        .unwrap_or_default();
-    Some(format!(
-        "logical_module {}: members[].selector.source_match for export `{}`{} did not match any \
-         top-level declaration in the chunk. Selector:\n{}",
-        request.id, member.export_name, target_binding_hint, selector.match_source,
-    ))
-}
-
 fn native_source_match_no_match_message(
     request: &LogicalRequest,
     member: &MemberRequest,
@@ -532,76 +441,6 @@ fn native_source_match_no_match_message(
          constraints; it may have no matching source declaration, or the joint constraints may \
          reject all otherwise matching declarations. Selector:\n{}",
         request.id, member.export_name, target_binding_hint, selector.match_source,
-    ))
-}
-
-fn source_match_joint_no_match_message(
-    request: &LogicalRequest,
-    member: &MemberRequest,
-    candidates: Option<&[source_match::MemberBindingMatch]>,
-) -> Option<String> {
-    let selector = member.source_match.as_ref()?;
-    let candidates = candidates?;
-    if candidates.is_empty() {
-        return None;
-    }
-    let target_binding_hint = selector
-        .target_binding
-        .as_deref()
-        .map(|target| format!(" target_binding `{target}`"))
-        .unwrap_or_default();
-    Some(format!(
-        "logical_module {}: members[].selector.source_match for export `{}`{} matched {} \
-         candidate top-level statement(s), but no valid global selector assignment survived the \
-         joint constraints (for example all_different / connected relational selectors). Matched \
-         body indices: {:?}; bindings: {}. Selector:\n{}",
-        request.id,
-        member.export_name,
-        target_binding_hint,
-        candidates.len(),
-        candidates
-            .iter()
-            .map(|candidate| candidate.body_idx)
-            .collect::<Vec<_>>(),
-        candidates
-            .iter()
-            .map(|candidate| candidate.binding.binding_name.as_str())
-            .collect::<Vec<_>>()
-            .join(", "),
-        selector.match_source,
-    ))
-}
-
-fn source_match_ambiguous_message(
-    request: &LogicalRequest,
-    member: &MemberRequest,
-    candidates: Option<&[source_match::MemberBindingMatch]>,
-) -> Option<String> {
-    let selector = member.source_match.as_ref()?;
-    let candidates = candidates?;
-    let target_binding_hint = selector
-        .target_binding
-        .as_deref()
-        .map(|target| format!(" target_binding `{target}`"))
-        .unwrap_or_default();
-    Some(format!(
-        "logical_module {}: members[].selector.source_match for export `{}`{} is ambiguous -- \
-         matched {} top-level statements at body indices {:?} (bindings: {}). Refine the \
-         selector. Source:\n{}",
-        request.id,
-        member.export_name,
-        target_binding_hint,
-        candidates.len(),
-        candidates
-            .iter()
-            .map(|candidate| candidate.body_idx)
-            .collect::<Vec<_>>(),
-        candidates
-            .iter()
-            .map(|candidate| candidate.binding.binding_name.as_str())
-            .collect::<Vec<_>>()
-            .join(", "),
-        selector.match_source,
     ))
 }
 
@@ -1175,7 +1014,6 @@ impl ChunkPlanBuilder {
         owner_graph: &analysis::OwnerGraph,
         module: &swc_ecma_ast::Module,
         import_sources: &HashMap<String, String>,
-        selector_resolver: &dyn source_match::SelectorResolver,
         runtime_import_facts: &RuntimeImportFacts,
         imported_binding_resolver: &mut ArtifactSourceImportResolutionCache<'_>,
         imported_from_by_src: &mut BTreeMap<String, String>,
@@ -1200,22 +1038,7 @@ impl ChunkPlanBuilder {
             chunk_id_interned,
             chunk_id,
         ));
-        let mut deferred_targets = BTreeMap::<
-            SelectorTargetId,
-            (usize, MemberRequest, Option<SourceMatchGroupAssignment>),
-        >::new();
-        let mut source_match_candidates =
-            BTreeMap::<SelectorTargetId, Vec<source_match::MemberBindingMatch>>::new();
-        let mut source_match_errors = BTreeMap::<SelectorTargetId, String>::new();
-        let mut source_match_candidate_cache = BTreeMap::<
-            spec::AnonymousStatementSelector,
-            Result<Vec<source_match::MemberBindingMatch>, String>,
-        >::new();
-        let mut source_match_group_candidate_cache = BTreeMap::<
-            SourceMatchGroupCacheKey,
-            Result<Vec<source_match::MemberBindingGroupMatch>, String>,
-        >::new();
-        let mut source_match_targets = Vec::<SourceMatchTargetInfo>::new();
+        let mut deferred_targets = BTreeMap::<SelectorTargetId, (usize, MemberRequest)>::new();
         let mut anonymous_statement_targets = Vec::<AnonymousStatementTargetInfo>::new();
         let mut pending_constraints = Vec::<(String, String, spec::MemberSelectorSpec)>::new();
         let mut pending_source_match_groups = Vec::<(String, SourceMatchGroupAssignment)>::new();
@@ -1253,19 +1076,7 @@ impl ChunkPlanBuilder {
                         ));
                     }
                     if member.resolves_after_stage_a() {
-                        deferred_targets
-                            .insert(target, (index, member.clone(), group_assignment.clone()));
-                    }
-                    if let Some(source_selector) = &member.source_match {
-                        let selector_key = source_match::selector_key(source_selector);
-                        source_match_targets.push(SourceMatchTargetInfo {
-                            target,
-                            request_id: request.id.clone(),
-                            export_name: member.export_name.clone(),
-                            selector: source_selector.clone(),
-                            selector_key: selector_key.clone(),
-                            group_assignment,
-                        });
+                        deferred_targets.insert(target, (index, member.clone()));
                     }
                 }
             }
@@ -1276,25 +1087,21 @@ impl ChunkPlanBuilder {
                     &request.id,
                     statement_index,
                     &statement.selector,
-                )? {
-                    Some(target) => {
-                        anonymous_statement_targets.push(AnonymousStatementTargetInfo {
-                            target,
-                            request_index,
-                            statement: statement.clone(),
-                        })
-                    }
-                    None => {
-                        let claims = resolve_anonymous_statement_request(
-                            &request.id,
-                            statement,
-                            selector_resolver,
-                            self.keep_going,
-                            &mut self.anonymous_statement_diagnostics,
+                ) {
+                    Ok(target) => anonymous_statement_targets.push(AnonymousStatementTargetInfo {
+                        target,
+                        request_index,
+                        statement: statement.clone(),
+                    }),
+                    Err(error) => {
+                        let message = format!(
+                            "logical_module {}: anonymous_statements[].match cannot be lowered \
+                             into native selector IR: {error}",
+                            request.id,
+                        );
+                        self.record_anonymous_statement_failure_or_bail(
+                            request, statement, message,
                         )?;
-                        for claim in claims {
-                            self.claim_anonymous_statement(request_index, &request.id, &claim)?;
-                        }
                     }
                 }
             }
@@ -1307,15 +1114,11 @@ impl ChunkPlanBuilder {
             )? {
                 continue;
             }
-            for (target_binding, export_name) in group.exports_by_target {
-                let mut selector = group.selector.clone();
-                selector.target_binding = Some(target_binding);
-                builder.lower_member_constraints_in_module(
-                    &logical_module,
-                    &export_name,
-                    &spec::MemberSelectorSpec::SourceMatch(selector),
-                )?;
+            return Err(selector_ir_lowering::SelectorIrLoweringError::Unsupported {
+                selector_kind: "binding_group.source_match",
+                reason: "selector shape is not yet supported by native selector IR",
             }
+            .into());
         }
         for (logical_module, export_name, selector) in pending_constraints {
             builder.lower_member_constraints_in_module(&logical_module, &export_name, &selector)?;
@@ -1324,100 +1127,11 @@ impl ChunkPlanBuilder {
         if program.targets.is_empty() {
             return Ok(());
         }
-        let source_match_ordinal_by_binding =
-            source_match_candidate_statement_ordinals(owner_graph);
-        let mut facts =
+        let facts =
             selector_fact_store_for_chunk(chunk_id_interned, owner_graph, module, import_sources)?;
-        let source_match_oracle_targets = source_match_targets
-            .iter()
-            .filter_map(|target| {
-                program_has_source_match_candidate_atom(
-                    &program,
-                    target.target,
-                    &target.selector_key,
-                )
-                .then_some(target.target)
-            })
-            .collect::<BTreeSet<_>>();
-        for target in &source_match_targets {
-            if !source_match_oracle_targets.contains(&target.target) {
-                continue;
-            }
-            let candidates = if let Some(group) = &target.group_assignment {
-                let target_binding =
-                    target.selector.target_binding.as_deref().with_context(|| {
-                        format!(
-                            "logical_module {}: binding-group member `{}` unexpectedly has no \
-                         target_binding",
-                            target.request_id, target.export_name,
-                        )
-                    })?;
-                let cache_key =
-                    SourceMatchGroupCacheKey::new(group.selector.clone(), &group.exports_by_target);
-                let group_candidates = match source_match_group_candidate_cache.get(&cache_key) {
-                    Some(cached) => cached.clone(),
-                    None => {
-                        let resolved = selector_resolver
-                            .member_group_candidates(
-                                &target.request_id,
-                                &group.selector,
-                                &group.exports_by_target,
-                            )
-                            .map_err(|error| format!("{error:#}"));
-                        source_match_group_candidate_cache.insert(cache_key, resolved.clone());
-                        resolved
-                    }
-                };
-                group_candidates.map(|groups| {
-                    groups
-                        .into_iter()
-                        .filter_map(|group| group.bindings.get(target_binding).cloned())
-                        .collect::<Vec<_>>()
-                })
-            } else {
-                match source_match_candidate_cache.get(&target.selector) {
-                    Some(cached) => cached.clone(),
-                    None => {
-                        let resolved = selector_resolver
-                            .member_candidates(
-                                &target.request_id,
-                                &target.export_name,
-                                &target.selector,
-                            )
-                            .map_err(|error| format!("{error:#}"));
-                        source_match_candidate_cache
-                            .insert(target.selector.clone(), resolved.clone());
-                        resolved
-                    }
-                }
-            };
-            match candidates {
-                Ok(candidates) => {
-                    for candidate in &candidates {
-                        let statement_ordinal = source_match_candidate_statement_ordinal(
-                            &source_match_ordinal_by_binding,
-                            &target.request_id,
-                            &target.export_name,
-                            candidate,
-                        )?;
-                        facts.push(SelectorFact::SourceMatchCandidate {
-                            chunk_id: chunk_id_interned,
-                            selector_key: target.selector_key.clone(),
-                            statement_ordinal,
-                            binding: candidate.binding.binding_name.clone(),
-                        });
-                    }
-                    source_match_candidates.insert(target.target, candidates);
-                }
-                Err(error) if self.keep_going => {
-                    source_match_errors.insert(target.target, error);
-                }
-                Err(error) => bail!("{error}"),
-            }
-        }
         let result = selector_ir_solver::solve(&program, &facts)?;
 
-        for (target, (index, member, _group_assignment)) in deferred_targets {
+        for (target, (index, member)) in deferred_targets {
             let request = &explicit_requests[index];
             match result.outcome_for(target) {
                 Some(ClaimOutcome::Unique { claim }) => {
@@ -1428,27 +1142,9 @@ impl ChunkPlanBuilder {
                             request.id, member.export_name, claim.owner,
                         )
                     })?;
-                    let oracle_selects_import = source_match_candidates
-                        .get(&target)
-                        .and_then(|candidates| {
-                            candidates.iter().find(|candidate| {
-                                candidate.binding.binding_name == binding
-                                    && StatementOrdinal(js_ast::statement_ordinal_for_body_index(
-                                        &module.body,
-                                        candidate.body_idx,
-                                    )) == claim.statement_ordinal
-                            })
-                        })
-                        .is_some_and(|candidate| {
-                            matches!(
-                                candidate.binding.kind,
-                                Some(BindingSourceKind::ImportSpecifier)
-                            )
-                        });
                     let native_selects_import = member.source_match.is_some()
-                        && !source_match_oracle_targets.contains(&target)
                         && solver_claim_is_import_specifier(&facts, claim);
-                    if oracle_selects_import || native_selects_import {
+                    if native_selects_import {
                         self.claim_post_stage_a_imported_binding(
                             request,
                             &member,
@@ -1474,42 +1170,14 @@ impl ChunkPlanBuilder {
                     )?;
                 }
                 Some(ClaimOutcome::NoMatch) => {
-                    let native_source_match = member.source_match.is_some()
-                        && !source_match_oracle_targets.contains(&target);
-                    if let Some(message) = source_match_errors
-                        .get(&target)
-                        .cloned()
-                        .or_else(|| {
-                            source_match_joint_no_match_message(
-                                request,
-                                &member,
-                                source_match_candidates.get(&target).map(Vec::as_slice),
-                            )
-                        })
-                        .or_else(|| {
-                            if native_source_match {
-                                native_source_match_no_match_message(request, &member)
-                            } else {
-                                source_match_no_match_message(request, &member)
-                            }
-                        })
-                    {
+                    if let Some(message) = native_source_match_no_match_message(request, &member) {
                         if self.keep_going {
-                            let body_indices = source_match_candidates
-                                .get(&target)
-                                .map(|candidates| {
-                                    candidates
-                                        .iter()
-                                        .map(|candidate| candidate.body_idx)
-                                        .collect::<Vec<_>>()
-                                })
-                                .unwrap_or_default();
                             self.source_match_diagnostics
                                 .push(SourceMatchDiagnostic::new(
                                     &request.id,
                                     &request.target_path,
                                     &member,
-                                    body_indices,
+                                    Vec::new(),
                                     message,
                                 ));
                             continue;
@@ -1526,37 +1194,14 @@ impl ChunkPlanBuilder {
                     );
                 }
                 Some(ClaimOutcome::Ambiguous { candidates }) => {
-                    let message = if member.source_match.is_some()
-                        && !source_match_oracle_targets.contains(&target)
-                    {
-                        native_source_match_ambiguous_message(request, &member, candidates)
-                    } else {
-                        source_match_ambiguous_message(
-                            request,
-                            &member,
-                            source_match_candidates.get(&target).map(Vec::as_slice),
-                        )
-                    };
+                    let message =
+                        native_source_match_ambiguous_message(request, &member, candidates);
                     if let Some(message) = message {
                         if self.keep_going {
-                            let body_indices = if member.source_match.is_some()
-                                && source_match_oracle_targets.contains(&target)
-                            {
-                                source_match_candidates
-                                    .get(&target)
-                                    .map(|candidates| {
-                                        candidates
-                                            .iter()
-                                            .map(|candidate| candidate.body_idx)
-                                            .collect::<Vec<_>>()
-                                    })
-                                    .unwrap_or_default()
-                            } else {
-                                candidates
-                                    .iter()
-                                    .map(|candidate| candidate.statement_ordinal.0)
-                                    .collect::<Vec<_>>()
-                            };
+                            let body_indices = candidates
+                                .iter()
+                                .map(|candidate| candidate.statement_ordinal.0)
+                                .collect::<Vec<_>>();
                             self.source_match_diagnostics
                                 .push(SourceMatchDiagnostic::new(
                                     &request.id,

--- a/devinfra/js/debundle/lowering/mod.rs
+++ b/devinfra/js/debundle/lowering/mod.rs
@@ -61,9 +61,7 @@ mod util;
 mod vendor_imports;
 mod visitors;
 
-use anonymous::{
-    AnonymousStatementDiagnostic, ResolvedAnonymousStatement, resolve_anonymous_statement_request,
-};
+use anonymous::{AnonymousStatementDiagnostic, ResolvedAnonymousStatement};
 use body_facts::{ModuleBodyFacts, collect_module_body_facts};
 use chunk_ast::{
     ChunkAstAnalysis, TopLevelDecl, analyze_chunk_ast, binding_ids, binding_names, declaration_ids,

--- a/devinfra/js/debundle/plans/selector_constraint_model.md
+++ b/devinfra/js/debundle/plans/selector_constraint_model.md
@@ -1,19 +1,20 @@
 # Plan: selectors as one global constraint problem (relational spec model)
 
-**Current state (2026-06-23, after #2447).** Ascent remains the selected
-production solver. PR #2439 landed on `devel` as `db25ef639` and closed the
-first global-solver bridge: `source_match` selectors now enter the global
-selector IR/solver instead of bypassing it. PR #2443 lowered exact
-single-statement selectors onto native AST facts. PR #2446 stopped asking
-`ChunkResolver` for candidate rows when a selector already lowers natively.
-PR #2447 added native `AstSuperClass` constraints for `class ... extends ...`
-matches.
+**Current state (2026-06-25).** Ascent remains the selected production solver.
+PR #2439 landed on `devel` as `db25ef639` and closed the first global-solver
+bridge: `source_match` selectors now enter the global selector IR/solver
+instead of bypassing it. PR #2443 lowered exact single-statement selectors onto
+native AST facts. PR #2446 stopped asking `ChunkResolver` for candidate rows
+when a selector already lowers natively. PR #2447 added native `AstSuperClass`
+constraints for `class ... extends ...` matches. Current work deletes
+`SourceMatchCandidate`, the member/group candidate-oracle injection path, and
+the production anonymous-statement `ChunkResolver` fallback.
 
-The bridge that remains is narrower: unsupported `source_match` shapes still
-lower to `SourceMatchCandidate`, and `plan_builder.rs` still asks
-`ChunkResolver` to enumerate rows for those fallback targets. The remaining P0
+The bridge that remains is narrower: some retained selector shapes still need
+faithful native lowering before they can be accepted in production, and
+tooling/authoring paths still call `ChunkResolver` directly. The remaining P0
 is to lower every retained selector form into one declarative Ascent/CSP-style
-constraint program and then delete the candidate oracle.
+constraint program and make tooling consume the same solver-backed semantics.
 
 **Reframing.** The next architectural goal is not to grow more bridge
 vocabulary. It is to make the global constraint solve native over AST +
@@ -46,9 +47,9 @@ Notation: `@Name` means "the binding/node pinned elsewhere in the spec as `Name`
 
 ## Goal
 
-Replace the remaining `SourceMatchCandidate` oracle with a Datalog/Ascent
-selector resolver that resolves every retained selector form over an explicit
-relational model of the program (owner graph + AST facts). Parity must be
+Complete the Datalog/Ascent selector resolver so it resolves every retained
+selector form over an explicit relational model of the program (owner graph +
+AST facts), without production calls to the procedural `ChunkResolver`. Parity must be
 **proven, not asserted**: each construct compiles to atoms provably faithful to
 current `source_match` semantics, or it remains an explicit unsupported
 fallback while that construct is being implemented. The design must stay
@@ -232,10 +233,10 @@ resolves_to(use, def).   member_of_module(binding, module).
 
 The AST projection already exists in `chunk_facts.rs` and
 `SelectorFactStore::extend_chunk_facts`; the owner/reference facts already feed
-the selector solver. The open work is to make the Ascent rule library consume
-the AST rows directly instead of only consuming `SourceMatchCandidate` rows
-pre-enumerated by `ChunkResolver`. `resolves_to` remains the genuinely semantic
-edge — the one minification preserves while names churn.
+the selector solver. The open work is to make every retained selector shape
+consume those rows directly, with no production pre-enumeration by
+`ChunkResolver`. `resolves_to` remains the genuinely semantic edge — the one
+minification preserves while names churn.
 
 **Derived predicates — a rule library, not engine primitives.** `calls`, `alias`, a
 decorator application, etc. are rules over AST shape + `resolves_to`:
@@ -341,10 +342,10 @@ This is not a side tool — it is the **resolution layer**: the code that maps
 each readable spec entity to its minified node on the chunk. After #2439, the
 global selector solver is on that path. After #2443/#2446/#2447, exact
 single-statement and superclass `source_match` forms lower to native AST
-constraints and no longer ask `ChunkResolver` for oracle rows. Unsupported
-`source_match` shapes still fall back through `ChunkResolver`-enumerated
-`SourceMatchCandidate` rows; the remaining cutover is to shrink that fallback
-set to zero for every retained selector form.
+constraints and no longer ask `ChunkResolver` for oracle rows. Current work
+deletes the member/group candidate-oracle schema entirely and removes the
+production anonymous fallback. Remaining production work is native coverage for
+retained selector shapes that now fail closed as unsupported.
 
 The reference oracle is named in code: `source_match::SelectorResolver`, the
 trait `ChunkResolver` implements — `(parsed chunk, JS-template selector) →
@@ -362,23 +363,22 @@ EDB:
 - owner/reference rows already consumed by `selector_ir_solver.rs`;
 - AST `kind` / `child` / literal / identifier / property / operator /
   top-level rows already stored by `SelectorFactStore::extend_chunk_facts`;
-- label posting lists still used by `ChunkResolver` as the current
-  `SourceMatchCandidate` oracle.
+- label posting lists still used by `ChunkResolver` in tooling/authoring paths.
 
 The cutover is a consumer change: add native AST relations and shape rules to
-the Ascent solver, delete each fallback shape after focused equivalence tests
-and corpus checks pass, then delete the candidate-oracle projection once every
-retained selector form resolves through the solver.
+the Ascent solver, delete each production fallback shape after focused
+equivalence tests and corpus checks pass, then keep tooling/authoring uses
+behind the same solver-backed semantics.
 
 ### It replaces several workflow parts, not just the matcher
 
-| Today                                                                                             | Becomes                                                                                                                                  |
-| ------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `lowering/materialize/plan_builder.rs` still asks `ChunkResolver` for `SourceMatchCandidate` rows | one native `solve(spec, edb)` over AST + owner/reference facts; the plan consumes per-target bindings                                    |
-| `validate` no-match / ambiguous / duplicate-claim (per-selector + post-hoc)                       | solver categoricity (no-match / ambiguous) + `all_different` (duplicate-claim) in one keep-going pass                                    |
-| `match_selector.rs` resolves one candidate                                                        | single-query solve over the EDB; gains probing of **relational/cross-ref** candidates, not just local shapes                             |
-| `selector_codemod.rs` prove-gate (candidate-index uniqueness)                                     | solver categoricity; the minimizer's search space grows to relational atoms — it can now _propose_ the cross-ref selectors that now skip |
-| `selector_debt.rs` source-aware near-ambiguous / repeated-body scan                               | solver reports per target **which atoms forced uniqueness, tagged invariant/variant**, and the categoricity margin                       |
+| Today                                                                       | Becomes                                                                                                                                  |
+| --------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| tooling command paths still call `ChunkResolver` directly                   | one native `solve(spec, edb)` over AST + owner/reference facts; callers consume solver outcomes                                          |
+| `validate` no-match / ambiguous / duplicate-claim (per-selector + post-hoc) | solver categoricity (no-match / ambiguous) + `all_different` (duplicate-claim) in one keep-going pass                                    |
+| `match_selector.rs` resolves one candidate                                  | single-query solve over the EDB; gains probing of **relational/cross-ref** candidates, not just local shapes                             |
+| `selector_codemod.rs` prove-gate (candidate-index uniqueness)               | solver categoricity; the minimizer's search space grows to relational atoms — it can now _propose_ the cross-ref selectors that now skip |
+| `selector_debt.rs` source-aware near-ambiguous / repeated-body scan         | solver reports per target **which atoms forced uniqueness, tagged invariant/variant**, and the categoricity margin                       |
 
 The cycle/atomic gate (`gate.rs`, `realizability/`, `atomic_units.rs`) and emit run
 **downstream of resolution on the resolved ownership** — unchanged, as are the module
@@ -646,7 +646,11 @@ lowering, not the solver's capability.
 - `source_match` selectors now enter the global selector IR/solver.
 - The materializer has a single Ascent-backed selector solve path for binding
   pins, staged relational selectors, and `source_match` claims.
-- Exact native `source_match` forms no longer call the legacy candidate oracle.
+- Exact native `source_match` forms no longer call the legacy candidate oracle,
+  and the member/group candidate-oracle schema has been deleted.
+- Production anonymous statements now lower into the global selector solver or
+  fail closed as unsupported; materialization no longer constructs
+  `ChunkResolver`.
 - Exact single-statement shape and superclass constraints lower to native AST
   facts.
 - Ascent remains the production solver choice; do not restart solver selection
@@ -674,12 +678,11 @@ This is the detailed P0 queue; <../TODO.md> should only summarize it.
   absence in a focused branch, delete the YAML/code/docs surface, and slate any
   other vestigial debundle features that gaffer-private does not use for
   removal rather than carrying them into the query model.
-- **G4 — candidate-oracle deletion.** Remove
-  `SelectorAtom::SourceMatchCandidate` / `SelectorFact::SourceMatchCandidate`
-  and the `ChunkResolver` pre-enumeration path after G1-G3 cover every retained
-  selector form. No-match, ambiguous, unsupported, and duplicate-claim
-  diagnostics should be projections of the native solver result, not
-  `ChunkResolver` side tables.
+- **G4 — tooling semantics cutover.** Move `match_selector`, selector codemods,
+  synthesis, and repair/prove gates onto solver-backed selector semantics so
+  authoring tools and production materialization do not drift. No-match,
+  ambiguous, unsupported, and duplicate-claim diagnostics should be projections
+  of the native solver result, not `ChunkResolver` side tables.
 - **G5 — relation/language fold-in.** Re-express `cross_ref`, `reads_member`,
   `member_of_module`, `passed_to_call`, `makes_decorate_call`,
   `intrinsic_alias`, and the Gaffer feature-request vocabulary as IR atoms or

--- a/devinfra/js/debundle/selector_ir.rs
+++ b/devinfra/js/debundle/selector_ir.rs
@@ -284,10 +284,6 @@ pub enum SelectorAtom {
         property: StringTerm,
         referenced_by: OwnerTerm,
     },
-    SourceMatchCandidate {
-        owner: OwnerTerm,
-        selector_key: StringTerm,
-    },
     Equal {
         left: SelectorVariableId,
         right: SelectorVariableId,
@@ -594,13 +590,6 @@ impl SelectorProgram {
                 self.validate_string_term(property, "intrinsic_alias.property")?;
                 self.validate_owner_term(referenced_by, "intrinsic_alias.referenced_by")
             }
-            SelectorAtom::SourceMatchCandidate {
-                owner,
-                selector_key,
-            } => {
-                self.validate_owner_term(owner, "source_match_candidate.owner")?;
-                self.validate_string_term(selector_key, "source_match_candidate.selector_key")
-            }
             SelectorAtom::Equal { left, right } | SelectorAtom::NotEqual { left, right } => {
                 let left_domain = self.require_variable(*left, "equality.left")?;
                 let right_domain = self.require_variable(*right, "equality.right")?;
@@ -898,12 +887,6 @@ pub enum SelectorFact {
         binding: String,
         property: String,
     },
-    SourceMatchCandidate {
-        chunk_id: ChunkId,
-        selector_key: String,
-        statement_ordinal: StatementOrdinal,
-        binding: String,
-    },
 }
 
 impl SelectorFact {
@@ -930,7 +913,6 @@ impl SelectorFact {
             Self::CallArgumentUse { .. } => "call_argument_use",
             Self::DecorateCallUse { .. } => "decorate_call_use",
             Self::IntrinsicAliasUse { .. } => "intrinsic_alias_use",
-            Self::SourceMatchCandidate { .. } => "source_match_candidate",
         }
     }
 }

--- a/devinfra/js/debundle/selector_ir_lowering.rs
+++ b/devinfra/js/debundle/selector_ir_lowering.rs
@@ -144,21 +144,28 @@ impl MemberSelectorProgramBuilder {
         logical_module: impl Into<String>,
         statement_index: usize,
         selector: &AnonymousStatementSelector,
-    ) -> Result<Option<SelectorTargetId>, SelectorIrLoweringError> {
+    ) -> Result<SelectorTargetId, SelectorIrLoweringError> {
         if !native_anonymous_source_match_supported(selector) {
-            return Ok(None);
+            return Err(SelectorIrLoweringError::unsupported(
+                "anonymous_statements.source_match",
+                "selector shape is not yet supported by native selector IR",
+            ));
         }
         let logical_module = logical_module.into();
-        let owner = self.program.add_variable(
+        let mut scratch = self.clone();
+        let owner = scratch.program.add_variable(
             VariableDomain::Owner,
             Some(format!(
                 "{logical_module}::anonymous_statement.{statement_index}"
             )),
         );
-        if !self.try_lower_native_source_match(&logical_module, owner, selector)? {
-            return Ok(None);
+        if !scratch.try_lower_native_source_match(&logical_module, owner, selector)? {
+            return Err(SelectorIrLoweringError::unsupported(
+                "anonymous_statements.source_match",
+                "selector shape is not yet supported by native selector IR",
+            ));
         }
-        Ok(Some(self.program.add_target(
+        let target = scratch.program.add_target(
             self.context.chunk_id,
             owner,
             logical_module,
@@ -166,7 +173,9 @@ impl MemberSelectorProgramBuilder {
             ClaimOrigin::AnonymousStatement {
                 index: statement_index,
             },
-        )))
+        );
+        *self = scratch;
+        Ok(target)
     }
 
     pub fn lower_member_constraints_in_module(
@@ -258,10 +267,10 @@ impl MemberSelectorProgramBuilder {
             MemberSelectorSpec::Binding(binding) => self.lower_binding_selector(owner, binding),
             MemberSelectorSpec::SourceMatch(selector) => {
                 if !self.try_lower_native_source_match(logical_module, owner, selector)? {
-                    self.program.add_atom(SelectorAtom::SourceMatchCandidate {
-                        owner: owner_term(owner),
-                        selector_key: const_str(&source_match::selector_key(selector)),
-                    });
+                    return Err(SelectorIrLoweringError::unsupported(
+                        "source_match",
+                        "selector shape is not yet supported by native selector IR",
+                    ));
                 }
                 Ok(())
             }
@@ -382,14 +391,19 @@ impl MemberSelectorProgramBuilder {
         owner: SelectorVariableId,
         selector: &AnonymousStatementSelector,
     ) -> Result<bool, SelectorIrLoweringError> {
-        let Ok(parsed) = js_ast::with_swc_globals(|| {
-            js_ast::parse_js_module_ast(
-                &format!("<selector ir source_match in {logical_module}>"),
+        let parsed = js_ast::with_swc_globals(|| {
+            source_match::parse_selector_module_with_capability_check(
+                logical_module,
+                "source_match",
+                format!("<selector ir source_match in {logical_module}>"),
                 &selector.match_source,
+                "source_match",
             )
-        }) else {
-            return Ok(false);
-        };
+        })
+        .map_err(|error| SelectorIrLoweringError::UnsupportedSourceMatch {
+            selector_kind: "source_match",
+            reason: error.to_string(),
+        })?;
         if parsed.body.is_empty() {
             return Ok(false);
         }
@@ -656,14 +670,19 @@ impl MemberSelectorProgramBuilder {
         if selector.target_binding.is_some() || exports_by_target.is_empty() {
             return Ok(false);
         }
-        let Ok(parsed) = js_ast::with_swc_globals(|| {
-            js_ast::parse_js_module_ast(
-                &format!("<selector ir binding_group source_match in {logical_module}>"),
+        let parsed = js_ast::with_swc_globals(|| {
+            source_match::parse_selector_module_with_capability_check(
+                logical_module,
+                "binding_group.source_match",
+                format!("<selector ir binding_group source_match in {logical_module}>"),
                 &selector.match_source,
+                "binding_group.source_match",
             )
-        }) else {
-            return Ok(false);
-        };
+        })
+        .map_err(|error| SelectorIrLoweringError::UnsupportedSourceMatch {
+            selector_kind: "binding_group.source_match",
+            reason: error.to_string(),
+        })?;
         if parsed.body.is_empty() {
             return Ok(false);
         }
@@ -2399,6 +2418,10 @@ pub enum SelectorIrLoweringError {
         selector_kind: &'static str,
         reason: &'static str,
     },
+    UnsupportedSourceMatch {
+        selector_kind: &'static str,
+        reason: String,
+    },
     DanglingAnchor {
         logical_module: String,
         export_name: String,
@@ -2422,6 +2445,13 @@ impl fmt::Display for SelectorIrLoweringError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Unsupported {
+                selector_kind,
+                reason,
+            } => write!(
+                f,
+                "unsupported selector IR lowering for {selector_kind}: {reason}"
+            ),
+            Self::UnsupportedSourceMatch {
                 selector_kind,
                 reason,
             } => write!(
@@ -2475,21 +2505,6 @@ mod tests {
 
     fn context() -> MemberSelectorLoweringContext {
         MemberSelectorLoweringContext::new(ChunkId(3), "runtime/widgets")
-    }
-
-    fn assert_source_match_oracle_only(
-        lowered: &LoweredMemberSelector,
-        selector: &AnonymousStatementSelector,
-    ) {
-        let target_owner = lowered.program.targets[lowered.target.0].owner;
-        assert_eq!(lowered.program.atoms.len(), 1);
-        assert!(matches!(
-            &lowered.program.atoms[0],
-            SelectorAtom::SourceMatchCandidate {
-                owner: OwnerTerm::Var { id },
-                selector_key: StringTerm::Const { value },
-            } if *id == target_owner && value == &source_match::selector_key(selector)
-        ));
     }
 
     #[test]
@@ -2568,14 +2583,6 @@ mod tests {
             &MemberSelectorSpec::SourceMatch(selector.clone()),
         )
         .unwrap();
-
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         assert!(
             lowered
                 .program
@@ -2615,14 +2622,6 @@ mod tests {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         assert!(
             lowered
                 .program
@@ -2644,15 +2643,6 @@ mod tests {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. })),
-            "fixed-window member source_match selectors should stay in native IR"
-        );
         let offsets = lowered
             .program
             .atoms
@@ -2687,14 +2677,6 @@ mod tests {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         let mut string_vars = lowered.program.atoms.iter().filter_map(|atom| match atom {
             SelectorAtom::AstStringLiteral {
                 value: StringTerm::Var { id },
@@ -2723,15 +2705,6 @@ mod tests {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. })),
-            "regex string-literal predicates should stay in the native selector IR"
-        );
         assert!(
             lowered.program.atoms.iter().any(|atom| {
                 matches!(
@@ -2769,14 +2742,6 @@ mod tests {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         assert!(
             !lowered.program.atoms.iter().any(|atom| {
                 matches!(
@@ -2810,14 +2775,6 @@ mod tests {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         assert!(
             !lowered.program.atoms.iter().any(|atom| {
                 matches!(
@@ -2854,14 +2811,6 @@ mod tests {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         let identifier_vars = lowered
             .program
             .atoms
@@ -2923,13 +2872,6 @@ mod tests {
         .unwrap();
 
         let target_owner = lowered.program.targets[lowered.target.0].owner;
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         assert!(lowered.program.atoms.iter().any(|atom| matches!(
             atom,
             SelectorAtom::OwnerDeclaresBinding {
@@ -2952,15 +2894,6 @@ mod tests {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. })),
-            "alpha_all source_match with target_binding in a multi-declarator should stay native",
-        );
         let target_owner = lowered.program.targets[lowered.target.0].owner;
         let projected_bindings = lowered
             .program
@@ -3020,13 +2953,6 @@ mod tests {
                 .unwrap()
         );
         let program = builder.into_program().unwrap();
-
-        assert!(
-            !program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         let first_owner = program.targets[first_target.0].owner;
         let second_owner = program.targets[second_target.0].owner;
         let shared_roots = program
@@ -3099,14 +3025,6 @@ function second() {
                 .unwrap()
         );
         let program = builder.into_program().unwrap();
-
-        assert!(
-            !program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. })),
-            "multi-statement binding_groups should stay in native IR"
-        );
         let first_owner = program.targets[first_target.0].owner;
         let second_owner = program.targets[second_target.0].owner;
         let roots = program
@@ -3185,14 +3103,6 @@ STMT_LIST_TAIL;"#,
                 .unwrap()
         );
         let program = builder.into_program().unwrap();
-
-        assert!(
-            !program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. })),
-            "outer module-level STMT_LIST holes should not force the group oracle"
-        );
         assert_eq!(
             program
                 .atoms
@@ -3259,14 +3169,6 @@ function second() {
             "internal top-level STMT_LIST should lower to an ordinal-before constraint"
         );
         let program = builder.into_program().unwrap();
-
-        assert!(
-            !program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. })),
-            "internal module-level STMT_LIST holes should not force the group oracle"
-        );
         assert!(program.atoms.iter().any(|atom| matches!(
             atom,
             SelectorAtom::OrdinalBefore {
@@ -3289,13 +3191,6 @@ function second() {
         .unwrap();
 
         let target_owner = lowered.program.targets[lowered.target.0].owner;
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         assert!(lowered.program.atoms.iter().any(|atom| matches!(
             atom,
             SelectorAtom::OwnerDeclaresBinding {
@@ -3316,14 +3211,6 @@ function second() {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         assert!(lowered.program.atoms.iter().any(|atom| matches!(
             atom,
             SelectorAtom::AstChildListPattern {
@@ -3346,14 +3233,6 @@ function second() {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         assert!(lowered.program.atoms.iter().any(|atom| matches!(
             atom,
             SelectorAtom::AstChildListPattern {
@@ -3384,14 +3263,6 @@ function second() {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         assert!(
             !lowered.program.atoms.iter().any(|atom| matches!(
                 atom,
@@ -3440,14 +3311,6 @@ function second() {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         let (segments, anchored_left, anchored_right) = lowered
             .program
             .atoms
@@ -3490,14 +3353,6 @@ function second() {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         assert!(
             !lowered.program.atoms.iter().any(|atom| matches!(
                 atom,
@@ -3546,14 +3401,6 @@ function second() {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         let (segments, anchored_left, anchored_right) = lowered
             .program
             .atoms
@@ -3595,14 +3442,6 @@ function second() {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         assert!(lowered.program.atoms.iter().any(|atom| matches!(
             atom,
             SelectorAtom::AstChildListPattern {
@@ -3627,14 +3466,6 @@ function second() {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         assert!(
             !lowered.program.atoms.iter().any(|atom| matches!(
                 atom,
@@ -3665,14 +3496,6 @@ function second() {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         assert!(
             !lowered.program.atoms.iter().any(|atom| matches!(
                 atom,
@@ -3702,14 +3525,6 @@ function second() {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         assert!(lowered.program.atoms.iter().any(|atom| matches!(
             atom,
             SelectorAtom::AstBareProperty {
@@ -3733,14 +3548,6 @@ function second() {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         assert!(lowered.program.atoms.iter().any(|atom| matches!(
             atom,
             SelectorAtom::AstBareProperty {
@@ -3764,14 +3571,6 @@ function second() {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         assert!(lowered.program.atoms.iter().any(|atom| matches!(
             atom,
             SelectorAtom::AstKind {
@@ -3792,14 +3591,6 @@ function second() {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         assert!(lowered.program.atoms.iter().any(|atom| matches!(
             atom,
             SelectorAtom::AstKind {
@@ -3820,14 +3611,21 @@ function second() {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
+        let identifier_var_count = lowered
+            .program
+            .atoms
+            .iter()
+            .filter(|atom| {
+                matches!(
+                    atom,
+                    SelectorAtom::AstIdentifierName {
+                        value: StringTerm::Var { .. },
+                        ..
+                    }
+                )
+            })
+            .count();
+        assert!(identifier_var_count >= 4);
     }
 
     #[test]
@@ -3844,13 +3642,6 @@ function second() {
         .unwrap();
 
         let target_owner = lowered.program.targets[lowered.target.0].owner;
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         assert!(lowered.program.atoms.iter().any(|atom| matches!(
             atom,
             SelectorAtom::OwnerDeclaresBinding {
@@ -3873,13 +3664,6 @@ function second() {
         .unwrap();
 
         let target_owner = lowered.program.targets[lowered.target.0].owner;
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         assert!(lowered.program.atoms.iter().any(|atom| matches!(
             atom,
             SelectorAtom::OwnerDeclaresBinding {
@@ -3890,16 +3674,22 @@ function second() {
     }
 
     #[test]
-    fn misplaced_argument_run_hole_stays_oracle_only() {
+    fn misplaced_argument_run_hole_fails_closed() {
         let selector = AnonymousStatementSelector::exact("const a = ARGS;");
-        let lowered = lower_member_selector(
+        let error = lower_member_selector(
             &context(),
             "Widget",
             &MemberSelectorSpec::SourceMatch(selector.clone()),
         )
-        .unwrap();
+        .unwrap_err();
 
-        assert_source_match_oracle_only(&lowered, &selector);
+        assert!(matches!(
+            error,
+            SelectorIrLoweringError::Unsupported {
+                selector_kind: "source_match",
+                reason: "selector shape is not yet supported by native selector IR",
+            }
+        ));
     }
 
     #[test]
@@ -3913,14 +3703,6 @@ function second() {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         assert!(lowered.program.atoms.iter().any(|atom| matches!(
             atom,
             SelectorAtom::AstChildListPattern {
@@ -3956,14 +3738,6 @@ function second() {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         assert!(lowered.program.atoms.iter().any(|atom| matches!(
             atom,
             SelectorAtom::AstChildListPattern {
@@ -3987,14 +3761,6 @@ function second() {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         assert!(lowered.program.atoms.iter().any(|atom| matches!(
             atom,
             SelectorAtom::AstChildListPattern {
@@ -4026,14 +3792,6 @@ function second() {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         assert!(
             !lowered
                 .program
@@ -4089,14 +3847,6 @@ function second() {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         assert!(lowered.program.atoms.iter().any(|atom| matches!(
             atom,
             SelectorAtom::AstChildListPattern {
@@ -4131,14 +3881,6 @@ function second() {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         assert!(lowered.program.atoms.iter().any(|atom| matches!(
             atom,
             SelectorAtom::AstChildListPattern {
@@ -4174,14 +3916,6 @@ function second() {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         assert!(lowered.program.atoms.iter().any(|atom| matches!(
             atom,
             SelectorAtom::AstChildListPattern {
@@ -4215,14 +3949,6 @@ function second() {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         assert!(lowered.program.atoms.iter().any(|atom| matches!(
             atom,
             SelectorAtom::AstChildListPattern {
@@ -4256,14 +3982,6 @@ function second() {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         assert!(lowered.program.atoms.iter().any(|atom| matches!(
             atom,
             SelectorAtom::AstChildListPattern {
@@ -4295,14 +4013,6 @@ function second() {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         assert!(
             !lowered.program.atoms.iter().any(|atom| matches!(
                 atom,
@@ -4351,14 +4061,6 @@ function second() {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         assert!(lowered.program.atoms.iter().any(|atom| matches!(
             atom,
             SelectorAtom::AstChildListPattern {
@@ -4399,14 +4101,6 @@ function second() {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         let switch_pattern_parent = lowered.program.atoms.iter().find_map(|atom| match atom {
             SelectorAtom::AstChildListPattern {
                 parent: NodeTerm::Var { id },
@@ -4450,13 +4144,6 @@ function second() {
         .unwrap();
 
         let target_owner = lowered.program.targets[lowered.target.0].owner;
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         let projected_bindings = lowered
             .program
             .atoms

--- a/devinfra/js/debundle/selector_ir_solver.rs
+++ b/devinfra/js/debundle/selector_ir_solver.rs
@@ -2,14 +2,16 @@
 //!
 //! The solver runs one Ascent derivation over the lowered selector constraints
 //! plus chunk-level owner/fact-store relations, then projects target claims from
-//! the derived candidate sets. It supports binding/name/kind constraints and
-//! `source_match` candidate constraints, and the current relational selector
-//! primitives. Unsupported atoms remain explicit `ClaimOutcome::Unsupported` rows
-//! instead of being ignored or approximated.
+//! the derived candidate sets. It supports binding/name/kind constraints,
+//! native AST-backed source-match constraints, and the current relational
+//! selector primitives. Unsupported atoms remain explicit
+//! `ClaimOutcome::Unsupported` rows instead of being ignored or approximated.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
 use std::fmt;
+use std::io::Write;
+use std::time::{Duration, Instant};
 
 use analysis::{OwnerId, StatementOrdinal};
 use ascent::ascent;
@@ -19,6 +21,19 @@ use selector_ir::{
     SelectorFact, SelectorFactStore, SelectorProgram, SelectorProgramError, SelectorTarget,
     SelectorVariableId, SolverClaim, SolverResult, StringTerm,
 };
+
+const SELECTOR_IR_STATS_ENV: &str = "DUCKTAPE_SELECTOR_IR_STATS";
+
+fn selector_ir_stats_enabled() -> bool {
+    std::env::var(SELECTOR_IR_STATS_ENV)
+        .ok()
+        .is_some_and(|raw| {
+            !matches!(
+                raw.to_ascii_lowercase().as_str(),
+                "" | "0" | "false" | "off" | "no"
+            )
+        })
+}
 
 fn optional_u32_matches(expected: &Option<u32>, actual: u32) -> bool {
     expected.is_none_or(|expected| expected == actual)
@@ -216,7 +231,6 @@ ascent! {
     relation call_arg_from(String, String, String, u32); // argument, callee object, member, index
     relation decorate_call(String, String, Option<String>); // callee, class binding, member
     relation intrinsic_alias(String, String); // binding, Object property
-    relation source_match_candidate(String, usize, String); // selector key, owner, matched binding
     relation ast_kind(u32, String); // AST node, node kind tag
     relation ast_child(u32, u32, u32); // parent, child index, child
     relation ast_child_count(u32, u32); // node, number of direct AST children
@@ -239,26 +253,6 @@ ascent! {
         owner_fact(owner, ordinal, _kind);
 
     relation owner_top_level_root(usize, u32);
-    owner_top_level_root(*owner, *node) <--
-        owner_fact(owner, ordinal, _kind),
-        ast_top_level(node, ordinal);
-    relation ast_descendant(u32, u32);
-    ast_descendant(*parent, *child) <--
-        ast_child(parent, _index, child);
-    ast_descendant(*ancestor, *descendant) <--
-        ast_child(ancestor, _index, child),
-        ast_descendant(child, descendant);
-    relation ast_top_level_binding(u32, String);
-    ast_top_level_binding(*root, binding.clone()) <--
-        ast_top_level(root, _ordinal),
-        ast_descendant(root, binding_node),
-        ast_kind(binding_node, kind),
-        ast_identifier_name(binding_node, binding),
-        if kind.as_str() == "BindingIdent";
-    owner_top_level_root(*owner, *root) <--
-        owner_fact(owner, _ordinal, _kind),
-        declares(owner, binding),
-        ast_top_level_binding(root, binding);
 
     relation name_owner(String, usize);
     name_owner(binding.clone(), *owner) <-- declares(owner, binding);
@@ -331,7 +325,6 @@ ascent! {
     relation required_passed_to_call(usize, usize, String, Option<u32>);
     relation required_passed_to_call_from_binding(usize, usize, String, String, Option<u32>);
     relation required_makes_decorate_call_for_binding(usize, usize, String, Option<String>);
-    relation required_source_match_candidate(usize, usize, String);
     relation required_owner_statement_ordinal(usize, usize, usize);
 
     relation constraint_support(usize, usize, usize); // constraint id, variable id, owner
@@ -387,10 +380,6 @@ ascent! {
         declares(owner, _declared),
         if actual_class_anchor == class_anchor,
         if optional_string_matches(member, actual_member);
-    constraint_support(*constraint, *var, *owner) <--
-        required_source_match_candidate(constraint, var, selector_key),
-        source_match_candidate(selector_key, owner, _binding),
-        owner_fact(owner, _ordinal, _kind);
     constraint_support(*constraint, *var, *owner) <--
         required_owner_statement_ordinal(constraint, var, ordinal),
         owner_statement_ordinal(owner, actual_ordinal),
@@ -592,6 +581,7 @@ ascent! {
     relation child_list_assignment(usize, AssignmentRow);
     relation equality_checks_after_step(usize, Vec<EqualityCheck>);
     relation live_variables_after_step(usize, Vec<usize>);
+    relation stored_variables_after_step(usize, Vec<usize>);
 
     relation atom_assignment(usize, AssignmentRow);
     atom_assignment(*constraint, row.clone()) <--
@@ -670,13 +660,15 @@ ascent! {
     relation partial_assignment(usize, AssignmentRow);
     partial_assignment(0, Vec::new());
     relation stepped_assignment(usize, AssignmentRow);
-    stepped_assignment(*step + 1, merged_row.clone()) <--
+    stepped_assignment(*step + 1, stored_row) <--
         partial_assignment(step, row),
         constraint_order(step, constraint),
         atom_assignment(constraint, constraint_row),
         if let Some(merged_row) = merge_assignment_rows(row, constraint_row),
         equality_checks_after_step((*step + 1), equality_checks),
-        if assignment_satisfies_equalities(&merged_row, equality_checks);
+        if assignment_satisfies_equalities(&merged_row, equality_checks),
+        stored_variables_after_step((*step + 1), stored_variables),
+        if let Some(stored_row) = project_assignment_row(&merged_row, stored_variables);
 
     partial_assignment(*step, projected_row) <--
         stepped_assignment(step, row),
@@ -719,6 +711,8 @@ pub fn solve(
     }
 
     let fact_index = FactIndex::from_store(facts);
+    let mut stats =
+        selector_ir_stats_enabled().then(|| SelectorIrStats::new(program, &fact_index, &support));
     let mut ascent = AscentProgram::default();
     for (owner, ordinal, kind) in &fact_index.owner_facts {
         ascent
@@ -771,11 +765,6 @@ pub fn solve(
         ascent
             .intrinsic_alias
             .push((binding.clone(), property.clone()));
-    }
-    for (selector_key, owner, binding) in &fact_index.source_match_candidates {
-        ascent
-            .source_match_candidate
-            .push((selector_key.clone(), owner.0, binding.clone()));
     }
     for (node, node_kind) in &fact_index.ast_kinds {
         ascent.ast_kind.push((*node, node_kind.clone()));
@@ -835,17 +824,28 @@ pub fn solve(
     for (node, ordinal) in &fact_index.ast_top_levels {
         ascent.ast_top_level.push((*node, ordinal.0));
     }
+    for (owner, root) in &fact_index.owner_top_level_roots {
+        ascent.owner_top_level_root.push((owner.0, *root));
+    }
     for (base, ordinal, offset) in top_level_ordinal_offset_rows(
         &fact_index.ast_top_levels,
         &support.required_ordinal_offsets(),
     ) {
         ascent.ordinal_offset.push((base, ordinal, offset));
     }
+    let child_list_started = Instant::now();
     for constraint in &support.node_list_constraints {
-        for row in child_list_assignment_rows(constraint, &fact_index) {
+        let candidate_parents = child_list_candidate_parents(constraint, &fact_index, &support);
+        let candidate_parent_count = candidate_parents.len();
+        let rows = child_list_assignment_rows(constraint, &fact_index, candidate_parents);
+        if let Some(stats) = &mut stats {
+            stats.record_child_list_rows(constraint, candidate_parent_count, rows.len());
+        }
+        for row in rows {
             ascent.child_list_assignment.push((constraint.id, row));
         }
     }
+    let child_list_elapsed = child_list_started.elapsed();
     let constraint_ids = support.constraint_ids();
     for (step, equality_checks) in support.equality_checks_by_step(&constraint_ids) {
         ascent
@@ -878,6 +878,13 @@ pub fn solve(
         ascent
             .live_variables_after_step
             .push((step, live_variables));
+    }
+    for (step, stored_variables) in
+        support.stored_variables_by_step(&constraint_ids, &program.targets)
+    {
+        ascent
+            .stored_variables_after_step
+            .push((step, stored_variables));
     }
     for (step, constraint) in constraint_ids.iter().enumerate() {
         ascent.constraint_order.push((step, *constraint));
@@ -957,13 +964,6 @@ pub fn solve(
                 class_anchor.clone(),
                 member.clone(),
             )),
-            UnaryConstraintKind::SourceMatchCandidate { selector_key } => {
-                ascent.required_source_match_candidate.push((
-                    constraint.id,
-                    constraint.variable.0,
-                    selector_key.clone(),
-                ));
-            }
             UnaryConstraintKind::OwnerStatementOrdinal { ordinal } => {
                 ascent.required_owner_statement_ordinal.push((
                     constraint.id,
@@ -1250,7 +1250,14 @@ pub fn solve(
             }
         }
     }
+    if let Some(stats) = &stats {
+        stats.emit_before_ascent(child_list_elapsed);
+    }
+    let ascent_started = Instant::now();
     ascent.run();
+    if let Some(stats) = &stats {
+        stats.emit_after_ascent(ascent_started.elapsed());
+    }
 
     let candidates = group_solution_owners(ascent.solution_owner);
     let projected_bindings = group_solution_target_bindings(ascent.solution_target_binding);
@@ -1267,13 +1274,7 @@ pub fn solve(
 
         let candidates = candidates.get(&target.owner).cloned().unwrap_or_default();
         let projected_bindings = projected_bindings.get(&target.owner).cloned();
-        let outcome = classify_candidates(
-            target,
-            candidates,
-            projected_bindings,
-            &fact_index,
-            &support,
-        );
+        let outcome = classify_candidates(target, candidates, projected_bindings, &fact_index);
         claims.push(SolverClaim {
             target: target.id,
             outcome,
@@ -1327,19 +1328,20 @@ fn group_solution_target_bindings(
 fn child_list_assignment_rows(
     constraint: &NodeListConstraint,
     facts: &FactIndex,
+    candidate_parents: BTreeSet<u32>,
 ) -> Vec<AssignmentRow> {
     let mut rows = Vec::new();
-    for parent in &facts.all_nodes {
+    for parent in candidate_parents {
         let subject_children = facts
             .ast_children_by_parent
-            .get(parent)
+            .get(&parent)
             .map(Vec::as_slice)
             .unwrap_or(&[])
             .iter()
             .filter(|(index, _child)| *index >= constraint.start_index)
             .map(|(_index, child)| *child)
             .collect::<Vec<_>>();
-        let mut current = vec![(constraint.parent.0, AssignmentValue::AstNode(*parent))];
+        let mut current = vec![(constraint.parent.0, AssignmentValue::AstNode(parent))];
         collect_child_list_assignment_rows(
             constraint,
             &subject_children,
@@ -1350,6 +1352,134 @@ fn child_list_assignment_rows(
         );
     }
     rows
+}
+
+fn child_list_candidate_parents(
+    constraint: &NodeListConstraint,
+    facts: &FactIndex,
+    support: &ProgramSupport,
+) -> BTreeSet<u32> {
+    let mut candidates: Option<BTreeSet<u32>> = None;
+    for node_constraint in support.node_unary_constraints_for_variable(constraint.parent) {
+        let matching = nodes_matching_unary_constraint(&node_constraint.kind, facts);
+        candidates = Some(match candidates {
+            Some(existing) => existing.intersection(&matching).copied().collect(),
+            None => matching,
+        });
+    }
+    candidates.unwrap_or_else(|| facts.all_nodes.clone())
+}
+
+fn nodes_matching_unary_constraint(
+    kind: &NodeUnaryConstraintKind,
+    facts: &FactIndex,
+) -> BTreeSet<u32> {
+    match kind {
+        NodeUnaryConstraintKind::Kind { node_kind } => facts
+            .ast_kinds
+            .iter()
+            .filter_map(|(node, actual)| (actual == node_kind).then_some(*node))
+            .collect(),
+        NodeUnaryConstraintKind::ChildCount { count } => facts
+            .ast_child_counts
+            .iter()
+            .filter_map(|(node, actual)| (actual == count).then_some(*node))
+            .collect(),
+        NodeUnaryConstraintKind::ChildParent { index, child } => facts
+            .ast_children
+            .iter()
+            .filter_map(|(parent, actual_index, actual_child)| {
+                (actual_index == index && actual_child == child).then_some(*parent)
+            })
+            .collect(),
+        NodeUnaryConstraintKind::ChildChild { parent, index } => facts
+            .ast_children
+            .iter()
+            .filter_map(|(actual_parent, actual_index, child)| {
+                (actual_parent == parent && actual_index == index).then_some(*child)
+            })
+            .collect(),
+        NodeUnaryConstraintKind::SuperClassClass { super_class } => facts
+            .ast_super_classes
+            .iter()
+            .filter_map(|(class_node, actual_super_class)| {
+                (actual_super_class == super_class).then_some(*class_node)
+            })
+            .collect(),
+        NodeUnaryConstraintKind::SuperClassSuper { class_node } => facts
+            .ast_super_classes
+            .iter()
+            .filter_map(|(actual_class_node, super_class)| {
+                (actual_class_node == class_node).then_some(*super_class)
+            })
+            .collect(),
+        NodeUnaryConstraintKind::StringLiteral { value } => facts
+            .ast_string_literals
+            .iter()
+            .filter_map(|(node, actual)| (actual == value).then_some(*node))
+            .collect(),
+        NodeUnaryConstraintKind::StringLiteralMatchingRegex { pattern } => {
+            let Ok(regex) = Regex::new(pattern) else {
+                return BTreeSet::new();
+            };
+            facts
+                .ast_string_literals
+                .iter()
+                .filter_map(|(node, actual)| regex.is_match(actual).then_some(*node))
+                .collect()
+        }
+        NodeUnaryConstraintKind::NumberLiteral { value } => facts
+            .ast_number_literals
+            .iter()
+            .filter_map(|(node, actual)| (actual == value).then_some(*node))
+            .collect(),
+        NodeUnaryConstraintKind::BoolLiteral { value } => facts
+            .ast_bool_literals
+            .iter()
+            .filter_map(|(node, actual)| (actual == value).then_some(*node))
+            .collect(),
+        NodeUnaryConstraintKind::IdentifierName { value } => facts
+            .ast_identifier_names
+            .iter()
+            .filter_map(|(node, actual)| (actual == value).then_some(*node))
+            .collect(),
+        NodeUnaryConstraintKind::PropertyName { value } => facts
+            .ast_property_names
+            .iter()
+            .filter_map(|(node, actual)| (actual == value).then_some(*node))
+            .collect(),
+        NodeUnaryConstraintKind::BareProperty {
+            key,
+            identifier,
+            is_binding,
+        } => facts
+            .ast_bare_properties
+            .iter()
+            .filter_map(|(node, actual_key, actual_identifier, actual_is_binding)| {
+                (actual_key == key
+                    && actual_identifier == identifier
+                    && actual_is_binding == is_binding)
+                    .then_some(*node)
+            })
+            .collect(),
+        NodeUnaryConstraintKind::Operator { value } => facts
+            .ast_operators
+            .iter()
+            .filter_map(|(node, actual)| (actual == value).then_some(*node))
+            .collect(),
+        NodeUnaryConstraintKind::RegexLiteral { pattern, flags } => facts
+            .ast_regex_literals
+            .iter()
+            .filter_map(|(node, actual_pattern, actual_flags)| {
+                (actual_pattern == pattern && actual_flags == flags).then_some(*node)
+            })
+            .collect(),
+        NodeUnaryConstraintKind::TopLevelOrdinal { ordinal } => facts
+            .ast_top_levels
+            .iter()
+            .filter_map(|(node, actual_ordinal)| (actual_ordinal == ordinal).then_some(*node))
+            .collect(),
+    }
 }
 
 fn collect_child_list_assignment_rows(
@@ -1405,30 +1535,146 @@ fn collect_child_list_assignment_rows(
     }
 }
 
+#[derive(Debug)]
+struct SelectorIrStats {
+    target_count: usize,
+    atom_count: usize,
+    owner_fact_count: usize,
+    ast_node_count: usize,
+    unary_constraint_count: usize,
+    node_unary_constraint_count: usize,
+    binary_constraint_count: usize,
+    owner_node_constraint_count: usize,
+    node_node_constraint_count: usize,
+    node_list_constraint_count: usize,
+    equality_constraint_count: usize,
+    child_list_rows: Vec<ChildListRowStats>,
+}
+
+#[derive(Debug, Clone)]
+struct ChildListRowStats {
+    constraint_id: usize,
+    parent_var: usize,
+    candidate_parent_count: usize,
+    row_count: usize,
+    segment_lengths: Vec<usize>,
+    anchored_left: bool,
+    anchored_right: bool,
+}
+
+impl SelectorIrStats {
+    fn new(program: &SelectorProgram, facts: &FactIndex, support: &ProgramSupport) -> Self {
+        Self {
+            target_count: program.targets.len(),
+            atom_count: program.atoms.len(),
+            owner_fact_count: facts.owner_facts.len(),
+            ast_node_count: facts.all_nodes.len(),
+            unary_constraint_count: support.unary_constraints.len(),
+            node_unary_constraint_count: support.node_unary_constraints.len(),
+            binary_constraint_count: support.binary_constraints.len(),
+            owner_node_constraint_count: support.owner_node_constraints.len(),
+            node_node_constraint_count: support.node_node_constraints.len(),
+            node_list_constraint_count: support.node_list_constraints.len(),
+            equality_constraint_count: support.equality_constraints.len(),
+            child_list_rows: Vec::new(),
+        }
+    }
+
+    fn record_child_list_rows(
+        &mut self,
+        constraint: &NodeListConstraint,
+        candidate_parent_count: usize,
+        row_count: usize,
+    ) {
+        self.child_list_rows.push(ChildListRowStats {
+            constraint_id: constraint.id,
+            parent_var: constraint.parent.0,
+            candidate_parent_count,
+            row_count,
+            segment_lengths: constraint.segments.iter().map(Vec::len).collect(),
+            anchored_left: constraint.anchored_left,
+            anchored_right: constraint.anchored_right,
+        });
+    }
+
+    fn emit_before_ascent(&self, child_list_elapsed: Duration) {
+        let child_list_row_count = self
+            .child_list_rows
+            .iter()
+            .map(|entry| entry.row_count)
+            .sum::<usize>();
+        let max_child_list_rows = self
+            .child_list_rows
+            .iter()
+            .map(|entry| entry.row_count)
+            .max()
+            .unwrap_or(0);
+        eprintln!(
+            "[debundle selector_ir] targets={} atoms={} owners={} ast_nodes={} constraints.unary={} constraints.node_unary={} constraints.binary={} constraints.owner_node={} constraints.node_node={} constraints.node_list={} constraints.equality={} child_list.rows={} child_list.max_rows={} child_list.row_generation_ms={}",
+            self.target_count,
+            self.atom_count,
+            self.owner_fact_count,
+            self.ast_node_count,
+            self.unary_constraint_count,
+            self.node_unary_constraint_count,
+            self.binary_constraint_count,
+            self.owner_node_constraint_count,
+            self.node_node_constraint_count,
+            self.node_list_constraint_count,
+            self.equality_constraint_count,
+            child_list_row_count,
+            max_child_list_rows,
+            child_list_elapsed.as_millis(),
+        );
+        let mut top_child_lists = self.child_list_rows.clone();
+        top_child_lists.sort_by_key(|entry| {
+            (
+                std::cmp::Reverse(entry.row_count),
+                std::cmp::Reverse(entry.candidate_parent_count),
+                entry.constraint_id,
+            )
+        });
+        for entry in top_child_lists.into_iter().take(10) {
+            eprintln!(
+                "[debundle selector_ir child_list] constraint={} parent_var={} candidate_parents={} rows={} segment_lengths={:?} anchored_left={} anchored_right={}",
+                entry.constraint_id,
+                entry.parent_var,
+                entry.candidate_parent_count,
+                entry.row_count,
+                entry.segment_lengths,
+                entry.anchored_left,
+                entry.anchored_right,
+            );
+        }
+        let _ = std::io::stderr().flush();
+    }
+
+    fn emit_after_ascent(&self, ascent_elapsed: Duration) {
+        eprintln!(
+            "[debundle selector_ir] ascent_run_ms={}",
+            ascent_elapsed.as_millis()
+        );
+        let _ = std::io::stderr().flush();
+    }
+}
+
 fn classify_candidates(
     target: &SelectorTarget,
     candidates: BTreeSet<OwnerId>,
     projected_bindings: Option<BTreeSet<(OwnerId, String)>>,
     facts: &FactIndex,
-    support: &ProgramSupport,
 ) -> ClaimOutcome {
-    let claims: Vec<ResolvedClaim> =
-        if let Some(selector_key) = support.source_match_selector_for(target.owner) {
-            candidates
-                .into_iter()
-                .flat_map(|owner| resolved_source_match_claims(target, owner, facts, &selector_key))
-                .collect()
-        } else if let Some(projected_bindings) = projected_bindings {
-            projected_bindings
-                .into_iter()
-                .filter_map(|(owner, binding)| resolved_claim(target, owner, Some(binding), facts))
-                .collect()
-        } else {
-            candidates
-                .into_iter()
-                .filter_map(|owner| resolved_claim(target, owner, None, facts))
-                .collect()
-        };
+    let claims: Vec<ResolvedClaim> = if let Some(projected_bindings) = projected_bindings {
+        projected_bindings
+            .into_iter()
+            .filter_map(|(owner, binding)| resolved_claim(target, owner, Some(binding), facts))
+            .collect()
+    } else {
+        candidates
+            .into_iter()
+            .filter_map(|owner| resolved_claim(target, owner, None, facts))
+            .collect()
+    };
     match claims.as_slice() {
         [] => ClaimOutcome::NoMatch,
         [claim] => ClaimOutcome::Unique {
@@ -1436,28 +1682,6 @@ fn classify_candidates(
         },
         _ => ClaimOutcome::Ambiguous { candidates: claims },
     }
-}
-
-fn resolved_source_match_claims(
-    target: &SelectorTarget,
-    owner: OwnerId,
-    facts: &FactIndex,
-    selector_key: &str,
-) -> Vec<ResolvedClaim> {
-    let Some(statement_ordinal) = facts.statement_ordinal_by_owner.get(&owner).copied() else {
-        return Vec::new();
-    };
-    facts
-        .source_match_bindings_for_owner(selector_key, owner)
-        .into_iter()
-        .map(|binding| ResolvedClaim {
-            chunk_id: target.chunk_id,
-            owner,
-            statement_ordinal,
-            binding: Some(binding),
-            provenance: Vec::new(),
-        })
-        .collect()
 }
 
 fn resolved_claim(
@@ -1881,15 +2105,6 @@ impl ProgramSupport {
                     *referenced_by,
                     BinaryConstraintKind::IntrinsicAlias {
                         property: value.clone(),
-                    },
-                ),
-                SelectorAtom::SourceMatchCandidate {
-                    owner: OwnerTerm::Var { id },
-                    selector_key: StringTerm::Const { value },
-                } => support.add_unary(
-                    *id,
-                    UnaryConstraintKind::SourceMatchCandidate {
-                        selector_key: value.clone(),
                     },
                 ),
                 SelectorAtom::Equal { left, right } => {
@@ -2438,30 +2653,27 @@ impl ProgramSupport {
             .collect()
     }
 
+    fn node_unary_constraints_for_variable(
+        &self,
+        variable: SelectorVariableId,
+    ) -> Vec<&NodeUnaryConstraint> {
+        self.node_unary_constraints_by_var
+            .get(&variable)
+            .into_iter()
+            .flatten()
+            .filter_map(|constraint_id| {
+                self.node_unary_constraints
+                    .iter()
+                    .find(|constraint| constraint.id == *constraint_id)
+            })
+            .collect()
+    }
+
     fn unsupported_reason_for_target(&self, target: &SelectorTarget) -> Option<String> {
         if !self.constraints_by_var.contains_key(&target.owner) {
             return Some("target owner variable has no selector constraints".to_string());
         }
         None
-    }
-
-    fn source_match_selector_for(&self, variable: SelectorVariableId) -> Option<String> {
-        self.unary_constraints_by_var
-            .get(&variable)?
-            .iter()
-            .filter_map(|constraint_id| {
-                let constraint = self
-                    .unary_constraints
-                    .iter()
-                    .find(|constraint| constraint.id == *constraint_id)?;
-                match &constraint.kind {
-                    UnaryConstraintKind::SourceMatchCandidate { selector_key } => {
-                        Some(selector_key.clone())
-                    }
-                    _ => None,
-                }
-            })
-            .next()
     }
 
     fn live_variables_by_step(
@@ -2502,6 +2714,40 @@ impl ProgramSupport {
         }
         (1..=constraint_ids.len())
             .map(|step| (step, by_step.get(&step).cloned().unwrap_or_default()))
+            .collect()
+    }
+
+    fn stored_variables_by_step(
+        &self,
+        constraint_ids: &[usize],
+        targets: &[SelectorTarget],
+    ) -> Vec<(usize, Vec<usize>)> {
+        let target_projection_steps = self.target_projection_steps(constraint_ids, targets);
+        let mut by_step = self
+            .live_variables_by_step(constraint_ids, targets)
+            .into_iter()
+            .map(|(step, variables)| (step, variables.into_iter().collect::<BTreeSet<_>>()))
+            .collect::<BTreeMap<_, _>>();
+        for (owner, projection_step) in target_projection_steps {
+            let stored = by_step.entry(projection_step).or_default();
+            stored.insert(owner.0);
+            if let Some(TargetBindingProjection::Var(binding)) =
+                self.target_binding_projection_by_owner.get(&owner)
+            {
+                stored.insert(binding.0);
+            }
+        }
+        (1..=constraint_ids.len())
+            .map(|step| {
+                (
+                    step,
+                    by_step
+                        .remove(&step)
+                        .unwrap_or_default()
+                        .into_iter()
+                        .collect(),
+                )
+            })
             .collect()
     }
 
@@ -2769,6 +3015,28 @@ impl ProgramSupport {
 
     fn constraint_order_rank(&self, id: usize) -> usize {
         if self
+            .unary_constraints
+            .iter()
+            .any(|constraint| constraint.id == id)
+            || self
+                .ordinal_unary_constraints
+                .iter()
+                .any(|constraint| constraint.id == id)
+        {
+            return 0;
+        }
+        if let Some(constraint) = self
+            .node_unary_constraints
+            .iter()
+            .find(|constraint| constraint.id == id)
+        {
+            return match &constraint.kind {
+                NodeUnaryConstraintKind::Kind { .. }
+                | NodeUnaryConstraintKind::ChildCount { .. } => 2,
+                _ => 1,
+            };
+        }
+        if self
             .owner_node_constraints
             .iter()
             .any(|constraint| constraint.id == id)
@@ -2785,7 +3053,7 @@ impl ProgramSupport {
                 .iter()
                 .any(|constraint| constraint.id == id)
         {
-            return 0;
+            return 3;
         }
         if self
             .binary_constraints
@@ -2800,42 +3068,20 @@ impl ProgramSupport {
                 .iter()
                 .any(|constraint| constraint.id == id)
         {
-            return 1;
+            return 4;
         }
         if self
-            .unary_constraints
+            .owner_string_constraints
             .iter()
             .any(|constraint| constraint.id == id)
-            || self
-                .owner_string_constraints
-                .iter()
-                .any(|constraint| constraint.id == id)
             || self
                 .node_string_constraints
                 .iter()
                 .any(|constraint| constraint.id == id)
         {
-            return 2;
+            return 5;
         }
-        if let Some(constraint) = self
-            .node_unary_constraints
-            .iter()
-            .find(|constraint| constraint.id == id)
-        {
-            return match &constraint.kind {
-                NodeUnaryConstraintKind::Kind { .. }
-                | NodeUnaryConstraintKind::ChildCount { .. } => 4,
-                _ => 3,
-            };
-        }
-        if self
-            .ordinal_unary_constraints
-            .iter()
-            .any(|constraint| constraint.id == id)
-        {
-            return 3;
-        }
-        5
+        6
     }
 }
 
@@ -2884,9 +3130,6 @@ enum UnaryConstraintKind {
     MakesDecorateCallForBinding {
         class_anchor: String,
         member: Option<String>,
-    },
-    SourceMatchCandidate {
-        selector_key: String,
     },
     OwnerStatementOrdinal {
         ordinal: StatementOrdinal,
@@ -3159,7 +3402,6 @@ fn atom_kind(atom: &SelectorAtom) -> &'static str {
         SelectorAtom::MakesDecorateCall { .. } => "makes_decorate_call",
         SelectorAtom::MakesDecorateCallForOwner { .. } => "makes_decorate_call_for_owner",
         SelectorAtom::IntrinsicAlias { .. } => "intrinsic_alias",
-        SelectorAtom::SourceMatchCandidate { .. } => "source_match_candidate",
         SelectorAtom::Equal { .. } => "equal",
         SelectorAtom::NotEqual { .. } => "not_equal",
     }
@@ -3183,7 +3425,6 @@ struct FactIndex {
     call_arguments_from: Vec<(String, String, String, usize)>,
     decorate_calls: Vec<(String, String, Option<String>)>,
     intrinsic_aliases: Vec<(String, String)>,
-    source_match_candidates: Vec<(String, OwnerId, String)>,
     ast_kinds: Vec<(u32, String)>,
     ast_children: Vec<(u32, u32, u32)>,
     ast_children_by_parent: BTreeMap<u32, Vec<(u32, u32)>>,
@@ -3199,6 +3440,7 @@ struct FactIndex {
     ast_regex_literals: Vec<(u32, String, String)>,
     ast_super_classes: Vec<(u32, u32)>,
     ast_top_levels: Vec<(u32, StatementOrdinal)>,
+    owner_top_level_roots: Vec<(OwnerId, u32)>,
 }
 
 impl FactIndex {
@@ -3323,20 +3565,6 @@ impl FactIndex {
                         .intrinsic_aliases
                         .push((binding.clone(), property.clone()));
                 }
-                SelectorFact::SourceMatchCandidate {
-                    selector_key,
-                    statement_ordinal,
-                    binding,
-                    ..
-                } => {
-                    if let Some(owner) = index.owner_by_statement_ordinal.get(statement_ordinal) {
-                        index.source_match_candidates.push((
-                            selector_key.clone(),
-                            *owner,
-                            binding.clone(),
-                        ));
-                    }
-                }
                 SelectorFact::AstKind {
                     node, node_kind, ..
                 } => {
@@ -3445,6 +3673,7 @@ impl FactIndex {
             children.sort_by_key(|(child_index, _child)| *child_index);
         }
         index.ast_children_by_parent = children_by_parent;
+        index.owner_top_level_roots = owner_top_level_root_rows(&index);
         index
     }
 
@@ -3456,18 +3685,69 @@ impl FactIndex {
         }
         Some(binding)
     }
+}
 
-    fn source_match_bindings_for_owner(&self, selector_key: &str, owner: OwnerId) -> Vec<String> {
-        self.source_match_candidates
-            .iter()
-            .filter(|(candidate_key, candidate_owner, _binding)| {
-                candidate_key == selector_key && *candidate_owner == owner
-            })
-            .map(|(_key, _owner, binding)| binding.clone())
-            .collect::<BTreeSet<_>>()
-            .into_iter()
-            .collect()
+fn owner_top_level_root_rows(index: &FactIndex) -> Vec<(OwnerId, u32)> {
+    let mut rows = BTreeSet::<(OwnerId, u32)>::new();
+    let ast_roots_by_ordinal = index
+        .ast_top_levels
+        .iter()
+        .map(|(node, ordinal)| (*ordinal, *node))
+        .fold(
+            BTreeMap::<StatementOrdinal, Vec<u32>>::new(),
+            |mut roots, (ordinal, node)| {
+                roots.entry(ordinal).or_default().push(node);
+                roots
+            },
+        );
+    for (owner, ordinal, _kind) in &index.owner_facts {
+        if let Some(roots) = ast_roots_by_ordinal.get(ordinal) {
+            for root in roots {
+                rows.insert((*owner, *root));
+            }
+        }
     }
+
+    let mut owners_by_binding = BTreeMap::<&str, Vec<OwnerId>>::new();
+    for (owner, binding) in &index.declared_bindings {
+        owners_by_binding
+            .entry(binding.as_str())
+            .or_default()
+            .push(*owner);
+    }
+    if owners_by_binding.is_empty() {
+        return rows.into_iter().collect();
+    }
+
+    let binding_ident_nodes = index
+        .ast_kinds
+        .iter()
+        .filter_map(|(node, kind)| (kind == "BindingIdent").then_some(*node))
+        .collect::<BTreeSet<_>>();
+    let identifier_by_node = index
+        .ast_identifier_names
+        .iter()
+        .map(|(node, value)| (*node, value.as_str()))
+        .collect::<BTreeMap<_, _>>();
+
+    for (root, _ordinal) in &index.ast_top_levels {
+        let mut stack = vec![*root];
+        while let Some(node) = stack.pop() {
+            if binding_ident_nodes.contains(&node)
+                && let Some(binding) = identifier_by_node.get(&node)
+                && let Some(owners) = owners_by_binding.get(binding)
+            {
+                for owner in owners {
+                    rows.insert((*owner, *root));
+                }
+            }
+            if let Some(children) = index.ast_children_by_parent.get(&node) {
+                stack.extend(children.iter().map(|(_index, child)| *child));
+            }
+        }
+    }
+
+    rows.into_iter().collect()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -4505,13 +4785,6 @@ mod tests {
         )
         .unwrap()
         .program;
-        assert!(
-            !program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. })),
-            "single-node expression holes should lower to native AST constraints"
-        );
         let facts = fact_store_from_analyzed_source(
             r#"
 const selected = Math.max(alpha + 1, beta ? beta.value : "fallback");
@@ -4544,13 +4817,6 @@ const wrongCallee = Math.min(alpha + 1, beta ? beta.value : "fallback");
         )
         .unwrap()
         .program;
-        assert!(
-            !program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. })),
-            "single-node statement holes should lower to native AST constraints"
-        );
         let facts = fact_store_from_analyzed_source(
             r#"
 function selected(flag) {
@@ -4590,13 +4856,6 @@ function wrongShape(flag) {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         let facts = fact_store_from_analyzed_source(
             r#"
 function bad() { return other; }
@@ -4631,13 +4890,6 @@ function good() { return good; }
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         let facts = fact_store_from_analyzed_source(
             r#"
 function bad() { return bad; }
@@ -4673,13 +4925,6 @@ function good() { return other; }
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         let facts = fact_store_from_analyzed_source(
             r#"
 function wrongKey(runtimeStable) {
@@ -4720,13 +4965,6 @@ function good(runtimeStable) {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         let facts = fact_store_from_analyzed_source(
             r#"
 function wrongKey(input) {
@@ -4769,13 +5007,6 @@ function good(input) {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         let facts = fact_store_from_analyzed_source(
             r#"
 function bad(target, decorators) {
@@ -4815,13 +5046,6 @@ function good(target, decorators) {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         let facts = fact_store_from_analyzed_source(
             r#"
 const bad = { runtimeStable = "wrong" };
@@ -4858,13 +5082,6 @@ const good = { runtimeStable = "ok" };
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         let facts = fact_store_from_analyzed_source(
             r#"
 function candidateLeft() {
@@ -4906,13 +5123,6 @@ function candidateRight() {
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         let facts = fact_store_from_analyzed_source(
             r#"
 const runtimeFirst = build("left"), runtimeSecond = build("right");
@@ -4948,13 +5158,6 @@ const otherFirst = build("left"), otherSecond = build("wrong");
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
         let facts = fact_store_from_analyzed_source(
             r#"
 function makeTarget(value) {
@@ -4997,13 +5200,6 @@ const wrongCallee = makeOther("value");
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. }))
-        );
 
         let adjacent = fact_store_from_analyzed_source(
             r#"
@@ -5058,14 +5254,6 @@ const selected = makeThing();
             &MemberSelectorSpec::SourceMatch(selector),
         )
         .unwrap();
-        assert!(
-            !lowered
-                .program
-                .atoms
-                .iter()
-                .any(|atom| matches!(atom, SelectorAtom::SourceMatchCandidate { .. })),
-            "STR_LITERAL_MATCHING_RE should lower into native AST constraints"
-        );
         assert!(
             lowered
                 .program
@@ -5389,7 +5577,7 @@ function targetClassName() {
     }
 
     #[test]
-    fn solves_intrinsic_alias_chain_when_class_anchor_is_source_match_candidate() {
+    fn solves_intrinsic_alias_chain_when_class_anchor_is_native_source_match() {
         let mut builder = MemberSelectorProgramBuilder::new(MemberSelectorLoweringContext::new(
             ChunkId(0),
             "features/widget",
@@ -5408,146 +5596,9 @@ function targetClassName() {
             kind: None,
         });
         let mut class_selector = AnonymousStatementSelector::exact(
-            "const DecoratedClass = class Widget { STMT_LIST; };",
+            r#"const DecoratedClass = class Widget { method() { return "selected"; } };"#,
         );
-        class_selector.target_binding = Some("DecoratedClass".to_string());
-        let class_member_selector = MemberSelectorSpec::SourceMatch(class_selector.clone());
-
-        let define_alias = builder
-            .declare_member_target_in_module(
-                "features/widget",
-                "definePropertyAlias",
-                &define_alias_selector,
-            )
-            .unwrap();
-        let descriptor_alias = builder
-            .declare_member_target_in_module(
-                "features/widget",
-                "descriptorAlias",
-                &descriptor_alias_selector,
-            )
-            .unwrap();
-        let helper = builder
-            .declare_member_target_in_module("features/widget", "applyDecorators", &helper_selector)
-            .unwrap();
-        let class = builder
-            .declare_member_target_in_module(
-                "features/widget",
-                "DecoratedClass",
-                &class_member_selector,
-            )
-            .unwrap();
-        for (export_name, selector) in [
-            ("definePropertyAlias", &define_alias_selector),
-            ("descriptorAlias", &descriptor_alias_selector),
-            ("applyDecorators", &helper_selector),
-            ("DecoratedClass", &class_member_selector),
-        ] {
-            builder
-                .lower_member_constraints_in_module("features/widget", export_name, selector)
-                .unwrap();
-        }
-        let program = builder.into_program().unwrap();
-        let class_owner = program.targets[class.0].owner;
-        let selector_key = program
-            .atoms
-            .iter()
-            .find_map(|atom| match atom {
-                selector_ir::SelectorAtom::SourceMatchCandidate {
-                    owner: selector_ir::OwnerTerm::Var { id },
-                    selector_key: selector_ir::StringTerm::Const { value },
-                } if *id == class_owner => Some(value.clone()),
-                _ => None,
-            })
-            .expect("class source_match should lower to a candidate selector key");
-        let facts = SelectorFactStore {
-            facts: vec![
-                owner(1, 1, "var_decl"),
-                declared(1, "defineAlias"),
-                owner(2, 2, "var_decl"),
-                declared(2, "descriptorAlias"),
-                owner(3, 3, "var_decl"),
-                declared(3, "decorateHelper"),
-                owner(4, 4, "var_decl"),
-                declared(4, "targetClass"),
-                SelectorFact::IntrinsicAliasUse {
-                    chunk_id: ChunkId(0),
-                    binding: "defineAlias".to_string(),
-                    property: "defineProperty".to_string(),
-                },
-                SelectorFact::IntrinsicAliasUse {
-                    chunk_id: ChunkId(0),
-                    binding: "descriptorAlias".to_string(),
-                    property: "getOwnPropertyDescriptor".to_string(),
-                },
-                SelectorFact::OwnerReferencesBinding {
-                    chunk_id: ChunkId(0),
-                    owner: OwnerId(3),
-                    binding: "defineAlias".to_string(),
-                    edge_kind: "eager_use".to_string(),
-                },
-                SelectorFact::OwnerReferencesBinding {
-                    chunk_id: ChunkId(0),
-                    owner: OwnerId(3),
-                    binding: "descriptorAlias".to_string(),
-                    edge_kind: "eager_use".to_string(),
-                },
-                SelectorFact::DecorateCallUse {
-                    chunk_id: ChunkId(0),
-                    callee: "decorateHelper".to_string(),
-                    class_anchor: "targetClass".to_string(),
-                    member: None,
-                },
-                SelectorFact::SourceMatchCandidate {
-                    chunk_id: ChunkId(0),
-                    selector_key,
-                    statement_ordinal: StatementOrdinal(4),
-                    binding: "targetClass".to_string(),
-                },
-            ],
-        };
-
-        let result = solve(&program, &facts).unwrap();
-
-        for (target, owner) in [
-            (define_alias, OwnerId(1)),
-            (descriptor_alias, OwnerId(2)),
-            (helper, OwnerId(3)),
-            (class, OwnerId(4)),
-        ] {
-            assert!(
-                matches!(
-                    result.outcome_for(target),
-                    Some(ClaimOutcome::Unique { claim }) if claim.owner == owner
-                ),
-                "target {target:?} should resolve to {owner:?}: {:#?}",
-                result.outcome_for(target)
-            );
-        }
-    }
-
-    #[test]
-    fn solves_intrinsic_alias_chain_from_analyzed_decorate_trio() {
-        let mut builder = MemberSelectorProgramBuilder::new(MemberSelectorLoweringContext::new(
-            ChunkId(0),
-            "features/widget",
-        ));
-        let define_alias_selector = MemberSelectorSpec::IntrinsicAlias(IntrinsicAliasTarget {
-            property: "defineProperty".to_string(),
-            referenced_by: "applyDecorators".to_string(),
-        });
-        let descriptor_alias_selector = MemberSelectorSpec::IntrinsicAlias(IntrinsicAliasTarget {
-            property: "getOwnPropertyDescriptor".to_string(),
-            referenced_by: "applyDecorators".to_string(),
-        });
-        let helper_selector = MemberSelectorSpec::MakesDecorateCall(MakesDecorateCallTarget {
-            class: "DecoratedClass".to_string(),
-            member: None,
-            kind: None,
-        });
-        let mut class_selector = AnonymousStatementSelector::exact(
-            "const DecoratedClass = class Widget { STMT_LIST; };",
-        );
+        class_selector.identifiers = spec::SourceMatchIdentifierMode::AlphaAll;
         class_selector.target_binding = Some("DecoratedClass".to_string());
         let class_member_selector = MemberSelectorSpec::SourceMatch(class_selector);
 
@@ -5586,20 +5637,104 @@ function targetClassName() {
                 .unwrap();
         }
         let program = builder.into_program().unwrap();
-        let class_owner_var = program.targets[class.0].owner;
-        let selector_key = program
-            .atoms
-            .iter()
-            .find_map(|atom| match atom {
-                selector_ir::SelectorAtom::SourceMatchCandidate {
-                    owner: selector_ir::OwnerTerm::Var { id },
-                    selector_key: selector_ir::StringTerm::Const { value },
-                } if *id == class_owner_var => Some(value.clone()),
-                _ => None,
-            })
-            .expect("class source_match should lower to a candidate selector key");
+        let facts = fact_store_from_analyzed_source(
+            r#"
+var defineAlias = Object.defineProperty,
+  descriptorAlias = Object.getOwnPropertyDescriptor,
+  decorateHelper = (decorators, target, key, kind) => {
+    const desc = kind ? descriptorAlias(target, key) : target;
+    for (const decorator of decorators) decorator(target, key, desc);
+    defineAlias(target, key, desc);
+  };
+const targetClass = class LocalWidget { method() { return "selected"; } };
+decorateHelper([tag], targetClass.prototype, "greet", 1);
+"#,
+        );
 
-        let mut facts = fact_store_from_analyzed_source(
+        let result = solve(&program, &facts).unwrap();
+
+        for (target, owner) in [
+            (define_alias, owner_for_binding(&facts, "defineAlias")),
+            (
+                descriptor_alias,
+                owner_for_binding(&facts, "descriptorAlias"),
+            ),
+            (helper, owner_for_binding(&facts, "decorateHelper")),
+            (class, owner_for_binding(&facts, "targetClass")),
+        ] {
+            assert!(
+                matches!(
+                    result.outcome_for(target),
+                    Some(ClaimOutcome::Unique { claim }) if claim.owner == owner
+                ),
+                "target {target:?} should resolve to {owner:?}: {:#?}",
+                result.outcome_for(target)
+            );
+        }
+    }
+
+    #[test]
+    fn solves_intrinsic_alias_chain_from_analyzed_decorate_trio() {
+        let mut builder = MemberSelectorProgramBuilder::new(MemberSelectorLoweringContext::new(
+            ChunkId(0),
+            "features/widget",
+        ));
+        let define_alias_selector = MemberSelectorSpec::IntrinsicAlias(IntrinsicAliasTarget {
+            property: "defineProperty".to_string(),
+            referenced_by: "applyDecorators".to_string(),
+        });
+        let descriptor_alias_selector = MemberSelectorSpec::IntrinsicAlias(IntrinsicAliasTarget {
+            property: "getOwnPropertyDescriptor".to_string(),
+            referenced_by: "applyDecorators".to_string(),
+        });
+        let helper_selector = MemberSelectorSpec::MakesDecorateCall(MakesDecorateCallTarget {
+            class: "DecoratedClass".to_string(),
+            member: None,
+            kind: None,
+        });
+        let mut class_selector =
+            AnonymousStatementSelector::exact("const DecoratedClass = class Widget {};");
+        class_selector.identifiers = spec::SourceMatchIdentifierMode::AlphaAll;
+        class_selector.target_binding = Some("DecoratedClass".to_string());
+        let class_member_selector = MemberSelectorSpec::SourceMatch(class_selector);
+
+        let define_alias = builder
+            .declare_member_target_in_module(
+                "features/widget",
+                "definePropertyAlias",
+                &define_alias_selector,
+            )
+            .unwrap();
+        let descriptor_alias = builder
+            .declare_member_target_in_module(
+                "features/widget",
+                "descriptorAlias",
+                &descriptor_alias_selector,
+            )
+            .unwrap();
+        let helper = builder
+            .declare_member_target_in_module("features/widget", "applyDecorators", &helper_selector)
+            .unwrap();
+        let class = builder
+            .declare_member_target_in_module(
+                "features/widget",
+                "DecoratedClass",
+                &class_member_selector,
+            )
+            .unwrap();
+        for (export_name, selector) in [
+            ("definePropertyAlias", &define_alias_selector),
+            ("descriptorAlias", &descriptor_alias_selector),
+            ("applyDecorators", &helper_selector),
+            ("DecoratedClass", &class_member_selector),
+        ] {
+            builder
+                .lower_member_constraints_in_module("features/widget", export_name, selector)
+                .unwrap();
+        }
+        let program = builder.into_program().unwrap();
+
+        let facts = fact_store_from_analyzed_source(
             r#"
 var defineAlias = Object.defineProperty,
   descriptorAlias = Object.getOwnPropertyDescriptor,
@@ -5613,12 +5748,6 @@ decorateHelper([tag], targetClass.prototype, "greet", 1);
 "#,
         );
         let class_owner = owner_for_binding(&facts, "targetClass");
-        facts.push(SelectorFact::SourceMatchCandidate {
-            chunk_id: ChunkId(0),
-            selector_key,
-            statement_ordinal: statement_ordinal_for_owner(&facts, class_owner),
-            binding: "targetClass".to_string(),
-        });
 
         let result = solve(&program, &facts).unwrap();
 

--- a/devinfra/js/debundle/source_match/mod.rs
+++ b/devinfra/js/debundle/source_match/mod.rs
@@ -66,7 +66,6 @@ mod types;
 pub(crate) use anonymous_statement::*;
 pub(crate) use declared_bindings::*;
 pub(crate) use holes::*;
-pub(crate) use parse_validate::*;
 pub(crate) use timing::{
     emit_source_match_timing, source_match_timings_enabled, time_source_match,
 };
@@ -75,6 +74,7 @@ pub(crate) use timing::{
 pub use binding_resolution::{binding_group_member_selectors, source_match_declared_binding_names};
 pub use datalog_resolver::ChunkResolver;
 pub use fact_near_miss::fact_source_match_body_debt;
+pub use parse_validate::parse_selector_module_with_capability_check;
 pub use resolver::SelectorResolver;
 pub use timing::{selector_body_key, selector_key, source_match_preview};
 pub use types::{

--- a/devinfra/js/debundle/source_match/parse_validate.rs
+++ b/devinfra/js/debundle/source_match/parse_validate.rs
@@ -141,7 +141,7 @@ impl Visit for UnsupportedAnythingCollector {
     }
 }
 
-pub(crate) fn parse_selector_module_with_capability_check(
+pub fn parse_selector_module_with_capability_check(
     request_id: &str,
     selector_kind: &str,
     file_label: String,


### PR DESCRIPTION
## Summary

- Fail closed when production `source_match` selectors cannot lower to native selector IR, including binding-group `source_match`.
- Delete the legacy `SourceMatchCandidate` selector atom/fact schema and the materializer path that pre-enumerated `source_match` candidates with `ChunkResolver`.
- Move production `anonymous_statements[]` resolution onto the global selector solver: anonymous selectors now lower natively or record/fail as unsupported instead of calling `ChunkResolver` during materialization.
- Keep diagnostics solver-based for no-match/ambiguous source_match outcomes, and update debundle planning docs to track the remaining single-model work.
- Keep the solver memory reductions already in this PR:
  - precompute `owner_top_level_root` facts instead of deriving an all-AST `ast_descendant` transitive closure;
  - rank unary support constraints before broad structural joins;
  - project `stepped_assignment` rows before storing them, while still preserving same-step target projection variables.
- Add env-gated debundle/selector progress hooks for future RBE diagnostics.

This removes the production candidate-oracle path: retained selectors must lower to native selector IR, and unsupported shapes fail closed rather than spawning a second resolver pass.

## Validation

- `nix --offline develop --command pre-commit run --files devinfra/js/debundle/TODO.md devinfra/js/debundle/lowering/anonymous.rs devinfra/js/debundle/lowering/mod.rs devinfra/js/debundle/lowering/materialize/mod.rs devinfra/js/debundle/lowering/materialize/plan_builder.rs devinfra/js/debundle/plans/selector_constraint_model.md devinfra/js/debundle/selector_ir.rs devinfra/js/debundle/selector_ir_lowering.rs devinfra/js/debundle/selector_ir_solver.rs`
- `nix --offline develop --command bbr test //devinfra/js/debundle:selector_ir_solver_test //devinfra/js/debundle:selector_ir_lowering_test //devinfra/js/debundle/e2e:syntactic_holes_test //devinfra/js/debundle/e2e:anonymous_statement_test //devinfra/js/debundle/e2e:selector_diagnostics_report_test`
  - BuildBuddy invocation: `5d4acbfd-6f72-417f-b5ca-628ac2853d4f`
- GitHub CI is running on `072e45a2dcdd5cfb1a4b8838a6e815777bcda3b9`.

## Gaffer-private

The full Tana debundle target still resource-exhausted before this latest deletion slice, so this PR is progress but not the end of the single-resolution performance work.

Command shape used for the local Ducktape override:

`nix --offline develop --command bb build --config=nolint --config=rbe --config=source-debundler --override_module=ducktape=/tmp/ducktape-global-anonymous --remote_download_outputs=minimal --action_env=DUCKTAPE_SELECTOR_IR_STATS=1 --action_env=DUCKTAPE_DEBUNDLE_PROGRESS=1 --action_env=DEBUNDLE_TIMING=1 //tana/re/web/78d928dca7:debundle`

BuildBuddy invocation: `c72a4891-7936-4ee4-903a-cfeecb7d2725`

Result: the debundle action still hit `Resource Exhausted: command was killed: signal: killed`; failed retries peaked at exactly `7,630,221,312` bytes. Action stdout/stderr were empty, so the process is being killed before useful buffered progress/stats reach the action result.

Note: `bb remote`/`bbr` cannot validate this local Ducktape override directly because the remote runner cannot see `/tmp/ducktape-global-anonymous`; local `bb build --config=rbe` is the workable validation mode for this specific override.
