### PR TITLE
haku: mirror hash routing + state-validation gate into state_template

### DIFF
--- a/haku/state_template/.forgejo/workflows/validate-state.yaml
+++ b/haku/state_template/.forgejo/workflows/validate-state.yaml
@@ -1,0 +1,37 @@
+# Validate the state files the UI backend reads live from HEAD (items/, runs/, and any
+# surface you add) against the backend's own Pydantic models — the actual read contract.
+# The backend has no build step for data (it parses these at request time), so without
+# this gate a malformed commit only surfaces when the dashboard 500s or silently renders
+# wrong. Runs on EVERY push to main — data commits vastly outnumber ui/ commits and are
+# not covered by build-ui.yaml's path filter.
+#
+# Kept deliberately light: models.py imports only pydantic + stdlib, so this installs
+# just pydantic + pyyaml (~seconds), not the whole backend.
+name: validate-state
+on:
+  push:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: haku-ci
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # `docker build` (not `docker run -v`): the runner's docker daemon is a dind sidecar,
+      # so a -v bind mount resolves on the SIDECAR's filesystem (empty), not the job
+      # container's checkout. Building streams the repo as context — same pattern as
+      # build-ui.yaml. The RUN validation failing fails the build, which fails the job.
+      - name: Validate state files against ui/backend/models.py
+        run: |
+          docker build -f - . <<'EOF'
+          FROM python:3.13-slim
+          RUN pip install --quiet --no-cache-dir "pydantic>=2" pyyaml
+          WORKDIR /repo
+          COPY . .
+          ENV PYTHONPATH=/repo/ui/backend
+          RUN python tools/validate_state.py
+          EOF

--- a/haku/state_template/tools/validate_state.py
+++ b/haku/state_template/tools/validate_state.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Validate every state file the UI backend reads live from HEAD.
+
+The backend parses these at request time (no build step), so a malformed commit — a
+YAML typo in an item, a manifest that drifted from the model — only surfaces when the
+dashboard 500s or silently renders wrong. This gate validates the repo against the
+backend's OWN Pydantic models (``ui/backend/models.py``), the actual read contract, so
+model edits and data edits can't drift apart unnoticed in either direction.
+
+Run by ``.forgejo/workflows/validate-state.yaml`` on every push to main. When you add a
+surface with its own state files (a board, signals, …), add its glob + model here — a
+surface this gate doesn't cover is one a bad commit can silently break.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+from models import Item, RunManifest
+from pydantic import ValidationError
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def check(path: Path, model, inject: dict | None = None) -> str | None:
+    """Returns an error string, or None if the file parses and validates."""
+    try:
+        data = yaml.safe_load(path.read_text())
+        if inject:
+            data = {**data, **inject}
+    except yaml.YAMLError as e:
+        return f"{path.relative_to(REPO)}: YAML parse error: {e}"
+    try:
+        model.model_validate(data)
+    except ValidationError as e:
+        return f"{path.relative_to(REPO)}: does not match {model.__name__}: {e}"
+    return None
+
+
+def main() -> int:
+    targets: list[tuple] = []
+    targets += [(p, Item) for p in sorted((REPO / "items").glob("*.yaml"))]
+    targets += [(p, RunManifest) for p in sorted((REPO / "runs").glob("*/*.yaml"))]
+
+    errors = [err for entry in targets for err in [check(entry[0], entry[1], *entry[2:])] if err]
+    for e in errors:
+        print(f"FAIL {e}", file=sys.stderr)
+    print(f"validate_state: {len(targets) - len(errors)}/{len(targets)} files valid")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/haku/state_template/ui/backend/models.py
+++ b/haku/state_template/ui/backend/models.py
@@ -152,7 +152,9 @@ class ScannedSource(BaseModel):
     # so accept either an int or a string.
     bookmark_before: int | str | None = None
     bookmark_after: int | str | None = None
