### PR TITLE
haku-ci: allow Bazel toolchain egress for the Bazelified haku-state build

### DIFF
--- a/cluster/k8s/haku-ci/README.md
+++ b/cluster/k8s/haku-ci/README.md
@@ -14,8 +14,8 @@ contained to roughly Haku's existing sandbox blast radius:
 
 - **Not in `haku-sandbox`.** It lives in its own namespace where Haku has **no RBAC**, so Haku
   can't tamper with the runner pod or its registry/git push creds — but it is **egress-fenced**
-  like haku-sandbox (`networkpolicy.yaml`: DNS + base-image registries/npm/pypi + in-cluster
-  only).
+  like haku-sandbox (`networkpolicy.yaml`: DNS + base-image registries/npm/pypi + the Bazel
+  build/toolchain hosts + in-cluster only).
 - **Rootless daemon in a privileged pod** (`docker:27-dind-rootless`, `privileged: true`). The
   dockerd still runs **rootless** (UID 1000), so it's strictly better than classic rootful
   dind — but `privileged: true` is the documented requirement for dind-rootless (it provides
@@ -45,7 +45,7 @@ on the runner and confirm it builds + pushes an image. Check
 | File                 | Role                                                                                     |
 | -------------------- | ---------------------------------------------------------------------------------------- |
 | `namespace.yaml`     | the `haku-ci` namespace                                                                  |
-| `networkpolicy.yaml` | egress fence (DNS + registries/npm/pypi + in-cluster)                                    |
+| `networkpolicy.yaml` | egress fence (DNS + registries/npm/pypi + Bazel toolchain hosts + in-cluster)            |
 | `config.yaml`        | the act_runner config (labels, dind `DOCKER_HOST`, capacity), via a `configMapGenerator` |
 | `deployment.yaml`    | the act_runner + rootless `dind` sidecar                                                 |
 

--- a/cluster/k8s/haku-ci/networkpolicy.yaml
+++ b/cluster/k8s/haku-ci/networkpolicy.yaml
@@ -1,8 +1,10 @@
 # Egress fence for the Haku CI runner. The runner builds Haku-authored images, so
 # it's agent-controlled compute — contain its egress to only what a build needs:
-# DNS, base-image registries + npm/pypi (to pull base images and deps), and
-# in-cluster services (the Forgejo git + registry it pulls source from and pushes
-# images to). Having any egress rule flips the selected pods to default-deny egress.
+# DNS, base-image registries + npm/pypi (to pull base images and deps), the Bazel
+# build/toolchain hosts (haku-state builds with Bazel, no RBE, so the runner fetches
+# its own Bazel + toolchains), and in-cluster services (the Forgejo git + registry it
+# pulls source from and pushes images to). Having any egress rule flips the selected
+# pods to default-deny egress.
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -54,6 +56,23 @@ spec:
         # action-download step (confirmed via Cilium's DNS cache: the runner
         # connects to data.forgejo.org but it wasn't allowlisted).
         - matchName: data.forgejo.org
+        # Bazel build hosts (haku-state is Bazelified; `bazel build //...` runs in
+        # this runner without BuildBuddy/RBE, so it fetches its own toolchains). This
+        # deliberately widens the fence beyond "just a container build" — accepted so
+        # the build graph (deps, codegen, image) is dependency-correct and hermetic.
+        # The host set is best-effort until the first real build confirms the DNS hits;
+        # add any that surface. npm/pypi/ghcr/docker (above) already cover JS/Py/image deps.
+        - matchName: releases.bazel.build # the Bazel binary (bazelisk downloads it)
+        - matchName: bcr.bazel.build # the bzlmod module registry (metadata + some archives)
+        # BCR module source archives + rules_python's python-build-standalone interpreter
+        # + rules_nodejs assets are hosted on GitHub releases/archives.
+        - matchName: github.com
+        - matchName: codeload.github.com
+        - matchName: objects.githubusercontent.com
+        - matchName: release-assets.githubusercontent.com
+        - matchName: raw.githubusercontent.com
+        # Node.js toolchain for aspect_rules_js / rules_nodejs.
+        - matchName: nodejs.org
       toPorts:
         - ports:
             - port: "443"


### PR DESCRIPTION
## What

Prerequisite for Bazelifying `haku-state` (per our decision to build it with a single
`bazel build //...` graph — including the container image via `rules_oci` — with **no
BuildBuddy/RBE**, so the runner executes actions and fetches its own toolchains).

The `haku-ci` Forgejo runner is egress-fenced (`networkpolicy.yaml`) to DNS +
base-image registries + npm/pypi + in-cluster only. That's enough for a `docker build`
but **not** for Bazel: it couldn't reach the Bazel binary, the bzlmod registry, or the
toolchain release hosts, so `bazel build` can't even start (confirmed — both the runner
and the web-home get `403 CONNECT` to `bcr.bazel.build` / `releases.bazel.build`).

This adds the Bazel build/toolchain hosts to the runner's `CiliumNetworkPolicy` `toFQDNs`:

- `releases.bazel.build` (Bazel binary via bazelisk), `bcr.bazel.build` (bzlmod registry)
- `github.com` + `codeload`/`objects`/`release-assets`/`raw.githubusercontent.com` — BCR
  module source archives + `rules_python`'s python-build-standalone interpreter + `rules_nodejs`
- `nodejs.org` — `aspect_rules_js` / `rules_nodejs` node toolchain

`npm`/`pypi`/`ghcr`/`docker` were already allowed and cover the JS/Py/image deps.

## Security note

This **deliberately widens the egress fence** on what the policy calls "agent-controlled
compute," beyond a plain container build. It's the accepted tradeoff (your call) for a
dependency-correct, hermetic Bazel build. `github.com` is the broadest addition; the
tighter alternative (vendoring all Bazel deps offline) was considered and set aside in
favor of this. The host set is **best-effort** — I can't run Bazel in the fenced
environments to enumerate the exact DNS hits, so the first real build may surface a
missing host or two to add.

## Follow-up

Once this merges and Flux reconciles, the `haku-state` Bazelification PR (Forgejo:
`MODULE.bazel`, BUILD files, `rules_oci` image, the Pydantic→OpenAPI→TS codegen genrule,
and a `bazel-ci` workflow) can build + verify in the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0189a1fUCQnvrMwEx5fedtYd

---
_Generated by [Claude Code](https://claude.ai/code/session_0189a1fUCQnvrMwEx5fedtYd)_