### PR TITLE
codex-pod: fix $imagepolicy marker placement (trailing comment)

### DIFF
--- a/cluster/k8s/agents/codex-pod/deployment.yaml
+++ b/cluster/k8s/agents/codex-pod/deployment.yaml
@@ -34,8 +34,9 @@ spec:
           type: RuntimeDefault
       containers:
         - name: codex
-          # {"$imagepolicy": "flux-system:codex-pod"}
-          image: git.allegedly.works/ducktape-ci/codex-pod:devel
+          # Flux image-automation setter: the marker MUST be a trailing comment on
+          # the image line (kyaml Setters ignores an own-line comment above it).
+          image: git.allegedly.works/ducktape-ci/codex-pod:devel # {"$imagepolicy": "flux-system:codex-pod"}
           # HOME (/home/codex) + all static config are baked into the image by
           # home-manager. The only runtime step is planting the SSH private key
           # (secret → 0600; a mount can't satisfy ssh's ownership/perms). Access


### PR DESCRIPTION
codex-pod was stuck in ImagePullBackOff on `:devel` (a tag that never exists) even after CI pushed the real `devel-<ts>-<sha7>` image and the codex-pod ImagePolicy resolved it.

Root cause: the `$imagepolicy` setter marker was on its own line **above** the `image:` field. Flux's kyaml Setters strategy only recognizes it as a **trailing comment on the image line** (as every other deployment in cluster/k8s has it), so `all-images` reported `repository up-to-date` and never rewrote the tag.

Fix: move the marker to a trailing comment on the image line. Once merged, `all-images` rewrites it to the resolved tag and the pod pulls the real image.