### PR TITLE
[codex] Scope alpha-all switch bindings

### DIFF
--- a/devinfra/js/debundle/e2e/syntactic_holes_test.rs
+++ b/devinfra/js/debundle/e2e/syntactic_holes_test.rs
@@ -159,6 +159,51 @@ export { actual };
 }
 
 #[test]
+fn member_source_match_alpha_all_allows_name_reuse_in_switch_scope() {
+    let fixture = run_fixture(FixtureOpts::new(
+        r#"function actual(input) {
+  const a = "outer";
+  switch (input.kind) {
+    case "left":
+      const b = input.left;
+      return b;
+  }
+  return a;
+}
+console.log(actual({ kind: "left", left: "L" }), actual({ kind: "right", left: "R" }));
+export { actual };
+"#,
+        vec![logical_module(
+            "format",
+            &[Member::source_alpha(
+                "format_value",
+                r#"function readable(input) {
+  const value = "outer";
+  switch (input.kind) {
+    case "left":
+      const value = input.left;
+      return value;
+  }
+  return value;
+}"#,
+            )],
+        )],
+    ));
+
+    assert_entry_output(&fixture, "L outer\n");
+    assert_module_source(
+        &fixture.out_root,
+        "static/app/modules/format.js",
+        &[
+            "function format_value",
+            r#"const a = "outer""#,
+            "const b = input.left",
+        ],
+        &["function actual", "function readable"],
+    );
+}
+
+#[test]
 fn member_source_match_alpha_all_named_function_expression_name_is_function_local() {
     let fixture = run_fixture(FixtureOpts::new(
         r#"const a = () => "outer";

--- a/devinfra/js/debundle/selector_ir_lowering.rs
+++ b/devinfra/js/debundle/selector_ir_lowering.rs
@@ -1647,7 +1647,8 @@ fn alpha_scope_kind(kind: NodeKind) -> Option<AlphaScopeKind> {
     )
     .then_some(AlphaScopeKind::Var)
     .or_else(|| {
-        matches!(kind, NodeKind::Block | NodeKind::Catch).then_some(AlphaScopeKind::Lexical)
+        matches!(kind, NodeKind::Block | NodeKind::Catch | NodeKind::Switch)
+            .then_some(AlphaScopeKind::Lexical)
     })
 }
 
@@ -4144,6 +4145,72 @@ function second() {
         assert!(
             !occurrence_counts.values().any(|count| *count > 2),
             "catch-local names must not merge with function-scope var names: {occurrence_counts:?}"
+        );
+    }
+
+    #[test]
+    fn alpha_all_switch_let_uses_switch_lexical_scope() {
+        let mut selector = AnonymousStatementSelector::exact(
+            r#"function readable(input) {
+  const value = "outer";
+  switch (input.kind) {
+    case "left":
+      const value = input.left;
+      return value;
+  }
+  return value;
+}"#,
+        );
+        selector.identifiers = SourceMatchIdentifierMode::AlphaAll;
+        let lowered = lower_member_selector(
+            &context(),
+            "Widget",
+            &MemberSelectorSpec::SourceMatch(selector),
+        )
+        .unwrap();
+
+        let identifier_vars = alpha_identifier_vars_in_source_order(&lowered.program);
+        let occurrence_counts = identifier_occurrence_counts(&identifier_vars);
+        assert_eq!(
+            occurrence_counts
+                .values()
+                .copied()
+                .filter(|count| *count == 2)
+                .count(),
+            2,
+            "outer and switch-local `value` bindings should each pair with their own return: {occurrence_counts:?}"
+        );
+        assert!(
+            !occurrence_counts.values().any(|count| *count == 4),
+            "switch-local lexical bindings must not collapse with the enclosing block binding: {occurrence_counts:?}"
+        );
+    }
+
+    #[test]
+    fn alpha_all_var_decl_inside_switch_binds_enclosing_var_scope() {
+        let mut selector = AnonymousStatementSelector::exact(
+            r#"function readable(input) {
+  switch (input.kind) {
+    case "left":
+      var hoisted = input.left;
+      return hoisted;
+  }
+  return hoisted;
+}"#,
+        );
+        selector.identifiers = SourceMatchIdentifierMode::AlphaAll;
+        let lowered = lower_member_selector(
+            &context(),
+            "Widget",
+            &MemberSelectorSpec::SourceMatch(selector),
+        )
+        .unwrap();
+
+        let identifier_vars = alpha_identifier_vars_in_source_order(&lowered.program);
+        let occurrence_counts = identifier_occurrence_counts(&identifier_vars);
+        assert!(
+            occurrence_counts.values().any(|count| *count == 3),
+            "switch-body var binding should pair with both in-switch and after-switch uses: {occurrence_counts:?}"
         );
     }
 


### PR DESCRIPTION
## Summary
- Treat `switch` as a lexical alpha-all scope so `let`/`const` declarations in cases do not collapse with enclosing block bindings.
- Preserve `var` behavior inside switches by continuing to bind `var` declarations to the nearest enclosing var scope.
- Add unit and e2e coverage for switch-local readable names mapping to distinct minified names.

## Validation
- `nix develop -c rustfmt devinfra/js/debundle/selector_ir_lowering.rs devinfra/js/debundle/e2e/syntactic_holes_test.rs`
- `nix develop -c bbr test //devinfra/js/debundle:selector_ir_lowering_test //devinfra/js/debundle/e2e:syntactic_holes_test --cache_test_results=no --test_output=errors`
  - BuildBuddy invocation: `79c63713-5198-441c-800f-cd4072759da3`
- `nix develop -c pre-commit run --files devinfra/js/debundle/selector_ir_lowering.rs devinfra/js/debundle/e2e/syntactic_holes_test.rs`