### PR TITLE
cluster/gateway: restrict agents from creating public routes (Kyverno denylist)

### DIFF
--- a/cluster/k8s/TODO.md
+++ b/cluster/k8s/TODO.md
@@ -144,16 +144,21 @@ Options to consider:
 
 ## Gateway: restrict `cluster-gateway` `allowedRoutes` (no agent self-exposure)
 
-- [ ] 2026-06-26: `cluster/k8s/gateway/gateway.yaml` listeners are all
-      `allowedRoutes: namespaces: from: All`, so an HTTPRoute in **any** namespace
-      can attach to the public gateway and bypass Authentik. Not currently
-      exploitable by the agents — `haku-sandbox-admin` / `claude-sandbox-admin` are
-      explicit resource allowlists that omit `httproutes`/`gateways` — but it's a
-      latent hole: any future RBAC slip granting an agent-writable namespace
-      `httproutes` would let it self-expose publicly. Tighten
-      `allowedRoutes.namespaces` to a label `Selector` (or explicit set) that agent
-      namespaces (`haku-sandbox`, `claude-sandbox`, …) never carry, so "the agent
-      can't create public routes" holds structurally at the gateway, not only via
-      RBAC. The agent-authored Haku UI (`haku/console/plans/free_form_ui_iframe.md`)
-      depends on this — its UI must stay reachable only via the operator-owned
-      Authentik route.
+The hole: `cluster/k8s/gateway/gateway.yaml` listeners are all `allowedRoutes:
+namespaces: from: All`, so an HTTPRoute in **any** namespace can attach to the public
+gateway and bypass Authentik. Not currently exploitable — `haku-sandbox-admin` /
+`claude-sandbox-admin` omit `httproutes`/`gateways` — but a latent hole the
+agent-authored Haku UI (`haku/console/plans/free_form_ui_iframe.md`) relies on staying
+closed (its UI must reach the operator only via the Authentik route).
+
+- [x] **Mitigated (Kyverno denylist).** `restrict-agent-gateway-routes` ClusterPolicy
+      denies route/Gateway creation in the agent namespaces — closes the hole without
+      touching the live gateway. This is the current fence.
+- [ ] **Still want the `allowedRoutes` Selector eventually** (belt-and-suspenders at
+      the gateway layer itself, not only via a per-namespace deny). Deferred because:
+      (a) Cilium bug #42159 — per-listener `allowedRoutes` bleeds across listeners in
+      this setup (see `cluster/docs/plan.md`); (b) the kube-API routes live in the
+      built-in `default` namespace (and a flux-system route) with no in-repo `Namespace`
+      manifest to carry a selector label. Revisit if/when #42159 is fixed and there's a
+      clean way to label those built-in namespaces — then switch listeners to
+      `from: Selector` and the denylist becomes redundant.

--- a/cluster/k8s/gateway/gateway.yaml
+++ b/cluster/k8s/gateway/gateway.yaml
@@ -7,6 +7,12 @@ metadata:
     cert-manager.io/cluster-issuer: "${LETSENCRYPT_ISSUER}"
 spec:
   gatewayClassName: cilium
+  # Every listener uses allowedRoutes.namespaces.from: All. Per-listener Selector
+  # restriction is avoided because Cilium bug #42159 makes listener-scoped
+  # allowedRoutes config bleed across listeners (see cluster/docs/plan.md). The
+  # fence against agents publishing public routes that bypass Authentik is instead
+  # the Kyverno ClusterPolicy `restrict-agent-gateway-routes`, which denies route
+  # creation in the agent sandbox namespaces.
   listeners:
     - name: https-wildcard
       hostname: "*.allegedly.works"

--- a/cluster/k8s/kyverno/policies/kustomization.yaml
+++ b/cluster/k8s/kyverno/policies/kustomization.yaml
@@ -5,5 +5,6 @@ resources:
   - inject-mitmproxy.yaml
   - inject-haku-mitmproxy.yaml
   - restrict-agent-kustomization-patch.yaml
+  - restrict-agent-gateway-routes.yaml
   - clusterrole-cleanup-controller-jobs.yaml
   - clusterrole-cleanup-controller-workloads.yaml

