### PR TITLE
litellm: finalize chatgpt deployment shape (RWX PVC, maxSurge:0, 2 replicas)

### DIFF
--- a/cluster/k8s/litellm/app/deployment.yaml
+++ b/cluster/k8s/litellm/app/deployment.yaml
@@ -16,11 +16,17 @@ metadata:
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
-  # RWO PVC (litellm-chatgpt-auth) can only be mounted by one pod; a RollingUpdate
-  # would deadlock the new pod on volume attach and briefly run two writers of the
-  # token file. Recreate guarantees a single writer.
+  # RWO PVC (litellm-chatgpt-auth) can only be mounted by one pod, so the rollout
+  # must never run two pods at once (attach deadlock + two writers of the token
+  # file). maxSurge:0 tears the old pod down before starting the new one — single
+  # writer, and unlike `type: Recreate` it doesn't require a destroy/recreate to
+  # transition the already-RollingUpdate live Deployment (server-side apply rejects
+  # setting type:Recreate while the API-defaulted rollingUpdate block is present).
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: litellm

--- a/cluster/k8s/litellm/app/deployment.yaml
+++ b/cluster/k8s/litellm/app/deployment.yaml
@@ -15,13 +15,23 @@ metadata:
   annotations:
     reloader.stakater.com/auto: "true"
 spec:
-  replicas: 1
-  # The chatgpt-auth PVC is RWX, but LiteLLM rewrites auth.json in place on token
-  # refresh, so two overlapping pods would race that file. maxSurge:0 tears the old
-  # pod down before starting the new one — single writer. Preferred over
-  # `type: Recreate` because server-side apply rejects transitioning the
-  # already-RollingUpdate live Deployment to type:Recreate while the API-defaulted
-  # rollingUpdate block is present, which would abort the whole apply.
+  replicas: 2
+  # 2 replicas for HA. Ollama/z.ai/Langfuse are all remote, so those are cleanly
+  # stateless. The one exception is the chatgpt provider's auth.json on the RWX
+  # chatgpt-auth PVC: both replicas share it and either may refresh+rewrite it.
+  #
+  # TODO(chatgpt-token-race): shared-token concurrency hazard. LiteLLM rewrites
+  # auth.json in place on refresh; with >1 replica two pods can refresh the same
+  # account concurrently and, because OpenAI rotates refresh tokens, invalidate
+  # each other's token — taking chatgpt models down until the seed is refreshed.
+  # Accepted for now: access tokens last ~10 days so the race window is a few
+  # seconds per refresh. Proper fix if it bites: move the chatgpt provider into a
+  # dedicated single-replica proxy and route chatgpt models to it from here.
+  #
+  # maxSurge:0/maxUnavailable:1 keeps >=1 pod serving during rollout and caps
+  # concurrent pods (writers) at replicas. type:Recreate is avoided because
+  # server-side apply rejects transitioning the already-RollingUpdate live
+  # Deployment to Recreate while the API-defaulted rollingUpdate block is present.
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/cluster/k8s/litellm/app/deployment.yaml
+++ b/cluster/k8s/litellm/app/deployment.yaml
@@ -16,12 +16,12 @@ metadata:
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
-  # RWO PVC (litellm-chatgpt-auth) can only be mounted by one pod, so the rollout
-  # must never run two pods at once (attach deadlock + two writers of the token
-  # file). maxSurge:0 tears the old pod down before starting the new one — single
-  # writer, and unlike `type: Recreate` it doesn't require a destroy/recreate to
-  # transition the already-RollingUpdate live Deployment (server-side apply rejects
-  # setting type:Recreate while the API-defaulted rollingUpdate block is present).
+  # The chatgpt-auth PVC is RWX, but LiteLLM rewrites auth.json in place on token
+  # refresh, so two overlapping pods would race that file. maxSurge:0 tears the old
+  # pod down before starting the new one — single writer. Preferred over
+  # `type: Recreate` because server-side apply rejects transitioning the
+  # already-RollingUpdate live Deployment to type:Recreate while the API-defaulted
+  # rollingUpdate block is present, which would abort the whole apply.
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/cluster/k8s/litellm/app/pvc.yaml
+++ b/cluster/k8s/litellm/app/pvc.yaml
@@ -10,9 +10,9 @@ metadata:
       rewrites this file, so it must survive restarts (refresh tokens rotate).
       Seeded copy-if-absent from the litellm-chatgpt-auth-seed secret.
 spec:
-  # RWX on SeaweedFS (a distributed FS) so the pod reschedules/rolls without RWO
-  # single-attach handoff friction. Concurrent-writer safety of auth.json is
-  # handled by the Deployment's maxSurge:0 (single writer), not the access mode.
+  # RWX on SeaweedFS (a distributed FS): shared by the litellm replicas that mount
+  # this token file, and free of RWO single-attach handoff on reschedule/rollout.
+  # See deployment.yaml TODO(chatgpt-token-race) for the shared-writer hazard.
   accessModes:
     - ReadWriteMany
   storageClassName: seaweedfs-ovh

--- a/cluster/k8s/litellm/app/pvc.yaml
+++ b/cluster/k8s/litellm/app/pvc.yaml
@@ -10,8 +10,11 @@ metadata:
       rewrites this file, so it must survive restarts (refresh tokens rotate).
       Seeded copy-if-absent from the litellm-chatgpt-auth-seed secret.
 spec:
+  # RWX on SeaweedFS (a distributed FS) so the pod reschedules/rolls without RWO
+  # single-attach handoff friction. Concurrent-writer safety of auth.json is
+  # handled by the Deployment's maxSurge:0 (single writer), not the access mode.
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   storageClassName: seaweedfs-ovh
   resources:
     requests:


### PR DESCRIPTION
Follow-up to #2722 (ChatGPT provider), covering three tightly-coupled deployment tweaks to the litellm proxy.

### 1. `maxSurge:0` RollingUpdate instead of `type: Recreate`
#2722 set `strategy: Recreate`, but server-side apply **rejects transitioning the live (already RollingUpdate) Deployment to `Recreate`** while the API-defaulted `rollingUpdate` block is present:

```
spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy type is 'Recreate'
```

That aborted the whole litellm app apply (so the PVC was never created and the pod never rolled). `RollingUpdate` with `maxSurge:0, maxUnavailable:1` keeps ≥1 pod serving, caps concurrent pods, and needs no `type` transition — Flux applies it in place.

### 2. chatgpt-auth PVC → `ReadWriteMany`
SeaweedFS is a distributed FS; RWX is the natural mode (matches the forgejo git PVC precedent) and avoids RWO single-attach handoff on reschedule/rollout.

### 3. 2 replicas (HA)
Ollama/z.ai/Langfuse are remote-stateless, so the proxy scales cleanly — **except** the chatgpt provider's `auth.json`, which both replicas share on the RWX PVC and either may refresh+rewrite. Left as `TODO(chatgpt-token-race)` in `deployment.yaml`: accepted risk (access tokens last ~10 days, so the concurrent-refresh window is seconds per refresh), with the proper fix noted (dedicated single-replica chatgpt proxy) if it ever bites.

Verified: `pre-commit` (incl. `kubeconform`) passes.