### PR TITLE
haku: mint a rotated grocy-mcp-sf JWT for read-only Grocy access

### DIFF
--- a/cluster/k8s/agents/authentik-jwt-rotation/cronjob.yaml
+++ b/cluster/k8s/agents/authentik-jwt-rotation/cronjob.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: agents-infra
   annotations:
     description: >-
-      Rotates every Authentik client_credentials JWT listed in rotations.yaml (claude-web k8s, haku k8s, alloy-otlp). Runs hourly; rotate.py reads each output's unencrypted `expires_unencrypted` field (no decryption needed) and skips entries with > rotate_below_hours remaining, so a real mint runs only ~every 44 days per token. Everything minted this cycle lands in one commit.
+      Rotates every Authentik client_credentials JWT listed in rotations.yaml (claude-web k8s, haku k8s, haku grocy, alloy-otlp). Runs hourly; rotate.py reads each output's unencrypted `expires_unencrypted` field (no decryption needed) and skips entries with > rotate_below_hours remaining, so a real mint runs only ~every 44 days per token. Everything minted this cycle lands in one commit.
 spec:
   schedule: "15 * * * *"
   successfulJobsHistoryLimit: 3
@@ -32,6 +32,9 @@ spec:
             - name: haku-k8s-creds
               secret:
                 secretName: haku-client-credentials
+            - name: haku-grocy-creds
+              secret:
+                secretName: haku-grocy-client-credentials
             - name: alloy-otlp-creds
               secret:
                 secretName: alloy-otlp-client-credentials
@@ -63,6 +66,9 @@ spec:
                   readOnly: true
                 - name: haku-k8s-creds
                   mountPath: /var/run/secrets/authentik/haku-k8s
+                  readOnly: true
+                - name: haku-grocy-creds
+                  mountPath: /var/run/secrets/authentik/haku-grocy
                   readOnly: true
                 - name: alloy-otlp-creds
                   mountPath: /var/run/secrets/authentik/alloy-otlp

--- a/cluster/k8s/agents/authentik-jwt-rotation/rotations.yaml
+++ b/cluster/k8s/agents/authentik-jwt-rotation/rotations.yaml
@@ -25,6 +25,20 @@ rotations:
     credentials_dir: /var/run/secrets/authentik/haku-k8s
     sops_file: secrets/haku-k8s-jwt.yaml
     token_field: jwt
+  - name: haku-grocy
+    # Source JWT for haku's read-only access to the grocy-sf MCP. Issued by the
+    # grocy-mcp-sf provider so its iss matches the MCP's JWTVerifier; the MCP runs
+    # the jwt-bearer exchange into the grocy-sf proxy itself, so no exchange_scopes
+    # here. The outpost then injects X-authentik-username=haku → the read-only
+    # `haku` Grocy user (empty perms). aud defaults to the provider client_id.
+    provider_slug: grocy-mcp-sf
+    scopes: openid profile email
+    credential_mode: user_password
+    expected_audiences:
+      - grocy-mcp-sf
+    credentials_dir: /var/run/secrets/authentik/haku-grocy
+    sops_file: secrets/haku-grocy-jwt.yaml
+    token_field: jwt
   - name: alloy-otlp
     provider_slug: alloy-otlp-client-credentials
     scopes: openid profile email

--- a/tf/gitops/agent-machine-access/main.tf
+++ b/tf/gitops/agent-machine-access/main.tf
@@ -925,3 +925,77 @@ resource "kubernetes_secret" "haku_client_credentials" {
     password  = authentik_token.haku_k8s.key
   }
 }
