### PR TITLE
haku-ci: provision registry push credential (Forgejo auto-token can't push packages)

### DIFF
--- a/haku/state_template/.forgejo/workflows/build-ui.yaml
+++ b/haku/state_template/.forgejo/workflows/build-ui.yaml
@@ -46,16 +46,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Auth to the Forgejo registry over HTTPS (git.allegedly.works, valid cert) with
-      # the built-in job token (github.actor + github.token) — Forgejo mints it per
-      # run, so there's no registry password secret to provision. Fallback if a push
-      # is ever rejected (token lacks package write): provision a
-      # `forgejo_repository_action_secret` push cred in tf/gitops/haku-state and use
-      # `${{ secrets.<NAME> }}` here.
+      # Auth to the Forgejo registry over HTTPS (git.allegedly.works, valid cert).
+      # NOT the built-in job token: Forgejo's auto github.token cannot push packages
+      # (the `permissions: packages: write` block isn't honored yet — forgejo#3571,
+      # targeted for Forgejo 16). So we log in as the repo owner (haku) with the
+      # REGISTRY_PUSH_TOKEN repo Action secret provisioned by tf/gitops/haku-state.
       - name: Log in to the Forgejo registry
         run: |
-          echo "${{ github.token }}" \
-            | docker login git.allegedly.works -u "${{ github.actor }}" --password-stdin
+          echo "${{ secrets.REGISTRY_PUSH_TOKEN }}" \
+            | docker login git.allegedly.works -u "${{ github.repository_owner }}" --password-stdin
 
       # Tag pattern is what Flux image automation sorts on: a UTC timestamp makes
       # the newest build the highest tag (ImagePolicy `numerical` on the captured

--- a/tf/gitops/haku-state/main.tf
+++ b/tf/gitops/haku-state/main.tf
@@ -98,8 +98,8 @@ resource "kubernetes_secret" "haku_state_git_write" {
 #     mitmproxy egress), and
 #   - the auth Haku's own ImageRepository uses to scan the registry for new tags (the image
 #     automation is reconciled into haku-sandbox; see haku/state_template/k8s/haku-ui-image-automation).
-# The CI workflow itself pushes with Forgejo Actions' built-in job token — no push cred
-# needed here. See cluster/k8s/haku-ci + haku/PLAN.md.
+# The CI push credential is a repo Action secret (below), NOT this pull secret.
+# See cluster/k8s/haku-ci + haku/PLAN.md.
 resource "kubernetes_secret" "haku_forgejo_registry_pull" {
   metadata {
     name      = "haku-forgejo-registry-pull"
@@ -119,6 +119,28 @@ resource "kubernetes_secret" "haku_forgejo_registry_pull" {
       }
     })
   }
+}
+
+# Registry push credential for the build-ui Forgejo Actions workflow, delivered as
+# a repo Action secret (`${{ secrets.REGISTRY_PUSH_TOKEN }}`).
+#
+# Why this is needed: Forgejo's auto-generated Actions token (github.token) CANNOT
+# push container packages — the workflow `permissions: { packages: write }` block is
+# not honored yet (the granular-permissions feature is forgejo/forgejo#3571, still
+# open, targeted for the Forgejo 16 dev cycle). On Forgejo 15 a real credential is
+# the only way. We use the haku owner's own credential (haku owns the haku/ui
+# package; verified: haku basic auth -> HTTP 202 on a blob-upload handshake = push
+# allowed). The workflow logs in as `${{ github.repository_owner }}` (= haku).
+#
+# Least-privilege note: this is haku's full credential rather than a scoped
+# write:package token — the svalabs/forgejo provider has no token-minting resource,
+# and the CI already runs as haku (it clones haku-state and builds haku's image), so
+# this isn't a new trust boundary. If a tighter scope is wanted later, mint a
+# write:package token via a small Job (cf. authentik-jwt-rotation) and swap it in.
+resource "forgejo_repository_action_secret" "registry_push" {
+  repository_id = forgejo_repository.state.id
+  name          = "REGISTRY_PUSH_TOKEN"
+  data          = random_password.haku.result
 }
 
 # Registration token for the contained Forgejo Actions runner (cluster/k8s/haku-ci),


### PR DESCRIPTION
Final piece of the haku-ui CI. Forgejo's auto `github.token` **cannot push container packages** — the `permissions: packages: write` block isn't honored on Forgejo 15 ([forgejo#3571](https://codeberg.org/forgejo/forgejo/issues/3571), open, targeted Forgejo 16). Confirmed: every build reached `docker push` then `unauthorized: reqPackageAccess`; the registry only issued a pull-scoped token.

Fix: `tf/gitops/haku-state` sets a `REGISTRY_PUSH_TOKEN` repo Action secret to the haku owner's credential (haku owns haku/ui — verified haku auth → HTTP 202 on a blob-upload handshake), and the workflow logs in as `${{ github.repository_owner }}` with it.

Least-privilege note (in the TF comment): this is haku's credential, not a scoped write:package token — the svalabs/forgejo provider can't mint tokens, and CI already runs as haku. Can tighten later via a mint Job.

Everything else verified green: in-cluster authenticated checkout, catthehacker base image, dind job-container wiring (host.docker.internal), full multi-stage build, HTTPS registry login. This unblocks the push.