### PR TITLE
authentik-jwt-rotation: isolate per-entry failures

### DIFF
--- a/cluster/k8s/agents/authentik-jwt-rotation/rotate.py
+++ b/cluster/k8s/agents/authentik-jwt-rotation/rotate.py
@@ -352,13 +352,26 @@ def main(
     os.chdir(repo_dir)
     sparse_clone(config, github_pat)
 
+    # Isolate entries: one broken rotation must not starve the others (a bad
+    # entry otherwise stalls every token in the cluster until someone notices).
+    # Failures still fail the Job at the end, after healthy entries commit.
+    rotated: list[str] = []
+    failed: list[str] = []
     with httpx.Client(verify=str(ca_bundle), timeout=30) as client:
-        rotated = [r.name for r in config.rotations if rotate_one(client, r, config)]
+        for rotation in config.rotations:
+            try:
+                if rotate_one(client, rotation, config):
+                    rotated.append(rotation.name)
+            except Exception:
+                logger.exception("%s: rotation failed; continuing with remaining entries", rotation.name)
+                failed.append(rotation.name)
 
-    if not rotated:
+    if rotated:
+        commit_and_push(config, rotated)
+    else:
         logger.info("no rotations needed this cycle")
-        return
-    commit_and_push(config, rotated)
+    if failed:
+        raise SystemExit(f"rotations failed: {', '.join(failed)}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Found while checking why haku's mail JWT never minted: the `haku-mail` rotation entry (#2724) fails its mint on **every hourly run since 08:15 UTC** (first run after the merge; last successful cycle 07:15 UTC) — and because `rotate.py` fail-fasted on the first exception, it took **every other rotation in the cluster** down with it (`claude-web-k8s`, `haku-k8s`, grocy, alloy…). Nothing is on fire — tokens carry weeks of validity — but one bad entry silently freezing all credential rotation is the wrong blast radius.

## Change

Per-entry try/except in the main loop: log the traceback, continue, commit whatever succeeded, and fail the Job at the end naming the broken entries.

## Diagnostics side-effect (intentional)

The failed pods are deleted on `BackoffLimitExceeded`, and `agents-infra` `pods/log` is operator-only — so the actual haku-mail traceback has been unreadable from agent sessions. After this lands, the next scheduled run rotates everything else normally **and** its log carries the haku-mail traceback for diagnosis.

What's already ruled out for the haku-mail failure: tofu applied (provider/app/policy-binding exist, no drift), the credentials secret has the right keys and mount, the token endpoint recognizes `stalwart-haku` identically to the working provider (both `invalid_grant` on bogus creds), and the missing seed SOPS file is a handled case (fresh mint).

`bbr test //cluster/k8s/agents/authentik-jwt-rotation/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQEcV7Uoc7vzq34JA5oBha

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQEcV7Uoc7vzq34JA5oBha)_