### PR TITLE
[codex] devinfra/js/debundle: improve perf artifacts

### DIFF
--- a/devinfra/js/debundle/AGENTS.md
+++ b/devinfra/js/debundle/AGENTS.md
@@ -134,6 +134,12 @@ stack samples. Keep production telemetry coarse and useful for users of
 the pipeline; don't add detailed stage fields solely because an
 optimization investigation needs temporary visibility.
 
+For `perf` captures, follow the artifact-reading guide in <README.md> rather
+than adding one-off summarizers or timing hooks. In short: use
+`perf_record_stderr.txt` for debundler progress markers,
+`perf_report_flat_symbols.txt` for top self-cost symbols, and the symbolized
+children report plus bounded head/mid/late stack slices for callgraph evidence.
+
 For timed perf repros, prefer stopping the process on timeout before
 killing it, then attach with `gdb` to inspect live stacks and memory
 state. Use a core dump only when the interrupted state needs to be

--- a/devinfra/js/debundle/README.md
+++ b/devinfra/js/debundle/README.md
@@ -164,13 +164,60 @@ Each profile target writes a `<target>.profile` tree artifact. Common files:
 Mode-specific files:
 
 - `time`: `stderr_time.txt` from `/usr/bin/time -v`.
-- `perf`: `perf.data`, `perf_report_children.txt`,
-  `perf_report_no_children.txt`, `perf_script_stacks.txt`, `perf_header.txt`,
-  and `perf_evlist.txt`.
+- `perf`: `perf.data`, `perf_report_flat_symbols.txt`,
+  `perf_report_children.txt`, `perf_report_no_children.txt`,
+  `perf_script_stacks_head.txt`, `perf_script_stacks_mid.txt`,
+  `perf_script_stacks_late.txt`, `perf_script_stacks.txt`,
+  `perf_header.txt`, `perf_evlist.txt`, `perf_wrapper_env.txt`,
+  `perf_record_stderr.txt`, and any `*.failed.txt` or `*.partial`
+  post-processing artifacts.
 - `massif_heap`: `massif_heap.out`, `massif_heap_stderr.txt`, and
   `ms_print_heap.txt` when `ms_print` is available.
 - `heaptrack`: `heaptrack*`, `heaptrack_stderr.txt`, and
   `heaptrack_print.txt` when `heaptrack_print` is available.
+
+Use the perf artifacts as follows:
+
+- `perf_record_stderr.txt`: debundler progress markers and `/usr/bin/time -v`
+  style resource output when the surrounding profile action records it. Use this
+  to identify the last started phase and whether the run reached CP-SAT output.
+- `perf_report_flat_symbols.txt`: fast no-callgraph view for top self-cost
+  symbols.
+- `perf_report_children.txt`: symbolized inclusive callgraph report. The
+  wrapper defaults to `PERF_ADDR2LINE_STYLE=llvm` because default perf
+  symbolization can be much slower on Rust DWARF. Use
+  `PERF_ADDR2LINE_STYLE=libdw` if llvm-style symbolization is unavailable or
+  needs comparison; use `default` only to debug perf itself.
+- `perf_report_no_children.txt`: flat report with the same symbolizer settings.
+- `perf_script_stacks_head.txt`, `perf_script_stacks_mid.txt`, and
+  `perf_script_stacks_late.txt`: bounded symbolized stack slices from the
+  beginning, middle, and end of the profile window. These are useful for
+  stage attribution even when full `perf script` output is too slow. If a
+  sibling `.failed.txt` exists but the stack file is non-empty, treat the stack
+  file as a partial but valid slice and read the failure file as timeout
+  metadata.
+- `perf_script_stacks.txt`: full `perf script` output when it completes within
+  the post-processing timeout.
+- `*.failed.txt` and `*.partial`: bounded post-processing failure metadata and
+  partial output. A failed full report with useful head/mid/late slices is still
+  a valid profiling run.
+
+Useful knobs:
+
+```sh
+PERF_RECORD_FREQ=49              # lower sample frequency for quick iteration
+PERF_ADDR2LINE_STYLE=libdw       # compare symbolizers; default is llvm
+PERF_POSTPROCESS_TIMEOUT=300s    # allow full report generation more time
+PERF_CALLGRAPH_TIMEOUT=30s       # allow each head/mid/late stack slice longer
+PERF_CALLGRAPH_MAX_STACK=64      # preserve deeper callchains in stack slices
+PERF_CALLGRAPH_SLICE_SECS=10     # widen each head/mid/late stack slice
+PERF_CALL_GRAPH=fp               # cheaper callgraphs if the binary has frame pointers
+```
+
+Lower `PERF_RECORD_FREQ` when iterating, but do not treat sampling frequency as
+the main fix for slow report generation. For debundler Rust profiles, the
+dominant post-processing issue is usually symbolization; tune the symbolizer
+and stack-capture knobs above before assuming the profile has too many samples.
 
 Save important runs before cleaning Bazel outputs:
 

