### PR TITLE
[codex] Serve Haku console with fingerprinted SPA assets

### DIFF
--- a/cluster/k8s/haku/console/deployment.yaml
+++ b/cluster/k8s/haku/console/deployment.yaml
@@ -1,8 +1,8 @@
-# The Haku console: a FastAPI dashboard that replaced the static nginx haku-dashboard.
-# Unlike the dashboard (nginx + a git-sync sidecar), the app owns git itself —
-# it clones haku-state into an emptyDir at /data at startup and pushes back. Access
-# is gated by Authentik (agentydragon-only) via the proxy outpost — the app has no
-# native auth.
+# The Haku console: reviewed FastAPI API code plus a static nginx frontend.
+# Unlike the old dashboard's nginx + git-sync shape, the FastAPI app owns git
+# itself — it clones haku-state into an emptyDir at /data at startup and pushes
+# back. nginx is only the production static/API routing layer. Access is gated by
+# Authentik (agentydragon-only) via the proxy outpost — the app has no native auth.
 #
 # Trust boundary: runs in its OWN `haku-console` namespace, NOT haku-sandbox. As
 # reviewed/released ducktape code it sits outside Haku's RBAC (Haku can't read its
@@ -42,12 +42,25 @@ spec:
         runAsUser: 1000
         runAsGroup: 1000
         fsGroup: 1000
+      initContainers:
+        - name: copy-web
+          image: ghcr.io/agentydragon/haku-console:devel-20260627091822-6a05fbf # {"$imagepolicy": "flux-system:haku-console"}
+          imagePullPolicy: Always
+          command: ["/bin/sh", "-c"]
+          args: ["cp -a /app/web/. /web/"]
+          volumeMounts:
+            - name: web
+              mountPath: /web
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
       containers:
         - name: server
           image: ghcr.io/agentydragon/haku-console:devel-20260627091822-6a05fbf # {"$imagepolicy": "flux-system:haku-console"}
           imagePullPolicy: Always
           ports:
-            - name: http
+            - name: api
               containerPort: 8080
           env:
             - name: HOME # libgit2/git config + temp writes land in the writable emptyDir
@@ -94,12 +107,12 @@ spec:
               memory: 512Mi
           livenessProbe:
             tcpSocket:
-              port: http
+              port: api
             initialDelaySeconds: 10
             periodSeconds: 30
           readinessProbe:
             tcpSocket:
-              port: http
+              port: api
             initialDelaySeconds: 5
             periodSeconds: 10
           volumeMounts:
@@ -111,8 +124,57 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
+        - name: static
+          image: nginxinc/nginx-unprivileged:1.27-alpine
+          ports:
+            - name: http
+              containerPort: 8081
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          volumeMounts:
+            - name: web
+              mountPath: /usr/share/nginx/html
+              readOnly: true
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: default.conf
+              readOnly: true
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+            - name: nginx-run
+              mountPath: /tmp
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
       volumes:
         - name: tmp
           emptyDir: {}
         - name: data
+          emptyDir: {}
+        - name: web
+          emptyDir: {}
+        - name: nginx-config
+          configMap:
+            name: haku-console-nginx
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-run
           emptyDir: {}

--- a/cluster/k8s/haku/console/kustomization.yaml
+++ b/cluster/k8s/haku/console/kustomization.yaml
@@ -4,3 +4,11 @@ resources:
   - deployment.yaml
   - routine-launch-token.sops.yaml
   - service.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+configMapGenerator:
+  - name: haku-console-nginx
+    files:
+      - default.conf=nginx.conf

--- a/cluster/k8s/haku/console/nginx.conf
+++ b/cluster/k8s/haku/console/nginx.conf
@@ -1,0 +1,38 @@
+map $uri $haku_cache_control {
+  ~^/assets/ "public, max-age=31536000, immutable";
+  ~^/api/ "no-store";
+  /healthz "no-store";
+  default "no-cache, max-age=0, must-revalidate";
+}
+
+server {
+  listen 8081;
+  server_name _;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  add_header Content-Security-Policy "frame-src 'self' https://haku-ui.allegedly.works; frame-ancestors 'none'" always;
+  add_header Cache-Control $haku_cache_control always;
+  proxy_http_version 1.1;
+  proxy_set_header Host $host;
+  proxy_set_header X-Real-IP $remote_addr;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header X-Forwarded-Proto $scheme;
+
+  location /assets/ {
+    try_files $uri =404;
+  }
+
+  location /api/ {
+    proxy_pass http://127.0.0.1:8080;
+  }
+
+  location = /healthz {
+    proxy_pass http://127.0.0.1:8080;
+  }
+
+  location / {
+    try_files $uri /index.html;
+  }
+}

