### PR TITLE
bazel-ci: fix target-determinator flag syntax in shadow-mode block

### DIFF
--- a/.github/workflows/bazel-ci.yml
+++ b/.github/workflows/bazel-ci.yml
@@ -96,10 +96,12 @@ jobs:
               if [ -n "$BASE" ] && [ -n "$HEAD_SHA" ]; then
                 echo "before-revision: $BASE"
                 echo "head:            $HEAD_SHA"
+                # -targets is the query (default //...); the before-revision
+                # is a positional argument, NOT -before-revision.
                 target-determinator \
                   -cache-dir=/tmp/td-cache \
-                  -before-revision="$BASE" \
-                  //...
+                  -targets=//... \
+                  "$BASE"
               else
                 echo "could not resolve merge-base (BASE=$BASE HEAD=$HEAD_SHA); skipping"
               fi


### PR DESCRIPTION
Fix a flag-syntax bug in the shadow-mode `target-determinator` invocation.

## The bug

`.github/workflows/bazel-ci.yml` currently calls:

```bash
target-determinator \
  -cache-dir=/tmp/td-cache \
  -before-revision="$BASE" \
  //...
```

`-before-revision` is not a valid flag. `target-determinator` errors out with `flag provided but not defined: -before-revision`. Real interface is:

```bash
target-determinator [flags] <before-revision>
```

where `-targets=<query>` (default `//...`) scopes the query and the before-revision is a **positional** argument.

## Why it wasn't caught earlier

The shadow block only runs when `command -v target-determinator` is true. The RBE image only started containing `target-determinator` after #2685's pin update landed (a7c7209). No PR since then has produced meaningful shadow output — every attempted shadow run has been silently swallowed by the block's `set +e` + `|| echo`, printing the Go flag-usage message instead of the affected-target set.

I hit this on #2683's actual gating path (same syntax, no `set +e`) which failed loudly with the same error.

## The fix

Swap `-before-revision="$BASE"` + trailing `//...` for `-targets=//...` + trailing `"$BASE"`. Tiny mechanical change; brief comment above the block calls out the flag-vs-positional distinction so it doesn't get re-introduced.

## After merge

Shadow mode starts producing real affected-set logs on every PR. Once those look sane, #2683 (already carries the same fix in its own block) can move out of draft.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcmYZYsrpgiZViSQeuNgXG)_