### PR TITLE
haku: drop ephemeral on haku_kube_token (unblocks vault credential)

### DIFF
--- a/tf/gitops/haku-cloud-agent/variables.tf
+++ b/tf/gitops/haku-cloud-agent/variables.tf
@@ -1,8 +1,12 @@
 variable "haku_kube_token" {
-  type        = string
-  ephemeral   = true
-  sensitive   = true
-  description = "haku-k8s Authentik JWT for the static_bearer vault credential. Set from the haku-cloud-kube-token Secret's jwt key via the Terraform CR's spec.vars. ephemeral so it never lands in plan or state (the credential's token attribute is also write-only). See main.tf rotation note."
+  type      = string
+  sensitive = true
+  # NOT ephemeral: the tofu-controller's spec.vars does not populate ephemeral
+  # input variables, so an ephemeral var arrives null and the provider rejects
+  # the credential ("auth.token: Field required"). The credential's `token` is a
+  # write-only attribute, which already keeps the value out of tfstate; sensitive
+  # keeps it out of logs. See main.tf rotation note.
+  description = "haku-k8s Authentik JWT for the static_bearer vault credential. Set from the haku-cloud-kube-token Secret's jwt key via the Terraform CR's spec.vars."
 }
 
 variable "haku_kube_token_wo_version" {


### PR DESCRIPTION
Apply got past env/agent/vault (key valid ✅) but failed on the vault credential: `400 auth.token: Field required`. The tofu-controller's `spec.vars` populates regular vars but **not ephemeral** ones — so ephemeral `haku_kube_token` arrived null (while non-ephemeral `haku_kube_token_wo_version` resolved; the plan passed `tonumber()`). Drop `ephemeral`; the credential's `token` is write-only (stays out of state) and the var stays `sensitive`. `tofu validate` ✅.