### PR TITLE
haku-grocy: mirror the bearer into haku-sandbox via ESO, not rotator+reflector

### DIFF
--- a/cluster/k8s/agents/authentik-jwt-rotation/rotate.py
+++ b/cluster/k8s/agents/authentik-jwt-rotation/rotate.py
@@ -60,13 +60,6 @@ class K8sSecretOutput(BaseModel):
     namespace: str
     token_key: str = Field(default="jwt", description="stringData key for the JWT")
     exp_key: str = Field(default="token-exp", description="stringData key for the JWT exp epoch (seconds)")
-    annotations: dict[str, str] | None = Field(
-        default=None,
-        description="Extra annotations merged into the Secret's metadata.annotations — e.g. "
-        "kubernetes-reflector reflection-* keys to auto-mirror the Secret into another namespace "
-        "(haku-sandbox, for the self-hosted Haku home to read the bearer). Single-write + reflector "
-        "fan-out, rather than the rotator looping over namespaces.",
-    )
 
 
 class Rotation(BaseModel):
@@ -281,19 +274,15 @@ def rotate_one(client: httpx.Client, rotation: Rotation, config: Config) -> bool
 
 
 def build_secret_manifest(out: K8sSecretOutput, token: str, exp_epoch: int) -> dict[str, Any]:
-    """The k8s Secret manifest carrying the token + exp (pre-encryption).
-
-    `out.annotations` is merged in (e.g. kubernetes-reflector keys to auto-mirror the
-    applied Secret into another namespace — single-write + fan-out, never a
-    per-namespace loop in the rotator).
-    """
-    annotations = {"description": "Authentik JWT minted by authentik-jwt-rotation (rotated ~biweekly)."}
-    if out.annotations:
-        annotations |= out.annotations
+    """The k8s Secret manifest carrying the token + exp (pre-encryption)."""
     return {
         "apiVersion": "v1",
         "kind": "Secret",
-        "metadata": {"name": out.name, "namespace": out.namespace, "annotations": annotations},
+        "metadata": {
+            "name": out.name,
+            "namespace": out.namespace,
+            "annotations": {"description": "Authentik JWT minted by authentik-jwt-rotation (rotated ~biweekly)."},
+        },
         "type": "Opaque",
         "stringData": {out.token_key: token, out.exp_key: str(exp_epoch)},
     }

--- a/cluster/k8s/agents/authentik-jwt-rotation/rotations.yaml
+++ b/cluster/k8s/agents/authentik-jwt-rotation/rotations.yaml
@@ -56,18 +56,13 @@ rotations:
     token_field: jwt
     # Also publish the JWT (+ exp) as an in-cluster Secret so tf/gitops/haku-cloud-agent
     # can hand it to the Anthropic vault as the grocy-sf MCP bearer (read via a no-fail
-    # lookup — absent secret just disables the grocy credential). Mirrors haku-k8s.
-    # The reflector annotations also mirror it into haku-sandbox, where the self-hosted
-    # Haku home reads the bearer to call the grocy-sf MCP directly (like haku-tana-ro-token).
+    # lookup — absent secret just disables the grocy credential). Mirrors haku-k8s. ESO
+    # mirrors this Secret into haku-sandbox for the self-hosted Haku home (a standalone
+    # ClusterExternalSecret, decoupled from the rotator — see cluster/k8s/haku/agent-worker).
     k8s_secret:
       path: cluster/k8s/haku/cloud-agent-tf/haku-grocy-sf-token.sops.yaml
       name: haku-cloud-grocy-sf-token
       namespace: flux-system
-      annotations:
-        reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-        reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: haku-sandbox
-        reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-        reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: haku-sandbox
   - name: alloy-otlp
     provider_slug: alloy-otlp-client-credentials
     scopes: openid profile email

--- a/cluster/k8s/agents/authentik-jwt-rotation/test_rotate.py
+++ b/cluster/k8s/agents/authentik-jwt-rotation/test_rotate.py
@@ -127,27 +127,15 @@ def test_rotation_k8s_secret_defaults_none_and_parses():
     assert r.k8s_secret.token_key == "jwt"  # default
     assert r.k8s_secret.exp_key == "token-exp"  # default
     assert r.k8s_secret.namespace == "flux-system"
