### PR TITLE
mcp/authentik: stop transient auth blips from permanently killing claude.ai connectors

### DIFF
--- a/cluster/k8s/agents/manifold-mcp/app/deployment.yaml
+++ b/cluster/k8s/agents/manifold-mcp/app/deployment.yaml
@@ -56,6 +56,10 @@ spec:
             - name: http
               containerPort: 8765
               protocol: TCP
+            # Prometheus metrics, cluster-internal only (not on the HTTPRoute).
+            - name: metrics
+              containerPort: 9090
+              protocol: TCP
           envFrom:
             - configMapRef:
                 name: manifold-mcp-config

--- a/cluster/k8s/agents/manifold-mcp/app/networkpolicy.yaml
+++ b/cluster/k8s/agents/manifold-mcp/app/networkpolicy.yaml
@@ -18,3 +18,11 @@ spec:
         - ports:
             - port: "8765"
               protocol: TCP
+    # monitoring: Prometheus metrics scraping
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: monitoring
+      toPorts:
+        - ports:
+            - port: "9090"
+              protocol: TCP

--- a/cluster/k8s/agents/manifold-mcp/app/service.yaml
+++ b/cluster/k8s/agents/manifold-mcp/app/service.yaml
@@ -13,4 +13,8 @@ spec:
       port: 8765
       targetPort: http
       protocol: TCP
+    - name: metrics
+      port: 9090
+      targetPort: metrics
+      protocol: TCP
   type: ClusterIP

--- a/cluster/k8s/agents/manifold-mcp/servicemonitor/flux-kustomization.yaml
+++ b/cluster/k8s/agents/manifold-mcp/servicemonitor/flux-kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: manifold-mcp-servicemonitor
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./cluster/k8s/agents/manifold-mcp/servicemonitor
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  dependsOn:
+    - name: manifold-mcp
+    - name: monitoring-stack

--- a/cluster/k8s/agents/manifold-mcp/servicemonitor/kustomization.yaml
+++ b/cluster/k8s/agents/manifold-mcp/servicemonitor/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - servicemonitor.yaml

--- a/cluster/k8s/agents/manifold-mcp/servicemonitor/servicemonitor.yaml
+++ b/cluster/k8s/agents/manifold-mcp/servicemonitor/servicemonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: manifold-mcp
+  namespace: manifold-mcp
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: manifold-mcp
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s

--- a/cluster/k8s/agents/plaid-db-mcp/app/deployment.yaml
+++ b/cluster/k8s/agents/plaid-db-mcp/app/deployment.yaml
@@ -73,6 +73,10 @@ spec:
             - name: http
               containerPort: 8765
               protocol: TCP
+            # Prometheus metrics, cluster-internal only (not on the HTTPRoute).
+            - name: metrics
+              containerPort: 9090
+              protocol: TCP
           envFrom:
             - configMapRef:
                 name: plaid-db-mcp-config

--- a/cluster/k8s/agents/plaid-db-mcp/app/networkpolicy.yaml
+++ b/cluster/k8s/agents/plaid-db-mcp/app/networkpolicy.yaml
@@ -16,3 +16,11 @@ spec:
         - ports:
             - port: "8765"
               protocol: TCP
+    # monitoring: Prometheus metrics scraping
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: monitoring
+      toPorts:
+        - ports:
+            - port: "9090"
+              protocol: TCP

--- a/cluster/k8s/agents/plaid-db-mcp/app/service.yaml
+++ b/cluster/k8s/agents/plaid-db-mcp/app/service.yaml
@@ -13,4 +13,8 @@ spec:
       port: 8765
       targetPort: http
       protocol: TCP
+    - name: metrics
+      port: 9090
+      targetPort: metrics
+      protocol: TCP
   type: ClusterIP

--- a/cluster/k8s/agents/plaid-db-mcp/servicemonitor/flux-kustomization.yaml
+++ b/cluster/k8s/agents/plaid-db-mcp/servicemonitor/flux-kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: plaid-db-mcp-servicemonitor
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./cluster/k8s/agents/plaid-db-mcp/servicemonitor
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  dependsOn:
+    - name: plaid-db-mcp
+    - name: monitoring-stack

--- a/cluster/k8s/agents/plaid-db-mcp/servicemonitor/kustomization.yaml
+++ b/cluster/k8s/agents/plaid-db-mcp/servicemonitor/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - servicemonitor.yaml

--- a/cluster/k8s/agents/plaid-db-mcp/servicemonitor/servicemonitor.yaml
+++ b/cluster/k8s/agents/plaid-db-mcp/servicemonitor/servicemonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: plaid-db-mcp
+  namespace: plaid-mcp
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: plaid-db-mcp
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s

--- a/cluster/k8s/agents/postscanmail-mcp/app/deployment.yaml
+++ b/cluster/k8s/agents/postscanmail-mcp/app/deployment.yaml
@@ -56,6 +56,10 @@ spec:
             - name: http
               containerPort: 8765
               protocol: TCP
+            # Prometheus metrics, cluster-internal only (not on the HTTPRoute).
+            - name: metrics
+              containerPort: 9090
+              protocol: TCP
           envFrom:
             - configMapRef:
                 name: postscanmail-mcp-config

