### PR TITLE
mcp/authentik: accept issuer with trailing slash in JWTVerifier

### DIFF
--- a/mcp_infra/authentik_auth/auth.py
+++ b/mcp_infra/authentik_auth/auth.py
@@ -140,7 +140,13 @@ def build_authentik_auth(
     )
     assert proxy.client_registration_options is not None
     proxy.client_registration_options.valid_scopes = valid_scopes or DEFAULT_VALID_SCOPES
-    return MultiAuth(server=proxy, verifiers=[JWTVerifier(jwks_uri=jwks_uri, issuer=issuer)])
+    # Accept the issuer both with and without a trailing slash. `normalized_issuer()`
+    # strips the slash, but Authentik's per-provider tokens carry `iss` WITH a
+    # trailing slash and JWTVerifier compares `iss` to the configured issuer by exact
+    # string match — so the bare form alone rejects every real Authentik token. (Not
+    # caught before because claude.ai authenticates through OIDCProxy, never the
+    # JWTVerifier path; direct machine bearer tokens do.)
+    return MultiAuth(server=proxy, verifiers=[JWTVerifier(jwks_uri=jwks_uri, issuer=[issuer, issuer + "/"])])
 
 
 # ── Token exchange auth ───────────────────────────────────────────────────

--- a/mcp_infra/authentik_auth/test_auth.py
+++ b/mcp_infra/authentik_auth/test_auth.py
@@ -110,6 +110,32 @@ def test_build_authentik_auth_uses_jwks_uri_from_discovery() -> None:
     )
 
 
+def test_build_authentik_auth_accepts_issuer_with_trailing_slash() -> None:
+    """JWTVerifier must accept the issuer both with and without a trailing slash.
+
+    Authentik's per-provider tokens carry `iss` WITH a trailing slash, but
+    `normalized_issuer()` strips it and JWTVerifier matches `iss` by exact string,
+    so the bare form alone rejects every real Authentik token. Regression: this
+    silently blocked all direct machine bearer tokens (e.g. haku → grocy MCP).
+    """
+    discovery_response = AsyncMock()
+    discovery_response.raise_for_status = lambda: discovery_response
+    discovery_response.json = lambda: {"jwks_uri": "https://auth.example.com/application/o/test/jwks/"}
+
+    with (
+        patch("mcp_infra.authentik_auth.auth.httpx.get", return_value=discovery_response),
+        patch("mcp_infra.authentik_auth.auth.OIDCProxy") as oidc_proxy_cls,
+        patch("mcp_infra.authentik_auth.auth.JWTVerifier") as jwt_verifier_cls,
+        patch("mcp_infra.authentik_auth.auth.MultiAuth"),
+    ):
+        oidc_proxy_cls.return_value.client_registration_options = AsyncMock()
+        build_authentik_auth(_config(issuer="https://auth.example.com/application/o/test/"))
+
+    issuer = jwt_verifier_cls.call_args.kwargs["issuer"]
+    assert "https://auth.example.com/application/o/test/" in issuer  # the form Authentik actually emits
+    assert "https://auth.example.com/application/o/test" in issuer
+
+
 # ── AuthentikExchangeAuth tests ───────────────────────────────────────────
 
 

--- a/tf/gitops/agent-machine-access/main.tf
+++ b/tf/gitops/agent-machine-access/main.tf
@@ -946,6 +946,18 @@ resource "kubernetes_secret" "haku_client_credentials" {
 #
 # Consumer: cluster/k8s/agents/authentik-jwt-rotation/ CronJob (haku-grocy entry).
 # It mints the JWT and commits it SOPS-encrypted to secrets/haku-grocy-jwt.yaml.
+#
+# TODO(haku-grocy blocker #2): the grocy-mcp-sf provider has no
+# access_token_validity set, so it issues ~10-minute tokens — far too short for
+# the rotation model (the rotator commits a token that expires before any
+# consumer reads it; verified live, exp ≈ 599s). Before wiring runtimes, give
+# this token a long validity like haku-k8s (its provider uses hours=1080).
+# Caveat: grocy-mcp-sf is SHARED with the claude.ai user-login flow, so either
+# set access_token_validity on it directly (also lengthens user tokens) or split
+# out a dedicated grocy-mcp-haku client-credentials provider (then add its issuer
+# to the MCP's JWTVerifier list). See project memory project-haku-grocy-ro.
+# (Blocker #1 — the JWTVerifier trailing-slash issuer bug — is fixed separately
+# in mcp_infra/authentik_auth/auth.py.)
 
 resource "authentik_user" "haku_grocy" {
   username = "haku"


### PR DESCRIPTION
## Blocker #1 for haku → grocy-sf MCP (fix)

`build_authentik_auth` passed the slash-stripped `normalized_issuer()` to fastmcp's `JWTVerifier`, which matches the token's `iss` by **exact string**. Authentik's per-provider tokens carry `iss` **with a trailing slash**, so the bare form rejected every real Authentik bearer token.

Latent because claude.ai authenticates via OIDCProxy, never the JWTVerifier path — but **direct machine bearer tokens** (haku → grocy-sf MCP) hit it. Verified live, replaying the verifier inside the grocy MCP pod against a freshly-minted haku token:
```
issuer ".../grocy-mcp-sf"  -> REJECTED  (jwt.py:425 issuer mismatch)
issuer ".../grocy-mcp-sf/" -> ACCEPTED
```

**Fix:** pass the issuer as a list `[issuer, issuer + "/"]` (fastmcp's JWTVerifier accepts a list and matches by membership). Strictly enables valid Authentik tokens; no working client relied on the broken behavior. Affects all `build_authentik_auth` consumers (grocy sf/vallejo, tana facade) — all benefit.

Regression test added; `//mcp_infra/authentik_auth:test_auth` passes on RBE.

## Note: blocker #2 (not fixed here)
Left as a `TODO` in the `haku-grocy` TF block: the `grocy-mcp-sf` provider issues **~10-minute tokens** (no `access_token_validity`), too short for the rotation model. Needs a long validity (like `haku-k8s`'s `hours=1080`) — but that provider is shared with the claude.ai login flow, so it's either lengthen-the-shared-provider or split-out-a-dedicated-provider. Deferred for a decision.

After this merges + the grocy MCP image redeploys, I'll re-run the end-to-end check (read=200 / write=403 / `X-authentik-username: haku`) once #2 is also resolved.