### PR TITLE
[codex] Exercise alpha-all global selector assignment

### DIFF
--- a/devinfra/js/debundle/e2e/BUILD.bazel
+++ b/devinfra/js/debundle/e2e/BUILD.bazel
@@ -138,6 +138,18 @@ rust_test(
 )
 
 rust_test(
+    name = "global_selector_assignment_test",
+    srcs = ["global_selector_assignment_test.rs"],
+    crate_root = "global_selector_assignment_test.rs",
+    data = [
+        "//devinfra/js/debundle",
+        "@nodejs_linux_amd64//:bin/node",
+    ],
+    edition = "2024",
+    deps = [":support"],
+)
+
+rust_test(
     name = "identifier_rename_queue_test",
     srcs = ["identifier_rename_queue_test.rs"],
     crate_root = "identifier_rename_queue_test.rs",

--- a/devinfra/js/debundle/e2e/global_selector_assignment_test.rs
+++ b/devinfra/js/debundle/e2e/global_selector_assignment_test.rs
@@ -1,0 +1,111 @@
+use debundle_e2e_support::{
+    FixtureOpts, Member, assert_entry_output, assert_module_exports, assert_module_source,
+    logical_module, run_fixture,
+};
+
+const ROUTE_COUNT: usize = 12;
+const SPECIFIC_ROUTE_EXPORTS: [&str; ROUTE_COUNT - 1] = [
+    "Route00", "Route01", "Route02", "Route03", "Route04", "Route05", "Route06", "Route07",
+    "Route08", "Route09", "Route10",
+];
+
+#[test]
+fn broad_alpha_all_selector_resolves_to_remaining_global_target() {
+    let source = route_source();
+    let specific_members: Vec<Member> = SPECIFIC_ROUTE_EXPORTS
+        .iter()
+        .enumerate()
+        .map(|(slot, &export_name)| {
+            Member::source_alpha_target(export_name, "targetRoute", route_selector(Some(slot)))
+        })
+        .collect();
+    let remainder_members = vec![Member::source_alpha_target(
+        "RouteRemainder",
+        "targetRoute",
+        route_selector(None),
+    )];
+
+    let fixture = run_fixture(FixtureOpts::new(
+        &source,
+        vec![
+            logical_module("routes/specific", &specific_members),
+            logical_module("routes/remainder", &remainder_members),
+        ],
+    ));
+
+    assert_module_exports(
+        &fixture.out_root,
+        "static/app/modules/routes/remainder.js",
+        &["RouteRemainder"],
+        &["Route00", "Route10"],
+    );
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/modules/routes/remainder.js",
+        &["slot-11"],
+        &["slot-00", "slot-10"],
+    );
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/modules/routes/specific.js",
+        &["slot-00", "slot-10"],
+        &["slot-11"],
+    );
+    assert_entry_output(&fixture, "slot-11\n");
+}
+
+fn route_source() -> String {
+    let mut source = r#"const sharedRuntime = {
+  normalize(value) {
+    return String(value).trim();
+  },
+  emit(kind, wrapped, slot) {
+    return { kind, wrapped, slot, marker: slot };
+  },
+};
+
+function sharedRead(input, key) {
+  return input[key] ?? "";
+}
+
+function commonWrap(label, value) {
+  return `${label}:${value}`;
+}
+"#
+    .to_string();
+    for slot in 0..ROUTE_COUNT {
+        source.push_str(&format!(
+            r#"
+function route{slot:02}(input) {{
+  const local{slot:02}A = sharedRead(input, "user");
+  const local{slot:02}B = sharedRuntime.normalize(local{slot:02}A);
+  return sharedRuntime.emit("route", commonWrap("common", local{slot:02}B), "slot-{slot:02}");
+}}
+"#
+        ));
+    }
+    source.push_str(
+        r#"
+console.log(route11({ user: " ok " }).marker);
+export {
+"#,
+    );
+    for slot in 0..ROUTE_COUNT {
+        source.push_str(&format!("  route{slot:02},\n"));
+    }
+    source.push_str("};\n");
+    source
+}
+
+fn route_selector(slot: Option<usize>) -> String {
+    let slot_arg = slot
+        .map(|slot| format!(r#""slot-{slot:02}""#))
+        .unwrap_or_else(|| "ANYTHING".to_string());
+    format!(
+        r#"function targetRoute(input) {{
+  const first = sharedRead(input, "user");
+  const second = sharedRuntime.normalize(first);
+  return sharedRuntime.emit("route", commonWrap("common", second), {slot_arg});
+}}"#
+    )
+}

