### PR TITLE
agent-box: enable cloud-init (fix host-key injection on direct-boot) + repin image

### DIFF
--- a/cluster/k8s/agent-box/app/virtualmachine.yaml
+++ b/cluster/k8s/agent-box/app/virtualmachine.yaml
@@ -29,7 +29,7 @@ spec:
             # IMAGE_OUTPUT=agent-box-image). The VM boots straight into the real
             # config — no bootstrap + nixos-rebuild switch. cloud-init still
             # injects the persisted host key. Repin after rebuilding the image.
-            url: "https://s3.allegedly.works/vm-images/agent-box/6382ab144c0384552f52fb262fb94fe3c271353e.qcow2"
+            url: "https://s3.allegedly.works/vm-images/agent-box/eb07e72dd83cd97a6d70eeae6402c12d8c513564.qcow2"
             secretRef: agent-box-vm-images-s3-reader
         pvc:
           accessModes:

--- a/nix/nixos/hosts/agent-box/default.nix
+++ b/nix/nixos/hosts/agent-box/default.nix
@@ -37,6 +37,18 @@ in
   #     sopsFile = ../../../../secrets/hosts/agent-box-attic.yaml;
   #   };
 
+  # Process KubeVirt's NoCloud seed to install the persisted Ed25519 host key
+  # (agent-box-host) before sshd starts — sops-nix decrypts the codex user key
+  # via that host key. Required because agent-box boots its OWN qcow2 image
+  # directly (no bootstrap image first), so unlike gecko it must run cloud-init
+  # itself; otherwise sshd self-generates a host key sops-nix can't match.
+  # Mirrors nix/nixos/hosts/bootstrap/default.nix.
+  services.cloud-init = {
+    enable = true;
+    network.enable = false;
+    settings.datasource_list = [ "NoCloud" ];
+  };
+
   # Passwordless sudo for read-only system inspection commands used by agents.
   ducktape.systemInspectionSudo.enable = true;
 


### PR DESCRIPTION
Fixes the bug found when recreating the agent-box VM from its own image (#2607).

**Symptom:** booting the agent-box image directly, the codex user's `id_ed25519`, BuildBuddy bazelrc, and Forgejo key were missing — even though login + the Codex CLI worked. The box's SSH host key was a self-generated `root@agent-box`, not the injected `agent-box-host`, so sops-nix couldn't decrypt.

**Cause:** the agent-box config (cloned from gecko) never enabled `services.cloud-init`. Gecko doesn't need it — it boots the *bootstrap* image (which enables cloud-init) and then `nixos-rebuild switch`. A direct-boot image has no prior step, so the KubeVirt NoCloud host-key seed was ignored.

**Fix:** enable `services.cloud-init` in the agent-box host config, mirroring `nix/nixos/hosts/bootstrap/default.nix`. Also repins the DataVolume to the rebuilt image (`agent-box/eb07e72…qcow2`).

After merge: recreate the VM and re-verify the full first-boot chain (host key → sops-nix plants `id_ed25519` → home-manager → BuildBuddy/Forgejo secrets).