### PR TITLE
haku-ui: Authentik-gated route haku-ui.allegedly.works

### DIFF
--- a/cluster/k8s/TODO.md
+++ b/cluster/k8s/TODO.md
@@ -162,3 +162,21 @@ closed (its UI must reach the operator only via the Authentik route).
       manifest to carry a selector label. Revisit if/when #42159 is fixed and there's a
       clean way to label those built-in namespaces — then switch listeners to
       `from: Selector` and the denylist becomes redundant.
+
+## Haku `haku-ui` / workloads pipe — hardening follow-ups
+
+The `cluster/k8s/haku/workloads/` Flux pipe and the `haku-ui.allegedly.works`
+Authentik route work; these tighten them (operator-approved as follow-ups):
+
+- [ ] **Read-only deploy key for the `haku-state` GitRepository.** The pipe's
+      `GitRepository` reuses the r/w `haku-state-git-write` Secret for basic auth
+      (Flux only pulls, but the cred is read/write — there's no separate read
+      principal on the repo). Mint a read-only Forgejo deploy key for `haku-state`
+      and point the GitRepository's `secretRef` at it instead.
+- [ ] **Ingress NetworkPolicy restricting `haku-ui` to the Authentik outpost.**
+      `haku-sandbox` has default-allow ingress (the mitmproxy fence is egress-only),
+      so any in-cluster pod can reach `svc/haku-ui` directly — external access is
+      still gateway→Authentik only, so this is defense-in-depth, not a perimeter
+      hole. Add a CiliumNetworkPolicy selecting `app: haku-ui` that admits ingress
+      only from the `authentik` server pods (same gap the README tracks for
+      `agents-mitmproxy`/`proxmox`).

--- a/cluster/k8s/authentik/app/blueprints/embedded-outpost.yaml
+++ b/cluster/k8s/authentik/app/blueprints/embedded-outpost.yaml
@@ -37,4 +37,5 @@ entries:
         - !Find [authentik_providers_proxy.proxyprovider, [name, openhands]]
         - !Find [authentik_providers_proxy.proxyprovider, [name, fava]]
         - !Find [authentik_providers_proxy.proxyprovider, [name, haku-dashboard]]
+        - !Find [authentik_providers_proxy.proxyprovider, [name, haku-ui]]
         - !Find [authentik_providers_proxy.proxyprovider, [name, tandoor]]

--- a/cluster/k8s/authentik/app/blueprints/haku-ui-sso.yaml
+++ b/cluster/k8s/authentik/app/blueprints/haku-ui-sso.yaml
@@ -1,0 +1,40 @@
+version: 1
+metadata:
+  name: SSO - Haku UI
+  labels:
+    blueprints.goauthentik.io/description: "Haku-authored UI (runs in haku-sandbox) proxy provider, application, and single-user access binding"
+
+entries:
+  - model: authentik_providers_proxy.proxyprovider
+    id: haku-ui-provider
+    state: present
+    identifiers:
+      name: haku-ui
+    attrs:
+      external_host: "https://haku-ui.allegedly.works"
+      internal_host: "http://haku-ui.haku-sandbox.svc.cluster.local:80"
+      mode: proxy
+      authentication_flow: !Find [authentik_flows.flow, [slug, default-authentication-flow]]
+      authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+      invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      access_token_validity: "hours=24"
+
+  - model: authentik_core.application
+    id: haku-ui-app
+    state: present
+    identifiers:
+      slug: haku-ui
+    attrs:
+      name: Haku UI
+      provider: !KeyOf haku-ui-provider
+      meta_description: "Haku's own UI service — agent-authored, runs in haku-sandbox, embedded in the Haku console iframe"
+      meta_launch_url: "https://haku-ui.allegedly.works"
+      open_in_new_tab: true
+
+  # Restrict access to the single user agentydragon (mirrors haku-dashboard).
+  - model: authentik_policies.policybinding
+    state: present
+    identifiers:
+      target: !KeyOf haku-ui-app
+      user: !Find [authentik_core.user, [username, agentydragon]]
+      order: 0

