### PR TITLE
[codex] Fix Haku console web copy init

### DIFF
--- a/cluster/k8s/haku/console/deployment.yaml
+++ b/cluster/k8s/haku/console/deployment.yaml
@@ -47,7 +47,7 @@ spec:
           image: ghcr.io/agentydragon/haku-console:devel-20260628000612-5c33640 # {"$imagepolicy": "flux-system:haku-console"}
           imagePullPolicy: Always
           command: ["/bin/sh", "-c"]
-          args: ["cp -a /app/web/. /web/"]
+          args: ["cp -R /app/web/. /web/"]
           volumeMounts:
             - name: web
               mountPath: /web


### PR DESCRIPTION
## Summary

- change the Haku console `copy-web` initContainer from `cp -a` to `cp -R`

## Root cause

The rolled pod entered `Init:Error`; the initContainer runs non-root and `cp -a` can fail when preserving root-owned metadata into the writable `emptyDir`.

## Validation

- `kubectl kustomize cluster/k8s/haku/console | rg -n "copy-web|cp -R|cp -a|image: ghcr.io/agentydragon/haku-console|namespace: haku-console"`
- `pre-commit run --files cluster/k8s/haku/console/deployment.yaml`