### PR TITLE
[codex] Allow Haku iframe Authentik redirect

### DIFF
--- a/cluster/k8s/haku/console/deployment.yaml
+++ b/cluster/k8s/haku/console/deployment.yaml
@@ -86,6 +86,8 @@ spec:
             # the haku-ui Authentik route). See haku/console/plans/free_form_ui_iframe.md.
             - name: HAKU_CONSOLE_HAKU_UI_URL
               value: https://haku-ui.allegedly.works
+            - name: HAKU_CONSOLE_AUTH_ORIGIN
+              value: https://auth.allegedly.works
           resources:
             requests:
               cpu: 50m
@@ -115,6 +117,14 @@ spec:
         - name: static
           image: ghcr.io/agentydragon/haku-console-static:devel-20260628020338-ff7fab7 # {"$imagepolicy": "flux-system:haku-console-static"}
           imagePullPolicy: Always
+          env:
+            # The nginx entrypoint renders /etc/nginx/templates/default.conf.template
+            # with these origins at startup, keeping frame-src environment-specific
+            # while the console itself remains unframeable via frame-ancestors 'none'.
+            - name: HAKU_CONSOLE_HAKU_UI_URL
+              value: https://haku-ui.allegedly.works
+            - name: HAKU_CONSOLE_AUTH_ORIGIN
+              value: https://auth.allegedly.works
           ports:
             - name: http
               containerPort: 8081

