### PR TITLE
haku: add SOPS decryption to cloud-agent-tf flux-kustomization

### DIFF
--- a/cluster/k8s/haku/cloud-agent-tf/flux-kustomization.yaml
+++ b/cluster/k8s/haku/cloud-agent-tf/flux-kustomization.yaml
@@ -13,6 +13,13 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
+  # Decrypt the SOPS Secrets in this dir (anthropic-api-key, haku-kube-token);
+  # without this Flux applies the raw ENC[...] ciphertext and the runner gets a
+  # bogus key/token (401).
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age-cluster-secrets
   healthChecks:
     - apiVersion: infra.contrib.fluxcd.io/v1alpha2
       kind: Terraform


### PR DESCRIPTION
Follow-up to #2484/#2496. The `haku-cloud-agent` tofu deploy 401s because the runner's `ANTHROPIC_API_KEY` (and the haku-token) are the literal SOPS **ciphertext** (`ENC[AES256_GCM…]`): the `cloud-agent-tf` flux-kustomization lacked `spec.decryption`, so Flux applied the encrypted Secrets verbatim. (Modeled on cpap-data, whose kustomization has no SOPS Secrets — its secrets are TF-created.)

This commit was meant for #2496 but landed on the branch *after* it auto-merged (spec.vars-only), so it never reached devel — hence a separate PR.

Fix: the standard `sops` / `sops-age-cluster-secrets` decryption block (fixes both `anthropic-api-key` and `haku-kube-token`). kubeconform ✅.