### PR TITLE
haku: pass kube-token vars via Terraform CR spec.vars (fix #2484 deploy)

### DIFF
--- a/cluster/k8s/haku/cloud-agent-tf/terraform.yaml
+++ b/cluster/k8s/haku/cloud-agent-tf/terraform.yaml
@@ -15,6 +15,23 @@ spec:
   serviceAccountName: tf-runner
   approvePlan: "auto"
 
+  # haku-k8s Authentik JWT (rotated by authentik-jwt-rotation into the
+  # haku-cloud-kube-token Secret) + its exp epoch. tofu writes the token into the
+  # Anthropic vault as a static_bearer credential; the exp drives the write-only
+  # token_wo_version so each rotation re-sends. Passed via the controller's native
+  # vars (NOT runner TF_VAR_* env — the tf-controller forbids that). See the root's main.tf.
+  vars:
+    - name: haku_kube_token
+      valueFrom:
+        secretKeyRef:
+          name: haku-cloud-kube-token
+          key: jwt
+    - name: haku_kube_token_wo_version
+      valueFrom:
+        secretKeyRef:
+          name: haku-cloud-kube-token
+          key: token-exp
+
   backendConfig:
     customConfiguration: |
       backend "pg" {
@@ -36,17 +53,3 @@ spec:
             secretKeyRef:
               name: haku-cloud-anthropic-api-key
               key: api-key
-        # haku-k8s Authentik JWT (rotated by authentik-jwt-rotation into the
-        # haku-cloud-kube-token Secret) + its exp epoch. tofu writes the token into
-        # the Anthropic vault as a static_bearer credential; the exp drives the
-        # write-only token_wo_version so each rotation re-sends. See the root's main.tf.
-        - name: TF_VAR_haku_kube_token
-          valueFrom:
-            secretKeyRef:
-              name: haku-cloud-kube-token
-              key: jwt
-        - name: TF_VAR_haku_kube_token_wo_version
-          valueFrom:
-            secretKeyRef:
-              name: haku-cloud-kube-token
-              key: token-exp

--- a/tf/gitops/haku-cloud-agent/main.tf
+++ b/tf/gitops/haku-cloud-agent/main.tf
@@ -102,7 +102,7 @@ resource "claude-managed-agents_vault_credential" "haku_kube" {
     type             = "static_bearer"
     mcp_server_url   = "https://kubectl-machine-mcp.allegedly.works/mcp"
     token            = var.haku_kube_token
-    token_wo_version = var.haku_kube_token_wo_version
+    token_wo_version = tonumber(var.haku_kube_token_wo_version)
   }
 }
 

--- a/tf/gitops/haku-cloud-agent/variables.tf
+++ b/tf/gitops/haku-cloud-agent/variables.tf
@@ -2,10 +2,12 @@ variable "haku_kube_token" {
   type        = string
   ephemeral   = true
   sensitive   = true
-  description = "haku-k8s Authentik JWT for the static_bearer vault credential. Injected into the tofu-controller runner from the haku-cloud-kube-token Secret as TF_VAR_haku_kube_token. ephemeral so it never lands in plan or state (the credential's token attribute is also write-only). See main.tf rotation note."
+  description = "haku-k8s Authentik JWT for the static_bearer vault credential. Set from the haku-cloud-kube-token Secret's jwt key via the Terraform CR's spec.vars. ephemeral so it never lands in plan or state (the credential's token attribute is also write-only). See main.tf rotation note."
 }
 
 variable "haku_kube_token_wo_version" {
-  type        = number
-  description = "The haku JWT's exp epoch (seconds). Drives the write-only token_wo_version so each rotation (new token -> later exp) re-sends the token into the Anthropic vault. From the haku-cloud-kube-token Secret's token-exp key (TF_VAR_haku_kube_token_wo_version)."
+  # String (not number): the tofu-controller passes Secret-sourced vars as strings;
+  # tonumber() at the use site in main.tf.
+  type        = string
+  description = "The haku JWT's exp epoch (seconds). Drives the write-only token_wo_version so each rotation (new token -> later exp) re-sends the token into the Anthropic vault. From the haku-cloud-kube-token Secret's token-exp key, via the CR's spec.vars."
 }


### PR DESCRIPTION
**Fix-forward for #2484.** On merge, the `haku-cloud-agent` Terraform CR got stuck at:
```
TFExecInitFailed: manual setting of env var "TF_VAR_haku_kube_token" detected
```
The tofu-controller forbids injecting `TF_VAR_*` through the runner pod env. Nothing was created in the Anthropic org (init fails before apply).

**Fix:** pass the two variables through the CR's native `spec.vars[].valueFrom.secretKeyRef` (from `haku-cloud-kube-token`: `jwt`, `token-exp`) instead of runner env. The controller passes Secret-sourced vars as strings, so `haku_kube_token_wo_version` is now a `string` var, `tonumber()`'d at the use site. `ANTHROPIC_API_KEY` stays a runner env var (not `TF_VAR_`, allowed).

Tested: `tofu validate` + `//tf/gitops/haku-cloud-agent:{validate,lint,format}` + `//cluster/validation:{test_k8s,test_flux,test_flux_build}` ✅