### PR TITLE
cluster/validation: pygohcl-parse dns-records test + doc manifest-regen recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,11 @@ bbr build //:requirements --remote_download_regex='.*requirements\.out' --noremo
 cp bb-out/bazel-out/k8-fastbuild/bin/requirements.out requirements_bazel.txt
 # Then regenerate the gazelle manifest:
 bb run //devinfra:gazelle_python_manifest.update
+# On a host without /bin/bash (the workspace bazelrc pins --shell_executable=/bin/bash,
+# which may not exist on NixOS), the update + gazelle runs need:
+#   bb run //devinfra:gazelle_python_manifest.update \
+#     --config=nolint --norun_validations --shell_executable="$(command -v bash)"
+# (--config=nolint + --norun_validations skip the ruff lint aspect, whose sandbox lacks coreutils.)
 
 bb run //devinfra/lint:buildifier    # Format Bazel files
 ```

--- a/cluster/validation/BUILD.bazel
+++ b/cluster/validation/BUILD.bazel
@@ -316,6 +316,7 @@ py_test(
     ],
     deps = [
         "//util/bazel:runfiles",
+        "@pypi//pygohcl",
         "@pypi//pytest_bazel",
     ],
 )

--- a/cluster/validation/test_dns_records.py
+++ b/cluster/validation/test_dns_records.py
@@ -3,23 +3,26 @@
 from __future__ import annotations
 
 import json
-import re
 from pathlib import Path
 from typing import Any
 
+import pygohcl
 import pytest_bazel
 
 from util.bazel.runfiles import get_required_path
 
-_LOCAL_LIST_RE_TEMPLATE = r"(?ms)^\s*{name}\s*=\s*\[(?P<body>.*?)^\s*\]"
-_IP_LITERAL_RE = re.compile(r'"(?P<ip>\d+\.\d+\.\d+\.\d+)"')
-
 
 def _terraform_local_ips(path: Path, name: str) -> set[str]:
-    pattern = re.compile(_LOCAL_LIST_RE_TEMPLATE.format(name=re.escape(name)))
-    match = pattern.search(path.read_text())
-    assert match is not None, f"{path}: missing local.{name} list"
-    return {match.group("ip") for match in _IP_LITERAL_RE.finditer(match.group("body"))}
+    # pygohcl (HashiCorp's HCL2 parser) decodes the `local.<name>` IP list straight to a
+    # Python list of strings — a structural parse, not a regex over the file text.
+    doc = pygohcl.loads(path.read_text())
+    # pygohcl collapses a single `locals {}` block to a dict but keeps multiple blocks as a
+    # list of dicts; normalize to a list so either shape works.
+    blocks = doc.get("locals", [])
+    for block in [blocks] if isinstance(blocks, dict) else blocks:
+        if name in block:
+            return set(block[name])
+    raise AssertionError(f"{path}: missing local.{name} list")
 
 
 def _mesh_hosts(path: Path) -> dict[str, Any]:

--- a/cluster/validation/test_nebula_mesh.py
+++ b/cluster/validation/test_nebula_mesh.py
@@ -80,9 +80,11 @@ def _control_plane_nebula_ips(mesh: nebula_mesh.Mesh) -> dict[str, str]:
 
 def _terraform_control_plane_nebula_ips(path: Path) -> dict[str, str]:
     doc = pygohcl.loads(path.read_text())
-    # `locals` is one dict per `locals {}` block; gather the node-inventory maps across them.
+    # pygohcl collapses a single `locals {}` block to a dict but keeps multiple blocks as a
+    # list of dicts; normalize to a list, then gather the node-inventory maps across them.
+    blocks = doc.get("locals", [])
     nodes: dict[str, dict[str, str]] = {}
-    for block in doc.get("locals", []):
+    for block in [blocks] if isinstance(blocks, dict) else blocks:
         for local_name in _NODE_INVENTORY_LOCALS:
             nodes.update(block.get(local_name, {}))
     by_role: dict[str, dict[str, str]] = defaultdict(dict)


### PR DESCRIPTION
Follow-ups from the pygohcl migration (#2611).

## `test_dns_records.py` → pygohcl

`_terraform_local_ips()` regex-scraped `local.public_gateway_ips` / `local.kube_api_ips` from `tf/gitops/dns-records/main.tf` — the same fragility class just removed from `test_nebula_mesh`. Now a structural `pygohcl.loads()` parse (pygohcl is already a repo dep). Added `@pypi//pygohcl` to the test target.

## pygohcl locals-shape quirk (both tests)

pygohcl collapses a **single** `locals {}` block to a `dict` but keeps **multiple** blocks as a `list` of dicts. `dns-records/main.tf` has one block (dict); `ovh-nodes.tf` has three (list). Both helpers now normalize to a list, so either shape works. `test_nebula_mesh` worked by luck (ovh-nodes has 3 blocks) — hardened it too so a future consolidation can't break it.

## README: manifest-regen fallback for no-`/bin/bash` hosts

The documented `bb run //devinfra:gazelle_python_manifest.update` fails where the workspace bazelrc's `--shell_executable=/bin/bash` doesn't resolve (e.g. this NixOS host). Documented the working flags: `--config=nolint --norun_validations --shell_executable="$(command -v bash)"`.

## Test

`bbr test //cluster/validation:test_dns_records //cluster/validation:test_nebula_mesh` → both PASS. pre-commit green.