### PR TITLE
nix/home/codex: fix activation snippet aborting the whole home-manager activation

### DIFF
--- a/cluster/k8s/agent-box/app/virtualmachine.yaml
+++ b/cluster/k8s/agent-box/app/virtualmachine.yaml
@@ -29,7 +29,7 @@ spec:
             # IMAGE_OUTPUT=agent-box-image). The VM boots straight into the real
             # config — no bootstrap + nixos-rebuild switch. cloud-init still
             # injects the persisted host key. Repin after rebuilding the image.
-            url: "https://s3.allegedly.works/vm-images/agent-box/8e55336861b06edad2e6600a47c890eaa416fe65.qcow2"
+            url: "https://s3.allegedly.works/vm-images/agent-box/f0f148c07c3ba97f02d8ac75d78b8e3e42cabddc.qcow2"
             secretRef: agent-box-vm-images-s3-reader
         pvc:
           accessModes:

--- a/nix/home/codex/default.nix
+++ b/nix/home/codex/default.nix
@@ -191,35 +191,26 @@ let
     mode = "directory-symlink";
   };
 
-  # Run in a subshell so `exit` and `set -e` stay contained. home-manager
-  # concatenates every activation snippet into one script, so a bare `exit` here
-  # terminates the WHOLE activation — skipping linkGeneration/reloadSystemd and
-  # leaving all home files + user systemd units unlinked. That bites a first-ever
-  # activation (where this snippet runs before linkGeneration has placed $BASE),
-  # e.g. a freshly-imaged headless host; it's masked on long-lived hosts where
-  # $BASE already exists from a prior generation.
+  # No `exit`/`set -e` here: home-manager concatenates every activation snippet
+  # into one script, so either would derail the WHOLE activation — skipping
+  # linkGeneration/reloadSystemd and leaving all home files + user systemd units
+  # unlinked. (That bit a first-ever activation on a freshly-imaged headless
+  # host, where this snippet runs before linkGeneration has placed $BASE; masked
+  # on long-lived hosts where $BASE already exists.) merge.py already no-ops when
+  # the base config isn't present, so no shell guard is needed.
   mergeScript = ''
-    (
-      set -euo pipefail
+    for dir in \
+      '${codexHomeAbsolute}' \
+      '${codexNpmCache}' \
+      '${codexNixCache}' \
+      '${codexPreCommitCache}' \
+      '${codexSccacheCache}' \
+      '${codexBazelCache}' \
+      '${codexBazeliskCache}'; do
+      mkdir -p "$dir"
+    done
 
-      CODEX_HOME='${codexHomeAbsolute}'
-      BASE='${baseFileAbsolute}'
-      LIVE='${liveFileAbsolute}'
-
-      if [ ! -f "$BASE" ]; then
-        exit 0
-      fi
-
-      mkdir -p "$CODEX_HOME"
-      mkdir -p '${codexNpmCache}'
-      mkdir -p '${codexNixCache}'
-      mkdir -p '${codexPreCommitCache}'
-      mkdir -p '${codexSccacheCache}'
-      mkdir -p '${codexBazelCache}'
-      mkdir -p '${codexBazeliskCache}'
-
-      BASE="$BASE" LIVE="$LIVE" ${pythonMerge}/bin/python ${./merge.py}
-    )
+    BASE='${baseFileAbsolute}' LIVE='${liveFileAbsolute}' ${pythonMerge}/bin/python ${./merge.py}
   '';
 in
 {

--- a/nix/home/codex/default.nix
+++ b/nix/home/codex/default.nix
@@ -191,26 +191,35 @@ let
     mode = "directory-symlink";
   };
 
+  # Run in a subshell so `exit` and `set -e` stay contained. home-manager
+  # concatenates every activation snippet into one script, so a bare `exit` here
+  # terminates the WHOLE activation — skipping linkGeneration/reloadSystemd and
+  # leaving all home files + user systemd units unlinked. That bites a first-ever
+  # activation (where this snippet runs before linkGeneration has placed $BASE),
+  # e.g. a freshly-imaged headless host; it's masked on long-lived hosts where
+  # $BASE already exists from a prior generation.
   mergeScript = ''
-    set -euo pipefail
+    (
+      set -euo pipefail
 
-    CODEX_HOME='${codexHomeAbsolute}'
-    BASE='${baseFileAbsolute}'
-    LIVE='${liveFileAbsolute}'
+      CODEX_HOME='${codexHomeAbsolute}'
+      BASE='${baseFileAbsolute}'
+      LIVE='${liveFileAbsolute}'
 
-    if [ ! -f "$BASE" ]; then
-      exit 0
-    fi
+      if [ ! -f "$BASE" ]; then
+        exit 0
+      fi
 
-    mkdir -p "$CODEX_HOME"
-    mkdir -p '${codexNpmCache}'
-    mkdir -p '${codexNixCache}'
-    mkdir -p '${codexPreCommitCache}'
-    mkdir -p '${codexSccacheCache}'
-    mkdir -p '${codexBazelCache}'
-    mkdir -p '${codexBazeliskCache}'
+      mkdir -p "$CODEX_HOME"
+      mkdir -p '${codexNpmCache}'
+      mkdir -p '${codexNixCache}'
+      mkdir -p '${codexPreCommitCache}'
+      mkdir -p '${codexSccacheCache}'
+      mkdir -p '${codexBazelCache}'
+      mkdir -p '${codexBazeliskCache}'
 
-    BASE="$BASE" LIVE="$LIVE" ${pythonMerge}/bin/python ${./merge.py}
+      BASE="$BASE" LIVE="$LIVE" ${pythonMerge}/bin/python ${./merge.py}
+    )
   '';
 in
 {

--- a/props/specimens/ducktape/2026-05-20-00/issues/exit-aborts-hm-activation.yaml
+++ b/props/specimens/ducktape/2026-05-20-00/issues/exit-aborts-hm-activation.yaml
@@ -1,0 +1,29 @@
+rationale: |
+  `mergeScript` is a home-manager activation snippet (wired in below via
+  `home.activation.codexConfig = lib.hm.dag.entryAfter [ "writeBoundary" ]
+  mergeScript`). Home-manager concatenates every activation snippet into a single
+  shell script, so a bare `exit 0` here does not skip just the codex config
+  merge — it terminates the ENTIRE home-manager activation. On a first-ever
+  activation (where this snippet runs before `linkGeneration` has linked `$BASE`)
+  the `if [ ! -f "$BASE" ]; then exit 0; fi` guard fires and aborts activation
+  before `linkGeneration` and `reloadSystemd` run, so no home files or user
+  systemd units get linked and nothing downstream activates. It is masked on
+  long-lived hosts, where `$BASE` already exists from a prior generation and the
+  guard is never taken, but bites a fresh activation (e.g. a freshly-imaged
+  headless host). The `set -euo pipefail` on the first line has the same class of
+  defect: it leaks into the concatenated script and changes error handling for
+  every later activation snippet. An activation snippet must not `exit` or
+  globally `set -e`; contain them in a subshell, or drop the guard entirely since
+  `merge.py` already no-ops when the base config is absent.
+should_flag: true
+occurrences:
+  - occurrence_id: occ-000
+    files:
+      nix/home/codex/default.nix:
+        - [156, 156]
+        - [162, 164]
+    note: "`exit 0` (and `set -euo pipefail`) in a home-manager activation snippet abort/alter the whole concatenated activation, not just this codex merge step — skipping linkGeneration/reloadSystemd"
+    critic_scopes_expected_to_recall:
+      - ["nix/home/codex/default.nix"]
+    match_file_restriction:
+      - "nix/home/codex/default.nix"


### PR DESCRIPTION
## The bug

`nix/home/codex/default.nix`'s config-merge activation snippet ran `set -euo pipefail` + a bare `exit 0` (when the base config isn't linked yet) directly in home-manager's activation. Home-manager concatenates **all** activation snippets into one shell script, so that `exit` doesn't skip just the codex merge — it **terminates the entire activation**, before `linkGeneration` and `reloadSystemd` run. Result on a *first-ever* activation (where the snippet runs before `linkGeneration` has placed `$BASE`): no home files or user systemd units get linked at all.

This was latent — masked on long-lived hosts (rugged/wyrm2/gecko) where `$BASE` already exists from a prior generation, so the guard is never taken. It surfaced on a freshly-imaged headless host (`agent-box`), where it silently broke home-manager sops (the `sops-nix.service` user unit was never linked, so BuildBuddy/Forgejo secrets never installed).

## The fix

Drop the `exit`/`set -e` entirely: `merge.py` already no-ops when the base config is absent, so the shell guard was redundant. Collapse the mkdirs into a for-loop. No `exit` or global `set -e` leaks into the concatenated activation anymore.

## Specimen

Also captures this as a code-quality issue in the `2026-05-20` ducktape snapshot (`issues/exit-aborts-hm-activation.yaml`) — that snapshot already bundles the buggy `default.nix`.

(An agent-box DataVolume repin to the rebuilt image follows once the in-cluster image build finishes.)