### PR TITLE
haku: split Managed Agents TODOs per runtime + record cloud v0 known issues / TF provider survey

### DIFF
--- a/haku/TODO.md
+++ b/haku/TODO.md
@@ -72,77 +72,24 @@ facade** in front (the Authentik OAuth facade is auth, not tool filtering — se
   `kubectl_sandbox_fixed_groups` `else` default with an explicit SA→group map
   once the claude-sandbox JWT path has soaked (`tf/gitops/agent-machine-access`).
 
-## Managed Agents runtime (Runtime B) — operator activation to go live
+## Managed Agents runtimes — per-runtime TODOs
 
-Runtime B (`runtime/managed_agent/self_hosted/`) is built end-to-end and its control plane is
-provisioned (environment `env_015uqL9WAMSDytQEWWmLG9zF`, agent, vault +
-`tana-mcp-ro` credential, scheduled deployment `depl_011DSrUoXuhoDWJoPyDuePqR`;
-full IDs recorded on #2438). PR #2442 adds the worker image build+push and the
-k8s manifests (`cluster/k8s/haku/agent-worker/`, shipped **suspended**). What
-remains is operator activation (runbook in that dir's README):
+Runtime-specific TODOs live with each runtime (the agent loop runs at Anthropic;
+the runtimes differ in where the sandbox runs — see
+<runtime/managed_agent/README.md>):
 
-- **Generate the environment key** in the Console (Environments →
-  `haku-selfhosted` → "Generate environment key") and `sops`
-  `cluster/k8s/haku/agent-worker/environment-key.sops.yaml` to the real value
-  (placeholder today, encrypted to the cluster/Flux age key).
-- **Activate + validate**: flip `suspend: false` on the Kustomization and watch
-  the Deployment — first systemd-PID1 pod in the cluster, so confirm it boots
-  unprivileged (cgroup-v2 delegation, writable `/run`) and tune the pod
-  `securityContext` if needed.
-- **Smoke test** — `ant beta:deployments run --deployment-id depl_011DSrUoXuhoDWJoPyDuePqR`,
-  watch in the Console.
-
-Settled (not blockers):
-
-- **Image build + push** — `nix build .#haku-worker-image` (full-NixOS,
-  `runtime/managed_agent/self_hosted/nixos.nix`) → `.github/workflows/haku-worker-image.yml`
-  imports + pushes to `ghcr.io/agentydragon/haku-worker`; Flux tracks the tag via
-  the `haku-worker` ImagePolicy.
-- **Egress** — `api.anthropic.com` is on the `haku-mitmproxy` allowlist
-  (`cluster/k8s/agents/haku-mitmproxy/cnp-haku-cloud-api-egress.yaml`); the worker
-  reaches the work queue through the TLS-terminating proxy and trusts its CA via
-  the inject policy (imported into the systemd unit).
-- **SOPS identity** — the in-cluster worker needs no `SOPS_AGE_KEY`: it uses its
-  `haku-worker` ServiceAccount for `kubectl` and reads creds from k8s secrets
-  (only the web home decrypts the public-`kubeapi` JWT via SOPS).
-- **Git sources** — haku-state on the in-cluster Forgejo
-  (`git.allegedly.works/haku/haku-state`, single `.netrc` via `HAKU_GIT_HOST` +
-  the `haku-state-git-write` creds); ducktape on public GitHub (anonymous,
-  read-only) — it isn't mirrored to the cluster Forgejo yet (that migration is
-  the "Cluster Forgejo repos" item above).
-
-## Managed Agents runtime — Anthropic-hosted (cloud) v0 known issues
-
-`runtime/managed_agent/anthropic_hosted/` P0 passed (cloud session reaches
-`kubeapi.allegedly.works` as `haku`). Open items from that bring-up:
-
-- **Auto-propagate the rotated k8s token into the Anthropic vault.** `provision.sh`
-  injects `KUBE_TOKEN` (from `secrets/haku-k8s-jwt.yaml`) as a one-shot vault
-  credential. `authentik-jwt-rotation` rotates the in-cluster secret but does
-  **not** push the refreshed token to the vault, so the cloud credential silently
-  expires → kube-apiserver 401s with no pod touched. Interim: extend the rotation
-  CronJob to `ant beta:vaults:credentials update` before expiry. Ideal would be
-  managing the agent/vault as IaC (a Terraform `ant`/Anthropic provider), but the
-  provider we found looked sparsely used / possibly immature — evaluate before
-  committing to it.
-- **Tighten cloud egress.** `haku.environment.yaml` has `networking.type:
-unrestricted` (TODO in-file). Narrow to `type: limited` + an explicit
-  `allowed_hosts`. (The `KUBE_TOKEN` secret is already scoped — only substituted
-  on `kubeapi.allegedly.works` — so this is hardening, not a leak fix.)
-- **Move off Path B to the k8s-MCP path.** v0 `curl`s kube-apiserver directly
-  with the `aud=kubectl-sandbox-client-credentials` token. The cleaner
-  `kubectl-sandbox-mcp` path needs a token with `aud=kubectl-sandbox-mcp` +
-  `groups=[haku]`, which no Authentik provider mints yet (PLAN.md P0 gate).
-
-The Sonnet pin (`model: claude-sonnet-4-6`) is intentional for bring-up test runs
-— not a TODO; revisit the model once the runtime is past v0.
+- **Self-hosted worker (Runtime B)** — operator activation to go live:
+  <runtime/managed_agent/self_hosted/TODO.md>.
+- **Anthropic-hosted cloud** — v0 known issues (token propagation, egress, the
+  k8s-MCP path) + the Terraform-provider evaluation:
+  <runtime/managed_agent/anthropic_hosted/TODO.md>.
 
 ## Later (post-v0)
 
 - **In-cluster runtime** — realized as `runtime/agent` (Runtime C, MAF
-  self-hosted loop) and `runtime/managed_agent/self_hosted` (Runtime B, Managed Agents
-  self-hosted worker; remaining wiring above). The old `haku-scanner` image +
-  CronJob idea is superseded.
+  self-hosted loop) and `runtime/managed_agent/self_hosted` (Runtime B, Managed
+  Agents self-hosted worker; remaining wiring in its per-runtime TODO above). The
+  old `haku-scanner` image + CronJob idea is superseded.
 - **haku-traces** — push Claude Code transcripts to a store separate from
   `haku-state` for replayability.
 - **tier-2 execution** — haku-owned execution behind stronger gating, only if

--- a/haku/TODO.md
+++ b/haku/TODO.md
@@ -111,6 +111,32 @@ Settled (not blockers):
   read-only) — it isn't mirrored to the cluster Forgejo yet (that migration is
   the "Cluster Forgejo repos" item above).
 
