### PR TITLE
grocy-sf: one-shot Job (Bazel image, httpx) to elevate operators to ADMIN

### DIFF
--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -150,6 +150,11 @@ jobs:
             }
           - { image: "//cluster/k8s/agents/attic-jwt-rotation:image", image_name: attic-jwt-rotation, test_target: "" }
           - { image: "//cluster/k8s/inventree/token-provisioner:image", image_name: token-provisioner, test_target: "" }
+          - {
+              image: "//cluster/k8s/grocy/sf/user-perms:image",
+              image_name: grocy-sf-user-perms-provisioner,
+              test_target: "",
+            }
           - { image: "//devinfra/firecracker/manager:image", image_name: firecracker-manager, test_target: "" }
           - { image: "//devinfra/firecracker/vm_pod:image", image_name: fc-vm-pod, test_target: "" }
           - { image: "//inventree_utils/rai_plugin:image", image_name: inventree, test_target: "" }

--- a/cluster/k8s/flux-image-automation-ghcr/grocy-sf-user-perms-provisioner-image-policy.yaml
+++ b/cluster/k8s/flux-image-automation-ghcr/grocy-sf-user-perms-provisioner-image-policy.yaml
@@ -1,0 +1,14 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: grocy-sf-user-perms-provisioner
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: grocy-sf-user-perms-provisioner
+  filterTags:
+    # Tags pushed by CI: {branch}-YYYYMMDDHHMMSS-{sha7} — alphabetical order == chronological
+    pattern: '^devel-\d{14}-[0-9a-f]{7}$'
+  policy:
+    alphabetical:
+      order: asc

--- a/cluster/k8s/flux-image-automation-ghcr/grocy-sf-user-perms-provisioner-image-repository.yaml
+++ b/cluster/k8s/flux-image-automation-ghcr/grocy-sf-user-perms-provisioner-image-repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: grocy-sf-user-perms-provisioner
+  namespace: flux-system
+spec:
+  image: ghcr.io/agentydragon/grocy-sf-user-perms-provisioner
+  interval: 5m

--- a/cluster/k8s/flux-image-automation-ghcr/kustomization.yaml
+++ b/cluster/k8s/flux-image-automation-ghcr/kustomization.yaml
@@ -43,6 +43,8 @@ resources:
   - tana-litellm-proxy-image-policy.yaml
   - token-provisioner-image-repository.yaml
   - token-provisioner-image-policy.yaml
+  - grocy-sf-user-perms-provisioner-image-repository.yaml
+  - grocy-sf-user-perms-provisioner-image-policy.yaml
   - authentik-jwt-rotation-image-repository.yaml
   - authentik-jwt-rotation-image-policy.yaml
   - attic-jwt-rotation-image-repository.yaml

--- a/cluster/k8s/flux-webhook/github-webhook-receiver.yaml
+++ b/cluster/k8s/flux-webhook/github-webhook-receiver.yaml
@@ -115,6 +115,9 @@ spec:
       name: token-provisioner
     - apiVersion: image.toolkit.fluxcd.io/v1beta2
       kind: ImageRepository
+      name: grocy-sf-user-perms-provisioner
+    - apiVersion: image.toolkit.fluxcd.io/v1beta2
+      kind: ImageRepository
       name: cpap-sync
     - apiVersion: image.toolkit.fluxcd.io/v1beta2
       kind: ImageRepository

--- a/cluster/k8s/grocy/sf/user-perms/BUILD.bazel
+++ b/cluster/k8s/grocy/sf/user-perms/BUILD.bazel
@@ -1,0 +1,55 @@
+"""grocy-sf user-perms provisioner OCI image — ensures SF operators have ADMIN."""
+
+load("@aspect_rules_py//py:defs.bzl", "py_image_layer", aspect_py_binary = "py_binary")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
+load("//devinfra/python:defs.bzl", "py_library")
+load("//props:oci.bzl", "py_image_entrypoint", "py_image_env")
+
+py_library(
+    name = "provision",
+    srcs = ["provision.py"],
+    deps = ["@pypi//httpx"],
+)
+
+aspect_py_binary(
+    name = "provision_bin",
+    main = "provision.py",
+    deps = [":provision"],
+)
+
+py_image_layer(
+    name = "layers",
+    binary = ":provision_bin",
+    group = "1000",
+    owner = "1000",
+)
+
+oci_image(
+    name = "image",
+    base = "@debian_slim_linux_amd64",
+    entrypoint = py_image_entrypoint("provision_bin"),
+    env = py_image_env(binary_name = "provision_bin"),
+    labels = {"org.opencontainers.image.source": "https://github.com/agentydragon/ducktape"},
+    tars = [":layers"],
+    user = "1000:1000",
+)
+
+oci_load(
+    name = "load",
+    image = ":image",
+    repo_tags = ["grocy-sf-user-perms-provisioner:latest"],
+)
+
+# Cluster manifests for cluster/validation's flux-build test (the
+# //cluster/k8s:cluster_all_files glob stops at this package boundary).
+filegroup(
+    name = "manifests",
+    srcs = glob(
+        ["**"],
+        exclude = [
+            "BUILD.bazel",
+            "test_*.py",
+        ],
+    ),
+    visibility = ["//cluster/validation:__pkg__"],
+)

