### PR TITLE
debundle: use protobuf CP-SAT sidecar transport

### DIFF
--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -852,7 +852,6 @@ rust_library(
         ":selector_diagnostics",
         ":selector_ir",
         ":selector_ir_lowering",
-        ":selector_ir_solver",
         ":selector_ortools_cpsat_backend",
         ":selector_solve",
         ":source_match",
@@ -1112,8 +1111,12 @@ rust_test(
     edition = "2024",
     deps = [
         ":analysis",
+        ":chunk_facts",
+        ":js_ast",
         ":selector_constraint_model",
         ":selector_ir",
+        ":selector_ir_lowering",
+        ":spec",
     ],
 )
 
@@ -1151,6 +1154,7 @@ rust_library(
         ":selector_constraint_backend",
         ":selector_constraint_model",
         "//devinfra/js/debundle/solver_backends/ortools_cpsat:selector_cp_sat_rust_proto",
+        "@crates//:serde_json",
         "@rules_rust_prost//private/3rdparty/crates:prost",
     ],
 )
@@ -1168,8 +1172,12 @@ rust_test(
     },
     deps = [
         ":analysis",
+        ":chunk_facts",
+        ":js_ast",
         ":selector_backend_solver",
         ":selector_ir",
+        ":selector_ir_lowering",
+        ":spec",
     ],
 )
 
@@ -1234,10 +1242,19 @@ label_flag(
     visibility = ["//visibility:public"],
 )
 
