### PR TITLE
rugged: bump Mesa to 26.1.2 + wire iris GPU-crash diagnostics

### DIFF
--- a/debug/rugged/gnome_shell_iris_abort.md
+++ b/debug/rugged/gnome_shell_iris_abort.md
@@ -1,0 +1,96 @@
+# GNOME Shell recurring crash → logged out (rugged)
+
+## Symptom
+
+Wake up / step away → graphical session gone, back at GDM greeter, GUI windows lost.
+tmux still reattachable; machine never rebooted (uptime continuous). Recurs every
+few days, any time of day. Example: 2026-06-27 03:46 (overnight).
+
+## Root cause
+
+Mesa **iris** GPU driver aborts when a GPU command-batch submission fails. The
+`abort()` raises SIGABRT in gnome-shell; on Wayland the shell _is_ the compositor, so
+the whole session tears down and GDM restarts the greeter. The system stays up, which
+is why tmux survives.
+
+Identical native sink across every captured core — three different GL entry points, one
+fatal path:
+
+```
+abort()
+_iris_batch_flush.cold()      (libgallium-25.2.6)
+  ├─ Jun 27  iris_fence_flush ← st_glFlush ← create_timestamp_query ← swap_buffers (frame redraw)
+  ├─ Jun 18  iris_fence_flush ← st_context_flush ← dri_create_fence_fd ← eglCreateSyncKHR
+  └─ Jun 21  iris_blit ← tc_batch_execute ← tc_texture_map ← st_TexSubImage (texture upload)
+```
+
+The GJS "== Stack trace ==" context dumps in the journal (pop-shell, appindicator,
+nightthemeswitcher, aiquota) are **red herrings** — ambient JS warnings, not the crash.
+The fault is entirely in C.
+
+## Environment
+
+- GPU: Intel Lunar Lake, Arc Graphics 130V/140V (`00:02.0`, rev 04)
+- Kernel DRM driver: `xe` 1.1.0 (GuC `lnl_guc_70.bin` 70.65.0) — the new Intel driver
+- Userspace: Mesa iris 25.2.6 (stable channel)
+- Kernel: 7.0.11
+
+## Why it's a driver-maturity bug, not a GPU hang
+
+No kernel-side GPU hang/reset is logged at any crash time. Only a boot-time
+`xe 0000:00:02.0: [drm] Selective fetch area calculation failed in pipe A` (a PSR /
+panel-self-refresh selective-fetch quirk). Userspace `abort()` with no kernel hang ⇒
+iris is intolerant of some return code from the young `xe` uAPI rather than recovering
+from a real reset. Reportable upstream: iris should not `abort()` on submission failure.
+
+## Captured evidence
+
+`coredumpctl list | grep gnome-shell` — 6 SIGABRT cores (May 25 → Jun 27); cores for
+Jun 18 (4335), Jun 21 (2538388), Jun 27 (4434) decompressed and symbolicated with
+`gdb` against `…gnome-shell-49.4/bin/.gnome-shell-wrapped`. Mesa is stripped, so `.cold`
+does not reveal the errno iris saw — that is the missing datum (see MESA_DEBUG below).
+
+## Mesa version gap (checked 2026-06-27)
+
+Stable channel (`nixos-25.11`) ships **mesa 25.2.6** (Oct 2025). Latest is **26.1.3**
+(2026-06-18). nixpkgs-unstable = 26.1.2, nixpkgs-master = 26.1.3.
+
+Scanned release notes 25.2.7 → 25.3.0 for iris/LNL fixes touching _this_ bug:
+
+- **No release note explicitly fixes "iris batch-flush abort on Lunar Lake."** No
+  guaranteed silver bullet.
+- Nearly all LNL fixes are **anv** (Vulkan / game crashes) — the compositor uses **iris**
+  (GL), so they don't apply here.
+- **Directly relevant:** 25.2.8 added _"drirc/iris: add drirc to disable threaded
+  context"_. Our backtraces run through gallium **threaded context** (`tc_flush`,
+  `tc_batch_execute`, `_tc_sync`, `tc_texture_map`) — TC is a plausible trigger.
+
+## What is wired up (PR: rugged gpu-debug.nix)
+
+`nix/nixos/hosts/rugged/gpu-debug.nix`:
+
+1. **Mesa bump** — `hardware.graphics.package{,32}` → `nixpkgs-unstable.mesa` (26.1.2,
+   Hydra-cached; master's 26.1.3 would build from source). Swaps only the driver
+   package; rest of the system stays on stable.
+2. **`MESA_DEBUG=1`** session-wide → iris logs the submit failure + errno before
+   `abort()`. **The missing datum.** Tombstoned for removal once root-caused.
+3. **Coredump retention raised** so gnome-shell cores aren't rotated out.
+4. **xe devcoredump capture** — udev → `capture-devcoredump@.service` copies
+   `/sys/class/devcoredump/*/data` to `/var/lib/devcoredump` before it self-expires.
+
+## Still on the table (not yet done)
+
+- **Disable iris threaded context** — cheapest experiment, backtrace implicates TC.
+  Confirm the exact 25.2.6 knob (`mesa_glthread=false` covers the glthread layer; the
+  drirc `intel_disable_threaded_context` for gallium TC only exists in 25.2.8+, so the
+  Mesa bump above is a prerequisite for the clean drirc form).
+- **Disable PSR** — the boot-time `Selective fetch … pipe A` failure is the LNL display
+  workaround target.
+- Kernel 7.0.11 is already very new; try the above first.
+
+## After the next crash
+
+1. `journalctl _SYSTEMD_USER_UNIT=org.gnome.Shell@wayland.service` around the crash —
+   with MESA_DEBUG=1, look for the iris submit error string + errno.
+2. `ls /var/lib/devcoredump/` for a captured kernel xe dump.
+3. If 26.1.2 stops the crashes → close out; remove the MESA_DEBUG tombstone.

--- a/nix/nixos/hosts/rugged/default.nix
+++ b/nix/nixos/hosts/rugged/default.nix
@@ -34,6 +34,7 @@ in
     ./foxconn-wwan.nix
     ./local_llm_arc.nix
     ./local_llm_npu.nix
+    ./gpu-debug.nix
     ./iio-debug.nix
     ../../modules/attic-substituter.nix
   ];

