### PR TITLE
Optimize selector CSP model lowering

### DIFF
--- a/devinfra/js/debundle/AGENTS.md
+++ b/devinfra/js/debundle/AGENTS.md
@@ -107,10 +107,9 @@ is slower and the repro can't be shared publicly.
 
 Use external profiling rather than fine-grained timing boilerplate in
 production code. The default downstream workflow is documented in
-<README.md>: use the profile sibling targets from
-`debundle_pipeline_with_profiles` so the profiling run shares the real
-Bazel action's spec paths, package roots, working directory, declared
-inputs, and debundler binary.
+<README.md>: use Bazel to build the optimized debundler and materialize
+inputs, then run host profilers outside Bazel unless the profiler is provided by
+a hermetic toolchain.
 
 Profile-mode samples answer "where is the runtime going relative to
 total time?" They are the right tool for discovering hot stack
@@ -123,10 +122,10 @@ than sprinkling more counters through the code.
 
 Do not commit ad hoc timing macros, detailed per-phase timers, or
 one-off elapsed-time counters solely for profiling. Use `perf`,
-Callgrind (`valgrind --tool=callgrind`), heaptrack, Massif, or the
-Bazel profile targets instead. If temporary instrumentation is
-unavoidable during an investigation, keep it local and remove it before
-review.
+Callgrind (`valgrind --tool=callgrind`), heaptrack, or Massif instead. Do not
+wrap host profilers in Bazel actions unless the profiler and its runtime
+dependencies are hermetic. If temporary instrumentation is unavoidable during an
+investigation, keep it local and remove it before review.
 
 Use production builds for absolute elapsed-time numbers. Symbol-heavy
 profiling flags can trade exact wall-clock comparability for better

--- a/devinfra/js/debundle/README.md
+++ b/devinfra/js/debundle/README.md
@@ -118,118 +118,27 @@ This emits `bazel-bin/path/to/debundle.selector_cpsat_request.pb` and
 `bazel-bin/path/to/debundle.selector_cpsat_summary.json` after the same selector
 lowering step the full pipeline uses.
 
-## Profiling Actions
+## Profiling
 
-For recurring performance work, prefer `debundle_pipeline_with_profiles`.
-It creates the normal pipeline target plus local profiling sibling targets that
-reuse the exact same action command, inputs, package roots, working directory,
-and debundler binary.
+Keep profiler execution outside Bazel unless the profiler itself is provided by
+a hermetic toolchain. Host profilers such as `perf`, Callgrind, Massif, and
+heaptrack depend on kernel settings and host binaries, so they should not run as
+cached or sandboxed Bazel actions.
 
-```python
-load(
-    "@ducktape//devinfra/js/debundle:pipeline.bzl",
-    "debundle_pipeline_with_profiles",
-)
-
-debundle_pipeline_with_profiles(
-    name = "debundle",
-    # Same attrs as debundle_pipeline.
-)
-```
-
-Generated targets:
-
-- `:debundle`
-- `:debundle_profile_time`
-- `:debundle_profile_perf`
-- `:debundle_profile_massif_heap`
-- `:debundle_profile_heaptrack`
-
-Profile actions are tagged `manual` and use local/no-remote/no-cache/no-sandbox
-execution requirements. Build them with full output downloads when remote
-execution is configured:
+Use Bazel to build the optimized debundler and materialize any inputs needed for
+the target corpus, then run the debundler directly under the real profiler. The
+standalone `perf_wrapper.sh` helper can still post-process `perf` output for
+ad-hoc local runs:
 
 ```sh
-nix develop --command bazelisk build //path/to:debundle_profile_perf \
-  --config=nolint \
-  --remote_download_outputs=all
+PERF_RECORD_FREQ=49 \
+  devinfra/js/debundle/perf_wrapper.sh --output-dir /tmp/debundle-profile -- \
+  <debundler> run <debundle args...>
 ```
 
-Each profile target writes a `<target>.profile` tree artifact. Common files:
-
-- `command.sh`: replayable command with the Bazel action cwd and argv.
-- `stdout.txt`: debundler stdout from the profiled run.
-- `debundle.out/`: the debundle output tree produced by the profiled run.
-
-Mode-specific files:
-
-- `time`: `stderr_time.txt` from `/usr/bin/time -v`.
-- `perf`: `perf.data`, `perf_report_flat_symbols.txt`,
-  `perf_report_children.txt`, `perf_report_no_children.txt`,
-  `perf_script_stacks_head.txt`, `perf_script_stacks_mid.txt`,
-  `perf_script_stacks_late.txt`, `perf_script_stacks.txt`,
-  `perf_header.txt`, `perf_evlist.txt`, `perf_wrapper_env.txt`,
-  `perf_record_stderr.txt`, and any `*.failed.txt` or `*.partial`
-  post-processing artifacts.
-- `massif_heap`: `massif_heap.out`, `massif_heap_stderr.txt`, and
-  `ms_print_heap.txt` when `ms_print` is available.
-- `heaptrack`: `heaptrack*`, `heaptrack_stderr.txt`, and
-  `heaptrack_print.txt` when `heaptrack_print` is available.
-
-Use the perf artifacts as follows:
-
-- `perf_record_stderr.txt`: debundler progress markers and `/usr/bin/time -v`
-  style resource output when the surrounding profile action records it. Use this
-  to identify the last started phase and whether the run reached CP-SAT output.
-- `perf_report_flat_symbols.txt`: fast no-callgraph view for top self-cost
-  symbols.
-- `perf_report_children.txt`: symbolized inclusive callgraph report. The
-  wrapper defaults to `PERF_ADDR2LINE_STYLE=llvm` because default perf
-  symbolization can be much slower on Rust DWARF. Use
-  `PERF_ADDR2LINE_STYLE=libdw` if llvm-style symbolization is unavailable or
-  needs comparison; use `default` only to debug perf itself.
-- `perf_report_no_children.txt`: flat report with the same symbolizer settings.
-- `perf_script_stacks_head.txt`, `perf_script_stacks_mid.txt`, and
-  `perf_script_stacks_late.txt`: bounded symbolized stack slices from the
-  beginning, middle, and end of the profile window. These are useful for
-  stage attribution even when full `perf script` output is too slow. If a
-  sibling `.failed.txt` exists but the stack file is non-empty, treat the stack
-  file as a partial but valid slice and read the failure file as timeout
-  metadata.
-- `perf_script_stacks.txt`: full `perf script` output when it completes within
-  the post-processing timeout.
-- `*.failed.txt` and `*.partial`: bounded post-processing failure metadata and
-  partial output. A failed full report with useful head/mid/late slices is still
-  a valid profiling run.
-
-Useful knobs:
-
-```sh
-PERF_RECORD_FREQ=49              # lower sample frequency for quick iteration
-PERF_ADDR2LINE_STYLE=libdw       # compare symbolizers; default is llvm
-PERF_POSTPROCESS_TIMEOUT=300s    # allow full report generation more time
-PERF_CALLGRAPH_TIMEOUT=30s       # allow each head/mid/late stack slice longer
-PERF_CALLGRAPH_MAX_STACK=64      # preserve deeper callchains in stack slices
-PERF_CALLGRAPH_SLICE_SECS=10     # widen each head/mid/late stack slice
-PERF_CALL_GRAPH=fp               # cheaper callgraphs if the binary has frame pointers
-```
-
-Lower `PERF_RECORD_FREQ` when iterating, but do not treat sampling frequency as
-the main fix for slow report generation. For debundler Rust profiles, the
-dominant post-processing issue is usually symbolization; tune the symbolizer
-and stack-capture knobs above before assuming the profile has too many samples.
-
-Save important runs before cleaning Bazel outputs:
-
-```sh
-mkdir -p debug/perf/YYYY-MM-DD-<short-name>
-cp -a bazel-bin/path/to/debundle_profile_perf.profile/. \
-  debug/perf/YYYY-MM-DD-<short-name>/
-```
-
-If `perf` is blocked by host kernel settings, use `time`, `massif_heap`, or
-`heaptrack` first and rerun `perf` on a host where userspace sampling is
-available.
+Save important runs under the consuming repo's `debug/perf/` directory with the
+captured command, stdout/stderr, profiler artifacts, and selector
+`debug/selector_cpsat_summary.json` when available.
 
 ## Comments
 

