### PR TITLE
cluster/haku-ci: allow Docker Hub blob CDN (CloudFront) egress

### DIFF
--- a/cluster/docs/plan.md
+++ b/cluster/docs/plan.md
@@ -87,6 +87,17 @@ returns (not independently parked):
       `runnerPodTemplate`s) and the cross-repo augur ingest job; then the structural
       etcd-on-NVMe move. Full RCA + remediation tracking:
       <lessons_learned/2026_06_19_etcd_hdd_io_contention.md>.
+- [ ] **haku-ci Docker Hub pull-through cache** (replace the CloudFront egress
+      band-aid). The haku-ci runner's rootless dind pulls base images from Docker
+      Hub, which 307-redirects config/layer blob GETs to AWS CloudFront; the egress
+      policy now allows `*.cloudfront.net` as a band-aid (broad, and brittle if
+      Docker shifts CDNs again). Replace with an in-cluster `registry:2` configured
+      as a Docker Hub pull-through cache: transparent via the dind
+      `--registry-mirror` (Harbor's proxy-cache can't act as a root mirror, and
+      Harbor is currently down anyway), then drop the `*.cloudfront.net` allow.
+      Bonus: caching + Docker Hub rate-limit relief. Diagnosis: blob downloads were
+      dial-timing-out (`dial tcp <cloudfront-ip>:443: i/o timeout`) because only the
+      registry/auth FQDNs were allowlisted, not the blob CDN.
 - [ ] **Investigate whether to re-enable VPA/Goldilocks recommendations.**
       Forgejo's namespace is Goldilocks-enabled and has a generated
       `goldilocks-forgejo` VPA, but the VPA control-plane deployments in

--- a/cluster/k8s/haku-ci/networkpolicy.yaml
+++ b/cluster/k8s/haku-ci/networkpolicy.yaml
@@ -31,6 +31,16 @@ spec:
         - matchName: auth.docker.io
         - matchName: production.cloudflare.docker.com
         - matchName: index.docker.io
+        # Docker Hub 307-redirects image config + layer blob GETs to AWS
+        # CloudFront, so the manifest/auth hosts above aren't enough — without
+        # this, blob downloads dial-timeout and pulls fail with "No such image".
+        # matchPattern (not matchName) because the edge hostnames vary
+        # (server-<ip>.<pop>.r.cloudfront.net).
+        # TODO(haku-ci-pull-through-cache): replace this broad CDN allow with an
+        # in-cluster registry:2 Docker Hub pull-through cache (transparent via the
+        # dind --registry-mirror, which Harbor's proxy-cache can't provide, and
+        # Harbor is down anyway). Tracked in cluster/docs/plan.md.
+        - matchPattern: "*.cloudfront.net"
         - matchName: registry.npmjs.org
         - matchName: pypi.org
         - matchName: files.pythonhosted.org


### PR DESCRIPTION
## Problem

The haku-ci runner's dind fails to pull `docker:27-cli` — `docker create` errors with `No such image` because the pull silently fails. The agent suspected cilium/veth or rootless dind; the real cause is the **egress FQDN allowlist**.

## Diagnosis (from the live dind)

- DNS + manifest fetch from `registry-1.docker.io` work fine.
- Every **config/layer blob** download fails: `dial tcp 52.84.217.97:443: i/o timeout` (and other `52.84.x`/`108.138.x`/`3.169.x` IPs).
- Those IPs reverse-resolve to **AWS CloudFront** (`server-…r.cloudfront.net`) — Docker Hub 307-redirects blob GETs there.
- The policy allowlists `registry-1.docker.io`, `auth.docker.io`, `production.cloudflare.docker.com` (Cloudflare, `104.16.x` — a *different* CDN), `index.docker.io` — but **not CloudFront**, so Cilium drops the blob connections → dial timeout.

A dial timeout is a dropped SYN (policy/routing), not MTU (which would stall mid-transfer) and not rootless/veth (pod-level egress applies either way) — so switching to rootful docker would **not** have helped.

## Fix

Add `matchPattern: "*.cloudfront.net"` to the haku-ci egress `toFQDNs`.

Band-aid (broad CDN allow, brittle if Docker shifts CDNs). Tracked follow-up in `plan.md`: replace with an in-cluster `registry:2` Docker Hub pull-through cache — transparent via the dind `--registry-mirror` (Harbor's proxy-cache can't root-mirror, and Harbor is currently down).

## Verify after merge

Reconcile, then re-run the haku-ui build (or `docker pull docker:27-cli` from the haku-ci dind) — blob downloads should complete.