### PR TITLE
cluster/seaweedfs: filer 2-replica HA + plan/backup-comment fixes

### DIFF
--- a/cluster/docs/plan.md
+++ b/cluster/docs/plan.md
@@ -74,9 +74,17 @@ returns (not independently parked):
 
 - [ ] **etcd lease-PUT latency / control-plane HDD I/O contention.** etcd runs on
       rotational HDDs on the KS-5 control planes (no SSD there; the NVMe is on the
-      KS-GAME workers). Defrag + flux-controller pinning applied 2026-06-19; remaining:
-      pin the tofu-controller runners (blocked on centralizing the ~22 copy-pasted
-      `runnerPodTemplate`s) and the cross-repo augur ingest job, then the structural
+      KS-GAME workers). **Recurred 2026-06-28 as a full outage** (two CPs NotReady,
+      Forgejo 500s); a `vm-images-publisher` build wrote ~15 GB to a CP disk and
+      starved etcd. Applied so far: defrag + flux-controller pins (2026-06-19); soft
+      anti-affinity on all ~22 hil-ovh stateful workloads + hard anti-affinity on the
+      `vm-images-publisher` CronJob (2026-06-28, PR #2614). Remaining: **actively
+      migrate the running stateful pods off the CP nodes** (anti-affinity is
+      forward-only — node-by-node, health-gated; CNPG/Loki/Mimir use node-pinned
+      `local-path-ovh`, so moving an instance is a re-clone; the single `seaweedfs-filer`
+      is the one workload that can't roll without a brief SeaweedFS-wide blip); pin the
+      tofu-controller runners (blocked on centralizing the ~22 copy-pasted
+      `runnerPodTemplate`s) and the cross-repo augur ingest job; then the structural
       etcd-on-NVMe move. Full RCA + remediation tracking:
       <lessons_learned/2026_06_19_etcd_hdd_io_contention.md>.
 - [ ] **Investigate whether to re-enable VPA/Goldilocks recommendations.**

--- a/cluster/k8s/seaweedfs/cluster/poddisruptionbudget.yaml
+++ b/cluster/k8s/seaweedfs/cluster/poddisruptionbudget.yaml
@@ -8,9 +8,10 @@
 #
 # minAvailable: 2 of 3 → at most one master/volume pod may be voluntarily
 # disrupted at a time, preserving raft quorum (master) and ≥2 replicas
-# (volume, replication=001). The singleton filer and the stateless s3 gateway
-# deliberately get no PDB (a maxUnavailable:0 PDB on a 1-replica set would wedge
-# node drains; s3 is freely reschedulable).
+# (volume, replication=001). The filer now runs 2 replicas and gets a
+# minAvailable: 1 PDB so a drain/descheduler can't take both filers down at
+# once (a SeaweedFS-wide metadata stall). The stateless s3 gateway deliberately
+# gets no PDB (freely reschedulable).
 #
 # See cluster/docs/lessons_learned/
 # 2026_06_19_seaweedfs_descheduler_dns_race_crashloop.md.
@@ -37,3 +38,15 @@ spec:
     matchLabels:
       app.kubernetes.io/name: seaweedfs
       app.kubernetes.io/component: volume
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: seaweedfs-filer
+  namespace: seaweedfs
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: seaweedfs
+      app.kubernetes.io/component: filer

--- a/cluster/k8s/seaweedfs/cluster/seaweed.yaml
+++ b/cluster/k8s/seaweedfs/cluster/seaweed.yaml
@@ -128,10 +128,16 @@ spec:
             topologyKey: kubernetes.io/hostname
 
   filer:
-    # Single replica today. postgres2 backend allows scaling later — once
-    # the cluster has been operating on Postgres for a while and we've
-    # established WAL/PITR backup is healthy, this can go to 2+.
-    replicas: 1
+    # 2-replica HA. The filer is a stateless metadata gateway to the shared
+    # postgres2 store (seaweedfs-filer-db), so both replicas serve identical
+    # data and concurrent writes are handled by enableUpsert. HA lets the filer
+    # roll / drain without a SeaweedFS-wide metadata stall, and (with the
+    # affinity below) keeps it off the control-plane HDD nodes.
+    # NOTE: the metadata DB still has no off-cluster WAL/PITR backup — only the
+    # 2-instance CNPG streaming replication. That gap is independent of the
+    # filer replica count but worth closing (it is the SSOT for all SeaweedFS
+    # data; see the 2026_05_27 filer-metadata-loss lesson).
+    replicas: 2
     # spec.filer.config is filled in from filer.toml via the kustomize
     # configMapGenerator + replacement in kustomization.yaml. The TOML
     # config lives in its own file so it can be syntax-checked and edited
@@ -157,9 +163,9 @@ spec:
             name: seaweedfs-filer-db-app
             key: password
     metricsPort: 9326
-    # QoS / eviction protection as on master. Singleton, so deliberately NO
-    # PodDisruptionBudget — a maxUnavailable:0 PDB on a 1-replica set would
-    # wedge node drains.
+    # QoS / eviction protection as on master. Now 2 replicas → a minAvailable:1
+    # PDB (poddisruptionbudget.yaml) keeps the descheduler / node drains from
+    # taking both filers down at once.
     #
     # Memory sizing: the filer is a metadata gateway to Postgres (postgres2
     # backend — metadata lives in the DB, not in-pod), so steady-state is
@@ -183,6 +189,26 @@ spec:
       memory: 768Mi
     nodeSelector:
       topology.kubernetes.io/zone: hil-ovh
+    affinity:
+      # Hard anti-affinity — one filer per host, so the 2 replicas never share
+      # a node and a single node loss can't take out both.
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: filer
+                app.kubernetes.io/name: seaweedfs
+            topologyKey: kubernetes.io/hostname
+      # Soft off the control-plane HDD nodes: in normal operation both filers
+      # land on the NVMe workers; CP stays a fallback if both workers are down.
+      # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+      nodeAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+                - key: node-role.kubernetes.io/control-plane
+                  operator: DoesNotExist
 
   s3:
     replicas: 2 # stateless S3 gateway — scales freely across the 3 kimsufi hosts

--- a/cluster/k8s/seaweedfs/db/postgres-cluster.yaml
+++ b/cluster/k8s/seaweedfs/db/postgres-cluster.yaml
@@ -3,9 +3,15 @@
 # Filer's previous leveldb2 setup lived in the pod's ephemeral writable
 # layer (no PVC) — the 3.93 → 4.29 upgrade rolled the filer pod and
 # wiped every bucket's filer metadata, orphaning .dat data in the
-# volume servers. CNPG fixes this with persistent storage + WAL backups +
-# replication, and removes the leveldb2 single-instance constraint so the
-# filer can be HA later.
+# volume servers. CNPG fixes this with persistent storage + 2-instance
+# streaming replication, and removes the leveldb2 single-instance constraint
+# so the filer can run HA (now 2 replicas — see ../cluster/seaweed.yaml).
+#
+# NOTE: there is no off-site / WAL-archive (PITR) backup yet — only the
+# in-cluster streaming replication. That is a cluster-wide CNPG gap (no Cluster
+# here configures barmanObjectStore; tracked in docs/cnpg_conventions.md). This
+# DB is the SSOT for ALL SeaweedFS metadata, so it is the highest-value one to
+# back up first.
 #
 # Profile: OVH-HA per cluster/docs/cnpg_conventions.md (two instances on
 # separate kimsufi nodes, co-located with the SeaweedFS volume servers).


### PR DESCRIPTION
Follow-up to #2614 — these three commits were pushed to that branch *after* its auto-merge had already fired (squashing only the anti-affinity + langfuse split), so they never reached `devel`.

## Commits
1. **plan.md** — record the 2026-06-28 etcd-HDD outage + remaining migration.
2. **SeaweedFS filer → 2-replica HA on the workers** — the single filer was the one stateful workload that couldn't roll without a SeaweedFS-wide metadata stall (it's the metadata gateway for every bucket). It's a stateless gateway to the shared postgres2 store, so scale to 2: hard podAntiAffinity (one per host) + soft off-CP → both on the NVMe workers; `minAvailable: 1` PDB. Unblocks the control-plane migration.
3. **Correct the filer-db comment** — it claimed CNPG gives "WAL backups", but no CNPG cluster in the repo configures any backup; flag the missing off-site/PITR backup as a cluster-wide gap.

NOTE: anti-affinity from #2614 is already merged + reconciled (verified: the vm-images-publisher CronJob hard-pin is live). This PR is the remainder.