### PR TITLE
Stop logging secrets: trilium OpenAI key, props admin token

### DIFF
--- a/props/backend/app.py
+++ b/props/backend/app.py
@@ -160,10 +160,14 @@ def _make_lifespan(deps: BackendDeps):
             else:
                 logger.info("Grader supervisor disabled (grader_model not set in config)")
 
-            admin_token = db_config.basic_auth_token
-            protocol = "https" if deps.port == 443 else "http"
-            logger.info(f"Admin token: {admin_token}")
-            logger.info(f"Admin URL: {protocol}://{deps.host}:{deps.port}/?token={admin_token}")
+            # The admin token is a credential; k8s log access is broader than
+            # admin access, so only surface it under an explicit dev-mode flag
+            # (off in the cluster deployment).
+            if deps.config.dev_mode:
+                admin_token = db_config.basic_auth_token
+                protocol = "https" if deps.port == 443 else "http"
+                logger.info(f"Admin token: {admin_token}")
+                logger.info(f"Admin URL: {protocol}://{deps.host}:{deps.port}/?token={admin_token}")
             logger.info("Props backend ready")
             app.state.startup_complete = True
 

--- a/props/config.py
+++ b/props/config.py
@@ -129,6 +129,9 @@ class PropsConfig(LLMProxyConfig):
     executor: ExecutorConfig = Field(default_factory=DockerExecutorConfig)
     auto_migrate: bool = False
     auto_sync_specimens: bool = False
+    # Dev-only conveniences (never enable in the cluster deployment): logs the
+    # admin token and a ready-to-use admin URL at startup.
+    dev_mode: bool = False
 
 
 def load_config(path: Path) -> PropsConfig:

--- a/trilium/issue_tracker/issue_widget.js
+++ b/trilium/issue_tracker/issue_widget.js
@@ -148,7 +148,6 @@ Existing hotlists:
     const OPENAI_API_KEY = await api.runOnBackend(() => {
       return api.searchForNote("#openaiApiKey").getContent();
     }, []);
-    console.log("OPENAI API KEY:", OPENAI_API_KEY);
     const prefix = '["';
     const openaiPrompt = (await this.makePrompt()) + prefix;
 

--- a/trilium/papers/paper_widget.js
+++ b/trilium/papers/paper_widget.js
@@ -103,7 +103,6 @@ Existing topics:
     const OPENAI_API_KEY = await api.runOnBackend(() => {
       return api.searchForNote("#openaiApiKey").getContent();
     }, []);
-    console.log("OPENAI API KEY:", OPENAI_API_KEY);
     const prefix = '["';
     const openaiPrompt = (await this.makePrompt()) + prefix;
 


### PR DESCRIPTION
Two "sensitive data in logs" High findings from the code audit.

## trilium — OpenAI key logged to the browser console
`trilium/papers/paper_widget.js` and `trilium/issue_tracker/issue_widget.js` each did `console.log("OPENAI API KEY:", OPENAI_API_KEY)` right after fetching the key. Deleted both lines (the key is still used for the request; only the log is removed).

## props — admin token logged to pod logs
`props/backend/app.py` logged `Admin token: <token>` and an `Admin URL: …?token=<token>` at INFO on every startup. k8s log access is broader than admin-token access, so this leaked a credential. Gated both behind a new explicit **`PropsConfig.dev_mode`** flag (default `False`; unset in the cluster `config.toml`), and moved the token computation inside the gate so it's only touched in dev.

## Verification
`ruff check` + `ruff format --check` clean; prettier clean on the JS. No `console.log(...OPENAI...)` or ungated `Admin token:` remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjEYLNhipPWErzEqJk9D3s)_