### PR TITLE
loom/gym: categorical headline metric is log_loss, not mean_pinball

### DIFF
--- a/loom/gym/BUILD.bazel
+++ b/loom/gym/BUILD.bazel
@@ -374,6 +374,18 @@ py_test(
     ],
 )
 
+py_test(
+    name = "test_headline_metric",
+    srcs = ["test_headline_metric.py"],
+    deps = [
+        ":inspect_harness",
+        ":scoring",
+        ":task",
+        "//:conftest",
+        "@pypi//pytest_bazel",
+    ],
+)
+
 # ── OCI image (driver for the in-cluster forecasting-eval Job) ────────────────
 #
 # Bundles the Python eval driver with the `docker` CLI + `docker compose` v2

--- a/loom/gym/inspect_harness.py
+++ b/loom/gym/inspect_harness.py
@@ -291,7 +291,10 @@ def sample_for_task(task: Task, dossier: dict[str, str], compose_path: Path, *, 
 
 
 def headline_metric(metrics: dict[str, float], kind: str) -> str:
-    if kind == "binary":
+    # binary and categorical scoring both emit log_loss; quantile (scalar) emits
+    # mean_pinball[_log]. Categorical must not fall through to mean_pinball — it
+    # isn't a key _score_categorical produces, so the lookup would KeyError.
+    if kind in ("binary", "categorical"):
         return "log_loss"
     return "mean_pinball_log" if "mean_pinball_log" in metrics else "mean_pinball"
 

--- a/loom/gym/test_headline_metric.py
+++ b/loom/gym/test_headline_metric.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from datetime import date
+
+import pytest_bazel
+
+from loom.gym.inspect_harness import headline_metric
+from loom.gym.scoring import CategoricalAnswer, score
+from loom.gym.task import CategoricalOutcome, CategoricalQuestion, Task
+
+
+def _categorical_task(*, ordered: bool) -> Task:
+    return Task(
+        task_id="t",
+        as_of=date(2024, 7, 1),
+        resolution_date=date(2024, 12, 31),
+        question=CategoricalQuestion(text="?", categories=("a", "b", "c"), ordered=ordered),
+        outcome=CategoricalOutcome(category="b"),
+        outcome_source="test fixture",
+    )
+
+
+def test_categorical_headline_metric_resolves():
+    # Regression: headline_metric fell through to "mean_pinball" for categorical
+    # tasks, but _score_categorical only emits log_loss/brier[/rps], so the
+    # score-time lookup raised KeyError for every categorical task.
+    metrics = score(
+        _categorical_task(ordered=True), CategoricalAnswer(probabilities={"a": 0.2, "b": 0.5, "c": 0.3})
+    ).metrics
+    key = headline_metric(metrics, "categorical")
+    assert key == "log_loss"
+    assert key in metrics
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()


### PR DESCRIPTION
Fixes a scorer crash on categorical tasks surfaced by the audit.

## The bug

`headline_metric` had no categorical branch: for `kind == "categorical"` it fell through to `"mean_pinball"`, but `_score_categorical` only emits `log_loss`/`brier`[/`rps`]. The score-time lookup in `gym_proper_loss` (`task_score.metrics[headline_metric(...)]`) then raised `KeyError` for **every** categorical task.

## The fix

Return `"log_loss"` for categorical (a key categorical scoring always produces). Adds `loom/gym/test_headline_metric.py`, which scores a real categorical task and asserts the headline key resolves to a produced metric.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjEYLNhipPWErzEqJk9D3s)_