### PR TITLE
branch-protection: gate PRs on `Build artifacts + imports check` (draft, land when stable)

### DIFF
--- a/tf/gitops/github-branch-protection/README.md
+++ b/tf/gitops/github-branch-protection/README.md
@@ -10,6 +10,8 @@ This Terraform module manages branch protection for
 - Required checks are exact GitHub check-run names:
   - `bazel-ci / Test & Build`
   - `Pre-commit checks`
+  - `Build artifacts + imports check` (the `Nix wheel check` workflow at
+    <../../../.github/workflows/nix-wheel-check.yml>)
 - Deletion, force-push, and non-linear history are blocked.
 - Pull requests are required so required checks can run, but the solo-repo
   review count is zero.
@@ -60,11 +62,6 @@ access control plus the `ducktape-automation` App for GitOps writes.
 
 ## Remaining Cleanup
 
-- Add `Build artifacts + imports check` (the `Nix wheel check` workflow's job
-  name; see <../../../.github/workflows/nix-wheel-check.yml>) to
-  `required_status_checks` once it has ~a week of green runs on devel — the
-  workflow landed with #2678 and needs some soak time to shake out any RBE
-  peer-exhaustion / nix substituter flakes before it becomes a merge gate.
 - Verify whether GitHub Secret Protection covers push protection on private
   personal-account repos now, then enable or explicitly reject it for
   `gaffer-private`.

--- a/tf/gitops/github-branch-protection/main.tf
+++ b/tf/gitops/github-branch-protection/main.tf
@@ -101,6 +101,15 @@ resource "github_repository_ruleset" "default_branch_protection" {
       required_check {
         context = "Pre-commit checks"
       }
+      # `Nix wheel check` (top-level `on: pull_request:` workflow — not a
+      # reusable one, so no `<caller>/` prefix) rebuilds every pinned wheel
+      # from PR source and runs each mkWheel's importsCheck against it.
+      # Landed with #2678; #2686 tracked flipping this to required. Blocks
+      # "wheel forgot a package" regressions like the gmail_api / ducktape_pkg
+      # drift in #2669 that motivated the workflow.
+      required_check {
+        context = "Build artifacts + imports check"
+      }
       strict_required_status_checks_policy = false
     }
   }


### PR DESCRIPTION
## Why

Follow-up to #2678 (which landed the `Nix wheel check` workflow as a per-PR nix imports-check gate) and #2686 (which parked a TODO next to the ruleset config). This is the actual gating: add `Build artifacts + imports check` to `required_status_checks`, so a red nix imports-check on a PR blocks merge — the whole reason the workflow exists.

**Kept as a draft on purpose** — hold merge until we've seen ~a week of green `Nix wheel check` runs on devel. That soak buys us signal on:

- RBE peer-exhaustion on the 8-target `bb remote` download (I've seen the workflow's `bb remote build` succeed cleanly so far, but the workload is uncommon in this repo)
- nix substituter reliability (Attic warm reuse vs. cold-build wall time on the ubuntu-latest runner)
- any drift between `devinfra/ci/artifact_targets.json` and reality that isn't caught until the workflow actually reruns

Once devel has ~5–7 consecutive green `Nix wheel check` runs and nothing surprising has surfaced, flip to "ready for review" and merge.

## What

- `main.tf`: one new `required_check { context = "Build artifacts + imports check" }` block inside the existing ruleset's `required_status_checks`. The check-run name is just the job's `name:` — no `<caller>/` prefix, because `nix-wheel-check.yml` is a top-level `on: pull_request:` workflow, not a reusable one called from `ci.yml` (contrast `bazel-ci / Test & Build`, which is called from `ci.yml`'s `bazel-ci:` job).
- `README.md`: add the new required check to the "Current Rules" list; drop the completed TODO from "Remaining Cleanup" (was #2686).

## Test plan

- [x] `bazelisk test //tf/gitops/github-branch-protection:validate //tf/gitops/github-branch-protection:format` (green — the terraform plan validates against the schema).
- [ ] Draft parking: watch devel runs of `Nix wheel check` for ~1 week; flip to ready + merge once we're confident the check is stable.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WAJ8JXpinZkv2x9GLD6ULj)_