### PR TITLE
vm-images-publisher: add SOPS decryption to its Flux Kustomization

### DIFF
--- a/cluster/k8s/vm-images-publisher/flux-kustomization.yaml
+++ b/cluster/k8s/vm-images-publisher/flux-kustomization.yaml
@@ -12,6 +12,12 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
+  # attic-reader-netrc.sops.yaml is SOPS-encrypted; without this, Flux applies
+  # the ciphertext literally and the publisher's attic auth (netrc) is garbage.
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age-cluster-secrets
   dependsOn:
     - name: external-secrets-operator
     - name: seaweedfs-public-s3

--- a/cluster/validation/TODO.md
+++ b/cluster/validation/TODO.md
@@ -1,0 +1,13 @@
+# cluster/validation TODO
+
+- **Detect SOPS secrets in a Flux Kustomization that lacks a `decryption` block.**
+  A `Kustomization` whose `spec.path` contains a SOPS-encrypted file (a manifest
+  with `ENC[AES256_GCM,...]` values / a `sops:` metadata block) but no
+  `spec.decryption.provider: sops` makes Flux apply the **ciphertext literally** —
+  the consumer gets `ENC[...]` instead of the secret, with no error. This bit the
+  `vm-images-publisher` attic-reader netrc (silently applied as ciphertext until
+  caught by hand). Consider a cluster-validation test that, for each
+  `flux-kustomization.yaml`, scans the files under its `path` for SOPS markers and
+  asserts the Kustomization declares `decryption.provider: sops` (+ the expected
+  `secretRef`). Pairs well with the existing structural checks in
+  `cluster/validation/`.


### PR DESCRIPTION
The `attic-reader-netrc` secret (#2617) is SOPS-encrypted, but the `vm-images-publisher` Kustomization had no `decryption` block — its s3 creds come via ESO, so this was the first SOPS file. Flux applied the `ENC[...]` ciphertext literally, so the publisher's attic netrc would be garbage on the next Flux-driven build (the pre-merge test worked only because I created the secret manually). Adds `decryption.provider: sops`.

Also leaves a `cluster/validation/TODO.md` note to consider a validation test that flags any Kustomization containing a SOPS file but missing a decryption block.