### PR TITLE
haku mailbox: exempt config ConfigMap from Flux post-build substitution

### DIFF
--- a/cluster/k8s/haku/mailbox/app/kustomization.yaml
+++ b/cluster/k8s/haku/mailbox/app/kustomization.yaml
@@ -13,8 +13,16 @@ resources:
   - haku-mail-token-eso.yaml
 configMapGenerator:
   # Hash-suffixed name: config/plan/wrapper changes roll the deployment.
+  # Flux post-build substitution is disabled for this ConfigMap: the embedded
+  # shell/sieve content uses ${...} forms (${STALWART_ADMIN_PASSWORD},
+  # ${env.dmarc.result}) that envsubst would blank or choke on ("missing
+  # closing brace" — dots are invalid in its variable names). Only
+  # certificate.yaml needs ${LETSENCRYPT_ISSUER} substituted.
   - name: haku-mailbox-config
     namespace: haku-mailbox
+    options:
+      annotations:
+        kustomize.toolkit.fluxcd.io/substitute: disabled
     files:
       - config.json
       - mailbox-plan.ndjson.tmpl


### PR DESCRIPTION
Deploy fix for #2724's first reconcile: the `haku-mailbox` Kustomization failed with

```text
BuildFailed: post build failed for 'ConfigMap.v1.[noGrp]/haku-mailbox-config-...':
envsubst error: variable substitution failed: missing closing brace
```

Flux post-build substitution runs over every built manifest, including the generated ConfigMap embedding the wrapper script and the Stalwart provisioning plan. The sieve script's `${env.dmarc.result}` breaks envsubst (dots are invalid in its variable names), and even without the hard error, substitution would silently blank the wrapper's `${STALWART_ADMIN_PASSWORD}`/`${tries}`.

Fix: annotate the generated ConfigMap with `kustomize.toolkit.fluxcd.io/substitute: disabled` (via `configMapGenerator.options`). Substitution stays active for `certificate.yaml`'s `${LETSENCRYPT_ISSUER}`, the only intended use.

Verified locally that the annotation lands on the generated ConfigMap via `kustomize build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQEcV7Uoc7vzq34JA5oBha

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQEcV7Uoc7vzq34JA5oBha)_