### PR TITLE
haku: read kube-token via kubernetes provider (fix vault credential)

### DIFF
--- a/cluster/k8s/haku/cloud-agent-tf/terraform.yaml
+++ b/cluster/k8s/haku/cloud-agent-tf/terraform.yaml
@@ -15,22 +15,10 @@ spec:
   serviceAccountName: tf-runner
   approvePlan: "auto"
 
-  # haku-k8s Authentik JWT (rotated by authentik-jwt-rotation into the
-  # haku-cloud-kube-token Secret) + its exp epoch. tofu writes the token into the
-  # Anthropic vault as a static_bearer credential; the exp drives the write-only
-  # token_wo_version so each rotation re-sends. Passed via the controller's native
-  # vars (NOT runner TF_VAR_* env — the tf-controller forbids that). See the root's main.tf.
-  vars:
-    - name: haku_kube_token
-      valueFrom:
-        secretKeyRef:
-          name: haku-cloud-kube-token
-          key: jwt
-    - name: haku_kube_token_wo_version
-      valueFrom:
-        secretKeyRef:
-          name: haku-cloud-kube-token
-          key: token-exp
+  # The static_bearer credential's haku-k8s JWT is read in-cluster by the tofu
+  # root itself (kubernetes_secret_v1 data source from the haku-cloud-kube-token
+  # Secret; see tf/gitops/haku-cloud-agent/main.tf) — not via spec.vars, whose
+  # valueFrom the tf-controller doesn't resolve here.
 
   backendConfig:
     customConfiguration: |

--- a/tf/gitops/haku-cloud-agent/.terraform.lock.hcl
+++ b/tf/gitops/haku-cloud-agent/.terraform.lock.hcl
@@ -1,6 +1,25 @@
 # This file is maintained automatically by "tofu init".
 # Manual edits may be lost in future updates.
 
