### PR TITLE
agent-box: correct first-boot secrets oneshot (setupSecrets snippet + HM restart)

### DIFF
--- a/cluster/k8s/agent-box/app/virtualmachine.yaml
+++ b/cluster/k8s/agent-box/app/virtualmachine.yaml
@@ -29,7 +29,7 @@ spec:
             # IMAGE_OUTPUT=agent-box-image). The VM boots straight into the real
             # config — no bootstrap + nixos-rebuild switch. cloud-init still
             # injects the persisted host key. Repin after rebuilding the image.
-            url: "https://s3.allegedly.works/vm-images/agent-box/766e7db396a5c0c182727cc7cbadb9292f1e2851.qcow2"
+            url: "https://s3.allegedly.works/vm-images/agent-box/8e55336861b06edad2e6600a47c890eaa416fe65.qcow2"
             secretRef: agent-box-vm-images-s3-reader
         pvc:
           accessModes:

--- a/nix/nixos/hosts/agent-box/default.nix
+++ b/nix/nixos/hosts/agent-box/default.nix
@@ -110,15 +110,18 @@ in
   ];
   services.openssh.settings.PermitRootLogin = lib.mkForce "prohibit-password";
 
-  # First-boot ordering fix (ugly but localized). On a cold first boot the boot
-  # order is: sops-install-secrets (early, sysinit) → cloud-init writes the
-  # persisted host key (later, cloud-config stage) → sshd. So system sops runs
-  # before the host key exists and can't decrypt codex_id_ed25519; the user-level
-  # sops then has no age key either. Once cloud-init has settled, re-apply both:
-  # restart system sops (plants id_ed25519, host key now present), then re-run
-  # home-manager (which restarts the codex user's sops-nix.service → user
-  # secrets). Idempotent: on a reboot the host key is already persisted, system
-  # sops succeeds early, and these restarts are no-ops.
+  # First-boot ordering fix (ugly but localized). On a cold first boot the
+  # NixOS `setupSecrets` activation snippet runs pre-systemd, before cloud-init
+  # writes the persisted host key (cloud-config stage), so it can't decrypt
+  # codex_id_ed25519. And home-manager-${username}.service runs at boot before
+  # the lingering user systemd manager is up, so it can't start the codex user's
+  # sops-nix.service either. Once cloud-init has settled, re-apply both:
+  # re-run setupSecrets (plants id_ed25519, host key now present), then restart
+  # home-manager (re-runs `systemctl restart --user sops-nix` with the user
+  # manager up + id present → user secrets). Idempotent on reboot.
+  #
+  # NOTE: system sops install is the `setupSecrets` activation snippet, NOT a
+  # systemd unit — there is no sops-install-secrets.service to restart.
   #
   # TODO(better): this re-run is a workaround for sops-runs-early vs
   #   cloud-init-writes-host-key-late. Cleaner options to evaluate:
@@ -140,7 +143,7 @@ in
     path = [ config.systemd.package ];
     serviceConfig.Type = "oneshot";
     script = ''
-      systemctl restart sops-install-secrets.service
+      ${config.system.activationScripts.setupSecrets.text}
       systemctl restart home-manager-${username}.service
     '';
   };


### PR DESCRIPTION
Correction to #2626 (which landed the oneshot with two wrong commands).

- System sops install is the `setupSecrets` **activation snippet**, not a systemd unit — there is no `sops-install-secrets.service` to restart. Re-run the snippet text directly.
- The user-level secrets need `home-manager-codex.service` *restarted* late (lingering user manager up + `id_ed25519` present) so its `systemctl restart --user sops-nix` actually installs them.

Both halves verified individually on the live VM (system sops plants `id_ed25519` on reboot; user sops plants buildbuddy+forgejo when triggered with `id_ed25519` present). Repins the DataVolume to the rebuilt image (`agent-box/8e55336861…`).

After merge: recreate + verify a clean cold first boot.