### PR TITLE
haku: fix dangling recipes refs + refresh north-star docs after item-agnostic move

### DIFF
--- a/haku/PLAN.md
+++ b/haku/PLAN.md
@@ -8,9 +8,10 @@ needs his name kept in writing — hence the repo).
 detail has moved to where the code lives — the component READMEs and the manual — and
 git history holds the original full design rationale:
 
-- What Haku is and how it reasons, the item contract, the dashboard spec, the
-  credential/perimeter model: `haku/base/instructions.md` (+ `haku/base/sources/`,
-  `haku/base/recipes.md`).
+- What Haku is, its objective, and how it reasons, plus the credential/perimeter model:
+  `haku/base/instructions.md` (+ `haku/base/sources/`). Base is **item-agnostic**; Haku's
+  current working method — the item model + schema, its procedures, and its UI — lives in
+  `haku/state_template/` (seeded into `haku-state`), not base.
 - The run procedure: `haku/run.md`; the web runtime: `haku/runtime/claude_web_env/`.
 - The dashboard service: `haku/console/README.md`. Alternative runtimes (Managed
   Agents): `haku/runtime/managed_agent/` + `haku/plans/`.
@@ -34,8 +35,9 @@ Status: v0 is live — the **Claude Code web home** (`haku/runtime/claude_web_en
 the loop by hand/scheduled, driving the cluster over `kubectl` with `haku-sandbox` as
 its compute surface. The data plane (scoped k8s identity + JWT rotation, the sandbox,
 Plaid/Google read-only mirrors, `haku-state`, the console) is landed. Current work is
-iterating the base (instructions/sources/recipes) until the items are genuinely good,
-and the not-yet-built items below.
+iterating the base (instructions/sources) and Haku's method (the procedures + UI in
+`state_template`) until what Haku surfaces is genuinely good, and the not-yet-built items
+below.
 
 ## Durable doctrine (keep honoring this as the system grows)
 
@@ -148,9 +150,12 @@ Still to build:
   console embeds it as a sandboxed cross-origin iframe — the **Free-form UI** tab — never
   rendering it itself. Still ahead: Haku replaces the placeholder with a real UI on its own
   backend; the shell gains a minimal `postMessage` bridge (`requestCapability` + a top-layer
-  confirm, then `openLink`). **North star:** even the item model + UI + build move into
-  agent-owned `haku-state`; the shell keeps only the boundary. Full design, containment
-  invariants, and remaining order: <console/plans/free_form_ui_iframe.md>.
+  confirm, then `openLink`). **North star — base side landed:** the item model + schema +
+  procedures have moved out of ducktape's base into agent-owned `haku-state` (seeded from
+  `state_template/`), and base is now item-agnostic. Still ahead: the UI's styling/build and
+  Flux image-automation become fully agent-owned, and the trace tier retires; the shell
+  keeps only the boundary. Full design, containment invariants, and remaining order:
+  <console/plans/free_form_ui_iframe.md>.
 
 ## Open questions
 

--- a/haku/TODO.md
+++ b/haku/TODO.md
@@ -7,7 +7,7 @@ actionable checklist. Remove entries once done.
 
 Each follows the same pattern: a read-only credential or filter facade reachable
 from `haku-sandbox`, plus a source guide in `base/sources/` (and any reusable
-technique as a recipe in `base/recipes.md`).
+technique as a pass in Haku's `state_template/procedures/`).
 
 - **CPAP data** — read-only access to daily summaries / AHI / compliance (see
   `cpap/`; WebDAV + EDF). Land scoped read creds as a `haku-sandbox` secret and

--- a/haku/base/sources/README.md
+++ b/haku/base/sources/README.md
@@ -47,10 +47,10 @@ shared mechanic, not a channel.
 ## Techniques live elsewhere
 
 Reusable, source-agnostic ways to be useful — inbox-like triage & cleanup, delegation
-scans, opportunistic synthesis, quiet-run recon, … — are **not** here; they're example
-**recipes** in [`../recipes.md`](../recipes.md), applied situationally across whatever
-sources fit (illustrations, not a checklist; invent your own). This directory is just
-the channels and how to read them.
+scans, opportunistic synthesis, quiet-run recon, … — are **not** here; they're your
+**procedures**, in your state (`procedures/`, seeded from `state_template/` and yours to
+grow), applied situationally across whatever sources fit (illustrations, not a checklist;
+invent your own). This directory is just the channels and how to read them.
 
 Designed but **not yet wired** (don't attempt; note the gap if one appears):
 PostScanMail (unopened mail) — blocked until it sits behind a read-only filter

--- a/haku/base/sources/calendar.md
+++ b/haku/base/sources/calendar.md
@@ -10,5 +10,5 @@ the event in items). Calendar is most useful **cross-referenced** — with mail/
 whether an event still stands or implies work, and as the "when/where" that reprioritizes
 other items.
 
-What to _do_ with it (prep gaps, conflicts, implied tasks) → the **calendar-prep** recipe in
-[`../recipes.md`](../recipes.md).
+What to _do_ with it (prep gaps, conflicts, implied tasks) → the **calendar-prep** pass in
+your procedures (`procedures/calendar_and_geo.md`, in your state).

--- a/haku/base/sources/grocy.md
+++ b/haku/base/sources/grocy.md
@@ -42,6 +42,7 @@ Read tools (writes exist but 403 for you — ignore them):
 Mine these for: items **expiring** (propose using them up — recipes, "eat this first"),
 items **below minimum** or absent that the operator relies on (a shopping nudge), and
 **opportunistic** suggestions that combine stock with where the operator is and what
-else is going on (see `../recipes.md` → _Generate, don't just detect_). Never surface a
+else is going on (see your procedures, `procedures/maintenance_and_synthesis.md` →
+_Generate, don't just detect_, in your state). Never surface a
 suggestion to buy something already on a shopping list. If `list` is empty or a call
 401s, note the gap in your log and move on (the bearer must be the one in `haku-sandbox`).

--- a/haku/base/sources/plaid.md
+++ b/haku/base/sources/plaid.md
@@ -17,4 +17,4 @@ Query `information_schema` (or `\dt`) first if you need to orient.
 
 What to _do_ with the transactions (duplicate charges, new recurring merchants, changed
 amounts, killable fees, unusually large charges, zombie subscriptions) → the **financial
-anomalies & leaks** recipe in [`../recipes.md`](../recipes.md).
+anomalies & leaks** pass in your procedures (`procedures/finance.md`, in your state).

--- a/haku/console/plans/free_form_ui_iframe.md
+++ b/haku/console/plans/free_form_ui_iframe.md
@@ -255,21 +255,23 @@ the shell opens. `state_template/k8s/haku-ui/index.html` carries a worked `openL
 
 ## North star: the shell owns nothing but the boundary
 
-The end state (later — not the next step) drops the last thing ducktape still owns on
-the _content_ side: the **item model and its UI**. Today the trusted console owns the
-item schema (`models.py` / `base/schema/item.json`), the declarative renderer, the SPA
-bundle + styling, and the trace tier. In the north star, **all of that moves into
-Haku's iframe service and `haku-state`**:
+**Status (2026-06-27): largely landed.** The trusted console no longer renders content
+(the item UI moved to Haku's own iframe service), and the **base scanner is now
+item-agnostic** — there is no ducktape-defined `Item`: the schema, the item contract, and
+the default passes moved out of `haku/base/` into agent-owned `haku-state` (seeded from
+`haku/state_template/`). Haku is given only the **high-level objective** — _make the
+operator's life go well; surface what's useful to act on_ — and **no schema**: it decides
+what the abstraction is, how to present it, and evolves it freely.
 
-- Haku is given a **high-level objective** — _"surface for the operator the things
-  that are useful to act on"_ — and **no schema**. There is no ducktape-defined
-  `Item`, no fixed action kinds, no prescribed layout. Haku decides what the
-  abstraction is and how to present it, and evolves it freely.
-- The frontend's **styling, compilation, and the console SPA's Flux image automation**
-  move out of ducktape into **agent-owned `haku-state` code** — Haku's UI service
-  builds and serves its own assets; no ducktape rebuild for a UI or schema change.
-- The **trace tier retires** — Haku's own backend records operator intent (it already
-  owns `haku-state`).
+Remaining to reach the full end state:
+
+- The UI's **styling, compilation, and image automation** become fully agent-owned — Haku's
+  UI service builds and serves its own assets (CI lives in `haku-state`); no ducktape
+  rebuild for a UI or format change. The Flux image-automation wiring is the open piece
+  (see `haku/PLAN.md` → _Haku UI paving_).
+- The **trace tier retires** — Haku's own backend records operator intent (it already owns
+  `haku-state`); the trusted console's only remaining write path is the opaque "Note to
+  Haku".
 
 What's left in ducktape is the **irreducible trusted core, and nothing else**:
 
