### PR TITLE
[codex] Serve Haku console assets from static image

### DIFF
--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -116,6 +116,7 @@ jobs:
             }
           - { image: "//grocy_mcp:server_image", image_name: grocy-mcp, test_target: "//grocy_mcp/..." }
           - { image: "//haku/console:server_image", image_name: haku-console, test_target: "//haku/console/..." }
+          - { image: "//haku/console:static_image", image_name: haku-console-static, test_target: "//haku/console/..." }
           - {
               image: "//finance/plaid/link:server_image",
               image_name: plaid-mcp-server,

--- a/cluster/k8s/flux-image-automation-ghcr/haku-console-static-image-policy.yaml
+++ b/cluster/k8s/flux-image-automation-ghcr/haku-console-static-image-policy.yaml
@@ -1,0 +1,13 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: haku-console-static
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: haku-console-static
+  filterTags:
+    pattern: '^devel-\d{14}-[0-9a-f]{7}$'
+  policy:
+    alphabetical:
+      order: asc

--- a/cluster/k8s/flux-image-automation-ghcr/haku-console-static-image-repository.yaml
+++ b/cluster/k8s/flux-image-automation-ghcr/haku-console-static-image-repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: haku-console-static
+  namespace: flux-system
+spec:
+  image: ghcr.io/agentydragon/haku-console-static
+  interval: 5m

--- a/cluster/k8s/flux-image-automation-ghcr/kustomization.yaml
+++ b/cluster/k8s/flux-image-automation-ghcr/kustomization.yaml
@@ -53,6 +53,8 @@ resources:
   - grocy-mcp-oidc-server-image-policy.yaml
   - haku-console-image-repository.yaml
   - haku-console-image-policy.yaml
+  - haku-console-static-image-repository.yaml
+  - haku-console-static-image-policy.yaml
   - haku-worker-image-repository.yaml
   - haku-worker-image-policy.yaml
   - rtl-tcp-image-repository.yaml

--- a/cluster/k8s/flux-webhook/github-webhook-receiver.yaml
+++ b/cluster/k8s/flux-webhook/github-webhook-receiver.yaml
@@ -54,6 +54,9 @@ spec:
       name: haku-console
     - apiVersion: image.toolkit.fluxcd.io/v1beta2
       kind: ImageRepository
+      name: haku-console-static
+    - apiVersion: image.toolkit.fluxcd.io/v1beta2
+      kind: ImageRepository
       name: haku-worker
     - apiVersion: image.toolkit.fluxcd.io/v1beta2
       kind: ImageRepository

--- a/cluster/k8s/haku/console/deployment.yaml
+++ b/cluster/k8s/haku/console/deployment.yaml
@@ -1,8 +1,9 @@
-# The Haku console: reviewed FastAPI API code plus the bundled React SPA.
-# Unlike the old dashboard's nginx + git-sync shape, the app owns git itself —
-# it clones haku-state into an emptyDir at /data at startup and pushes back.
-# Access is gated by Authentik (agentydragon-only) via the proxy outpost — the
-# app has no native auth.
+# The Haku console: reviewed FastAPI API code plus a baked nginx static frontend.
+# Unlike the old dashboard's nginx + git-sync shape, the FastAPI app owns git
+# itself — it clones haku-state into an emptyDir at /data at startup and pushes
+# back. nginx only serves the bundled SPA image and proxies API calls to
+# localhost. Access is gated by Authentik (agentydragon-only) via the proxy
+# outpost — the app has no native auth.
 #
 # Trust boundary: runs in its OWN `haku-console` namespace, NOT haku-sandbox. As
 # reviewed/released ducktape code it sits outside Haku's RBAC (Haku can't read its
@@ -47,7 +48,7 @@ spec:
           image: ghcr.io/agentydragon/haku-console:devel-20260628000612-5c33640 # {"$imagepolicy": "flux-system:haku-console"}
           imagePullPolicy: Always
           ports:
-            - name: http
+            - name: api
               containerPort: 8080
           env:
             - name: HOME # libgit2/git config + temp writes land in the writable emptyDir
@@ -94,12 +95,12 @@ spec:
               memory: 512Mi
           livenessProbe:
             tcpSocket:
-              port: http
+              port: api
             initialDelaySeconds: 10
             periodSeconds: 30
           readinessProbe:
             tcpSocket:
-              port: http
+              port: api
             initialDelaySeconds: 5
             periodSeconds: 10
           volumeMounts:
@@ -107,6 +108,35 @@ spec:
               mountPath: /tmp
             - name: data # the haku-state clone
               mountPath: /data
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+        - name: static
+          image: ghcr.io/agentydragon/haku-console-static:devel-20260628000612-5c33640 # {"$imagepolicy": "flux-system:haku-console-static"}
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8081
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/haku/console/BUILD.bazel
+++ b/haku/console/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@aspect_rules_py//py:defs.bzl", "py_image_layer", aspect_py_binary = "py_binary")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "strip_prefix")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
@@ -169,36 +170,40 @@ py_image_layer(
     owner = "1000",
 )
 
-# The built React SPA, flattened to /app/web (index.html + assets/*).
-# FastAPI serves this directory via HAKU_CONSOLE_STATIC_DIR with route-specific
-# cache headers.
 pkg_files(
     name = "web_files",
     srcs = ["//haku/console/frontend:bundle"],
-    prefix = "/app/web",
+    # The bundle output keeps its `dist/` directory; nginx roots at this child path.
+    prefix = "/usr/share/nginx/html",
+    strip_prefix = strip_prefix.files_only(),
+)
+
+pkg_files(
+    name = "nginx_conf_files",
+    srcs = ["default.conf"],
+    prefix = "/etc/nginx/conf.d",
     strip_prefix = strip_prefix.files_only(),
 )
 
 pkg_tar(
-    name = "web_tar",
-    srcs = [":web_files"],
+    name = "static_tar",
+    srcs = [
+        ":nginx_conf_files",
+        ":web_files",
+    ],
 )
 
 oci_image(
     name = "server_image",
     base = "@debian_trixie_slim_linux_amd64",
     entrypoint = py_image_entrypoint("server_bin"),
-    env = dict(
-        py_image_env(binary_name = "server_bin"),
-        HAKU_CONSOLE_STATIC_DIR = "/app/web",
-    ),
+    env = py_image_env(binary_name = "server_bin"),
     labels = {
         "org.opencontainers.image.source": "https://github.com/agentydragon/ducktape",
         "org.opencontainers.image.title": "haku-console",
     },
     tars = [
         ":server_layers",
-        ":web_tar",
         "@trixie_ca_certificates//:flat",
     ],
     user = "1000:1000",
@@ -209,4 +214,30 @@ oci_load(
     name = "server_load",
     image = ":server_image",
     repo_tags = ["haku-console:latest"],
+)
+
+oci_image(
+    name = "static_image",
+    base = "@nginx_unprivileged_linux_amd64",
+    exposed_ports = ["8081/tcp"],
+    labels = {
+        "org.opencontainers.image.source": "https://github.com/agentydragon/ducktape",
+        "org.opencontainers.image.title": "haku-console-static",
+    },
+    tars = [":static_tar"],
+    visibility = ["//visibility:public"],
+)
+
+oci_load(
+    name = "static_load",
+    image = ":static_image",
+    repo_tags = ["haku-console-static:latest"],
+)
+
+build_test(
+    name = "static_image_build_test",
+    targets = [
+        ":static_image",
+        ":static_image.digest",
+    ],
 )

--- a/haku/console/README.md
+++ b/haku/console/README.md
@@ -68,24 +68,27 @@ and decides. See `console/plans/free_form_ui_iframe.md`.
 
 ## Layout
 
-| Path               | Role                                                                                                                                                                                                                 |
-| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `app.py`           | FastAPI `create_app` + lifespan (clone). `GET /api/config`, `GET /healthz`, CSRF config, mounts the trace + capability routers. Also serves the fingerprinted SPA (`StaticFiles`) with route-specific cache headers. |
-| `trace.py`         | Trace-tier router (`/api/trace`): a single `POST` that records an opaque operator note to haku-state. Low-privilege haku-state write; reads `git_state` off `app.state`.                                             |
-| `capabilities.py`  | Capability-tier router (`/api/capabilities/*`): CSRF-gated, audited privileged actions. `POST /launch-routine` fires the routine with the server-side bearer; `GET /csrf` issues the double-submit token.            |
-| `git_state.py`     | pygit2 clone of haku-state; `reconcile` (fetch + hard-reset), `commit_push` with retry, `append_trace` (the single write path). Talks to the cluster-internal **plaintext-HTTP** Forgejo (no TLS/CA needed).         |
-| `models.py`        | Pydantic `TraceRequest` and `ConfigResponse` — the `/api` request/response models.                                                                                                                                   |
-| `config.py`        | Env settings (`HAKU_CONSOLE_*`).                                                                                                                                                                                     |
-| `export_schema.py` | Prints the OpenAPI schema; the frontend generates its TypeScript types from it.                                                                                                                                      |
-| `frontend/`        | React SPA (esbuild bundle) — see `frontend/README.md`.                                                                                                                                                               |
+| Path               | Role                                                                                                                                                                                                                  |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `app.py`           | FastAPI `create_app` + lifespan (clone). `GET /api/config`, `GET /healthz`, CSRF config, mounts the trace + capability routers. It can serve the SPA for local/direct fallback when `HAKU_CONSOLE_STATIC_DIR` is set. |
+| `trace.py`         | Trace-tier router (`/api/trace`): a single `POST` that records an opaque operator note to haku-state. Low-privilege haku-state write; reads `git_state` off `app.state`.                                              |
+| `capabilities.py`  | Capability-tier router (`/api/capabilities/*`): CSRF-gated, audited privileged actions. `POST /launch-routine` fires the routine with the server-side bearer; `GET /csrf` issues the double-submit token.             |
+| `git_state.py`     | pygit2 clone of haku-state; `reconcile` (fetch + hard-reset), `commit_push` with retry, `append_trace` (the single write path). Talks to the cluster-internal **plaintext-HTTP** Forgejo (no TLS/CA needed).          |
+| `models.py`        | Pydantic `TraceRequest` and `ConfigResponse` — the `/api` request/response models.                                                                                                                                    |
+| `config.py`        | Env settings (`HAKU_CONSOLE_*`).                                                                                                                                                                                      |
+| `export_schema.py` | Prints the OpenAPI schema; the frontend generates its TypeScript types from it.                                                                                                                                       |
+| `frontend/`        | React SPA (esbuild bundle) — see `frontend/README.md`.                                                                                                                                                                |
 
 ## Perimeter / deploy
 
 Manifests live in `cluster/k8s/haku/console/` (operator-owned — the perimeter is not
 Haku's to change); the `haku-console` namespace itself is `cluster/k8s/haku/console-namespace/`.
-The image bundles the fingerprinted SPA under `/app/web`; FastAPI serves it via
-`HAKU_CONSOLE_STATIC_DIR` and sets cache policy by route (`/assets/*` immutable,
-app shell revalidated, API/health uncached).
+The deployment runs two containers in one pod: the `haku-console` FastAPI API
+image and a separate `haku-console-static` nginx image that bakes in the
+fingerprinted SPA. nginx serves `/` and `/assets/*`, proxies `/api/*` and
+`/healthz` to FastAPI on localhost, and sets cache policy by route (`/assets/*`
+immutable, app shell revalidated, API/health uncached). No runtime asset copy or
+shared web volume is used.
 Non-root, dropped caps, no service-account token. Credentials: the `haku-state-git-write`
 secret (provisioned into `haku-console` by the `tf/gitops/haku-state` module) and the
 `haku-routine-launch-token` secret (the capability tier's bearer; `HAKU_CONSOLE_LAUNCH_ROUTINE__TOKEN`).

--- a/haku/console/app.py
+++ b/haku/console/app.py
@@ -1,4 +1,4 @@
-"""FastAPI app for the Haku console: JSON API + same-origin React SPA.
+"""FastAPI app for the Haku console JSON API.
 
 The console is a thin shell: the capability tier (launch-routine) + a generic
 "Note to Haku" trace box + the Free-form UI iframe. Item rendering has moved to
@@ -9,7 +9,9 @@ the **trace tier** (``haku.console.trace``) records opaque operator text into
 haku-state and is the low-privilege surface safe for agent-authored UI. The
 high-privilege **capability tier** (``haku.console.capabilities``) uses console-only
 secrets and acts on the world (launching the routine); it is CSRF-gated and audited.
-``app.py`` wires both routers, configures CSRF, and serves the config endpoint + SPA.
+``app.py`` wires both routers, configures CSRF, and serves the config endpoint. It
+can also mount the built SPA when ``static_dir`` is explicitly configured for a
+direct local/dev fallback.
 """
 
 from __future__ import annotations
@@ -97,8 +99,9 @@ def create_app(settings: Settings, *, git_state: GitState) -> FastAPI:
     app.include_router(trace.router)
     app.include_router(capabilities.router)
 
-    # The built React SPA is served same-origin for everything else. Mounted last so the
-    # API routes above take precedence; left unmounted in tests (static_dir unset).
+    # Optional direct local/dev fallback. Production serves the SPA from the
+    # haku-console-static nginx image and leaves static_dir unset on this process.
+    # Mounted last so the API routes above take precedence.
     if settings.static_dir is not None and settings.static_dir.is_dir():
         app.mount("/", StaticFiles(directory=settings.static_dir, html=True), name="spa")
 

--- a/haku/console/config.py
+++ b/haku/console/config.py
@@ -48,8 +48,9 @@ class Settings(BaseSettings):
 
     clone_dir: Path = Path("/data/haku-state")
 
-    # Directory holding the built React SPA (index.html + assets), served same-origin.
-    # Unset in tests (the API runs without a UI); set to the bundled dir in the image.
+    # Optional directory holding the built React SPA (index.html + assets), served
+    # same-origin by FastAPI for direct local/dev fallback. Production leaves this
+    # unset and serves the SPA from the haku-console-static nginx image.
     static_dir: Path | None = None
 
     # Capability tier. launch_routine enables POST /api/capabilities/launch-routine

--- a/haku/console/default.conf
+++ b/haku/console/default.conf
@@ -1,0 +1,42 @@
+map $uri $haku_cache_control {
+  ~^/assets/ "public, max-age=31536000, immutable";
+  ~^/api/ "no-store";
+  /healthz "no-store";
+  default "no-cache, max-age=0, must-revalidate";
+}
+
+server {
+  listen 8081;
+  server_name _;
+
+  root /usr/share/nginx/html/dist;
+  index index.html;
+
+  proxy_hide_header Content-Security-Policy;
+  proxy_hide_header Cache-Control;
+
+  add_header Content-Security-Policy "frame-src 'self' https://haku-ui.allegedly.works; frame-ancestors 'none'" always;
+  add_header Cache-Control $haku_cache_control always;
+
+  proxy_http_version 1.1;
+  proxy_set_header Host $host;
+  proxy_set_header X-Real-IP $remote_addr;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header X-Forwarded-Proto $scheme;
+
+  location /assets/ {
+    try_files $uri =404;
+  }
+
+  location /api/ {
+    proxy_pass http://127.0.0.1:8080;
+  }
+
+  location = /healthz {
+    proxy_pass http://127.0.0.1:8080;
+  }
+
+  location / {
+    try_files $uri /index.html;
+  }
+}

--- a/haku/console/frontend/BUILD.bazel
+++ b/haku/console/frontend/BUILD.bazel
@@ -185,7 +185,7 @@ js_run_binary(
     tool = ":tailwind_cli",
 )
 
-# Everything the backend serves as the SPA docroot.
+# Everything the static frontend image serves as the SPA docroot.
 spa_bundle(
     name = "bundle",
     entry_point = "main.tsx",

--- a/haku/console/frontend/README.md
+++ b/haku/console/frontend/README.md
@@ -1,8 +1,9 @@
 # haku/console/frontend — dashboard SPA
 
 React 18 single-page app for the Haku console, bundled with esbuild and served
-same-origin by the console service. The FastAPI app serves the fingerprinted
-bundle with route-specific cache headers. Styled with the repo's house stack — **Mantine v7**
+same-origin by the console service. Production serves the fingerprinted bundle
+from the baked `haku-console-static` nginx image, with route-specific cache
+headers. Styled with the repo's house stack — **Mantine v7**
 components + **Tailwind v4** utilities — modeled on
 `finance/augur/frontend` (references root `//:node_modules/*`; no per-package
 `package.json`).

--- a/haku/console/frontend/client.ts
+++ b/haku/console/frontend/client.ts
@@ -2,7 +2,7 @@ import createClient from "openapi-fetch";
 
 import type { components, paths } from "./api/schema";
 
-// Same-origin typed client (the FastAPI backend serves this bundle). Types are
+// Same-origin typed client (nginx serves this bundle and proxies /api). Types are
 // generated from the backend's OpenAPI schema: //haku/console/frontend:schema.
 const api = createClient<paths>({ baseUrl: "" });
 


### PR DESCRIPTION
## Summary

- add a dedicated `haku-console-static` nginx OCI image that bakes in the fingerprinted SPA and cache-policy nginx config
- run the Haku console pod as API + static sidecar, with nginx serving `/` and `/assets/*` and proxying `/api/*` plus `/healthz` to FastAPI on localhost
- wire GHCR image publishing, Flux image automation, and the Flux webhook Receiver for `haku-console-static`
- update docs/comments so production is no longer described as FastAPI static serving or runtime asset copying

## Validation

- `kubectl kustomize cluster/k8s/haku/console`
- `kubectl kustomize cluster/k8s/flux-image-automation-ghcr | rg -n "haku-console-static|haku-console"`
- `pre-commit run --files .github/workflows/push-images.yml cluster/k8s/flux-image-automation-ghcr/kustomization.yaml cluster/k8s/flux-image-automation-ghcr/haku-console-static-image-repository.yaml cluster/k8s/flux-image-automation-ghcr/haku-console-static-image-policy.yaml cluster/k8s/haku/console/deployment.yaml haku/console/BUILD.bazel haku/console/default.conf haku/console/README.md haku/console/app.py haku/console/config.py haku/console/frontend/BUILD.bazel haku/console/frontend/README.md haku/console/frontend/client.ts`
- `pre-commit run --files cluster/k8s/flux-webhook/github-webhook-receiver.yaml`
- `bbr build //haku/console:static_tar //haku/console:static_image //haku/console:server_image --remote_download_outputs=all`
- `bbr test //haku/console/...`
- `bbr test //cluster/validation:test_cluster_integration --test_output=errors`
- inspected `static_tar.tar`: nginx config is packaged at `/etc/nginx/conf.d/default.conf`, SPA at `/usr/share/nginx/html/dist`, and `index.html` references fingerprinted `/assets/...` URLs