--- a/devinfra/js/debundle/perf_wrapper.sh
+++ b/devinfra/js/debundle/perf_wrapper.sh
@@ -12,33 +12,42 @@
 #     perf_wrapper.sh --output-dir <dir> -- <debundler> [args...]
 #
 # Outputs (under <dir>):
-#     command.sh                  — rerunner stub
-#     perf.data                   — raw perf samples
-#     perf_report_children.txt    — tree report (sorted comm,dso,symbol)
-#     perf_report_no_children.txt — flat report
-#     perf_script_stacks.txt      — perf script (per-sample stacks)
-#     perf_header.txt             — perf.data header
-#     perf_evlist.txt             — recorded event list
-#     stdout.txt                  — debundler stdout
-#     perf_record_stderr.txt      — debundler+perf stderr
+#     command.sh                    — rerunner stub
+#     perf.data                     — raw perf samples
+#     perf_report_flat_symbols.txt  — fast no-callgraph flat report
+#     perf_report_children.txt      — tree report (sorted comm,dso,symbol)
+#     perf_report_no_children.txt   — flat report with callgraph context
+#     perf_script_stacks_head.txt   — bounded early perf script stack slice
+#     perf_script_stacks_mid.txt    — bounded middle perf script stack slice
+#     perf_script_stacks_late.txt   — bounded late perf script stack slice
+#     perf_script_stacks.txt        — full perf script output, if it finishes
+#     perf_header.txt               — perf.data header
+#     perf_evlist.txt               — recorded event list
+#     stdout.txt                    — debundler stdout
+#     perf_record_stderr.txt        — debundler+perf stderr
 #
-# `perf report` shells out to whatever `addr2line` it finds on $PATH for
-# inlined-frame resolution. On Rust binaries with deep DWARF, the GNU
-# addr2line is single-threaded and has no inter-invocation cache, so
-# symbolization can dominate wall time (30+ minutes observed). LLVM's
-# llvm-addr2line is command-line compatible with the flags perf uses
-# (-e/-a/-i/-f) and is typically 10-50x faster on Rust DWARF thanks to a
-# persistent in-process symbol cache.
+# Knobs:
+#     PERF_RECORD_FREQ          sample frequency; default 99
+#     PERF_CALL_GRAPH           perf call graph mode; default dwarf,8192
+#     PERF_ADDR2LINE_STYLE      report symbolizer style; default llvm
+#                               use "default" to let perf choose
+#     PERF_POSTPROCESS_TIMEOUT  per-report timeout; default 120s
+#     PERF_CALLGRAPH_TIMEOUT    per-stack-slice timeout; default 20s
+#     PERF_CALLGRAPH_MAX_STACK  stack depth for perf script slices; default 48
+#     PERF_CALLGRAPH_SLICE_SECS seconds in each stack slice; default 6
 #
-# Two interlocking hacks make this work on Nix:
+# Report generation defaults to llvm-style symbolization and bounded
+# post-processing. Timeout metadata lands in <output>.failed.txt; full-report
+# partial output lands in <output>.partial.
 #
-# 1. A shim dir that aliases `addr2line` -> `llvm-addr2line` and is
-#    prepended to PATH.
+# A remaining Nix compatibility shim aliases addr2line -> llvm-addr2line when
+# that binary is available. This mostly helps commands that do not support
+# perf's `--addr2line-style` flag.
 #
-# 2. The `perf` binary on Nix is a wrapper shell script that itself
-#    re-prepends GNU binutils to PATH before exec'ing the real perf,
-#    which shadows our shim. Bypass the wrapper by invoking the inner
-#    `.perf-wrapped` binary directly when present.
+# The `perf` binary on Nix is itself a wrapper shell script that re-prepends GNU
+# binutils to PATH before exec'ing the real perf, which can shadow that shim.
+# Bypass the wrapper by invoking the inner `.perf-wrapped` binary directly when
+# present.
 
 set -euo pipefail
 
@@ -108,28 +117,186 @@ else
   perf_cmd="$(command -v perf)"
 fi
 
