### PR TITLE
[codex] Treat catch alpha scope as lexical

### DIFF
--- a/devinfra/js/debundle/selector_ir_lowering.rs
+++ b/devinfra/js/debundle/selector_ir_lowering.rs
@@ -1644,10 +1644,11 @@ fn alpha_scope_kind(kind: NodeKind) -> Option<AlphaScopeKind> {
             | NodeKind::AsyncArrow
             | NodeKind::Constructor
             | NodeKind::Setter
-            | NodeKind::Catch
     )
     .then_some(AlphaScopeKind::Var)
-    .or_else(|| (kind == NodeKind::Block).then_some(AlphaScopeKind::Lexical))
+    .or_else(|| {
+        matches!(kind, NodeKind::Block | NodeKind::Catch).then_some(AlphaScopeKind::Lexical)
+    })
 }
 
 fn native_target_binding_node(
@@ -4106,6 +4107,43 @@ function second() {
         assert!(
             !occurrence_counts.values().any(|count| *count == 4),
             "sibling block destructuring bindings must not collapse into one alpha variable: {occurrence_counts:?}"
+        );
+    }
+
+    #[test]
+    fn alpha_all_var_decl_inside_catch_binds_enclosing_var_scope() {
+        let mut selector = AnonymousStatementSelector::exact(
+            r#"function readable() {
+  try {
+    risky();
+  } catch (err) {
+    var hoisted = err;
+  }
+  return hoisted;
+}"#,
+        );
+        selector.identifiers = SourceMatchIdentifierMode::AlphaAll;
+        let lowered = lower_member_selector(
+            &context(),
+            "Widget",
+            &MemberSelectorSpec::SourceMatch(selector),
+        )
+        .unwrap();
+
+        let identifier_vars = alpha_identifier_vars_in_source_order(&lowered.program);
+        let occurrence_counts = identifier_occurrence_counts(&identifier_vars);
+        assert_eq!(
+            occurrence_counts
+                .values()
+                .copied()
+                .filter(|count| *count == 2)
+                .count(),
+            2,
+            "catch param uses and catch-body var/return uses should each pair: {occurrence_counts:?}"
+        );
+        assert!(
+            !occurrence_counts.values().any(|count| *count > 2),
+            "catch-local names must not merge with function-scope var names: {occurrence_counts:?}"
         );
     }
 


### PR DESCRIPTION
## Summary
- Treat `catch` as a lexical alpha scope instead of a var scope.
- Keep `var` declarations inside a catch body bound to the enclosing function/root var scope.
- Add coverage for catch-param uses versus catch-body `var`/return uses under `alpha_all`.

## Validation
- `nix develop -c rustfmt devinfra/js/debundle/selector_ir_lowering.rs`
- `nix develop -c bbr test //devinfra/js/debundle:selector_ir_lowering_test --cache_test_results=no --test_output=errors`
  - BuildBuddy invocation: `a7f55cab-87a0-4a9d-880f-28832c1f99af`
- `nix develop -c pre-commit run --files devinfra/js/debundle/selector_ir_lowering.rs`