### PR TITLE
haku-ui: one git store — central read layer, progress indicator, persistent cache, consistent errors

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -63,6 +63,13 @@ instead, so they load on demand.
   - **Never swallow**: no bare/broad `except` as a silent fallback, no defaulting to
     empty values on parse/IO errors — real errors must surface. Broad catch is fine
     only for cleanup-then-`raise` (e.g. `__exit__`).
+  - **Degrade loud, not silent**: when a fallback genuinely is correct (best-effort
+    cache write, optional prefill, non-critical fetch, graceful UI degradation), the
+    `catch` still **logs the exception** — module logger (`logging.getLogger(__name__)`;
+    frontend `log.ts`) at `warning`/`error`, never a bare `console.*`. No empty
+    `catch {}`, comment-only catch, or `.catch(() => {})`. The only exception is when the
+    failure already surfaces through another path (e.g. the caller re-throws with the
+    detail) — then a second log is noise.
   - **Raise, don't return error lists**, from validation/precondition checks.
   - **Let them propagate** to the single error boundary (CLI wrapper, request
     middleware, FastMCP handler — FastMCP already converts unhandled exceptions to MCP

--- a/STYLE.md
+++ b/STYLE.md
@@ -65,11 +65,11 @@ instead, so they load on demand.
     only for cleanup-then-`raise` (e.g. `__exit__`).
   - **Degrade loud, not silent**: when a fallback genuinely is correct (best-effort
     cache write, optional prefill, non-critical fetch, graceful UI degradation), the
-    `catch` still **logs the exception** — module logger (`logging.getLogger(__name__)`;
-    frontend `log.ts`) at `warning`/`error`, never a bare `console.*`. No empty
-    `catch {}`, comment-only catch, or `.catch(() => {})`. The only exception is when the
-    failure already surfaces through another path (e.g. the caller re-throws with the
-    detail) — then a second log is noise.
+    `catch` still **logs the exception** via a module-level logger
+    (`logging.getLogger(__name__)`, or the component's frontend logging wrapper) at
+    `warning`/`error`. No empty `catch {}`, comment-only catch, or `.catch(() => {})`.
+    The only exception is when the failure already surfaces through another path (e.g. the
+    caller re-throws with the detail) — then a second log is noise.
   - **Raise, don't return error lists**, from validation/precondition checks.
   - **Let them propagate** to the single error boundary (CLI wrapper, request
     middleware, FastMCP handler — FastMCP already converts unhandled exceptions to MCP

--- a/haku/state_template/ui/README.md
+++ b/haku/state_template/ui/README.md
@@ -33,6 +33,12 @@ npm run build   # → dist/  (the Dockerfile copies this into the backend's stat
 npm run dev     # local dev server; proxies /api to a backend on :8080
 ```
 
+Repo reads all funnel through the two git primitives in `src/repo.ts` (recursive tree, bulk
+blobs). Both register with a central tracker (`src/git_progress.ts`), and `src/git_progress_bar.tsx`
+renders one app-wide top progress bar mirroring git's object-transfer count (`done/total`) whenever
+any read — from any surface — is in flight; per-view "Loading…" text stays as each surface's
+first-paint skeleton.
+
 Because this UI runs **inside** the console's sandboxed iframe (no `allow-popups`),
 it cannot open links itself. All outbound navigation (`<handoff>` deep-links, item source)
 goes through the console's **`openLink` postMessage bridge**: `src/bridge.ts` posts

--- a/haku/state_template/ui/README.md
+++ b/haku/state_template/ui/README.md
@@ -17,7 +17,7 @@ the Forgejo CI **test gate** (see _Tests_ below).
 | `frontend/`                           | React + TypeScript SPA (standard Vite). Value-ranked **Up next** (top 7) + collapsible **Backlog**, collapsible item cards, `marked`+`dompurify` markdown bodies rendering inline affordance widgets (`<signal-toggle>`, `<handoff>`, `<launch>`, `<feedback>`), per-item + global feedback. |
 | `backend/`                            | FastAPI app (no build step). Talks to the **Forgejo contents API** (no local clone): a generic content proxy (tree + bulk blobs) the SPA composes to read `items/*.md`, serves the SPA + a JSON API, and writes operator intent (`responses/`, `intake/`) back to `haku-state`.              |
 | `Dockerfile`                          | Multi-stage: `frontend` builds the SPA → `backend-base` installs deps → `test` runs pytest → `runtime` runs uvicorn on `:8080` as non-root with the built SPA copied in.                                                                                                                     |
-| `backend/test_*.py`                   | Backend pytest suite (models parsing, the Forgejo read path, the FastAPI endpoints). Run during the CI test gate; dev-only deps in `backend/requirements-dev.txt`.                                                                                                                           |
+| `backend/test_*.py`                   | Backend pytest suite (models parsing, the Forgejo read path, the FastAPI endpoints). Run during the CI test gate; dev-only deps via `backend/pyproject.toml`'s `[dev]` extra.                                                                                                                |
 | `../.forgejo/workflows/build-ui.yaml` | Forgejo Actions workflow: **test** (gate) → **build** push `forgejo.example.com/haku/ui:main-<utc>-<sha>`. Flux image automation (not CI) then writes the tag into `../k8s/haku-ui/deployment.yaml`.                                                                                         |
 | `../k8s/haku-ui/`                     | Deployment (the built image, registry-pull imagePullSecret, `haku-state-git-write` env) + Service (`80` → `8080`).                                                                                                                                                                           |
 
@@ -35,9 +35,9 @@ npm run dev     # local dev server; proxies /api to a backend on :8080
 
 Repo reads all funnel through the two git primitives in `src/repo.ts` (recursive tree, bulk
 blobs). Both register with a central tracker (`src/git_progress.ts`), and `src/git_progress_bar.tsx`
-renders one app-wide top progress bar mirroring git's object-transfer count (`done/total`) whenever
-any read — from any surface — is in flight; per-view "Loading…" text stays as each surface's
-first-paint skeleton.
+renders one app-wide bottom-fixed progress bar mirroring git's object-transfer count (`done/total`)
+whenever any read — from any surface — is in flight; per-view "Loading…" text stays as each
+surface's first-paint skeleton.
 
 Because this UI runs **inside** the console's sandboxed iframe (no `allow-popups`),
 it cannot open links itself. All outbound navigation (`<handoff>` deep-links, item source)
@@ -53,8 +53,8 @@ FastAPI, port `8080`. Endpoints:
 - `GET /api/meta` — footer freshness (last Haku scan time) + which commit the running image was
   built from.
 - `GET /api/repo/tree` + `GET /api/repo/blobs` — the generic read-only content proxy the SPA
-  composes to read `items/*.md`, `memory/improvements/*.md`, and any repo markdown at HEAD.
-- `GET /api/runs` — recent run manifests + their prose notes (`runs/<date>/<ulid>.{yaml,md}`).
+  composes to read `items/*.md`, `memory/improvements/*.md`, the run manifests
+  (`runs/<date>/<ulid>.{yaml,md}`, paired on the frontend), and any repo markdown at HEAD.
 - `PUT/DELETE /api/responses/{scope}/{field}` — record/clear an operator response
   (item status, form answer) as `responses/<scope>/<field>.yaml`.
 - `POST /api/trace/feedback` — append an intake note (`text`, optional `item_id`).
@@ -81,7 +81,7 @@ internal Forgejo API root
 
 ```bash
 cd backend
-pip install -r requirements.txt
+pip install .
 HAKU_UI_GIT_USERNAME=… HAKU_UI_GIT_PASSWORD=… HAKU_UI_FORGEJO_API_URL=… python app.py
 ```
 
@@ -103,7 +103,7 @@ Run the backend tests locally:
 
 ```bash
 cd backend
-pip install -r requirements.txt -r requirements-dev.txt
+pip install .[dev]
 python -m pytest -q
 ```
 

--- a/haku/state_template/ui/README.md
+++ b/haku/state_template/ui/README.md
@@ -23,8 +23,8 @@ the Forgejo CI **test gate** (see _Tests_ below).
 
 ## Frontend
 
-Standard Vite React+TS — no Mantine/Tailwind/Bazel (lean and self-contained). Plain
-CSS in `src/styles.css`.
+Standard Vite React+TS with Mantine (`@mantine/core`) — no Tailwind/Bazel (lean and
+self-contained). App-specific CSS in `src/styles.css`.
 
 ```bash
 cd frontend

--- a/haku/state_template/ui/backend/app.py
+++ b/haku/state_template/ui/backend/app.py
@@ -36,8 +36,8 @@ from config import Settings
 from fastapi import Depends, FastAPI, Header, HTTPException, Request, Response
 from fastapi.staticfiles import StaticFiles
 from forgejo import Forgejo
-from models import FeedbackRequest, MetaResponse, RepoBlob, RepoTree, RepoTreeEntry, ResponseRequest, RunsResponse
-from reads import read_runs, read_scan_time
+from models import FeedbackRequest, MetaResponse, RepoBlob, RepoTree, RepoTreeEntry, ResponseRequest
+from reads import read_scan_time
 
 logger = logging.getLogger(__name__)
 
@@ -141,12 +141,9 @@ def create_app(settings: Settings) -> FastAPI:
     # generic tree+blobs proxy and rendered by the <improvement-board/> garden widget — no
     # bespoke endpoint. See plans/garden-gradient.md → Settled mechanism.
 
-    # --- Runs surface: per-run propagation record (runs/<date>/<ulid>.{yaml,md}) -
-    @app.get("/api/runs")
-    async def runs(forgejo: ForgejoDep) -> RunsResponse:
-        """Recent run manifests + their prose notes — proves each source was processed and shows
-        how each change propagated to every surface. Read-only; empty if no runs recorded yet."""
-        return RunsResponse(runs=await read_runs(forgejo))
+    # The runs surface (runs/<date>/<ulid>.{yaml,md}) composes over the generic tree+blobs proxy —
+    # the frontend pairs each manifest with its prose notes and parses them (client.ts:fetchRuns).
+    # No bespoke endpoint. RunManifest/RunsResponse stay in models.py as the wire contract.
 
     # The knowledge garden (browse + file read) now composes over the generic content proxy
     # below — the frontend filters the tree to the curated dirs and fetches blobs. No bespoke

--- a/haku/state_template/ui/backend/reads.py
+++ b/haku/state_template/ui/backend/reads.py
@@ -1,18 +1,13 @@
 """Feature reads — compose the generic Forgejo client into haku-state's data shapes.
 
-This is the layer that DOES know about features (which file/dir, how to parse it). It sits
-above the feature-agnostic `Forgejo` client so that adding a surface changes only this layer
-(and the endpoint), never the git-content client. Simple single-file reads are just
-`forgejo.read_yaml(path)` inline in the endpoint; surfaces that need the batched tree+blobs read
-(e.g. the runs manifests) live here. Content collections (e.g. items, improvements) skip this
-layer entirely — the frontend composes over the generic tree+blobs proxy.
+Nearly every surface now composes over the generic tree+blobs proxy on the *frontend* (items,
+garden, runs, responses) — see repo.ts/client.ts. What's left here is the one read that isn't a
+content fetch: the "last scan" freshness stamp, derived from the commit log.
 """
 
 from __future__ import annotations
 
-import yaml
 from forgejo import Forgejo
-from models import RunManifest
 
 # Haku-the-scanner commits as this author; the "last scan" time is the newest such commit
 # (NOT the UI's response/feedback writes, NOT Flux image-automation commits).
@@ -28,33 +23,3 @@ async def read_scan_time(forgejo: Forgejo) -> str:
         (c["commit"]["author"]["date"] for c in commits if c["commit"]["author"]["email"] == _HAKU_AUTHOR_EMAIL),
         commits[0]["commit"]["author"]["date"],
     )
-
-
-async def read_runs(forgejo: Forgejo, limit: int = 20) -> list[RunManifest]:
-    """Recent per-run propagation manifests (``runs/<date>/<ulid>.yaml``) with their prose
-    notes (the sibling ``.md``) attached, newest-first by ``started``.
-
-    Two reads beyond the commits list (tree + one batched blobs fetch), regardless of run
-    count. A run needs a ``.yaml`` to appear; the ``.md``
-    is optional (``runs/README.md`` and other dangling ``.md`` are ignored)."""
-    commits = await forgejo.commits(1)
-    tree = await forgejo.tree(commits[0]["sha"])
-    pairs: dict[str, dict[str, str]] = {}  # run base path -> {"yaml": sha, "md": sha}
-    for e in tree:
-        if e["type"] != "blob" or not e["path"].startswith("runs/"):
-            continue
-        path = e["path"]
-        if path.endswith(".yaml"):
-            pairs.setdefault(path.removesuffix(".yaml"), {})["yaml"] = e["sha"]
-        elif path.endswith(".md") and not path.endswith("/README.md"):
-            pairs.setdefault(path.removesuffix(".md"), {})["md"] = e["sha"]
-    bases = [b for b, s in pairs.items() if "yaml" in s]
-    shas = [sha for b in bases for sha in (pairs[b]["yaml"], *([pairs[b]["md"]] if "md" in pairs[b] else []))]
-    blobs = iter(await forgejo.blobs(shas))
-    runs: list[RunManifest] = []
-    for b in bases:
-        manifest = yaml.safe_load(next(blobs)) or {}
-        manifest["notes_md"] = next(blobs).decode() if "md" in pairs[b] else ""
-        runs.append(RunManifest.model_validate(manifest))
-    runs.sort(key=lambda m: m.started, reverse=True)
-    return runs[:limit]

--- a/haku/state_template/ui/backend/test_models.py
+++ b/haku/state_template/ui/backend/test_models.py
@@ -1,13 +1,14 @@
-"""Frontmatter models the validate-state gate checks — item docs + the improvements backlog.
+"""Models the validate-state gate checks — item docs, the improvements backlog, run manifests.
 
-The bug class these guard: a malformed frontmatter file silently parsing into a wrong shape, or a
-bad enum/out-of-range value slipping through (items/ + memory/improvements/ are hand/Haku-authored).
+The bug class these guard: a malformed authored file silently parsing into a wrong shape, or a bad
+enum/out-of-range value slipping through (items/, memory/improvements/, and runs/ are hand/
+Haku-authored, parsed live at read time / in CI, never build-checked).
 """
 
 from __future__ import annotations
 
 import pytest
-from models import ImprovementDoc, ItemDoc, ItemStatus
+from models import ImprovementDoc, ItemDoc, ItemStatus, RunManifest
 from pydantic import ValidationError
 
 # --- item frontmatter (items/<slug>.md) ---------------------------------------
@@ -46,6 +47,32 @@ def test_improvement_doc_rejects_bad_weight_kind_and_class():
     for bad in ({"weight": "huge"}, {"kind": "note"}, {"class": "bug"}):
         with pytest.raises(ValidationError):
             ImprovementDoc.model_validate({**base, **bad})
+
+
+# --- run manifests (runs/<date>/<ulid>.yaml) ----------------------------------
+# The runs surface is composed on the frontend now (client.ts pairs each manifest with its .md over
+# the tree+blobs proxy); this schema stays the floor those manifests must satisfy.
+
+
+def test_run_manifest_accepts_prose_changes_seen_and_created_action():
+    # Real manifests carry prose where a count would mislead, and surfaces that were created.
+    m = RunManifest.model_validate(
+        {
+            "run_id": "x",
+            "sources": [{"source": "ducktape-git", "changes_seen": "2 commits, neither touches base"}],
+            "propagation": [{"change": "c", "surfaces": [{"surface": "s", "action": "created"}]}],
+        }
+    )
+    assert m.sources[0].changes_seen == "2 commits, neither touches base"
+    assert m.propagation[0].surfaces[0].action == "created"
+
+
+def test_run_manifest_rejects_bad_propagation_action():
+    # CI schema floor: an unknown propagation action is a hard error.
+    with pytest.raises(ValidationError):
+        RunManifest.model_validate(
+            {"run_id": "x", "propagation": [{"change": "c", "surfaces": [{"surface": "s", "action": "bogus"}]}]}
+        )
 
 
 if __name__ == "__main__":

--- a/haku/state_template/ui/frontend/package-lock.json
+++ b/haku/state_template/ui/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@mantine/core": "^9.4.1",
         "@mantine/hooks": "^9.4.1",
+        "@mantine/notifications": "^9.4.1",
         "dompurify": "^3.4.11",
         "marked": "^18.0.5",
         "react": "^19.2.7",
@@ -118,7 +119,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
       "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -853,6 +853,31 @@
       "version": "9.4.1",
       "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-9.4.1.tgz",
       "integrity": "sha512-eTI8wmzPx3r98zgKIEuvukmoGTHBhmtI6+9E6o2DbTmEU2eM1bCdjE2vFdf0op2AlRO0KEYEcZhNQi4T/SJk0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^19.2.0"
+      }
+    },
+    "node_modules/@mantine/notifications": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/@mantine/notifications/-/notifications-9.4.1.tgz",
+      "integrity": "sha512-Sm1g8E8RkFmesxpNz9zFvOjkTVxOa7dJJjMGoHNIXH+9/wO0s9kInny4mVnxTbLJJsD6nTqIQlk1v8tq2C4Ftw==",
+      "license": "MIT",
+      "dependencies": {
+        "@mantine/store": "9.4.1",
+        "react-transition-group": "4.4.5"
+      },
+      "peerDependencies": {
+        "@mantine/core": "9.4.1",
+        "@mantine/hooks": "9.4.1",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0"
+      }
+    },
+    "node_modules/@mantine/store": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/@mantine/store/-/store-9.4.1.tgz",
+      "integrity": "sha512-/DCZq0aqqIdm03J0RJ7pbzoau2cwY8ndSOjskHOKHhTeWMnOBdCKXA3oMO5aIDldDqJ9T7Io4Boh4Pt461zNQw==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^19.2.0"
@@ -1894,7 +1919,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -1978,6 +2002,16 @@
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
     },
     "node_modules/dompurify": {
       "version": "3.4.11",
@@ -2441,6 +2475,24 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/loose-envify/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -2521,6 +2573,15 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/parse5": {
@@ -2743,6 +2804,23 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2858,6 +2936,22 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
       }
     },
     "node_modules/require-from-string": {

--- a/haku/state_template/ui/frontend/package.json
+++ b/haku/state_template/ui/frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@mantine/core": "^9.4.1",
     "@mantine/hooks": "^9.4.1",
+    "@mantine/notifications": "^9.4.1",
     "dompurify": "^3.4.11",
     "marked": "^18.0.5",
     "react": "^19.2.7",

--- a/haku/state_template/ui/frontend/src/affordances.test.tsx
+++ b/haku/state_template/ui/frontend/src/affordances.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { MantineProvider } from "@mantine/core";
+import { cleanNotifications, Notifications } from "@mantine/notifications";
 import { cleanup, fireEvent, render as rtlRender, screen, waitFor } from "@testing-library/react";
 import type { ReactElement } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -27,12 +28,19 @@ window.matchMedia ??= ((query: string) => ({
   dispatchEvent: () => false,
 })) as typeof window.matchMedia;
 
+// Mount <Notifications> so a failure toast (notifyError) actually renders into the DOM.
 function render(ui: ReactElement) {
-  return rtlRender(<MantineProvider>{ui}</MantineProvider>);
+  return rtlRender(
+    <MantineProvider>
+      <Notifications />
+      {ui}
+    </MantineProvider>
+  );
 }
 
 afterEach(() => {
   cleanup();
+  cleanNotifications(); // the notifications store is module-global — clear it between tests
   vi.clearAllMocks();
 });
 

--- a/haku/state_template/ui/frontend/src/affordances.tsx
+++ b/haku/state_template/ui/frontend/src/affordances.tsx
@@ -3,6 +3,7 @@ import { Children, createContext, useContext, useEffect, useState, type ReactNod
 
 import { openLink, requestLaunch, type LaunchResult } from "./bridge.ts";
 import { clearResponse, readResponse, sendFeedback, setResponse } from "./client.ts";
+import { notifyError } from "./errors.ts";
 import { ItemScopeContext } from "./item_scope.ts";
 
 // Affordance widgets — a growing library of reviewed, embeddable action buttons Haku can drop
@@ -89,7 +90,7 @@ export function Launch({ prompt, label = "Launch run" }: { prompt: string; label
 // text="not useful" label="👎 not useful"></feedback>` — instead of a free-form box. Optional
 // `item` scopes the feedback to an item id.
 export function Feedback({ text, label = "Send feedback", item }: { text: string; label?: string; item?: string }) {
-  const [state, setState] = useState<"idle" | "sending" | "sent" | { error: string }>("idle");
+  const [state, setState] = useState<"idle" | "sending" | "sent">("idle");
   if (state === "sent")
     return (
       <Text size="xs" c="teal">
@@ -97,27 +98,23 @@ export function Feedback({ text, label = "Send feedback", item }: { text: string
       </Text>
     );
   return (
-    <Group gap="xs">
-      <Button
-        size="xs"
-        variant="default"
-        loading={state === "sending"}
-        onClick={() => {
-          setState("sending");
-          void sendFeedback(text, item).then(
-            () => setState("sent"),
-            (e: unknown) => setState({ error: e instanceof Error ? e.message : String(e) })
-          );
-        }}
-      >
-        {label}
-      </Button>
-      {typeof state === "object" && (
-        <Text size="xs" c="red">
-          {state.error}
-        </Text>
-      )}
-    </Group>
+    <Button
+      size="xs"
+      variant="default"
+      loading={state === "sending"}
+      onClick={() => {
+        setState("sending");
+        void sendFeedback(text, item).then(
+          () => setState("sent"),
+          (e: unknown) => {
+            notifyError("Couldn't send feedback", e);
+            setState("idle");
+          }
+        );
+      }}
+    >
+      {label}
+    </Button>
   );
 }
 
@@ -150,7 +147,6 @@ const ChoicesContext = createContext<ChoicesCtx | null>(null);
 export function Choices({ item, prompt, children }: { item?: string; prompt?: string; children?: ReactNode }) {
   const [recorded, setRecorded] = useState<string | null>(null);
   const [pending, setPending] = useState<string | null>(null); // value of the answer currently sending
-  const [error, setError] = useState<string | null>(null);
   const [otherOpen, setOtherOpen] = useState(false);
   const [otherText, setOtherText] = useState("");
 
@@ -158,7 +154,6 @@ export function Choices({ item, prompt, children }: { item?: string; prompt?: st
   // answered, then the answer; `recordedLabel` is what we echo back to the operator.
   function submit(key: string, recordedLabel: string, answer: string) {
     setPending(key);
-    setError(null);
     void sendFeedback(prompt ? `${prompt} → ${answer}` : answer, item).then(
       () => {
         setRecorded(recordedLabel);
@@ -166,7 +161,7 @@ export function Choices({ item, prompt, children }: { item?: string; prompt?: st
         setOtherOpen(false);
       },
       (e: unknown) => {
-        setError(e instanceof Error ? e.message : String(e));
+        notifyError("Couldn't record your answer", e);
         setPending(null);
       }
     );
@@ -215,11 +210,6 @@ export function Choices({ item, prompt, children }: { item?: string; prompt?: st
             Send
           </Button>
         </Group>
-      )}
-      {error && (
-        <Text size="xs" c="red">
-          {error}
-        </Text>
       )}
     </Stack>
   );
@@ -272,7 +262,6 @@ export function SignalToggle({
   const resolvedScope = scope || itemScope;
   const [selected, setSelected] = useState<string | null>(null);
   const [pending, setPending] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!resolvedScope) return;
@@ -299,7 +288,6 @@ export function SignalToggle({
   function pick(value: string) {
     const clearing = selected === value; // re-picking the active answer retracts it
     setPending(value);
-    setError(null);
     const op = clearing ? clearResponse(activeScope, field) : setResponse(activeScope, field, value);
     void op.then(
       () => {
@@ -307,7 +295,7 @@ export function SignalToggle({
         setPending(null);
       },
       (e: unknown) => {
-        setError(e instanceof Error ? e.message : String(e));
+        notifyError("Couldn't save your answer", e);
         setPending(null);
       }
     );
@@ -323,11 +311,6 @@ export function SignalToggle({
       <Group gap="xs">
         <ChoicesContext.Provider value={{ pick, pending, selected }}>{children}</ChoicesContext.Provider>
       </Group>
-      {error && (
-        <Text size="xs" c="red">
-          {error}
-        </Text>
-      )}
     </Stack>
   );
 }

--- a/haku/state_template/ui/frontend/src/affordances.tsx
+++ b/haku/state_template/ui/frontend/src/affordances.tsx
@@ -5,6 +5,9 @@ import { openLink, requestLaunch, type LaunchResult } from "./bridge.ts";
 import { clearResponse, readResponse, sendFeedback, setResponse } from "./client.ts";
 import { notifyError } from "./errors.ts";
 import { ItemScopeContext } from "./item_scope.ts";
+import { logger } from "./log.ts";
+
+const log = logger("affordances");
 
 // Affordance widgets — a growing library of reviewed, embeddable action buttons Haku can drop
 // free-form into any item/note body (via the garden renderer's registry), instead of a rigid
@@ -270,7 +273,10 @@ export function SignalToggle({
       (v) => {
         if (live) setSelected(v);
       },
-      () => {} // prefill is best-effort; a read failure just leaves the slot unanswered
+      (e: unknown) => {
+        // Prefill is best-effort — a read failure just leaves the slot unanswered — but log it.
+        log.warn(`signal-toggle prefill read failed for ${resolvedScope}/${field}`, e);
+      }
     );
     return () => {
       live = false;

--- a/haku/state_template/ui/frontend/src/app.tsx
+++ b/haku/state_template/ui/frontend/src/app.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { notifyRouteChanged } from "./bridge.ts";
 import { fetchMeta } from "./client.ts";
 import { NoteToHaku } from "./feedback_button.tsx";
+import { errText } from "./errors.ts";
 import { GitProgressBar } from "./git_progress_bar.tsx";
 import { GardenPage } from "./garden.tsx";
 import { ImprovementBoard } from "./improvement_board.tsx";
@@ -43,7 +44,7 @@ export default function App() {
     let alive = true;
     docsUnder("items")
       .then((docs) => alive && setDocItems(docs))
-      .catch((e: unknown) => alive && setError(e instanceof Error ? e.message : String(e)));
+      .catch((e: unknown) => alive && setError(errText(e)));
     // Footer metadata is best-effort — the board still renders without it.
     fetchMeta()
       .then((m) => alive && setMeta(m))

--- a/haku/state_template/ui/frontend/src/app.tsx
+++ b/haku/state_template/ui/frontend/src/app.tsx
@@ -10,11 +10,14 @@ import { GardenPage } from "./garden.tsx";
 import { ImprovementBoard } from "./improvement_board.tsx";
 import { InboxView } from "./inbox.tsx";
 import { LaunchButton } from "./launch.tsx";
+import { logger } from "./log.ts";
 import { type Doc, docsUnder } from "./repo.ts";
 import { formatHash, useHashRoute } from "./routes.ts";
 import type { View } from "./routes.ts";
 import { RunsPage } from "./runs.tsx";
 import type { MetaResponse } from "./types.ts";
+
+const log = logger("app");
 
 export default function App() {
   // Items are read straight from `items/*.md`; `meta` is just the footer's freshness/deploy stamp.
@@ -48,7 +51,7 @@ export default function App() {
     // Footer metadata is best-effort — the board still renders without it.
     fetchMeta()
       .then((m) => alive && setMeta(m))
-      .catch(() => {});
+      .catch((e: unknown) => log.warn("footer meta failed to load (scan time / deployed commit)", e));
     return () => {
       alive = false;
     };

--- a/haku/state_template/ui/frontend/src/app.tsx
+++ b/haku/state_template/ui/frontend/src/app.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { notifyRouteChanged } from "./bridge.ts";
 import { fetchMeta } from "./client.ts";
 import { NoteToHaku } from "./feedback_button.tsx";
+import { GitProgressBar } from "./git_progress_bar.tsx";
 import { GardenPage } from "./garden.tsx";
 import { ImprovementBoard } from "./improvement_board.tsx";
 import { InboxView } from "./inbox.tsx";
@@ -61,6 +62,9 @@ export default function App() {
 
   return (
     <Container size={760} px="md" pb="xl">
+      {/* App-wide git transfer indicator: fixed to the viewport top, shows whenever any repo
+          tree/blob read is in flight (any surface), idle otherwise. */}
+      <GitProgressBar />
       {/* The header (logo + Note/Launch) and the tab strip stay pinned as content scrolls
             (operator: keep the top menu fixed). Sticky within the scrolling iframe body; a solid
             body background + subtle shadow so content scrolls under it and it reads as a bar. */}

--- a/haku/state_template/ui/frontend/src/blob_cache.test.ts
+++ b/haku/state_template/ui/frontend/src/blob_cache.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { clearBlobCache, getBlob, hasBlob, setBlob } from "./blob_cache.ts";
+
+afterEach(() => {
+  clearBlobCache();
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("blob cache", () => {
+  it("persists a blob to localStorage and reads it back", () => {
+    setBlob("sha1", "hello");
+    expect(localStorage.getItem("haku-blob:sha1")).toBe("hello");
+    expect(getBlob("sha1")).toBe("hello");
+    expect(hasBlob("sha1")).toBe(true);
+  });
+
+  it("reads a localStorage-only entry (a prior session's) on a memory miss", () => {
+    // Written directly to storage, never through this session's memory tier — the reload case.
+    localStorage.setItem("haku-blob:sha2", "from-disk");
+    expect(getBlob("sha2")).toBe("from-disk");
+  });
+
+  it("returns undefined for an uncached sha", () => {
+    expect(getBlob("nope")).toBeUndefined();
+    expect(hasBlob("nope")).toBe(false);
+  });
+
+  it("keeps the blob in memory and logs (never swallows) when localStorage.setItem throws", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("quota", "QuotaExceededError");
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(() => setBlob("sha3", "big")).not.toThrow();
+    expect(getBlob("sha3")).toBe("big"); // memory tier still serves it
+    expect(warn).toHaveBeenCalled(); // the failure is surfaced, not silent
+  });
+
+  it("clearBlobCache removes only our keys, leaving unrelated localStorage entries", () => {
+    setBlob("sha4", "x");
+    localStorage.setItem("unrelated", "keep");
+    clearBlobCache();
+    expect(getBlob("sha4")).toBeUndefined();
+    expect(localStorage.getItem("haku-blob:sha4")).toBeNull();
+    expect(localStorage.getItem("unrelated")).toBe("keep");
+  });
+});

--- a/haku/state_template/ui/frontend/src/blob_cache.ts
+++ b/haku/state_template/ui/frontend/src/blob_cache.ts
@@ -1,0 +1,88 @@
+// Content-addressed blob store for repo.ts. A git blob's content is immutable for its sha, so a
+// blob is safe to keep forever AND across reloads — that's what lets us persist it. Two tiers:
+//   - an in-memory Map (always), and
+//   - localStorage keyed by sha (best-effort).
+// The UI runs in a sandboxed cross-origin iframe where localStorage may be absent or throw on touch
+// (see main.tsx), so every localStorage access is guarded — but never silently: a failure degrades
+// to the memory tier and is logged, never swallowed. No invalidation: an entry keyed by sha can
+// never be stale (content-addressed), so nothing here expires — clearBlobCache is only for tests /
+// an explicit reset.
+
+import { logger } from "./log.ts";
+
+const log = logger("blob-cache");
+const memory = new Map<string, string>();
+const PREFIX = "haku-blob:";
+
+// Probe once at load: the working Storage, or null if touching it throws (disabled iframe, private
+// mode) or it's absent (node/SSR). After this, `store === null` means "memory only".
+const store: Storage | null = (() => {
+  try {
+    const s = globalThis.localStorage;
+    const probe = `${PREFIX}\0probe`;
+    s.setItem(probe, "1");
+    s.removeItem(probe);
+    return s;
+  } catch (e) {
+    log.info("localStorage unavailable, using in-memory cache only", e);
+    return null;
+  }
+})();
+
+// Content for a sha, promoting a localStorage-only hit (a prior session's) into memory; undefined
+// if uncached anywhere.
+export function getBlob(sha: string): string | undefined {
+  const hit = memory.get(sha);
+  if (hit !== undefined) return hit;
+  if (store === null) return undefined;
+  try {
+    const stored = store.getItem(PREFIX + sha);
+    if (stored === null) return undefined;
+    memory.set(sha, stored);
+    return stored;
+  } catch (e) {
+    log.warn(`localStorage read failed for ${sha}`, e);
+    return undefined; // treat as a miss
+  }
+}
+
+export const hasBlob = (sha: string): boolean => getBlob(sha) !== undefined;
+
+export function setBlob(sha: string, content: string): void {
+  memory.set(sha, content);
+  if (store === null) return;
+  try {
+    store.setItem(PREFIX + sha, content);
+  } catch {
+    // Likely quota — drop our persisted blobs and retry once (a real recovery, not a swallow).
+    evictPersisted();
+    try {
+      store.setItem(PREFIX + sha, content);
+    } catch (e) {
+      // Still failing: the memory tier holds it, so we only forfeit cross-reload persistence here.
+      log.warn(`could not persist ${sha} to localStorage (kept in memory)`, e);
+    }
+  }
+}
+
+// Remove only our keys, leaving the rest of localStorage alone.
+function evictPersisted(): void {
+  if (store === null) return;
+  try {
+    const ours: string[] = [];
+    for (let i = 0; i < store.length; i++) {
+      const key = store.key(i);
+      if (key !== null && key.startsWith(PREFIX)) ours.push(key);
+    }
+    for (const key of ours) store.removeItem(key);
+  } catch (e) {
+    log.warn("localStorage eviction failed", e);
+  }
+}
+
+// Full reset — memory + persisted. For tests and an explicit session reset; production never needs
+// it (blobs are immutable by sha).
+export function clearBlobCache(): void {
+  memory.clear();
+  evictPersisted();
+}

--- a/haku/state_template/ui/frontend/src/client.test.ts
+++ b/haku/state_template/ui/frontend/src/client.test.ts
@@ -1,6 +1,58 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { sendFeedback } from "./client.ts";
+import { fetchRuns, sendFeedback } from "./client.ts";
+import { resetRepoCache } from "./repo.ts";
+
+// Stub /api/repo/tree + /api/repo/blobs with a given tree and sha→content map.
+function stubRepo(tree: unknown, blobs: Record<string, string>) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((url: string) => {
+      if (url === "/api/repo/tree") return Promise.resolve({ ok: true, json: () => Promise.resolve(tree) } as Response);
+      const shas = new URL(url, "http://x").searchParams.get("shas")!.split(",");
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(shas.map((s) => ({ sha: s, content: blobs[s] }))),
+      } as Response);
+    })
+  );
+}
+
+describe("fetchRuns (composed over the shared git-store reader)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    resetRepoCache();
+  });
+
+  const RUNS_TREE = {
+    sha: "h",
+    entries: [
+      { path: "runs/2026-06-29/01RUNAAA.yaml", type: "blob", sha: "a-yaml" },
+      { path: "runs/2026-06-29/01RUNAAA.md", type: "blob", sha: "a-md" },
+      { path: "runs/2026-06-28/01RUNBBB.yaml", type: "blob", sha: "b-yaml" }, // no .md sibling
+      { path: "runs/README.md", type: "blob", sha: "readme" }, // ignored
+      { path: "items/01X.yaml", type: "blob", sha: "item" }, // ignored (not a run)
+    ],
+  };
+  const RUNS_BLOBS: Record<string, string> = {
+    "a-yaml":
+      "run_id: 01RUNAAA\nstarted: '2026-06-29T09:08:00-07:00'\n" +
+      "sources:\n  - {source: gmail, changes_seen: 2}\n  - {source: tana, skipped: 'no egress'}\n",
+    "a-md": "## Run notes\n\nQuiet run.",
+    "b-yaml": "run_id: 01RUNBBB\nstarted: '2026-06-28T08:00:00-07:00'\n", // older; no md
+  };
+
+  it("pairs each run yaml with its sibling md, ignores README/non-runs, sorts newest-first", async () => {
+    stubRepo(RUNS_TREE, RUNS_BLOBS);
+    const { runs } = await fetchRuns();
+    expect(runs.map((r) => r.run_id)).toEqual(["01RUNAAA", "01RUNBBB"]); // newest `started` first
+    expect(runs[0].notes_md).toMatch(/^## Run notes/);
+    expect(runs[0].sources.map((s) => s.source)).toEqual(["gmail", "tana"]);
+    expect("skipped" in runs[0].sources[1]).toBe(true); // discriminated union preserved
+    expect(runs[1].notes_md).toBe(""); // B has no .md sibling
+    expect(runs[1].propagation).toEqual([]); // omitted section → default
+  });
+});
 
 describe("sendFeedback", () => {
   afterEach(() => vi.unstubAllGlobals());

--- a/haku/state_template/ui/frontend/src/client.ts
+++ b/haku/state_template/ui/frontend/src/client.ts
@@ -1,7 +1,7 @@
 import { parse } from "yaml";
 
-import { invalidateTree, repoFile } from "./repo.ts";
-import type { FeedbackContext, MetaResponse, RunsResponse } from "./types.ts";
+import { invalidateTree, readBlobs, repoFile } from "./repo.ts";
+import type { FeedbackContext, MetaResponse, RunManifest, RunsResponse } from "./types.ts";
 
 // Same-origin JSON client: the FastAPI backend serves this bundle and the API.
 // FastAPI error responses are `{detail: string}`; surface that real reason.
@@ -68,11 +68,40 @@ export async function readResponse(scope: string, field: string): Promise<string
   return typeof parsed.value === "string" ? parsed.value : null;
 }
 
-export async function fetchRuns(): Promise<RunsResponse> {
-  const res = await fetch("/api/runs");
-  if (!res.ok) throw new Error(await detail(res, "Failed to load runs"));
-  return (await res.json()) as RunsResponse;
+// Recent per-run propagation manifests, composed over the shared git-store reader (no bespoke
+// /api/runs): pair each `runs/<date>/<ulid>.yaml` with its sibling `.md` prose notes (README.md
+// and dangling `.md` ignored), newest-first by `started`. Missing optional fields default (mirrors
+// the backend RunManifest) so one lean manifest can't crash the table.
+const EMPTY_RUN: Omit<RunManifest, "run_id" | "notes_md"> = {
+  date: "",
+  started: "",
+  finished: "",
+  sources: [],
+  checklists: [],
+  propagation: [],
+};
+
+export async function fetchRuns(limit = 20): Promise<RunsResponse> {
+  const blobs = await readBlobs(
+    (e) =>
+      e.path.startsWith("runs/") &&
+      (e.path.endsWith(".yaml") || (e.path.endsWith(".md") && !e.path.endsWith("/README.md")))
+  );
+  // Pair each runs/<date>/<ulid>.yaml manifest with its sibling .md notes (by shared base path).
+  const yamls = new Map<string, string>(); // base → manifest yaml
+  const notes = new Map<string, string>(); // base → prose notes
+  for (const b of blobs) {
+    if (b.path.endsWith(".yaml")) yamls.set(b.path.slice(0, -".yaml".length), b.content);
+    else notes.set(b.path.slice(0, -".md".length), b.content);
+  }
+  const runs = [...yamls]
+    .map(([base, yamlText]): RunManifest => {
+      const m = (parse(yamlText) ?? {}) as Partial<RunManifest>;
+      return { ...EMPTY_RUN, ...m, run_id: m.run_id ?? base, notes_md: notes.get(base) ?? "" };
+    })
+    .sort((a, b) => b.started.localeCompare(a.started));
+  return { runs: runs.slice(0, limit) };
 }
 
-// Garden browse + file read now compose over the generic content proxy (repo.ts:
-// repoTree/repoFile) — no bespoke garden endpoints.
+// Garden browse + file read compose over the shared git-store reader (repo.ts: readBlobs/repoFile)
+// — no bespoke garden endpoints.

--- a/haku/state_template/ui/frontend/src/errors.ts
+++ b/haku/state_template/ui/frontend/src/errors.ts
@@ -1,0 +1,18 @@
+import { notifications } from "@mantine/notifications";
+
+// How errors reach the operator, by failure kind:
+//   - A *user action* failed (a save, a toggle, a note) → notifyError → a red toast. Non-blocking,
+//     the surface stays put, the operator can retry. The default for mutations.
+//   - A *surface can't load* its content at all → <LoadError> (load_error.tsx), replacing the region.
+//
+// NOTE(later): notifyError is also the choke point to ship errors to the backend for Haku to review
+//   and fix — see memory/improvements/ui-error-telemetry.md.
+
+// Render an unknown thrown value as a readable string (Error message, else String()).
+export const errText = (e: unknown): string => (e instanceof Error ? e.message : String(e));
+
+// Surface a failed user action as a red toast. `title` names the action ("Couldn't save your
+// answer"); the thrown value supplies the detail line.
+export function notifyError(title: string, e: unknown): void {
+  notifications.show({ color: "red", title, message: errText(e), autoClose: 8000 });
+}

--- a/haku/state_template/ui/frontend/src/feedback.tsx
+++ b/haku/state_template/ui/frontend/src/feedback.tsx
@@ -2,15 +2,13 @@ import { Button, Group, Text, Textarea } from "@mantine/core";
 import { type FormEvent, type KeyboardEvent, useState } from "react";
 
 import { sendFeedback } from "./client.ts";
+import { notifyError } from "./errors.ts";
 import type { FeedbackContext } from "./types.ts";
 
 // Submit lifecycle as a closed union so the spinner/disabled states can't be
-// combined into something nonsensical.
-type SubmitState =
-  | { status: "idle" }
-  | { status: "sending" }
-  | { status: "sent" }
-  | { status: "error"; message: string };
+// combined into something nonsensical. Failure surfaces as a toast (notifyError), not a fourth
+// state — the box returns to idle so the operator can retry with their text intact.
+type SubmitState = { status: "idle" } | { status: "sending" } | { status: "sent" };
 
 interface FeedbackFormProps {
   minRows: number;
@@ -40,7 +38,8 @@ export function FeedbackForm({ minRows, placeholder, submitLabel, itemId, contex
         setState({ status: "sent" });
       })
       .catch((e: unknown) => {
-        setState({ status: "error", message: e instanceof Error ? e.message : String(e) });
+        notifyError("Couldn't send your note", e);
+        setState({ status: "idle" });
       });
   }
 
@@ -85,11 +84,6 @@ export function FeedbackForm({ minRows, placeholder, submitLabel, itemId, contex
         <Text size="xs" c="dimmed">
           Shift+Enter for newline
         </Text>
-        {state.status === "error" && (
-          <Text size="xs" c="red">
-            {state.message}
-          </Text>
-        )}
       </Group>
     </form>
   );

--- a/haku/state_template/ui/frontend/src/frontmatter.ts
+++ b/haku/state_template/ui/frontend/src/frontmatter.ts
@@ -1,9 +1,13 @@
 import { parse } from "yaml";
 
+import { logger } from "./log.ts";
+
 // Split a Haku-authored garden doc into its leading `---` YAML front-matter and the markdown
 // body. The front-matter is parsed with a real YAML parser (the `yaml` package) — the same
 // language `validate_state.py` (PyYAML) validates it with, so the two agree. `data` is untyped
 // on purpose (YAML yields anything); callers read the fields they need defensively.
+
+const log = logger("frontmatter");
 
 export interface FrontMatter {
   data: Record<string, unknown>;
@@ -18,9 +22,11 @@ export function parseFrontmatter(text: string): FrontMatter {
   let parsed: unknown;
   try {
     parsed = parse(m[1]);
-  } catch {
-    // Malformed YAML — the validate-state CI gate blocks this from reaching prod; degrade to
-    // empty front-matter so one bad file never blanks the whole board (the widget then skips it).
+  } catch (e) {
+    // Malformed YAML — the validate-state CI gate blocks this from reaching prod; degrade to empty
+    // front-matter so one bad file never blanks the whole board (the widget then skips it), but log
+    // it so a file that slips through is visible rather than silently empty.
+    log.warn("malformed YAML front-matter, treating as empty", e);
     return { data: {}, body: m[2] };
   }
   const data = parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : {};

--- a/haku/state_template/ui/frontend/src/garden.tsx
+++ b/haku/state_template/ui/frontend/src/garden.tsx
@@ -1,6 +1,8 @@
 import { Anchor, Group, NavLink, Stack, Text, Title } from "@mantine/core";
 import { useEffect, useState } from "react";
 
+import { errText } from "./errors.ts";
+import { LoadError } from "./load_error.tsx";
 import { Mdx } from "./mdx.tsx";
 import { repoFile, repoTree } from "./repo.ts";
 
@@ -27,18 +29,13 @@ function FileView({ path, onNavigate }: { path: string; onNavigate: (path: strin
     setError(null);
     repoFile(path)
       .then((md) => alive && (md === null ? setError("not found") : setMarkdown(md)))
-      .catch((e: unknown) => alive && setError(e instanceof Error ? e.message : String(e)));
+      .catch((e: unknown) => alive && setError(errText(e)));
     return () => {
       alive = false;
     };
   }, [path]);
 
-  if (error)
-    return (
-      <Text c="red">
-        Failed to load {path}: {error}
-      </Text>
-    );
+  if (error) return <LoadError what={path} error={error} />;
   if (markdown === null) return <Text c="dimmed">Loading…</Text>;
   return <Mdx source={markdown} basePath={path} onNavigate={onNavigate} />;
 }
@@ -61,7 +58,7 @@ export function GardenPage({ path, onSelect }: { path: string | null; onSelect: 
             .sort()
         )
       )
-      .catch((e: unknown) => setError(e instanceof Error ? e.message : String(e)));
+      .catch((e: unknown) => setError(errText(e)));
   }, []);
 
   // A selected file renders independently of the index (so a deep-link works before it loads).
@@ -80,7 +77,7 @@ export function GardenPage({ path, onSelect }: { path: string | null; onSelect: 
       </Stack>
     );
 
-  if (error) return <Text c="red">Failed to load garden: {error}</Text>;
+  if (error) return <LoadError what="the garden" error={error} />;
   if (!paths) return <Text c="dimmed">Loading…</Text>;
   if (paths.length === 0) return <Text c="dimmed">The garden is empty.</Text>;
 

--- a/haku/state_template/ui/frontend/src/git_progress.test.ts
+++ b/haku/state_template/ui/frontend/src/git_progress.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { getGitProgress, trackGit } from "./git_progress.ts";
+import { gitProgress } from "./git_progress.ts";
 
 // A resolvable/rejectable promise so a test can hold an op "in flight", inspect the store, then
 // drain it deterministically.
@@ -23,58 +23,58 @@ afterEach(() => vi.useRealTimers());
 describe("git progress tracker", () => {
   it("counts one op in flight, holds through the settle window, then goes idle", async () => {
     const d = deferred<void>();
-    const op = trackGit(3, () => d.promise);
+    const op = gitProgress.track(3, () => d.promise);
     // While in flight: one op active, three objects requested, nothing done yet.
-    expect(getGitProgress()).toEqual({ activeOps: 1, doneOps: 0, totalObjects: 3, doneObjects: 0 });
+    expect(gitProgress.get()).toEqual({ activeOps: 1, doneOps: 0, totalObjects: 3, doneObjects: 0 });
     d.resolve();
     await op;
     // Drained but still within the settle window: op + objects counted done, 100%.
-    expect(getGitProgress()).toEqual({ activeOps: 0, doneOps: 1, totalObjects: 3, doneObjects: 3 });
+    expect(gitProgress.get()).toEqual({ activeOps: 0, doneOps: 1, totalObjects: 3, doneObjects: 3 });
     await vi.advanceTimersByTimeAsync(200);
-    expect(getGitProgress()).toEqual(IDLE);
+    expect(gitProgress.get()).toEqual(IDLE);
   });
 
   it("accumulates concurrent ops and advances done-counts as each resolves", async () => {
     const a = deferred<void>();
     const b = deferred<void>();
-    const opA = trackGit(1, () => a.promise);
-    const opB = trackGit(8, () => b.promise);
+    const opA = gitProgress.track(1, () => a.promise);
+    const opB = gitProgress.track(8, () => b.promise);
     // Two ops active, 9 objects requested across them.
-    expect(getGitProgress()).toEqual({ activeOps: 2, doneOps: 0, totalObjects: 9, doneObjects: 0 });
+    expect(gitProgress.get()).toEqual({ activeOps: 2, doneOps: 0, totalObjects: 9, doneObjects: 0 });
     a.resolve();
     await opA;
     // One op left; the finished op + its object count as done, the burst totals unchanged.
-    expect(getGitProgress()).toEqual({ activeOps: 1, doneOps: 1, totalObjects: 9, doneObjects: 1 });
+    expect(gitProgress.get()).toEqual({ activeOps: 1, doneOps: 1, totalObjects: 9, doneObjects: 1 });
     b.resolve();
     await opB;
     await vi.advanceTimersByTimeAsync(200);
-    expect(getGitProgress()).toEqual(IDLE);
+    expect(gitProgress.get()).toEqual(IDLE);
   });
 
   it("coalesces back-to-back reads into one burst (the settle is cancelled by new activity)", async () => {
     const a = deferred<void>();
-    const opA = trackGit(1, () => a.promise); // e.g. the tree read
+    const opA = gitProgress.track(1, () => a.promise); // e.g. the tree read
     a.resolve();
     await opA;
     // Settle is now pending at 1 op / 1 object. A second read starting before it fires extends it.
     const b = deferred<void>();
-    const opB = trackGit(50, () => b.promise); // e.g. the first blob chunk
-    expect(getGitProgress()).toEqual({ activeOps: 1, doneOps: 1, totalObjects: 51, doneObjects: 1 });
+    const opB = gitProgress.track(50, () => b.promise); // e.g. the first blob chunk
+    expect(gitProgress.get()).toEqual({ activeOps: 1, doneOps: 1, totalObjects: 51, doneObjects: 1 });
     b.resolve();
     await opB;
-    expect(getGitProgress()).toEqual({ activeOps: 0, doneOps: 2, totalObjects: 51, doneObjects: 51 });
+    expect(gitProgress.get()).toEqual({ activeOps: 0, doneOps: 2, totalObjects: 51, doneObjects: 51 });
     await vi.advanceTimersByTimeAsync(200);
-    expect(getGitProgress()).toEqual(IDLE);
+    expect(gitProgress.get()).toEqual(IDLE);
   });
 
   it("drains the indicator even when the op throws", async () => {
     const d = deferred<void>();
-    const op = trackGit(2, () => d.promise);
-    expect(getGitProgress().activeOps).toBe(1);
+    const op = gitProgress.track(2, () => d.promise);
+    expect(gitProgress.get().activeOps).toBe(1);
     d.reject(new Error("boom"));
     await expect(op).rejects.toThrow("boom");
-    expect(getGitProgress()).toEqual({ activeOps: 0, doneOps: 1, totalObjects: 2, doneObjects: 2 });
+    expect(gitProgress.get()).toEqual({ activeOps: 0, doneOps: 1, totalObjects: 2, doneObjects: 2 });
     await vi.advanceTimersByTimeAsync(200);
-    expect(getGitProgress()).toEqual(IDLE);
+    expect(gitProgress.get()).toEqual(IDLE);
   });
 });

--- a/haku/state_template/ui/frontend/src/git_progress.test.ts
+++ b/haku/state_template/ui/frontend/src/git_progress.test.ts
@@ -14,39 +14,41 @@ function deferred<T>() {
   return { promise, resolve, reject };
 }
 
+const IDLE = { activeOps: 0, doneOps: 0, totalObjects: 0, doneObjects: 0 };
+
 // Fake timers so the burst's settle window is advanced explicitly rather than waited on.
 beforeEach(() => vi.useFakeTimers());
 afterEach(() => vi.useRealTimers());
 
 describe("git progress tracker", () => {
-  it("counts a single op in flight, holds 100% through the settle window, then goes idle", async () => {
+  it("counts one op in flight, holds through the settle window, then goes idle", async () => {
     const d = deferred<void>();
     const op = trackGit(3, () => d.promise);
-    // While in flight: one op, three objects requested, none done yet.
-    expect(getGitProgress()).toEqual({ inFlight: 1, total: 3, done: 0 });
+    // While in flight: one op active, three objects requested, nothing done yet.
+    expect(getGitProgress()).toEqual({ activeOps: 1, doneOps: 0, totalObjects: 3, doneObjects: 0 });
     d.resolve();
     await op;
-    // Drained but still within the settle window: 100%, not yet reset.
-    expect(getGitProgress()).toEqual({ inFlight: 0, total: 3, done: 3 });
+    // Drained but still within the settle window: op + objects counted done, 100%.
+    expect(getGitProgress()).toEqual({ activeOps: 0, doneOps: 1, totalObjects: 3, doneObjects: 3 });
     await vi.advanceTimersByTimeAsync(200);
-    expect(getGitProgress()).toEqual({ inFlight: 0, total: 0, done: 0 });
+    expect(getGitProgress()).toEqual(IDLE);
   });
 
-  it("accumulates concurrent ops and advances `done` as each resolves", async () => {
+  it("accumulates concurrent ops and advances done-counts as each resolves", async () => {
     const a = deferred<void>();
     const b = deferred<void>();
     const opA = trackGit(1, () => a.promise);
     const opB = trackGit(8, () => b.promise);
-    // Both in flight: 9 objects requested across two ops.
-    expect(getGitProgress()).toEqual({ inFlight: 2, total: 9, done: 0 });
+    // Two ops active, 9 objects requested across them.
+    expect(getGitProgress()).toEqual({ activeOps: 2, doneOps: 0, totalObjects: 9, doneObjects: 0 });
     a.resolve();
     await opA;
-    // One op left; the finished op's object counts toward `done`, the burst total unchanged.
-    expect(getGitProgress()).toEqual({ inFlight: 1, total: 9, done: 1 });
+    // One op left; the finished op + its object count as done, the burst totals unchanged.
+    expect(getGitProgress()).toEqual({ activeOps: 1, doneOps: 1, totalObjects: 9, doneObjects: 1 });
     b.resolve();
     await opB;
     await vi.advanceTimersByTimeAsync(200);
-    expect(getGitProgress()).toEqual({ inFlight: 0, total: 0, done: 0 });
+    expect(getGitProgress()).toEqual(IDLE);
   });
 
   it("coalesces back-to-back reads into one burst (the settle is cancelled by new activity)", async () => {
@@ -54,25 +56,25 @@ describe("git progress tracker", () => {
     const opA = trackGit(1, () => a.promise); // e.g. the tree read
     a.resolve();
     await opA;
-    // Settle is now pending at 1/1. A second read starting before it fires extends the same burst.
+    // Settle is now pending at 1 op / 1 object. A second read starting before it fires extends it.
     const b = deferred<void>();
     const opB = trackGit(50, () => b.promise); // e.g. the first blob chunk
-    expect(getGitProgress()).toEqual({ inFlight: 1, total: 51, done: 1 });
+    expect(getGitProgress()).toEqual({ activeOps: 1, doneOps: 1, totalObjects: 51, doneObjects: 1 });
     b.resolve();
     await opB;
-    expect(getGitProgress()).toEqual({ inFlight: 0, total: 51, done: 51 });
+    expect(getGitProgress()).toEqual({ activeOps: 0, doneOps: 2, totalObjects: 51, doneObjects: 51 });
     await vi.advanceTimersByTimeAsync(200);
-    expect(getGitProgress()).toEqual({ inFlight: 0, total: 0, done: 0 });
+    expect(getGitProgress()).toEqual(IDLE);
   });
 
   it("drains the indicator even when the op throws", async () => {
     const d = deferred<void>();
     const op = trackGit(2, () => d.promise);
-    expect(getGitProgress().inFlight).toBe(1);
+    expect(getGitProgress().activeOps).toBe(1);
     d.reject(new Error("boom"));
     await expect(op).rejects.toThrow("boom");
-    expect(getGitProgress()).toEqual({ inFlight: 0, total: 2, done: 2 });
+    expect(getGitProgress()).toEqual({ activeOps: 0, doneOps: 1, totalObjects: 2, doneObjects: 2 });
     await vi.advanceTimersByTimeAsync(200);
-    expect(getGitProgress()).toEqual({ inFlight: 0, total: 0, done: 0 });
+    expect(getGitProgress()).toEqual(IDLE);
   });
 });

--- a/haku/state_template/ui/frontend/src/git_progress.test.ts
+++ b/haku/state_template/ui/frontend/src/git_progress.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { getGitProgress, trackGit } from "./git_progress.ts";
+
+// A resolvable/rejectable promise so a test can hold an op "in flight", inspect the store, then
+// drain it deterministically.
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("git progress tracker", () => {
+  it("counts a single op in flight, then drains to idle on completion", async () => {
+    const d = deferred<void>();
+    const op = trackGit(3, () => d.promise);
+    // While in flight: one op, three objects requested, none done yet.
+    expect(getGitProgress()).toEqual({ inFlight: 1, total: 3, done: 0 });
+    d.resolve();
+    await op;
+    // Burst emptied → back to idle.
+    expect(getGitProgress()).toEqual({ inFlight: 0, total: 0, done: 0 });
+  });
+
+  it("accumulates concurrent ops and advances `done` as each resolves", async () => {
+    const a = deferred<void>();
+    const b = deferred<void>();
+    const opA = trackGit(1, () => a.promise);
+    const opB = trackGit(8, () => b.promise);
+    // Both in flight: 9 objects requested across two ops.
+    expect(getGitProgress()).toEqual({ inFlight: 2, total: 9, done: 0 });
+    a.resolve();
+    await opA;
+    // One op left; the finished op's object counts toward `done`, the burst total unchanged.
+    expect(getGitProgress()).toEqual({ inFlight: 1, total: 9, done: 1 });
+    b.resolve();
+    await opB;
+    expect(getGitProgress()).toEqual({ inFlight: 0, total: 0, done: 0 });
+  });
+
+  it("drains the indicator even when the op throws", async () => {
+    const d = deferred<void>();
+    const op = trackGit(2, () => d.promise);
+    expect(getGitProgress().inFlight).toBe(1);
+    d.reject(new Error("boom"));
+    await expect(op).rejects.toThrow("boom");
+    expect(getGitProgress()).toEqual({ inFlight: 0, total: 0, done: 0 });
+  });
+});

--- a/haku/state_template/ui/frontend/src/git_progress.test.ts
+++ b/haku/state_template/ui/frontend/src/git_progress.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getGitProgress, trackGit } from "./git_progress.ts";
 
@@ -14,15 +14,21 @@ function deferred<T>() {
   return { promise, resolve, reject };
 }
 
+// Fake timers so the burst's settle window is advanced explicitly rather than waited on.
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
 describe("git progress tracker", () => {
-  it("counts a single op in flight, then drains to idle on completion", async () => {
+  it("counts a single op in flight, holds 100% through the settle window, then goes idle", async () => {
     const d = deferred<void>();
     const op = trackGit(3, () => d.promise);
     // While in flight: one op, three objects requested, none done yet.
     expect(getGitProgress()).toEqual({ inFlight: 1, total: 3, done: 0 });
     d.resolve();
     await op;
-    // Burst emptied → back to idle.
+    // Drained but still within the settle window: 100%, not yet reset.
+    expect(getGitProgress()).toEqual({ inFlight: 0, total: 3, done: 3 });
+    await vi.advanceTimersByTimeAsync(200);
     expect(getGitProgress()).toEqual({ inFlight: 0, total: 0, done: 0 });
   });
 
@@ -39,6 +45,23 @@ describe("git progress tracker", () => {
     expect(getGitProgress()).toEqual({ inFlight: 1, total: 9, done: 1 });
     b.resolve();
     await opB;
+    await vi.advanceTimersByTimeAsync(200);
+    expect(getGitProgress()).toEqual({ inFlight: 0, total: 0, done: 0 });
+  });
+
+  it("coalesces back-to-back reads into one burst (the settle is cancelled by new activity)", async () => {
+    const a = deferred<void>();
+    const opA = trackGit(1, () => a.promise); // e.g. the tree read
+    a.resolve();
+    await opA;
+    // Settle is now pending at 1/1. A second read starting before it fires extends the same burst.
+    const b = deferred<void>();
+    const opB = trackGit(50, () => b.promise); // e.g. the first blob chunk
+    expect(getGitProgress()).toEqual({ inFlight: 1, total: 51, done: 1 });
+    b.resolve();
+    await opB;
+    expect(getGitProgress()).toEqual({ inFlight: 0, total: 51, done: 51 });
+    await vi.advanceTimersByTimeAsync(200);
     expect(getGitProgress()).toEqual({ inFlight: 0, total: 0, done: 0 });
   });
 
@@ -48,6 +71,8 @@ describe("git progress tracker", () => {
     expect(getGitProgress().inFlight).toBe(1);
     d.reject(new Error("boom"));
     await expect(op).rejects.toThrow("boom");
+    expect(getGitProgress()).toEqual({ inFlight: 0, total: 2, done: 2 });
+    await vi.advanceTimersByTimeAsync(200);
     expect(getGitProgress()).toEqual({ inFlight: 0, total: 0, done: 0 });
   });
 });

--- a/haku/state_template/ui/frontend/src/git_progress.ts
+++ b/haku/state_template/ui/frontend/src/git_progress.ts
@@ -1,20 +1,22 @@
-// Central progress tracker for the repo's git primitives (repo.ts). Every tree/blob read registers
-// here, so one global indicator can mirror git's own object-transfer progress ("Fetching objects:
-// n/m") across the whole app — instead of each view spinning its own local bar. The two git
-// primitives (recursive tree, bulk blobs) are the only content I/O the UI does, and every surface
-// composes over them (items, garden, improvements, kitchen, runs, responses), so wrapping them
-// captures all of it at one choke point.
-//
-// A *burst* is a run of activity. Two things accumulate over it: the operation count (each
-// trackGit call — a tree read or one ≤50-blob chunk — is one operation) and the git-object count
-// (a tree is one object; a bulk-blob read is one per sha). The bar fills doneObjects/totalObjects
-// and the summary reports operations in-flight vs done. When the last op finishes the burst doesn't
-// reset instantly — it lingers for SETTLE_MS. A `docsUnder` read fires its tree then several blob
-// chunks back-to-back with only synchronous gaps between them, so the settle window keeps them in
-// ONE burst: the bar fills smoothly instead of restarting per chunk. Counters are plain module
-// state mutated synchronously in start/finally, consistent under JS's single thread.
-
 import { useSyncExternalStore } from "react";
+
+// Progress across the repo's git primitives (repo.ts). Every tree/blob read runs through
+// `gitProgress.track`, so one global indicator can mirror git's own object-transfer progress
+// ("Fetching objects: n/m") across the whole app instead of each view spinning its own bar.
+//
+// Why a module-level singleton (not React state/context): the git primitives are plain async
+// functions, not components, so they can't reach a Context — yet both they (writing progress) and
+// the bar (reading it) need one shared source. That's exactly a `useSyncExternalStore` store, and
+// it matches repo.ts's own module-singleton caches. `createStore` keeps the mutable pieces — the
+// snapshot, the settle timer, the listeners — private to the one instance rather than loose
+// module-level bindings.
+//
+// A *burst* is a run of activity: operation counts (each `track` call — a tree read or one ≤50-blob
+// chunk) and git-object counts (a tree is 1, a bulk read is one per sha) accumulate over it. When
+// the last op finishes the burst lingers for SETTLE_MS: a `docsUnder` read fires its tree then
+// several blob chunks with only synchronous gaps between them, so the window keeps them in ONE
+// burst and the bar fills smoothly instead of restarting per chunk. Counters mutate synchronously
+// in start/finally, consistent under JS's single thread.
 
 export interface GitProgress {
   activeOps: number; // tree/blob fetches currently in flight
@@ -26,57 +28,59 @@ export interface GitProgress {
 const IDLE: GitProgress = { activeOps: 0, doneOps: 0, totalObjects: 0, doneObjects: 0 };
 const SETTLE_MS = 150;
 
-let state: GitProgress = IDLE;
-let settleTimer: ReturnType<typeof setTimeout> | null = null;
-const listeners = new Set<() => void>();
+function createStore() {
+  let state: GitProgress = IDLE;
+  let settleTimer: ReturnType<typeof setTimeout> | null = null;
+  const listeners = new Set<() => void>();
 
-function set(next: GitProgress): void {
-  state = next;
-  for (const notify of listeners) notify();
-}
+  const emit = (next: GitProgress): void => {
+    state = next;
+    for (const notify of listeners) notify();
+  };
 
-function subscribe(listener: () => void): () => void {
-  listeners.add(listener);
-  return () => {
-    listeners.delete(listener);
+  return {
+    // Live snapshot — referentially stable between emits, as useSyncExternalStore requires.
+    get: (): GitProgress => state,
+
+    subscribe(listener: () => void): () => void {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+
+    // Run a git primitive, accounting for its `objects` git objects in the shared burst. The
+    // finally drains whether `run` resolves or throws, then schedules the settle once idle.
+    async track<T>(objects: number, run: () => Promise<T>): Promise<T> {
+      if (settleTimer !== null) {
+        clearTimeout(settleTimer); // new activity extends the burst — cancel the pending settle
+        settleTimer = null;
+      }
+      emit({ ...state, activeOps: state.activeOps + 1, totalObjects: state.totalObjects + objects });
+      try {
+        return await run();
+      } finally {
+        const activeOps = state.activeOps - 1;
+        emit({
+          activeOps,
+          doneOps: state.doneOps + 1,
+          totalObjects: state.totalObjects,
+          doneObjects: state.doneObjects + objects,
+        });
+        if (activeOps === 0) {
+          settleTimer = setTimeout(() => {
+            settleTimer = null;
+            if (state.activeOps === 0) emit(IDLE); // still idle after the window → end the burst
+          }, SETTLE_MS);
+        }
+      }
+    },
   };
 }
 
-// Live snapshot — the store's single source of truth. `useGitProgress` reads it through React;
-// tests read it directly. Referentially stable between `set`s, as useSyncExternalStore requires.
-export function getGitProgress(): GitProgress {
-  return state;
-}
-
-// Run a git primitive while accounting for its `objects` git objects in the shared burst. The
-// finally drains whether `run` resolves or throws — the indicator must clear on error too — and
-// when the last op finishes, schedules the settle that ends the burst.
-export async function trackGit<T>(objects: number, run: () => Promise<T>): Promise<T> {
-  // New activity extends the burst — cancel any pending settle so back-to-back reads stay merged.
-  if (settleTimer !== null) {
-    clearTimeout(settleTimer);
-    settleTimer = null;
-  }
-  set({ ...state, activeOps: state.activeOps + 1, totalObjects: state.totalObjects + objects });
-  try {
-    return await run();
-  } finally {
-    const activeOps = state.activeOps - 1;
-    set({
-      activeOps,
-      doneOps: state.doneOps + 1,
-      totalObjects: state.totalObjects,
-      doneObjects: state.doneObjects + objects,
-    });
-    if (activeOps === 0) {
-      settleTimer = setTimeout(() => {
-        settleTimer = null;
-        if (state.activeOps === 0) set(IDLE); // still idle after the window → end the burst
-      }, SETTLE_MS);
-    }
-  }
-}
+// One app-wide instance: there's one git read layer and one indicator.
+export const gitProgress = createStore();
 
 export function useGitProgress(): GitProgress {
-  return useSyncExternalStore(subscribe, getGitProgress);
+  return useSyncExternalStore(gitProgress.subscribe, gitProgress.get);
 }

--- a/haku/state_template/ui/frontend/src/git_progress.ts
+++ b/haku/state_template/ui/frontend/src/git_progress.ts
@@ -1,26 +1,29 @@
 // Central progress tracker for the repo's git primitives (repo.ts). Every tree/blob read registers
 // here, so one global indicator can mirror git's own object-transfer progress ("Fetching objects:
 // n/m") across the whole app — instead of each view spinning its own local bar. The two git
-// primitives (recursive tree, bulk blobs) are the only I/O the UI does, so wrapping them captures
-// all of it — item reads, garden files, improvements, responses, kitchen — at one choke point.
+// primitives (recursive tree, bulk blobs) are the only content I/O the UI does, and every surface
+// composes over them (items, garden, improvements, kitchen, runs, responses), so wrapping them
+// captures all of it at one choke point.
 //
-// A *burst* is a run of activity: its object counts accumulate (a tree is one object; a bulk-blob
-// read is one per sha) and the bar climbs done/total as each fetch resolves. When the last fetch
-// completes the burst doesn't reset instantly — it lingers for SETTLE_MS. A `docsUnder` read fires
-// its tree then several ≤50-blob chunks back-to-back with only synchronous gaps between them, so
-// the settle window keeps them in ONE burst: the bar fills smoothly to 100% instead of sawtoothing
-// per chunk. If nothing new starts, the settle fires and clears the bar. Counters are plain module
+// A *burst* is a run of activity. Two things accumulate over it: the operation count (each
+// trackGit call — a tree read or one ≤50-blob chunk — is one operation) and the git-object count
+// (a tree is one object; a bulk-blob read is one per sha). The bar fills doneObjects/totalObjects
+// and the summary reports operations in-flight vs done. When the last op finishes the burst doesn't
+// reset instantly — it lingers for SETTLE_MS. A `docsUnder` read fires its tree then several blob
+// chunks back-to-back with only synchronous gaps between them, so the settle window keeps them in
+// ONE burst: the bar fills smoothly instead of restarting per chunk. Counters are plain module
 // state mutated synchronously in start/finally, consistent under JS's single thread.
 
 import { useSyncExternalStore } from "react";
 
 export interface GitProgress {
-  inFlight: number; // active tree/blob fetches
-  total: number; // git objects requested in the current burst
-  done: number; // objects whose fetch has resolved (or errored out)
+  activeOps: number; // tree/blob fetches currently in flight
+  doneOps: number; // fetches completed this burst
+  totalObjects: number; // git objects requested this burst (tree = 1, blobs = one per sha)
+  doneObjects: number; // git objects whose fetch has resolved (or errored out)
 }
 
-const IDLE: GitProgress = { inFlight: 0, total: 0, done: 0 };
+const IDLE: GitProgress = { activeOps: 0, doneOps: 0, totalObjects: 0, doneObjects: 0 };
 const SETTLE_MS = 150;
 
 let state: GitProgress = IDLE;
@@ -54,16 +57,21 @@ export async function trackGit<T>(objects: number, run: () => Promise<T>): Promi
     clearTimeout(settleTimer);
     settleTimer = null;
   }
-  set({ inFlight: state.inFlight + 1, total: state.total + objects, done: state.done });
+  set({ ...state, activeOps: state.activeOps + 1, totalObjects: state.totalObjects + objects });
   try {
     return await run();
   } finally {
-    const inFlight = state.inFlight - 1;
-    set({ inFlight, total: state.total, done: state.done + objects });
-    if (inFlight === 0) {
+    const activeOps = state.activeOps - 1;
+    set({
+      activeOps,
+      doneOps: state.doneOps + 1,
+      totalObjects: state.totalObjects,
+      doneObjects: state.doneObjects + objects,
+    });
+    if (activeOps === 0) {
       settleTimer = setTimeout(() => {
         settleTimer = null;
-        if (state.inFlight === 0) set(IDLE); // still idle after the window → end the burst
+        if (state.activeOps === 0) set(IDLE); // still idle after the window → end the burst
       }, SETTLE_MS);
     }
   }

--- a/haku/state_template/ui/frontend/src/git_progress.ts
+++ b/haku/state_template/ui/frontend/src/git_progress.ts
@@ -1,15 +1,16 @@
-// Central progress tracker for the repo's git primitives (repo.ts). Every tree/blob read
-// registers here, so a single global indicator can mirror git's own object-transfer progress
-// ("Fetching objects: n/m") across the whole app — instead of each view spinning its own local
-// "Loading…". The two git primitives (recursive tree, bulk blobs) are the only I/O the UI does,
-// so wrapping them captures all of it — item reads, garden files, improvements, responses — at
-// one choke point.
+// Central progress tracker for the repo's git primitives (repo.ts). Every tree/blob read registers
+// here, so one global indicator can mirror git's own object-transfer progress ("Fetching objects:
+// n/m") across the whole app — instead of each view spinning its own local bar. The two git
+// primitives (recursive tree, bulk blobs) are the only I/O the UI does, so wrapping them captures
+// all of it — item reads, garden files, improvements, responses, kitchen — at one choke point.
 //
-// A *burst* is the window from the first in-flight fetch to the moment the last one drains. Its
-// object counts (a tree is one object; a bulk-blob read is one per sha) accumulate while anything
-// is in flight and reset to zero once the burst empties, so the next activity starts a fresh
-// 0→100%. Counters are plain module state mutated synchronously in start/finally, so overlapping
-// bursts (several widgets mounting at once) stay consistent under JS's single thread.
+// A *burst* is a run of activity: its object counts accumulate (a tree is one object; a bulk-blob
+// read is one per sha) and the bar climbs done/total as each fetch resolves. When the last fetch
+// completes the burst doesn't reset instantly — it lingers for SETTLE_MS. A `docsUnder` read fires
+// its tree then several ≤50-blob chunks back-to-back with only synchronous gaps between them, so
+// the settle window keeps them in ONE burst: the bar fills smoothly to 100% instead of sawtoothing
+// per chunk. If nothing new starts, the settle fires and clears the bar. Counters are plain module
+// state mutated synchronously in start/finally, consistent under JS's single thread.
 
 import { useSyncExternalStore } from "react";
 
@@ -20,8 +21,10 @@ export interface GitProgress {
 }
 
 const IDLE: GitProgress = { inFlight: 0, total: 0, done: 0 };
+const SETTLE_MS = 150;
 
 let state: GitProgress = IDLE;
+let settleTimer: ReturnType<typeof setTimeout> | null = null;
 const listeners = new Set<() => void>();
 
 function set(next: GitProgress): void {
@@ -44,14 +47,25 @@ export function getGitProgress(): GitProgress {
 
 // Run a git primitive while accounting for its `objects` git objects in the shared burst. The
 // finally drains whether `run` resolves or throws — the indicator must clear on error too — and
-// snaps the whole burst back to IDLE when it empties.
+// when the last op finishes, schedules the settle that ends the burst.
 export async function trackGit<T>(objects: number, run: () => Promise<T>): Promise<T> {
+  // New activity extends the burst — cancel any pending settle so back-to-back reads stay merged.
+  if (settleTimer !== null) {
+    clearTimeout(settleTimer);
+    settleTimer = null;
+  }
   set({ inFlight: state.inFlight + 1, total: state.total + objects, done: state.done });
   try {
     return await run();
   } finally {
     const inFlight = state.inFlight - 1;
-    set(inFlight === 0 ? IDLE : { inFlight, total: state.total, done: state.done + objects });
+    set({ inFlight, total: state.total, done: state.done + objects });
+    if (inFlight === 0) {
+      settleTimer = setTimeout(() => {
+        settleTimer = null;
+        if (state.inFlight === 0) set(IDLE); // still idle after the window → end the burst
+      }, SETTLE_MS);
+    }
   }
 }
 

--- a/haku/state_template/ui/frontend/src/git_progress.ts
+++ b/haku/state_template/ui/frontend/src/git_progress.ts
@@ -1,0 +1,60 @@
+// Central progress tracker for the repo's git primitives (repo.ts). Every tree/blob read
+// registers here, so a single global indicator can mirror git's own object-transfer progress
+// ("Fetching objects: n/m") across the whole app — instead of each view spinning its own local
+// "Loading…". The two git primitives (recursive tree, bulk blobs) are the only I/O the UI does,
+// so wrapping them captures all of it — item reads, garden files, improvements, responses — at
+// one choke point.
+//
+// A *burst* is the window from the first in-flight fetch to the moment the last one drains. Its
+// object counts (a tree is one object; a bulk-blob read is one per sha) accumulate while anything
+// is in flight and reset to zero once the burst empties, so the next activity starts a fresh
+// 0→100%. Counters are plain module state mutated synchronously in start/finally, so overlapping
+// bursts (several widgets mounting at once) stay consistent under JS's single thread.
+
+import { useSyncExternalStore } from "react";
+
+export interface GitProgress {
+  inFlight: number; // active tree/blob fetches
+  total: number; // git objects requested in the current burst
+  done: number; // objects whose fetch has resolved (or errored out)
+}
+
+const IDLE: GitProgress = { inFlight: 0, total: 0, done: 0 };
+
+let state: GitProgress = IDLE;
+const listeners = new Set<() => void>();
+
+function set(next: GitProgress): void {
+  state = next;
+  for (const notify of listeners) notify();
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+// Live snapshot — the store's single source of truth. `useGitProgress` reads it through React;
+// tests read it directly. Referentially stable between `set`s, as useSyncExternalStore requires.
+export function getGitProgress(): GitProgress {
+  return state;
+}
+
+// Run a git primitive while accounting for its `objects` git objects in the shared burst. The
+// finally drains whether `run` resolves or throws — the indicator must clear on error too — and
+// snaps the whole burst back to IDLE when it empties.
+export async function trackGit<T>(objects: number, run: () => Promise<T>): Promise<T> {
+  set({ inFlight: state.inFlight + 1, total: state.total + objects, done: state.done });
+  try {
+    return await run();
+  } finally {
+    const inFlight = state.inFlight - 1;
+    set(inFlight === 0 ? IDLE : { inFlight, total: state.total, done: state.done + objects });
+  }
+}
+
+export function useGitProgress(): GitProgress {
+  return useSyncExternalStore(subscribe, getGitProgress);
+}

--- a/haku/state_template/ui/frontend/src/git_progress_bar.test.tsx
+++ b/haku/state_template/ui/frontend/src/git_progress_bar.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { MantineProvider } from "@mantine/core";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { trackGit } from "./git_progress.ts";
+import { GitProgressBar } from "./git_progress_bar.tsx";
+
+window.matchMedia ??= ((query: string) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addListener: () => {},
+  removeListener: () => {},
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  dispatchEvent: () => false,
+})) as typeof window.matchMedia;
+
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+afterEach(cleanup);
+
+describe("GitProgressBar", () => {
+  it("shows a bar only while a git read is in flight, then hides when the burst drains", async () => {
+    render(
+      <MantineProvider>
+        <GitProgressBar />
+      </MantineProvider>
+    );
+    // Idle → renders nothing.
+    expect(screen.queryByRole("progressbar")).toBeNull();
+
+    const d = deferred<void>();
+    let op!: Promise<void>;
+    act(() => {
+      op = trackGit(2, () => d.promise);
+    });
+    // In flight → the bar appears, labelled with the object counts.
+    expect(screen.getByRole("progressbar")).toBeTruthy();
+    expect(screen.getByLabelText(/Fetching repository content: 0\/2 objects/)).toBeTruthy();
+
+    await act(async () => {
+      d.resolve();
+      await op;
+    });
+    // Drained → hidden again.
+    expect(screen.queryByRole("progressbar")).toBeNull();
+  });
+});

--- a/haku/state_template/ui/frontend/src/git_progress_bar.test.tsx
+++ b/haku/state_template/ui/frontend/src/git_progress_bar.test.tsx
@@ -32,7 +32,7 @@ afterEach(() => {
 });
 
 describe("GitProgressBar", () => {
-  it("shows a bar while a git read is in flight, then hides once the burst settles", async () => {
+  it("shows the bar + ops summary while reads are in flight, then hides once the burst settles", async () => {
     render(
       <MantineProvider>
         <GitProgressBar />
@@ -41,21 +41,31 @@ describe("GitProgressBar", () => {
     // Idle → renders nothing.
     expect(screen.queryByRole("progressbar")).toBeNull();
 
-    const d = deferred<void>();
-    let op!: Promise<void>;
+    const a = deferred<void>();
+    const b = deferred<void>();
+    let opA!: Promise<void>;
+    let opB!: Promise<void>;
     act(() => {
-      op = trackGit(2, () => d.promise);
+      opA = trackGit(1, () => a.promise); // tree
+      opB = trackGit(8, () => b.promise); // a blob chunk
     });
-    // In flight → the bar appears, labelled with the object counts.
+    // In flight → the bar appears with the ops + objects summary.
     expect(screen.getByRole("progressbar")).toBeTruthy();
-    expect(screen.getByLabelText(/Fetching repository content: 0\/2 objects/)).toBeTruthy();
+    expect(screen.getByText(/2 in progress · 0 done · 0\/9 objects/)).toBeTruthy();
 
     await act(async () => {
-      d.resolve();
-      await op;
+      a.resolve();
+      await opA;
     });
-    // Drained but settling → still shown at 100%.
-    expect(screen.getByLabelText(/Fetching repository content: 2\/2 objects/)).toBeTruthy();
+    // One op done, one still going.
+    expect(screen.getByText(/1 in progress · 1 done · 1\/9 objects/)).toBeTruthy();
+
+    await act(async () => {
+      b.resolve();
+      await opB;
+    });
+    // Drained but settling → shown at completion.
+    expect(screen.getByText(/0 in progress · 2 done · 9\/9 objects/)).toBeTruthy();
 
     // Settle window elapses → hidden again.
     await act(async () => {

--- a/haku/state_template/ui/frontend/src/git_progress_bar.test.tsx
+++ b/haku/state_template/ui/frontend/src/git_progress_bar.test.tsx
@@ -3,7 +3,7 @@ import { MantineProvider } from "@mantine/core";
 import { act, cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { trackGit } from "./git_progress.ts";
+import { gitProgress } from "./git_progress.ts";
 import { GitProgressBar } from "./git_progress_bar.tsx";
 
 window.matchMedia ??= ((query: string) => ({
@@ -46,8 +46,8 @@ describe("GitProgressBar", () => {
     let opA!: Promise<void>;
     let opB!: Promise<void>;
     act(() => {
-      opA = trackGit(1, () => a.promise); // tree
-      opB = trackGit(8, () => b.promise); // a blob chunk
+      opA = gitProgress.track(1, () => a.promise); // tree
+      opB = gitProgress.track(8, () => b.promise); // a blob chunk
     });
     // In flight → the bar appears with the ops + objects summary.
     expect(screen.getByRole("progressbar")).toBeTruthy();

--- a/haku/state_template/ui/frontend/src/git_progress_bar.test.tsx
+++ b/haku/state_template/ui/frontend/src/git_progress_bar.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { MantineProvider } from "@mantine/core";
 import { act, cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { trackGit } from "./git_progress.ts";
 import { GitProgressBar } from "./git_progress_bar.tsx";
@@ -25,10 +25,14 @@ function deferred<T>() {
   return { promise, resolve };
 }
 
-afterEach(cleanup);
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
 
 describe("GitProgressBar", () => {
-  it("shows a bar only while a git read is in flight, then hides when the burst drains", async () => {
+  it("shows a bar while a git read is in flight, then hides once the burst settles", async () => {
     render(
       <MantineProvider>
         <GitProgressBar />
@@ -50,7 +54,13 @@ describe("GitProgressBar", () => {
       d.resolve();
       await op;
     });
-    // Drained → hidden again.
+    // Drained but settling → still shown at 100%.
+    expect(screen.getByLabelText(/Fetching repository content: 2\/2 objects/)).toBeTruthy();
+
+    // Settle window elapses → hidden again.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200);
+    });
     expect(screen.queryByRole("progressbar")).toBeNull();
   });
 });

--- a/haku/state_template/ui/frontend/src/git_progress_bar.tsx
+++ b/haku/state_template/ui/frontend/src/git_progress_bar.tsx
@@ -3,14 +3,14 @@ import { Progress } from "@mantine/core";
 import { useGitProgress } from "./git_progress.ts";
 
 // Global transfer indicator for repo reads: a thin bar pinned to the top of the viewport that
-// mirrors git's object-transfer progress (done/total) whenever any tree/blob fetch is in flight,
-// anywhere in the app. Idle → renders nothing. This is the app-wide "talking to the repo" signal;
-// the per-view "Loading…" placeholders stay as region skeletons for a surface's first paint.
+// mirrors git's object-transfer progress (done/total) whenever any tree/blob fetch is in flight
+// (or just settling), anywhere in the app. Idle → renders nothing. This is the one app-wide
+// "talking to the repo" signal; individual surfaces no longer carry their own loading bar.
 export function GitProgressBar() {
-  const { inFlight, total, done } = useGitProgress();
-  if (inFlight === 0) return null;
+  const { total, done } = useGitProgress();
+  if (total === 0) return null; // idle burst
   // Floor the width so the bar is visible the instant a burst starts (done === 0 → 0% is invisible).
-  const pct = total > 0 ? Math.max(8, Math.round((done / total) * 100)) : 8;
+  const pct = Math.max(8, Math.round((done / total) * 100));
   return (
     <Progress
       value={pct}

--- a/haku/state_template/ui/frontend/src/git_progress_bar.tsx
+++ b/haku/state_template/ui/frontend/src/git_progress_bar.tsx
@@ -1,26 +1,46 @@
-import { Progress } from "@mantine/core";
+import { Box, Group, Progress, Text } from "@mantine/core";
 
 import { useGitProgress } from "./git_progress.ts";
 
-// Global transfer indicator for repo reads: a thin bar pinned to the top of the viewport that
-// mirrors git's object-transfer progress (done/total) whenever any tree/blob fetch is in flight
-// (or just settling), anywhere in the app. Idle → renders nothing. This is the one app-wide
-// "talking to the repo" signal; individual surfaces no longer carry their own loading bar.
+// Global transfer indicator for repo reads: a thin bar pinned to the BOTTOM of the viewport,
+// mirroring git's object-transfer progress whenever any tree/blob fetch is in flight (or settling),
+// anywhere in the app. Idle → renders nothing. This is the one app-wide "talking to the repo"
+// signal; individual surfaces no longer carry their own loading bar. Above the bar sits a compact
+// summary of the burst: operations in flight vs done, and git objects fetched vs requested.
 export function GitProgressBar() {
-  const { total, done } = useGitProgress();
-  if (total === 0) return null; // idle burst
-  // Floor the width so the bar is visible the instant a burst starts (done === 0 → 0% is invisible).
-  const pct = Math.max(8, Math.round((done / total) * 100));
+  const { activeOps, doneOps, totalObjects, doneObjects } = useGitProgress();
+  if (totalObjects === 0) return null; // idle burst
+  // Floor the width so the bar is visible the instant a burst starts (doneObjects 0 → 0% invisible).
+  const pct = Math.max(8, Math.round((doneObjects / totalObjects) * 100));
   return (
-    <Progress
-      value={pct}
-      size="xs"
-      radius={0}
-      striped
-      animated
-      transitionDuration={200}
-      aria-label={`Fetching repository content: ${done}/${total} objects`}
-      style={{ position: "fixed", top: 0, left: 0, right: 0, zIndex: 1000 }}
-    />
+    <Box
+      style={{
+        position: "fixed",
+        bottom: 0,
+        left: 0,
+        right: 0,
+        zIndex: 1000,
+        background: "var(--mantine-color-body)",
+        borderTop: "1px solid var(--mantine-color-default-border)",
+      }}
+    >
+      <Group justify="space-between" wrap="nowrap" px="sm" py={4} gap="sm">
+        <Text size="xs" c="dimmed" fw={600} style={{ whiteSpace: "nowrap" }}>
+          Fetching from git…
+        </Text>
+        <Text size="xs" c="dimmed" style={{ whiteSpace: "nowrap" }}>
+          {activeOps} in progress · {doneOps} done · {doneObjects}/{totalObjects} objects
+        </Text>
+      </Group>
+      <Progress
+        value={pct}
+        size="xs"
+        radius={0}
+        striped
+        animated
+        transitionDuration={200}
+        aria-label={`Fetching from git: ${activeOps} operations in progress, ${doneOps} done, ${doneObjects} of ${totalObjects} objects`}
+      />
+    </Box>
   );
 }

--- a/haku/state_template/ui/frontend/src/git_progress_bar.tsx
+++ b/haku/state_template/ui/frontend/src/git_progress_bar.tsx
@@ -1,0 +1,26 @@
+import { Progress } from "@mantine/core";
+
+import { useGitProgress } from "./git_progress.ts";
+
+// Global transfer indicator for repo reads: a thin bar pinned to the top of the viewport that
+// mirrors git's object-transfer progress (done/total) whenever any tree/blob fetch is in flight,
+// anywhere in the app. Idle → renders nothing. This is the app-wide "talking to the repo" signal;
+// the per-view "Loading…" placeholders stay as region skeletons for a surface's first paint.
+export function GitProgressBar() {
+  const { inFlight, total, done } = useGitProgress();
+  if (inFlight === 0) return null;
+  // Floor the width so the bar is visible the instant a burst starts (done === 0 → 0% is invisible).
+  const pct = total > 0 ? Math.max(8, Math.round((done / total) * 100)) : 8;
+  return (
+    <Progress
+      value={pct}
+      size="xs"
+      radius={0}
+      striped
+      animated
+      transitionDuration={200}
+      aria-label={`Fetching repository content: ${done}/${total} objects`}
+      style={{ position: "fixed", top: 0, left: 0, right: 0, zIndex: 1000 }}
+    />
+  );
+}

--- a/haku/state_template/ui/frontend/src/improvement_board.tsx
+++ b/haku/state_template/ui/frontend/src/improvement_board.tsx
@@ -2,6 +2,8 @@ import { Badge, Card, Group, Stack, Text, Title } from "@mantine/core";
 import { useEffect, useState } from "react";
 
 import { Disclosure } from "./disclosure.tsx";
+import { errText } from "./errors.ts";
+import { LoadError } from "./load_error.tsx";
 import { renderMarkdown } from "./markdown.ts";
 import { type Doc, docsUnder } from "./repo.ts";
 
@@ -104,10 +106,10 @@ export function ImprovementBoard() {
   useEffect(() => {
     docsUnder("memory/improvements")
       .then((entries) => setDocs(entries.map(toDoc).filter((d): d is ImprovementDoc => d !== null)))
-      .catch((e: unknown) => setError(e instanceof Error ? e.message : String(e)));
+      .catch((e: unknown) => setError(errText(e)));
   }, []);
 
-  if (error) return <Text c="red">Failed to load improvements: {error}</Text>;
+  if (error) return <LoadError what="improvements" error={error} />;
   if (!docs) return <Text c="dimmed">Loading…</Text>;
 
   const ideas = docs.filter((d) => d.cls === "idea").sort((a, b) => rank(a) - rank(b));

--- a/haku/state_template/ui/frontend/src/inbox.test.tsx
+++ b/haku/state_template/ui/frontend/src/inbox.test.tsx
@@ -67,6 +67,6 @@ describe("InboxView", () => {
         <InboxView docItems={null} meta={null} error="boom" now={0} />
       </MantineProvider>
     );
-    expect(screen.getByText(/Failed to load: boom/)).toBeTruthy();
+    expect(screen.getByText(/Failed to load items: boom/)).toBeTruthy();
   });
 });

--- a/haku/state_template/ui/frontend/src/inbox.tsx
+++ b/haku/state_template/ui/frontend/src/inbox.tsx
@@ -5,6 +5,7 @@ import { openLink } from "./bridge.ts";
 import { UP_NEXT } from "./constants.ts";
 import { countdown } from "./deadline.ts";
 import { ItemCard } from "./item_card.tsx";
+import { LoadError } from "./load_error.tsx";
 import type { Doc } from "./repo.ts";
 import type { MetaResponse } from "./types.ts";
 
@@ -52,12 +53,7 @@ interface InboxProps {
 // The triage board: a value-ranked list of items with a time-critical "Due soon" section.
 // One surface among several (see App's tabs) — not the whole of haku-ui.
 export function InboxView({ docItems, meta, error, now, onNavigate }: InboxProps) {
-  if (error)
-    return (
-      <Text c="red" my="lg">
-        Failed to load: {error}
-      </Text>
-    );
+  if (error) return <LoadError what="items" error={error} />;
   if (!docItems)
     return (
       <Text c="dimmed" my="lg">

--- a/haku/state_template/ui/frontend/src/item_card.tsx
+++ b/haku/state_template/ui/frontend/src/item_card.tsx
@@ -3,6 +3,7 @@ import { useDisclosure } from "@mantine/hooks";
 import { useEffect, useState } from "react";
 
 import { countdown, type Urgency } from "./deadline.ts";
+import { errText } from "./errors.ts";
 import { parseFrontmatter } from "./frontmatter.ts";
 import { ItemScopeContext } from "./item_scope.ts";
 import { Mdx } from "./mdx.tsx";
@@ -109,7 +110,7 @@ export function ItemCardById({
         if (live) setState(content === null ? { error: `item not found: ${id}` } : parseFrontmatter(content));
       },
       (e: unknown) => {
-        if (live) setState({ error: e instanceof Error ? e.message : String(e) });
+        if (live) setState({ error: errText(e) });
       }
     );
     return () => {

--- a/haku/state_template/ui/frontend/src/load_error.tsx
+++ b/haku/state_template/ui/frontend/src/load_error.tsx
@@ -1,0 +1,12 @@
+import { Text } from "@mantine/core";
+
+// Inline error for a surface that couldn't load its content — replaces the region. `what` names the
+// surface ("the garden", "runs", "items"); it reads "Failed to load <what>: <error>". User-action
+// failures use a toast instead (notifyError, errors.ts) so they don't blank a whole surface.
+export function LoadError({ what, error }: { what: string; error: string }) {
+  return (
+    <Text c="red" my="lg">
+      Failed to load {what}: {error}
+    </Text>
+  );
+}

--- a/haku/state_template/ui/frontend/src/log.test.ts
+++ b/haku/state_template/ui/frontend/src/log.test.ts
@@ -1,0 +1,20 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { logger } from "./log.ts";
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("logger", () => {
+  it("prefixes the message with the scope and forwards detail to the matching console level", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const err = new Error("boom");
+    logger("blob-cache").warn("could not persist", err);
+    expect(warn).toHaveBeenCalledWith("[blob-cache] could not persist", err);
+  });
+
+  it("routes each level to the same-named console method", () => {
+    const info = vi.spyOn(console, "info").mockImplementation(() => {});
+    logger("routes").info("fell back to home");
+    expect(info).toHaveBeenCalledWith("[routes] fell back to home");
+  });
+});

--- a/haku/state_template/ui/frontend/src/log.ts
+++ b/haku/state_template/ui/frontend/src/log.ts
@@ -1,0 +1,25 @@
+// Minimal logging front-end for the UI — not a framework, just namespaced levels over `console`.
+// One choke point so every diagnostic has a consistent `[scope]` shape and there's a single place
+// to later fan out to backend telemetry (see memory/improvements/ui-error-telemetry.md). House
+// rule (STYLE.md): a catch that degrades gracefully still logs here — never a silent swallow.
+//
+// Usage, mirroring Python's `logger = logging.getLogger(__name__)`:
+//   const log = logger("blob-cache");
+//   log.warn("could not persist to localStorage", e);
+
+type Level = "debug" | "info" | "warn" | "error";
+
+export interface Logger {
+  debug(message: string, ...detail: unknown[]): void;
+  info(message: string, ...detail: unknown[]): void;
+  warn(message: string, ...detail: unknown[]): void;
+  error(message: string, ...detail: unknown[]): void;
+}
+
+function at(level: Level, scope: string) {
+  return (message: string, ...detail: unknown[]): void => console[level](`[${scope}] ${message}`, ...detail);
+}
+
+export function logger(scope: string): Logger {
+  return { debug: at("debug", scope), info: at("info", scope), warn: at("warn", scope), error: at("error", scope) };
+}

--- a/haku/state_template/ui/frontend/src/main.tsx
+++ b/haku/state_template/ui/frontend/src/main.tsx
@@ -1,12 +1,21 @@
 import { MantineProvider, type MantineColorScheme, type MantineColorSchemeManager } from "@mantine/core";
+import { Notifications } from "@mantine/notifications";
 import { createRoot } from "react-dom/client";
 
 import "@mantine/core/styles.css";
+import "@mantine/notifications/styles.css";
 
 import { openLink } from "./bridge.ts";
 import App from "./app.tsx";
+import { notifyError } from "./errors.ts";
 import { theme } from "./theme.ts";
 import "./styles.css";
+
+// Last-resort surfacing: anything that escapes a component's own handling (a bug, an unhandled
+// rejection) still reaches the operator as a toast instead of vanishing into the console. This is
+// also where backend error telemetry would hook in later (see errors.ts / the improvement note).
+window.addEventListener("error", (e) => notifyError("Unexpected error", e.error ?? e.message));
+window.addEventListener("unhandledrejection", (e) => notifyError("Unexpected error", e.reason));
 
 // Intercept all anchor clicks: the iframe is sandboxed without allow-popups, so
 // bare <a> navigation is blocked in the sandbox. Route every link through the
@@ -40,6 +49,8 @@ const container = document.getElementById("root");
 if (!container) throw new Error("missing #root");
 createRoot(container).render(
   <MantineProvider theme={theme} defaultColorScheme="auto" colorSchemeManager={noopColorSchemeManager}>
+    {/* Top-right so toasts don't collide with the bottom-fixed GitProgressBar. */}
+    <Notifications position="top-right" />
     <App />
   </MantineProvider>
 );

--- a/haku/state_template/ui/frontend/src/mdx.tsx
+++ b/haku/state_template/ui/frontend/src/mdx.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from "react";
 import { createElement, Fragment, useMemo } from "react";
 
 import { Choice, Choices, Feedback, Handoff, Launch, SignalToggle } from "./affordances.tsx";
+import { errText } from "./errors.ts";
 import { ItemCardById } from "./item_card.tsx";
 import { ImprovementBoard } from "./improvement_board.tsx";
 import { Callout, StatusBadge } from "./widgets.tsx";
@@ -194,7 +195,7 @@ export function Mdx({
       ));
       return { tree };
     } catch (e) {
-      return { error: e instanceof Error ? e.message : String(e) };
+      return { error: errText(e) };
     }
   }, [source, basePath, onNavigate]);
 

--- a/haku/state_template/ui/frontend/src/repo.test.ts
+++ b/haku/state_template/ui/frontend/src/repo.test.ts
@@ -93,4 +93,14 @@ describe("docsUnder + read caches", () => {
     await repoBlobs(["a1"]);
     expect(blobCalls(fetchMock)).toBe(1);
   });
+
+  it("throws — never yields '' — when the backend omits a requested blob (no silent truncation)", async () => {
+    // Backend responds 200 but drops one of the two requested shas (a proxy truncating the query,
+    // a short git/blobs response that slipped the backend's guard, …).
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve([{ sha: "a1", content: "x" }]) } as Response))
+    );
+    await expect(repoBlobs(["a1", "b2"])).rejects.toThrow(/missing from response/);
+  });
 });

--- a/haku/state_template/ui/frontend/src/repo.ts
+++ b/haku/state_template/ui/frontend/src/repo.ts
@@ -11,7 +11,7 @@
 
 import { type FrontMatter, parseFrontmatter } from "./frontmatter.ts";
 import { trackGit } from "./git_progress.ts";
-import type { RepoBlob, RepoTree } from "./types.ts";
+import type { RepoBlob, RepoTree, RepoTreeEntry } from "./types.ts";
 
 const blobCache = new Map<string, string>();
 let treeInFlight: Promise<RepoTree> | null = null;
@@ -46,26 +46,62 @@ export function repoTree(): Promise<RepoTree> {
   return treeInFlight;
 }
 
-// Blobs by sha, in input order. Content-addressed → cached permanently; only uncached shas are fetched.
+// Blobs by sha, in input order. Content-addressed → cached permanently; only uncached shas fetched.
+// The backend returns every requested blob or errors (it chunks below Forgejo's 50-blob cap and
+// raises on a short response — see ui/backend/forgejo.py), so a sha still missing after the fetch
+// means a truncation slipped through (a proxy dropping the query, say). Surface it — never yield ""
+// for a dropped blob, which would silently render an item blank.
 export async function repoBlobs(shas: string[]): Promise<RepoBlob[]> {
   const missing = shas.filter((s) => !blobCache.has(s));
-  // Only a real fetch registers with the tracker — a fully-cached read (missing empty) does no I/O.
   if (missing.length > 0) {
     await trackGit(missing.length, async () => {
       const res = await fetch(`/api/repo/blobs?shas=${missing.join(",")}`);
       if (!res.ok) throw new Error(`repo blobs: ${res.status}`);
       for (const b of (await res.json()) as RepoBlob[]) blobCache.set(b.sha, b.content);
     });
+    const dropped = missing.filter((s) => !blobCache.has(s));
+    if (dropped.length > 0)
+      throw new Error(
+        `repo blobs: ${dropped.length}/${missing.length} missing from response (${dropped.slice(0, 3).join(", ")})`
+      );
   }
-  return shas.map((sha) => ({ sha, content: blobCache.get(sha) ?? "" }));
+  return shas.map((sha) => ({ sha, content: blobCache.get(sha)! }));
 }
 
-// One file's text by exact repo path — resolves its blob sha via the tree, then fetches it.
-// `null` if the path isn't a blob in the tree. Both reads hit the caches above.
+// One repo blob resolved to its path + text content — the unit `readBlobs` yields.
+export interface Blob {
+  path: string;
+  content: string;
+}
+
+// We read blobs in ≤50-sha chunks: it bounds the request URL (no proxy silently truncating a huge
+// query string) and doubles as the batching unit for streaming partial renders. The backend chunks
+// again below Forgejo's own 50-blob cap.
+const BLOB_CHUNK = 50;
+
+// THE shared high-level read over the git store: the text of every tree blob matching `select`, in
+// one tree read + chunked bulk-blob reads (all tracked by git_progress.ts, none silently dropped —
+// see repoBlobs). Blobs come back in tree order; the optional `onBatch` fires after each chunk with
+// everything read so far, for progressive rendering. Every surface — items, garden, runs, responses
+// — composes over this instead of re-implementing tree-filtering, sha-mapping, chunking.
+export async function readBlobs(
+  select: (e: RepoTreeEntry) => boolean,
+  onBatch?: (soFar: Blob[]) => void
+): Promise<Blob[]> {
+  const entries = (await repoTree()).entries.filter((e) => e.type === "blob" && select(e));
+  const out: Blob[] = [];
+  for (let i = 0; i < entries.length; i += BLOB_CHUNK) {
+    const chunk = entries.slice(i, i + BLOB_CHUNK);
+    const bySha = new Map((await repoBlobs(chunk.map((e) => e.sha))).map((b) => [b.sha, b.content] as const));
+    for (const e of chunk) out.push({ path: e.path, content: bySha.get(e.sha)! });
+    onBatch?.(out);
+  }
+  return out;
+}
+
+// One file's text by exact repo path, or `null` if the path isn't a blob in the tree.
 export async function repoFile(path: string): Promise<string | null> {
-  const entry = (await repoTree()).entries.find((e) => e.type === "blob" && e.path === path);
-  if (!entry) return null;
-  const [blob] = await repoBlobs([entry.sha]);
+  const [blob] = await readBlobs((e) => e.path === path);
   return blob?.content ?? null;
 }
 
@@ -73,15 +109,23 @@ export interface Doc extends FrontMatter {
   path: string;
 }
 
-// Every `.md` file directly-or-deeper under `dir` with its parsed frontmatter + body, sorted by
-// path. The trailing "/" on the dir match keeps a sibling like `memory/improvements-archive` out of
-// `memory/improvements`.
-export async function docsUnder(dir: string): Promise<Doc[]> {
-  const tree = await repoTree();
-  const under = tree.entries.filter((e) => e.type === "blob" && e.path.endsWith(".md") && e.path.startsWith(`${dir}/`));
-  const blobs = await repoBlobs(under.map((e) => e.sha));
-  const bySha = new Map(blobs.map((b): [string, string] => [b.sha, b.content]));
-  return under
-    .map((e) => ({ path: e.path, ...parseFrontmatter(bySha.get(e.sha) ?? "") }))
-    .sort((a, b) => a.path.localeCompare(b.path));
+// Streaming hook for `docsUnder`: `onDocs` gets the accumulated (path-sorted) docs after each blob
+// chunk so a view can render items as they stream in. Load progress itself is not reported here —
+// the git-object transfer is tracked centrally (git_progress.ts) and shown by the one global bar.
+export interface DocsUnderOpts {
+  onDocs?: (docs: Doc[]) => void;
+}
+
+const toDocs = (blobs: Blob[]): Doc[] =>
+  blobs.map((b) => ({ path: b.path, ...parseFrontmatter(b.content) })).sort((a, b) => a.path.localeCompare(b.path));
+
+// Every `.md` file directly-or-deeper under `dir` with its parsed frontmatter + body, path-sorted.
+// The trailing "/" on the dir match keeps a sibling like `memory/improvements-archive` out of
+// `memory/improvements`. Composes over readBlobs; `onDocs` streams the accumulated set per chunk.
+export async function docsUnder(dir: string, opts: DocsUnderOpts = {}): Promise<Doc[]> {
+  const blobs = await readBlobs(
+    (e) => e.path.endsWith(".md") && e.path.startsWith(`${dir}/`),
+    opts.onDocs ? (soFar) => opts.onDocs!(toDocs(soFar)) : undefined
+  );
+  return toDocs(blobs);
 }

--- a/haku/state_template/ui/frontend/src/repo.ts
+++ b/haku/state_template/ui/frontend/src/repo.ts
@@ -10,7 +10,7 @@
 // where several widgets mount at once and each want the tree.
 
 import { type FrontMatter, parseFrontmatter } from "./frontmatter.ts";
-import { trackGit } from "./git_progress.ts";
+import { gitProgress } from "./git_progress.ts";
 import type { RepoBlob, RepoTree, RepoTreeEntry } from "./types.ts";
 
 const blobCache = new Map<string, string>();
@@ -35,7 +35,7 @@ export function repoTree(): Promise<RepoTree> {
   treeAt = Date.now();
   // A tree read is one git object; the shared in-flight promise means concurrent callers
   // ride one fetch, so it registers with the tracker exactly once.
-  treeInFlight = trackGit(1, async () => {
+  treeInFlight = gitProgress.track(1, async () => {
     const res = await fetch("/api/repo/tree");
     if (!res.ok) {
       invalidateTree(); // don't cache a failure
@@ -54,7 +54,7 @@ export function repoTree(): Promise<RepoTree> {
 export async function repoBlobs(shas: string[]): Promise<RepoBlob[]> {
   const missing = shas.filter((s) => !blobCache.has(s));
   if (missing.length > 0) {
-    await trackGit(missing.length, async () => {
+    await gitProgress.track(missing.length, async () => {
       const res = await fetch(`/api/repo/blobs?shas=${missing.join(",")}`);
       if (!res.ok) throw new Error(`repo blobs: ${res.status}`);
       for (const b of (await res.json()) as RepoBlob[]) blobCache.set(b.sha, b.content);

--- a/haku/state_template/ui/frontend/src/repo.ts
+++ b/haku/state_template/ui/frontend/src/repo.ts
@@ -3,17 +3,19 @@
 // build on: `docsUnder` loads every .md under a directory in exactly two calls (one tree, one
 // bulk blobs), parsing each file's frontmatter. New directories/views need no backend work.
 //
-// Session read caches (content-addressing makes this nearly free): blobs are immutable by sha, so
-// they're cached permanently; the tree (HEAD's entries) is cached with a short TTL and invalidated
-// on any local write (client.ts write helpers call `invalidateTree`), so a write's new blob sha is
-// discovered on the next read. Concurrent callers share one in-flight tree fetch — the common case
-// where several widgets mount at once and each want the tree.
+// Read caches (content-addressing makes this nearly free): blobs are immutable by sha, so they're
+// cached permanently and persisted across reloads (blob_cache.ts: memory + localStorage). The tree
+// (HEAD's entries) is fetched as "current HEAD", not by sha — so it can't be a by-sha persistent
+// cache — and is kept only in-memory with a short TTL, invalidated on any local write (client.ts
+// write helpers call `invalidateTree`) so a write's new blob sha is discovered on the next read.
+// Concurrent callers share one in-flight tree fetch — the common case where several widgets mount
+// at once and each want the tree.
 
+import { clearBlobCache, getBlob, hasBlob, setBlob } from "./blob_cache.ts";
 import { type FrontMatter, parseFrontmatter } from "./frontmatter.ts";
 import { gitProgress } from "./git_progress.ts";
 import type { RepoBlob, RepoTree, RepoTreeEntry } from "./types.ts";
 
-const blobCache = new Map<string, string>();
 let treeInFlight: Promise<RepoTree> | null = null;
 let treeAt = 0;
 const TREE_TTL_MS = 15_000;
@@ -24,10 +26,10 @@ export function invalidateTree(): void {
   treeAt = 0;
 }
 
-// Full reset (tree + the immutable blob cache) — for tests, and available for a session/HEAD reset.
+// Full reset (tree + the immutable blob cache, memory + persisted) — for tests and a session reset.
 export function resetRepoCache(): void {
   invalidateTree();
-  blobCache.clear();
+  clearBlobCache();
 }
 
 export function repoTree(): Promise<RepoTree> {
@@ -52,20 +54,20 @@ export function repoTree(): Promise<RepoTree> {
 // means a truncation slipped through (a proxy dropping the query, say). Surface it — never yield ""
 // for a dropped blob, which would silently render an item blank.
 export async function repoBlobs(shas: string[]): Promise<RepoBlob[]> {
-  const missing = shas.filter((s) => !blobCache.has(s));
+  const missing = shas.filter((s) => !hasBlob(s)); // hasBlob promotes a persisted hit into memory
   if (missing.length > 0) {
     await gitProgress.track(missing.length, async () => {
       const res = await fetch(`/api/repo/blobs?shas=${missing.join(",")}`);
       if (!res.ok) throw new Error(`repo blobs: ${res.status}`);
-      for (const b of (await res.json()) as RepoBlob[]) blobCache.set(b.sha, b.content);
+      for (const b of (await res.json()) as RepoBlob[]) setBlob(b.sha, b.content);
     });
-    const dropped = missing.filter((s) => !blobCache.has(s));
+    const dropped = missing.filter((s) => !hasBlob(s));
     if (dropped.length > 0)
       throw new Error(
         `repo blobs: ${dropped.length}/${missing.length} missing from response (${dropped.slice(0, 3).join(", ")})`
       );
   }
-  return shas.map((sha) => ({ sha, content: blobCache.get(sha)! }));
+  return shas.map((sha) => ({ sha, content: getBlob(sha)! }));
 }
 
 // One repo blob resolved to its path + text content — the unit `readBlobs` yields.
@@ -82,8 +84,8 @@ const BLOB_CHUNK = 50;
 // THE shared high-level read over the git store: the text of every tree blob matching `select`, in
 // one tree read + chunked bulk-blob reads (all tracked by git_progress.ts, none silently dropped —
 // see repoBlobs). Blobs come back in tree order; the optional `onBatch` fires after each chunk with
-// everything read so far, for progressive rendering. Every surface — items, garden, runs, responses
-// — composes over this instead of re-implementing tree-filtering, sha-mapping, chunking.
+// everything read so far, for progressive rendering. Every surface — items, garden, kitchen, runs,
+// responses — composes over this instead of re-implementing tree-filtering, sha-mapping, chunking.
 export async function readBlobs(
   select: (e: RepoTreeEntry) => boolean,
   onBatch?: (soFar: Blob[]) => void

--- a/haku/state_template/ui/frontend/src/repo.ts
+++ b/haku/state_template/ui/frontend/src/repo.ts
@@ -10,6 +10,7 @@
 // where several widgets mount at once and each want the tree.
 
 import { type FrontMatter, parseFrontmatter } from "./frontmatter.ts";
+import { trackGit } from "./git_progress.ts";
 import type { RepoBlob, RepoTree } from "./types.ts";
 
 const blobCache = new Map<string, string>();
@@ -32,24 +33,29 @@ export function resetRepoCache(): void {
 export function repoTree(): Promise<RepoTree> {
   if (treeInFlight && Date.now() - treeAt < TREE_TTL_MS) return treeInFlight;
   treeAt = Date.now();
-  treeInFlight = (async () => {
+  // A tree read is one git object; the shared in-flight promise means concurrent callers
+  // ride one fetch, so it registers with the tracker exactly once.
+  treeInFlight = trackGit(1, async () => {
     const res = await fetch("/api/repo/tree");
     if (!res.ok) {
       invalidateTree(); // don't cache a failure
       throw new Error(`repo tree: ${res.status}`);
     }
     return (await res.json()) as RepoTree;
-  })();
+  });
   return treeInFlight;
 }
 
 // Blobs by sha, in input order. Content-addressed → cached permanently; only uncached shas are fetched.
 export async function repoBlobs(shas: string[]): Promise<RepoBlob[]> {
   const missing = shas.filter((s) => !blobCache.has(s));
+  // Only a real fetch registers with the tracker — a fully-cached read (missing empty) does no I/O.
   if (missing.length > 0) {
-    const res = await fetch(`/api/repo/blobs?shas=${missing.join(",")}`);
-    if (!res.ok) throw new Error(`repo blobs: ${res.status}`);
-    for (const b of (await res.json()) as RepoBlob[]) blobCache.set(b.sha, b.content);
+    await trackGit(missing.length, async () => {
+      const res = await fetch(`/api/repo/blobs?shas=${missing.join(",")}`);
+      if (!res.ok) throw new Error(`repo blobs: ${res.status}`);
+      for (const b of (await res.json()) as RepoBlob[]) blobCache.set(b.sha, b.content);
+    });
   }
   return shas.map((sha) => ({ sha, content: blobCache.get(sha) ?? "" }));
 }

--- a/haku/state_template/ui/frontend/src/repo.ts
+++ b/haku/state_template/ui/frontend/src/repo.ts
@@ -84,7 +84,7 @@ const BLOB_CHUNK = 50;
 // THE shared high-level read over the git store: the text of every tree blob matching `select`, in
 // one tree read + chunked bulk-blob reads (all tracked by git_progress.ts, none silently dropped —
 // see repoBlobs). Blobs come back in tree order; the optional `onBatch` fires after each chunk with
-// everything read so far, for progressive rendering. Every surface — items, garden, kitchen, runs,
+// everything read so far, for progressive rendering. Every surface — items, garden, runs,
 // responses — composes over this instead of re-implementing tree-filtering, sha-mapping, chunking.
 export async function readBlobs(
   select: (e: RepoTreeEntry) => boolean,

--- a/haku/state_template/ui/frontend/src/routes.ts
+++ b/haku/state_template/ui/frontend/src/routes.ts
@@ -12,6 +12,10 @@
 
 import { useCallback, useEffect, useState } from "react";
 
+import { logger } from "./log.ts";
+
+const log = logger("routes");
+
 export type View = "inbox" | "improvements" | "runs" | "garden";
 
 export interface Route {
@@ -33,9 +37,10 @@ export function parseHash(hash: string): Route {
     if (segments.length === 0) return { view: "garden", gardenPath: null };
     try {
       return { view: "garden", gardenPath: segments.map(decodeURIComponent).join("/") };
-    } catch {
-      // Malformed percent-encoding in a user-edited URL — same contract as any other
-      // unparseable route: fall back, never throw (this runs in the useState initializer).
+    } catch (e) {
+      // Malformed percent-encoding in a user-edited URL — same contract as any other unparseable
+      // route: fall back, never throw (this runs in the useState initializer) — but log it.
+      log.warn("malformed garden path in URL, falling back to home", e);
       return HOME;
     }
   }

--- a/haku/state_template/ui/frontend/src/runs.tsx
+++ b/haku/state_template/ui/frontend/src/runs.tsx
@@ -2,6 +2,8 @@ import { Anchor, Group, Stack, Table, Text, Title } from "@mantine/core";
 import { useEffect, useState } from "react";
 
 import { fetchRuns } from "./client.ts";
+import { errText } from "./errors.ts";
+import { LoadError } from "./load_error.tsx";
 import { Mdx } from "./mdx.tsx";
 import type { RunManifest, RunSource, ScannedSource } from "./types.ts";
 import { PropagationMatrix } from "./widgets.tsx";
@@ -204,15 +206,10 @@ export function RunsPage({ openInGarden }: { openInGarden: (path: string) => voi
   useEffect(() => {
     fetchRuns()
       .then((r) => setRuns(r.runs))
-      .catch((e: unknown) => setError(e instanceof Error ? e.message : String(e)));
+      .catch((e: unknown) => setError(errText(e)));
   }, []);
 
-  if (error)
-    return (
-      <Text c="red" my="lg">
-        Failed to load runs: {error}
-      </Text>
-    );
+  if (error) return <LoadError what="runs" error={error} />;
   if (!runs)
     return (
       <Text c="dimmed" my="lg">


### PR DESCRIPTION
## Summary

Reworks the haku-ui frontend's git read layer into a single content-addressed store with one global progress indicator, persistent caching, uniform error surfacing, and a small logging convention. Changes land in `haku/state_template/` (the seed); the live `haku-state` repo carries the same set.

> Scope note: this touches `haku/state_template/` (React SPA + FastAPI backend) and `STYLE.md`. It is **starter source**, not wired into Bazel — its own gate is Forgejo CI.

## Key changes

**One shared read over the git store** (`repo.ts`)
- `readBlobs(select, onBatch?)` is the single high-level read: filter the tree, fetch blobs in ≤50-sha chunks (bounds the request URL; also the streaming unit), map by sha, tree order. `docsUnder`/`repoFile`/`fetchRuns` compose over it instead of each re-implementing tree-filter → bulk-fetch → parse.
- **No silent truncation:** `repoBlobs` throws if the backend omits a requested sha (never yields `""` for a dropped blob). The backend already errors on its side — `forgejo.blobs` chunks below Forgejo's 50-blob cap and raises on a short response.

**Persistent, content-addressed blob cache** (`blob_cache.ts`)
- Blobs are immutable by sha, so they persist across reloads: a two-tier cache (in-memory Map + `localStorage` keyed by sha). Guarded for the sandboxed cross-origin iframe — every `localStorage` access falls back to memory-only if it's absent or throws, with quota-eviction retry.
- The **tree is not** persisted: it's fetched as "current HEAD" (not by sha) and is freshness-sensitive (15s TTL + invalidate-on-write), so a by-sha cache wouldn't help.

**Central progress indicator** (`git_progress.ts`, `git_progress_bar.tsx`)
- One `useSyncExternalStore` singleton (`createStore()`) every tree/blob read registers with. A "burst" coalesces back-to-back reads (150ms settle) so a read's tree + blob chunks fill one bar smoothly.
- One app-wide **bottom-fixed** bar showing git object-transfer (`done/total`) plus an operations summary (`N in progress · M done · X/Y objects`), whenever any read on any surface is in flight; idle → nothing. Replaces the old per-view "Loading…" bars.

**Runs through the one store** (`client.ts`, backend)
- `fetchRuns` composes over `readBlobs` (pairs each `runs/<date>/<ulid>.yaml` with its sibling `.md`, newest-first). The dead `GET /api/runs` endpoint + `reads.read_runs` are removed; the `RunManifest` schema stays (validate-state CI checks every run commit) and its tests move to `test_models.py`.

**Consistent error surfacing** (`errors.ts`, `load_error.tsx`)
- A user action fails → `notifyError` red toast (`@mantine/notifications`), non-blocking. A surface can't load → one shared `<LoadError>`. A global `window` `error`/`unhandledrejection` handler catches the rest. Fixes the kitchen signal-toggle that used to blank the whole board on a write error (live repo only).

**Logging + "degrade loud" rule** (`log.ts`, `STYLE.md`)
- A minimal namespaced logger over `console` — one choke point (and the future hook for backend error telemetry). Every graceful-degradation `catch` now logs the exception instead of swallowing silently (blob cache, footer meta, prefill, frontmatter, routes). Codified in STYLE.md as **"Degrade loud, not silent"**.

**Docs** — corrected `ui/README.md` staleness (endpoint methods, bar location, `pip install .` / `.[dev]`) surfaced by a knowledge-hygiene pass.

## Testing

Frontend: full `vitest` suite (new `blob_cache`, `log`, `git_progress`, `git_progress_bar`, `client` cases; `repo.test` covers truncation detection), `tsc -b`, eslint, production build. Backend: `pytest` + ruff + `validate_state`. All pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LD4L7Z4fZ3yEqTmUMzn8NG