### PR TITLE
[codex] debundle: model alpha identifiers as variable all-different

### DIFF
--- a/devinfra/js/debundle/selector_constraint_model_builder.rs
+++ b/devinfra/js/debundle/selector_constraint_model_builder.rs
@@ -12,8 +12,8 @@ use std::fmt;
 use analysis::{OwnerId, StatementOrdinal};
 use chunk_facts::NodeId;
 use selector_constraint_model::{
-    BinaryConstraintKind, ConstraintModelError, ConstraintValue, ConstraintVariableId,
-    SelectorConstraintModel,
+    AllDifferentReason, BinaryConstraintKind, ConstraintModelError, ConstraintValue,
+    ConstraintVariableId, SelectorConstraintModel,
 };
 use selector_ir::{
     ClaimKind, NodeTerm, OrdinalTerm, OwnerTerm, SelectorAtom, SelectorFact, SelectorFactStore,
@@ -64,6 +64,18 @@ pub fn build_selector_constraint_model(
 
     for targets in &program.all_different {
         model.require_target_all_different(targets.clone())?;
+    }
+    for variable_set in &program.all_different_variables {
+        model.add_all_different(
+            variable_set
+                .variables
+                .iter()
+                .map(|variable| model_variable(&variables, *variable))
+                .collect::<Result<Vec<_>, _>>()?,
+            AllDifferentReason::SelectorSemantics {
+                label: variable_set.label.clone(),
+            },
+        )?;
     }
 
     model.validate()?;
@@ -2426,6 +2438,61 @@ mod tests {
                 variables: vec![ConstraintVariableId(1)],
                 tuples: vec![vec![owner(20)]],
             }
+        );
+    }
+
+    #[test]
+    fn lowers_selector_semantic_variable_all_different() {
+        let mut program = SelectorProgram::default();
+        let owner = program.add_variable(VariableDomain::Owner, Some("owner".to_string()));
+        let left = program.add_variable(VariableDomain::String, Some("alpha.left".to_string()));
+        let right = program.add_variable(VariableDomain::String, Some("alpha.right".to_string()));
+        program.add_target(
+            ChunkId(0),
+            owner,
+            "module",
+            ClaimKind::Binding {
+                export_name: Some("Widget".to_string()),
+            },
+            ClaimOrigin::Synthetic,
+        );
+        program.add_atom(SelectorAtom::OwnerDeclaresBinding {
+            owner: OwnerTerm::Var { id: owner },
+            binding: StringTerm::Const {
+                value: "widget".to_string(),
+            },
+        });
+        program.add_atom(SelectorAtom::AstIdentifierName {
+            node: NodeTerm::Const { node: 1 },
+            value: StringTerm::Var { id: left },
+        });
+        program.add_atom(SelectorAtom::AstIdentifierName {
+            node: NodeTerm::Const { node: 2 },
+            value: StringTerm::Var { id: right },
+        });
+        program.require_variables_all_different(
+            vec![left, right],
+            "module::source_match.alpha_all.frame",
+        );
+
+        let facts = fact_store(vec![
+            owner_fact(10, 0, "var"),
+            declared_binding(10, "widget"),
+            ast_identifier_name(1, "a"),
+            ast_identifier_name(2, "b"),
+        ]);
+
+        let model = build_selector_constraint_model(&program, &facts).unwrap();
+
+        assert_eq!(
+            model.all_different,
+            vec![AllDifferentConstraint {
+                id: AllDifferentConstraintId(0),
+                variables: vec![ConstraintVariableId(1), ConstraintVariableId(2)],
+                reason: AllDifferentReason::SelectorSemantics {
+                    label: "module::source_match.alpha_all.frame".to_string(),
+                },
+            }]
         );
     }
 

