### PR TITLE
[codex] Clarify Haku iframe CSP docs

### DIFF
--- a/cluster/k8s/haku/console/deployment.yaml
+++ b/cluster/k8s/haku/console/deployment.yaml
@@ -148,7 +148,8 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
           volumeMounts:
-            # The nginx entrypoint writes the envsubst-rendered template here.
+            # The SPA is baked into the image, but the nginx entrypoint still writes
+            # the envsubst-rendered runtime config here before nginx starts.
             - name: nginx-conf
               mountPath: /etc/nginx/conf.d
           securityContext:

--- a/haku/console/plans/free_form_ui_iframe.md
+++ b/haku/console/plans/free_form_ui_iframe.md
@@ -63,7 +63,8 @@ trusting the content:
    third-party cookie. Pin it with `sandbox="allow-scripts allow-same-origin allow-forms"`
    on the `<iframe>` (same-origin + forms are needed for the framed app's own Authentik
    auth; **no `allow-popups`** — only the shell opens links) and
-   `frame-src https://haku-ui.allegedly.works` in the shell's CSP.
+   `frame-src` for both `https://haku-ui.allegedly.works` and
+   `https://auth.allegedly.works` in the shell's CSP.
 
 2. **Haku's UI is never publicly exposed.** Its only ingress is the
    operator-owned, **Authentik-gated** route. Haku cannot publish private


### PR DESCRIPTION
## Summary

- update the free-form UI iframe plan so the load-bearing containment section names both the Haku UI origin and Authentik origin in `frame-src`
- clarify that the Haku console static image bakes the SPA but still needs a writable nginx config directory for envsubst-rendered runtime config

## Validation

- `pre-commit run --files cluster/k8s/haku/console/deployment.yaml haku/console/plans/free_form_ui_iframe.md`
- `git diff --check`