### PR TITLE
haku/console: split writes into a trace tier under /api/trace (Phase 1a)

### DIFF
--- a/haku/console/BUILD.bazel
+++ b/haku/console/BUILD.bazel
@@ -33,12 +33,23 @@ py_library(
 )
 
 py_library(
+    name = "trace",
+    srcs = ["trace.py"],
+    deps = [
+        ":git_state",
+        ":models",
+        "@pypi//fastapi",
+    ],
+)
+
+py_library(
     name = "app",
     srcs = ["app.py"],
     deps = [
         ":config",
         ":git_state",
         ":models",
+        ":trace",
         "@pypi//fastapi",
         "@pypi//uvicorn",
     ],

--- a/haku/console/README.md
+++ b/haku/console/README.md
@@ -20,15 +20,21 @@ session bearer). See `haku/PLAN.md` → _The agent-authored console_.
 The console never interprets what an action _means_. Each item Haku writes can carry
 `actions[]` (e.g. _Snooze 30d_, _Draft the email_, _Research deeper_); the dashboard
 renders each `command` action as a **click/un-click toggle**. Clicking records an
-overlay file `clicks/<item-id>/<action-id>` (`POST /api/items/<id>/actions/<aid>`),
+overlay file `clicks/<item-id>/<action-id>` (`PUT /api/trace/items/<id>/actions/<aid>`),
 un-clicking removes it (`DELETE`) — each a commit by the `haku-console` identity.
 **Haku reduces the overlay on its next run**: it reads the clicked actions, carries
 out each one's intent, and clears the click. So new verbs need no backend change —
 Haku invents the action and its meaning; the console only records the click.
 `claude_handoff` actions are stateless `claude.ai/new` deep-links (no commit).
-Feedback — the global box, or a per-item box on each card — appends to `intake/`;
-per-item notes are tagged with the item id, which Haku reduces as feedback on that
-item.
+Feedback — the global box, or a per-item box on each card — appends to `intake/`
+(`POST /api/trace/feedback`); per-item notes are tagged with the item id, which Haku
+reduces as feedback on that item.
+
+These writes are the **trace tier** (`trace.py`): they only record operator-expressed
+intent into haku-state, which Haku already owns, so they're safe to expose to
+agent-authored UI. Privileged actions that use console-only secrets or act on the
+world will live in a separate, gated **capability tier**. See `haku/PLAN.md` → _The
+agent-authored console_.
 
 ## Boundary
 
@@ -43,7 +49,8 @@ item.
 
 | Path               | Role                                                                                                                                                                                                                           |
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `app.py`           | FastAPI `create_app` + lifespan (clone + background pull loop). JSON API: `GET /api/dashboard`, `POST`/`DELETE /api/items/{id}/actions/{aid}`, `POST /api/feedback`, `GET /healthz`; serves the SPA (`StaticFiles`) otherwise. |
+| `app.py`           | FastAPI `create_app` + lifespan (clone + background pull loop). Read endpoints (`GET /api/dashboard`, `GET /healthz`), mounts the trace router, serves the SPA (`StaticFiles`) otherwise.                                      |
+| `trace.py`         | Trace-tier router (`/api/trace/*`): the overlay toggle (`PUT`/`DELETE /api/trace/items/{id}/actions/{aid}`) and `POST /api/trace/feedback`. Low-privilege haku-state writes; reads `git_state` off `app.state`.                |
 | `git_state.py`     | pygit2 clone of haku-state; `reconcile` (fetch + hard-reset), `commit_push` with retry, `read_items`, and the clicks/-overlay + feedback writers. Talks to the cluster-internal **plaintext-HTTP** Forgejo (no TLS/CA needed). |
 | `models.py`        | Pydantic `Item` (discriminated-union `action` + `actions[]`) and the `/api` request/response models.                                                                                                                           |
 | `config.py`        | Env settings (`HAKU_CONSOLE_*`).                                                                                                                                                                                               |

--- a/haku/console/app.py
+++ b/haku/console/app.py
@@ -1,11 +1,13 @@
 """FastAPI app for the Haku console: JSON API + same-origin React SPA.
 
 The dashboard is a React single-page app (static bundle) served same-origin with a
-JSON API under ``/api``. The write endpoints are **generic**: clicking an action
-records ``clicks/<item>/<action>`` and un-clicking removes it — the backend never
-interprets what an action *means* (snooze, reject, research…); Haku reduces the
-clicks overlay on its next run. Free-form feedback (global, or tagged to an item)
-appends to ``intake/``.
+JSON API under ``/api``. Writes are split into tiers (see `haku/PLAN.md` → _The
+agent-authored console_): the **trace tier** (`haku.console.trace`) only records
+operator-expressed intent into haku-state — clicks (the overlay Haku reduces) and
+feedback — and is the low-privilege surface safe for agent-authored UI. The
+high-privilege **capability tier** (console-only secrets, real-world side effects)
+will be a separate, gated router. ``app.py`` itself serves the read endpoints and
+the SPA.
 """
 
 from __future__ import annotations
@@ -19,9 +21,10 @@ import uvicorn
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 
+from haku.console import trace
 from haku.console.config import Settings
 from haku.console.git_state import GitState