+
+# ============================================================================
+# haku-grocy — Haku's read-only identity for the grocy-sf MCP server
+# ============================================================================
+# Haku reads the SF Grocy instance through the standard grocy-sf MCP
+# (grocy-mcp-sf.allegedly.works), no separate facade. The authentik-jwt-rotation
+# CronJob mints a client_credentials JWT FOR this `haku` service account against
+# the grocy-mcp-sf OAuth2 provider, so the token's iss matches the MCP's
+# JWTVerifier. The MCP then runs its usual jwt-bearer exchange into the grocy-sf
+# proxy provider and the outpost injects X-authentik-username=haku — which maps to
+# the read-only `haku` Grocy user (empty permission set, provisioned by
+# cluster/k8s/grocy/sf/haku-user). Read-only is enforced server-side by Grocy
+# (its API gates every write on a permission this user lacks); this identity adds
+# no write capability.
+#
+# Mirrors the haku-k8s pattern above, but issues from grocy-mcp-sf (not the shared
+# kubectl provider) and the SA username is `haku` (not haku-k8s) because that
+# username is what the outpost forwards to Grocy.
+#
+# Consumer: cluster/k8s/agents/authentik-jwt-rotation/ CronJob (haku-grocy entry).
+# It mints the JWT and commits it SOPS-encrypted to secrets/haku-grocy-jwt.yaml.
+
+resource "authentik_user" "haku_grocy" {
+  username = "haku"
+  name     = "Haku grocy read-only service account"
+  type     = "service_account"
+  path     = "goauthentik.io/service-accounts"
+}
+
+# App-password token, used as the password in the client_credentials
+# username/password exchange against the grocy-mcp-sf provider's client_id.
+resource "authentik_token" "haku_grocy" {
+  identifier   = "haku-grocy-client-credentials"
+  user         = authentik_user.haku_grocy.id
+  intent       = "app_password"
+  expiring     = false
+  retrieve_key = true
+  description  = "client_credentials app-password for Haku's grocy-sf JWT rotation"
+}
+
+# Authorize the haku SA to mint tokens on the grocy-mcp-sf OAuth2 application.
+resource "authentik_policy_binding" "haku_grocy_mcp_sf" {
+  target = authentik_application.grocy_mcp_sf.uuid
+  user   = authentik_user.haku_grocy.id
+  order  = 1
+}
+
+# Authorize the haku SA on the grocy-sf proxy application too: the MCP's
+# downstream call to Grocy traverses that outpost, so the jwt-bearer exchange must
+# be authorized end to end (the household group binding covers humans, not this SA).
+resource "authentik_policy_binding" "haku_grocy_sf_proxy" {
+  target = authentik_application.grocy_sf.uuid
+  user   = authentik_user.haku_grocy.id
+  order  = 1
+}
+
+# K8s Secret holding the grocy-mcp-sf provider's client_id + the haku username and
+# app-password. Lives in agents-infra (where the authentik-jwt-rotation CronJob
+# runs); the minted JWT lives SOPS-encrypted in secrets/haku-grocy-jwt.yaml.
+resource "kubernetes_secret" "haku_grocy_client_credentials" {
+  metadata {
+    name      = "haku-grocy-client-credentials"
+    namespace = "agents-infra"
+    annotations = {
+      description = "client_id (grocy-mcp-sf OAuth2 provider) + haku username/app-password, authenticating the haku service account so the authentik-jwt-rotation CronJob can mint its grocy-sf MCP JWT"
+    }
+  }
+
+  data = {
+    client_id = authentik_provider_oauth2.grocy_mcp_sf.client_id
+    username  = authentik_user.haku_grocy.username
+    password  = authentik_token.haku_grocy.key
+  }
+}


### PR DESCRIPTION
Wires **haku**'s identity for the grocy-sf MCP server. We decided **against a separate facade**: haku talks to the standard `grocy-mcp-sf.allegedly.works` MCP with this JWT, and read-only is enforced server-side by the empty-permission `haku` Grocy user (provisioned in #2483 — Grocy's API gates every write on a permission that user lacks; verified: zero-perm user gets 200 on reads, 403 on writes).

Mirrors the existing `haku-k8s` machine-identity pattern, retargeted at grocy.

## Changes
- **TF** (`tf/gitops/agent-machine-access`): a `haku` service account + non-expiring app-password, authorized on **both** the `grocy-mcp-sf` OAuth2 app (to mint) and the `grocy-sf` proxy app (so the MCP's downstream call passes the outpost). Credential secret `haku-grocy-client-credentials` in `agents-infra`. The SA username is `haku` because that's what the outpost forwards as `X-authentik-username` after the exchange — landing on the read-only `haku` Grocy user.
- **`rotations.yaml`**: a `haku-grocy` entry. Mints a `client_credentials` JWT from the `grocy-mcp-sf` provider so its `iss` matches the MCP's `JWTVerifier` (`…/application/o/grocy-mcp-sf/`, confirmed against the SF MCP's `GROCY_MCP_AUTH__OIDC_ISSUER`). **No `exchange_scopes`** — the MCP performs the jwt-bearer exchange into the grocy-sf proxy itself; haku holds only the raw source JWT. `aud` defaults to the provider client_id (asserted via `expected_audiences`).
- **`cronjob.yaml`**: mounts the new credential secret at `/var/run/secrets/authentik/haku-grocy`.

The rotator commits the minted JWT to `secrets/haku-grocy-jwt.yaml` on its next run.

## Validation
- `tofu fmt`, `tflint`, `checkov`, `kubeconform`, `prettier` all pass via pre-commit.
- `rotations.yaml` parses; the `Rotation` schema accepts every field used.

## Post-merge verification (can't be done pre-apply)
After tofu-controller applies the TF and the rotation CronJob runs once:
1. Decrypt `secrets/haku-grocy-jwt.yaml`, `curl -H "Authorization: Bearer <jwt>" https://grocy-mcp-sf.allegedly.works/mcp` and confirm a **read** tool works.
2. Confirm a **write** tool 403s (defense-in-depth from the grocy user).
3. The genuinely novel bit to watch: that the jwt-bearer exchange maps the `haku` SA through the proxy federation and the outpost injects `X-authentik-username: haku` (not the provider's default SA). If the username comes through wrong, we add a `preferred_username` property mapping.

## Depends on / follow-ups
- Depends on #2483 (read-only `haku` Grocy user) — already merged.
- **Follow-up PR:** consume the JWT in the three haku runtimes (in-cluster agent-framework env+`MCPStreamableHTTPTool`; self-hosted managed-agent vault credential + `haku.agent.yaml`; web-home source doc), incl. re-pushing to the Anthropic vault on rotation (same hook `haku-cloud-agent` uses for `haku-k8s`).