### PR TITLE
Use inline format strings in selector constraint backend

### DIFF
--- a/devinfra/js/debundle/selector_constraint_backend.rs
+++ b/devinfra/js/debundle/selector_constraint_backend.rs
@@ -1531,8 +1531,7 @@ impl CompiledSelectorProblemBuilder {
         if kept_rows.is_empty() {
             self.known_unsat.get_or_insert_with(|| {
                 format!(
-                    "allowed tuple constraint over {:?} has no rows after domain pruning",
-                    variables
+                    "allowed tuple constraint over {variables:?} has no rows after domain pruning"
                 )
             });
             return Ok(None);
@@ -1670,8 +1669,7 @@ impl CompiledSelectorProblemBuilder {
                         if !fixed_values.insert(*value) {
                             self.known_unsat.get_or_insert_with(|| {
                                 format!(
-                                    "all_different has duplicate fixed value {:?} for variable {:?}",
-                                    value, variable
+                                    "all_different has duplicate fixed value {value:?} for variable {variable:?}"
                                 )
                             });
                         }


### PR DESCRIPTION
## Summary
Modernize string formatting in the selector constraint backend by using Rust's inline format string syntax instead of separate format arguments.

## Changes
- Updated error message formatting in `CompiledSelectorProblemBuilder` to use inline `{variable:?}` syntax instead of positional arguments
- Affected two error messages:
  - "allowed tuple constraint over..." message (line 1534)
  - "all_different has duplicate fixed value..." message (line 1673)

## Details
These changes improve code readability by keeping variable references inline with their usage in format strings, making the code more maintainable and easier to understand at a glance. This is a stylistic improvement with no functional changes to the error messages or behavior.

https://claude.ai/code/session_01Ya2CjwFWgyqNtjLx9tYiqe