### PR TITLE
cluster: keep stateful tier + VM-image builds off control-plane HDD nodes

### DIFF
--- a/cluster/docs/lessons_learned/2026_06_19_etcd_hdd_io_contention.md
+++ b/cluster/docs/lessons_learned/2026_06_19_etcd_hdd_io_contention.md
@@ -6,7 +6,50 @@ controllers pinned off the control-plane nodes). Structural fix (etcd on NVMe) a
 remaining workload pins (tofu runners, augur) are tracked below.
 **Severity:** Intermittent — `ControlPlaneLeasePutLatencyCritical` fires under load
 bursts; etcd health checks occasionally fail `context deadline exceeded`. No data loss,
-no quorum loss observed.
+no quorum loss observed. **Recurred 2026-06-28 as a full outage** (two control planes
+NotReady, Forgejo 500s) — see the dated section below.
+
+## 2026-06-28 recurrence — escalated to a real outage
+
+The same mechanism recurred and this time **flapped two control planes NotReady**
+(`ovh-ns103656`, `ovh-ns103711`) for ~10–15 min around 03:06–03:11Z, throwing Forgejo
+500s and restarting `authentik-server`. etcd raft apply latency hit **60 s**
+(`apply request took too long: 59.9s`); `talosctl service etcd` showed `Fail` on `.13`.
+Quorum held (leader `.15` + `.14` stayed in sync), so no data loss — but the API-server
+brownout cascaded. Hosts were alive throughout (ping + Talos `apid`/`kubelet` healthy);
+the failure was purely etcd fsync starvation, not hardware.
+
+**Data-driven trigger** (Mimir `container_fs_writes_bytes_total` per pod, increase over
+the 15 min into the stall, on the two CP nodes) — one batch job dominated by an order of
+magnitude:
+
+| pod                    | namespace             | node | MB written / 15 min |
+| ---------------------- | --------------------- | ---- | ------------------- |
+| `agent-box-img-…`      | `vm-images-publisher` | .14  | **15014**           |
+| `mimir-ingester-1`     | monitoring            | .14  | 916                 |
+| `mimir-ingester-0`     | monitoring            | .13  | 814                 |
+| `attic-db-3`           | nix-cache             | .13  | 270                 |
+| `loki-write-0`         | loki                  | .13  | 214                 |
+| `seaweedfs-filer-db-3` | seaweedfs             | .13  | 213                 |
+
+The `vm-images-publisher` CronJob (NixOS VM-image build → qcow2, ~15 GB written to the
+node overlay/emptyDir) carried only `nodeSelector: region=hil` and landed on a CP HDD
+node, saturating `sda5` (I/O-pressure `full avg10 ≈ 35 %`, queue depth ~28) and starving
+etcd. The chronic stateful writers (mimir/attic/loki/seaweedfs/CNPG) are real but each
+< ~1 MB/s sustained; the acute trigger was this single ~17 MB/s batch build.
+
+### Mitigation applied (2026-06-28)
+
+- **Stateful tier pinned soft-off the control plane** — `preferred` nodeAffinity
+  `node-role.kubernetes.io/control-plane DoesNotExist` added to all ~22 hil-ovh stateful
+  workloads (9 CNPG clusters, 8 Valkey, Loki, Mimir, langfuse + its clickhouse/zookeeper,
+  gatus, forgejo). Soft, to keep the CP nodes as overflow capacity if both workers are
+  down.
+- **VM-image builder pinned hard-off the control plane** — `required` nodeAffinity on the
+  `vm-images-publisher` CronJob jobTemplate. A batch build has no availability need and
+  belongs on the NVMe workers; this is the workload that caused the outage.
+- Complements the 2026-06-19 flux-controller pins. Still pending: the tofu-runner pins
+  (item 3 below) and the structural etcd-on-NVMe move (item 5).
 
 ## Symptom
 

--- a/cluster/k8s/agents/manifold-mcp/app/valkey-kimsufi-instance.yaml
+++ b/cluster/k8s/agents/manifold-mcp/app/valkey-kimsufi-instance.yaml
@@ -33,6 +33,15 @@ spec:
               - key: topology.kubernetes.io/zone
                 operator: In
                 values: ["hil-ovh"]
+      # Soft anti-affinity off control-plane nodes (their etcd is on a rotational
+      # HDD; co-located I/O starves etcd fsync — 2026-06-28 outage).
+      # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: DoesNotExist
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:

--- a/cluster/k8s/agents/plaid-db-mcp/app/valkey-kimsufi-instance.yaml
+++ b/cluster/k8s/agents/plaid-db-mcp/app/valkey-kimsufi-instance.yaml
@@ -33,6 +33,15 @@ spec:
               - key: topology.kubernetes.io/zone
                 operator: In
                 values: ["hil-ovh"]
+      # Soft anti-affinity off control-plane nodes (their etcd is on a rotational
+      # HDD; co-located I/O starves etcd fsync — 2026-06-28 outage).
+      # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: DoesNotExist
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:

--- a/cluster/k8s/agents/postscanmail-mcp/app/valkey-kimsufi-instance.yaml
+++ b/cluster/k8s/agents/postscanmail-mcp/app/valkey-kimsufi-instance.yaml
@@ -33,6 +33,15 @@ spec:
               - key: topology.kubernetes.io/zone
                 operator: In
                 values: ["hil-ovh"]
+      # Soft anti-affinity off control-plane nodes (their etcd is on a rotational
+      # HDD; co-located I/O starves etcd fsync — 2026-06-28 outage).
+      # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: DoesNotExist
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:

--- a/cluster/k8s/agents/tana-mcp-facade/valkey-ovh-instance.yaml
+++ b/cluster/k8s/agents/tana-mcp-facade/valkey-ovh-instance.yaml
@@ -32,6 +32,15 @@ spec:
               - key: topology.kubernetes.io/zone
                 operator: In
                 values: ["hil-ovh"]
+      # Soft anti-affinity off control-plane nodes (their etcd is on a rotational
+      # HDD; co-located I/O starves etcd fsync — 2026-06-28 outage).
+      # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: DoesNotExist
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:

--- a/cluster/k8s/authentik/db/postgres-cluster-ovh.yaml
+++ b/cluster/k8s/authentik/db/postgres-cluster-ovh.yaml
@@ -16,6 +16,16 @@ spec:
     nodeSelector:
       topology.kubernetes.io/zone: hil-ovh
     topologyKey: kubernetes.io/hostname
+    # Soft anti-affinity off control-plane nodes (their etcd is on a rotational
+    # HDD; co-located I/O starves etcd fsync — 2026-06-28 outage).
+    # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: DoesNotExist
 
   storage:
     storageClass: local-path-ovh

--- a/cluster/k8s/forgejo/app/helmrelease.yaml
+++ b/cluster/k8s/forgejo/app/helmrelease.yaml
@@ -52,6 +52,17 @@ spec:
     # and co-located with the OVH-HA forgejo-db (cnpg_conventions R5).
     nodeSelector:
       topology.kubernetes.io/zone: hil-ovh
+    # Soft anti-affinity off control-plane nodes (their etcd is on a rotational
+    # HDD; co-located I/O starves etcd fsync — 2026-06-28 outage).
+    # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+    affinity:
+      nodeAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+                - key: node-role.kubernetes.io/control-plane
+                  operator: DoesNotExist
 
     # Forgejo configuration (chart retains the legacy `gitea:` values key)
     gitea:

--- a/cluster/k8s/forgejo/db/postgres-cluster.yaml
+++ b/cluster/k8s/forgejo/db/postgres-cluster.yaml
@@ -20,6 +20,16 @@ spec:
     nodeSelector:
       topology.kubernetes.io/zone: hil-ovh
     topologyKey: kubernetes.io/hostname
+    # Soft anti-affinity off control-plane nodes (their etcd is on a rotational
+    # HDD; co-located I/O starves etcd fsync — 2026-06-28 outage).
+    # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: DoesNotExist
 
   storage:
     storageClass: local-path-ovh

--- a/cluster/k8s/gatus/app/helmrelease.yaml
+++ b/cluster/k8s/gatus/app/helmrelease.yaml
@@ -60,6 +60,17 @@ spec:
 
     nodeSelector:
       topology.kubernetes.io/zone: hil-ovh
+    # Soft anti-affinity off control-plane nodes (their etcd is on a rotational
+    # HDD; co-located I/O starves etcd fsync — 2026-06-28 outage).
+    # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+    affinity:
+      nodeAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+                - key: node-role.kubernetes.io/control-plane
+                  operator: DoesNotExist
 
     resources:
       requests:

--- a/cluster/k8s/gatus/db/postgres-cluster.yaml
+++ b/cluster/k8s/gatus/db/postgres-cluster.yaml
@@ -16,6 +16,16 @@ spec:
     nodeSelector:
       topology.kubernetes.io/zone: hil-ovh
     topologyKey: kubernetes.io/hostname
+    # Soft anti-affinity off control-plane nodes (their etcd is on a rotational
+    # HDD; co-located I/O starves etcd fsync — 2026-06-28 outage).
+    # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: DoesNotExist
 
   storage:
     storageClass: local-path-ovh

--- a/cluster/k8s/grocy/sf/mcp/valkey-ovh-instance.yaml
+++ b/cluster/k8s/grocy/sf/mcp/valkey-ovh-instance.yaml
@@ -32,6 +32,15 @@ spec:
               - key: topology.kubernetes.io/zone
                 operator: In
                 values: ["hil-ovh"]
+      # Soft anti-affinity off control-plane nodes (their etcd is on a rotational
+      # HDD; co-located I/O starves etcd fsync — 2026-06-28 outage).
+      # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: DoesNotExist
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:

--- a/cluster/k8s/grocy/vallejo/mcp/valkey-ovh-instance.yaml
+++ b/cluster/k8s/grocy/vallejo/mcp/valkey-ovh-instance.yaml
@@ -32,6 +32,15 @@ spec:
               - key: topology.kubernetes.io/zone
                 operator: In
                 values: ["hil-ovh"]
+      # Soft anti-affinity off control-plane nodes (their etcd is on a rotational
+      # HDD; co-located I/O starves etcd fsync — 2026-06-28 outage).
+      # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: DoesNotExist
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:

--- a/cluster/k8s/langfuse/app/helmrelease.yaml
+++ b/cluster/k8s/langfuse/app/helmrelease.yaml
@@ -38,6 +38,17 @@ spec:
         signUpDisabled: false
       nodeSelector:
         topology.kubernetes.io/zone: hil-ovh
+      # Soft anti-affinity off control-plane nodes (their etcd is on a rotational
+      # HDD; co-located I/O starves etcd fsync — 2026-06-28 outage).
+      # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
       nextauth:
         url: "https://langfuse.allegedly.works"
         secret:
@@ -182,11 +193,33 @@ spec:
         resourcesPreset: small
         nodeSelector:
           topology.kubernetes.io/zone: hil-ovh
+        # Soft anti-affinity off control-plane nodes (their etcd is on a rotational
+        # HDD; co-located I/O starves etcd fsync — 2026-06-28 outage).
+        # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+        affinity:
+          nodeAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                preference:
+                  matchExpressions:
+                    - key: node-role.kubernetes.io/control-plane
+                      operator: DoesNotExist
         persistence:
           storageClass: local-path-ovh
           size: 8Gi
       nodeSelector:
         topology.kubernetes.io/zone: hil-ovh
+      # Soft anti-affinity off control-plane nodes (their etcd is on a rotational
+      # HDD; co-located I/O starves etcd fsync — 2026-06-28 outage).
+      # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
       persistence:
         storageClass: local-path-ovh
         size: 20Gi

--- a/cluster/k8s/langfuse/app/helmrelease.yaml
+++ b/cluster/k8s/langfuse/app/helmrelease.yaml
@@ -1,13 +1,3 @@
----
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: HelmRepository
-metadata:
-  name: langfuse
-  namespace: langfuse
-spec:
-  interval: 24h
-  url: https://langfuse.github.io/langfuse-k8s
----
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/cluster/k8s/langfuse/app/helmrepository.yaml
+++ b/cluster/k8s/langfuse/app/helmrepository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: langfuse
+  namespace: langfuse
+spec:
+  interval: 24h
+  url: https://langfuse.github.io/langfuse-k8s

--- a/cluster/k8s/langfuse/app/kustomization.yaml
+++ b/cluster/k8s/langfuse/app/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - helmrepository.yaml
   - helmrelease.yaml
   - httproute.yaml
   - role-log-reader.yaml

--- a/cluster/k8s/langfuse/cache/valkey-ovh-instance.yaml
+++ b/cluster/k8s/langfuse/cache/valkey-ovh-instance.yaml
@@ -35,6 +35,15 @@ spec:
               - key: topology.kubernetes.io/zone
                 operator: In
                 values: ["hil-ovh"]
+      # Soft anti-affinity off control-plane nodes (their etcd is on a rotational
+      # HDD; co-located I/O starves etcd fsync — 2026-06-28 outage).
+      # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: DoesNotExist
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:

--- a/cluster/k8s/monitoring/grafana-db/postgres-cluster-ovh.yaml
+++ b/cluster/k8s/monitoring/grafana-db/postgres-cluster-ovh.yaml
@@ -16,6 +16,16 @@ spec:
     nodeSelector:
       topology.kubernetes.io/zone: hil-ovh
     topologyKey: kubernetes.io/hostname
+    # Soft anti-affinity off control-plane nodes (their etcd is on a rotational
+    # HDD; co-located I/O starves etcd fsync — 2026-06-28 outage).
+    # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: DoesNotExist
 
   storage:
     storageClass: local-path-ovh

--- a/cluster/k8s/monitoring/loki/helmrelease.yaml
+++ b/cluster/k8s/monitoring/loki/helmrelease.yaml
@@ -80,6 +80,17 @@ spec:
         goldilocks.fairwinds.com/enabled: "false"
       nodeSelector:
         topology.kubernetes.io/zone: hil-ovh
+      # Soft anti-affinity off control-plane nodes (their etcd is on a rotational
+      # HDD; co-located I/O starves etcd fsync — 2026-06-28 outage).
+      # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
       persistence:
         storageClass: local-path-ovh
         size: 10Gi
@@ -100,6 +111,17 @@ spec:
         goldilocks.fairwinds.com/enabled: "false"
       nodeSelector:
         topology.kubernetes.io/zone: hil-ovh
+      # Soft anti-affinity off control-plane nodes (their etcd is on a rotational
+      # HDD; co-located I/O starves etcd fsync — 2026-06-28 outage).
+      # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
       extraEnvFrom:
         - secretRef:
             name: loki-s3-credentials
@@ -117,6 +139,17 @@ spec:
         goldilocks.fairwinds.com/enabled: "false"
       nodeSelector:
         topology.kubernetes.io/zone: hil-ovh
+      # Soft anti-affinity off control-plane nodes (their etcd is on a rotational
+      # HDD; co-located I/O starves etcd fsync — 2026-06-28 outage).
+      # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
       persistence:
         volumeClaimsEnabled: false
       extraEnvFrom:
@@ -142,6 +175,17 @@ spec:
           memory: 32Mi
       nodeSelector:
         topology.kubernetes.io/zone: hil-ovh
+      # Soft anti-affinity off control-plane nodes (their etcd is on a rotational
+      # HDD; co-located I/O starves etcd fsync — 2026-06-28 outage).
+      # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
 
     # Disable bundled monitoring (we have kube-prometheus-stack)
     monitoring:

--- a/cluster/k8s/monitoring/mimir/helmrelease.yaml
+++ b/cluster/k8s/monitoring/mimir/helmrelease.yaml
@@ -96,6 +96,17 @@ spec:
           memory: 128Mi
       nodeSelector:
         topology.kubernetes.io/zone: hil-ovh
+      # Soft anti-affinity off control-plane nodes (their etcd is on a rotational
+      # HDD; co-located I/O starves etcd fsync — 2026-06-28 outage).
+      # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
 
     ingester:
       replicas: 2
@@ -114,6 +125,16 @@ spec:
       zoneAwareReplication:
         enabled: false
       affinity:
+        # Soft anti-affinity off control-plane nodes (their etcd is on a rotational
+        # HDD; co-located I/O starves etcd fsync — 2026-06-28 outage).
+        # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
@@ -131,6 +152,17 @@ spec:
           memory: 128Mi
       nodeSelector:
         topology.kubernetes.io/zone: hil-ovh
+      # Soft anti-affinity off control-plane nodes (their etcd is on a rotational
+      # HDD; co-located I/O starves etcd fsync — 2026-06-28 outage).
+      # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
 
     query_frontend:
       replicas: 1
@@ -140,6 +172,17 @@ spec:
           memory: 128Mi
       nodeSelector:
         topology.kubernetes.io/zone: hil-ovh
