### PR TITLE
debundle: resolve anonymous claims via selector runtime

### DIFF
--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -1021,6 +1021,9 @@ rust_library(
 rust_test(
     name = "cli_test",
     crate = ":cli",
+    data = [
+        "//devinfra/js/debundle/solver_backends/ortools_cpsat:selector_cpsat_solver",
+    ],
     edition = "2024",
     deps = [
         ":js_ast",

--- a/devinfra/js/debundle/anonymous_resolution.rs
+++ b/devinfra/js/debundle/anonymous_resolution.rs
@@ -16,10 +16,11 @@ use analysis::{
     build_owner_graph,
 };
 use anyhow::{Context, Result, bail};
-use selector_ir::{ClaimOutcome, ResolvedClaim, SelectorFact, SelectorFactStore};
-use selector_ir_lowering::{MemberSelectorLoweringContext, lower_member_selector};
+use selector_ir::{ClaimOutcome, ResolvedClaim, SelectorFact, SelectorFactStore, SelectorTargetId};
+use selector_ir_lowering::{
+    MemberSelectorLoweringContext, MemberSelectorProgramBuilder, lower_member_selector,
+};
 use selector_runtime::solve_global_selector_program;
-use source_match::SelectorResolver;
 use spec::{AnonymousStatementSelector, MemberSelectorSpec};
 use swc_common::{EqIgnoreSpan, SyntaxContext};
 use swc_ecma_ast::Module;
@@ -347,14 +348,14 @@ fn resolve_anonymous_statement_claims_in_globals(
         return Ok(vec![BTreeSet::new(); claims_by_module.len()]);
     }
 
-    with_source_resolvers(
+    with_source_modules(
         graph,
         owner_graph_path,
         modules_root,
         source_root,
         "spec contains anonymous_statements, but owner_graph.json has no source_location \
          data; cannot resolve anonymous selectors",
-        |parsed_by_source, resolvers_by_source| {
+        |parsed_by_source| {
             let mut out = vec![BTreeSet::<OwnerId>::new(); claims_by_module.len()];
             let mut anonymous_owner_by_source_ordinal = HashMap::<(String, usize), OwnerId>::new();
             for (idx, node) in graph.nodes.iter().enumerate() {
@@ -369,63 +370,175 @@ fn resolve_anonymous_statement_claims_in_globals(
                 }
             }
 
-            for (module_idx, claims) in claims_by_module.iter().enumerate() {
-                for selector in claims.selectors {
-                    let mut match_groups = Vec::<Vec<(String, OwnerId)>>::new();
-                    for (source_path, parsed) in parsed_by_source {
-                        let body_index_groups = resolvers_by_source[source_path]
-                            .resolve_anonymous_groups(
-                                &claims.module_path.to_string_lossy(),
+            let anonymous_claims =
+                claims_by_module
+                    .iter()
+                    .enumerate()
+                    .flat_map(|(module_idx, claims)| {
+                        let request_id = claims.module_path.to_string_lossy().to_string();
+                        claims.selectors.iter().enumerate().map(
+                            move |(selector_index, selector)| AnonymousSelectorClaimInfo {
+                                module_idx,
+                                selector_index,
+                                module_path: claims.module_path,
+                                request_id: request_id.clone(),
                                 selector,
-                            )?;
-                        for body_indices in body_index_groups {
-                            let mut owners = Vec::with_capacity(body_indices.len());
-                            for body_idx in body_indices {
-                                let statement_ordinal = js_ast::statement_ordinal_for_body_index(
-                                    &parsed.module.body,
-                                    body_idx,
-                                );
-                                let Some(&owner) = anonymous_owner_by_source_ordinal
-                                    .get(&(source_path.clone(), statement_ordinal))
-                                else {
-                                    bail!(
-                                        "module {} anonymous statement selector matched source {} body \
-                                 index {} / statement ordinal {}, but owner_graph.json has no \
-                                 anonymous owner at that source position",
-                                        claims.module_path.display(),
-                                        source_path,
-                                        body_idx,
-                                        statement_ordinal,
-                                    );
-                                };
-                                owners.push((source_path.clone(), owner));
-                            }
-                            match_groups.push(owners);
-                        }
-                    }
-                    match match_groups.as_slice() {
-                        [owners] => {
-                            out[module_idx].extend(owners.iter().map(|(_, owner)| *owner));
-                        }
-                        [] => bail!(
-                            "module {} anonymous statement selector did not match any source statement:\n{}",
-                            claims.module_path.display(),
-                            selector.match_source,
-                        ),
-                        multiple => bail!(
-                            "module {} anonymous statement selector matched {} source statement groups; \
-                     refine the selector:\n{}",
-                            claims.module_path.display(),
-                            multiple.len(),
-                            selector.match_source,
-                        ),
-                    }
+                            },
+                        )
+                    })
+                    .collect::<Vec<_>>();
+            let mut match_groups_by_claim =
+                vec![Vec::<Vec<(String, OwnerId)>>::new(); anonymous_claims.len()];
+
+            for (source_path, parsed) in parsed_by_source {
+                let mut builder = MemberSelectorProgramBuilder::new(
+                    MemberSelectorLoweringContext::new(ChunkId(0), source_path),
+                );
+                let mut targets = Vec::<AnonymousSelectorTargetInfo>::new();
+                for (claim_idx, claim) in anonymous_claims.iter().enumerate() {
+                    let target = builder
+                        .declare_native_anonymous_statement_target_in_module(
+                            &claim.request_id,
+                            claim.selector_index,
+                            claim.selector,
+                        )
+                        .with_context(|| {
+                            format!(
+                                "module {} anonymous statement selector cannot be lowered into \
+                                 native selector IR",
+                                claim.module_path.display(),
+                            )
+                        })?;
+                    targets.push(AnonymousSelectorTargetInfo { claim_idx, target });
+                }
+                if targets.is_empty() {
+                    continue;
+                }
+                let program = builder.into_program()?;
+                let facts = selector_fact_store_for_module(&parsed.module)
+                    .with_context(|| format!("building selector facts for source {source_path}"))?;
+                let result =
+                    solve_global_selector_program(&program, &facts).with_context(|| {
+                        format!("solving anonymous selectors for source {source_path}")
+                    })?;
+                for target in targets {
+                    let claim = &anonymous_claims[target.claim_idx];
+                    let outcome = result.outcome_for(target.target).with_context(|| {
+                        format!(
+                            "selector solver did not return anonymous statement target for module {}",
+                            claim.module_path.display(),
+                        )
+                    })?;
+                    let groups = anonymous_match_groups_for_outcome(
+                        source_path,
+                        claim,
+                        outcome,
+                        &anonymous_owner_by_source_ordinal,
+                    )?;
+                    match_groups_by_claim[target.claim_idx].extend(groups);
                 }
             }
 
+            for (claim, match_groups) in anonymous_claims.iter().zip(match_groups_by_claim) {
+                match match_groups.as_slice() {
+                    [owners] => {
+                        out[claim.module_idx].extend(owners.iter().map(|(_, owner)| *owner));
+                    }
+                    [] => bail!(
+                        "module {} anonymous statement selector did not match any source statement:\n{}",
+                        claim.module_path.display(),
+                        claim.selector.match_source,
+                    ),
+                    multiple => bail!(
+                        "module {} anonymous statement selector matched {} source statement groups; \
+                 refine the selector:\n{}",
+                        claim.module_path.display(),
+                        multiple.len(),
+                        claim.selector.match_source,
+                    ),
+                }
+            }
             Ok(out)
         },
     )
+}
+
+#[derive(Debug, Clone)]
+struct AnonymousSelectorClaimInfo<'a> {
+    module_idx: usize,
+    selector_index: usize,
+    module_path: &'a Path,
+    request_id: String,
+    selector: &'a AnonymousStatementSelector,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct AnonymousSelectorTargetInfo {
+    claim_idx: usize,
+    target: SelectorTargetId,
+}
+
+fn anonymous_match_groups_for_outcome(
+    source_path: &str,
+    claim: &AnonymousSelectorClaimInfo<'_>,
+    outcome: &ClaimOutcome,
+    anonymous_owner_by_source_ordinal: &HashMap<(String, usize), OwnerId>,
+) -> Result<Vec<Vec<(String, OwnerId)>>> {
+    match outcome {
+        ClaimOutcome::Unique { claim: resolved } => Ok(vec![vec![anonymous_owner_for_claim(
+            source_path,
+            claim,
+            resolved,
+            anonymous_owner_by_source_ordinal,
+        )?]]),
+        ClaimOutcome::Ambiguous { candidates } => candidates
+            .iter()
+            .map(|resolved| {
+                Ok(vec![anonymous_owner_for_claim(
+                    source_path,
+                    claim,
+                    resolved,
+                    anonymous_owner_by_source_ordinal,
+                )?])
+            })
+            .collect(),
+        ClaimOutcome::NoMatch => Ok(Vec::new()),
+        ClaimOutcome::Unsupported { message } => {
+            bail!(
+                "module {} anonymous statement selector is unsupported by selector IR solver: {message}",
+                claim.module_path.display(),
+            )
+        }
+        ClaimOutcome::Duplicate {
+            owner,
+            conflicting_targets,
+        } => bail!(
+            "module {} anonymous statement selector produced a duplicate claim for owner {owner:?} \
+             across {conflicting_targets:?}",
+            claim.module_path.display(),
+        ),
+    }
+}
+
+fn anonymous_owner_for_claim(
+    source_path: &str,
+    claim: &AnonymousSelectorClaimInfo<'_>,
+    resolved: &ResolvedClaim,
+    anonymous_owner_by_source_ordinal: &HashMap<(String, usize), OwnerId>,
+) -> Result<(String, OwnerId)> {
+    let statement_ordinal = resolved.statement_ordinal.0;
+    let Some(&owner) =
+        anonymous_owner_by_source_ordinal.get(&(source_path.to_string(), statement_ordinal))
+    else {
+        bail!(
+            "module {} anonymous statement selector matched source {} statement ordinal {}, \
+             but owner_graph.json has no anonymous owner at that source position",
+            claim.module_path.display(),
+            source_path,
+            statement_ordinal,
+        );
+    };
+    Ok((source_path.to_string(), owner))
 }
 
 /// Parse every distinct `source_location.source_path` in `graph` and hand
@@ -459,43 +572,6 @@ fn with_source_modules<R>(
         })
         .collect::<Result<_>>()?;
     body(&parsed_by_source)
-}
-
-/// Parse every distinct `source_location.source_path` in `graph` and hand
-/// `body` a per-source `ChunkResolver` map alongside the parsed modules.
-/// Resolvers are built once and borrow the parsed modules, so the parsed map and
-/// its resolvers are produced together and lent through the closure rather than
-/// returned.
-fn with_source_resolvers<R>(
-    graph: &OwnerGraphReport,
-    owner_graph_path: &Path,
-    modules_root: &Path,
-    source_root: Option<&Path>,
-    no_sources: &str,
-    body: impl for<'m> FnOnce(
-        &'m BTreeMap<String, js_ast::ParsedJsModule>,
-        &BTreeMap<String, source_match::ChunkResolver<'m>>,
-    ) -> Result<R>,
-) -> Result<R> {
-    with_source_modules(
-        graph,
-        owner_graph_path,
-        modules_root,
-        source_root,
-        no_sources,
-        |parsed_by_source| {
-            let resolvers_by_source: BTreeMap<_, _> = parsed_by_source
-                .iter()
-                .map(|(source_path, parsed)| {
-                    (
-                        source_path.clone(),
-                        source_match::ChunkResolver::new(&parsed.module),
-                    )
-                })
-                .collect();
-            body(parsed_by_source, &resolvers_by_source)
-        },
-    )
 }
 
 /// Resolve `source_path` to a file on disk, read it, and parse it as a JS

--- a/devinfra/js/debundle/lowering/materialize/plan_builder.rs
+++ b/devinfra/js/debundle/lowering/materialize/plan_builder.rs
@@ -57,7 +57,6 @@ use selector_ir::{
 };
 use selector_ir_lowering::{MemberSelectorLoweringContext, MemberSelectorProgramBuilder};
 use selector_runtime::solve_global_selector_program;
-use source_match::SelectorResolver;
 
 impl From<&DuplicateClaimSite> for DuplicateClaimSiteReport {
     fn from(site: &DuplicateClaimSite) -> Self {
@@ -630,40 +629,6 @@ fn anonymous_statement_ambiguous_message(
     )
 }
 
-fn anonymous_statement_diagnostic_message(
-    module: &swc_ecma_ast::Module,
-    request: &LogicalRequest,
-    statement: &AnonymousStatementRequest,
-) -> Option<String> {
-    let resolver = source_match::ChunkResolver::new(module);
-    let matches = match resolver.resolve_anonymous_groups(&request.id, &statement.selector) {
-        Ok(matches) => matches,
-        Err(error) => {
-            return Some(format!(
-                "logical_module {}: anonymous_statements[].match could not be checked after \
-                 global selector no-match: {error}. Selector:\n{}",
-                request.id, statement.selector.match_source,
-            ));
-        }
-    };
-    match matches.as_slice() {
-        [] => Some(anonymous_statement_no_match_message(request, statement)),
-        [_single] => None,
-        multiple => {
-            let body_indices = multiple
-                .iter()
-                .flat_map(|group| group.iter().copied())
-                .collect::<Vec<_>>();
-            Some(anonymous_statement_ambiguous_message(
-                request,
-                statement,
-                multiple.len(),
-                &body_indices,
-            ))
-        }
-    }
-}
-
 /// Output of `ChunkPlanBuilder::finalize`: everything downstream
 /// `lower_chunk` + the chunk-report builder need from the plan
 /// construction phase.
@@ -1047,20 +1012,10 @@ impl ChunkPlanBuilder {
         bail!("{message}")
     }
 
-    fn report_anonymous_statement_failure_before_binding_no_match(
-        &mut self,
-        module: &swc_ecma_ast::Module,
-        request: &LogicalRequest,
-    ) -> Result<bool> {
-        for statement in &request.anonymous_statements {
-            let Some(message) = anonymous_statement_diagnostic_message(module, request, statement)
-            else {
-                continue;
-            };
-            self.record_anonymous_statement_failure_or_bail(request, statement, message)?;
-            return Ok(true);
-        }
-        Ok(false)
+    fn has_recorded_anonymous_statement_failure(&self, request: &LogicalRequest) -> bool {
+        self.anonymous_statement_diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.module_id == request.id)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1334,9 +1289,7 @@ impl ChunkPlanBuilder {
                     if member.binding_selector.is_some()
                         && member.source_match.is_none()
                         && member.relational.is_none()
-                        && self.report_anonymous_statement_failure_before_binding_no_match(
-                            module, request,
-                        )?
+                        && self.has_recorded_anonymous_statement_failure(request)
                     {
                         continue;
                     }


### PR DESCRIPTION
## Summary

- Rewrite graph-backed `anonymous_statements` claim resolution to build native anonymous selector targets and solve through `selector_runtime` instead of constructing `source_match::ChunkResolver` instances.
- Remove the materializer's post-`NoMatch` anonymous diagnostic rematch through `ChunkResolver`; generic member `NoMatch` now defers to already-recorded anonymous solver diagnostics when present.
- Delete the now-unused per-source `ChunkResolver` helper path from `anonymous_resolution`.
- Add the OR-Tools CP-SAT sidecar to `//devinfra/js/debundle:cli_test` runfiles now that the CLI edit-gate path exercises anonymous selector solving.

This keeps anonymous claim resolution on the same selector IR / CP-SAT runtime model as materialization and removes another production procedural matcher fallback.

## Validation

- `nix develop -c pre-commit run --files devinfra/js/debundle/BUILD.bazel devinfra/js/debundle/anonymous_resolution.rs devinfra/js/debundle/lowering/materialize/plan_builder.rs`
- `nix develop -c bbr test //devinfra/js/debundle:cli_test --cache_test_results=no --test_output=errors`
  - BuildBuddy Bazel invocation: `53ca3376-2f73-4b1e-9ed0-5f25d18e7b7d`
- `nix develop -c bbr test //devinfra/js/debundle:cli_test //devinfra/js/debundle/e2e:anonymous_statement_test //devinfra/js/debundle/e2e:selector_diagnostics_report_test //devinfra/js/debundle/e2e:top_level_query_cli_test //devinfra/js/debundle/e2e:edit_gate_source_match_cli_test //devinfra/js/debundle:selector_ir_lowering_test //devinfra/js/debundle:selector_backend_solver_test //devinfra/js/debundle:selector_ortools_cpsat_backend_test --cache_test_results=no --test_output=errors`
  - BuildBuddy Bazel invocation: `77ea8ced-62fb-4268-bf02-51ef2c0a320e`
