### PR TITLE
litellm-keys-tf: add the decryption secretRef (sops-age-cluster-secrets)

### DIFF
--- a/cluster/k8s/litellm/keys-tf/flux-kustomization.yaml
+++ b/cluster/k8s/litellm/keys-tf/flux-kustomization.yaml
@@ -16,10 +16,12 @@ spec:
   path: ./cluster/k8s/litellm/keys-tf
   prune: true
   # Decrypt litellm-zai-clients-sops-age-key.sops.yaml (the narrow SOPS_AGE_KEY for
-  # the tf-runner) so sops_external in tf/gitops/litellm-keys can read the virtual-key
+  # the tf-runner) so sops_file in tf/gitops/litellm-keys can read the virtual-key
   # SSOT. Added when that SOPS file arrived — previously this dir held only plain YAML.
   decryption:
     provider: sops
+    secretRef:
+      name: sops-age-cluster-secrets
   sourceRef:
     kind: GitRepository
     name: flux-system


### PR DESCRIPTION
Fixes the `litellm-keys-tf` kustomization decryption failure: the `decryption` block from #2792 was missing `secretRef: sops-age-cluster-secrets`, so Flux couldn't find the age key and the `litellm-zai-clients-sops-age-key` Secret was never created (the litellm-keys runner then had no `SOPS_AGE_KEY` → sops decrypt '0 successful groups'). Matches every other decrypting kustomization in the repo.