### PR TITLE
agent-box: fix first-boot sops ordering (linger + post-cloud-init re-apply)

### DIFF
--- a/cluster/k8s/agent-box/app/virtualmachine.yaml
+++ b/cluster/k8s/agent-box/app/virtualmachine.yaml
@@ -29,7 +29,7 @@ spec:
             # IMAGE_OUTPUT=agent-box-image). The VM boots straight into the real
             # config — no bootstrap + nixos-rebuild switch. cloud-init still
             # injects the persisted host key. Repin after rebuilding the image.
-            url: "https://s3.allegedly.works/vm-images/agent-box/5417c5d00a30f18c521b4b4f7c124cfe80d00e17.qcow2"
+            url: "https://s3.allegedly.works/vm-images/agent-box/6860a934a0ebae0c1b9cf96524b20250abd0eff4.qcow2"
             secretRef: agent-box-vm-images-s3-reader
         pvc:
           accessModes:

--- a/cluster/k8s/agent-box/app/virtualmachine.yaml
+++ b/cluster/k8s/agent-box/app/virtualmachine.yaml
@@ -29,7 +29,7 @@ spec:
             # IMAGE_OUTPUT=agent-box-image). The VM boots straight into the real
             # config — no bootstrap + nixos-rebuild switch. cloud-init still
             # injects the persisted host key. Repin after rebuilding the image.
-            url: "https://s3.allegedly.works/vm-images/agent-box/6860a934a0ebae0c1b9cf96524b20250abd0eff4.qcow2"
+            url: "https://s3.allegedly.works/vm-images/agent-box/766e7db396a5c0c182727cc7cbadb9292f1e2851.qcow2"
             secretRef: agent-box-vm-images-s3-reader
         pvc:
           accessModes:

--- a/cluster/k8s/agent-box/app/virtualmachine.yaml
+++ b/cluster/k8s/agent-box/app/virtualmachine.yaml
@@ -29,7 +29,7 @@ spec:
             # IMAGE_OUTPUT=agent-box-image). The VM boots straight into the real
             # config — no bootstrap + nixos-rebuild switch. cloud-init still
             # injects the persisted host key. Repin after rebuilding the image.
-            url: "https://s3.allegedly.works/vm-images/agent-box/e2c6c93a1a802d7bbc9381918e977243ba9caf86.qcow2"
+            url: "https://s3.allegedly.works/vm-images/agent-box/5417c5d00a30f18c521b4b4f7c124cfe80d00e17.qcow2"
             secretRef: agent-box-vm-images-s3-reader
         pvc:
           accessModes:

--- a/nix/nixos/hosts/agent-box/default.nix
+++ b/nix/nixos/hosts/agent-box/default.nix
@@ -6,6 +6,7 @@
 {
   pkgs,
   lib,
+  config,
   username,
   ...
 }:
@@ -90,6 +91,14 @@ in
     shell = pkgs.zsh;
     openssh.authorizedKeys.keys = loginKeys;
     extraGroups = [ "systemd-journal" ];
+    # home-manager installs the user-level sops secrets (BuildBuddy, Forgejo,
+    # attic) via the codex user's `sops-nix.service` systemd *user* unit. A
+    # headless, non-lingering user has no `systemd --user`, so that unit never
+    # starts and the secrets never land. Linger keeps the user manager up at boot.
+    # TODO(better): can home-manager sops install user secrets without a
+    #   lingering session (activation-time install, not a user service)? Linger
+    #   is a heavy hammer for "run one oneshot at boot".
+    linger = true;
   };
 
   users.users.root.openssh.authorizedKeys.keys = loginKeys;
@@ -100,6 +109,41 @@ in
     }
   ];
   services.openssh.settings.PermitRootLogin = lib.mkForce "prohibit-password";
