### PR TITLE
nix/forgejo-ssh: enable programs.ssh so the matchBlock is actually written

### DIFF
--- a/nix/home/modules/forgejo-ssh.nix
+++ b/nix/home/modules/forgejo-ssh.nix
@@ -22,6 +22,13 @@ in
       mode = "0600";
     };
 
+    # home-manager only writes ~/.ssh/config (and thus the matchBlock below) when
+    # programs.ssh is enabled. Full home.nix hosts set this explicitly; the slim
+    # agent-box codex config doesn't — so default it on here, or this module's
+    # matchBlock is silently dropped and git falls back to port 22 + the default
+    # key (Permission denied). mkDefault lets home.nix's explicit value still win.
+    programs.ssh.enable = lib.mkDefault true;
+
     programs.ssh.matchBlocks."git.allegedly.works" = {
       hostname = "git.allegedly.works";
       user = "git";

--- a/plans/agent-box.md
+++ b/plans/agent-box.md
@@ -54,6 +54,22 @@ You log in _as_ codex with your personal keys (in `authorizedKeys`); the
 - **Attic rotator entry**: `rotators.json` mints `secrets/hosts/agent-box-attic.yaml`
   after merge.
 
+## Cloning Forgejo repos as codex
+
+The codex user can clone the repos it collaborates on over SSH using the planted
+bot key — no netrc/HTTP credential is involved:
+
+```bash
+git clone git@git.allegedly.works:agentydragon/ducktape.git
+git clone git@git.allegedly.works:agentydragon/gaffer-private.git
+```
+
+This relies on the `git.allegedly.works` matchBlock (port 2222 + the
+`agent-box-codex-forgejo` key) that `nix/home/modules/forgejo-ssh.nix` writes to
+`~/.ssh/config`. Forgejo is the working forge for codex (push topic branches,
+open PRs there); the Forgejo repos are not formal pull-mirrors of GitHub, so
+sync them from GitHub manually when needed.
+
 ## Deferred (tombstoned in-code)
 
 - **Attic substituter** on agent-box: the Nix wiring is tombstoned in


### PR DESCRIPTION
## Symptom

On the agent-box VM, `git clone git@git.allegedly.works:agentydragon/ducktape` fails with `Permission denied (publickey)` even though the codex Forgejo user, its write collaboration, and the `agent-box-codex-forgejo` push key are all correctly provisioned (tofu `forgejo-codex` applied clean).

## Root cause

home-manager only writes `~/.ssh/config` when `programs.ssh.enable = true`. The full `home.nix` workstation config sets it; the **slim `agent-box.nix`** codex config doesn't. So `forgejo-ssh.nix`'s matchBlock (port 2222 + `~/.ssh/agentydragon_forgejo_id_ed25519`, `IdentitiesOnly`) was **silently dropped** — agent-box's home closure produced no `.ssh/config` at all. `git clone` then fell back to the default port 22 and the default identity `~/.ssh/id_ed25519` (the `agent-box-codex-user` key, which Forgejo doesn't accept as a codex push key) → permission denied. The bot key was planted on disk but nothing told ssh to use it.

## Fix

Make `forgejo-ssh.nix` self-contained: `programs.ssh.enable = lib.mkDefault true`. A module that contributes an ssh matchBlock should enable the config it depends on. `mkDefault` keeps `home.nix`'s explicit `enable = true` authoritative on workstations.

## Verified (nix eval)

- **agent-box**: now renders `~/.ssh/config` with the `Host git.allegedly.works` block (Port 2222, `IdentityFile ~/.ssh/agentydragon_forgejo_id_ed25519`, `IdentitiesOnly yes`).
- **gecko**: `programs.ssh.enable` still `true`, no conflict.

Note: the running VM is on an older image and needs an image rebuild + recreate to pick this up. Immediate workaround until then: `GIT_SSH_COMMAND='ssh -p 2222 -i ~/.ssh/agentydragon_forgejo_id_ed25519 -o IdentitiesOnly=yes' git clone ssh://git@git.allegedly.works:2222/agentydragon/ducktape.git`.