--- a/cluster/k8s/agents/postscanmail-mcp/app/networkpolicy.yaml
+++ b/cluster/k8s/agents/postscanmail-mcp/app/networkpolicy.yaml
@@ -16,3 +16,11 @@ spec:
         - ports:
             - port: "8765"
               protocol: TCP
+    # monitoring: Prometheus metrics scraping
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: monitoring
+      toPorts:
+        - ports:
+            - port: "9090"
+              protocol: TCP

--- a/cluster/k8s/agents/postscanmail-mcp/app/service.yaml
+++ b/cluster/k8s/agents/postscanmail-mcp/app/service.yaml
@@ -13,4 +13,8 @@ spec:
       port: 8765
       targetPort: http
       protocol: TCP
+    - name: metrics
+      port: 9090
+      targetPort: metrics
+      protocol: TCP
   type: ClusterIP

--- a/cluster/k8s/agents/postscanmail-mcp/servicemonitor/flux-kustomization.yaml
+++ b/cluster/k8s/agents/postscanmail-mcp/servicemonitor/flux-kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: postscanmail-mcp-servicemonitor
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./cluster/k8s/agents/postscanmail-mcp/servicemonitor
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  dependsOn:
+    - name: postscanmail-mcp
+    - name: monitoring-stack

--- a/cluster/k8s/agents/postscanmail-mcp/servicemonitor/kustomization.yaml
+++ b/cluster/k8s/agents/postscanmail-mcp/servicemonitor/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - servicemonitor.yaml

--- a/cluster/k8s/agents/postscanmail-mcp/servicemonitor/servicemonitor.yaml
+++ b/cluster/k8s/agents/postscanmail-mcp/servicemonitor/servicemonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: postscanmail-mcp
+  namespace: postscanmail-mcp
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postscanmail-mcp
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s

--- a/cluster/k8s/authentik/app/helmrelease.yaml
+++ b/cluster/k8s/authentik/app/helmrelease.yaml
@@ -101,8 +101,19 @@ spec:
 
       # Default 3s timeout is too tight — outpost API calls regularly take
       # 1s+ even with OVH-local PostgreSQL. Give enough headroom.
+      #
+      # Authentik's /-/health/live/ returns 500 whenever PostgreSQL is
+      # unreachable, so with the default failureThreshold every transient
+      # DB/DNS blip (CNPG failover, node churn) liveness-killed a healthy
+      # server and turned a seconds-long blip into a ~90s reboot — the 503
+      # windows that killed claude.ai MCP connectors
+      # (debug/2026_06_claude_ai_connector_deauth.md). Ride out ~2min of DB
+      # unavailability before restarting; readiness stays fast so the pod
+      # drops out of the Service immediately.
       livenessProbe:
         timeoutSeconds: 10
+        periodSeconds: 15
+        failureThreshold: 8
       readinessProbe:
         timeoutSeconds: 10
 

--- a/cluster/k8s/grocy/mcp-base/server-deployment.yaml
+++ b/cluster/k8s/grocy/mcp-base/server-deployment.yaml
@@ -29,6 +29,10 @@ spec:
             - name: http
               containerPort: 8765
               protocol: TCP
+            # Prometheus metrics, cluster-internal only (not on the HTTPRoute).
+            - name: metrics
+              containerPort: 9090
+              protocol: TCP
           env:
             - name: LOG_LEVEL
               value: "DEBUG"

--- a/cluster/k8s/grocy/mcp-base/server-service.yaml
+++ b/cluster/k8s/grocy/mcp-base/server-service.yaml
@@ -14,4 +14,8 @@ spec:
       port: 8765
       targetPort: 8765
       protocol: TCP
+    - name: metrics
+      port: 9090
+      targetPort: metrics
+      protocol: TCP
   type: ClusterIP

--- a/cluster/k8s/grocy/mcp-servicemonitor-base/kustomization.yaml
+++ b/cluster/k8s/grocy/mcp-servicemonitor-base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - servicemonitor.yaml

--- a/cluster/k8s/grocy/mcp-servicemonitor-base/servicemonitor.yaml
+++ b/cluster/k8s/grocy/mcp-servicemonitor-base/servicemonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: grocy-mcp-server
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: grocy-mcp
+      app.kubernetes.io/component: server
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s

--- a/cluster/k8s/grocy/sf/mcp-servicemonitor/flux-kustomization.yaml
+++ b/cluster/k8s/grocy/sf/mcp-servicemonitor/flux-kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: grocy-mcp-sf-servicemonitor
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./cluster/k8s/grocy/sf/mcp-servicemonitor
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  dependsOn:
+    - name: grocy-mcp-sf
+    - name: monitoring-stack

--- a/cluster/k8s/grocy/sf/mcp-servicemonitor/kustomization.yaml
+++ b/cluster/k8s/grocy/sf/mcp-servicemonitor/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: grocy-sf
+resources:
+  - ../../mcp-servicemonitor-base

--- a/cluster/k8s/grocy/vallejo/mcp-servicemonitor/flux-kustomization.yaml
+++ b/cluster/k8s/grocy/vallejo/mcp-servicemonitor/flux-kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: grocy-mcp-vallejo-servicemonitor
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./cluster/k8s/grocy/vallejo/mcp-servicemonitor
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  dependsOn:
+    - name: grocy-mcp-vallejo
+    - name: monitoring-stack

