### PR TITLE
ci(bazel-ci): use bb remote --run_from_commit to bypass patch sync

### DIFF
--- a/.github/actions/bb-remote/action.yml
+++ b/.github/actions/bb-remote/action.yml
@@ -65,6 +65,17 @@ inputs:
       emitted linkage JSON, e.g. "test,build".
     required: false
     default: ""
+  run_from_commit:
+    description: >
+      If set, passes --run_from_commit=<sha>: the runner checks out that exact commit
+      and skips workspace patch sync. bazel-ci uses this because the patch-sync path
+      (bb's generatePatches) can't mirror binary-file *deletions* — it emits "Binary
+      files differ" with no applyable hunk, so the runner's `git apply` fails before
+      Bazel runs. Only safe when the workspace is a clean checkout of that commit (the
+      patch path's "drops uncommitted changes" caveat doesn't apply). See
+      .github/workflows/bazel-ci.yml and devinfra/docs/bb_remote_internals.md.
+    required: false
+    default: ""
 
 outputs:
   log_path:
@@ -88,6 +99,7 @@ runs:
         INPUT_DISK_BYTES: ${{ inputs.disk_bytes }}
         INPUT_COMPUTE_UNITS: ${{ inputs.compute_units }}
         INPUT_LINKAGE_ROLES: ${{ inputs.linkage_roles }}
+        INPUT_RUN_FROM_COMMIT: ${{ inputs.run_from_commit }}
       run: |
         set -euo pipefail
 
@@ -137,6 +149,14 @@ runs:
           --runner_exec_properties=snapshot-read-policy=newest
         )
 
+        # --run_from_commit (optional): runner checks out the exact commit instead of
+        # mirroring the working tree as a patchset. See the run_from_commit input and
+        # bazel-ci.yml for the binary-deletion rationale.
+        RUN_FROM_COMMIT_ARGS=()
+        if [[ -n "$INPUT_RUN_FROM_COMMIT" ]]; then
+          RUN_FROM_COMMIT_ARGS=(--run_from_commit="$INPUT_RUN_FROM_COMMIT")
+        fi
+
         if [[ -n "$INPUT_SCRIPT" ]]; then
           # Forward RBE_IMAGE so the script can interpolate it into Bazel flags.
           ENV_ARGS+=(--remote_run_header="x-buildbuddy-platform.env-overrides=RBE_IMAGE=${RBE_IMAGE}")
@@ -145,6 +165,7 @@ runs:
             "${RUNNER_EXEC_PROPS[@]}"
             "${ENV_ARGS[@]}"
             "${BB_IMAGE_ARGS[@]}"
+            "${RUN_FROM_COMMIT_ARGS[@]}"
             --script="$INPUT_SCRIPT"
           )
         else
@@ -156,6 +177,7 @@ runs:
             "${RUNNER_EXEC_PROPS[@]}"
             "${ENV_ARGS[@]}"
             "${BB_IMAGE_ARGS[@]}"
+            "${RUN_FROM_COMMIT_ARGS[@]}"
             "${INPUT_ARGS_ARRAY[@]}"
             --config=rbe
             --config=ci

--- a/.github/workflows/bazel-ci.yml
+++ b/.github/workflows/bazel-ci.yml
@@ -39,26 +39,29 @@ jobs:
         with:
           sops_age_key: ${{ secrets.SOPS_AGE_KEY }}
 
-      # bb remote's base resolution falls back to `git rev-parse <default-branch>@{upstream}`
-      # (and then the local `<default-branch>` ref) — both need a local branch. actions/checkout
-      # only creates remote-tracking refs (origin/devel), not local branches, so create one for
-      # PR builds. buildbuddy#11838 fixed the unpushed-local-commits case but still reads
-      # @{upstream}, which requires the local branch.
-      - name: Create local ref for default branch
-        if: github.event_name == 'pull_request'
-        run: git branch "$GIT_REPO_DEFAULT_BRANCH" "origin/$GIT_REPO_DEFAULT_BRANCH"
-
       # Combined test + build in one bb-remote `--script` invocation:
       # - Saves one Firecracker VM allocation per CI run.
       # - Avoids `bb remote build`'s post-run `downloadOutputs` path, which
       #   currently fails with "Exhausted all peers" — see
       #   devinfra/debug/bb_remote_peers_exhausted.md.
       # `&&` matches the previous step ordering: build runs only if test passed.
