### PR TITLE
haku/sources: factor fastmcp+curl MCP transport into a shared doc

### DIFF
--- a/haku/base/sources/README.md
+++ b/haku/base/sources/README.md
@@ -39,6 +39,11 @@ grows its own techniques and records them in its state `memory/`.
   (always reachable; you have the checkout). The **cluster** is likewise a standing
   source — see `../instructions.md` → _How you reason_ (read-only diagnostics).
 
+The MCP-server sources (`tana`, `grocy`) share one transport how-to —
+[`mcp_over_http.md`](mcp_over_http.md) (`fastmcp`, `curl` fallback, reading the
+bearer); their own files carry only the URL, secret, tools, and gotchas. It's a
+shared mechanic, not a channel.
+
 ## Techniques live elsewhere
 
 Reusable, source-agnostic ways to be useful — inbox-like triage & cleanup, delegation

--- a/haku/base/sources/grocy.md
+++ b/haku/base/sources/grocy.md
@@ -10,34 +10,21 @@ add, consume, or edit stock.
 
 ## Reaching it
 
-Grocy is exposed as an MCP server at `https://grocy-mcp-sf.allegedly.works/mcp`,
-authenticated by a bearer JWT (the MCP validates it and runs the auth handshake into
-Grocy itself, injecting your read-only `haku` user). Your home has the `fastmcp` CLI
-(baked into the agent-haku closure — see `haku/runtime/claude_web_env/`), so talk to it
-**directly** — no pod. Read the bearer from the reflected `haku-cloud-grocy-sf-token`
-secret (the same rotated grocy JWT the cloud agent uses, mirrored into `haku-sandbox`)
-into a shell variable — reference `"$TOKEN"`, never the literal, so the secret stays out
-of your transcript:
+Grocy is an MCP server at `https://grocy-mcp-sf.allegedly.works/mcp`. The transport
+mechanics — `fastmcp`, the `curl` fallback, reading the bearer into `"$TOKEN"` — are
+shared across MCP sources; see [`mcp_over_http.md`](mcp_over_http.md). Grocy specifics:
+
+- **Bearer:** the reflected `haku-cloud-grocy-sf-token` secret, key `jwt` (the same
+  rotated grocy JWT the cloud agent uses, mirrored into `haku-sandbox`). The MCP
+  validates it and runs the auth handshake into Grocy, injecting your read-only `haku`
+  user — so reads return 200 and **every write 403s** server-side.
 
 ```bash
 TOKEN=$(kubectl -n haku-sandbox get secret haku-cloud-grocy-sf-token \
   -o jsonpath='{.data.jwt}' | base64 -d)
-URL=https://grocy-mcp-sf.allegedly.works/mcp
-
-# What's exposed, with each tool's argument schema:
-fastmcp list "$URL" --auth "$TOKEN" --transport http --input-schema
-
-# Call a read tool (--json for machine-readable output):
-fastmcp call "$URL" stock_get --auth "$TOKEN" --transport http --json
+fastmcp call https://grocy-mcp-sf.allegedly.works/mcp stock_get \
+  --auth "$TOKEN" --transport http --json
 ```
-
-### Fallback: `curl` when `fastmcp` is missing
-
-`fastmcp` is just a convenience wrapper (see `tana.md` for the same situation). If it
-isn't on your `PATH`, drive the facade with `curl` over the standard streamable-HTTP MCP
-handshake (`initialize` → capture `Mcp-Session-Id` → `notifications/initialized` →
-`tools/call`, threading the header; responses may arrive SSE-framed on `data:` lines).
-**Surface the `fastmcp` gap as an item** so the operator can fix the closure.
 
 ## What to read
 

--- a/haku/base/sources/mcp_over_http.md
+++ b/haku/base/sources/mcp_over_http.md
@@ -1,0 +1,47 @@
+# Calling an MCP-server source (`fastmcp`, with a `curl` fallback)
+
+Several sources — Tana, Grocy, … — are **MCP servers reached over HTTP behind a
+bearer token**. The transport is identical across them; only the URL, the bearer
+secret, and the exposed tools differ (those live in each source's own file). This is
+the shared how-to; the per-channel files just point here.
+
+## With `fastmcp` (the normal path)
+
+Your home has the `fastmcp` CLI (baked into the agent-haku closure — see
+`haku/runtime/claude_web_env/`), so talk to the server **directly** — no pod, no
+hand-rolled JSON-RPC. Read the bearer from the source's reflected `haku-sandbox`
+secret into a shell variable, and **always reference `"$TOKEN"`, never the literal
+value**, so the secret stays out of your transcript:
+
+```bash
+TOKEN=$(kubectl -n haku-sandbox get secret <secret-name> \
+  -o jsonpath='{.data.<key>}' | base64 -d)
+URL=<the source's …/mcp URL>
+
+# Discover the exposed tools with their argument schemas:
+fastmcp list "$URL" --auth "$TOKEN" --transport http --input-schema
+
+# Call a tool — args are key=value per the schema above (or --input-json '{…}' for
+# nested); add --json for machine-readable output:
+fastmcp call "$URL" <tool> key=value --auth "$TOKEN" --transport http --json
+```
+
+## Fallback: `curl` when `fastmcp` is missing
+
+`fastmcp` is just a convenience wrapper. If it isn't on your `PATH` (e.g. the web home
+came up with the lean `.#devtools` instead of `.#agent-haku`), **do not skip the
+source** — drive it with `curl` over the standard streamable-HTTP MCP handshake you
+already know:
+
+1. `initialize` → capture the `Mcp-Session-Id` **response header**.
+2. `notifications/initialized` (threading that header).
+3. `tools/list` / `tools/call` (still threading the header).
+
+Read `"$TOKEN"` from the secret as above and send it as `Authorization: Bearer
+$TOKEN`; curl goes through the egress proxy transparently. **Gotcha:** responses often
+come back **SSE-framed** — the JSON-RPC payload is on `data: {…}` lines, not a bare
+body, so strip the `data: ` prefix before parsing.
+
+**Surface the `fastmcp` gap itself as an item** (environment self-check) so the
+operator can fix the closure — `curl` keeps you working meanwhile, but the root cause
+should reach the dashboard.

