### PR TITLE
[codex] debundle: remove wildcard string selector field

### DIFF
--- a/devinfra/js/debundle/match_selector.rs
+++ b/devinfra/js/debundle/match_selector.rs
@@ -123,7 +123,6 @@ fn run_match_selector_impl(config: &MatchSelectorConfig) -> Result<MatchSelector
             match_source,
             identifiers: SourceMatchIdentifierMode::AlphaAll,
             target_binding: config.target_binding.clone(),
-            wildcard_string_literals: BTreeSet::new(),
         }
         .selector();
         resolver.member_candidates("<match-selector>", &selector)

--- a/devinfra/js/debundle/selector_candidate_index.rs
+++ b/devinfra/js/debundle/selector_candidate_index.rs
@@ -518,11 +518,6 @@ impl<'a, 'features> AstFeatureCollector<'a, 'features> {
         self.selector
             .is_none_or(|selector| selector.identifiers == SourceMatchIdentifierMode::Exact)
     }
-
-    fn string_literal_is_wildcard(&self, value: &str) -> bool {
-        self.selector
-            .is_some_and(|selector| selector.wildcard_string_literals.contains(value))
-    }
 }
 
 impl Visit for AstFeatureCollector<'_, '_> {
@@ -534,9 +529,7 @@ impl Visit for AstFeatureCollector<'_, '_> {
             match lit {
                 Lit::Str(str_) => {
                     let value = str_.value.to_string_lossy().to_string();
-                    if !self.string_literal_is_wildcard(&value) {
-                        self.features.insert(SelectorFeature::StringLiteral(value));
-                    }
+                    self.features.insert(SelectorFeature::StringLiteral(value));
                 }
                 // Number / bool literals are never wildcarded or holed in place
                 // (only an `EXPR`/`ANYTHING` hole erases them, handled above),
@@ -968,7 +961,6 @@ mod tests {
             match_source: match_source.to_string(),
             identifiers: SourceMatchIdentifierMode::AlphaAll,
             target_binding: None,
-            wildcard_string_literals: BTreeSet::new(),
         }
     }
 
@@ -1152,32 +1144,6 @@ const alpha = makeOther("shared-token");"#,
                 .contains(&SelectorFeature::CallCallee("makeWidget".to_string()))
         );
         assert_eq!(body_indices(index.candidate_set_for_query(&query)), vec![0]);
-    }
-
-    #[test]
-    fn wildcard_string_literals_are_not_index_anchors() {
-        let runtime = parse_module(
-            r#"const alpha = "runtime-a";
-const beta = "runtime-b";
-let gamma = "runtime-a";"#,
-        );
-        let index = SelectorCandidateIndex::new(&runtime);
-        let mut selector = selector(r#"const readable = "STRING_HOLE";"#);
-        selector
-            .wildcard_string_literals
-            .insert("STRING_HOLE".to_string());
-
-        let query = SelectorCandidateIndex::query_for_source_match(&selector).unwrap();
-        assert!(
-            !query.alternatives()[0]
-                .features()
-                .iter()
-                .any(|feature| matches!(feature, SelectorFeature::StringLiteral(_)))
-        );
-        assert_eq!(
-            body_indices(index.candidate_set_for_query(&query)),
-            vec![0, 1]
-        );
     }
 
     #[test]

--- a/devinfra/js/debundle/selector_codemod.rs
+++ b/devinfra/js/debundle/selector_codemod.rs
@@ -1323,7 +1323,6 @@ fn prove_synthesized_selector(
             match_source: match_source.to_string(),
             identifiers: SourceMatchIdentifierMode::AlphaAll,
             target_binding: None,
-            wildcard_string_literals: BTreeSet::new(),
         }
         .selector();
         let exports_by_target = targets
@@ -1368,7 +1367,6 @@ fn prove_synthesized_selector(
         match_source: match_source.to_string(),
         identifiers: SourceMatchIdentifierMode::AlphaAll,
         target_binding: Some(target.export_name.clone()),
-        wildcard_string_literals: BTreeSet::new(),
     };
     let selector = source_match.selector();
     // Prove gate. The fact resolver returns every candidate the selector resolves
@@ -1499,7 +1497,6 @@ fn matched_binding_candidates(
         match_source: match_source.to_string(),
         identifiers: SourceMatchIdentifierMode::AlphaAll,
         target_binding: Some(export_name.to_string()),
-        wildcard_string_literals: BTreeSet::new(),
     };
     index
         .resolver()

--- a/devinfra/js/debundle/selector_ir_lowering.rs
+++ b/devinfra/js/debundle/selector_ir_lowering.rs
@@ -410,9 +410,7 @@ impl MemberSelectorProgramBuilder {
         if parsed.body.len() > 1 && selector.target_binding.is_none() {
             return Ok(false);
         }
-        let Ok(facts) =
-            chunk_facts::extract_facts_needle(&parsed.body, &selector.wildcard_string_literals)
-        else {
+        let Ok(facts) = chunk_facts::extract_facts_items(&parsed.body) else {
             return Ok(false);
         };
         if parsed.body.len() > 1 && !native_module_stmt_list_hole_roots(&facts).is_empty() {
@@ -686,9 +684,7 @@ impl MemberSelectorProgramBuilder {
         if parsed.body.is_empty() {
             return Ok(false);
         }
-        let Ok(facts) =
-            chunk_facts::extract_facts_needle(&parsed.body, &selector.wildcard_string_literals)
-        else {
+        let Ok(facts) = chunk_facts::extract_facts_items(&parsed.body) else {
             return Ok(false);
         };
         let module_stmt_list_hole_roots = native_module_stmt_list_hole_roots(&facts);
@@ -2662,36 +2658,6 @@ mod tests {
                 .count(),
             2
         );
-    }
-
-    #[test]
-    fn exact_source_match_wildcard_strings_lower_to_shared_string_var() {
-        let mut selector =
-            AnonymousStatementSelector::exact("const pair = [\"__VALUE__\", \"__VALUE__\"];");
-        selector
-            .wildcard_string_literals
-            .insert("__VALUE__".to_string());
-        let lowered = lower_member_selector(
-            &context(),
-            "Widget",
-            &MemberSelectorSpec::SourceMatch(selector),
-        )
-        .unwrap();
-        let mut string_vars = lowered.program.atoms.iter().filter_map(|atom| match atom {
-            SelectorAtom::AstStringLiteral {
-                value: StringTerm::Var { id },
-                ..
-            } => Some(*id),
-            _ => None,
-        });
-        let first = string_vars.next().expect("first wildcard string atom");
-        let second = string_vars.next().expect("second wildcard string atom");
-        assert_eq!(first, second);
-        assert!(string_vars.next().is_none());
-        assert!(matches!(
-            lowered.program.variables[first.0].domain,
-            VariableDomain::String
-        ));
     }
 
     #[test]

--- a/devinfra/js/debundle/shape_index_soundness_test.rs
+++ b/devinfra/js/debundle/shape_index_soundness_test.rs
@@ -67,7 +67,6 @@ fn render_selector(module: &Module, anchor: &AnchorSet) -> AnonymousStatementSel
         match_source,
         identifiers: SourceMatchIdentifierMode::AlphaAll,
         target_binding: None,
-        wildcard_string_literals: BTreeSet::new(),
     }
 }
 

--- a/devinfra/js/debundle/source_match/datalog_resolver.rs
+++ b/devinfra/js/debundle/source_match/datalog_resolver.rs
@@ -18,19 +18,14 @@ fn item_facts(item: &ModuleItem) -> Option<chunk_facts::ChunkFacts> {
     chunk_facts::extract_facts_items(std::slice::from_ref(item)).ok()
 }
 
-/// Facts for a single **needle** statement, honoring the selector's
-/// `wildcard_string_literals` (a `StrLit` whose value is a wildcard projects to a
-/// `str_wildcard` fact the matcher matches against any string value). Subject
-/// (chunk-body) facts use [`item_facts`] — real source carries no wildcards.
+/// Facts for a single **needle** statement. Source-match selectors no longer
+/// carry string-literal wildcards, so needle facts use the same projection as
+/// subject facts.
 fn needle_item_facts(
     item: &ModuleItem,
-    selector: &AnonymousStatementSelector,
+    _selector: &AnonymousStatementSelector,
 ) -> Option<chunk_facts::ChunkFacts> {
-    chunk_facts::extract_facts_needle(
-        std::slice::from_ref(item),
-        &selector.wildcard_string_literals,
-    )
-    .ok()
+    chunk_facts::extract_facts_items(std::slice::from_ref(item)).ok()
 }
 
 /// One chunk's relational model, built once: the AST plus its top-level body
@@ -1180,7 +1175,6 @@ mod tests {
             match_source: match_source.to_string(),
             identifiers: SourceMatchIdentifierMode::AlphaAll,
             target_binding: target_binding.map(str::to_string),
-            wildcard_string_literals: BTreeSet::new(),
         }
     }
 
@@ -1193,7 +1187,6 @@ mod tests {
             match_source: match_source.to_string(),
             identifiers: SourceMatchIdentifierMode::AlphaAll,
             target_binding: None,
-            wildcard_string_literals: BTreeSet::new(),
         }
     }
 

--- a/devinfra/js/debundle/source_match/fact_near_miss.rs
+++ b/devinfra/js/debundle/source_match/fact_near_miss.rs
@@ -909,7 +909,6 @@ mod tests {
                 SourceMatchIdentifierMode::Exact
             },
             target_binding: None,
-            wildcard_string_literals: BTreeSet::new(),
         }
     }
 

