### PR TITLE
haku egress: swap proxy impl mitmproxy → Squid ssl-bump + cache

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -74,3 +74,20 @@ Needs verification:
 ## Repository
 
 - [ ] Add an AGPL-3.0 `LICENSE` file at the repo root and standardize AGPL-3.0 license headers across source files (`README.md` declares AGPL 3.0, but there is no `LICENSE` file and headers are inconsistent)
+
+## Egress proxies
+
+- [ ] **Shared HTTP cache across egress proxies (mind the trust boundary).** As the
+      repo grows more egress proxies (e.g. `haku-egress-proxy`, and future ones per
+      trust tier), each with its **own** allowlist, they re-cache the same public
+      toolchains/wheels/base images N times. A shared artifact cache would dedupe
+      that — but naive sharing weakens the per-proxy allowlist: a cache HIT could
+      serve proxy B an object only proxy A was allowed to _fetch_, and a lower-trust
+      proxy could poison entries a higher-trust one reads. Any shared cache must
+      enforce each proxy's allowlist on **hits** (not just origin fetches) and
+      partition/authenticate entries by trust scope. Options: a Squid `cache_peer`
+      sibling hierarchy with each proxy keeping its own `http_access allowed` in
+      front (share the store, not the gate); or a separate pull-through artifact
+      cache each proxy is explicitly allowlisted to reach (see the
+      `TODO(pull-through-cache)` notes in
+      `cluster/k8s/agents/haku-egress-proxy/cnp-haku-cloud-api-egress.yaml`).

--- a/cluster/k8s/agents/haku-egress-proxy/README.md
+++ b/cluster/k8s/agents/haku-egress-proxy/README.md
@@ -1,24 +1,75 @@
-# Haku Egress Proxy Trust Management
+# Haku Egress Proxy
 
-Haku's egress fence for `haku-sandbox` **and `haku-ci`** — enforcement inventory #5 in
-<../../../../haku/docs/security.md>. The name is implementation-neutral on
-purpose: it is **currently implemented with mitmproxy** (mirroring
-`../mitmproxy`, but with a separate CA and proxy namespace), but the object
-names deliberately avoid `mitmproxy` so the implementation can be swapped (e.g.
-to Squid) without renaming the Namespace/Deployment/Service/CA wiring that other
-manifests depend on.
+`haku-egress-proxy` is Haku's single egress fence for `haku-sandbox` **and `haku-ci`** —
+enforcement inventory #5 in <../../../../haku/docs/security.md>.
+
+The k8s object names are implementation-neutral (`haku-egress-proxy`, not
+`haku-squid`) so a future proxy swap doesn't cascade renames. **It is currently
+implemented with Squid** — the `squid.conf`, the `ubuntu/squid` image, and
+squid-specific paths (`/etc/squid`, `squid-ca.pem`) are the only Squid-named
+artifacts; everything else is generic.
+
+It is a Squid `ssl-bump` caching forward proxy. It does everything mitmproxy did —
+terminate + inspect client TLS, enforce a host allowlist, and splice
+`api.anthropic.com` untouched — **plus** it caches immutable public build/package
+artifacts that haku-sandbox's ad-hoc `pip`/`npx`/nix installs and the Bazelified
+`haku-ci` build pull. `haku-sandbox` pods reach it via the Kyverno
+`inject-haku-egress-proxy` policy; `haku-ci` reaches it via a force-proxy CCNP plus
+its own runner config (see <../../haku-ci/>). Both set `HTTP_PROXY`/`HTTPS_PROXY`
+to `haku-egress-proxy.haku-egress-proxy.svc:8080` and mount the CA bundle. There is
+no credential injection.
+
+## Trust flow
 
 - cert-manager creates `Secret/haku-egress-proxy-ca` in `haku-egress-proxy`.
-- The proxy mounts that Secret and builds mitmproxy's CA file from
-  `tls.key` and `tls.crt`.
-- Reflector mirrors the Secret into `cert-manager`, which is trust-manager's
-  source namespace in this cluster.
+- The init container builds the ssl-bump signing CA (`squid-ca.pem` = `tls.key` +
+  `tls.crt`), initializes the generated-leaf cert DB (`security_file_certgen`),
+  and lays down the `cache_dir` swap structure on the PVC.
+- Reflector mirrors the Secret into `cert-manager`, trust-manager's source
+  namespace in this cluster.
 - trust-manager writes `ConfigMap/haku-egress-proxy-ca-cert` into `haku-sandbox`
-  **and `haku-ci`** (the `Bundle` `namespaceSelector` in `trust-bundle.yaml`).
-- Kyverno mounts that ConfigMap into haku sandbox pods and points common TLS
+  **and `haku-ci`** (the `Bundle` `namespaceSelector` in `trust-bundle.yaml`). The
+  bundle contains public roots, the cluster internal root, and the Squid root.
+- Kyverno mounts that ConfigMap into haku-sandbox pods and points common TLS
   clients at `/egress-proxy-ca/ca-certificates.crt`; `haku-ci` mounts it via its
   own Deployment/runner config (not Kyverno) — see <../../haku-ci/>.
 
-Keep haku CA rotation separate from the main sandbox mitmproxy CA. For planned
-root rollover, trust both old and new roots before restarting the egress proxy
+The CA is the same cert-manager `Certificate`/`Secret` the mitmproxy
+implementation used; the swap only changes which process consumes it (Squid's
+`security_file_certgen` instead of mitmproxy) and how leaves are minted. Keep haku
+CA rotation separate. For a planned root rollover, publish both old and new roots
+in the trust bundle, wait for clients to see it, then restart haku-egress-proxy
 with the new signing key.
