### PR TITLE
[codex] Allow Haku nginx template rendering

### DIFF
--- a/cluster/k8s/haku/console/deployment.yaml
+++ b/cluster/k8s/haku/console/deployment.yaml
@@ -147,6 +147,10 @@ spec:
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10
+          volumeMounts:
+            # The nginx entrypoint writes the envsubst-rendered template here.
+            - name: nginx-conf
+              mountPath: /etc/nginx/conf.d
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -155,4 +159,6 @@ spec:
         - name: tmp
           emptyDir: {}
         - name: data
+          emptyDir: {}
+        - name: nginx-conf
           emptyDir: {}


### PR DESCRIPTION
## Summary

Fix the Haku console static nginx container after moving its config to an envsubst template. The official nginx entrypoint renders `/etc/nginx/templates/default.conf.template` into `/etc/nginx/conf.d`, but the existing pod did not provide a writable config directory for that runtime output.

This adds an `emptyDir` mounted only at `/etc/nginx/conf.d` in the `static` container, matching the live patch that restored the rollout.

## Root Cause

The static image started with nginx's stock default config because envsubst could not write the rendered config. That default config listened on `8080`, colliding with the FastAPI server container in the same pod. The server then crashed with `address already in use`, and the static readiness probe also targeted the wrong port.

## Validation

- `kubectl kustomize cluster/k8s/haku/console`
- `pre-commit run --files cluster/k8s/haku/console/deployment.yaml`
- `bbr test //cluster/validation:test_cluster_integration`

Live mitigation applied and the Haku console pod reached `2/2 Running` with the new images.