### PR TITLE
agents: add kubectl-machine-mcp (passthrough MCP for the machine issuer)

### DIFF
--- a/cluster/k8s/agents/authentik-jwt-rotation/rotations.yaml
+++ b/cluster/k8s/agents/authentik-jwt-rotation/rotations.yaml
@@ -15,16 +15,13 @@ rotations:
     scopes: openid profile email groups
     credential_mode: user_password
     expected_group: haku
-    # Multi-audience: the provider default aud (kubectl-sandbox-client-credentials)
-    # keeps the direct kubeapi.allegedly.works path working; kubectl-passthrough-mcp
-    # lets the same token authenticate to the passthrough kubectl MCP that Haku's
-    # Anthropic-hosted managed agent uses (tf/gitops/haku-cloud-agent). The audience
-    # is injected by the haku-k8s branch of the kubectl_machine_groups scope mapping
-    # in tf/gitops/agent-machine-access. Listing it here makes the rotator assert it
-    # on every mint and force a re-mint if a stored token doesn't carry it yet.
+    # Assert the token carries the audience kubectl-machine-mcp validates (the
+    # provider-default aud = its client_id). Haku's Anthropic-hosted managed agent
+    # reaches the cluster through that passthrough MCP with a static_bearer vault
+    # credential carrying this token (tf/gitops/haku-cloud-agent); the same aud also
+    # keeps the direct kubeapi.allegedly.works path working.
     expected_audiences:
       - kubectl-sandbox-client-credentials
-      - kubectl-passthrough-mcp
     credentials_dir: /var/run/secrets/authentik/haku-k8s
     sops_file: secrets/haku-k8s-jwt.yaml
     token_field: jwt

--- a/cluster/k8s/agents/kubectl-machine-mcp/app/configmap.yaml
+++ b/cluster/k8s/agents/kubectl-machine-mcp/app/configmap.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubectl-machine-mcp-public
+  namespace: kubectl-machine-mcp
+data:
+  00-public.toml: |
+    require_oauth = true
+    # Machine (client_credentials) issuer — the non-interactive sibling of
+    # kubectl-passthrough-mcp, which trusts the PKCE/interactive issuer. Tokens
+    # minted by the kubectl-sandbox-client-credentials provider (authentik-jwt-rotation
+    # CronJob) validate here; the caller's own group claim drives RBAC. haku-k8s
+    # maps to oidc-ksbx-groups:haku, the generic machine principal to
+    # kubectl-sandbox-users (see tf/gitops/agent-machine-access kubectl_machine_groups).
+    authorization_url = "https://auth.allegedly.works/application/o/kubectl-sandbox-client-credentials/"
+    oauth_audience = "kubectl-sandbox-client-credentials"
+    # Passthrough forwards the caller's JWT as-is to kube-apiserver. No STS
+    # credentials needed because there's no token exchange on this server.
+    cluster_auth_mode = "passthrough"
+    cluster_provider_strategy = "in-cluster"
+    server_url = "https://kubectl-machine-mcp.allegedly.works"
+    port = "8080"

--- a/cluster/k8s/agents/kubectl-machine-mcp/app/deployment.yaml
+++ b/cluster/k8s/agents/kubectl-machine-mcp/app/deployment.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubectl-machine-mcp
+  namespace: kubectl-machine-mcp
+  labels:
+    app.kubernetes.io/name: kubectl-machine-mcp
+  annotations:
+    description: "containers/kubernetes-mcp-server in OAuth passthrough mode, trusting the kubectl-sandbox-client-credentials (machine) issuer. Caller's Authentik JWT is forwarded directly to kube-apiserver; server itself is unprivileged."
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kubectl-machine-mcp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kubectl-machine-mcp
+    spec:
+      serviceAccountName: kubectl-machine-mcp
+      # Prevent kubernetes-mcp-server from picking up *_SERVICE_* env vars injected
+      # by kube for same-namespace Services — they could confuse config parsing.
+      enableServiceLinks: false
+      containers:
+        - name: server
+          # CLEANUP: switch back to ghcr.io/containers/kubernetes-mcp-server:<version>
+          # when upstream releases a version with the /.well-known/oauth-authorization-server
+          # 404 fallback (currently pinned at our fork build via third_party/kubernetes-mcp-server-pin.txt).
+          image: ghcr.io/agentydragon/kubernetes-mcp-server:devel-20260613012509-edec06a # {"$imagepolicy": "flux-system:kubernetes-mcp-server"}
+          imagePullPolicy: IfNotPresent
+          args:
+            # Config is public-only — token validation uses the issuer's published
+            # JWKS (no client secret), and passthrough mode does no token exchange.
+            - --config=/etc/kubectl-machine-mcp/00-public.toml
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: public
+              mountPath: /etc/kubectl-machine-mcp/00-public.toml
+              subPath: 00-public.toml
+              readOnly: true
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "256Mi"
+              cpu: "200m"
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 20
+      volumes:
+        - name: public
+          configMap:
+            name: kubectl-machine-mcp-public

