### PR TITLE
haku/console: add the shell-owned launch button to the SPA

### DIFF
--- a/haku/PLAN.md
+++ b/haku/PLAN.md
@@ -192,9 +192,8 @@ Two tiers the console treats completely differently:
 - **Phase 1 — declarative (1a).** A richer **typed widget schema** (containers, inputs,
   selects, links, sub-pages) emitted in `haku-state` and interpreted by a **trusted
   renderer** — _no agent JS executes_ — beyond today's `actions[]`. Also still to build:
-  the shell-owned **launch control + executions panel** in the SPA, and
-  `GET /api/capabilities/launch-routine/executions` + a **one-in-flight guard** (both
-  gated on the routine-listing API, not yet wired).
+  the **executions panel** in the SPA, and `GET /api/capabilities/launch-routine/executions`
+  - a **one-in-flight guard** (both gated on the routine-listing API, not yet wired).
 - **Phase 2 — free-form (1b, the destination).** Haku writes TSX/JS into `haku-state`; the
   untrusted render origin transpiles it **at runtime** (never compiled into the trusted
   bundle) and runs it in a **sandboxed cross-origin iframe** (`sandbox` without

--- a/haku/console/capabilities.py
+++ b/haku/console/capabilities.py
@@ -15,8 +15,7 @@ import logging
 from typing import Annotated, cast
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Request
-from fastapi.responses import JSONResponse
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi_csrf_protect import CsrfProtect
 from pydantic import BaseModel
 
@@ -27,6 +26,10 @@ logger = logging.getLogger(__name__)
 Csrf = Annotated[CsrfProtect, Depends()]
 
 router = APIRouter(prefix="/api/capabilities", tags=["capabilities"])
+
+
+class CsrfTokenResponse(BaseModel):
+    csrf_token: str
 
 
 class LaunchRoutineResult(BaseModel):
@@ -50,11 +53,12 @@ def _launch_config(settings: Annotated[Settings, Depends(_settings)]) -> LaunchR
 # privileged tier this way stops a cross-site request from riding the operator's
 # Authentik session cookie to fire a capability.
 @router.get("/csrf")
-async def csrf_token(csrf_protect: Csrf) -> JSONResponse:
+async def csrf_token(response: Response, csrf_protect: Csrf) -> CsrfTokenResponse:
+    # Set the signed cookie on the injected Response (which FastAPI returns) so the
+    # body can stay a typed model — the frontend generates its client off this schema.
     token, signed = csrf_protect.generate_csrf_tokens()
-    response = JSONResponse({"csrf_token": token})
     csrf_protect.set_csrf_cookie(signed, response)
-    return response
+    return CsrfTokenResponse(csrf_token=token)
 
 
 @router.post("/launch-routine")

--- a/haku/console/frontend/BUILD.bazel
+++ b/haku/console/frontend/BUILD.bazel
@@ -62,12 +62,23 @@ js_library(
 )
 
 js_library(
+    name = "launch",
+    srcs = ["launch.tsx"],
+    deps = [
+        ":client",
+        "//:node_modules/@mantine/core",
+        "//:node_modules/react",
+    ],
+)
+
+js_library(
     name = "app",
     srcs = ["app.tsx"],
     deps = [
         ":client",
         ":constants",
         ":feedback",
+        ":launch",
         ":task",
         "//:node_modules/@mantine/core",
         "//:node_modules/react",
@@ -113,6 +124,7 @@ filegroup(
         "constants.ts",
         "feedback.tsx",
         "index.html",
+        "launch.tsx",
         "main.tsx",
         "markdown.ts",
         "task.tsx",

--- a/haku/console/frontend/app.tsx
+++ b/haku/console/frontend/app.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from "react";
-import { Anchor, Loader, Text, Title } from "@mantine/core";
+import { Anchor, Group, Loader, Text, Title } from "@mantine/core";
 
 import { type DashboardResponse, type Item, clickAction, fetchDashboard, unclickAction } from "./client.ts";
 import { INTAKE_NEW, UP_NEXT } from "./constants.ts";
 import { FeedbackForm } from "./feedback.tsx";
+import { LaunchRoutineButton } from "./launch.tsx";
 import { TaskCard, clickKey } from "./task.tsx";
 
 function statusCounts(items: Item[]): string {
@@ -70,7 +71,10 @@ export default function App() {
 
   return (
     <div className="mx-auto max-w-3xl px-4 py-8">
-      <Title order={1}>Haku</Title>
+      <Group justify="space-between" align="center">
+        <Title order={1}>Haku</Title>
+        <LaunchRoutineButton />
+      </Group>
       <Text c="dimmed" mb="lg">
         Your value-ranked backlog ·{" "}
         <Anchor href={INTAKE_NEW} c="dimmed" underline="always">

--- a/haku/console/frontend/client.ts
+++ b/haku/console/frontend/client.ts
@@ -35,3 +35,15 @@ export async function sendFeedback(text: string, itemId?: string): Promise<void>
   const { error } = await api.POST("/api/trace/feedback", { body: { text, item_id: itemId } });
   if (error) throw new Error("Failed to send feedback");
 }
+
+// Capability tier. Fetch a CSRF token (which also sets the signed double-submit
+// cookie), then fire the routine echoing the token in X-CSRF-Token. The bearer
+// stays server-side; this only triggers the action.
+export async function launchRoutine(): Promise<void> {
+  const { data, error: csrfError } = await api.GET("/api/capabilities/csrf");
+  if (csrfError || !data) throw new Error("Failed to get CSRF token");
+  const { error } = await api.POST("/api/capabilities/launch-routine", {
+    headers: { "X-CSRF-Token": data.csrf_token },
+  });
+  if (error) throw new Error("Failed to launch routine");
+}

--- a/haku/console/frontend/launch.tsx
+++ b/haku/console/frontend/launch.tsx
@@ -1,0 +1,70 @@
+import { useState } from "react";
+import { Button, Group, Modal, Text } from "@mantine/core";
+
+import { launchRoutine } from "./client.ts";
+
+// Lifecycle as a closed union so the confirm/launching/done/error states can't be
+// combined into something nonsensical.
+type State =
+  | { status: "idle" }
+  | { status: "confirming" }
+  | { status: "launching" }
+  | { status: "launched" }
+  | { status: "error"; message: string };
+
+// Shell-owned launch control for the `launch-routine` capability. This button and its
+// confirm copy live in the trusted bundle (never agent-authored), so a genuine operator
+// gesture against trusted-rendered text is what fires the capability — agent UI can at
+// most ask for it, never script or spoof it. The actual CSRF + server-side bearer live
+// in the backend (see haku/console/capabilities.py).
+export function LaunchRoutineButton() {
+  const [state, setState] = useState<State>({ status: "idle" });
+  const launching = state.status === "launching";
+
+  function confirm() {
+    setState({ status: "launching" });
+    void launchRoutine()
+      .then(() => setState({ status: "launched" }))
+      .catch((e: unknown) => setState({ status: "error", message: e instanceof Error ? e.message : String(e) }));
+  }
+
+  return (
+    <>
+      <Group gap="sm">
+        <Button
+          variant="light"
+          color="indigo"
+          size="xs"
+          loading={launching}
+          onClick={() => setState({ status: "confirming" })}
+        >
+          {state.status === "launched" ? "Launched ✓" : "Launch Haku run"}
+        </Button>
+        {state.status === "error" && (
+          <Text size="sm" c="red">
+            Failed: {state.message}
+          </Text>
+        )}
+      </Group>
+
+      <Modal
+        opened={state.status === "confirming" || launching}
+        onClose={() => !launching && setState({ status: "idle" })}
+        title="Launch a Haku run?"
+        centered
+      >
+        <Text size="sm" mb="md">
+          This starts a new Claude Code web session running Haku now.
+        </Text>
+        <Group justify="flex-end">
+          <Button variant="default" disabled={launching} onClick={() => setState({ status: "idle" })}>
+            Cancel
+          </Button>
+          <Button color="indigo" loading={launching} onClick={confirm}>
+            Launch
+          </Button>
+        </Group>
+      </Modal>
+    </>
+  );
+}


### PR DESCRIPTION
## What

The frontend half of the `launch-routine` capability (#2478): a button in the dashboard header that fires a Haku run.

## Shell-owned, by design

The button and its confirm copy live in the **trusted bundle** — never agent-authored. So a genuine operator gesture against trusted-rendered text is what fires the capability; agent-authored UI (Phase 2) can at most *ask* for the control, never script or spoof it. This is the "privileged controls are shell-owned, confirmed against trusted copy" principle from `haku/PLAN.md → The agent-authored console`.

## Changes

- **`launch.tsx`** — `LaunchRoutineButton`: a closed-union lifecycle (idle/confirming/launching/launched/error) and a Mantine confirm modal ("Launch a Haku run? This starts a new Claude Code web session running Haku now."). Rendered in the header next to the title.
- **`client.ts`** — `launchRoutine()`: `GET /api/capabilities/csrf` for the token (+ signed cookie), then `POST /launch-routine` echoing it in `X-CSRF-Token`.
- **`capabilities.py`** — `/csrf` now returns a typed `CsrfTokenResponse` (cookie set on the injected `Response`) so the generated OpenAPI schema types the frontend client; `tsc_test` then proves the client matches the routes.
- **frontend BUILD** — `launch` js_library + tailwind content source.

## Validation

`bbr test //haku/console/...` green — `tsc_test` type-checks `launch.tsx` + `client.ts` against the regenerated schema; `server_image` bundles. Pre-commit clean.

## Not in scope

The **executions panel** and **one-in-flight guard** remain (both gated on the routine-*listing* API, which isn't wired). The button works standalone — it just doesn't yet show history or block a double-launch beyond the modal.