### PR TITLE
bazel-ci: swap target-determinator shadow for bazel-diff shadow

### DIFF
--- a/.github/workflows/bazel-ci.yml
+++ b/.github/workflows/bazel-ci.yml
@@ -98,9 +98,9 @@ jobs:
                 echo "head:            $HEAD_SHA"
                 mkdir -p /tmp/bd-cache
                 git -c advice.detachedHead=false checkout --quiet "$BASE" \
-                  && bazel-diff generate-hashes -w . -b bazel /tmp/bd-cache/base.json \
+                  && bazel-diff generate-hashes -w "$PWD" -b bazel /tmp/bd-cache/base.json \
                   && git -c advice.detachedHead=false checkout --quiet "$HEAD_SHA" \
-                  && bazel-diff generate-hashes -w . -b bazel /tmp/bd-cache/head.json \
+                  && bazel-diff generate-hashes -w "$PWD" -b bazel /tmp/bd-cache/head.json \
                   && bazel-diff get-impacted-targets \
                        -sh /tmp/bd-cache/base.json -fh /tmp/bd-cache/head.json \
                        > /tmp/bd-affected.txt \

--- a/.github/workflows/bazel-ci.yml
+++ b/.github/workflows/bazel-ci.yml
@@ -75,43 +75,43 @@ jobs:
             }
             trap finalize_bb_runner_probe EXIT
 
-            # Shadow mode (informational only): on PRs, compute the
-            # target-determinator affected set and print it. Not used for gating.
-            # Once the set is proven sane over several PRs, gating flips to only
-            # test/build affected targets on PRs; devel keeps `//...`.
-            # Gracefully skips when TD is missing from the RBE image (pin lag
-            # after devtools/rbetools#2679).
+            # Shadow mode (informational only): on PRs, compute the affected
+            # target set with bazel-diff and print it. Not used for gating.
+            # Once the set is proven sane over several PRs, gating flips to
+            # only test/build affected targets on PRs; devel keeps `//...`.
+            # Gracefully skips when bazel-diff is missing from the RBE image
+            # (pin lag after devtools/rbetools#2706).
             #
             # `set +e` inside the block: any failure in git fetch, merge-base,
-            # rev-parse, or target-determinator itself must NOT abort the CI
+            # rev-parse, checkout, or bazel-diff itself must NOT abort the CI
             # script under the outer `set -euo pipefail`. Restored after the
             # block so the real test/build stages still fail fast.
-            if [ "${{ github.event_name }}" = "pull_request" ] && command -v target-determinator >/dev/null 2>&1; then
+            if [ "${{ github.event_name }}" = "pull_request" ] && command -v bazel-diff >/dev/null 2>&1; then
               set +e
-              echo "::group::target-determinator (shadow)"
-              mkdir -p /tmp/td-cache
-              git fetch --no-tags origin devel
+              echo "::group::bazel-diff (shadow)"
+              git fetch --deepen=200 --no-tags origin devel 2>/dev/null \
+                || git fetch --no-tags origin devel
               BASE=$(git merge-base origin/devel HEAD)
               HEAD_SHA=$(git rev-parse HEAD)
               if [ -n "$BASE" ] && [ -n "$HEAD_SHA" ]; then
                 echo "before-revision: $BASE"
                 echo "head:            $HEAD_SHA"
-                # -targets is the query (default //...); the before-revision
-                # is a positional argument, NOT -before-revision.
-                #
-                # Exclude //website/...: it carries tags=["manual"] so `bazel
-                # test //...` (and its analysis) skip it, but TD's cquery
-                # doesn't respect manual-tag filtering and trips a deprecated
-                # ctx.resolve_tools call in rules_haskell during analysis of
-                # the Hakyll REPL target. Excluding matches what `bazel test
-                # //...` on devel already sees.
-                target-determinator \
-                  -cache-dir=/tmp/td-cache \
-                  -targets='//... except //website/...' \
-                  "$BASE"
+                mkdir -p /tmp/bd-cache
+                git -c advice.detachedHead=false checkout --quiet "$BASE" \
+                  && bazel-diff generate-hashes -w . -b bazelisk /tmp/bd-cache/base.json \
+                  && git -c advice.detachedHead=false checkout --quiet "$HEAD_SHA" \
+                  && bazel-diff generate-hashes -w . -b bazelisk /tmp/bd-cache/head.json \
+                  && bazel-diff get-impacted-targets \
+                       -sh /tmp/bd-cache/base.json -fh /tmp/bd-cache/head.json \
+                       > /tmp/bd-affected.txt \
+                  && echo "affected targets: $(wc -l < /tmp/bd-affected.txt)" \
+                  && sed -n '1,20p' /tmp/bd-affected.txt
               else
                 echo "could not resolve merge-base (BASE=$BASE HEAD=$HEAD_SHA); skipping"
               fi
