### PR TITLE
haku-state tf: provision the haku-ci runner registration token via Forgejo API

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -136,6 +136,7 @@ tf.download(
         "hcloud": "hetznercloud/hcloud:1.60.0",
         "headscale": "awlsring/headscale:0.5.0",
         "helm": "hashicorp/helm:3.1.1",
+        "http": "hashicorp/http:3.6.0",
         "kubernetes": "hashicorp/kubernetes:2.38.0",
         "libvirt": "dmacvicar/libvirt:0.9.3",
         "local": "hashicorp/local:2.5.3",

--- a/cluster/k8s/haku-ci/README.md
+++ b/cluster/k8s/haku-ci/README.md
@@ -28,28 +28,25 @@ adversarial (containment = cross-origin iframe isolation + the capability gate +
 scheme-gate). A CI-built image vs committed files doesn't widen that — it only changes _how_
 Haku produces the image, and the runner can't escape its perimeter.
 
-## ⚠️ Paving steps (not yet done — fill in during the iterate loop)
+## ⚠️ Paving — validate the builder
 
-1. **Registration token (required — the pod stays pending without it).** A **repo-scoped**
-   runner registration token for `haku-state`, provisioned as Secret `haku-ci-runner-token`
-   (key `token`) in `haku-ci`. **Ideal: tofu-controller-provisioned** — but the `svalabs/forgejo`
-   provider doesn't expose runner registration tokens, so until that's added (or we drive the
-   Forgejo `…/runners/registration-token` API from a tofu `null_resource`/`restapi` provider),
-   it's generated once from the repo's Actions → Runners settings and committed as a SOPS
-   `runner-token.sops.yaml` here. **TODO: replace the manual SOPS step with tofu provisioning.**
-2. **Validate the builder.** Rootless `dind` on Talos is the **main risk** and may need
-   securityContext/seccomp tuning, `/dev/fuse`, or a switch to **rootless buildkit** if the
-   daemon won't start. Check `kubectl -n haku-ci logs deploy/haku-runner -c dind`, run a trivial
-   `.forgejo/workflows/` build, and iterate here.
+Rootless `dind` on Talos is the **main risk** and may need securityContext/seccomp tuning,
+`/dev/fuse`, or a switch to **rootless buildkit** if the daemon won't start. Check
+`kubectl -n haku-ci logs deploy/haku-runner -c dind`, run a trivial `.forgejo/workflows/`
+build, and iterate here.
 
 ## What's here
 
-| File                 | Role                                                                |
-| -------------------- | ------------------------------------------------------------------- |
-| `namespace.yaml`     | the `haku-ci` namespace                                             |
-| `networkpolicy.yaml` | egress fence (DNS + registries/npm/pypi + in-cluster)               |
-| `runner-config.yaml` | the act_runner `config.yaml` (labels, dind `DOCKER_HOST`, capacity) |
-| `deployment.yaml`    | the act_runner + rootless `dind` sidecar                            |
+| File                 | Role                                                                                     |
+| -------------------- | ---------------------------------------------------------------------------------------- |
+| `namespace.yaml`     | the `haku-ci` namespace                                                                  |
+| `networkpolicy.yaml` | egress fence (DNS + registries/npm/pypi + in-cluster)                                    |
+| `config.yaml`        | the act_runner config (labels, dind `DOCKER_HOST`, capacity), via a `configMapGenerator` |
+| `deployment.yaml`    | the act_runner + rootless `dind` sidecar                                                 |
 
-`flux-kustomization.yaml` (root-wired) applies this dir; `wait: false` because the runner is
-pending until the token lands.
+The registration-token Secret (`haku-ci-runner-token`) is provisioned by `tf/gitops/haku-state`
+(a `hashicorp/http` GET of the repo's runner registration-token API, written to the Secret) —
+not committed here.
+
+`flux-kustomization.yaml` (root-wired) applies this dir; `wait: false` because the runner stays
+pending until that token Secret lands.

--- a/tf/gitops/haku-state/BUILD.bazel
+++ b/tf/gitops/haku-state/BUILD.bazel
@@ -4,6 +4,7 @@ tf_providers_versions(
     name = "providers",
     providers = {
         "forgejo": "svalabs/forgejo:~>1.5",
+        "http": "hashicorp/http:~>3.4",
         "kubernetes": "hashicorp/kubernetes:~>2.38",
         "random": "hashicorp/random:~>3.7",
     },
@@ -14,6 +15,7 @@ tf_module(
     name = "haku-state",
     providers = [
         "forgejo",
+        "http",
         "kubernetes",
         "random",
     ],

--- a/tf/gitops/haku-state/main.tf
+++ b/tf/gitops/haku-state/main.tf
@@ -118,3 +118,33 @@ resource "kubernetes_secret" "haku_forgejo_registry_pull" {
     })
   }
 }
+
+# Registration token for the contained Forgejo Actions runner (cluster/k8s/haku-ci),
+# which builds Haku's UI image from haku-state. The svalabs/forgejo provider has no
+# runner-token resource, so fetch it from the repo's registration-token API as the
+# repo-owning haku user (owner ⇒ repo admin) and deliver it to the haku-ci namespace
+# as the Secret the runner registers with. GET returns the repo's *current* token
+# (it doesn't rotate on read), so repeated applies don't churn the Secret.
+# depends_on forces the read to apply-time, after the repo exists.
+data "http" "haku_ci_registration_token" {
+  url    = "${var.forgejo_url}/api/v1/repos/${forgejo_user.haku.login}/${forgejo_repository.state.name}/actions/runners/registration-token"
+  method = "GET"
+  request_headers = {
+    Authorization = "Basic ${base64encode("${forgejo_user.haku.login}:${random_password.haku.result}")}"
+    Accept        = "application/json"
+  }
+  depends_on = [forgejo_repository.state]
+}
+
+# The haku-ci namespace is created by its own Flux kustomization (cluster/k8s/haku-ci);
+# this resource retries until it exists. Replaces the manual SOPS bootstrap token.
+resource "kubernetes_secret" "haku_ci_runner_token" {
+  metadata {
+    name      = "haku-ci-runner-token"
+    namespace = "haku-ci"
+  }
+
+  data = {
+    token = jsondecode(data.http.haku_ci_registration_token.response_body).token
+  }
+}

--- a/tf/gitops/haku-state/terraform.tf
+++ b/tf/gitops/haku-state/terraform.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "svalabs/forgejo"
       version = "~> 1.5"
     }