+      # Soft anti-affinity off control-plane nodes (their etcd is on a rotational
+      # HDD; co-located I/O starves etcd fsync — 2026-06-28 outage).
+      # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
 
     query_scheduler:
       replicas: 1
@@ -149,6 +192,17 @@ spec:
           memory: 64Mi
       nodeSelector:
         topology.kubernetes.io/zone: hil-ovh
+      # Soft anti-affinity off control-plane nodes (their etcd is on a rotational
+      # HDD; co-located I/O starves etcd fsync — 2026-06-28 outage).
+      # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
 
     compactor:
       replicas: 1
@@ -163,6 +217,17 @@ spec:
           memory: 128Mi
       nodeSelector:
         topology.kubernetes.io/zone: hil-ovh
+      # Soft anti-affinity off control-plane nodes (their etcd is on a rotational
+      # HDD; co-located I/O starves etcd fsync — 2026-06-28 outage).
+      # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
 
     store_gateway:
       replicas: 1
@@ -178,6 +243,17 @@ spec:
           memory: 128Mi
       nodeSelector:
         topology.kubernetes.io/zone: hil-ovh
+      # Soft anti-affinity off control-plane nodes (their etcd is on a rotational
+      # HDD; co-located I/O starves etcd fsync — 2026-06-28 outage).
+      # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
       zoneAwareReplication:
         enabled: false
 
@@ -195,6 +271,17 @@ spec:
           memory: 32Mi
       nodeSelector:
         topology.kubernetes.io/zone: hil-ovh
+      # Soft anti-affinity off control-plane nodes (their etcd is on a rotational
+      # HDD; co-located I/O starves etcd fsync — 2026-06-28 outage).
+      # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
 
     # --- Disabled components ---
 
@@ -207,6 +294,17 @@ spec:
           memory: 128Mi
       nodeSelector:
         topology.kubernetes.io/zone: hil-ovh
+      # Soft anti-affinity off control-plane nodes (their etcd is on a rotational
+      # HDD; co-located I/O starves etcd fsync — 2026-06-28 outage).
+      # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
 
     alertmanager:
       enabled: false

--- a/cluster/k8s/nix-cache/db/postgres-cluster.yaml
+++ b/cluster/k8s/nix-cache/db/postgres-cluster.yaml
@@ -18,6 +18,16 @@ spec:
       topology.kubernetes.io/zone: hil-ovh
     # One PostgreSQL instance per OVH kimsufi node for real HA.
     topologyKey: kubernetes.io/hostname
+    # Soft anti-affinity off control-plane nodes (their etcd is on a rotational
+    # HDD; co-located I/O starves etcd fsync — 2026-06-28 outage).
+    # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: DoesNotExist
 
   storage:
     storageClass: local-path-ovh

--- a/cluster/k8s/paperless/cache/valkey-ovh-instance.yaml
+++ b/cluster/k8s/paperless/cache/valkey-ovh-instance.yaml
@@ -35,6 +35,15 @@ spec:
               - key: topology.kubernetes.io/zone
                 operator: In
                 values: ["hil-ovh"]
+      # Soft anti-affinity off control-plane nodes (their etcd is on a rotational
+      # HDD; co-located I/O starves etcd fsync — 2026-06-28 outage).
+      # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: DoesNotExist
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:

--- a/cluster/k8s/paperless/db/postgres-cluster.yaml
+++ b/cluster/k8s/paperless/db/postgres-cluster.yaml
@@ -18,6 +18,16 @@ spec:
     nodeSelector:
       topology.kubernetes.io/zone: hil-ovh
     topologyKey: kubernetes.io/hostname
+    # Soft anti-affinity off control-plane nodes (their etcd is on a rotational
+    # HDD; co-located I/O starves etcd fsync — 2026-06-28 outage).
+    # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: DoesNotExist
 
   storage:
     storageClass: local-path-ovh

--- a/cluster/k8s/props/db/postgres-cluster.yaml
+++ b/cluster/k8s/props/db/postgres-cluster.yaml
@@ -20,6 +20,16 @@ spec:
     nodeSelector:
       topology.kubernetes.io/zone: hil-ovh
     topologyKey: kubernetes.io/hostname
