### PR TITLE
[codex] Clean up debundle chunk-analysis instrumentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,15 @@ When renaming/moving/deleting files or symbols, search **all references** across
 
 **Atomic API changes**: update all callers in the same commit. No transitional shims within this monorepo.
 
+## Profiling
+
+Use real profilers for performance investigations: `perf`, Callgrind
+(`valgrind --tool=callgrind`), heaptrack, Massif, or the component's
+Bazel profile targets. Do not commit ad hoc timing macros, fine-grained
+phase timers, or one-off elapsed-time counters to production code just
+to understand a hotspot. If temporary instrumentation is unavoidable,
+keep it local to the investigation and remove it before review.
+
 ## Before Hand-off
 
 ```bash

--- a/devinfra/js/debundle/AGENTS.md
+++ b/devinfra/js/debundle/AGENTS.md
@@ -105,8 +105,8 @@ is slower and the repro can't be shared publicly.
 
 ## Performance Profiling
 
-Use external profiling before adding fine-grained timing boilerplate
-to production code. The default downstream workflow is documented in
+Use external profiling rather than fine-grained timing boilerplate in
+production code. The default downstream workflow is documented in
 <README.md>: use the profile sibling targets from
 `debundle_pipeline_with_profiles` so the profiling run shares the real
 Bazel action's spec paths, package roots, working directory, declared
@@ -120,6 +120,13 @@ shape problems. Many fixes should be structural: change maps to dense
 typed-id vectors, cache instead of recomputing, use a better graph
 algorithm, fuse passes, or adopt a proven crate/data structure rather
 than sprinkling more counters through the code.
+
+Do not commit ad hoc timing macros, detailed per-phase timers, or
+one-off elapsed-time counters solely for profiling. Use `perf`,
+Callgrind (`valgrind --tool=callgrind`), heaptrack, Massif, or the
+Bazel profile targets instead. If temporary instrumentation is
+unavoidable during an investigation, keep it local and remove it before
+review.
 
 Use production builds for absolute elapsed-time numbers. Symbol-heavy
 profiling flags can trade exact wall-clock comparability for better

--- a/devinfra/js/debundle/README.md
+++ b/devinfra/js/debundle/README.md
@@ -158,7 +158,7 @@ nix develop --command bazelisk build //path/to:debundle_profile_perf \
 Each profile target writes a `<target>.profile` tree artifact. Common files:
 
 - `command.sh`: replayable command with the Bazel action cwd and argv.
-- `stdout.txt`: debundler stage timings.
+- `stdout.txt`: debundler stdout from the profiled run.
 - `debundle.out/`: the debundle output tree produced by the profiled run.
 
 Mode-specific files:
@@ -301,7 +301,7 @@ spec field (`spec::OwnerGraphOptions::local_property_effects`) and in
 Every materialized chunk is screened against the statically checkable
 input assumptions of `docs/design.md` → "Conditions on the input
 chunk" before any quotient or lowering work (`chunk_admission.rs`,
-run from `stage_one::compute_stage_one_analysis` next to the A2
+run from `stage_one::compute_chunk_analysis` next to the A2
 top-level-await bail). The enforced shapes:
 
 - **A1** — direct `eval(...)` / seq-indirect `(0, eval)(...)` calls at

--- a/devinfra/js/debundle/TODO.md
+++ b/devinfra/js/debundle/TODO.md
@@ -96,7 +96,10 @@ parallel dispatch queue.
   carrying it forward. The landed bridge primitives (`cross_ref`,
   `reads_member`, `member_of_module`, `passed_to_call`, `makes_decorate_call`,
   `intrinsic_alias`) are useful fact/selector vocabulary, but are bridge
-  implementations until they fold into derived predicates. See
+  implementations until they fold into derived predicates. The solver-backend
+  pivot has landed far enough that production materialization now uses the
+  protobuf CP-SAT sidecar for the supported subset; the remaining priority is
+  language coverage, not another exact-assignment backend switch. See
   <debug/2026_06_19_p4_debt_worklist.md> for real-spec evidence.
 - <plans/automated_spec_workflows.md> — **active design, downstream of P0.**
   North-star for the inventory/plan/apply/validate CLI surface and the
@@ -121,13 +124,12 @@ this list as the dispatch summary, not a second plan.
 
 1. **Wire the exact-assignment backend.** The backend-neutral
    `SelectorConstraintModel`, backend problem contract, CP-SAT sidecar,
-   generated Rust proto bindings, Rust backend adapter, and opt-in production
-   selector backend switch are in flight through #2536/#2537. The anonymized
+   generated Rust proto bindings, Rust backend adapter, and production
+   materialization hook have landed for the supported subset. The anonymized
    broad-vs-specific injectivity fixture resolves through CP-SAT rather than
    `AssignmentRow` enumeration. Remaining work in this slice is to run the
-   supported subset against real Gaffer evidence through the opt-in backend and
-   make CP-SAT the default only after alpha-all/hole coverage stops blocking the
-   real Tana spec.
+   supported subset against real Gaffer evidence and use its unsupported-form
+   failures to drive native selector-language coverage.
 2. **Keep Ascent on fact/table derivation, not exact assignment.** Ascent may
    continue deriving relation support and allowed tuples, but exact target
    assignment must be owned by OR-Tools CP-SAT or a measured SAT fallback with
@@ -321,12 +323,11 @@ applied. The applied items (the empty-arm collapse, the `Resolution`
   the passes have genuinely different resolution-builder signatures
   (`member_of_module` needs `import_sources`; others do not), different anchor
   sources (`resolved_anchor_bindings` vs `claimed_member_bindings` vs none),
-  different per-primitive kernel calls and `with_context` closures, and each
-  call site carries a distinct `time_phase!` timing label. If attempted,
-  preserve every `time_phase!` label and keep the per-primitive bits legible
-  (shared-helper route, not a code-gen macro). The per-resolver
-  `#[allow(clippy::too_many_arguments)]`s only become removable once the
-  standalone resolvers disappear into the loop.
+  and different per-primitive kernel calls and `with_context` closures. If
+  attempted, keep the per-primitive bits legible (shared-helper route, not a
+  code-gen macro), and profile with external tools if runtime changes are in
+  question. The per-resolver `#[allow(clippy::too_many_arguments)]`s only
+  become removable once the standalone resolvers disappear into the loop.
 
 ## Excalidraw live-browser smoke
 

--- a/devinfra/js/debundle/chunk_factorization.rs
+++ b/devinfra/js/debundle/chunk_factorization.rs
@@ -65,7 +65,7 @@ impl ChunkFactorization {
     ///
     /// Panics on facts where two statements declare the same binding
     /// (`analysis::DuplicateTopLevelDeclaration`) — the production
-    /// path goes through `compute_stage_one_analysis`, which surfaces
+    /// path goes through `compute_chunk_analysis`, which surfaces
     /// that as a spec-facing error before any factorization runs.
     pub fn build(
         chunk_id: String,

--- a/devinfra/js/debundle/docs/design.md
+++ b/devinfra/js/debundle/docs/design.md
@@ -976,7 +976,7 @@ output, the Vite ecosystem, and most React/Vue/Angular SPAs.
   scope at the call site; the static analyzer cannot see what it
   references; `I` would be incomplete. **Enforced (partially)**: the
   input-chunk admission scan (`chunk_admission`, run by
-  `stage_one::compute_stage_one_analysis` next to the A2 bail)
+  `stage_one::compute_chunk_analysis` next to the A2 bail)
   rejects direct `eval(...)` and seq-indirect `(0, eval)(...)` calls
   at module top level (looking through parens and comma sequences to
   the callee), with the offending statement ordinal in the
@@ -992,7 +992,7 @@ output, the Vite ecosystem, and most React/Vue/Angular SPAs.
   `facts::analyze_chunk_structural` records the first module-top
   `AwaitExpr`, excluding lazy positions like
   function/arrow/method/getter/setter bodies and instance class
-  fields), and `stage_one::compute_stage_one_analysis` `bail!`s
+  fields), and `stage_one::compute_chunk_analysis` `bail!`s
   with the offending statement ordinal as soon as fact analysis
   returns — before any quotient or lowering work. Production
   chunks we target are TLA-free in practice; the rejection turns
