### PR TITLE
haku: update tracking docs — free-form-UI foundation shipped; prune completed TODOs

### DIFF
--- a/cluster/k8s/TODO.md
+++ b/cluster/k8s/TODO.md
@@ -142,20 +142,18 @@ Options to consider:
       Python image pattern with `pygit2` and certifi/CA-certs, matching the
       other pygit2-based images, and remove the extra package cruft.
 
-## Gateway: restrict `cluster-gateway` `allowedRoutes` (no agent self-exposure)
+## Gateway: `allowedRoutes` Selector (belt-and-suspenders; deferred)
 
-The hole: `cluster/k8s/gateway/gateway.yaml` listeners are all `allowedRoutes:
-namespaces: from: All`, so an HTTPRoute in **any** namespace can attach to the public
-gateway and bypass Authentik. Not currently exploitable — `haku-sandbox-admin` /
-`claude-sandbox-admin` omit `httproutes`/`gateways` — but a latent hole the
-agent-authored Haku UI (`haku/console/plans/free_form_ui_iframe.md`) relies on staying
-closed (its UI must reach the operator only via the Authentik route).
+Agent self-exposure — an HTTPRoute in any namespace attaching to the public gateway and
+bypassing Authentik (`cluster/k8s/gateway/gateway.yaml` listeners are all `allowedRoutes:
+namespaces: from: All`) — is **already fenced**: the `restrict-agent-gateway-routes`
+Kyverno ClusterPolicy denies route/Gateway creation in the agent namespaces, and
+`haku-sandbox-admin`/`claude-sandbox-admin` omit `httproutes`/`gateways` anyway. So the
+hole the agent-authored Haku UI (`haku/console/plans/free_form_ui_iframe.md`) relies on
+staying closed is closed. What's left is the gateway-layer belt-and-suspenders:
 
-- [x] **Mitigated (Kyverno denylist).** `restrict-agent-gateway-routes` ClusterPolicy
-      denies route/Gateway creation in the agent namespaces — closes the hole without
-      touching the live gateway. This is the current fence.
-- [ ] **Still want the `allowedRoutes` Selector eventually** (belt-and-suspenders at
-      the gateway layer itself, not only via a per-namespace deny). Deferred because:
+- [ ] **Still want the `allowedRoutes` Selector eventually** (at the gateway layer
+      itself, not only via a per-namespace deny). Deferred because:
       (a) Cilium bug #42159 — per-listener `allowedRoutes` bleeds across listeners in
       this setup (see `cluster/docs/plan.md`); (b) the kube-API routes live in the
       built-in `default` namespace (and a flux-system route) with no in-repo `Namespace`

--- a/haku/PLAN.md
+++ b/haku/PLAN.md
@@ -143,12 +143,14 @@ Still to build:
   surfaces and we build the panel, adopt the `anthropic` Python SDK (it auto-sends
   `anthropic-version` — the omission that 502'd the bare-`httpx` fire — plus bearer auth,
   typed errors, retries) and migrate the launch POST onto it then.
-- **Free-form UI (1b, the destination).** Haku runs its own UI service in `haku-sandbox`
-  and the console embeds it in a cross-origin iframe, never rendering it itself; a minimal
-  `postMessage` bridge carries only capability requests + `openLink`. **North star:** even
-  the item model + UI + build move into agent-owned `haku-state`; the shell keeps only the
-  boundary. Full design, containment invariants, and implementation order:
-  <console/plans/free_form_ui_iframe.md>.
+- **Free-form UI (1b).** Foundation shipped (2026-06-26): Haku runs its own UI service in
+  `haku-sandbox` (reconciled from its `haku-state` `k8s/` under a constrained SA) and the
+  console embeds it as a sandboxed cross-origin iframe — the **Free-form UI** tab — never
+  rendering it itself. Still ahead: Haku replaces the placeholder with a real UI on its own
+  backend; the shell gains a minimal `postMessage` bridge (`requestCapability` + a top-layer
+  confirm, then `openLink`). **North star:** even the item model + UI + build move into
+  agent-owned `haku-state`; the shell keeps only the boundary. Full design, containment
+  invariants, and remaining order: <console/plans/free_form_ui_iframe.md>.
 
 ## Open questions
 

--- a/haku/console/README.md
+++ b/haku/console/README.md
@@ -63,6 +63,16 @@ so Haku evolves _what_ the dashboard shows without an image rebuild. The _look_ 
 in the bundle (a frontend rebuild changes it) — unlike the old server-rendered console,
 whose page/CSS templates could be overridden from the clone.
 
+## Free-form UI — Haku's own UI, embedded
+
+A **Free-form UI** tab embeds Haku's own UI service (`haku-ui.allegedly.works`, a separate
+Authentik-gated app Haku runs in `haku-sandbox`) as a **sandboxed cross-origin iframe** — the
+console never renders or even sees it. `HAKU_CONSOLE_HAKU_UI_URL` enables it; when set, the
+dashboard exposes the tab and the response CSP adds `frame-src` for that origin (and only it).
+Containment is cross-origin isolation: the iframe can't read the console's DOM/cookies or act
+as it — so Haku's UI can't act as the console. This is the first step of the agent-authored-UI
+direction; roadmap + boundary doctrine: `console/plans/free_form_ui_iframe.md`.
+
 ## Layout
 
 | Path               | Role                                                                                                                                                                                                                           |

