### PR TITLE
container-images: rebuild rbe-worker on flake / nix/packages changes

### DIFF
--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -17,8 +17,19 @@ name: Container Images
 on:
   push:
     branches: [main, devel]
+    # rbe-worker's Dockerfile COPYs flake.nix + nix/packages/** + the two
+    # pins JSONs and runs `nix build .#rbetools`, so the image's content
+    # depends on those trees, not just devinfra/rbe_image/**. Missing them
+    # here means a nix/packages change (e.g. #2679 adding
+    # target-determinator) doesn't rebuild the image and image_pins.json
+    # falls out of date; the next `bazel-ci` run silently uses the old image.
     paths:
       - "devinfra/rbe_image/**"
+      - "flake.nix"
+      - "flake.lock"
+      - "nix/packages/**"
+      - "nix/artifact-pins.json"
+      - "nix/gaffer-pins.json"
       - "skills/freecad/Dockerfile.test"
       - "x/rtl_tcp/Dockerfile"
       - "loom/gym/sandbox/**"


### PR DESCRIPTION
Fix a missed-rebuild bug in `container-images.yml`.

## The bug

The `rbe-worker` Dockerfile (`devinfra/rbe_image/Dockerfile`) builds its userland via `nix build .#rbetools` after `COPY`ing:

- `flake.nix`, `flake.lock`
- `nix/artifact-pins.json`
- `nix/packages/` (whole tree)
- `nix/gaffer-pins.json`

So the image's effective input set is those trees **plus** `devinfra/rbe_image/`. But the `paths:` trigger on `container-images.yml` only watched `devinfra/rbe_image/**`. #2679 added `target-determinator` via `nix/packages/target-determinator.nix` and edits to `flake.nix` + `nix/packages/default.nix`; none matched the trigger; `container-images.yml` didn't fire; `image_pins.json` stayed at the pre-#2679 digest; downstream `bazel-ci` runs (and the shadow-mode step in #2680) silently kept using the old image, where `target-determinator` isn't on PATH.

## The fix

Add the missing paths so the trigger's watched set matches the Dockerfile's actual `COPY` set. Brief comment above the block explains why these paths belong here — the connection isn't obvious from reading the trigger in isolation.

## Verification path

Once merged, the push to `devel` should:

1. Trigger `container-images.yml` (all rbe-worker-affecting paths are touched by the merge base of this PR).
2. Rebuild `ghcr.io/agentydragon/rbe-worker` — now containing `target-determinator` from #2679.
3. `Pin Digests` job runs `python3 devinfra/update_image_pin.py rbe_worker --digest <new>` and pushes a `chore: pin rbe_worker image digest(s) [skip ci]` commit.
4. From that commit onward:
   - #2680's shadow-mode step stops no-op'ing (its `command -v target-determinator` guard passes) and starts logging the affected set on every PR.
   - #2683's CI stops failing with `command not found`.

## Scope

Trigger-paths only. No workflow logic changes. No effect on any workflow that was already firing correctly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcmYZYsrpgiZViSQeuNgXG)_