### PR TITLE
haku: manage the Anthropic-hosted cloud agent via Terraform (Stage 2)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -105,6 +105,13 @@ tf.download(
     mirror = {
         "authentik": "goauthentik/authentik:2026.2.0",
         "aws": "hashicorp/aws:5.100.0",
+        # CAUTION: low-user-count community provider holding an Anthropic API key.
+        # On every version bump, manually review the source diff since the last
+        # pinned tag (focus: internal/client/ egress+secret handling,
+        # .github/workflows/release.yml) BEFORE updating the lock hashes. Do not
+        # auto-merge Renovate/update_deps bumps. See memory
+        # project_acma_provider_repin_review and tf/gitops/haku-cloud-agent/terraform.tf.
+        "claude-managed-agents": "modus-agendi/anthropic-claude-managed-agents:1.1.0",
         "external": "hashicorp/external:2.3.5",
         "flux": "fluxcd/flux:1.7.6",
         "forgejo": "svalabs/forgejo:1.5.0",

--- a/cluster/k8s/agents/authentik-jwt-rotation/rotate.py
+++ b/cluster/k8s/agents/authentik-jwt-rotation/rotate.py
@@ -44,6 +44,24 @@ TOKEN_URL = f"{AUTH_BASE}/application/o/token/"
 CredentialMode = Literal["client_secret", "user_password"]
 
 
+class K8sSecretOutput(BaseModel):
+    """Optional second output: write the minted token as a k8s Secret manifest.
+
+    Lets a rotation feed an in-cluster consumer (Flux decrypts + applies the
+    Secret) without that consumer ever touching SOPS. The `path` lives under
+    `cluster/k8s/` so the `.sops.yaml` cluster catch-all rule encrypts stringData
+    for Flux + admin. The token's `exp` epoch is written alongside so consumers
+    that need a monotonic "the token changed" signal (e.g. a Terraform write-only
+    `*_wo_version`) have one without decrypting the token.
+    """
+
+    path: Path = Field(description="Repo-relative path for the Secret manifest (under cluster/k8s/, *.sops.yaml)")
+    name: str
+    namespace: str
+    token_key: str = Field(default="jwt", description="stringData key for the JWT")
+    exp_key: str = Field(default="token-exp", description="stringData key for the JWT exp epoch (seconds)")
+
+
 class Rotation(BaseModel):
     name: str = Field(description="Human-readable name for logs and the commit message")
     provider_slug: str = Field(description="Authentik provider slug; pins the expected source-JWT issuer")
@@ -71,6 +89,11 @@ class Rotation(BaseModel):
         default=None,
         description="When set, exchange the source JWT into a proxy-provider token "
         "(client_id from credentials_dir/proxy_client_id) with these scopes",
+    )
+    k8s_secret: K8sSecretOutput | None = Field(
+        default=None,
+        description="When set, also write the minted token as a k8s Secret manifest (in addition "
+        "to sops_file) for an in-cluster consumer to read via Flux.",
     )
 
     @property
@@ -243,13 +266,41 @@ def rotate_one(client: httpx.Client, rotation: Rotation, config: Config) -> bool
     rotation.sops_file.write_text(yaml.safe_dump(stamps, sort_keys=False, width=2**31))
     subprocess.run(["sops", "encrypt", "--in-place", str(rotation.sops_file)], check=True)
     logger.info("%s: wrote token expiring %s", rotation.name, expires_iso)
+
+    if rotation.k8s_secret:
+        write_k8s_secret(rotation.k8s_secret, final_jwt, int(final_payload["exp"]))
+        logger.info("%s: wrote k8s Secret %s", rotation.name, rotation.k8s_secret.path)
     return True
+
+
+def write_k8s_secret(out: K8sSecretOutput, token: str, exp_epoch: int) -> None:
+    """Write `out.path` as a SOPS-encrypted k8s Secret manifest carrying the token + exp.
+
+    stringData is encrypted by the `.sops.yaml` cluster catch-all rule; metadata
+    stays plaintext. The exp epoch is the monotonic signal a consumer uses to know
+    the token rotated (e.g. a Terraform write-only `*_wo_version`).
+    """
+    manifest = {
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "metadata": {
+            "name": out.name,
+            "namespace": out.namespace,
+            "annotations": {"description": "Authentik JWT minted by authentik-jwt-rotation (rotated ~biweekly)."},
+        },
+        "type": "Opaque",
+        "stringData": {out.token_key: token, out.exp_key: str(exp_epoch)},
+    }
+    out.path.parent.mkdir(parents=True, exist_ok=True)
+    out.path.write_text(yaml.safe_dump(manifest, sort_keys=False, width=2**31))
+    subprocess.run(["sops", "encrypt", "--in-place", str(out.path)], check=True)
 
 
 def sparse_clone(config: Config, github_pat: str) -> None:
     """Init + sparse-fetch only .sops.yaml and the rotations' sops_files into cwd."""
     remote = f"https://x-access-token:{github_pat}@github.com/{config.github_repo}.git"
     sparse_paths = [config.sops_config, *(str(r.sops_file) for r in config.rotations)]
+    sparse_paths += [str(r.k8s_secret.path) for r in config.rotations if r.k8s_secret]
     subprocess.run(["git", "init", "-q"], check=True)
     subprocess.run(["git", "remote", "add", "origin", remote], check=True)
     subprocess.run(["git", "config", "core.sparseCheckout", "true"], check=True)
@@ -264,6 +315,8 @@ def commit_and_push(config: Config, rotated: list[str]) -> None:
     for rotation in config.rotations:
         if rotation.name in rotated:
             subprocess.run(["git", "add", "--", str(rotation.sops_file)], check=True)
+            if rotation.k8s_secret:
+                subprocess.run(["git", "add", "--", str(rotation.k8s_secret.path)], check=True)
     if subprocess.run(["git", "diff", "--cached", "--quiet"], check=False).returncode == 0:
         logger.info("tokens minted but SOPS files unchanged on disk (unexpected); nothing to commit")
         return

--- a/cluster/k8s/agents/authentik-jwt-rotation/rotations.yaml
+++ b/cluster/k8s/agents/authentik-jwt-rotation/rotations.yaml
@@ -25,6 +25,20 @@ rotations:
     credentials_dir: /var/run/secrets/authentik/haku-k8s
     sops_file: secrets/haku-k8s-jwt.yaml
     token_field: jwt
+    # Also publish the token as an in-cluster k8s Secret so the haku-cloud-agent
+    # tofu root can read it (env var) and write it into Haku's Anthropic vault as a
+    # static_bearer credential. `token-exp` is the monotonic signal tofu uses for
+    # the write-only token_wo_version, so a rotation re-sends the new token.
+    # TODO: the token now lives SOPS-encrypted in two places — secrets/haku-k8s-jwt.yaml
+    #   (bare, for the CLI/write_kubeconfig path) and this k8s Secret manifest (for
+    #   Flux). That duplication is annoying. Nicer would be a single SOPS file that
+    #   Flux can turn into a Secret directly (Flux only decrypts+applies files that
+    #   are already k8s manifests; it won't synthesize a Secret from a bare jwt:
+    #   file). Revisit if Flux/an operator grows a "SOPS data file -> Secret" path.
+    k8s_secret:
+      path: cluster/k8s/haku/cloud-agent-tf/haku-kube-token.sops.yaml
+      name: haku-cloud-kube-token
+      namespace: flux-system
   - name: haku-grocy
     # Source JWT for haku's read-only access to the grocy-sf MCP. Issued by the
     # grocy-mcp-sf provider so its iss matches the MCP's JWTVerifier; the MCP runs

--- a/cluster/k8s/agents/authentik-jwt-rotation/test_rotate.py
+++ b/cluster/k8s/agents/authentik-jwt-rotation/test_rotate.py
@@ -6,7 +6,16 @@ from pathlib import Path
 import pytest
 import pytest_bazel
 from pydantic import ValidationError
-from rotate import Config, Rotation, jwt_payload, mint_jwt, remaining_hours, stamped_audiences, token_audiences
+from rotate import (
+    Config,
+    K8sSecretOutput,
+    Rotation,
+    jwt_payload,
+    mint_jwt,
+    remaining_hours,
+    stamped_audiences,
+    token_audiences,
+)
 
 
 def _make_jwt(claims: dict) -> str:
@@ -91,6 +100,32 @@ def test_rotation_expected_audiences_defaults_none_and_parses_list():
         base | {"expected_audiences": ["kubectl-sandbox-client-credentials", "kubectl-passthrough-mcp"]}
     )
     assert with_aud.expected_audiences == ["kubectl-sandbox-client-credentials", "kubectl-passthrough-mcp"]
