### PR TITLE
docs(tana): drop shipped LiteLLM-proxy-backend items from TODO

### DIFF
--- a/tana/litellm_proxy/TODO.md
+++ b/tana/litellm_proxy/TODO.md
@@ -8,13 +8,6 @@ source-faithful to that evidence.
 
 ## P0: Required before OpenCode or Claude Code use
 
-- Run this as the cluster's real LiteLLM Proxy backend, not only a Python demo:
-  - switch `cluster/k8s/litellm` to the custom image
-  - add `custom_provider_map` config for provider `tana`
-  - add model entries with Claude-shaped external names, e.g.
-    `claude-3-5-sonnet-latest -> tana/claude-3-5-sonnet-latest`
-  - keep `tana.litellm_proxy.custom_handler.tana_handler` as the stable handler
-    object referenced by the proxy config
 - Add OpenAI-compatible smoke tests through LiteLLM Proxy:
   - `/v1/chat/completions`
   - streaming `/v1/chat/completions`


### PR DESCRIPTION
Audit of `tana/litellm_proxy/TODO.md` P0 against the live deployment. Removes the one fully-shipped block; keeps genuinely-open work.

**Removed — "Run this as the cluster's real LiteLLM Proxy backend"** (all four sub-bullets are live in `cluster/k8s/litellm/tana/`):
- custom image — `ghcr.io/agentydragon/tana-litellm-proxy` (`deployment.yaml`, Flux image policy)
- `custom_provider_map` for provider `tana` (`proxy-config.yaml`, `generate_tana_litellm.py`)
- Claude-shaped model entries — `claude-3-5-sonnet-latest`, `claude-3-7-sonnet-*` (`proxy-config.yaml`)
- `tana.litellm_proxy.custom_handler.tana_handler` referenced as the stable handler

**Kept (still open):**
- OpenAI + Anthropic smoke tests through the proxy (existing tests are import/config only, not endpoint smoke tests)
- auth deployment-safe cross-namespace reflection (`TANA_FIREBASE_REFRESH_TOKEN` is wired, but the reflection-into-namespace mechanism wasn't confirmed)
- upstream-failure → client-error mapping (`custom_handler.py` is a 7-line shim)
- RE-listed models still failing (`gpt-4*`, `gpt-5.2/xhigh`, `gpt-5.4/xhigh`)

Docs only. `pre-commit run --files` → prettier passes.