### PR TITLE
haku/console: fix pod crashloop — add ca-certificates layer for pygit2

### DIFF
--- a/haku/console/BUILD.bazel
+++ b/haku/console/BUILD.bazel
@@ -138,9 +138,11 @@ py_test(
 )
 
 # ── OCI image (the haku-console service) ──────────────────────────────────────
-# Plain debian-slim base: the console clones/pushes haku-state over cluster-internal
-# plaintext HTTP, so (unlike finance/beancount_export) it needs no ca-certificates
-# apt layer for pygit2.
+# ca-certificates apt layer (@trixie_ca_certificates): pygit2's Settings() eagerly
+# loads libgit2's OpenSSL cert locations from the system trust store at *import*
+# time, so `import pygit2` raises GitError on a bare slim base before any code runs
+# — even though the haku-state remote is plaintext HTTP and the certs are never
+# used. Same fix as finance/scraper and finance/augur/api.
 
 aspect_py_binary(
     name = "server_bin",
@@ -171,7 +173,7 @@ pkg_tar(
 
 oci_image(
     name = "server_image",
-    base = "@debian_slim_linux_amd64",
+    base = "@debian_trixie_slim_linux_amd64",
     entrypoint = py_image_entrypoint("server_bin"),
     env = dict(
         py_image_env(binary_name = "server_bin"),
@@ -184,6 +186,7 @@ oci_image(
     tars = [
         ":server_layers",
         ":web_tar",
+        "@trixie_ca_certificates//:flat",
     ],
     user = "1000:1000",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
## Outage fix

The `haku-console` pod is in **CrashLoopBackOff** (dashboard at `haku.allegedly.works` down). Root cause:

```
_pygit2.GitError: OpenSSL error: failed to load certificates
```

`import pygit2` (1.19) eagerly initializes libgit2's OpenSSL cert locations from the system trust store **at import time**, but the image's `debian-slim` base ships **no CA bundle** — the BUILD comment wrongly assumed none was needed "because the remote is plaintext HTTP." (The certs genuinely aren't used for the plaintext Forgejo clone; pygit2 just refuses to import without them.) The console image hadn't been rebuilt since pygit2 1.19 was pinned, so the first rebuild (the recent console-tier PRs) baked in the new pygit2 and surfaced the latent break.

## Fix

Identical to the existing precedent in `finance/scraper` and `finance/augur/api`: switch to `@debian_trixie_slim` base + the shared `@trixie_ca_certificates//:flat` apt layer.

## Verification

- `bbr build //haku/console:server_image` succeeds.
- The layer ships `/usr/lib/ssl/cert.pem` (OpenSSL's default cafile on Debian).
- The **same layer + same pygit2 import runs in production** for `augur-evidence` (`finance/scraper`).
- Final check: pod becomes Ready after the image builds and Flux rolls it out.