### PR TITLE
debundle: add anonymized global selector fixture

### DIFF
--- a/devinfra/js/debundle/e2e/testdata/global_selector_assignment_stress/broad_specific_injective/README.md
+++ b/devinfra/js/debundle/e2e/testdata/global_selector_assignment_stress/broad_specific_injective/README.md
@@ -1,0 +1,48 @@
+# Broad Specific Injective Global Selector Fixture
+
+This fixture is a public, anonymized stand-in for the hard global-selector
+assignment shape: many alpha-renamed declarations match one broad selector,
+most of those declarations are pinned by more specific selectors, and the
+remaining broad claim becomes unique only through `all_different`.
+
+The source is intentionally synthetic. It does not preserve names, literals,
+module paths, or source text from any private bundle.
+
+## Shape
+
+- `source.js` declares twelve same-shape exported functions, `route00` through
+  `route11`.
+- Each route has the same structural body and the same stable labels except for
+  one slot literal, `slot-00` through `slot-11`.
+- Local variable names differ across routes to mimic `identifiers: alpha_all`
+  without requiring real minified names.
+- `pending_selector_constraints.yaml` sketches the future benchmark contract:
+  eleven specific targets pin `slot-00` through `slot-10`; one broad target
+  matches every route and is forced to `route11` only by the target-level
+  `all_different` constraint.
+
+The fixture is not wired into a Bazel target yet. It should become executable
+when the selector backend benchmark harness can build a `SelectorProgram` from
+this pending contract and run alternate `SelectorConstraintModel` backends.
+
+## Expected Semantics
+
+- Without `all_different`, the broad target is ambiguous over twelve owners.
+- With the eleven specific claims and target-level injectivity, the broad target
+  is forced to the one remaining owner, `route11`.
+- Every backend should return the same unique claim map.
+
+## Bottleneck Shape
+
+This fixture stresses the costly selector-assignment shape without copying real
+code:
+
+- a broad source match creates a large candidate domain for one target;
+- specific selectors create many small domains that overlap the broad one;
+- alpha-renamed locals prevent spelling-based pruning;
+- injectivity is the semantic reason the broad target becomes categorical.
+
+Scale the same template by increasing route count `N` and pinning `N - 1`
+specific slots. Useful points are `N = 12` for smoke, `N = 48` for interactive
+regression checks, and `N = 96` for offline profiling once a real harness
+exists.

--- a/devinfra/js/debundle/e2e/testdata/global_selector_assignment_stress/broad_specific_injective/pending_selector_constraints.yaml
+++ b/devinfra/js/debundle/e2e/testdata/global_selector_assignment_stress/broad_specific_injective/pending_selector_constraints.yaml
@@ -1,0 +1,55 @@
+# Pending contract for a future global-selector backend benchmark.
+#
+# This is deliberately not current debundle spec YAML. It records the intended
+# constraint model for the harness that will compare SelectorConstraintModel
+# backends without carrying private bundle source.
+status: pending-selector-backend-harness
+source: source.js
+targets:
+  specific_slots:
+    export_prefix: Route
+    runtime_prefix: route
+    slot_range: [0, 10]
+    identifiers: alpha_all
+    selector_template: |
+      export function targetRoute(arg) {
+        const first = sharedRead(arg, "user");
+        const second = sharedRuntime.normalize(first);
+        return sharedRuntime.emit("route", commonWrap("common", second), "slot-{index:02}");
+      }
+    expected_runtime_template: "route{index:02}"
+  broad_remainder:
+    export_name: RouteRemainder
+    identifiers: alpha_all
+    selector: |
+      export function targetRoute(arg) {
+        const first = sharedRead(arg, "user");
+        const second = sharedRuntime.normalize(first);
+        return sharedRuntime.emit("route", commonWrap("common", second), ANYTHING);
+      }
+    broad_domain_size: 12
+    expected_runtime_after_all_different: route11
+constraints:
+  all_different:
+    - Route00
+    - Route01
+    - Route02
+    - Route03
+    - Route04
+    - Route05
+    - Route06
+    - Route07
+    - Route08
+    - Route09
+    - Route10
+    - RouteRemainder
+expected:
+  specific_unique_claims: 11
+  broad_claim_without_all_different: ambiguous
+  broad_claim_with_all_different: route11
+measure:
+  - total wall time
+  - backend solve time
+  - assignment row count or equivalent candidate tuple count
+  - peak memory
+  - per-target outcome counts

