### PR TITLE
litellm: trim chatgpt models to served set + bump image to 1.90.2

### DIFF
--- a/cluster/k8s/litellm/app/deployment.yaml
+++ b/cluster/k8s/litellm/app/deployment.yaml
@@ -52,7 +52,7 @@ spec:
         # if absent — LiteLLM refreshes/rotates the token in place, and the seed
         # secret is not updated after rotation, so we must never clobber the live file.
         - name: seed-chatgpt-auth
-          image: litellm/litellm:1.86.3
+          image: litellm/litellm:1.90.2
           command:
             - sh
             - -c
@@ -79,7 +79,7 @@ spec:
                       - proxmox
       containers:
         - name: litellm
-          image: litellm/litellm:1.86.3
+          image: litellm/litellm:1.90.2
           args: ["--config", "/etc/litellm/config.yaml"]
           ports:
             - name: http

--- a/cluster/k8s/litellm/app/generate_litellm.py
+++ b/cluster/k8s/litellm/app/generate_litellm.py
@@ -66,15 +66,16 @@ _ZAI_ANTHROPIC_MODELS: list[str] = [
 # litellm-chatgpt-auth-seed secret; see deployment.yaml. The provider refreshes the access
 # token on demand and rewrites that file, so the mount must be read-write. `drop_params`
 # (below) strips the max_tokens/metadata fields this backend rejects.
-_CHATGPT_MODELS: list[str] = [
-    "gpt-5.4",
-    "gpt-5.4-pro",
-    "gpt-5.3-codex",
-    "gpt-5.3-codex-spark",
-    "gpt-5.3-instant",
-    "gpt-5.3-chat-latest",
-    "gpt-5.5",
-]
+#
+# Only these three are served by the Codex/ChatGPT-account backend (verified live).
+# Others tried and rejected with "not supported when using Codex with a ChatGPT
+# account": gpt-5.4-pro, gpt-5.3-codex, gpt-5.3-instant, gpt-5.3-chat-latest.
+#
+# GOTCHA: usable via STREAMING only. Non-streaming responses come back with an empty
+# output[] and the /v1/chat/completions bridge fails with "Unknown items in responses
+# API response: []" — an unfixed LiteLLM bug (BerriAI/litellm#25429; fix PRs like #27562
+# still unmerged as of litellm 1.90.x). Callers must send stream:true to /v1/responses.
+_CHATGPT_MODELS: list[str] = ["gpt-5.4", "gpt-5.5", "gpt-5.3-codex-spark"]
 
 
 def _chatgpt_entries() -> Iterator[dict]:

--- a/cluster/k8s/litellm/app/proxy-config.yaml
+++ b/cluster/k8s/litellm/app/proxy-config.yaml
@@ -177,34 +177,14 @@ model_list:
       model: chatgpt/gpt-5.4
     model_info:
       mode: responses
-  - model_name: gpt-5.4-pro-chatgpt
+  - model_name: gpt-5.5-chatgpt
     litellm_params:
-      model: chatgpt/gpt-5.4-pro
-    model_info:
-      mode: responses
-  - model_name: gpt-5.3-codex-chatgpt
-    litellm_params:
-      model: chatgpt/gpt-5.3-codex
+      model: chatgpt/gpt-5.5
     model_info:
       mode: responses
   - model_name: gpt-5.3-codex-spark-chatgpt
     litellm_params:
       model: chatgpt/gpt-5.3-codex-spark
-    model_info:
-      mode: responses
-  - model_name: gpt-5.3-instant-chatgpt
-    litellm_params:
-      model: chatgpt/gpt-5.3-instant
-    model_info:
-      mode: responses
-  - model_name: gpt-5.3-chat-latest-chatgpt
-    litellm_params:
-      model: chatgpt/gpt-5.3-chat-latest
-    model_info:
-      mode: responses
-  - model_name: gpt-5.5-chatgpt
-    litellm_params:
-      model: chatgpt/gpt-5.5
     model_info:
       mode: responses
 litellm_settings:


### PR DESCRIPTION
Follow-up to #2722/#2725 after live-testing the ChatGPT provider on the cluster.

### Trim model list
The Codex/ChatGPT-account backend only serves **`gpt-5.4`, `gpt-5.5`, `gpt-5.3-codex-spark`** (verified live — all return output). The rest 400 with *"not supported when using Codex with a ChatGPT account"*, so drop them: `gpt-5.4-pro`, `gpt-5.3-codex`, `gpt-5.3-instant`, `gpt-5.3-chat-latest`.

### Bump image 1.86.3 → 1.90.2
General currency (latest stable). **Does not fix** the non-streaming aggregation bug — see below.

### Known limitation (documented in `generate_litellm.py`)
ChatGPT models are **streaming-only**. Non-streaming `/v1/responses` returns an empty `output[]` and `/v1/chat/completions` fails with `Unknown items in responses API response: []`. Root cause is an **unfixed upstream LiteLLM bug** ([BerriAI/litellm#25429](https://github.com/BerriAI/litellm/issues/25429)); the fix PRs (e.g. #27562) are unmerged as of 1.90.x. Callers must send `stream:true` to `/v1/responses`. Verified working that way: `gpt-5.4`/`gpt-5.5`/`gpt-5.3-codex-spark` all return text.

Verified: `bazel test //cluster/k8s/litellm/app:test_generate_litellm //cluster/validation/...` (14 pass), pre-commit incl. kubeconform, and Docker tag `litellm/litellm:1.90.2` exists.