+
+## squid.conf design
+
+- **ssl_bump**: `peek step1` → `splice anthropic` (raw passthrough for
+  `api.anthropic.com`, never bumped, never cached) → `bump all` (decrypt, inspect,
+  and cache everything else).
+- **Host allowlist** (`allowed` dstdomain, default-deny): the union of the
+  haku-sandbox set (image registries, pypi/npm, nix, Google APIs, the Haku mailbox,
+  Anthropic) and the `haku-ci` Bazel/toolchain + Forgejo hosts. `http_access allow
+  allowed` / `http_access deny all`. This set MUST equal the pod-egress CNP's
+  `toFQDNs` (cnp-haku-cloud-api-egress.yaml) — enforced by
+  <../../../validation/test_haku_egress_proxy_consistency.py>.
+- **Cache**: `cache_dir` on the 25Gi seaweedfs PVC. Credentialed / user-data hosts
+  (Google APIs, Haku mailbox, the Docker token endpoint, Anthropic) are
+  `cache deny` — no credentialed response can enter the cache. Immutable public
+  hosts (registries, npm/pypi, nix, Bazel/toolchain) are cached, respecting origin
+  `Cache-Control` (no `override-expire` / `ignore-no-cache`, so `no-store`/`private`
+  is always honored; non-200 and `Set-Cookie` responses are never cached).
+- **Audit**: `access_log` to stdout — the L7 audit trail that replaces the mitmweb
+  UI (`kubectl logs` / Loki).
+
+## Deviation: leaf-cert AKI/SKI
+
+Standard cert-manager-issued CA fed to a bumping proxy. **Gotcha carried from the
+mitmproxy incident** (<../../../docs/lessons_learned/2026_06_25_mitmproxy_ca_ski_aki_mismatch.md>):
+cert-manager mints the CA's `SubjectKeyIdentifier` per RFC 7093 (truncated
+SHA-256), and a strict client links a leaf to its issuer by
+`leaf.AKI.keyid == issuer.SKI`. Squid's `security_file_certgen` must therefore
+stamp each generated leaf's `AuthorityKeyIdentifier` with the CA cert's **actual**
+SKI (OpenSSL's `keyid` method copies the issuer's SKI extension when present),
+NOT a recomputed SHA-1. **Verify** after first deploy: extract a bumped leaf and
+confirm its AKI equals the CA SKI, and that `curl` (via the injected trust bundle)
+validates the chain without `-k`.

--- a/cluster/k8s/agents/haku-egress-proxy/README.md
+++ b/cluster/k8s/agents/haku-egress-proxy/README.md
@@ -73,25 +73,3 @@ SKI (OpenSSL's `keyid` method copies the issuer's SKI extension when present),
 NOT a recomputed SHA-1. **Verify** after first deploy: extract a bumped leaf and
 confirm its AKI equals the CA SKI, and that `curl` (via the injected trust bundle)
 validates the chain without `-k`.
-
-## TODO: sharing the cache across proxies (mind the trust boundary)
-
-As the repo grows more egress proxies — likely several, each with its **own**
-allowlist and trust tier — they will re-cache the same public toolchains/wheels/base
-images N times. A shared HTTP artifact cache would deduplicate that. **But naive
-sharing weakens the per-proxy allowlist**, so this needs care:
-
-- **Allowlist bypass on HITs**: if proxy A (allowlist `{X}`) and proxy B (allowlist
-  `{Y}`, `X ∉ Y`) share one store, a cache HIT could serve B an object from `X` that
-  B's allowlist would never let it _fetch_. The allowlist must be enforced on cache
-  **hits**, not just origin fetches — i.e. a HIT for a host outside the requesting
-  proxy's allowlist is still a `deny`.
-- **Cross-tier poisoning**: a lower-trust proxy populating a shared entry that a
-  higher-trust proxy then reads. Entries must be partitioned/authenticated by trust
-  scope, not blindly shared by URL key.
-- **Options**: a Squid `cache_peer` sibling hierarchy with each proxy keeping its own
-  `http_access allowed` in front (allowlist stays per-proxy, only the _store_ is
-  shared); or a separate shared pull-through artifact cache that each proxy is
-  explicitly allowlisted to reach (see the `TODO(pull-through-cache)` notes in
-  `cnp-haku-cloud-api-egress.yaml`). Prefer whichever keeps the allowlist the
-  authoritative gate on every request, cached or not.

