### PR TITLE
haku/console: embed Haku UI in a sandboxed iframe + frame-src CSP

### DIFF
--- a/cluster/k8s/haku/console/deployment.yaml
+++ b/cluster/k8s/haku/console/deployment.yaml
@@ -78,6 +78,13 @@ spec:
                 secretKeyRef:
                   name: haku-routine-launch-token
                   key: token
+            # Free-form UI (Phase 1b): the Authentik-gated origin of Haku's own UI
+            # service (haku-sandbox). The console embeds it in a sandboxed cross-origin
+            # iframe and sets a CSP frame-src for it; it never renders Haku's UI itself.
+            # Lights up once the haku-ui workload serves (cluster/k8s/haku/workloads +
+            # the haku-ui Authentik route). See haku/console/plans/free_form_ui_iframe.md.
+            - name: HAKU_CONSOLE_HAKU_UI_URL
+              value: https://haku-ui.allegedly.works
           resources:
             requests:
               cpu: 50m

--- a/haku/console/app.py
+++ b/haku/console/app.py
@@ -17,9 +17,10 @@ import contextlib
 import datetime as dt
 import logging
 import secrets
+from collections.abc import Awaitable, Callable
 
 import uvicorn
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, Response
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi_csrf_protect import CsrfProtect
@@ -61,6 +62,19 @@ def create_app(settings: Settings, *, git_state: GitState) -> FastAPI:
     app.state.git_state = git_state
     app.state.settings = settings
 