--- a/devinfra/js/debundle/spec.rs
+++ b/devinfra/js/debundle/spec.rs
@@ -801,7 +801,6 @@ impl AnonymousStatement {
                 match_source: match_source.clone(),
                 identifiers: SourceMatchIdentifierMode::Exact,
                 target_binding: None,
-                wildcard_string_literals: BTreeSet::new(),
             }),
             (None, Some(source_match)) if source_match.target_binding.is_some() => {
                 Err(AnonymousStatementSelectorError {
@@ -845,10 +844,6 @@ pub struct SourceMatch {
     /// binding from it. Invalid on `anonymous_statements[].source_match`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub target_binding: Option<String>,
-    /// Internal-only string-literal placeholder values used by legacy matcher
-    /// tests. The public YAML surface no longer accepts or emits this field.
-    #[serde(skip)]
-    pub wildcard_string_literals: BTreeSet<String>,
     #[serde(rename = "match")]
     pub match_source: String,
 }
@@ -895,7 +890,6 @@ impl<'de> Deserialize<'de> for SourceMatch {
         Ok(Self {
             identifiers,
             target_binding: wire.target_binding,
-            wildcard_string_literals: BTreeSet::new(),
             match_source: wire.match_source,
         })
     }
@@ -907,7 +901,6 @@ impl SourceMatch {
             match_source: self.match_source.clone(),
             identifiers: self.identifiers,
             target_binding: self.target_binding.clone(),
-            wildcard_string_literals: self.wildcard_string_literals.clone(),
         }
     }
 }
@@ -917,7 +910,6 @@ pub struct AnonymousStatementSelector {
     pub match_source: String,
     pub identifiers: SourceMatchIdentifierMode,
     pub target_binding: Option<String>,
-    pub wildcard_string_literals: BTreeSet<String>,
 }
 
 impl AnonymousStatementSelector {
@@ -926,7 +918,6 @@ impl AnonymousStatementSelector {
             match_source: match_source.into(),
             identifiers: SourceMatchIdentifierMode::Exact,
             target_binding: None,
-            wildcard_string_literals: BTreeSet::new(),
         }
     }
 }

