### PR TITLE
haku/state_template: build pushes with the built-in Forgejo Actions token (A2)

### DIFF
--- a/haku/state_template/.forgejo/workflows/build-ui.yaml
+++ b/haku/state_template/.forgejo/workflows/build-ui.yaml
@@ -28,17 +28,26 @@ on:
 jobs:
   build:
     runs-on: haku-ci # the repo-scoped, contained runner label (cluster/k8s/haku-ci)
+    # The built-in Forgejo Actions job token (github.token) authenticates the registry
+    # push — no separately-provisioned secret. packages:write scopes it to push to the
+    # repo owner's (haku/*) package namespace.
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # The runner provides a Docker-compatible builder. Auth to the in-cluster
-      # Forgejo registry using the `haku` user + a Forgejo Actions secret
-      # (FORGEJO_REGISTRY_PASSWORD) scoped to the haku/* package namespace.
+      # The runner provides a Docker-compatible builder. Auth to the in-cluster Forgejo
+      # registry with the built-in job token (github.actor + github.token) — Forgejo
+      # mints it per run, so there's no FORGEJO_REGISTRY_PASSWORD secret to provision.
+      # Fallback if a push is ever rejected (token lacks package write): provision a
+      # `forgejo_repository_action_secret` push cred in tf/gitops/haku-state and use
+      # `${{ secrets.<NAME> }}` here instead.
       - name: Log in to the Forgejo registry
         run: |
-          echo "${{ secrets.FORGEJO_REGISTRY_PASSWORD }}" \
-            | docker login git.allegedly.works -u haku --password-stdin
+          echo "${{ github.token }}" \
+            | docker login git.allegedly.works -u "${{ github.actor }}" --password-stdin
 
       # Tag pattern is what Flux image automation sorts on: a UTC timestamp makes
       # the newest build the highest tag (ImagePolicy `numerical` on the captured

--- a/haku/state_template/ui/README.md
+++ b/haku/state_template/ui/README.md
@@ -83,6 +83,7 @@ HAKU_UI_GIT_USERNAME=… HAKU_UI_GIT_PASSWORD=… HAKU_UI_FORGEJO_API_URL=… py
    at the `{"$imagepolicy": ...}` marker.
 4. Flux reconciles `haku-state` `k8s/` → the `haku-ui` Deployment rolls the new image.
 
-Runtime deps land separately: the runner (`cluster/k8s/haku-ci`), the registry push
-cred (`FORGEJO_REGISTRY_PASSWORD` Actions secret), and the `haku-forgejo-registry-pull`
-imagePullSecret. Real end-to-end validation happens in the paving loop after those land.
+Runtime deps land separately: the runner (`cluster/k8s/haku-ci`) and the
+`haku-forgejo-registry-pull` imagePullSecret. The registry **push** needs no secret —
+CI uses the built-in Forgejo Actions job token (`github.token`, `packages: write`). Real
+end-to-end validation happens in the paving loop after those land.


### PR DESCRIPTION
Closes the **A2** paving gap: `build-ui.yaml` did `docker login … ${{ secrets.FORGEJO_REGISTRY_PASSWORD }}`, but nothing provisions that secret — the first build would fail at login.

Switches to Forgejo Actions' **built-in job token**: `docker login -u ${{ github.actor }} -p ${{ github.token }}` with job `permissions: packages: write`. Forgejo mints the token per run, scoped to the repo owner's (`haku/*`) package namespace — no secret to provision.

"If it works": this is the standard GHCR-style pattern and Forgejo supports it, but it can't be verified until the runner is up (#2571) and Haku adopts the workflow. The workflow carries an explicit **fallback** comment — if a push is ever rejected, provision a `forgejo_repository_action_secret` push cred in `tf/gitops/haku-state` and use `${{ secrets.<NAME> }}`.

Part of paving the haku-ui CI chain (with #2571 and the still-to-build Flux image automation).