### PR TITLE
codex-pod: bake unattended Codex config (never-prompt, full-access)

### DIFF
--- a/cluster/k8s/agents/codex-pod/README.md
+++ b/cluster/k8s/agents/codex-pod/README.md
@@ -11,7 +11,11 @@ Registry-hosting rationale (why Forgejo over GHCR) + the general pattern:
 - **Image + env**: `x/codex_pod_image/default.nix` — a `buildEnv` tool set on
   `/bin` plus the user's static dotfiles baked from a home-manager config
   (`x/codex_pod_image/home.nix`). No runtime bootstrap script; all static config
-  is Nix-built and baked into the image.
+  is Nix-built and baked into the image — including Codex's `~/.codex/config.toml`
+  (`approval_policy = "never"`, `sandbox_mode = "danger-full-access"`, mirroring
+  agent-box's unattended `ducktape.codex`). Baked directly rather than via the
+  upstream `programs.codex` module, whose config.toml comes from a home-manager
+  _activation_ script that never runs in this activation-less image.
 - **CI**: `.github/workflows/codex-pod-image.yml` builds `.#codex-pod-image` and
   `skopeo copy`s a `devel-<ts>-<sha7>` tag to our Forgejo registry
   `git.allegedly.works/ducktape-ci/codex-pod` (as the `ducktape-ci` tenant).
@@ -22,12 +26,14 @@ Registry-hosting rationale (why Forgejo over GHCR) + the general pattern:
 - **Registry credential**: `cluster/k8s/forgejo-images/` provisions the
   `ducktape-ci` Forgejo user (Terraform) and a `forgejo-images-creds` Secret
   reflected into `flux-system` (scan) + `codex-pod` (`imagePullSecrets`).
-- **Runtime**: non-root UID 1000. `HOME=/home/codex` (the baked dotfiles) is
-  distinct from the work dir: the `codex-workspace` PVC (`seaweedfs-ovh`) mounts at
-  `/workspace` so it doesn't shadow the baked home, and holds the work tree,
-  `CODEX_HOME` (`/workspace/.codex`), and `XDG_CACHE_HOME` (`/workspace/.cache`).
-  Access is `kubectl exec` (no sshd) — the container's baked env carries into exec
-  sessions.
+- **Runtime**: non-root UID 1000. `HOME=/home/codex` (the baked dotfiles, incl.
+  the Codex config) is distinct from the work dir: the `codex-workspace` PVC
+  (`seaweedfs-ovh`) mounts at `/workspace` so it doesn't shadow the baked home, and
+  holds the work tree plus `XDG_CACHE_HOME` (`/workspace/.cache`) for build caches.
+  `CODEX_HOME` is left at its default (`~/.codex`, baked); Codex's own state
+  (history/sessions) is ephemeral there — durable state is the git work tree on the
+  PVC. Access is `kubectl exec` (no sshd) — the container's baked env carries into
+  exec sessions.
 
 ## Bring-up
 

--- a/x/codex_pod_image/default.nix
+++ b/x/codex_pod_image/default.nix
@@ -76,11 +76,13 @@ pkgs.dockerTools.buildLayeredImage {
     chmod 1777 tmp
 
     # Bake the home-manager dotfiles into /home/codex (HOME; the /workspace PVC is
-    # mounted elsewhere so it doesn't shadow these). Make ~/.ssh writable — the
-    # entrypoint plants id_ed25519 into it at runtime; home-manager leaves it 0555.
+    # mounted elsewhere so it doesn't shadow these). home-manager leaves these dirs
+    # 0555; make them writable so the entrypoint can plant id_ed25519 into ~/.ssh
+    # and Codex can write history/sessions/auth into ~/.codex (its baked config.toml
+    # stays a read-only store symlink, which Codex only reads).
     mkdir -p home/codex
     cp -a ${homeFiles}/. home/codex/
-    chmod 700 home/codex/.ssh
+    chmod 700 home/codex/.ssh home/codex/.codex
     chown -R 1000:1000 home/codex workspace
 
     cat > etc/passwd <<'PASSWD'
@@ -106,8 +108,8 @@ pkgs.dockerTools.buildLayeredImage {
       "PATH=/bin:${codexEnv}/bin"
       "HOME=/home/codex"
       "USER=codex"
-      # Persistent state on the /workspace PVC; config stays in the baked ~/.config.
-      "CODEX_HOME=/workspace/.codex"
+      # Codex reads its baked config.toml from the default CODEX_HOME (~/.codex);
+      # don't override it. Build caches persist on the /workspace PVC.
       "XDG_CACHE_HOME=/workspace/.cache"
       "SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt"
       "NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt"

--- a/x/codex_pod_image/home.nix
+++ b/x/codex_pod_image/home.nix
@@ -3,7 +3,8 @@
 # bootstrap script for static config. Secrets are NOT here — they come from k8s
 # (BUILDBUDDY_API_KEY env, the id_ed25519 plant, ESO-templated files); so no
 # sops-nix, no systemd, non-root.
-_: {
+{ pkgs, ... }:
+{
   home.username = "codex";
   home.homeDirectory = "/home/codex";
   home.stateVersion = "25.11";
@@ -36,5 +37,30 @@ _: {
   programs.direnv = {
     enable = true;
     nix-direnv.enable = true;
+  };
+
+  # Codex runs fully unattended in this isolated agent pod — never prompt, no
+  # sandbox — mirroring agent-box's `ducktape.codex` (nix/home/hosts/agent-box/
+  # codex.nix). The upstream programs.codex module writes config.toml from a
+  # home-manager *activation* script (merge.py), but this image bakes only the
+  # static home-files and never runs activation — so we bake config.toml directly.
+  # Codex reads it from its default CODEX_HOME (~/.codex).
+  home.file.".codex/config.toml".source = (pkgs.formats.toml { }).generate "codex-config.toml" {
+    model = "gpt-5.5";
+    model_reasoning_effort = "xhigh";
+    approval_policy = "never";
+    sandbox_mode = "danger-full-access";
+    history.persistence = "save-all";
+    features = {
+      streamable_shell = true;
+      unified_exec = true;
+      apply_patch_freeform = true;
+      shell_tool = true;
+      view_image_tool = true;
+    };
+    shell_environment_policy = {
+      "inherit" = "all";
+      set.CODEX_AGENT = "1";
+    };
   };
 }


### PR DESCRIPTION
You wanted the pod's Codex to run fully YOLO from a **baked** config — never ask for permissions. It had none: `CODEX_HOME` pointed at the empty `/workspace` PVC, so `codex --version` warned `CODEX_HOME ... does not exist` and there was no approval/sandbox config at all.

The upstream `programs.codex` home-manager module can't supply it here — it writes `config.toml` from a home-manager **activation** script (`merge.py`), and this baked image never runs activation (no systemd, no `home-manager switch`).

## Change

- Bake `~/.codex/config.toml` directly via `home.file`, mirroring agent-box's unattended `ducktape.codex`:
  - `approval_policy = "never"`
  - `sandbox_mode = "danger-full-access"`
  - plus `model`/reasoning/features/history to match the shared base.
- Drop the `CODEX_HOME=/workspace/.codex` env override → Codex uses its default `~/.codex` (baked). Make `~/.codex` writable (`0700`) so Codex can write history/sessions there.
- `/workspace` still holds the git work tree + `XDG_CACHE_HOME` build caches.

Verified in the built image: `~/.codex/config.toml` present with the YOLO settings, `~/.codex` is `drwx------ 1000/1000`, and no `CODEX_HOME` in the image env (so no more warning).