### PR TITLE
haku/workloads: Flux pipe reconciling Haku's haku-state k8s/ under a constrained SA

### DIFF
--- a/cluster/k8s/haku/workloads/README.md
+++ b/cluster/k8s/haku/workloads/README.md
@@ -1,0 +1,32 @@
+# haku/workloads — Flux pipe for Haku's self-authored workloads
+
+Operator-owned plumbing that lets Haku run **persistent workloads** in `haku-sandbox`
+via GitOps (not just ad-hoc `kubectl apply`), while keeping the perimeter operator-owned.
+Haku writes manifests under `k8s/` in its `haku-state` repo (seeded from
+`haku/state_template/k8s/`); this pipe reconciles them.
+
+| Object                         | Kind                 | Namespace      | Role                                                                         |
+| ------------------------------ | -------------------- | -------------- | ---------------------------------------------------------------------------- |
+| `haku-state`                   | `GitRepository`      | `flux-system`  | source: Haku's state repo (internal Forgejo, read-only pull)                 |
+| `haku-state-workloads`         | `Kustomization`      | `flux-system`  | reconciles `haku-state` `./k8s` → `haku-sandbox`, impersonating the SA below |
+| `haku-state-reconciler`        | `ServiceAccount`     | `flux-system`  | impersonation identity for the apply                                         |
+| `haku-state-workload-deployer` | `Role`/`RoleBinding` | `haku-sandbox` | the only grant the SA has                                                    |
+
+**Containment.** The apply runs as `haku-state-reconciler` (`serviceAccountName` on the
+Kustomization), so it can only do what its Role allows: Deployments/StatefulSets/
+DaemonSets/ReplicaSets, Services/ConfigMaps/PVCs, Jobs/CronJobs — **no Secrets, no
+Gateway-API routes** (Kyverno denies routes in `haku-sandbox` too). `targetNamespace:
+haku-sandbox` forces everything into the one namespace regardless of what the manifests
+declare. So Haku gets a GitOps workload path that can never widen its own perimeter — it
+applies a strict subset of what Haku itself already could.
+
+**Trust posture (flagged for review).** This points cluster Flux at a repo Haku can
+write. The kustomize-controller will build agent-authored kustomize; the impersonation
+SA + `targetNamespace` pin + `prune` + the Kyverno route-deny are what bound the blast
+radius. Basic-auth uses the existing `haku-state-git-write` Secret (the only creds; the
+`haku` Forgejo user is r/w on its own repo — there is no separate read principal). A
+read-only deploy key would be tighter; deferred.
+
+Until Haku first seeds `k8s/`, `haku-state-workloads` is `NotReady` (path not found) —
+expected pre-first-run. First workload: the `haku-ui` placeholder
+(`haku/console/plans/free_form_ui_iframe.md`).

--- a/cluster/k8s/haku/workloads/flux-kustomization.yaml
+++ b/cluster/k8s/haku/workloads/flux-kustomization.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: haku-workloads
+  namespace: flux-system
+spec:
+  interval: 10m
+  retryInterval: 1m
+  timeout: 5m
+  path: ./cluster/k8s/haku/workloads
+  prune: true
+  # Don't gate on the inner haku-state-workloads Kustomization's readiness — it's
+  # NotReady until Haku first seeds k8s/, which would otherwise wedge this wrapper.
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  dependsOn:
+    # The forgejo/haku-state Terraform apply provisions the haku-state repo and the
+    # haku-state-git-write Secret (now also reflected into flux-system for the
+    # GitRepository's basic auth).
+    - name: haku-state

--- a/cluster/k8s/haku/workloads/gitrepository.yaml
+++ b/cluster/k8s/haku/workloads/gitrepository.yaml
@@ -1,0 +1,14 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: haku-state
+  namespace: flux-system
+  annotations:
+    description: "Haku's own state repo (internal Forgejo, plaintext HTTP). Source for the haku-state-workloads Kustomization, which reconciles Haku-authored manifests under k8s/ into haku-sandbox. Read-only pull; basic-auth via the haku-state-git-write Secret (the only creds available — Flux never pushes)."
+spec:
+  interval: 5m
+  url: http://forgejo-http.forgejo:3000/haku/haku-state.git
+  ref:
+    branch: main
+  secretRef:
+    name: haku-state-git-write

