### PR TITLE
x/agent_server/e2e: document why the browser E2E tests are manual/broken

### DIFF
--- a/x/agent_server/e2e/BUILD.bazel
+++ b/x/agent_server/e2e/BUILD.bazel
@@ -1,4 +1,19 @@
-# Agent server E2E tests (manual, require Playwright).
+# Agent server browser E2E tests. Tagged `manual` and NOT run in CI — they are
+# currently unrunnable there: agent_server has no Bazel-built served frontend
+# (`//x/agent_server/web:bundle` sets `index_html = None` and there is no
+# `server/static/`), so `create_app(require_static_assets=True)` can't serve the
+# UI these tests drive with Playwright. They only run locally against a
+# hand-built frontend + a locally-installed Playwright browser.
+#
+# TODO: make these runnable on RBE (mirror //x/study_casino/tests:test_e2e_browser):
+#   1. make `web:bundle` served-ready — `index_html = "index.html"` and convert
+#      web/index.html to the served form (`/main.js`, `#root`) without breaking
+#      the Vite dev server;
+#   2. add a static-dir override to `create_app` (like study_casino's
+#      `frontend_dist_dir`) and point it at the bundle via `//util/bazel:runfiles`;
+#   3. add `@playwright_browsers//:chromium-headless-shell` (+ CHROMIUM_HEADLESS_SHELL
+#      env) and `requires_docker = True`, then drop `manual`.
+# Until then these tests silently do not protect against regressions.
 
 load("//devinfra/python:defs.bzl", "py_library", "py_test")
 

--- a/x/agent_server/e2e/BUILD.bazel
+++ b/x/agent_server/e2e/BUILD.bazel
@@ -6,13 +6,15 @@
 # hand-built frontend + a locally-installed Playwright browser.
 #
 # TODO: make these runnable on RBE (mirror //x/study_casino/tests:test_e2e_browser):
-#   1. make `web:bundle` served-ready — `index_html = "index.html"` and convert
-#      web/index.html to the served form (`/main.js`, `#root`) without breaking
-#      the Vite dev server;
+#   1. make `web:bundle` served-ready — `index_html = "index.html"` and point the
+#      served index.html at the built entry `/main.js`, keeping the current `#app`
+#      mount target (see web/src/main.ts; study_casino uses `#root`), without
+#      breaking the Vite dev server;
 #   2. add a static-dir override to `create_app` (like study_casino's
 #      `frontend_dist_dir`) and point it at the bundle via `//util/bazel:runfiles`;
-#   3. add `@playwright_browsers//:chromium-headless-shell` (+ CHROMIUM_HEADLESS_SHELL
-#      env) and `requires_docker = True`, then drop `manual`.
+#   3. add `@playwright_browsers//:chromium-headless-shell` AND `web:bundle` to each
+#      test's `data` (so the `$(rootpath ...)` runfiles exist), set the
+#      `CHROMIUM_HEADLESS_SHELL` env, `requires_docker = True`, then drop `manual`.
 # Until then these tests silently do not protect against regressions.
 
 load("//devinfra/python:defs.bzl", "py_library", "py_test")

--- a/x/agent_server/e2e/test_abort.py
+++ b/x/agent_server/e2e/test_abort.py
@@ -1,3 +1,6 @@
+# TODO: unrunnable in CI — agent_server has no Bazel-built served frontend, so
+# this browser E2E test can't serve the UI on RBE. Tagged `manual`; runs locally
+# only. See BUILD.bazel for how to enable it.
 from __future__ import annotations
 
 import asyncio

--- a/x/agent_server/e2e/test_approvals.py
+++ b/x/agent_server/e2e/test_approvals.py
@@ -1,3 +1,6 @@
+# TODO: unrunnable in CI — agent_server has no Bazel-built served frontend, so
+# this browser E2E test can't serve the UI on RBE. Tagged `manual`; runs locally
+# only. See BUILD.bazel for how to enable it.
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/x/agent_server/e2e/test_proposals_reject.py
+++ b/x/agent_server/e2e/test_proposals_reject.py
@@ -1,3 +1,6 @@
+# TODO: unrunnable in CI — agent_server has no Bazel-built served frontend, so
+# this browser E2E test can't serve the UI on RBE. Tagged `manual`; runs locally
+# only. See BUILD.bazel for how to enable it.
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/x/agent_server/e2e/test_ui.py
+++ b/x/agent_server/e2e/test_ui.py
@@ -1,3 +1,6 @@
+# TODO: unrunnable in CI — agent_server has no Bazel-built served frontend, so
+# this browser E2E test can't serve the UI on RBE. Tagged `manual`; runs locally
+# only. See BUILD.bazel for how to enable it.
 from __future__ import annotations
 
 import pytest


### PR DESCRIPTION
Documents that the `x/agent_server/e2e` Playwright tests are knowingly parked, so they don't silently rot unnoticed.

These tests are tagged `manual` and don't run in CI — and can't, currently: agent_server has **no Bazel-built served frontend** (`//x/agent_server/web:bundle` sets `index_html = None`; there's no `server/static/`), so `create_app(require_static_assets=True)` can't serve the UI they drive with Playwright. They only ever ran on a dev machine with hand-built assets + a local browser, so they've stopped guarding against regressions without anyone noticing.

## Changes (comments only)

- **`e2e/BUILD.bazel` header**: explains why they're `manual`/unrunnable and gives the concrete steps to make them RBE-runnable (mirroring `//x/study_casino/tests:test_e2e_browser`): make `web:bundle` served-ready, add a `create_app` static-dir override, add `@playwright_browsers` + `requires_docker`, drop `manual`.
- **Each test file** (`test_abort`, `test_approvals`, `test_proposals_reject`, `test_ui`): a one-line TODO pointer at the top.

No code/behavior changes. Follow-up to #2741 (which excludes `manual` tests from CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjEYLNhipPWErzEqJk9D3s)_