### PR TITLE
debundle: hide legacy source_match resolver API

### DIFF
--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -109,8 +109,9 @@ rust_test(
 )
 
 # Soundness validation: every read-off, rendered to a source_match and run
-# through the production matcher, must resolve uniquely to the intended item.
-# Separate crate so it exercises the public shape_index API plus the matcher.
+# through the legacy matcher oracle, must resolve uniquely to the intended item.
+# Separate crate so it exercises the public shape_index API plus the oracle
+# boundary explicitly.
 rust_test(
     name = "shape_index_soundness_test",
     srcs = ["shape_index_soundness_test.rs"],
@@ -178,7 +179,6 @@ rust_library(
         ":selector_ir",
         ":selector_ir_lowering",
         ":selector_runtime",
-        ":source_match",
         ":spec",
         "@crates//:anyhow",
         "@crates//:swc_common",

--- a/devinfra/js/debundle/anonymous_resolution.rs
+++ b/devinfra/js/debundle/anonymous_resolution.rs
@@ -4,7 +4,8 @@
 //! snippets (`anonymous_statements[].match`). Graph-backed CLI paths
 //! that need owner ids use this module as the single implementation
 //! for mapping matched selectors back to owner-graph nodes. The
-//! selector parser and AST equality live in `source_match`.
+//! selector parser, fact lowering, and assignment solving live in the
+//! selector-IR/runtime path.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::env;

--- a/devinfra/js/debundle/selector_candidate_index.rs
+++ b/devinfra/js/debundle/selector_candidate_index.rs
@@ -979,9 +979,9 @@ mod tests {
     /// `ChunkResolver` — the correctness ground truth the candidate-index
     /// prefilter must be a sound superset of.
     fn exact_matches(runtime: &Module, selector: &AnonymousStatementSelector) -> Vec<usize> {
-        use source_match::SelectorResolver;
+        use source_match::legacy_resolver::SelectorResolver;
         js_ast::with_swc_globals(|| {
-            source_match::ChunkResolver::new(runtime)
+            source_match::legacy_resolver::ChunkResolver::new(runtime)
                 .resolve_anonymous_groups("<test>", selector)
                 .unwrap()
                 .into_iter()

--- a/devinfra/js/debundle/shape_index_soundness_test.rs
+++ b/devinfra/js/debundle/shape_index_soundness_test.rs
@@ -1,8 +1,8 @@
 //! Soundness validation for the Layer-1 read-off API (W1).
 //!
 //! The shape index is only a candidate ranker; the fact-based `source_match`
-//! resolver stays the correctness gate. This test renders every read-off result
-//! to a `source_match` selector and runs it through the resolver
+//! resolver is retained here as the legacy correctness oracle. This test renders
+//! every read-off result to a `source_match` selector and runs it through the resolver
 //! (`ChunkResolver::resolve_anonymous_groups`), asserting it resolves **uniquely**
 //! to the intended item.
 //!
@@ -13,7 +13,7 @@
 
 use selector_candidate_index::SelectorFeature;
 use shape_index::{AnchorSet, ShapeFeature, ShapeIndex, Stability};
-use source_match::{ChunkResolver, SelectorResolver};
+use source_match::legacy_resolver::{ChunkResolver, SelectorResolver};
 use spec::{AnonymousStatementSelector, SourceMatchIdentifierMode};
 use std::collections::BTreeSet;
 use swc_ecma_ast::*;
@@ -218,7 +218,7 @@ fn prop_name(name: &PropName) -> Option<String> {
     }
 }
 
-/// Render a read-off for `body_idx`, run it through the production matcher, and
+/// Render a read-off for `body_idx`, run it through the legacy matcher oracle, and
 /// assert unique resolution to `body_idx`.
 fn assert_read_off_resolves_uniquely(module: &Module, body_idx: usize) -> AnchorSet {
     let index = ShapeIndex::new(module);

--- a/devinfra/js/debundle/source_match/fact_near_miss.rs
+++ b/devinfra/js/debundle/source_match/fact_near_miss.rs
@@ -28,7 +28,7 @@ use selector_match::{Index, Mode};
 
 /// The exact-match top-level alignments of a parsed selector body against a chunk
 /// body, over the fact model — the same `Vec<Vec<Option<usize>>>` shape the
-/// production resolver's anonymous path (`ChunkResolver::resolve_anonymous_groups`
+/// legacy resolver's anonymous path (`ChunkResolver::resolve_anonymous_groups`
 /// → [`selector_match::match_top_level_sequence_indexed`]) produces. A needle
 /// statement that does not project to facts (an unsupported construct) yields an
 /// empty index whose match fails closed, so it pins nothing — the same outcome as

--- a/devinfra/js/debundle/source_match/mod.rs
+++ b/devinfra/js/debundle/source_match/mod.rs
@@ -14,9 +14,9 @@
 //! - `binding_resolution` — binding-group selector expansion and declared-binding
 //!   extraction.
 //! - `declared_bindings` — declared-binding extraction from AST items.
-//! - `datalog_resolver` — the fact-based `ChunkResolver` (`SelectorResolver`).
+//! - `datalog_resolver` — the legacy fact-based resolver retained as an oracle.
 //! - `fact_near_miss` — fact-based `source_match` debt / near-miss diagnostics.
-//! - `resolver` — the `SelectorResolver` seam trait.
+//! - `resolver` — the legacy resolver seam trait.
 //! - `anonymous_statement` — anonymous source-match statement validation.
 //! - `holes` — local hole-keyword dispatch over AST nodes.
 
@@ -66,14 +66,21 @@ mod types;
 pub(crate) use anonymous_statement::*;
 pub(crate) use declared_bindings::*;
 pub(crate) use holes::*;
+pub(crate) use resolver::SelectorResolver;
 
-// Public API: importable at `source_match::<item>` exactly as before the split.
+/// Legacy procedural resolver API retained for parity tests and migration
+/// oracles while production resolution moves through `selector_runtime`.
+#[doc(hidden)]
+pub mod legacy_resolver {
+    pub use crate::datalog_resolver::ChunkResolver;
+    pub use crate::resolver::SelectorResolver;
+}
+
+// Public API for selector parsing, normalization, and diagnostics.
 pub use binding_resolution::{binding_group_member_selectors, source_match_declared_binding_names};
-pub use datalog_resolver::ChunkResolver;
 pub use fact_near_miss::fact_source_match_body_debt;
 pub use identity::{selector_body_key, selector_key, source_match_preview};
 pub use parse_validate::parse_selector_module_with_capability_check;
-pub use resolver::SelectorResolver;
 pub use types::{
     BindingGroupMemberSelector, MemberBindingGroupMatch, MemberBindingMatch, ResolvedMemberBinding,
     ResolvedMemberBindingGroup, SourceMatchBodyDebt, SourceMatchNearMiss,

--- a/devinfra/js/debundle/source_match/resolver.rs
+++ b/devinfra/js/debundle/source_match/resolver.rs
@@ -1,11 +1,10 @@
-//! The selector-resolution seam: the `SelectorResolver` trait.
+//! Legacy selector-resolution seam: the `SelectorResolver` trait.
 //!
 //! A resolver answers, for a parsed chunk and a JS-template selector: which
 //! top-level statement does the selector claim, and what binding(s) does it
 //! resolve to? The fact-based `ChunkResolver` (`datalog_resolver`) is the sole
-//! implementor — it builds its per-chunk model (the EDB) once and resolves many
-//! selectors against it. The trait is the seam the lowering pipeline dispatches
-//! through.
+//! implementor. This API is retained for parity tests and migration oracles;
+//! production selector resolution should go through `selector_runtime`.
 //!
 //! The output granularity is deliberately coarse: a member resolves to its
 //! `ResolvedMemberBinding` (the claimed binding + kind), an anonymous selector to


### PR DESCRIPTION
## Summary

- Stop exporting `ChunkResolver` / `SelectorResolver` from the root `source_match` API; keep them behind an explicit hidden `source_match::legacy_resolver` oracle module.
- Update the remaining oracle tests to import the legacy resolver explicitly and fix stale comments that described it as production matcher infrastructure.
- Remove the now-stale `:source_match` dependency from `anonymous_resolution`, which resolves member-form `source_match` claims through selector IR / `selector_runtime`.

This makes the old procedural resolver boundary explicit: production code no longer imports it directly outside `source_match`, and the remaining uses are parity/oracle tests.

## Validation

- `nix develop -c pre-commit run --files devinfra/js/debundle/BUILD.bazel devinfra/js/debundle/anonymous_resolution.rs devinfra/js/debundle/source_match/mod.rs devinfra/js/debundle/source_match/resolver.rs devinfra/js/debundle/source_match/fact_near_miss.rs devinfra/js/debundle/selector_candidate_index.rs devinfra/js/debundle/shape_index_soundness_test.rs`
- `nix develop -c bbr test //devinfra/js/debundle:source_match_test //devinfra/js/debundle:selector_candidate_index_test //devinfra/js/debundle:shape_index_soundness_test //devinfra/js/debundle:cli_test //devinfra/js/debundle/e2e:anonymous_statement_test --cache_test_results=no --test_output=errors`
  - BuildBuddy Bazel invocation: `e0b13f9a-01c7-42a3-829e-313c21076fee`
