### PR TITLE
[codex] debundle: drop string wildcard plumbing

### DIFF
--- a/devinfra/js/debundle/chunk_facts.rs
+++ b/devinfra/js/debundle/chunk_facts.rs
@@ -256,13 +256,6 @@ pub struct ChunkFacts {
     pub child: Vec<(NodeId, u32, NodeId)>,
     /// string-literal value, unescaped via `js_ast::str_value`.
     pub str_lit: Vec<(NodeId, String)>,
-    /// A `StrLit` **needle** node whose value is a selector wildcard string literal
-    /// (`wildcard_string_literals`) -> the wildcard token. Only needle facts carry
-    /// these (real subject source never does): the matcher treats such a node as a
-    /// string wildcard that matches any string-literal subject, binding the token
-    /// to one concrete value across the match. Absent ⟹ the `str_lit` value is
-    /// matched exactly.
-    pub str_wildcard: Vec<(NodeId, String)>,
     /// numeric-literal token, rendered faithfully (source `raw` when present).
     pub num_lit: Vec<(NodeId, String)>,
     pub bool_lit: Vec<(NodeId, bool)>,
@@ -322,10 +315,6 @@ fn expr_variant_name(expr: &Expr) -> &'static str {
 struct Extractor {
     facts: ChunkFacts,
     next: NodeId,
-    /// The selector's wildcard string literals, for a **needle** projection — a
-    /// `StrLit` whose value is in this set is additionally recorded in
-    /// `str_wildcard`. Empty for subject (chunk-body) projection.
-    wildcard_string_literals: std::collections::BTreeSet<String>,
 }
 
 impl Extractor {
@@ -1218,9 +1207,6 @@ impl Extractor {
             Lit::Str(value) => {
                 let id = self.node(NodeKind::StrLit);
                 let text = js_ast::str_value(value);
-                if self.wildcard_string_literals.contains(&text) {
-                    self.facts.str_wildcard.push((id, text.clone()));
-                }
                 self.facts.str_lit.push((id, text));
                 Ok(id)
             }
@@ -1273,27 +1259,6 @@ pub fn extract_facts(module: &Module) -> Result<ChunkFacts, Unsupported> {
 /// item into a one-item [`Module`] first.
 pub fn extract_facts_items(items: &[ModuleItem]) -> Result<ChunkFacts, Unsupported> {
     let mut extractor = Extractor::default();
-    for (body_idx, item) in items.iter().enumerate() {
-        let ordinal = statement_ordinal_for_body_index(items, body_idx);
-        extractor.module_item(item, ordinal)?;
-    }
-    Ok(extractor.facts)
-}
-
-/// Like [`extract_facts_items`], but for a **needle** projection: a `StrLit` whose
-/// value is in `wildcard_string_literals` is additionally recorded in
-/// `ChunkFacts::str_wildcard`, so the matcher matches it as a string wildcard
-/// (any string-literal value, bound consistently) instead of by exact value.
-/// Subject (chunk-body) facts use [`extract_facts_items`] — they carry no
-/// wildcards.
-pub fn extract_facts_needle(
-    items: &[ModuleItem],
-    wildcard_string_literals: &std::collections::BTreeSet<String>,
-) -> Result<ChunkFacts, Unsupported> {
-    let mut extractor = Extractor {
-        wildcard_string_literals: wildcard_string_literals.clone(),
-        ..Extractor::default()
-    };
     for (body_idx, item) in items.iter().enumerate() {
         let ordinal = statement_ordinal_for_body_index(items, body_idx);
         extractor.module_item(item, ordinal)?;

--- a/devinfra/js/debundle/selector_constraint_model_builder.rs
+++ b/devinfra/js/debundle/selector_constraint_model_builder.rs
@@ -497,7 +497,6 @@ impl FactDomains {
                 }
                 SelectorFact::AstKind { node, .. }
                 | SelectorFact::AstStringLiteral { node, .. }
-                | SelectorFact::AstStringWildcard { node, .. }
                 | SelectorFact::AstNumberLiteral { node, .. }
                 | SelectorFact::AstBoolLiteral { node, .. }
                 | SelectorFact::AstIdentifierName { node, .. }
@@ -580,7 +579,6 @@ impl FactDomains {
     fn add_fact_strings(&mut self, fact: &SelectorFact) {
         match fact {
             SelectorFact::AstStringLiteral { value, .. }
-            | SelectorFact::AstStringWildcard { token: value, .. }
             | SelectorFact::AstNumberLiteral { value, .. }
             | SelectorFact::AstIdentifierName { value, .. }
             | SelectorFact::AstPropertyName { value, .. }

--- a/devinfra/js/debundle/selector_ir.rs
+++ b/devinfra/js/debundle/selector_ir.rs
@@ -801,11 +801,6 @@ pub enum SelectorFact {
         node: NodeId,
         value: String,
     },
-    AstStringWildcard {
-        chunk_id: ChunkId,
-        node: NodeId,
-        token: String,
-    },
     AstNumberLiteral {
         chunk_id: ChunkId,
         node: NodeId,
@@ -898,7 +893,6 @@ impl SelectorFact {
             Self::AstKind { .. } => "ast_kind",
             Self::AstChild { .. } => "ast_child",
             Self::AstStringLiteral { .. } => "ast_string_literal",
-            Self::AstStringWildcard { .. } => "ast_string_wildcard",
             Self::AstNumberLiteral { .. } => "ast_number_literal",
             Self::AstBoolLiteral { .. } => "ast_bool_literal",
             Self::AstIdentifierName { .. } => "ast_identifier_name",
@@ -977,14 +971,6 @@ impl SelectorFactStore {
                 value: value.clone(),
             }
         }));
-        self.facts
-            .extend(facts.str_wildcard.iter().map(|(node, token)| {
-                SelectorFact::AstStringWildcard {
-                    chunk_id,
-                    node: *node,
-                    token: token.clone(),
-                }
-            }));
         self.facts.extend(facts.num_lit.iter().map(|(node, value)| {
             SelectorFact::AstNumberLiteral {
                 chunk_id,

--- a/devinfra/js/debundle/selector_ir_lowering.rs
+++ b/devinfra/js/debundle/selector_ir_lowering.rs
@@ -65,7 +65,6 @@ pub struct MemberSelectorProgramBuilder {
 }
 
 struct NativeAstFactLowering<'a> {
-    logical_module: &'a str,
     facts: &'a ChunkFacts,
     node_vars: &'a BTreeMap<NodeId, SelectorVariableId>,
     skipped_nodes: &'a BTreeSet<NodeId>,
@@ -557,7 +556,6 @@ impl MemberSelectorProgramBuilder {
             (None, _) => {}
         }
         self.lower_native_ast_facts(NativeAstFactLowering {
-            logical_module,
             facts: &facts,
             node_vars: &node_vars,
             skipped_nodes: &skipped_nodes,
@@ -835,7 +833,6 @@ impl MemberSelectorProgramBuilder {
         }
 
         self.lower_native_ast_facts(NativeAstFactLowering {
-            logical_module,
             facts: &facts,
             node_vars: &node_vars,
             skipped_nodes: &skipped_nodes,
@@ -851,7 +848,6 @@ impl MemberSelectorProgramBuilder {
 
     fn lower_native_ast_facts(&mut self, lowering: NativeAstFactLowering<'_>) {
         let NativeAstFactLowering {
-            logical_module,
             facts,
             node_vars,
             skipped_nodes,
@@ -871,26 +867,6 @@ impl MemberSelectorProgramBuilder {
                 || bare_properties.contains_key(node)
                 || bare_property_structural_nodes.contains(node)
         };
-        let mut wildcard_string_vars = BTreeMap::<String, SelectorVariableId>::new();
-        for (_node, token) in &facts.str_wildcard {
-            if structurally_skipped_node(_node) {
-                continue;
-            }
-            wildcard_string_vars
-                .entry(token.clone())
-                .or_insert_with(|| {
-                    self.program.add_variable(
-                        VariableDomain::String,
-                        Some(format!("{logical_module}::source_match.string.{token}")),
-                    )
-                });
-        }
-        let wildcard_string_by_node: BTreeMap<NodeId, SelectorVariableId> = facts
-            .str_wildcard
-            .iter()
-            .filter(|(node, _token)| !structurally_skipped_node(node))
-            .filter_map(|(node, token)| wildcard_string_vars.get(token).map(|var| (*node, *var)))
-            .collect();
         let mut child_counts: BTreeMap<NodeId, u32> =
             facts.node_kind.iter().map(|(node, _)| (*node, 0)).collect();
         for (parent, _index, _child) in &facts.child {
@@ -1008,18 +984,9 @@ impl MemberSelectorProgramBuilder {
             if structurally_skipped_node(node) {
                 continue;
             }
-            if let Some(wildcard_string_var) = wildcard_string_by_node.get(node).copied() {
-                if let Some(node) = node_vars.get(node).copied() {
-                    self.program.add_atom(SelectorAtom::AstStringLiteral {
-                        node: node_term(node),
-                        value: string_term(wildcard_string_var),
-                    });
-                }
-            } else {
-                self.add_ast_string_label(node_vars, *node, value, |node, value| {
-                    SelectorAtom::AstStringLiteral { node, value }
-                });
-            }
+            self.add_ast_string_label(node_vars, *node, value, |node, value| {
+                SelectorAtom::AstStringLiteral { node, value }
+            });
         }
         for (node, value) in &facts.num_lit {
             if structurally_skipped_node(node) {

--- a/devinfra/js/debundle/selector_ir_solver.rs
+++ b/devinfra/js/debundle/selector_ir_solver.rs
@@ -220,7 +220,6 @@ ascent! {
     relation ast_child(u32, u32, u32); // parent, child index, child
     relation ast_child_count(u32, u32); // node, number of direct AST children
     relation ast_string_literal(u32, String); // node, value
-    relation ast_string_wildcard(u32, String); // needle node, wildcard token
     relation ast_number_literal(u32, String); // node, value
     relation ast_bool_literal(u32, bool); // node, value
     relation ast_identifier_name(u32, String); // node, value
@@ -772,9 +771,6 @@ pub fn solve(
                     .push((*node, pattern.clone()));
             }
         }
-    }
-    for (node, value) in &fact_index.ast_string_wildcards {
-        ascent.ast_string_wildcard.push((*node, value.clone()));
     }
     for (node, value) in &fact_index.ast_number_literals {
         ascent.ast_number_literal.push((*node, value.clone()));
@@ -3277,7 +3273,6 @@ struct FactIndex {
     ast_children_by_parent: BTreeMap<u32, Vec<(u32, u32)>>,
     ast_child_counts: Vec<(u32, u32)>,
     ast_string_literals: Vec<(u32, String)>,
-    ast_string_wildcards: Vec<(u32, String)>,
     ast_number_literals: Vec<(u32, String)>,
     ast_bool_literals: Vec<(u32, bool)>,
     ast_identifier_names: Vec<(u32, String)>,
@@ -3433,10 +3428,6 @@ impl FactIndex {
                 SelectorFact::AstStringLiteral { node, value, .. } => {
                     index.all_nodes.insert(*node);
                     index.ast_string_literals.push((*node, value.clone()));
-                }
-                SelectorFact::AstStringWildcard { node, token, .. } => {
-                    index.all_nodes.insert(*node);
-                    index.ast_string_wildcards.push((*node, token.clone()));
                 }
                 SelectorFact::AstNumberLiteral { node, value, .. } => {
                     index.all_nodes.insert(*node);

--- a/devinfra/js/debundle/selector_match.rs
+++ b/devinfra/js/debundle/selector_match.rs
@@ -100,18 +100,12 @@ struct AlphaScope {
 #[derive(Clone)]
 struct Bindings {
     scopes: Vec<AlphaScope>,
-    /// Wildcard-string-literal token -> the concrete subject string value it bound
-    /// to, so one wildcard matches one value consistently across the match (the
-    /// deleted matcher's `bind_string`). Not lexically scoped — a wildcard literal
-    /// pins a value globally within the match, like the regex predicate.
-    string_wildcards: HashMap<String, String>,
 }
 
 impl Default for Bindings {
     fn default() -> Self {
         Self {
             scopes: vec![AlphaScope::default()],
-            string_wildcards: HashMap::new(),
         }
     }
 }
@@ -176,19 +170,6 @@ impl Bindings {
         }
     }
 
-    /// Match a wildcard string literal against a subject value, binding the token
-    /// the first time and requiring consistency after (see `string_wildcards`).
-    fn match_string_wildcard(&mut self, wildcard: &str, value: &str) -> bool {
-        match self.string_wildcards.get(wildcard) {
-            Some(existing) => existing == value,
-            None => {
-                self.string_wildcards
-                    .insert(wildcard.to_string(), value.to_string());
-                true
-            }
-        }
-    }
-
     /// Force a needle↔subject mapping in the current frame before matching (the
     /// `target_binding` alpha coupling). Honors an existing mapping; fails if
     /// either side is already mapped incompatibly. Used in both identifier modes.
@@ -240,10 +221,6 @@ pub struct Index {
     children: Vec<Vec<NodeId>>,
     ident: Vec<Option<Box<str>>>,
     str_lit: Vec<Option<Box<str>>>,
-    /// A needle `StrLit` node -> its wildcard token (`str_wildcard` fact). Present
-    /// only on needle indices; `homo` matches such a node as a string wildcard
-    /// (any string-literal subject, bound consistently) instead of by exact value.
-    str_wildcard: Vec<Option<Box<str>>>,
     num_lit: Vec<Option<Box<str>>>,
     bool_lit: Vec<Option<bool>>,
     prop_name: Vec<Option<Box<str>>>,
@@ -300,7 +277,6 @@ impl Index {
             children,
             ident: label(&facts.ident_name),
             str_lit: label(&facts.str_lit),
-            str_wildcard: label(&facts.str_wildcard),
             num_lit: label(&facts.num_lit),
             bool_lit,
             prop_name: label(&facts.prop_name),
@@ -338,12 +314,6 @@ impl Index {
 
     fn str_lit_of(&self, id: NodeId) -> Option<&str> {
         self.str_lit
-            .get(id as usize)
-            .and_then(|slot| slot.as_deref())
-    }
-
-    fn str_wildcard_of(&self, id: NodeId) -> Option<&str> {
-        self.str_wildcard
             .get(id as usize)
             .and_then(|slot| slot.as_deref())
     }
@@ -785,17 +755,6 @@ fn homo(
                 (Some(re), Some(value)) => re.is_match(value),
                 _ => false,
             });
-    }
-
-    // Wildcard string literal (`wildcard_string_literals`): matches any
-    // string-literal subject value, binding the wildcard token to one value
-    // consistently across the match. The needle node is a `StrLit` carrying a
-    // `str_wildcard` fact; the subject must be a real `StrLit`.
-    if let Some(wildcard) = needle.str_wildcard_of(nid) {
-        return Ok(match (subject.kind_of(sid), subject.str_lit_of(sid)) {
-            (NodeKind::StrLit, Some(value)) => bindings.match_string_wildcard(wildcard, value),
-            _ => false,
-        });
     }
 
     // Shorthand ⟷ explicit same-name property equivalence (object literals and
@@ -1403,10 +1362,7 @@ pub fn invariant_tokens(index: &Index) -> Vec<Token> {
         .collect();
     let mut tokens: HashSet<Token> = HashSet::new();
     for node in 0..node_count {
-        // A wildcard string literal matches any value, so it pins no `Str` token
-        // (indexing its placeholder text would wrongly require it of the subject).
         if !predicate_args.contains(&node)
-            && index.str_wildcard_of(node).is_none()
             && let Some(value) = index.str_lit_of(node)
         {
             tokens.insert(Token::Str(value.into()));


### PR DESCRIPTION
## Summary

Removes the now-unreachable string-wildcard internals after the public selector field removal landed in #2498.

- drops `ChunkFacts::str_wildcard`, wildcard-aware extraction state, and `extract_facts_needle`
- removes string-wildcard binding/index/match/token logic from `selector_match`
- removes `SelectorFact::AstStringWildcard` and downstream model-builder / solver cases
- simplifies native selector IR lowering now that string literals are always literal values or regex predicates

## Validation

- `nix develop -c bbr test //devinfra/js/debundle:chunk_facts_test //devinfra/js/debundle:selector_match_differential_test //devinfra/js/debundle:selector_ir_test //devinfra/js/debundle:selector_ir_lowering_test //devinfra/js/debundle:source_match_test //devinfra/js/debundle:selector_candidate_index_test //devinfra/js/debundle:selector_constraint_model_builder_test //devinfra/js/debundle:selector_ir_solver_test --test_output=errors --cache_test_results=no`
  - BuildBuddy: https://app.buildbuddy.io/invocation/38fb8326-f16b-4354-8b3c-a568af4779f6
- `nix develop -c pre-commit run --files devinfra/js/debundle/chunk_facts.rs devinfra/js/debundle/selector_match.rs devinfra/js/debundle/selector_ir.rs devinfra/js/debundle/selector_ir_lowering.rs devinfra/js/debundle/selector_ir_solver.rs devinfra/js/debundle/selector_constraint_model_builder.rs`
- `rg -n "str_wildcard|AstStringWildcard|extract_facts_needle|wildcard_string_literals" devinfra/js/debundle` leaves only the legacy public rejection test and existing tracking docs