### PR TITLE
debundle: add CP-SAT sidecar wire backend

### DIFF
--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -118,19 +118,17 @@ propose`.
 Detailed design and gates live in <plans/selector_constraint_model.md>; keep
 this list as the dispatch summary, not a second plan.
 
-1. **Carve the exact-assignment backend boundary.** Materialize a
-   `SelectorConstraintModel` from `SelectorProgram` + facts, with typed finite
-   domains, allowed tuples, target projections, and semantic `all_different`.
-   Ascent may stay on the fact/table side; the exact target assignment must be
-   owned by OR-Tools CP-SAT or a measured SAT fallback, not by
-   `AssignmentRow` enumeration.
-2. **Unblock the solver dependency path before wiring it into production.**
-   OR-Tools CP-SAT remains the target backend, but the first sidecar spike hit a
-   Bzlmod conflict: `or-tools@9.15` pulls `pybind11_abseil`, whose dev-only pip
-   hub is also named `pypi`. Resolve that as a dependency-only slice, prove a
-   tiny CP-SAT target under RBE, and only then wire selector solving to it. If
-   that integration stays too expensive, encode the same
-   `SelectorConstraintModel` through the RustSAT + CaDiCaL/Kissat fallback.
+1. **Wire the exact-assignment backend.** The backend-neutral
+   `SelectorConstraintModel`, backend problem contract, and backend solver
+   adapter are landed, and OR-Tools CP-SAT now builds under RBE with
+   `all_different`/table-constraint smoke coverage. Next, convert the typed
+   Rust backend problem into the CP-SAT sidecar wire format, run it through the
+   backend adapter, and make the anonymized broad-vs-specific fixture resolve
+   through CP-SAT rather than `AssignmentRow` enumeration.
+2. **Keep Ascent on fact/table derivation, not exact assignment.** Ascent may
+   continue deriving relation support and allowed tuples, but exact target
+   assignment must be owned by OR-Tools CP-SAT or a measured SAT fallback with
+   semantic `all_different`.
 3. **Lower alpha-all declaratively.** Represent selector-local identifier
    bindings/references as variables and constraints over facts, including
    equality, disequality / `all_different`, and scope. This is the blocker for

--- a/devinfra/js/debundle/plans/selector_constraint_model.md
+++ b/devinfra/js/debundle/plans/selector_constraint_model.md
@@ -726,17 +726,17 @@ This is the detailed P0 queue; <../TODO.md> should only summarize it.
   equality/disequality constraints, and native `all_different` where the
   selector semantics require injectivity. Do not clone `MatcherState` or add a
   procedural alpha resolver.
-- **G2 — exact-assignment backend spike.** Implement enough of
-  `SelectorConstraintModel` plus the exact backend to solve one hard
-  global-selector case with semantic `all_different`. Sequence this as:
-  first land the backend-neutral model boundary; next unblock and prove the
-  OR-Tools CP-SAT sidecar under RBE with a tiny finite-domain / `all_different`
-  / table-constraint target; then solve the anonymized broad-vs-specific
-  fixture. Private-corpus runs are optional smoke evidence, not checked-in
-  fixtures or the primary acceptance gate. If the OR-Tools Bzlmod conflict or
-  native dependency surface remains too expensive, perform the same spike
-  through RustSAT + CaDiCaL/Kissat. The acceptance bar is measured runtime and
-  matching semantics, not a nicer hand-written scheduler.
+- **G2 — exact-assignment backend spike.** The backend-neutral
+  `SelectorConstraintModel`, backend problem contract, backend solver adapter,
+  and OR-Tools CP-SAT dependency smoke test are landed. The remaining spike is
+  to make CP-SAT consume the backend problem through a maintained sidecar wire
+  format, return target-support-complete assignments, and solve the anonymized
+  broad-vs-specific fixture with semantic `all_different`. Private-corpus runs
+  are optional smoke evidence, not checked-in fixtures or the primary
+  acceptance gate. If the OR-Tools native path becomes too expensive after this
+  wire contract, encode the same `SelectorConstraintModel` through RustSAT +
+  CaDiCaL/Kissat. The acceptance bar is measured runtime and matching
+  semantics, not a nicer hand-written scheduler.
 - **G3 — retained hole and predicate lowering.** Lower today's retained
   JS-with-holes selectors and binding groups into native AST/owner IR atoms:
   simple existential holes, regex string predicates, run-hole placement

--- a/devinfra/js/debundle/solver_backends/ortools_cpsat/BUILD.bazel
+++ b/devinfra/js/debundle/solver_backends/ortools_cpsat/BUILD.bazel
@@ -1,0 +1,55 @@
+load("@protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
+package(default_visibility = ["//visibility:public"])
+
+COPTS = ["-std=c++23"]
+
+proto_library(
+    name = "selector_cp_sat_proto",
+    srcs = ["selector_cp_sat.proto"],
+)
+
+cc_proto_library(
+    name = "selector_cp_sat_cc_proto",
+    deps = [":selector_cp_sat_proto"],
+)
+
+cc_library(
+    name = "solver",
+    srcs = ["solver.cc"],
+    hdrs = ["solver.h"],
+    copts = COPTS,
+    deps = [
+        ":selector_cp_sat_cc_proto",
+        "@abseil-cpp//absl/status",
+        "@abseil-cpp//absl/status:statusor",
+        "@abseil-cpp//absl/strings",
+        "@or-tools//ortools/sat:cp_model",
+        "@or-tools//ortools/sat:cp_model_solver",
+    ],
+)
+
+cc_binary(
+    name = "selector_cpsat_solver",
+    srcs = ["main.cc"],
+    copts = COPTS,
+    deps = [
+        ":selector_cp_sat_cc_proto",
+        ":solver",
+        "@abseil-cpp//absl/log:check",
+    ],
+)
+
+cc_test(
+    name = "solver_test",
+    srcs = ["solver_test.cc"],
+    copts = COPTS,
+    deps = [
+        ":selector_cp_sat_cc_proto",
+        ":solver",
+        "@abseil-cpp//absl/log:check",
+        "@protobuf",
+    ],
+)

--- a/devinfra/js/debundle/solver_backends/ortools_cpsat/main.cc
+++ b/devinfra/js/debundle/solver_backends/ortools_cpsat/main.cc
@@ -1,0 +1,18 @@
+#include <iostream>
+
+#include "absl/log/check.h"
+#include "devinfra/js/debundle/solver_backends/ortools_cpsat/selector_cp_sat.pb.h"
+#include "devinfra/js/debundle/solver_backends/ortools_cpsat/solver.h"
+
+namespace cpsat = ducktape::debundle::solver_backends::ortools_cpsat;
+
+int main() {
+  cpsat::SelectorCpSatRequest request;
+  CHECK(request.ParseFromIstream(&std::cin))
+      << "failed to parse SelectorCpSatRequest from stdin";
+  const cpsat::SelectorCpSatResponse response =
+      cpsat::SolveSelectorCpSat(request);
+  CHECK(response.SerializeToOstream(&std::cout))
+      << "failed to write SelectorCpSatResponse to stdout";
+  return 0;
+}

--- a/devinfra/js/debundle/solver_backends/ortools_cpsat/selector_cp_sat.proto
+++ b/devinfra/js/debundle/solver_backends/ortools_cpsat/selector_cp_sat.proto
@@ -1,0 +1,83 @@
+syntax = "proto3";
+
+package ducktape.debundle.solver_backends.ortools_cpsat;
+
+message SelectorCpSatRequest {
+  repeated Variable variables = 1;
+  repeated TableConstraint allowed_tables = 2;
+  repeated BinaryConstraint binary_constraints = 3;
+  repeated AllDifferent all_different = 4;
+  repeated TargetProjection target_projections = 5;
+}
+
+message Variable {
+  uint32 id = 1;
+  repeated int64 values = 2;
+  string debug_name = 3;
+}
+
+message TableConstraint {
+  uint32 id = 1;
+  repeated uint32 variable_ids = 2;
+  repeated Tuple allowed_rows = 3;
+}
+
+message Tuple {
+  repeated int64 values = 1;
+}
+
+message BinaryConstraint {
+  uint32 left_variable_id = 1;
+  uint32 right_variable_id = 2;
+  BinaryConstraintKind kind = 3;
+}
+
+enum BinaryConstraintKind {
+  BINARY_CONSTRAINT_KIND_UNSPECIFIED = 0;
+  BINARY_CONSTRAINT_KIND_EQUAL = 1;
+  BINARY_CONSTRAINT_KIND_NOT_EQUAL = 2;
+  BINARY_CONSTRAINT_KIND_ORDINAL_BEFORE = 3;
+}
+
+message AllDifferent {
+  uint32 id = 1;
+  repeated uint32 variable_ids = 2;
+}
+
+message TargetProjection {
+  uint32 target_id = 1;
+  uint32 owner_variable_id = 2;
+  bool has_binding_variable = 3;
+  uint32 binding_variable_id = 4;
+}
+
+message SelectorCpSatResponse {
+  SolverStatus status = 1;
+  AssignmentCoverage assignment_coverage = 2;
+  repeated AssignmentRow assignments = 3;
+  string diagnostic = 4;
+}
+
+enum SolverStatus {
+  SOLVER_STATUS_UNSPECIFIED = 0;
+  SOLVER_STATUS_SATISFIABLE = 1;
+  SOLVER_STATUS_UNSATISFIABLE = 2;
+  SOLVER_STATUS_AMBIGUOUS = 3;
+  SOLVER_STATUS_INVALID = 4;
+  SOLVER_STATUS_UNKNOWN = 5;
+}
+
+enum AssignmentCoverage {
+  ASSIGNMENT_COVERAGE_UNSPECIFIED = 0;
+  ASSIGNMENT_COVERAGE_SAMPLE = 1;
+  ASSIGNMENT_COVERAGE_TARGET_SUPPORT_COMPLETE = 2;
+}
+
+message AssignmentRow {
+  repeated Assignment values = 1;
+}
+
+message Assignment {
+  uint32 variable_id = 1;
+  int64 value = 2;
+}

--- a/devinfra/js/debundle/solver_backends/ortools_cpsat/solver.cc
+++ b/devinfra/js/debundle/solver_backends/ortools_cpsat/solver.cc
@@ -1,0 +1,303 @@
+#include "devinfra/js/debundle/solver_backends/ortools_cpsat/solver.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <map>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "ortools/sat/cp_model.h"
+#include "ortools/sat/cp_model.pb.h"
+#include "ortools/sat/cp_model_solver.h"
+#include "ortools/sat/model.h"
+
+namespace ducktape::debundle::solver_backends::ortools_cpsat {
+namespace {
+
+namespace sat = ::operations_research::sat;
+using VariableMap = std::map<uint32_t, sat::IntVar>;
+
+struct ProjectionRow {
+  std::vector<std::pair<uint32_t, int64_t>> values;
+
+  bool operator<(const ProjectionRow& other) const {
+    return values < other.values;
+  }
+};
+
+SelectorCpSatResponse InvalidResponse(const absl::Status& status) {
+  SelectorCpSatResponse response;
+  response.set_status(SOLVER_STATUS_INVALID);
+  response.set_assignment_coverage(ASSIGNMENT_COVERAGE_SAMPLE);
+  response.set_diagnostic(std::string(status.message()));
+  return response;
+}
+
+absl::Status MissingVariableStatus(uint32_t variable_id) {
+  return absl::InvalidArgumentError(
+      absl::StrCat("unknown variable id ", variable_id));
+}
+
+absl::Status AddVariables(const SelectorCpSatRequest& request,
+                          sat::CpModelBuilder* model,
+                          VariableMap* variables) {
+  for (const Variable& variable : request.variables()) {
+    if (variable.values().empty()) {
+      return absl::InvalidArgumentError(
+          absl::StrCat("variable ", variable.id(), " has an empty domain"));
+    }
+    if (variables->contains(variable.id())) {
+      return absl::InvalidArgumentError(
+          absl::StrCat("duplicate variable id ", variable.id()));
+    }
+
+    std::vector<int64_t> values(variable.values().begin(),
+                                variable.values().end());
+    std::sort(values.begin(), values.end());
+    if (std::adjacent_find(values.begin(), values.end()) != values.end()) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          "variable ", variable.id(), " has duplicate domain values"));
+    }
+
+    sat::IntVar int_var =
+        model->NewIntVar(::operations_research::Domain::FromValues(values))
+            .WithName(variable.debug_name());
+    variables->emplace(variable.id(), int_var);
+  }
+  return absl::OkStatus();
+}
+
+absl::StatusOr<std::vector<sat::IntVar>> LookupVariables(
+    const VariableMap& variables,
+    const google::protobuf::RepeatedField<uint32_t>& ids) {
+  std::vector<sat::IntVar> found;
+  found.reserve(ids.size());
+  for (uint32_t id : ids) {
+    const auto it = variables.find(id);
+    if (it == variables.end()) {
+      return MissingVariableStatus(id);
+    }
+    found.push_back(it->second);
+  }
+  return found;
+}
+
+absl::Status AddAllowedTables(const SelectorCpSatRequest& request,
+                              const VariableMap& variables,
+                              sat::CpModelBuilder* model) {
+  for (const TableConstraint& table : request.allowed_tables()) {
+    absl::StatusOr<std::vector<sat::IntVar>> table_variables =
+        LookupVariables(variables, table.variable_ids());
+    if (!table_variables.ok()) {
+      return table_variables.status();
+    }
+    if (table_variables->empty()) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          "table constraint ", table.id(), " has no variables"));
+    }
+
+    sat::TableConstraint allowed =
+        model->AddAllowedAssignments(*table_variables);
+    for (int row_index = 0; row_index < table.allowed_rows_size();
+         ++row_index) {
+      const Tuple& row = table.allowed_rows(row_index);
+      if (static_cast<size_t>(row.values_size()) != table_variables->size()) {
+        return absl::InvalidArgumentError(absl::StrCat(
+            "table constraint ", table.id(), " row ", row_index,
+            " has arity ", row.values_size(), ", expected ",
+            table_variables->size()));
+      }
+      const std::vector<int64_t> values(row.values().begin(),
+                                        row.values().end());
+      allowed.AddTuple(values);
+    }
+  }
+  return absl::OkStatus();
+}
+
+absl::Status AddBinaryConstraints(const SelectorCpSatRequest& request,
+                                  const VariableMap& variables,
+                                  sat::CpModelBuilder* model) {
+  for (const BinaryConstraint& constraint : request.binary_constraints()) {
+    const auto left = variables.find(constraint.left_variable_id());
+    if (left == variables.end()) {
+      return MissingVariableStatus(constraint.left_variable_id());
+    }
+    const auto right = variables.find(constraint.right_variable_id());
+    if (right == variables.end()) {
+      return MissingVariableStatus(constraint.right_variable_id());
+    }
+
+    switch (constraint.kind()) {
+      case BINARY_CONSTRAINT_KIND_EQUAL:
+        model->AddEquality(left->second, right->second);
+        break;
+      case BINARY_CONSTRAINT_KIND_NOT_EQUAL:
+        model->AddNotEqual(left->second, right->second);
+        break;
+      case BINARY_CONSTRAINT_KIND_ORDINAL_BEFORE:
+        model->AddLessThan(left->second, right->second);
+        break;
+      case BINARY_CONSTRAINT_KIND_UNSPECIFIED:
+      default:
+        return absl::InvalidArgumentError(absl::StrCat(
+            "unsupported binary constraint kind ",
+            static_cast<int>(constraint.kind())));
+    }
+  }
+  return absl::OkStatus();
+}
+
+absl::Status AddAllDifferentConstraints(const SelectorCpSatRequest& request,
+                                        const VariableMap& variables,
+                                        sat::CpModelBuilder* model) {
+  for (const AllDifferent& all_different : request.all_different()) {
+    absl::StatusOr<std::vector<sat::IntVar>> all_different_variables =
+        LookupVariables(variables, all_different.variable_ids());
+    if (!all_different_variables.ok()) {
+      return all_different_variables.status();
+    }
+    if (all_different_variables->size() < 2) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          "all_different constraint ", all_different.id(),
+          " has fewer than two variables"));
+    }
+    model->AddAllDifferent(*all_different_variables);
+  }
+  return absl::OkStatus();
+}
+
+absl::StatusOr<std::vector<uint32_t>> ProjectionVariableIds(
+    const SelectorCpSatRequest& request, const VariableMap& variables) {
+  std::set<uint32_t> ids;
+  for (const TargetProjection& projection : request.target_projections()) {
+    ids.insert(projection.owner_variable_id());
+    if (projection.has_binding_variable()) {
+      ids.insert(projection.binding_variable_id());
+    }
+  }
+  for (uint32_t id : ids) {
+    if (!variables.contains(id)) {
+      return MissingVariableStatus(id);
+    }
+  }
+  return std::vector<uint32_t>(ids.begin(), ids.end());
+}
+
+SelectorCpSatResponse ResponseFromSolver(
+    const sat::CpSolverResponse& solver_response,
+    const std::set<ProjectionRow>& projection_rows, bool complete) {
+  SelectorCpSatResponse response;
+
+  switch (solver_response.status()) {
+    case sat::CpSolverStatus::INFEASIBLE:
+      response.set_status(SOLVER_STATUS_UNSATISFIABLE);
+      response.set_assignment_coverage(
+          ASSIGNMENT_COVERAGE_TARGET_SUPPORT_COMPLETE);
+      return response;
+    case sat::CpSolverStatus::OPTIMAL:
+    case sat::CpSolverStatus::FEASIBLE:
+      break;
+    case sat::CpSolverStatus::MODEL_INVALID:
+      response.set_status(SOLVER_STATUS_INVALID);
+      response.set_assignment_coverage(ASSIGNMENT_COVERAGE_SAMPLE);
+      response.set_diagnostic(sat::CpSolverResponseStats(solver_response));
+      return response;
+    case sat::CpSolverStatus::UNKNOWN:
+    default:
+      response.set_status(SOLVER_STATUS_UNKNOWN);
+      response.set_assignment_coverage(ASSIGNMENT_COVERAGE_SAMPLE);
+      response.set_diagnostic(sat::CpSolverResponseStats(solver_response));
+      return response;
+  }
+
+  response.set_status(projection_rows.size() == 1 ? SOLVER_STATUS_SATISFIABLE
+                                                  : SOLVER_STATUS_AMBIGUOUS);
+  response.set_assignment_coverage(
+      complete ? ASSIGNMENT_COVERAGE_TARGET_SUPPORT_COMPLETE
+               : ASSIGNMENT_COVERAGE_SAMPLE);
+  if (!complete) {
+    response.set_diagnostic(sat::CpSolverResponseStats(solver_response));
+  }
+  for (const ProjectionRow& row : projection_rows) {
+    AssignmentRow* assignment_row = response.add_assignments();
+    for (const auto& [variable_id, value] : row.values) {
+      Assignment* assignment = assignment_row->add_values();
+      assignment->set_variable_id(variable_id);
+      assignment->set_value(value);
+    }
+  }
+  return response;
+}
+
+absl::Status BuildCpModel(const SelectorCpSatRequest& request,
+                          sat::CpModelBuilder* model,
+                          VariableMap* variables) {
+  if (const absl::Status status = AddVariables(request, model, variables);
+      !status.ok()) {
+    return status;
+  }
+  if (const absl::Status status = AddAllowedTables(request, *variables, model);
+      !status.ok()) {
+    return status;
+  }
+  if (const absl::Status status =
+          AddBinaryConstraints(request, *variables, model);
+      !status.ok()) {
+    return status;
+  }
+  if (const absl::Status status =
+          AddAllDifferentConstraints(request, *variables, model);
+      !status.ok()) {
+    return status;
+  }
+  return absl::OkStatus();
+}
+
+}  // namespace
+
+SelectorCpSatResponse SolveSelectorCpSat(const SelectorCpSatRequest& request) {
+  sat::CpModelBuilder model;
+  VariableMap variables;
+  const absl::Status build_status =
+      BuildCpModel(request, &model, &variables);
+  if (!build_status.ok()) {
+    return InvalidResponse(build_status);
+  }
+
+  absl::StatusOr<std::vector<uint32_t>> projection_variable_ids =
+      ProjectionVariableIds(request, variables);
+  if (!projection_variable_ids.ok()) {
+    return InvalidResponse(projection_variable_ids.status());
+  }
+
+  std::set<ProjectionRow> projection_rows;
+  sat::Model solver_model;
+  sat::SatParameters parameters;
+  parameters.set_enumerate_all_solutions(true);
+  parameters.set_num_search_workers(1);
+  solver_model.Add(sat::NewSatParameters(parameters));
+  solver_model.Add(sat::NewFeasibleSolutionObserver(
+      [&](const sat::CpSolverResponse& response) {
+        ProjectionRow row;
+        row.values.reserve(projection_variable_ids->size());
+        for (uint32_t variable_id : *projection_variable_ids) {
+          row.values.push_back(
+              {variable_id,
+               sat::SolutionIntegerValue(response, variables.at(variable_id))});
+        }
+        projection_rows.insert(std::move(row));
+      }));
+
+  const sat::CpSolverResponse solver_response =
+      sat::SolveCpModel(model.Build(), &solver_model);
+  const bool complete = solver_response.status() == sat::CpSolverStatus::OPTIMAL;
+  return ResponseFromSolver(solver_response, projection_rows, complete);
+}
+
+}  // namespace ducktape::debundle::solver_backends::ortools_cpsat

--- a/devinfra/js/debundle/solver_backends/ortools_cpsat/solver.h
+++ b/devinfra/js/debundle/solver_backends/ortools_cpsat/solver.h
@@ -1,0 +1,12 @@
+#ifndef DEVINFRA_JS_DEBUNDLE_SOLVER_BACKENDS_ORTOOLS_CPSAT_SOLVER_H_
+#define DEVINFRA_JS_DEBUNDLE_SOLVER_BACKENDS_ORTOOLS_CPSAT_SOLVER_H_
+
+#include "devinfra/js/debundle/solver_backends/ortools_cpsat/selector_cp_sat.pb.h"
+
+namespace ducktape::debundle::solver_backends::ortools_cpsat {
+
+SelectorCpSatResponse SolveSelectorCpSat(const SelectorCpSatRequest& request);
+
+}  // namespace ducktape::debundle::solver_backends::ortools_cpsat
+
+#endif  // DEVINFRA_JS_DEBUNDLE_SOLVER_BACKENDS_ORTOOLS_CPSAT_SOLVER_H_

--- a/devinfra/js/debundle/solver_backends/ortools_cpsat/solver_test.cc
+++ b/devinfra/js/debundle/solver_backends/ortools_cpsat/solver_test.cc
@@ -1,0 +1,128 @@
+#include "devinfra/js/debundle/solver_backends/ortools_cpsat/solver.h"
+
+#include "absl/log/check.h"
+#include "google/protobuf/text_format.h"
+
+namespace cpsat = ducktape::debundle::solver_backends::ortools_cpsat;
+
+namespace {
+
+cpsat::SelectorCpSatRequest ParseRequestOrDie(const char* textproto) {
+  cpsat::SelectorCpSatRequest request;
+  CHECK(google::protobuf::TextFormat::ParseFromString(textproto, &request))
+      << textproto;
+  return request;
+}
+
+bool RowHas(const cpsat::AssignmentRow& row, uint32_t variable_id,
+            int64_t value) {
+  for (const cpsat::Assignment& assignment : row.values()) {
+    if (assignment.variable_id() == variable_id &&
+        assignment.value() == value) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void AllDifferentPropagatesBroadSpecificFixture() {
+  const cpsat::SelectorCpSatRequest request = ParseRequestOrDie(R"pb(
+    variables { id: 0 values: 0 values: 1 debug_name: "broad_owner" }
+    variables { id: 1 values: 0 values: 1 debug_name: "strict_owner" }
+    variables { id: 2 values: 0 values: 1 values: 2 debug_name: "reserved_owner" }
+
+    all_different { id: 0 variable_ids: 0 variable_ids: 1 variable_ids: 2 }
+
+    allowed_tables {
+      id: 0
+      variable_ids: 0
+      allowed_rows { values: 0 }
+      allowed_rows { values: 1 }
+    }
+    allowed_tables {
+      id: 1
+      variable_ids: 1
+      allowed_rows { values: 1 }
+    }
+    allowed_tables {
+      id: 2
+      variable_ids: 2
+      allowed_rows { values: 2 }
+    }
+
+    target_projections { target_id: 0 owner_variable_id: 0 }
+    target_projections { target_id: 1 owner_variable_id: 1 }
+  )pb");
+
+  const cpsat::SelectorCpSatResponse response =
+      cpsat::SolveSelectorCpSat(request);
+
+  CHECK_EQ(response.status(), cpsat::SOLVER_STATUS_SATISFIABLE);
+  CHECK_EQ(response.assignment_coverage(),
+           cpsat::ASSIGNMENT_COVERAGE_TARGET_SUPPORT_COMPLETE);
+  CHECK_EQ(response.assignments_size(), 1);
+  CHECK(RowHas(response.assignments(0), 0, 0));
+  CHECK(RowHas(response.assignments(0), 1, 1));
+}
+
+void MultipleProjectionRowsAreAmbiguous() {
+  const cpsat::SelectorCpSatRequest request = ParseRequestOrDie(R"pb(
+    variables { id: 0 values: 0 values: 1 debug_name: "owner" }
+    target_projections { target_id: 0 owner_variable_id: 0 }
+  )pb");
+
+  const cpsat::SelectorCpSatResponse response =
+      cpsat::SolveSelectorCpSat(request);
+
+  CHECK_EQ(response.status(), cpsat::SOLVER_STATUS_AMBIGUOUS);
+  CHECK_EQ(response.assignment_coverage(),
+           cpsat::ASSIGNMENT_COVERAGE_TARGET_SUPPORT_COMPLETE);
+  CHECK_EQ(response.assignments_size(), 2);
+}
+
+void ConflictingTablesAreUnsat() {
+  const cpsat::SelectorCpSatRequest request = ParseRequestOrDie(R"pb(
+    variables { id: 0 values: 0 values: 1 debug_name: "owner" }
+    allowed_tables {
+      id: 0
+      variable_ids: 0
+      allowed_rows { values: 0 }
+    }
+    allowed_tables {
+      id: 1
+      variable_ids: 0
+      allowed_rows { values: 1 }
+    }
+    target_projections { target_id: 0 owner_variable_id: 0 }
+  )pb");
+
+  const cpsat::SelectorCpSatResponse response =
+      cpsat::SolveSelectorCpSat(request);
+
+  CHECK_EQ(response.status(), cpsat::SOLVER_STATUS_UNSATISFIABLE);
+  CHECK_EQ(response.assignment_coverage(),
+           cpsat::ASSIGNMENT_COVERAGE_TARGET_SUPPORT_COMPLETE);
+  CHECK_EQ(response.assignments_size(), 0);
+}
+
+void InvalidProblemReportsDiagnostic() {
+  const cpsat::SelectorCpSatRequest request = ParseRequestOrDie(R"pb(
+    variables { id: 0 debug_name: "owner" }
+  )pb");
+
+  const cpsat::SelectorCpSatResponse response =
+      cpsat::SolveSelectorCpSat(request);
+
+  CHECK_EQ(response.status(), cpsat::SOLVER_STATUS_INVALID);
+  CHECK(!response.diagnostic().empty());
+}
+
+}  // namespace
+
+int main() {
+  AllDifferentPropagatesBroadSpecificFixture();
+  MultipleProjectionRowsAreAmbiguous();
+  ConflictingTablesAreUnsat();
+  InvalidProblemReportsDiagnostic();
+  return 0;
+}


### PR DESCRIPTION
## Summary

- add a maintained OR-Tools CP-SAT sidecar wire format for selector backend problems and results
- add a C++23 CP-SAT solver library plus stdin/stdout sidecar binary using Abseil status/check helpers
- cover target-support-complete projection rows, semantic `all_different`, ambiguity, unsat, and invalid-problem diagnostics with textproto-shaped solver fixtures
- refresh debundle planning docs now that the backend model/adapter and OR-Tools dependency unblock have landed

## Validation

- `nix develop -c pre-commit run --files devinfra/js/debundle/TODO.md devinfra/js/debundle/plans/selector_constraint_model.md devinfra/js/debundle/solver_backends/ortools_cpsat/BUILD.bazel devinfra/js/debundle/solver_backends/ortools_cpsat/selector_cp_sat.proto devinfra/js/debundle/solver_backends/ortools_cpsat/solver.h devinfra/js/debundle/solver_backends/ortools_cpsat/solver.cc devinfra/js/debundle/solver_backends/ortools_cpsat/main.cc devinfra/js/debundle/solver_backends/ortools_cpsat/solver_test.cc`
- `nix develop -c bbr test //devinfra/js/debundle/solver_backends/ortools_cpsat:solver_test --cache_test_results=no --test_output=errors`
  - BuildBuddy: https://app.buildbuddy.io/invocation/01eec94d-bcc8-43e9-9548-5a8ae02a0ce8