### PR TITLE
[codex] Parse Claude spend usage in aiquota

### DIFF
--- a/aiquota/AGENTS.md
+++ b/aiquota/AGENTS.md
@@ -12,10 +12,10 @@ The CLI default output and the GNOME popup are two presentations of the same
 state. **Any presentation change to one must be mirrored in the other.** That
 includes:
 
-- What counts as "currently over plan" / "extra usage active" (single signal —
+- What counts as "currently over plan" / "extra spend active" (single signal —
   do not let the two surfaces drift apart on this).
 - Window-row layout (label, used %, reset, pace, forecast).
-- Header structure (provider name, error/stale annotations, extra-usage tail).
+- Header structure (provider name, error/stale annotations, extra-spend tail).
 - Collapsed-view behavior when the user is currently burning extra.
 
 If you change one and not the other, the user will report it as a bug. The
@@ -31,10 +31,10 @@ the snake_case fields silently parse as `None` and the CLI degrades to
 adding a new provider, default to the same alias config and write a test
 that round-trips a realistic API response.
 
-`extra_usage.is_enabled` from the Claude API only signals "feature enabled
-on this account", not "currently paying above subscription". The
-"currently over plan" signal is `long_window.used_percent >= 100`.
-`extra_usage.used_usd` is cumulative across the billing month, not a
-right-now indicator. Both surfaces consume this rule via the same helper
-(`_currently_over_plan` in `render/human.py`, `currentlyOverPlan` in
-`gnome/extension.js`).
+Claude's `spend.enabled`, surfaced internally as `ExtraSpend.is_enabled`,
+only signals "feature enabled on this account", not "currently paying above
+subscription". The "currently over plan" signal is any window at or above
+100% usage. `ExtraSpend.used_usd` is cumulative across the billing month,
+not a right-now indicator. Both surfaces consume this rule via the shared
+Python view model (`currently_over_plan` / `extra_status` in
+`render/view_model.py`).

--- a/aiquota/gnome/extension.js
+++ b/aiquota/gnome/extension.js
@@ -82,19 +82,19 @@ function formatAge(seconds) {
 }
 
 // Pick the state to render: prefer the latest fetch, but fall back to the
-// last successful snapshot (windows + extraUsage) when the latest call
+// last successful snapshot (windows + extraSpend) when the latest call
 // returned nothing usable. `staleAge` is null when no fallback was needed.
 function effectiveState(state) {
   if (state.short != null || state.long != null) {
     const staleAge = state.error && state.lastFetch != null ? Math.max(0, (Date.now() - state.lastFetch) / 1000) : null;
-    return { short: state.short, long: state.long, extraUsage: state.extraUsage, staleAge };
+    return { short: state.short, long: state.long, extraSpend: state.extraSpend, staleAge };
   }
   const snap = state.lastSuccess;
   if (!snap || (snap.short == null && snap.long == null)) {
-    return { short: null, long: null, extraUsage: null, staleAge: null };
+    return { short: null, long: null, extraSpend: null, staleAge: null };
   }
   const ageSeconds = snap.fetchedAt != null ? Math.max(0, (Date.now() - snap.fetchedAt) / 1000) : null;
-  return { short: snap.short, long: snap.long, extraUsage: snap.extraUsage, staleAge: ageSeconds };
+  return { short: snap.short, long: snap.long, extraSpend: snap.extraSpend, staleAge: ageSeconds };
 }
 
 function formatFreshness(lastFetch) {
@@ -183,7 +183,7 @@ function formatCompactDollars(usd) {
 // (see aiquota/render/view_model.py) and is delivered to us by
 // `aiquota gnome-extension-json` as state.currentlyOverPlan. Don't
 // reintroduce a local copy: see aiquota/AGENTS.md.
-function formatExtraUsage(extra) {
+function formatExtraSpend(extra) {
   if (!extra || !extra.is_enabled || !(extra.used_usd > 0)) return null;
   const used = extra.used_usd;
   const limit = extra.monthly_limit_usd;
@@ -208,11 +208,11 @@ function emptyProviderState() {
     lastFetch: null,
     lastCheck: null,
     error: null,
-    extraUsage: null,
+    extraSpend: null,
     currentlyOverPlan: false,
     extraStatus: "none",
     // Last successful fetch — populated when the most recent attempt failed
-    // but a prior good snapshot exists. {short, long, extraUsage, fetchedAt}.
+    // but a prior good snapshot exists. {short, long, extraSpend, fetchedAt}.
     lastSuccess: null,
   };
 }
@@ -299,7 +299,7 @@ const QuotaIndicator = GObject.registerClass(
         return {
           short: snap.short ?? null,
           long: snap.long ?? null,
-          extraUsage: snap.extraUsage ?? null,
+          extraSpend: snap.extraSpend ?? null,
           fetchedAt,
         };
       };
@@ -312,7 +312,7 @@ const QuotaIndicator = GObject.registerClass(
           lastFetch,
           lastCheck,
           error: node?.error ?? null,
-          extraUsage: node?.extraUsage ?? null,
+          extraSpend: node?.extraSpend ?? null,
           currentlyOverPlan: node?.currentlyOverPlan === true,
           extraStatus: node?.extraStatus ?? "none",
           lastSuccess: loadLastSuccess(node?.lastSuccess),
@@ -470,7 +470,7 @@ const QuotaIndicator = GObject.registerClass(
       };
     }
 
-    _mapExtraUsage(extra) {
+    _mapExtraSpend(extra) {
       if (!extra) return null;
       return {
         is_enabled: extra.is_enabled,
@@ -486,7 +486,7 @@ const QuotaIndicator = GObject.registerClass(
       return {
         short: this._mapWindow(snap.result.short_window),
         long: this._mapWindow(snap.result.long_window),
-        extraUsage: this._mapExtraUsage(snap.result.extra_usage),
+        extraSpend: this._mapExtraSpend(snap.result.extra_spend),
         fetchedAt: snap.fetched_at ? new Date(snap.fetched_at).getTime() : null,
       };
     }
@@ -511,7 +511,7 @@ const QuotaIndicator = GObject.registerClass(
           lastFetch: isSuccess ? lastCheck : (lastSuccess?.fetchedAt ?? null),
           lastCheck,
           error: isSuccess ? null : (result.error ?? null),
-          extraUsage: isSuccess ? this._mapExtraUsage(result.extra_usage) : null,
+          extraSpend: isSuccess ? this._mapExtraSpend(result.extra_spend) : null,
           // Derived policy bits from the Python view model — single source of truth.
           currentlyOverPlan: pq.currently_over_plan === true,
           extraStatus: pq.extra_status ?? "none",
@@ -561,7 +561,7 @@ const QuotaIndicator = GObject.registerClass(
       this._setTint(icon, paceLabel, tint);
       const paceText = formatPace(longPace) ?? "";
       if (overPlan) {
-        paceLabel.set_text(`${formatCompactDollars(state.extraUsage.used_usd)} ⚡`);
+        paceLabel.set_text(`${formatCompactDollars(state.extraSpend.used_usd)} ⚡`);
       } else {
         paceLabel.set_text(paceText);
       }
@@ -589,7 +589,7 @@ const QuotaIndicator = GObject.registerClass(
       item.label.remove_style_class_name("quota-popup-header-error");
       item.label.remove_style_class_name("quota-popup-header-stale");
 
-      const { short, long, extraUsage, staleAge } = effectiveState(state);
+      const { short, long, extraSpend, staleAge } = effectiveState(state);
       const haveWindows = short != null || long != null;
       const parts = [title];
       if (state.error) {
@@ -599,7 +599,7 @@ const QuotaIndicator = GObject.registerClass(
         item.label.add_style_class_name("quota-popup-header-stale");
       }
       if (staleAge != null) parts.push(`(stale ${formatAge(staleAge)})`);
-      const extraStr = formatExtraUsage(extraUsage);
+      const extraStr = formatExtraSpend(extraSpend);
       if (extraStr) parts.push(extraStr);
       if (!state.error) parts.push(formatFreshness(state.lastFetch));
       item.label.set_text(parts.join(" · "));

--- a/aiquota/gnome/test_fixtures/empty.json
+++ b/aiquota/gnome/test_fixtures/empty.json
@@ -5,20 +5,20 @@
     "long": null,
     "lastFetch": null,
     "error": null,
-    "extraUsage": null
+    "extraSpend": null
   },
   "codex": {
     "short": null,
     "long": null,
     "lastFetch": null,
     "error": null,
-    "extraUsage": null
+    "extraSpend": null
   },
   "zai": {
     "short": null,
     "long": null,
     "lastFetch": null,
     "error": null,
-    "extraUsage": null
+    "extraSpend": null
   }
 }

--- a/aiquota/gnome/test_fixtures/extra_enabled_not_burning.json
+++ b/aiquota/gnome/test_fixtures/extra_enabled_not_burning.json
@@ -1,17 +1,13 @@
 {
-  "_comment": "Anthropic extra-usage feature is on for the account and the user has incurred extra spend earlier in the billing month, but the weekly cap still has room — so they are NOT *currently* burning extra. This regression existed before the view-model refactor: the panel pill + popup collapsed view both fired purely on extraUsage.is_enabled. The fixture pins that they only fire when long.usedPercent >= 100 (currentlyOverPlan=false here). Numbers loosely match the maintainer's real bill at the time the bug was found ($2324.85 / $4600).",
+  "_comment": "Anthropic extra-spend feature is on for the account and the user has incurred extra spend earlier in the billing month, but the weekly cap still has room — so they are NOT *currently* burning extra. This regression existed before the view-model refactor: the panel pill + popup collapsed view both fired purely on extraSpend.is_enabled. The fixture pins that they only fire when a window is exhausted (currentlyOverPlan=false here). Numbers loosely match the maintainer's real bill at the time the bug was found ($2324.85 / $4600).",
   "claude": {
     "short": { "usedPercent": 6, "resetSeconds": 7200, "windowSeconds": 18000 },
     "long": { "usedPercent": 2, "resetSeconds": 432000, "windowSeconds": 604800 },
     "lastFetch": 1,
     "error": null,
-    "extraUsage": {
+    "extraSpend": {
       "is_enabled": true,
-      "monthly_limit": 460000,
-      "used_credits": 232485.0,
       "utilization": 50.540217391304346,
-      "currency": "USD",
-      "disabled_reason": null,
       "used_usd": 2324.85,
       "monthly_limit_usd": 4600.0
     },
@@ -23,13 +19,13 @@
     "long": { "usedPercent": 30, "resetSeconds": 432000, "windowSeconds": 604800 },
     "lastFetch": 1,
     "error": null,
-    "extraUsage": null
+    "extraSpend": null
   },
   "zai": {
     "short": { "usedPercent": 20, "resetSeconds": 12600, "windowSeconds": 18000 },
     "long": { "usedPercent": 25, "resetSeconds": 432000, "windowSeconds": 604800 },
     "lastFetch": 1,
     "error": null,
-    "extraUsage": null
+    "extraSpend": null
   }
 }

--- a/aiquota/gnome/test_fixtures/hot.json
+++ b/aiquota/gnome/test_fixtures/hot.json
@@ -1,17 +1,13 @@
 {
-  "_comment": "Pace-based hot with Anthropic extra usage burning. claude: short=hot(dev+20, 50% used at 30% elapsed)/long=100% → extra usage active, ⚡ in panel, one 5h/7d text-only reset row without bars. extraUsage matches real api.anthropic.com/api/oauth/usage shape (nothing-up-my-sleeve: 314159/500000 = pi digits). codex: both ok(dev+0) → panel ok. zai: short=null (off-peak)/long=warn(dev+10, 40% at 30%) → panel warn.",
+  "_comment": "Pace-based hot with Anthropic extra spend burning. claude: short=hot(dev+20, 50% used at 30% elapsed)/long=100% → extra spend active, ⚡ in panel, one 5h/7d text-only reset row without bars. extraSpend uses aiquota's ExtraSpend fields (nothing-up-my-sleeve: 314159/500000 = pi digits). codex: both ok(dev+0) → panel ok. zai: short=null (off-peak)/long=warn(dev+10, 40% at 30%) → panel warn.",
   "claude": {
     "short": { "usedPercent": 50, "resetSeconds": 12600, "windowSeconds": 18000 },
     "long": { "usedPercent": 100, "resetSeconds": 423360, "windowSeconds": 604800 },
     "lastFetch": 1,
     "error": null,
-    "extraUsage": {
+    "extraSpend": {
       "is_enabled": true,
-      "monthly_limit": 500000,
-      "used_credits": 314159.0,
       "utilization": 62.8318,
-      "currency": "USD",
-      "disabled_reason": null,
       "used_usd": 3141.59,
       "monthly_limit_usd": 5000.0
     },
@@ -23,13 +19,13 @@
     "long": { "usedPercent": 30, "resetSeconds": 423360, "windowSeconds": 604800 },
     "lastFetch": 1,
     "error": null,
-    "extraUsage": null
+    "extraSpend": null
   },
   "zai": {
     "short": null,
     "long": { "usedPercent": 40, "resetSeconds": 423360, "windowSeconds": 604800 },
     "lastFetch": 1,
     "error": null,
-    "extraUsage": null
+    "extraSpend": null
   }
 }

--- a/aiquota/gnome/test_fixtures/stale_fallback.json
+++ b/aiquota/gnome/test_fixtures/stale_fallback.json
@@ -6,11 +6,11 @@
     "lastFetch": 1,
     "lastCheckAgeSeconds": 120,
     "error": "HTTP 503 Service Unavailable",
-    "extraUsage": null,
+    "extraSpend": null,
     "lastSuccess": {
       "short": { "usedPercent": 35, "resetSeconds": 7920, "windowSeconds": 18000 },
       "long": { "usedPercent": 72, "resetSeconds": 442800, "windowSeconds": 604800 },
-      "extraUsage": null,
+      "extraSpend": null,
       "ageSeconds": 86400
     }
   },
@@ -19,13 +19,13 @@
     "long": { "usedPercent": 30, "resetSeconds": 423360, "windowSeconds": 604800 },
     "lastFetch": 1,
     "error": null,
-    "extraUsage": null
+    "extraSpend": null
   },
   "zai": {
     "short": null,
     "long": null,
     "lastFetch": null,
     "error": null,
-    "extraUsage": null
+    "extraSpend": null
   }
 }

--- a/aiquota/gnome/test_fixtures/tints.json
+++ b/aiquota/gnome/test_fixtures/tints.json
@@ -5,20 +5,20 @@
     "long": null,
     "lastFetch": null,
     "error": "HTTP 401 invalid_request: invalid_token",
-    "extraUsage": null
+    "extraSpend": null
   },
   "codex": {
     "short": { "usedPercent": 60, "resetSeconds": 9000, "windowSeconds": 18000 },
     "long": { "usedPercent": 15, "resetSeconds": 423360, "windowSeconds": 604800 },
     "lastFetch": 1,
     "error": null,
-    "extraUsage": null
+    "extraSpend": null
   },
   "zai": {
     "short": { "usedPercent": 90, "resetSeconds": 9000, "windowSeconds": 18000 },
     "long": { "usedPercent": 30, "resetSeconds": 423360, "windowSeconds": 604800 },
     "lastFetch": 1,
     "error": null,
-    "extraUsage": null
+    "extraSpend": null
   }
 }

--- a/aiquota/gnome/test_render.py
+++ b/aiquota/gnome/test_render.py
@@ -22,9 +22,9 @@ multiple tints simultaneously (providers can have different short vs long states
   empty                       all providers null                                — unknown/no-data state
   tints                       claude=error; codex=warn-short/cool-long;        — error, warn, cool, hot(absolute), ok
                               zai=absolute-hot-short/ok-long
-  hot                         claude=pace-hot-short/long-100%+extra-usage(⚡); — hot(pace), one-line reset row, extra usage header + ⚡ icon
+  hot                         claude=pace-hot-short/long-100%+extra-spend(⚡); — hot(pace), one-line reset row, extra spend header + ⚡ icon
                               codex=ok/ok; zai=null-short/warn-long
-  extra_enabled_not_burning   claude has extra-usage on with $2324.85 already   — pins the regression where the popup
+  extra_enabled_not_burning   claude has extra-spend on with $2324.85 already   — pins the regression where the popup
                               spent this month, but long=2% — must NOT collapse  collapsed purely on is_enabled
 
 Update flow when the rendering changes intentionally:

--- a/aiquota/models.py
+++ b/aiquota/models.py
@@ -18,7 +18,9 @@ class PaceResult(BaseModel):
     stable: bool
 
 
-class ExtraUsage(BaseModel):
+class ExtraSpend(BaseModel):
+    """Internal summary of billable spend above the subscription quota."""
+
     is_enabled: bool
     monthly_limit_usd: float
     used_usd: float
@@ -36,7 +38,7 @@ class FetchSuccess(BaseModel):
     kind: Literal["success"] = "success"
     short_window: QuotaWindow | None = None
     long_window: QuotaWindow | None = None
-    extra_usage: ExtraUsage | None = None
+    extra_spend: ExtraSpend | None = None
 
 
 class FetchError(BaseModel):

--- a/aiquota/providers/BUILD.bazel
+++ b/aiquota/providers/BUILD.bazel
@@ -16,6 +16,7 @@ py_library(
     deps = [
         ":base",
         "//aiquota:models",
+        "//devinfra/claude/claude_api:usage",
         "@pypi//httpx",
         "@pypi//pydantic",
     ],
@@ -54,6 +55,7 @@ py_test(
     imports = ["../.."],
     deps = [
         ":claude_lib",
+        "//devinfra/claude/claude_api:usage",
         "@pypi//pydantic",
         "@pypi//pytest",
         "@pypi//pytest_bazel",

--- a/aiquota/providers/claude.py
+++ b/aiquota/providers/claude.py
@@ -14,7 +14,7 @@ from pydantic.alias_generators import to_camel
 
 from aiquota.models import ExtraUsage, FetchError, FetchSuccess, ProviderFetch, QuotaWindow
 from aiquota.providers.base import Provider
-from devinfra.claude.claude_api.usage import ExtraUsageTotals, UsageBucket, UsageResponse, normalized_extra_usage
+from devinfra.claude.claude_api.usage import Spend, UsageBucket, UsageResponse
 
 logger = logging.getLogger(__name__)
 
@@ -125,14 +125,16 @@ def _to_window(bucket: UsageBucket | None, window_secs: float) -> QuotaWindow | 
     )
 
 
-def _to_aiquota_extra_usage(extra: ExtraUsageTotals | None) -> ExtraUsage | None:
-    if extra is None:
+def _spend_to_extra_usage(spend: Spend | None) -> ExtraUsage | None:
+    if spend is None or not spend.has_usage_totals:
         return None
+    assert spend.limit is not None
+    assert spend.used is not None
     return ExtraUsage(
         is_enabled=True,
-        monthly_limit_usd=extra.monthly_limit / 100,
-        used_usd=extra.used_credits / 100,
-        utilization=extra.utilization,
+        monthly_limit_usd=spend.limit.major_units,
+        used_usd=spend.used.major_units,
+        utilization=spend.utilization_percent,
     )
 
 
@@ -165,7 +167,7 @@ class ClaudeProvider(Provider):
 
         short = _to_window(usage.five_hour, SHORT_WINDOW_SECS)
         long = _to_window(usage.seven_day, LONG_WINDOW_SECS)
-        extra = _to_aiquota_extra_usage(normalized_extra_usage(usage))
+        extra = _spend_to_extra_usage(usage.spend)
         return ProviderFetch(
             fetched_at=now, result=FetchSuccess(short_window=short, long_window=long, extra_usage=extra)
         )

--- a/aiquota/providers/claude.py
+++ b/aiquota/providers/claude.py
@@ -12,7 +12,7 @@ import httpx
 from pydantic import BaseModel, ConfigDict
 from pydantic.alias_generators import to_camel
 
-from aiquota.models import ExtraUsage, FetchError, FetchSuccess, ProviderFetch, QuotaWindow
+from aiquota.models import ExtraSpend, FetchError, FetchSuccess, ProviderFetch, QuotaWindow
 from aiquota.providers.base import Provider
 from devinfra.claude.claude_api.usage import Spend, UsageBucket, UsageResponse
 
@@ -125,12 +125,12 @@ def _to_window(bucket: UsageBucket | None, window_secs: float) -> QuotaWindow | 
     )
 
 
-def _spend_to_extra_usage(spend: Spend | None) -> ExtraUsage | None:
+def _spend_to_extra_spend(spend: Spend | None) -> ExtraSpend | None:
     if spend is None or not spend.has_usage_totals:
         return None
     assert spend.limit is not None
     assert spend.used is not None
-    return ExtraUsage(
+    return ExtraSpend(
         is_enabled=True,
         monthly_limit_usd=spend.limit.major_units,
         used_usd=spend.used.major_units,
@@ -167,7 +167,7 @@ class ClaudeProvider(Provider):
 
         short = _to_window(usage.five_hour, SHORT_WINDOW_SECS)
         long = _to_window(usage.seven_day, LONG_WINDOW_SECS)
-        extra = _spend_to_extra_usage(usage.spend)
+        extra = _spend_to_extra_spend(usage.spend)
         return ProviderFetch(
-            fetched_at=now, result=FetchSuccess(short_window=short, long_window=long, extra_usage=extra)
+            fetched_at=now, result=FetchSuccess(short_window=short, long_window=long, extra_spend=extra)
         )

--- a/aiquota/providers/claude.py
+++ b/aiquota/providers/claude.py
@@ -14,7 +14,7 @@ from pydantic.alias_generators import to_camel
 
 from aiquota.models import ExtraUsage, FetchError, FetchSuccess, ProviderFetch, QuotaWindow
 from aiquota.providers.base import Provider
-from devinfra.claude.claude_api.usage import UsageBucket, UsageResponse, normalized_extra_usage
+from devinfra.claude.claude_api.usage import ExtraUsageTotals, UsageBucket, UsageResponse, normalized_extra_usage
 
 logger = logging.getLogger(__name__)
 
@@ -125,8 +125,7 @@ def _to_window(bucket: UsageBucket | None, window_secs: float) -> QuotaWindow | 
     )
 
 
-def _to_extra_usage(usage: UsageResponse) -> ExtraUsage | None:
-    extra = normalized_extra_usage(usage)
+def _to_aiquota_extra_usage(extra: ExtraUsageTotals | None) -> ExtraUsage | None:
     if extra is None:
         return None
     return ExtraUsage(
@@ -166,7 +165,7 @@ class ClaudeProvider(Provider):
 
         short = _to_window(usage.five_hour, SHORT_WINDOW_SECS)
         long = _to_window(usage.seven_day, LONG_WINDOW_SECS)
-        extra = _to_extra_usage(usage)
+        extra = _to_aiquota_extra_usage(normalized_extra_usage(usage))
         return ProviderFetch(
             fetched_at=now, result=FetchSuccess(short_window=short, long_window=long, extra_usage=extra)
         )

--- a/aiquota/providers/claude.py
+++ b/aiquota/providers/claude.py
@@ -7,14 +7,14 @@ with automatic token refresh via the platform token endpoint.
 import logging
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Annotated, Literal
 
 import httpx
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict
 from pydantic.alias_generators import to_camel
 
 from aiquota.models import ExtraUsage, FetchError, FetchSuccess, ProviderFetch, QuotaWindow
 from aiquota.providers.base import Provider
+from devinfra.claude.claude_api.usage import UsageBucket, UsageResponse, normalized_extra_usage
 
 logger = logging.getLogger(__name__)
 
@@ -51,42 +51,6 @@ class _Credentials(BaseModel):
     model_config = _CAMEL
 
     claude_ai_oauth: _OAuthTokens | None = None
-
-
-class _UsageBucket(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    utilization: float
-    resets_at: str | None = None
-
-
-# Discriminated union: the API returns explicit `null` for the numeric
-# fields when extra-usage isn't entitled on the plan, so the only sane
-# representation gates them behind `is_enabled`.
-class _ExtraUsageDisabled(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    is_enabled: Literal[False] = False
-
-
-class _ExtraUsageEnabled(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    is_enabled: Literal[True]
-    monthly_limit: float
-    used_credits: float
-    utilization: float
-
-
-_ExtraUsage = Annotated[_ExtraUsageEnabled | _ExtraUsageDisabled, Field(discriminator="is_enabled")]
-
-
-class _UsageResponse(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    five_hour: _UsageBucket | None = None
-    seven_day: _UsageBucket | None = None
-    extra_usage: _ExtraUsage | None = None
 
 
 class _TokenRefreshResponse(BaseModel):
@@ -149,19 +113,27 @@ def _token_expired(creds: _Credentials) -> bool:
     return oauth.expires_at - datetime.now(UTC).timestamp() * 1000 <= TOKEN_EXPIRY_SKEW_SECS * 1000
 
 
-def _to_window(bucket: _UsageBucket | None, window_secs: float) -> QuotaWindow | None:
+def _to_window(bucket: UsageBucket | None, window_secs: float) -> QuotaWindow | None:
     if bucket is None:
         return None
-    reset_at: datetime | None = None
+    reset_at = bucket.resets_at
     reset_secs = 0.0
-    if bucket.resets_at:
-        try:
-            reset_at = datetime.fromisoformat(bucket.resets_at)
-            reset_secs = max(0, (reset_at.timestamp() - datetime.now(UTC).timestamp()))
-        except (ValueError, OSError):
-            pass
+    if reset_at is not None:
+        reset_secs = max(0, (reset_at.timestamp() - datetime.now(UTC).timestamp()))
     return QuotaWindow(
         used_percent=bucket.utilization, reset_seconds=reset_secs, window_seconds=window_secs, reset_at=reset_at
+    )
+
+
+def _to_extra_usage(usage: UsageResponse) -> ExtraUsage | None:
+    extra = normalized_extra_usage(usage)
+    if extra is None:
+        return None
+    return ExtraUsage(
+        is_enabled=True,
+        monthly_limit_usd=extra.monthly_limit / 100,
+        used_usd=extra.used_credits / 100,
+        utilization=extra.utilization,
     )
 
 
@@ -188,21 +160,13 @@ class ClaudeProvider(Provider):
                     USAGE_URL, headers={"Authorization": f"Bearer {token}", "anthropic-beta": "oauth-2025-04-20"}
                 )
             resp.raise_for_status()
-            usage = _UsageResponse.model_validate(resp.json())
+            usage = UsageResponse.model_validate(resp.json())
         except Exception as e:
             return ProviderFetch(fetched_at=now, result=FetchError.from_exception(e, "claude quota fetch"))
 
         short = _to_window(usage.five_hour, SHORT_WINDOW_SECS)
         long = _to_window(usage.seven_day, LONG_WINDOW_SECS)
-        extra: ExtraUsage | None = None
-        if isinstance(usage.extra_usage, _ExtraUsageEnabled):
-            eu = usage.extra_usage
-            extra = ExtraUsage(
-                is_enabled=True,
-                monthly_limit_usd=eu.monthly_limit / 100,
-                used_usd=eu.used_credits / 100,
-                utilization=eu.utilization,
-            )
+        extra = _to_extra_usage(usage)
         return ProviderFetch(
             fetched_at=now, result=FetchSuccess(short_window=short, long_window=long, extra_usage=extra)
         )

--- a/aiquota/providers/test_claude.py
+++ b/aiquota/providers/test_claude.py
@@ -1,13 +1,13 @@
 import pytest_bazel
 
-from aiquota.providers.claude import _spend_to_extra_usage
+from aiquota.providers.claude import _spend_to_extra_spend
 from devinfra.claude.claude_api.usage import UsageResponse
 
 if __name__ == "__main__":
     pytest_bazel.main()
 
 
-def test_spend_shape_drives_extra_usage() -> None:
+def test_spend_shape_drives_extra_spend() -> None:
     usage = UsageResponse.model_validate(
         {
             "spend": {
@@ -19,13 +19,13 @@ def test_spend_shape_drives_extra_usage() -> None:
             }
         }
     )
-    extra = _spend_to_extra_usage(usage.spend)
+    extra = _spend_to_extra_spend(usage.spend)
     assert extra is not None
     assert extra.monthly_limit_usd == 2500.0
     assert extra.used_usd == 123.45
     assert extra.utilization == 4.94
 
 
-def test_disabled_spend_does_not_render_extra_usage() -> None:
+def test_disabled_spend_does_not_render_extra_spend() -> None:
     usage = UsageResponse.model_validate({"spend": {"enabled": False, "disabled_reason": "payment_method_required"}})
-    assert _spend_to_extra_usage(usage.spend) is None
+    assert _spend_to_extra_spend(usage.spend) is None

--- a/aiquota/providers/test_claude.py
+++ b/aiquota/providers/test_claude.py
@@ -2,8 +2,8 @@ import pytest
 import pytest_bazel
 from pydantic import ValidationError
 
-from aiquota.providers.claude import _to_extra_usage
-from devinfra.claude.claude_api.usage import UsageResponse
+from aiquota.providers.claude import _to_aiquota_extra_usage
+from devinfra.claude.claude_api.usage import UsageResponse, normalized_extra_usage
 
 if __name__ == "__main__":
     pytest_bazel.main()
@@ -38,7 +38,7 @@ def test_extra_usage_enabled_allows_null_utilization() -> None:
         "extra_usage": {"is_enabled": True, "monthly_limit": 250000, "used_credits": 125000, "utilization": None}
     }
     usage = UsageResponse.model_validate(payload)
-    extra = _to_extra_usage(usage)
+    extra = _to_aiquota_extra_usage(normalized_extra_usage(usage))
     assert extra is not None
     assert extra.monthly_limit_usd == 2500.0
     assert extra.used_usd == 1250.0
@@ -63,7 +63,7 @@ def test_spend_shape_drives_extra_usage() -> None:
         },
     }
     usage = UsageResponse.model_validate(payload)
-    extra = _to_extra_usage(usage)
+    extra = _to_aiquota_extra_usage(normalized_extra_usage(usage))
     assert extra is not None
     assert extra.monthly_limit_usd == 2500.0
     assert extra.used_usd == 123.45

--- a/aiquota/providers/test_claude.py
+++ b/aiquota/providers/test_claude.py
@@ -1,70 +1,31 @@
-import pytest
 import pytest_bazel
-from pydantic import ValidationError
 
-from aiquota.providers.claude import _to_aiquota_extra_usage
-from devinfra.claude.claude_api.usage import UsageResponse, normalized_extra_usage
+from aiquota.providers.claude import _spend_to_extra_usage
+from devinfra.claude.claude_api.usage import UsageResponse
 
 if __name__ == "__main__":
     pytest_bazel.main()
 
 
-def test_extra_usage_disabled_with_null_numbers_parses() -> None:
-    # The OAuth usage API returns explicit `null` for the numeric fields
-    # when extra-usage isn't entitled on the plan. Parsing must succeed
-    # (the disabled variant carries no numbers) — see the regression
-    # report where this raised three `float_type` ValidationErrors.
-    payload = {
-        "five_hour": None,
-        "seven_day": None,
-        "extra_usage": {"is_enabled": False, "monthly_limit": None, "used_credits": None, "utilization": None},
-    }
-    usage = UsageResponse.model_validate(payload)
-    assert usage.extra_usage is not None
-    assert usage.extra_usage.is_enabled is False
-
-
-def test_extra_usage_enabled_requires_numbers() -> None:
-    payload = {
-        "extra_usage": {"is_enabled": True, "monthly_limit": 4600.0, "used_credits": 2324.85, "utilization": 50.54}
-    }
-    usage = UsageResponse.model_validate(payload)
-    assert usage.extra_usage is not None
-    assert usage.extra_usage.monthly_limit == 4600.0
-
-
-def test_extra_usage_enabled_allows_null_utilization() -> None:
-    payload = {
-        "extra_usage": {"is_enabled": True, "monthly_limit": 250000, "used_credits": 125000, "utilization": None}
-    }
-    usage = UsageResponse.model_validate(payload)
-    extra = _to_aiquota_extra_usage(normalized_extra_usage(usage))
-    assert extra is not None
-    assert extra.monthly_limit_usd == 2500.0
-    assert extra.used_usd == 1250.0
-    assert extra.utilization == 50.0
-
-
-def test_extra_usage_enabled_rejects_null_money() -> None:
-    payload = {"extra_usage": {"is_enabled": True, "monthly_limit": None, "used_credits": None}}
-    with pytest.raises(ValidationError):
-        UsageResponse.model_validate(payload)
-
-
 def test_spend_shape_drives_extra_usage() -> None:
-    payload = {
-        "extra_usage": {"is_enabled": True, "monthly_limit": 250000, "used_credits": 0.0, "utilization": None},
-        "spend": {
-            "enabled": True,
-            "limit": {"amount_minor": 250000, "currency": "USD", "exponent": 2},
-            "used": {"amount_minor": 12345, "currency": "USD", "exponent": 2},
-            "percent": 4.94,
-            "severity": "normal",
-        },
-    }
-    usage = UsageResponse.model_validate(payload)
-    extra = _to_aiquota_extra_usage(normalized_extra_usage(usage))
+    usage = UsageResponse.model_validate(
+        {
+            "spend": {
+                "enabled": True,
+                "limit": {"amount_minor": 250000, "currency": "USD", "exponent": 2},
+                "used": {"amount_minor": 12345, "currency": "USD", "exponent": 2},
+                "percent": 4.94,
+                "severity": "normal",
+            }
+        }
+    )
+    extra = _spend_to_extra_usage(usage.spend)
     assert extra is not None
     assert extra.monthly_limit_usd == 2500.0
     assert extra.used_usd == 123.45
     assert extra.utilization == 4.94
+
+
+def test_disabled_spend_does_not_render_extra_usage() -> None:
+    usage = UsageResponse.model_validate({"spend": {"enabled": False, "disabled_reason": "payment_method_required"}})
+    assert _spend_to_extra_usage(usage.spend) is None

--- a/aiquota/render/__snapshots__/test_human.ambr
+++ b/aiquota/render/__snapshots__/test_human.ambr
@@ -22,7 +22,7 @@
     5h:  24%  ↻ 1h33m  Δ-45%  leaves ~65% unused at reset
     7d:  48%  ↻ 5d12h  Δ+27%  exhausts ~3d21h before reset
   zai
-    5h:  49%  ↻ 2h45m  Δ+4%  exhausts ~24m before reset
+    5h:  49%  ↻ 2h45m  Δ+4%   exhausts ~24m before reset
     7d: 100%  ↻ 6d14h  Δ+94%  exhausts ~6d14h before reset
   '''
 # ---

--- a/aiquota/render/human.py
+++ b/aiquota/render/human.py
@@ -1,5 +1,6 @@
 """Human-readable CLI rendering — mirrors the GNOME extension popup bars."""
 
+from dataclasses import dataclass
 from datetime import UTC, datetime
 
 from aiquota.models import AllQuotas, ExtraUsage, FetchSuccess, QuotaWindow, SuccessfulProviderFetch
@@ -11,22 +12,30 @@ from aiquota.render.view_model import ProviderView, to_view
 def render(quotas: AllQuotas, now: datetime | None = None) -> str:
     view = to_view(quotas)
     render_time = now or datetime.now(UTC)
-    return "\n".join(_render_provider(pv, render_time) for pv in view.providers)
+    widths = _column_widths(view.providers, render_time)
+    return "\n".join(_render_provider(pv, render_time, widths) for pv in view.providers)
 
 
-def _render_provider(pv: ProviderView, now: datetime) -> str:
+@dataclass(frozen=True)
+class _ColumnWidths:
+    reset: int = 0
+    pace: int = 0
+
+
+@dataclass(frozen=True)
+class _WindowRow:
+    label: str
+    used: str
+    reset: str
+    pace: str | None
+    forecast: str | None
+
+
+def _render_provider(pv: ProviderView, now: datetime, widths: _ColumnWidths) -> str:
     out_result = pv.last_output.result
     error = out_result.error if not isinstance(out_result, FetchSuccess) else None
 
-    # If the latest call gave us nothing usable, fall back to the prior
-    # successful snapshot — stale-but-real numbers beat "no data".
-    if isinstance(out_result, FetchSuccess) and (out_result.short_window or out_result.long_window):
-        short, long, extra, stale_age = out_result.short_window, out_result.long_window, out_result.extra_usage, None
-    elif pv.last_success is not None:
-        short, long, extra, stale_age = _stale_windows(pv.last_success, now)
-    else:
-        short = long = extra = None
-        stale_age = None
+    short, long, extra, stale_age = _effective_windows(pv, now)
 
     if error and short is None and long is None:
         return _header(pv.provider, error, pv.last_output.fetched_at, now, stale_age)
@@ -40,9 +49,9 @@ def _render_provider(pv: ProviderView, now: datetime) -> str:
 
     lines = [_header(pv.provider, error, pv.last_output.fetched_at, now, stale_age)]
     if short is not None:
-        lines.append(_window_line("5h", short))
+        lines.append(_format_window_line(_window_row("5h", short), widths))
     if long is not None:
-        lines.append(_window_line("7d", long))
+        lines.append(_format_window_line(_window_row("7d", long), widths))
     if pv.extra_status == "informational" and extra is not None:
         # Prepaid still has room, but the user incurred extra-usage spend earlier
         # in the billing month. Surface it so the monthly bill doesn't sneak up.
@@ -50,6 +59,35 @@ def _render_provider(pv: ProviderView, now: datetime) -> str:
     if len(lines) == 1:
         lines.append("  no data")
     return "\n".join(lines)
+
+
+def _effective_windows(
+    pv: ProviderView, now: datetime
+) -> tuple[QuotaWindow | None, QuotaWindow | None, ExtraUsage | None, str | None]:
+    out_result = pv.last_output.result
+    # If the latest call gave us nothing usable, fall back to the prior
+    # successful snapshot — stale-but-real numbers beat "no data".
+    if isinstance(out_result, FetchSuccess) and (out_result.short_window or out_result.long_window):
+        return out_result.short_window, out_result.long_window, out_result.extra_usage, None
+    if pv.last_success is not None:
+        return _stale_windows(pv.last_success, now)
+    return None, None, None, None
+
+
+def _column_widths(providers: list[ProviderView], now: datetime) -> _ColumnWidths:
+    rows: list[_WindowRow] = []
+    for pv in providers:
+        if pv.currently_over_plan:
+            continue
+        short, long, _, _ = _effective_windows(pv, now)
+        if short is not None:
+            rows.append(_window_row("5h", short))
+        if long is not None:
+            rows.append(_window_row("7d", long))
+    return _ColumnWidths(
+        reset=max((len(row.reset) for row in rows), default=0),
+        pace=max((len(row.pace) for row in rows if row.pace), default=0),
+    )
 
 
 def _stale_windows(
@@ -109,15 +147,23 @@ def _active_window_part(label: str, w: QuotaWindow | None) -> str:
     return f"{label}: {round(w.used_percent):>3d}% ↻ {format_duration(w.reset_seconds)}"
 
 
-def _window_line(label: str, w: QuotaWindow) -> str:
+def _window_row(label: str, w: QuotaWindow) -> _WindowRow:
     used = f"{round(w.used_percent):>3d}%"
-    reset = f"↻ {format_duration(w.reset_seconds)}"
     pace = compute_pace(w)
-    parts = [f"{label}: {used}", reset]
     pace_str = format_pace(pace)
-    if pace_str:
-        parts.append(f"Δ{pace_str}")
-    forecast = format_pace_forecast(pace, w.reset_seconds)
-    if forecast:
-        parts.append(forecast)
-    return "  " + "  ".join(parts)
+    return _WindowRow(
+        label=label,
+        used=used,
+        reset=format_duration(w.reset_seconds),
+        pace=f"Δ{pace_str}" if pace_str else None,
+        forecast=format_pace_forecast(pace, w.reset_seconds),
+    )
+
+
+def _format_window_line(row: _WindowRow, widths: _ColumnWidths) -> str:
+    parts = [f"{row.label}: {row.used}", f"↻ {row.reset:<{widths.reset}}"]
+    if row.pace:
+        parts.append(f"{row.pace:<{widths.pace}}" if row.forecast else row.pace)
+    if row.forecast:
+        parts.append(row.forecast)
+    return ("  " + "  ".join(parts)).rstrip()

--- a/aiquota/render/human.py
+++ b/aiquota/render/human.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
-from aiquota.models import AllQuotas, ExtraUsage, FetchSuccess, QuotaWindow, SuccessfulProviderFetch
+from aiquota.models import AllQuotas, ExtraSpend, FetchSuccess, QuotaWindow, SuccessfulProviderFetch
 from aiquota.pace import compute_pace
 from aiquota.render.format import format_age, format_duration, format_pace, format_pace_forecast
 from aiquota.render.view_model import ProviderView, to_view
@@ -53,7 +53,7 @@ def _render_provider(pv: ProviderView, now: datetime, widths: _ColumnWidths) -> 
     if long is not None:
         lines.append(_format_window_line(_window_row("7d", long), widths))
     if pv.extra_status == "informational" and extra is not None:
-        # Prepaid still has room, but the user incurred extra-usage spend earlier
+        # Prepaid still has room, but the user incurred billable spend earlier
         # in the billing month. Surface it so the monthly bill doesn't sneak up.
         lines.append(f"  {_format_extra_informational(extra)}")
     if len(lines) == 1:
@@ -63,12 +63,12 @@ def _render_provider(pv: ProviderView, now: datetime, widths: _ColumnWidths) -> 
 
 def _effective_windows(
     pv: ProviderView, now: datetime
-) -> tuple[QuotaWindow | None, QuotaWindow | None, ExtraUsage | None, str | None]:
+) -> tuple[QuotaWindow | None, QuotaWindow | None, ExtraSpend | None, str | None]:
     out_result = pv.last_output.result
     # If the latest call gave us nothing usable, fall back to the prior
     # successful snapshot — stale-but-real numbers beat "no data".
     if isinstance(out_result, FetchSuccess) and (out_result.short_window or out_result.long_window):
-        return out_result.short_window, out_result.long_window, out_result.extra_usage, None
+        return out_result.short_window, out_result.long_window, out_result.extra_spend, None
     if pv.last_success is not None:
         return _stale_windows(pv.last_success, now)
     return None, None, None, None
@@ -92,11 +92,11 @@ def _column_widths(providers: list[ProviderView], now: datetime) -> _ColumnWidth
 
 def _stale_windows(
     snap: SuccessfulProviderFetch, now: datetime
-) -> tuple[QuotaWindow | None, QuotaWindow | None, ExtraUsage | None, str]:
+) -> tuple[QuotaWindow | None, QuotaWindow | None, ExtraSpend | None, str]:
     return (
         _refreshed_window(snap.result.short_window, now),
         _refreshed_window(snap.result.long_window, now),
-        snap.result.extra_usage,
+        snap.result.extra_spend,
         format_age((now - snap.fetched_at).total_seconds()),
     )
 
@@ -123,7 +123,7 @@ def _header(provider: str, error: str | None, checked_at: datetime, now: datetim
     return "  ".join(parts)
 
 
-def _format_extra_active(extra: ExtraUsage | None) -> str:
+def _format_extra_active(extra: ExtraSpend | None) -> str:
     # `⚡` flags "paying above subscription right now" — louder than just a number.
     if extra is None:
         return "⚡ OVER PLAN"
@@ -131,7 +131,7 @@ def _format_extra_active(extra: ExtraUsage | None) -> str:
     return f"⚡ OVER PLAN — extra ${extra.used_usd:.2f}/${extra.monthly_limit_usd:.0f} ({pct}%) this month"
 
 
-def _format_extra_informational(extra: ExtraUsage) -> str:
+def _format_extra_informational(extra: ExtraSpend) -> str:
     pct = round(extra.utilization)
     return f"extra: ${extra.used_usd:.2f}/${extra.monthly_limit_usd:.0f} ({pct}%) spent this month"
 

--- a/aiquota/render/test_human.py
+++ b/aiquota/render/test_human.py
@@ -69,6 +69,48 @@ def test_renders_both_windows_with_reset_and_pace(snapshot: SnapshotAssertion) -
     assert out == snapshot
 
 
+def test_aligns_reset_and_pace_columns_across_providers() -> None:
+    out = human.render(
+        _quotas(
+            _pq(
+                "claude",
+                _success(
+                    short_window=QuotaWindow(
+                        used_percent=14, reset_seconds=2 * 3600 + 38 * 60, window_seconds=5 * 3600
+                    ),
+                    long_window=QuotaWindow(
+                        used_percent=33, reset_seconds=2 * 86400 + 11 * 3600, window_seconds=7 * 86400
+                    ),
+                ),
+            ),
+            _pq(
+                "codex",
+                _success(
+                    short_window=QuotaWindow(used_percent=19, reset_seconds=31 * 60, window_seconds=5 * 3600),
+                    long_window=QuotaWindow(
+                        used_percent=3, reset_seconds=6 * 86400 + 19 * 3600, window_seconds=7 * 86400
+                    ),
+                ),
+            ),
+            _pq(
+                "zai",
+                _success(
+                    short_window=QuotaWindow(used_percent=0, reset_seconds=0, window_seconds=5 * 3600),
+                    long_window=QuotaWindow(
+                        used_percent=35, reset_seconds=15 * 3600 + 39 * 60, window_seconds=7 * 86400
+                    ),
+                ),
+            ),
+        ),
+        now=_FETCHED_AT,
+    )
+    lines = out.splitlines()
+    delta_columns = [line.index("Δ") for line in lines if "Δ" in line]
+    forecast_columns = [line.index("leaves") for line in lines if "leaves" in line]
+    assert len(set(delta_columns)) == 1
+    assert len(set(forecast_columns)) == 1
+
+
 def test_extra_enabled_but_prepaid_has_room_shows_normal_bars(snapshot: SnapshotAssertion) -> None:
     # extra_usage.is_enabled=True just means the feature is on; non-zero
     # used_usd is *this month's* total, not "currently burning". While the 7d

--- a/aiquota/render/test_human.py
+++ b/aiquota/render/test_human.py
@@ -5,7 +5,7 @@ from syrupy.assertion import SnapshotAssertion
 
 from aiquota.models import (
     AllQuotas,
-    ExtraUsage,
+    ExtraSpend,
     FetchError,
     FetchSuccess,
     ProviderFetch,
@@ -112,7 +112,7 @@ def test_aligns_reset_and_pace_columns_across_providers() -> None:
 
 
 def test_extra_enabled_but_prepaid_has_room_shows_normal_bars(snapshot: SnapshotAssertion) -> None:
-    # extra_usage.is_enabled=True just means the feature is on; non-zero
+    # ExtraSpend.is_enabled=True just means the feature is on; non-zero
     # used_usd is *this month's* total, not "currently burning". While the 7d
     # window still has room, render the normal bars and surface the monthly
     # spend as an informational tail line so it doesn't sneak up.
@@ -125,7 +125,7 @@ def test_extra_enabled_but_prepaid_has_room_shows_normal_bars(snapshot: Snapshot
                     long_window=QuotaWindow(
                         used_percent=2, reset_seconds=4 * 86400 + 21 * 3600, window_seconds=7 * 86400
                     ),
-                    extra_usage=ExtraUsage(
+                    extra_spend=ExtraSpend(
                         is_enabled=True, monthly_limit_usd=4600.0, used_usd=2324.85, utilization=50.54
                     ),
                 ),
@@ -149,7 +149,7 @@ def test_currently_over_plan_shows_text_only_window_resets_on_one_line(snapshot:
                     long_window=QuotaWindow(
                         used_percent=100, reset_seconds=6 * 86400 + 10 * 3600, window_seconds=7 * 86400
                     ),
-                    extra_usage=ExtraUsage(
+                    extra_spend=ExtraSpend(
                         is_enabled=True, monthly_limit_usd=4600.0, used_usd=3120.50, utilization=67.84
                     ),
                 ),

--- a/aiquota/render/test_view_model.py
+++ b/aiquota/render/test_view_model.py
@@ -2,7 +2,7 @@ from datetime import UTC, datetime
 
 import pytest_bazel
 
-from aiquota.models import AllQuotas, ExtraUsage, FetchSuccess, ProviderFetch, ProviderQuota, QuotaWindow
+from aiquota.models import AllQuotas, ExtraSpend, FetchSuccess, ProviderFetch, ProviderQuota, QuotaWindow
 from aiquota.render.view_model import currently_over_plan, to_view
 
 if __name__ == "__main__":
@@ -16,7 +16,7 @@ def _fetch(**kw) -> ProviderFetch:
     return ProviderFetch(fetched_at=_NOW, result=FetchSuccess(**kw))
 
 
-def test_no_extra_usage_is_not_over_plan() -> None:
+def test_no_extra_spend_is_not_over_plan() -> None:
     assert not currently_over_plan(_fetch())
 
 
@@ -24,18 +24,18 @@ def test_feature_off_is_not_over_plan() -> None:
     # is_enabled=False (no credit card / opted out) → never over plan, no matter the 7d window.
     fetch = _fetch(
         long_window=QuotaWindow(used_percent=100, reset_seconds=0, window_seconds=604800),
-        extra_usage=ExtraUsage(is_enabled=False, monthly_limit_usd=100, used_usd=0, utilization=0),
+        extra_spend=ExtraSpend(is_enabled=False, monthly_limit_usd=100, used_usd=0, utilization=0),
     )
     assert not currently_over_plan(fetch)
 
 
 def test_feature_on_but_prepaid_not_exhausted_is_not_over_plan() -> None:
-    # The user's exact scenario: extra-usage feature on, $2324.85 spent earlier
+    # The user's exact scenario: extra-spend feature on, $2324.85 spent earlier
     # this month, but the weekly quota is fresh — they are not *currently* burning.
     fetch = _fetch(
         short_window=QuotaWindow(used_percent=6, reset_seconds=3600, window_seconds=18000),
         long_window=QuotaWindow(used_percent=2, reset_seconds=86400, window_seconds=604800),
-        extra_usage=ExtraUsage(is_enabled=True, monthly_limit_usd=4600, used_usd=2324.85, utilization=50.54),
+        extra_spend=ExtraSpend(is_enabled=True, monthly_limit_usd=4600, used_usd=2324.85, utilization=50.54),
     )
     assert not currently_over_plan(fetch)
 
@@ -43,7 +43,7 @@ def test_feature_on_but_prepaid_not_exhausted_is_not_over_plan() -> None:
 def test_prepaid_exhausted_with_feature_on_is_over_plan() -> None:
     fetch = _fetch(
         long_window=QuotaWindow(used_percent=100, reset_seconds=86400, window_seconds=604800),
-        extra_usage=ExtraUsage(is_enabled=True, monthly_limit_usd=4600, used_usd=3120, utilization=67),
+        extra_spend=ExtraSpend(is_enabled=True, monthly_limit_usd=4600, used_usd=3120, utilization=67),
     )
     assert currently_over_plan(fetch)
 
@@ -53,7 +53,7 @@ def test_short_window_exhausted_with_feature_on_is_over_plan() -> None:
     fetch = _fetch(
         short_window=QuotaWindow(used_percent=105, reset_seconds=1200, window_seconds=18000),
         long_window=QuotaWindow(used_percent=96, reset_seconds=86400, window_seconds=604800),
-        extra_usage=ExtraUsage(is_enabled=True, monthly_limit_usd=4600, used_usd=3120, utilization=67),
+        extra_spend=ExtraSpend(is_enabled=True, monthly_limit_usd=4600, used_usd=3120, utilization=67),
     )
     assert currently_over_plan(fetch)
 
@@ -66,7 +66,7 @@ def test_extra_status_transitions() -> None:
                 provider="claude",
                 last_output=_fetch(
                     long_window=QuotaWindow(used_percent=100, reset_seconds=86400, window_seconds=604800),
-                    extra_usage=ExtraUsage(is_enabled=True, monthly_limit_usd=100, used_usd=50, utilization=50),
+                    extra_spend=ExtraSpend(is_enabled=True, monthly_limit_usd=100, used_usd=50, utilization=50),
                 ),
             ),
             # informational: feature on, money spent this month, but prepaid has room
@@ -74,10 +74,10 @@ def test_extra_status_transitions() -> None:
                 provider="codex",
                 last_output=_fetch(
                     long_window=QuotaWindow(used_percent=5, reset_seconds=86400, window_seconds=604800),
-                    extra_usage=ExtraUsage(is_enabled=True, monthly_limit_usd=100, used_usd=10, utilization=10),
+                    extra_spend=ExtraSpend(is_enabled=True, monthly_limit_usd=100, used_usd=10, utilization=10),
                 ),
             ),
-            # none: no extra usage at all
+            # none: no extra spend at all
             ProviderQuota(
                 provider="zai",
                 last_output=_fetch(long_window=QuotaWindow(used_percent=5, reset_seconds=86400, window_seconds=604800)),
@@ -87,7 +87,7 @@ def test_extra_status_transitions() -> None:
                 provider="opus",
                 last_output=_fetch(
                     long_window=QuotaWindow(used_percent=5, reset_seconds=86400, window_seconds=604800),
-                    extra_usage=ExtraUsage(is_enabled=True, monthly_limit_usd=100, used_usd=0, utilization=0),
+                    extra_spend=ExtraSpend(is_enabled=True, monthly_limit_usd=100, used_usd=0, utilization=0),
                 ),
             ),
         ],

--- a/aiquota/render/view_model.py
+++ b/aiquota/render/view_model.py
@@ -1,7 +1,7 @@
 """View model shared by the CLI and the GNOME extension.
 
 The extension and the CLI used to each carry their own copy of policy
-decisions like "is the user currently burning extra usage" — and predictably
+decisions like "is the user currently burning extra spend" — and predictably
 drifted (see aiquota/AGENTS.md). This module is the single source of truth
 for those derived booleans; the GNOME extension consumes them via the
 `aiquota gnome-extension-json` subcommand instead of re-deriving locally.
@@ -54,14 +54,14 @@ def _provider_view(pq: ProviderQuota) -> ProviderView:
 def currently_over_plan(out: ProviderFetch) -> bool:
     """True when the user is actively paying USD above subscription right now.
 
-    `extra_usage.is_enabled` only signals "feature enabled on the account",
-    and `extra_usage.used_usd` is a cumulative monthly tally — neither says
+    `ExtraSpend.is_enabled` only signals "feature enabled on the account",
+    and `ExtraSpend.used_usd` is a cumulative monthly tally — neither says
     anything about "right now". The real signal is *any* rate-limit window
     being exhausted (every further call now hits the monthly bill).
     """
     if not isinstance(out.result, FetchSuccess):
         return False
-    extra = out.result.extra_usage
+    extra = out.result.extra_spend
     if extra is None or not extra.is_enabled:
         return False
     short = out.result.short_window
@@ -76,7 +76,7 @@ def _extra_status(out: ProviderFetch) -> ExtraStatus:
         return "active"
     if not isinstance(out.result, FetchSuccess):
         return "none"
-    extra = out.result.extra_usage
+    extra = out.result.extra_spend
     if extra is not None and extra.is_enabled and extra.used_usd > 0:
         return "informational"
     return "none"

--- a/aiquota/test_models.py
+++ b/aiquota/test_models.py
@@ -4,7 +4,7 @@ import pytest_bazel
 
 from aiquota.models import (
     AllQuotas,
-    ExtraUsage,
+    ExtraSpend,
     FetchError,
     FetchSuccess,
     ProviderFetch,
@@ -46,7 +46,7 @@ def test_all_quotas_roundtrip() -> None:
     payload = FetchSuccess(
         short_window=QuotaWindow(used_percent=72.0, reset_seconds=3600.0, window_seconds=18000.0, reset_at=reset_at),
         long_window=QuotaWindow(used_percent=45.0, reset_seconds=86400.0, window_seconds=604800.0),
-        extra_usage=ExtraUsage(is_enabled=True, monthly_limit_usd=100.0, used_usd=62.83, utilization=62.83),
+        extra_spend=ExtraSpend(is_enabled=True, monthly_limit_usd=100.0, used_usd=62.83, utilization=62.83),
     )
     quotas = AllQuotas(
         providers=[
@@ -65,8 +65,8 @@ def test_all_quotas_roundtrip() -> None:
     assert p.last_output.result.short_window is not None
     assert p.last_output.result.short_window.used_percent == 72.0
     assert p.last_output.result.short_window.reset_at == reset_at
-    assert p.last_output.result.extra_usage is not None
-    assert p.last_output.result.extra_usage.monthly_limit_usd == 100.0
+    assert p.last_output.result.extra_spend is not None
+    assert p.last_output.result.extra_spend.monthly_limit_usd == 100.0
     assert p.last_success is not None
     assert p.last_success.result.long_window is not None
     assert restored.fetched_at == quotas.fetched_at

--- a/devinfra/claude/claude_api/BUILD.bazel
+++ b/devinfra/claude/claude_api/BUILD.bazel
@@ -51,6 +51,17 @@ py_library(
 )
 
 py_test(
+    name = "test_usage",
+    srcs = ["test_usage.py"],
+    deps = [
+        ":usage",
+        "@pypi//pydantic",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
+    ],
+)
+
+py_test(
     name = "test_schema_equivalence",
     srcs = ["test_schema_equivalence.py"],
     data = [

--- a/devinfra/claude/claude_api/test_usage.py
+++ b/devinfra/claude/claude_api/test_usage.py
@@ -1,68 +1,46 @@
-import pytest
 import pytest_bazel
-from pydantic import ValidationError
 
-from devinfra.claude.claude_api.usage import UsageResponse, normalized_extra_usage
+from devinfra.claude.claude_api.usage import UsageResponse
 
 if __name__ == "__main__":
     pytest_bazel.main()
 
 
-def test_extra_usage_disabled_with_null_numbers_parses() -> None:
+def test_usage_response_spend() -> None:
     payload = {
-        "five_hour": None,
-        "seven_day": None,
-        "extra_usage": {"is_enabled": False, "monthly_limit": None, "used_credits": None, "utilization": None},
-    }
-    usage = UsageResponse.model_validate(payload)
-    assert usage.extra_usage is not None
-    assert usage.extra_usage.is_enabled is False
-    assert normalized_extra_usage(usage) is None
-
-
-def test_extra_usage_enabled_allows_null_utilization() -> None:
-    payload = {
-        "extra_usage": {"is_enabled": True, "monthly_limit": 250000, "used_credits": 125000, "utilization": None}
-    }
-    usage = UsageResponse.model_validate(payload)
-    extra = normalized_extra_usage(usage)
-    assert extra is not None
-    assert extra.monthly_limit == 250000
-    assert extra.used_credits == 125000
-    assert extra.utilization == 50.0
-
-
-def test_extra_usage_enabled_rejects_null_money() -> None:
-    payload = {"extra_usage": {"is_enabled": True, "monthly_limit": None, "used_credits": None}}
-    with pytest.raises(ValidationError):
-        UsageResponse.model_validate(payload)
-
-
-def test_spend_shape_drives_extra_usage() -> None:
-    payload = {
-        "extra_usage": {
-            "currency": "USD",
-            "daily": None,
-            "decimal_places": 2,
-            "disabled_reason": None,
-            "is_enabled": True,
-            "monthly_limit": 250000,
-            "used_credits": 0.0,
-            "utilization": None,
-            "weekly": None,
-        },
         "spend": {
             "enabled": True,
             "limit": {"amount_minor": 250000, "currency": "USD", "exponent": 2},
             "percent": 4.94,
             "severity": "normal",
             "used": {"amount_minor": 12345, "currency": "USD", "exponent": 2},
-        },
+        }
     }
     usage = UsageResponse.model_validate(payload)
-    extra = normalized_extra_usage(usage)
-    assert extra is not None
-    assert extra.monthly_limit == 250000
-    assert extra.used_credits == 12345
-    assert extra.utilization == 4.94
-    assert extra.currency == "USD"
+    assert usage.spend is not None
+    assert usage.spend.has_usage_totals
+    assert usage.spend.limit is not None
+    assert usage.spend.limit.major_units == 2500.0
+    assert usage.spend.used is not None
+    assert usage.spend.used.major_units == 123.45
+    assert usage.spend.utilization_percent == 4.94
+
+
+def test_usage_response_spend_derives_percent_when_missing() -> None:
+    usage = UsageResponse.model_validate(
+        {
+            "spend": {
+                "enabled": True,
+                "limit": {"amount_minor": 250000, "currency": "USD", "exponent": 2},
+                "used": {"amount_minor": 125000, "currency": "USD", "exponent": 2},
+            }
+        }
+    )
+    assert usage.spend is not None
+    assert usage.spend.utilization_percent == 50.0
+
+
+def test_usage_response_disabled_spend_has_no_usage_totals() -> None:
+    usage = UsageResponse.model_validate({"spend": {"enabled": False, "disabled_reason": "payment_method_required"}})
+    assert usage.spend is not None
+    assert not usage.spend.has_usage_totals

--- a/devinfra/claude/claude_api/test_usage.py
+++ b/devinfra/claude/claude_api/test_usage.py
@@ -2,18 +2,13 @@ import pytest
 import pytest_bazel
 from pydantic import ValidationError
 
-from aiquota.providers.claude import _to_extra_usage
-from devinfra.claude.claude_api.usage import UsageResponse
+from devinfra.claude.claude_api.usage import UsageResponse, normalized_extra_usage
 
 if __name__ == "__main__":
     pytest_bazel.main()
 
 
 def test_extra_usage_disabled_with_null_numbers_parses() -> None:
-    # The OAuth usage API returns explicit `null` for the numeric fields
-    # when extra-usage isn't entitled on the plan. Parsing must succeed
-    # (the disabled variant carries no numbers) — see the regression
-    # report where this raised three `float_type` ValidationErrors.
     payload = {
         "five_hour": None,
         "seven_day": None,
@@ -22,15 +17,7 @@ def test_extra_usage_disabled_with_null_numbers_parses() -> None:
     usage = UsageResponse.model_validate(payload)
     assert usage.extra_usage is not None
     assert usage.extra_usage.is_enabled is False
-
-
-def test_extra_usage_enabled_requires_numbers() -> None:
-    payload = {
-        "extra_usage": {"is_enabled": True, "monthly_limit": 4600.0, "used_credits": 2324.85, "utilization": 50.54}
-    }
-    usage = UsageResponse.model_validate(payload)
-    assert usage.extra_usage is not None
-    assert usage.extra_usage.monthly_limit == 4600.0
+    assert normalized_extra_usage(usage) is None
 
 
 def test_extra_usage_enabled_allows_null_utilization() -> None:
@@ -38,10 +25,10 @@ def test_extra_usage_enabled_allows_null_utilization() -> None:
         "extra_usage": {"is_enabled": True, "monthly_limit": 250000, "used_credits": 125000, "utilization": None}
     }
     usage = UsageResponse.model_validate(payload)
-    extra = _to_extra_usage(usage)
+    extra = normalized_extra_usage(usage)
     assert extra is not None
-    assert extra.monthly_limit_usd == 2500.0
-    assert extra.used_usd == 1250.0
+    assert extra.monthly_limit == 250000
+    assert extra.used_credits == 125000
     assert extra.utilization == 50.0
 
 
@@ -53,18 +40,29 @@ def test_extra_usage_enabled_rejects_null_money() -> None:
 
 def test_spend_shape_drives_extra_usage() -> None:
     payload = {
-        "extra_usage": {"is_enabled": True, "monthly_limit": 250000, "used_credits": 0.0, "utilization": None},
+        "extra_usage": {
+            "currency": "USD",
+            "daily": None,
+            "decimal_places": 2,
+            "disabled_reason": None,
+            "is_enabled": True,
+            "monthly_limit": 250000,
+            "used_credits": 0.0,
+            "utilization": None,
+            "weekly": None,
+        },
         "spend": {
             "enabled": True,
             "limit": {"amount_minor": 250000, "currency": "USD", "exponent": 2},
-            "used": {"amount_minor": 12345, "currency": "USD", "exponent": 2},
             "percent": 4.94,
             "severity": "normal",
+            "used": {"amount_minor": 12345, "currency": "USD", "exponent": 2},
         },
     }
     usage = UsageResponse.model_validate(payload)
-    extra = _to_extra_usage(usage)
+    extra = normalized_extra_usage(usage)
     assert extra is not None
-    assert extra.monthly_limit_usd == 2500.0
-    assert extra.used_usd == 123.45
+    assert extra.monthly_limit == 250000
+    assert extra.used_credits == 12345
     assert extra.utilization == 4.94
+    assert extra.currency == "USD"

--- a/devinfra/claude/claude_api/usage.py
+++ b/devinfra/claude/claude_api/usage.py
@@ -1,9 +1,10 @@
 """Client and models for the Claude subscription usage API."""
 
 from datetime import datetime
+from typing import Self
 
 import httpx
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
 
 # Undocumented Claude Code-specific endpoint for subscription utilization
 # (5-hour / 7-day quotas). Not part of the official Anthropic Python SDK,
@@ -23,11 +24,44 @@ class ExtraUsage(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     is_enabled: bool
+    monthly_limit: float | None = None
+    used_credits: float | None = None
+    utilization: float | None = None
+    currency: str | None = None
+    disabled_reason: str | None = None
+
+    @model_validator(mode="after")
+    def _enabled_requires_money(self) -> Self:
+        if self.is_enabled and (self.monthly_limit is None or self.used_credits is None):
+            raise ValueError("enabled extra_usage requires monthly_limit and used_credits")
+        return self
+
+
+class MoneyAmount(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    amount_minor: float
+    exponent: int = 2
+    currency: str | None = None
+
+
+class Spend(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    enabled: bool | None = None
+    limit: MoneyAmount | None = None
+    used: MoneyAmount | None = None
+    percent: float | None = None
+    severity: str | None = None
+    disabled_reason: str | None = None
+
+
+class ExtraUsageTotals(BaseModel):
+    is_enabled: bool = True
     monthly_limit: float
     used_credits: float
     utilization: float
-    currency: str
-    disabled_reason: str | None = None
+    currency: str | None = None
 
 
 class UsageResponse(BaseModel):
@@ -38,6 +72,45 @@ class UsageResponse(BaseModel):
     seven_day_opus: UsageBucket | None = None
     seven_day_sonnet: UsageBucket | None = None
     extra_usage: ExtraUsage | None = None
+    spend: Spend | None = None
+
+
+def _major_to_minor_units(amount: MoneyAmount) -> float:
+    return amount.amount_minor * (100 / (10**amount.exponent))
+
+
+def _utilization(used_credits: float, monthly_limit: float, explicit: float | None) -> float:
+    if explicit is not None:
+        return explicit
+    return used_credits / monthly_limit * 100 if monthly_limit > 0 else 0.0
+
+
+def normalized_extra_usage(usage: UsageResponse) -> ExtraUsageTotals | None:
+    spend = usage.spend
+    if spend is not None:
+        if spend.enabled is False:
+            return None
+        if spend.enabled is True and spend.limit is not None and spend.used is not None:
+            monthly_limit = _major_to_minor_units(spend.limit)
+            used_credits = _major_to_minor_units(spend.used)
+            return ExtraUsageTotals(
+                monthly_limit=monthly_limit,
+                used_credits=used_credits,
+                utilization=_utilization(used_credits, monthly_limit, spend.percent),
+                currency=spend.used.currency or spend.limit.currency,
+            )
+
+    extra = usage.extra_usage
+    if extra is None or not extra.is_enabled:
+        return None
+    assert extra.monthly_limit is not None
+    assert extra.used_credits is not None
+    return ExtraUsageTotals(
+        monthly_limit=extra.monthly_limit,
+        used_credits=extra.used_credits,
+        utilization=_utilization(extra.used_credits, extra.monthly_limit, extra.utilization),
+        currency=extra.currency,
+    )
 
 
 def fetch_usage(token: str) -> UsageResponse:

--- a/devinfra/claude/claude_api/usage.py
+++ b/devinfra/claude/claude_api/usage.py
@@ -1,10 +1,9 @@
 """Client and models for the Claude subscription usage API."""
 
 from datetime import datetime
-from typing import Self
 
 import httpx
-from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic import BaseModel, ConfigDict
 
 # Undocumented Claude Code-specific endpoint for subscription utilization
 # (5-hour / 7-day quotas). Not part of the official Anthropic Python SDK,
@@ -20,29 +19,16 @@ class UsageBucket(BaseModel):
     resets_at: datetime | None = None
 
 
-class ExtraUsage(BaseModel):
-    model_config = ConfigDict(extra="ignore")
-
-    is_enabled: bool
-    monthly_limit: float | None = None
-    used_credits: float | None = None
-    utilization: float | None = None
-    currency: str | None = None
-    disabled_reason: str | None = None
-
-    @model_validator(mode="after")
-    def _enabled_requires_money(self) -> Self:
-        if self.is_enabled and (self.monthly_limit is None or self.used_credits is None):
-            raise ValueError("enabled extra_usage requires monthly_limit and used_credits")
-        return self
-
-
 class MoneyAmount(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     amount_minor: float
     exponent: int = 2
     currency: str | None = None
+
+    @property
+    def major_units(self) -> float:
+        return self.amount_minor / (10**self.exponent)
 
 
 class Spend(BaseModel):
@@ -55,13 +41,17 @@ class Spend(BaseModel):
     severity: str | None = None
     disabled_reason: str | None = None
 
+    @property
+    def has_usage_totals(self) -> bool:
+        return self.enabled is True and self.limit is not None and self.used is not None
 
-class ExtraUsageTotals(BaseModel):
-    is_enabled: bool = True
-    monthly_limit: float
-    used_credits: float
-    utilization: float
-    currency: str | None = None
+    @property
+    def utilization_percent(self) -> float:
+        if self.percent is not None:
+            return self.percent
+        if self.limit is None or self.used is None or self.limit.amount_minor <= 0:
+            return 0.0
+        return self.used.amount_minor / self.limit.amount_minor * 100
 
 
 class UsageResponse(BaseModel):
@@ -71,46 +61,7 @@ class UsageResponse(BaseModel):
     seven_day: UsageBucket | None = None
     seven_day_opus: UsageBucket | None = None
     seven_day_sonnet: UsageBucket | None = None
-    extra_usage: ExtraUsage | None = None
     spend: Spend | None = None
-
-
-def _major_to_minor_units(amount: MoneyAmount) -> float:
-    return amount.amount_minor * (100 / (10**amount.exponent))
-
-
-def _utilization(used_credits: float, monthly_limit: float, explicit: float | None) -> float:
-    if explicit is not None:
-        return explicit
-    return used_credits / monthly_limit * 100 if monthly_limit > 0 else 0.0
-
-
-def normalized_extra_usage(usage: UsageResponse) -> ExtraUsageTotals | None:
-    spend = usage.spend
-    if spend is not None:
-        if spend.enabled is False:
-            return None
-        if spend.enabled is True and spend.limit is not None and spend.used is not None:
-            monthly_limit = _major_to_minor_units(spend.limit)
-            used_credits = _major_to_minor_units(spend.used)
-            return ExtraUsageTotals(
-                monthly_limit=monthly_limit,
-                used_credits=used_credits,
-                utilization=_utilization(used_credits, monthly_limit, spend.percent),
-                currency=spend.used.currency or spend.limit.currency,
-            )
-
-    extra = usage.extra_usage
-    if extra is None or not extra.is_enabled:
-        return None
-    assert extra.monthly_limit is not None
-    assert extra.used_credits is not None
-    return ExtraUsageTotals(
-        monthly_limit=extra.monthly_limit,
-        used_credits=extra.used_credits,
-        utilization=_utilization(extra.used_credits, extra.monthly_limit, extra.utilization),
-        currency=extra.currency,
-    )
 
 
 def fetch_usage(token: str) -> UsageResponse:

--- a/devinfra/claude/statusline/BUILD.bazel
+++ b/devinfra/claude/statusline/BUILD.bazel
@@ -19,6 +19,7 @@ py_library(
         "//devinfra/claude:session_paths",
         "//devinfra/claude/claude_api:credentials",
         "//devinfra/claude/claude_api:statusline",
+        "//devinfra/claude/claude_api:usage",
         "@pypi//rich",
     ],
 )

--- a/devinfra/claude/statusline/statusline.py
+++ b/devinfra/claude/statusline/statusline.py
@@ -17,7 +17,7 @@ from rich.text import Text
 
 from devinfra.claude.claude_api.credentials import read_credentials
 from devinfra.claude.claude_api.statusline import ContextWindow, Input
-from devinfra.claude.claude_api.usage import ExtraUsageTotals, normalized_extra_usage
+from devinfra.claude.claude_api.usage import Spend
 from devinfra.claude.session_paths import default_cache_dir, hook_daemon_sock
 from devinfra.claude.statusline.usage_cache import CachedUsage, UsageCache
 
@@ -42,10 +42,12 @@ def _format_delta(delta: timedelta) -> str:
     return f"{total_seconds}s"
 
 
-def _format_extra_usage(extra: ExtraUsageTotals) -> str:
-    used = extra.used_credits / 100
-    limit = extra.monthly_limit / 100
-    pct = extra.utilization
+def _format_spend(spend: Spend) -> str:
+    assert spend.limit is not None
+    assert spend.used is not None
+    used = spend.used.major_units
+    limit = spend.limit.major_units
+    pct = spend.utilization_percent
     return f"extra ${used:.0f}/${limit:.0f} ({pct:.0f}%)"
 
 
@@ -73,9 +75,8 @@ def _format_quota(cached: CachedUsage | None, now: datetime) -> Text | None:
                         if time_to_exhaust < remaining:
                             part += f" dry {_format_delta(time_to_exhaust)}"
         parts.append(part)
-    extra = normalized_extra_usage(usage)
-    if extra is not None:
-        parts.append(_format_extra_usage(extra))
+    if usage.spend is not None and usage.spend.has_usage_totals:
+        parts.append(_format_spend(usage.spend))
     if parts:
         age = now - cached.fetched_at
         if age > _STALE_THRESHOLD:

--- a/devinfra/claude/statusline/statusline.py
+++ b/devinfra/claude/statusline/statusline.py
@@ -17,7 +17,7 @@ from rich.text import Text
 
 from devinfra.claude.claude_api.credentials import read_credentials
 from devinfra.claude.claude_api.statusline import ContextWindow, Input
-from devinfra.claude.claude_api.usage import ExtraUsage
+from devinfra.claude.claude_api.usage import ExtraUsageTotals, normalized_extra_usage
 from devinfra.claude.session_paths import default_cache_dir, hook_daemon_sock
 from devinfra.claude.statusline.usage_cache import CachedUsage, UsageCache
 
@@ -42,7 +42,7 @@ def _format_delta(delta: timedelta) -> str:
     return f"{total_seconds}s"
 
 
-def _format_extra_usage(extra: ExtraUsage) -> str:
+def _format_extra_usage(extra: ExtraUsageTotals) -> str:
     used = extra.used_credits / 100
     limit = extra.monthly_limit / 100
     pct = extra.utilization
@@ -73,8 +73,9 @@ def _format_quota(cached: CachedUsage | None, now: datetime) -> Text | None:
                         if time_to_exhaust < remaining:
                             part += f" dry {_format_delta(time_to_exhaust)}"
         parts.append(part)
-    if usage.extra_usage is not None and usage.extra_usage.is_enabled:
-        parts.append(_format_extra_usage(usage.extra_usage))
+    extra = normalized_extra_usage(usage)
+    if extra is not None:
+        parts.append(_format_extra_usage(extra))
     if parts:
         age = now - cached.fetched_at
         if age > _STALE_THRESHOLD:

--- a/devinfra/claude/statusline/test_statusline.py
+++ b/devinfra/claude/statusline/test_statusline.py
@@ -372,6 +372,27 @@ def test_format_quota_extra_usage():
     assert "extra $2317/$4600 (50%)" in result.plain
 
 
+def test_format_quota_spend_extra_usage():
+    now = datetime.now(UTC)
+    usage = UsageResponse.model_validate(
+        {
+            "seven_day": {"utilization": 100.0},
+            "extra_usage": {"is_enabled": True, "monthly_limit": 250000, "used_credits": 0.0, "utilization": None},
+            "spend": {
+                "enabled": True,
+                "limit": {"amount_minor": 250000, "currency": "USD", "exponent": 2},
+                "used": {"amount_minor": 12345, "currency": "USD", "exponent": 2},
+                "percent": 4.94,
+            },
+        }
+    )
+    cached = CachedUsage(fetched_at=now, usage=usage)
+    result = _format_quota(cached, now=now)
+    assert result is not None
+    assert "7d:100%" in result.plain
+    assert "extra $123/$2500 (5%)" in result.plain
+
+
 def test_format_quota_extra_usage_disabled_not_shown():
     now = datetime.now(UTC)
     usage = UsageResponse(

--- a/devinfra/claude/statusline/test_statusline.py
+++ b/devinfra/claude/statusline/test_statusline.py
@@ -11,7 +11,7 @@ from syrupy.assertion import SnapshotAssertion
 
 from devinfra.claude.claude_api.credentials import read_credentials
 from devinfra.claude.claude_api.statusline import ContextWindow, Input
-from devinfra.claude.claude_api.usage import ExtraUsage, UsageBucket, UsageResponse
+from devinfra.claude.claude_api.usage import UsageBucket, UsageResponse
 from devinfra.claude.statusline.statusline import _format_context, _format_quota, render
 from devinfra.claude.statusline.usage_cache import CACHE_TTL, CachedUsage, UsageCache
 
@@ -146,47 +146,6 @@ def test_usage_response_null_resets_at():
     assert resp.seven_day is not None
     assert resp.seven_day.utilization == 100.0
     assert resp.seven_day.resets_at is not None
-
-
-def test_usage_response_extra_usage():
-    raw = {
-        "five_hour": {"utilization": 0.0, "resets_at": None},
-        "seven_day": {"utilization": 100.0, "resets_at": "2026-05-15T16:00:00+00:00"},
-        "extra_usage": {
-            "is_enabled": True,
-            "monthly_limit": 460000,
-            "used_credits": 231689.0,
-            "utilization": 50.37,
-            "currency": "USD",
-            "disabled_reason": None,
-        },
-    }
-    resp = UsageResponse.model_validate(raw)
-    assert resp.extra_usage is not None
-    assert resp.extra_usage.is_enabled is True
-    assert resp.extra_usage.monthly_limit == 460000
-    assert resp.extra_usage.used_credits == 231689.0
-    assert resp.extra_usage.utilization == 50.37
-    assert resp.extra_usage.currency == "USD"
-    assert resp.extra_usage.disabled_reason is None
-
-
-def test_usage_response_extra_usage_disabled():
-    raw = {
-        "five_hour": {"utilization": 5.0},
-        "extra_usage": {
-            "is_enabled": False,
-            "monthly_limit": 0,
-            "used_credits": 0,
-            "utilization": 0,
-            "currency": "USD",
-            "disabled_reason": "payment_method_required",
-        },
-    }
-    resp = UsageResponse.model_validate(raw)
-    assert resp.extra_usage is not None
-    assert resp.extra_usage.is_enabled is False
-    assert resp.extra_usage.disabled_reason == "payment_method_required"
 
 
 def test_read_credentials(tmp_path: Path):
@@ -357,27 +316,11 @@ def test_format_quota_exhaustion_projection(utilization: float, resets_in: timed
         assert result.plain.endswith(expected_dry)
 
 
-def test_format_quota_extra_usage():
-    now = datetime.now(UTC)
-    usage = UsageResponse(
-        seven_day=UsageBucket(utilization=100.0),
-        extra_usage=ExtraUsage(
-            is_enabled=True, monthly_limit=460000, used_credits=231689.0, utilization=50.37, currency="USD"
-        ),
-    )
-    cached = CachedUsage(fetched_at=now, usage=usage)
-    result = _format_quota(cached, now=now)
-    assert result is not None
-    assert "7d:100%" in result.plain
-    assert "extra $2317/$4600 (50%)" in result.plain
-
-
 def test_format_quota_spend_extra_usage():
     now = datetime.now(UTC)
     usage = UsageResponse.model_validate(
         {
             "seven_day": {"utilization": 100.0},
-            "extra_usage": {"is_enabled": True, "monthly_limit": 250000, "used_credits": 0.0, "utilization": None},
             "spend": {
                 "enabled": True,
                 "limit": {"amount_minor": 250000, "currency": "USD", "exponent": 2},
@@ -393,18 +336,10 @@ def test_format_quota_spend_extra_usage():
     assert "extra $123/$2500 (5%)" in result.plain
 
 
-def test_format_quota_extra_usage_disabled_not_shown():
+def test_format_quota_disabled_spend_not_shown():
     now = datetime.now(UTC)
-    usage = UsageResponse(
-        seven_day=UsageBucket(utilization=30.0),
-        extra_usage=ExtraUsage(
-            is_enabled=False,
-            monthly_limit=0,
-            used_credits=0,
-            utilization=0,
-            currency="USD",
-            disabled_reason="payment_method_required",
-        ),
+    usage = UsageResponse.model_validate(
+        {"seven_day": {"utilization": 30.0}, "spend": {"enabled": False, "disabled_reason": "payment_method_required"}}
     )
     cached = CachedUsage(fetched_at=now, usage=usage)
     result = _format_quota(cached, now=now)


### PR DESCRIPTION
## Summary

- Move Claude usage response parsing into `devinfra/claude/claude_api:usage` so aiquota and statusline share the same current API model.
- Parse Claude's current `spend` object directly into aiquota's `ExtraSpend` / `extra_spend` summary for billable spend fields.
- Align aiquota CLI reset, pace, and forecast columns across providers.

## Root Cause

Claude's usage API now exposes the usable extra spend billing state in `spend` (`enabled`, `limit`, `used`, `percent`). The older `extra_usage` object is still present in responses but is not a reliable source for rendering because its `utilization` can be `null`. aiquota had a separate stale response model and was rejecting the live response before it could render.

## Validation

- `pre-commit run --files aiquota/AGENTS.md aiquota/gnome/extension.js aiquota/gnome/test_fixtures/empty.json aiquota/gnome/test_fixtures/extra_enabled_not_burning.json aiquota/gnome/test_fixtures/hot.json aiquota/gnome/test_fixtures/stale_fallback.json aiquota/gnome/test_fixtures/tints.json aiquota/gnome/test_render.py aiquota/models.py aiquota/providers/claude.py aiquota/providers/test_claude.py aiquota/render/human.py aiquota/render/test_human.py aiquota/render/test_view_model.py aiquota/render/view_model.py aiquota/test_models.py`
- `bazelisk test //aiquota:test_models //aiquota/providers:test_claude //aiquota/render:test_human //aiquota/render:test_view_model //aiquota/gnome:test_render //devinfra/claude/claude_api:test_usage //devinfra/claude/statusline:test_statusline`
- `bazelisk run --run_under=env\ XDG_CACHE_HOME=/tmp/aiquota-pr-smoke-2 //aiquota -- --config /home/agentydragon/.config/aiquota/config.toml`