### PR TITLE
haku/console: design doc — free-form agent UI via a Haku-run iframe service

### DIFF
--- a/cluster/k8s/TODO.md
+++ b/cluster/k8s/TODO.md
@@ -141,3 +141,19 @@ Options to consider:
       bundles shell tools like `curl`/`git`; consider moving to the standard
       Python image pattern with `pygit2` and certifi/CA-certs, matching the
       other pygit2-based images, and remove the extra package cruft.
+
+## Gateway: restrict `cluster-gateway` `allowedRoutes` (no agent self-exposure)
+
+- [ ] 2026-06-26: `cluster/k8s/gateway/gateway.yaml` listeners are all
+      `allowedRoutes: namespaces: from: All`, so an HTTPRoute in **any** namespace
+      can attach to the public gateway and bypass Authentik. Not currently
+      exploitable by the agents — `haku-sandbox-admin` / `claude-sandbox-admin` are
+      explicit resource allowlists that omit `httproutes`/`gateways` — but it's a
+      latent hole: any future RBAC slip granting an agent-writable namespace
+      `httproutes` would let it self-expose publicly. Tighten
+      `allowedRoutes.namespaces` to a label `Selector` (or explicit set) that agent
+      namespaces (`haku-sandbox`, `claude-sandbox`, …) never carry, so "the agent
+      can't create public routes" holds structurally at the gateway, not only via
+      RBAC. The agent-authored Haku UI (`haku/console/plans/free_form_ui_iframe.md`)
+      depends on this — its UI must stay reachable only via the operator-owned
+      Authentik route.

--- a/haku/PLAN.md
+++ b/haku/PLAN.md
@@ -201,13 +201,18 @@ Two tiers the console treats completely differently:
   calls (it auto-sends the `anthropic-version` header — the omission that 502'd the
   bare-`httpx` fire call — plus `auth_token` bearer, typed errors, and retries) and
   migrate the `launch-routine` POST onto it at the same time.
-- **Phase 2 — free-form (1b, the destination).** Haku writes TSX/JS into `haku-state`; the
-  untrusted render origin transpiles it **at runtime** (never compiled into the trusted
-  bundle) and runs it in a **sandboxed cross-origin iframe** (`sandbox` without
-  `allow-same-origin`, strict CSP). It reaches the outside only via a `postMessage` bridge
-  to the shell, which exposes **only the trace tier**; capabilities stay shell-owned. The
-  widget schema becomes "the bridge API, declaratively"; free-form TSX is "the bridge API,
-  imperatively" — same boundary, two front-ends.
+- **Phase 1b — free-form (the destination).** Haku runs **its own UI service** in
+  `haku-sandbox` (its Deployment, its choice of runtime, app code from `haku-state`, no
+  image build) and the console **embeds it in a cross-origin same-site iframe** — the
+  console never renders or even sees Haku's UI. The trusted shell shrinks to: hold the
+  bearer, own privileged actions, and frame the UI. Data + operator intent go straight to
+  Haku's own backend (it has the `haku-state` creds); a minimal `postMessage` bridge
+  carries only **capability requests** (shell still confirms + fires). Containment rests on
+  cross-origin isolation (the bearer is unreachable from any browser context), Haku's UI
+  being reachable **only** via the operator-owned **Authentik-gated** route (no public
+  exposure), and the agent being unable to create public routes (its RBAC allowlist omits
+  `httproutes`; harden the `from: All` gateway too). Full design + invariants + phasing:
+  <console/plans/free_form_ui_iframe.md>.
 
 ### Server-side compute for agent UI
 

--- a/haku/PLAN.md
+++ b/haku/PLAN.md
@@ -217,7 +217,7 @@ Two tiers the console treats completely differently:
   item model + its UI + styling/build/image-automation move out of ducktape into
   agent-owned `haku-state` — Haku is given a high-level objective ("surface what's useful
   to act on"), not a ducktape schema, and the shell keeps only the boundary (capability
-  tier, iframe host, protocol, CSP/trust indicator, perimeter); the trusted renderer +
+  tier, iframe host, protocol, CSP, top-layer confirm, perimeter); the trusted renderer +
   trace tier retire. Full design + invariants + phasing:
   <console/plans/free_form_ui_iframe.md>.
 

