### PR TITLE
haku/console: wire the postMessage bridge + openLink (free-form UI)

### DIFF
--- a/haku/console/frontend/BUILD.bazel
+++ b/haku/console/frontend/BUILD.bazel
@@ -83,9 +83,26 @@ js_library(
 )
 
 js_library(
+    name = "bridge",
+    srcs = ["bridge.ts"],
+)
+
+js_library(
+    name = "confirm_dialog",
+    srcs = ["confirm_dialog.tsx"],
+    deps = [
+        "//:node_modules/@mantine/core",
+        "//:node_modules/react",
+    ],
+)
+
+js_library(
     name = "haku_ui",
     srcs = ["haku_ui.tsx"],
     deps = [
+        ":bridge",
+        ":confirm_dialog",
+        ":toast",
         "//:node_modules/react",
     ],
 )
@@ -143,6 +160,7 @@ filegroup(
     srcs = [
         "app.tsx",
         "client.ts",
+        "confirm_dialog.tsx",
         "constants.ts",
         "feedback.tsx",
         "haku_ui.tsx",
@@ -212,6 +230,7 @@ tsc_bin.tsc_test(
     ],
     chdir = package_name(),
     data = [
+        "bridge.test.ts",
         "markdown.test.ts",
         "tsconfig.json",
         ":main_lib",
@@ -229,6 +248,18 @@ vitest_bin.vitest_test(
         "markdown.test.ts",
         "vitest.config.ts",
         ":markdown",
+        "//:node_modules",
+    ],
+)
+
+vitest_bin.vitest_test(
+    name = "bridge_test",
+    args = ["run"],
+    chdir = package_name(),
+    data = [
+        "bridge.test.ts",
+        "vitest.config.ts",
+        ":bridge",
         "//:node_modules",
     ],
 )

--- a/haku/console/frontend/bridge.test.ts
+++ b/haku/console/frontend/bridge.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { parseInbound, vetOpenLink } from "./bridge.ts";
+
+describe("parseInbound", () => {
+  it("accepts a well-formed openLink", () => {
+    expect(parseInbound({ type: "openLink", url: "https://x" })).toEqual({ type: "openLink", url: "https://x" });
+  });
+
+  it("rejects malformed / unknown payloads", () => {
+    expect(parseInbound(null)).toBeNull();
+    expect(parseInbound("nope")).toBeNull();
+    expect(parseInbound({ type: "openLink" })).toBeNull(); // missing url
+    expect(parseInbound({ type: "openLink", url: 42 })).toBeNull(); // wrong type
+    expect(parseInbound({ type: "requestCapability", id: "x" })).toBeNull(); // not wired yet
+    expect(parseInbound({ type: "evalThis", code: "x" })).toBeNull(); // unknown verb
+  });
+});
+
+describe("vetOpenLink", () => {
+  it("opens whitelisted https hosts (and their subdomains) directly", () => {
+    expect(vetOpenLink("https://claude.ai/new?q=hi").action).toBe("open");
+    expect(vetOpenLink("https://www.github.com/a/b").action).toBe("open");
+    expect(vetOpenLink("https://haku-ui.allegedly.works/x").action).toBe("open");
+  });
+
+  it("confirms off-whitelist https hosts", () => {
+    expect(vetOpenLink("https://evil.example.com/phish").action).toBe("confirm");
+    // a host that merely ends with a whitelisted label but isn't a subdomain
+    expect(vetOpenLink("https://notgithub.com").action).toBe("confirm");
+  });
+
+  it("allows mailto without a host check", () => {
+    expect(vetOpenLink("mailto:ops@allegedly.works").action).toBe("open");
+  });
+
+  it("hard-rejects non-https/mailto schemes regardless of whitelist", () => {
+    expect(vetOpenLink("javascript:alert(1)").action).toBe("reject");
+    expect(vetOpenLink("data:text/html,<script>").action).toBe("reject");
+    expect(vetOpenLink("file:///etc/passwd").action).toBe("reject");
+    expect(vetOpenLink("http://claude.ai").action).toBe("reject"); // plain http rejected even if host is whitelisted
+    expect(vetOpenLink("not a url").action).toBe("reject");
+  });
+});

--- a/haku/console/frontend/bridge.ts
+++ b/haku/console/frontend/bridge.ts
@@ -1,0 +1,53 @@
+// postMessage protocol between the trusted shell (this console) and Haku's
+// agent-authored UI iframe. The iframe may only **request**; the shell decides and
+// acts. Every inbound message is origin-checked and schema-validated.
+// See plans/free_form_ui_iframe.md → "The protocol".
+
+// Inbound (iframe → shell). Today only `openLink` is wired; `requestCapability`
+// (perform a shell-owned action like launch-routine) is the next affordance.
+export type Inbound = { type: "openLink"; url: string };
+
+// Outbound result (shell → iframe), so Haku's UI can react to the outcome.
+export type Outbound = { type: "openLinkResult"; url: string; opened: boolean; reason?: string };
+
+// Narrow an untrusted postMessage payload to a known message, or null.
+export function parseInbound(data: unknown): Inbound | null {
+  if (!data || typeof data !== "object") return null;
+  const m = data as Record<string, unknown>;
+  if (m.type === "openLink" && typeof m.url === "string") return { type: "openLink", url: m.url };
+  return null;
+}
+
+// Operator-owned trusted whitelist — it lives in the **shell** (ducktape, PR-gated),
+// deliberately NOT in haku-state, or Haku could whitelist a phishing host to skip the
+// confirm. An entry matches the host exactly or any subdomain of it.
+export const OPEN_LINK_WHITELIST = [
+  "claude.ai",
+  "github.com",
+  "allegedly.works", // the operator's own services (*.allegedly.works)
+  "mail.google.com",
+  "drive.google.com",
+  "calendar.google.com",
+  "app.tana.inc",
+];
+
+export type LinkVerdict = { action: "open" } | { action: "confirm" } | { action: "reject"; reason: string };
+
+// Scheme is a HARD gate (never behind a confirm): only `https` + `mailto` — opening
+// `javascript:`/`data:`/`blob:`/`file:` in the top context would run code in the
+// shell's origin. The host whitelist only decides warn-vs-not for `https`.
+export function vetOpenLink(rawUrl: string): LinkVerdict {
+  let u: URL;
+  try {
+    u = new URL(rawUrl);
+  } catch {
+    return { action: "reject", reason: "unparseable URL" };
+  }
+  if (u.protocol === "mailto:") return { action: "open" };
+  if (u.protocol !== "https:") {
+    return { action: "reject", reason: `scheme "${u.protocol}" not allowed (https/mailto only)` };
+  }
+  const host = u.hostname.toLowerCase();
+  const ok = OPEN_LINK_WHITELIST.some((w) => host === w || host.endsWith(`.${w}`));
+  return { action: ok ? "open" : "confirm" };
+}

--- a/haku/console/frontend/confirm_dialog.tsx
+++ b/haku/console/frontend/confirm_dialog.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useRef, useState } from "react";
+import { Button, Group, Text } from "@mantine/core";
+
+export interface ConfirmRequest {
+  title: string;
+  body?: string; // what the action does, in trusted shell copy
+  url?: string; // for openLink — the full URL shown verbatim
+  approveLabel: string;
+}
+
+// Top-layer modal confirm — the only trustworthy surface at the moment of a privileged
+// action. Rendered with the native `<dialog>.showModal()` (the browser **top layer**)
+// so the cross-origin iframe cannot draw over it, read it, or intercept its clicks; the
+// `::backdrop` dims the agent UI so "the shell is talking now" is unambiguous. The
+// approve button stays disabled for a beat so a baited click-through can't land on a
+// freshly-rendered confirm. See plans/free_form_ui_iframe.md → "The shell as a thin
+// trusted layer".
+const ARM_DELAY_MS = 400;
+
+export function ConfirmDialog({
+  request,
+  onApprove,
+  onCancel,
+}: {
+  request: ConfirmRequest | null;
+  onApprove: () => void;
+  onCancel: () => void;
+}) {
+  const ref = useRef<HTMLDialogElement>(null);
+  const [armed, setArmed] = useState(false);
+
+  useEffect(() => {
+    const d = ref.current;
+    if (!d) return;
+    if (request && !d.open) {
+      setArmed(false);
+      d.showModal();
+      const t = setTimeout(() => setArmed(true), ARM_DELAY_MS);
+      return () => clearTimeout(t);
+    }
+    if (!request && d.open) d.close();
+  }, [request]);
+
+  return (
+    <dialog
+      ref={ref}
+      onCancel={(e) => {
+        e.preventDefault(); // route Esc through our handler so the iframe gets a result
+        onCancel();
+      }}
+      className="max-w-md rounded-lg border border-slate-300 p-5 shadow-xl [&::backdrop]:bg-black/60 dark:border-slate-600 dark:bg-slate-800"
+    >
+      {request && (
+        <div className="flex flex-col gap-3">
+          <Text fw={600}>{request.title}</Text>
+          {request.body && <Text size="sm">{request.body}</Text>}
+          {request.url && (
+            <Text size="sm" className="rounded bg-slate-100 p-2 font-mono break-all dark:bg-slate-900">
+              {request.url}
+            </Text>
+          )}
+          <Group justify="flex-end" gap="sm" mt="xs">
+            <Button variant="default" size="xs" onClick={onCancel}>
+              Cancel
+            </Button>
+            <Button color="teal" size="xs" disabled={!armed} onClick={onApprove}>
+              {request.approveLabel}
+            </Button>
+          </Group>
+        </div>
+      )}
+    </dialog>
+  );
+}

--- a/haku/console/frontend/haku_ui.tsx
+++ b/haku/console/frontend/haku_ui.tsx
@@ -1,19 +1,88 @@
-// Haku's own UI service — a separate, Authentik-gated origin running in
-// haku-sandbox — embedded in a sandboxed cross-origin iframe as the "Free-form UI"
-// tab. The console never renders Haku's UI itself; it only frames this origin (the
-// backend CSP frame-src is what permits the embed). `allow-same-origin` keeps the
-// framed app on its OWN origin (a different subdomain, so NOT the console's) so its
-// Authentik session cookie works; being cross-origin, it cannot reach into the
-// parent. No `allow="fullscreen"` and no allow-top-navigation, so it stays
-// contained. See plans/free_form_ui_iframe.md.
+import { useEffect, useRef, useState } from "react";
+
+import { type Outbound, parseInbound, vetOpenLink } from "./bridge.ts";
+import { ConfirmDialog } from "./confirm_dialog.tsx";
+import { toastError } from "./toast.ts";
+
+// Haku's own UI service — a separate, Authentik-gated origin running in haku-sandbox —
+// embedded as a sandboxed cross-origin iframe (the "Free-form UI" tab). The console
+// never renders Haku's UI itself; it only frames this origin (the backend CSP frame-src
+// permits the embed) and runs the trusted **bridge**: the iframe may `openLink` via
+// postMessage, but only the shell decides and acts (origin-checked + schema-validated +
+// scheme-gated + whitelist/confirm). `allow-same-origin`/`allow-forms` are needed for
+// the framed app's own Authentik auth; **no `allow-popups`** (only the shell opens
+// links) and **no `allow="fullscreen"`**. See plans/free_form_ui_iframe.md.
+
+// window.open relayed from a postMessage handler loses user-activation, so it needs the
+// operator's one-time "allow pop-ups for this site" (the shell origin only). Returns
+// false when the browser blocked it.
+function openExternal(url: string): boolean {
+  return window.open(url, "_blank", "noopener,noreferrer") !== null;
+}
+
+const POPUP_HINT = "Allow pop-ups for this site so the console can open links.";
+
 export function HakuUiFrame({ uiUrl }: { uiUrl: string }) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [pendingUrl, setPendingUrl] = useState<string | null>(null);
+  const origin = new URL(uiUrl).origin;
+
+  function reply(msg: Outbound) {
+    iframeRef.current?.contentWindow?.postMessage(msg, origin);
+  }
+
+  function openAndReply(url: string) {
+    const opened = openExternal(url);
+    if (!opened) toastError("Pop-up blocked", POPUP_HINT);
+    reply({ type: "openLinkResult", url, opened });
+  }
+
+  useEffect(() => {
+    function onMessage(e: MessageEvent) {
+      if (e.origin !== origin) return; // only Haku's UI origin may talk to the shell
+      const msg = parseInbound(e.data);
+      if (!msg) return;
+      const verdict = vetOpenLink(msg.url);
+      if (verdict.action === "reject") {
+        toastError("Link blocked", verdict.reason);
+        reply({ type: "openLinkResult", url: msg.url, opened: false, reason: verdict.reason });
+      } else if (verdict.action === "open") {
+        openAndReply(msg.url);
+      } else {
+        setPendingUrl(msg.url); // off-whitelist → operator confirm
+      }
+    }
+    window.addEventListener("message", onMessage);
+    return () => window.removeEventListener("message", onMessage);
+  }, [origin]);
+
+  function onApprove() {
+    const url = pendingUrl;
+    setPendingUrl(null);
+    if (url) openAndReply(url);
+  }
+
+  function onCancel() {
+    const url = pendingUrl;
+    setPendingUrl(null);
+    if (url) reply({ type: "openLinkResult", url, opened: false, reason: "cancelled" });
+  }
+
   return (
-    <iframe
-      src={uiUrl}
-      title="Haku UI"
-      sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
-      className="mt-4 w-full"
-      style={{ height: "80vh", border: 0 }}
-    />
+    <>
+      <iframe
+        ref={iframeRef}
+        src={uiUrl}
+        title="Haku UI"
+        sandbox="allow-scripts allow-same-origin allow-forms"
+        className="mt-4 w-full"
+        style={{ height: "80vh", border: 0 }}
+      />
+      <ConfirmDialog
+        request={pendingUrl ? { title: "Open this link?", url: pendingUrl, approveLabel: "Open" } : null}
+        onApprove={onApprove}
+        onCancel={onCancel}
+      />
+    </>
   );
 }

