### PR TITLE
grocy-sf: make user-perms a policy-driven reconciler with daily drift correction

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -72,6 +72,8 @@ cluster/k8s/evidence/market-roster/market-roster.yaml cluster-manifest-ignored=t
 cluster/k8s/agents/authentik-jwt-rotation/rotations.yaml cluster-manifest-ignored=true
 # rotate.py's token list, mounted via configMapGenerator — not a K8s manifest.
 cluster/k8s/agents/attic-jwt-rotation/rotators.yaml cluster-manifest-ignored=true
+# provision.py's user→permission policy, mounted via configMapGenerator — not a K8s manifest.
+cluster/k8s/grocy/sf/user-perms/policy.yaml cluster-manifest-ignored=true
 
 # Dotfiles/dotdirs follow their own naming conventions
 .* filename-conventions-ignored=true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -294,6 +294,8 @@ repos:
             cluster/k8s/agents/authentik-jwt-rotation/rotations\.yaml|
             # rotate.py token list, mounted via configMapGenerator, not a K8s manifest
             cluster/k8s/agents/attic-jwt-rotation/rotators\.yaml|
+            # provision.py user→permission policy, mounted via configMapGenerator, not a K8s manifest
+            cluster/k8s/grocy/sf/user-perms/policy\.yaml|
             # APT manifests for Bazel rules_distroless, not K8s manifests
             cluster/k8s/agents/authentik-jwt-rotation/trixie_authentik_rotation\.yaml|
             cluster/k8s/agents/attic-jwt-rotation/trixie_attic_rotation\.yaml|

--- a/cluster/k8s/grocy/sf/user-perms/BUILD.bazel
+++ b/cluster/k8s/grocy/sf/user-perms/BUILD.bazel
@@ -1,18 +1,39 @@
-"""grocy-sf user-perms provisioner OCI image — ensures SF operators have ADMIN."""
+"""grocy-sf user-perms reconciler OCI image — converges Grocy user permissions to policy.yaml."""
 
 load("@aspect_rules_py//py:defs.bzl", "py_image_layer", aspect_py_binary = "py_binary")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
-load("//devinfra/python:defs.bzl", "py_library")
+load("//devinfra/python:defs.bzl", "py_library", "py_test")
 load("//props:oci.bzl", "py_image_entrypoint", "py_image_env")
 
+# imports=["."] puts this (kebab-cased, non-importable-as-a-package) directory on
+# sys.path so provision.py is importable as the top-level module `provision`.
 py_library(
     name = "provision",
     srcs = ["provision.py"],
-    deps = ["@pypi//httpx"],
+    imports = ["."],
+    deps = [
+        "@pypi//httpx",
+        "@pypi//pydantic",
+        "@pypi//pyyaml",
+        "@pypi//typer",
+    ],
+)
+
+py_test(
+    name = "test_provision",
+    srcs = ["test_provision.py"],
+    imports = ["."],
+    deps = [
+        ":provision",
+        "@pypi//httpx",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
+    ],
 )
 
 aspect_py_binary(
     name = "provision_bin",
+    imports = ["."],
     main = "provision.py",
     deps = [":provision"],
 )

