### PR TITLE
bbapi: repin BuildBuddy protos, tolerate unknown fields, add `execution files`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1053,6 +1053,7 @@ use_repo(
     "com_github_blacktop_go_macho",
     "com_github_cheynewallace_tabby",
     "com_github_docker_docker",
+    "com_github_dustin_go_humanize",
     "com_github_elliotchance_orderedmap",
     "com_github_firebase_genkit_go",
     "com_github_fsouza_go_dockerclient",

--- a/devinfra/buildbuddy_cli/BUILD.bazel
+++ b/devinfra/buildbuddy_cli/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "@buildbuddy_protos//:suggestion_go_proto",
         "@buildbuddy_protos//:target_go_proto",
         "@buildbuddy_protos//:workflow_go_proto",
+        "@com_github_dustin_go_humanize//:go-humanize",
         "@com_github_go_git_go_git_v5//:go-git",
         "@com_github_spf13_cobra//:cobra",
         "@org_golang_google_protobuf//encoding/protojson",

--- a/devinfra/buildbuddy_cli/client.go
+++ b/devinfra/buildbuddy_cli/client.go
@@ -65,10 +65,19 @@ func (c *client) call(method string, req proto.Message, resp proto.Message) erro
 	if httpResp.StatusCode != http.StatusOK {
 		return fmt.Errorf("HTTP %d: %s", httpResp.StatusCode, string(respBody))
 	}
-	if err := protojson.Unmarshal(respBody, resp); err != nil {
+	if err := unmarshalJSON(respBody, resp); err != nil {
 		return fmt.Errorf("unmarshal response: %w", err)
 	}
 	return nil
+}
+
+// unmarshalJSON parses a proto JSON message while discarding fields unknown to
+// our pinned protos, so a newer BuildBuddy API or BES response doesn't
+// hard-fail the parse. bbapi only reads named fields, so unknown ones are safe
+// to drop; repinning keeps the schema current, and this guards against drift
+// between repins (e.g. an invocation-link-type field added after the last pin).
+func unmarshalJSON(b []byte, m proto.Message) error {
+	return protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(b, m)
 }
 
 // resolveGroupID fetches the group_id by searching for a recent invocation

--- a/devinfra/buildbuddy_cli/cmd_artifact.go
+++ b/devinfra/buildbuddy_cli/cmd_artifact.go
@@ -10,7 +10,6 @@ import (
 
 	bespb "github.com/buildbuddy-io/buildbuddy/proto/build_event_stream"
 	"github.com/spf13/cobra"
-	"google.golang.org/protobuf/encoding/protojson"
 )
 
 // matchGlob reports whether s matches a simple glob pattern supporting '*' only.
@@ -348,7 +347,7 @@ func listArtifacts(c *client, invocationID string) ([]artifact, error) {
 	var result []artifact
 	for _, raw := range rawEvents {
 		var ev bespb.BuildEvent
-		if err := protojson.Unmarshal(raw, &ev); err != nil {
+		if err := unmarshalJSON(raw, &ev); err != nil {
 			return nil, fmt.Errorf("parse BES event: %w", err)
 		}
 		tr := ev.GetTestResult()

--- a/devinfra/buildbuddy_cli/cmd_execution.go
+++ b/devinfra/buildbuddy_cli/cmd_execution.go
@@ -3,8 +3,10 @@ package main
 import (
 	"fmt"
 
+	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 
+	cachepb "github.com/buildbuddy-io/buildbuddy/proto/cache"
 	executionpb "github.com/buildbuddy-io/buildbuddy/proto/execution_stats"
 )
 
@@ -44,6 +46,7 @@ func executionCmd() *cobra.Command {
 		},
 	}
 	cmd.AddCommand(executionSearchCmd())
+	cmd.AddCommand(executionFilesCmd())
 	return cmd
 }
 
@@ -94,5 +97,58 @@ func executionSearchCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&repo, "repo", "", "Repository URL (default: auto-detect from git)")
 	cmd.Flags().Int32Var(&count, "count", 20, "Number of results to return")
+	return cmd
+}
+
+func executionFilesCmd() *cobra.Command {
+	var pageSize int32
+	cmd := &cobra.Command{
+		Use:   "files <invocation-id> <execution-id>",
+		Short: "List a remote execution's output files",
+		Long: "List the output files of a remote execution via GetExecutionDownloads. " +
+			"The execution ID is the one shown by `bbapi execution <invocation-id>`.",
+		Args: cobra.ExactArgs(2),
+		RunE: func(_ *cobra.Command, args []string) error {
+			c, err := newClient()
+			if err != nil {
+				return err
+			}
+			out := &cachepb.GetExecutionDownloadsResponse{}
+			var pageToken string
+			for i := 0; i < 100; i++ { // bound pagination as a safety cap
+				req := &cachepb.GetExecutionDownloadsRequest{
+					InvocationId: args[0],
+					ExecutionId:  args[1],
+					PageSize:     pageSize,
+					PageToken:    pageToken,
+				}
+				resp := &cachepb.GetExecutionDownloadsResponse{}
+				if err := c.call("GetExecutionDownloads", req, resp); err != nil {
+					return err
+				}
+				out.Downloads = append(out.Downloads, resp.GetDownloads()...)
+				pageToken = resp.GetNextPageToken()
+				if pageToken == "" {
+					break
+				}
+			}
+			if jsonOutput {
+				return printProtoJSON(out)
+			}
+			t := newTable()
+			t.header("PATH", "SIZE", "EXEC", "DIGEST")
+			for _, dl := range out.GetDownloads() {
+				exec := ""
+				if dl.GetIsExecutable() {
+					exec = "x"
+				}
+				dg := dl.GetDigest()
+				t.row(dl.GetPath(), humanize.IBytes(uint64(dg.GetSizeBytes())), exec, dg.GetHash())
+			}
+			t.flush()
+			return nil
+		},
+	}
+	cmd.Flags().Int32Var(&pageSize, "page-size", 0, "Results per page (0 = server default)")
 	return cmd
 }

