### PR TITLE
haku-ui: Haku-owned image automation + operator-owned webhook Receiver (A1)

### DIFF
--- a/cluster/k8s/haku/ui-image-webhook/README.md
+++ b/cluster/k8s/haku/ui-image-webhook/README.md
@@ -1,0 +1,28 @@
+# haku-ui image webhook (operator-owned)
+
+The **operator-owned** half of haku-ui's image automation: a generic Flux `Receiver` that a
+Forgejo `package` webhook (provisioned by `tf/gitops/haku-state`) hits on image publish, so
+Flux reconciles the `haku-ui` ImageRepository immediately instead of on its 5m poll.
+
+**Why this isn't in Haku's state_template** (where the rest of the automation lives —
+`haku/state_template/k8s/haku-ui-image-automation/`): a `Receiver` can force-reconcile any
+Flux resource cluster-wide (the notification-controller runs `--watch-all-namespaces` with no
+`--no-cross-namespace-refs` guard). That's a cross-namespace primitive the constrained
+`haku-state-reconciler` SA is designed to deny, so the Receiver stays operator-owned and just
+references Haku's `haku-sandbox:haku-ui` ImageRepository. The bounded image/source CRDs are
+Haku's.
+
+Generic receiver (not gitea/generic-hmac): Flux has no Forgejo receiver type and Forgejo's
+HMAC headers don't match generic-hmac; security is the unguessable `sha256(token)` path. If
+the webhook never fires (Forgejo package webhooks are owner-scoped — a repo webhook may not
+fire for `haku/ui`), the 5m ImageRepository poll is the safety net.
+
+## TODO: consider moving the Receiver into Haku too
+
+The only reason this is operator-owned is the cross-namespace force-reconcile primitive. If
+the notification-controller ran with **`--no-cross-namespace-refs`** (cluster-wide), a
+Haku-authored Receiver would be bounded to `haku-sandbox` resources — defanging the primitive
+— and the Receiver could move into `haku/state_template/` alongside the rest of the
+automation, making the whole pipeline Haku-owned. That flag is a cluster-wide change (audit
+existing cross-namespace Receivers first, e.g. the `github` one), so it's parked here as a
+follow-up rather than done now.

--- a/cluster/k8s/haku/ui-image-webhook/flux-kustomization.yaml
+++ b/cluster/k8s/haku/ui-image-webhook/flux-kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: haku-ui-image-webhook
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./cluster/k8s/haku/ui-image-webhook
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  dependsOn:
+    # haku-state provisions the forgejo-webhook-token Secret (the Receiver's secretRef)
+    # and the Forgejo package webhook that targets this receiver.
+    - name: haku-state

--- a/cluster/k8s/haku/ui-image-webhook/kustomization.yaml
+++ b/cluster/k8s/haku/ui-image-webhook/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - receiver.yaml

--- a/cluster/k8s/haku/ui-image-webhook/receiver.yaml
+++ b/cluster/k8s/haku/ui-image-webhook/receiver.yaml
@@ -1,0 +1,28 @@
+apiVersion: notification.toolkit.fluxcd.io/v1
+kind: Receiver
+metadata:
+  name: haku-ui-forgejo
+  namespace: flux-system
+spec:
+  # Forgejo's container-registry push fires a `package` webhook (provisioned by
+  # tf/gitops/haku-state) that hits this receiver, reconciling the haku-ui
+  # ImageRepository immediately instead of waiting for its 5m poll.
+  #
+  # Operator-owned (NOT in Haku's state_template): a Receiver lists resources to
+  # force-reconcile, which the notification-controller patches cluster-wide — a
+  # cross-namespace primitive we deliberately keep out of Haku's hands. The
+  # ImageRepository it triggers is Haku's own (haku-sandbox), referenced cross-namespace.
+  #
+  # type: generic — Flux has no Forgejo/Gitea receiver type, and Forgejo's HMAC headers
+  # (X-Gitea-Signature / X-Hub-Signature-256) don't match generic-hmac's X-Signature.
+  # Security is therefore the unguessable sha256(token) webhook path; a leaked URL only
+  # triggers a harmless ImageRepository re-scan. The token is the forgejo-webhook-token
+  # Secret (flux-system), which the Forgejo webhook URL also derives its path from.
+  type: generic
+  secretRef:
+    name: forgejo-webhook-token
+  resources:
+    - apiVersion: image.toolkit.fluxcd.io/v1beta2
+      kind: ImageRepository
+      name: haku-ui
+      namespace: haku-sandbox

