### PR TITLE
inventree token-provisioner: distribute the token via ESO, not reflector

### DIFF
--- a/cluster/k8s/inventree/token-provisioner/job.yaml
+++ b/cluster/k8s/inventree/token-provisioner/job.yaml
@@ -1,6 +1,6 @@
 # Fetches the InvenTree admin API token and writes it to the inventree namespace.
-# Reflector mirrors the Secret to openclaw-sandbox and claude-sandbox automatically
-# via the annotation-based reflection policy.
+# An ESO ClusterExternalSecret (token-eso.yaml) mirrors the Secret to openclaw-sandbox
+# and claude-sandbox.
 # Script is baked into ghcr.io/agentydragon/token-provisioner via Bazel.
 apiVersion: batch/v1
 kind: Job

--- a/cluster/k8s/inventree/token-provisioner/kustomization.yaml
+++ b/cluster/k8s/inventree/token-provisioner/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - service-account.yaml
   - job.yaml
   - cronjob.yaml
+  - token-eso.yaml

--- a/cluster/k8s/inventree/token-provisioner/provision.py
+++ b/cluster/k8s/inventree/token-provisioner/provision.py
@@ -2,8 +2,9 @@
 
 Creates a non-privileged sandbox-agent user in InvenTree (if absent), issues
 a named API token for that user as superuser, and writes the token to a K8s
-Secret in the inventree namespace. Reflector mirrors the Secret to
-openclaw-sandbox and claude-sandbox.
+Secret in the inventree namespace. An ESO ClusterExternalSecret mirrors the
+Secret to openclaw-sandbox and claude-sandbox (token-eso.yaml) — distribution is
+decoupled from this provisioner, so it just writes one plain Secret.
 
 On subsequent runs (CronJob), checks the token expiry via the InvenTree API
 and renews it when fewer than RENEW_DAYS_BEFORE days remain: revokes the old
@@ -29,13 +30,6 @@ INVENTREE_NS = "inventree"
 SANDBOX_USERNAME = "sandbox-agent"
 TOKEN_NAME = "inventree-token-provisioner"
 RENEW_DAYS_BEFORE = 30
-
-_SECRET_ANNOTATIONS = {
-    "reflector.v1.k8s.emberstack.com/reflection-allowed": "true",
-    "reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces": "openclaw-sandbox,claude-sandbox",
-    "reflector.v1.k8s.emberstack.com/reflection-auto-enabled": "true",
-    "reflector.v1.k8s.emberstack.com/reflection-auto-namespaces": "openclaw-sandbox,claude-sandbox",
-}
 
 
 def get_or_create_sandbox_user(api: InvenTreeAPI) -> int:
@@ -119,12 +113,7 @@ def main() -> None:
         token = provision_token(api, user_pk, existing=existing_token)
         print(f"Token renewed (first 8 chars): {token[:8]}...")
         v1.patch_namespaced_secret(
-            SECRET_NAME,
-            INVENTREE_NS,
-            client.V1Secret(
-                metadata=client.V1ObjectMeta(annotations=_SECRET_ANNOTATIONS),
-                string_data={"token": token, "username": SANDBOX_USERNAME},
-            ),
+            SECRET_NAME, INVENTREE_NS, client.V1Secret(string_data={"token": token, "username": SANDBOX_USERNAME})
         )
         print(f"Secret {SECRET_NAME} updated in {INVENTREE_NS}.")
     else:
@@ -133,13 +122,13 @@ def main() -> None:
         v1.create_namespaced_secret(
             INVENTREE_NS,
             client.V1Secret(
-                metadata=client.V1ObjectMeta(name=SECRET_NAME, namespace=INVENTREE_NS, annotations=_SECRET_ANNOTATIONS),
+                metadata=client.V1ObjectMeta(name=SECRET_NAME, namespace=INVENTREE_NS),
                 string_data={"token": token, "username": SANDBOX_USERNAME},
             ),
         )
         print(f"Secret {SECRET_NAME} created in {INVENTREE_NS}.")
 
-    print("Reflector will mirror to openclaw-sandbox and claude-sandbox.")
+    print("ESO ClusterExternalSecret mirrors the Secret to openclaw-sandbox and claude-sandbox.")
 
 
 if __name__ == "__main__":

--- a/cluster/k8s/inventree/token-provisioner/service-account.yaml
+++ b/cluster/k8s/inventree/token-provisioner/service-account.yaml
@@ -5,8 +5,8 @@ metadata:
   namespace: inventree
 ---
 # Allows the provisioner Job to check for and create the inventree-api-token
-# Secret in the inventree namespace. Reflector mirrors it to openclaw-sandbox
-# and claude-sandbox.
+# Secret in the inventree namespace. An ESO ClusterExternalSecret (token-eso.yaml)
+# mirrors it to openclaw-sandbox and claude-sandbox.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/cluster/k8s/inventree/token-provisioner/token-eso.yaml
+++ b/cluster/k8s/inventree/token-provisioner/token-eso.yaml
@@ -1,0 +1,44 @@
+# Mirror the provisioner-written inventree-api-token (token + username) out of the
+# inventree namespace into the sandbox namespaces, where the agents read it. ESO
+# replaces the kubernetes-reflector annotations the provisioner used to bake onto the
+# Secret — distribution is now a standalone, continuously-reconciled resource decoupled
+# from the provisioner (same pattern as agents/airlock/eso-access-tokens.yaml). The ESO
+# ServiceAccount already has cluster-wide secret read. Lives in this (suspended) unit so
+# it activates together with InvenTree.
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: kubernetes-inventree-secret-store
+spec:
+  provider:
+    kubernetes:
+      server:
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          key: ca.crt
+          namespace: default
+      auth:
+        serviceAccount:
+          name: external-secrets
+          namespace: external-secrets-system
+      remoteNamespace: inventree
+---
+apiVersion: external-secrets.io/v1
+kind: ClusterExternalSecret
+metadata:
+  name: inventree-api-token
+spec:
+  namespaces:
+    - openclaw-sandbox
+    - claude-sandbox
+  externalSecretSpec:
+    refreshInterval: 1m
+    secretStoreRef:
+      name: kubernetes-inventree-secret-store
+      kind: ClusterSecretStore
+    target:
+      name: inventree-api-token
+    dataFrom:
+      - extract:
+          key: inventree-api-token


### PR DESCRIPTION
Same simplification as haku-grocy (#2548), applied to the InvenTree sandbox token — the remaining spot where a **controller baked reflector annotations onto the Secret it regenerates** (the coupling smell from the earlier scan).

- `provision.py`: drop the `_SECRET_ANNOTATIONS` reflector dict and stop setting it on create/patch. The provisioner now writes one plain Secret (`token` + `username`) in the `inventree` namespace; distribution is no longer its concern.
- `token-eso.yaml`: a `ClusterSecretStore` (remoteNamespace `inventree`; the ESO SA already has cluster-wide secret read) + a `ClusterExternalSecret` that `extract`s `inventree-api-token` into `openclaw-sandbox` and `claude-sandbox`, reconciling continuously. Co-located in this (suspended) unit so it activates together with InvenTree.
- Comment fixups in `job.yaml` / `service-account.yaml`.

**No live migration:** the `inventree` namespace isn't currently deployed (the flux-kustomization is suspended), so this is a pure declarative change — nothing to reconcile until InvenTree comes up.

Cluster validation + provisioner image build both pass.