### PR TITLE
sops: add creation rule for secrets/haku-grocy-jwt.yaml

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -465,6 +465,18 @@ creation_rules:
           - *rugged-agentydragon
           - *atlas-agentydragon
           - *iguana-agentydragon
+  # Haku read-only grocy-sf MCP bearer JWT (auto-rotated by the
+  # authentik-jwt-rotation CronJob). Same readers as haku-k8s-jwt: the Haku
+  # routine (haku) plus admin + user keys for break-glass.
+  - path_regex: secrets/haku-grocy-jwt\.yaml$
+    key_groups:
+      - age:
+          - *admin
+          - *haku
+          - *wyrm2-agentydragon
+          - *rugged-agentydragon
+          - *atlas-agentydragon
+          - *iguana-agentydragon
   # Shared claude-web Attic reader token (auto-rotated by attic-token-rotation
   # CronJob). Used by all claude-web sessions to substitute from
   # cache.allegedly.works/{main,gaffer}.


### PR DESCRIPTION
Fixes a breakage from #2487. That PR added a `haku-grocy` rotation writing `secrets/haku-grocy-jwt.yaml`, but I forgot the matching `.sops.yaml` creation rule — so `sops encrypt --in-place` fails with "no matching creation rules found" and the shared `authentik-jwt-rotation` CronJob errors out on every run.

Verified by running the rotator as a standalone pod: the Authentik token mint **succeeds** (`POST …/o/token/ 200`, `haku-grocy: rotating`); it only fails at the encrypt step. Nothing was committed/pushed (the crash is before the git commit).

Readers mirror `haku-k8s-jwt`: the Haku routine (`haku`) + admin/user keys for break-glass.

Existing tokens have large runway (claude-web ~649h, haku-k8s ~1072h), so no token is at risk — but the CronJob fails hourly until this lands.