--- a/cluster/k8s/haku/workloads/rbac.yaml
+++ b/cluster/k8s/haku/workloads/rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   name: haku-state-workload-deployer
   namespace: haku-sandbox
   annotations:
-    description: "What Flux may apply when reconciling Haku's haku-state k8s/ dir — the workload subset of haku-sandbox-admin: Deployments/StatefulSets/DaemonSets/ReplicaSets, Services/ConfigMaps/PVCs, Jobs/CronJobs. Deliberately NOT secrets (no plaintext-git secrets) and NOT Gateway-API routes (Kyverno denies those too). So Haku's GitOps path can run workloads but never widen its own perimeter."
+    description: "What Flux may apply when reconciling Haku's haku-state k8s/ dir — the workload subset of haku-sandbox-admin: Deployments/StatefulSets/DaemonSets/ReplicaSets, Services/ConfigMaps/PVCs, Jobs/CronJobs, plus its own Flux image automation (image.toolkit ImageRepository/ImagePolicy/ImageUpdateAutomation + source.toolkit GitRepository). Those are bounded — the controllers that reconcile them only ever touch Haku's own images + haku-state. Deliberately NOT secrets (no plaintext-git secrets), NOT Gateway-API routes (Kyverno denies those too), and NOT notification.toolkit Receivers (a cross-namespace force-reconcile primitive — kept operator-owned, see cluster/k8s/haku/ui-image-webhook). So Haku's GitOps path can run + ship its own workloads but never widen its own perimeter."
 rules:
   - apiGroups: [""]
     resources:
@@ -23,6 +23,17 @@ rules:
     resources:
       - jobs
       - cronjobs
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Haku's own image automation (bounded — see the description). NOT Receivers.
+  - apiGroups: ["image.toolkit.fluxcd.io"]
+    resources:
+      - imagerepositories
+      - imagepolicies
+      - imageupdateautomations
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["source.toolkit.fluxcd.io"]
+    resources:
+      - gitrepositories
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -209,6 +209,7 @@ resources:
   - haku/agent-worker/flux-kustomization.yaml # suspended; see the dir README to activate
   - haku/cloud-agent-tf/flux-kustomization.yaml # Anthropic-hosted agent via claude-managed-agents tofu provider
   - haku/workloads/flux-kustomization.yaml # Flux reconciles Haku's haku-state k8s/ workloads under a constrained SA
+  - haku/ui-image-webhook/flux-kustomization.yaml # operator-owned Receiver: Forgejo package webhook → reconcile the (Haku-owned) haku-ui ImageRepository
 
   # --- matrix ---
   - matrix/namespace/flux-kustomization.yaml

--- a/cluster/validation/image_automation.py
+++ b/cluster/validation/image_automation.py
@@ -17,6 +17,12 @@ from __future__ import annotations
 from cluster.validation.cluster import ParsedCluster
 from cluster.validation.k8s import ImagePolicyResource, ImageRepositoryResource, ReceiverResource
 
+# ImageRepositories defined in Haku's haku-state (haku/state_template), reconciled into
+# haku-sandbox — not under cluster/k8s, so the validator can't see them. An operator-owned
+# Receiver here may still reference one (cluster/k8s/haku/ui-image-webhook), so exempt these
+# from the "Receiver references an undefined ImageRepository" check.
+_HAKU_STATE_IMAGE_REPOS = {"haku-ui"}
+
 
 def check_image_automation_webhook(cluster: ParsedCluster) -> list[str]:
     image_repos: set[str] = set()
