### PR TITLE
talos-ccm: pin chart version 0.5.4 + CCM secure port (kill control-plane drift)

### DIFF
--- a/cluster/k8s/talos-cloud-controller-manager/helmrelease.yaml
+++ b/cluster/k8s/talos-cloud-controller-manager/helmrelease.yaml
@@ -11,11 +11,21 @@ spec:
   chart:
     spec:
       chart: talos-cloud-controller-manager
+      # Pinned: the inline tofu render (terraform/main/talos-ccm.tf) reads this version too,
+      # so Flux + bootstrap stay reproducible and a chart bump can't silently move defaults.
+      version: 0.5.4
       sourceRef:
         kind: HelmRepository
         name: siderolabs
         namespace: kube-system
   values:
+    # Pin the CCM metrics/secure port explicitly. The chart's default is not stable across
+    # versions (0.5.4's values.yaml defaults to 10458, but the cluster is on 50258); pinning
+    # it here keeps Flux, the inline bootstrap manifest, and the live deployment all on one
+    # value, so there is no perpetual drift. 50258 = the value already applied (zero churn).
+    service:
+      port: 50258
+      containerPort: 50258
     enabledControllers:
       - cloud-node
       - cloud-node-lifecycle


### PR DESCRIPTION
## What

Pin two things in `cluster/k8s/talos-cloud-controller-manager/helmrelease.yaml`:
- `spec.chart.spec.version: 0.5.4`
- `spec.values.service.{port,containerPort}: 50258`

## Why

The CCM HelmRelease pinned neither the chart version nor the metrics/secure port, so it took the chart's **default** port. That default isn't stable across chart releases — `0.5.4`'s `values.yaml` defaults to `10458`, but the cluster runs `50258`. Since `terraform/main/talos-ccm.tf` renders the **same chart inline** into each control-plane machine config (for bootstrap), this left all three OVH control planes showing a perpetual `50258 → 10458` drift in `tofu plan` (`talos_machine_configuration_apply` "update in-place"), which is what kept surfacing as unexplained CP drift.

The inline tofu render reads `version` straight from this HelmRelease, so pinning here fixes both Flux and the bootstrap render.

## Value choice: 50258 (zero churn)

`50258` is the port already applied in tofu state **and** running live, so pinning to it means nothing restarts and there's no `tofu apply` to chase — it just makes current reality explicit and immune to future chart-default changes.

## Verification

- `helm template ... --version 0.5.4 --set service.port=50258 --set service.containerPort=50258` → renders `50258` in all four spots (Service `port`/`targetPort`, `--secure-port`, `containerPort`).
- `tofu plan` against live state with this HelmRelease swapped in: **0 `talos_machine_configuration_apply` changes** (was 3), i.e. CP drift resolved. (The only remaining plan item is `proxmox_virtual_environment_download_file.talos_disk`, a bootstrap-`exclude`d resource — unrelated.)
- pre-commit (incl. `kubeconform`) green.

## Note

This is the declarative fix for the CP drift discussed separately; no manual `tofu apply` is needed since applied == rendered == live.