### PR TITLE
mcp/authentik: review follow-ups for #2743 (oauth-outcome metric precision, grocy metrics bind addr)

### DIFF
--- a/grocy_mcp/server.py
+++ b/grocy_mcp/server.py
@@ -137,7 +137,7 @@ def main() -> None:
     app = mcp.http_app(path="/mcp")
     # Metrics (incl. mcp_auth_upstream_refresh_failures_total) on a dedicated
     # cluster-internal port, off the public HTTPRoute.
-    start_http_server(settings.metrics_port)
+    start_http_server(settings.metrics_port, addr=settings.host)
     logger.info("grocy-mcp listening on %s:%d, metrics on :%d", settings.host, settings.port, settings.metrics_port)
     uvicorn.run(app, host=settings.host, port=settings.port, log_level="info")
 

--- a/mcp_infra/authentik_auth/auth.py
+++ b/mcp_infra/authentik_auth/auth.py
@@ -31,6 +31,7 @@ from urllib.parse import urlparse, urlunparse
 
 import httpx
 from authlib.integrations.httpx_client import AsyncOAuth2Client
+from authlib.oauth2 import OAuth2Error
 from authlib.oauth2.rfc6749.wrappers import OAuth2Token
 from fastmcp.server.auth import MultiAuth
 from fastmcp.server.auth.auth import AuthProvider, TokenVerifier
@@ -141,6 +142,18 @@ def _is_transient_token_error(exc: BaseException) -> bool:
     return isinstance(exc, TokenError) and _transient_upstream_error(exc.__cause__)
 
 
+def _upstream_oauth_rejection(exc: BaseException | None) -> bool:
+    """True when Authentik itself answered the refresh with an OAuth rejection.
+
+    authlib raises OAuth2Error subclasses for error-body responses; a
+    non-5xx HTTPStatusError is an upstream rejection without a parseable
+    body. TokenErrors with any other cause (or none) are local — unknown
+    refresh token, missing JTI mapping — i.e. normal client churn that never
+    reached Authentik, and must not fire the upstream-failure alert.
+    """
+    return isinstance(exc, OAuth2Error | httpx.HTTPStatusError)
+
+
 class ResilientOIDCProxy(OIDCProxy):
     """OIDCProxy that doesn't convert transient upstream failures into invalid_grant.
 
@@ -189,7 +202,8 @@ class ResilientOIDCProxy(OIDCProxy):
                     detail="Upstream authorization server temporarily unavailable; retry later.",
                     headers={"Retry-After": str(_RETRY_AFTER_SECONDS)},
                 ) from e.__cause__
-            UPSTREAM_REFRESH_FAILURES.labels(outcome="oauth").inc()
+            if _upstream_oauth_rejection(e.__cause__):
+                UPSTREAM_REFRESH_FAILURES.labels(outcome="oauth").inc()
             raise
         raise AssertionError("unreachable")  # the retry loop always returns or raises
 

--- a/mcp_infra/authentik_auth/test_auth.py
+++ b/mcp_infra/authentik_auth/test_auth.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, patch
 import httpx
 import pytest
 import pytest_bazel
+from authlib.oauth2 import OAuth2Error
 from authlib.oauth2.rfc6749.wrappers import OAuth2Token
 from fastmcp.server.auth.auth import TokenVerifier
 from fastmcp.server.auth.oidc_proxy import OIDCProxy
@@ -439,13 +440,20 @@ async def test_resilient_proxy_retries_then_succeeds(proxy: ResilientOIDCProxy) 
     assert upstream.call_count == 2
 
 
-async def test_resilient_proxy_genuine_oauth_error_stays_invalid_grant(proxy: ResilientOIDCProxy) -> None:
-    """Authentik actually rejecting the grant (4xx OAuth error response) must
+@pytest.mark.parametrize(
+    "upstream_rejection",
+    [_http_error(400), OAuth2Error(description="Token is invalid or expired")],
+    ids=["http-4xx", "authlib-oauth2error"],
+)
+async def test_resilient_proxy_genuine_oauth_error_stays_invalid_grant(
+    proxy: ResilientOIDCProxy, upstream_rejection: Exception
+) -> None:
+    """Authentik actually rejecting the grant (4xx / OAuth error response) must
     still surface as invalid_grant so the client knows to re-authenticate."""
     before = _failures("oauth")
     with (
         patch.object(
-            OIDCProxy, "exchange_refresh_token", AsyncMock(side_effect=_invalid_grant_from(_http_error(400)))
+            OIDCProxy, "exchange_refresh_token", AsyncMock(side_effect=_invalid_grant_from(upstream_rejection))
         ) as upstream,
         pytest.raises(TokenError),
     ):
@@ -456,13 +464,16 @@ async def test_resilient_proxy_genuine_oauth_error_stays_invalid_grant(proxy: Re
 
 async def test_resilient_proxy_local_token_errors_pass_through(proxy: ResilientOIDCProxy) -> None:
     """TokenErrors with no upstream cause (unknown refresh token, missing JTI
-    mapping) are genuine invalid_grant — re-raised untouched, no retry."""
+    mapping) are local invalid_grant — re-raised untouched, no retry, and NOT
+    counted as an upstream failure (they'd false-fire the alert)."""
+    before = _failures("oauth")
     with (
         patch.object(OIDCProxy, "exchange_refresh_token", AsyncMock(side_effect=_invalid_grant_from(None))) as upstream,
         pytest.raises(TokenError),
     ):
         await proxy.exchange_refresh_token(AsyncMock(), AsyncMock(), [])
     assert upstream.call_count == 1
+    assert _failures("oauth") == before  # local churn never reached Authentik
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to #2743, which was merged while these review fixes were in flight (addresses both Copilot comments):

- `outcome="oauth"` on `mcp_auth_upstream_refresh_failures_total` now increments only when the cause is a genuine upstream rejection (authlib `OAuth2Error` or non-5xx `HTTPStatusError`). Local `TokenError`s — unknown refresh token, missing JTI mapping, i.e. normal client churn that never reached Authentik — are re-raised uncounted, so they can't false-fire `McpUpstreamTokenRefreshFailed` with "Authentik rejected a grant" text.
- grocy-mcp's Prometheus `start_http_server` now binds to `settings.host` instead of unconditionally `0.0.0.0`.

Tests: `bbr test //mcp_infra/authentik_auth:test_auth //grocy_mcp:test_server` green; local-token-error test now asserts no counter increment, and the genuine-rejection test is parameterized over HTTP-4xx and authlib `OAuth2Error` causes.