### PR TITLE
docs: pivot debundle selector backend plan

### DIFF
--- a/devinfra/js/debundle/SELECTOR_BUGS.md
+++ b/devinfra/js/debundle/SELECTOR_BUGS.md
@@ -3,6 +3,37 @@
 This note tracks selector issues found while porting a downstream debundle spec.
 Examples are intentionally generic and anonymized.
 
+## Global Matching Needs Injective Target Assignment
+
+Some selectors are intentionally broad, and the spec relies on the whole
+assignment to disambiguate them. Solving each selector independently, or
+dropping target injectivity, leaves those broad selectors ambiguous.
+
+Observed pattern:
+
+```js
+const broadCandidate = f(134);
+const exactCandidate = f(123);
+```
+
+Given two readable claims:
+
+- `X`: `const x = f(ANYTHING);`
+- `Y`: `const y = f(123);`
+
+`Y` should bind to `exactCandidate`, and target injectivity should force `X` to
+`broadCandidate`. Without a native/global `all_different`, both `X` and `Y` can
+claim `exactCandidate`, or `X` can remain ambiguous between both candidates.
+
+Desired behavior:
+
+- Treat `all_different` across claimed targets as selector semantics, not as a
+  best-effort diagnostic.
+- Enforce it in the exact-assignment backend so forced matches propagate to
+  broader selectors instead of enumerating invalid duplicate rows and rejecting
+  them late.
+- Add regression coverage before replacing the current `AssignmentRow` solver.
+
 ## Stable Identifiers Are Only Local To One Match
 
 `source_match` with `identifiers: alpha_all` makes readable names usable for

--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -24,34 +24,44 @@ records and scoped backlogs; when a plan's core work is complete, its remaining
 tail should be summarized here instead of leaving the plan looking like a second
 priority queue.
 
-**Current focus (2026-06-25).** PRs #2439, #2443, #2446, and #2447 moved
+**Current focus (2026-06-26).** PRs #2439, #2443, #2446, and #2447 moved
 `source_match` onto the Ascent-backed selector path, lowered the exact
 single-statement AST subset, stopped calling `ChunkResolver` for native
-selectors, and added native class-superclass constraints. Current work deletes
-the `SourceMatchCandidate` schema, member/group candidate-oracle injection, and
-production anonymous-statement `ChunkResolver` fallback. The remaining P0 is to
-make every retained selector form lower faithfully into one declarative
-Ascent/CSP-style constraint program; unsupported forms now fail closed instead
+selectors, and added native class-superclass constraints. That proved the
+global-resolution direction, but profiling the production-sized path showed the
+current Ascent exact-assignment encoding is not the endpoint: it carries
+`AssignmentRow` payloads through `partial_assignment` / `stepped_assignment`
+relations and implements target injectivity as pairwise row filtering instead
+of a native global constraint. The remaining P0 is to carve a
+`SelectorConstraintModel` boundary, keep Ascent/Rust as fact and allowed-tuple
+derivation where useful, and move exact target assignment to a CP/SAT backend
+with first-class `all_different`. Unsupported forms still fail closed instead
 of taking a production procedural fallback.
 
 Dispatch work in this order:
 
-1. **Alpha-all as query structure (P0.1).** Lower `identifiers: alpha_all` to
+1. **Constraint-model/backend pivot (P0.0).** Introduce the explicit
+   `SelectorConstraintModel` contract: typed finite domains, allowed tuples,
+   equality/disequality, ordering, target projection, and semantic
+   `all_different`. Target OR-Tools CP-SAT first; use RustSAT + CaDiCaL/Kissat
+   only if OR-Tools integration is too expensive. Do not optimize the current
+   `AssignmentRow` scheduler as if it were the final solver.
+2. **Alpha-all as query structure (P0.1).** Lower `identifiers: alpha_all` to
    logic variables, equality, disequality / `all_different`, and scope facts.
    Do not clone the procedural `selector_match::Bindings` matcher inside the
    solver; alpha-renaming should fall out of the query.
-2. **Core hole predicates (P0.2).** Lower simple `ANYTHING` / `EXPR` / `STMT`
+3. **Core hole predicates (P0.2).** Lower simple `ANYTHING` / `EXPR` / `STMT`
    holes, regex string predicates, and then ordered run holes (`STMT_LIST`,
    `OBJECT_PROPS`, `DECLARATORS`, `ARGS`, `CLASS_REST`, `CASE_REST`,
    `ARRAY_ELEMENTS`) as native constraints. Preserve the fail-closed rule:
    unsupported constructs report `unsupported` until their faithful encoding is
    implemented.
-3. **Source-match surface pruning (P0.3).** Remove legacy `source_match`
+4. **Source-match surface pruning (P0.3).** Remove legacy `source_match`
    options that no current downstream spec uses before nativeization hardens
    them into the new IR. `target_statement` / `target_statements` have been
    removed; the remaining gaffer-private census follow-up is
    `wildcard_string_literals`.
-4. **Derived relational predicates (P0.4).** Fold the remaining bridge
+5. **Derived relational predicates (P0.4).** Fold the remaining bridge
    vocabulary (`cross_ref`, `reads_member`, `member_of_module`,
    `passed_to_call`, `makes_decorate_call`, `intrinsic_alias`) into IR atoms or
    derived predicates over owner/reference + AST facts.
@@ -73,12 +83,14 @@ One-line status for each `plans/` design doc; this is the discovery index, not a
 parallel dispatch queue.
 
 - <plans/selector_constraint_model.md> — **active (P0 global resolver).**
