### PR TITLE
haku: shared TF vault + identical toolsets across both agents

### DIFF
--- a/haku/base/BUILD.bazel
+++ b/haku/base/BUILD.bazel
@@ -12,6 +12,7 @@ py_test(
     deps = [
         "//util/bazel:runfiles",
         "@pypi//pygohcl",
+        "@pypi//pytest",
         "@pypi//pytest_bazel",
         "@pypi//pyyaml",
     ],

--- a/haku/base/agent_shared.yaml
+++ b/haku/base/agent_shared.yaml
@@ -14,21 +14,19 @@
 # Secret); both agents reference it. (Runtime C, haku/runtime/agent, is env-driven via
 # HAKU_MODEL — a separate architecture, not covered here.)
 model: claude-sonnet-4-6
-# The fixed in-sandbox bash/read/write/edit/glob/grep toolset (always_allow — the
-# execution sandbox is the trust boundary in both runtimes).
-agent_toolset: agent_toolset_20260401
-# Every MCP server + its mcp_toolset permission policy. All always_allow; each is
-# bounded server-side (read-only facades, or gmail-labeling's `haku/`-prefix closure).
-mcp_servers:
-  kubectl-machine:
-    url: https://kubectl-machine-mcp.allegedly.works/mcp
-    toolset_permission_policy: always_allow
-  grocy-sf:
-    url: https://grocy-mcp-sf.allegedly.works/mcp
-    toolset_permission_policy: always_allow
-  tana-ro:
-    url: https://tana-mcp-ro.allegedly.works/mcp
-    toolset_permission_policy: always_allow
-  gmail-labeling:
-    url: https://gmail-labeling.allegedly.works/mcp
-    toolset_permission_policy: always_allow
+# Every toolset -> permission policy: mcp toolsets keyed by MCP server name, the
+# fixed in-sandbox bash/read/write/edit/glob/grep toolset by its type. All
+# always_allow — the execution sandbox is the trust boundary, and each MCP is bounded
+# server-side (read-only facades, or gmail-labeling's `haku/`-prefix closure).
+toolset_policies:
+  agent_toolset_20260401: always_allow
+  kubectl-machine: always_allow
+  grocy-sf: always_allow
+  tana-ro: always_allow
+  gmail-labeling: always_allow
+# MCP server name -> URL.
+mcp_urls:
+  kubectl-machine: https://kubectl-machine-mcp.allegedly.works/mcp
+  grocy-sf: https://grocy-mcp-sf.allegedly.works/mcp
+  tana-ro: https://tana-mcp-ro.allegedly.works/mcp
+  gmail-labeling: https://gmail-labeling.allegedly.works/mcp

--- a/haku/base/agent_shared.yaml
+++ b/haku/base/agent_shared.yaml
@@ -1,17 +1,31 @@
-# Single source of truth for the Haku agent-config fields that are duplicated
-# across the two managed-agent surfaces:
+# Single source of truth for the shared Haku agent config. The two managed-agent
+# surfaces are now identical on everything below — same model, same toolset:
 #   - cloud (Anthropic-hosted): ../../tf/gitops/haku-cloud-agent/main.tf (HCL)
 #   - self-hosted:              ../runtime/managed_agent/self_hosted/haku.agent.yaml (YAML)
 #
-# test_agent_config_ssot.py parses both surfaces and fails if either drifts from
-# the values here — so edit these, then update both surfaces to match.
+# test_agent_config_ssot.py parses both surfaces and asserts (a) each matches these
+# values and (b) the two are identical to each other (toolset parity). Edit here,
+# then update both surfaces, or the test fails.
 #
-# Only genuinely-shared, static fields belong here. Surface-specific wiring stays
-# per-surface: cloud-only kubectl-machine/grocy-sf MCPs, networking, and the vault
-# credentials that read live k8s secrets; self-hosted's in-pod agent_toolset.
-# (Runtime C, haku/runtime/agent, is env-driven via HAKU_MODEL — not covered here.)
+# What stays per-surface (NOT here): `name` (haku-cloud vs haku-selfhosted), the
+# `system` bootstrap prose, the `environment` (cloud+networking vs self_hosted), and
+# how each reaches its vault. The vault + all four MCP credentials are one shared,
+# TF-managed vault (tf/gitops/haku-cloud-agent, published to the haku-cloud-agent-ids
+# Secret); both agents reference it. (Runtime C, haku/runtime/agent, is env-driven via
+# HAKU_MODEL — a separate architecture, not covered here.)
 model: claude-sonnet-4-6
+# The fixed in-sandbox bash/read/write/edit/glob/grep toolset (always_allow — the
+# execution sandbox is the trust boundary in both runtimes).
+agent_toolset: agent_toolset_20260401
+# Every MCP server + its mcp_toolset permission policy. All always_allow; each is
+# bounded server-side (read-only facades, or gmail-labeling's `haku/`-prefix closure).
 mcp_servers:
+  kubectl-machine:
+    url: https://kubectl-machine-mcp.allegedly.works/mcp
+    toolset_permission_policy: always_allow
+  grocy-sf:
+    url: https://grocy-mcp-sf.allegedly.works/mcp
+    toolset_permission_policy: always_allow
   tana-ro:
     url: https://tana-mcp-ro.allegedly.works/mcp
     toolset_permission_policy: always_allow

--- a/haku/base/test_agent_config_ssot.py
+++ b/haku/base/test_agent_config_ssot.py
@@ -25,35 +25,24 @@ _CLOUD = pygohcl.loads(get_required_path("_main/tf/gitops/haku-cloud-agent/main.
 _SURFACES = {"self_hosted": _SELF_HOSTED, "cloud": _CLOUD}
 
 
-def _mcp_urls(agent: dict) -> dict[str, str]:
-    return {s["name"]: s["url"] for s in agent["mcp_servers"]}
-
-
-def _toolset_policies(agent: dict) -> dict[str, str]:
-    """mcp_server_name -> permission-policy type, for every mcp_toolset."""
+def _normalize(surface: dict) -> dict:
+    """Re-express a parsed surface (YAML or HCL) in agent_shared.yaml's shape. An
+    mcp_toolset is keyed by its MCP server name, the built-in toolset by its type."""
     return {
-        t["mcp_server_name"]: t["default_config"]["permission_policy"]["type"]
-        for t in agent["tools"]
-        if t["type"] == "mcp_toolset"
-    }
-
-
-def _builtin_toolsets(agent: dict) -> dict[str, str]:
-    """non-mcp toolset type -> permission-policy type (e.g. agent_toolset_20260401)."""
-    return {
-        t["type"]: t["default_config"]["permission_policy"]["type"]
-        for t in agent["tools"]
-        if t["type"] != "mcp_toolset"
+        "model": surface["model"],
+        "toolset_policies": {
+            (t["mcp_server_name"] if t["type"] == "mcp_toolset" else t["type"]): t["default_config"][
+                "permission_policy"
+            ]["type"]
+            for t in surface["tools"]
+        },
+        "mcp_urls": {s["name"]: s["url"] for s in surface["mcp_servers"]},
     }
 
 
 @pytest.mark.parametrize("surface", _SURFACES.values(), ids=list(_SURFACES))
 def test_surface_matches_ssot(surface):
-    assert surface["model"] == _SHARED["model"]
-    assert _mcp_urls(surface) == {n: s["url"] for n, s in _SHARED["mcp_servers"].items()}
-    assert _toolset_policies(surface) == {n: s["toolset_permission_policy"] for n, s in _SHARED["mcp_servers"].items()}
-    # The built-in agent_toolset is shared too (always_allow in both).
-    assert _builtin_toolsets(surface) == {_SHARED["agent_toolset"]: "always_allow"}
+    assert _normalize(surface) == _SHARED
 
 
 if __name__ == "__main__":

--- a/haku/base/test_agent_config_ssot.py
+++ b/haku/base/test_agent_config_ssot.py
@@ -23,7 +23,6 @@ _CLOUD = pygohcl.loads(get_required_path("_main/tf/gitops/haku-cloud-agent/main.
 ]["haku_cloud"]
 
 _SURFACES = {"self_hosted": _SELF_HOSTED, "cloud": _CLOUD}
-_surface = pytest.mark.parametrize("surface", _SURFACES.values(), ids=list(_SURFACES))
 
 
 def _mcp_urls(agent: dict) -> dict[str, str]:
@@ -48,18 +47,10 @@ def _builtin_toolsets(agent: dict) -> dict[str, str]:
     }
 
 
-@_surface
-def test_model_matches_ssot(surface):
+@pytest.mark.parametrize("surface", _SURFACES.values(), ids=list(_SURFACES))
+def test_surface_matches_ssot(surface):
     assert surface["model"] == _SHARED["model"]
-
-
-@_surface
-def test_mcp_servers_match_ssot(surface):
     assert _mcp_urls(surface) == {n: s["url"] for n, s in _SHARED["mcp_servers"].items()}
-
-
-@_surface
-def test_toolset_policies_match_ssot(surface):
     assert _toolset_policies(surface) == {n: s["toolset_permission_policy"] for n, s in _SHARED["mcp_servers"].items()}
     # The built-in agent_toolset is shared too (always_allow in both).
     assert _builtin_toolsets(surface) == {_SHARED["agent_toolset"]: "always_allow"}

--- a/haku/base/test_agent_config_ssot.py
+++ b/haku/base/test_agent_config_ssot.py
@@ -1,6 +1,6 @@
-"""SSOT / parity guard: the two Haku managed-agent surfaces — cloud (TF/HCL) and
-self-hosted (`ant` YAML) — must share an identical config (model + full toolset),
-and both must match haku/base/agent_shared.yaml.
+"""SSOT guard: both Haku managed-agent surfaces — cloud (TF/HCL) and self-hosted
+(`ant` YAML) — must match haku/base/agent_shared.yaml on model + full toolset.
+Matching a shared SSOT is what keeps the two identical ("one brain, two substrates").
 
 Both surfaces are parsed structurally — the self-hosted YAML with PyYAML, the
 cloud HCL with pygohcl (HashiCorp's parser) — not by regex over the text. Edit
@@ -54,14 +54,6 @@ def test_surface_matches_ssot(surface):
     assert _toolset_policies(surface) == {n: s["toolset_permission_policy"] for n, s in _SHARED["mcp_servers"].items()}
     # The built-in agent_toolset is shared too (always_allow in both).
     assert _builtin_toolsets(surface) == {_SHARED["agent_toolset"]: "always_allow"}
-
-
-def test_toolset_parity_between_surfaces():
-    # Belt-and-suspenders: the two agents must be identical on the whole toolset,
-    # independent of the SSOT file — "one brain, two substrates".
-    assert _mcp_urls(_SELF_HOSTED) == _mcp_urls(_CLOUD)
-    assert _toolset_policies(_SELF_HOSTED) == _toolset_policies(_CLOUD)
-    assert _builtin_toolsets(_SELF_HOSTED) == _builtin_toolsets(_CLOUD)
 
 
 if __name__ == "__main__":

--- a/haku/base/test_agent_config_ssot.py
+++ b/haku/base/test_agent_config_ssot.py
@@ -1,5 +1,6 @@
-"""SSOT drift guard: the Haku agent fields duplicated across the cloud (TF) and
-self-hosted (`ant` YAML) surfaces must match haku/base/agent_shared.yaml.
+"""SSOT / parity guard: the two Haku managed-agent surfaces — cloud (TF/HCL) and
+self-hosted (`ant` YAML) — must share an identical config (model + full toolset),
+and both must match haku/base/agent_shared.yaml.
 
 Both surfaces are parsed structurally — the self-hosted YAML with PyYAML, the
 cloud HCL with pygohcl (HashiCorp's parser) — not by regex over the text. Edit
@@ -7,6 +8,7 @@ agent_shared.yaml, then update both surfaces, or this fails.
 """
 
 import pygohcl
+import pytest
 import pytest_bazel
 import yaml
 
@@ -20,12 +22,16 @@ _CLOUD = pygohcl.loads(get_required_path("_main/tf/gitops/haku-cloud-agent/main.
     "claude-managed-agents_agent"
 ]["haku_cloud"]
 
+_SURFACES = {"self_hosted": _SELF_HOSTED, "cloud": _CLOUD}
+_surface = pytest.mark.parametrize("surface", _SURFACES.values(), ids=list(_SURFACES))
 
-def _urls(agent: dict) -> dict[str, str]:
+
+def _mcp_urls(agent: dict) -> dict[str, str]:
     return {s["name"]: s["url"] for s in agent["mcp_servers"]}
 
 
 def _toolset_policies(agent: dict) -> dict[str, str]:
+    """mcp_server_name -> permission-policy type, for every mcp_toolset."""
     return {
         t["mcp_server_name"]: t["default_config"]["permission_policy"]["type"]
         for t in agent["tools"]
@@ -33,19 +39,38 @@ def _toolset_policies(agent: dict) -> dict[str, str]:
     }
 
 
-def test_model_matches_ssot():
-    assert _SELF_HOSTED["model"] == _SHARED["model"]
-    assert _CLOUD["model"] == _SHARED["model"]
+def _builtin_toolsets(agent: dict) -> dict[str, str]:
+    """non-mcp toolset type -> permission-policy type (e.g. agent_toolset_20260401)."""
+    return {
+        t["type"]: t["default_config"]["permission_policy"]["type"]
+        for t in agent["tools"]
+        if t["type"] != "mcp_toolset"
+    }
 
 
-def test_shared_mcp_servers_match_ssot():
-    self_hosted_urls, cloud_urls = _urls(_SELF_HOSTED), _urls(_CLOUD)
-    self_hosted_pol, cloud_pol = _toolset_policies(_SELF_HOSTED), _toolset_policies(_CLOUD)
-    for name, spec in _SHARED["mcp_servers"].items():
-        assert self_hosted_urls[name] == spec["url"]
-        assert cloud_urls[name] == spec["url"]
-        assert self_hosted_pol[name] == spec["toolset_permission_policy"]
-        assert cloud_pol[name] == spec["toolset_permission_policy"]
+@_surface
+def test_model_matches_ssot(surface):
+    assert surface["model"] == _SHARED["model"]
+
+
+@_surface
+def test_mcp_servers_match_ssot(surface):
+    assert _mcp_urls(surface) == {n: s["url"] for n, s in _SHARED["mcp_servers"].items()}
+
+
+@_surface
+def test_toolset_policies_match_ssot(surface):
+    assert _toolset_policies(surface) == {n: s["toolset_permission_policy"] for n, s in _SHARED["mcp_servers"].items()}
+    # The built-in agent_toolset is shared too (always_allow in both).
+    assert _builtin_toolsets(surface) == {_SHARED["agent_toolset"]: "always_allow"}
+
+
+def test_toolset_parity_between_surfaces():
+    # Belt-and-suspenders: the two agents must be identical on the whole toolset,
+    # independent of the SSOT file — "one brain, two substrates".
+    assert _mcp_urls(_SELF_HOSTED) == _mcp_urls(_CLOUD)
+    assert _toolset_policies(_SELF_HOSTED) == _toolset_policies(_CLOUD)
+    assert _builtin_toolsets(_SELF_HOSTED) == _builtin_toolsets(_CLOUD)
 
 
 if __name__ == "__main__":

--- a/haku/runtime/managed_agent/self_hosted/README.md
+++ b/haku/runtime/managed_agent/self_hosted/README.md
@@ -39,6 +39,15 @@ applied for this reason, so it was reverted. Revisit only if the provider gains
 issue is the path there. The **cloud** agent stays on TF — the provider handles
 `type = "cloud"` fine.
 
+Only the **environment / agent / deployment** are imperative. The **vault + all MCP
+credentials are declarative and shared**: the cloud agent module
+(`tf/gitops/haku-cloud-agent`) owns one vault used by both agents, publishing its ID
+to the `haku-cloud-agent-ids` Secret; `provision.sh` reads that ID instead of creating
+its own vault, so tana-ro/gmail-labeling/kubectl-machine/grocy-sf tokens get TF
+drift-detection + rotation for the self-hosted agent too. The agent's toolset is
+identical to the cloud agent's — kept in step by
+`//haku/base:test_agent_config_ssot`.
+
 ## The worker is `worker.py` on the anthropic Python SDK (not `ant`)
 
 The poll loop is `worker.py`, built on the official `anthropic` Python SDK's
@@ -71,9 +80,9 @@ durable memory, so a cold session just re-orients.
 | File                    | Role                                                                                 | Runs on       |
 | ----------------------- | ------------------------------------------------------------------------------------ | ------------- |
 | `haku.environment.yaml` | self-hosted environment (`ant beta:environments create`)                             | control plane |
-| `haku.agent.yaml`       | agent: thin `system` pointer, fixed toolset + tana-ro & gmail-labeling `mcp_toolset` | control plane |
+| `haku.agent.yaml`       | agent: thin `system` pointer, fixed toolset + 4 MCP `mcp_toolset`s (= cloud agent)   | control plane |
 | `haku.deployment.yaml`  | scheduled-deployment wake trigger                                                    | control plane |
-| `provision.sh`          | one-shot: create environment/agent/vault/deployment via `ant`                        | operator / CI |
+| `provision.sh`          | one-shot: create environment/agent/deployment via `ant` (vault is the shared TF one) | operator / CI |
 | `entrypoint.sh`         | clone ducktape + haku-state, then exec `haku-worker`                                 | `haku-worker` |
 | `worker.py`             | the poll loop (anthropic Python SDK `EnvironmentWorker`)                             | `haku-worker` |
 | `nixos.nix`             | full-NixOS worker image (`nix build .#haku-worker-image`)                            | CI / build    |
@@ -103,9 +112,11 @@ by Flux — see <../../../../cluster/docs/container-images.md>.
 
 The fixed toolset is `agent_toolset_20260401` (`bash/read/write/edit/glob/grep`);
 Haku reaches Plaid (`psql`), Google (`curl`), and the cluster (`kubectl`,
-in-cluster `haku` SA) through `bash`. Tana (read-only) and gmail-labeling (Haku's
-one sanctioned world-write, bounded server-side to labels under `haku/`) are
-native `mcp_toolset`s (Anthropic-side, vault auth).
+in-cluster `haku` SA) through `bash`. On top of that it has four native
+`mcp_toolset`s (Anthropic-side, shared-vault auth), identical to the cloud agent:
+`tana-ro` (read-only Tana), `gmail-labeling` (the one sanctioned world-write,
+bounded to `haku/` labels), `grocy-sf` (read-only grocy), and `kubectl-machine`
+(a machine-JWT cluster path — redundant here with in-pod `kubectl`, kept for parity).
 
 ## k8s wiring
 
@@ -135,11 +146,12 @@ through CI + Flux. Live IDs: agent `agent_01CV5VupX8ALuVD1dsoEzHY6`, deployment
 `depl_011DSrUoXuhoDWJoPyDuePqR` (haku-scan), environment
 `env_015uqL9WAMSDytQEWWmLG9zF`.
 
-Enabling gmail-labeling on the **live** agent (added after first bring-up) is the
-same two-step: create the gmail-labeling vault credential (the new block in
-`provision.sh`, or `ant beta:vaults:credentials create --vault-id <VAULT_ID>`
-against the live vault), then push the new agent version below so the
-`gmail-labeling` `mcp_toolset` takes effect.
+The MCP **credentials** live in the shared TF vault (`tf/gitops/haku-cloud-agent`),
+so enabling a new MCP on the live agent no longer means creating a credential here —
+Flux applies it on the shared vault. You only push the new agent version (below) so
+the `mcp_toolset` takes effect, and re-point the deployment at the shared vault once
+(`ant beta:deployments update --deployment-id <id> --vault-id <shared-vault-id>`,
+from the `haku-cloud-agent-ids` Secret).
 
 After editing `haku.agent.yaml`, apply it and re-pin in **both** steps:
 

--- a/haku/runtime/managed_agent/self_hosted/haku.agent.yaml
+++ b/haku/runtime/managed_agent/self_hosted/haku.agent.yaml
@@ -3,20 +3,15 @@
 # behavior stays single-sourced in haku/base + haku/run.md, which the worker
 # clones into the agent workdir at startup (see entrypoint.sh).
 #
-# SYNC: the shared bits below — `model`, and the `tana-ro` + `gmail-labeling` MCP
-# servers/toolsets (URLs + always_allow) — are duplicated in the cloud surface,
-# <../../../../tf/gitops/haku-cloud-agent/main.tf> (HCL). SSOT is
-# <../../../base/agent_shared.yaml>, enforced by //haku/base:test_agent_config_ssot
-# (fails on drift) — no live codegen (the tofu-controller runner can't read repo-wide
-# files), so update this + main.tf to match the SSOT. Runtime C (haku/runtime/agent,
-# env-driven via HAKU_MODEL) is a separate architecture, not a copy.
-# Agent object name (matches the `haku-selfhosted` environment; sibling is `haku-cloud`).
-# The persona is still "Haku" (see `system` below); this is just the control-plane name.
+# SYNC: `model` + full toolset are identical to the cloud agent
+# (<../../../../tf/gitops/haku-cloud-agent/main.tf>). SSOT haku/base/agent_shared.yaml,
+# parity enforced by //haku/base:test_agent_config_ssot — a red run shows any drift.
+#
+# `name`: the control-plane object name (matches the `haku-selfhosted` environment;
+# sibling `haku-cloud`). Persona stays "Haku" (see `system`).
 name: haku-selfhosted
 # TEMP(debugging): Sonnet while we shake out the self-hosted worker; restore
-# claude-opus-4-8 once sessions run end-to-end. `model` is SSOT'd in
-# haku/base/agent_shared.yaml (//haku/base:test_agent_config_ssot enforces) — change
-# it there and in the cloud main.tf together, or the test fails.
+# claude-opus-4-8 once sessions run end-to-end.
 model: claude-sonnet-4-6
 system: |
   You are Haku, the operator's tireless background executive assistant. A worker
@@ -31,6 +26,10 @@ system: |
   Read the manual and the run procedure, then execute the run procedure end to
   end. Each user message is a wake: do one scan pass, commit and push haku-state,
   then stop and wait for the next wake.
+# The MCP-credential auth for every mcp_toolset below is injected at Anthropic's
+# egress from the SHARED, TF-managed vault (tf/gitops/haku-cloud-agent; both agents
+# reference it) — the pod never sees a token. Toolset set is identical to the cloud
+# agent; keep it that way (test_agent_config_ssot).
 tools:
   # Fixed built-in toolset, supplied by the `ant` worker in the pod. The Pod is
   # the trust boundary (Ember posture), so everything is auto-allowed.
@@ -39,21 +38,33 @@ tools:
       enabled: true
       permission_policy:
         type: always_allow
-  # Tana (read-only) as a native MCP tool; auth is injected at Anthropic's egress
-  # from the vault credential (provision.sh), so the pod never sees the token.
-  # Auto-allow like the bash toolset: it's the read-only Tana facade and the pod
-  # is the trust boundary — without this the mcp_toolset defaults to always_ask,
-  # which parks an unattended scan on the first Tana call awaiting approval.
+  # kubectl-machine — cluster access via the machine-JWT MCP. Redundant with this
+  # runtime's in-pod kubectl (in-cluster SA), but kept for parity with the cloud
+  # agent; Anthropic calls the MCP, so no pod egress is involved.
+  - type: mcp_toolset
+    mcp_server_name: kubectl-machine
+    default_config:
+      enabled: true
+      permission_policy:
+        type: always_allow
+  # grocy-sf — read-only grocy facade.
+  - type: mcp_toolset
+    mcp_server_name: grocy-sf
+    default_config:
+      enabled: true
+      permission_policy:
+        type: always_allow
+  # tana-ro — read-only Tana facade. Auto-allow (read-only facade + trust boundary);
+  # without it the mcp_toolset defaults to always_ask and parks an unattended scan.
   - type: mcp_toolset
     mcp_server_name: tana-ro
     default_config:
       enabled: true
       permission_policy:
         type: always_allow
-  # gmail-labeling toolset — write, but bounded by construction to `haku/` labels
-  # (closure invariant enforced server-side before any Gmail call), so always_allow
-  # is safe; the server, not in-agent gating, is the fence. Haku's ONE sanctioned
-  # world-write. Bearer-gated by the gmail-labeling vault credential (provision.sh).
+  # gmail-labeling — write, but bounded by construction to `haku/` labels (closure
+  # invariant enforced server-side), so always_allow is safe; the server is the
+  # fence. Haku's ONE sanctioned world-write.
   - type: mcp_toolset
     mcp_server_name: gmail-labeling
     default_config:
@@ -61,6 +72,12 @@ tools:
       permission_policy:
         type: always_allow
 mcp_servers:
+  - type: url
+    name: kubectl-machine
+    url: https://kubectl-machine-mcp.allegedly.works/mcp
+  - type: url
+    name: grocy-sf
+    url: https://grocy-mcp-sf.allegedly.works/mcp
   - type: url
     name: tana-ro
     url: https://tana-mcp-ro.allegedly.works/mcp

--- a/haku/runtime/managed_agent/self_hosted/provision.sh
+++ b/haku/runtime/managed_agent/self_hosted/provision.sh
@@ -22,34 +22,14 @@ echo "     secret on the haku-worker Deployment (it is never created via the API
 AGENT_ID=$(ant beta:agents create --transform id -r <"$here/haku.agent.yaml")
 echo "agent: $AGENT_ID"
 
-# Vault for MCP credentials. Each static bearer is read from the owning namespace
-# and piped via stdin, never argv. Anthropic injects it at egress; the pod never
-# sees it.
-VAULT_ID=$(ant beta:vaults create --display-name haku-mcp --transform id -r)
-echo "vault: $VAULT_ID"
-
-# tana-mcp-ro: read-only Tana facade. Bearer already reflected into haku-sandbox.
-TANA_TOKEN=$(kubectl -n haku-sandbox get secret haku-tana-ro-token -o jsonpath='{.data.token}' | base64 -d)
-ant beta:vaults:credentials create --vault-id "$VAULT_ID" >/dev/null <<YAML
-display_name: tana-mcp-ro (read-only)
-auth:
-  type: static_bearer
-  mcp_server_url: https://tana-mcp-ro.allegedly.works/mcp
-  token: ${TANA_TOKEN}
-YAML
-echo "  -> tana-mcp-ro credential stored in vault $VAULT_ID"
-
-# gmail-labeling: Haku's ONE sanctioned world-write, bounded server-side to
-# labels under `haku/`. The MCP's static client bearer lives in its own namespace.
-GMAIL_TOKEN=$(kubectl -n gmail-labeling get secret haku-gmail-labeling-token -o jsonpath='{.data.token}' | base64 -d)
-ant beta:vaults:credentials create --vault-id "$VAULT_ID" >/dev/null <<YAML
-display_name: gmail-labeling (managed labels under haku/)
-auth:
-  type: static_bearer
-  mcp_server_url: https://gmail-labeling.allegedly.works/mcp
-  token: ${GMAIL_TOKEN}
-YAML
-echo "  -> gmail-labeling credential stored in vault $VAULT_ID"
+# Shared vault: the vault + ALL MCP credentials (kubectl-machine, grocy-sf, tana-ro,
+# gmail-labeling) are TF-managed by the cloud agent module (tf/gitops/haku-cloud-agent)
+# and published to the haku-cloud-agent-ids Secret. Both agents reference the same
+# vault, so this agent no longer creates its own — read the shared ID. (The vault +
+# creds are the one part of the self-hosted agent that IS declarative; only the
+# environment/agent/deployment stay imperative, since the provider can't do self_hosted.)
+VAULT_ID=$(kubectl -n flux-system get secret haku-cloud-agent-ids -o jsonpath='{.data.vault_id}' | base64 -d)
+echo "shared vault: $VAULT_ID"
 
 # Scheduled deployment = the wake trigger (one fresh session per fire).
 DEPL_ID=$(ant beta:deployments create \

--- a/tf/gitops/haku-cloud-agent/main.tf
+++ b/tf/gitops/haku-cloud-agent/main.tf
@@ -38,17 +38,13 @@ resource "claude-managed-agents_environment" "haku_cloud" {
   }
 }
 
-# SYNC: the shared bits below — `model`, and the `tana-ro` + `gmail-labeling` MCP
-# servers/toolsets (URLs + always_allow) — are duplicated in the self-hosted surface,
-# <../../../haku/runtime/managed_agent/self_hosted/haku.agent.yaml> (YAML applied via `ant`).
-# SSOT is <../../../haku/base/agent_shared.yaml>, enforced by
-# //haku/base:test_agent_config_ssot (fails on drift) — no live codegen (this module can't
-# read repo-wide files from the runner), so update this + haku.agent.yaml to match the SSOT.
-# Cloud-only here: kubectl-machine + grocy-sf MCPs and networking.
+# SYNC: `model` + full toolset are identical to the self-hosted agent
+# (<../../../haku/runtime/managed_agent/self_hosted/haku.agent.yaml>). SSOT
+# haku/base/agent_shared.yaml, parity enforced by //haku/base:test_agent_config_ssot
+# — a red run shows any drift. The vault + all four credentials below are shared:
+# self-hosted references this vault via the haku-cloud-agent-ids output Secret.
 resource "claude-managed-agents_agent" "haku_cloud" {
-  name = "haku-cloud"
-  # `model` is SSOT'd in haku/base/agent_shared.yaml (//haku/base:test_agent_config_ssot
-  # enforces) — change it there and in the self-hosted haku.agent.yaml together.
+  name  = "haku-cloud"
   model = "claude-sonnet-4-6" # TEMP(bring-up): revisit (opus) once the cloud runtime is proven.
 
   system = <<-EOT


### PR DESCRIPTION
Makes the two Haku managed-agents "one brain, two substrates": identical `model` + toolset, one shared vault.

## Shared vault (creds in TF for self-hosted too)
The vault + all four MCP credentials already live in `tf/gitops/haku-cloud-agent` and it already outputs `vault_id` to the `haku-cloud-agent-ids` Secret. So **no new module and no cross-state migration** — self-hosted just references it:
- `provision.sh` stops creating its own vault; it reads the shared vault ID from that Secret and passes it to the deployment. The self-hosted agent's MCP creds are now **declarative** (TF drift-detection + rotation), not hand-created. Only env/agent/deployment stay imperative (the provider still can't do `self_hosted`).

## Identical toolsets
- Self-hosted `haku.agent.yaml` gains `kubectl-machine` + `grocy-sf` `mcp_toolset`s → now identical to cloud. (kubectl-machine is redundant with in-pod `kubectl` but kept for parity; Anthropic calls the MCP, no pod egress involved.)

## SSOT / parity test
- `agent_shared.yaml` extended to the full toolset. `test_agent_config_ssot` now (parametrized over both surfaces) asserts each matches the SSOT **and** that the two are identical to each other (toolset parity). Verified on RBE — green, and red on injected drift.
- SYNC comments trimmed to terse pointers now the test is the enforcement.

## Not in this PR — live migration (post-merge)
Point the self-hosted deployment (`depl_011…`) at the shared vault, then delete the old imperative `haku-mcp` vault + the gmail-labeling credential I created imperatively earlier. I'll do that as a separate, confirmed step after merge.