### PR TITLE
haku: move console to its own haku-console namespace (boundary Phase 0)

### DIFF
--- a/cluster/k8s/authentik/app/blueprints/haku-dashboard-sso.yaml
+++ b/cluster/k8s/authentik/app/blueprints/haku-dashboard-sso.yaml
@@ -12,7 +12,7 @@ entries:
       name: haku-dashboard
     attrs:
       external_host: "https://haku.allegedly.works"
-      internal_host: "http://haku-console.haku-sandbox.svc.cluster.local:8080"
+      internal_host: "http://haku-console.haku-console.svc.cluster.local:8080"
       mode: proxy
       authentication_flow: !Find [authentik_flows.flow, [slug, default-authentication-flow]]
       authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]

--- a/cluster/k8s/forgejo/haku-state/flux-kustomization.yaml
+++ b/cluster/k8s/forgejo/haku-state/flux-kustomization.yaml
@@ -24,4 +24,6 @@ spec:
     - name: forgejo # Forgejo API must be up (provider target)
     - name: tofu-controller
     - name: tofu-state-db
-    - name: haku-namespace # the git-creds Secret lands in the haku-sandbox namespace
+    # The git-creds Secret lands in both target namespaces; wait for each to exist.
+    - name: haku-namespace
+    - name: haku-console-namespace

--- a/cluster/k8s/haku/console-namespace/flux-kustomization.yaml
+++ b/cluster/k8s/haku/console-namespace/flux-kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: haku-console-namespace
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./cluster/k8s/haku/console-namespace
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m

--- a/cluster/k8s/haku/console-namespace/kustomization.yaml
+++ b/cluster/k8s/haku/console-namespace/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml

--- a/cluster/k8s/haku/console-namespace/namespace.yaml
+++ b/cluster/k8s/haku/console-namespace/namespace.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  # The Haku console's own trusted namespace — deliberately NOT haku-sandbox.
+  # The console is reviewed/released ducktape code, so it sits OUTSIDE Haku's
+  # RBAC (no `haku` RoleBinding here) and OUTSIDE the haku-mitmproxy egress fence
+  # (the fence's CiliumClusterwideNetworkPolicy keys on the haku-sandbox
+  # namespace; this one gets ordinary egress). This is the confidentiality
+  # boundary that lets the console later hold secrets Haku may not read — e.g.
+  # the Claude Code web session bearer. See haku/PLAN.md → "The agent-authored
+  # console (free-form UI behind a trusted boundary)".
+  name: haku-console
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"
+    goldilocks.fairwinds.com/vpa-update-mode: "auto"
+    name: haku-console

--- a/cluster/k8s/haku/console/deployment.yaml
+++ b/cluster/k8s/haku/console/deployment.yaml
@@ -2,15 +2,22 @@
 # Unlike the dashboard (nginx + a git-sync sidecar), the app owns git itself —
 # it clones haku-state into an emptyDir at /data at startup and pushes back. Access
 # is gated by Authentik (agentydragon-only) via the proxy outpost — the app has no
-# native auth. Runs with Haku's exact perimeter (haku-sandbox namespace, uid/gid 1000,
-# non-root, no service-account token, all capabilities dropped). readOnlyRootFilesystem
-# is intentionally NOT set: the aspect py_binary launcher materializes its venv on the
-# rootfs at startup (same as grocy-mcp), so the root fs must be writable.
+# native auth.
+#
+# Trust boundary: runs in its OWN `haku-console` namespace, NOT haku-sandbox. As
+# reviewed/released ducktape code it sits outside Haku's RBAC (Haku can't read its
+# secrets/logs or patch it) and outside the haku-mitmproxy egress fence (which keys
+# on the haku-sandbox namespace) — so it gets ordinary egress and can later hold
+# secrets Haku may not read. See haku/PLAN.md → "The agent-authored console". It
+# still runs locked down (uid/gid 1000, non-root, no service-account token, all
+# capabilities dropped). readOnlyRootFilesystem is intentionally NOT set: the aspect
+# py_binary launcher materializes its venv on the rootfs at startup (same as
+# grocy-mcp), so the root fs must be writable.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: haku-console
-  namespace: haku-sandbox
+  namespace: haku-console
   labels:
     app.kubernetes.io/name: haku-console
 spec:

--- a/cluster/k8s/haku/console/flux-kustomization.yaml
+++ b/cluster/k8s/haku/console/flux-kustomization.yaml
@@ -14,9 +14,7 @@ spec:
     kind: GitRepository
     name: flux-system
   dependsOn:
