### PR TITLE
rustfmt: format support.rs note-helper call (unbreak devel pre-commit)

### DIFF
--- a/devinfra/js/debundle/e2e/support.rs
+++ b/devinfra/js/debundle/e2e/support.rs
@@ -779,14 +779,7 @@ pub fn logical_module_with_note(
     members: &[Member],
     note: impl Into<String>,
 ) -> LogicalModuleEntry {
-    logical_module_entry_with_note(
-        path,
-        members,
-        &[],
-        Vec::new(),
-        None,
-        Some(note.into()),
-    )
+    logical_module_entry_with_note(path, members, &[], Vec::new(), None, Some(note.into()))
 }
 
 /// Like [`logical_module`] but also emits an `anonymous_statements:`


### PR DESCRIPTION
## Why

`pub fn logical_module_with_note` (added in `0dc24f2a1`, "Round out note support test helpers") left its `logical_module_entry_with_note(...)` call expanded across multiple lines. rustfmt collapses it to a single line, so `devinfra/js/debundle/e2e/support.rs` is not rustfmt-clean on `devel`.

This makes **`pre-commit run --all-files` red on devel**, which fails the **Pre-commit** check on *every open PR* — GitHub runs that check on the PR-merge checkout, so the drift is pulled into each PR and reformatted there. (Surfaced while working on #2670, whose own changes are clean.)

## What

`rustfmt devinfra/js/debundle/e2e/support.rs` — collapses the one call. Pure formatting, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WPYQfvQ9q4NEwNwpjnYR8J)_