### PR TITLE
[codex] Fix Haku popup blocked signal

### DIFF
--- a/haku/console/app.py
+++ b/haku/console/app.py
@@ -39,6 +39,7 @@ logger = logging.getLogger(__name__)
 APP_SHELL_CACHE_CONTROL = "no-cache, max-age=0, must-revalidate"
 IMMUTABLE_ASSET_CACHE_CONTROL = "public, max-age=31536000, immutable"
 NO_STORE_CACHE_CONTROL = "no-store"
+REFERRER_POLICY = "no-referrer"
 
 
 def _cache_control_for_path(path: str) -> str:
@@ -73,6 +74,7 @@ def create_app(settings: Settings, *, git_state: GitState) -> FastAPI:
         response = await call_next(request)
         response.headers["Content-Security-Policy"] = csp
         response.headers["Cache-Control"] = _cache_control_for_path(request.url.path)
+        response.headers["Referrer-Policy"] = REFERRER_POLICY
         return response
 
     # CSRF for the capability tier: a header-located double-submit token (the SPA

--- a/haku/console/default.conf.template
+++ b/haku/console/default.conf.template
@@ -14,11 +14,13 @@ server {
 
   proxy_hide_header Content-Security-Policy;
   proxy_hide_header Cache-Control;
+  proxy_hide_header Referrer-Policy;
 
   add_header Content-Security-Policy
     "frame-src 'self' ${HAKU_CONSOLE_HAKU_UI_URL} ${HAKU_CONSOLE_AUTH_ORIGIN}; frame-ancestors 'none'"
     always;
   add_header Cache-Control $haku_cache_control always;
+  add_header Referrer-Policy "no-referrer" always;
 
   proxy_http_version 1.1;
   proxy_set_header Host $host;

--- a/haku/console/frontend/BUILD.bazel
+++ b/haku/console/frontend/BUILD.bazel
@@ -203,6 +203,7 @@ tsc_bin.tsc_test(
     chdir = package_name(),
     data = [
         "bridge.test.ts",
+        "haku_ui_embed.test.ts",
         "tabler-icons.d.ts",
         "tsconfig.json",
         ":main_lib",
@@ -218,8 +219,10 @@ vitest_bin.vitest_test(
     chdir = package_name(),
     data = [
         "bridge.test.ts",
+        "haku_ui_embed.test.ts",
         "vitest.config.ts",
         ":bridge",
+        ":haku_ui_embed",
         "//:node_modules",
     ],
 )

--- a/haku/console/frontend/haku_ui_embed.test.ts
+++ b/haku/console/frontend/haku_ui_embed.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { openExternal } from "./haku_ui_embed.tsx";
+
+describe("openExternal", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses the blank-tab handle as the HTTPS popup signal, then severs opener before navigation", () => {
+    const opened = { opener: window, location: { replace: vi.fn() } };
+    vi.spyOn(window, "open").mockReturnValue(opened as unknown as Window);
+
+    expect(openExternal("https://example.com/path")).toBe(true);
+
+    expect(window.open).toHaveBeenCalledWith("about:blank", "_blank");
+    expect(opened.opener).toBeNull();
+    expect(opened.location.replace).toHaveBeenCalledWith("https://example.com/path");
+  });
+
+  it("reports blocked HTTPS tabs when the blank tab returns no handle", () => {
+    vi.spyOn(window, "open").mockReturnValue(null);
+
+    expect(openExternal("https://example.com/path")).toBe(false);
+  });
+
+  it("opens mailto directly without leaving an about:blank tab", () => {
+    const opened = { opener: window };
+    vi.spyOn(window, "open").mockReturnValue(opened as unknown as Window);
+
+    expect(openExternal("mailto:ops@allegedly.works")).toBe(true);
+
+    expect(window.open).toHaveBeenCalledWith("mailto:ops@allegedly.works", "_blank");
+    expect(opened.opener).toBeNull();
+  });
+});

--- a/haku/console/frontend/haku_ui_embed.tsx
+++ b/haku/console/frontend/haku_ui_embed.tsx
@@ -13,11 +13,16 @@ import { toastError } from "./toast.ts";
 // the framed app's own Authentik auth; **no `allow-popups`** (only the shell opens
 // links) and **no `allow="fullscreen"`**. See plans/free_form_ui_iframe.md.
 
