### PR TITLE
grocy_mcp: never re-POST mutating requests on timeout

### DIFF
--- a/grocy_mcp/batch_tools.py
+++ b/grocy_mcp/batch_tools.py
@@ -12,7 +12,7 @@ overwhelm Grocy's PHP/SQLite backend or the Authentik token exchange endpoint
 IMPORTANT: reads/GETs go through _retry(), which retries transient errors
 including timeouts. Mutating requests go through _retry_mutation(), which NEVER
 retries a timeout — a mutating request that times out may already have been
-applied server-side, so a blind re-POST double-applies it (the 2026-04-17
+applied server-side, so a blind re-send double-applies it (the 2026-04-17
 stock-inflation incident: products 90, 95, 97). On such a timeout it raises
 MutationMayHaveAppliedError so the caller can verify state before retrying
 manually. Server-side rejections (429/5xx) stay retryable there since the request
@@ -138,7 +138,7 @@ class MutationMayHaveAppliedError(Exception):
     """A mutating request timed out before Grocy responded.
 
     Grocy may or may not have applied the mutation, so it must never be
-    auto-retried — a blind re-POST double-applies it (the 2026-04-17
+    auto-retried — a blind re-send double-applies it (the 2026-04-17
     stock-inflation incident: products 90, 95, 97). Surfaced to the caller with
     instructions to verify state before retrying manually.
     """
@@ -216,7 +216,7 @@ def register_batch_tools(mcp: FastMCP, client: httpx.AsyncClient, settings: Serv
         """Run a mutating request under semaphore, never re-sending on timeout.
 
         Unlike `_retry`, a timeout is not retried: the mutation may already have
-        been applied server-side, and a blind re-POST double-applies it (the
+        been applied server-side, and a blind re-send double-applies it (the
         2026-04-17 incident). On timeout, raise `MutationMayHaveAppliedError`
         telling the caller to verify state before retrying manually. Server-side
         errors (429/5xx) are still retried — the request was rejected, not applied.
@@ -1206,10 +1206,16 @@ def register_batch_tools(mcp: FastMCP, client: httpx.AsyncClient, settings: Serv
                 "location_id_from": from_loc.id,
                 "location_id_to": to_loc.id,
             }
-            r = await client.post(f"/stock/products/{prod.id}/transfer", json=body)
-            r.raise_for_status()
-            entries: list[dict[str, Any]] = r.json()
-            tx_id = entries[0]["transaction_id"] if entries else None
+
+            async def _do() -> str | None:
+                r = await client.post(f"/stock/products/{prod.id}/transfer", json=body)
+                r.raise_for_status()
+                entries: list[dict[str, Any]] = r.json()
+                return entries[0]["transaction_id"] if entries else None
+
+            tx_id = await _retry_mutation(
+                _do, describe=f"stock transfer of {amount} {rqu.name} for product {prod.name!r}"
+            )
 
             return StockOpOk(
                 product_name=prod.name,
@@ -1313,14 +1319,14 @@ def register_batch_tools(mcp: FastMCP, client: httpx.AsyncClient, settings: Serv
                 if item.note is not None:
                     body["note"] = item.note
 
-                r = await client.post("/objects/shopping_list", json=body)
-                r.raise_for_status()
-                data = r.json()
+                async def _do() -> int:
+                    r = await client.post("/objects/shopping_list", json=body)
+                    r.raise_for_status()
+                    return int(r.json().get("created_object_id", 0))
+
+                item_id = await _retry_mutation(_do, describe=f"add item to shopping list {item.shopping_list!r}")
                 return ShoppingListItemOk(
-                    item_id=int(data.get("created_object_id", 0)),
-                    product_name=product_name,
-                    amount=item.amount,
-                    qu_name=qu_name,
+                    item_id=item_id, product_name=product_name, amount=item.amount, qu_name=qu_name
                 )
             except Exception as e:
                 return ShoppingListItemError(error=_format_exc(e))

--- a/grocy_mcp/batch_tools.py
+++ b/grocy_mcp/batch_tools.py
@@ -9,10 +9,15 @@ overwhelm Grocy's PHP/SQLite backend or the Authentik token exchange endpoint
 (each request triggers a per-user JWT exchange). Transient errors (timeouts,
 5xx) are retried with exponential backoff.
 
-IMPORTANT: Only idempotent/read operations go inside _retry(). Mutating POSTs
-are retried only for the mutation itself — the follow-up GET (to read new_amount)
-is best-effort outside the retry loop. This prevents retry-induced stock inflation
-(see 2026-04-17 incident: products 90, 95, 97).
+IMPORTANT: reads/GETs go through _retry(), which retries transient errors
+including timeouts. Mutating requests go through _retry_mutation(), which NEVER
+retries a timeout — a mutating request that times out may already have been
+applied server-side, so a blind re-POST double-applies it (the 2026-04-17
+stock-inflation incident: products 90, 95, 97). On such a timeout it raises
+MutationMayHaveAppliedError so the caller can verify state before retrying
+manually. Server-side rejections (429/5xx) stay retryable there since the request
+was received but not applied. The follow-up GET that reads new_amount is
+best-effort, outside any retry loop.
 """
 
 from __future__ import annotations
@@ -129,13 +134,26 @@ def _compute_default_bbd(product: dict[str, Any], *, is_freezer: bool) -> str:
     return (date.today() + timedelta(days=days)).isoformat()
 
 
+class MutationMayHaveAppliedError(Exception):
+    """A mutating request timed out before Grocy responded.
+
+    Grocy may or may not have applied the mutation, so it must never be
+    auto-retried — a blind re-POST double-applies it (the 2026-04-17
+    stock-inflation incident: products 90, 95, 97). Surfaced to the caller with
+    instructions to verify state before retrying manually.
+    """
+
+
 def _format_exc(e: Exception) -> str:
     """Format exceptions for tool error payloads.
 
     For ``HTTPStatusError``, return a compact, user-facing message with:
     HTTP status, method, URL, and Grocy response body (when present).
+    For ``MutationMayHaveAppliedError``, return its explanatory message.
     For all other exception types, keep the full traceback.
     """
+    if isinstance(e, MutationMayHaveAppliedError):
+        return str(e)
     if isinstance(e, httpx.HTTPStatusError):
         status = e.response.status_code
         reason = e.response.reason_phrase
@@ -150,9 +168,21 @@ def _format_exc(e: Exception) -> str:
 
 
 def _is_retryable(exc: BaseException) -> bool:
-    """Whether an exception is transient and worth retrying."""
+    """Whether an exception is transient and worth retrying (reads/GETs)."""
     if isinstance(exc, httpx.TimeoutException):
         return True
+    return isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code in {429, 500, 502, 503, 504}
+
+
+def _is_retryable_mutation(exc: BaseException) -> bool:
+    """Retry predicate for mutating requests.
+
+    Deviation from ``_is_retryable``: timeouts are NOT retryable. A mutating
+    request that times out may already have been applied server-side, so a
+    retry risks double-applying it. Server-side error responses (429/5xx) stay
+    retryable (matching prior behavior) — the request reached Grocy but was
+    rejected, so no mutation was applied to duplicate.
+    """
     return isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code in {429, 500, 502, 503, 504}
 
 
@@ -180,6 +210,34 @@ def register_batch_tools(mcp: FastMCP, client: httpx.AsyncClient, settings: Serv
             ):
                 with attempt:
                     return await fn()
+        raise AssertionError("unreachable")
+
+    async def _retry_mutation[T](fn: Callable[[], Awaitable[T]], *, describe: str) -> T:
+        """Run a mutating request under semaphore, never re-sending on timeout.
+
+        Unlike `_retry`, a timeout is not retried: the mutation may already have
+        been applied server-side, and a blind re-POST double-applies it (the
+        2026-04-17 incident). On timeout, raise `MutationMayHaveAppliedError`
+        telling the caller to verify state before retrying manually. Server-side
+        errors (429/5xx) are still retried — the request was rejected, not applied.
+        """
+        async with sem:
+            try:
+                async for attempt in AsyncRetrying(
+                    retry=retry_if_exception(_is_retryable_mutation),
+                    stop=stop_after_attempt(1 + settings.max_retries),
+                    wait=wait_exponential(multiplier=settings.retry_base_delay, exp_base=2),
+                    reraise=True,
+                ):
+                    with attempt:
+                        return await fn()
+            except httpx.TimeoutException as e:
+                raise MutationMayHaveAppliedError(
+                    f"{describe} timed out before Grocy responded; the mutation may or may not "
+                    "have been applied. Do NOT retry blindly — that risks double-applying it. "
+                    "Verify current state (e.g. the stock_log entity via entities_list, or "
+                    "stock_get) before retrying manually."
+                ) from e
         raise AssertionError("unreachable")
 
     # ── Helpers ──────────────────────────────────────────────────────────
@@ -272,7 +330,7 @@ def register_batch_tools(mcp: FastMCP, client: httpx.AsyncClient, settings: Serv
                     raw_id = data.get("created_object_id")
                     return CreateOk(created_object_id=int(raw_id) if raw_id is not None else None)
 
-                return await _retry(_do)
+                return await _retry_mutation(_do, describe=f"create {item.entity_type}")
             except Exception as e:
                 return CreateError(error=_format_exc(e))
 
@@ -538,7 +596,9 @@ def register_batch_tools(mcp: FastMCP, client: httpx.AsyncClient, settings: Serv
                 amount_delta = sum(float(e.get("amount", 0)) for e in entries) if entries else None
                 return tx_id, amount_delta, stock_id
 
-            tx_id, amount_delta, stock_id = await _retry(_do_post)
+            tx_id, amount_delta, stock_id = await _retry_mutation(
+                _do_post, describe=f"stock {endpoint} of {input_amount} {rqu.name} for product {product.name!r}"
+            )
             if isinstance(item, AddItem) and stock_id is not None:
                 new_amount, entry_id = await asyncio.gather(
                     _best_effort_new_amount(product.id), _best_effort_entry_id(product.id, stock_id)
@@ -875,7 +935,7 @@ def register_batch_tools(mcp: FastMCP, client: httpx.AsyncClient, settings: Serv
                     raw_id = r.json().get("created_object_id")
                     return CreateOk(created_object_id=int(raw_id) if raw_id is not None else None)
 
-                return await _retry(_do)
+                return await _retry_mutation(_do, describe=f"create at {entity_path}")
             except Exception as e:
                 return CreateError(error=_format_exc(e))
 
@@ -1028,7 +1088,7 @@ def register_batch_tools(mcp: FastMCP, client: httpx.AsyncClient, settings: Serv
                     raw_id = r.json().get("created_object_id")
                     return CreateOk(created_object_id=int(raw_id) if raw_id is not None else None)
 
-                return await _retry(_do)
+                return await _retry_mutation(_do, describe=f"create product {item.name!r}")
             except Exception as e:
                 return CreateError(error=_format_exc(e))
 

--- a/grocy_mcp/test_retry_safety.py
+++ b/grocy_mcp/test_retry_safety.py
@@ -97,6 +97,41 @@ async def test_add_stock_post_retried_on_transient_failure(mcp_client: tuple[Cli
     assert post_route.call_count == 2  # first attempt failed, second succeeded
 
 
+async def test_mutating_post_not_retried_on_timeout(mcp_client: tuple[Client, respx.Router]) -> None:
+    """A timeout on a mutating POST must NOT re-send — a re-POST would double-apply it."""
+    client, router = mcp_client
+
+    post_route = router.post("/stock/products/1/consume").mock(side_effect=httpx.ReadTimeout("simulated timeout"))
+
+    result = await client.call_tool(
+        "stock_consume", {"items": [{"product": 1, "amount": 5, "qu": "pieces", "location": "TestLoc"}]}
+    )
+    sc = result.structured_content
+    assert sc is not None
+    op = sc["result"][0]
+    assert op["kind"] == "error", f"expected error, got: {op}"
+    assert post_route.call_count == 1, "mutating POST must be sent exactly once on timeout"
+    error = op["error"]
+    assert "consume" in error, "error should name the endpoint"
+    assert "may or may not" in error, "error should say the mutation may or may not have applied"
+    assert "double-appl" in error, "error should warn against a blind retry"
+
+
+async def test_read_get_still_retried_on_timeout(mcp_client: tuple[Client, respx.Router]) -> None:
+    """Regression guard: reads/GETs still retry on timeout (only mutations changed)."""
+    client, router = mcp_client
+
+    stock_route = router.get("/stock").mock(
+        side_effect=[httpx.ReadTimeout("simulated timeout"), httpx.Response(200, json=[])]
+    )
+
+    result = await client.call_tool("stock_get", {"products": [], "locations": []})
+    sc = result.structured_content
+    assert sc is not None
+    assert sc["result"] == []
+    assert stock_route.call_count == 2, "read GET should retry after a timeout"
+
+
 async def test_unit_validation_rejects_wrong_qu(mcp_client: tuple[Client, respx.Router]) -> None:
     """Specifying a QU with no conversion to stock QU should fail validation."""
     client, _router = mcp_client


### PR DESCRIPTION
Fixes a stock double-apply risk surfaced by the audit.

## The bug

Mutating stock POSTs (`/add`, `/consume`, `/inventory`) ran inside `_retry`, which retries on `httpx.TimeoutException`. A POST that Grocy actually applied but whose response timed out was re-sent, double-applying the mutation — the same class as the module's documented 2026-04-17 stock-inflation incident (products 90, 95, 97).

## The fix

New `_retry_mutation` helper for mutating requests, distinct from `_retry`:
- A **timeout** is no longer retried. Instead it raises `MutationMayHaveAppliedError` naming the operation and telling the caller the mutation may or may not have applied — verify state (`stock_log` / `stock_get`) before retrying manually. `_format_exc` renders it as a clean message (no traceback).
- **429/5xx** stay retryable (the request reached Grocy but was rejected, so nothing was applied to duplicate).
- Reads/GETs keep using `_retry` unchanged (timeouts still retried).

Applied to the mutating-POST call sites: the `/add` `/consume` `/inventory` stock mutations plus the other create POSTs (`entities_create`, `products_create`, batch entity creates), which share the same double-apply exposure.

## Tests

`grocy_mcp/test_retry_safety.py`: a timeout on `POST .../consume` is not retried (call count 1) and raises the explanatory error; a timeout on `GET /stock` still retries then succeeds. The existing 500→retry test still holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjEYLNhipPWErzEqJk9D3s)_