### PR TITLE
Add debundle selector pre-solver summaries

### DIFF
--- a/devinfra/js/debundle/AGENTS.md
+++ b/devinfra/js/debundle/AGENTS.md
@@ -134,6 +134,11 @@ stack samples. Keep production telemetry coarse and useful for users of
 the pipeline; don't add detailed stage fields solely because an
 optimization investigation needs temporary visibility.
 
+For timed perf repros, prefer stopping the process on timeout before
+killing it, then attach with `gdb` to inspect live stacks and memory
+state. Use a core dump only when the interrupted state needs to be
+preserved after the process exits.
+
 ## Test shape preferences
 
 Strongly prefer **executable e2e tests with high-level assertions**

--- a/devinfra/js/debundle/BUILD.bazel
+++ b/devinfra/js/debundle/BUILD.bazel
@@ -1118,6 +1118,7 @@ rust_library(
         ":selector_constraint_backend",
         ":selector_constraint_model_builder",
         ":selector_ir",
+        "@crates//:serde_json",
     ],
 )
 
@@ -1129,7 +1130,9 @@ rust_test(
     deps = [
         ":analysis",
         ":selector_constraint_backend",
+        ":selector_constraint_model_builder",
         ":selector_ir",
+        "@crates//:serde_json",
     ],
 )
 

--- a/devinfra/js/debundle/debug/perf/2026_06_27_large_bundle_selector_csp_profile.md
+++ b/devinfra/js/debundle/debug/perf/2026_06_27_large_bundle_selector_csp_profile.md
@@ -161,3 +161,15 @@ The next PR should target the high-level Rust-side shape, not solver heuristics:
    cap;
 4. if the run reaches the sidecar, capture CP-SAT problem-size stats and profile
    the sidecar separately.
+
+For future timeout investigations, prefer stopping instead of immediately
+killing the profiled debundler at the cap. A stopped process can be inspected
+with `gdb` to read live stacks, heap shape, and relation/model state without
+writing a large core file. Dump core only if the exact interrupted state must be
+kept after the process exits.
+
+The pre-solver summary side files should be enabled during these runs. They
+report selector-program counts, input fact relation cardinalities, model-build
+domain/relation counts when reached, and compiled CSP shape when reached:
+variables by domain, domain-size histograms, allowed-table row/cell histograms,
+linear/binary/all-different counts, and broad `constraint_count_by_kind`.

--- a/devinfra/js/debundle/selector_backend_solver.rs
+++ b/devinfra/js/debundle/selector_backend_solver.rs
@@ -8,6 +8,10 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
 use std::fmt;
