### PR TITLE
chore(haku): suspend cloud-agent-tf (operator deleted the live objects)

### DIFF
--- a/cluster/k8s/haku/cloud-agent-tf/terraform.yaml
+++ b/cluster/k8s/haku/cloud-agent-tf/terraform.yaml
@@ -4,6 +4,15 @@ metadata:
   name: haku-cloud-agent
   namespace: flux-system
 spec:
+  # SUSPENDED 2026-07-04: the operator deleted the cloud managed-agent objects
+  # (agent/env/vault/deployment) directly at Anthropic. The claude-managed-agents
+  # provider's Read doesn't detect the 404s, so tofu-controller would keep reporting
+  # "no changes" against a phantom state (and the haku-cloud-agent-ids Secret still
+  # points at the deleted vault). Pause reconciliation until we decide to recreate the
+  # cloud agent (unsuspend) or retire it. NOTE: the self-hosted agent's shared-vault
+  # wiring (PR #2788) reads vault_id from this module's output Secret, so it can't be
+  # cut over until this is unsuspended and re-applied to a live vault.
+  suspend: true
   interval: 15m
   refreshBeforeApply: true
   path: ./tf/gitops/haku-cloud-agent


### PR DESCRIPTION
You deleted the cloud managed-agent objects (agent/env/vault/deployment) directly at Anthropic. The `claude-managed-agents` provider's `Read` doesn't detect the 404s, so tofu-controller keeps reporting `Plan no changes` against phantom state, and the `haku-cloud-agent-ids` output Secret still points at the deleted vault.

Set `spec.suspend: true` on the `haku-cloud-agent` Terraform CR to pause reconciliation until you decide to recreate or retire the cloud agent. Also patched the live CR to `suspend: true` immediately (this manifest makes it durable).

Note: the self-hosted shared-vault cutover (from #2788) stays parked until this is unsuspended and re-applied to a live vault.