### PR TITLE
haku/console: mirror haku-ui's route into the console URL

### DIFF
--- a/haku/console/README.md
+++ b/haku/console/README.md
@@ -57,8 +57,9 @@ redirect can complete.
 Containment is cross-origin isolation: the iframe can't read the console's DOM/cookies or
 act as it. The trusted **bridge** (`bridge.ts`) lets the iframe _request_ two things via
 postMessage — opening a link (`openLink`) and launching a run (`requestLaunch`); the shell
-origin-checks, schema-validates, and decides/confirms before acting. See
-`console/docs/containment.md`.
+origin-checks, schema-validates, and decides/confirms before acting. It also mirrors the
+iframe's hash route (`routeChanged`, validated as a path) into the console's own URL
+fragment so refresh and deep links restore the view. See `console/docs/containment.md`.
 
 ## Layout
 

--- a/haku/console/README.md
+++ b/haku/console/README.md
@@ -59,7 +59,7 @@ act as it. The trusted **bridge** (`bridge.ts`) lets the iframe _request_ two th
 postMessage — opening a link (`openLink`) and launching a run (`requestLaunch`); the shell
 origin-checks, schema-validates, and decides/confirms before acting. It also mirrors the
 iframe's hash route (`routeChanged`, validated as a path) into the console's own URL
-fragment so refresh and deep links restore the view. See `console/docs/containment.md`.
+fragment so refresh and deep links restore the view. See <docs/containment.md>.
 
 ## Layout
 

--- a/haku/console/docs/containment.md
+++ b/haku/console/docs/containment.md
@@ -123,6 +123,19 @@ popups). Rules:
   pop-ups for `haku.allegedly.works`") — postMessage-relayed opens lose user activation.
   The iframe still cannot open anything itself.
 
+### `routeChanged` — mirror the route for refresh/deep-links
+
+haku-ui posts `{type: "routeChanged", path}` on hash-route changes; the shell
+`history.replaceState`s the path into its **own** URL fragment, and on load carries its
+fragment back into the frame `src` so F5 / a deep link restores the view. Rules:
+
+- **The path is never a URL.** `isRoutePath` (bridge.ts) enforces a leading `/` (not
+  `//`), a conservative charset, and a length cap; the shell only ever puts the value in
+  a fragment, and the restored `src` is always `uiUrl` with only its fragment replaced —
+  the frame origin cannot be steered.
+- Fragments never reach servers, so the mirrored route leaks nothing to the SSO hop and
+  survives the in-frame Authentik 302 chain when a session exists.
+
 ## Operator identity — forward-auth headers, made trustworthy
 
 Haku's backend reads `X-authentik-username` on requests arriving through its gated route.

--- a/haku/console/frontend/bridge.test.ts
+++ b/haku/console/frontend/bridge.test.ts
@@ -21,6 +21,24 @@ describe("parseInbound", () => {
     });
   });
 
