### PR TITLE
haku mailbox: exec a cap-less copy of the stalwart binary (fixes the crashloop)

### DIFF
--- a/cluster/k8s/haku/mailbox/app/bootstrap-and-run.sh
+++ b/cluster/k8s/haku/mailbox/app/bootstrap-and-run.sh
@@ -40,7 +40,10 @@ fail() {
   {
     echo "$1"
     echo "--- recovery server log (tail) ---"
-    tail -c 1600 "$RUN/recovery.log"
+    # Non-fatal + explicit newline: a tail failure or a cut-off last line must
+    # not truncate the failure report this function exists to emit.
+    tail -c 1600 "$RUN/recovery.log" || true
+    echo
   } >&2
   exit 1
 }
@@ -57,7 +60,8 @@ until stalwart-cli apply --file "$RUN/plan.ndjson" --quiet >"$RUN/apply.log" 2>&
   if [ "$tries" -ge 30 ]; then
     {
       echo "--- last apply output (tail) ---"
-      tail -c 400 "$RUN/apply.log"
+      tail -c 400 "$RUN/apply.log" || true
+      echo
     } >&2
     fail "provisioning apply did not succeed after ${tries} attempts"
   fi

--- a/cluster/k8s/haku/mailbox/app/bootstrap-and-run.sh
+++ b/cluster/k8s/haku/mailbox/app/bootstrap-and-run.sh
@@ -15,6 +15,14 @@ mkdir -p "$RUN"
 # stalwart-cli caches the server schema under $HOME.
 export HOME="$RUN"
 
+# The upstream image setcaps cap_net_bind_service on the server binary (for
+# :25/:443 as non-root). Under this pod's no-new-privs securityContext
+# (allowPrivilegeEscalation: false) the kernel refuses to exec ANY
+# capability-bearing file — EPERM before main() ("Operation not permitted").
+# We bind only unprivileged ports (2525/8080), so run a cap-less copy: cp
+# does not preserve the security.capability xattr.
+cp /usr/local/bin/stalwart "$RUN/stalwart"
+
 # JSON-escape a PEM file as a single \n-joined line. The PEM alphabet
 # (base64 + header dashes/spaces) contains no character that needs further
 # JSON escaping and none special to the sed replacement below. awk emits
@@ -33,7 +41,7 @@ sed -e "s|@@TLS_CERT@@|$(pem_json /tls/tls.crt)|" \
 # (pods/log here is operator-only; that tail is the agent-visible channel).
 STALWART_RECOVERY_MODE=1 \
   STALWART_RECOVERY_ADMIN="admin:${STALWART_ADMIN_PASSWORD}" \
-  stalwart --config /etc/stalwart/config.json >"$RUN/recovery.log" 2>&1 &
+  "$RUN/stalwart" --config /etc/stalwart/config.json >"$RUN/recovery.log" 2>&1 &
 recovery_pid=$!
 
 fail() {
@@ -74,4 +82,4 @@ kill "$recovery_pid"
 wait "$recovery_pid" || true
 rm -f "$RUN/plan.ndjson"
 
-exec stalwart --config /etc/stalwart/config.json
+exec "$RUN/stalwart" --config /etc/stalwart/config.json


### PR DESCRIPTION
Root-cause fix for the stalwart pod crashloop, diagnosed via the terminationMessage channel built in #2745/#2746:

```text
recovery server exited before provisioning completed
--- recovery server log (tail) ---
/etc/stalwart/bootstrap-and-run.sh: 34: stalwart: Operation not permitted
```

## Root cause

The upstream image runs `setcap 'cap_net_bind_service=+ep' /usr/local/bin/stalwart` (so stock deployments can bind :25/:443 as non-root). Our pod sets `allowPrivilegeEscalation: false`, i.e. no-new-privs — and the kernel refuses to `exec` **any** capability-bearing file under no-new-privs, failing with EPERM before `main()` ever runs. (The `stalwart-cli` binary works because the Bazel `pkg_tar` layer carries no xattrs.)

## Fix

Our listeners are unprivileged (2525/8080), so the file capability is useless here: the wrapper copies the binary at startup (`cp` drops the `security.capability` xattr) and execs the copy — both for the recovery phase and the final server. The strict securityContext stays exactly as is.

Also includes the post-merge Copilot follow-ups to #2746 (failure-report `tail`s get explicit newlines and `|| true`).

## Rollout

ConfigMap is hash-suffixed → pod rolls on reconcile. After this the bootstrap should get past exec; any remaining `stalwart-cli apply` schema issues will now be legible in the termination message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQEcV7Uoc7vzq34JA5oBha

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQEcV7Uoc7vzq34JA5oBha)_