### PR TITLE
[codex] Port Haku console colors to theme

### DIFF
--- a/haku/console/frontend/BUILD.bazel
+++ b/haku/console/frontend/BUILD.bazel
@@ -30,9 +30,16 @@ js_library(
 )
 
 js_library(
+    name = "theme",
+    srcs = ["theme.ts"],
+    deps = ["//:node_modules/@mantine/core"],
+)
+
+js_library(
     name = "toast",
     srcs = ["toast.ts"],
     deps = [
+        ":theme",
         "//:node_modules/@mantine/notifications",
         "//:node_modules/react",
     ],
@@ -43,6 +50,7 @@ js_library(
     srcs = ["feedback.tsx"],
     deps = [
         ":client",
+        ":theme",
         ":toast",
         "//:node_modules/@mantine/core",
         "//:node_modules/react",
@@ -54,6 +62,7 @@ js_library(
     srcs = ["launch.tsx"],
     deps = [
         ":client",
+        ":theme",
         ":toast",
         "//:node_modules/@mantine/core",
         "//:node_modules/react",
@@ -69,6 +78,7 @@ js_library(
     name = "confirm_dialog",
     srcs = ["confirm_dialog.tsx"],
     deps = [
+        ":theme",
         "//:node_modules/@mantine/core",
         "//:node_modules/react",
     ],
@@ -105,6 +115,7 @@ js_library(
     srcs = ["main.tsx"],
     deps = [
         ":app",
+        ":theme",
         "//:node_modules/@mantine/core",
         "//:node_modules/@mantine/notifications",
         "//:node_modules/react",
@@ -150,6 +161,7 @@ filegroup(
         "index.html",
         "launch.tsx",
         "main.tsx",
+        "theme.ts",
         "toast.ts",
     ],
 )

--- a/haku/console/frontend/confirm_dialog.tsx
+++ b/haku/console/frontend/confirm_dialog.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState } from "react";
 import { Button, Group, Text } from "@mantine/core";
 
+import { ACTION_COLOR } from "./theme.ts";
+
 export interface ConfirmRequest {
   title: string;
   body?: string; // what the action does, in trusted shell copy
@@ -48,14 +50,14 @@ export function ConfirmDialog({
         e.preventDefault(); // route Esc through our handler so the iframe gets a result
         onCancel();
       }}
-      className="max-w-md rounded-lg border border-slate-300 p-5 shadow-xl [&::backdrop]:bg-black/60 dark:border-slate-600 dark:bg-slate-800"
+      className="haku-confirm-dialog max-w-md rounded-lg p-5 shadow-xl"
     >
       {request && (
         <div className="flex flex-col gap-3">
           <Text fw={600}>{request.title}</Text>
           {request.body && <Text size="sm">{request.body}</Text>}
           {request.url && (
-            <Text size="sm" className="rounded bg-slate-100 p-2 font-mono break-all dark:bg-slate-900">
+            <Text size="sm" className="haku-url-preview rounded p-2 font-mono break-all">
               {request.url}
             </Text>
           )}
@@ -63,7 +65,7 @@ export function ConfirmDialog({
             <Button variant="default" size="xs" onClick={onCancel}>
               Cancel
             </Button>
-            <Button color="teal" size="xs" disabled={!armed} onClick={onApprove}>
+            <Button color={ACTION_COLOR} size="xs" disabled={!armed} onClick={onApprove}>
               {request.approveLabel}
             </Button>
           </Group>

--- a/haku/console/frontend/feedback.tsx
+++ b/haku/console/frontend/feedback.tsx
@@ -2,6 +2,7 @@ import { type FormEvent, type KeyboardEvent, useState } from "react";
 import { Button, Text, Textarea } from "@mantine/core";
 
 import { postTrace } from "./client.ts";
+import { ACTION_COLOR } from "./theme.ts";
 import { toastError } from "./toast.ts";
 
 // Submit lifecycle as a closed union so the spinner/disabled states can't be combined
@@ -84,7 +85,7 @@ export function FeedbackForm({ minRows, placeholder, submitLabel }: FeedbackForm
       <div className="flex items-center gap-3">
         <Button
           type="submit"
-          color="teal"
+          color={ACTION_COLOR}
           loading={sending}
           disabled={!text.trim()}
           rightSection={

--- a/haku/console/frontend/launch.tsx
+++ b/haku/console/frontend/launch.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Anchor, Button, Group, Modal, Text } from "@mantine/core";
 
 import { launchRoutine } from "./client.ts";
+import { CAPABILITY_COLOR } from "./theme.ts";
 import { toastError, toastSuccess } from "./toast.ts";
 
 type State = { status: "idle" } | { status: "confirming" } | { status: "launching" } | { status: "launched" };
@@ -39,7 +40,7 @@ export function LaunchRoutineButton({ routineUrl }: { routineUrl?: string | null
       <Group gap="sm">
         <Button
           variant="light"
-          color="indigo"
+          color={CAPABILITY_COLOR}
           size="xs"
           loading={launching}
           onClick={() => setState({ status: "confirming" })}
@@ -66,7 +67,7 @@ export function LaunchRoutineButton({ routineUrl }: { routineUrl?: string | null
           <Button variant="default" disabled={launching} onClick={() => setState({ status: "idle" })}>
             Cancel
           </Button>
-          <Button color="indigo" loading={launching} onClick={confirm}>
+          <Button color={CAPABILITY_COLOR} loading={launching} onClick={confirm}>
             Launch
           </Button>
         </Group>

--- a/haku/console/frontend/main.tsx
+++ b/haku/console/frontend/main.tsx
@@ -3,11 +3,12 @@ import { Notifications } from "@mantine/notifications";
 import { createRoot } from "react-dom/client";
 
 import App from "./app.tsx";
+import { hakuTheme } from "./theme.ts";
 
 const container = document.getElementById("root");
 if (!container) throw new Error("missing #root");
 createRoot(container).render(
-  <MantineProvider defaultColorScheme="auto">
+  <MantineProvider defaultColorScheme="auto" theme={hakuTheme}>
     <Notifications position="top-right" />
     <App />
   </MantineProvider>

--- a/haku/console/frontend/styles.src.css
+++ b/haku/console/frontend/styles.src.css
@@ -9,9 +9,25 @@
 @layer base {
   :root {
     color-scheme: light dark;
+    --haku-page-bg: #fbfaf6;
+    --haku-panel-bg: #fffdf8;
+    --haku-border: #d8d0df;
+    --haku-code-bg: #eaf6f2;
+    --haku-code-fg: #202728;
+    --haku-backdrop: rgb(21 74 70 / 55%);
+  }
+  :root[data-mantine-color-scheme="dark"] {
+    --haku-page-bg: #0f1f1d;
+    --haku-panel-bg: #142724;
+    --haku-border: #3b5652;
+    --haku-code-bg: #172f2b;
+    --haku-code-fg: #e8f4f0;
+    --haku-backdrop: rgb(0 0 0 / 68%);
   }
   body {
     margin: 0;
+    background: var(--haku-page-bg);
+    color: var(--mantine-color-text);
   }
 }
 
@@ -34,7 +50,7 @@
   margin: 0.2rem 0;
 }
 .md code {
-  background: var(--mantine-color-default-hover);
+  background: var(--haku-code-bg);
   padding: 0.05rem 0.3rem;
   border-radius: 4px;
   font-size: 0.9em;
@@ -43,4 +59,20 @@
 .md a {
   color: var(--mantine-color-anchor);
   overflow-wrap: anywhere;
+}
+
+.haku-confirm-dialog {
+  border: 1px solid var(--haku-border);
+  background: var(--haku-panel-bg);
+  color: var(--mantine-color-text);
+}
+
+.haku-confirm-dialog::backdrop {
+  background: var(--haku-backdrop);
+}
+
+.haku-url-preview {
+  border: 1px solid var(--haku-border);
+  background: var(--haku-code-bg);
+  color: var(--haku-code-fg);
 }

--- a/haku/console/frontend/theme.ts
+++ b/haku/console/frontend/theme.ts
@@ -1,0 +1,36 @@
+import { createTheme, type MantineColorsTuple } from "@mantine/core";
+
+const haku: MantineColorsTuple = [
+  "#edf9f5",
+  "#d9f1eb",
+  "#bae3d8",
+  "#8fd0bf",
+  "#7ac5b2",
+  "#55aa99",
+  "#2f8f80",
+  "#237d73",
+  "#1d645e",
+  "#154a46",
+];
+
+const hakuSpirit: MantineColorsTuple = [
+  "#f4f1f7",
+  "#e8e2ef",
+  "#d2c8dc",
+  "#c2bacd",
+  "#b8aec7",
+  "#9a8dab",
+  "#756a8d",
+  "#5f5477",
+  "#4a415e",
+  "#332d42",
+];
+
+export const ACTION_COLOR = "haku";
+export const SUCCESS_COLOR = ACTION_COLOR;
+export const CAPABILITY_COLOR = "hakuSpirit";
+
+export const hakuTheme = createTheme({
+  primaryColor: ACTION_COLOR,
+  colors: { haku, hakuSpirit },
+});

--- a/haku/console/frontend/toast.ts
+++ b/haku/console/frontend/toast.ts
@@ -1,6 +1,8 @@
 import { notifications } from "@mantine/notifications";
 import type { ReactNode } from "react";
 
+import { SUCCESS_COLOR } from "./theme.ts";
+
 // The single mechanism for surfacing action outcomes to the operator. Failures
 // (launch, feedback, a click that didn't commit) route here as a red toast rather
 // than inline/quiet, so a 502/timeout is always visible instead of being swallowed.
@@ -14,5 +16,5 @@ export function toastError(title: string, error: unknown): void {
 }
 
 export function toastSuccess(title: string, message?: ReactNode): void {
-  notifications.show({ color: "teal", title, message, autoClose: 6000 });
+  notifications.show({ color: SUCCESS_COLOR, title, message, autoClose: 6000 });
 }


### PR DESCRIPTION
## Summary

- Add a Haku console Mantine theme with logo-derived `haku` and `hakuSpirit` palettes.
- Route trusted shell color choices through semantic constants for action, success, and capability controls.
- Port page, dialog, URL preview, and markdown code surfaces from default/slate colors to the Haku palette.

## Impact

The console keeps its existing layout and Mantine/Tailwind split, but button, toast, dialog, and surface colors now share one local color source of truth.

## Validation

- `pre-commit run --files haku/console/frontend/BUILD.bazel haku/console/frontend/confirm_dialog.tsx haku/console/frontend/feedback.tsx haku/console/frontend/launch.tsx haku/console/frontend/main.tsx haku/console/frontend/styles.src.css haku/console/frontend/theme.ts haku/console/frontend/toast.ts`
- `bbr test //haku/console/frontend/...`
- `bbr build //haku/console/frontend:bundle`