--- a/haku/console/plans/free_form_ui_iframe.md
+++ b/haku/console/plans/free_form_ui_iframe.md
@@ -1,9 +1,9 @@
 # Free-form agent UI via a Haku-run iframe service
 
-Status: **design / not started.** This is the concrete shape for Phase 1b of
-`haku/PLAN.md` → _The agent-authored console_ — letting Haku author increasingly
-free-form interactive UI, without the trusted console having to render or even
-understand it.
+Status: **foundation shipped (2026-06-26); steps 1–4 remaining** — see
+_Implementation order_. This is the concrete shape for Phase 1b of `haku/PLAN.md` →
+_The agent-authored console_ — letting Haku author increasingly free-form interactive
+UI, without the trusted console having to render or even understand it.
 
 ## The shift
 
@@ -77,13 +77,13 @@ trusting the content:
      `secrets`, …) and does **not** include `httproutes`/`gateways`
      (`gateway.networking.k8s.io`), so Haku cannot attach a route to the public
      gateway. **Do not add those resources to the Role.**
-   - **Defense-in-depth (recommended, not yet done):** the `cluster-gateway`
-     listeners are `allowedRoutes: namespaces: from: All`
-     (`cluster/k8s/gateway/gateway.yaml`). That is a latent hole — if any
-     agent-writable namespace ever gained `httproutes` permission, it could
-     self-expose. Tighten `allowedRoutes.namespaces` to a label `Selector` (or an
-     explicit set) that agent namespaces never carry, so "agent can't create
-     public routes" holds structurally at the gateway layer too.
+   - **Defense-in-depth:** the `cluster-gateway` listeners are `allowedRoutes:
+namespaces: from: All` (`cluster/k8s/gateway/gateway.yaml`) — a latent hole if any
+     agent-writable namespace ever gained `httproutes` permission. **Fenced** by the
+     `restrict-agent-gateway-routes` Kyverno ClusterPolicy (denies route/Gateway
+     creation in agent namespaces). The remaining gateway-layer belt-and-suspenders —
+     tightening `allowedRoutes.namespaces` to a `Selector` agent namespaces never carry —
+     is deferred (`cluster/k8s/TODO.md`).
 
 4. **Worst case is bounded.** What a hostile iframe can do: render misleading UI,
    and read/write `haku-state` — both of which Haku can already do. It cannot
@@ -216,42 +216,37 @@ fine for a single-operator Chrome/Firefox tool.)
 
 ## Implementation order
 
-Sequenced to **de-risk the biggest unknown first** (does Authentik auth work inside
-the iframe?), deliver value incrementally, and leave the disruptive subsumption last.
-Each step is roughly PR-sized; the **owner** is who builds it.
+**Shipped — the foundation (2026-06-26).** Gateway hardening (Kyverno denylist so agents
+can't create public routes); the `haku-state` workloads Flux pipe (Haku's `k8s/` reconciled
+into `haku-sandbox` under a constrained impersonation SA, `cluster/k8s/haku/workloads/`)
+seeded from `haku/state_template/`; the Authentik-gated `haku-ui.allegedly.works` route; and
+the console's **Free-form UI** tab embedding it as a sandboxed cross-origin iframe (`frame-src`
+CSP, `sandbox="allow-scripts allow-same-origin allow-forms allow-popups"`). The de-risking
+question — _does a same-site Authentik-gated app authenticate inside the iframe?_ — is
+**answered yes**: the proxied haku-ui content is frameable; the only blocker was Authentik's
+flow page sending `X-Frame-Options: DENY`, fixed by serving
+`Content-Security-Policy: frame-ancestors 'self' https://haku.allegedly.works` on
+`auth.allegedly.works` so only the console may frame it. Cross-origin isolation holds, so
+`haku-ui ≠ haku-console` regardless of framing headers.
 