--- a/devinfra/js/BUILD.bazel
+++ b/devinfra/js/BUILD.bazel
@@ -1,10 +1,17 @@
 # Shared JavaScript/TypeScript Bazel macros.
 
 load("@aspect_rules_js//js:defs.bzl", "js_binary")
+load("//devinfra/python:defs.bzl", "py_binary")
 
 js_binary(
     name = "strip_ts_types",
     data = ["//:node_modules/typescript"],
     entry_point = "strip_ts_types.mjs",
+    visibility = ["//visibility:public"],
+)
+
+py_binary(
+    name = "spa_fingerprint",
+    srcs = ["spa_fingerprint.py"],
     visibility = ["//visibility:public"],
 )

--- a/devinfra/js/spa_bundle.bzl
+++ b/devinfra/js/spa_bundle.bzl
@@ -23,12 +23,81 @@ Two configuration paths:
 
 The bundle is emitted into an `output_dir` TreeArtifact so CSS imports and code
 splitting (multiple chunks) are captured without enumerating output filenames.
-`index.html` references the entry by its stable name (`/main.js`), so no
-content-hash rewrite is needed.
+By default, `index.html` references the entry by its stable name (`/main.js`).
+Apps that opt into `fingerprint = True` instead emit content-hashed assets under
+`/assets/` and get an `index.html` rewritten from explicit placeholders.
 """
 
 load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
+
+def _fingerprinted_spa_bundle_impl(ctx):
+    esbuild_outputs = ctx.attr.esbuild[DefaultInfo].files.to_list()
+    esbuild_dirs = [f for f in esbuild_outputs if f.is_directory]
+    metafiles = [f for f in esbuild_outputs if f.basename.endswith("_metadata.json")]
+    if len(esbuild_dirs) != 1:
+        fail("fingerprinted spa bundle expected exactly one esbuild output directory, got %d" % len(esbuild_dirs))
+    if len(metafiles) != 1:
+        fail("fingerprinted spa bundle expected exactly one esbuild metafile, got %d" % len(metafiles))
+
+    asset_manifest_entries = []
+    asset_files = []
+    for asset_target, placeholder in ctx.attr.fingerprinted_assets.items():
+        files = asset_target[DefaultInfo].files.to_list()
+        if len(files) != 1:
+            fail("fingerprinted asset %s must produce exactly one file, got %d" % (asset_target.label, len(files)))
+        asset = files[0]
+        asset_files.append(asset)
+        asset_manifest_entries.append({
+            "basename": asset.basename,
+            "path": asset.path,
+            "placeholder": placeholder,
+        })
+
+    asset_manifest = ctx.actions.declare_file(ctx.label.name + "_fingerprinted_assets.json")
+    ctx.actions.write(asset_manifest, json.encode(asset_manifest_entries))
+
+    out_dir = ctx.actions.declare_directory(ctx.attr.out_dir)
+    args = ctx.actions.args()
+    args.add("--esbuild-dir", esbuild_dirs[0].path)
+    args.add("--metafile", metafiles[0].path)
+    args.add("--index-template", ctx.file.index_html.path)
+    args.add("--asset-manifest", asset_manifest.path)
+    args.add("--out-dir", out_dir.path)
+    args.add("--entry-placeholder", ctx.attr.entry_placeholder)
+    args.add("--url-prefix", ctx.attr.url_prefix)
+
+    ctx.actions.run(
+        executable = ctx.executable._tool,
+        arguments = [args],
+        inputs = depset(
+            [esbuild_dirs[0], metafiles[0], ctx.file.index_html, asset_manifest] + asset_files,
+        ),
+        outputs = [out_dir],
+        mnemonic = "FingerprintSpaBundle",
+        progress_message = "Assembling fingerprinted SPA bundle %s" % ctx.label,
+    )
+    return [DefaultInfo(files = depset([out_dir]))]
+
+_fingerprinted_spa_bundle = rule(
+    implementation = _fingerprinted_spa_bundle_impl,
+    attrs = {
+        "esbuild": attr.label(mandatory = True),
+        "index_html": attr.label(mandatory = True, allow_single_file = True),
+        "fingerprinted_assets": attr.label_keyed_string_dict(
+            allow_files = True,
+            doc = "Extra files to copy under /assets/ with content-hashed names: label -> index.html placeholder.",
+        ),
+        "entry_placeholder": attr.string(default = "__SPA_ENTRY__"),
+        "out_dir": attr.string(default = "dist"),
+        "url_prefix": attr.string(default = "/"),
+        "_tool": attr.label(
+            default = "//devinfra/js:spa_fingerprint",
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+)
 
 def spa_bundle(
         name,
@@ -45,6 +114,10 @@ def spa_bundle(
         target = "es2022",
         minify = True,
         sourcemap = "linked",
+        fingerprint = False,
+        fingerprinted_assets = None,
+        entry_placeholder = "__SPA_ENTRY__",
+        url_prefix = "/",
         visibility = None,
         **kwargs):
     """Bundle a browser SPA into a served directory of static assets.
