### PR TITLE
debundle: lower AST selector atoms into constraint model

### DIFF
--- a/devinfra/js/debundle/selector_constraint_model_builder.rs
+++ b/devinfra/js/debundle/selector_constraint_model_builder.rs
@@ -189,6 +189,157 @@ fn lower_atom_constraint(
             export_name,
             &domains.export_names,
         ),
+        SelectorAtom::OwnerTopLevelRoot { owner, root } => add_owner_node_allowed_tuples(
+            model,
+            variables,
+            owner,
+            root,
+            &domains.owner_top_level_roots,
+        ),
+        SelectorAtom::AstKind { node, node_kind } => add_node_string_allowed_tuples(
+            model,
+            variables,
+            node,
+            &StringTerm::Const {
+                value: node_kind.as_tag().to_string(),
+            },
+            &domains.ast_kinds,
+        ),
+        SelectorAtom::AstChild {
+            parent,
+            index,
+            child,
+        } => {
+            let facts = domains
+                .ast_children
+                .iter()
+                .filter_map(|(fact_parent, fact_index, fact_child)| {
+                    (*fact_index == *index).then_some((*fact_parent, *fact_child))
+                })
+                .collect::<BTreeSet<_>>();
+            add_node_node_allowed_tuples(model, variables, parent, child, &facts)
+        }
+        SelectorAtom::AstSuperClass {
+            class_node,
+            super_class,
+        } => add_node_node_allowed_tuples(
+            model,
+            variables,
+            class_node,
+            super_class,
+            &domains.ast_super_classes,
+        ),
+        SelectorAtom::AstChildCount { node, count } => {
+            let facts = domains
+                .ast_child_counts
+                .iter()
+                .filter_map(|(fact_node, fact_count)| {
+                    (*fact_count == *count).then_some((*fact_node, fact_count.to_string()))
+                })
+                .collect::<BTreeSet<_>>();
+            add_node_string_allowed_tuples(
+                model,
+                variables,
+                node,
+                &StringTerm::Const {
+                    value: count.to_string(),
+                },
+                &facts,
+            )
+        }
+        SelectorAtom::AstStringLiteral { node, value } => add_node_string_allowed_tuples(
+            model,
+            variables,
+            node,
+            value,
+            &domains.ast_string_literals,
+        ),
+        SelectorAtom::AstNumberLiteral { node, value } => add_node_string_allowed_tuples(
+            model,
+            variables,
+            node,
+            value,
+            &domains.ast_number_literals,
+        ),
+        SelectorAtom::AstBoolLiteral { node, value } => {
+            let facts = domains
+                .ast_bool_literals
+                .iter()
+                .filter_map(|(fact_node, fact_value)| {
+                    (*fact_value == *value).then_some((*fact_node, fact_value.to_string()))
+                })
+                .collect::<BTreeSet<_>>();
+            add_node_string_allowed_tuples(
+                model,
+                variables,
+                node,
+                &StringTerm::Const {
+                    value: value.to_string(),
+                },
+                &facts,
+            )
+        }
+        SelectorAtom::AstIdentifierName { node, value } => add_node_string_allowed_tuples(
+            model,
+            variables,
+            node,
+            value,
+            &domains.ast_identifier_names,
+        ),
+        SelectorAtom::AstPropertyName { node, value } => add_node_string_allowed_tuples(
+            model,
+            variables,
+            node,
+            value,
+            &domains.ast_property_names,
+        ),
+        SelectorAtom::AstBareProperty {
+            node,
+            key,
+            identifier,
+            is_binding,
+        } => add_ast_bare_property_allowed_tuples(
+            model,
+            variables,
+            node,
+            key,
+            identifier,
+            *is_binding,
+            &domains.ast_bare_properties,
+        ),
+        SelectorAtom::AstOperator { node, value } => {
+            add_node_string_allowed_tuples(model, variables, node, value, &domains.ast_operators)
+        }
+        SelectorAtom::AstRegexLiteral {
+            node,
+            pattern,
+            flags,
+        } => add_ast_regex_literal_allowed_tuples(
+            model,
+            variables,
+            node,
+            pattern,
+            flags,
+            &domains.ast_regex_literals,
+        ),
+        SelectorAtom::AstTopLevel { node, ordinal } => add_node_ordinal_allowed_tuples(
+            model,
+            variables,
+            node,
+            ordinal,
+            &domains.ast_top_levels,
+        ),
+        SelectorAtom::OrdinalOffset {
+            base,
+            ordinal,
+            offset,
+        } => add_ordinal_ordinal_allowed_tuples(
+            model,
+            variables,
+            base,
+            ordinal,
+            &domains.ordinal_offset_rows(*offset),
+        ),
         SelectorAtom::Equal { left, right } => model
             .add_binary_constraint(
                 model_variable(variables, *left)?,
@@ -316,6 +467,370 @@ fn add_owner_ordinal_allowed_tuples(
     add_allowed_tuple_set(model, constraint_variables, tuples)
 }
 
+fn add_owner_node_allowed_tuples(
+    model: &mut SelectorConstraintModel,
+    variables: &[ConstraintVariableId],
+    owner: &OwnerTerm,
+    node: &NodeTerm,
+    facts: &BTreeSet<(OwnerId, NodeId)>,
+) -> Result<(), SelectorConstraintModelBuildError> {
+    let mut constraint_variables = Vec::new();
+    if let OwnerTerm::Var { id } = owner {
+        constraint_variables.push(model_variable(variables, *id)?);
+    }
+    if let NodeTerm::Var { id } = node {
+        constraint_variables.push(model_variable(variables, *id)?);
+    }
+    if constraint_variables.is_empty() {
+        return facts
+            .iter()
+            .any(|(fact_owner, fact_node)| {
+                owner_term_matches(owner, *fact_owner) && node_term_matches(node, *fact_node)
+            })
+            .then_some(())
+            .ok_or_else(
+                || SelectorConstraintModelBuildError::ConstantOnlyAtomUnsatisfied {
+                    atom: format!("owner/node fact {owner:?} {node:?}"),
+                },
+            );
+    }
+
+    let tuples = facts
+        .iter()
+        .filter(|(fact_owner, fact_node)| {
+            owner_term_matches(owner, *fact_owner) && node_term_matches(node, *fact_node)
+        })
+        .map(|(fact_owner, fact_node)| {
+            let mut tuple = Vec::with_capacity(constraint_variables.len());
+            if matches!(owner, OwnerTerm::Var { .. }) {
+                tuple.push(ConstraintValue::Owner(*fact_owner));
+            }
+            if matches!(node, NodeTerm::Var { .. }) {
+                tuple.push(ConstraintValue::AstNode(*fact_node));
+            }
+            tuple
+        })
+        .collect::<BTreeSet<_>>();
+
+    add_allowed_tuple_set(model, constraint_variables, tuples)
+}
+
+fn add_node_node_allowed_tuples(
+    model: &mut SelectorConstraintModel,
+    variables: &[ConstraintVariableId],
+    left: &NodeTerm,
+    right: &NodeTerm,
+    facts: &BTreeSet<(NodeId, NodeId)>,
+) -> Result<(), SelectorConstraintModelBuildError> {
+    let mut constraint_variables = Vec::new();
+    if let NodeTerm::Var { id } = left {
+        constraint_variables.push(model_variable(variables, *id)?);
+    }
+    if let NodeTerm::Var { id } = right {
+        constraint_variables.push(model_variable(variables, *id)?);
+    }
+    if constraint_variables.is_empty() {
+        return facts
+            .iter()
+            .any(|(fact_left, fact_right)| {
+                node_term_matches(left, *fact_left) && node_term_matches(right, *fact_right)
+            })
+            .then_some(())
+            .ok_or_else(
+                || SelectorConstraintModelBuildError::ConstantOnlyAtomUnsatisfied {
+                    atom: format!("node/node fact {left:?} {right:?}"),
+                },
+            );
+    }
+
+    let tuples = facts
+        .iter()
+        .filter(|(fact_left, fact_right)| {
+            node_term_matches(left, *fact_left) && node_term_matches(right, *fact_right)
+        })
+        .map(|(fact_left, fact_right)| {
+            let mut tuple = Vec::with_capacity(constraint_variables.len());
+            if matches!(left, NodeTerm::Var { .. }) {
+                tuple.push(ConstraintValue::AstNode(*fact_left));
+            }
+            if matches!(right, NodeTerm::Var { .. }) {
+                tuple.push(ConstraintValue::AstNode(*fact_right));
+            }
+            tuple
+        })
+        .collect::<BTreeSet<_>>();
+
+    add_allowed_tuple_set(model, constraint_variables, tuples)
+}
+
+fn add_node_string_allowed_tuples(
+    model: &mut SelectorConstraintModel,
+    variables: &[ConstraintVariableId],
+    node: &NodeTerm,
+    string: &StringTerm,
+    facts: &BTreeSet<(NodeId, String)>,
+) -> Result<(), SelectorConstraintModelBuildError> {
+    let mut constraint_variables = Vec::new();
+    if let NodeTerm::Var { id } = node {
+        constraint_variables.push(model_variable(variables, *id)?);
+    }
+    if let StringTerm::Var { id } = string {
+        constraint_variables.push(model_variable(variables, *id)?);
+    }
+    if constraint_variables.is_empty() {
+        return facts
+            .iter()
+            .any(|(fact_node, fact_string)| {
+                node_term_matches(node, *fact_node) && string_term_matches(string, fact_string)
+            })
+            .then_some(())
+            .ok_or_else(
+                || SelectorConstraintModelBuildError::ConstantOnlyAtomUnsatisfied {
+                    atom: format!("node/string fact {node:?} {string:?}"),
+                },
+            );
+    }
+
+    let tuples = facts
+        .iter()
+        .filter(|(fact_node, fact_string)| {
+            node_term_matches(node, *fact_node) && string_term_matches(string, fact_string)
+        })
+        .map(|(fact_node, fact_string)| {
+            let mut tuple = Vec::with_capacity(constraint_variables.len());
+            if matches!(node, NodeTerm::Var { .. }) {
+                tuple.push(ConstraintValue::AstNode(*fact_node));
+            }
+            if matches!(string, StringTerm::Var { .. }) {
+                tuple.push(ConstraintValue::String(fact_string.clone()));
+            }
+            tuple
+        })
+        .collect::<BTreeSet<_>>();
+
+    add_allowed_tuple_set(model, constraint_variables, tuples)
+}
+
+fn add_node_ordinal_allowed_tuples(
+    model: &mut SelectorConstraintModel,
+    variables: &[ConstraintVariableId],
+    node: &NodeTerm,
+    ordinal: &OrdinalTerm,
+    facts: &BTreeSet<(NodeId, StatementOrdinal)>,
+) -> Result<(), SelectorConstraintModelBuildError> {
+    let mut constraint_variables = Vec::new();
+    if let NodeTerm::Var { id } = node {
+        constraint_variables.push(model_variable(variables, *id)?);
+    }
+    if let OrdinalTerm::Var { id } = ordinal {
+        constraint_variables.push(model_variable(variables, *id)?);
+    }
+    if constraint_variables.is_empty() {
+        return facts
+            .iter()
+            .any(|(fact_node, fact_ordinal)| {
+                node_term_matches(node, *fact_node) && ordinal_term_matches(ordinal, *fact_ordinal)
+            })
+            .then_some(())
+            .ok_or_else(
+                || SelectorConstraintModelBuildError::ConstantOnlyAtomUnsatisfied {
+                    atom: format!("node/ordinal fact {node:?} {ordinal:?}"),
+                },
+            );
+    }
+
+    let tuples = facts
+        .iter()
+        .filter(|(fact_node, fact_ordinal)| {
+            node_term_matches(node, *fact_node) && ordinal_term_matches(ordinal, *fact_ordinal)
+        })
+        .map(|(fact_node, fact_ordinal)| {
+            let mut tuple = Vec::with_capacity(constraint_variables.len());
+            if matches!(node, NodeTerm::Var { .. }) {
+                tuple.push(ConstraintValue::AstNode(*fact_node));
+            }
+            if matches!(ordinal, OrdinalTerm::Var { .. }) {
+                tuple.push(ConstraintValue::StatementOrdinal(*fact_ordinal));
+            }
+            tuple
+        })
+        .collect::<BTreeSet<_>>();
+
+    add_allowed_tuple_set(model, constraint_variables, tuples)
+}
+
+fn add_ordinal_ordinal_allowed_tuples(
+    model: &mut SelectorConstraintModel,
+    variables: &[ConstraintVariableId],
+    base: &OrdinalTerm,
+    ordinal: &OrdinalTerm,
+    facts: &BTreeSet<(StatementOrdinal, StatementOrdinal)>,
+) -> Result<(), SelectorConstraintModelBuildError> {
+    let mut constraint_variables = Vec::new();
+    if let OrdinalTerm::Var { id } = base {
+        constraint_variables.push(model_variable(variables, *id)?);
+    }
+    if let OrdinalTerm::Var { id } = ordinal {
+        constraint_variables.push(model_variable(variables, *id)?);
+    }
+    if constraint_variables.is_empty() {
+        return facts
+            .iter()
+            .any(|(fact_base, fact_ordinal)| {
+                ordinal_term_matches(base, *fact_base)
+                    && ordinal_term_matches(ordinal, *fact_ordinal)
+            })
+            .then_some(())
+            .ok_or_else(
+                || SelectorConstraintModelBuildError::ConstantOnlyAtomUnsatisfied {
+                    atom: format!("ordinal/ordinal fact {base:?} {ordinal:?}"),
+                },
+            );
+    }
+
+    let tuples = facts
+        .iter()
+        .filter(|(fact_base, fact_ordinal)| {
+            ordinal_term_matches(base, *fact_base) && ordinal_term_matches(ordinal, *fact_ordinal)
+        })
+        .map(|(fact_base, fact_ordinal)| {
+            let mut tuple = Vec::with_capacity(constraint_variables.len());
+            if matches!(base, OrdinalTerm::Var { .. }) {
+                tuple.push(ConstraintValue::StatementOrdinal(*fact_base));
+            }
+            if matches!(ordinal, OrdinalTerm::Var { .. }) {
+                tuple.push(ConstraintValue::StatementOrdinal(*fact_ordinal));
+            }
+            tuple
+        })
+        .collect::<BTreeSet<_>>();
+
+    add_allowed_tuple_set(model, constraint_variables, tuples)
+}
+
+fn add_ast_bare_property_allowed_tuples(
+    model: &mut SelectorConstraintModel,
+    variables: &[ConstraintVariableId],
+    node: &NodeTerm,
+    key: &StringTerm,
+    identifier: &StringTerm,
+    is_binding: bool,
+    facts: &BTreeSet<(NodeId, String, String, bool)>,
+) -> Result<(), SelectorConstraintModelBuildError> {
+    let mut constraint_variables = Vec::new();
+    if let NodeTerm::Var { id } = node {
+        constraint_variables.push(model_variable(variables, *id)?);
+    }
+    if let StringTerm::Var { id } = key {
+        constraint_variables.push(model_variable(variables, *id)?);
+    }
+    if let StringTerm::Var { id } = identifier {
+        constraint_variables.push(model_variable(variables, *id)?);
+    }
+    if constraint_variables.is_empty() {
+        return facts
+            .iter()
+            .any(|(fact_node, fact_key, fact_identifier, fact_is_binding)| {
+                *fact_is_binding == is_binding
+                    && node_term_matches(node, *fact_node)
+                    && string_term_matches(key, fact_key)
+                    && string_term_matches(identifier, fact_identifier)
+            })
+            .then_some(())
+            .ok_or_else(
+                || SelectorConstraintModelBuildError::ConstantOnlyAtomUnsatisfied {
+                    atom: format!(
+                        "ast_bare_property fact {node:?} {key:?} {identifier:?} {is_binding}"
+                    ),
+                },
+            );
+    }
+
+    let tuples = facts
+        .iter()
+        .filter(|(fact_node, fact_key, fact_identifier, fact_is_binding)| {
+            *fact_is_binding == is_binding
+                && node_term_matches(node, *fact_node)
+                && string_term_matches(key, fact_key)
+                && string_term_matches(identifier, fact_identifier)
+        })
+        .map(|(fact_node, fact_key, fact_identifier, _)| {
+            let mut tuple = Vec::with_capacity(constraint_variables.len());
+            if matches!(node, NodeTerm::Var { .. }) {
+                tuple.push(ConstraintValue::AstNode(*fact_node));
+            }
+            if matches!(key, StringTerm::Var { .. }) {
+                tuple.push(ConstraintValue::String(fact_key.clone()));
+            }
+            if matches!(identifier, StringTerm::Var { .. }) {
+                tuple.push(ConstraintValue::String(fact_identifier.clone()));
+            }
+            tuple
+        })
+        .collect::<BTreeSet<_>>();
+
+    add_allowed_tuple_set(model, constraint_variables, tuples)
+}
+
+fn add_ast_regex_literal_allowed_tuples(
+    model: &mut SelectorConstraintModel,
+    variables: &[ConstraintVariableId],
+    node: &NodeTerm,
+    pattern: &StringTerm,
+    flags: &StringTerm,
+    facts: &BTreeSet<(NodeId, String, String)>,
+) -> Result<(), SelectorConstraintModelBuildError> {
+    let mut constraint_variables = Vec::new();
+    if let NodeTerm::Var { id } = node {
+        constraint_variables.push(model_variable(variables, *id)?);
+    }
+    if let StringTerm::Var { id } = pattern {
+        constraint_variables.push(model_variable(variables, *id)?);
+    }
+    if let StringTerm::Var { id } = flags {
+        constraint_variables.push(model_variable(variables, *id)?);
+    }
+    if constraint_variables.is_empty() {
+        return facts
+            .iter()
+            .any(|(fact_node, fact_pattern, fact_flags)| {
+                node_term_matches(node, *fact_node)
+                    && string_term_matches(pattern, fact_pattern)
+                    && string_term_matches(flags, fact_flags)
+            })
+            .then_some(())
+            .ok_or_else(
+                || SelectorConstraintModelBuildError::ConstantOnlyAtomUnsatisfied {
+                    atom: format!("ast_regex_literal fact {node:?} {pattern:?} {flags:?}"),
+                },
+            );
+    }
+
+    let tuples = facts
+        .iter()
+        .filter(|(fact_node, fact_pattern, fact_flags)| {
+            node_term_matches(node, *fact_node)
+                && string_term_matches(pattern, fact_pattern)
+                && string_term_matches(flags, fact_flags)
+        })
+        .map(|(fact_node, fact_pattern, fact_flags)| {
+            let mut tuple = Vec::with_capacity(constraint_variables.len());
+            if matches!(node, NodeTerm::Var { .. }) {
+                tuple.push(ConstraintValue::AstNode(*fact_node));
+            }
+            if matches!(pattern, StringTerm::Var { .. }) {
+                tuple.push(ConstraintValue::String(fact_pattern.clone()));
+            }
+            if matches!(flags, StringTerm::Var { .. }) {
+                tuple.push(ConstraintValue::String(fact_flags.clone()));
+            }
+            tuple
+        })
+        .collect::<BTreeSet<_>>();
+
+    add_allowed_tuple_set(model, constraint_variables, tuples)
+}
+
 fn add_allowed_tuple_set(
     model: &mut SelectorConstraintModel,
     variables: Vec<ConstraintVariableId>,
@@ -333,6 +848,15 @@ fn owner_term_matches(term: &OwnerTerm, owner: OwnerId) -> bool {
         OwnerTerm::Const {
             owner: expected_owner,
         } => *expected_owner == owner,
+    }
+}
+
+fn node_term_matches(term: &NodeTerm, node: NodeId) -> bool {
+    match term {
+        NodeTerm::Var { .. } => true,
+        NodeTerm::Const {
+            node: expected_node,
+        } => *expected_node == node,
     }
 }
 
@@ -434,14 +958,29 @@ struct FactDomains {
     ordinals: BTreeSet<StatementOrdinal>,
     owner_kinds: BTreeSet<(OwnerId, String)>,
     owner_statement_ordinals: BTreeSet<(OwnerId, StatementOrdinal)>,
+    owner_top_level_roots: BTreeSet<(OwnerId, NodeId)>,
     declared_bindings: BTreeSet<(OwnerId, String)>,
     export_names: BTreeSet<(OwnerId, String)>,
+    ast_kinds: BTreeSet<(NodeId, String)>,
+    ast_children: BTreeSet<(NodeId, u32, NodeId)>,
+    ast_child_counts: BTreeSet<(NodeId, u32)>,
+    ast_super_classes: BTreeSet<(NodeId, NodeId)>,
+    ast_string_literals: BTreeSet<(NodeId, String)>,
+    ast_number_literals: BTreeSet<(NodeId, String)>,
+    ast_bool_literals: BTreeSet<(NodeId, bool)>,
+    ast_identifier_names: BTreeSet<(NodeId, String)>,
+    ast_property_names: BTreeSet<(NodeId, String)>,
+    ast_bare_properties: BTreeSet<(NodeId, String, String, bool)>,
+    ast_operators: BTreeSet<(NodeId, String)>,
+    ast_regex_literals: BTreeSet<(NodeId, String, String)>,
+    ast_top_levels: BTreeSet<(NodeId, StatementOrdinal)>,
 }
 
 impl FactDomains {
     fn from_program_and_facts(program: &SelectorProgram, facts: &SelectorFactStore) -> Self {
         let mut domains = Self::default();
         domains.add_facts(facts);
+        domains.add_derived_facts();
         domains.add_program_constants(program);
         domains
     }
@@ -515,19 +1054,79 @@ impl FactDomains {
                     self.add_string(binding);
                     self.add_string(edge_kind);
                 }
-                SelectorFact::AstKind { node, .. }
-                | SelectorFact::AstStringLiteral { node, .. }
-                | SelectorFact::AstNumberLiteral { node, .. }
-                | SelectorFact::AstBoolLiteral { node, .. }
-                | SelectorFact::AstIdentifierName { node, .. }
-                | SelectorFact::AstPropertyName { node, .. }
-                | SelectorFact::AstBareProperty { node, .. }
-                | SelectorFact::AstOperator { node, .. }
-                | SelectorFact::AstRegexLiteral { node, .. }
-                | SelectorFact::AstTopLevel { node, .. } => self.add_node(*node),
-                SelectorFact::AstChild { parent, child, .. } => {
+                SelectorFact::AstKind {
+                    node, node_kind, ..
+                } => {
+                    self.add_node(*node);
+                    self.ast_kinds
+                        .insert((*node, node_kind.as_tag().to_string()));
+                }
+                SelectorFact::AstStringLiteral { node, value, .. } => {
+                    self.add_node(*node);
+                    self.ast_string_literals.insert((*node, value.clone()));
+                }
+                SelectorFact::AstNumberLiteral { node, value, .. } => {
+                    self.add_node(*node);
+                    self.ast_number_literals.insert((*node, value.clone()));
+                }
+                SelectorFact::AstBoolLiteral { node, value, .. } => {
+                    self.add_node(*node);
+                    self.ast_bool_literals.insert((*node, *value));
+                }
+                SelectorFact::AstIdentifierName { node, value, .. } => {
+                    self.add_node(*node);
+                    self.ast_identifier_names.insert((*node, value.clone()));
+                }
+                SelectorFact::AstPropertyName { node, value, .. } => {
+                    self.add_node(*node);
+                    self.ast_property_names.insert((*node, value.clone()));
+                }
+                SelectorFact::AstBareProperty {
+                    node,
+                    key,
+                    identifier,
+                    is_binding,
+                    ..
+                } => {
+                    self.add_node(*node);
+                    self.ast_bare_properties.insert((
+                        *node,
+                        key.clone(),
+                        identifier.clone(),
+                        *is_binding,
+                    ));
+                }
+                SelectorFact::AstOperator { node, value, .. } => {
+                    self.add_node(*node);
+                    self.ast_operators.insert((*node, value.clone()));
+                }
+                SelectorFact::AstRegexLiteral {
+                    node,
+                    pattern,
+                    flags,
+                    ..
+                } => {
+                    self.add_node(*node);
+                    self.ast_regex_literals
+                        .insert((*node, pattern.clone(), flags.clone()));
+                }
+                SelectorFact::AstTopLevel {
+                    node,
+                    statement_ordinal,
+                    ..
+                } => {
+                    self.add_node(*node);
+                    self.ast_top_levels.insert((*node, *statement_ordinal));
+                }
+                SelectorFact::AstChild {
+                    parent,
+                    index,
+                    child,
+                    ..
+                } => {
                     self.add_node(*parent);
                     self.add_node(*child);
+                    self.ast_children.insert((*parent, *index, *child));
                 }
                 SelectorFact::AstSuperClass {
                     class_node,
@@ -536,6 +1135,7 @@ impl FactDomains {
                 } => {
                     self.add_node(*class_node);
                     self.add_node(*super_class);
+                    self.ast_super_classes.insert((*class_node, *super_class));
                 }
                 SelectorFact::MemberRead {
                     statement_ordinal,
@@ -594,6 +1194,48 @@ impl FactDomains {
             self.add_fact_strings(fact);
             self.add_fact_ordinals(fact);
         }
+    }
+
+    fn add_derived_facts(&mut self) {
+        let mut child_counts = BTreeMap::new();
+        for (parent, index, _child) in &self.ast_children {
+            let count = child_counts.entry(*parent).or_insert(0);
+            *count = (*count).max(index + 1);
+        }
+        self.ast_child_counts
+            .extend(child_counts.into_iter().collect::<BTreeSet<_>>());
+
+        for (owner, ordinal) in &self.owner_statement_ordinals {
+            for (node, top_level_ordinal) in &self.ast_top_levels {
+                if ordinal == top_level_ordinal {
+                    self.owner_top_level_roots.insert((*owner, *node));
+                }
+            }
+        }
+    }
+
+    fn ordinal_offset_rows(&self, offset: i32) -> BTreeSet<(StatementOrdinal, StatementOrdinal)> {
+        let ordinals = self
+            .ast_top_levels
+            .iter()
+            .map(|(_node, ordinal)| *ordinal)
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        let mut rows = BTreeSet::new();
+        for (base_index, base) in ordinals.iter().enumerate() {
+            let Some(target_index) = (base_index as isize).checked_add(offset as isize) else {
+                continue;
+            };
+            if target_index < 0 {
+                continue;
+            }
+            let Some(ordinal) = ordinals.get(target_index as usize) else {
+                continue;
+            };
+            rows.insert((*base, *ordinal));
+        }
+        rows
     }
 
     fn add_fact_strings(&mut self, fact: &SelectorFact) {
@@ -904,6 +1546,10 @@ mod tests {
         ConstraintValue::StatementOrdinal(StatementOrdinal(value))
     }
 
+    fn ast_node(value: u32) -> ConstraintValue {
+        ConstraintValue::AstNode(value)
+    }
+
     fn owner_fact(owner: usize, ordinal: usize, statement_kind: &str) -> SelectorFact {
         SelectorFact::Owner {
             chunk_id: ChunkId(0),
@@ -927,6 +1573,66 @@ mod tests {
             chunk_id: ChunkId(0),
             node,
             node_kind,
+        }
+    }
+
+    fn ast_child(parent: u32, index: u32, child: u32) -> SelectorFact {
+        SelectorFact::AstChild {
+            chunk_id: ChunkId(0),
+            parent,
+            index,
+            child,
+        }
+    }
+
+    fn ast_string_literal(node: u32, value: &str) -> SelectorFact {
+        SelectorFact::AstStringLiteral {
+            chunk_id: ChunkId(0),
+            node,
+            value: value.to_string(),
+        }
+    }
+
+    fn ast_identifier_name(node: u32, value: &str) -> SelectorFact {
+        SelectorFact::AstIdentifierName {
+            chunk_id: ChunkId(0),
+            node,
+            value: value.to_string(),
+        }
+    }
+
+    fn ast_bare_property(node: u32, key: &str, identifier: &str, is_binding: bool) -> SelectorFact {
+        SelectorFact::AstBareProperty {
+            chunk_id: ChunkId(0),
+            node,
+            key: key.to_string(),
+            identifier: identifier.to_string(),
+            is_binding,
+        }
+    }
+
+    fn ast_regex_literal(node: u32, pattern: &str, flags: &str) -> SelectorFact {
+        SelectorFact::AstRegexLiteral {
+            chunk_id: ChunkId(0),
+            node,
+            pattern: pattern.to_string(),
+            flags: flags.to_string(),
+        }
+    }
+
+    fn ast_super_class(class_node: u32, super_class: u32) -> SelectorFact {
+        SelectorFact::AstSuperClass {
+            chunk_id: ChunkId(0),
+            class_node,
+            super_class,
+        }
+    }
+
+    fn ast_top_level(node: u32, ordinal: usize) -> SelectorFact {
+        SelectorFact::AstTopLevel {
+            chunk_id: ChunkId(0),
+            node,
+            statement_ordinal: StatementOrdinal(ordinal),
         }
     }
 
@@ -1094,6 +1800,142 @@ mod tests {
     }
 
     #[test]
+    fn ast_fact_atoms_lower_to_allowed_tuple_constraints() {
+        let mut program = SelectorProgram::default();
+        let owner_var = program.add_variable(VariableDomain::Owner, Some("owner".to_string()));
+        let root_var = program.add_variable(VariableDomain::AstNode, Some("root".to_string()));
+        let ident_node_var =
+            program.add_variable(VariableDomain::AstNode, Some("ident_node".to_string()));
+        let literal_node_var =
+            program.add_variable(VariableDomain::AstNode, Some("literal_node".to_string()));
+        let prop_node_var =
+            program.add_variable(VariableDomain::AstNode, Some("prop_node".to_string()));
+        let super_node_var =
+            program.add_variable(VariableDomain::AstNode, Some("super_node".to_string()));
+        let ordinal_var = program.add_variable(
+            VariableDomain::StatementOrdinal,
+            Some("ordinal".to_string()),
+        );
+        let next_ordinal_var =
+            program.add_variable(VariableDomain::StatementOrdinal, Some("next".to_string()));
+        let ident_var = program.add_variable(VariableDomain::String, Some("ident".to_string()));
+        let regex_pattern_var =
+            program.add_variable(VariableDomain::String, Some("regex_pattern".to_string()));
+
+        program.add_atom(SelectorAtom::OwnerTopLevelRoot {
+            owner: OwnerTerm::Var { id: owner_var },
+            root: NodeTerm::Var { id: root_var },
+        });
+        program.add_atom(SelectorAtom::AstTopLevel {
+            node: NodeTerm::Var { id: root_var },
+            ordinal: OrdinalTerm::Var { id: ordinal_var },
+        });
+        program.add_atom(SelectorAtom::AstKind {
+            node: NodeTerm::Var { id: root_var },
+            node_kind: NodeKind::FnDecl,
+        });
+        program.add_atom(SelectorAtom::AstChild {
+            parent: NodeTerm::Var { id: root_var },
+            index: 0,
+            child: NodeTerm::Var { id: ident_node_var },
+        });
+        program.add_atom(SelectorAtom::AstChild {
+            parent: NodeTerm::Var { id: root_var },
+            index: 1,
+            child: NodeTerm::Var {
+                id: literal_node_var,
+            },
+        });
+        program.add_atom(SelectorAtom::AstChildCount {
+            node: NodeTerm::Var { id: root_var },
+            count: 2,
+        });
+        program.add_atom(SelectorAtom::AstIdentifierName {
+            node: NodeTerm::Var { id: ident_node_var },
+            value: StringTerm::Var { id: ident_var },
+        });
+        program.add_atom(SelectorAtom::AstStringLiteral {
+            node: NodeTerm::Var {
+                id: literal_node_var,
+            },
+            value: StringTerm::Const {
+                value: "needle".to_string(),
+            },
+        });
+        program.add_atom(SelectorAtom::AstBareProperty {
+            node: NodeTerm::Var { id: prop_node_var },
+            key: StringTerm::Const {
+                value: "key".to_string(),
+            },
+            identifier: StringTerm::Var { id: ident_var },
+            is_binding: true,
+        });
+        program.add_atom(SelectorAtom::AstRegexLiteral {
+            node: NodeTerm::Var { id: prop_node_var },
+            pattern: StringTerm::Var {
+                id: regex_pattern_var,
+            },
+            flags: StringTerm::Const {
+                value: "g".to_string(),
+            },
+        });
+        program.add_atom(SelectorAtom::AstSuperClass {
+            class_node: NodeTerm::Var { id: root_var },
+            super_class: NodeTerm::Var { id: super_node_var },
+        });
+        program.add_atom(SelectorAtom::OrdinalOffset {
+            base: OrdinalTerm::Var { id: ordinal_var },
+            ordinal: OrdinalTerm::Var {
+                id: next_ordinal_var,
+            },
+            offset: 1,
+        });
+
+        let facts = fact_store(vec![
+            owner_fact(1, 0, "function"),
+            owner_fact(2, 1, "function"),
+            ast_top_level(100, 0),
+            ast_top_level(200, 1),
+            ast_kind(100, NodeKind::FnDecl),
+            ast_kind(200, NodeKind::ClassDecl),
+            ast_child(100, 0, 110),
+            ast_child(100, 1, 120),
+            ast_identifier_name(110, "selectedIdent"),
+            ast_string_literal(120, "needle"),
+            ast_bare_property(130, "key", "selectedIdent", true),
+            ast_regex_literal(130, "^x", "g"),
+            ast_super_class(100, 140),
+        ]);
+
+        let model = build_selector_constraint_model(&program, &facts).unwrap();
+
+        assert_eq!(
+            allowed_tuples_for(&model, &[ConstraintVariableId(0), ConstraintVariableId(1)]).tuples,
+            vec![vec![owner(1), ast_node(100)], vec![owner(2), ast_node(200)]]
+        );
+        assert_eq!(
+            allowed_tuples_for(&model, &[ConstraintVariableId(1), ConstraintVariableId(2)]).tuples,
+            vec![vec![ast_node(100), ast_node(110)]]
+        );
+        assert_eq!(
+            allowed_tuples_for(&model, &[ConstraintVariableId(2), ConstraintVariableId(8)]).tuples,
+            vec![vec![ast_node(110), string("selectedIdent")]]
+        );
+        assert_eq!(
+            allowed_tuples_for(&model, &[ConstraintVariableId(4), ConstraintVariableId(8)]).tuples,
+            vec![vec![ast_node(130), string("selectedIdent")]]
+        );
+        assert_eq!(
+            allowed_tuples_for(&model, &[ConstraintVariableId(4), ConstraintVariableId(9)]).tuples,
+            vec![vec![ast_node(130), string("^x")]]
+        );
+        assert_eq!(
+            allowed_tuples_for(&model, &[ConstraintVariableId(6), ConstraintVariableId(7)]).tuples,
+            vec![vec![ordinal(0), ordinal(1)]]
+        );
+    }
+
+    #[test]
     fn explicit_binary_atoms_stay_binary_constraints() {
         let mut program = SelectorProgram::default();
         let left = program.add_variable(VariableDomain::StatementOrdinal, Some("left".to_string()));
@@ -1124,16 +1966,14 @@ mod tests {
     fn unsupported_atoms_fail_closed() {
         let mut program = SelectorProgram::default();
         let owner_var = program.add_variable(VariableDomain::Owner, Some("owner".to_string()));
-        let root_var = program.add_variable(VariableDomain::AstNode, Some("root".to_string()));
-        program.add_atom(SelectorAtom::OwnerTopLevelRoot {
+        let referenced_var =
+            program.add_variable(VariableDomain::Owner, Some("referenced".to_string()));
+        program.add_atom(SelectorAtom::OwnerReferencesOwner {
             owner: OwnerTerm::Var { id: owner_var },
-            root: NodeTerm::Var { id: root_var },
+            referenced: OwnerTerm::Var { id: referenced_var },
         });
 
-        let facts = fact_store(vec![
-            owner_fact(10, 0, "var"),
-            ast_kind(99, NodeKind::FnDecl),
-        ]);
+        let facts = fact_store(vec![owner_fact(10, 0, "var"), owner_fact(20, 1, "var")]);
 
         let err = build_selector_constraint_model(&program, &facts).unwrap_err();
         assert!(matches!(


### PR DESCRIPTION
## Summary

- lower basic AST/fact selector atoms into `SelectorConstraintModel` allowed-tuple constraints
- add derived model-builder fact indexes for owner-to-top-level-root joins, child counts, AST top-level ordinals, ordinal offsets, node kinds, children, superclass, literals, identifier/property/operator labels, bare properties, and regex literals
- add a synthetic model-builder test that verifies the generated finite-domain tuples for the new AST relations

## Why

This moves the backend path closer to the real Tana `source_match` workload without changing production solver behavior. It handles the first broad layer of AST facts; variable-length `AstChildListPattern` run-hole lowering remains separate follow-up work.

## Validation

- `nix develop -c pre-commit run --files devinfra/js/debundle/selector_constraint_model_builder.rs`
- `nix develop -c bbr test //devinfra/js/debundle:selector_constraint_model_builder_test --cache_test_results=no --test_output=errors`
  - BuildBuddy invocation: https://app.buildbuddy.io/invocation/4b61da32-aba0-45f7-bfad-dbf0a2ecfe79