--- a/cluster/k8s/agents/haku-egress-proxy/README.md
+++ b/cluster/k8s/agents/haku-egress-proxy/README.md
@@ -49,7 +49,7 @@ with the new signing key.
 - **Host allowlist** (`allowed` dstdomain, default-deny): the union of the
   haku-sandbox set (image registries, pypi/npm, nix, Google APIs, the Haku mailbox,
   Anthropic) and the `haku-ci` Bazel/toolchain + Forgejo hosts. `http_access allow
-  allowed` / `http_access deny all`. This set MUST equal the pod-egress CNP's
+allowed` / `http_access deny all`. This set MUST equal the pod-egress CNP's
   `toFQDNs` (cnp-haku-cloud-api-egress.yaml) — enforced by
   <../../../validation/test_haku_egress_proxy_consistency.py>.
 - **Cache**: `cache_dir` on the 25Gi seaweedfs PVC. Credentialed / user-data hosts

--- a/cluster/k8s/agents/haku-egress-proxy/README.md
+++ b/cluster/k8s/agents/haku-egress-proxy/README.md
@@ -73,3 +73,25 @@ SKI (OpenSSL's `keyid` method copies the issuer's SKI extension when present),
 NOT a recomputed SHA-1. **Verify** after first deploy: extract a bumped leaf and
 confirm its AKI equals the CA SKI, and that `curl` (via the injected trust bundle)
 validates the chain without `-k`.
+
+## TODO: sharing the cache across proxies (mind the trust boundary)
+
+As the repo grows more egress proxies — likely several, each with its **own**
+allowlist and trust tier — they will re-cache the same public toolchains/wheels/base
+images N times. A shared HTTP artifact cache would deduplicate that. **But naive
+sharing weakens the per-proxy allowlist**, so this needs care:
+
+- **Allowlist bypass on HITs**: if proxy A (allowlist `{X}`) and proxy B (allowlist
+  `{Y}`, `X ∉ Y`) share one store, a cache HIT could serve B an object from `X` that
+  B's allowlist would never let it _fetch_. The allowlist must be enforced on cache
+  **hits**, not just origin fetches — i.e. a HIT for a host outside the requesting
+  proxy's allowlist is still a `deny`.
+- **Cross-tier poisoning**: a lower-trust proxy populating a shared entry that a
+  higher-trust proxy then reads. Entries must be partitioned/authenticated by trust
+  scope, not blindly shared by URL key.
+- **Options**: a Squid `cache_peer` sibling hierarchy with each proxy keeping its own
+  `http_access allowed` in front (allowlist stays per-proxy, only the _store_ is
+  shared); or a separate shared pull-through artifact cache that each proxy is
+  explicitly allowlisted to reach (see the `TODO(pull-through-cache)` notes in
+  `cnp-haku-cloud-api-egress.yaml`). Prefer whichever keeps the allowlist the
+  authoritative gate on every request, cached or not.

--- a/cluster/k8s/agents/haku-egress-proxy/cache-pvc.yaml
+++ b/cluster/k8s/agents/haku-egress-proxy/cache-pvc.yaml
@@ -1,0 +1,17 @@
+# Backing store for Squid's HTTP cache (cache_dir in squid.conf). seaweedfs-ovh
+# (the cluster default for app data): not node-pinned, so the proxy pod can
+# reschedule within region hil and keep its cache. Content is only immutable
+# public artifacts (credentialed hosts are `cache deny` in squid.conf) — losing it
+# costs a cold re-fetch, never correctness.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: haku-egress-proxy-cache
+  namespace: haku-egress-proxy
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: seaweedfs-ovh
+  resources:
+    requests:
+      storage: 25Gi

--- a/cluster/k8s/agents/haku-egress-proxy/cnp-haku-cloud-api-egress.yaml
+++ b/cluster/k8s/agents/haku-egress-proxy/cnp-haku-cloud-api-egress.yaml
@@ -1,5 +1,11 @@
 # Allow the haku-egress-proxy egress to the external endpoints Haku workloads need.
-# Additive with the operator's default-deny NetworkPolicy.
+# Squid goes DIRECT to origins (no upstream cache_peer). Additive with the
+# operator's default-deny NetworkPolicy.
+#
+# This L3/L4 FQDN allowlist MUST equal squid.conf's `allowed` dstdomain L7
+# allowlist — Cilium decides whether the packet leaves the proxy pod, Squid decides
+# whether the request is served; drift is caught by
+# cluster/validation/test_haku_egress_proxy_consistency.py.
 #
 # The registry FQDNs (ghcr.io, *.githubusercontent.com, Docker Hub) cover
 # image-related pod egress; Gmail/Calendar reach Google's APIs; the Managed
@@ -125,10 +131,10 @@ spec:
         - ports:
             - port: "443"
               protocol: TCP
-    # Allow forwarding to any in-cluster Service. Sandbox workloads keep
-    # mitmproxy in-path even when targeting cluster endpoints; NO_PROXY in the
-    # inject policy still permits explicit bypass for Service FQDNs that already
-    # match (`*.svc.cluster.local` and `10.0.0.0/8`).
+    # Allow forwarding to any in-cluster Service. Sandbox workloads keep Squid
+    # in-path even when targeting cluster endpoints; NO_PROXY in the inject policy
+    # still permits explicit bypass for Service FQDNs that already match
+    # (`*.svc.cluster.local` and `10.0.0.0/8`).
     - toEntities:
         - cluster
       toPorts:

--- a/cluster/k8s/agents/haku-egress-proxy/deployment.yaml
+++ b/cluster/k8s/agents/haku-egress-proxy/deployment.yaml
@@ -1,3 +1,8 @@
+# Haku's egress proxy for haku-sandbox — currently implemented with Squid (the
+# ubuntu/squid image + squid.conf below). The k8s object names stay
+# implementation-neutral (haku-egress-proxy) so swapping the proxy doesn't
+# cascade renames; only the image, config file, and squid-internal paths are
+# Squid-named.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -9,6 +14,10 @@ metadata:
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
+  # RWO cache PVC: a RollingUpdate would try to mount it on the new pod before the
+  # old pod releases it (multi-attach deadlock). Recreate serializes the swap.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: haku-egress-proxy
@@ -17,85 +26,86 @@ spec:
       labels:
         app.kubernetes.io/name: haku-egress-proxy
     spec:
+      # OVH workers (region hil): keeps the pod near the seaweedfs-ovh (hil-ovh)
+      # volume servers so the cache is region-local. seaweedfs is not node-pinned,
+      # so the pod still reschedules freely within the region.
+      nodeSelector:
+        topology.kubernetes.io/region: hil
       initContainers:
-        - name: mitmproxy-ca-init
-          image: busybox:1.37
-          command:
-            - sh
-            - -c
+        # Build the ssl-bump signing CA, initialize the generated-leaf cert DB, and
+        # lay down the cache_dir swap structure — then hand ownership to `proxy`,
+        # the user Squid's workers run as (cache_effective_user).
+        - name: squid-init
+          # Same image as the main container so security_file_certgen + `squid -z`
+          # match the runtime Squid. Pin verified against the registry before merge
+          # (see README risk note).
+          image: ubuntu/squid:6.6-24.04_beta
+          command: [sh, -c]
+          args:
             - |
-              cat /mitmproxy-ca/tls.key /mitmproxy-ca/tls.crt > /mitmproxy-data/mitmproxy-ca.pem
-              cp /mitmproxy-ca/tls.crt /mitmproxy-data/mitmproxy-ca-cert.pem
+              set -e
+              cat /egress-proxy-ca/tls.key /egress-proxy-ca/tls.crt > /etc/squid/ssl/squid-ca.pem
+              chmod 400 /etc/squid/ssl/squid-ca.pem
+              rm -rf /var/lib/squid/ssl_db
+              /usr/lib/squid/security_file_certgen -c -s /var/lib/squid/ssl_db -M 8MB
+              squid -z -f /config/squid.conf --foreground
+              chown -R proxy:proxy /etc/squid/ssl /var/lib/squid /var/cache/squid
           volumeMounts:
-            - name: mitmproxy-ca
-              mountPath: /mitmproxy-ca
+            - name: egress-proxy-ca
+              mountPath: /egress-proxy-ca
               readOnly: true
-            - name: mitmproxy-data
-              mountPath: /mitmproxy-data
+            - name: config
+              mountPath: /config
+              readOnly: true
+            - name: ssl
+              mountPath: /etc/squid/ssl
+            - name: ssl-db
+              mountPath: /var/lib/squid
+            - name: cache-data
+              mountPath: /var/cache/squid
       containers:
-        - name: mitmproxy
-          # Egress proxy — currently implemented with mitmproxy.
-          # >=12.2.3 (mitmproxy#8214): the leaf's AuthorityKeyIdentifier now
-          # copies the CA cert's SubjectKeyIdentifier instead of recomputing it
-          # as SHA-1. cert-manager mints CA SKIs per RFC 7093 (truncated
-          # SHA-256), so on <12.2.3 every intercepted leaf's AKID mismatched the
-          # CA SKI and strict clients rejected the chain ("unable to get local
-          # issuer certificate"). See
-          # cluster/docs/lessons_learned/2026_06_25_mitmproxy_ca_ski_aki_mismatch.md.
-          image: mitmproxy/mitmproxy:12.2.3
-          command:
-            - mitmweb
-            - --listen-host
-            - "0.0.0.0"
-            - --listen-port
-            - "8080"
-            - --web-host
-            - "0.0.0.0"
-            - --web-port
-            - "8081"
-            - --set
-            - confdir=/mitmproxy-data
-            # Stream (don't buffer) response bodies over 1 MB. dind pulls
-            # multi-hundred-MB image layers through here; buffering them OOM-killed
-            # the container (exit 137, connection refused mid-restart → haku-ci
-            # builds failed). We gate at the CONNECT/host level (the allowlist), not
-            # blob content, so streaming loses no enforcement.
-            - --set
-            - stream_large_bodies=1m
-            # Passthrough (raw TCP, no TLS interception) for Anthropic's control
-            # plane. The haku-worker drives Managed Agents sessions over a
-            # long-lived HTTP/2 stream to api.anthropic.com; mitmproxy's
-            # interception buffers/breaks that stream, so the worker claims work
-            # but tool results never post and sessions deadlock at "idle". This
-            # traffic carries only the scoped environment key and needs no
-            # inspection. Egress still flows through the proxy (the CCNP
-            # chokepoint is unchanged); only TLS interception is skipped here.
-            # TODO(haku): tighten later — this passes ALL of api.anthropic.com
-            #   through untouched. Revisit whether only the session stream needs
-            #   passthrough (and whether to inspect the rest).
-            - --ignore-hosts
-            - api\.anthropic\.com
+        - name: squid
+          image: ubuntu/squid:6.6-24.04_beta
+          command: [squid]
+          args:
+            - -N
+            - -f
+            - /config/squid.conf
           ports:
+            # 8080 is the contract the Kyverno inject-haku-egress-proxy policy sets
+            # HTTPS_PROXY/HTTP_PROXY to; keep it in sync with the Service, the
+            # NetworkPolicy ingress, and the force-egress CCNP.
             - name: proxy
               containerPort: 8080
-            - name: web
-              containerPort: 8081
           volumeMounts:
-            - name: mitmproxy-data
-              mountPath: /mitmproxy-data
+            - name: config
+              mountPath: /config
+              readOnly: true
+            - name: ssl
+              mountPath: /etc/squid/ssl
+              readOnly: true
+            - name: ssl-db
+              mountPath: /var/lib/squid
+            - name: cache-data
+              mountPath: /var/cache/squid
           resources:
             requests:
-              cpu: 50m
+              cpu: 100m
               memory: 256Mi
             limits:
-              cpu: 500m
-              # Headroom over the 512Mi that OOM-killed under haku-ci build traffic;
-              # with stream_large_bodies the working set stays bounded, this is slack
-              # for concurrent connections + the dynamic cert cache.
+              cpu: "1"
               memory: 1Gi
       volumes:
-        - name: mitmproxy-ca
+        - name: egress-proxy-ca
           secret:
             secretName: haku-egress-proxy-ca
-        - name: mitmproxy-data
+        - name: config
+          configMap:
+            name: haku-egress-proxy-config
+        - name: ssl
           emptyDir: {}
+        - name: ssl-db
+          emptyDir: {}
+        - name: cache-data
+          persistentVolumeClaim:
+            claimName: haku-egress-proxy-cache

--- a/cluster/k8s/agents/haku-egress-proxy/kustomization.yaml
+++ b/cluster/k8s/agents/haku-egress-proxy/kustomization.yaml
@@ -8,3 +8,13 @@ resources:
   - networkpolicy.yaml
   - cnp-haku-cloud-api-egress.yaml
   - ccnp-haku-proxy-egress.yaml
+  - cache-pvc.yaml
+generatorOptions:
+  # Stable ConfigMap name so the Deployment volume can reference it directly; the
+  # reloader annotation on the Deployment handles restart-on-change.
+  disableNameSuffixHash: true
+configMapGenerator:
+  - name: haku-egress-proxy-config
+    namespace: haku-egress-proxy
+    files:
+      - squid.conf

--- a/cluster/k8s/agents/haku-egress-proxy/networkpolicy.yaml
+++ b/cluster/k8s/agents/haku-egress-proxy/networkpolicy.yaml
@@ -1,12 +1,11 @@
-# Allow proxy clients (haku-sandbox + haku-ci) to reach the egress proxy (port 8080)
-# and the Authentik outpost to reach the mitmweb UI (port 8081) for proxy auth.
-# haku-ci was rehomed onto this proxy (cluster/k8s/haku-ci) as a client but its ingress
-# was missed — without it the runner/dind get `proxyconnect ... i/o timeout` on every
-# egress and all haku-ci builds fail.
+# Allow proxy clients (haku-sandbox + haku-ci) to reach the egress proxy (port 8080).
+# haku-ci was rehomed onto this proxy (cluster/k8s/haku-ci) as a client — without this
+# ingress the runner/dind get `proxyconnect ... i/o timeout` and every haku-ci build
+# fails. Squid has no web UI (unlike mitmweb), so there is no mitmweb-UI ingress rule.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: allow-authentik-egress-proxy-ingress
+  name: allow-proxy-client-ingress
   namespace: haku-egress-proxy
 spec:
   podSelector:
@@ -22,13 +21,6 @@ spec:
               kubernetes.io/metadata.name: haku-ci
       ports:
         - port: 8080
-          protocol: TCP
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: authentik
-      ports:
-        - port: 8081
           protocol: TCP
   policyTypes:
     - Ingress

--- a/cluster/k8s/agents/haku-egress-proxy/service.yaml
+++ b/cluster/k8s/agents/haku-egress-proxy/service.yaml
@@ -10,6 +10,3 @@ spec:
     - name: proxy
       port: 8080
       targetPort: 8080
-    - name: web
-      port: 8081
-      targetPort: 8081

--- a/cluster/k8s/agents/haku-egress-proxy/squid.conf
+++ b/cluster/k8s/agents/haku-egress-proxy/squid.conf
@@ -50,6 +50,9 @@ acl allowed dstdomain registry-1.docker.io
 acl allowed dstdomain auth.docker.io
 acl allowed dstdomain index.docker.io
 acl allowed dstdomain production.cloudflare.docker.com
+# Docker Hub 307-redirects blob/config GETs to BOTH cloudFLARE and cloudFRONT
+# fronts — both required (missing cloudfront makes blob pulls dial-timeout).
+acl allowed dstdomain production.cloudfront.docker.com
 # Python / npm package registries (ad-hoc `pip install` / `npx` in sandbox pods):
 acl allowed dstdomain pypi.org
 acl allowed dstdomain files.pythonhosted.org
@@ -58,6 +61,20 @@ acl allowed dstdomain registry.npmjs.org
 acl allowed dstdomain cache.nixos.org
 acl allowed dstdomain nixos.org
 acl allowed dstdomain channels.nixos.org
+# Bazel registry + release artifacts, GitHub source/release archives, Node.js
+# toolchain (haku-ci Bazel cold-fetch, NO RBE):
+acl allowed dstdomain releases.bazel.build
+acl allowed dstdomain bcr.bazel.build
+acl allowed dstdomain github.com
+acl allowed dstdomain codeload.github.com
+acl allowed dstdomain objects.githubusercontent.com
+acl allowed dstdomain release-assets.githubusercontent.com
+acl allowed dstdomain raw.githubusercontent.com
+acl allowed dstdomain nodejs.org
+# Forgejo Actions: `uses:` actions from data.forgejo.org, act_runner +
+# job-container images from code.forgejo.org:
+acl allowed dstdomain code.forgejo.org
+acl allowed dstdomain data.forgejo.org
 # Google APIs (Gmail read, Calendar/Drive, Tasks) — credentialed, cache-denied below:
 acl allowed dstdomain gmail.googleapis.com
 acl allowed dstdomain www.googleapis.com

--- a/cluster/k8s/agents/haku-egress-proxy/squid.conf
+++ b/cluster/k8s/agents/haku-egress-proxy/squid.conf
@@ -1,0 +1,147 @@
+# Squid ssl-bump caching forward proxy — Haku's single egress fence for
+# haku-sandbox.
+#
+# Replaces the mitmproxy implementation in-place. It does everything mitmproxy
+# did (terminate + inspect client TLS, enforce a host allowlist, splice
+# api.anthropic.com untouched) PLUS HTTP caching of immutable public
+# build/package artifacts that haku-sandbox's ad-hoc pip/npx/nix installs pull.
+#
+# Directive syntax targets Squid 5/6 (ubuntu/squid). If the pinned image ships a
+# different Squid, re-check http_port ssl-bump options and cache_dir syntax.
+
+# --- listener + ssl-bump ---------------------------------------------------
+# Port 8080 is the contract the Kyverno inject-haku-egress-proxy policy points
+# HTTPS_PROXY/HTTP_PROXY at (haku-egress-proxy.haku-egress-proxy.svc:8080) — keep
+# it in sync with that policy and the Service/NetworkPolicy/CCNP port.
+#
+# The CA (key+cert concatenated) is built by the init container from the
+# cert-manager Secret/haku-egress-proxy-ca. generate-host-certificates mints a
+# per-host leaf on the fly, signed by this CA; clients trust it via the
+# trust-manager bundle (trust-bundle.yaml). See the AKI/SKI note in README.md.
+http_port 8080 ssl-bump \
+  generate-host-certificates=on \
+  dynamic_cert_mem_cache_size=8MB \
+  tls-cert=/etc/squid/ssl/squid-ca.pem \
+  tls-key=/etc/squid/ssl/squid-ca.pem \
+  cipher=HIGH:!aNULL:!MD5
+
+# On-disk store of generated leaf certs (initialized by the init container).
+sslcrtd_program /usr/lib/squid/security_file_certgen -s /var/lib/squid/ssl_db -M 8MB
+sslcrtd_children 5
+
+# --- ACLs ------------------------------------------------------------------
+acl step1 at_step SslBump1
+
+# api.anthropic.com is SPLICED (raw passthrough, never bumped, never cached): the
+# haku-worker drives Managed Agents sessions over a long-lived HTTP/2 stream that
+# TLS interception breaks, and the stream carries only the scoped environment key
+# (no inspection needed). Egress still flows through this proxy (the CCNP
+# chokepoint is unchanged); only TLS interception is skipped for this host.
+acl anthropic ssl::server_name api.anthropic.com
+
+# Host allowlist (default-deny). MUST equal the haku-sandbox pod-egress CNP's
+# `toFQDNs` set (cnp-haku-cloud-api-egress.yaml) — enforced by
+# cluster/validation/test_haku_egress_proxy_consistency.py. dstdomain matches the
+# CONNECT authority / SNI (pre-bump) and the decrypted request Host (post-bump).
+# Container image registries (base-image + tooling pulls):
+acl allowed dstdomain ghcr.io
+acl allowed dstdomain pkg-containers.githubusercontent.com
+acl allowed dstdomain registry-1.docker.io
+acl allowed dstdomain auth.docker.io
+acl allowed dstdomain index.docker.io
+acl allowed dstdomain production.cloudflare.docker.com
+# Python / npm package registries (ad-hoc `pip install` / `npx` in sandbox pods):
+acl allowed dstdomain pypi.org
+acl allowed dstdomain files.pythonhosted.org
+acl allowed dstdomain registry.npmjs.org
+# Nix binary cache + channels:
+acl allowed dstdomain cache.nixos.org
+acl allowed dstdomain nixos.org
+acl allowed dstdomain channels.nixos.org
+# Google APIs (Gmail read, Calendar/Drive, Tasks) — credentialed, cache-denied below:
+acl allowed dstdomain gmail.googleapis.com
+acl allowed dstdomain www.googleapis.com
+acl allowed dstdomain tasks.googleapis.com
+# Haku mailbox read API (bearer-gated) — credentialed, cache-denied below:
+acl allowed dstdomain haku-mailbox.allegedly.works
+# Anthropic work queue (spliced above):
+acl allowed dstdomain api.anthropic.com
+
+# Standard CONNECT / port safety.
+acl SSL_ports port 443
+acl Safe_ports port 80
+acl Safe_ports port 443
+acl CONNECT method CONNECT
+
+# --- ssl-bump policy -------------------------------------------------------
+# Peek at the ClientHello (learn SNI) at step 1, then: splice Anthropic (never
+# decrypt), bump everything else (decrypt + inspect + cache).
+ssl_bump peek step1
+ssl_bump splice anthropic
+ssl_bump bump all
+
+# --- access ----------------------------------------------------------------
+http_access deny !Safe_ports
+http_access deny CONNECT !SSL_ports
+http_access allow allowed
+http_access deny all
+
+# --- caching ---------------------------------------------------------------
+# Cache dir on the PVC (aufs = threaded UFS; handles large objects better than rock,
+# which is better for many-small — our objects skew large). 20000 MB leaves headroom
+# in the 25Gi PVC for the ssl_db + swap metadata.
+cache_dir aufs /var/cache/squid 20000 16 256
+cache_mem 256 MB
+# Cache large build artifacts whole. The Squid default is 4 MB, which silently
+# refuses toolchains/wheels/node dists that run to ~1 GB — the whole point of this
+# cache. Kept well under the cache_dir budget so one object can't dominate it.
+maximum_object_size 2 GB
+maximum_object_size_in_memory 512 KB
+# Byte-hit-ratio replacement: keep large, frequently-fetched artifacts over churn
+# (default LRU evicts by recency and would drop a big popular toolchain for small noise).
+cache_replacement_policy heap LFUDA
+# Deduplicate concurrent identical fetches: when many jobs pull the same artifact at
+# once, one request goes to origin and the rest wait on it instead of stampeding.
+collapsed_forwarding on
+cache_effective_user proxy
+
+# No-double-caching principle: never cache a host that is in-cluster or that we
+# already cache at another layer. In-cluster services must bypass this proxy
+# entirely (clients' NO_PROXY + the CNP's `toEntities: cluster` rule) OR, if they
+# do transit the proxy, be listed in `no_cache_hosts` below. Today the only
+# in-cluster app host that reaches the allowlist, `haku-mailbox.allegedly.works`,
+# is `cache deny`. Public caches we mirror at another layer (e.g. the cluster's own
+# cache.allegedly.works) are NOT in the allowlist — only the public origins
+# (cache.nixos.org) are, and those are not our cache to double.
+#
+# NEVER cache credentialed / user-data / auth hosts, even though they pass the
+# allowlist: Google APIs (Gmail/Calendar/Tasks user data), the Haku mailbox, the
+# Docker token endpoint (per-pull scoped bearer), and Anthropic (spliced anyway).
+# Squid also refuses by default to cache responses carrying Set-Cookie or
+# Cache-Control: private/no-store, and never caches non-200 — this list is the
+# belt-and-braces host-level deny on top of that.
+acl no_cache_hosts dstdomain gmail.googleapis.com
+acl no_cache_hosts dstdomain www.googleapis.com
+acl no_cache_hosts dstdomain tasks.googleapis.com
+acl no_cache_hosts dstdomain haku-mailbox.allegedly.works
+acl no_cache_hosts dstdomain auth.docker.io
+acl no_cache_hosts dstdomain api.anthropic.com
+cache deny no_cache_hosts
+
+# Freshness: honor origin Cache-Control (no override-expire / ignore-no-cache, so
+# no-store/private is always respected). Immutable content-addressed artifacts get
+# a long heuristic freshness; dynamic/query URLs are never heuristically cached.
+refresh_pattern -i (/cgi-bin/|\?) 0 0% 0
+refresh_pattern -i \.(whl|tar\.gz|tgz|tar\.zst|tar\.xz|tar\.bz2|zip|jar|deb|nar|nar\.xz|nar\.zst)$ 43200 100% 129600
+refresh_pattern . 0 20% 4320
+
+# --- logging (L7 audit that replaces the mitmweb UI) -----------------------
+# Access log to stdout so `kubectl logs` / Loki captures the per-request audit.
+logfile_rotate 0
+access_log stdio:/dev/stdout squid
+cache_log stdio:/dev/stderr
+
+# Do not leak the proxy's presence / internal details.
+httpd_suppress_version_string on
+via off
+forwarded_for delete

--- a/cluster/k8s/agents/haku-egress-proxy/squid.conf
+++ b/cluster/k8s/agents/haku-egress-proxy/squid.conf
@@ -43,16 +43,12 @@ acl anthropic ssl::server_name api.anthropic.com
 # `toFQDNs` set (cnp-haku-cloud-api-egress.yaml) — enforced by
 # cluster/validation/test_haku_egress_proxy_consistency.py. dstdomain matches the
 # CONNECT authority / SNI (pre-bump) and the decrypted request Host (post-bump).
-# Container image registries (base-image + tooling pulls):
+# Container image registries (base-image + tooling pulls). Docker Hub itself is
+# deliberately NOT here — dind + rules_oci pull it through the in-cluster oci-cache
+# mirror (cluster/k8s/oci-cache), so its FQDNs were dropped from both the CNP and
+# this allowlist; only ghcr passes through this proxy:
 acl allowed dstdomain ghcr.io
 acl allowed dstdomain pkg-containers.githubusercontent.com
-acl allowed dstdomain registry-1.docker.io
-acl allowed dstdomain auth.docker.io
-acl allowed dstdomain index.docker.io
-acl allowed dstdomain production.cloudflare.docker.com
-# Docker Hub 307-redirects blob/config GETs to BOTH cloudFLARE and cloudFRONT
-# fronts — both required (missing cloudfront makes blob pulls dial-timeout).
-acl allowed dstdomain production.cloudfront.docker.com
 # Python / npm package registries (ad-hoc `pip install` / `npx` in sandbox pods):
 acl allowed dstdomain pypi.org
 acl allowed dstdomain files.pythonhosted.org
@@ -71,6 +67,8 @@ acl allowed dstdomain objects.githubusercontent.com
 acl allowed dstdomain release-assets.githubusercontent.com
 acl allowed dstdomain raw.githubusercontent.com
 acl allowed dstdomain nodejs.org
+# GNU source tarballs (autotools/coreutils fetched by some source builds):
+acl allowed dstdomain ftp.gnu.org
 # Forgejo Actions: `uses:` actions from data.forgejo.org, act_runner +
 # job-container images from code.forgejo.org:
 acl allowed dstdomain code.forgejo.org
@@ -132,16 +130,14 @@ cache_effective_user proxy
 # (cache.nixos.org) are, and those are not our cache to double.
 #
 # NEVER cache credentialed / user-data / auth hosts, even though they pass the
-# allowlist: Google APIs (Gmail/Calendar/Tasks user data), the Haku mailbox, the
-# Docker token endpoint (per-pull scoped bearer), and Anthropic (spliced anyway).
-# Squid also refuses by default to cache responses carrying Set-Cookie or
-# Cache-Control: private/no-store, and never caches non-200 — this list is the
-# belt-and-braces host-level deny on top of that.
+# allowlist: Google APIs (Gmail/Calendar/Tasks user data), the Haku mailbox, and
+# Anthropic (spliced anyway). Squid also refuses by default to cache responses
+# carrying Set-Cookie or Cache-Control: private/no-store, and never caches non-200 —
+# this list is the belt-and-braces host-level deny on top of that.
 acl no_cache_hosts dstdomain gmail.googleapis.com
 acl no_cache_hosts dstdomain www.googleapis.com
 acl no_cache_hosts dstdomain tasks.googleapis.com
 acl no_cache_hosts dstdomain haku-mailbox.allegedly.works
-acl no_cache_hosts dstdomain auth.docker.io
 acl no_cache_hosts dstdomain api.anthropic.com
 cache deny no_cache_hosts
 

--- a/cluster/validation/BUILD.bazel
+++ b/cluster/validation/BUILD.bazel
@@ -405,3 +405,14 @@ py_test(
         "@pypi//pytest_bazel",
     ],
 )
+
+py_test(
+    name = "test_haku_egress_proxy_consistency",
+    srcs = ["test_haku_egress_proxy_consistency.py"],
+    data = ["//cluster/k8s:cluster_all_files"],
+    deps = [
+        "//util/bazel:runfiles",
+        "@pypi//pytest_bazel",
+        "@pypi//pyyaml",
+    ],
+)

--- a/cluster/validation/test_haku_egress_proxy_consistency.py
+++ b/cluster/validation/test_haku_egress_proxy_consistency.py
@@ -1,0 +1,66 @@
+"""SSOT check: the haku-egress-proxy egress allowlist is maintained in two places that MUST agree.
+
+- `squid.conf` — the L7 allowlist Squid enforces (`acl allowed dstdomain <host>` →
+  `http_access allow allowed` / `deny all`): which hosts a bumped request may reach.
+- `cnp-haku-cloud-api-egress.yaml` — the Squid pod's own Cilium egress (`toFQDNs: matchName`):
+  which hosts the pod is allowed to connect out to at L3/L4.
+
+If they drift, failures are silent-ish: a host allowed at L7 but missing from the CNP dies at
+connect; a host in the CNP but not the L7 allowlist is a dead rule. This test pins them to one
+source of truth — the exact FQDN set must be identical.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest_bazel
+import yaml
+
+from util.bazel.runfiles import get_required_path
+
+_HAKU_EGRESS_PROXY = "_main/cluster/k8s/agents/haku-egress-proxy"
+
+
+def _egress_proxy_allowed_hosts(conf: str) -> set[str]:
+    """Every host in Squid's `acl allowed dstdomain …` lines (comments stripped, multi-host ok)."""
+    hosts: set[str] = set()
+    for line in conf.splitlines():
+        m = re.match(r"acl\s+allowed\s+dstdomain\s+(.+)$", line.split("#", 1)[0].strip())
+        if m:
+            hosts.update(m.group(1).split())
+    return hosts
+
+
+def _cnp_egress_hosts(cnp: dict) -> set[str]:
+    """Every `toFQDNs: - matchName:` host across the CNP's egress rules."""
+    hosts: set[str] = set()
+    for rule in cnp["spec"]["egress"]:
+        for fqdn in rule.get("toFQDNs", []):
+            if "matchName" in fqdn:
+                hosts.add(fqdn["matchName"])
+    return hosts
+
+
+def test_egress_proxy_acl_matches_egress_cnp() -> None:
+    conf = Path(get_required_path(f"{_HAKU_EGRESS_PROXY}/squid.conf")).read_text()
+    cnp = yaml.safe_load(Path(get_required_path(f"{_HAKU_EGRESS_PROXY}/cnp-haku-cloud-api-egress.yaml")).read_text())
+
+    acl_hosts = _egress_proxy_allowed_hosts(conf)
+    egress_hosts = _cnp_egress_hosts(cnp)
+
+    only_in_acl = acl_hosts - egress_hosts
+    only_in_cnp = egress_hosts - acl_hosts
+    drift = (
+        "haku-egress-proxy allowlist drift — squid.conf `acl allowed dstdomain` and the pod egress CNP "
+        "`toFQDNs matchName` must be the same set of FQDNs.\n"
+        f"  allowed at L7 (squid.conf) but not reachable (CNP): {sorted(only_in_acl)}\n"
+        f"  reachable (CNP) but not allowed at L7 (squid.conf): {sorted(only_in_cnp)}"
+    )
+    assert not only_in_acl, drift
+    assert not only_in_cnp, drift
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()


### PR DESCRIPTION
**The "proxy config" step** — the final egress-proxy PR. Rebased onto current `devel` (which now carries the merged allowlist #2801, haku-ci rehome #2799, and cache-TODOs #2817).

Order: rename (#2794 ✅) → allowlist (#2801 ✅) → haku-ci rehome (#2799 ✅) → **this: swap the impl to Squid**.

## What

Swaps the `haku-egress-proxy` implementation from mitmproxy to a **Squid `ssl-bump` caching forward proxy**, behind the stable client contract the rehome established (Service port **8080**, the same cert-manager CA) — so no `haku-sandbox`/`haku-ci` client changes.

- `squid.conf` (new) — `ssl_bump peek→splice anthropic→bump all`; the **28-host** `allowed` allowlist (kept equal to the CNP `toFQDNs`); on-PVC `cache_dir` with `cache deny` for credentialed hosts; stdout access log.
- `cache-pvc.yaml` (new) — 25Gi seaweedfs PVC for the Squid cache.
- `deployment.yaml` / `service.yaml` / `networkpolicy.yaml` / `kustomization.yaml` — run Squid (init container builds the ssl-bump CA + cert DB + cache dir), keep the `:8080` Service.
- `cluster/validation/test_haku_egress_proxy_consistency.py` (new) + `BUILD.bazel` — SSOT test asserting `squid.conf` `allowed` == CNP `toFQDNs`. Verified locally: **28 == 28**.
- `README.md` / `haku/docs/security.md` #5 — impl now reads **Squid** (retaining the haku-sandbox **and haku-ci** scope from #2799).

The CNP itself is unchanged from devel (28 hosts + the #2817 pull-through-cache TODOs) — this PR only adds `squid.conf` to mirror it.

## Gating check (in-cluster, before un-drafting)

The `ssl-bump` leaf-cert **AKI must equal the CA SKI** for strict clients to validate — the 2026-06-25 mitmproxy lesson. `security_file_certgen` must stamp each leaf's AKI with the CA's actual SKI. Verify after deploy: extract a bumped leaf, confirm `leaf.AKI.keyid == CA.SKI`, and that `curl` validates without `-k`.

## Follow-on (Bazel client)

Bazel's Java repository downloader reads the JDK cacerts, not `SSL_CERT_FILE` — so the haku-state Bazel CI must import this CA into the JDK cacerts to fetch through the bump. Tracked with the haku-state Bazelification PR, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)