### PR TITLE
agent-box: repin VM image to 4918b140c7 (SSH matchBlock + full-auto)

### DIFF
--- a/cluster/k8s/agent-box/app/virtualmachine.yaml
+++ b/cluster/k8s/agent-box/app/virtualmachine.yaml
@@ -29,7 +29,7 @@ spec:
             # IMAGE_OUTPUT=agent-box-image). The VM boots straight into the real
             # config — no bootstrap + nixos-rebuild switch. cloud-init still
             # injects the persisted host key. Repin after rebuilding the image.
-            url: "https://s3.allegedly.works/vm-images/agent-box/f0f148c07c3ba97f02d8ac75d78b8e3e42cabddc.qcow2"
+            url: "https://s3.allegedly.works/vm-images/agent-box/4918b140c7d1d4a4a5c30c3ca95b1cbb188ad893.qcow2"
             secretRef: agent-box-vm-images-s3-reader
         pvc:
           accessModes:


### PR DESCRIPTION
Repins the agent-box DataVolume image to the freshly published `agent-box/4918b140c7…qcow2`, built off `devel@4918b140c7` by `vm-images-publisher` (`IMAGE_OUTPUT=agent-box-image`).

That commit includes:
- **#2643** — `forgejo-ssh` enables `programs.ssh`, so `~/.ssh/config` (and the `git.allegedly.works` matchBlock) is actually written → `git clone git@git.allegedly.works:…` works as codex.
- **#2642** — codex config relayer (lean full-auto base; workstation models opt-in).
- attic substituter + full-auto config.

After merge, the VM is recreated (delete VM + `agent-box-root` DataVolume) so CDI re-imports the new qcow2 and the codex user boots with the working Forgejo SSH config.