### PR TITLE
[codex] Cache agent devtools in Attic

### DIFF
--- a/devinfra/ci/nix_attic_build_and_push.sh
+++ b/devinfra/ci/nix_attic_build_and_push.sh
@@ -77,10 +77,20 @@ for host in $(nix eval --impure --json .#homeConfigurations --apply builtins.att
   " --no-link --print-out-paths >>"$out_paths"
 done
 
-# Other outputs
-nix build --impure \
+# Agent/bootstrap outputs. Keep the individual tools here even though devtools
+# includes them: these are the bootstrap tools agent hosts need before they can
+# run BuildBuddy-backed validation, so stale package composition should not hide
+# a missing cache path.
+for output in \
+  .#packages.x86_64-linux.bb \
+  .#packages.x86_64-linux.bbr \
+  .#packages.x86_64-linux.bbapi \
   .#packages.x86_64-linux.devtools \
-  --no-link --print-out-paths >>"$out_paths"
+  .#devShells.x86_64-linux.default; do
+  nix build --impure \
+    "$output" \
+    --no-link --print-out-paths >>"$out_paths"
+done
 
 echo "Final sweep: pushing $(wc -l <"$out_paths") paths to Attic (most already uploaded by watch-store)..."
 xargs attic push ducktape:main <"$out_paths"

--- a/flake.nix
+++ b/flake.nix
@@ -71,16 +71,18 @@
       };
 
       # CI-released artifact pins (nix/artifact-pins.json), updated by sync-pins.yml.
-      # All entries are plain fetchurl; sha256 is SHA-256 SRI of the downloaded file.
+      # Use Nixpkgs fetchurl derivations, not builtins.fetchurl: hosts behind
+      # restricted egress can substitute these fixed-output paths from Attic
+      # instead of doing evaluator-time downloads from GitHub Releases.
       artifacts =
         let
           data = builtins.fromJSON (builtins.readFile ./nix/artifact-pins.json);
         in
         builtins.mapAttrs (
           _: spec:
-          builtins.fetchurl {
+          pkgs.fetchurl {
             inherit (spec) url;
-            sha256 = "sha256-${spec.sha256}";
+            hash = "sha256-${spec.sha256}";
           }
         ) data.pins;
 


### PR DESCRIPTION
## Summary

- Switch pinned release artifacts from `builtins.fetchurl` to Nixpkgs `fetchurl` derivations so fixed-output paths can be substituted from Attic instead of fetched during evaluation.
- Make the Attic push workflow explicitly realize `bb`, `bbr`, `bbapi`, `devtools`, and the default devshell before pushing closures to `cache.allegedly.works/main`.

## Why

`codex@agent-box` should be able to get BuildBuddy bootstrap tools from the trusted Nix cache. The previous `builtins.fetchurl` path could still require direct GitHub Release downloads, which is brittle behind restricted MITM/proxy egress.

## Validation

- `bash -n devinfra/ci/nix_attic_build_and_push.sh`
- `git diff --check`
- `nix eval --impure --raw .#packages.x86_64-linux.bbr.drvPath`
- `nix eval --impure --raw .#devShells.x86_64-linux.default.drvPath`
- `nix build --impure .#packages.x86_64-linux.bbr --no-link --print-out-paths`
- `nix build --impure .#devShells.x86_64-linux.default --no-link --print-out-paths`
- `SKIP=no-commit-to-branch nix develop -c pre-commit run --files flake.nix devinfra/ci/nix_attic_build_and_push.sh`