### PR TITLE
haku-ui: ingress NetworkPolicy → Authentik outpost only (forward-auth trust)

### DIFF
--- a/cluster/k8s/TODO.md
+++ b/cluster/k8s/TODO.md
@@ -171,10 +171,3 @@ Authentik route work; these tighten them (operator-approved as follow-ups):
       (Flux only pulls, but the cred is read/write — there's no separate read
       principal on the repo). Mint a read-only Forgejo deploy key for `haku-state`
       and point the GitRepository's `secretRef` at it instead.
-- [ ] **Ingress NetworkPolicy restricting `haku-ui` to the Authentik outpost.**
-      `haku-sandbox` has default-allow ingress (the mitmproxy fence is egress-only),
-      so any in-cluster pod can reach `svc/haku-ui` directly — external access is
-      still gateway→Authentik only, so this is defense-in-depth, not a perimeter
-      hole. Add a CiliumNetworkPolicy selecting `app: haku-ui` that admits ingress
-      only from the `authentik` server pods (same gap the README tracks for
-      `agents-mitmproxy`/`proxmox`).

--- a/cluster/k8s/haku/namespace/kustomization.yaml
+++ b/cluster/k8s/haku/namespace/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yaml
+  - networkpolicy.yaml

--- a/cluster/k8s/haku/namespace/networkpolicy.yaml
+++ b/cluster/k8s/haku/namespace/networkpolicy.yaml
@@ -1,0 +1,30 @@
+# Restrict ingress to Haku's UI service to the Authentik proxy outpost only.
+#
+# haku-sandbox has default-allow ingress (the mitmproxy fence is egress-only), so
+# without this any in-cluster pod could reach svc/haku-ui directly. Haku's UI backend
+# trusts the `X-authentik-username` forward-auth header to identify the operator — so a
+# direct in-cluster call could forge operator intent (clicks/feedback). Admitting
+# ingress to `haku-ui` ONLY from the authentik-server pods (which run the embedded
+# outpost) makes those headers trustworthy. External access is gateway→Authentik either
+# way; this is the in-cluster defense-in-depth the design doc + cluster TODO flagged.
+#
+# Operator-owned (Haku has no route/netpol RBAC), and it selects the `app: haku-ui`
+# label the starter Deployment uses (haku/state_template/k8s/haku-ui).
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: haku-ui-ingress-authentik-only
+  namespace: haku-sandbox
+spec:
+  endpointSelector:
+    matchLabels:
+      app: haku-ui
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: authentik
+            app.kubernetes.io/name: authentik
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP


### PR DESCRIPTION
Hardening step for Haku's full read+write UI (and closes the deferred `cluster/k8s/TODO.md` follow-up). For review — no automerge.

## Why
Haku's UI backend will read the **`X-authentik-username`** forward-auth header to identify the operator (for writing clicks/feedback). But `haku-sandbox` has **default-allow ingress** (the mitmproxy fence is egress-only), so any in-cluster pod could hit `svc/haku-ui` directly and **forge** that header → forge operator intent.

## What
A `CiliumNetworkPolicy` in `haku-sandbox` selecting `app: haku-ui` that admits ingress **only from the authentik-server pods** (the embedded outpost). That makes the forward-auth headers trustworthy. External access is gateway→Authentik either way; this is the in-cluster defense-in-depth. Operator-owned (in the haku namespace dir; Haku has no netpol RBAC). Removes the now-addressed item from `cluster/k8s/TODO.md`.

## Notes
- Selects the `app: haku-ui` label the starter Deployment uses (`haku/state_template/k8s/haku-ui`) — soft contract; if Haku relabels its pods the policy fails open (back to default-allow), which is why it's defense-in-depth.
- kubelet health probes (host→pod) are allowed by Cilium independent of pod policy, so readiness/liveness still work; if not, add a `fromEntities: [host]` rule in the iterate loop.

Verify: kubeconform + cluster-validate green.