### PR TITLE
haku-grocy: dedicated 30-day client-credentials provider (blocker #2)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -273,6 +273,8 @@ repos:
             cluster/k8s/evidence/market-roster/market-roster\.yaml|
             cluster/k8s/agents/airlock/config\.yaml|
             cluster/k8s/agents/tana-mcp-ro/config\.yaml|
+            cluster/k8s/grocy/sf/mcp/config\.yaml|
+            cluster/k8s/grocy/vallejo/mcp/config\.yaml|
             cluster/k8s/agents/plaid-mcp/app/items\.yaml|
             cluster/k8s/agents/grocy-mcp/envoy\.yaml|
             cluster/k8s/agents/homeassistant-proxy/config\.yaml|

--- a/cluster/k8s/agents/authentik-jwt-rotation/rotations.yaml
+++ b/cluster/k8s/agents/authentik-jwt-rotation/rotations.yaml
@@ -41,15 +41,16 @@ rotations:
       namespace: flux-system
   - name: haku-grocy
     # Source JWT for haku's read-only access to the grocy-sf MCP. Issued by the
-    # grocy-mcp-sf provider so its iss matches the MCP's JWTVerifier; the MCP runs
-    # the jwt-bearer exchange into the grocy-sf proxy itself, so no exchange_scopes
-    # here. The outpost then injects X-authentik-username=haku → the read-only
-    # `haku` Grocy user (empty perms). aud defaults to the provider client_id.
-    provider_slug: grocy-mcp-sf
+    # dedicated grocy-mcp-haku-sf provider (30-day validity; shares grocy-mcp-sf's
+    # signing key so the MCP's JWKS validates it, and the MCP accepts its issuer via
+    # GROCY_MCP_AUTH__EXTRA_JWT_ISSUERS). No exchange_scopes — the MCP runs the
+    # jwt-bearer exchange into the grocy-sf proxy itself. The outpost then injects
+    # X-authentik-username=haku → the read-only `haku` Grocy user (empty perms).
+    provider_slug: grocy-mcp-haku-sf
     scopes: openid profile email
     credential_mode: user_password
     expected_audiences:
-      - grocy-mcp-sf
+      - grocy-mcp-haku-sf
     credentials_dir: /var/run/secrets/authentik/haku-grocy
     sops_file: secrets/haku-grocy-jwt.yaml
     token_field: jwt

--- a/cluster/k8s/grocy/mcp-base/server-deployment.yaml
+++ b/cluster/k8s/grocy/mcp-base/server-deployment.yaml
@@ -32,13 +32,12 @@ spec:
           env:
             - name: LOG_LEVEL
               value: "DEBUG"
-            # Overlay patches replace these values per household.
-            - name: GROCY_MCP_AUTH__OIDC_ISSUER
-              value: "MUST_BE_PATCHED"
-            - name: GROCY_MCP_AUTH__PUBLIC_BASE_URL
-              value: "MUST_BE_PATCHED"
-            - name: GROCY_MCP_GROCY_URL
-              value: "MUST_BE_PATCHED"
+            # Non-secret structured config (grocy_url, auth issuer/URLs/
+            # extra_jwt_issuers, persistence) comes from this YAML file, supplied
+            # per household by the overlay's grocy-mcp-config configMap. Secrets
+            # stay in env below (per-household secret via overlay patch).
+            - name: GROCY_MCP_CONFIG_FILE
+              value: /etc/grocy-mcp/config.yaml
             - name: GROCY_MCP_AUTH__OIDC_CLIENT_ID
               valueFrom:
                 secretKeyRef:
@@ -61,6 +60,10 @@ spec:
             limits:
               memory: "256Mi"
               cpu: "200m"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/grocy-mcp
+              readOnly: true
           readinessProbe:
             tcpSocket:
               port: 8765
@@ -71,3 +74,7 @@ spec:
               port: 8765
             initialDelaySeconds: 15
             periodSeconds: 20
+      volumes:
+        - name: config
+          configMap:
+            name: grocy-mcp-config

--- a/cluster/k8s/grocy/sf/mcp/config.yaml
+++ b/cluster/k8s/grocy/sf/mcp/config.yaml
@@ -1,0 +1,15 @@
+# Non-secret config for the grocy-sf MCP server, mounted at GROCY_MCP_CONFIG_FILE.
+# Secrets (oidc client_id/secret, proxy client_id) come from env (grocy-mcp-oidc-sf
+# k8s Secret), so no single field here is secret.
+grocy_url: https://grocy-sf.allegedly.works
+auth:
+  oidc_issuer: https://auth.allegedly.works/application/o/grocy-mcp-sf/
+  public_base_url: https://grocy-mcp-sf.allegedly.works
+  # Also accept haku's machine token from the dedicated grocy-mcp-haku-sf provider,
+  # which shares grocy-mcp-sf's signing key so the configured JWKS validates it.
+  extra_jwt_issuers:
+    - https://auth.allegedly.works/application/o/grocy-mcp-haku-sf/
+persistence:
+  kind: valkey
+  host: grocy-sf-valkey-ovh-master.grocy-sf.svc.cluster.local
+  db: 0

--- a/cluster/k8s/grocy/sf/mcp/kustomization.yaml
+++ b/cluster/k8s/grocy/sf/mcp/kustomization.yaml
@@ -5,20 +5,12 @@ resources:
   - ../../mcp-base
   - valkey-ovh-instance.yaml
   - server-httproute.yaml
+configMapGenerator:
+  - name: grocy-mcp-config
+    files:
+      - config.yaml
 patches:
-  - target:
-      kind: Deployment
-      name: grocy-mcp-server
-    patch: |
-      - op: replace
-        path: /spec/template/spec/containers/0/env/1/value
-        value: "https://auth.allegedly.works/application/o/grocy-mcp-sf/"
-      - op: replace
-        path: /spec/template/spec/containers/0/env/2/value
-        value: "https://grocy-mcp-sf.allegedly.works"
-      - op: replace
-        path: /spec/template/spec/containers/0/env/3/value
-        value: "https://grocy-sf.allegedly.works"
+  # Point the secret env at this household's OIDC secret (base uses grocy-mcp-oidc).
   - target:
       kind: Deployment
       name: grocy-mcp-server
@@ -49,15 +41,3 @@ patches:
                       secretKeyRef:
                         name: grocy-mcp-oidc-sf
                         key: grocy_proxy_client_id
-                  # Also accept haku's machine token from the dedicated
-                  # grocy-mcp-haku-sf provider (shares grocy-mcp-sf's signing key, so
-                  # the configured JWKS validates it; this widens the JWTVerifier's
-                  # accepted issuers). JSON list — extra_jwt_issuers is a list field.
-                  - name: GROCY_MCP_AUTH__EXTRA_JWT_ISSUERS
-                    value: '["https://auth.allegedly.works/application/o/grocy-mcp-haku-sf/"]'
-                  - name: GROCY_MCP_PERSISTENCE__KIND
-                    value: "valkey"
-                  - name: GROCY_MCP_PERSISTENCE__HOST
-                    value: "grocy-sf-valkey-ovh-master.grocy-sf.svc.cluster.local"
-                  - name: GROCY_MCP_PERSISTENCE__DB
-                    value: "0"

--- a/cluster/k8s/grocy/sf/mcp/kustomization.yaml
+++ b/cluster/k8s/grocy/sf/mcp/kustomization.yaml
@@ -49,6 +49,12 @@ patches:
                       secretKeyRef:
                         name: grocy-mcp-oidc-sf
                         key: grocy_proxy_client_id
+                  # Also accept haku's machine token from the dedicated
+                  # grocy-mcp-haku-sf provider (shares grocy-mcp-sf's signing key, so
+                  # the configured JWKS validates it; this widens the JWTVerifier's
+                  # accepted issuers). JSON list — extra_jwt_issuers is a list field.
+                  - name: GROCY_MCP_AUTH__EXTRA_JWT_ISSUERS
+                    value: '["https://auth.allegedly.works/application/o/grocy-mcp-haku-sf/"]'
                   - name: GROCY_MCP_PERSISTENCE__KIND
                     value: "valkey"
                   - name: GROCY_MCP_PERSISTENCE__HOST

--- a/cluster/k8s/grocy/vallejo/mcp/config.yaml
+++ b/cluster/k8s/grocy/vallejo/mcp/config.yaml
@@ -1,0 +1,11 @@
+# Non-secret config for the grocy-vallejo MCP server, mounted at GROCY_MCP_CONFIG_FILE.
+# Secrets (oidc client_id/secret, proxy client_id) come from env (grocy-mcp-oidc-vallejo
+# k8s Secret), so no single field here is secret.
+grocy_url: https://grocy-vallejo.allegedly.works
+auth:
+  oidc_issuer: https://auth.allegedly.works/application/o/grocy-mcp-vallejo/
+  public_base_url: https://grocy-mcp-vallejo.allegedly.works
+persistence:
+  kind: valkey
+  host: grocy-vallejo-valkey-ovh-master.grocy-vallejo.svc.cluster.local
+  db: 0

--- a/cluster/k8s/grocy/vallejo/mcp/kustomization.yaml
+++ b/cluster/k8s/grocy/vallejo/mcp/kustomization.yaml
@@ -5,20 +5,12 @@ resources:
   - ../../mcp-base
   - valkey-ovh-instance.yaml
   - server-httproute.yaml
+configMapGenerator:
+  - name: grocy-mcp-config
+    files:
+      - config.yaml
 patches:
-  - target:
-      kind: Deployment
-      name: grocy-mcp-server
-    patch: |
-      - op: replace
-        path: /spec/template/spec/containers/0/env/1/value
-        value: "https://auth.allegedly.works/application/o/grocy-mcp-vallejo/"
-      - op: replace
-        path: /spec/template/spec/containers/0/env/2/value
-        value: "https://grocy-mcp-vallejo.allegedly.works"
-      - op: replace
-        path: /spec/template/spec/containers/0/env/3/value
-        value: "https://grocy-vallejo.allegedly.works"
+  # Point the secret env at this household's OIDC secret (base uses grocy-mcp-oidc).
   - target:
       kind: Deployment
       name: grocy-mcp-server
@@ -49,9 +41,3 @@ patches:
                       secretKeyRef:
                         name: grocy-mcp-oidc-vallejo
                         key: grocy_proxy_client_id
-                  - name: GROCY_MCP_PERSISTENCE__KIND
-                    value: "valkey"
-                  - name: GROCY_MCP_PERSISTENCE__HOST
-                    value: "grocy-vallejo-valkey-ovh-master.grocy-vallejo.svc.cluster.local"
-                  - name: GROCY_MCP_PERSISTENCE__DB
-                    value: "0"

--- a/grocy_mcp/mcp_types.py
+++ b/grocy_mcp/mcp_types.py
@@ -7,12 +7,13 @@ modelling Grocy's API surface, see ``grocy_types.py``.
 
 from __future__ import annotations
 
+import os
 from datetime import date
 from enum import StrEnum
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict, YamlConfigSettingsSource
 
 from grocy_mcp.grocy_types import ReadableEntityType, WriteableEntityType
 from mcp_infra.authentik_auth.auth import AuthentikAuthConfig
@@ -24,7 +25,14 @@ MAX_BATCH_SIZE = 100
 
 
 class ServerSettings(BaseSettings):
-    """Config for the Grocy MCP server."""
+    """Config for the Grocy MCP server.
+
+    Non-secret structured config (grocy_url, auth issuer/URLs/extra_jwt_issuers,
+    persistence) is loaded from the YAML file at ``GROCY_MCP_CONFIG_FILE``; secrets
+    (auth ``oidc_client_secret``, …) stay in ``GROCY_MCP_*`` env from a k8s Secret.
+    Env outranks the file and the two are deep-merged, so a single nested model
+    (``auth``) draws its non-secret fields from YAML and its secret fields from env.
+    """
 
     model_config = SettingsConfigDict(env_prefix="GROCY_MCP_", env_nested_delimiter="__")
 
@@ -42,6 +50,22 @@ class ServerSettings(BaseSettings):
     max_retries: int = Field(default=2, description="Retry count for transient errors (timeouts, 5xx).")
     retry_base_delay: float = Field(default=0.5, description="Initial retry delay in seconds; doubles each attempt.")
     persistence: PersistenceConfig = Field(default=FilePersistence(), description="OAuth state storage backend.")
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        """Insert an optional YAML file source (below env) when ``GROCY_MCP_CONFIG_FILE`` is set."""
+        sources: list[PydanticBaseSettingsSource] = [init_settings, env_settings, dotenv_settings]
+        if config_file := os.environ.get("GROCY_MCP_CONFIG_FILE"):
+            sources.append(YamlConfigSettingsSource(settings_cls, yaml_file=config_file))
+        sources.append(file_secret_settings)
+        return tuple(sources)
 
 
 # ── Shared field descriptions ───────────────────────────────────────────────

--- a/grocy_mcp/test_config.py
+++ b/grocy_mcp/test_config.py
@@ -7,11 +7,15 @@ nested Pydantic model loads/omits correctly on `ServerSettings`.
 
 from __future__ import annotations
 
+import textwrap
+from pathlib import Path
+
 import pytest
 import pytest_bazel
 
 from grocy_mcp.mcp_types import ServerSettings
 from mcp_infra.authentik_auth.auth import AuthentikAuthConfig
+from mcp_infra.persistence import ValkeyPersistence
 
 
 def test_auth_none_when_unset() -> None:
@@ -35,6 +39,43 @@ def test_extra_jwt_issuers_parses_from_json_env(monkeypatch: pytest.MonkeyPatch)
     settings = ServerSettings()
     assert settings.auth is not None
     assert settings.auth.extra_jwt_issuers == ("https://auth.example.com/application/o/machine/",)
+
+
+def test_yaml_config_deep_merges_with_env_secrets(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-secret config from GROCY_MCP_CONFIG_FILE (YAML) deep-merges with env, so a
+    single `auth` model draws its issuer/URLs/extra_jwt_issuers from the file and its
+    secret (`oidc_client_secret`) from env — the split the k8s deployment relies on."""
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        textwrap.dedent("""
+        grocy_url: https://grocy-sf.example.com
+        auth:
+          oidc_issuer: https://auth.example.com/application/o/grocy-mcp-sf/
+          public_base_url: https://grocy-mcp-sf.example.com
+          extra_jwt_issuers:
+            - https://auth.example.com/application/o/grocy-mcp-haku-sf/
+        persistence:
+          kind: valkey
+          host: valkey.example.com
+          db: 0
+        """)
+    )
+    monkeypatch.setenv("GROCY_MCP_CONFIG_FILE", str(config_file))
+    # Secrets stay in env (a k8s Secret in production).
+    monkeypatch.setenv("GROCY_MCP_AUTH__OIDC_CLIENT_ID", "grocy-mcp-sf")
+    monkeypatch.setenv("GROCY_MCP_AUTH__OIDC_CLIENT_SECRET", "shh")
+    monkeypatch.setenv("GROCY_MCP_AUTH__PROXY_CLIENT_ID", "grocy-sf")
+
+    settings = ServerSettings()
+    assert settings.grocy_url == "https://grocy-sf.example.com"
+    assert settings.persistence == ValkeyPersistence(kind="valkey", host="valkey.example.com", db=0)
+    assert settings.auth is not None
+    # from YAML:
+    assert settings.auth.oidc_issuer == "https://auth.example.com/application/o/grocy-mcp-sf/"
+    assert settings.auth.extra_jwt_issuers == ("https://auth.example.com/application/o/grocy-mcp-haku-sf/",)
+    # from env (the secret):
+    assert settings.auth.oidc_client_secret == "shh"
+    assert settings.auth.proxy_client_id == "grocy-sf"
 
 
 def test_auth_round_trips_through_settings() -> None:

--- a/grocy_mcp/test_config.py
+++ b/grocy_mcp/test_config.py
@@ -7,6 +7,7 @@ nested Pydantic model loads/omits correctly on `ServerSettings`.
 
 from __future__ import annotations
 
+import pytest
 import pytest_bazel
 
 from grocy_mcp.mcp_types import ServerSettings
@@ -15,6 +16,25 @@ from mcp_infra.authentik_auth.auth import AuthentikAuthConfig
 
 def test_auth_none_when_unset() -> None:
     assert ServerSettings(grocy_url="https://grocy.example.com").auth is None
+
+
+def test_extra_jwt_issuers_parses_from_json_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The deployment passes GROCY_MCP_AUTH__EXTRA_JWT_ISSUERS as a JSON list; pin
+    that pydantic-settings parses it into the nested tuple field (else the server
+    would crash on boot)."""
+    for key, value in {
+        "GROCY_MCP_GROCY_URL": "https://grocy.example.com",
+        "GROCY_MCP_AUTH__OIDC_ISSUER": "https://auth.example.com/application/o/grocy-mcp/",
+        "GROCY_MCP_AUTH__OIDC_CLIENT_ID": "id",
+        "GROCY_MCP_AUTH__OIDC_CLIENT_SECRET": "secret",
+        "GROCY_MCP_AUTH__PUBLIC_BASE_URL": "https://grocy-mcp.example.com",
+        "GROCY_MCP_AUTH__EXTRA_JWT_ISSUERS": '["https://auth.example.com/application/o/machine/"]',
+    }.items():
+        monkeypatch.setenv(key, value)
+
+    settings = ServerSettings()
+    assert settings.auth is not None
+    assert settings.auth.extra_jwt_issuers == ("https://auth.example.com/application/o/machine/",)
 
 
 def test_auth_round_trips_through_settings() -> None:

--- a/mcp_infra/authentik_auth/auth.py
+++ b/mcp_infra/authentik_auth/auth.py
@@ -38,7 +38,7 @@ from fastmcp.server.auth.oidc_proxy import OIDCProxy
 from fastmcp.server.auth.providers.jwt import JWTVerifier
 from fastmcp.server.dependencies import get_access_token
 from key_value.aio.protocols import AsyncKeyValue
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
@@ -82,6 +82,13 @@ class AuthentikAuthConfig(BaseModel):
     public_base_url: str
     proxy_client_id: str | None = None
     exchange_timeout: float = 10.0
+    extra_jwt_issuers: tuple[str, ...] = Field(
+        default=(),
+        description="Additional issuers the JWTVerifier accepts (beyond oidc_issuer). "
+        "Only valid for providers that share oidc_issuer's signing key, so the same "
+        "JWKS validates their tokens. Used for dedicated machine client_credentials "
+        "providers reaching the same MCP.",
+    )
 
     def normalized_public_base_url(self) -> str:
         return self.public_base_url.rstrip("/")
@@ -140,13 +147,21 @@ def build_authentik_auth(
     )
     assert proxy.client_registration_options is not None
     proxy.client_registration_options.valid_scopes = valid_scopes or DEFAULT_VALID_SCOPES
-    # Accept the issuer both with and without a trailing slash. `normalized_issuer()`
+    # Accept each issuer both with and without a trailing slash. `normalized_issuer()`
     # strips the slash, but Authentik's per-provider tokens carry `iss` WITH a
     # trailing slash and JWTVerifier compares `iss` to the configured issuer by exact
     # string match — so the bare form alone rejects every real Authentik token. (Not
     # caught before because claude.ai authenticates through OIDCProxy, never the
     # JWTVerifier path; direct machine bearer tokens do.)
-    return MultiAuth(server=proxy, verifiers=[JWTVerifier(jwks_uri=jwks_uri, issuer=[issuer, issuer + "/"])])
+    #
+    # extra_jwt_issuers lets the verifier also accept tokens from sibling providers
+    # that share this provider's signing key (so the same JWKS validates them) — e.g.
+    # a dedicated machine client_credentials provider whose tokens reach the same MCP.
+    issuers = [issuer, issuer + "/"]
+    for extra in config.extra_jwt_issuers:
+        bare = extra.rstrip("/")
+        issuers += [bare, bare + "/"]
+    return MultiAuth(server=proxy, verifiers=[JWTVerifier(jwks_uri=jwks_uri, issuer=issuers)])
 
 
 # ── Token exchange auth ───────────────────────────────────────────────────

--- a/mcp_infra/authentik_auth/test_auth.py
+++ b/mcp_infra/authentik_auth/test_auth.py
@@ -136,6 +136,33 @@ def test_build_authentik_auth_accepts_issuer_with_trailing_slash() -> None:
     assert "https://auth.example.com/application/o/test" in issuer
 
 
+def test_build_authentik_auth_includes_extra_jwt_issuers() -> None:
+    """extra_jwt_issuers widen the JWTVerifier's accepted issuers (both slash forms),
+    so a sibling provider sharing the signing key (e.g. a dedicated machine
+    client_credentials provider) is accepted on the same MCP.
+    """
+    discovery_response = AsyncMock()
+    discovery_response.raise_for_status = lambda: discovery_response
+    discovery_response.json = lambda: {"jwks_uri": "https://auth.example.com/application/o/test/jwks/"}
+
+    cfg = _config(issuer="https://auth.example.com/application/o/test/").model_copy(
+        update={"extra_jwt_issuers": ("https://auth.example.com/application/o/machine/",)}
+    )
+    with (
+        patch("mcp_infra.authentik_auth.auth.httpx.get", return_value=discovery_response),
+        patch("mcp_infra.authentik_auth.auth.OIDCProxy") as oidc_proxy_cls,
+        patch("mcp_infra.authentik_auth.auth.JWTVerifier") as jwt_verifier_cls,
+        patch("mcp_infra.authentik_auth.auth.MultiAuth"),
+    ):
+        oidc_proxy_cls.return_value.client_registration_options = AsyncMock()
+        build_authentik_auth(cfg)
+
+    issuer = jwt_verifier_cls.call_args.kwargs["issuer"]
+    assert "https://auth.example.com/application/o/machine/" in issuer
+    assert "https://auth.example.com/application/o/machine" in issuer
+    assert "https://auth.example.com/application/o/test/" in issuer  # primary still present
+
+
 # ── AuthentikExchangeAuth tests ───────────────────────────────────────────
 
 

--- a/tf/gitops/agent-machine-access/main.tf
+++ b/tf/gitops/agent-machine-access/main.tf
@@ -130,7 +130,12 @@ resource "authentik_provider_proxy" "grocy_sf" {
   invalidation_flow     = data.authentik_flow.invalidation.id
   access_token_validity = "hours=24"
 
-  jwt_federation_providers = [authentik_provider_oauth2.grocy_mcp_sf.id]
+  # grocy_mcp_haku_sf federates here too, so haku's machine token can be exchanged
+  # for a grocy-sf proxy token (the MCP performs that jwt-bearer exchange).
+  jwt_federation_providers = [
+    authentik_provider_oauth2.grocy_mcp_sf.id,
+    authentik_provider_oauth2.grocy_mcp_haku_sf.id,
+  ]
 }
 
 resource "authentik_application" "grocy_sf" {
@@ -210,6 +215,47 @@ resource "kubernetes_secret" "grocy_mcp_oidc_sf" {
     client_secret         = authentik_provider_oauth2.grocy_mcp_sf.client_secret
     grocy_proxy_client_id = authentik_provider_proxy.grocy_sf.client_id
   }
+}
+
+# Dedicated machine client_credentials provider for haku's read-only grocy-sf MCP
+# token, kept separate from the user-facing grocy-mcp-sf so its long access-token
+# validity doesn't lengthen claude.ai user tokens. It SHARES grocy-mcp-sf's
+# self_signed signing key, so the grocy-mcp-sf JWKS (which the MCP's JWTVerifier is
+# configured from) already validates tokens minted here — the MCP only has to also
+# accept this provider's issuer (GROCY_MCP_AUTH__EXTRA_JWT_ISSUERS on the grocy-sf
+# MCP deployment). The grocy-sf proxy federates this provider too (above), so the
+# MCP's jwt-bearer exchange into the proxy works; the haku SA carries username
+# `haku`, which the outpost forwards to Grocy.
+resource "authentik_provider_oauth2" "grocy_mcp_haku_sf" {
+  name        = "grocy-mcp-haku-sf"
+  client_id   = "grocy-mcp-haku-sf"
+  client_type = "confidential"
+
+  authorization_flow = data.authentik_flow.implicit_consent.id
+  invalidation_flow  = data.authentik_flow.invalidation.id
+  signing_key        = data.authentik_certificate_key_pair.self_signed.id
+
+  issuer_mode                = "per_provider"
+  include_claims_in_id_token = true
+
+  # 30d access-token validity — comfortable margin over the rotation CronJob's 24h
+  # re-mint threshold (re-mints ~every 29 days). See cluster/k8s/agents/authentik-jwt-rotation/.
+  access_token_validity = "days=30"
+
+  property_mappings = [
+    data.authentik_property_mapping_provider_scope.openid.id,
+    data.authentik_property_mapping_provider_scope.email.id,
+    data.authentik_property_mapping_provider_scope.profile.id,
+  ]
+
+  # client_credentials doesn't redirect, so allowed_redirect_uris is omitted.
+}
+
+resource "authentik_application" "grocy_mcp_haku_sf" {
+  name              = "Grocy MCP Haku (SF)"
+  slug              = "grocy-mcp-haku-sf"
+  protocol_provider = authentik_provider_oauth2.grocy_mcp_haku_sf.id
+  meta_description  = "Machine client_credentials provider for haku's read-only grocy-sf MCP access"
 }
 
 # --- Grocy Vallejo household (proxy provider + MCP OAuth2) ---
@@ -932,32 +978,21 @@ resource "kubernetes_secret" "haku_client_credentials" {
 # Haku reads the SF Grocy instance through the standard grocy-sf MCP
 # (grocy-mcp-sf.allegedly.works), no separate facade. The authentik-jwt-rotation
 # CronJob mints a client_credentials JWT FOR this `haku` service account against
-# the grocy-mcp-sf OAuth2 provider, so the token's iss matches the MCP's
-# JWTVerifier. The MCP then runs its usual jwt-bearer exchange into the grocy-sf
-# proxy provider and the outpost injects X-authentik-username=haku — which maps to
-# the read-only `haku` Grocy user (empty permission set, provisioned by
-# cluster/k8s/grocy/sf/haku-user). Read-only is enforced server-side by Grocy
-# (its API gates every write on a permission this user lacks); this identity adds
-# no write capability.
+# the dedicated grocy-mcp-haku-sf provider (above) — separate from the user-facing
+# grocy-mcp-sf so its 30-day validity doesn't lengthen claude.ai user tokens, but
+# sharing the same signing key so the MCP's JWKS still validates it. The MCP runs
+# its usual jwt-bearer exchange into the grocy-sf proxy provider and the outpost
+# injects X-authentik-username=haku — which maps to the read-only `haku` Grocy user
+# (empty permission set, provisioned by cluster/k8s/grocy/sf/haku-user). Read-only
+# is enforced server-side by Grocy (its API gates every write on a permission this
+# user lacks); this identity adds no write capability.
 #
-# Mirrors the haku-k8s pattern above, but issues from grocy-mcp-sf (not the shared
-# kubectl provider) and the SA username is `haku` (not haku-k8s) because that
-# username is what the outpost forwards to Grocy.
+# Mirrors the haku-k8s pattern above (user_password client_credentials), but the SA
+# username is `haku` (not haku-k8s) because that username is what the outpost
+# forwards to Grocy.
 #
 # Consumer: cluster/k8s/agents/authentik-jwt-rotation/ CronJob (haku-grocy entry).
 # It mints the JWT and commits it SOPS-encrypted to secrets/haku-grocy-jwt.yaml.
-#
-# TODO(haku-grocy blocker #2): the grocy-mcp-sf provider has no
-# access_token_validity set, so it issues ~10-minute tokens — far too short for
-# the rotation model (the rotator commits a token that expires before any
-# consumer reads it; verified live, exp ≈ 599s). Before wiring runtimes, give
-# this token a long validity like haku-k8s (its provider uses hours=1080).
-# Caveat: grocy-mcp-sf is SHARED with the claude.ai user-login flow, so either
-# set access_token_validity on it directly (also lengthens user tokens) or split
-# out a dedicated grocy-mcp-haku client-credentials provider (then add its issuer
-# to the MCP's JWTVerifier list). See project memory project-haku-grocy-ro.
-# (Blocker #1 — the JWTVerifier trailing-slash issuer bug — is fixed separately
-# in mcp_infra/authentik_auth/auth.py.)
 
 resource "authentik_user" "haku_grocy" {
   username = "haku"
@@ -967,7 +1002,7 @@ resource "authentik_user" "haku_grocy" {
 }
 
 # App-password token, used as the password in the client_credentials
-# username/password exchange against the grocy-mcp-sf provider's client_id.
+# username/password exchange against the grocy-mcp-haku-sf provider's client_id.
 resource "authentik_token" "haku_grocy" {
   identifier   = "haku-grocy-client-credentials"
   user         = authentik_user.haku_grocy.id
@@ -977,9 +1012,9 @@ resource "authentik_token" "haku_grocy" {
   description  = "client_credentials app-password for Haku's grocy-sf JWT rotation"
 }
 
-# Authorize the haku SA to mint tokens on the grocy-mcp-sf OAuth2 application.
-resource "authentik_policy_binding" "haku_grocy_mcp_sf" {
-  target = authentik_application.grocy_mcp_sf.uuid
+# Authorize the haku SA to mint tokens on the dedicated grocy-mcp-haku-sf application.
+resource "authentik_policy_binding" "haku_grocy_mcp_haku" {
+  target = authentik_application.grocy_mcp_haku_sf.uuid
   user   = authentik_user.haku_grocy.id
   order  = 1
 }
@@ -993,20 +1028,20 @@ resource "authentik_policy_binding" "haku_grocy_sf_proxy" {
   order  = 1
 }
 
-# K8s Secret holding the grocy-mcp-sf provider's client_id + the haku username and
-# app-password. Lives in agents-infra (where the authentik-jwt-rotation CronJob
+# K8s Secret holding the grocy-mcp-haku-sf provider's client_id + the haku username
+# and app-password. Lives in agents-infra (where the authentik-jwt-rotation CronJob
 # runs); the minted JWT lives SOPS-encrypted in secrets/haku-grocy-jwt.yaml.
 resource "kubernetes_secret" "haku_grocy_client_credentials" {
   metadata {
     name      = "haku-grocy-client-credentials"
     namespace = "agents-infra"
     annotations = {
-      description = "client_id (grocy-mcp-sf OAuth2 provider) + haku username/app-password, authenticating the haku service account so the authentik-jwt-rotation CronJob can mint its grocy-sf MCP JWT"
+      description = "client_id (grocy-mcp-haku-sf OAuth2 provider) + haku username/app-password, authenticating the haku service account so the authentik-jwt-rotation CronJob can mint its grocy-sf MCP JWT"
     }
   }
 
   data = {
-    client_id = authentik_provider_oauth2.grocy_mcp_sf.client_id
+    client_id = authentik_provider_oauth2.grocy_mcp_haku_sf.client_id
     username  = authentik_user.haku_grocy.username
     password  = authentik_token.haku_grocy.key
   }


### PR DESCRIPTION
## Blocker #2 fix (option b, 30 days) + grocy MCP YAML config

### Part 1 — dedicated 30-day machine provider (blocker #2)
The `grocy-mcp-sf` provider issued **~10-minute tokens** (no `access_token_validity`) — too short for the rotation model (verified live, exp ≈ 599s). Rather than lengthen the shared user-login provider, use a **dedicated machine provider** at **30 days**.
- **TF:** new `grocy-mcp-haku-sf` OAuth2 provider (`days=30`) + app + haku-SA mint binding. **Shares `grocy-mcp-sf`'s `self_signed` signing key** so the MCP's existing JWKS validates its tokens; the `grocy-sf` proxy **federates it too**. Credential secret + rotation now mint from it; old mint binding replaced.
- **auth module:** `AuthentikAuthConfig` gains `extra_jwt_issuers`, widening the `JWTVerifier`'s accepted issuers (both slash forms). Builds on #2497.

### Part 2 — grocy MCP loads non-secret config from YAML
Switches the grocy MCP from all-env to a mounted `config.yaml` for non-secret structured fields (`grocy_url`, auth issuer/URLs, `extra_jwt_issuers`, persistence), keeping **secrets in env** from the per-household k8s Secret. Mirrors `oauth_facade`'s `FacadeSettings` (`settings_customise_sources` + `YamlConfigSettingsSource`). Motivated by `extra_jwt_issuers` — a JSON-string env var becomes a plain YAML list.
- Env still outranks the file and the two **deep-merge**, so the single `auth` model draws non-secret fields from YAML and its secret from env (test pins this — else the server crashes on boot).
- `mcp-base` + `sf`/`vallejo` overlays drop the per-household env patches and mount a `grocy-mcp-config` configMap instead.

### Why the auth path works end-to-end
A token from `grocy-mcp-haku-sf` (a) is signed by the shared key → passes the MCP's JWKS check; (b) `iss = …/grocy-mcp-haku-sf/` → accepted via `extra_jwt_issuers`; (c) federated into the `grocy-sf` proxy → exchange succeeds; (d) username `haku` → outpost injects `X-authentik-username: haku` → read-only Grocy user.

### Validation
`bbr test` (auth + grocy config incl. the YAML/env deep-merge), grocy MCP server binary builds, `kustomize build` both overlays, tofu fmt / tflint / checkov / kubeconform / prettier all pass.

### Sequencing
Takes effect once the grocy MCP **image rebuilds** with the new code (push-images → ImagePolicy bump). After it redeploys + TF applies + the rotation runs, I'll do the full end-to-end check (read=200 / write=403 / `X-authentik-username: haku`).

Depends on #2497 (merged).