+postprocess_timeout="${PERF_POSTPROCESS_TIMEOUT:-120s}"
+record_frequency="${PERF_RECORD_FREQ:-99}"
+call_graph="${PERF_CALL_GRAPH:-dwarf,8192}"
+addr2line_style="${PERF_ADDR2LINE_STYLE:-llvm}"
+callgraph_timeout="${PERF_CALLGRAPH_TIMEOUT:-20s}"
+callgraph_max_stack="${PERF_CALLGRAPH_MAX_STACK:-48}"
+callgraph_slice_secs="${PERF_CALLGRAPH_SLICE_SECS:-6}"
+perf_report_symbolizer_args=()
+if [[ -n "${addr2line_style}" && "${addr2line_style}" != "default" ]]; then
+  perf_report_symbolizer_args+=(--addr2line-style "${addr2line_style}")
+fi
+
+{
+  echo "PERF_RECORD_FREQ=${record_frequency}"
+  echo "PERF_CALL_GRAPH=${call_graph}"
+  echo "PERF_ADDR2LINE_STYLE=${addr2line_style}"
+  echo "PERF_POSTPROCESS_TIMEOUT=${postprocess_timeout}"
+  echo "PERF_CALLGRAPH_TIMEOUT=${callgraph_timeout}"
+  echo "PERF_CALLGRAPH_MAX_STACK=${callgraph_max_stack}"
+  echo "PERF_CALLGRAPH_SLICE_SECS=${callgraph_slice_secs}"
+  echo "PERF_CMD=${perf_cmd}"
+  if command -v addr2line >/dev/null; then
+    echo "ADDR2LINE=$(command -v addr2line)"
+  fi
+} >"${profile_dir}/perf_wrapper_env.txt"
+
+run_perf_command() {
+  local output="$1"
+  local timeout_value="$2"
+  local failure_message="$3"
+  local partial_suffix="$4"
+  shift 4
+  local tmp_output="${output}.tmp"
+  local tmp_stderr="${output}.stderr.tmp"
+
+  rm -f "${tmp_output}" "${tmp_stderr}" "${output}.failed.txt" "${output}.partial"
+  if timeout --foreground "${timeout_value}" \
+    "${perf_cmd}" "$@" >"${tmp_output}" 2>"${tmp_stderr}"; then
+    mv "${tmp_output}" "${output}"
+    if [[ -s "${tmp_stderr}" ]]; then
+      mv "${tmp_stderr}" "${output}.stderr"
+    else
+      rm -f "${tmp_stderr}" "${output}.stderr"
+    fi
+    return 0
+  fi
+
+  local status=$?
+  {
+    echo "${failure_message}"
+    echo "status=${status}"
+    echo "timeout=${timeout_value}"
+    printf 'command=%q' "${perf_cmd}"
+    for arg in "$@"; do
+      printf ' %q' "${arg}"
+    done
+    printf '\n'
+    if [[ -s "${tmp_stderr}" ]]; then
+      echo
+      echo "stderr:"
+      cat "${tmp_stderr}"
+    fi
+  } >"${output}.failed.txt"
+  if [[ -s "${tmp_output}" ]]; then
+    mv "${tmp_output}" "${output}${partial_suffix}"
+  else
+    rm -f "${tmp_output}"
+  fi
+  rm -f "${tmp_stderr}"
+  return 0
+}
+
+run_perf_output() {
+  local output="$1"
+  shift
+  run_perf_command \
+    "${output}" \
+    "${postprocess_timeout}" \
+    "perf post-processing command failed" \
+    .partial \
+    "$@"
+}
+
+run_perf_stack_slice() {
+  local output="$1"
+  shift
+  run_perf_command \
+    "${output}" \
+    "${callgraph_timeout}" \
+    "perf stack-slice command failed" \
+    "" \
+    "$@"
+}
+
+extract_stack_slices() {
+  local header="${profile_dir}/perf_header.txt"
+  local first_sample=""
+  local last_sample=""
+
+  if [[ -s "${header}" ]]; then
+    first_sample="$(awk -F': ' '/# time of first sample/ { print $2 }' "${header}")"
+    last_sample="$(awk -F': ' '/# time of last sample/ { print $2 }' "${header}")"
+  fi
+  if [[ -z "${first_sample}" || -z "${last_sample}" ]]; then
+    run_perf_stack_slice "${profile_dir}/perf_script_stacks_head.txt" \
+      script --input "${profile_dir}/perf.data" \
+      --max-stack "${callgraph_max_stack}"
+    return 0
+  fi
+
+  read -r head_start head_end mid_start mid_end late_start late_end < <(
+    awk -v first="${first_sample}" \
+      -v last="${last_sample}" \
+      -v requested_window="${callgraph_slice_secs}" \
+      'BEGIN {
+        duration = last - first
+        window = requested_window
+        if (duration <= 0) {
+          printf "%.6f %.6f %.6f %.6f %.6f %.6f\n", first, last, first, last, first, last
+          exit
+        }
+        if (window <= 0 || window > duration) {
+          window = duration
+        }
+        mid = first + duration / 2
+        printf "%.6f %.6f %.6f %.6f %.6f %.6f\n",
+          first, first + window,
+          mid - window / 2, mid + window / 2,
+          last - window, last
+      }'
+  )
+
+  run_perf_stack_slice "${profile_dir}/perf_script_stacks_head.txt" \
+    script --input "${profile_dir}/perf.data" \
+    --max-stack "${callgraph_max_stack}" \
+    --time "${head_start},${head_end}"
+
+  run_perf_stack_slice "${profile_dir}/perf_script_stacks_mid.txt" \
+    script --input "${profile_dir}/perf.data" \
+    --max-stack "${callgraph_max_stack}" \
+    --time "${mid_start},${mid_end}"
+
+  run_perf_stack_slice "${profile_dir}/perf_script_stacks_late.txt" \
+    script --input "${profile_dir}/perf.data" \
+    --max-stack "${callgraph_max_stack}" \
+    --time "${late_start},${late_end}"
+}
+
 "${perf_cmd}" record \