+  it("accepts a well-formed routeChanged", () => {
+    expect(parseInbound({ type: "routeChanged", path: "/" })).toEqual({ type: "routeChanged", path: "/" });
+    expect(parseInbound({ type: "routeChanged", path: "/garden/notes%2Ffoo.md" })).toEqual({
+      type: "routeChanged",
+      path: "/garden/notes%2Ffoo.md",
+    });
+  });
+
+  it("rejects routeChanged payloads that aren't validated route paths", () => {
+    expect(parseInbound({ type: "routeChanged" })).toBeNull(); // missing path
+    expect(parseInbound({ type: "routeChanged", path: 42 })).toBeNull(); // wrong type
+    expect(parseInbound({ type: "routeChanged", path: "runs" })).toBeNull(); // no leading slash
+    expect(parseInbound({ type: "routeChanged", path: "//evil.example/x" })).toBeNull(); // protocol-relative
+    expect(parseInbound({ type: "routeChanged", path: "https://evil.example" })).toBeNull(); // a URL, not a path
+    expect(parseInbound({ type: "routeChanged", path: "/has space" })).toBeNull(); // outside the charset
+    expect(parseInbound({ type: "routeChanged", path: `/${"a".repeat(600)}` })).toBeNull(); // over the length cap
+  });
+
   it("rejects malformed / unknown payloads", () => {
     expect(parseInbound(null)).toBeNull();
     expect(parseInbound("nope")).toBeNull();

--- a/haku/console/frontend/bridge.test.ts
+++ b/haku/console/frontend/bridge.test.ts
@@ -36,6 +36,8 @@ describe("parseInbound", () => {
     expect(parseInbound({ type: "routeChanged", path: "//evil.example/x" })).toBeNull(); // protocol-relative
     expect(parseInbound({ type: "routeChanged", path: "https://evil.example" })).toBeNull(); // a URL, not a path
     expect(parseInbound({ type: "routeChanged", path: "/has space" })).toBeNull(); // outside the charset
+    expect(parseInbound({ type: "routeChanged", path: "/garden/%2G" })).toBeNull(); // malformed %-escape
+    expect(parseInbound({ type: "routeChanged", path: "/garden/x%" })).toBeNull(); // trailing bare %
     expect(parseInbound({ type: "routeChanged", path: `/${"a".repeat(600)}` })).toBeNull(); // over the length cap
   });
 

--- a/haku/console/frontend/bridge.ts
+++ b/haku/console/frontend/bridge.ts
@@ -30,10 +30,11 @@ export type Outbound =
 // A mirrored route is strictly a PATH, never a URL: leading `/` (but not a
 // protocol-relative `//`, so the value stays inert even if a future caller drops it into
 // a URL context), a length cap, and a conservative charset — `/` plus what haku-ui's
-// per-segment encodeURIComponent can emit — so a hostile iframe can't put arbitrary
-// content in the console's URL bar.
+// per-segment encodeURIComponent can emit, so `%` only as a well-formed `%XX` escape
+// (malformed escapes get normalized inconsistently by URL serializers) — so a hostile
+// iframe can't put arbitrary content in the console's URL bar.
 export const ROUTE_PATH_MAX_LENGTH = 512;
-const ROUTE_PATH_RE = /^\/[A-Za-z0-9/._~%!'()*-]*$/;
+const ROUTE_PATH_RE = /^\/(?:[A-Za-z0-9/._~!'()*-]|%[0-9A-Fa-f]{2})*$/;
 export function isRoutePath(path: string): boolean {
   return path.length <= ROUTE_PATH_MAX_LENGTH && !path.startsWith("//") && ROUTE_PATH_RE.test(path);
 }

--- a/haku/console/frontend/bridge.ts
+++ b/haku/console/frontend/bridge.ts
@@ -14,12 +14,29 @@
 //    capability must be a genuine operator gesture against trusted chrome, so the iframe
 //    can only request it; the shell renders its OWN confirm (showing the prompt) and only
 //    then fires. `id` correlates the eventual `launchResult`.
-export type Inbound = { type: "openLink"; url: string } | { type: "requestLaunch"; id: string; prompt: string };
+//  - `routeChanged`: mirror the iframe's current hash route into the console's own URL
+//    fragment so refresh/deep-links restore the view. Strictly a validated path
+//    (`isRoutePath`), never a URL — the shell only ever puts it in a fragment.
+export type Inbound =
+  | { type: "openLink"; url: string }
+  | { type: "requestLaunch"; id: string; prompt: string }
+  | { type: "routeChanged"; path: string };
 
 // Outbound result (shell → iframe), so Haku's UI can react to the outcome.
 export type Outbound =
   | { type: "openLinkResult"; url: string; opened: boolean; reason?: string }
   | { type: "launchResult"; id: string; ok: boolean; sessionUrl?: string; reason?: string };
+
+// A mirrored route is strictly a PATH, never a URL: leading `/` (but not a
+// protocol-relative `//`, so the value stays inert even if a future caller drops it into
+// a URL context), a length cap, and a conservative charset — `/` plus what haku-ui's
+// per-segment encodeURIComponent can emit — so a hostile iframe can't put arbitrary
+// content in the console's URL bar.
+export const ROUTE_PATH_MAX_LENGTH = 512;
+const ROUTE_PATH_RE = /^\/[A-Za-z0-9/._~%!'()*-]*$/;
+export function isRoutePath(path: string): boolean {
+  return path.length <= ROUTE_PATH_MAX_LENGTH && !path.startsWith("//") && ROUTE_PATH_RE.test(path);
+}
 
 // Narrow an untrusted postMessage payload to a known message, or null.
 export function parseInbound(data: unknown): Inbound | null {
@@ -28,6 +45,9 @@ export function parseInbound(data: unknown): Inbound | null {
   if (m.type === "openLink" && typeof m.url === "string") return { type: "openLink", url: m.url };
   if (m.type === "requestLaunch" && typeof m.id === "string" && typeof m.prompt === "string") {
     return { type: "requestLaunch", id: m.id, prompt: m.prompt };
+  }
+  if (m.type === "routeChanged" && typeof m.path === "string" && isRoutePath(m.path)) {
+    return { type: "routeChanged", path: m.path };
   }
   return null;
 }

--- a/haku/console/frontend/haku_ui_embed.test.ts
+++ b/haku/console/frontend/haku_ui_embed.test.ts
@@ -1,6 +1,28 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { openExternal } from "./haku_ui_embed.tsx";
+import { initialFrameSrc, openExternal } from "./haku_ui_embed.tsx";
+
+describe("initialFrameSrc", () => {
+  it("pins the origin and carries only the console hash into the frame's fragment", () => {
+    expect(initialFrameSrc("https://haku-ui.allegedly.works/", "#/runs")).toBe(
+      "https://haku-ui.allegedly.works/#/runs"
+    );
+    expect(initialFrameSrc("https://haku-ui.allegedly.works/", "#/garden/notes%2Ffoo.md")).toBe(
+      "https://haku-ui.allegedly.works/#/garden/notes%2Ffoo.md"
+    );
+  });
+
+  it("falls back to the bare uiUrl when the hash is absent or not a valid route path", () => {
+    expect(initialFrameSrc("https://haku-ui.allegedly.works/", "")).toBe("https://haku-ui.allegedly.works/");
+    expect(initialFrameSrc("https://haku-ui.allegedly.works/", "#runs")).toBe("https://haku-ui.allegedly.works/");
+    expect(initialFrameSrc("https://haku-ui.allegedly.works/", "#https://evil.example")).toBe(
+      "https://haku-ui.allegedly.works/"
+    );
+    expect(initialFrameSrc("https://haku-ui.allegedly.works/", "#//evil.example/x")).toBe(
+      "https://haku-ui.allegedly.works/"
+    );
+  });
+});
 
 describe("openExternal", () => {
   afterEach(() => {

--- a/haku/console/frontend/haku_ui_embed.tsx
+++ b/haku/console/frontend/haku_ui_embed.tsx
@@ -1,7 +1,7 @@
 import { Anchor } from "@mantine/core";
 import { useEffect, useRef, useState } from "react";
 
-import { type Outbound, parseInbound, vetOpenLink } from "./bridge.ts";
+import { isRoutePath, type Outbound, parseInbound, vetOpenLink } from "./bridge.ts";
 import { launchRoutine } from "./client.ts";
 import { ConfirmDialog, type Escalation } from "./confirm_dialog.tsx";
 import { toastError, toastSuccess } from "./toast.ts";
@@ -29,11 +29,27 @@ export function openExternal(url: string): boolean {
 
 const POPUP_HINT = "Allow pop-ups for this site so the console can open links.";
 
+// Restore the route the console URL carries into the frame on first mount. The console
+// hash is treated strictly as a validated path, never a URL: the src is always `uiUrl`
+// with only its fragment replaced, so the frame origin stays pinned. Fragments never
+// reach servers and survive the in-frame Authentik 302 chain when an SSO session already
+// exists; an interactive login may drop the fragment (degrades to haku-ui's home view).
+export function initialFrameSrc(uiUrl: string, consoleHash: string): string {
+  const path = consoleHash.replace(/^#/, "");
+  if (!isRoutePath(path)) return uiUrl;
+  const src = new URL(uiUrl);
+  src.hash = path;
+  return src.toString();
+}
+
 export function HakuUiEmbed({ uiUrl, launchAvailable }: { uiUrl: string; launchAvailable: boolean }) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   // The single escalation awaiting the operator's trusted confirm (a link to open or a run
   // to launch). One typed action, dispatched on its `kind` — see ConfirmDialog's Escalation.
   const [pending, setPending] = useState<Escalation | null>(null);
+  // Computed once: later routeChanged mirroring must not rewrite `src` (that would
+  // reload the frame); the iframe navigates itself, the console only reflects.
+  const [frameSrc] = useState(() => initialFrameSrc(uiUrl, window.location.hash));
   const origin = new URL(uiUrl).origin;
 
   function reply(msg: Outbound) {
@@ -59,6 +75,13 @@ export function HakuUiEmbed({ uiUrl, launchAvailable }: { uiUrl: string; launchA
           return;
         }
         setPending({ kind: "launch", id: msg.id, prompt: msg.prompt });
+        return;
+      }
+      if (msg.type === "routeChanged") {
+        // Mirror the iframe's route into the console's own fragment so refresh/deep-links
+        // restore the view. replaceState, not pushState: the iframe's hash navigations
+        // already create joint-session-history entries, so Back works via the frame.
+        history.replaceState(null, "", `#${msg.path}`);
         return;
       }
       // openLink: scheme-gate + whitelist; whitelisted opens directly, off-whitelist confirms.
@@ -117,7 +140,7 @@ export function HakuUiEmbed({ uiUrl, launchAvailable }: { uiUrl: string; launchA
     <>
       <iframe
         ref={iframeRef}
-        src={uiUrl}
+        src={frameSrc}
         title="Haku UI"
         sandbox="allow-scripts allow-same-origin allow-forms"
         style={{ display: "block", width: "100vw", height: "100vh", border: 0 }}

--- a/haku/state_template/ui/frontend/src/app.tsx
+++ b/haku/state_template/ui/frontend/src/app.tsx
@@ -1,11 +1,12 @@
 import { Container, Tabs, Title } from "@mantine/core";
 import { useEffect, useState } from "react";
 
+import { notifyRouteChanged } from "./bridge.ts";
 import { clickAction, fetchDashboard, unclickAction } from "./client.ts";
 import { GardenPage } from "./garden.tsx";
 import { ImprovementsPage } from "./improvements.tsx";
 import { InboxView } from "./inbox.tsx";
-import { useHashRoute } from "./routes.ts";
+import { formatHash, useHashRoute } from "./routes.ts";
 import type { View } from "./routes.ts";
 import { RunsPage } from "./runs.tsx";
 import { clickKey } from "./task.tsx";
@@ -27,6 +28,11 @@ export default function App() {
   // F5, permalinks, and back/forward come from the browser (routes.ts → useHashRoute).
   const [route, navigate] = useHashRoute();
   const { view, gardenPath } = route;
+  // Mirror every route change (and the initial route) to the console shell so its URL
+  // fragment tracks this view — the shell restores it into the iframe src on reload.
+  useEffect(() => {
+    notifyRouteChanged(formatHash(route).slice(1));
+  }, [route]);
   function openInGarden(path: string) {
     navigate({ view: "garden", gardenPath: path });
   }

--- a/haku/state_template/ui/frontend/src/bridge.ts
+++ b/haku/state_template/ui/frontend/src/bridge.ts
@@ -36,3 +36,12 @@ export function openLink(url: string): Promise<OpenLinkResult> {
     window.parent.postMessage({ type: "openLink", url }, SHELL_ORIGIN);
   });
 }
+
+// Fire-and-forget: mirror the current hash route into the console shell's own URL
+// fragment so F5 / deep-links of the console restore this view (shell contract:
+// ducktape haku/console/docs/containment.md → `routeChanged`). `path` is the hash minus
+// the "#" (always "/"-prefixed); the shell validates it as a strict path before
+// replaceState. Unframed (top-level) the targetOrigin check drops the self-post.
+export function notifyRouteChanged(path: string): void {
+  window.parent.postMessage({ type: "routeChanged", path }, SHELL_ORIGIN);
+}


### PR DESCRIPTION
Console side of haku-state `plans/url-topology.md` item 2 — delivers "F5 of the console re-renders the tab/page of Haku UI it was displaying".

## What

- **`bridge.ts`**: new inbound `routeChanged {path}` verb. `isRoutePath` gates it hard: leading `/` (but not protocol-relative `//`), conservative charset (`/` plus what haku-ui's per-segment `encodeURIComponent` can emit), 512-char cap. The mirrored value is strictly a path, never a URL.
- **`haku_ui_embed.tsx`**:
  - `routeChanged` → `history.replaceState` of `#<path>` into the console's own URL fragment. `replaceState`, not `pushState`: the iframe's hash navigations already create joint-session-history entries, so Back keeps working via the frame.
  - On mount, `initialFrameSrc(uiUrl, location.hash)` carries the console's fragment back into the frame `src` with the **origin pinned** — the src is always `uiUrl` with only its fragment replaced, so the hash can never steer the frame elsewhere.
- Tests for the verb validation (`bridge.test.ts`) and the src restoration (`haku_ui_embed.test.ts`).
- `containment.md` + console README document the new bridge verb.
- **`state_template/ui`**: the client side — `notifyRouteChanged` (fire-and-forget, targetOrigin-pinned to the shell; a no-op when unframed) posted from an `app.tsx` effect on mount and on every route change.

## Security notes

- The path never leaves a fragment context: fragments don't reach servers (nothing leaks to the SSO hop) and survive the in-frame Authentik 302 chain when a session exists; an interactive login may drop it (degrades to haku-ui's home view).
- Addresses the three design nits pinned in the plan: origin pinned on restore, `routeChanged` syntax constrained (charset + length cap) before `replaceState`, SSO-fragment caveat documented with postMessage-init as the fallback if live verification disproves fragment survival.

## Rollout

The live haku-ui side ships from haku-state (same change as the template). Version skew is harmless in both directions: an old console parses unknown verbs to null; a new console simply never receives `routeChanged` from an old haku-ui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0189a1fUCQnvrMwEx5fedtYd