### PR TITLE
[codex] debundle: refresh pruning docs after wildcard cleanup

### DIFF
--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -56,13 +56,13 @@ Dispatch work in this order:
    `ARRAY_ELEMENTS`) as native constraints. Preserve the fail-closed rule:
    unsupported constructs report `unsupported` until their faithful encoding is
    implemented.
-4. **Source-match surface pruning (P0.3).** Remove legacy `source_match`
-   options that no current downstream spec uses before nativeization hardens
-   them into the new IR. `target_statement` / `target_statements` have been
-   removed, and `wildcard_string_literals` plus the single-choice
-   `match-selector --identifiers` CLI flag are no longer public authoring
-   surfaces. Remaining pruning should target tooling-only conveniences, not
-   selector semantics that Gaffer still needs.
+4. **Source-match surface pruning (P0.3).** Keep unused selector/tooling
+   options out of the native IR. The known unused surfaces
+   (`target_statement`, `target_statements`, authored `wildcard_string_literals`,
+   the single-choice `match-selector --identifiers` flag, and the exact-body
+   selector-codemod fallback knobs) have been removed. Remaining pruning should
+   target tooling-only conveniences, not selector semantics that Gaffer still
+   needs.
 5. **Derived relational predicates (P0.4).** Fold the remaining bridge
    vocabulary (`cross_ref`, `reads_member`, `member_of_module`,
    `passed_to_call`, `makes_decorate_call`, `intrinsic_alias`) into IR atoms or
@@ -142,13 +142,12 @@ this list as the dispatch summary, not a second plan.
    lowering must be faithful or fail closed.
 5. **Prune unused tooling options before nativeizing them.** The current
    Ducktape/Gaffer census no longer has public `wildcard_string_literals`,
-   `target_statement`, `target_statements`, or `match-selector --identifiers`
-   surfaces to carry forward. The next safe tooling cleanup is removing the
-   `selector-codemod` exact-body fallback knobs; current Gaffer workflows do
-   not call them. Source-aware `selector-debt` debug options should be trimmed
-   once their solver-backed replacements are scoped. The retained `EXPR_*` /
-   `STMT_*` / `STMT_LIST_*` forms are readability labels and run holes, not old
-   `STATEMENT_*` compatibility spellings.
+   `target_statement`, `target_statements`, `match-selector --identifiers`, or
+   selector-codemod exact-body fallback surfaces to carry forward. Source-aware
+   `selector-debt` debug options should be trimmed once their solver-backed
+   replacements are scoped. The retained `EXPR_*` / `STMT_*` / `STMT_LIST_*`
+   forms are readability labels and run holes, not old `STATEMENT_*`
+   compatibility spellings.
 6. **Fold bridge vocabulary into derived predicates.** Re-express the staged
    relational selectors as solver predicates over owner/reference + AST facts.
    Real-spec Gaffer work should supply missing predicates and diagnostics, not

--- a/devinfra/js/debundle/plans/selector_constraint_model.md
+++ b/devinfra/js/debundle/plans/selector_constraint_model.md
@@ -744,11 +744,11 @@ This is the detailed P0 queue; <../TODO.md> should only summarize it.
   `CASE_REST`), anonymous statements as distinguished targets, exact
   identifiers, target bindings, and binding groups. Each construct either
   compiles faithfully or reports `unsupported`.
-- **G4 — source-match surface pruning.** Remove unused authoring options before
-  nativeizing them. Current Gaffer/Tana census shows no use of
-  `target_statement`, `target_statements`, or authored
-  `wildcard_string_literals`; those public surfaces plus the single-choice
-  `match-selector --identifiers` CLI flag have been removed. Slate any other
+- **G4 — source-match surface pruning.** Keep unused authoring/tooling options
+  out of the native query model. Current Gaffer/Tana census showed no use of
+  `target_statement`, `target_statements`, authored `wildcard_string_literals`,
+  the single-choice `match-selector --identifiers` CLI flag, or selector-codemod
+  exact-body fallbacks; those surfaces have been removed. Slate any other
   vestigial debundle features that gaffer-private does not use for removal
   rather than carrying them into the query model. Defer the alpha-all identifier
   mode, exact anonymous `match`, readability labels, and top-level `STMT_LIST`


### PR DESCRIPTION
## Summary

Updates debundle planning/tracking docs after the wildcard and exact-fallback cleanup PRs landed.

- marks the known unused selector/tooling surfaces as completed removals
- removes stale wording that still called selector-codemod exact-body fallback knobs the next safe cleanup
- keeps the remaining pruning guidance focused on future vestigial-feature inventory and solver-backed replacements

## Validation

- `nix develop -c pre-commit run --files devinfra/js/debundle/TODO.md devinfra/js/debundle/plans/selector_constraint_model.md`
- `git diff --check`