--- a/cluster/k8s/grocy/vallejo/mcp-servicemonitor/kustomization.yaml
+++ b/cluster/k8s/grocy/vallejo/mcp-servicemonitor/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: grocy-vallejo
+resources:
+  - ../../mcp-servicemonitor-base

--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -80,7 +80,9 @@ resources:
   - agents/kagent/crds/flux-kustomization.yaml
   - agents/kagent/app/flux-kustomization.yaml
   - grocy/sf/mcp/flux-kustomization.yaml
+  - grocy/sf/mcp-servicemonitor/flux-kustomization.yaml
   - grocy/vallejo/mcp/flux-kustomization.yaml
+  - grocy/vallejo/mcp-servicemonitor/flux-kustomization.yaml
   - agents/kubectl-passthrough-mcp/namespace/flux-kustomization.yaml
   - agents/kubectl-passthrough-mcp/app/flux-kustomization.yaml
   - agents/kubectl-sandbox-mcp/namespace/flux-kustomization.yaml
@@ -89,13 +91,16 @@ resources:
   - agents/kubectl-machine-mcp/app/flux-kustomization.yaml
   - agents/manifold-mcp/namespace/flux-kustomization.yaml
   - agents/manifold-mcp/app/flux-kustomization.yaml
+  - agents/manifold-mcp/servicemonitor/flux-kustomization.yaml
   - agents/plaid-mcp/namespace/flux-kustomization.yaml
   - agents/plaid-mcp/db/flux-kustomization.yaml
   - agents/plaid-mcp/app/flux-kustomization.yaml
   - agents/plaid-db-mcp/app/flux-kustomization.yaml
+  - agents/plaid-db-mcp/servicemonitor/flux-kustomization.yaml
   - agents/plaid-mcp/agent-rbac/flux-kustomization.yaml
   - agents/postscanmail-mcp/namespace/flux-kustomization.yaml
   - agents/postscanmail-mcp/app/flux-kustomization.yaml
+  - agents/postscanmail-mcp/servicemonitor/flux-kustomization.yaml
   - agents/homeassistant-proxy/flux-kustomization.yaml
   - agents/openclaw/operator/flux-kustomization.yaml
   - agents/openclaw/gateway-namespace/flux-kustomization.yaml

--- a/cluster/k8s/monitoring/rules/kustomization.yaml
+++ b/cluster/k8s/monitoring/rules/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - control-plane-io-prometheus-rule.yaml
   - flux-prometheus-rule.yaml
+  - mcp-auth-prometheus-rule.yaml

--- a/cluster/k8s/monitoring/rules/mcp-auth-prometheus-rule.yaml
+++ b/cluster/k8s/monitoring/rules/mcp-auth-prometheus-rule.yaml
@@ -1,0 +1,33 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: mcp-auth-alerts
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: mcp-auth
+      rules:
+        # An OIDCProxy-fronted MCP server (oauth facades, grocy-mcp) failed to
+        # refresh a client's token against Authentik. Before the
+        # ResilientOIDCProxy fix this instantly killed the claude.ai connector
+        # (invalid_grant is terminal); now transient failures answer 503, but
+        # each one still means claude.ai saw an error and the connector may
+        # need a manual Reconnect. RCA:
+        # debug/2026_06_claude_ai_connector_deauth.md
+        - alert: McpUpstreamTokenRefreshFailed
+          expr: increase(mcp_auth_upstream_refresh_failures_total[1h]) > 0
+          labels:
+            severity: warning
+          annotations:
+            summary: "MCP server {{ $labels.namespace }}/{{ $labels.pod }} failed an upstream token refresh (outcome: {{ $labels.outcome }})"
+            description: >
+              {{ $value | printf "%.0f" }} upstream token refresh failure(s) in
+              the last hour on {{ $labels.namespace }}/{{ $labels.pod }}
+              (outcome={{ $labels.outcome }}). outcome=transient means Authentik
+              was unreachable/5xx (client got 503 and may recover on its own);
+              outcome=oauth means Authentik genuinely rejected a grant — the
+              claude.ai connector is likely dead until manually reconnected.
+              Check Settings → Connectors in claude.ai and authentik-server
+              health.