--- a/haku/console/plans/free_form_ui_iframe.md
+++ b/haku/console/plans/free_form_ui_iframe.md
@@ -60,7 +60,9 @@ trusting the content:
    launch bearer is unreachable from any browser context. Use a **same-site**
    subdomain (`*.allegedly.works`) so it's _cross-origin but same-site_: isolated
    from the shell, yet the Authentik SSO cookie isn't treated as a blocked
-   third-party cookie. Pin it with `sandbox="allow-scripts"` on the `<iframe>` and
+   third-party cookie. Pin it with `sandbox="allow-scripts allow-same-origin allow-forms"`
+   on the `<iframe>` (same-origin + forms are needed for the framed app's own Authentik
+   auth; **no `allow-popups`** — only the shell opens links) and
    `frame-src https://haku-ui.allegedly.works` in the shell's CSP.
 
 2. **Haku's UI is never publicly exposed.** Its only ingress is the
@@ -221,7 +223,7 @@ can't create public routes); the `haku-state` workloads Flux pipe (Haku's `k8s/`
 into `haku-sandbox` under a constrained impersonation SA, `cluster/k8s/haku/workloads/`)
 seeded from `haku/state_template/`; the Authentik-gated `haku-ui.allegedly.works` route; and
 the console's **Free-form UI** tab embedding it as a sandboxed cross-origin iframe (`frame-src`
