### PR TITLE
haku-dispatch: agent logs/configmaps RoleBinding (rollout debugging)

### DIFF
--- a/cluster/k8s/haku/dispatch/agent-rbac/flux-kustomization.yaml
+++ b/cluster/k8s/haku/dispatch/agent-rbac/flux-kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: haku-dispatch-agent-rbac
+  namespace: flux-system
+  annotations:
+    description: Agent RBAC for haku-dispatch. Lightweight — only RoleBindings. Depends on namespace existing + agent RBAC base for ClusterRoles.
+spec:
+  interval: 10m
+  path: ./cluster/k8s/haku/dispatch/agent-rbac
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  dependsOn:
+    - name: haku-dispatch-namespace
+    - name: claude-rbac

--- a/cluster/k8s/haku/dispatch/agent-rbac/kustomization.yaml
+++ b/cluster/k8s/haku/dispatch/agent-rbac/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - rolebinding-logs-configmaps-reader.yaml

--- a/cluster/k8s/haku/dispatch/agent-rbac/rolebinding-logs-configmaps-reader.yaml
+++ b/cluster/k8s/haku/dispatch/agent-rbac/rolebinding-logs-configmaps-reader.yaml
@@ -1,0 +1,20 @@
+# Dispatcher/workers-LiteLLM logs are controller diagnostics, not user content
+# (haku/plans/multi_agent.md pre-approves this class of access) — co-subject
+# the usual agent readers so rollout debugging is self-serve. Worker ZONE
+# namespaces deliberately get no such binding at v1.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: agent-logs-configmaps-reader
+  namespace: haku-dispatch
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: logs-configmaps-reader
+subjects:
+  - kind: Group
+    name: oidc-ksbx-groups:kubectl-sandbox-users
+    apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: oidc-ksbx-groups:haku
+    apiGroup: rbac.authorization.k8s.io

--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -228,6 +228,7 @@ resources:
   - haku/zones/zai/flux-kustomization.yaml # z.ai/GLM worker zone (pure perimeter; Jobs only)
   - haku/zones/policies/flux-kustomization.yaml # Kyverno proxy/CA injection for zone pods
   - haku/dispatch/namespace/flux-kustomization.yaml
+  - haku/dispatch/agent-rbac/flux-kustomization.yaml # logs/configmaps read for rollout debugging (dispatcher logs = controller diagnostics)
   - haku/dispatch/db/flux-kustomization.yaml # CNPG: workers-LiteLLM key DB (+ validator DB later)
   - haku/dispatch/litellm/flux-kustomization.yaml # second-layer workers-LiteLLM (zone keys upstream; CNP: zone pods only)
   - haku/dispatch/dispatcher/flux-kustomization.yaml # dispatcher: classifier gate + Job stamping + result turn-in


### PR DESCRIPTION
**Access-widening change — flagging for conscious review.**

The dispatcher currently crashloops with exit 1 ~12s after start (a Python startup exception — most likely the first awaited call, the `dispatcher`-database connect), and neither agent principal can read the traceback: `haku-dispatch` has no `agent-rbac/` layer, so rollout debugging requires you to run `kubectl logs` by hand each round.

This adds the standard per-service `agent-rbac/` directory co-subjecting `kubectl-sandbox-users` + `haku` on **`logs-configmaps-reader`** in `haku-dispatch` only:

- Dispatcher/workers-LiteLLM logs are **controller diagnostics, not user content** — the class of access `haku/plans/multi_agent.md` pre-approves. The only credential that could ever appear in these logs is a per-job virtual key, which is unusable outside zone namespaces by CNP (that was the point of the reachability design).
- ConfigMaps in this namespace are reviewed git content (job template, zones.yaml, workers-LiteLLM config). Secrets remain unreadable.
- Worker **zone** namespaces deliberately get no such binding at v1 (unchanged).

With this merged I can pull the dispatcher traceback myself and fix the actual crash instead of guessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDFQogCNq94uP7rdiYYBZg

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDFQogCNq94uP7rdiYYBZg)_