@@ -282,11 +284,7 @@ What's left in ducktape is the **irreducible trusted core, and nothing else**:
 
 The litmus test for "does this belong in ducktape": **does it hold a secret, perform a
 privileged action, or define the trust boundary?** If not, it's Haku's — and the item
-abstraction fails that test, so it goes.
-
-Deliberately deferred: this only makes sense once the iframe UI + the affordances are
-proven and Haku can author an experience at least as good as today's declarative list.
-Until then, Phase 1a's trusted item list coexists.
+abstraction failed that test, so it went.
 
 ## Open questions
 

--- a/haku/run.md
+++ b/haku/run.md
@@ -40,27 +40,30 @@ applies.
 
 1. **Orient — fully, before you dig.** Read your `memory/` (standing operator guidance,
    the live situational-awareness note, how far you got last time), your recent `log/`
-   files, and **all** of `items/` (terminal ones included — they encode what the operator
-   already decided). **Finish this before you scan or file anything**: load every existing
-   `dedup_key` first, so you advance what's already there instead of creating duplicates.
-   Check your watch-list and `snoozed` items for **wake triggers that have now arrived**.
-   **Confirm this isn't a false first run:** if `items/` looks empty, verify the **remote**
-   is genuinely seedless rather than a partial/mid-bootstrap checkout (re-pull / wait for
-   the clone). Then a quick **environment self-check** (manual → _Environment self-check_):
-   confirm the tools/credentials/egress you'll rely on are present, and **surface a finding** for
-   any documented capability that's broken (then work around it) rather than degrading silently.
+   files, and **all of your existing working set** (today: every file in `items/`, terminal
+   ones included — they encode what the operator already decided). **Finish this before you
+   scan or record anything**: load what you already have first (today: every `dedup_key`), so
+   you advance what's there instead of duplicating it. Check your watch-list and anything
+   deferred (today: `snoozed` items) for **wake triggers that have now arrived**. **Confirm
+   this isn't a false first run:** if your working set looks empty, verify the **remote** is
+   genuinely seedless rather than a partial/mid-bootstrap checkout (re-pull / wait for the
+   clone). Then a quick **environment self-check** (manual → _Environment self-check_):
+   confirm the tools/credentials/egress you'll rely on are present, and **surface a finding**
+   for any documented capability that's broken (then work around it) rather than degrading
+   silently.
 2. **Adopt base updates.** Compare the ducktape `HEAD` to the pin in `memory/base-sync.md`;
    if it advanced, diff `haku/base` + `haku/run.md` since the pin, migrate state to match
    (manual → _Adopting base updates_), update the pin, log what you reconciled. **For each
    base change that affects how you frame or prioritize what you surface** — vs. structural
    migrations — **note it as a retroactive obligation** to apply to everything already in
    your working set during curation. The diff is the spec; your open work is the scope.
