### PR TITLE
haku-ci: enforce privileged Pod Security so the rootless dind runner can schedule

### DIFF
--- a/cluster/k8s/haku-ci/namespace.yaml
+++ b/cluster/k8s/haku-ci/namespace.yaml
@@ -12,3 +12,12 @@ metadata:
     name: haku-ci
     # The runner's resources are set deliberately; no VPA recommendations wanted.
     goldilocks.fairwinds.com/enabled: "false"
+    # Enforce the privileged Pod Security level. The rootless dind sidecar needs
+    # seccompProfile: Unconfined (nested-container clone/unshare), which the baseline
+    # and restricted levels both forbid. This does NOT make the pod privileged — it
+    # stays rootless (runAsUser 1000, no privileged:true, caps dropped); privileged
+    # PSA only stops *restricting* it. Safe because haku-ci is operator-only (Haku has
+    # no RBAC here; only Flux applies), so the loosened level grants Haku nothing.
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/audit: privileged


### PR DESCRIPTION
**Runtime paving fix.** After #2571 the `haku-runner` Deployment reconciles, but **no pod is created** — PodSecurity Admission rejects it:

```
violates PodSecurity "baseline:latest": seccompProfile (container "dind" must not set
securityContext.seccompProfile.type to "Unconfined")
```

The `haku-ci` namespace runs under the cluster-default **baseline** PSS, which forbids `seccompProfile: Unconfined` — but rootless `dind` requires it (nested-container `clone`/`unshare`). Unconfined seccomp is only allowed under the **privileged** level (baseline *and* restricted both forbid it), so the namespace enforces `privileged`.

**This does not make the pod privileged.** The dind pod stays rootless (`runAsUser: 1000`, no `privileged: true`, caps dropped) — privileged PSA only stops *restricting* it. And it's safe because `haku-ci` is **operator-only** (Haku has no RBAC there; only Flux applies), so loosening the namespace's PSA grants Haku nothing.

Rejected alternatives: a Localhost seccomp profile (would satisfy baseline but needs a profile shipped to the Talos nodes) or rootless buildkit (bigger rework — the README's other option).

Found while paving the runner end-to-end; next up is verifying dind actually starts + the runner registers once it schedules.