### PR TITLE
haku-ci: pin runner to actual OVH workers (off control planes)

### DIFF
--- a/cluster/k8s/haku-ci/deployment.yaml
+++ b/cluster/k8s/haku-ci/deployment.yaml
@@ -18,10 +18,24 @@ spec:
         app.kubernetes.io/name: haku-runner
     spec:
       automountServiceAccountToken: false
-      # Schedule on OVH workers (same as docker-ci): the build layer cache is a
-      # disposable emptyDir, so it lives wherever it can schedule.
-      nodeSelector:
-        topology.kubernetes.io/region: hil
+      # Pin to the ACTUAL OVH workers (ks_game_worker0/1), not the OVH control planes.
+      # The OVH CPs are schedulable (allowSchedulingOnControlPlanes) and region=hil, and
+      # are misleadingly keyed kimsufi_worker0/1 in tofu though their role is controlplane
+      # — so a plain region selector landed this runner on a control plane. That's wrong
+      # twice over: (1) this is agent-controlled build compute, which must stay off
+      # control-plane nodes, and (2) the user.max_user_namespaces sysctl rootless dind
+      # needs is set only on role==worker nodes (cluster/terraform/main/ovh-nodes.tf), so
+      # the runner must land there. Exclude any node carrying the control-plane label.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: topology.kubernetes.io/region
+                    operator: In
+                    values: ["hil"]
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
       containers:
         # The Forgejo Actions runner: registers (ephemerally) with the haku-state
         # repo via the registration token, long-polls for jobs, and runs them in


### PR DESCRIPTION
Follow-up to #2583. The runner was scheduling on **ovh-ns103711, an OVH control plane** — it's keyed `kimsufi_worker1` in tofu but its role is `controlplane`, and the OVH CPs are schedulable + `region=hil`, so the plain `nodeSelector: region=hil` matched it.

Wrong twice over:
1. **Containment:** this runner executes Haku-authored build steps — it must not run on a control-plane node (a node escape there is on etcd/cluster-control compute).
2. **Functional:** the `user.max_user_namespaces` sysctl rootless dind needs (#2583) is set only on `role==worker` nodes (`ks_game_worker0/1`). On a control plane the sysctl isn't there, so dind would keep crashlooping.

Fix: replace the region-only `nodeSelector` with a `nodeAffinity` that requires `region=hil` **and** `node-role.kubernetes.io/control-plane DoesNotExist` → pins the runner to the real workers where the sysctl lives.

(Surfaced while investigating the OVH node-naming inconsistency — the lying `kimsufi_worker*` tofu keys, tracked for rename in `plans/rename_ovh_nodes_role_neutral.md`.) Cluster integration test green.