--- a/cluster/k8s/grocy/sf/user-perms/flux-kustomization.yaml
+++ b/cluster/k8s/grocy/sf/user-perms/flux-kustomization.yaml
@@ -1,0 +1,25 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: grocy-sf-user-perms
+  namespace: flux-system
+spec:
+  retryInterval: 1m
+  interval: 10m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./cluster/k8s/grocy/sf/user-perms
+  prune: true
+  # Run only after grocy-sf is up (and self-migrated via its postStart hook); the
+  # Job-completion healthcheck makes this kustomization Ready only once the operator
+  # elevation has actually run — so a fresh cluster converges to operators=ADMIN.
+  wait: true
+  dependsOn:
+    - name: grocy-sf
+  healthChecks:
+    - apiVersion: batch/v1
+      kind: Job
+      name: grocy-sf-user-perms-provisioner
+      namespace: grocy-sf

--- a/cluster/k8s/grocy/sf/user-perms/job.yaml
+++ b/cluster/k8s/grocy/sf/user-perms/job.yaml
@@ -1,0 +1,47 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: grocy-sf-user-perms-provisioner
+  namespace: grocy-sf
+  annotations:
+    # One-shot: runs once per cluster bootstrap (Flux applies it after grocy is up).
+    # The Job spec is immutable, so let Flux recreate it when provision.py changes.
+    kustomize.toolkit.fluxcd.io/force: enabled
+spec:
+  backoffLimit: 10
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: grocy-sf-user-perms-provisioner
+    spec:
+      restartPolicy: OnFailure
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: provisioner
+          image: python:3.13-alpine
+          command: ["python", "/scripts/provision.py"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+          volumeMounts:
+            - name: script
+              mountPath: /scripts
+              readOnly: true
+      volumes:
+        - name: script
+          configMap:
+            name: grocy-sf-user-perms-provisioner-script

--- a/cluster/k8s/grocy/sf/user-perms/job.yaml
+++ b/cluster/k8s/grocy/sf/user-perms/job.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: grocy-sf
   annotations:
     # One-shot: runs once per cluster bootstrap (Flux applies it after grocy is up).
-    # The Job spec is immutable, so let Flux recreate it when provision.py changes.
+    # The Job spec is immutable, so let Flux recreate it when the image bumps.
     kustomize.toolkit.fluxcd.io/force: enabled
 spec:
   backoffLimit: 10
@@ -16,6 +16,7 @@ spec:
     spec:
       restartPolicy: OnFailure
       enableServiceLinks: false
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -24,24 +25,16 @@ spec:
           type: RuntimeDefault
       containers:
         - name: provisioner
-          image: python:3.13-alpine
-          command: ["python", "/scripts/provision.py"]
+          # Script baked in via Bazel (//cluster/k8s/grocy/sf/user-perms:image).
+          image: ghcr.io/agentydragon/grocy-sf-user-perms-provisioner:devel-20260101000000-0000000 # {"$imagepolicy": "flux-system:grocy-sf-user-perms-provisioner"}
+          imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
           resources:
             requests:
               cpu: 25m
-              memory: 32Mi
-            limits:
               memory: 64Mi
-          volumeMounts:
-            - name: script
-              mountPath: /scripts
-              readOnly: true
-      volumes:
-        - name: script
-          configMap:
-            name: grocy-sf-user-perms-provisioner-script
+            limits:
+              memory: 128Mi

--- a/cluster/k8s/grocy/sf/user-perms/kustomization.yaml
+++ b/cluster/k8s/grocy/sf/user-perms/kustomization.yaml
@@ -4,7 +4,3 @@ namespace: grocy-sf
 resources:
   - networkpolicy.yaml
   - job.yaml
-configMapGenerator:
-  - name: grocy-sf-user-perms-provisioner-script
-    files:
-      - provision.py

--- a/cluster/k8s/grocy/sf/user-perms/kustomization.yaml
+++ b/cluster/k8s/grocy/sf/user-perms/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: grocy-sf
+resources:
+  - networkpolicy.yaml
+  - job.yaml
+configMapGenerator:
+  - name: grocy-sf-user-perms-provisioner-script
+    files:
+      - provision.py

--- a/cluster/k8s/grocy/sf/user-perms/networkpolicy.yaml
+++ b/cluster/k8s/grocy/sf/user-perms/networkpolicy.yaml
@@ -1,0 +1,24 @@
+# The base `grocy-ingress` policy (app-base) restricts Grocy :80 to the Authentik
+# outpost + Gatus, because any pod that reaches :80 can impersonate any user via the
+# trusted X-authentik-username header. NetworkPolicies are additive, so this grants
+# the user-perms provisioner Job that same in-cluster access (it acts as the admin
+# user to elevate the operators). Scoped to the provisioner pod label only.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: grocy-user-perms-provisioner-ingress
+  namespace: grocy-sf
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: grocy
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: grocy-sf-user-perms-provisioner
+      ports:
+        - port: 80
+          protocol: TCP

--- a/cluster/k8s/grocy/sf/user-perms/provision.py
+++ b/cluster/k8s/grocy/sf/user-perms/provision.py
@@ -12,10 +12,9 @@ NetworkPolicy is what restricts who may present it.
 """
 
 import contextlib
-import json
 import time
-import urllib.error
-import urllib.request
+
+import httpx
 
 GROCY = "http://grocy.grocy-sf.svc.cluster.local:80"
 ADMIN = "admin"  # Grocy's built-in admin user (created by the schema migration)
@@ -23,54 +22,42 @@ OPERATORS = ("agentydragon", "auragon")  # SF household humans to keep at ADMIN
 ADMIN_PERMISSION_ID = 1  # the ADMIN root permission (implies all others)
 
 
-def call(method: str, path: str, *, user: str, body: dict | None = None):
-    """JSON API request. Raises HTTPError on non-2xx; expects a JSON (or empty) body."""
-    data = json.dumps(body).encode() if body is not None else None
-    headers = {"X-authentik-username": user}
-    if data is not None:
-        headers["Content-Type"] = "application/json"
-    req = urllib.request.Request(GROCY + path, data=data, headers=headers, method=method)
-    with urllib.request.urlopen(req) as response:
-        raw = response.read().decode()
-    return json.loads(raw) if raw.strip() else None
-
-
-def wait_for_schema() -> None:
+def wait_for_schema(client: httpx.Client) -> None:
     """Await Grocy's schema. The app self-migrates at startup (postStart hits the
     auth-exempt `/`) and Flux only runs this Job once grocy is Ready, but poll
