### PR TITLE
docs: promote RBE-workflow reasoning, dedupe SOPS + roaming-DaemonSet guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ bbr query '...'
 bb run //devinfra:gazelle
 ```
 
-Remote execution (RBE) and remote caching are the **expected defaults** — do not disable them. In particular:
+Remote execution (RBE) and remote caching are the **expected defaults** — do not disable them. No workflow needs `--remote_executor=""` — see <devinfra/docs/rbe_workflows.md> for the per-workflow reasoning (gazelle, requirements, cargo repin, pnpm, syrupy). In particular:
 
 - **Browser/visual tests must run with remote execution.** RBE runner VMs have the required Docker and display stack; local machines typically do not. Never skip or stub these tests to avoid needing RBE.
 - `--noremote_cache` / `--noremote_accept_cached` are fine for forcing a fresh run; they don't break correctness.

--- a/cluster/docs/plan.md
+++ b/cluster/docs/plan.md
@@ -438,17 +438,13 @@ hil-ovh`) and apply the same `nodePathMap` entry to any matching node.
       service unit) — restarts kubelet if it deadlocks
 - [ ] NVIDIA GPU monitoring: add DCGM exporter ServiceMonitor + Grafana dashboard (gnetId 12239)
 - [ ] etcd: add dedicated ServiceMonitor for full etcd metrics (current scrape is partial via apiserver, now via Alloy)
-- [ ] **Roaming node DaemonSet problem** (high priority): Offline roaming nodes
-      (iguana/rugged) cause DaemonSet pods to stay Pending, which makes Helm
-      install/upgrade timeout. Current workaround is `disableWait: true` in
-      monitoring-stack — this is unsatisfying because it suppresses all readiness
-      checking, not just for roaming nodes. Affects every HelmRelease with a
-      DaemonSet. Need a proper solution:
-  - Option A: Taint roaming nodes + add tolerations to DaemonSets that should
-    run there (node-exporter, Cilium). DaemonSets without toleration skip roaming.
-  - Option B: `nodeAffinity` on DaemonSets to exclude `roaming` region entirely.
-  - Option C: Custom Flux health check that ignores Pending pods on NotReady nodes.
-  - `rugged` already has `NoSchedule` taint; `iguana` does not — add it.
+- [ ] **Roaming node DaemonSet problem** (high priority; recurs for any DaemonSet):
+      Offline roaming nodes (iguana/rugged) leave DaemonSet pods Pending, which
+      makes Helm `--wait` time out and blocks Flux reconciliation. Current
+      workaround: `disableWait: true` on the affected HelmReleases (monitoring-stack,
+      promtail) — unsatisfying because it suppresses all readiness checking. Full
+      options, analysis, and the long-term fix (auto-remove stale NotReady nodes):
+      <docs/plans/offline_node_daemonset_health.md>.
 - [ ] Enable roaming-tolerant workloads on rugged (`grocy`, `scanner`, `activitywatch`,
       `proxmox-proxy`, `props`/`props-registry`)
 - [ ] OpenClaw: obfuscation detection forces approval despite `security: full`

--- a/cluster/docs/plans/offline_node_daemonset_health.md
+++ b/cluster/docs/plans/offline_node_daemonset_health.md
@@ -1,5 +1,10 @@
 # Offline Nodes Block DaemonSet Health Checks
 
+> **Status (2026-06):** Option A (`disableWait`) is the live workaround — applied
+> to `monitoring/kube-prometheus-stack` and `loki/promtail` HelmReleases. Options
+> B–D remain unimplemented; the long-term fix is still Option B (auto-remove stale
+> NotReady nodes). Full options/analysis below.
+
 ## Problem
 
 The cluster includes roaming nodes (laptops) and a Proxmox CP node that are

--- a/cluster/docs/secrets.md
+++ b/cluster/docs/secrets.md
@@ -17,6 +17,11 @@ infrastructure tokens. Files in `secrets/*.yaml` contain infrastructure secrets
 
 ## Age Keys
 
+Generic SOPS rules — `.sops.yaml` path matching (encrypt in-place at the final repo
+path; `sops -e /tmp/...` fails with "no matching creation rules") and `SOPS_AGE_KEY`
+derivation from `~/.ssh/id_ed25519` — live in root `AGENTS.md` § SOPS. The
+cluster-specific keys and their storage:
+
 Defined in `.sops.yaml` creation rules:
 
 | Key                              | Purpose                                       | Storage                                                                                        |