--- a/debug/2026_06_claude_ai_connector_deauth.md
+++ b/debug/2026_06_claude_ai_connector_deauth.md
@@ -1,0 +1,124 @@
+# claude.ai custom connectors recurringly flip to "Reconnect" — RCA (2026-07-02)
+
+## Symptom
+
+claude.ai Settings → Connectors periodically shows self-hosted (allegedly.works)
+MCP connectors as "Reconnect" while third-party connectors (Gmail, GDrive, …)
+stay connected. As of 2026-07-02: Cluster kubernetes (sandbox), Grocy Vallejo,
+Manifold, PostScanMail dead; Grocy SF, Tana, Plaid Postgres alive. It keeps
+recurring; each recovery requires a manual Reconnect click.
+
+## Root cause (proven)
+
+Three-link chain:
+
+1. **authentik-server is a single replica and restarts frequently** (13
+   container restarts in 5.5 days as of 2026-07-02; ~35 boots on 2026-06-24
+   alone). Diagnosed from two restart specimens (07-01 01:16:49, 07-02
+   09:10:49): authentik's `/-/health/live/` endpoint **returns 500 whenever
+   PostgreSQL is unreachable**, so any transient DB/DNS blip (CNPG failover,
+   node churn, CoreDNS loss — the known etcd-HDD/CP instability) fails the
+   liveness probe and kubelet SIGTERMs a healthy server (graceful exit 0,
+   `Handling signal: term`, probes 500ing only in the final seconds). The
+   reboot takes ~90 s (bootstrap 25 s + app init + 16 s/worker), so a
+   seconds-long DB blip becomes a minutes-long `auth.allegedly.works` 503
+   window. Mitigated by relaxing the server livenessProbe
+   (`failureThreshold: 8`, `periodSeconds: 15` — ride out ~2 min) in
+   `cluster/k8s/authentik/app/helmrelease.yaml`.
+
+2. **FastMCP's OAuthProxy translates ANY upstream refresh failure into OAuth
+   `invalid_grant`** (fastmcp 3.1.0,
+   `fastmcp/server/auth/oauth_proxy/proxy.py` ~1206):
+
+   ```python
+   except Exception as e:
+       logger.error("Upstream token refresh failed: %s", e)
+       raise TokenError("invalid_grant", f"Upstream refresh failed: {e}") from e
+   ```
+
+   A transient Authentik 503 or a DNS error becomes `invalid_grant` (HTTP 401)
+   at the facade's `/token` endpoint.
+
+3. **claude.ai treats one `invalid_grant` refresh response as terminal** —
+   correctly per RFC 6749 (`invalid_grant` means "refresh token
+   invalid/expired/revoked"). It flips the connector to "Reconnect" and stops
+   ALL traffic permanently. Observed: manifold facade logged zero claude.ai
+   requests after its single 401.
+
+claude.ai proactively refreshes each connector's token every ~10–40 min around
+the clock, so each Authentik restart is a dice roll across every connector:
+~50 restarts/month × ~2%–5% collision probability per connector per restart ≈
+several connector deaths per month. Matches observed cadence.
+
+## Evidence
+
+Loki (`kubectl -n loki port-forward svc/loki-read 3100`), facade access logs.
+Every death event is a `proxy.py:1207 "Upstream token refresh failed"` ERROR +
+`POST /token → 401` with **zero claude.ai traffic afterward**:
+
+| Event (UTC)    | Upstream failure                                            | Connectors killed                       |
+| -------------- | ----------------------------------------------------------- | --------------------------------------- |
+| 06-11 03:31:36 | (truncated reason)                                          | grocy-vallejo                           |
+| 06-20 00:45:29 | Authentik 503 — authentik booted 00:45:11, mid-start        | manifold + postscanmail + grocy-vallejo |
+| 06-22 07:20:14 | 5xx                                                         | postscanmail, grocy-vallejo             |
+| 06-24 18:43:07 | 5xx — during a ~35-restart authentik flap day               | postscanmail, grocy-vallejo             |
+| 06-28 03:09:58 | DNS "Temporary failure in name resolution" (etcd/CP outage) | postscanmail, grocy-sf                  |
+
+Kills across connectors land in the **same second** — claude.ai refreshes them
+on a synchronized cadence, so one outage window can kill several at once.
+
+Corroboration:
+
+- Valkey OAuth state (`mcp-oauth-proxy-clients::*`, no TTL) counts one DCR
+  registration per Reconnect click: manifold 1 (never reconnected since
+  06-20), postscanmail 3, grocy-vallejo 4, grocy-sf 4.
+- Valkey persistence is fine (RDB+AOF on `local-path-ovh`, data survived the
+  07-01 full-cluster restart) — state loss is NOT the mechanism.
+- Server-side refresh tokens for dead connectors are still valid (TTLs show
+  they simply stopped being renewed at each connector's death date).
+- kubectl-sandbox-mcp (no facade; claude.ai refreshes directly against
+  Authentik): **zero** claude.ai token requests in Authentik logs over the
+  full 29-day Loki retention → it died >29 days ago (visibility boundary) and
+  was never reconnected. Same class of failure, exact date unrecoverable.
+- Tana + Plaid facades logged zero refresh failures in 29 d — their refresh
+  timing just never collided with an outage window; survival is luck, not
+  configuration.
+
+## Why the earlier "reconnect one and the rest fix themselves" theory is wrong
+
+There is no shared session between connectors. Each has an independent DCR
+registration + token chain against its own facade. They die in batches only
+because refreshes are synchronized and the outage (Authentik restart) is
+shared.
+
+## Fixes (implemented 2026-07-02)
+
+1. **`ResilientOIDCProxy`** (`mcp_infra/authentik_auth/auth.py`, wired via
+   `build_authentik_auth` → all facades + grocy MCPs): transient upstream
+   failures (httpx transport errors, 5xx) are retried (tenacity,
+   3 attempts) and, if persistent, answered with **HTTP 503 + Retry-After**
+   instead of `invalid_grant`. Genuine upstream OAuth error responses still
+   surface as `invalid_grant`. Note: whether claude.ai retries after a 503 at
+   `/token` is unverified — but `invalid_grant` is guaranteed-terminal, 503
+   at least may be retried.
+2. **Alerting**: `mcp_auth_upstream_refresh_failures_total{outcome}` counter,
+   scraped via new metrics ports + ServiceMonitors on
+   manifold/postscanmail/plaid-db facades and grocy MCP servers (tana already
+   had one); central `McpUpstreamTokenRefreshFailed` alert in
+   `cluster/k8s/monitoring/rules/mcp-auth-prometheus-rule.yaml`.
+3. **Authentik liveness relaxed** (see cause 1 above): `failureThreshold: 8`,
+   `periodSeconds: 15`.
+
+## Still open
+
+- **2 server replicas**: clean to enable (chart `server.replicas: 2`,
+  anti-affinity already configured, nodes have ample memory headroom — the
+  "OVH memory too tight" comment in the helmrelease is stale). Helps for
+  node-local events, but note both replicas share the DB, so DB-blip liveness
+  kills would have hit both simultaneously — the probe relaxation above is the
+  higher-leverage change. Bundled single-replica chart redis is a remaining
+  SPOF (existing TODO in the helmrelease to move to operator-managed Valkey).
+- **Underlying DB/DNS blips**: the known etcd-HDD/CP-contention instability
+  (see `project_etcd_hdd_cp_contention` memory / cluster plan).
+- Dead connectors can only be revived by clicking Reconnect in claude.ai —
+  nothing cluster-side re-establishes them.

--- a/grocy_mcp/BUILD.bazel
+++ b/grocy_mcp/BUILD.bazel
@@ -87,6 +87,7 @@ py_library(
         "//util/bazel:runfiles",
         "@pypi//fastmcp",
         "@pypi//httpx",
+        "@pypi//prometheus_client",
         "@pypi//pydantic",
         "@pypi//uvicorn",
     ],

--- a/grocy_mcp/mcp_types.py
+++ b/grocy_mcp/mcp_types.py
@@ -43,6 +43,9 @@ class ServerSettings(BaseSettings):
     grocy_url: str = Field(description="URL of the Grocy instance. For production this is the outpost-protected URL.")
     host: str = "0.0.0.0"
     port: int = 8765
+    metrics_port: int = Field(
+        default=9090, description="Prometheus metrics port (cluster-internal, not on the HTTPRoute)."
+    )
 
     grocy_timeout: float = Field(default=30.0, description="Timeout (seconds) for Grocy API requests.")
     max_batch_size: int = Field(default=MAX_BATCH_SIZE, description="Maximum items per batch tool call.")

--- a/grocy_mcp/server.py
+++ b/grocy_mcp/server.py
@@ -28,6 +28,7 @@ import uvicorn
 from fastmcp import FastMCP
 from fastmcp.server.providers.openapi import MCPType, OpenAPIResource, OpenAPIResourceTemplate, OpenAPITool, RouteMap
 from fastmcp.utilities.openapi import HTTPRoute
+from prometheus_client import start_http_server
 from pydantic.networks import AnyUrl
 
 from grocy_mcp.batch_tools import register_batch_tools
@@ -134,7 +135,10 @@ def main() -> None:
     settings = ServerSettings()
     mcp = build_server(settings)
     app = mcp.http_app(path="/mcp")
-    logger.info("grocy-mcp listening on %s:%d", settings.host, settings.port)
+    # Metrics (incl. mcp_auth_upstream_refresh_failures_total) on a dedicated
+    # cluster-internal port, off the public HTTPRoute.
+    start_http_server(settings.metrics_port)
+    logger.info("grocy-mcp listening on %s:%d, metrics on :%d", settings.host, settings.port, settings.metrics_port)
     uvicorn.run(app, host=settings.host, port=settings.port, log_level="info")
 
 

--- a/mcp_infra/authentik_auth/BUILD.bazel
+++ b/mcp_infra/authentik_auth/BUILD.bazel
@@ -8,8 +8,12 @@ py_library(
         "@pypi//authlib",
         "@pypi//fastmcp",
         "@pypi//httpx",
+        "@pypi//mcp",
+        "@pypi//prometheus_client",
         "@pypi//py_key_value_aio",
         "@pypi//pydantic",
+        "@pypi//starlette",
+        "@pypi//tenacity",
     ],
 )
 
@@ -30,9 +34,15 @@ py_test(
         ":auth",
         ":conftest",
         "@pypi//authlib",
+        "@pypi//fastmcp",
+        "@pypi//httpx",
+        "@pypi//mcp",
+        "@pypi//prometheus_client",
         "@pypi//py_key_value_aio",
         "@pypi//pytest",
         "@pypi//pytest_asyncio",
         "@pypi//pytest_bazel",
+        "@pypi//starlette",
+        "@pypi//tenacity",
     ],
 )