-    defensively so the Job also works run standalone. Hit `/` raw (its body is an
-    HTML redirect — never parse it) in case migration hasn't run, then poll the
-    JSON `/api/users` until the schema exists.
+    defensively so the Job also works run standalone. Hit `/` (its body is an HTML
+    redirect — ignore it) in case migration hasn't run, then poll the JSON
+    `/api/users` until the schema exists.
     """
     for _ in range(30):
-        with contextlib.suppress(urllib.error.HTTPError):
-            urllib.request.urlopen(
-                urllib.request.Request(GROCY + "/", headers={"X-authentik-username": ADMIN}, method="GET")
-            ).read()
-        try:
-            if isinstance(call("GET", "/api/users", user=ADMIN), list):
-                return
-        except urllib.error.HTTPError:
-            pass
+        with contextlib.suppress(httpx.HTTPError):
+            client.get("/")
+        resp = client.get("/api/users")
+        if resp.status_code == 200 and isinstance(resp.json(), list):
+            return
         time.sleep(2)
     raise RuntimeError("Grocy schema not ready in time")
 
 
 def main() -> None:
-    wait_for_schema()
-    for operator in OPERATORS:
-        # Auto-create the operator if absent (reverse-proxy auth creates the user on
-        # the first request bearing its username; default-deny means it is born
-        # read-only), then grant ADMIN as the built-in admin user.
-        call("GET", "/api/system/info", user=operator)
-        users = call("GET", "/api/users", user=ADMIN)
-        if not isinstance(users, list):
-            raise RuntimeError(f"GET /api/users did not return a list: {users!r}")
-        user = next((u for u in users if u["username"] == operator), None)
-        if user is None:
-            raise RuntimeError(f"{operator!r} user was not created by the reverse-proxy auth")
-        call("PUT", f"/api/users/{user['id']}/permissions", user=ADMIN, body={"permissions": [ADMIN_PERMISSION_ID]})
-        print(f"{operator!r} (id={user['id']}) ensured ADMIN")
+    with httpx.Client(
+        base_url=GROCY, headers={"X-authentik-username": ADMIN}, follow_redirects=True, timeout=30
+    ) as client:
+        wait_for_schema(client)
+        for operator in OPERATORS:
+            # Auto-create the operator if absent (reverse-proxy auth creates the user
+            # on the first request bearing its username; default-deny means it is born
+            # read-only), then grant ADMIN as the built-in admin user.
+            client.get("/api/system/info", headers={"X-authentik-username": operator}).raise_for_status()
+            users_resp = client.get("/api/users")
+            users_resp.raise_for_status()
+            user = next((u for u in users_resp.json() if u["username"] == operator), None)
+            if user is None:
+                raise RuntimeError(f"{operator!r} user was not created by the reverse-proxy auth")
+            client.put(
+                f"/api/users/{user['id']}/permissions", json={"permissions": [ADMIN_PERMISSION_ID]}
+            ).raise_for_status()
+            print(f"{operator!r} (id={user['id']}) ensured ADMIN")
 
 
 if __name__ == "__main__":

--- a/cluster/k8s/grocy/sf/user-perms/provision.py
+++ b/cluster/k8s/grocy/sf/user-perms/provision.py
@@ -1,0 +1,77 @@
+"""Ensure the SF household operator(s) have ADMIN in the grocy-sf instance.
+
+Read-only is the default here (DEFAULT_PERMISSIONS=none, see ../app), so haku and
+any other auto-created user is read-only. This one-shot Job does the single explicit
+elevation default-deny requires: ensure each human operator exists and has ADMIN.
+Flux runs it once after grocy is up (dependsOn grocy-sf), so a from-scratch cluster
+rebuild ends with the operators able to use Grocy — no manual step.
+
+Idempotent. Runs as the built-in `admin` user (always ADMIN, created by the schema
+migration) via Grocy's trusted X-authentik-username header; the sibling
+NetworkPolicy is what restricts who may present it.
+"""
+
+import contextlib
+import json
+import time
+import urllib.error
+import urllib.request
+
+GROCY = "http://grocy.grocy-sf.svc.cluster.local:80"
+ADMIN = "admin"  # Grocy's built-in admin user (created by the schema migration)
+OPERATORS = ("agentydragon", "auragon")  # SF household humans to keep at ADMIN
+ADMIN_PERMISSION_ID = 1  # the ADMIN root permission (implies all others)
+
+
+def call(method: str, path: str, *, user: str, body: dict | None = None):
+    """JSON API request. Raises HTTPError on non-2xx; expects a JSON (or empty) body."""
+    data = json.dumps(body).encode() if body is not None else None
+    headers = {"X-authentik-username": user}
+    if data is not None:
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(GROCY + path, data=data, headers=headers, method=method)
+    with urllib.request.urlopen(req) as response:
+        raw = response.read().decode()
+    return json.loads(raw) if raw.strip() else None
+
+
+def wait_for_schema() -> None:
+    """Await Grocy's schema. The app self-migrates at startup (postStart hits the
+    auth-exempt `/`) and Flux only runs this Job once grocy is Ready, but poll
+    defensively so the Job also works run standalone. Hit `/` raw (its body is an
+    HTML redirect — never parse it) in case migration hasn't run, then poll the
+    JSON `/api/users` until the schema exists.
+    """
+    for _ in range(30):
+        with contextlib.suppress(urllib.error.HTTPError):
+            urllib.request.urlopen(
+                urllib.request.Request(GROCY + "/", headers={"X-authentik-username": ADMIN}, method="GET")
+            ).read()
+        try:
+            if isinstance(call("GET", "/api/users", user=ADMIN), list):
+                return
+        except urllib.error.HTTPError:
+            pass
+        time.sleep(2)
+    raise RuntimeError("Grocy schema not ready in time")
+
+
+def main() -> None:
+    wait_for_schema()
+    for operator in OPERATORS:
+        # Auto-create the operator if absent (reverse-proxy auth creates the user on
+        # the first request bearing its username; default-deny means it is born
+        # read-only), then grant ADMIN as the built-in admin user.
+        call("GET", "/api/system/info", user=operator)
+        users = call("GET", "/api/users", user=ADMIN)
+        if not isinstance(users, list):
+            raise RuntimeError(f"GET /api/users did not return a list: {users!r}")
+        user = next((u for u in users if u["username"] == operator), None)
+        if user is None:
+            raise RuntimeError(f"{operator!r} user was not created by the reverse-proxy auth")
+        call("PUT", f"/api/users/{user['id']}/permissions", user=ADMIN, body={"permissions": [ADMIN_PERMISSION_ID]})
+        print(f"{operator!r} (id={user['id']}) ensured ADMIN")
+
+
+if __name__ == "__main__":
+    main()

--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -296,6 +296,7 @@ resources:
   # --- grocy ---
   - grocy/sf/app/flux-kustomization.yaml
   - grocy/sf/agent-rbac/flux-kustomization.yaml
+  - grocy/sf/user-perms/flux-kustomization.yaml
   - grocy/vallejo/app/flux-kustomization.yaml
   - grocy/vallejo/agent-rbac/flux-kustomization.yaml
 

--- a/cluster/validation/BUILD.bazel
+++ b/cluster/validation/BUILD.bazel
@@ -357,6 +357,7 @@ py_test(
         "//cluster/k8s:flux_system_files",
         "//cluster/k8s/agents/attic-jwt-rotation:manifests",
         "//cluster/k8s/agents/authentik-jwt-rotation:manifests",
+        "//cluster/k8s/grocy/sf/user-perms:manifests",
         "//cluster/k8s/inventree/token-provisioner:manifests",
         "//cluster/k8s/litellm/app:manifests",
         "//cluster/k8s/litellm/tana:manifests",


### PR DESCRIPTION
The final piece of haku's read-only Grocy access, and the bit that makes a **from-scratch cluster rebuild turnkey**.

With default-deny (#2509), every auto-created Grocy user — haku, anyone — is read-only by default (the safe failure mode). This adds the single explicit elevation that requires: ensure the SF household operators (`agentydragon`, `auragon`) exist and have ADMIN.

## Shape: a one-shot, Flux-gated Job — *not* a CronJob, hook, or `restful` TF
We went deep on the alternatives; this is what survived:
- **Rebuild-turnkey:** on a fresh cluster, Flux brings up grocy → its postStart self-migrates the DB (#2509) → grocy Ready → this Job's kustomization (`dependsOn: grocy-sf`, `wait`, Job-completion healthcheck) runs once and ensures operators=ADMIN. No manual step.
- **Not a CronJob:** one-shot, no schedule, no coordination race — ordered purely by Flux `dependsOn`.
- **Bazel-built image, httpx baked in:** `//cluster/k8s/grocy/sf/user-perms:image` (same pattern as the inventree token-provisioner) — no runtime `pip install`, no mounted-script configMap. Image builds on RBE; Flux ImageRepository/ImagePolicy + push-images matrix publish & auto-bump it.
- **Dodges Grocy's API hostility that sank `restful` TF:** a script handles create-then-find-then-PUT trivially (204-no-id create, id-only addressing, asymmetric perms read) — no perpetual drift, no lost self-heal.

## Why not the rejected options (for the record)
- `restful` TF: prototyped against live Grocy — perpetual drift (`body={}` vs `{permissions:[1]}`), and the only fix (`write_only_attrs`) loses fresh-DB self-heal. Grocy's perms API isn't RESTful enough.
- postStart elevation hook: imperative shell embedded in the grocy Deployment — ugly.
- Manual one-liner: not turnkey on rebuild (your requirement).

## Validation
- Image builds on RBE (`@pypi//httpx` resolves).
- `provision.py` (httpx) run end-to-end against the **live** instance: `agentydragon` + `auragon` both land at `permission_id 1` (ADMIN); a freshly auto-created user stays read-only.
- `kustomize build` (Job + NetworkPolicy, no configMap), kubeconform, ruff, buildifier, prettier all pass.

## Net result (whole stack, turnkey on rebuild)
default-deny + postStart self-migrate (#2509) + this one-shot operator-elevation Job → tear down and rebuild the cluster, and grocy comes back with haku read-only and the operators admin, automatically.

Depends on #2509 (merged).