--- a/cluster/k8s/grocy/sf/user-perms/cronjob.yaml
+++ b/cluster/k8s/grocy/sf/user-perms/cronjob.yaml
@@ -1,0 +1,63 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: grocy-sf-user-perms-reconciler
+  namespace: grocy-sf
+  annotations:
+    description: >-
+      Daily drift correction for the user→permission policy in policy.yaml. The
+      one-shot provisioner Job converges at bootstrap and on policy changes;
+      this CronJob re-asserts the same policy so manual permission edits in the
+      Grocy UI (e.g. elevating haku) converge back within a day.
+spec:
+  schedule: "40 4 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        metadata:
+          labels:
+            # Same label as the provisioner Job's pods — the sibling
+            # NetworkPolicy admits it to grocy:80.
+            app.kubernetes.io/name: grocy-sf-user-perms-provisioner
+        spec:
+          restartPolicy: OnFailure
+          enableServiceLinks: false
+          automountServiceAccountToken: false
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumes:
+            - name: policy
+              configMap:
+                name: grocy-sf-user-perms-policy
+          containers:
+            - name: reconciler
+              # Script baked in via Bazel (//cluster/k8s/grocy/sf/user-perms:image).
+              image: ghcr.io/agentydragon/grocy-sf-user-perms-provisioner:devel-20260626195242-4cbec4e # {"$imagepolicy": "flux-system:grocy-sf-user-perms-provisioner"}
+              imagePullPolicy: Always
+              args:
+                - --policy
+                - /config/policy.yaml
+                - --grocy-url
+                - http://grocy.grocy-sf.svc.cluster.local
+              volumeMounts:
+                - name: policy
+                  mountPath: /config
+                  readOnly: true
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+              resources:
+                requests:
+                  cpu: 25m
+                  memory: 64Mi
+                limits:
+                  memory: 128Mi

--- a/cluster/k8s/grocy/sf/user-perms/flux-kustomization.yaml
+++ b/cluster/k8s/grocy/sf/user-perms/flux-kustomization.yaml
@@ -13,8 +13,9 @@ spec:
   path: ./cluster/k8s/grocy/sf/user-perms
   prune: true
   # Run only after grocy-sf is up (and self-migrated via its postStart hook); the
-  # Job-completion healthcheck makes this kustomization Ready only once the operator
-  # elevation has actually run — so a fresh cluster converges to operators=ADMIN.
+  # Job-completion healthcheck makes this kustomization Ready only once the policy
+  # in policy.yaml has actually been applied — so a fresh cluster converges to the
+  # committed user→permission policy.
   wait: true
   dependsOn:
     - name: grocy-sf

--- a/cluster/k8s/grocy/sf/user-perms/job.yaml
+++ b/cluster/k8s/grocy/sf/user-perms/job.yaml
@@ -4,8 +4,9 @@ metadata:
   name: grocy-sf-user-perms-provisioner
   namespace: grocy-sf
   annotations:
-    # One-shot: runs once per cluster bootstrap (Flux applies it after grocy is up).
-    # The Job spec is immutable, so let Flux recreate it when the image bumps.
+    # One-shot: runs at cluster bootstrap and again whenever the policy ConfigMap
+    # (hash-suffixed by kustomize) or the image changes. The Job spec is
+    # immutable, so let Flux recreate it.
     kustomize.toolkit.fluxcd.io/force: enabled
 spec:
   backoffLimit: 10
@@ -23,11 +24,24 @@ spec:
         runAsGroup: 1000
         seccompProfile:
           type: RuntimeDefault
+      volumes:
+        - name: policy
+          configMap:
+            name: grocy-sf-user-perms-policy
       containers:
         - name: provisioner
           # Script baked in via Bazel (//cluster/k8s/grocy/sf/user-perms:image).
           image: ghcr.io/agentydragon/grocy-sf-user-perms-provisioner:devel-20260626195242-4cbec4e # {"$imagepolicy": "flux-system:grocy-sf-user-perms-provisioner"}
           imagePullPolicy: Always
+          args:
+            - --policy
+            - /config/policy.yaml
+            - --grocy-url
+            - http://grocy.grocy-sf.svc.cluster.local
+          volumeMounts:
+            - name: policy
+              mountPath: /config
+              readOnly: true
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/cluster/k8s/grocy/sf/user-perms/kustomization.yaml
+++ b/cluster/k8s/grocy/sf/user-perms/kustomization.yaml
@@ -4,3 +4,10 @@ namespace: grocy-sf
 resources:
   - networkpolicy.yaml
   - job.yaml
+  - cronjob.yaml
+configMapGenerator:
+  # Hash-suffixed: a policy edit changes the Job spec, which (with the force
+  # annotation) makes Flux recreate the one-shot Job — immediate convergence.
+  - name: grocy-sf-user-perms-policy
+    files:
+      - policy.yaml

