### PR TITLE
attic-jwt-rotation: fix libgit2 CA bundle load (None, not empty-string dir)

### DIFF
--- a/cluster/k8s/agents/attic-jwt-rotation/BUILD.bazel
+++ b/cluster/k8s/agents/attic-jwt-rotation/BUILD.bazel
@@ -24,6 +24,7 @@ py_test(
     imports = ["."],
     deps = [
         ":rotate",
+        "@pypi//certifi",
         "@pypi//pydantic",
         "@pypi//pygit2",
         "@pypi//pytest",

--- a/cluster/k8s/agents/attic-jwt-rotation/rotate.py
+++ b/cluster/k8s/agents/attic-jwt-rotation/rotate.py
@@ -207,6 +207,16 @@ def commit_and_push(repo: pygit2.Repository, config: Config, rotated: list[str],
     logger.info("pushed: %s", ", ".join(rotated))
 
 
+def _configure_ca_trust(ca_bundle: Path) -> None:
+    """Point libgit2 at the assembled CA bundle.
+
+    libgit2 ignores GIT_SSL_CAINFO/SSL_CERT_FILE, so set_ssl_cert_locations is the
+    supported knob. The dir arg must be None (NULL), not "" -- an empty string makes
+    OpenSSL reject "invalid directory" while loading the bundle.
+    """
+    pygit2.settings.set_ssl_cert_locations(str(ca_bundle), None)
+
+
 def main(
     config_path: Annotated[Path, typer.Option("--config", exists=True, dir_okay=False, help="rotators.yaml")],
     token: Annotated[str, typer.Option("--token", envvar="GIT_TOKEN", help="Git HTTPS token (or set GIT_TOKEN)")],
@@ -222,7 +232,7 @@ def main(
     ca_bundle.write_text(
         "".join(p.read_text() for p in sorted(Path("/usr/share/ca-certificates/mozilla").glob("*.crt")))
     )
-    pygit2.settings.set_ssl_cert_locations(str(ca_bundle), "")
+    _configure_ca_trust(ca_bundle)
 
     repo_dir = Path("/tmp/repo")
     repo_dir.mkdir()

--- a/cluster/k8s/agents/attic-jwt-rotation/test_rotate.py
+++ b/cluster/k8s/agents/attic-jwt-rotation/test_rotate.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
+import certifi
 import pygit2
 import pytest
 import pytest_bazel
@@ -13,6 +14,7 @@ from pydantic import ValidationError
 from rotate import (
     Config,
     Token,
+    _configure_ca_trust,
     clone_repo,
     commit_and_push,
     jwt_payload,
@@ -249,6 +251,12 @@ def test_commit_and_push_skips_when_nothing_staged(upstream: Path, tmp_path: Pat
     before = _devel_oid(upstream)
     commit_and_push(repo, config, rotated=[], token="unused-for-local-transport")
     assert _devel_oid(upstream) == before
+
+
+def test_configure_ca_trust_loads_a_real_bundle():
+    # Regression: the libgit2 dir arg must be None, not "" (OpenSSL rejects the
+    # empty string as "invalid directory" while loading the bundle).
+    _configure_ca_trust(Path(certifi.where()))  # must not raise
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to #2603. The first post-merge manual CronJob run crashed at startup:

\`\`\`
GitError: OpenSSL error: failed to load certificates: error:05800071:x509 certificate routines::invalid directory
\`\`\`

at \`pygit2.settings.set_ssl_cert_locations(bundle, \"\")\`. libgit2 wants \`NULL\` (Python \`None\`) for the unused directory arg — an empty string makes OpenSSL reject "invalid directory". Verified locally: \`dir=None\` loads, \`dir=\"\"\` errors.

- \`_configure_ca_trust\` now passes \`None\`.
- Regression test loads a real bundle (\`certifi.where()\`) through real pygit2 — the CA setup lives in \`main()\`, which the mocked-pygit2 + real-repo tests don't cover, so they missed this.

Verified via \`bbr\`: \`test_rotate\`, image build, \`//cluster/validation:test_flux_build\`.

Low urgency: tokens have ~1 year of validity headroom, so the failing hourly cron just pauses rotation until this lands.