-from haku.console.models import Click, DashboardResponse, FeedbackRequest
+from haku.console.models import Click, DashboardResponse
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +53,8 @@ def create_app(settings: Settings, *, git_state: GitState) -> FastAPI:
                 await pull
 
     app = FastAPI(title="Haku console", lifespan=lifespan)
+    # Routers read git_state off app.state (see haku.console.trace).
+    app.state.git_state = git_state
 
     @app.get("/healthz")
     async def healthz() -> dict[str, str]:
@@ -65,26 +70,7 @@ def create_app(settings: Settings, *, git_state: GitState) -> FastAPI:
         clicked = [Click(item_id=item_id, action_id=action_id) for item_id, action_id in sorted(clicks)]
         return DashboardResponse(scan_time=scan_time, items=items, clicks=clicked)
 
-    # Generic action recording: the backend never interprets an action's meaning — it
-    # only records (POST) or retracts (DELETE) the click. Haku reads the clicks/ overlay
-    # on its next run and carries out each action's intent.
-    @app.post("/api/items/{item_id}/actions/{action_id}")
-    async def click(item_id: str, action_id: str) -> dict[str, str]:
-        async with git_state.lock:
-            await asyncio.to_thread(git_state.set_click, item_id, action_id)
-        return {"status": "clicked"}
-
-    @app.delete("/api/items/{item_id}/actions/{action_id}")
-    async def unclick(item_id: str, action_id: str) -> dict[str, str]:
-        async with git_state.lock:
-            await asyncio.to_thread(git_state.clear_click, item_id, action_id)
-        return {"status": "cleared"}
-
-    @app.post("/api/feedback")
-    async def feedback(req: FeedbackRequest) -> dict[str, str]:
-        async with git_state.lock:
-            await asyncio.to_thread(git_state.write_feedback, req.text, req.item_id)
-        return {"status": "ok"}
+    app.include_router(trace.router)
 
     # The built React SPA is served same-origin for everything else. Mounted last so the
     # API routes above take precedence; left unmounted in tests (static_dir unset).

