### PR TITLE
haku mailbox: File-reference the TLS cert; drop plan templating

### DIFF
--- a/cluster/k8s/haku/mailbox/README.md
+++ b/cluster/k8s/haku/mailbox/README.md
@@ -20,20 +20,20 @@ deliberately tiny (its documented declarative-deployments workflow):
 - `app/config.json` — the DataStore object only (Postgres via the
   CNPG-generated `haku-mailbox-db-app` credentials; password injected as an
   env var).
-- `app/mailbox-plan.ndjson.tmpl` — everything else, as an idempotent
+- `app/mailbox-plan.ndjson` — everything else, as an idempotent
   `stalwart-cli apply` plan of `upsert`s: domain, the `haku` account
   (pre-created so inbound RCPT resolves before first login — required for
   OIDC directories), the Authentik OIDC directory, the DMARC-gated
   whitelist Sieve script wired to the SMTP DATA stage, the two listeners
-  (SMTP :2525 STARTTLS, HTTP :8080), and the TLS certificate (PEM pushed
-  from the cert-manager secret). The certificate upsert matches on the PEM
-  itself: a cert-manager renewal creates a fresh Certificate object and
-  repoints `defaultCertificateId`; superseded cert objects accumulate
-  (one per ~60-day renewal) — harmless.
-- `app/bootstrap-and-run.sh` — pod entrypoint: renders the plan (cert PEMs),
-  applies it against a temporary recovery-mode instance, then execs the
-  normal server. Every pod start reconciles config; the reloader annotation
-  makes cert-manager renewals trigger exactly such a restart.
+  (SMTP :2525 STARTTLS, HTTP :8080), and the TLS certificate. The
+  certificate is a `File` reference to the mounted cert-manager secret
+  (`/tls/tls.{crt,key}`), so the plan is fully static and the upsert is
+  idempotent across renewals — a renewal just restarts the pod (reloader)
+  and the server re-reads the PEMs.
+- `app/bootstrap-and-run.sh` — pod entrypoint: applies the plan against a
+  temporary recovery-mode instance, then execs the normal server. Every pod
+  start reconciles config; the reloader annotation makes cert-manager
+  renewals trigger exactly such a restart.
 - The pod image is the in-repo repack from `image/BUILD.bazel` — upstream
   server + the pinned static `stalwart-cli` (upstream ships the CLI only as
   a distroless image, unusable from the pod). Published as
@@ -108,6 +108,4 @@ schema drifts.
   `MtaStageData`, the `Authentication`/`SystemSettings` singletons, and
   `Certificate` (as of 2026-07, `flungo/stalwart` v0.1.0 covers
   accounts/domains/directories/listeners only); (b) upstream grows a
-  file-based/declarative bootstrap; (c) if only the cert-push half hurts,
-  Stalwart-native ACME (`AcmeProvider` + Route 53 DNS-01) can delete the PEM
-  templating at the cost of the cert-manager convention.
+  file-based/declarative bootstrap.

--- a/cluster/k8s/haku/mailbox/app/bootstrap-and-run.sh
+++ b/cluster/k8s/haku/mailbox/app/bootstrap-and-run.sh
@@ -1,13 +1,14 @@
 #!/bin/sh
-# Startup wrapper for the Stalwart mailserver: render the provisioning plan,
-# apply it against a temporary recovery-mode instance (idempotent upserts, per
+# Startup wrapper for the Stalwart mailserver: apply the provisioning plan
+# against a temporary recovery-mode instance (idempotent upserts, per
 # Stalwart's declarative-deployments workflow), then exec the normal server.
 # TODO: this dance is ugly but currently irreducible — see the README's
 # "Future" section for the revisit gates (tofu provider coverage, upstream
 # declarative bootstrap, native ACME).
-# Running on every pod start makes the plan the reconcile loop — a
+# Running on every pod start makes the plan the reconcile loop. The TLS
+# certificate is File-referenced (/tls/*.pem paths in the plan), so a
 # reloader-triggered restart after cert-manager renews mx-allegedly-works-tls
-# re-pushes the fresh certificate.
+# simply re-reads the fresh PEMs — no plan change involved.
 set -eu
 
 RUN=/tmp/stalwart-run
@@ -22,19 +23,6 @@ export HOME="$RUN"
 # We bind only unprivileged ports (2525/8080), so run a cap-less copy: cp
 # does not preserve the security.capability xattr.
 cp /usr/local/bin/stalwart "$RUN/stalwart"
