### PR TITLE
feat(nix): add unofficial zai-cli package

### DIFF
--- a/nix/home/home.nix
+++ b/nix/home/home.nix
@@ -323,6 +323,7 @@ in
       bbapi
       gterm-theme
       ducktapePackages.tana-outliner
+      ducktapePackages.zai-cli
     ]
     ++ [
       eza

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -317,6 +317,7 @@ rec {
   gnome-shell-aiquota = aiquota;
   tana-outliner = pkgs.callPackage ./tana-outliner.nix { };
   gmail-mcp = pkgs.callPackage ./gmail-mcp.nix { };
+  zai-cli = pkgs.callPackage ./zai-cli.nix { };
   foxflss = pkgs.callPackage ./foxflss.nix { };
   litert-lm = pkgs.callPackage ./litert-lm.nix { };
   prettier = pkgs.callPackage ./prettier/prettier.nix { };

--- a/nix/packages/zai-cli.nix
+++ b/nix/packages/zai-cli.nix
@@ -1,0 +1,58 @@
+# Unofficial CLI for Z.AI capabilities: vision analysis, web search, web reader,
+# and GitHub repo exploration. MCP-native. Not in nixpkgs.
+# https://github.com/numman-ali/zai-cli
+#
+# Reads the API key from the environment (no key is baked in):
+#   export Z_AI_API_KEY="..."      # (ZAI_API_KEY also accepted)
+#   export Z_AI_MODE=ZHIPU          # use the Zhipu endpoint instead of z.ai
+#
+# UPDATING:
+#   nix run nixpkgs#nix-update -- --flake zai-cli \
+#     --version branch=main --url https://github.com/numman-ali/zai-cli
+#   If npmDepsHash changes, build will fail with the correct hash — update manually.
+{ pkgs, lib }:
+pkgs.buildNpmPackage {
+  pname = "zai-cli";
+  version = "1.1.0";
+
+  src = pkgs.fetchFromGitHub {
+    owner = "numman-ali";
+    repo = "zai-cli";
+    rev = "v1.1.0"; # Latest as of 2026-07-03
+    hash = "sha256-eEF5lwF5Aup17Z4fhjI0OLmNjbdS9ioRvCFtltzOcYY=";
+  };
+
+  # Monorepo: the package lives under packages/zai-cli (no workspace root).
+  sourceRoot = "source/packages/zai-cli";
+
+  npmDepsHash = "sha256-s0LXHJuRWpZx74G1ODgMoNMazoawJY6QKaugh/n3UwY=";
+
+  buildPhase = ''
+    runHook preBuild
+    npm run build
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/zai-cli
+    # bin/zai-cli.js imports ../dist/index.js (relative) — keep the layout.
+    cp -r bin dist package.json node_modules $out/lib/zai-cli/
+
+    mkdir -p $out/bin
+    makeWrapper ${pkgs.nodejs}/bin/node $out/bin/zai-cli \
+      --add-flags "$out/lib/zai-cli/bin/zai-cli.js"
+
+    runHook postInstall
+  '';
+
+  nativeBuildInputs = [ pkgs.makeWrapper ];
+
+  meta = {
+    description = "Unofficial CLI for Z.AI capabilities: vision, web search, web reader, repo exploration";
+    homepage = "https://github.com/numman-ali/zai-cli";
+    license = lib.licenses.mit;
+    mainProgram = "zai-cli";
+  };
+}


### PR DESCRIPTION
## What

Packages the unofficial **`zai-cli`** (`numman-ali/zai-cli`, v1.1.0) — a CLI for Z.AI capabilities (vision, web search, web reader, GitHub repo exploration). It is **not in nixpkgs**, so this vendors it.

## Changes

- `nix/packages/zai-cli.nix` (new) — `buildNpmPackage` from the GitHub source (the published npm tarball carries no lockfile): `tsc` build, `node_modules` assembled from the committed lockfile, `bin/zai-cli.js` wrapped with `makeWrapper`.
- `nix/packages/default.nix` — expose via `ducktapePackages`.
- `nix/home/home.nix` — add `ducktapePackages.zai-cli` to `home.packages` (lands on every home-manager host; inert without a key).

## API key

Reads from the environment — none is baked in:

```bash
export Z_AI_API_KEY="..."   # ZAI_API_KEY also accepted
export Z_AI_MODE=ZHIPU       # Zhipu endpoint instead of z.ai
```

## Verification

- `nix build` of the derivation succeeds (content hashes pinned, no guessing).
- `zai-cli --help` runs and prints v1.1.0 with all subcommands.
- `nix eval .#homeConfigurations.atlas.config.home.packages` evaluates and contains `zai-cli-1.1.0`.
- `pre-commit` (nixfmt, statix) passes on the changed files.

BAZEL_TEST_INVOCATIONS=none: Nix-only packaging change; no Bazel build/test targets affected.