-  -F 99 \
+  -F "${record_frequency}" \
   -e cycles:u \
-  --call-graph dwarf,8192 \
+  --call-graph "${call_graph}" \
   -o "${profile_dir}/perf.data" \
   -- "$@" \
   >"${profile_dir}/stdout.txt" \
   2>"${profile_dir}/perf_record_stderr.txt"
 
-"${perf_cmd}" report --stdio --input "${profile_dir}/perf.data" \
-  --children --sort comm,dso,symbol \
-  >"${profile_dir}/perf_report_children.txt"
+run_perf_output "${profile_dir}/perf_header.txt" \
+  report "${perf_report_symbolizer_args[@]}" \
+  --stdio --header-only --input "${profile_dir}/perf.data"
 
-"${perf_cmd}" report --stdio --input "${profile_dir}/perf.data" \
-  --no-children --sort comm,dso,symbol \
-  >"${profile_dir}/perf_report_no_children.txt"
+run_perf_output "${profile_dir}/perf_evlist.txt" \
+  evlist --input "${profile_dir}/perf.data"
 
-"${perf_cmd}" script --input "${profile_dir}/perf.data" \
-  >"${profile_dir}/perf_script_stacks.txt"
+run_perf_output "${profile_dir}/perf_report_flat_symbols.txt" \
+  report "${perf_report_symbolizer_args[@]}" \
+  --stdio --input "${profile_dir}/perf.data" \
+  --no-children -g none --percent-limit 0.5 --sort symbol
 
-"${perf_cmd}" report --stdio --header-only --input "${profile_dir}/perf.data" \
-  >"${profile_dir}/perf_header.txt"
+extract_stack_slices
 
-"${perf_cmd}" evlist --input "${profile_dir}/perf.data" \
-  >"${profile_dir}/perf_evlist.txt"
+run_perf_output "${profile_dir}/perf_report_children.txt" \
+  report "${perf_report_symbolizer_args[@]}" \
+  --stdio --input "${profile_dir}/perf.data" \
+  --children --sort comm,dso,symbol
+
+run_perf_output "${profile_dir}/perf_report_no_children.txt" \
+  report "${perf_report_symbolizer_args[@]}" \
+  --stdio --input "${profile_dir}/perf.data" \
+  --no-children --sort comm,dso,symbol
+
+run_perf_output "${profile_dir}/perf_script_stacks.txt" \
+  script --input "${profile_dir}/perf.data"


### PR DESCRIPTION
## Summary

- make the perf wrapper default `perf report` symbolization to `PERF_ADDR2LINE_STYLE=llvm`, with `libdw`/`default` override support
- emit bounded head/mid/late `perf script` stack slices so useful callgraph evidence survives even when full stack dumping is slow
- keep timeout handling in one wrapper helper while preserving different behavior for full reports versus bounded stack slices
- document how to read the standard perf artifacts directly without adding a bespoke summarizer

## Why

The existing saved debundle profile did emit useful symbolized evidence, but only when `perf report --children` used a faster symbolizer path. Default symbolization timed out, while `--addr2line-style=llvm` produced symbolized inclusive stacks quickly. Since the standard perf outputs are now reliable enough, this PR avoids adding a fragile Python summarizer and keeps the guidance concentrated in the README.

## Validation

- `bash -n devinfra/js/debundle/perf_wrapper.sh`
- `git diff --check`
- `perf report --children --addr2line-style=llvm` against the saved profile emitted symbolized callgraph output within the timeout
- scoped `pre-commit run --files devinfra/js/debundle/AGENTS.md devinfra/js/debundle/README.md devinfra/js/debundle/perf_wrapper.sh`