### PR TITLE
haku: wire read-only grocy as a self-hosted source (reflect token + docs)

### DIFF
--- a/cluster/k8s/agents/authentik-jwt-rotation/rotate.py
+++ b/cluster/k8s/agents/authentik-jwt-rotation/rotate.py
@@ -60,6 +60,13 @@ class K8sSecretOutput(BaseModel):
     namespace: str
     token_key: str = Field(default="jwt", description="stringData key for the JWT")
     exp_key: str = Field(default="token-exp", description="stringData key for the JWT exp epoch (seconds)")
+    annotations: dict[str, str] | None = Field(
+        default=None,
+        description="Extra annotations merged into the Secret's metadata.annotations — e.g. "
+        "kubernetes-reflector reflection-* keys to auto-mirror the Secret into another namespace "
+        "(haku-sandbox, for the self-hosted Haku home to read the bearer). Single-write + reflector "
+        "fan-out, rather than the rotator looping over namespaces.",
+    )
 
 
 class Rotation(BaseModel):
@@ -273,6 +280,25 @@ def rotate_one(client: httpx.Client, rotation: Rotation, config: Config) -> bool
     return True
 
 
+def build_secret_manifest(out: K8sSecretOutput, token: str, exp_epoch: int) -> dict[str, Any]:
+    """The k8s Secret manifest carrying the token + exp (pre-encryption).
+
+    `out.annotations` is merged in (e.g. kubernetes-reflector keys to auto-mirror the
+    applied Secret into another namespace — single-write + fan-out, never a
+    per-namespace loop in the rotator).
+    """
+    annotations = {"description": "Authentik JWT minted by authentik-jwt-rotation (rotated ~biweekly)."}
+    if out.annotations:
+        annotations |= out.annotations
+    return {
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "metadata": {"name": out.name, "namespace": out.namespace, "annotations": annotations},
+        "type": "Opaque",
+        "stringData": {out.token_key: token, out.exp_key: str(exp_epoch)},
+    }
+
+
 def write_k8s_secret(out: K8sSecretOutput, token: str, exp_epoch: int) -> None:
     """Write `out.path` as a SOPS-encrypted k8s Secret manifest carrying the token + exp.
 
@@ -280,19 +306,8 @@ def write_k8s_secret(out: K8sSecretOutput, token: str, exp_epoch: int) -> None:
     stays plaintext. The exp epoch is the monotonic signal a consumer uses to know
     the token rotated (e.g. a Terraform write-only `*_wo_version`).
     """
-    manifest = {
-        "apiVersion": "v1",
-        "kind": "Secret",
-        "metadata": {
-            "name": out.name,
-            "namespace": out.namespace,
-            "annotations": {"description": "Authentik JWT minted by authentik-jwt-rotation (rotated ~biweekly)."},
-        },
-        "type": "Opaque",
-        "stringData": {out.token_key: token, out.exp_key: str(exp_epoch)},
-    }
     out.path.parent.mkdir(parents=True, exist_ok=True)
-    out.path.write_text(yaml.safe_dump(manifest, sort_keys=False, width=2**31))
+    out.path.write_text(yaml.safe_dump(build_secret_manifest(out, token, exp_epoch), sort_keys=False, width=2**31))
     subprocess.run(["sops", "encrypt", "--in-place", str(out.path)], check=True)
 
 

--- a/cluster/k8s/agents/authentik-jwt-rotation/rotations.yaml
+++ b/cluster/k8s/agents/authentik-jwt-rotation/rotations.yaml
@@ -57,10 +57,17 @@ rotations:
     # Also publish the JWT (+ exp) as an in-cluster Secret so tf/gitops/haku-cloud-agent
     # can hand it to the Anthropic vault as the grocy-sf MCP bearer (read via a no-fail
     # lookup — absent secret just disables the grocy credential). Mirrors haku-k8s.
+    # The reflector annotations also mirror it into haku-sandbox, where the self-hosted
+    # Haku home reads the bearer to call the grocy-sf MCP directly (like haku-tana-ro-token).
     k8s_secret:
       path: cluster/k8s/haku/cloud-agent-tf/haku-grocy-sf-token.sops.yaml
       name: haku-cloud-grocy-sf-token
       namespace: flux-system
+      annotations:
+        reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+        reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: haku-sandbox
+        reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+        reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: haku-sandbox
   - name: alloy-otlp
     provider_slug: alloy-otlp-client-credentials
     scopes: openid profile email