@@ -72,11 +145,24 @@ def spa_bundle(
         target: esbuild target (default `es2022`).
         minify: Minify the output (default True).
         sourcemap: esbuild sourcemap mode (default `linked`).
+        fingerprint: If True, emit entry/chunk/assets under `assets/[name]-[hash]`
+            and rewrite `index_html` placeholders to the generated URLs.
+        fingerprinted_assets: Extra single-file labels to copy under `/assets/`
+            with content-hashed names, as `{label: placeholder}`. Use this for
+            assets produced outside esbuild, such as a Tailwind CLI stylesheet.
+        entry_placeholder: Placeholder in `index_html` for the esbuild entry URL.
+        url_prefix: URL prefix prepended to generated asset paths.
         visibility: Visibility of the produced directory target.
         **kwargs: Passed through to the underlying `esbuild` rule.
     """
     if config != None and (jsx != None or loader != None):
         fail("spa_bundle: pass jsx/loader OR config (a plugin esbuild.config.mjs), not both")
+    if fingerprint and config != None:
+        fail("spa_bundle: fingerprint=True currently supports inline jsx/loader config only")
+    if fingerprint and index_html == None:
+        fail("spa_bundle: fingerprint=True requires an index_html template")
+    if fingerprint and public:
+        fail("spa_bundle: fingerprint=True does not yet support public=; pass files through fingerprinted_assets")
 
     esbuild_config = config
     if config == None:
@@ -85,6 +171,12 @@ def spa_bundle(
             esbuild_config["jsx"] = jsx
         if loader != None:
             esbuild_config["loader"] = loader
+        if fingerprint:
+            esbuild_config.update({
+                "assetNames": "assets/[name]-[hash]",
+                "chunkNames": "assets/[name]-[hash]",
+                "entryNames": "assets/[name]-[hash]",
+            })
 
     esbuild_name = name + "_esbuild"
     esbuild(
@@ -97,10 +189,24 @@ def spa_bundle(
         platform = "browser",
         target = [target],
         sourcemap = sourcemap,
+        metafile = fingerprint,
         minify = minify,
         splitting = splitting,
         **kwargs
     )
+
+    if fingerprint:
+        _fingerprinted_spa_bundle(
+            name = name,
+            esbuild = ":" + esbuild_name,
+            index_html = index_html,
+            fingerprinted_assets = fingerprinted_assets or {},
+            entry_placeholder = entry_placeholder,
+            out_dir = out_dir,
+            url_prefix = url_prefix,
+            visibility = visibility,
+        )
+        return
 
     pkg = native.package_name()
     esbuild_root = "{}/{}".format(pkg, esbuild_name) if pkg else esbuild_name

--- a/devinfra/js/spa_fingerprint.py
+++ b/devinfra/js/spa_fingerprint.py
@@ -1,0 +1,100 @@
+"""Assemble a fingerprinted SPA bundle from esbuild output plus extra assets."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+from pathlib import Path
+from typing import Any
+
+
+def _url(prefix: str, path: str) -> str:
+    normalized = path.replace("\\", "/").lstrip("/")
+    if prefix.endswith("/"):
+        return prefix + normalized
+    return prefix + "/" + normalized
+
+
+def _copy_tree(src: Path, dst: Path) -> None:
+    for path in src.rglob("*"):
+        if path.is_dir():
+            continue
+        rel = path.relative_to(src)
+        out = dst / rel
+        out.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(path, out)
+
+
+def _output_relative_to_esbuild_dir(output_path: str, esbuild_dir: Path) -> str:
+    normalized = output_path.replace("\\", "/")
+    marker = esbuild_dir.name + "/"
+    if marker in normalized:
+        return normalized.split(marker, 1)[1]
+    return normalized
+
+
+def _entry_output(metafile: dict[str, Any], esbuild_dir: Path) -> str:
+    entry_outputs = [
+        path
+        for path, output in metafile["outputs"].items()
+        if output.get("entryPoint") is not None and path.endswith(".js")
+    ]
+    if len(entry_outputs) != 1:
+        raise ValueError(f"expected exactly one JS entry output in esbuild metafile, got {entry_outputs!r}")
+    return _output_relative_to_esbuild_dir(entry_outputs[0], esbuild_dir)
+
+
+def _fingerprint_asset(src: Path, out_dir: Path) -> str:
+    digest = hashlib.sha256(src.read_bytes()).hexdigest()[:16]
+    stem = src.stem
+    suffix = "".join(src.suffixes)
+    out_rel = Path("assets") / f"{stem}-{digest}{suffix}"
+    out = out_dir / out_rel
+    out.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, out)
+    return out_rel.as_posix()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--esbuild-dir", type=Path, required=True)
+    parser.add_argument("--metafile", type=Path, required=True)
+    parser.add_argument("--index-template", type=Path, required=True)
+    parser.add_argument("--asset-manifest", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, required=True)
+    parser.add_argument("--entry-placeholder", required=True)
+    parser.add_argument("--url-prefix", default="/")
+    args = parser.parse_args()
+
+    if args.out_dir.exists():
+        shutil.rmtree(args.out_dir)
+    args.out_dir.mkdir(parents=True)
+
+    _copy_tree(args.esbuild_dir, args.out_dir)
+
+    metafile = json.loads(args.metafile.read_text(encoding="utf-8"))
+    replacements = {args.entry_placeholder: _url(args.url_prefix, _entry_output(metafile, args.esbuild_dir))}
+
+    asset_manifest = json.loads(args.asset_manifest.read_text(encoding="utf-8"))
+    for asset in asset_manifest:
+        replacements[asset["placeholder"]] = _url(
+            args.url_prefix, _fingerprint_asset(Path(asset["path"]), args.out_dir)
+        )
+
+    html = args.index_template.read_text(encoding="utf-8")
+    for placeholder, replacement in replacements.items():
+        if placeholder not in html:
+            raise ValueError(f"index template {args.index_template} does not contain placeholder {placeholder!r}")
+        html = html.replace(placeholder, replacement)
+
+    leftovers = [placeholder for placeholder in replacements if placeholder in html]
+    if leftovers:
+        raise ValueError(f"index template still contains unreplaced placeholders: {leftovers!r}")
+
+    (args.out_dir / "index.html").write_text(html, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/haku/console/BUILD.bazel
+++ b/haku/console/BUILD.bazel
@@ -169,8 +169,9 @@ py_image_layer(
     owner = "1000",
 )
 
-# The built React SPA, flattened to /app/web (index.html + main.js + styles.css),
-# served by StaticFiles via HAKU_CONSOLE_STATIC_DIR below.
+# The built React SPA, flattened to /app/web (index.html + assets/*).
+# Production nginx serves this directory; FastAPI also mounts it as a direct
+# local/dev fallback via HAKU_CONSOLE_STATIC_DIR below.
 pkg_files(
     name = "web_files",
     srcs = ["//haku/console/frontend:bundle"],

--- a/haku/console/README.md
+++ b/haku/console/README.md
@@ -68,29 +68,32 @@ and decides. See `console/plans/free_form_ui_iframe.md`.
 
 ## Layout
 
-| Path               | Role                                                                                                                                                                                                         |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `app.py`           | FastAPI `create_app` + lifespan (clone). `GET /api/config`, `GET /healthz`, CSRF config, mounts the trace + capability routers, serves the SPA (`StaticFiles`) otherwise.                                    |
-| `trace.py`         | Trace-tier router (`/api/trace`): a single `POST` that records an opaque operator note to haku-state. Low-privilege haku-state write; reads `git_state` off `app.state`.                                     |
-| `capabilities.py`  | Capability-tier router (`/api/capabilities/*`): CSRF-gated, audited privileged actions. `POST /launch-routine` fires the routine with the server-side bearer; `GET /csrf` issues the double-submit token.    |
-| `git_state.py`     | pygit2 clone of haku-state; `reconcile` (fetch + hard-reset), `commit_push` with retry, `append_trace` (the single write path). Talks to the cluster-internal **plaintext-HTTP** Forgejo (no TLS/CA needed). |
-| `models.py`        | Pydantic `TraceRequest` and `ConfigResponse` — the `/api` request/response models.                                                                                                                           |
-| `config.py`        | Env settings (`HAKU_CONSOLE_*`).                                                                                                                                                                             |
-| `export_schema.py` | Prints the OpenAPI schema; the frontend generates its TypeScript types from it.                                                                                                                              |
-| `frontend/`        | React SPA (esbuild bundle) — see `frontend/README.md`.                                                                                                                                                       |
+| Path               | Role                                                                                                                                                                                                                                         |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `app.py`           | FastAPI `create_app` + lifespan (clone). `GET /api/config`, `GET /healthz`, CSRF config, mounts the trace + capability routers. Also serves the SPA (`StaticFiles`) for local/direct fallback; production static traffic goes through nginx. |
+| `trace.py`         | Trace-tier router (`/api/trace`): a single `POST` that records an opaque operator note to haku-state. Low-privilege haku-state write; reads `git_state` off `app.state`.                                                                     |
+| `capabilities.py`  | Capability-tier router (`/api/capabilities/*`): CSRF-gated, audited privileged actions. `POST /launch-routine` fires the routine with the server-side bearer; `GET /csrf` issues the double-submit token.                                    |
+| `git_state.py`     | pygit2 clone of haku-state; `reconcile` (fetch + hard-reset), `commit_push` with retry, `append_trace` (the single write path). Talks to the cluster-internal **plaintext-HTTP** Forgejo (no TLS/CA needed).                                 |
+| `models.py`        | Pydantic `TraceRequest` and `ConfigResponse` — the `/api` request/response models.                                                                                                                                                           |
+| `config.py`        | Env settings (`HAKU_CONSOLE_*`).                                                                                                                                                                                                             |
+| `export_schema.py` | Prints the OpenAPI schema; the frontend generates its TypeScript types from it.                                                                                                                                                              |
+| `frontend/`        | React SPA (esbuild bundle) — see `frontend/README.md`.                                                                                                                                                                                       |
 
 ## Perimeter / deploy
 
 Manifests live in `cluster/k8s/haku/console/` (operator-owned — the perimeter is not
 Haku's to change); the `haku-console` namespace itself is `cluster/k8s/haku/console-namespace/`.
+The image bundles the fingerprinted SPA under `/app/web`; an initContainer copies it
+to an `emptyDir`, and an nginx sidecar serves static paths on the Service port while
+proxying `/api/*` and `/healthz` to FastAPI on localhost.
 Non-root, dropped caps, no service-account token. Credentials: the `haku-state-git-write`
 secret (provisioned into `haku-console` by the `tf/gitops/haku-state` module) and the
 `haku-routine-launch-token` secret (the capability tier's bearer; `HAKU_CONSOLE_LAUNCH_ROUTINE__TOKEN`).
 As trusted ducktape code in its own namespace it is **not** behind the `haku-mitmproxy`
 fence — it gets ordinary cluster egress (which the capability tier needs to reach the
-Anthropic fire URL). The image bundles the built SPA at `/app/web`
-(`HAKU_CONSOLE_STATIC_DIR`). Design + roadmap: `haku/PLAN.md` and the `haku-state` repo's
-`plans/dashboard-arm.md`.
+Anthropic fire URL). FastAPI's direct StaticFiles fallback still points at
+`HAKU_CONSOLE_STATIC_DIR` for local/dev serving. Design + roadmap: `haku/PLAN.md` and the
+`haku-state` repo's `plans/dashboard-arm.md`.
 
 ## Test
 

--- a/haku/console/app.py
+++ b/haku/console/app.py
@@ -34,6 +34,18 @@ from haku.console.models import ConfigResponse
 
 logger = logging.getLogger(__name__)
 
+APP_SHELL_CACHE_CONTROL = "no-cache, max-age=0, must-revalidate"
+IMMUTABLE_ASSET_CACHE_CONTROL = "public, max-age=31536000, immutable"
+NO_STORE_CACHE_CONTROL = "no-store"
+
+
+def _cache_control_for_path(path: str) -> str:
+    if path.startswith("/assets/"):
+        return IMMUTABLE_ASSET_CACHE_CONTROL
+    if path.startswith("/api/") or path == "/healthz":
+        return NO_STORE_CACHE_CONTROL
+    return APP_SHELL_CACHE_CONTROL
+
 
 def create_app(settings: Settings, *, git_state: GitState) -> FastAPI:
     @contextlib.asynccontextmanager
@@ -55,9 +67,10 @@ def create_app(settings: Settings, *, git_state: GitState) -> FastAPI:
     csp = f"frame-src {frame_src}; frame-ancestors 'none'"
 
     @app.middleware("http")
-    async def _csp_headers(request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
+    async def _security_headers(request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
         response = await call_next(request)
         response.headers["Content-Security-Policy"] = csp
+        response.headers["Cache-Control"] = _cache_control_for_path(request.url.path)
         return response
 
     # CSRF for the capability tier: a header-located double-submit token (the SPA

--- a/haku/console/frontend/BUILD.bazel
+++ b/haku/console/frontend/BUILD.bazel
@@ -1,10 +1,9 @@
-load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//js:defs.bzl", "js_library", "js_run_binary")
-load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@npm_ducktape//:@tailwindcss/cli/package_json.bzl", tailwindcss_bin = "bin")
 load("@npm_ducktape//:typescript/package_json.bzl", tsc_bin = "bin")
 load("@npm_ducktape//:vitest/package_json.bzl", vitest_bin = "bin")
 load("//devinfra/js:openapi.bzl", "js_openapi_schema")
+load("//devinfra/js:spa_bundle.bzl", "spa_bundle")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -27,6 +26,11 @@ js_library(
         ":schema",
         "//:node_modules/openapi-fetch",
     ],
+)
+
+js_library(
+    name = "assets",
+    srcs = ["assets.ts"],
 )
 
 js_library(
@@ -99,6 +103,7 @@ js_library(
     name = "app",
     srcs = ["app.tsx"],
     deps = [
+        ":assets",
         ":client",
         ":constants",
         ":feedback",
@@ -123,36 +128,13 @@ js_library(
     ],
 )
 
-esbuild(
-    name = "main_bundle",
-    config = {"jsx": "automatic"},
-    entry_point = "main.tsx",
-    format = "esm",
-    output = "dist/main.js",
-    platform = "browser",
-    sourcemap = "linked",
-    target = ["es2022"],
-    deps = [":main_lib"],
-)
-
-copy_file(
-    name = "bundle_index_html",
-    src = "index.html",
-    out = "dist/index.html",
-)
-
-copy_file(
-    name = "bundle_logo_svg",
-    src = "//haku/console:logo.svg",
-    out = "dist/logo.svg",
-)
-
 # Tailwind v4 scans the `@source`-declared file for class names; concatenate every
 # source whose utility classes the stylesheet must keep into the one file it lists.
 filegroup(
     name = "tailwind_content_srcs",
     srcs = [
         "app.tsx",
+        "assets.ts",
         "client.ts",
         "confirm_dialog.tsx",
         "constants.ts",
@@ -191,12 +173,12 @@ js_run_binary(
         "styles.src.css",
         ":tailwind_content_index",
     ],
-    outs = ["dist/styles.css"],
+    outs = ["generated/styles.css"],
     args = [
         "--input",
         "styles.src.css",
         "--output",
-        "dist/styles.css",
+        "generated/styles.css",
         "--minify",
     ],
     chdir = package_name(),
@@ -204,14 +186,16 @@ js_run_binary(
 )
 
 # Everything the backend serves as the SPA docroot.
-filegroup(
+spa_bundle(
     name = "bundle",
-    srcs = [
-        ":bundle_index_html",
-        ":bundle_logo_svg",
-        ":main_bundle",
-        ":styles_css",
-    ],
+    entry_point = "main.tsx",
+    fingerprint = True,
+    fingerprinted_assets = {
+        ":styles_css": "__STYLES_CSS__",
+        "//haku/console:logo.svg": "__LOGO_SVG__",
+    },
+    jsx = "automatic",
+    deps = [":main_lib"],
 )
 
 # Full TypeScript type-check (the correctness gate esbuild bundling skips).

--- a/haku/console/frontend/README.md
+++ b/haku/console/frontend/README.md
@@ -1,8 +1,10 @@
 # haku/console/frontend — dashboard SPA
 
 React 18 single-page app for the Haku console, bundled with esbuild and served
-same-origin by the console's FastAPI backend. Styled with the repo's house stack —
-**Mantine v7** components + **Tailwind v4** utilities — modeled on
+same-origin by the console service. Production serves static files through nginx
+in front of the FastAPI API process; FastAPI still has a direct StaticFiles mount
+for local/dev serving. Styled with the repo's house stack — **Mantine v7**
+components + **Tailwind v4** utilities — modeled on
 `finance/augur/frontend` (references root `//:node_modules/*`; no per-package
 `package.json`).
 
@@ -17,10 +19,12 @@ same-origin by the console's FastAPI backend. Styled with the repo's house stack
   the `Item` Pydantic models are the single source of truth for the wire contract.
 - `markdown.ts` — item `body` → sanitized HTML (`marked` + `dompurify`).
 - `styles.src.css` — `@import`s Tailwind + `@mantine/core` CSS; compiled by
-  `@tailwindcss/cli` to `dist/styles.css`. Deviation from a plain Tailwind setup: the
-  `@source` content index is a generated file (`tailwind_content_index`) concatenating
-  the sources Tailwind must scan, since Bazel sandboxes the inputs.
-- `index.html` — the docroot shell the backend serves (links `styles.css` + `main.js`).
+  `@tailwindcss/cli` to `generated/styles.css`, then fingerprinted into
+  `dist/assets/styles-<hash>.css`. Deviation from a plain Tailwind setup: the `@source`
+  content index is a generated file (`tailwind_content_index`) concatenating the sources
+  Tailwind must scan, since Bazel sandboxes the inputs.
+- `index.html` — the docroot shell template; `spa_bundle(fingerprint = True)` rewrites
+  placeholders to hashed JS/CSS/logo URLs under `dist/assets/`.
 
 ```bash
 bbr build //haku/console/frontend:bundle   # production bundle (dist/)

--- a/haku/console/frontend/app.tsx
+++ b/haku/console/frontend/app.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Anchor, Group, Loader, Text, Title } from "@mantine/core";
 
+import { LOGO_URL } from "./assets.ts";
 import { type ConfigResponse, fetchConfig } from "./client.ts";
 import { INTAKE_NEW } from "./constants.ts";
 import { FeedbackForm } from "./feedback.tsx";
@@ -46,7 +47,7 @@ export default function App() {
     <div className="mx-auto max-w-3xl px-4 py-8">
       <Group justify="space-between" align="center" mb="xs">
         <Group gap="sm" align="center">
-          <img src="./logo.svg" alt="" aria-hidden="true" className="h-10 w-10 shrink-0" />
+          <img src={LOGO_URL} alt="" aria-hidden="true" className="h-10 w-10 shrink-0" />
           <Title order={1}>Haku</Title>
         </Group>
         <LaunchRoutineButton routineUrl={config.launch_routine_url} />

--- a/haku/console/frontend/assets.ts
+++ b/haku/console/frontend/assets.ts
@@ -1,0 +1,9 @@
+type HakuAssetGlobals = {
+  __HAKU_ASSETS__?: {
+    logo?: string;
+  };
+};
+
+const assets = (globalThis as HakuAssetGlobals).__HAKU_ASSETS__;
+
+export const LOGO_URL = assets?.logo ?? "/logo.svg";

--- a/haku/console/frontend/index.html
+++ b/haku/console/frontend/index.html
@@ -4,11 +4,14 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Haku — dashboard</title>
-    <link rel="icon" type="image/svg+xml" href="./logo.svg" />
-    <link rel="stylesheet" href="./styles.css" />
+    <link rel="icon" type="image/svg+xml" href="__LOGO_SVG__" />
+    <link rel="stylesheet" href="__STYLES_CSS__" />
+    <script>
+      window.__HAKU_ASSETS__ = { logo: "__LOGO_SVG__" };
+    </script>
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="./main.js"></script>
+    <script type="module" src="__SPA_ENTRY__"></script>
   </body>
 </html>

--- a/haku/console/test_app.py
+++ b/haku/console/test_app.py
@@ -44,6 +44,20 @@ def test_config_unconfigured_csp_denies_framing(client) -> None:
     assert "frame-src 'none'" in resp.headers["content-security-policy"]
 
 
+def test_cache_policy_splits_hashed_assets_app_shell_and_api(make_client, tmp_path: Path) -> None:
+    static_dir = tmp_path / "web"
+    assets_dir = static_dir / "assets"
+    assets_dir.mkdir(parents=True)
+    (static_dir / "index.html").write_text("<!doctype html><div id='root'></div>", encoding="utf-8")
+    (assets_dir / "main-abcdef123456.js").write_text("console.log('haku')", encoding="utf-8")
+
+    with make_client(static_dir=static_dir) as c:
+        assert c.get("/assets/main-abcdef123456.js").headers["cache-control"] == ("public, max-age=31536000, immutable")
+        assert c.get("/").headers["cache-control"] == "no-cache, max-age=0, must-revalidate"
+        assert c.get("/api/config").headers["cache-control"] == "no-store"
+        assert c.get("/healthz").headers["cache-control"] == "no-store"
+
+
 def test_trace_appends_intake_note(client, seeded) -> None:
     assert client.post("/api/trace", json={"text": "please prioritize taxes"}).json() == {"status": "ok"}
     tip = _remote_tip(seeded.bare)


### PR DESCRIPTION
## Summary

- extend `spa_bundle` with an opt-in fingerprinted mode that emits hashed assets under `/assets/` and rewrites explicit `index.html` placeholders
- move Haku console onto the fingerprinted bundle path, including hashed Tailwind CSS and logo URLs
- put nginx in front of the Haku FastAPI API process in production so static/app-shell/API routes get separate cache policy
- keep FastAPI static serving as a local/direct fallback with matching cache headers

## Root cause

The console served stable `/main.js` and `/styles.css` paths without cache policy. A mobile browser could keep executing an older bundle after deploy; the live symptom was the phone still calling the retired `/api/dashboard` endpoint while the deployed bundle called `/api/config`.

## Validation

- `pre-commit run --files cluster/k8s/haku/console/deployment.yaml cluster/k8s/haku/console/kustomization.yaml cluster/k8s/haku/console/nginx.conf devinfra/js/BUILD.bazel devinfra/js/spa_bundle.bzl devinfra/js/spa_fingerprint.py haku/console/BUILD.bazel haku/console/README.md haku/console/app.py haku/console/frontend/BUILD.bazel haku/console/frontend/README.md haku/console/frontend/app.tsx haku/console/frontend/assets.ts haku/console/frontend/index.html haku/console/test_app.py`
- `bbr test //haku/console/... //haku/console/frontend/...`
- `bbr build //haku/console:server_image`
- `kubectl kustomize cluster/k8s/haku/console`
- inspected downloaded frontend bundle: `index.html` references only `/assets/main-<hash>.js`, `/assets/styles-<hash>.css`, and `/assets/logo-<hash>.svg`