### PR TITLE
haku/console: surface routine deep-link; configure by routine id

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -60,8 +60,9 @@ devinfra/js/debundle/peel/golden/**
 # TODO: have the rotator format with prettier (or stop using prettier on yaml
 # entirely, which would also unblock cluster/k8s/flux-system, kustomization,
 # etc.) and drop these excludes.
-secrets/claude-web-k8s-jwt.yaml
-secrets/haku-k8s-jwt.yaml
+# Glob covers every rotated JWT (claude-web-k8s, haku-k8s, haku-grocy, …) so a new
+# rotation target doesn't break CI until someone adds it here by hand.
+secrets/*-jwt.yaml
 **/*.sops.yaml
 secrets/claude-web-attic.yaml
 secrets/hosts/*-attic.yaml

--- a/cluster/k8s/haku/console/deployment.yaml
+++ b/cluster/k8s/haku/console/deployment.yaml
@@ -67,11 +67,12 @@ spec:
                 secretKeyRef:
                   name: haku-state-git-write
                   key: password
-            # Capability tier: the launch-routine action. The fire URL is public
-            # (clear text); the bearer comes from the haku-console-only secret so
-            # Haku can't read it. See haku/PLAN.md → "The agent-authored console".
-            - name: HAKU_CONSOLE_LAUNCH_ROUTINE__URL
-              value: https://api.anthropic.com/v1/claude_code/routines/trig_0158pCMU1XBhoALBWikwSyK4/fire
+            # Capability tier: the launch-routine action. The console builds both the
+            # (public) fire URL and the claude.ai/code page deep-link from this routine
+            # (trigger) id; the bearer comes from the haku-console-only secret so Haku
+            # can't read it. See haku/PLAN.md → "The agent-authored console".
+            - name: HAKU_CONSOLE_LAUNCH_ROUTINE__ROUTINE_ID
+              value: trig_0158pCMU1XBhoALBWikwSyK4
             - name: HAKU_CONSOLE_LAUNCH_ROUTINE__TOKEN
               valueFrom:
                 secretKeyRef:

--- a/haku/PLAN.md
+++ b/haku/PLAN.md
@@ -191,9 +191,16 @@ Two tiers the console treats completely differently:
 
 - **Phase 1 — declarative (1a).** A richer **typed widget schema** (containers, inputs,
   selects, links, sub-pages) emitted in `haku-state` and interpreted by a **trusted
-  renderer** — _no agent JS executes_ — beyond today's `actions[]`. Also still to build:
-  the **executions panel** in the SPA, and `GET /api/capabilities/launch-routine/executions`
-  - a **one-in-flight guard** (both gated on the routine-listing API, not yet wired).
+  renderer** — _no agent JS executes_ — beyond today's `actions[]`. Still to build: an
+  in-console **executions panel** and a **one-in-flight guard**. Both want a
+  routine-runs-listing API — **none is known to exist** for `claude_code` routines
+  (only the `/fire` endpoint), so the interim "review past runs" affordance is the
+  deep-link to the routine's `claude.ai/code` page (built from the routine id alongside
+  the fire URL); each fire also returns its session deep-link. **When the listing API
+  surfaces and we build the panel, adopt the `anthropic` Python SDK** for the Anthropic
+  calls (it auto-sends the `anthropic-version` header — the omission that 502'd the
+  bare-`httpx` fire call — plus `auth_token` bearer, typed errors, and retries) and
+  migrate the `launch-routine` POST onto it at the same time.
 - **Phase 2 — free-form (1b, the destination).** Haku writes TSX/JS into `haku-state`; the
   untrusted render origin transpiles it **at runtime** (never compiled into the trusted
   bundle) and runs it in a **sandboxed cross-origin iframe** (`sandbox` without

--- a/haku/console/app.py
+++ b/haku/console/app.py
@@ -84,7 +84,10 @@ def create_app(settings: Settings, *, git_state: GitState) -> FastAPI:
             clicks = await asyncio.to_thread(git_state.read_clicks)
         scan_time = dt.datetime.now(dt.UTC).strftime("%Y-%m-%d %H:%M UTC")
         clicked = [Click(item_id=item_id, action_id=action_id) for item_id, action_id in sorted(clicks)]
-        return DashboardResponse(scan_time=scan_time, items=items, clicks=clicked)
+        launch = settings.launch_routine
+        return DashboardResponse(
+            scan_time=scan_time, items=items, clicks=clicked, launch_routine_url=launch.page_url if launch else None
+        )
 
     app.include_router(trace.router)
     app.include_router(capabilities.router)

--- a/haku/console/capabilities.py
+++ b/haku/console/capabilities.py
@@ -80,7 +80,7 @@ async def launch_routine(
     await csrf_protect.validate_csrf(request)
     async with httpx.AsyncClient(timeout=30.0) as client:
         resp = await client.post(
-            config.url,
+            config.fire_url,
             headers={
                 "Authorization": f"Bearer {config.token.get_secret_value()}",
                 "anthropic-version": ANTHROPIC_VERSION,

--- a/haku/console/config.py
+++ b/haku/console/config.py
@@ -7,21 +7,35 @@ from pathlib import Path
 from pydantic import BaseModel, SecretStr
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+# Both URLs are built from the routine (trigger) id, so only the id + token are
+# configured. The fire endpoint performs the launch; the claude.ai page is the
+# operator-facing deep-link to review past runs (there's no runs-listing API).
+_FIRE_URL = "https://api.anthropic.com/v1/claude_code/routines/{id}/fire"
+_PAGE_URL = "https://claude.ai/code/routines/{id}"
+
 
 class LaunchRoutineConfig(BaseModel):
-    """The `launch-routine` capability's target: the public Anthropic fire URL plus
-    the bearer that authorizes it. Both come from the `haku-routine-launch-token`
-    secret / deployment env; set together or not at all (the capability is disabled
-    when unset). The token lives only in the haku-console namespace — Haku can't
-    read it."""
+    """The `launch-routine` capability: the routine (trigger) id plus the bearer that
+    authorizes firing it. Both come from the deployment env / `haku-routine-launch-token`
+    secret; set together or not at all (the capability is disabled when unset). Only the
+    token is secret, and it lives only in the haku-console namespace — Haku can't read
+    it. The fire and page URLs are derived from the id."""
 
-    url: str
+    routine_id: str
     token: SecretStr
+
+    @property
+    def fire_url(self) -> str:
+        return _FIRE_URL.format(id=self.routine_id)
+
+    @property
+    def page_url(self) -> str:
+        return _PAGE_URL.format(id=self.routine_id)
 
 
 class Settings(BaseSettings):
-    # env_nested_delimiter so launch_routine.{url,token} read from
-    # HAKU_CONSOLE_LAUNCH_ROUTINE__URL / __TOKEN.
+    # env_nested_delimiter so launch_routine.{routine_id,token} read from
+    # HAKU_CONSOLE_LAUNCH_ROUTINE__{ROUTINE_ID,TOKEN}.
     model_config = SettingsConfigDict(env_prefix="HAKU_CONSOLE_", env_nested_delimiter="__")
 
     # haku-state git access. The repo_url is the cluster-internal plaintext-HTTP

--- a/haku/console/frontend/app.tsx
+++ b/haku/console/frontend/app.tsx
@@ -79,7 +79,7 @@ export default function App() {
     <div className="mx-auto max-w-3xl px-4 py-8">
       <Group justify="space-between" align="center">
         <Title order={1}>Haku</Title>
-        <LaunchRoutineButton />
+        <LaunchRoutineButton routineUrl={data.launch_routine_url} />
       </Group>
       <Text c="dimmed" mb="lg">
         Your value-ranked backlog ·{" "}

--- a/haku/console/frontend/launch.tsx
+++ b/haku/console/frontend/launch.tsx
@@ -10,8 +10,9 @@ type State = { status: "idle" } | { status: "confirming" } | { status: "launchin
 // confirm copy live in the trusted bundle (never agent-authored), so a genuine operator
 // gesture against trusted-rendered text is what fires the capability — agent UI can at
 // most ask for it, never script or spoof it. The CSRF + server-side bearer live in the
-// backend (see haku/console/capabilities.py). Outcomes surface as toasts.
-export function LaunchRoutineButton() {
+// backend (see haku/console/capabilities.py). Outcomes surface as toasts. routineUrl, when
+// set, deep-links to the routine's claude.ai/code page to review past runs (no listing API).
+export function LaunchRoutineButton({ routineUrl }: { routineUrl?: string | null }) {
   const [state, setState] = useState<State>({ status: "idle" });
   const launching = state.status === "launching";
 
@@ -35,15 +36,22 @@ export function LaunchRoutineButton() {
 
   return (
     <>
-      <Button
-        variant="light"
-        color="indigo"
-        size="xs"
-        loading={launching}
-        onClick={() => setState({ status: "confirming" })}
-      >
-        {state.status === "launched" ? "Launched ✓" : "Launch Haku run"}
-      </Button>
+      <Group gap="sm">
+        <Button
+          variant="light"
+          color="indigo"
+          size="xs"
+          loading={launching}
+          onClick={() => setState({ status: "confirming" })}
+        >
+          {state.status === "launched" ? "Launched ✓" : "Launch Haku run"}
+        </Button>
+        {routineUrl && (
+          <Anchor href={routineUrl} target="_blank" rel="noreferrer" size="xs" c="dimmed">
+            View runs ↗
+          </Anchor>
+        )}
+      </Group>
 
       <Modal
         opened={state.status === "confirming" || launching}

--- a/haku/console/models.py
+++ b/haku/console/models.py
@@ -99,6 +99,11 @@ class DashboardResponse(BaseModel):
     scan_time: str
     items: list[Item]
     clicks: list[Click]
+    # The launch-routine's claude.ai/code page, surfaced as a "view past runs" deep-link
+    # (there's no runs-listing API). None when the launch capability isn't configured.
+    # This is a benign public link — the privileged launch action stays on the
+    # capability tier (see haku.console.capabilities).
+    launch_routine_url: str | None = None
 
 
 class FeedbackRequest(BaseModel):

--- a/haku/console/test_capabilities.py
+++ b/haku/console/test_capabilities.py
@@ -18,7 +18,9 @@ from pydantic import SecretStr
 from haku.console.app import create_app
 from haku.console.config import LaunchRoutineConfig
 
-FIRE_URL = "https://fire.test.example/routines/trig_test/fire"
+ROUTINE_ID = "trig_test"
+FIRE_URL = f"https://api.anthropic.com/v1/claude_code/routines/{ROUTINE_ID}/fire"
+PAGE_URL = f"https://claude.ai/code/routines/{ROUTINE_ID}"
 
 
 @pytest.fixture
@@ -26,12 +28,22 @@ def cap_client(seeded) -> Iterator[TestClient]:
     """Console app with the launch-routine capability configured (over the seeded remote)."""
     settings = seeded.settings.model_copy(
         update={
-            "launch_routine": LaunchRoutineConfig(url=FIRE_URL, token=SecretStr("sk-test-token")),
+            "launch_routine": LaunchRoutineConfig(routine_id=ROUTINE_ID, token=SecretStr("sk-test-token")),
             "csrf_secret": SecretStr("test-csrf-secret"),
         }
     )
     with TestClient(create_app(settings, git_state=seeded.git_state)) as c:
         yield c
+
+
+def test_dashboard_surfaces_routine_page_url(cap_client) -> None:
+    # The routine deep-link (built from the id) reaches the SPA via the dashboard read.
+    assert cap_client.get("/api/dashboard").json()["launch_routine_url"] == PAGE_URL
+
+
+def test_dashboard_routine_url_none_when_unconfigured(client) -> None:
+    # The `client` fixture has no launch_routine configured.
+    assert client.get("/api/dashboard").json()["launch_routine_url"] is None
 
 
 def _csrf(client: TestClient) -> str:


### PR DESCRIPTION
## What

Two related changes:

1. **Surface the routine deep-link.** A "View runs ↗" link next to the Launch button → the routine's `claude.ai/code/routines/{id}` page. There's no runs-listing API for `claude_code` routines (only `/fire`), so a logged-in operator clicking through lands straight on the routine where past runs are visible. (Each fire already toasts its own session deep-link.)
2. **Configure by routine id.** Both URLs are derived from the routine (trigger) id, so only the **id + token** are configured — no hand-written/duplicated full URLs.

## Changes

- **`config.py`** — `LaunchRoutineConfig` is now `routine_id` + `token`; `fire_url` / `page_url` are derived properties. Env: `HAKU_CONSOLE_LAUNCH_ROUTINE__{ROUTINE_ID,TOKEN}`.
- **`capabilities.py`** — fires `config.fire_url`.
- **`models.py` + `app.py`** — `DashboardResponse.launch_routine_url` carries the page link (`None` when the capability isn't configured). It's a benign public hyperlink surfaced via the read API; the **privileged launch POST stays on the capability tier** (CSRF-gated, server-side bearer).
- **`launch.tsx` / `app.tsx`** — render the deep-link from the dashboard data.
- **`deployment.yaml`** — `HAKU_CONSOLE_LAUNCH_ROUTINE__ROUTINE_ID` replaces the full fire URL.
- **`PLAN.md`** — records that no runs-listing API is known, the deep-link is the interim affordance, and to adopt the `anthropic` Python SDK when the executions panel is built (auto `anthropic-version` header — the omission that 502'd the bare-`httpx` fire call — plus `auth_token`, typed errors, retries).

## Notes

- Same trigger id (`trig_…`) drives both the `api.anthropic.com/.../fire` action and the `claude.ai/code/routines/…` page — confirmed identical.
- Tests: dashboard surfaces the derived page URL (and `None` when unconfigured); the fire path still hits the derived `fire_url` with the `anthropic-version` header.

## Validation

`bbr test //haku/console/...` green (`test_app`, `test_capabilities`, `tsc_test`, `markdown_test`); `server_image` builds; pre-commit clean.