--- a/haku/console/frontend/client.ts
+++ b/haku/console/frontend/client.ts
@@ -18,20 +18,20 @@ export async function fetchDashboard(): Promise<DashboardResponse> {
 }
 
 export async function clickAction(itemId: string, actionId: string): Promise<void> {
-  const { error } = await api.POST("/api/items/{item_id}/actions/{action_id}", {
+  const { error } = await api.PUT("/api/trace/items/{item_id}/actions/{action_id}", {
     params: { path: { item_id: itemId, action_id: actionId } },
   });
   if (error) throw new Error("Failed to record click");
 }
 
 export async function unclickAction(itemId: string, actionId: string): Promise<void> {
-  const { error } = await api.DELETE("/api/items/{item_id}/actions/{action_id}", {
+  const { error } = await api.DELETE("/api/trace/items/{item_id}/actions/{action_id}", {
     params: { path: { item_id: itemId, action_id: actionId } },
   });
   if (error) throw new Error("Failed to retract click");
 }
 
 export async function sendFeedback(text: string, itemId?: string): Promise<void> {
-  const { error } = await api.POST("/api/feedback", { body: { text, item_id: itemId } });
+  const { error } = await api.POST("/api/trace/feedback", { body: { text, item_id: itemId } });
   if (error) throw new Error("Failed to send feedback");
 }

--- a/haku/console/test_app.py
+++ b/haku/console/test_app.py
@@ -30,7 +30,7 @@ def test_dashboard_lists_seeded_items(client, seeded) -> None:
 
 def test_click_records_overlay(client, seeded) -> None:
     item_id = seeded.ids[0]
-    assert client.post(f"/api/items/{item_id}/actions/snooze").json() == {"status": "clicked"}
+    assert client.put(f"/api/trace/items/{item_id}/actions/snooze").json() == {"status": "clicked"}
     assert {"item_id": item_id, "action_id": "snooze"} in client.get("/api/dashboard").json()["clicks"]
     assert (item_id, "snooze") in seeded.git_state.read_clicks()
     tip = _remote_tip(seeded.bare)
@@ -40,15 +40,15 @@ def test_click_records_overlay(client, seeded) -> None:
 
 def test_unclick_retracts_overlay(client, seeded) -> None:
     item_id = seeded.ids[0]
-    client.post(f"/api/items/{item_id}/actions/snooze")
-    assert client.delete(f"/api/items/{item_id}/actions/snooze").json() == {"status": "cleared"}
+    client.put(f"/api/trace/items/{item_id}/actions/snooze")
+    assert client.delete(f"/api/trace/items/{item_id}/actions/snooze").json() == {"status": "cleared"}
     assert seeded.git_state.read_clicks() == set()
     assert client.get("/api/dashboard").json()["clicks"] == []
     assert _remote_tip(seeded.bare).message == f"console: unclick snooze on {item_id}"
 
 
 def test_feedback_appends_intake_note(client, seeded) -> None:
-    assert client.post("/api/feedback", json={"text": "please prioritize taxes"}).json() == {"status": "ok"}
+    assert client.post("/api/trace/feedback", json={"text": "please prioritize taxes"}).json() == {"status": "ok"}
     tip = _remote_tip(seeded.bare)
     assert tip.author.name == "haku-console"
     assert tip.message == "console: feedback"
@@ -59,7 +59,7 @@ def test_feedback_appends_intake_note(client, seeded) -> None:
 
 def test_item_feedback_appends_tagged_intake_note(client, seeded) -> None:
     item_id = seeded.ids[0]
-    assert client.post("/api/feedback", json={"text": "this one is urgent", "item_id": item_id}).json() == {
+    assert client.post("/api/trace/feedback", json={"text": "this one is urgent", "item_id": item_id}).json() == {
         "status": "ok"
     }
     tip = _remote_tip(seeded.bare)

--- a/haku/console/trace.py
+++ b/haku/console/trace.py
@@ -1,0 +1,52 @@
+"""Trace tier: operator-expressed intent recorded into haku-state.
+
+These endpoints only write to the haku-state repo — the `clicks/` overlay Haku
+reduces, and feedback notes in `intake/`. They grant Haku nothing it can't already
+do (it owns haku-state), so this is the **low-privilege** tier, safe to expose to
+agent-authored UI. The **high-privilege** capability tier (console-only secrets,
+real-world side effects) is a separate router, gated and audited; see
+`haku/PLAN.md` → _The agent-authored console_.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Annotated, cast
+
+from fastapi import APIRouter, Depends, Request
+
+from haku.console.git_state import GitState
+from haku.console.models import FeedbackRequest
+
+
+def _git_state(request: Request) -> GitState:
+    # app.state is Starlette's untyped (Any) container; create_app puts the GitState there.
+    return cast(GitState, request.app.state.git_state)
+
+
+GitStateDep = Annotated[GitState, Depends(_git_state)]
+
+router = APIRouter(prefix="/api/trace", tags=["trace"])
+
+
+# Recording the overlay is an idempotent set (the marker either exists or not), so
+# the verb is PUT, not POST. Haku reduces the clicks/ overlay on its next run.
+@router.put("/items/{item_id}/actions/{action_id}")
+async def set_click(item_id: str, action_id: str, git_state: GitStateDep) -> dict[str, str]:
+    async with git_state.lock:
+        await asyncio.to_thread(git_state.set_click, item_id, action_id)
+    return {"status": "clicked"}
+
+
+@router.delete("/items/{item_id}/actions/{action_id}")
+async def clear_click(item_id: str, action_id: str, git_state: GitStateDep) -> dict[str, str]:
+    async with git_state.lock:
+        await asyncio.to_thread(git_state.clear_click, item_id, action_id)
+    return {"status": "cleared"}
+
+
+@router.post("/feedback")
+async def feedback(req: FeedbackRequest, git_state: GitStateDep) -> dict[str, str]:
+    async with git_state.lock:
+        await asyncio.to_thread(git_state.write_feedback, req.text, req.item_id)
+    return {"status": "ok"}


### PR DESCRIPTION
## What

Reframes the console's write endpoints as the low-privilege **trace tier**, moving them under `/api/trace/`. Pure restructure — no change to what lands in `haku-state`.

| Before | After |
|---|---|
| `POST /api/items/{id}/actions/{aid}` | `PUT /api/trace/items/{id}/actions/{aid}` |
| `DELETE /api/items/{id}/actions/{aid}` | `DELETE /api/trace/items/{id}/actions/{aid}` |
| `POST /api/feedback` | `POST /api/trace/feedback` |

(Click set moves `POST`→`PUT` since writing the overlay marker is idempotent.)

## Why

This is **Phase 1a** of `haku/PLAN.md → "The agent-authored console"`. The trace tier only records operator-expressed intent into `haku-state`, which Haku already owns — so it grants the agent nothing new and is the surface that's safe to expose to agent-authored UI. The teeth (console-only secrets, real-world side effects like launching the routine) will live in a separate, gated **capability tier** added once the launch bearer lands in the `haku-console` namespace.

Splitting now keeps the boundary legible in the code: a `grep` for "what touches a privileged secret" will return exactly the capability module, never the trace router.

## Changes

- **`haku/console/trace.py`** (new) — `APIRouter(prefix="/api/trace")` with the overlay toggle + feedback; reads `git_state` off `app.state`.
- **`app.py`** — keeps only the read endpoints (`/api/dashboard`, `/healthz`) + the SPA mount; includes the trace router; stashes `git_state` on `app.state`.
- **`client.ts`**, **`test_app.py`**, **`README.md`**, **`BUILD.bazel`** updated.

## Validation

`bbr test //haku/console/...` green (backend `test_app`, `markdown_test`, and `tsc_test`). The generated OpenAPI schema + `tsc_test` confirm the frontend `client.ts` paths match the new routes. `bbr build //haku/console:server_image` succeeds.

## Notes

- The frontend client function signatures are unchanged, so callers in `task.tsx`/`feedback.tsx` are untouched.
- No cluster/manifest changes — this is app code only, independent of #2473 (the namespace split, already merged).