### PR TITLE
lint: pin markdownlint-cli2 via Nix, switch pre-commit hook to local

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,14 +99,17 @@ repos:
         types: [nix]
         pass_filenames: false
 
-  # Markdown linting. Scoped to staged files via `files:` regex below; the
-  # markdownlint-cli2 config (.markdownlint-cli2.jsonc) has no globs of its
-  # own, so pre-commit's positional args (= staged files) are the only inputs.
-  - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: v0.22.0
+  # Markdown linting — markdownlint-cli2 provided by devShell / web-session via
+  # Nix (avoids a git clone of the hook's repo just to install it). Scoped to
+  # staged files via `files:` regex below; the markdownlint-cli2 config
+  # (.markdownlint-cli2.jsonc) has no globs of its own, so pre-commit's
+  # positional args (= staged files) are the only inputs.
+  - repo: local
     hooks:
       - id: markdownlint-cli2
-        args: [--fix]
+        name: markdownlint-cli2
+        entry: markdownlint-cli2 --fix
+        language: system
         files: ^(cluster|website)/.*\.md$
 
   # NOTE: ESLint and svelte-check are handled by Bazel:

--- a/devinfra/docs/linting.md
+++ b/devinfra/docs/linting.md
@@ -96,17 +96,17 @@ All hooks respect `.gitattributes` and `.pre-commit-config.yaml` exclusions.
 
 Key hooks in `.pre-commit-config.yaml`:
 
-| Hook                 | Source                       | Purpose                           |
-| -------------------- | ---------------------------- | --------------------------------- |
-| `ruff-check`         | astral-sh/ruff-pre-commit    | Python linting                    |
-| `ruff-format`        | astral-sh/ruff-pre-commit    | Python formatting                 |
-| `buildifier`         | keith/pre-commit-buildifier  | Starlark formatting               |
-| `buildifier-lint`    | keith/pre-commit-buildifier  | Starlark linting                  |
-| `ducktape-precommit` | local (system)               | Filename + frozen-specimen checks |
-| `prettier`           | local (node)                 | JS/TS/MD/YAML formatting          |
-| `rustfmt`            | local (system)               | Rust formatting                   |
-| `nixfmt`             | local (static binary)        | Nix formatting                    |
-| `markdownlint-cli2`  | DavidAnson/markdownlint-cli2 | Markdown linting                  |
+| Hook                 | Source                      | Purpose                           |
+| -------------------- | --------------------------- | --------------------------------- |
+| `ruff-check`         | astral-sh/ruff-pre-commit   | Python linting                    |
+| `ruff-format`        | astral-sh/ruff-pre-commit   | Python formatting                 |
+| `buildifier`         | keith/pre-commit-buildifier | Starlark formatting               |
+| `buildifier-lint`    | keith/pre-commit-buildifier | Starlark linting                  |
+| `ducktape-precommit` | local (system)              | Filename + frozen-specimen checks |
+| `prettier`           | local (node)                | JS/TS/MD/YAML formatting          |
+| `rustfmt`            | local (system)              | Rust formatting                   |
+| `nixfmt`             | local (static binary)       | Nix formatting                    |
+| `markdownlint-cli2`  | local (system)              | Markdown linting                  |
 
 Cluster-specific hooks run only on `cluster/` files:
 

--- a/flake.nix
+++ b/flake.nix
@@ -320,6 +320,7 @@
         pkgs.shfmt
         pkgs.buildifier
         pkgs.gofumpt
+        pkgs.markdownlint-cli2
         ducktapePkgs.prettier
         pkgs.openssl
         # Codex setup materializes kubeconfig via devinfra/k8s/kubeconfig.py;


### PR DESCRIPTION
## Summary

Switch the `markdownlint-cli2` pre-commit hook from the community GitHub-hosted repo (`DavidAnson/markdownlint-cli2, rev: v0.22.0`) to the Nix-provided binary (`pkgs.markdownlint-cli2` in devToolsCommon), matching `nixfmt` / `statix` / `buildifier` / etc. Installing it no longer requires a git clone of a third-party repo — repo-scoped sessions can't do that even when the underlying repo is public.

## Files

- `flake.nix`: `+pkgs.markdownlint-cli2` in `devToolsCommon`.
- `.pre-commit-config.yaml`: swap the hook definition from `repo: https://github.com/DavidAnson/markdownlint-cli2` (`rev: v0.22.0`) to `repo: local` with `entry: markdownlint-cli2 --fix, language: system`.
- `devinfra/docs/linting.md`: update the "Source" column for the `markdownlint-cli2` row from `DavidAnson/markdownlint-cli2` to `local (system)` (also shrinks the column widths, which pre-commit auto-fixes to match).

## Split from #2696

Split off from #2696, which combined this pin with unrelated bbr git-mirroring reconciliation work. The bbr fixes stay on #2696; this PR is just the markdownlint-cli2 pin.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcmYZYsrpgiZViSQeuNgXG)_