### PR TITLE
forgejo: enable Forgejo Actions (in-cluster CI) — step 1 of Haku CI paving

### DIFF
--- a/cluster/k8s/forgejo/app/helmrelease.yaml
+++ b/cluster/k8s/forgejo/app/helmrelease.yaml
@@ -102,6 +102,14 @@ spec:
         queue:
           TYPE: level
 
+        # In-cluster CI (Forgejo Actions). Enables the server-side feature; a
+        # registered act_runner (cluster/k8s/haku-ci) executes workflows. Used so
+        # Haku can build its own UI image from haku-state source entirely
+        # in-cluster — haku-state may hold private operator data, so its builds must
+        # never go to BuildBuddy/RBE or any external CI. See haku/PLAN.md.
+        actions:
+          ENABLED: true
+
         metrics:
           ENABLED: true
           TOKEN: ""


### PR DESCRIPTION
**Step 1 of the "move the item UI into Haku's own CI-built service" plan** (`~/.claude/plans/nifty-wondering-toucan.md`). Reviewable + safe on its own; the runner and the rest follow as separate PRs.

## What
Enables the **server-side Forgejo Actions** feature (`gitea.config.actions.ENABLED: true`) in the Forgejo HelmRelease.

## Why
Haku will build its own UI image (React SPA + Python backend) from `haku-state` source. `haku-state` may hold **private operator data**, so its builds must stay **entirely in-cluster** — never BuildBuddy/RBE or any external CI. Forgejo (already running, already hosts the registry on SeaweedFS-S3) gives us in-cluster CI + registry.

## Scope / safety
- **No runner yet.** Enabling the feature alone is inert — workflows just queue with no runner to pick them up. So this changes nothing operationally until the next PR.
- Next PRs (separate, for review): (2) a **contained, rootless** `act_runner` in `cluster/k8s/haku-ci/` registered repo-scoped to `haku-state`; (3) registry push/pull creds; (4) the ported starter UI in `haku/state_template/`; (5) ingress netpol + the Haku directive.

## Verify after merge
Forgejo reconciles the HelmRelease upgrade cleanly; the Forgejo UI shows Actions settings and repos gain an Actions tab. (Builds won't run until the runner lands.)