-3. **Process intake + reduce clicks.** For each file in `intake/` (not `processed/`): fold
-   standing guidance into `memory/` (note expiry if time-bound), apply item-referencing
-   feedback to that item, then move it to `intake/processed/` with a note on how you read it.
-   For each `clicks/<item-id>/<action-id>` marker: carry out that action's `intent` (e.g.
-   `snooze` → `status: snoozed` + `snoozed_until`; `reject` → `rejected` + reason; a custom
-   command → do the research/follow-up), then **delete the click**.
+3. **Process operator feedback.** For each file in `intake/` (not `processed/`): fold
+   standing guidance into `memory/` (note expiry if time-bound), apply feedback that targets
+   something you surfaced to that thing, then move it to `intake/processed/` with a note on
+   how you read it. Then reduce the action markers your UI recorded (today: each
+   `clicks/<item-id>/<action-id>`): carry out that action's intent (today e.g. `snooze` →
+   `status: snoozed` + `snoozed_until`; `reject` → `rejected` + reason; a custom command → do
+   the research/follow-up), then **clear the marker**.
 
 ### The work — a continuous understand → synthesize loop
 
@@ -76,18 +79,19 @@ backlogs) you advance a little each run and pick up next time — not a one-pass
   options, **invent novel angles no single source implies**. Let current context
   reprioritize (down-rank what they can't act on now; surface what's useful given where/when
   they are). Honor the operator guidance in `memory/`.
