### PR TITLE
grocy_mcp: don't mask a missing stock_amount as zero

### DIFF
--- a/grocy_mcp/batch_tools.py
+++ b/grocy_mcp/batch_tools.py
@@ -428,7 +428,7 @@ def register_batch_tools(mcp: FastMCP, client: httpx.AsyncClient, settings: Serv
             async with sem:
                 stock_r = await client.get(f"/stock/products/{product_id}")
                 stock_r.raise_for_status()
-                return float(stock_r.json().get("stock_amount", 0))
+                return float(stock_r.json()["stock_amount"])
         except Exception:
             logger.warning("failed to read new_amount for product %d after mutation", product_id, exc_info=True)
             return None


### PR DESCRIPTION
## Summary

Follow-up to #2699 (merged before this review comment could be addressed — same designated branch, restarted from latest `devel`).

Copilot caught: `_best_effort_new_amount`'s `.get("stock_amount", 0)` silently returned a plausible-looking `0` for a malformed/shape-mismatched response, instead of the `None` the function is documented to degrade to — indistinguishable from a product genuinely at zero stock (the exact same "false 0 vs real 0" ambiguity that motivated the original `default_best_before_days` change in #2695). Index directly (`json()["stock_amount"]`) so a missing key raises and is caught by the surrounding best-effort handler instead of being silently papered over.

## Test plan

- [x] `bbr test //grocy_mcp:test_e2e` passes (cached, unaffected by this one-line change; the underlying real-Grocy behavior was already validated in #2699)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jp4qPMQ8AEHWzXoRVZMMc7)_