+
+  # First-boot ordering fix (ugly but localized). On a cold first boot the boot
+  # order is: sops-install-secrets (early, sysinit) → cloud-init writes the
+  # persisted host key (later, cloud-config stage) → sshd. So system sops runs
+  # before the host key exists and can't decrypt codex_id_ed25519; the user-level
+  # sops then has no age key either. Once cloud-init has settled, re-apply both:
+  # restart system sops (plants id_ed25519, host key now present), then re-run
+  # home-manager (which restarts the codex user's sops-nix.service → user
+  # secrets). Idempotent: on a reboot the host key is already persisted, system
+  # sops succeeds early, and these restarts are no-ops.
+  #
+  # TODO(better): this re-run is a workaround for sops-runs-early vs
+  #   cloud-init-writes-host-key-late. Cleaner options to evaluate:
+  #   (a) deliver the host key *before* sysinit (cloud-init `bootcmd` in the
+  #       cloud-init-local stage, or an initrd write) so system sops decrypts on
+  #       the first try and no re-run is needed;
+  #   (b) a sops-nix option to defer secret install past cloud-init without the
+  #       Before=sysinit ordering cycle;
+  #   (c) accept bootstrap+switch for hosts that need sops at first boot.
+  #   See plans/agent-box.md and the boot-ordering discussion.
+  systemd.services.agent-box-secrets-after-cloud-init = {
+    description = "Re-apply sops secrets after cloud-init persisted the host key (first-boot race)";
+    after = [
+      "cloud-final.service"
+      "home-manager-${username}.service"
+    ];
+    wants = [ "cloud-final.service" ];
+    wantedBy = [ "multi-user.target" ];
+    path = [ config.systemd.package ];
+    serviceConfig.Type = "oneshot";
+    script = ''
+      systemctl restart sops-install-secrets.service
+      systemctl restart home-manager-${username}.service
+    '';
+  };
 
   users.motd = "agent-box - headless KubeVirt agent VM (codex user: OpenAI Codex)\n";
 }

--- a/plans/agent-box.md
+++ b/plans/agent-box.md
@@ -73,6 +73,28 @@ You log in _as_ codex with your personal keys (in `authorizedKeys`); the
 - No GitHub identity for codex in v1 (Forgejo-primary). The existing `agentydragon-agent`
   machine user already gets PR-but-not-push for free via the GitHub ruleset if wired later.
 
+## First-boot secret ordering (known-ugly, works)
+
+Direct-boot images have a first-boot race that bootstrap+switch never hits (gecko's sops
+runs at `nixos-rebuild switch`, long after cloud-init). Two bugs, both fixed in
+`nix/nixos/hosts/agent-box/default.nix` with localized workarounds:
+
+1. **system sops vs cloud-init**: `sops-install-secrets` runs early (sysinit) but
+   cloud-init writes the persisted host key late (cloud-config stage), so the first-boot
+   sops can't decrypt `codex_id_ed25519`. Worked around by a `oneshot` after
+   `cloud-final.service` that restarts sops + home-manager.
+2. **headless home-manager sops**: the user-level secrets install via the codex user's
+   `sops-nix.service` (a `systemd --user` unit), which never starts without a session.
+   Worked around with `users.users.codex.linger = true`.
+
+**TODOs — do better:**
+
+- Deliver the host key _before_ sysinit (cloud-init `bootcmd` in the `cloud-init-local`
+  stage, or initrd) so system sops decrypts on the first try — removes the re-run oneshot.
+- Find a way for home-manager sops to install user secrets without a lingering session
+  (activation-time install rather than a user service), so `linger` isn't needed.
+- Or decide direct-boot isn't worth it for sops-bearing hosts and use bootstrap+switch.
+
 ## Future
 
 - **More agent users on agent-box**: `claude`, `z-claude` — each with its own login keys,


### PR DESCRIPTION
Fixes the two first-boot secret-ordering bugs found while verifying the direct-boot agent-box image (follow-up to #2607/#2610/#2617).

**Bug 1 — system sops vs cloud-init.** `sops-install-secrets` runs early (sysinit); cloud-init writes the persisted host key in its later config stage. On a cold first boot system sops can't decrypt `codex_id_ed25519` (host key absent). Confirmed: a reboot (key already persisted) fixed it.

**Bug 2 — headless home-manager sops.** The user-level secrets (BuildBuddy, Forgejo, attic) install via the codex user's `sops-nix.service` *systemd --user* unit, which never starts for a headless non-lingering user. Confirmed: manually linking+starting that unit (with `id_ed25519` present) installed buildbuddy+forgejo.

**Fix (localized to the agent-box host config):**
- `users.users.codex.linger = true` — user systemd runs at boot, so HM sops runs.
- a `oneshot` after `cloud-final.service` restarts system sops (host key now present) then home-manager (re-runs user sops) — so a *cold* first boot lands all secrets without a manual reboot. Idempotent.

Ugly-but-localized; TODOs in the host config + `plans/agent-box.md` track cleaner directions (deliver host key pre-sysinit; headless HM sops without linger; or bootstrap+switch). Repins the DataVolume to the rebuilt image (`agent-box/766e7db…`, attic-substituted, contains the fix).

After merge: recreate + verify a clean first boot.