### PR TITLE
Add email claim to haku_grocy Authentik service account

### DIFF
--- a/tf/gitops/agent-machine-access/main.tf
+++ b/tf/gitops/agent-machine-access/main.tf
@@ -1050,8 +1050,12 @@ resource "kubernetes_secret" "agent_box_codex_client_credentials" {
 resource "authentik_user" "haku_grocy" {
   username = "haku"
   name     = "Haku grocy read-only service account"
-  type     = "service_account"
-  path     = "goauthentik.io/service-accounts"
+  # Required for the same SA's stalwart-haku provider (below): Stalwart's OIDC
+  # directory requires the "email" scope/claim and rejects an empty one, so
+  # /jmap/session 403s without this even though the token authenticates fine.
+  email = "haku@allegedly.works"
+  type  = "service_account"
+  path  = "goauthentik.io/service-accounts"
 }
 
 # App-password token, used as the password in the client_credentials


### PR DESCRIPTION
## Summary
Added the `email` claim to the `haku_grocy` Authentik service account to support OIDC authentication requirements for the Stalwart email provider.

## Key Changes
- Added `email = "haku@allegedly.works"` to the `authentik_user.haku_grocy` resource
- Added explanatory comment documenting why the email claim is required: Stalwart's OIDC directory requires the "email" scope/claim and rejects an empty one, causing `/jmap/session` to return 403 without it

## Implementation Details
The email claim is necessary for the same service account's Stalwart-Haku provider configuration. Without this claim, Stalwart's OIDC directory validation fails even though the token authenticates successfully, resulting in authorization errors when accessing JMAP endpoints.

https://claude.ai/code/session_01Ta13s4j8nXANE1mdjCn2r5