+      #
+      # run_from_commit: have the runner check out the exact commit instead of mirroring the
+      # PR as a patchset (base=devel + diff). The patch path (bb's generatePatches) can't sync
+      # binary-file *deletions* — for a deleted binary it emits "Binary files differ" with no
+      # applyable hunk, so the runner's `git apply` fails (exit 255) before Bazel even runs.
+      # Checking out the commit skips patch sync entirely. Safe here because the CI checkout is
+      # a clean commit (no uncommitted changes for the patch path to drop). Uses the PR head
+      # SHA (on origin, fetchable by the runner); GITHUB_SHA for push/dispatch. This also makes
+      # the old "create local devel ref" step unnecessary — run_from_commit skips base
+      # resolution (@{upstream}) entirely. See devinfra/docs/bb_remote_internals.md
+      # §"Git state synchronization" ("--run_from_commit disables patches").
       - name: Test + Build + lint
         id: bb-remote
         uses: ./.github/actions/bb-remote
         with:
           rbe_image: ${{ inputs.rbe_image }}
+          run_from_commit: ${{ github.event.pull_request.head.sha || github.sha }}
           linkage_roles: test,build
           script: |
             set -euo pipefail


### PR DESCRIPTION
## Context

PRs that **delete a binary file** fail CI at the `bb remote` workspace-sync step, before Bazel runs. Current example: #2599 (deletes `x/orcaslicer_config/user/hints.cereal`, a 12-byte binary cache).

## Root cause

`bb remote` mirrors a PR to the BuildBuddy runner as a git patchset (base `devel` + diff). Its `generatePatches` (buildbuddy-io/buildbuddy, `cli/remotebazel/remotebazel.go`) routes *modified* binary files through `git diff --binary`, but a binary-file **deletion** falls through to the plain `git diff` path, which emits `Binary files … differ` with no applyable hunk. The runner's `git apply` rejects it:

```
error: cannot apply binary patch to '…/hints.cereal' without full index line
Action failed: failed to set up git repo: exit status 1   ##[error] exit code 255
```

No upstream fix exists: `isBinaryFile()` inspects the working-tree path, which a deleted file lacks (master errors `check binary file`; our pinned `5.0.387` emits the broken patch). Recent `remotebazel.go` history is all unrelated.

This only affects **PR** builds — on `push`, bb uses `base=devel`/HEAD/no-patches, so it never hits patch sync.

## Fix

Pass `--run_from_commit` so the runner checks out the exact commit instead of patch-syncing the working tree. No patchset = no binary-deletion patch.

- `bb-remote` action: new `run_from_commit` input → `--run_from_commit=<sha>`.
- `bazel-ci`: `run_from_commit: ${{ github.event.pull_request.head.sha || github.sha }}` (PR head SHA is on origin and fetchable by the runner; `GITHUB_SHA` for push/dispatch).
- Dropped the now-obsolete "Create local ref for default branch" step — `run_from_commit` skips base resolution (`@{upstream}`) entirely.

## Why it's safe

`--run_from_commit`'s only caveat (per `devinfra/docs/bb_remote_internals.md`) is that it drops *uncommitted* local changes — but the CI checkout is a clean commit, so there's nothing to drop. On `push` events the behavior is equivalent to today (it was already no-patch).

## Verification

- pre-commit (check-yaml, prettier, ducktape-precommit) passes on both files.
- This PR's own bazel-ci run exercises the new `--run_from_commit` path — green here confirms it doesn't regress normal builds; re-running #2599 after merge confirms the binary-deletion case.

## Merge before

#2599 — refresh it onto `devel` after this lands so its CI uses the new path.