--- a/haku/base/sources/tana.md
+++ b/haku/base/sources/tana.md
@@ -10,24 +10,17 @@ the Tana PAT stays server-side, so you never see it.
 ## Reaching it
 
 `tana-mcp-ro` is exposed at `https://tana-mcp-ro.allegedly.works/mcp`, gated by a
-static bearer. Your home has the `fastmcp` CLI (baked into the agent-haku closure —
-see `haku/runtime/claude_web_env/`), so talk to it **directly** — no pod, no JSON-RPC
-handshake. Read the bearer from the reflected `haku-tana-ro-token` secret into a
-shell variable (reference `"$TOKEN"`, never the literal, so the secret stays out of
-your transcript), then list and call:
+**static bearer** — the reflected `haku-tana-ro-token` secret, key `token`. The
+transport mechanics (`fastmcp`, the `curl` fallback, reading the bearer into
+`"$TOKEN"`) are shared across MCP sources; see [`mcp_over_http.md`](mcp_over_http.md).
+Tana is the operator's most important source — if `fastmcp` is missing, fall back to
+`curl`, never skip it.
 
 ```bash
 TOKEN=$(kubectl -n haku-sandbox get secret haku-tana-ro-token \
   -o jsonpath='{.data.token}' | base64 -d)
-URL=https://tana-mcp-ro.allegedly.works/mcp
-
-# What's exposed, with each tool's argument schema:
-fastmcp list "$URL" --auth "$TOKEN" --transport http --input-schema
-
-# Call a tool — args are key=value pairs per the schema above (or
-# --input-json '{…}' for nested); add --json for machine-readable output:
-fastmcp call "$URL" search_nodes query="follow up" --auth "$TOKEN" --transport http
-fastmcp call "$URL" read_node nodeId="<id>" --auth "$TOKEN" --transport http
+fastmcp call https://tana-mcp-ro.allegedly.works/mcp \
+  search_nodes query="follow up" --auth "$TOKEN" --transport http --json
 ```
 
 Read tools only — `search_nodes`, `read_node`, `get_children`, `open_node`,
@@ -35,24 +28,9 @@ Read tools only — `search_nodes`, `read_node`, `get_children`, `open_node`,
 `list` is empty or a call 401s, note the gap in your log and move on (the facade
 flips NotReady on a bad upstream, and the bearer must be the reflected one).
 
-### Fallback: `curl` when `fastmcp` is missing
-
-`fastmcp` is just a convenience wrapper. If it isn't on your `PATH` (e.g. the web
-home came up with the lean `.#devtools` instead of `.#agent-haku`), **do not skip
-Tana** — it's the operator's most important source. The facade is plain
-MCP-over-HTTP behind the same bearer and the same `…/mcp` endpoint, so drive it with
-`curl` using the standard streamable-HTTP MCP handshake you already know
-(`initialize`, capturing the `Mcp-Session-Id` response header → `notifications/
-initialized` → `tools/call`, threading that header). Read `"$TOKEN"` from the secret
-as above. **Tana gotcha:** responses come back as SSE — the JSON-RPC payload is on
-`data: {…}` lines, not a bare body, so strip the prefix before parsing.
-
 `search_nodes` takes a top-level `query` (and `limit`, max ~100) — **no
 `workspaceId`**; the structured query DSL is in the tool's own `description`. Link
-Tana nodes in items as `https://app.tana.inc?nodeid=<nodeId>`. **Surface the
-`fastmcp` gap itself as an item** (see _Environment self-check_) so the operator can
-fix the closure — curl keeps you working meanwhile, but the root cause should reach
-the dashboard.
+Tana nodes in items as `https://app.tana.inc?nodeid=<nodeId>`.
 
 ## Determining whether a task is actually open — use the `Task status` field, NOT the checkbox or `is:todo`
 


### PR DESCRIPTION
The `fastmcp`/`curl`-fallback mechanics were duplicated in `tana.md` and `grocy.md` — it's the same process across every MCP-server source (read the reflected bearer into `$TOKEN`, `fastmcp list`/`call`, or the streamable-HTTP `curl` handshake with SSE-framed responses, plus surfacing the `fastmcp` gap).

- New `haku/base/sources/mcp_over_http.md` carries the shared transport how-to.
- `tana.md` and `grocy.md` now link there and keep only their URL, bearer secret, tools, and source-specific gotchas (Tana's `Task status`/`inTrash`/no-pagination scan rules; Grocy's read tools / 403 writes).
- `sources/README.md` notes it's a shared mechanic, not a channel.

Pure docs refactor — no behavior change.