+
+
+def test_rotation_k8s_secret_defaults_none_and_parses():
+    base = {
+        "name": "haku-k8s",
+        "provider_slug": "kubectl-sandbox-client-credentials",
+        "scopes": "openid profile email groups",
+        "credentials_dir": "/creds",
+        "sops_file": "secrets/haku-k8s-jwt.yaml",
+        "token_field": "jwt",
+    }
+    assert Rotation.model_validate(base).k8s_secret is None
+    r = Rotation.model_validate(
+        base
+        | {
+            "k8s_secret": {
+                "path": "cluster/k8s/haku/cloud-agent-tf/haku-kube-token.sops.yaml",
+                "name": "haku-cloud-kube-token",
+                "namespace": "flux-system",
+            }
+        }
+    )
+    assert isinstance(r.k8s_secret, K8sSecretOutput)
+    assert r.k8s_secret.token_key == "jwt"  # default
+    assert r.k8s_secret.exp_key == "token-exp"  # default
+    assert r.k8s_secret.namespace == "flux-system"
 
 
 def test_rotation_expected_issuer_derived_from_slug():

--- a/cluster/k8s/haku/cloud-agent-tf/anthropic-api-key.sops.yaml
+++ b/cluster/k8s/haku/cloud-agent-tf/anthropic-api-key.sops.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: haku-cloud-anthropic-api-key
+    namespace: flux-system
+    annotations:
+        description: Anthropic workspace API key (dedicated 'haku' workspace) for the haku-cloud-agent tofu root. Injected into the tofu-controller runner as ANTHROPIC_API_KEY so the claude-managed-agents provider can manage Haku's Anthropic-hosted agent. Regular workspace key, NOT admin.
+type: Opaque
+stringData:
+    api-key: ENC[AES256_GCM,data:KYDTBY9S8PMhwWNO0ZMZM6FO523ngsj7u45pdzNqK32vDVkJil6b0THKcQ5D3H1nGrQ/cO0Iska2qHXO/zssf81ypvHZEENLXvMWPfzwxh9DVkxYzczUtUQ0hdetWq18ei6BWc39yXmNhTh/,iv:d1YoMbfBsBDr0F/5w2rgOVIJC4Bj23+Lko/Nv2UQ7D8=,tag:HhZUipiGkqeqZZTfkOf9Hw==,type:str]
+sops:
+    age:
+        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBiTHE1cUJOVnVodzh2VG8y
+            SkVHbmNWbzNJVjA4aG13Mm96MXRJTWc2bUdRCjMwV2p6eFlaVUZRbDJvNGJwSy9t
+            WHBFYkhzbUhwMUt0YktFSm1kRko0cjgKLS0tIGlobTNWaEUyeHJSZzR3SkE2Qm9I
+            eG1SZ2xaNzNPMGxGbXJJdi9yU3dSbG8KufA29ZggouKRxtRd5Cb8BxqLnkzoYu/O
+            FfUu2v0/2dbI6fQmIKiqiN63yvLLjP6eKHjK60lUkkEj+yQGBrBjtw==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1nywlwepsyfxvyhqwkjquzz02nmus65gf6qewfjju4alym8f7se5qnua8na
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrczBySmpKdmYzWlhHZ25H
+            ZFdtcFQwZ0MxdnIycHNQRVJObjN1WlN5NENzCjdBRE9NTlFuU3MwQlRSQW9ERXVo
+            bU92ODc4bHNFRDl4YTlXbGc4SlE2UHcKLS0tIGE0NUM4M0dEU3pVdW9UcHM3TW1X
+            QUNNRmhVNmJzWUtqNFZrZGczNjcwOUEKjGhweaX/E3cyeK+IhZX/wq8j5gzlwhu/
+            O9VNBBtCBM3KvtiluEJYIHXobeNbHZy5tEtHU6vQX8IYt3ZqwEMhIw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-06-26T09:18:10Z"
+    mac: ENC[AES256_GCM,data:VqesepF3TZCcETZdSsJgaM8W+3Ada9WAxhkBun8qVso7DX0bacm0F220a5Y1QcsMK0ytNTQLIUyaBFM150KVd7Bcf3O+7knkuR+fJclE3ySsQpiuH6+95uD8S37yA390cQuB3hzvTGCcoypm5T5JouIh/NGpC40/MvoqjGKLXY4=,iv:/DtxQsqDrhmOBtTkqYeURhxBC/nhqKd6iH2N1TEbgJs=,tag:KOHupw4qUM0INqQj0uqSrw==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.1

--- a/cluster/k8s/haku/cloud-agent-tf/flux-kustomization.yaml
+++ b/cluster/k8s/haku/cloud-agent-tf/flux-kustomization.yaml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: haku-cloud-agent
+  namespace: flux-system
+spec:
+  interval: 10m
+  retryInterval: 1m
+  timeout: 10m
+  path: ./cluster/k8s/haku/cloud-agent-tf
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  healthChecks:
+    - apiVersion: infra.contrib.fluxcd.io/v1alpha2
+      kind: Terraform
+      name: haku-cloud-agent
+      namespace: flux-system
+  dependsOn:
+    - name: tofu-controller
+    - name: tofu-state-db
+    # The agent reaches the cluster through this MCP; its first deployment run
+    # needs it serving.
+    - name: kubectl-machine-mcp

--- a/cluster/k8s/haku/cloud-agent-tf/haku-kube-token.sops.yaml
+++ b/cluster/k8s/haku/cloud-agent-tf/haku-kube-token.sops.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: haku-cloud-kube-token
+    namespace: flux-system
+    annotations:
+        description: Authentik JWT minted by authentik-jwt-rotation (rotated ~biweekly). Seed; rotator overwrites at next mint. Read by tf/gitops/haku-cloud-agent -> Anthropic vault static_bearer.
+type: Opaque
+stringData:
+    jwt: ENC[AES256_GCM,data:6H+edCu134N6llVMetOgf1Dz2AElRENpkUfKsEls07BUJe6Z8tuUM8sqEaHYcCrUsLfY0fuAcY3oO5qryLdtZBN1zx2NcCJi7qa5inhqxeTmkAW9Oz4xITxQa/BoD0rMgISPdYoHuwe2Vo03DwUfb+uKLjzX6+Y61d9uhIth1mvzJ1/X9qWm2aAbwI+MdF9Ws5pqzVh1ql+pFfHmJorMDfeOdd940usQNQKd8hsbKZ9yeGQkkVZa8TAxt05KPl5DQOQrOCLL2oB2dpPdX2mnG92WSsu360gQ4+LXjtMB/yD9LoZ+PKVt9iEXGZZatc+it5ckesNxy0WDX0+MCYU6f5f6Hfsc/Gv6dawne398fd7dhsyq+0ge2lfH+k6MLpzl9XTyj5eekaxnjUxn+8YxZ+0OeoBYXns9pVKGLxCaf1oCKf56pEUePj7SJ8Dc3/Lh4cDeECFAFwYJfoDGEyD5FSCZsN/ZbHYKhml6sDS7RHES7Xw2hFzAuyhvcHi8wuHMNIiSADG4t5y4f5cSF+xcwSCiT1vdMJtLXiIPQwjlDrxGXgbFVF/Jv0ClLuYPVWDRrq2E7dyrwFaL7qALdZj4o0n+PNwX7gs+7SDip66PpZU7UTHcCaTKP6beFOEh7XGexbHnJexhXFGubW4jaX6dYkT6qHlOMkBy2CUxVPHBirqTuqfv29JWxig0W/EhDCrzCTzmTrMS+n+MJ07PBe/9OKCOzMjBN5zNMhYeBAeX/E9hubx+jkSUmATaHB70+8vNU5fvj3NCGv7iwF7l7rvbciI2nDrK2jHLZ1tMlLP0riQ45bejfXPtwyFErY7RJW4kskP/vRFzJD8SCyiB+VqOr2ziUHv8s61b5lDij0zur7K2rofjW0p21M9Bnr6+bw/95cKEI1IRHYPNUd3Bp0pcVostD1iwax5M84wQ7u4soIVh6AbU0UtkyCCz7GZF5BuEdSa8gM/pKd/FEcCdvaJ3MnIBEX4uiwDu5ufmM/r2RUcww2nXV1bmksx3XQmfglt+RGZWqokT2bjOgvNM8GSgSwxjcL5zFfqnML7arEhfxITr1ycEneJJ35Dvv51JvCKlQs7jxtXKHt7a4ZDWB3xbeHV53OCQWVqt53Vq4E9qSzdcUqv2B2B6w44UP7HI4aNAkS42KUUzJRuuDAWsakm+oOgtrLRPTn0wkNpJq7x82nVQuix6Na7ctGjhFLIw5CI4J2c6WCPWX8ZXBx3M+K3D94ThU1dDmh7T5SvxTF/1zvrTzvGSqYThxUGXuSETYrdWlj6pEAM4mYi/Msn8WE/qY4woMbeAGAxLTInB7Wht7k3O3pzQ+dt9wSyCJQWj7LCouqooHij9O436hqxlhHxSFZEUqp6PukQIOV8THkpXXxAwc3O7XdlegDQd6ZTBZxhFe46S5IsPwU3eKxtD0E3EBkcfTXTDT6+ZjhiSTZPG0fiV0KO+sFFMTOulLGLQ6NGzRWxjzkH0rCOlazO8Hto3E7d5h/Ig0og3ej4x/tFFhi2vD+6uZPaahT11c3TLKeitp9qrF/3Qt9mZNzWxYw65+hzyQkk94i1AI6Bju6idf2fTIeMfMpLAV8wo8/CgcnOT4T6k/SemTRHBwvl4sW1ADBmiUEYUA/QuvwDObosbP25FJS5QlCV910zjJt//SgOcH9OJNxp0kieNDaWgTyF6evu+DnrXaHPgSKsfbNKTxhBAQe2/AvFAIYZmxTu2mb2jzfyJJn+0l+CC/R38/AVGkxYglmRfkRSkB/2qV7bIPeYKCf58hJ68UXX6Qax1a/yFezk8FbbH1W7mLIQ0EsddYJpLizGhm1Qe4ST9vwzLfDrA5VAmJDvWizjJrfDjzViKbZmGPQrEGG4QLBdnXIJ30aVbYV2KkSs47FGf3g38UnqJRhIO3/j3+MASJl/u03zD3f0IanJibWFAGorTYgjJD/Rjz1YU3JdhvBoXqZ+lc2YTiyOLoOS7hk6SHm7NX89VWF9KVbGfWA1RlxrK/PQ7rIiJVTUbCtW476p1QAZ2D0kIGTtbYe9PpPXs+jdlFh9rCtrA6FFNX1C1e4cyPasX+xeaPuuf6v+Up7T+9NSWmLQQaxnvjDQ6wKBL+brQZRQsWfTrZNFSBgPGNBRkuuDnWzggOM5tW3oTVyHsK3s2WE0EuyDfmbzhOVZNH6GmxpMu4xlRtGDs7jGLbCGesCT+TmGO60L8JdLFuTfnSMxHC7i21QhEqVlAMomCFDN6fkxAFkOV2K5lXWpsJE3kzT7cJUl3jKPF9RpJ14S4MpBeVgo4Ygac98guKcfW1qwAlW6qWvl+ygLcDAZmX+yxpCN5nWDsLsQEWKl/b3hA2ZvPJRckqbHoq8BR86QBm3h4QjzV,iv:H7A+PPOe5pG51tKNoHeIX/8jrlKqLyXhIJp0TWbVVvw=,tag:ECnhRKvlELL68M6Q/ZjOlg==,type:str]
+    token-exp: ENC[AES256_GCM,data:klZey43bdX+FrA==,iv:gr4yVSxEwkhuhwzKeHoVasTVx8glVRTMMOYzj9L6mfc=,tag:Bjp3L/TD6c8XGP7S4ULzgw==,type:str]
+sops:
+    age:
+        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaeE0zb0ZtMThtUEsvWkMx
+            WndLQmdxaDlSbFlDMDJadVpzcGtVSmJkNjEwCktvM1NVS3FMT2k2MDRvYnhCdFIx
+            RUF6T21wRWJGcVgvUGFjeURBUWhsOUEKLS0tIFpjZ3F3clpST0U0bEM1ZUVSbFQz
+            b2VWNFB4WVJYUjh5TWlwR2dBc05OQ2cKEfi2PhD+CKhjnGG+TUeqoJ0YUq/GWbCr
+            2cZjRzHVzOi4eozJVyT2prpaSwyqFhA4nROJxhizLS8KK3MAlVy9GQ==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1nywlwepsyfxvyhqwkjquzz02nmus65gf6qewfjju4alym8f7se5qnua8na
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6MXg5OSsrV0hiUmM0WHg0
+            NVNpQXhsanNHZ1VNVjMrNTl6OVYvNkJMbkJFCjdSLzVyWndWanR3b08zbERacDEw
+            cU9yWStqYVYxdUVQdVdHNmpqQ3pUbmcKLS0tIFVHNTVjOTZHbUt5T3lYTGpESVZO
+            RzZHb0hJZTdFaHVXWmhyUGhtaFZwT1EKBja7N4TRXiectYHetdsu2jN3ol6/dKF6
+            D8XNsCU+B4kUoDvBHyOeXcmv2Sh5zdSjGTj2T4yig2NtkJd4UBArjw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-06-26T15:36:13Z"
+    mac: ENC[AES256_GCM,data:xu12y/jyDMOZt7mqqiFM7BoIQ5h4uXyEFJ4elRcw3kPAX2CRSqhcdAmNTdtt4hipnErQ6TuztsWdTew/XXOqAbzjNth9Sjf80nSRug3Blhw3esWJ4A/L8TY2LrDhYjLaX8NwMZh83vrFnFejrfWhBh8hH/RaR/tSwnDaq4Irj4o=,iv:Am8mBZvXmjy9tOaZaHIKFTGGGvceXym0SfRE7IQLdoU=,tag:+QkJ+gOJq1duDBqxg2WWPw==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.1

--- a/cluster/k8s/haku/cloud-agent-tf/kustomization.yaml
+++ b/cluster/k8s/haku/cloud-agent-tf/kustomization.yaml
@@ -2,4 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - anthropic-api-key.sops.yaml
+  # Seeded here; authentik-jwt-rotation overwrites it on each mint (rotations.yaml).
+  - haku-kube-token.sops.yaml
   - terraform.yaml

--- a/cluster/k8s/haku/cloud-agent-tf/kustomization.yaml
+++ b/cluster/k8s/haku/cloud-agent-tf/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - anthropic-api-key.sops.yaml
+  - terraform.yaml

--- a/cluster/k8s/haku/cloud-agent-tf/terraform.yaml
+++ b/cluster/k8s/haku/cloud-agent-tf/terraform.yaml
@@ -1,0 +1,38 @@
+apiVersion: infra.contrib.fluxcd.io/v1alpha2
+kind: Terraform
+metadata:
+  name: haku-cloud-agent
+  namespace: flux-system
+spec:
+  interval: 15m
+  refreshBeforeApply: true
+  path: ./tf/gitops/haku-cloud-agent
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+
+  serviceAccountName: tf-runner
+  approvePlan: "auto"
+
+  backendConfig:
+    customConfiguration: |
+      backend "pg" {
+        conn_str    = "postgres://tfstate@tofu-state-db-ovh-rw.tofu-state.svc:5432/tfstate?sslmode=disable"
+        schema_name = "haku_cloud_agent"
+      }
+  runnerPodTemplate:
+    spec:
+      env:
+        - name: PGPASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: tofu-state-db-credentials
+              key: password
+        # The claude-managed-agents provider reads ANTHROPIC_API_KEY directly.
+        # Dedicated, spend-capped Anthropic workspace; regular key, not admin.
+        - name: ANTHROPIC_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: haku-cloud-anthropic-api-key
+              key: api-key

--- a/cluster/k8s/haku/cloud-agent-tf/terraform.yaml
+++ b/cluster/k8s/haku/cloud-agent-tf/terraform.yaml
@@ -36,3 +36,17 @@ spec:
             secretKeyRef:
               name: haku-cloud-anthropic-api-key
               key: api-key
+        # haku-k8s Authentik JWT (rotated by authentik-jwt-rotation into the
+        # haku-cloud-kube-token Secret) + its exp epoch. tofu writes the token into
+        # the Anthropic vault as a static_bearer credential; the exp drives the
+        # write-only token_wo_version so each rotation re-sends. See the root's main.tf.
+        - name: TF_VAR_haku_kube_token
+          valueFrom:
+            secretKeyRef:
+              name: haku-cloud-kube-token
+              key: jwt
+        - name: TF_VAR_haku_kube_token_wo_version
+          valueFrom:
+            secretKeyRef:
+              name: haku-cloud-kube-token
+              key: token-exp

--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -206,6 +206,7 @@ resources:
   - haku/console-namespace/flux-kustomization.yaml # the console's own trusted namespace
   - haku/console/flux-kustomization.yaml
   - haku/agent-worker/flux-kustomization.yaml # suspended; see the dir README to activate
+  - haku/cloud-agent-tf/flux-kustomization.yaml # Anthropic-hosted agent via claude-managed-agents tofu provider
 
   # --- matrix ---
   - matrix/namespace/flux-kustomization.yaml

--- a/tf/gitops/haku-cloud-agent/.terraform.lock.hcl
+++ b/tf/gitops/haku-cloud-agent/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/modus-agendi/anthropic-claude-managed-agents" {
+  version     = "1.1.0"
+  constraints = "~> 1.1"
+  hashes = [
+    "h1:2i8A2Tf04gQdSZTAH/AHCKlENdKNGZMrI73fLPAuRos=",
+    "h1:gvxS6twzByBLh92zSaTGIeVmAmeCUyeZD+pfCmXf7e4=",
+    "h1:l8Y0r6KVZzUVZ05RBa167UahB92lF1lQ3m0ZI4s8lOo=",
+    "zh:143d354ffd29a912b663b0852d5d99cdf0b16dfdf4bd01728099ee883316f610",
+    "zh:3e19bd2da2309cb0db78471ea1ffa948b0062b6e65a770d4545b73c78da280d1",
+    "zh:3efd3db69dcbc6121be98fce298cc230b0db6272750d83a42e43a242a50e84a7",
+    "zh:41cc4e8e00f9570e80b5d5253f2b211df0ca00c72fe0fe8d86724a60051e3cf2",
+    "zh:6135cf887a9ab47186d90d700005a43118e46d97c004ab0036acf4b51115a28c",
+    "zh:6b5e166329cfe0d3b104a40bd30f3515d58a55b33cde590eab1dbaac565bcbad",
+    "zh:777825ff7184d361480b3bb62e5fe9e05803bf33ef90a8ef8bd7fe6156a924a6",
+    "zh:8a9cedcd8bdc080d5a86612d6f12e5b648277623617f925cdb251950d2ba59f6",
+    "zh:911cfe6897efb46319214412ae90490f46698d8c1c4dac5d904bcbff67b54a97",
+    "zh:9bd55506403b8f1aeff9c998e04ecaa12f78fe4f00247e36f91104bdd66089a1",
+    "zh:a4530407c9998d140b801882b308d9255039bbc054cc958992a7947abed09f87",
+    "zh:b7d3b69a0357f05e259afe4275f832d5b69311c070cc6d0d233fd9d683ecf11a",
+    "zh:ee30c22ac73ae82720a10f41ceac8681dcfb6d0a7e84bef9ee16211020c7b1df",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}

--- a/tf/gitops/haku-cloud-agent/BUILD.bazel
+++ b/tf/gitops/haku-cloud-agent/BUILD.bazel
@@ -5,7 +5,7 @@ tf_providers_versions(
     providers = {
         "claude-managed-agents": "modus-agendi/anthropic-claude-managed-agents:~>1.1",
     },
-    tf_version = "1.9.8",
+    tf_version = "1.11.2",
 )
 
 tf_module(

--- a/tf/gitops/haku-cloud-agent/BUILD.bazel
+++ b/tf/gitops/haku-cloud-agent/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@rules_tf//tf:def.bzl", "tf_module", "tf_providers_versions")
+
+tf_providers_versions(
+    name = "providers",
+    providers = {
+        "claude-managed-agents": "modus-agendi/anthropic-claude-managed-agents:~>1.1",
+    },
+    tf_version = "1.9.8",
+)
+
+tf_module(
+    name = "haku-cloud-agent",
+    providers = [
+        "claude-managed-agents",
+    ],
+    providers_versions = ":providers",
+)

--- a/tf/gitops/haku-cloud-agent/main.tf
+++ b/tf/gitops/haku-cloud-agent/main.tf
@@ -1,0 +1,119 @@
+# Haku's Anthropic-hosted (cloud) Managed Agent, managed declaratively via the
+# claude-managed-agents provider. Anthropic runs the agent loop and the sandbox;
+# Haku reaches the operator's cluster through the kubectl-machine-mcp passthrough
+# MCP (cluster/k8s/agents/kubectl-machine-mcp), authenticated by a static_bearer
+# vault credential carrying the haku-k8s Authentik JWT. The MCP forwards the JWT
+# to kube-apiserver, which maps groups:["haku"] -> oidc-ksbx-groups:haku, so Haku
+# gets full CRUD in haku-sandbox plus cluster-wide diagnostics read.
+#
+# Supersedes the imperative anthropic_hosted/provision.sh bring-up (Path B,
+# bash+curl+env-var KUBE_TOKEN), which the provider couldn't model.
+#
+# CREDENTIAL OWNERSHIP: Terraform owns the environment, agent, vault shell, and
+# deployment. The vault's static_bearer credential (the rotating haku JWT) is
+# seeded and refreshed OUT OF BAND — the haku JWT rotates ~every 44 days and the
+# provider's write-only token can't track that. Per anthropic_hosted/PLAN.md
+# ("static_bearer + rotation CronJob"), the authentik-jwt-rotation CronJob will
+# own it (follow-up). Until then, seed it once against the TF-created vault:
+#
+#   ant beta:vaults:credentials create --vault-id "$(tofu output -raw vault_id)" <<'YAML'
+#   display_name: haku k8s bearer (kubectl-machine-mcp)
+#   auth:
+#     type: static_bearer
+#     mcp_server_url: https://kubectl-machine-mcp.allegedly.works/mcp
+#     token: <sops -d --extract '["jwt"]' secrets/haku-k8s-jwt.yaml>
+#   YAML
+
+# api_key is read from the ANTHROPIC_API_KEY env var, injected into the
+# tofu-controller runner from the haku-cloud-anthropic-api-key Secret (a
+# dedicated, spend-capped Anthropic workspace; regular key, not admin).
+provider "claude-managed-agents" {}
+
+resource "claude-managed-agents_environment" "haku_cloud" {
+  name = "haku-cloud"
+
+  config = {
+    type = "cloud"
+    # v0: open egress — Haku reaches many domains (Gmail, Plaid, the MCP, …). The
+    # cluster credential stays scoped regardless: it is only presented to the
+    # kubectl-machine-mcp URL via the vault. TODO: tighten to `limited` with an
+    # explicit allowed_hosts list once the data-source set is settled.
+    networking = {
+      type = "unrestricted"
+    }
+  }
+}
+
+resource "claude-managed-agents_agent" "haku_cloud" {
+  name  = "haku-cloud"
+  model = "claude-sonnet-4-6" # TEMP(bring-up): revisit (opus) once the cloud runtime is proven
+
+  system = <<-EOT
+    You are Haku, the operator's tireless background executive assistant, running
+    in an Anthropic-hosted sandbox.
+
+    You reach the operator's Kubernetes cluster through the `kubectl-machine`
+    MCP server (tools prefixed `pods_`, `resources_`, `events_`, …). Your access
+    is scoped by the bearer token the platform injects: full CRUD in the
+    `haku-sandbox` namespace (create/exec/delete pods for ephemeral compute) and
+    cluster-wide read for diagnostics. Spin ephemeral pods in `haku-sandbox` to
+    do in-cluster work (Plaid, in-cluster MCPs, git), then clean them up.
+
+    IMPORTANT (v0 bring-up): your operating manual and run procedure are not wired
+    yet. Do exactly what each user message asks, then stop.
+  EOT
+
+  mcp_servers = [
+    {
+      type = "url"
+      name = "kubectl-machine"
+      url  = "https://kubectl-machine-mcp.allegedly.works/mcp"
+    },
+  ]
+
+  tools = [
+    # Cloud-sandbox built-ins (bash/read/write/edit/glob/grep) for orchestration
+    # glue; the cluster fence is RBAC on the haku token, so auto-allow.
+    {
+      type = "agent_toolset_20260401"
+      default_config = {
+        enabled           = true
+        permission_policy = { type = "always_allow" }
+      }
+    },
+    # The kubectl MCP toolset — Haku's hands on the cluster.
+    {
+      type            = "mcp_toolset"
+      mcp_server_name = "kubectl-machine"
+      default_config = {
+        permission_policy = { type = "always_allow" }
+      }
+    },
+  ]
+}
+
+# Vault shell. The static_bearer credential inside it is seeded/rotated out of
+# band (see the header comment) — Terraform does not manage it.
+resource "claude-managed-agents_vault" "haku_cloud" {
+  display_name = "haku-cloud"
+}
+
+resource "claude-managed-agents_deployment" "haku_cloud" {
+  name           = "haku-cloud"
+  description    = "Haku's Anthropic-hosted agent: reaches the cluster via kubectl-machine-mcp."
+  agent          = claude-managed-agents_agent.haku_cloud.id
+  environment_id = claude-managed-agents_environment.haku_cloud.id
+  vault_ids      = [claude-managed-agents_vault.haku_cloud.id]
+  desired_status = "active"
+
+  # v0/P0: the initial message is a connectivity test (list haku-sandbox pods).
+  # Replace with the real wake ("do one scan pass per the run procedure, then
+  # commit, push, stop") and add a `schedule` block once the run procedure is
+  # wired. For now it is on-demand: `ant beta:deployments run`.
+  initial_events = [
+    {
+      type    = "user.message"
+      content = jsonencode([{ type = "text", text = "List the pods in the haku-sandbox namespace and report their names and status." }])
+    },
+  ]
+}

--- a/tf/gitops/haku-cloud-agent/main.tf
+++ b/tf/gitops/haku-cloud-agent/main.tf
@@ -9,20 +9,14 @@
 # Supersedes the imperative anthropic_hosted/provision.sh bring-up (Path B,
 # bash+curl+env-var KUBE_TOKEN), which the provider couldn't model.
 #
-# CREDENTIAL OWNERSHIP: Terraform owns the environment, agent, vault shell, and
-# deployment. The vault's static_bearer credential (the rotating haku JWT) is
-# seeded and refreshed OUT OF BAND — the haku JWT rotates ~every 44 days and the
-# provider's write-only token can't track that. Per anthropic_hosted/PLAN.md
-# ("static_bearer + rotation CronJob"), the authentik-jwt-rotation CronJob will
-# own it (follow-up). Until then, seed it once against the TF-created vault:
-#
-#   ant beta:vaults:credentials create --vault-id "$(tofu output -raw vault_id)" <<'YAML'
-#   display_name: haku k8s bearer (kubectl-machine-mcp)
-#   auth:
-#     type: static_bearer
-#     mcp_server_url: https://kubectl-machine-mcp.allegedly.works/mcp
-#     token: <sops -d --extract '["jwt"]' secrets/haku-k8s-jwt.yaml>
-#   YAML
+# CREDENTIAL ROTATION: the static_bearer credential carries the haku-k8s Authentik
+# JWT, which rotates ~every 44 days. The chain is fully automatic and the rotator
+# stays dumb (it only mints + commits): authentik-jwt-rotation writes the token as
+# the haku-cloud-kube-token k8s Secret -> Flux applies it -> this runner reads it
+# (var.haku_kube_token + var.haku_kube_token_wo_version) -> tofu re-sends it into
+# the Anthropic vault. The token is a TF 1.11 write-only attribute, so it only
+# re-sends when token_wo_version changes; we set that to the JWT's exp epoch
+# (monotonic, bumps on every mint).
 
 # api_key is read from the ANTHROPIC_API_KEY env var, injected into the
 # tofu-controller runner from the haku-cloud-anthropic-api-key Secret (a
@@ -92,10 +86,24 @@ resource "claude-managed-agents_agent" "haku_cloud" {
   ]
 }
 
-# Vault shell. The static_bearer credential inside it is seeded/rotated out of
-# band (see the header comment) — Terraform does not manage it.
 resource "claude-managed-agents_vault" "haku_cloud" {
   display_name = "haku-cloud"
+}
+
+# The haku-k8s Authentik JWT, bound to the kubectl-machine-mcp URL. Anthropic
+# presents it when the agent connects to that MCP; the MCP forwards it to
+# kube-apiserver (groups:["haku"] -> oidc-ksbx-groups:haku). token is write-only;
+# token_wo_version = the JWT exp epoch so each rotation re-sends (see header).
+resource "claude-managed-agents_vault_credential" "haku_kube" {
+  vault_id     = claude-managed-agents_vault.haku_cloud.id
+  display_name = "haku k8s bearer (kubectl-machine-mcp)"
+
+  auth = {
+    type             = "static_bearer"
+    mcp_server_url   = "https://kubectl-machine-mcp.allegedly.works/mcp"
+    token            = var.haku_kube_token
+    token_wo_version = var.haku_kube_token_wo_version
+  }
 }
 
 resource "claude-managed-agents_deployment" "haku_cloud" {

--- a/tf/gitops/haku-cloud-agent/outputs.tf
+++ b/tf/gitops/haku-cloud-agent/outputs.tf
@@ -1,0 +1,19 @@
+output "vault_id" {
+  description = "Vault ID, consumed by the out-of-band static_bearer credential seed/rotation step (see main.tf header)."
+  value       = claude-managed-agents_vault.haku_cloud.id
+}
+
+output "agent_id" {
+  description = "Anthropic-hosted Haku agent ID (agent_*)."
+  value       = claude-managed-agents_agent.haku_cloud.id
+}
+
+output "environment_id" {
+  description = "Cloud environment ID (env_*) the agent runs in."
+  value       = claude-managed-agents_environment.haku_cloud.id
+}
+
+output "deployment_id" {
+  description = "Deployment ID (depl_*); use with `ant beta:deployments run` to trigger a session."
+  value       = claude-managed-agents_deployment.haku_cloud.id
+}

--- a/tf/gitops/haku-cloud-agent/terraform.tf
+++ b/tf/gitops/haku-cloud-agent/terraform.tf
@@ -1,5 +1,7 @@
 terraform {
-  required_version = ">= 1.0"
+  # >= 1.11: the vault_credential token is a write-only attribute and the
+  # haku_kube_token variable is ephemeral.
+  required_version = ">= 1.11"
 
   required_providers {
     # CAUTION: low-user-count community provider holding an Anthropic API key.

--- a/tf/gitops/haku-cloud-agent/terraform.tf
+++ b/tf/gitops/haku-cloud-agent/terraform.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    # CAUTION: low-user-count community provider holding an Anthropic API key.
+    # On every version bump, manually review the source diff since the last
+    # pinned tag (focus: internal/client/ egress+secret handling,
+    # .github/workflows/release.yml) BEFORE updating the lock hashes. Do not
+    # auto-merge Renovate/update_deps bumps. See memory
+    # project_acma_provider_repin_review and the matching MODULE.bazel comment.
+    claude-managed-agents = {
+      source  = "modus-agendi/anthropic-claude-managed-agents"
+      version = "~> 1.1"
+    }
+  }
+
+  # Placeholder; the actual backend (pg, tofu-state) is injected by the Terraform
+  # CR's backendConfig.customConfiguration (see cluster/k8s/haku/cloud-agent-tf).
+  backend "kubernetes" {
+    secret_suffix = "haku-cloud-agent"
+    namespace     = "flux-system"
+  }
+}

--- a/tf/gitops/haku-cloud-agent/variables.tf
+++ b/tf/gitops/haku-cloud-agent/variables.tf
@@ -1,0 +1,5 @@
+# No input variables: the claude-managed-agents provider reads its API key from
+# the ANTHROPIC_API_KEY env var (injected into the tofu-controller runner from
+# the haku-cloud-anthropic-api-key Secret), and the static_bearer credential's
+# token is seeded out-of-band (see main.tf). Present to satisfy tflint's
+# terraform_standard_module_structure rule.

--- a/tf/gitops/haku-cloud-agent/variables.tf
+++ b/tf/gitops/haku-cloud-agent/variables.tf
@@ -1,5 +1,11 @@
-# No input variables: the claude-managed-agents provider reads its API key from
-# the ANTHROPIC_API_KEY env var (injected into the tofu-controller runner from
-# the haku-cloud-anthropic-api-key Secret), and the static_bearer credential's
-# token is seeded out-of-band (see main.tf). Present to satisfy tflint's
-# terraform_standard_module_structure rule.
+variable "haku_kube_token" {
+  type        = string
+  ephemeral   = true
+  sensitive   = true
+  description = "haku-k8s Authentik JWT for the static_bearer vault credential. Injected into the tofu-controller runner from the haku-cloud-kube-token Secret as TF_VAR_haku_kube_token. ephemeral so it never lands in plan or state (the credential's token attribute is also write-only). See main.tf rotation note."
+}
+
+variable "haku_kube_token_wo_version" {
+  type        = number
+  description = "The haku JWT's exp epoch (seconds). Drives the write-only token_wo_version so each rotation (new token -> later exp) re-sends the token into the Anthropic vault. From the haku-cloud-kube-token Secret's token-exp key (TF_VAR_haku_kube_token_wo_version)."
+}


### PR DESCRIPTION
**Stage 2 of 2** — Haku's Anthropic-hosted Managed Agent, managed declaratively via the `modus-agendi/anthropic-claude-managed-agents` OpenTofu provider and applied by the in-cluster tofu-controller. Builds on `kubectl-machine-mcp` from #2477 (Stage 1, gate verified green end-to-end).

## What's here
- **Provider pin + hash:** `MODULE.bazel` mirror → `…:1.1.0` (+ repin-review caution comment) and a **committed `.terraform.lock.hcl`** (GPG-signed hashes, key `40BAB415432DA093`). Committing the lock is a deliberate deviation from the other gitops roots — it gives the controller's `tofu init` real hash-verification, the supply-chain pin requested for this low-user-count provider.
- **`tf/gitops/haku-cloud-agent`** (✅ `tofu validate` vs the real provider schema): `environment` (cloud) + `agent` (`mcp_toolset`→`kubectl-machine-mcp` + cloud bash toolset) + `vault` + **`vault_credential` (static_bearer)** + `deployment` (on-demand). Provider auth via `ANTHROPIC_API_KEY` from a **dedicated, spend-capped workspace key** (regular, not admin).
- **Controller wiring** `cluster/k8s/haku/cloud-agent-tf`: `Terraform` CR (pg backend, env from SOPS Secrets), flux-kustomization (`dependsOn` tofu-controller + tofu-state-db + kubectl-machine-mcp), the two encrypted Secrets, root-kustomization entry.

## Credential rotation — fully automatic, TF-managed
The static_bearer credential carries the haku-k8s Authentik JWT (rotates ~44d). The rotator stays dumb (mint + commit); freshness propagates through Flux→tofu:
```
authentik-jwt-rotation → SOPS k8s Secret (haku-cloud-kube-token) → Flux → tofu runner env → Anthropic vault
```
`rotate.py` gains an optional `k8s_secret` output emitting `{jwt, token-exp}`; the token is a TF 1.11 **write-only** attribute and `token_wo_version = exp epoch` (monotonic) so each mint re-sends. The Secret is **seeded** in this PR (current token), and the rotator overwrites it at the next mint.

## ⚠️ This PR mutates the Anthropic org
`approvePlan: auto` — merging triggers the controller to **create the resources** (env/agent/vault/credential/deployment) in the dedicated workspace. The deployment is **on-demand (no schedule)**, so nothing runs automatically. After merge: `ant beta:deployments run` (or the Console) to confirm Haku reaches the cluster via `kubectl-machine-mcp`. No manual credential seeding needed — the seeded Secret + tofu handle it.

## Tested
`bbr test //tf/gitops/haku-cloud-agent:{validate,lint,format}` ✅ · `//cluster/k8s/agents/authentik-jwt-rotation:test_rotate` ✅ · local `tofu validate` (write-only credential + ephemeral var) ✅ · `//cluster/validation/...` 13/13 ✅ · pre-commit (kubeconform/checkov/tflint/sops) ✅

## Follow-up (TODO in rotations.yaml)
The haku JWT now lives SOPS-encrypted in two places (bare `secrets/haku-k8s-jwt.yaml` for the CLI/kubeconfig path + this k8s Secret manifest for Flux). Nicer would be Flux turning the bare SOPS file into a Secret directly.