--- a/devinfra/js/debundle/spec_modules.rs
+++ b/devinfra/js/debundle/spec_modules.rs
@@ -346,7 +346,6 @@ anonymous_statements:
                     match_source: "register(Co);".to_string(),
                     identifiers: spec::SourceMatchIdentifierMode::AlphaAll,
                     target_binding: None,
-                    wildcard_string_literals: BTreeSet::new(),
                 },
             ])
         );


### PR DESCRIPTION
## Summary

Removes the now-private/deprecated `wildcard_string_literals` selector field from the active source-match selector model.

- drops `SourceMatch::wildcard_string_literals` and `AnonymousStatementSelector::wildcard_string_literals`
- removes constructor/read call sites and wildcard-specific unit coverage that mutated the field directly
- switches source-match needle fact extraction back to the ordinary item fact projection now that selectors cannot carry string-literal wildcards
- keeps the public legacy-field rejection test and leaves lower-level `chunk_facts` / `selector_match` wildcard plumbing for a follow-up deletion pass

## Validation

- `nix develop -c bbr test //devinfra/js/debundle:spec_test //devinfra/js/debundle:spec_modules_test //devinfra/js/debundle:source_match_test //devinfra/js/debundle:selector_codemod_test //devinfra/js/debundle:selector_candidate_index_test //devinfra/js/debundle:selector_ir_lowering_test //devinfra/js/debundle:shape_index_soundness_test --test_output=errors --cache_test_results=no`
  - BuildBuddy: https://app.buildbuddy.io/invocation/948e8f44-a57b-4227-8927-901d86e1e7ac
- `nix develop -c pre-commit run --files devinfra/js/debundle/match_selector.rs devinfra/js/debundle/selector_candidate_index.rs devinfra/js/debundle/selector_codemod.rs devinfra/js/debundle/selector_ir_lowering.rs devinfra/js/debundle/shape_index_soundness_test.rs devinfra/js/debundle/source_match/datalog_resolver.rs devinfra/js/debundle/source_match/fact_near_miss.rs devinfra/js/debundle/spec.rs devinfra/js/debundle/spec_modules.rs`