### PR TITLE
branch-protection: TODO to gate PRs on nix-wheel-check once it's stable

### DIFF
--- a/tf/gitops/github-branch-protection/README.md
+++ b/tf/gitops/github-branch-protection/README.md
@@ -60,6 +60,11 @@ access control plus the `ducktape-automation` App for GitOps writes.
 
 ## Remaining Cleanup
 
+- Add `Build artifacts + imports check` (the `Nix wheel check` workflow's job
+  name; see <../../../.github/workflows/nix-wheel-check.yml>) to
+  `required_status_checks` once it has ~a week of green runs on devel — the
+  workflow landed with #2678 and needs some soak time to shake out any RBE
+  peer-exhaustion / nix substituter flakes before it becomes a merge gate.
 - Verify whether GitHub Secret Protection covers push protection on private
   personal-account repos now, then enable or explicitly reject it for
   `gaffer-private`.


### PR DESCRIPTION
## Why

Follow-up to #2678, which landed the `Nix wheel check` workflow (`.github/workflows/nix-wheel-check.yml`) as a per-PR nix imports-check gate but didn't make it a required status check yet — waiting to see it stay green on devel for a bit before turning it into a merge gate.

Landing a TODO next to the branch-protection ruleset so the follow-up (add `required_check { context = "Build artifacts + imports check" }` to the ruleset's `required_status_checks` block in `main.tf`) doesn't rot.

## What

One-line entry in the "Remaining Cleanup" section of <tf/gitops/github-branch-protection/README.md>. Documents:

- The exact check-run name to add (`Build artifacts + imports check` — the job's `name:` in the workflow; no `<caller> /` prefix because nix-wheel-check.yml is a top-level `on: pull_request:` workflow, not a reusable one).
- The trigger to remove the TODO: ~a week of green runs on devel.
- The reason to wait: shake out any RBE peer-exhaustion / nix substituter flakes before every PR gets stuck on this gate.

## Test plan

- [x] Prettier check on the touched file
- Nothing to CI here — pure prose in a doc file


---
_Generated by [Claude Code](https://claude.ai/code/session_01WAJ8JXpinZkv2x9GLD6ULj)_