### PR TITLE
haku/console: land the routine-launch bearer as a SOPS secret in haku-console

### DIFF
--- a/cluster/k8s/haku/console/flux-kustomization.yaml
+++ b/cluster/k8s/haku/console/flux-kustomization.yaml
@@ -13,6 +13,10 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age-cluster-secrets
   dependsOn:
     - name: haku-console-namespace # the console's own trusted namespace (not haku-sandbox)
     - name: haku-state # provisions haku-state-git-write into the haku-console namespace

--- a/cluster/k8s/haku/console/kustomization.yaml
+++ b/cluster/k8s/haku/console/kustomization.yaml
@@ -2,4 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - deployment.yaml
+  - routine-launch-token.sops.yaml
   - service.yaml

--- a/cluster/k8s/haku/console/routine-launch-token.sops.yaml
+++ b/cluster/k8s/haku/console/routine-launch-token.sops.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: haku-routine-launch-token
+    namespace: haku-console
+    annotations:
+        description: 'Bearer (sk-ant-oat01-…) that fires the Haku "claude-code-web routine" — a Claude Code web session that runs the Haku loop. The console''s (forthcoming) capability tier POSTs to the routine''s public fire URL with this token to launch a run on operator click. Public fire URL: https://api.anthropic.com/v1/claude_code/routines/trig_0158pCMU1XBhoALBWikwSyK4/fire Deliberately lives in the haku-console namespace (NOT haku-sandbox) so Haku itself cannot read it — this is the secret the trust boundary exists to hold. Rotate by minting a new routine trigger token in the Anthropic Console and re-`sops`-ing this file. See haku/PLAN.md → "The agent-authored console" (capability tier).'
+type: Opaque
+stringData:
+    token: ENC[AES256_GCM,data:w0arGochPwpuJ9CKTDlE5nmkLwCuFj1wZZh22AbdRa1U+Q9FsDRiuk4v7udeZC9qT51h2N4fRV86aXOAyF3gQlaFHXIzRbb00KVpBnBLEqDDTeucRQng1QWvRt7Yk+QZM++emBKTGPMqGLaq,iv:5e/AmPgvp/eyFgOkHhuGg0Jnb0cgcNWwkthd4N3mh9M=,tag:i8NRemfKjjmReH4Iaoxmng==,type:str]
+sops:
+    age:
+        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1UXUrcjdKdkxzQ3lDQUZs
+            T1FPMmkxUlhlSVdtYzFPZVNBcWQ0elBCWTFBClZlUW5pR2RRMmZ5SUFhejF5L0NH
+            WmU4dVlKNFpFekRRcGJJZm1VVUNZUmsKLS0tIEhJRUZEN3lBOFNYQ2Y3R1ByUGFR
+            cG5SSDQraEhOZktIYXd5TWVqSUs0UEEKeLa2UR2hyujXxqKTh7s/0Lfk+svU3rxL
+            TaMQRkNKnDbVdWtYH79QATv2iGB7uVqYmmWnr1hkXxhWXw9Di3w/fA==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1nywlwepsyfxvyhqwkjquzz02nmus65gf6qewfjju4alym8f7se5qnua8na
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA5eldQRE9zVzY1Rk1HcjRl
+            K3UxMnNGNGxMQzFucFY4OGVZQVpWVGtJWlZjCi8rYXh1NUZwSTlYTStYejR3MDlv
+            QTdVa1pqNHA3eTFwaTN4N3B6SlNOYWcKLS0tIGRiSEZZOGhaN010R3M4R2pBUFZB
+            QTFqSXRHV1R0bktSYkRzL3lhTjRRa2MKRptS2V8uaPeK9x6yy9r4F6sHrpo2ZJPl
+            XuJWPmHKSIWUGDLbq+Eiw+sjYJzuMQHkP/eEadUmxrPYsiXtWwf3eQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-06-26T08:37:24Z"
+    mac: ENC[AES256_GCM,data:D9ciQSZWA6SacEeJcPnvd50F6lHbbbOLUBt2Xkst9qt/aYkCCumHG8PNx8rP3WrqxstI6mPYSQw6ON8TIU3oMt6IvUCuCOaYE6VCfuimPfFEUPRgtNBFdNhwh1S+wiJ1WQaETyeApVr8TRavLoQHCIsR5UUkI2Gd6Os2GKkJY3I=,iv:+EyuVKME96vZ2HLGI0DMRwYhK4HG/MNnYSD7wYZlsfg=,tag:LvkJdLmyIxRJlONPxLbB+w==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.1


### PR DESCRIPTION
## What

Adds `haku-routine-launch-token` (a SOPS-encrypted Secret in the **`haku-console`** namespace): the bearer that fires the Haku "claude-code-web routine" via its public Anthropic fire URL.

## Why

This is the secret the trust boundary built in #2473 exists to hold. It lives in `haku-console`, **not** `haku-sandbox`, so Haku itself has no RBAC to read it — exactly the property we wanted before the console could hold a token Haku can't see.

Prerequisite for the **capability tier** (`haku/PLAN.md → "The agent-authored console"`): the forthcoming `POST /api/capabilities/launch-routine` handler reads this token and POSTs to the fire URL on operator click.

## Changes

- **`routine-launch-token.sops.yaml`** — the token in `stringData` (encrypted to `admin` + `cluster-secrets` via the catch-all `cluster/k8s/*.sops.yaml` rule; no `.sops.yaml` change needed). The **public** fire URL + rotation instructions live in a clear-text `description` annotation (`metadata` isn't in the encrypted set), matching the `haku-environment-key` pattern.
- **`flux-kustomization.yaml`** — gains `decryption: { provider: sops, secretRef: sops-age-cluster-secrets }` so Flux can decrypt+apply it (the console kustomization had no secrets before).
- **`kustomization.yaml`** — lists the secret.

## Notes

- **Not yet consumed.** The deployment env wiring + `Settings` field + the capability handler land with the capability-tier PR. This PR just gets the secret safely into the right namespace.
- The token was rotated into this secret directly; the plaintext shared out-of-band should be considered burned (rotate via the Anthropic Console + re-`sops` per the annotation when needed).
- Validation: `pre-commit` (incl. `kubeconform`, the SOPS-encryption check, and the cluster validator — no orphan complaint) passes.