### PR TITLE
gmail_archiver: raise on unrepresentable filter criteria instead of over-broadening

### DIFF
--- a/gmail_archiver/BUILD.bazel
+++ b/gmail_archiver/BUILD.bazel
@@ -181,3 +181,15 @@ py_test(
         "@pypi//pytest_bazel",
     ],
 )
+
+py_test(
+    name = "test_filter_sync",
+    srcs = ["test_filter_sync.py"],
+    deps = [
+        ":filter_sync",
+        ":gmail_yaml_filters_models",
+        "//gmail_api:labels",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
+    ],
+)

--- a/gmail_archiver/filter_sync.py
+++ b/gmail_archiver/filter_sync.py
@@ -106,13 +106,13 @@ def normalize_yaml_rule(rule: FilterRule) -> NormalizedFilter:
 
     # from/to/subject and has/does_not_have accept compound (any/all/not) conditions
     # in the YAML model, but NormalizedFilter can only carry plain string criteria.
-    for name, value in [("from", rule.from_), ("to", rule.to), ("subject", rule.subject)]:
-        if isinstance(value, CompoundCondition):
-            raise ValueError(
-                f"FilterRule criterion {name!r} uses a compound (any/all/not) condition, "
-                "which cannot be synced to Gmail filters"
-            )
-    for name, value in [("has", rule.has), ("does_not_have", rule.does_not_have)]:
+    for name, value in [
+        ("from", rule.from_),
+        ("to", rule.to),
+        ("subject", rule.subject),
+        ("has", rule.has),
+        ("does_not_have", rule.does_not_have),
+    ]:
         if isinstance(value, CompoundCondition):
             raise ValueError(
                 f"FilterRule criterion {name!r} uses a compound (any/all/not) condition, "

--- a/gmail_archiver/filter_sync.py
+++ b/gmail_archiver/filter_sync.py
@@ -8,7 +8,7 @@ from typing import Self
 from gmail_api.labels import GmailLabel, SystemLabel, resolve_label_id
 from gmail_archiver.filter_planner import criteria_to_gmail_query
 from gmail_archiver.gmail_api_models import CreateFilterRequest, FilterAction, FilterCriteria, GmailFilter
-from gmail_archiver.gmail_yaml_filters_models import FilterRule
+from gmail_archiver.gmail_yaml_filters_models import CompoundCondition, FilterRule
 
 
 def _strip_gmail_quotes(s: str | None) -> str | None:
@@ -69,7 +69,56 @@ def normalize_gmail_filter(gmail_filter: GmailFilter, labels_by_id: dict[str, st
 
 
 def normalize_yaml_rule(rule: FilterRule) -> NormalizedFilter:
-    """Convert FilterRule from YAML to normalized form."""
+    """Convert FilterRule from YAML to normalized form.
+
+    Raises ValueError if the rule uses criteria that NormalizedFilter cannot
+    represent. Silently dropping such criteria would produce a Gmail filter that
+    matches a *broader* set of messages than the YAML intended -- and for
+    trash/delete rules that over-deletes mail matching the residual criteria.
+    """
+    # Criteria fields NormalizedFilter has no slot for. Dropping any would broaden
+    # the synced filter beyond what the YAML specified.
+    unrepresentable = [
+        name
+        for name, value in [
+            ("match", rule.match),
+            ("missing", rule.missing),
+            ("no_match", rule.no_match),
+            ("bcc", rule.bcc),
+            ("cc", rule.cc),
+            ("list", rule.list),
+            ("labeled", rule.labeled),
+            ("is", rule.is_),
+            ("category", rule.category),
+            ("deliveredto", rule.deliveredto),
+            ("filename", rule.filename),
+            ("larger", rule.larger),
+            ("smaller", rule.smaller),
+            ("size", rule.size),
+            ("rfc822msgid", rule.rfc822msgid),
+        ]
+        if value is not None
+    ]
+    if unrepresentable:
+        raise ValueError(
+            f"FilterRule uses criteria that cannot be synced to Gmail filters: {', '.join(unrepresentable)}"
+        )
+
+    # from/to/subject and has/does_not_have accept compound (any/all/not) conditions
+    # in the YAML model, but NormalizedFilter can only carry plain string criteria.
+    for name, value in [("from", rule.from_), ("to", rule.to), ("subject", rule.subject)]:
+        if isinstance(value, CompoundCondition):
+            raise ValueError(
+                f"FilterRule criterion {name!r} uses a compound (any/all/not) condition, "
+                "which cannot be synced to Gmail filters"
+            )
+    for name, value in [("has", rule.has), ("does_not_have", rule.does_not_have)]:
+        if isinstance(value, CompoundCondition):
+            raise ValueError(
+                f"FilterRule criterion {name!r} uses a compound (any/all/not) condition, "
+                "which cannot be synced to Gmail filters"
+            )
+
     add_labels = frozenset(
         label
         for label, condition in [

--- a/gmail_archiver/test_filter_sync.py
+++ b/gmail_archiver/test_filter_sync.py
@@ -1,0 +1,43 @@
+"""Tests for filter normalization and synchronization."""
+
+import pytest
+import pytest_bazel
+
+from gmail_api.labels import SystemLabel
+from gmail_archiver.filter_sync import NormalizedFilter, normalize_yaml_rule
+from gmail_archiver.gmail_yaml_filters_models import CompoundCondition, FilterRule
+
+
+def test_representable_rule_normalizes():
+    """A rule using only representable criteria round-trips into NormalizedFilter."""
+    rule = FilterRule(from_="alerts@example.com", subject="Receipt", has="invoice", does_not_have="draft", trash=True)
+
+    normalized = normalize_yaml_rule(rule)
+
+    assert normalized == NormalizedFilter(
+        from_="alerts@example.com",
+        subject="Receipt",
+        query="invoice",
+        negated_query="draft",
+        add_labels=frozenset({SystemLabel.TRASH}),
+    )
+
+
+def test_compound_from_condition_raises():
+    """A compound `from` condition cannot be represented and must raise."""
+    rule = FilterRule(from_=CompoundCondition(any=["a@example.com", "b@example.com"]))
+
+    with pytest.raises(ValueError, match="from"):
+        normalize_yaml_rule(rule)
+
+
+def test_unrepresentable_cc_field_raises():
+    """A criteria field the normalizer cannot represent (cc) must raise."""
+    rule = FilterRule(cc="boss@example.com", trash=True)
+
+    with pytest.raises(ValueError, match="cc"):
+        normalize_yaml_rule(rule)
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/gmail_archiver/test_filter_sync.py
+++ b/gmail_archiver/test_filter_sync.py
@@ -23,19 +23,52 @@ def test_representable_rule_normalizes():
     )
 
 
-def test_compound_from_condition_raises():
-    """A compound `from` condition cannot be represented and must raise."""
-    rule = FilterRule(from_=CompoundCondition(any=["a@example.com", "b@example.com"]))
+# Every criteria field NormalizedFilter cannot represent: setting any of them must
+# fail closed rather than silently broaden the synced filter. Parameterized so a
+# typo/omission in the reject list regresses a test. (attr, expected-name-in-error)
+UNREPRESENTABLE_FIELDS = [
+    ("match", "match"),
+    ("missing", "missing"),
+    ("no_match", "no_match"),
+    ("bcc", "bcc"),
+    ("cc", "cc"),
+    ("list", "list"),
+    ("labeled", "labeled"),
+    ("is_", "is"),
+    ("category", "category"),
+    ("deliveredto", "deliveredto"),
+    ("filename", "filename"),
+    ("larger", "larger"),
+    ("smaller", "smaller"),
+    ("size", "size"),
+    ("rfc822msgid", "rfc822msgid"),
+]
 
-    with pytest.raises(ValueError, match="from"):
+
+@pytest.mark.parametrize(("attr", "error_name"), UNREPRESENTABLE_FIELDS)
+def test_unrepresentable_field_raises(attr: str, error_name: str):
+    rule = FilterRule(**{attr: "x"}, trash=True)
+
+    with pytest.raises(ValueError, match=error_name):
         normalize_yaml_rule(rule)
 
 
-def test_unrepresentable_cc_field_raises():
-    """A criteria field the normalizer cannot represent (cc) must raise."""
-    rule = FilterRule(cc="boss@example.com", trash=True)
+# from/to/subject/has/does_not_have accept plain strings (representable) but also
+# compound any/all/not conditions, which NormalizedFilter cannot carry.
+COMPOUND_FIELDS = [
+    ("from_", "from"),
+    ("to", "to"),
+    ("subject", "subject"),
+    ("has", "has"),
+    ("does_not_have", "does_not_have"),
+]
 
-    with pytest.raises(ValueError, match="cc"):
+
+@pytest.mark.parametrize(("attr", "error_name"), COMPOUND_FIELDS)
+def test_compound_condition_raises(attr: str, error_name: str):
+    rule = FilterRule(**{attr: CompoundCondition(any=["a@example.com", "b@example.com"])})
+
+    with pytest.raises(ValueError, match=f"'{error_name}'"):
         normalize_yaml_rule(rule)
 
 


### PR DESCRIPTION
Fixes an over-deletion risk in `filters sync` surfaced by the audit.

## The bug

`normalize_yaml_rule` silently dropped any YAML criterion that `NormalizedFilter` can't represent: it mapped `from_`/`to`/`subject` via `... if isinstance(..., str) else None` (dropping `CompoundCondition` to `None`) and only read `has`→`query` and `does_not_have`→`negated_query`. Every other `FilterRule` criterion (`cc`, `bcc`, `list`, `is`, `category`, `larger`, `smaller`, …) was never read. Dropping a criterion makes the synced Gmail filter match a **broader** set of messages than the YAML intended — and for `trash`/`delete` rules that over-deletes mail matching the residual criteria.

## The fix

`normalize_yaml_rule` now raises `ValueError` (naming the offending field) when a rule sets:
- any never-read criterion: `match`, `missing`, `no_match`, `bcc`, `cc`, `list`, `labeled`, `is`, `category`, `deliveredto`, `filename`, `larger`, `smaller`, `size`, `rfc822msgid`; or
- a compound (`any`/`all`/`not`) condition on `from`/`to`/`subject`/`has`/`does_not_have`, which `NormalizedFilter` can only carry as plain strings.

This fails closed instead of silently syncing a broader filter.

## Tests

`gmail_archiver/test_filter_sync.py`: a compound `from` raises, an unrepresentable `cc` raises, and a fully representable rule still normalizes unchanged.

## Behavior note

Any existing `filters.yaml` relying on a now-unrepresentable criterion will error on `filters sync/diff` rather than silently syncing a broader filter — that surfacing is the intended correctness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjEYLNhipPWErzEqJk9D3s)_