### PR TITLE
feat(cluster/validation): require decryption.secretRef + document the bug class

### DIFF
--- a/cluster/docs/lessons_learned/2026_07_04_flux_sops_ciphertext_applied_literally.md
+++ b/cluster/docs/lessons_learned/2026_07_04_flux_sops_ciphertext_applied_literally.md
@@ -1,0 +1,54 @@
+# Flux SOPS Ciphertext Applied Literally (Missing/Incomplete `decryption` Block)
+
+**Date**: 2026-07-04
+**Status**: Resolved — structural guard in `cluster/validation` (#2795, strengthened to require `secretRef`)
+
+## Symptom
+
+A Flux `Kustomization` whose built output contains a SOPS-encrypted Secret, but whose
+`spec.decryption` is missing or incomplete, makes Flux apply the Secret's `ENC[AES256_GCM,…]`
+**ciphertext literally** — silently, with no error in `kubectl get kustomization`. The
+consumer gets garbage bytes where it expected a credential: a 401, a bogus netrc, a TF
+runner holding a key that decrypts nothing.
+
+## Two shapes of the same bug
+
+1. **No `decryption` block at all** — Flux never tries to decrypt; the rendered Secret's
+   values are the raw `ENC[…]` strings.
+   - `vm-images-publisher` (#2621) — attic netrc
+   - `haku/cloud-agent-tf` (#2504) — anthropic-api-key / haku-token → runner 401
+   - `agents/tana-mcp-ro`
+   - `harbor-secrets` (#2796, suspended at the time)
+
+2. **`provider: sops` declared but no `secretRef.name`** — Flux is told to decrypt but
+   given no age key, so it can't; ciphertext is still applied.
+   - `litellm-keys-tf` (#2797)
+
+## Root cause
+
+kustomize-controller decrypts SOPS **only** when the Kustomization declares
+`spec.decryption.provider: sops` **and** a `secretRef` naming the key Secret. Omit either
+and the controller applies the manifest exactly as kustomize built it — which for a
+`.sops.yaml` is the still-encrypted `ENC[…]` payload plus the `sops:` metadata block. There
+is no warning: `Ready=True`, no events, the Secret object exists with ciphertext values.
+
+It recurs because the block is easy to forget when adding a _first_ SOPS file to a
+kustomization whose other secrets arrive via ESO (vm-images-publisher), and because
+`provider` without `secretRef` reads as "mostly there" (litellm-keys-tf).
+
+## Prevention
+
+`cluster/validation/checks.py::check_sops_decryption_blocks` (run by the
+`test_cluster_integration` Bazel target in CI) is **build-level**: it builds every active
+Flux kustomization and flags any that render a SOPS-encrypted Secret (a `SecretResource`
+carrying the `sops:` metadata block) without `decryption.provider: sops` **and** a
+non-empty `secretRef.name`. Build-level is what makes it precise — it inspects what Flux
+actually applies, so it neither over-counts SOPS files owned by a sibling/child
+kustomization nor misses those pulled in via nested kustomize refs. The canonical key
+Secret across the cluster is `sops-age-cluster-secrets`.
+
+## Detection tip
+
+A live Secret whose data value is `ENC[AES256_GCM,…]` is this bug: `sops -d` works on the
+git file, but the in-cluster value is ciphertext → the owning kustomization lacks (or
+shorts) its `decryption` block.

--- a/cluster/validation/checks.py
+++ b/cluster/validation/checks.py
@@ -115,19 +115,28 @@ def check_goldilocks_explicit_decision(cluster: ParsedCluster) -> list[str]:
 
 def check_sops_decryption_blocks(cluster: ParsedCluster, k8s_dir: Path) -> list[str]:
     """Active Flux Kustomizations that render a SOPS-encrypted Secret must declare
-    spec.decryption.provider: sops, or Flux applies the ENC[...] ciphertext literally
-    (silently — no error). Build-level: inspects what Flux actually applies, so it
-    neither over-counts SOPS files in sibling/child kustomizations nor misses those
-    pulled in via nested kustomize refs."""
+    spec.decryption with provider: sops AND a secretRef.name — otherwise Flux applies
+    the ENC[...] ciphertext literally (no provider) or has no age key to decrypt with
+    (no secretRef). Both fail silently. Build-level: inspects what Flux actually
+    applies, so it neither over-counts SOPS files in sibling/child kustomizations nor
+    misses those pulled in via nested kustomize refs."""
     errors: list[str] = []
     for name, resources in cluster.flux_kust_resources(k8s_dir).items():
         if not any(isinstance(r, SecretResource) and r.sops is not None for r in resources):
             continue
         spec = cluster.active_flux_kustomizations[name]
-        if spec.decryption is None or spec.decryption.provider != "sops":
+        dec = spec.decryption
+        if dec is None or dec.provider != "sops":
             errors.append(
                 f"Flux Kustomization '{name}' renders a SOPS-encrypted Secret but has no "
                 f"spec.decryption.provider: sops. Without it Flux applies the ENC[...] "
                 f"ciphertext literally — add a decryption block pointing at sops-age-cluster-secrets."
+            )
+        elif dec.secret_ref is None or not dec.secret_ref.name:
+            errors.append(
+                f"Flux Kustomization '{name}' declares decryption.provider: sops but no "
+                f"spec.decryption.secretRef.name — Flux has no age key to decrypt with, so the "
+                f"Secret's ENC[...] ciphertext is applied literally. Add a secretRef pointing at "
+                f"sops-age-cluster-secrets."
             )
     return errors

--- a/cluster/validation/flux.py
+++ b/cluster/validation/flux.py
@@ -12,7 +12,7 @@ import yaml
 from pydantic import BaseModel, ConfigDict
 from pydantic.alias_generators import to_camel
 
-from cluster.validation.k8s import Condition, parse_k8s_resources
+from cluster.validation.k8s import Condition, SecretRef, parse_k8s_resources
 from cluster.validation.tool_resolve import resolve_tool
 
 
@@ -37,12 +37,15 @@ class HealthCheck(BaseModel):
 
 class Decryption(BaseModel):
     """Flux Kustomization spec.decryption — declares how Flux decrypts SOPS
-    Secrets under the path. `provider: sops` is required for any SOPS-encrypted
-    Secret to apply as plaintext instead of literal ENC[...] ciphertext."""
+    Secrets under the path. A SOPS-encrypted Secret needs both `provider: sops`
+    and a `secretRef.name` pointing at the age-key Secret: without the provider
+    Flux applies ENC[...] ciphertext literally; without the secretRef it has no
+    key to decrypt with. Both fail silently."""
 
-    model_config = ConfigDict(extra="ignore")
+    model_config = ConfigDict(extra="ignore", alias_generator=to_camel, populate_by_name=True)
 
     provider: str = ""
+    secret_ref: SecretRef | None = None
 
 
 class FluxKustomizationSpec(BaseModel):

--- a/cluster/validation/test_sops_decryption.py
+++ b/cluster/validation/test_sops_decryption.py
@@ -9,7 +9,7 @@ import pytest_bazel
 from cluster.validation.checks import check_sops_decryption_blocks
 from cluster.validation.cluster import ParsedCluster
 from cluster.validation.flux import Decryption, FluxKustomizationSpec
-from cluster.validation.k8s import parse_k8s_resources
+from cluster.validation.k8s import SecretRef, parse_k8s_resources
 from cluster.validation.kustomize import KustomizeBuildResult
 
 _NAME = "synthetic"
@@ -62,11 +62,26 @@ def test_sops_secret_without_decryption_is_flagged(tmp_path: Path) -> None:
     assert "decryption.provider: sops" in errors[0]
 
 
-def test_sops_secret_with_decryption_is_ok(tmp_path: Path) -> None:
-    spec = FluxKustomizationSpec(path=_PATH, decryption=Decryption(provider="sops"))
+def test_sops_secret_with_decryption_and_secretref_is_ok(tmp_path: Path) -> None:
+    spec = FluxKustomizationSpec(
+        path=_PATH, decryption=Decryption(provider="sops", secret_ref=SecretRef(name="sops-age-cluster-secrets"))
+    )
     cluster = _cluster(tmp_path, _sops_secret(), spec)
 
     assert check_sops_decryption_blocks(cluster, tmp_path) == []
+
+
+def test_sops_secret_with_provider_but_no_secretref_is_flagged(tmp_path: Path) -> None:
+    # The litellm-keys-tf (#2797) shape: provider: sops declared, but no secretRef —
+    # Flux is told to decrypt SOPS yet given no key, so ciphertext is applied literally.
+    spec = FluxKustomizationSpec(path=_PATH, decryption=Decryption(provider="sops"))
+    cluster = _cluster(tmp_path, _sops_secret(), spec)
+
+    errors = check_sops_decryption_blocks(cluster, tmp_path)
+
+    assert len(errors) == 1
+    assert _NAME in errors[0]
+    assert "secretRef.name" in errors[0]
 
 
 def test_plain_secret_without_decryption_is_ok(tmp_path: Path) -> None:


### PR DESCRIPTION
Strengthens the SOPS-decryption check from #2795 to also require `spec.decryption.secretRef.name`, and adds a `lessons_learned` entry for the whole bug class.

**Why:** #2795 only validated `decryption.provider`, so it passed `litellm-keys-tf` which had `provider: sops` but **no `secretRef`** (#2797) — Flux was told to decrypt yet given no key, so the `ENC[...]` ciphertext was still applied. The cluster is 100% `sops-age-cluster-secrets`, so every SOPS kustomization satisfies the strengthened check today.

**Test (folded in):** `test_sops_secret_with_provider_but_no_secretref_is_flagged` reproduces the litellm-keys-tf shape; the happy-path test now carries a `secretRef`.

**Verified:** `test_sops_decryption` + `test_cluster_integration` PASSED on RBE; ruff/markdownlint/prettier clean. `cluster/docs/lessons_learned/2026_07_04_flux_sops_ciphertext_applied_literally.md` captures the bug class across all five incidents.