-
-# JSON-escape a PEM file as a single \n-joined line. The PEM alphabet
-# (base64 + header dashes/spaces) contains no character that needs further
-# JSON escaping and none special to the sed replacement below. awk emits
-# doubled backslashes because GNU sed collapses \\ -> \ in the replacement
-# (a single \n there would become a real newline and break the NDJSON).
-pem_json() {
-  awk 'BEGIN { ORS = "\\\\n" } { print }' "$1"
-}
-
-sed -e "s|@@TLS_CERT@@|$(pem_json /tls/tls.crt)|" \
-  -e "s|@@TLS_KEY@@|$(pem_json /tls/tls.key)|" \
-  /etc/stalwart/mailbox-plan.ndjson.tmpl >"$RUN/plan.ndjson"
 
 # The recovery server's output goes to a file, not straight to stdout: on
 # failure it is printed LAST so it survives the 2KiB terminationMessage tail
@@ -62,7 +50,7 @@ export STALWART_URL=http://127.0.0.1:8080
 export STALWART_USER=admin
 export STALWART_PASSWORD="${STALWART_ADMIN_PASSWORD}"
 tries=0
-until stalwart-cli apply --file "$RUN/plan.ndjson" --quiet >"$RUN/apply.log" 2>&1; do
+until stalwart-cli apply --file /etc/stalwart/mailbox-plan.ndjson --quiet >"$RUN/apply.log" 2>&1; do
   kill -0 "$recovery_pid" 2>/dev/null || fail "recovery server exited before provisioning completed"
   tries=$((tries + 1))
   if [ "$tries" -ge 30 ]; then
@@ -80,6 +68,5 @@ unset STALWART_URL STALWART_USER STALWART_PASSWORD
 
 kill "$recovery_pid"
 wait "$recovery_pid" || true
-rm -f "$RUN/plan.ndjson"
 
 exec "$RUN/stalwart" --config /etc/stalwart/config.json

--- a/cluster/k8s/haku/mailbox/app/kustomization.yaml
+++ b/cluster/k8s/haku/mailbox/app/kustomization.yaml
@@ -25,5 +25,5 @@ configMapGenerator:
         kustomize.toolkit.fluxcd.io/substitute: disabled
     files:
       - config.json
-      - mailbox-plan.ndjson.tmpl
+      - mailbox-plan.ndjson
       - bootstrap-and-run.sh

--- a/cluster/k8s/haku/mailbox/app/mailbox-plan.ndjson
+++ b/cluster/k8s/haku/mailbox/app/mailbox-plan.ndjson
@@ -1,4 +1,4 @@
-{"@type":"upsert","object":"Certificate","matchOn":["certificate"],"value":{"cert-mx":{"certificate":"@@TLS_CERT@@","privateKey":"@@TLS_KEY@@"}}}
+{"@type":"upsert","object":"Certificate","matchOn":["certificate"],"value":{"cert-mx":{"certificate":{"@type":"File","filePath":"/tls/tls.crt"},"privateKey":{"@type":"File","filePath":"/tls/tls.key"}}}}
 {"@type":"upsert","object":"Domain","matchOn":["name"],"value":{"dom":{"name":"allegedly.works","description":"Haku mailbox domain"}}}
 {"@type":"upsert","object":"Account","matchOn":["name"],"value":{"acct-haku":{"@type":"User","name":"haku","domainId":"#dom","description":"Haku background agent (auth: Authentik OIDC bearer only)"}}}
 {"@type":"upsert","object":"Directory","matchOn":["description"],"value":{"dir-authentik":{"@type":"Oidc","description":"Authentik (stalwart-haku provider)","issuerUrl":"https://auth.allegedly.works/application/o/stalwart-haku/","requireAudience":"stalwart-haku","requireScopes":["openid","email"],"claimUsername":"preferred_username","usernameDomain":"allegedly.works","claimName":"name"}}}


### PR DESCRIPTION
Next apply error after #2749, via the termination-message channel:

```text
✗ upsert Certificate: invalidPatch | Missing or invalid '@type' property in object | Properties: certificate
```

`Certificate.certificate`/`privateKey` are `PublicText`/`SecretText` — `@type`-tagged unions (`Text` / `EnvironmentVariable` / **`File`**), not plain strings. The `File` variant is strictly better than inlining PEMs:

- The plan's Certificate object now points at the mounted cert-manager secret: `{"@type":"File","filePath":"/tls/tls.crt"}` (+ key).
- The plan becomes a **fully static** NDJSON file — the `pem_json` awk-escaping + `sed` placeholder dance is deleted from `bootstrap-and-run.sh`, and `mailbox-plan.ndjson.tmpl` is renamed to `mailbox-plan.ndjson`.
- The certificate upsert is now idempotent across renewals: the File reference never changes, `matchOn` always matches, and a cert-manager renewal is just a reloader-triggered pod restart that re-reads the PEMs. (Supersedes #2749's object-accumulation caveat, which is removed from the README.)
- README: dropped the "native ACME to delete the PEM templating" revisit gate — there is no templating left.

Field encodings verified against `crates/registry/src/schema/structs.rs` at v0.16.11 (`PublicText`/`SecretText` enums, `SecretKeyFile.filePath`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQEcV7Uoc7vzq34JA5oBha

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQEcV7Uoc7vzq34JA5oBha)_