### PR TITLE
[codex] Namespace Haku console nginx ConfigMap

### DIFF
--- a/cluster/k8s/haku/console/kustomization.yaml
+++ b/cluster/k8s/haku/console/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: haku-console
+
 resources:
   - deployment.yaml
   - routine-launch-token.sops.yaml


### PR DESCRIPTION
## Summary

- set `namespace: haku-console` on the Haku console kustomization so the generated nginx ConfigMap is namespaced

## Root cause

Flux applied the image-automation commit with the new Haku console sidecar wiring, but reconciliation failed because `ConfigMap/haku-console-nginx` was generated without a namespace.

## Validation

- `kubectl kustomize cluster/k8s/haku/console`
- `pre-commit run --files cluster/k8s/haku/console/kustomization.yaml`