--- a/devinfra/docs/rbe_workflows.md
+++ b/devinfra/docs/rbe_workflows.md
@@ -5,15 +5,15 @@ this repo runs on RBE. The root `AGENTS.md` rule ("RBE is the expected default �
 not disable it") holds for all of these. Full evidence and per-workflow source
 analysis: <../../debug/rbe-compatibility/audit.md>.
 
-| Workflow | Why `--remote_executor=""` is NOT needed |
-| --- | --- |
-| `bb run //devinfra:gazelle` | `bazel run` always executes the binary locally; the Gazelle Go-binary build uses RBE. |
-| `bb run //devinfra:gazelle_python_manifest.update` | Same — binary runs locally and writes the source tree. |
-| `//:requirements` | The build action runs on RBE and emits `requirements.out`; download with `--remote_download_regex` and copy it into place. |
-| `CARGO_BAZEL_REPIN=1 bazelisk build @crates//:all` | The repin is a **module extension** — module extensions always run locally on the Bazel client, never on RBE. The subsequent build actions use RBE. |
-| `update_pnpm_lock` (`pnpm-lock.yaml`) | Also a module extension — runs locally regardless. |
-| Syrupy snapshot updates | `BazelAmberExtension` copies `.ambr` files to undeclared outputs on RBE; fetch from `bazel-testlogs/.../test.outputs/` and `cp` back. `--remote_executor=""` only saves that one `cp` — a DX shortcut, never required. |
-| Normal builds/tests | RBE is the default and correct choice. |
+| Workflow                                           | Why `--remote_executor=""` is NOT needed                                                                                                                                                                               |
+| -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bb run //devinfra:gazelle`                        | `bazel run` always executes the binary locally; the Gazelle Go-binary build uses RBE.                                                                                                                                  |
+| `bb run //devinfra:gazelle_python_manifest.update` | Same — binary runs locally and writes the source tree.                                                                                                                                                                 |
+| `//:requirements`                                  | The build action runs on RBE and emits `requirements.out`; download with `--remote_download_regex` and copy it into place.                                                                                             |
+| `CARGO_BAZEL_REPIN=1 bazelisk build @crates//:all` | The repin is a **module extension** — module extensions always run locally on the Bazel client, never on RBE. The subsequent build actions use RBE.                                                                    |
+| `update_pnpm_lock` (`pnpm-lock.yaml`)              | Also a module extension — runs locally regardless.                                                                                                                                                                     |
+| Syrupy snapshot updates                            | `BazelAmberExtension` copies `.ambr` files to undeclared outputs on RBE; fetch from `bazel-testlogs/.../test.outputs/` and `cp` back. `--remote_executor=""` only saves that one `cp` — a DX shortcut, never required. |
+| Normal builds/tests                                | RBE is the default and correct choice.                                                                                                                                                                                 |
 
 Two mechanics make this hold:
 
@@ -21,7 +21,7 @@ Two mechanics make this hold:
   executes spawn actions, not repository rules — so repins and lock updates are
   local by definition; `--remote_executor=""` changes nothing about them.
 - **`bazel run` always runs the produced binary locally** (that's how it writes the
-  source tree). Its *build* still uses RBE.
+  source tree). Its _build_ still uses RBE.
 
 So the only place `--remote_executor=""` ever appears is the optional syrupy DX
 shortcut, and even there the RBE path (`BazelAmberExtension` + undeclared outputs)

--- a/devinfra/docs/rbe_workflows.md
+++ b/devinfra/docs/rbe_workflows.md
@@ -1,0 +1,28 @@
+# Why no workflow needs `--remote_executor=""`
+
+`--remote_executor=""` is **never required for correctness** — every workflow in
+this repo runs on RBE. The root `AGENTS.md` rule ("RBE is the expected default — do
+not disable it") holds for all of these. Full evidence and per-workflow source
+analysis: <../../debug/rbe-compatibility/audit.md>.
+
+| Workflow | Why `--remote_executor=""` is NOT needed |
+| --- | --- |
+| `bb run //devinfra:gazelle` | `bazel run` always executes the binary locally; the Gazelle Go-binary build uses RBE. |
+| `bb run //devinfra:gazelle_python_manifest.update` | Same — binary runs locally and writes the source tree. |
+| `//:requirements` | The build action runs on RBE and emits `requirements.out`; download with `--remote_download_regex` and copy it into place. |
+| `CARGO_BAZEL_REPIN=1 bazelisk build @crates//:all` | The repin is a **module extension** — module extensions always run locally on the Bazel client, never on RBE. The subsequent build actions use RBE. |
+| `update_pnpm_lock` (`pnpm-lock.yaml`) | Also a module extension — runs locally regardless. |
+| Syrupy snapshot updates | `BazelAmberExtension` copies `.ambr` files to undeclared outputs on RBE; fetch from `bazel-testlogs/.../test.outputs/` and `cp` back. `--remote_executor=""` only saves that one `cp` — a DX shortcut, never required. |
+| Normal builds/tests | RBE is the default and correct choice. |
+
+Two mechanics make this hold:
+
+- **Module extensions (repo rules) always run locally on the Bazel client.** RBE
+  executes spawn actions, not repository rules — so repins and lock updates are
+  local by definition; `--remote_executor=""` changes nothing about them.
+- **`bazel run` always runs the produced binary locally** (that's how it writes the
+  source tree). Its *build* still uses RBE.
+
+So the only place `--remote_executor=""` ever appears is the optional syrupy DX
+shortcut, and even there the RBE path (`BazelAmberExtension` + undeclared outputs)
+is fully functional.


### PR DESCRIPTION
Markdown-only follow-up from the \`/knowledge_hygiene\` audit (batch 3).

- **D (promote)** — new \`devinfra/docs/rbe_workflows.md\`: a per-workflow table showing why no workflow needs \`--remote_executor=""\` (gazelle, gazelle_python_manifest, requirements, cargo repin, pnpm lock, syrupy) — because module extensions run locally on the Bazel client and \`bazel run\` runs locally. Linked from root \`AGENTS.md\` "Bazel Commands". The bare rule was already in AGENTS.md + memory; this stops it being re-litigated as dogma. Evidence trail stays in \`debug/rbe-compatibility/audit.md\`.
- **K (SSOT)** — \`cluster/docs/secrets.md\` Age Keys now points up to root \`AGENTS.md\` § SOPS for the generic SOPS rules (\`.sops.yaml\` path-matching, \`SOPS_AGE_KEY\` derivation from \`~/.ssh/id_ed25519\`); keeps its cluster-specific key table. Removes the two-homes drift on a critical procedure.
- **P (reconcile)** — \`offline_node_daemonset_health.md\` gets a status banner (Option A \`disableWait\` is the live workaround, applied to monitoring-stack + promtail; long-term fix still Option B). \`cluster/docs/plan.md\`'s divergent option list for the same problem is replaced with a pointer to the dedicated plan; \`plan.md\` still tracks the problem (it recurs for any DaemonSet).

Net: 4 files modified + 1 new doc. No code changes.