-CSP, `sandbox="allow-scripts allow-same-origin allow-forms allow-popups"`). The de-risking
+CSP, `sandbox="allow-scripts allow-same-origin allow-forms"`). The de-risking
 question — _does a same-site Authentik-gated app authenticate inside the iframe?_ — is
 **answered yes**: the proxied haku-ui content is frameable; the only blocker was Authentik's
 flow page sending `X-Frame-Options: DENY`, fixed by serving
@@ -229,24 +231,27 @@ flow page sending `X-Frame-Options: DENY`, fixed by serving
 `auth.allegedly.works` so only the console may frame it. Cross-origin isolation holds, so
 `haku-ui ≠ haku-console` regardless of framing headers.
 
-**Remaining**, in order (critical path 1→2→3; each ~PR-sized; **owner** is who builds it):
+Also shipped: the **`postMessage` bridge** (origin-checked transport + the top-layer
+native-`<dialog>` confirm with backdrop) and the **`openLink`** affordance — scheme hard-gate
+(`https`/`mailto` only), operator-owned host whitelist in the shell (`bridge.ts`, not
+`haku-state`), off-whitelist confirm, and `window.open(…, "noopener,noreferrer")` (assumes the
+one-time per-origin pop-up allow). The iframe sandbox dropped `allow-popups` accordingly — only
+the shell opens. `state_template/k8s/haku-ui/index.html` carries a worked `openLink` demo.
+
+**Remaining**, in order (each ~PR-sized; **owner** is who builds it):
 
 1. **Haku's real UI service** _(Haku)._ Haku replaces the placeholder under its `k8s/`
    (stock runtime + `haku-state` code), serves a real first page (re-create the item list as
    a starting point), records operator intent to its **own** backend, reads operator identity
    from the forward-auth headers. Coexists with the trusted list; needs nothing from the shell
    yet.
