### PR TITLE
grocy_mcp: require default_best_before_days on products_create

### DIFF
--- a/grocy_mcp/TODO.md
+++ b/grocy_mcp/TODO.md
@@ -34,21 +34,6 @@ remainder needs a bit more care:
   `stock_entries` filtered by product. Worth thinking about whether to
   promote to a batch tool that groups with `stock_*`.
 
-## Echo server-computed values in mutation responses
-
-Stock mutations (e.g. `stock_add`) let Grocy compute derived values
-like `best_before_date` (from `default_best_before_days`). The current
-response only returns `new_amount` — the agent can't see what
-best-before date Grocy assigned without a follow-up `stock_entries_list`
-call. Echoing computed values back (best-before date, resolved location,
-etc.) would let the agent catch surprises (e.g. "expires today" when it
-expected no expiry) without extra round-trips.
-
-Needs design thought: Grocy's `POST /stock/products/{id}/add` response
-includes a list of created stock entries with their IDs but not the full
-entry bodies. We'd need to either fetch entries by ID after the mutation
-or parse the transaction log. Figure out the cleanest approach.
-
 ## Consider per-test container isolation for e2e tests
 
 Tests currently share a session-scoped Grocy container and use uuid

--- a/grocy_mcp/batch_tools.py
+++ b/grocy_mcp/batch_tools.py
@@ -455,6 +455,7 @@ def register_batch_tools(mcp: FastMCP, client: httpx.AsyncClient, settings: Serv
             stock_amount = input_amount * rqu.conversion_factor
 
             body: dict[str, Any] = {"location_id": location.id}
+            applied_best_before_date: date | None = None
             match item:
                 case AddItem():
                     endpoint = "add"
@@ -473,6 +474,7 @@ def register_batch_tools(mcp: FastMCP, client: httpx.AsyncClient, settings: Serv
                         body["best_before_date"] = _compute_default_bbd(
                             product_row, is_freezer=bool(int(location_row.get("is_freezer") or 0))
                         )
+                    applied_best_before_date = _parse_date(body["best_before_date"])
                     if item.price is not None:
                         body["price"] = item.price
                     if item.note is not None:
@@ -510,6 +512,7 @@ def register_batch_tools(mcp: FastMCP, client: httpx.AsyncClient, settings: Serv
                 qu_name=rqu.name,
                 stock_qu_name=rqu.stock_qu_name if rqu.conversion_factor != 1.0 else None,
                 location_name=location.name,
+                best_before_date=applied_best_before_date,
             )
         except Exception as e:
             return StockOpError(error=_format_exc(e))
@@ -527,7 +530,11 @@ def register_batch_tools(mcp: FastMCP, client: httpx.AsyncClient, settings: Serv
 
         Returns one result per input item, in order. Each success carries
         a `transaction_id` you can pass to `transaction_undo` to revert
-        that single addition. See also `stock_consume`,
+        that single addition, and `best_before_date` — the date actually
+        applied to the new entry, whether you passed it explicitly or it
+        was computed from `default_best_before_days` — so you can catch
+        surprises (e.g. "expires today") without a follow-up
+        `stock_entries_list` call. See also `stock_consume`,
         `stock_set`, `stock_transfer`.
         """
         _check_batch_size(items, "items")

--- a/grocy_mcp/batch_tools.py
+++ b/grocy_mcp/batch_tools.py
@@ -914,7 +914,10 @@ def register_batch_tools(mcp: FastMCP, client: httpx.AsyncClient, settings: Serv
     ) -> list[CreateOk | CreateError]:
         """Create one or more products.
 
-        Each item needs `name`, `stock_qu`, and `location`. All entity
+        Each item needs `name`, `stock_qu`, `location`, and
+        `default_best_before_days` — the last one is required with no
+        default so you have to decide the product's shelf-life policy
+        up front rather than one silently getting applied. All entity
         references (`stock_qu`, `location`, `purchase_qu`, `product_group`)
         take names or IDs and resolve via `quantity_units_list` /
         `locations_list` / `product_groups_list`. `purchase_qu` defaults to

--- a/grocy_mcp/docs/agent_interaction_design.md
+++ b/grocy_mcp/docs/agent_interaction_design.md
@@ -90,10 +90,12 @@ Agent: create_product(
   Notes on this tool:
   - `stock_qu` accepts a name (or ID). It's required — no default.
   - `location` is the default storage location. Required — no default.
+  - `default_best_before_days` (auto-calculates expiry on add) is
+    required — no default. Forces the agent to decide the product's
+    shelf-life policy instead of one being silently applied.
   - purchase_qu defaults to stock_qu (90% of the time they're the same).
     Agent can override: `purchase_qu: "Crate"` if buying in bulk units.
   - Optional fields: `min_stock_amount` (for low-stock alerts),
-    `default_best_before_days` (auto-calculates expiry on add),
     `product_group` (int|str), `description`.
   - Response confirms what was created with names, not just IDs.
 
@@ -417,12 +419,12 @@ Notes:
 
 ### Product Management
 
-| Tool             | Purpose                  | Required Params          | Notes                                                                            |
-| ---------------- | ------------------------ | ------------------------ | -------------------------------------------------------------------------------- |
-| `products_list`  | All products             | (none)                   | `detail: "brief"\|"full"`, default brief (id + name)                             |
-| `create_product` | Create a new product     | name, stock_qu, location | Optional: min_stock_amount, default_best_before_days, product_group, description |
-| `products_edit`  | Partial-update a product | product + changed fields |                                                                                  |
-| `product_delete` | Delete a product         | product                  |                                                                                  |
+| Tool             | Purpose                  | Required Params                                    | Notes                                                  |
+| ---------------- | ------------------------ | -------------------------------------------------- | ------------------------------------------------------ |
+| `products_list`  | All products             | (none)                                             | `detail: "brief"\|"full"`, default brief (id + name)   |
+| `create_product` | Create a new product     | name, stock_qu, location, default_best_before_days | Optional: min_stock_amount, product_group, description |
+| `products_edit`  | Partial-update a product | product + changed fields                           |                                                        |
+| `product_delete` | Delete a product         | product                                            |                                                        |
 
 ### Reference Data
 

--- a/grocy_mcp/docs/agent_interaction_design.md
+++ b/grocy_mcp/docs/agent_interaction_design.md
@@ -81,11 +81,13 @@ Agent: quantity_units_list()
 Agent: create_product(
     name: "Cucumbers",
     stock_qu: "Kilogram",
-    location: "Fridge"
+    location: "Fridge",
+    default_best_before_days: 7
   )
   Response:
     {product_id: 42, name: "Cucumbers",
-     stock_qu: "Kilogram", default_location: "Fridge"}
+     stock_qu: "Kilogram", default_location: "Fridge",
+     default_best_before_days: 7}
 
   Notes on this tool:
   - `stock_qu` accepts a name (or ID). It's required — no default.

--- a/grocy_mcp/mcp_types.py
+++ b/grocy_mcp/mcp_types.py
@@ -248,6 +248,14 @@ class StockOpOk(BaseModel):
     location_name: str = Field(
         description="Name of the storage location. For `stock_transfer`, formatted as `from -> to`."
     )
+    best_before_date: date | None = Field(
+        default=None,
+        description=(
+            "The best-before date applied to the new stock entry — whichever you passed explicitly, "
+            "or the one computed from `default_best_before_days` when you omitted it. `stock_add` "
+            "only; null for `stock_consume`/`stock_set`/`stock_transfer`, which don't create dated entries."
+        ),
+    )
 
 
 class StockOpError(BaseModel):

--- a/grocy_mcp/mcp_types.py
+++ b/grocy_mcp/mcp_types.py
@@ -87,7 +87,7 @@ PRICE_DESC = "Per-unit price. Omit to use the last recorded price."
 DETAIL_DESC = "`brief` returns only `id` + `name`. `full` returns every column."
 DEFAULT_BBD_DESC = (
     "Auto-fill best-before date when `stock_add` omits it. "
-    "-1 = never expires, 0 (default) = today, N > 0 = today + N days."
+    "-1 = never expires, 0 = best-before today, N > 0 = today + N days."
 )
 DUE_TYPE_DESC = (
     "How to treat the best-before date. "
@@ -358,7 +358,14 @@ class CreateProductItem(BaseModel):
     consume_qu: int | str | None = Field(
         default=None, description="Consume quantity unit. Name or ID. Defaults to `stock_qu`."
     )
-    default_best_before_days: int = Field(default=0, description=DEFAULT_BBD_DESC)
+    default_best_before_days: int = Field(
+        description=(
+            f"{DEFAULT_BBD_DESC} Required — there is no default. A caller that hasn't "
+            "considered this product's shelf life must still pick a value (e.g. `0` for "
+            "consciously same-day, `-1` for shelf-stable) rather than silently getting one; "
+            "0 is not a fallback here, only a valid, deliberate choice."
+        )
+    )
     due_type: Literal[1, 2] = Field(default=1, description=DUE_TYPE_DESC)
     parent_product: int | str | None = Field(default=None, description=PARENT_PRODUCT_DESC)
     product_group: int | str | None = Field(default=None, description="Product group / category. Name or ID.")

--- a/grocy_mcp/server_instructions.md
+++ b/grocy_mcp/server_instructions.md
@@ -156,10 +156,14 @@ sentinel is `2999-12-31`.
 `stock_add` omits `best_before_date`:
 
 - `-1` → never expires (`2999-12-31`)
-- `0` (default) → **today** (not "disabled" — stock appears due immediately)
+- `0` → **today** (not "disabled" — stock appears due immediately)
 - `N > 0` → today + N days
 
-For products that don't expire (salt, vinegar, etc.), set
+`products_create` requires this field on every item — there is no
+default. Decide the product's shelf-life policy at creation time
+instead of leaving it to chance; `0` is a valid, deliberate choice
+(same-day), not a fallback for "didn't think about it". For products
+that don't expire (salt, vinegar, etc.), set
 `default_best_before_days = -1` at creation time, or pass
 `best_before_date = "2999-12-31"` on every `stock_add`.
 

--- a/grocy_mcp/server_instructions.md
+++ b/grocy_mcp/server_instructions.md
@@ -167,6 +167,11 @@ that don't expire (salt, vinegar, etc.), set
 `default_best_before_days = -1` at creation time, or pass
 `best_before_date = "2999-12-31"` on every `stock_add`.
 
+`stock_add` echoes the date it actually applied back as
+`best_before_date` on each result — whether you passed it explicitly or
+it was computed from `default_best_before_days` — so check that field
+for surprises instead of following up with `stock_entries_list`.
+
 **`due_type`** on a product (settable via `products_edit` or
 `entity_update`) controls how Grocy treats the best-before date:
 

--- a/grocy_mcp/test_e2e.py
+++ b/grocy_mcp/test_e2e.py
@@ -493,7 +493,9 @@ async def test_stock_add_applies_default_best_before_days(mcp_client: Client, re
         )
     )
     assert ops[0]["kind"] == "ok", ops
-    assert await _latest_bbd() == (date.today() + timedelta(days=300)).isoformat()
+    expected_case1 = (date.today() + timedelta(days=300)).isoformat()
+    assert ops[0]["best_before_date"] == expected_case1
+    assert await _latest_bbd() == expected_case1
 
     # Case 2: non-freezer, default_best_before_days=-1 → 2999-12-31.
     edit = unwrap_result(
@@ -506,6 +508,7 @@ async def test_stock_add_applies_default_best_before_days(mcp_client: Client, re
         )
     )
     assert ops[0]["kind"] == "ok", ops
+    assert ops[0]["best_before_date"] == "2999-12-31"
     assert await _latest_bbd() == "2999-12-31"
 
     # Case 3 (regression for the reported bug): freezer location,
@@ -528,6 +531,7 @@ async def test_stock_add_applies_default_best_before_days(mcp_client: Client, re
     )
     assert ops[0]["kind"] == "ok", ops
     expected = (date.today() + timedelta(days=300)).isoformat()
+    assert ops[0]["best_before_date"] == expected
     actual = await _latest_bbd()
     assert actual == expected, (
         f"Freezer-location stock_add with default_best_before_days=300 and "
@@ -554,6 +558,7 @@ async def test_stock_add_applies_default_best_before_days(mcp_client: Client, re
         )
     )
     assert ops[0]["kind"] == "ok", ops
+    assert ops[0]["best_before_date"] == override.isoformat()
     assert await _latest_bbd() == override.isoformat()
 
 

--- a/grocy_mcp/test_e2e.py
+++ b/grocy_mcp/test_e2e.py
@@ -213,7 +213,7 @@ async def test_product_lifecycle(mcp_client: Client, refunwrap_result: RefData) 
     )
     assert edit_results[0]["kind"] == "ok"
     # TODO: test batch edit (multiple items in one call)
-    # TODO: test editing due_type, default_best_before_days, clear_fields
+    # TODO: test editing due_type, clear_fields
     # TODO: test that clear_fields nulls product_group while preserving other fields
 
     products = unwrap_result(await mcp_client.call_tool("products_list", {"detail": "full"}))
@@ -226,6 +226,51 @@ async def test_product_lifecycle(mcp_client: Client, refunwrap_result: RefData) 
     for name in (new_name, refunwrap_result.products[1]):
         del_result = unwrap_result(await mcp_client.call_tool("product_delete", {"product": name}))
         assert del_result["kind"] == "ok", f"product_delete({name}) failed: {del_result}"
+
+
+# -- default_best_before_days: required on create, preserved on edit --------
+
+
+async def test_products_create_requires_default_best_before_days(mcp_client: Client) -> None:
+    """`products_create` rejects an item that omits `default_best_before_days`.
+
+    Omission used to silently store 0 (best-before today), indistinguishable
+    from a caller who deliberately chose same-day best-before — the field
+    must be required with no default.
+    """
+    with pytest.raises(Exception, match="default_best_before_days"):
+        await mcp_client.call_tool(
+            "products_create", {"items": [{"name": "MissingBBD", "stock_qu": "Piece", "location": "Pantry"}]}
+        )
+
+
+async def test_products_edit_preserves_default_best_before_days_when_omitted(
+    mcp_client: Client, refunwrap_result: RefData
+) -> None:
+    """`products_edit` omitting `default_best_before_days` leaves it unchanged.
+
+    Unlike `products_create` (which now requires the field explicitly),
+    omission on edit means "leave the existing value alone" — the two
+    endpoints must not share the same omission semantics.
+    """
+    product = refunwrap_result.products[0]
+
+    edit = unwrap_result(
+        await mcp_client.call_tool("products_edit", {"items": [{"product": product, "default_best_before_days": 42}]})
+    )
+    assert edit[0]["kind"] == "ok", edit
+
+    # Edit an unrelated field, omitting default_best_before_days.
+    unrelated_edit = unwrap_result(
+        await mcp_client.call_tool(
+            "products_edit", {"items": [{"product": product, "description": "unrelated change"}]}
+        )
+    )
+    assert unrelated_edit[0]["kind"] == "ok", unrelated_edit
+
+    products = unwrap_result(await mcp_client.call_tool("products_list", {"detail": "full"}))
+    our_product = next(p for p in products if p["name"] == product)
+    assert int(our_product["default_best_before_days"]) == 42
 
 
 # -- entity_update PATCH semantics -------------------------------------------

--- a/grocy_mcp/test_helpers.py
+++ b/grocy_mcp/test_helpers.py
@@ -81,9 +81,15 @@ async def create_refunwrap_result(client: Client) -> RefData:
                         "stock_qu": qu_name,
                         "location": loc_name,
                         "min_stock_amount": 1,
+                        "default_best_before_days": 0,
                         "description": "Test product for e2e",
                     },
-                    {"name": product_names[1], "stock_qu": qu_name, "location": loc_name},
+                    {
+                        "name": product_names[1],
+                        "stock_qu": qu_name,
+                        "location": loc_name,
+                        "default_best_before_days": 0,
+                    },
                 ]
             },
         )


### PR DESCRIPTION
Omitting the field on creation silently stored 0 (best-before today),
indistinguishable from a caller that deliberately chose same-day
best-before. Make the field required with no default so every created
product gets a considered shelf-life policy. products_edit is
unaffected: omission there still means "leave the existing value
alone".

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Jp4qPMQ8AEHWzXoRVZMMc7