### PR TITLE
ci: guard that in-cluster GHCR images are public (anonymously pullable)

### DIFF
--- a/.github/scripts/check_public_images.py
+++ b/.github/scripts/check_public_images.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Assert every in-cluster GHCR image is anonymously pullable (i.e. public).
+
+New GHCR packages default to private, and GitHub exposes no API to set package
+visibility, so a new in-cluster image silently ``ImagePullBackOff``s on the
+credential-less Talos nodes until someone flips it to public by hand. This
+detects that and fails loudly (it cannot auto-fix).
+
+SSOT for "which images must be public" is the ``ImageRepository`` manifests under
+``cluster/k8s/flux-image-automation-ghcr/`` (their ``spec.image``), filtered to
+``ghcr.io``. We test anonymous pullability against the registry rather than the
+packages API: the packages API requires auth even for public packages, whereas an
+anonymous ``ghcr.io`` pull token grants ``tags/list`` only for a public package —
+which is exactly the property the nodes rely on, and needs no secret.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import yaml
+
+REGISTRY = "ghcr.io"
+MANIFEST_DIR = Path("cluster/k8s/flux-image-automation-ghcr")
+TIMEOUT = 15
+
+
+def ghcr_packages(owner: str) -> list[str]:
+    """Package names (``spec.image`` minus the ``ghcr.io/<owner>/`` prefix)."""
+    prefix = f"{REGISTRY}/{owner}/"
+    packages: set[str] = set()
+    for path in sorted(MANIFEST_DIR.glob("*.yaml")):
+        for doc in yaml.safe_load_all(path.read_text()):
+            if not isinstance(doc, dict) or doc.get("kind") != "ImageRepository":
+                continue
+            image = doc.get("spec", {}).get("image", "")
+            if image.startswith(prefix):
+                packages.add(image.removeprefix(prefix))
+    return sorted(packages)
+
+
+def anon_pullable(owner: str, pkg: str) -> tuple[bool, str]:
+    """Whether ``pkg`` is anonymously pullable from GHCR (public).
+
+    A private or not-yet-pushed package is denied at either step: the anonymous
+    token request itself 403s, or the granted token lacks pull scope so
+    ``tags/list`` 403s.
+    """
+    token_url = f"https://{REGISTRY}/token?scope=repository:{owner}/{pkg}:pull"
+    try:
+        with urllib.request.urlopen(token_url, timeout=TIMEOUT) as resp:
+            token = json.load(resp)["token"]
+        req = urllib.request.Request(
+            f"https://{REGISTRY}/v2/{owner}/{pkg}/tags/list", headers={"Authorization": f"Bearer {token}"}
+        )
+        with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
+            return resp.status == 200, str(resp.status)
+    except urllib.error.HTTPError as err:
+        return False, str(err.code)
+
+
+def main() -> int:
+    owner = os.environ.get("OWNER") or "agentydragon"
+    packages = ghcr_packages(owner)
+    if not packages:
+        print(f"No {REGISTRY}/{owner} images found under {MANIFEST_DIR}", file=sys.stderr)
+        return 1
+
+    print(f"Checking {len(packages)} in-cluster GHCR packages for {owner}:")
+    bad: list[str] = []
+    for pkg in packages:
+        ok, code = anon_pullable(owner, pkg)
+        print(f"  {'ok    ' if ok else 'NOT OK'}  {pkg}{'' if ok else f' (http {code})'}")
+        if not ok:
+            bad.append(pkg)
+
+    if not bad:
+        print(f"All {len(packages)} packages are anonymously pullable. ✅")
+        return 0
+
+    report = "\n".join(
+        [
+            "### ❌ GHCR packages not anonymously pullable",
+            "",
+            "Cluster nodes pull without credentials, so each must be public",
+            "(or, if brand new, pushed once then flipped public).",
+            "GitHub has no API to set visibility — fix each in the UI:",
+            "",
+            *(f"- `{p}` — https://github.com/users/{owner}/packages/container/{p}/settings" for p in bad),
+        ]
+    )
+    print("\n" + report, file=sys.stderr)
+    if summary := os.environ.get("GITHUB_STEP_SUMMARY"):
+        with Path(summary).open("a") as fh:
+            fh.write(report + "\n")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/check-public-images.yml
+++ b/.github/workflows/check-public-images.yml
@@ -1,18 +1,6 @@
 # Guard: every in-cluster GHCR image must be pullable WITHOUT credentials, so