--- a/cluster/k8s/kyverno/policies/restrict-agent-gateway-routes.yaml
+++ b/cluster/k8s/kyverno/policies/restrict-agent-gateway-routes.yaml
@@ -1,0 +1,63 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-agent-gateway-routes
+  annotations:
+    policies.kyverno.io/title: Restrict Agent Gateway API Routes
+    policies.kyverno.io/category: Access Control
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/subject: HTTPRoute, TLSRoute, TCPRoute, UDPRoute, GRPCRoute, Gateway
+    policies.kyverno.io/description: >-
+      Blocks creation/modification of any Gateway API route (HTTPRoute, TLSRoute,
+      TCPRoute, UDPRoute, GRPCRoute) or Gateway in the agent-writable sandbox
+      namespaces (claude-sandbox, haku-sandbox, openclaw-sandbox,
+      openhands-sandboxes). The public `cluster-gateway` listeners use
+      `allowedRoutes.namespaces.from: All`, so without this fence an agent that
+      gained `httproutes`/`gateways` RBAC could publish a route that attaches to
+      the public gateway and bypasses the operator-owned Authentik proxy. Agents
+      have no legitimate need to create routes — their sandbox Roles already omit
+      these resources — so a blanket deny in those namespaces closes the latent
+      hole structurally without touching any existing route (none live in a
+      sandbox namespace). This denylist is preferred over per-listener
+      `allowedRoutes` selectors because the public gateway's listener-level
+      `allowedRoutes` is affected by Cilium bug #42159 (see
+      cluster/docs/plan.md), and the Selector approach would require labeling the
+      built-in `default` and `flux-system` namespaces that host critical routes.
+spec:
+  admission: true
+  # background: false because the policy scopes by namespace only (no subject
+  # match), so it does not need request.userInfo; admission-time enforcement is
+  # what matters for the GitOps + agent threat model.
+  background: false
+  validationFailureAction: Enforce
+  rules:
+    - name: deny-routes-in-agent-namespaces
+      match:
+        any:
+          # Bare kind names (not Group/Version/Kind-pinned) so the deny matches
+          # every served apiVersion — an agent can't evade by submitting a route
+          # at v1beta1/v1alpha2 instead of v1. These kind names are unique to the
+          # gateway.networking.k8s.io group, so no disambiguation is needed.
+          - resources:
+              kinds:
+                - HTTPRoute
+                - GRPCRoute
+                - TLSRoute
+                - TCPRoute
+                - UDPRoute
+                - Gateway
+              operations:
+                - CREATE
+                - UPDATE
+              namespaces:
+                - claude-sandbox
+                - haku-sandbox
+                - openclaw-sandbox
+                - openhands-sandboxes
+      validate:
+        message: >-
+          Gateway API routes and Gateways may not be created in agent sandbox
+          namespaces. Public ingress is operator-owned: route through the
+          Authentik proxy (HTTPRoutes in the `authentik` namespace) instead.
+          Resource: {{request.object.kind}}/{{request.object.metadata.name}}
+        deny: {}

--- a/cluster/validation/test_kyverno_policies.py
+++ b/cluster/validation/test_kyverno_policies.py
@@ -37,6 +37,32 @@ def mitmproxy_policy() -> Path:
     return _policy_path("cluster/k8s/kyverno/policies/inject-mitmproxy.yaml")
 
 
+@pytest.fixture
+def agent_gateway_routes_policy() -> Path:
+    return _policy_path("cluster/k8s/kyverno/policies/restrict-agent-gateway-routes.yaml")
+
+
+class TestRestrictAgentGatewayRoutes:
+    """The deny policy fences agents off the public gateway.
+
+    Namespace-scoped (no subject match), so it is testable with plain
+    `kyverno apply` — no admission --userinfo context needed.
+    """
+
+    def test_httproute_in_agent_namespace_denied(self, agent_gateway_routes_policy: Path):
+        result = apply_policy(agent_gateway_routes_policy, _testdata("httproute_in_agent_namespace.yaml"))
+        assert result.failed == 1, f"HTTPRoute in claude-sandbox must be denied\n{result.stdout}"
+
+    def test_tlsroute_in_agent_namespace_denied(self, agent_gateway_routes_policy: Path):
+        result = apply_policy(agent_gateway_routes_policy, _testdata("tlsroute_in_agent_namespace.yaml"))
+        assert result.failed == 1, f"TLSRoute in haku-sandbox must be denied\n{result.stdout}"
+
+    def test_httproute_in_service_namespace_allowed(self, agent_gateway_routes_policy: Path):
+        """Routes in non-agent (operator-owned) namespaces are untouched."""
+        result = apply_policy(agent_gateway_routes_policy, _testdata("httproute_in_service_namespace.yaml"))
+        assert result.failed == 0, f"HTTPRoute in forgejo must not be denied\n{result.stdout}"
+
+
 class TestInjectMitmproxyProxy:
     """Tests for the inject-mitmproxy-proxy ClusterPolicy."""
 

