### PR TITLE
gmail-labeling: accept operator OAuth (Authentik) alongside Haku's static bearer on one endpoint

### DIFF
--- a/cluster/k8s/agents/gmail-labeling/README.md
+++ b/cluster/k8s/agents/gmail-labeling/README.md
@@ -5,11 +5,23 @@ confined to the `haku/` namespace. Source + contract: <../../../../haku/gmail_la
 (`SPEC.md` is the closure invariant). Deployed as a sibling MCP service (the
 `tana-mcp-ro` shape), not behind Airlock — the tool surface is safe by construction.
 
-## Credential model (two layers)
+## Credential model
 
-- **Haku → server:** static bearer `haku-gmail-labeling-token` (this dir, SOPS), reflected
-  into `haku-sandbox`. The only gate. Haku calls `https://gmail-labeling.allegedly.works/mcp`
-  with it (see `httproute.yaml`).
+Inbound `/mcp` accepts **two credentials on one endpoint** (FastMCP `MultiAuth`):
+
+- **Haku → server (static bearer):** `haku-gmail-labeling-token` (this dir, SOPS), reflected
+  into `haku-sandbox`. Haku calls `https://gmail-labeling.allegedly.works/mcp` with it (see
+  `httproute.yaml`).
+- **Operator → server (Authentik OAuth):** the `gmail-labeling-mcp` Authentik provider (app
+  restricted to agentydragon), so the operator can attach the server to claude.ai / Claude
+  Code as an OAuth connector. Provider + the `gmail-labeling-mcp-oidc` Secret are provisioned
+  by `agents/machine-access-tf` (TF: `tf/gitops/agent-machine-access`); the deployment injects
+  that Secret via an **optional** `envFrom`, so the server runs static-bearer-only until it
+  lands (Haku's path is never blocked). OAuth authenticates the _caller_; the server still
+  uses its own `gmail.modify` token below.
+
+Outbound:
+
 - **Server → Gmail:** a `gmail.modify` access token **provisioned and rotated by Airlock**.
   Airlock holds the refresh token (`gmail-modify-tokens`, airlock ns) and writes an
   access-only secret (`gmail-modify-access-token`); ESO mirrors that into this namespace

--- a/cluster/k8s/agents/gmail-labeling/deployment.yaml
+++ b/cluster/k8s/agents/gmail-labeling/deployment.yaml
@@ -7,10 +7,12 @@ metadata:
     app.kubernetes.io/name: gmail-labeling
   annotations:
     description: >-
-      Namespace-scoped Gmail label MCP server for the Haku background agent. Manages only labels under the `haku/` prefix (enforced in-process), creating/applying/ removing/renaming/deleting them. Holds the Airlock-provisioned gmail.modify access token (mounted, read-only); callers authenticate with a static bearer (haku-gmail-labeling-token, reflected into haku-sandbox). Exposed publicly via a bearer-gated HTTPRoute (gmail-labeling.allegedly.works) so Haku's Claude Code web home can reach it with fastmcp.
-    # Restart only when the bearer rotates — NOT on gmail.modify token rotation, which
-    # the server picks up by re-reading the mounted secret (google-auth refresh_handler).
-    secret.reloader.stakater.com/reload: "haku-gmail-labeling-token"
+      Namespace-scoped Gmail label MCP server for the Haku background agent. Manages only labels under the `haku/` prefix (enforced in-process), creating/applying/ removing/renaming/deleting them. Holds the Airlock-provisioned gmail.modify access token (mounted, read-only). Callers authenticate on one /mcp endpoint with EITHER a static bearer (haku-gmail-labeling-token, Haku's path) OR an Authentik OAuth flow restricted to agentydragon (gmail-labeling-mcp-oidc, for attaching to claude.ai). Exposed publicly via HTTPRoute (gmail-labeling.allegedly.works).
+    # Restart when the bearer rotates or when the operator-OAuth creds
+    # (gmail-labeling-mcp-oidc, written by agent-machine-access TF) first appear /
+    # rotate — NOT on gmail.modify token rotation, which the server picks up by
+    # re-reading the mounted secret (google-auth refresh_handler).
+    secret.reloader.stakater.com/reload: "haku-gmail-labeling-token,gmail-labeling-mcp-oidc"
 spec:
   replicas: 1
   selector:
@@ -23,6 +25,10 @@ spec:
     spec:
       automountServiceAccountToken: false
       enableServiceLinks: false
+      # fsGroup so the fastmcp-home emptyDir is writable by the container's gid —
+      # the OAuth OIDCProxy persists its state there (see FASTMCP_HOME below).
+      securityContext:
+        fsGroup: 1000
       containers:
         - name: server
           image: ghcr.io/agentydragon/gmail-labeling:devel-20260629234300-77ace87 # {"$imagepolicy": "flux-system:gmail-labeling"}
@@ -43,7 +49,20 @@ spec:
                 secretKeyRef:
                   name: haku-gmail-labeling-token
                   key: token
+            # Writable dir for the OAuth OIDCProxy's file-backed state store.
+            - name: FASTMCP_HOME
+              value: /var/lib/fastmcp
+          # Operator-OAuth config (GMAIL_LABELING_AUTHENTIK__*), provisioned by
+          # agent-machine-access TF. OPTIONAL: when the Secret is absent the server runs
+          # static-bearer-only (Haku's path is unaffected); when present, all four values
+          # arrive together and enable the Authentik OAuth flow on the same /mcp endpoint.
+          envFrom:
+            - secretRef:
+                name: gmail-labeling-mcp-oidc
+                optional: true
           volumeMounts:
+            - name: fastmcp-home
+              mountPath: /var/lib/fastmcp
             # gmail.modify access token (access_token + expires_at), written by Airlock
             # into the airlock namespace and mirrored here by ESO. Rotates in place;
             # the server re-reads it via google-auth's refresh_handler.
@@ -77,3 +96,5 @@ spec:
         - name: gmail-token
           secret:
             secretName: gmail-modify-access-token
+        - name: fastmcp-home
+          emptyDir: {}

--- a/cluster/k8s/agents/gmail-labeling/deployment.yaml
+++ b/cluster/k8s/agents/gmail-labeling/deployment.yaml
@@ -25,10 +25,6 @@ spec:
     spec:
       automountServiceAccountToken: false
       enableServiceLinks: false
-      # fsGroup so the fastmcp-home emptyDir is writable by the container's gid —
-      # the OAuth OIDCProxy persists its state there (see FASTMCP_HOME below).
-      securityContext:
-        fsGroup: 1000
       containers:
         - name: server
           image: ghcr.io/agentydragon/gmail-labeling:devel-20260629234300-77ace87 # {"$imagepolicy": "flux-system:gmail-labeling"}
@@ -49,9 +45,13 @@ spec:
                 secretKeyRef:
                   name: haku-gmail-labeling-token
                   key: token
-            # Writable dir for the OAuth OIDCProxy's file-backed state store.
-            - name: FASTMCP_HOME
-              value: /var/lib/fastmcp
+            # OAuth OIDCProxy state (DCR registrations + tokens) → Valkey, so the
+            # operator's claude.ai connector survives pod restarts. Only used when the
+            # Authentik OAuth path is active (valkey-ovh-instance.yaml); harmless otherwise.
+            - name: GMAIL_LABELING_PERSISTENCE__KIND
+              value: valkey
+            - name: GMAIL_LABELING_PERSISTENCE__HOST
+              value: gmail-labeling-valkey-ovh-master.gmail-labeling.svc.cluster.local
           # Operator-OAuth config (GMAIL_LABELING_AUTHENTIK__*), provisioned by
           # agent-machine-access TF. OPTIONAL: when the Secret is absent the server runs
           # static-bearer-only (Haku's path is unaffected); when present, all four values
@@ -61,8 +61,6 @@ spec:
                 name: gmail-labeling-mcp-oidc
                 optional: true
           volumeMounts:
-            - name: fastmcp-home
-              mountPath: /var/lib/fastmcp
             # gmail.modify access token (access_token + expires_at), written by Airlock
             # into the airlock namespace and mirrored here by ESO. Rotates in place;
             # the server re-reads it via google-auth's refresh_handler.
@@ -96,5 +94,3 @@ spec:
         - name: gmail-token
           secret:
             secretName: gmail-modify-access-token
-        - name: fastmcp-home
-          emptyDir: {}

--- a/cluster/k8s/agents/gmail-labeling/flux-kustomization.yaml
+++ b/cluster/k8s/agents/gmail-labeling/flux-kustomization.yaml
@@ -26,3 +26,4 @@ spec:
     - name: external-secrets-config # ClusterSecretStore + ESO controller
     - name: gateway # public HTTPRoute
     - name: reflector # mirrors the bearer into haku-sandbox
+    - name: valkey # RedisReplication operator (OAuth-state store for the OIDCProxy)

--- a/cluster/k8s/agents/gmail-labeling/kustomization.yaml
+++ b/cluster/k8s/agents/gmail-labeling/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - haku-gmail-labeling-token.sops.yaml
+  - valkey-ovh-instance.yaml
   - deployment.yaml
   - service.yaml
   - httproute.yaml

--- a/cluster/k8s/agents/gmail-labeling/valkey-ovh-instance.yaml
+++ b/cluster/k8s/agents/gmail-labeling/valkey-ovh-instance.yaml
@@ -1,0 +1,50 @@
+apiVersion: redis.redis.opstreelabs.in/v1beta2
+kind: RedisReplication
+metadata:
+  name: gmail-labeling-valkey-ovh
+  namespace: gmail-labeling
+  annotations:
+    description: OAuth-state store for the gmail-labeling MCP's OIDCProxy (DCR registrations + tokens), so the operator's claude.ai connector survives pod restarts.
+spec:
+  clusterSize: 2
+  kubernetesConfig:
+    image: valkey/valkey:8-alpine
+    imagePullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 128Mi
+  storage:
+    volumeClaimTemplate:
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: local-path-ovh
+        resources:
+          requests:
+            storage: 1Gi
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values: ["hil-ovh"]
+      # Soft anti-affinity off control-plane nodes (their etcd is on a rotational
+      # HDD; co-located I/O starves etcd fsync — 2026-06-28 outage).
+      # TODO(etcd-hdd-contention): proper fix tracked in cluster/docs/plan.md.
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: DoesNotExist
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app: gmail-labeling-valkey-ovh
+          topologyKey: kubernetes.io/hostname

--- a/cluster/k8s/agents/machine-access-tf/flux-kustomization.yaml
+++ b/cluster/k8s/agents/machine-access-tf/flux-kustomization.yaml
@@ -34,3 +34,5 @@ spec:
     - name: postscanmail-mcp-namespace
     # Same for plaid-mcp.
     - name: plaid-mcp-namespace
+    # TF writes gmail-labeling-mcp-oidc into the gmail-labeling namespace.
+    - name: gmail-labeling

--- a/haku/gmail_labeling/BUILD.bazel
+++ b/haku/gmail_labeling/BUILD.bazel
@@ -42,6 +42,8 @@ py_library(
     srcs = ["config.py"],
     visibility = ["//:__subpackages__"],
     deps = [
+        "//mcp_infra:persistence",
+        "//mcp_infra/authentik_auth:auth",
         "@pypi//pydantic",
         "@pypi//pydantic_settings",
     ],
@@ -58,7 +60,8 @@ py_library(
         ":models",
         ":namespace",
         "//gmail_api:service",
-        "//mcp_infra:static_bearer",
+        "//mcp_infra:persistence",
+        "//mcp_infra/authentik_auth:auth",
         "@pypi//fastmcp",
         "@pypi//pydantic",
         "@pypi//starlette",

--- a/haku/gmail_labeling/README.md
+++ b/haku/gmail_labeling/README.md
@@ -28,19 +28,36 @@ namespace check runs before any Gmail call.
 
 Environment variables, prefix `GMAIL_LABELING_`:
 
-| Var               | Default            | Meaning                                                                                   |
-| ----------------- | ------------------ | ----------------------------------------------------------------------------------------- |
-| `GMAIL_TOKEN_DIR` | required           | Dir with the Airlock-managed `gmail.modify` access token (`access_token` + `expires_at`). |
-| `ALLOWED_PREFIX`  | `haku/`            | Managed namespace; only labels under this prefix are touched.                             |
-| `STATIC_BEARER`   | unset              | If set, require `Authorization: Bearer <token>` on `/mcp`.                                |
-| `HOST` / `PORT`   | `0.0.0.0` / `8080` | Bind address.                                                                             |
+| Var                                                                                        | Default            | Meaning                                                                                                  |
+| ------------------------------------------------------------------------------------------ | ------------------ | -------------------------------------------------------------------------------------------------------- |
+| `GMAIL_TOKEN_DIR`                                                                          | required           | Dir with the Airlock-managed `gmail.modify` access token (`access_token` + `expires_at`).                |
+| `ALLOWED_PREFIX`                                                                           | `haku/`            | Managed namespace; only labels under this prefix are touched.                                            |
+| `STATIC_BEARER`                                                                            | unset              | Machine bearer for `/mcp` (Haku). Accepted alongside `AUTHENTIK__*` when both are set; sole gate if not. |
+| `AUTHENTIK__OIDC_ISSUER` (+ `__OIDC_CLIENT_ID`/`__OIDC_CLIENT_SECRET`/`__PUBLIC_BASE_URL`) | unset              | If set, also gate `/mcp` with an Authentik OAuth flow for an interactive operator (e.g. claude.ai).      |
+| `HOST` / `PORT`                                                                            | `0.0.0.0` / `8080` | Bind address.                                                                                            |
+
+## Authentication
+
+`/mcp` accepts **two credentials on one endpoint**, composed into a single FastMCP
+`MultiAuth`:
+
+- **Static bearer** (`STATIC_BEARER`) — Haku's machine path (`fastmcp call … --auth <token>`).
+- **Authentik OAuth** (`AUTHENTIK__*`) — an interactive operator (agentydragon) attaching the
+  server to claude.ai / Claude Code as an OAuth connector; the JWT is verified against
+  Authentik's JWKS, and the Authentik application restricts consent to agentydragon. Provisioned
+  in `tf/gitops/agent-machine-access`, mirroring `grocy-sf`/`manifold-mcp`.
+
+OAuth authenticates the _caller_ to use the server; the server still talks to Gmail with its
+own `gmail.modify` token (below) — not the operator's Google creds. With neither set, `/mcp` is
+unauthenticated (local/dev only).
 
 ## Credentials
 
-Two layers (see `SPEC.md`):
+Layers (see `SPEC.md`):
 
 - **Haku → this server:** a static bearer (the `tana-mcp-ro` pattern), so Haku's
-  own Google token can stay `.readonly`.
+  own Google token can stay `.readonly`. The operator may instead reach it via the
+  Authentik OAuth flow above (same endpoint).
 - **This server → Gmail:** a `gmail.modify` access token, **provisioned and rotated
   by Airlock** (the `gmail_modify` provider). Airlock holds the refresh token and writes
   an access-only secret; ESO mirrors it into the server's namespace and the server

--- a/haku/gmail_labeling/config.py
+++ b/haku/gmail_labeling/config.py
@@ -5,9 +5,12 @@ from pathlib import Path
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from mcp_infra.authentik_auth.auth import AuthentikAuthConfig
+from mcp_infra.persistence import FilePersistence, PersistenceConfig
+
 
 class Settings(BaseSettings):
-    model_config = SettingsConfigDict(env_prefix="GMAIL_LABELING_")
+    model_config = SettingsConfigDict(env_prefix="GMAIL_LABELING_", env_nested_delimiter="__")
 
     gmail_token_dir: Path = Field(
         description="Directory holding the Airlock-managed gmail.modify access token (files: access_token, expires_at), mounted from the gmail-modify-access-token secret."
@@ -18,7 +21,15 @@ class Settings(BaseSettings):
     )
     static_bearer: str | None = Field(
         default=None,
-        description="If set, require `Authorization: Bearer <token>` on /mcp. Unset means the endpoint is unauthenticated (local/dev only).",
+        description="Machine bearer for /mcp (Haku's path). Accepted alongside the Authentik OAuth flow when `authentik` is also set; the sole gate when it isn't. Unset with no `authentik` leaves /mcp unauthenticated (local/dev only).",
+    )
+    authentik: AuthentikAuthConfig | None = Field(
+        default=None,
+        description="If set, also gate /mcp with an Authentik OAuth flow (for an interactive operator, e.g. claude.ai) on the same endpoint as `static_bearer`. Loads from GMAIL_LABELING_AUTHENTIK__* (oidc_issuer/client_id/client_secret/public_base_url).",
+    )
+    persistence: PersistenceConfig = Field(
+        default=FilePersistence(),
+        description="Backend for the OAuth flow's OIDCProxy state (DCR registrations, tokens); only used when `authentik` is set.",
     )
     host: str = "0.0.0.0"
     port: int = 8080

--- a/haku/gmail_labeling/server.py
+++ b/haku/gmail_labeling/server.py
@@ -15,6 +15,7 @@ from typing import Annotated
 
 import uvicorn
 from fastmcp import FastMCP
+from fastmcp.server.auth import MultiAuth
 from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
 from pydantic import Field
 from starlette.applications import Starlette
@@ -89,21 +90,19 @@ def build_app(settings: Settings) -> Starlette:
     client = LabelClient(GmailLabelBackend(service), LabelNamespace(settings.allowed_prefix))
     mcp = build_mcp(client)
 
-    # One endpoint, up to two accepted credentials. Haku's fixed bearer is a
-    # StaticTokenVerifier; the operator's interactive OAuth (claude.ai) is the
-    # Authentik flow. When both are configured they share one MultiAuth — the
-    # static token rides as an extra verifier alongside the Authentik JWTVerifier.
-    static_verifier = (
-        StaticTokenVerifier({settings.static_bearer: {"client_id": "haku"}}) if settings.static_bearer else None
-    )
+    # One endpoint, up to two accepted credentials, always composed with FastMCP's
+    # MultiAuth. MultiAuth is asymmetric: one `server` owns the OAuth routes/metadata
+    # (the Authentik OIDCProxy) and the `verifiers` are token validators tried after
+    # it — so Haku's static bearer rides as a verifier alongside the OAuth flow (there
+    # can only be one OAuth server). With no Authentik config, the static bearer is the
+    # sole verifier and there's no OAuth flow.
+    verifiers = [StaticTokenVerifier({settings.static_bearer: {"client_id": "haku"}})] if settings.static_bearer else []
     if settings.authentik:
         mcp.auth = build_authentik_auth(
-            settings.authentik,
-            client_storage=build_client_storage(settings.persistence),
-            extra_verifiers=[static_verifier] if static_verifier else None,
+            settings.authentik, client_storage=build_client_storage(settings.persistence), extra_verifiers=verifiers
         )
-    elif static_verifier:
-        mcp.auth = static_verifier
+    elif verifiers:
+        mcp.auth = MultiAuth(verifiers=verifiers)
     else:
         logger.warning("no auth configured — /mcp is unauthenticated (local/dev only)")
 

--- a/haku/gmail_labeling/server.py
+++ b/haku/gmail_labeling/server.py
@@ -2,7 +2,9 @@
 
 The whole tool surface is closed over `allowed_prefix` (enforced in `LabelClient`),
 so the server is safe to attach to an autonomous agent without a human-in-the-loop
-gate. Cluster-internal access is gated by a static bearer (see `StaticBearerGuard`).
+gate. `/mcp` accepts two credentials on one endpoint: a static bearer (Haku's machine
+path) and, when configured, an Authentik OAuth flow (an interactive operator, e.g.
+claude.ai) — both ride one FastMCP `MultiAuth` (see `build_app`).
 """
 
 import asyncio
@@ -13,12 +15,12 @@ from typing import Annotated
 
 import uvicorn
 from fastmcp import FastMCP
+from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
 from pydantic import Field
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.routing import Mount, Route
-from starlette.types import ASGIApp
 
 from gmail_api.service import build_gmail_service_from_token_dir
 from haku.gmail_labeling.backend import GmailLabelBackend
@@ -26,7 +28,8 @@ from haku.gmail_labeling.client import LabelClient
 from haku.gmail_labeling.config import Settings
 from haku.gmail_labeling.models import Label
 from haku.gmail_labeling.namespace import LabelNamespace
-from mcp_infra.static_bearer import StaticBearerGuard
+from mcp_infra.authentik_auth.auth import build_authentik_auth
+from mcp_infra.persistence import build_client_storage
 
 logger = logging.getLogger(__name__)
 
@@ -84,17 +87,32 @@ def build_mcp(client: LabelClient) -> FastMCP:
 def build_app(settings: Settings) -> Starlette:
     service = build_gmail_service_from_token_dir(settings.gmail_token_dir)
     client = LabelClient(GmailLabelBackend(service), LabelNamespace(settings.allowed_prefix))
-    mcp_app = build_mcp(client).http_app(path="/mcp")
+    mcp = build_mcp(client)
+
+    # One endpoint, up to two accepted credentials. Haku's fixed bearer is a
+    # StaticTokenVerifier; the operator's interactive OAuth (claude.ai) is the
+    # Authentik flow. When both are configured they share one MultiAuth — the
+    # static token rides as an extra verifier alongside the Authentik JWTVerifier.
+    static_verifier = (
+        StaticTokenVerifier({settings.static_bearer: {"client_id": "haku"}}) if settings.static_bearer else None
+    )
+    if settings.authentik:
+        mcp.auth = build_authentik_auth(
+            settings.authentik,
+            client_storage=build_client_storage(settings.persistence),
+            extra_verifiers=[static_verifier] if static_verifier else None,
+        )
+    elif static_verifier:
+        mcp.auth = static_verifier
+    else:
+        logger.warning("no auth configured — /mcp is unauthenticated (local/dev only)")
+
+    mcp_app = mcp.http_app(path="/mcp")
 
     async def healthz(request: Request) -> JSONResponse:
         return JSONResponse({"ok": True})
 
-    mounted: ASGIApp = mcp_app
-    if settings.static_bearer:
-        mounted = StaticBearerGuard(mcp_app, token=settings.static_bearer)
-    else:
-        logger.warning("no static_bearer configured — /mcp is unauthenticated (local/dev only)")
-    return Starlette(routes=[Route("/healthz", healthz), Mount("/", app=mounted)], lifespan=mcp_app.lifespan)
+    return Starlette(routes=[Route("/healthz", healthz), Mount("/", app=mcp_app)], lifespan=mcp_app.lifespan)
 
 
 def main() -> None:

--- a/mcp_infra/authentik_auth/auth.py
+++ b/mcp_infra/authentik_auth/auth.py
@@ -33,7 +33,7 @@ import httpx
 from authlib.integrations.httpx_client import AsyncOAuth2Client
 from authlib.oauth2.rfc6749.wrappers import OAuth2Token
 from fastmcp.server.auth import MultiAuth
-from fastmcp.server.auth.auth import AuthProvider
+from fastmcp.server.auth.auth import AuthProvider, TokenVerifier
 from fastmcp.server.auth.oidc_proxy import OIDCProxy
 from fastmcp.server.auth.providers.jwt import JWTVerifier
 from fastmcp.server.dependencies import get_access_token
@@ -116,7 +116,11 @@ class AuthentikAuthConfig(BaseModel):
 
 
 def build_authentik_auth(
-    config: AuthentikAuthConfig, *, valid_scopes: list[str] | None = None, client_storage: Any | None = None
+    config: AuthentikAuthConfig,
+    *,
+    valid_scopes: list[str] | None = None,
+    client_storage: Any | None = None,
+    extra_verifiers: list[TokenVerifier] | None = None,
 ) -> AuthProvider:
     """Build OIDCProxy + JWTVerifier auth for an Authentik-backed MCP server.
 
@@ -132,6 +136,10 @@ def build_authentik_auth(
         client_storage: Optional ``AsyncKeyValue`` backend for OIDCProxy state
             (DCR registrations, tokens). Defaults to FastMCP's file-based
             encrypted store under ``FASTMCP_HOME``.
+        extra_verifiers: Additional ``TokenVerifier``s appended to the MultiAuth
+            after the Authentik JWTVerifier — e.g. a ``StaticTokenVerifier`` so a
+            machine caller's fixed bearer is accepted on the same endpoint as the
+            human OAuth flow. Each is tried in turn; the first to accept wins.
     """
     issuer = config.normalized_issuer()
     config_url = f"{issuer}/.well-known/openid-configuration"
@@ -161,7 +169,10 @@ def build_authentik_auth(
     for extra in config.extra_jwt_issuers:
         bare = extra.rstrip("/")
         issuers += [bare, bare + "/"]
-    return MultiAuth(server=proxy, verifiers=[JWTVerifier(jwks_uri=jwks_uri, issuer=issuers)])
+    verifiers: list[TokenVerifier] = [JWTVerifier(jwks_uri=jwks_uri, issuer=issuers)]
+    if extra_verifiers:
+        verifiers.extend(extra_verifiers)
+    return MultiAuth(server=proxy, verifiers=verifiers)
 
 
 # ── Token exchange auth ───────────────────────────────────────────────────

--- a/mcp_infra/authentik_auth/test_auth.py
+++ b/mcp_infra/authentik_auth/test_auth.py
@@ -163,6 +163,29 @@ def test_build_authentik_auth_includes_extra_jwt_issuers() -> None:
     assert "https://auth.example.com/application/o/test/" in issuer  # primary still present
 
 
+def test_build_authentik_auth_appends_extra_verifiers() -> None:
+    """extra_verifiers ride the MultiAuth after the Authentik JWTVerifier, so a
+    machine caller's StaticTokenVerifier is accepted on the same endpoint as the
+    human OAuth flow (gmail-labeling's Haku bearer + operator OAuth).
+    """
+    discovery_response = AsyncMock()
+    discovery_response.raise_for_status = lambda: discovery_response
+    discovery_response.json = lambda: {"jwks_uri": "https://auth.example.com/application/o/test/jwks/"}
+
+    sentinel = object()
+    with (
+        patch("mcp_infra.authentik_auth.auth.httpx.get", return_value=discovery_response),
+        patch("mcp_infra.authentik_auth.auth.OIDCProxy") as oidc_proxy_cls,
+        patch("mcp_infra.authentik_auth.auth.JWTVerifier") as jwt_verifier_cls,
+        patch("mcp_infra.authentik_auth.auth.MultiAuth") as multi_auth_cls,
+    ):
+        oidc_proxy_cls.return_value.client_registration_options = AsyncMock()
+        build_authentik_auth(_config(), extra_verifiers=[sentinel])
+
+    verifiers = multi_auth_cls.call_args.kwargs["verifiers"]
+    assert verifiers == [jwt_verifier_cls.return_value, sentinel]  # JWT first, extra appended
+
+
 # ── AuthentikExchangeAuth tests ───────────────────────────────────────────
 
 

--- a/tf/gitops/agent-machine-access/main.tf
+++ b/tf/gitops/agent-machine-access/main.tf
@@ -1099,3 +1099,72 @@ resource "kubernetes_secret" "haku_grocy_client_credentials" {
     password  = authentik_token.haku_grocy.key
   }
 }
+
+# --- gmail-labeling MCP (operator OAuth, same endpoint as Haku's static bearer) ---
+# The gmail-labeling MCP server (haku/gmail_labeling) accepts BOTH Haku's static bearer
+# and this Authentik OAuth flow on one endpoint (FastMCP MultiAuth). This provider lets the
+# operator attach https://gmail-labeling.allegedly.works/mcp to claude.ai / Claude Code as an
+# OAuth connector; consent is restricted to agentydragon. No proxy provider — the MCP isn't
+# behind an Authentik outpost; the server's OIDCProxy runs the user-facing OAuth dance and
+# validates the resulting JWT against this provider's JWKS.
+resource "authentik_provider_oauth2" "gmail_labeling_mcp" {
+  name               = "gmail-labeling-mcp"
+  client_id          = "gmail-labeling-mcp"
+  client_type        = "confidential"
+  authorization_flow = data.authentik_flow.implicit_consent.id
+  invalidation_flow  = data.authentik_flow.invalidation.id
+  signing_key        = data.authentik_certificate_key_pair.self_signed.id
+
+  issuer_mode                = "per_provider"
+  include_claims_in_id_token = true
+
+  property_mappings = [
+    data.authentik_property_mapping_provider_scope.openid.id,
+    data.authentik_property_mapping_provider_scope.email.id,
+    data.authentik_property_mapping_provider_scope.profile.id,
+    data.authentik_property_mapping_provider_scope.offline_access.id,
+  ]
+
+  allowed_redirect_uris = [
+    {
+      matching_mode = "strict"
+      url           = "https://gmail-labeling.allegedly.works/auth/callback"
+    },
+  ]
+}
+
+resource "authentik_application" "gmail_labeling_mcp" {
+  name              = "Gmail labeling MCP"
+  slug              = "gmail-labeling-mcp"
+  protocol_provider = authentik_provider_oauth2.gmail_labeling_mcp.id
+  meta_description  = "Operator OAuth for the haku/ gmail-labeling MCP server"
+  meta_launch_url   = "https://gmail-labeling.allegedly.works/mcp"
+}
+
+# Restrict consent to agentydragon (single-user binding, like kubectl_sandbox_cc_auto).
+resource "authentik_policy_binding" "gmail_labeling_mcp_agentydragon" {
+  target = authentik_application.gmail_labeling_mcp.uuid
+  user   = data.authentik_user.agentydragon.pk
+  order  = 0
+}
+
+# The full GMAIL_LABELING_AUTHENTIK__* env block the MCP loads. Keyed by the exact env
+# var names so the deployment can inject the whole thing via one OPTIONAL `envFrom` — when
+# this Secret is absent (provider not provisioned yet) the MCP runs static-bearer-only and
+# Haku's path is unaffected; when present, all four arrive together (no partial Authentik
+# config, which would fail validation). Non-secret values (issuer/public_base_url) are
+# co-located here for that all-or-nothing atomicity. Written into the gmail-labeling
+# namespace (machine-access-tf dependsOn gmail-labeling so it exists first).
+resource "kubernetes_secret" "gmail_labeling_mcp_oidc" {
+  metadata {
+    name      = "gmail-labeling-mcp-oidc"
+    namespace = "gmail-labeling"
+  }
+
+  data = {
+    "GMAIL_LABELING_AUTHENTIK__OIDC_ISSUER"        = "https://auth.allegedly.works/application/o/gmail-labeling-mcp/"
+    "GMAIL_LABELING_AUTHENTIK__OIDC_CLIENT_ID"     = authentik_provider_oauth2.gmail_labeling_mcp.client_id
+    "GMAIL_LABELING_AUTHENTIK__OIDC_CLIENT_SECRET" = authentik_provider_oauth2.gmail_labeling_mcp.client_secret
+    "GMAIL_LABELING_AUTHENTIK__PUBLIC_BASE_URL"    = "https://gmail-labeling.allegedly.works"
+  }
+}


### PR DESCRIPTION
## Summary

Lets the operator (agentydragon) reach the `gmail-labeling` MCP server via **Authentik OAuth** — e.g. attaching it to claude.ai / Claude Code as a connector — **on the same `/mcp` endpoint** Haku already uses with its static bearer. No facade, no second host: the server accepts *two credentials* via one FastMCP `MultiAuth`.

We can do this in-process (rather than the facade pattern manifold/tana use) because **we own the gmail-labeling server**. OAuth authenticates the *caller* to use the server; the server still talks to Gmail with its own `gmail.modify` token — not the operator's Google creds. No new blast radius (the `haku/` closure invariant is unchanged).

## Changes

**Server (`haku/gmail_labeling/` + `mcp_infra/authentik_auth/`)**
- `build_authentik_auth` gains `extra_verifiers`, appended to its `MultiAuth` after the JWTVerifier — so a `StaticTokenVerifier` (Haku's bearer) rides alongside the Authentik OAuth flow. +unit test.
- `config.py`: optional `authentik: AuthentikAuthConfig` (from `GMAIL_LABELING_AUTHENTIK__*`) + `persistence` for the OIDCProxy state store.
- `server.py`: the auth is **always composed with FastMCP's `MultiAuth`** — `build_authentik_auth(..., extra_verifiers=[static])` when OAuth is configured, else `MultiAuth(verifiers=[static])`. `MultiAuth` is asymmetric by design (one OAuth `server` that owns routes/metadata + N token `verifiers`), so the static bearer *has* to ride as a verifier alongside the OAuth flow — this is the idiomatic composition, verified against fastmcp 3.1.0. Replaces the `StaticBearerGuard` ASGI wrap. `/healthz` still bypasses.

**Authentik (`tf/gitops/agent-machine-access`)** — mirrors `grocy-sf`/`manifold-mcp`
- A `gmail-labeling-mcp` OAuth2 provider + application, **consent restricted to agentydragon** (single-user policy binding).
- The `gmail-labeling-mcp-oidc` Secret into the `gmail-labeling` namespace, holding all four `GMAIL_LABELING_AUTHENTIK__*` values (keyed by env-var name for an all-or-nothing optional `envFrom`). `machine-access-tf` now `dependsOn` `gmail-labeling`.

**Deployment (`cluster/k8s/agents/gmail-labeling`)**
- **Optional** `envFrom` the oidc Secret — when absent, the server runs static-bearer-only, so **Haku's path is never blocked** by OAuth provisioning ordering; when present, OAuth turns on.
- **OAuth-state persistence → Valkey** (`RedisReplication`, mirroring `grocy-sf`) + `ValkeyPersistence`, so the operator's claude.ai connector (OIDCProxy DCR registrations + tokens) **survives pod restarts**. `flux-kustomization` `dependsOn` the `valkey` operator.
- The OAuth callback (`/auth/callback`) is served by the same app — the existing HTTPRoute needs no change.

## Caveats

- Validated locally: `ruff`, `py_compile`, `tofu fmt`, prettier, YAML syntax. `fastmcp` isn't importable in the authoring sandbox, so the **mypy aspect in CI is the real check** on the `TokenVerifier`/`MultiAuth` shapes — both follow the canonical FastMCP 3.1.0 layout (confirmed against the on-disk source).

## Operator step after deploy

Once Flux applies the TF, the `gmail-labeling-mcp-oidc` Secret lands and the pod restarts with OAuth on. Then add `https://gmail-labeling.allegedly.works/mcp` as an OAuth MCP connector in claude.ai — consent is gated to agentydragon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)