### PR TITLE
agent-box: boot directly from a full host image (no bootstrap+switch)

### DIFF
--- a/cluster/k8s/agent-box/app/virtualmachine.yaml
+++ b/cluster/k8s/agent-box/app/virtualmachine.yaml
@@ -25,7 +25,11 @@ spec:
       spec:
         source:
           s3:
-            url: "https://s3.allegedly.works/vm-images/bootstrap/f484cb3f043f7dab65528c4ad22330dace7b9fdb.qcow2"
+            # Full agent-box host image (built by vm-images-publisher with
+            # IMAGE_OUTPUT=agent-box-image). The VM boots straight into the real
+            # config — no bootstrap + nixos-rebuild switch. cloud-init still
+            # injects the persisted host key. Repin after rebuilding the image.
+            url: "https://s3.allegedly.works/vm-images/agent-box/6382ab144c0384552f52fb262fb94fe3c271353e.qcow2"
             secretRef: agent-box-vm-images-s3-reader
         pvc:
           accessModes:

--- a/flake.nix
+++ b/flake.nix
@@ -429,6 +429,11 @@
           # Uses built-in system.build.images.qemu-efi (nixos-generators upstreamed in 25.05+).
           wyrm2-image = self.nixosConfigurations.wyrm2.config.system.build.images.qemu-efi;
           bootstrap-image = self.nixosConfigurations.bootstrap.config.system.build.images.qemu-efi;
+          # Full agent-box host image: the VM boots straight into the real config
+          # (codex user, Codex CLI, planted keys) — no bootstrap + nixos-rebuild
+          # switch. Published by vm-images-publisher with IMAGE_OUTPUT=agent-box-image,
+          # OBJECT_PREFIX=agent-box. cloud-init still injects the persisted host key.
+          agent-box-image = self.nixosConfigurations.agent-box.config.system.build.images.qemu-efi;
         };
 
       homeConfigurations = {


### PR DESCRIPTION
Follow-up to #2601. Makes the `agent-box` VM boot straight into its real NixOS config (codex user, Codex CLI, planted keys) instead of the generic bootstrap image + manual `nixos-rebuild switch`.

- **flake**: add `agent-box-image` output (`nixosConfigurations.agent-box…build.images.qemu-efi`), same mechanism as `bootstrap-image`/`wyrm2-image`.
- **DataVolume**: point at the published `agent-box/<sha>.qcow2` (built by `vm-images-publisher` with `IMAGE_OUTPUT=agent-box-image`, `OBJECT_PREFIX=agent-box`). cloud-init still injects the persisted host key.

The image was already built + published for this branch's HEAD (`6382ab1`, 3.6 GB, verified `Complete`). After merge, the VM must be **recreated** (delete `vm/agent-box` so Flux re-provisions the DataVolume from the new image URL) — the existing VM is fresh/empty so there's nothing to lose.

Tradeoff: per-host image means future config changes need a rebuild+republish+recreate (or `nixos-rebuild switch` for quick in-place iterations).