### PR TITLE
Increase bootstrap timeout from 90s to 600s

### DIFF
--- a/haku/runtime/claude_web_env/profile.yaml
+++ b/haku/runtime/claude_web_env/profile.yaml
@@ -30,7 +30,11 @@ background_commands:
   # after_env so the K8S_* exports above are in scope.
   - name: bootstrap
     command: bash "$CLAUDE_PROJECT_DIR/haku/runtime/claude_web_env/bootstrap.sh"
-    timeout: 90
+    # TODO: investigate why git clone of haku-state takes 4+ minutes over web-home
+    # egress (observed 11th run 2026-06-26). 90s timed out every run; bumped to 600s
+    # as a stopgap. Root cause unknown — may be egress throttling on large initial
+    # clone, or Forgejo slow on cold start. Check with a fresh clone + timing.
+    timeout: 600
     after_env: true
   - name: creds banner
     command: bash "$CLAUDE_PROJECT_DIR/devinfra/claude/claude_hook/creds_banner.sh"


### PR DESCRIPTION
## Summary
Increased the bootstrap command timeout in the Claude web environment from 90 seconds to 600 seconds to accommodate slower git clone operations.

## Changes
- Bumped `bootstrap` command timeout from 90s to 600s in `haku/runtime/claude_web_env/profile.yaml`
- Added detailed TODO comment documenting the issue: git clone of haku-state takes 4+ minutes over web-home egress, causing consistent timeouts at 90s
- Noted potential root causes: egress throttling on large initial clone or Forgejo cold start performance

## Implementation Details
This is a temporary stopgap measure while the underlying performance issue is investigated. The comment recommends checking with a fresh clone and timing to identify whether the slowness is due to egress throttling or Forgejo startup latency.

https://claude.ai/code/session_01TKXbbgqbewcAxr6Mv2y2Xj