### PR TITLE
cluster/seaweedfs: fix metrics scraping + alert on under-replication

### DIFF
--- a/cluster/k8s/seaweedfs/monitoring/kustomization.yaml
+++ b/cluster/k8s/seaweedfs/monitoring/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - servicemonitor.yaml
+  - prometheusrule.yaml

--- a/cluster/k8s/seaweedfs/monitoring/prometheusrule.yaml
+++ b/cluster/k8s/seaweedfs/monitoring/prometheusrule.yaml
@@ -1,0 +1,36 @@
+# SeaweedFS replication alert. SeaweedFS does NOT auto-re-replicate
+# under-replicated volumes (neither the operator nor the master self-heals);
+# restoring replica count is the manual `weed shell volume.fix.replication
+# -apply`. Without this alert an unplanned volume-server/node loss silently
+# leaves volumes at 1 copy (replication 001) until a human notices.
+#
+# `SeaweedFS_master_replica_placement_mismatch` is a leader-only, per-volume
+# gauge (labels: collection, id) = 1 when a volume's replica count/placement
+# does not match its target (under- or over-replicated), else 0. Only the
+# leader emits it, so `sum()` counts mismatched volumes cluster-wide.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: seaweedfs-replication
+  namespace: seaweedfs
+  labels:
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: seaweedfs-replication
+      rules:
+        - alert: SeaweedFSReplicaPlacementMismatch
+          expr: sum(SeaweedFS_master_replica_placement_mismatch) > 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "SeaweedFS has {{ $value }} volume(s) off their replica count"
+            description: >-
+              {{ $value }} SeaweedFS volume(s) have not matched their target
+              replica placement for 15m (replication 001 = 2 copies).
+              SeaweedFS does not self-heal — diagnose with `volume.list` and
+              re-replicate with `volume.fix.replication -apply` from a master
+              pod (`weed shell` reads commands on stdin). Re-replication needs a
+              volume server with a free volume slot, so also check for
+              slot-exhausted servers.

--- a/cluster/k8s/seaweedfs/monitoring/servicemonitor.yaml
+++ b/cluster/k8s/seaweedfs/monitoring/servicemonitor.yaml
@@ -4,8 +4,10 @@
 #
 # Metrics ports configured on the Seaweed CR (cluster/seaweed.yaml):
 #   master 9321, volume 9325, filer 9326, s3 9327
-# Each component's Service includes the metrics port; the operator names it
-# "metrics" by default.
+# The seaweedfs-operator names each component's metrics Service port
+# `<component>-metrics` (e.g. `master-metrics`), NOT `metrics` — so each
+# endpoint below must reference that exact name or the ServiceMonitor matches
+# no port and nothing is scraped.
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -18,7 +20,7 @@ spec:
       app.kubernetes.io/component: master
       app.kubernetes.io/name: seaweedfs
   endpoints:
-    - port: metrics
+    - port: master-metrics
       interval: 30s
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -32,7 +34,7 @@ spec:
       app.kubernetes.io/component: volume
       app.kubernetes.io/name: seaweedfs
   endpoints:
-    - port: metrics
+    - port: volume-metrics
       interval: 30s
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -46,7 +48,7 @@ spec:
       app.kubernetes.io/component: filer
       app.kubernetes.io/name: seaweedfs
   endpoints:
-    - port: metrics
+    - port: filer-metrics
       interval: 30s
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -60,5 +62,5 @@ spec:
       app.kubernetes.io/component: s3
       app.kubernetes.io/name: seaweedfs
   endpoints:
-    - port: metrics
+    - port: s3-metrics
       interval: 30s


### PR DESCRIPTION
## What

SeaweedFS metrics were **not reaching Mimir at all** — the ServiceMonitors scrape `port: metrics`, but the seaweedfs-operator names each component's metrics Service port `<component>-metrics` (`master-metrics`, `volume-metrics`, `filer-metrics`, `s3-metrics`). No port match → no scraping. The stale `SeaweedFS_*` metric names in the TSDB are from before an operator port rename. So the cluster has been **blind to all SeaweedFS health**.

This PR:
- Fixes the four ServiceMonitor endpoint port names.
- Adds a `PrometheusRule` alerting on under-replication via `SeaweedFS_master_replica_placement_mismatch` (leader-only, per-volume gauge; `sum(...) > 0 for 15m`).

## Why an alert is needed

SeaweedFS does **not** auto-re-replicate — neither the operator (no repair field in the CRD) nor the master self-heals. An unplanned volume-server/node loss silently leaves volumes at 1 copy (replication `001`) until a human runs `volume.fix.replication -apply`. This alert makes that visible.

## ⚠️ Pre-existing issue this surfaces

As of authoring, **~10 volumes already read `mismatch=1`** — stuck at 1 copy. Verified via `volume.list`: healthy volumes have 2 copies, these have 1. Likely because `volume-0` is at its volume-slot cap (24/24) so re-replication has no free slot to land on. Once metrics flow, this alert will (correctly) fire on it. Remediation (free slots / `volume.fix.replication -apply`) is tracked separately.

## Testing

- `bbr test //cluster/validation/...` → 14/14 pass (`buildbuddy:25b0725c-1bbd-4273-9383-17fe66c4fdbf`)
- `kubectl kustomize` renders all 5 resources; kubeconform passes.
- Metric confirmed present and >0 on the live leader master (`seaweedfs-master-2`).