### PR TITLE
codex-pod: ssh access via sshd-over-kubectl-exec

### DIFF
--- a/cluster/k8s/agents/codex-pod/README.md
+++ b/cluster/k8s/agents/codex-pod/README.md
@@ -32,8 +32,13 @@ Registry-hosting rationale (why Forgejo over GHCR) + the general pattern:
   holds the work tree plus `XDG_CACHE_HOME` (`/workspace/.cache`) for build caches.
   `CODEX_HOME` is left at its default (`~/.codex`, baked); Codex's own state
   (history/sessions) is ephemeral there — durable state is the git work tree on the
-  PVC. Access is `kubectl exec` (no sshd) — the container's baked env carries into
-  exec sessions.
+  PVC.
+- **Access**: `kubectl exec` (env inherited), or `ssh codex-pod` — the container's
+  main process is `sshd -D` on `127.0.0.1:2222`, reached via a `kubectl exec` +
+  `socat` `ProxyCommand` (baked into `nix/home/home.nix`; no exposed port, no
+  Service). kube RBAC gates the transport; sshd adds pubkey auth (workstation keys
+  baked into `~/.ssh/authorized_keys`) so ssh-native tooling (rsync/scp/git/VS Code
+  Remote) works. The sshd host key persists on the PVC (`/workspace/.sshd`).
 
 ## Bring-up
 

--- a/cluster/k8s/agents/codex-pod/deployment.yaml
+++ b/cluster/k8s/agents/codex-pod/deployment.yaml
@@ -37,15 +37,22 @@ spec:
           # Flux image-automation setter: the marker MUST be a trailing comment on
           # the image line (kyaml Setters ignores an own-line comment above it).
           image: git.allegedly.works/ducktape-ci/codex-pod:devel-20260704064328-2c474db # {"$imagepolicy": "flux-system:codex-pod"}
-          # HOME (/home/codex) + all static config are baked into the image by
-          # home-manager. The only runtime step is planting the SSH private key
-          # (secret → 0600; a mount can't satisfy ssh's ownership/perms). Access
-          # is via `kubectl exec`, which inherits the container env.
+          # HOME (/home/codex) + all static config (incl. sshd_config +
+          # authorized_keys) are baked into the image by home-manager. Runtime
+          # steps: (1) plant the outbound SSH private key (secret → 0600; a mount
+          # can't satisfy ssh's ownership/perms); (2) ensure a persistent host key
+          # on the PVC; (3) run sshd as the main process — it keeps the container
+          # alive and serves inbound `ssh codex-pod` over `kubectl exec` (127.0.0.1
+          # only; see the ProxyCommand matchBlock in nix/home/home.nix). `kubectl
+          # exec` still works too.
           command: ["/bin/bash", "-c"]
           args:
             - |
               install -D -m600 /run/codex-secret/id_ed25519 "$HOME/.ssh/id_ed25519"
-              exec sleep infinity
+              install -d -m700 /workspace/.sshd
+              [ -f /workspace/.sshd/ssh_host_ed25519_key ] \
+                || ssh-keygen -q -t ed25519 -N "" -f /workspace/.sshd/ssh_host_ed25519_key
+              exec sshd -D -e -f "$HOME/.ssh/sshd_config"
           env:
             # Shared BuildBuddy key (bbr reads BUILDBUDDY_API_KEY), reflected into
             # this namespace from shared-secrets/buildbuddy-api-key. Optional so a

--- a/cluster/k8s/agents/codex-pod/deployment.yaml
+++ b/cluster/k8s/agents/codex-pod/deployment.yaml
@@ -41,11 +41,12 @@ spec:
           # authorized_keys) are baked into the image by home-manager. Runtime
           # steps: (1) plant the outbound SSH private key (secret → 0600; a mount
           # can't satisfy ssh's ownership/perms); (2) ensure a persistent host key
