### PR TITLE
[codex] debundle: preserve cpsat binding constants

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,6 +14,7 @@ bazel_dep(name = "rules_proto", version = "7.1.0")
 bazel_dep(name = "rules_cc", version = "0.2.16")
 bazel_dep(name = "or-tools", version = "9.15")
 bazel_dep(name = "abseil-cpp", version = "20260107.1")
+bazel_dep(name = "googletest", version = "1.17.0")
 bazel_dep(name = "googleapis", version = "0.0.0-20260223-edfe7983")
 bazel_dep(name = "googleapis-go", version = "1.0.0")
 bazel_dep(name = "rules_shell", version = "0.6.1")  # Required by buildifier_prebuilt

--- a/devinfra/js/debundle/selector_ortools_cpsat_backend.rs
+++ b/devinfra/js/debundle/selector_ortools_cpsat_backend.rs
@@ -242,6 +242,8 @@ fn target_projection_from_backend(
         owner_variable_id: constraint_variable_id(projection.owner_variable)?,
         has_binding_variable: binding_variable_id.is_some(),
         binding_variable_id: binding_variable_id.unwrap_or_default(),
+        has_binding_const: projection.binding_const.is_some(),
+        binding_const: projection.binding_const.clone().unwrap_or_default(),
     })
 }
 
@@ -317,7 +319,7 @@ mod tests {
     use selector_backend_solver::solve_with_backend;
     use selector_ir::{
         ClaimKind, ClaimOrigin, ClaimOutcome, OwnerTerm, ResolvedClaim, SelectorAtom, SelectorFact,
-        SelectorFactStore, SelectorProgram, StringTerm, VariableDomain,
+        SelectorFactStore, SelectorProgram, SelectorTargetId, StringTerm, VariableDomain,
     };
 
     use super::*;
@@ -356,6 +358,25 @@ mod tests {
             }
         }
         panic!("could not resolve sidecar runfile {rlocation}");
+    }
+
+    #[test]
+    fn request_preserves_constant_binding_projection() {
+        let projection = BackendTargetProjection {
+            target: SelectorTargetId(7),
+            owner_variable: ConstraintVariableId(0),
+            binding_variable: None,
+            binding_const: Some("minA".to_string()),
+        };
+
+        let wire_projection = target_projection_from_backend(&projection).unwrap();
+
+        assert_eq!(wire_projection.target_id, 7);
+        assert_eq!(wire_projection.owner_variable_id, 0);
+        assert!(!wire_projection.has_binding_variable);
+        assert_eq!(wire_projection.binding_variable_id, 0);
+        assert!(wire_projection.has_binding_const);
+        assert_eq!(wire_projection.binding_const, "minA");
     }
 
     #[test]

--- a/devinfra/js/debundle/solver_backends/ortools_cpsat/BUILD.bazel
+++ b/devinfra/js/debundle/solver_backends/ortools_cpsat/BUILD.bazel
@@ -55,7 +55,7 @@ cc_test(
     deps = [
         ":selector_cp_sat_cc_proto",
         ":solver",
-        "@abseil-cpp//absl/log:check",
+        "@googletest//:gtest_main",
         "@protobuf",
     ],
 )

