### PR TITLE
haku-ci: set namespace in kustomization (fixes runner never deploying)

### DIFF
--- a/cluster/k8s/haku-ci/kustomization.yaml
+++ b/cluster/k8s/haku-ci/kustomization.yaml
@@ -1,5 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+# Stamp the namespace on every resource — crucially the generated ConfigMap below,
+# which otherwise lands namespaceless and makes Flux fail the whole apply ("namespace
+# not specified"), so the runner Deployment never reconciles. (Skipped for the
+# cluster-scoped Namespace; idempotent for the others, which already set it.)
+namespace: haku-ci
 resources:
   - namespace.yaml
   - networkpolicy.yaml


### PR DESCRIPTION
**Regression fix.** The haku-ci Flux Kustomization is failing in-cluster:

```
ConfigMap/haku-runner-config-8b2g6b548d namespace not specified: the server could not find the requested resource
```

The configMapGenerator output lands namespaceless because neither `kustomization.yaml` (`namespace:`) nor `flux-kustomization.yaml` (`targetNamespace`) sets one — only the hand-written resources hardcode `namespace: haku-ci`. So Flux fails the apply and **the runner Deployment never reconciles** (verified: namespace + token Secret exist, but no Deployment/pods).

Fix: `namespace: haku-ci` in the kustomization stamps it on the generated ConfigMap (idempotent for the others; skipped for the cluster-scoped Namespace). `kubectl kustomize` confirms the ConfigMap now gets `namespace: haku-ci`.

Found while paving the haku-ci runner end-to-end.