@@ -43,7 +49,7 @@ def check_image_automation_webhook(cluster: ParsedCluster) -> list[str]:
         *(
             f"flux-webhook/github-webhook-receiver.yaml references ImageRepository '{name}', "
             "but no such ImageRepository is defined under cluster/k8s."
-            for name in sorted(webhook_repos - image_repos)
+            for name in sorted(webhook_repos - image_repos - _HAKU_STATE_IMAGE_REPOS)
         ),
         *(
             f"ImagePolicy '{policy}' references ImageRepository '{ref}', which is not defined."

--- a/haku/state_template/k8s/haku-ui-image-automation/README.md
+++ b/haku/state_template/k8s/haku-ui-image-automation/README.md
@@ -1,0 +1,24 @@
+# haku-ui image automation (Haku-owned)
+
+Rolls the CI-built `haku-ui` image into the deployment, as **Haku's own** Flux image
+automation — reconciled into `haku-sandbox` by the workloads pipe (so Haku owns and can
+evolve it, like the rest of its state). The cluster's privileged Flux controllers
+(image-reflector, image-automation) reconcile these CRs; everything they touch — the
+`haku/ui` image, `haku-state` — is already Haku's, so this grants no perimeter widening
+(the constrained reconciler SA is widened only for these bounded `image.toolkit` /
+`source.toolkit` kinds — **not** `Receiver`, which stays operator-owned).
+
+- `image-repository.yaml` — scans `git.allegedly.works/haku/ui` (private; auth via the
+  `haku-forgejo-registry-pull` Secret in haku-sandbox).
+- `image-policy.yaml` — newest `main-<utc14>-<sha>` tag, numeric.
+- `image-update-automation.yaml` — writes the tag into `k8s/haku-ui/deployment.yaml` (the
+  `{"$imagepolicy": "haku-sandbox:haku-ui"}` marker) and commits it back to haku-state via
+  the `haku-state-write` GitRepository.
+- `haku-state-write-source.yaml` — authenticated haku-state checkout (the
+  `haku-state-git-write` Secret) the automation pushes through.
+
+Push-driven reconcile (on image publish) is provided by an **operator-owned** generic Flux
+`Receiver` + Forgejo webhook (`cluster/k8s/haku/ui-image-webhook/`) that references this
+`haku-sandbox:haku-ui` ImageRepository — kept operator-side so Haku can't author a Receiver
+(a cross-namespace force-reconcile primitive). Without it, the 5m ImageRepository poll still
+applies.

--- a/haku/state_template/k8s/haku-ui-image-automation/haku-state-write-source.yaml
+++ b/haku/state_template/k8s/haku-ui-image-automation/haku-state-write-source.yaml
@@ -1,0 +1,13 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: haku-state-write
+  annotations:
+    description: "Authenticated haku-state checkout for image-automation pushes (the haku-ui ImageUpdateAutomation writes the deploy tag back here). Separate from the read-only `haku-state` source used by the workloads pipe. Internal Forgejo, plaintext HTTP; basic auth via the haku-state-git-write Secret — the haku user owns the repo, so these creds can push."
+spec:
+  interval: 5m
+  url: http://forgejo-http.forgejo:3000/haku/haku-state.git
+  ref:
+    branch: main
+  secretRef:
+    name: haku-state-git-write

--- a/haku/state_template/k8s/haku-ui-image-automation/image-policy.yaml
+++ b/haku/state_template/k8s/haku-ui-image-automation/image-policy.yaml
@@ -1,0 +1,15 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: haku-ui
+spec:
+  imageRepositoryRef:
+    name: haku-ui
+  # Tags are main-<utc14>-<sha> (see haku/state_template/.forgejo/workflows/build-ui.yaml).
+  # Extract the 14-digit timestamp and pick the newest numerically.
+  filterTags:
+    pattern: "^main-(?P<ts>[0-9]{14})-[0-9a-f]+$"
+    extract: $ts
+  policy:
+    numerical:
+      order: asc

--- a/haku/state_template/k8s/haku-ui-image-automation/image-repository.yaml
+++ b/haku/state_template/k8s/haku-ui-image-automation/image-repository.yaml
@@ -1,0 +1,12 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: haku-ui
+spec:
+  # The image the deployment marker pins (git.allegedly.works/haku/ui). Private
+  # package, so the reflector authenticates with the haku creds via the
+  # haku-forgejo-registry-pull dockerconfigjson Secret (same namespace, haku-sandbox).
+  image: git.allegedly.works/haku/ui
+  interval: 5m
+  secretRef:
+    name: haku-forgejo-registry-pull

--- a/haku/state_template/k8s/haku-ui-image-automation/image-update-automation.yaml
+++ b/haku/state_template/k8s/haku-ui-image-automation/image-update-automation.yaml
@@ -1,0 +1,33 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageUpdateAutomation
+metadata:
+  name: haku-ui
+spec:
+  interval: 5m
+  sourceRef:
+    kind: GitRepository
+    name: haku-state-write
+  git:
+    checkout:
+      ref:
+        branch: main
+    commit:
+      author:
+        name: flux-image-automation
+        email: flux@allegedly.works
+      messageTemplate: |-
+        chore: update haku-ui image [skip ci]
+
+        {{ range $resource, $changes := .Changed.Objects -}}
+        {{ range $_, $change := $changes -}}
+        {{ $change.OldValue }} -> {{ $change.NewValue }}
+        {{ end -}}
+        {{ end -}}
+    push:
+      branch: main
+  update:
+    # Scan haku-state's k8s/ for the {"$imagepolicy": "haku-sandbox:haku-ui"} marker
+    # (on the haku-ui Deployment image line) and write the newest tag. [skip ci] keeps
+    # the bump from re-triggering the ui build (which only watches ui/** anyway).
+    strategy: Setters
+    path: ./k8s

--- a/haku/state_template/k8s/haku-ui-image-automation/kustomization.yaml
+++ b/haku/state_template/k8s/haku-ui-image-automation/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - haku-state-write-source.yaml
+  - image-repository.yaml
+  - image-policy.yaml
+  - image-update-automation.yaml

--- a/haku/state_template/k8s/haku-ui/deployment.yaml
+++ b/haku/state_template/k8s/haku-ui/deployment.yaml
@@ -32,9 +32,10 @@ spec:
           # Flux image automation writes this tag (NOT CI — the build-ui workflow
           # only pushes the image). The trailing `$imagepolicy` marker tells Flux's
           # ImageUpdateAutomation which image ref to rewrite; keep it on this line.
-          # Adopt the matching ImageRepository/ImagePolicy/ImageUpdateAutomation
-          # (ducktape ships them; see haku/state_template/README.md).
-          image: git.allegedly.works/haku/ui:latest # {"$imagepolicy": "flux-system:haku-ui"}
+          # The matching ImageRepository/ImagePolicy/ImageUpdateAutomation are Haku's
+          # own (the sibling k8s/haku-ui-image-automation/ dir), reconciled into
+          # haku-sandbox — hence the haku-sandbox:haku-ui policy ref.
+          image: git.allegedly.works/haku/ui:latest # {"$imagepolicy": "haku-sandbox:haku-ui"}
           ports:
             - containerPort: 8080
           env:

--- a/haku/state_template/k8s/kustomization.yaml
+++ b/haku/state_template/k8s/kustomization.yaml
@@ -6,3 +6,4 @@ kind: Kustomization
 # haku-sandbox only; routes denied by Kyverno). Add a dir per workload here.
 resources:
   - haku-ui
+  - haku-ui-image-automation

--- a/tf/gitops/haku-state/main.tf
+++ b/tf/gitops/haku-state/main.tf
@@ -92,12 +92,14 @@ resource "kubernetes_secret" "haku_state_git_write" {
   }
 }
 