--- a/cluster/k8s/haku/workloads/kustomization.yaml
+++ b/cluster/k8s/haku/workloads/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - gitrepository.yaml
+  - serviceaccount.yaml
+  - rbac.yaml
+  - reconcile.yaml

--- a/cluster/k8s/haku/workloads/rbac.yaml
+++ b/cluster/k8s/haku/workloads/rbac.yaml
@@ -1,0 +1,40 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: haku-state-workload-deployer
+  namespace: haku-sandbox
+  annotations:
+    description: "What Flux may apply when reconciling Haku's haku-state k8s/ dir — the workload subset of haku-sandbox-admin: Deployments/StatefulSets/DaemonSets/ReplicaSets, Services/ConfigMaps/PVCs, Jobs/CronJobs. Deliberately NOT secrets (no plaintext-git secrets) and NOT Gateway-API routes (Kyverno denies those too). So Haku's GitOps path can run workloads but never widen its own perimeter."
+rules:
+  - apiGroups: [""]
+    resources:
+      - services
+      - configmaps
+      - persistentvolumeclaims
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+      - statefulsets
+      - daemonsets
+      - replicasets
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["batch"]
+    resources:
+      - jobs
+      - cronjobs
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: haku-state-workload-deployer
+  namespace: haku-sandbox
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: haku-state-workload-deployer
+subjects:
+  - kind: ServiceAccount
+    name: haku-state-reconciler
+    namespace: flux-system

--- a/cluster/k8s/haku/workloads/reconcile.yaml
+++ b/cluster/k8s/haku/workloads/reconcile.yaml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: haku-state-workloads
+  namespace: flux-system
+  annotations:
+    description: "Reconciles Haku-authored workload manifests (haku-state k8s/) into haku-sandbox. Impersonates the constrained haku-state-reconciler SA, so it may apply only what that SA's Role allows (Deployments/Services/ConfigMaps/Jobs/CronJobs/PVCs in haku-sandbox — no Secrets, no routes). Until Haku seeds k8s/ this is NotReady (path not found); that is expected pre-first-run."
+spec:
+  interval: 5m
+  retryInterval: 1m
+  timeout: 5m
+  path: ./k8s
+  prune: true
+  # Don't gate on workload health — these are Haku's own workloads; their
+  # readiness is Haku's concern, not the pipe's.
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: haku-state
+  # Force everything into haku-sandbox regardless of what the manifests declare,
+  # so Haku can't target another namespace via this pipe.
+  targetNamespace: haku-sandbox
+  # Apply as the constrained SA (kustomize-controller impersonates
+  # system:serviceaccount:flux-system:haku-state-reconciler). RBAC + Kyverno are
+  # the fence; this just executes a subset of what Haku itself could do.
+  serviceAccountName: haku-state-reconciler

--- a/cluster/k8s/haku/workloads/serviceaccount.yaml
+++ b/cluster/k8s/haku/workloads/serviceaccount.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: haku-state-reconciler
+  namespace: flux-system
+  annotations:
+    description: "Impersonation identity for the haku-state-workloads Kustomization. Lives in flux-system (kustomize-controller impersonates SAs in the Kustomization's own namespace); its only grant is the haku-state-workload-deployer Role in haku-sandbox."
+automountServiceAccountToken: false

--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -207,6 +207,7 @@ resources:
   - haku/console/flux-kustomization.yaml
   - haku/agent-worker/flux-kustomization.yaml # suspended; see the dir README to activate
   - haku/cloud-agent-tf/flux-kustomization.yaml # Anthropic-hosted agent via claude-managed-agents tofu provider
+  - haku/workloads/flux-kustomization.yaml # Flux reconciles Haku's haku-state k8s/ workloads under a constrained SA
 
   # --- matrix ---
   - matrix/namespace/flux-kustomization.yaml

