### PR TITLE
haku: make item primary action optional (fixes dashboard 500)

### DIFF
--- a/haku/base/instructions.md
+++ b/haku/base/instructions.md
@@ -458,7 +458,8 @@ no urgency. A big payoff that demands a lot of operator effort ranks **below** a
 small one they can approve in seconds. Calibrate against rejection feedback over
 time.
 
-Action kinds (only these two):
+Action kinds (only these two; `action` itself is **optional** — omit it for a pure
+FYI item with no primary button):
 
 - `suggestion` — FYI / "do this yourself"; no machine payload.
 - `prepared_prompt` — the workhorse, for anything worth handing to an agent with

--- a/haku/base/schema/item.json
+++ b/haku/base/schema/item.json
@@ -4,7 +4,7 @@
   "title": "Haku item",
   "type": "object",
   "additionalProperties": false,
-  "required": ["id", "dedup_key", "title", "body", "value", "action", "status"],
+  "required": ["id", "dedup_key", "title", "body", "value", "status"],
   "properties": {
     "id": {
       "type": "string",

--- a/haku/console/frontend/task.tsx
+++ b/haku/console/frontend/task.tsx
@@ -9,10 +9,11 @@ export function clickKey(itemId: string, actionId: string): string {
   return `${itemId} ${actionId}`;
 }
 
-// (href, label) for an item's primary action button.
+// (href, label) for an item's primary action button. `action` is optional — a pure
+// FYI item has none, in which case we just link to the item source.
 function primaryDeeplink(item: Item): [string, string] {
   const action = item.action;
-  if (action.kind === "prepared_prompt") {
+  if (action?.kind === "prepared_prompt") {
     const encoded = encodeURIComponent(action.prompt);
     if (encoded.length <= MAX_DEEPLINK) return [CLAUDE_NEW + encoded, "Hand to Claude →"];
   }
@@ -82,9 +83,11 @@ export function TaskCard({ item, clicked, onToggle }: TaskProps) {
               ⏳ {deadline}
             </Badge>
           )}
-          <Badge color="gray" variant="light" size="sm">
-            {item.action.kind}
-          </Badge>
+          {item.action && (
+            <Badge color="gray" variant="light" size="sm">
+              {item.action.kind}
+            </Badge>
+          )}
         </span>
       </summary>
       <div className="flex flex-col gap-3 py-2 pl-5">

--- a/haku/console/models.py
+++ b/haku/console/models.py
@@ -29,7 +29,7 @@ class ItemStatus(StrEnum):
     EXPIRED = "expired"
 
 
-# --- primary action (item.action, required) ----------------------------------
+# --- primary action (item.action, optional) -----------------------------------
 
 
 class Suggestion(BaseModel):
@@ -79,7 +79,8 @@ class Item(BaseModel):
     title: str
     body: str
     value: int
-    action: PrimaryAction
+    # Optional for now: an item may be a pure FYI with no primary action button.
+    action: PrimaryAction | None = None
     status: ItemStatus
     deadline: datetime | None = None
     actions: list[OperatorAction] = Field(default_factory=list)


### PR DESCRIPTION
## The outage
The console dashboard returned 500 (`Failed to load dashboard`). Root cause: `git_state.read_items` runs `Item.model_validate` on **every** `items/*.yaml`, and one item Haku wrote — `01KW2S6DMY…`, a snoozed Oura-renewal FYI — had `actions` (buttons) but **no top-level `action`**, which was required. So a single item without a primary action **took down the entire operator dashboard**.

## Fix (per operator: make it not required for now)
`action` is now optional everywhere, kept in sync across the contract:
- **`haku/base/schema/item.json`** — `action` dropped from `required` (still defined in `properties`).
- **`haku/console/models.py`** — `action: PrimaryAction | None = None`.
- **`haku/console/frontend/task.tsx`** — tolerates a null `action`: no primary-action badge in the summary, and `primaryDeeplink` falls back to the item-source link.
- **`haku/base/instructions.md`** — notes `action` is optional (omit it for a pure FYI item).

Haku's existing item is left untouched (no edit to haku-state) — it's now valid as-is.

## Verification
`bbr test //haku/console/...` green — frontend `tsc` typechecks the nullable `action` against the regenerated OpenAPI schema, plus the py/mypy aspects.

## Note
The console stays down until this merges + the image builds/deploys. The deeper resilience question — should one malformed item ever 500 the whole dashboard? — is worth a follow-up (skip + surface bad items), but this unblocks now without changing the strict-parse behavior for genuinely-required fields.