### PR TITLE
codex-pod: invoke sshd by absolute path

### DIFF
--- a/cluster/k8s/agents/codex-pod/deployment.yaml
+++ b/cluster/k8s/agents/codex-pod/deployment.yaml
@@ -53,7 +53,9 @@ spec:
               install -d -m700 /workspace/.sshd
               [ -f /workspace/.sshd/ssh_host_ed25519_key ] \
                 || ssh-keygen -q -t ed25519 -N "" -f /workspace/.sshd/ssh_host_ed25519_key
-              exec sshd -D -e -f "$HOME/.ssh/sshd_config"
+              # sshd re-execs itself for privsep, so it refuses a PATH-resolved
+              # invocation ("sshd requires execution with an absolute path").
+              exec /bin/sshd -D -e -f "$HOME/.ssh/sshd_config"
           env:
             # Shared BuildBuddy key (bbr reads BUILDBUDDY_API_KEY), reflected into
             # this namespace from shared-secrets/buildbuddy-api-key. Optional so a


### PR DESCRIPTION
Follow-up to #2810. The pod crashlooped with `sshd requires execution with an absolute path` — sshd re-execs itself for privilege separation and refuses a PATH-resolved (`sshd`) invocation. Use `/bin/sshd`. Manifest-only (no image rebuild).