### PR TITLE
haku/console: move note-to-haku into a floating corner button

### DIFF
--- a/haku/console/debug/esbuild_tabler_memory.md
+++ b/haku/console/debug/esbuild_tabler_memory.md
@@ -1,0 +1,135 @@
+# haku/console frontend bundle: esbuild OOMs the @tabler/icons-react barrel
+
+Status: **resolved — landed the deep per-icon import (no RAM override needed).**
+The barrel's ~8.7 GB esbuild peak has no clean per-action RAM lever (only
+platform-global works — see below), so `feedback.tsx` imports `IconMessage2` by
+subpath (`dist/esm/icons/IconMessage2.mjs`, default export), which esbuild
+processes in ~tens of MB. The subpath ships no types, so an ambient declaration in
+`tabler-icons.d.ts` types it for `tsc_test`. The investigation/memory notes below
+are retained for the next time a `@tabler` barrel import tempts someone.
+
+The SPA bundle `//haku/console/frontend:bundle` OOMs esbuild on BuildBuddy RBE
+whenever `feedback.tsx` imports from the `@tabler/icons-react` _barrel_
+(`import { IconMessage2 } from "@tabler/icons-react"`). Investigation notes
+below. BuildBuddy source referenced from a clone at `~/code/buildbuddy`.
+
+## Symptom
+
+```
+Splitting Javascript .../main.tsx [esbuild] failed: (Exit 1): launcher failed:
+error executing esbuild command ... Error: The service was stopped
+  at .../esbuild@0.19.9/.../esbuild/lib/main.js:1083:25
+```
+
+Fails after ~95–140s of critical path. esbuild 0.19.9 (pinned via rules_esbuild).
+
+## Confirmed: it's an OOM-kill, and esbuild needs ~1 GB (not multi-GB)
+
+Reproduced locally under a memory cgroup (`systemd-run --user --scope -p MemoryMax=…`)
+with the exact esbuild 0.19.9 native binary, bundling an isolated
+`import { IconMessage2 } from "@tabler/icons-react"`:
+
+| `MemoryMax` | result                                                     |
+| ----------- | ---------------------------------------------------------- |
+| 400 M       | esbuild **exit 137** (SIGKILL = "The service was stopped") |
+| 1 G         | ✅ succeeds                                                |
+
+Peak RSS measurements (native esbuild, `/proc/<pid>/status` VmHWM):
+
+- Isolated `@tabler` barrel (one icon): **~543 MB**.
+- Full app `main.tsx` standalone (top-level pnpm deps only — a SUBSET): peaked
+  ~1008 MB before bailing on an unresolved `@mantine/notifications` import.
+- **Actual on RBE (authoritative):** `usageStats.peakMemoryBytes` for the esbuild
+  action = **8741 MB (~8.5 GiB)** — read from the execution metadata via
+  `GetExecution` (raw curl; `bbapi execution` has a proto-version mismatch on
+  `invocationLinkType`, but raw JSON is fine).
+
+The local ~1 GB figure was a **subset** (only top-level pnpm deps resolved). The
+full rules_js `node_modules` tree (all transitive deps of the `@tabler` barrel +
+Mantine + everything) makes esbuild process ~9× more → **8.7 GB peak**. The exact
+bazel action args (`bundle_esbuild.args.json`) confirm **no `--splitting`**, so
+metafile/minify don't change this.
+
+## The BuildBuddy memory mechanism (traced in source)
+
+The firecracker microVM RAM is the ceiling (cgroup hard-limit is OFF by default:
+`ociruntime/ociruntime.go:92` `executor.oci.enable_cgroup_memory_limit=false`):
+
+- `firecracker.go:598` → `MemSizeMb = TaskSize.EstimatedMemoryBytes / 1e6`.
+- `effectiveSize = getMostAccurateTaskSize` (`scheduler_server.go:520`):
+  **Measured → Predicted → naive**, where **Measured is disabled for Firecracker**
+  (`tasksize/tasksize.go:178`).
+- The naive base = `Override(Default, Requested)` (`execution_server.go:966`) — so
+  exec_properties **are** applied to the base size. `Default` for our platform
+  (`tasksize.go:Default`) = `400 MB` + `200 MB` (firecracker) + `800 MB`
+  (init-dockerd) ≈ **1.4 GB**, shared with dockerd/node/OS.
+- The **ML model predictor can override** the requested size (Predicted > naive).
+  Disable with exec_property `debug-disable-predicted-task-size=true`
+  (`server/util/platform/platform.go:97`, `tasksize_model.go:203`).
+- **GOTCHA:** the memory exec_property key is `EstimatedMemory`
+  (`platform.go:171`), **not** `EstimatedMemoryBytes`. (Disk is `EstimatedFreeDiskBytes`,
+  CPU is `EstimatedComputeUnits`; memory is the odd one out.)
+
+## RBE experiments — the override DOES work; esbuild just needs 8.7 GB
+
+| change                                                                     | result                                                  |
+| -------------------------------------------------------------------------- | ------------------------------------------------------- |
+| platform `EstimatedMemoryBytes=8GB` (**wrong key**)                        | OOM (key unrecognized — no effect)                      |
+| platform `EstimatedMemory=8GB` + `debug-disable-predicted-task-size=true`  | esbuild peaked **8741 MB**, OOM (8 GB short by ~0.7 GB) |
+| platform `EstimatedMemory=16GB` + `debug-disable-predicted-task-size=true` | ✅ **builds + all tests pass**                          |
+
+The override (correct key `EstimatedMemory` + disable the model so the request
+wins) reaches the VM — proven by the 8741 MB peak (impossible on the ~1.4 GB
+default). It just had to exceed esbuild's 8.7 GB need.
+
+Note: action-level exec_properties via `--modify_execution_info` do **not** reach
+the memory sizing — confirmed empirically: a fresh (`--noremote_accept_cached`)
+run with `--modify_execution_info=esbuild=+EstimatedMemory=16GB
++debug-disable-predicted-task-size=true` still OOM'd (esbuild capped at the
+model's ~7.6 GB default prediction). Only **platform** `exec_properties` flow into
+the memory sizing BuildBuddy uses. Combined with `rules_esbuild`'s `esbuild()`
+not exposing an `exec_properties` attr (per-target), the override **cannot** be
+scoped to the esbuild action or mnemonic — only platform-global.
+
+The Bazel `modify_execution_info` comma-combined form (`+a=1,+b=2`) is also
+rejected as "malformed"; use two separate flags (both parse fine) — but they still
+don't reach memory.
+
+## Why per-target / per-mnemonic is blocked (tried all three)
+
+1. **`--modify_execution_info` (per-mnemonic):** doesn't reach BuildBuddy's memory
+   sizing (see above) — fresh 16 GB mnemonic-scoped run still OOM'd.
+2. **Patch `rules_esbuild` + forward to `ctx.actions.run`:** `ctx.actions.run()`
+   has **no `exec_properties` parameter** in this Bazel version
+   (`run() got unexpected keyword argument 'exec_properties'`).
+3. **Use the built-in `exec_properties` rule attr** (it IS built-in — declaring a
+   custom one named `exec_properties` fails as "built-in attributes cannot be
+   overridden"): setting it on the bundle target forwards to the action, **but**
+   triggers a Bazel action conflict — `main.tsx`'s `copy_to_bin` action is
+   generated under two exec configs (bundle_esbuild with the override vs `tsc_test`
+   without), producing "file main.tsx is generated by these conflicting actions."
+
+So per-target override is genuinely blocked by Bazel/BuildBuddy mechanics; the
+barrel works only via the platform-global override.
+
+## Caveat: the working config is global
+
+Setting `EstimatedMemory=16GB` + `debug-disable-predicted-task-size=true` on the
+`rbe_linux_x64` platform makes **every** RBE action claim 16 GB and disables the
+task-size model for all of them. That hurts CI (16 GB/action caps concurrency;
+no model right-sizing). It works for this one esbuild action but is a blunt
+instrument.
+
+## Alternatives (avoid the global cost)
+
+- **Deep per-icon import** (`@tabler/icons-react/dist/esm/icons/IconMessage2.mjs`):
+  esbuild processes one icon (~tens of MB), fits the default VM, no platform change.
+  Needs a small ambient `declare module` for tsc (no `.d.mts` for the subpath).
+  This is what `x/rspcache/admin_ui` does (it has no tsc gate).
+- **Inline SVG**: drop `@tabler`; render the message-2 paths inline. No dependency,
+  no RAM issue, passes esbuild + tsc.
+
+## Artifacts
+
+- esbuild 0.19.9 native binary fetched to `/tmp/claude/esbuild-mem/package/bin/esbuild`.
+- BuildBuddy source cloned to `/home/agentydragon/code/buildbuddy`.

--- a/haku/console/frontend/BUILD.bazel
+++ b/haku/console/frontend/BUILD.bazel
@@ -15,11 +15,6 @@ js_openapi_schema(
 )
 
 js_library(
-    name = "constants",
-    srcs = ["constants.ts"],
-)
-
-js_library(
     name = "client",
     srcs = ["client.ts"],
     deps = [
@@ -57,6 +52,7 @@ js_library(
         ":theme",
         ":toast",
         "//:node_modules/@mantine/core",
+        "//:node_modules/@tabler/icons-react",
         "//:node_modules/react",
     ],
 )
@@ -105,7 +101,6 @@ js_library(
     deps = [
         ":assets",
         ":client",
-        ":constants",
         ":feedback",
         ":haku_ui_embed",
         ":launch",
@@ -137,7 +132,6 @@ filegroup(
         "assets.ts",
         "client.ts",
         "confirm_dialog.tsx",
-        "constants.ts",
         "feedback.tsx",
         "haku_ui_embed.tsx",
         "index.html",
@@ -209,6 +203,7 @@ tsc_bin.tsc_test(
     chdir = package_name(),
     data = [
         "bridge.test.ts",
+        "tabler-icons.d.ts",
         "tsconfig.json",
         ":main_lib",
         ":schema",

--- a/haku/console/frontend/app.tsx
+++ b/haku/console/frontend/app.tsx
@@ -1,10 +1,9 @@
 import { useEffect, useState } from "react";
-import { Anchor, Group, Loader, Text, Title } from "@mantine/core";
+import { Group, Loader, Text, Title } from "@mantine/core";
 
 import { LOGO_URL } from "./assets.ts";
 import { type ConfigResponse, fetchConfig } from "./client.ts";
-import { INTAKE_NEW } from "./constants.ts";
-import { FeedbackForm } from "./feedback.tsx";
+import { FeedbackFab } from "./feedback.tsx";
 import { HakuUiEmbed } from "./haku_ui_embed.tsx";
 import { LaunchRoutineButton } from "./launch.tsx";
 import { toastError } from "./toast.ts";
@@ -52,31 +51,10 @@ export default function App() {
         </Group>
         <LaunchRoutineButton routineUrl={config.launch_routine_url} />
       </Group>
-      <Text c="dimmed" mb="xl">
-        <Anchor href={INTAKE_NEW} c="dimmed" underline="always">
-          + Add intake note
-        </Anchor>
-      </Text>
+      {/* The Free-form UI is the main surface; the note-to-haku form opens from the corner button. */}
+      {config.haku_ui_url && <HakuUiEmbed uiUrl={config.haku_ui_url} />}
 
-      <section>
-        <Title order={2} mb="sm">
-          Note to Haku
-        </Title>
-        <FeedbackForm
-          minRows={3}
-          placeholder="Anything for Haku to fold into its next run…"
-          submitLabel="Send to Haku"
-        />
-      </section>
-
-      {config.haku_ui_url && (
-        <section className="mt-10">
-          <Title order={2} mb="sm">
-            Free-form UI
-          </Title>
-          <HakuUiEmbed uiUrl={config.haku_ui_url} />
-        </section>
-      )}
+      <FeedbackFab />
     </div>
   );
 }

--- a/haku/console/frontend/app.tsx
+++ b/haku/console/frontend/app.tsx
@@ -43,18 +43,21 @@ export default function App() {
     );
 
   return (
-    <div className="mx-auto max-w-3xl px-4 py-8">
-      <Group justify="space-between" align="center" mb="xs">
-        <Group gap="sm" align="center">
-          <img src={LOGO_URL} alt="" aria-hidden="true" className="h-10 w-10 shrink-0" />
-          <Title order={1}>Haku</Title>
+    <>
+      <div className="mx-auto max-w-3xl px-4 py-8">
+        <Group justify="space-between" align="center" mb="xs">
+          <Group gap="sm" align="center">
+            <img src={LOGO_URL} alt="" aria-hidden="true" className="h-10 w-10 shrink-0" />
+            <Title order={1}>Haku</Title>
+          </Group>
+          <LaunchRoutineButton routineUrl={config.launch_routine_url} />
         </Group>
-        <LaunchRoutineButton routineUrl={config.launch_routine_url} />
-      </Group>
-      {/* The Free-form UI is the main surface; the note-to-haku form opens from the corner button. */}
-      {config.haku_ui_url && <HakuUiEmbed uiUrl={config.haku_ui_url} />}
+        {/* The Free-form UI is the main surface; the note-to-haku form opens from the corner button. */}
+        {config.haku_ui_url && <HakuUiEmbed uiUrl={config.haku_ui_url} />}
+      </div>
 
+      {/* Viewport-pinned (not inside the centered content column); see FeedbackFab. */}
       <FeedbackFab />
-    </div>
+    </>
   );
 }

--- a/haku/console/frontend/constants.ts
+++ b/haku/console/frontend/constants.ts
@@ -1,3 +1,0 @@
-// Public Forgejo web URL for the browser-facing "Add intake note" link.
-export const FORGEJO = "https://git.allegedly.works/haku/haku-state";
-export const INTAKE_NEW = `${FORGEJO}/_new/main/intake/`;

--- a/haku/console/frontend/feedback.tsx
+++ b/haku/console/frontend/feedback.tsx
@@ -1,5 +1,10 @@
 import { type FormEvent, type KeyboardEvent, useState } from "react";
-import { Button, Text, Textarea } from "@mantine/core";
+import { ActionIcon, Button, Popover, Text, Textarea } from "@mantine/core";
+// Deep per-icon import (default export), not the barrel: the @tabler barrel makes
+// esbuild OOM tree-shaking it (~8.7 GB peak with the full node_modules tree), and
+// there's no clean per-action RAM lever (see debug/esbuild_tabler_memory.md). The
+// subpath ships no .d.mts, so it's typed via tabler-icons.d.ts.
+import IconMessage2 from "@tabler/icons-react/dist/esm/icons/IconMessage2.mjs";
 
 import { postTrace } from "./client.ts";
 import { ACTION_COLOR } from "./theme.ts";
@@ -101,5 +106,38 @@ export function FeedbackForm({ minRows, placeholder, submitLabel }: FeedbackForm
         </Text>
       </div>
     </form>
+  );
+}
+
+// Floating corner button that pops the note-to-haku form open as a popover, so the
+// form is an on-demand affordance instead of permanent real estate at the top of the
+// page. The form itself (FeedbackForm above) is unchanged; this only owns open/close
+// state and frames it. The popover closes on outside-click / Esc (Mantine defaults);
+// a successful send leaves it open showing "Sent ✓" rather than auto-closing, since
+// closing would hide the only success signal (there is no success toast).
+export function FeedbackFab() {
+  const [open, setOpen] = useState(false);
+  return (
+    <Popover opened={open} onChange={setOpen} position="top-end" withArrow shadow="md" width={360}>
+      <Popover.Target>
+        <ActionIcon
+          color={ACTION_COLOR}
+          variant="filled"
+          size="xl"
+          radius="xl"
+          aria-label="Note to Haku"
+          className="fixed bottom-6 right-6 z-50 shadow-lg"
+        >
+          <IconMessage2 size={20} />
+        </ActionIcon>
+      </Popover.Target>
+      <Popover.Dropdown>
+        <FeedbackForm
+          minRows={4}
+          placeholder="Anything for Haku to fold into its next run…"
+          submitLabel="Send to Haku"
+        />
+      </Popover.Dropdown>
+    </Popover>
   );
 }

--- a/haku/console/frontend/feedback.tsx
+++ b/haku/console/frontend/feedback.tsx
@@ -118,26 +118,25 @@ export function FeedbackForm({ minRows, placeholder, submitLabel }: FeedbackForm
 export function FeedbackFab() {
   const [open, setOpen] = useState(false);
   return (
-    <Popover opened={open} onChange={setOpen} position="top-end" withArrow shadow="md" width={360}>
-      <Popover.Target>
-        <ActionIcon
-          color={ACTION_COLOR}
-          variant="filled"
-          size="xl"
-          radius="xl"
-          aria-label="Note to Haku"
-          className="fixed bottom-6 right-6 z-50 shadow-lg"
-        >
-          <IconMessage2 size={20} />
-        </ActionIcon>
-      </Popover.Target>
-      <Popover.Dropdown>
-        <FeedbackForm
-          minRows={4}
-          placeholder="Anything for Haku to fold into its next run…"
-          submitLabel="Send to Haku"
-        />
-      </Popover.Dropdown>
-    </Popover>
+    // Fixed to the viewport (not the centered content column) so the button stays
+    // pinned bottom-right regardless of scroll. A plain div carries the fixed
+    // positioning so no Mantine component styles can override it; the Popover's
+    // dropdown is portaled to <body> and still anchors to the ActionIcon.
+    <div className="fixed bottom-6 right-6 z-50">
+      <Popover opened={open} onChange={setOpen} position="top-end" withArrow shadow="md" width={360}>
+        <Popover.Target>
+          <ActionIcon color={ACTION_COLOR} variant="filled" size="xl" radius="xl" aria-label="Note to Haku">
+            <IconMessage2 size={20} />
+          </ActionIcon>
+        </Popover.Target>
+        <Popover.Dropdown>
+          <FeedbackForm
+            minRows={4}
+            placeholder="Anything for Haku to fold into its next run…"
+            submitLabel="Send to Haku"
+          />
+        </Popover.Dropdown>
+      </Popover>
+    </div>
   );
 }

--- a/haku/console/frontend/feedback.tsx
+++ b/haku/console/frontend/feedback.tsx
@@ -1,5 +1,5 @@
-import { type FormEvent, type KeyboardEvent, useState } from "react";
-import { ActionIcon, Button, Popover, Text, Textarea } from "@mantine/core";
+import { type FormEvent, type KeyboardEvent, useEffect, useRef, useState } from "react";
+import { ActionIcon, Button, Text, Textarea } from "@mantine/core";
 // Deep per-icon import (default export), not the barrel: the @tabler barrel makes
 // esbuild OOM tree-shaking it (~8.7 GB peak with the full node_modules tree), and
 // there's no clean per-action RAM lever (see debug/esbuild_tabler_memory.md). The
@@ -117,26 +117,52 @@ export function FeedbackForm({ minRows, placeholder, submitLabel }: FeedbackForm
 // closing would hide the only success signal (there is no success toast).
 export function FeedbackFab() {
   const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside click / Esc. Done by hand (not Mantine Popover) because the
+  // button is position:fixed and Mantine's Floating-UI portal mis-anchored the
+  // dropdown to it — an explicit toggle + absolutely-positioned panel is reliable.
+  useEffect(() => {
+    if (!open) return;
+    function onPointerDown(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) setOpen(false);
+    }
+    function onKey(e: globalThis.KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", onPointerDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onPointerDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
   return (
     // Fixed to the viewport (not the centered content column) so the button stays
-    // pinned bottom-right regardless of scroll. A plain div carries the fixed
-    // positioning so no Mantine component styles can override it; the Popover's
-    // dropdown is portaled to <body> and still anchors to the ActionIcon.
-    <div className="fixed bottom-6 right-6 z-50">
-      <Popover opened={open} onChange={setOpen} position="top-end" withArrow shadow="md" width={360}>
-        <Popover.Target>
-          <ActionIcon color={ACTION_COLOR} variant="filled" size="xl" radius="xl" aria-label="Note to Haku">
-            <IconMessage2 size={20} />
-          </ActionIcon>
-        </Popover.Target>
-        <Popover.Dropdown>
+    // pinned bottom-right regardless of scroll. The panel is absolutely positioned
+    // within this fixed container, so it reliably opens above the button.
+    <div ref={containerRef} className="fixed bottom-6 right-6 z-50">
+      <ActionIcon
+        onClick={() => setOpen((o) => !o)}
+        color={ACTION_COLOR}
+        variant="filled"
+        size="xl"
+        radius="xl"
+        aria-label="Note to Haku"
+        aria-expanded={open}
+      >
+        <IconMessage2 size={20} />
+      </ActionIcon>
+      {open && (
+        <div className="absolute bottom-full right-0 mb-2 w-[360px] rounded-md border border-[var(--haku-border)] bg-[var(--haku-panel-bg)] p-4 shadow-xl">
           <FeedbackForm
             minRows={4}
             placeholder="Anything for Haku to fold into its next run…"
             submitLabel="Send to Haku"
           />
-        </Popover.Dropdown>
-      </Popover>
+        </div>
+      )}
     </div>
   );
 }

--- a/haku/console/frontend/tabler-icons.d.ts
+++ b/haku/console/frontend/tabler-icons.d.ts
@@ -1,0 +1,21 @@
+// Ambient types for deep per-icon imports from @tabler/icons-react.
+//
+// The package ships only barrel types (dist/tabler-icons-react.d.ts) — there are no
+// .d.mts files for the per-icon modules under dist/esm/icons/. But the barrel makes
+// esbuild OOM tree-shaking it (~8.7 GB peak with the full node_modules tree, and no
+// clean per-action RAM lever exists — see debug/esbuild_tabler_memory.md), so icons
+// are imported by subpath (default export). This gives those imports accurate types:
+// a forward-ref SVG component accepting the Tabler size/stroke/title props (matching
+// the barrel's IconProps).
+declare module "@tabler/icons-react/dist/esm/icons/IconMessage2.mjs" {
+  import type { ForwardRefExoticComponent, RefAttributes, SVGProps } from "react";
+
+  const IconMessage2: ForwardRefExoticComponent<
+    SVGProps<SVGSVGElement> & {
+      size?: string | number;
+      stroke?: string | number;
+      title?: string;
+    } & RefAttributes<SVGSVGElement>
+  >;
+  export default IconMessage2;
+}


### PR DESCRIPTION
## What

- The **"Note to Haku"** trace form moves from a permanent top-of-page section into a small circular button fixed in the corner that pops open a popover with the form. The embedded **Free-form UI** is now the page's main surface.
- Dropped the now-redundant **"+ Add intake note"** link (the trace form already appends to `intake/`) and the **"Free-form UI"** heading.

## Why the `@tabler` icon uses a deep per-icon import

Importing from the `@tabler/icons-react` **barrel** makes `bbr build //haku/console/frontend:bundle` OOM esbuild on BuildBuddy RBE — tree-shaking the ~5000-icon barrel peaks at **~8.7 GB** with the full `node_modules` tree, and there's no clean **per-action** RAM lever (only a platform-global one; per-target `exec_properties` and `--modify_execution_info` both fail to reach the memory sizing). So the icon is imported by subpath (`dist/esm/icons/IconMessage2.mjs`, default export), which esbuild processes in ~tens of MB. The subpath ships no types, so an ambient `declare module` in `tabler-icons.d.ts` types it for `tsc_test`. Full investigation + the alternatives considered: `haku/console/debug/esbuild_tabler_memory.md`.

## Verified

`bbr test //haku/console/...` — all green: `tsc_test`, `bridge_test`, `test_app`, `test_capabilities`, `static_image_build_test`.