### PR TITLE
agent-box zai: add buildbuddy recipient + silence ssh warning

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -636,6 +636,7 @@ creation_rules:
           - *claude-web
           - *codex-cloud-agent
           - *agent-box-codex-user
+          - *agent-box-zai-user
           - *haku
           - *ci
   # Hetzner Robot webservice credentials (admin + all user keys)

--- a/nix/home/modules/forgejo-ssh.nix
+++ b/nix/home/modules/forgejo-ssh.nix
@@ -28,6 +28,10 @@ in
     # matchBlock is silently dropped and git falls back to port 22 + the default
     # key (Permission denied). mkDefault lets home.nix's explicit value still win.
     programs.ssh.enable = lib.mkDefault true;
+    # Silence the home-manager "default values will be removed" warning: the only ssh
+    # config these slim agent profiles need is the matchBlock below; the system
+    # /etc/ssh/ssh_config covers the rest.
+    programs.ssh.enableDefaultConfig = lib.mkDefault false;
 
     programs.ssh.matchBlocks."git.allegedly.works" = {
       hostname = "git.allegedly.works";

--- a/secrets/buildbuddy.yaml
+++ b/secrets/buildbuddy.yaml
@@ -4,101 +4,110 @@ sops:
     - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzRjcxR0w5b3R4N3M1M2ND
-        Um1SK3l3WHZ2cEJBQk9mR2dmekd0Q011V1JnCm9SSXRGUzAxaU9iN2Y0N3NGRCtW
-        bEdWcGx5VEpYaXJjbzQyU0duWEVERVUKLS0tIEhDeW5iS21GUFgyUnBMektFcHlW
-        SUlFWWJHYml3MFRTMWZRa1VtVlVDTlEKaalMd7LaKrNKCIePrl33dZAuZAXWzmQG
-        XMtmrSe7Ba/u377q+d9YP0Chl1oIG/womsP/bHQPrkqOi2FRxCF8OQ==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxN0g2NHpsRnlxcDM5bFlJ
+        eWNMbWt1U2srenBqRVlVMjNGZEZZSEFSVW5vCkhaZ1hERk5jRVdGZ2hKdzZhem9K
+        U3NxRjduU0V0Snl2cVM4WDIreERrWVUKLS0tIHE0SzFJVTJPV2RVUnhKME5JMUxX
+        QVZIamJBUlgwUnJ5Z01ndWVnaEk4cDgKOzRj9Mh7Ix4dkx9LkU6N3TNfS3ALE09A
+        6hDerSOqiuy5+df1nuLs9I4K+bumScTwNYsHZGwjDYbrmacjgam4XA==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age12c2ef6ayydzvmz6k49pyyhtgu2g00nyynmht8y3laqvxn3wya4wselpc4s
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBiSmxpNjhjVHFYNGhiaFdx
-        V0VURGl6MCtqSzhtdTZyZ3M1cytTM2dWZURjClJDOEdldEZEVE02aFVRM1h0czhl
-        SWNPR3hUVGZ5WndzMCtUMnZqbUlxelEKLS0tIExNNVQ0ckZDYWtFd3hXMjE3bEJi
-        UkFlTnhqZGlCLy9ISUx6SzlEVW5QRkkKj0hQGxQSmekDwCzSIAtiG/vZIP1MLzWl
-        XrQrKgVg2Lv2RBmHSQDjM4pSIT42VcYOPXsRguMMSQZUC5rO0i1etQ==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsMmJEdVVOaCtZa3JUZDkv
+        S3ZQSzFrQktWTDFpOVNKR2d4S3p0azNPdjFjCk1pTTVDd1diT1duejdrYnBUZ1Zs
+        aC8wN2VJMTFvOEd0RWt3R2t2bjlnc0kKLS0tIFE4Ym5uU0pSSzdzUkxLZkRhYmxJ
+        UjJjcGpsNXliZ2J3ODExL0ZiU3U4bkUKSikmYbaxqymkjYlir5GdQjA5wORPbH6J
+        OH7XgSqLvyGow9tC6GQ1N0feEanWKJnmF87OznMsed2RhnTfa1KmRQ==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age1qdgn0k59t7ghg3t4gg02g2ppnzp7uz0ddplup38y84hqslcsgsxq3v9tkz
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2WmM3cjNReDZ5NmdFTk1t
-        SmZYbEg0V1hDZUtub0RkZTgwamVYZWtJekZBCmc2T085RFFFS0h1SElWRExVV3Zz
-        Wk1jaGd2UlVJaDhmWXVSZnNONVIwcmsKLS0tIHducktZSnkva1VJYmZJWmVxekwr
-        L3N6VHhNYS9jOGZBb2hHODU4NmpXQWMKktIdND+LCdus17i7VkPmKla7lWP0JvAK
-        CQ9odEY+1SR+N53bmXbpfbMxX0xKz8PQuxYvby8vquY/sCxdNqv6XQ==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBKNmQ5dzVjTVlzMVRKVW5p
+        T1g0YmNGSkJ2UXRscWNRZ0hHaDNKMXUyQXhBCkNROS9HbkE3TDNaUnlUZ255ZW1M
+        Q3hrdGxCQTJFZWFpWUtNQVI0SVJGV1EKLS0tIGkwWDZieDZEblZnaVVUdzQ4cUkx
+        R0dOaUFkd1FVQUNSMnRLbjEvalhvQlUKjRJsSajYGMO34ks4g0n37D3KKT+ga7UR
+        9qJd7eOlDhmdvGDi1ixq5fQjvJIF2le9adILjgybP8FpQGQtcvsVkQ==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age15hfg4r2zfc2zl6zarecpvykxjktw4zu3grlahz4397rstmhqpvtqjgf6yy
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBydjFMU3pBZFFoZ1BWRXJv
-        NWtNeFFRQVRHajBqeHVNdkhjZDZ5YmFWa1c4CjJOaXZzKzlZKy9jNm5rekZCRVl0
-        VTVIQVZIazVnRUlXaFNQbTVraXZqWTAKLS0tIEtIZkRxSzc1OW9NT3MwSCtMa0pF
-        ajU1TGhKTHFjSVlJa2ZaT1JYcko2VTAKM3PPjbJ27WA4l1fnOaz6H6acJ7pjkY0r
-        5hoCSNxLFxQgKYYlmnezrd53NtaDApuI9Vpc5ysJ/79Y0NupDMsvmg==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBtcEpLK2tZUlJBbElvQk9h
+        WXpsMDBlYTBqelZWZDY0RGpmYlRMcnc4aHpVCnpSZFI2Z0hucDN3WGk3bUVzb0Vr
+        UGdicTllVlNZdVREcmMyL3U3a1JsZlkKLS0tIHVFRzVZeWlldVdHeWIrU1R3U0FX
+        NDZEajFhdjJQb0ErV29EUm5GaEZXWFUK+HvpOJK27Nb+gWDzShExtVs4u+VcOrjH
+        M5WOel6sQAgXvAkN92P08biHe8qzJtnMJ9wIuswEZjMmhVU27z8oMg==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age1l325yz3v2mev3t896mzvmmkaatjc7z4d9kukvnjuslgwwd8zg9ss9pnsc7
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqZ0ZIRWErOTY3RVV2RkYy
-        SEtsV1VzSDdNS2F6SkpkN0ZEUXdOa00raEUwClc5cnVURVh1bHgreDBHSzhjbWZq
-        ZzNtbEF1UE1FUDBSYXFTM2Y5MGREOVkKLS0tIEtPN1VweTdjOHlUdXU4SlF4ZzQz
-        ZW1RcUJENVcwUEI3ZkRjT05vbFJQTWcKsA2d6zMeKuVs7okroFZGryFQN48NYPFt
-        kYVtHwk6HdDLv9EaBGWdID2g+qaDMM0zjor6a3qe11HrBll4RTAh3w==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA4TVZNaGtiTEgwZDV3a0ZE
+        SzhmQTJjUFRjMWVRN1YxUGFmaGN5RnliSlJJCkEwcThIa3NHdmhCSDEyZ2J3aWV0
+        Z1hCNGE2WHVZQUM4aDJrdWlrb1NiMncKLS0tIDhDZ1lMdFhmMzArekpWc1pic3ZO
+        S0tPaWIyNzlIR3BCRTJqV3VUSnhEMm8KgYRaRowW7WDe42A3nqyOfE4Lx+kA1vKj
+        CW3oXx9e0++JcDNBcsr+ptVkLJTJjqjlhxLC6TdIWaJ1b5U9a6fcCw==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age1wjv755gsh9l02wm3wet48kjl6ju5ckk3jgllfpe8xmfauqqardgq7pt7ud
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOTGduU1VSNTNCUy9WV0Jm
-        T092K2NBRWZIZjdqbXNnVlZDOG5DQ0JLd0VvCmVvNFNUZWN3OExZMDhKTW5OcjM4
-        TlljWUQ5OENUdGFFb280a2dMSWhWKzQKLS0tIHIyb05ibC9FZlVxYTdKaVNIZWVD
-        Qk9pVXdTMEdnRlRjclRxcUNZZ1FZb2sKJI1mdxaDC/EHltzFKvn4AUn/Abqh3Z9f
-        +86KlYxp0CVSuf1ZPjhs6lZAZGwv3uZl/gooxJvwi5SJ37N0urUeuw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMandvcHlua3pEemQ0emw4
+        UTliV2NFMHlVMzBVd2lXVzN2bWVtZ25BR1U4Cmtlck53U0lmRCtnaC9SVEVMVmpC
+        TS82WjFENnl6MWdxWVhMY0lYc0dvL3cKLS0tIFp5dlhDY1F2SU5aNHJBQ3J2MkJi
+        OEdtZ2lGZUl1ZkxGdHFyenNreXlWM1UKbVF/iFCNAx+Z9NFd8sI5s9Ek4k2tHGjF
+        bgjLoYGT/YkZo6TVbK5L777iYcQw9uGLYAudY4vUdz5K4HIMRBcwAA==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age15gxxqn49sp8qhdya6utanzsxgzpfup63yfuht9yza4adpule4auqzsddj2
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3MkVPaDdrVEhCOXA5UTBU
-        ODdOZDU1T2pRbG13a1lFZVhMVXNldks4R0JrClQxcHdDTHJXS2J5cTY4dGhYSTZl
-        V1FhTjMyVjFjc1puU2E2VXArMlFnc28KLS0tIHp6aFd3aVJkS2pnUVBFdnhKZjlL
-        THcrRk50bndrakJHOTA3djRlU2pGUk0KK/e964eK7H+RUCNfXrQQfXaC5TKbuHrS
-        gfqhrE7+ssHPcfOGm6gqcfrrqjsShlvH3tF5i0Byu3uNx2xhXdd5GQ==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDSGZpam9XcmlJamwzeTZP
+        K0hIL08rUlltZ1luWUZXTzJlK3JOUWVSMlNrCnhiVEFlTjMrdmh0aHVtUThGenZq
+        SVVhVXpQNmt2SWV5aU51U1FoUHZWNk0KLS0tIHN6a3hBWTk4YU5tZjJpT0ljS0Yz
+        K2NOTkVLRWlaTmJvN0JkdHgwSGJiclEKXQVnWmI99PYtMFCSdUCUkv2yFbbws/Ea
+        LdetGdzrLyOURQAFTyOWqTjWO0lqywc6PkzjEXBjtiQp1CGLOtKa/A==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age1hy7al8s2cxjhehgf93mnkfdv2plr579t9uhvtdaxlmh3rx0j2g7sludsex
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPWDlOdFllRmhkWXIwZmpk
-        U3NWU2dHS0h3aUJnNjZUcTV1a20xcFR5U3hjCmlEbVBKdHNvYTA4NnZucGVJYldx
-        eE5hZllnSDZsREpRYnpXdEdZT3h2UGcKLS0tIGtnMnE4WE9JajBwelA2NkZZOTJw
-        Ry9IZ1FGUXY4dUcxNUxaUmFYaGYxd2sKQM2GCXKaagX/2ymSWXG6xDGq6A+pOVW3
-        OO595ZdPgzSaIX8yzBXF+nsvtQ+ApEnmg53K6j1lXwGeZRYkQsFEPw==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLVzd1OFpyNlJuRHFPVXUv
+        WDd5YmppRFZrcndFRHUwYjIxcFJZVHV1SkJNCkUzeVNoUEtMaG9WRVFyZXpPc3k2
+        T25XM0liTnl2b2JKUzlpY0VBdC9uM3cKLS0tIHFjTkh2V3h3T013TmtJZ0hhdVQ0
+        Z1pPdXhrdWRaRnhIRjZZeUI2K2FRSjgKjGiNquw0Kw4ohw8F15qR86msPxQ9koXR
+        OmaZjXMBUVHs8saKMI0sUQfGhhKNJHthDs2sp30+1EuEa1jMNPOzxQ==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age16madmg3yjv39dekr6dscqr2slv0haxcw7lw25v8vmly4wl95td4qwev54u
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpZjZDaE1UVDlmbkg5REho
-        THBXT21FSXljdHU5MFdpYXBwRUpOdHlKVlg4CnVIdkVSMDhPcFBpV3ptZFplR0c1
-        Y3p6OS9Eb3U5N1VhbXQ5S2RaUnE3b0EKLS0tIHpqOXYrWUtETWJOZng0NjZCNlc5
-        MkNkOXo3dXg3Z1pWMmhFRm5Ha3RKZEUKOnTep02LJdyvifx7aiNxqlkFX6zi0r2H
-        lyM6b59WGHZ7KDVGvigOvjGnPIGJ38tvFSkqmJzrPiIBlX2q2/UILQ==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEaTA0bFlwaU9qOVFINUpE
+        MUFkbXBHZ1VobHVSMEZLU3V0SFgwcGdWR3dZCkFaNmJtRUJpZzhtSUY1RWd6T0lV
+        QjdGcmNEL0VHZGhzd05RNGErcXpBMDQKLS0tIFp5Q28vS2RiZktiU3JGTGlWVDQ2
+        dFRHS3pDTHFWd0k3cENTM2xXZkV2STQKZZS4M/lIAyDyWjj2KJUFg1nplSxtEvnO
+        OIU/DxtXqjbBei5XlaOBGNUwsJkjFQvC8qIHTYQjsWhQrODhCLzdvw==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age14zkdx3rku2yp9zv8ejrlv0yd53yx7rmmtfzxmxhawvc5hp2gxf7sxnv4sv
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTTllyRGc3eXhEVFNKU1Vs
+        Yi9DUSt1Y1hsa0hFb1R3WjhxbG02OC9lRkJNClpUclZqTTNpNUovT1QwSlkxbG52
+        UFFFQVIrSW1HSmF6NGYzQWxQQXYyQncKLS0tIDJDMkJEZjdWMFZXOURWZjRlOTdZ
+        OUhsOHYwK20vYWVwa3lNcXN6clY5ekUKl4uG6fno9VJJnA0la8BMjm40Hp6gHpAu
+        FnKBcIVFBPENA0isnb7CSEAVe9Rd3k1q/ILFFiwwBYTJY0Dxc/HhIA==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age1756xpy6yg7r8vdducm5cdn4cqt3m5qkcncxumsh8htlfdzpae4cq0c6gqf
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOUDVreFlzWDVNa1ZUbURT
-        YjYwdHFlYml2UHRENVVNUFU3TjlDcm80ZERRCk15cG50czlpaE04a3VRdW05RC9p
-        L2Q3dk1zeCtnRUp3TlJhVStmeTVHZzgKLS0tIGE1TjkrVW9hMHJzY0FOaDRyT0Fo
-        cmFlS1JPQXZJbFdvcDEvQ1pFemJQVlEKMbgNULWKqLwS/1GHLBdd/QD79aNx+IxZ
-        wTwRGZLdveiveszIAtahGP1WRsg+XIxEhehiiloVYs5m/TS/RJBfLg==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGZXQ0VVd0YnlyMk1yVVFv
+        dlJiUHpaejR4T2tnS1NabmoyaE85a290YWdZClYwSTVBSzgxYmVza1d5WEVQL0Ux
+        c2Y3Wit6T3lwTnJ5WjFNaDYyK3ZvS1UKLS0tIHdVWUJkSjZhRHJEOG1lRjNvR056
+        T1pXY2RmT3hIYzM1bkhnR2xIaHlDUmsKJ9X4HIY82khraXI8ddIWhurAQHhOzaa6
+        kXByxmYingrP9nLFFlCpGbVjPksYRC0aZiDyL12C03QNm9E6T6256w==
         -----END AGE ENCRYPTED FILE-----
     - recipient: age1zl5lv4g0lzd4pcwx9q4vvq0w4rpmkde5r68k4n2zu89urmnx9svs3c2mef
       enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZTTdNTTZvTHB4dFlLcVcy
-        YW1GSWdqWDRpOGhXREZXNjEzeWNVWEtrZEY4CkFDWTgwNk5PcFlreHpBS0JlQXAy
-        YWdwZVpHUHpRcEk5Zjc5bmswL2thVjQKLS0tIEhUWHpPbm1vTUZaM3dKQ1JuUk9h
-        bXdOdGF6QW5aemhIN2lxd2toSWdlSFUK2VklwjlDuXWqWw/1wfSPVxDyCWseMVl4
-        jjrl0qQNlTbjwpnLwJ/7VqYWCzJusfTMJjfr4iNzXsKNp4xTZCr6GQ==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSNzFQV0lrb2cxcmJPU3dx
+        MjFXUGwwQVFJWVVzdENrSXpXVnBialRmZTA0CkYzajhkVE0zc1VTYnRnNjREQ3Y4
+        RW5sbVo3L2R4S08yUHlSWFlwT1dXazQKLS0tIGVmSXV2N3JXaE9YOXhJNGM2eEls
+        bDJNaUhBTG9ldm9obnNTN3crSmZPbXcKzOcx36+2Fae6+6lRm4mCG4HcI1UCSQKz
+        EvR6Z/bg2yepubmigY0agN1/lvYTvH/qE1I0vjQ8u14XHqsKbG+n8w==
         -----END AGE ENCRYPTED FILE-----
   lastmodified: "2026-03-11T07:57:59Z"
   mac: ENC[AES256_GCM,data:EFPQ1auS7eiu0sXnSCOYwrQ1oVeNj+rMEEvGbZKATdn10XY/bZjAGI6qd4R/BZgariE1DABL6K2gWSM9dSlzx2w5ARN8leSnfQ6tfY8wld8MoJetoEwIY46U6hqB7CgMVH3d2bEpm3uX80VJys1siFLqdTBQbTrmAeXI2IvKKBg=,iv:sPFDzFDgKNgM0lGFf4Xay2T1cQFjyObIaVKHzJ7B9G8=,tag:6qIUhHLMB7ink/HGNF4DYQ==,type:str]


### PR DESCRIPTION
Two fixes for the \`zai\` nixos-rebuild switch:

1. **buildbuddy recipient** — \`secrets/buildbuddy.yaml\` was missing \`agent-box-zai-user\` (had \`agent-box-codex-user\` but not zai). The \`zai\` user consumes buildbuddy via \`common.nix → buildbuddy.nix\`, so its sops-nix couldn't decrypt → \`home-manager-zai.service\` failed → the \`agent-box-secrets-after-cloud-init\` oneshot cascaded. Now zai-user is added to the rule + the file is re-encrypted (\`sops updatekeys\`).

2. **ssh warning** — \`programs.ssh.enableDefaultConfig = false\` in \`forgejo-ssh.nix\` silences the home-manager "default values will be removed" warning on the codex + zai profiles. The matchBlock is the only ssh config they need; the system ssh_config covers the rest.

After merge, re-run: \`nixos-rebuild switch --flake .#agent-box\` on the VM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)