### PR TITLE
nix wheels: add PR-blocking imports check + fix ducktape wheel gmail_api drop

### DIFF
--- a/.github/workflows/nix-wheel-check.yml
+++ b/.github/workflows/nix-wheel-check.yml
@@ -7,6 +7,10 @@
 #
 # nix-attic-push.yml still does the full-fleet build against pinned artifacts on
 # push to devel/main; this workflow is the fast per-PR gate.
+#
+# Source of truth for pin → Bazel target + output: devinfra/ci/wheel_targets.json.
+# Keep it in sync with the wheel entries in release.yml's matrix (SYNC comment
+# there points here).
 name: Nix wheel check
 
 on:
@@ -43,61 +47,51 @@ jobs:
         with:
           sops_age_key: ${{ secrets.SOPS_AGE_KEY }}
 
-      # Build every wheel + the aiquota extension zip in one bb-remote call so
-      # RBE cache hits carry across targets. Keep the target list in sync with
-      # release.yml's matrix (below in "Assemble overrides").
+      # Derive the Bazel target list + nix package list from the SSOT.
+      - name: Compute build inputs
+        id: inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          spec=devinfra/ci/wheel_targets.json
+          bazel_targets=$(jq -r '.pins | [.[] .target] | join(" ")' "$spec")
+          nix_pkgs=$(jq -r '
+            .pins | to_entries
+              | map(select(.value.nixPackage) | ".#packages.x86_64-linux.\(.key)")
+              | join(" ")
+          ' "$spec")
+          echo "bazel_targets=$bazel_targets" >> "$GITHUB_OUTPUT"
+          echo "nix_pkgs=$nix_pkgs" >> "$GITHUB_OUTPUT"
+
+      # --remote_download_outputs=toplevel keeps only the wheel/zip files
+      # (not Bazel action intermediates) coming back from RBE — same pattern
+      # as push-images.yml.
+      # run_from_commit: actions/checkout in PR mode doesn't fetch a local
+      # `devel` ref, so bb remote's default base-branch patch sync fails with
+      # `git rev-parse devel: exit status 128`. Same rationale as bazel-ci.yml.
       - name: Build wheels from source
         uses: ./.github/actions/bb-remote
         with:
-          # --remote_download_outputs=toplevel keeps only the wheel/zip files
-          # (not Bazel action intermediates) coming back from RBE — same pattern
-          # as push-images.yml.
-          args: >-
-            build
-            //:wheel
-            //:bbr_wheel
-            //:claude_hooks_wheel
-            //:ducktape_git_hooks_wheel
-            //util:wheel
-            //gnome/gterm_theme:wheel
-            //aiquota:aiquota_wheel
-            //aiquota/gnome:aiquota_zip
-            --remote_download_outputs=toplevel
-          # actions/checkout in PR mode doesn't fetch a local `devel` ref, so bb
-          # remote's default base-branch patch-sync path fails with
-          # `git rev-parse devel: exit status 128`. run_from_commit tells the
-          # runner to check out this exact commit and skip base resolution —
-          # same rationale as bazel-ci.yml.
+          args: build ${{ steps.inputs.outputs.bazel_targets }} --remote_download_outputs=toplevel
           run_from_commit: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      # Map each mkWheel pin name -> Bazel output path, verify every artifact
-      # exists, and emit the JSON blob flake.nix's artifacts logic consumes.
-      # SYNC with the ducktape wheel family in release.yml + nix/packages/default.nix.
+      # Emit the JSON blob flake.nix's artifacts logic consumes. Verifying every
+      # expected output exists here surfaces build/output-path drift with a
+      # clear error before nix reads a missing file.
       - name: Assemble artifact overrides
         id: overrides
         shell: bash
         run: |
           set -euo pipefail
-          declare -A MAP=(
-            [ducktape]=bb-out/bazel-out/k8-fastbuild/bin/ducktape-0.1.0-py3-none-any.whl
-            [bbr]=bb-out/bazel-out/k8-fastbuild/bin/bbr-0.1.0-py3-none-any.whl
-            [claude-hooks]=bb-out/bazel-out/k8-fastbuild/bin/claude_hooks-0.1.0-py3-none-any.whl
-            [ducktape-git-hooks]=bb-out/bazel-out/k8-fastbuild/bin/ducktape_git_hooks-0.1.0-py3-none-any.whl
-            [ducktape-util]=bb-out/bazel-out/k8-fastbuild/bin/util/ducktape_util-0.1.0-py3-none-any.whl
-            [gterm-theme]=bb-out/bazel-out/k8-fastbuild/bin/gnome/gterm_theme/gterm_theme-0.1.0-py3-none-any.whl
-            [aiquota]=bb-out/bazel-out/k8-fastbuild/bin/aiquota/aiquota-0.1.0-py3-none-any.whl
-            [aiquota-extension]=bb-out/bazel-out/k8-fastbuild/bin/aiquota/gnome/aiquota.zip
-          )
           json='{}'
-          for k in "${!MAP[@]}"; do
-            f="${MAP[$k]}"
-            if [[ ! -f "$f" ]]; then
-              echo "::error::missing artifact for pin '$k' at $f"
+          while IFS=$'\t' read -r pin rel; do
+            if [[ ! -f "$rel" ]]; then
+              echo "::error::missing artifact for pin '$pin' at $rel"
               exit 1
             fi
-            abs="$(realpath "$f")"
-            json="$(jq --arg k "$k" --arg v "$abs" '. + {($k): $v}' <<<"$json")"
-          done
+            abs=$(readlink -f "$rel")
+            json=$(jq -c --arg k "$pin" --arg v "$abs" '. + {($k): $v}' <<<"$json")
+          done < <(jq -r '.pins | to_entries[] | "\(.key)\t\(.value.output)"' devinfra/ci/wheel_targets.json)
           {
             echo 'overrides<<EOF'
             echo "$json"
@@ -109,12 +103,4 @@ jobs:
       - name: Nix build + imports check
         env:
           DUCKTAPE_ARTIFACT_OVERRIDES: ${{ steps.overrides.outputs.overrides }}
-        run: >-
-          nix build --impure --no-link --print-out-paths
-          .#packages.x86_64-linux.ducktape
-          .#packages.x86_64-linux.bbr
-          .#packages.x86_64-linux.claude-hooks
-          .#packages.x86_64-linux.ducktape-git-hooks
-          .#packages.x86_64-linux.ducktape-util
-          .#packages.x86_64-linux.gterm-theme
-          .#packages.x86_64-linux.aiquota
+        run: nix build --impure --no-link --print-out-paths ${{ steps.inputs.outputs.nix_pkgs }}

--- a/.github/workflows/nix-wheel-check.yml
+++ b/.github/workflows/nix-wheel-check.yml
@@ -1,0 +1,114 @@
+# Rebuild ducktape's own Python wheels from PR source and imports-check them
+# via the flake. On PRs, DUCKTAPE_ARTIFACT_OVERRIDES (see flake.nix) swaps the
+# released pin for the freshly-Bazel-built wheel so nix's `mkWheel` imports
+# check runs against PR source — catches "wheel forgot a package" bugs like
+# gmail_api / ducktape_pkg drift in #2669 at PR time, before release.yml
+# publishes a broken wheel and sync-pins.yml rotates the pin onto it.
+#
+# nix-attic-push.yml still does the full-fleet build against pinned artifacts on
+# push to devel/main; this workflow is the fast per-PR gate.
+name: Nix wheel check
+
+on:
+  push:
+    branches: [main, devel]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: nix-wheel-check-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  GIT_REPO_DEFAULT_BRANCH: devel
+
+jobs:
+  nix-wheel-check:
+    name: Build wheels + imports check
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-nix-devtools
+        with:
+          package: citools
+
+      - uses: ./.github/actions/setup-ci-secrets
+        with:
+          sops_age_key: ${{ secrets.SOPS_AGE_KEY }}
+
+      # Build every wheel + the aiquota extension zip in one bb-remote call so
+      # RBE cache hits carry across targets. Keep the target list in sync with
+      # release.yml's matrix (below in "Assemble overrides").
+      - name: Build wheels from source
+        uses: ./.github/actions/bb-remote
+        with:
+          # --remote_download_outputs=toplevel keeps only the wheel/zip files
+          # (not Bazel action intermediates) coming back from RBE — same pattern
+          # as push-images.yml.
+          args: >-
+            build
+            //:wheel
+            //:bbr_wheel
+            //:claude_hooks_wheel
+            //:ducktape_git_hooks_wheel
+            //util:wheel
+            //gnome/gterm_theme:wheel
+            //aiquota:aiquota_wheel
+            //aiquota/gnome:aiquota_zip
+            --remote_download_outputs=toplevel
+
+      # Map each mkWheel pin name -> Bazel output path, verify every artifact
+      # exists, and emit the JSON blob flake.nix's artifacts logic consumes.
+      # SYNC with the ducktape wheel family in release.yml + nix/packages/default.nix.
+      - name: Assemble artifact overrides
+        id: overrides
+        shell: bash
+        run: |
+          set -euo pipefail
+          declare -A MAP=(
+            [ducktape]=bb-out/bazel-out/k8-fastbuild/bin/ducktape-0.1.0-py3-none-any.whl
+            [bbr]=bb-out/bazel-out/k8-fastbuild/bin/bbr-0.1.0-py3-none-any.whl
+            [claude-hooks]=bb-out/bazel-out/k8-fastbuild/bin/claude_hooks-0.1.0-py3-none-any.whl
+            [ducktape-git-hooks]=bb-out/bazel-out/k8-fastbuild/bin/ducktape_git_hooks-0.1.0-py3-none-any.whl
+            [ducktape-util]=bb-out/bazel-out/k8-fastbuild/bin/util/ducktape_util-0.1.0-py3-none-any.whl
+            [gterm-theme]=bb-out/bazel-out/k8-fastbuild/bin/gnome/gterm_theme/gterm_theme-0.1.0-py3-none-any.whl
+            [aiquota]=bb-out/bazel-out/k8-fastbuild/bin/aiquota/aiquota-0.1.0-py3-none-any.whl
+            [aiquota-extension]=bb-out/bazel-out/k8-fastbuild/bin/aiquota/gnome/aiquota.zip
+          )
+          json='{}'
+          for k in "${!MAP[@]}"; do
+            f="${MAP[$k]}"
+            if [[ ! -f "$f" ]]; then
+              echo "::error::missing artifact for pin '$k' at $f"
+              exit 1
+            fi
+            abs="$(realpath "$f")"
+            json="$(jq --arg k "$k" --arg v "$abs" '. + {($k): $v}' <<<"$json")"
+          done
+          {
+            echo 'overrides<<EOF'
+            echo "$json"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      # Drives each mkWheel's `importsCheck` (nix/packages/default.nix) against
+      # the PR-source wheel. --impure is required for the getEnv override read.
+      - name: Nix build + imports check
+        env:
+          DUCKTAPE_ARTIFACT_OVERRIDES: ${{ steps.overrides.outputs.overrides }}
+        run: >-
+          nix build --impure --no-link --print-out-paths
+          .#packages.x86_64-linux.ducktape
+          .#packages.x86_64-linux.bbr
+          .#packages.x86_64-linux.claude-hooks
+          .#packages.x86_64-linux.ducktape-git-hooks
+          .#packages.x86_64-linux.ducktape-util
+          .#packages.x86_64-linux.gterm-theme
+          .#packages.x86_64-linux.aiquota

--- a/.github/workflows/nix-wheel-check.yml
+++ b/.github/workflows/nix-wheel-check.yml
@@ -49,10 +49,12 @@ jobs:
           sops_age_key: ${{ secrets.SOPS_AGE_KEY }}
 
       # Derive the Bazel target list + nix package list from the SSOT.
-      # Filter to nixPackage entries: the non-wheel binaries (bbapi,
-      # claude-hook-rs, debundle, skills) go through mkBinaryArtifact whose
-      # nix build is a trivial install/autoPatchelfHook — bazel-ci already
-      # rebuilds them, so the PR gate skips them to keep wall-time bounded.
+      # A release is in-gate when its `nixPackage: true`; every pin in an
+      # in-gate release gets its target built and its output overridden.
+      # Non-wheel binaries (bbapi, claude-hook-rs, debundle, skills) go
+      # through mkBinaryArtifact whose nix build is a trivial install/
+      # autoPatchelfHook — bazel-ci already rebuilds them, so the PR gate
+      # skips them to keep wall-time bounded.
       - name: Compute build inputs
         id: inputs
         shell: bash
@@ -60,14 +62,15 @@ jobs:
           set -euo pipefail
           spec=devinfra/ci/artifact_targets.json
           bazel_targets=$(jq -r '
-            .pins | to_entries
-              | map(select(.value.nixPackage) | .value.target)
-              | join(" ")
+            . as $doc |
+            [$doc.pins | to_entries[] |
+               select($doc.releases[.value.release].nixPackage) |
+               .value.target] | join(" ")
           ' "$spec")
           nix_pkgs=$(jq -r '
-            .pins | to_entries
-              | map(select(.value.nixPackage) | ".#packages.x86_64-linux.\(.key)")
-              | join(" ")
+            [.releases | to_entries[] |
+               select(.value.nixPackage) |
+               ".#packages.x86_64-linux.\(.key)"] | join(" ")
           ' "$spec")
           echo "bazel_targets=$bazel_targets" >> "$GITHUB_OUTPUT"
           echo "nix_pkgs=$nix_pkgs" >> "$GITHUB_OUTPUT"
@@ -84,11 +87,11 @@ jobs:
           args: build ${{ steps.inputs.outputs.bazel_targets }} --remote_download_outputs=toplevel
           run_from_commit: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      # Emit the JSON blob flake.nix's artifacts logic consumes. Covers each
-      # nixPackage pin plus its companions (aiquota's extension zip rides on
-      # aiquota's Bazel build). Verifying every expected output exists here
-      # surfaces build/output-path drift with a clear error before nix reads
-      # a missing file.
+      # Emit the JSON blob flake.nix's artifacts logic consumes. Every pin
+      # in an in-gate release gets an override entry (so aiquota's wheel
+      # AND its extension zip both land as overrides). Verifying every
+      # expected output exists surfaces build/output-path drift with a
+      # clear error before nix reads a missing file.
       - name: Assemble artifact overrides
         id: overrides
         shell: bash
@@ -103,10 +106,10 @@ jobs:
             abs=$(readlink -f "$rel")
             json=$(jq -c --arg k "$pin" --arg v "$abs" '. + {($k): $v}' <<<"$json")
           done < <(jq -r '
-            .pins | to_entries[]
-              | select(.value.nixPackage)
-              | ( "\(.key)\t\(.value.output)",
-                  ( .value.companions // {} | to_entries[] | "\(.key)\t\(.value)" ) )
+            . as $doc |
+            $doc.pins | to_entries[] |
+            select($doc.releases[.value.release].nixPackage) |
+            "\(.key)\t\(.value.output)"
           ' devinfra/ci/artifact_targets.json)
           {
             echo 'overrides<<EOF'

--- a/.github/workflows/nix-wheel-check.yml
+++ b/.github/workflows/nix-wheel-check.yml
@@ -49,13 +49,21 @@ jobs:
           sops_age_key: ${{ secrets.SOPS_AGE_KEY }}
 
       # Derive the Bazel target list + nix package list from the SSOT.
+      # Filter to nixPackage entries: the non-wheel binaries (bbapi,
+      # claude-hook-rs, debundle, skills) go through mkBinaryArtifact whose
+      # nix build is a trivial install/autoPatchelfHook — bazel-ci already
+      # rebuilds them, so the PR gate skips them to keep wall-time bounded.
       - name: Compute build inputs
         id: inputs
         shell: bash
         run: |
           set -euo pipefail
           spec=devinfra/ci/artifact_targets.json
-          bazel_targets=$(jq -r '.pins | [.[] .target] | join(" ")' "$spec")
+          bazel_targets=$(jq -r '
+            .pins | to_entries
+              | map(select(.value.nixPackage) | .value.target)
+              | join(" ")
+          ' "$spec")
           nix_pkgs=$(jq -r '
             .pins | to_entries
               | map(select(.value.nixPackage) | ".#packages.x86_64-linux.\(.key)")
@@ -76,9 +84,11 @@ jobs:
           args: build ${{ steps.inputs.outputs.bazel_targets }} --remote_download_outputs=toplevel
           run_from_commit: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      # Emit the JSON blob flake.nix's artifacts logic consumes. Verifying every
-      # expected output exists here surfaces build/output-path drift with a
-      # clear error before nix reads a missing file.
+      # Emit the JSON blob flake.nix's artifacts logic consumes. Covers each
+      # nixPackage pin plus its companions (aiquota's extension zip rides on
+      # aiquota's Bazel build). Verifying every expected output exists here
+      # surfaces build/output-path drift with a clear error before nix reads
+      # a missing file.
       - name: Assemble artifact overrides
         id: overrides
         shell: bash
@@ -92,7 +102,12 @@ jobs:
             fi
             abs=$(readlink -f "$rel")
             json=$(jq -c --arg k "$pin" --arg v "$abs" '. + {($k): $v}' <<<"$json")
-          done < <(jq -r '.pins | to_entries[] | "\(.key)\t\(.value.output)"' devinfra/ci/artifact_targets.json)
+          done < <(jq -r '
+            .pins | to_entries[]
+              | select(.value.nixPackage)
+              | ( "\(.key)\t\(.value.output)",
+                  ( .value.companions // {} | to_entries[] | "\(.key)\t\(.value)" ) )
+          ' devinfra/ci/artifact_targets.json)
           {
             echo 'overrides<<EOF'
             echo "$json"

--- a/.github/workflows/nix-wheel-check.yml
+++ b/.github/workflows/nix-wheel-check.yml
@@ -1,16 +1,17 @@
-# Rebuild ducktape's own Python wheels from PR source and imports-check them
-# via the flake. On PRs, DUCKTAPE_ARTIFACT_OVERRIDES (see flake.nix) swaps the
-# released pin for the freshly-Bazel-built wheel so nix's `mkWheel` imports
-# check runs against PR source — catches "wheel forgot a package" bugs like
+# Rebuild ducktape's own pinned artifacts (Python wheels + aiquota's GNOME
+# Shell extension zip) from PR source and run each nix package's importsCheck
+# against them. DUCKTAPE_ARTIFACT_OVERRIDES (see flake.nix) swaps the released
+# pin for the freshly-Bazel-built artifact so nix's `mkWheel` imports check
+# runs against PR source — catches "wheel forgot a package" bugs like the
 # gmail_api / ducktape_pkg drift in #2669 at PR time, before release.yml
-# publishes a broken wheel and sync-pins.yml rotates the pin onto it.
+# publishes a broken artifact and sync-pins.yml rotates the pin onto it.
 #
 # nix-attic-push.yml still does the full-fleet build against pinned artifacts on
 # push to devel/main; this workflow is the fast per-PR gate.
 #
-# Source of truth for pin → Bazel target + output: devinfra/ci/wheel_targets.json.
-# Keep it in sync with the wheel entries in release.yml's matrix (SYNC comment
-# there points here).
+# Source of truth for pin → Bazel target + output: devinfra/ci/artifact_targets.json.
+# Keep it in sync with the artifact entries in release.yml's matrix (SYNC
+# comment there points here).
 name: Nix wheel check
 
 on:
@@ -31,7 +32,7 @@ env:
 
 jobs:
   nix-wheel-check:
-    name: Build wheels + imports check
+    name: Build artifacts + imports check
     runs-on: ubuntu-latest
     timeout-minutes: 40
     steps:
@@ -53,7 +54,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          spec=devinfra/ci/wheel_targets.json
+          spec=devinfra/ci/artifact_targets.json
           bazel_targets=$(jq -r '.pins | [.[] .target] | join(" ")' "$spec")
           nix_pkgs=$(jq -r '
             .pins | to_entries
@@ -69,7 +70,7 @@ jobs:
       # run_from_commit: actions/checkout in PR mode doesn't fetch a local
       # `devel` ref, so bb remote's default base-branch patch sync fails with
       # `git rev-parse devel: exit status 128`. Same rationale as bazel-ci.yml.
-      - name: Build wheels from source
+      - name: Build artifacts from source
         uses: ./.github/actions/bb-remote
         with:
           args: build ${{ steps.inputs.outputs.bazel_targets }} --remote_download_outputs=toplevel
@@ -91,7 +92,7 @@ jobs:
             fi
             abs=$(readlink -f "$rel")
             json=$(jq -c --arg k "$pin" --arg v "$abs" '. + {($k): $v}' <<<"$json")
-          done < <(jq -r '.pins | to_entries[] | "\(.key)\t\(.value.output)"' devinfra/ci/wheel_targets.json)
+          done < <(jq -r '.pins | to_entries[] | "\(.key)\t\(.value.output)"' devinfra/ci/artifact_targets.json)
           {
             echo 'overrides<<EOF'
             echo "$json"
@@ -99,7 +100,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       # Drives each mkWheel's `importsCheck` (nix/packages/default.nix) against
-      # the PR-source wheel. --impure is required for the getEnv override read.
+      # the PR-source artifact. --impure is required for the getEnv override read.
       - name: Nix build + imports check
         env:
           DUCKTAPE_ARTIFACT_OVERRIDES: ${{ steps.overrides.outputs.overrides }}

--- a/.github/workflows/nix-wheel-check.yml
+++ b/.github/workflows/nix-wheel-check.yml
@@ -63,6 +63,12 @@ jobs:
             //aiquota:aiquota_wheel
             //aiquota/gnome:aiquota_zip
             --remote_download_outputs=toplevel
+          # actions/checkout in PR mode doesn't fetch a local `devel` ref, so bb
+          # remote's default base-branch patch-sync path fails with
+          # `git rev-parse devel: exit status 128`. run_from_commit tells the
+          # runner to check out this exact commit and skip base resolution —
+          # same rationale as bazel-ci.yml.
+          run_from_commit: ${{ github.event.pull_request.head.sha || github.sha }}
 
       # Map each mkWheel pin name -> Bazel output path, verify every artifact
       # exists, and emit the JSON blob flake.nix's artifacts logic consumes.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,9 @@ jobs:
             target: //:wheel
             # SYNC: keep this list aligned with `packages =` in //:ducktape_pkg
             # (root BUILD.bazel) so tests cover every module the wheel ships.
+            # Also SYNC the (pkg, target, bazel_output) triples across this
+            # matrix and devinfra/ci/wheel_targets.json (the SSOT the PR-time
+            # nix-wheel-check.yml gate reads).
             tests: //agent_core/... //difftree/... //git_commit_ai/... //gmail_api/... //gmail_archiver/... //mako_utils/... //mcp_infra/... //mcp_utils/... //openai_utils/... //cluster/skills/hetzner_vnc_screenshot/... //cluster/skills/proxmox_vm/...
             bazel_output: bb-out/bazel-out/k8-fastbuild/bin/ducktape-0.1.0-py3-none-any.whl
           - pkg: aiquota

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
             # SYNC: keep this list aligned with `packages =` in //:ducktape_pkg
             # (root BUILD.bazel) so tests cover every module the wheel ships.
             # Also SYNC the (pkg, target, bazel_output) triples across this
-            # matrix and devinfra/ci/wheel_targets.json (the SSOT the PR-time
+            # matrix and devinfra/ci/artifact_targets.json (the SSOT the PR-time
             # nix-wheel-check.yml gate reads).
             tests: //agent_core/... //difftree/... //git_commit_ai/... //gmail_api/... //gmail_archiver/... //mako_utils/... //mcp_infra/... //mcp_utils/... //openai_utils/... //cluster/skills/hetzner_vnc_screenshot/... //cluster/skills/proxmox_vm/...
             bazel_output: bb-out/bazel-out/k8-fastbuild/bin/ducktape-0.1.0-py3-none-any.whl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@
 #
 # The matrix is derived from devinfra/ci/artifact_targets.json — the same SSOT
 # .github/workflows/nix-wheel-check.yml reads. See the schema note at the top
-# of that file for field semantics (target/output/tests/extraOutputs/... etc.).
+# of that file for field semantics (pins ↔ releases, primaryPin, etc.).
 name: Release
 
 on:
@@ -38,22 +38,33 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # Companions (aiquota-extension) ship on their host's release tag —
-          # they don't get their own matrix row. Every other pin does.
-          matrix=$(jq -c '{
-            include: (
-              .pins | to_entries | map({
-                pkg: .key,
-                target: .value.target,
-                bazel_output: .value.output,
-                tests: (.value.tests // ""),
-                extra_outputs: (.value.extraOutputs // ""),
-                bazel_flags: (.value.bazelFlags // ""),
-                release_metadata: ((.value.releaseMetadata // false) | tostring),
-                metadata_platform: (.value.metadataPlatform // "")
-              })
-            )
-          }' devinfra/ci/artifact_targets.json)
+          # One matrix row per release. Aggregate every pin whose
+          # `.release == <name>`: join their targets for the Bazel build,
+          # take primaryPin's output as bazel_output (release-artifact
+          # needs a single hash source for the release tag), space-join
+          # the others as extra_outputs.
+          matrix=$(jq -c '
+            . as $doc |
+            {
+              include: (
+                $doc.releases | to_entries | map(
+                  .key as $rname |
+                  .value.primaryPin as $primary |
+                  ([$doc.pins | to_entries[] | select(.value.release == $rname)]) as $ps |
+                  {
+                    pkg: $rname,
+                    target: ([$ps[] | .value.target] | join(" ")),
+                    bazel_output: ([$ps[] | select(.key == $primary) | .value.output][0]),
+                    tests: (.value.tests // ""),
+                    extra_outputs: ([$ps[] | select(.key != $primary) | .value.output] | join(" ")),
+                    bazel_flags: (.value.bazelFlags // ""),
+                    release_metadata: ((.value.releaseMetadata // false) | tostring),
+                    metadata_platform: (.value.metadataPlatform // "")
+                  }
+                )
+              )
+            }
+          ' devinfra/ci/artifact_targets.json)
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
             target: //:wheel
             # SYNC: keep this list aligned with `packages =` in //:ducktape_pkg
             # (root BUILD.bazel) so tests cover every module the wheel ships.
-            tests: //agent_core/... //difftree/... //git_commit_ai/... //gmail_archiver/... //mako_utils/... //mcp_infra/... //mcp_utils/... //openai_utils/... //cluster/skills/hetzner_vnc_screenshot/... //cluster/skills/proxmox_vm/...
+            tests: //agent_core/... //difftree/... //git_commit_ai/... //gmail_api/... //gmail_archiver/... //mako_utils/... //mcp_infra/... //mcp_utils/... //openai_utils/... //cluster/skills/hetzner_vnc_screenshot/... //cluster/skills/proxmox_vm/...
             bazel_output: bb-out/bazel-out/k8-fastbuild/bin/ducktape-0.1.0-py3-none-any.whl
           - pkg: aiquota
             target: //aiquota:aiquota_wheel //aiquota/gnome:aiquota_zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,10 @@
 # Release artifacts to GitHub via per-artifact build + gh release.
 # Each matrix entry builds its artifact on RBE, computes SHA, and creates
 # a GitHub Release if the content changed.
+#
+# The matrix is derived from devinfra/ci/artifact_targets.json — the same SSOT
+# .github/workflows/nix-wheel-check.yml reads. See the schema note at the top
+# of that file for field semantics (target/output/tests/extraOutputs/... etc.).
 name: Release
 
 on:
@@ -20,73 +24,46 @@ env:
   GIT_REPO_DEFAULT_BRANCH: devel
 
 jobs:
+  matrix:
+    name: Compute release matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      matrix: ${{ steps.gen.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v6
+      # jq is preinstalled on ubuntu-latest runners; no nix bootstrap needed
+      # here (the matrix job just parses JSON and emits a matrix.include).
+      - id: gen
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Companions (aiquota-extension) ship on their host's release tag —
+          # they don't get their own matrix row. Every other pin does.
+          matrix=$(jq -c '{
+            include: (
+              .pins | to_entries | map({
+                pkg: .key,
+                target: .value.target,
+                bazel_output: .value.output,
+                tests: (.value.tests // ""),
+                extra_outputs: (.value.extraOutputs // ""),
+                bazel_flags: (.value.bazelFlags // ""),
+                release_metadata: ((.value.releaseMetadata // false) | tostring),
+                metadata_platform: (.value.metadataPlatform // "")
+              })
+            )
+          }' devinfra/ci/artifact_targets.json)
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
   release:
+    needs: [matrix]
     name: Release ${{ matrix.pkg }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - pkg: bbr
-            target: //:bbr_wheel
-            bazel_output: bb-out/bazel-out/k8-fastbuild/bin/bbr-0.1.0-py3-none-any.whl
-            tests: //devinfra:test_bbr
-          - pkg: claude-hooks
-            target: //:claude_hooks_wheel
-            bazel_output: bb-out/bazel-out/k8-fastbuild/bin/claude_hooks-0.1.0-py3-none-any.whl
-            tests: //devinfra/claude/...
-          - pkg: ducktape-git-hooks
-            target: //:ducktape_git_hooks_wheel
-            bazel_output: bb-out/bazel-out/k8-fastbuild/bin/ducktape_git_hooks-0.1.0-py3-none-any.whl
-            tests: //devinfra/precommit/... //cluster/validation/...
-          - pkg: claude-hook-rs
-            target: //devinfra/claude/claude_hook:claude_hook
-            bazel_output: bb-out/bazel-out/k8-fastbuild/bin/devinfra/claude/claude_hook/claude_hook
-            tests: //devinfra/claude/claude_hook/...
-          - pkg: ducktape-util
-            target: //util:wheel
-            bazel_output: bb-out/bazel-out/k8-fastbuild/bin/util/ducktape_util-0.1.0-py3-none-any.whl
-            tests: //util/...
-          - pkg: ducktape
-            target: //:wheel
-            # SYNC: keep this list aligned with `packages =` in //:ducktape_pkg
-            # (root BUILD.bazel) so tests cover every module the wheel ships.
-            # Also SYNC the (pkg, target, bazel_output) triples across this
-            # matrix and devinfra/ci/artifact_targets.json (the SSOT the PR-time
-            # nix-wheel-check.yml gate reads).
-            tests: //agent_core/... //difftree/... //git_commit_ai/... //gmail_api/... //gmail_archiver/... //mako_utils/... //mcp_infra/... //mcp_utils/... //openai_utils/... //cluster/skills/hetzner_vnc_screenshot/... //cluster/skills/proxmox_vm/...
-            bazel_output: bb-out/bazel-out/k8-fastbuild/bin/ducktape-0.1.0-py3-none-any.whl
-          - pkg: aiquota
-            target: //aiquota:aiquota_wheel //aiquota/gnome:aiquota_zip
-            bazel_output: bb-out/bazel-out/k8-fastbuild/bin/aiquota/aiquota-0.1.0-py3-none-any.whl
-            extra_outputs: bb-out/bazel-out/k8-fastbuild/bin/aiquota/gnome/aiquota.zip
-            tests: //aiquota/...
-          - pkg: gterm-theme
-            target: //gnome/gterm_theme:wheel
-            bazel_output: bb-out/bazel-out/k8-fastbuild/bin/gnome/gterm_theme/gterm_theme-0.1.0-py3-none-any.whl
-            tests: ""
-          - pkg: skills
-            target: //skills:all_skills
-            bazel_output: bb-out/bazel-out/k8-fastbuild/bin/skills/all_skills.skill
-            tests: //skills/... //cluster/skills/...
-          - pkg: bbapi
-            target: //devinfra/buildbuddy_cli:bbapi
-            bazel_output: bb-out/bazel-out/k8-fastbuild/bin/devinfra/buildbuddy_cli/bbapi_/bbapi
-            tests: //devinfra/buildbuddy_cli/...
-          - pkg: debundle
-            target: //devinfra/js/debundle:debundle
-            # Ship an optimized binary: opt-level=3 LLVM optimizations,
-            # debug-assertions off. Cuts `modules propose` wall on the
-            # tana corpus from ~5 min to ~45 s (7x). Debuginfo=1 (line
-            # tables only) preserves addr2line + inlined-frame resolution
-            # for downstream perf profiling at ~5-10% size cost.
-            # See devinfra/js/debundle/perf/proposer_roadmap.md (#0).
-            bazel_flags: "-c opt --@rules_rust//:extra_rustc_flag=-Cdebuginfo=1"
-            bazel_output: bb-out/bazel-out/k8-opt/bin/devinfra/js/debundle/debundle
-            tests: //devinfra/js/debundle/...
-            release_metadata: true
-            metadata_platform: linux-amd64
+      matrix: ${{ fromJSON(needs.matrix.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -112,8 +89,8 @@ jobs:
           pkg: ${{ matrix.pkg }}
           bazel_target: ${{ matrix.target }}
           bazel_output: ${{ matrix.bazel_output }}
-          bazel_flags: ${{ matrix.bazel_flags || '' }}
-          extra_outputs: ${{ matrix.extra_outputs || '' }}
-          release_metadata: ${{ matrix.release_metadata || 'false' }}
-          metadata_platform: ${{ matrix.metadata_platform || '' }}
+          bazel_flags: ${{ matrix.bazel_flags }}
+          extra_outputs: ${{ matrix.extra_outputs }}
+          release_metadata: ${{ matrix.release_metadata }}
+          metadata_platform: ${{ matrix.metadata_platform }}
           rbe_image: ${{ inputs.rbe_image }}

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -287,6 +287,7 @@ py_package(
         "cluster.skills.proxmox_vm",
         "difftree",
         "git_commit_ai",
+        "gmail_api",
         "gmail_archiver",
         "gmail_archiver.cli",
         "gmail_archiver.planners",

--- a/devinfra/ci/README.md
+++ b/devinfra/ci/README.md
@@ -1,0 +1,71 @@
+# devinfra/ci
+
+CI-side utilities and configuration.
+
+## `artifact_targets.json`
+
+Single source of truth for Bazel targets, artifact outputs, and release
+grouping for every artifact pinned in `nix/artifact-pins.json` (except `bb`,
+which is an external buildbuddy-io binary). Consumed by:
+
+- <../../.github/workflows/release.yml> — builds + publishes each release
+  group. `matrix` job jq-transforms this file into `matrix.include`.
+- <../../.github/workflows/nix-wheel-check.yml> — the PR-time nix
+  imports-check gate. Rebuilds artifacts from PR source and feeds them into
+  `nix build .#packages.x86_64-linux.<pin>` via `DUCKTAPE_ARTIFACT_OVERRIDES`
+  (see `flake.nix`).
+
+### Schema
+
+Two tables, symmetric on pins:
+
+```text
+pins:
+  <pin_name>:
+    target:   Bazel label that produces `output`
+    output:   file path under bb-out/
+    release:  release group this pin ships in
+```
+
+Every pin corresponds 1:1 to a same-named entry in `nix/artifact-pins.json`.
+
+```text
+releases:
+  <release_name>:
+    primaryPin:        pin whose sha256 drives the release tag suffix (see below)
+    tests:             (optional) Bazel test targets to run before publishing
+    nixPackage:        (optional, default false) has a `.#packages.x86_64-linux.<release_name>`
+                       flake output the PR gate builds + imports-checks
+    bazelFlags:        (optional) extra flags passed to bazel build
+    releaseMetadata:   (optional, default false) upload a <pkg>.release.json alongside
+    metadataPlatform:  (optional) `platforms` string in that release.json
+```
+
+`primaryPin` is required because `release-artifact` (the composite action)
+hashes a single file to build the release tag suffix — from nix's point of
+view every pin in the release is equally real, but release-artifact needs
+one nominated hash source. Pick the pin most likely to change.
+
+`nixPackage: false` means release.yml still publishes it but the PR gate
+skips it — typical for binary drops (bbapi, claude-hook-rs, debundle,
+skills) whose nix package is a trivial `install`/`autoPatchelfHook`;
+bazel-ci already rebuilds them from source so the gate would be redundant.
+
+### Notes on specific entries
+
+**`debundle.bazelFlags: "-c opt --@rules_rust//:extra_rustc_flag=-Cdebuginfo=1"`**
+
+Ship an optimized binary — opt-level=3 LLVM optimizations, debug-assertions
+off. Cuts `modules propose` wall on the tana corpus from ~5 min to ~45 s
+(7x). `-Cdebuginfo=1` (line tables only) preserves addr2line + inlined-frame
+resolution for downstream perf profiling at ~5–10% size cost. See
+<../js/debundle/perf/proposer_roadmap.md> §0.
+
+**`aiquota` / `aiquota-extension`**
+
+Two pins ship on one release tag: the Python wheel and the GNOME Shell
+extension zip come out of one `bazel build //aiquota:aiquota_wheel
+//aiquota/gnome:aiquota_zip` invocation, and `nix/packages/gnome-shell-aiquota.nix`
+consumes both via `artifacts.aiquota` and `artifacts.aiquota-extension`.
+`aiquota.primaryPin: "aiquota"` — the wheel drives the tag hash — but from
+nix's POV both pins are equal.

--- a/devinfra/ci/artifact_targets.json
+++ b/devinfra/ci/artifact_targets.json
@@ -1,73 +1,120 @@
 {
-  "_comment": "Single source of truth for the Bazel targets that produce each artifact pinned in nix/artifact-pins.json. Consumed by .github/workflows/release.yml's matrix (which builds + publishes each artifact) and .github/workflows/nix-wheel-check.yml's PR-time imports-check gate (which rebuilds artifacts from PR source and feeds them into `nix build .#packages.x86_64-linux.<pin>` via DUCKTAPE_ARTIFACT_OVERRIDES). Keys are pin names from nix/artifact-pins.json. `target` is one or more space-separated Bazel labels. `output` is the primary artifact path under bb-out/. `tests` (optional) runs before releasing. `extraOutputs` (optional) uploads additional files under the same release tag. `bazelFlags`, `releaseMetadata`, `metadataPlatform` (optional) are release.yml customizations. `nixPackage: true` means the entry has a corresponding .#packages.x86_64-linux.<pin> flake output that the PR gate imports-checks; `false` means release.yml still publishes it but the PR gate skips it (typical for binary drops with no meaningful nix-side check beyond autoPatchelfHook). `companions` (optional) lists sibling artifacts that ride on this entry's release tag — no independent Bazel target, no independent nix package, but still valid override pins the PR gate consumes.",
+  "_comment": "Bazel targets, artifact outputs, and release grouping for every artifact pinned in nix/artifact-pins.json (except `bb`, which is an external buildbuddy-io binary). Single source of truth for .github/workflows/release.yml's matrix (builds + publishes each release group) and .github/workflows/nix-wheel-check.yml's PR-time imports-check gate.\n\nSchema:\n  pins: pin_name -> { target, output, release }\n    Every pin here corresponds 1:1 to a same-named entry in nix/artifact-pins.json. `target` is the Bazel label that produces `output` on RBE. `release` back-points to the release group this pin ships in.\n\n  releases: release_name -> { primaryPin, tests?, nixPackage?, bazelFlags?, releaseMetadata?, metadataPlatform? }\n    Each release entry becomes one release.yml matrix row + one gh-release call + one release tag. `primaryPin` names the pin whose sha256 drives the tag suffix — release-artifact needs a single hash source, so we pick one; from nix's point of view every pin in the release is equally real. `tests` runs before publishing. `nixPackage: true` means the release has a corresponding .#packages.x86_64-linux.<release_name> flake output that the PR gate builds + imports-checks against PR-source artifacts (every pin in the release gets its output overridden). `false` means release.yml still publishes it but the PR gate skips it — typical for binary drops (bbapi/claude-hook-rs/debundle/skills) whose nix package is a trivial install/autoPatchelfHook that bazel-ci already covers. `bazelFlags`, `releaseMetadata`, `metadataPlatform` are per-entry release.yml overrides.",
   "pins": {
     "ducktape": {
       "target": "//:wheel",
       "output": "bb-out/bazel-out/k8-fastbuild/bin/ducktape-0.1.0-py3-none-any.whl",
-      "tests": "//agent_core/... //difftree/... //git_commit_ai/... //gmail_api/... //gmail_archiver/... //mako_utils/... //mcp_infra/... //mcp_utils/... //openai_utils/... //cluster/skills/hetzner_vnc_screenshot/... //cluster/skills/proxmox_vm/...",
-      "nixPackage": true
+      "release": "ducktape"
     },
     "bbr": {
       "target": "//:bbr_wheel",
       "output": "bb-out/bazel-out/k8-fastbuild/bin/bbr-0.1.0-py3-none-any.whl",
-      "tests": "//devinfra:test_bbr",
-      "nixPackage": true
+      "release": "bbr"
     },
     "claude-hooks": {
       "target": "//:claude_hooks_wheel",
       "output": "bb-out/bazel-out/k8-fastbuild/bin/claude_hooks-0.1.0-py3-none-any.whl",
-      "tests": "//devinfra/claude/...",
-      "nixPackage": true
+      "release": "claude-hooks"
     },
     "ducktape-git-hooks": {
       "target": "//:ducktape_git_hooks_wheel",
       "output": "bb-out/bazel-out/k8-fastbuild/bin/ducktape_git_hooks-0.1.0-py3-none-any.whl",
-      "tests": "//devinfra/precommit/... //cluster/validation/...",
-      "nixPackage": true
+      "release": "ducktape-git-hooks"
     },
     "ducktape-util": {
       "target": "//util:wheel",
       "output": "bb-out/bazel-out/k8-fastbuild/bin/util/ducktape_util-0.1.0-py3-none-any.whl",
-      "tests": "//util/...",
-      "nixPackage": true
+      "release": "ducktape-util"
     },
     "gterm-theme": {
       "target": "//gnome/gterm_theme:wheel",
       "output": "bb-out/bazel-out/k8-fastbuild/bin/gnome/gterm_theme/gterm_theme-0.1.0-py3-none-any.whl",
-      "tests": "",
-      "nixPackage": true
+      "release": "gterm-theme"
     },
     "aiquota": {
-      "target": "//aiquota:aiquota_wheel //aiquota/gnome:aiquota_zip",
+      "target": "//aiquota:aiquota_wheel",
       "output": "bb-out/bazel-out/k8-fastbuild/bin/aiquota/aiquota-0.1.0-py3-none-any.whl",
-      "extraOutputs": "bb-out/bazel-out/k8-fastbuild/bin/aiquota/gnome/aiquota.zip",
-      "tests": "//aiquota/...",
-      "nixPackage": true,
-      "companions": {
-        "aiquota-extension": "bb-out/bazel-out/k8-fastbuild/bin/aiquota/gnome/aiquota.zip"
-      }
+      "release": "aiquota"
+    },
+    "aiquota-extension": {
+      "target": "//aiquota/gnome:aiquota_zip",
+      "output": "bb-out/bazel-out/k8-fastbuild/bin/aiquota/gnome/aiquota.zip",
+      "release": "aiquota"
     },
     "skills": {
       "target": "//skills:all_skills",
       "output": "bb-out/bazel-out/k8-fastbuild/bin/skills/all_skills.skill",
-      "tests": "//skills/... //cluster/skills/...",
-      "nixPackage": false
+      "release": "skills"
     },
     "bbapi": {
       "target": "//devinfra/buildbuddy_cli:bbapi",
       "output": "bb-out/bazel-out/k8-fastbuild/bin/devinfra/buildbuddy_cli/bbapi_/bbapi",
-      "tests": "//devinfra/buildbuddy_cli/...",
-      "nixPackage": false
+      "release": "bbapi"
     },
     "claude-hook-rs": {
       "target": "//devinfra/claude/claude_hook:claude_hook",
       "output": "bb-out/bazel-out/k8-fastbuild/bin/devinfra/claude/claude_hook/claude_hook",
-      "tests": "//devinfra/claude/claude_hook/...",
-      "nixPackage": false
+      "release": "claude-hook-rs"
     },
     "debundle": {
       "target": "//devinfra/js/debundle:debundle",
       "output": "bb-out/bazel-out/k8-opt/bin/devinfra/js/debundle/debundle",
+      "release": "debundle"
+    }
+  },
+  "releases": {
+    "ducktape": {
+      "primaryPin": "ducktape",
+      "tests": "//agent_core/... //difftree/... //git_commit_ai/... //gmail_api/... //gmail_archiver/... //mako_utils/... //mcp_infra/... //mcp_utils/... //openai_utils/... //cluster/skills/hetzner_vnc_screenshot/... //cluster/skills/proxmox_vm/...",
+      "nixPackage": true
+    },
+    "bbr": {
+      "primaryPin": "bbr",
+      "tests": "//devinfra:test_bbr",
+      "nixPackage": true
+    },
+    "claude-hooks": {
+      "primaryPin": "claude-hooks",
+      "tests": "//devinfra/claude/...",
+      "nixPackage": true
+    },
+    "ducktape-git-hooks": {
+      "primaryPin": "ducktape-git-hooks",
+      "tests": "//devinfra/precommit/... //cluster/validation/...",
+      "nixPackage": true
+    },
+    "ducktape-util": {
+      "primaryPin": "ducktape-util",
+      "tests": "//util/...",
+      "nixPackage": true
+    },
+    "gterm-theme": {
+      "primaryPin": "gterm-theme",
+      "tests": "",
+      "nixPackage": true
+    },
+    "aiquota": {
+      "primaryPin": "aiquota",
+      "tests": "//aiquota/...",
+      "nixPackage": true
+    },
+    "skills": {
+      "primaryPin": "skills",
+      "tests": "//skills/... //cluster/skills/...",
+      "nixPackage": false
+    },
+    "bbapi": {
+      "primaryPin": "bbapi",
+      "tests": "//devinfra/buildbuddy_cli/...",
+      "nixPackage": false
+    },
+    "claude-hook-rs": {
+      "primaryPin": "claude-hook-rs",
+      "tests": "//devinfra/claude/claude_hook/...",
+      "nixPackage": false
+    },
+    "debundle": {
+      "primaryPin": "debundle",
       "tests": "//devinfra/js/debundle/...",
       "bazelFlags": "-c opt --@rules_rust//:extra_rustc_flag=-Cdebuginfo=1",
       "_bazelFlagsRationale": "Ship an optimized binary: opt-level=3 LLVM optimizations, debug-assertions off. Cuts `modules propose` wall on the tana corpus from ~5 min to ~45 s (7x). Debuginfo=1 (line tables only) preserves addr2line + inlined-frame resolution for downstream perf profiling at ~5-10% size cost. See devinfra/js/debundle/perf/proposer_roadmap.md (#0).",

--- a/devinfra/ci/artifact_targets.json
+++ b/devinfra/ci/artifact_targets.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "Bazel targets, artifact outputs, and release grouping for every artifact pinned in nix/artifact-pins.json (except `bb`, which is an external buildbuddy-io binary). Single source of truth for .github/workflows/release.yml's matrix (builds + publishes each release group) and .github/workflows/nix-wheel-check.yml's PR-time imports-check gate.\n\nSchema:\n  pins: pin_name -> { target, output, release }\n    Every pin here corresponds 1:1 to a same-named entry in nix/artifact-pins.json. `target` is the Bazel label that produces `output` on RBE. `release` back-points to the release group this pin ships in.\n\n  releases: release_name -> { primaryPin, tests?, nixPackage?, bazelFlags?, releaseMetadata?, metadataPlatform? }\n    Each release entry becomes one release.yml matrix row + one gh-release call + one release tag. `primaryPin` names the pin whose sha256 drives the tag suffix — release-artifact needs a single hash source, so we pick one; from nix's point of view every pin in the release is equally real. `tests` runs before publishing. `nixPackage: true` means the release has a corresponding .#packages.x86_64-linux.<release_name> flake output that the PR gate builds + imports-checks against PR-source artifacts (every pin in the release gets its output overridden). `false` means release.yml still publishes it but the PR gate skips it — typical for binary drops (bbapi/claude-hook-rs/debundle/skills) whose nix package is a trivial install/autoPatchelfHook that bazel-ci already covers. `bazelFlags`, `releaseMetadata`, `metadataPlatform` are per-entry release.yml overrides.",
   "pins": {
     "ducktape": {
       "target": "//:wheel",
@@ -117,7 +116,6 @@
       "primaryPin": "debundle",
       "tests": "//devinfra/js/debundle/...",
       "bazelFlags": "-c opt --@rules_rust//:extra_rustc_flag=-Cdebuginfo=1",
-      "_bazelFlagsRationale": "Ship an optimized binary: opt-level=3 LLVM optimizations, debug-assertions off. Cuts `modules propose` wall on the tana corpus from ~5 min to ~45 s (7x). Debuginfo=1 (line tables only) preserves addr2line + inlined-frame resolution for downstream perf profiling at ~5-10% size cost. See devinfra/js/debundle/perf/proposer_roadmap.md (#0).",
       "releaseMetadata": true,
       "metadataPlatform": "linux-amd64",
       "nixPackage": false

--- a/devinfra/ci/artifact_targets.json
+++ b/devinfra/ci/artifact_targets.json
@@ -1,44 +1,78 @@
 {
-  "_comment": "Bazel targets that produce the artifacts nix/artifact-pins.json pins, consumed by .github/workflows/nix-wheel-check.yml (the PR-time nix imports-check gate). Keys are pin names from nix/artifact-pins.json. `target` and `output` mirror the entries in .github/workflows/release.yml's matrix. `nixPackage: true` means the entry has a corresponding .#packages.x86_64-linux.<pin> flake output to build; `false` means it is a companion artifact (e.g. aiquota's GNOME Shell extension zip) that only gets consumed as an override into another package.",
+  "_comment": "Single source of truth for the Bazel targets that produce each artifact pinned in nix/artifact-pins.json. Consumed by .github/workflows/release.yml's matrix (which builds + publishes each artifact) and .github/workflows/nix-wheel-check.yml's PR-time imports-check gate (which rebuilds artifacts from PR source and feeds them into `nix build .#packages.x86_64-linux.<pin>` via DUCKTAPE_ARTIFACT_OVERRIDES). Keys are pin names from nix/artifact-pins.json. `target` is one or more space-separated Bazel labels. `output` is the primary artifact path under bb-out/. `tests` (optional) runs before releasing. `extraOutputs` (optional) uploads additional files under the same release tag. `bazelFlags`, `releaseMetadata`, `metadataPlatform` (optional) are release.yml customizations. `nixPackage: true` means the entry has a corresponding .#packages.x86_64-linux.<pin> flake output that the PR gate imports-checks; `false` means release.yml still publishes it but the PR gate skips it (typical for binary drops with no meaningful nix-side check beyond autoPatchelfHook). `companions` (optional) lists sibling artifacts that ride on this entry's release tag — no independent Bazel target, no independent nix package, but still valid override pins the PR gate consumes.",
   "pins": {
     "ducktape": {
       "target": "//:wheel",
       "output": "bb-out/bazel-out/k8-fastbuild/bin/ducktape-0.1.0-py3-none-any.whl",
+      "tests": "//agent_core/... //difftree/... //git_commit_ai/... //gmail_api/... //gmail_archiver/... //mako_utils/... //mcp_infra/... //mcp_utils/... //openai_utils/... //cluster/skills/hetzner_vnc_screenshot/... //cluster/skills/proxmox_vm/...",
       "nixPackage": true
     },
     "bbr": {
       "target": "//:bbr_wheel",
       "output": "bb-out/bazel-out/k8-fastbuild/bin/bbr-0.1.0-py3-none-any.whl",
+      "tests": "//devinfra:test_bbr",
       "nixPackage": true
     },
     "claude-hooks": {
       "target": "//:claude_hooks_wheel",
       "output": "bb-out/bazel-out/k8-fastbuild/bin/claude_hooks-0.1.0-py3-none-any.whl",
+      "tests": "//devinfra/claude/...",
       "nixPackage": true
     },
     "ducktape-git-hooks": {
       "target": "//:ducktape_git_hooks_wheel",
       "output": "bb-out/bazel-out/k8-fastbuild/bin/ducktape_git_hooks-0.1.0-py3-none-any.whl",
+      "tests": "//devinfra/precommit/... //cluster/validation/...",
       "nixPackage": true
     },
     "ducktape-util": {
       "target": "//util:wheel",
       "output": "bb-out/bazel-out/k8-fastbuild/bin/util/ducktape_util-0.1.0-py3-none-any.whl",
+      "tests": "//util/...",
       "nixPackage": true
     },
     "gterm-theme": {
       "target": "//gnome/gterm_theme:wheel",
       "output": "bb-out/bazel-out/k8-fastbuild/bin/gnome/gterm_theme/gterm_theme-0.1.0-py3-none-any.whl",
+      "tests": "",
       "nixPackage": true
     },
     "aiquota": {
-      "target": "//aiquota:aiquota_wheel",
+      "target": "//aiquota:aiquota_wheel //aiquota/gnome:aiquota_zip",
       "output": "bb-out/bazel-out/k8-fastbuild/bin/aiquota/aiquota-0.1.0-py3-none-any.whl",
-      "nixPackage": true
+      "extraOutputs": "bb-out/bazel-out/k8-fastbuild/bin/aiquota/gnome/aiquota.zip",
+      "tests": "//aiquota/...",
+      "nixPackage": true,
+      "companions": {
+        "aiquota-extension": "bb-out/bazel-out/k8-fastbuild/bin/aiquota/gnome/aiquota.zip"
+      }
     },
-    "aiquota-extension": {
-      "target": "//aiquota/gnome:aiquota_zip",
-      "output": "bb-out/bazel-out/k8-fastbuild/bin/aiquota/gnome/aiquota.zip",
+    "skills": {
+      "target": "//skills:all_skills",
+      "output": "bb-out/bazel-out/k8-fastbuild/bin/skills/all_skills.skill",
+      "tests": "//skills/... //cluster/skills/...",
+      "nixPackage": false
+    },
+    "bbapi": {
+      "target": "//devinfra/buildbuddy_cli:bbapi",
+      "output": "bb-out/bazel-out/k8-fastbuild/bin/devinfra/buildbuddy_cli/bbapi_/bbapi",
+      "tests": "//devinfra/buildbuddy_cli/...",
+      "nixPackage": false
+    },
+    "claude-hook-rs": {
+      "target": "//devinfra/claude/claude_hook:claude_hook",
+      "output": "bb-out/bazel-out/k8-fastbuild/bin/devinfra/claude/claude_hook/claude_hook",
+      "tests": "//devinfra/claude/claude_hook/...",
+      "nixPackage": false
+    },
+    "debundle": {
+      "target": "//devinfra/js/debundle:debundle",
+      "output": "bb-out/bazel-out/k8-opt/bin/devinfra/js/debundle/debundle",
+      "tests": "//devinfra/js/debundle/...",
+      "bazelFlags": "-c opt --@rules_rust//:extra_rustc_flag=-Cdebuginfo=1",
+      "_bazelFlagsRationale": "Ship an optimized binary: opt-level=3 LLVM optimizations, debug-assertions off. Cuts `modules propose` wall on the tana corpus from ~5 min to ~45 s (7x). Debuginfo=1 (line tables only) preserves addr2line + inlined-frame resolution for downstream perf profiling at ~5-10% size cost. See devinfra/js/debundle/perf/proposer_roadmap.md (#0).",
+      "releaseMetadata": true,
+      "metadataPlatform": "linux-amd64",
       "nixPackage": false
     }
   }

--- a/devinfra/ci/artifact_targets.json
+++ b/devinfra/ci/artifact_targets.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Bazel wheel targets consumed by .github/workflows/nix-wheel-check.yml (the PR-time nix imports-check gate). Keys are pin names from nix/artifact-pins.json. `target` and `output` mirror the wheel entries in .github/workflows/release.yml's matrix. `nixPackage: true` means the entry has a corresponding .#packages.x86_64-linux.<pin> flake output to imports-check; `false` means it is a companion artifact (e.g. aiquota's extension zip) that only gets consumed as an override.",
+  "_comment": "Bazel targets that produce the artifacts nix/artifact-pins.json pins, consumed by .github/workflows/nix-wheel-check.yml (the PR-time nix imports-check gate). Keys are pin names from nix/artifact-pins.json. `target` and `output` mirror the entries in .github/workflows/release.yml's matrix. `nixPackage: true` means the entry has a corresponding .#packages.x86_64-linux.<pin> flake output to build; `false` means it is a companion artifact (e.g. aiquota's GNOME Shell extension zip) that only gets consumed as an override into another package.",
   "pins": {
     "ducktape": {
       "target": "//:wheel",

--- a/devinfra/ci/wheel_targets.json
+++ b/devinfra/ci/wheel_targets.json
@@ -1,0 +1,45 @@
+{
+  "_comment": "Bazel wheel targets consumed by .github/workflows/nix-wheel-check.yml (the PR-time nix imports-check gate). Keys are pin names from nix/artifact-pins.json. `target` and `output` mirror the wheel entries in .github/workflows/release.yml's matrix. `nixPackage: true` means the entry has a corresponding .#packages.x86_64-linux.<pin> flake output to imports-check; `false` means it is a companion artifact (e.g. aiquota's extension zip) that only gets consumed as an override.",
+  "pins": {
+    "ducktape": {
+      "target": "//:wheel",
+      "output": "bb-out/bazel-out/k8-fastbuild/bin/ducktape-0.1.0-py3-none-any.whl",
+      "nixPackage": true
+    },
+    "bbr": {
+      "target": "//:bbr_wheel",
+      "output": "bb-out/bazel-out/k8-fastbuild/bin/bbr-0.1.0-py3-none-any.whl",
+      "nixPackage": true
+    },
+    "claude-hooks": {
+      "target": "//:claude_hooks_wheel",
+      "output": "bb-out/bazel-out/k8-fastbuild/bin/claude_hooks-0.1.0-py3-none-any.whl",
+      "nixPackage": true
+    },
+    "ducktape-git-hooks": {
+      "target": "//:ducktape_git_hooks_wheel",
+      "output": "bb-out/bazel-out/k8-fastbuild/bin/ducktape_git_hooks-0.1.0-py3-none-any.whl",
+      "nixPackage": true
+    },
+    "ducktape-util": {
+      "target": "//util:wheel",
+      "output": "bb-out/bazel-out/k8-fastbuild/bin/util/ducktape_util-0.1.0-py3-none-any.whl",
+      "nixPackage": true
+    },
+    "gterm-theme": {
+      "target": "//gnome/gterm_theme:wheel",
+      "output": "bb-out/bazel-out/k8-fastbuild/bin/gnome/gterm_theme/gterm_theme-0.1.0-py3-none-any.whl",
+      "nixPackage": true
+    },
+    "aiquota": {
+      "target": "//aiquota:aiquota_wheel",
+      "output": "bb-out/bazel-out/k8-fastbuild/bin/aiquota/aiquota-0.1.0-py3-none-any.whl",
+      "nixPackage": true
+    },
+    "aiquota-extension": {
+      "target": "//aiquota/gnome:aiquota_zip",
+      "output": "bb-out/bazel-out/k8-fastbuild/bin/aiquota/gnome/aiquota.zip",
+      "nixPackage": false
+    }
+  }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -74,16 +74,32 @@
       # Use Nixpkgs fetchurl derivations, not builtins.fetchurl: hosts behind
       # restricted egress can substitute these fixed-output paths from Attic
       # instead of doing evaluator-time downloads from GitHub Releases.
+      #
+      # PR-time override: DUCKTAPE_ARTIFACT_OVERRIDES (JSON object of pin
+      # name -> absolute file path) swaps the fetched wheel for a local one.
+      # Set by .github/workflows/nix-wheel-check.yml so the imports check runs
+      # against the PR's freshly-built wheel instead of the last released pin —
+      # that is what catches "wheel forgot a package" regressions like the
+      # gmail_api / ducktape_pkg drift in #2669. Requires --impure (getEnv).
+      # Empty in normal use; behaviour is identical to the pre-override flake.
       artifacts =
         let
           data = builtins.fromJSON (builtins.readFile ./nix/artifact-pins.json);
+          rawOverrides = builtins.getEnv "DUCKTAPE_ARTIFACT_OVERRIDES";
+          overrides = if rawOverrides == "" then { } else builtins.fromJSON rawOverrides;
         in
         builtins.mapAttrs (
-          _: spec:
-          pkgs.fetchurl {
-            inherit (spec) url;
-            hash = "sha256-${spec.sha256}";
-          }
+          name: spec:
+          if overrides ? ${name} then
+            builtins.path {
+              path = /. + overrides.${name};
+              name = "ducktape-artifact-${name}";
+            }
+          else
+            pkgs.fetchurl {
+              inherit (spec) url;
+              hash = "sha256-${spec.sha256}";
+            }
         ) data.pins;
 
       # all_skills.skill (a zip) unpacked into a flat directory of skill subdirs.

--- a/flake.nix
+++ b/flake.nix
@@ -91,9 +91,13 @@
         builtins.mapAttrs (
           name: spec:
           if overrides ? ${name} then
+            # Preserve the URL's basename so consumers that read the store
+            # path's suffix (aiquota's buildPythonApplication glob for *.whl,
+            # extension-zip unzip) work identically to the fetchurl path.
+            # renameWheel-based mkWheel callers are agnostic to this name.
             builtins.path {
               path = /. + overrides.${name};
-              name = "ducktape-artifact-${name}";
+              name = baseNameOf spec.url;
             }
           else
             pkgs.fetchurl {


### PR DESCRIPTION
## Why

#2669 added `gmail_api/` and refactored `gmail_archiver` to import from it, but `ducktape_pkg.packages` in root `BUILD.bazel` wasn't extended — `py_package.packages` is a prefix filter, so `gmail_api/*.py` silently gets dropped from the wheel `release.yml` publishes. `release.yml` runs no imports check on the wheel it publishes, so the failure only surfaced after `sync-pins.yml` rotated the pin (8ec6977) and the next `nix-attic-push` on devel tripped `mkWheel`'s `importsCheck`:

```
File ".../gmail_archiver/main.py", line 19, in <module>
    from gmail_api.labels import SystemLabel
ModuleNotFoundError: No module named 'gmail_api'
```

Reproduced locally with `nix build --impure .#packages.x86_64-linux.ducktape`.

## What

**Fix the immediate breakage:**

- `BUILD.bazel`: add `gmail_api` to `ducktape_pkg.packages`.
- `.github/workflows/release.yml`: add `//gmail_api/...` to the ducktape matrix's tests list (matching the SYNC comment that already keeps that list aligned with `ducktape_pkg.packages`).

**Turn nix wheel builds into a PR gate so the same class of drift can't recur:**

- `flake.nix`: `artifacts` now consults an optional `DUCKTAPE_ARTIFACT_OVERRIDES` env var (JSON of pin-name → absolute path) to swap fetched wheels for local ones. No-op when unset — `builtins.getEnv` returns `""` in pure mode, so every existing caller (`nix profile install .#devtools`, `home-manager switch --flake .#…`, `nixos-rebuild`, `nix build .#bazel-test-docker`) evaluates identically to before.
- `.github/workflows/nix-wheel-check.yml` (new, `on: pull_request` + push to devel/main): `bbr build`s every ducktape wheel from source (with `--remote_download_outputs=toplevel` so only the `.whl`/`.zip` come back), assembles the override JSON, then runs `nix build --impure .#packages.x86_64-linux.<wheel...>`. That drives each `mkWheel`'s `importsCheck` against the PR's freshly-built wheel instead of the last released pin. This is what would have caught #2669 pre-merge.

`nix-attic-push.yml` continues to do the full flake-fleet build against pinned artifacts on push to devel/main.

## Follow-up (owner action)

Flip the new `Nix wheel check` to a required status check in the branch protection rules for `devel`/`main` so it actually blocks merges — a workflow file can't set that on its own.

## Test plan

- [x] Reproduced the failure locally against the current pinned wheel (`ModuleNotFoundError: No module named 'gmail_api'`).
- [x] Confirmed pure-mode flake evaluation is unchanged: `nix build .#packages.x86_64-linux.bbr` (no `--impure`) still succeeds.
- [x] Confirmed the override mechanism works end-to-end: synthesized a "fixed" wheel by adding `gmail_api/{labels,service}.py` + updated `RECORD` to the currently pinned broken wheel, set `DUCKTAPE_ARTIFACT_OVERRIDES={"ducktape":"<path>"}`, and `nix build --impure .#packages.x86_64-linux.ducktape` succeeded — importsCheck of `gmail_archiver.main` passed.
- [ ] Waiting on CI: `Nix wheel check` on this PR should build all ducktape wheels from source (including the now-fixed `ducktape` wheel that ships `gmail_api`) and pass all `importsCheck`s.
- [ ] Waiting on CI: `Bazel CI` should stay green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WAJ8JXpinZkv2x9GLD6ULj)_