### PR TITLE
haku/console: rename HakuUiFrame -> HakuUiEmbed (it's shell code, not Haku's UI)

### DIFF
--- a/haku/console/frontend/BUILD.bazel
+++ b/haku/console/frontend/BUILD.bazel
@@ -97,8 +97,8 @@ js_library(
 )
 
 js_library(
-    name = "haku_ui",
-    srcs = ["haku_ui.tsx"],
+    name = "haku_ui_embed",
+    srcs = ["haku_ui_embed.tsx"],
     deps = [
         ":bridge",
         ":confirm_dialog",
@@ -114,7 +114,7 @@ js_library(
         ":client",
         ":constants",
         ":feedback",
-        ":haku_ui",
+        ":haku_ui_embed",
         ":launch",
         ":task",
         ":toast",
@@ -163,7 +163,7 @@ filegroup(
         "confirm_dialog.tsx",
         "constants.ts",
         "feedback.tsx",
-        "haku_ui.tsx",
+        "haku_ui_embed.tsx",
         "index.html",
         "launch.tsx",
         "main.tsx",

--- a/haku/console/frontend/app.tsx
+++ b/haku/console/frontend/app.tsx
@@ -4,7 +4,7 @@ import { Anchor, Group, Loader, Tabs, Text, Title } from "@mantine/core";
 import { type DashboardResponse, type Item, clickAction, fetchDashboard, unclickAction } from "./client.ts";
 import { INTAKE_NEW, UP_NEXT } from "./constants.ts";
 import { FeedbackForm } from "./feedback.tsx";
-import { HakuUiFrame } from "./haku_ui.tsx";
+import { HakuUiEmbed } from "./haku_ui_embed.tsx";
 import { LaunchRoutineButton } from "./launch.tsx";
 import { TaskCard, clickKey } from "./task.tsx";
 import { toastError } from "./toast.ts";
@@ -148,7 +148,7 @@ export default function App() {
 
         {data.haku_ui_url && (
           <Tabs.Panel value="ui">
-            <HakuUiFrame uiUrl={data.haku_ui_url} />
+            <HakuUiEmbed uiUrl={data.haku_ui_url} />
           </Tabs.Panel>
         )}
       </Tabs>

--- a/haku/console/frontend/haku_ui_embed.tsx
+++ b/haku/console/frontend/haku_ui_embed.tsx
@@ -22,7 +22,7 @@ function openExternal(url: string): boolean {
 
 const POPUP_HINT = "Allow pop-ups for this site so the console can open links.";
 
-export function HakuUiFrame({ uiUrl }: { uiUrl: string }) {
+export function HakuUiEmbed({ uiUrl }: { uiUrl: string }) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [pendingUrl, setPendingUrl] = useState<string | null>(null);
   const origin = new URL(uiUrl).origin;


### PR DESCRIPTION
Pure rename, no behavior change. `haku_ui.tsx`/`HakuUiFrame` is the trusted **shell** component (runs in the console's `haku.allegedly.works` origin) that embeds Haku's UI iframe and runs the postMessage bridge — it is **not** Haku's UI. The old name read like it was; `HakuUiEmbed`/`haku_ui_embed.tsx` makes clear it's the embedder.

Touches: the file (`git mv`), the exported component, the BUILD `js_library` target + the `app` dep + the tailwind content src, and the `app.tsx` import/usage. `bbr test //haku/console/...` green (tsc revalidates).