-- **Act — write & curate `items/` as you go** (no separate write-then-curate phase):
-  - New findings → `items/<id>.yaml` per the contract; aim for a **deep backlog**, no
-    minimum `value`. Update existing items when evidence changed; never duplicate a
-    `dedup_key`; don't re-raise a rejected idea without materially new evidence (say what's new).
-  - Re-score; `expired` past-`deadline` items; **promote** `snoozed`/watch-list items whose
-    wake trigger arrived; `snooze` anything whose only next step is to wait; keep valid
-    lower-priority items `open` as backlog.
-  - Bring open items into conformance with the current contract (links-as-affordances,
-    actionability gate, …). **If you adopted a base update this run, the conformance sweep is
-    mandatory over _every_ open item** — apply each noted convention change wherever it
-    applies, not just the commit's examples. (Your UI renders live from your state; no page
-    to regenerate.)
+- **Act — record & curate your working set as you go** (no separate write-then-curate phase):
+  - New findings → record them in your format (today: `items/<id>.yaml`); aim for a **deep
+    backlog**, no minimum to surface. Update existing entries when evidence changed; never
+    duplicate (today: a `dedup_key`); don't re-raise a rejected idea without materially new
+    evidence (say what's new).
+  - Re-rank; retire what's elapsed (today: `expired` past-`deadline` entries); **promote**
+    anything deferred whose wake trigger arrived; **defer** anything whose only next step is
+    to wait (today: `snooze`); keep valid lower-priority work as backlog.
+  - Bring your open set into conformance with your current method's conventions (today:
+    links-as-affordances, the actionability gate, …). **If you adopted a base update this
+    run, the conformance sweep is mandatory over _everything_ open** — apply each noted
+    change wherever it applies, not just the commit's examples. (Your UI renders live from
+    your state; no page to regenerate.)
 - **Decide how much to invest**: weigh each path's value against the operator's
   value-of-time and the rough cost of your effort (manual → _How you reason_, effort
   budgeting). **A quiet run is not over** — deepen unfinished source coverage, research


### PR DESCRIPTION
Followups to #2579 (item-agnostic base refactor), surfaced by `/followups`.

- **Fix broken links (the defect):** moving `base/recipes.md` → `state_template/procedures/` left dangling `../recipes.md` links in `base/sources/{README,calendar,plaid,grocy}.md`, plus stale `base/recipes.md` mentions in `haku/PLAN.md` (×2) and `haku/TODO.md`. Haku reads these source guides at runtime. Repointed to Haku's state procedures as prose refs (procedures left base, so no longer relatively linkable from `base/sources/`).
- **Refresh north-star framing:** `haku/PLAN.md` and the `free_form_ui_iframe.md` "north star" section described the item-model extraction as deferred-future — the base side landed in #2579. Marked status (base side done: schema + contract + procedures out of base, base item-agnostic) vs. genuinely-remaining (UI styling/build + Flux automation fully agent-owned; trace-tier retirement).
- **Make `run.md`'s loop format-agnostic:** the orient / process-feedback / act steps now lead with the generic action and name the concrete item mechanics (`items/`, `clicks/`, `dedup_key`, `value`, `snooze`) as `today:` parentheticals — the current method, defined in Haku's state, that the loop operates on.

No code touched; docs only. `pre-commit` green.