### PR TITLE
Fix bazel-ci (debundle proptest build + gmail-labeling mypy) so images publish again

### DIFF
--- a/devinfra/js/debundle/selector_minimizer_proptest.rs
+++ b/devinfra/js/debundle/selector_minimizer_proptest.rs
@@ -457,6 +457,7 @@ proptest! {
                     export_name: format!("Export{member_index}"),
                     binding_name: binding.clone(),
                     comment: None,
+                    note: None,
                 })
                 .collect();
 

--- a/haku/gmail_labeling/server.py
+++ b/haku/gmail_labeling/server.py
@@ -16,6 +16,7 @@ from typing import Annotated
 import uvicorn
 from fastmcp import FastMCP
 from fastmcp.server.auth import MultiAuth
+from fastmcp.server.auth.auth import TokenVerifier
 from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
 from pydantic import Field
 from starlette.applications import Starlette
@@ -96,7 +97,11 @@ def build_app(settings: Settings) -> Starlette:
     # it — so Haku's static bearer rides as a verifier alongside the OAuth flow (there
     # can only be one OAuth server). With no Authentik config, the static bearer is the
     # sole verifier and there's no OAuth flow.
-    verifiers = [StaticTokenVerifier({settings.static_bearer: {"client_id": "haku"}})] if settings.static_bearer else []
+    # Annotated as list[TokenVerifier] (not the inferred list[StaticTokenVerifier]) — list
+    # is invariant, so the concrete type wouldn't satisfy MultiAuth/build_authentik_auth.
+    verifiers: list[TokenVerifier] = (
+        [StaticTokenVerifier({settings.static_bearer: {"client_id": "haku"}})] if settings.static_bearer else []
+    )
     if settings.authentik:
         mcp.auth = build_authentik_auth(
             settings.authentik, client_storage=build_client_storage(settings.persistence), extra_verifiers=verifiers


### PR DESCRIPTION
## Summary

`bazel-ci` has been red on `devel` for several PRs, and `push-images` (+ `release`) is gated on it — so **no container images have been publishing**, including the `gmail-labeling` image carrying the new OAuth/MultiAuth server code. This fixes the two build failures so bazel-ci goes green and image publishing resumes.

## The two build failures

1. **debundle** — `//devinfra/js/debundle:selector_codemod_test` fails to build with `error[E0063]: missing field 'note' in initializer of 'NameBindingMember'` at `selector_minimizer_proptest.rs:455`. A recent commit added `note: Option<String>` to the struct but missed this proptest initializer; that build failure cascades into the 10 `//devinfra/js/debundle/e2e:*` tests. Fix: add `note: None` (as its sibling `comment: None`).

2. **gmail-labeling mypy** — `//haku/gmail_labeling:server` fails the mypy aspect: `[StaticTokenVerifier(...)]` infers `list[StaticTokenVerifier]`, which list-invariance rejects where `list[TokenVerifier]` is expected (by `build_authentik_auth`'s `extra_verifiers` and `MultiAuth`'s `verifiers`). This is a regression from the MultiAuth-composition polish in #2674 — it was masked in the test summary by the debundle noise but is a real second build failure. Fix: annotate `verifiers: list[TokenVerifier]`.

## Why this matters now

The `gmail-labeling` OAuth feature (merged in #2674) can't actually go live until a fresh image publishes, which needs bazel-ci green. This PR is the unblock: debundle #1 has been blocking bazel-ci (and thus every image publish) cluster-wide; #2 is my own regression.

## Validation

Local: `rustfmt --edition 2024 --check` (clean), `ruff`, `py_compile`. The mypy fix follows list-invariance; the debundle struct has exactly the 5 fields the initializer now sets. CI is the full check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016f17bLNaRjCaV231QuXLKk)_