-          # on the PVC; (3) run sshd as the main process — it keeps the container
-          # alive and serves inbound `ssh codex-pod` over `kubectl exec` (127.0.0.1
-          # only; see the ProxyCommand matchBlock in nix/home/home.nix). `kubectl
-          # exec` still works too.
-          command: ["/bin/bash", "-c"]
+          # on the PVC; (3) run sshd as the long-lived process — it keeps the
+          # container alive and serves inbound `ssh codex-pod` over `kubectl exec`
+          # (127.0.0.1 only; see the ProxyCommand matchBlock in nix/home/home.nix).
+          # `kubectl exec` still works too. tini is PID 1 (reaps zombies orphaned by
+          # exec/ssh sessions — sshd wouldn't; forwards signals for clean shutdown).
+          command: ["/bin/tini", "--", "/bin/bash", "-c"]
           args:
             - |
               install -D -m600 /run/codex-secret/id_ed25519 "$HOME/.ssh/id_ed25519"

--- a/nix/home/home.nix
+++ b/nix/home/home.nix
@@ -248,6 +248,20 @@ in
         user = "codex";
         port = 2201;
       };
+      # codex-pod (k8s image pod): no exposed port — tunnel to its 127.0.0.1 sshd
+      # through `kubectl exec` + a socat relay. kube RBAC gates the transport; the
+      # pod's sshd adds pubkey auth so ssh-native tools (rsync/scp/git/VS Code
+      # Remote) work. Host key isn't verified (exec-gated, and the PVC host key can
+      # be reprovisioned). Needs a cluster kubeconfig on PATH.
+      "codex-pod" = {
+        user = "codex";
+        identityFile = "~/.ssh/id_ed25519";
+        proxyCommand = "kubectl exec -i -n codex-pod deploy/codex-pod -c codex -- socat - TCP:127.0.0.1:2222";
+        extraOptions = {
+          StrictHostKeyChecking = "no";
+          UserKnownHostsFile = "/dev/null";
+        };
+      };
     };
   };
   xdg.configFile."appimagelauncher.cfg".text = ''

--- a/x/codex_pod_image/default.nix
+++ b/x/codex_pod_image/default.nix
@@ -36,7 +36,8 @@ let
       pkgs.which
       pkgs.psmisc
       pkgs.git
-      pkgs.openssh
+      pkgs.openssh # ssh client + sshd (inbound `ssh codex-pod` over kubectl exec)
+      pkgs.socat # relay for the ssh-over-kubectl-exec ProxyCommand
       pkgs.curl
       pkgs.jq
       pkgs.ripgrep

--- a/x/codex_pod_image/default.nix
+++ b/x/codex_pod_image/default.nix
@@ -38,6 +38,7 @@ let
       pkgs.git
       pkgs.openssh # ssh client + sshd (inbound `ssh codex-pod` over kubectl exec)
       pkgs.socat # relay for the ssh-over-kubectl-exec ProxyCommand
+      pkgs.tini # PID 1 init: reaps zombies from exec/ssh sessions, forwards signals
       pkgs.curl
       pkgs.jq
       pkgs.ripgrep

--- a/x/codex_pod_image/home.nix
+++ b/x/codex_pod_image/home.nix
@@ -3,7 +3,17 @@
 # bootstrap script for static config. Secrets are NOT here — they come from k8s
 # (BUILDBUDDY_API_KEY env, the id_ed25519 plant, ESO-templated files); so no
 # sops-nix, no systemd, non-root.
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
+let
+  keys = import ../../nix/ssh-keys.nix;
+  # Humans authorised to `ssh codex-pod` (over `kubectl exec`) — same workstation
+  # keys agent-box authorises for inbound login (nix/nixos/hosts/agent-box).
+  loginKeys = [
+    keys.wyrm2
+    keys.atlas
+    keys.rugged
+  ];
+in
 {
   home.username = "codex";
   home.homeDirectory = "/home/codex";
@@ -33,6 +43,40 @@
       identitiesOnly = true;
     };
   };
+
+  # Inbound `ssh codex-pod` over `kubectl exec` (no exposed port): a persistent
+  # `sshd -D` listens on 127.0.0.1:2222; clients tunnel to it with a socat relay
+  # (see the codex-pod matchBlock in nix/home/home.nix). The transport is already
+  # gated by kube RBAC (you can only exec into the pod if allowed); this sshd layer
+  # adds pubkey auth so ssh-native tooling (rsync/scp/git/VS Code Remote) works.
+  #
+  # StrictModes off because ~/.ssh and authorized_keys are read-only /nix/store
+  # symlinks; the host key lives on the /workspace PVC (planted at startup) so it's
+  # stable across restarts. Non-root sshd => UsePAM off, no privsep user.
+  home.file.".ssh/authorized_keys".text = lib.concatStringsSep "\n" loginKeys + "\n";
+  home.file.".ssh/sshd_config".text = ''
+    Port 2222
+    ListenAddress 127.0.0.1
+    HostKey /workspace/.sshd/ssh_host_ed25519_key
+    AuthorizedKeysFile /home/codex/.ssh/authorized_keys
+    AllowUsers codex
+    PasswordAuthentication no
+    PubkeyAuthentication yes
+    StrictModes no
+    UsePAM no
+    PidFile /tmp/sshd.pid
+    Subsystem sftp internal-sftp
+    # sshd sanitizes the environment; pass the tools + trust store that the
+    # container Env sets, so ssh sessions match `kubectl exec`.
+    SetEnv PATH=/bin SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt GIT_SSL_CAINFO=/etc/ssl/certs/ca-certificates.crt XDG_CACHE_HOME=/workspace/.cache
+  '';
+
+  # nix.conf so flakes work in ssh sessions too (the image's NIX_CONFIG env is not
+  # forwarded by sshd; nix reads this file regardless of env).
+  home.file.".config/nix/nix.conf".text = ''
+    experimental-features = nix-command flakes
+    accept-flake-config = true
+  '';
 
   programs.direnv = {
     enable = true;


### PR DESCRIPTION
You asked for `ssh codex-pod` back. The Option B rewrite had dropped sshd; this re-adds it the way the original `codex-nix-pvc-uid-pod` spike proved out — **persistent `sshd -D` on `127.0.0.1:2222` reached through a `kubectl exec` + `socat` `ProxyCommand`**. No exposed port, no Service.

Security model: kube RBAC gates the transport (you can only reach the pod if you can already `kubectl exec` into it); sshd adds pubkey auth on top so ssh-native tooling (rsync/scp/git/VS Code Remote-SSH) works.

## Changes

- **image** (`x/codex_pod_image/default.nix`): add `socat` (the in-pod relay endpoint).
- **`home.nix`**: bake `~/.ssh/{authorized_keys,sshd_config}` + `~/.config/nix/nix.conf`. `authorized_keys` = the same workstation `loginKeys` agent-box authorises (`wyrm2`/`atlas`/`rugged`, from `nix/ssh-keys.nix`). Non-root sshd ⇒ `StrictModes`/`UsePAM` off; `SetEnv` restores `PATH` + trust store (sshd sanitizes the env).
- **`deployment.yaml`**: entrypoint plants the outbound key, ensures a persistent host key on the PVC (`/workspace/.sshd`), and `exec sshd -D` as the container main process (keeps it alive + serves ssh).
- **`nix/home/home.nix`**: `ssh codex-pod` matchBlock with the `kubectl exec` + `socat` ProxyCommand (host key unverified — exec-gated transport).

## Verified

- Non-root `sshd` (uid 1000) authenticates a workstation pubkey in this OpenSSH 10.3 image (tested live in the running pod).
- Image builds with `authorized_keys`/`sshd_config`/`nix.conf` baked + `socat` on PATH.

Full `ssh codex-pod` round-trip verified after this deploys.