### PR TITLE
claude_api/usage: type divisor as float so major_units keeps its type

### DIFF
--- a/devinfra/claude/claude_api/usage.py
+++ b/devinfra/claude/claude_api/usage.py
@@ -28,7 +28,11 @@ class MoneyAmount(BaseModel):
 
     @property
     def major_units(self) -> float:
-        return self.amount_minor / (10**self.exponent)
+        # `10 ** int` returns `int | Any` (typeshed overloads a negative-
+        # exponent branch that returns float), so `float / (10**int)` widens
+        # to `Any` and trips mypy's warn_return_any. `10.0 ** int` returns
+        # float unconditionally, keeping the division typed.
+        return self.amount_minor / (10.0**self.exponent)
 
 
 class Spend(BaseModel):


### PR DESCRIPTION
## Why

#2682 landed `MoneyAmount.major_units`:

```python
@property
def major_units(self) -> float:
    return self.amount_minor / (10**self.exponent)
```

`10 ** int` widens to `int | Any` in typeshed — the negative-exponent branch is typed as returning `float`, so mypy can't narrow the union when the exponent value isn't known statically. Then `float / (int | Any)` widens to `Any`, `warn_return_any` fires, and the mypy lint aspect on `//devinfra/claude/claude_api:usage` fails:

```
devinfra/claude/claude_api/usage.py:31: error: Returning Any from function declared to return "float"  [no-any-return]
Found 1 error in 1 file (checked 1 source file)
```

Seen on bazel-ci for PR #2690 (invocation [f3a3888c-882c-40f8-adf6-59f3e96daf80](https://app.buildbuddy.io/invocation/f3a3888c-882c-40f8-adf6-59f3e96daf80)).

Since #2688 (bazel-ci: target-determinator flag fix) landed, this mypy failure is the *only* remaining bazel-ci failure on devel-targeted PRs — the debundle e2e failures I've been skipping in webhook events are actually gone. Unblocks bazel-ci for every open PR against devel.

## What

Use `10.0 ** self.exponent` — a float base makes `pow(float, int)` return `float` unconditionally, so the division stays typed and mypy is happy. Left a comment explaining the typeshed subtlety so it doesn't get "simplified" back.

## Test plan

- [x] `bazelisk build //devinfra/claude/claude_api:usage` (which runs the default mypy aspect) succeeds locally.
- [ ] Waiting on CI: `bazel-ci / Test & Build` should be green on this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WAJ8JXpinZkv2x9GLD6ULj)_