### PR TITLE
haku: mint haku-k8s token with kubectl-passthrough-mcp audience (Stage 1)

### DIFF
--- a/cluster/k8s/agents/authentik-jwt-rotation/rotate.py
+++ b/cluster/k8s/agents/authentik-jwt-rotation/rotate.py
@@ -7,13 +7,15 @@ One run processes every rotation listed in the YAML config. For each rotation it
      remaining validity exceeds `rotate_below_hours`. A real mint therefore
      happens only every ~44 days (45d validity - 1d threshold), but a failed
      rotation self-heals on the next hourly run.
-  2. Mints a fresh JWT via `client_credentials`, verifies its issuer and an
-     optional group claim, and — for proxy-fronted consumers — exchanges it
-     into a proxy-provider-scoped token (the JWT-bearer two-hop pattern the
-     Authentik outposts in this repo require).
+  2. Mints a fresh JWT via `client_credentials`, verifies its issuer, an
+     optional group claim, and an optional set of expected audiences on the
+     final token, and — for proxy-fronted consumers — exchanges it into a
+     proxy-provider-scoped token (the JWT-bearer two-hop pattern the Authentik
+     outposts in this repo require).
   3. Writes `expires_unencrypted` (from the final token's own `exp` claim, so
-     the freshness check is authoritative) plus the token, then `sops encrypt`s
-     in place.
+     the freshness check is authoritative), an `audiences_unencrypted` stamp
+     when audiences are expected (so the next run can force a re-mint if the
+     expectation changes), plus the token, then `sops encrypt`s in place.
 
 Everything that actually rotated this cycle lands in a single combined commit.
 The whole run operates from the clone root so SOPS creation rules (matched on
@@ -58,6 +60,13 @@ class Rotation(BaseModel):
     expected_group: str | None = Field(
         default=None, description="Group claim that must be present on the source JWT; aborts the rotation if missing"
     )
+    expected_audiences: list[str] | None = Field(
+        default=None,
+        description="Audiences (aud claim) that must all be present on the final written token. "
+        "Asserted on every mint, and forces a re-mint when the stored token's "
+        "audiences_unencrypted stamp does not already cover them — so adding an audience "
+        "rolls out on the next run instead of waiting for expiry.",
+    )
     exchange_scopes: str | None = Field(
         default=None,
         description="When set, exchange the source JWT into a proxy-provider token "
@@ -89,16 +98,42 @@ def jwt_payload(token: str) -> dict[str, Any]:
     return payload
 
 
+def unencrypted_stamps(sops_file: Path) -> dict[str, Any]:
+    """The plaintext `*_unencrypted` stamps from a sops file, parsed as YAML.
+
+    A sops-encrypted YAML file is still valid YAML, and the `*_unencrypted`-suffixed
+    keys keep their plaintext values (SOPS leaves them in clear), so the freshness
+    and audience stamps load straight out without the in-cluster age key. Returns
+    `{}` when the file is absent or empty.
+    """
+    if not sops_file.exists():
+        return {}
+    return yaml.safe_load(sops_file.read_text()) or {}
+
+
 def remaining_hours(sops_file: Path) -> float | None:
     """Hours until the existing token expires, or None if absent/unstamped."""
-    if not sops_file.exists():
+    expires = unencrypted_stamps(sops_file).get("expires_unencrypted")
+    if expires is None:
         return None
-    for line in sops_file.read_text().splitlines():
-        if line.startswith("expires_unencrypted:"):
-            value = line.split(":", 1)[1].strip().strip('"')
-            expires = datetime.fromisoformat(value)
-            return (expires - datetime.now(UTC)).total_seconds() / 3600
-    return None
+    return (datetime.fromisoformat(expires) - datetime.now(UTC)).total_seconds() / 3600
+
+
+def token_audiences(payload: dict[str, Any]) -> list[str]:
+    """The `aud` claim normalized to a list (the JWT spec allows a string or a list)."""
+    aud = payload.get("aud")
+    if aud is None:
+        return []
+    return [aud] if isinstance(aud, str) else list(aud)
+
+
+def stamped_audiences(sops_file: Path) -> list[str] | None:
+    """Audiences from the plaintext `audiences_unencrypted` stamp, or None if absent.
+
+    Lets the freshness check notice an audience-expectation change without
+    decrypting the token (the rotator has no in-cluster age key).
+    """
+    return unencrypted_stamps(sops_file).get("audiences_unencrypted")
 
 
 def mint_jwt(client: httpx.Client, rotation: Rotation) -> str:
@@ -143,7 +178,22 @@ def exchange_jwt(client: httpx.Client, rotation: Rotation, source_jwt: str, exch
 def rotate_one(client: httpx.Client, rotation: Rotation, config: Config) -> bool:
     """Mint + write a fresh token for one rotation. Returns True if it wrote."""
     remaining = remaining_hours(rotation.sops_file)
-    if remaining is not None and remaining > config.rotate_below_hours:
+    fresh = remaining is not None and remaining > config.rotate_below_hours
+    # An audience expectation the stored token doesn't already satisfy forces a
+    # re-mint regardless of remaining validity — otherwise adding an audience
+    # wouldn't take effect until the (~44-day) expiry. Read from the plaintext
+    # `audiences_unencrypted` stamp (no SOPS decryption needed).
+    if fresh and rotation.expected_audiences:
+        stored = stamped_audiences(rotation.sops_file)
+        if stored is None or not set(rotation.expected_audiences) <= set(stored):
+            logger.info(
+                "%s: stored audiences %s do not cover expected %s; forcing re-mint",
+                rotation.name,
+                stored,
+                rotation.expected_audiences,
+            )
+            fresh = False
+    if fresh:
         logger.info(
             "%s: %.0fh remaining > %dh threshold; skipping", rotation.name, remaining, config.rotate_below_hours
         )
@@ -168,14 +218,29 @@ def rotate_one(client: httpx.Client, rotation: Rotation, config: Config) -> bool
     else:
         final_jwt = source_jwt
 
+    final_payload = jwt_payload(final_jwt)
+    final_audiences = token_audiences(final_payload)
+    if rotation.expected_audiences:
+        missing = set(rotation.expected_audiences) - set(final_audiences)
+        if missing:
+            raise RuntimeError(
+                f"{rotation.name}: minted token missing expected audiences {sorted(missing)} "
+                f"(got {final_audiences!r}); check the Authentik provider's audience mapping"
+            )
+
     # `exp` from the token we actually write — the proxy provider's lifetime can
     # differ from the source provider's, so freshness must key off the final token.
-    expires_iso = datetime.fromtimestamp(int(jwt_payload(final_jwt)["exp"]), UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    expires_iso = datetime.fromtimestamp(int(final_payload["exp"]), UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    # `expires_unencrypted` matches SOPS's default unencrypted_suffix, so it
-    # stays plaintext after `sops encrypt --in-place`.
+    # `*_unencrypted` keys match SOPS's default unencrypted_suffix, so they stay
+    # plaintext after `sops encrypt --in-place`. The audiences stamp lets the next
+    # run detect an audience-expectation change without decrypting the token.
+    stamps: dict[str, Any] = {"expires_unencrypted": expires_iso}
+    if rotation.expected_audiences:
+        stamps["audiences_unencrypted"] = final_audiences
+    stamps[rotation.token_field] = final_jwt
     rotation.sops_file.parent.mkdir(parents=True, exist_ok=True)
-    rotation.sops_file.write_text(f'expires_unencrypted: "{expires_iso}"\n{rotation.token_field}: {final_jwt}\n')
+    rotation.sops_file.write_text(yaml.safe_dump(stamps, sort_keys=False, width=2**31))
     subprocess.run(["sops", "encrypt", "--in-place", str(rotation.sops_file)], check=True)
     logger.info("%s: wrote token expiring %s", rotation.name, expires_iso)
     return True

--- a/cluster/k8s/agents/authentik-jwt-rotation/rotations.yaml
+++ b/cluster/k8s/agents/authentik-jwt-rotation/rotations.yaml
@@ -15,6 +15,16 @@ rotations:
     scopes: openid profile email groups
     credential_mode: user_password
     expected_group: haku
+    # Multi-audience: the provider default aud (kubectl-sandbox-client-credentials)
+    # keeps the direct kubeapi.allegedly.works path working; kubectl-passthrough-mcp
+    # lets the same token authenticate to the passthrough kubectl MCP that Haku's
+    # Anthropic-hosted managed agent uses (tf/gitops/haku-cloud-agent). The audience
+    # is injected by the haku-k8s branch of the kubectl_machine_groups scope mapping
+    # in tf/gitops/agent-machine-access. Listing it here makes the rotator assert it
+    # on every mint and force a re-mint if a stored token doesn't carry it yet.
+    expected_audiences:
+      - kubectl-sandbox-client-credentials
+      - kubectl-passthrough-mcp
     credentials_dir: /var/run/secrets/authentik/haku-k8s
     sops_file: secrets/haku-k8s-jwt.yaml
     token_field: jwt

--- a/cluster/k8s/agents/authentik-jwt-rotation/test_rotate.py
+++ b/cluster/k8s/agents/authentik-jwt-rotation/test_rotate.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 import pytest_bazel
 from pydantic import ValidationError
-from rotate import Config, Rotation, jwt_payload, mint_jwt, remaining_hours
+from rotate import Config, Rotation, jwt_payload, mint_jwt, remaining_hours, stamped_audiences, token_audiences
 
 
 def _make_jwt(claims: dict) -> str:
@@ -56,6 +56,41 @@ def test_remaining_hours_reads_unencrypted_expiry(tmp_path: Path):
     remaining = remaining_hours(f)
     assert remaining is not None
     assert 9 < remaining < 11
+
+
+def test_token_audiences_normalizes_string_list_and_missing():
+    assert token_audiences({"aud": "one"}) == ["one"]
+    assert token_audiences({"aud": ["one", "two"]}) == ["one", "two"]
+    assert token_audiences({}) == []
+
+
+def test_stamped_audiences_reads_yaml_list(tmp_path: Path):
+    f = tmp_path / "t.yaml"
+    f.write_text('expires_unencrypted: "2030-01-01T00:00:00Z"\naudiences_unencrypted:\n  - a\n  - b\njwt: abc\n')
+    assert stamped_audiences(f) == ["a", "b"]
+
+
+def test_stamped_audiences_absent_is_none(tmp_path: Path):
+    f = tmp_path / "t.yaml"
+    f.write_text("jwt: abc\n")
+    assert stamped_audiences(f) is None
+    assert stamped_audiences(tmp_path / "absent.yaml") is None
+
+
+def test_rotation_expected_audiences_defaults_none_and_parses_list():
+    base = {
+        "name": "haku-k8s",
+        "provider_slug": "kubectl-sandbox-client-credentials",
+        "scopes": "openid profile email groups",
+        "credentials_dir": "/creds",
+        "sops_file": "secrets/haku-k8s-jwt.yaml",
+        "token_field": "jwt",
+    }
+    assert Rotation.model_validate(base).expected_audiences is None
+    with_aud = Rotation.model_validate(
+        base | {"expected_audiences": ["kubectl-sandbox-client-credentials", "kubectl-passthrough-mcp"]}
+    )
+    assert with_aud.expected_audiences == ["kubectl-sandbox-client-credentials", "kubectl-passthrough-mcp"]
 
 
 def test_rotation_expected_issuer_derived_from_slug():

--- a/tf/gitops/agent-machine-access/main.tf
+++ b/tf/gitops/agent-machine-access/main.tf
@@ -754,7 +754,17 @@ resource "authentik_property_mapping_provider_scope" "kubectl_machine_groups" {
     if username == "ak-kubectl-sandbox-client-credentials-client_credentials":
         return {"groups": ["kubectl-sandbox-users"]}
     if username == "haku-k8s":
-        return {"groups": ["haku"]}
+        # Multi-audience: the default aud is this provider's client_id
+        # (kubectl-sandbox-client-credentials), which kube-apiserver trusts for
+        # the direct kubeapi.allegedly.works path. Adding kubectl-passthrough-mcp
+        # lets the SAME token also authenticate to the passthrough kubectl MCP
+        # (its oauth_audience is kubectl-passthrough-mcp), which forwards the JWT
+        # to kube-apiserver. Consumer: tf/gitops/haku-cloud-agent — Haku's
+        # Anthropic-hosted managed agent reaches the cluster via that MCP with a
+        # static_bearer vault credential carrying this token. Authentik merges
+        # this aud with the provider default, so the minted token carries both;
+        # the authentik-jwt-rotation rotator asserts expected_audiences on mint.
+        return {"groups": ["haku"], "aud": "kubectl-passthrough-mcp"}
     return {"groups": []}
   EXPR
 }


### PR DESCRIPTION
**Stage 1 of 2** — make Haku's Anthropic-hosted managed agent reach the cluster via the passthrough kubectl MCP (the TF-native Path A), instead of the bash+curl env-var `KUBE_TOKEN` path that the `modus-agendi/anthropic-claude-managed-agents` provider can't model (it only supports `static_bearer`/`mcp_oauth` vault credentials, not `environment_variable`).

## Why
`kubectl-passthrough-mcp` requires `aud=kubectl-passthrough-mcp`. Haku's token currently carries only `aud=kubectl-sandbox-client-credentials`, so the MCP 401s it (verified live: `WWW-Authenticate: ... audience="kubectl-passthrough-mcp", error="invalid_token"`).

## Changes
- **`tf/gitops/agent-machine-access`**: the `haku-k8s` branch of the `kubectl_machine_groups` scope mapping now also emits `aud=kubectl-passthrough-mcp`. Authentik merges it with the provider-default aud, so the minted token carries **both** — the direct `kubeapi.allegedly.works` path keeps working, and the same token satisfies the passthrough MCP (which forwards the JWT to kube-apiserver; that audience is already trusted end-to-end since human OIDC users use the same server).
- **`authentik-jwt-rotation`**: optional `expected_audiences` on a `Rotation`. The rotator asserts every expected audience is on the minted token (self-heals next run if Authentik drifts) and **force-re-mints** when a stored token's audiences don't yet cover the expectation — so this rolls out on the next hourly run, not in ~44 days. Stored audiences read from a new plaintext `audiences_unencrypted` stamp (no in-cluster age key). Stamp read/write moved from hand-rolled line parsing to YAML.

## Verification gate before Stage 2
After this merges + applies and the rotator re-mints, the new token must return **HTTP 200 + `tools/list`** against `https://kubectl-passthrough-mcp.allegedly.works/mcp`. Stage 2 (the pinned `claude-managed-agents` provider + the `tf/gitops/haku-cloud-agent` root: environment + agent via `mcp_toolset` + vault + `static_bearer` credential + deployment, wired to the tofu-controller) is **not built until that gate is green**.

## Tested
- `bbr test //cluster/k8s/agents/authentik-jwt-rotation:test_rotate` ✅ (added coverage for `token_audiences`, `stamped_audiences`, `expected_audiences`)
- `bbr test //tf/gitops/agent-machine-access/...` ✅ (format/lint/validate)