--- a/cluster/k8s/grocy/sf/user-perms/networkpolicy.yaml
+++ b/cluster/k8s/grocy/sf/user-perms/networkpolicy.yaml
@@ -1,8 +1,9 @@
 # The base `grocy-ingress` policy (app-base) restricts Grocy :80 to the Authentik
 # outpost + Gatus, because any pod that reaches :80 can impersonate any user via the
 # trusted X-authentik-username header. NetworkPolicies are additive, so this grants
-# the user-perms provisioner Job that same in-cluster access (it acts as the admin
-# user to elevate the operators). Scoped to the provisioner pod label only.
+# the user-perms reconciler pods (bootstrap Job + daily CronJob) that same in-cluster
+# access (they act as the admin user to apply policy.yaml). Scoped to the shared
+# provisioner pod label only.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/cluster/k8s/grocy/sf/user-perms/policy.yaml
+++ b/cluster/k8s/grocy/sf/user-perms/policy.yaml
@@ -1,0 +1,10 @@
+# Grocy SF user→permission policy. The reconciler (provision.py; bootstrap Job +
+# daily CronJob) converges each listed user to exactly this permission set,
+# creating the user if absent. Unlisted users are untouched — born read-only via
+# DEFAULT_PERMISSIONS=none (../app). Permission names are rows of Grocy's
+# permission_hierarchy table; ADMIN is the root and implies everything else.
+users:
+  agentydragon: [ADMIN]
+  auragon: [ADMIN]
+  # Explicitly empty: haku stays read-only, converged back even if elevated in the UI.
+  haku: []

--- a/cluster/k8s/grocy/sf/user-perms/provision.py
+++ b/cluster/k8s/grocy/sf/user-perms/provision.py
@@ -1,33 +1,46 @@
-"""Ensure the SF household operator(s) have ADMIN in the grocy-sf instance.
+"""Reconcile Grocy user permissions against a declarative policy file.
 
-Read-only is the default here (DEFAULT_PERMISSIONS=none, see ../app), so haku and
-any other auto-created user is read-only. This one-shot Job does the single explicit
-elevation default-deny requires: ensure each human operator exists and has ADMIN.
-Flux runs it once after grocy is up (dependsOn grocy-sf), so a from-scratch cluster
-rebuild ends with the operators able to use Grocy — no manual step.
+Read-only is the default in grocy-sf (DEFAULT_PERMISSIONS=none, see ../app), so
+every auto-created user is born with no permissions. This reconciler converges
+each user listed in the policy to exactly its declared permission set (creating
+the user via reverse-proxy auth if absent); unlisted users are left untouched.
 
-Idempotent. Runs as the built-in `admin` user (always ADMIN, created by the schema
-migration) via Grocy's trusted X-authentik-username header; the sibling
+Two triggers, same convergence: the one-shot Job (runs at bootstrap; policy or
+image changes recreate it via the Flux force annotation, and the kustomization's
+healthcheck gates on its completion) and the daily CronJob (drift correction —
+an operator demoted or haku elevated in the web UI converges back within a day).
+
+Idempotent. Runs as the built-in `admin` user (always ADMIN, created by the
+schema migration) via Grocy's trusted X-authentik-username header; the sibling
 NetworkPolicy is what restricts who may present it.
 """
 
 import contextlib
 import time
+from pathlib import Path
+from typing import Annotated, Any
 
 import httpx
+import typer
+import yaml
+from pydantic import BaseModel, Field
 
-GROCY = "http://grocy.grocy-sf.svc.cluster.local:80"
 ADMIN = "admin"  # Grocy's built-in admin user (created by the schema migration)
-OPERATORS = ("agentydragon", "auragon")  # SF household humans to keep at ADMIN
-ADMIN_PERMISSION_ID = 1  # the ADMIN root permission (implies all others)
+
+
+class Policy(BaseModel):
+    users: dict[str, set[str]] = Field(
+        description="username -> permission_hierarchy names the user holds exactly"
+        " (empty = no permissions, i.e. read-only)"
+    )
 
 
 def wait_for_schema(client: httpx.Client) -> None:
     """Await Grocy's schema. The app self-migrates at startup (postStart hits the
-    auth-exempt `/`) and Flux only runs this Job once grocy is Ready, but poll
-    defensively so the Job also works run standalone. Hit `/` (its body is an HTML
-    redirect — ignore it) in case migration hasn't run, then poll the JSON
-    `/api/users` until the schema exists.
+    auth-exempt `/`) and Flux only runs the Job once grocy is Ready, but poll
+    defensively so this also works run standalone (e.g. the CronJob racing a fresh
+    deploy). Hit `/` (its body is an HTML redirect — ignore it) in case migration
+    hasn't run, then poll the JSON `/api/users` until the schema exists.
     """
     for _ in range(30):
         with contextlib.suppress(httpx.HTTPError):
@@ -39,26 +52,47 @@ def wait_for_schema(client: httpx.Client) -> None:
     raise RuntimeError("Grocy schema not ready in time")
 
 
-def main() -> None:
+def get_json(client: httpx.Client, path: str) -> Any:
+    resp = client.get(path)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def reconcile(client: httpx.Client, policy: Policy) -> None:
+    # Grocy serializes SQLite rows with numeric columns as strings — int() them.
+    permission_ids = {row["name"]: int(row["id"]) for row in get_json(client, "/api/objects/permission_hierarchy")}
+    for username in policy.users:
+        # Reverse-proxy auth auto-creates the user on the first request bearing its
+        # username; default-deny means it is born with no permissions.
+        client.get("/api/system/info", headers={"X-authentik-username": username}).raise_for_status()
+    user_ids = {u["username"]: int(u["id"]) for u in get_json(client, "/api/users")}
+    for username, permission_names in policy.users.items():
+        if username not in user_ids:
+            raise RuntimeError(f"{username!r} user was not created by the reverse-proxy auth")
+        user_id = user_ids[username]
+        desired = {permission_ids[name] for name in permission_names}
+        current = {int(row["permission_id"]) for row in get_json(client, f"/api/users/{user_id}/permissions")}
+        if current == desired:
+            print(f"{username!r} (id={user_id}) already at {sorted(permission_names)}")
+            continue
+        client.put(f"/api/users/{user_id}/permissions", json={"permissions": sorted(desired)}).raise_for_status()
+        print(
+            f"{username!r} (id={user_id}) converged to {sorted(permission_names)}"
+            f" (permission ids {sorted(current)} -> {sorted(desired)})"
+        )
+
+
+def main(
+    policy_path: Annotated[Path, typer.Option("--policy", exists=True, dir_okay=False, help="policy.yaml")],
+    grocy_url: Annotated[str, typer.Option()],
+) -> None:
+    policy = Policy.model_validate(yaml.safe_load(policy_path.read_text()))
     with httpx.Client(
-        base_url=GROCY, headers={"X-authentik-username": ADMIN}, follow_redirects=True, timeout=30
+        base_url=grocy_url, headers={"X-authentik-username": ADMIN}, follow_redirects=True, timeout=30
     ) as client:
         wait_for_schema(client)
-        for operator in OPERATORS:
-            # Auto-create the operator if absent (reverse-proxy auth creates the user
-            # on the first request bearing its username; default-deny means it is born
-            # read-only), then grant ADMIN as the built-in admin user.
-            client.get("/api/system/info", headers={"X-authentik-username": operator}).raise_for_status()
-            users_resp = client.get("/api/users")
-            users_resp.raise_for_status()
-            user = next((u for u in users_resp.json() if u["username"] == operator), None)
-            if user is None:
-                raise RuntimeError(f"{operator!r} user was not created by the reverse-proxy auth")
-            client.put(
-                f"/api/users/{user['id']}/permissions", json={"permissions": [ADMIN_PERMISSION_ID]}
-            ).raise_for_status()
-            print(f"{operator!r} (id={user['id']}) ensured ADMIN")
+        reconcile(client, policy)
 
 
 if __name__ == "__main__":
-    main()
+    typer.run(main)

--- a/cluster/k8s/grocy/sf/user-perms/provision.py
+++ b/cluster/k8s/grocy/sf/user-perms/provision.py
@@ -43,11 +43,13 @@ def wait_for_schema(client: httpx.Client) -> None:
     hasn't run, then poll the JSON `/api/users` until the schema exists.
     """
     for _ in range(30):
-        with contextlib.suppress(httpx.HTTPError):
+        # Transient connection errors and non-JSON bodies (mid-migration HTML)
+        # are all just "not ready yet" — keep polling.
+        with contextlib.suppress(httpx.HTTPError, ValueError):
             client.get("/")
-        resp = client.get("/api/users")
-        if resp.status_code == 200 and isinstance(resp.json(), list):
-            return
+            resp = client.get("/api/users")
+            if resp.status_code == 200 and isinstance(resp.json(), list):
+                return
         time.sleep(2)
     raise RuntimeError("Grocy schema not ready in time")
 
@@ -61,6 +63,9 @@ def get_json(client: httpx.Client, path: str) -> Any:
 def reconcile(client: httpx.Client, policy: Policy) -> None:
     # Grocy serializes SQLite rows with numeric columns as strings — int() them.
     permission_ids = {row["name"]: int(row["id"]) for row in get_json(client, "/api/objects/permission_hierarchy")}
+    # Validate every name upfront so a typo can't leave the policy half-applied.
+    if unknown := {name for names in policy.users.values() for name in names} - permission_ids.keys():
+        raise ValueError(f"unknown permission names {sorted(unknown)}; valid: {sorted(permission_ids)}")
     for username in policy.users:
         # Reverse-proxy auth auto-creates the user on the first request bearing its
         # username; default-deny means it is born with no permissions.

--- a/cluster/k8s/grocy/sf/user-perms/test_provision.py
+++ b/cluster/k8s/grocy/sf/user-perms/test_provision.py
@@ -1,0 +1,79 @@
+"""Reconciler behavior against a mocked Grocy API: auto-creation via the
+reverse-proxy header, string-typed SQLite ids, PUT only on drift."""
+
+import json
+
+import httpx
+import pytest
+import pytest_bazel
+from provision import Policy, reconcile
+
+PERMISSION_HIERARCHY = [{"id": "1", "name": "ADMIN"}, {"id": "2", "name": "MASTER_DATA_EDIT"}]
+
+
+class FakeGrocy:
+    """Minimal Grocy API double; numeric ids serialize as strings like the real one."""
+
+    def __init__(self, user_permissions: dict[str, set[int]]) -> None:
+        self.user_permissions = user_permissions
+        self.puts: dict[str, list[int]] = {}
+
+    def _user_ids(self) -> dict[str, int]:
+        return {name: i + 1 for i, name in enumerate(self.user_permissions)}
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path == "/api/system/info":
+            # Reverse-proxy auth auto-creates the requesting user.
+            self.user_permissions.setdefault(request.headers["X-authentik-username"], set())
+            return httpx.Response(200, json={})
+        if path == "/api/objects/permission_hierarchy":
+            return httpx.Response(200, json=PERMISSION_HIERARCHY)
+        if path == "/api/users":
+            return httpx.Response(
+                200, json=[{"id": str(uid), "username": name} for name, uid in self._user_ids().items()]
+            )
+        username = {uid: name for name, uid in self._user_ids().items()}[int(path.split("/")[3])]
+        if request.method == "GET":
+            return httpx.Response(
+                200,
+                json=[
+                    {"id": "99", "user_id": path.split("/")[3], "permission_id": str(p)}
+                    for p in sorted(self.user_permissions[username])
+                ],
+            )
+        assert request.method == "PUT"
+        granted = json.loads(request.content)["permissions"]
+        self.puts[username] = granted
+        self.user_permissions[username] = set(granted)
+        return httpx.Response(204)
+
+
+def make_client(fake: FakeGrocy) -> httpx.Client:
+    return httpx.Client(base_url="http://grocy", transport=httpx.MockTransport(fake.handler))
+
+
+def test_converges_only_drifted_users():
+    # agentydragon already ADMIN (no PUT), haku wrongly elevated (PUT back to
+    # empty), auragon absent (auto-created, then PUT to ADMIN).
+    fake = FakeGrocy({"agentydragon": {1}, "haku": {2}})
+    reconcile(make_client(fake), Policy(users={"agentydragon": {"ADMIN"}, "auragon": {"ADMIN"}, "haku": set()}))
+    assert fake.puts == {"auragon": [1], "haku": []}
+    assert fake.user_permissions == {"agentydragon": {1}, "auragon": {1}, "haku": set()}
+
+
+def test_unlisted_users_untouched():
+    fake = FakeGrocy({"agentydragon": {1}, "bystander": {2}})
+    reconcile(make_client(fake), Policy(users={"agentydragon": {"ADMIN"}}))
+    assert fake.puts == {}
+    assert fake.user_permissions["bystander"] == {2}
+
+
+def test_unknown_permission_name_raises():
+    fake = FakeGrocy({"agentydragon": {1}})
+    with pytest.raises(KeyError, match="NOT_A_PERMISSION"):
+        reconcile(make_client(fake), Policy(users={"agentydragon": {"NOT_A_PERMISSION"}}))
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/cluster/k8s/grocy/sf/user-perms/test_provision.py
+++ b/cluster/k8s/grocy/sf/user-perms/test_provision.py
@@ -69,10 +69,11 @@ def test_unlisted_users_untouched():
     assert fake.user_permissions["bystander"] == {2}
 
 
