### PR TITLE
[codex] debundle: model cpsat binding projection as oneof

### DIFF
--- a/devinfra/js/debundle/selector_ortools_cpsat_backend.rs
+++ b/devinfra/js/debundle/selector_ortools_cpsat_backend.rs
@@ -233,17 +233,21 @@ fn all_different_from_backend(
 fn target_projection_from_backend(
     projection: &BackendTargetProjection,
 ) -> Result<wire::TargetProjection, OrToolsCpSatBackendError> {
-    let binding_variable_id = projection
+    let binding_projection = projection
         .binding_variable
         .map(constraint_variable_id)
-        .transpose()?;
+        .transpose()?
+        .map(wire::target_projection::BindingProjection::BindingVariableId)
+        .or_else(|| {
+            projection
+                .binding_const
+                .clone()
+                .map(wire::target_projection::BindingProjection::BindingConst)
+        });
     Ok(wire::TargetProjection {
         target_id: u32_id("target_projections.target_id", projection.target.0)?,
         owner_variable_id: constraint_variable_id(projection.owner_variable)?,
-        has_binding_variable: binding_variable_id.is_some(),
-        binding_variable_id: binding_variable_id.unwrap_or_default(),
-        has_binding_const: projection.binding_const.is_some(),
-        binding_const: projection.binding_const.clone().unwrap_or_default(),
+        binding_projection,
     })
 }
 
@@ -373,10 +377,12 @@ mod tests {
 
         assert_eq!(wire_projection.target_id, 7);
         assert_eq!(wire_projection.owner_variable_id, 0);
-        assert!(!wire_projection.has_binding_variable);
-        assert_eq!(wire_projection.binding_variable_id, 0);
-        assert!(wire_projection.has_binding_const);
-        assert_eq!(wire_projection.binding_const, "minA");
+        assert_eq!(
+            wire_projection.binding_projection,
+            Some(wire::target_projection::BindingProjection::BindingConst(
+                "minA".to_string()
+            ))
+        );
     }
 
     #[test]

--- a/devinfra/js/debundle/solver_backends/ortools_cpsat/selector_cp_sat.proto
+++ b/devinfra/js/debundle/solver_backends/ortools_cpsat/selector_cp_sat.proto
@@ -47,10 +47,10 @@ message AllDifferent {
 message TargetProjection {
   uint32 target_id = 1;
   uint32 owner_variable_id = 2;
-  bool has_binding_variable = 3;
-  uint32 binding_variable_id = 4;
-  bool has_binding_const = 5;
-  string binding_const = 6;
+  oneof binding_projection {
+    uint32 binding_variable_id = 3;
+    string binding_const = 4;
+  }
 }
 
 message SelectorCpSatResponse {

--- a/devinfra/js/debundle/solver_backends/ortools_cpsat/solver.cc
+++ b/devinfra/js/debundle/solver_backends/ortools_cpsat/solver.cc
@@ -176,13 +176,8 @@ absl::StatusOr<std::vector<uint32_t>> ProjectionVariableIds(
     const SelectorCpSatRequest& request, const VariableMap& variables) {
   std::set<uint32_t> ids;
   for (const TargetProjection& projection : request.target_projections()) {
-    if (projection.has_binding_variable() && projection.has_binding_const()) {
-      return absl::InvalidArgumentError(absl::StrCat(
-          "target projection ", projection.target_id(),
-          " has both binding variable and binding const"));
-    }
     ids.insert(projection.owner_variable_id());
-    if (projection.has_binding_variable()) {
+    if (projection.has_binding_variable_id()) {
       ids.insert(projection.binding_variable_id());
     }
   }

--- a/devinfra/js/debundle/solver_backends/ortools_cpsat/solver_test.cc
+++ b/devinfra/js/debundle/solver_backends/ortools_cpsat/solver_test.cc
@@ -117,16 +117,12 @@ TEST(SelectorCpSatSolverTest, InvalidProblemReportsDiagnostic) {
   EXPECT_FALSE(response.diagnostic().empty());
 }
 
-TEST(SelectorCpSatSolverTest, ConflictingBindingProjectionReportsDiagnostic) {
+TEST(SelectorCpSatSolverTest, ConstantBindingProjectionDoesNotAddVariable) {
   const cpsat::SelectorCpSatRequest request = ParseRequest(R"pb(
     variables { id: 0 values: 0 debug_name: "owner" }
-    variables { id: 1 values: 10 debug_name: "binding" }
     target_projections {
       target_id: 0
       owner_variable_id: 0
-      has_binding_variable: true
-      binding_variable_id: 1
-      has_binding_const: true
       binding_const: "minA"
     }
   )pb");
@@ -134,8 +130,12 @@ TEST(SelectorCpSatSolverTest, ConflictingBindingProjectionReportsDiagnostic) {
   const cpsat::SelectorCpSatResponse response =
       cpsat::SolveSelectorCpSat(request);
 
-  EXPECT_EQ(response.status(), cpsat::SOLVER_STATUS_INVALID);
-  EXPECT_FALSE(response.diagnostic().empty());
+  EXPECT_EQ(response.status(), cpsat::SOLVER_STATUS_SATISFIABLE);
+  EXPECT_EQ(response.assignment_coverage(),
+            cpsat::ASSIGNMENT_COVERAGE_TARGET_SUPPORT_COMPLETE);
+  ASSERT_EQ(response.assignments_size(), 1);
+  EXPECT_TRUE(RowHas(response.assignments(0), 0, 0));
+  EXPECT_EQ(response.assignments(0).values_size(), 1);
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

- replace CP-SAT `TargetProjection` binding presence booleans with a proto `oneof`
- serialize Rust backend target binding projections through the generated oneof enum
- simplify the C++ sidecar projection-variable extraction now that the wire type cannot represent both binding forms
- adjust the C++ sidecar test to cover constant binding projections without expecting a malformed both-fields diagnostic

## Why

The CP-SAT request is an internal solver wire format, so it should express the real discriminated-union shape directly: no binding projection, a binding variable, or a binding constant. Encoding that with parallel `has_*` booleans made an invalid state representable.

## Validation

- `nix develop -c pre-commit run --files devinfra/js/debundle/selector_ortools_cpsat_backend.rs devinfra/js/debundle/solver_backends/ortools_cpsat/selector_cp_sat.proto devinfra/js/debundle/solver_backends/ortools_cpsat/solver.cc devinfra/js/debundle/solver_backends/ortools_cpsat/solver_test.cc`
- `nix develop -c bbr test //devinfra/js/debundle/solver_backends/ortools_cpsat:solver_test //devinfra/js/debundle:selector_ortools_cpsat_backend_test --cache_test_results=no --test_output=errors`
- BuildBuddy: https://app.buildbuddy.io/invocation/03c321d3-bdeb-4d9b-a54c-4f565c9b52ad