### PR TITLE
Grant Haku read access to Budget Ledger

### DIFF
--- a/cluster/k8s/forgejo/budget-ledger/terraform.yaml
+++ b/cluster/k8s/forgejo/budget-ledger/terraform.yaml
@@ -12,10 +12,10 @@ spec:
     name: flux-system
     namespace: flux-system
 
-  # forgejo_collaborator.claude grants read to the claude agent account, so the
-  # forgejo-claude module (which provisions that user) must apply first.
+  # Collaborator grants reference service users provisioned by these modules.
   dependsOn:
     - name: forgejo-claude
+    - name: haku-state
 
   serviceAccountName: tf-runner
   approvePlan: "auto"

--- a/tf/gitops/budget-ledger/main.tf
+++ b/tf/gitops/budget-ledger/main.tf
@@ -2,8 +2,9 @@
 #
 # Provisions a private `budget-ledger/ledger` repo owned by a dedicated
 # `budget-ledger` service user (so the user has full read/write on it without a
-# separate collaborator grant), plus a Kubernetes Secret carrying that user's git
-# credentials in the `budget` namespace -- consumed by the exporter CronJob
+# separate collaborator grant), read-only collaborator grants for agent users,
+# plus a Kubernetes Secret carrying that user's git credentials in the `budget`
+# namespace -- consumed by the exporter CronJob
 # (push) and the Fava git-sync sidecar (pull). Auth is HTTPS Basic over the
 # in-cluster Forgejo service (no SSH endpoint needed).
 
@@ -50,6 +51,14 @@ resource "forgejo_repository" "ledger" {
 resource "forgejo_collaborator" "claude" {
   repository_id = forgejo_repository.ledger.id
   user          = "claude"
+  permission    = "read"
+}
+
+# Read-only access for the haku agent account (user provisioned by
+# tf/gitops/haku-state).
+resource "forgejo_collaborator" "haku" {
+  repository_id = forgejo_repository.ledger.id
+  user          = "haku"
   permission    = "read"
 }
 


### PR DESCRIPTION
## Summary

- Grant the `haku` Forgejo user read access to `budget-ledger/ledger`.
- Add `haku-state` as a Terraform dependency so the `haku` service user exists before the collaborator grant is applied.

## Validation

- `bazelisk build //tf/gitops/budget-ledger:format //tf/gitops/budget-ledger:validate //tf/gitops/budget-ledger:lint`
- `bazelisk test //cluster/validation:test_cluster_integration //cluster/validation:test_flux_build`
- `git diff --check`
- commit hooks / pre-commit on commit