--- a/cluster/validation/testdata/kyverno/httproute_in_agent_namespace.yaml
+++ b/cluster/validation/testdata/kyverno/httproute_in_agent_namespace.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: agent-escape
+  namespace: claude-sandbox
+spec:
+  parentRefs:
+    - name: cluster-gateway
+      namespace: gateway-system
+  hostnames:
+    - "agent-escape.allegedly.works"
+  rules:
+    - backendRefs:
+        - name: agent-backdoor
+          port: 8080

--- a/cluster/validation/testdata/kyverno/httproute_in_service_namespace.yaml
+++ b/cluster/validation/testdata/kyverno/httproute_in_service_namespace.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: legit-service
+  namespace: forgejo
+spec:
+  parentRefs:
+    - name: cluster-gateway
+      namespace: gateway-system
+  hostnames:
+    - "git.allegedly.works"
+  rules:
+    - backendRefs:
+        - name: forgejo-http
+          port: 3000

--- a/cluster/validation/testdata/kyverno/tlsroute_in_agent_namespace.yaml
+++ b/cluster/validation/testdata/kyverno/tlsroute_in_agent_namespace.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: agent-tls-escape
+  namespace: haku-sandbox
+spec:
+  parentRefs:
+    - name: cluster-gateway
+      namespace: gateway-system
+  hostnames:
+    - "agent-tls-escape.allegedly.works"
+  rules:
+    - backendRefs:
+        - name: agent-backdoor
+          port: 8443


### PR DESCRIPTION
Closes the `cluster/k8s/TODO.md` "restrict cluster-gateway allowedRoutes" item. **Not auto-merged — for operator review.**

## What & why
The public `cluster-gateway` listeners are `allowedRoutes: namespaces: from: All`, so a route in any namespace can attach to the public gateway and bypass the Authentik proxy. Today agents can't exploit it (their `*-sandbox-admin` Roles omit `httproutes`/`gateways`), but it's a latent hole. This adds a Kyverno `ClusterPolicy` (`restrict-agent-gateway-routes`, **Enforce**) that **denies CREATE/UPDATE of HTTPRoute/GRPCRoute/TLSRoute/TCPRoute/UDPRoute/Gateway in the agent sandbox namespaces** (`claude-sandbox`, `haku-sandbox`, `openclaw-sandbox`, `openhands-sandboxes`). Bare kind names so an agent can't evade via a different apiVersion.

## Why a denylist instead of `allowedRoutes` Selector
Enumerated all 57 route objects attaching to `cluster-gateway` — none live in an agent namespace, so the deny breaks **zero** existing routes. The Selector approach was rejected as higher-risk:
1. The kube-API routes (`kubeapi-allegedly-works` HTTPRoute, `kube-api-passthrough` TLSRoute — the path agents use to reach the cluster) live in the built-in **`default`** namespace, which has no in-repo `Namespace` manifest; `flux-system`'s route namespace is likewise not a normal in-repo namespace. Labeling these built-ins is risky.
2. **Cilium bug #42159** (see `cluster/docs/plan.md`): per-listener `allowedRoutes` config bleeds across listeners in this Cilium 1.19.2 / Gateway API v1.5.1 setup, so changing the live public gateway's listener `allowedRoutes` is riskier than on stock Gateway API.

The denylist touches only the 4 agent namespaces and closes the hole structurally.

## Coverage
- **Denied:** `claude-sandbox`, `haku-sandbox`, `openclaw-sandbox`, `openhands-sandboxes` (all full-CRUD core/apps/batch, no gateway resources, no routes today).
- **Unaffected:** all 57 routes (authentik proxy-routes, default kube-API, flux-system, gateway-system redirect, and ~30 service namespaces). The policy never matches them.

## Validation
- `bbr test //cluster/validation:test_kyverno_policies` **passes** — new tests run the policy through the kyverno CLI and prove it denies an HTTPRoute/TLSRoute in an agent namespace and allows one in a service namespace.
- `bbr test //cluster/...` green (kubeconform, crd-layering, flux, etc.); pre-commit clean.
- `gateway.yaml` left as `from: All` with an inline comment documenting the rationale (no live-gateway change).

## Flagged for review
- **Policy starts in `Enforce`** (existing `require-gitops` started in `Audit`). Safe since no agent route exists to break, but you may prefer `Audit` first.
- **Pre-existing dangling route (not from this change):** `docker-ci` TLSRoute references a removed listener (`sectionName: docker-ci-tls`, removed in `8ac660457e` per Cilium #42159) — already can't attach; restoration is an open TODO in `plan.md`.

(Designed/drafted by a delegated agent; reviewed, rebased onto current `devel`, validated, and shipped by me.)