### PR TITLE
chore: stage gaffer deploy-key retirement

### DIFF
--- a/cluster/k8s/gaffer-private-source/deploy-key-tf.yaml
+++ b/cluster/k8s/gaffer-private-source/deploy-key-tf.yaml
@@ -1,25 +1,19 @@
-# CLEANUP(added 2026-05-03): superseded by ducktape-automation GitHub App auth
-#   (cluster/k8s/flux-system/ducktape-automation-github-app.sops.yaml).
-#   Once App auth on the gaffer-private GitRepository has been Ready=True for
-#   ≥1 day, retire by:
-#     1. Remove this file and github-pat-gaffer-private-flux.sops.yaml from
-#        cluster/k8s/gaffer-private-source/kustomization.yaml.
-#     2. Strip prevent_destroy lifecycle blocks in
-#        tf/gitops/gaffer-private-flux/main.tf, then `tofu destroy` the module
-#        (revokes the GitHub deploy key, deletes the gaffer-private-deploy-key
-#        Secret, and the github-pat-gaffer-private-flux PAT).
-#     3. Delete tf/gitops/gaffer-private-flux/ and the BUILD.bazel target.
+# Staged retirement for the old gaffer-private Flux deploy key. The
+# GitRepository now uses the ducktape-automation GitHub App secret directly.
+# Keep this Terraform object and the github-pat-gaffer-private-flux Secret until
+# the destroy plan has completed, then delete both plus tf/gitops/gaffer-private-flux.
 apiVersion: infra.contrib.fluxcd.io/v1alpha2
 kind: Terraform
 metadata:
   name: gaffer-private-flux
   namespace: flux-system
   annotations:
-    description: "Generates the gaffer-private flux deploy keypair, registers it on GitHub, and writes the flux Secret. Sourced from the flux-system GitRepository (NOT gaffer-private — chicken-and-egg). Superseded by ducktape-automation GitHub App auth — see top-of-file CLEANUP."
+    description: "Destroys the retired gaffer-private Flux deploy key and generated Secret; gaffer-private now uses ducktape-automation GitHub App auth."
 spec:
   interval: 15m
   refreshBeforeApply: true
   approvePlan: "auto"
+  destroy: true
   path: ./tf/gitops/gaffer-private-flux
   sourceRef:
     kind: GitRepository

--- a/cluster/k8s/gaffer-private-source/kustomization.yaml
+++ b/cluster/k8s/gaffer-private-source/kustomization.yaml
@@ -4,8 +4,7 @@ resources:
   - source.yaml
   - bridge.yaml
   - image-update-automation.yaml
-  # CLEANUP(added 2026-05-03): retire deploy-key-tf.yaml + the PAT below once
-  # ducktape-automation GitHub App auth on `gaffer-private` is verified
-  # stable. See deploy-key-tf.yaml header for the full retirement steps.
+  # Keep these while deploy-key-tf.yaml runs its destroy plan; delete them after
+  # the Terraform object reports the old deploy key destroyed.
   - deploy-key-tf.yaml
   - github-pat-gaffer-private-flux.sops.yaml

--- a/cluster/k8s/github-branch-protection/flux-kustomization.yaml
+++ b/cluster/k8s/github-branch-protection/flux-kustomization.yaml
@@ -24,8 +24,3 @@ spec:
     - name: tofu-state-db
     # Provides github-secrets-sync-pat (Administration:R/W on ducktape).
     - name: github-secrets-sync-secrets
-    # Provides github-pat-gaffer-private-flux (Administration:R/W on
-    # gaffer-private). gaffer-private-source's flux-kustomization
-    # deploys this PAT alongside the gaffer-private GitRepository
-    # source and the deploy-key tofu module.
-    - name: gaffer-private-source

--- a/tf/gitops/gaffer-private-flux/main.tf
+++ b/tf/gitops/gaffer-private-flux/main.tf
@@ -1,30 +1,9 @@
-# Gaffer-private Flux deploy-key.
+# Gaffer-private Flux deploy-key retirement.
 #
