### PR TITLE
haku-ci: standard act job image (node+git+docker), simplified workflow

### DIFF
--- a/cluster/k8s/haku-ci/config.yaml
+++ b/cluster/k8s/haku-ci/config.yaml
@@ -1,16 +1,18 @@
-# act_runner (forgejo-runner) daemon config. Jobs run in a docker-cli container (so
-# workflows can `docker build`/`docker push`) talking to the rootless dind sidecar
-# via DOCKER_HOST. capacity:1 keeps builds serial (bounded blast radius + resource
-# use). See README for the builder iterate notes.
+# act_runner (forgejo-runner) daemon config. Jobs run in a standard "act" image
+# (catthehacker/ubuntu) that carries node + git + the docker CLI, talking to the
+# rootless dind sidecar via DOCKER_HOST. node+git let JS actions (actions/checkout)
+# run; the docker CLI reaches dind for `docker build`/`docker push`. capacity:1 keeps
+# builds serial (bounded blast radius + resource use). See README for builder notes.
 log:
   level: info
 runner:
   capacity: 1
   timeout: 30m
-  # `<label>:docker://<image>` runs jobs in that container image (which must carry
-  # the docker CLI to reach the dind sidecar).
+  # `<label>:docker://<image>` runs jobs in that container image. Must carry the
+  # docker CLI (to reach the dind sidecar) AND node+git (so actions/checkout and
+  # other JS actions run). The standard act image bundles all three.
   labels:
-    - "haku-ci:docker://docker:27-cli"
+    - "haku-ci:docker://catthehacker/ubuntu:act-latest"
 container:
   docker_host: "tcp://localhost:2375"
   options: ""

--- a/cluster/k8s/haku-ci/deployment.yaml
+++ b/cluster/k8s/haku-ci/deployment.yaml
@@ -52,7 +52,7 @@ spec:
                 --instance "$FORGEJO_INSTANCE_URL" \
                 --token "$(cat /secrets/token)" \
                 --name "$RUNNER_NAME" \
-                --labels "haku-ci:docker://docker:27-cli" \
+                --labels "haku-ci:docker://catthehacker/ubuntu:act-latest" \
                 --config /config/config.yaml
               exec forgejo-runner daemon --config /config/config.yaml
           env:

--- a/haku/state_template/.forgejo/workflows/build-ui.yaml
+++ b/haku/state_template/.forgejo/workflows/build-ui.yaml
@@ -2,18 +2,18 @@
 #
 # Runs IN-CLUSTER on the contained, repo-scoped Forgejo Actions runner provided by
 # `cluster/k8s/haku-ci` — NOT on Bazel/BuildBuddy (haku-state may hold private
-# operator info, so its source never leaves the cluster). The runner is rootless.
+# operator info, so its source never leaves the cluster). The runner is rootless and
+# runs jobs in a standard "act" image (node + git + docker CLI).
 #
-# Everything talks to Forgejo over the in-cluster service (forgejo-http.forgejo:3000,
-# plain HTTP) rather than the public git.allegedly.works — so no build traffic
-# hairpins out to the public ingress. The dind daemon is started with
+# Everything talks to Forgejo over the in-cluster service: actions/checkout clones
+# from the runner's instance URL (forgejo-http.forgejo:3000), and the image is pushed
+# to that same in-cluster registry — so no build traffic hairpins out to the public
+# git.allegedly.works ingress. The dind daemon is started with
 # `--insecure-registry=forgejo-http.forgejo:3000` (see cluster/k8s/haku-ci) so the
 # HTTP registry push is allowed.
 #
 # Flow:
-#   1. clone the repo (the job container `docker:27-cli` is a minimal Alpine image
-#      with the docker CLI but no node — so JS actions like actions/checkout can't
-#      run — and no git, so we apk-add it and clone manually)
+#   1. check out the repo
 #   2. build the image from ui/Dockerfile
 #   3. push it to the Forgejo registry as
 #      forgejo-http.forgejo:3000/haku/ui:main-<utc-timestamp>-<short-sha>
@@ -39,23 +39,15 @@ jobs:
   build:
     runs-on: haku-ci # the repo-scoped, contained runner label (cluster/k8s/haku-ci)
     # The built-in Forgejo Actions job token (github.token) authenticates both the
-    # clone (contents:read) and the registry push (packages:write) — no separately
+    # checkout (contents:read) and the registry push (packages:write) — no separately
     # provisioned secret.
     permissions:
       contents: read
       packages: write
     steps:
-      # No actions/checkout: that's a JS action and docker:27-cli has no node. Install
-      # git and clone over the in-cluster Forgejo HTTP service. Clone to /tmp first so
-      # this doesn't depend on the workspace being empty, then copy in (incl. .git).
-      - name: Checkout (in-cluster, no JS action)
-        run: |
-          apk add --no-cache git
-          git clone --quiet \
-            "http://x-access-token:${{ github.token }}@forgejo-http.forgejo:3000/${{ github.repository }}.git" \
-            /tmp/src
-          git -C /tmp/src checkout --quiet "${{ github.sha }}"
-          cp -a /tmp/src/. .
+      # Clones from the runner's instance URL (forgejo-http.forgejo:3000) — in-cluster.
+      - name: Checkout
+        uses: actions/checkout@v4
 
       # Auth to the in-cluster Forgejo registry with the built-in job token
       # (github.actor + github.token) — Forgejo mints it per run, so there's no


### PR DESCRIPTION
Run #9 progress chain ended at `exec: "bash": not found` then would've hit `node` for JS actions — `docker:27-cli` is too minimal. Switch the job-container label to the standard act image `catthehacker/ubuntu:act-latest` (node + git + docker CLI + bash) and revert the workflow to plain `actions/checkout@v4` (still in-cluster via the runner's instance URL) + in-cluster registry push. Removes the apk-add-git/shell:sh hacks.