### PR TITLE
haku/console: fix launch (anthropic-version header) + standardize error reporting

### DIFF
--- a/haku/console/capabilities.py
+++ b/haku/console/capabilities.py
@@ -17,11 +17,15 @@ from typing import Annotated, cast
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi_csrf_protect import CsrfProtect
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from haku.console.config import LaunchRoutineConfig, Settings
 
 logger = logging.getLogger(__name__)
+
+# Required on every Anthropic API request; without it the fire endpoint 400s
+# ("anthropic-version: header is required").
+ANTHROPIC_VERSION = "2023-06-01"
 
 Csrf = Annotated[CsrfProtect, Depends()]
 
@@ -33,8 +37,15 @@ class CsrfTokenResponse(BaseModel):
 
 
 class LaunchRoutineResult(BaseModel):
-    status: str
-    upstream_status: int
+    session_url: str = Field(description="claude.ai/code URL of the launched Haku session")
+
+
+def _upstream_detail(resp: httpx.Response) -> str:
+    """Best-effort human-readable reason from an upstream error response."""
+    try:
+        return str(resp.json()["error"]["message"])
+    except (ValueError, KeyError, TypeError):
+        return resp.text[:300]
 
 
 def _settings(request: Request) -> Settings:
@@ -68,9 +79,18 @@ async def launch_routine(
     """Fire the Haku claude-code-web routine. CSRF-gated; the bearer stays server-side."""
     await csrf_protect.validate_csrf(request)
     async with httpx.AsyncClient(timeout=30.0) as client:
-        resp = await client.post(config.url, headers={"Authorization": f"Bearer {config.token.get_secret_value()}"})
+        resp = await client.post(
+            config.url,
+            headers={
+                "Authorization": f"Bearer {config.token.get_secret_value()}",
+                "anthropic-version": ANTHROPIC_VERSION,
+            },
+        )
     # Audit to stdout in the haku-console namespace (Haku can't read these logs).
     logger.info("capability launch-routine fired: upstream status %s", resp.status_code)
     if not resp.is_success:
-        raise HTTPException(status_code=502, detail=f"routine fire failed upstream ({resp.status_code})")
-    return LaunchRoutineResult(status="launched", upstream_status=resp.status_code)
+        # Surface the upstream reason so the frontend can show it, not a bare 502.
+        raise HTTPException(
+            status_code=502, detail=f"routine fire failed ({resp.status_code}): {_upstream_detail(resp)}"
+        )
+    return LaunchRoutineResult(session_url=resp.json()["claude_code_session_url"])

--- a/haku/console/frontend/BUILD.bazel
+++ b/haku/console/frontend/BUILD.bazel
@@ -39,10 +39,20 @@ js_library(
 )
 
 js_library(
+    name = "toast",
+    srcs = ["toast.ts"],
+    deps = [
+        "//:node_modules/@mantine/notifications",
+        "//:node_modules/react",
+    ],
+)
+
+js_library(
     name = "feedback",
     srcs = ["feedback.tsx"],
     deps = [
         ":client",
+        ":toast",
         "//:node_modules/@mantine/core",
         "//:node_modules/react",
     ],
@@ -66,6 +76,7 @@ js_library(
     srcs = ["launch.tsx"],
     deps = [
         ":client",
+        ":toast",
         "//:node_modules/@mantine/core",
         "//:node_modules/react",
     ],
@@ -80,6 +91,7 @@ js_library(
         ":feedback",
         ":launch",
         ":task",
+        ":toast",
         "//:node_modules/@mantine/core",
         "//:node_modules/react",
     ],
@@ -91,6 +103,7 @@ js_library(
     deps = [
         ":app",
         "//:node_modules/@mantine/core",
+        "//:node_modules/@mantine/notifications",
         "//:node_modules/react",
         "//:node_modules/react-dom",
     ],
@@ -128,6 +141,7 @@ filegroup(
         "main.tsx",
         "markdown.ts",
         "task.tsx",
+        "toast.ts",
     ],
 )
 
@@ -142,6 +156,8 @@ tailwindcss_bin.tailwindcss_binary(
     name = "tailwind_cli",
     data = [
         "//:node_modules/@mantine/core",
+        # `@import "@mantine/notifications/styles.css"` in styles.src.css.
+        "//:node_modules/@mantine/notifications",
         "//:node_modules/@tailwindcss/cli",
         # `@import "tailwindcss"` in styles.src.css resolves to this package.
         "//:node_modules/tailwindcss",

--- a/haku/console/frontend/app.tsx
+++ b/haku/console/frontend/app.tsx
@@ -6,6 +6,7 @@ import { INTAKE_NEW, UP_NEXT } from "./constants.ts";
 import { FeedbackForm } from "./feedback.tsx";
 import { LaunchRoutineButton } from "./launch.tsx";
 import { TaskCard, clickKey } from "./task.tsx";
+import { toastError } from "./toast.ts";
 
 function statusCounts(items: Item[]): string {
   const counts: Record<string, number> = {};
@@ -44,14 +45,19 @@ export default function App() {
     if (wasClicked) next.delete(key);
     else next.add(key);
     setClicked(next); // optimistic; reverted below on failure
-    void (wasClicked ? unclickAction(itemId, actionId) : clickAction(itemId, actionId)).catch(() => {
+    void (wasClicked ? unclickAction(itemId, actionId) : clickAction(itemId, actionId)).catch((e: unknown) => {
       const reverted = new Set(next);
       if (wasClicked) reverted.add(key);
       else reverted.delete(key);
       setClicked(reverted);
+      toastError("Action failed", e);
     });
   }
 
+  // Error reporting standard: action failures (launch, feedback, a click) surface as
+  // toasts (see toast.ts). The initial dashboard load is the one exception — a failure
+  // leaves nothing to render, so it gets a persistent page-level message rather than a
+  // toast that could auto-dismiss over a blank screen.
   if (error)
     return (
       <Text c="red" className="mx-auto max-w-3xl p-4">

--- a/haku/console/frontend/client.ts
+++ b/haku/console/frontend/client.ts
@@ -8,12 +8,23 @@ const api = createClient<paths>({ baseUrl: "" });
 
 export type Item = components["schemas"]["Item"];
 export type DashboardResponse = components["schemas"]["DashboardResponse"];
+export type LaunchRoutineResult = components["schemas"]["LaunchRoutineResult"];
 export type OperatorAction = NonNullable<Item["actions"]>[number];
 export type PrimaryAction = Item["action"];
 
+// FastAPI error responses are `{detail: string}`; surface that real reason rather
+// than a generic message, falling back when the body isn't shaped that way.
+function errorDetail(error: unknown, fallback: string): string {
+  if (error && typeof error === "object" && "detail" in error) {
+    const { detail } = error as { detail: unknown };
+    if (typeof detail === "string") return detail;
+  }
+  return fallback;
+}
+
 export async function fetchDashboard(): Promise<DashboardResponse> {
   const { data, error } = await api.GET("/api/dashboard");
-  if (error || !data) throw new Error("Failed to load dashboard");
+  if (error || !data) throw new Error(errorDetail(error, "Failed to load dashboard"));
   return data;
 }
 
@@ -21,29 +32,30 @@ export async function clickAction(itemId: string, actionId: string): Promise<voi
   const { error } = await api.PUT("/api/trace/items/{item_id}/actions/{action_id}", {
     params: { path: { item_id: itemId, action_id: actionId } },
   });
-  if (error) throw new Error("Failed to record click");
+  if (error) throw new Error(errorDetail(error, "Failed to record click"));
 }
 
 export async function unclickAction(itemId: string, actionId: string): Promise<void> {
   const { error } = await api.DELETE("/api/trace/items/{item_id}/actions/{action_id}", {
     params: { path: { item_id: itemId, action_id: actionId } },
   });
-  if (error) throw new Error("Failed to retract click");
+  if (error) throw new Error(errorDetail(error, "Failed to retract click"));
 }
 
 export async function sendFeedback(text: string, itemId?: string): Promise<void> {
   const { error } = await api.POST("/api/trace/feedback", { body: { text, item_id: itemId } });
-  if (error) throw new Error("Failed to send feedback");
+  if (error) throw new Error(errorDetail(error, "Failed to send feedback"));
 }
 
 // Capability tier. Fetch a CSRF token (which also sets the signed double-submit
 // cookie), then fire the routine echoing the token in X-CSRF-Token. The bearer
-// stays server-side; this only triggers the action.
-export async function launchRoutine(): Promise<void> {
-  const { data, error: csrfError } = await api.GET("/api/capabilities/csrf");
-  if (csrfError || !data) throw new Error("Failed to get CSRF token");
-  const { error } = await api.POST("/api/capabilities/launch-routine", {
-    headers: { "X-CSRF-Token": data.csrf_token },
+// stays server-side; this only triggers the action and returns the new session URL.
+export async function launchRoutine(): Promise<LaunchRoutineResult> {
+  const { data: csrf, error: csrfError } = await api.GET("/api/capabilities/csrf");
+  if (csrfError || !csrf) throw new Error(errorDetail(csrfError, "Failed to get CSRF token"));
+  const { data, error } = await api.POST("/api/capabilities/launch-routine", {
+    headers: { "X-CSRF-Token": csrf.csrf_token },
   });
-  if (error) throw new Error("Failed to launch routine");
+  if (error || !data) throw new Error(errorDetail(error, "Failed to launch routine"));
+  return data;
 }

--- a/haku/console/frontend/feedback.tsx
+++ b/haku/console/frontend/feedback.tsx
@@ -2,14 +2,11 @@ import { type FormEvent, type KeyboardEvent, useState } from "react";
 import { Button, Text, Textarea } from "@mantine/core";
 
 import { sendFeedback } from "./client.ts";
+import { toastError } from "./toast.ts";
 
-// Submit lifecycle as a closed union so the spinner/disabled/error states can't be
-// combined into something nonsensical (e.g. "sending" while also showing an error).
-type SubmitState =
-  | { status: "idle" }
-  | { status: "sending" }
-  | { status: "sent" }
-  | { status: "error"; message: string };
+// Submit lifecycle as a closed union so the spinner/disabled states can't be combined
+// into something nonsensical. Failures surface as a toast (toast.ts), not inline.
+type SubmitState = { status: "idle" } | { status: "sending" } | { status: "sent" };
 
 interface FeedbackFormProps {
   minRows: number;
@@ -24,7 +21,7 @@ interface FeedbackFormProps {
 // Textarea + submit button that appends an intake note for Haku. Shared by the global
 // "Note to Haku" box and the per-item box. The Mantine Button's `loading` shows a
 // spinner and disables the form while the commit-push is in flight, so the operator
-// sees it land; a failure surfaces inline on the Textarea instead of being swallowed.
+// sees it land; a failure surfaces as a toast (toast.ts) instead of being swallowed.
 //
 // Enter-to-send: the textarea's default (Enter inserts a newline) is inverted so the
 // common "type a line, hit Enter" sends without reaching for the mouse — the ↵ on the
@@ -43,7 +40,8 @@ export function FeedbackForm({ minRows, placeholder, submitLabel, itemId }: Feed
         setState({ status: "sent" });
       })
       .catch((e: unknown) => {
-        setState({ status: "error", message: e instanceof Error ? e.message : String(e) });
+        setState({ status: "idle" });
+        toastError("Feedback failed", e);
       });
   }
 
@@ -86,7 +84,6 @@ export function FeedbackForm({ minRows, placeholder, submitLabel, itemId }: Feed
         onKeyDown={onKeyDown}
         placeholder={placeholder}
         disabled={sending}
-        error={state.status === "error" ? `Failed: ${state.message}` : undefined}
       />
       <div className="flex items-center gap-3">
         <Button

--- a/haku/console/frontend/launch.tsx
+++ b/haku/console/frontend/launch.tsx
@@ -1,22 +1,16 @@
 import { useState } from "react";
-import { Button, Group, Modal, Text } from "@mantine/core";
+import { Anchor, Button, Group, Modal, Text } from "@mantine/core";
 
 import { launchRoutine } from "./client.ts";
+import { toastError, toastSuccess } from "./toast.ts";
 
-// Lifecycle as a closed union so the confirm/launching/done/error states can't be
-// combined into something nonsensical.
-type State =
-  | { status: "idle" }
-  | { status: "confirming" }
-  | { status: "launching" }
-  | { status: "launched" }
-  | { status: "error"; message: string };
+type State = { status: "idle" } | { status: "confirming" } | { status: "launching" } | { status: "launched" };
 
 // Shell-owned launch control for the `launch-routine` capability. This button and its
 // confirm copy live in the trusted bundle (never agent-authored), so a genuine operator
 // gesture against trusted-rendered text is what fires the capability — agent UI can at
-// most ask for it, never script or spoof it. The actual CSRF + server-side bearer live
-// in the backend (see haku/console/capabilities.py).
+// most ask for it, never script or spoof it. The CSRF + server-side bearer live in the
+// backend (see haku/console/capabilities.py). Outcomes surface as toasts.
 export function LaunchRoutineButton() {
   const [state, setState] = useState<State>({ status: "idle" });
   const launching = state.status === "launching";
@@ -24,28 +18,32 @@ export function LaunchRoutineButton() {
   function confirm() {
     setState({ status: "launching" });
     void launchRoutine()
-      .then(() => setState({ status: "launched" }))
-      .catch((e: unknown) => setState({ status: "error", message: e instanceof Error ? e.message : String(e) }));
+      .then((result) => {
+        setState({ status: "launched" });
+        toastSuccess(
+          "Haku run launched",
+          <Anchor href={result.session_url} target="_blank" rel="noreferrer">
+            Open session
+          </Anchor>
+        );
+      })
+      .catch((e: unknown) => {
+        setState({ status: "idle" });
+        toastError("Launch failed", e);
+      });
   }
 
   return (
     <>
-      <Group gap="sm">
-        <Button
-          variant="light"
-          color="indigo"
-          size="xs"
-          loading={launching}
-          onClick={() => setState({ status: "confirming" })}
-        >
-          {state.status === "launched" ? "Launched ✓" : "Launch Haku run"}
-        </Button>
-        {state.status === "error" && (
-          <Text size="sm" c="red">
-            Failed: {state.message}
-          </Text>
-        )}
-      </Group>
+      <Button
+        variant="light"
+        color="indigo"
+        size="xs"
+        loading={launching}
+        onClick={() => setState({ status: "confirming" })}
+      >
+        {state.status === "launched" ? "Launched ✓" : "Launch Haku run"}
+      </Button>
 
       <Modal
         opened={state.status === "confirming" || launching}

--- a/haku/console/frontend/main.tsx
+++ b/haku/console/frontend/main.tsx
@@ -1,4 +1,5 @@
 import { MantineProvider } from "@mantine/core";
+import { Notifications } from "@mantine/notifications";
 import { createRoot } from "react-dom/client";
 
 import App from "./app.tsx";
@@ -7,6 +8,7 @@ const container = document.getElementById("root");
 if (!container) throw new Error("missing #root");
 createRoot(container).render(
   <MantineProvider defaultColorScheme="auto">
+    <Notifications position="top-right" />
     <App />
   </MantineProvider>
 );

--- a/haku/console/frontend/styles.src.css
+++ b/haku/console/frontend/styles.src.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "@mantine/core/styles.css";
+@import "@mantine/notifications/styles.css";
 
 /* Tailwind v4 scans the class names listed in this generated index (see BUILD:
    tailwind_content_index) so utility classes used in the .tsx survive the build. */

--- a/haku/console/frontend/toast.ts
+++ b/haku/console/frontend/toast.ts
@@ -1,0 +1,18 @@
+import { notifications } from "@mantine/notifications";
+import type { ReactNode } from "react";
+
+// The single mechanism for surfacing action outcomes to the operator. Failures
+// (launch, feedback, a click that didn't commit) route here as a red toast rather
+// than inline/quiet, so a 502/timeout is always visible instead of being swallowed.
+export function toastError(title: string, error: unknown): void {
+  notifications.show({
+    color: "red",
+    title,
+    message: error instanceof Error ? error.message : String(error),
+    autoClose: 8000,
+  });
+}
+
+export function toastSuccess(title: string, message?: ReactNode): void {
+  notifications.show({ color: "teal", title, message, autoClose: 6000 });
+}

--- a/haku/console/test_capabilities.py
+++ b/haku/console/test_capabilities.py
@@ -42,12 +42,29 @@ def _csrf(client: TestClient) -> str:
 
 @respx.mock
 def test_launch_routine_fires_with_server_side_bearer(cap_client) -> None:
-    route = respx.post(FIRE_URL).mock(return_value=httpx.Response(200, json={"queued": True}))
+    session_url = "https://claude.ai/code/session_test123"
+    route = respx.post(FIRE_URL).mock(
+        return_value=httpx.Response(200, json={"claude_code_session_url": session_url, "type": "routine_fire"})
+    )
     resp = cap_client.post("/api/capabilities/launch-routine", headers={"X-CSRF-Token": _csrf(cap_client)})
     assert resp.status_code == 200
-    assert resp.json() == {"status": "launched", "upstream_status": 200}
-    # The bearer is attached server-side and never returned to the client.
-    assert route.calls.last.request.headers["authorization"] == "Bearer sk-test-token"
+    assert resp.json() == {"session_url": session_url}
+    # The bearer + required anthropic-version header are attached server-side; the
+    # bearer is never returned to the client.
+    sent = route.calls.last.request
+    assert sent.headers["authorization"] == "Bearer sk-test-token"
+    assert sent.headers["anthropic-version"] == "2023-06-01"
+
+
+@respx.mock
+def test_launch_routine_surfaces_upstream_error_detail(cap_client) -> None:
+    respx.post(FIRE_URL).mock(
+        return_value=httpx.Response(400, json={"error": {"message": "anthropic-version: header is required"}})
+    )
+    resp = cap_client.post("/api/capabilities/launch-routine", headers={"X-CSRF-Token": _csrf(cap_client)})
+    assert resp.status_code == 502
+    # The real upstream reason is propagated to the client, not a bare 502.
+    assert "anthropic-version: header is required" in resp.json()["detail"]
 
 
 @respx.mock


### PR DESCRIPTION
## What happened

The launch button always failed with a generic **"Failed: Failed to launch routine"**. Root cause: the fire request omitted the required **`anthropic-version`** header, so Anthropic returned `400 "anthropic-version: header is required"`, which the console surfaced as a bare `502` the frontend couldn't explain. (Confirmed by reproducing the call: with the header it returns `200` + a session URL.)

## Fix + error-reporting standardization

**Backend (`capabilities.py`)**
- Send `anthropic-version: 2023-06-01` on the fire request.
- Return the launched **session URL** (`LaunchRoutineResult.session_url`).
- On upstream failure, propagate the **real reason** (`_upstream_detail` pulls the Anthropic `error.message`) in the 502 detail instead of a bare status.

**Frontend — one consistent mechanism**
- `toast.ts`: `toastError` / `toastSuccess` over Mantine notifications (already a dep; mirrors `finance/augur`). Provider wired in `main.tsx` + CSS import.
- `client.ts`: `errorDetail()` surfaces the backend's `{detail}` across **all** endpoints instead of generic strings.
- All **action** errors now toast: launch (plus a success toast linking the new session), feedback (was inline), and the previously **silent** click-revert in `app.tsx`.
- The initial **dashboard-load** failure stays a page-level message (nothing to render) — documented as the one intentional exception to the toast standard.

**Tests** (`test_capabilities.py`): assert the `anthropic-version` header is sent, the `session_url` result shape, and that an upstream error's detail is propagated into the 502.

## Validation

`bbr test //haku/console/...` green (`test_app`, `test_capabilities`, `tsc_test`, `markdown_test`); `server_image` builds (incl. the notifications CSS layer); pre-commit clean.