### PR TITLE
haku/console: mark bridge.ts authoritative iframe protocol + duplication/Bazel TODOs

### DIFF
--- a/haku/console/frontend/bridge.ts
+++ b/haku/console/frontend/bridge.ts
@@ -2,6 +2,11 @@
 // agent-authored UI iframe. The iframe may only **request**; the shell decides and
 // acts. Every inbound message is origin-checked and schema-validated.
 // See plans/free_form_ui_iframe.md → "The protocol".
+//
+// AUTHORITATIVE COPY of the iframe protocol contract. Haku's UI (the client side)
+// keeps a hand-maintained DUPLICATE of the message shapes in `haku-state` (seeded
+// from `haku/state_template/ui/`); this file is the source of truth — keep the two in
+// sync. See plans/free_form_ui_iframe.md → _Open questions_ (share-the-protocol TODO).
 
 // Inbound (iframe → shell). Today only `openLink` is wired; `requestCapability`
 // (perform a shell-owned action like launch-routine) is the next affordance.

--- a/haku/console/plans/free_form_ui_iframe.md
+++ b/haku/console/plans/free_form_ui_iframe.md
@@ -290,6 +290,18 @@ Until then, Phase 1a's trusted item list coexists.
 
 ## Open questions
 
+- **Share the iframe protocol instead of duplicating it.** The protocol contract is
+  small, so for now Haku's UI keeps a hand-maintained copy of the message shapes,
+  with `haku/console/frontend/bridge.ts` as the authoritative source (notes in both
+  copies). They can drift. Share it properly later — a tiny package both pin, or a
+  generated/sync-checked artifact.
+- **Consider building Haku's UI with Bazel sometime.** It's currently a standalone
+  app (Vite + FastAPI + Dockerfile, built by Forgejo CI with rootless buildkit) —
+  ordinary tooling, deliberately _not_ Bazel, since the build is a small agent-owned
+  app, must stay off BuildBuddy (private), and should be easy for Haku to iterate on.
+  If we later want ducktape's build consistency + lint aspects + the shared protocol
+  as a real `bazel_dep`, revisit a Bazel build (the gaffer-private pattern: a
+  `haku-state` Bazel workspace on pinned ducktape, built local-only in the runner).
 - **Forward-auth header trust** — how Haku's backend distinguishes outpost traffic
   from direct in-cluster calls (so header identity can't be spoofed by another
   `haku-sandbox` pod).


### PR DESCRIPTION
Records the decision to keep Haku's UI a **standalone (non-Bazel) app** with a **duplicated** protocol contract (ducktape's copy authoritative). Adds the AUTHORITATIVE-COPY header to `bridge.ts` + two follow-ups in the design doc: share the protocol properly later, and consider a Bazel build someday. No behavior change.