### PR TITLE
haku egress: add Bazel/toolchain hosts to the proxy allowlist

### DIFF
--- a/cluster/k8s/agents/haku-egress-proxy/cnp-haku-cloud-api-egress.yaml
+++ b/cluster/k8s/agents/haku-egress-proxy/cnp-haku-cloud-api-egress.yaml
@@ -34,6 +34,10 @@ spec:
         - matchName: registry-1.docker.io
         - matchName: auth.docker.io
         - matchName: production.cloudflare.docker.com
+        # Docker Hub 307-redirects blob/config GETs to BOTH cloudFLARE and
+        # cloudFRONT fronts — both required (the easily-confused pair; missing
+        # cloudfront makes blob pulls dial-timeout with "No such image").
+        - matchName: production.cloudfront.docker.com
         - matchName: index.docker.io
         - matchName: gmail.googleapis.com
         - matchName: www.googleapis.com
@@ -69,6 +73,32 @@ spec:
         - matchName: cache.nixos.org
         - matchName: nixos.org
         - matchName: channels.nixos.org
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+    # Bazel registry + release artifacts, GitHub source/release archives, and the
+    # Node.js toolchain — the haku-ci Bazel cold-fetch closure (NO RBE). Added ahead
+    # of the haku-ci rehoming (next PR) so the proxy allowlist is ready when the
+    # runner starts egressing through it.
+    - toFQDNs:
+        - matchName: releases.bazel.build
+        - matchName: bcr.bazel.build
+        - matchName: github.com
+        - matchName: codeload.github.com
+        - matchName: objects.githubusercontent.com
+        - matchName: release-assets.githubusercontent.com
+        - matchName: raw.githubusercontent.com
+        - matchName: nodejs.org
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+    # Forgejo Actions: `uses:` actions from data.forgejo.org, act_runner +
+    # job-container images from code.forgejo.org.
+    - toFQDNs:
+        - matchName: code.forgejo.org
+        - matchName: data.forgejo.org
       toPorts:
         - ports:
             - port: "443"


### PR DESCRIPTION
**1 of 2 easy-merge PRs** that onboard haku-ci to the shared egress proxy, ahead of any proxy-implementation change.

Order: **this (add hosts)** → #2799 (rehome haku-ci) → _then_ validate CI → _then_ the proxy-config swap (#2798, deferred).

## What

Widens `cnp-haku-cloud-api-egress.yaml` — the egress-proxy pod's own L3/L4 FQDN allowlist (`app.kubernetes.io/name: haku-egress-proxy`) — from the haku-sandbox set (17 hosts) to also cover the Bazelified haku-ci build's cold-fetch closure (28 hosts):

- **Bazel + toolchain (NO RBE):** `releases.bazel.build`, `bcr.bazel.build`, `github.com`, `codeload.github.com`, `objects.githubusercontent.com`, `release-assets.githubusercontent.com`, `raw.githubusercontent.com`, `nodejs.org`
- **Forgejo Actions:** `code.forgejo.org`, `data.forgejo.org`
- **Docker Hub blob CDN:** `production.cloudfront.docker.com` (the CloudFront twin of the already-allowed CloudFlare front)

## Why this order

Pure additive allowlist change against the **current** proxy (mitmproxy). No client is routed through these hosts yet — #2799 flips haku-ci onto the proxy. Landing the allowlist first keeps each PR a small, independently-reviewable merge, and decouples the whole rehoming from the later (unproven) proxy-implementation swap.

Base: `devel`. Squid / caching / the squid.conf⇔CNP SSOT test are **not** here — they live in the deferred proxy-config PR (#2798).

🤖 Generated with [Claude Code](https://claude.com/claude-code)