--- a/cluster/k8s/agents/kubectl-machine-mcp/app/flux-kustomization.yaml
+++ b/cluster/k8s/agents/kubectl-machine-mcp/app/flux-kustomization.yaml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kubectl-machine-mcp
+  namespace: flux-system
+spec:
+  suspend: false
+  retryInterval: 1m
+  interval: 10m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./cluster/k8s/agents/kubectl-machine-mcp/app
+  prune: true
+  wait: true
+  healthChecks:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: kubectl-machine-mcp
+      namespace: kubectl-machine-mcp
+  dependsOn:
+    - name: gateway
+    # The kubectl-sandbox-client-credentials Authentik provider (whose OIDC
+    # discovery + JWKS this server validates against) is created by this TF.
+    - name: agent-machine-access-tf

--- a/cluster/k8s/agents/kubectl-machine-mcp/app/httproute.yaml
+++ b/cluster/k8s/agents/kubectl-machine-mcp/app/httproute.yaml
@@ -1,0 +1,25 @@
+# HTTPRoute for kubectl-machine-mcp.
+# NOT behind the Authentik outpost — the MCP server validates Bearer tokens
+# itself (JWKS from the kubectl-sandbox-client-credentials issuer) using
+# containers/kubernetes-mcp-server's built-in OAuth2/OIDC support. Public so
+# Anthropic-hosted managed agents (e.g. Haku) can reach it with a vault-injected
+# static_bearer token; the token is the only secret, and it carries the caller's
+# own RBAC group.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: kubectl-machine-mcp
+  namespace: kubectl-machine-mcp
+spec:
+  parentRefs:
+    - name: cluster-gateway
+      namespace: gateway-system
+  hostnames:
+    - "kubectl-machine-mcp.allegedly.works"
+  rules:
+    - backendRefs:
+        - name: kubectl-machine-mcp
+          port: 8080
+      timeouts:
+        request: "60s"
+        backendRequest: "60s"

--- a/cluster/k8s/agents/kubectl-machine-mcp/app/kustomization.yaml
+++ b/cluster/k8s/agents/kubectl-machine-mcp/app/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - serviceaccount.yaml
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml
+  - httproute.yaml

--- a/cluster/k8s/agents/kubectl-machine-mcp/app/service.yaml
+++ b/cluster/k8s/agents/kubectl-machine-mcp/app/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubectl-machine-mcp
+  namespace: kubectl-machine-mcp
+spec:
+  selector:
+    app.kubernetes.io/name: kubectl-machine-mcp
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+  type: ClusterIP

--- a/cluster/k8s/agents/kubectl-machine-mcp/app/serviceaccount.yaml
+++ b/cluster/k8s/agents/kubectl-machine-mcp/app/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubectl-machine-mcp
+  namespace: kubectl-machine-mcp
+  annotations:
+    description: "Service account for kubectl-machine-mcp pod. No k8s permissions — server uses the caller's passthrough OAuth token for kube-apiserver calls."

--- a/cluster/k8s/agents/kubectl-machine-mcp/namespace/flux-kustomization.yaml
+++ b/cluster/k8s/agents/kubectl-machine-mcp/namespace/flux-kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kubectl-machine-mcp-namespace
+  namespace: flux-system
+spec:
+  retryInterval: 1m
+  interval: 10m
+  timeout: 1m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./cluster/k8s/agents/kubectl-machine-mcp/namespace
+  prune: false
+  wait: true

--- a/cluster/k8s/agents/kubectl-machine-mcp/namespace/kustomization.yaml
+++ b/cluster/k8s/agents/kubectl-machine-mcp/namespace/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml

--- a/cluster/k8s/agents/kubectl-machine-mcp/namespace/namespace.yaml
+++ b/cluster/k8s/agents/kubectl-machine-mcp/namespace/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubectl-machine-mcp
+  labels:
+    goldilocks.fairwinds.com/enabled: "false"

--- a/cluster/k8s/authentik/app/networkpolicy.yaml
+++ b/cluster/k8s/authentik/app/networkpolicy.yaml
@@ -74,6 +74,8 @@ spec:
             k8s:io.kubernetes.pod.namespace: kubectl-sandbox-mcp
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: kubectl-passthrough-mcp
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kubectl-machine-mcp
       toPorts:
         - ports:
             - port: "9000"