-    assert r.k8s_secret.annotations is None  # default
 
 
-def test_build_secret_manifest_carries_token_exp_and_merges_annotations():
+def test_build_secret_manifest_carries_token_exp_under_configured_keys():
     out = K8sSecretOutput(
-        path=Path("cluster/k8s/x.sops.yaml"),
-        name="haku-cloud-grocy-sf-token",
-        namespace="flux-system",
-        annotations={"reflector.v1.k8s.emberstack.com/reflection-auto-namespaces": "haku-sandbox"},
+        path=Path("cluster/k8s/x.sops.yaml"), name="haku-cloud-grocy-sf-token", namespace="flux-system"
     )
     manifest = build_secret_manifest(out, token="the-jwt", exp_epoch=1750000000)
     assert manifest["stringData"] == {"jwt": "the-jwt", "token-exp": "1750000000"}
-    annotations = manifest["metadata"]["annotations"]
-    # The rotator's own description annotation survives, the configured one is merged in.
-    assert "description" in annotations
-    assert annotations["reflector.v1.k8s.emberstack.com/reflection-auto-namespaces"] == "haku-sandbox"
-
-
-def test_build_secret_manifest_without_annotations_keeps_only_description():
-    out = K8sSecretOutput(path=Path("cluster/k8s/x.sops.yaml"), name="t", namespace="flux-system")
-    assert list(build_secret_manifest(out, token="j", exp_epoch=1)["metadata"]["annotations"]) == ["description"]
+    assert list(manifest["metadata"]["annotations"]) == ["description"]
 
 
 def test_rotation_expected_issuer_derived_from_slug():

--- a/cluster/k8s/external-secrets/config/flux-system-secret-store.yaml
+++ b/cluster/k8s/external-secrets/config/flux-system-secret-store.yaml
@@ -1,0 +1,22 @@
+# ESO Kubernetes-provider store reading Secrets from the flux-system namespace.
+# Used to mirror rotator-published tokens (authentik-jwt-rotation k8s_secret outputs)
+# into consumer namespaces without coupling distribution to the rotator. The ESO
+# ServiceAccount already has cluster-wide secret read.
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: kubernetes-flux-system-secret-store
+spec:
+  provider:
+    kubernetes:
+      server:
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          key: ca.crt
+          namespace: default
+      auth:
+        serviceAccount:
+          name: external-secrets
+          namespace: external-secrets-system
+      remoteNamespace: flux-system

--- a/cluster/k8s/external-secrets/config/kustomization.yaml
+++ b/cluster/k8s/external-secrets/config/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - external-secrets-config.yaml
   - airlock-secret-store.yaml
+  - flux-system-secret-store.yaml

--- a/cluster/k8s/haku/agent-worker/grocy-token-eso.yaml
+++ b/cluster/k8s/haku/agent-worker/grocy-token-eso.yaml
@@ -1,0 +1,25 @@
+# Mirror the rotator-published grocy-sf bearer JWT into haku-sandbox, where the
+# self-hosted Haku home reads it to call the grocy-sf MCP directly (base/sources/grocy.md).
+# Same ESO pattern the airlock OAuth tokens use to reach the sandbox namespaces
+# (agents/airlock/eso-access-tokens.yaml). Decoupled from the rotator: it sources the
+# flux-system Secret the rotator writes (k8s_secret output) and refreshes continuously,
+# so the rotated token propagates without any rotator-side distribution config.
+apiVersion: external-secrets.io/v1
+kind: ClusterExternalSecret
+metadata:
+  name: haku-grocy-sf-token
+spec:
+  namespaces:
+    - haku-sandbox
+  externalSecretSpec:
+    refreshInterval: 1m
+    secretStoreRef:
+      name: kubernetes-flux-system-secret-store
+      kind: ClusterSecretStore
+    target:
+      name: haku-cloud-grocy-sf-token
+    data:
+      - secretKey: jwt
+        remoteRef:
+          key: haku-cloud-grocy-sf-token
+          property: jwt