-def test_unknown_permission_name_raises():
-    fake = FakeGrocy({"agentydragon": {1}})
-    with pytest.raises(KeyError, match="NOT_A_PERMISSION"):
-        reconcile(make_client(fake), Policy(users={"agentydragon": {"NOT_A_PERMISSION"}}))
+def test_unknown_permission_name_rejected_before_any_write():
+    fake = FakeGrocy({"agentydragon": {1}, "haku": {2}})
+    with pytest.raises(ValueError, match="NOT_A_PERMISSION"):
+        reconcile(make_client(fake), Policy(users={"agentydragon": {"NOT_A_PERMISSION"}, "haku": set()}))
+    assert fake.puts == {}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Replaces the hardcoded operator list in `provision.py` with a declarative `policy.yaml` (username → exact permission set, mounted via `configMapGenerator`):

```yaml
users:
  agentydragon: [ADMIN]
  auragon: [ADMIN]
  haku: []
```

- Listed users are **converged**: created via reverse-proxy auth if absent, permissions replaced only on drift (permission names resolved against Grocy's `permission_hierarchy` table).
- Unlisted users stay untouched — born read-only via `DEFAULT_PERMISSIONS=none`.
- `haku` is pinned to an explicitly empty permission set, so a manual elevation in the Grocy UI converges back.

Trigger model:

- The one-shot Job still gates bootstrap via the Flux healthcheck, and now also re-runs on policy edits (hash-suffixed ConfigMap + `kustomize.toolkit.fluxcd.io/force`).
- New daily CronJob (04:40) re-asserts the same policy for drift correction. Its pods share the provisioner pod label, so the existing NetworkPolicy covers both.

Tests: new `test_provision.py` covers drift-only PUTs, auto-creation, unlisted-user isolation, and Grocy's string-typed SQLite ids against a mocked API (`httpx.MockTransport`). Full `//cluster/validation/...` suite and the image build pass; `policy.yaml` is registered as a non-manifest YAML in `.gitattributes` + the kubeconform exclude list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEreAv2WZiimQwRZww87Et

---
_Generated by [Claude Code](https://claude.ai/code/session_01UEreAv2WZiimQwRZww87Et)_