### PR TITLE
haku dispatcher: add asyncpg to the db library (image crashed at startup)

### DIFF
--- a/haku/dispatch/BUILD.bazel
+++ b/haku/dispatch/BUILD.bazel
@@ -44,6 +44,11 @@ py_library(
     srcs = ["db.py"],
     deps = [
         ":models",
+        # asyncpg is imported dynamically by SQLAlchemy's postgresql+asyncpg
+        # dialect — without the explicit dep it's absent from the image
+        # (ModuleNotFoundError at startup; tests run sqlite+aiosqlite and
+        # can't catch it).
+        "@pypi//asyncpg",
         "@pypi//sqlalchemy",
     ],
 )


### PR DESCRIPTION
First traceback via the new #2769 log access:

```text
File ".../haku/dispatch/db.py", line 73, in make_engine
    return create_async_engine(url)
...
ModuleNotFoundError: No module named 'asyncpg'
```

SQLAlchemy imports the `postgresql+asyncpg` driver **dynamically**, so the missing Bazel dep never failed at build time, and the endpoint tests run `sqlite+aiosqlite` (aiosqlite arrives via the test conftest) so they couldn't catch it either. Add `@pypi//asyncpg` to the `:db` library — the same pairing `airlock`'s storage target uses.

Once merged, `push-images` publishes the fixed `haku-dispatcher` and Flux rolls it. Meanwhile the rest of the plane is green: **workers-litellm is Running 1/1 under the 4Gi limit** (#2764 applied), image name fixed (#2762), keys minted (#2761).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDFQogCNq94uP7rdiYYBZg

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDFQogCNq94uP7rdiYYBZg)_