--- a/cluster/k8s/authentik/app/kustomization.yaml
+++ b/cluster/k8s/authentik/app/kustomization.yaml
@@ -33,4 +33,5 @@ configMapGenerator:
       - blueprints/openhands-sso.yaml
       - blueprints/fava-sso.yaml
       - blueprints/haku-dashboard-sso.yaml
+      - blueprints/haku-ui-sso.yaml
     namespace: authentik

--- a/cluster/k8s/authentik/proxy-routes/haku-ui-httproute.yaml
+++ b/cluster/k8s/authentik/proxy-routes/haku-ui-httproute.yaml
@@ -1,0 +1,21 @@
+# HTTPRoute for the agent-authored Haku UI via the shared Authentik proxy outpost.
+# Traffic flows: Gateway -> outpost (auth, agentydragon-only) -> haku-ui backend
+# (Service haku-ui in haku-sandbox, via the provider's internal_host).
+# Operator-owned by construction: Kyverno forbids Haku creating routes in
+# haku-sandbox, so this authentik-namespace route is the only public path to haku-ui.
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: haku-ui
+  namespace: authentik
+spec:
+  parentRefs:
+    - name: cluster-gateway
+      namespace: gateway-system
+  hostnames:
+    - "haku-ui.allegedly.works"
+  rules:
+    - backendRefs:
+        - name: authentik-server
+          port: 80

--- a/cluster/k8s/authentik/proxy-routes/kustomization.yaml
+++ b/cluster/k8s/authentik/proxy-routes/kustomization.yaml
@@ -18,3 +18,4 @@ resources:
   - openhands-httproute.yaml
   - fava-httproute.yaml
   - haku-dashboard-httproute.yaml
+  - haku-ui-httproute.yaml


### PR DESCRIPTION
PR3 of the free-form-UI arc (`haku/console/plans/free_form_ui_iframe.md`). Exposes Haku's `haku-ui` workload operator-only via the shared Authentik proxy outpost — exactly how the console (`haku.allegedly.works`) is gated. File-independent of #2520/#2524; **503s until `haku-ui` exists** (PR2 pipe + Haku seeding `k8s/`).

## What it adds
- `authentik/app/blueprints/haku-ui-sso.yaml` — proxy provider (`external_host` `haku-ui.allegedly.works` → `internal_host` `haku-ui.haku-sandbox.svc:80`), application, and a **single-user (agentydragon)** access binding. Registered in the app `configMapGenerator` + on the embedded outpost.
- `authentik/proxy-routes/haku-ui-httproute.yaml` — HTTPRoute in the `authentik` namespace → `authentik-server`. **Operator-owned by construction**: Kyverno forbids Haku creating routes in `haku-sandbox`, so this is the only public path to `haku-ui`.

## Networking
No NetworkPolicy needed for the outpost→`haku-ui` hop: `haku-sandbox` has **default-allow ingress** (the mitmproxy fence — `ccnp-haku-proxy-egress` — is egress-only), same as the console namespace. External access remains gateway→Authentik only, so the perimeter property ("no public exposure without Authentik") holds.

## Follow-ups (operator-approved, in `cluster/k8s/TODO.md`)
- Read-only deploy key for the workloads-pipe `GitRepository` (currently reuses the r/w `haku-state-git-write`; Flux only pulls).
- Defense-in-depth: a CiliumNetworkPolicy restricting `haku-ui` ingress to only the Authentik outpost (same gap the README tracks for `agents-mitmproxy`/`proxmox`).

## Verification
- `kubeconform (cluster)` + cluster-validate + prettier — green via pre-commit.
- Post-merge (after #2524 + first seed): `https://haku-ui.allegedly.works` serves the placeholder behind Authentik, agentydragon-only.

## Next
- **PR4** — console CSP + sandboxed iframe embedding `haku-ui.allegedly.works` (the auth-in-iframe go/no-go).