### PR TITLE
[codex] Publish InvenTree token provisioner to linked GHCR package

### DIFF
--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -149,7 +149,11 @@ jobs:
               test_target: "//cluster/k8s/agents/authentik-jwt-rotation/...",
             }
           - { image: "//cluster/k8s/agents/attic-jwt-rotation:image", image_name: attic-jwt-rotation, test_target: "" }
-          - { image: "//cluster/k8s/inventree/token-provisioner:image", image_name: token-provisioner, test_target: "" }
+          - {
+              image: "//cluster/k8s/inventree/token-provisioner:image",
+              image_name: inventree-token-provisioner,
+              test_target: "",
+            }
           - {
               image: "//cluster/k8s/grocy/sf/user-perms:image",
               image_name: grocy-sf-user-perms-provisioner,

--- a/cluster/k8s/flux-image-automation-ghcr/token-provisioner-image-repository.yaml
+++ b/cluster/k8s/flux-image-automation-ghcr/token-provisioner-image-repository.yaml
@@ -4,5 +4,5 @@ metadata:
   name: token-provisioner
   namespace: flux-system
 spec:
-  image: ghcr.io/agentydragon/token-provisioner
+  image: ghcr.io/agentydragon/inventree-token-provisioner
   interval: 5m

--- a/cluster/k8s/inventree/token-provisioner/job.yaml
+++ b/cluster/k8s/inventree/token-provisioner/job.yaml
@@ -1,7 +1,7 @@
 # Fetches the InvenTree admin API token and writes it to the inventree namespace.
 # An ESO ClusterExternalSecret (token-eso.yaml) mirrors the Secret to openclaw-sandbox
 # and claude-sandbox.
-# Script is baked into ghcr.io/agentydragon/token-provisioner via Bazel.
+# Script is baked into the InvenTree token-provisioner image via Bazel.
 apiVersion: batch/v1
 kind: Job
 metadata:


### PR DESCRIPTION
## Summary

- Publish the InvenTree token provisioner image as `ghcr.io/agentydragon/inventree-token-provisioner` instead of the stale unlinked `token-provisioner` GHCR package.
- Point the Flux `ImageRepository` at the new package while leaving the currently deployed image tag untouched until Flux image automation observes the first pushed tag.
- Replace the stale exact-package comment in the provisioner Job manifest.

## Root Cause

Post-merge CI for #2564 was red in `push-images / Push token-provisioner`: the Bazel image build succeeded, but `crane push` to `ghcr.io/agentydragon/token-provisioner` failed with `DENIED: permission_denied: write_package`. GitHub package metadata shows that package has no linked repository, unlike the successfully publishing packages.

## Validation

- `nix develop -c pre-commit run --files .github/workflows/push-images.yml cluster/k8s/flux-image-automation-ghcr/token-provisioner-image-repository.yaml cluster/k8s/inventree/token-provisioner/job.yaml`
- `nix develop -c bbr test //cluster/validation:test_flux_build //cluster/validation:test_image_automation //cluster/validation:test_cluster_integration --cache_test_results=no --test_output=errors`
  - BuildBuddy Bazel invocation: `6d4ca705-e110-4879-acfa-6a2d7e25f576`