-// window.open relayed from a postMessage handler loses user-activation, so it needs the
-// operator's one-time "allow pop-ups for this site" (the shell origin only). Returns
-// false when the browser blocked it.
-function openExternal(url: string): boolean {
-  return window.open(url, "_blank", "noopener,noreferrer") !== null;
+// `noopener`/`noreferrer` force window.open() to return null even when the tab
+// opened, so open a same-origin blank tab first. The handle is the only reliable
+// popup-block signal; once it exists, sever opener before navigating it.
+export function openExternal(url: string): boolean {
+  const parsed = new URL(url);
+  const opened = window.open(parsed.protocol === "mailto:" ? url : "about:blank", "_blank");
+  if (!opened) return false;
+  opened.opener = null;
+  if (parsed.protocol !== "mailto:") opened.location.replace(url);
+  return true;
 }
 
 const POPUP_HINT = "Allow pop-ups for this site so the console can open links.";

--- a/haku/console/frontend/index.html
+++ b/haku/console/frontend/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="referrer" content="no-referrer" />
     <title>Haku — dashboard</title>
     <link rel="icon" type="image/svg+xml" href="__LOGO_SVG__" />
     <link rel="stylesheet" href="__STYLES_CSS__" />

--- a/haku/console/plans/free_form_ui_iframe.md
+++ b/haku/console/plans/free_form_ui_iframe.md
@@ -201,7 +201,11 @@ iframe can't: tight sandbox + cross-origin). Rules:
   - otherwise → shell **confirm overlay showing the real, full URL** → Open / Cancel
     (a consent + anti-phishing gate: the agent supplies the URL, the shell displays it
     honestly).
-- Always `window.open(url, "_blank", "noopener,noreferrer")`.
+- Open a same-origin blank tab first, treat a missing handle as the popup-block
+  signal, sever `opener`, then navigate it. The shell serves `Referrer-Policy:
+no-referrer`; using `noopener`/`noreferrer` in the `window.open` feature string is
+  intentionally avoided because those features make `window.open` return `null` even
+  when the tab opened.
 
 This subsumes the item→handoff loop (a `claude.ai/new` deep-link is just a whitelisted
 open) and gives Haku a general "send me to a link" verb without ever letting agent UI
@@ -235,8 +239,8 @@ holds, so `haku-ui ≠ haku-console` regardless of framing headers.
 Also shipped: the **`postMessage` bridge** (origin-checked transport + the top-layer
 native-`<dialog>` confirm with backdrop) and the **`openLink`** affordance — scheme hard-gate
 (`https`/`mailto` only), operator-owned host whitelist in the shell (`bridge.ts`, not
-`haku-state`), off-whitelist confirm, and `window.open(…, "noopener,noreferrer")` (assumes the
-one-time per-origin pop-up allow). The iframe sandbox dropped `allow-popups` accordingly — only
+`haku-state`), off-whitelist confirm, and shell-owned tab opening (assumes the one-time
+per-origin pop-up allow). The iframe sandbox dropped `allow-popups` accordingly — only
 the shell opens. `state_template/k8s/haku-ui/index.html` carries a worked `openLink` demo.
 
 **Remaining**, in order (each ~PR-sized; **owner** is who builds it):

--- a/haku/console/test_app.py
+++ b/haku/console/test_app.py
@@ -43,6 +43,7 @@ def test_config_unconfigured_csp_denies_framing(client) -> None:
     resp = client.get("/api/config")
     assert resp.json()["haku_ui_url"] is None
     assert "frame-src 'none'" in resp.headers["content-security-policy"]
+    assert resp.headers["referrer-policy"] == "no-referrer"
 
 
 def test_cache_policy_splits_hashed_assets_app_shell_and_api(make_client, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Fix the Haku console external-link bridge so a successful tab open is not reported as a blocked popup.

## Root Cause

The bridge used `window.open(url, "_blank", "noopener,noreferrer") !== null` as the popup-block signal. Browser behavior makes that signal ambiguous: `noopener`/`noreferrer` can make `window.open` return `null` even when the tab opened successfully.

## Changes

- Open a same-origin `about:blank` tab first and use that handle as the popup-block signal.
- Immediately sever `opener`, then navigate the tab to the requested URL.
- Add `Referrer-Policy: no-referrer` in the FastAPI and nginx/static shell paths, plus the SPA meta tag, so referrer suppression no longer depends on the `noreferrer` window feature.
- Add Vitest coverage for successful HTTPS opens, blocked opens, and `mailto:` handling.
- Update the free-form UI iframe plan doc to match the implemented signal semantics.

## Validation

- `bazelisk test //haku/console/frontend:bridge_test //haku/console/frontend:tsc_test //haku/console:test_app`
- `pre-commit run --files haku/console/app.py haku/console/default.conf.template haku/console/test_app.py haku/console/plans/free_form_ui_iframe.md haku/console/frontend/BUILD.bazel haku/console/frontend/haku_ui_embed.tsx haku/console/frontend/haku_ui_embed.test.ts haku/console/frontend/index.html`