### PR TITLE
props: add llm-proxy service to compose so the documented deployment boots

### DIFF
--- a/props/README.md
+++ b/props/README.md
@@ -53,10 +53,11 @@ cd props
 # 1. Allow direnv (generates PGPASSWORD, sets env vars)
 direnv allow
 
-# 2. Build and load backend image (includes frontend)
+# 2. Build and load backend image (includes frontend) and the LLM proxy image
 bazelisk run //props/backend:load
+bazelisk run //props/llm_proxy:load
 
-# 3. Start infrastructure (postgres, registry, backend+frontend)
+# 3. Start infrastructure (postgres, registry, backend+frontend, llm-proxy)
 docker compose up -d
 
 # 4. Initialize database (runs migrations, syncs specimens)

--- a/props/compose.yaml
+++ b/props/compose.yaml
@@ -80,6 +80,39 @@ services:
       timeout: 5s
       retries: 5
 
+  # LLM proxy data plane — agents reach the LLM through here (auth + budget +
+  # cost + upstream routing), split out of the backend so the API can roll
+  # without disrupting in-flight agents. config.toml's llm_proxy_url points
+  # agents at this service. Mirrors cluster/k8s/props/app/llm-proxy-deployment.yaml.
+  llm-proxy:
+    image: props-llm-proxy:latest
+    container_name: props-llm-proxy
+    volumes:
+      - ./config.toml:/etc/props/config.toml:ro
+    environment:
+      PROPS_CONFIG_FILE: /etc/props/config.toml
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      OPENAI_BASE_URL: https://api.openai.com/v1
+      PGHOST: props-postgres
+      PGPORT: "5432"
+      PGUSER: postgres
+      PGPASSWORD: ${PGPASSWORD}
+      PGDATABASE: eval_results
+    networks:
+      # props-agents: agents resolve `props-llm-proxy` here and it reaches the
+      # upstream LLM (this network has egress; props-internal does not).
+      # props-internal: reach props-postgres for auth/budget/cost queries.
+      - props-internal
+      - props-agents
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
 volumes:
   props_eval_results_data:
   props_registry_data:

--- a/props/config.py
+++ b/props/config.py
@@ -121,7 +121,8 @@ class PropsConfig(LLMProxyConfig):
 
     backend_url: str
     # Base URL agents use for the LLM proxy (split out of the backend); agents get
-    # OPENAI_BASE_URL = <llm_proxy_url>/v1. None falls back to backend_url.
+    # OPENAI_BASE_URL = <llm_proxy_url>/v1. Required for agent runs: the backend
+    # raises at startup if it's None (there is no backend_url fallback).
     llm_proxy_url: str | None = None
     grader_model: str | None = None
     agent_env: dict[str, str]

--- a/props/config.toml
+++ b/props/config.toml
@@ -2,8 +2,13 @@
 # Pointed to by PROPS_CONFIG_FILE env var.
 
 # Backend URL used by host-side code (CLI, backend) and injected into containers.
-# OPENAI_BASE_URL is derived from this (+ "/v1").
 backend_url = "http://props-backend:8000"
+
+# Agents reach the LLM proxy (split out of the backend) here, not the dashboard,
+# so the API server can roll without disrupting in-flight agents. Agents get
+# OPENAI_BASE_URL = <llm_proxy_url>/v1. Mirrors the `llm-proxy` service in
+# compose.yaml (and cluster/k8s/props/app/config.toml).
+llm_proxy_url = "http://props-llm-proxy:8000"
 
 # Model for snapshot graders. If unset, grader supervisor is disabled.
 grader_model = "gpt-5.1-codex-mini"


### PR DESCRIPTION
Fixes the documented `docker compose` deployment failing to boot (audit finding).

## The bug

`props/backend/app.py:139-141` hard-requires `config.llm_proxy_url` at startup and raises when it's `None`; the startup callback turns that into `os._exit(1)`, a boot loop. But the checked-in compose config never set `llm_proxy_url` and had no proxy service, so `docker compose up` couldn't boot the backend. `config.py:124` also carried a stale comment claiming a removed `backend_url` fallback.

## What the llm-proxy is (repo evidence)

`llm_proxy_url` is a `config.toml` field (not an env var). The cluster is the source of truth: `cluster/k8s/props/app/config.toml` sets `llm_proxy_url = "http://props-llm-proxy:8000"`, and `cluster/k8s/props/app/llm-proxy-deployment.yaml` runs a **separate** `props-llm-proxy` image on port 8000 — the standalone `//props/llm_proxy` app (built locally via `//props/llm_proxy:load` as `props-llm-proxy:latest`).

## Changes

- **`props/compose.yaml`** — add an `llm-proxy` service (`props-llm-proxy:latest`, mounts `config.toml`, `OPENAI_API_KEY`/`OPENAI_BASE_URL` + `PG*` matching the backend service, on `props-internal` + `props-agents`, `depends_on` postgres healthy, `/health` healthcheck mirroring the backend). Agents attach to `props-agents`, so the proxy is reachable there.
- **`props/config.toml`** — set `llm_proxy_url = "http://props-llm-proxy:8000"` (matches cluster).
- **`props/config.py`** — fix the stale comment (no `backend_url` fallback; backend raises when `None`).
- **`props/README.md`** — add `bazelisk run //props/llm_proxy:load` to setup so the image exists.

Per your instruction, this adds the proxy service rather than restoring any fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjEYLNhipPWErzEqJk9D3s)_