### PR TITLE
followups skill: reframe around open-ended judgment, structural tier, loop

### DIFF
--- a/skills/followups/SKILL.md
+++ b/skills/followups/SKILL.md
@@ -1,260 +1,224 @@
 ---
 name: followups
 description: >
-  Surface pending followups, natural extensions, incomplete migrations, code
-  quality issues, and "what's next" suggestions. Verify session work is on disk.
-  Use when wrapping up a task or session, or when user asks "what's next",
-  "anything else", "what did we miss".
+  Apply full judgment to "what would the user want to do, know, or reconsider
+  next?" — from pending followups and incomplete migrations up to premortem
+  risks, architectural rethinks, and owner's-eye strategy for the work lane.
+  Verify session work is on disk. Use when wrapping up a task or session, or
+  when user asks "what's next", "anything else", "what did we miss".
 ---
 
-Surface pending followups, natural next steps, and quality improvements. Verify session work is on disk.
+Surface what the user would most plausibly want to do, know, or reconsider next.
 
 ## Purpose
 
-**"What's next?" advisor** — Proactively find natural extensions, incomplete migrations, unwired components, and quality improvements related to the session's work. Think like a colleague who sees what you just did and says "oh, and you probably also want to..."
+This skill's job is to apply **all available intelligence** — full session
+context, repo knowledge, and genuine judgment — to one question: _given
+everything that happened this session, what next?_ Think like a sharp colleague
+who watched the whole session and also happens to co-own the repo.
 
-**Save user time and cognitive load** — If there's >10-20% chance the user wants to do something, surface it for them to select with a key press. Much cheaper than having to remember/type it themselves.
+The core questions. Everything else in this file is technique for answering
+them:
 
-**Catch loose threads** — Both agent and user loose threads: things discussed 15 minutes ago but abandoned when we pivoted, half-finished migrations, components built but not wired up.
+1. **What did we miss?** The most important things not taken into account:
+   assumptions never validated, consumers/stakeholders not considered, failure
+   modes not discussed, angles skipped entirely (security, cost, scale,
+   operability, rollback).
+2. **Could this be the wrong approach?** Premortem: imagine it's three months
+   later and what we did or planned turned out to be a mistake — what's the
+   most likely reason? Is there a simpler or more standard mechanism that makes
+   this work unnecessary?
+3. **What would the owner do?** You own this repo / work lane and care about it
+   shipping, staying healthy, and evolving well over the next year. From that
+   seat, what should happen next — regardless of whether it came up this
+   session? Direction, de-risking, debt paydown, sequencing, things to _stop_
+   doing.
+4. **What will the user want next?** If there's >10–20% chance the user wants
+   something, surface it for a one-keypress decision — much cheaper than making
+   them remember and type it. Catch loose threads: things discussed but
+   abandoned in a pivot, half-finished work, components built but never wired
+   up.
 
-**Verify persistence** — Double-check work done in this session is actually on disk (not stashed/reverted by parallel process).
+**Aim high as well as low.** The skill fails just as badly by only suggesting
+`git push` when the honest answer is "this subsystem should be a reconciler"
+as it does by missing the push. Small completions and big rethinks are both in
+scope; they just have different output contracts (see Structural angles).
+
+Answering rules:
+
+- **Ground every answer in this session's specifics.** If an answer would apply
+  to any session verbatim ("add more tests", "improve documentation"), it's
+  boilerplate — drop it.
+- **"Nothing significant" is a valid answer.** Don't invent concerns to fill
+  space; a fabricated risk costs more attention than an empty section.
+- **Disagree plainly.** Answers may contradict the session's direction — that's
+  the point. Don't soften a real concern into a hedge.
 
 ## Process
 
-### Phase 1: Check Session Work Status
-
-Run `git status` and `git log --oneline origin/HEAD..HEAD` to determine whether session work is:
-
-- **Uncommitted** — suggest committing
-- **Committed but not pushed** — suggest pushing
-- **Pushed but not deployed** — note if relevant (e.g., Flux reconciliation pending)
-
-Brief output, one line per state.
-
-### Phase 2: Extract What We Talked About But Didn't Do
-
-**Consider delegating** conversation analysis for large sessions:
-
-- Good for: Scanning long conversations, extracting patterns
-- Can provide session log access (see Phase 1)
-
-Scan conversation for:
-
-- "should...", "could...", "TODO", "later", "next time"
-- "maybe add...", "consider...", "might want to..."
-- Incomplete actions ("let's do X" → did it actually get done?)
-- Questions asked but not fully answered
-
-**Check `/later` items**: Scan `TODO.md` files and `plans/` for items added during this session (via `/later` or manually). Surface any that haven't been addressed yet.
-
-### Phase 3: Find Natural Followups
-
-**Consider delegating** independent discovery tasks:
-
-- Good for: Code pattern searches, workflow checks, cleanup scans
-- Can split into distinct scopes with separate files-allowed-to-edit blocks
-
-**Code propagation analysis:**
-
-- If created new helper/class → search for hand-rolled equivalents
-- If DRYed pattern → search for remaining duplicates
-- If fixed bug → search for similar bugs
-- If added validation → find sites missing it
-
-**Workflow completion:**
-
-- Git: Any modified files? → suggest commit message
-- Tests: Did code change? → suggest test command
-- Docs: Did behavior change? → check if docs updated
-- Pre-commit: Any pre-commit hooks to run?
-
-**Cleanup opportunities:**
-
-- Dead code from this session's changes
-- Newly unused imports
-- Outdated comments referencing old code
-- Inconsistencies introduced
-
-### Phase 4: Natural Extensions and Incomplete Migrations
-
-Look beyond what was explicitly discussed. Based on what the session actually changed, search for natural next steps the user might not have thought of yet.
-
-**Incomplete migrations:**
-
-- If the session moved field/config/pattern A→B for one instance, search for remaining instances still on A
-- If the session replaced one tool/library/approach with another in one place, check if the old approach is still used elsewhere
-
-Examples:
-
-- "Moved `storageClass` from default to `lvm-proxmox-hdd` for grocy — 3 other PVCs still use the default class."
-- "Replaced Vault/ESO with SOPS for authentik secrets — harbor and grafana still use ESO."
-- "`ghcr-build-push` action now uses `github.token` directly instead of a `github_token` input — are any callers still passing the old input?"
-- "Removed `master` from branch triggers in 5 workflows — any others still referencing `master`?"
-
-**Extracted patterns not yet applied everywhere:**
-
-- If inline logic was extracted into a shared action/helper/utility, check for remaining copies of the inline version
-- "Extracted digest-pinning into `pin-image-digest` action for rbe-image and freecad-test — openclaw-image and tana-mcp-image still inline the same logic (or skip pinning entirely)."
-- "Added Docker layer caching (`cache_from`/`cache_to`) to 4 workflows — openclaw-image got caching but doesn't use the shared pin action yet."
-
-**Multi-layer version/config alignment:**
-
-- If the session fixed a version mismatch or config inconsistency in one layer, check all other layers that might have the same issue
-
-Examples:
-
-- "Fixed protobuf version in nix to match Bazel gencode — pip layer and MODULE.bazel still have the old version. All three need to agree."
-- "Updated Docker mTLS env vars in `py_test` macro — but the firewall doesn't allow port 2376 yet, and the test fixture isn't wired to the new env var name."
-
-**Unwired components:**
-
-- Session created a Dockerfile/image but no CI workflow builds it
-- Session created a k8s manifest but nothing applies/reconciles it
-- Session created a library/module but nothing imports it yet
-- Session added a config option but no documentation mentions it
-- Session added infrastructure (fixture, helper, env var) but the consumers aren't connected yet
-
-Example: "Created Docker mTLS test fixture and env var setup — but the firewall port isn't open, and no tests actually use the fixture yet."
-
-**Generalizations:**
-
-- If a fix or improvement was made to one instance of a pattern, check if similar instances would benefit. Example: "Added `requires_docker = True` to one test — 4 other tests also use Docker fixtures but don't have it."
-- If a new utility/helper was created, search for places that hand-roll the same logic
-
-**Better ways to do what we're doing manually:**
-
-- If the session used a manual/ad-hoc approach, check if there's a more standard or automated way. Example: "Passing `github_token` as an explicit input — GitHub Actions provides `github.token` automatically, no need to thread it through."
-
-**Stale names after renames:**
-
-- If the session renamed a class, function, or concept, check whether file names, test file names, variable names, and documentation still use the old name
-
-Example: "Renamed `FooClass` to `BarClass` but it still lives in `foo.py` with test in `test_foo.py` — should be `bar.py` / `test_bar.py`."
-
-**Tests must move with the code they test:**
-
-- If session refactored config, APIs, or function signatures, check whether tests still compile and match the new interfaces. Don't leave test fixes for later commits.
-
-Example: "Deleted `HookConfig` class and switched to standalone profile YAML — 5 test files still import `HookConfig` and pass it to `configure()`. These will break."
-
-**Optimizations and correctness:**
-
-- If session added functionality, are there edge cases not handled?
-- If session touched performance-sensitive code, are there obvious improvements?
-- If session changed data formats, are there consumers that need updating?
-
-Surface these with enough context for the user to judge value, not just "you could also do X." Include what specifically would change and why.
-
-### Phase 5: Prevent Recurrence Analysis
-
-If the session involved debugging, diagnosing, or working around a problem, ask:
-
-**Has this happened before?**
-
-- Search recent Claude session logs for similar symptoms, error messages, or affected components
-- Check `debug/` directories and `lessons_learned/` for prior investigations of the same area
-- If recurring: this is a higher-priority followup — the pattern needs a structural fix, not another one-off diagnosis
-
-**Can we prevent it from happening again?**
-
-For each significant problem encountered, consider whether any of these would be worth the effort:
-
-- **Pre-commit check or CI test**: Catches the problem before it ships (e.g., lint rule, validation script, regression test)
-- **Automated guard**: Code-level assertion, type constraint, or invariant that makes the bad state unrepresentable
-- **Better diagnostics**: More logging, metrics, or transparency that would make the _next_ occurrence faster to diagnose (e.g., structured error messages, health check endpoints, undeclared test outputs)
-- **Easier workflow**: A CLI command, script, or alias that automates the manual steps we had to do (e.g., `bbapi target history --failures-only` was built this session because manual API calls were painful)
-- **Documentation**: A `lessons_learned/` entry, `AGENTS.md` update, or troubleshooting section that captures the diagnosis path so future sessions don't start from scratch
-
-Surface these as followup suggestions with concrete proposals, not vague "consider adding tests." Example:
-
-```
-B. **Add pre-commit check for unquoted URLs in pnpm lockfiles**
-   - We spent time diagnosing a check-yaml failure caused by pnpm's YAML output
-   - A targeted check could catch this on lockfile regeneration
-```
-
-### Phase 6: Code Quality Audit of Changed Files
-
-**Delegate to subagent(s)** — these are read-only searches well suited for parallel execution.
-
-**Duplicate code detection:**
-
-- For each function/class added or substantially modified this session, search the repo for similar logic elsewhere
-- Look for: copy-pasted blocks, reimplemented stdlib/library functionality, patterns that exist in shared utilities (`util/`, `mcp_infra/`, etc.) but were hand-rolled instead
-- Surface as refactoring opportunities with specific file:line references
-
-**Refactoring opportunities:**
-
-- If a pattern was repeated 3+ times across the session's changes, suggest extracting it
-- If session changes introduced a new abstraction, check whether older code could use it
-- If session touched a module with known code smells (long functions, deep nesting, god classes), note the opportunity but at MAYBE priority
-
-**STYLE.md compliance audit:**
-
-Read `STYLE.md` and check all files modified this session against its rules. Common violations to scan for:
-
-- Exception swallowing (`except Exception: ... = {}`)
-- Unnecessary aliasing (`import foo as bar`, `x = param`)
-- String forward references instead of reordering
-- `model_dump()` used for logic instead of field access
-- Missing `Field(description=...)` on Pydantic models (docstring listing fields instead)
-- Verbose docstrings that restate the signature
-- `dict` construction instead of Pydantic model construction
-- `getattr`/`hasattr` usage without justification
-- Grab-bag module names (`utils.py`, `constants.py`, `core.py`)
-- `list` used where `set` is semantically correct
-- Manual iterator patterns where `more_itertools.one()`/`first()` fits
-
-Only flag **actual violations found in the diff**, not hypothetical ones. Include the file path, line number, the STYLE.md rule violated, and a concrete fix.
-
-### Phase 7: Verify Suggestions Are Actionable
-
-Before surfacing any suggestion, verify it's actually actionable right now:
-
-- **Git push/commit**: Re-run `git status` and `git log --oneline origin/HEAD..HEAD` fresh — the user may have committed, pushed, or staged files since the last check. Don't suggest pushing if already pushed, don't suggest committing if nothing is staged/modified
-- **Run tests**: Confirm the test target exists and the test runner is available
-- **Code changes**: Confirm the file/function still exists and hasn't been changed by a concurrent agent
-- **Cleanup**: Confirm the dead code / unused import is actually still there
-
-Drop suggestions that fail verification. A stale or impossible suggestion wastes more attention than omitting it. If a suggestion is borderline (e.g., "bench.py might need updating" but you haven't checked), either verify it or drop it — don't surface uncertain claims as actionable items.
-
-### Phase 8: Probabilistic Action Suggestions
-
-For each verified action, estimate probability user wants it:
-
-**>80% probability - DO NOW category:**
-
-- Commit modified files (if changes were made)
-- Fix breaking changes introduced
-- Complete half-finished work
-
-**40-80% probability - LIKELY category:**
-
-- Run tests after code changes
-- Propagate new pattern to obvious sites
-- Update related documentation
-- Push committed work
-
-**20-40% probability - MAYBE category:**
-
-- Add tests for new feature
-- Refactor similar code
-- Improve error messages
-- Add logging
-
-**10-20% probability - OPTIONAL category:**
-
-- Performance optimizations
-- Nice-to-have cleanups
-- Documentation improvements for edge cases
-
-**<10% probability - omit** (don't waste user's attention)
+`/followups` is a **loop, not a one-shot menu**: as long as the user keeps
+selecting items, keep executing, re-thinking, and re-presenting.
+
+1. **Ground** — establish what actually happened vs. what was merely discussed.
+   Verify session work is on disk (not stashed/reverted by a parallel process):
+   `git status` and `git log --oneline origin/HEAD..HEAD`. Classify:
+   uncommitted / committed-not-pushed / pushed-not-deployed (e.g., Flux
+   reconciliation pending).
+2. **Generate** — work the core questions. Use the angle library below as an
+   accelerant, and go beyond it wherever the session suggests an angle it
+   doesn't list. Delegate read-only searches to parallel subagents when there
+   are multiple independent checks.
+3. **Filter** — verify each candidate is actionable right now (see below); drop
+   what fails.
+4. **Present** — probability-bucketed suggestions via AskUserQuestion, plus a
+   "⚠ Reconsider" section for approach-risk flags (see Output).
+5. **Execute** — do everything the user selected.
+6. **Loop** — the work just executed changed the ground truth: new diffs, new
+   loose ends, unblocked items, sometimes invalidated ones. Go back to step 1
+   and **genuinely re-derive** the suggestion set — don't just re-show the
+   leftover menu. First-iteration angles that were fully covered don't need
+   re-scanning; focus regeneration on what the executed work touched, plus
+   still-pending Skip items (re-verified). Exit when the user selects nothing,
+   answers "stop"/"done", or only No/Skip remain with nothing new surfacing.
+
+## Angle Library
+
+Known-productive instantiations of the core questions. This is a **library of
+examples, not a checklist that bounds the search** — pursue angles it doesn't
+list; skip angles that obviously don't apply, without comment.
+
+### Mechanical angles
+
+The easy tier: each finding maps to a concrete command or small edit.
+
+- **Loose threads**: "should/could/TODO/later" from the conversation; "let's do
+  X" that never happened; questions left unanswered; `/later` items added to
+  `TODO.md` / `plans/` this session.
+- **Finish the migration**: moved pattern/config A→B in one place → find
+  instances still on A; replaced a tool/approach → old one still used
+  elsewhere; fixed a version/config mismatch in one layer → other layers still
+  disagree. ("Moved `storageClass` for grocy — 3 other PVCs still on the
+  default class.")
+- **Propagate the pattern**: new helper → hand-rolled equivalents elsewhere;
+  bug fixed → similar bugs; validation added → sites missing it; improvement to
+  one instance of a pattern → its siblings.
+- **Wire it up**: built but not connected — image no CI workflow builds,
+  manifest nothing reconciles, module nothing imports, fixture no test uses,
+  config option no doc mentions.
+- **Workflow completion**: commit / push / test / docs / pre-commit for the
+  session's changes.
+- **Hygiene after change**: dead code, newly unused imports, comments
+  referencing old code, file/test names stale after renames, tests that no
+  longer match refactored interfaces (fix in the same change, not later).
+- **Prevent recurrence** (after debugging): has this happened before? Check
+  session logs, `debug/`, `lessons_learned/` — recurring means structural fix,
+  not another one-off diagnosis. Worth a CI check, a guard/invariant that makes
+  the bad state unrepresentable, better diagnostics, a workflow script, or a
+  `lessons_learned/` entry? Concrete proposals only, never "consider adding
+  tests".
+- **Quality audit of the diff** (delegate to subagents): logic duplicating
+  shared utilities, patterns repeated 3+ times wanting extraction, STYLE.md
+  violations actually present in the diff — file:line, rule, concrete fix.
+
+### Structural angles
+
+The ambitious tier: step-change moves, not incremental cleanup. These fire
+rarely, but when one is right it's the most valuable output this skill can
+produce. Each must be grounded in friction actually observed — this session's
+pain is the evidence.
+
+- **Adopt instead of build**: this hand-rolled subsystem is a worse version of
+  something standard — a framework, library, or platform capability already in
+  the stack. "This app's routing/state handling is a buggy reimplementation of
+  what any sane JS framework provides — switching to X deletes half the code
+  and the whole bug class we just fought."
+- **Wrong architectural shape**: the design fights the problem's nature; name
+  the known-good shape that fits. Reconciler/controller (declare desired state,
+  converge level-triggered, requeue on error — instead of imperative
+  edge-triggered sync scripts that drift), state machine, queue + workers,
+  append-only event log, pipeline of pure stages. "These sync scripts keep
+  drifting and we keep patching them — this wants to be a reconciler."
+- **Algorithmic headroom**: the hot path does avoidable work; estimate current
+  and achievable complexity and say what closes the gap. "This is
+  O(n² log m + nm); with an interval tree and incremental updates it should be
+  near O((n+m) log n) — worth digging into before the dataset grows 10×."
+- **Wrong data model**: the special cases we keep patching are symptoms; the
+  schema forces the complexity. Restructure the model and the patches vanish.
+- **Collapse layers**: services/processes/repos that should be one thing; a
+  service that should be a library; indirection that no longer pays rent.
+- **Delete the problem**: change something upstream so the whole component is
+  unnecessary — the best version of this component may be its absence.
+- **Promote a one-off to a capability**: this session built the third bespoke
+  solution of its kind — build the general mechanism, delete all three.
+- **Verify the invariant, not examples**: a tricky invariant defended by
+  hand-picked example tests wants property-based testing, fuzzing, or
+  exhaustive checking over the real input space.
+
+**Output contract for structural items** (different from mechanical):
+
+- **Claim + evidence + shape**: state the thesis crisply, name the friction
+  from this session that motivates it, sketch the target shape and rough
+  payoff.
+- **Next step is a probe, not a leap**: a spike branch, a profiling run, a
+  half-page design note — sized in hours, cheap to abandon. Never "rewrite it".
+- **Cap 1–3 per session**, highest expected value first. These compete on
+  probability × payoff, not raw probability — a 20% chance of killing a whole
+  maintenance lane beats an 80% chance of a nice cleanup.
+
+## Filtering
+
+Before surfacing any suggestion, verify it's actionable right now:
+
+- **Git push/commit**: re-run `git status` and
+  `git log --oneline origin/HEAD..HEAD` fresh — the user may have committed,
+  pushed, or staged since the last check
+- **Run tests**: confirm the target exists and the runner is available
+- **Code changes**: confirm the file/function still exists and wasn't changed
+  by a concurrent agent
+- **Cleanup**: confirm the dead code / unused import is actually still there
+
+Drop suggestions that fail verification — a stale suggestion wastes more
+attention than omitting it. If borderline ("bench.py might need updating" but
+unchecked), verify or drop.
+
+**Exempt from verification**: approach-risk flags (premortem) and structural
+items — they're judgments and probes, not actions to validate. Their quality
+gate is the grounding rule: real evidence from this session, or drop.
 
 ## Output and Interaction
 
+### Priority buckets
+
+For each mechanical action, estimate the probability the user wants it:
+
+- **>80% — DO NOW** 🔴: commit modified files, fix breaking changes introduced,
+  complete half-finished work
+- **40–80% — LIKELY** 🟡: run tests after code changes, propagate new pattern
+  to obvious sites, update related docs, push committed work
+- **20–40% — MAYBE** 🟢: add tests for new feature, refactor similar code,
+  improve error messages
+- **10–20% — OPTIONAL** 🔵: nice-to-have cleanups, edge-case documentation
+- **<10% — omit** (don't waste the user's attention)
+
+Calibration anchors: 90% = user explicitly said "do this next"; 70% = standard
+workflow step (commit after edits); 50% = natural followup (tests after code
+change); 30% = improvement opportunity; 15% = nice-to-have.
+
+**Outside the buckets** (not probability-gated):
+
+- **⚠ Reconsider** — approach-risk flags from the premortem, surfaced even at
+  low probability; suppressing a correct one costs far more than reading a
+  wrong one.
+- **Structural items** — ranked by expected value (probability × payoff),
+  capped at 1–3, presented with their probe as the yes-action.
+- Owner-view lane-level items: at most 1–2 per session, highest-leverage
+  first — a steering nudge, not a backlog dump.
+- Otherwise err toward over-suggesting: better five low-probability items than
+  missing the one the user wanted.
+
 ### Phase output (text)
 
-Print verification results and a brief summary of findings as text:
+Print verification results and a brief summary as text:
 
 ```markdown
 ## Verification
@@ -264,71 +228,62 @@ Print verification results and a brief summary of findings as text:
 - src/feature/ (3 files modified)
 - config/settings.yaml (new validation added)
 
+## ⚠ Reconsider
+
+- <approach-risk flag, if any — plain statement of why the approach may be
+  wrong, no hedging>
+
 ## Summary
 
-Found 3 immediate actions, 4 likely followups, 2 optional items.
+Found 3 immediate actions, 4 likely followups, 1 structural proposal.
 ```
+
+Omit the Reconsider section entirely when there are no approach-risk flags.
 
 ### Action selection (AskUserQuestion)
 
-Present followup suggestions using AskUserQuestion. Each item needs a tri-state response:
+Present suggestions using AskUserQuestion. Each item needs a tri-state
+response:
 
-- **Yes**: Do it now.
-- **Skip**: Not now, but resurface if `/followups` is called again this session.
-- **No**: Don't do it, and don't suggest it again this session. Track in conversation context only — do not save to memory.
+- **Yes**: do it now (for structural items: run the probe, not the rewrite).
+- **Skip**: not this round — re-verify and resurface in later loop iterations
+  (and on any later `/followups` call this session).
+- **No**: don't do it, don't suggest it again this session — not in later
+  iterations either. Track in conversation context only — do not save to
+  memory.
 
 Items not explicitly addressed default to **Skip**.
 
-**Priority indicators** (include in option descriptions):
+**Loop cadence**: after executing the Yes items, return to Process step 1 and
+re-present (fresh items first, surviving Skip items after). Each round's
+presentation should be cheaper than the first — only what's new or changed
+needs re-derivation. Stop looping when the user selects nothing, picks
+"stop"/"done" via Other, or a round produces no new items and only
+Skip/No leftovers. On exit, print a one-line wrap-up of what was done across
+all rounds and what remains parked.
 
-- 🔴 = DO NOW (>80% probability)
-- 🟡 = LIKELY (40-80%)
-- 🟢 = MAYBE (20-40%)
-- 🔵 = OPTIONAL (10-20%)
+Include the priority emoji (🔴🟡🟢🔵) in option descriptions; structural items
+get 🏗 instead of a probability emoji.
 
 **AskUserQuestion constraints:**
 
-- 1-4 questions per call, 2-4 options per question
-- Labels: 1-5 words. Details go in description.
+- 1–4 questions per call, 2–4 options per question
+- Labels: 1–5 words; details go in description
 - Headers: max 12 chars (chip/tag)
 - `multiSelect: true` allows multiple selections
 - "Other" freeform option is auto-provided
 - Can call the tool multiple times sequentially
 
-**Presentation strategy**: Choose whatever interaction pattern best fits the specific suggestions being presented. Options include:
+**Presentation strategy**: choose whatever pattern fits the suggestions —
+multi-select by topic (selected=yes, unselected=skip) with a follow-up for
+explicit "no"; per-item single-select when items are few or need individual
+attention; batched by priority (DO NOW first); multiple sequential calls for
+overflow. Optimize for quick decisions with minimal friction.
 
-- Multi-select by topic (selected=yes, unselected=skip), then a follow-up to capture explicit "no" items
-- Per-item single-select with Yes/Skip/No options (when items are few or need individual attention)
-- Batched by priority, processing DO NOW items first before presenting lower-priority ones
-- Multiple sequential calls to work through more items than fit in one call
-
-Use judgment — optimize for the user making quick decisions with minimal friction.
-
-## Implementation Requirements
-
-### 1. Consider Delegation
-
-Delegate read-only tasks (verification, code search, git status) to subagents
-when there are multiple independent checks. Spawn in parallel when possible.
-
-### 2. Concrete Commands
-
-Every suggestion includes the exact command in the description:
-
-- ✅ `git push origin devel`
-- ✅ `bbr test //path/to:target`
-- ❌ "consider committing changes"
-
-### 3. Probability Calibration
-
-- 90%: User explicitly said "do this next"
-- 70%: Standard workflow step (commit after edits)
-- 50%: Natural followup (tests after code change)
-- 30%: Improvement opportunity (refactor similar code)
-- 15%: Nice-to-have (documentation polish)
-- <10%: Omit entirely
-
-### 4. Zero False Omissions
-
-Better to show 5 low-probability items than miss the one action user wanted.
-Err on side of over-suggesting rather than under-suggesting.
+**Concrete next step**: every suggestion names its next step. For mechanical
+items that's the exact command — `git push origin devel`,
+`bbr test //path/to:target` — never "consider committing changes". For
+structural items, where the work is not one command, it's the first probe:
+"spike: swap the hand-rolled router for X in one page", "profile with n=10⁴ to
+confirm the n² term dominates", "half-page design note on the reconciler
+shape".


### PR DESCRIPTION
Rework of the `/followups` skill around the idea that open-ended judgment is the skill's actual job, and the mechanical scans are examples of it.

## Changes

- **Purpose-first structure**: leads with four core questions — what did we miss (blind spots), could this be the wrong approach (premortem), what would the owner of this repo/work lane do, what will the user want next. Everything else is technique for answering them. Grounding rules: session-specific only (no boilerplate), "nothing significant" is a valid answer, disagree plainly.
- **Angle library instead of numbered phases**: former phases 1–6 squashed into 8 tight "mechanical angles" (loose threads, finish-the-migration, propagate-the-pattern, wire-it-up, workflow completion, hygiene, prevent-recurrence, diff quality audit) — explicitly a non-exhaustive library, not a checklist that bounds the search.
- **New structural tier** for ambitious suggestions: adopt-instead-of-build, wrong architectural shape (e.g. reconciler/controller over drifting sync scripts), algorithmic headroom, wrong data model, collapse layers, delete the problem, promote one-off to capability, verify-the-invariant. Output contract: claim + session evidence + target shape, next step is an hours-sized probe (spike/profile/design note), ranked by expected value not raw probability, capped 1–3 per session.
- **⚠ Reconsider section**: premortem approach-risk flags are exempt from the probability cutoff and actionability verification — judgments, not actions.
- **Loop semantics**: `/followups` executes selected items, then re-derives the suggestion set from the changed ground truth and re-presents, repeating until the user stops selecting. Skip = resurface next round; No = suppressed for the session. Exit prints a wrap-up of all rounds.