### PR TITLE
talos(ovh): rename node for_each keys to role-neutral hostnames (state-only)

### DIFF
--- a/cluster/terraform/main/infrastructure.tf
+++ b/cluster/terraform/main/infrastructure.tf
@@ -23,7 +23,7 @@ locals {
   proxmox_gateway = "10.2.0.1"
 
   # Stable Talos endpoint used for post-bootstrap client configuration reads.
-  primary_controlplane_ip     = data.ovh_dedicated_server.kimsufi_cp["kimsufi_cp0"].ip
+  primary_controlplane_ip     = data.ovh_dedicated_server.kimsufi_cp["ovh-ns102453"].ip
   kubeconfig_cluster_endpoint = "https://api.${var.cluster_domain}:6443"
 
   # Total expected node count (for health checks)

--- a/cluster/terraform/main/nebula.tf
+++ b/cluster/terraform/main/nebula.tf
@@ -18,14 +18,17 @@ locals {
   nebula_hosts = local.nebula_mesh.hosts
 
   # Map TF resource keys → roster host names (cert subject =
-  # "<host>.nebula.allegedly.works"). Add a row when adding a TF-managed
-  # host to the roster.
+  # "<host>.nebula.allegedly.works").
+  # CLEANUP(added 2026-06-28): now an identity map — the TF for_each keys were renamed to
+  #   the hostnames (this commit), so key == value. Drop this local and replace its sole
+  #   consumer (nebula_node_names) with the keys directly. Left in place here only to keep
+  #   this rename a pure, state-only refactor (no behavior change); remove in a follow-up.
   nebula_tf_key_to_host = {
-    kimsufi_worker0 = "ovh-ns103656"
-    kimsufi_worker1 = "ovh-ns103711"
-    ks_game_worker0 = "ovh-ns104952"
-    ks_game_worker1 = "ovh-ns104963"
-    kimsufi_cp0     = "ovh-ns102453"
+    "ovh-ns103656" = "ovh-ns103656"
+    "ovh-ns103711" = "ovh-ns103711"
+    "ovh-ns104952" = "ovh-ns104952"
+    "ovh-ns104963" = "ovh-ns104963"
+    "ovh-ns102453" = "ovh-ns102453"
   }
 
   # Derived: list of all lighthouse IPs (for non-lighthouse nodes' `lighthouse.hosts`).

--- a/cluster/terraform/main/ovh-nodes-moved.tf
+++ b/cluster/terraform/main/ovh-nodes-moved.tf
@@ -1,0 +1,179 @@
+# Rename the OVH node for_each keys from the role-encoded names (which lie —
+# kimsufi_worker0/1 are control planes) to the role-neutral provider hostnames,
+# matching the already-renamed Talos/k8s node names. State-only: moved blocks keep
+# every instance in place (tofu plan must show 0 destroy/recreate).
+
+moved {
+  from = null_resource.install_talos_kimsufi["kimsufi_worker0"]
+  to   = null_resource.install_talos_kimsufi["ovh-ns103656"]
+}
+
+moved {
+  from = null_resource.install_talos_kimsufi["kimsufi_worker1"]
+  to   = null_resource.install_talos_kimsufi["ovh-ns103711"]
+}
+
+moved {
+  from = null_resource.install_talos_kimsufi["ks_game_worker0"]
+  to   = null_resource.install_talos_kimsufi["ovh-ns104952"]
+}
+
+moved {
+  from = null_resource.install_talos_kimsufi["ks_game_worker1"]
+  to   = null_resource.install_talos_kimsufi["ovh-ns104963"]
+}
+
+moved {
+  from = ovh_dedicated_server.kimsufi["kimsufi_worker0"]
+  to   = ovh_dedicated_server.kimsufi["ovh-ns103656"]
+}
+
+moved {
+  from = ovh_dedicated_server.kimsufi["kimsufi_worker1"]
+  to   = ovh_dedicated_server.kimsufi["ovh-ns103711"]
+}
+
+moved {
+  from = ovh_dedicated_server.kimsufi["ks_game_worker0"]
+  to   = ovh_dedicated_server.kimsufi["ovh-ns104952"]
+}
+
+moved {
+  from = ovh_dedicated_server.kimsufi["ks_game_worker1"]
+  to   = ovh_dedicated_server.kimsufi["ovh-ns104963"]
+}
+
+moved {
+  from = ovh_dedicated_server_reboot_task.kimsufi_to_rescue["kimsufi_worker0"]
+  to   = ovh_dedicated_server_reboot_task.kimsufi_to_rescue["ovh-ns103656"]
+}
+
+moved {
+  from = ovh_dedicated_server_reboot_task.kimsufi_to_rescue["kimsufi_worker1"]
+  to   = ovh_dedicated_server_reboot_task.kimsufi_to_rescue["ovh-ns103711"]
+}
+
+moved {
+  from = ovh_dedicated_server_reboot_task.kimsufi_to_rescue["ks_game_worker0"]
+  to   = ovh_dedicated_server_reboot_task.kimsufi_to_rescue["ovh-ns104952"]
+}
+
+moved {
+  from = ovh_dedicated_server_reboot_task.kimsufi_to_rescue["ks_game_worker1"]
+  to   = ovh_dedicated_server_reboot_task.kimsufi_to_rescue["ovh-ns104963"]
+}
+
+moved {
+  from = ovh_dedicated_server_reboot_task.kimsufi_to_talos["kimsufi_worker0"]
+  to   = ovh_dedicated_server_reboot_task.kimsufi_to_talos["ovh-ns103656"]
+}
+
+moved {
+  from = ovh_dedicated_server_reboot_task.kimsufi_to_talos["kimsufi_worker1"]
+  to   = ovh_dedicated_server_reboot_task.kimsufi_to_talos["ovh-ns103711"]
+}
+
+moved {
+  from = ovh_dedicated_server_reboot_task.kimsufi_to_talos["ks_game_worker0"]
+  to   = ovh_dedicated_server_reboot_task.kimsufi_to_talos["ovh-ns104952"]
+}
+
+moved {
+  from = ovh_dedicated_server_reboot_task.kimsufi_to_talos["ks_game_worker1"]
+  to   = ovh_dedicated_server_reboot_task.kimsufi_to_talos["ovh-ns104963"]
+}
+
+moved {
+  from = ovh_dedicated_server_update.kimsufi_harddisk["kimsufi_worker0"]
+  to   = ovh_dedicated_server_update.kimsufi_harddisk["ovh-ns103656"]
+}
+
+moved {
+  from = ovh_dedicated_server_update.kimsufi_harddisk["kimsufi_worker1"]
+  to   = ovh_dedicated_server_update.kimsufi_harddisk["ovh-ns103711"]
+}
+
+moved {
+  from = ovh_dedicated_server_update.kimsufi_harddisk["ks_game_worker0"]
+  to   = ovh_dedicated_server_update.kimsufi_harddisk["ovh-ns104952"]
+}
+
+moved {
+  from = ovh_dedicated_server_update.kimsufi_harddisk["ks_game_worker1"]
+  to   = ovh_dedicated_server_update.kimsufi_harddisk["ovh-ns104963"]
+}
+
+moved {
+  from = ovh_dedicated_server_update.kimsufi_rescue["kimsufi_worker0"]
+  to   = ovh_dedicated_server_update.kimsufi_rescue["ovh-ns103656"]
+}
+
+moved {
+  from = ovh_dedicated_server_update.kimsufi_rescue["kimsufi_worker1"]
+  to   = ovh_dedicated_server_update.kimsufi_rescue["ovh-ns103711"]
+}
+
+moved {
+  from = ovh_dedicated_server_update.kimsufi_rescue["ks_game_worker0"]
+  to   = ovh_dedicated_server_update.kimsufi_rescue["ovh-ns104952"]
+}
+
+moved {
+  from = ovh_dedicated_server_update.kimsufi_rescue["ks_game_worker1"]
+  to   = ovh_dedicated_server_update.kimsufi_rescue["ovh-ns104963"]
+}
+
+moved {
+  from = talos_machine_configuration_apply.kimsufi["kimsufi_worker0"]
+  to   = talos_machine_configuration_apply.kimsufi["ovh-ns103656"]
+}
+
+moved {
+  from = talos_machine_configuration_apply.kimsufi["kimsufi_worker1"]
+  to   = talos_machine_configuration_apply.kimsufi["ovh-ns103711"]
+}
+
+moved {
+  from = talos_machine_configuration_apply.kimsufi["ks_game_worker0"]
+  to   = talos_machine_configuration_apply.kimsufi["ovh-ns104952"]
+}
+
+moved {
+  from = talos_machine_configuration_apply.kimsufi["ks_game_worker1"]
+  to   = talos_machine_configuration_apply.kimsufi["ovh-ns104963"]
+}
+
+moved {
+  from = null_resource.install_talos_kimsufi_cp["kimsufi_cp0"]
+  to   = null_resource.install_talos_kimsufi_cp["ovh-ns102453"]
+}
+
+moved {
+  from = ovh_dedicated_server.kimsufi_cp["kimsufi_cp0"]
+  to   = ovh_dedicated_server.kimsufi_cp["ovh-ns102453"]
+}
+
+moved {
+  from = ovh_dedicated_server_reboot_task.kimsufi_cp_to_rescue["kimsufi_cp0"]
+  to   = ovh_dedicated_server_reboot_task.kimsufi_cp_to_rescue["ovh-ns102453"]
+}
+
+moved {
+  from = ovh_dedicated_server_reboot_task.kimsufi_cp_to_talos["kimsufi_cp0"]
+  to   = ovh_dedicated_server_reboot_task.kimsufi_cp_to_talos["ovh-ns102453"]
+}
+
+moved {
+  from = ovh_dedicated_server_update.kimsufi_cp_harddisk["kimsufi_cp0"]
+  to   = ovh_dedicated_server_update.kimsufi_cp_harddisk["ovh-ns102453"]
+}
+
+moved {
+  from = ovh_dedicated_server_update.kimsufi_cp_rescue["kimsufi_cp0"]
+  to   = ovh_dedicated_server_update.kimsufi_cp_rescue["ovh-ns102453"]
+}
+
+moved {
+  from = talos_machine_configuration_apply.kimsufi_cp["kimsufi_cp0"]
+  to   = talos_machine_configuration_apply.kimsufi_cp["ovh-ns102453"]
+}

--- a/cluster/terraform/main/ovh-nodes.tf
+++ b/cluster/terraform/main/ovh-nodes.tf
@@ -19,7 +19,7 @@
 
 locals {
   kimsufi_servers = {
-    kimsufi_worker0 = {
+    "ovh-ns103656" = {
       service_name    = var.kimsufi_service_name
       hostname        = "ovh-ns103656"
       nebula_ip       = "10.42.0.13"
@@ -29,7 +29,7 @@ locals {
       data_disk_match = "disk.dev_path == '/dev/sdb'"
       zone            = "hil-ovh"
     }
-    kimsufi_worker1 = {
+    "ovh-ns103711" = {
       service_name    = var.kimsufi_service_name_1
       hostname        = "ovh-ns103711"
       nebula_ip       = "10.42.0.14"
@@ -39,7 +39,7 @@ locals {
       data_disk_match = "disk.dev_path == '/dev/sdb'"
       zone            = "hil-ovh"
     }
-    ks_game_worker0 = {
+    "ovh-ns104952" = {
       service_name    = var.kimsufi_service_name_ks_game_0
       hostname        = "ovh-ns104952"
       nebula_ip       = "10.42.0.16"
@@ -48,7 +48,7 @@ locals {
       data_disk_match = "disk.serial == 'BTPF8304019P450RGN'"
       zone            = "hil-ovh"
     }
-    ks_game_worker1 = {
+    "ovh-ns104963" = {
       service_name    = var.kimsufi_service_name_ks_game_1
       hostname        = "ovh-ns104963"
       nebula_ip       = "10.42.0.17"
@@ -64,7 +64,7 @@ locals {
   }
 
   kimsufi_cp_servers = {
-    kimsufi_cp0 = {
+    "ovh-ns102453" = {
       service_name    = var.kimsufi_service_name_cp0
       hostname        = "ovh-ns102453"
       nebula_ip       = "10.42.0.15"
@@ -198,7 +198,7 @@ resource "ovh_dedicated_server_reboot_task" "kimsufi_to_rescue" {
 # Step 3: SSH into rescue, dd Talos image.
 # connection.timeout covers the window waiting for rescue to boot over SSH.
 # triggers on schematic_id so a kernel/extension change triggers re-provisioning.
-# To re-provision: tofu taint null_resource.install_talos_kimsufi["kimsufi_worker0"]
+# To re-provision: tofu taint null_resource.install_talos_kimsufi["ovh-ns103656"]
 resource "null_resource" "install_talos_kimsufi" {
   for_each = local.active_kimsufi_servers
 
@@ -378,10 +378,10 @@ locals {
   # paired DHCPv4Config below and should be canaried with talosctl --mode=try
   # before being added here.
   kimsufi_eno1_peer_route_enabled_nodes = toset([
-    "kimsufi_worker0",
-    "kimsufi_worker1",
-    "ks_game_worker0",
-    "ks_game_worker1",
+    "ovh-ns103656",
+    "ovh-ns103711",
+    "ovh-ns104952",
+    "ovh-ns104963",
   ])
 
   kimsufi_eno1_peer_route_patches = {
@@ -429,11 +429,11 @@ locals {
   # ExternalIP and removes the taint, and the node is in steady state.
   # Fresh-bootstrapped nodes (post-flag install) get this for free.
   kimsufi_cloud_provider_external_enabled_nodes = toset([
-    "kimsufi_cp0",
-    "kimsufi_worker0",
-    "kimsufi_worker1",
-    "ks_game_worker0",
-    "ks_game_worker1",
+    "ovh-ns102453",
+    "ovh-ns103656",
+    "ovh-ns103711",
+    "ovh-ns104952",
+    "ovh-ns104963",
   ])
 
   kimsufi_cloud_provider_external_patches = {

--- a/cluster/validation/test_nebula_mesh.py
+++ b/cluster/validation/test_nebula_mesh.py
@@ -13,7 +13,11 @@ import yaml
 from cluster.scripts import nebula_mesh
 from util.bazel.runfiles import get_required_path
 
-_TERRAFORM_NODE_RE = re.compile(r"^    (?P<key>[A-Za-z0-9_]+)\s*=\s*\{(?P<body>.*?)^    \}", re.MULTILINE | re.DOTALL)
+# Node-map keys may be bare identifiers or quoted (the OVH keys are role-neutral hostnames
+# like "ovh-ns103656", which contain hyphens and so must be quoted in HCL).
+_TERRAFORM_NODE_RE = re.compile(
+    r'^    "?(?P<key>[A-Za-z0-9_-]+)"?\s*=\s*\{(?P<body>.*?)^    \}', re.MULTILINE | re.DOTALL
+)
 _TERRAFORM_STRING_ATTR_RE = re.compile(r'^\s*(?P<name>[A-Za-z0-9_]+)\s*=\s*"(?P<value>[^"]*)"', re.MULTILINE)
 
 


### PR DESCRIPTION
The OVH node tofu `for_each` keys are role-encoded and **lie** — `kimsufi_worker0/1` are control planes (this is what made the haku-ci runner land on a CP). Rename them to the provider hostnames, which are *already* the Talos/k8s node names:

| old key | new key | role |
|---|---|---|
| `kimsufi_worker0` | `ovh-ns103656` | control plane |
| `kimsufi_worker1` | `ovh-ns103711` | control plane |
| `ks_game_worker0` | `ovh-ns104952` | worker |
| `ks_game_worker1` | `ovh-ns104963` | worker |
| `kimsufi_cp0` | `ovh-ns102453` | control plane |

**Pure refactor — no infra change.** Renaming `for_each` keys changes resource addresses, so `ovh-nodes-moved.tf` carries **35 `moved` blocks** (the 7 `kimsufi` × 4 + 7 `kimsufi_cp` × 1 stateful resources; data sources re-read). Map keys re-keyed in `ovh-nodes.tf` (`kimsufi_servers`, `kimsufi_cp_servers` + the node-list locals), `nebula.tf`, and the one explicit ref in `infrastructure.tf`.

**Verified against live state** (`tofu plan`): **`0 to change, 0 to destroy`** — all 35 instances show `has moved to`, nothing replaced. (The plan's only `3 to add` are gitignored generated `local_file`s absent from the throwaway plan worktree; they're present in the real module dir, so the operator's plan from there is a clean 35-moves / 0-add.)

Apply is a plain `tofu apply` (state moves only). Implements `plans/rename_ovh_nodes_role_neutral.md` — the hostnames were already migrated; this aligns the tofu keys.

Note: the `nebula.tf` map is now identity (`"ovh-ns103656" = "ovh-ns103656"`) — harmless; a follow-up could drop it. Pairs with #2583 (sysctl) + #2587 (runner pinned to real workers).