--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -83,6 +83,8 @@ resources:
   - agents/kubectl-passthrough-mcp/app/flux-kustomization.yaml
   - agents/kubectl-sandbox-mcp/namespace/flux-kustomization.yaml
   - agents/kubectl-sandbox-mcp/app/flux-kustomization.yaml
+  - agents/kubectl-machine-mcp/namespace/flux-kustomization.yaml
+  - agents/kubectl-machine-mcp/app/flux-kustomization.yaml
   - agents/manifold-mcp/namespace/flux-kustomization.yaml
   - agents/manifold-mcp/app/flux-kustomization.yaml
   - agents/plaid-mcp/namespace/flux-kustomization.yaml

--- a/tf/gitops/agent-machine-access/main.tf
+++ b/tf/gitops/agent-machine-access/main.tf
@@ -754,18 +754,7 @@ resource "authentik_property_mapping_provider_scope" "kubectl_machine_groups" {
     if username == "ak-kubectl-sandbox-client-credentials-client_credentials":
         return {"groups": ["kubectl-sandbox-users"]}
     if username == "haku-k8s":
-        # Multi-audience. NOTE: Authentik REPLACES the token aud with whatever
-        # this mapping returns — it does NOT merge with the provider-default
-        # client_id — so every audience must be listed explicitly here, or the
-        # default (kubectl-sandbox-client-credentials) is dropped. That default
-        # keeps the direct kubeapi.allegedly.works path working; kubectl-passthrough-mcp
-        # lets the SAME token authenticate to the passthrough kubectl MCP (its
-        # oauth_audience is kubectl-passthrough-mcp), which forwards the JWT to
-        # kube-apiserver. Consumer: tf/gitops/haku-cloud-agent — Haku's Anthropic-
-        # hosted managed agent reaches the cluster via that MCP with a static_bearer
-        # vault credential carrying this token. The authentik-jwt-rotation rotator
-        # asserts both audiences on every mint.
-        return {"groups": ["haku"], "aud": ["kubectl-sandbox-client-credentials", "kubectl-passthrough-mcp"]}
+        return {"groups": ["haku"]}
     return {"groups": []}
   EXPR
 }


### PR DESCRIPTION
Enables Haku's Anthropic-hosted managed agent to reach the cluster via a kubectl MCP using a provider-modelable `static_bearer` credential.

## Problem
The existing `kubectl-passthrough-mcp` trusts the `kubectl-passthrough-mcp` issuer (a `public`/PKCE provider for interactive humans). Haku's token is minted by `kubectl-sandbox-client-credentials` (machine grant) — a different issuer it can't change. Verified live (401), and confirmed via kube-apiserver `AuthenticationConfiguration` that each MCP is bound to exactly one issuer+audience. So the earlier multi-aud change (#2472/#2474) was necessary-but-insufficient — the shared MCP rejects on `iss` regardless of `aud`.

## Fix
Add `kubectl-machine-mcp`: a second `kubernetes-mcp-server` (passthrough mode) whose `authorization_url`/`oauth_audience` point at the **machine** (`kubectl-sandbox-client-credentials`) issuer. Generic, not haku-specific — any machine principal from that provider validates and gets its own RBAC (`haku-k8s` → `oidc-ksbx-groups:haku`). Public at `kubectl-machine-mcp.allegedly.works`; the bearer is the only secret and carries the caller's own group.

**Pre-flight verified** (not assumed): the `kubectl-sandbox-client-credentials` OIDC discovery + JWKS `kid` validate haku's existing token.

Since the machine MCP uses the provider-default audience, the multi-aud scope-mapping injection is unnecessary → **reverted to groups-only**. The rotator's `expected_audiences` guard stays, now asserting the single audience the MCP needs.

## Contents
- `cluster/k8s/agents/kubectl-machine-mcp/{namespace,app}/` — new MCP instance
- authentik CNP: allow the new namespace to reach OIDC discovery (port 9000)
- root kustomization wiring; `agent-machine-access` revert; `rotations.yaml` aud guard

## Tested
`bbr test //tf/gitops/agent-machine-access:{validate,lint,format}` ✅ · `bbr test //cluster/validation/...` (13/13) ✅ · pre-commit (kubeconform/checkov/tflint) ✅

## Gate after apply
`curl` haku's token against `https://kubectl-machine-mcp.allegedly.works/mcp` → expect **HTTP 200 + tools/list** (vs 401 on the shared server). Then Stage 2 (provider pin + `tf/gitops/haku-cloud-agent`).