### PR TITLE
[codex] debundle: remove wildcard string literal source_match option

### DIFF
--- a/devinfra/js/debundle/e2e/anonymous_statement_test.rs
+++ b/devinfra/js/debundle/e2e/anonymous_statement_test.rs
@@ -620,48 +620,6 @@ export { selectedValue, existingValue };
 }
 
 #[test]
-fn alpha_anonymous_statement_selector_supports_explicit_string_literal_wildcards() {
-    let fixture = run_fixture(FixtureOpts::new(
-        r#"const selectedValue = 1;
-const existingValue = 2;
-(function () {
-  const target = globalThis;
-  target.auditMarkers = target.auditMarkers || {};
-  target.auditMarkers["primary-slot"] = "runtime-generated-primary";
-})();
-(function () {
-  const target = globalThis;
-  target.auditMarkers = target.auditMarkers || {};
-  target.auditMarkers["secondary-slot"] = "runtime-generated-secondary";
-})();
-export { selectedValue, existingValue };
-"#,
-        vec![logical_module_with_anon_alpha_string_wildcards(
-            "primary_marker",
-            &[Member::new("selectedValue")],
-            r#"(function () {
-  const target = globalThis;
-  target.auditMarkers = target.auditMarkers || {};
-  target.auditMarkers["primary-slot"] = "<generated-id>";
-})();"#,
-            &["<generated-id>"],
-        )],
-    ));
-
-    assert_module_source(
-        &fixture.out_root,
-        "static/app/modules/primary_marker.js",
-        &["selectedValue", "primary-slot", "runtime-generated-primary"],
-        &[
-            "<generated-id>",
-            "secondary-slot",
-            "runtime-generated-secondary",
-        ],
-    );
-    assert_entry_output(&fixture, "");
-}
-
-#[test]
 fn member_source_match_variable_declarator_survives_binding_name_drift() {
     let fixture = run_fixture(FixtureOpts::new(
         r#"const runtimeBinding = { kind: "selected", enabled: true },

--- a/devinfra/js/debundle/e2e/support.rs
+++ b/devinfra/js/debundle/e2e/support.rs
@@ -66,7 +66,6 @@ impl BindingGroup {
             source_match: FixtureSourceMatch {
                 identifiers: "alpha_all",
                 target_binding: None,
-                wildcard_string_literals: Vec::new(),
                 match_source: match_source.into(),
             },
             adopt_names: None,
@@ -80,7 +79,6 @@ impl BindingGroup {
             source_match: FixtureSourceMatch {
                 identifiers: "alpha_all",
                 target_binding: None,
-                wildcard_string_literals: Vec::new(),
                 match_source: match_source.into(),
             },
             adopt_names: Some(FixtureAdoptNames::All(true)),
@@ -97,7 +95,6 @@ impl BindingGroup {
             source_match: FixtureSourceMatch {
                 identifiers: "alpha_all",
                 target_binding: None,
-                wildcard_string_literals: Vec::new(),
                 match_source: match_source.into(),
             },
             adopt_names: Some(FixtureAdoptNames::Names(names.to_vec())),
@@ -114,7 +111,6 @@ impl BindingGroup {
             source_match: FixtureSourceMatch {
                 identifiers: "alpha_all",
                 target_binding: None,
-                wildcard_string_literals: Vec::new(),
                 match_source: match_source.into(),
             },
             adopt_names: Some(FixtureAdoptNames::All(true)),
@@ -183,7 +179,6 @@ impl Member {
             source_match: Some(FixtureSourceMatch {
                 identifiers: "alpha_all",
                 target_binding: None,
-                wildcard_string_literals: Vec::new(),
                 match_source: match_source.into(),
             }),
             cross_ref: None,
@@ -209,7 +204,6 @@ impl Member {
             source_match: Some(FixtureSourceMatch {
                 identifiers: "alpha_all",
                 target_binding: Some(target_binding.into()),
-                wildcard_string_literals: Vec::new(),
                 match_source: match_source.into(),
             }),
             cross_ref: None,
@@ -563,8 +557,6 @@ struct FixtureSourceMatch {
     identifiers: &'static str,
     #[serde(skip_serializing_if = "Option::is_none")]
     target_binding: Option<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    wildcard_string_literals: Vec<String>,
     #[serde(rename = "match")]
     match_source: String,
 }
@@ -584,26 +576,6 @@ impl FixtureAnonymousStatement {
             source_match: Some(FixtureSourceMatch {
                 identifiers: "alpha_all",
                 target_binding: None,
-                wildcard_string_literals: Vec::new(),
-                match_source: match_source.into(),
-            }),
-            comment: None,
-        }
-    }
-
-    fn alpha_all_with_wildcard_strings(
-        match_source: impl Into<String>,
-        wildcard_string_literals: &[&str],
-    ) -> Self {
-        Self {
-            match_source: None,
-            source_match: Some(FixtureSourceMatch {
-                identifiers: "alpha_all",
-                target_binding: None,
-                wildcard_string_literals: wildcard_string_literals
-                    .iter()
-                    .map(|literal| (*literal).to_string())
-                    .collect(),
                 match_source: match_source.into(),
             }),
             comment: None,
@@ -770,24 +742,6 @@ pub fn logical_module_with_anon_alpha(
         members,
         &[],
         vec![FixtureAnonymousStatement::alpha_all(anon_match)],
-        None,
-    )
-}
-
-pub fn logical_module_with_anon_alpha_string_wildcards(
-    path: &str,
-    members: &[Member],
-    anon_match: &str,
-    wildcard_string_literals: &[&str],
-) -> LogicalModuleEntry {
-    logical_module_entry(
-        path,
-        members,
-        &[],
-        vec![FixtureAnonymousStatement::alpha_all_with_wildcard_strings(
-            anon_match,
-            wildcard_string_literals,
-        )],
         None,
     )
 }

--- a/devinfra/js/debundle/selector_debt.rs
+++ b/devinfra/js/debundle/selector_debt.rs
@@ -683,7 +683,6 @@ struct BindingGroupSuggestionCandidate {
     declarator: VarDeclarator,
     declaration_kind: VarDeclKind,
     identifiers: spec::SourceMatchIdentifierMode,
-    wildcard_string_literals: Vec<String>,
 }
 
 fn collect_binding_group_suggestion_candidate(
@@ -742,7 +741,6 @@ fn collect_binding_group_suggestion_candidate(
         declarator: declarator.clone(),
         declaration_kind: needle_var.kind,
         identifiers: selector.identifiers,
-        wildcard_string_literals: selector.wildcard_string_literals.iter().cloned().collect(),
     }))
 }
 
@@ -793,12 +791,8 @@ fn build_binding_group_suggestion(
             declarator_idx: candidate.declarator_idx,
         })
         .collect::<Vec<_>>();
-    let candidate_yaml = render_binding_group_candidate_yaml(
-        &selectors,
-        &match_source,
-        first.identifiers,
-        &first.wildcard_string_literals,
-    );
+    let candidate_yaml =
+        render_binding_group_candidate_yaml(&selectors, &match_source, first.identifiers);
     SourceAwareBindingGroupSuggestion {
         module: first.key.module.clone(),
         body_idx: first.key.body_idx,
@@ -810,9 +804,8 @@ fn build_binding_group_suggestion(
 
 fn selector_group_key(selector: &AnonymousStatementSelector) -> String {
     format!(
-        "{:?}\0{:?}\0{}",
+        "{:?}\0{}",
         selector.identifiers,
-        selector.wildcard_string_literals,
         normalize_match(&selector.match_source),
     )
 }
@@ -856,7 +849,6 @@ fn render_binding_group_candidate_yaml(
     selectors: &[SourceMatchBindingGroupSelector],
     match_source: &str,
     identifiers: spec::SourceMatchIdentifierMode,
-    wildcard_string_literals: &[String],
 ) -> String {
     let mut lines = vec![
         "binding_groups:".to_string(),
@@ -866,16 +858,6 @@ fn render_binding_group_candidate_yaml(
         lines.push(format!(
             "      identifiers: {}",
             source_match_identifier_mode_label(identifiers),
-        ));
-    }
-    if !wildcard_string_literals.is_empty() {
-        lines.push(format!(
-            "      wildcard_string_literals: [{}]",
-            wildcard_string_literals
-                .iter()
-                .map(|value| yaml_single_quoted(value))
-                .collect::<Vec<_>>()
-                .join(", "),
         ));
     }
     lines.push("      match: |".to_string());
@@ -944,10 +926,6 @@ fn js_string_escape(value: &str) -> String {
         }
     }
     escaped
-}
-
-fn yaml_single_quoted(value: &str) -> String {
-    format!("'{}'", value.replace('\'', "''"))
 }
 
 fn source_match_identifier_mode_label(mode: spec::SourceMatchIdentifierMode) -> &'static str {

--- a/devinfra/js/debundle/spec.rs
+++ b/devinfra/js/debundle/spec.rs
@@ -845,10 +845,9 @@ pub struct SourceMatch {
     /// binding from it. Invalid on `anonymous_statements[].source_match`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub target_binding: Option<String>,
-    /// String-literal placeholder values in `match` that should match any
-    /// candidate string literal at the same AST position. Use this for
-    /// volatile generated literals while keeping all other strings exact.
-    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    /// Internal-only string-literal placeholder values used by legacy matcher
+    /// tests. The public YAML surface no longer accepts or emits this field.
+    #[serde(skip)]
     pub wildcard_string_literals: BTreeSet<String>,
     #[serde(rename = "match")]
     pub match_source: String,
@@ -860,8 +859,6 @@ struct SourceMatchWire {
     identifiers: Option<SourceMatchIdentifierMode>,
     #[serde(default)]
     target_binding: Option<String>,
-    #[serde(default)]
-    wildcard_string_literals: BTreeSet<String>,
     #[serde(rename = "match")]
     match_source: String,
     #[serde(flatten)]
@@ -898,7 +895,7 @@ impl<'de> Deserialize<'de> for SourceMatch {
         Ok(Self {
             identifiers,
             target_binding: wire.target_binding,
-            wildcard_string_literals: wire.wildcard_string_literals,
+            wildcard_string_literals: BTreeSet::new(),
             match_source: wire.match_source,
         })
     }
@@ -1683,6 +1680,27 @@ mod tests {
         );
         assert!(
             message.contains("object_props"),
+            "unexpected error: {message}"
+        );
+    }
+
+    #[test]
+    fn source_match_rejects_legacy_wildcard_string_literals() {
+        let error: serde_json::Error = serde_json::from_str::<SourceMatch>(
+            r#"{
+              "identifiers": "alpha_all",
+              "match": "const readable = \"TOKEN\";",
+              "wildcard_string_literals": ["TOKEN"]
+            }"#,
+        )
+        .unwrap_err();
+        let message = error.to_string();
+        assert!(
+            message.contains("unsupported selector capability"),
+            "unexpected error: {message}"
+        );
+        assert!(
+            message.contains("wildcard_string_literals"),
             "unexpected error: {message}"
         );
     }


### PR DESCRIPTION
## Summary

Removes the public `source_match.wildcard_string_literals` YAML surface instead of carrying it into the native selector model.

- stops accepting/emitting `wildcard_string_literals` on `SourceMatch`
- removes e2e fixture helpers and explicit coverage for authored string-literal wildcards
- stops `selector-debt` from suggesting the removed field in binding-group sketches

## Validation

- `nix develop -c rustfmt devinfra/js/debundle/spec.rs devinfra/js/debundle/e2e/support.rs devinfra/js/debundle/e2e/anonymous_statement_test.rs devinfra/js/debundle/selector_debt.rs`
- `nix develop -c bbr test //devinfra/js/debundle:spec_test //devinfra/js/debundle:selector_debt_test //devinfra/js/debundle/e2e:anonymous_statement_test --test_output=errors --cache_test_results=no`
  - BuildBuddy: https://app.buildbuddy.io/invocation/ddef8792-c516-4954-8cdc-ed06bf4aa08b
- `nix develop -c pre-commit run --files devinfra/js/debundle/spec.rs devinfra/js/debundle/e2e/support.rs devinfra/js/debundle/e2e/anonymous_statement_test.rs devinfra/js/debundle/selector_debt.rs`