+use std::fs;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use analysis::{OwnerId, StatementOrdinal};
 use selector_constraint_backend::{
@@ -16,12 +20,17 @@ use selector_constraint_backend::{
     SelectorProblemBackend, TargetBindingProjection,
 };
 use selector_constraint_model_builder::{
-    CompiledSelectorProblemBuildError, compile_selector_problem,
+    CompiledSelectorProblemBuildError, SelectorModelBuildSummary, compile_selector_problem,
+    compile_selector_problem_with_summary,
 };
 use selector_ir::{
-    ClaimKind, ClaimOutcome, ResolvedClaim, SelectorFact, SelectorFactStore, SelectorProgram,
-    SelectorTargetId, SolverClaim, SolverResult,
+    ClaimKind, ClaimOutcome, ResolvedClaim, SelectorAtom, SelectorFact, SelectorFactStore,
+    SelectorProgram, SelectorTargetId, SolverClaim, SolverResult,
 };
+
+const SUMMARY_JSON_ENV: &str = "DUCKTAPE_DEBUNDLE_ORTOOLS_CPSAT_SUMMARY_JSON";
+const SUMMARY_JSON_DIR_ENV: &str = "DUCKTAPE_DEBUNDLE_ORTOOLS_CPSAT_SUMMARY_JSON_DIR";
+static SUMMARY_SEQUENCE: AtomicUsize = AtomicUsize::new(0);
 
 pub fn compile_backend_problem(
     program: &SelectorProgram,
@@ -38,8 +47,13 @@ pub fn solve_with_backend<B>(
 where
     B: SelectorProblemBackend,
 {
-    let problem =
-        compile_backend_problem(program, facts).map_err(SelectorBackendSolveError::Build)?;
+    write_selector_build_summary(program, facts, None, None)
+        .map_err(SelectorBackendSolveError::Summary)?;
+    let compiled = compile_selector_problem_with_summary(program, facts)
+        .map_err(SelectorBackendSolveError::Build)?;
+    let problem = compiled.problem;
+    write_selector_build_summary(program, facts, Some(&compiled.summary), Some(&problem))
+        .map_err(SelectorBackendSolveError::Summary)?;
     if problem.known_unsat.is_some() {
         return Ok(no_match_result(program));
     }
@@ -49,10 +63,11 @@ where
     decode_backend_result(program, facts, &problem, result)
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub enum SelectorBackendSolveError<E> {
     Build(CompiledSelectorProblemBuildError),
     Backend(E),
+    Summary(SelectorBuildSummaryError),
     Assignment(BackendAssignmentError),
     MissingTargetProjection {
         target: SelectorTargetId,
@@ -79,6 +94,7 @@ impl<E: fmt::Display> fmt::Display for SelectorBackendSolveError<E> {
         match self {
             Self::Build(err) => write!(f, "{err}"),
             Self::Backend(err) => write!(f, "selector backend failed: {err}"),
+            Self::Summary(err) => write!(f, "{err}"),
             Self::Assignment(err) => {
                 write!(f, "selector backend returned invalid assignment: {err}")
             }
@@ -132,6 +148,7 @@ where
         match self {
             Self::Build(err) => Some(err),
             Self::Backend(err) => Some(err),
+            Self::Summary(err) => Some(err),
             Self::Assignment(err) => Some(err),
             Self::MissingTargetProjection { .. }
             | Self::MissingAssignmentVariable { .. }
@@ -139,6 +156,343 @@ where
             | Self::MissingOwnerFact { .. }
             | Self::EmptySatisfyingAssignments { .. }
             | Self::UnsatReturnedAssignments => None,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum SelectorBuildSummaryError {
+    Io {
+        path: PathBuf,
+        source: io::Error,
+    },
+    Json {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
+}
+
+impl fmt::Display for SelectorBuildSummaryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io { path, source } => {
+                write!(
+                    f,
+                    "failed to write selector build summary at {}: {source}",
+                    path.display()
+                )
+            }
+            Self::Json { path, source } => {
+                write!(
+                    f,
+                    "failed to serialize selector build summary at {}: {source}",
+                    path.display()
+                )
+            }
+        }
+    }
+}
+
+impl Error for SelectorBuildSummaryError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Io { source, .. } => Some(source),
+            Self::Json { source, .. } => Some(source),
+        }
+    }
+}
+
+fn write_selector_build_summary(
+    program: &SelectorProgram,
+    facts: &SelectorFactStore,
+    model_summary: Option<&SelectorModelBuildSummary>,
+    problem: Option<&CompiledSelectorProblem>,
+) -> Result<(), SelectorBuildSummaryError> {
+    let paths = selector_build_summary_paths();
+    if paths.is_empty() {
+        return Ok(());
+    }
+
+    let summary = selector_build_summary_json(program, facts, model_summary, problem);
+    for path in paths {
+        write_summary_json(&path, &summary)?;
+    }
+    Ok(())
+}
+
+fn selector_build_summary_paths() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    if let Some(path) = env_path(SUMMARY_JSON_ENV) {
+        paths.push(path);
+    }
+    if let Some(dir) = env_path(SUMMARY_JSON_DIR_ENV) {
+        let sequence = SUMMARY_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        paths.push(dir.join(format!("selector-pre-solver-{sequence:06}.json")));
+    }
+    paths
+}
+
+fn env_path(env: &str) -> Option<PathBuf> {
+    std::env::var_os(env)
+        .map(PathBuf::from)
+        .filter(|path| !path.as_os_str().is_empty())
+}
+
+fn write_summary_json(
+    path: &Path,
+    summary: &serde_json::Value,
+) -> Result<(), SelectorBuildSummaryError> {
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent).map_err(|source| SelectorBuildSummaryError::Io {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+    let temp_path = path.with_extension("json.tmp");
+    let mut file =
+        fs::File::create(&temp_path).map_err(|source| SelectorBuildSummaryError::Io {
+            path: temp_path.clone(),
+            source,
+        })?;
+    serde_json::to_writer_pretty(&mut file, summary).map_err(|source| {
+        SelectorBuildSummaryError::Json {
+            path: temp_path.clone(),
+            source,
+        }
+    })?;
+    file.write_all(b"\n")
+        .map_err(|source| SelectorBuildSummaryError::Io {
+            path: temp_path.clone(),
+            source,
+        })?;
+    file.flush()
+        .map_err(|source| SelectorBuildSummaryError::Io {
+            path: temp_path.clone(),
+            source,
+        })?;
+    drop(file);
+    fs::rename(&temp_path, path).map_err(|source| SelectorBuildSummaryError::Io {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+fn selector_build_summary_json(
+    program: &SelectorProgram,
+    facts: &SelectorFactStore,
+    model_summary: Option<&SelectorModelBuildSummary>,
+    problem: Option<&CompiledSelectorProblem>,
+) -> serde_json::Value {
+    let compiled_problem = problem.map(compiled_problem_summary_json);
+    serde_json::json!({
+        "summary_kind": "selector_pre_solver",
+        "stage": if problem.is_some() { "compiled_problem" } else { "input" },
+        "selector_program": selector_program_summary_json(program),
+        "facts": {
+            "total": facts.len(),
+            "count_by_relation": facts.counts_by_relation(),
+        },
+        "model_build": model_summary.map(model_build_summary_json),
+        "compiled_problem": compiled_problem,
+    })
+}
+
+fn selector_program_summary_json(program: &SelectorProgram) -> serde_json::Value {
+    serde_json::json!({
+        "variable_count": program.variables.len(),
+        "variable_count_by_domain": keyed_count(program.variables.iter().map(|variable| variable_domain_name(variable.domain))),
+        "target_count": program.targets.len(),
+        "target_count_by_claim_kind": keyed_count(program.targets.iter().map(|target| claim_kind_name(&target.claim))),
+        "atom_count": program.atoms.len(),
+        "atom_count_by_kind": keyed_count(program.atoms.iter().map(selector_atom_kind_name)),
+        "all_different_count": program.all_different.len(),
+        "all_different_variables_count": program.all_different_variables.len(),
+        "all_different_arity_histogram": usize_histogram(program.all_different.iter().map(Vec::len)),
+        "all_different_variable_arity_histogram": usize_histogram(
+            program
+                .all_different_variables
+                .iter()
+                .map(|group| group.variables.len())
+        ),
+    })
+}
+
+fn model_build_summary_json(summary: &SelectorModelBuildSummary) -> serde_json::Value {
+    serde_json::json!({
+        "domain_value_counts": summary.domain_value_counts,
+        "stored_relation_counts": summary.stored_relation_counts,
+        "derived_relation_counts": summary.derived_relation_counts,
+    })
+}
+
+fn compiled_problem_summary_json(problem: &CompiledSelectorProblem) -> serde_json::Value {
+    let mut constraint_count_by_kind = BTreeMap::from([
+        ("allowed_table", problem.allowed_tuples.len()),
+        ("linear", problem.linear_constraints.len()),
+        ("all_different", problem.all_different.len()),
+    ]);
+    for constraint in &problem.binary_constraints {
+        let key = match constraint.kind {
+            selector_constraint_backend::BinaryConstraintKind::Equal => "binary_equal",
+            selector_constraint_backend::BinaryConstraintKind::NotEqual => "binary_not_equal",
+            selector_constraint_backend::BinaryConstraintKind::OrdinalBefore => {
+                "binary_ordinal_before"
+            }
+        };
+        *constraint_count_by_kind.entry(key).or_insert(0) += 1;
+    }
+    let domain_sizes = problem
+        .variables
+        .iter()
+        .map(|variable| problem.variable_domain_values(variable).len())
+        .collect::<Vec<_>>();
+    let allowed_table_rows = problem
+        .allowed_tuples
+        .iter()
+        .map(|constraint| constraint.tuples.len())
+        .collect::<Vec<_>>();
+    let allowed_table_cells = problem
+        .allowed_tuples
+        .iter()
+        .map(|constraint| {
+            constraint
+                .tuples
+                .iter()
+                .map(|tuple| tuple.len())
+                .sum::<usize>()
+        })
+        .collect::<Vec<_>>();
+
+    serde_json::json!({
+        "known_unsat": problem.known_unsat.is_some(),
+        "variable_count": problem.variables.len(),
+        "variable_count_by_domain": keyed_count(problem.variables.iter().map(|variable| variable_domain_name(variable.domain))),
+        "variable_domain_representation_count_by_kind": keyed_count(problem.variables.iter().map(|variable| match &variable.values {
+            selector_constraint_backend::CompiledVariableDomain::Full(_) => "full",
+            selector_constraint_backend::CompiledVariableDomain::Sparse(_) => "sparse",
+        })),
+        "domain_size_histogram": usize_histogram(domain_sizes.iter().copied()),
+        "max_domain_values": domain_sizes.into_iter().max().unwrap_or(0),
+        "full_domain_value_counts": {
+            "owner": problem.full_domains.owners.len(),
+            "ast_node": problem.full_domains.ast_nodes.len(),
+            "string": problem.full_domains.strings.len(),
+            "statement_ordinal": problem.full_domains.statement_ordinals.len(),
+        },
+        "value_dictionary_count": problem.value_dictionary.total_len(),
+        "constraint_count_by_kind": constraint_count_by_kind,
+        "allowed_table_count": problem.allowed_tuples.len(),
+        "allowed_table_arity_histogram": usize_histogram(problem.allowed_tuples.iter().map(|constraint| constraint.variables.len())),
+        "allowed_table_row_count_histogram": usize_histogram(allowed_table_rows.iter().copied()),
+        "allowed_table_cell_count_histogram": usize_histogram(allowed_table_cells.iter().copied()),
+        "allowed_row_count": allowed_table_rows.into_iter().sum::<usize>(),
+        "allowed_cell_count": allowed_table_cells.into_iter().sum::<usize>(),
+        "binary_constraint_count": problem.binary_constraints.len(),
+        "binary_constraint_count_by_kind": keyed_count(problem.binary_constraints.iter().map(|constraint| binary_constraint_kind_name(constraint.kind))),
+        "linear_constraint_count": problem.linear_constraints.len(),
+        "linear_constraint_arity_histogram": usize_histogram(problem.linear_constraints.iter().map(|constraint| constraint.variables.len())),
+        "all_different_count": problem.all_different.len(),
+        "all_different_count_by_reason": keyed_count(problem.all_different.iter().map(|constraint| all_different_reason_name(&constraint.reason))),
+        "all_different_arity_histogram": usize_histogram(problem.all_different.iter().map(|constraint| constraint.variables.len())),
+        "target_projection_count": problem.target_projections.len(),
+    })
+}
+
+fn usize_histogram(values: impl IntoIterator<Item = usize>) -> BTreeMap<String, usize> {
+    let mut histogram = BTreeMap::new();
+    for value in values {
+        *histogram.entry(value.to_string()).or_insert(0) += 1;
+    }
+    histogram
+}
+
+fn keyed_count(keys: impl IntoIterator<Item = &'static str>) -> BTreeMap<&'static str, usize> {
+    let mut counts = BTreeMap::new();
+    for key in keys {
+        *counts.entry(key).or_insert(0) += 1;
+    }
+    counts
+}
+
+fn variable_domain_name(domain: selector_ir::VariableDomain) -> &'static str {
+    match domain {
+        selector_ir::VariableDomain::Owner => "owner",
+        selector_ir::VariableDomain::AstNode => "ast_node",
+        selector_ir::VariableDomain::String => "string",
+        selector_ir::VariableDomain::StatementOrdinal => "statement_ordinal",
+    }
+}
+
+fn claim_kind_name(claim: &ClaimKind) -> &'static str {
+    match claim {
+        ClaimKind::Binding { .. } => "binding",
+        ClaimKind::AnonymousStatement => "anonymous_statement",
+        ClaimKind::BindingGroupMember { .. } => "binding_group_member",
+    }
+}
+
+fn selector_atom_kind_name(atom: &SelectorAtom) -> &'static str {
+    match atom {
+        SelectorAtom::OwnerKind { .. } => "owner_kind",
+        SelectorAtom::OwnerStatementOrdinal { .. } => "owner_statement_ordinal",
+        SelectorAtom::OwnerTopLevelRoot { .. } => "owner_top_level_root",
+        SelectorAtom::OwnerDeclaresBinding { .. } => "owner_declares_binding",
+        SelectorAtom::OwnerExportName { .. } => "owner_export_name",
+        SelectorAtom::OwnerReferencesBinding { .. } => "owner_references_binding",
+        SelectorAtom::OwnerReferencesOwner { .. } => "owner_references_owner",
+        SelectorAtom::OwnerAliasesOwner { .. } => "owner_aliases_owner",
+        SelectorAtom::AstKind { .. } => "ast_kind",
+        SelectorAtom::AstChild { .. } => "ast_child",
+        SelectorAtom::AstChildListPattern { .. } => "ast_child_list_pattern",
+        SelectorAtom::AstSuperClass { .. } => "ast_super_class",
+        SelectorAtom::AstChildCount { .. } => "ast_child_count",
+        SelectorAtom::AstStringLiteral { .. } => "ast_string_literal",
+        SelectorAtom::AstStringLiteralMatchingRegex { .. } => "ast_string_literal_matching_regex",
+        SelectorAtom::AstNumberLiteral { .. } => "ast_number_literal",
+        SelectorAtom::AstBoolLiteral { .. } => "ast_bool_literal",
+        SelectorAtom::AstIdentifierName { .. } => "ast_identifier_name",
+        SelectorAtom::AstPropertyName { .. } => "ast_property_name",
+        SelectorAtom::AstBareProperty { .. } => "ast_bare_property",
+        SelectorAtom::AstOperator { .. } => "ast_operator",
+        SelectorAtom::AstRegexLiteral { .. } => "ast_regex_literal",
+        SelectorAtom::AstTopLevel { .. } => "ast_top_level",
+        SelectorAtom::OrdinalOffset { .. } => "ordinal_offset",
+        SelectorAtom::OrdinalBefore { .. } => "ordinal_before",
+        SelectorAtom::ReadsMember { .. } => "reads_member",
+        SelectorAtom::ReadsMemberOfOwner { .. } => "reads_member_of_owner",
+        SelectorAtom::ConsumesModuleMember { .. } => "consumes_module_member",
+        SelectorAtom::PassedToCall { .. } => "passed_to_call",
+        SelectorAtom::PassedToCallOfOwner { .. } => "passed_to_call_of_owner",
+        SelectorAtom::MakesDecorateCall { .. } => "makes_decorate_call",
+        SelectorAtom::MakesDecorateCallForOwner { .. } => "makes_decorate_call_for_owner",
+        SelectorAtom::IntrinsicAlias { .. } => "intrinsic_alias",
+        SelectorAtom::Equal { .. } => "equal",
+        SelectorAtom::NotEqual { .. } => "not_equal",
+    }
+}
+
+fn binary_constraint_kind_name(
+    kind: selector_constraint_backend::BinaryConstraintKind,
+) -> &'static str {
+    match kind {
+        selector_constraint_backend::BinaryConstraintKind::Equal => "equal",
+        selector_constraint_backend::BinaryConstraintKind::NotEqual => "not_equal",
+        selector_constraint_backend::BinaryConstraintKind::OrdinalBefore => "ordinal_before",
+    }
+}
+
+fn all_different_reason_name(
+    reason: &selector_constraint_backend::AllDifferentReason,
+) -> &'static str {
+    match reason {
+        selector_constraint_backend::AllDifferentReason::TargetInjectivity { .. } => {
+            "target_injectivity"
+        }
+        selector_constraint_backend::AllDifferentReason::SelectorSemantics { .. } => {
+            "selector_semantics"
         }
     }
 }
@@ -370,7 +724,9 @@ mod tests {
         BackendAssignment, BackendAssignmentCoverage, BackendSolveResult, BackendSolveStatus,
         BackendValueId, BackendVariableAssignment,
     };
+    use selector_constraint_model_builder::compile_selector_problem_with_summary;
     use selector_ir::{ClaimOrigin, OwnerTerm, SelectorAtom, StringTerm, VariableDomain};
+    use serde_json::json;
 
     use super::*;
 
@@ -528,6 +884,85 @@ mod tests {
                 .value_dictionary
                 .encode(&ConstraintValue::String("minA".to_string()))
                 .is_some()
+        );
+    }
+
+    #[test]
+    fn selector_build_summary_json_reports_input_shape_before_model_build() {
+        let (program, _) = binding_program();
+        let summary = selector_build_summary_json(&program, &facts(), None, None);
+
+        assert_eq!(summary["summary_kind"], json!("selector_pre_solver"));
+        assert_eq!(summary["stage"], json!("input"));
+        assert_eq!(summary["selector_program"]["variable_count"], json!(2));
+        assert_eq!(
+            summary["selector_program"]["variable_count_by_domain"]["owner"],
+            json!(1)
+        );
+        assert_eq!(
+            summary["selector_program"]["atom_count_by_kind"]["owner_declares_binding"],
+            json!(1)
+        );
+        assert_eq!(
+            summary["selector_program"]["atom_count_by_kind"]["owner_export_name"],
+            json!(1)
+        );
+        assert_eq!(summary["facts"]["total"], json!(4));
+        assert_eq!(summary["facts"]["count_by_relation"]["owner"], json!(2));
+        assert_eq!(
+            summary["facts"]["count_by_relation"]["declared_binding"],
+            json!(2)
+        );
+        assert!(summary["model_build"].is_null());
+        assert!(summary["compiled_problem"].is_null());
+    }
+
+    #[test]
+    fn selector_build_summary_json_reports_compiled_problem_shape() {
+        let (program, _) = binding_program();
+        let facts = facts();
+        let compiled = compile_selector_problem_with_summary(&program, &facts).unwrap();
+        let summary = selector_build_summary_json(
+            &program,
+            &facts,
+            Some(&compiled.summary),
+            Some(&compiled.problem),
+        );
+
+        assert_eq!(summary["stage"], json!("compiled_problem"));
+        assert_eq!(
+            summary["model_build"]["domain_value_counts"]["owner"],
+            json!(2)
+        );
+        assert_eq!(
+            summary["model_build"]["domain_value_counts"]["string"],
+            json!(4)
+        );
+        assert_eq!(
+            summary["model_build"]["stored_relation_counts"]["owner_kind"],
+            json!(2)
+        );
+        assert_eq!(
+            summary["model_build"]["stored_relation_counts"]["declared_binding"],
+            json!(2)
+        );
+        assert_eq!(summary["compiled_problem"]["variable_count"], json!(2));
+        assert_eq!(
+            summary["compiled_problem"]["variable_count_by_domain"]["owner"],
+            json!(1)
+        );
+        assert_eq!(
+            summary["compiled_problem"]["variable_count_by_domain"]["string"],
+            json!(1)
+        );
+        assert_eq!(summary["compiled_problem"]["allowed_table_count"], json!(2));
+        assert_eq!(
+            summary["compiled_problem"]["constraint_count_by_kind"]["allowed_table"],
+            json!(2)
+        );
+        assert_eq!(
+            summary["compiled_problem"]["constraint_count_by_kind"]["linear"],
+            json!(0)
         );
     }
 

--- a/devinfra/js/debundle/selector_constraint_model_builder.rs
+++ b/devinfra/js/debundle/selector_constraint_model_builder.rs
@@ -21,11 +21,32 @@ pub fn compile_selector_problem(
     program: &SelectorProgram,
     facts: &SelectorFactStore,
 ) -> Result<CompiledSelectorProblem, CompiledSelectorProblemBuildError> {
+    Ok(compile_selector_problem_with_summary(program, facts)?.problem)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompiledSelectorProblemWithSummary {
+    pub problem: CompiledSelectorProblem,
+    pub summary: SelectorModelBuildSummary,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SelectorModelBuildSummary {
+    pub domain_value_counts: BTreeMap<&'static str, usize>,
+    pub stored_relation_counts: BTreeMap<&'static str, usize>,
+    pub derived_relation_counts: BTreeMap<&'static str, usize>,
+}
+
+pub fn compile_selector_problem_with_summary(
+    program: &SelectorProgram,
+    facts: &SelectorFactStore,
+) -> Result<CompiledSelectorProblemWithSummary, CompiledSelectorProblemBuildError> {
     program
         .validate()
         .map_err(CompiledSelectorProblemBuildError::InvalidProgram)?;
 
     let domains = FactDomains::from_program_and_facts(program, facts);
+    let summary = domains.summary();
     let target_binding_projections = TargetBindingProjections::from_program(program)?;
 
     let mut model = CompiledSelectorProblemBuilder::default();
@@ -80,7 +101,10 @@ pub fn compile_selector_problem(
         )?;
     }
 
-    model.finish().map_err(Into::into)
+    let problem = model
+        .finish()
+        .map_err(CompiledSelectorProblemBuildError::from)?;
+    Ok(CompiledSelectorProblemWithSummary { problem, summary })
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -569,16 +593,9 @@ fn lower_atom_constraint(
                 BinaryConstraintKind::NotEqual,
             )
             .map_err(Into::into),
-        SelectorAtom::OrdinalBefore {
-            before: OrdinalTerm::Var { id: before },
-            after: OrdinalTerm::Var { id: after },
-        } => model
-            .add_binary_constraint(
-                model_variable(variables, *before)?,
-                model_variable(variables, *after)?,
-                BinaryConstraintKind::OrdinalBefore,
-            )
-            .map_err(Into::into),
+        SelectorAtom::OrdinalBefore { before, after } => {
+            add_ordinal_before_constraint(model, variables, before, after)
+        }
         SelectorAtom::AstChildListPattern {
             parent,
             start_index,
@@ -597,9 +614,6 @@ fn lower_atom_constraint(
             },
             domains,
         ),
-        _ => Err(CompiledSelectorProblemBuildError::UnsupportedAtom {
-            atom: format!("{atom:?}"),
-        }),
     }
 }
 
@@ -1083,6 +1097,17 @@ fn add_ordinal_offset_constraint(
     let base = ordinal_linear_variable(model, variables, base)?;
     let ordinal = ordinal_linear_variable(model, variables, ordinal)?;
     add_linear_offset_equality(model, base, ordinal, i64::from(offset))
+}
+
+fn add_ordinal_before_constraint(
+    model: &mut CompiledSelectorProblemBuilder,
+    variables: &[ConstraintVariableId],
+    before: &OrdinalTerm,
+    after: &OrdinalTerm,
+) -> Result<(), CompiledSelectorProblemBuildError> {
+    let before = ordinal_linear_variable(model, variables, before)?;
+    let after = ordinal_linear_variable(model, variables, after)?;
+    add_linear_offset_less_or_equal(model, before, after, 1)
 }
 
 fn ordinal_linear_variable(
@@ -1828,6 +1853,124 @@ impl FactDomains {
         domains.add_derived_facts();
         domains.add_program_constants(program);
         domains
+    }
+
+    fn summary(&self) -> SelectorModelBuildSummary {
+        SelectorModelBuildSummary {
+            domain_value_counts: BTreeMap::from([
+                ("owner", self.owners.len()),
+                ("ast_node", self.nodes.len()),
+                ("string", self.strings.len()),
+                ("statement_ordinal", self.ordinals.len()),
+            ]),
+            stored_relation_counts: BTreeMap::from([
+                ("owner_kind", self.owner_kinds.len()),
+                (
+                    "owner_statement_ordinal",
+                    self.owner_statement_ordinals.len(),
+                ),
+                ("owner_top_level_root", self.owner_top_level_roots.len()),
+                ("declared_binding", self.declared_bindings.len()),
+                ("export_name", self.export_names.len()),
+                (
+                    "raw_owner_references_binding",
+                    self.raw_owner_references_binding.len(),
+                ),
+                (
+                    "owner_references_binding",
+                    self.owner_references_binding.len(),
+                ),
+                ("references_owner", self.references_owner.len()),
+                ("aliases_owner", self.aliases_owner.len()),
+                ("ast_kind", self.ast_kinds.len()),
+                ("ast_child", ast_child_count(&self.ast_children_by_parent)),
+                ("ast_child_parent", self.ast_children_by_parent.len()),
+                ("ast_child_count", self.ast_child_counts.len()),
+                ("ast_super_class", self.ast_super_classes.len()),
+                ("ast_string_literal", self.ast_string_literals.len()),
+                ("ast_number_literal", self.ast_number_literals.len()),
+                ("ast_bool_literal", self.ast_bool_literals.len()),
+                ("ast_identifier_name", self.ast_identifier_names.len()),
+                ("ast_property_name", self.ast_property_names.len()),
+                ("ast_bare_property", self.ast_bare_properties.len()),
+                ("ast_operator", self.ast_operators.len()),
+                ("ast_regex_literal", self.ast_regex_literals.len()),
+                ("ast_top_level", self.ast_top_levels.len()),
+                ("ast_top_level_position", self.ast_top_level_positions.len()),
+                ("raw_member_read", self.raw_member_reads.len()),
+                ("member_read", self.member_reads.len()),
+                (
+                    "member_read_from_binding",
+                    self.member_reads_from_binding.len(),
+                ),
+                ("reads_member_of_owner", self.reads_member_of_owner.len()),
+                ("raw_module_member_use", self.raw_module_member_uses.len()),
+                ("module_member_use", self.module_member_uses.len()),
+                ("raw_call_argument", self.raw_call_arguments.len()),
+                ("call_argument", self.call_arguments.len()),
+                (
+                    "call_argument_from_binding",
+                    self.call_arguments_from_binding.len(),
+                ),
+                (
+                    "call_argument_from_owner",
+                    self.call_arguments_from_owner.len(),
+                ),
+                ("decorate_call", self.decorate_calls.len()),
+                (
+                    "makes_decorate_call_for_binding",
+                    self.makes_decorate_call_for_binding.len(),
+                ),
+                (
+                    "makes_decorate_call_for_owner",
+                    self.makes_decorate_call_for_owner.len(),
+                ),
+                ("intrinsic_alias", self.intrinsic_aliases.len()),
+                (
+                    "intrinsic_alias_referenced_by",
+                    self.intrinsic_alias_referenced_by.len(),
+                ),
+            ]),
+            derived_relation_counts: BTreeMap::from([
+                ("owner_top_level_root", self.owner_top_level_roots.len()),
+                (
+                    "owner_references_binding",
+                    self.owner_references_binding.len(),
+                ),
+                ("references_owner", self.references_owner.len()),
+                ("aliases_owner", self.aliases_owner.len()),
+                ("ast_child_count", self.ast_child_counts.len()),
+                ("ast_top_level_position", self.ast_top_level_positions.len()),
+                ("member_read", self.member_reads.len()),
+                (
+                    "member_read_from_binding",
+                    self.member_reads_from_binding.len(),
+                ),
+                ("reads_member_of_owner", self.reads_member_of_owner.len()),
+                ("module_member_use", self.module_member_uses.len()),
+                ("call_argument", self.call_arguments.len()),
+                (
+                    "call_argument_from_binding",
+                    self.call_arguments_from_binding.len(),
+                ),
+                (
+                    "call_argument_from_owner",
+                    self.call_arguments_from_owner.len(),
+                ),
+                (
+                    "makes_decorate_call_for_binding",
+                    self.makes_decorate_call_for_binding.len(),
+                ),
+                (
+                    "makes_decorate_call_for_owner",
+                    self.makes_decorate_call_for_owner.len(),
+                ),
+                (
+                    "intrinsic_alias_referenced_by",
+                    self.intrinsic_alias_referenced_by.len(),
+                ),
+            ]),
+        }
     }
 
     fn values_for(&self, domain: VariableDomain) -> Vec<ConstraintValue> {
@@ -2586,6 +2729,13 @@ impl FactDomains {
     fn add_ordinal(&mut self, ordinal: StatementOrdinal) {
         self.ordinals.insert(ordinal);
     }
+}
+
+fn ast_child_count(ast_children_by_parent: &BTreeMap<NodeId, Vec<(u32, NodeId)>>) -> usize {
+    ast_children_by_parent
+        .values()
+        .map(|children| children.len())
+        .sum()
 }
 
 #[cfg(test)]
@@ -3743,7 +3893,7 @@ mod tests {
     }
 
     #[test]
-    fn explicit_binary_atoms_stay_binary_constraints() {
+    fn ordinal_before_lowers_to_linear_constraint() {
         let mut program = SelectorProgram::default();
         let left = program.add_variable(VariableDomain::StatementOrdinal, Some("left".to_string()));
         let right =
@@ -3758,12 +3908,14 @@ mod tests {
         let model = compile_selector_problem(&program, &facts).unwrap();
 
         assert!(model.allowed_tuples.is_empty());
+        assert!(model.binary_constraints.is_empty());
         assert_eq!(
-            model.binary_constraints,
-            vec![BinaryConstraint {
-                left: ConstraintVariableId(0),
-                right: ConstraintVariableId(1),
-                kind: BinaryConstraintKind::OrdinalBefore,
+            model.linear_constraints,
+            vec![LinearConstraint {
+                variables: vec![ConstraintVariableId(0), ConstraintVariableId(1)],
+                coefficients: vec![1, -1],
+                offset: 1,
+                domain: vec![0, 0],
             }]
         );
         assert_eq!(


### PR DESCRIPTION
## Summary
- emit selector pre-solver JSON summaries before and after Rust-side model compilation, using the existing OR-Tools summary env vars/dirs
- include input fact counts, model-build domain/relation counts, compiled CSP constraint/domain histograms, and broad constraint counts by kind
- lower `SelectorAtom::OrdinalBefore` as a linear ordinal constraint (`before + 1 <= after`) instead of the bespoke binary constraint path
- document timeout profiling as stop-and-attach with `gdb` first, core dump only when preservation is needed

## Validation
- `nix develop -c pre-commit run --files devinfra/js/debundle/AGENTS.md devinfra/js/debundle/BUILD.bazel devinfra/js/debundle/debug/perf/2026_06_27_large_bundle_selector_csp_profile.md devinfra/js/debundle/selector_backend_solver.rs devinfra/js/debundle/selector_constraint_model_builder.rs`
- `nix develop -c bazelisk test //devinfra/js/debundle:selector_backend_solver_test //devinfra/js/debundle:selector_constraint_model_builder_test //devinfra/js/debundle:selector_ortools_cpsat_backend_test --config=nolint --config=rbe --remote_download_outputs=all --cache_test_results=no`

BuildBuddy invocation after rebase: https://app.buildbuddy.io/invocation/415a3b4f-18cb-4633-83bf-0f588c60eb44