--- a/haku/PLAN.md
+++ b/haku/PLAN.md
@@ -213,7 +213,12 @@ Two tiers the console treats completely differently:
   cross-origin isolation (the bearer is unreachable from any browser context), Haku's UI
   being reachable **only** via the operator-owned **Authentik-gated** route (no public
   exposure), and the agent being unable to create public routes (its RBAC allowlist omits
-  `httproutes`; harden the `from: All` gateway too). Full design + invariants + phasing:
+  `httproutes`; harden the `from: All` gateway too). **North star (later):** even the
+  item model + its UI + styling/build/image-automation move out of ducktape into
+  agent-owned `haku-state` — Haku is given a high-level objective ("surface what's useful
+  to act on"), not a ducktape schema, and the shell keeps only the boundary (capability
+  tier, iframe host, protocol, CSP/trust indicator, perimeter); the trusted renderer +
+  trace tier retire. Full design + invariants + phasing:
   <console/plans/free_form_ui_iframe.md>.
 
 ### Server-side compute for agent UI

--- a/haku/PLAN.md
+++ b/haku/PLAN.md
@@ -207,7 +207,9 @@ Two tiers the console treats completely differently:
   console never renders or even sees Haku's UI. The trusted shell shrinks to: hold the
   bearer, own privileged actions, and frame the UI. Data + operator intent go straight to
   Haku's own backend (it has the `haku-state` creds); a minimal `postMessage` bridge
