### PR TITLE
haku dispatcher: fix image reference (dispatcher → haku-dispatcher)

### DIFF
--- a/cluster/k8s/haku/dispatch/dispatcher/deployment.yaml
+++ b/cluster/k8s/haku/dispatch/dispatcher/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: dispatcher
       containers:
         - name: dispatcher
-          image: ghcr.io/agentydragon/dispatcher:latest # {"$imagepolicy": "flux-system:dispatcher"}
+          image: ghcr.io/agentydragon/haku-dispatcher:latest # {"$imagepolicy": "flux-system:haku-dispatcher"}
           ports:
             - name: http
               containerPort: 8000


### PR DESCRIPTION
Post-#2761 rollout verification: the dependency-cycle fix worked — `litellm` rolled with its DB, the `litellm-keys` Terraform **Applied** (all keys minted), and **workers-LiteLLM is Running** in `haku-dispatch`. The one remaining red pod is the dispatcher, in `ErrImagePull`:

```text
failed to resolve reference "ghcr.io/agentydragon/dispatcher:latest": not found
```

The terminology rename overshot the deployment's image line — it pulls `ghcr.io/agentydragon/dispatcher`, but `push-images.yml` publishes **`haku-dispatcher`** (package exists on GHCR) and the Flux `ImageRepository`/`ImagePolicy` pair is also named `haku-dispatcher`. One-line fix to the image and its `$imagepolicy` marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDFQogCNq94uP7rdiYYBZg

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDFQogCNq94uP7rdiYYBZg)_