### PR TITLE
[codex] Resolve edit-gate source matches via selector solver

### DIFF
--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -173,11 +173,16 @@ rust_library(
     edition = "2024",
     deps = [
         ":analysis",
+        ":chunk_facts",
         ":js_ast",
+        ":selector_ir",
+        ":selector_ir_lowering",
+        ":selector_runtime",
         ":source_match",
         ":spec",
         "@crates//:anyhow",
         "@crates//:swc_common",
+        "@crates//:swc_ecma_ast",
     ],
 )
 
@@ -850,6 +855,7 @@ rust_library(
         ":selector_ir",
         ":selector_ir_lowering",
         ":selector_ortools_cpsat_backend",
+        ":selector_runtime",
         ":source_match",
         ":spec",
         ":stage_one",
@@ -1175,6 +1181,24 @@ rust_test(
         ":selector_ir_lowering",
         ":spec",
     ],
+)
+
+rust_library(
+    name = "selector_runtime",
+    srcs = ["selector_runtime.rs"],
+    edition = "2024",
+    deps = [
+        ":selector_backend_solver",
+        ":selector_ir",
+        ":selector_ortools_cpsat_backend",
+        "@crates//:anyhow",
+    ],
+)
+
+rust_test(
+    name = "selector_runtime_test",
+    crate = ":selector_runtime",
+    edition = "2024",
 )
 
 rust_library(

--- a/devinfra/js/debundle/anonymous_resolution.rs
+++ b/devinfra/js/debundle/anonymous_resolution.rs
@@ -11,11 +11,18 @@ use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use analysis::{OwnerGraphReport, OwnerId, StatementKind};
+use analysis::{
+    AnalysisHints, ChunkId, OwnerGraphReport, OwnerId, StatementKind, analyze_chunk,
+    build_owner_graph,
+};
 use anyhow::{Context, Result, bail};
+use selector_ir::{ClaimOutcome, ResolvedClaim, SelectorFact, SelectorFactStore};
+use selector_ir_lowering::{MemberSelectorLoweringContext, lower_member_selector};
+use selector_runtime::solve_global_selector_program;
 use source_match::SelectorResolver;
-use spec::AnonymousStatementSelector;
+use spec::{AnonymousStatementSelector, MemberSelectorSpec};
 use swc_common::{EqIgnoreSpan, SyntaxContext};
+use swc_ecma_ast::Module;
 
 #[derive(Debug, Clone, Copy)]
 pub struct AnonymousStatementClaimSet<'a> {
@@ -35,9 +42,8 @@ pub struct MemberSelectorClaimSet<'a> {
 
 /// Resolve member-form `source_match` selectors to the chunk-top
 /// binding names they claim, by matching each selector against the
-/// chunk sources referenced by `graph`'s `source_location` data —
-/// the same source-backed matching (`source_match`) the run
-/// pipeline's member materialization applies. Each selector must
+/// chunk sources referenced by `graph`'s `source_location` data through
+/// the same selector-IR/CP-SAT path the run pipeline applies. Each selector must
 /// match exactly one declared binding across all chunk sources;
 /// zero or multiple matches are hard errors, as is unresolvable
 /// chunk source — the caller (the CLI edit gate) must never
@@ -78,32 +84,56 @@ fn resolve_member_selector_claims_in_globals(
         return Ok(vec![BTreeSet::new(); claims_by_module.len()]);
     }
 
-    with_source_resolvers(
+    with_source_modules(
         graph,
         owner_graph_path,
         modules_root,
         source_root,
         "spec contains members[].selector.source_match claims, but owner_graph.json has no \
          source_location data; cannot resolve source_match selectors",
-        |parsed_by_source, resolvers_by_source| {
+        |parsed_by_source| {
+            let facts_by_source: BTreeMap<String, SelectorFactStore> = parsed_by_source
+                .iter()
+                .map(|(source_path, parsed)| {
+                    Ok((
+                        source_path.clone(),
+                        selector_fact_store_for_module(&parsed.module).with_context(|| {
+                            format!("building selector facts for source {source_path}")
+                        })?,
+                    ))
+                })
+                .collect::<Result<_>>()?;
             let mut out = vec![BTreeSet::<String>::new(); claims_by_module.len()];
             for (module_idx, claims) in claims_by_module.iter().enumerate() {
                 let request_id = claims.module_path.to_string_lossy();
                 for selector in claims.selectors {
-                    let mut matches = Vec::new();
-                    for source_path in parsed_by_source.keys() {
-                        matches.extend(
-                            resolvers_by_source[source_path]
-                                .member_candidates(&request_id, selector)?,
-                        );
+                    let mut matches = Vec::<MemberSelectorMatch>::new();
+                    for (source_path, facts) in &facts_by_source {
+                        for claim in
+                            resolve_member_source_match_claims(facts, &request_id, selector)?
+                        {
+                            let binding_name = claim.binding.clone().with_context(|| {
+                                format!(
+                                    "module {} members[].selector.source_match matched source {} \
+                                     owner {:?} without a single declared binding; use \
+                                     target_binding or a single-binding selector",
+                                    claims.module_path.display(),
+                                    source_path,
+                                    claim.owner,
+                                )
+                            })?;
+                            matches.push(MemberSelectorMatch {
+                                binding_name,
+                                is_import_specifier: solver_claim_is_import_specifier(
+                                    facts, &claim,
+                                ),
+                            });
+                        }
                     }
                     match matches.as_slice() {
                         [single] => {
-                            if !matches!(
-                                single.binding.kind,
-                                Some(spec::BindingSourceKind::ImportSpecifier)
-                            ) {
-                                out[module_idx].insert(single.binding.binding_name.clone());
+                            if !single.is_import_specifier {
+                                out[module_idx].insert(single.binding_name.clone());
                             }
                         }
                         [] => bail!(
@@ -119,7 +149,7 @@ fn resolve_member_selector_claims_in_globals(
                             multiple.len(),
                             multiple
                                 .iter()
-                                .map(|matched| matched.binding.binding_name.as_str())
+                                .map(|matched| matched.binding_name.as_str())
                                 .collect::<Vec<_>>()
                                 .join(", "),
                             selector.match_source,
@@ -131,6 +161,81 @@ fn resolve_member_selector_claims_in_globals(
             Ok(out)
         },
     )
+}
+
+#[derive(Debug, Clone)]
+struct MemberSelectorMatch {
+    binding_name: String,
+    is_import_specifier: bool,
+}
+
+fn resolve_member_source_match_claims(
+    facts: &SelectorFactStore,
+    logical_module: &str,
+    selector: &AnonymousStatementSelector,
+) -> Result<Vec<ResolvedClaim>> {
+    let selector = MemberSelectorSpec::SourceMatch(selector.clone());
+    let lowered = lower_member_selector(
+        &MemberSelectorLoweringContext::new(ChunkId(0), logical_module),
+        "candidate",
+        &selector,
+    )
+    .with_context(|| "lowering members[].selector.source_match to selector IR")?;
+    let result = solve_global_selector_program(&lowered.program, facts)
+        .with_context(|| "solving members[].selector.source_match selector IR")?;
+    let outcome = result
+        .outcome_for(lowered.target)
+        .with_context(|| "selector solver did not return the member source_match target")?;
+    match outcome {
+        ClaimOutcome::Unique { claim } => Ok(vec![claim.clone()]),
+        ClaimOutcome::Ambiguous { candidates } => Ok(candidates.clone()),
+        ClaimOutcome::NoMatch => Ok(Vec::new()),
+        ClaimOutcome::Unsupported { message } => {
+            bail!("members[].selector.source_match is unsupported by selector IR solver: {message}")
+        }
+        ClaimOutcome::Duplicate {
+            owner,
+            conflicting_targets,
+        } => bail!(
+            "members[].selector.source_match produced a duplicate claim for owner {owner:?} \
+             across {conflicting_targets:?}",
+        ),
+    }
+}
+
+fn selector_fact_store_for_module(module: &Module) -> Result<SelectorFactStore> {
+    let analysis = analyze_chunk(module, &AnalysisHints::default(), None, |_| None);
+    let owner_graph = build_owner_graph(&analysis.facts)?;
+    let chunk_id = ChunkId(0);
+    let mut facts = SelectorFactStore::default();
+    facts.extend_chunk_facts(
+        chunk_id,
+        &chunk_facts::extract_facts(module).map_err(|unsupported| {
+            anyhow::anyhow!(
+                "selector AST fact extraction failed at {}; edit-gate source_match resolution \
+                 needs a complete AST EDB",
+                unsupported.context
+            )
+        })?,
+    );
+    facts.extend_owner_graph_facts(chunk_id, &owner_graph);
+    Ok(facts)
+}
+
+fn solver_claim_is_import_specifier(facts: &SelectorFactStore, claim: &ResolvedClaim) -> bool {
+    facts.facts.iter().any(|fact| {
+        matches!(
+            fact,
+            SelectorFact::Owner {
+                owner,
+                statement_ordinal,
+                statement_kind,
+                ..
+            } if *owner == claim.owner
+                && *statement_ordinal == claim.statement_ordinal
+                && statement_kind == "import"
+        )
+    })
 }
 
 pub fn resolve_anonymous_statement_claims(
@@ -324,23 +429,15 @@ fn resolve_anonymous_statement_claims_in_globals(
 }
 
 /// Parse every distinct `source_location.source_path` in `graph` and hand
-/// `body` a per-source `ChunkResolver` map alongside the parsed modules.
-/// Resolvers are built once and borrow the parsed modules (the build-once seam
-/// contract; the fact resolver would otherwise rebuild a per-source EDB on every
-/// selector), which is why the parsed map and its resolvers are produced
-/// together and lent through the closure rather than returned. `no_sources` is
-/// the caller-specific error raised when the graph carries no `source_location`
-/// data.
-fn with_source_resolvers<R>(
+/// `body` the parsed modules. `no_sources` is the caller-specific error raised
+/// when the graph carries no `source_location` data.
+fn with_source_modules<R>(
     graph: &OwnerGraphReport,
     owner_graph_path: &Path,
     modules_root: &Path,
     source_root: Option<&Path>,
     no_sources: &str,
-    body: impl for<'m> FnOnce(
-        &'m BTreeMap<String, js_ast::ParsedJsModule>,
-        &BTreeMap<String, source_match::ChunkResolver<'m>>,
-    ) -> Result<R>,
+    body: impl FnOnce(&BTreeMap<String, js_ast::ParsedJsModule>) -> Result<R>,
 ) -> Result<R> {
     let source_paths: BTreeSet<String> = graph
         .nodes
@@ -361,16 +458,44 @@ fn with_source_resolvers<R>(
             ))
         })
         .collect::<Result<_>>()?;
-    let resolvers_by_source: BTreeMap<_, _> = parsed_by_source
-        .iter()
-        .map(|(source_path, parsed)| {
-            (
-                source_path.clone(),
-                source_match::ChunkResolver::new(&parsed.module),
-            )
-        })
-        .collect();
-    body(&parsed_by_source, &resolvers_by_source)
+    body(&parsed_by_source)
+}
+
+/// Parse every distinct `source_location.source_path` in `graph` and hand
+/// `body` a per-source `ChunkResolver` map alongside the parsed modules.
+/// Resolvers are built once and borrow the parsed modules, so the parsed map and
+/// its resolvers are produced together and lent through the closure rather than
+/// returned.
+fn with_source_resolvers<R>(
+    graph: &OwnerGraphReport,
+    owner_graph_path: &Path,
+    modules_root: &Path,
+    source_root: Option<&Path>,
+    no_sources: &str,
+    body: impl for<'m> FnOnce(
+        &'m BTreeMap<String, js_ast::ParsedJsModule>,
+        &BTreeMap<String, source_match::ChunkResolver<'m>>,
+    ) -> Result<R>,
+) -> Result<R> {
+    with_source_modules(
+        graph,
+        owner_graph_path,
+        modules_root,
+        source_root,
+        no_sources,
+        |parsed_by_source| {
+            let resolvers_by_source: BTreeMap<_, _> = parsed_by_source
+                .iter()
+                .map(|(source_path, parsed)| {
+                    (
+                        source_path.clone(),
+                        source_match::ChunkResolver::new(&parsed.module),
+                    )
+                })
+                .collect();
+            body(parsed_by_source, &resolvers_by_source)
+        },
+    )
 }
 
 /// Resolve `source_path` to a file on disk, read it, and parse it as a JS

--- a/devinfra/js/debundle/lowering/materialize/plan_builder.rs
+++ b/devinfra/js/debundle/lowering/materialize/plan_builder.rs
@@ -53,50 +53,11 @@ use selector_diagnostics::{
 };
 use selector_ir::{
     ClaimOutcome, ResolvedClaim, SelectorAtom, SelectorFact, SelectorFactStore, SelectorProgram,
-    SelectorTargetId, SolverResult,
+    SelectorTargetId,
 };
 use selector_ir_lowering::{MemberSelectorLoweringContext, MemberSelectorProgramBuilder};
-use selector_ortools_cpsat_backend::OrToolsCpSatBackend;
+use selector_runtime::solve_global_selector_program;
 use source_match::SelectorResolver;
-
-const ORTOOLS_CPSAT_SOLVER_ENV: &str = "DUCKTAPE_DEBUNDLE_ORTOOLS_CPSAT_SOLVER";
-const ORTOOLS_CPSAT_SOLVER_RUNFILE: &str =
-    "_main/devinfra/js/debundle/solver_backends/ortools_cpsat/selector_cpsat_solver";
-
-fn ortools_cpsat_solver_from_env() -> Result<PathBuf> {
-    if let Ok(solver_path) = std::env::var(ORTOOLS_CPSAT_SOLVER_ENV) {
-        return parse_ortools_cpsat_solver_path(Some(&solver_path));
-    }
-    if let Some(solver_path) = ortools_cpsat_solver_from_runfiles() {
-        return Ok(solver_path);
-    }
-    bail!("{ORTOOLS_CPSAT_SOLVER_ENV} must point at selector_cpsat_solver")
-}
-
-fn parse_ortools_cpsat_solver_path(solver_path: Option<&str>) -> Result<PathBuf> {
-    let solver_path = solver_path
-        .map(str::trim)
-        .filter(|path| !path.is_empty())
-        .with_context(|| {
-            format!("{ORTOOLS_CPSAT_SOLVER_ENV} must point at selector_cpsat_solver")
-        })?;
-    Ok(PathBuf::from(solver_path))
-}
-
-fn ortools_cpsat_solver_from_runfiles() -> Option<PathBuf> {
-    let runfiles_dir = std::env::var_os("RUNFILES_DIR").map(PathBuf::from)?;
-    let path = runfiles_dir.join(ORTOOLS_CPSAT_SOLVER_RUNFILE);
-    path.exists().then_some(path)
-}
-
-fn solve_global_selector_program(
-    program: &selector_ir::SelectorProgram,
-    facts: &SelectorFactStore,
-) -> Result<SolverResult> {
-    let backend = OrToolsCpSatBackend::new(ortools_cpsat_solver_from_env()?);
-    selector_backend_solver::solve_with_backend(program, facts, &backend)
-        .context("global selector CP-SAT backend failed")
-}
 
 impl From<&DuplicateClaimSite> for DuplicateClaimSiteReport {
     fn from(site: &DuplicateClaimSite) -> Self {
@@ -2193,38 +2154,5 @@ impl ChunkPlanBuilder {
             anonymous_ordinal_assignment: self.anonymous_ordinal_assignment,
             unmatched_spec_claims: self.unmatched_spec_claims,
         })
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn ortools_cpsat_solver_path_accepts_non_empty_path() {
-        assert_eq!(
-            parse_ortools_cpsat_solver_path(Some(" /tmp/solver ")).unwrap(),
-            PathBuf::from("/tmp/solver")
-        );
-    }
-
-    #[test]
-    fn ortools_cpsat_solver_path_requires_sidecar_path() {
-        let error =
-            parse_ortools_cpsat_solver_path(None).expect_err("missing sidecar path should fail");
-        assert!(
-            error
-                .to_string()
-                .contains("DUCKTAPE_DEBUNDLE_ORTOOLS_CPSAT_SOLVER"),
-            "{error}"
-        );
-        let error =
-            parse_ortools_cpsat_solver_path(Some(" ")).expect_err("empty sidecar path should fail");
-        assert!(
-            error
-                .to_string()
-                .contains("DUCKTAPE_DEBUNDLE_ORTOOLS_CPSAT_SOLVER"),
-            "{error}"
-        );
     }
 }

--- a/devinfra/js/debundle/selector_runtime.rs
+++ b/devinfra/js/debundle/selector_runtime.rs
@@ -1,0 +1,84 @@
+//! Runtime wiring for production selector solving.
+//!
+//! Selector lowering and fact extraction are owned by callers. This module only
+//! chooses the backend executable and runs the shared backend solver.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, bail};
+use selector_ir::{SelectorFactStore, SelectorProgram, SolverResult};
+use selector_ortools_cpsat_backend::OrToolsCpSatBackend;
+
+const ORTOOLS_CPSAT_SOLVER_ENV: &str = "DUCKTAPE_DEBUNDLE_ORTOOLS_CPSAT_SOLVER";
+const ORTOOLS_CPSAT_SOLVER_RUNFILE: &str =
+    "_main/devinfra/js/debundle/solver_backends/ortools_cpsat/selector_cpsat_solver";
+
+fn ortools_cpsat_solver_from_env() -> Result<PathBuf> {
+    if let Ok(solver_path) = std::env::var(ORTOOLS_CPSAT_SOLVER_ENV) {
+        return parse_ortools_cpsat_solver_path(Some(&solver_path));
+    }
+    if let Some(solver_path) = ortools_cpsat_solver_from_runfiles() {
+        return Ok(solver_path);
+    }
+    bail!("{ORTOOLS_CPSAT_SOLVER_ENV} must point at selector_cpsat_solver")
+}
+
+fn parse_ortools_cpsat_solver_path(solver_path: Option<&str>) -> Result<PathBuf> {
+    let solver_path = solver_path
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+        .with_context(|| {
+            format!("{ORTOOLS_CPSAT_SOLVER_ENV} must point at selector_cpsat_solver")
+        })?;
+    Ok(PathBuf::from(solver_path))
+}
+
+fn ortools_cpsat_solver_from_runfiles() -> Option<PathBuf> {
+    let runfiles_dir = std::env::var_os("RUNFILES_DIR").map(PathBuf::from)?;
+    let path = runfiles_dir.join(ORTOOLS_CPSAT_SOLVER_RUNFILE);
+    path.exists().then_some(path)
+}
+
+pub fn solve_global_selector_program(
+    program: &SelectorProgram,
+    facts: &SelectorFactStore,
+) -> Result<SolverResult> {
+    let backend = OrToolsCpSatBackend::new(ortools_cpsat_solver_from_env()?);
+    selector_backend_solver::solve_with_backend(program, facts, &backend)
+        .with_context(|| "global selector CP-SAT backend failed")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    #[test]
+    fn ortools_cpsat_solver_path_accepts_non_empty_path() {
+        assert_eq!(
+            parse_ortools_cpsat_solver_path(Some(" /tmp/solver ")).unwrap(),
+            PathBuf::from("/tmp/solver")
+        );
+    }
+
+    #[test]
+    fn ortools_cpsat_solver_path_requires_sidecar_path() {
+        let error =
+            parse_ortools_cpsat_solver_path(None).expect_err("missing sidecar path should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("DUCKTAPE_DEBUNDLE_ORTOOLS_CPSAT_SOLVER"),
+            "{error}"
+        );
+        let error =
+            parse_ortools_cpsat_solver_path(Some(" ")).expect_err("empty sidecar path should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("DUCKTAPE_DEBUNDLE_ORTOOLS_CPSAT_SOLVER"),
+            "{error}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Add a shared `selector_runtime` helper for locating the OR-Tools CP-SAT sidecar and solving selector IR with the production backend.
- Switch edit-gate/peel member-form `source_match` claim resolution from `ChunkResolver::member_candidates` to selector IR lowering plus CP-SAT solving.
- Keep anonymous statement grouping on the existing `source_match` resolver for now; this PR only peels the member-claim edit-gate path.

## Validation

- `nix develop -c pre-commit run --files devinfra/js/debundle/BUILD.bazel devinfra/js/debundle/anonymous_resolution.rs devinfra/js/debundle/lowering/materialize/plan_builder.rs devinfra/js/debundle/selector_runtime.rs`
- `nix develop -c bbr test //devinfra/js/debundle:lowering_test //devinfra/js/debundle:selector_runtime_test //devinfra/js/debundle/e2e:edit_gate_source_match_cli_test //devinfra/js/debundle/e2e:anonymous_statement_test //devinfra/js/debundle:peel_gate_differential_test --cache_test_results=no --test_output=errors`
  - BuildBuddy Bazel invocation after CI fix: `c21c8a4e-fc4e-431c-9c3b-f16e50552978`
- `nix develop -c bbr test //devinfra/js/debundle/e2e:edit_gate_source_match_cli_test //devinfra/js/debundle/e2e:anonymous_statement_test //devinfra/js/debundle:peel_gate_differential_test //devinfra/js/debundle:selector_ir_lowering_test //devinfra/js/debundle:selector_backend_solver_test //devinfra/js/debundle:selector_ortools_cpsat_backend_test //devinfra/js/debundle/e2e:cross_module_emission_test //devinfra/js/debundle/e2e:syntactic_holes_test --cache_test_results=no --test_output=errors`
  - BuildBuddy Bazel invocation before final test move: `3462d178-f2d2-4822-8779-1a9f9ecde24b`