### PR TITLE
devinfra: bump go_sdk toolchain to 1.26.4

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -819,7 +819,7 @@ http_archive(
 
 # ─ Go toolchain ──────────────────────────────────────────────────────────
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
-go_sdk.download(version = "1.26.2")
+go_sdk.download(version = "1.26.4")
 go_sdk.nogo(nogo = "//devinfra/lint:nogo")
 
 # ─ Go dependencies ───────────────────────────────────────────────────────

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -815,7 +815,6 @@ http_archive(
 
 # ─ Go toolchain and dependencies ─────────────────────────────────────────────
 # Go toolchain and external module dependencies.
-# Included from the root MODULE.bazel via include("//third_party:go.MODULE.bazel").
 
 # ─ Go toolchain ──────────────────────────────────────────────────────────
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")

--- a/skills/reverse_engineer/TODO.md
+++ b/skills/reverse_engineer/TODO.md
@@ -1,5 +1,28 @@
 # reverse_engineer skill — open work
 
+## `test_binary_diff_demo` pins toolchain-specific golden values
+
+`examples/binary_diff_recipe.sh` hardcodes exact instruction PCs and instruction
+bytes for three functions (`assert_eq` on literal hex). These are artifacts of
+the Go compiler's codegen, not of the diffing technique — they broke and needed
+regenerating when this repo's `go_sdk` toolchain version bumped (1.26.2 →
+1.26.4), and will break again on any future Go/garble version change.
+
+String VMAs and garbled function names proved toolchain-stable across that bump
+(`.rodata` layout and garble's seed+symbol-based naming didn't move) — only the
+PC/instruction-bytes assertions are fragile.
+
+See if it's worth replacing the exact-byte assertions with structural/invariant
+checks instead: verify the found bytes match the `lea reg, [rip+disp32]` opcode
+shape (`48 8d 05 XX XX XX XX`, not literal `XX` values) and that decoding the
+little-endian displacement plus `PC+7` reproduces the target VMA. That proves
+the technique correctly locates and decodes the instruction without pinning to
+one compiler's output. Tradeoff: the script's header comment currently doubles
+as a worked-example reference with fixed numbers for a human reading along;
+decoupling from hardcoded values means those become "whatever this run
+computed" rather than a citable snapshot — a fine trade for CI robustness, but
+worth deciding deliberately rather than doing by default.
+
 ## Undefeated garble techniques in environment-manager
 
 `environment-manager` uses garble with default flags (confirmed by binary analysis):

--- a/skills/reverse_engineer/examples/binary_diff_recipe.sh
+++ b/skills/reverse_engineer/examples/binary_diff_recipe.sh
@@ -10,9 +10,9 @@
 #   → instruction PC → pclntool maps PC to garbled function name
 #
 # Golden values (seed=ZHVja3RhcGU=, i.e. base64("ducktape")):
-#   connectToServer  string VMA 0x51a851  PC 0x4dfccd  → main.h8n9KNzKUCmw
-#   loadConfig       string VMA 0x5162ef  PC 0x4dfdc2  → main.bhY2uMqP4
-#   validateConfig   string VMA 0x518f8a  PC 0x4dfb9c  → main.epq7tEoS
+#   connectToServer  string VMA 0x51a851  PC 0x4dff2d  → main.h8n9KNzKUCmw
+#   loadConfig       string VMA 0x5162ef  PC 0x4e0022  → main.bhY2uMqP4
+#   validateConfig   string VMA 0x518f8a  PC 0x4dfdfc  → main.epq7tEoS
 #
 # Prerequisites:
 #   - 'v1_plain'   in cwd — Go binary built without garble (has pclntab + symbols)
@@ -113,13 +113,13 @@ echo "  main.validateConfig absent from v1 (new in v2)"
 echo "=== string→fn mapping ==="
 S1="connection refused: server not accepting connections"
 echo "Locating '$S1':"
-# Expected: string VMA 0x51a851, lea at PC 0x4dfccd, bytes 48 8d 05 7d ab 03 00
-fn1_v2=$(fn_for_string_v2 "$S1" "0x51a851" "0x4dfccd" "48 8d 05 7d ab 03 00" "main.h8n9KNzKUCmw")
+# Expected: string VMA 0x51a851, lea at PC 0x4dff2d, bytes 48 8d 05 1d a9 03 00
+fn1_v2=$(fn_for_string_v2 "$S1" "0x51a851" "0x4dff2d" "48 8d 05 1d a9 03 00" "main.h8n9KNzKUCmw")
 echo "  → $fn1_v2"
 S2="failed to read config file"
 echo "Locating '$S2':"
-# Expected: string VMA 0x5162ef, lea at PC 0x4dfdc2, bytes 48 8d 05 26 65 03 00
-fn2_v2=$(fn_for_string_v2 "$S2" "0x5162ef" "0x4dfdc2" "48 8d 05 26 65 03 00" "main.bhY2uMqP4")
+# Expected: string VMA 0x5162ef, lea at PC 0x4e0022, bytes 48 8d 05 c6 62 03 00
+fn2_v2=$(fn_for_string_v2 "$S2" "0x5162ef" "0x4e0022" "48 8d 05 c6 62 03 00" "main.bhY2uMqP4")
 echo "  → $fn2_v2"
 [ "$fn1_v2" != "$fn2_v2" ] \
   || fail "connectToServer and loadConfig garbled to same name ($fn1_v2)"
@@ -130,8 +130,8 @@ S_NEW="invalid port: must be between 1 and 65535"
   || fail "'$S_NEW' found in v1_plain — expected only in v2"
 echo "'$S_NEW': absent from v1 (validateConfig only exists in v2)"
 echo "Locating '$S_NEW' in v2_garbled:"
-# Expected: string VMA 0x518f8a, lea at PC 0x4dfb9c, bytes 48 8d 05 e7 93 03 00
-fn_new=$(fn_for_string_v2 "$S_NEW" "0x518f8a" "0x4dfb9c" "48 8d 05 e7 93 03 00" "main.epq7tEoS")
+# Expected: string VMA 0x518f8a, lea at PC 0x4dfdfc, bytes 48 8d 05 87 91 03 00
+fn_new=$(fn_for_string_v2 "$S_NEW" "0x518f8a" "0x4dfdfc" "48 8d 05 87 91 03 00" "main.epq7tEoS")
 echo "  → $fn_new"
 [ "$fn_new" != "$fn1_v2" ] \
   || fail "validateConfig collides with connectToServer garbled name"
@@ -139,7 +139,7 @@ echo "  → $fn_new"
   || fail "validateConfig collides with loadConfig garbled name"
 echo "PASS: three distinct garbled names for three distinct source functions"
 echo "=== summary ==="
-echo "  connectToServer  string VMA 0x51a851  PC 0x4dfccd  →  $fn1_v2"
-echo "  loadConfig       string VMA 0x5162ef  PC 0x4dfdc2  →  $fn2_v2"
-echo "  validateConfig   string VMA 0x518f8a  PC 0x4dfb9c  →  $fn_new  (v2-only)"
+echo "  connectToServer  string VMA 0x51a851  PC 0x4dff2d  →  $fn1_v2"
+echo "  loadConfig       string VMA 0x5162ef  PC 0x4e0022  →  $fn2_v2"
+echo "  validateConfig   string VMA 0x518f8a  PC 0x4dfdfc  →  $fn_new  (v2-only)"
 echo "All assertions passed."


### PR DESCRIPTION
## Summary

- Bump `go_sdk.download(version = ...)` in root `MODULE.bazel` from
  `1.26.2` to `1.26.4`. Split out of #2708, which needs this toolchain
  version to vendor a Go module (`buildbuddy-io/buildbuddy`) whose
  `go.mod` declares `go 1.26.4` — but the version bump itself is
  independent of that work and affects the whole repo's Go compilation,
  so it gets its own PR and review.
- The version bump shifts compiled code layout (different codegen
  offsets/instruction encoding), which invalidated the hardcoded golden
  values in `skills/reverse_engineer/examples/binary_diff_recipe.sh` — a
  reverse-engineering demo/test that walks through locating three
  functions in a garble-obfuscated binary by hardcoding their exact
  string VMAs, instruction PCs, instruction bytes, and garbled names.
  String VMAs are unchanged (`.rodata` placement didn't shift); the
  codegen offsets/instruction bytes at each `lea` site did. Regenerated
  by rebuilding `v1_plain`/`v2_garbled` with the new toolchain and
  recomputing `string_vma` + `fn_at_vma` for each of the three target
  functions. Garbled function names are unaffected (garble's naming is
  seed+symbol-based, not address-based), so only the PC/bytes columns
  changed.

## Test plan

- [x] `bazel test //skills/reverse_engineer/examples:test_binary_diff_demo`
      passes with the new toolchain and updated golden values
- [x] `bazel query //...` succeeds (no loading/analysis breakage from
      the toolchain bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jp4qPMQ8AEHWzXoRVZMMc7)_