### PR TITLE
haku mailbox: fix stale wrapper header comments (review follow-up)

### DIFF
--- a/cluster/k8s/haku/mailbox/app/bootstrap-and-run.sh
+++ b/cluster/k8s/haku/mailbox/app/bootstrap-and-run.sh
@@ -4,9 +4,9 @@
 # Stalwart's declarative-deployments workflow), then exec the normal server.
 # TODO: this dance is ugly but currently irreducible — see the README's
 # "Future" section for the revisit gates (tofu provider coverage, upstream
-# declarative bootstrap, native ACME).
+# declarative bootstrap).
 # Running on every pod start makes the plan the reconcile loop. The TLS
-# certificate is File-referenced (/tls/*.pem paths in the plan), so a
+# certificate is File-referenced (/tls/tls.{crt,key} in the plan), so a
 # reloader-triggered restart after cert-manager renews mx-allegedly-works-tls
 # simply re-reads the fresh PEMs — no plan change involved.
 set -eu


### PR DESCRIPTION
Copilot review comments on #2750 that landed after auto-merge fired: the wrapper header still listed the removed native-ACME revisit gate and described the cert paths as `/tls/*.pem` instead of the actual `/tls/tls.{crt,key}`. Comment-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQEcV7Uoc7vzq34JA5oBha

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQEcV7Uoc7vzq34JA5oBha)_