### PR TITLE
forgejo: CPU limit 2 -> 4 cores (more burst headroom)

### DIFF
--- a/cluster/k8s/forgejo/app/helmrelease.yaml
+++ b/cluster/k8s/forgejo/app/helmrelease.yaml
@@ -212,7 +212,7 @@ spec:
     # ops), making even trivial /api/v1/version take ~7s. Give it real headroom.
     resources:
       limits:
-        cpu: "2"
+        cpu: "4"
         memory: 2Gi
       requests:
         cpu: 500m


### PR DESCRIPTION
Follow-up to #2640. Forgejo is one pod doing web/API/git/registry/Actions; give it 4 cores of burst headroom for spikes (CI image pushes + Actions + the haku-ui reads). Request stays 500m.