-    - name: haku-namespace
-    - name: haku-rbac
-    - name: haku-state # provisions haku-state-git-write in the haku-sandbox namespace
-    - name: haku-mitmproxy
+    - name: haku-console-namespace # the console's own trusted namespace (not haku-sandbox)
+    - name: haku-state # provisions haku-state-git-write into the haku-console namespace
     - name: gateway
     - name: authentik

--- a/cluster/k8s/haku/console/service.yaml
+++ b/cluster/k8s/haku/console/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: haku-console
-  namespace: haku-sandbox
+  namespace: haku-console
   labels:
     app.kubernetes.io/name: haku-console
 spec:

--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -201,6 +201,7 @@ resources:
   # --- haku (personal background agent; see haku/PLAN.md) ---
   - haku/namespace/flux-kustomization.yaml
   - haku/rbac/flux-kustomization.yaml
+  - haku/console-namespace/flux-kustomization.yaml # the console's own trusted namespace
   - haku/console/flux-kustomization.yaml
   - haku/agent-worker/flux-kustomization.yaml # suspended; see the dir README to activate
 

--- a/haku/PLAN.md
+++ b/haku/PLAN.md
@@ -119,6 +119,112 @@ earns its place only if execution becomes agent-mediated (where what runs can di
 from what was reviewed). Its credentials get the same treatment as everything else —
 scoped or proxied, never trusted to the agent's restraint.
 