-  carries only **capability requests** (shell still confirms + fires). Containment rests on
+  carries only what needs trusted authority — **capability requests** (shell confirms +
+  fires) and **`openLink`** (shell vets scheme + host whitelist, confirms off-whitelist,
+  opens). Containment rests on
   cross-origin isolation (the bearer is unreachable from any browser context), Haku's UI
   being reachable **only** via the operator-owned **Authentik-gated** route (no public
   exposure), and the agent being unable to create public routes (its RBAC allowlist omits

--- a/haku/console/plans/free_form_ui_iframe.md
+++ b/haku/console/plans/free_form_ui_iframe.md
@@ -1,0 +1,176 @@
+# Free-form agent UI via a Haku-run iframe service
+
+Status: **design / not started.** This is the concrete shape for Phase 1b of
+`haku/PLAN.md` → _The agent-authored console_ — letting Haku author increasingly
+free-form interactive UI, without the trusted console having to render or even
+understand it.
+
+## The shift
+
+Earlier sketches had the console **render** Haku's UI (ship a transpiler, run
+Haku's TSX in a sandboxed iframe, relay source/data over `postMessage`). This
+drops all of that. Instead:
+
+> Haku runs **its own UI service** in `haku-sandbox` and serves whatever it wants.
+> The trusted console **embeds it in a cross-origin iframe** and does nothing else
+> with it. The console never sees Haku's UI code, framework, or build.
+
+The trusted console shrinks to its irreducible job: **hold the launch bearer, own
+privileged actions, and frame Haku's UI.** Everything visual — and the reading and
+writing of `haku-state` for display and operator intent — moves into Haku's
+service, which already runs inside Haku's own perimeter.
+
+```
+ haku.allegedly.works            TRUSTED shell (ducktape, Authentik, holds the bearer)
+   • chrome + Launch button (capability tier: CSRF, bearer, shell-owned)
+   • <iframe src="https://haku-ui.allegedly.works">   ← cross-origin, same-site
+        │
+        ▼
+ haku-ui.allegedly.works         operator-owned Authentik-gated route (PR-gated)
+        │   → Service (haku-sandbox)
+        ▼
+   Haku's UI Deployment + pods   HAKU-OWNED (haku-sandbox CRUD)
+   • serves whatever UI Haku wants (its choice of framework/runtime)
+   • reads/writes haku-state itself (it already has the creds)
+   • sees the operator identity from the Authentik forward-auth headers
+```
+
+## Division of ownership
+
+| Thing                                                                                                         | Owner               | PR-gated?                    |
+| ------------------------------------------------------------------------------------------------------------- | ------------------- | ---------------------------- |
+| Trusted shell: capability tier (bearer), iframe host, CSP, the protocol                                       | operator / ducktape | ✅                           |
+| **Public route** `haku-ui.allegedly.works` (HTTPRoute + Authentik provider/blueprint) → the `haku-ui` Service | operator            | ✅                           |
+| The `haku-ui` Service contract (name, port, pod label selector) in `haku-sandbox`                             | operator            | ✅                           |
+| **The UI Deployment + pods + everything served**                                                              | **Haku**            | ❌ — Haku's to evolve freely |
+
+The boundary lands exactly where it should: the operator owns _the frame, the
+secret, and the public door_; Haku owns _the picture inside the frame_.
+
+## Containment invariants (the load-bearing part)
+
+The iframe content is **100% Haku-controlled and is assumed adversarial** (a
+prompt-injected Haku could author hostile UI — see `haku/PLAN.md` doctrine, "the
+container is the trust boundary"). Safety comes from the perimeter, not from
+trusting the content:
+
+1. **Cross-origin isolation from the shell.** `haku-ui` is a different origin than
+   `haku`, so the iframe cannot read the shell's DOM, cookies, or `localStorage`,
+   and cannot call the shell's capability API with the operator's credentials. The
+   launch bearer is unreachable from any browser context. Use a **same-site**
+   subdomain (`*.allegedly.works`) so it's _cross-origin but same-site_: isolated
+   from the shell, yet the Authentik SSO cookie isn't treated as a blocked
+   third-party cookie. Pin it with `sandbox="allow-scripts"` on the `<iframe>` and
+   `frame-src https://haku-ui.allegedly.works` in the shell's CSP.
+
+2. **Haku's UI is never publicly exposed.** Its only ingress is the
+   operator-owned, **Authentik-gated** route. Haku cannot publish private
+   information to the public through it, because the only door is gated to the
+   operator.
+
+3. **The agent cannot create public routes — keep it that way.** This is a cluster
+   invariant, not specific to this UI:
+   - **Today (RBAC):** Haku's full-CRUD Role is `haku-sandbox-admin` in
+     `haku-sandbox` (bound to group `oidc-ksbx-groups:haku`; a sibling of the
+     claude agent's `claude-sandbox-admin`, not the same role). It is an explicit
+     resource allowlist (`pods`, `services`, `deployments`, `configmaps`,
+     `secrets`, …) and does **not** include `httproutes`/`gateways`
+     (`gateway.networking.k8s.io`), so Haku cannot attach a route to the public
+     gateway. **Do not add those resources to the Role.**
+   - **Defense-in-depth (recommended, not yet done):** the `cluster-gateway`
+     listeners are `allowedRoutes: namespaces: from: All`
+     (`cluster/k8s/gateway/gateway.yaml`). That is a latent hole — if any
+     agent-writable namespace ever gained `httproutes` permission, it could
+     self-expose. Tighten `allowedRoutes.namespaces` to a label `Selector` (or an
+     explicit set) that agent namespaces never carry, so "agent can't create
+     public routes" holds structurally at the gateway layer too.
+
+4. **Worst case is bounded.** What a hostile iframe can do: render misleading UI,
+   and read/write `haku-state` — both of which Haku can already do. It cannot
+   exfiltrate to the public (invariant 2), cannot reach the bearer or fire a
+   capability (invariant 1), and cannot open a new public door (invariant 3).
+   Residual risk is **consent fidelity** — agent UI could phish the operator
+   (fake "approve X" that records Y). Mitigations: keep privileged controls and
+   their copy in the **shell chrome** (not the iframe), and mark the iframe region
+   visibly as agent-authored.
+
+## How Haku runs the service (no image builds)
+
+Haku can't build/push container images (GHCR/CI is PR-gated), but it has full CRUD
+in `haku-sandbox`. So it runs a **stock runtime image** and sources its app from
+`haku-state` at runtime — the same "edit via git, no rebuild" model the console
+itself uses. Concretely, Haku's Deployment is some public base image (a static
+server, or a Node/Python runtime) with an init/sidecar that clones/pulls
+`haku-state` and serves the app from a `ui/` dir. Haku evolves the UI by committing
+to `haku-state`; the running service picks it up. The console does not care which
+runtime or framework Haku chooses — it only frames the URL.
+
+The operator pins the **Service contract** (name `haku-ui`, a port, a pod label
+selector); Haku runs pods matching it. If Haku breaks its own Service, its UI is
+down — self-inflicted, no security impact.
+
+## Data and operator-intent flow
+
+Because Haku's service has the `haku-state` creds, **data and intent do not go
+through the shell**:
+
+- **Display data** — Haku's backend reads `haku-state` (items, etc.) and serves it
+  to its own UI. No shell involvement.
+- **Operator intent** — a click in Haku's UI calls Haku's own backend (same-origin
+  to the iframe), which writes `haku-state` (the equivalent of today's
+  `clicks/`/`intake/`). Haku reduces it on its next run.
+- **Operator identity** — Haku's backend reads the **Authentik forward-auth
+  headers** (e.g. `X-authentik-username`) on requests to its gated route, so it
+  knows the request is genuinely the operator. (Caveat: it must only trust those
+  headers on traffic that arrived through the outpost, not direct in-cluster
+  calls — standard forward-auth hygiene.)
+
+This means the console's existing **trace tier becomes legacy**: it stays only for
+the trusted declarative item list (Phase 1a). Once the UI lives in Haku's iframe,
+Haku's own backend records intent, and the trace tier can eventually be retired.
+
+## The protocol (postMessage) — minimal
+
+Since data + intent go to Haku's backend directly, the bridge carries only what
+genuinely needs the trusted side:
+
+1. **Capability requests** — the iframe asks the shell to perform a shell-owned
+   action: `postMessage {type: "requestCapability", id: "launch-routine"}` → the
+   shell renders its **own** confirm (trusted copy, CSRF, gesture) and fires with
+   the bearer. The iframe can _request_, never _invoke_. Origin is validated
+   against the real string `https://haku-ui.allegedly.works`.
+2. _(Possible later)_ richer host affordances (notifications, navigation) if the
+   agent UI needs them — added one verb at a time, each evaluated for blast radius.
+
+**v1 ships no bridge at all:** the Launch button stays in the shell chrome, and the
+iframe is a self-contained Haku app. The bridge is introduced only when Haku wants
+its own UI to surface the launch control.
+
+## Phasing
+
+- **v1 — frame it.** Operator stands up the Authentik-gated same-site route → the
+  `haku-ui` Service in `haku-sandbox`; the console embeds the iframe (`sandbox` +
+  CSP); Launch stays in shell chrome (no bridge). Haku stands up its Deployment and
+  serves a first page reading `haku-state`. Goal: prove the frame + isolation
+  end-to-end, with a real agent-authored page.
+- **v1.5 — gateway hardening.** Tighten `cluster-gateway` `allowedRoutes` so the
+  "no agent public routes" invariant holds at the gateway, not only via RBAC.
+- **v2 — the bridge.** Add the `requestCapability` protocol so agent UI can host a
+  launch control itself (shell still confirms + fires).
+- **later — retire the trace tier / declarative list** once the agent-authored UI
+  fully subsumes it.
+
+## Open questions
+
+- **Service contract specifics** — exact Service name/port/label, and whether the
+  operator also provides a baseline Deployment skeleton or leaves the whole
+  workload to Haku.
+- **Authentik in an iframe** — confirm the same-site SSO cookie + outpost
+  forward-auth works cleanly inside the iframe without an in-frame login redirect;
+  if not, fall back to bridging display data from the shell and keeping Haku's
+  service un-gated of operator data.
+- **Forward-auth header trust** — how Haku's backend distinguishes outpost traffic
+  from direct in-cluster calls (so header identity can't be spoofed by another
+  `haku-sandbox` pod).
+- **Visible agent-authored boundary** — how the shell frames the iframe so the
+  operator always knows in-iframe content is agent-authored (anti-phishing).

--- a/haku/console/plans/free_form_ui_iframe.md
+++ b/haku/console/plans/free_form_ui_iframe.md
@@ -129,36 +129,77 @@ This means the console's existing **trace tier becomes legacy**: it stays only f
 the trusted declarative item list (Phase 1a). Once the UI lives in Haku's iframe,
 Haku's own backend records intent, and the trace tier can eventually be retired.
 
-## The protocol (postMessage) — minimal
+## The shell in the fullscreen model
 
-Since data + intent go to Haku's backend directly, the bridge carries only what
-genuinely needs the trusted side:
+The iframe is expected to **fill the viewport** — Haku's UI scrolls internally like
+any full-page app, so there's no content-height autosizing. The trusted shell is then
+a **thin layer over** the iframe, not chrome around it. It owns, on its **own z-layer**
+(which the agent UI can't draw over or intercept):
 
-1. **Capability requests** — the iframe asks the shell to perform a shell-owned
-   action: `postMessage {type: "requestCapability", id: "launch-routine"}` → the
-   shell renders its **own** confirm (trusted copy, CSRF, gesture) and fires with
-   the bearer. The iframe can _request_, never _invoke_. Origin is validated
-   against the real string `https://haku-ui.allegedly.works`.
-2. _(Possible later)_ richer host affordances (notifications, navigation) if the
-   agent UI needs them — added one verb at a time, each evaluated for blast radius.
+- **a persistent trust indicator** (small badge / border) so the operator can always
+  tell shell pixels from agent-authored pixels — the only pixels to trust for a
+  privileged prompt. This matters more fullscreen: the agent surface is a large
+  phishing canvas.
+- **privileged-action confirms** (below), rendered as overlays above the iframe.
+- the frame + the bridge endpoint.
 
-**v1 ships no bridge at all:** the Launch button stays in the shell chrome, and the
-iframe is a self-contained Haku app. The bridge is introduced only when Haku wants
-its own UI to surface the launch control.
+## The protocol (postMessage)
+
+Data + intent go to Haku's backend directly, so the bridge carries only actions that
+need the trusted side. Every inbound message is origin-checked
+(`event.origin === "https://haku-ui.allegedly.works"`) and schema-validated; the
+iframe can only _request_ — the shell decides and acts. Two first affordances:
+
+### `requestCapability` — perform a shell-owned action
+
+`{type: "requestCapability", id: "launch-routine"}` → the shell pops its **own**
+confirm overlay (trusted copy, CSRF) and fires with the bearer. The iframe never
+holds the bearer or invokes directly. This is the cheapest first affordance — it
+reuses the existing capability tier; the request just triggers the flow already there.
+
+### `openLink` — send the operator to a URL
+
+`{type: "openLink", url}` → the shell opens the link on the operator's behalf (the
+iframe can't: tight sandbox + cross-origin). Rules:
+
+- **Scheme is a hard gate** (never behind a confirm): allow only `https` (and
+  `mailto`); reject `javascript:` / `data:` / `blob:` / `file:` / … outright —
+  opening those in the top context would be code execution in the _shell's_ origin.
+  "Arbitrary links" means arbitrary `https` hosts, not arbitrary schemes.
+- **The host whitelist decides warn-vs-not.** It is **operator-owned trusted config
+  in the shell** — _not_ in `haku-state`, or Haku could whitelist a phishing host and
+  skip the confirm:
+  - whitelisted (claude.ai, github.com, your own services, …) → open directly;
+  - otherwise → shell **confirm overlay showing the real, full URL** → Open / Cancel
+    (a consent + anti-phishing gate: the agent supplies the URL, the shell displays it
+    honestly).
+- Always `window.open(url, "_blank", "noopener,noreferrer")`.
+
+This subsumes the item→handoff loop (a `claude.ai/new` deep-link is just a whitelisted
+open) and gives Haku a general "send me to a link" verb without ever letting agent UI
+navigate the operator unsupervised.
+
+**Popup permission (assumed one-time setup).** A `window.open` relayed over
+`postMessage` loses user-activation and gets popup-blocked. Rather than engineer
+around it, the operator grants a one-time per-origin **"allow pop-ups for
+`haku.allegedly.works`"**; thereafter the shell opens freely from postMessage
+handlers. The permission is on the **shell** origin only — the iframe stays
+`sandbox="allow-scripts"` (no `allow-popups`), so it still cannot open anything itself;
+only the trusted shell opens, and only after the scheme gate + whitelist/confirm.
+(Chrome/Firefox honor the persistent per-site allow cleanly; Safari is fiddlier —
+fine for a single-operator Chrome/Firefox tool.)
 
 ## Phasing
 
-- **v1 — frame it.** Operator stands up the Authentik-gated same-site route → the
-  `haku-ui` Service in `haku-sandbox`; the console embeds the iframe (`sandbox` +
-  CSP); Launch stays in shell chrome (no bridge). Haku stands up its Deployment and
-  serves a first page reading `haku-state`. Goal: prove the frame + isolation
-  end-to-end, with a real agent-authored page.
+- **v1 — frame it + the minimal bridge.** Operator stands up the Authentik-gated
+  same-site route → the `haku-ui` Service in `haku-sandbox`, the fullscreen iframe
+  (`sandbox` + CSP + trust indicator), and ships `requestCapability("launch-routine")`
+  - `openLink`. Haku stands up its Deployment and serves a first page reading
+    `haku-state`. Goal: prove the frame + isolation + the two affordances end-to-end.
 - **v1.5 — gateway hardening.** Tighten `cluster-gateway` `allowedRoutes` so the
   "no agent public routes" invariant holds at the gateway, not only via RBAC.
-- **v2 — the bridge.** Add the `requestCapability` protocol so agent UI can host a
-  launch control itself (shell still confirms + fires).
-- **later — retire the trace tier / declarative list** once the agent-authored UI
-  fully subsumes it.
+- **later — more capabilities; retire the trace tier / declarative list** once the
+  agent-authored UI fully subsumes it.
 
 ## Open questions
 

--- a/haku/console/plans/free_form_ui_iframe.md
+++ b/haku/console/plans/free_form_ui_iframe.md
@@ -198,8 +198,43 @@ fine for a single-operator Chrome/Firefox tool.)
     `haku-state`. Goal: prove the frame + isolation + the two affordances end-to-end.
 - **v1.5 — gateway hardening.** Tighten `cluster-gateway` `allowedRoutes` so the
   "no agent public routes" invariant holds at the gateway, not only via RBAC.
-- **later — more capabilities; retire the trace tier / declarative list** once the
-  agent-authored UI fully subsumes it.
+- **later — the north star below**: more capabilities, then fully subsume the item UI
+  into Haku's iframe and retire the trusted renderer + trace tier.
+
+## North star: the shell owns nothing but the boundary
+
+The end state (later — not the next step) drops the last thing ducktape still owns on
+the _content_ side: the **item model and its UI**. Today the trusted console owns the
+item schema (`models.py` / `base/schema/item.json`), the declarative renderer, the SPA
+bundle + styling, and the trace tier. In the north star, **all of that moves into
+Haku's iframe service and `haku-state`**:
+
+- Haku is given a **high-level objective** — _"surface for the operator the things
+  that are useful to act on"_ — and **no schema**. There is no ducktape-defined
+  `Item`, no fixed action kinds, no prescribed layout. Haku decides what the
+  abstraction is and how to present it, and evolves it freely.
+- The frontend's **styling, compilation, and the console SPA's Flux image automation**
+  move out of ducktape into **agent-owned `haku-state` code** — Haku's UI service
+  builds and serves its own assets; no ducktape rebuild for a UI or schema change.
+- The **trace tier retires** — Haku's own backend records operator intent (it already
+  owns `haku-state`).
+
+What's left in ducktape is the **irreducible trusted core, and nothing else**:
+
+- the **capability tier** (the bearer + CSRF + `launch-routine` and any future
+  privileged verbs);
+- the **iframe host** page + the **`postMessage` protocol** and its validation;
+- the **CSP + trust indicator** (the pixels the operator is entitled to trust);
+- the **perimeter** (`haku-console` namespace, the Authentik-gated route, the
+  gateway-route invariant).
+
+The litmus test for "does this belong in ducktape": **does it hold a secret, perform a
+privileged action, or define the trust boundary?** If not, it's Haku's — and the item
+abstraction fails that test, so it goes.
+
+Deliberately deferred: this only makes sense once the iframe UI + the affordances are
+proven and Haku can author an experience at least as good as today's declarative list.
+Until then, Phase 1a's trusted item list coexists.
 
 ## Open questions
 

--- a/haku/console/plans/free_form_ui_iframe.md
+++ b/haku/console/plans/free_form_ui_iframe.md
@@ -90,9 +90,10 @@ trusting the content:
    exfiltrate to the public (invariant 2), cannot reach the bearer or fire a
    capability (invariant 1), and cannot open a new public door (invariant 3).
    Residual risk is **consent fidelity** — agent UI could phish the operator
-   (fake "approve X" that records Y). Mitigations: keep privileged controls and
-   their copy in the **shell chrome** (not the iframe), and mark the iframe region
-   visibly as agent-authored.
+   (fake "approve X" that records Y). Mitigation is the capability gate (a faked
+   control is inert) plus the **top-layer modal confirm + backdrop** at the moment of
+   a privileged action — _not_ a visible "agent-authored" marker, which the iframe can
+   spoof. See "The shell as a thin trusted layer".
 
 ## How Haku runs the service (no image builds)
 
@@ -129,19 +130,43 @@ This means the console's existing **trace tier becomes legacy**: it stays only f
 the trusted declarative item list (Phase 1a). Once the UI lives in Haku's iframe,
 Haku's own backend records intent, and the trace tier can eventually be retired.
 
-## The shell in the fullscreen model
+## The shell as a thin trusted layer
 
-The iframe is expected to **fill the viewport** — Haku's UI scrolls internally like
-any full-page app, so there's no content-height autosizing. The trusted shell is then
-a **thin layer over** the iframe, not chrome around it. It owns, on its **own z-layer**
-(which the agent UI can't draw over or intercept):
+The iframe is expected to **cover most of the page** — Haku's UI scrolls internally
+like a full-page app, so there's no content-height autosizing. The trusted shell is
+then a **thin layer**, not chrome around it. It owns:
 
-- **a persistent trust indicator** (small badge / border) so the operator can always
-  tell shell pixels from agent-authored pixels — the only pixels to trust for a
-  privileged prompt. This matters more fullscreen: the agent surface is a large
-  phishing canvas.
-- **privileged-action confirms** (below), rendered as overlays above the iframe.
-- the frame + the bridge endpoint.
+- **the moment-of-decision confirm** for any privileged action — see below. This, not
+  a badge, is the trustworthy surface.
+- the frame + the bridge endpoint + the CSP.
+
+**A persistent "trust indicator" is not a security control — don't rely on it.** A web
+page has no secure-attention channel (the OS has Ctrl-Alt-Del; the browser has the
+address bar — neither is available to a sub-region of a page). An iframe covering most
+of the page can render a pixel-perfect **decoy** badge; the shell's real badge sits on
+a higher z-layer so it can't be drawn _over_, but the operator can't reliably tell it
+from a decoy drawn beside it. A static frame/border is at most cosmetic honesty, never
+a boundary.
+
+Security therefore does **not** depend on the operator visually distinguishing shell
+pixels from agent pixels. It rests on two things:
+
+1. **The capability gate makes a faked control inert.** If the iframe draws a fake
+   "Launch" button, clicking it only emits a `requestCapability` (below) — which the
+   shell re-gates with its own CSRF + confirm + bearer. Spoofing the _look_ of a
+   privileged control accomplishes nothing on the privileged path.
+2. **The confirm is the only trustworthy surface, and it only has to exist at the
+   moment of approval.** Render it as a **top-layer modal** (`<dialog>.showModal()`)
+   with a **backdrop**: the iframe cannot draw over it, read it, or intercept clicks
+   meant for it (top layer + cross-origin + pointer capture), and the backdrop dims
+   the agent UI so "the shell is talking now" is unambiguous. Anti-clickjacking
+   hygiene on it: explicit action text the operator must read, a deliberate click on a
+   freshly-rendered button (no click-through / brief focus delay) — the residual
+   attack isn't spoofing a badge, it's baiting the operator's click onto the real
+   confirm.
+
+Also **withhold the Fullscreen API** from the iframe (no `allow="fullscreen"`) so it
+can't go truly fullscreen and spoof the browser chrome itself.
 
 ## The protocol (postMessage)
 
@@ -193,7 +218,7 @@ fine for a single-operator Chrome/Firefox tool.)
 
 - **v1 — frame it + the minimal bridge.** Operator stands up the Authentik-gated
   same-site route → the `haku-ui` Service in `haku-sandbox`, the fullscreen iframe
-  (`sandbox` + CSP + trust indicator), and ships `requestCapability("launch-routine")`
+  (`sandbox` + CSP + top-layer confirm), and ships `requestCapability("launch-routine")`
   - `openLink`. Haku stands up its Deployment and serves a first page reading
     `haku-state`. Goal: prove the frame + isolation + the two affordances end-to-end.
 - **v1.5 — gateway hardening.** Tighten `cluster-gateway` `allowedRoutes` so the
@@ -224,7 +249,7 @@ What's left in ducktape is the **irreducible trusted core, and nothing else**:
 - the **capability tier** (the bearer + CSRF + `launch-routine` and any future
   privileged verbs);
 - the **iframe host** page + the **`postMessage` protocol** and its validation;
-- the **CSP + trust indicator** (the pixels the operator is entitled to trust);
+- the **CSP** + the **top-layer modal confirm** (the only trustworthy surface, at the moment of a privileged action);
 - the **perimeter** (`haku-console` namespace, the Authentik-gated route, the
   gateway-route invariant).
 


### PR DESCRIPTION
## What

A design doc for **Phase 1b** (free-form agent-authored UI), reflecting the decision to **not** have the console render Haku's UI. Instead:

> Haku runs **its own UI service** in `haku-sandbox` (its Deployment, its runtime, app code from `haku-state`, no image build) and the console **embeds it in a cross-origin same-site iframe**. The trusted shell shrinks to: hold the launch bearer, own privileged actions, frame the UI.

Docs only — `haku/console/plans/free_form_ui_iframe.md` + a rewrite of `haku/PLAN.md`'s Phase 1b bullet to this hosted-service model (replacing the render-it-ourselves transpiler variant).

## Containment invariants captured

- **Cross-origin isolation** → the launch bearer is unreachable from any browser context; the iframe can't read the shell's cookies/DOM or call its capability API.
- **Never publicly exposed** → Haku's UI is reachable *only* through the operator-owned **Authentik-gated** route, so the agent can't use it to leak private info publicly.
- **Agent can't create public routes** → Haku's `haku-sandbox-admin` Role omits `httproutes`/`gateways` (keep it that way); plus a recommended defense-in-depth fix to the `cluster-gateway`'s `allowedRoutes: from: All`.
- **Worst case bounded** to "render misleading UI + write `haku-state`" — both already possible; residual risk is consent fidelity, mitigated by keeping privileged controls + copy in the shell chrome.

Also documents how Haku runs the service without image builds (stock runtime + `haku-state`-sourced app), the data/intent/identity flow (direct to Haku's backend; operator identity via Authentik forward-auth headers), the minimal `postMessage` bridge (capability requests only), and phasing (v1 frame-it → gateway hardening → bridge).

## Notes

- Fixes a naming error caught in review: Haku's role is `haku-sandbox-admin` (a sibling of the claude agent's `claude-sandbox-admin`), not the claude one.
- No code; this is the plan to build against.