-# CLEANUP(added 2026-05-03): superseded by ducktape-automation GitHub App auth
-# (cluster/k8s/flux-system/ducktape-automation-github-app.sops.yaml).
-# `gaffer-private` GitRepository now references that Secret directly. To
-# retire this module: drop prevent_destroy on all three resources below,
-# `tofu destroy` (revokes the deploy key, deletes the in-cluster Secret),
-# then delete this directory + BUILD.bazel target + the
-# cluster/k8s/gaffer-private-source/{deploy-key-tf,github-pat-gaffer-private-flux.sops}.yaml
-# manifests.
-#
-# Self-contained: generates an ED25519 keypair, registers the public half
-# as a write-scoped GitHub deploy key on agentydragon/gaffer-private, and
-# writes the flux SSH GitRepository secret consumed by the
-# `gaffer-private` GitRepository
-# (cluster/k8s/gaffer-private-source/source.yaml).
-#
-# Auth: fine-grained PAT with Administration:R/W on
-# agentydragon/gaffer-private, deployed as the
-# `github-pat-gaffer-private-flux` Secret via SOPS-encrypted manifest in
-# cluster/k8s/gaffer-private-source/.
-#
-# Rotation: bump tls_private_key.gaffer_private_flux's keepers and TF
-# generates a new keypair, re-registers it on GitHub, and rotates the
-# k8s secret atomically. prevent_destroy guards against accidental
-# destruction (matching the existing ducktape flux-system deploy-key
-# lifecycle).
+# The `gaffer-private` GitRepository uses the ducktape-automation GitHub App
+# secret directly. This module is kept only while the Terraform CR runs its
+# destroy plan to revoke the old deploy key and delete its generated Secret.
+# Keep `github-pat-gaffer-private-flux` present until that destroy has completed.
 
 provider "github" {
   owner = "agentydragon"
@@ -40,8 +19,6 @@ data "kubernetes_secret" "github_pat" {
 
 resource "tls_private_key" "gaffer_private_flux" {
   algorithm = "ED25519"
-
-  lifecycle { prevent_destroy = true }
 }
 
 resource "github_repository_deploy_key" "gaffer_private_flux" {
@@ -49,8 +26,6 @@ resource "github_repository_deploy_key" "gaffer_private_flux" {
   repository = "gaffer-private"
   key        = tls_private_key.gaffer_private_flux.public_key_openssh
   read_only  = false
-
-  lifecycle { prevent_destroy = true }
 }
 
 resource "kubernetes_secret" "gaffer_private_deploy_key" {
@@ -71,8 +46,6 @@ resource "kubernetes_secret" "gaffer_private_deploy_key" {
   }
 
   type = "Opaque"
-
-  lifecycle { prevent_destroy = true }
 
   depends_on = [github_repository_deploy_key.gaffer_private_flux]
 }

--- a/tf/gitops/github-branch-protection/README.md
+++ b/tf/gitops/github-branch-protection/README.md
@@ -63,9 +63,5 @@ access control plus the `ducktape-automation` App for GitOps writes.
 - Verify whether GitHub Secret Protection covers push protection on private
   personal-account repos now, then enable or explicitly reject it for
   `gaffer-private`.
-- Retire legacy SSH deploy keys superseded by `ducktape-automation` GitHub App
-  auth. Cleanup markers are in:
-  - `cluster/k8s/gaffer-private-source/deploy-key-tf.yaml`
-  - `cluster/k8s/gaffer-private-source/kustomization.yaml`
-  - `tf/gitops/gaffer-private-flux/main.tf`
-  - the Flux bootstrap git secret/deploy key for `agentydragon/ducktape`
+- Retire the Flux bootstrap git secret/deploy key for `agentydragon/ducktape`
+  if the root GitRepository moves to GitHub App auth.


### PR DESCRIPTION
## Summary

- stage destruction of the retired `gaffer-private-flux` Terraform resources with `spec.destroy: true`
- remove `prevent_destroy` from the old deploy-key module so tofu-controller can revoke the GitHub deploy key and delete the generated Flux Secret
- keep the Terraform CR and `github-pat-gaffer-private-flux` Secret wired during the destroy step
- remove the stale `github-branch-protection -> gaffer-private-source` dependency and cleanup notes that no longer match the auth flow

## Destructive Behavior

Merging this PR intentionally asks tofu-controller to destroy the old gaffer-private deploy-key module. The live precheck before authoring this change showed `GitRepository/gaffer-private` Ready=True since `2026-06-25T06:35:59Z`, using the GitHub App auth path.

Follow-up after Flux/tofu-controller reports the destroy completed: delete `cluster/k8s/gaffer-private-source/deploy-key-tf.yaml`, `github-pat-gaffer-private-flux.sops.yaml`, and `tf/gitops/gaffer-private-flux/`.

## Validation

- `nix develop --command bazelisk build //tf/gitops/gaffer-private-flux:gaffer-private-flux //tf/gitops/github-branch-protection:github-branch-protection --config=rbe` passed
  - BuildBuddy invocation: https://app.buildbuddy.io/invocation/f360eb25-15b8-4cc8-9530-1e2b853f5313
- `nix develop --command bazelisk test //cluster/validation:test_cluster_integration //cluster/validation:test_flux_build //cluster/validation:test_terraform_backends --config=rbe` passed
  - BuildBuddy invocation: https://app.buildbuddy.io/invocation/a25581b2-d520-4e9a-a663-cd1dfb5a0b99
- Commit hooks passed, including `kubeconform (cluster)`, `Checkov Diff`, and `tflint (cluster)`