### PR TITLE
bazel-ci: skip bazel test when the affected set has no test targets

### DIFF
--- a/.github/workflows/bazel-ci.yml
+++ b/.github/workflows/bazel-ci.yml
@@ -129,16 +129,40 @@ jobs:
                 exit 0
               fi
               TARGETS="--target_pattern_file=/tmp/affected.txt"
+              # `bazel query` has no --target_pattern_file flag (only
+              # build/test/etc. do), so the affected set can't be handed to
+              # `tests(...)` the same way it's handed to `bazel test`.
+              # set(...) embeds the same patterns directly in the query
+              # expression instead.
+              QUERY_TARGETS="set($(tr '\n' ' ' < /tmp/affected.txt))"
             else
               # push to devel / workflow_dispatch: full sweep.
               TARGETS="//..."
+              QUERY_TARGETS="//..."
             fi
 
+            # `bazel test` requires the resolved pattern to include at least
+            # one *_test rule -- unlike `bazel build`, it hard-fails ("No
+            # test targets were found, yet testing was requested", exit 4)
+            # if the affected set is all non-test files (e.g. a PR that only
+            # touches BUILD-file-exported source/patch files). tests(...)
+            # is Bazel's own query for "just the test rules in this target
+            # set" (it expands test_suite too), so this check stays exactly
+            # in sync with what `bazel test` would itself select.
+            TEST_TARGET_COUNT=$(bazel query "tests($QUERY_TARGETS)" 2>/dev/null | wc -l)
+            echo "test targets in scope: $TEST_TARGET_COUNT"
+
             probe_bb_runner before-test
-            bazel test --keep_going $RBE_FLAGS $TARGETS && \
-              probe_bb_runner after-test && \
+            if [ "$TEST_TARGET_COUNT" -eq 0 ]; then
+              echo "No test targets in scope -- skipping bazel test."
               bazel build --keep_going $RBE_FLAGS $TARGETS && \
-              probe_bb_runner after-build
+                probe_bb_runner after-build
+            else
+              bazel test --keep_going $RBE_FLAGS $TARGETS && \
+                probe_bb_runner after-test && \
+                bazel build --keep_going $RBE_FLAGS $TARGETS && \
+                probe_bb_runner after-build
+            fi
 
       - name: Upload BuildBuddy linkage
         if: always()

--- a/.github/workflows/bazel-ci.yml
+++ b/.github/workflows/bazel-ci.yml
@@ -132,13 +132,15 @@ jobs:
               # `bazel query` has no --target_pattern_file flag (only
               # build/test/etc. do), so the affected set can't be handed to
               # `tests(...)` the same way it's handed to `bazel test`.
-              # set(...) embeds the same patterns directly in the query
-              # expression instead.
-              QUERY_TARGETS="set($(tr '\n' ' ' < /tmp/affected.txt))"
+              # set(...) embeds the same patterns in the query expression
+              # instead, written to a file (--query_file) rather than argv
+              # so a large affected set can't hit command-line length limits.
+              { printf 'tests(set('; tr '\n' ' ' < /tmp/affected.txt; printf '))\n'; } \
+                > /tmp/test-query.txt
             else
               # push to devel / workflow_dispatch: full sweep.
               TARGETS="//..."
-              QUERY_TARGETS="//..."
+              echo 'tests(//...)' > /tmp/test-query.txt
             fi
 
             # `bazel test` requires the resolved pattern to include at least
@@ -148,8 +150,10 @@ jobs:
             # touches BUILD-file-exported source/patch files). tests(...)
             # is Bazel's own query for "just the test rules in this target
             # set" (it expands test_suite too), so this check stays exactly
-            # in sync with what `bazel test` would itself select.
-            TEST_TARGET_COUNT=$(bazel query "tests($QUERY_TARGETS)" 2>/dev/null | wc -l)
+            # in sync with what `bazel test` would itself select. stderr is
+            # left unredirected so a genuine query failure is still visible
+            # in the CI log, not just its (fail-hard, per set -e) exit code.
+            TEST_TARGET_COUNT=$(bazel query --query_file=/tmp/test-query.txt | wc -l)
             echo "test targets in scope: $TEST_TARGET_COUNT"
 
             probe_bb_runner before-test


### PR DESCRIPTION
## Summary

- `bazel-diff`'s PR-scoped affected-target gating hard-fails (`bazel test` exit 4, "No test targets were found, yet testing was requested") whenever a PR's affected set is entirely non-test files — e.g. a diff touching only `exports_files()`'d patch/source files. `bazel test` requires the resolved pattern to include at least one `*_test` rule; `bazel build` has no such restriction.
- Compute the affected set's test-target count via `bazel query "tests(...)"` before deciding whether to run `bazel test`, and skip straight to `bazel build` when the count is zero.
- `bazel query` has no `--target_pattern_file` flag (only `build`/`test`/etc. do — confirmed empirically), so the file-based affected-target list is embedded into the query expression via `set(...)` instead of reusing `$TARGETS` verbatim.
- Both paths stay under `set -euo pipefail`, so a genuine `bazel query` failure (bad pattern, bazel-diff bug, etc.) still aborts the script rather than silently defaulting to "skip test" — consistent with this script's existing "fail hard, no silent fallback to `//...`" policy for `bazel-diff` errors.

Discovered while investigating an unrelated PR (#2708) that failed CI with exactly this error despite its own changes being correct.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — YAML parses correctly
- [x] `pre-commit run --files .github/workflows/bazel-ci.yml` — passes
- [x] Manually verified the `tests(set(...))` query mechanism against real Bazel targets in this repo: returns the test target when one is in the set, returns 0 with no error when the set is all non-test targets, and correctly propagates a nonzero exit under `set -euo pipefail` on a malformed pattern
- [ ] This PR's own `bazel-ci` CI run is the real end-to-end verification (the failure mode only reproduces under actual GitHub Actions/`bb-remote` execution)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jp4qPMQ8AEHWzXoRVZMMc7)_