### PR TITLE
haku/console: add the capability tier (CSRF-gated launch-routine)

### DIFF
--- a/cluster/k8s/haku/console/deployment.yaml
+++ b/cluster/k8s/haku/console/deployment.yaml
@@ -67,6 +67,16 @@ spec:
                 secretKeyRef:
                   name: haku-state-git-write
                   key: password
+            # Capability tier: the launch-routine action. The fire URL is public
+            # (clear text); the bearer comes from the haku-console-only secret so
+            # Haku can't read it. See haku/PLAN.md → "The agent-authored console".
+            - name: HAKU_CONSOLE_LAUNCH_ROUTINE__URL
+              value: https://api.anthropic.com/v1/claude_code/routines/trig_0158pCMU1XBhoALBWikwSyK4/fire
+            - name: HAKU_CONSOLE_LAUNCH_ROUTINE__TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: haku-routine-launch-token
+                  key: token
           resources:
             requests:
               cpu: 50m

--- a/haku/PLAN.md
+++ b/haku/PLAN.md
@@ -189,14 +189,12 @@ Two tiers the console treats completely differently:
 
 ### Phasing
 
-- **Phase 0 (prerequisite).** Split the trusted console into the `haku-console` namespace;
-  never put an agent-forbidden secret in `haku-sandbox`. Smallest, highest-leverage step;
-  stands alone.
-- **Phase 1 — declarative (1a).** Generalize today's `actions[]` discriminated union into
-  a richer **typed widget schema** (containers, inputs, selects, links, sub-pages) emitted
-  in `haku-state` and interpreted by a **trusted renderer** — _no agent JS executes_.
-  Introduce the trace/capability split and the shell-owned launch control. Delivers the
-  launch feature + the boundary with modest work.
+- **Phase 1 — declarative (1a).** A richer **typed widget schema** (containers, inputs,
+  selects, links, sub-pages) emitted in `haku-state` and interpreted by a **trusted
+  renderer** — _no agent JS executes_ — beyond today's `actions[]`. Also still to build:
+  the shell-owned **launch control + executions panel** in the SPA, and
+  `GET /api/capabilities/launch-routine/executions` + a **one-in-flight guard** (both
+  gated on the routine-listing API, not yet wired).
 - **Phase 2 — free-form (1b, the destination).** Haku writes TSX/JS into `haku-state`; the
   untrusted render origin transpiles it **at runtime** (never compiled into the trusted
   bundle) and runs it in a **sandboxed cross-origin iframe** (`sandbox` without

--- a/haku/console/BUILD.bazel
+++ b/haku/console/BUILD.bazel
@@ -43,14 +43,28 @@ py_library(
 )
 
 py_library(
+    name = "capabilities",
+    srcs = ["capabilities.py"],
+    deps = [
+        ":config",
+        "@pypi//fastapi",
+        "@pypi//fastapi_csrf_protect",
+        "@pypi//httpx",
+        "@pypi//pydantic",
+    ],
+)
+
+py_library(
     name = "app",
     srcs = ["app.py"],
     deps = [
+        ":capabilities",
         ":config",
         ":git_state",
         ":models",
         ":trace",
         "@pypi//fastapi",
+        "@pypi//fastapi_csrf_protect",
         "@pypi//uvicorn",
     ],
 )
@@ -103,6 +117,23 @@ py_test(
         "//:conftest",
         "@pypi//pygit2",
         "@pypi//pytest_bazel",
+    ],
+)
+
+py_test(
+    name = "test_capabilities",
+    srcs = ["test_capabilities.py"],
+    deps = [
+        ":app",
+        ":config",
+        ":conftest",
+        "//:conftest",
+        "@pypi//fastapi",
+        "@pypi//httpx",
+        "@pypi//pydantic",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
+        "@pypi//respx",
     ],
 )
 

