### PR TITLE
Include devinfra.claude packages in aiquota distribution

### DIFF
--- a/aiquota/BUILD.bazel
+++ b/aiquota/BUILD.bazel
@@ -104,7 +104,11 @@ py_test(
 
 py_package(
     name = "aiquota_pkg",
-    packages = ["aiquota"],
+    packages = [
+        "aiquota",
+        "devinfra.claude",
+        "devinfra.claude.claude_api",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         ":cli_lib",


### PR DESCRIPTION
## Summary
Updated the `aiquota_pkg` build target to include the `devinfra.claude` and `devinfra.claude.claude_api` packages in the distributed package alongside the main `aiquota` package.

## Changes
- Expanded the `packages` list in the `aiquota_pkg` py_package target to include:
  - `devinfra.claude`
  - `devinfra.claude.claude_api`

This ensures that the Claude API integration modules are bundled with the aiquota package distribution.

https://claude.ai/code/session_018dXQBtr8dn4S7y3uDx3n5h