--- a/devinfra/js/debundle/e2e/testdata/global_selector_assignment_stress/broad_specific_injective/README.md
+++ b/devinfra/js/debundle/e2e/testdata/global_selector_assignment_stress/broad_specific_injective/README.md
@@ -21,9 +21,11 @@ module paths, or source text from any private bundle.
   matches every route and is forced to `route11` only by the target-level
   `all_different` constraint.
 
-The fixture is not wired into a Bazel target yet. It should become executable
-when the selector backend benchmark harness can build a `SelectorProgram` from
-this pending contract and run alternate `SelectorConstraintModel` backends.
+The smoke form is wired into
+`//devinfra/js/debundle/e2e:global_selector_assignment_test`. The pending YAML
+contract remains the backend-benchmark sketch for building a `SelectorProgram`
+directly from this shape and running alternate `SelectorConstraintModel`
+backends.
 
 ## Expected Semantics
 

--- a/devinfra/js/debundle/lowering/materialize/mod.rs
+++ b/devinfra/js/debundle/lowering/materialize/mod.rs
@@ -309,6 +309,7 @@ pub(super) fn materialize_logical_chunk(
     );
     emit_debundle_progress(chunk_id, "resolve_global_selector_members", "end");
     result?;
+    builder.pull_destructure_siblings(&destructure_siblings, chunk_top_level_mark)?;
     builder.adopt_bindings_of_claimed_anonymous_statements(&declarations);
     drop(imported_binding_resolver);
     apply_rebind_folds_from_chunk_analysis(&mut builder, &precomputed);

--- a/devinfra/js/debundle/lowering/materialize/plan_builder.rs
+++ b/devinfra/js/debundle/lowering/materialize/plan_builder.rs
@@ -52,10 +52,12 @@ use selector_diagnostics::{
     SelectorDiagnosticsReport,
 };
 use selector_ir::{
-    ClaimOutcome, ResolvedClaim, SelectorFact, SelectorFactStore, SelectorTargetId, SolverResult,
+    ClaimOutcome, ResolvedClaim, SelectorAtom, SelectorFact, SelectorFactStore, SelectorProgram,
+    SelectorTargetId, SolverResult,
 };
 use selector_ir_lowering::{MemberSelectorLoweringContext, MemberSelectorProgramBuilder};
 use selector_ortools_cpsat_backend::OrToolsCpSatBackend;
+use source_match::SelectorResolver;
 
 const ORTOOLS_CPSAT_SOLVER_ENV: &str = "DUCKTAPE_DEBUNDLE_ORTOOLS_CPSAT_SOLVER";
 const ORTOOLS_CPSAT_SOLVER_RUNFILE: &str =