-2. **Bridge + `requestCapability`** _(operator)._ Add the `postMessage` transport + origin
-   validation + the **top-layer modal confirm** (`<dialog>` + backdrop) in the shell; wire
-   `requestCapability("launch-routine")` (cheapest — reuses the existing capability tier).
-   Establishes the confirm pattern everything else reuses.
-3. **`openLink`** _(operator)._ Scheme hard-gate + operator-owned host whitelist +
-   off-whitelist confirm overlay; assume the one-time popup-allow. The high-value affordance —
-   it plugs agent UI into the item→handoff loop.
-4. **North star — subsume the item UI** _(last; see below)._ Once Haku's UI is at least as
+2. **`requestCapability`** _(operator)._ The remaining bridge affordance: wire
+   `requestCapability("launch-routine")` onto the already-shipped transport + top-layer confirm
+   (reuses the existing capability tier — the request just triggers the flow already there).
+3. **North star — subsume the item UI** _(last; see below)._ Once Haku's UI is at least as
    good as the trusted list, retire the trusted renderer + item schema + trace tier from
    ducktape, move styling/build/image-automation into `haku-state`, and shrink the shell to
-   the irreducible core. Most disruptive; only safe once 1–3 are proven.
+   the irreducible core. Most disruptive; only safe once 1–2 are proven.
 
 ## North star: the shell owns nothing but the boundary
 

