### PR TITLE
ci: propagate FORGEJO_IMAGES creds to GITHUB_ENV

### DIFF
--- a/.github/actions/setup-ci-secrets/action.yml
+++ b/.github/actions/setup-ci-secrets/action.yml
@@ -43,11 +43,11 @@ runs:
         # now use the workflow-scoped secrets.GITHUB_TOKEN plumbed directly
         # through bb remote env_overrides (see push-images.yml).
         for var in BUILDBUDDY_API_KEY ATTIC_TOKEN \
-                   PROPS_REGISTRY_PASSWORD GH_RELEASE_PAT; do
+                   PROPS_REGISTRY_PASSWORD FORGEJO_IMAGES_PASSWORD GH_RELEASE_PAT; do
           val="${!var:-}"
           if [ -n "$val" ]; then
             echo "::add-mask::$val"
           fi
         done
         # Export to GITHUB_ENV for subsequent steps
-        env | grep -E '^(BUILDBUDDY_API_KEY|ATTIC_TOKEN|PROPS_REGISTRY_USERNAME|PROPS_REGISTRY_PASSWORD|GH_RELEASE_PAT)=' >> "$GITHUB_ENV"
+        env | grep -E '^(BUILDBUDDY_API_KEY|ATTIC_TOKEN|PROPS_REGISTRY_USERNAME|PROPS_REGISTRY_PASSWORD|FORGEJO_IMAGES_USERNAME|FORGEJO_IMAGES_PASSWORD|GH_RELEASE_PAT)=' >> "$GITHUB_ENV"


### PR DESCRIPTION
## Problem

After #2774 merged, the `codex-pod image` workflow failed on **Push to Forgejo**:

```
level=fatal msg="username can't be empty"
```

`.github/actions/setup-ci-secrets` only writes an **allowlisted** set of decrypted
vars to `$GITHUB_ENV` (so later steps see them). `ci_env.sh` exports
`FORGEJO_IMAGES_{USERNAME,PASSWORD}`, but they weren't in the allowlist grep — so
they lived only in the decrypt step's shell and never reached the push step.

## Fix

- Add `FORGEJO_IMAGES_{USERNAME,PASSWORD}` to the `$GITHUB_ENV` allowlist grep.
- Mask `FORGEJO_IMAGES_PASSWORD` alongside the other secret passwords.

Mirrors the existing `PROPS_REGISTRY_*` handling exactly.

## Note

Separately, the first push also races the in-cluster `forgejo-images` Terraform
that provisions the `ducktape-ci` user; once that's applied a re-run of the image
workflow will push successfully.