@@ -251,6 +253,12 @@ fn resolve_anchor<'a>(
 fn member_selector_spec_for_global_solver(
     member: &MemberRequest,
 ) -> Option<spec::MemberSelectorSpec> {
+    if let Some(binding) = &member.binding_selector
+        && !member.is_import_specifier
+    {
+        return Some(spec::MemberSelectorSpec::Binding(binding.clone()));
+    }
+
     if let Some(selector) = &member.source_match {
         return Some(spec::MemberSelectorSpec::SourceMatch(selector.clone()));
     }
@@ -288,21 +296,13 @@ fn member_selector_spec_for_global_solver(
 }
 
 fn selector_fact_store_for_chunk(
+    program: &SelectorProgram,
     chunk_id: ChunkId,
     owner_graph: &analysis::OwnerGraph,
     module: &swc_ecma_ast::Module,
     import_sources: &HashMap<String, String>,
 ) -> Result<SelectorFactStore> {
     let mut store = SelectorFactStore::default();
-    let ast_facts = chunk_facts::extract_facts(module).map_err(|unsupported| {
-        anyhow!(
-            "chunk {:?}: selector AST fact extraction failed at {}; global selector solving needs \
-             a complete AST EDB",
-            chunk_id,
-            unsupported.context,
-        )
-    })?;
-    store.extend_chunk_facts(chunk_id, &ast_facts);
     for node in owner_graph.iter_nodes() {
         store.push(SelectorFact::Owner {
             chunk_id,
@@ -329,51 +329,138 @@ fn selector_fact_store_for_chunk(
             });
         }
     }
-    for (ordinal, reads) in chunk_facts::member_reads_by_ordinal(module) {
-        for read in reads {
-            store.push(SelectorFact::MemberRead {
+
+    if selector_program_needs_ast_edb(program) {
+        let ast_facts = chunk_facts::extract_facts(module).map_err(|unsupported| {
+            anyhow!(
+                "chunk {:?}: selector AST fact extraction failed at {}; global selector solving \
+                 needs a complete AST EDB for this selector program",
                 chunk_id,
-                statement_ordinal: StatementOrdinal(ordinal),
-                object: read.object,
-                member: read.member,
+                unsupported.context,
+            )
+        })?;
+        store.extend_chunk_facts(chunk_id, &ast_facts);
+    }
+    if selector_program_needs_member_reads(program) {
+        for (ordinal, reads) in chunk_facts::member_reads_by_ordinal(module) {
+            for read in reads {
+                store.push(SelectorFact::MemberRead {
+                    chunk_id,
+                    statement_ordinal: StatementOrdinal(ordinal),
+                    object: read.object,
+                    member: read.member,
+                });
+            }
+        }
+    }
+    if selector_program_needs_module_member_uses(program) {
+        for (ordinal, uses) in chunk_facts::module_member_uses_by_ordinal(module, import_sources) {
+            for use_site in uses {
+                store.push(SelectorFact::ModuleMemberUse {
+                    chunk_id,
+                    statement_ordinal: StatementOrdinal(ordinal),
+                    module: use_site.module,
+                    member: use_site.member,
+                });
+            }
+        }
+    }
+    if selector_program_needs_call_argument_uses(program) {
+        for call in chunk_facts::call_argument_uses(module) {
+            store.push(SelectorFact::CallArgumentUse {
+                chunk_id,
+                argument: call.argument,
+                callee_object: call.callee_object,
+                callee_member: call.callee_member,
+                arg_index: call.arg_index,
             });
         }
     }
-    for (ordinal, uses) in chunk_facts::module_member_uses_by_ordinal(module, import_sources) {
-        for use_site in uses {
-            store.push(SelectorFact::ModuleMemberUse {
+    if selector_program_needs_decorate_call_uses(program) {
+        for call in chunk_facts::decorate_call_uses(module) {
+            store.push(SelectorFact::DecorateCallUse {
                 chunk_id,
-                statement_ordinal: StatementOrdinal(ordinal),
-                module: use_site.module,
-                member: use_site.member,
+                callee: call.callee,
+                class_anchor: call.class_anchor,
+                member: call.member,
             });
         }
     }
-    for call in chunk_facts::call_argument_uses(module) {
-        store.push(SelectorFact::CallArgumentUse {
-            chunk_id,
-            argument: call.argument,
-            callee_object: call.callee_object,
-            callee_member: call.callee_member,
-            arg_index: call.arg_index,
-        });
-    }
-    for call in chunk_facts::decorate_call_uses(module) {
-        store.push(SelectorFact::DecorateCallUse {
-            chunk_id,
-            callee: call.callee,
-            class_anchor: call.class_anchor,
-            member: call.member,
-        });
-    }
-    for alias in chunk_facts::intrinsic_alias_uses(module) {
-        store.push(SelectorFact::IntrinsicAliasUse {
-            chunk_id,
-            binding: alias.binding,
-            property: alias.property,
-        });
+    if selector_program_needs_intrinsic_alias_uses(program) {
+        for alias in chunk_facts::intrinsic_alias_uses(module) {
+            store.push(SelectorFact::IntrinsicAliasUse {
+                chunk_id,
+                binding: alias.binding,
+                property: alias.property,
+            });
+        }
     }
     Ok(store)
+}
+
+fn selector_program_needs_ast_edb(program: &SelectorProgram) -> bool {
+    program.atoms.iter().any(|atom| {
+        matches!(
+            atom,
+            SelectorAtom::OwnerTopLevelRoot { .. }
+                | SelectorAtom::AstKind { .. }
+                | SelectorAtom::AstChild { .. }
+                | SelectorAtom::AstChildListPattern { .. }
+                | SelectorAtom::AstSuperClass { .. }
+                | SelectorAtom::AstChildCount { .. }
+                | SelectorAtom::AstStringLiteral { .. }
+                | SelectorAtom::AstStringLiteralMatchingRegex { .. }
+                | SelectorAtom::AstNumberLiteral { .. }
+                | SelectorAtom::AstBoolLiteral { .. }
+                | SelectorAtom::AstIdentifierName { .. }
+                | SelectorAtom::AstPropertyName { .. }
+                | SelectorAtom::AstBareProperty { .. }
+                | SelectorAtom::AstOperator { .. }
+                | SelectorAtom::AstRegexLiteral { .. }
+                | SelectorAtom::AstTopLevel { .. }
+        )
+    })
+}
+
+fn selector_program_needs_member_reads(program: &SelectorProgram) -> bool {
+    program.atoms.iter().any(|atom| {
+        matches!(
+            atom,
+            SelectorAtom::ReadsMember { .. } | SelectorAtom::ReadsMemberOfOwner { .. }
+        )
+    })
+}
+
+fn selector_program_needs_module_member_uses(program: &SelectorProgram) -> bool {
+    program
+        .atoms
+        .iter()
+        .any(|atom| matches!(atom, SelectorAtom::ConsumesModuleMember { .. }))
+}
+
+fn selector_program_needs_call_argument_uses(program: &SelectorProgram) -> bool {
+    program.atoms.iter().any(|atom| {
+        matches!(
+            atom,
+            SelectorAtom::PassedToCall { .. } | SelectorAtom::PassedToCallOfOwner { .. }
+        )
+    })
+}
+
+fn selector_program_needs_decorate_call_uses(program: &SelectorProgram) -> bool {
+    program.atoms.iter().any(|atom| {
+        matches!(
+            atom,
+            SelectorAtom::MakesDecorateCall { .. } | SelectorAtom::MakesDecorateCallForOwner { .. }
+        )
+    })
+}
+
+fn selector_program_needs_intrinsic_alias_uses(program: &SelectorProgram) -> bool {
+    program
+        .atoms
+        .iter()
+        .any(|atom| matches!(atom, SelectorAtom::IntrinsicAlias { .. }))
 }
 
 fn solver_claim_is_import_specifier(facts: &SelectorFactStore, claim: &ResolvedClaim) -> bool {
@@ -683,6 +770,40 @@ fn anonymous_statement_ambiguous_message(
     )
 }
 
+fn anonymous_statement_diagnostic_message(
+    module: &swc_ecma_ast::Module,
+    request: &LogicalRequest,
+    statement: &AnonymousStatementRequest,
+) -> Option<String> {
+    let resolver = source_match::ChunkResolver::new(module);
+    let matches = match resolver.resolve_anonymous_groups(&request.id, &statement.selector) {
+        Ok(matches) => matches,
+        Err(error) => {
+            return Some(format!(
+                "logical_module {}: anonymous_statements[].match could not be checked after \
+                 global selector no-match: {error}. Selector:\n{}",
+                request.id, statement.selector.match_source,
+            ));
+        }
+    };
+    match matches.as_slice() {
+        [] => Some(anonymous_statement_no_match_message(request, statement)),
+        [_single] => None,
+        multiple => {
+            let body_indices = multiple
+                .iter()
+                .flat_map(|group| group.iter().copied())
+                .collect::<Vec<_>>();
+            Some(anonymous_statement_ambiguous_message(
+                request,
+                statement,
+                multiple.len(),
+                &body_indices,
+            ))
+        }
+    }
+}
+
 /// Output of `ChunkPlanBuilder::finalize`: everything downstream
 /// `lower_chunk` + the chunk-report builder need from the plan
 /// construction phase.
@@ -759,6 +880,11 @@ pub(super) struct ChunkPlanBuilder {
     /// known source binding spelling but whose ownership is claimed after chunk
     /// analysis through the global solver.
     deferred_binding_claims_by_name: HashMap<String, DuplicateClaimSite>,
+    /// Deferred binding selector names that were duplicate claims during
+    /// request construction. Every member for such a binding stays out of the
+    /// solver program so the existing duplicate-claim report remains the
+    /// primary diagnostic.
+    duplicate_deferred_binding_names: BTreeSet<String>,
     /// Duplicate binding claims found while processing explicit
     /// requests. We keep scanning later requests after recording a
     /// duplicate so one run can report all duplicate claim sites in
@@ -794,6 +920,7 @@ impl ChunkPlanBuilder {
             unmatched_spec_claims: Vec::new(),
             catalogue_index_by_name: HashMap::new(),
             deferred_binding_claims_by_name: HashMap::new(),
+            duplicate_deferred_binding_names: BTreeSet::new(),
             duplicate_binding_claims: Vec::new(),
             source_match_diagnostics: Vec::new(),
             anonymous_statement_diagnostics: Vec::new(),
@@ -835,6 +962,10 @@ impl ChunkPlanBuilder {
                     );
                     self.duplicate_binding_claims.push(duplicate);
                     duplicate_bindings.insert(member.binding.clone());
+                    if member.resolves_after_chunk_analysis() {
+                        self.duplicate_deferred_binding_names
+                            .insert(member.binding.clone());
+                    }
                     continue;
                 }
                 if let Some(existing) = self
@@ -852,6 +983,8 @@ impl ChunkPlanBuilder {
                         },
                     });
                     duplicate_bindings.insert(member.binding.clone());
+                    self.duplicate_deferred_binding_names
+                        .insert(member.binding.clone());
                     continue;
                 }
             }
@@ -1054,6 +1187,22 @@ impl ChunkPlanBuilder {
         bail!("{message}")
     }
 
+    fn report_anonymous_statement_failure_before_binding_no_match(
+        &mut self,
+        module: &swc_ecma_ast::Module,
+        request: &LogicalRequest,
+    ) -> Result<bool> {
+        for statement in &request.anonymous_statements {
+            let Some(message) = anonymous_statement_diagnostic_message(module, request, statement)
+            else {
+                continue;
+            };
+            self.record_anonymous_statement_failure_or_bail(request, statement, message)?;
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub(super) fn resolve_and_claim_global_selectors(
         &mut self,
@@ -1095,6 +1244,14 @@ impl ChunkPlanBuilder {
             for (index, request) in explicit_requests.iter().enumerate() {
                 let group_assignments = source_match_group_assignments(request);
                 for (member_index, member) in request.members.iter().enumerate() {
+                    if member.resolves_after_chunk_analysis()
+                        && !member.binding.is_empty()
+                        && self
+                            .duplicate_deferred_binding_names
+                            .contains(&member.binding)
+                    {
+                        continue;
+                    }
                     if member.binding_selector.is_some() && !member.is_import_specifier {
                         let binding_id = top_level_id(&member.binding, chunk_top_level_mark);
                         if !declaration_by_name.contains_key(&binding_id) {
@@ -1180,9 +1337,86 @@ impl ChunkPlanBuilder {
         if program.targets.is_empty() {
             return Ok(());
         }
-        let facts =
-            selector_fact_store_for_chunk(chunk_id_interned, owner_graph, module, import_sources)?;
+        let facts = selector_fact_store_for_chunk(
+            &program,
+            chunk_id_interned,
+            owner_graph,
+            module,
+            import_sources,
+        )?;
         let result = solve_global_selector_program(&program, &facts)?;
+
+        for info in anonymous_statement_targets {
+            let request = &explicit_requests[info.request_index];
+            match result.outcome_for(info.target) {
+                Some(ClaimOutcome::Unique { claim }) => {
+                    self.claim_anonymous_statement_from_solver(
+                        module,
+                        info.request_index,
+                        &request.id,
+                        &info.statement,
+                        claim,
+                    )?;
+                }
+                Some(ClaimOutcome::NoMatch) => {
+                    self.record_anonymous_statement_failure_or_bail(
+                        request,
+                        &info.statement,
+                        anonymous_statement_no_match_message(request, &info.statement),
+                    )?;
+                    continue;
+                }
+                Some(ClaimOutcome::Ambiguous { candidates }) => {
+                    let body_indices = candidates
+                        .iter()
+                        .filter_map(|candidate| {
+                            body_index_for_statement_ordinal(
+                                &module.body,
+                                candidate.statement_ordinal.0,
+                            )
+                        })
+                        .collect::<Vec<_>>();
+                    self.record_anonymous_statement_failure_or_bail(
+                        request,
+                        &info.statement,
+                        anonymous_statement_ambiguous_message(
+                            request,
+                            &info.statement,
+                            candidates.len(),
+                            &body_indices,
+                        ),
+                    )?;
+                    continue;
+                }
+                Some(ClaimOutcome::Duplicate {
+                    owner,
+                    conflicting_targets,
+                }) => {
+                    bail!(
+                        "logical_module {}: global selector solver assigned anonymous statement \
+                         to duplicate owner {:?} shared by targets {:?}",
+                        request.id,
+                        owner,
+                        conflicting_targets,
+                    );
+                }
+                Some(ClaimOutcome::Unsupported { message }) => {
+                    bail!(
+                        "logical_module {}: global selector solver does not support anonymous \
+                         statement selector: {}",
+                        request.id,
+                        message,
+                    );
+                }
+                None => {
+                    bail!(
+                        "logical_module {}: global selector solver returned no outcome for \
+                         anonymous statement selector",
+                        request.id,
+                    );
+                }
+            }
+        }
 
         for (target, (index, member)) in deferred_targets {
             let request = &explicit_requests[index];
@@ -1236,6 +1470,15 @@ impl ChunkPlanBuilder {
                             continue;
                         }
                         bail!("{message}");
+                    }
+                    if member.binding_selector.is_some()
+                        && member.source_match.is_none()
+                        && member.relational.is_none()
+                        && self.report_anonymous_statement_failure_before_binding_no_match(
+                            module, request,
+                        )?
+                    {
+                        continue;
                     }
                     bail!(
                         "logical_module {}: global selector solver found no match for selector \
@@ -1307,77 +1550,6 @@ impl ChunkPlanBuilder {
                         request.id,
                         member.export_name,
                         member.claim_origin,
-                    );
-                }
-            }
-        }
-        for info in anonymous_statement_targets {
-            let request = &explicit_requests[info.request_index];
-            match result.outcome_for(info.target) {
-                Some(ClaimOutcome::Unique { claim }) => {
-                    self.claim_anonymous_statement_from_solver(
-                        module,
-                        info.request_index,
-                        &request.id,
-                        &info.statement,
-                        claim,
-                    )?;
-                }
-                Some(ClaimOutcome::NoMatch) => {
-                    self.record_anonymous_statement_failure_or_bail(
-                        request,
-                        &info.statement,
-                        anonymous_statement_no_match_message(request, &info.statement),
-                    )?;
-                    continue;
-                }
-                Some(ClaimOutcome::Ambiguous { candidates }) => {
-                    let body_indices = candidates
-                        .iter()
-                        .filter_map(|candidate| {
-                            body_index_for_statement_ordinal(
-                                &module.body,
-                                candidate.statement_ordinal.0,
-                            )
-                        })
-                        .collect::<Vec<_>>();
-                    self.record_anonymous_statement_failure_or_bail(
-                        request,
-                        &info.statement,
-                        anonymous_statement_ambiguous_message(
-                            request,
-                            &info.statement,
-                            candidates.len(),
-                            &body_indices,
-                        ),
-                    )?;
-                    continue;
-                }
-                Some(ClaimOutcome::Duplicate {
-                    owner,
-                    conflicting_targets,
-                }) => {
-                    bail!(
-                        "logical_module {}: global selector solver assigned anonymous statement \
-                         to duplicate owner {:?} shared by targets {:?}",
-                        request.id,
-                        owner,
-                        conflicting_targets,
-                    );
-                }
-                Some(ClaimOutcome::Unsupported { message }) => {
-                    bail!(
-                        "logical_module {}: global selector solver does not support anonymous \
-                         statement selector: {}",
-                        request.id,
-                        message,
-                    );
-                }
-                None => {
-                    bail!(
-                        "logical_module {}: global selector solver returned no outcome for \
-                         anonymous statement selector",
-                        request.id,
                     );
                 }
             }

--- a/devinfra/js/debundle/lowering/plans.rs
+++ b/devinfra/js/debundle/lowering/plans.rs
@@ -118,12 +118,14 @@ impl MemberRequest {
     /// Whether this member's ownership is intentionally unknown until chunk
     /// analysis facts are available and the global selector solver runs.
     ///
-    /// Source-match and relational selectors resolve through the global solver.
-    /// Plain binding selectors stay on the direct claim path for now so they
-    /// keep their existing duplicate/unmatched diagnostics and do not require
-    /// full AST selector facts.
+    /// Source-match, relational, and non-import binding selectors resolve
+    /// through the global solver. Plain binding selectors keep their binding
+    /// spelling for hints and duplicate diagnostics, but ownership is read back
+    /// from the solver.
     pub(super) fn resolves_after_chunk_analysis(&self) -> bool {
-        self.source_match.is_some() || self.relational.is_some()
+        self.source_match.is_some()
+            || self.relational.is_some()
+            || (self.binding_selector.is_some() && !self.is_import_specifier)
     }
 
     pub(super) fn cross_ref(&self) -> Option<&spec::CrossRefTarget> {

--- a/devinfra/js/debundle/selector_ir_lowering.rs
+++ b/devinfra/js/debundle/selector_ir_lowering.rs
@@ -62,6 +62,7 @@ pub struct MemberSelectorProgramBuilder {
     owners_by_export: BTreeMap<(String, String), SelectorVariableId>,
     global_owner_by_export: BTreeMap<String, Option<SelectorVariableId>>,
     targeted_owners: BTreeMap<SelectorVariableId, String>,
+    injective_targeted_owners: BTreeSet<SelectorVariableId>,
     owner_injectivity_classes: BTreeMap<SelectorVariableId, String>,
 }
 
@@ -91,6 +92,7 @@ impl MemberSelectorProgramBuilder {
             owners_by_export: BTreeMap::new(),
             global_owner_by_export: BTreeMap::new(),
             targeted_owners: BTreeMap::new(),
+            injective_targeted_owners: BTreeSet::new(),
             owner_injectivity_classes: BTreeMap::new(),
         }
     }
@@ -127,6 +129,9 @@ impl MemberSelectorProgramBuilder {
         let owner = self.owner_for_local_export(&logical_module, export_name);
         self.targeted_owners
             .insert(owner, format!("{logical_module}::{export_name}"));
+        if !matches!(selector, MemberSelectorSpec::Binding(_)) {
+            self.injective_targeted_owners.insert(owner);
+        }
         self.global_owner_by_export
             .entry(export_name.to_string())
             .and_modify(|slot| {
@@ -207,7 +212,7 @@ impl MemberSelectorProgramBuilder {
         let mut unique_target_by_owner_class =
             BTreeMap::<OwnerInjectivityClass, SelectorTargetId>::new();
         for target in &self.program.targets {
-            if self.targeted_owners.contains_key(&target.owner) {
+            if self.injective_targeted_owners.contains(&target.owner) {
                 let class = self
                     .owner_injectivity_classes
                     .get(&target.owner)
@@ -4265,7 +4270,10 @@ function second() {
         let delegator_owner = program.targets[delegator.0].owner;
 
         assert_eq!(program.variables.len(), 2);
-        assert_eq!(program.all_different, vec![vec![anchor, delegator]]);
+        assert!(
+            program.all_different.is_empty(),
+            "plain binding targets are not owner-injective by themselves"
+        );
         assert!(matches!(
             program.atoms.iter().find(|atom| matches!(atom, SelectorAtom::OwnerReferencesOwner { .. })),
             Some(SelectorAtom::OwnerReferencesOwner {
@@ -4273,5 +4281,51 @@ function second() {
                 referenced: OwnerTerm::Var { id: referenced_id },
             }) if *owner_id == delegator_owner && *referenced_id == anchor_owner
         ));
+    }
+
+    #[test]
+    fn relational_targets_remain_owner_injective_without_binding_anchors() {
+        let mut builder = MemberSelectorProgramBuilder::new(context());
+        let anchor = builder
+            .lower_member_selector(
+                "Anchor",
+                &MemberSelectorSpec::Binding(BindingSelector {
+                    name: "a".to_string(),
+                    kind: None,
+                }),
+            )
+            .unwrap();
+        let first = builder
+            .lower_member_selector(
+                "First",
+                &MemberSelectorSpec::CrossRef(CrossRefTarget {
+                    relation: CrossRefRelation::References,
+                    anchor: "Anchor".to_string(),
+                    kind: Some(BindingSourceKind::FunctionDeclaration),
+                }),
+            )
+            .unwrap();
+        let second = builder
+            .lower_member_selector(
+                "Second",
+                &MemberSelectorSpec::CrossRef(CrossRefTarget {
+                    relation: CrossRefRelation::References,
+                    anchor: "Anchor".to_string(),
+                    kind: Some(BindingSourceKind::FunctionDeclaration),
+                }),
+            )
+            .unwrap();
+
+        let program = builder.into_program().unwrap();
+
+        assert_eq!(program.all_different, vec![vec![first, second]]);
+        assert!(
+            !program
+                .all_different
+                .iter()
+                .flatten()
+                .any(|target| *target == anchor),
+            "plain binding anchors should not participate in target owner injectivity"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Add an anonymized e2e smoke test for the broad/specific alpha-all selector shape.
- Prove eleven specific source-match claims plus one broad claim resolve through global target injectivity, selecting the remaining route.
- Wire the existing global-selector stress fixture into that executable smoke-test story while keeping the pending YAML as the backend benchmark sketch.

## Validation

- `nix develop -c bbr test //devinfra/js/debundle/e2e:global_selector_assignment_test --cache_test_results=no --test_output=errors`
  - BuildBuddy invocation: `7611a8e9-9dd2-41a2-afc6-4061d2be6b05`
- `nix develop -c pre-commit run --files devinfra/js/debundle/e2e/global_selector_assignment_test.rs devinfra/js/debundle/e2e/BUILD.bazel devinfra/js/debundle/e2e/testdata/global_selector_assignment_stress/broad_specific_injective/README.md`