### PR TITLE
authentik: let the Haku console frame Authentik (frame-ancestors) for the haku-ui iframe

### DIFF
--- a/cluster/k8s/authentik/app/httproute.yaml
+++ b/cluster/k8s/authentik/app/httproute.yaml
@@ -10,6 +10,21 @@ spec:
   hostnames:
     - "auth.allegedly.works"
   rules:
-    - backendRefs:
+    # Let the operator-owned Haku console (haku.allegedly.works) frame Authentik's
+    # pages, so the agent-authored Haku UI iframe (haku-ui.allegedly.works, a separate
+    # Authentik proxy app) can complete its first-time auth in-frame off the existing
+    # SSO session instead of forcing a separate top-level login. Authentik defaults to
+    # `X-Frame-Options: DENY` and sets no CSP; we swap that for a `frame-ancestors`
+    # whitelist so ONLY the console (and Authentik itself) may frame it — every other
+    # origin still can't. This does not let the framed app act as the console: that is
+    # cross-origin isolation (separate origins/cookies), independent of framing headers.
+    - filters:
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            remove: ["X-Frame-Options"]
+            set:
+              - name: Content-Security-Policy
+                value: "frame-ancestors 'self' https://haku.allegedly.works"
+      backendRefs:
         - name: authentik-server
           port: 80


### PR DESCRIPTION
## Why
The agent-authored Haku UI (`haku-ui.allegedly.works`, a separate Authentik proxy app) is embedded as a cross-origin iframe in the console's **Free-form UI** tab. It loads fine **once a haku-ui proxy session exists** (the proxied content sets no `X-Frame-Options`), but **first-time auth failed in-frame**: Authentik's flow page sends `X-Frame-Options: DENY`, so the browser blocked the frame ("This content is blocked").

## Fix
Add a `ResponseHeaderModifier` to the `auth.allegedly.works` route: **remove `X-Frame-Options`** and **set `Content-Security-Policy: frame-ancestors 'self' https://haku.allegedly.works`**. Now only the operator-owned console (and Authentik itself) may frame Authentik — every other origin still can't — so the haku-ui auth completes in-frame off the existing SSO session (implicit consent → no manual login), and the iframe fills in with no separate tab.

## Security
- **Does not weaken `haku-ui ≠ haku-console`.** That boundary is cross-origin isolation (separate origins, separate Authentik cookies); the iframe can't read the console's DOM/cookies or act as it regardless of framing headers. During auth the iframe shows `auth.allegedly.works` (the agent's page isn't running), so the agent never sees credentials.
- Authentik set **no CSP** before (only `X-Frame-Options: DENY`), so nothing is clobbered; `referrer-policy`/`x-content-type-options` are untouched.
- Caveat: Authentik's auth flow is shared across apps, so this lets the console frame *any* Authentik page — but bounded to the console origin, so in practice it only matters for this iframe.

## Verification
- `kubeconform (cluster)` + cluster-validate green.
- Post-merge + reconcile: the Free-form UI tab loads the haku-ui placeholder without a separate login.