-0. **Gateway hardening** _(operator; independent, do early)._ Scope `cluster-gateway`
-   `allowedRoutes` to a selector agent namespaces don't carry, so "agent can't create
-   public routes" holds structurally before Haku runs public-facing services. Not
-   blocked by anything (`cluster/k8s/TODO.md` tracks it); land it before the route goes
-   live. Can run in parallel with step 1.
-1. **Perimeter + isolation spike** _(operator; the linchpin)._ Stand up
-   `haku-ui.allegedly.works` (Authentik-gated, same-site) → a **trivial placeholder**
-   Service/Deployment, and embed it in the console as a sandboxed iframe (CSP
-   `frame-src`, `sandbox="allow-scripts"`, no `allow="fullscreen"`). Validates the
-   redesign-forcing unknowns cheaply: **does a same-site Authentik-gated app
-   authenticate inside the iframe** (no broken cookie / login-redirect), and does
-   cross-origin isolation hold? **Go/no-go gate before step 2** — if auth-in-iframe is
-   fiddly, fall back to bridging display data from the shell.
-2. **Haku's real UI service** _(Haku)._ Haku takes over the Deployment (stock runtime +
-   `haku-state` code), reads `haku-state`, serves a real first page (re-create the item
-   list as a starting point), records operator intent to its **own** backend, reads
-   operator identity from the forward-auth headers. Coexists with the trusted list;
-   needs nothing from the shell yet.
-3. **Bridge + `requestCapability`** _(operator)._ Add the `postMessage` transport +
-   origin validation + the **top-layer modal confirm** (`<dialog>` + backdrop) in the
-   shell; wire `requestCapability("launch-routine")` (cheapest — reuses the existing
-   capability tier). Establishes the confirm pattern everything else reuses.
-4. **`openLink`** _(operator)._ Scheme hard-gate + operator-owned host whitelist +
-   off-whitelist confirm overlay; assume the one-time popup-allow. The high-value
-   affordance — it plugs agent UI into the item→handoff loop.
-5. **North star — subsume the item UI** _(last; see below)._ Once Haku's UI is at least
-   as good as the trusted list, retire the trusted renderer + item schema + trace tier
-   from ducktape, move styling/build/image-automation into `haku-state`, and shrink the
-   shell to the irreducible core. Most disruptive; only safe once 1–4 are proven.
+**Remaining**, in order (critical path 1→2→3; each ~PR-sized; **owner** is who builds it):
 
-Critical path is 1→2→3→4 (each builds on the prior); step 0 parallels step 1; treat
-step 1 as a spike with an explicit go/no-go before committing to step 2.
+1. **Haku's real UI service** _(Haku)._ Haku replaces the placeholder under its `k8s/`
+   (stock runtime + `haku-state` code), serves a real first page (re-create the item list as
+   a starting point), records operator intent to its **own** backend, reads operator identity
+   from the forward-auth headers. Coexists with the trusted list; needs nothing from the shell
+   yet.
+2. **Bridge + `requestCapability`** _(operator)._ Add the `postMessage` transport + origin
+   validation + the **top-layer modal confirm** (`<dialog>` + backdrop) in the shell; wire
+   `requestCapability("launch-routine")` (cheapest — reuses the existing capability tier).
+   Establishes the confirm pattern everything else reuses.
+3. **`openLink`** _(operator)._ Scheme hard-gate + operator-owned host whitelist +
+   off-whitelist confirm overlay; assume the one-time popup-allow. The high-value affordance —
+   it plugs agent UI into the item→handoff loop.
+4. **North star — subsume the item UI** _(last; see below)._ Once Haku's UI is at least as
+   good as the trusted list, retire the trusted renderer + item schema + trace tier from
+   ducktape, move styling/build/image-automation into `haku-state`, and shrink the shell to
+   the irreducible core. Most disruptive; only safe once 1–3 are proven.
 
 ## North star: the shell owns nothing but the boundary
 
@@ -290,13 +285,6 @@ Until then, Phase 1a's trusted item list coexists.
 
 ## Open questions
 
-- **Service contract specifics** — exact Service name/port/label, and whether the
-  operator also provides a baseline Deployment skeleton or leaves the whole
-  workload to Haku.
-- **Authentik in an iframe** — confirm the same-site SSO cookie + outpost
-  forward-auth works cleanly inside the iframe without an in-frame login redirect;
-  if not, fall back to bridging display data from the shell and keeping Haku's
-  service un-gated of operator data.
 - **Forward-auth header trust** — how Haku's backend distinguishes outpost traffic
   from direct in-cluster calls (so header identity can't be spoofed by another
   `haku-sandbox` pod).


### PR DESCRIPTION
Docs-only. The free-form-UI arc's foundation is live, so move the tracking docs from "to build" → "built; what remains", and prune what this arc completed (PLAN/plans stay forward-looking).

- **`console/plans/free_form_ui_iframe.md`** — status header → "foundation shipped (2026-06-26); steps 1–4 remaining". Implementation order drops the done steps 0–1 (replaced by a **Shipped** summary that records the resolved auth-in-iframe go/no-go — yes, via the `frame-ancestors` fix), renumbers the remaining 1–4. Containment "defense-in-depth" now notes the gateway hole is **Kyverno-fenced** (not "not yet done"). Open questions drop the resolved **Authentik in an iframe** and the settled **Service contract specifics** (the `haku-ui` Service + `state_template/` starter define it).
- **`PLAN.md`** — Free-form UI (1b) bullet: trim the shipped foundation (own UI service + iframe tab), keep the remaining (real UI on Haku's backend, the `postMessage` bridge, north star).
- **`console/README.md`** — add a **Free-form UI** section to the current contract (the shipped tab/iframe/CSP + `HAKU_CONSOLE_HAKU_UI_URL`).
- **`cluster/k8s/TODO.md`** — gateway entry: fold the completed Kyverno mitigation into prose context, keep only the still-deferred `allowedRoutes` Selector item.

Verification: `prettier`/`markdownlint`/`kubeconform` green via pre-commit.