### PR TITLE
cluster/validation: dedupe pygohcl locals-shape helper

### DIFF
--- a/cluster/validation/BUILD.bazel
+++ b/cluster/validation/BUILD.bazel
@@ -289,6 +289,12 @@ py_test(
     ],
 )
 
+py_library(
+    name = "terraform_hcl",
+    srcs = ["terraform_hcl.py"],
+    deps = ["@pypi//pygohcl"],
+)
+
 py_test(
     name = "test_nebula_mesh",
     srcs = ["test_nebula_mesh.py"],
@@ -298,9 +304,9 @@ py_test(
         "//cluster/terraform/main:ovh-nodes.tf",
     ],
     deps = [
+        ":terraform_hcl",
         "//cluster/scripts:nebula_mesh",
         "//util/bazel:runfiles",
-        "@pypi//pygohcl",
         "@pypi//pytest",
         "@pypi//pytest_bazel",
         "@pypi//pyyaml",
@@ -315,8 +321,8 @@ py_test(
         "//tf/gitops/dns-records:main.tf",
     ],
     deps = [
+        ":terraform_hcl",
         "//util/bazel:runfiles",
-        "@pypi//pygohcl",
         "@pypi//pytest_bazel",
     ],
 )

--- a/cluster/validation/terraform_hcl.py
+++ b/cluster/validation/terraform_hcl.py
@@ -1,0 +1,18 @@
+"""Read Terraform `locals` blocks via pygohcl (HashiCorp's HCL2 parser)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pygohcl
+
+
+def locals_blocks(path: Path) -> list[dict[str, Any]]:
+    """Parse `path` and return its `locals {}` blocks as a list of dicts.
+
+    pygohcl collapses a single `locals {}` block to a dict and keeps multiple blocks as a
+    list of dicts; normalize to a list so callers can iterate uniformly.
+    """
+    blocks = pygohcl.loads(path.read_text()).get("locals", [])
+    return [blocks] if isinstance(blocks, dict) else blocks

--- a/cluster/validation/test_dns_records.py
+++ b/cluster/validation/test_dns_records.py
@@ -6,20 +6,16 @@ import json
 from pathlib import Path
 from typing import Any
 
-import pygohcl
 import pytest_bazel
 
+from cluster.validation.terraform_hcl import locals_blocks
 from util.bazel.runfiles import get_required_path
 
 
 def _terraform_local_ips(path: Path, name: str) -> set[str]:
-    # pygohcl (HashiCorp's HCL2 parser) decodes the `local.<name>` IP list straight to a
-    # Python list of strings — a structural parse, not a regex over the file text.
-    doc = pygohcl.loads(path.read_text())
-    # pygohcl collapses a single `locals {}` block to a dict but keeps multiple blocks as a
-    # list of dicts; normalize to a list so either shape works.
-    blocks = doc.get("locals", [])
-    for block in [blocks] if isinstance(blocks, dict) else blocks:
+    # pygohcl decodes the `local.<name>` IP list straight to a Python list of strings
+    # — a structural parse, not a regex over the file text.
+    for block in locals_blocks(path):
         if name in block:
             return set(block[name])
     raise AssertionError(f"{path}: missing local.{name} list")

--- a/cluster/validation/test_nebula_mesh.py
+++ b/cluster/validation/test_nebula_mesh.py
@@ -6,12 +6,12 @@ import ipaddress
 from collections import defaultdict
 from pathlib import Path
 
-import pygohcl
 import pytest
 import pytest_bazel
 import yaml
 
 from cluster.scripts import nebula_mesh
+from cluster.validation.terraform_hcl import locals_blocks
 from util.bazel.runfiles import get_required_path
 
 # The `locals` maps in ovh-nodes.tf that carry per-node role/hostname/nebula_ip. pygohcl decodes
@@ -79,12 +79,8 @@ def _control_plane_nebula_ips(mesh: nebula_mesh.Mesh) -> dict[str, str]:
 
 
 def _terraform_control_plane_nebula_ips(path: Path) -> dict[str, str]:
-    doc = pygohcl.loads(path.read_text())
-    # pygohcl collapses a single `locals {}` block to a dict but keeps multiple blocks as a
-    # list of dicts; normalize to a list, then gather the node-inventory maps across them.
-    blocks = doc.get("locals", [])
     nodes: dict[str, dict[str, str]] = {}
-    for block in [blocks] if isinstance(blocks, dict) else blocks:
+    for block in locals_blocks(path):
         for local_name in _NODE_INVENTORY_LOCALS:
             nodes.update(block.get(local_name, {}))
     by_role: dict[str, dict[str, str]] = defaultdict(dict)


### PR DESCRIPTION
Follow-up to #2611/#2613. `test_nebula_mesh` and `test_dns_records` both inlined the same pygohcl quirk handling — a single `locals {}` block decodes to a `dict`, multiple to a `list`.

Extracted it into `cluster/validation/terraform_hcl.locals_blocks(path)` (parses the file, returns the `locals` blocks as a normalized list). Both tests now depend on `:terraform_hcl` and drop their direct `@pypi//pygohcl` dep.

`bbr test //cluster/validation:test_nebula_mesh //cluster/validation:test_dns_records` → both PASS. pre-commit green.