### PR TITLE
forgejo: HA — 2 replicas on an RWX git PVC (step 2)

### DIFF
--- a/cluster/k8s/forgejo/app/git-storage-pvc.yaml
+++ b/cluster/k8s/forgejo/app/git-storage-pvc.yaml
@@ -1,0 +1,22 @@
+# Git repositories volume for Forgejo, ReadWriteMany so the two forgejo replicas
+# (helmrelease.yaml: replicaCount 2) can mount it concurrently. Provisioned here
+# rather than by the chart because the chart's default claim (gitea-shared-storage)
+# is RWO and accessModes are immutable — going HA required a fresh RWX claim, with
+# the existing git data copied over during the 2026-06-28 migration cutover.
+#
+# SeaweedFS RWX multi-mount and the cross-node git filesystem semantics it depends
+# on (immediate write visibility, atomic exclusive-create for *.lock, atomic
+# rename) were verified on this cluster before the cutover.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: forgejo-git-rwx
+  namespace: forgejo
+  annotations:
+    description: Forgejo git repos on SeaweedFS, RWX for 2-replica HA (replaces RWO gitea-shared-storage)
+spec:
+  accessModes: ["ReadWriteMany"]
+  storageClassName: seaweedfs-ovh
+  resources:
+    requests:
+      storage: 50Gi

--- a/cluster/k8s/forgejo/app/helmrelease.yaml
+++ b/cluster/k8s/forgejo/app/helmrelease.yaml
@@ -42,11 +42,15 @@ spec:
     global:
       imageRegistry: ""
 
-    # CRITICAL: Use Recreate strategy for RWO volumes
-    # RollingUpdate + RWO volumes = deadlock when init containers fail
-    # See docs/RWO_VOLUME_DEPLOYMENT_STRATEGY.md for details
+    # HA: two replicas sharing the RWX git PVC (forgejo-git-rwx). Both pods mount
+    # the same SeaweedFS volume concurrently (RWX multi-mount + cross-node git
+    # lock/rename semantics verified 2026-06-28), so a rolling update is safe — the
+    # old RWO Recreate-only deadlock (RollingUpdate + RWO = stuck init container)
+    # no longer applies. Session lives in Postgres and cache/queue in the shared
+    # valkey (../cache), so neither replica holds per-instance state.
+    replicaCount: 2
     strategy:
-      type: Recreate
+      type: RollingUpdate
 
     # Pin to OVH kimsufi nodes: required by the seaweedfs-ovh CSI (OVH-only)
     # and co-located with the OVH-HA forgejo-db (cnpg_conventions R5).
@@ -63,6 +67,18 @@ spec:
               matchExpressions:
                 - key: node-role.kubernetes.io/control-plane
                   operator: DoesNotExist
+      # Keep the two replicas on different hosts so a single node loss can't take
+      # both down. Required (not preferred): with two off-CP workers they land one
+      # each; if a worker is gone the second can still schedule elsewhere (the
+      # off-CP rule above is only a soft preference), so this never blocks the
+      # second replica — it only forbids co-location.
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: forgejo
+                app.kubernetes.io/instance: forgejo
+            topologyKey: kubernetes.io/hostname
 
     # Forgejo configuration (chart retains the legacy `gitea:` values key)
     gitea:
@@ -234,8 +250,22 @@ spec:
     # the seaweedfs-ovh CSI (object-backed; git needs a POSIX FS, so no S3 backend).
     persistence:
       enabled: true
-      size: 50Gi
-      storageClass: seaweedfs-ovh
+      # Mount our pre-provisioned RWX claim (git-storage-pvc.yaml) instead of the
+      # chart's default RWO gitea-shared-storage. This chart has no `existingClaim`:
+      # it mounts whatever `claimName` points at and only creates the PVC itself when
+      # `create: true`. So create:false + claimName makes it adopt our externally
+      # managed PVC and create nothing. accessModes are immutable, so HA needed a
+      # fresh claim — existing git data was copied old->new during the 2026-06-28
+      # migration cutover. (The old gitea-shared-storage PVC has the chart's
+      # helm.sh/resource-policy:keep annotation, so it survives as a rollback.)
+      create: false
+      claimName: forgejo-git-rwx
+      # The chart refuses replicaCount > 1 unless accessModes[0] is ReadWriteMany
+      # (a guard against a single-writer FS under multiple replicas). create:false
+      # means the chart won't actually create a PVC from this — our git-storage-pvc.yaml
+      # owns the real RWX claim — but the assertion still reads this value.
+      accessModes:
+        - ReadWriteMany
 
     # PostgreSQL: external CNPG cluster (forgejo-db)
     postgresql:

--- a/cluster/k8s/forgejo/app/kustomization.yaml
+++ b/cluster/k8s/forgejo/app/kustomization.yaml
@@ -4,4 +4,6 @@ resources:
   - helmrelease.yaml
   - httproute.yaml
   - ciliumenvoyconfig.yaml
+  - git-storage-pvc.yaml
+  - poddisruptionbudget.yaml
 # OAuth OIDC credentials provisioned by tf/gitops/sso-providers/ as a k8s Secret.

--- a/cluster/k8s/forgejo/app/poddisruptionbudget.yaml
+++ b/cluster/k8s/forgejo/app/poddisruptionbudget.yaml
@@ -1,0 +1,16 @@
+# Keep at least one Forgejo replica serving during voluntary disruption (node
+# drain, descheduler eviction, rolling update). With replicaCount 2 this lets one
+# pod be evicted at a time but never both — git/CI/registry/API stay up. The
+# descheduler honors PDBs unconditionally, so this is also what stops it from
+# taking both replicas down at once.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: forgejo
+  namespace: forgejo
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: forgejo
+      app.kubernetes.io/instance: forgejo


### PR DESCRIPTION
Final step of Forgejo HA (step 1 = shared valkey, #2644). Git repos move to a
ReadWriteMany SeaweedFS PVC so two replicas mount concurrently.

## Changes
- `git-storage-pvc.yaml`: `forgejo-git-rwx` (RWX, seaweedfs-ovh, 50Gi). The chart
  default `gitea-shared-storage` is RWO and accessModes are immutable → HA needs a
  fresh claim. Old data copied old→new at cutover; the old PVC keeps the chart's
  `helm.sh/resource-policy: keep` annotation, so it survives as a rollback.
- helmrelease: `replicaCount: 2`, strategy `Recreate`→`RollingUpdate`,
  `persistence.create: false` + `claimName: forgejo-git-rwx` + `accessModes: [RWX]`
  (the chart asserts RWX when replicas>1), required per-host `podAntiAffinity`.
- `poddisruptionbudget.yaml`: `minAvailable: 1`.

## Verified before cutover
- SeaweedFS RWX multi-mount across distinct nodes + cross-node git semantics
  (immediate write visibility, atomic exclusive-create for `*.lock`, atomic rename).
- `helm template` → chart renders **no** PVC (`create:false`) and mounts
  `forgejo-git-rwx` at `replicas:2`, `RollingUpdate`.

## Cutover (orchestrated, Flux suspended)
Suspend Flux → scale to 0 → create RWX PVC → **copy old data into it** → verify →
merge → resume → 2 replicas come up on the populated volume. Depends on #2644.