--- a/devinfra/js/debundle/selector_ir.rs
+++ b/devinfra/js/debundle/selector_ir.rs
@@ -303,6 +303,15 @@ pub struct SelectorProgram {
     /// Sets of target ids that must land on distinct owners.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub all_different: Vec<Vec<SelectorTargetId>>,
+    /// Sets of variables that must land on distinct values.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub all_different_variables: Vec<SelectorVariableAllDifferent>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SelectorVariableAllDifferent {
+    pub variables: Vec<SelectorVariableId>,
+    pub label: String,
 }
 
 impl SelectorProgram {
@@ -348,6 +357,18 @@ impl SelectorProgram {
         self.all_different.push(targets);
     }
 
+    pub fn require_variables_all_different(
+        &mut self,
+        variables: Vec<SelectorVariableId>,
+        label: impl Into<String>,
+    ) {
+        self.all_different_variables
+            .push(SelectorVariableAllDifferent {
+                variables,
+                label: label.into(),
+            });
+    }
+
     pub fn validate(&self) -> Result<(), SelectorProgramError> {
         for (idx, variable) in self.variables.iter().enumerate() {
             if variable.id != SelectorVariableId(idx) {
@@ -375,6 +396,26 @@ impl SelectorProgram {
             }
             for target in target_set {
                 self.require_target(*target)?;
+            }
+        }
+        for variable_set in &self.all_different_variables {
+            if variable_set.variables.len() < 2 {
+                return Err(SelectorProgramError::DegenerateAllDifferent);
+            }
+            let mut expected_domain = None;
+            for variable in &variable_set.variables {
+                let domain = self.require_variable(*variable, "all_different_variables")?;
+                match expected_domain {
+                    None => expected_domain = Some(domain),
+                    Some(expected) if expected != domain => {
+                        return Err(SelectorProgramError::DomainMismatch {
+                            context: "all_different_variables",
+                            expected,
+                            actual: domain,
+                        });
+                    }
+                    Some(_) => {}
+                }
             }
         }
         Ok(())
@@ -744,7 +785,7 @@ impl fmt::Display for SelectorProgramError {
                 )
             }
             Self::DegenerateAllDifferent => {
-                write!(f, "all_different requires at least two targets")
+                write!(f, "all_different requires at least two entries")
             }
             Self::EmptyChildListPattern => {
                 write!(
@@ -1268,6 +1309,33 @@ mod tests {
                 context: "selector target owner",
                 expected: VariableDomain::Owner,
                 actual: VariableDomain::AstNode,
+            })
+        );
+    }
+
+    #[test]
+    fn validates_variable_all_different_domains() {
+        let mut program = SelectorProgram::default();
+        let left = program.add_variable(VariableDomain::String, Some("left".to_string()));
+        let right = program.add_variable(VariableDomain::String, Some("right".to_string()));
+        program.require_variables_all_different(vec![left, right], "alpha frame");
+
+        assert_eq!(program.validate(), Ok(()));
+    }
+
+    #[test]
+    fn rejects_variable_all_different_domain_mismatch() {
+        let mut program = SelectorProgram::default();
+        let string = program.add_variable(VariableDomain::String, Some("string".to_string()));
+        let owner = program.add_variable(VariableDomain::Owner, Some("owner".to_string()));
+        program.require_variables_all_different(vec![string, owner], "mixed");
+
+        assert_eq!(
+            program.validate(),
+            Err(SelectorProgramError::DomainMismatch {
+                context: "all_different_variables",
+                expected: VariableDomain::String,
+                actual: VariableDomain::Owner,
             })
         );
     }

--- a/devinfra/js/debundle/selector_ir_lowering.rs
+++ b/devinfra/js/debundle/selector_ir_lowering.rs
@@ -1104,6 +1104,7 @@ impl MemberSelectorProgramBuilder {
                 *root,
             ));
         }
+        self.add_alpha_identifier_frame_all_different(logical_module, state.current_frame());
         result
     }
 
@@ -1156,7 +1157,8 @@ impl MemberSelectorProgramBuilder {
             ));
         }
         if pushes_scope {
-            state.frames.pop();
+            let frame = state.frames.pop().expect("pushed alpha scope should exist");
+            self.add_alpha_identifier_frame_all_different(logical_module, &frame);
         }
         result
     }
@@ -1243,6 +1245,23 @@ impl MemberSelectorProgramBuilder {
                 });
             }
         }
+    }
+
+    fn add_alpha_identifier_frame_all_different(
+        &mut self,
+        logical_module: &str,
+        frame: &AlphaIdentifierFrame,
+    ) {
+        let mut variables = frame.by_name.values().copied().collect::<Vec<_>>();
+        variables.sort();
+        variables.dedup();
+        if variables.len() < 2 {
+            return;
+        }
+        self.program.require_variables_all_different(
+            variables,
+            format!("{logical_module}::source_match.alpha_all.frame"),
+        );
     }
 
     fn add_kind_atom(&mut self, owner: SelectorVariableId, kind: Option<BindingSourceKind>) {
@@ -2769,6 +2788,15 @@ mod tests {
             .filter(|atom| matches!(atom, SelectorAtom::NotEqual { .. }))
             .count();
         assert_eq!(not_equal_pairs, 3);
+        assert_eq!(lowered.program.all_different_variables.len(), 1);
+        assert_eq!(
+            lowered.program.all_different_variables[0].variables,
+            vec![identifier_vars[0], identifier_vars[1], identifier_vars[2]]
+        );
+        assert_eq!(
+            lowered.program.all_different_variables[0].label,
+            "runtime/widgets::source_match.alpha_all.frame"
+        );
     }
 
     #[test]

--- a/devinfra/js/debundle/selector_ir_solver.rs
+++ b/devinfra/js/debundle/selector_ir_solver.rs
@@ -1983,6 +1983,13 @@ impl ProgramSupport {
                 }
             }
         }
+        for variable_set in &program.all_different_variables {
+            for (left_index, left) in variable_set.variables.iter().enumerate() {
+                for right in variable_set.variables.iter().skip(left_index + 1) {
+                    support.add_equality(*left, *right, EqualityConstraintKind::NotEqual);
+                }
+            }
+        }
         support
     }
 


### PR DESCRIPTION
## Summary

- add selector IR support for variable-level `all_different` groups
- lower `alpha_all` identifier frames into semantic variable `all_different` constraints
- lower those groups into the CP-SAT constraint model while preserving pairwise `NotEqual` expansion for the current Ascent solver path

## Why

`alpha_all` distinctness should be represented as a native global selector constraint instead of only as pairwise filter atoms. This gives the CP-SAT backend an all-different group to solve directly while keeping the existing evaluator behavior unchanged.

## Validation

- `nix develop -c pre-commit run --files devinfra/js/debundle/selector_ir.rs devinfra/js/debundle/selector_ir_lowering.rs devinfra/js/debundle/selector_constraint_model_builder.rs devinfra/js/debundle/selector_ir_solver.rs`
- `nix develop -c bbr test //devinfra/js/debundle:selector_ir_test //devinfra/js/debundle:selector_ir_lowering_test //devinfra/js/debundle:selector_constraint_model_builder_test //devinfra/js/debundle:selector_ir_solver_test --cache_test_results=no --test_output=errors`
- BuildBuddy: https://app.buildbuddy.io/invocation/44cf39bc-cf80-464e-abb9-af20730e2679