### PR TITLE
ci: exclude manual-tagged tests from CI test runs

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -117,5 +117,11 @@ common:quiet --show_progress_rate_limit=30
 # CI and AI agent modes both use quiet output.
 common:ci --config=quiet
 common:ci --announce_rc
-test:ci --test_tag_filters=-live_openai_api
+# -manual so manual tests never run in CI. On push CI expands `//...`, which
+# already skips manual-tagged targets; but PR CI runs an explicit target list
+# from bazel-diff, and the `manual` tag only excludes from wildcard expansion —
+# not explicit labels — so without this filter a PR that touches a widely-depended
+# file drags manual tests (e.g. the Playwright e2e tests, which aren't wired for
+# hermetic Chromium) into the run and fails on them.
+test:ci --test_tag_filters=-live_openai_api,-manual
 common:ai_agent --config=quiet


### PR DESCRIPTION
Fixes `manual`-tagged tests leaking into PR CI and failing.

## Root cause

On push, CI runs `bazel test //...`, and the `manual` tag excludes those targets from wildcard expansion — so they never run. On PRs, CI instead runs an **explicit target list** from `bazel-diff get-impacted-targets`, and the `manual` tag only excludes from *wildcard* expansion, **not** explicit labels. `test:ci` filtered only `-live_openai_api`, so any PR touching a widely-depended file pulled `manual` tests into the run.

That's what failed #2740 (deny-continue fix): touching `x/agent_server/mcp/approval_policy/engine.py` made bazel-diff select the `x/agent_server/e2e` Playwright tests, which are `manual` because agent_server has **no Bazel-built served frontend** (no `server/static/`, the web bundle sets `index_html=None`, no served OCI image). They can't run on RBE and fail launching a browser against missing assets.

## Fix

Add `-manual` to the CI test tag filter so PR runs match push runs — manual tests never execute in CI regardless of how targets are specified. Non-test `manual` targets are unaffected (`--test_tag_filters` only gates test execution; `bazel build` still builds them).

## Note

Actually *running* the agent_server e2e tests on RBE is a separate, larger task: it needs the served-frontend build wired in Bazel (SPA incl. `index.html` → assembled `server/static/`), a static-dir override in `create_app`, and browser+docker test deps — then they could be un-`manual`ed. Not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjEYLNhipPWErzEqJk9D3s)_