### PR TITLE
airlock: cover expired OAuth provider status

### DIFF
--- a/airlock/models.py
+++ b/airlock/models.py
@@ -213,9 +213,9 @@ WaitMode = Annotated[BlockingWait | YieldAfterMs, Field(discriminator="mode")]
 
 
 class ConnectedOAuthStatus(BaseModel):
-    state: Literal["connected"] = "connected"
-    expires_at: datetime
-    scope: str
+    state: Literal["connected"] = Field(default="connected", description="Provider has a valid stored access token")
+    expires_at: datetime = Field(description="Access token expiry timestamp")
+    scope: str = Field(description="Provider-granted scope string stored with the access token")
 
     model_config = ConfigDict(extra="forbid")
 
@@ -227,9 +227,9 @@ class ExpiredOAuthStatus(BaseModel):
     (e.g. the refresh token was revoked). Re-authorization is required.
     """
 
-    state: Literal["expired"] = "expired"
-    expires_at: datetime
-    scope: str
+    state: Literal["expired"] = Field(default="expired", description="Stored access token has expired")
+    expires_at: datetime = Field(description="Expired access token timestamp")
+    scope: str = Field(description="Provider-granted scope string stored with the expired token")
     last_refresh_error: str | None = Field(
         default=None, description="Most recent error from the background refresh loop, if any."
     )
@@ -238,7 +238,7 @@ class ExpiredOAuthStatus(BaseModel):
 
 
 class DisconnectedOAuthStatus(BaseModel):
-    state: Literal["disconnected"] = "disconnected"
+    state: Literal["disconnected"] = Field(default="disconnected", description="Provider has no stored token")
 
     model_config = ConfigDict(extra="forbid")
 
@@ -268,7 +268,7 @@ class OAuthProviderStatus(BaseModel):
             "connected token to surface scope drift (re-auth required)."
         )
     )
-    status: OAuthConnectionStatus
+    status: OAuthConnectionStatus = Field(description="Current token connection state for this provider")
 
     model_config = ConfigDict(extra="forbid")
 

--- a/airlock/test_app_integration.py
+++ b/airlock/test_app_integration.py
@@ -6,6 +6,9 @@ at startup, causing /api/actions to return 500.
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Mapping
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from textwrap import dedent
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -22,7 +25,14 @@ from starlette.routing import Mount
 from airlock.app import create_app
 from airlock.config import Settings
 from airlock.conftest import GateClient, agent_transport, serve_app
-from airlock.oauth.provider import OAuthConfig
+from airlock.oauth.k8s_client import K8sTokenStore
+from airlock.oauth.provider import (
+    GenericOAuth2Provider,
+    OAuth2ProviderConfig,
+    OAuthConfig,
+    TokenData,
+    TokenSecretConfig,
+)
 from mcp_infra.prefix import MCPMountPrefix
 from util.net import pick_free_port
 
@@ -47,16 +57,16 @@ def predicate_file(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
-def _mock_k8s_store():
+def mock_k8s_store():
     """Patch K8sTokenStore.from_incluster since tests don't run in a k8s pod."""
     mock_store = MagicMock()
     mock_store.list_secrets = AsyncMock(return_value=[])
     mock_store.delete_orphaned_secrets = AsyncMock()
     with patch("airlock.app.K8sTokenStore.from_incluster", new_callable=AsyncMock, return_value=mock_store):
-        yield
+        yield mock_store
 
 
-@pytest.mark.usefixtures("_mock_k8s_store")
+@pytest.mark.usefixtures("mock_k8s_store")
 async def test_rest_api_works_after_startup(rsa_key_pair: RSAKeyPair, predicate_file: Path, db_url: str):
     """GET /api/actions returns 200 immediately — no MCP client needed."""
     port = pick_free_port()