@@ -1211,12 +1211,12 @@ member names`, it projects onto each importing chunk's local binding
 
 A1–A5 are statically checkable on each chunk, and each now has an
 enforced core. A2 is enforced by the TLA scan inside fact analysis —
-`stage_one::compute_stage_one_analysis` `bail!`s with the offending
+`stage_one::compute_chunk_analysis` `bail!`s with the offending
 statement ordinal as soon as fact analysis returns, before any
 quotient or lowering work. A1, A3, and A5 are enforced (to the
 per-assumption strengths described above) by the input-chunk
 admission scan in `chunk_admission`, which
-`compute_stage_one_analysis` runs right after the A2 bail; its
+`compute_chunk_analysis` runs right after the A2 bail; its
 diagnostics carry the chunk id, the offending statement ordinal,
 and the matched shape. A4 is enforced at parse time. The admission
 scan is on by default for every materialized chunk; for audited
@@ -1380,7 +1380,7 @@ It does not establish:
   different evaluation algorithm (`InnerModuleEvaluation` returns
   a Promise; cyclic async-module groups have AsyncCycleRoot
   semantics). A separate proof would be needed; instead the
-  materializer refuses TLA chunks explicitly (the Stage A bail
+  materializer refuses TLA chunks explicitly (the chunk-analysis bail
   described under A2 above).
 - **Dynamic eval / reflection bypassing the static graph (A1, A5
   violations).** The `I` graph is incomplete in this case;
@@ -1507,35 +1507,36 @@ as `ExternalChunk(_)` leaves in the per-chunk graph. **Future
 work**: a multi-chunk lift would have `validate_factorization` take a
 `BTreeMap<ChunkId, ChunkFactorization>` and walk the union graph.
 
-### Pipeline split (Stage A / Stage B)
+### Pipeline split (chunk analysis / materialization)
 
 The per-chunk pipeline is two halves with sharply different
 dependencies:
 
-- **Stage A** (spec-independent): parse → per-statement facts →
+- **Chunk analysis** (spec-independent): parse → per-statement facts →
   owner graph → structural atomic units. Pure function of
   `(source bytes, analysis hints, OwnerGraphOptions)`. The composer
-  is `stage_one::compute_stage_one_analysis`, returning a
-  `StageOneAnalysis` that bundles `ChunkFactAnalysis` (facts +
+  is `stage_one::compute_chunk_analysis`, returning a
+  `ChunkAnalysis` that bundles `ChunkFactAnalysis` (facts +
   top-level-await detection + redundant-hint warnings) with the
   `OwnerGraphAndUnits` derived from those facts.
-- **Stage B** (spec-dependent): assemble the partition from the
+- **Materialization** (spec-dependent): assemble the partition from the
   spec's binding claims, run the realizability gate, lower to ESM.
   Today this lives inline in `lowering::materialize_logical_chunk`.
 
 The materializer is the composition of both. Current code materializes
-Stage A in-memory through one named call site. Keep that shape: it makes
-the boundary explicit without committing the pipeline to cross-process
-fact reuse. If future work tries to cache Stage A across processes, it
-must first solve SWC hygiene replay for pre-filter facts; see
+chunk analysis in-memory through one named call site. Keep that shape:
+it makes the boundary explicit without committing the pipeline to
+cross-process fact reuse. If future work tries to cache chunk analysis
+across processes, it must first solve SWC hygiene replay for pre-filter
+facts; see
 `docs/wire_format.md` and `docs/lessons_learned/cross_process_stage_b.md`.
 
 The reason to call this out: every diagnostic in §"Two classes of
-atom" lives in Stage B (it depends on the spec's quotient), but its
-inputs all come from Stage A. Refactors that move work between the
-two halves must respect the boundary — anything spec-dependent
-cannot move into Stage A; anything that only depends on source bytes
-should not stay in Stage B.
+atom" lives in materialization (it depends on the spec's quotient), but
+its inputs all come from chunk analysis. Refactors that move work
+between the two halves must respect the boundary — anything
+spec-dependent cannot move into chunk analysis; anything that only
+depends on source bytes should not stay in materialization.
 
 ### Two classes of atom
 

--- a/devinfra/js/debundle/docs/lessons_learned/cross_process_stage_b.md
+++ b/devinfra/js/debundle/docs/lessons_learned/cross_process_stage_b.md
@@ -8,7 +8,7 @@ spec edits hit only Stage B; Stage A's expensive parse + analysis
 gets cached.
 
 The plan landed partially — the structural composer
-(`stage_one/mod.rs::compute_stage_one_analysis`) and the on-disk
+(`stage_one/mod.rs::compute_chunk_analysis`) and the on-disk
 sidecars (`reports/tree/<chunk_id>/chunk_analysis/{facts,
 atomic_units,manifest}.json`) shipped. **The cross-process consumer
 never did, and the design is abandoned.** This note records why, so
@@ -108,10 +108,10 @@ doesn't justify it.
 
 ## What we kept
 
-The composer pattern survived: `compute_stage_one_analysis` is a
+The composer pattern survived: `compute_chunk_analysis` is a
 clean function that runs parse → facts → owner-graph → atomic-units
 behind one named call. Its value is **structural readability** —
-the materializer reads more cleanly when Stage A is a single
+the materializer reads more cleanly when chunk analysis is a single
 function call rather than four inline stages — not cross-process
 caching.
 

--- a/devinfra/js/debundle/e2e/chunk_admission_test.rs
+++ b/devinfra/js/debundle/e2e/chunk_admission_test.rs
@@ -127,7 +127,7 @@ export { A, lazyByName, loadVendor };
 fn with_block_is_rejected_at_parse() {
     // Module code is strict per ECMA-262, and the parser surfaces
     // `with` as a recoverable parse error that fails chunk loading —
-    // so A4 never reaches the Stage A admission scan and needs no AST
+    // so A4 never reaches the chunk-analysis admission scan and needs no AST
     // check there. This test pins the parse-time rejection (and that
     // the error message names the strict-mode `with` ban, not just an
     // opaque error count).

--- a/devinfra/js/debundle/facts/analyze.rs
+++ b/devinfra/js/debundle/facts/analyze.rs
@@ -69,11 +69,11 @@ impl Visit for TopLevelAwaitFinder {
 /// [`analyze_chunk_with_policy`].
 ///
 /// **Cross-pass sharing**: this layer is NOT shareable across the two
-/// `analyze_chunk` call sites (Stage A composer vs `vendor::strip`)
+/// `analyze_chunk` call sites (chunk-analysis composer vs `vendor::strip`)
 /// because they analyze different `Module` values. Vendor strip
 /// reparses the emitted chunk file from disk and then mutates it
 /// (`split_top_level_var_decls`, `strip_export_specifiers`) before
-/// analyzing; Stage A analyzes the in-memory lowered runtime AST.
+/// analyzing; chunk analysis analyzes the in-memory lowered runtime AST.
 /// Even ignoring the reparse, `strip_export_specifiers` rewrites
 /// `ExportNamed` items and folds `ExportDecl` into `Stmt::Decl`, which
 /// changes the body view that `top_level_item_views` produces. So this

--- a/devinfra/js/debundle/facts/wire.rs
+++ b/devinfra/js/debundle/facts/wire.rs
@@ -12,10 +12,10 @@
 //! conversion functions.
 //!
 //! These types are not serialized. An earlier design serialized them
-//! as a per-chunk `facts.json` sidecar so a separate-process Stage B
-//! could consume Stage A's cached output. That plan was abandoned —
-//! the `ctxt` is `Globals`-local and the rejected alternatives are
-//! all unsound or value-less. See
+//! as a per-chunk `facts.json` sidecar so a separate-process
+//! materializer could consume cached chunk-analysis output. That plan
+//! was abandoned — the `ctxt` is `Globals`-local and the rejected
+//! alternatives are all unsound or value-less. See
 //! `docs/lessons_learned/cross_process_stage_b.md`.
 
 use std::collections::BTreeSet;

--- a/devinfra/js/debundle/graph/tests.rs
+++ b/devinfra/js/debundle/graph/tests.rs
@@ -336,7 +336,7 @@ mod edge_role_wire_format_tests {
     /// JSON serialization shape: a `Direct` role omits the `role`
     /// field; a `PromotedAtInit` role nests `{kind: "promoted_at_init",
     /// callee_owner: "owner:N"}`. This pins the wire encoding so
-    /// callers (Stage A artifact readers) don't drift.
+    /// callers (chunk-analysis artifact readers) don't drift.
     #[test]
     fn role_json_shape_pinned() {
         let direct_report = OwnerGraphEdgeReport {

--- a/devinfra/js/debundle/lib.rs
+++ b/devinfra/js/debundle/lib.rs
@@ -13,8 +13,8 @@
 //! 4. Emit stable graph reports from that same graph model (`reports`).
 //!
 //! Realizability checking and factorization validation live in the
-//! `gate` crate; the spec-independent per-chunk Stage A composer lives
-//! in the `stage_one` crate. Both build on this core.
+//! `gate` crate; the spec-independent per-chunk chunk-analysis
+//! composer lives in the `stage_one` crate. Both build on this core.
 
 pub mod analysis_hints;
 pub mod atomic_units;

--- a/devinfra/js/debundle/lowering/exports.rs
+++ b/devinfra/js/debundle/lowering/exports.rs
@@ -187,16 +187,13 @@ pub(super) fn reject_duplicate_export_names(
 
 /// Reject two members of one logical module claiming the same source binding.
 ///
-/// Only members with a resolved (non-empty) `binding` participate: every selector
-/// form (`source_match`, `cross_ref`, `reads_member`, `member_of_module`,
-/// `passed_to_call`, `makes_decorate_call`) carries an empty `binding` until its
-/// dedicated resolution pass fills it in (see `MemberRequest`), and this gate runs
-/// before those passes. Grouping the still-empty bindings here would collapse every
-/// unresolved selector member in a module into one bogus `<unresolved>` claim —
-/// e.g. two `cross_ref` members anchored in their own module would falsely clash
-/// before either resolved. Duplicate claims among resolved selector members are
-/// caught later, against their real bindings, in
-/// `ChunkPlanBuilder::claim_post_stage_a_binding`.
+/// Only members with a known binding spelling participate. Relational and
+/// source-match selectors generally carry an empty `binding` until their
+/// post-analysis pass resolves them; grouping those still-empty bindings here
+/// would collapse every unresolved selector member in a module into one bogus
+/// `<unresolved>` claim. Plain `selector.binding` members keep their known
+/// spelling even though ownership is now solver-resolved, so duplicate authored
+/// binding claims still fail before the expensive path.
 pub(super) fn reject_duplicate_member_bindings(
     operation: &str,
     id: &str,
@@ -204,7 +201,7 @@ pub(super) fn reject_duplicate_member_bindings(
 ) -> Result<()> {
     let mut by_binding = BTreeMap::<String, Vec<&MemberRequest>>::new();
     for member in members {
-        if member.resolves_after_stage_a() {
+        if member.binding.is_empty() {
             continue;
         }
         by_binding

--- a/devinfra/js/debundle/lowering/lower.rs
+++ b/devinfra/js/debundle/lowering/lower.rs
@@ -20,7 +20,6 @@ use super::scope_names::{
 };
 use super::util::remaining_item_after_selection;
 use super::*;
-use crate::time_phase;
 
 pub(super) const ENTRY_IMPORT_LOCAL_CONTRIBUTOR: &str = "entry import-local disambiguation";
 
@@ -36,7 +35,6 @@ pub(super) struct LoweredChunk {
     /// time across this chunk's module bodies (see
     /// `vendor_imports::plan_vendor_reimports`).
     pub(super) vendor_reference_rewrites: BTreeMap<(ChunkId, String), usize>,
-    pub(super) timings: PhaseTimings,
 }
 
 /// Chunk-identity + file-path inputs to `lower_chunk`. Held in
@@ -153,25 +151,20 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
     let is_module_owned = |name: &str| -> bool {
         binding_assignment.contains_key(&top_level_id(name, chunk_top_level_mark))
     };
-    let mut timings = PhaseTimings::default();
-    let selected_ordinals = time_phase!(timings, "compute_selected_ordinals", {
-        compute_selected_ordinals(
-            declarations,
-            binding_assignment,
-            anonymous_ordinal_assignment,
-        )
-    });
+    let selected_ordinals = compute_selected_ordinals(
+        declarations,
+        binding_assignment,
+        anonymous_ordinal_assignment,
+    );
 
     let mut selected_by_module = vec![Vec::<ModuleItem>::new(); module_plans.len()];
     let mut selected_exports_by_module =
         vec![Option::<BTreeMap<String, String>>::None; module_plans.len()];
-    time_phase!(timings, "plan_selected_exports", {
-        plan_selected_exports(
-            module_plans,
-            &is_module_owned,
-            &mut selected_exports_by_module,
-        );
-    });
+    plan_selected_exports(
+        module_plans,
+        &is_module_owned,
+        &mut selected_exports_by_module,
+    );
 
     let mut entry_body = Vec::new();
     let import_insert_index = runtime_ast
@@ -180,16 +173,14 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
         .iter()
         .take_while(|item| matches!(item, ModuleItem::ModuleDecl(ModuleDecl::Import(_))))
         .count();
-    time_phase!(timings, "split_entry_body", {
-        split_entry_body(
-            &runtime_ast.module.body,
-            &selected_ordinals,
-            anonymous_ordinal_assignment,
-            binding_assignment,
-            &mut entry_body,
-            &mut selected_by_module,
-        )
-    })?;
+    split_entry_body(
+        &runtime_ast.module.body,
+        &selected_ordinals,
+        anonymous_ordinal_assignment,
+        binding_assignment,
+        &mut entry_body,
+        &mut selected_by_module,
+    )?;
     // Two passes: build entry imports in plan order (so the
     // first plan to claim a binding wins disambiguation), then
     // order them through the shared `EsmImportOrder` so ECMA-262's
@@ -198,7 +189,6 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
     // the import-collision contract while satisfying Lemma 2's
     // emit-side constraint. See docs/design.md "Module dep graphs"
     // and "Lemma 2".
-    let build_entry_imports_started = Instant::now();
     let mut entry_imports: Vec<(ModuleId, ModuleItem)> = Vec::new();
     // Entry-side renames flow through ONE per-chunk ledger sealed once:
     // the chunk_renames entries staying in entry (Explicit, Chunk scope),
@@ -326,7 +316,6 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
         .import_order()
         .sort_entry_imports(&mut entry_imports);
     let entry_imports: Vec<ModuleItem> = entry_imports.into_iter().map(|(_, it)| it).collect();
-    timings.add("build_entry_imports", build_entry_imports_started.elapsed());
     // Capture probe: a read-only walk of the un-renamed entry body with
     // the pending Chunk-scope map, reporting the precise capture facts
     // seal validates (a target bound nested is harmless when the source
@@ -336,16 +325,11 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
     let entry_candidate_renames = entry_ledger.pending_renames_by_name(&RenameScope::Chunk);
     let mut entry_captured = BTreeSet::new();
     if !entry_candidate_renames.is_empty() {
-        let probe_entry_captures_started = Instant::now();
         let mut probe = RenameCaptureProbe::new(&entry_candidate_renames);
         for item in entry_body.iter() {
             item.visit_with(&mut probe);
         }
         entry_captured = probe.captured;
-        timings.add(
-            "probe_entry_captures",
-            probe_entry_captures_started.elapsed(),
-        );
     }
     // Naturalize every moved body up front and cache the per-plan
     // local renames + post-naturalize body facts. Both
@@ -366,26 +350,22 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
     let mut local_renames_by_module: Vec<NaturalizedRenames> =
         Vec::with_capacity(module_plans.len());
     let mut body_facts_by_module: Vec<ModuleBodyFacts> = Vec::with_capacity(module_plans.len());
-    time_phase!(timings, "module.naturalize_body", {
-        for (index, plan) in module_plans.iter().enumerate() {
-            let mut body = std::mem::take(&mut selected_by_module[index]);
-            let plan_driven = sealed_renames.module_renames_by_name(ModuleId::logical(index));
-            let renames = naturalize_module_body(
-                &mut body,
-                plan,
-                ModuleId::logical(index),
-                plan_driven,
-                chunk_top_level_mark,
-            )?;
-            naturalized_bodies.push(body);
-            local_renames_by_module.push(renames);
-        }
-    });
-    time_phase!(timings, "module.collect_body_facts", {
-        for body in &naturalized_bodies {
-            body_facts_by_module.push(collect_module_body_facts(body));
-        }
-    });
+    for (index, plan) in module_plans.iter().enumerate() {
+        let mut body = std::mem::take(&mut selected_by_module[index]);
+        let plan_driven = sealed_renames.module_renames_by_name(ModuleId::logical(index));
+        let renames = naturalize_module_body(
+            &mut body,
+            plan,
+            ModuleId::logical(index),
+            plan_driven,
+            chunk_top_level_mark,
+        )?;
+        naturalized_bodies.push(body);
+        local_renames_by_module.push(renames);
+    }
+    for body in &naturalized_bodies {
+        body_facts_by_module.push(collect_module_body_facts(body));
+    }
     // Auto-grow entry's export list for any residual binding a
     // moved module body references. Without this, the per-module
     // emit path below would surface a "moved module references
@@ -403,27 +383,25 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
     // with the source-level public names so the grown names suffix past
     // them. Intents are keyed by the residual binding's ORIGINAL name;
     // the emitted clause remaps to entry's post-rename local below.
-    time_phase!(timings, "collect_export_growth", {
-        let entry_declared_names: HashSet<String> = entry_body
-            .iter()
-            .flat_map(|item| top_level_declaration_names(item).0)
-            .collect();
-        entry_ledger.seed_taken(
-            RenameScope::EntryPublicExports,
-            pre_existing_public_export_names.iter().cloned(),
-        );
-        auto_grown_residual_exports(
-            &body_facts_by_module,
-            &ExportGrowthFacts {
-                declaration_by_name,
-                binding_assignment,
-                pre_existing_entry_exports,
-                entry_declared_names: &entry_declared_names,
-            },
-            chunk_top_level_mark,
-            &mut entry_ledger,
-        );
-    });
+    let entry_declared_names: HashSet<String> = entry_body
+        .iter()
+        .flat_map(|item| top_level_declaration_names(item).0)
+        .collect();
+    entry_ledger.seed_taken(
+        RenameScope::EntryPublicExports,
+        pre_existing_public_export_names.iter().cloned(),
+    );
+    auto_grown_residual_exports(
+        &body_facts_by_module,
+        &ExportGrowthFacts {
+            declaration_by_name,
+            binding_assignment,
+            pre_existing_entry_exports,
+            entry_declared_names: &entry_declared_names,
+        },
+        chunk_top_level_mark,
+        &mut entry_ledger,
+    );
     // Seal the chunk ledger: the single validation point for every
     // entry-side rename. Chunk scope: conflicting targets (target name
     // already taken by a body local that isn't being renamed away, or
@@ -433,30 +411,28 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
     // silently. EntryPublicExports scope: a single contributor over a
     // set-deduped source set cannot conflict; the occupancy check
     // asserts the mints stayed clear of pre-existing public names.
-    let sealed_entry_renames = time_phase!(timings, "seal_entry_ledger", {
-        entry_ledger.seal(&SealValidation {
-            occupancy: BTreeMap::from([
-                (
-                    RenameScope::Chunk,
-                    ScopeOccupancy::Body {
-                        label: chunk_id.to_string(),
-                        root: entry_root_names,
-                        nested: entry_nested_names,
-                        captured: entry_captured,
-                    },
-                ),
-                (
-                    RenameScope::EntryPublicExports,
-                    ScopeOccupancy::Body {
-                        label: chunk_id.to_string(),
-                        root: pre_existing_public_export_names.iter().cloned().collect(),
-                        nested: BTreeSet::new(),
-                        captured: BTreeSet::new(),
-                    },
-                ),
-            ]),
-            reserved: BTreeSet::new(),
-        })
+    let sealed_entry_renames = entry_ledger.seal(&SealValidation {
+        occupancy: BTreeMap::from([
+            (
+                RenameScope::Chunk,
+                ScopeOccupancy::Body {
+                    label: chunk_id.to_string(),
+                    root: entry_root_names,
+                    nested: entry_nested_names,
+                    captured: entry_captured,
+                },
+            ),
+            (
+                RenameScope::EntryPublicExports,
+                ScopeOccupancy::Body {
+                    label: chunk_id.to_string(),
+                    root: pre_existing_public_export_names.iter().cloned().collect(),
+                    nested: BTreeSet::new(),
+                    captured: BTreeSet::new(),
+                },
+            ),
+        ]),
+        reserved: BTreeSet::new(),
     })?;
     let entry_binding_renames = sealed_entry_renames.scope_renames_by_name(&RenameScope::Chunk);
     debug_assert_eq!(
@@ -471,7 +447,6 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
     // renamer visits the rest. The probe above already fed seal the walk's
     // capture verdict, so a capture here means probe and executor diverged.
     if !entry_binding_renames.is_empty() {
-        let rename_entry_body_started = Instant::now();
         for item in entry_body.iter_mut() {
             preserve_export_specifier_names(item, &entry_binding_renames);
         }
@@ -484,58 +459,45 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
             "entry rename executor captured despite seal validation: {:?}",
             renamer.captured,
         );
-        timings.add("rename_entry_body", rename_entry_body_started.elapsed());
     }
     if !entry_imports.is_empty() {
-        let splice_entry_imports_started = Instant::now();
         let tail = entry_body.split_off(import_insert_index);
         entry_body.extend(entry_imports);
         entry_body.extend(tail);
-        timings.add(
-            "splice_entry_imports",
-            splice_entry_imports_started.elapsed(),
-        );
     }
-    time_phase!(timings, "entry_exports_and_trim", {
-        for export in entry_exports_for_moved_bindings(
-            declarations,
-            binding_assignment,
-            &entry_binding_renames,
-        ) {
-            entry_body.push(export);
-        }
-        // The sealed EntryPublicExports map is keyed by the residual
-        // binding's original name; the emitted export clause is keyed by
-        // entry's post-rename local, so remap through
-        // `entry_binding_renames` at application.
-        let auto_grow: BTreeMap<String, String> = sealed_entry_renames
-            .scope_renames_by_name(&RenameScope::EntryPublicExports)
-            .into_iter()
-            .map(|(original, public_name)| {
-                (
-                    entry_binding_renames
-                        .get(&original)
-                        .cloned()
-                        .unwrap_or(original),
-                    public_name,
-                )
-            })
-            .collect();
-        if !auto_grow.is_empty() {
-            entry_body.push(export_named_for_bindings(&auto_grow));
-        }
-        trim_dead_named_specifiers(&mut entry_body, factorization.analysis.bindings());
-    });
-    let entry_exports_by_original_local = time_phase!(timings, "collect_entry_exports", {
-        collect_entry_exports_by_original_local(
-            &entry_body,
-            &entry_binding_renames,
-            chunk_top_level_mark,
-        )
-    });
-    let imported_reexports_by_module = time_phase!(timings, "collect_imported_reexports", {
-        collect_imported_reexports_by_module(factorization, module_plans.len())
-    });
+    for export in
+        entry_exports_for_moved_bindings(declarations, binding_assignment, &entry_binding_renames)
+    {
+        entry_body.push(export);
+    }
+    // The sealed EntryPublicExports map is keyed by the residual
+    // binding's original name; the emitted export clause is keyed by
+    // entry's post-rename local, so remap through
+    // `entry_binding_renames` at application.
+    let auto_grow: BTreeMap<String, String> = sealed_entry_renames
+        .scope_renames_by_name(&RenameScope::EntryPublicExports)
+        .into_iter()
+        .map(|(original, public_name)| {
+            (
+                entry_binding_renames
+                    .get(&original)
+                    .cloned()
+                    .unwrap_or(original),
+                public_name,
+            )
+        })
+        .collect();
+    if !auto_grow.is_empty() {
+        entry_body.push(export_named_for_bindings(&auto_grow));
+    }
+    trim_dead_named_specifiers(&mut entry_body, factorization.analysis.bindings());
+    let entry_exports_by_original_local = collect_entry_exports_by_original_local(
+        &entry_body,
+        &entry_binding_renames,
+        chunk_top_level_mark,
+    );
+    let imported_reexports_by_module =
+        collect_imported_reexports_by_module(factorization, module_plans.len());
     let source_import_cache = Mutex::new(ArtifactSourceImportResolutionCache::new(
         artifact,
         artifact_indexes,
@@ -589,11 +551,6 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
     // `module.naturalize_body` / `module.collect_body_facts` passes
     // above); the per-plan worker just consumes them.
     //
-    // `PhaseTimings` is a per-iteration local; merged into the chunk-
-    // level `timings` once the parallel work completes. `time_phase!`
-    // requires `&mut PhaseTimings`, which the per-iter local
-    // satisfies.
-    //
     // `swc_common::GLOBALS` is a `scoped_tls` thread-local; it does
     // NOT carry into rayon worker threads, so we capture the parent
     // thread's `Globals` and re-set it inside each worker closure.
@@ -645,9 +602,6 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
         for (key, count) in output.vendor_reference_rewrites {
             *vendor_reference_rewrites.entry(key).or_insert(0) += count;
         }
-        for (name, duration) in output.timings.durations {
-            timings.add(name, duration);
-        }
     }
 
     Ok(LoweredChunk {
@@ -655,7 +609,6 @@ pub(super) fn lower_chunk(inputs: LowerChunkInputs<'_>) -> Result<LoweredChunk> 
         file_records,
         applied,
         vendor_reference_rewrites,
-        timings,
     })
 }
 
@@ -765,7 +718,6 @@ struct LoweredModuleOutput {
     record: (String, FileRole),
     lowering: SelectedModuleLowering,
     vendor_reference_rewrites: BTreeMap<(ChunkId, String), usize>,
-    timings: PhaseTimings,
 }
 
 fn lower_single_plan(inputs: LowerSinglePlanInputs<'_>) -> Result<LoweredModuleOutput> {
@@ -792,31 +744,28 @@ fn lower_single_plan(inputs: LowerSinglePlanInputs<'_>) -> Result<LoweredModuleO
         runtime_ast,
         vendor_import_oracle,
     } = inputs;
-    let mut timings = PhaseTimings::default();
     let ModuleReferenceNeeds {
         cross_module_imports_by_provider,
         residual_entry_imports,
         missing_residual_exports,
         runtime_reimports,
         phantom_side_effect_providers,
-    } = time_phase!(timings, "module.plan_references", {
-        plan_module_reference_needs(
-            index,
-            body_facts,
-            factorization,
-            declaration_by_name,
-            binding_assignment,
-            entry_exports_by_original_local,
-            RuntimeImportLookup {
-                imports: runtime_import_facts,
-                original_by_renamed: local_renames
-                    .merged
-                    .iter()
-                    .map(|(pre, post)| (post.clone(), pre.clone()))
-                    .collect(),
-            },
-        )
-    });
+    } = plan_module_reference_needs(
+        index,
+        body_facts,
+        factorization,
+        declaration_by_name,
+        binding_assignment,
+        entry_exports_by_original_local,
+        RuntimeImportLookup {
+            imports: runtime_import_facts,
+            original_by_renamed: local_renames
+                .merged
+                .iter()
+                .map(|(pre, post)| (post.clone(), pre.clone()))
+                .collect(),
+        },
+    );
     // Import-local mints for this plan's body flow through a per-plan
     // ledger (scope: this plan's `Module`, origin: `ImportInduced`);
     // the ledger's taken-name set is seeded with every name bound
@@ -843,35 +792,29 @@ fn lower_single_plan(inputs: LowerSinglePlanInputs<'_>) -> Result<LoweredModuleO
     // import order and the gate's predicted evaluation order cannot
     // diverge. See `esm_import_order` and
     // `accepted_spec_runs_under_node_test::early_entry_importer_…`.
-    let mut intra_chunk_imports = time_phase!(timings, "module.build_cross_imports", {
-        cross_module_imports_for_plan(
-            &plan.target_file,
-            cross_module_imports_by_provider,
-            factorization,
-            &mut import_rename_sink,
-        )
-    });
+    let mut intra_chunk_imports = cross_module_imports_for_plan(
+        &plan.target_file,
+        cross_module_imports_by_provider,
+        factorization,
+        &mut import_rename_sink,
+    );
     // Phantom side-effect imports surface at-init-promotion-derived
     // constraining edges as real ESM imports so the linker's DFS
     // visits the provider modules as dependencies. See
     // `phantom_side_effect_imports`.
-    time_phase!(timings, "module.build_phantom_imports", {
-        intra_chunk_imports.extend(phantom_side_effect_imports(
-            &plan.target_file,
-            phantom_side_effect_providers,
-            factorization,
-        ));
-    });
-    let residual_entry_import_items = time_phase!(timings, "module.build_residual_imports", {
-        residual_entry_imports_for_moved_body(
-            &plan.id,
-            entry_file,
-            &plan.target_file,
-            residual_entry_imports,
-            missing_residual_exports,
-            &mut import_rename_sink,
-        )
-    })?;
+    intra_chunk_imports.extend(phantom_side_effect_imports(
+        &plan.target_file,
+        phantom_side_effect_providers,
+        factorization,
+    ));
+    let residual_entry_import_items = residual_entry_imports_for_moved_body(
+        &plan.id,
+        entry_file,
+        &plan.target_file,
+        residual_entry_imports,
+        missing_residual_exports,
+        &mut import_rename_sink,
+    )?;
     // Seal the per-plan import ledger; the Module-scope projection is
     // the import-local rename map the pre-ledger code accumulated
     // across the two minting passes above. Seal asserts the mints
@@ -916,15 +859,13 @@ fn lower_single_plan(inputs: LowerSinglePlanInputs<'_>) -> Result<LoweredModuleO
         external_imports: vendor_external_imports,
         body_rewrites: vendor_body_rewrites,
         references_rewritten: mut vendor_reference_rewrites,
-    } = time_phase!(timings, "module.plan_vendor_reimports", {
-        plan_vendor_reimports(
-            runtime_reimports,
-            vendor_import_oracle,
-            chunk_id_interned,
-            entry_file,
-            &plan.target_file,
-        )
-    });
+    } = plan_vendor_reimports(
+        runtime_reimports,
+        vendor_import_oracle,
+        chunk_id_interned,
+        entry_file,
+        &plan.target_file,
+    );
     // Re-import any source-chunk import-specifier-bound locals that
     // moved code in `body` references but no top-level decl
     // satisfies (e.g. `const { decode } = gge;` where `gge` was an
@@ -935,7 +876,7 @@ fn lower_single_plan(inputs: LowerSinglePlanInputs<'_>) -> Result<LoweredModuleO
     // `source_import_cache` is shared across parallel per-plan
     // workers; the `Mutex` serialises the BTreeMap lookups but the
     // critical section is short (a key lookup + possible insert).
-    let mut runtime_reimports = time_phase!(timings, "module.build_runtime_reimports", {
+    let mut runtime_reimports = {
         let mut cache = source_import_cache
             .lock()
             .expect("source_import_cache poisoned");
@@ -947,7 +888,7 @@ fn lower_single_plan(inputs: LowerSinglePlanInputs<'_>) -> Result<LoweredModuleO
             runtime_reimports,
             &imported_overrides,
         )
-    })?;
+    }?;
     // The residual-entry import targets the chunk's residual module
     // (the emitted entry file — always the ESM DFS root, so its slot
     // in the list is a runtime no-op, but it still gets its shared-
@@ -981,22 +922,20 @@ fn lower_single_plan(inputs: LowerSinglePlanInputs<'_>) -> Result<LoweredModuleO
     // producing two disagreeing local aliases for the same
     // upstream binding.
     if !cross_module_chunk_renames.is_empty() {
-        time_phase!(timings, "module.rename_chunk_renames", {
-            let mut renamer = IdentifierRenamer::new(cross_module_chunk_renames);
-            for item in body.iter_mut() {
-                item.visit_mut_with(&mut renamer);
-            }
-            if !renamer.captured.is_empty() {
-                // The entry-side chunk_renames validation only sees
-                // entry's post-split body; a target can still collide
-                // with a binding nested inside this moved module body.
-                bail!(
-                    "chunk_renames applied to module {} would be captured by a nested binding: {:?}",
-                    plan.id,
-                    renamer.captured,
-                );
-            }
-        });
+        let mut renamer = IdentifierRenamer::new(cross_module_chunk_renames);
+        for item in body.iter_mut() {
+            item.visit_mut_with(&mut renamer);
+        }
+        if !renamer.captured.is_empty() {
+            // The entry-side chunk_renames validation only sees
+            // entry's post-split body; a target can still collide
+            // with a binding nested inside this moved module body.
+            bail!(
+                "chunk_renames applied to module {} would be captured by a nested binding: {:?}",
+                plan.id,
+                renamer.captured,
+            );
+        }
     }
     // External package / facade imports join the runtime re-import
     // block after the retained chunk re-imports, deterministic in
@@ -1014,9 +953,7 @@ fn lower_single_plan(inputs: LowerSinglePlanInputs<'_>) -> Result<LoweredModuleO
         body.extend(vendor_external_imports);
         body.extend(tail);
     }
-    time_phase!(timings, "module.rewrite_runtime_sources", {
-        rewrite_runtime_sources_for_target(&mut body, chunk_id, entry_file, &plan.target_file);
-    });
+    rewrite_runtime_sources_for_target(&mut body, chunk_id, entry_file, &plan.target_file);
     // Plan-driven vendor body replacements (member accesses off the
     // package / facade namespace, named-kind auto-renames). Not a
     // RenameLedger entry — ident→member-expression replacement is an
@@ -1024,27 +961,25 @@ fn lower_single_plan(inputs: LowerSinglePlanInputs<'_>) -> Result<LoweredModuleO
     // plan-driven visitor sequenced after the sealed rename
     // application, like the runtime-URL rewrite above.
     if !vendor_body_rewrites.is_empty() {
-        time_phase!(timings, "module.vendor_body_rewrites", {
-            // `cross_module_chunk_renames` may have renamed an import
-            // local's sym in place (ctxt preserved); remap the keys so
-            // the replacement still matches the body's idents.
-            let bindings: BTreeMap<Id, vendor::IdentRewriteTarget> = vendor_body_rewrites
-                .into_iter()
-                .map(
-                    |(id, target)| match cross_module_chunk_renames.get(id.0.as_ref()) {
-                        Some(renamed) => ((renamed.as_str().into(), id.1), target),
-                        None => (id, target),
-                    },
-                )
-                .collect();
-            let mut rewriter = vendor::PartialSwapIdentRewriter {
-                bindings: &bindings,
-                references_by_symbol: &mut vendor_reference_rewrites,
-            };
-            for item in body.iter_mut() {
-                item.visit_mut_with(&mut rewriter);
-            }
-        });
+        // `cross_module_chunk_renames` may have renamed an import
+        // local's sym in place (ctxt preserved); remap the keys so
+        // the replacement still matches the body's idents.
+        let bindings: BTreeMap<Id, vendor::IdentRewriteTarget> = vendor_body_rewrites
+            .into_iter()
+            .map(
+                |(id, target)| match cross_module_chunk_renames.get(id.0.as_ref()) {
+                    Some(renamed) => ((renamed.as_str().into(), id.1), target),
+                    None => (id, target),
+                },
+            )
+            .collect();
+        let mut rewriter = vendor::PartialSwapIdentRewriter {
+            bindings: &bindings,
+            references_by_symbol: &mut vendor_reference_rewrites,
+        };
+        for item in body.iter_mut() {
+            item.visit_mut_with(&mut rewriter);
+        }
     }
     // ImportSpecifier-bound members (`BindingKind::Imported` in
     // `factorization.analysis.bindings()`): for each `Imported` binding whose
@@ -1053,76 +988,69 @@ fn lower_single_plan(inputs: LowerSinglePlanInputs<'_>) -> Result<LoweredModuleO
     // public-name export. Per-destination relative paths are
     // computed here so multiple modules at different output
     // depths each get a correctly-relativised path.
-    let import_member_exports = time_phase!(timings, "module.imported_reexports", {
-        let mut import_member_exports = BTreeMap::<String, String>::new();
-        let reexports = &imported_reexports_by_module[index];
-        if !reexports.is_empty() {
-            let import_count = body
+    let mut import_member_exports = BTreeMap::<String, String>::new();
+    let reexports = &imported_reexports_by_module[index];
+    if !reexports.is_empty() {
+        let import_count = body
+            .iter()
+            .take_while(|item| matches!(item, ModuleItem::ModuleDecl(ModuleDecl::Import(_))))
+            .count();
+        // `imported_from` on `BindingKind::Imported` is output-tree-
+        // rooted absolute; `plan.target_file` is chunk-rooted. Lift
+        // the destination to the same coordinate system before
+        // computing the relative path.
+        let dest_abs = join_module_path(&[chunk_id, &plan.target_file]);
+        // Group reexports by rewritten source so multiple bindings
+        // re-exported from the same import-from end up in a single
+        // `import { ... } from "<src>"` statement, not one statement
+        // per binding. All specifiers emitted here are Named, so the
+        // namespace-split rule in the shared grouper is a no-op for
+        // this path, but routing through it keeps the grouping logic
+        // single-sourced with `source_chunk_imports_for_moved_body`.
+        let mut pairs: Vec<(String, ImportSpecifier)> = Vec::with_capacity(reexports.len());
+        for reexport in reexports {
+            let src = relative_source(&dest_abs, &reexport.imported_from);
+            let specifier =
+                imported_binding_named_specifier(&reexport.local, &reexport.imported_name);
+            pairs.push((src, specifier));
+            import_member_exports.insert(reexport.local.clone(), reexport.public_name.clone());
+        }
+        let reexport_imports = group_specifiers_into_import_decls(pairs);
+        let tail = body.split_off(import_count);
+        body.extend(reexport_imports);
+        body.extend(tail);
+    }
+    if let Some(exports) = &selected_exports_by_module[index] {
+        // Export locals remap through the explicit map only: heuristic
+        // renames never rename the top-level declaration an export
+        // specifier refers to, so mapping through the merged map can
+        // emit `export { x as y }` for an `x` that was never declared
+        // (a load-time SyntaxError).
+        let mut exports = final_module_exports(exports, &local_renames.explicit);
+        exports.extend(
+            import_member_exports
                 .iter()
-                .take_while(|item| matches!(item, ModuleItem::ModuleDecl(ModuleDecl::Import(_))))
-                .count();
-            // `imported_from` on `BindingKind::Imported` is output-tree-
-            // rooted absolute; `plan.target_file` is chunk-rooted. Lift
-            // the destination to the same coordinate system before
-            // computing the relative path.
-            let dest_abs = join_module_path(&[chunk_id, &plan.target_file]);
-            // Group reexports by rewritten source so multiple bindings
-            // re-exported from the same import-from end up in a single
-            // `import { ... } from "<src>"` statement, not one statement
-            // per binding. All specifiers emitted here are Named, so the
-            // namespace-split rule in the shared grouper is a no-op for
-            // this path, but routing through it keeps the grouping logic
-            // single-sourced with `source_chunk_imports_for_moved_body`.
-            let mut pairs: Vec<(String, ImportSpecifier)> = Vec::with_capacity(reexports.len());
-            for reexport in reexports {
-                let src = relative_source(&dest_abs, &reexport.imported_from);
-                let specifier =
-                    imported_binding_named_specifier(&reexport.local, &reexport.imported_name);
-                pairs.push((src, specifier));
-                import_member_exports.insert(reexport.local.clone(), reexport.public_name.clone());
-            }
-            let reexport_imports = group_specifiers_into_import_decls(pairs);
-            let tail = body.split_off(import_count);
-            body.extend(reexport_imports);
-            body.extend(tail);
-        }
-        import_member_exports
-    });
-    time_phase!(timings, "module.final_exports", {
-        if let Some(exports) = &selected_exports_by_module[index] {
-            // Export locals remap through the explicit map only: heuristic
-            // renames never rename the top-level declaration an export
-            // specifier refers to, so mapping through the merged map can
-            // emit `export { x as y }` for an `x` that was never declared
-            // (a load-time SyntaxError).
-            let mut exports = final_module_exports(exports, &local_renames.explicit);
-            exports.extend(
-                import_member_exports
-                    .iter()
-                    .map(|(k, v)| (k.clone(), v.clone())),
-            );
-            body.push(export_named_for_bindings(&exports));
-        } else if !import_member_exports.is_empty() {
-            body.push(export_named_for_bindings(&import_member_exports));
-        }
-    });
-    let (file, record, lowering) = time_phase!(timings, "module.build_output_records", {
-        let output_context = ModuleOutputContext {
-            factorization,
-            runtime_ast,
-            chunk_top_level_mark,
-            chunk_id,
-            entry_file,
-            source_path,
-        };
-        build_module_output(plan, body, &local_renames.explicit, &output_context)
-    });
+                .map(|(k, v)| (k.clone(), v.clone())),
+        );
+        body.push(export_named_for_bindings(&exports));
+    } else if !import_member_exports.is_empty() {
+        body.push(export_named_for_bindings(&import_member_exports));
+    }
+    let output_context = ModuleOutputContext {
+        factorization,
+        runtime_ast,
+        chunk_top_level_mark,
+        chunk_id,
+        entry_file,
+        source_path,
+    };
+    let (file, record, lowering) =
+        build_module_output(plan, body, &local_renames.explicit, &output_context);
     Ok(LoweredModuleOutput {
         file,
         record,
         lowering,
         vendor_reference_rewrites,
-        timings,
     })
 }
 

--- a/devinfra/js/debundle/lowering/materialize/mod.rs
+++ b/devinfra/js/debundle/lowering/materialize/mod.rs
@@ -22,7 +22,6 @@ use plan_builder::{ChunkPlan, ChunkPlanBuilder, ExplicitRequestContext};
 use super::io::write_chunk_report_json;
 use super::util::{render_atomic_unit_cause_guidance, target_file_for_request};
 use super::*;
-use crate::time_phase;
 use js_ast::statement_ordinal_for_body_index;
 use output_layout::{
     ATOMIC_UNIT_CONFLICTS_REPORT, CYCLES_REPORT, OWNER_GRAPH_REPORT, SELECTOR_DIAGNOSTICS_REPORT,
@@ -139,18 +138,15 @@ pub(super) fn materialize_logical_chunk(
         .get(chunk_id)
         .with_context(|| format!("materialize_logical_modules unknown chunk: {chunk_id}"))?;
     emit_debundle_progress(chunk_id, "materialize_logical_chunk", "start");
-    let chunk_started = Instant::now();
-    let mut timings = PhaseTimings::default();
-    let target_file = time_phase!(timings, "resolve_entry", {
-        file.map(normalize_module_path)
-            .transpose()?
-            .or_else(|| get_chunk_entry_path(artifact, chunk_id_interned))
-            .with_context(|| {
-                format!(
-                    "materialize_logical_modules could not determine entry file for chunk: {chunk_id}"
-                )
-            })
-    })?;
+    let target_file = file
+        .map(normalize_module_path)
+        .transpose()?
+        .or_else(|| get_chunk_entry_path(artifact, chunk_id_interned))
+        .with_context(|| {
+            format!(
+                "materialize_logical_modules could not determine entry file for chunk: {chunk_id}"
+            )
+        })?;
     let runtime_file = artifact
         .js_chunk(chunk_id_interned)?
         .get_file(&target_file)
@@ -165,9 +161,7 @@ pub(super) fn materialize_logical_chunk(
     let chunk_top_level_mark = runtime_ast.top_level_mark;
     let header_lines = runtime_file.header_lines.clone();
     let source_path = runtime_file.metadata.source_path.clone();
-    let chunk_ast_analysis = time_phase!(timings, "analyze_chunk_ast", {
-        analyze_chunk_ast(&runtime_ast.module)
-    });
+    let chunk_ast_analysis = analyze_chunk_ast(&runtime_ast.module);
     let ChunkAstAnalysis {
         runtime_import_facts,
         declarations,
@@ -176,15 +170,13 @@ pub(super) fn materialize_logical_chunk(
         pre_existing_entry_exports,
         pre_existing_public_export_names,
     } = chunk_ast_analysis;
-    let requests = time_phase!(timings, "build_requests", {
-        logical_requests_for_chunk(
-            logical_modules.get(chunk_id),
-            &chunk_unassigned_mode,
-            chunk_renames.contains_key(chunk_id),
-            chunk_id,
-            target_dir,
-        )
-    })?;
+    let requests = logical_requests_for_chunk(
+        logical_modules.get(chunk_id),
+        &chunk_unassigned_mode,
+        chunk_renames.contains_key(chunk_id),
+        chunk_id,
+        target_dir,
+    )?;
     let mut explicit_requests = requests
         .iter()
         .filter(|request| !request.residual)
@@ -192,7 +184,6 @@ pub(super) fn materialize_logical_chunk(
         .collect::<Vec<_>>();
     let residual_request = requests.iter().find(|request| request.residual).cloned();
 
-    let build_module_plans_started = Instant::now();
     let mut builder = ChunkPlanBuilder::new(keep_going);
     let mut imported_binding_resolver =
         ArtifactSourceImportResolutionCache::new(artifact, artifact_indexes);
@@ -222,7 +213,6 @@ pub(super) fn materialize_logical_chunk(
         &declarations,
         target_dir,
     )?;
-    timings.add("build_module_plans", build_module_plans_started.elapsed());
 
     // Fetched before hints assembly: `local_property_effects` selects
     // the facts pass's local-effect policy, which travels in the hints.
@@ -230,7 +220,7 @@ pub(super) fn materialize_logical_chunk(
         .get(chunk_id)
         .copied()
         .unwrap_or_default();
-    let analysis_hints: AnalysisHints = time_phase!(timings, "collect_analysis_hints", {
+    let analysis_hints: AnalysisHints = {
         let mut hints = collect_analysis_hints(&explicit_requests, chunk_renames.get(chunk_id));
         hints.imported_purities = cross_module_purities
             .bindings
@@ -259,12 +249,10 @@ pub(super) fn materialize_logical_chunk(
         }
         hints.trusted_dataflow_summaries = owner_graph_options.trusted_dataflow_summaries;
         hints
-    });
-    let line_index = time_phase!(timings, "build_source_line_index", {
-        runtime_ast.line_index()
-    });
-    // Stage A: spec-independent analysis (facts + owner graph +
-    // structural atomic units). See `stage_one/mod.rs` for the composer.
+    };
+    let line_index = runtime_ast.line_index();
+    // Chunk analysis: spec-independent facts, owner graph, and structural
+    // atomic units. See `stage_one/mod.rs` for the current implementation.
     // A3 admission resolver: where does a dynamic-import specifier in
     // this chunk's entry land? Same artifact resolution the specifier
     // rewriter uses; `SameChunk` marks a debundled internal module.
@@ -281,72 +269,61 @@ pub(super) fn materialize_logical_chunk(
         Some(_) => DynamicImportTarget::OtherChunk,
         None => DynamicImportTarget::External,
     };
-    let stage_one = time_phase!(timings, "compute_stage_one_analysis", {
-        emit_debundle_progress(chunk_id, "compute_stage_one_analysis", "start");
-        let stage_one = compute_stage_one_analysis(
-            chunk_id,
-            &runtime_ast.module,
-            &analysis_hints,
-            Some(&source_path),
-            |span| line_index.line_range_for_span(span),
-            owner_graph_options,
-            &resolve_dynamic_import,
-        )?;
-        emit_debundle_progress(chunk_id, "compute_stage_one_analysis", "end");
-        stage_one
-    });
-    let StageOneAnalysis {
+    emit_debundle_progress(chunk_id, "compute_chunk_analysis", "start");
+    let chunk_analysis = compute_chunk_analysis(
+        chunk_id,
+        &runtime_ast.module,
+        &analysis_hints,
+        Some(&source_path),
+        |span| line_index.line_range_for_span(span),
+        owner_graph_options,
+        &resolve_dynamic_import,
+    )?;
+    emit_debundle_progress(chunk_id, "compute_chunk_analysis", "end");
+    let ChunkAnalysis {
         fact_analysis: analysis,
         owner_graph_and_units: precomputed,
-    } = stage_one;
+    } = chunk_analysis;
     // Global selector resolution: `add_explicit_request` left deferred selector
     // members unclaimed. Compile binding anchors, source_match constraints, and
-    // relational selectors into one IR program and run one Ascent solver pass over
-    // the owner graph + chunk AST relation facts.
+    // relational selectors into one IR program and solve over the owner graph +
+    // chunk AST relation facts.
     let import_sources: HashMap<String, String> = runtime_import_facts
         .iter_local_sources()
         .map(|(local, src)| (local.to_string(), src.to_string()))
         .collect();
-    time_phase!(timings, "resolve_global_selector_members", {
-        emit_debundle_progress(chunk_id, "resolve_global_selector_members", "start");
-        let result = builder.resolve_and_claim_global_selectors(
-            &explicit_requests,
-            &precomputed.owner_graph,
-            &runtime_ast.module,
-            &import_sources,
-            &runtime_import_facts,
-            &mut imported_binding_resolver,
-            &mut imported_from_by_src,
-            chunk_top_level_mark,
-            chunk_id,
-            &target_file,
-            chunk_id_interned,
-            &declaration_by_name,
-        );
-        emit_debundle_progress(chunk_id, "resolve_global_selector_members", "end");
-        result
-    })?;
+    emit_debundle_progress(chunk_id, "resolve_global_selector_members", "start");
+    let result = builder.resolve_and_claim_global_selectors(
+        &explicit_requests,
+        &precomputed.owner_graph,
+        &runtime_ast.module,
+        &import_sources,
+        &runtime_import_facts,
+        &mut imported_binding_resolver,
+        &mut imported_from_by_src,
+        chunk_top_level_mark,
+        chunk_id,
+        &target_file,
+        chunk_id_interned,
+        &declaration_by_name,
+    );
+    emit_debundle_progress(chunk_id, "resolve_global_selector_members", "end");
+    result?;
     builder.adopt_bindings_of_claimed_anonymous_statements(&declarations);
     drop(imported_binding_resolver);
-    time_phase!(timings, "fold_rebind_atomic_units", {
-        apply_stage_one_a5(&mut builder, &precomputed);
-    });
+    apply_rebind_folds_from_chunk_analysis(&mut builder, &precomputed);
     if matches!(chunk_unassigned_mode, UnassignedMode::MiniFactors) {
-        time_phase!(timings, "synthesize_mini_factor_plans", {
-            builder.synthesize_mini_factors(&precomputed, &runtime_ast.module.body, target_dir)
-        })?;
+        builder.synthesize_mini_factors(&precomputed, &runtime_ast.module.body, target_dir)?;
     }
     if let Some(report) = builder.selector_diagnostics_report(chunk_id)
         && let Some(report_out_dir) = report_emission.rejection_dir()
     {
-        time_phase!(timings, "write_selector_diagnostics_report", {
-            write_chunk_report_json(
-                report_out_dir,
-                chunk_id,
-                SELECTOR_DIAGNOSTICS_REPORT,
-                &report,
-            )
-        })?;
+        write_chunk_report_json(
+            report_out_dir,
+            chunk_id,
+            SELECTOR_DIAGNOSTICS_REPORT,
+            &report,
+        )?;
     }
     // Plan construction is finished — consume the builder and use
     // owned state from here on.
@@ -368,27 +345,24 @@ pub(super) fn materialize_logical_chunk(
     // entry ledger in `lower_chunk` re-collects the Chunk-scope intents
     // and the per-module naturalize ledgers re-collect the Module-scope
     // ones, each sealing against its body's occupancy.
-    let sealed_renames = time_phase!(timings, "seal_rename_ledger", {
+    let sealed_renames = {
         let mut ledger = RenameLedger::default();
         if let Some(renames) = chunk_renames.get(chunk_id) {
             collect_chunk_renames(renames, chunk_top_level_mark, &mut ledger)?;
         }
         collect_plan_export_rename_intents(&module_plans, chunk_top_level_mark, &mut ledger);
         ledger.seal(&SealValidation::default())
-    })?;
+    }?;
     let chunk_renames_map = sealed_renames.chunk_renames_by_name();
-    let (logical_modules, default_destination) =
-        time_phase!(timings, "project_factorization_modules", {
-            project_factorization_modules_with_sentinel(
-                &module_plans,
-                &runtime_ast.module.body,
-                chunk_top_level_mark,
-                chunk_id,
-                target_dir,
-                &target_file,
-                chunk_unassigned_mode.catchall_file_target(),
-            )
-        })?;
+    let (logical_modules, default_destination) = project_factorization_modules_with_sentinel(
+        &module_plans,
+        &runtime_ast.module.body,
+        chunk_top_level_mark,
+        chunk_id,
+        target_dir,
+        &target_file,
+        chunk_unassigned_mode.catchall_file_target(),
+    )?;
     let redundant_purity_hints = analysis.redundant_purity_hints;
     let factorization_chunk_renames: HashMap<Id, swc_atoms::Atom> = chunk_renames_map
         .iter()
@@ -399,80 +373,67 @@ pub(super) fn materialize_logical_chunk(
             )
         })
         .collect();
-    let factorization = time_phase!(timings, "build_factorization", {
-        ChunkFactorization::build_with(
-            chunk_id.to_string(),
-            precomputed,
-            bindings_catalogue,
-            logical_modules,
-            factorization_chunk_renames,
-            default_destination,
-        )
-    });
-    let factorization_report = time_phase!(timings, "validate_factorization", {
-        factorization.validate()
-    });
+    let factorization = ChunkFactorization::build_with(
+        chunk_id.to_string(),
+        precomputed,
+        bindings_catalogue,
+        logical_modules,
+        factorization_chunk_renames,
+        default_destination,
+    );
+    let factorization_report = factorization.validate();
     validate_and_emit_reports(
         chunk_id,
         report_emission,
         &factorization,
         &factorization_report,
-        &mut timings,
     )?;
 
-    let lowered = time_phase!(timings, "lower_chunk_total", {
-        lower_chunk(LowerChunkInputs {
-            context: LowerChunkContext {
-                artifact,
-                artifact_indexes,
-                chunk_id,
-                chunk_id_interned,
-                source_path: &source_path,
-                entry_file: &target_file,
-                header_lines: &header_lines,
-                vendor_import_oracle,
-            },
-            ast: LowerChunkAst {
-                runtime_ast,
-                declarations: &declarations,
-                declaration_by_name: &declaration_by_name,
-                chunk_top_level_mark,
-            },
-            plan: LowerChunkPlan {
-                module_plans: &module_plans,
-                binding_assignment: &binding_assignment,
-                anonymous_ordinal_assignment: &anonymous_ordinal_assignment,
-                factorization: &factorization,
-            },
-            spec_facts: LowerChunkSpecFacts {
-                runtime_import_facts: &runtime_import_facts,
-                sealed_renames: &sealed_renames,
-                chunk_renames: &chunk_renames_map,
-                pre_existing_entry_exports: &pre_existing_entry_exports,
-                pre_existing_public_export_names: &pre_existing_public_export_names,
-            },
-        })
+    let lowered = lower_chunk(LowerChunkInputs {
+        context: LowerChunkContext {
+            artifact,
+            artifact_indexes,
+            chunk_id,
+            chunk_id_interned,
+            source_path: &source_path,
+            entry_file: &target_file,
+            header_lines: &header_lines,
+            vendor_import_oracle,
+        },
+        ast: LowerChunkAst {
+            runtime_ast,
+            declarations: &declarations,
+            declaration_by_name: &declaration_by_name,
+            chunk_top_level_mark,
+        },
+        plan: LowerChunkPlan {
+            module_plans: &module_plans,
+            binding_assignment: &binding_assignment,
+            anonymous_ordinal_assignment: &anonymous_ordinal_assignment,
+            factorization: &factorization,
+        },
+        spec_facts: LowerChunkSpecFacts {
+            runtime_import_facts: &runtime_import_facts,
+            sealed_renames: &sealed_renames,
+            chunk_renames: &chunk_renames_map,
+            pre_existing_entry_exports: &pre_existing_entry_exports,
+            pre_existing_public_export_names: &pre_existing_public_export_names,
+        },
     })?;
     let LoweredChunk {
         files,
         file_records,
         applied,
         vendor_reference_rewrites,
-        timings: lower_timings,
     } = lowered;
-    timings.extend_prefixed("lower", lower_timings);
 
-    let final_modules = time_phase!(timings, "build_final_module_report", {
-        build_final_module_report(&module_plans, &factorization, chunk_top_level_mark)
-    });
-    let directory_dependency_facts = time_phase!(timings, "build_directory_dependency_facts", {
-        build_directory_dependency_facts(chunk_id, &factorization)
-    });
+    let final_modules =
+        build_final_module_report(&module_plans, &factorization, chunk_top_level_mark);
+    let directory_dependency_facts = build_directory_dependency_facts(chunk_id, &factorization);
     let validation = ChunkValidationSummary {
         status: "ok",
         linker_order: factorization_report.linker_order.clone(),
     };
-    let timings = timings.into_durations(chunk_started.elapsed());
     let report = ChunkModulesReport {
         chunk_id: chunk_id.to_string(),
         counts: ChunkModulesCounts {
@@ -489,7 +450,6 @@ pub(super) fn materialize_logical_chunk(
             })
             .collect(),
         redundant_purity_hints,
-        timings,
     };
     Ok(MaterializedLogicalChunk {
         chunk_id: chunk_id_interned,
@@ -506,25 +466,28 @@ pub(super) fn materialize_logical_chunk(
     })
 }
 
-/// Stage A.5 composer: fold rebind-only atomic units into their
+/// Rebind-fold composer: fold rebind-only atomic units into their
 /// explicit destination. Bridges the pure
 /// `stage_one::compute_rebind_folds` decision over the chunk's
 /// post-seed partition (managed by `ChunkPlanBuilder`) into the
 /// builder's plan-list/catalogue state.
 ///
-/// Stage A.5 runs after the seed phases of partition construction
+/// This runs after the seed phases of partition construction
 /// (explicit requests, destructure pull, residual sweep) and before
 /// `synthesize_mini_factors`. The decision step is spec-independent —
-/// it only inspects Stage A's owner graph + atomic units, the
+/// it only inspects the chunk-analysis owner graph + atomic units, the
 /// builder's binding→plan assignment, and the residual landing-site
 /// index — so it lives in the `analysis` crate; this thin composer
 /// owns the application of those decisions to the builder's
 /// `ModulePlan` list.
 ///
-/// See `ARCHITECTURE_BACKLOG.md` § "`compute_stage_one_analysis` —
+/// See `ARCHITECTURE_BACKLOG.md` § "`compute_chunk_analysis` —
 /// only rebind-folding still leaks into the materializer" for the
 /// original separation rationale.
-fn apply_stage_one_a5(builder: &mut ChunkPlanBuilder, precomputed: &OwnerGraphAndUnits) {
+fn apply_rebind_folds_from_chunk_analysis(
+    builder: &mut ChunkPlanBuilder,
+    precomputed: &OwnerGraphAndUnits,
+) {
     let folds = compute_rebind_folds(
         precomputed,
         builder.binding_assignment(),
@@ -642,7 +605,6 @@ fn validate_and_emit_reports(
     report_emission: &ReportEmission,
     factorization: &ChunkFactorization,
     factorization_report: &::gate::FactorizationReport,
-    timings: &mut PhaseTimings,
 ) -> Result<()> {
     let rejected = !factorization_report.atomic_unit_conflicts.is_empty()
         || !factorization_report.cycles.is_empty();
@@ -655,17 +617,13 @@ fn validate_and_emit_reports(
         report_emission.full_dir()
     };
     if let Some(report_out_dir) = report_out_dir {
-        let owner_graph_report = time_phase!(timings, "build_owner_graph_report", {
-            factorization.owner_graph_report()
-        });
-        time_phase!(timings, "write_owner_graph_report", {
-            write_chunk_report_json(
-                report_out_dir,
-                chunk_id,
-                OWNER_GRAPH_REPORT,
-                &owner_graph_report,
-            )
-        })?;
+        let owner_graph_report = factorization.owner_graph_report();
+        write_chunk_report_json(
+            report_out_dir,
+            chunk_id,
+            OWNER_GRAPH_REPORT,
+            &owner_graph_report,
+        )?;
     }
     if !factorization_report.atomic_unit_conflicts.is_empty() {
         if let Some(report_out_dir) = report_out_dir {
@@ -677,14 +635,12 @@ fn validate_and_emit_reports(
                 &factorization_report.atomic_unit_conflicts,
                 &|id| factorization.analysis.module_path(id),
             );
-            time_phase!(timings, "write_atomic_unit_conflicts_report", {
-                write_chunk_report_json(
-                    report_out_dir,
-                    chunk_id,
-                    ATOMIC_UNIT_CONFLICTS_REPORT,
-                    &wire,
-                )
-            })?;
+            write_chunk_report_json(
+                report_out_dir,
+                chunk_id,
+                ATOMIC_UNIT_CONFLICTS_REPORT,
+                &wire,
+            )?;
         }
         let summary = render_atomic_unit_conflict_summary(
             &factorization_report.atomic_unit_conflicts,
@@ -705,9 +661,7 @@ fn validate_and_emit_reports(
             // `validation.rs` `BlockingSccEntry` for the schema and
             // `docs/cli.md` § "Gate queries" for the CLI surface.
             let wire = ::gate::BlockingSccEntry::from_cycle_reports(&factorization_report.cycles);
-            time_phase!(timings, "write_cycles_report", {
-                write_chunk_report_json(report_out_dir, chunk_id, CYCLES_REPORT, &wire)
-            })?;
+            write_chunk_report_json(report_out_dir, chunk_id, CYCLES_REPORT, &wire)?;
         }
         let summary = render_cycle_summary(&factorization_report.cycles);
         bail!(

--- a/devinfra/js/debundle/lowering/materialize/plan_builder.rs
+++ b/devinfra/js/debundle/lowering/materialize/plan_builder.rs
@@ -148,13 +148,13 @@ fn render_duplicate_binding_claims(duplicates: &[DuplicateBindingClaim]) -> Stri
 }
 
 /// `export_name → minified binding` over the members already resolved by
-/// `add_explicit_request` — the anchor-first handle a post-Stage-A selector pass
+/// `add_explicit_request` — the anchor-first handle a post-analysis selector pass
 /// uses to resolve a `@Anchor` reference (`cross_ref`'s anchor, `reads_member`'s
 /// `object:`) to a minified binding. The owner graph's `export_name` is not
 /// populated at member-resolution time, so the readable→binding map is rebuilt
 /// from the resolved members instead (see `materialize::cross_ref`).
 ///
-/// Members still unresolved at this point (the post-Stage-A selectors themselves)
+/// Members still unresolved at this point (the post-analysis selectors themselves)
 /// have an empty `binding` and are skipped. An export name claimed by two
 /// resolved members maps to `None` so it cannot anchor ambiguously — resolution
 /// stays categorical, and a missing/ambiguous anchor fails closed at the use site.
@@ -164,7 +164,7 @@ fn resolved_anchor_bindings(
     let mut anchor_binding: HashMap<String, Option<String>> = HashMap::new();
     for request in explicit_requests {
         for member in &request.members {
-            if member.resolves_after_stage_a() {
+            if member.resolves_after_chunk_analysis() {
                 continue;
             }
             anchor_binding
@@ -278,13 +278,13 @@ fn member_selector_spec_for_global_solver(
         });
     }
 
-    if member.resolves_after_stage_a() || member.is_import_specifier {
+    if member.resolves_after_chunk_analysis() || member.is_import_specifier {
         return None;
     }
-    Some(spec::MemberSelectorSpec::Binding(spec::BindingSelector {
-        name: member.binding.clone(),
-        kind: None,
-    }))
+    member
+        .binding_selector
+        .clone()
+        .map(spec::MemberSelectorSpec::Binding)
 }
 
 fn selector_fact_store_for_chunk(
@@ -755,6 +755,10 @@ pub(super) struct ChunkPlanBuilder {
     /// name-collision checks. The map is dropped by
     /// `drop_explicit_request_scratch`.
     catalogue_index_by_name: HashMap<String, BindingKind>,
+    /// Name-keyed duplicate-check scratch for binding selectors that have a
+    /// known source binding spelling but whose ownership is claimed after chunk
+    /// analysis through the global solver.
+    deferred_binding_claims_by_name: HashMap<String, DuplicateClaimSite>,
     /// Duplicate binding claims found while processing explicit
     /// requests. We keep scanning later requests after recording a
     /// duplicate so one run can report all duplicate claim sites in
@@ -789,6 +793,7 @@ impl ChunkPlanBuilder {
             residual_plan_index: None,
             unmatched_spec_claims: Vec::new(),
             catalogue_index_by_name: HashMap::new(),
+            deferred_binding_claims_by_name: HashMap::new(),
             duplicate_binding_claims: Vec::new(),
             source_match_diagnostics: Vec::new(),
             anonymous_statement_diagnostics: Vec::new(),
@@ -797,12 +802,12 @@ impl ChunkPlanBuilder {
     }
 
     /// Process one explicit (non-residual) logical-module request:
-    /// claim each pre-Stage-A named member, and append a `ModulePlan`.
+    /// claim each member that does not need chunk-analysis facts, and append a
+    /// `ModulePlan`.
     /// Solver-resolved members and anonymous statement selectors are left
-    /// unclaimed until `resolve_and_claim_global_selectors` runs over Stage A
-    /// facts. Duplicate-claim detection across all explicit requests is keyed
-    /// by binding-name via the builder's `catalogue_index_by_name` scratch
-    /// index.
+    /// unclaimed until `resolve_and_claim_global_selectors` runs over chunk
+    /// analysis facts. Duplicate-claim detection across all explicit requests is
+    /// keyed by binding-name via the builder's scratch indexes.
     pub(super) fn add_explicit_request(
         &mut self,
         index: usize,
@@ -817,63 +822,63 @@ impl ChunkPlanBuilder {
         let module_id = ModuleId(LogicalModuleIndex(index));
         let mut duplicate_bindings = BTreeSet::<String>::new();
         for member in &request.members {
-            // Deferred selector members resolve in the global selector pass after
-            // Stage A has produced the owner graph and selector fact store. Until
-            // then their `binding` is empty, so they contribute nothing here.
-            if member.resolves_after_stage_a() {
-                continue;
+            if !member.binding.is_empty() {
+                if let Some(existing_kind) =
+                    self.catalogue_index_by_name.get(member.binding.as_str())
+                {
+                    let duplicate = self.duplicate_claim_for(
+                        existing_kind,
+                        &member.binding,
+                        ctx.chunk_id,
+                        request,
+                        member,
+                    );
+                    self.duplicate_binding_claims.push(duplicate);
+                    duplicate_bindings.insert(member.binding.clone());
+                    continue;
+                }
+                if let Some(existing) = self
+                    .deferred_binding_claims_by_name
+                    .get(member.binding.as_str())
+                {
+                    self.duplicate_binding_claims.push(DuplicateBindingClaim {
+                        chunk_id: ctx.chunk_id.to_string(),
+                        binding: member.binding.clone(),
+                        existing: existing.clone(),
+                        duplicate: DuplicateClaimSite {
+                            module_id: request.id.clone(),
+                            export_name: Some(member.export_name.clone()),
+                            claim_origin: Some(member.claim_origin.clone()),
+                        },
+                    });
+                    duplicate_bindings.insert(member.binding.clone());
+                    continue;
+                }
             }
-            if let Some(existing_kind) = self.catalogue_index_by_name.get(member.binding.as_str()) {
-                let existing = match existing_kind {
-                    BindingKind::Owned {
-                        module: ModuleId(LogicalModuleIndex(owner_index)),
-                    } => {
-                        let plan = self.module_plans.get(*owner_index);
-                        DuplicateClaimSite {
-                            module_id: plan
-                                .map(|plan| plan.id.clone())
-                                .unwrap_or_else(|| format!("<plan#{owner_index}>")),
-                            export_name: plan
-                                .and_then(|plan| plan.bindings.get(member.binding.as_str()))
-                                .cloned(),
-                            claim_origin: plan
-                                .and_then(|plan| {
-                                    plan.binding_claim_origins.get(member.binding.as_str())
-                                })
-                                .cloned(),
-                        }
+            if member.resolves_after_chunk_analysis() {
+                if member.binding_selector.is_some() && !member.is_import_specifier {
+                    let binding_id = top_level_id(&member.binding, ctx.chunk_top_level_mark);
+                    if !ctx.declaration_by_name.contains_key(&binding_id) {
+                        self.unmatched_spec_claims.push(crate::UnmatchedSpecClaim {
+                            chunk_id: ctx.chunk_id.to_string(),
+                            module_path: spec::ModulePath::parse(&request.target_path, "")
+                                .expect("request target_path is a canonical module path"),
+                            binding_name: member.binding.clone(),
+                            export_name: member.export_name.clone(),
+                        });
+                        continue;
                     }
-                    BindingKind::Imported {
-                        re_exporter: ModuleId(LogicalModuleIndex(re_index)),
-                        public_name,
-                        ..
-                    } => {
-                        let plan = self.module_plans.get(*re_index);
+                }
+                if !member.binding.is_empty() {
+                    self.deferred_binding_claims_by_name.insert(
+                        member.binding.clone(),
                         DuplicateClaimSite {
-                            module_id: plan
-                                .map(|plan| plan.id.clone())
-                                .unwrap_or_else(|| format!("<plan#{re_index}>")),
-                            export_name: Some(public_name.to_string()),
-                            claim_origin: plan
-                                .and_then(|plan| {
-                                    plan.binding_claim_origins.get(member.binding.as_str())
-                                })
-                                .cloned(),
-                        }
-                    }
-                };
-                let duplicate = DuplicateBindingClaim {
-                    chunk_id: ctx.chunk_id.to_string(),
-                    binding: member.binding.clone(),
-                    existing,
-                    duplicate: DuplicateClaimSite {
-                        module_id: request.id.clone(),
-                        export_name: Some(member.export_name.clone()),
-                        claim_origin: Some(member.claim_origin.clone()),
-                    },
-                };
-                self.duplicate_binding_claims.push(duplicate);
-                duplicate_bindings.insert(member.binding.clone());
+                            module_id: request.id.clone(),
+                            export_name: Some(member.export_name.clone()),
+                            claim_origin: Some(member.claim_origin.clone()),
+                        },
+                    );
+                }
                 continue;
             }
             if member.is_import_specifier {
@@ -932,7 +937,7 @@ impl ChunkPlanBuilder {
         let binding_comments: BTreeMap<String, String> = request
             .members
             .iter()
-            .filter(|member| !member.resolves_after_stage_a())
+            .filter(|member| !member.resolves_after_chunk_analysis())
             .filter(|member| !duplicate_bindings.contains(member.binding.as_str()))
             .filter_map(|member| {
                 member
@@ -944,7 +949,7 @@ impl ChunkPlanBuilder {
         let binding_claim_origins: BTreeMap<String, String> = request
             .members
             .iter()
-            .filter(|member| !member.resolves_after_stage_a())
+            .filter(|member| !member.resolves_after_chunk_analysis())
             .filter(|member| !duplicate_bindings.contains(member.binding.as_str()))
             .map(|member| (member.binding.clone(), member.claim_origin.clone()))
             .collect();
@@ -1068,7 +1073,7 @@ impl ChunkPlanBuilder {
         let has_deferred_members = explicit_requests
             .iter()
             .flat_map(|request| &request.members)
-            .any(MemberRequest::resolves_after_stage_a);
+            .any(MemberRequest::resolves_after_chunk_analysis);
         let has_anonymous_statements = explicit_requests
             .iter()
             .any(|request| !request.anonymous_statements.is_empty());
@@ -1090,6 +1095,12 @@ impl ChunkPlanBuilder {
             for (index, request) in explicit_requests.iter().enumerate() {
                 let group_assignments = source_match_group_assignments(request);
                 for (member_index, member) in request.members.iter().enumerate() {
+                    if member.binding_selector.is_some() && !member.is_import_specifier {
+                        let binding_id = top_level_id(&member.binding, chunk_top_level_mark);
+                        if !declaration_by_name.contains_key(&binding_id) {
+                            continue;
+                        }
+                    }
                     let Some(selector) = member_selector_spec_for_global_solver(member) else {
                         continue;
                     };
@@ -1117,7 +1128,7 @@ impl ChunkPlanBuilder {
                             selector,
                         ));
                     }
-                    if member.resolves_after_stage_a() {
+                    if member.resolves_after_chunk_analysis() {
                         deferred_targets.insert(target, (index, member.clone()));
                     }
                 }
@@ -1187,7 +1198,7 @@ impl ChunkPlanBuilder {
                     let native_selects_import = member.source_match.is_some()
                         && solver_claim_is_import_specifier(&facts, claim);
                     if native_selects_import {
-                        self.claim_post_stage_a_imported_binding(
+                        self.claim_imported_binding_after_chunk_analysis(
                             request,
                             &member,
                             binding,
@@ -1201,7 +1212,7 @@ impl ChunkPlanBuilder {
                         )?;
                         continue;
                     }
-                    self.claim_post_stage_a_binding(
+                    self.claim_binding_after_chunk_analysis(
                         request,
                         &member,
                         binding,
@@ -1375,7 +1386,7 @@ impl ChunkPlanBuilder {
     }
 
     /// Resolve and claim every `cross_ref` member across all explicit requests,
-    /// using the chunk's owner-graph `Resolution`. Runs after Stage A (the owner
+    /// using the chunk's owner-graph `Resolution`. Runs after chunk analysis (the owner
     /// graph carries the reference/alias edges cross-refs ride) but before
     /// `finalize`. Cross-ref members were left unclaimed by `add_explicit_request`
     /// (their target binding isn't known until here).
@@ -1479,10 +1490,10 @@ impl ChunkPlanBuilder {
                 )
             })?;
         // The cross-ref residual-move citation: the binding was parked at the
-        // residual plan by the pre-Stage-A sweep, exactly as `apply_rebind_folds`
+        // residual plan by the pre-analysis sweep, exactly as `apply_rebind_folds`
         // / `synthesize_mini_factors` handle their late claims; the shared tail
         // moves it out.
-        self.claim_post_stage_a_binding(
+        self.claim_binding_after_chunk_analysis(
             request,
             member,
             binding,
@@ -1550,7 +1561,7 @@ impl ChunkPlanBuilder {
 
     /// Resolve and claim every `reads_member` member across all explicit
     /// requests, using the chunk's owner-graph `Resolution` (with the chunk's AST
-    /// member-read facts joined in). Runs after Stage A (the owner graph exists
+    /// member-read facts joined in). Runs after chunk analysis (the owner graph exists
     /// and the AST is in scope) but before `finalize`. Reads-member members were
     /// left unclaimed by `add_explicit_request` (their target binding isn't known
     /// until here).
@@ -1653,7 +1664,7 @@ impl ChunkPlanBuilder {
                     request.id, member.export_name, target.member,
                 )
             })?;
-        self.claim_post_stage_a_binding(
+        self.claim_binding_after_chunk_analysis(
             request,
             member,
             binding,
@@ -1666,7 +1677,7 @@ impl ChunkPlanBuilder {
 
     /// Resolve and claim every `passed_to_call` member across all explicit
     /// requests, using the chunk's owner-graph `Resolution` (with the chunk's AST
-    /// call-argument facts joined in). Runs after Stage A (the owner graph exists
+    /// call-argument facts joined in). Runs after chunk analysis (the owner graph exists
     /// and the AST is in scope) but before `finalize`. Passed-to-call members were
     /// left unclaimed by `add_explicit_request` (their target binding isn't known
     /// until here).
@@ -1774,7 +1785,7 @@ impl ChunkPlanBuilder {
                     request.id, member.export_name, target.callee_member,
                 )
             })?;
-        self.claim_post_stage_a_binding(
+        self.claim_binding_after_chunk_analysis(
             request,
             member,
             binding,
@@ -1788,7 +1799,7 @@ impl ChunkPlanBuilder {
     /// Resolve and claim every `makes_decorate_call` member across all explicit
     /// requests, using the chunk's owner-graph `Resolution` (with the chunk's AST
     /// decorator-application facts joined in). The inverse-direction sibling of
-    /// `resolve_and_claim_passed_to_calls`, with the same post-Stage-A timing and
+    /// `resolve_and_claim_passed_to_calls`, with the same post-analysis timing and
     /// no-op-when-absent contract. Makes-decorate-call members were left unclaimed
     /// by `add_explicit_request` (their target binding isn't known until here).
     ///
@@ -1889,7 +1900,7 @@ impl ChunkPlanBuilder {
                         request.id, member.export_name, target.class,
                     )
                 })?;
-        self.claim_post_stage_a_binding(
+        self.claim_binding_after_chunk_analysis(
             request,
             member,
             binding,
@@ -1903,7 +1914,7 @@ impl ChunkPlanBuilder {
     /// Resolve and claim every `intrinsic_alias` member across all explicit
     /// requests, using the chunk's owner-graph `Resolution` (with the chunk's AST
     /// intrinsic-alias facts joined in). The follow-on companion of
-    /// `resolve_and_claim_makes_decorate_calls`, with the same post-Stage-A timing
+    /// `resolve_and_claim_makes_decorate_calls`, with the same post-analysis timing
     /// and no-op-when-absent contract. Intrinsic-alias members were left unclaimed by
     /// `add_explicit_request` (their target binding isn't known until here).
     ///
@@ -2013,7 +2024,7 @@ impl ChunkPlanBuilder {
                         request.id, member.export_name, target.property, target.referenced_by,
                     )
                 })?;
-        self.claim_post_stage_a_binding(
+        self.claim_binding_after_chunk_analysis(
             request,
             member,
             binding,
@@ -2027,7 +2038,7 @@ impl ChunkPlanBuilder {
     /// Resolve and claim every `member_of_module` member across all explicit
     /// requests, using the chunk's owner-graph `Resolution` with the
     /// `member_of_module` use-site EDB (member accesses joined to the chunk's
-    /// import table). Runs after Stage A, mirroring
+    /// import table). Runs after chunk analysis, mirroring
     /// [`Self::resolve_and_claim_reads_members`]; `member_of_module` members were
     /// left unclaimed by `add_explicit_request` (their target binding isn't known
     /// until here).
@@ -2076,7 +2087,7 @@ impl ChunkPlanBuilder {
                         request.id, member.export_name, target.module, target.member,
                     )
                 })?;
-            self.claim_post_stage_a_binding(
+            self.claim_binding_after_chunk_analysis(
                 request,
                 member,
                 binding,
@@ -2091,11 +2102,11 @@ impl ChunkPlanBuilder {
 
     /// `export_name → resolved minified binding` over the already-claimed members
     /// of **one logical module** (`module_plans[index]`), including those resolved
-    /// by earlier *post-Stage-A* passes (`reads_member` / `member_of_module` /
+    /// by earlier *post-analysis* passes (`reads_member` / `member_of_module` /
     /// `passed_to_call` / `makes_decorate_call`). Unlike [`resolved_anchor_bindings`]
     /// — which sees only `add_explicit_request`-resolved `binding`/`source_match`
     /// members — this reads the claimed bindings back out of the module plan, so an
-    /// anchor pinned by a prior post-Stage-A pass is resolvable. An export name
+    /// anchor pinned by a prior post-analysis pass is resolvable. An export name
     /// claimed by two distinct bindings *within this module* maps to `None`
     /// (ambiguous → fail-closed), matching `resolved_anchor_bindings`' semantics.
     ///
@@ -2123,16 +2134,16 @@ impl ChunkPlanBuilder {
         by_export
     }
 
-    /// Claim a binding a post-Stage-A selector pass resolved to (the shared tail
+    /// Claim a binding a post-analysis selector pass resolved to (the shared tail
     /// of `reads_member` and `member_of_module`): record an unmatched-claim if the
     /// binding has no top-level declaration; error / record a duplicate if already
     /// claimed; otherwise move it out of the residual sweep and into module
     /// `index`, registering its export name, claim origin, and comment. The
     /// residual move mirrors the cross-ref pass — the binding was parked at the
-    /// residual plan when the pre-Stage-A sweep ran, before this pass knew its
+    /// residual plan when the pre-analysis sweep ran, before this pass knew its
     /// identity.
     #[allow(clippy::too_many_arguments)]
-    fn claim_post_stage_a_imported_binding(
+    fn claim_imported_binding_after_chunk_analysis(
         &mut self,
         request: &LogicalRequest,
         member: &MemberRequest,
@@ -2213,7 +2224,7 @@ impl ChunkPlanBuilder {
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn claim_post_stage_a_binding(
+    fn claim_binding_after_chunk_analysis(
         &mut self,
         request: &LogicalRequest,
         member: &MemberRequest,
@@ -2256,7 +2267,7 @@ impl ChunkPlanBuilder {
             self.duplicate_binding_claims.push(duplicate);
             return Ok(());
         }
-        // The residual sweep ran before Stage A (before this pass), so the target
+        // The residual sweep ran before chunk analysis (before this pass), so the target
         // binding — unclaimed at sweep time — was parked at the residual plan. Move
         // it out: overwrite its assignment and prune the residual plan's export
         // list, so the residual module doesn't keep `export { <binding> }` for a
@@ -2289,6 +2300,7 @@ impl ChunkPlanBuilder {
     /// the residual sweep don't consult this index.
     pub(super) fn drop_explicit_request_scratch(&mut self) {
         self.catalogue_index_by_name = HashMap::new();
+        self.deferred_binding_claims_by_name = HashMap::new();
     }
 
     /// Destructure-atomicity: a destructuring declarator like
@@ -2328,6 +2340,15 @@ impl ChunkPlanBuilder {
                             .insert(sibling_id.clone(), owner_index);
                         self.bindings_catalogue
                             .insert(sibling_id, BindingKind::Owned { module: owner_id });
+                        let plan = &mut self.module_plans[owner_index];
+                        plan.bindings.insert(sibling.clone(), sibling.clone());
+                    }
+                    Some(other_index) if Some(other_index) == self.residual_plan_index => {
+                        self.binding_assignment
+                            .insert(sibling_id.clone(), owner_index);
+                        self.bindings_catalogue
+                            .insert(sibling_id, BindingKind::Owned { module: owner_id });
+                        self.module_plans[other_index].bindings.remove(sibling);
                         let plan = &mut self.module_plans[owner_index];
                         plan.bindings.insert(sibling.clone(), sibling.clone());
                     }
@@ -2478,10 +2499,9 @@ impl ChunkPlanBuilder {
     }
 
     /// `MiniFactors` mode: every unclaimed atomic factor unit gets
-    /// its own synthesized plan at `__auto/mini/NNNN`. Run after
-    /// Stage A.5 (`apply_rebind_folds`) so the residual sweep +
-    /// rebind folding have already settled which units are still
-    /// unclaimed. Bindings
+    /// its own synthesized plan at `__auto/mini/NNNN`. Run after rebind folding
+    /// so the residual sweep and fold decisions have already settled which
+    /// units are still unclaimed. Bindings
     /// previously parked at the residual plan are moved out into the
     /// synthesized plan; the residual plan's `bindings` map is
     /// pruned to match.
@@ -2612,8 +2632,8 @@ impl ChunkPlanBuilder {
         Ok(())
     }
 
-    /// Apply a batch of rebind-fold decisions produced by the
-    /// Stage A.5 composer (`stage_one::compute_rebind_folds`).
+    /// Apply a batch of rebind-fold decisions produced from chunk analysis
+    /// (`stage_one::compute_rebind_folds`).
     ///
     /// Each fold reroutes a single binding from its previous plan
     /// (if any) to the cycle's explicit destination. The
@@ -2650,16 +2670,15 @@ impl ChunkPlanBuilder {
         }
     }
 
-    /// Borrow access to the current binding assignment so the
-    /// Stage A.5 composer can compute folds against it without
-    /// mutating the builder.
+    /// Borrow access to the current binding assignment so the rebind-fold
+    /// composer can compute folds without mutating the builder.
     pub(super) fn binding_assignment(&self) -> &HashMap<Id, usize> {
         &self.binding_assignment
     }
 
-    /// The residual landing-site plan index, if one was created by
-    /// the residual sweep. Needed by Stage A.5 to know which
-    /// existing claims count as "swept" (and hence still foldable).
+    /// The residual landing-site plan index, if one was created by the residual
+    /// sweep. Needed by rebind folding to know which existing claims count as
+    /// "swept" (and hence still foldable).
     pub(super) fn residual_plan_index(&self) -> Option<usize> {
         self.residual_plan_index
     }

--- a/devinfra/js/debundle/lowering/mod.rs
+++ b/devinfra/js/debundle/lowering/mod.rs
@@ -1,6 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, bail};
 use rayon::prelude::*;
@@ -16,8 +15,7 @@ use analysis::{
 };
 use gate::{ChunkFactorization, render_atomic_unit_conflict_summary, render_cycle_summary};
 use stage_one::{
-    DynamicImportTarget, RebindFold, StageOneAnalysis, compute_rebind_folds,
-    compute_stage_one_analysis,
+    ChunkAnalysis, DynamicImportTarget, RebindFold, compute_chunk_analysis, compute_rebind_folds,
 };
 
 use artifact::{
@@ -111,38 +109,6 @@ use visitors::{
     IdentifierRenamer, RenameAndShorthandNaturalizer, RenameCaptureProbe, ShorthandNaturalizer,
 };
 
-macro_rules! time_phase {
-    ($timings:expr, $name:expr, $body:block) => {{
-        let phase_started = std::time::Instant::now();
-        let value = $body;
-        $timings.add($name, phase_started.elapsed());
-        value
-    }};
-}
-pub(crate) use time_phase;
-
-#[derive(Debug, Default, Clone)]
-struct PhaseTimings {
-    durations: BTreeMap<String, Duration>,
-}
-
-impl PhaseTimings {
-    fn add(&mut self, name: impl Into<String>, duration: Duration) {
-        *self.durations.entry(name.into()).or_default() += duration;
-    }
-
-    fn extend_prefixed(&mut self, prefix: &str, other: PhaseTimings) {
-        for (name, duration) in other.durations {
-            self.add(format!("{prefix}.{name}"), duration);
-        }
-    }
-
-    fn into_durations(mut self, total: Duration) -> BTreeMap<String, Duration> {
-        self.durations.insert("total".to_string(), total);
-        self.durations
-    }
-}
-
 pub struct MaterializeLogicalModulesResult {
     pub artifact: ChunkBundle,
     pub selected_lowerings: Vec<SelectedModuleLowering>,
@@ -190,7 +156,6 @@ pub struct ChunkModulesReport {
     /// on the report so JSON consumers can pin behavior across runs.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub redundant_purity_hints: Vec<RedundantPurityHint>,
-    pub timings: BTreeMap<String, Duration>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/devinfra/js/debundle/lowering/plans.rs
+++ b/devinfra/js/debundle/lowering/plans.rs
@@ -35,7 +35,7 @@ pub(super) struct AnonymousStatementRequest {
 /// name. At most one relation can apply to a member, so the variants are mutually
 /// exclusive (an enum, not sibling `Option`s). Each is resolved after the chunk's
 /// owner graph is built — the relational facts live there / are derived from the
-/// chunk AST and joined to it — by the matching post-Stage-A pass in
+/// chunk AST and joined to it — by the matching post-analysis pass in
 /// `materialize::*`. A member carrying one has an empty `binding` and `None`
 /// `source_match` until its pass resolves the target into the plan.
 #[derive(Debug, Clone)]
@@ -69,10 +69,11 @@ pub(super) enum RelationalSelector {
 pub(super) struct MemberRequest {
     pub(super) binding: String,
     pub(super) export_name: String,
+    pub(super) binding_selector: Option<spec::BindingSelector>,
     pub(super) source_match: Option<spec::AnonymousStatementSelector>,
     /// The relational selector pinning this member's target, if any. Mutually
     /// exclusive with `binding`/`source_match`: a member carrying one has an empty
-    /// `binding` until its post-Stage-A pass resolves the target. See
+    /// `binding` until its post-analysis pass resolves the target. See
     /// [`RelationalSelector`].
     pub(super) relational: Option<RelationalSelector>,
     /// When `true`, the member's source is an import specifier in the
@@ -114,14 +115,15 @@ pub(super) struct MemberRequest {
 }
 
 impl MemberRequest {
-    /// Whether this member's binding is intentionally unknown until Stage A
-    /// facts are available and the global selector solver runs.
+    /// Whether this member's ownership is intentionally unknown until chunk
+    /// analysis facts are available and the global selector solver runs.
     ///
-    /// Request lowering canonicalizes every non-name member selector into this
-    /// shape. Callers should route on that semantic state instead of re-spelling
-    /// individual selector forms such as `source_match` versus the relation enum.
-    pub(super) fn resolves_after_stage_a(&self) -> bool {
-        self.binding.is_empty()
+    /// Source-match and relational selectors resolve through the global solver.
+    /// Plain binding selectors stay on the direct claim path for now so they
+    /// keep their existing duplicate/unmatched diagnostics and do not require
+    /// full AST selector facts.
+    pub(super) fn resolves_after_chunk_analysis(&self) -> bool {
+        self.source_match.is_some() || self.relational.is_some()
     }
 
     pub(super) fn cross_ref(&self) -> Option<&spec::CrossRefTarget> {
@@ -351,78 +353,102 @@ pub(super) fn build_members(
                     )
                 })
             };
-            let (binding, export_name, source_match, relational, is_import_specifier) =
-                match selected {
-                    spec::MemberSelectorSpec::Binding(binding) => {
-                        let export_name = m.name.clone().unwrap_or_else(|| binding.name.clone());
-                        let is_import_specifier =
-                            matches!(binding.kind, Some(BindingSourceKind::ImportSpecifier));
-                        (binding.name, export_name, None, None, is_import_specifier)
-                    }
-                    spec::MemberSelectorSpec::SourceMatch(selector) => {
-                        (String::new(), require_name()?, Some(selector), None, false)
-                    }
-                    spec::MemberSelectorSpec::CrossRef(target) => {
-                        let relational = RelationalSelector::CrossRef(target);
-                        (
-                            String::new(),
-                            require_name()?,
-                            None,
-                            Some(relational),
-                            false,
-                        )
-                    }
-                    spec::MemberSelectorSpec::ReadsMember(target) => {
-                        let relational = RelationalSelector::ReadsMember(target);
-                        (
-                            String::new(),
-                            require_name()?,
-                            None,
-                            Some(relational),
-                            false,
-                        )
-                    }
-                    spec::MemberSelectorSpec::MemberOfModule(target) => {
-                        let relational = RelationalSelector::MemberOfModule(target);
-                        (
-                            String::new(),
-                            require_name()?,
-                            None,
-                            Some(relational),
-                            false,
-                        )
-                    }
-                    spec::MemberSelectorSpec::PassedToCall(target) => {
-                        let relational = RelationalSelector::PassedToCall(target);
-                        (
-                            String::new(),
-                            require_name()?,
-                            None,
-                            Some(relational),
-                            false,
-                        )
-                    }
-                    spec::MemberSelectorSpec::MakesDecorateCall(target) => {
-                        let relational = RelationalSelector::MakesDecorateCall(target);
-                        (
-                            String::new(),
-                            require_name()?,
-                            None,
-                            Some(relational),
-                            false,
-                        )
-                    }
-                    spec::MemberSelectorSpec::IntrinsicAlias(target) => {
-                        let relational = RelationalSelector::IntrinsicAlias(target);
-                        (
-                            String::new(),
-                            require_name()?,
-                            None,
-                            Some(relational),
-                            false,
-                        )
-                    }
-                };
+            let (
+                binding,
+                export_name,
+                binding_selector,
+                source_match,
+                relational,
+                is_import_specifier,
+            ) = match selected {
+                spec::MemberSelectorSpec::Binding(binding) => {
+                    let export_name = m.name.clone().unwrap_or_else(|| binding.name.clone());
+                    let is_import_specifier =
+                        matches!(binding.kind, Some(BindingSourceKind::ImportSpecifier));
+                    (
+                        binding.name.clone(),
+                        export_name,
+                        Some(binding),
+                        None,
+                        None,
+                        is_import_specifier,
+                    )
+                }
+                spec::MemberSelectorSpec::SourceMatch(selector) => (
+                    String::new(),
+                    require_name()?,
+                    None,
+                    Some(selector),
+                    None,
+                    false,
+                ),
+                spec::MemberSelectorSpec::CrossRef(target) => {
+                    let relational = RelationalSelector::CrossRef(target);
+                    (
+                        String::new(),
+                        require_name()?,
+                        None,
+                        None,
+                        Some(relational),
+                        false,
+                    )
+                }
+                spec::MemberSelectorSpec::ReadsMember(target) => {
+                    let relational = RelationalSelector::ReadsMember(target);
+                    (
+                        String::new(),
+                        require_name()?,
+                        None,
+                        None,
+                        Some(relational),
+                        false,
+                    )
+                }
+                spec::MemberSelectorSpec::MemberOfModule(target) => {
+                    let relational = RelationalSelector::MemberOfModule(target);
+                    (
+                        String::new(),
+                        require_name()?,
+                        None,
+                        None,
+                        Some(relational),
+                        false,
+                    )
+                }
+                spec::MemberSelectorSpec::PassedToCall(target) => {
+                    let relational = RelationalSelector::PassedToCall(target);
+                    (
+                        String::new(),
+                        require_name()?,
+                        None,
+                        None,
+                        Some(relational),
+                        false,
+                    )
+                }
+                spec::MemberSelectorSpec::MakesDecorateCall(target) => {
+                    let relational = RelationalSelector::MakesDecorateCall(target);
+                    (
+                        String::new(),
+                        require_name()?,
+                        None,
+                        None,
+                        Some(relational),
+                        false,
+                    )
+                }
+                spec::MemberSelectorSpec::IntrinsicAlias(target) => {
+                    let relational = RelationalSelector::IntrinsicAlias(target);
+                    (
+                        String::new(),
+                        require_name()?,
+                        None,
+                        None,
+                        Some(relational),
+                        false,
+                    )
+                }
+            };
             // `source_match` with an explicit `target_binding` and a plain `binding`
             // get richer origins; every other (relational / bare source_match) form
             // is just its selector-kind label.
@@ -452,6 +478,7 @@ pub(super) fn build_members(
             Ok(MemberRequest {
                 binding,
                 export_name,
+                binding_selector,
                 source_match,
                 relational,
                 is_import_specifier,
@@ -471,6 +498,7 @@ pub(super) fn build_members(
             requests.push(MemberRequest {
                 binding: String::new(),
                 export_name: expanded.export_name,
+                binding_selector: None,
                 source_match: Some(expanded.selector),
                 relational: None,
                 is_import_specifier: false,

--- a/devinfra/js/debundle/perf/source_match_selector_profile.md
+++ b/devinfra/js/debundle/perf/source_match_selector_profile.md
@@ -107,7 +107,7 @@ member-form no-`target_binding` path that otherwise only reaches the
 "matched a multi-binding declaration" ambiguity diagnostic after a full
 AST match.
 
-### Generic after timings
+### Generic after optimization
 
 Same small workload, after the optimization:
 
@@ -174,7 +174,7 @@ next performance blocker is command-level filtering and plan application, not
 only the inner declaration-hole matcher. No private source text is reproduced
 here.
 
-Observed timings from an optimized merged binary:
+Observed elapsed times from an optimized merged binary:
 
 | Scope                    | Elapsed | Candidate changes | Notes                                       |
 | ------------------------ | ------: | ----------------: | ------------------------------------------- |

--- a/devinfra/js/debundle/plans/selector_constraint_model.md
+++ b/devinfra/js/debundle/plans/selector_constraint_model.md
@@ -309,19 +309,12 @@ for the exact-assignment backend. It matches this problem directly: finite
 integer domains, allowed-assignment table constraints, solution/status
 reporting, and a native
 [`AllDifferent`](https://developers.google.com/optimization/reference/python/sat/python/cp_model#AddAllDifferent)
-global constraint. The main risk is integration cost, because OR-Tools is not a
-Rust-native dependency; treat the first implementation as a thin Bazel/C++
-sidecar or protobuf boundary and measure it on the hardest Tana selector case
-before broad cutover.
-
-Known integration blocker: a first sidecar spike with `or-tools@9.15` reached
-Bazel analysis on RBE and then failed because `pybind11_abseil` defines a
-dev-only pip hub named `pypi`, conflicting with Ducktape's existing `pypi` hub.
-Handle this as a dependency-only unblock before production solver work. Viable
-directions are a Bzlmod override/patch for `pybind11_abseil`, an isolated
-sidecar Bazel module boundary, or switching to the SAT fallback if the OR-Tools
-dependency surface stays too expensive. The concrete unblock plan lives in
-<ortools_bzlmod_unblock.md>.
+global constraint. The first production implementation is the thin Bazel/C++
+sidecar with protobuf transport. That keeps OR-Tools ownership on the C++ side
+and keeps the Rust boundary as `SelectorBackendProblem -> SelectorCpSatRequest`.
+The next risk is not integration feasibility; it is whether the retained Tana
+selector language lowers into this model with enough coverage and acceptable
+runtime.
 
 The fallback is **[RustSAT](https://github.com/chrjabs/rustsat) +
 CaDiCaL/Kissat** if OR-Tools integration is too expensive. In that shape the

--- a/devinfra/js/debundle/selector_backend_solver.rs
+++ b/devinfra/js/debundle/selector_backend_solver.rs
@@ -15,7 +15,7 @@ use selector_constraint_backend::{
     BackendSolveStatus, SelectorBackendProblem, SelectorBackendProblemError,
     SelectorConstraintBackend,
 };
-use selector_constraint_model::{ConstraintValue, ConstraintVariableId};
+use selector_constraint_model::{ConstraintValue, ConstraintVariableId, TargetBindingProjection};
 use selector_constraint_model_builder::{
     SelectorConstraintModelBuildError, build_selector_constraint_model,
 };
@@ -232,14 +232,14 @@ fn decode_satisfying_assignments<E>(
                 .get(&target.id)
                 .ok_or(SelectorBackendSolveError::MissingTargetProjection { target: target.id })?;
             let owner = assigned_owner(&decoded, projection.owner_variable)?;
-            let binding = if let Some(binding_const) = &projection.binding_const {
-                Some(binding_const.clone())
-            } else if let Some(binding_variable) = projection.binding_variable {
-                Some(assigned_string(&decoded, binding_variable)?)
-            } else {
-                facts
+            let binding = match &projection.binding_projection {
+                Some(TargetBindingProjection::Const(binding)) => Some(binding.clone()),
+                Some(TargetBindingProjection::Variable(binding_variable)) => {
+                    Some(assigned_string(&decoded, *binding_variable)?)
+                }
+                None => facts
                     .single_binding_for_owner(owner)
-                    .map(ToString::to_string)
+                    .map(ToString::to_string),
             };
             if matches!(
                 target.claim,
@@ -542,10 +542,9 @@ mod tests {
             ConstraintVariableId(0)
         );
         assert_eq!(
-            problem.target_projections[0].binding_variable,
-            Some(ConstraintVariableId(1))
+            problem.target_projections[0].binding_projection,
+            Some(TargetBindingProjection::Variable(ConstraintVariableId(1)))
         );
-        assert_eq!(problem.target_projections[0].binding_const, None);
         assert!(
             problem
                 .value_dictionary
@@ -564,10 +563,9 @@ mod tests {
         let problem = build_backend_problem(&program, &facts()).unwrap();
 
         assert_eq!(problem.target_projections[0].target, target);
-        assert_eq!(problem.target_projections[0].binding_variable, None);
         assert_eq!(
-            problem.target_projections[0].binding_const.as_deref(),
-            Some("minA")
+            problem.target_projections[0].binding_projection,
+            Some(TargetBindingProjection::Const("minA".to_string()))
         );
     }
 

--- a/devinfra/js/debundle/selector_constraint_backend.rs
+++ b/devinfra/js/debundle/selector_constraint_backend.rs
@@ -13,6 +13,7 @@ use std::fmt;
 use selector_constraint_model::{
     AllDifferentConstraintId, AllDifferentReason, AllowedTupleConstraintId, BinaryConstraintKind,
     ConstraintModelError, ConstraintValue, ConstraintVariableId, SelectorConstraintModel,
+    TargetBindingProjection,
 };
 use selector_ir::{SelectorTargetId, SelectorVariableId, VariableDomain};
 use serde::{Deserialize, Serialize};
@@ -57,9 +58,7 @@ pub struct BackendTargetProjection {
     pub target: SelectorTargetId,
     pub owner_variable: ConstraintVariableId,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub binding_variable: Option<ConstraintVariableId>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub binding_const: Option<String>,
+    pub binding_projection: Option<TargetBindingProjection>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -161,8 +160,7 @@ impl SelectorBackendProblem {
                 .map(|projection| BackendTargetProjection {
                     target: projection.target,
                     owner_variable: projection.owner_variable,
-                    binding_variable: projection.binding_variable,
-                    binding_const: projection.binding_const.clone(),
+                    binding_projection: projection.binding_projection.clone(),
                 })
                 .collect(),
             allowed_tuples,

--- a/devinfra/js/debundle/selector_constraint_model.rs
+++ b/devinfra/js/debundle/selector_constraint_model.rs
@@ -60,9 +60,23 @@ pub struct TargetProjection {
     pub target: SelectorTargetId,
     pub owner_variable: ConstraintVariableId,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub binding_variable: Option<ConstraintVariableId>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub binding_const: Option<String>,
+    pub binding_projection: Option<TargetBindingProjection>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "value", rename_all = "snake_case")]
+pub enum TargetBindingProjection {
+    Variable(ConstraintVariableId),
+    Const(String),
+}
+
+impl TargetBindingProjection {
+    pub fn variable(&self) -> Option<ConstraintVariableId> {
+        match self {
+            Self::Variable(variable) => Some(*variable),
+            Self::Const(_) => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -151,28 +165,13 @@ impl SelectorConstraintModel {
         &mut self,
         target: SelectorTargetId,
         owner_variable: ConstraintVariableId,
-        binding_variable: Option<ConstraintVariableId>,
+        binding_projection: Option<TargetBindingProjection>,
     ) -> Result<(), ConstraintModelError> {
-        self.add_target_projection_with_binding_const(
-            target,
-            owner_variable,
-            binding_variable,
-            None,
-        )
-    }
-
-    pub fn add_target_projection_with_binding_const(
-        &mut self,
-        target: SelectorTargetId,
-        owner_variable: ConstraintVariableId,
-        binding_variable: Option<ConstraintVariableId>,
-        binding_const: Option<String>,
-    ) -> Result<(), ConstraintModelError> {
-        if binding_variable.is_some() && binding_const.is_some() {
-            return Err(ConstraintModelError::ConflictingTargetBindingProjection { target });
-        }
         self.require_domain(owner_variable, VariableDomain::Owner)?;
-        if let Some(binding_variable) = binding_variable {
+        if let Some(binding_variable) = binding_projection
+            .as_ref()
+            .and_then(TargetBindingProjection::variable)
+        {
             self.require_domain(binding_variable, VariableDomain::String)?;
         }
         if self
@@ -185,8 +184,7 @@ impl SelectorConstraintModel {
         self.target_projections.push(TargetProjection {
             target,
             owner_variable,
-            binding_variable,
-            binding_const,
+            binding_projection,
         });
         Ok(())
     }
@@ -260,13 +258,12 @@ impl SelectorConstraintModel {
         let mut targets = BTreeSet::new();
         for projection in &self.target_projections {
             self.require_domain(projection.owner_variable, VariableDomain::Owner)?;
-            if let Some(binding_variable) = projection.binding_variable {
+            if let Some(binding_variable) = projection
+                .binding_projection
+                .as_ref()
+                .and_then(TargetBindingProjection::variable)
+            {
                 self.require_domain(binding_variable, VariableDomain::String)?;
-            }
-            if projection.binding_variable.is_some() && projection.binding_const.is_some() {
-                return Err(ConstraintModelError::ConflictingTargetBindingProjection {
-                    target: projection.target,
-                });
             }
             if !targets.insert(projection.target) {
                 return Err(ConstraintModelError::DuplicateTargetProjection {
@@ -542,9 +539,6 @@ pub enum ConstraintModelError {
     DuplicateTargetProjection {
         target: SelectorTargetId,
     },
-    ConflictingTargetBindingProjection {
-        target: SelectorTargetId,
-    },
     UnknownTargetProjection {
         target: SelectorTargetId,
     },
@@ -641,10 +635,6 @@ impl fmt::Display for ConstraintModelError {
             Self::DuplicateTargetProjection { target } => {
                 write!(f, "target {target:?} has multiple projections")
             }
-            Self::ConflictingTargetBindingProjection { target } => write!(
-                f,
-                "target {target:?} projects both a binding variable and a constant binding"
-            ),
             Self::UnknownTargetProjection { target } => {
                 write!(f, "target {target:?} has no model projection")
             }

--- a/devinfra/js/debundle/selector_constraint_model_builder.rs
+++ b/devinfra/js/debundle/selector_constraint_model_builder.rs
@@ -14,7 +14,7 @@ use chunk_facts::NodeId;
 use regex::Regex;
 use selector_constraint_model::{
     AllDifferentReason, BinaryConstraintKind, ConstraintModelError, ConstraintValue,
-    ConstraintVariableId, SelectorConstraintModel,
+    ConstraintVariableId, SelectorConstraintModel, TargetBindingProjection,
 };
 use selector_ir::{
     ClaimKind, NodeTerm, OrdinalTerm, OwnerTerm, SelectorAtom, SelectorFact, SelectorFactStore,
@@ -45,18 +45,16 @@ pub fn build_selector_constraint_model(
 
     for target in &program.targets {
         let owner_variable = model_variable(&variables, target.owner)?;
-        let binding_projection = target_binding_projections.binding_projection(target.owner);
-        let binding_variable = binding_projection
-            .and_then(TargetBindingProjection::variable)
-            .map(|binding| model_variable(&variables, binding))
-            .transpose()?;
-        let binding_const = binding_projection.and_then(TargetBindingProjection::constant);
-        model.add_target_projection_with_binding_const(
-            target.id,
-            owner_variable,
-            binding_variable,
-            binding_const,
-        )?;
+        let binding_projection = match target_binding_projections.binding_projection(target.owner) {
+            Some(SourceBindingProjection::Const(binding)) => {
+                Some(TargetBindingProjection::Const(binding.clone()))
+            }
+            Some(SourceBindingProjection::Var(binding)) => Some(TargetBindingProjection::Variable(
+                model_variable(&variables, *binding)?,
+            )),
+            None => None,
+        };
+        model.add_target_projection(target.id, owner_variable, binding_projection)?;
     }
 
     for atom in &program.atoms {
@@ -98,8 +96,8 @@ pub enum SelectorConstraintModelBuildError {
     },
     ConflictingTargetBindingProjection {
         owner: SelectorVariableId,
-        existing: TargetBindingProjection,
-        actual: TargetBindingProjection,
+        existing: SourceBindingProjection,
+        actual: SourceBindingProjection,
     },
 }
 
@@ -1643,14 +1641,14 @@ fn required_string_term_const(
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum TargetBindingProjection {
+pub enum SourceBindingProjection {
     Const(String),
     Var(SelectorVariableId),
 }
 
 #[derive(Debug, Default)]
 struct TargetBindingProjections {
-    by_owner: BTreeMap<SelectorVariableId, TargetBindingProjection>,
+    by_owner: BTreeMap<SelectorVariableId, SourceBindingProjection>,
 }
 
 impl TargetBindingProjections {
@@ -1661,11 +1659,11 @@ impl TargetBindingProjections {
                 SelectorAtom::OwnerDeclaresBinding {
                     owner: OwnerTerm::Var { id: owner },
                     binding: StringTerm::Const { value },
-                } => projections.insert(*owner, TargetBindingProjection::Const(value.clone()))?,
+                } => projections.insert(*owner, SourceBindingProjection::Const(value.clone()))?,
                 SelectorAtom::OwnerDeclaresBinding {
                     owner: OwnerTerm::Var { id: owner },
                     binding: StringTerm::Var { id: binding },
-                } => projections.insert(*owner, TargetBindingProjection::Var(*binding))?,
+                } => projections.insert(*owner, SourceBindingProjection::Var(*binding))?,
                 _ => {}
             }
         }
@@ -1675,7 +1673,7 @@ impl TargetBindingProjections {
     fn insert(
         &mut self,
         owner: SelectorVariableId,
-        binding: TargetBindingProjection,
+        binding: SourceBindingProjection,
     ) -> Result<(), SelectorConstraintModelBuildError> {
         match self.by_owner.get(&owner) {
             Some(existing) if existing != &binding => Err(
@@ -1693,24 +1691,8 @@ impl TargetBindingProjections {
         }
     }
 
-    fn binding_projection(&self, owner: SelectorVariableId) -> Option<&TargetBindingProjection> {
+    fn binding_projection(&self, owner: SelectorVariableId) -> Option<&SourceBindingProjection> {
         self.by_owner.get(&owner)
-    }
-}
-
-impl TargetBindingProjection {
-    fn variable(&self) -> Option<SelectorVariableId> {
-        match self {
-            Self::Var(binding) => Some(*binding),
-            Self::Const(_) => None,
-        }
-    }
-
-    fn constant(&self) -> Option<String> {
-        match self {
-            Self::Const(binding) => Some(binding.clone()),
-            Self::Var(_) => None,
-        }
     }
 }
 
@@ -2867,20 +2849,18 @@ mod tests {
             model.target_projections[0].owner_variable,
             ConstraintVariableId(0)
         );
-        assert_eq!(model.target_projections[0].binding_variable, None);
         assert_eq!(
-            model.target_projections[0].binding_const.as_deref(),
-            Some("shared")
+            model.target_projections[0].binding_projection,
+            Some(TargetBindingProjection::Const("shared".to_string()))
         );
         assert_eq!(model.target_projections[1].target, strict_target);
         assert_eq!(
             model.target_projections[1].owner_variable,
             ConstraintVariableId(1)
         );
-        assert_eq!(model.target_projections[1].binding_variable, None);
         assert_eq!(
-            model.target_projections[1].binding_const.as_deref(),
-            Some("specific")
+            model.target_projections[1].binding_projection,
+            Some(TargetBindingProjection::Const("specific".to_string()))
         );
         assert_eq!(model.binary_constraints, Vec::<BinaryConstraint>::new());
         assert_eq!(
@@ -3000,10 +2980,9 @@ mod tests {
             ConstraintVariableId(0)
         );
         assert_eq!(
-            model.target_projections[0].binding_variable,
-            Some(ConstraintVariableId(1))
+            model.target_projections[0].binding_projection,
+            Some(TargetBindingProjection::Variable(ConstraintVariableId(1)))
         );
-        assert_eq!(model.target_projections[0].binding_const, None);
         assert_eq!(
             allowed_tuples_for(&model, &[ConstraintVariableId(0), ConstraintVariableId(1)]),
             &AllowedTupleConstraint {
@@ -3466,9 +3445,10 @@ mod tests {
                 "source_match model has empty allowed-tuple constraints: {empty_constraints:#?}"
             );
             let projection = &model.target_projections[0];
-            let binding_variable = projection
-                .binding_variable
-                .expect("alpha_all source_match should project its binding variable");
+            let binding_variable = match projection.binding_projection {
+                Some(TargetBindingProjection::Variable(variable)) => variable,
+                _ => panic!("alpha_all source_match should project its binding variable"),
+            };
 
             assert_eq!(
                 satisfying_tuples_for(&model, &[projection.owner_variable, binding_variable]),

--- a/devinfra/js/debundle/selector_ortools_cpsat_backend.rs
+++ b/devinfra/js/debundle/selector_ortools_cpsat_backend.rs
@@ -18,7 +18,9 @@ use selector_constraint_backend::{
     BackendTargetProjection, BackendValueId, BackendVariable, BackendVariableAssignment,
     SelectorBackendProblem, SelectorConstraintBackend,
 };
-use selector_constraint_model::{BinaryConstraintKind, ConstraintVariableId};
+use selector_constraint_model::{
+    BinaryConstraintKind, ConstraintVariableId, TargetBindingProjection,
+};
 use selector_cp_sat_proto::ducktape::debundle::solver_backends::ortools_cpsat as wire;
 
 const REQUEST_PROTO_ENV: &str = "DUCKTAPE_DEBUNDLE_ORTOOLS_CPSAT_REQUEST_PROTO";
@@ -476,17 +478,17 @@ fn all_different_from_backend(
 fn target_projection_from_backend(
     projection: &BackendTargetProjection,
 ) -> Result<wire::TargetProjection, OrToolsCpSatBackendError> {
-    let binding_projection = projection
-        .binding_variable
-        .map(constraint_variable_id)
-        .transpose()?
-        .map(wire::target_projection::BindingProjection::BindingVariableId)
-        .or_else(|| {
-            projection
-                .binding_const
-                .clone()
-                .map(wire::target_projection::BindingProjection::BindingConst)
-        });
+    let binding_projection = match &projection.binding_projection {
+        Some(TargetBindingProjection::Variable(variable)) => Some(
+            wire::target_projection::BindingProjection::BindingVariableId(constraint_variable_id(
+                *variable,
+            )?),
+        ),
+        Some(TargetBindingProjection::Const(binding)) => Some(
+            wire::target_projection::BindingProjection::BindingConst(binding.clone()),
+        ),
+        None => None,
+    };
     Ok(wire::TargetProjection {
         target_id: u32_id("target_projections.target_id", projection.target.0)?,
         owner_variable_id: constraint_variable_id(projection.owner_variable)?,
@@ -657,8 +659,7 @@ mod tests {
         let projection = BackendTargetProjection {
             target: SelectorTargetId(7),
             owner_variable: ConstraintVariableId(0),
-            binding_variable: None,
-            binding_const: Some("minA".to_string()),
+            binding_projection: Some(TargetBindingProjection::Const("minA".to_string())),
         };
 
         let wire_projection = target_projection_from_backend(&projection).unwrap();

--- a/devinfra/js/debundle/stage_one/chunk_admission.rs
+++ b/devinfra/js/debundle/stage_one/chunk_admission.rs
@@ -1,8 +1,8 @@
 //! Input-chunk admission scan for the statically-checkable
 //! assumptions of docs/design.md §"Conditions on the input chunk"
 //! (A1 `eval`, A3 internal dynamic `import()`, A5 cheap
-//! `import.meta` reflection shapes). Runs in Stage A
-//! ([`crate::compute_stage_one_analysis`]) right next to the A2
+//! `import.meta` reflection shapes). Runs during chunk analysis
+//! ([`crate::compute_chunk_analysis`]) right next to the A2
 //! top-level-await bail, before any quotient or lowering work.
 //!
 //! The scan is deliberately partial — it enforces the cheap,
@@ -29,7 +29,7 @@
 //!   `import.meta` use inside lazy positions.
 //!
 //! **A4 (`with` blocks) is not checked here** because it never
-//! reaches Stage A: module code is strict per ECMA-262, and the
+//! reaches chunk analysis: module code is strict per ECMA-262, and the
 //! production parser rejects `with` as a recoverable parse error
 //! even with `no_early_errors: true`
 //! (`js_ast::parse_module_from_source_file` fails on any recovered
@@ -50,7 +50,8 @@ use analysis::facts::top_level_item_views;
 
 /// Where a dynamic-import specifier resolves, from the caller chunk's
 /// perspective. Produced by the artifact-aware resolver the lowering
-/// layer passes into Stage A (Stage A itself is artifact-free).
+/// layer passes into chunk analysis (chunk analysis itself is
+/// artifact-free).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DynamicImportTarget {
     /// Resolves to a file of the chunk being analyzed — a debundled

--- a/devinfra/js/debundle/stage_one/mod.rs
+++ b/devinfra/js/debundle/stage_one/mod.rs
@@ -1,8 +1,8 @@
-//! Stage A composer for the per-chunk pipeline.
+//! Chunk-analysis composer for the per-chunk pipeline.
 //!
-//! Stage A is the **spec-independent** half of the per-chunk
-//! pipeline. Given a parsed chunk AST plus analysis hints + per-
-//! chunk owner-graph options, it produces:
+//! Chunk analysis is the **spec-independent** half of the per-chunk
+//! pipeline. Given a parsed chunk AST plus analysis hints +
+//! per-chunk owner-graph options, it produces:
 //!
 //! - per-statement static facts (declared bindings, eager/lazy reads,
 //!   side-effect summaries, purity classification, top-level-await
@@ -11,8 +11,8 @@
 //! - the structural atomic units (owner-level SCCs of `G_atomic`),
 //!   which any valid factorization must keep co-located.
 //!
-//! The composer also owns the side-effects that derive purely
-//! from Stage A output:
+//! The composer also owns the side-effects that derive purely from
+//! chunk-analysis output:
 //!
 //! - stderr warnings for redundant-purity / redundant-pure-member
 //!   spec hints the analyzer can already infer;
@@ -22,26 +22,27 @@
 //!   checkable input assumptions (docs/design.md A1/A3/A5; see
 //!   `chunk_admission`), including its override notices.
 //!
-//! Stage A is a pure function of `(chunk_id, module, hints,
+//! Chunk analysis is a pure function of `(chunk_id, module, hints,
 //! owner_graph_options)` plus the spec-free `source_path` annotation,
 //! the line-index callback for source-location resolution, and the
 //! caller-supplied dynamic-import resolver (the A3 admission check
-//! needs "which chunk does this specifier land in", but Stage A
-//! itself stays artifact-free). It does not read the spec, the
-//! partition, chunk renames, or the unassigned-mode policy — those
-//! are Stage B inputs.
+//! needs "which chunk does this specifier land in", but chunk
+//! analysis itself stays artifact-free). It does not read the spec,
+//! the partition, chunk renames, or the unassigned-mode policy —
+//! those are materialization inputs.
 //!
-//! Stage A is materialized only in memory, by callers
+//! Chunk analysis is materialized only in memory, by callers
 //! (today: `materialize_logical_chunk`) that call
-//! [`compute_stage_one_analysis`] and pass its components to Stage B.
-//! A previous design also serialized Stage A's output to disk so a
-//! separate-process Stage B could consume the cache; that design was
-//! abandoned (see `docs/lessons_learned/cross_process_stage_b.md`).
+//! [`compute_chunk_analysis`] and pass its components to the
+//! materializer. A previous design also serialized chunk-analysis
+//! output to disk so a separate-process materialization action could
+//! consume the cache; that design was abandoned (see
+//! `docs/lessons_learned/cross_process_stage_b.md`).
 //! The composer survives as a structural readability boundary.
 //!
-//! Atomic-unit-rebind folding is the "Stage A.5" step: it runs after
+//! Atomic-unit-rebind folding runs after
 //! the partition seed phases (explicit requests, destructure pull,
-//! residual sweep) but is purely a function of Stage A's output
+//! residual sweep) but is purely a function of chunk-analysis output
 //! (owner graph + atomic units) and the post-seed binding→module
 //! assignment. The decision logic lives at
 //! [`compute_rebind_folds`]; the lowering-side caller applies the
@@ -63,10 +64,10 @@ use analysis::facts::{ChunkFactAnalysis, analyze_chunk};
 use analysis::graph::OwnerGraphOptions;
 use analysis::purity::{RedundantPureMemberReason, RedundantPurityReason};
 
-/// Output of Stage A: the per-chunk analysis that does not depend on
-/// the spec.
+/// Output of chunk analysis: the per-chunk analysis that does not
+/// depend on the spec.
 #[derive(Debug, Clone)]
-pub struct StageOneAnalysis {
+pub struct ChunkAnalysis {
     /// Per-statement static facts plus chunk-wide flags (top-level
     /// await detection, redundant purity / pure-member hints).
     pub fact_analysis: ChunkFactAnalysis,
@@ -78,7 +79,7 @@ pub struct StageOneAnalysis {
     pub owner_graph_and_units: OwnerGraphAndUnits,
 }
 
-/// Run Stage A: analyze the chunk's facts, emit any
+/// Run chunk analysis: analyze the chunk's facts, emit any
 /// redundant-purity-hint diagnostics, fail fast if the chunk has
 /// top-level `await` or fails the input-chunk admission scan, then
 /// derive the owner graph + structural atomic units.
@@ -88,9 +89,9 @@ pub struct StageOneAnalysis {
 /// violates a non-overridden admission check (docs/design.md
 /// A1/A3/A5; see `chunk_admission`). `resolve_dynamic_import`
 /// supplies the artifact-aware "where does this dynamic-import
-/// specifier land" answer for the A3 check — Stage A itself stays
-/// artifact-free.
-pub fn compute_stage_one_analysis<F>(
+/// specifier land" answer for the A3 check — chunk analysis itself
+/// stays artifact-free.
+pub fn compute_chunk_analysis<F>(
     chunk_id: &str,
     module: &Module,
     hints: &AnalysisHints,
@@ -98,7 +99,7 @@ pub fn compute_stage_one_analysis<F>(
     line_range_for_span: F,
     owner_graph_options: OwnerGraphOptions,
     resolve_dynamic_import: &dyn Fn(&str) -> DynamicImportTarget,
-) -> Result<StageOneAnalysis>
+) -> Result<ChunkAnalysis>
 where
     F: FnMut(Span) -> Option<(usize, usize)>,
 {
@@ -122,7 +123,7 @@ where
     let owner_graph_and_units =
         compute_owner_graph_and_units_with(&fact_analysis.facts, owner_graph_options)
             .with_context(|| format!("building owner graph for chunk {chunk_id}"))?;
-    Ok(StageOneAnalysis {
+    Ok(ChunkAnalysis {
         fact_analysis,
         owner_graph_and_units,
     })
@@ -197,7 +198,7 @@ mod tests {
     #[test]
     fn composer_runs_facts_and_owner_graph_together() {
         let module = parse("const A = 1;\nconst B = A + 1;\nexport { A, B };\n");
-        let stage_one = compute_stage_one_analysis(
+        let chunk_analysis = compute_chunk_analysis(
             "test_chunk",
             &module,
             &AnalysisHints::default(),
@@ -206,13 +207,13 @@ mod tests {
             OwnerGraphOptions::default(),
             &|_| DynamicImportTarget::External,
         )
-        .expect("stage one");
+        .expect("chunk analysis");
 
         // Three top-level items: two consts + one export.
-        assert_eq!(stage_one.fact_analysis.facts.len(), 3);
-        assert!(stage_one.fact_analysis.top_level_await.is_none());
+        assert_eq!(chunk_analysis.fact_analysis.facts.len(), 3);
+        assert!(chunk_analysis.fact_analysis.top_level_await.is_none());
 
-        let owner_count = stage_one.owner_graph_and_units.owner_graph.num_nodes();
+        let owner_count = chunk_analysis.owner_graph_and_units.owner_graph.num_nodes();
         assert!(
             owner_count >= 2,
             "owner graph must hold at least one node per declared \
@@ -220,7 +221,7 @@ mod tests {
         );
 
         assert!(
-            !stage_one.owner_graph_and_units.atomic_units.is_empty(),
+            !chunk_analysis.owner_graph_and_units.atomic_units.is_empty(),
             "atomic-units pass produced no structural units",
         );
     }
@@ -232,7 +233,7 @@ mod tests {
     #[test]
     fn composer_bails_on_top_level_await() {
         let module = parse("const data = await fetch('/api');\n");
-        let result = compute_stage_one_analysis(
+        let result = compute_chunk_analysis(
             "tla_chunk",
             &module,
             &AnalysisHints::default(),
@@ -241,7 +242,7 @@ mod tests {
             OwnerGraphOptions::default(),
             &|_| DynamicImportTarget::External,
         );
-        let err = result.expect_err("TLA chunks must fail Stage A");
+        let err = result.expect_err("TLA chunks must fail chunk analysis");
         let msg = format!("{err:#}");
         assert!(msg.contains("tla_chunk"), "error names chunk: {msg}");
         assert!(msg.contains("top-level `await`"), "error names TLA: {msg}");

--- a/devinfra/js/debundle/stage_one/rebind_fold.rs
+++ b/devinfra/js/debundle/stage_one/rebind_fold.rs
@@ -1,4 +1,4 @@
-//! Stage A.5 composer: rebind-only atomic-unit folding.
+//! Rebind-only atomic-unit folding.
 //!
 //! Background: see `docs/design.md` and `atomic_units.rs`. The
 //! structural-atomic-unit pass over the owner graph symmetrizes
@@ -9,7 +9,7 @@
 //! assignment fires. Without folding, such a spec would surface as
 //! an `atomic_unit_conflict` and the materializer would bail.
 //!
-//! Stage A.5 takes the post-seed binding→module assignment (the
+//! The pass takes the post-seed binding→module assignment (the
 //! "partition" after explicit requests + destructure pull + residual
 //! sweep have all run) plus the structural atomic units, and decides
 //! which unclaimed cycle members should silently fold into the
@@ -17,10 +17,8 @@
 //! only reads the owner graph + atomic-units + assignment + the
 //! residual plan index. Mutation of the lowering-side `ModulePlan`
 //! list happens at the caller (today: `ChunkPlanBuilder::apply_rebind_folds`).
-//!
-//! "Stage A.5" because it runs after Stage A (`compute_stage_one_analysis`)
-//! and after the partition's seed phases, but before Stage B (lowering
-//! proper). See `ARCHITECTURE_BACKLOG.md` for the separation rationale.
+//! It runs after chunk analysis (`compute_chunk_analysis`) and after
+//! the partition's seed phases, but before module emission.
 
 use std::collections::HashMap;
 


### PR DESCRIPTION
## Summary

- Rename the debundle chunk-analysis API from `compute_stage_one_analysis` / `StageOneAnalysis` to `compute_chunk_analysis` / `ChunkAnalysis`.
- Remove committed ad hoc phase timing machinery from the lowering/materialization path, including `time_phase!`, `PhaseTimings`, and the `modules_report.json` timing field.
- Document the profiler-first rule in root and debundle `AGENTS.md`: use real profilers such as `perf`, Callgrind, heaptrack, Massif, or Bazel profile targets instead of adding fine-grained timing hooks.
- Keep ordinary `selector.binding` on the existing direct-claim path while still lowering direct binding members as constraints for relational selector anchors.

## Validation

- `nix develop -c pre-commit run --files devinfra/js/debundle/lowering/materialize/mod.rs devinfra/js/debundle/lowering/materialize/plan_builder.rs`
- `nix develop -c bbr test //devinfra/js/debundle:stage_one_test //devinfra/js/debundle:lowering_test //devinfra/js/debundle:selector_constraint_model_builder_test //devinfra/js/debundle:selector_backend_solver_test //devinfra/js/debundle:selector_ortools_cpsat_backend_test //devinfra/js/debundle/solver_backends/ortools_cpsat:solver_test //devinfra/js/debundle/e2e:chunk_admission_test //devinfra/js/debundle/e2e:lowering_test //devinfra/js/debundle/e2e:cross_module_emission_test //devinfra/js/debundle/e2e:cross_ref_lowering_test //devinfra/js/debundle/e2e:passed_to_call_lowering_test --cache_test_results=no --test_output=errors`
  - BuildBuddy Bazel invocation on rebased head: `ad5f30e9-bb92-4078-b4d7-17aec09677a0`