--- a/devinfra/js/debundle/solver_backends/ortools_cpsat/selector_cp_sat.proto
+++ b/devinfra/js/debundle/solver_backends/ortools_cpsat/selector_cp_sat.proto
@@ -49,6 +49,8 @@ message TargetProjection {
   uint32 owner_variable_id = 2;
   bool has_binding_variable = 3;
   uint32 binding_variable_id = 4;
+  bool has_binding_const = 5;
+  string binding_const = 6;
 }
 
 message SelectorCpSatResponse {

--- a/devinfra/js/debundle/solver_backends/ortools_cpsat/solver.cc
+++ b/devinfra/js/debundle/solver_backends/ortools_cpsat/solver.cc
@@ -176,6 +176,11 @@ absl::StatusOr<std::vector<uint32_t>> ProjectionVariableIds(
     const SelectorCpSatRequest& request, const VariableMap& variables) {
   std::set<uint32_t> ids;
   for (const TargetProjection& projection : request.target_projections()) {
+    if (projection.has_binding_variable() && projection.has_binding_const()) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          "target projection ", projection.target_id(),
+          " has both binding variable and binding const"));
+    }
     ids.insert(projection.owner_variable_id());
     if (projection.has_binding_variable()) {
       ids.insert(projection.binding_variable_id());

--- a/devinfra/js/debundle/solver_backends/ortools_cpsat/solver_test.cc
+++ b/devinfra/js/debundle/solver_backends/ortools_cpsat/solver_test.cc
@@ -1,15 +1,15 @@
 #include "devinfra/js/debundle/solver_backends/ortools_cpsat/solver.h"
 
-#include "absl/log/check.h"
 #include "google/protobuf/text_format.h"
+#include "gtest/gtest.h"
 
 namespace cpsat = ducktape::debundle::solver_backends::ortools_cpsat;
 
 namespace {
 
-cpsat::SelectorCpSatRequest ParseRequestOrDie(const char* textproto) {
+cpsat::SelectorCpSatRequest ParseRequest(const char* textproto) {
   cpsat::SelectorCpSatRequest request;
-  CHECK(google::protobuf::TextFormat::ParseFromString(textproto, &request))
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(textproto, &request))
       << textproto;
   return request;
 }
@@ -25,8 +25,8 @@ bool RowHas(const cpsat::AssignmentRow& row, uint32_t variable_id,
   return false;
 }
 
-void AllDifferentPropagatesBroadSpecificFixture() {
-  const cpsat::SelectorCpSatRequest request = ParseRequestOrDie(R"pb(
+TEST(SelectorCpSatSolverTest, AllDifferentPropagatesBroadSpecificFixture) {
+  const cpsat::SelectorCpSatRequest request = ParseRequest(R"pb(
     variables { id: 0 values: 0 values: 1 debug_name: "broad_owner" }
     variables { id: 1 values: 0 values: 1 debug_name: "strict_owner" }
     variables { id: 2 values: 0 values: 1 values: 2 debug_name: "reserved_owner" }
@@ -57,16 +57,16 @@ void AllDifferentPropagatesBroadSpecificFixture() {
   const cpsat::SelectorCpSatResponse response =
       cpsat::SolveSelectorCpSat(request);
 
-  CHECK_EQ(response.status(), cpsat::SOLVER_STATUS_SATISFIABLE);
-  CHECK_EQ(response.assignment_coverage(),
-           cpsat::ASSIGNMENT_COVERAGE_TARGET_SUPPORT_COMPLETE);
-  CHECK_EQ(response.assignments_size(), 1);
-  CHECK(RowHas(response.assignments(0), 0, 0));
-  CHECK(RowHas(response.assignments(0), 1, 1));
+  EXPECT_EQ(response.status(), cpsat::SOLVER_STATUS_SATISFIABLE);
+  EXPECT_EQ(response.assignment_coverage(),
+            cpsat::ASSIGNMENT_COVERAGE_TARGET_SUPPORT_COMPLETE);
+  ASSERT_EQ(response.assignments_size(), 1);
+  EXPECT_TRUE(RowHas(response.assignments(0), 0, 0));
+  EXPECT_TRUE(RowHas(response.assignments(0), 1, 1));
 }
 
-void MultipleProjectionRowsAreAmbiguous() {
-  const cpsat::SelectorCpSatRequest request = ParseRequestOrDie(R"pb(
+TEST(SelectorCpSatSolverTest, MultipleProjectionRowsAreAmbiguous) {
+  const cpsat::SelectorCpSatRequest request = ParseRequest(R"pb(
     variables { id: 0 values: 0 values: 1 debug_name: "owner" }
     target_projections { target_id: 0 owner_variable_id: 0 }
   )pb");
@@ -74,14 +74,14 @@ void MultipleProjectionRowsAreAmbiguous() {
   const cpsat::SelectorCpSatResponse response =
       cpsat::SolveSelectorCpSat(request);
 
-  CHECK_EQ(response.status(), cpsat::SOLVER_STATUS_AMBIGUOUS);
-  CHECK_EQ(response.assignment_coverage(),
-           cpsat::ASSIGNMENT_COVERAGE_TARGET_SUPPORT_COMPLETE);
-  CHECK_EQ(response.assignments_size(), 2);
+  EXPECT_EQ(response.status(), cpsat::SOLVER_STATUS_AMBIGUOUS);
+  EXPECT_EQ(response.assignment_coverage(),
+            cpsat::ASSIGNMENT_COVERAGE_TARGET_SUPPORT_COMPLETE);
+  EXPECT_EQ(response.assignments_size(), 2);
 }
 
-void ConflictingTablesAreUnsat() {
-  const cpsat::SelectorCpSatRequest request = ParseRequestOrDie(R"pb(
+TEST(SelectorCpSatSolverTest, ConflictingTablesAreUnsat) {
+  const cpsat::SelectorCpSatRequest request = ParseRequest(R"pb(
     variables { id: 0 values: 0 values: 1 debug_name: "owner" }
     allowed_tables {
       id: 0
@@ -99,30 +99,43 @@ void ConflictingTablesAreUnsat() {
   const cpsat::SelectorCpSatResponse response =
       cpsat::SolveSelectorCpSat(request);
 
-  CHECK_EQ(response.status(), cpsat::SOLVER_STATUS_UNSATISFIABLE);
-  CHECK_EQ(response.assignment_coverage(),
-           cpsat::ASSIGNMENT_COVERAGE_TARGET_SUPPORT_COMPLETE);
-  CHECK_EQ(response.assignments_size(), 0);
+  EXPECT_EQ(response.status(), cpsat::SOLVER_STATUS_UNSATISFIABLE);
+  EXPECT_EQ(response.assignment_coverage(),
+            cpsat::ASSIGNMENT_COVERAGE_TARGET_SUPPORT_COMPLETE);
+  EXPECT_EQ(response.assignments_size(), 0);
 }
 
-void InvalidProblemReportsDiagnostic() {
-  const cpsat::SelectorCpSatRequest request = ParseRequestOrDie(R"pb(
+TEST(SelectorCpSatSolverTest, InvalidProblemReportsDiagnostic) {
+  const cpsat::SelectorCpSatRequest request = ParseRequest(R"pb(
     variables { id: 0 debug_name: "owner" }
   )pb");
 
   const cpsat::SelectorCpSatResponse response =
       cpsat::SolveSelectorCpSat(request);
 
-  CHECK_EQ(response.status(), cpsat::SOLVER_STATUS_INVALID);
-  CHECK(!response.diagnostic().empty());
+  EXPECT_EQ(response.status(), cpsat::SOLVER_STATUS_INVALID);
+  EXPECT_FALSE(response.diagnostic().empty());
+}
+
+TEST(SelectorCpSatSolverTest, ConflictingBindingProjectionReportsDiagnostic) {
+  const cpsat::SelectorCpSatRequest request = ParseRequest(R"pb(
+    variables { id: 0 values: 0 debug_name: "owner" }
+    variables { id: 1 values: 10 debug_name: "binding" }
+    target_projections {
+      target_id: 0
+      owner_variable_id: 0
+      has_binding_variable: true
+      binding_variable_id: 1
+      has_binding_const: true
+      binding_const: "minA"
+    }
+  )pb");
+
+  const cpsat::SelectorCpSatResponse response =
+      cpsat::SolveSelectorCpSat(request);
+
+  EXPECT_EQ(response.status(), cpsat::SOLVER_STATUS_INVALID);
+  EXPECT_FALSE(response.diagnostic().empty());
 }
 
 }  // namespace
-
-int main() {
-  AllDifferentPropagatesBroadSpecificFixture();
-  MultipleProjectionRowsAreAmbiguous();
-  ConflictingTablesAreUnsat();
-  InvalidProblemReportsDiagnostic();
-  return 0;
-}


### PR DESCRIPTION
## Summary

- add explicit constant-binding projection fields to the CP-SAT request proto
- serialize `BackendTargetProjection::binding_const` from Rust into the CP-SAT request
- reject malformed CP-SAT target projections that specify both a binding variable and a binding const
- convert the C++ solver test from manual `CHECK`/`main` plumbing to GoogleTest-style test cases and assertions

## Why

The Rust-side selector backend problem already preserved constant binding projections, and the solver result decoder could use them. The external CP-SAT request shape did not carry that field, which made the wire boundary less faithful than the backend-neutral model.

## Validation

- `nix develop -c pre-commit run --files MODULE.bazel devinfra/js/debundle/selector_ortools_cpsat_backend.rs devinfra/js/debundle/solver_backends/ortools_cpsat/BUILD.bazel devinfra/js/debundle/solver_backends/ortools_cpsat/selector_cp_sat.proto devinfra/js/debundle/solver_backends/ortools_cpsat/solver.cc devinfra/js/debundle/solver_backends/ortools_cpsat/solver_test.cc`
- `nix develop -c bbr test //devinfra/js/debundle/solver_backends/ortools_cpsat:solver_test //devinfra/js/debundle:selector_ortools_cpsat_backend_test --cache_test_results=no --test_output=errors`
- BuildBuddy: https://app.buildbuddy.io/invocation/5c09e3f0-e62b-452c-8688-ccc26611a7b7