### PR TITLE
haku/console: trim shipped state from PLAN/TODO, dedup test app-construction

### DIFF
--- a/haku/PLAN.md
+++ b/haku/PLAN.md
@@ -122,124 +122,30 @@ scoped or proxied, never trusted to the agent's restraint.
 ## The agent-authored console (free-form UI behind a trusted boundary)
 
 Direction (operator, 2026-06-26): grow the console so **Haku authors more and more of
-it** — today operator-clickable `actions[]` + free-text feedback, evolving toward Haku
-writing arbitrary interactive UI (inputs, interlinked pages, TSX/JS) that records what
-the operator expressed into `haku-state` for Haku to reduce on its next run. The console
-stays the operator's interface _with_ Haku; Haku just gets to shape it.
+it** — from today's operator-clickable `actions[]` + feedback toward Haku writing
+arbitrary interactive UI, with the trusted console shrinking to just the security
+boundary. That boundary — the `haku-console` namespace split, and the low-privilege
+**trace tier** vs. the secret-holding, CSRF-gated **capability tier** — is built; see
+`console/README.md` for the current contract and
+`console/plans/free_form_ui_iframe.md` for the boundary doctrine and the free-form design.
 
-The hard constraint: the console must eventually hold secrets **Haku may not have** (the
-Claude Code web session bearer that launches the routine — see `TODO.md` → _Console_)
-and run privileged actions Haku itself can't. So agent-authored UI and the
-secret-holding trusted code must sit on opposite sides of a real boundary.
+Still to build:
 