+              # Restore checkout even on failure so bazel test/build below run
+              # against the PR head.
+              git -c advice.detachedHead=false checkout --quiet "${HEAD_SHA:-HEAD}" >/dev/null 2>&1
               echo "::endgroup::"
               set -e
             fi

--- a/.github/workflows/bazel-ci.yml
+++ b/.github/workflows/bazel-ci.yml
@@ -98,9 +98,9 @@ jobs:
                 echo "head:            $HEAD_SHA"
                 mkdir -p /tmp/bd-cache
                 git -c advice.detachedHead=false checkout --quiet "$BASE" \
-                  && bazel-diff generate-hashes -w . -b bazelisk /tmp/bd-cache/base.json \
+                  && bazel-diff generate-hashes -w . -b bazel /tmp/bd-cache/base.json \
                   && git -c advice.detachedHead=false checkout --quiet "$HEAD_SHA" \
-                  && bazel-diff generate-hashes -w . -b bazelisk /tmp/bd-cache/head.json \
+                  && bazel-diff generate-hashes -w . -b bazel /tmp/bd-cache/head.json \
                   && bazel-diff get-impacted-targets \
                        -sh /tmp/bd-cache/base.json -fh /tmp/bd-cache/head.json \
                        > /tmp/bd-affected.txt \


### PR DESCRIPTION
Step 3 of the bazel-diff rollout (see #2706 for step 1). On pull_request events, replace the existing `target-determinator` shadow block in `bazel-ci.yml` with an equivalent `bazel-diff` shadow block: log the affected set, don't gate on it. Same fail-safe wrapping (`set +e`, checkout-restore on failure, `command -v` guard for RBE image pin lag).

## Rollout stage

1. Package `bazel-diff` in `.#rbetools` (#2706) — **base of this PR**
2. Container-images auto-rebuild + repin (nix/packages/** trigger already in place)
3. **This PR**: shadow-mode bazel-diff on PRs
4. Observe a few PRs' shadow output
5. Flip to gating (#2705, rebased onto this branch next)
6. Cleanup: drop target-determinator per repo TODO added in #2706

## Why not keep TD shadow alongside

The target-determinator shadow's real observed cost on this repo (~11 GB peak, 20+ min cold, OOM-killed on CI at `compute_units=4`) makes it not worth keeping around just for comparison — we already have that data. Once #2705 flips gating to bazel-diff, the shadow block comes out entirely anyway.

## Guardrails

- **`command -v bazel-diff` guard**: no-op if `bazel-diff` isn't on the runner yet (pin lag after #2706 merges but before container-images auto-rebuild + repin).
- **`set +e` inside the block**: any failure in `git fetch` / `merge-base` / `rev-parse` / `checkout` / `bazel-diff` itself does NOT abort the CI script under the outer `set -euo pipefail`. Restored after the block.
- **Explicit restore-checkout**: even if bazel-diff errors mid-flow, restore the workspace to the PR head so the real test/build below run against the right code.
- **`git fetch --deepen=200`**: same as #2705 — makes `git merge-base` resolvable inside bb-remote's shallow-cloned runner.

## Stacked PR

Base is `claude/nix-package-bazel-diff` (#2706). Will retarget to `devel` once #2706 lands. Reviewing the diff on top of #2706's diff should show only the shadow-block swap.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcmYZYsrpgiZViSQeuNgXG)_