### PR TITLE
ci: run pre-commit on changed files only for PRs

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -67,7 +67,24 @@ jobs:
           # Unset NODE_OPTIONS to avoid global-agent requirement in pre-commit's
           # isolated node environments (markdownlint-cli2 hook uses npm)
           unset NODE_OPTIONS
-          pre-commit run --all-files --show-diff-on-failure -v
+
+          # PRs: check only files changed in the PR (fast feedback).
+          # Branch pushes + manual runs: check all files (full gate before merge).
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            # GITHUB_BASE_REF is only set on pull_request events. A depth-1 fetch is
+            # enough: git diff compares the two trees directly (no merge-base needed).
+            git fetch --depth=1 origin "$GITHUB_BASE_REF"
+            mapfile -t changed < <(git diff --name-only --diff-filter=d "origin/$GITHUB_BASE_REF" HEAD)
+            if [ "${#changed[@]}" -eq 0 ]; then
+              echo "No files changed; nothing for pre-commit to check."
+              exit 0
+            fi
+            echo "Running pre-commit on ${#changed[@]} changed file(s):"
+            printf '  %s\n' "${changed[@]}"
+            pre-commit run --files "${changed[@]}" --show-diff-on-failure -v
+          else
+            pre-commit run --all-files --show-diff-on-failure -v
+          fi
 
       # ============================================================================
       # CACHE SAVES


### PR DESCRIPTION
## What

`pull_request` events now run pre-commit only against the files changed in the PR.
`push` (to `main`/`devel`) and manual `workflow_dispatch` runs still use `--all-files`,
so merges keep a full-repo gate.

## Why

Every PR currently lints the entire tree (`pre-commit run --all-files`), which is slow
on a monorepo this size and re-checks untouched files. Running only on changed files
gives fast PR feedback; keeping `--all-files` on branch pushes preserves the thorough
pre-merge check.

## How

Single edit to the "Run pre-commit" step in `.github/workflows/pre-commit.yml`. It
branches on `GITHUB_EVENT_NAME`:

- **PR** — `git fetch --depth=1 origin "$GITHUB_BASE_REF"`, then
  `git diff --name-only --diff-filter=d` against `HEAD` to get changed files
  (deletions excluded via lowercase `d` so no non-existent paths reach pre-commit),
  then `pre-commit run --files <list>`. Depth-1 suffices because `git diff` compares
  the two trees directly — no merge-base history needed, so no `fetch-depth: 0`.
- **else** — unchanged `pre-commit run --all-files`.

`always_run` hooks (`ducktape-precommit`, etc.) still run on PRs as intended — they do
their own git-diff or are env-gated no-ops. File-typed hooks run only when a changed
file matches.

## Verification

- `pre-commit run check-yaml prettier --files .github/workflows/pre-commit.yml` → Passed (and full `pre-commit run --files` on it → all relevant hooks Passed).
- This PR's own CI run exercises the changed-files path (GitHub uses the PR HEAD workflow for `pull_request` events): expect `Running pre-commit on N changed file(s):` then only `check-yaml` + `prettier` (+ no-op always-run hooks), not a full-repo run.
- `workflow_dispatch` on this branch confirms the `else` branch still runs `--all-files`.