--- a/haku/console/BUILD.bazel
+++ b/haku/console/BUILD.bazel
@@ -180,8 +180,8 @@ pkg_files(
 
 pkg_files(
     name = "nginx_conf_files",
-    srcs = ["default.conf"],
-    prefix = "/etc/nginx/conf.d",
+    srcs = ["default.conf.template"],
+    prefix = "/etc/nginx/templates",
     strip_prefix = strip_prefix.files_only(),
 )
 

--- a/haku/console/README.md
+++ b/haku/console/README.md
@@ -60,7 +60,9 @@ no real operator behind it** (see `haku/PLAN.md` → _The agent-authored console
 The console embeds Haku's own UI service (`haku-ui.allegedly.works`, a separate
 Authentik-gated app Haku runs in `haku-sandbox`) as a **sandboxed cross-origin iframe** —
 the console never renders or even sees its content. `HAKU_CONSOLE_HAKU_UI_URL` enables it;
-when set, the response CSP adds `frame-src` for that origin (and only it).
+when set, the response CSP adds `frame-src` for that origin and Authentik's origin
+(`HAKU_CONSOLE_AUTH_ORIGIN`, default `https://auth.allegedly.works`) so the in-frame SSO
+redirect can complete.
 Containment is cross-origin isolation: the iframe can't read the console's DOM/cookies
 or act as it — so Haku's UI can't act as the console. The trusted **bridge** (`bridge.ts`)
 lets the iframe request link opens via postMessage; the shell origin-checks, schema-validates,

--- a/haku/console/app.py
+++ b/haku/console/app.py
@@ -62,10 +62,10 @@ def create_app(settings: Settings, *, git_state: GitState) -> FastAPI:
     app.state.settings = settings
 
     # Content-Security-Policy: let the dashboard frame Haku's own UI origin (the
-    # sandboxed cross-origin iframe) and nothing else, and forbid the console itself
-    # from being framed. Only frame-* is set, so the SPA's own scripts/styles are
-    # unaffected. See haku/console/plans/free_form_ui_iframe.md.
-    frame_src = f"'self' {settings.haku_ui_url}" if settings.haku_ui_url else "'none'"
+    # sandboxed cross-origin iframe) and Authentik's origin for the SSO redirect,
+    # and forbid the console itself from being framed. Only frame-* is set, so the
+    # SPA's own scripts/styles are unaffected. See haku/console/plans/free_form_ui_iframe.md.
+    frame_src = f"'self' {settings.haku_ui_url} {settings.auth_origin}" if settings.haku_ui_url else "'none'"
     csp = f"frame-src {frame_src}; frame-ancestors 'none'"
 
     @app.middleware("http")

--- a/haku/console/config.py
+++ b/haku/console/config.py
@@ -64,6 +64,8 @@ class Settings(BaseSettings):
     # Free-form UI (Phase 1b): the Authentik-gated origin of Haku's own UI service
     # (runs in haku-sandbox), embedded in the console as a sandboxed cross-origin
     # iframe. When set, the dashboard surfaces the embed and the CSP allows framing
-    # that origin (and only it); unset → the feature is dormant. The console never
-    # renders Haku's UI itself. See haku/console/plans/free_form_ui_iframe.md.
+    # that origin plus Authentik's origin for the in-iframe SSO redirect; unset →
+    # the feature is dormant. The console never renders Haku's UI itself. See
+    # haku/console/plans/free_form_ui_iframe.md.
     haku_ui_url: str | None = None
+    auth_origin: str = "https://auth.allegedly.works"

--- a/haku/console/default.conf.template
+++ b/haku/console/default.conf.template
@@ -15,7 +15,9 @@ server {
   proxy_hide_header Content-Security-Policy;
   proxy_hide_header Cache-Control;
 
-  add_header Content-Security-Policy "frame-src 'self' https://haku-ui.allegedly.works; frame-ancestors 'none'" always;
+  add_header Content-Security-Policy
+    "frame-src 'self' ${HAKU_CONSOLE_HAKU_UI_URL} ${HAKU_CONSOLE_AUTH_ORIGIN}; frame-ancestors 'none'"
+    always;
   add_header Cache-Control $haku_cache_control always;
 
   proxy_http_version 1.1;

--- a/haku/console/plans/free_form_ui_iframe.md
+++ b/haku/console/plans/free_form_ui_iframe.md
@@ -225,11 +225,11 @@ seeded from `haku/state_template/`; the Authentik-gated `haku-ui.allegedly.works
 the console's **Free-form UI** tab embedding it as a sandboxed cross-origin iframe (`frame-src`
 CSP, `sandbox="allow-scripts allow-same-origin allow-forms"`). The de-risking
 question — _does a same-site Authentik-gated app authenticate inside the iframe?_ — is
-**answered yes**: the proxied haku-ui content is frameable; the only blocker was Authentik's
-flow page sending `X-Frame-Options: DENY`, fixed by serving
+**answered yes** once both sides permit the handshake: Authentik must serve
 `Content-Security-Policy: frame-ancestors 'self' https://haku.allegedly.works` on
-`auth.allegedly.works` so only the console may frame it. Cross-origin isolation holds, so
-`haku-ui ≠ haku-console` regardless of framing headers.
+`auth.allegedly.works`, and the console's `frame-src` must include both
+`https://haku-ui.allegedly.works` and `https://auth.allegedly.works`. Cross-origin isolation
+holds, so `haku-ui ≠ haku-console` regardless of framing headers.
 
 Also shipped: the **`postMessage` bridge** (origin-checked transport + the top-layer
 native-`<dialog>` confirm with backdrop) and the **`openLink`** affordance — scheme hard-gate

--- a/haku/console/test_app.py
+++ b/haku/console/test_app.py
@@ -30,11 +30,12 @@ def test_config_returns_none_when_unconfigured(client) -> None:
 
 def test_config_haku_ui_url_surfaced_and_csp_allows_framing_it(make_client) -> None:
     ui = "https://haku-ui.example.test"
-    with make_client(haku_ui_url=ui) as c:
+    auth_origin = "https://auth.example.test"
+    with make_client(haku_ui_url=ui, auth_origin=auth_origin) as c:
         resp = c.get("/api/config")
         assert resp.json()["haku_ui_url"] == ui
         csp = resp.headers["content-security-policy"]
-        assert f"frame-src 'self' {ui}" in csp
+        assert f"frame-src 'self' {ui} {auth_origin}" in csp
         assert "frame-ancestors 'none'" in csp
 
 


### PR DESCRIPTION
## Summary

- include Authentik's origin in the Haku console `frame-src` CSP so the free-form UI iframe can complete its SSO redirect
- make the production nginx CSP use startup envsubst via `/etc/nginx/templates/default.conf.template` instead of hardcoding environment-specific origins into the static image
- add `HAKU_CONSOLE_AUTH_ORIGIN` beside `HAKU_CONSOLE_HAKU_UI_URL` for both the API fallback and static nginx container, and update docs/tests for the two-origin iframe handshake

## Root Cause

The console CSP only allowed `frame-src 'self' https://haku-ui.allegedly.works`. The iframe initially loads `haku-ui.allegedly.works`, but Authentik redirects it through `https://auth.allegedly.works/...` for SSO. Browsers block that framed navigation when the parent page's `frame-src` does not include `auth.allegedly.works`, producing the "This content is blocked" iframe error.

## Validation

- `pre-commit run --files cluster/k8s/haku/console/deployment.yaml haku/console/BUILD.bazel haku/console/README.md haku/console/app.py haku/console/config.py haku/console/default.conf.template haku/console/plans/free_form_ui_iframe.md haku/console/test_app.py`
- `bbr test //haku/console:test_app //haku/console:static_image_build_test`
- `kubectl kustomize cluster/k8s/haku/console`
- `bbr build //haku/console:static_tar //haku/console:static_image //haku/console:server_image --remote_download_outputs=all`
- inspected `bb-out/bazel-out/k8-fastbuild/bin/haku/console/static_tar.tar`: nginx template is packaged at `/etc/nginx/templates/default.conf.template`, SPA remains under `/usr/share/nginx/html/dist`, and the template references `HAKU_CONSOLE_HAKU_UI_URL` plus `HAKU_CONSOLE_AUTH_ORIGIN`
- `bbr test //haku/console/... //cluster/validation:test_cluster_integration`