--- a/mcp_infra/authentik_auth/auth.py
+++ b/mcp_infra/authentik_auth/auth.py
@@ -38,10 +38,17 @@ from fastmcp.server.auth.oidc_proxy import OIDCProxy
 from fastmcp.server.auth.providers.jwt import JWTVerifier
 from fastmcp.server.dependencies import get_access_token
 from key_value.aio.protocols import AsyncKeyValue
+from mcp.server.auth.provider import TokenError
+from prometheus_client import Counter
 from pydantic import BaseModel, ConfigDict, Field
+from starlette.exceptions import HTTPException
+from tenacity import AsyncRetrying, before_sleep_log, retry_if_exception, stop_after_attempt, wait_exponential
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
+
+    from mcp.server.auth.provider import RefreshToken
+    from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
 
 logger = logging.getLogger(__name__)
 
@@ -112,6 +119,81 @@ class AuthentikAuthConfig(BaseModel):
         return urlunparse(parsed._replace(path=f"{prefix}{marker}token/"))
 
 
+# ── Resilient refresh proxy ───────────────────────────────────────────────
+
+UPSTREAM_REFRESH_FAILURES = Counter(
+    "mcp_auth_upstream_refresh_failures_total",
+    "MCP client token refreshes that failed at the upstream Authentik token endpoint",
+    ["outcome"],  # transient (upstream unreachable/5xx) | oauth (real OAuth error response)
+)
+
+_RETRY_AFTER_SECONDS = 60
+
+
+def _transient_upstream_error(exc: BaseException | None) -> bool:
+    """True for upstream failures that say nothing about the grant's validity."""
+    if isinstance(exc, httpx.TransportError):  # DNS, connect, timeout, protocol errors
+        return True
+    return isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code >= 500
+
+
+def _is_transient_token_error(exc: BaseException) -> bool:
+    return isinstance(exc, TokenError) and _transient_upstream_error(exc.__cause__)
+
+
+class ResilientOIDCProxy(OIDCProxy):
+    """OIDCProxy that doesn't convert transient upstream failures into invalid_grant.
+
+    Stock fastmcp (3.1.0, oauth_proxy/proxy.py `exchange_refresh_token`) wraps the
+    upstream refresh call in a blanket `except Exception` and raises
+    `TokenError("invalid_grant")`. Per RFC 6749 §5.2, invalid_grant tells the client
+    its refresh token is revoked — claude.ai correctly treats it as terminal, flips
+    the connector to "Reconnect", and never retries. A single Authentik restart
+    (503) or DNS blip therefore permanently killed connectors
+    (see debug/2026_06_claude_ai_connector_deauth.md).
+
+    This subclass retries transient upstream failures briefly, and if they persist
+    answers HTTP 503 + Retry-After (via Starlette's default HTTPException handler)
+    instead of invalid_grant. Genuine upstream OAuth error responses (Authentik
+    actually rejecting the grant) still surface as invalid_grant.
+
+    Detection relies on fastmcp raising its TokenError `from` the original httpx
+    exception — pinned by test_auth.py against the vendored fastmcp version.
+    """
+
+    # Short on purpose: retries only bridge sub-second blips; longer outages are
+    # answered with 503 so the client may retry. Class attrs so tests can drop
+    # the wait.
+    refresh_retry_stop = stop_after_attempt(3)
+    refresh_retry_wait = wait_exponential(multiplier=0.5, max=2)
+
+    async def exchange_refresh_token(
+        self, client: OAuthClientInformationFull, refresh_token: RefreshToken, scopes: list[str]
+    ) -> OAuthToken:
+        try:
+            async for attempt in AsyncRetrying(
+                retry=retry_if_exception(_is_transient_token_error),
+                stop=self.refresh_retry_stop,
+                wait=self.refresh_retry_wait,
+                before_sleep=before_sleep_log(logger, logging.WARNING),
+                reraise=True,
+            ):
+                with attempt:
+                    return await super().exchange_refresh_token(client, refresh_token, scopes)
+        except TokenError as e:
+            if _is_transient_token_error(e):
+                UPSTREAM_REFRESH_FAILURES.labels(outcome="transient").inc()
+                logger.exception("Upstream auth server unavailable during token refresh")
+                raise HTTPException(
+                    status_code=503,
+                    detail="Upstream authorization server temporarily unavailable; retry later.",
+                    headers={"Retry-After": str(_RETRY_AFTER_SECONDS)},
+                ) from e.__cause__
+            UPSTREAM_REFRESH_FAILURES.labels(outcome="oauth").inc()
+            raise
+        raise AssertionError("unreachable")  # the retry loop always returns or raises
+
+
 # ── Auth builder ──────────────────────────────────────────────────────────
 
 