-### Two boundaries, not one
-
-Different threats, different mechanisms — keep them distinct:
-
-- **Confidentiality / integrity (k8s layer).** Haku must not _read_ the console's secrets
-  or logs, nor _change_ its trusted code/perimeter without a PR. The existing agent RBAC
-  is already shaped for this: `cluster-diagnostics-reader` is **secret-free** (no
-  `secrets`/`pods/log`/`configmaps` cluster-wide; logs only in infra namespaces), so a
-  console in its **own namespace** is invisible to Haku for free. Today the console runs
-  **in `haku-sandbox`** (`haku-sandbox-admin` = full CRUD), so Haku can already read its
-  git secret and exec its pod — **no boundary exists yet.** Splitting it out is the
-  prerequisite for holding any agent-forbidden secret.
-- **Confused deputy (browser layer).** Agent-authored UI runs in the **operator's
-  authenticated browser**, same-origin with the console API and holding the Authentik
-  session. So agent JS needn't _read_ a secret to abuse it — it can _call the privileged
-  endpoint_ with the operator's authority. Hiding the secret server-side does nothing
-  here. This is the boundary that actually constrains "Haku writes arbitrary TSX," and
-  it's enforced in the browser (origin isolation), not in k8s.
-
-### Trust zones
-
-- **`haku-console` (trusted, new namespace).** Ducktape code, Bazel→GHCR→Flux — so its
-  code, its **capability allowlist**, and its secrets change only by a merged PR. Holds
-  the launch bearer; exposes the API (below); owns and renders privileged controls.
-  Because it's **reviewed/released ducktape code, not agent-driven, it does not sit
-  behind the `haku-mitmproxy` fence** — that fence exists to contain _the agent_; the
-  console is contained by code review + the PR gate, so it gets ordinary
-  (least-privilege) egress to reach the Claude Code web API. No `haku` RoleBinding → Haku
-  can't read its secrets/logs or patch it.
-- **Agent-UI render/sandbox (untrusted by construction).** Serves and runs the UI Haku
-  authored into `haku-state`. Holds no secrets; may stay in `haku-sandbox` (Haku owning
-  it costs nothing). In the 1b target it's a **separate browser origin**.
-- **Haku agent (`haku-sandbox`).** Authors UI + content into `haku-state`; reads back
-  traces. No access to the trusted side.
-- **`haku-state` git.** The shared medium: Haku writes content+UI, the console writes
-  operator traces, Haku reduces them.
-
-### The API split
-
-Two tiers the console treats completely differently:
-
-- **Trace API (low-priv).** Records operator-expressed intent into `haku-state`. Exposed
-  to agent-authored UI. **Grants Haku nothing new** — it already writes `haku-state`
-  directly — so it's cheap and broad; its only real property is _consent fidelity_ (did
-  the operator genuinely express this?), a UX/trust concern, not a confidentiality one.
-- **Capability API (high-priv).** Anything using a console-only secret or acting on the
-  world (launch the routine). The teeth live here. Per capability: rendered/owned by the
-  **trusted shell** (never agent UI), fired only on a **genuine operator gesture** against
-  **trusted-rendered copy** (not agent free-text, so Haku can't phish consent),
-  CSRF-gated, and **audited** in the trusted namespace (the audit log doubles as the
-  "recent executions" view). The allowlist stays **tiny and PR-gated** — the standing
-  question per verb is "if Haku tricked the operator into firing this once, is the worst
-  case acceptable?" (Yes for _launch the routine_; a future _move money_ verb changes the
-  whole design.)
-
-### Phasing
-
-- **Phase 1 — declarative (1a).** A richer **typed widget schema** (containers, inputs,
-  selects, links, sub-pages) emitted in `haku-state` and interpreted by a **trusted
-  renderer** — _no agent JS executes_ — beyond today's `actions[]`. Still to build: an
-  in-console **executions panel** and a **one-in-flight guard**. Both want a
-  routine-runs-listing API — **none is known to exist** for `claude_code` routines
-  (only the `/fire` endpoint), so the interim "review past runs" affordance is the
-  deep-link to the routine's `claude.ai/code` page (built from the routine id alongside
-  the fire URL); each fire also returns its session deep-link. **When the listing API
-  surfaces and we build the panel, adopt the `anthropic` Python SDK** for the Anthropic
-  calls (it auto-sends the `anthropic-version` header — the omission that 502'd the
-  bare-`httpx` fire call — plus `auth_token` bearer, typed errors, and retries) and
-  migrate the `launch-routine` POST onto it at the same time.
-- **Phase 1b — free-form (the destination).** Haku runs **its own UI service** in
-  `haku-sandbox` (its Deployment, its choice of runtime, app code from `haku-state`, no
-  image build) and the console **embeds it in a cross-origin same-site iframe** — the
-  console never renders or even sees Haku's UI. The trusted shell shrinks to: hold the
-  bearer, own privileged actions, and frame the UI. Data + operator intent go straight to
-  Haku's own backend (it has the `haku-state` creds); a minimal `postMessage` bridge
-  carries only what needs trusted authority — **capability requests** (shell confirms +
-  fires) and **`openLink`** (shell vets scheme + host whitelist, confirms off-whitelist,
-  opens). Containment rests on
-  cross-origin isolation (the bearer is unreachable from any browser context), Haku's UI
-  being reachable **only** via the operator-owned **Authentik-gated** route (no public
-  exposure), and the agent being unable to create public routes (its RBAC allowlist omits
-  `httproutes`; harden the `from: All` gateway too). **North star (later):** even the
-  item model + its UI + styling/build/image-automation move out of ducktape into
-  agent-owned `haku-state` — Haku is given a high-level objective ("surface what's useful
-  to act on"), not a ducktape schema, and the shell keeps only the boundary (capability
-  tier, iframe host, protocol, CSP, top-layer confirm, perimeter); the trusted renderer +
-  trace tier retire. Full design + invariants + phasing:
+- **Richer declarative UI (1a).** A typed widget schema (containers, inputs, selects,
+  links, sub-pages) emitted in `haku-state` and interpreted by a trusted renderer —
+  _no agent JS_ — beyond today's `actions[]`. Plus an in-console **executions panel** + a
+  **one-in-flight guard**; both want a routine-runs-**listing** API, and **none is known
+  to exist** for `claude_code` routines (only `/fire`), so the interim "review past runs"
+  affordance is the deep-link to the routine's `claude.ai/code` page. When a listing API
+  surfaces and we build the panel, adopt the `anthropic` Python SDK (it auto-sends
+  `anthropic-version` — the omission that 502'd the bare-`httpx` fire — plus bearer auth,
+  typed errors, retries) and migrate the launch POST onto it then.
+- **Free-form UI (1b, the destination).** Haku runs its own UI service in `haku-sandbox`
+  and the console embeds it in a cross-origin iframe, never rendering it itself; a minimal
+  `postMessage` bridge carries only capability requests + `openLink`. **North star:** even
+  the item model + UI + build move into agent-owned `haku-state`; the shell keeps only the
+  boundary. Full design, containment invariants, and implementation order:
   <console/plans/free_form_ui_iframe.md>.
