### PR TITLE
haku-ci: disable dind TLS so the runner connects (builder now fully works)

### DIFF
--- a/cluster/k8s/haku-ci/deployment.yaml
+++ b/cluster/k8s/haku-ci/deployment.yaml
@@ -93,6 +93,14 @@ spec:
           args:
             - --host=tcp://0.0.0.0:2375
             - --tls=false
+          # --tls=false alone isn't enough: the dind entrypoint defaults DOCKER_TLS_CERTDIR
+          # to /certs and re-enables TLS on 2375, so the runner's plain-HTTP client hits
+          # "HTTP request to an HTTPS server". Emptying it disables TLS so 2375 is plain HTTP
+          # (localhost-only inside the pod). This is the last piece that lets the runner
+          # connect to the rootless daemon.
+          env:
+            - name: DOCKER_TLS_CERTDIR
+              value: ""
           securityContext:
             privileged: true
             runAsUser: 1000


### PR DESCRIPTION
**The last piece — the runner is now fully operational.**

With privileged dind (#2594) the daemon comes up, but the runner couldn't connect: the `docker:dind-rootless` entrypoint defaults `DOCKER_TLS_CERTDIR=/certs` and **re-enables TLS on 2375 despite `--tls=false`**, so the runner's plain-HTTP client hit `Client sent an HTTP request to an HTTPS server`. Setting `DOCKER_TLS_CERTDIR=""` disables TLS → 2375 is plain HTTP → the runner connects.

(Diagnosed live by walking the chain: daemon up → port unreachable → reachable-but-TLS → this. The RootlessKit port-publish hacks turned out unnecessary once TLS was off — the entrypoint binds 2375 on the pod's localhost directly.)

**Verified live:**
```
runner: haku-ci, with version: v6.4.0, with labels: [haku-ci], declared successfully
[poller 0] launched
```
Both containers ready; the runner is polling Forgejo for jobs.

Completes the runner-paving chain: #2580 (PSA) + #2583 (userns sysctl) + #2587 (pinned to real workers) + #2594 (privileged) + this. Next paving step is an actual end-to-end build once Haku adopts the `ui/` starter.