@@ -145,7 +227,7 @@ def build_authentik_auth(
     config_url = f"{issuer}/.well-known/openid-configuration"
     discovery = httpx.get(config_url, timeout=10.0).raise_for_status().json()
     jwks_uri = discovery["jwks_uri"]
-    proxy = OIDCProxy(
+    proxy = ResilientOIDCProxy(
         config_url=config_url,
         client_id=config.oidc_client_id,
         client_secret=config.oidc_client_secret,

--- a/mcp_infra/authentik_auth/test_auth.py
+++ b/mcp_infra/authentik_auth/test_auth.py
@@ -1,21 +1,29 @@
-"""Tests for AuthentikAuthConfig and AuthentikExchangeAuth."""
+"""Tests for AuthentikAuthConfig, AuthentikExchangeAuth, and ResilientOIDCProxy."""
 
 from __future__ import annotations
 
 import time
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, patch
 
+import httpx
 import pytest
 import pytest_bazel
 from authlib.oauth2.rfc6749.wrappers import OAuth2Token
+from fastmcp.server.auth.auth import TokenVerifier
+from fastmcp.server.auth.oidc_proxy import OIDCProxy
 from key_value.aio.stores.memory import MemoryStore
+from mcp.server.auth.provider import TokenError
+from prometheus_client import REGISTRY
+from starlette.exceptions import HTTPException
+from tenacity import wait_none
 
 from mcp_infra.authentik_auth.auth import (
     _EXCHANGE_TOKEN_COLLECTION,
     _EXPIRY_LEEWAY,
     AuthentikAuthConfig,
     AuthentikExchangeAuth,
+    ResilientOIDCProxy,
     _cache_key,
     build_authentik_auth,
 )
@@ -94,7 +102,7 @@ def test_build_authentik_auth_uses_jwks_uri_from_discovery() -> None:
 
     with (
         patch("mcp_infra.authentik_auth.auth.httpx.get", return_value=discovery_response) as http_get,
-        patch("mcp_infra.authentik_auth.auth.OIDCProxy") as oidc_proxy_cls,
+        patch("mcp_infra.authentik_auth.auth.ResilientOIDCProxy") as oidc_proxy_cls,
         patch("mcp_infra.authentik_auth.auth.JWTVerifier") as jwt_verifier_cls,
         patch("mcp_infra.authentik_auth.auth.MultiAuth"),
     ):
@@ -124,7 +132,7 @@ def test_build_authentik_auth_accepts_issuer_with_trailing_slash() -> None:
 
     with (
         patch("mcp_infra.authentik_auth.auth.httpx.get", return_value=discovery_response),
-        patch("mcp_infra.authentik_auth.auth.OIDCProxy") as oidc_proxy_cls,
+        patch("mcp_infra.authentik_auth.auth.ResilientOIDCProxy") as oidc_proxy_cls,
         patch("mcp_infra.authentik_auth.auth.JWTVerifier") as jwt_verifier_cls,
         patch("mcp_infra.authentik_auth.auth.MultiAuth"),
     ):
@@ -150,7 +158,7 @@ def test_build_authentik_auth_includes_extra_jwt_issuers() -> None:
     )
     with (
         patch("mcp_infra.authentik_auth.auth.httpx.get", return_value=discovery_response),
-        patch("mcp_infra.authentik_auth.auth.OIDCProxy") as oidc_proxy_cls,
+        patch("mcp_infra.authentik_auth.auth.ResilientOIDCProxy") as oidc_proxy_cls,
         patch("mcp_infra.authentik_auth.auth.JWTVerifier") as jwt_verifier_cls,
         patch("mcp_infra.authentik_auth.auth.MultiAuth"),
     ):
@@ -172,10 +180,10 @@ def test_build_authentik_auth_appends_extra_verifiers() -> None:
     discovery_response.raise_for_status = lambda: discovery_response
     discovery_response.json = lambda: {"jwks_uri": "https://auth.example.com/application/o/test/jwks/"}
 
-    sentinel = object()
+    sentinel = cast("TokenVerifier", object())
     with (
         patch("mcp_infra.authentik_auth.auth.httpx.get", return_value=discovery_response),
-        patch("mcp_infra.authentik_auth.auth.OIDCProxy") as oidc_proxy_cls,
+        patch("mcp_infra.authentik_auth.auth.ResilientOIDCProxy") as oidc_proxy_cls,
         patch("mcp_infra.authentik_auth.auth.JWTVerifier") as jwt_verifier_cls,
         patch("mcp_infra.authentik_auth.auth.MultiAuth") as multi_auth_cls,
     ):
@@ -355,6 +363,106 @@ async def test_exchange_auth_works_without_store() -> None:
         assert fetch.call_count == 1
 
     await auth.aclose()
+
+
+# ── ResilientOIDCProxy tests ──────────────────────────────────────────────
+#
+# These pin the load-bearing assumption that fastmcp's OAuthProxy raises its
+# blanket TokenError("invalid_grant") `from` the original httpx exception
+# (fastmcp 3.1.0 oauth_proxy/proxy.py exchange_refresh_token) — and that our
+# subclass reclassifies transient upstream failures instead of surfacing the
+# terminal invalid_grant that makes claude.ai permanently drop the connector.
+
+
+@pytest.fixture
+def proxy(monkeypatch: pytest.MonkeyPatch) -> ResilientOIDCProxy:
+    # exchange_refresh_token (the code under test) only calls super() and module
+    # globals; OIDCProxy.__init__ would fetch the OIDC discovery URL over the
+    # network, so skip it. No waiting between retries in tests.
+    monkeypatch.setattr(ResilientOIDCProxy, "refresh_retry_wait", wait_none())
+    return object.__new__(ResilientOIDCProxy)
+
+
+def _invalid_grant_from(cause: BaseException | None) -> TokenError:
+    # TokenError is a frozen dataclass — __cause__ can't be assigned directly.
+    # `raise ... from` sets it at the interpreter level, exactly like fastmcp does.
+    try:
+        raise TokenError("invalid_grant", "Upstream refresh failed: boom") from cause
+    except TokenError as raised:
+        return raised
+
+
+def _http_error(status: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "https://auth.example.com/application/o/token/")
+    return httpx.HTTPStatusError(f"HTTP {status}", request=request, response=httpx.Response(status, request=request))
+
+
+def _failures(outcome: str) -> float:
+    return REGISTRY.get_sample_value("mcp_auth_upstream_refresh_failures_total", {"outcome": outcome}) or 0.0
+
+
+async def test_resilient_proxy_transient_5xx_becomes_503(proxy: ResilientOIDCProxy) -> None:
+    """Authentik down (gateway 503) must NOT surface as invalid_grant."""
+    before = _failures("transient")
+    with (
+        patch.object(
+            OIDCProxy, "exchange_refresh_token", AsyncMock(side_effect=_invalid_grant_from(_http_error(503)))
+        ) as upstream,
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await proxy.exchange_refresh_token(AsyncMock(), AsyncMock(), [])
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.headers is not None
+    assert "Retry-After" in exc_info.value.headers
+    assert upstream.call_count == 3  # stop_after_attempt(3)
+    assert _failures("transient") == before + 1
+
+
+async def test_resilient_proxy_dns_failure_becomes_503(proxy: ResilientOIDCProxy) -> None:
+    """DNS resolution failure (cluster DNS outage) is transient, not invalid_grant."""
+    dns_error = httpx.ConnectError("[Errno -3] Temporary failure in name resolution")
+    with (
+        patch.object(OIDCProxy, "exchange_refresh_token", AsyncMock(side_effect=_invalid_grant_from(dns_error))),
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await proxy.exchange_refresh_token(AsyncMock(), AsyncMock(), [])
+    assert exc_info.value.status_code == 503
+
+
+async def test_resilient_proxy_retries_then_succeeds(proxy: ResilientOIDCProxy) -> None:
+    """A blip on the first attempt is absorbed by the in-process retry."""
+    token = object()
+    with patch.object(
+        OIDCProxy, "exchange_refresh_token", AsyncMock(side_effect=[_invalid_grant_from(_http_error(503)), token])
+    ) as upstream:
+        assert await proxy.exchange_refresh_token(AsyncMock(), AsyncMock(), []) is token
+    assert upstream.call_count == 2
+
+
+async def test_resilient_proxy_genuine_oauth_error_stays_invalid_grant(proxy: ResilientOIDCProxy) -> None:
+    """Authentik actually rejecting the grant (4xx OAuth error response) must
+    still surface as invalid_grant so the client knows to re-authenticate."""
+    before = _failures("oauth")
+    with (
+        patch.object(
+            OIDCProxy, "exchange_refresh_token", AsyncMock(side_effect=_invalid_grant_from(_http_error(400)))
+        ) as upstream,
+        pytest.raises(TokenError),
+    ):
+        await proxy.exchange_refresh_token(AsyncMock(), AsyncMock(), [])
+    assert upstream.call_count == 1  # no retry for genuine rejections
+    assert _failures("oauth") == before + 1
+
+
+async def test_resilient_proxy_local_token_errors_pass_through(proxy: ResilientOIDCProxy) -> None:
+    """TokenErrors with no upstream cause (unknown refresh token, missing JTI
+    mapping) are genuine invalid_grant — re-raised untouched, no retry."""
+    with (
+        patch.object(OIDCProxy, "exchange_refresh_token", AsyncMock(side_effect=_invalid_grant_from(None))) as upstream,
+        pytest.raises(TokenError),
+    ):
+        await proxy.exchange_refresh_token(AsyncMock(), AsyncMock(), [])
+    assert upstream.call_count == 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Root cause (full RCA in `debug/2026_06_claude_ai_connector_deauth.md`)

Recurring claude.ai "Reconnect" on self-hosted MCP connectors, proven from Loki + valkey state + fastmcp source:

1. **authentik-server restarts constantly** — its `/-/health/live/` returns 500 whenever PostgreSQL is briefly unreachable (CNPG failover, node churn, CoreDNS blips), so kubelet liveness-kills a healthy server; each reboot ≈ 90 s of `auth.allegedly.works` 503s.
2. **fastmcp 3.1.0 `OAuthProxy.exchange_refresh_token`** blanket-maps any upstream refresh failure (503, DNS error) to `invalid_grant`.
3. **claude.ai treats one `invalid_grant` as terminal** (correct per RFC 6749) — connector flips to Reconnect and is never retried. Five kill events in June (06-11/20/22/24/28), several connectors in the same second.

## Changes

- **`ResilientOIDCProxy`** (`mcp_infra/authentik_auth`, used by all facades + grocy MCPs): retries transient upstream refresh failures (tenacity, 3 attempts) and answers **503 + Retry-After** if they persist; genuine upstream OAuth rejections still surface as `invalid_grant`. Pinned by tests against the frozen-dataclass `TokenError` + `raise ... from` behavior of the vendored fastmcp.
- **Alerting**: `mcp_auth_upstream_refresh_failures_total{outcome}` counter; metrics ports + CNP scrape rules + `servicemonitor/` flux kustomizations (repo convention) for manifold/postscanmail/plaid-db facades and both grocy MCP servers; central `McpUpstreamTokenRefreshFailed` PrometheusRule.
- **Authentik liveness relaxed** (`failureThreshold: 8`, `periodSeconds: 15`): rides out ~2 min DB blips instead of converting them into 90 s reboots. Readiness untouched.

## Verified

- `bbr test //mcp_infra/... //grocy_mcp/... //cluster/validation/...` green (the `.live`-tagged exec roundtrip is CI-excluded, unrelated).
- New unit tests: transient 5xx → 503, DNS error → 503, retry-then-success, genuine OAuth 4xx stays `invalid_grant`, local token errors pass through.

## Not in this PR

- `server.replicas: 2` for authentik — clean to enable (anti-affinity already set, node memory headroom is ample; the "too tight" comment is stale), but both replicas share the DB so the probe fix above is the higher-leverage change. Bundled single-replica redis is the remaining SPOF (existing TODO).
- Upstreaming the error-mapping fix to fastmcp.
- Dead connectors still need a manual Reconnect click in claude.ai settings.