+label_flag(
+    name = "ortools_cpsat_solver",
+    build_setting_default = "//devinfra/js/debundle/solver_backends/ortools_cpsat:selector_cpsat_solver",
+    visibility = ["//visibility:public"],
+)
+
 rust_binary(
     name = "debundle",
     srcs = ["main.rs"],
     crate_root = "main.rs",
+    data = [
+        "//devinfra/js/debundle/solver_backends/ortools_cpsat:selector_cpsat_solver",
+    ],
     edition = "2024",
     deps = [
         ":cli",

--- a/devinfra/js/debundle/README.md
+++ b/devinfra/js/debundle/README.md
@@ -95,6 +95,29 @@ bazel build //path/to:debundle \
   --@ducktape//devinfra/js/debundle:debundler=@my_debundle_bin//file
 ```
 
+The rule declares `@ducktape//devinfra/js/debundle:ortools_cpsat_solver` as an
+action tool and passes its execroot path to the debundler. The materializer uses
+that OR-Tools CP-SAT sidecar for global selector assignment. Consumers can
+override the solver tool with the matching label flag when needed.
+
+Pipeline outputs include `debug/selector_cpsat_request.pb`, the exact protobuf
+payload sent to the OR-Tools CP-SAT sidecar, plus
+`debug/selector_cpsat_summary.json` with compact counts for variables, finite
+domains, allowed tables, binary constraints, and global `all_different`
+constraints. The Rust debundler and C++ sidecar communicate through the binary
+protobuf request/response; JSON here is only human-readable metadata.
+
+For slow solver investigations, build the problem output group without running
+the CP-SAT search:
+
+```sh
+bazel build //path/to:debundle --output_groups=selector_problem
+```
+
+This emits `bazel-bin/path/to/debundle.selector_cpsat_request.pb` and
+`bazel-bin/path/to/debundle.selector_cpsat_summary.json` after the same selector
+lowering step the full pipeline uses.
+
 ## Profiling Actions
 
 For recurring performance work, prefer `debundle_pipeline_with_profiles`.

--- a/devinfra/js/debundle/lowering/materialize/plan_builder.rs
+++ b/devinfra/js/debundle/lowering/materialize/plan_builder.rs
@@ -57,58 +57,43 @@ use selector_ir::{
 use selector_ir_lowering::{MemberSelectorLoweringContext, MemberSelectorProgramBuilder};
 use selector_ortools_cpsat_backend::OrToolsCpSatBackend;
 
-const SELECTOR_BACKEND_ENV: &str = "DUCKTAPE_DEBUNDLE_SELECTOR_BACKEND";
 const ORTOOLS_CPSAT_SOLVER_ENV: &str = "DUCKTAPE_DEBUNDLE_ORTOOLS_CPSAT_SOLVER";
+const ORTOOLS_CPSAT_SOLVER_RUNFILE: &str =
+    "_main/devinfra/js/debundle/solver_backends/ortools_cpsat/selector_cpsat_solver";
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum GlobalSelectorBackendChoice {
-    Ascent,
-    OrToolsCpSat { solver_path: PathBuf },
+fn ortools_cpsat_solver_from_env() -> Result<PathBuf> {
+    if let Ok(solver_path) = std::env::var(ORTOOLS_CPSAT_SOLVER_ENV) {
+        return parse_ortools_cpsat_solver_path(Some(&solver_path));
+    }
+    if let Some(solver_path) = ortools_cpsat_solver_from_runfiles() {
+        return Ok(solver_path);
+    }
+    bail!("{ORTOOLS_CPSAT_SOLVER_ENV} must point at selector_cpsat_solver")
 }
 
-fn global_selector_backend_from_env() -> Result<GlobalSelectorBackendChoice> {
-    let backend = std::env::var(SELECTOR_BACKEND_ENV).ok();
-    let solver_path = std::env::var(ORTOOLS_CPSAT_SOLVER_ENV).ok();
-    parse_global_selector_backend(backend.as_deref(), solver_path.as_deref())
+fn parse_ortools_cpsat_solver_path(solver_path: Option<&str>) -> Result<PathBuf> {
+    let solver_path = solver_path
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+        .with_context(|| {
+            format!("{ORTOOLS_CPSAT_SOLVER_ENV} must point at selector_cpsat_solver")
+        })?;
+    Ok(PathBuf::from(solver_path))
 }
 
-fn parse_global_selector_backend(
-    backend: Option<&str>,
-    solver_path: Option<&str>,
-) -> Result<GlobalSelectorBackendChoice> {
-    let backend = backend.unwrap_or_default().trim();
-    if backend.is_empty() || backend.eq_ignore_ascii_case("ascent") {
-        return Ok(GlobalSelectorBackendChoice::Ascent);
-    }
-    if matches!(
-        backend.to_ascii_lowercase().as_str(),
-        "ortools-cpsat" | "ortools_cpsat" | "cp-sat" | "cpsat"
-    ) {
-        let solver_path = solver_path
-            .map(str::trim)
-            .filter(|path| !path.is_empty())
-            .with_context(|| {
-                format!("{SELECTOR_BACKEND_ENV}=ortools-cpsat requires {ORTOOLS_CPSAT_SOLVER_ENV}")
-            })?;
-        return Ok(GlobalSelectorBackendChoice::OrToolsCpSat {
-            solver_path: PathBuf::from(solver_path),
-        });
-    }
-    bail!("unknown {SELECTOR_BACKEND_ENV} value {backend:?}; expected `ascent` or `ortools-cpsat`")
+fn ortools_cpsat_solver_from_runfiles() -> Option<PathBuf> {
+    let runfiles_dir = std::env::var_os("RUNFILES_DIR").map(PathBuf::from)?;
+    let path = runfiles_dir.join(ORTOOLS_CPSAT_SOLVER_RUNFILE);
+    path.exists().then_some(path)
 }
 
 fn solve_global_selector_program(
     program: &selector_ir::SelectorProgram,
     facts: &SelectorFactStore,
 ) -> Result<SolverResult> {
-    match global_selector_backend_from_env()? {
-        GlobalSelectorBackendChoice::Ascent => Ok(selector_ir_solver::solve(program, facts)?),
-        GlobalSelectorBackendChoice::OrToolsCpSat { solver_path } => {
-            let backend = OrToolsCpSatBackend::new(solver_path);
-            selector_backend_solver::solve_with_backend(program, facts, &backend)
-                .context("global selector CP-SAT backend failed")
-        }
-    }
+    let backend = OrToolsCpSatBackend::new(ortools_cpsat_solver_from_env()?);
+    selector_backend_solver::solve_with_backend(program, facts, &backend)
+        .context("global selector CP-SAT backend failed")
 }
 
 impl From<&DuplicateClaimSite> for DuplicateClaimSiteReport {
@@ -2822,53 +2807,29 @@ mod tests {
     use super::*;
 
     #[test]
-    fn selector_backend_choice_defaults_to_ascent() {
+    fn ortools_cpsat_solver_path_accepts_non_empty_path() {
         assert_eq!(
-            parse_global_selector_backend(None, None).unwrap(),
-            GlobalSelectorBackendChoice::Ascent
-        );
-        assert_eq!(
-            parse_global_selector_backend(Some(""), None).unwrap(),
-            GlobalSelectorBackendChoice::Ascent
-        );
-        assert_eq!(
-            parse_global_selector_backend(Some("ascent"), None).unwrap(),
-            GlobalSelectorBackendChoice::Ascent
+            parse_ortools_cpsat_solver_path(Some(" /tmp/solver ")).unwrap(),
+            PathBuf::from("/tmp/solver")
         );
     }
 
     #[test]
-    fn selector_backend_choice_accepts_ortools_cpsat_aliases() {
-        for backend in ["ortools-cpsat", "ortools_cpsat", "cp-sat", "cpsat"] {
-            assert_eq!(
-                parse_global_selector_backend(Some(backend), Some(" /tmp/solver ")).unwrap(),
-                GlobalSelectorBackendChoice::OrToolsCpSat {
-                    solver_path: PathBuf::from("/tmp/solver")
-                }
-            );
-        }
-    }
-
-    #[test]
-    fn selector_backend_choice_requires_sidecar_path() {
-        let error = parse_global_selector_backend(Some("ortools-cpsat"), None)
-            .expect_err("missing sidecar path should fail");
+    fn ortools_cpsat_solver_path_requires_sidecar_path() {
+        let error =
+            parse_ortools_cpsat_solver_path(None).expect_err("missing sidecar path should fail");
         assert!(
             error
                 .to_string()
                 .contains("DUCKTAPE_DEBUNDLE_ORTOOLS_CPSAT_SOLVER"),
             "{error}"
         );
-    }
-
-    #[test]
-    fn selector_backend_choice_rejects_unknown_backend() {
-        let error = parse_global_selector_backend(Some("manual-csp"), None)
-            .expect_err("unknown backend should fail");
+        let error =
+            parse_ortools_cpsat_solver_path(Some(" ")).expect_err("empty sidecar path should fail");
         assert!(
             error
                 .to_string()
-                .contains("unknown DUCKTAPE_DEBUNDLE_SELECTOR_BACKEND"),
+                .contains("DUCKTAPE_DEBUNDLE_ORTOOLS_CPSAT_SOLVER"),
             "{error}"
         );
     }

--- a/devinfra/js/debundle/pipeline.bzl
+++ b/devinfra/js/debundle/pipeline.bzl
@@ -12,14 +12,28 @@ load("@bazel_skylib//lib:shell.bzl", "shell")
 
 def _debundle_pipeline_impl(ctx):
     out_dir = ctx.actions.declare_directory(ctx.label.name + ".out")
+    selector_request_proto = ctx.actions.declare_file(ctx.label.name + ".selector_cpsat_request.pb")
+    selector_summary_json = ctx.actions.declare_file(ctx.label.name + ".selector_cpsat_summary.json")
+    selector_problem_scratch = ctx.actions.declare_directory(ctx.label.name + ".selector_problem.out")
     bin_dir = ctx.bin_dir.path
     plan = _debundle_pipeline_plan(ctx, out_dir.short_path)
+    selector_problem_plan = _debundle_pipeline_plan(ctx, selector_problem_scratch.short_path)
+    tools = [
+        ctx.executable.debundler,
+        ctx.executable.ortools_cpsat_solver,
+    ]
+    exec_env = _selector_solver_env(
+        ctx,
+        _shell_execroot_path(paths.join(out_dir.path, "debug/selector_cpsat_request.pb")),
+        _shell_execroot_path(paths.join(out_dir.path, "debug/selector_cpsat_summary.json")),
+    )
 
     ctx.actions.run_shell(
         inputs = plan.inputs,
-        tools = [ctx.executable.debundler],
+        tools = tools,
         outputs = [out_dir],
-        command = "cd \"${{BAZEL_BINDIR}}\" && exec {command}".format(
+        command = "cd \"${{BAZEL_BINDIR}}\" && {exec_env}exec {command}".format(
+            exec_env = exec_env,
             command = plan.command,
         ),
         env = {"BAZEL_BINDIR": bin_dir},
@@ -35,7 +49,73 @@ def _debundle_pipeline_impl(ctx):
         mnemonic = "DebundlePipeline",
     )
 
-    return [DefaultInfo(files = depset([out_dir]))]
+    selector_problem_env = _selector_solver_env(
+        ctx,
+        _shell_execroot_path(selector_request_proto.path),
+        _shell_execroot_path(selector_summary_json.path),
+        dump_only = True,
+    )
+    selector_request_proto_path = _shell_execroot_path(selector_request_proto.path)
+    selector_summary_json_path = _shell_execroot_path(selector_summary_json.path)
+    selector_problem_scratch_path = _shell_execroot_path(selector_problem_scratch.path)
+    selector_problem_log_path = _shell_execroot_path(paths.join(selector_problem_scratch.path, "selector_problem.log"))
+    ctx.actions.run_shell(
+        inputs = selector_problem_plan.inputs,
+        tools = tools,
+        outputs = [selector_request_proto, selector_summary_json, selector_problem_scratch],
+        command = """
+cd "${{BAZEL_BINDIR}}"
+mkdir -p {selector_problem_scratch}
+({exec_env}{command}) > {log} 2>&1 || true
+if test -s {request_proto} && test -s {summary_json}; then
+  exit 0
+fi
+cat {log} >&2
+if ! test -s {request_proto}; then
+  echo "selector CP-SAT request protobuf was not written: {request_proto}" >&2
+fi
+if ! test -s {summary_json}; then
+  echo "selector CP-SAT summary JSON was not written: {summary_json}" >&2
+fi
+exit 1
+""".format(
+            exec_env = selector_problem_env,
+            command = selector_problem_plan.command,
+            log = selector_problem_log_path,
+            request_proto = selector_request_proto_path,
+            summary_json = selector_summary_json_path,
+            selector_problem_scratch = selector_problem_scratch_path,
+        ),
+        env = {"BAZEL_BINDIR": bin_dir},
+        execution_requirements = {"no-sandbox": "1"},
+        progress_message = "Dumping selector CP-SAT request for %{label}",
+        mnemonic = "DebundleSelectorProblem",
+    )
+
+    return [
+        DefaultInfo(files = depset([out_dir])),
+        OutputGroupInfo(selector_problem = depset([selector_request_proto, selector_summary_json])),
+    ]
+
+def _selector_solver_env(ctx, request_proto_path, summary_json_path, dump_only = False):
+    exec_env = "{}={} ".format(
+        "DUCKTAPE_DEBUNDLE_ORTOOLS_CPSAT_SOLVER",
+        _shell_execroot_path(ctx.executable.ortools_cpsat_solver.path),
+    )
+    exec_env += "{}={} ".format(
+        "DUCKTAPE_DEBUNDLE_ORTOOLS_CPSAT_REQUEST_PROTO",
+        request_proto_path,
+    )
+    exec_env += "{}={} ".format(
+        "DUCKTAPE_DEBUNDLE_ORTOOLS_CPSAT_SUMMARY_JSON",
+        summary_json_path,
+    )
+    if dump_only:
+        exec_env += "{}={} ".format(
+            "DUCKTAPE_DEBUNDLE_ORTOOLS_CPSAT_DUMP_ONLY",
+            shell.quote("1"),
+        )
+    return exec_env
 
 def _debundle_pipeline_plan(ctx, out_root):
     bin_dir = ctx.bin_dir.path
@@ -109,7 +189,11 @@ def _shell_source_path(workspace_relative):
     """
     if workspace_relative.startswith("/"):
         return shell.quote(workspace_relative)
-    return "\"${{OLDPWD}}/{}\"".format(workspace_relative)
+    return _shell_execroot_path(workspace_relative)
+
+def _shell_execroot_path(execroot_relative):
+    """Shell expression referencing an execroot-relative path."""
+    return "\"${{OLDPWD}}/{}\"".format(execroot_relative)
 
 _DEBUNDLE_PIPELINE_ATTRS = {
     "spec": attr.label(
@@ -134,6 +218,12 @@ _DEBUNDLE_PIPELINE_ATTRS = {
         cfg = "exec",
         default = Label("//devinfra/js/debundle:debundler"),
         doc = "Debundler binary; must support `run` with flat transform spec or tree-shaped spec args.",
+    ),
+    "ortools_cpsat_solver": attr.label(
+        executable = True,
+        cfg = "exec",
+        default = Label("//devinfra/js/debundle:ortools_cpsat_solver"),
+        doc = "OR-Tools CP-SAT selector solver used for global selector assignment.",
     ),
     "input_data": attr.label_list(
         allow_files = True,

--- a/devinfra/js/debundle/selector_constraint_model_builder.rs
+++ b/devinfra/js/debundle/selector_constraint_model_builder.rs
@@ -1112,7 +1112,9 @@ impl LoweredChildListPattern {
             for child in segment {
                 lowered_segment.push(lower_node_term(child, variables)?);
             }
-            segments.push(lowered_segment);
+            if !lowered_segment.is_empty() {
+                segments.push(lowered_segment);
+            }
         }
         Ok(Self {
             parent,
@@ -1121,19 +1123,6 @@ impl LoweredChildListPattern {
             anchored_left: terms.anchored_left,
             anchored_right: terms.anchored_right,
         })
-    }
-
-    fn variables(&self) -> Vec<ConstraintVariableId> {
-        let mut variables = Vec::new();
-        let mut seen = BTreeSet::new();
-        for term in std::iter::once(self.parent).chain(self.segments.iter().flatten().copied()) {
-            if let LoweredNodeTerm::Var(variable) = term
-                && seen.insert(variable)
-            {
-                variables.push(variable);
-            }
-        }
-        variables
     }
 }
 
@@ -1149,7 +1138,25 @@ fn add_ast_child_list_pattern_allowed_tuples(
         return Ok(());
     }
 
-    let constraint_variables = pattern.variables();
+    for segment_index in 0..pattern.segments.len() {
+        add_child_list_segment_constraint(model, &pattern, segment_index, domains)?;
+    }
+    for segment_index in 1..pattern.segments.len() {
+        add_child_list_segment_order_constraint(model, &pattern, segment_index, domains)?;
+    }
+    Ok(())
+}
+
+fn add_child_list_segment_constraint(
+    model: &mut SelectorConstraintModel,
+    pattern: &LoweredChildListPattern,
+    segment_index: usize,
+    domains: &FactDomains,
+) -> Result<(), SelectorConstraintModelBuildError> {
+    let segment = &pattern.segments[segment_index];
+    let constraint_variables = child_list_constraint_variables(
+        std::iter::once(pattern.parent).chain(segment.iter().copied()),
+    );
     let mut tuples = BTreeSet::new();
     let mut constant_only_match = false;
 
@@ -1159,19 +1166,42 @@ fn add_ast_child_list_pattern_allowed_tuples(
             candidate_parent,
             pattern.start_index,
         );
-
-        let mut current = Vec::new();
-        if !bind_node_term(pattern.parent, candidate_parent, &mut current) {
+        let Some(latest_start) = subject_children.len().checked_sub(segment.len()) else {
+            continue;
+        };
+        let mut lo = 0;
+        let mut hi = latest_start;
+        if segment_index == 0 && pattern.anchored_left {
+            hi = 0;
+        }
+        if segment_index == pattern.segments.len() - 1 && pattern.anchored_right {
+            lo = latest_start;
+        }
+        if lo > hi {
             continue;
         }
-        ChildListTupleCollector {
-            pattern: &pattern,
-            subject_children: &subject_children,
-            constraint_variables: &constraint_variables,
-            tuples: &mut tuples,
-            constant_only_match: &mut constant_only_match,
+
+        for start in lo..=hi {
+            let mut current = Vec::new();
+            if !bind_node_term(pattern.parent, candidate_parent, &mut current) {
+                continue;
+            }
+            let mut segment_matches = true;
+            for (offset, term) in segment.iter().enumerate() {
+                if !bind_node_term(*term, subject_children[start + offset], &mut current) {
+                    segment_matches = false;
+                    break;
+                }
+            }
+            if segment_matches {
+                finish_child_list_tuple(
+                    &constraint_variables,
+                    &current,
+                    &mut tuples,
+                    &mut constant_only_match,
+                );
+            }
         }
-        .collect(0, 0, &mut current);
     }
 
     if constraint_variables.is_empty() {
@@ -1183,6 +1213,77 @@ fn add_ast_child_list_pattern_allowed_tuples(
     }
 
     add_allowed_tuple_set(model, constraint_variables, tuples)
+}
+
+fn add_child_list_segment_order_constraint(
+    model: &mut SelectorConstraintModel,
+    pattern: &LoweredChildListPattern,
+    segment_index: usize,
+    domains: &FactDomains,
+) -> Result<(), SelectorConstraintModelBuildError> {
+    let previous = &pattern.segments[segment_index - 1];
+    let current = &pattern.segments[segment_index];
+    let previous_last = *previous
+        .last()
+        .expect("child-list pattern segments are filtered to be non-empty");
+    let current_first = *current
+        .first()
+        .expect("child-list pattern segments are filtered to be non-empty");
+    let constraint_variables =
+        child_list_constraint_variables([pattern.parent, previous_last, current_first]);
+    let mut tuples = BTreeSet::new();
+    let mut constant_only_match = false;
+
+    for candidate_parent in child_list_candidate_parents(pattern.parent, &domains.ast_children) {
+        let subject_children = child_list_subject_children(
+            &domains.ast_children,
+            candidate_parent,
+            pattern.start_index,
+        );
+        for (left_index, left_child) in subject_children.iter().enumerate() {
+            for right_child in subject_children.iter().skip(left_index + 1) {
+                let mut current = Vec::new();
+                if !bind_node_term(pattern.parent, candidate_parent, &mut current)
+                    || !bind_node_term(previous_last, *left_child, &mut current)
+                    || !bind_node_term(current_first, *right_child, &mut current)
+                {
+                    continue;
+                }
+                finish_child_list_tuple(
+                    &constraint_variables,
+                    &current,
+                    &mut tuples,
+                    &mut constant_only_match,
+                );
+            }
+        }
+    }
+
+    if constraint_variables.is_empty() {
+        return constant_only_match.then_some(()).ok_or_else(|| {
+            SelectorConstraintModelBuildError::ConstantOnlyAtomUnsatisfied {
+                atom: "ast_child_list_pattern".to_string(),
+            }
+        });
+    }
+
+    add_allowed_tuple_set(model, constraint_variables, tuples)
+}
+
+fn child_list_constraint_variables<I>(terms: I) -> Vec<ConstraintVariableId>
+where
+    I: IntoIterator<Item = LoweredNodeTerm>,
+{
+    let mut variables = Vec::new();
+    let mut seen = BTreeSet::new();
+    for term in terms {
+        if let LoweredNodeTerm::Var(variable) = term
+            && seen.insert(variable)
+        {
+            variables.push(variable);
+        }
+    }
+    variables
 }
 
 fn lower_node_term(
@@ -1223,81 +1324,6 @@ fn child_list_subject_children(
         .collect()
 }
 
-struct ChildListTupleCollector<'a> {
-    pattern: &'a LoweredChildListPattern,
-    subject_children: &'a [NodeId],
-    constraint_variables: &'a [ConstraintVariableId],
-    tuples: &'a mut BTreeSet<Vec<ConstraintValue>>,
-    constant_only_match: &'a mut bool,
-}
-
-impl ChildListTupleCollector<'_> {
-    fn collect(
-        &mut self,
-        segment_index: usize,
-        candidate_min: usize,
-        current: &mut Vec<(ConstraintVariableId, ConstraintValue)>,
-    ) {
-        let Some(segment) = self.pattern.segments.get(segment_index) else {
-            self.finish_row(current);
-            return;
-        };
-
-        let remaining: usize = self.pattern.segments[segment_index..]
-            .iter()
-            .map(Vec::len)
-            .sum();
-        let Some(latest_start) = self.subject_children.len().checked_sub(remaining) else {
-            return;
-        };
-        let mut lo = candidate_min;
-        let mut hi = latest_start;
-        if segment_index == 0 && self.pattern.anchored_left {
-            hi = hi.min(0);
-        }
-        if segment_index == self.pattern.segments.len() - 1 && self.pattern.anchored_right {
-            lo = lo.max(latest_start);
-        }
-        if lo > hi {
-            return;
-        }
-
-        for start in lo..=hi {
-            let current_len = current.len();
-            let mut segment_matches = true;
-            for (offset, term) in segment.iter().enumerate() {
-                if !bind_node_term(*term, self.subject_children[start + offset], current) {
-                    segment_matches = false;
-                    break;
-                }
-            }
-            if segment_matches {
-                self.collect(segment_index + 1, start + segment.len(), current);
-            }
-            current.truncate(current_len);
-        }
-    }
-
-    fn finish_row(&mut self, current: &[(ConstraintVariableId, ConstraintValue)]) {
-        let Some(merged) = merge_node_assignment_bindings(current.to_vec()) else {
-            return;
-        };
-        if self.constraint_variables.is_empty() {
-            *self.constant_only_match = true;
-            return;
-        }
-        let assignments = merged.into_iter().collect::<BTreeMap<_, _>>();
-        if let Some(tuple) = self
-            .constraint_variables
-            .iter()
-            .map(|variable| assignments.get(variable).cloned())
-            .collect::<Option<Vec<_>>>()
-        {
-            self.tuples.insert(tuple);
-        }
-    }
-}
-
 fn bind_node_term(
     term: LoweredNodeTerm,
     actual: NodeId,
@@ -1309,6 +1335,29 @@ fn bind_node_term(
             true
         }
         LoweredNodeTerm::Const(expected) => expected == actual,
+    }
+}
+
+fn finish_child_list_tuple(
+    constraint_variables: &[ConstraintVariableId],
+    current: &[(ConstraintVariableId, ConstraintValue)],
+    tuples: &mut BTreeSet<Vec<ConstraintValue>>,
+    constant_only_match: &mut bool,
+) {
+    let Some(merged) = merge_node_assignment_bindings(current.to_vec()) else {
+        return;
+    };
+    if constraint_variables.is_empty() {
+        *constant_only_match = true;
+        return;
+    }
+    let assignments = merged.into_iter().collect::<BTreeMap<_, _>>();
+    if let Some(tuple) = constraint_variables
+        .iter()
+        .map(|variable| assignments.get(variable).cloned())
+        .collect::<Option<Vec<_>>>()
+    {
+        tuples.insert(tuple);
     }
 }
 
@@ -1459,10 +1508,64 @@ fn add_allowed_tuple_set(
     variables: Vec<ConstraintVariableId>,
     tuples: BTreeSet<Vec<ConstraintValue>>,
 ) -> Result<(), SelectorConstraintModelBuildError> {
+    let (variables, tuples) = normalize_allowed_tuple_columns(variables, tuples);
     model
         .add_allowed_tuples(variables, tuples.into_iter().collect())
         .map(|_| ())
         .map_err(Into::into)
+}
+
+fn normalize_allowed_tuple_columns(
+    variables: Vec<ConstraintVariableId>,
+    tuples: BTreeSet<Vec<ConstraintValue>>,
+) -> (Vec<ConstraintVariableId>, BTreeSet<Vec<ConstraintValue>>) {
+    if tuples.iter().any(|tuple| tuple.len() != variables.len()) {
+        return (variables, tuples);
+    }
+
+    let mut unique_variables = Vec::new();
+    let mut column_by_variable = BTreeMap::new();
+    let mut output_column_by_input = Vec::with_capacity(variables.len());
+    for variable in &variables {
+        let output_column = if let Some(output_column) = column_by_variable.get(variable) {
+            *output_column
+        } else {
+            let output_column = unique_variables.len();
+            unique_variables.push(*variable);
+            column_by_variable.insert(*variable, output_column);
+            output_column
+        };
+        output_column_by_input.push(output_column);
+    }
+
+    if unique_variables.len() == variables.len() {
+        return (variables, tuples);
+    }
+
+    let mut normalized_tuples = BTreeSet::new();
+    'row: for tuple in tuples {
+        let mut normalized = vec![None; unique_variables.len()];
+        for (value, output_column) in tuple
+            .into_iter()
+            .zip(output_column_by_input.iter().copied())
+        {
+            if let Some(existing) = &normalized[output_column] {
+                if existing != &value {
+                    continue 'row;
+                }
+            } else {
+                normalized[output_column] = Some(value);
+            }
+        }
+        normalized_tuples.insert(
+            normalized
+                .into_iter()
+                .map(|value| value.expect("every output column is referenced"))
+                .collect(),
+        );
+    }
+
+    (unique_variables, normalized_tuples)
 }
 
 fn owner_term_matches(term: &OwnerTerm, owner: OwnerId) -> bool {
@@ -2059,7 +2162,11 @@ impl FactDomains {
             }
         }
 
-        let mut child_counts = BTreeMap::new();
+        let mut child_counts = self
+            .nodes
+            .iter()
+            .map(|node| (*node, 0))
+            .collect::<BTreeMap<_, _>>();
         for (parent, index, _child) in &self.ast_children {
             let count = child_counts.entry(*parent).or_insert(0);
             *count = (*count).max(index + 1);
@@ -2071,6 +2178,38 @@ impl FactDomains {
             for (node, top_level_ordinal) in &self.ast_top_levels {
                 if ordinal == top_level_ordinal {
                     self.owner_top_level_roots.insert((*owner, *node));
+                }
+            }
+        }
+
+        let binding_ident_nodes = self
+            .ast_kinds
+            .iter()
+            .filter_map(|(node, kind)| {
+                (kind == chunk_facts::NodeKind::BindingIdent.as_tag()).then_some(*node)
+            })
+            .collect::<BTreeSet<_>>();
+        let identifier_by_node = self
+            .ast_identifier_names
+            .iter()
+            .map(|(node, value)| (*node, value.as_str()))
+            .collect::<BTreeMap<_, _>>();
+        let mut children_by_parent = BTreeMap::<NodeId, Vec<NodeId>>::new();
+        for (parent, _index, child) in &self.ast_children {
+            children_by_parent.entry(*parent).or_default().push(*child);
+        }
+        for (root, _ordinal) in &self.ast_top_levels {
+            let mut stack = vec![*root];
+            while let Some(node) = stack.pop() {
+                if binding_ident_nodes.contains(&node)
+                    && let Some(binding) = identifier_by_node.get(&node)
+                    && let Some(owners) = owners_by_binding.get(*binding)
+                {
+                    self.owner_top_level_roots
+                        .extend(owners.iter().map(|owner| (*owner, *root)));
+                }
+                if let Some(children) = children_by_parent.get(&node) {
+                    stack.extend(children.iter().copied());
                 }
             }
         }
@@ -2395,6 +2534,8 @@ mod tests {
         ConstraintValue,
     };
     use selector_ir::{ClaimOrigin, SelectorTargetId};
+    use selector_ir_lowering::{MemberSelectorLoweringContext, MemberSelectorProgramBuilder};
+    use spec::{AnonymousStatementSelector, MemberSelectorSpec, SourceMatchIdentifierMode};
 
     fn owner(value: usize) -> ConstraintValue {
         ConstraintValue::Owner(OwnerId(value))
@@ -2570,6 +2711,107 @@ mod tests {
             .iter()
             .find(|constraint| constraint.variables == variables)
             .unwrap()
+    }
+
+    fn satisfying_tuples_for(
+        model: &SelectorConstraintModel,
+        variables: &[ConstraintVariableId],
+    ) -> Vec<Vec<ConstraintValue>> {
+        let mut rows = BTreeSet::new();
+        let mut assignment = BTreeMap::new();
+        collect_satisfying_tuples(model, variables, 0, &mut assignment, &mut rows);
+        rows.into_iter().collect()
+    }
+
+    fn collect_satisfying_tuples(
+        model: &SelectorConstraintModel,
+        variables: &[ConstraintVariableId],
+        variable_index: usize,
+        assignment: &mut BTreeMap<ConstraintVariableId, ConstraintValue>,
+        rows: &mut BTreeSet<Vec<ConstraintValue>>,
+    ) {
+        let Some(variable) = model.variables.get(variable_index) else {
+            if model_constraints_satisfied(model, assignment)
+                && let Some(row) = variables
+                    .iter()
+                    .map(|variable| assignment.get(variable).cloned())
+                    .collect::<Option<Vec<_>>>()
+            {
+                rows.insert(row);
+            }
+            return;
+        };
+
+        for value in &variable.values {
+            assignment.insert(variable.id, value.clone());
+            collect_satisfying_tuples(model, variables, variable_index + 1, assignment, rows);
+        }
+        assignment.remove(&variable.id);
+    }
+
+    fn model_constraints_satisfied(
+        model: &SelectorConstraintModel,
+        assignment: &BTreeMap<ConstraintVariableId, ConstraintValue>,
+    ) -> bool {
+        model.allowed_tuples.iter().all(|constraint| {
+            constraint
+                .variables
+                .iter()
+                .map(|variable| assignment.get(variable).cloned())
+                .collect::<Option<Vec<_>>>()
+                .is_some_and(|row| constraint.tuples.contains(&row))
+        }) && model.binary_constraints.iter().all(|constraint| {
+            let Some(left) = assignment.get(&constraint.left) else {
+                return false;
+            };
+            let Some(right) = assignment.get(&constraint.right) else {
+                return false;
+            };
+            match constraint.kind {
+                BinaryConstraintKind::Equal => left == right,
+                BinaryConstraintKind::NotEqual => left != right,
+                BinaryConstraintKind::OrdinalBefore => {
+                    matches!(
+                        (left, right),
+                        (
+                            ConstraintValue::StatementOrdinal(left),
+                            ConstraintValue::StatementOrdinal(right)
+                        ) if left < right
+                    )
+                }
+            }
+        }) && model
+            .all_different
+            .iter()
+            .all(|constraint| constraint.is_satisfied_by(assignment) == Some(true))
+    }
+
+    #[test]
+    fn duplicate_variables_in_allowed_tuple_atoms_are_merged() {
+        let mut program = SelectorProgram::default();
+        let node = program.add_variable(VariableDomain::AstNode, Some("node".to_string()));
+        program.add_atom(SelectorAtom::AstChild {
+            parent: NodeTerm::Var { id: node },
+            index: 0,
+            child: NodeTerm::Var { id: node },
+        });
+
+        let facts = fact_store(vec![
+            ast_child(10, 0, 10),
+            ast_child(10, 1, 20),
+            ast_child(20, 0, 20),
+        ]);
+
+        let model = build_selector_constraint_model(&program, &facts).unwrap();
+
+        assert_eq!(
+            allowed_tuples_for(&model, &[ConstraintVariableId(0)]),
+            &AllowedTupleConstraint {
+                id: AllowedTupleConstraintId(0),
+                variables: vec![ConstraintVariableId(0)],
+                tuples: vec![vec![ast_node(10)], vec![ast_node(20)]],
+            }
+        );
     }
 
     #[test]
@@ -2987,7 +3229,7 @@ mod tests {
         let model = build_selector_constraint_model(&program, &facts).unwrap();
 
         assert_eq!(
-            allowed_tuples_for(
+            satisfying_tuples_for(
                 &model,
                 &[
                     ConstraintVariableId(0),
@@ -2995,20 +3237,12 @@ mod tests {
                     ConstraintVariableId(2)
                 ]
             ),
-            &AllowedTupleConstraint {
-                id: AllowedTupleConstraintId(0),
-                variables: vec![
-                    ConstraintVariableId(0),
-                    ConstraintVariableId(1),
-                    ConstraintVariableId(2)
-                ],
-                tuples: vec![
-                    vec![ast_node(100), ast_node(10), ast_node(20)],
-                    vec![ast_node(100), ast_node(10), ast_node(30)],
-                    vec![ast_node(100), ast_node(20), ast_node(30)],
-                    vec![ast_node(200), ast_node(20), ast_node(10)],
-                ],
-            }
+            vec![
+                vec![ast_node(100), ast_node(10), ast_node(20)],
+                vec![ast_node(100), ast_node(10), ast_node(30)],
+                vec![ast_node(100), ast_node(20), ast_node(30)],
+                vec![ast_node(200), ast_node(20), ast_node(10)],
+            ]
         );
     }
 
@@ -3042,12 +3276,8 @@ mod tests {
         let model = build_selector_constraint_model(&program, &facts).unwrap();
 
         assert_eq!(
-            allowed_tuples_for(&model, &[ConstraintVariableId(0)]),
-            &AllowedTupleConstraint {
-                id: AllowedTupleConstraintId(0),
-                variables: vec![ConstraintVariableId(0)],
-                tuples: vec![vec![ast_node(100)]],
-            }
+            satisfying_tuples_for(&model, &[ConstraintVariableId(0)]),
+            vec![vec![ast_node(100)]]
         );
     }
 
@@ -3186,6 +3416,146 @@ mod tests {
                 tuples: vec![vec![ast_node(100), ast_node(10)]],
             }
         );
+    }
+
+    #[test]
+    fn alpha_all_source_match_model_accepts_matching_chunk_facts() {
+        js_ast::with_swc_globals(|| {
+            let mut selector =
+                AnonymousStatementSelector::exact("function readable(items) { return items; }");
+            selector.identifiers = SourceMatchIdentifierMode::AlphaAll;
+            let lowered = selector_ir_lowering::lower_member_selector(
+                &MemberSelectorLoweringContext::new(ChunkId(0), "static/app::format"),
+                "format_items",
+                &MemberSelectorSpec::SourceMatch(selector),
+            )
+            .unwrap();
+
+            let module = js_ast::parse_js_module_ast(
+                "<chunk>",
+                "function actual(values) { return values; }\nexport { actual };\n",
+            )
+            .unwrap();
+            let chunk_facts = chunk_facts::extract_facts(&module).unwrap();
+            let mut facts = SelectorFactStore::default();
+            facts.extend_chunk_facts(ChunkId(0), &chunk_facts);
+            facts.push(owner_fact(0, 0, "fn_decl"));
+            facts.push(declared_binding(0, "actual"));
+
+            let model = build_selector_constraint_model(&lowered.program, &facts).unwrap();
+            let empty_constraints = model
+                .allowed_tuples
+                .iter()
+                .filter(|constraint| constraint.tuples.is_empty())
+                .map(|constraint| {
+                    let variable_names = constraint
+                        .variables
+                        .iter()
+                        .map(|variable| {
+                            model.variables[variable.0]
+                                .debug_name
+                                .clone()
+                                .unwrap_or_else(|| format!("{variable:?}"))
+                        })
+                        .collect::<Vec<_>>();
+                    (constraint, variable_names)
+                })
+                .collect::<Vec<_>>();
+            assert!(
+                empty_constraints.is_empty(),
+                "source_match model has empty allowed-tuple constraints: {empty_constraints:#?}"
+            );
+            let projection = &model.target_projections[0];
+            let binding_variable = projection
+                .binding_variable
+                .expect("alpha_all source_match should project its binding variable");
+
+            assert_eq!(
+                satisfying_tuples_for(&model, &[projection.owner_variable, binding_variable]),
+                vec![vec![owner(0), string("actual")]]
+            );
+        });
+    }
+
+    #[test]
+    fn alpha_all_binding_group_model_accepts_multideclarator_chunk_facts() {
+        js_ast::with_swc_globals(|| {
+            let mut group_selector = AnonymousStatementSelector::exact(
+                "const primary = EXPR_PRIMARY, secondary = EXPR_SECONDARY;",
+            );
+            group_selector.identifiers = SourceMatchIdentifierMode::AlphaAll;
+            let mut primary_selector = group_selector.clone();
+            primary_selector.target_binding = Some("primary".to_string());
+            let mut secondary_selector = group_selector.clone();
+            secondary_selector.target_binding = Some("secondary".to_string());
+
+            let mut builder = MemberSelectorProgramBuilder::new(
+                MemberSelectorLoweringContext::new(ChunkId(0), "static/app::settings"),
+            );
+            builder
+                .declare_member_target_in_module(
+                    "static/app::settings",
+                    "primary",
+                    &MemberSelectorSpec::SourceMatch(primary_selector),
+                )
+                .unwrap();
+            builder
+                .declare_member_target_in_module(
+                    "static/app::settings",
+                    "secondary",
+                    &MemberSelectorSpec::SourceMatch(secondary_selector),
+                )
+                .unwrap();
+            assert!(
+                builder
+                    .try_lower_native_source_match_group(
+                        "static/app::settings",
+                        &group_selector,
+                        &BTreeMap::from([
+                            ("primary".to_string(), "primary".to_string()),
+                            ("secondary".to_string(), "secondary".to_string()),
+                        ]),
+                    )
+                    .unwrap()
+            );
+            let program = builder.into_program().unwrap();
+
+            let module = js_ast::parse_js_module_ast(
+                "<chunk>",
+                "const primary = 10, secondary = 20;\nexport { primary, secondary };\n",
+            )
+            .unwrap();
+            let chunk_facts = chunk_facts::extract_facts(&module).unwrap();
+            let mut facts = SelectorFactStore::default();
+            facts.extend_chunk_facts(ChunkId(0), &chunk_facts);
+            facts.push(owner_fact(0, 0, "var_decl"));
+            facts.push(declared_binding(0, "primary"));
+            facts.push(declared_binding(0, "secondary"));
+
+            let model = build_selector_constraint_model(&program, &facts).unwrap();
+            let empty_constraints = model
+                .allowed_tuples
+                .iter()
+                .filter(|constraint| constraint.tuples.is_empty())
+                .map(|constraint| {
+                    let variable_names = constraint
+                        .variables
+                        .iter()
+                        .map(|variable| {
+                            model.variables[variable.0]
+                                .debug_name
+                                .clone()
+                                .unwrap_or_else(|| format!("{variable:?}"))
+                        })
+                        .collect::<Vec<_>>();
+                    (constraint, variable_names)
+                })
+                .collect::<Vec<_>>();
+            assert!(
+                empty_constraints.is_empty(),
+                "binding group model has empty allowed-tuple constraints: {empty_constraints:#?}"
+            );
+        });
     }
 
     #[test]

--- a/devinfra/js/debundle/selector_ir_lowering.rs
+++ b/devinfra/js/debundle/selector_ir_lowering.rs
@@ -62,6 +62,7 @@ pub struct MemberSelectorProgramBuilder {
     owners_by_export: BTreeMap<(String, String), SelectorVariableId>,
     global_owner_by_export: BTreeMap<String, Option<SelectorVariableId>>,
     targeted_owners: BTreeMap<SelectorVariableId, String>,
+    owner_injectivity_classes: BTreeMap<SelectorVariableId, String>,
 }
 
 struct NativeAstFactLowering<'a> {
@@ -76,6 +77,12 @@ struct NativeAstFactLowering<'a> {
     regex_predicates: &'a NativeRegexPredicateIndex,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+enum OwnerInjectivityClass {
+    Owner(SelectorVariableId),
+    Shared(String),
+}
+
 impl MemberSelectorProgramBuilder {
     pub fn new(context: MemberSelectorLoweringContext) -> Self {
         Self {
@@ -84,6 +91,7 @@ impl MemberSelectorProgramBuilder {
             owners_by_export: BTreeMap::new(),
             global_owner_by_export: BTreeMap::new(),
             targeted_owners: BTreeMap::new(),
+            owner_injectivity_classes: BTreeMap::new(),
         }
     }
 
@@ -196,15 +204,24 @@ impl MemberSelectorProgramBuilder {
                 });
             }
         }
-        let mut unique_target_by_owner = BTreeMap::<SelectorVariableId, SelectorTargetId>::new();
+        let mut unique_target_by_owner_class =
+            BTreeMap::<OwnerInjectivityClass, SelectorTargetId>::new();
         for target in &self.program.targets {
             if self.targeted_owners.contains_key(&target.owner) {
-                unique_target_by_owner
-                    .entry(target.owner)
+                let class = self
+                    .owner_injectivity_classes
+                    .get(&target.owner)
+                    .cloned()
+                    .map(OwnerInjectivityClass::Shared)
+                    .unwrap_or(OwnerInjectivityClass::Owner(target.owner));
+                unique_target_by_owner_class
+                    .entry(class)
                     .or_insert(target.id);
             }
         }
-        let all_different_targets = unique_target_by_owner.into_values().collect::<Vec<_>>();
+        let all_different_targets = unique_target_by_owner_class
+            .into_values()
+            .collect::<Vec<_>>();
         if all_different_targets.len() > 1 {
             self.program.require_all_different(all_different_targets);
         }
@@ -792,11 +809,23 @@ impl MemberSelectorProgramBuilder {
         let mut exact_identifier_projection_vars = BTreeMap::new();
         for (target_binding, export_name) in exports_by_target {
             let owner = self.owner_for_local_export(logical_module, export_name);
-            let root = root_by_target_binding
+            let root_node = root_by_target_binding
                 .get(target_binding)
-                .and_then(|root| node_vars.get(root))
                 .copied()
                 .expect("target binding roots were collected for every export");
+            self.owner_injectivity_classes.insert(
+                owner,
+                binding_group_owner_injectivity_class(
+                    logical_module,
+                    selector,
+                    exports_by_target,
+                    root_node,
+                ),
+            );
+            let root = node_vars
+                .get(&root_node)
+                .copied()
+                .expect("target binding root should have a node variable");
             self.program.add_atom(SelectorAtom::OwnerTopLevelRoot {
                 owner: owner_term(owner),
                 root: node_term(root),
@@ -869,8 +898,9 @@ impl MemberSelectorProgramBuilder {
         };
         let mut child_counts: BTreeMap<NodeId, u32> =
             facts.node_kind.iter().map(|(node, _)| (*node, 0)).collect();
-        for (parent, _index, _child) in &facts.child {
-            *child_counts.entry(*parent).or_insert(0) += 1;
+        for (parent, index, _child) in &facts.child {
+            let count = child_counts.entry(*parent).or_insert(0);
+            *count = (*count).max(index + 1);
         }
         for (node, kind) in &facts.node_kind {
             if skipped_nodes.contains(node) {
@@ -1323,10 +1353,11 @@ fn native_top_level_root_containing_node(
         .copied()
         .filter(|root| native_node_contains(index, *root, target))
         .collect::<Vec<_>>();
-    let [root] = roots.as_slice() else {
-        return None;
-    };
-    Some(*root)
+    roots.iter().copied().find(|candidate| {
+        !roots
+            .iter()
+            .any(|other| *other != *candidate && native_node_contains(index, *candidate, *other))
+    })
 }
 
 fn native_node_contains(index: &AlphaIdentifierIndex, root: NodeId, target: NodeId) -> bool {
@@ -1448,6 +1479,10 @@ fn native_declared_binding_nodes(
                     .into_iter()
                     .flat_map(|pattern| native_pattern_binding_nodes(index, skipped_nodes, pattern))
             })
+            .collect(),
+        Some(NodeKind::VarDeclarator) => child_at(index, node, 0)
+            .into_iter()
+            .flat_map(|pattern| native_pattern_binding_nodes(index, skipped_nodes, pattern))
             .collect(),
         _ => Vec::new(),
     }
@@ -2378,6 +2413,23 @@ fn selector_origin(selector: &MemberSelectorSpec) -> ClaimOrigin {
     }
 }
 
+fn binding_group_owner_injectivity_class(
+    logical_module: &str,
+    selector: &AnonymousStatementSelector,
+    exports_by_target: &BTreeMap<String, String>,
+    root: NodeId,
+) -> String {
+    let target_bindings = exports_by_target
+        .keys()
+        .map(String::as_str)
+        .collect::<Vec<_>>()
+        .join(",");
+    format!(
+        "{logical_module}|binding_group.source_match|{}|{target_bindings}|root:{root}",
+        selector.match_source
+    )
+}
+
 fn statement_kind_str_for_spec(kind: BindingSourceKind) -> &'static str {
     let statement_kind = match kind {
         BindingSourceKind::VariableDeclarator => StatementKind::VarDecl,
@@ -2611,6 +2663,42 @@ mod tests {
                 .iter()
                 .any(|atom| matches!(atom, SelectorAtom::AstSuperClass { .. }))
         );
+    }
+
+    #[test]
+    fn exact_source_match_sparse_child_indices_use_index_arity() {
+        let selector = AnonymousStatementSelector::exact("!(function () {})();");
+        let lowered = lower_member_selector(
+            &context(),
+            "Widget",
+            &MemberSelectorSpec::SourceMatch(selector),
+        )
+        .unwrap();
+        let fn_expr_node = lowered
+            .program
+            .atoms
+            .iter()
+            .find_map(|atom| match atom {
+                SelectorAtom::AstKind {
+                    node: NodeTerm::Var { id },
+                    node_kind: NodeKind::FnExpr,
+                } => Some(*id),
+                _ => None,
+            })
+            .expect("anonymous function expression should be lowered");
+        let fn_expr_child_count = lowered
+            .program
+            .atoms
+            .iter()
+            .find_map(|atom| match atom {
+                SelectorAtom::AstChildCount {
+                    node: NodeTerm::Var { id },
+                    count,
+                } if *id == fn_expr_node => Some(*count),
+                _ => None,
+            })
+            .expect("function expression should carry an arity constraint");
+        assert_eq!(fn_expr_child_count, 2);
     }
 
     #[test]
@@ -2929,6 +3017,10 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(shared_roots.len(), 2);
         assert_eq!(shared_roots[0], shared_roots[1]);
+        assert!(
+            program.all_different.is_empty(),
+            "same-root binding group exports must not be forced to distinct owners"
+        );
 
         let projected_bindings = program
             .atoms

--- a/devinfra/js/debundle/selector_ortools_cpsat_backend.rs
+++ b/devinfra/js/debundle/selector_ortools_cpsat_backend.rs
@@ -6,6 +6,7 @@
 
 use std::error::Error;
 use std::fmt;
+use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus, Stdio};
@@ -19,6 +20,10 @@ use selector_constraint_backend::{
 };
 use selector_constraint_model::{BinaryConstraintKind, ConstraintVariableId};
 use selector_cp_sat_proto::ducktape::debundle::solver_backends::ortools_cpsat as wire;
+
+const REQUEST_PROTO_ENV: &str = "DUCKTAPE_DEBUNDLE_ORTOOLS_CPSAT_REQUEST_PROTO";
+const SUMMARY_JSON_ENV: &str = "DUCKTAPE_DEBUNDLE_ORTOOLS_CPSAT_SUMMARY_JSON";
+const DUMP_ONLY_ENV: &str = "DUCKTAPE_DEBUNDLE_ORTOOLS_CPSAT_DUMP_ONLY";
 
 #[derive(Debug, Clone)]
 pub struct OrToolsCpSatBackend {
@@ -42,7 +47,14 @@ impl SelectorConstraintBackend for OrToolsCpSatBackend {
 
     fn solve(&self, problem: &SelectorBackendProblem) -> Result<BackendSolveResult, Self::Error> {
         let request = request_from_problem(problem)?;
-        let output = run_sidecar(&self.solver_path, request.encode_to_vec().as_slice())?;
+        let request_bytes = request.encode_to_vec();
+        let dumped_request_path = dump_request_if_requested(problem, &request, &request_bytes)?;
+        if dump_only_requested() {
+            return Err(OrToolsCpSatBackendError::DumpOnly {
+                path: dumped_request_path,
+            });
+        }
+        let output = run_sidecar(&self.solver_path, request_bytes.as_slice())?;
         let response = wire::SelectorCpSatResponse::decode(output.as_slice())
             .map_err(OrToolsCpSatBackendError::DecodeResponse)?;
         response_into_backend_result(response)
@@ -82,15 +94,36 @@ fn run_sidecar(
 
 #[derive(Debug)]
 pub enum OrToolsCpSatBackendError {
-    IdOutOfRange { field: &'static str, value: usize },
+    IdOutOfRange {
+        field: &'static str,
+        value: usize,
+    },
     Spawn(io::Error),
     MissingChildStdin,
     WriteRequest(io::Error),
     Wait(io::Error),
-    SidecarFailed { status: ExitStatus, stderr: String },
+    SidecarFailed {
+        status: ExitStatus,
+        stderr: String,
+    },
     DecodeResponse(prost::DecodeError),
-    InvalidStatus { status: i32 },
-    InvalidAssignmentCoverage { coverage: i32 },
+    DumpSummaryJson {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
+    DumpIo {
+        path: PathBuf,
+        source: io::Error,
+    },
+    DumpOnly {
+        path: Option<PathBuf>,
+    },
+    InvalidStatus {
+        status: i32,
+    },
+    InvalidAssignmentCoverage {
+        coverage: i32,
+    },
 }
 
 impl fmt::Display for OrToolsCpSatBackendError {
@@ -112,6 +145,33 @@ impl fmt::Display for OrToolsCpSatBackendError {
             Self::DecodeResponse(err) => {
                 write!(f, "failed to decode CP-SAT response protobuf: {err}")
             }
+            Self::DumpSummaryJson { path, source } => {
+                write!(
+                    f,
+                    "failed to serialize CP-SAT summary JSON at {}: {source}",
+                    path.display()
+                )
+            }
+            Self::DumpIo { path, source } => {
+                write!(
+                    f,
+                    "failed to write CP-SAT diagnostic artifact at {}: {source}",
+                    path.display()
+                )
+            }
+            Self::DumpOnly { path: Some(path) } => {
+                write!(
+                    f,
+                    "dumped CP-SAT request at {}; stopping before sidecar because {DUMP_ONLY_ENV}=1",
+                    path.display()
+                )
+            }
+            Self::DumpOnly { path: None } => {
+                write!(
+                    f,
+                    "{DUMP_ONLY_ENV}=1 requires {REQUEST_PROTO_ENV} or {SUMMARY_JSON_ENV} to point at an output file"
+                )
+            }
             Self::InvalidStatus { status } => {
                 write!(f, "CP-SAT sidecar returned invalid status {status}")
             }
@@ -130,13 +190,196 @@ impl Error for OrToolsCpSatBackendError {
         match self {
             Self::Spawn(err) | Self::WriteRequest(err) | Self::Wait(err) => Some(err),
             Self::DecodeResponse(err) => Some(err),
+            Self::DumpSummaryJson { source, .. } => Some(source),
+            Self::DumpIo { source, .. } => Some(source),
             Self::IdOutOfRange { .. }
             | Self::MissingChildStdin
             | Self::SidecarFailed { .. }
+            | Self::DumpOnly { .. }
             | Self::InvalidStatus { .. }
             | Self::InvalidAssignmentCoverage { .. } => None,
         }
     }
+}
+
+fn dump_request_if_requested(
+    problem: &SelectorBackendProblem,
+    request: &wire::SelectorCpSatRequest,
+    request_bytes: &[u8],
+) -> Result<Option<PathBuf>, OrToolsCpSatBackendError> {
+    let request_proto_path = env_path(REQUEST_PROTO_ENV);
+    let summary_json_path = env_path(SUMMARY_JSON_ENV);
+    if request_proto_path.is_none() && summary_json_path.is_none() {
+        return Ok(None);
+    }
+
+    if let Some(path) = &request_proto_path {
+        write_request_proto(path, request_bytes)?;
+    }
+    if let Some(path) = &summary_json_path {
+        write_summary_json(path, problem, request, request_bytes.len())?;
+    }
+    Ok(request_proto_path.or(summary_json_path))
+}
+
+fn env_path(env: &str) -> Option<PathBuf> {
+    std::env::var_os(env)
+        .map(PathBuf::from)
+        .filter(|path| !path.as_os_str().is_empty())
+}
+
+fn write_request_proto(path: &Path, request_bytes: &[u8]) -> Result<(), OrToolsCpSatBackendError> {
+    create_parent_dir(path)?;
+    let temp_path = path.with_extension("pb.tmp");
+    fs::write(&temp_path, request_bytes).map_err(|source| OrToolsCpSatBackendError::DumpIo {
+        path: temp_path.clone(),
+        source,
+    })?;
+    fs::rename(&temp_path, path).map_err(|source| OrToolsCpSatBackendError::DumpIo {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+fn write_summary_json(
+    path: &Path,
+    problem: &SelectorBackendProblem,
+    request: &wire::SelectorCpSatRequest,
+    request_encoded_bytes: usize,
+) -> Result<(), OrToolsCpSatBackendError> {
+    create_parent_dir(path)?;
+    let temp_path = path.with_extension("json.tmp");
+    let mut file =
+        fs::File::create(&temp_path).map_err(|source| OrToolsCpSatBackendError::DumpIo {
+            path: temp_path.clone(),
+            source,
+        })?;
+    let summary = problem_summary(problem, request, request_encoded_bytes);
+    serde_json::to_writer_pretty(&mut file, &summary).map_err(|source| {
+        OrToolsCpSatBackendError::DumpSummaryJson {
+            path: temp_path.clone(),
+            source,
+        }
+    })?;
+    file.write_all(b"\n")
+        .map_err(|source| OrToolsCpSatBackendError::DumpIo {
+            path: temp_path.clone(),
+            source,
+        })?;
+    file.flush()
+        .map_err(|source| OrToolsCpSatBackendError::DumpIo {
+            path: temp_path.clone(),
+            source,
+        })?;
+    drop(file);
+    fs::rename(&temp_path, path).map_err(|source| OrToolsCpSatBackendError::DumpIo {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+fn create_parent_dir(path: &Path) -> Result<(), OrToolsCpSatBackendError> {
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent).map_err(|source| OrToolsCpSatBackendError::DumpIo {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+    Ok(())
+}
+
+fn dump_only_requested() -> bool {
+    std::env::var_os(DUMP_ONLY_ENV)
+        .map(|value| !value.is_empty() && value != "0")
+        .unwrap_or(false)
+}
+
+fn problem_summary(
+    problem: &SelectorBackendProblem,
+    request: &wire::SelectorCpSatRequest,
+    request_encoded_bytes: usize,
+) -> serde_json::Value {
+    let total_domain_values = problem
+        .variables
+        .iter()
+        .map(|variable| variable.values.len())
+        .sum::<usize>();
+    let max_domain_values = problem
+        .variables
+        .iter()
+        .map(|variable| variable.values.len())
+        .max()
+        .unwrap_or(0);
+    let allowed_row_count = problem
+        .allowed_tuples
+        .iter()
+        .map(|constraint| constraint.tuples.len())
+        .sum::<usize>();
+    let allowed_cell_count = problem
+        .allowed_tuples
+        .iter()
+        .map(|constraint| {
+            constraint
+                .tuples
+                .iter()
+                .map(|tuple| tuple.len())
+                .sum::<usize>()
+        })
+        .sum::<usize>();
+    let max_allowed_rows = problem
+        .allowed_tuples
+        .iter()
+        .map(|constraint| constraint.tuples.len())
+        .max()
+        .unwrap_or(0);
+    let max_allowed_arity = problem
+        .allowed_tuples
+        .iter()
+        .map(|constraint| constraint.variables.len())
+        .max()
+        .unwrap_or(0);
+    let binary_equal_count = problem
+        .binary_constraints
+        .iter()
+        .filter(|constraint| matches!(constraint.kind, BinaryConstraintKind::Equal))
+        .count();
+    let binary_not_equal_count = problem
+        .binary_constraints
+        .iter()
+        .filter(|constraint| matches!(constraint.kind, BinaryConstraintKind::NotEqual))
+        .count();
+    let binary_ordinal_before_count = problem
+        .binary_constraints
+        .iter()
+        .filter(|constraint| matches!(constraint.kind, BinaryConstraintKind::OrdinalBefore))
+        .count();
+
+    serde_json::json!({
+        "all_different_count": problem.all_different.len(),
+        "allowed_cell_count": allowed_cell_count,
+        "allowed_row_count": allowed_row_count,
+        "allowed_table_count": problem.allowed_tuples.len(),
+        "binary_constraint_count": problem.binary_constraints.len(),
+        "binary_equal_count": binary_equal_count,
+        "binary_not_equal_count": binary_not_equal_count,
+        "binary_ordinal_before_count": binary_ordinal_before_count,
+        "max_allowed_arity": max_allowed_arity,
+        "max_allowed_rows": max_allowed_rows,
+        "max_domain_values": max_domain_values,
+        "request_encoded_bytes": request_encoded_bytes,
+        "target_projection_count": problem.target_projections.len(),
+        "total_domain_values": total_domain_values,
+        "value_dictionary_count": problem.value_dictionary.len(),
+        "variable_count": problem.variables.len(),
+        "wire_all_different_count": request.all_different.len(),
+        "wire_allowed_table_count": request.allowed_tables.len(),
+        "wire_binary_constraint_count": request.binary_constraints.len(),
+        "wire_target_projection_count": request.target_projections.len(),
+        "wire_variable_count": request.variables.len(),
+    })
 }
 
 fn request_from_problem(
@@ -317,14 +560,17 @@ fn u32_id(field: &'static str, value: usize) -> Result<u32, OrToolsCpSatBackendE
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
     use std::path::{Path, PathBuf};
 
-    use analysis::{ChunkId, OwnerId, StatementOrdinal};
+    use analysis::{AnalysisHints, ChunkId, OwnerId, StatementOrdinal};
     use selector_backend_solver::solve_with_backend;
     use selector_ir::{
         ClaimKind, ClaimOrigin, ClaimOutcome, OwnerTerm, ResolvedClaim, SelectorAtom, SelectorFact,
         SelectorFactStore, SelectorProgram, SelectorTargetId, StringTerm, VariableDomain,
     };
+    use selector_ir_lowering::{MemberSelectorLoweringContext, MemberSelectorProgramBuilder};
+    use spec::{AnonymousStatementSelector, MemberSelectorSpec, SourceMatchIdentifierMode};
 
     use super::*;
 
@@ -498,6 +744,119 @@ mod tests {
                 }
             })
         );
+    }
+
+    #[test]
+    fn cpsat_sidecar_resolves_alpha_all_binding_group_multideclarator() {
+        js_ast::with_swc_globals(|| {
+            let mut group_selector = AnonymousStatementSelector::exact(
+                "const primary = EXPR_PRIMARY, secondary = EXPR_SECONDARY;",
+            );
+            group_selector.identifiers = SourceMatchIdentifierMode::AlphaAll;
+            let mut primary_selector = group_selector.clone();
+            primary_selector.target_binding = Some("primary".to_string());
+            let mut secondary_selector = group_selector.clone();
+            secondary_selector.target_binding = Some("secondary".to_string());
+
+            let mut builder = MemberSelectorProgramBuilder::new(
+                MemberSelectorLoweringContext::new(ChunkId(0), "static/app::settings"),
+            );
+            let primary_target = builder
+                .declare_member_target_in_module(
+                    "static/app::settings",
+                    "primary",
+                    &MemberSelectorSpec::SourceMatch(primary_selector),
+                )
+                .unwrap();
+            let secondary_target = builder
+                .declare_member_target_in_module(
+                    "static/app::settings",
+                    "secondary",
+                    &MemberSelectorSpec::SourceMatch(secondary_selector),
+                )
+                .unwrap();
+            assert!(
+                builder
+                    .try_lower_native_source_match_group(
+                        "static/app::settings",
+                        &group_selector,
+                        &BTreeMap::from([
+                            ("primary".to_string(), "primary".to_string()),
+                            ("secondary".to_string(), "secondary".to_string()),
+                        ]),
+                    )
+                    .unwrap()
+            );
+            let program = builder.into_program().unwrap();
+
+            let module = js_ast::parse_js_module_ast(
+                "<chunk>",
+                "const primary = 10, secondary = 20;\n\
+                 console.log(primary + secondary);\n\
+                 export { primary, secondary };\n",
+            )
+            .unwrap();
+            let chunk_facts = chunk_facts::extract_facts(&module).unwrap();
+            let analysis =
+                analysis::facts::analyze_chunk(&module, &AnalysisHints::default(), None, |_| None);
+            let owner_graph = analysis::graph::build_owner_graph(&analysis.facts).unwrap();
+            let mut facts = SelectorFactStore::default();
+            facts.extend_chunk_facts(ChunkId(0), &chunk_facts);
+            for node in owner_graph.iter_nodes() {
+                facts.push(SelectorFact::Owner {
+                    chunk_id: ChunkId(0),
+                    owner: node.id,
+                    statement_ordinal: node.statement_ordinal,
+                    statement_kind: node.kind.to_string(),
+                });
+                for binding in &node.declared {
+                    facts.push(SelectorFact::DeclaredBinding {
+                        chunk_id: ChunkId(0),
+                        owner: node.id,
+                        binding: binding.0.as_str().to_string(),
+                        export_name: None,
+                    });
+                }
+            }
+            for edge in owner_graph.iter_edges() {
+                if let Some(binding) = edge.reason.binding() {
+                    facts.push(SelectorFact::OwnerReferencesBinding {
+                        chunk_id: ChunkId(0),
+                        owner: edge.from,
+                        binding: binding.0.as_str().to_string(),
+                        edge_kind: edge.reason.kind().to_string(),
+                    });
+                }
+            }
+
+            let backend = OrToolsCpSatBackend::new(sidecar_path());
+            let result = solve_with_backend(&program, &facts, &backend).unwrap();
+
+            assert_eq!(
+                result.outcome_for(primary_target),
+                Some(&ClaimOutcome::Unique {
+                    claim: ResolvedClaim {
+                        chunk_id: ChunkId(0),
+                        owner: OwnerId(0),
+                        statement_ordinal: StatementOrdinal(0),
+                        binding: Some("primary".to_string()),
+                        provenance: Vec::new(),
+                    }
+                })
+            );
+            assert_eq!(
+                result.outcome_for(secondary_target),
+                Some(&ClaimOutcome::Unique {
+                    claim: ResolvedClaim {
+                        chunk_id: ChunkId(0),
+                        owner: OwnerId(1),
+                        statement_ordinal: StatementOrdinal(1),
+                        binding: Some("secondary".to_string()),
+                        provenance: Vec::new(),
+                    }
+                })
+            );
+        });
     }
 
     #[test]

--- a/devinfra/js/debundle/solver_backends/ortools_cpsat/solver.cc
+++ b/devinfra/js/debundle/solver_backends/ortools_cpsat/solver.cc
@@ -30,6 +30,11 @@ struct ProjectionRow {
   }
 };
 
+struct ProjectionVariable {
+  uint32_t id;
+  sat::IntVar variable;
+};
+
 SelectorCpSatResponse InvalidResponse(const absl::Status& status) {
   SelectorCpSatResponse response;
   response.set_status(SOLVER_STATUS_INVALID);
@@ -172,7 +177,7 @@ absl::Status AddAllDifferentConstraints(const SelectorCpSatRequest& request,
   return absl::OkStatus();
 }
 
-absl::StatusOr<std::vector<uint32_t>> ProjectionVariableIds(
+absl::StatusOr<std::vector<ProjectionVariable>> ProjectionVariables(
     const SelectorCpSatRequest& request, const VariableMap& variables) {
   std::set<uint32_t> ids;
   for (const TargetProjection& projection : request.target_projections()) {
@@ -186,13 +191,71 @@ absl::StatusOr<std::vector<uint32_t>> ProjectionVariableIds(
       return MissingVariableStatus(id);
     }
   }
-  return std::vector<uint32_t>(ids.begin(), ids.end());
+  std::vector<ProjectionVariable> projection_variables;
+  projection_variables.reserve(ids.size());
+  for (uint32_t id : ids) {
+    projection_variables.push_back({id, variables.at(id)});
+  }
+  return projection_variables;
+}
+
+ProjectionRow ProjectionRowFromSolution(
+    const sat::CpSolverResponse& response,
+    const std::vector<ProjectionVariable>& projection_variables) {
+  ProjectionRow row;
+  row.values.reserve(projection_variables.size());
+  for (const ProjectionVariable& projection_variable : projection_variables) {
+    row.values.push_back(
+        {projection_variable.id,
+         sat::SolutionIntegerValue(response, projection_variable.variable)});
+  }
+  return row;
+}
+
+void AddForbiddenProjectionRow(
+    const ProjectionRow& row,
+    const std::vector<ProjectionVariable>& projection_variables,
+    sat::CpModelBuilder* model) {
+  std::vector<sat::IntVar> variables;
+  variables.reserve(projection_variables.size());
+  for (const ProjectionVariable& projection_variable : projection_variables) {
+    variables.push_back(projection_variable.variable);
+  }
+  sat::TableConstraint forbidden = model->AddForbiddenAssignments(variables);
+  std::vector<int64_t> values;
+  values.reserve(row.values.size());
+  for (const auto& [_variable_id, value] : row.values) {
+    values.push_back(value);
+  }
+  forbidden.AddTuple(values);
 }
 
 SelectorCpSatResponse ResponseFromSolver(
     const sat::CpSolverResponse& solver_response,
     const std::set<ProjectionRow>& projection_rows, bool complete) {
   SelectorCpSatResponse response;
+
+  if (!projection_rows.empty()) {
+    if (!complete) {
+      response.set_status(SOLVER_STATUS_UNKNOWN);
+      response.set_assignment_coverage(ASSIGNMENT_COVERAGE_SAMPLE);
+      response.set_diagnostic(sat::CpSolverResponseStats(solver_response));
+    } else {
+      response.set_status(projection_rows.size() == 1 ? SOLVER_STATUS_SATISFIABLE
+                                                      : SOLVER_STATUS_AMBIGUOUS);
+      response.set_assignment_coverage(
+          ASSIGNMENT_COVERAGE_TARGET_SUPPORT_COMPLETE);
+    }
+    for (const ProjectionRow& row : projection_rows) {
+      AssignmentRow* assignment_row = response.add_assignments();
+      for (const auto& [variable_id, value] : row.values) {
+        Assignment* assignment = assignment_row->add_values();
+        assignment->set_variable_id(variable_id);
+        assignment->set_value(value);
+      }
+    }
+    return response;
+  }
 
   switch (solver_response.status()) {
     case sat::CpSolverStatus::INFEASIBLE:
@@ -202,7 +265,10 @@ SelectorCpSatResponse ResponseFromSolver(
       return response;
     case sat::CpSolverStatus::OPTIMAL:
     case sat::CpSolverStatus::FEASIBLE:
-      break;
+      response.set_status(SOLVER_STATUS_UNKNOWN);
+      response.set_assignment_coverage(ASSIGNMENT_COVERAGE_SAMPLE);
+      response.set_diagnostic(sat::CpSolverResponseStats(solver_response));
+      return response;
     case sat::CpSolverStatus::MODEL_INVALID:
       response.set_status(SOLVER_STATUS_INVALID);
       response.set_assignment_coverage(ASSIGNMENT_COVERAGE_SAMPLE);
@@ -214,23 +280,6 @@ SelectorCpSatResponse ResponseFromSolver(
       response.set_assignment_coverage(ASSIGNMENT_COVERAGE_SAMPLE);
       response.set_diagnostic(sat::CpSolverResponseStats(solver_response));
       return response;
-  }
-
-  response.set_status(projection_rows.size() == 1 ? SOLVER_STATUS_SATISFIABLE
-                                                  : SOLVER_STATUS_AMBIGUOUS);
-  response.set_assignment_coverage(
-      complete ? ASSIGNMENT_COVERAGE_TARGET_SUPPORT_COMPLETE
-               : ASSIGNMENT_COVERAGE_SAMPLE);
-  if (!complete) {
-    response.set_diagnostic(sat::CpSolverResponseStats(solver_response));
-  }
-  for (const ProjectionRow& row : projection_rows) {
-    AssignmentRow* assignment_row = response.add_assignments();
-    for (const auto& [variable_id, value] : row.values) {
-      Assignment* assignment = assignment_row->add_values();
-      assignment->set_variable_id(variable_id);
-      assignment->set_value(value);
-    }
   }
   return response;
 }
@@ -270,34 +319,40 @@ SelectorCpSatResponse SolveSelectorCpSat(const SelectorCpSatRequest& request) {
     return InvalidResponse(build_status);
   }
 
-  absl::StatusOr<std::vector<uint32_t>> projection_variable_ids =
-      ProjectionVariableIds(request, variables);
-  if (!projection_variable_ids.ok()) {
-    return InvalidResponse(projection_variable_ids.status());
+  absl::StatusOr<std::vector<ProjectionVariable>> projection_variables =
+      ProjectionVariables(request, variables);
+  if (!projection_variables.ok()) {
+    return InvalidResponse(projection_variables.status());
   }
 
   std::set<ProjectionRow> projection_rows;
-  sat::Model solver_model;
-  sat::SatParameters parameters;
-  parameters.set_enumerate_all_solutions(true);
-  parameters.set_num_search_workers(1);
-  solver_model.Add(sat::NewSatParameters(parameters));
-  solver_model.Add(sat::NewFeasibleSolutionObserver(
-      [&](const sat::CpSolverResponse& response) {
-        ProjectionRow row;
-        row.values.reserve(projection_variable_ids->size());
-        for (uint32_t variable_id : *projection_variable_ids) {
-          row.values.push_back(
-              {variable_id,
-               sat::SolutionIntegerValue(response, variables.at(variable_id))});
-        }
-        projection_rows.insert(std::move(row));
-      }));
+  sat::CpSolverResponse solver_response;
+  for (;;) {
+    sat::Model solver_model;
+    sat::SatParameters parameters;
+    parameters.set_num_search_workers(1);
+    solver_model.Add(sat::NewSatParameters(parameters));
 
-  const sat::CpSolverResponse solver_response =
-      sat::SolveCpModel(model.Build(), &solver_model);
-  const bool complete = solver_response.status() == sat::CpSolverStatus::OPTIMAL;
-  return ResponseFromSolver(solver_response, projection_rows, complete);
+    solver_response = sat::SolveCpModel(model.Build(), &solver_model);
+    switch (solver_response.status()) {
+      case sat::CpSolverStatus::OPTIMAL:
+      case sat::CpSolverStatus::FEASIBLE: {
+        ProjectionRow row =
+            ProjectionRowFromSolution(solver_response, *projection_variables);
+        projection_rows.insert(row);
+        AddForbiddenProjectionRow(row, *projection_variables, &model);
+        break;
+      }
+      case sat::CpSolverStatus::INFEASIBLE:
+        return ResponseFromSolver(solver_response, projection_rows,
+                                  /*complete=*/true);
+      case sat::CpSolverStatus::MODEL_INVALID:
+      case sat::CpSolverStatus::UNKNOWN:
+      default:
+        return ResponseFromSolver(solver_response, projection_rows,
+                                  /*complete=*/false);
+    }
+  }
 }
 
 }  // namespace ducktape::debundle::solver_backends::ortools_cpsat

--- a/devinfra/js/debundle/solver_backends/ortools_cpsat/solver_test.cc
+++ b/devinfra/js/debundle/solver_backends/ortools_cpsat/solver_test.cc
@@ -80,6 +80,32 @@ TEST(SelectorCpSatSolverTest, MultipleProjectionRowsAreAmbiguous) {
   EXPECT_EQ(response.assignments_size(), 2);
 }
 
+TEST(SelectorCpSatSolverTest, UnprojectedVariablesDoNotCreateRows) {
+  const cpsat::SelectorCpSatRequest request = ParseRequest(R"pb(
+    variables { id: 0 values: 0 debug_name: "owner" }
+    variables {
+      id: 1
+      values: 10
+      values: 11
+      values: 12
+      values: 13
+      values: 14
+      debug_name: "internal_ast_node"
+    }
+    target_projections { target_id: 0 owner_variable_id: 0 }
+  )pb");
+
+  const cpsat::SelectorCpSatResponse response =
+      cpsat::SolveSelectorCpSat(request);
+
+  EXPECT_EQ(response.status(), cpsat::SOLVER_STATUS_SATISFIABLE);
+  EXPECT_EQ(response.assignment_coverage(),
+            cpsat::ASSIGNMENT_COVERAGE_TARGET_SUPPORT_COMPLETE);
+  ASSERT_EQ(response.assignments_size(), 1);
+  EXPECT_TRUE(RowHas(response.assignments(0), 0, 0));
+  EXPECT_EQ(response.assignments(0).values_size(), 1);
+}
+
 TEST(SelectorCpSatSolverTest, ConflictingTablesAreUnsat) {
   const cpsat::SelectorCpSatRequest request = ParseRequest(R"pb(
     variables { id: 0 values: 0 values: 1 debug_name: "owner" }


### PR DESCRIPTION
## Summary
- Send the selector CP-SAT request/response over binary protobuf between Rust and the C++ sidecar.
- Add request `.pb` and compact summary JSON diagnostics, plus a `selector_problem` output group.
- Fix binding-group/global selector assignment cases where multiple readable exports share one source-match root, and normalize duplicate allowed-table variables.

## Validation
- `nix develop -c bbr test //devinfra/js/debundle:selector_match_differential_test //devinfra/js/debundle:selector_ir_lowering_test //devinfra/js/debundle:selector_constraint_model_builder_test //devinfra/js/debundle:selector_ortools_cpsat_backend_test //devinfra/js/debundle/solver_backends/ortools_cpsat:solver_test --cache_test_results=no --test_output=errors`
- `nix develop -c bbr test //devinfra/js/debundle/e2e:syntactic_holes_test --test_arg=binding_group_comments_emit_for_adopted_names --test_timeout=300 --cache_test_results=no --test_output=all`
- `nix develop -c pre-commit run --files devinfra/js/debundle/BUILD.bazel devinfra/js/debundle/README.md devinfra/js/debundle/lowering/materialize/plan_builder.rs devinfra/js/debundle/pipeline.bzl devinfra/js/debundle/selector_constraint_model_builder.rs devinfra/js/debundle/selector_ir_lowering.rs devinfra/js/debundle/selector_ortools_cpsat_backend.rs`

Note: attempted gaffer-private `selector_problem` output-group build with the Ducktape override, but it failed during Bazel analysis because `rules_rust` lockfile generation timed out fetching `alphavantage` from crates.io, before reaching the debundle action.