--- a/nix/nixos/hosts/rugged/gpu-debug.nix
+++ b/nix/nixos/hosts/rugged/gpu-debug.nix
@@ -1,0 +1,84 @@
+# GPU crash mitigation + diagnostics for the Lunar Lake (Arc 130V/140V) iGPU.
+#
+# gnome-shell aborts every few days inside Mesa iris's batch-submit error path
+# (_iris_batch_flush -> abort), which on Wayland tears the whole session down to
+# GDM (tmux survives — the machine never reboots). Full forensics, including the
+# native backtraces shared across crashes, are in:
+#   debug/rugged/gnome_shell_iris_abort.md
+#
+# This module does two things:
+#   1. Mitigation — bump Mesa from the stable channel's 25.2.6 to nixpkgs-unstable
+#      (26.1.x), pulling in ~8 months of Intel/LNL driver work. No release note
+#      names this exact abort, so it is an attempt, not a guaranteed fix.
+#   2. Diagnostics — make the *next* crash conclusive: log the iris submit errno,
+#      retain gnome-shell cores, and capture kernel xe devcoredumps before they
+#      auto-expire.
+{
+  config,
+  inputs,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  # nixpkgs-unstable mesa is 26.1.2 and Hydra-cached. nixpkgs-master has 26.1.3
+  # but is not built by the binary cache, so it would compile Mesa from source.
+  pkgsUnstable = import inputs.nixpkgs-unstable {
+    inherit (pkgs.stdenv.hostPlatform) system;
+    config.allowUnfree = true;
+  };
+in
+{
+  # --- Mitigation: newer Mesa --------------------------------------------------
+  # Swap only the graphics driver package; the rest of the system stays on the
+  # stable channel. hardware.graphics.package feeds /run/opengl-driver, which is
+  # where gnome-shell loads its iris / EGL / Vulkan drivers from.
+  hardware.graphics = {
+    package = pkgsUnstable.mesa;
+    package32 = pkgsUnstable.pkgsi686Linux.mesa;
+  };
+
+  # --- Diagnostics for the next crash -----------------------------------------
+
+  # iris logs the GPU submit failure (and errno) to stderr — which lands in the
+  # journal under org.gnome.Shell@wayland.service — before it calls abort().
+  # CLEANUP: remove MESA_DEBUG once the iris batch-flush abort is root-caused
+  #   (debug/rugged/gnome_shell_iris_abort.md). It is global session log noise.
+  environment.sessionVariables.MESA_DEBUG = "1";
+
+  # Keep gnome-shell cores long enough to inspect (default rotates aggressively).
+  systemd.coredump.extraConfig = ''
+    MaxUse=4G
+    KeepFree=2G
+    ProcessSizeMax=8G
+    ExternalSizeMax=8G
+  '';
+
+  # The xe kernel driver drops a devcoredump under /sys/class/devcoredump/ on a
+  # GPU fault, but it self-deletes after ~5 minutes. On appearance, copy it to
+  # /var/lib/devcoredump (which also frees the kernel slot).
+  services.udev.extraRules = ''
+    ACTION=="add", SUBSYSTEM=="devcoredump", TAG+="systemd", ENV{SYSTEMD_WANTS}+="capture-devcoredump@$kernel.service"
+  '';
+  systemd.services."capture-devcoredump@" = {
+    description = "Capture GPU devcoredump %i";
+    path = [ pkgs.coreutils ];
+    serviceConfig = {
+      Type = "oneshot";
+      ExecStart =
+        let
+          script = pkgs.writeShellScript "capture-devcoredump" ''
+            set -eu
+            dev="/sys/class/devcoredump/$1"
+            out="/var/lib/devcoredump"
+            mkdir -p "$out"
+            ts="$(date +%Y%m%d-%H%M%S)"
+            [ -r "$dev/data" ] && cp "$dev/data" "$out/$ts-$1.bin" || true
+            # Writing to data releases the kernel devcoredump slot.
+            echo 1 > "$dev/data" 2>/dev/null || true
+          '';
+        in
+        "${script} %i";
+    };
+  };
+}


### PR DESCRIPTION
## Why

`gnome-shell` on **rugged** aborts every few days and dumps you back at the GDM greeter
with your windows gone (tmux survives — the machine never reboots). Forensics on the
captured cores pinned it: all crashes share the **identical native sink** across three
different GL entry points —

```
abort()
_iris_batch_flush.cold()        (Mesa iris)
  ├─ swap_buffers → st_glFlush → iris_fence_flush          (Jun 27)
  ├─ eglCreateSyncKHR → dri_create_fence_fd                (Jun 18)
  └─ st_TexSubImage → iris_blit → tc_batch_execute         (Jun 21)
```

Mesa's iris driver calls `abort()` when a GPU command-batch submission fails. The GJS
extension stack dumps in the journal (aiquota, pop-shell, appindicator, nightthemeswitcher)
are **red herrings** — ambient JS warnings, not the crash. No kernel GPU hang is logged at
any crash time, so this is iris being intolerant of a return code from the young Lunar Lake
`xe` kernel driver — a driver-maturity bug on brand-new Arc 130V/140V hardware.

Full investigation: `debug/rugged/gnome_shell_iris_abort.md`.

## What this does — `nix/nixos/hosts/rugged/gpu-debug.nix`

**Mitigation**
- Bumps Mesa `25.2.6` (stable channel) → **`26.1.2`** from `nixpkgs-unstable` via
  `hardware.graphics.package{,32}`. ~8 months of Intel/LNL driver work. Cache-fetched
  (254 MiB download, **no source build**). Swaps only the driver package; the rest of the
  system stays on the stable channel. No release note names this exact abort, so it's an
  attempt, not a guaranteed fix.

**Diagnostics for the next crash**
- `MESA_DEBUG=1` session-wide → iris logs the submit failure + errno before `abort()`
  (the one datum the stripped library doesn't currently give us). Tombstoned for removal
  once root-caused.
- Raised `systemd-coredump` retention so gnome-shell cores aren't rotated out.
- Captures kernel `xe` devcoredumps (`udev` → `capture-devcoredump@.service`) before they
  self-expire (~5 min), to `/var/lib/devcoredump`.

## Validation
- `hardware.graphics.package.version` evaluates to `26.1.2`, `MESA_DEBUG` to `1`, capture
  service `ExecStart` resolves.
- `nix build --dry-run` confirms mesa-26.1.2 is **fetched from cache**, not built.
- pre-commit clean.

## Activation
Requires `nixos-rebuild switch` on rugged (left to @agentydragon).

## Not in this PR (documented as next steps in the debug note)
- Disabling iris threaded context (backtrace implicates gallium TC; clean drirc form
  needs Mesa ≥25.2.8, so this bump is a prerequisite).
- Disabling PSR (the boot-time `Selective fetch … pipe A` failure).