### PR TITLE
haku-ui: no-cache the SPA shell (prevent stale iframe placeholder)

### DIFF
--- a/haku/state_template/ui/backend/app.py
+++ b/haku/state_template/ui/backend/app.py
@@ -64,9 +64,15 @@ def create_app(settings: Settings) -> FastAPI:
     # This UI is itself framed by the console; forbid it from being framed by anyone
     # else (the console's own CSP frame-src already whitelists this origin).
     @app.middleware("http")
-    async def _frame_headers(request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
+    async def _response_headers(request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
         response = await call_next(request)
         response.headers["Content-Security-Policy"] = "frame-ancestors https://haku.allegedly.works"
+        # The SPA shell (index.html) must always revalidate: a new build references new
+        # hashed asset filenames, so a stale-cached index.html would keep loading the old
+        # app — and the console iframe would keep showing the previous (placeholder) page.
+        # The hashed assets themselves are safe to cache (new build = new filename).
+        if response.headers.get("content-type", "").startswith("text/html"):
+            response.headers["Cache-Control"] = "no-cache"
         return response
 
     @app.get("/healthz")


### PR DESCRIPTION
Follow-up to the iframe-placeholder investigation. The haku-ui index.html was served with etag/last-modified but no `Cache-Control`, so browsers heuristically cache it — after a new build the console iframe could keep showing the old page until a hard-refresh. Set `Cache-Control: no-cache` on text/html in the existing response-headers middleware so the SPA shell always revalidates (hashed JS/CSS assets stay cacheable since new builds get new filenames).

Template change; takes effect on the next haku-ui build Haku adopts (or a rebuild of the live repo).