### PR TITLE
devinfra: run checkov from the Nix devshell instead of cloning its repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -307,14 +307,19 @@ repos:
   # CLUSTER-SPECIFIC HOOKS (external repos, scoped to cluster/ directory)
   # ============================================================================
 
-  # Checkov security scanner for Terraform
-  - repo: https://github.com/bridgecrewio/checkov
-    rev: 3.2.513
+  # Checkov security scanner for Terraform — checkov provided by devShell / web-session
+  # via Nix (pkgs.checkov). Local hook (not repo: github) so pre-commit needn't clone
+  # the checkov repo, which web sessions cannot fetch through the egress proxy.
+  # Mirrors the upstream checkov_diff hook: `entry: checkov` + pass_filenames with `-f`.
+  - repo: local
     hooks:
       - id: checkov_diff
+        name: checkov (terraform)
+        language: system
+        entry: checkov
         args: ["--framework", "terraform", "--skip-check", "CKV_TF_1,CKV2_AWS_23", "-f"]
         files: "^(cluster/terraform|tf)/.*\\.tf$"
-        additional_dependencies: ["urllib3", "python-dateutil"]
+        require_serial: true
 
   # TFLint - Terraform linter — tflint provided by devShell / web-session via Nix
   # Config: cluster/.tflint.hcl; plugins cached in ~/.tflint.d/plugins

--- a/flake.nix
+++ b/flake.nix
@@ -335,6 +335,7 @@
         pkgs.kubeconform
         pkgs.opentofu
         pkgs.tflint
+        pkgs.checkov # Terraform security scanner; backs the checkov_diff pre-commit hook
         pkgs.sops
         pkgs.ssh-to-age
         ducktapePkgs.kubernetes-mcp-server


### PR DESCRIPTION
## Problem

`checkov` was the only pre-commit hook still using `repo: <github>`, which forces `pre-commit` to clone `github.com/bridgecrewio/checkov` to build its own hook environment. Web/agent sessions cannot fetch that repo through the egress proxy (403), so `pre-commit` aborts during hook-env init — blocking **every** commit, not just Terraform changes:

```
[INFO] Initializing environment for https://github.com/bridgecrewio/checkov.
fatal: unable to access '.../git/bridgecrewio/checkov/': The requested URL returned error: 403
```

## Change

Convert the `checkov_diff` hook to the same `repo: local` + `language: system` pattern every other tool in the repo already uses (ruff, tflint, buildifier, nixfmt, statix, …), backed by `pkgs.checkov` added to `devToolsCommon` in `flake.nix`. The local hook mirrors the upstream `checkov_diff` behavior (`entry: checkov` + `pass_filenames` with the trailing `-f`), keeping the same `--framework`/`--skip-check` args and `files:` filter. `additional_dependencies` is dropped since the Nix closure supplies checkov's deps.

- nixpkgs 25.11 ships **checkov 3.2.495** (was pinned `3.2.513`; the delta is patch-level check additions).
- No behavior change to what gets scanned or which checks are skipped.

## Verification

- `pkgs.checkov` builds and pulls from `cache.nixos.org`; `flake.nix` still evaluates with it added.
- `pre-commit run checkov_diff --all-files` **passes** using the devshell checkov and performs **no network fetch**.
- Full pre-commit chain on the changed files passes nixfmt, statix, prettier, and check-yaml.

## Note

Fixing checkov removes it from the set of proxy-blocked hooks, but it is not the only one: `ducktape-precommit`'s `cluster-validate` still runs `kustomize build` against remote `kubevirt`/`cdi-operator` bases that the egress proxy also 403s. That is a separate, pre-existing web-session limitation and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjEYLNhipPWErzEqJk9D3s)_