### PR TITLE
[codex] enable haku Forgejo image webhook

### DIFF
--- a/tf/gitops/haku-state/main.tf
+++ b/tf/gitops/haku-state/main.tf
@@ -208,6 +208,7 @@ resource "kubernetes_secret" "forgejo_webhook_token" {
 resource "forgejo_repository_webhook" "haku_ui_image" {
   repository_id = forgejo_repository.state.id
   type          = "forgejo"
+  active        = true
   events        = ["package"]
   config = {
     content_type = "json"


### PR DESCRIPTION
## Summary

- enable the Forgejo package webhook managed by `tf/gitops/haku-state`
- keeps the existing `package` event and Flux receiver URL unchanged

## Validation

- `tofu fmt -check tf/gitops/haku-state`
- `bbr build //tf/gitops/haku-state:haku-state`
- pre-commit hooks during commit