### PR TITLE
[codex] Leave Forgejo mirrors unprotected

### DIFF
--- a/tf/gitops/forgejo-codex/main.tf
+++ b/tf/gitops/forgejo-codex/main.tf
@@ -2,9 +2,8 @@
 #
 # Provisions an `agent-box-codex` service user, attaches its SSH push key
 # (agent-box-codex-forgejo), adopts the existing `agentydragon/{ducktape,
-# gaffer-private}` repos under Terraform, grants agent-box-codex write
-# collaboration, and protects the default branches so it must open PRs while agentydragon keeps
-# direct push (push whitelist). Provider wiring mirrors tf/gitops/forgejo-claude.
+# gaffer-private}` repos under Terraform, and grants agent-box-codex write
+# collaboration. Provider wiring mirrors tf/gitops/forgejo-claude.
 
 data "kubernetes_secret" "forgejo_admin" {
   metadata {
@@ -77,8 +76,7 @@ import {
 }
 
 # --- agent-box-codex write collaboration ---
-# Write (not read) so agent-box-codex can push topic branches for PRs; branch
-# protection below blocks direct pushes to the default branch.
+# Write (not read) so agent-box-codex can push topic branches for PRs.
 resource "forgejo_collaborator" "agent_box_codex_ducktape" {
   repository_id = forgejo_repository.ducktape.id
   user          = forgejo_user.agent_box_codex.login
@@ -91,28 +89,11 @@ resource "forgejo_collaborator" "agent_box_codex_gaffer" {
   permission    = "write"
 }
 
-# --- Branch protection: PR-but-not-push for everyone except agentydragon ---
-# enable_push + push whitelist keeps agentydragon's direct pushes working while
-# forcing agent-box-codex (and any other collaborator) through PRs. Forgejo
-# always rejects force-push on a protected branch, so no separate toggle is
-# needed.
-resource "forgejo_branch_protection" "ducktape_devel" {
-  repository_id            = forgejo_repository.ducktape.id
-  branch_name              = "devel"
-  enable_push              = true
-  enable_push_whitelist    = true
-  push_whitelist_usernames = [data.forgejo_user.agentydragon.login]
-}
-
-# gaffer-private is currently empty (no `main` branch yet); the rule attaches by
-# branch name and takes effect once the first push creates main.
-resource "forgejo_branch_protection" "gaffer_main" {
-  repository_id            = forgejo_repository.gaffer_private.id
-  branch_name              = "main"
-  enable_push              = true
-  enable_push_whitelist    = true
-  push_whitelist_usernames = [data.forgejo_user.agentydragon.login]
-}
+# --- Default branches intentionally unprotected ---
+# Forgejo's protected-branch API can whitelist normal pushes, but it cannot
+# whitelist force-push. Protected branches reject `git push --force` even when
+# `agentydragon` is in `push_whitelist_usernames`, so the Forgejo mirrors leave
+# `ducktape/devel` and `gaffer-private/main` unprotected.
 
 moved {
   from = random_password.codex


### PR DESCRIPTION
## Summary

- remove the Forgejo `branch_protection` resources for `agentydragon/ducktape:devel` and `agentydragon/gaffer-private:main`
- document why the mirrors are intentionally unprotected: Forgejo can whitelist normal pushes, but protected branches still reject force-push and the API has no force-push whitelist field

## Why

`agentydragon` needs to be able to force-push these Forgejo mirror branches. The existing Terraform push whitelist only allowed ordinary pushes; Forgejo rejected `git push --force` with `branch main is protected from force push`.

The durable Terraform behavior is therefore to stop managing those protected-branch rules. This is broader than a per-user force-push exception because Forgejo 15.0.2 / Gitea 1.22 does not expose a narrower policy knob.

## Validation

- `nix develop -c tofu fmt -check tf/gitops/forgejo-codex`
- `TF_DATA_DIR=/tmp/... nix develop -c tofu -chdir=tf/gitops/forgejo-codex init -backend=false -input=false`
- `TF_DATA_DIR=/tmp/... nix develop -c tofu -chdir=tf/gitops/forgejo-codex validate`

Tried `bbr build //tf/gitops/forgejo-codex:forgejo-codex`, but BuildBuddy rejected the remote run before analysis because the local mirrored git state was ~766 MB, above its 75 MB message limit.