### PR TITLE
ci: treat bazel test exit 4 (no tests after filtering) as benign

### DIFF
--- a/.github/workflows/bazel-ci.yml
+++ b/.github/workflows/bazel-ci.yml
@@ -162,8 +162,18 @@ jobs:
               bazel build --keep_going $RBE_FLAGS $TARGETS && \
                 probe_bb_runner after-build
             else
-              bazel test --keep_going $RBE_FLAGS $TARGETS && \
-                probe_bb_runner after-test && \
+              # `bazel test` still hard-fails with exit 4 ("no test targets were
+              # found") when every test in the affected set is filtered out by
+              # --test_tag_filters -- e.g. a PR that only touches `manual`-tagged
+              # tests. The TEST_TARGET_COUNT probe above counts test *rules* and
+              # can't see tag filters, so it can't pre-empt this. Treat exit 4 as
+              # benign (nothing to run) and still build.
+              test_rc=0
+              bazel test --keep_going $RBE_FLAGS $TARGETS || test_rc=$?
+              if [ "$test_rc" -ne 0 ] && [ "$test_rc" -ne 4 ]; then
+                exit "$test_rc"
+              fi
+              probe_bb_runner after-test && \
                 bazel build --keep_going $RBE_FLAGS $TARGETS && \
                 probe_bb_runner after-build
             fi


### PR DESCRIPTION
Follow-up to #2741 (exclude `manual` from CI).

## Problem

With `test_tag_filters=-manual`, a PR whose **entire** bazel-diff affected set is `manual`-tagged tests filters down to zero runnable tests, and `bazel test` hard-fails with exit 4 (`No test targets were found, yet testing was requested`). The existing `TEST_TARGET_COUNT` probe counts test *rules* via `bazel query tests(...)` and can't see tag filters, so it doesn't pre-empt this — the tests are counted, `bazel test` runs, and everything gets filtered out.

That's what fails #2752 (a comments-only PR touching only the `manual` e2e tests).

## Fix

Treat `bazel test` exit code 4 as benign in the affected-set path (nothing to run after filtering) and still run the build. Any other non-zero exit still fails.

Workflow-only change → no bazel targets affected, so this PR's own CI skips test/build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjEYLNhipPWErzEqJk9D3s)_