### PR TITLE
agent-box: enable attic substituter (rotator minted the token)

### DIFF
--- a/nix/home/hosts/agent-box.nix
+++ b/nix/home/hosts/agent-box.nix
@@ -17,15 +17,16 @@
     ../modules/sops-env.nix # ducktape.sopsEnv (BuildBuddy key reads this)
     ../modules/buildbuddy.nix # BuildBuddy creds -> bazelrc + BUILDBUDDY_API_KEY
     ../modules/forgejo-ssh.nix # Forgejo bot push key + git.allegedly.works ssh block
+    ../modules/attic.nix # attic ~/.config/attic/config.toml (push/pull client)
   ];
 
   # home-manager sops-nix decrypts the codex user's secrets with its planted id.
   sops.age.sshKeyPaths = [ "${config.home.homeDirectory}/.ssh/id_ed25519" ];
 
-  # CLEANUP(added 2026-06-27): enable the home-manager attic client once
-  # secrets/hosts/agent-box-attic.yaml exists on devel (minted by attic-jwt-rotation):
-  #   imports += ../modules/attic.nix
-  #   ducktape.attic = { enable = true; sopsFile = ../../../secrets/hosts/agent-box-attic.yaml; };
+  ducktape.attic = {
+    enable = true;
+    sopsFile = ../../../secrets/hosts/agent-box-attic.yaml;
+  };
   ducktape.forgejoSsh.sopsFile = ../../../ssh_keys/agent-box-codex-forgejo.sops.key;
 
   programs.zsh.enable = true;

--- a/nix/nixos/hosts/agent-box/default.nix
+++ b/nix/nixos/hosts/agent-box/default.nix
@@ -25,18 +25,16 @@ in
     ../../modules/vm-hardware.nix
     ../../modules/bazel
     ../../modules/system-inspection-sudo.nix
+    ../../modules/attic-substituter.nix
   ];
 
-  # CLEANUP(added 2026-06-27): enable the Attic substituter once the
-  # attic-jwt-rotation CronJob (rotators.json -> `agent-box`) has minted and
-  # committed secrets/hosts/agent-box-attic.yaml to devel. Until that file
-  # exists, the path literal below would fail flake evaluation, so the wiring
-  # waits:
-  #   imports += ../../modules/attic-substituter.nix
-  #   ducktape.attic-substituter = {
-  #     enable = true;
-  #     sopsFile = ../../../../secrets/hosts/agent-box-attic.yaml;
-  #   };
+  # Pull from cache.allegedly.works/{main,gaffer}. Reader JWT auto-rotated by the
+  # attic-jwt-rotation CronJob (rotators.json -> `agent-box`), decryptable by the
+  # host key (cluster... agent-box-host) + the codex user key.
+  ducktape.attic-substituter = {
+    enable = true;
+    sopsFile = ../../../../secrets/hosts/agent-box-attic.yaml;
+  };
 
   # Process KubeVirt's NoCloud seed to install the persisted Ed25519 host key
   # (agent-box-host) before sshd starts — sops-nix decrypts the codex user key


### PR DESCRIPTION
Follow-up to the agent-box stack. The attic-jwt-rotation CronJob has minted `secrets/hosts/agent-box-attic.yaml` on devel, so the path literal now resolves. Un-tombstones the attic-substituter (NixOS) + attic client (home-manager) that were deferred in #2601. Takes effect on the next agent-box image build.