### PR TITLE
Migrate OAuth callbacks to shared endpoint

### DIFF
--- a/airlock/app.py
+++ b/airlock/app.py
@@ -88,7 +88,7 @@ def create_app(settings: Settings, *, auth: AuthProvider, include_static: bool =
     @contextlib.asynccontextmanager
     async def app_lifespan(app: FastAPI):
         nonlocal oauth_providers, oauth_k8s_store, oauth_target_ns
-        oauth_providers = build_oauth_providers(settings.oauth)
+        oauth_providers = build_oauth_providers(settings.oauth, f"{settings.public_base_url}/oauth/callback")
         oauth_k8s_store = await K8sTokenStore.from_incluster(managed_by=settings.oauth.managed_by)
         oauth_target_ns = settings.oauth.target_namespace or _detect_namespace()
 

--- a/airlock/config.py
+++ b/airlock/config.py
@@ -93,12 +93,16 @@ class Settings(BaseSettings):
         return settings
 
 
-def build_oauth_providers(oauth_config: OAuthConfig) -> dict[str, GenericOAuth2Provider]:
-    """Construct OAuth provider instances from config + env vars."""
+def build_oauth_providers(oauth_config: OAuthConfig, default_redirect_uri: str) -> dict[str, GenericOAuth2Provider]:
+    """Construct OAuth provider instances from config + env vars.
+
+    `default_redirect_uri` is the shared callback URL used by any provider that does
+    not set its own (legacy) `redirect_uri`.
+    """
     providers: dict[str, GenericOAuth2Provider] = {}
     for p in oauth_config.providers:
         prefix = p.name.upper()
         client_id = os.environ[f"{prefix}_CLIENT_ID"]
         client_secret = os.environ[f"{prefix}_CLIENT_SECRET"]
-        providers[p.name] = GenericOAuth2Provider(p, client_id, client_secret)
+        providers[p.name] = GenericOAuth2Provider(p, client_id, client_secret, default_redirect_uri)
     return providers

--- a/airlock/oauth/provider.py
+++ b/airlock/oauth/provider.py
@@ -33,7 +33,11 @@ class TokenSecretConfig(BaseModel):
 class BaseProviderConfig(BaseModel):
     name: str = Field(description="Provider identifier used in URL paths and env var prefixes")
     display_name: str = Field(description="Human-readable provider name for the UI")
-    redirect_uri: str = Field(description="Redirect URI registered with the provider")
+    redirect_uri: str | None = Field(
+        default=None,
+        description="Legacy per-provider redirect URI. Omit to use the shared "
+        "{public_base_url}/oauth/callback (the provider is resolved from OAuth state).",
+    )
     refresh_secret: TokenSecretConfig = Field(description="Secret holding all token fields including refresh_token")
     access_secret: TokenSecretConfig = Field(description="Secret holding access_token, token_type, expires_at, scope")
 
@@ -76,16 +80,20 @@ class _BaseProvider:
 
 
 class GenericOAuth2Provider(_BaseProvider):
-    def __init__(self, config: OAuth2ProviderConfig, client_id: str, client_secret: str) -> None:
+    def __init__(
+        self, config: OAuth2ProviderConfig, client_id: str, client_secret: str, default_redirect_uri: str
+    ) -> None:
         self.config = config
         self.client_id = client_id
         self.client_secret = client_secret
+        # Per-provider redirect_uri is legacy; new providers omit it and share one URL.
+        self.redirect_uri = config.redirect_uri or default_redirect_uri
 
     def build_authorize_url(self, state: str, code_challenge: str | None = None) -> str:
         params = {
             "response_type": "code",
             "client_id": self.client_id,
-            "redirect_uri": self.config.redirect_uri,
+            "redirect_uri": self.redirect_uri,
             "scope": " ".join(self.config.scopes),
             "state": state,
             **self.config.extra_auth_params,
@@ -103,7 +111,7 @@ class GenericOAuth2Provider(_BaseProvider):
             "code": code,
             "client_id": self.client_id,
             "client_secret": self.client_secret,
-            "redirect_uri": self.config.redirect_uri,
+            "redirect_uri": self.redirect_uri,
         }
         if code_verifier is not None:
             data["code_verifier"] = code_verifier

--- a/airlock/oauth/routes.py
+++ b/airlock/oauth/routes.py
@@ -45,12 +45,7 @@ def create_oauth_router(
         url = provider.build_authorize_url(state, code_challenge=code_challenge)
         return RedirectResponse(url)
 
-    @router.get("/callback/{provider_name}", response_model=None)
-    async def callback_get(provider_name: str, request: Request) -> RedirectResponse:
-        provider = providers.get(provider_name)
-        if provider is None:
-            raise HTTPException(404, f"Unknown provider: {provider_name}")
-
+    async def _complete(request: Request, expected_provider: str | None) -> RedirectResponse:
         code = request.query_params.get("code")
         state_param = request.query_params.get("state")
         error = request.query_params.get("error")
@@ -60,18 +55,37 @@ def create_oauth_router(
         if not code or not state_param:
             raise HTTPException(400, "Missing code or state parameter")
 
+        # The provider is resolved from `state` (set at /authorize), so the single
+        # /oauth/callback works for every provider — no per-provider URL needed.
         pending = pending_states.pop(state_param, None)
         if pending is None:
             raise HTTPException(400, "Invalid or expired state parameter")
-        if pending.provider_name != provider_name:
+        if expected_provider is not None and pending.provider_name != expected_provider:
             raise HTTPException(400, "State/provider mismatch")
 
+        provider = providers[pending.provider_name]
         token = await provider.exchange_code(code, code_verifier=pending.code_verifier)
         await k8s_store.write_token(provider.config.refresh_secret.name, target_namespace, token)
         await k8s_store.write_token(
             provider.config.access_secret.name, target_namespace, token, fields=ACCESS_TOKEN_FIELDS
         )
-        logger.info(f"Stored tokens for {provider_name} (expires {token.expires_at})")
+        logger.info(f"Stored tokens for {pending.provider_name} (expires {token.expires_at})")
         return RedirectResponse("/#/oauth")
+
+    @router.get("/callback", response_model=None)
+    async def callback(request: Request) -> RedirectResponse:
+        """Single shared OAuth callback; the provider is resolved from `state`."""
+        return await _complete(request, expected_provider=None)
+
+    # CLEANUP(added 2026-06-29): legacy per-provider callback path, kept so providers
+    # still configured with a `/oauth/callback/<name>` redirect_uri (and the matching
+    # URI registered in their OAuth app) keep working during the migration to the shared
+    # /oauth/callback. Remove once every provider omits `redirect_uri` and the old URIs
+    # are deregistered from the OAuth apps.
+    @router.get("/callback/{provider_name}", response_model=None)
+    async def callback_legacy(provider_name: str, request: Request) -> RedirectResponse:
+        if provider_name not in providers:
+            raise HTTPException(404, f"Unknown provider: {provider_name}")
+        return await _complete(request, expected_provider=provider_name)
 
     return router

--- a/airlock/oauth/routes.py
+++ b/airlock/oauth/routes.py
@@ -83,7 +83,9 @@ def create_oauth_router(
     # migrated to the shared /oauth/callback (see config.yaml TODOs) and their old URIs
     # are deregistered from their OAuth apps.
     @router.get("/callback/{provider_name}", response_model=None)
-    async def callback_legacy(request: Request) -> RedirectResponse:
+    async def callback_legacy(provider_name: str, request: Request) -> RedirectResponse:
+        # `provider_name` is just the registered-URI path segment (kept so FastAPI matches
+        # the route); the actual provider is resolved from `state` in `_complete`.
         return await _complete(request)
 
     return router

--- a/airlock/oauth/routes.py
+++ b/airlock/oauth/routes.py
@@ -45,7 +45,7 @@ def create_oauth_router(
         url = provider.build_authorize_url(state, code_challenge=code_challenge)
         return RedirectResponse(url)
 
-    async def _complete(request: Request, expected_provider: str | None) -> RedirectResponse:
+    async def _complete(request: Request) -> RedirectResponse:
         code = request.query_params.get("code")
         state_param = request.query_params.get("state")
         error = request.query_params.get("error")
@@ -55,13 +55,12 @@ def create_oauth_router(
         if not code or not state_param:
             raise HTTPException(400, "Missing code or state parameter")
 
-        # The provider is resolved from `state` (set at /authorize), so the single
-        # /oauth/callback works for every provider — no per-provider URL needed.
+        # The provider is resolved from `state` (set at /authorize), never from the URL,
+        # so any registered redirect URI works: the shared /oauth/callback, a legacy
+        # /oauth/callback/<name>, or a provider piggybacking on another's registered URI.
         pending = pending_states.pop(state_param, None)
         if pending is None:
             raise HTTPException(400, "Invalid or expired state parameter")
-        if expected_provider is not None and pending.provider_name != expected_provider:
-            raise HTTPException(400, "State/provider mismatch")
 
         provider = providers[pending.provider_name]
         token = await provider.exchange_code(code, code_verifier=pending.code_verifier)
@@ -74,18 +73,17 @@ def create_oauth_router(
 
     @router.get("/callback", response_model=None)
     async def callback(request: Request) -> RedirectResponse:
-        """Single shared OAuth callback; the provider is resolved from `state`."""
-        return await _complete(request, expected_provider=None)
+        """Shared OAuth callback; the provider is resolved from `state`."""
+        return await _complete(request)
 
-    # CLEANUP(added 2026-06-29): legacy per-provider callback path, kept so providers
-    # still configured with a `/oauth/callback/<name>` redirect_uri (and the matching
-    # URI registered in their OAuth app) keep working during the migration to the shared
-    # /oauth/callback. Remove once every provider omits `redirect_uri` and the old URIs
-    # are deregistered from the OAuth apps.
+    # CLEANUP(added 2026-06-29): legacy per-provider callback path. The {provider_name}
+    # segment is cosmetic — it only lets already-registered /oauth/callback/<name> URIs
+    # (and providers piggybacking on one, e.g. gmail_modify on google's) keep routing
+    # here; the provider is resolved from `state`. Remove once oura/google/bsc are
+    # migrated to the shared /oauth/callback (see config.yaml TODOs) and their old URIs
+    # are deregistered from their OAuth apps.
     @router.get("/callback/{provider_name}", response_model=None)
-    async def callback_legacy(provider_name: str, request: Request) -> RedirectResponse:
-        if provider_name not in providers:
-            raise HTTPException(404, f"Unknown provider: {provider_name}")
-        return await _complete(request, expected_provider=provider_name)
+    async def callback_legacy(request: Request) -> RedirectResponse:
+        return await _complete(request)
 
     return router

--- a/airlock/oauth/test_provider.py
+++ b/airlock/oauth/test_provider.py
@@ -37,7 +37,9 @@ def provider_config() -> OAuth2ProviderConfig:
 
 @pytest.fixture
 def provider(provider_config: OAuth2ProviderConfig) -> GenericOAuth2Provider:
-    return GenericOAuth2Provider(provider_config, "test-client-id", "test-client-secret")
+    return GenericOAuth2Provider(
+        provider_config, "test-client-id", "test-client-secret", "http://localhost/oauth/callback"
+    )
 
 
 def test_build_authorize_url(provider: GenericOAuth2Provider) -> None:
@@ -54,6 +56,26 @@ def test_build_authorize_url(provider: GenericOAuth2Provider) -> None:
     assert params["state"] == ["test-state"]
 
 
+def test_explicit_redirect_uri_wins(provider: GenericOAuth2Provider) -> None:
+    params = parse_qs(urlparse(provider.build_authorize_url("st")).query)
+    assert params["redirect_uri"] == ["http://localhost:8080/callback/test"]
+
+
+def test_redirect_uri_falls_back_to_shared_default() -> None:
+    config = OAuth2ProviderConfig(
+        name="new",
+        display_name="New",
+        authorize_url="https://example.com/authorize",
+        token_url="https://example.com/token",
+        scopes=["s"],
+        refresh_secret=TokenSecretConfig(name="new-tokens"),
+        access_secret=TokenSecretConfig(name="new-access"),
+    )
+    provider = GenericOAuth2Provider(config, "id", "sec", "https://airlock.example.com/oauth/callback")
+    params = parse_qs(urlparse(provider.build_authorize_url("st")).query)
+    assert params["redirect_uri"] == ["https://airlock.example.com/oauth/callback"]
+
+
 def test_build_authorize_url_with_extra_params() -> None:
     config = OAuth2ProviderConfig(
         name="google",
@@ -66,7 +88,7 @@ def test_build_authorize_url_with_extra_params() -> None:
         access_secret=TokenSecretConfig(name="google-access-token"),
         extra_auth_params={"access_type": "offline", "prompt": "consent"},
     )
-    provider = GenericOAuth2Provider(config, "gid", "gsecret")
+    provider = GenericOAuth2Provider(config, "gid", "gsecret", "http://localhost/oauth/callback")
     url = provider.build_authorize_url("state123")
     params = parse_qs(urlparse(url).query)
 
@@ -132,7 +154,7 @@ def test_build_authorize_url_with_pkce_and_aud() -> None:
         use_pkce=True,
         aud="https://fhir.example.com/r4",
     )
-    provider = GenericOAuth2Provider(config, "cid", "csec")
+    provider = GenericOAuth2Provider(config, "cid", "csec", "http://localhost/oauth/callback")
     url = provider.build_authorize_url("st", code_challenge="CHAL")
     params = parse_qs(urlparse(url).query)
 

--- a/airlock/oauth/test_refresh.py
+++ b/airlock/oauth/test_refresh.py
@@ -33,6 +33,7 @@ def provider() -> GenericOAuth2Provider:
         ),
         client_id="test-id",
         client_secret="test-secret",
+        default_redirect_uri="https://example.com/oauth/callback",
     )
 
 

--- a/cluster/k8s/agents/airlock/config.yaml
+++ b/cluster/k8s/agents/airlock/config.yaml
@@ -31,6 +31,9 @@ oauth:
         - tag
         - session
         - spo2
+      # TODO(shared-callback): migrate to the shared /oauth/callback — register
+      # https://airlock.allegedly.works/oauth/callback on the Oura OAuth app, then drop
+      # this line. Until then the legacy /oauth/callback/<name> route serves it.
       redirect_uri: https://airlock.allegedly.works/oauth/callback/oura
       refresh_secret:
         name: oura-tokens
@@ -53,6 +56,9 @@ oauth:
         - https://www.googleapis.com/auth/spreadsheets.readonly
         - https://www.googleapis.com/auth/presentations.readonly
         - https://www.googleapis.com/auth/youtube.readonly
+      # TODO(shared-callback): migrate to the shared /oauth/callback — register
+      # https://airlock.allegedly.works/oauth/callback on this Google OAuth client, then
+      # drop this line (gmail_modify piggybacks on this URI, so migrate them together).
       redirect_uri: https://airlock.allegedly.works/oauth/callback/google
       refresh_secret:
         name: google-tokens
@@ -75,9 +81,10 @@ oauth:
       token_url: https://oauth2.googleapis.com/token
       scopes:
         - https://www.googleapis.com/auth/gmail.modify
-      # No redirect_uri → uses the shared https://airlock.allegedly.works/oauth/callback
-      # (register that one URI on the Google OAuth client). oura/google/bsc keep their
-      # legacy per-provider redirect_uri for now (back-compat).
+      # Piggyback on the `google` provider's already-registered redirect URI (same OAuth
+      # client), so gmail.modify needs NO new redirect URI in the Google console. The
+      # callback resolves the provider from OAuth `state`, not this path.
+      redirect_uri: https://airlock.allegedly.works/oauth/callback/google
       refresh_secret:
         name: gmail-modify-tokens
       access_secret:
@@ -103,6 +110,9 @@ oauth:
         - interop
         - PatientEOB
         - PatientRead
+      # TODO(shared-callback): migrate to the shared /oauth/callback — register
+      # https://airlock.allegedly.works/oauth/callback on the BSC OAuth app, then drop
+      # this line. Until then the legacy /oauth/callback/<name> route serves it.
       redirect_uri: https://airlock.allegedly.works/oauth/callback/bsc
       refresh_secret:
         name: bsc-tokens

--- a/cluster/k8s/agents/airlock/config.yaml
+++ b/cluster/k8s/agents/airlock/config.yaml
@@ -75,7 +75,9 @@ oauth:
       token_url: https://oauth2.googleapis.com/token
       scopes:
         - https://www.googleapis.com/auth/gmail.modify
-      redirect_uri: https://airlock.allegedly.works/oauth/callback/gmail_modify
+      # No redirect_uri → uses the shared https://airlock.allegedly.works/oauth/callback
+      # (register that one URI on the Google OAuth client). oura/google/bsc keep their
+      # legacy per-provider redirect_uri for now (back-compat).
       refresh_secret:
         name: gmail-modify-tokens
       access_secret:

--- a/cluster/k8s/agents/gmail-labeling/README.md
+++ b/cluster/k8s/agents/gmail-labeling/README.md
@@ -22,6 +22,10 @@ confined to the `haku/` namespace. Source + contract: <../../../../haku/gmail_la
 The pod stays in `ContainerCreating` until `gmail-modify-access-token` exists, which needs a
 one-time browser consent for the `gmail.modify` scope:
 
+0. In Google Cloud Console → Credentials → the OAuth client backing `google-client-credentials`,
+   add the redirect URI `https://airlock.allegedly.works/oauth/callback` (the shared callback;
+   `gmail_modify` sets no per-provider `redirect_uri`). One entry covers all future providers
+   on that client.
 1. Visit `https://airlock.allegedly.works/oauth/authorize/gmail_modify` and consent as the
    target Google account. Airlock's callback writes `gmail-modify-tokens` (refresh) and
    `gmail-modify-access-token` (access-only) into the `airlock` namespace; the refresh loop

--- a/cluster/k8s/agents/gmail-labeling/README.md
+++ b/cluster/k8s/agents/gmail-labeling/README.md
@@ -22,10 +22,9 @@ confined to the `haku/` namespace. Source + contract: <../../../../haku/gmail_la
 The pod stays in `ContainerCreating` until `gmail-modify-access-token` exists, which needs a
 one-time browser consent for the `gmail.modify` scope:
 
-0. In Google Cloud Console → Credentials → the OAuth client backing `google-client-credentials`,
-   add the redirect URI `https://airlock.allegedly.works/oauth/callback` (the shared callback;
-   `gmail_modify` sets no per-provider `redirect_uri`). One entry covers all future providers
-   on that client.
+0. No Google console change needed: `gmail_modify` reuses the `google` provider's
+   already-registered redirect URI (`…/oauth/callback/google`) on the same OAuth client —
+   the callback resolves the provider from OAuth `state`, not the path.
 1. Visit `https://airlock.allegedly.works/oauth/authorize/gmail_modify` and consent as the
    target Google account. Airlock's callback writes `gmail-modify-tokens` (refresh) and
    `gmail-modify-access-token` (access-only) into the `airlock` namespace; the refresh loop

--- a/devinfra/js/debundle/e2e/support.rs
+++ b/devinfra/js/debundle/e2e/support.rs
@@ -779,14 +779,7 @@ pub fn logical_module_with_note(
     members: &[Member],
     note: impl Into<String>,
 ) -> LogicalModuleEntry {
-    logical_module_entry_with_note(
-        path,
-        members,
-        &[],
-        Vec::new(),
-        None,
-        Some(note.into()),
-    )
+    logical_module_entry_with_note(path, members, &[], Vec::new(), None, Some(note.into()))
 }
 
 /// Like [`logical_module`] but also emits an `anonymous_statements:`


### PR DESCRIPTION
## Summary

Consolidates OAuth provider callbacks from per-provider URLs (`/oauth/callback/{provider_name}`) to a single shared endpoint (`/oauth/callback`). The provider is now resolved from the OAuth `state` parameter rather than the URL path, so each OAuth app needs only one registered redirect URI.

## Key changes

- **Shared callback endpoint**: new `/oauth/callback` resolves the provider from `state` (set at `/authorize`), so it works for every provider.
- **Legacy route kept for back-compat**: `/oauth/callback/{provider_name}` still routes here so already-registered per-provider URIs keep working during migration. The `{provider_name}` segment is **cosmetic** — the provider is always resolved from `state`, never the path. A `CLEANUP` tombstone marks it for removal once oura/google/bsc migrate to the shared URL.
- **Shared `_complete(request)` helper**: both routes delegate to it; it pops the pending state, resolves the provider from `state`, exchanges the code, and writes the tokens.
- **Optional per-provider `redirect_uri`**: now `str | None`; omit it to use the shared `{public_base_url}/oauth/callback`.
- **`GenericOAuth2Provider(..., default_redirect_uri)`**: providers fall back to the shared URL when no per-provider `redirect_uri` is set (`self.redirect_uri = config.redirect_uri or default_redirect_uri`).
- **`build_oauth_providers(oauth_config, default_redirect_uri)`**: threads the shared callback URL through; `app.py` passes `{public_base_url}/oauth/callback`.
- **`gmail_modify` piggybacks on `google`**: it reuses the `google` provider's already-registered redirect URI on the same OAuth client, so `gmail.modify` consent needs **no** new redirect URI in the Google console.
- **Migration TODOs**: each of oura/google/bsc carries a `TODO(shared-callback)` to register the shared URL on its OAuth app and drop the per-provider `redirect_uri`.

## Tests

- All `GenericOAuth2Provider(...)` constructions updated to pass `default_redirect_uri`.
- New: `test_explicit_redirect_uri_wins` and `test_redirect_uri_falls_back_to_shared_default`.

https://claude.ai/code/session_016f17bLNaRjCaV231QuXLKk