@@ -82,7 +92,83 @@ async def test_rest_api_works_after_startup(rsa_key_pair: RSAKeyPair, predicate_
         assert r.json() == []
 
 
-@pytest.mark.usefixtures("_mock_k8s_store")
+async def test_oauth_providers_reports_expired_token_status(
+    rsa_key_pair: RSAKeyPair,
+    predicate_file: Path,
+    db_url: str,
+    monkeypatch: pytest.MonkeyPatch,
+    mock_k8s_store: MagicMock,
+):
+    monkeypatch.setenv("TEST_CLIENT_ID", "test-client-id")
+    monkeypatch.setenv("TEST_CLIENT_SECRET", "test-client-secret")
+    expired_token = TokenData(
+        access_token="old-access",
+        refresh_token="old-refresh",
+        expires_at=datetime.now(UTC) - timedelta(minutes=5),
+        scope="daily sleep",
+    )
+    mock_k8s_store.read_token = AsyncMock(return_value=expired_token)
+
+    def fake_token_refresh_loop(
+        providers: Mapping[str, GenericOAuth2Provider],
+        k8s_store: K8sTokenStore,
+        target_namespace: str,
+        check_interval: float = 300,
+        refresh_errors: dict[str, str] | None = None,
+    ):
+        assert refresh_errors is not None
+        refresh_errors["test"] = "RuntimeError('refresh failed')"
+
+        async def wait_forever() -> None:
+            await asyncio.Event().wait()
+
+        return wait_forever()
+
+    port = pick_free_port()
+    settings = Settings(
+        backends={},
+        public_base_url=f"http://127.0.0.1:{port}",
+        db_url=db_url,
+        predicate_path=predicate_file,
+        oidc_issuer="https://unused.example.com",
+        oidc_client_id="test",
+        oauth=OAuthConfig(
+            target_namespace="airlock-test",
+            providers=[
+                OAuth2ProviderConfig(
+                    name="test",
+                    display_name="Test Provider",
+                    authorize_url="https://example.com/authorize",
+                    token_url="https://example.com/token",
+                    scopes=["daily", "sleep"],
+                    redirect_uri="https://example.com/callback/test",
+                    refresh_secret=TokenSecretConfig(name="test-refresh"),
+                    access_secret=TokenSecretConfig(name="test-access"),
+                )
+            ],
+        ),
+        port=port,
+    )
+    auth = JWTVerifier(public_key=rsa_key_pair.public_key)
+
+    with patch("airlock.app.token_refresh_loop", side_effect=fake_token_refresh_loop):
+        app = create_app(settings, auth=auth, include_static=False)
+        async with serve_app(app, port=port), httpx.AsyncClient(base_url=f"http://127.0.0.1:{port}") as http:
+            r = await http.get("/api/oauth/providers")
+
+    assert r.status_code == 200
+    providers = r.json()
+    assert len(providers) == 1
+    assert providers[0]["name"] == "test"
+    assert providers[0]["display_name"] == "Test Provider"
+    assert providers[0]["requested_scopes"] == ["daily", "sleep"]
+    assert providers[0]["status"]["state"] == "expired"
+    assert providers[0]["status"]["scope"] == "daily sleep"
+    assert providers[0]["status"]["last_refresh_error"] == "RuntimeError('refresh failed')"
+    mock_k8s_store.read_token.assert_called_once_with("test-refresh", "airlock-test")
+
+
+@pytest.mark.usefixtures("mock_k8s_store")
 async def test_mcp_action_visible_via_rest(rsa_key_pair: RSAKeyPair, predicate_file: Path, db_url: str):
     """An action created via MCP appears in GET /api/actions."""
     port = pick_free_port()


### PR DESCRIPTION
## Summary
- add OpenAPI field descriptions for OAuth provider status payloads
- add an integration test proving expired OAuth tokens surface `last_refresh_error` through `/api/oauth/providers`

## Validation
- `pre-commit run --files airlock/models.py airlock/test_app_integration.py`
- `bbr test //airlock/...` (BuildBuddy invocation `8f262f21-e45d-48e3-ae57-78da90d8a537`)