+    # Content-Security-Policy: let the dashboard frame Haku's own UI origin (the
+    # sandboxed cross-origin iframe) and nothing else, and forbid the console itself
+    # from being framed. Only frame-* is set, so the SPA's own scripts/styles are
+    # unaffected. See haku/console/plans/free_form_ui_iframe.md.
+    frame_src = f"'self' {settings.haku_ui_url}" if settings.haku_ui_url else "'none'"
+    csp = f"frame-src {frame_src}; frame-ancestors 'none'"
+
+    @app.middleware("http")
+    async def _csp_headers(request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
+        response = await call_next(request)
+        response.headers["Content-Security-Policy"] = csp
+        return response
+
     # CSRF for the capability tier: a header-located double-submit token (the SPA
     # echoes the token from GET /api/capabilities/csrf in X-CSRF-Token). Use the
     # configured secret, else an ephemeral one (fine for the single-replica console
@@ -86,7 +100,11 @@ def create_app(settings: Settings, *, git_state: GitState) -> FastAPI:
         clicked = [Click(item_id=item_id, action_id=action_id) for item_id, action_id in sorted(clicks)]
         launch = settings.launch_routine
         return DashboardResponse(
-            scan_time=scan_time, items=items, clicks=clicked, launch_routine_url=launch.page_url if launch else None
+            scan_time=scan_time,
+            items=items,
+            clicks=clicked,
+            launch_routine_url=launch.page_url if launch else None,
+            haku_ui_url=settings.haku_ui_url,
         )
 
     app.include_router(trace.router)

--- a/haku/console/config.py
+++ b/haku/console/config.py
@@ -60,3 +60,10 @@ class Settings(BaseSettings):
     # makes the SPA refetch its token).
     launch_routine: LaunchRoutineConfig | None = None
     csrf_secret: SecretStr | None = None
+
+    # Free-form UI (Phase 1b): the Authentik-gated origin of Haku's own UI service
+    # (runs in haku-sandbox), embedded in the console as a sandboxed cross-origin
+    # iframe. When set, the dashboard surfaces the embed and the CSP allows framing
+    # that origin (and only it); unset → the feature is dormant. The console never
+    # renders Haku's UI itself. See haku/console/plans/free_form_ui_iframe.md.
+    haku_ui_url: str | None = None

--- a/haku/console/frontend/BUILD.bazel
+++ b/haku/console/frontend/BUILD.bazel
@@ -83,12 +83,22 @@ js_library(
 )
 
 js_library(
+    name = "haku_ui",
+    srcs = ["haku_ui.tsx"],
+    deps = [
+        "//:node_modules/@mantine/core",
+        "//:node_modules/react",
+    ],
+)
+
+js_library(
     name = "app",
     srcs = ["app.tsx"],
     deps = [
         ":client",
         ":constants",
         ":feedback",
+        ":haku_ui",
         ":launch",
         ":task",
         ":toast",
@@ -136,6 +146,7 @@ filegroup(
         "client.ts",
         "constants.ts",
         "feedback.tsx",
+        "haku_ui.tsx",
         "index.html",
         "launch.tsx",
         "main.tsx",

--- a/haku/console/frontend/BUILD.bazel
+++ b/haku/console/frontend/BUILD.bazel
@@ -86,7 +86,6 @@ js_library(
     name = "haku_ui",
     srcs = ["haku_ui.tsx"],
     deps = [
-        "//:node_modules/@mantine/core",
         "//:node_modules/react",
     ],
 )

--- a/haku/console/frontend/app.tsx
+++ b/haku/console/frontend/app.tsx
@@ -4,6 +4,7 @@ import { Anchor, Group, Loader, Text, Title } from "@mantine/core";
 import { type DashboardResponse, type Item, clickAction, fetchDashboard, unclickAction } from "./client.ts";
 import { INTAKE_NEW, UP_NEXT } from "./constants.ts";
 import { FeedbackForm } from "./feedback.tsx";
+import { HakuUiButton } from "./haku_ui.tsx";
 import { LaunchRoutineButton } from "./launch.tsx";
 import { TaskCard, clickKey } from "./task.tsx";
 import { toastError } from "./toast.ts";
@@ -79,7 +80,10 @@ export default function App() {
     <div className="mx-auto max-w-3xl px-4 py-8">
       <Group justify="space-between" align="center">
         <Title order={1}>Haku</Title>
-        <LaunchRoutineButton routineUrl={data.launch_routine_url} />
+        <Group>
+          <HakuUiButton uiUrl={data.haku_ui_url} />
+          <LaunchRoutineButton routineUrl={data.launch_routine_url} />
+        </Group>
       </Group>
       <Text c="dimmed" mb="lg">
         Your value-ranked backlog ·{" "}

--- a/haku/console/frontend/app.tsx
+++ b/haku/console/frontend/app.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from "react";
-import { Anchor, Group, Loader, Text, Title } from "@mantine/core";
+import { Anchor, Group, Loader, Tabs, Text, Title } from "@mantine/core";
 
 import { type DashboardResponse, type Item, clickAction, fetchDashboard, unclickAction } from "./client.ts";
 import { INTAKE_NEW, UP_NEXT } from "./constants.ts";
 import { FeedbackForm } from "./feedback.tsx";
-import { HakuUiButton } from "./haku_ui.tsx";
+import { HakuUiFrame } from "./haku_ui.tsx";
 import { LaunchRoutineButton } from "./launch.tsx";
 import { TaskCard, clickKey } from "./task.tsx";
 import { toastError } from "./toast.ts";
@@ -76,61 +76,82 @@ export default function App() {
   const upNext = open.slice(0, UP_NEXT);
   const backlog = open.slice(UP_NEXT);
 
+  // Two peer views as tabs: the trusted "Action items" dashboard, and "Free-form UI"
+  // (Haku's own UI in a sandboxed iframe — only when configured). The items column
+  // stays readable (max-w-3xl); the UI tab breaks out to full width for room.
   return (
-    <div className="mx-auto max-w-3xl px-4 py-8">
-      <Group justify="space-between" align="center">
-        <Title order={1}>Haku</Title>
-        <Group>
-          <HakuUiButton uiUrl={data.haku_ui_url} />
+    <div className="px-4 py-8">
+      <div className="mx-auto max-w-3xl">
+        <Group justify="space-between" align="center">
+          <Title order={1}>Haku</Title>
           <LaunchRoutineButton routineUrl={data.launch_routine_url} />
         </Group>
-      </Group>
-      <Text c="dimmed" mb="lg">
-        Your value-ranked backlog ·{" "}
-        <Anchor href={INTAKE_NEW} c="dimmed" underline="always">
-          + Add intake note
-        </Anchor>
-      </Text>
+        <Text c="dimmed" mb="lg">
+          Your value-ranked backlog ·{" "}
+          <Anchor href={INTAKE_NEW} c="dimmed" underline="always">
+            + Add intake note
+          </Anchor>
+        </Text>
+      </div>
 
-      <Title order={2} mt="xl" mb="sm">
-        Up next
-      </Title>
-      {upNext.length > 0 ? (
-        upNext.map((item) => <TaskCard key={item.id} item={item} clicked={clicked} onToggle={onToggle} />)
-      ) : (
-        <Text>No open items.</Text>
-      )}
-      {backlog.length > 0 && (
-        <details className="my-4">
-          <summary className="cursor-pointer font-semibold">Backlog — {backlog.length} more open item(s)</summary>
-          {backlog.map((item) => (
-            <TaskCard key={item.id} item={item} clicked={clicked} onToggle={onToggle} />
-          ))}
-        </details>
-      )}
+      <Tabs defaultValue="items">
+        <div className="mx-auto max-w-3xl">
+          <Tabs.List>
+            <Tabs.Tab value="items">Action items</Tabs.Tab>
+            {data.haku_ui_url && <Tabs.Tab value="ui">Free-form UI</Tabs.Tab>}
+          </Tabs.List>
+        </div>
 
-      <section className="mt-10">
-        <Title order={2} mb="sm">
-          Note to Haku
-        </Title>
-        <FeedbackForm
-          minRows={3}
-          placeholder="Anything for Haku to fold into its next run…"
-          submitLabel="Send to Haku"
-        />
-      </section>
+        <Tabs.Panel value="items">
+          <div className="mx-auto max-w-3xl">
+            <Title order={2} mt="xl" mb="sm">
+              Up next
+            </Title>
+            {upNext.length > 0 ? (
+              upNext.map((item) => <TaskCard key={item.id} item={item} clicked={clicked} onToggle={onToggle} />)
+            ) : (
+              <Text>No open items.</Text>
+            )}
+            {backlog.length > 0 && (
+              <details className="my-4">
+                <summary className="cursor-pointer font-semibold">Backlog — {backlog.length} more open item(s)</summary>
+                {backlog.map((item) => (
+                  <TaskCard key={item.id} item={item} clicked={clicked} onToggle={onToggle} />
+                ))}
+              </details>
+            )}
 
-      <Text
-        component="footer"
-        c="dimmed"
-        size="sm"
-        mt="xl"
-        className="border-t border-slate-200 pt-4 dark:border-slate-700"
-      >
-        {open.length} open · {statusCounts(data.items)}
-        <br />
-        Last scan: {data.scan_time}
-      </Text>
+            <section className="mt-10">
+              <Title order={2} mb="sm">
+                Note to Haku
+              </Title>
+              <FeedbackForm
+                minRows={3}
+                placeholder="Anything for Haku to fold into its next run…"
+                submitLabel="Send to Haku"
+              />
+            </section>
+
+            <Text
+              component="footer"
+              c="dimmed"
+              size="sm"
+              mt="xl"
+              className="border-t border-slate-200 pt-4 dark:border-slate-700"
+            >
+              {open.length} open · {statusCounts(data.items)}
+              <br />
+              Last scan: {data.scan_time}
+            </Text>
+          </div>
+        </Tabs.Panel>
+
+        {data.haku_ui_url && (
+          <Tabs.Panel value="ui">
+            <HakuUiFrame uiUrl={data.haku_ui_url} />
+          </Tabs.Panel>
+        )}
+      </Tabs>
     </div>
   );
 }

--- a/haku/console/frontend/haku_ui.tsx
+++ b/haku/console/frontend/haku_ui.tsx
@@ -1,0 +1,35 @@
+import { useState } from "react";
+import { Button, Modal } from "@mantine/core";
+
+// Embeds Haku's own UI service — a separate, Authentik-gated origin running in
+// haku-sandbox — in a sandboxed cross-origin iframe. The console never renders
+// Haku's UI itself; it only frames this origin (the backend CSP frame-src is what
+// permits the embed). `allow-same-origin` keeps the framed app on its OWN origin (a
+// different subdomain, so NOT the console's) so its Authentik session cookie works;
+// being cross-origin, it cannot reach into the parent. No `allow="fullscreen"` and no
+// allow-top-navigation, so it stays contained. See plans/free_form_ui_iframe.md.
+export function HakuUiButton({ uiUrl }: { uiUrl: string | null | undefined }) {
+  const [opened, setOpened] = useState(false);
+  if (!uiUrl) return null;
+  return (
+    <>
+      <Button variant="default" onClick={() => setOpened(true)}>
+        Haku UI
+      </Button>
+      <Modal
+        opened={opened}
+        onClose={() => setOpened(false)}
+        title="Haku UI"
+        size="90%"
+        styles={{ body: { height: "80vh", padding: 0 } }}
+      >
+        <iframe
+          src={uiUrl}
+          title="Haku UI"
+          sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+          style={{ width: "100%", height: "100%", border: 0 }}
+        />
+      </Modal>
+    </>
+  );
+}

--- a/haku/console/frontend/haku_ui.tsx
+++ b/haku/console/frontend/haku_ui.tsx
@@ -1,35 +1,19 @@
-import { useState } from "react";
-import { Button, Modal } from "@mantine/core";
-
-// Embeds Haku's own UI service — a separate, Authentik-gated origin running in
-// haku-sandbox — in a sandboxed cross-origin iframe. The console never renders
-// Haku's UI itself; it only frames this origin (the backend CSP frame-src is what
-// permits the embed). `allow-same-origin` keeps the framed app on its OWN origin (a
-// different subdomain, so NOT the console's) so its Authentik session cookie works;
-// being cross-origin, it cannot reach into the parent. No `allow="fullscreen"` and no
-// allow-top-navigation, so it stays contained. See plans/free_form_ui_iframe.md.
-export function HakuUiButton({ uiUrl }: { uiUrl: string | null | undefined }) {
-  const [opened, setOpened] = useState(false);
-  if (!uiUrl) return null;
+// Haku's own UI service — a separate, Authentik-gated origin running in
+// haku-sandbox — embedded in a sandboxed cross-origin iframe as the "Free-form UI"
+// tab. The console never renders Haku's UI itself; it only frames this origin (the
+// backend CSP frame-src is what permits the embed). `allow-same-origin` keeps the
+// framed app on its OWN origin (a different subdomain, so NOT the console's) so its
+// Authentik session cookie works; being cross-origin, it cannot reach into the
+// parent. No `allow="fullscreen"` and no allow-top-navigation, so it stays
+// contained. See plans/free_form_ui_iframe.md.
+export function HakuUiFrame({ uiUrl }: { uiUrl: string }) {
   return (
-    <>
-      <Button variant="default" onClick={() => setOpened(true)}>
-        Haku UI
-      </Button>
-      <Modal
-        opened={opened}
-        onClose={() => setOpened(false)}
-        title="Haku UI"
-        size="90%"
-        styles={{ body: { height: "80vh", padding: 0 } }}
-      >
-        <iframe
-          src={uiUrl}
-          title="Haku UI"
-          sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
-          style={{ width: "100%", height: "100%", border: 0 }}
-        />
-      </Modal>
-    </>
+    <iframe
+      src={uiUrl}
+      title="Haku UI"
+      sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+      className="mt-4 w-full"
+      style={{ height: "80vh", border: 0 }}
+    />
   );
 }

--- a/haku/console/models.py
+++ b/haku/console/models.py
@@ -104,6 +104,10 @@ class DashboardResponse(BaseModel):
     # This is a benign public link — the privileged launch action stays on the
     # capability tier (see haku.console.capabilities).
     launch_routine_url: str | None = None
+    # The Authentik-gated origin of Haku's own UI service (haku-sandbox), embedded in a
+    # sandboxed cross-origin iframe. None when unconfigured. The console never renders
+    # Haku's UI itself; it only frames this origin. See plans/free_form_ui_iframe.md.
+    haku_ui_url: str | None = None
 
 
 class FeedbackRequest(BaseModel):

--- a/haku/console/test_app.py
+++ b/haku/console/test_app.py
@@ -73,5 +73,21 @@ def test_item_feedback_appends_tagged_intake_note(client, seeded) -> None:
     assert item_id in body
 
 
+def test_haku_ui_url_surfaced_and_csp_allows_framing_it(make_client) -> None:
+    ui = "https://haku-ui.example.test"
+    with make_client(haku_ui_url=ui) as c:
+        resp = c.get("/api/dashboard")
+        assert resp.json()["haku_ui_url"] == ui
+        csp = resp.headers["content-security-policy"]
+        assert f"frame-src 'self' {ui}" in csp
+        assert "frame-ancestors 'none'" in csp
+
+
+def test_haku_ui_unconfigured_is_none_and_csp_denies_framing(client) -> None:
+    resp = client.get("/api/dashboard")
+    assert resp.json()["haku_ui_url"] is None
+    assert "frame-src 'none'" in resp.headers["content-security-policy"]
+
+
 if __name__ == "__main__":
     pytest_bazel.main()


### PR DESCRIPTION
PR4 (final) of the free-form-UI arc (`haku/console/plans/free_form_ui_iframe.md`) — the **auth-in-iframe go/no-go**. The console embeds Haku's own UI service (the Authentik-gated `haku-ui.allegedly.works` origin) in a sandboxed cross-origin iframe; it never renders Haku's UI itself. Lights up once `haku-ui` is serving (#2520 + #2524 + #2526 + Haku's first seed).

## Changes
- **`config.py` / `models.py`** — `HAKU_CONSOLE_HAKU_UI_URL` setting + `haku_ui_url` on the dashboard response (`None` → feature dormant: no tab, CSP denies frames).
- **`app.py`** — CSP middleware: `Content-Security-Policy: frame-src 'self' <ui-url>` (or `'none'`) + `frame-ancestors 'none'`. **Only `frame-*` is set**, so the SPA's own scripts/styles are unaffected (no risk of breaking Mantine).
- **Frontend — the UI is a peer tab, not a modal.** `app.tsx` now uses Mantine `Tabs`: **Action items** (the trusted dashboard, default) and **Free-form UI** (shown only when configured). The items column stays `max-w-3xl`; the UI tab breaks out to **full width × ~80vh** so the iframe covers most of the page. `haku_ui.tsx` is a plain `HakuUiFrame` with `sandbox="allow-scripts allow-same-origin allow-forms allow-popups"`:
  - `allow-same-origin` keeps the framed app on its **own** origin (different subdomain → not the console's) so its **Authentik session cookie works**; being cross-origin it still can't reach the parent.
  - `allow-forms` for the Authentik login POST; `allow-popups` for the future `openLink`. No `allow="fullscreen"`, no top-navigation → contained.
- **console deployment** — `HAKU_CONSOLE_HAKU_UI_URL=https://haku-ui.allegedly.works` (activation).
- **`test_app.py`** — dashboard surfaces `haku_ui_url` + CSP allows framing it; unset → `None` + `frame-src 'none'`.

## The go/no-go this validates at runtime
1. Does a same-site Authentik-gated app **authenticate inside the iframe** (cookies/redirects survive)? `allow-same-origin` is the bet.
2. Does Authentik permit being framed, or does its proxy send `X-Frame-Options`/restrictive `frame-ancestors` that blocks the embed? **If framing is refused, that's the finding** — adjust the Authentik proxy provider's headers or fall back to bridging display data from the shell (design doc step-1 fallback).

## Verification
- `bbr test //haku/console/...` green — frontend `tsc` (typechecks the tabs + component against the regenerated OpenAPI schema), schema regen, the new CSP tests, ruff/mypy aspects.
- Runtime check after the stack is live: open the console, switch to the **Free-form UI** tab, confirm the placeholder renders authenticated.