### PR TITLE
forgejo: shared replicated valkey for cache + queue (HA prep, step 1)

### DIFF
--- a/cluster/k8s/forgejo/app/flux-kustomization.yaml
+++ b/cluster/k8s/forgejo/app/flux-kustomization.yaml
@@ -22,6 +22,7 @@ spec:
   dependsOn:
     - name: forgejo-namespace
     - name: forgejo-db
+    - name: forgejo-cache # shared valkey for cache + queue (HA prerequisite)
     - name: gateway
     - name: cert-manager
     - name: forgejo-secrets

--- a/cluster/k8s/forgejo/app/helmrelease.yaml
+++ b/cluster/k8s/forgejo/app/helmrelease.yaml
@@ -212,7 +212,7 @@ spec:
     # ops), making even trivial /api/v1/version take ~7s. Give it real headroom.
     resources:
       limits:
-        cpu: "2"
+        cpu: "4"
         memory: 2Gi
       requests:
         cpu: 500m

--- a/cluster/k8s/forgejo/app/helmrelease.yaml
+++ b/cluster/k8s/forgejo/app/helmrelease.yaml
@@ -103,15 +103,26 @@ spec:
           START_SSH_SERVER: true
           LFS_START_SERVER: true
 
+        # Session stays in Postgres (the CNPG forgejo-db is already HA), so it's
+        # shared across replicas — no per-instance state. Cache + queue, however,
+        # default to per-instance backends (memory / leveldb on the pod's PVC):
+        # with >1 replica each instance would keep its own cache (stale reads) and,
+        # worse, two leveldb queues on one shared volume would corrupt. Both move
+        # to the shared, replicated forgejo-valkey-ovh (cluster/k8s/forgejo/cache)
+        # so the deployment can scale to 2 replicas. (Switching the queue backend
+        # abandons any in-flight leveldb queue items on the next restart — fine for
+        # this instance's transient queues: webhook deliveries, mirror syncs.)
         session:
           PROVIDER: db
 
         cache:
           ENABLED: true
-          ADAPTER: memory
+          ADAPTER: redis
+          HOST: redis://forgejo-valkey-ovh-master.forgejo.svc.cluster.local:6379/0
 
         queue:
-          TYPE: level
+          TYPE: redis
+          CONN_STR: redis://forgejo-valkey-ovh-master.forgejo.svc.cluster.local:6379/0
 
         # In-cluster CI (Forgejo Actions). Enables the server-side feature; a
         # registered act_runner (cluster/k8s/haku-ci) executes workflows. Used so

--- a/cluster/k8s/forgejo/cache/flux-kustomization.yaml
+++ b/cluster/k8s/forgejo/cache/flux-kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: forgejo-cache
+  namespace: flux-system
+spec:
+  retryInterval: 1m
+  interval: 10m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./cluster/k8s/forgejo/cache
+  prune: true
+  wait: true
+  dependsOn:
+    - name: forgejo-namespace
+    - name: valkey
+    - name: local-path-provisioner

--- a/cluster/k8s/forgejo/cache/kustomization.yaml
+++ b/cluster/k8s/forgejo/cache/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - valkey-ovh-instance.yaml

--- a/cluster/k8s/forgejo/cache/valkey-ovh-instance.yaml
+++ b/cluster/k8s/forgejo/cache/valkey-ovh-instance.yaml
@@ -1,0 +1,52 @@
+apiVersion: redis.redis.opstreelabs.in/v1beta2
+kind: RedisReplication
+metadata:
+  name: forgejo-valkey-ovh
+  namespace: forgejo
+  annotations:
+    description: OVH Valkey for Forgejo cache + queue (shared, HA-ready replacement for per-instance memory cache / leveldb queue)
+spec:
+  clusterSize: 2
+  kubernetesConfig:
+    image: valkey/valkey:8-alpine
+    imagePullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+  redisConfig:
+    maxMemoryPercentOfLimit: 80
+  storage:
+    volumeClaimTemplate:
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: local-path-ovh
+        resources:
+          requests:
+            storage: 2Gi
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values: ["hil-ovh"]
+      # Soft anti-affinity off control-plane nodes (their etcd is on a rotational
+      # HDD; co-located I/O starves etcd fsync — 2026-06-28 outage).
+      # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: DoesNotExist
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app: forgejo-valkey-ovh
+          topologyKey: kubernetes.io/hostname

--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -182,6 +182,7 @@ resources:
   # --- forgejo ---
   - forgejo/namespace/flux-kustomization.yaml
   - forgejo/db/flux-kustomization.yaml
+  - forgejo/cache/flux-kustomization.yaml
   - forgejo/app/flux-kustomization.yaml
   - forgejo/servicemonitor/flux-kustomization.yaml
   - forgejo/secrets/flux-kustomization.yaml


### PR DESCRIPTION
First, non-disruptive step toward Forgejo HA: move the per-instance
state backends to a shared, replicated valkey so the deployment can later
scale to 2 replicas. **The git storage and replica count are untouched here**
— that's the deferred, riskier follow-up.

## What changes
- New `cluster/k8s/forgejo/cache/` → `forgejo-valkey-ovh` `RedisReplication`
  (clusterSize 2, hil-ovh, off-CP soft anti-affinity, per-host pod anti-affinity)
  — same pattern as langfuse/grocy/paperless.
- helmrelease `[cache]` `memory`→`redis`, `[queue]` `level`→`redis`, both pointed
  at `forgejo-valkey-ovh-master`. `[session]` stays `db` (CNPG forgejo-db is
  already HA, so sessions are already shared — no need to log everyone out).
- Wired `forgejo-cache` into the root kustomization and as a `dependsOn` of the
  forgejo app (so the HR never points at a valkey that isn't up yet).

## Why
With >1 replica, the memory cache is per-instance (stale reads) and — the real
blocker — two leveldb queues on one shared volume corrupt each other. Both must
move to shared redis before scaling out.

## Risk / rollout
- Single replica throughout; RWO git PVC unchanged → no storage surgery.
- Switching the queue backend abandons any in-flight leveldb queue items on the
  next pod restart (transient: webhook deliveries, mirror syncs). Acceptable.

## Deferred to a follow-up (the pause point)
RWO→RWX migration of `gitea-shared-storage` + `replicas: 2` + RollingUpdate +
podAntiAffinity + PDB, gated on an off-cluster backup first. The
concurrent-git-on-SeaweedFS-FUSE consistency risk is the reason this is split.