### PR TITLE
cluster/haku-ci: allow real Docker Hub blob host (cloudfront, not cloudflare)

### DIFF
--- a/cluster/docs/plan.md
+++ b/cluster/docs/plan.md
@@ -87,17 +87,17 @@ returns (not independently parked):
       `runnerPodTemplate`s) and the cross-repo augur ingest job; then the structural
       etcd-on-NVMe move. Full RCA + remediation tracking:
       <lessons_learned/2026_06_19_etcd_hdd_io_contention.md>.
-- [ ] **haku-ci Docker Hub pull-through cache** (replace the CloudFront egress
-      band-aid). The haku-ci runner's rootless dind pulls base images from Docker
-      Hub, which 307-redirects config/layer blob GETs to AWS CloudFront; the egress
-      policy now allows `*.cloudfront.net` as a band-aid (broad, and brittle if
-      Docker shifts CDNs again). Replace with an in-cluster `registry:2` configured
-      as a Docker Hub pull-through cache: transparent via the dind
-      `--registry-mirror` (Harbor's proxy-cache can't act as a root mirror, and
-      Harbor is currently down anyway), then drop the `*.cloudfront.net` allow.
-      Bonus: caching + Docker Hub rate-limit relief. Diagnosis: blob downloads were
-      dial-timing-out (`dial tcp <cloudfront-ip>:443: i/o timeout`) because only the
-      registry/auth FQDNs were allowlisted, not the blob CDN.
+- [ ] **haku-ci Docker Hub pull-through cache** (replace the external-CDN egress
+      allows). The haku-ci runner's rootless dind pulls base images from Docker
+      Hub, which 307-redirects config/layer blob GETs to `production.cloudfront.docker.com`
+      (AWS CloudFront). The egress policy now allowlists that host explicitly
+      (root cause was a `cloudflare` vs `cloudfront` hostname mix-up — only the
+      Cloudflare front was allowed). It works but couples the runner to Docker's
+      CDN hostnames. Replace with an in-cluster `registry:2` configured as a Docker
+      Hub pull-through cache: transparent via the dind `--registry-mirror` (Harbor's
+      proxy-cache can't act as a root mirror, and Harbor is currently down anyway),
+      then drop the docker.com CDN allows. Bonus: caching + Docker Hub rate-limit
+      relief.
 - [ ] **Investigate whether to re-enable VPA/Goldilocks recommendations.**
       Forgejo's namespace is Goldilocks-enabled and has a generated
       `goldilocks-forgejo` VPA, but the VPA control-plane deployments in

--- a/cluster/k8s/haku-ci/networkpolicy.yaml
+++ b/cluster/k8s/haku-ci/networkpolicy.yaml
@@ -29,18 +29,20 @@ spec:
         - matchName: pkg-containers.githubusercontent.com
         - matchName: registry-1.docker.io
         - matchName: auth.docker.io
-        - matchName: production.cloudflare.docker.com
         - matchName: index.docker.io
-        # Docker Hub 307-redirects image config + layer blob GETs to AWS
-        # CloudFront, so the manifest/auth hosts above aren't enough — without
-        # this, blob downloads dial-timeout and pulls fail with "No such image".
-        # matchPattern (not matchName) because the edge hostnames vary
-        # (server-<ip>.<pop>.r.cloudfront.net).
-        # TODO(haku-ci-pull-through-cache): replace this broad CDN allow with an
+        # Docker Hub 307-redirects image config + layer blob GETs to its CDN.
+        # Both fronts must be allowed: production.cloudFLARE.docker.com (above)
+        # AND production.cloudFRONT.docker.com (AWS CloudFront) — note the easily
+        # confused cloudflare/cloudfront pair. Without the CloudFront host, blob
+        # downloads dial-timeout and pulls fail with "No such image" while the
+        # manifest/auth hosts work fine (confirmed via Cilium's DNS cache:
+        # production.cloudfront.docker.com resolved to the timing-out IPs).
+        # TODO(haku-ci-pull-through-cache): drop these external CDN allows for an
         # in-cluster registry:2 Docker Hub pull-through cache (transparent via the
         # dind --registry-mirror, which Harbor's proxy-cache can't provide, and
         # Harbor is down anyway). Tracked in cluster/docs/plan.md.
-        - matchPattern: "*.cloudfront.net"
+        - matchName: production.cloudflare.docker.com
+        - matchName: production.cloudfront.docker.com
         - matchName: registry.npmjs.org
         - matchName: pypi.org
         - matchName: files.pythonhosted.org


### PR DESCRIPTION
Fixes the haku-ci dind pull failure for real. #2622's `*.cloudfront.net` was a no-op — Cilium FQDN policy matches the **queried DNS name**, not the resolved IP. The dind queries `production.cloud**front**.docker.com` for blobs (Cilium's DNS cache shows it resolving to the exact IPs dockerd dial-timed-out on), but only `production.cloud**flare**.docker.com` (a different CDN) was allowlisted — a cloudflare/cloudfront mix-up. Swap in the correct host. Verified post-merge by a clean `docker pull docker:27-cli` from the live dind.