### PR TITLE
haku-ci: run dind privileged (rootless daemon in a privileged pod)

### DIFF
--- a/cluster/k8s/haku-ci/README.md
+++ b/cluster/k8s/haku-ci/README.md
@@ -16,8 +16,13 @@ contained to roughly Haku's existing sandbox blast radius:
   can't tamper with the runner pod or its registry/git push creds — but it is **egress-fenced**
   like haku-sandbox (`networkpolicy.yaml`: DNS + base-image registries/npm/pypi + in-cluster
   only).
-- **Rootless builder** (`docker:27-dind-rootless`, non-privileged) — a node escape would break
-  the whole Haku perimeter, so no privileged docker-in-docker (unlike the parked `docker-ci`).
+- **Rootless daemon in a privileged pod** (`docker:27-dind-rootless`, `privileged: true`). The
+  dockerd still runs **rootless** (UID 1000), so it's strictly better than classic rootful
+  dind — but `privileged: true` is the documented requirement for dind-rootless (it provides
+  `/dev/net/tun` and disables the mount masks RootlessKit needs). The non-privileged path was
+  attempted and cleared seccomp + `user.max_user_namespaces` but couldn't get past the masks
+  (see the paving section). The privileged pod's blast radius is bounded by this namespace
+  being operator-only (no Haku RBAC), pinned **off the control planes**, and egress-fenced.
 - **Repo-scoped runner** registered only to the `haku-state` repo, so it only ever runs Haku's
   jobs; `capacity: 1` (serial builds).
 - **Scoped creds**: pushes only to the `haku/*` Forgejo package namespace; commits back only to
@@ -28,12 +33,12 @@ adversarial (containment = cross-origin iframe isolation + the capability gate +
 scheme-gate). A CI-built image vs committed files doesn't widen that — it only changes _how_
 Haku produces the image, and the runner can't escape its perimeter.
 
-## ⚠️ Paving — validate the builder
+## ⚠️ Paving — validate a real build
 
-Rootless `dind` on Talos is the **main risk** and may need securityContext/seccomp tuning,
-`/dev/fuse`, or a switch to **rootless buildkit** if the daemon won't start. Check
-`kubectl -n haku-ci logs deploy/haku-runner -c dind`, run a trivial `.forgejo/workflows/`
-build, and iterate here.
+The dind daemon now starts (privileged-pod rootless, after the non-privileged path dead-ended
+on the mount masks). What's left is an end-to-end check: trigger a `.forgejo/workflows/` build
+on the runner and confirm it builds + pushes an image. Check
+`kubectl -n haku-ci logs deploy/haku-runner -c dind` (daemon up) and the runner's job logs.
 
 ## What's here
 

--- a/cluster/k8s/haku-ci/deployment.yaml
+++ b/cluster/k8s/haku-ci/deployment.yaml
@@ -78,20 +78,25 @@ spec:
             limits:
               cpu: "1"
               memory: 1Gi
-        # Rootless Docker daemon (NOT privileged) for the builds. Listens only on
-        # localhost:2375 inside the pod. **Builder is the main iterate point** —
-        # rootless dind on Talos may need securityContext/seccomp tuning or a
-        # switch to rootless buildkit; see README.
+        # Docker daemon for the builds, listening only on localhost:2375 inside the pod.
+        # privileged: true is the documented requirement for docker:dind-rootless — it
+        # provides /dev (incl. /dev/net/tun for RootlessKit) and disables the mount masks
+        # that otherwise hide those devices from RootlessKit's nested namespaces. The
+        # non-privileged path cleared seccomp (PSA) + user.max_user_namespaces (the OVH
+        # worker sysctl) but still couldn't create the rootless TAP because of the masks.
+        # Crucially the DAEMON still runs ROOTLESS (UID 1000 via the -rootless image), so
+        # this is strictly better than classic rootful dind; the privileged POD is the
+        # price, contained by haku-ci being operator-only (no Haku RBAC), off control
+        # planes, and egress-fenced. See README.
         - name: dind
           image: docker:27-dind-rootless
           args:
             - --host=tcp://0.0.0.0:2375
             - --tls=false
           securityContext:
+            privileged: true
             runAsUser: 1000
             runAsGroup: 1000
-            seccompProfile:
-              type: Unconfined
           volumeMounts:
             - name: docker-data
               mountPath: /var/lib/docker

--- a/cluster/k8s/haku-ci/namespace.yaml
+++ b/cluster/k8s/haku-ci/namespace.yaml
@@ -5,19 +5,20 @@ metadata:
   # haku-sandbox — Haku has no RBAC here, so a prompt-injected Haku cannot tamper
   # with the runner pod or its registry/git push creds. But the runner executes
   # Haku-authored build steps (its workflow + Dockerfile), so it IS agent-controlled
-  # compute and is egress-fenced like haku-sandbox (networkpolicy.yaml) + builds
-  # rootless (no privileged escape). See README.md.
+  # compute and is egress-fenced like haku-sandbox (networkpolicy.yaml) + pinned off
+  # the control planes (deployment.yaml affinity). See README.md.
   name: haku-ci
   labels:
     name: haku-ci
     # The runner's resources are set deliberately; no VPA recommendations wanted.
     goldilocks.fairwinds.com/enabled: "false"
-    # Enforce the privileged Pod Security level. The rootless dind sidecar needs
-    # seccompProfile: Unconfined (nested-container clone/unshare), which the baseline
-    # and restricted levels both forbid. This does NOT make the pod privileged — it
-    # stays rootless (runAsUser 1000, no privileged:true, caps dropped); privileged
-    # PSA only stops *restricting* it. Safe because haku-ci is operator-only (Haku has
-    # no RBAC here; only Flux applies), so the loosened level grants Haku nothing.
+    # Enforce the privileged Pod Security level. The dind sidecar runs privileged
+    # (the documented requirement for docker:dind-rootless — it provides /dev/net/tun
+    # and disables the mount masks RootlessKit needs; the daemon itself still runs
+    # rootless as UID 1000). baseline/restricted forbid both privileged and its
+    # Unconfined seccomp, so the namespace must enforce privileged. Safe because
+    # haku-ci is operator-only (Haku has no RBAC here; only Flux applies), so the
+    # loosened level grants Haku nothing.
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/warn: privileged
     pod-security.kubernetes.io/audit: privileged


### PR DESCRIPTION
The non-privileged rootless dind path dead-ended. We cleared seccomp (PSA, #2580) and `user.max_user_namespaces` (#2583), but dind still fails creating its RootlessKit TAP:

```
[rootlesskit:child] error: executing [ip tuntap add name tap0 mode tap]: exit status 1   (open: No such file or directory)
```

Even with `/dev/net/tun` device-mounted (verified present on the node + in the container), it fails — because **`docker:dind-rootless` requires `privileged: true`** to disable the *mount masks* that hide `/dev` from RootlessKit's nested namespaces (per the Docker rootless docs). A device mount can't lift the masks; only privileged can.

So: set `privileged: true` on the dind sidecar. **The daemon still runs rootless** (UID 1000 via the `-rootless` image) — strictly better than classic rootful dind. The privileged *pod*'s blast radius is bounded by `haku-ci` being **operator-only** (Haku has no RBAC), **off the control planes** (#2587 affinity), and **egress-fenced**. Dropped the now-redundant Unconfined seccompProfile (privileged covers it); kept #2583's sysctl (rootless dockerd still creates userns). README + namespace comments updated.

Cluster integration test + kubeconform + Checkov green. Last builder-side blocker before an end-to-end build test.