+    http = {
+      source  = "hashicorp/http"
+      version = "~> 3.4"
+    }
     kubernetes = {
       source  = "hashicorp/kubernetes"
       version = "~> 2.38"


### PR DESCRIPTION
Provisions the Forgejo Actions runner registration token (for the merged `cluster/k8s/haku-ci` runner) in Terraform, replacing the manual-SOPS bootstrap step.

The `svalabs/forgejo` provider has no runner-registration-token resource, so:
- a **`hashicorp/http`** data source `GET`s `…/repos/haku/haku-state/actions/runners/registration-token`, authenticated as the **repo-owning `haku` user** (owner ⇒ repo admin; creds already in-module). The endpoint returns the repo's *current* token (stable on read), so applies don't churn the Secret.
- a **`kubernetes_secret`** writes it to `haku-ci-runner-token` (key `token`) in the `haku-ci` namespace — the Secret the runner registers with. `tf-runner` already has cross-namespace secret access, so no new RBAC. The CR retries until the `haku-ci` namespace exists.

Provider wiring: `http` added to the module's `tf_providers_versions` (BUILD) + `terraform.tf`, **and** to the central provider mirror in `MODULE.bazel` (`hashicorp/http:3.6.0`, satisfies `~>3.4`) so `tofu validate` resolves it hermetically. The registry **push** cred is unchanged — CI uses Forgejo Actions' built-in job token.

`bbr test //tf/gitops/haku-state:validate` green; pre-commit (tflint/checkov/buildifier) green. The `cluster/k8s/haku-ci` README drops the (now-done) token paving step and records the token source as plain prose.

Base `devel`.