### PR TITLE
agent-box: re-encrypt attic token with all agent-user recipients

### DIFF
--- a/secrets/hosts/agent-box-attic.yaml
+++ b/secrets/hosts/agent-box-attic.yaml
@@ -1,40 +1,44 @@
 expires_unencrypted: "2027-06-28T07:28:49Z"
-attic_token: ENC[AES256_GCM,data:d52VvWELb6wxnGrmPZ2oxwfupDvawex3KTvwTFjVSUPyZxBj0Y3d2p60e7BcmPHLIk2SWcinDy3WK076QHN8mHAtZ21o5+6yiQGeIvkNGlCrXAOmvAeW1hgQGgVe40WXARBhZO+CcNJmRfFyarXAck3zsWLQt8LzHe5i4ZSENq9yG5qxxydwTDRZpBZeZnSPVVCgfIIxGC3OrexgUGoLBAd3YyFVe5T6/Bshxxy4+6dzNajkf6ult2s0KnudC5fY+KRl3PGfBEG8EXq8YDnhT9+0U1d2eua3vu6W/AiZsgNIIn6W+eiCV1dPhXsU/O5tqnMa+trbew==,iv:en+RUT9eiquFeGv//0RiUWGQQA0BMdaTLEzTzz8frhE=,tag:VgWerRgCF/Tb1GwAhOZPqA==,type:str]
+attic_token: ENC[AES256_GCM,data:4MACMzTWTHEZ86tkIUP/JDmgtM2ckxIB3nhFabfw9oHpiD7zdDMyOZ+pyasDNR2pGXafFq8y53xeOntUgDjkEuwUi17Uh9V3+/XK7URv98WAKvnBYG4l/M7i0YEKmAGhJe52FvHawf1EqQUbNg2z3IDq9wgKmUqQDop4SOTBn8AqdJwOUvl2taOf734aIGeI0XXbf9MRD6l0lBja+JIuATjr8RkV8UTrvecqEKflc/8oiFudq+JD3Zvxb1omq1sYBqoodwlaR4ebHTCSuzHXWKvf0H2NCgn+1EXjAIRHEWSFac2g70jOsXnqf4GViUVBjXBu5rVxKA==,iv:dWv995Dkz01G8FZ46VEYgGdvIw9h8bc8rv99dX03pRw=,tag:wqASOTZZWq5dCh2slrSpkw==,type:str]
 sops:
-    kms: []
-    gcp_kms: []
-    azure_kv: []
-    hc_vault: []
     age:
         - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFdnJjcjFXV0JQb201dVc2
-            M2hCeHlpSXlYQkgrbTFFQUIxK3ZxbC8yRkhnCmxqc2RVaFVVTGNGVEZNdWtreFR3
-            K2ZOc3crU01MUysyU0ExZ3VHeFlWS2MKLS0tIFpwbTFyRmQ3VTZnTFM3UmZSTHd4
-            S3VMUVpMNHNqQUF2VlJDWExTbWxHbFUKLcNTZf7CitZ1/25n60uPPDkJ8s0/CXHA
-            Z+Kyoq9A8hVazswFUZ4799fAPgNB43fGLuyhX3YHQ1dZDGeGdg18AQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBXYTlkUjNtaWZhdW5zZWtD
+            ODlCdjByaG0wUGdMYnZBUkZPL3FkVjVFNEhVClk0MEdOSkdYR0owNUlyTmtnMmFW
+            Y25Rb1JsUGx3cHFFVCtkNXl2VHpkWG8KLS0tIFF4VmJCQ1FBbEF3WnVPazhTYjRB
+            U3U1VnlHV2IyZ25neGJnV2Vya3JncFEKb024WMAj2PSINU1fi/v6s4ZiCbUBSe+c
+            NSxcieFQCELbF/JHMez/pDJpbv2Qrt3H9gkjiyhD3PQo1UauwhSeGQ==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1gzgkw3pcyd4aan0ndqnc7g7q4rrg3ufpd7n2hepuqpjcmqjj056s4lqawx
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOclBzbjZHajkxRzVDQmdl
-            WnhSRzdXMWJJNU11WElJWUcyMlhYTHRqM3hRCmVydHlNQlVvMmxCejRFTnZiQVg0
-            bjVNd3NWYWEySFVJeGVNd0ZSVHZnc2sKLS0tIEJpZXdhcmxYZHV5ZTR2NjI4V1Qx
-            UHE3Vytsbko0Ulo1UEVJUHd1eExsOVEKqcUclXbXCPlxzQpoVtAsu85n339h09+Z
-            kEEUVjaSwSyhU9ES/YTimLA7T8oZMJAfeBitBZuYrSA33kpSubl0QA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1N3Z5YkxFbkJsaU9YSDZL
+            R2UzWEpucTZkRXgyQnQyK3lVL1FSVWRvVEJrClJhVVZqZ2V5T3duZnZoMHBaSVRu
+            bFEyVHIxcTZkNjdOY1RZeExoSjNjRm8KLS0tIGczS2lVRm1vS3ZveS9YZE9mYUIr
+            RmFnWVdBWXJMRlZvN0toOWd6Sng4QlEKf6RfY1P+U+QTb84vhoaPRMVWo1WY/oS6
+            57c/A08YCFOta2ym30X/qhyZS/QyKcnM7X01/NkvKWdWiAiHM0y+wg==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age16madmg3yjv39dekr6dscqr2slv0haxcw7lw25v8vmly4wl95td4qwev54u
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQVEQ1eTAyY0JjTEJyeEc4
-            akt3OWdPZm5QUWhmREJQV2Y5cDNpOHhMcEd3CmpqUU15UTVacno4LzZyODQ5VVlY
-            VXNRbktFc05tZ2JaNUlDTXpTZ3RJR00KLS0tIFhsbTNwRHF4YnB3aXAzL2o0Zm1r
-            VURMQlRhdTR4SWpKampNRDRxaW5RblEKhDIiCKBz8dWps/LyaK8Ekho5AAlSyFO2
-            jwDwrjeaz6cguzmcGn63ChbClOlwI6SjrKh9PTyMnNpyUM5xgT1w8g==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTRUllNUplZTBxVkZBSTU1
+            SmxIMGxTR3V2R2dzOXNjdWwyMmhjWTJiQ2c0CkpBVzBSNVBUZlFlbnBhejZoNGY0
+            UHluSFlHcWlNT3M1V1hFMk5QRkZjSXMKLS0tIEMrVTIyelBhRXI3ZjU2eG11MGVK
+            WE9jenNTNTZNaUExcnJLTFdpY1U2aXMK+xurKZ4OJV9FDTmkCGP5EI//23sk+Loo
+            iSn+Nt+5z1Y+DJtJJGEawAXKaCmam6UgFvDJVOJFLIc6Xhly8UqqCA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-06-28T01:28:49Z"
-    mac: ENC[AES256_GCM,data:Kf0b9yh2o1ZmzCrwDx+8g9IGxPt5ayw3UVXFTxlZhNgqU78cncT/iTkQ9ZarzYv0O/W9HR0KRMYchvRJ8WrmrMnGoWN5lzyTsR1T3eIfeP1Cuo2WRgDFNKrX4rBzueG1vv1PdgcIBHouMklAufsMHcE0zjaX4Udpz0V2eLu0/84=,iv:+Jd4lOxSnX5WfscOljRjru3pEs0GUhWb899rWc+1ELo=,tag:RTW79mRXe9min6aa9JeG0g==,type:str]
-    pgp: []
+        - recipient: age14zkdx3rku2yp9zv8ejrlv0yd53yx7rmmtfzxmxhawvc5hp2gxf7sxnv4sv
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYbUQzck9YMjJCbjdOeldj
+            RXMvaUMyK2FyakdwKzJHZGpXV013ajF2T1ZzCkw2dzVuVytUUmVPS3l4UXFjRTFl
+            SmE4ZVk4UitMME9JcG9GQkRieEJLZzAKLS0tIDhXNUEwY3p3bmxST1hiQVIvQ3FJ
+            akZxOG9yMklsZ0ZQM3VlQUR3cWVDK1EKgPaMJxVkDir35oBqNskwBjWkFDWITK/g
+            8ZY8e8JdD8roQcqwTNuVYgl4ioQJPKe4V0UBpuEKNJuGwTcUTKrHYg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-07-04T05:42:28Z"
+    mac: ENC[AES256_GCM,data:vzSeZJvSp6YzJPOdQNpRbuwuONfmeKOXas3cLJrdXO1mPpDmLENpLK4MTitySm3WbG4H2BMT3DUpf5z4mDx4bQHhvCDGGo7/9gYL/PwYSQH8kJ5V+dgS7a7x/BxwEFmcR944oVkbAvoTvZ6e9jMABLN6iNNYu1zRAPKKzVGiLSY=,iv:eiysguoLdnjMBQxiCbl4bCgzrEtjcseJoq2lj7UWmbQ=,tag:S0fGnpOiPpPilupUTh8ylw==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.9.4
+    version: 3.12.1


### PR DESCRIPTION
The attic file was encrypted to only admin + agent-box-host, missing both agent-box-codex-user and agent-box-zai-user. Both home-manager sops-nix instances failed to decrypt it. Re-encrypted from the plaintext (decrypted on the VM via ssh-to-age) with all 4 recipients per the .sops.yaml rule. This was the remaining `sops-nix.service` failure preventing the `zai` nixos-rebuild switch from completing.