### PR TITLE
aiquota: ship devinfra.claude.claude_api in the wheel

### DIFF
--- a/aiquota/BUILD.bazel
+++ b/aiquota/BUILD.bazel
@@ -104,7 +104,16 @@ py_test(
 
 py_package(
     name = "aiquota_pkg",
-    packages = ["aiquota"],
+    packages = [
+        "aiquota",
+        # aiquota.providers.claude imports Spend/UsageBucket/UsageResponse
+        # from devinfra.claude.claude_api.usage — bundle those source files
+        # into the wheel. `packages` is a prefix filter and py_package only
+        # ships files also reachable through `deps`, so cli_lib's transitive
+        # graph (which already reaches //devinfra/claude/claude_api:usage)
+        # scopes what actually lands here to what aiquota uses.
+        "devinfra.claude.claude_api",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         ":cli_lib",


### PR DESCRIPTION
## Why

#2682 taught aiquota to parse Claude spend usage — `aiquota/providers/claude.py` now imports `Spend`, `UsageBucket`, `UsageResponse` from `devinfra.claude.claude_api.usage`. The Bazel dep on `//devinfra/claude/claude_api:usage` was added (aiquota's `cli_lib` transitively reaches it, so bazel-ci and per-target tests all pass), but the aiquota `py_wheel`'s `py_package` still had `packages = ["aiquota"]`. `packages` is a prefix filter — so `devinfra/*.py` files got dropped from the wheel at packaging time even though they were in the dep graph.

Live consequences on devel today:

- `nix build .#packages.x86_64-linux.aiquota` fails with `ModuleNotFoundError: No module named 'devinfra'` on the imports check
- Anyone `nix profile install`-ing aiquota gets a broken CLI on first `import aiquota.cli`
- Next `nix-attic-push` on devel will fail once the ducktape-automation bot rotates the aiquota pin to the post-#2682 wheel (the pinned release hasn't rotated yet, but every fresh build from the current sources is broken).

`nix-wheel-check.yml` (from #2678) was designed to catch exactly this class of drift — and did: [run 28498842548](https://github.com/agentydragon/ducktape/actions/runs/28498842548/job/84471119495) surfaced it on PR #2686. Same class of bug as the `gmail_api` / `ducktape_pkg` drift from #2669 / #2678.

## What

Add `"devinfra.claude.claude_api"` to `aiquota_pkg.packages`. The prefix scoping means only `devinfra.claude.claude_api.*` files reachable from `cli_lib` land in the wheel (Spend/UsageBucket/UsageResponse and their deps — currently just `usage.py`).

Precedent for a Python wheel bundling a slice of `devinfra/`: `bbr_pkg` ships `["devinfra"]`, `ducktape_git_hooks_pkg` ships `["devinfra", "devinfra.precommit", ...]`, `claude_hooks_pkg` ships `["devinfra.claude", "devinfra.claude.claude_api", ...]`. Every `buildPythonApplication` in nix is a self-contained env, so multi-wheel duplication of these source files doesn't cause runtime collisions.

## Test plan

- [x] Locally build `//aiquota:aiquota_wheel` and confirm `devinfra/claude/claude_api/usage.py` is now inside the wheel: `unzip -l aiquota-0.1.0-py3-none-any.whl` shows it alongside `aiquota/providers/claude.py`.
- [x] Locally run the nix imports check against the freshly-built wheel via `DUCKTAPE_ARTIFACT_OVERRIDES` (the override mechanism from #2678): `nix build --impure .#packages.x86_64-linux.aiquota` now succeeds.
- [ ] Waiting on CI: `Nix wheel check` on this PR — the same gate that flagged the bug — should pass end-to-end.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WAJ8JXpinZkv2x9GLD6ULj)_