--- a/haku/state_template/k8s/haku-ui/index.html
+++ b/haku/state_template/k8s/haku-ui/index.html
@@ -4,14 +4,62 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>haku-ui</title>
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        margin: 2rem;
+        max-width: 48rem;
+      }
+      button {
+        margin: 0.25rem 0.25rem 0.25rem 0;
+        padding: 0.4rem 0.7rem;
+      }
+      #log {
+        margin-top: 1rem;
+        padding: 0.5rem;
+        background: #f4f4f5;
+        border-radius: 4px;
+        font-family: monospace;
+        font-size: 0.85rem;
+        white-space: pre-wrap;
+      }
+    </style>
   </head>
   <body>
     <h1>haku-ui placeholder</h1>
     <p>
       This is the starter UI service Haku runs in <code>haku-sandbox</code>. If you can read this
-      <em>authenticated</em> and <em>inside the console iframe</em>, the perimeter spike passed: a same-site
-      Authentik-gated app authenticates within the frame, and the cross-origin boundary holds.
+      <em>authenticated</em> and <em>inside the console iframe</em>, the perimeter holds: a same-site Authentik-gated
+      app authenticates within the frame, and the cross-origin boundary is intact.
     </p>
     <p>Haku replaces this page (and everything under its own <code>k8s/</code>) with its real UI.</p>
