### PR TITLE
debundle: prove OR-Tools CP-SAT sidecar

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,6 +11,9 @@ bazel_dep(name = "gazelle", version = "0.47.0", repo_name = "bazel_gazelle")
 bazel_dep(name = "rules_go", version = "0.60.0", repo_name = "io_bazel_rules_go")
 bazel_dep(name = "protobuf", version = "33.1")
 bazel_dep(name = "rules_proto", version = "7.1.0")
+bazel_dep(name = "rules_cc", version = "0.2.16")
+bazel_dep(name = "or-tools", version = "9.15")
+bazel_dep(name = "abseil-cpp", version = "20260107.1")
 bazel_dep(name = "googleapis", version = "0.0.0-20260223-edfe7983")
 bazel_dep(name = "googleapis-go", version = "1.0.0")
 bazel_dep(name = "rules_shell", version = "0.6.1")  # Required by buildifier_prebuilt
@@ -32,6 +35,17 @@ single_version_override(
     module_name = "rules_conda",
     patch_strip = 1,
     patches = ["//third_party/patches:rules_conda_sanitize_repo_name.patch"],
+)
+
+# or-tools@9.15 pulls pybind11_abseil for wrapper targets even when we only
+# build the C++ CP-SAT backend. Its module creates a dev-only pip hub named
+# "pypi", which collides with Ducktape's root pip hub during module extension
+# resolution. Keep pybind11_abseil's apparent @pypi mapping inside that module,
+# but give its generated hub a module-specific name.
+single_version_override(
+    module_name = "pybind11_abseil",
+    patch_strip = 1,
+    patches = ["//third_party/patches:pybind11_abseil_rename_pypi_hub.patch"],
 )
 
 # Fork with two fixes for CI disk exhaustion during mypy type-checking:

--- a/devinfra/js/debundle/solver_backends/ortools_spike/BUILD.bazel
+++ b/devinfra/js/debundle/solver_backends/ortools_spike/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_test(
+    name = "ortools_cpsat_smoke_test",
+    size = "small",
+    srcs = ["ortools_cpsat_smoke_test.cc"],
+    deps = [
+        "@abseil-cpp//absl/log:check",
+        "@or-tools//ortools/sat:cp_model",
+        "@or-tools//ortools/sat:cp_model_solver",
+    ],
+)

--- a/devinfra/js/debundle/solver_backends/ortools_spike/ortools_cpsat_smoke_test.cc
+++ b/devinfra/js/debundle/solver_backends/ortools_spike/ortools_cpsat_smoke_test.cc
@@ -1,0 +1,52 @@
+#include "absl/log/check.h"
+#include "ortools/sat/cp_model.h"
+#include "ortools/sat/cp_model.pb.h"
+#include "ortools/sat/cp_model_solver.h"
+
+namespace sat = operations_research::sat;
+
+namespace {
+
+bool IsSolved(const sat::CpSolverResponse& response) {
+  return response.status() == sat::CpSolverStatus::OPTIMAL ||
+         response.status() == sat::CpSolverStatus::FEASIBLE;
+}
+
+}  // namespace
+
+int main() {
+  sat::CpModelBuilder model;
+  const operations_research::Domain candidate_domain(0, 2);
+  const sat::IntVar broad_owner =
+      model.NewIntVar(candidate_domain).WithName("broad_owner");
+  const sat::IntVar strict_owner =
+      model.NewIntVar(candidate_domain).WithName("strict_owner");
+  const sat::IntVar reserved_owner =
+      model.NewIntVar(candidate_domain).WithName("reserved_owner");
+
+  model.AddAllDifferent({broad_owner, strict_owner, reserved_owner});
+
+  sat::TableConstraint broad_candidates =
+      model.AddAllowedAssignments({broad_owner});
+  broad_candidates.AddTuple({0});
+  broad_candidates.AddTuple({1});
+
+  sat::TableConstraint strict_candidates =
+      model.AddAllowedAssignments({strict_owner});
+  strict_candidates.AddTuple({1});
+
+  model.AddEquality(reserved_owner, 2);
+
+  const sat::CpSolverResponse response = sat::Solve(model.Build());
+  CHECK(IsSolved(response)) << "CP-SAT did not find a feasible solution:\n"
+                            << sat::CpSolverResponseStats(response);
+
+  CHECK_EQ(sat::SolutionIntegerValue(response, strict_owner), 1)
+      << "strict owner should be fixed by its singleton table";
+  CHECK_EQ(sat::SolutionIntegerValue(response, reserved_owner), 2)
+      << "reserved owner should be fixed by equality";
+  CHECK_EQ(sat::SolutionIntegerValue(response, broad_owner), 0)
+      << "broad owner should be forced by all_different propagation";
+
+  return 0;
+}

--- a/third_party/patches/pybind11_abseil_rename_pypi_hub.patch
+++ b/third_party/patches/pybind11_abseil_rename_pypi_hub.patch
@@ -1,0 +1,15 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index 071898b..5d241c0 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -62,7 +62,7 @@ pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+ [
+   pip.parse(
+-    hub_name = "pypi",
++    hub_name = "pybind11_abseil_pypi",
+     python_version = version,
+     requirements_lock = "//pybind11_abseil/requirements:requirements_lock_" + version.replace('.','_') + ".txt",
+   )
+@@ -72 +72 @@ pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+-use_repo(pip, "pypi")
++use_repo(pip, pypi = "pybind11_abseil_pypi")


### PR DESCRIPTION
## Summary

- add `or-tools@9.15`, `rules_cc`, and `abseil-cpp@20260107.1` to Bzlmod for a debundle solver sidecar spike
- patch `pybind11_abseil`'s transitive pip hub name so it no longer collides with Ducktape's root `pypi` hub
- add a tiny C++ CP-SAT smoke test using finite domains, allowed assignments, native `AllDifferent`, and Abseil `CHECK` assertions

## Validation

- `nix develop -c pre-commit run --files MODULE.bazel third_party/patches/pybind11_abseil_rename_pypi_hub.patch devinfra/js/debundle/solver_backends/ortools_spike/BUILD.bazel devinfra/js/debundle/solver_backends/ortools_spike/ortools_cpsat_smoke_test.cc`
- `nix develop -c bbr test //devinfra/js/debundle/solver_backends/ortools_spike:ortools_cpsat_smoke_test --cache_test_results=no --test_output=errors`
  - BuildBuddy invocation: https://app.buildbuddy.io/invocation/a06566b4-98e0-49fb-bd84-adc0a3f838a1

## Notes

This is intentionally a backend proof, not the production resolver cutover. The direct OR-Tools path is viable under RBE, but the initial cold build is heavy; the production integration should keep OR-Tools behind a sidecar/binary boundary rather than linking it into the Rust debundler.

I checked for a root-side Bzlmod replacement for the `pybind11_abseil` `@pypi` collision. With the pinned `rules_python@1.9.0`, the duplicate hub check keys directly on the dependency module's `pip.parse(hub_name = ...)` before any root-side repo remapping can help, so the MODULE patch remains the smallest concrete fix for this spike.