### PR TITLE
vm-images-publisher: attic substituter (fix host-image builds) + repin agent-box

### DIFF
--- a/cluster/k8s/agent-box/app/virtualmachine.yaml
+++ b/cluster/k8s/agent-box/app/virtualmachine.yaml
@@ -29,7 +29,7 @@ spec:
             # IMAGE_OUTPUT=agent-box-image). The VM boots straight into the real
             # config — no bootstrap + nixos-rebuild switch. cloud-init still
             # injects the persisted host key. Repin after rebuilding the image.
-            url: "https://s3.allegedly.works/vm-images/agent-box/eb07e72dd83cd97a6d70eeae6402c12d8c513564.qcow2"
+            url: "https://s3.allegedly.works/vm-images/agent-box/e2c6c93a1a802d7bbc9381918e977243ba9caf86.qcow2"
             secretRef: agent-box-vm-images-s3-reader
         pvc:
           accessModes:

--- a/cluster/k8s/vm-images-publisher/attic-reader-netrc.sops.yaml
+++ b/cluster/k8s/vm-images-publisher/attic-reader-netrc.sops.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: attic-reader-netrc
+    namespace: vm-images-publisher
+    annotations:
+        description: Attic main:r reader token as a netrc, so the publisher can substitute host-image closures (e.g. sops-install-secrets) from cache.allegedly.works instead of building them with no network egress.
+type: Opaque
+stringData:
+    netrc: ENC[AES256_GCM,data:+0RbNYmLJ+JevPY9CGycAAkk7o3d/vGYdH7ru7OW1R27Pb/xrG32RTdqbSIYoMEDeY/eTHp54Hx0HsoOM6KGxP/R6dIhGGVFuVbLdp7ik3BTIHE2LCU7pzh4b4k3PtHL2i3DDL3rs2tEBiE9lVyUiQ4mJ3g6F09YEUTpPacBo8QgOhuCRJLoV8zxXQT1SA5dwL303faE47IbwCsRJX+2qjPknd15E9DZTqzrZGIDLTIEoBwrD3e/4voU6VHglQ3pe6o/+K9F8DW62W9ETirzEL8Ehht4nxKAoN4QaYwN4nuPQSgJLarR/hp93YHnRM2XrSSZDui9rXQRIg5oC6nqkz6C8rLx1t5iHye2J+pqY5NtYC5iEQ==,iv:PIEp4NDSdq+7aT3v5Xyc1XEcT0j09GrvvL3J4tt8K1o=,tag:FKm9z476ceE0zyxQfZR4/Q==,type:str]
+sops:
+    age:
+        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGN3FZRU1JSDRtSDVGRDBS
+            czE1ZW02bEVxYXlYSC8zTXk2NWFZNGJ2QkZZCmZBM2xROUMxMUxUNGdMeUwwSmZu
+            bmp3eDJGY3hKM09pL1RRV0xnRTVBS0EKLS0tIDFmQk96LzhHc3grRVgydnh2QkY0
+            VlcvQ2dYeWVBeGdwZlNYcmx0dHpsQlkKuQFLIFhNh0MqnJWBogOqZe75v6aU+33n
+            khOMVyc/f8D62CPcarDGUCh9o8a+XgOL1TNH1LadrKh1eUvcNpHI5g==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1nywlwepsyfxvyhqwkjquzz02nmus65gf6qewfjju4alym8f7se5qnua8na
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBudGwzNmJpNExud1pkZDZa
+            eVVLTmtHeEV1R2QvVHFWeCtXVUN5ZEpSNG1JCk9vNXV6YXhXM3NkYmlsTU5udmNL
+            ek5rWHNyQmFSTGxPNTdONzkzOCtWV3cKLS0tIHJOWFhxZzRIM21qa3dkUU9DZG9J
+            Q1c2bHo4aTZteDhmZklGc0pGclh6dGsK9nPUnxOd58x2yoNW7yuQdgx04RNANqJV
+            tZwZbMVShP9m/QDSdKcZwcVJ/vFPGpRRC/hU5HZyeiEATIkux5WwmA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-06-28T03:35:49Z"
+    mac: ENC[AES256_GCM,data:sqIIIRRJj1xngOTf8jY+afBYS5c6m+zDeHa0lH5IzDsZ98mV/l89juLAEPYypYgClmq2IZs+CZcvOOJcfsO9A8usqIJvso426fnPIKqFSuNXLIdZw+da76Sp+UvbJ9zWf5TrYPjxJDBJIkPJVfo9/SJDF93Prh3G4fQxCvRxOq0=,iv:hGQpGu3ZA0SLncezpMAcNmhyNbaBI3al+n0RT89J87g=,tag:XN7JTEAtl79KTcFbAtTIqQ==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.1

--- a/cluster/k8s/vm-images-publisher/cronjob.yaml
+++ b/cluster/k8s/vm-images-publisher/cronjob.yaml
@@ -39,10 +39,18 @@ spec:
                   memory: 8Gi
               env:
                 - name: NIX_CONFIG
+                  # cache.allegedly.works/main lets the publisher substitute
+                  # host-image closures (e.g. sops-install-secrets, which is a
+                  # sops-nix package absent from cache.nixos.org) instead of
+                  # building them — the build pod has no egress for go-module
+                  # fetches. nix-attic-push builds every flake output on devel,
+                  # so the agent-box-image closure is already cached. main pubkey
+                  # SSOT: nix/attic-pubkeys.json. Auth via the mounted netrc.
                   value: |
                     experimental-features = nix-command flakes
-                    substituters = https://cache.nixos.org/
-                    trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+                    substituters = https://cache.nixos.org/ https://cache.allegedly.works/main
+                    trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= main:owYQITaq2ixR/EnqKoIQAxgjalKKVqMemFwRMaUW53U=
+                    netrc-file = /etc/nix-netrc/netrc
                     system-features = benchmark big-parallel kvm nixos-test uid-range
                     accept-flake-config = true
               envFrom:
@@ -65,6 +73,9 @@ spec:
               volumeMounts:
                 - name: scripts
                   mountPath: /scripts
+                - name: attic-netrc
+                  mountPath: /etc/nix-netrc
+                  readOnly: true
                 - name: kvm
                   mountPath: /dev/kvm
                 - name: tmp
@@ -74,6 +85,12 @@ spec:
               configMap:
                 name: vm-images-publisher-scripts
                 defaultMode: 0o555
+            - name: attic-netrc
+              secret:
+                secretName: attic-reader-netrc
+                items:
+                  - key: netrc
+                    path: netrc
             - name: kvm
               hostPath:
                 path: /dev/kvm

--- a/cluster/k8s/vm-images-publisher/kustomization.yaml
+++ b/cluster/k8s/vm-images-publisher/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - s3-credentials.yaml
+  - attic-reader-netrc.sops.yaml
   - cronjob.yaml
 configMapGenerator:
   - name: vm-images-publisher-scripts


### PR DESCRIPTION
Fixes the agent-box image build (follow-up to #2610).

**Problem:** the publisher only had `cache.nixos.org` as a substituter. Host images pull in `sops-install-secrets` (a sops-nix package not on cache.nixos.org), so a cold build node tried to *build* it — which needs Go modules from `proxy.golang.org`, and the build pod has no egress. (The first agent-box build only worked on a warm node.)

**Fix:** add `cache.allegedly.works/main` as a substituter to the publisher, with a `main:r` reader-token netrc mounted from a SOPS k8s Secret (`attic-reader-netrc`, same static pattern as `attic-push-token`). `nix-attic-push` builds every flake output on devel — including `agent-box-image` — so its closure (incl. sops-install-secrets) is already cached.

**Verified end-to-end pre-merge:** ran a one-off publish job rendered from this pod spec — `sops-install-secrets` substituted from attic (`copying path '…sops-install-secrets…' from 'https://cache.allegedly.works/main'`), the build completed, and published `agent-box/e2c6c93….qcow2` (3.64 GB). This PR repins the DataVolume to that image.

After merge + reconcile: recreate `vm/agent-box` and re-verify the full first-boot chain (host key → sops-nix plants id_ed25519 → home-manager → BuildBuddy/Forgejo secrets).