-# imagePullSecret so Haku's UI Deployment (haku-sandbox) can pull the image its
-# Forgejo CI builds (git.allegedly.works/haku/ui:<sha>). The package is private
-# (haku's repo is private), so the kubelet needs auth. Pulls go over HTTPS via the
-# public host (kubelet image pulls are node-level, not subject to the pod's
-# mitmproxy egress). The CI workflow itself pushes with Forgejo Actions' built-in
-# job token — no push cred needed here. See cluster/k8s/haku-ci + haku/PLAN.md.
+# dockerconfigjson for the private git.allegedly.works/haku/ui package, in haku-sandbox:
+#   - the imagePullSecret Haku's UI Deployment uses to pull the image its Forgejo CI builds
+#     (kubelet pulls over HTTPS via the public host — node-level, not subject to the pod's
+#     mitmproxy egress), and
+#   - the auth Haku's own ImageRepository uses to scan the registry for new tags (the image
+#     automation is reconciled into haku-sandbox; see haku/state_template/k8s/haku-ui-image-automation).
+# The CI workflow itself pushes with Forgejo Actions' built-in job token — no push cred
+# needed here. See cluster/k8s/haku-ci + haku/PLAN.md.
 resource "kubernetes_secret" "haku_forgejo_registry_pull" {
   metadata {
     name      = "haku-forgejo-registry-pull"
@@ -146,5 +148,47 @@ resource "kubernetes_secret" "haku_ci_runner_token" {
 
   data = {
     token = jsondecode(data.http.haku_ci_registration_token.response_body).token
+  }
+}
+
+# Webhook token shared between the Forgejo package webhook and the Flux generic
+# Receiver `haku-ui-forgejo` (cluster/k8s/haku/ui-image-automation). The Receiver's
+# webhook path is sha256(token + receiver-name + namespace), so the token must match
+# on both ends. Don't rotate after creation — the path would change and orphan the
+# Forgejo webhook URL.
+resource "random_password" "forgejo_webhook_token" {
+  length  = 40
+  special = false
+}
+
+resource "kubernetes_secret" "forgejo_webhook_token" {
+  metadata {
+    name      = "forgejo-webhook-token"
+    namespace = "flux-system"
+  }
+
+  data = {
+    token = random_password.forgejo_webhook_token.result
+  }
+
+  lifecycle {
+    ignore_changes = [data]
+  }
+}
+
+# Fire a webhook on container-package publish (the CI image push) so Flux reconciles the
+# haku-ui ImageRepository immediately rather than on its 5m poll. Points at the in-cluster
+# receiver service (no hairpin / TLS). The generic receiver doesn't validate a signature,
+# so the unguessable sha256(token) path is the secret — no `secret` in the webhook config.
+# NOTE (verify in the paving loop): Forgejo packages are owner-scoped; a *repo* webhook may
+# not fire for `haku/ui` package pushes. If it doesn't, the 5m ImageRepository poll still
+# covers it — the webhook is a latency optimization, not a correctness dependency.
+resource "forgejo_repository_webhook" "haku_ui_image" {
+  repository_id = forgejo_repository.state.id
+  type          = "forgejo"
+  events        = ["package"]
+  config = {
+    content_type = "json"
+    url          = "http://webhook-receiver.flux-system/hook/${sha256(join("", [random_password.forgejo_webhook_token.result, "haku-ui-forgejo", "flux-system"]))}"
   }
 }


### PR DESCRIPTION
Closes the **A1** paving gap (the `$imagepolicy` marker was inert), with the automation **moved into Haku's `state_template`** so the pipeline is Haku's to own — split by the trust boundary.

### Haku-owned — `haku/state_template/k8s/haku-ui-image-automation/`
Adopted into haku-state, reconciled into **haku-sandbox** by the workloads pipe:
- **ImageRepository** scans private `git.allegedly.works/haku/ui` (`haku-forgejo-registry-pull` Secret, haku-sandbox).
- **ImagePolicy** — newest `main-<utc14>-<sha>`, numeric.
- **ImageUpdateAutomation** writes the tag into haku-state's `k8s/haku-ui/deployment.yaml` (marker now `haku-sandbox:haku-ui`) via a `haku-state-write` GitRepository.
- The constrained `haku-state-reconciler` Role is widened **only for the bounded** `image.toolkit`/`source.toolkit` kinds — the controllers reconciling them only ever touch Haku's own images + haku-state, so no perimeter widening.

### Operator-owned — `cluster/k8s/haku/ui-image-webhook/`
- A **generic** Flux `Receiver` + Forgejo `package` webhook (TF) for push-driven reconcile, referencing the Haku-owned `haku-sandbox:haku-ui` ImageRepository cross-namespace.
- **Why not in Haku's hands:** a `Receiver` is a cross-namespace force-reconcile primitive (the notification-controller runs `--watch-all-namespaces`, no `--no-cross-namespace-refs`). Kept operator-owned; the constrained SA is **not** granted `notification.toolkit`. README carries a **TODO** to move it into Haku too if that guardrail is ever enabled.

### Notes
- **Generic receiver** (not gitea/generic-hmac): Flux has no Forgejo receiver type and Forgejo's HMAC headers don't match generic-hmac; security is the unguessable `sha256(token)` path. Owner-scoped package-webhook unknown remains — the **5m poll is the safety net**.
- **Validator:** one-line carve-out so the operator Receiver may reference the haku-state-defined ImageRepository the cluster validator can't see.

Green: cluster integration + image_automation tests, `//tf/gitops/haku-state:validate`+`lint`, pre-commit (kubeconform/tflint/checkov/ruff/prettier).