-# Talos nodes (which have no pull secret) can pull it. New GHCR packages default
-# to private, and GitHub has no API to set visibility
-# (docs.github.com/en/rest/packages/packages is GET/DELETE/restore only) — so
-# this can only *detect* and fail loudly, not auto-fix. Flip the package to
-# public in the UI when it fails.
-#
-# We test anonymous pullability directly against the registry rather than the
-# packages API: the packages API requires auth even for public packages (401),
-# whereas an anonymous ghcr.io pull token grants `tags/list` (200) only for a
-# public package (403 for private or not-yet-pushed) — which is exactly the
-# property the nodes rely on, and needs no secret.
-#
-# SSOT for "which images must be public" = the ImageRepository manifests under
-# cluster/k8s/flux-image-automation-ghcr/ (spec.image), filtered to ghcr.io.
+# Talos nodes (which have no pull secret) can pull it. Detection only — GitHub
+# exposes no API to set package visibility. Logic + rationale live in the script.
 name: check public images
 
 on:
@@ -20,6 +8,7 @@ on:
     branches: [devel]
     paths:
       - "cluster/k8s/flux-image-automation-ghcr/**"
+      - ".github/scripts/check_public_images.py"
       - ".github/workflows/check-public-images.yml"
   schedule:
     - cron: "0 7 * * *" # daily drift check
@@ -35,51 +24,11 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
-
-      - name: Check anonymous pullability
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - run: pip install --quiet pyyaml
+      - name: Check GHCR packages are anonymously pullable
         env:
           OWNER: ${{ github.repository_owner }}
-        run: |
-          set -uo pipefail
-
-          # ghcr.io/<owner>/<pkg> image names from the ImageRepository manifests
-          # (package name may contain slashes). Harbor images
-          # (registry.allegedly.works/...) are not GHCR, so they're excluded.
-          mapfile -t images < <(
-            grep -rhoE "ghcr\.io/${OWNER}/[A-Za-z0-9._/-]+" \
-              cluster/k8s/flux-image-automation-ghcr/ \
-              | sed "s#ghcr.io/${OWNER}/##" | sort -u
-          )
-          [ "${#images[@]}" -gt 0 ] || { echo "No ghcr.io/${OWNER} images found." >&2; exit 1; }
-
-          echo "Checking ${#images[@]} in-cluster GHCR packages are anonymously pullable:"
-          bad=()
-          for pkg in "${images[@]}"; do
-            # Anonymous pull token; tags/list is 200 only for a public package.
-            tok=$(curl -sS "https://ghcr.io/token?scope=repository:${OWNER}/${pkg}:pull" | jq -r '.token // empty')
-            code=$(curl -sS -o /dev/null -w '%{http_code}' \
-              -H "Authorization: Bearer ${tok}" \
-              "https://ghcr.io/v2/${OWNER}/${pkg}/tags/list")
-            if [ "$code" = 200 ]; then
-              echo "  ok      ${pkg}"
-            else
-              echo "  NOT OK  ${pkg} (anonymous pull http ${code})"
-              bad+=("${pkg}")
-            fi
-          done
-
-          if [ "${#bad[@]}" -gt 0 ]; then
-            {
-              echo "### ❌ GHCR packages not anonymously pullable"
-              echo
-              echo "Cluster nodes pull without credentials, so each must be public"
-              echo "(or, if brand new, pushed at least once then flipped public)."
-              echo "GitHub has no API to set visibility — fix each in the UI:"
-              echo
-              for p in "${bad[@]}"; do
-                echo "- \`${p}\` — https://github.com/users/${OWNER}/packages/container/${p}/settings"
-              done
-            } | tee -a "$GITHUB_STEP_SUMMARY"
-            exit 1
-          fi
-          echo "All ${#images[@]} packages are anonymously pullable. ✅"
+        run: python3 .github/scripts/check_public_images.py