--- a/tf/gitops/haku-state/main.tf
+++ b/tf/gitops/haku-state/main.tf
@@ -70,11 +70,15 @@ resource "forgejo_collaborator" "claude" {
 #     haku-sandbox) so it can hold secrets Haku may not read. The git creds are
 #     not such a secret (Haku writes haku-state anyway), but the console needs
 #     them there. See haku/PLAN.md → "The agent-authored console".
-# Each target namespace is created by its own Flux kustomization, which the
-# wrapping forgejo/haku-state Kustomization dependsOn; this resource retries
-# until the namespace exists.
+#   - flux-system: basic auth for the haku-state GitRepository, which the
+#     haku-state-workloads Kustomization reconciles into haku-sandbox under a
+#     constrained SA (cluster/k8s/haku/workloads). Read-only pull — Flux never
+#     pushes; the haku user is just the only principal on the repo.
+# The haku-sandbox/haku-console namespaces are each created by their own Flux
+# kustomization (the wrapping forgejo/haku-state Kustomization dependsOn them);
+# flux-system always exists. This resource retries until each namespace exists.
 resource "kubernetes_secret" "haku_state_git_write" {
-  for_each = toset(["haku-sandbox", "haku-console"])
+  for_each = toset(["haku-sandbox", "haku-console", "flux-system"])
 
   metadata {
     name      = "haku-state-git-write"


### PR DESCRIPTION
PR2 of the free-form-UI arc (`haku/console/plans/free_form_ui_iframe.md`). The operator-owned **perimeter pipe**. Depends on **#2520** at runtime (which seeds `k8s/` into haku-state) but is file-independent. **No public exposure** — `haku-ui` is reachable only in-cluster (ClusterIP) until the Authentik route lands (PR3).

## What it does
Gives Haku a **GitOps path** for persistent workloads in `haku-sandbox` (vs. ad-hoc `kubectl apply`), while the perimeter stays operator-owned. Haku writes manifests under `k8s/` in `haku-state`; this pipe reconciles them.

`cluster/k8s/haku/workloads/`:
| Object | Kind | Namespace |
|---|---|---|
| `haku-state` | `GitRepository` | `flux-system` |
| `haku-state-workloads` | `Kustomization` | `flux-system` |
| `haku-state-reconciler` | `ServiceAccount` | `flux-system` |
| `haku-state-workload-deployer` | `Role` + `RoleBinding` | `haku-sandbox` |

## Containment (the crux — please review)
- The `Kustomization` applies via **`serviceAccountName: haku-state-reconciler`** — kustomize-controller impersonates that SA, so the apply can only do what its Role grants: **Deployments/StatefulSets/DaemonSets/ReplicaSets, Services/ConfigMaps/PVCs, Jobs/CronJobs** — **NOT Secrets, NOT Gateway-API routes** (Kyverno denies routes in haku-sandbox too). A strict subset of what Haku itself already could.
- **`targetNamespace: haku-sandbox`** forces every applied object into the one namespace regardless of what the manifest declares.
- `prune: true`. So Haku's GitOps path can run workloads but **never widen its own perimeter**.

## Trust posture (flagged)
This points cluster Flux at a **Haku-writable repo**. The kustomize-controller builds agent-authored kustomize; the impersonation SA + targetNamespace pin + prune + Kyverno route-deny bound the blast radius. Basic-auth reuses the existing `haku-state-git-write` Secret (now also reflected into `flux-system` by `tf/gitops/haku-state`) — the `haku` Forgejo user is the only principal on the repo, and Flux only pulls. A read-only deploy key would be tighter; noted as a follow-up.

## Until Haku seeds `k8s/`
`haku-state-workloads` is `NotReady` (path not found) — expected pre-first-run. The wrapper sets `wait: false` so it doesn't wedge on that.

## Verification
- `kubeconform (cluster)`, cluster-validate, Checkov, tflint — all green via pre-commit.
- Post-merge: tofu applies the flux-system secret → GitRepository authenticates; once Haku seeds `k8s/`, `haku-ui` runs in haku-sandbox (verify by `kubectl -n haku-sandbox port-forward svc/haku-ui 8080:80`).

## Next
- **PR3** — Authentik proxy provider/app/outpost + HTTPRoute `haku-ui.allegedly.works` (in `authentik` ns) + NetworkPolicy.
- **PR4** — console CSP + sandboxed iframe (auth-in-iframe go/no-go).