+
+    <h2><code>openLink</code> bridge demo</h2>
+    <p>
+      The trusted console exposes a <code>postMessage</code> bridge: the iframe may <em>request</em> a link be opened;
+      the shell scheme-gates it (https/mailto only), opens whitelisted hosts directly, confirms off-whitelist hosts, and
+      rejects other schemes. The iframe never opens anything itself.
+    </p>
+    <button onclick="openLink('https://github.com/agentydragon/ducktape')">Open GitHub (whitelisted → direct)</button>
+    <button onclick="openLink('https://example.com/')">Open example.com (off-whitelist → confirm)</button>
+    <button onclick="openLink('javascript:alert(1)')">Try javascript: (hard-rejected)</button>
+    <div id="log">results appear here…</div>
+
+    <script>
+      // The shell origin (the console). The bridge only accepts messages from haku-ui's
+      // origin and only replies to it; we post to the parent (the console) explicitly.
+      const SHELL_ORIGIN = "https://haku.allegedly.works";
+      function openLink(url) {
+        window.parent.postMessage({ type: "openLink", url }, SHELL_ORIGIN);
+      }
+      window.addEventListener("message", (e) => {
+        if (e.origin !== SHELL_ORIGIN) return;
+        const m = e.data;
+        if (m && m.type === "openLinkResult") {
+          const line = `openLink(${m.url}) → opened=${m.opened}${m.reason ? " (" + m.reason + ")" : ""}`;
+          document.getElementById("log").textContent = line;
+        }
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
Next step of the free-form-UI arc. The Free-form UI iframe gets a trusted **`postMessage` bridge**: the iframe may *request* a link be opened; only the shell decides and acts. Scoped to **`openLink` only** — the generic `requestCapability` is deferred.

## Shell side (operator-owned)
- **`bridge.ts`** — the protocol (`openLink` in / `openLinkResult` out), `parseInbound` schema-validation, and `vetOpenLink`: **scheme is a hard gate** (`https`/`mailto` only — `javascript:`/`data:`/`file:` rejected outright), and an **operator-owned host whitelist that lives in the shell** (not `haku-state`, or Haku could whitelist a phishing host to skip the confirm). Unit-tested in `bridge.test.ts` (scheme rejects incl. plain-http on a whitelisted host, subdomain matching, mailto, malformed payloads).
- **`confirm_dialog.tsx`** — the top-layer confirm: native `<dialog>.showModal()` + `::backdrop`, so the cross-origin iframe can't draw over it, read it, or click-jack it; the approve button is disabled for a beat (anti click-through). This is the trustworthy moment-of-decision surface the design calls for.
- **`haku_ui.tsx`** — origin-checked message listener: whitelisted → open directly; off-whitelist → confirm; bad scheme → blocked + toast. `window.open(…, "noopener,noreferrer")`; a blocked pop-up toasts the one-time "allow pop-ups" hint. **Dropped `allow-popups`** from the sandbox (only the shell opens) — keeps `allow-scripts allow-same-origin allow-forms` for the framed app's Authentik auth. No `allow="fullscreen"`.

## Contract + docs
- **`state_template/k8s/haku-ui/index.html`** — a worked `openLink` demo (whitelisted → direct, off-whitelist → confirm, `javascript:` → rejected) so Haku has a concrete contract and the operator can test live.
- **design doc** — bridge transport + `openLink` marked shipped; `requestCapability` is now the one remaining bridge affordance (reuses the shipped transport + confirm).

## Verification
`bbr test //haku/console/...` green — new `bridge_test` (vitest) + `tsc_test` typechecks the new components; pre-commit clean.

## Note on live testing
The currently-running `haku-ui` is the *old* placeholder (the seed is first-run-only, so updating `state_template` doesn't refresh the live copy). To exercise `openLink` end-to-end against the deployed console I can push the updated demo page to `haku-state` once this deploys — say the word.