--- a/.github/workflows/check-public-images.yml
+++ b/.github/workflows/check-public-images.yml
@@ -1,0 +1,85 @@
+# Guard: every in-cluster GHCR image must be pullable WITHOUT credentials, so
+# Talos nodes (which have no pull secret) can pull it. New GHCR packages default
+# to private, and GitHub has no API to set visibility
+# (docs.github.com/en/rest/packages/packages is GET/DELETE/restore only) — so
+# this can only *detect* and fail loudly, not auto-fix. Flip the package to
+# public in the UI when it fails.
+#
+# We test anonymous pullability directly against the registry rather than the
+# packages API: the packages API requires auth even for public packages (401),
+# whereas an anonymous ghcr.io pull token grants `tags/list` (200) only for a
+# public package (403 for private or not-yet-pushed) — which is exactly the
+# property the nodes rely on, and needs no secret.
+#
+# SSOT for "which images must be public" = the ImageRepository manifests under
+# cluster/k8s/flux-image-automation-ghcr/ (spec.image), filtered to ghcr.io.
+name: check public images
+
+on:
+  push:
+    branches: [devel]
+    paths:
+      - "cluster/k8s/flux-image-automation-ghcr/**"
+      - ".github/workflows/check-public-images.yml"
+  schedule:
+    - cron: "0 7 * * *" # daily drift check
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: GHCR packages are public
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check anonymous pullability
+        env:
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          set -uo pipefail
+
+          # ghcr.io/<owner>/<pkg> image names from the ImageRepository manifests
+          # (package name may contain slashes). Harbor images
+          # (registry.allegedly.works/...) are not GHCR, so they're excluded.
+          mapfile -t images < <(
+            grep -rhoE "ghcr\.io/${OWNER}/[A-Za-z0-9._/-]+" \
+              cluster/k8s/flux-image-automation-ghcr/ \
+              | sed "s#ghcr.io/${OWNER}/##" | sort -u
+          )
+          [ "${#images[@]}" -gt 0 ] || { echo "No ghcr.io/${OWNER} images found." >&2; exit 1; }
+
+          echo "Checking ${#images[@]} in-cluster GHCR packages are anonymously pullable:"
+          bad=()
+          for pkg in "${images[@]}"; do
+            # Anonymous pull token; tags/list is 200 only for a public package.
+            tok=$(curl -sS "https://ghcr.io/token?scope=repository:${OWNER}/${pkg}:pull" | jq -r '.token // empty')
+            code=$(curl -sS -o /dev/null -w '%{http_code}' \
+              -H "Authorization: Bearer ${tok}" \
+              "https://ghcr.io/v2/${OWNER}/${pkg}/tags/list")
+            if [ "$code" = 200 ]; then
+              echo "  ok      ${pkg}"
+            else
+              echo "  NOT OK  ${pkg} (anonymous pull http ${code})"
+              bad+=("${pkg}")
+            fi
+          done
+
+          if [ "${#bad[@]}" -gt 0 ]; then
+            {
+              echo "### ❌ GHCR packages not anonymously pullable"
+              echo
+              echo "Cluster nodes pull without credentials, so each must be public"
+              echo "(or, if brand new, pushed at least once then flipped public)."
+              echo "GitHub has no API to set visibility — fix each in the UI:"
+              echo
+              for p in "${bad[@]}"; do
+                echo "- \`${p}\` — https://github.com/users/${OWNER}/packages/container/${p}/settings"
+              done
+            } | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          echo "All ${#images[@]} packages are anonymously pullable. ✅"


### PR DESCRIPTION
## Summary

New GHCR packages default to **private**, and GitHub exposes **no API to set package visibility** (the [packages REST API](https://docs.github.com/en/rest/packages/packages) is GET/DELETE/restore only). So every new in-cluster image silently `ImagePullBackOff`s on the credential-less Talos nodes until someone flips it to public in the UI — a recurring, easy-to-miss trap.

This adds a `devel` CI guard that **detects** the problem loudly (it can't auto-fix, since there's no API).

## How

- **SSOT**: reads `ghcr.io/<owner>/<pkg>` image names from the `ImageRepository` manifests under `cluster/k8s/flux-image-automation-ghcr/` (Harbor images excluded).
- **Test**: for each, requests an anonymous `ghcr.io` pull token and hits `tags/list` — `200` means anonymously pullable (public), `403` means private/not-pushed. This tests the *actual property nodes rely on* and needs **no secret** (the packages API requires auth even for public packages, so it's unusable here).
- **On failure**: fails the job with a per-package settings link in the step summary.

Runs on `flux-image-automation-ghcr/**` changes, daily (drift), and `workflow_dispatch`.

## Notes

- Verified locally: public `haku-worker`/`airlock` → 200; unpushed `codex-pod` → 403.
- Follow-up idea (auto-fix if a mechanism is ever found) captured in `idea/ghcr_public_image_automation.md`.