--- a/cluster/k8s/agents/authentik-jwt-rotation/test_rotate.py
+++ b/cluster/k8s/agents/authentik-jwt-rotation/test_rotate.py
@@ -10,6 +10,7 @@ from rotate import (
     Config,
     K8sSecretOutput,
     Rotation,
+    build_secret_manifest,
     jwt_payload,
     mint_jwt,
     remaining_hours,
@@ -126,6 +127,27 @@ def test_rotation_k8s_secret_defaults_none_and_parses():
     assert r.k8s_secret.token_key == "jwt"  # default
     assert r.k8s_secret.exp_key == "token-exp"  # default
     assert r.k8s_secret.namespace == "flux-system"
+    assert r.k8s_secret.annotations is None  # default
+
+
+def test_build_secret_manifest_carries_token_exp_and_merges_annotations():
+    out = K8sSecretOutput(
+        path=Path("cluster/k8s/x.sops.yaml"),
+        name="haku-cloud-grocy-sf-token",
+        namespace="flux-system",
+        annotations={"reflector.v1.k8s.emberstack.com/reflection-auto-namespaces": "haku-sandbox"},
+    )
+    manifest = build_secret_manifest(out, token="the-jwt", exp_epoch=1750000000)
+    assert manifest["stringData"] == {"jwt": "the-jwt", "token-exp": "1750000000"}
+    annotations = manifest["metadata"]["annotations"]
+    # The rotator's own description annotation survives, the configured one is merged in.
+    assert "description" in annotations
+    assert annotations["reflector.v1.k8s.emberstack.com/reflection-auto-namespaces"] == "haku-sandbox"
+
+
+def test_build_secret_manifest_without_annotations_keeps_only_description():
+    out = K8sSecretOutput(path=Path("cluster/k8s/x.sops.yaml"), name="t", namespace="flux-system")
+    assert list(build_secret_manifest(out, token="j", exp_epoch=1)["metadata"]["annotations"]) == ["description"]
 
 
 def test_rotation_expected_issuer_derived_from_slug():

--- a/haku/PLAN.md
+++ b/haku/PLAN.md
@@ -70,9 +70,12 @@ and the not-yet-built items below.
   read-only-credential trick gets fronted by **another instance** of it: a Deployment +
   a `config.yaml` allowlist + the upstream secret + a bearer-gated route — no new
   boundary code, the generalization is mechanical. Still to wire this way: PostScanMail
-  (unopened mail), Grocy (expiring / below-minimum stock), Manifold. (The Authentik
-  OAuth facades are _auth_ only — they forward the full tool set — so they don't
-  substitute for this.)
+  (unopened mail), Manifold. (The Authentik OAuth facades are _auth_ only — they forward
+  the full tool set — so they don't substitute for this.) **Grocy** went a different,
+  cheaper route — no facade: its upstream enforces per-user permissions, so the read-only
+  `haku` Grocy user (empty perms → API serves reads, 403s writes) _is_ the boundary, and
+  Haku calls the grocy-sf MCP directly (`base/sources/grocy.md`). Prefer that whenever an
+  upstream has its own read-only-credential model; the facade is for the ones that don't.
 - **In-cluster runtime** (the `haku-scanner` CronJob / self-hosted Managed-Agents
   worker) as an alternative to the web home — deferred; see `TODO.md` → _Later_ and
   `haku/runtime/managed_agent/`. Revisit if scanner-image upkeep or the

--- a/haku/TODO.md
+++ b/haku/TODO.md
@@ -58,7 +58,11 @@ facade** in front (the Authentik OAuth facade is auth, not tool filtering — se
 
 - **PostScanMail** — unopened-mail → open/discard/shred suggestions. First filter
   facade to build; also proves the `client_credentials` facade-auth path.
-- **Grocy** — expiring / below-minimum stock, shopping-list suggestions.
+
+**Grocy is wired** (`base/sources/grocy.md`) — it didn't need a tool-filter facade:
+the `haku` Grocy user has empty permissions, so the Grocy API enforces read-only
+(200 reads / 403 writes) server-side. Haku reaches the grocy-sf MCP directly with a
+rotated JWT, reflected into `haku-sandbox` as `haku-cloud-grocy-sf-token`.
 
 ## Wiring / hardening
 

--- a/haku/base/sources/README.md
+++ b/haku/base/sources/README.md
@@ -32,6 +32,9 @@ grows its own techniques and records them in its state `memory/`.
   intentions tracked nowhere else — a must-read source, not optional.
 - [`plaid`](plaid.md) — financial transactions (read-only SQL via
   a `haku-sandbox` pod).
+- [`grocy`](grocy.md) — the operator's household stock (expiring /
+  below-minimum items, shopping suggestions); reached via the grocy-sf MCP
+  (`fastmcp`), read-only because the `haku` Grocy user has empty permissions.
 - [`ducktape`](ducktape.md) — the operator's recent repo work
   (always reachable; you have the checkout). The **cluster** is likewise a standing
   source — see `../instructions.md` → _How you reason_ (read-only diagnostics).
@@ -45,5 +48,5 @@ sources fit (illustrations, not a checklist; invent your own). This directory is
 the channels and how to read them.
 
 Designed but **not yet wired** (don't attempt; note the gap if one appears):
-PostScanMail (unopened mail), Grocy (expiring / below-minimum stock) — each blocked
-until it sits behind a read-only filter facade; see `../../PLAN.md`.
+PostScanMail (unopened mail) — blocked until it sits behind a read-only filter
+facade; see `../../PLAN.md`.

--- a/haku/base/sources/grocy.md
+++ b/haku/base/sources/grocy.md
@@ -1,0 +1,60 @@
+# Grocy
+
+The operator's **Grocy** tracks their household stock — what food and supplies are on
+hand, where, how much, and what's about to expire or run low. It's the seam for
+quality-of-life suggestions: "the eggs expire in two days → here's an omelette," "you're
+down to one roll of paper towels," "you're already out of the wall filler your project
+needs." You read it **read-only**: your Grocy user has empty permissions, so the Grocy
+API serves every read (200) and rejects every write (403) server-side — never try to
+add, consume, or edit stock.
+
+## Reaching it
+
+Grocy is exposed as an MCP server at `https://grocy-mcp-sf.allegedly.works/mcp`,
+authenticated by a bearer JWT (the MCP validates it and runs the auth handshake into
+Grocy itself, injecting your read-only `haku` user). Your home has the `fastmcp` CLI
+(baked into the agent-haku closure — see `haku/runtime/claude_web_env/`), so talk to it
+**directly** — no pod. Read the bearer from the reflected `haku-cloud-grocy-sf-token`
+secret (the same rotated grocy JWT the cloud agent uses, mirrored into `haku-sandbox`)
+into a shell variable — reference `"$TOKEN"`, never the literal, so the secret stays out
+of your transcript:
+
+```bash
+TOKEN=$(kubectl -n haku-sandbox get secret haku-cloud-grocy-sf-token \
+  -o jsonpath='{.data.jwt}' | base64 -d)
+URL=https://grocy-mcp-sf.allegedly.works/mcp
+
+# What's exposed, with each tool's argument schema:
+fastmcp list "$URL" --auth "$TOKEN" --transport http --input-schema
+
+# Call a read tool (--json for machine-readable output):
+fastmcp call "$URL" stock_get --auth "$TOKEN" --transport http --json
+```
+
+### Fallback: `curl` when `fastmcp` is missing
+
+`fastmcp` is just a convenience wrapper (see `tana.md` for the same situation). If it
+isn't on your `PATH`, drive the facade with `curl` over the standard streamable-HTTP MCP
+handshake (`initialize` → capture `Mcp-Session-Id` → `notifications/initialized` →
+`tools/call`, threading the header; responses may arrive SSE-framed on `data:` lines).
+**Surface the `fastmcp` gap as an item** so the operator can fix the closure.
+
+## What to read
+
+Read tools (writes exist but 403 for you — ignore them):
+
+- **`stock_get`** — current stock overview: product, amount, location, and best-before
+  dates. The primary read; scan it for items expiring soon or below their minimum.
+- **`stock_entries_list`** — individual stock entries (per-lot best-before / opened
+  state) when you need finer detail than the aggregated overview.
+- **`products_list`**, **`product_groups_list`** — the product catalog and its grouping
+  (min-stock thresholds, quantity units, default locations).
+- **`shopping_lists_list`**, **`shopping_list_get`** — what the operator has already
+  queued to buy (so you don't re-suggest it).
+
+Mine these for: items **expiring** (propose using them up — recipes, "eat this first"),
+items **below minimum** or absent that the operator relies on (a shopping nudge), and
+**opportunistic** suggestions that combine stock with where the operator is and what
+else is going on (see `../recipes.md` → _Generate, don't just detect_). Never surface a
+suggestion to buy something already on a shopping list. If `list` is empty or a call
+401s, note the gap in your log and move on (the bearer must be the reflected one).


### PR DESCRIPTION
Gives the **self-hosted Haku home** read-only grocy access the same way it already has Tana: read the bearer from a reflected secret in `haku-sandbox` and call the grocy-sf MCP directly via `fastmcp`.

**Plumbing** (per the "one namespace + reflector, no rotator for-each" guidance):
- `rotate.py`: `K8sSecretOutput` gains a generic `annotations` dict merged into the Secret's metadata (more flexible than a reflector-specific field — the reflector keys live in config, not Python). Extracted a pure `build_secret_manifest()` so the merge is unit-tested without shelling to `sops`.
- `rotations.yaml`: the `haku-grocy` `k8s_secret` carries `kubernetes-reflector` annotations → the `flux-system` Secret auto-mirrors into `haku-sandbox` as `haku-cloud-grocy-sf-token` (key `jwt`).

**Docs:**
- New `haku/base/sources/grocy.md` (mirrors `tana.md`): what grocy tells Haku, `fastmcp` + `curl`-fallback reach, the read tools (`stock_get`, `stock_entries_list`, `products_list`, `shopping_list*`), and that writes 403 server-side.
- `sources/README.md`, `TODO.md`, `PLAN.md`: move grocy from "not yet wired / needs a read-only filter facade" → **wired**. It didn't need a facade: the empty-perm `haku` Grocy user is the server-side read-only boundary (200 reads / 403 writes), so Haku calls the MCP directly.

**After merge:** a rotator re-mint stamps the reflector annotations onto the `flux-system` Secret → reflector mirrors it into `haku-sandbox` → the home can read it. (I'll trigger the re-mint post-merge, as with #2523.)