### PR TITLE
haku-ci: wire job containers to the dind daemon (build was never reaching docker)

### DIFF
--- a/cluster/k8s/haku-ci/config.yaml
+++ b/cluster/k8s/haku-ci/config.yaml
@@ -14,7 +14,14 @@ runner:
   labels:
     - "haku-ci:docker://catthehacker/ubuntu:act-latest"
 container:
+  # How the RUNNER reaches the dind daemon: it shares the pod network namespace
+  # with the dind sidecar, so localhost works here.
   docker_host: "tcp://localhost:2375"
-  options: ""
+  # How JOB CONTAINERS reach the dind daemon. They run on a per-job docker bridge
+  # network (not the pod netns), so `localhost` is the job container itself — the
+  # default unix socket doesn't exist and `docker build`/`push` fail. Map
+  # host.docker.internal to the host-gateway (the dind/pod) and point DOCKER_HOST
+  # at it so the in-container docker CLI talks to the dind sidecar.
+  options: "--add-host host.docker.internal:host-gateway -e DOCKER_HOST=tcp://host.docker.internal:2375"
 cache:
   enabled: false

--- a/cluster/k8s/haku-ci/deployment.yaml
+++ b/cluster/k8s/haku-ci/deployment.yaml
@@ -93,12 +93,6 @@ spec:
           args:
             - --host=tcp://0.0.0.0:2375
             - --tls=false
-            # The build-ui workflow pushes to the Forgejo registry over the
-            # in-cluster service (forgejo-http.forgejo:3000, plain HTTP) instead of
-            # the public git.allegedly.works — keeps build traffic off the public
-            # hairpin. dockerd rejects HTTP registries unless they're declared
-            # insecure.
-            - --insecure-registry=forgejo-http.forgejo:3000
           # --tls=false alone isn't enough: the dind entrypoint defaults DOCKER_TLS_CERTDIR
           # to /certs and re-enables TLS on 2375, so the runner's plain-HTTP client hits
           # "HTTP request to an HTTPS server". Emptying it disables TLS so 2375 is plain HTTP

--- a/haku/state_template/.forgejo/workflows/build-ui.yaml
+++ b/haku/state_template/.forgejo/workflows/build-ui.yaml
@@ -5,24 +5,20 @@
 # operator info, so its source never leaves the cluster). The runner is rootless and
 # runs jobs in a standard "act" image (node + git + docker CLI).
 #
-# Everything talks to Forgejo over the in-cluster service: actions/checkout clones
-# from the runner's instance URL (forgejo-http.forgejo:3000), and the image is pushed
-# to that same in-cluster registry — so no build traffic hairpins out to the public
-# git.allegedly.works ingress. The dind daemon is started with
-# `--insecure-registry=forgejo-http.forgejo:3000` (see cluster/k8s/haku-ci) so the
-# HTTP registry push is allowed.
+# All Forgejo access is authenticated (no anonymous clones/pulls): actions/checkout
+# clones over the runner's in-cluster instance URL (forgejo-http.forgejo:3000) with
+# the run token, and the registry push authenticates to git.allegedly.works (HTTPS,
+# valid cert) with the same token.
 #
 # Flow:
 #   1. check out the repo
 #   2. build the image from ui/Dockerfile
 #   3. push it to the Forgejo registry as
-#      forgejo-http.forgejo:3000/haku/ui:main-<utc-timestamp>-<short-sha>
-# The image is the same per-owner Forgejo package whatever host pushed it, so it is
-# pullable as git.allegedly.works/haku/ui — which is what k8s/haku-ui/deployment.yaml
-# and the Flux ImageRepository reference. CI does NOT touch the deployment manifest:
-# Flux image automation watches the registry, picks the newest tag by its timestamp,
-# and writes it into the deployment itself (the `{"$imagepolicy": ...}` marker). So
-# there is no CI commit-back and no `[skip ci]` loop.
+#      git.allegedly.works/haku/ui:main-<utc-timestamp>-<short-sha>
+# CI does NOT touch the deployment manifest: Flux image automation watches the
+# registry, picks the newest tag by its timestamp, and writes it into the deployment
+# itself (the `{"$imagepolicy": ...}` marker). So there is no CI commit-back and no
+# `[skip ci]` loop.
 #
 # This is STARTER source Haku adopts and evolves. Heavily commented on purpose.
 
@@ -45,19 +41,21 @@ jobs:
       contents: read
       packages: write
     steps:
-      # Clones from the runner's instance URL (forgejo-http.forgejo:3000) — in-cluster.
+      # Clones from the runner's in-cluster instance URL (forgejo-http.forgejo:3000)
+      # with the run token — authenticated and in-cluster.
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Auth to the in-cluster Forgejo registry with the built-in job token
-      # (github.actor + github.token) — Forgejo mints it per run, so there's no
-      # registry password secret to provision. Fallback if a push is ever rejected
-      # (token lacks package write): provision a `forgejo_repository_action_secret`
-      # push cred in tf/gitops/haku-state and use `${{ secrets.<NAME> }}` here.
-      - name: Log in to the in-cluster Forgejo registry
+      # Auth to the Forgejo registry over HTTPS (git.allegedly.works, valid cert) with
+      # the built-in job token (github.actor + github.token) — Forgejo mints it per
+      # run, so there's no registry password secret to provision. Fallback if a push
+      # is ever rejected (token lacks package write): provision a
+      # `forgejo_repository_action_secret` push cred in tf/gitops/haku-state and use
+      # `${{ secrets.<NAME> }}` here.
+      - name: Log in to the Forgejo registry
         run: |
           echo "${{ github.token }}" \
-            | docker login forgejo-http.forgejo:3000 -u "${{ github.actor }}" --password-stdin
+            | docker login git.allegedly.works -u "${{ github.actor }}" --password-stdin
 
       # Tag pattern is what Flux image automation sorts on: a UTC timestamp makes
       # the newest build the highest tag (ImagePolicy `numerical` on the captured
@@ -65,6 +63,6 @@ jobs:
       - name: Build and push the image
         run: |
           TAG="main-$(date -u +%Y%m%d%H%M%S)-$(echo "${{ github.sha }}" | cut -c1-7)"
-          IMAGE="forgejo-http.forgejo:3000/haku/ui:${TAG}"
+          IMAGE="git.allegedly.works/haku/ui:${TAG}"
           docker build -f ui/Dockerfile -t "$IMAGE" ui
           docker push "$IMAGE"


### PR DESCRIPTION
The real reason every haku-ui run failed: the **job container's docker CLI couldn't reach the dind daemon**. Job containers run on a per-job bridge network, so `localhost:2375`/the default unix socket don't reach the dind sidecar — `docker build` failed with 'Cannot connect to the Docker daemon'.

Verified from a live job container: the dind is reachable at `host.docker.internal:2375` (host-gateway), not localhost; a real `docker build` succeeds that way.

- **config.yaml**: `container.options` adds `--add-host host.docker.internal:host-gateway -e DOCKER_HOST=tcp://host.docker.internal:2375` so job containers talk to the dind.
- **workflow**: push to `git.allegedly.works` over HTTPS (token-authenticated; 'Login Succeeded' verified) — checkout stays in-cluster+authenticated. Both paths authenticated, no anonymous access.
- **deployment**: drop the now-unneeded `--insecure-registry`.

Earlier egress + base-image PRs (#2622/2623/2624/2629) got us past docker-pull / actions-fetch / node; this is the last wiring gap. Build itself already verified green in the dind.