-
-### Server-side compute for agent UI
-
-When agent-authored UI needs a backend, it talks to a **Haku-owned backend running in
-`haku-sandbox`** (the agent's own perimeter), **separate from the console's** — one option
-among several. This keeps the rule clean: code Haku authors never runs with the console's
-secret privileges. The console backend stays the fixed, PR-gated capability/trace
-provider; arbitrary agent compute lives agent-side, behind the agent's own fence.
-
-### Open question — proving "this really came from the operator" to agent-side code
-
-Phase 2 wants agent-side code (or the trace it reduces) to trust that an action
-_genuinely_ came from the real operator, not from agent-authored UI forging it. Sketch
-(operator, 2026-06-26): an **Authentik-native** attestation — e.g. give Haku its own
-Authentik OIDC provider so the console can hand agent-side code a short-lived,
-operator-authenticated token (or sign the trace with an operator-attested claim) that
-agent-side code verifies. Open: exact shape (signed trace vs. a token the agent's backend
-validates), how it composes with _Haku is its own principal_, and whether it's worth it
-before free-form UI lands. Until then, consent fidelity rests on the trusted shell
-rendering canonical copy for anything that matters.
 
 ## Open questions
 

--- a/haku/TODO.md
+++ b/haku/TODO.md
@@ -75,28 +75,18 @@ facade** in front (the Authentik OAuth facade is auth, not tool filtering — se
 
 ## Console — operator-facing dashboard
 
-The console design + action model live in `console/README.md`.
+The console design + action model live in `console/README.md`; the free-form-UI
+direction in `console/plans/free_form_ui_iframe.md`. (The launch-routine button itself
+has shipped on the capability tier — see the README.)
 
-- **Launch the claude-code-web routine from a click.** Add a console button that
-  starts a Haku Claude Code web session via the minted bearer (a Claude Code web
-  session API token). This is a **new shape** for the console: today the backend
-  "stays dumb" — every action is a click-overlay commit Haku reduces on its next
-  run — but a launch is an **immediate side-effecting POST** to the Claude Code
-  web session API, so it needs a real backend endpoint (e.g. `POST /api/launch`),
-  not the overlay/toggle path.
-  - **Perimeter (operator-owned — `cluster/k8s/haku/console/`).** The console
-    today writes only to the internal `haku-state` Forgejo and makes no external
-    calls; its only credential is `haku-state-git-write`. Launching adds (a) the
-    bearer as a **new console secret**, and (b) `haku-sandbox` mitmproxy **egress
-    to the Claude Code web API host**. Both widen the console's perimeter — land
-    them as operator-owned manifest changes.
-  - **Guardrails.** Gate to one in-flight run (disable / suppress duplicates while
-    a session is live) so a stray click can't fan out sessions. Authentik already
-    scopes the console to the operator.
-- **Show recent routine executions.** A read-only panel listing recent
-  claude-code-web sessions of the routine (status, start time, link to the session
-  in the Claude Code web UI), rendered alongside the launch button. Source: the
-  Claude Code web sessions API (list scope on the same / a companion token).
+- **Recent routine executions + one-in-flight guard.** A read-only panel listing recent
+  runs of the claude-code-web routine (status, start time, link), and a guard that blocks
+  a second launch while one is in flight so a stray click can't fan out sessions. Both
+  need a routine-runs **listing** API — **none is known to exist** for `claude_code`
+  routines (only `/fire`), so until one surfaces the interim affordance is the deep-link
+  to the routine's `claude.ai/code` page (already surfaced in the console). When a listing
+  API exists, build the panel and adopt the `anthropic` Python SDK for the Anthropic calls
+  (migrating the launch POST onto it).
 
 ## Managed Agents runtimes — per-runtime TODOs
 

--- a/haku/console/BUILD.bazel
+++ b/haku/console/BUILD.bazel
@@ -33,10 +33,20 @@ py_library(
 )
 
 py_library(
+    name = "deps",
+    srcs = ["deps.py"],
+    deps = [
+        ":config",
+        ":git_state",
+        "@pypi//fastapi",
+    ],
+)
+
+py_library(
     name = "trace",
     srcs = ["trace.py"],
     deps = [
-        ":git_state",
+        ":deps",
         ":models",
         "@pypi//fastapi",
     ],
@@ -47,6 +57,7 @@ py_library(
     srcs = ["capabilities.py"],
     deps = [
         ":config",
+        ":deps",
         "@pypi//fastapi",
         "@pypi//fastapi_csrf_protect",
         "@pypi//httpx",

--- a/haku/console/README.md
+++ b/haku/console/README.md
@@ -56,14 +56,12 @@ no real operator behind it** (see `haku/PLAN.md` → _The agent-authored console
   The split is legible in the code: a search for what touches a privileged secret
   returns `capabilities.py` and never the trace router.
 
-## Boundary
+## Content vs. look
 
-- The backend (git layer, FastAPI JSON API) and frontend (React SPA) are **tested
-  ducktape code**, built Bazel→GHCR→Flux and deployed in the `haku-console` namespace.
-- It is **driven by haku-state at runtime for content**: items (data) are read from
-  the clone, so Haku evolves _what_ the dashboard shows without an image rebuild. The
-  _look_ now lives in the bundle (a frontend rebuild changes it) — unlike the old
-  server-rendered console, whose page/CSS templates could be overridden from the clone.
+Driven by `haku-state` **at runtime for content**: items (data) are read from the clone,
+so Haku evolves _what_ the dashboard shows without an image rebuild. The _look_ now lives
+in the bundle (a frontend rebuild changes it) — unlike the old server-rendered console,
+whose page/CSS templates could be overridden from the clone.
 
 ## Layout
 

--- a/haku/console/capabilities.py
+++ b/haku/console/capabilities.py
@@ -12,14 +12,15 @@ this process. See `haku/PLAN.md` → _The agent-authored console_.
 from __future__ import annotations
 
 import logging
-from typing import Annotated, cast
+from typing import Annotated
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi_csrf_protect import CsrfProtect
 from pydantic import BaseModel, Field
 
-from haku.console.config import LaunchRoutineConfig, Settings
+from haku.console.config import LaunchRoutineConfig
+from haku.console.deps import SettingsDep
 
 logger = logging.getLogger(__name__)
 
@@ -48,12 +49,7 @@ def _upstream_detail(resp: httpx.Response) -> str:
         return resp.text[:300]
 
 
-def _settings(request: Request) -> Settings:
-    # app.state is Starlette's untyped (Any) container; create_app puts Settings there.
-    return cast(Settings, request.app.state.settings)
-
-
-def _launch_config(settings: Annotated[Settings, Depends(_settings)]) -> LaunchRoutineConfig:
+def _launch_config(settings: SettingsDep) -> LaunchRoutineConfig:
     if settings.launch_routine is None:
         raise HTTPException(status_code=503, detail="launch-routine capability is not configured")
     return settings.launch_routine

--- a/haku/console/conftest.py
+++ b/haku/console/conftest.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 
 import pygit2
 import pytest
@@ -68,8 +70,20 @@ def seeded(tmp_path: Path) -> SimpleNamespace:
 
 
 @pytest.fixture
-def client(seeded: SimpleNamespace) -> Iterator[TestClient]:
-    """App over the seeded remote; the context manager runs the lifespan, which clones it."""
-    app = create_app(seeded.settings, git_state=seeded.git_state)
-    with TestClient(app) as c:
+def make_client(seeded: SimpleNamespace) -> Callable[..., Any]:
+    """Factory: a TestClient over the seeded remote, with optional `Settings` overrides.
+    The context manager runs the lifespan, which clones the remote."""
+
+    @contextmanager
+    def _make(**settings_overrides: Any) -> Iterator[TestClient]:
+        settings = seeded.settings.model_copy(update=settings_overrides) if settings_overrides else seeded.settings
+        with TestClient(create_app(settings, git_state=seeded.git_state)) as c:
+            yield c
+
+    return _make
+
+
+@pytest.fixture
+def client(make_client: Callable[..., Any]) -> Iterator[TestClient]:
+    with make_client() as c:
         yield c

--- a/haku/console/deps.py
+++ b/haku/console/deps.py
@@ -1,0 +1,23 @@
+"""Shared FastAPI dependencies: typed accessors for the objects `create_app`
+stashes on `app.state` (Starlette's untyped `Any` container)."""
+
+from __future__ import annotations
+
+from typing import Annotated, cast
+
+from fastapi import Depends, Request
+
+from haku.console.config import Settings
+from haku.console.git_state import GitState
+
+
+def _git_state(request: Request) -> GitState:
+    return cast(GitState, request.app.state.git_state)
+
+
+def _settings(request: Request) -> Settings:
+    return cast(Settings, request.app.state.settings)
+
+
+GitStateDep = Annotated[GitState, Depends(_git_state)]
+SettingsDep = Annotated[Settings, Depends(_settings)]

--- a/haku/console/test_capabilities.py
+++ b/haku/console/test_capabilities.py
@@ -6,7 +6,8 @@ real transport, not TestClient's ASGI transport, so app calls still reach the ap
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
+from typing import Any
 
 import httpx
 import pytest
@@ -15,7 +16,6 @@ import respx
 from fastapi.testclient import TestClient
 from pydantic import SecretStr
 
-from haku.console.app import create_app
 from haku.console.config import LaunchRoutineConfig
 
 ROUTINE_ID = "trig_test"
@@ -24,15 +24,12 @@ PAGE_URL = f"https://claude.ai/code/routines/{ROUTINE_ID}"
 
 
 @pytest.fixture
-def cap_client(seeded) -> Iterator[TestClient]:
+def cap_client(make_client: Callable[..., Any]) -> Iterator[TestClient]:
     """Console app with the launch-routine capability configured (over the seeded remote)."""
-    settings = seeded.settings.model_copy(
-        update={
-            "launch_routine": LaunchRoutineConfig(routine_id=ROUTINE_ID, token=SecretStr("sk-test-token")),
-            "csrf_secret": SecretStr("test-csrf-secret"),
-        }
-    )
-    with TestClient(create_app(settings, git_state=seeded.git_state)) as c:
+    with make_client(
+        launch_routine=LaunchRoutineConfig(routine_id=ROUTINE_ID, token=SecretStr("sk-test-token")),
+        csrf_secret=SecretStr("test-csrf-secret"),
+    ) as c:
         yield c
 
 
@@ -94,9 +91,8 @@ def test_launch_routine_upstream_failure_is_502(cap_client) -> None:
     assert resp.status_code == 502
 
 
-def test_launch_routine_unconfigured_is_503(seeded) -> None:
-    settings = seeded.settings.model_copy(update={"csrf_secret": SecretStr("test-csrf-secret")})
-    with TestClient(create_app(settings, git_state=seeded.git_state)) as c:
+def test_launch_routine_unconfigured_is_503(make_client: Callable[..., Any]) -> None:
+    with make_client(csrf_secret=SecretStr("test-csrf-secret")) as c:
         resp = c.post("/api/capabilities/launch-routine", headers={"X-CSRF-Token": _csrf(c)})
     assert resp.status_code == 503
 

--- a/haku/console/trace.py
+++ b/haku/console/trace.py
@@ -11,20 +11,11 @@ real-world side effects) is a separate router, gated and audited; see
 from __future__ import annotations
 
 import asyncio
-from typing import Annotated, cast
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter
 
-from haku.console.git_state import GitState
+from haku.console.deps import GitStateDep
 from haku.console.models import FeedbackRequest
-
-
-def _git_state(request: Request) -> GitState:
-    # app.state is Starlette's untyped (Any) container; create_app puts the GitState there.
-    return cast(GitState, request.app.state.git_state)
-
-
-GitStateDep = Annotated[GitState, Depends(_git_state)]
 
 router = APIRouter(prefix="/api/trace", tags=["trace"])
 


### PR DESCRIPTION
Knowledge-hygiene + refactor cleanup after the launch-routine work shipped. Docs-only churn plus a small test/code dedup; no behavior change.

## Docs — forward-looking only / SSOT
- **`haku/PLAN.md` "agent-authored console":** dropped the now-shipped current-state prose (the `haku-console` namespace split, the trace/capability tiers, the launch button — all landed). Kept only what's still to build: 1a (richer declarative widget schema + executions panel + one-in-flight guard) and 1b (free-form iframe + north star). Current contract → `console/README.md`; boundary doctrine + free-form design → `console/plans/free_form_ui_iframe.md`. (PLAN is forward-looking; no completed-work tracking.)
- **`haku/TODO.md` Console:** removed the shipped launch-button entry (and its stale `POST /api/launch` + `haku-sandbox` mitmproxy-egress claims — the real endpoint is `/api/capabilities/launch-routine` and the console isn't behind the fence). Folded the one-in-flight guard into the still-pending "recent executions" item (gated on a routine-runs **listing** API that doesn't exist → deep-link interim; adopt the `anthropic` SDK when built).
- **`console/README.md`:** collapsed the `## Boundary` section whose first bullet triplicated the **Trust boundary** para + **Perimeter / deploy** ("ducktape code / own namespace / outside mitmproxy fence"); kept the unique content-vs-look point.

## Code / tests
- **`deps.py` (new):** factored the two `app.state` typed accessors (`GitStateDep`, `SettingsDep`) out of `trace.py`/`capabilities.py` into one shared module.
- **`conftest.py`:** added a `make_client(**settings_overrides)` factory fixture; refactored the `client`/`cap_client` fixtures and the unconfigured-503 test onto it, collapsing the triplicated `create_app` + `TestClient` + `model_copy` boilerplate to settings deltas only.

## Verification
- `bbr test //haku/console/...` → 4/4 pass (lint + mypy via Bazel aspects included).
- `pre-commit` clean over all touched files.