+provider "registry.opentofu.org/hashicorp/kubernetes" {
+  version     = "2.38.0"
+  constraints = "~> 2.38"
+  hashes = [
+    "h1:ems+O2dA7atxMWpbtqIrsH7Oa+u+ERWSfpMaFnZPbh0=",
+    "h1:iEDf790HE0h3kz58zfj5IhTVODCDqWF1hISPHz210Uw=",
+    "h1:nY7J9jFXcsRINog0KYagiWZw1GVYF9D2JmtIB7Wnrao=",
+    "zh:1096b41c4e5b2ee6c1980916fb9a8579bc1892071396f7a9432be058aabf3cbc",
+    "zh:2959fde9ae3d1deb5e317df0d7b02ea4977951ee6b9c4beb083c148ca8f3681c",
+    "zh:5082f98fcb3389c73339365f7df39fc6912bf2bd1a46d5f97778f441a67fd337",
+    "zh:620fd5d0fbc2d7a24ac6b420a4922e6093020358162a62fa8cbd37b2bac1d22e",
+    "zh:7f47c2de179bba35d759147c53082cad6c3449d19b0ec0c5a4ca8db5b06393e1",
+    "zh:89c3aa2a87e29febf100fd21cead34f9a4c0e6e7ae5f383b5cef815c677eb52a",
+    "zh:96eecc9f94938a0bc35b8a63d2c4a5f972395e44206620db06760b730d0471fc",
+    "zh:e15567c1095f898af173c281b66bffdc4f3068afdd9f84bb5b5b5521d9f29584",
+    "zh:ecc6b912629734a9a41a7cf1c4c73fb13b4b510afc9e7b2e0011d290bcd6d77f",
+  ]
+}
+
 provider "registry.opentofu.org/modus-agendi/anthropic-claude-managed-agents" {
   version     = "1.1.0"
   constraints = "~> 1.1"

--- a/tf/gitops/haku-cloud-agent/BUILD.bazel
+++ b/tf/gitops/haku-cloud-agent/BUILD.bazel
@@ -4,6 +4,7 @@ tf_providers_versions(
     name = "providers",
     providers = {
         "claude-managed-agents": "modus-agendi/anthropic-claude-managed-agents:~>1.1",
+        "kubernetes": "hashicorp/kubernetes:~>2.38",
     },
     tf_version = "1.11.2",
 )
@@ -12,6 +13,7 @@ tf_module(
     name = "haku-cloud-agent",
     providers = [
         "claude-managed-agents",
+        "kubernetes",
     ],
     providers_versions = ":providers",
 )

--- a/tf/gitops/haku-cloud-agent/main.tf
+++ b/tf/gitops/haku-cloud-agent/main.tf
@@ -12,8 +12,8 @@
 # CREDENTIAL ROTATION: the static_bearer credential carries the haku-k8s Authentik
 # JWT, which rotates ~every 44 days. The chain is fully automatic and the rotator
 # stays dumb (it only mints + commits): authentik-jwt-rotation writes the token as
-# the haku-cloud-kube-token k8s Secret -> Flux applies it -> this runner reads it
-# (var.haku_kube_token + var.haku_kube_token_wo_version) -> tofu re-sends it into
+# the haku-cloud-kube-token k8s Secret -> Flux applies it -> tofu reads it
+# in-cluster (kubernetes_secret_v1 data source, below) -> tofu re-sends it into
 # the Anthropic vault. The token is a TF 1.11 write-only attribute, so it only
 # re-sends when token_wo_version changes; we set that to the JWT's exp epoch
 # (monotonic, bumps on every mint).
@@ -90,6 +90,18 @@ resource "claude-managed-agents_vault" "haku_cloud" {
   display_name = "haku-cloud"
 }
 
+# Read the rotator-published token in-cluster (tf-runner SA; kubernetes provider
+# auto-configures in-cluster, as in tf/gitops/cpap-data). The tofu-controller's
+# spec.vars don't resolve secretKeyRef, so we read the Secret here instead. The
+# JWT lands in tfstate (sensitive) — same as cpap-data's data.kubernetes_secret;
+# the credential's `token` is still write-only so it isn't re-emitted on read.
+data "kubernetes_secret_v1" "kube_token" {
+  metadata {
+    name      = "haku-cloud-kube-token"
+    namespace = "flux-system"
+  }
+}
+
 # The haku-k8s Authentik JWT, bound to the kubectl-machine-mcp URL. Anthropic
 # presents it when the agent connects to that MCP; the MCP forwards it to
 # kube-apiserver (groups:["haku"] -> oidc-ksbx-groups:haku). token is write-only;
@@ -101,8 +113,8 @@ resource "claude-managed-agents_vault_credential" "haku_kube" {
   auth = {
     type             = "static_bearer"
     mcp_server_url   = "https://kubectl-machine-mcp.allegedly.works/mcp"
-    token            = var.haku_kube_token
-    token_wo_version = tonumber(var.haku_kube_token_wo_version)
+    token            = data.kubernetes_secret_v1.kube_token.data["jwt"]
+    token_wo_version = tonumber(data.kubernetes_secret_v1.kube_token.data["token-exp"])
   }
 }
 

--- a/tf/gitops/haku-cloud-agent/terraform.tf
+++ b/tf/gitops/haku-cloud-agent/terraform.tf
@@ -1,6 +1,5 @@
 terraform {
-  # >= 1.11: the vault_credential token is a write-only attribute and the
-  # haku_kube_token variable is ephemeral.
+  # >= 1.11: the vault_credential token is a write-only attribute.
   required_version = ">= 1.11"
 
   required_providers {
@@ -13,6 +12,12 @@ terraform {
     claude-managed-agents = {
       source  = "modus-agendi/anthropic-claude-managed-agents"
       version = "~> 1.1"
+    }
+    # Reads the haku-cloud-kube-token Secret in-cluster for the static_bearer
+    # credential token. In-cluster auth via the tf-runner SA.
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.38"
     }
   }
 

--- a/tf/gitops/haku-cloud-agent/variables.tf
+++ b/tf/gitops/haku-cloud-agent/variables.tf
@@ -1,17 +1,5 @@
-variable "haku_kube_token" {
-  type      = string
-  sensitive = true
-  # NOT ephemeral: the tofu-controller's spec.vars does not populate ephemeral
-  # input variables, so an ephemeral var arrives null and the provider rejects
-  # the credential ("auth.token: Field required"). The credential's `token` is a
-  # write-only attribute, which already keeps the value out of tfstate; sensitive
-  # keeps it out of logs. See main.tf rotation note.
-  description = "haku-k8s Authentik JWT for the static_bearer vault credential. Set from the haku-cloud-kube-token Secret's jwt key via the Terraform CR's spec.vars."
-}
-
-variable "haku_kube_token_wo_version" {
-  # String (not number): the tofu-controller passes Secret-sourced vars as strings;
-  # tonumber() at the use site in main.tf.
-  type        = string
-  description = "The haku JWT's exp epoch (seconds). Drives the write-only token_wo_version so each rotation (new token -> later exp) re-sends the token into the Anthropic vault. From the haku-cloud-kube-token Secret's token-exp key, via the CR's spec.vars."
-}
+# No input variables: the provider's API key comes from the ANTHROPIC_API_KEY
+# env var (injected into the tofu-controller runner), and the static_bearer
+# credential's token is read in-cluster from the haku-cloud-kube-token Secret
+# via a kubernetes_secret_v1 data source (see main.tf). Present to
+# satisfy tflint's terraform_standard_module_structure rule.


### PR DESCRIPTION
Final fix for the haku-cloud-agent deploy. The vault credential kept failing `400 auth.token: Field required`: the tofu-controller doesn't resolve `spec.vars[].valueFrom.secretKeyRef`, so the token arrived `null`. No repo CR uses `spec.vars` valueFrom — the proven pattern (cpap-data) reads secrets in-cluster via the **kubernetes provider**. Switched to `data.kubernetes_secret_v1` reading `haku-cloud-kube-token` (tf-runner has cluster-wide `secrets get`); dropped `spec.vars` + the unused input vars; lock regenerated with kubernetes. `tofu validate` + tf {validate,lint,format} + cluster {test_k8s,test_flux_build} ✅.