### PR TITLE
forgejo: raise CPU (500m→2 cores) — monolith was CFS-throttled

### DIFF
--- a/cluster/k8s/forgejo/app/helmrelease.yaml
+++ b/cluster/k8s/forgejo/app/helmrelease.yaml
@@ -205,13 +205,17 @@ spec:
         type: ClusterIP
         port: 2222
 
-    # Resources
+    # Resources. Forgejo is a monolith: the web UI, API, git HTTP/SSH, the
+    # container/package registry, AND the Actions coordinator all run in this one
+    # process — so they share this CPU budget. The old 500m limit caused constant
+    # CFS throttling under load (CI image pushes + the haku-ui app's reads + git
+    # ops), making even trivial /api/v1/version take ~7s. Give it real headroom.
     resources:
       limits:
-        cpu: 500m
+        cpu: "2"
         memory: 2Gi
       requests:
-        cpu: 100m
+        cpu: 500m
         memory: 512Mi
 
     # Persistence


### PR DESCRIPTION
Forgejo is a single monolithic pod serving web/API/git/registry/Actions; the 500m CPU limit caused constant CFS throttling (`nr_throttled 30678 / nr_periods 86310` ≈ 36%, ~3280s throttled), so even the trivial `/api/v1/version` took ~7s under load (CI image pushes + the now-working haku-ui app's per-item reads + augur git ops). Bump limit 500m→2 cores, request 100m→500m for scheduling headroom. Pod rolls (Recreate, single replica) on apply.