### PR TITLE
talos(ovh): enable user.max_user_namespaces for the haku-ci rootless dind

### DIFF
--- a/cluster/terraform/main/ovh-nodes.tf
+++ b/cluster/terraform/main/ovh-nodes.tf
@@ -331,6 +331,13 @@ locals {
         install = {
           image = "factory.talos.dev/installer/${talos_image_factory_schematic.kimsufi.id}:${var.talos_version}"
         }
+        # Talos hardens user.max_user_namespaces to 0; the haku-ci runner's rootless
+        # dind (docker:dind-rootless) needs user namespaces to start. Scoped to the
+        # OVH/hil workers (where the runner schedules via nodeSelector region=hil), not
+        # cluster-wide. Applies live — no reboot. See cluster/k8s/haku-ci.
+        sysctls = {
+          "user.max_user_namespaces" = "1048576"
+        }
         # Topology labels set explicitly — no CCM for OVH bare metal.
         nodeLabels = {
           "topology.kubernetes.io/region" = "hil"


### PR DESCRIPTION
**Runtime paving — the real dind-on-Talos fix.** With #2580 the haku-ci runner pod schedules and **registers with Forgejo successfully**, but the rootless `dind` sidecar crashloops:

```
error: attempting to run rootless dockerd but need 'user.max_user_namespaces'
  (/proc/sys/user/max_user_namespaces) set to a sufficiently large value
```

Talos hardens `user.max_user_namespaces` to 0, so rootless dockerd can't create the nested user namespaces it needs. This sets it (`1048576`) via `machine.sysctls` — **scoped to the OVH/hil workers** (the runner's `nodeSelector` is `region: hil`), not cluster-wide — keeping the runner **rootless/non-privileged** (the chosen alternative to rootful DinD).

`//cluster/terraform/main:{validate,format,lint}` green.

**⚠️ Apply note:** `cluster/terraform/main` is the core bootstrap TF (not gitops), so merging doesn't apply it — needs a `tofu apply` (updates the OVH workers' `talos_machine_configuration_apply`; sysctls apply live, no reboot). After apply, the crashlooping dind should come up on its next restart.