--- a/devinfra/js/debundle/e2e/testdata/global_selector_assignment_stress/broad_specific_injective/source.js
+++ b/devinfra/js/debundle/e2e/testdata/global_selector_assignment_stress/broad_specific_injective/source.js
@@ -1,0 +1,88 @@
+const sharedRuntime = {
+  normalize(value) {
+    return String(value).trim();
+  },
+  emit(kind, value, marker) {
+    return { kind, value, marker };
+  },
+};
+
+function sharedRead(input, key) {
+  return input[key] ?? "";
+}
+
+function commonWrap(label, value) {
+  return `${label}:${value}`;
+}
+
+export function route00(input) {
+  const a0 = sharedRead(input, "user");
+  const b0 = sharedRuntime.normalize(a0);
+  return sharedRuntime.emit("route", commonWrap("common", b0), "slot-00");
+}
+
+export function route01(payload) {
+  const c1 = sharedRead(payload, "user");
+  const d1 = sharedRuntime.normalize(c1);
+  return sharedRuntime.emit("route", commonWrap("common", d1), "slot-01");
+}
+
+export function route02(message) {
+  const e2 = sharedRead(message, "user");
+  const f2 = sharedRuntime.normalize(e2);
+  return sharedRuntime.emit("route", commonWrap("common", f2), "slot-02");
+}
+
+export function route03(record) {
+  const g3 = sharedRead(record, "user");
+  const h3 = sharedRuntime.normalize(g3);
+  return sharedRuntime.emit("route", commonWrap("common", h3), "slot-03");
+}
+
+export function route04(event) {
+  const i4 = sharedRead(event, "user");
+  const j4 = sharedRuntime.normalize(i4);
+  return sharedRuntime.emit("route", commonWrap("common", j4), "slot-04");
+}
+
+export function route05(packet) {
+  const k5 = sharedRead(packet, "user");
+  const l5 = sharedRuntime.normalize(k5);
+  return sharedRuntime.emit("route", commonWrap("common", l5), "slot-05");
+}
+
+export function route06(frame) {
+  const m6 = sharedRead(frame, "user");
+  const n6 = sharedRuntime.normalize(m6);
+  return sharedRuntime.emit("route", commonWrap("common", n6), "slot-06");
+}
+
+export function route07(row) {
+  const o7 = sharedRead(row, "user");
+  const p7 = sharedRuntime.normalize(o7);
+  return sharedRuntime.emit("route", commonWrap("common", p7), "slot-07");
+}
+
+export function route08(entry) {
+  const q8 = sharedRead(entry, "user");
+  const r8 = sharedRuntime.normalize(q8);
+  return sharedRuntime.emit("route", commonWrap("common", r8), "slot-08");
+}
+
+export function route09(item) {
+  const s9 = sharedRead(item, "user");
+  const t9 = sharedRuntime.normalize(s9);
+  return sharedRuntime.emit("route", commonWrap("common", t9), "slot-09");
+}
+
+export function route10(point) {
+  const u10 = sharedRead(point, "user");
+  const v10 = sharedRuntime.normalize(u10);
+  return sharedRuntime.emit("route", commonWrap("common", v10), "slot-10");
+}
+
+export function route11(unit) {
+  const w11 = sharedRead(unit, "user");
+  const x11 = sharedRuntime.normalize(w11);
+  return sharedRuntime.emit("route", commonWrap("common", x11), "slot-11");
+}


### PR DESCRIPTION
## Summary
- add a synthetic broad-vs-specific selector fixture for the global assignment backend work
- document the intended pending constraint shape next to the fixture
- avoid private/minified bundle source by using generic route names and slot literals

## Validation
- `node --input-type=module --check < devinfra/js/debundle/e2e/testdata/global_selector_assignment_stress/broad_specific_injective/source.js`
- `yq '.' devinfra/js/debundle/e2e/testdata/global_selector_assignment_stress/broad_specific_injective/pending_selector_constraints.yaml >/dev/null`
- `git diff --check -- devinfra/js/debundle/e2e/testdata/global_selector_assignment_stress`
- `nix develop --command git commit --amend --no-edit` hooks passed before rebase

This is intentionally a pending fixture contract, not a live Bazel test target yet. It should become executable once the selector backend harness can construct `SelectorConstraintModel` inputs from the fixture contract.