### PR TITLE
llm/html: require TOKEN_SECRET, drop the "hunter2" default

### DIFF
--- a/llm/html/README.md
+++ b/llm/html/README.md
@@ -12,6 +12,9 @@ python html_server.py
 
 ## Environment Variables
 
-- `TOKEN_SECRET`: secret for token generation (default: `hunter2`)
+- `TOKEN_SECRET`: HMAC secret for token generation. **Required** — the server
+  refuses to start without it. For local development set `LLM_HTML_DEV=1` to use an
+  insecure built-in dev secret instead.
+- `LLM_HTML_DEV`: set to `1` to allow running without `TOKEN_SECRET` (local dev only).
 - `PORT`: listen port (default: `9000`)
 - `SITE_URL`: base URL for verification links

--- a/llm/html/llm_html/BUILD.bazel
+++ b/llm/html/llm_html/BUILD.bazel
@@ -58,6 +58,10 @@ py_image_layer(
 py_test(
     name = "test_html_rendering",
     srcs = ["test_html_rendering.py"],
+    # Exercises request handlers that need a token secret; run in dev mode so no
+    # real TOKEN_SECRET is required. The requires-secret path is covered by a
+    # monkeypatch test that clears the flag.
+    env = {"LLM_HTML_DEV": "1"},
     deps = [
         ":server",
         ":token_scheme",

--- a/llm/html/llm_html/server.py
+++ b/llm/html/llm_html/server.py
@@ -123,7 +123,8 @@ def load_page_titles():
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    """Load page titles on startup."""
+    """Resolve the token secret (fail fast if misconfigured) and load page titles."""
+    token_secret()  # raise at startup if TOKEN_SECRET is unset and not in dev mode
     load_page_titles()
     yield
 

--- a/llm/html/llm_html/server.py
+++ b/llm/html/llm_html/server.py
@@ -2,6 +2,7 @@
 """FastAPI server for LLM instructions with token generation."""
 
 import asyncio
+import functools
 import logging
 import os
 import sys
@@ -42,7 +43,33 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 # Global configuration
-TOKEN_SECRET = os.environ.get("TOKEN_SECRET", "hunter2").encode()
+
+# Insecure placeholder secret used only when LLM_HTML_DEV=1 (local dev). The tokens
+# this signs are trivially forgeable, so it must never be used in a real deployment.
+_DEV_TOKEN_SECRET = b"llm-html-insecure-dev-secret"
+
+
+def _resolve_token_secret() -> bytes:
+    """The HMAC secret that signs/verifies page tokens.
+
+    Raises if `TOKEN_SECRET` is unset so a real deployment can never silently fall
+    back to a known secret. Set `LLM_HTML_DEV=1` to run locally without one.
+    """
+    secret = os.environ.get("TOKEN_SECRET")
+    if secret:
+        return secret.encode()
+    if os.environ.get("LLM_HTML_DEV") == "1":
+        logger.warning(
+            "TOKEN_SECRET unset; using an insecure dev secret because LLM_HTML_DEV=1. Never use in production."
+        )
+        return _DEV_TOKEN_SECRET
+    raise RuntimeError("TOKEN_SECRET is required. Set it, or set LLM_HTML_DEV=1 for local development.")
+
+
+@functools.cache
+def token_secret() -> bytes:
+    return _resolve_token_secret()
+
 
 # Content directory: where .md, .html, .css files live.
 # Defaults to parent of this module's directory (i.e., llm/html/).
@@ -136,7 +163,7 @@ async def index():
     """Serve the main page with rendered markdown."""
     try:
         text = await asyncio.to_thread((CONTENT_DIR / "index.md").read_text)
-        ts = TokenScheme(TOKEN_SECRET, text)
+        ts = TokenScheme(token_secret(), text)
 
         # Use configured timezone
         current_time = datetime.now(TIMEZONE)
@@ -194,7 +221,7 @@ async def analyze_page_tokens(
 
         if is_index:
             # Step 2: Render template variables for index
-            ts = TokenScheme(TOKEN_SECRET, text)
+            ts = TokenScheme(token_secret(), text)
             current_time = datetime.now(TIMEZONE)
             prefix, bits = ts.make_token(current_time)
             tpl = env.get_template("index.md")
@@ -296,7 +323,7 @@ async def verify_token(request: Request, token: str = ""):
         try:
             # Read the source index.md file (not rendered)
             text = await asyncio.to_thread((CONTENT_DIR / "index.md").read_text)
-            ts = TokenScheme(TOKEN_SECRET, text)
+            ts = TokenScheme(token_secret(), text)
 
             ts.verify_token(token)
             result = {"status": "success", "message": "Token is valid ✅"}

--- a/llm/html/llm_html/test_html_rendering.py
+++ b/llm/html/llm_html/test_html_rendering.py
@@ -6,7 +6,7 @@ import pytest
 import pytest_bazel
 from starlette.testclient import TestClient
 
-from llm.html.llm_html.server import app
+from llm.html.llm_html.server import _DEV_TOKEN_SECRET, _resolve_token_secret, app
 from llm.html.llm_html.token_scheme import N_TAGS, TokenScheme
 
 
@@ -41,6 +41,25 @@ def test_each_tag_exactly_once(client, mock_token_scheme, mock_token_bits):
         expected_tag = f"᚛{i}:{expected_bit}᚜"
         count = html_content.count(expected_tag)
         assert count == 1, f"Tag {expected_tag} found {count}x, not 1x"
+
+
+def test_resolve_token_secret_uses_env(monkeypatch):
+    monkeypatch.setenv("TOKEN_SECRET", "s3cret")
+    assert _resolve_token_secret() == b"s3cret"
+
+
+def test_resolve_token_secret_dev_fallback(monkeypatch):
+    monkeypatch.delenv("TOKEN_SECRET", raising=False)
+    monkeypatch.setenv("LLM_HTML_DEV", "1")
+    assert _resolve_token_secret() == _DEV_TOKEN_SECRET
+
+
+def test_resolve_token_secret_requires_secret(monkeypatch):
+    # No TOKEN_SECRET and not in dev mode: must fail closed, never a default.
+    monkeypatch.delenv("TOKEN_SECRET", raising=False)
+    monkeypatch.delenv("LLM_HTML_DEV", raising=False)
+    with pytest.raises(RuntimeError, match="TOKEN_SECRET is required"):
+        _resolve_token_secret()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Removes a hard-coded secret fallback (audit finding).

## The bug

`llm/html/llm_html/server.py` signed/verified page tokens with `TOKEN_SECRET = os.environ.get("TOKEN_SECRET", "hunter2")` — so any deployment that didn't set `TOKEN_SECRET` used a publicly-known signing key, and the README documented the default.

## The fix

Resolve the secret lazily via `token_secret()` and **raise** if `TOKEN_SECRET` is unset — no default. For local development, `LLM_HTML_DEV=1` selects an explicitly-labeled insecure dev secret (with a loud warning) so you can run the server without provisioning a real one. Handlers now call `token_secret()` instead of the module global; resolution is lazy so importing the module (tests, tooling) never requires the env.

## Tests

`test_html_rendering.py` gains coverage for the three paths — env-provided secret, dev fallback, and the fail-closed `RuntimeError` when neither is set. Its handler-render test runs with `LLM_HTML_DEV=1` (the requires-secret path is exercised by a monkeypatch test that clears the flag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjEYLNhipPWErzEqJk9D3s)_