### PR TITLE
[codex] Model debundle selector arithmetic as linear constraints

### DIFF
--- a/devinfra/js/debundle/debug/perf/2026_06_27_large_bundle_selector_csp_profile.md
+++ b/devinfra/js/debundle/debug/perf/2026_06_27_large_bundle_selector_csp_profile.md
@@ -6,6 +6,8 @@ downstream product or copying any private source/code excerpts.
 
 ## Current Measurement
 
+- **Use the 2026-06-28 current-branch replay below as the active profile.** The
+  older measurements remain as historical context only.
 - A remote Bazel build with the downstream target and local Ducktape override was
   capped at 5 minutes. The build did not complete.
 - The Bazel critical path included normal tool rebuild cost, but the debundle
@@ -20,6 +22,84 @@ downstream product or copying any private source/code excerpts.
 - The run also appeared memory-heavy. We did not capture a reliable max-RSS or
   heap allocation profile in this pass, so memory needs to be measured explicitly
   on the next replay.
+
+### 2026-06-28 Three-Minute Current-Branch Replay
+
+This replay used the same private downstream direct-action wrapper, but with the
+current Ducktape branch binaries at commit
+`ec4416d7e08445ce3e9c8105910c08cecbffc0e7`.
+
+```sh
+/usr/bin/time -v timeout --foreground --kill-after=30s 180s \
+  perf record -F 99 -e cycles:u --call-graph dwarf,8192 \
+  -o <profile-dir>/perf.data -- <direct-replay-wrapper>
+```
+
+The replay exited with status `124` after `3:01.89`; `perf` captured an
+approximately `179.897s` sample window with about `18K` user-space cycle samples
+and no lost samples. Max RSS was `3,723,844 KB`. The run emitted no CP-SAT
+request proto and no CP-SAT summary JSON, so it still timed out before the
+OR-Tools sidecar was invoked.
+
+The completed flat `perf report` points at Rust-side construction work, not
+solver search. The top self-cost symbols were dominated by:
+
+- equality/comparison over compact ids: `PartialEq for u32`;
+- allocator and movement costs: `malloc`, `_int_malloc`, `_int_free`,
+  `__memmove_avx_unaligned_erms`, vector growth/deallocation;
+- hashing and hash-table lookup: `Sip*`, `hashbrown::RawTable::find`,
+  `find_or_find_insert_slot`, `reserve_rehash`;
+- BTree navigation/replacement: `alloc::collections::btree::mem::replace`;
+- selector model lowering: `selector_constraint_model_builder::add_ast_child_allowed_tuples`;
+- normal parse/setup residue from SWC parsing.
+
+The important current conclusion is narrower than the older two-minute profile:
+after compact domains, interned ids, and arithmetic-as-linear-constraints, the
+run still does not reach OR-Tools within three minutes. We are no longer looking
+at the old full-domain typed-model validation shape as the only explanation.
+The remaining visible costs are relation/table construction, row/domain
+interning and lookup, allocation/copying while building those relations, and
+AST-child allowed-table lowering.
+
+That makes the next performance work:
+
+1. profile-guided reduction of allowed-table construction, starting with
+   `add_ast_child_allowed_tuples` and other relation-to-table lowerings;
+2. flatten allowed-table storage/serialization so rows are not nested heap
+   objects across Rust and protobuf;
+3. represent sparse/range-like integer domains as OR-Tools-style interval
+   domains instead of value lists;
+4. keep using native OR-Tools constraints for arithmetic and `all_different`;
+   do not add solver heuristics until a saved CP-SAT request shows the sidecar
+   is the bottleneck.
+
+### 2026-06-27 Two-Minute Direct Replay
+
+A later direct replay used the same private downstream action wrapper under:
+
+```sh
+/usr/bin/time -v timeout --foreground --kill-after=30s 2m \
+  perf record -F 99 -g --call-graph fp -- <direct-replay-wrapper>
+```
+
+The replay exited with status `124` after `120.17s`; `perf` captured a
+`119.889s` sample window. Max RSS from `/usr/bin/time -v` was `3,353,792 KB`.
+No CP-SAT request proto or CP-SAT summary JSON was emitted, so the run was still
+inside Rust-side model construction when `timeout` killed it.
+
+The sampled stacks show this approximate stage timeline:
+
+|      Time | Stage                                                                         | Stack evidence                                                                                                                                                                                                                                                    |
+| --------: | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    `0-1s` | wrapper setup, module discovery, spec/YAML loading                            | `spec_modules::collect_module_files_into`, `std::fs::metadata`, `serde_yaml` / `unsafe_libyaml`                                                                                                                                                                   |
+|    `1-4s` | source reads and SWC parse                                                    | `std::fs::read_to_string`, Rayon worker stacks in `swc_ecma_parser::parse_*`                                                                                                                                                                                      |
+|   `4-40s` | JavaScript traversal, fact extraction, purity/dataflow-style analysis         | `PlainDataWriteScanner::*`, `is_shadowed`, `ts_enum_iife`, `analysis::purity`, plus BTree and iterator frames                                                                                                                                                     |
+|  `40-80s` | allocation-heavy fact/index/lowering transition                               | `_int_malloc`, `_int_free`, `malloc_consolidate`, `__memmove`, BTree replacement/navigation                                                                                                                                                                       |
+| `80-120s` | selector constraint model/backend construction, especially allowed tuple work | `selector_constraint_model_builder::{add_node_string_allowed_tuples,string_term_matches}`, `selector_constraint_backend::{intern_ast_node,add_encoded_allowed_tuples_with_domains,FullDomainValues::get_mut}`, `hashbrown::RawTable::find`, BTree iteration/dedup |
+
+The kill point was the final row: selector constraint construction and encoded
+allowed-table insertion. This profile does not justify OR-Tools tuning yet; the
+sidecar had not started and the Rust wrapper had not emitted its request.
 
 ## Hot Path
 

--- a/devinfra/js/debundle/selector_backend_solver.rs
+++ b/devinfra/js/debundle/selector_backend_solver.rs
@@ -405,6 +405,7 @@ mod tests {
                 assignment_coverage: self.coverage,
                 assignments,
                 diagnostic: None,
+                solver_response_stats: None,
             })
         }
     }
@@ -413,12 +414,10 @@ mod tests {
         problem: &CompiledSelectorProblem,
         value: &ConstraintValue,
     ) -> BackendValueId {
-        let index = problem
+        problem
             .value_dictionary
-            .iter()
-            .position(|candidate| candidate == value)
-            .expect("test backend value must be in dictionary");
-        BackendValueId(index.try_into().unwrap())
+            .encode(value)
+            .expect("test backend value must be in dictionary")
     }
 
     fn owner(value: usize) -> ConstraintValue {
@@ -521,12 +520,14 @@ mod tests {
         assert!(
             problem
                 .value_dictionary
-                .contains(&ConstraintValue::Owner(OwnerId(1)))
+                .encode(&ConstraintValue::Owner(OwnerId(1)))
+                .is_some()
         );
         assert!(
             problem
                 .value_dictionary
-                .contains(&ConstraintValue::String("minA".to_string()))
+                .encode(&ConstraintValue::String("minA".to_string()))
+                .is_some()
         );
     }
 

--- a/devinfra/js/debundle/selector_constraint_backend.rs
+++ b/devinfra/js/debundle/selector_constraint_backend.rs
@@ -4,7 +4,7 @@
 //! backend. Values are interned once, variables hold compact full-domain handles
 //! or sparse candidate sets, and allowed tuples are stored as interned ids.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::error::Error;
 use std::fmt;
 
@@ -59,7 +59,8 @@ pub enum CompiledVariableDomain {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CompiledVariable {
     pub id: ConstraintVariableId,
-    pub source: SelectorVariableId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<SelectorVariableId>,
     pub domain: VariableDomain,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub debug_name: Option<String>,
@@ -113,6 +114,14 @@ pub struct CompiledBinaryConstraint {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompiledLinearConstraint {
+    pub variables: Vec<ConstraintVariableId>,
+    pub coefficients: Vec<i64>,
+    pub offset: i64,
+    pub domain: Vec<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum AllDifferentReason {
     TargetInjectivity { targets: Vec<SelectorTargetId> },
@@ -155,13 +164,83 @@ impl FullDomainValues {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DomainValueDictionary {
+    pub owners: Vec<OwnerId>,
+    pub ast_nodes: Vec<NodeId>,
+    pub strings: Vec<String>,
+    pub statement_ordinals: Vec<StatementOrdinal>,
+}
+
+impl DomainValueDictionary {
+    pub fn total_len(&self) -> usize {
+        self.owners.len()
+            + self.ast_nodes.len()
+            + self.strings.len()
+            + self.statement_ordinals.len()
+    }
+
+    fn domain_len(&self, domain: VariableDomain) -> usize {
+        match domain {
+            VariableDomain::Owner => self.owners.len(),
+            VariableDomain::AstNode => self.ast_nodes.len(),
+            VariableDomain::String => self.strings.len(),
+            VariableDomain::StatementOrdinal => self.statement_ordinals.len(),
+        }
+    }
+
+    pub fn encode(&self, value: &ConstraintValue) -> Option<BackendValueId> {
+        let index = match value {
+            ConstraintValue::Owner(value) => {
+                self.owners.iter().position(|candidate| candidate == value)
+            }
+            ConstraintValue::AstNode(value) => self
+                .ast_nodes
+                .iter()
+                .position(|candidate| candidate == value),
+            ConstraintValue::String(value) => {
+                self.strings.iter().position(|candidate| candidate == value)
+            }
+            ConstraintValue::StatementOrdinal(value) => self
+                .statement_ordinals
+                .iter()
+                .position(|candidate| candidate == value),
+        }?;
+        Some(BackendValueId(index.try_into().ok()?))
+    }
+
+    fn decode(&self, domain: VariableDomain, value: BackendValueId) -> Option<ConstraintValue> {
+        let index = backend_value_index(value).ok()?;
+        match domain {
+            VariableDomain::Owner => self.owners.get(index).copied().map(ConstraintValue::Owner),
+            VariableDomain::AstNode => self
+                .ast_nodes
+                .get(index)
+                .copied()
+                .map(ConstraintValue::AstNode),
+            VariableDomain::String => self
+                .strings
+                .get(index)
+                .cloned()
+                .map(ConstraintValue::String),
+            VariableDomain::StatementOrdinal => self
+                .statement_ordinals
+                .get(index)
+                .copied()
+                .map(ConstraintValue::StatementOrdinal),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CompiledSelectorProblem {
-    pub value_dictionary: Vec<ConstraintValue>,
+    pub value_dictionary: DomainValueDictionary,
     pub full_domains: FullDomainValues,
     pub variables: Vec<CompiledVariable>,
     pub target_projections: Vec<TargetProjection>,
     pub allowed_tuples: Vec<CompiledAllowedTupleConstraint>,
     pub binary_constraints: Vec<CompiledBinaryConstraint>,
+    #[serde(default)]
+    pub linear_constraints: Vec<CompiledLinearConstraint>,
     pub all_different: Vec<CompiledAllDifferentConstraint>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub known_unsat: Option<String>,
@@ -201,8 +280,7 @@ impl CompiledSelectorProblem {
             }
             let value = self
                 .value_dictionary
-                .get(backend_value_index(entry.value)?)
-                .cloned()
+                .decode(variable.domain, entry.value)
                 .ok_or(BackendAssignmentError::UnknownValue { value: entry.value })?;
             if decoded.insert(entry.variable, value).is_some() {
                 return Err(BackendAssignmentError::DuplicateVariable {
@@ -215,40 +293,50 @@ impl CompiledSelectorProblem {
 
     fn variable_domain_contains(&self, variable: &CompiledVariable, value: BackendValueId) -> bool {
         match &variable.values {
-            CompiledVariableDomain::Full(domain) => {
-                let Ok(index) = backend_value_index(value) else {
-                    return false;
-                };
-                self.value_dictionary
-                    .get(index)
-                    .is_some_and(|candidate| candidate.domain() == *domain)
-                    && self.full_domains.get(*domain).binary_search(&value).is_ok()
-            }
+            CompiledVariableDomain::Full(domain) => backend_value_index(value)
+                .is_ok_and(|index| index < self.full_domains.get(*domain).len()),
             CompiledVariableDomain::Sparse(values) => values.binary_search(&value).is_ok(),
         }
+    }
+
+    pub fn decode_value(
+        &self,
+        domain: VariableDomain,
+        value: BackendValueId,
+    ) -> Option<ConstraintValue> {
+        self.value_dictionary.decode(domain, value)
     }
 }
 
 #[derive(Debug, Default)]
 pub struct CompiledSelectorProblemBuilder {
-    value_ids: BTreeMap<ConstraintValue, BackendValueId>,
-    value_dictionary: Vec<ConstraintValue>,
+    value_ids: DomainValueIds,
+    value_dictionary: DomainValueDictionary,
     full_domains: FullDomainValues,
     variables: Vec<CompiledVariableBuilder>,
     target_projections: Vec<TargetProjection>,
     allowed_tuples: Vec<CompiledAllowedTupleConstraint>,
     binary_constraints: Vec<CompiledBinaryConstraint>,
+    linear_constraints: Vec<CompiledLinearConstraint>,
     all_different: Vec<CompiledAllDifferentConstraint>,
-    variable_supports: Vec<Option<BTreeSet<BackendValueId>>>,
     known_unsat: Option<String>,
+}
+
+#[derive(Debug, Default)]
+struct DomainValueIds {
+    owners: HashMap<OwnerId, BackendValueId>,
+    ast_nodes: HashMap<NodeId, BackendValueId>,
+    strings: HashMap<String, BackendValueId>,
+    statement_ordinals: HashMap<StatementOrdinal, BackendValueId>,
 }
 
 #[derive(Debug, Clone)]
 struct CompiledVariableBuilder {
     id: ConstraintVariableId,
-    source: SelectorVariableId,
+    source: Option<SelectorVariableId>,
     domain: VariableDomain,
     debug_name: Option<String>,
+    values: CompiledVariableDomain,
 }
 
 impl CompiledSelectorProblemBuilder {
@@ -283,11 +371,40 @@ impl CompiledSelectorProblemBuilder {
         let id = ConstraintVariableId(self.variables.len());
         self.variables.push(CompiledVariableBuilder {
             id,
-            source,
+            source: Some(source),
             domain,
             debug_name,
+            values: CompiledVariableDomain::Full(domain),
         });
-        self.variable_supports.push(None);
+        Ok(id)
+    }
+
+    pub fn add_internal_integer_variable(
+        &mut self,
+        debug_name: Option<String>,
+        values: impl IntoIterator<Item = BackendValueId>,
+    ) -> Result<ConstraintVariableId, CompiledSelectorProblemError> {
+        let mut values = values.into_iter().collect::<Vec<_>>();
+        values.sort_unstable();
+        values.dedup();
+        if values.is_empty() {
+            self.known_unsat
+                .get_or_insert_with(|| "internal integer variable has empty domain".to_string());
+            values.push(BackendValueId(0));
+        }
+        if let Some(value) = values.iter().find(|value| value.0 < 0) {
+            return Err(
+                CompiledSelectorProblemError::InternalVariableValueOutOfDomain { value: *value },
+            );
+        }
+        let id = ConstraintVariableId(self.variables.len());
+        self.variables.push(CompiledVariableBuilder {
+            id,
+            source: None,
+            domain: VariableDomain::StatementOrdinal,
+            debug_name,
+            values: CompiledVariableDomain::Sparse(values),
+        });
         Ok(id)
     }
 
@@ -324,31 +441,12 @@ impl CompiledSelectorProblemBuilder {
         variables: Vec<ConstraintVariableId>,
         tuples: Vec<Vec<ConstraintValue>>,
     ) -> Result<AllowedTupleConstraintId, CompiledSelectorProblemError> {
-        let id = AllowedTupleConstraintId(self.allowed_tuples.len());
-        if variables.is_empty() {
-            return Err(CompiledSelectorProblemError::EmptyAllowedTupleVariables { id });
-        }
-
-        let mut seen_variables = BTreeSet::new();
-        let domains = variables
-            .iter()
-            .map(|variable| {
-                if !seen_variables.insert(*variable) {
-                    return Err(CompiledSelectorProblemError::DuplicateTupleVariable {
-                        id,
-                        variable: *variable,
-                    });
-                }
-                Ok(self.require_variable(*variable)?.domain)
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-
+        let domains = self.validate_allowed_tuple_variables(&variables)?;
         let mut compiled_tuples = Vec::with_capacity(tuples.len());
-        let mut supports = vec![BTreeSet::new(); variables.len()];
         for (tuple_index, tuple) in tuples.into_iter().enumerate() {
             if tuple.len() != variables.len() {
                 return Err(CompiledSelectorProblemError::TupleArityMismatch {
-                    id,
+                    id: AllowedTupleConstraintId(self.allowed_tuples.len()),
                     tuple_index,
                     expected: variables.len(),
                     actual: tuple.len(),
@@ -359,16 +457,118 @@ impl CompiledSelectorProblemBuilder {
                 let actual = value.domain();
                 if actual != *expected {
                     return Err(CompiledSelectorProblemError::TupleDomainMismatch {
-                        id,
+                        id: AllowedTupleConstraintId(self.allowed_tuples.len()),
                         tuple_index,
                         variable: variables[column],
                         expected: *expected,
                         actual,
                     });
                 }
-                let value_id = self.intern_value(value)?;
+                compiled.push(self.intern_value(value)?);
+            }
+            compiled_tuples.push(compiled);
+        }
+        self.add_encoded_allowed_tuples_with_domains(variables, domains, compiled_tuples)
+    }
+
+    pub fn add_encoded_allowed_tuples(
+        &mut self,
+        variables: Vec<ConstraintVariableId>,
+        tuples: Vec<Vec<BackendValueId>>,
+    ) -> Result<AllowedTupleConstraintId, CompiledSelectorProblemError> {
+        let domains = self.validate_allowed_tuple_variables(&variables)?;
+        self.add_encoded_allowed_tuples_with_domains(variables, domains, tuples)
+    }
+
+    pub fn intern_owner(
+        &mut self,
+        value: OwnerId,
+    ) -> Result<BackendValueId, CompiledSelectorProblemError> {
+        if let Some(id) = self.value_ids.owners.get(&value) {
+            return Ok(*id);
+        }
+        let count = self.value_dictionary.owners.len();
+        let id = backend_value_id(count)?;
+        self.value_ids.owners.insert(value, id);
+        self.value_dictionary.owners.push(value);
+        Ok(id)
+    }
+
+    pub fn intern_ast_node(
+        &mut self,
+        value: NodeId,
+    ) -> Result<BackendValueId, CompiledSelectorProblemError> {
+        if let Some(id) = self.value_ids.ast_nodes.get(&value) {
+            return Ok(*id);
+        }
+        let count = self.value_dictionary.ast_nodes.len();
+        let id = backend_value_id(count)?;
+        self.value_ids.ast_nodes.insert(value, id);
+        self.value_dictionary.ast_nodes.push(value);
+        Ok(id)
+    }
+
+    pub fn intern_string(
+        &mut self,
+        value: &str,
+    ) -> Result<BackendValueId, CompiledSelectorProblemError> {
+        if let Some(id) = self.value_ids.strings.get(value) {
+            return Ok(*id);
+        }
+        let count = self.value_dictionary.strings.len();
+        let id = backend_value_id(count)?;
+        let value = value.to_string();
+        self.value_ids.strings.insert(value.clone(), id);
+        self.value_dictionary.strings.push(value);
+        Ok(id)
+    }
+
+    pub fn intern_statement_ordinal(
+        &mut self,
+        value: StatementOrdinal,
+    ) -> Result<BackendValueId, CompiledSelectorProblemError> {
+        if let Some(id) = self.value_ids.statement_ordinals.get(&value) {
+            return Ok(*id);
+        }
+        let count = self.value_dictionary.statement_ordinals.len();
+        let id = backend_value_id(count)?;
+        self.value_ids.statement_ordinals.insert(value, id);
+        self.value_dictionary.statement_ordinals.push(value);
+        Ok(id)
+    }
+
+    fn add_encoded_allowed_tuples_with_domains(
+        &mut self,
+        variables: Vec<ConstraintVariableId>,
+        domains: Vec<VariableDomain>,
+        tuples: Vec<Vec<BackendValueId>>,
+    ) -> Result<AllowedTupleConstraintId, CompiledSelectorProblemError> {
+        let id = AllowedTupleConstraintId(self.allowed_tuples.len());
+        if variables.is_empty() {
+            return Err(CompiledSelectorProblemError::EmptyAllowedTupleVariables { id });
+        }
+
+        let mut compiled_tuples = Vec::with_capacity(tuples.len());
+        for (tuple_index, tuple) in tuples.into_iter().enumerate() {
+            if tuple.len() != variables.len() {
+                return Err(CompiledSelectorProblemError::TupleArityMismatch {
+                    id,
+                    tuple_index,
+                    expected: variables.len(),
+                    actual: tuple.len(),
+                });
+            }
+            let mut compiled = Vec::with_capacity(tuple.len());
+            for (column, (value_id, expected)) in tuple.into_iter().zip(domains.iter()).enumerate()
+            {
+                self.validate_encoded_value(
+                    id,
+                    tuple_index,
+                    variables[column],
+                    *expected,
+                    value_id,
+                )?;
                 self.ensure_full_domain_contains(*expected, value_id);
-                supports[column].insert(value_id);
                 compiled.push(value_id);
             }
             compiled_tuples.push(compiled);
@@ -379,10 +579,6 @@ impl CompiledSelectorProblemBuilder {
         if compiled_tuples.is_empty() {
             self.known_unsat
                 .get_or_insert_with(|| format!("allowed tuple constraint {id:?} has no rows"));
-        } else {
-            for (variable, support) in variables.iter().zip(supports.into_iter()) {
-                self.intersect_variable_support(*variable, support)?;
-            }
         }
 
         self.allowed_tuples.push(CompiledAllowedTupleConstraint {
@@ -403,6 +599,33 @@ impl CompiledSelectorProblemBuilder {
         self.binary_constraints
             .push(CompiledBinaryConstraint { left, right, kind });
         Ok(())
+    }
+
+    pub fn add_linear_constraint(
+        &mut self,
+        variables: Vec<ConstraintVariableId>,
+        coefficients: Vec<i64>,
+        offset: i64,
+        domain: Vec<i64>,
+    ) -> Result<(), CompiledSelectorProblemError> {
+        self.validate_linear_constraint(&variables, &coefficients, &domain)?;
+        self.linear_constraints.push(CompiledLinearConstraint {
+            variables,
+            coefficients,
+            offset,
+            domain,
+        });
+        Ok(())
+    }
+
+    pub fn variable_domain_values(
+        &self,
+        variable: ConstraintVariableId,
+    ) -> Result<Vec<BackendValueId>, CompiledSelectorProblemError> {
+        match &self.require_variable(variable)?.values {
+            CompiledVariableDomain::Full(domain) => Ok(self.full_domains.get(*domain).to_vec()),
+            CompiledVariableDomain::Sparse(values) => Ok(values.clone()),
+        }
     }
 
     pub fn add_all_different(
@@ -431,64 +654,27 @@ impl CompiledSelectorProblemBuilder {
         self.add_all_different(variables, AllDifferentReason::TargetInjectivity { targets })
     }
 
-    pub fn finish(mut self) -> Result<CompiledSelectorProblem, CompiledSelectorProblemError> {
+    pub fn finish(self) -> Result<CompiledSelectorProblem, CompiledSelectorProblemError> {
         let variables: Vec<CompiledVariable> = self
             .variables
             .iter()
-            .map(|variable| {
-                let values = match &self.variable_supports[variable.id.0] {
-                    Some(support) if support.is_empty() => {
-                        self.known_unsat.get_or_insert_with(|| {
-                            format!("variable {:?} has no supported values", variable.id)
-                        });
-                        CompiledVariableDomain::Full(variable.domain)
-                    }
-                    Some(support) => {
-                        CompiledVariableDomain::Sparse(support.iter().copied().collect())
-                    }
-                    None => CompiledVariableDomain::Full(variable.domain),
-                };
-                CompiledVariable {
-                    id: variable.id,
-                    source: variable.source,
-                    domain: variable.domain,
-                    debug_name: variable.debug_name.clone(),
-                    values,
-                }
+            .map(|variable| CompiledVariable {
+                id: variable.id,
+                source: variable.source,
+                domain: variable.domain,
+                debug_name: variable.debug_name.clone(),
+                values: variable.values.clone(),
             })
             .collect();
-        let mut allowed_tuples = self.allowed_tuples;
-        for constraint in &mut allowed_tuples {
-            constraint.tuples.retain(|tuple| {
-                constraint
-                    .variables
-                    .iter()
-                    .zip(tuple.iter())
-                    .all(|(variable, value)| {
-                        compiled_variable_domain_contains(
-                            &variables[variable.0].values,
-                            &self.full_domains,
-                            *value,
-                        )
-                    })
-            });
-            if constraint.tuples.is_empty() {
-                self.known_unsat.get_or_insert_with(|| {
-                    format!(
-                        "allowed tuple constraint {:?} has no rows after domain narrowing",
-                        constraint.id
-                    )
-                });
-            }
-        }
 
         Ok(CompiledSelectorProblem {
             value_dictionary: self.value_dictionary,
             full_domains: self.full_domains,
             variables,
             target_projections: self.target_projections,
-            allowed_tuples,
+            allowed_tuples: self.allowed_tuples,
             binary_constraints: self.binary_constraints,
+            linear_constraints: self.linear_constraints,
             all_different: self.all_different,
             known_unsat: self.known_unsat,
         })
@@ -498,43 +684,102 @@ impl CompiledSelectorProblemBuilder {
         &mut self,
         value: ConstraintValue,
     ) -> Result<BackendValueId, CompiledSelectorProblemError> {
-        if let Some(id) = self.value_ids.get(&value) {
-            return Ok(*id);
+        match value {
+            ConstraintValue::Owner(value) => self.intern_owner(value),
+            ConstraintValue::AstNode(value) => self.intern_ast_node(value),
+            ConstraintValue::String(value) => self.intern_string(&value),
+            ConstraintValue::StatementOrdinal(value) => self.intern_statement_ordinal(value),
         }
-        let count = self.value_dictionary.len();
-        let id = BackendValueId(
-            i64::try_from(count)
-                .map_err(|_| CompiledSelectorProblemError::TooManyValues { count })?,
-        );
-        self.value_ids.insert(value.clone(), id);
-        self.value_dictionary.push(value);
-        Ok(id)
+    }
+
+    fn validate_allowed_tuple_variables(
+        &self,
+        variables: &[ConstraintVariableId],
+    ) -> Result<Vec<VariableDomain>, CompiledSelectorProblemError> {
+        let id = AllowedTupleConstraintId(self.allowed_tuples.len());
+        if variables.is_empty() {
+            return Err(CompiledSelectorProblemError::EmptyAllowedTupleVariables { id });
+        }
+        let mut seen_variables = BTreeSet::new();
+        variables
+            .iter()
+            .map(|variable| {
+                if !seen_variables.insert(*variable) {
+                    return Err(CompiledSelectorProblemError::DuplicateTupleVariable {
+                        id,
+                        variable: *variable,
+                    });
+                }
+                Ok(self.require_variable(*variable)?.domain)
+            })
+            .collect()
+    }
+
+    fn validate_encoded_value(
+        &self,
+        id: AllowedTupleConstraintId,
+        tuple_index: usize,
+        variable: ConstraintVariableId,
+        domain: VariableDomain,
+        value: BackendValueId,
+    ) -> Result<(), CompiledSelectorProblemError> {
+        if value.0 < 0 {
+            return Err(CompiledSelectorProblemError::EncodedTupleValueOutOfDomain {
+                id,
+                tuple_index,
+                variable,
+                domain,
+                value,
+            });
+        }
+        let Ok(index) = usize::try_from(value.0) else {
+            return Err(CompiledSelectorProblemError::EncodedTupleValueOutOfDomain {
+                id,
+                tuple_index,
+                variable,
+                domain,
+                value,
+            });
+        };
+        let variable_domain = &self.require_variable(variable)?.values;
+        match variable_domain {
+            CompiledVariableDomain::Full(_) => {
+                if index >= self.value_dictionary.domain_len(domain) {
+                    return Err(CompiledSelectorProblemError::EncodedTupleValueOutOfDomain {
+                        id,
+                        tuple_index,
+                        variable,
+                        domain,
+                        value,
+                    });
+                }
+            }
+            CompiledVariableDomain::Sparse(values) => {
+                if values.binary_search(&value).is_err() {
+                    return Err(CompiledSelectorProblemError::EncodedTupleValueOutOfDomain {
+                        id,
+                        tuple_index,
+                        variable,
+                        domain,
+                        value,
+                    });
+                }
+            }
+        }
+        Ok(())
     }
 
     fn ensure_full_domain_contains(&mut self, domain: VariableDomain, value: BackendValueId) {
         let values = self.full_domains.get_mut(domain);
-        match values.binary_search(&value) {
-            Ok(_) => {}
-            Err(index) => values.insert(index, value),
+        let Ok(index) = usize::try_from(value.0) else {
+            return;
+        };
+        if index < values.len() {
+            return;
         }
-    }
-
-    fn intersect_variable_support(
-        &mut self,
-        variable: ConstraintVariableId,
-        support: BTreeSet<BackendValueId>,
-    ) -> Result<(), CompiledSelectorProblemError> {
-        let slot = self
-            .variable_supports
-            .get_mut(variable.0)
-            .ok_or(CompiledSelectorProblemError::UnknownVariable { variable })?;
-        match slot {
-            None => *slot = Some(support),
-            Some(existing) => {
-                *existing = existing.intersection(&support).copied().collect();
-            }
+        if index == values.len() {
+            values.push(value);
         }
-        Ok(())
     }
 
     fn validate_binary_constraint(
@@ -565,6 +810,41 @@ impl CompiledSelectorProblemBuilder {
                         right,
                     });
                 }
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_linear_constraint(
+        &self,
+        variables: &[ConstraintVariableId],
+        coefficients: &[i64],
+        domain: &[i64],
+    ) -> Result<(), CompiledSelectorProblemError> {
+        if variables.is_empty() {
+            return Err(CompiledSelectorProblemError::DegenerateLinearConstraint);
+        }
+        if variables.len() != coefficients.len() {
+            return Err(CompiledSelectorProblemError::LinearArityMismatch {
+                variables: variables.len(),
+                coefficients: coefficients.len(),
+            });
+        }
+        if domain.is_empty() || domain.len() % 2 != 0 {
+            return Err(CompiledSelectorProblemError::InvalidLinearDomain);
+        }
+        for interval in domain.chunks_exact(2) {
+            if interval[0] > interval[1] {
+                return Err(CompiledSelectorProblemError::InvalidLinearDomain);
+            }
+        }
+        for variable in variables {
+            let domain = self.require_variable(*variable)?.domain;
+            if domain != VariableDomain::StatementOrdinal {
+                return Err(CompiledSelectorProblemError::LinearDomainMismatch {
+                    variable: *variable,
+                    domain,
+                });
             }
         }
         Ok(())
@@ -657,19 +937,6 @@ impl CompiledSelectorProblemBuilder {
     }
 }
 
-fn compiled_variable_domain_contains(
-    values: &CompiledVariableDomain,
-    full_domains: &FullDomainValues,
-    value: BackendValueId,
-) -> bool {
-    match values {
-        CompiledVariableDomain::Full(domain) => {
-            full_domains.get(*domain).binary_search(&value).is_ok()
-        }
-        CompiledVariableDomain::Sparse(values) => values.binary_search(&value).is_ok(),
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CompiledSelectorProblemError {
     UnknownVariable {
@@ -710,6 +977,13 @@ pub enum CompiledSelectorProblemError {
         expected: VariableDomain,
         actual: VariableDomain,
     },
+    EncodedTupleValueOutOfDomain {
+        id: AllowedTupleConstraintId,
+        tuple_index: usize,
+        variable: ConstraintVariableId,
+        domain: VariableDomain,
+        value: BackendValueId,
+    },
     BinaryDomainMismatch {
         left: ConstraintVariableId,
         right: ConstraintVariableId,
@@ -719,6 +993,16 @@ pub enum CompiledSelectorProblemError {
     OrdinalBeforeDomainMismatch {
         left: ConstraintVariableId,
         right: ConstraintVariableId,
+    },
+    DegenerateLinearConstraint,
+    LinearArityMismatch {
+        variables: usize,
+        coefficients: usize,
+    },
+    InvalidLinearDomain,
+    LinearDomainMismatch {
+        variable: ConstraintVariableId,
+        domain: VariableDomain,
     },
     DegenerateAllDifferent {
         id: AllDifferentConstraintId,
@@ -731,6 +1015,9 @@ pub enum CompiledSelectorProblemError {
         id: AllDifferentConstraintId,
         expected: VariableDomain,
         actual: VariableDomain,
+    },
+    InternalVariableValueOutOfDomain {
+        value: BackendValueId,
     },
     TargetInjectivityProjectionMismatch {
         id: AllDifferentConstraintId,
@@ -789,6 +1076,16 @@ impl fmt::Display for CompiledSelectorProblemError {
                 f,
                 "allowed tuple constraint {id:?} row {tuple_index} variable {variable:?} expected {expected:?}, found {actual:?}"
             ),
+            Self::EncodedTupleValueOutOfDomain {
+                id,
+                tuple_index,
+                variable,
+                domain,
+                value,
+            } => write!(
+                f,
+                "allowed tuple constraint {id:?} row {tuple_index} variable {variable:?} has encoded value {value:?} outside {domain:?} domain"
+            ),
             Self::BinaryDomainMismatch {
                 left,
                 right,
@@ -801,6 +1098,23 @@ impl fmt::Display for CompiledSelectorProblemError {
             Self::OrdinalBeforeDomainMismatch { left, right } => write!(
                 f,
                 "ordinal_before constraint {left:?}/{right:?} must reference statement ordinals"
+            ),
+            Self::DegenerateLinearConstraint => {
+                write!(f, "linear constraint has no variables")
+            }
+            Self::LinearArityMismatch {
+                variables,
+                coefficients,
+            } => write!(
+                f,
+                "linear constraint has {variables} variables but {coefficients} coefficients"
+            ),
+            Self::InvalidLinearDomain => {
+                write!(f, "linear constraint has an invalid domain")
+            }
+            Self::LinearDomainMismatch { variable, domain } => write!(
+                f,
+                "linear constraint variable {variable:?} has {domain:?} domain, expected statement ordinals"
             ),
             Self::DegenerateAllDifferent { id } => {
                 write!(
@@ -820,6 +1134,9 @@ impl fmt::Display for CompiledSelectorProblemError {
                 f,
                 "all_different constraint {id:?} mixes {expected:?} and {actual:?} domains"
             ),
+            Self::InternalVariableValueOutOfDomain { value } => {
+                write!(f, "internal integer variable has invalid value {value:?}")
+            }
             Self::TargetInjectivityProjectionMismatch { id } => write!(
                 f,
                 "target-injectivity all_different constraint {id:?} does not match target projections"
@@ -866,6 +1183,7 @@ pub struct BackendSolveResult {
     pub assignment_coverage: BackendAssignmentCoverage,
     pub assignments: Vec<BackendAssignment>,
     pub diagnostic: Option<String>,
+    pub solver_response_stats: Option<String>,
 }
 
 pub trait SelectorProblemBackend {
@@ -935,4 +1253,10 @@ fn backend_value_index(value: BackendValueId) -> Result<usize, BackendAssignment
         return Err(BackendAssignmentError::NegativeValue { value });
     }
     usize::try_from(value.0).map_err(|_| BackendAssignmentError::ValueIndexOutOfRange { value })
+}
+
+fn backend_value_id(count: usize) -> Result<BackendValueId, CompiledSelectorProblemError> {
+    Ok(BackendValueId(i64::try_from(count).map_err(|_| {
+        CompiledSelectorProblemError::TooManyValues { count }
+    })?))
 }

--- a/devinfra/js/debundle/selector_constraint_model_builder.rs
+++ b/devinfra/js/debundle/selector_constraint_model_builder.rs
@@ -1,6 +1,6 @@
 //! Lowering from selector IR plus facts into a compact finite-domain problem.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::error::Error;
 use std::fmt;
 
@@ -8,7 +8,7 @@ use analysis::{OwnerId, StatementOrdinal};
 use chunk_facts::NodeId;
 use regex::Regex;
 use selector_constraint_backend::{
-    AllDifferentReason, BinaryConstraintKind, CompiledSelectorProblem,
+    AllDifferentReason, BackendValueId, BinaryConstraintKind, CompiledSelectorProblem,
     CompiledSelectorProblemBuilder, CompiledSelectorProblemError, ConstraintValue,
     ConstraintVariableId, TargetBindingProjection,
 };
@@ -256,16 +256,14 @@ fn lower_atom_constraint(
             parent,
             index,
             child,
-        } => {
-            let facts = domains
-                .ast_children
-                .iter()
-                .filter_map(|(fact_parent, fact_index, fact_child)| {
-                    (*fact_index == *index).then_some((*fact_parent, *fact_child))
-                })
-                .collect::<BTreeSet<_>>();
-            add_node_node_allowed_tuples(model, variables, parent, child, &facts)
-        }
+        } => add_ast_child_allowed_tuples(
+            model,
+            variables,
+            parent,
+            *index,
+            child,
+            &domains.ast_children_by_parent,
+        ),
         SelectorAtom::AstSuperClass {
             class_node,
             super_class,
@@ -383,19 +381,13 @@ fn lower_atom_constraint(
             variables,
             node,
             ordinal,
-            &domains.ast_top_levels,
+            &domains.ast_top_level_positions,
         ),
         SelectorAtom::OrdinalOffset {
             base,
             ordinal,
             offset,
-        } => add_ordinal_ordinal_allowed_tuples(
-            model,
-            variables,
-            base,
-            ordinal,
-            &domains.ordinal_offset_rows(*offset),
-        ),
+        } => add_ordinal_offset_constraint(model, variables, base, ordinal, *offset),
         SelectorAtom::ReadsMember {
             owner,
             object: None,
@@ -647,16 +639,16 @@ fn add_owner_string_allowed_tuples(
         .map(|(fact_owner, fact_string)| {
             let mut tuple = Vec::with_capacity(constraint_variables.len());
             if matches!(owner, OwnerTerm::Var { .. }) {
-                tuple.push(ConstraintValue::Owner(*fact_owner));
+                tuple.push(model.intern_owner(*fact_owner)?);
             }
             if matches!(string, StringTerm::Var { .. }) {
-                tuple.push(ConstraintValue::String(fact_string.clone()));
+                tuple.push(model.intern_string(fact_string)?);
             }
-            tuple
+            Ok(tuple)
         })
-        .collect::<BTreeSet<_>>();
+        .collect::<Result<Vec<_>, CompiledSelectorProblemError>>()?;
 
-    add_allowed_tuple_set(model, constraint_variables, tuples)
+    add_encoded_allowed_tuple_set(model, constraint_variables, tuples)
 }
 
 fn add_owner_ordinal_allowed_tuples(
@@ -696,16 +688,16 @@ fn add_owner_ordinal_allowed_tuples(
         .map(|(fact_owner, fact_ordinal)| {
             let mut tuple = Vec::with_capacity(constraint_variables.len());
             if matches!(owner, OwnerTerm::Var { .. }) {
-                tuple.push(ConstraintValue::Owner(*fact_owner));
+                tuple.push(model.intern_owner(*fact_owner)?);
             }
             if matches!(ordinal, OrdinalTerm::Var { .. }) {
-                tuple.push(ConstraintValue::StatementOrdinal(*fact_ordinal));
+                tuple.push(model.intern_statement_ordinal(*fact_ordinal)?);
             }
-            tuple
+            Ok(tuple)
         })
-        .collect::<BTreeSet<_>>();
+        .collect::<Result<Vec<_>, CompiledSelectorProblemError>>()?;
 
-    add_allowed_tuple_set(model, constraint_variables, tuples)
+    add_encoded_allowed_tuple_set(model, constraint_variables, tuples)
 }
 
 fn add_owner_allowed_tuples(
@@ -733,10 +725,10 @@ fn add_owner_allowed_tuples(
     let tuples = facts
         .iter()
         .filter(|fact_owner| owner_term_matches(owner, **fact_owner))
-        .map(|fact_owner| vec![ConstraintValue::Owner(*fact_owner)])
-        .collect::<BTreeSet<_>>();
+        .map(|fact_owner| model.intern_owner(*fact_owner).map(|value| vec![value]))
+        .collect::<Result<Vec<_>, _>>()?;
 
-    add_allowed_tuple_set(model, constraint_variables, tuples)
+    add_encoded_allowed_tuple_set(model, constraint_variables, tuples)
 }
 
 fn add_owner_owner_allowed_tuples(
@@ -775,16 +767,16 @@ fn add_owner_owner_allowed_tuples(
         .map(|(fact_left, fact_right)| {
             let mut tuple = Vec::with_capacity(constraint_variables.len());
             if matches!(left, OwnerTerm::Var { .. }) {
-                tuple.push(ConstraintValue::Owner(*fact_left));
+                tuple.push(model.intern_owner(*fact_left)?);
             }
             if matches!(right, OwnerTerm::Var { .. }) {
-                tuple.push(ConstraintValue::Owner(*fact_right));
+                tuple.push(model.intern_owner(*fact_right)?);
             }
-            tuple
+            Ok(tuple)
         })
-        .collect::<BTreeSet<_>>();
+        .collect::<Result<Vec<_>, CompiledSelectorProblemError>>()?;
 
-    add_allowed_tuple_set(model, constraint_variables, tuples)
+    add_encoded_allowed_tuple_set(model, constraint_variables, tuples)
 }
 
 fn add_owner_node_allowed_tuples(
@@ -823,16 +815,16 @@ fn add_owner_node_allowed_tuples(
         .map(|(fact_owner, fact_node)| {
             let mut tuple = Vec::with_capacity(constraint_variables.len());
             if matches!(owner, OwnerTerm::Var { .. }) {
-                tuple.push(ConstraintValue::Owner(*fact_owner));
+                tuple.push(model.intern_owner(*fact_owner)?);
             }
             if matches!(node, NodeTerm::Var { .. }) {
-                tuple.push(ConstraintValue::AstNode(*fact_node));
+                tuple.push(model.intern_ast_node(*fact_node)?);
             }
-            tuple
+            Ok(tuple)
         })
-        .collect::<BTreeSet<_>>();
+        .collect::<Result<Vec<_>, CompiledSelectorProblemError>>()?;
 
-    add_allowed_tuple_set(model, constraint_variables, tuples)
+    add_encoded_allowed_tuple_set(model, constraint_variables, tuples)
 }
 
 fn add_node_node_allowed_tuples(
@@ -871,16 +863,68 @@ fn add_node_node_allowed_tuples(
         .map(|(fact_left, fact_right)| {
             let mut tuple = Vec::with_capacity(constraint_variables.len());
             if matches!(left, NodeTerm::Var { .. }) {
-                tuple.push(ConstraintValue::AstNode(*fact_left));
+                tuple.push(model.intern_ast_node(*fact_left)?);
             }
             if matches!(right, NodeTerm::Var { .. }) {
-                tuple.push(ConstraintValue::AstNode(*fact_right));
+                tuple.push(model.intern_ast_node(*fact_right)?);
             }
-            tuple
+            Ok(tuple)
         })
-        .collect::<BTreeSet<_>>();
+        .collect::<Result<Vec<_>, CompiledSelectorProblemError>>()?;
 
-    add_allowed_tuple_set(model, constraint_variables, tuples)
+    add_encoded_allowed_tuple_set(model, constraint_variables, tuples)
+}
+
+fn add_ast_child_allowed_tuples(
+    model: &mut CompiledSelectorProblemBuilder,
+    variables: &[ConstraintVariableId],
+    parent: &NodeTerm,
+    child_index: u32,
+    child: &NodeTerm,
+    ast_children_by_parent: &BTreeMap<NodeId, Vec<(u32, NodeId)>>,
+) -> Result<(), CompiledSelectorProblemBuildError> {
+    let mut constraint_variables = Vec::new();
+    if let NodeTerm::Var { id } = parent {
+        constraint_variables.push(model_variable(variables, *id)?);
+    }
+    if let NodeTerm::Var { id } = child {
+        constraint_variables.push(model_variable(variables, *id)?);
+    }
+
+    let mut tuples = Vec::new();
+    let mut constant_only_match = false;
+    for (fact_parent, children) in ast_children_by_parent {
+        if !node_term_matches(parent, *fact_parent) {
+            continue;
+        }
+        for (fact_index, fact_child) in children {
+            if *fact_index != child_index || !node_term_matches(child, *fact_child) {
+                continue;
+            }
+            if constraint_variables.is_empty() {
+                constant_only_match = true;
+                continue;
+            }
+            let mut tuple = Vec::with_capacity(constraint_variables.len());
+            if matches!(parent, NodeTerm::Var { .. }) {
+                tuple.push(model.intern_ast_node(*fact_parent)?);
+            }
+            if matches!(child, NodeTerm::Var { .. }) {
+                tuple.push(model.intern_ast_node(*fact_child)?);
+            }
+            tuples.push(tuple);
+        }
+    }
+
+    if constraint_variables.is_empty() {
+        return constant_only_match.then_some(()).ok_or_else(|| {
+            CompiledSelectorProblemBuildError::ConstantOnlyAtomUnsatisfied {
+                atom: format!("ast_child fact {parent:?} {child_index} {child:?}"),
+            }
+        });
+    }
+
+    add_encoded_allowed_tuple_set(model, constraint_variables, tuples)
 }
 
 fn add_node_allowed_tuples(
@@ -908,10 +952,10 @@ fn add_node_allowed_tuples(
     let tuples = facts
         .iter()
         .filter(|fact_node| node_term_matches(node, **fact_node))
-        .map(|fact_node| vec![ConstraintValue::AstNode(*fact_node)])
-        .collect::<BTreeSet<_>>();
+        .map(|fact_node| model.intern_ast_node(*fact_node).map(|value| vec![value]))
+        .collect::<Result<Vec<_>, _>>()?;
 
-    add_allowed_tuple_set(model, constraint_variables, tuples)
+    add_encoded_allowed_tuple_set(model, constraint_variables, tuples)
 }
 
 fn add_node_string_allowed_tuples(
@@ -950,16 +994,16 @@ fn add_node_string_allowed_tuples(
         .map(|(fact_node, fact_string)| {
             let mut tuple = Vec::with_capacity(constraint_variables.len());
             if matches!(node, NodeTerm::Var { .. }) {
-                tuple.push(ConstraintValue::AstNode(*fact_node));
+                tuple.push(model.intern_ast_node(*fact_node)?);
             }
             if matches!(string, StringTerm::Var { .. }) {
-                tuple.push(ConstraintValue::String(fact_string.clone()));
+                tuple.push(model.intern_string(fact_string)?);
             }
-            tuple
+            Ok(tuple)
         })
-        .collect::<BTreeSet<_>>();
+        .collect::<Result<Vec<_>, CompiledSelectorProblemError>>()?;
 
-    add_allowed_tuple_set(model, constraint_variables, tuples)
+    add_encoded_allowed_tuple_set(model, constraint_variables, tuples)
 }
 
 fn add_ast_string_literal_matching_regex_allowed_tuples(
@@ -1017,65 +1061,91 @@ fn add_node_ordinal_allowed_tuples(
         .map(|(fact_node, fact_ordinal)| {
             let mut tuple = Vec::with_capacity(constraint_variables.len());
             if matches!(node, NodeTerm::Var { .. }) {
-                tuple.push(ConstraintValue::AstNode(*fact_node));
+                tuple.push(model.intern_ast_node(*fact_node)?);
             }
             if matches!(ordinal, OrdinalTerm::Var { .. }) {
-                tuple.push(ConstraintValue::StatementOrdinal(*fact_ordinal));
+                tuple.push(model.intern_statement_ordinal(*fact_ordinal)?);
             }
-            tuple
+            Ok(tuple)
         })
-        .collect::<BTreeSet<_>>();
+        .collect::<Result<Vec<_>, CompiledSelectorProblemError>>()?;
 
-    add_allowed_tuple_set(model, constraint_variables, tuples)
+    add_encoded_allowed_tuple_set(model, constraint_variables, tuples)
 }
 
-fn add_ordinal_ordinal_allowed_tuples(
+fn add_ordinal_offset_constraint(
     model: &mut CompiledSelectorProblemBuilder,
     variables: &[ConstraintVariableId],
     base: &OrdinalTerm,
     ordinal: &OrdinalTerm,
-    facts: &BTreeSet<(StatementOrdinal, StatementOrdinal)>,
+    offset: i32,
 ) -> Result<(), CompiledSelectorProblemBuildError> {
-    let mut constraint_variables = Vec::new();
-    if let OrdinalTerm::Var { id } = base {
-        constraint_variables.push(model_variable(variables, *id)?);
-    }
-    if let OrdinalTerm::Var { id } = ordinal {
-        constraint_variables.push(model_variable(variables, *id)?);
-    }
-    if constraint_variables.is_empty() {
-        return facts
-            .iter()
-            .any(|(fact_base, fact_ordinal)| {
-                ordinal_term_matches(base, *fact_base)
-                    && ordinal_term_matches(ordinal, *fact_ordinal)
-            })
-            .then_some(())
-            .ok_or_else(
-                || CompiledSelectorProblemBuildError::ConstantOnlyAtomUnsatisfied {
-                    atom: format!("ordinal/ordinal fact {base:?} {ordinal:?}"),
-                },
-            );
-    }
+    let base = ordinal_linear_variable(model, variables, base)?;
+    let ordinal = ordinal_linear_variable(model, variables, ordinal)?;
+    add_linear_offset_equality(model, base, ordinal, i64::from(offset))
+}
 
-    let tuples = facts
-        .iter()
-        .filter(|(fact_base, fact_ordinal)| {
-            ordinal_term_matches(base, *fact_base) && ordinal_term_matches(ordinal, *fact_ordinal)
-        })
-        .map(|(fact_base, fact_ordinal)| {
-            let mut tuple = Vec::with_capacity(constraint_variables.len());
-            if matches!(base, OrdinalTerm::Var { .. }) {
-                tuple.push(ConstraintValue::StatementOrdinal(*fact_base));
-            }
-            if matches!(ordinal, OrdinalTerm::Var { .. }) {
-                tuple.push(ConstraintValue::StatementOrdinal(*fact_ordinal));
-            }
-            tuple
-        })
-        .collect::<BTreeSet<_>>();
+fn ordinal_linear_variable(
+    model: &mut CompiledSelectorProblemBuilder,
+    variables: &[ConstraintVariableId],
+    term: &OrdinalTerm,
+) -> Result<ConstraintVariableId, CompiledSelectorProblemBuildError> {
+    match term {
+        OrdinalTerm::Var { id } => model_variable(variables, *id),
+        OrdinalTerm::Const { ordinal } => {
+            let value = model.intern_statement_ordinal(*ordinal)?;
+            model
+                .add_internal_integer_variable(
+                    Some(format!("ordinal_const.{}", ordinal.0)),
+                    std::iter::once(value),
+                )
+                .map_err(Into::into)
+        }
+    }
+}
 
-    add_allowed_tuple_set(model, constraint_variables, tuples)
+fn add_linear_offset_equality(
+    model: &mut CompiledSelectorProblemBuilder,
+    left: ConstraintVariableId,
+    right: ConstraintVariableId,
+    offset: i64,
+) -> Result<(), CompiledSelectorProblemBuildError> {
+    model
+        .add_linear_constraint(vec![left, right], vec![1, -1], offset, vec![0, 0])
+        .map_err(Into::into)
+}
+
+fn add_linear_offset_less_or_equal(
+    model: &mut CompiledSelectorProblemBuilder,
+    left: ConstraintVariableId,
+    right: ConstraintVariableId,
+    offset: i64,
+) -> Result<(), CompiledSelectorProblemBuildError> {
+    let lower_bound = linear_offset_less_or_equal_lower_bound(model, left, right, offset)?;
+    model
+        .add_linear_constraint(vec![left, right], vec![1, -1], offset, vec![lower_bound, 0])
+        .map_err(Into::into)
+}
+
+fn linear_offset_less_or_equal_lower_bound(
+    model: &CompiledSelectorProblemBuilder,
+    left: ConstraintVariableId,
+    right: ConstraintVariableId,
+    offset: i64,
+) -> Result<i64, CompiledSelectorProblemBuildError> {
+    let left_values = model.variable_domain_values(left)?;
+    let right_values = model.variable_domain_values(right)?;
+    let Some(min_left) = left_values.first() else {
+        return Ok(0);
+    };
+    let Some(max_right) = right_values.last() else {
+        return Ok(0);
+    };
+    let lower = i128::from(min_left.0) - i128::from(max_right.0) + i128::from(offset);
+    let lower = lower.min(0);
+    i64::try_from(lower).map_err(|_| CompiledSelectorProblemBuildError::UnsupportedAtom {
+        atom: "linear constraint lower bound exceeds i64 range".to_string(),
+    })
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1126,6 +1196,11 @@ impl LoweredChildListPattern {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+struct ChildListSegmentPosition {
+    start: ConstraintVariableId,
+}
+
 fn add_ast_child_list_pattern_allowed_tuples(
     model: &mut CompiledSelectorProblemBuilder,
     variables: &[ConstraintVariableId],
@@ -1138,31 +1213,94 @@ fn add_ast_child_list_pattern_allowed_tuples(
         return Ok(());
     }
 
-    for segment_index in 0..pattern.segments.len() {
-        add_child_list_segment_constraint(model, &pattern, segment_index, domains)?;
+    if pattern.segments.len() == 1 {
+        return add_child_list_segment_constraint(model, &pattern, 0, None, domains);
+    }
+
+    let positions = add_child_list_segment_position_variables(model, &pattern, domains)?;
+    for (segment_index, position) in positions.iter().copied().enumerate() {
+        add_child_list_segment_constraint(model, &pattern, segment_index, Some(position), domains)?;
     }
     for segment_index in 1..pattern.segments.len() {
-        add_child_list_segment_order_constraint(model, &pattern, segment_index, domains)?;
+        add_linear_offset_less_or_equal(
+            model,
+            positions[segment_index - 1].start,
+            positions[segment_index].start,
+            child_list_segment_length(&pattern.segments[segment_index - 1])?,
+        )?;
     }
     Ok(())
+}
+
+fn add_child_list_segment_position_variables(
+    model: &mut CompiledSelectorProblemBuilder,
+    pattern: &LoweredChildListPattern,
+    domains: &FactDomains,
+) -> Result<Vec<ChildListSegmentPosition>, CompiledSelectorProblemBuildError> {
+    let index_values = child_list_index_domain_values(pattern, domains);
+    let mut positions = Vec::with_capacity(pattern.segments.len());
+    for segment_index in 0..pattern.segments.len() {
+        let start = model.add_internal_integer_variable(
+            Some(format!("ast_child_list.segment{segment_index}.start")),
+            index_values.iter().copied(),
+        )?;
+        positions.push(ChildListSegmentPosition { start });
+    }
+    Ok(positions)
+}
+
+fn child_list_segment_length(
+    segment: &[LoweredNodeTerm],
+) -> Result<i64, CompiledSelectorProblemBuildError> {
+    i64::try_from(segment.len()).map_err(|_| CompiledSelectorProblemBuildError::UnsupportedAtom {
+        atom: "child-list segment length exceeds i64 range".to_string(),
+    })
+}
+
+fn child_list_index_domain_values(
+    pattern: &LoweredChildListPattern,
+    domains: &FactDomains,
+) -> Vec<BackendValueId> {
+    let mut values = BTreeSet::new();
+    for candidate_parent in
+        child_list_candidate_parents(pattern.parent, &domains.ast_children_by_parent)
+    {
+        for (index, _child) in child_list_subject_children(
+            &domains.ast_children_by_parent,
+            candidate_parent,
+            pattern.start_index,
+        ) {
+            values.insert(BackendValueId(i64::from(*index)));
+        }
+    }
+    if values.is_empty() {
+        return vec![BackendValueId(0)];
+    }
+    values.into_iter().collect()
 }
 
 fn add_child_list_segment_constraint(
     model: &mut CompiledSelectorProblemBuilder,
     pattern: &LoweredChildListPattern,
     segment_index: usize,
+    position: Option<ChildListSegmentPosition>,
     domains: &FactDomains,
 ) -> Result<(), CompiledSelectorProblemBuildError> {
     let segment = &pattern.segments[segment_index];
-    let constraint_variables = child_list_constraint_variables(
+    let mut constraint_variables = position
+        .map(|position| vec![position.start])
+        .unwrap_or_default();
+    constraint_variables.extend(child_list_constraint_variables(
         std::iter::once(pattern.parent).chain(segment.iter().copied()),
-    );
-    let mut tuples = BTreeSet::new();
+    ));
+    let mut tuples = Vec::new();
     let mut constant_only_match = false;
 
-    for candidate_parent in child_list_candidate_parents(pattern.parent, &domains.ast_children) {
+    for candidate_parent in
+        child_list_candidate_parents(pattern.parent, &domains.ast_children_by_parent)
+    {
         let subject_children = child_list_subject_children(
-            &domains.ast_children,
+            &domains.ast_children_by_parent,
             candidate_parent,
             pattern.start_index,
         );
@@ -1183,12 +1321,23 @@ fn add_child_list_segment_constraint(
 
         for start in lo..=hi {
             let mut current = Vec::new();
-            if !bind_node_term(pattern.parent, candidate_parent, &mut current) {
+            if let Some(position) = position {
+                current.push((
+                    position.start,
+                    BackendValueId(i64::from(subject_children[start].0)),
+                ));
+            }
+            if !bind_node_term(model, pattern.parent, candidate_parent, &mut current)? {
                 continue;
             }
             let mut segment_matches = true;
             for (offset, term) in segment.iter().enumerate() {
-                if !bind_node_term(*term, subject_children[start + offset], &mut current) {
+                if !bind_node_term(
+                    model,
+                    *term,
+                    subject_children[start + offset].1,
+                    &mut current,
+                )? {
                     segment_matches = false;
                     break;
                 }
@@ -1212,62 +1361,7 @@ fn add_child_list_segment_constraint(
         });
     }
 
-    add_allowed_tuple_set(model, constraint_variables, tuples)
-}
-
-fn add_child_list_segment_order_constraint(
-    model: &mut CompiledSelectorProblemBuilder,
-    pattern: &LoweredChildListPattern,
-    segment_index: usize,
-    domains: &FactDomains,
-) -> Result<(), CompiledSelectorProblemBuildError> {
-    let previous = &pattern.segments[segment_index - 1];
-    let current = &pattern.segments[segment_index];
-    let previous_last = *previous
-        .last()
-        .expect("child-list pattern segments are filtered to be non-empty");
-    let current_first = *current
-        .first()
-        .expect("child-list pattern segments are filtered to be non-empty");
-    let constraint_variables =
-        child_list_constraint_variables([pattern.parent, previous_last, current_first]);
-    let mut tuples = BTreeSet::new();
-    let mut constant_only_match = false;
-
-    for candidate_parent in child_list_candidate_parents(pattern.parent, &domains.ast_children) {
-        let subject_children = child_list_subject_children(
-            &domains.ast_children,
-            candidate_parent,
-            pattern.start_index,
-        );
-        for (left_index, left_child) in subject_children.iter().enumerate() {
-            for right_child in subject_children.iter().skip(left_index + 1) {
-                let mut current = Vec::new();
-                if !bind_node_term(pattern.parent, candidate_parent, &mut current)
-                    || !bind_node_term(previous_last, *left_child, &mut current)
-                    || !bind_node_term(current_first, *right_child, &mut current)
-                {
-                    continue;
-                }
-                finish_child_list_tuple(
-                    &constraint_variables,
-                    &current,
-                    &mut tuples,
-                    &mut constant_only_match,
-                );
-            }
-        }
-    }
-
-    if constraint_variables.is_empty() {
-        return constant_only_match.then_some(()).ok_or_else(|| {
-            CompiledSelectorProblemBuildError::ConstantOnlyAtomUnsatisfied {
-                atom: "ast_child_list_pattern".to_string(),
-            }
-        });
-    }
-
-    add_allowed_tuple_set(model, constraint_variables, tuples)
+    add_encoded_allowed_tuple_set(model, constraint_variables, tuples)
 }
 
 fn child_list_constraint_variables<I>(terms: I) -> Vec<ConstraintVariableId>
@@ -1298,86 +1392,72 @@ fn lower_node_term(
 
 fn child_list_candidate_parents(
     parent: LoweredNodeTerm,
-    ast_children: &BTreeSet<(NodeId, u32, NodeId)>,
+    ast_children_by_parent: &BTreeMap<NodeId, Vec<(u32, NodeId)>>,
 ) -> Box<dyn Iterator<Item = NodeId> + '_> {
     match parent {
         LoweredNodeTerm::Const(node) => Box::new(std::iter::once(node)),
-        LoweredNodeTerm::Var(_) => Box::new(
-            ast_children
-                .iter()
-                .map(|(parent, _index, _child)| *parent)
-                .collect::<BTreeSet<_>>()
-                .into_iter(),
-        ),
+        LoweredNodeTerm::Var(_) => Box::new(ast_children_by_parent.keys().copied()),
     }
 }
 
 fn child_list_subject_children(
-    ast_children: &BTreeSet<(NodeId, u32, NodeId)>,
+    ast_children_by_parent: &BTreeMap<NodeId, Vec<(u32, NodeId)>>,
     parent: NodeId,
     start_index: u32,
-) -> Vec<NodeId> {
-    ast_children
-        .iter()
-        .filter(|(fact_parent, index, _child)| *fact_parent == parent && *index >= start_index)
-        .map(|(_parent, _index, child)| *child)
-        .collect()
+) -> &[(u32, NodeId)] {
+    let Some(children) = ast_children_by_parent.get(&parent) else {
+        return &[];
+    };
+    let start = children.partition_point(|(index, _child)| *index < start_index);
+    &children[start..]
 }
 
 fn bind_node_term(
+    model: &mut CompiledSelectorProblemBuilder,
     term: LoweredNodeTerm,
     actual: NodeId,
-    current: &mut Vec<(ConstraintVariableId, ConstraintValue)>,
-) -> bool {
+    current: &mut Vec<(ConstraintVariableId, BackendValueId)>,
+) -> Result<bool, CompiledSelectorProblemError> {
     match term {
         LoweredNodeTerm::Var(variable) => {
-            current.push((variable, ConstraintValue::AstNode(actual)));
-            true
+            current.push((variable, model.intern_ast_node(actual)?));
+            Ok(true)
         }
-        LoweredNodeTerm::Const(expected) => expected == actual,
+        LoweredNodeTerm::Const(expected) => Ok(expected == actual),
     }
 }
 
 fn finish_child_list_tuple(
     constraint_variables: &[ConstraintVariableId],
-    current: &[(ConstraintVariableId, ConstraintValue)],
-    tuples: &mut BTreeSet<Vec<ConstraintValue>>,
+    current: &[(ConstraintVariableId, BackendValueId)],
+    tuples: &mut Vec<Vec<BackendValueId>>,
     constant_only_match: &mut bool,
 ) {
-    let Some(merged) = merge_node_assignment_bindings(current.to_vec()) else {
-        return;
-    };
     if constraint_variables.is_empty() {
         *constant_only_match = true;
         return;
     }
-    let assignments = merged.into_iter().collect::<BTreeMap<_, _>>();
-    if let Some(tuple) = constraint_variables
-        .iter()
-        .map(|variable| assignments.get(variable).cloned())
-        .collect::<Option<Vec<_>>>()
-    {
-        tuples.insert(tuple);
-    }
-}
-
-fn merge_node_assignment_bindings(
-    mut row: Vec<(ConstraintVariableId, ConstraintValue)>,
-) -> Option<Vec<(ConstraintVariableId, ConstraintValue)>> {
-    row.sort_by_key(|(variable, _value)| *variable);
-    let mut merged = Vec::with_capacity(row.len());
-    for (variable, value) in row {
-        if let Some((last_variable, last_value)) = merged.last() {
-            if *last_variable == variable {
-                if *last_value != value {
-                    return None;
-                }
+    let mut tuple = Vec::with_capacity(constraint_variables.len());
+    for variable in constraint_variables {
+        let mut bound_value = None;
+        for (current_variable, current_value) in current {
+            if current_variable != variable {
                 continue;
             }
+            match bound_value {
+                Some(existing) if existing != *current_value => {
+                    return;
+                }
+                Some(_) => {}
+                None => bound_value = Some(*current_value),
+            }
         }
-        merged.push((variable, value));
+        let Some(value) = bound_value else {
+            return;
+        };
+        tuple.push(value);
     }
-    Some(merged)
+    tuples.push(tuple);
 }
 
 fn add_ast_bare_property_allowed_tuples(
@@ -1429,19 +1509,19 @@ fn add_ast_bare_property_allowed_tuples(
         .map(|(fact_node, fact_key, fact_identifier, _)| {
             let mut tuple = Vec::with_capacity(constraint_variables.len());
             if matches!(node, NodeTerm::Var { .. }) {
-                tuple.push(ConstraintValue::AstNode(*fact_node));
+                tuple.push(model.intern_ast_node(*fact_node)?);
             }
             if matches!(key, StringTerm::Var { .. }) {
-                tuple.push(ConstraintValue::String(fact_key.clone()));
+                tuple.push(model.intern_string(fact_key)?);
             }
             if matches!(identifier, StringTerm::Var { .. }) {
-                tuple.push(ConstraintValue::String(fact_identifier.clone()));
+                tuple.push(model.intern_string(fact_identifier)?);
             }
-            tuple
+            Ok(tuple)
         })
-        .collect::<BTreeSet<_>>();
+        .collect::<Result<Vec<_>, CompiledSelectorProblemError>>()?;
 
-    add_allowed_tuple_set(model, constraint_variables, tuples)
+    add_encoded_allowed_tuple_set(model, constraint_variables, tuples)
 }
 
 fn add_ast_regex_literal_allowed_tuples(
@@ -1488,41 +1568,37 @@ fn add_ast_regex_literal_allowed_tuples(
         .map(|(fact_node, fact_pattern, fact_flags)| {
             let mut tuple = Vec::with_capacity(constraint_variables.len());
             if matches!(node, NodeTerm::Var { .. }) {
-                tuple.push(ConstraintValue::AstNode(*fact_node));
+                tuple.push(model.intern_ast_node(*fact_node)?);
             }
             if matches!(pattern, StringTerm::Var { .. }) {
-                tuple.push(ConstraintValue::String(fact_pattern.clone()));
+                tuple.push(model.intern_string(fact_pattern)?);
             }
             if matches!(flags, StringTerm::Var { .. }) {
-                tuple.push(ConstraintValue::String(fact_flags.clone()));
+                tuple.push(model.intern_string(fact_flags)?);
             }
-            tuple
+            Ok(tuple)
         })
-        .collect::<BTreeSet<_>>();
+        .collect::<Result<Vec<_>, CompiledSelectorProblemError>>()?;
 
-    add_allowed_tuple_set(model, constraint_variables, tuples)
+    add_encoded_allowed_tuple_set(model, constraint_variables, tuples)
 }
 
-fn add_allowed_tuple_set(
+fn add_encoded_allowed_tuple_set(
     model: &mut CompiledSelectorProblemBuilder,
     variables: Vec<ConstraintVariableId>,
-    tuples: BTreeSet<Vec<ConstraintValue>>,
+    tuples: Vec<Vec<BackendValueId>>,
 ) -> Result<(), CompiledSelectorProblemBuildError> {
-    let (variables, tuples) = normalize_allowed_tuple_columns(variables, tuples);
+    let (variables, tuples) = normalize_encoded_allowed_tuple_columns(variables, tuples);
     model
-        .add_allowed_tuples(variables, tuples.into_iter().collect())
+        .add_encoded_allowed_tuples(variables, tuples)
         .map(|_| ())
         .map_err(Into::into)
 }
 
-fn normalize_allowed_tuple_columns(
+fn normalize_encoded_allowed_tuple_columns(
     variables: Vec<ConstraintVariableId>,
-    tuples: BTreeSet<Vec<ConstraintValue>>,
-) -> (Vec<ConstraintVariableId>, BTreeSet<Vec<ConstraintValue>>) {
-    if tuples.iter().any(|tuple| tuple.len() != variables.len()) {
-        return (variables, tuples);
-    }
-
+    tuples: Vec<Vec<BackendValueId>>,
+) -> (Vec<ConstraintVariableId>, Vec<Vec<BackendValueId>>) {
     let mut unique_variables = Vec::new();
     let mut column_by_variable = BTreeMap::new();
     let mut output_column_by_input = Vec::with_capacity(variables.len());
@@ -1542,7 +1618,7 @@ fn normalize_allowed_tuple_columns(
         return (variables, tuples);
     }
 
-    let mut normalized_tuples = BTreeSet::new();
+    let mut normalized_tuples = HashSet::new();
     'row: for tuple in tuples {
         let mut normalized = vec![None; unique_variables.len()];
         for (value, output_column) in tuple
@@ -1565,7 +1641,7 @@ fn normalize_allowed_tuple_columns(
         );
     }
 
-    (unique_variables, normalized_tuples)
+    (unique_variables, normalized_tuples.into_iter().collect())
 }
 
 fn owner_term_matches(term: &OwnerTerm, owner: OwnerId) -> bool {
@@ -1714,7 +1790,7 @@ struct FactDomains {
     references_owner: BTreeSet<(OwnerId, OwnerId)>,
     aliases_owner: BTreeSet<(OwnerId, OwnerId)>,
     ast_kinds: BTreeSet<(NodeId, String)>,
-    ast_children: BTreeSet<(NodeId, u32, NodeId)>,
+    ast_children_by_parent: BTreeMap<NodeId, Vec<(u32, NodeId)>>,
     ast_child_counts: BTreeSet<(NodeId, u32)>,
     ast_super_classes: BTreeSet<(NodeId, NodeId)>,
     ast_string_literals: BTreeSet<(NodeId, String)>,
@@ -1726,6 +1802,7 @@ struct FactDomains {
     ast_operators: BTreeSet<(NodeId, String)>,
     ast_regex_literals: BTreeSet<(NodeId, String, String)>,
     ast_top_levels: BTreeSet<(NodeId, StatementOrdinal)>,
+    ast_top_level_positions: BTreeSet<(NodeId, StatementOrdinal)>,
     raw_member_reads: BTreeSet<(StatementOrdinal, Option<String>, String)>,
     member_reads: BTreeSet<(OwnerId, String)>,
     member_reads_from_binding: BTreeSet<(OwnerId, String, String)>,
@@ -1747,6 +1824,7 @@ impl FactDomains {
     fn from_program_and_facts(program: &SelectorProgram, facts: &SelectorFactStore) -> Self {
         let mut domains = Self::default();
         domains.add_facts(facts);
+        domains.finalize_indexes();
         domains.add_derived_facts();
         domains.add_program_constants(program);
         domains
@@ -1898,7 +1976,10 @@ impl FactDomains {
                 } => {
                     self.add_node(*parent);
                     self.add_node(*child);
-                    self.ast_children.insert((*parent, *index, *child));
+                    self.ast_children_by_parent
+                        .entry(*parent)
+                        .or_default()
+                        .push((*index, *child));
                 }
                 SelectorFact::AstSuperClass {
                     class_node,
@@ -1992,6 +2073,13 @@ impl FactDomains {
         }
     }
 
+    fn finalize_indexes(&mut self) {
+        for children in self.ast_children_by_parent.values_mut() {
+            children.sort_unstable();
+            children.dedup();
+        }
+    }
+
     fn add_derived_facts(&mut self) {
         let mut owners_with_declarations = BTreeSet::new();
         let mut owners_by_binding: BTreeMap<String, BTreeSet<OwnerId>> = BTreeMap::new();
@@ -2001,6 +2089,28 @@ impl FactDomains {
                 .entry(binding.clone())
                 .or_default()
                 .insert(*owner);
+        }
+        let mut top_level_nodes_by_ordinal: BTreeMap<StatementOrdinal, Vec<NodeId>> =
+            BTreeMap::new();
+        for (node, ordinal) in &self.ast_top_levels {
+            top_level_nodes_by_ordinal
+                .entry(*ordinal)
+                .or_default()
+                .push(*node);
+        }
+        let mut top_levels = self.ast_top_levels.iter().copied().collect::<Vec<_>>();
+        top_levels.sort_by_key(|(node, ordinal)| (*ordinal, *node));
+        for (position, (node, _ordinal)) in top_levels.into_iter().enumerate() {
+            let position = StatementOrdinal(position);
+            self.add_ordinal(position);
+            self.ast_top_level_positions.insert((node, position));
+        }
+        let mut raw_referencers_by_binding: BTreeMap<&str, Vec<OwnerId>> = BTreeMap::new();
+        for (referencer, binding, _edge_kind) in &self.raw_owner_references_binding {
+            raw_referencers_by_binding
+                .entry(binding.as_str())
+                .or_default()
+                .push(*referencer);
         }
 
         for (owner, binding, edge_kind) in &self.raw_owner_references_binding {
@@ -2134,15 +2244,13 @@ impl FactDomains {
             let Some(alias_owners) = owners_by_binding.get(binding) else {
                 continue;
             };
-            for (referencer, used_binding, _edge_kind) in &self.raw_owner_references_binding {
-                if used_binding != binding {
-                    continue;
-                }
-                self.intrinsic_alias_referenced_by.extend(
-                    alias_owners
-                        .iter()
-                        .map(|alias_owner| (*alias_owner, property.clone(), *referencer)),
-                );
+            if let Some(referencers) = raw_referencers_by_binding.get(binding.as_str()) {
+                self.intrinsic_alias_referenced_by
+                    .extend(alias_owners.iter().flat_map(|alias_owner| {
+                        referencers
+                            .iter()
+                            .map(|referencer| (*alias_owner, property.clone(), *referencer))
+                    }));
             }
         }
 
@@ -2151,18 +2259,19 @@ impl FactDomains {
             .iter()
             .map(|node| (*node, 0))
             .collect::<BTreeMap<_, _>>();
-        for (parent, index, _child) in &self.ast_children {
+        for (parent, children) in &self.ast_children_by_parent {
             let count = child_counts.entry(*parent).or_insert(0);
-            *count = (*count).max(index + 1);
+            for (index, _child) in children {
+                *count = (*count).max(index + 1);
+            }
         }
         self.ast_child_counts
             .extend(child_counts.into_iter().collect::<BTreeSet<_>>());
 
         for (owner, ordinal) in &self.owner_statement_ordinals {
-            for (node, top_level_ordinal) in &self.ast_top_levels {
-                if ordinal == top_level_ordinal {
-                    self.owner_top_level_roots.insert((*owner, *node));
-                }
+            if let Some(nodes) = top_level_nodes_by_ordinal.get(ordinal) {
+                self.owner_top_level_roots
+                    .extend(nodes.iter().map(|node| (*owner, *node)));
             }
         }
 
@@ -2178,10 +2287,6 @@ impl FactDomains {
             .iter()
             .map(|(node, value)| (*node, value.as_str()))
             .collect::<BTreeMap<_, _>>();
-        let mut children_by_parent = BTreeMap::<NodeId, Vec<NodeId>>::new();
-        for (parent, _index, child) in &self.ast_children {
-            children_by_parent.entry(*parent).or_default().push(*child);
-        }
         for (root, _ordinal) in &self.ast_top_levels {
             let mut stack = vec![*root];
             while let Some(node) = stack.pop() {
@@ -2192,35 +2297,11 @@ impl FactDomains {
                     self.owner_top_level_roots
                         .extend(owners.iter().map(|owner| (*owner, *root)));
                 }
-                if let Some(children) = children_by_parent.get(&node) {
-                    stack.extend(children.iter().copied());
+                if let Some(children) = self.ast_children_by_parent.get(&node) {
+                    stack.extend(children.iter().map(|(_index, child)| *child));
                 }
             }
         }
-    }
-
-    fn ordinal_offset_rows(&self, offset: i32) -> BTreeSet<(StatementOrdinal, StatementOrdinal)> {
-        let ordinals = self
-            .ast_top_levels
-            .iter()
-            .map(|(_node, ordinal)| *ordinal)
-            .collect::<BTreeSet<_>>()
-            .into_iter()
-            .collect::<Vec<_>>();
-        let mut rows = BTreeSet::new();
-        for (base_index, base) in ordinals.iter().enumerate() {
-            let Some(target_index) = (base_index as isize).checked_add(offset as isize) else {
-                continue;
-            };
-            if target_index < 0 {
-                continue;
-            }
-            let Some(ordinal) = ordinals.get(target_index as usize) else {
-                continue;
-            };
-            rows.insert((*base, *ordinal));
-        }
-        rows
     }
 
     fn add_fact_strings(&mut self, fact: &SelectorFact) {
@@ -2515,7 +2596,8 @@ mod tests {
     use selector_constraint_backend::{
         AllDifferentConstraintId, AllDifferentReason, AllowedTupleConstraintId, BackendValueId,
         BinaryConstraintKind, CompiledAllDifferentConstraint as AllDifferentConstraint,
-        CompiledBinaryConstraint as BinaryConstraint, ConstraintValue,
+        CompiledBinaryConstraint as BinaryConstraint, CompiledLinearConstraint as LinearConstraint,
+        ConstraintValue,
     };
     use selector_ir::{ClaimOrigin, SelectorTargetId};
     use selector_ir_lowering::{MemberSelectorLoweringContext, MemberSelectorProgramBuilder};
@@ -2714,7 +2796,7 @@ mod tests {
             tuples: constraint
                 .tuples
                 .iter()
-                .map(|tuple| decode_tuple(model, tuple))
+                .map(|tuple| decode_tuple(model, &constraint.variables, tuple))
                 .collect(),
         }
     }
@@ -2743,7 +2825,7 @@ mod tests {
                     .map(|variable| {
                         assignment
                             .get(variable)
-                            .map(|value| decode_value(model, *value))
+                            .map(|value| decode_variable_value(model, *variable, *value))
                     })
                     .collect::<Option<Vec<_>>>()
             {
@@ -2780,18 +2862,23 @@ mod tests {
             match constraint.kind {
                 BinaryConstraintKind::Equal => left == right,
                 BinaryConstraintKind::NotEqual => left != right,
-                BinaryConstraintKind::OrdinalBefore => {
-                    let left = decode_value(model, *left);
-                    let right = decode_value(model, *right);
-                    matches!(
-                        (&left, &right),
-                        (
-                            ConstraintValue::StatementOrdinal(left),
-                            ConstraintValue::StatementOrdinal(right)
-                        ) if left < right
-                    )
-                }
+                BinaryConstraintKind::OrdinalBefore => left < right,
             }
+        }) && model.linear_constraints.iter().all(|constraint| {
+            let mut value = i128::from(constraint.offset);
+            for (variable, coefficient) in constraint
+                .variables
+                .iter()
+                .zip(constraint.coefficients.iter())
+            {
+                let Some(variable_value) = assignment.get(variable) else {
+                    return false;
+                };
+                value += i128::from(variable_value.0) * i128::from(*coefficient);
+            }
+            constraint.domain.chunks_exact(2).any(|interval| {
+                i128::from(interval[0]) <= value && value <= i128::from(interval[1])
+            })
         }) && model.all_different.iter().all(|constraint| {
             let mut seen = BTreeSet::new();
             constraint.variables.iter().all(|variable| {
@@ -2804,16 +2891,25 @@ mod tests {
 
     fn decode_tuple(
         model: &CompiledSelectorProblem,
+        variables: &[ConstraintVariableId],
         values: &[BackendValueId],
     ) -> Vec<ConstraintValue> {
-        values
+        variables
             .iter()
-            .map(|value| decode_value(model, *value))
+            .zip(values.iter())
+            .map(|(variable, value)| decode_variable_value(model, *variable, *value))
             .collect()
     }
 
-    fn decode_value(model: &CompiledSelectorProblem, value: BackendValueId) -> ConstraintValue {
-        model.value_dictionary[value.0 as usize].clone()
+    fn decode_variable_value(
+        model: &CompiledSelectorProblem,
+        variable: ConstraintVariableId,
+        value: BackendValueId,
+    ) -> ConstraintValue {
+        let variable = &model.variables[variable.0];
+        model
+            .decode_value(variable.domain, value)
+            .expect("test fixture assigns values from the variable domain")
     }
 
     fn decoded_variable_domain(
@@ -2823,7 +2919,7 @@ mod tests {
         model
             .variable_domain_values(&model.variables[variable.0])
             .iter()
-            .map(|value| decode_value(model, *value))
+            .map(|value| decode_variable_value(model, variable, *value))
             .collect()
     }
 
@@ -3167,7 +3263,7 @@ mod tests {
 
         assert_eq!(
             allowed_tuples_for(&model, &[ConstraintVariableId(0), ConstraintVariableId(1)]).tuples,
-            vec![vec![owner(1), ast_node(100)]]
+            vec![vec![owner(1), ast_node(100)], vec![owner(2), ast_node(200)]]
         );
         assert_eq!(
             allowed_tuples_for(&model, &[ConstraintVariableId(1), ConstraintVariableId(2)]).tuples,
@@ -3186,8 +3282,49 @@ mod tests {
             vec![vec![ast_node(130), string("^x")]]
         );
         assert_eq!(
-            allowed_tuples_for(&model, &[ConstraintVariableId(6), ConstraintVariableId(7)]).tuples,
-            vec![vec![ordinal(0), ordinal(1)]]
+            model.linear_constraints,
+            vec![LinearConstraint {
+                variables: vec![ConstraintVariableId(6), ConstraintVariableId(7)],
+                coefficients: vec![1, -1],
+                offset: 1,
+                domain: vec![0, 0],
+            }]
+        );
+    }
+
+    #[test]
+    fn ast_top_level_constraints_use_dense_top_level_positions() {
+        let mut program = SelectorProgram::default();
+        let first_root = program.add_variable(VariableDomain::AstNode, Some("first".to_string()));
+        let second_root = program.add_variable(VariableDomain::AstNode, Some("second".to_string()));
+        let first_ordinal = program.add_variable(
+            VariableDomain::StatementOrdinal,
+            Some("first_ord".to_string()),
+        );
+        let second_ordinal = program.add_variable(
+            VariableDomain::StatementOrdinal,
+            Some("second_ord".to_string()),
+        );
+        program.add_atom(SelectorAtom::AstTopLevel {
+            node: NodeTerm::Var { id: first_root },
+            ordinal: OrdinalTerm::Var { id: first_ordinal },
+        });
+        program.add_atom(SelectorAtom::AstTopLevel {
+            node: NodeTerm::Var { id: second_root },
+            ordinal: OrdinalTerm::Var { id: second_ordinal },
+        });
+        program.add_atom(SelectorAtom::OrdinalOffset {
+            base: OrdinalTerm::Var { id: first_ordinal },
+            ordinal: OrdinalTerm::Var { id: second_ordinal },
+            offset: 1,
+        });
+        let facts = fact_store(vec![ast_top_level(100, 0), ast_top_level(200, 3)]);
+
+        let model = compile_selector_problem(&program, &facts).unwrap();
+
+        assert_eq!(
+            satisfying_tuples_for(&model, &[ConstraintVariableId(0), ConstraintVariableId(1)]),
+            vec![vec![ast_node(100), ast_node(200)]]
         );
     }
 
@@ -3266,6 +3403,15 @@ mod tests {
 
         let model = compile_selector_problem(&program, &facts).unwrap();
 
+        assert_eq!(
+            model.linear_constraints,
+            vec![LinearConstraint {
+                variables: vec![ConstraintVariableId(3), ConstraintVariableId(4)],
+                coefficients: vec![1, -1],
+                offset: 1,
+                domain: vec![-1, 0],
+            }]
+        );
         assert_eq!(
             satisfying_tuples_for(
                 &model,

--- a/devinfra/js/debundle/selector_ir_lowering.rs
+++ b/devinfra/js/debundle/selector_ir_lowering.rs
@@ -462,11 +462,20 @@ impl MemberSelectorProgramBuilder {
             .iter()
             .map(|(root, _ordinal)| *root)
             .collect::<Vec<_>>();
+        let alpha_index = (selector.target_binding.is_some()
+            || selector.identifiers == SourceMatchIdentifierMode::AlphaAll)
+            .then(|| AlphaIdentifierIndex::new(&facts));
         let target_binding_node = match &selector.target_binding {
             Some(target_binding) => {
-                let Some(target_binding_node) =
-                    native_target_binding_node(&facts, &skipped_nodes, target_binding)
-                else {
+                let Some(index) = alpha_index.as_ref() else {
+                    return Ok(false);
+                };
+                let Some(target_binding_node) = native_target_binding_node(
+                    index,
+                    &top_level_roots,
+                    &skipped_nodes,
+                    target_binding,
+                ) else {
                     return Ok(false);
                 };
                 Some((target_binding.as_str(), target_binding_node))
@@ -475,27 +484,31 @@ impl MemberSelectorProgramBuilder {
         };
         let alpha_projected_binding_node = match (&selector.target_binding, selector.identifiers) {
             (None, SourceMatchIdentifierMode::AlphaAll) => {
-                native_single_declared_binding_node(&facts, &skipped_nodes)
+                let Some(index) = alpha_index.as_ref() else {
+                    return Ok(false);
+                };
+                native_single_declared_binding_node(index, &top_level_roots, &skipped_nodes)
             }
             _ => None,
         };
-        let target_root_node =
-            if let Some((_target_binding, target_binding_node)) = target_binding_node {
-                let index = AlphaIdentifierIndex::new(&facts);
-                let Some(root) = native_top_level_root_containing_node(
-                    &index,
-                    &top_level_roots,
-                    target_binding_node,
-                ) else {
-                    return Ok(false);
-                };
-                root
-            } else {
-                let [root] = top_level_roots.as_slice() else {
-                    return Ok(false);
-                };
-                *root
+        let target_root_node = if let Some((_target_binding, target_binding_node)) =
+            target_binding_node
+        {
+            let Some(index) = alpha_index.as_ref() else {
+                return Ok(false);
             };
+            let Some(root) =
+                native_top_level_root_containing_node(index, &top_level_roots, target_binding_node)
+            else {
+                return Ok(false);
+            };
+            root
+        } else {
+            let [root] = top_level_roots.as_slice() else {
+                return Ok(false);
+            };
+            *root
+        };
         let Some(target_root_index) = top_level_roots
             .iter()
             .position(|root| *root == target_root_node)
@@ -744,10 +757,14 @@ impl MemberSelectorProgramBuilder {
         }
 
         let mut target_binding_nodes = BTreeMap::<String, NodeId>::new();
+        let index = AlphaIdentifierIndex::new(&facts);
         for target_binding in exports_by_target.keys() {
-            let Some(target_binding_node) =
-                native_target_binding_node(&facts, &skipped_nodes, target_binding)
-            else {
+            let Some(target_binding_node) = native_target_binding_node(
+                &index,
+                &top_level_roots,
+                &skipped_nodes,
+                target_binding,
+            ) else {
                 return Ok(false);
             };
             target_binding_nodes.insert(target_binding.clone(), target_binding_node);
@@ -766,7 +783,6 @@ impl MemberSelectorProgramBuilder {
             );
         }
         let root_by_target_binding = {
-            let index = AlphaIdentifierIndex::new(&facts);
             target_binding_nodes
                 .iter()
                 .map(|(target_binding, target_binding_node)| {
@@ -1653,18 +1669,17 @@ fn alpha_scope_kind(kind: NodeKind) -> Option<AlphaScopeKind> {
 }
 
 fn native_target_binding_node(
-    facts: &ChunkFacts,
+    index: &AlphaIdentifierIndex,
+    top_level_roots: &[NodeId],
     skipped_nodes: &BTreeSet<NodeId>,
     target_binding: &str,
 ) -> Option<NodeId> {
-    if facts.top_level.is_empty() {
+    if top_level_roots.is_empty() {
         return None;
     }
-    let index = AlphaIdentifierIndex::new(facts);
-    let declared_nodes = facts
-        .top_level
+    let declared_nodes = top_level_roots
         .iter()
-        .flat_map(|(root, _ordinal)| native_declared_binding_nodes(&index, skipped_nodes, *root))
+        .flat_map(|root| native_declared_binding_nodes(index, skipped_nodes, *root))
         .collect::<Vec<_>>();
     let matches = declared_nodes
         .into_iter()
@@ -1750,14 +1765,14 @@ fn native_pinned_top_level_segments(
 }
 
 fn native_single_declared_binding_node(
-    facts: &ChunkFacts,
+    index: &AlphaIdentifierIndex,
+    top_level_roots: &[NodeId],
     skipped_nodes: &BTreeSet<NodeId>,
 ) -> Option<NodeId> {
-    let [(root, _ordinal)] = facts.top_level.as_slice() else {
+    let [root] = top_level_roots else {
         return None;
     };
-    let index = AlphaIdentifierIndex::new(facts);
-    let declared_nodes = native_declared_binding_nodes(&index, skipped_nodes, *root);
+    let declared_nodes = native_declared_binding_nodes(index, skipped_nodes, *root);
     let [node] = declared_nodes.as_slice() else {
         return None;
     };

--- a/devinfra/js/debundle/selector_ortools_cpsat_backend.rs
+++ b/devinfra/js/debundle/selector_ortools_cpsat_backend.rs
@@ -20,8 +20,9 @@ use selector_constraint_backend::{
 use selector_constraint_backend::{
     BackendAssignment, BackendAssignmentCoverage, BackendSolveResult, BackendSolveStatus,
     BackendValueId, BackendVariableAssignment, CompiledAllDifferentConstraint,
-    CompiledAllowedTupleConstraint, CompiledBinaryConstraint, CompiledSelectorProblem,
-    CompiledVariable, CompiledVariableDomain, SelectorProblemBackend, TargetProjection,
+    CompiledAllowedTupleConstraint, CompiledBinaryConstraint, CompiledLinearConstraint,
+    CompiledSelectorProblem, CompiledVariable, CompiledVariableDomain, SelectorProblemBackend,
+    TargetProjection,
 };
 use selector_cp_sat_proto::ducktape::debundle::solver_backends::ortools_cpsat as wire;
 use selector_ir::VariableDomain;
@@ -128,6 +129,7 @@ pub enum OrToolsCpSatBackendError {
     },
     InvalidStatus {
         status: i32,
+        diagnostic: Option<String>,
     },
     InvalidAssignmentCoverage {
         coverage: i32,
@@ -180,8 +182,12 @@ impl fmt::Display for OrToolsCpSatBackendError {
                     "{DUMP_ONLY_ENV}=1 requires {REQUEST_PROTO_ENV} or {SUMMARY_JSON_ENV} to point at an output file"
                 )
             }
-            Self::InvalidStatus { status } => {
-                write!(f, "CP-SAT sidecar returned invalid status {status}")
+            Self::InvalidStatus { status, diagnostic } => {
+                write!(f, "CP-SAT sidecar returned invalid status {status}")?;
+                if let Some(diagnostic) = diagnostic {
+                    write!(f, ": {diagnostic}")?;
+                }
+                Ok(())
             }
             Self::InvalidAssignmentCoverage { coverage } => {
                 write!(
@@ -479,6 +485,7 @@ fn problem_summary(
         "domain_size_histogram": domain_size_histogram,
         "domain_size_histogram_by_domain": domain_size_histogram_by_domain,
         "dump_sequence": dump_sequence,
+        "linear_constraint_count": problem.linear_constraints.len(),
         "max_allowed_arity": max_allowed_arity,
         "max_allowed_rows": max_allowed_rows,
         "max_domain_values": max_domain_values,
@@ -487,12 +494,13 @@ fn problem_summary(
         "total_domain_values": total_domain_values,
         "variable_domain_representation_count_by_kind": variable_domain_representation_count_by_kind,
         "variable_domain_sharing": domain_sharing,
-        "value_dictionary_count": problem.value_dictionary.len(),
+        "value_dictionary_count": problem.value_dictionary.total_len(),
         "variable_count": problem.variables.len(),
         "variable_count_by_domain": variable_count_by_domain,
         "wire_all_different_count": request.all_different.len(),
         "wire_allowed_table_count": request.allowed_tables.len(),
         "wire_binary_constraint_count": request.binary_constraints.len(),
+        "wire_linear_constraint_count": request.linear_constraints.len(),
         "wire_target_projection_count": request.target_projections.len(),
         "wire_variable_count": request.variables.len(),
     })
@@ -605,6 +613,11 @@ fn request_from_problem(
             .iter()
             .map(binary_constraint_from_backend)
             .collect::<Result<Vec<_>, _>>()?,
+        linear_constraints: problem
+            .linear_constraints
+            .iter()
+            .map(linear_constraint_from_backend)
+            .collect::<Result<Vec<_>, _>>()?,
         all_different: problem
             .all_different
             .iter()
@@ -622,14 +635,25 @@ fn variable_from_backend(
     problem: &CompiledSelectorProblem,
     variable: &CompiledVariable,
 ) -> Result<wire::Variable, OrToolsCpSatBackendError> {
+    let domain = match &variable.values {
+        CompiledVariableDomain::Full(domain) => {
+            Some(wire::variable::Domain::DenseDomain(wire::DenseDomain {
+                value_count: u32_id(
+                    "variables.dense_domain.value_count",
+                    problem.full_domains.get(*domain).len(),
+                )?,
+            }))
+        }
+        CompiledVariableDomain::Sparse(values) => {
+            Some(wire::variable::Domain::SparseDomain(wire::SparseDomain {
+                values: values.iter().map(|value| value.0).collect(),
+            }))
+        }
+    };
     Ok(wire::Variable {
         id: constraint_variable_id(variable.id)?,
-        values: problem
-            .variable_domain_values(variable)
-            .iter()
-            .map(|value| value.0)
-            .collect(),
         debug_name: variable.debug_name.clone().unwrap_or_default(),
+        domain,
     })
 }
 
@@ -665,6 +689,22 @@ fn binary_constraint_from_backend(
             BinaryConstraintKind::NotEqual => wire::BinaryConstraintKind::NotEqual,
             BinaryConstraintKind::OrdinalBefore => wire::BinaryConstraintKind::OrdinalBefore,
         } as i32,
+    })
+}
+
+fn linear_constraint_from_backend(
+    constraint: &CompiledLinearConstraint,
+) -> Result<wire::LinearConstraint, OrToolsCpSatBackendError> {
+    Ok(wire::LinearConstraint {
+        variable_ids: constraint
+            .variables
+            .iter()
+            .copied()
+            .map(constraint_variable_id)
+            .collect::<Result<Vec<_>, _>>()?,
+        coefficients: constraint.coefficients.clone(),
+        offset: constraint.offset,
+        domain: constraint.domain.clone(),
     })
 }
 
@@ -706,18 +746,28 @@ fn target_projection_from_backend(
 fn response_into_backend_result(
     response: wire::SelectorCpSatResponse,
 ) -> Result<BackendSolveResult, OrToolsCpSatBackendError> {
-    let status = match wire::SolverStatus::try_from(response.status).map_err(|_| {
-        OrToolsCpSatBackendError::InvalidStatus {
-            status: response.status,
+    let status_code = response.status;
+    let diagnostic = (!response.diagnostic.is_empty()).then_some(response.diagnostic);
+    let solver_response_stats =
+        (!response.solver_response_stats.is_empty()).then_some(response.solver_response_stats);
+    let solver_status = match wire::SolverStatus::try_from(status_code) {
+        Ok(status) => status,
+        Err(_) => {
+            return Err(OrToolsCpSatBackendError::InvalidStatus {
+                status: status_code,
+                diagnostic,
+            });
         }
-    })? {
+    };
+    let status = match solver_status {
         wire::SolverStatus::Unsatisfiable => BackendSolveStatus::Unsatisfiable,
         wire::SolverStatus::Satisfiable => BackendSolveStatus::Satisfiable,
         wire::SolverStatus::Ambiguous => BackendSolveStatus::Ambiguous,
         wire::SolverStatus::Unknown => BackendSolveStatus::Unknown,
         wire::SolverStatus::Invalid | wire::SolverStatus::Unspecified => {
             return Err(OrToolsCpSatBackendError::InvalidStatus {
-                status: response.status,
+                status: status_code,
+                diagnostic,
             });
         }
     };
@@ -740,7 +790,8 @@ fn response_into_backend_result(
             .into_iter()
             .map(assignment_row_into_backend)
             .collect(),
-        diagnostic: (!response.diagnostic.is_empty()).then_some(response.diagnostic),
+        diagnostic,
+        solver_response_stats,
     })
 }
 
@@ -841,6 +892,73 @@ mod tests {
             callee_member: callee_member.to_string(),
             arg_index,
         }
+    }
+
+    fn selector_fact_store_from_source(source: &str) -> SelectorFactStore {
+        let module = js_ast::parse_js_module_ast("<chunk>", source).unwrap();
+        let chunk_facts = chunk_facts::extract_facts(&module).unwrap();
+        let analysis =
+            analysis::facts::analyze_chunk(&module, &AnalysisHints::default(), None, |_| None);
+        let owner_graph = analysis::graph::build_owner_graph(&analysis.facts).unwrap();
+        let mut facts = SelectorFactStore::default();
+        facts.extend_chunk_facts(ChunkId(0), &chunk_facts);
+        for node in owner_graph.iter_nodes() {
+            facts.push(SelectorFact::Owner {
+                chunk_id: ChunkId(0),
+                owner: node.id,
+                statement_ordinal: node.statement_ordinal,
+                statement_kind: node.kind.to_string(),
+            });
+            for binding in &node.declared {
+                facts.push(SelectorFact::DeclaredBinding {
+                    chunk_id: ChunkId(0),
+                    owner: node.id,
+                    binding: binding.0.as_str().to_string(),
+                    export_name: None,
+                });
+            }
+        }
+        for edge in owner_graph.iter_edges() {
+            if let Some(binding) = edge.reason.binding() {
+                facts.push(SelectorFact::OwnerReferencesBinding {
+                    chunk_id: ChunkId(0),
+                    owner: edge.from,
+                    binding: binding.0.as_str().to_string(),
+                    edge_kind: edge.reason.kind().to_string(),
+                });
+            }
+        }
+        facts
+    }
+
+    fn owner_for_binding(facts: &SelectorFactStore, binding: &str) -> OwnerId {
+        facts
+            .facts
+            .iter()
+            .find_map(|fact| match fact {
+                SelectorFact::DeclaredBinding {
+                    owner,
+                    binding: fact_binding,
+                    ..
+                } if fact_binding == binding => Some(*owner),
+                _ => None,
+            })
+            .unwrap_or_else(|| panic!("missing owner for binding {binding}"))
+    }
+
+    fn statement_ordinal_for_owner(facts: &SelectorFactStore, owner: OwnerId) -> StatementOrdinal {
+        facts
+            .facts
+            .iter()
+            .find_map(|fact| match fact {
+                SelectorFact::Owner {
+                    owner: fact_owner,
+                    statement_ordinal,
+                    ..
+                } if *fact_owner == owner => Some(*statement_ordinal),
+                _ => None,
+            })
+            .unwrap_or_else(|| panic!("missing statement ordinal for owner {owner:?}"))
     }
 
     fn sidecar_path() -> PathBuf {
@@ -1060,6 +1178,54 @@ mod tests {
                         owner: OwnerId(1),
                         statement_ordinal: StatementOrdinal(1),
                         binding: Some("secondary".to_string()),
+                        provenance: Vec::new(),
+                    }
+                })
+            );
+        });
+    }
+
+    #[test]
+    fn cpsat_sidecar_resolves_alpha_target_binding_with_multideclarator_context() {
+        js_ast::with_swc_globals(|| {
+            let mut selector = AnonymousStatementSelector::exact(
+                r#"const config = { kind: "selected", enabled: true };
+function readConfig() {
+  return config.kind;
+}"#,
+            );
+            selector.identifiers = SourceMatchIdentifierMode::AlphaAll;
+            selector.target_binding = Some("config".to_string());
+            let lowered = selector_ir_lowering::lower_member_selector(
+                &MemberSelectorLoweringContext::new(ChunkId(0), "static/app::selected_config"),
+                "selectedConfig",
+                &MemberSelectorSpec::SourceMatch(selector),
+            )
+            .unwrap();
+            let facts = selector_fact_store_from_source(
+                r#"const helperBinding = { kind: "helper" },
+  runtimeBinding = { kind: "selected", enabled: true },
+  trailingBinding = { kind: "trailing" };
+function runtimeReader() {
+  return runtimeBinding.kind;
+}
+console.log(runtimeReader(), helperBinding.kind, trailingBinding.kind);
+export { helperBinding, runtimeBinding, trailingBinding, runtimeReader };
+"#,
+            );
+
+            let backend = OrToolsCpSatBackend::new(sidecar_path());
+            let result = solve_with_backend(&lowered.program, &facts, &backend).unwrap();
+            let owner = owner_for_binding(&facts, "runtimeBinding");
+
+            assert_eq!(
+                result.outcome_for(lowered.target),
+                Some(&ClaimOutcome::Unique {
+                    claim: ResolvedClaim {
+                        chunk_id: ChunkId(0),
+                        owner,
+                        statement_ordinal: statement_ordinal_for_owner(&facts, owner),
+                        binding: Some("runtimeBinding".to_string()),
                         provenance: Vec::new(),
                     }
                 })

--- a/devinfra/js/debundle/solver_backends/ortools_cpsat/BUILD.bazel
+++ b/devinfra/js/debundle/solver_backends/ortools_cpsat/BUILD.bazel
@@ -33,6 +33,7 @@ cc_library(
         "@abseil-cpp//absl/status:statusor",
         "@abseil-cpp//absl/strings",
         "@or-tools//ortools/sat:cp_model",
+        "@or-tools//ortools/sat:cp_model_checker",
         "@or-tools//ortools/sat:cp_model_solver",
     ],
 )

--- a/devinfra/js/debundle/solver_backends/ortools_cpsat/selector_cp_sat.proto
+++ b/devinfra/js/debundle/solver_backends/ortools_cpsat/selector_cp_sat.proto
@@ -8,12 +8,24 @@ message SelectorCpSatRequest {
   repeated BinaryConstraint binary_constraints = 3;
   repeated AllDifferent all_different = 4;
   repeated TargetProjection target_projections = 5;
+  repeated LinearConstraint linear_constraints = 6;
 }
 
 message Variable {
   uint32 id = 1;
-  repeated int64 values = 2;
   string debug_name = 3;
+  oneof domain {
+    DenseDomain dense_domain = 4;
+    SparseDomain sparse_domain = 5;
+  }
+}
+
+message DenseDomain {
+  uint32 value_count = 1;
+}
+
+message SparseDomain {
+  repeated int64 values = 1;
 }
 
 message TableConstraint {
@@ -39,6 +51,15 @@ enum BinaryConstraintKind {
   BINARY_CONSTRAINT_KIND_ORDINAL_BEFORE = 3;
 }
 
+message LinearConstraint {
+  // Mirrors OR-Tools' LinearConstraintProto shape: sum(vars[i] * coeffs[i]) +
+  // offset must fall in the flat interval-domain list [lb0, ub0, lb1, ub1, ...].
+  repeated uint32 variable_ids = 1;
+  repeated int64 coefficients = 2;
+  int64 offset = 3;
+  repeated int64 domain = 4;
+}
+
 message AllDifferent {
   uint32 id = 1;
   repeated uint32 variable_ids = 2;
@@ -58,6 +79,7 @@ message SelectorCpSatResponse {
   AssignmentCoverage assignment_coverage = 2;
   repeated AssignmentRow assignments = 3;
   string diagnostic = 4;
+  string solver_response_stats = 5;
 }
 
 enum SolverStatus {

--- a/devinfra/js/debundle/solver_backends/ortools_cpsat/solver.cc
+++ b/devinfra/js/debundle/solver_backends/ortools_cpsat/solver.cc
@@ -13,6 +13,7 @@
 #include "absl/strings/str_cat.h"
 #include "ortools/sat/cp_model.h"
 #include "ortools/sat/cp_model.pb.h"
+#include "ortools/sat/cp_model_checker.h"
 #include "ortools/sat/cp_model_solver.h"
 #include "ortools/sat/model.h"
 
@@ -43,35 +44,78 @@ SelectorCpSatResponse InvalidResponse(const absl::Status& status) {
   return response;
 }
 
+SelectorCpSatResponse InvalidModelResponse(
+    const sat::CpSolverResponse& solver_response,
+    const sat::CpModelProto& model_proto) {
+  SelectorCpSatResponse response;
+  response.set_status(SOLVER_STATUS_INVALID);
+  response.set_assignment_coverage(ASSIGNMENT_COVERAGE_SAMPLE);
+  response.set_solver_response_stats(sat::CpSolverResponseStats(solver_response));
+  const std::string validation_error = sat::ValidateCpModel(model_proto);
+  if (validation_error.empty()) {
+    response.set_diagnostic(
+        "CP-SAT reported MODEL_INVALID, but ValidateCpModel returned no error");
+  } else {
+    response.set_diagnostic(validation_error);
+  }
+  return response;
+}
+
 absl::Status MissingVariableStatus(uint32_t variable_id) {
   return absl::InvalidArgumentError(
       absl::StrCat("unknown variable id ", variable_id));
+}
+
+absl::StatusOr<::operations_research::Domain> DomainForVariable(
+    const Variable& variable) {
+  switch (variable.domain_case()) {
+    case Variable::kDenseDomain: {
+      if (variable.dense_domain().value_count() == 0) {
+        return absl::InvalidArgumentError(
+            absl::StrCat("variable ", variable.id(), " has an empty domain"));
+      }
+      return ::operations_research::Domain(
+          0, static_cast<int64_t>(variable.dense_domain().value_count()) - 1);
+    }
+    case Variable::kSparseDomain: {
+      if (variable.sparse_domain().values().empty()) {
+        return absl::InvalidArgumentError(
+            absl::StrCat("variable ", variable.id(), " has an empty domain"));
+      }
+      std::vector<int64_t> values(variable.sparse_domain().values().begin(),
+                                  variable.sparse_domain().values().end());
+      std::sort(values.begin(), values.end());
+      if (std::adjacent_find(values.begin(), values.end()) != values.end()) {
+        return absl::InvalidArgumentError(absl::StrCat(
+            "variable ", variable.id(), " has duplicate domain values"));
+      }
+      return ::operations_research::Domain::FromValues(values);
+    }
+    case Variable::DOMAIN_NOT_SET:
+      return absl::InvalidArgumentError(
+          absl::StrCat("variable ", variable.id(), " has no domain"));
+  }
+  return absl::InvalidArgumentError(
+      absl::StrCat("variable ", variable.id(), " has unsupported domain"));
 }
 
 absl::Status AddVariables(const SelectorCpSatRequest& request,
                           sat::CpModelBuilder* model,
                           VariableMap* variables) {
   for (const Variable& variable : request.variables()) {
-    if (variable.values().empty()) {
-      return absl::InvalidArgumentError(
-          absl::StrCat("variable ", variable.id(), " has an empty domain"));
-    }
     if (variables->contains(variable.id())) {
       return absl::InvalidArgumentError(
           absl::StrCat("duplicate variable id ", variable.id()));
     }
 
-    std::vector<int64_t> values(variable.values().begin(),
-                                variable.values().end());
-    std::sort(values.begin(), values.end());
-    if (std::adjacent_find(values.begin(), values.end()) != values.end()) {
-      return absl::InvalidArgumentError(absl::StrCat(
-          "variable ", variable.id(), " has duplicate domain values"));
+    absl::StatusOr<::operations_research::Domain> domain =
+        DomainForVariable(variable);
+    if (!domain.ok()) {
+      return domain.status();
     }
 
     sat::IntVar int_var =
-        model->NewIntVar(::operations_research::Domain::FromValues(values))
-            .WithName(variable.debug_name());
+        model->NewIntVar(*domain).WithName(variable.debug_name());
     variables->emplace(variable.id(), int_var);
   }
   return absl::OkStatus();
@@ -158,6 +202,51 @@ absl::Status AddBinaryConstraints(const SelectorCpSatRequest& request,
   return absl::OkStatus();
 }
 
+absl::Status AddLinearConstraints(const SelectorCpSatRequest& request,
+                                  const VariableMap& variables,
+                                  sat::CpModelBuilder* model) {
+  for (const LinearConstraint& constraint : request.linear_constraints()) {
+    if (constraint.variable_ids_size() == 0) {
+      return absl::InvalidArgumentError("linear constraint has no variables");
+    }
+    if (constraint.variable_ids_size() != constraint.coefficients_size()) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          "linear constraint has ", constraint.variable_ids_size(),
+          " variables but ", constraint.coefficients_size(), " coefficients"));
+    }
+    if (constraint.domain_size() == 0 || constraint.domain_size() % 2 != 0) {
+      return absl::InvalidArgumentError(
+          "linear constraint has invalid flat interval domain");
+    }
+    for (int index = 0; index < constraint.domain_size(); index += 2) {
+      if (constraint.domain(index) > constraint.domain(index + 1)) {
+        return absl::InvalidArgumentError(
+            "linear constraint has inverted domain interval");
+      }
+    }
+    std::vector<sat::IntVar> linear_variables;
+    linear_variables.reserve(constraint.variable_ids_size());
+    for (uint32_t variable_id : constraint.variable_ids()) {
+      const auto variable = variables.find(variable_id);
+      if (variable == variables.end()) {
+        return MissingVariableStatus(variable_id);
+      }
+      linear_variables.push_back(variable->second);
+    }
+    const std::vector<int64_t> coefficients(constraint.coefficients().begin(),
+                                            constraint.coefficients().end());
+    const std::vector<int64_t> domain(constraint.domain().begin(),
+                                      constraint.domain().end());
+    const sat::LinearExpr expression =
+        sat::LinearExpr::WeightedSum(linear_variables, coefficients) +
+        constraint.offset();
+    model->AddLinearConstraint(expression,
+                               ::operations_research::Domain::FromFlatIntervals(
+                                   domain));
+  }
+  return absl::OkStatus();
+}
+
 absl::Status AddAllDifferentConstraints(const SelectorCpSatRequest& request,
                                         const VariableMap& variables,
                                         sat::CpModelBuilder* model) {
@@ -234,12 +323,14 @@ SelectorCpSatResponse ResponseFromSolver(
     const sat::CpSolverResponse& solver_response,
     const std::set<ProjectionRow>& projection_rows, bool complete) {
   SelectorCpSatResponse response;
+  response.set_solver_response_stats(sat::CpSolverResponseStats(solver_response));
 
   if (!projection_rows.empty()) {
     if (!complete) {
       response.set_status(SOLVER_STATUS_UNKNOWN);
       response.set_assignment_coverage(ASSIGNMENT_COVERAGE_SAMPLE);
-      response.set_diagnostic(sat::CpSolverResponseStats(solver_response));
+      response.set_diagnostic(
+          "CP-SAT stopped before proving complete target support");
     } else {
       response.set_status(projection_rows.size() == 1 ? SOLVER_STATUS_SATISFIABLE
                                                       : SOLVER_STATUS_AMBIGUOUS);
@@ -267,18 +358,19 @@ SelectorCpSatResponse ResponseFromSolver(
     case sat::CpSolverStatus::FEASIBLE:
       response.set_status(SOLVER_STATUS_UNKNOWN);
       response.set_assignment_coverage(ASSIGNMENT_COVERAGE_SAMPLE);
-      response.set_diagnostic(sat::CpSolverResponseStats(solver_response));
+      response.set_diagnostic(
+          "CP-SAT found a feasible solve but returned no projected rows");
       return response;
     case sat::CpSolverStatus::MODEL_INVALID:
       response.set_status(SOLVER_STATUS_INVALID);
       response.set_assignment_coverage(ASSIGNMENT_COVERAGE_SAMPLE);
-      response.set_diagnostic(sat::CpSolverResponseStats(solver_response));
+      response.set_diagnostic("CP-SAT reported MODEL_INVALID");
       return response;
     case sat::CpSolverStatus::UNKNOWN:
     default:
       response.set_status(SOLVER_STATUS_UNKNOWN);
       response.set_assignment_coverage(ASSIGNMENT_COVERAGE_SAMPLE);
-      response.set_diagnostic(sat::CpSolverResponseStats(solver_response));
+      response.set_diagnostic("CP-SAT returned UNKNOWN");
       return response;
   }
   return response;
@@ -297,6 +389,11 @@ absl::Status BuildCpModel(const SelectorCpSatRequest& request,
   }
   if (const absl::Status status =
           AddBinaryConstraints(request, *variables, model);
+      !status.ok()) {
+    return status;
+  }
+  if (const absl::Status status =
+          AddLinearConstraints(request, *variables, model);
       !status.ok()) {
     return status;
   }
@@ -333,7 +430,8 @@ SelectorCpSatResponse SolveSelectorCpSat(const SelectorCpSatRequest& request) {
     parameters.set_num_search_workers(1);
     solver_model.Add(sat::NewSatParameters(parameters));
 
-    solver_response = sat::SolveCpModel(model.Build(), &solver_model);
+    const sat::CpModelProto model_proto = model.Build();
+    solver_response = sat::SolveCpModel(model_proto, &solver_model);
     switch (solver_response.status()) {
       case sat::CpSolverStatus::OPTIMAL:
       case sat::CpSolverStatus::FEASIBLE: {
@@ -347,6 +445,7 @@ SelectorCpSatResponse SolveSelectorCpSat(const SelectorCpSatRequest& request) {
         return ResponseFromSolver(solver_response, projection_rows,
                                   /*complete=*/true);
       case sat::CpSolverStatus::MODEL_INVALID:
+        return InvalidModelResponse(solver_response, model_proto);
       case sat::CpSolverStatus::UNKNOWN:
       default:
         return ResponseFromSolver(solver_response, projection_rows,

--- a/devinfra/js/debundle/solver_backends/ortools_cpsat/solver_test.cc
+++ b/devinfra/js/debundle/solver_backends/ortools_cpsat/solver_test.cc
@@ -27,9 +27,13 @@ bool RowHas(const cpsat::AssignmentRow& row, uint32_t variable_id,
 
 TEST(SelectorCpSatSolverTest, AllDifferentPropagatesBroadSpecificFixture) {
   const cpsat::SelectorCpSatRequest request = ParseRequest(R"pb(
-    variables { id: 0 values: 0 values: 1 debug_name: "broad_owner" }
-    variables { id: 1 values: 0 values: 1 debug_name: "strict_owner" }
-    variables { id: 2 values: 0 values: 1 values: 2 debug_name: "reserved_owner" }
+    variables { id: 0 debug_name: "broad_owner" dense_domain { value_count: 2 } }
+    variables { id: 1 debug_name: "strict_owner" dense_domain { value_count: 2 } }
+    variables {
+      id: 2
+      debug_name: "reserved_owner"
+      dense_domain { value_count: 3 }
+    }
 
     all_different { id: 0 variable_ids: 0 variable_ids: 1 variable_ids: 2 }
 
@@ -67,7 +71,7 @@ TEST(SelectorCpSatSolverTest, AllDifferentPropagatesBroadSpecificFixture) {
 
 TEST(SelectorCpSatSolverTest, MultipleProjectionRowsAreAmbiguous) {
   const cpsat::SelectorCpSatRequest request = ParseRequest(R"pb(
-    variables { id: 0 values: 0 values: 1 debug_name: "owner" }
+    variables { id: 0 debug_name: "owner" dense_domain { value_count: 2 } }
     target_projections { target_id: 0 owner_variable_id: 0 }
   )pb");
 
@@ -82,15 +86,11 @@ TEST(SelectorCpSatSolverTest, MultipleProjectionRowsAreAmbiguous) {
 
 TEST(SelectorCpSatSolverTest, UnprojectedVariablesDoNotCreateRows) {
   const cpsat::SelectorCpSatRequest request = ParseRequest(R"pb(
-    variables { id: 0 values: 0 debug_name: "owner" }
+    variables { id: 0 debug_name: "owner" dense_domain { value_count: 1 } }
     variables {
       id: 1
-      values: 10
-      values: 11
-      values: 12
-      values: 13
-      values: 14
       debug_name: "internal_ast_node"
+      sparse_domain { values: [10, 11, 12, 13, 14] }
     }
     target_projections { target_id: 0 owner_variable_id: 0 }
   )pb");
@@ -108,7 +108,7 @@ TEST(SelectorCpSatSolverTest, UnprojectedVariablesDoNotCreateRows) {
 
 TEST(SelectorCpSatSolverTest, ConflictingTablesAreUnsat) {
   const cpsat::SelectorCpSatRequest request = ParseRequest(R"pb(
-    variables { id: 0 values: 0 values: 1 debug_name: "owner" }
+    variables { id: 0 debug_name: "owner" dense_domain { value_count: 2 } }
     allowed_tables {
       id: 0
       variable_ids: 0
@@ -145,7 +145,7 @@ TEST(SelectorCpSatSolverTest, InvalidProblemReportsDiagnostic) {
 
 TEST(SelectorCpSatSolverTest, ConstantBindingProjectionDoesNotAddVariable) {
   const cpsat::SelectorCpSatRequest request = ParseRequest(R"pb(
-    variables { id: 0 values: 0 debug_name: "owner" }
+    variables { id: 0 debug_name: "owner" dense_domain { value_count: 1 } }
     target_projections {
       target_id: 0
       owner_variable_id: 0


### PR DESCRIPTION
## Summary

- Add an OR-Tools-shaped linear constraint representation to the selector CP-SAT request: variable ids, coefficients, offset, and flat interval domain.
- Lower `OrdinalOffset` to a linear equality instead of materializing ordinal pair rows.
- Lower multi-segment child-list ordering to linear constraints over segment start variables, removing the derived segment-end variable and ordered-pair relation.
- Keep CP-SAT response stats in a dedicated response field and propagate invalid-model diagnostics through the Rust backend.
- Use dense top-level source positions for selector top-level windows so multi-declarator owner ordinals do not break multi-statement source matches.
- Keep perf notes updated with the Rust-side construction bottleneck found during profiling.

## Validation

- `git diff --check`
- `nix develop -c pre-commit run --files devinfra/js/debundle/debug/perf/2026_06_27_large_bundle_selector_csp_profile.md devinfra/js/debundle/selector_backend_solver.rs devinfra/js/debundle/selector_constraint_backend.rs devinfra/js/debundle/selector_constraint_model_builder.rs devinfra/js/debundle/selector_ortools_cpsat_backend.rs devinfra/js/debundle/solver_backends/ortools_cpsat/BUILD.bazel devinfra/js/debundle/solver_backends/ortools_cpsat/selector_cp_sat.proto devinfra/js/debundle/solver_backends/ortools_cpsat/solver.cc devinfra/js/debundle/solver_backends/ortools_cpsat/solver_test.cc`
- `nix develop -c bazelisk test //devinfra/js/debundle/e2e:match_selector_cli_test //devinfra/js/debundle/e2e:syntactic_holes_test //devinfra/js/debundle/e2e:anonymous_statement_test //devinfra/js/debundle/e2e:cross_module_emission_test //devinfra/js/debundle/e2e:selector_codemod_cli_test //devinfra/js/debundle/e2e:selector_minimizer_expectation_test //devinfra/js/debundle/solver_backends/ortools_cpsat:solver_test //devinfra/js/debundle:selector_constraint_model_builder_test //devinfra/js/debundle:selector_ortools_cpsat_backend_test --config=nolint --config=rbe --remote_download_outputs=all --cache_test_results=no`