--- a/devinfra/js/debundle/perf/fact_resolver.md
+++ b/devinfra/js/debundle/perf/fact_resolver.md
@@ -20,15 +20,14 @@ downstream chunk is ~6.9 MiB / 204k lines (<source_match_selector_profile.md> �
 
 ## Workload (2026-06-21)
 
-**Why not the documented default.** AGENTS.md → "Performance Profiling" points at
-the `debundle_pipeline_with_profiles` sibling targets over the
-`props/frontend/debundle/` corpus. At HEAD `05572738` (the #2398 commit) neither
-exists yet: `pipeline.bzl` defines only `debundle_pipeline` (no
-`_with_profiles`), and there is no `props/frontend/debundle/` corpus. The gaffer
+**Why not the documented default.** Current profiling guidance keeps host
+profilers outside Bazel unless they are supplied by a hermetic toolchain. This
+historical run predates the current public corpus setup: at HEAD `05572738` (the
+#2398 commit), there was no `props/frontend/debundle/` corpus. The gaffer
 `tana/re/web/78d928dca7` spec was off-limits (a concurrent lane worker was
 editing it). So this run uses the reproducible public stand-in the proposer note
-already established — the `gen_synth_corpus.py` corpus (gaffer-scale graph shape)
-— with one rewrite to make it exercise the fact resolver.
+already established — the `gen_synth_corpus.py` corpus (gaffer-scale graph
+shape) — with one rewrite to make it exercise the fact resolver.
 
 **Corpus.** `gen_synth_corpus.py --statements 10000 --seed 1 --claim-blocks 62`
 → a single 10051-statement / 436 KB chunk, 62 claimed modules, **2461 member

--- a/devinfra/js/debundle/selector_backend_solver.rs
+++ b/devinfra/js/debundle/selector_backend_solver.rs
@@ -955,10 +955,10 @@ mod tests {
             summary["compiled_problem"]["variable_count_by_domain"]["string"],
             json!(1)
         );
-        assert_eq!(summary["compiled_problem"]["allowed_table_count"], json!(2));
+        assert_eq!(summary["compiled_problem"]["allowed_table_count"], json!(1));
         assert_eq!(
             summary["compiled_problem"]["constraint_count_by_kind"]["allowed_table"],
-            json!(2)
+            json!(1)
         );
         assert_eq!(
             summary["compiled_problem"]["constraint_count_by_kind"]["linear"],

--- a/devinfra/js/debundle/selector_constraint_backend.rs
+++ b/devinfra/js/debundle/selector_constraint_backend.rs
@@ -480,6 +480,57 @@ impl CompiledSelectorProblemBuilder {
         self.add_encoded_allowed_tuples_with_domains(variables, domains, tuples)
     }
 
+    pub fn restrict_variable_to_encoded_values(
+        &mut self,
+        variable: ConstraintVariableId,
+        values: impl IntoIterator<Item = BackendValueId>,
+    ) -> Result<(), CompiledSelectorProblemError> {
+        let domain = self.require_variable(variable)?.domain;
+        let mut values = values.into_iter().collect::<Vec<_>>();
+        values.sort_unstable();
+        values.dedup();
+        for value in &values {
+            self.validate_encoded_variable_domain_value(variable, domain, *value)?;
+        }
+
+        let full_domain = self.full_domains.get(domain).to_vec();
+        let empty_domain = {
+            let variable = self.require_variable_mut(variable)?;
+            match &mut variable.values {
+                CompiledVariableDomain::Full(_) => {
+                    values.retain(|value| full_domain.binary_search(value).is_ok());
+                    let empty_domain = values.is_empty();
+                    variable.values = CompiledVariableDomain::Sparse(values);
+                    empty_domain
+                }
+                CompiledVariableDomain::Sparse(existing) => {
+                    let mut restricted = Vec::new();
+                    let mut left = 0;
+                    let mut right = 0;
+                    while left < existing.len() && right < values.len() {
+                        match existing[left].cmp(&values[right]) {
+                            std::cmp::Ordering::Less => left += 1,
+                            std::cmp::Ordering::Greater => right += 1,
+                            std::cmp::Ordering::Equal => {
+                                restricted.push(existing[left]);
+                                left += 1;
+                                right += 1;
+                            }
+                        }
+                    }
+                    let empty_domain = restricted.is_empty();
+                    *existing = restricted;
+                    empty_domain
+                }
+            }
+        };
+        if empty_domain {
+            self.known_unsat
+                .get_or_insert_with(|| "variable restriction has empty domain".to_string());
+        }
+        Ok(())
+    }
+
     pub fn intern_owner(
         &mut self,
         value: OwnerId,
@@ -559,19 +610,26 @@ impl CompiledSelectorProblemBuilder {
                 });
             }
             let mut compiled = Vec::with_capacity(tuple.len());
+            let mut row_matches_variable_domains = true;
             for (column, (value_id, expected)) in tuple.into_iter().zip(domains.iter()).enumerate()
             {
-                self.validate_encoded_value(
+                self.validate_encoded_value_domain(
                     id,
                     tuple_index,
                     variables[column],
                     *expected,
                     value_id,
                 )?;
+                if !self.encoded_value_matches_variable_domain(variables[column], value_id)? {
+                    row_matches_variable_domains = false;
+                    break;
+                }
                 self.ensure_full_domain_contains(*expected, value_id);
                 compiled.push(value_id);
             }
-            compiled_tuples.push(compiled);
+            if row_matches_variable_domains {
+                compiled_tuples.push(compiled);
+            }
         }
         compiled_tuples.sort();
         compiled_tuples.dedup();
@@ -715,7 +773,7 @@ impl CompiledSelectorProblemBuilder {
             .collect()
     }
 
-    fn validate_encoded_value(
+    fn validate_encoded_value_domain(
         &self,
         id: AllowedTupleConstraintId,
         tuple_index: usize,
@@ -741,30 +799,64 @@ impl CompiledSelectorProblemBuilder {
                 value,
             });
         };
-        let variable_domain = &self.require_variable(variable)?.values;
-        match variable_domain {
-            CompiledVariableDomain::Full(_) => {
-                if index >= self.value_dictionary.domain_len(domain) {
-                    return Err(CompiledSelectorProblemError::EncodedTupleValueOutOfDomain {
-                        id,
-                        tuple_index,
-                        variable,
-                        domain,
-                        value,
-                    });
-                }
-            }
-            CompiledVariableDomain::Sparse(values) => {
-                if values.binary_search(&value).is_err() {
-                    return Err(CompiledSelectorProblemError::EncodedTupleValueOutOfDomain {
-                        id,
-                        tuple_index,
-                        variable,
-                        domain,
-                        value,
-                    });
-                }
-            }
+        if self.require_variable(variable)?.source.is_none() {
+            return Ok(());
+        }
+        if index >= self.value_dictionary.domain_len(domain) {
+            return Err(CompiledSelectorProblemError::EncodedTupleValueOutOfDomain {
+                id,
+                tuple_index,
+                variable,
+                domain,
+                value,
+            });
+        }
+        Ok(())
+    }
+
+    fn encoded_value_matches_variable_domain(
+        &self,
+        variable: ConstraintVariableId,
+        value: BackendValueId,
+    ) -> Result<bool, CompiledSelectorProblemError> {
+        match &self.require_variable(variable)?.values {
+            CompiledVariableDomain::Full(_) => Ok(true),
+            CompiledVariableDomain::Sparse(values) => Ok(values.binary_search(&value).is_ok()),
+        }
+    }
+
+    fn validate_encoded_variable_domain_value(
+        &self,
+        variable: ConstraintVariableId,
+        domain: VariableDomain,
+        value: BackendValueId,
+    ) -> Result<(), CompiledSelectorProblemError> {
+        if value.0 < 0 {
+            return Err(
+                CompiledSelectorProblemError::EncodedVariableDomainValueOutOfDomain {
+                    variable,
+                    domain,
+                    value,
+                },
+            );
+        }
+        let Ok(index) = usize::try_from(value.0) else {
+            return Err(
+                CompiledSelectorProblemError::EncodedVariableDomainValueOutOfDomain {
+                    variable,
+                    domain,
+                    value,
+                },
+            );
+        };
+        if index >= self.value_dictionary.domain_len(domain) {
+            return Err(
+                CompiledSelectorProblemError::EncodedVariableDomainValueOutOfDomain {
+                    variable,
+                    domain,
+                    value,
+                },
+            );
         }
         Ok(())
     }
@@ -935,6 +1027,15 @@ impl CompiledSelectorProblemBuilder {
             .get(variable.0)
             .ok_or(CompiledSelectorProblemError::UnknownVariable { variable })
     }
+
+    fn require_variable_mut(
+        &mut self,
+        variable: ConstraintVariableId,
+    ) -> Result<&mut CompiledVariableBuilder, CompiledSelectorProblemError> {
+        self.variables
+            .get_mut(variable.0)
+            .ok_or(CompiledSelectorProblemError::UnknownVariable { variable })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -980,6 +1081,11 @@ pub enum CompiledSelectorProblemError {
     EncodedTupleValueOutOfDomain {
         id: AllowedTupleConstraintId,
         tuple_index: usize,
+        variable: ConstraintVariableId,
+        domain: VariableDomain,
+        value: BackendValueId,
+    },
+    EncodedVariableDomainValueOutOfDomain {
         variable: ConstraintVariableId,
         domain: VariableDomain,
         value: BackendValueId,
@@ -1085,6 +1191,14 @@ impl fmt::Display for CompiledSelectorProblemError {
             } => write!(
                 f,
                 "allowed tuple constraint {id:?} row {tuple_index} variable {variable:?} has encoded value {value:?} outside {domain:?} domain"
+            ),
+            Self::EncodedVariableDomainValueOutOfDomain {
+                variable,
+                domain,
+                value,
+            } => write!(
+                f,
+                "variable {variable:?} restriction contains encoded value {value:?} outside {domain:?} domain"
             ),
             Self::BinaryDomainMismatch {
                 left,

--- a/devinfra/js/debundle/selector_constraint_model_builder.rs
+++ b/devinfra/js/debundle/selector_constraint_model_builder.rs
@@ -198,12 +198,12 @@ fn lower_atom_constraint(
         SelectorAtom::OwnerKind {
             owner,
             statement_kind,
-        } => add_owner_string_allowed_tuples(
+        } => add_owner_string_indexed_allowed_tuples(
             model,
             variables,
             owner,
             statement_kind,
-            &domains.owner_kinds,
+            &domains.owner_kinds_index,
         ),
         SelectorAtom::OwnerStatementOrdinal { owner, ordinal } => add_owner_ordinal_allowed_tuples(
             model,
@@ -212,20 +212,24 @@ fn lower_atom_constraint(
             ordinal,
             &domains.owner_statement_ordinals,
         ),
-        SelectorAtom::OwnerDeclaresBinding { owner, binding } => add_owner_string_allowed_tuples(
-            model,
-            variables,
-            owner,
-            binding,
-            &domains.declared_bindings,
-        ),
-        SelectorAtom::OwnerExportName { owner, export_name } => add_owner_string_allowed_tuples(
-            model,
-            variables,
-            owner,
-            export_name,
-            &domains.export_names,
-        ),
+        SelectorAtom::OwnerDeclaresBinding { owner, binding } => {
+            add_owner_string_indexed_allowed_tuples(
+                model,
+                variables,
+                owner,
+                binding,
+                &domains.declared_bindings_index,
+            )
+        }
+        SelectorAtom::OwnerExportName { owner, export_name } => {
+            add_owner_string_indexed_allowed_tuples(
+                model,
+                variables,
+                owner,
+                export_name,
+                &domains.export_names_index,
+            )
+        }
         SelectorAtom::OwnerReferencesBinding {
             owner,
             binding,
@@ -267,27 +271,20 @@ fn lower_atom_constraint(
             root,
             &domains.owner_top_level_roots,
         ),
-        SelectorAtom::AstKind { node, node_kind } => add_node_string_allowed_tuples(
+        SelectorAtom::AstKind { node, node_kind } => add_node_string_indexed_allowed_tuples(
             model,
             variables,
             node,
             &StringTerm::Const {
                 value: node_kind.as_tag().to_string(),
             },
-            &domains.ast_kinds,
+            &domains.ast_kinds_index,
         ),
         SelectorAtom::AstChild {
             parent,
             index,
             child,
-        } => add_ast_child_allowed_tuples(
-            model,
-            variables,
-            parent,
-            *index,
-            child,
-            &domains.ast_children_by_parent,
-        ),
+        } => add_ast_child_indexed_allowed_tuples(model, variables, parent, *index, child, domains),
         SelectorAtom::AstSuperClass {
             class_node,
             super_class,
@@ -298,30 +295,23 @@ fn lower_atom_constraint(
             super_class,
             &domains.ast_super_classes,
         ),
-        SelectorAtom::AstChildCount { node, count } => {
-            let facts = domains
-                .ast_child_counts
-                .iter()
-                .filter_map(|(fact_node, fact_count)| {
-                    (*fact_count == *count).then_some((*fact_node, fact_count.to_string()))
-                })
-                .collect::<BTreeSet<_>>();
-            add_node_string_allowed_tuples(
-                model,
-                variables,
-                node,
-                &StringTerm::Const {
-                    value: count.to_string(),
-                },
-                &facts,
-            )
-        }
-        SelectorAtom::AstStringLiteral { node, value } => add_node_string_allowed_tuples(
+        SelectorAtom::AstChildCount { node, count } => add_node_indexed_allowed_tuples(
+            model,
+            variables,
+            node,
+            domains
+                .ast_child_counts_by_count
+                .get(count)
+                .map(Vec::as_slice)
+                .unwrap_or(&[]),
+            format!("ast_child_count fact {node:?} {count:?}"),
+        ),
+        SelectorAtom::AstStringLiteral { node, value } => add_node_string_indexed_allowed_tuples(
             model,
             variables,
             node,
             value,
-            &domains.ast_string_literals,
+            &domains.ast_string_literals_index,
         ),
         SelectorAtom::AstStringLiteralMatchingRegex { node, pattern } => {
             add_ast_string_literal_matching_regex_allowed_tuples(
@@ -332,44 +322,37 @@ fn lower_atom_constraint(
                 &domains.ast_string_literals,
             )
         }
-        SelectorAtom::AstNumberLiteral { node, value } => add_node_string_allowed_tuples(
+        SelectorAtom::AstNumberLiteral { node, value } => add_node_string_indexed_allowed_tuples(
             model,
             variables,
             node,
             value,
-            &domains.ast_number_literals,
+            &domains.ast_number_literals_index,
         ),
-        SelectorAtom::AstBoolLiteral { node, value } => {
-            let facts = domains
-                .ast_bool_literals
-                .iter()
-                .filter_map(|(fact_node, fact_value)| {
-                    (*fact_value == *value).then_some((*fact_node, fact_value.to_string()))
-                })
-                .collect::<BTreeSet<_>>();
-            add_node_string_allowed_tuples(
-                model,
-                variables,
-                node,
-                &StringTerm::Const {
-                    value: value.to_string(),
-                },
-                &facts,
-            )
-        }
-        SelectorAtom::AstIdentifierName { node, value } => add_node_string_allowed_tuples(
+        SelectorAtom::AstBoolLiteral { node, value } => add_node_indexed_allowed_tuples(
             model,
             variables,
             node,
-            value,
-            &domains.ast_identifier_names,
+            domains
+                .ast_bool_literals_by_value
+                .get(value)
+                .map(Vec::as_slice)
+                .unwrap_or(&[]),
+            format!("ast_bool_literal fact {node:?} {value:?}"),
         ),
-        SelectorAtom::AstPropertyName { node, value } => add_node_string_allowed_tuples(
+        SelectorAtom::AstIdentifierName { node, value } => add_node_string_indexed_allowed_tuples(
             model,
             variables,
             node,
             value,
-            &domains.ast_property_names,
+            &domains.ast_identifier_names_index,
+        ),
+        SelectorAtom::AstPropertyName { node, value } => add_node_string_indexed_allowed_tuples(
+            model,
+            variables,
+            node,
+            value,
+            &domains.ast_property_names_index,
         ),
         SelectorAtom::AstBareProperty {
             node,
@@ -385,9 +368,13 @@ fn lower_atom_constraint(
             *is_binding,
             &domains.ast_bare_properties,
         ),
-        SelectorAtom::AstOperator { node, value } => {
-            add_node_string_allowed_tuples(model, variables, node, value, &domains.ast_operators)
-        }
+        SelectorAtom::AstOperator { node, value } => add_node_string_indexed_allowed_tuples(
+            model,
+            variables,
+            node,
+            value,
+            &domains.ast_operators_index,
+        ),
         SelectorAtom::AstRegexLiteral {
             node,
             pattern,
@@ -614,6 +601,257 @@ fn lower_atom_constraint(
             },
             domains,
         ),
+    }
+}
+
+fn restrict_owner_variable_to_candidates(
+    model: &mut CompiledSelectorProblemBuilder,
+    variable: ConstraintVariableId,
+    candidates: impl IntoIterator<Item = OwnerId>,
+) -> Result<(), CompiledSelectorProblemBuildError> {
+    let values = candidates
+        .into_iter()
+        .map(|owner| model.intern_owner(owner))
+        .collect::<Result<Vec<_>, _>>()?;
+    model
+        .restrict_variable_to_encoded_values(variable, values)
+        .map_err(Into::into)
+}
+
+fn restrict_node_variable_to_candidates(
+    model: &mut CompiledSelectorProblemBuilder,
+    variable: ConstraintVariableId,
+    candidates: impl IntoIterator<Item = NodeId>,
+) -> Result<(), CompiledSelectorProblemBuildError> {
+    let values = candidates
+        .into_iter()
+        .map(|node| model.intern_ast_node(node))
+        .collect::<Result<Vec<_>, _>>()?;
+    model
+        .restrict_variable_to_encoded_values(variable, values)
+        .map_err(Into::into)
+}
+
+fn restrict_string_variable_to_candidates<'a>(
+    model: &mut CompiledSelectorProblemBuilder,
+    variable: ConstraintVariableId,
+    candidates: impl IntoIterator<Item = &'a str>,
+) -> Result<(), CompiledSelectorProblemBuildError> {
+    let values = candidates
+        .into_iter()
+        .map(|value| model.intern_string(value))
+        .collect::<Result<Vec<_>, _>>()?;
+    model
+        .restrict_variable_to_encoded_values(variable, values)
+        .map_err(Into::into)
+}
+
+fn add_owner_string_indexed_allowed_tuples(
+    model: &mut CompiledSelectorProblemBuilder,
+    variables: &[ConstraintVariableId],
+    owner: &OwnerTerm,
+    string: &StringTerm,
+    index: &OwnerStringIndex,
+) -> Result<(), CompiledSelectorProblemBuildError> {
+    match (owner, string) {
+        (OwnerTerm::Const { owner }, StringTerm::Const { value }) => {
+            index.contains(*owner, value).then_some(()).ok_or_else(|| {
+                CompiledSelectorProblemBuildError::ConstantOnlyAtomUnsatisfied {
+                    atom: format!("owner/string fact {owner:?} {value:?}"),
+                }
+            })
+        }
+        (OwnerTerm::Var { id }, StringTerm::Const { value }) => {
+            let variable = model_variable(variables, *id)?;
+            restrict_owner_variable_to_candidates(
+                model,
+                variable,
+                index
+                    .owners_by_value
+                    .get(value)
+                    .into_iter()
+                    .flatten()
+                    .copied(),
+            )
+        }
+        (OwnerTerm::Const { owner }, StringTerm::Var { id }) => {
+            let variable = model_variable(variables, *id)?;
+            restrict_string_variable_to_candidates(
+                model,
+                variable,
+                index
+                    .values_by_owner
+                    .get(owner)
+                    .into_iter()
+                    .flatten()
+                    .map(String::as_str),
+            )
+        }
+        (OwnerTerm::Var { id: owner_id }, StringTerm::Var { id: string_id }) => {
+            let constraint_variables = vec![
+                model_variable(variables, *owner_id)?,
+                model_variable(variables, *string_id)?,
+            ];
+            let tuples = index
+                .rows
+                .iter()
+                .map(|(fact_owner, fact_string)| {
+                    Ok(vec![
+                        model.intern_owner(*fact_owner)?,
+                        model.intern_string(fact_string)?,
+                    ])
+                })
+                .collect::<Result<Vec<_>, CompiledSelectorProblemError>>()?;
+            add_encoded_allowed_tuple_set(model, constraint_variables, tuples)
+        }
+    }
+}
+
+fn add_node_string_indexed_allowed_tuples(
+    model: &mut CompiledSelectorProblemBuilder,
+    variables: &[ConstraintVariableId],
+    node: &NodeTerm,
+    string: &StringTerm,
+    index: &NodeStringIndex,
+) -> Result<(), CompiledSelectorProblemBuildError> {
+    match (node, string) {
+        (NodeTerm::Const { node }, StringTerm::Const { value }) => {
+            index.contains(*node, value).then_some(()).ok_or_else(|| {
+                CompiledSelectorProblemBuildError::ConstantOnlyAtomUnsatisfied {
+                    atom: format!("node/string fact {node:?} {value:?}"),
+                }
+            })
+        }
+        (NodeTerm::Var { id }, StringTerm::Const { value }) => {
+            let variable = model_variable(variables, *id)?;
+            restrict_node_variable_to_candidates(
+                model,
+                variable,
+                index
+                    .nodes_by_value
+                    .get(value)
+                    .into_iter()
+                    .flatten()
+                    .copied(),
+            )
+        }
+        (NodeTerm::Const { node }, StringTerm::Var { id }) => {
+            let variable = model_variable(variables, *id)?;
+            restrict_string_variable_to_candidates(
+                model,
+                variable,
+                index
+                    .values_by_node
+                    .get(node)
+                    .into_iter()
+                    .flatten()
+                    .map(String::as_str),
+            )
+        }
+        (NodeTerm::Var { id: node_id }, StringTerm::Var { id: string_id }) => {
+            let constraint_variables = vec![
+                model_variable(variables, *node_id)?,
+                model_variable(variables, *string_id)?,
+            ];
+            let tuples = index
+                .rows
+                .iter()
+                .map(|(fact_node, fact_string)| {
+                    Ok(vec![
+                        model.intern_ast_node(*fact_node)?,
+                        model.intern_string(fact_string)?,
+                    ])
+                })
+                .collect::<Result<Vec<_>, CompiledSelectorProblemError>>()?;
+            add_encoded_allowed_tuple_set(model, constraint_variables, tuples)
+        }
+    }
+}
+
+fn add_node_indexed_allowed_tuples(
+    model: &mut CompiledSelectorProblemBuilder,
+    variables: &[ConstraintVariableId],
+    node: &NodeTerm,
+    candidates: &[NodeId],
+    atom: String,
+) -> Result<(), CompiledSelectorProblemBuildError> {
+    match node {
+        NodeTerm::Var { id } => {
+            let variable = model_variable(variables, *id)?;
+            restrict_node_variable_to_candidates(model, variable, candidates.iter().copied())
+        }
+        NodeTerm::Const { node } => candidates
+            .binary_search(node)
+            .is_ok()
+            .then_some(())
+            .ok_or(CompiledSelectorProblemBuildError::ConstantOnlyAtomUnsatisfied { atom }),
+    }
+}
+
+fn add_ast_child_indexed_allowed_tuples(
+    model: &mut CompiledSelectorProblemBuilder,
+    variables: &[ConstraintVariableId],
+    parent: &NodeTerm,
+    child_index: u32,
+    child: &NodeTerm,
+    domains: &FactDomains,
+) -> Result<(), CompiledSelectorProblemBuildError> {
+    match (parent, child) {
+        (NodeTerm::Const { node: parent }, NodeTerm::Const { node: child }) => domains
+            .ast_children_by_parent_index
+            .get(&(*parent, child_index))
+            .is_some_and(|children| children.binary_search(child).is_ok())
+            .then_some(())
+            .ok_or_else(
+                || CompiledSelectorProblemBuildError::ConstantOnlyAtomUnsatisfied {
+                    atom: format!("ast_child fact {parent:?} {child_index} {child:?}"),
+                },
+            ),
+        (NodeTerm::Const { node: parent }, NodeTerm::Var { id }) => {
+            let variable = model_variable(variables, *id)?;
+            restrict_node_variable_to_candidates(
+                model,
+                variable,
+                domains
+                    .ast_children_by_parent_index
+                    .get(&(*parent, child_index))
+                    .into_iter()
+                    .flatten()
+                    .copied(),
+            )
+        }
+        (NodeTerm::Var { id }, NodeTerm::Const { node: child }) => {
+            let variable = model_variable(variables, *id)?;
+            restrict_node_variable_to_candidates(
+                model,
+                variable,
+                domains
+                    .ast_child_parents_by_child_index
+                    .get(&(*child, child_index))
+                    .into_iter()
+                    .flatten()
+                    .copied(),
+            )
+        }
+        (NodeTerm::Var { id: parent_id }, NodeTerm::Var { id: child_id }) => {
+            let constraint_variables = vec![
+                model_variable(variables, *parent_id)?,
+                model_variable(variables, *child_id)?,
+            ];
+            let tuples = domains
+                .ast_children_by_index
+                .get(&child_index)
+                .into_iter()
+                .flatten()
+                .map(|(fact_parent, fact_child)| {
+                    Ok(vec![
+                        model.intern_ast_node(*fact_parent)?,
+                        model.intern_ast_node(*fact_child)?,
+                    ])
+                })
+                .collect::<Result<Vec<_>, CompiledSelectorProblemError>>()?;
+            add_encoded_allowed_tuple_set(model, constraint_variables, tuples)
+        }
     }
 }
 
@@ -889,58 +1127,6 @@ fn add_node_node_allowed_tuples(
     add_encoded_allowed_tuple_set(model, constraint_variables, tuples)
 }
 
-fn add_ast_child_allowed_tuples(
-    model: &mut CompiledSelectorProblemBuilder,
-    variables: &[ConstraintVariableId],
-    parent: &NodeTerm,
-    child_index: u32,
-    child: &NodeTerm,
-    ast_children_by_parent: &BTreeMap<NodeId, Vec<(u32, NodeId)>>,
-) -> Result<(), CompiledSelectorProblemBuildError> {
-    let mut constraint_variables = Vec::new();
-    if let NodeTerm::Var { id } = parent {
-        constraint_variables.push(model_variable(variables, *id)?);
-    }
-    if let NodeTerm::Var { id } = child {
-        constraint_variables.push(model_variable(variables, *id)?);
-    }
-
-    let mut tuples = Vec::new();
-    let mut constant_only_match = false;
-    for (fact_parent, children) in ast_children_by_parent {
-        if !node_term_matches(parent, *fact_parent) {
-            continue;
-        }
-        for (fact_index, fact_child) in children {
-            if *fact_index != child_index || !node_term_matches(child, *fact_child) {
-                continue;
-            }
-            if constraint_variables.is_empty() {
-                constant_only_match = true;
-                continue;
-            }
-            let mut tuple = Vec::with_capacity(constraint_variables.len());
-            if matches!(parent, NodeTerm::Var { .. }) {
-                tuple.push(model.intern_ast_node(*fact_parent)?);
-            }
-            if matches!(child, NodeTerm::Var { .. }) {
-                tuple.push(model.intern_ast_node(*fact_child)?);
-            }
-            tuples.push(tuple);
-        }
-    }
-
-    if constraint_variables.is_empty() {
-        return constant_only_match.then_some(()).ok_or_else(|| {
-            CompiledSelectorProblemBuildError::ConstantOnlyAtomUnsatisfied {
-                atom: format!("ast_child fact {parent:?} {child_index} {child:?}"),
-            }
-        });
-    }
-
-    add_encoded_allowed_tuple_set(model, constraint_variables, tuples)
-}
-
 fn add_node_allowed_tuples(
     model: &mut CompiledSelectorProblemBuilder,
     variables: &[ConstraintVariableId],
@@ -968,54 +1154,6 @@ fn add_node_allowed_tuples(
         .filter(|fact_node| node_term_matches(node, **fact_node))
         .map(|fact_node| model.intern_ast_node(*fact_node).map(|value| vec![value]))
         .collect::<Result<Vec<_>, _>>()?;
-
-    add_encoded_allowed_tuple_set(model, constraint_variables, tuples)
-}
-
-fn add_node_string_allowed_tuples(
-    model: &mut CompiledSelectorProblemBuilder,
-    variables: &[ConstraintVariableId],
-    node: &NodeTerm,
-    string: &StringTerm,
-    facts: &BTreeSet<(NodeId, String)>,
-) -> Result<(), CompiledSelectorProblemBuildError> {
-    let mut constraint_variables = Vec::new();
-    if let NodeTerm::Var { id } = node {
-        constraint_variables.push(model_variable(variables, *id)?);
-    }
-    if let StringTerm::Var { id } = string {
-        constraint_variables.push(model_variable(variables, *id)?);
-    }
-    if constraint_variables.is_empty() {
-        return facts
-            .iter()
-            .any(|(fact_node, fact_string)| {
-                node_term_matches(node, *fact_node) && string_term_matches(string, fact_string)
-            })
-            .then_some(())
-            .ok_or_else(
-                || CompiledSelectorProblemBuildError::ConstantOnlyAtomUnsatisfied {
-                    atom: format!("node/string fact {node:?} {string:?}"),
-                },
-            );
-    }
-
-    let tuples = facts
-        .iter()
-        .filter(|(fact_node, fact_string)| {
-            node_term_matches(node, *fact_node) && string_term_matches(string, fact_string)
-        })
-        .map(|(fact_node, fact_string)| {
-            let mut tuple = Vec::with_capacity(constraint_variables.len());
-            if matches!(node, NodeTerm::Var { .. }) {
-                tuple.push(model.intern_ast_node(*fact_node)?);
-            }
-            if matches!(string, StringTerm::Var { .. }) {
-                tuple.push(model.intern_string(fact_string)?);
-            }
-            Ok(tuple)
-        })
-        .collect::<Result<Vec<_>, CompiledSelectorProblemError>>()?;
 
     add_encoded_allowed_tuple_set(model, constraint_variables, tuples)
 }
@@ -1614,6 +1752,16 @@ fn add_encoded_allowed_tuple_set(
     tuples: Vec<Vec<BackendValueId>>,
 ) -> Result<(), CompiledSelectorProblemBuildError> {
     let (variables, tuples) = normalize_encoded_allowed_tuple_columns(variables, tuples);
+    if let [variable] = variables.as_slice()
+        && tuples.iter().all(|tuple| tuple.len() == 1)
+    {
+        return model
+            .restrict_variable_to_encoded_values(
+                *variable,
+                tuples.into_iter().map(|mut tuple| tuple.remove(0)),
+            )
+            .map_err(Into::into);
+    }
     model
         .add_encoded_allowed_tuples(variables, tuples)
         .map(|_| ())
@@ -1800,6 +1948,96 @@ impl TargetBindingProjections {
 }
 
 #[derive(Debug, Default)]
+struct OwnerStringIndex {
+    owners_by_value: BTreeMap<String, Vec<OwnerId>>,
+    values_by_owner: BTreeMap<OwnerId, Vec<String>>,
+    rows: Vec<(OwnerId, String)>,
+}
+
+impl OwnerStringIndex {
+    fn from_facts(facts: &BTreeSet<(OwnerId, String)>) -> Self {
+        let mut index = Self::default();
+        for (owner, value) in facts {
+            index
+                .owners_by_value
+                .entry(value.clone())
+                .or_default()
+                .push(*owner);
+            index
+                .values_by_owner
+                .entry(*owner)
+                .or_default()
+                .push(value.clone());
+            index.rows.push((*owner, value.clone()));
+        }
+        for owners in index.owners_by_value.values_mut() {
+            owners.sort_unstable();
+            owners.dedup();
+        }
+        for values in index.values_by_owner.values_mut() {
+            values.sort();
+            values.dedup();
+        }
+        index.rows.sort();
+        index.rows.dedup();
+        index
+    }
+
+    fn contains(&self, owner: OwnerId, value: &str) -> bool {
+        self.values_by_owner.get(&owner).is_some_and(|values| {
+            values
+                .binary_search_by(|candidate| candidate.as_str().cmp(value))
+                .is_ok()
+        })
+    }
+}
+
+#[derive(Debug, Default)]
+struct NodeStringIndex {
+    nodes_by_value: BTreeMap<String, Vec<NodeId>>,
+    values_by_node: BTreeMap<NodeId, Vec<String>>,
+    rows: Vec<(NodeId, String)>,
+}
+
+impl NodeStringIndex {
+    fn from_facts(facts: &BTreeSet<(NodeId, String)>) -> Self {
+        let mut index = Self::default();
+        for (node, value) in facts {
+            index
+                .nodes_by_value
+                .entry(value.clone())
+                .or_default()
+                .push(*node);
+            index
+                .values_by_node
+                .entry(*node)
+                .or_default()
+                .push(value.clone());
+            index.rows.push((*node, value.clone()));
+        }
+        for nodes in index.nodes_by_value.values_mut() {
+            nodes.sort_unstable();
+            nodes.dedup();
+        }
+        for values in index.values_by_node.values_mut() {
+            values.sort();
+            values.dedup();
+        }
+        index.rows.sort();
+        index.rows.dedup();
+        index
+    }
+
+    fn contains(&self, node: NodeId, value: &str) -> bool {
+        self.values_by_node.get(&node).is_some_and(|values| {
+            values
+                .binary_search_by(|candidate| candidate.as_str().cmp(value))
+                .is_ok()
+        })
+    }
+}
+
+#[derive(Debug, Default)]
 struct FactDomains {
     owners: BTreeSet<OwnerId>,
     nodes: BTreeSet<NodeId>,
@@ -1843,6 +2081,20 @@ struct FactDomains {
     makes_decorate_call_for_owner: BTreeSet<(OwnerId, OwnerId, Option<String>)>,
     intrinsic_aliases: BTreeSet<(String, String)>,
     intrinsic_alias_referenced_by: BTreeSet<(OwnerId, String, OwnerId)>,
+    owner_kinds_index: OwnerStringIndex,
+    declared_bindings_index: OwnerStringIndex,
+    export_names_index: OwnerStringIndex,
+    ast_kinds_index: NodeStringIndex,
+    ast_string_literals_index: NodeStringIndex,
+    ast_number_literals_index: NodeStringIndex,
+    ast_identifier_names_index: NodeStringIndex,
+    ast_property_names_index: NodeStringIndex,
+    ast_operators_index: NodeStringIndex,
+    ast_child_counts_by_count: BTreeMap<u32, Vec<NodeId>>,
+    ast_bool_literals_by_value: BTreeMap<bool, Vec<NodeId>>,
+    ast_children_by_index: BTreeMap<u32, Vec<(NodeId, NodeId)>>,
+    ast_children_by_parent_index: BTreeMap<(NodeId, u32), Vec<NodeId>>,
+    ast_child_parents_by_child_index: BTreeMap<(NodeId, u32), Vec<NodeId>>,
 }
 
 impl FactDomains {
@@ -1852,6 +2104,7 @@ impl FactDomains {
         domains.finalize_indexes();
         domains.add_derived_facts();
         domains.add_program_constants(program);
+        domains.build_lookup_indexes();
         domains
     }
 
@@ -2220,6 +2473,75 @@ impl FactDomains {
         for children in self.ast_children_by_parent.values_mut() {
             children.sort_unstable();
             children.dedup();
+        }
+    }
+
+    fn build_lookup_indexes(&mut self) {
+        self.owner_kinds_index = OwnerStringIndex::from_facts(&self.owner_kinds);
+        self.declared_bindings_index = OwnerStringIndex::from_facts(&self.declared_bindings);
+        self.export_names_index = OwnerStringIndex::from_facts(&self.export_names);
+        self.ast_kinds_index = NodeStringIndex::from_facts(&self.ast_kinds);
+        self.ast_string_literals_index = NodeStringIndex::from_facts(&self.ast_string_literals);
+        self.ast_number_literals_index = NodeStringIndex::from_facts(&self.ast_number_literals);
+        self.ast_identifier_names_index = NodeStringIndex::from_facts(&self.ast_identifier_names);
+        self.ast_property_names_index = NodeStringIndex::from_facts(&self.ast_property_names);
+        self.ast_operators_index = NodeStringIndex::from_facts(&self.ast_operators);
+
+        self.ast_child_counts_by_count.clear();
+        for (node, count) in &self.ast_child_counts {
+            self.ast_child_counts_by_count
+                .entry(*count)
+                .or_default()
+                .push(*node);
+        }
+
+        self.ast_bool_literals_by_value.clear();
+        for (node, value) in &self.ast_bool_literals {
+            self.ast_bool_literals_by_value
+                .entry(*value)
+                .or_default()
+                .push(*node);
+        }
+
+        self.ast_children_by_index.clear();
+        self.ast_children_by_parent_index.clear();
+        self.ast_child_parents_by_child_index.clear();
+        for (parent, children) in &self.ast_children_by_parent {
+            for (index, child) in children {
+                self.ast_children_by_index
+                    .entry(*index)
+                    .or_default()
+                    .push((*parent, *child));
+                self.ast_children_by_parent_index
+                    .entry((*parent, *index))
+                    .or_default()
+                    .push(*child);
+                self.ast_child_parents_by_child_index
+                    .entry((*child, *index))
+                    .or_default()
+                    .push(*parent);
+            }
+        }
+
+        for nodes in self.ast_child_counts_by_count.values_mut() {
+            nodes.sort_unstable();
+            nodes.dedup();
+        }
+        for nodes in self.ast_bool_literals_by_value.values_mut() {
+            nodes.sort_unstable();
+            nodes.dedup();
+        }
+        for pairs in self.ast_children_by_index.values_mut() {
+            pairs.sort_unstable();
+            pairs.dedup();
+        }
+        for children in self.ast_children_by_parent_index.values_mut() {
+            children.sort_unstable();
+            children.dedup();
+        }
+        for parents in self.ast_child_parents_by_child_index.values_mut() {
+            parents.sort_unstable();
+            parents.dedup();
         }
     }
 
@@ -3092,12 +3414,8 @@ mod tests {
         let model = compile_selector_problem(&program, &facts).unwrap();
 
         assert_eq!(
-            allowed_tuples_for(&model, &[ConstraintVariableId(0)]),
-            &AllowedTupleConstraint {
-                id: AllowedTupleConstraintId(0),
-                variables: vec![ConstraintVariableId(0)],
-                tuples: vec![vec![ast_node(10)], vec![ast_node(20)]],
-            }
+            decoded_variable_domain(&model, ConstraintVariableId(0)),
+            vec![ast_node(10), ast_node(20)]
         );
     }
 
@@ -3180,20 +3498,12 @@ mod tests {
         );
 
         assert_eq!(
-            allowed_tuples_for(&model, &[ConstraintVariableId(0)]),
-            &AllowedTupleConstraint {
-                id: AllowedTupleConstraintId(0),
-                variables: vec![ConstraintVariableId(0)],
-                tuples: vec![vec![owner(10)], vec![owner(20)]],
-            }
+            decoded_variable_domain(&model, ConstraintVariableId(0)),
+            vec![owner(10), owner(20)]
         );
         assert_eq!(
-            allowed_tuples_for(&model, &[ConstraintVariableId(1)]),
-            &AllowedTupleConstraint {
-                id: AllowedTupleConstraintId(1),
-                variables: vec![ConstraintVariableId(1)],
-                tuples: vec![vec![owner(20)]],
-            }
+            decoded_variable_domain(&model, ConstraintVariableId(1)),
+            vec![owner(20)]
         );
     }
 
@@ -3498,12 +3808,8 @@ mod tests {
         let model = compile_selector_problem(&program, &facts).unwrap();
 
         assert_eq!(
-            allowed_tuples_for(&model, &[ConstraintVariableId(0)]),
-            &AllowedTupleConstraint {
-                id: AllowedTupleConstraintId(0),
-                variables: vec![ConstraintVariableId(0)],
-                tuples: vec![vec![ast_node(10)], vec![ast_node(30)]],
-            }
+            decoded_variable_domain(&model, ConstraintVariableId(0)),
+            vec![ast_node(10), ast_node(30)]
         );
     }
 
@@ -3671,12 +3977,8 @@ mod tests {
         let model = compile_selector_problem(&program, &facts).unwrap();
 
         assert_eq!(
-            allowed_tuples_for(&model, &[ConstraintVariableId(0)]),
-            &AllowedTupleConstraint {
-                id: AllowedTupleConstraintId(0),
-                variables: vec![ConstraintVariableId(0)],
-                tuples: vec![vec![ast_node(100)], vec![ast_node(200)]],
-            }
+            decoded_variable_domain(&model, ConstraintVariableId(0)),
+            vec![ast_node(100), ast_node(200)]
         );
     }
 
@@ -4083,12 +4385,12 @@ mod tests {
             ]
         );
         assert_eq!(
-            allowed_tuples_for(&model, &[ConstraintVariableId(1)]).tuples,
-            vec![vec![owner(10)]]
+            decoded_variable_domain(&model, ConstraintVariableId(1)),
+            vec![owner(10)]
         );
         assert_eq!(
-            allowed_tuples_for(&model, &[ConstraintVariableId(2)]).tuples,
-            vec![vec![owner(10)]]
+            decoded_variable_domain(&model, ConstraintVariableId(2)),
+            vec![owner(10)]
         );
         assert_eq!(
             allowed_tuples_for(&model, &[ConstraintVariableId(3), ConstraintVariableId(9)]).tuples,
@@ -4098,28 +4400,28 @@ mod tests {
             ]
         );
         assert_eq!(
-            allowed_tuples_for(&model, &[ConstraintVariableId(10)]).tuples,
-            vec![vec![string("value")]]
+            decoded_variable_domain(&model, ConstraintVariableId(10)),
+            vec![string("value")]
         );
         assert_eq!(
-            allowed_tuples_for(&model, &[ConstraintVariableId(4)]).tuples,
-            vec![vec![owner(50)]]
+            decoded_variable_domain(&model, ConstraintVariableId(4)),
+            vec![owner(50)]
         );
         assert_eq!(
-            allowed_tuples_for(&model, &[ConstraintVariableId(5)]).tuples,
-            vec![vec![owner(60)]]
+            decoded_variable_domain(&model, ConstraintVariableId(5)),
+            vec![owner(60)]
         );
         assert_eq!(
-            allowed_tuples_for(&model, &[ConstraintVariableId(6)]).tuples,
-            vec![vec![owner(70)]]
+            decoded_variable_domain(&model, ConstraintVariableId(6)),
+            vec![owner(70)]
         );
         assert_eq!(
-            allowed_tuples_for(&model, &[ConstraintVariableId(7)]).tuples,
-            vec![vec![owner(90)]]
+            decoded_variable_domain(&model, ConstraintVariableId(7)),
+            vec![owner(90)]
         );
         assert_eq!(
-            allowed_tuples_for(&model, &[ConstraintVariableId(11)]).tuples,
-            vec![vec![owner(65)]]
+            decoded_variable_domain(&model, ConstraintVariableId(11)),
+            vec![owner(65)]
         );
     }
 
@@ -4201,16 +4503,16 @@ mod tests {
         let model = compile_selector_problem(&program, &facts).unwrap();
 
         assert_eq!(
-            allowed_tuples_for(&model, &[ConstraintVariableId(0)]).tuples,
-            vec![vec![owner(10)]]
+            decoded_variable_domain(&model, ConstraintVariableId(0)),
+            vec![owner(10)]
         );
         assert_eq!(
-            allowed_tuples_for(&model, &[ConstraintVariableId(1)]).tuples,
-            vec![vec![owner(20)]]
+            decoded_variable_domain(&model, ConstraintVariableId(1)),
+            vec![owner(20)]
         );
         assert_eq!(
-            allowed_tuples_for(&model, &[ConstraintVariableId(2)]).tuples,
-            vec![vec![owner(30)]]
+            decoded_variable_domain(&model, ConstraintVariableId(2)),
+            vec![owner(30)]
         );
         assert_eq!(
             allowed_tuples_for(&model, &[ConstraintVariableId(3), ConstraintVariableId(4)]).tuples,

--- a/devinfra/js/debundle/selector_ortools_cpsat_backend.rs
+++ b/devinfra/js/debundle/selector_ortools_cpsat_backend.rs
@@ -402,6 +402,19 @@ fn problem_summary(
         .iter()
         .filter(|constraint| matches!(constraint.kind, BinaryConstraintKind::OrdinalBefore))
         .count();
+    let mut constraint_count_by_kind = BTreeMap::from([
+        ("allowed_table", problem.allowed_tuples.len()),
+        ("linear", problem.linear_constraints.len()),
+        ("all_different", problem.all_different.len()),
+    ]);
+    for constraint in &problem.binary_constraints {
+        let key = match constraint.kind {
+            BinaryConstraintKind::Equal => "binary_equal",
+            BinaryConstraintKind::NotEqual => "binary_not_equal",
+            BinaryConstraintKind::OrdinalBefore => "binary_ordinal_before",
+        };
+        *constraint_count_by_kind.entry(key).or_insert(0) += 1;
+    }
     let variable_count_by_domain = keyed_count(
         problem
             .variables
@@ -459,12 +472,25 @@ fn problem_summary(
             .iter()
             .map(|constraint| all_different_reason_name(&constraint.reason)),
     );
-    let variable_domain_representation_count_by_kind = keyed_count(problem.variables.iter().map(
-        |variable| match &variable.values {
-            CompiledVariableDomain::Full(_) => "full",
-            CompiledVariableDomain::Sparse(_) => "sparse",
-        },
-    ));
+    let linear_constraint_arity_histogram = usize_histogram(
+        problem
+            .linear_constraints
+            .iter()
+            .map(|constraint| constraint.variables.len()),
+    );
+    let variable_domain_representation_count_by_kind = keyed_count(
+        problem
+            .variables
+            .iter()
+            .map(|variable| variable_domain_representation_name(&variable.values)),
+    );
+    let variable_domain_encoding_count_by_domain =
+        grouped_keyed_count(problem.variables.iter().map(|variable| {
+            (
+                variable_domain_name(variable.domain),
+                variable_domain_encoding_name(&variable.values),
+            )
+        }));
     let domain_sharing = variable_domain_sharing_summary(problem);
 
     serde_json::json!({
@@ -482,16 +508,20 @@ fn problem_summary(
         "binary_equal_count": binary_equal_count,
         "binary_not_equal_count": binary_not_equal_count,
         "binary_ordinal_before_count": binary_ordinal_before_count,
+        "constraint_count_by_kind": constraint_count_by_kind,
         "domain_size_histogram": domain_size_histogram,
         "domain_size_histogram_by_domain": domain_size_histogram_by_domain,
         "dump_sequence": dump_sequence,
         "linear_constraint_count": problem.linear_constraints.len(),
+        "linear_constraint_arity_histogram": linear_constraint_arity_histogram,
         "max_allowed_arity": max_allowed_arity,
         "max_allowed_rows": max_allowed_rows,
         "max_domain_values": max_domain_values,
         "request_encoded_bytes": request_encoded_bytes,
+        "request_proto_bytes": request_encoded_bytes,
         "target_projection_count": problem.target_projections.len(),
         "total_domain_values": total_domain_values,
+        "variable_domain_encoding_count_by_domain": variable_domain_encoding_count_by_domain,
         "variable_domain_representation_count_by_kind": variable_domain_representation_count_by_kind,
         "variable_domain_sharing": domain_sharing,
         "value_dictionary_count": problem.value_dictionary.total_len(),
@@ -507,27 +537,70 @@ fn problem_summary(
 }
 
 fn variable_domain_sharing_summary(problem: &CompiledSelectorProblem) -> serde_json::Value {
-    let mut domain_use_counts: BTreeMap<Vec<BackendValueId>, usize> = BTreeMap::new();
+    let mut domain_use_counts: BTreeMap<(&'static str, Vec<BackendValueId>), usize> =
+        BTreeMap::new();
+    let mut domain_use_counts_by_domain: BTreeMap<
+        &'static str,
+        BTreeMap<Vec<BackendValueId>, usize>,
+    > = BTreeMap::new();
     for variable in &problem.variables {
+        let domain = variable_domain_name(variable.domain);
+        let values = problem.variable_domain_values(variable);
         *domain_use_counts
-            .entry(problem.variable_domain_values(variable))
+            .entry((domain, values.clone()))
+            .or_insert(0) += 1;
+        *domain_use_counts_by_domain
+            .entry(domain)
+            .or_default()
+            .entry(values)
             .or_insert(0) += 1;
     }
-    let unique_domain_value_count = domain_use_counts
-        .keys()
-        .map(|values| values.len())
-        .sum::<usize>();
-    let total_variable_domain_values = domain_use_counts
+
+    let by_domain = domain_use_counts_by_domain
         .iter()
-        .map(|(values, use_count)| values.len() * use_count)
-        .sum::<usize>();
-    let shared_domain_group_count = domain_use_counts
-        .values()
-        .filter(|use_count| **use_count > 1)
-        .count();
-    let max_variables_sharing_domain = domain_use_counts.values().copied().max().unwrap_or(0);
-    let variables_per_unique_domain_histogram =
-        usize_histogram(domain_use_counts.values().copied());
+        .map(|(domain, counts)| {
+            (
+                *domain,
+                domain_sharing_stats(
+                    counts
+                        .iter()
+                        .map(|(values, use_count)| (values.len(), *use_count)),
+                ),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let mut summary = domain_sharing_stats(
+        domain_use_counts
+            .iter()
+            .map(|((_domain, values), use_count)| (values.len(), *use_count)),
+    );
+    summary
+        .as_object_mut()
+        .expect("domain sharing stats should be a JSON object")
+        .insert("by_domain".to_string(), serde_json::json!(by_domain));
+    summary
+}
+
+fn domain_sharing_stats(
+    domain_value_use_counts: impl IntoIterator<Item = (usize, usize)>,
+) -> serde_json::Value {
+    let mut unique_domain_count = 0;
+    let mut unique_domain_value_count = 0;
+    let mut total_variable_domain_values = 0;
+    let mut shared_domain_group_count = 0;
+    let mut max_variables_sharing_domain = 0;
+    let mut variables_per_unique_domain = Vec::new();
+
+    for (value_count, use_count) in domain_value_use_counts {
+        unique_domain_count += 1;
+        unique_domain_value_count += value_count;
+        total_variable_domain_values += value_count * use_count;
+        if use_count > 1 {
+            shared_domain_group_count += 1;
+        }
+        max_variables_sharing_domain = max_variables_sharing_domain.max(use_count);
+        variables_per_unique_domain.push(use_count);
+    }
 
     serde_json::json!({
         "current_encoded_value_count": total_variable_domain_values,
@@ -535,8 +608,8 @@ fn variable_domain_sharing_summary(problem: &CompiledSelectorProblem) -> serde_j
         "encoded_value_savings_if_deduplicated": total_variable_domain_values.saturating_sub(unique_domain_value_count),
         "max_variables_sharing_domain": max_variables_sharing_domain,
         "shared_domain_group_count": shared_domain_group_count,
-        "unique_domain_count": domain_use_counts.len(),
-        "variables_per_unique_domain_histogram": variables_per_unique_domain_histogram,
+        "unique_domain_count": unique_domain_count,
+        "variables_per_unique_domain_histogram": usize_histogram(variables_per_unique_domain),
     })
 }
 
@@ -562,6 +635,20 @@ fn grouped_usize_histogram(
     grouped
 }
 
+fn grouped_keyed_count(
+    values: impl IntoIterator<Item = (&'static str, &'static str)>,
+) -> BTreeMap<&'static str, BTreeMap<&'static str, usize>> {
+    let mut grouped = BTreeMap::new();
+    for (group, key) in values {
+        *grouped
+            .entry(group)
+            .or_insert_with(BTreeMap::new)
+            .entry(key)
+            .or_insert(0) += 1;
+    }
+    grouped
+}
+
 fn keyed_count(keys: impl IntoIterator<Item = &'static str>) -> BTreeMap<&'static str, usize> {
     let mut counts = BTreeMap::new();
     for key in keys {
@@ -576,6 +663,20 @@ fn variable_domain_name(domain: VariableDomain) -> &'static str {
         VariableDomain::AstNode => "ast_node",
         VariableDomain::String => "string",
         VariableDomain::StatementOrdinal => "statement_ordinal",
+    }
+}
+
+fn variable_domain_representation_name(values: &CompiledVariableDomain) -> &'static str {
+    match values {
+        CompiledVariableDomain::Full(_) => "full",
+        CompiledVariableDomain::Sparse(_) => "sparse",
+    }
+}
+
+fn variable_domain_encoding_name(values: &CompiledVariableDomain) -> &'static str {
+    match values {
+        CompiledVariableDomain::Full(_) => "dense",
+        CompiledVariableDomain::Sparse(_) => "sparse",
     }
 }
 
@@ -825,6 +926,9 @@ mod tests {
 
     use analysis::{AnalysisHints, ChunkId, OwnerId, StatementOrdinal};
     use selector_backend_solver::solve_with_backend;
+    use selector_constraint_backend::{
+        AllDifferentConstraintId, DomainValueDictionary, FullDomainValues,
+    };
     use selector_ir::{
         ClaimKind, ClaimOrigin, ClaimOutcome, OwnerTerm, ResolvedClaim, SelectorAtom, SelectorFact,
         SelectorFactStore, SelectorProgram, SelectorTargetId, StringTerm, VariableDomain,
@@ -996,6 +1100,149 @@ mod tests {
             Some(wire::target_projection::BindingProjection::BindingConst(
                 "minA".to_string()
             ))
+        );
+    }
+
+    #[test]
+    fn problem_summary_reports_request_shape_and_domain_diagnostics() {
+        let problem = CompiledSelectorProblem {
+            value_dictionary: DomainValueDictionary {
+                owners: vec![OwnerId(10), OwnerId(20), OwnerId(30)],
+                strings: vec!["alpha".to_string(), "beta".to_string()],
+                statement_ordinals: vec![StatementOrdinal(0), StatementOrdinal(1)],
+                ..Default::default()
+            },
+            full_domains: FullDomainValues {
+                owners: vec![BackendValueId(0), BackendValueId(1), BackendValueId(2)],
+                strings: vec![BackendValueId(0), BackendValueId(1)],
+                statement_ordinals: vec![BackendValueId(0), BackendValueId(1)],
+                ..Default::default()
+            },
+            variables: vec![
+                CompiledVariable {
+                    id: ConstraintVariableId(0),
+                    source: None,
+                    domain: VariableDomain::Owner,
+                    debug_name: Some("owner_dense_a".to_string()),
+                    values: CompiledVariableDomain::Full(VariableDomain::Owner),
+                },
+                CompiledVariable {
+                    id: ConstraintVariableId(1),
+                    source: None,
+                    domain: VariableDomain::Owner,
+                    debug_name: Some("owner_dense_b".to_string()),
+                    values: CompiledVariableDomain::Full(VariableDomain::Owner),
+                },
+                CompiledVariable {
+                    id: ConstraintVariableId(2),
+                    source: None,
+                    domain: VariableDomain::Owner,
+                    debug_name: Some("owner_sparse".to_string()),
+                    values: CompiledVariableDomain::Sparse(vec![
+                        BackendValueId(0),
+                        BackendValueId(1),
+                    ]),
+                },
+                CompiledVariable {
+                    id: ConstraintVariableId(3),
+                    source: None,
+                    domain: VariableDomain::String,
+                    debug_name: Some("string_sparse".to_string()),
+                    values: CompiledVariableDomain::Sparse(vec![
+                        BackendValueId(0),
+                        BackendValueId(1),
+                    ]),
+                },
+                CompiledVariable {
+                    id: ConstraintVariableId(4),
+                    source: None,
+                    domain: VariableDomain::StatementOrdinal,
+                    debug_name: Some("ordinal_dense".to_string()),
+                    values: CompiledVariableDomain::Full(VariableDomain::StatementOrdinal),
+                },
+            ],
+            target_projections: Vec::new(),
+            allowed_tuples: Vec::new(),
+            binary_constraints: vec![CompiledBinaryConstraint {
+                left: ConstraintVariableId(0),
+                right: ConstraintVariableId(1),
+                kind: BinaryConstraintKind::NotEqual,
+            }],
+            linear_constraints: vec![CompiledLinearConstraint {
+                variables: vec![ConstraintVariableId(0), ConstraintVariableId(2)],
+                coefficients: vec![1, -1],
+                offset: 0,
+                domain: vec![0, 0],
+            }],
+            all_different: vec![CompiledAllDifferentConstraint {
+                id: AllDifferentConstraintId(0),
+                variables: vec![
+                    ConstraintVariableId(0),
+                    ConstraintVariableId(1),
+                    ConstraintVariableId(2),
+                ],
+                reason: AllDifferentReason::SelectorSemantics {
+                    label: "summary test".to_string(),
+                },
+            }],
+            known_unsat: None,
+        };
+        let request = request_from_problem(&problem).unwrap();
+        let request_encoded_bytes = request.encode_to_vec().len();
+
+        let summary = problem_summary(&problem, &request, request_encoded_bytes, Some(9));
+
+        assert_eq!(
+            summary["request_proto_bytes"],
+            serde_json::json!(request_encoded_bytes)
+        );
+        assert_eq!(
+            summary["constraint_count_by_kind"]["binary_not_equal"],
+            serde_json::json!(1)
+        );
+        assert_eq!(
+            summary["constraint_count_by_kind"]["linear"],
+            serde_json::json!(1)
+        );
+        assert_eq!(
+            summary["constraint_count_by_kind"]["all_different"],
+            serde_json::json!(1)
+        );
+        assert_eq!(
+            summary["linear_constraint_arity_histogram"]["2"],
+            serde_json::json!(1)
+        );
+        assert_eq!(
+            summary["variable_domain_encoding_count_by_domain"]["owner"]["dense"],
+            serde_json::json!(2)
+        );
+        assert_eq!(
+            summary["variable_domain_encoding_count_by_domain"]["owner"]["sparse"],
+            serde_json::json!(1)
+        );
+        assert_eq!(
+            summary["variable_domain_encoding_count_by_domain"]["string"]["sparse"],
+            serde_json::json!(1)
+        );
+        assert_eq!(
+            summary["variable_domain_sharing"]["unique_domain_count"],
+            serde_json::json!(4)
+        );
+        assert_eq!(
+            summary["variable_domain_sharing"]["shared_domain_group_count"],
+            serde_json::json!(1)
+        );
+        assert_eq!(
+            summary["variable_domain_sharing"]["by_domain"]["owner"]["unique_domain_count"],
+            serde_json::json!(2)
+        );
+        assert_eq!(
+            summary["variable_domain_sharing"]["by_domain"]["owner"]["shared_domain_group_count"],
+            serde_json::json!(1)
+        );
+        assert_eq!(
+            summary["variable_domain_sharing"]["by_domain"]["string"]["shared_domain_group_count"],
+            serde_json::json!(0)
         );
     }
 


### PR DESCRIPTION
## Summary
- lower indexed unary selector facts directly into sparse CSP variable domains instead of materializing one-column tables
- prune encoded allowed-table rows against narrowed sparse domains while preserving domain validation
- add selector CP-SAT summary diagnostics for constraint counts, linear arity, proto bytes, and domain sharing
- remove stale Bazel profile-target guidance; host profilers stay outside Bazel unless supplied by a hermetic toolchain

## Verification
- `nix develop --command pre-commit run --files devinfra/js/debundle/AGENTS.md devinfra/js/debundle/README.md devinfra/js/debundle/perf/fact_resolver.md devinfra/js/debundle/selector_backend_solver.rs devinfra/js/debundle/selector_constraint_backend.rs devinfra/js/debundle/selector_constraint_model_builder.rs devinfra/js/debundle/selector_ortools_cpsat_backend.rs`
- `nix develop --command bazelisk --output_base=/tmp/agentydragon/bazel-output/ducktape-debundle-indexed-model test --config=rbe --config=nolint //devinfra/js/debundle:selector_backend_solver_test //devinfra/js/debundle:selector_constraint_backend_test //devinfra/js/debundle:selector_constraint_model_builder_test //devinfra/js/debundle:selector_ortools_cpsat_backend_test //devinfra/js/debundle/solver_backends/ortools_cpsat:solver_test //devinfra/js/debundle/e2e:global_selector_assignment_test`
- `nix develop --command bazelisk --output_base=/tmp/agentydragon/bazel-output/ducktape-debundle-indexed-model test --config=rbe --config=ci //devinfra/js/debundle:selector_ortools_cpsat_backend_test //devinfra/js/debundle:selector_backend_solver_test`
- `nix develop --command bazelisk --output_base=/tmp/agentydragon/bazel-output/ducktape-debundle-indexed-model-clippy build --config=rbe --config=ci //devinfra/js/debundle:selector_ortools_cpsat_backend //devinfra/js/debundle:selector_ortools_cpsat_backend_test`
- from `../gaffer-private`: `nix develop --command bazelisk --output_base=/tmp/agentydragon/bazel-output/gaffer-debundle-nobuild-indexed build --override_module=ducktape=/tmp/ducktape-debundle-indexed-model-lowering --config=rbe --config=nolint --nobuild //tana/re/web/78d928dca7:debundle`