### PR TITLE
bazel-ci: exclude //website from target-determinator's query

### DIFF
--- a/.github/workflows/bazel-ci.yml
+++ b/.github/workflows/bazel-ci.yml
@@ -98,9 +98,16 @@ jobs:
                 echo "head:            $HEAD_SHA"
                 # -targets is the query (default //...); the before-revision
                 # is a positional argument, NOT -before-revision.
+                #
+                # Exclude //website/...: it carries tags=["manual"] so `bazel
+                # test //...` (and its analysis) skip it, but TD's cquery
+                # doesn't respect manual-tag filtering and trips a deprecated
+                # ctx.resolve_tools call in rules_haskell during analysis of
+                # the Hakyll REPL target. Excluding matches what `bazel test
+                # //...` on devel already sees.
                 target-determinator \
                   -cache-dir=/tmp/td-cache \
-                  -targets=//... \
+                  -targets='//... except //website/...' \
                   "$BASE"
               else
                 echo "could not resolve merge-base (BASE=$BASE HEAD=$HEAD_SHA); skipping"


### PR DESCRIPTION
Fix a real analysis-time failure in the shadow-mode `target-determinator` invocation.

## The bug

`.github/workflows/bazel-ci.yml`'s shadow block currently calls:

```bash
target-determinator -cache-dir=/tmp/td-cache -targets=//... "$BASE"
```

TD runs `bazel cquery` under the hood. `//website/BUILD` has `tags = ["manual"]`, and Bazel filters manual-tagged targets out of `//...` expansion *for `bazel test` only* — analysis-time filtering happens before analysis when `bazel test //...` walks the pattern, so devel never analyzes it. `bazel query //...` does not filter, so TD's cquery analyzes `//website:site@repl@bios-script` and trips a deprecated `ctx.resolve_tools` call in `rules_haskell` that current Bazel rejects:

```
Error in resolve_tools: Pass an executable or tools argument to
ctx.actions.run or ctx.actions.run_shell instead of calling
ctx.resolve_tools.
Use --noincompatible_disallow_ctx_resolve_tools to temporarily disable this check.
```

Result: every shadow-mode run since #2685's pin landed target-determinator on PATH has been silently emitting this Bazel error into the CI log (swallowed by the shadow block's `set +e`) instead of the affected-target set.

## The fix

Narrow TD's query from `//...` to `'//... except //website/...'`. Matches what `bazel test //...` on devel already analyzes.

## Why exclusion (not fix rules_haskell)

`--noincompatible_disallow_ctx_resolve_tools` isn't set in `.bazelrc`, but `bazel test //...` on devel currently passes — because it never analyzes the Haskell REPL target thanks to the `manual` tag. Aligning TD with that filter is the smallest change that unblocks shadow data. If the manual-tag skip is ever removed from `//website`, the rules_haskell issue would surface on plain `bazel test //...` and can be dealt with separately.

## Discovered via

#2683's affected-only gating hit the same error (same query, no `set +e`) and failed loudly. Fix is included in #2683's own block via the same change, but landing it on devel now lets shadow output on other PRs start producing real affected sets while #2683 waits for data.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcmYZYsrpgiZViSQeuNgXG)_