--- a/haku/console/README.md
+++ b/haku/console/README.md
@@ -30,11 +30,31 @@ Feedback — the global box, or a per-item box on each card — appends to `inta
 (`POST /api/trace/feedback`); per-item notes are tagged with the item id, which Haku
 reduces as feedback on that item.
 
-These writes are the **trace tier** (`trace.py`): they only record operator-expressed
-intent into haku-state, which Haku already owns, so they're safe to expose to
-agent-authored UI. Privileged actions that use console-only secrets or act on the
-world will live in a separate, gated **capability tier**. See `haku/PLAN.md` → _The
-agent-authored console_.
+## Two write tiers — the internal security split
+
+Writes are split by **what's the worst case if agent-authored UI made this call with
+no real operator behind it** (see `haku/PLAN.md` → _The agent-authored console_):
+
+- **Trace tier** (`trace.py`, `/api/trace/*`) — only records operator-expressed intent
+  into `haku-state`, which Haku already owns, so it grants the agent **nothing new**.
+  Low-privilege; safe to expose to agent-authored UI.
+- **Capability tier** (`capabilities.py`, `/api/capabilities/*`) — uses console-only
+  secrets and acts on the world. The teeth live here, so it's treated very differently:
+  - **CSRF-gated.** A header-located double-submit token: the SPA fetches it from
+    `GET /api/capabilities/csrf` (which also sets the signed cookie) and echoes it in
+    `X-CSRF-Token` on the POST — so a cross-site request can't ride the operator's
+    Authentik session cookie to fire a capability.
+  - **Server-side secret.** The bearer is read from `Settings` / the
+    `haku-routine-launch-token` secret and attached to the upstream call; it never
+    reaches the client.
+  - **Audited.** Every invocation logs to stdout in the `haku-console` namespace, which
+    Haku has no RBAC to read.
+  - **Tiny, PR-gated allowlist.** Today one capability: `POST
+/api/capabilities/launch-routine` fires the Haku claude-code-web routine via its
+    public Anthropic fire URL. Adding a verb is a ducktape PR, never runtime data.
+
+  The split is legible in the code: a search for what touches a privileged secret
+  returns `capabilities.py` and never the trace router.
 
 ## Boundary
 
@@ -49,8 +69,9 @@ agent-authored console_.
 
 | Path               | Role                                                                                                                                                                                                                           |
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `app.py`           | FastAPI `create_app` + lifespan (clone + background pull loop). Read endpoints (`GET /api/dashboard`, `GET /healthz`), mounts the trace router, serves the SPA (`StaticFiles`) otherwise.                                      |
+| `app.py`           | FastAPI `create_app` + lifespan (clone + background pull loop). Read endpoints (`GET /api/dashboard`, `GET /healthz`), CSRF config, mounts the trace + capability routers, serves the SPA (`StaticFiles`) otherwise.           |
 | `trace.py`         | Trace-tier router (`/api/trace/*`): the overlay toggle (`PUT`/`DELETE /api/trace/items/{id}/actions/{aid}`) and `POST /api/trace/feedback`. Low-privilege haku-state writes; reads `git_state` off `app.state`.                |
+| `capabilities.py`  | Capability-tier router (`/api/capabilities/*`): CSRF-gated, audited privileged actions. `POST /launch-routine` fires the routine with the server-side bearer; `GET /csrf` issues the double-submit token.                      |
 | `git_state.py`     | pygit2 clone of haku-state; `reconcile` (fetch + hard-reset), `commit_push` with retry, `read_items`, and the clicks/-overlay + feedback writers. Talks to the cluster-internal **plaintext-HTTP** Forgejo (no TLS/CA needed). |
 | `models.py`        | Pydantic `Item` (discriminated-union `action` + `actions[]`) and the `/api` request/response models.                                                                                                                           |
 | `config.py`        | Env settings (`HAKU_CONSOLE_*`).                                                                                                                                                                                               |
@@ -61,12 +82,14 @@ agent-authored console_.
 
 Manifests live in `cluster/k8s/haku/console/` (operator-owned — the perimeter is not
 Haku's to change); the `haku-console` namespace itself is `cluster/k8s/haku/console-namespace/`.
-Non-root, dropped caps, no service-account token; the only credential is the
-`haku-state-git-write` secret (provisioned into `haku-console` by the
-`tf/gitops/haku-state` module). As trusted ducktape code in its own namespace it is
-**not** behind the `haku-mitmproxy` fence — it gets ordinary cluster egress. The image
-bundles the built SPA at `/app/web` (`HAKU_CONSOLE_STATIC_DIR`). Design + roadmap:
-`haku/PLAN.md` and the `haku-state` repo's `plans/dashboard-arm.md`.
+Non-root, dropped caps, no service-account token. Credentials: the `haku-state-git-write`
+secret (provisioned into `haku-console` by the `tf/gitops/haku-state` module) and the
+`haku-routine-launch-token` secret (the capability tier's bearer; `HAKU_CONSOLE_LAUNCH_ROUTINE__TOKEN`).
+As trusted ducktape code in its own namespace it is **not** behind the `haku-mitmproxy`
+fence — it gets ordinary cluster egress (which the capability tier needs to reach the
+Anthropic fire URL). The image bundles the built SPA at `/app/web`
+(`HAKU_CONSOLE_STATIC_DIR`). Design + roadmap: `haku/PLAN.md` and the `haku-state` repo's
+`plans/dashboard-arm.md`.
 
 ## Test
 

--- a/haku/console/app.py
+++ b/haku/console/app.py
@@ -5,9 +5,9 @@ JSON API under ``/api``. Writes are split into tiers (see `haku/PLAN.md` → _Th
 agent-authored console_): the **trace tier** (`haku.console.trace`) only records
 operator-expressed intent into haku-state — clicks (the overlay Haku reduces) and
 feedback — and is the low-privilege surface safe for agent-authored UI. The
-high-privilege **capability tier** (console-only secrets, real-world side effects)
-will be a separate, gated router. ``app.py`` itself serves the read endpoints and
-the SPA.
+high-privilege **capability tier** (`haku.console.capabilities`) uses console-only
+secrets and acts on the world (launching the routine); it is CSRF-gated and audited.
+``app.py`` wires both routers, configures CSRF, and serves the read endpoints + SPA.
 """
 
 from __future__ import annotations
@@ -16,12 +16,16 @@ import asyncio
 import contextlib
 import datetime as dt
 import logging
+import secrets
 
 import uvicorn
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
+from fastapi_csrf_protect import CsrfProtect
+from fastapi_csrf_protect.exceptions import CsrfProtectError
 
-from haku.console import trace
+from haku.console import capabilities, trace
 from haku.console.config import Settings
 from haku.console.git_state import GitState
 from haku.console.models import Click, DashboardResponse
@@ -53,8 +57,20 @@ def create_app(settings: Settings, *, git_state: GitState) -> FastAPI:
                 await pull
 
     app = FastAPI(title="Haku console", lifespan=lifespan)
-    # Routers read git_state off app.state (see haku.console.trace).
+    # Routers read git_state / settings off app.state (see haku.console.{trace,capabilities}).
     app.state.git_state = git_state
+    app.state.settings = settings
+
+    # CSRF for the capability tier: a header-located double-submit token (the SPA
+    # echoes the token from GET /api/capabilities/csrf in X-CSRF-Token). Use the
+    # configured secret, else an ephemeral one (fine for the single-replica console
+    # — a restart just makes the SPA refetch its token).
+    csrf_secret = settings.csrf_secret.get_secret_value() if settings.csrf_secret else secrets.token_urlsafe(32)
+    CsrfProtect.load_config(lambda: [("secret_key", csrf_secret), ("token_location", "header")])
+
+    @app.exception_handler(CsrfProtectError)
+    async def _csrf_error(request: Request, exc: CsrfProtectError) -> JSONResponse:
+        return JSONResponse(status_code=exc.status_code, content={"detail": exc.message})
 
     @app.get("/healthz")
     async def healthz() -> dict[str, str]:
@@ -71,6 +87,7 @@ def create_app(settings: Settings, *, git_state: GitState) -> FastAPI:
         return DashboardResponse(scan_time=scan_time, items=items, clicks=clicked)
 
     app.include_router(trace.router)
+    app.include_router(capabilities.router)
 
     # The built React SPA is served same-origin for everything else. Mounted last so the
     # API routes above take precedence; left unmounted in tests (static_dir unset).

--- a/haku/console/capabilities.py
+++ b/haku/console/capabilities.py
@@ -1,0 +1,72 @@
+"""Capability tier: high-privilege actions the console performs that Haku cannot.
+
+Unlike the trace tier (`haku.console.trace`), these endpoints use console-only
+secrets and act on the world, so they are **CSRF-gated**, **audited** to this
+trusted namespace's logs (which Haku has no RBAC to read), and the capability set
+is a small, **PR-gated** allowlist. Today the one capability is `launch-routine`:
+firing the Haku "claude-code-web routine" via its public Anthropic fire URL with
+the bearer from the `haku-routine-launch-token` secret. The bearer never leaves
+this process. See `haku/PLAN.md` → _The agent-authored console_.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Annotated, cast
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import JSONResponse
+from fastapi_csrf_protect import CsrfProtect
+from pydantic import BaseModel
+
+from haku.console.config import LaunchRoutineConfig, Settings
+
+logger = logging.getLogger(__name__)
+
+Csrf = Annotated[CsrfProtect, Depends()]
+
+router = APIRouter(prefix="/api/capabilities", tags=["capabilities"])
+
+
+class LaunchRoutineResult(BaseModel):
+    status: str
+    upstream_status: int
+
+
+def _settings(request: Request) -> Settings:
+    # app.state is Starlette's untyped (Any) container; create_app puts Settings there.
+    return cast(Settings, request.app.state.settings)
+
+
+def _launch_config(settings: Annotated[Settings, Depends(_settings)]) -> LaunchRoutineConfig:
+    if settings.launch_routine is None:
+        raise HTTPException(status_code=503, detail="launch-routine capability is not configured")
+    return settings.launch_routine
+
+
+# The SPA fetches a CSRF token here (and gets the signed double-submit cookie), then
+# echoes the token in the X-CSRF-Token header on capability POSTs. Gating the
+# privileged tier this way stops a cross-site request from riding the operator's
+# Authentik session cookie to fire a capability.
+@router.get("/csrf")
+async def csrf_token(csrf_protect: Csrf) -> JSONResponse:
+    token, signed = csrf_protect.generate_csrf_tokens()
+    response = JSONResponse({"csrf_token": token})
+    csrf_protect.set_csrf_cookie(signed, response)
+    return response
+
+
+@router.post("/launch-routine")
+async def launch_routine(
+    request: Request, csrf_protect: Csrf, config: Annotated[LaunchRoutineConfig, Depends(_launch_config)]
+) -> LaunchRoutineResult:
+    """Fire the Haku claude-code-web routine. CSRF-gated; the bearer stays server-side."""
+    await csrf_protect.validate_csrf(request)
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.post(config.url, headers={"Authorization": f"Bearer {config.token.get_secret_value()}"})
+    # Audit to stdout in the haku-console namespace (Haku can't read these logs).
+    logger.info("capability launch-routine fired: upstream status %s", resp.status_code)
+    if not resp.is_success:
+        raise HTTPException(status_code=502, detail=f"routine fire failed upstream ({resp.status_code})")
+    return LaunchRoutineResult(status="launched", upstream_status=resp.status_code)

--- a/haku/console/config.py
+++ b/haku/console/config.py
@@ -4,12 +4,25 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from pydantic import SecretStr
+from pydantic import BaseModel, SecretStr
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
+class LaunchRoutineConfig(BaseModel):
+    """The `launch-routine` capability's target: the public Anthropic fire URL plus
+    the bearer that authorizes it. Both come from the `haku-routine-launch-token`
+    secret / deployment env; set together or not at all (the capability is disabled
+    when unset). The token lives only in the haku-console namespace — Haku can't
+    read it."""
+
+    url: str
+    token: SecretStr
+
+
 class Settings(BaseSettings):
-    model_config = SettingsConfigDict(env_prefix="HAKU_CONSOLE_")
+    # env_nested_delimiter so launch_routine.{url,token} read from
+    # HAKU_CONSOLE_LAUNCH_ROUTINE__URL / __TOKEN.
+    model_config = SettingsConfigDict(env_prefix="HAKU_CONSOLE_", env_nested_delimiter="__")
 
     # haku-state git access. The repo_url is the cluster-internal plaintext-HTTP
     # Forgejo (no TLS, so no CA bundle needed); credentials come from the
@@ -25,3 +38,11 @@ class Settings(BaseSettings):
     # Directory holding the built React SPA (index.html + assets), served same-origin.
     # Unset in tests (the API runs without a UI); set to the bundled dir in the image.
     static_dir: Path | None = None
+
+    # Capability tier. launch_routine enables POST /api/capabilities/launch-routine
+    # (None → the capability returns 503). csrf_secret signs the double-submit CSRF
+    # tokens that gate the capability tier; when unset, create_app generates an
+    # ephemeral one at startup (fine for the single-replica console — a restart just
+    # makes the SPA refetch its token).
+    launch_routine: LaunchRoutineConfig | None = None
+    csrf_secret: SecretStr | None = None

--- a/haku/console/test_capabilities.py
+++ b/haku/console/test_capabilities.py
@@ -1,0 +1,76 @@
+"""Capability-tier tests: the launch-routine action is CSRF-gated, forwards the
+server-side bearer to the fire URL, and maps upstream failure / missing config to
+clean statuses. The external fire call is mocked with respx (which patches httpx's
+real transport, not TestClient's ASGI transport, so app calls still reach the app).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import httpx
+import pytest
+import pytest_bazel
+import respx
+from fastapi.testclient import TestClient
+from pydantic import SecretStr
+
+from haku.console.app import create_app
+from haku.console.config import LaunchRoutineConfig
+
+FIRE_URL = "https://fire.test.example/routines/trig_test/fire"
+
+
+@pytest.fixture
+def cap_client(seeded) -> Iterator[TestClient]:
+    """Console app with the launch-routine capability configured (over the seeded remote)."""
+    settings = seeded.settings.model_copy(
+        update={
+            "launch_routine": LaunchRoutineConfig(url=FIRE_URL, token=SecretStr("sk-test-token")),
+            "csrf_secret": SecretStr("test-csrf-secret"),
+        }
+    )
+    with TestClient(create_app(settings, git_state=seeded.git_state)) as c:
+        yield c
+
+
+def _csrf(client: TestClient) -> str:
+    token = client.get("/api/capabilities/csrf").json()["csrf_token"]
+    assert isinstance(token, str)
+    return token
+
+
+@respx.mock
+def test_launch_routine_fires_with_server_side_bearer(cap_client) -> None:
+    route = respx.post(FIRE_URL).mock(return_value=httpx.Response(200, json={"queued": True}))
+    resp = cap_client.post("/api/capabilities/launch-routine", headers={"X-CSRF-Token": _csrf(cap_client)})
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "launched", "upstream_status": 200}
+    # The bearer is attached server-side and never returned to the client.
+    assert route.calls.last.request.headers["authorization"] == "Bearer sk-test-token"
+
+
+@respx.mock
+def test_launch_routine_without_csrf_token_is_rejected(cap_client) -> None:
+    route = respx.post(FIRE_URL).mock(return_value=httpx.Response(200))
+    resp = cap_client.post("/api/capabilities/launch-routine")
+    assert resp.status_code in (400, 401)
+    assert not route.called  # rejected before any upstream call
+
+
+@respx.mock
+def test_launch_routine_upstream_failure_is_502(cap_client) -> None:
+    respx.post(FIRE_URL).mock(return_value=httpx.Response(500))
+    resp = cap_client.post("/api/capabilities/launch-routine", headers={"X-CSRF-Token": _csrf(cap_client)})
+    assert resp.status_code == 502
+
+
+def test_launch_routine_unconfigured_is_503(seeded) -> None:
+    settings = seeded.settings.model_copy(update={"csrf_secret": SecretStr("test-csrf-secret")})
+    with TestClient(create_app(settings, git_state=seeded.git_state)) as c:
+        resp = c.post("/api/capabilities/launch-routine", headers={"X-CSRF-Token": _csrf(c)})
+    assert resp.status_code == 503
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()


### PR DESCRIPTION
## What

Adds the **capability tier** — the high-privilege counterpart to the trace tier (#2475). These endpoints use console-only secrets and act on the world, so they're treated very differently from trace writes (which only touch `haku-state`, something Haku already owns).

`POST /api/capabilities/launch-routine` fires the Haku claude-code-web routine by POSTing the public Anthropic fire URL with the bearer landed in #2476.

## The internal security split, enforced in code

- **Separate module/router** (`capabilities.py`, `/api/capabilities/*`) — a grep for what touches a privileged secret returns this file and never the trace router.
- **CSRF-gated.** `fastapi-csrf-protect` (header double-submit, the repo's existing pattern from `x/gatelet`): the SPA fetches a token from `GET /api/capabilities/csrf` (which sets the signed cookie) and echoes it in `X-CSRF-Token`. Stops a cross-site request riding the operator's Authentik session cookie to fire a capability.
- **Server-side secret.** The bearer is read from `Settings`/the `haku-routine-launch-token` secret and attached to the upstream call; it never reaches the client.
- **Audited.** Every invocation logs to stdout in the `haku-console` namespace, which Haku has no RBAC to read.
- **Tiny, PR-gated allowlist.** One capability today; adding a verb is a ducktape PR, never runtime data.

## Changes

- `capabilities.py` — the router; `POST /launch-routine` (502 on upstream failure, 503 when unconfigured) + `GET /csrf`.
- `config.py` — `LaunchRoutineConfig` (url + token), nested-env optional so the capability is disabled unless both are set; `csrf_secret` (ephemeral if unset — fine for the single-replica console).
- `app.py` — wires both routers, configures CSRF + the `CsrfProtectError` handler, stashes `settings` on `app.state`.
- `deployment.yaml` — `HAKU_CONSOLE_LAUNCH_ROUTINE__URL` (public, clear) + `__TOKEN` (from the secret).
- `test_capabilities.py` (respx) — bearer forwarded, CSRF required, upstream-fail→502, unconfigured→503.
- README documents the split; PLAN trimmed to remaining Phase 1 work.

## Deferred (need the routine-listing API, not wired yet)

- `GET /api/capabilities/launch-routine/executions` (the "recent executions" panel, upstream-sourced) and the **one-in-flight guard**.
- The shell-owned **launch control + executions panel** in the SPA (this PR is backend-only; the endpoint is live and curl-able but no UI button yet).

## Validation

`bbr test //haku/console/...` green (`test_app`, `test_capabilities`, `tsc_test`, `markdown_test`); pre-commit clean.