### PR TITLE
codex: per-host settings override; agent-box runs Codex full-auto

### DIFF
--- a/nix/home/codex/default.nix
+++ b/nix/home/codex/default.nix
@@ -8,6 +8,7 @@
   ...
 }:
 let
+  cfg = config.ducktape.codex;
   execPolicyRules = import ./execpolicy-rules.nix { inherit lib; };
   codexNpmCache = "${config.xdg.cacheHome}/codex/npm";
   codexNixCache = "${config.xdg.cacheHome}/nix";
@@ -165,7 +166,11 @@ let
   };
 
   tomlFormat = pkgs.formats.toml { };
-  baseConfigFile = tomlFormat.generate "codex-config.nix-base" codexSettings;
+  # Host overrides (ducktape.codex.settings) deep-merge over the defaults, using
+  # Codex's own config.toml keys.
+  baseConfigFile = tomlFormat.generate "codex-config.nix-base" (
+    lib.recursiveUpdate codexSettings cfg.settings
+  );
 
   useXdgDirectories = config.home.preferXdgDirectories;
   xdgConfigHomeRelative = lib.removePrefix "${config.home.homeDirectory}/" config.xdg.configHome;
@@ -214,7 +219,16 @@ let
   '';
 in
 {
-  programs.codex = {
+  # Per-host Codex config.toml overrides, expressed in Codex's own schema and
+  # deep-merged over the defaults above. e.g. an isolated agent VM can set
+  # `approval_policy = "never"` + `sandbox_mode = "danger-full-access"`.
+  options.ducktape.codex.settings = lib.mkOption {
+    inherit (tomlFormat) type;
+    default = { };
+    description = "Overrides deep-merged over the generated Codex config.toml, using Codex's native config keys.";
+  };
+
+  config.programs.codex = {
     enable = true;
     # Prefer the unstable codex package if available.
     package = pkgsUnstable.codex;
@@ -222,7 +236,7 @@ in
     # The activation script below handles merging our desired settings.
   };
 
-  home = {
+  config.home = {
     file = {
       "${baseFileRelative}".source = baseConfigFile;
       "${rulesFileRelative}".text = execPolicyRules.text;

--- a/nix/home/hosts/agent-box.nix
+++ b/nix/home/hosts/agent-box.nix
@@ -29,6 +29,13 @@
   };
   ducktape.forgejoSsh.sopsFile = ../../../ssh_keys/agent-box-codex-forgejo.sops.key;
 
+  # This is a dedicated, scoped, isolated agent VM — let Codex run fully
+  # unattended: execute every command without prompting and with no sandbox.
+  ducktape.codex.settings = {
+    approval_policy = "never";
+    sandbox_mode = "danger-full-access";
+  };
+
   programs.zsh.enable = true;
   programs.direnv = {
     enable = true;


### PR DESCRIPTION
The codex VM exists to run an agent unattended, so Codex there should execute everything without asking.

- **`nix/home/codex`**: add `ducktape.codex.settings` — a TOML-typed override (Codex's own config schema) that deep-merges over the generated `config.toml` defaults. No custom abstraction; you set Codex's native keys.
- **agent-box**: `ducktape.codex.settings = { approval_policy = "never"; sandbox_mode = "danger-full-access"; }` — full-auto, no sandbox. It's a dedicated, scoped, isolated VM with least-privilege creds, so this is the intended use.

Default is `{}`, and `recursiveUpdate codexSettings {} == codexSettings`, so interactive hosts (rugged/wyrm2/gecko) are byte-identical. Verified: agent-box's generated `config.nix-base.toml` shows `approval_policy = "never"` / `sandbox_mode = "danger-full-access"`; gecko + agent-box both eval clean.

Takes effect on the next agent-box image build.