-  Canonical plan for the selector model, Ascent solver choice, execution
-  phases, verification gates, and Gaffer evidence queue. #2439 closed the
-  global-solver admission path for `source_match`; #2443/#2446/#2447 moved the
-  exact native subset out of the oracle. Current top priority is alpha-all and
-  hole lowering as one declarative query, plus pruning unused source-match
-  surface before carrying it forward. The landed bridge primitives (`cross_ref`,
+  Canonical plan for the selector model, backend ownership, execution phases,
+  verification gates, and Gaffer evidence queue. #2439 closed the global-solver
+  admission path for `source_match`; #2443/#2446/#2447 moved the exact native
+  subset out of the oracle. Current top priority is the solver-backend pivot:
+  preserve one whole-spec constraint model, but stop treating Ascent row
+  enumeration as the exact-assignment backend. Next work is alpha-all and hole
+  lowering into that model, plus pruning unused source-match surface before
+  carrying it forward. The landed bridge primitives (`cross_ref`,
   `reads_member`, `member_of_module`, `passed_to_call`, `makes_decorate_call`,
   `intrinsic_alias`) are useful fact/selector vocabulary, but are bridge
   implementations until they fold into derived predicates. See
@@ -104,19 +116,37 @@ propose`.
 Detailed design and gates live in <plans/selector_constraint_model.md>; keep
 this list as the dispatch summary, not a second plan.
 
-1. **Lower alpha-all declaratively.** Represent selector-local identifier
+1. **Carve the exact-assignment backend boundary.** Materialize a
+   `SelectorConstraintModel` from `SelectorProgram` + facts, with typed finite
+   domains, allowed tuples, target projections, and semantic `all_different`.
+   Ascent may stay on the fact/table side; the exact target assignment must be
+   owned by OR-Tools CP-SAT or a measured SAT fallback, not by
+   `AssignmentRow` enumeration.
+2. **Unblock the solver dependency path before wiring it into production.**
+   OR-Tools CP-SAT remains the target backend, but the first sidecar spike hit a
+   Bzlmod conflict: `or-tools@9.15` pulls `pybind11_abseil`, whose dev-only pip
+   hub is also named `pypi`. Resolve that as a dependency-only slice, prove a
+   tiny CP-SAT target under RBE, and only then wire selector solving to it. If
+   that integration stays too expensive, encode the same
+   `SelectorConstraintModel` through the RustSAT + CaDiCaL/Kissat fallback.
+3. **Lower alpha-all declaratively.** Represent selector-local identifier
    bindings/references as variables and constraints over facts, including
    equality, disequality / `all_different`, and scope. This is the blocker for
    current gaffer-private payoff: its Tana spec uses `identifiers: alpha_all`
    for every `source_match`.
-2. **Lower the retained hole vocabulary.** Start with simple single-node holes
+4. **Lower the retained hole vocabulary.** Start with simple single-node holes
    and regex string predicates, then add ordered run-hole placement for the
    high-volume families (`STMT_LIST`, `DECLARATORS`, `OBJECT_PROPS`). Each
    lowering must be faithful or fail closed.
-3. **Prune unused source-match options.** Finish the
-   `wildcard_string_literals` census/removal decision, and run a broader
-   vestigial-feature audit before nativeizing more rarely-used spec surface.
-4. **Fold bridge vocabulary into derived predicates.** Re-express the staged
+5. **Prune unused source-match/options before nativeizing them.** Safe cleanup
+   candidates from the current Ducktape/Gaffer census: remove or hide
+   `source_match.wildcard_string_literals`, remove the single-choice
+   `match-selector --identifiers` flag, and avoid preserving old
+   `STATEMENT_*` compatibility names. Likely follow-ups: trim
+   `selector-codemod` exact-body fallback knobs and source-aware
+   `selector-debt` debug options once their solver-backed replacements are
+   scoped.
+6. **Fold bridge vocabulary into derived predicates.** Re-express the staged
    relational selectors as solver predicates over owner/reference + AST facts.
    Real-spec Gaffer work should supply missing predicates and diagnostics, not
    another permanent resolver layer.
@@ -127,12 +157,15 @@ this list as the dispatch summary, not a second plan.
    or add adjacent verbs so every broad rewrite can emit a dry-run patch plan,
    apply with filters, and explain every skipped candidate. The prove gate
    should be solver categoricity, not an independent selector-matcher path.
-2. **Selector diagnostics — remaining extensions.** The keep-going JSON report
-   (`debundle spec validate --keep-going --format text|json|ndjson`) landed
-   (#2302; shared contract in `selector_diagnostics.rs`) and classifies
-   unresolved / ambiguous / duplicate-claim failures with full provenance. Fold
-   remaining anonymous-statement failures, blocker comments, and
-   free-readable-identifier cases into the solver-backed report shape.
+2. **Selector diagnostics — solver-backed replacement.** The keep-going JSON
+   report (`debundle spec validate --keep-going --format text|json|ndjson`)
+   landed (#2302; shared contract in `selector_diagnostics.rs`) and classifies
+   unresolved / ambiguous / duplicate-claim failures with full provenance.
+   Treat that as the current user-facing contract, not as architecture to carry
+   forward unchanged: the new backend should emit per-target solver
+   explanations directly. Fold remaining anonymous-statement failures, blocker
+   comments, free-readable-identifier cases, and nearest-candidate needs into
+   that solver-backed report shape.
 3. **Spec repair from diagnostics.** Add a workflow that consumes the
    solver-backed keep-going report, proposes mechanically proven patch plans for
    no-match, ambiguous, duplicate-claim, and unsupported-selector cases, and
@@ -187,6 +220,12 @@ this list as the dispatch summary, not a second plan.
    path-keyed index if fresh profiles show chunk file lookup hot.
 5. Move `split_entry_body` to a draining/move-based implementation if fresh
    profiles show retained-statement cloning hot.
+6. Replace diagnostic-only matcher mirrors with solver-native explanations:
+   generic `NoMatch` fallback reporting, empty `nearest_candidates`, fact
+   near-miss/source-aware debt scoring, `match-selector` slack relaxation, old
+   source-match timing hooks, and selector-IR row/stat stderr diagnostics.
+   Keep cheap wrappers over production data; remove side data structures that
+   exist only for the old matcher/row-solver path.
 
 ### P3 — read-off minimizer polish
 

--- a/devinfra/js/debundle/plans/ortools_bzlmod_unblock.md
+++ b/devinfra/js/debundle/plans/ortools_bzlmod_unblock.md
@@ -1,0 +1,136 @@
+# OR-Tools CP-SAT Bzlmod Unblock Plan
+
+Status: implementation spike only. The root `or-tools@9.15` Bzlmod path
+currently fails during analysis before compiling the C++ CP-SAT smoke test.
+
+## Evidence
+
+- Ducktape owns the root Python hub in `MODULE.bazel` via `pip.parse` with
+  `hub_name = "pypi"`, Python 3.13, and
+  `requirements_lock = "//:requirements_bazel.txt"`.
+- Ducktape validation normally runs under BuildBuddy RBE through `bbr`.
+- OR-Tools C++ has the needed API surface: `CpModelBuilder::NewIntVar`,
+  `AddAllDifferent`, and `AddAllowedAssignments`.
+- OR-Tools BCR/source `MODULE.bazel` for `9.15` declares C++ deps and wrapper
+  deps: `pybind11_abseil`, `pybind11_bazel`, `pybind11_protobuf`, and `swig`.
+- `pybind11_abseil@202402.0` declares `pip.parse(hub_name = "pypi", ...)` and
+  `use_repo(pip, "pypi")`.
+- Bazel module overrides must be expressed by the root module; overrides in a
+  dependency's `MODULE.bazel` are ignored.
+- RBE failures observed:
+  - `//devinfra/js/debundle/solver_backends/ortools_spike/...`:
+    `Duplicate cross-module pip hub named 'pypi'`.
+  - Re-running with `--config=nolint` failed the same way, so this is module
+    extension resolution, not a target lint action.
+
+## Option A: Root Override For `pybind11_abseil`
+
+Patch only the transitive module that collides with Ducktape's root hub.
+
+Expected changes:
+
+- Keep root direct deps:
+  - `bazel_dep(name = "rules_cc", version = "0.2.16")`
+  - `bazel_dep(name = "or-tools", version = "9.15")`
+- Add a root `git_override` or `archive_override` for `pybind11_abseil`.
+- Add `third_party/patches/pybind11_abseil_rename_pypi_hub.patch` that changes
+  the module-local pip hub from `pypi` to `pybind11_abseil_pypi`, while
+  preserving apparent `@pypi` labels inside that module:
+
+```starlark
+pip.parse(
+    hub_name = "pybind11_abseil_pypi",
+    ...
+)
+use_repo(pip, pypi = "pybind11_abseil_pypi")
+```
+
+Risk:
+
+- Low-to-medium. This directly fixes the observed failure and matches the
+  repo's existing practice of root-module overrides plus small patches.
+- It may expose the next OR-Tools integration issue: protobuf/rules version
+  skew, heavy SCIP/HiGHS downloads, or C++ toolchain warnings.
+- The root override must track whichever `pybind11_abseil` source OR-Tools
+  actually resolves to.
+
+First validation:
+
+```bash
+nix develop -c bbr test //devinfra/js/debundle/solver_backends/ortools_spike/... --cache_test_results=no
+```
+
+## Option B: Root Override For A C++-Only OR-Tools Module
+
+Patch OR-Tools' own module metadata so the root graph never includes Python
+wrapper dependencies for a C++-only sidecar.
+
+Expected changes:
+
+- Keep the spike target under
+  `devinfra/js/debundle/solver_backends/ortools_spike/`.
+- Add a root `archive_override` or `git_override` for `or-tools`.
+- Add `third_party/patches/or_tools_cxx_only_module.patch` that removes wrapper
+  deps and unused module extensions from OR-Tools' `MODULE.bazel`, at minimum:
+  `pybind11_abseil`, `pybind11_bazel`, `pybind11_protobuf`, `swig`, and Python
+  pip extension setup.
+
+Risk:
+
+- Medium-to-high. It avoids the known `pybind11_abseil` collision more cleanly,
+  but carries a larger upstream-module patch.
+- OR-Tools BUILD packages may still load non-C++ rule files at package-load
+  time, so this may still require Java/Go/Python rule deps even if no wrapper
+  targets are built.
+- More maintenance burden when OR-Tools updates.
+
+First validation:
+
+```bash
+nix develop -c bbr test //devinfra/js/debundle/solver_backends/ortools_spike/... --cache_test_results=no
+```
+
+## Option C: Isolated Or Prebuilt Sidecar Package
+
+Avoid putting OR-Tools' Bzlmod graph into Ducktape's root module.
+
+Expected changes:
+
+- Either create a nested sidecar module with its own `MODULE.bazel` under
+  `devinfra/js/debundle/solver_backends/ortools_sidecar/`, or register an
+  official OR-Tools C++ release tarball as a sidecar-only external repo.
+- For the prebuilt path, the official v9.15 release includes an Ubuntu 24.04
+  C++ tarball close to the repo's BuildBuddy worker baseline.
+- Add a small protobuf/stdin-stdout contract between Rust and the sidecar
+  process. Do not link OR-Tools into the production Rust binary.
+
+Risk:
+
+- Medium. This isolates dependency churn best, but it weakens monorepo-native
+  validation and packaging unless a dedicated sidecar CI target is added.
+- The nested-module `bbr` workflow must be proven; `bbr` normally mirrors the
+  git repo and runs remote Bazel from the selected workspace.
+- The prebuilt binary path is platform-specific and may need `cc_import`,
+  runtime library path handling, and license review.
+
+First validation for nested module:
+
+```bash
+cd devinfra/js/debundle/solver_backends/ortools_sidecar
+nix develop -c bbr test //... --cache_test_results=no
+```
+
+First validation for prebuilt sidecar:
+
+```bash
+nix develop -c bbr test //devinfra/js/debundle/solver_backends/ortools_binary_spike/... --cache_test_results=no
+```
+
+## Recommendation
+
+Try Option A first. It is the smallest dependency unblock that addresses the
+observed failure without changing solver code or carrying a broad OR-Tools fork.
+If Option A reaches C++ compilation but reveals deeper OR-Tools module churn,
+switch to Option C with an isolated sidecar boundary. Reserve Option B for the
+case where root-graph OR-Tools integration remains desirable but wrapper deps
+keep causing unrelated analysis failures.

--- a/devinfra/js/debundle/plans/selector_constraint_model.md
+++ b/devinfra/js/debundle/plans/selector_constraint_model.md
@@ -1,20 +1,24 @@
 # Plan: selectors as one global constraint problem (relational spec model)
 
-**Current state (2026-06-25).** Ascent remains the selected production solver.
-PR #2439 landed on `devel` as `db25ef639` and closed the first global-solver
-bridge: `source_match` selectors now enter the global selector IR/solver
-instead of bypassing it. PR #2443 lowered exact single-statement selectors onto
-native AST facts. PR #2446 stopped asking `ChunkResolver` for candidate rows
-when a selector already lowers natively. PR #2447 added native `AstSuperClass`
-constraints for `class ... extends ...` matches. Current work deletes
-`SourceMatchCandidate`, the member/group candidate-oracle injection path, and
-the production anonymous-statement `ChunkResolver` fallback.
+**Current state (2026-06-26).** PR #2439 landed on `devel` as `db25ef639`
+and closed the first global-solver bridge: `source_match` selectors now enter
+the global selector IR/solver instead of bypassing it. PR #2443 lowered exact
+single-statement selectors onto native AST facts. PR #2446 stopped asking
+`ChunkResolver` for candidate rows when a selector already lowers natively. PR
+#2447 added native `AstSuperClass` constraints for `class ... extends ...`
+matches. That proved the right architectural direction, but profiling the
+production-sized path showed the current Ascent exact-assignment encoding is
+not the final backend: it pushes `AssignmentRow = Vec<(var, value)>` payloads
+through `partial_assignment` / `stepped_assignment`, and `all_different` becomes
+pairwise row filtering instead of native finite-domain propagation.
 
 The bridge that remains is narrower: some retained selector shapes still need
 faithful native lowering before they can be accepted in production, and
-tooling/authoring paths still call `ChunkResolver` directly. The remaining P0
-is to lower every retained selector form into one declarative Ascent/CSP-style
-constraint program and make tooling consume the same solver-backed semantics.
+tooling/authoring paths still call `ChunkResolver` directly. The P0 pivot is to
+keep one whole-spec constraint model, but split backend ownership explicitly:
+Ascent/Rust may derive facts and allowed tuples; exact assignment belongs to a
+finite-domain CP/SAT backend with semantic `all_different`, not to
+`AssignmentRow` enumeration.
 
 **Reframing.** The next architectural goal is not to grow more bridge
 vocabulary. It is to make the global constraint solve native over AST +
@@ -47,12 +51,12 @@ Notation: `@Name` means "the binding/node pinned elsewhere in the spec as `Name`
 
 ## Goal
 
-Complete the Datalog/Ascent selector resolver so it resolves every retained
-selector form over an explicit relational model of the program (owner graph +
-AST facts), without production calls to the procedural `ChunkResolver`. Parity must be
-**proven, not asserted**: each construct compiles to atoms provably faithful to
-current `source_match` semantics, or it remains an explicit unsupported
-fallback while that construct is being implemented. The design must stay
+Complete the global selector resolver so it resolves every retained selector
+form over an explicit relational model of the program (owner graph + AST
+facts), without production calls to the procedural `ChunkResolver`. Parity must
+be **proven, not asserted**: each construct compiles to constraints provably
+faithful to current `source_match` semantics, or it remains an explicit
+unsupported fallback while that construct is being implemented. The design must stay
 **principled** — one general, faithful encoding per selector kind and hole, with
 no per-selector special cases, silent fallbacks, or hacks to force a hard
 construct through. If any retained construct, or the model itself, turns out not
@@ -70,9 +74,12 @@ Operationally, this means the Ducktape-side work leads with the engine contract:
 3. one logical whole-spec solve, with `@Name` as a shared logic variable rather
    than a lookup into already-resolved members; the engine may decompose
    independent connected components internally without changing the model;
-4. one diagnostic/result projection for no-match, ambiguity, duplicate claims,
+4. one explicit exact-assignment backend boundary with typed finite domains,
+   allowed tuples, equality/disequality, ordering, target projection, and a
+   native/global `all_different`;
+5. one diagnostic/result projection for no-match, ambiguity, duplicate claims,
    unsupported constructs, and "which facts forced uniqueness";
-5. one resolved claim map consumed by the existing atomic-DAG / realizability /
+6. one resolved claim map consumed by the existing atomic-DAG / realizability /
    emission pipeline.
 
 ## Problem: the only join we have is adjacency
@@ -217,11 +224,19 @@ parsers feeding one constraint store.
 ## Implementation: the solving core
 
 Conjunctive-query evaluation over a fixed relational structure _is_ the
-CSP/homomorphism problem, but its natural off-the-shelf engine is **Datalog**, not a
-numeric finite-domain solver: the structure is a large fixed EDB (~1–2M AST facts)
-joined by selective equality atoms (database territory), and a Datalog engine takes
-exactly `(facts, rules, query) → answers`. Using one avoids reimplementing a solver and
-**forces a clean serialization boundary** (program → facts, spec → rules).
+CSP/homomorphism problem. There are two distinct engine jobs here, and the
+profiling result says not to collapse them:
+
+- **relation derivation** over a large fixed EDB (~1-2M AST facts), joined by
+  selective equality atoms. This is database/Datalog territory, and Ascent or
+  direct Rust indexes can produce compact domains and allowed tuples.
+- **exact assignment** of selector variables to candidate values, including
+  target categoricity and `all_different`. This is finite-domain CP/SAT
+  territory, and should use the backend named below.
+
+The serialization boundary is therefore `facts + lowered selectors ->
+SelectorConstraintModel`, not "generate a second procedural matcher" and not
+"push whole assignment rows through Datalog until one survives."
 
 **EDB — facts extracted once per chunk.** The AST plus the one semantic edge:
 
@@ -264,28 +279,65 @@ recursion or sibling-order atoms, and are T-variant anyway.)
 - _Clause-local holes_ = pattern-internal throwaways (a param, an `EXPR`), standardized
   apart per selector so unrelated functions' `n`s do not collide.
 
