### PR TITLE
debundle: add backend solver entry point

### DIFF
--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -1115,6 +1115,32 @@ rust_test(
 )
 
 rust_library(
+    name = "selector_backend_solver",
+    srcs = ["selector_backend_solver.rs"],
+    edition = "2024",
+    deps = [
+        ":analysis",
+        ":selector_constraint_backend",
+        ":selector_constraint_model",
+        ":selector_constraint_model_builder",
+        ":selector_ir",
+    ],
+)
+
+rust_test(
+    name = "selector_backend_solver_test",
+    size = "small",
+    crate = ":selector_backend_solver",
+    edition = "2024",
+    deps = [
+        ":analysis",
+        ":selector_constraint_backend",
+        ":selector_constraint_model",
+        ":selector_ir",
+    ],
+)
+
+rust_library(
     name = "selector_ir_lowering",
     srcs = ["selector_ir_lowering.rs"],
     edition = "2024",

--- a/devinfra/js/debundle/selector_backend_solver.rs
+++ b/devinfra/js/debundle/selector_backend_solver.rs
@@ -1,0 +1,692 @@
+//! Backend-backed selector solver entry point.
+//!
+//! This module is the narrow bridge from selector IR/facts to a finite-domain
+//! backend. It does not choose assignments itself: it lowers to
+//! `SelectorBackendProblem`, calls a `SelectorConstraintBackend`, and decodes
+//! the backend's assignment into the existing materializer-facing `SolverResult`.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::error::Error;
+use std::fmt;
+
+use analysis::{OwnerId, StatementOrdinal};
+use selector_constraint_backend::{
+    BackendAssignment, BackendAssignmentCoverage, BackendAssignmentError, BackendSolveResult,
+    BackendSolveStatus, SelectorBackendProblem, SelectorBackendProblemError,
+    SelectorConstraintBackend,
+};
+use selector_constraint_model::{ConstraintValue, ConstraintVariableId};
+use selector_constraint_model_builder::{
+    SelectorConstraintModelBuildError, build_selector_constraint_model,
+};
+use selector_ir::{
+    ClaimKind, ClaimOutcome, ResolvedClaim, SelectorFact, SelectorFactStore, SelectorProgram,
+    SelectorTargetId, SolverClaim, SolverResult,
+};
+
+pub fn build_backend_problem(
+    program: &SelectorProgram,
+    facts: &SelectorFactStore,
+) -> Result<SelectorBackendProblem, SelectorBackendProblemBuildError> {
+    let model = build_selector_constraint_model(program, facts)
+        .map_err(SelectorBackendProblemBuildError::Model)?;
+    SelectorBackendProblem::from_model(&model)
+        .map_err(SelectorBackendProblemBuildError::BackendProblem)
+}
+
+pub fn solve_with_backend<B>(
+    program: &SelectorProgram,
+    facts: &SelectorFactStore,
+    backend: &B,
+) -> Result<SolverResult, SelectorBackendSolveError<B::Error>>
+where
+    B: SelectorConstraintBackend,
+{
+    let problem =
+        build_backend_problem(program, facts).map_err(SelectorBackendSolveError::Build)?;
+    let result = backend
+        .solve(&problem)
+        .map_err(SelectorBackendSolveError::Backend)?;
+    decode_backend_result(program, facts, &problem, result)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SelectorBackendProblemBuildError {
+    Model(SelectorConstraintModelBuildError),
+    BackendProblem(SelectorBackendProblemError),
+}
+
+impl fmt::Display for SelectorBackendProblemBuildError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Model(err) => write!(f, "failed to build selector constraint model: {err}"),
+            Self::BackendProblem(err) => {
+                write!(f, "failed to build selector backend problem: {err}")
+            }
+        }
+    }
+}
+
+impl Error for SelectorBackendProblemBuildError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Model(err) => Some(err),
+            Self::BackendProblem(err) => Some(err),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SelectorBackendSolveError<E> {
+    Build(SelectorBackendProblemBuildError),
+    Backend(E),
+    Assignment(BackendAssignmentError),
+    MissingTargetProjection {
+        target: SelectorTargetId,
+    },
+    MissingAssignmentVariable {
+        variable: ConstraintVariableId,
+    },
+    DecodedAssignmentDomainMismatch {
+        variable: ConstraintVariableId,
+        expected: &'static str,
+        actual: ConstraintValue,
+    },
+    MissingOwnerFact {
+        owner: OwnerId,
+    },
+    EmptySatisfyingAssignments {
+        status: BackendSolveStatus,
+    },
+    UnsatReturnedAssignments,
+}
+
+impl<E: fmt::Display> fmt::Display for SelectorBackendSolveError<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Build(err) => write!(f, "{err}"),
+            Self::Backend(err) => write!(f, "selector backend failed: {err}"),
+            Self::Assignment(err) => {
+                write!(f, "selector backend returned invalid assignment: {err}")
+            }
+            Self::MissingTargetProjection { target } => {
+                write!(
+                    f,
+                    "selector backend problem has no projection for target {target:?}"
+                )
+            }
+            Self::MissingAssignmentVariable { variable } => {
+                write!(
+                    f,
+                    "selector backend assignment has no value for variable {variable:?}"
+                )
+            }
+            Self::DecodedAssignmentDomainMismatch {
+                variable,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "selector backend assignment gave variable {variable:?} a {actual:?} value, expected {expected}"
+            ),
+            Self::MissingOwnerFact { owner } => {
+                write!(
+                    f,
+                    "selector backend assignment selected owner {owner:?} without an owner fact"
+                )
+            }
+            Self::EmptySatisfyingAssignments { status } => {
+                write!(
+                    f,
+                    "selector backend returned {status:?} with no assignments"
+                )
+            }
+            Self::UnsatReturnedAssignments => {
+                write!(
+                    f,
+                    "selector backend returned unsatisfiable with assignments"
+                )
+            }
+        }
+    }
+}
+
+impl<E> Error for SelectorBackendSolveError<E>
+where
+    E: Error + 'static,
+{
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Build(err) => Some(err),
+            Self::Backend(err) => Some(err),
+            Self::Assignment(err) => Some(err),
+            Self::MissingTargetProjection { .. }
+            | Self::MissingAssignmentVariable { .. }
+            | Self::DecodedAssignmentDomainMismatch { .. }
+            | Self::MissingOwnerFact { .. }
+            | Self::EmptySatisfyingAssignments { .. }
+            | Self::UnsatReturnedAssignments => None,
+        }
+    }
+}
+
+fn decode_backend_result<E>(
+    program: &SelectorProgram,
+    facts: &SelectorFactStore,
+    problem: &SelectorBackendProblem,
+    result: BackendSolveResult,
+) -> Result<SolverResult, SelectorBackendSolveError<E>> {
+    match result.status {
+        BackendSolveStatus::Unsatisfiable => {
+            if !result.assignments.is_empty() {
+                return Err(SelectorBackendSolveError::UnsatReturnedAssignments);
+            }
+            Ok(no_match_result(program))
+        }
+        BackendSolveStatus::Unknown => Ok(unsupported_result(
+            program,
+            result
+                .diagnostic
+                .unwrap_or_else(|| "selector backend returned unknown".to_string()),
+        )),
+        BackendSolveStatus::Satisfiable | BackendSolveStatus::Ambiguous => {
+            if result.assignment_coverage != BackendAssignmentCoverage::TargetSupportComplete {
+                return Ok(unsupported_result(
+                    program,
+                    result.diagnostic.unwrap_or_else(|| {
+                        "selector backend returned sample assignments, not complete target support"
+                            .to_string()
+                    }),
+                ));
+            }
+            if result.assignments.is_empty() {
+                return Err(SelectorBackendSolveError::EmptySatisfyingAssignments {
+                    status: result.status,
+                });
+            }
+            decode_satisfying_assignments(program, facts, problem, &result.assignments)
+        }
+    }
+}
+
+fn decode_satisfying_assignments<E>(
+    program: &SelectorProgram,
+    facts: &SelectorFactStore,
+    problem: &SelectorBackendProblem,
+    assignments: &[BackendAssignment],
+) -> Result<SolverResult, SelectorBackendSolveError<E>> {
+    let facts = MaterializationFacts::from_store(facts);
+    let projections = problem
+        .target_projections
+        .iter()
+        .map(|projection| (projection.target, projection))
+        .collect::<BTreeMap<_, _>>();
+    let mut claims_by_target: BTreeMap<SelectorTargetId, Vec<ResolvedClaim>> = BTreeMap::new();
+
+    for assignment in assignments {
+        let decoded = problem
+            .decode_assignment(assignment)
+            .map_err(SelectorBackendSolveError::Assignment)?;
+        for target in &program.targets {
+            let projection = projections
+                .get(&target.id)
+                .ok_or(SelectorBackendSolveError::MissingTargetProjection { target: target.id })?;
+            let owner = assigned_owner(&decoded, projection.owner_variable)?;
+            let binding = if let Some(binding_const) = &projection.binding_const {
+                Some(binding_const.clone())
+            } else if let Some(binding_variable) = projection.binding_variable {
+                Some(assigned_string(&decoded, binding_variable)?)
+            } else {
+                facts
+                    .single_binding_for_owner(owner)
+                    .map(ToString::to_string)
+            };
+            if matches!(
+                target.claim,
+                ClaimKind::Binding { .. } | ClaimKind::BindingGroupMember { .. }
+            ) && binding.is_none()
+            {
+                continue;
+            }
+            let statement_ordinal = facts
+                .statement_ordinal_by_owner
+                .get(&owner)
+                .copied()
+                .ok_or(SelectorBackendSolveError::MissingOwnerFact { owner })?;
+            let claim = ResolvedClaim {
+                chunk_id: target.chunk_id,
+                owner,
+                statement_ordinal,
+                binding,
+                provenance: Vec::new(),
+            };
+            let claims = claims_by_target.entry(target.id).or_default();
+            if !claims.contains(&claim) {
+                claims.push(claim);
+            }
+        }
+    }
+
+    Ok(SolverResult {
+        claims: program
+            .targets
+            .iter()
+            .map(|target| SolverClaim {
+                target: target.id,
+                outcome: claims_to_outcome(claims_by_target.remove(&target.id).unwrap_or_default()),
+            })
+            .collect(),
+    })
+}
+
+fn assigned_owner<E>(
+    assignment: &BTreeMap<ConstraintVariableId, ConstraintValue>,
+    variable: ConstraintVariableId,
+) -> Result<OwnerId, SelectorBackendSolveError<E>> {
+    match assignment.get(&variable) {
+        Some(ConstraintValue::Owner(owner)) => Ok(*owner),
+        Some(value) => Err(SelectorBackendSolveError::DecodedAssignmentDomainMismatch {
+            variable,
+            expected: "owner",
+            actual: value.clone(),
+        }),
+        None => Err(SelectorBackendSolveError::MissingAssignmentVariable { variable }),
+    }
+}
+
+fn assigned_string<E>(
+    assignment: &BTreeMap<ConstraintVariableId, ConstraintValue>,
+    variable: ConstraintVariableId,
+) -> Result<String, SelectorBackendSolveError<E>> {
+    match assignment.get(&variable) {
+        Some(ConstraintValue::String(value)) => Ok(value.clone()),
+        Some(value) => Err(SelectorBackendSolveError::DecodedAssignmentDomainMismatch {
+            variable,
+            expected: "string",
+            actual: value.clone(),
+        }),
+        None => Err(SelectorBackendSolveError::MissingAssignmentVariable { variable }),
+    }
+}
+
+fn claims_to_outcome(claims: Vec<ResolvedClaim>) -> ClaimOutcome {
+    match claims.as_slice() {
+        [] => ClaimOutcome::NoMatch,
+        [claim] => ClaimOutcome::Unique {
+            claim: claim.clone(),
+        },
+        _ => ClaimOutcome::Ambiguous { candidates: claims },
+    }
+}
+
+fn no_match_result(program: &SelectorProgram) -> SolverResult {
+    SolverResult {
+        claims: program
+            .targets
+            .iter()
+            .map(|target| SolverClaim {
+                target: target.id,
+                outcome: ClaimOutcome::NoMatch,
+            })
+            .collect(),
+    }
+}
+
+fn unsupported_result(program: &SelectorProgram, message: String) -> SolverResult {
+    SolverResult {
+        claims: program
+            .targets
+            .iter()
+            .map(|target| SolverClaim {
+                target: target.id,
+                outcome: ClaimOutcome::Unsupported {
+                    message: message.clone(),
+                },
+            })
+            .collect(),
+    }
+}
+
+#[derive(Debug, Default)]
+struct MaterializationFacts {
+    statement_ordinal_by_owner: BTreeMap<OwnerId, StatementOrdinal>,
+    bindings_by_owner: BTreeMap<OwnerId, BTreeSet<String>>,
+}
+
+impl MaterializationFacts {
+    fn from_store(facts: &SelectorFactStore) -> Self {
+        let mut index = Self::default();
+        for fact in &facts.facts {
+            match fact {
+                SelectorFact::Owner {
+                    owner,
+                    statement_ordinal,
+                    ..
+                } => {
+                    index
+                        .statement_ordinal_by_owner
+                        .insert(*owner, *statement_ordinal);
+                }
+                SelectorFact::DeclaredBinding { owner, binding, .. } => {
+                    index
+                        .bindings_by_owner
+                        .entry(*owner)
+                        .or_default()
+                        .insert(binding.clone());
+                }
+                _ => {}
+            }
+        }
+        index
+    }
+
+    fn single_binding_for_owner(&self, owner: OwnerId) -> Option<&str> {
+        let mut bindings = self.bindings_by_owner.get(&owner)?.iter();
+        let binding = bindings.next()?;
+        bindings.next().is_none().then_some(binding.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::Infallible;
+
+    use analysis::{ChunkId, OwnerId, StatementOrdinal};
+    use selector_constraint_backend::{
+        BackendAssignment, BackendAssignmentCoverage, BackendSolveResult, BackendSolveStatus,
+        BackendValueId, BackendVariableAssignment,
+    };
+    use selector_constraint_model::ConstraintValue;
+    use selector_ir::{ClaimOrigin, OwnerTerm, SelectorAtom, StringTerm, VariableDomain};
+
+    use super::*;
+
+    #[derive(Debug)]
+    struct SelectingBackend {
+        assignments: Vec<Vec<(ConstraintVariableId, ConstraintValue)>>,
+        coverage: BackendAssignmentCoverage,
+        status: BackendSolveStatus,
+    }
+
+    impl SelectorConstraintBackend for SelectingBackend {
+        type Error = Infallible;
+
+        fn solve(
+            &self,
+            problem: &SelectorBackendProblem,
+        ) -> Result<BackendSolveResult, Self::Error> {
+            let mut assignments = Vec::new();
+            for assignment in &self.assignments {
+                assignments.push(BackendAssignment {
+                    values: assignment
+                        .iter()
+                        .map(|(variable, value)| BackendVariableAssignment {
+                            variable: *variable,
+                            value: backend_value_for(problem, value),
+                        })
+                        .collect(),
+                });
+            }
+            Ok(BackendSolveResult {
+                status: self.status.clone(),
+                assignment_coverage: self.coverage,
+                assignments,
+                diagnostic: None,
+            })
+        }
+    }
+
+    fn backend_value_for(
+        problem: &SelectorBackendProblem,
+        value: &ConstraintValue,
+    ) -> BackendValueId {
+        let index = problem
+            .value_dictionary
+            .iter()
+            .position(|candidate| candidate == value)
+            .expect("test backend value must be in dictionary");
+        BackendValueId(index.try_into().unwrap())
+    }
+
+    fn owner(value: usize) -> ConstraintValue {
+        ConstraintValue::Owner(OwnerId(value))
+    }
+
+    fn string(value: &str) -> ConstraintValue {
+        ConstraintValue::String(value.to_string())
+    }
+
+    fn owner_fact(owner: OwnerId, ordinal: usize, kind: &str) -> SelectorFact {
+        SelectorFact::Owner {
+            chunk_id: ChunkId(0),
+            owner,
+            statement_ordinal: StatementOrdinal(ordinal),
+            statement_kind: kind.to_string(),
+        }
+    }
+
+    fn binding_fact(owner: OwnerId, binding: &str, export_name: &str) -> SelectorFact {
+        SelectorFact::DeclaredBinding {
+            chunk_id: ChunkId(0),
+            owner,
+            binding: binding.to_string(),
+            export_name: Some(export_name.to_string()),
+        }
+    }
+
+    fn binding_program() -> (SelectorProgram, SelectorTargetId) {
+        let mut program = SelectorProgram::default();
+        let owner = program.add_variable(VariableDomain::Owner, Some("owner".to_string()));
+        let binding = program.add_variable(VariableDomain::String, Some("binding".to_string()));
+        let target = program.add_target(
+            ChunkId(0),
+            owner,
+            "module",
+            ClaimKind::Binding {
+                export_name: Some("Readable".to_string()),
+            },
+            ClaimOrigin::Synthetic,
+        );
+        program.add_atom(SelectorAtom::OwnerDeclaresBinding {
+            owner: OwnerTerm::Var { id: owner },
+            binding: StringTerm::Var { id: binding },
+        });
+        program.add_atom(SelectorAtom::OwnerExportName {
+            owner: OwnerTerm::Var { id: owner },
+            export_name: StringTerm::Const {
+                value: "Readable".to_string(),
+            },
+        });
+        (program, target)
+    }
+
+    fn const_binding_program() -> (SelectorProgram, SelectorTargetId) {
+        let mut program = SelectorProgram::default();
+        let owner = program.add_variable(VariableDomain::Owner, Some("owner".to_string()));
+        let target = program.add_target(
+            ChunkId(0),
+            owner,
+            "module",
+            ClaimKind::Binding {
+                export_name: Some("Readable".to_string()),
+            },
+            ClaimOrigin::Synthetic,
+        );
+        program.add_atom(SelectorAtom::OwnerDeclaresBinding {
+            owner: OwnerTerm::Var { id: owner },
+            binding: StringTerm::Const {
+                value: "minA".to_string(),
+            },
+        });
+        (program, target)
+    }
+
+    fn facts() -> SelectorFactStore {
+        let mut facts = SelectorFactStore::default();
+        facts.push(owner_fact(OwnerId(1), 10, "function"));
+        facts.push(binding_fact(OwnerId(1), "minA", "Readable"));
+        facts.push(owner_fact(OwnerId(2), 20, "function"));
+        facts.push(binding_fact(OwnerId(2), "minB", "Other"));
+        facts
+    }
+
+    #[test]
+    fn builds_backend_problem_from_selector_program() {
+        let (program, target) = binding_program();
+        let problem = build_backend_problem(&program, &facts()).unwrap();
+
+        assert_eq!(problem.variables.len(), 2);
+        assert_eq!(problem.target_projections[0].target, target);
+        assert_eq!(
+            problem.target_projections[0].owner_variable,
+            ConstraintVariableId(0)
+        );
+        assert_eq!(
+            problem.target_projections[0].binding_variable,
+            Some(ConstraintVariableId(1))
+        );
+        assert_eq!(problem.target_projections[0].binding_const, None);
+        assert!(
+            problem
+                .value_dictionary
+                .contains(&ConstraintValue::Owner(OwnerId(1)))
+        );
+        assert!(
+            problem
+                .value_dictionary
+                .contains(&ConstraintValue::String("minA".to_string()))
+        );
+    }
+
+    #[test]
+    fn backend_problem_preserves_constant_binding_projection() {
+        let (program, target) = const_binding_program();
+        let problem = build_backend_problem(&program, &facts()).unwrap();
+
+        assert_eq!(problem.target_projections[0].target, target);
+        assert_eq!(problem.target_projections[0].binding_variable, None);
+        assert_eq!(
+            problem.target_projections[0].binding_const.as_deref(),
+            Some("minA")
+        );
+    }
+
+    #[test]
+    fn backend_assignment_decodes_to_solver_result() {
+        let (program, target) = binding_program();
+        let backend = SelectingBackend {
+            status: BackendSolveStatus::Satisfiable,
+            coverage: BackendAssignmentCoverage::TargetSupportComplete,
+            assignments: vec![vec![
+                (ConstraintVariableId(0), owner(1)),
+                (ConstraintVariableId(1), string("minA")),
+            ]],
+        };
+
+        let result = solve_with_backend(&program, &facts(), &backend).unwrap();
+
+        assert_eq!(
+            result.outcome_for(target),
+            Some(&ClaimOutcome::Unique {
+                claim: ResolvedClaim {
+                    chunk_id: ChunkId(0),
+                    owner: OwnerId(1),
+                    statement_ordinal: StatementOrdinal(10),
+                    binding: Some("minA".to_string()),
+                    provenance: Vec::new(),
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn constant_binding_projection_decodes_without_binding_variable() {
+        let (program, target) = const_binding_program();
+        let backend = SelectingBackend {
+            status: BackendSolveStatus::Satisfiable,
+            coverage: BackendAssignmentCoverage::TargetSupportComplete,
+            assignments: vec![vec![(ConstraintVariableId(0), owner(1))]],
+        };
+
+        let result = solve_with_backend(&program, &facts(), &backend).unwrap();
+
+        assert_eq!(
+            result.outcome_for(target),
+            Some(&ClaimOutcome::Unique {
+                claim: ResolvedClaim {
+                    chunk_id: ChunkId(0),
+                    owner: OwnerId(1),
+                    statement_ordinal: StatementOrdinal(10),
+                    binding: Some("minA".to_string()),
+                    provenance: Vec::new(),
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn multiple_backend_assignments_become_ambiguous_claims() {
+        let (program, target) = binding_program();
+        let backend = SelectingBackend {
+            status: BackendSolveStatus::Ambiguous,
+            coverage: BackendAssignmentCoverage::TargetSupportComplete,
+            assignments: vec![
+                vec![
+                    (ConstraintVariableId(0), owner(1)),
+                    (ConstraintVariableId(1), string("minA")),
+                ],
+                vec![
+                    (ConstraintVariableId(0), owner(2)),
+                    (ConstraintVariableId(1), string("minB")),
+                ],
+            ],
+        };
+
+        let result = solve_with_backend(&program, &facts(), &backend).unwrap();
+
+        match result.outcome_for(target) {
+            Some(ClaimOutcome::Ambiguous { candidates }) => {
+                assert_eq!(candidates.len(), 2);
+                assert!(candidates.iter().any(|claim| claim.owner == OwnerId(1)));
+                assert!(candidates.iter().any(|claim| claim.owner == OwnerId(2)));
+            }
+            other => panic!("expected ambiguous backend result, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unsat_backend_result_maps_to_no_match() {
+        let (program, target) = binding_program();
+        let backend = SelectingBackend {
+            status: BackendSolveStatus::Unsatisfiable,
+            coverage: BackendAssignmentCoverage::Sample,
+            assignments: Vec::new(),
+        };
+
+        let result = solve_with_backend(&program, &facts(), &backend).unwrap();
+
+        assert_eq!(result.outcome_for(target), Some(&ClaimOutcome::NoMatch));
+    }
+
+    #[test]
+    fn sample_backend_assignment_maps_to_unsupported_not_unique() {
+        let (program, target) = binding_program();
+        let backend = SelectingBackend {
+            status: BackendSolveStatus::Satisfiable,
+            coverage: BackendAssignmentCoverage::Sample,
+            assignments: vec![vec![
+                (ConstraintVariableId(0), owner(1)),
+                (ConstraintVariableId(1), string("minA")),
+            ]],
+        };
+
+        let result = solve_with_backend(&program, &facts(), &backend).unwrap();
+
+        match result.outcome_for(target) {
+            Some(ClaimOutcome::Unsupported { message }) => {
+                assert!(message.contains("sample assignments"));
+            }
+            other => panic!("expected unsupported sample backend result, got {other:?}"),
+        }
+    }
+}

--- a/devinfra/js/debundle/selector_constraint_backend.rs
+++ b/devinfra/js/debundle/selector_constraint_backend.rs
@@ -58,6 +58,8 @@ pub struct BackendTargetProjection {
     pub owner_variable: ConstraintVariableId,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub binding_variable: Option<ConstraintVariableId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub binding_const: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -160,6 +162,7 @@ impl SelectorBackendProblem {
                     target: projection.target,
                     owner_variable: projection.owner_variable,
                     binding_variable: projection.binding_variable,
+                    binding_const: projection.binding_const.clone(),
                 })
                 .collect(),
             allowed_tuples,
@@ -247,9 +250,23 @@ pub enum BackendSolveStatus {
     Unknown,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BackendAssignmentCoverage {
+    /// Returned assignments are examples only. They must not be used to classify
+    /// selector claims as unique or ambiguous.
+    #[default]
+    Sample,
+    /// Returned assignments cover every owner/binding support value that any
+    /// target projection can take across all satisfying global assignments.
+    TargetSupportComplete,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BackendSolveResult {
     pub status: BackendSolveStatus,
+    #[serde(default)]
+    pub assignment_coverage: BackendAssignmentCoverage,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub assignments: Vec<BackendAssignment>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/devinfra/js/debundle/selector_constraint_model.rs
+++ b/devinfra/js/debundle/selector_constraint_model.rs
@@ -61,6 +61,8 @@ pub struct TargetProjection {
     pub owner_variable: ConstraintVariableId,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub binding_variable: Option<ConstraintVariableId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub binding_const: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -151,6 +153,24 @@ impl SelectorConstraintModel {
         owner_variable: ConstraintVariableId,
         binding_variable: Option<ConstraintVariableId>,
     ) -> Result<(), ConstraintModelError> {
+        self.add_target_projection_with_binding_const(
+            target,
+            owner_variable,
+            binding_variable,
+            None,
+        )
+    }
+
+    pub fn add_target_projection_with_binding_const(
+        &mut self,
+        target: SelectorTargetId,
+        owner_variable: ConstraintVariableId,
+        binding_variable: Option<ConstraintVariableId>,
+        binding_const: Option<String>,
+    ) -> Result<(), ConstraintModelError> {
+        if binding_variable.is_some() && binding_const.is_some() {
+            return Err(ConstraintModelError::ConflictingTargetBindingProjection { target });
+        }
         self.require_domain(owner_variable, VariableDomain::Owner)?;
         if let Some(binding_variable) = binding_variable {
             self.require_domain(binding_variable, VariableDomain::String)?;
@@ -166,6 +186,7 @@ impl SelectorConstraintModel {
             target,
             owner_variable,
             binding_variable,
+            binding_const,
         });
         Ok(())
     }
@@ -241,6 +262,11 @@ impl SelectorConstraintModel {
             self.require_domain(projection.owner_variable, VariableDomain::Owner)?;
             if let Some(binding_variable) = projection.binding_variable {
                 self.require_domain(binding_variable, VariableDomain::String)?;
+            }
+            if projection.binding_variable.is_some() && projection.binding_const.is_some() {
+                return Err(ConstraintModelError::ConflictingTargetBindingProjection {
+                    target: projection.target,
+                });
             }
             if !targets.insert(projection.target) {
                 return Err(ConstraintModelError::DuplicateTargetProjection {
@@ -516,6 +542,9 @@ pub enum ConstraintModelError {
     DuplicateTargetProjection {
         target: SelectorTargetId,
     },
+    ConflictingTargetBindingProjection {
+        target: SelectorTargetId,
+    },
     UnknownTargetProjection {
         target: SelectorTargetId,
     },
@@ -612,6 +641,10 @@ impl fmt::Display for ConstraintModelError {
             Self::DuplicateTargetProjection { target } => {
                 write!(f, "target {target:?} has multiple projections")
             }
+            Self::ConflictingTargetBindingProjection { target } => write!(
+                f,
+                "target {target:?} projects both a binding variable and a constant binding"
+            ),
             Self::UnknownTargetProjection { target } => {
                 write!(f, "target {target:?} has no model projection")
             }

--- a/devinfra/js/debundle/selector_constraint_model_builder.rs
+++ b/devinfra/js/debundle/selector_constraint_model_builder.rs
@@ -44,11 +44,18 @@ pub fn build_selector_constraint_model(
 
     for target in &program.targets {
         let owner_variable = model_variable(&variables, target.owner)?;
-        let binding_variable = target_binding_projections
-            .binding_variable(target.owner)
+        let binding_projection = target_binding_projections.binding_projection(target.owner);
+        let binding_variable = binding_projection
+            .and_then(TargetBindingProjection::variable)
             .map(|binding| model_variable(&variables, binding))
             .transpose()?;
-        model.add_target_projection(target.id, owner_variable, binding_variable)?;
+        let binding_const = binding_projection.and_then(TargetBindingProjection::constant);
+        model.add_target_projection_with_binding_const(
+            target.id,
+            owner_variable,
+            binding_variable,
+            binding_const,
+        )?;
     }
 
     for atom in &program.atoms {
@@ -398,10 +405,23 @@ impl TargetBindingProjections {
         }
     }
 
-    fn binding_variable(&self, owner: SelectorVariableId) -> Option<SelectorVariableId> {
-        match self.by_owner.get(&owner) {
-            Some(TargetBindingProjection::Var(binding)) => Some(*binding),
-            Some(TargetBindingProjection::Const(_)) | None => None,
+    fn binding_projection(&self, owner: SelectorVariableId) -> Option<&TargetBindingProjection> {
+        self.by_owner.get(&owner)
+    }
+}
+
+impl TargetBindingProjection {
+    fn variable(&self) -> Option<SelectorVariableId> {
+        match self {
+            Self::Var(binding) => Some(*binding),
+            Self::Const(_) => None,
+        }
+    }
+
+    fn constant(&self) -> Option<String> {
+        match self {
+            Self::Const(binding) => Some(binding.clone()),
+            Self::Var(_) => None,
         }
     }
 }
@@ -979,12 +999,20 @@ mod tests {
             ConstraintVariableId(0)
         );
         assert_eq!(model.target_projections[0].binding_variable, None);
+        assert_eq!(
+            model.target_projections[0].binding_const.as_deref(),
+            Some("shared")
+        );
         assert_eq!(model.target_projections[1].target, strict_target);
         assert_eq!(
             model.target_projections[1].owner_variable,
             ConstraintVariableId(1)
         );
         assert_eq!(model.target_projections[1].binding_variable, None);
+        assert_eq!(
+            model.target_projections[1].binding_const.as_deref(),
+            Some("specific")
+        );
         assert_eq!(model.binary_constraints, Vec::<BinaryConstraint>::new());
         assert_eq!(
             model.all_different,
@@ -1051,6 +1079,7 @@ mod tests {
             model.target_projections[0].binding_variable,
             Some(ConstraintVariableId(1))
         );
+        assert_eq!(model.target_projections[0].binding_const, None);
         assert_eq!(
             allowed_tuples_for(&model, &[ConstraintVariableId(0), ConstraintVariableId(1)]),
             &AllowedTupleConstraint {


### PR DESCRIPTION
## Summary

- add `selector_backend_solver`, a backend-backed entry point that lowers `SelectorProgram + SelectorFactStore` into `SelectorBackendProblem`, calls a `SelectorConstraintBackend`, and decodes results into the existing `SolverResult` shape
- preserve constant binding projections through `SelectorConstraintModel` and `SelectorBackendProblem` so backend decoding does not drop `OwnerDeclaresBinding(..., Const(...))` target bindings
- add `BackendAssignmentCoverage` so sample CP/SAT assignments cannot be misclassified as unique selector matches; the adapter only classifies assignments marked `target_support_complete`

## Why

This keeps the production seam aligned with `selector_ir_solver::solve(program, facts) -> SolverResult` while giving the CP/SAT path one coherent API to mature behind. It is intentionally not a production cutover yet; model-builder atom coverage still needs to catch up before this can replace the current Ascent-backed solver.

## Validation

- `nix develop -c pre-commit run --files devinfra/js/debundle/BUILD.bazel devinfra/js/debundle/selector_constraint_backend.rs devinfra/js/debundle/selector_constraint_model.rs devinfra/js/debundle/selector_constraint_model_builder.rs devinfra/js/debundle/selector_backend_solver.rs`
- `nix develop -c bbr test //devinfra/js/debundle:selector_constraint_model_test //devinfra/js/debundle:selector_constraint_model_builder_test //devinfra/js/debundle:selector_constraint_backend_test //devinfra/js/debundle:selector_backend_solver_test --cache_test_results=no --test_output=errors`
  - BuildBuddy invocation: https://app.buildbuddy.io/invocation/7bd2433c-b2f7-4fe5-a38b-271d533cf4ec