### PR TITLE
gmail-labeling: add batched label modification (Gmail batchModify shape)

### DIFF
--- a/haku/gmail_labeling/AGENTS.md
+++ b/haku/gmail_labeling/AGENTS.md
@@ -3,4 +3,6 @@
 The closure invariant (`SPEC.md`) is enforced in `client.py`, before any Gmail
 call — never in the agent prompt. When adding a tool, route every label-name
 argument through `LabelNamespace.require` (or a method that does) so a new verb
-cannot widen the namespace. `rename_label` must validate both names.
+cannot widen the namespace. `rename_label` must validate both names;
+`modify_labels` must validate every name in both `add` and `remove` before
+touching the backend.

--- a/haku/gmail_labeling/BUILD.bazel
+++ b/haku/gmail_labeling/BUILD.bazel
@@ -123,7 +123,9 @@ py_test(
     name = "test_namespace",
     srcs = ["test_namespace.py"],
     deps = [
+        ":conftest",
         ":namespace",
+        "//:conftest",
         "@pypi//fastmcp",
         "@pypi//pytest",
         "@pypi//pytest_bazel",
@@ -134,10 +136,22 @@ py_test(
     name = "test_client",
     srcs = ["test_client.py"],
     deps = [
-        ":client",
         ":conftest",
+        "//:conftest",
         "//gmail_api:labels",
         "@pypi//fastmcp",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
+    ],
+)
+
+py_test(
+    name = "test_backend",
+    srcs = ["test_backend.py"],
+    deps = [
+        ":backend",
+        ":conftest",
+        "//:conftest",
         "@pypi//pytest",
         "@pypi//pytest_bazel",
     ],
@@ -152,6 +166,9 @@ py_test(
         "//:conftest",
         "@pypi//fastmcp",
         "@pypi//pytest",
+        # Not statically imported -- pytest-asyncio auto mode (set in root conftest.py)
+        # needs the plugin importable at runtime for its entry-point autoload; Gazelle
+        # can't see that and will try to drop this dep on regen.
         "@pypi//pytest_asyncio",
         "@pypi//pytest_bazel",
     ],

--- a/haku/gmail_labeling/README.md
+++ b/haku/gmail_labeling/README.md
@@ -12,14 +12,20 @@ REST API directly (via `gmail_api`) and exposes **only** label management.
 
 All mutating tools reject any label name outside `allowed_prefix`.
 
-| Tool           | Effect                                                         |
-| -------------- | -------------------------------------------------------------- |
-| `list_labels`  | List managed labels (those under the prefix).                  |
-| `apply_label`  | Add a managed label to a thread (creates the label if needed). |
-| `remove_label` | Remove a managed label from a thread.                          |
-| `create_label` | Create a managed label without applying it.                    |
-| `rename_label` | Rename a managed label (both names must be under the prefix).  |
-| `delete_label` | Delete a managed label (drops it from every thread).           |
+| Tool            | Effect                                                                  |
+| --------------- | ----------------------------------------------------------------------- |
+| `list_labels`   | List managed labels (those under the prefix).                           |
+| `modify_labels` | Add and/or remove managed labels across a batch of threads in one call. |
+| `create_label`  | Create a managed label without applying it.                             |
+| `rename_label`  | Rename a managed label (both names must be under the prefix).           |
+| `delete_label`  | Delete a managed label (drops it from every thread).                    |
+
+`modify_labels` takes `thread_ids` plus `add`/`remove` label-name lists, mirroring
+Gmail's own `batchModify` request shape (a set of IDs, labels to add, labels to
+remove). Gmail has no `threads.batchModify` endpoint, so the backend folds the
+per-thread `threads.modify` calls into as few HTTP requests as possible via Gmail's
+generic batch-request mechanism (`GmailLabelBackend.modify_threads`, `backend.py`)
+instead of one round trip per thread.
 
 Enforcement lives in `client.py` (`LabelClient`), not in the agent's prompt — the
 namespace check runs before any Gmail call.

--- a/haku/gmail_labeling/backend.py
+++ b/haku/gmail_labeling/backend.py
@@ -4,9 +4,18 @@
 implements it over the Gmail REST API, and tests substitute an in-memory fake.
 """
 
+from collections.abc import Sequence
+from itertools import batched
 from typing import Any, Protocol
 
 from gmail_api.labels import GmailLabel
+
+# Gmail has no `threads.batchModify` (only `messages.batchModify`, a different resource).
+# Batching thread modifications means folding many `threads.modify` calls into few HTTP
+# requests via `new_batch_http_request` -- the mechanism Gmail's own batch guide describes
+# (https://developers.google.com/gmail/api/guides/batch) -- capped at its recommended 100
+# calls per batch.
+_MAX_BATCH_SIZE = 100
 
 
 class LabelBackend(Protocol):
@@ -16,7 +25,7 @@ class LabelBackend(Protocol):
     def create_label(self, name: str) -> GmailLabel: ...
     def rename_label(self, label_id: str, new_name: str) -> GmailLabel: ...
     def delete_label(self, label_id: str) -> None: ...
-    def modify_thread(self, thread_id: str, *, add: list[str], remove: list[str]) -> None: ...
+    def modify_threads(self, thread_ids: Sequence[str], *, add: list[str], remove: list[str]) -> None: ...
 
 
 class GmailLabelBackend:
@@ -44,10 +53,26 @@ class GmailLabelBackend:
     def delete_label(self, label_id: str) -> None:
         self._service.users().labels().delete(userId="me", id=label_id).execute()
 
-    def modify_thread(self, thread_id: str, *, add: list[str], remove: list[str]) -> None:
+    def modify_threads(self, thread_ids: Sequence[str], *, add: list[str], remove: list[str]) -> None:
         body: dict[str, list[str]] = {}
         if add:
             body["addLabelIds"] = add
         if remove:
             body["removeLabelIds"] = remove
-        self._service.users().threads().modify(userId="me", id=thread_id, body=body).execute()
+
+        errors: dict[str, Exception] = {}
+
+        def record_error(thread_id: str, _response: object, exception: Exception | None) -> None:
+            if exception is not None:
+                errors[thread_id] = exception
+
+        for chunk in batched(thread_ids, _MAX_BATCH_SIZE, strict=False):
+            batch_request = self._service.new_batch_http_request(callback=record_error)
+            for thread_id in chunk:
+                batch_request.add(
+                    self._service.users().threads().modify(userId="me", id=thread_id, body=body), request_id=thread_id
+                )
+            batch_request.execute()
+
+        if errors:
+            raise ExceptionGroup(f"failed to modify {len(errors)}/{len(thread_ids)} thread(s)", list(errors.values()))

--- a/haku/gmail_labeling/client.py
+++ b/haku/gmail_labeling/client.py
@@ -39,7 +39,7 @@ class LabelClient:
         created = self._backend.create_label(name)
         return Label(name=created.name, id=created.id)
 
-    def modify_labels(self, thread_ids: list[str], *, add: list[str], remove: list[str]) -> ModifyLabelsResult:
+    def modify_labels(self, thread_ids: list[str], *, add: set[str], remove: set[str]) -> ModifyLabelsResult:
         """Add and/or remove labels across a batch of threads in one call.
 
         Mirrors Gmail's own `batchModify` shape: one set of IDs, one set of labels to add,
@@ -49,9 +49,9 @@ class LabelClient:
             raise ToolError("thread_ids must be non-empty")
         if not add and not remove:
             raise ToolError("must specify at least one label in `add` or `remove`")
-        for name in (*add, *remove):
+        for name in add | remove:
             self._ns.require(name)
-        if overlap := set(add) & set(remove):
+        if overlap := add & remove:
             raise ToolError(f"label(s) {sorted(overlap)} cannot be both added and removed in the same call")
 
         existing = self._name_to_id()

--- a/haku/gmail_labeling/client.py
+++ b/haku/gmail_labeling/client.py
@@ -10,7 +10,7 @@ from fastmcp.exceptions import ToolError
 
 from gmail_api.labels import GmailLabel, LabelType
 from haku.gmail_labeling.backend import LabelBackend
-from haku.gmail_labeling.models import Label
+from haku.gmail_labeling.models import Label, ModifyLabelsResult
 from haku.gmail_labeling.namespace import LabelNamespace
 
 
@@ -39,17 +39,37 @@ class LabelClient:
         created = self._backend.create_label(name)
         return Label(name=created.name, id=created.id)
 
-    def apply_label(self, thread_id: str, name: str) -> Label:
-        self._ns.require(name)
-        label_id = self._resolve_or_create(name)
-        self._backend.modify_thread(thread_id, add=[label_id], remove=[])
-        return Label(name=name, id=label_id)
+    def modify_labels(self, thread_ids: list[str], *, add: list[str], remove: list[str]) -> ModifyLabelsResult:
+        """Add and/or remove labels across a batch of threads in one call.
 
-    def remove_label(self, thread_id: str, name: str) -> Label:
-        self._ns.require(name)
-        label_id = self._require_existing(name)
-        self._backend.modify_thread(thread_id, add=[], remove=[label_id])
-        return Label(name=name, id=label_id)
+        Mirrors Gmail's own `batchModify` shape: one set of IDs, one set of labels to add,
+        one set of labels to remove -- applied identically to every thread in `thread_ids`.
+        """
+        if not thread_ids:
+            raise ToolError("thread_ids must be non-empty")
+        if not add and not remove:
+            raise ToolError("must specify at least one label in `add` or `remove`")
+        for name in (*add, *remove):
+            self._ns.require(name)
+        if overlap := set(add) & set(remove):
+            raise ToolError(f"label(s) {sorted(overlap)} cannot be both added and removed in the same call")
+
+        existing = self._name_to_id()
+        if missing := [name for name in remove if name not in existing]:
+            raise ToolError(f"label(s) {missing} do not exist")
+
+        added = [self._get_or_create(name, existing) for name in add]
+        removed = [Label(name=name, id=existing[name]) for name in remove]
+        self._backend.modify_threads(
+            thread_ids, add=[label.id for label in added], remove=[label.id for label in removed]
+        )
+        return ModifyLabelsResult(added=added, removed=removed)
+
+    def _get_or_create(self, name: str, existing: dict[str, str]) -> Label:
+        if label_id := existing.get(name):
+            return Label(name=name, id=label_id)
+        created = self._backend.create_label(name)
+        return Label(name=created.name, id=created.id)
 
     def rename_label(self, old: str, new: str) -> Label:
         self._ns.require(old)
@@ -65,12 +85,6 @@ class LabelClient:
     def delete_label(self, name: str) -> None:
         self._ns.require(name)
         self._backend.delete_label(self._require_existing(name))
-
-    def _resolve_or_create(self, name: str) -> str:
-        existing = self._name_to_id()
-        if name in existing:
-            return existing[name]
-        return self._backend.create_label(name).id
 
     def _require_existing(self, name: str) -> str:
         existing = self._name_to_id()

--- a/haku/gmail_labeling/conftest.py
+++ b/haku/gmail_labeling/conftest.py
@@ -1,5 +1,7 @@
 """Shared test fakes/fixtures for gmail_labeling."""
 
+from collections.abc import Sequence
+
 import pytest
 
 from gmail_api.labels import GmailLabel, LabelType
@@ -17,7 +19,7 @@ class FakeLabelBackend:
     def __init__(self, labels: list[GmailLabel] | None = None) -> None:
         self._labels: dict[str, GmailLabel] = {label.id: label for label in (labels or [])}
         self._created = 0
-        self.thread_mods: list[tuple[str, list[str], list[str]]] = []
+        self.thread_mods: list[tuple[list[str], list[str], list[str]]] = []
 
     def list_labels(self) -> list[GmailLabel]:
         return list(self._labels.values())
@@ -36,8 +38,8 @@ class FakeLabelBackend:
     def delete_label(self, label_id: str) -> None:
         del self._labels[label_id]
 
-    def modify_thread(self, thread_id: str, *, add: list[str], remove: list[str]) -> None:
-        self.thread_mods.append((thread_id, add, remove))
+    def modify_threads(self, thread_ids: Sequence[str], *, add: list[str], remove: list[str]) -> None:
+        self.thread_mods.append((list(thread_ids), add, remove))
 
 
 def user_label(name: str, label_id: str) -> GmailLabel:

--- a/haku/gmail_labeling/models.py
+++ b/haku/gmail_labeling/models.py
@@ -8,3 +8,10 @@ class Label(BaseModel):
 
     name: str = Field(description="Full label display name, e.g. 'haku/triaged'.")
     id: str = Field(description="Gmail label ID.")
+
+
+class ModifyLabelsResult(BaseModel):
+    """Result of a batched label add/remove across one or more threads."""
+
+    added: list[Label] = Field(description="Labels added to every thread in the batch (created if they were new).")
+    removed: list[Label] = Field(description="Labels removed from every thread in the batch.")

--- a/haku/gmail_labeling/server.py
+++ b/haku/gmail_labeling/server.py
@@ -28,7 +28,7 @@ from gmail_api.service import build_gmail_service_from_token_dir
 from haku.gmail_labeling.backend import GmailLabelBackend
 from haku.gmail_labeling.client import LabelClient
 from haku.gmail_labeling.config import Settings
-from haku.gmail_labeling.models import Label
+from haku.gmail_labeling.models import Label, ModifyLabelsResult
 from haku.gmail_labeling.namespace import LabelNamespace
 from mcp_infra.authentik_auth.auth import build_authentik_auth
 from mcp_infra.persistence import build_client_storage
@@ -43,9 +43,27 @@ def build_mcp(client: LabelClient) -> FastMCP:
         f"with {prefix!r}; the server refuses anything else, so you cannot touch system labels "
         "(INBOX/TRASH/SPAM/…) or the user's other labels."
     )
-    thread_id_ann = Annotated[str, Field(description="Gmail thread ID to label (from Gmail search results).")]
+    thread_ids_ann = Annotated[
+        list[str], Field(description="Gmail thread IDs to modify in one batch (from Gmail search results).")
+    ]
     label_name_ann = Annotated[
         str, Field(description=f"Label display name; must start with {prefix!r}, e.g. {prefix + 'triaged'!r}.")
+    ]
+    add_ann = Annotated[
+        list[str] | None,
+        Field(
+            default=None,
+            description=f"Label names to add to every thread; each must start with {prefix!r}. Creates a label "
+            "that doesn't exist yet. Omit or leave empty if only removing.",
+        ),
+    ]
+    remove_ann = Annotated[
+        list[str] | None,
+        Field(
+            default=None,
+            description=f"Label names to remove from every thread; each must start with {prefix!r} and already "
+            "exist. Omit or leave empty if only adding.",
+        ),
     ]
 
     mcp: FastMCP = FastMCP(name="gmail-labeling", instructions=instructions)
@@ -56,14 +74,15 @@ def build_mcp(client: LabelClient) -> FastMCP:
         return await asyncio.to_thread(client.list_labels)
 
     @mcp.tool
-    async def apply_label(thread_id: thread_id_ann, name: label_name_ann) -> Label:
-        """Add a managed label to a thread, creating the label if it does not exist yet."""
-        return await asyncio.to_thread(client.apply_label, thread_id, name)
+    async def modify_labels(
+        thread_ids: thread_ids_ann, add: add_ann = None, remove: remove_ann = None
+    ) -> ModifyLabelsResult:
+        """Add and/or remove managed labels across a batch of threads in one call.
 
-    @mcp.tool
-    async def remove_label(thread_id: thread_id_ann, name: label_name_ann) -> Label:
-        """Remove a managed label from a thread."""
-        return await asyncio.to_thread(client.remove_label, thread_id, name)
+        Mirrors Gmail's own batchModify shape (a set of IDs, labels to add, labels to remove)
+        so labeling many threads costs one call instead of one per thread.
+        """
+        return await asyncio.to_thread(client.modify_labels, thread_ids, add=add or [], remove=remove or [])
 
     @mcp.tool
     async def create_label(name: label_name_ann) -> Label:

--- a/haku/gmail_labeling/server.py
+++ b/haku/gmail_labeling/server.py
@@ -50,7 +50,7 @@ def build_mcp(client: LabelClient) -> FastMCP:
         str, Field(description=f"Label display name; must start with {prefix!r}, e.g. {prefix + 'triaged'!r}.")
     ]
     add_ann = Annotated[
-        list[str] | None,
+        set[str] | None,
         Field(
             default=None,
             description=f"Label names to add to every thread; each must start with {prefix!r}. Creates a label "
@@ -58,7 +58,7 @@ def build_mcp(client: LabelClient) -> FastMCP:
         ),
     ]
     remove_ann = Annotated[
-        list[str] | None,
+        set[str] | None,
         Field(
             default=None,
             description=f"Label names to remove from every thread; each must start with {prefix!r} and already "
@@ -82,7 +82,7 @@ def build_mcp(client: LabelClient) -> FastMCP:
         Mirrors Gmail's own batchModify shape (a set of IDs, labels to add, labels to remove)
         so labeling many threads costs one call instead of one per thread.
         """
-        return await asyncio.to_thread(client.modify_labels, thread_ids, add=add or [], remove=remove or [])
+        return await asyncio.to_thread(client.modify_labels, thread_ids, add=add or set(), remove=remove or set())
 
     @mcp.tool
     async def create_label(name: label_name_ann) -> Label:

--- a/haku/gmail_labeling/test_backend.py
+++ b/haku/gmail_labeling/test_backend.py
@@ -1,0 +1,91 @@
+from collections.abc import Collection
+from dataclasses import dataclass
+
+import pytest
+import pytest_bazel
+
+from haku.gmail_labeling.backend import GmailLabelBackend
+
+
+@dataclass
+class _FakeRequest:
+    thread_id: str
+    body: dict[str, list[str]]
+
+
+class _FakeThreads:
+    def modify(self, *, userId, id, body):  # noqa: N803 -- mirrors Gmail's kwarg casing
+        return _FakeRequest(thread_id=id, body=body)
+
+
+class _FakeUsers:
+    def threads(self):
+        return _FakeThreads()
+
+
+class _FakeBatchRequest:
+    def __init__(self, callback, fail_thread_ids: Collection[str]) -> None:
+        self._callback = callback
+        self._fail_thread_ids = fail_thread_ids
+        self.requests: list[tuple[str, _FakeRequest]] = []
+
+    def add(self, request, *, request_id):
+        self.requests.append((request_id, request))
+
+    def execute(self):
+        for request_id, _request in self.requests:
+            if request_id in self._fail_thread_ids:
+                self._callback(request_id, None, RuntimeError(f"boom: {request_id}"))
+            else:
+                self._callback(request_id, {}, None)
+
+
+class _FakeService:
+    def __init__(self, fail_thread_ids: Collection[str] = frozenset()) -> None:
+        self._fail_thread_ids = fail_thread_ids
+        self.batches: list[_FakeBatchRequest] = []
+
+    def users(self):
+        return _FakeUsers()
+
+    def new_batch_http_request(self, callback):
+        batch = _FakeBatchRequest(callback, self._fail_thread_ids)
+        self.batches.append(batch)
+        return batch
+
+
+def test_modify_threads_sends_one_batch_within_limit():
+    service = _FakeService()
+    backend = GmailLabelBackend(service)
+    backend.modify_threads(["t1", "t2"], add=["Label_1"], remove=[])
+    assert len(service.batches) == 1
+    assert {request_id for request_id, _ in service.batches[0].requests} == {"t1", "t2"}
+
+
+def test_modify_threads_chunks_over_the_batch_limit():
+    service = _FakeService()
+    backend = GmailLabelBackend(service)
+    thread_ids = [f"t{i}" for i in range(150)]
+    backend.modify_threads(thread_ids, add=["Label_1"], remove=[])
+    assert [len(batch.requests) for batch in service.batches] == [100, 50]
+
+
+def test_modify_threads_raises_exception_group_on_partial_failure():
+    service = _FakeService(fail_thread_ids={"t2"})
+    backend = GmailLabelBackend(service)
+    with pytest.raises(ExceptionGroup) as exc_info:
+        backend.modify_threads(["t1", "t2", "t3"], add=["Label_1"], remove=[])
+    assert len(exc_info.value.exceptions) == 1
+    assert "boom: t2" in str(exc_info.value.exceptions[0])
+
+
+def test_modify_threads_body_carries_add_and_remove():
+    service = _FakeService()
+    backend = GmailLabelBackend(service)
+    backend.modify_threads(["t1"], add=["Label_1"], remove=["Label_2"])
+    ((_request_id, request),) = service.batches[0].requests
+    assert request.body == {"addLabelIds": ["Label_1"], "removeLabelIds": ["Label_2"]}
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/haku/gmail_labeling/test_client.py
+++ b/haku/gmail_labeling/test_client.py
@@ -8,7 +8,7 @@ from haku.gmail_labeling.conftest import user_label
 
 def test_modify_add_creates_label_and_records_modify(make_client):
     client, backend = make_client()
-    result = client.modify_labels(["t1"], add=["haku/triaged"], remove=[])
+    result = client.modify_labels(["t1"], add={"haku/triaged"}, remove=set())
     assert [label.name for label in result.added] == ["haku/triaged"]
     assert result.removed == []
     assert backend.thread_mods == [(["t1"], [result.added[0].id], [])]
@@ -16,7 +16,7 @@ def test_modify_add_creates_label_and_records_modify(make_client):
 
 def test_modify_add_reuses_existing_label(make_client):
     client, backend = make_client([user_label("haku/triaged", "Label_7")])
-    result = client.modify_labels(["t1"], add=["haku/triaged"], remove=[])
+    result = client.modify_labels(["t1"], add={"haku/triaged"}, remove=set())
     assert [label.id for label in result.added] == ["Label_7"]
     # No new label created.
     assert {label.id for label in backend.list_labels()} == {"Label_7"}
@@ -24,13 +24,13 @@ def test_modify_add_reuses_existing_label(make_client):
 
 def test_modify_batches_multiple_thread_ids_in_one_call(make_client):
     client, backend = make_client()
-    result = client.modify_labels(["t1", "t2", "t3"], add=["haku/triaged"], remove=[])
+    result = client.modify_labels(["t1", "t2", "t3"], add={"haku/triaged"}, remove=set())
     assert backend.thread_mods == [(["t1", "t2", "t3"], [result.added[0].id], [])]
 
 
 def test_modify_add_and_remove_together(make_client):
     client, backend = make_client([user_label("haku/old", "Label_1")])
-    result = client.modify_labels(["t1", "t2"], add=["haku/new"], remove=["haku/old"])
+    result = client.modify_labels(["t1", "t2"], add={"haku/new"}, remove={"haku/old"})
     assert [label.name for label in result.added] == ["haku/new"]
     assert [label.name for label in result.removed] == ["haku/old"]
     assert backend.thread_mods == [(["t1", "t2"], [result.added[0].id], ["Label_1"])]
@@ -39,28 +39,28 @@ def test_modify_add_and_remove_together(make_client):
 def test_modify_rejects_empty_thread_ids(make_client):
     client, backend = make_client()
     with pytest.raises(ToolError):
-        client.modify_labels([], add=["haku/triaged"], remove=[])
+        client.modify_labels([], add={"haku/triaged"}, remove=set())
     assert backend.thread_mods == []
 
 
 def test_modify_rejects_no_add_or_remove(make_client):
     client, backend = make_client()
     with pytest.raises(ToolError):
-        client.modify_labels(["t1"], add=[], remove=[])
+        client.modify_labels(["t1"], add=set(), remove=set())
     assert backend.thread_mods == []
 
 
 def test_modify_rejects_overlap_between_add_and_remove(make_client):
     client, backend = make_client([user_label("haku/x", "Label_1")])
     with pytest.raises(ToolError):
-        client.modify_labels(["t1"], add=["haku/x"], remove=["haku/x"])
+        client.modify_labels(["t1"], add={"haku/x"}, remove={"haku/x"})
     assert backend.thread_mods == []
 
 
 def test_modify_rejects_outside_prefix_before_any_io(make_client):
     client, backend = make_client()
     with pytest.raises(ToolError):
-        client.modify_labels(["t1"], add=["Important"], remove=[])
+        client.modify_labels(["t1"], add={"Important"}, remove=set())
     # Enforcement happens before touching the backend.
     assert backend.thread_mods == []
     assert backend.list_labels() == []
@@ -69,19 +69,19 @@ def test_modify_rejects_outside_prefix_before_any_io(make_client):
 def test_modify_rejects_system_label(make_client):
     client, backend = make_client()
     with pytest.raises(ToolError):
-        client.modify_labels(["t1"], add=["INBOX"], remove=[])
+        client.modify_labels(["t1"], add={"INBOX"}, remove=set())
     assert backend.thread_mods == []
 
 
 def test_modify_remove_requires_existing_label(make_client):
     client, _ = make_client()
     with pytest.raises(ToolError):
-        client.modify_labels(["t1"], add=[], remove=["haku/nope"])
+        client.modify_labels(["t1"], add=set(), remove={"haku/nope"})
 
 
 def test_modify_remove_records_modify(make_client):
     client, backend = make_client([user_label("haku/triaged", "Label_3")])
-    client.modify_labels(["t1"], add=[], remove=["haku/triaged"])
+    client.modify_labels(["t1"], add=set(), remove={"haku/triaged"})
     assert backend.thread_mods == [(["t1"], [], ["Label_3"])]
 
 

--- a/haku/gmail_labeling/test_client.py
+++ b/haku/gmail_labeling/test_client.py
@@ -6,47 +6,83 @@ from gmail_api.labels import GmailLabel, LabelType
 from haku.gmail_labeling.conftest import user_label
 
 
-def test_apply_creates_label_and_records_modify(make_client):
+def test_modify_add_creates_label_and_records_modify(make_client):
     client, backend = make_client()
-    label = client.apply_label("t1", "haku/triaged")
-    assert label.name == "haku/triaged"
-    assert backend.thread_mods == [("t1", [label.id], [])]
+    result = client.modify_labels(["t1"], add=["haku/triaged"], remove=[])
+    assert [label.name for label in result.added] == ["haku/triaged"]
+    assert result.removed == []
+    assert backend.thread_mods == [(["t1"], [result.added[0].id], [])]
 
 
-def test_apply_reuses_existing_label(make_client):
+def test_modify_add_reuses_existing_label(make_client):
     client, backend = make_client([user_label("haku/triaged", "Label_7")])
-    label = client.apply_label("t1", "haku/triaged")
-    assert label.id == "Label_7"
+    result = client.modify_labels(["t1"], add=["haku/triaged"], remove=[])
+    assert [label.id for label in result.added] == ["Label_7"]
     # No new label created.
     assert {label.id for label in backend.list_labels()} == {"Label_7"}
 
 
-def test_apply_rejects_outside_prefix_before_any_io(make_client):
+def test_modify_batches_multiple_thread_ids_in_one_call(make_client):
+    client, backend = make_client()
+    result = client.modify_labels(["t1", "t2", "t3"], add=["haku/triaged"], remove=[])
+    assert backend.thread_mods == [(["t1", "t2", "t3"], [result.added[0].id], [])]
+
+
+def test_modify_add_and_remove_together(make_client):
+    client, backend = make_client([user_label("haku/old", "Label_1")])
+    result = client.modify_labels(["t1", "t2"], add=["haku/new"], remove=["haku/old"])
+    assert [label.name for label in result.added] == ["haku/new"]
+    assert [label.name for label in result.removed] == ["haku/old"]
+    assert backend.thread_mods == [(["t1", "t2"], [result.added[0].id], ["Label_1"])]
+
+
+def test_modify_rejects_empty_thread_ids(make_client):
     client, backend = make_client()
     with pytest.raises(ToolError):
-        client.apply_label("t1", "Important")
+        client.modify_labels([], add=["haku/triaged"], remove=[])
+    assert backend.thread_mods == []
+
+
+def test_modify_rejects_no_add_or_remove(make_client):
+    client, backend = make_client()
+    with pytest.raises(ToolError):
+        client.modify_labels(["t1"], add=[], remove=[])
+    assert backend.thread_mods == []
+
+
+def test_modify_rejects_overlap_between_add_and_remove(make_client):
+    client, backend = make_client([user_label("haku/x", "Label_1")])
+    with pytest.raises(ToolError):
+        client.modify_labels(["t1"], add=["haku/x"], remove=["haku/x"])
+    assert backend.thread_mods == []
+
+
+def test_modify_rejects_outside_prefix_before_any_io(make_client):
+    client, backend = make_client()
+    with pytest.raises(ToolError):
+        client.modify_labels(["t1"], add=["Important"], remove=[])
     # Enforcement happens before touching the backend.
     assert backend.thread_mods == []
     assert backend.list_labels() == []
 
 
-def test_apply_rejects_system_label(make_client):
+def test_modify_rejects_system_label(make_client):
     client, backend = make_client()
     with pytest.raises(ToolError):
-        client.apply_label("t1", "INBOX")
+        client.modify_labels(["t1"], add=["INBOX"], remove=[])
     assert backend.thread_mods == []
 
 
-def test_remove_requires_existing_label(make_client):
+def test_modify_remove_requires_existing_label(make_client):
     client, _ = make_client()
     with pytest.raises(ToolError):
-        client.remove_label("t1", "haku/nope")
+        client.modify_labels(["t1"], add=[], remove=["haku/nope"])
 
 
-def test_remove_records_modify(make_client):
+def test_modify_remove_records_modify(make_client):
     client, backend = make_client([user_label("haku/triaged", "Label_3")])
-    client.remove_label("t1", "haku/triaged")
-    assert backend.thread_mods == [("t1", [], ["Label_3"])]
+    client.modify_labels(["t1"], add=[], remove=["haku/triaged"])
+    assert backend.thread_mods == [(["t1"], [], ["Label_3"])]
 
 
 def test_create_duplicate_rejected(make_client):

--- a/haku/gmail_labeling/test_server.py
+++ b/haku/gmail_labeling/test_server.py
@@ -9,21 +9,30 @@ from haku.gmail_labeling.server import build_mcp
 async def test_tool_surface(client):
     async with Client(build_mcp(client)) as mcp_client:
         tools = {tool.name for tool in await mcp_client.list_tools()}
-    assert tools == {"list_labels", "apply_label", "remove_label", "create_label", "rename_label", "delete_label"}
+    assert tools == {"list_labels", "modify_labels", "create_label", "rename_label", "delete_label"}
 
 
-async def test_apply_label_tool_succeeds(client, backend):
+async def test_modify_labels_tool_succeeds(client, backend):
     async with Client(build_mcp(client)) as mcp_client:
-        result = await mcp_client.call_tool("apply_label", {"thread_id": "t1", "name": "haku/triaged"})
+        result = await mcp_client.call_tool("modify_labels", {"thread_ids": ["t1"], "add": ["haku/triaged"]})
     assert not result.is_error
     assert len(backend.thread_mods) == 1
-    assert backend.thread_mods[0][0] == "t1"
+    assert backend.thread_mods[0][0] == ["t1"]
 
 
-async def test_apply_label_tool_rejects_outside_prefix(client):
+async def test_modify_labels_tool_batches_multiple_threads(client, backend):
+    async with Client(build_mcp(client)) as mcp_client:
+        result = await mcp_client.call_tool(
+            "modify_labels", {"thread_ids": ["t1", "t2", "t3"], "add": ["haku/triaged"]}
+        )
+    assert not result.is_error
+    assert backend.thread_mods == [(["t1", "t2", "t3"], [backend.list_labels()[0].id], [])]
+
+
+async def test_modify_labels_tool_rejects_outside_prefix(client):
     async with Client(build_mcp(client)) as mcp_client:
         with pytest.raises(ToolError):
-            await mcp_client.call_tool("apply_label", {"thread_id": "t1", "name": "Important"})
+            await mcp_client.call_tool("modify_labels", {"thread_ids": ["t1"], "add": ["Important"]})
 
 
 if __name__ == "__main__":

--- a/haku/state_template/procedures/manage_gmail_labels.md
+++ b/haku/state_template/procedures/manage_gmail_labels.md
@@ -28,14 +28,16 @@ fastmcp list "$URL" --auth "$TOKEN" --transport http --input-schema   # tools + 
 
 Reference `"$TOKEN"`, never the literal value, so the bearer stays out of your transcript.
 
-| Tool           | Effect                                                         |
-| -------------- | -------------------------------------------------------------- |
-| `list_labels`  | List managed labels (those under `haku/`).                     |
-| `apply_label`  | Add a managed label to a thread (creates the label if needed). |
-| `remove_label` | Remove a managed label from a thread.                          |
-| `create_label` | Create a managed label without applying it.                    |
-| `rename_label` | Rename a managed label (both names must be under `haku/`).     |
-| `delete_label` | Delete a managed label (drops it from every thread).           |
+| Tool            | Effect                                                                  |
+| --------------- | ----------------------------------------------------------------------- |
+| `list_labels`   | List managed labels (those under `haku/`).                              |
+| `modify_labels` | Add and/or remove managed labels across a batch of threads in one call. |
+| `create_label`  | Create a managed label without applying it.                             |
+| `rename_label`  | Rename a managed label (both names must be under `haku/`).              |
+| `delete_label`  | Delete a managed label (drops it from every thread).                    |
+
+`modify_labels` takes a list of `thread_ids` plus `add`/`remove` label lists (Gmail's
+own `batchModify` shape) — label many threads at once instead of one call per thread.
 
 ## Current policy
 
@@ -67,7 +69,8 @@ made, so the policy is explicit and auditable:
 - **Log every labeling action** in the day's run log (`log/YYYY-MM-DD.md`): which threads,
   which labels, why. This is your audit trail for a capability that changes the operator's
   mailbox.
-- **Reversibility first** — prefer schemes you can cleanly undo (`remove_label` / `delete_label`
-  stay within the same bound). Confirm a rule on a handful of threads before any breadth.
+- **Reversibility first** — prefer schemes you can cleanly undo (`modify_labels` removal /
+  `delete_label` stay within the same bound). Confirm a rule on a handful of threads before
+  any breadth.
 - **Surface, don't hide** — when you run a labeling pass, put a short summary on the dashboard
   so the operator always sees what you changed.


### PR DESCRIPTION
## Summary

- Replace the single-thread `apply_label`/`remove_label` MCP tools with one `modify_labels(thread_ids, add, remove)` tool, mirroring Gmail's own `batchModify` request shape (a set of IDs, labels to add, labels to remove) instead of inventing a bespoke batch API.
- Gmail has no `threads.batchModify` endpoint (only `messages.batchModify`, a different resource), so `GmailLabelBackend.modify_threads` folds many `threads.modify` calls into as few HTTP requests as possible via Gmail's generic batch-request mechanism (`new_batch_http_request`), chunked at its recommended 100 calls per batch, aggregating any per-thread failures into an `ExceptionGroup`.
- Updated docs (`README.md`, `AGENTS.md`) and the Haku procedure doc (`manage_gmail_labels.md`) to reflect the new tool surface.

## Test plan

- [x] `bazelisk test //haku/gmail_labeling/...` — all 4 targets pass (`test_namespace`, `test_client`, `test_backend` (new), `test_server`)
- [x] `bazelisk build //haku/gmail_labeling/...` — builds clean (mypy/lint included)
- [x] New `test_backend.py` covers chunking above the 100-item batch limit and per-thread error aggregation via a fake Gmail service
- [x] `pre-commit` hooks (ruff, buildifier, prettier, commit-msg tag) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AY7t3iKetbEeaR2cFKihwf)_