+    # Soft anti-affinity off control-plane nodes (their etcd is on a rotational
+    # HDD; co-located I/O starves etcd fsync — 2026-06-28 outage).
+    # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: DoesNotExist
 
   storage:
     storageClass: local-path-ovh

--- a/cluster/k8s/seaweedfs/db/postgres-cluster.yaml
+++ b/cluster/k8s/seaweedfs/db/postgres-cluster.yaml
@@ -29,6 +29,16 @@ spec:
       topology.kubernetes.io/zone: hil-ovh
     # One PostgreSQL instance per OVH kimsufi node for real HA.
     topologyKey: kubernetes.io/hostname
+    # Soft anti-affinity off control-plane nodes (their etcd is on a rotational
+    # HDD; co-located I/O starves etcd fsync — 2026-06-28 outage).
+    # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: DoesNotExist
 
   storage:
     storageClass: local-path-ovh

--- a/cluster/k8s/tofu-state/db/postgres-cluster-ovh.yaml
+++ b/cluster/k8s/tofu-state/db/postgres-cluster-ovh.yaml
@@ -16,6 +16,16 @@ spec:
     nodeSelector:
       topology.kubernetes.io/zone: hil-ovh
     topologyKey: kubernetes.io/hostname
+    # Soft anti-affinity off control-plane nodes (their etcd is on a rotational
+    # HDD; co-located I/O starves etcd fsync — 2026-06-28 outage).
+    # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: DoesNotExist
 
   storage:
     storageClass: local-path-ovh

--- a/cluster/k8s/vm-images-publisher/cronjob.yaml
+++ b/cluster/k8s/vm-images-publisher/cronjob.yaml
@@ -26,6 +26,19 @@ spec:
           # sandbox-namespace DNS quirk that doesn't exist here).
           nodeSelector:
             topology.kubernetes.io/region: hil
+          # Keep VM-image builds OFF the control-plane HDD nodes: one such build
+          # wrote ~15 GB to ovh-ns103711's spinning disk in 15 min, starving etcd
+          # fsync and flapping 2 control planes NotReady (2026-06-28 outage).
+          # Hard (required), not preferred: a batch build has no availability need
+          # and belongs on the NVMe workers (region=hil + non-control-plane).
+          # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: node-role.kubernetes.io/control-plane
+                        operator: DoesNotExist
           containers:
             - name: publish
               image: nixos/nix:2.24.11


### PR DESCRIPTION
## Why

The OVH control-plane nodes run **etcd on rotational HDDs** and carry **no `NoSchedule` taint**, so co-located workload disk I/O competes with etcd's WAL `fsync`. On **2026-06-28** a `vm-images-publisher` build wrote **~15 GB to a control-plane node in 15 min**, saturating `sda5` (I/O-pressure `full≈35%`, queue depth ~28). etcd raft apply latency hit **60 s**, flapping **two control planes NotReady** (`ovh-ns103656`, `ovh-ns103711`) → Forgejo 500s + authentik restart.

Per-pod Mimir attribution (`container_fs_writes_bytes_total`, 15 min into the stall) confirmed the trigger:

| pod | namespace | node | MB / 15 min |
| --- | --- | --- | --- |
| `agent-box-img-…` | vm-images-publisher | .14 | **15014** |
| `mimir-ingester-1` | monitoring | .14 | 916 |
| `mimir-ingester-0` | monitoring | .13 | 814 |
| `attic-db-3` | nix-cache | .13 | 270 |
| `loki-write-0` | loki | .13 | 214 |

Full RCA: `cluster/docs/lessons_learned/2026_06_19_etcd_hdd_io_contention.md` (2026-06-28 recurrence section).

## What

- **Soft (`preferred`) anti-affinity** off control-plane on all ~22 `hil-ovh` stateful workloads: 9 CNPG clusters, 8 Valkey, Loki, Mimir, langfuse (+ clickhouse/zookeeper), gatus, forgejo. Soft keeps the CP nodes as overflow capacity if both NVMe workers are down.
- **Hard (`required`) anti-affinity** on the `vm-images-publisher` CronJob jobTemplate — the outage trigger; a batch image build has no availability need and belongs on the NVMe workers.

Forward-looking only (`IgnoredDuringExecution`) — running pods are unaffected; an active node-by-node migration is planned separately. Complements the 2026-06-19 flux-controller pins. Pending: tofu-runner pins + structural etcd-on-NVMe move.