-    changes_seen: int = 0  # a real count (0 = scanned, nothing new), not absence
+    # A real count when countable (0 = scanned, nothing new); a short prose summary when a
+    # count would be misleading (e.g. "2 commits, neither touches base"). Never absence.
+    changes_seen: int | str = 0
 
 
 class SkippedSource(BaseModel):
@@ -183,8 +185,9 @@ class RunChecklist(BaseModel):
 
 class PropagationTarget(BaseModel):
     surface: str
-    # "n/a" = this surface never applies to this change; "no_change" = considered, didn't apply.
-    action: Literal["updated", "no_change", "n/a"]
+    # "created" = a new entry/file was made on the surface; "n/a" = this surface never
+    # applies to this change; "no_change" = considered, didn\'t apply.
+    action: Literal["created", "updated", "no_change", "n/a"]
     note: str = ""
 
 

--- a/haku/state_template/ui/backend/test_runs.py
+++ b/haku/state_template/ui/backend/test_runs.py
@@ -102,6 +102,19 @@ def test_read_runs_pairs_yaml_and_md_sorts_newest_first_and_ignores_readme():
     assert runs[1].sources[0].bookmark_after == 130  # int bookmark parses (Grocy id)
 
 
+def test_run_manifest_accepts_prose_changes_seen_and_created_action():
+    # Real manifests carry prose where a count would mislead, and surfaces that were created.
+    m = RunManifest.model_validate(
+        {
+            "run_id": "x",
+            "sources": [{"source": "base-git", "changes_seen": "2 commits, neither touches base"}],
+            "propagation": [{"change": "c", "surfaces": [{"surface": "s", "action": "created"}]}],
+        }
+    )
+    assert m.sources[0].changes_seen == "2 commits, neither touches base"
+    assert m.propagation[0].surfaces[0].action == "created"
+
+
 def test_run_manifest_rejects_bad_propagation_action():
     # CI schema floor: an unknown propagation action is a hard error.
     with pytest.raises(ValidationError):

--- a/haku/state_template/ui/frontend/package-lock.json
+++ b/haku/state_template/ui/frontend/package-lock.json
@@ -17,15 +17,264 @@
         "react-dom": "^19.2.7"
       },
       "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.2",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.3",
+        "jsdom": "^29.1.1",
         "postcss": "^8.5.16",
         "postcss-preset-mantine": "^1.18.0",
         "postcss-simple-vars": "^7.0.1",
         "typescript": "^6.0.3",
         "vite": "^8.1.0",
         "vitest": "^3.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -502,6 +751,24 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -1271,6 +1538,54 @@
         "win32"
       ]
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -1281,6 +1596,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1528,6 +1850,39 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1555,6 +1910,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/cac": {
@@ -1683,6 +2048,20 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -1703,6 +2082,20 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1719,6 +2112,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
@@ -1781,6 +2181,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/dompurify": {
       "version": "3.4.11",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
@@ -1788,6 +2195,19 @@
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-module-lexer": {
@@ -2088,6 +2508,19 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
@@ -2150,12 +2583,60 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -2435,6 +2916,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2638,6 +3139,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/micromark": {
       "version": "4.0.2",
@@ -3285,6 +3793,19 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -3477,6 +3998,21 @@
         "postcss": "^8.2.1"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
     "node_modules/property-information": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
@@ -3485,6 +4021,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/react": {
@@ -3507,6 +4053,13 @@
       "peerDependencies": {
         "react": "^19.2.7"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-number-format": {
       "version": "5.4.5",
@@ -3716,6 +4269,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.3.tgz",
@@ -3793,6 +4356,19 @@
         "@rollup/rollup-win32-x64-gnu": "4.62.2",
         "@rollup/rollup-win32-x64-msvc": "4.62.2",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -3919,6 +4495,13 @@
         "postcss": "^8.3.3"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tabbable": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
@@ -3998,6 +4581,52 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.5.tgz",
+      "integrity": "sha512-RfEzKWcq5fHUOFq7J3rl3Oz6ylKGtcHqUznzj4EcXsxLSIjJcvpbXAQtWGeJQ0xKnimR5e0Cn+cn9TssfMzm+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.5"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.5.tgz",
+      "integrity": "sha512-pGrwzZDvPwKe+7NNUqAunb6rqTfynr0VOUhCMdqbu5xlvNiszsAJygRzwvpVycdzejlbpY+SWJOn+s75Og7FEA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -4051,6 +4680,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/unified": {
@@ -4582,6 +5221,54 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -4598,6 +5285,23 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/zwitch": {
       "version": "2.0.4",

--- a/haku/state_template/ui/frontend/package.json
+++ b/haku/state_template/ui/frontend/package.json
@@ -19,9 +19,12 @@
     "react-dom": "^19.2.7"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.3",
+    "jsdom": "^29.1.1",
     "postcss": "^8.5.16",
     "postcss-preset-mantine": "^1.18.0",
     "postcss-simple-vars": "^7.0.1",

--- a/haku/state_template/ui/frontend/src/app.tsx
+++ b/haku/state_template/ui/frontend/src/app.tsx
@@ -5,6 +5,8 @@ import { clickAction, fetchDashboard, unclickAction } from "./client.ts";
 import { GardenPage } from "./garden.tsx";
 import { ImprovementsPage } from "./improvements.tsx";
 import { InboxView } from "./inbox.tsx";
+import { useHashRoute } from "./routes.ts";
+import type { View } from "./routes.ts";
 import { RunsPage } from "./runs.tsx";
 import { clickKey } from "./task.tsx";
 import type { DashboardResponse } from "./types.ts";
@@ -13,22 +15,20 @@ import type { DashboardResponse } from "./types.ts";
 // ships two person-agnostic surfaces: the **Inbox** (the items board) and **Improvements**
 // (Haku's self-backlog). Haku adds more tabs as bespoke surfaces for its operator's life
 // (e.g. a Kitchen/shopping board, a one-off decision page) by writing a new `*.tsx`, a
-// backend endpoint, and a `View` entry here. Those operator-specific surfaces live in that
-// operator's haku-state, not in this generic starter.
-type View = "inbox" | "improvements" | "runs" | "garden";
+// backend endpoint, and a `View` entry in routes.ts. Those operator-specific surfaces live
+// in that operator's haku-state, not in this generic starter.
 
 export default function App() {
   const [data, setData] = useState<DashboardResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [clicked, setClicked] = useState<ReadonlySet<string>>(new Set());
   const [actionError, setActionError] = useState<string | null>(null);
-  const [view, setView] = useState<View>("inbox");
-  // The garden file currently open (null = the index). Lifted here so any surface can deep-link
-  // into a garden note (a run note → the procedure it cites, etc.).
-  const [gardenPath, setGardenPath] = useState<string | null>(null);
+  // The URL hash is the source of truth for which surface (and which garden file) is open —
+  // F5, permalinks, and back/forward come from the browser (routes.ts → useHashRoute).
+  const [route, navigate] = useHashRoute();
+  const { view, gardenPath } = route;
   function openInGarden(path: string) {
-    setGardenPath(path);
-    setView("garden");
+    navigate({ view: "garden", gardenPath: path });
   }
   // Ticks the live deadline countdowns; 30s is fine at minute granularity.
   const [now, setNow] = useState(() => Date.now());
@@ -82,7 +82,7 @@ export default function App() {
       <Title order={1} mb="sm">
         Haku
       </Title>
-      <Tabs value={view} onChange={(value) => value && setView(value as View)} mb="md">
+      <Tabs value={view} onChange={(value) => value && navigate({ view: value as View, gardenPath: null })} mb="md">
         <Tabs.List>
           {tabs.map(([id, label]) => (
             <Tabs.Tab key={id} value={id}>
@@ -97,7 +97,7 @@ export default function App() {
       ) : view === "runs" ? (
         <RunsPage openInGarden={openInGarden} />
       ) : view === "garden" ? (
-        <GardenPage path={gardenPath} onSelect={setGardenPath} />
+        <GardenPage path={gardenPath} onSelect={(path) => navigate({ view: "garden", gardenPath: path })} />
       ) : (
         <InboxView
           data={data}

--- a/haku/state_template/ui/frontend/src/routes.test.ts
+++ b/haku/state_template/ui/frontend/src/routes.test.ts
@@ -17,6 +17,14 @@ describe("parseHash", () => {
     expect(parseHash("#/improvements")).toEqual({ view: "improvements", gardenPath: null });
   });
 
+  it("treats a trailing slash as the garden index, not an empty file", () => {
+    expect(parseHash("#/garden/")).toEqual({ view: "garden", gardenPath: null });
+  });
+
+  it("falls back to Inbox on malformed percent-encoding instead of throwing", () => {
+    expect(parseHash("#/garden/%E0%A4%A")).toEqual(HOME);
+  });
+
   it("parses the garden index vs a garden file", () => {
     expect(parseHash("#/garden")).toEqual({ view: "garden", gardenPath: null });
     expect(parseHash("#/garden/memory/operator.md")).toEqual({

--- a/haku/state_template/ui/frontend/src/routes.test.ts
+++ b/haku/state_template/ui/frontend/src/routes.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { formatHash, HOME, parseHash, type Route } from "./routes.ts";
+
+describe("parseHash", () => {
+  it("defaults to Inbox for empty/bare hashes", () => {
+    for (const h of ["", "#", "#/"]) expect(parseHash(h)).toEqual(HOME);
+  });
+
+  it("falls back to Inbox on unknown routes instead of crashing", () => {
+    expect(parseHash("#/nonsense")).toEqual(HOME);
+    expect(parseHash("#/https://evil.example")).toEqual(HOME);
+  });
+
+  it("parses plain views", () => {
+    expect(parseHash("#/runs")).toEqual({ view: "runs", gardenPath: null });
+    expect(parseHash("#/improvements")).toEqual({ view: "improvements", gardenPath: null });
+  });
+
+  it("parses the garden index vs a garden file", () => {
+    expect(parseHash("#/garden")).toEqual({ view: "garden", gardenPath: null });
+    expect(parseHash("#/garden/memory/operator.md")).toEqual({
+      view: "garden",
+      gardenPath: "memory/operator.md",
+    });
+  });
+
+  it("decodes encoded path segments", () => {
+    expect(parseHash("#/garden/runs/2026-07-01/a%20b.md").gardenPath).toBe("runs/2026-07-01/a b.md");
+  });
+});
+
+describe("formatHash / round-trip", () => {
+  it("formats Inbox as the bare root", () => {
+    expect(formatHash(HOME)).toBe("#/");
+  });
+
+  it("keeps slashes readable in garden paths", () => {
+    expect(formatHash({ view: "garden", gardenPath: "memory/operator.md" })).toBe("#/garden/memory/operator.md");
+  });
+
+  it("round-trips every route shape", () => {
+    const routes: Route[] = [
+      HOME,
+      { view: "improvements", gardenPath: null },
+      { view: "runs", gardenPath: null },
+      { view: "garden", gardenPath: null },
+      { view: "garden", gardenPath: "procedures/tana_runbook.md" },
+      { view: "garden", gardenPath: "runs/2026-07-01/note with spaces.md" },
+    ];
+    for (const r of routes) expect(parseHash(formatHash(r))).toEqual(r);
+  });
+});

--- a/haku/state_template/ui/frontend/src/routes.ts
+++ b/haku/state_template/ui/frontend/src/routes.ts
@@ -30,8 +30,16 @@ export function parseHash(hash: string): Route {
   const path = hash.replace(/^#\/?/, "");
   if (!path) return HOME;
   const [head, ...rest] = path.split("/");
-  if (head === "garden" && rest.length > 0) {
-    return { view: "garden", gardenPath: rest.map(decodeURIComponent).join("/") };
+  if (head === "garden") {
+    const segments = rest.filter((s) => s.length > 0); // "#/garden/" or "//" collapse to the index
+    if (segments.length === 0) return { view: "garden", gardenPath: null };
+    try {
+      return { view: "garden", gardenPath: segments.map(decodeURIComponent).join("/") };
+    } catch {
+      // Malformed percent-encoding in a user-edited URL — same contract as any other
+      // unparseable route: fall back, never throw (this runs in the useState initializer).
+      return HOME;
+    }
   }
   if ((VIEWS as readonly string[]).includes(head)) {
     return { view: head as View, gardenPath: null };

--- a/haku/state_template/ui/frontend/src/routes.ts
+++ b/haku/state_template/ui/frontend/src/routes.ts
@@ -1,0 +1,65 @@
+// Hash routing — the SPA's own URL is the source of truth for which surface is open.
+// Hash, not path, so the StaticFiles backend needs no catch-all and nothing depends on
+// history.pushState semantics inside the sandboxed console iframe; `location.hash`/
+// `hashchange` are the primitive, safe pair. Hand-rolled on purpose: the route space is
+// small and flat — a router dependency would be premature machinery.
+//
+// Scheme:  #/            Inbox (default; unknown routes also fall back here)
+//          #/<view>      any other top-level tab
+//          #/garden      Garden index
+//          #/garden/<repo-relative-path>   a specific garden file
+//
+// When you add a surface (a new View entry in app.tsx), add it to VIEWS here — the route
+// falls back to Inbox until you do.
+
+import { useCallback, useEffect, useState } from "react";
+
+export type View = "inbox" | "improvements" | "runs" | "garden";
+
+export interface Route {
+  view: View;
+  /** Only meaningful for view === "garden": the open file, null = the index. */
+  gardenPath: string | null;
+}
+
+const VIEWS: readonly View[] = ["inbox", "improvements", "runs", "garden"];
+
+export const HOME: Route = { view: "inbox", gardenPath: null };
+
+export function parseHash(hash: string): Route {
+  const path = hash.replace(/^#\/?/, "");
+  if (!path) return HOME;
+  const [head, ...rest] = path.split("/");
+  if (head === "garden" && rest.length > 0) {
+    return { view: "garden", gardenPath: rest.map(decodeURIComponent).join("/") };
+  }
+  if ((VIEWS as readonly string[]).includes(head)) {
+    return { view: head as View, gardenPath: null };
+  }
+  return HOME;
+}
+
+export function formatHash(route: Route): string {
+  if (route.view === "garden" && route.gardenPath) {
+    // Encode per segment so slashes stay readable in the address bar.
+    return "#/garden/" + route.gardenPath.split("/").map(encodeURIComponent).join("/");
+  }
+  return route.view === "inbox" ? "#/" : `#/${route.view}`;
+}
+
+/** The URL hash as React state: parse on mount, follow `hashchange`, navigate by writing
+ * `location.hash` (so the browser owns history/back/forward — F5 and permalinks come free). */
+export function useHashRoute(): [Route, (next: Route) => void] {
+  const [route, setRoute] = useState<Route>(() => parseHash(window.location.hash));
+  useEffect(() => {
+    const onHashChange = () => setRoute(parseHash(window.location.hash));
+    window.addEventListener("hashchange", onHashChange);
+    return () => window.removeEventListener("hashchange", onHashChange);
+  }, []);
+  const navigate = useCallback((next: Route) => {
+    const target = formatHash(next);
+    if (window.location.hash === target) setRoute(next);
+    else window.location.hash = target; // the hashchange listener updates state
+  }, []);
+  return [route, navigate];
+}

--- a/haku/state_template/ui/frontend/src/runs.tsx
+++ b/haku/state_template/ui/frontend/src/runs.tsx
@@ -31,7 +31,11 @@ function whenLabel(run: RunManifest): string {
 // A concise, clickable row in the runs list: when, the source-coverage badges, and a one-line
 // summary (changes / surface updates / skipped sources). Click → the full per-run detail.
 function RunRow({ run, onOpen }: { run: RunManifest; onOpen: () => void }) {
-  const updated = run.propagation.reduce((n, p) => n + p.surfaces.filter((s) => s.action === "updated").length, 0);
+  // "created" is a surface update too (a new entry/file landed on the surface).
+  const updated = run.propagation.reduce(
+    (n, p) => n + p.surfaces.filter((s) => s.action === "updated" || s.action === "created").length,
+    0
+  );
   const skipped = run.sources.filter((s) => "skipped" in s).length;
   return (
     <Card

--- a/haku/state_template/ui/frontend/src/runs.tsx
+++ b/haku/state_template/ui/frontend/src/runs.tsx
@@ -17,7 +17,8 @@ function sourceBadge(s: RunSource) {
     );
   }
   return (
-    <Badge key={s.source} color={s.changes_seen > 0 ? "teal" : "gray"} variant="light">
+    // Prose changes_seen (a summary instead of a count) means something happened — teal.
+    <Badge key={s.source} color={s.changes_seen !== 0 ? "teal" : "gray"} variant="light">
       {s.source}: {s.changes_seen}
     </Badge>
   );

--- a/haku/state_template/ui/frontend/src/types.ts
+++ b/haku/state_template/ui/frontend/src/types.ts
@@ -67,7 +67,7 @@ export interface ScannedSource {
   source: string;
   bookmark_before: string | number | null;
   bookmark_after: string | number | null;
-  changes_seen: number;
+  changes_seen: number | string;
 }
 
 export interface SkippedSource {
@@ -85,7 +85,7 @@ export interface RunChecklist {
 
 export interface PropagationTarget {
   surface: string;
-  action: "updated" | "no_change" | "n/a";
+  action: "created" | "updated" | "no_change" | "n/a";
   note: string;
 }
 

--- a/haku/state_template/ui/frontend/src/use_hash_route.test.tsx
+++ b/haku/state_template/ui/frontend/src/use_hash_route.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+// The wiring half of hash routing (the pure parse/format half is routes.test.ts): initial
+// parse on mount, navigate() writing location.hash, hashchange driving state, junk fallback.
+// This is the formal promotion of the pre-deploy Playwright checks' app-logic portion; real
+// browser history semantics (back/forward) stay browser behavior, verified by the manual
+// Playwright recipe in memory/haku-ui.md when routing is touched.
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { HOME, useHashRoute } from "./routes.ts";
+
+function fireHashChange() {
+  window.dispatchEvent(new HashChangeEvent("hashchange"));
+}
+
+afterEach(() => {
+  window.location.hash = "";
+});
+
+describe("useHashRoute", () => {
+  it("parses the current hash on mount", () => {
+    window.location.hash = "#/garden/memory/operator.md";
+    const { result } = renderHook(() => useHashRoute());
+    expect(result.current[0]).toEqual({ view: "garden", gardenPath: "memory/operator.md" });
+  });
+
+  it("navigate() writes the hash and the hashchange event updates state", () => {
+    window.location.hash = "";
+    const { result } = renderHook(() => useHashRoute());
+    expect(result.current[0]).toEqual(HOME);
+
+    act(() => result.current[1]({ view: "runs", gardenPath: null }));
+    expect(window.location.hash).toBe("#/runs");
+    // jsdom doesn't reliably auto-fire hashchange on assignment — dispatch explicitly,
+    // like the browser would.
+    act(() => fireHashChange());
+    expect(result.current[0]).toEqual({ view: "runs", gardenPath: null });
+  });
+
+  it("follows external hash changes (back/forward, manual edit)", () => {
+    window.location.hash = "";
+    const { result } = renderHook(() => useHashRoute());
+    act(() => {
+      window.location.hash = "#/improvements";
+      fireHashChange();
+    });
+    expect(result.current[0]).toEqual({ view: "improvements", gardenPath: null });
+  });
+
+  it("falls back to Inbox on a junk hash", () => {
+    window.location.hash = "";
+    const { result } = renderHook(() => useHashRoute());
+    act(() => {
+      window.location.hash = "#/garbage/route";
+      fireHashChange();
+    });
+    expect(result.current[0]).toEqual(HOME);
+  });
+
+  it("navigating to the already-current hash still syncs state", () => {
+    window.location.hash = "#/runs";
+    const { result } = renderHook(() => useHashRoute());
+    act(() => result.current[1]({ view: "runs", gardenPath: null }));
+    expect(result.current[0]).toEqual({ view: "runs", gardenPath: null });
+  });
+});

--- a/haku/state_template/ui/frontend/src/widgets.tsx
+++ b/haku/state_template/ui/frontend/src/widgets.tsx
@@ -44,6 +44,7 @@ export function StatusBadge({ status, color = "gray" }: { status: string; color?
 
 // updated = it landed; no_change = considered, didn't apply; n/a = surface never applies.
 const ACTION_COLOR: Record<PropagationTarget["action"], string> = {
+  created: "teal",
   updated: "teal",
   no_change: "gray",
   "n/a": "gray",


### PR DESCRIPTION
## What

Mirrors the generic halves of tonight's haku-state work into the starter template, per the
sync-back convention (structural/high-level changes yes, operator specifics no):

- **Hash routing** (`ui/frontend/src/routes.ts`): the URL hash is the SPA's source of truth —
  `#/`, `#/<view>`, `#/garden/<repo-relative-path>` (per-segment encoding), unknown routes fall
  back to Inbox — with `useHashRoute()` consumed by `app.tsx`. Direct visits get F5, permalinks,
  and back/forward natively. Adapted to the template's generic `View` set (no kitchen/tender).
- **Tests for both halves**: `routes.test.ts` (pure parse/format round-trips) and
  `use_hash_route.test.tsx` (the wiring under jsdom: mount-parse, navigate→hash,
  hashchange→state, junk fallback, same-hash sync). Adds `jsdom` + `@testing-library/{react,dom}`
  devDeps + lockfile; both run in the existing `frontend-test` Docker CI gate.
- **`RunManifest` widened to real authoring practice**: `changes_seen: int | str` (prose when a
  count would mislead) and a `created` propagation action — with a semantic backend test, and the
  `types.ts` / runs badge / `PropagationMatrix` consumers updated. In the live haku-state, the
  strict model had silently drifted from 5 real manifests; the gate below is what caught it.
- **NEW `validate-state.yaml` workflow + `tools/validate_state.py`**: every push to main
  validates `items/` + `runs/` against the backend's **own Pydantic models** — the actual
  live-read contract (`build-ui.yaml`'s path filter never covered data commits, which dominate a
  working haku-state). Documented gotcha baked into the workflow: the runner's docker is a dind
  sidecar, so `docker run -v` mounts the sidecar's empty filesystem — stream the repo via
  `docker build -f - .` instead.

## Why

Follow-through on "repo best-practices pass" + "runs verify their CI": these are the pieces an
arbitrary new haku instance wants from day one. Everything here is already live and proven in
the operator's haku-state (the gate's first production run caught 7 files of real model↔data
drift; the routing shipped as image `…-68dfd1d`).

## Verification

- Template frontend: `npm ci && npm run build` (tsc+vite) clean, `npm test` 22/22 green.
- Template gate: runs clean against the template's (empty) seed data; exit-code contract
  covered by the live repo's production use.
- Deliberately **not** seeded: the operator-specific run tools (`ci_wait.sh`,
  `validate_local.sh`, `push_state.sh` hook) — they encode web-home runtime specifics and live
  in haku-state's `tools/` with their conventions in state-side memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0189a1fUCQnvrMwEx5fedtYd

---
_Generated by [Claude Code](https://claude.ai/code/session_0189a1fUCQnvrMwEx5fedtYd)_