--- a/cluster/k8s/haku/agent-worker/kustomization.yaml
+++ b/cluster/k8s/haku/agent-worker/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - rolebinding.yaml
   - environment-key.sops.yaml
   - deployment.yaml
+  - grocy-token-eso.yaml

--- a/haku/TODO.md
+++ b/haku/TODO.md
@@ -62,7 +62,7 @@ facade** in front (the Authentik OAuth facade is auth, not tool filtering — se
 **Grocy is wired** (`base/sources/grocy.md`) — it didn't need a tool-filter facade:
 the `haku` Grocy user has empty permissions, so the Grocy API enforces read-only
 (200 reads / 403 writes) server-side. Haku reaches the grocy-sf MCP directly with a
-rotated JWT, reflected into `haku-sandbox` as `haku-cloud-grocy-sf-token`.
+rotated JWT, mirrored into `haku-sandbox` by ESO as `haku-cloud-grocy-sf-token`.
 
 ## Wiring / hardening
 

--- a/haku/base/sources/grocy.md
+++ b/haku/base/sources/grocy.md
@@ -14,10 +14,10 @@ Grocy is an MCP server at `https://grocy-mcp-sf.allegedly.works/mcp`. The transp
 mechanics — `fastmcp`, the `curl` fallback, reading the bearer into `"$TOKEN"` — are
 shared across MCP sources; see [`mcp_over_http.md`](mcp_over_http.md). Grocy specifics:
 
-- **Bearer:** the reflected `haku-cloud-grocy-sf-token` secret, key `jwt` (the same
-  rotated grocy JWT the cloud agent uses, mirrored into `haku-sandbox`). The MCP
-  validates it and runs the auth handshake into Grocy, injecting your read-only `haku`
-  user — so reads return 200 and **every write 403s** server-side.
+- **Bearer:** the `haku-cloud-grocy-sf-token` secret, key `jwt` (the same rotated grocy
+  JWT the cloud agent uses, mirrored into `haku-sandbox` by ESO). The MCP validates it
+  and runs the auth handshake into Grocy, injecting your read-only `haku` user — so
+  reads return 200 and **every write 403s** server-side.
 
 ```bash
 TOKEN=$(kubectl -n haku-sandbox get secret haku-cloud-grocy-sf-token \
@@ -44,4 +44,4 @@ items **below minimum** or absent that the operator relies on (a shopping nudge)
 **opportunistic** suggestions that combine stock with where the operator is and what
 else is going on (see `../recipes.md` → _Generate, don't just detect_). Never surface a
 suggestion to buy something already on a shopping list. If `list` is empty or a call
-401s, note the gap in your log and move on (the bearer must be the reflected one).
+401s, note the gap in your log and move on (the bearer must be the one in `haku-sandbox`).

--- a/secrets/haku-grocy-jwt.yaml
+++ b/secrets/haku-grocy-jwt.yaml
@@ -1,0 +1,69 @@
+expires_unencrypted: "2026-07-26T20:27:30Z"
+audiences_unencrypted:
+    - grocy-mcp-haku-sf
+jwt: ENC[AES256_GCM,data:lQ8QnIQvmlfM232uafUADqmFcb98AkZV9BHhEzyYMfOWfRjs70O1YKryiQBtFTocOE+2FvqBC1KEBSDYfOc0H9vrg9iYu31Bz7uj3WLXnEAXzgN65H9qxyf/9MwT10dvlzJ4+CrP4HlqUbqhq4N9zl0h+Kf3A5jms1v2C9A9dFE1U0YabBrZ15DxZxE5Oc2RlYhno1tCdoa4oXeordJJ5i3jIf/zgBF2Jefw9MTqJunhetQqQsCkUgvLzh16kKyAqlcCD5sAm9K3lYG6wkagiN9NNu6eVb6NCWhSR7gRfCBiUBqMBit77oU+ze5fTgw95edGbROenlqngTNQeO6mBYnc5CD+PsB4dXXSw3aS8hHwqcLfsK/LPHIPKDBU1xuLwALln6XMTNIKPRI6mM4sDo0Jm00NWVNJZZgAqxt2MVbKDeHnSG5n4ijM8rbZg8L4agL9NLMAbtrgDrSXK3BLsU3BPwfFpPDR6Vlqd10xUtyoVSY9A70q3MWBOjaq4Mw2HViYqI8jwdkpFz3aPYQoCV+XBN2FtgMK5ACwDQjqqc+du+42+59vstU7CDb7p7lDyf7ctL+8BIG4So0djbqkd/aqgmFeDlADZvASrXFuVXeeJ6zdfUrqrgv+WHPsQiDK/34nZ66Y6LQ1XYYCPP/Xd7fFOa+KGO1Yv4GPKT+y+dCG/0q5ARiPnhuay1iP3l0KMsPEJjlsyYjDqTSO7uATbumRX4J6GkMUURYjpYx4iywtomiWrIzDjLieRUaOaSBEB7gcSlbzyYG66qFlZwVHQ+Qx9ExFaC+75haluzpsFIY4o5guNTjFMvyXRleY0rdqKjlKpp9yBdqPjPGa7jLbLYuiNK0zPYub+8WgBJaWb0VjQTthfmoV3fSjgTPX6Of3Jry41eSeDcNK0Q0JcrlBebj4uLVKvaJgTxVeSwSSuOR4eKg8waKZy4HahN7XqhPFAIZ6jbHzOfA0HjQihBWQGS0YeSDE2K6kR5xFg5/EUe2IxNP+rOLlD2KlW5QhBcFcBuB133ZQRaoWxTG5+RHsnTTZ2oCMUrSTrqzhzFoeOapXiKz/KB0wQaya8cCZQO94DiC/NV9ocyYw+F5ba6s2QJL6sbmFlXCFWghckegDDuoyDpTKctF10S4ciHGJ/roRb4X7njB6Cir0moRLqvDyz4NYc7hOyssvKftGGKaND7Wnc7gaKAhNp10TAxPf2EFfciBZ+Al+pbvxb3xn4GyCzPUekwiFd1Z7nyszLr4bqE6SH27UqFEDKsooxItSWl53pINYUYn9AC0WNf0/6iunttDqvLjnQ7lL+LSqj0Xi3VGFUKWcjXh9kxAX35c+c4NGdTtMaojgevOeWNppiwSeOz9P4SHDRwkva/0xzJnIQ5lIY73dEN9/XdnIL/dkE5vpXhDjPXdlgp0UG/rk4iscLOpQTjnQikL/rl5IOCJOGYM6/gUhm39v68s1ZSYP3beZfsNi8iBugRDnI0A91xdYlmz8pkaITGGeCF9H3KsUQpN3doTpllzM4EiR19RiGGwSKbFX/ZPICBS9+MmmYi1YBEllpIDlQavKbOWFLw+FT5YhWr5ZsJK1jOtQSljjSA3mg9zCimFEME1NDp9hVaWUDW8a07yMofq6KmrN20hehpdUsrm2v4OJ/m5RxxPsuxBtxcK7tvyE9o28IU2h2bjnqBIk20NR9SuesTPRGBbXkCdRqlnU/oO0N4osJwjfN47CShSG7PJqSm/ZK07zSYAqVUrXf4qqf21X/+w0HT1s7vzWLdicPnL0i09TXfZW3xOTumMvnmF3u+y+D7Udq0wkjaI237b1DTPyCD1xhptNlvRbvwpPEECrcTqQgXmB1G/oSn8+LBUKXd5+p9lJEvH3xrAmoQCO3cDCQbdWfg2jl4VycFm2rFg+n7N1OxNXZEc145pFGJAwm3qGKd+wQWsyin7LWkDsL/gLsdZDccfXaoTyhhNZt9ZRCN73Kk1BAiAket8JSbX2CxgN8IxCTck84Ulz0K8mciYtJkKJo9+jAXxP/hKPjkHoGzE6tc9o+LHZstbfBnUUxp1RlFHQYRSfLliVTobOhskktoUqbKXyvNuI0pJ+c4qF1IKiWpBVmYXFcXk95CpvWI16K/nYK4U352GUUIl2nuwy3TSywByG7nnbjEAjIGrCS2n9LCbgCAvMYkw0AAuzasC2XVEnDtUfz7kpOFwF2WdXOV492fR0P4BClePunqo2TnvogA==,iv:ywN0cUlj67Zn4B4aZ0vh+98LuN1owRcUZQ4lojKLIBA=,tag:0Ang5OC/D6FRLBqAaqFP/Q==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPeGFTOW1BN3M1TGVabk5o
+            YXdqTTllRjR1SzR3WElOd3lRMFlHMG1FcG5jCndKTDBoZmxNdVdlYkpCb09DMzZL
+            b2gzVHJybnUraitOY3ArTkdFaFZXL1kKLS0tIDVudHVXc0M5S2tDSmREK3RYb25o
+            RGpoZ3ZuQnFkRytja1dSYjQ0TnlEejgKQt36BdScYOjBC4uxahkkKidxFUSY94xf
+            S6xHb8tw/L3OP4a/1opW9OMmaZQAmHyPOpSiJpxmpGeAnL67nwvFyQ==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1756xpy6yg7r8vdducm5cdn4cqt3m5qkcncxumsh8htlfdzpae4cq0c6gqf
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnSDIwV2oySi9zN2JYQnpj
+            aVcrTk9LOGc2VTZzUFVJcTRuYkhuMFRUZWw0CmRQeUdXYnplZU9BM3NTc0NCUUZK
+            R3NWbHlMU3lxUVlhMDV6aWNVc0JzQmMKLS0tIE5KMk1xdHp5QmNuaENMQlMzaGdI
+            bHFoQlFLWXc5TS9qRHNnL09QMGlaV2sKeEhhQvL2EwMYo5q/2aBeguA98Xf0CeyL
+            KBPezfLsK1R3ZeAVnRJ8gAIg70/cD8SwtR9F2vkKKUF0KRCFqcoP5w==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age12c2ef6ayydzvmz6k49pyyhtgu2g00nyynmht8y3laqvxn3wya4wselpc4s
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBKV2c5VXRVWmRVWm5xVlBY
+            a0hDa0kwNThyb1lqTGgxcTUwblB1UXFpYjBrCmV4dURtbEZjTkFnZFQxaFY2U08y
+            VDdmd3lIMzFRQ2hiaTJsUC9nSC9BVEUKLS0tIEd3ZkdOZ0RLS3hMTXRwMzlPaVR5
+            ZXIydFNSNmVWeFdQMGpRbEpndE5GakEKjI/zXqqk0TjrhL1JKSVYuyOSGTOp7ZE/
+            xYP5JVNA1QYZjKYsNalji5Tq0bKvXxVqU3764QpumkWzj1LH/LDZ8Q==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1qdgn0k59t7ghg3t4gg02g2ppnzp7uz0ddplup38y84hqslcsgsxq3v9tkz
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA4UG1QVVZNTmF5UG41d3V6
+            L3F6S3ovS3FMeFY3TzFDeHcwSGlLLzJNUFVFCk5jUTBpQzVTMXJMcHZoR3J1a01L
+            Y1JwQ3R0QUhQOUREb3NUR3RUNjhVU1UKLS0tIDA1dnlQZGh1VmF0QzJDNUxvRkl6
+            RitST3ZVcS9NUmRXU0E3a0lEelYwSTQK5L5EnCF1zT/SvfE2m9agMjAZaRVmYCPx
+            ty0yEasyWh/m7vzOsqxnEV0b9lYKU+9Wys+Ruc04/L/L9CY7IrOl7g==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age15hfg4r2zfc2zl6zarecpvykxjktw4zu3grlahz4397rstmhqpvtqjgf6yy
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlb0pLWDY0Z29GSGpXNnFU
+            cFRoT200VWhvUHdZQlpsTzE5a2JWNnlMclRBCkRtSXpsblZxSDkyTUJMSFZLblBX
+            SlY2bXc4NlUyNjFCNFhUSXNhZWVxMDAKLS0tIFEvSzhBdFpmOTlwa1pENkdoOE55
+            dUxTNnhzd0pvK0NRdjdyTXZGRnY0ZDgK4XDlE1eirNT4LMLXM3GF17qCGrDGeQpW
+            V5h5YFYgM4OSRdhc+N1nrleovulplAg0A8a5YZWE6VDjMZhpx+mNsQ==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1l325yz3v2mev3t896mzvmmkaatjc7z4d9kukvnjuslgwwd8zg9ss9pnsc7
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEWnVhWlRwV2gzN1Rya2g4
+            U1NSb2pzbExZZ1pYK0ZVK29vYzFBZXB3NEh3CmJmWlQ2NkJlR0Z5S1ZrNm0wL0pD
+            cTdNeDRLaVV6VmsvdnVwQkFhVjJQZkEKLS0tIHFwUUpXVEc2anJKSUdDNDA3eTNT
+            S2o3MkVyLzE0QnkycmVwMTNTWlU3TXcKFVGcuAAVkQm0Ff6fSKOCCvRExcNvr49D
+            sJghaMxzD6iPQ3nR4SyFw+7VJSwE/t+psntXPEMHKF+fXi8ePm789Q==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-06-26T20:27:31Z"
+    mac: ENC[AES256_GCM,data:YFGSjCBDbyXGPptumwnrO0fLr6qPZJxIK01DX/f2BtEac//sAyL9c4h75tNKZUyYEDlrttnjWNzNegnrYWlMbioLMD5Tt9MKaJZn12+lMKcJ+MGTlXBRsQf8wTHcghHJqLJ96IczAVWifbTs8aE9i/MNxcjheLgO0hMvQQzffK4=,iv:VdWi99P0fQ3zFvB5r4uWG622UAfcU6HBqHMxKLH1kMM=,tag:st+EHbaQsXxemqQ0yArYRQ==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.9.4


### PR DESCRIPTION
Replaces the reflector-on-rotator-Secret approach (#2541/#2544) with a standalone ESO **ClusterExternalSecret** — the cluster's established pattern for sandbox token delivery (`agents/airlock/eso-access-tokens.yaml` mirrors the Google/Oura tokens into the sandbox namespaces the same way).

**Why.** Putting `kubernetes-reflector` annotations *on the rotator-emitted Secret* coupled distribution to minting: the rotator only rewrites the manifest when it mints, so a distribution-config change wouldn't roll out without a forced re-mint — which is exactly what pushed toward a "re-mint-on-annotation-drift" feature in the rotator. ESO decouples it: the `ClusterExternalSecret` sources the `flux-system` Secret the rotator already writes and reconciles continuously, so the rotated token propagates and target namespaces can change freely — no rotator-side distribution state, no re-mint, no drift feature.

**Changes**
- Add `ClusterSecretStore kubernetes-flux-system-secret-store` (the ESO SA already has cluster-wide secret read — verified) + a `ClusterExternalSecret` mirroring `haku-cloud-grocy-sf-token` (key `jwt`) into `haku-sandbox`.
- Revert the rotator's generic `annotations` field and the reflector annotations on the `haku-grocy` `k8s_secret` (now unused dead config), keeping the clean `build_secret_manifest` extraction + test.
- Restore `secrets/haku-grocy-jwt.yaml` (reverts #2544) so the now-pointless forced re-mint doesn't run — the token is valid to 2026-07-26 and the `flux-system` Secret already holds it, so ESO mirrors it immediately.
- `grocy.md` / `TODO.md`: "reflected" → "mirrored by ESO".

Net: the self-hosted Haku home gets the grocy bearer in `haku-sandbox` via the same ESO mechanism as the other sandbox tokens, and the rotator goes back to just minting + writing one Secret.