### PR TITLE
grocy-sf: provision read-only haku Grocy user (Flux-gated Job)

### DIFF
--- a/cluster/k8s/grocy/sf/haku-user/flux-kustomization.yaml
+++ b/cluster/k8s/grocy/sf/haku-user/flux-kustomization.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: grocy-sf-haku-user
+  namespace: flux-system
+spec:
+  retryInterval: 1m
+  interval: 10m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./cluster/k8s/grocy/sf/haku-user
+  prune: true
+  # Block dependents (the haku read-only facade) until the provisioner Job has
+  # completed, so haku never connects before its Grocy user is locked read-only.
+  wait: true
+  dependsOn:
+    - name: grocy-sf
+  healthChecks:
+    - apiVersion: batch/v1
+      kind: Job
+      name: grocy-sf-haku-user-provisioner
+      namespace: grocy-sf

--- a/cluster/k8s/grocy/sf/haku-user/job.yaml
+++ b/cluster/k8s/grocy/sf/haku-user/job.yaml
@@ -1,0 +1,46 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: grocy-sf-haku-user-provisioner
+  namespace: grocy-sf
+  annotations:
+    # The Job spec is immutable; let Flux recreate it when provision.py changes.
+    kustomize.toolkit.fluxcd.io/force: enabled
+spec:
+  backoffLimit: 10
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: grocy-sf-haku-user-provisioner
+    spec:
+      restartPolicy: OnFailure
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: provisioner
+          image: python:3.13-alpine
+          command: ["python", "/scripts/provision.py"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+          volumeMounts:
+            - name: script
+              mountPath: /scripts
+              readOnly: true
+      volumes:
+        - name: script
+          configMap:
+            name: grocy-sf-haku-user-provisioner-script

--- a/cluster/k8s/grocy/sf/haku-user/kustomization.yaml
+++ b/cluster/k8s/grocy/sf/haku-user/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: grocy-sf
+resources:
+  - networkpolicy.yaml
+  - job.yaml
+configMapGenerator:
+  - name: grocy-sf-haku-user-provisioner-script
+    files:
+      - provision.py

--- a/cluster/k8s/grocy/sf/haku-user/networkpolicy.yaml
+++ b/cluster/k8s/grocy/sf/haku-user/networkpolicy.yaml
@@ -1,0 +1,24 @@
+# The base `grocy-ingress` policy (app-base) restricts Grocy :80 to the Authentik
+# outpost + Gatus, because any pod that reaches :80 can impersonate any user via
+# the trusted X-authentik-username header. NetworkPolicies are additive, so this
+# grants the one-shot provisioner Job that same in-cluster access (it acts as the
+# admin user to set haku's permissions). Scoped to the provisioner pod label only.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: grocy-haku-user-provisioner-ingress
+  namespace: grocy-sf
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: grocy
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: grocy-sf-haku-user-provisioner
+      ports:
+        - port: 80
+          protocol: TCP

--- a/cluster/k8s/grocy/sf/haku-user/provision.py
+++ b/cluster/k8s/grocy/sf/haku-user/provision.py
@@ -1,0 +1,78 @@
+"""Provision the read-only `haku` Grocy user in the grocy-sf instance.
+
+Grocy's REST API enforces per-user permissions: reads require none, every write
+requires a specific permission (verified empirically: a user with no permissions
+gets 200 on reads and 403 on writes). Permissions are assigned only at user
+creation (default `ADMIN`) and never re-asserted on login, so stripping them once
+sticks. Therefore a read-only user is simply a user with an empty permission set.
+
+Idempotent: ensures the `haku` user exists, then sets its permissions to []. Runs
+as the built-in `admin` user via Grocy's trusted `X-authentik-username` header —
+the dedicated NetworkPolicy is what restricts who may present it (the pod talks to
+Grocy in-cluster, bypassing the Authentik outpost).
+"""
+
+import json
+import time
+import urllib.error
+import urllib.request
+
+GROCY = "http://grocy.grocy-sf.svc.cluster.local:80"
+ADMIN = "admin"  # Grocy's built-in admin user (created by the schema migration)
+HAKU = "haku"
+
+
+def call(method: str, path: str, *, user: str, body: dict | None = None):
+    data = json.dumps(body).encode() if body is not None else None
+    headers = {"X-authentik-username": user}
+    if data is not None:
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(GROCY + path, data=data, headers=headers, method=method)
+    with urllib.request.urlopen(req) as response:
+        raw = response.read().decode()
+    return json.loads(raw) if raw.strip() else None
+
+
+def wait_for_migration() -> None:
+    """Trigger and await Grocy's schema migration.
+
+    Migration runs on the first request to a content route, NOT on the `/login`
+    readiness probe — a freshly-provisioned PVC has a 0-byte DB until something
+    hits `/`. Until the schema exists, the auth middleware errors on the missing
+    `users` table, so poll `/api/users` (as admin) until it returns a list.
+    """
+    for _ in range(30):
+        try:
+            call("GET", "/", user=ADMIN)  # 302 to login; side effect: run migration
+            if isinstance(call("GET", "/api/users", user=ADMIN), list):
+                return
+        except urllib.error.HTTPError:
+            pass
+        time.sleep(2)
+    raise RuntimeError("Grocy schema migration did not complete in time")
+
+
+def main() -> None:
+    wait_for_migration()
+
+    # Auto-create `haku` if absent: reverse-proxy auth creates the user on the
+    # first request bearing its username; a GET needs no permission.
+    call("GET", "/api/system/info", user=HAKU)
+
+    users = call("GET", "/api/users", user=ADMIN)
+    if not isinstance(users, list):
+        raise RuntimeError(f"GET /api/users did not return a list: {users!r}")
+    haku = next((u for u in users if u["username"] == HAKU), None)
+    if haku is None:
+        raise RuntimeError(f"{HAKU!r} user was not created by the reverse-proxy auth")
+
+    call("PUT", f"/api/users/{haku['id']}/permissions", user=ADMIN, body={"permissions": []})
+
+    perms = call("GET", f"/api/users/{haku['id']}/permissions", user=ADMIN)
+    if perms:
+        raise RuntimeError(f"expected empty permissions for {HAKU!r}, got {perms}")
+    print(f"{HAKU!r} user (id={haku['id']}) provisioned read-only (permissions=[])")
+
+
+if __name__ == "__main__":
+    main()

--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -293,6 +293,7 @@ resources:
   # --- grocy ---
   - grocy/sf/app/flux-kustomization.yaml
   - grocy/sf/agent-rbac/flux-kustomization.yaml
+  - grocy/sf/haku-user/flux-kustomization.yaml
   - grocy/vallejo/app/flux-kustomization.yaml
   - grocy/vallejo/agent-rbac/flux-kustomization.yaml
 


### PR DESCRIPTION
First step toward a read-only Grocy MCP facade for **haku**: ensure the `haku` Grocy user exists and is locked to **read-only**, gated by Flux so nothing connects as `haku` before its user is provisioned. SF only for now.

## Why empty permissions = read-only
Investigated against the live grocy-sf instance:
- Grocy's REST API **does** enforce per-user permissions (`checkPermission()` in the API controllers). **Reads require no permission; every write requires a specific one** (`MASTER_DATA_EDIT`, `STOCK_PURCHASE/CONSUME/INVENTORY/OPEN/TRANSFER/EDIT`, …).
- Verified empirically: a zero-permission user gets **200 on reads, 403 on writes** (stock add/consume, object create).
- Permissions are assigned only at user **creation** (default `ADMIN`) and **never re-asserted on login** — the reverse-proxy middleware just looks the user up by name. So stripping to `[]` once sticks.

⇒ A read-only user is simply a user with an **empty permission set** — no allowlist to curate. This is genuine server-side defense-in-depth, independent of the MCP `ToolFilter` the facade will add later.

## What's here
- **`provision.py`** — idempotent Job script (stdlib only). Triggers Grocy's schema migration (the `/login` readiness probe does *not*, so a fresh PVC has a 0-byte DB), ensures the `haku` user exists, then `PUT`s empty permissions and verifies. Acts as the built-in `admin` user via the trusted `X-authentik-username` header.
- **`networkpolicy.yaml`** — scoped allowance for the provisioner pod to reach `grocy:80`. The base `grocy-ingress` policy otherwise admits only the Authentik outpost + Gatus, since any pod reaching `:80` can impersonate any user via the header; NetworkPolicies are additive, so this opens only the provisioner pod label.
- **`flux-kustomization.yaml`** — `dependsOn: grocy-sf`, `wait: true` + a Job-completion healthcheck, so dependents (the future haku RO facade) block until `haku` is locked read-only.

## Validation
- `kustomize build` clean; `kubeconform`, `ruff`, `prettier` pass via pre-commit.

## Follow-ups (separate PRs)
- The read-only facade itself (Option A: `oauth_facade` over the existing grocy-sf MCP, forwarding a rotated `haku` Authentik machine-JWT via the existing `authentik-jwt-rotation` rotator → SOPS → secret) + `ToolFilter` allowlist.
- Wire the facade into the three haku runtimes.
- Consider promoting this Job to a CronJob to re-assert read-only after a DB reset (a wiped DB would otherwise auto-create `haku` as ADMIN on first contact).