-**Solve / read-back.** Evaluate once. Per target symbol: exactly one binding → pinned;
-zero → `no-match`; ≥2 → `ambiguous` (categoricity is just _counting_ answer bindings, no
-full-solution enumeration). `all_different(targets)` is a rule
-`dup(A, B) :- claims(A, N), claims(B, N), A < B.` → `duplicate-claim`. Translate-out =
-answer tuple per distinguished variable → claim node → module.
+**Solve / read-back.** Evaluate once. Per target symbol: exactly one binding →
+pinned; zero → `no-match`; ≥2 → `ambiguous`. `all_different(targets)` is a
+semantic constraint over the distinguished target variables, not an optional
+post-pass: two distinct claims may not land on the same source owner, and the
+constraint should propagate during assignment. Translate-out = answer tuple per
+distinguished variable → claim node → module.
 
-**Solver choice.** Use **Ascent** as the first production solver. It is already
-in the Rust dependency set, `selector_solve.rs` uses it for the owner-graph
-relational kernel, and the synthetic query examples already prove the needed
-feature shape: cross-ref joins, disequality / `all_different`, stratified
-negation, recursion, count aggregation, and mixed AST-label + graph-edge joins.
-The selector IR should be represented as EDB facts consumed by a fixed Ascent
-rule library, not by generating Rust or raw Datalog per selector. That keeps the
-Bazel/Rust integration in-process and makes the current `selector_solve` tests a
-real migration bridge.
+**Backend ownership.** Keep the model as one global constraint problem, but do
+not make Ascent own the exact assignment search. The owned layers are:
 
