### PR TITLE
cluster/haku-ci: allow data.forgejo.org (Forgejo default actions URL)

### DIFF
--- a/cluster/k8s/haku-ci/networkpolicy.yaml
+++ b/cluster/k8s/haku-ci/networkpolicy.yaml
@@ -48,6 +48,12 @@ spec:
         - matchName: files.pythonhosted.org
         # code.forgejo.org: the act_runner + forgejo job-container images.
         - matchName: code.forgejo.org
+        # data.forgejo.org: this Forgejo instance's default actions URL — the
+        # runner fetches `uses:` actions (actions/checkout, etc.) from here when
+        # they aren't hosted on the local instance. Without it, jobs fail at the
+        # action-download step (confirmed via Cilium's DNS cache: the runner
+        # connects to data.forgejo.org but it wasn't allowlisted).
+        - matchName: data.forgejo.org
       toPorts:
         - ports:
             - port: "443"


### PR DESCRIPTION
After the docker:27-cli pull fix (#2623), haku-ci jobs now reach the step-execution phase but fail fetching their `uses:` actions. The Forgejo instance's **default actions URL** is `data.forgejo.org` (the runner logs each task as `repo is haku/haku-state https://data.forgejo.org http://forgejo-http.forgejo:3000`), so `actions/checkout` etc. are pulled from there — but the egress allowlist only had `code.forgejo.org`. Cilium's DNS cache confirmed the runner connecting to `data.forgejo.org` (188.40.16.47) with no matching FQDN rule. Add it.