### PR TITLE
haku-state tf: imagePullSecret for Haku's CI-built UI image (step 3)

### DIFF
--- a/tf/gitops/haku-state/main.tf
+++ b/tf/gitops/haku-state/main.tf
@@ -91,3 +91,30 @@ resource "kubernetes_secret" "haku_state_git_write" {
     repo_url = "http://forgejo-http.forgejo:3000/${forgejo_user.haku.login}/${forgejo_repository.state.name}.git"
   }
 }
+
+# imagePullSecret so Haku's UI Deployment (haku-sandbox) can pull the image its
+# Forgejo CI builds (git.allegedly.works/haku/ui:<sha>). The package is private
+# (haku's repo is private), so the kubelet needs auth. Pulls go over HTTPS via the
+# public host (kubelet image pulls are node-level, not subject to the pod's
+# mitmproxy egress). The CI workflow itself pushes with Forgejo Actions' built-in
+# job token — no push cred needed here. See cluster/k8s/haku-ci + haku/PLAN.md.
+resource "kubernetes_secret" "haku_forgejo_registry_pull" {
+  metadata {
+    name      = "haku-forgejo-registry-pull"
+    namespace = "haku-sandbox"
+  }
+
+  type = "kubernetes.io/dockerconfigjson"
+
+  data = {
+    ".dockerconfigjson" = jsonencode({
+      auths = {
+        "git.allegedly.works" = {
+          username = forgejo_user.haku.login
+          password = random_password.haku.result
+          auth     = base64encode("${forgejo_user.haku.login}:${random_password.haku.result}")
+        }
+      }
+    })
+  }
+}


### PR DESCRIPTION
**Step 3** of the "move the item UI into Haku's own CI-built service" plan. For review — no automerge.

Adds a `dockerconfigjson` Secret **`haku-forgejo-registry-pull`** in `haku-sandbox` so Haku's UI Deployment can pull the **private** image its Forgejo CI builds (`git.allegedly.works/haku/ui:<sha>`).

- Auth as the `haku` Forgejo user (reuses the existing `random_password.haku` — no new principal).
- Pull host is the **public HTTPS** `git.allegedly.works` (kubelet image pulls are node-level, so they're not subject to the pod's mitmproxy egress).
- **No push cred here** — the CI workflow pushes with Forgejo Actions' built-in per-job token (package-write to the repo owner's `haku/*` namespace). If that token turns out to lack package-write in practice, we add a scoped push secret in the iterate loop.

The UI Deployment (in `haku/state_template/`, separate PR building now) references this secret by name (`imagePullSecrets: [{name: haku-forgejo-registry-pull}]`).

Verify: `tflint`/`checkov` green via pre-commit. Post-merge, tofu applies the secret into `haku-sandbox`.