--- a/devinfra/buildbuddy_cli/cmd_tool_log.go
+++ b/devinfra/buildbuddy_cli/cmd_tool_log.go
@@ -11,7 +11,6 @@ import (
 
 	bespb "github.com/buildbuddy-io/buildbuddy/proto/build_event_stream"
 	"github.com/spf13/cobra"
-	"google.golang.org/protobuf/encoding/protojson"
 )
 
 type toolLog struct {
@@ -250,7 +249,7 @@ func listToolLogs(c *client, invocationID string) ([]toolLog, error) {
 	var result []toolLog
 	for _, raw := range rawEvents {
 		var ev bespb.BuildEvent
-		if err := protojson.Unmarshal(raw, &ev); err != nil {
+		if err := unmarshalJSON(raw, &ev); err != nil {
 			return nil, fmt.Errorf("parse BES event: %w", err)
 		}
 		logs := ev.GetBuildToolLogs()

--- a/devinfra/buildbuddy_cli/skills/buildbuddy_api/SKILL.md
+++ b/devinfra/buildbuddy_cli/skills/buildbuddy_api/SKILL.md
@@ -91,6 +91,10 @@ bbapi execution <invocation-id>
 # Search remote executions across invocations
 bbapi execution search <query>
 
+# List the output files of a remote execution (path, size, digest, exec bit)
+# The execution-id is the EXECUTION column from `bbapi execution <invocation-id>`
+bbapi execution files <invocation-id> <execution-id>
+
 # Aggregated invocation statistics (by branch, user, commit, etc.)
 bbapi invocation stat [--agg-type branch|user|host|repo|commit|pattern] [--repo URL] [--limit N]
 
@@ -117,6 +121,10 @@ bbapi trend [--days N] [--repo URL]
 ```
 
 All `bbapi` commands support `--json` for raw JSON output.
+
+Responses are parsed against pinned BuildBuddy protos but unknown fields are
+discarded, so `bbapi` tolerates API/proto drift between repins (newly added
+response fields) instead of hard-failing on the parse.
 
 ## Investigating Failed CI Builds
 

--- a/third_party/buildbuddy/buildbuddy_protos.bzl
+++ b/third_party/buildbuddy/buildbuddy_protos.bzl
@@ -2,14 +2,14 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-_COMMIT = "1222e417a7c36619102ea9436fc35045ce5f421e"
+_COMMIT = "a07198b9707dc26cbce3827d807da6854a978638"
 _PREFIX = "buildbuddy-" + _COMMIT
 
 def _buildbuddy_protos_impl(_ctx):
     http_archive(
         name = "buildbuddy_protos",
         url = "https://github.com/buildbuddy-io/buildbuddy/archive/{}.tar.gz".format(_COMMIT),
-        integrity = "sha256-CszZEJ3TfXIKSGhVeEns4r8DRYzEkn8KQXxwxXNy6ZA=",
+        integrity = "sha256-QCziTN+n9maFiVJD18q73gcJiwnti5gtaOBtCJIZX1o=",
         strip_prefix = _PREFIX,
         build_file = "//third_party/buildbuddy:BUILD.protos.bazel",
         patch_cmds = [

--- a/third_party/go.mod
+++ b/third_party/go.mod
@@ -82,6 +82,7 @@ require (
 	github.com/cheynewallace/tabby v1.1.1 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/cyphar/filepath-securejoin v0.6.1 // indirect
+	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/elliotchance/orderedmap v1.4.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect


### PR DESCRIPTION
## Problem

`bbapi` strict-unmarshals API responses into the pinned BuildBuddy protos. Any field added upstream after the last pin hard-fails the parse — notably `invocation_link_type` on `StoredExecution` (`remote_execution`/`execution_stats`), which made `bbapi execution` / `bbapi invocation` fail while raw curl → JSON worked fine.

## Changes

- **Repin** `@buildbuddy_protos` `1222e417` → `a07198b9` (2026-06-26). The protos `bbapi` actually consumes (`cache`, `remote_execution`, `execution_stats`, …) gained only scalar fields and **no new imports** since the old pin, so the `BUILD.protos.bazel` overlay needs no changes. (`patch_cmds` vtproto stripping still matches upstream.)
- **Root-cause fix**: parse RPC responses and BES event streams with `protojson` `DiscardUnknown`, so future API/proto drift no longer breaks the CLI between repins. (Hoisted into a small `unmarshalJSON` helper; the Go parser can't take a composite literal directly in an `if` init.)
- **New feature**: `bbapi execution files <invocation-id> <execution-id>` (`GetExecutionDownloads`) lists a remote execution's output files (path, humanized size, digest, exec bit), paginated. Uses `dustin/go-humanize` (already a transitive dep — added explicitly to `go.mod`/`MODULE.bazel` `use_repo`, same as the other BUILD-file-only deps).

## Validation

- `bbr build` + `bbr test` for `//devinfra/buildbuddy_cli:bbapi` (+ `bbapi_test`) — green
- `bbr build //devinfra/precommit:commit_tag` (the other `@buildbuddy_protos` consumer, Python side) — green
- gazelle `--mode=diff` — no BUILD drift (only the documented benign `bazel mod tidy` warning for BUILD-file-only deps)
- pre-commit (buildifier, gofumpt, prettier, …) — green
- Live: `bbapi invocation`, `bbapi execution`, and the new `bbapi execution files` all run against the real API without hard-failing

## Out of scope

The unconsumed `@buildbuddy_protos` targets (`buildbuddy_service_proto` + its exclusive deps incl. `search`) were **already broken** at the old pin — `search.proto` imports Kythe protos that aren't vendored — and no target in the repo builds them (`//…` doesn't build external-repo orphans). They are left untouched here; trimming the overlay to the consumed set would be a separate cleanup.