### PR TITLE
litellm: 4Gi memory limits on both instances (workers OOMKilled at 1Gi)

### DIFF
--- a/cluster/k8s/haku/dispatch/litellm/deployment.yaml
+++ b/cluster/k8s/haku/dispatch/litellm/deployment.yaml
@@ -87,10 +87,13 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 512Mi
+              memory: 1Gi
             limits:
               cpu: "1"
-              memory: 1Gi
+              # LiteLLM 1.90.2 with the virtual-key DB idles at ~1020Mi — the
+              # original 1Gi limit OOMKilled this pod at startup (operator:
+              # give it real headroom).
+              memory: 4Gi
           volumeMounts:
             - name: config
               mountPath: /etc/litellm

--- a/cluster/k8s/litellm/app/deployment.yaml
+++ b/cluster/k8s/litellm/app/deployment.yaml
@@ -166,6 +166,15 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 12
+          resources:
+            requests:
+              cpu: 100m
+              memory: 1Gi
+            limits:
+              cpu: "1"
+              # LiteLLM 1.90.2 with the virtual-key DB idles at ~1020Mi
+              # (measured); this deployment previously ran uncapped.
+              memory: 4Gi
           volumeMounts:
             - name: config
               mountPath: /etc/litellm


### PR DESCRIPTION
Second finding from post-#2761 rollout verification: `workers-litellm` crashloops with **exit 137 (OOMKilled)** ~50s after start.

Measurement: the main `litellm` instance — same image (`litellm/litellm:1.90.2`), same DB-backed config shape, running **without** resource limits — idles at **1020Mi** (`kubectl top`). The workers instance's 1Gi limit is below LiteLLM's actual working set, so the kernel kills it during startup every time.

Per operator direction (~4 GB): both instances get `requests: 1Gi` / `limits: 4Gi` — the workers-LiteLLM bumps from the fatal 1Gi, and the main instance gets its first cap (previously uncapped, i.e. one memory leak away from evicting neighbors).

With this + #2762 (image name), the dispatch-plane pods should converge: workers-litellm restarts under the new limit, dispatcher pulls `haku-dispatcher` once Flux applies the corrected image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDFQogCNq94uP7rdiYYBZg