### PR TITLE
bazel-ci: run target-determinator on PRs in shadow mode

### DIFF
--- a/.github/workflows/bazel-ci.yml
+++ b/.github/workflows/bazel-ci.yml
@@ -74,6 +74,31 @@ jobs:
               python3 devinfra/ci/bb_runner_probe.py finalize --upload || true
             }
             trap finalize_bb_runner_probe EXIT
+
+            # Shadow mode (informational only): on PRs, compute the
+            # target-determinator affected set and print it. Not used for gating.
+            # Once the set is proven sane over several PRs, gating flips to only
+            # test/build affected targets on PRs; devel keeps //....
+            # Gracefully skips when TD is missing from the RBE image (pin lag
+            # after devtools/rbetools#2679).
+            if [ "${{ github.event_name }}" = "pull_request" ] && command -v target-determinator >/dev/null 2>&1; then
+              echo "::group::target-determinator (shadow)"
+              mkdir -p /tmp/td-cache
+              if git fetch --no-tags origin devel; then
+                BASE=$(git merge-base origin/devel HEAD)
+                echo "before-revision: $BASE"
+                echo "head:            $(git rev-parse HEAD)"
+                target-determinator \
+                  -cache-dir=/tmp/td-cache \
+                  -before-revision="$BASE" \
+                  //... \
+                  || echo "target-determinator failed (shadow, non-blocking)"
+              else
+                echo "git fetch origin devel failed; skipping"
+              fi
+              echo "::endgroup::"
+            fi
+
             probe_bb_runner before-test
             bazel test --keep_going $RBE_FLAGS //... && \
               probe_bb_runner after-test && \

--- a/.github/workflows/bazel-ci.yml
+++ b/.github/workflows/bazel-ci.yml
@@ -78,25 +78,33 @@ jobs:
             # Shadow mode (informational only): on PRs, compute the
             # target-determinator affected set and print it. Not used for gating.
             # Once the set is proven sane over several PRs, gating flips to only
-            # test/build affected targets on PRs; devel keeps //....
+            # test/build affected targets on PRs; devel keeps `//...`.
             # Gracefully skips when TD is missing from the RBE image (pin lag
             # after devtools/rbetools#2679).
+            #
+            # `set +e` inside the block: any failure in git fetch, merge-base,
+            # rev-parse, or target-determinator itself must NOT abort the CI
+            # script under the outer `set -euo pipefail`. Restored after the
+            # block so the real test/build stages still fail fast.
             if [ "${{ github.event_name }}" = "pull_request" ] && command -v target-determinator >/dev/null 2>&1; then
+              set +e
               echo "::group::target-determinator (shadow)"
               mkdir -p /tmp/td-cache
-              if git fetch --no-tags origin devel; then
-                BASE=$(git merge-base origin/devel HEAD)
+              git fetch --no-tags origin devel
+              BASE=$(git merge-base origin/devel HEAD)
+              HEAD_SHA=$(git rev-parse HEAD)
+              if [ -n "$BASE" ] && [ -n "$HEAD_SHA" ]; then
                 echo "before-revision: $BASE"
-                echo "head:            $(git rev-parse HEAD)"
+                echo "head:            $HEAD_SHA"
                 target-determinator \
                   -cache-dir=/tmp/td-cache \
                   -before-revision="$BASE" \
-                  //... \
-                  || echo "target-determinator failed (shadow, non-blocking)"
+                  //...
               else
-                echo "git fetch origin devel failed; skipping"
+                echo "could not resolve merge-base (BASE=$BASE HEAD=$HEAD_SHA); skipping"
               fi
               echo "::endgroup::"
+              set -e
             fi
 
             probe_bb_runner before-test


### PR DESCRIPTION
Follow-up to #2679. On pull_request events, invoke `target-determinator` inside the existing `bb-remote` script to compute the set of Bazel targets affected by the PR diff and print it to the CI log. **Informational only** — the required check is still `bazel test //... && bazel build //...`.

## Why shadow first

Before flipping PR gating to "only affected targets", verify over several real PRs that the affected set matches what a human would expect from the diff. Shadow mode surfaces the set without any risk of misclassifying failures.

## Rollout stage

This is step 2 of 4 in the affected-targets rollout:

1. ✅ Package `target-determinator` in `.#rbetools` (#2679)
2. **This PR:** run TD in shadow (log only, no gating)
3. Flip PR gating to affected-only (devel keeps `//...`)
4. Drop shadow scaffolding

## Guardrails

- **`command -v target-determinator` guard**: the current `devinfra/image_pins.json` digest predates #2679, so the RBE image on live PRs may not yet have TD. The guard makes shadow mode a no-op in that case, and it starts producing data automatically once the image auto-rebuild + pin refresh lands.
- **Non-blocking on TD failure**: `|| echo "target-determinator failed (shadow, non-blocking)"`. Shadow doesn't gate; we tolerate errors and rely on `//...` for correctness.
- **PR events only**: `github.event_name == "pull_request"`. Devel pushes keep testing `//...` with no TD detour.
- **`git fetch --no-tags origin devel`**: needed because `run_from_commit` checks out only the PR head; TD needs `origin/devel` in the local object store to resolve the merge-base and create its "before" worktree.
- **Explicit `-cache-dir=/tmp/td-cache`**: TD's default is `/root/.cache/target-determinator`, which isn't writable as the `buildbuddy` user on the RBE runner.

## What to look for while in shadow

- Does the affected set look right on small PRs (a handful of targets for a single-file diff)?
- Root-file changes (`MODULE.bazel`, `.bazelrc`, top-level `.bzl`) should produce large sets — that's correct behavior.
- Any TD errors that keep surfacing (analysis cache issues, worktree failures) → address before flipping to gating.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcmYZYsrpgiZViSQeuNgXG)_