+## The agent-authored console (free-form UI behind a trusted boundary)
+
+Direction (operator, 2026-06-26): grow the console so **Haku authors more and more of
+it** — today operator-clickable `actions[]` + free-text feedback, evolving toward Haku
+writing arbitrary interactive UI (inputs, interlinked pages, TSX/JS) that records what
+the operator expressed into `haku-state` for Haku to reduce on its next run. The console
+stays the operator's interface _with_ Haku; Haku just gets to shape it.
+
+The hard constraint: the console must eventually hold secrets **Haku may not have** (the
+Claude Code web session bearer that launches the routine — see `TODO.md` → _Console_)
+and run privileged actions Haku itself can't. So agent-authored UI and the
+secret-holding trusted code must sit on opposite sides of a real boundary.
+
+### Two boundaries, not one
+
+Different threats, different mechanisms — keep them distinct:
+
+- **Confidentiality / integrity (k8s layer).** Haku must not _read_ the console's secrets
+  or logs, nor _change_ its trusted code/perimeter without a PR. The existing agent RBAC
+  is already shaped for this: `cluster-diagnostics-reader` is **secret-free** (no
+  `secrets`/`pods/log`/`configmaps` cluster-wide; logs only in infra namespaces), so a
+  console in its **own namespace** is invisible to Haku for free. Today the console runs
+  **in `haku-sandbox`** (`haku-sandbox-admin` = full CRUD), so Haku can already read its
+  git secret and exec its pod — **no boundary exists yet.** Splitting it out is the
+  prerequisite for holding any agent-forbidden secret.
+- **Confused deputy (browser layer).** Agent-authored UI runs in the **operator's
+  authenticated browser**, same-origin with the console API and holding the Authentik
+  session. So agent JS needn't _read_ a secret to abuse it — it can _call the privileged
+  endpoint_ with the operator's authority. Hiding the secret server-side does nothing
+  here. This is the boundary that actually constrains "Haku writes arbitrary TSX," and
+  it's enforced in the browser (origin isolation), not in k8s.
+
+### Trust zones
+
+- **`haku-console` (trusted, new namespace).** Ducktape code, Bazel→GHCR→Flux — so its
+  code, its **capability allowlist**, and its secrets change only by a merged PR. Holds
+  the launch bearer; exposes the API (below); owns and renders privileged controls.
+  Because it's **reviewed/released ducktape code, not agent-driven, it does not sit
+  behind the `haku-mitmproxy` fence** — that fence exists to contain _the agent_; the
+  console is contained by code review + the PR gate, so it gets ordinary
+  (least-privilege) egress to reach the Claude Code web API. No `haku` RoleBinding → Haku
+  can't read its secrets/logs or patch it.
+- **Agent-UI render/sandbox (untrusted by construction).** Serves and runs the UI Haku
+  authored into `haku-state`. Holds no secrets; may stay in `haku-sandbox` (Haku owning
+  it costs nothing). In the 1b target it's a **separate browser origin**.
+- **Haku agent (`haku-sandbox`).** Authors UI + content into `haku-state`; reads back
+  traces. No access to the trusted side.
+- **`haku-state` git.** The shared medium: Haku writes content+UI, the console writes
+  operator traces, Haku reduces them.
+
+### The API split
+
+Two tiers the console treats completely differently:
+
+- **Trace API (low-priv).** Records operator-expressed intent into `haku-state`. Exposed
+  to agent-authored UI. **Grants Haku nothing new** — it already writes `haku-state`
+  directly — so it's cheap and broad; its only real property is _consent fidelity_ (did
+  the operator genuinely express this?), a UX/trust concern, not a confidentiality one.
+- **Capability API (high-priv).** Anything using a console-only secret or acting on the
+  world (launch the routine). The teeth live here. Per capability: rendered/owned by the
+  **trusted shell** (never agent UI), fired only on a **genuine operator gesture** against
+  **trusted-rendered copy** (not agent free-text, so Haku can't phish consent),
+  CSRF-gated, and **audited** in the trusted namespace (the audit log doubles as the
+  "recent executions" view). The allowlist stays **tiny and PR-gated** — the standing
+  question per verb is "if Haku tricked the operator into firing this once, is the worst
+  case acceptable?" (Yes for _launch the routine_; a future _move money_ verb changes the
+  whole design.)
+
+### Phasing
+
+- **Phase 0 (prerequisite).** Split the trusted console into the `haku-console` namespace;
+  never put an agent-forbidden secret in `haku-sandbox`. Smallest, highest-leverage step;
+  stands alone.
+- **Phase 1 — declarative (1a).** Generalize today's `actions[]` discriminated union into
+  a richer **typed widget schema** (containers, inputs, selects, links, sub-pages) emitted
+  in `haku-state` and interpreted by a **trusted renderer** — _no agent JS executes_.
+  Introduce the trace/capability split and the shell-owned launch control. Delivers the
+  launch feature + the boundary with modest work.
+- **Phase 2 — free-form (1b, the destination).** Haku writes TSX/JS into `haku-state`; the
+  untrusted render origin transpiles it **at runtime** (never compiled into the trusted
+  bundle) and runs it in a **sandboxed cross-origin iframe** (`sandbox` without
+  `allow-same-origin`, strict CSP). It reaches the outside only via a `postMessage` bridge
+  to the shell, which exposes **only the trace tier**; capabilities stay shell-owned. The
+  widget schema becomes "the bridge API, declaratively"; free-form TSX is "the bridge API,
+  imperatively" — same boundary, two front-ends.
+
+### Server-side compute for agent UI
+
+When agent-authored UI needs a backend, it talks to a **Haku-owned backend running in
+`haku-sandbox`** (the agent's own perimeter), **separate from the console's** — one option
+among several. This keeps the rule clean: code Haku authors never runs with the console's
+secret privileges. The console backend stays the fixed, PR-gated capability/trace
+provider; arbitrary agent compute lives agent-side, behind the agent's own fence.
+
+### Open question — proving "this really came from the operator" to agent-side code
+
+Phase 2 wants agent-side code (or the trace it reduces) to trust that an action
+_genuinely_ came from the real operator, not from agent-authored UI forging it. Sketch
+(operator, 2026-06-26): an **Authentik-native** attestation — e.g. give Haku its own
+Authentik OIDC provider so the console can hand agent-side code a short-lived,
+operator-authenticated token (or sign the trace with an operator-attested claim) that
+agent-side code verifies. Open: exact shape (signed trace vs. a token the agent's backend
+validates), how it composes with _Haku is its own principal_, and whether it's worth it
+before free-form UI lands. Until then, consent fidelity rests on the trusted shell
+rendering canonical copy for anything that matters.
+
 ## Open questions
 
 - **Value scoring**: single curator-owned 0–100 plus deadline is probably enough; resist

--- a/haku/TODO.md
+++ b/haku/TODO.md
@@ -73,6 +73,31 @@ facade** in front (the Authentik OAuth facade is auth, not tool filtering — se
   `kubectl_sandbox_fixed_groups` `else` default with an explicit SA→group map
   once the claude-sandbox JWT path has soaked (`tf/gitops/agent-machine-access`).
 
+## Console — operator-facing dashboard
+
+The console design + action model live in `console/README.md`.
+
+- **Launch the claude-code-web routine from a click.** Add a console button that
+  starts a Haku Claude Code web session via the minted bearer (a Claude Code web
+  session API token). This is a **new shape** for the console: today the backend
+  "stays dumb" — every action is a click-overlay commit Haku reduces on its next
+  run — but a launch is an **immediate side-effecting POST** to the Claude Code
+  web session API, so it needs a real backend endpoint (e.g. `POST /api/launch`),
+  not the overlay/toggle path.
+  - **Perimeter (operator-owned — `cluster/k8s/haku/console/`).** The console
+    today writes only to the internal `haku-state` Forgejo and makes no external
+    calls; its only credential is `haku-state-git-write`. Launching adds (a) the
+    bearer as a **new console secret**, and (b) `haku-sandbox` mitmproxy **egress
+    to the Claude Code web API host**. Both widen the console's perimeter — land
+    them as operator-owned manifest changes.
+  - **Guardrails.** Gate to one in-flight run (disable / suppress duplicates while
+    a session is live) so a stray click can't fan out sessions. Authentik already
+    scopes the console to the operator.
+- **Show recent routine executions.** A read-only panel listing recent
+  claude-code-web sessions of the routine (status, start time, link to the session
+  in the Claude Code web UI), rendered alongside the launch button. Source: the
+  Claude Code web sessions API (list scope on the same / a companion token).
+
 ## Managed Agents runtimes — per-runtime TODOs
 
 Runtime-specific TODOs live with each runtime (the agent loop runs at Anthropic;

--- a/haku/console/README.md
+++ b/haku/console/README.md
@@ -3,10 +3,17 @@
 A small FastAPI service that serves Haku's dashboard as a **React single-page app
 over a JSON API**, reading items from a clone of the `haku-state` repo and writing
 operator actions back as git commits. It is the **Haku console**: an interface Haku
-builds for the operator to interact _with Haku_, running with **exactly Haku's
-perimeter** — read-only to the world, write only to the internal `haku-state`
-Forgejo, Authentik operator-only — and never anything more. It replaced the static
-nginx + git-sync dashboard (now retired).
+builds for the operator to interact _with Haku_, Authentik operator-only, read-only
+to the world, writing only to the internal `haku-state` Forgejo. It replaced the
+static nginx + git-sync dashboard (now retired).
+
+**Trust boundary:** the console is reviewed/released ducktape code, so it runs in
+its **own `haku-console` namespace** — deliberately _not_ `haku-sandbox`, the
+namespace Haku has full CRUD over. Haku therefore has no RBAC to read the console's
+secrets/logs or patch it, and the console sits outside the `haku-mitmproxy` egress
+fence (that fence keys on `haku-sandbox`). This is the confidentiality boundary that
+lets the console later hold secrets Haku may not read (e.g. the Claude Code web
+session bearer). See `haku/PLAN.md` → _The agent-authored console_.
 
 ## Action model — the backend stays dumb
 
@@ -26,7 +33,7 @@ item.
 ## Boundary
 
 - The backend (git layer, FastAPI JSON API) and frontend (React SPA) are **tested
-  ducktape code**, built Bazel→GHCR→Flux and deployed in the `haku-sandbox` namespace.
+  ducktape code**, built Bazel→GHCR→Flux and deployed in the `haku-console` namespace.
 - It is **driven by haku-state at runtime for content**: items (data) are read from
   the clone, so Haku evolves _what_ the dashboard shows without an image rebuild. The
   _look_ now lives in the bundle (a frontend rebuild changes it) — unlike the old
@@ -46,11 +53,13 @@ item.
 ## Perimeter / deploy
 
 Manifests live in `cluster/k8s/haku/console/` (operator-owned — the perimeter is not
-Haku's to change). Non-root, dropped caps, no service-account token; the only
-credential is the `haku-state-git-write` secret; egress is the existing
-`haku-sandbox` mitmproxy policy (no new NetworkPolicy). The image bundles the built
-SPA at `/app/web` (`HAKU_CONSOLE_STATIC_DIR`). Design + roadmap: `haku/PLAN.md` and
-the `haku-state` repo's `plans/dashboard-arm.md`.
+Haku's to change); the `haku-console` namespace itself is `cluster/k8s/haku/console-namespace/`.
+Non-root, dropped caps, no service-account token; the only credential is the
+`haku-state-git-write` secret (provisioned into `haku-console` by the
+`tf/gitops/haku-state` module). As trusted ducktape code in its own namespace it is
+**not** behind the `haku-mitmproxy` fence — it gets ordinary cluster egress. The image
+bundles the built SPA at `/app/web` (`HAKU_CONSOLE_STATIC_DIR`). Design + roadmap:
+`haku/PLAN.md` and the `haku-state` repo's `plans/dashboard-arm.md`.
 
 ## Test
 

--- a/tf/gitops/haku-state/main.tf
+++ b/tf/gitops/haku-state/main.tf
@@ -64,12 +64,21 @@ resource "forgejo_collaborator" "claude" {
   permission    = "read"
 }
 
-# Write credentials for scan runs, delivered to the haku-sandbox namespace so
-# the in-cluster scanner can clone/commit/push state.
+# Write credentials for the haku-state git consumers, delivered to:
+#   - haku-sandbox: in-cluster scan runs / the self-hosted worker.
+#   - haku-console: the console, which lives in its own trusted namespace (NOT
+#     haku-sandbox) so it can hold secrets Haku may not read. The git creds are
+#     not such a secret (Haku writes haku-state anyway), but the console needs
+#     them there. See haku/PLAN.md → "The agent-authored console".
+# Each target namespace is created by its own Flux kustomization, which the
+# wrapping forgejo/haku-state Kustomization dependsOn; this resource retries
+# until the namespace exists.
 resource "kubernetes_secret" "haku_state_git_write" {
+  for_each = toset(["haku-sandbox", "haku-console"])
+
   metadata {
     name      = "haku-state-git-write"
-    namespace = "haku-sandbox"
+    namespace = each.value
   }
 
   data = {


### PR DESCRIPTION
## What

Moves the Haku console out of the `haku-sandbox` namespace into a dedicated **`haku-console`** namespace.

## Why

The console ran in `haku-sandbox` — the namespace Haku has full CRUD over (`haku-sandbox-admin`) — so Haku could already read its secrets/logs and patch its Deployment. **No console↔agent boundary existed.** As reviewed/released ducktape code, the console belongs on the *trusted* side.

Landing it in its own namespace puts it:
- **outside Haku's RBAC** — the agent's cluster-wide read is secret-free and it has no RoleBinding into `haku-console`, so it can't read the console's secrets/logs or patch it; and
- **outside the `haku-mitmproxy` egress fence** — that `CiliumClusterwideNetworkPolicy` keys on the `haku-sandbox` namespace, so `haku-console` gets ordinary cluster egress (the console is contained by code review + the PR gate, not the agent fence).

This is **Phase 0** in `haku/PLAN.md → "The agent-authored console (free-form UI behind a trusted boundary)"` — the prerequisite that lets the console later hold secrets Haku may not read (e.g. the Claude Code web session bearer that launches the routine).

## Changes

- **`cluster/k8s/haku/console-namespace/`** — new namespace as its *own* Flux kustomization. Kept separate from the console deployment deliberately: the console needs the `haku-state-git-write` secret from the `haku-state` Terraform module, and that module needs the namespace to exist — folding the namespace into the console kustomization would create a dependency cycle.
- **`cluster/k8s/haku/console/`** — Deployment + Service → `haku-console`; dropped the now-irrelevant `haku-rbac` / `haku-mitmproxy` / `haku-namespace` deps; refreshed the perimeter comment.
- **`tf/gitops/haku-state`** — provisions `haku-state-git-write` into **both** `haku-sandbox` (the self-hosted worker still consumes it) and `haku-console` (the console), via `for_each`.
- **`cluster/k8s/forgejo/haku-state/flux-kustomization.yaml`** — also waits on `haku-console-namespace`.
- **`cluster/k8s/authentik/.../haku-dashboard-sso.yaml`** — proxy `internal_host` → `haku-console.haku-console.svc`. External host `haku.allegedly.works` unchanged.
- **Docs** — console README + the `haku/PLAN.md` design section + a `haku/TODO.md` Console section.

## Notes / risk

- **Brief dashboard blip** during rollout: Flux prunes the old `haku-sandbox` Deployment/Service and creates them in `haku-console`, and the Authentik proxy repoints. Same URL after.
- **TF state migration**: the `for_each` moves `kubernetes_secret.haku_state_git_write` from an unindexed address to `["haku-sandbox"]`/`["haku-console"]`, so the auto-apply destroys + recreates the (identical) `haku-sandbox` secret. Running pods are unaffected (env resolves at pod start); the self-hosted worker is suspended.
- Haku still reads/writes `haku-state` directly (not via the console), so the move is transparent to the agent.

## Validation

`pre-commit` (incl. `kubeconform`, `Checkov`, `tflint`) passes; `bbr build //tf/gitops/haku-state:haku-state` succeeds. Cluster wiring itself is verified by Flux reconcile, not tests.