### PR TITLE
haku: list both audiences explicitly (Authentik replaces aud, not merges)

### DIFF
--- a/tf/gitops/agent-machine-access/main.tf
+++ b/tf/gitops/agent-machine-access/main.tf
@@ -754,17 +754,18 @@ resource "authentik_property_mapping_provider_scope" "kubectl_machine_groups" {
     if username == "ak-kubectl-sandbox-client-credentials-client_credentials":
         return {"groups": ["kubectl-sandbox-users"]}
     if username == "haku-k8s":
-        # Multi-audience: the default aud is this provider's client_id
-        # (kubectl-sandbox-client-credentials), which kube-apiserver trusts for
-        # the direct kubeapi.allegedly.works path. Adding kubectl-passthrough-mcp
-        # lets the SAME token also authenticate to the passthrough kubectl MCP
-        # (its oauth_audience is kubectl-passthrough-mcp), which forwards the JWT
-        # to kube-apiserver. Consumer: tf/gitops/haku-cloud-agent — Haku's
-        # Anthropic-hosted managed agent reaches the cluster via that MCP with a
-        # static_bearer vault credential carrying this token. Authentik merges
-        # this aud with the provider default, so the minted token carries both;
-        # the authentik-jwt-rotation rotator asserts expected_audiences on mint.
-        return {"groups": ["haku"], "aud": "kubectl-passthrough-mcp"}
+        # Multi-audience. NOTE: Authentik REPLACES the token aud with whatever
+        # this mapping returns — it does NOT merge with the provider-default
+        # client_id — so every audience must be listed explicitly here, or the
+        # default (kubectl-sandbox-client-credentials) is dropped. That default
+        # keeps the direct kubeapi.allegedly.works path working; kubectl-passthrough-mcp
+        # lets the SAME token authenticate to the passthrough kubectl MCP (its
+        # oauth_audience is kubectl-passthrough-mcp), which forwards the JWT to
+        # kube-apiserver. Consumer: tf/gitops/haku-cloud-agent — Haku's Anthropic-
+        # hosted managed agent reaches the cluster via that MCP with a static_bearer
+        # vault credential carrying this token. The authentik-jwt-rotation rotator
+        # asserts both audiences on every mint.
+        return {"groups": ["haku"], "aud": ["kubectl-sandbox-client-credentials", "kubectl-passthrough-mcp"]}
     return {"groups": []}
   EXPR
 }


### PR DESCRIPTION
Follow-up fix to #2472.

The `haku-k8s` scope mapping returned a single `aud` (`kubectl-passthrough-mcp`) on the assumption Authentik would **merge** it with the provider-default client_id. It doesn't — and the rotator's `expected_audiences` assertion (added in #2472) **caught it**, refusing to commit a token that came back as `aud=[kubectl-passthrough-mcp]` only (which would have dropped `kubectl-sandbox-client-credentials` and broken Haku's direct `kubeapi.allegedly.works` access).

**Verified against Authentik source** (`authentik/providers/oauth2/id_token.py`, deployed v2026.2.1), not assumed:
- `aud: str | list[str] | None` — a list is a supported type.
- `to_dict()` sets `aud = provider.client_id` then `id_dict.update(self.claims)` → a scope mapping's `aud` **overwrites** the default (hence "replace, not merge").
- `to_access_token()` uses `to_dict()`, so the access token carries the overwritten `aud`.

Fix: return both audiences as a list from the mapping, so the minted token carries `aud=[kubectl-sandbox-client-credentials, kubectl-passthrough-mcp]` — keeping the direct kubeapi path **and** satisfying the passthrough MCP.

Tested: `bbr test //tf/gitops/agent-machine-access:{validate,lint,format}` ✅