-Do **not** start with Soufflé, Crepe, or DDlog. Soufflé is the fallback if
-Ascent cannot hit the latency/memory target after profiling, but it would add an
-out-of-process toolchain and serialization boundary now. Crepe does not buy us
-anything over the already-used Ascent path. Differential Dataflow / DDlog is a
-future incremental-evaluation option for interactive `stabilize` loops, not the
-initial batch resolver.
+1. **Lowering:** selector YAML / `source_match` / relational atoms →
+   `SelectorProgram`.
+2. **Fact and tuple derivation:** bundle AST + owner/reference facts →
+   finite domains and allowed tuples. This may use Ascent or direct Rust joins
+   where Datalog-style relation derivation is a good fit.
+3. **Constraint model:** `SelectorConstraintModel` with typed finite-domain
+   variables, allowed tuples, equality/disequality, ordinal/order constraints,
+   `all_different`, and target projections.
+4. **Exact solve:** a CP/SAT backend searches the model and returns enough
+   solutions/projections to decide target categoricity.
+5. **Projection/diagnostics:** map solver assignments to claims and explain
+   no-match, ambiguity, duplicate claim, unsupported constructs, and forcing
+   facts.
+
+**Solver choice.** Target
+**[OR-Tools CP-SAT](https://developers.google.com/optimization/cp/cp_solver)**
+for the exact-assignment backend. It matches this problem directly: finite
+integer domains, allowed-assignment table constraints, solution/status
+reporting, and a native
+[`AllDifferent`](https://developers.google.com/optimization/reference/python/sat/python/cp_model#AddAllDifferent)
+global constraint. The main risk is integration cost, because OR-Tools is not a
+Rust-native dependency; treat the first implementation as a thin Bazel/C++
+sidecar or protobuf boundary and measure it on the hardest Tana selector case
+before broad cutover.
+
+Known integration blocker: a first sidecar spike with `or-tools@9.15` reached
+Bazel analysis on RBE and then failed because `pybind11_abseil` defines a
+dev-only pip hub named `pypi`, conflicting with Ducktape's existing `pypi` hub.
+Handle this as a dependency-only unblock before production solver work. Viable
+directions are a Bzlmod override/patch for `pybind11_abseil`, an isolated
+sidecar Bazel module boundary, or switching to the SAT fallback if the OR-Tools
+dependency surface stays too expensive. The concrete unblock plan lives in
+<ortools_bzlmod_unblock.md>.
+
+The fallback is **[RustSAT](https://github.com/chrjabs/rustsat) +
+CaDiCaL/Kissat** if OR-Tools integration is too expensive. In that shape the
+`SelectorConstraintModel` is encoded to SAT: boolean variables for `(selector
+variable, candidate value)`, exactly-one domain constraints, at-most-one per
+candidate value for `all_different`, and clauses/auxiliary variables for
+allowed tuples. This is an implementation fallback for the same CP model, not a
+license to hand-roll CSP heuristics in debundle.
+
+Do **not** keep optimizing the current `AssignmentRow` scheduler as the
+destination. It is useful as a migration oracle and as evidence for which facts
+and tuples are needed, but it is exactly the wrong shape for target injection:
+it enumerates partial/full assignment rows and checks pairwise disequality after
+rows are materialized. Also do **not** restart this as Soufflé, Crepe, DDlog, or
+a bespoke backtracking solver unless a measured backend spike proves both
+OR-Tools and the SAT fallback are unsuitable.
 
 **Caveats.** Pure positive Datalog needs care for closed-world / counting anchors ("the
 class with _exactly_ these members"; "the _only_ class with method m" as a writable
@@ -300,12 +352,12 @@ wrongly.
 
 ## Scale and performance
 
-The problem **decomposes by connected components**: a selector that shares no symbol
-with any other is an independent subquery whose rare-literal anchors prune it to
-near-singleton — so the common single-match case is as cheap as today's matcher, and
-only the small cross-reference clusters need a genuine joint solve. With the Datalog
-back-end this falls out of indexing + selectivity-ordered semi-naive evaluation rather
-than hand-rolled propagation.
+The model may decompose by connected components as a backend optimization, but
+that must not weaken the semantics. A selector that shares no symbol with any
+other is an independent subproblem; a selector cluster connected by shared
+targets, alpha variables, relation atoms, or `all_different` is one exact
+assignment problem. Diagnostics should not force a Rust-level decomposition that
+changes the model or sacrifices propagation.
 
 Tooling payoff: have the solver **report, per target, which relations forced
 uniqueness, tagged invariant/variant**. Then `selector-debt` can auto-flag "unique only
@@ -366,9 +418,10 @@ EDB:
 - label posting lists still used by `ChunkResolver` in tooling/authoring paths.
 
 The cutover is a consumer change: add native AST relations and shape rules to
-the Ascent solver, delete each production fallback shape after focused
-equivalence tests and corpus checks pass, then keep tooling/authoring uses
-behind the same solver-backed semantics.
+the fact/tuple derivation layer, build the shared `SelectorConstraintModel`,
+delete each production fallback shape after focused equivalence tests and
+corpus checks pass, then keep tooling/authoring uses behind the same
+solver-backed semantics.
 
 ### It replaces several workflow parts, not just the matcher
 
@@ -388,14 +441,17 @@ taxonomy and `describe`/`show-source`/`cluster` (they read the graph, not select
 
 Two layers, kept distinct:
 
-- **IR (engine-facing) — Datalog-native.** The compiled form the solver consumes is a
-  normalized atom/rule set: per-target distinguished variables, the derived-predicate
-  library (`calls`/`alias`/… as rules), `@Name` cross-refs as shared variables, and any
-  negation. Non-negotiable — it is what the engine evaluates.
+- **IR (engine-facing) — constraint-native.** The compiled form the solver
+  consumes is a normalized constraint model: per-target distinguished variables,
+  finite domains, allowed tuples derived from the predicate library
+  (`calls`/`alias`/…), `@Name` cross-refs as shared variables, and any
+  equality/disequality/negation-derived constraints. Non-negotiable — it is what
+  the engine evaluates.
 - **Authoring (human/agent-facing) — a structured 1:1 skin over that IR**, not a raw
-  Datalog file. A _pure_ `.dl` spec isn't actually on the table: the dominant **shape**
-  atom must stay JS-with-holes (hand-written AST atoms are the unreadable dump the rubric
-  exists to avoid), so the format is always Datalog-for-relations + a JS-shape escape.
+  Datalog or SAT file. The dominant **shape** atom must stay JS-with-holes
+  (hand-written AST atoms are the unreadable dump the rubric exists to avoid),
+  so the format is always relational atoms + a JS-shape escape, compiled to the
+  constraint model.
 
 So the authoring vocabulary — today `selector.binding.name`, one contiguous
 `source_match`, `binding_groups`, `anonymous_statements`, none of which can express a
@@ -414,7 +470,7 @@ conjunction of atoms**:
   clause-local hole.
 - **escape hatch** — a `where:` block of raw IR atoms sharing `$` variables, for the rare
   multi-atom join or negation the structured keys express clumsily. This is where the
-  format goes rule-native exactly when YAML would fight the semantics, without paying that
+  format goes relation-native exactly when YAML would fight the semantics, without paying that
   cost for the simple 95%.
 - **negation / uniqueness** (later) — "the _only_ X with method m", "whose sole use is
   @Y" — stratified-negation atoms (most naturally written in the `where:` escape hatch);
@@ -529,14 +585,14 @@ In the endpoint, neither part is a procedural side table: placement choices and
 the identifier equalities/disequalities they induce are facts in the same
 solver model.
 
-- **(A) placement is cleanly Datalog-expressible — backtracking and all.** A list-with-holes is
+- **(A) placement is cleanly relation-expressible — backtracking and all.** A list-with-holes is
   `[hole?, seg₁, hole, …, segₖ, hole?]`; "`segᵢ` matches starting at ordinal `p`" is the
   node-homomorphism over its elements vs `subject[p..]`, and a full match is a **chain**
   `seg_at(1,p₁), seg_at(2,p₂), …` with `end(i) < start(i+1)` per gap-allowing hole plus the
-  anchoring equalities. Datalog evaluates the whole feasible-placement set at once, so the
-  imperative greedy+snapshot/restore search **disappears** — it was one operational strategy for a
-  relation Datalog computes set-at-a-time. **≥2 holes per list (interior segments with a free
-  start) are fine, and the corpus uses them** — `infra/sentryInit.initSentry` is
+  anchoring equalities. The feasible-placement set should be derived as allowed
+  tuples, then handed to the exact backend; the imperative
+  greedy+snapshot/restore search **disappears** because placement is data, not a
+  side resolver. **≥2 holes per list (interior segments with a free start) are fine, and the corpus uses them** — `infra/sentryInit.initSentry` is
   `[STMT_LIST, const s = …, STMT_LIST]`, `infra/android.serializeNodeForNativeBridge` is
   `{OBJECT_PROPS, isTag: ANYTHING, OBJECT_PROPS}`. So the earlier "≤1 hole per list" intuition is
   **empirically false**; the chain-join handles interior links regardless.
@@ -545,11 +601,11 @@ solver model.
   declarative rejection condition: reject any placement where one selector
   identifier maps to two source identifiers, where two selector identifiers map
   to the same source identifier, or where required `resolves_to` / scope facts
-  disagree. In Ascent terms this is ordinary
-  disequality/stratified-negation/all-different over placement-tagged rows. If
-  the row set gets too large, that is a profiling and encoding problem to solve
-  with better indexes or a different off-the-shelf solver, not a reason to
-  reintroduce a procedural `MatcherState` side resolver.
+  disagree. In the backend model this is equality/disequality plus
+  `all_different` over placement-tagged variables. If the tuple set gets too
+  large, that is a profiling and encoding problem to solve with better indexes
+  or the SAT fallback, not a reason to reintroduce a procedural `MatcherState`
+  side resolver.
 
 So we narrow on the coupling axis, not the hole-count axis. The faithful
 encoding lowers **placement** and **alpha constraints** together. The only
@@ -634,12 +690,15 @@ classes, consumer clusters the matcher can reach only by minified name or a frag
 re-minification-proof identity anchor.
 
 **All six are implemented and pass** as Ascent rules over a synthetic EDB in
-`selector_query_examples.rs` (`selector_query_examples_test`): cross-ref joins, a disequality
-`all_different`, stratified negation (`!rel`), recursive transitive closure, `count` aggregation
-with a uniqueness guard, and an AST-literal-∧-import-edge join all resolve to the expected owners.
-So the vocabulary is proven expressible in the engine we picked — the gap to
-production is native consumption of the AST-facts EDB plus template→atoms
-lowering, not the solver's capability.
+`selector_query_examples.rs` (`selector_query_examples_test`): cross-ref joins,
+disequality, stratified negation (`!rel`), recursive transitive closure, `count`
+aggregation with a uniqueness guard, and an AST-literal-∧-import-edge join all
+resolve to the expected owners. That proves the fact vocabulary and rule shape
+are useful. It does **not** prove Ascent is the right exact-assignment backend
+for production-sized selector programs, because the current solver reaches
+target assignment by enumerating `AssignmentRow` tuples and filtering them. The
+backend pivot preserves the vocabulary proof while moving exact target
+assignment to a finite-domain solver.
 
 ## Closed so far
 
@@ -653,9 +712,10 @@ lowering, not the solver's capability.
   `ChunkResolver`.
 - Exact single-statement shape and superclass constraints lower to native AST
   facts.
-- Ascent remains the production solver choice; do not restart solver selection
-  unless profiling proves the in-process path cannot meet the latency/memory
-  target.
+- Profiling identified the production-sized bottleneck in the current
+  `AssignmentRow` exact-assignment encoding. Ascent remains useful for relation
+  derivation and as a migration oracle, but it is no longer the planned
+  production owner of target assignment.
 
 ## Remaining work (single-model cutover)
 
@@ -663,27 +723,44 @@ This is the detailed P0 queue; <../TODO.md> should only summarize it.
 
 - **G1 — alpha-all as query constraints.** Lower `identifiers: alpha_all` to
   identifier occurrence variables, `resolves_to`/scope facts, placement-tagged
-  equality and disequality rows, and `all_different`-style rejection rules. Do
-  not clone `MatcherState` or add a procedural alpha resolver.
-- **G2 — retained hole and predicate lowering.** Lower today's retained
+  equality/disequality constraints, and native `all_different` where the
+  selector semantics require injectivity. Do not clone `MatcherState` or add a
+  procedural alpha resolver.
+- **G2 — exact-assignment backend spike.** Implement enough of
+  `SelectorConstraintModel` plus the exact backend to solve one hard
+  global-selector case with semantic `all_different`. Sequence this as:
+  first land the backend-neutral model boundary; next unblock and prove the
+  OR-Tools CP-SAT sidecar under RBE with a tiny finite-domain / `all_different`
+  / table-constraint target; then solve the anonymized broad-vs-specific
+  fixture. Private-corpus runs are optional smoke evidence, not checked-in
+  fixtures or the primary acceptance gate. If the OR-Tools Bzlmod conflict or
+  native dependency surface remains too expensive, perform the same spike
+  through RustSAT + CaDiCaL/Kissat. The acceptance bar is measured runtime and
+  matching semantics, not a nicer hand-written scheduler.
+- **G3 — retained hole and predicate lowering.** Lower today's retained
   JS-with-holes selectors and binding groups into native AST/owner IR atoms:
   simple existential holes, regex string predicates, run-hole placement
   (`STMT_LIST`, `ARGS`, `OBJECT_PROPS`, `DECLARATORS`, `CLASS_REST`,
   `CASE_REST`), anonymous statements as distinguished targets, exact
   identifiers, target bindings, and binding groups. Each construct either
   compiles faithfully or reports `unsupported`.
-- **G3 — source-match surface pruning.** Remove unused authoring options before
+- **G4 — source-match surface pruning.** Remove unused authoring options before
   nativeizing them. Current Gaffer/Tana census shows no use of
   `target_statement`, `target_statements`, or `wildcard_string_literals`; verify
   absence in a focused branch, delete the YAML/code/docs surface, and slate any
   other vestigial debundle features that gaffer-private does not use for
-  removal rather than carrying them into the query model.
-- **G4 — tooling semantics cutover.** Move `match_selector`, selector codemods,
+  removal rather than carrying them into the query model. Current safe cleanup
+  queue: `wildcard_string_literals`, `match-selector --identifiers`, and old
+  `STATEMENT_*` compatibility spellings if any remain in tests/docs. Defer
+  `identifiers: alpha_all`, exact anonymous `match`, readability labels, and
+  top-level `STMT_LIST` cleanup until either gaffer-private is migrated or the
+  single-resolution backend owns the retained forms.
+- **G5 — tooling semantics cutover.** Move `match_selector`, selector codemods,
   synthesis, and repair/prove gates onto solver-backed selector semantics so
   authoring tools and production materialization do not drift. No-match,
   ambiguous, unsupported, and duplicate-claim diagnostics should be projections
   of the native solver result, not `ChunkResolver` side tables.
-- **G5 — relation/language fold-in.** Re-express `cross_ref`, `reads_member`,
+- **G6 — relation/language fold-in.** Re-express `cross_ref`, `reads_member`,
   `member_of_module`, `passed_to_call`, `makes_decorate_call`,
   `intrinsic_alias`, and the Gaffer feature-request vocabulary as IR atoms or
   derived predicates over owner/reference + AST facts. The real-spec conversion
@@ -695,6 +772,12 @@ This is the detailed P0 queue; <../TODO.md> should only summarize it.
 - **Build/test gate**: build the changed debundler library and its consumers;
   run the changed area's tests with `--cache_test_results=no` and lint on for a
   final step.
+- **Injective-disambiguation gate**: a broad selector and a stricter selector
+  must resolve jointly through target injectivity. Example: if `X` is
+  constrained by `const x = f(ANYTHING)` and `Y` by `const y = f(123)`, while
+  the source has `xx = f(134)` and `yy = f(123)`, the global solve must force
+  `Y = yy` and then `X = xx`. Disabling `all_different` may be used only as a
+  temporary profiling switch, never as final semantics.
 - **Resolver parity gate**: while fallback shapes still exist, the native solve
   and the current fallback resolver agree on every covered resolved target,
   no-match, ambiguous match, duplicate claim, and unsupported construct.
@@ -742,6 +825,34 @@ resolver architecture:
   "the second variable in this declaration."
 - **Registry and roster selectors**: identify values by stable membership in an
   object/array table, call, key, or adapter roster.
+
+## Cleanup Dispatch Queue
+
+Do not preserve old matcher conveniences merely because they exist today. The
+safe early cleanup queue is:
+
+- remove or hide `source_match.wildcard_string_literals`;
+- remove `debundle spec match-selector --identifiers`, since the public flag is
+  single-choice and gaffer-private does not call it;
+- drop obsolete `STATEMENT_*` compatibility spelling if any tests/docs still
+  mention it.
+
+Likely cleanup after a focused branch or solver-backed replacement:
+
+- trim `selector-codemod --no-minimize` / `--full-ast-fallback` exact-body
+  knobs;
+- narrow source-aware `selector-debt` near-match options;
+- replace generic `NoMatch` fallback text, empty `nearest_candidates`, fact
+  near-miss scoring, `match-selector` slack relaxation, legacy source-match
+  timing hooks, and selector-IR row/stat stderr diagnostics with solver-native
+  explanations.
+
+Defer removal of `identifiers: alpha_all`, exact anonymous `match`, readability
+labels / typed holes, and top-level anonymous `STMT_LIST` until a gaffer-private
+migration or the single-resolution backend covers the retained form.
+
+Further synthesis/planning work:
+
 - **Large-prefix synthesis performance**: make prefix-wide inventory and
   candidate discovery practical for `app/bootstrap` scale, ideally under 10s on
   warmed inputs or with an explicit resumable offline mode.


### PR DESCRIPTION
## Summary

- update the debundle selector plan to split fact/table derivation from exact assignment
- name OR-Tools CP-SAT as the target exact-assignment backend, with RustSAT + CaDiCaL/Kissat as fallback
- document the observed OR-Tools Bzlmod blocker (`pybind11_abseil` duplicate `pypi` hub) as a dependency-only unblock before production solver wiring
- add `plans/ortools_bzlmod_unblock.md` with concrete OR-Tools dependency-unblock options and validation commands
- document injective target assignment as semantics and add the broad/specific selector regression requirement
- add audit-driven cleanup dispatch for unused source-match/options and diagnostic-only matcher mirrors

## Validation

- `git diff --check -- devinfra/js/debundle/TODO.md devinfra/js/debundle/plans/selector_constraint_model.md devinfra/js/debundle/plans/ortools_bzlmod_unblock.md`
- `nix develop --command git commit --amend --no-edit` hooks passed