+## Managed Agents runtime — Anthropic-hosted (cloud) v0 known issues
+
+`runtime/managed_agent/anthropic_hosted/` P0 passed (cloud session reaches
+`kubeapi.allegedly.works` as `haku`). Open items from that bring-up:
+
+- **Auto-propagate the rotated k8s token into the Anthropic vault.** `provision.sh`
+  injects `KUBE_TOKEN` (from `secrets/haku-k8s-jwt.yaml`) as a one-shot vault
+  credential. `authentik-jwt-rotation` rotates the in-cluster secret but does
+  **not** push the refreshed token to the vault, so the cloud credential silently
+  expires → kube-apiserver 401s with no pod touched. Interim: extend the rotation
+  CronJob to `ant beta:vaults:credentials update` before expiry. Ideal would be
+  managing the agent/vault as IaC (a Terraform `ant`/Anthropic provider), but the
+  provider we found looked sparsely used / possibly immature — evaluate before
+  committing to it.
+- **Tighten cloud egress.** `haku.environment.yaml` has `networking.type:
+unrestricted` (TODO in-file). Narrow to `type: limited` + an explicit
+  `allowed_hosts`. (The `KUBE_TOKEN` secret is already scoped — only substituted
+  on `kubeapi.allegedly.works` — so this is hardening, not a leak fix.)
+- **Move off Path B to the k8s-MCP path.** v0 `curl`s kube-apiserver directly
+  with the `aud=kubectl-sandbox-client-credentials` token. The cleaner
+  `kubectl-sandbox-mcp` path needs a token with `aud=kubectl-sandbox-mcp` +
+  `groups=[haku]`, which no Authentik provider mints yet (PLAN.md P0 gate).
+
+The Sonnet pin (`model: claude-sonnet-4-6`) is intentional for bring-up test runs
+— not a TODO; revisit the model once the runtime is past v0.
+
 ## Later (post-v0)
 
 - **In-cluster runtime** — realized as `runtime/agent` (Runtime C, MAF

--- a/haku/runtime/managed_agent/anthropic_hosted/TODO.md
+++ b/haku/runtime/managed_agent/anthropic_hosted/TODO.md
@@ -1,0 +1,45 @@
+# Managed Agents — Anthropic-hosted cloud TODO
+
+P0 passed (cloud session reaches `kubeapi.allegedly.works` as `haku`); the phased
+build plan is <PLAN.md>. Open items from the v0 bring-up:
+
+- **Auto-propagate the rotated k8s token into the Anthropic vault.** `provision.sh`
+  injects `KUBE_TOKEN` (from `secrets/haku-k8s-jwt.yaml`) as a one-shot vault
+  credential. `authentik-jwt-rotation` rotates the in-cluster secret but does
+  **not** push the refreshed token to the vault, so the cloud credential silently
+  expires → kube-apiserver 401s with no pod touched. Interim: extend the rotation
+  CronJob to `ant beta:vaults:credentials update` before expiry. The IaC
+  alternative (manage the agent/vault with a Terraform provider) is evaluated
+  below.
+- **Tighten cloud egress.** `haku.environment.yaml` has `networking.type:
+unrestricted` (TODO in-file). Narrow to `type: limited` + an explicit
+  `allowed_hosts`. (The `KUBE_TOKEN` secret is already scoped — only substituted
+  on `kubeapi.allegedly.works` — so this is hardening, not a leak fix.)
+- **Move off Path B to the k8s-MCP path.** v0 `curl`s kube-apiserver directly
+  with the `aud=kubectl-sandbox-client-credentials` token. The cleaner
+  `kubectl-sandbox-mcp` path needs a token with `aud=kubectl-sandbox-mcp` +
+  `groups=[haku]`, which no Authentik provider mints yet (<PLAN.md> P0 gate).
+
+The Sonnet pin (`model: claude-sonnet-4-6`) is intentional for bring-up test runs
+— not a TODO; revisit the model once the runtime is past v0.
+
+## Terraform provider options (the IaC alternative for token propagation)
+
+Managing the agent + vault credential as IaC would resolve the token-propagation
+item cleanly. There is **no official/verified Anthropic provider** — all options
+are `community` tier (surveyed 2026-06-25):
+
+| Provider                                     | Scope                                                                   | Adoption                                  | Verdict                                                         |
+| -------------------------------------------- | ----------------------------------------------------------------------- | ----------------------------------------- | --------------------------------------------------------------- |
+| **`andasv/anthropic-claude-managed-agents`** | Managed Agents: agents, environments, **vaults**, skill uploads, memory | 2★, created 2026-05-12, no registry stats | Only one that fits — but immature; single author, no real users |
+| `ippontech/anthropic`                        | Admin API (workspaces / API keys / members) — **not** agents/vaults     | ~8.5k downloads, 10★, active              | Doesn't cover our use case                                      |
+| `jianyuan/anthropic`                         | Admin API — **not** agents/vaults                                       | ~1.7k downloads, oldest (since 2024-12)   | Doesn't cover our use case                                      |
+| `gszzzzzz/claude`                            | Claude Admin API — **not** agents/vaults                                | ~1.3k downloads, 0★, stale (push 2026-03) | Doesn't cover our use case                                      |
+
+Only `andasv/anthropic-claude-managed-agents` models `vaults` + credentials (the
+resource we'd need), and it's too young to trust for Haku's control plane (uses
+TF ≥1.11 write-only attributes for secrets, which is the right shape).
+
+**Decision:** stay with scripting `ant beta:vaults:credentials update` from the
+`authentik-jwt-rotation` CronJob for now; re-evaluate `andasv` once it has real
+adoption.

--- a/haku/runtime/managed_agent/self_hosted/TODO.md
+++ b/haku/runtime/managed_agent/self_hosted/TODO.md
@@ -1,0 +1,38 @@
+# Managed Agents — self-hosted worker (Runtime B) TODO
+
+Built end-to-end and its control plane is provisioned (environment
+`env_015uqL9WAMSDytQEWWmLG9zF`, agent, vault + `tana-mcp-ro` credential, scheduled
+deployment `depl_011DSrUoXuhoDWJoPyDuePqR`; full IDs recorded on #2438). PR #2442
+adds the worker image build+push and the k8s manifests
+(`cluster/k8s/haku/agent-worker/`, shipped **suspended**). What remains is
+operator activation (runbook in <README.md>):
+
+- **Generate the environment key** in the Console (Environments →
+  `haku-selfhosted` → "Generate environment key") and `sops`
+  `cluster/k8s/haku/agent-worker/environment-key.sops.yaml` to the real value
+  (placeholder today, encrypted to the cluster/Flux age key).
+- **Activate + validate**: flip `suspend: false` on the Kustomization and watch
+  the Deployment — first systemd-PID1 pod in the cluster, so confirm it boots
+  unprivileged (cgroup-v2 delegation, writable `/run`) and tune the pod
+  `securityContext` if needed.
+- **Smoke test** — `ant beta:deployments run --deployment-id depl_011DSrUoXuhoDWJoPyDuePqR`,
+  watch in the Console.
+
+## Settled (not blockers)
+
+- **Image build + push** — `nix build .#haku-worker-image` (full-NixOS,
+  `nixos.nix`) → `.github/workflows/haku-worker-image.yml` imports + pushes to
+  `ghcr.io/agentydragon/haku-worker`; Flux tracks the tag via the `haku-worker`
+  ImagePolicy.
+- **Egress** — `api.anthropic.com` is on the `haku-mitmproxy` allowlist
+  (`cluster/k8s/agents/haku-mitmproxy/cnp-haku-cloud-api-egress.yaml`); the worker
+  reaches the work queue through the TLS-terminating proxy and trusts its CA via
+  the inject policy (imported into the systemd unit).
+- **SOPS identity** — the in-cluster worker needs no `SOPS_AGE_KEY`: it uses its
+  `haku-worker` ServiceAccount for `kubectl` and reads creds from k8s secrets
+  (only the web home decrypts the public-`kubeapi` JWT via SOPS).
+- **Git sources** — haku-state on the in-cluster Forgejo
+  (`git.allegedly.works/haku/haku-state`, single `.netrc` via `HAKU_GIT_HOST` +
+  the `haku-state-git-write` creds); ducktape on public GitHub (anonymous,
+  read-only) — it isn't mirrored to the cluster Forgejo yet (the "Cluster Forgejo
+  repos" item in <../../../TODO.md>).


### PR DESCRIPTION
Reorganizes Haku's Managed Agents TODOs and records the bring-up findings.

**Split per runtime.** The runtime-specific sections move out of `haku/TODO.md` into per-runtime files (the agent loop runs at Anthropic; runtimes differ only in sandbox location):
- `runtime/managed_agent/self_hosted/TODO.md` — operator activation to go live (env key, activate+validate, smoke test) + the settled-not-blocker notes.
- `runtime/managed_agent/anthropic_hosted/TODO.md` — v0 known issues from the P0 spike:
  - **Token propagation** — the vault `KUBE_TOKEN` expires silently because `authentik-jwt-rotation` doesn't push refreshes; interim is scripting `ant beta:vaults:credentials update`.
  - **Tighten cloud egress** `unrestricted` → `limited`.
  - **Move off Path B** to the `kubectl-sandbox-mcp` path.

`haku/TODO.md` keeps the cross-cutting source-wiring / facade / hardening items and points to the two per-runtime TODOs.

**Terraform provider survey** (recorded in the cloud TODO). No official/verified Anthropic provider exists; all four community providers surveyed:
- `andasv/anthropic-claude-managed-agents` — the **only** one covering agents/environments/**vaults**/skills/memory, but immature (2★, created 2026-05-12, no real adoption).
- `ippontech/anthropic`, `jianyuan/anthropic`, `gszzzzzz/claude` — Admin-API only (workspaces / keys / members); don't cover agents/vaults.

Decision: script `ant beta:vaults:credentials update` from the rotation CronJob for now; re-evaluate `andasv` once it has adoption.

The Sonnet model pin stays — intentional for bring-up test runs, explicitly noted as *not* a TODO.