### PR TITLE
Add target-determinator to devtools/rbetools

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -317,6 +317,7 @@
         pkgs.sops
         pkgs.ssh-to-age
         ducktapePkgs.kubernetes-mcp-server
+        ducktapePkgs.target-determinator
       ];
       # Rust claude-hook is the active hook/shim implementation. The statusline
       # remains Python, exposed through a package that does not put the legacy

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -315,6 +315,7 @@ rec {
   litert-lm = pkgs.callPackage ./litert-lm.nix { };
   prettier = pkgs.callPackage ./prettier/prettier.nix { };
   kubernetes-mcp-server = pkgs.callPackage ./kubernetes-mcp-server.nix { };
+  target-determinator = pkgs.callPackage ./target-determinator.nix { };
   # Anthropic CLI (`ant`): Claude API / Managed Agents control plane. Not in
   # nixpkgs; vendored static release binary. Used by haku/runtime/managed_agent/self_hosted.
   anthropic-cli = pkgs.callPackage ./anthropic-cli.nix { };

--- a/nix/packages/target-determinator.nix
+++ b/nix/packages/target-determinator.nix
@@ -1,0 +1,28 @@
+# target-determinator — pre-built binary from GitHub releases.
+# https://github.com/bazel-contrib/target-determinator
+{
+  pkgs,
+  lib,
+}:
+let
+  version = "0.34.0";
+in
+pkgs.stdenv.mkDerivation {
+  pname = "target-determinator";
+  inherit version;
+  src = pkgs.fetchurl {
+    url = "https://github.com/bazel-contrib/target-determinator/releases/download/v${version}/target-determinator.linux.amd64";
+    hash = "sha256-EV4cY9OeLNDQsBHJ+tyA8FnwIRdqSuDeIjLN2DsfgBE=";
+  };
+  dontUnpack = true;
+  installPhase = ''
+    install -Dm755 $src $out/bin/target-determinator
+  '';
+  meta = {
+    description = "Determine which Bazel targets changed between two git commits";
+    homepage = "https://github.com/bazel-contrib/target-determinator";
+    license = lib.licenses.asl20;
+    mainProgram = "target-determinator";
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
Package the [bazel-contrib/target-determinator](https://github.com/bazel-contrib/target-determinator) v0.34.0 release binary as a Nix package (`nix/packages/target-determinator.nix`, same shape as `kubernetes-mcp-server.nix`), and include it in `devToolsCommon` so it lands in:

- the local devshell (`nix develop` / direnv)
- the `.#devtools` closure (Claude Code web setup)
- the `.#rbetools` closure baked into the RBE worker image (`ghcr.io/agentydragon/rbe-worker`)

## Why

Groundwork for filtering PR CI to only the Bazel targets affected by a diff. On PRs, `bazel-ci.yml` will invoke `target-determinator --before-revision $(git merge-base origin/devel HEAD) //...` inside the existing `bb-remote` script, then `bazel test --target_pattern_file=...` against the affected set. Devel-branch runs will continue to test `//...` unchanged.

This PR only introduces the binary; a follow-up PR wires it into the workflow (behind shadow mode first, then flipped to gating).

## Verification

- `nix build .#target-determinator` builds successfully.
- `nix build .#rbetools` includes the binary at `bin/target-determinator`.
- `--help` reports v0.34.0 flags.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcmYZYsrpgiZViSQeuNgXG)_