### PR TITLE
haku: unify per-run manifest + notes into one .md with frontmatter

### DIFF
--- a/haku/run.md
+++ b/haku/run.md
@@ -105,9 +105,10 @@ backlogs) you advance a little each run and pick up next time — not a one-pass
   chose not to file and why. Compact/prune old days when stale.
 - **Write the run manifest** — record the run's propagation (every source processed, and how
   each change reached every surface it belongs on) per _Propagation discipline_ in your manual:
-  walk your propagation checklists and write the run record (current method: a structured
-  manifest + notes under `runs/`). This is what proves coverage rather than asserting it; it's
-  the floor, the judgment is yours.
+  walk your propagation checklists and write the run record (current method: one
+  `runs/<date>/<ulid>.md` per run — the structured manifest as YAML frontmatter, free-form
+  reasoning as the body). This is what proves coverage rather than asserting it; it's the floor,
+  the judgment is yours.
 - **Commit and push to `main`** — push **everything** before you finish; your state is your
   only memory and pushing updates what your UI shows. One commit per logical change
   (`scan:` / `intake:` / `log:`). Your UI's backend is a **concurrent writer** (it commits

--- a/haku/state_template/README.md
+++ b/haku/state_template/README.md
@@ -38,7 +38,7 @@ it; if it only makes sense for this person, leave it in their `haku-state`.
 | `log/`                 | empty (`.gitkeep`)                                                                         | per-day run journal `log/YYYY-MM-DD.md`                       |
 | `intake/processed/`    | empty (`.gitkeep`)                                                                         | operator feedback lands in `intake/`; reduced → `processed/`  |
 | `responses/`           | empty (`.gitkeep`)                                                                         | operator affordance answers Haku reduces (below)              |
-| `runs/`                | `README.md`                                                                                | per-run propagation manifests `runs/<date>/<ulid>.{yaml,md}`  |
+| `runs/`                | `README.md`                                                                                | per-run propagation manifests `runs/<date>/<ulid>.md`         |
 | `procedures/`          | the starter passes (README + topical files)                                                | Haku's playbook — read + grow (below)                         |
 | `ui/`                  | the starter multi-surface UI (React SPA + FastAPI backend + Dockerfile)                    | Haku's own UI service, CI-built (below)                       |
 | `items/`               | `README.md` (the example "items" model) + `.gitkeep`                                       | Haku writes one `<slug>.md` per item, if it keeps this format |

--- a/haku/state_template/procedures/propagation/README.md
+++ b/haku/state_template/procedures/propagation/README.md
@@ -6,7 +6,7 @@ for one change-domain: the surfaces I must consider when something in that domai
 
 **Each run, for each set of changes I saw, I walk the relevant checklist(s)** — for each surface,
 decide whether it needs the new info, and record the verdict (including "considered, no change")
-in that run's manifest (`runs/<date>/<ulid>.yaml`: `checklists[]` + `propagation[]`).
+in that run's manifest (`runs/<date>/<ulid>.md` frontmatter: `checklists[]` + `propagation[]`).
 
 These are a **FLOOR, not a ceiling.** They enumerate the surfaces I must not forget; free-form
 sources (a Gmail thread, a Tana note) carry meaning no checklist can pre-list — apply judgment

--- a/haku/state_template/runs/README.md
+++ b/haku/state_template/runs/README.md
@@ -4,15 +4,16 @@ Each run writes a manifest here proving every source was processed and recording
 propagated to every surface it belongs on. The UI's **Runs** tab reads these. See the base
 "Propagation discipline" obligation and `procedures/propagation/`.
 
-Two files per run, ULID-keyed (like `items/`), date-foldered (like `log/`):
+One markdown file per run, ULID-keyed (like `items/`), date-foldered (like `log/`):
+`runs/<YYYY-MM-DD>/<ulid>.md` — the propagation manifest as YAML **frontmatter** (the structured
+spine, CI-validated against `RunManifest` and read by the UI), then free-form reasoning as the
+markdown **body** (rendered in the Runs tab).
 
-- `runs/<YYYY-MM-DD>/<ulid>.yaml` — the structured spine (CI- and UI-readable)
-- `runs/<YYYY-MM-DD>/<ulid>.md` — free-form reasoning (rendered as markdown in the Runs tab)
+## Manifest schema (the `<ulid>.md` frontmatter)
 
-## Manifest schema (`<ulid>.yaml`)
-
-```yaml
-run_id: <ulid> # matches the filename + the .md sibling
+```markdown
+---
+run_id: <ulid> # matches the filename
 date: "YYYY-MM-DD" # operator-local (the log/ date)
 started: <iso8601>
 finished: <iso8601>
@@ -26,8 +27,10 @@ propagation: # change-set → where it landed (the judgment record)
     source: <source>
     surfaces:
       - { surface: "<surface>", action: updated|no_change|n/a, note: "<why>" }
+---
+
+<free-form reasoning for the run — the judgment no checklist can capture>
 ```
 
 `changes_seen: 0` and `action: no_change`/`n/a` are first-class — "considered, didn't apply" is
-recorded, not absent. Keep it lean; it's hand-written each run. The free-form judgment that no
-checklist can capture goes in the `.md` sibling.
+recorded, not absent. Keep the frontmatter lean; it's hand-written each run.

--- a/haku/state_template/ui/README.md
+++ b/haku/state_template/ui/README.md
@@ -54,7 +54,7 @@ FastAPI, port `8080`. Endpoints:
   built from.
 - `GET /api/repo/tree` + `GET /api/repo/blobs` — the generic read-only content proxy the SPA
   composes to read `items/*.md`, `memory/improvements/*.md`, the run manifests
-  (`runs/<date>/<ulid>.{yaml,md}`, paired on the frontend), and any repo markdown at HEAD.
+  (`runs/<date>/<ulid>.md`, frontmatter + body parsed on the frontend), and any repo markdown at HEAD.
 - `PUT/DELETE /api/responses/{scope}/{field}` — record/clear an operator response
   (item status, form answer) as `responses/<scope>/<field>.yaml`.
 - `POST /api/trace/feedback` — append an intake note (`text`, optional `item_id`).

--- a/haku/state_template/ui/backend/app.py
+++ b/haku/state_template/ui/backend/app.py
@@ -141,8 +141,8 @@ def create_app(settings: Settings) -> FastAPI:
     # generic tree+blobs proxy and rendered by the <improvement-board/> garden widget — no
     # bespoke endpoint. See plans/garden-gradient.md → Settled mechanism.
 
-    # The runs surface (runs/<date>/<ulid>.{yaml,md}) composes over the generic tree+blobs proxy —
-    # the frontend pairs each manifest with its prose notes and parses them (client.ts:fetchRuns).
+    # The runs surface (runs/<date>/<ulid>.md) composes over the generic tree+blobs proxy — the
+    # frontend reads each run's manifest frontmatter + prose body and parses them (client.ts:fetchRuns).
     # No bespoke endpoint. RunManifest/RunsResponse stay in models.py as the wire contract.
 
     # The knowledge garden (browse + file read) now composes over the generic content proxy

--- a/haku/state_template/ui/backend/models.py
+++ b/haku/state_template/ui/backend/models.py
@@ -1,7 +1,7 @@
 """Typed models the backend reads from haku-state and serves over JSON.
 
 Each content collection carries thin, typed frontmatter (``items/<slug>.md``,
-``memory/improvements/<id>.md``, ``runs/<date>/<ulid>.yaml``); the validate-state gate
+``memory/improvements/<id>.md``, ``runs/<date>/<ulid>.md``); the validate-state gate
 parses every file through these models so a malformed frontmatter file can't silently
 parse into a wrong shape. Typed values (enum, dates) validate strictly.
 
@@ -105,11 +105,11 @@ class ImprovementDoc(BaseModel):
     summary: str = ""  # ideas carry a one-liner; friction usually omits it
 
 
-# --- Runs surface (runs/<date>/<ulid>.{yaml,md}) -------------------------------
+# --- Runs surface (runs/<date>/<ulid>.md) --------------------------------------
 # Per-run propagation record: proves every source was processed and shows how each change
-# propagated to every surface. The .yaml is the machine-checkable spine; the sibling .md is
-# free-form reasoning (rendered as markdown). See procedures/propagation/ + the base
-# "Propagation discipline" obligation.
+# propagated to every surface. One markdown file per run — this manifest as YAML frontmatter (the
+# machine-checkable spine, validated below), prose reasoning as the body (rendered in the Runs
+# tab). See procedures/propagation/ + the base "Propagation discipline" obligation.
 
 
 class ScannedSource(BaseModel):
@@ -173,7 +173,8 @@ class RunManifest(BaseModel):
     sources: list[RunSource] = Field(default_factory=list)
     checklists: list[RunChecklist] = Field(default_factory=list)
     propagation: list[PropagationEntry] = Field(default_factory=list)
-    notes_md: str = ""  # the sibling .md (raw markdown), attached by reads.read_runs
+    # Prose notes are the markdown *body* of the run's .md, not a manifest field: the frontend
+    # reads them from the body; validate-state checks only this frontmatter.
 
 
 class RunsResponse(BaseModel):

--- a/haku/state_template/ui/backend/test_models.py
+++ b/haku/state_template/ui/backend/test_models.py
@@ -49,9 +49,9 @@ def test_improvement_doc_rejects_bad_weight_kind_and_class():
             ImprovementDoc.model_validate({**base, **bad})
 
 
-# --- run manifests (runs/<date>/<ulid>.yaml) ----------------------------------
-# The runs surface is composed on the frontend now (client.ts pairs each manifest with its .md over
-# the tree+blobs proxy); this schema stays the floor those manifests must satisfy.
+# --- run manifests (runs/<date>/<ulid>.md frontmatter) ------------------------
+# The runs surface is composed on the frontend now (client.ts reads each run's frontmatter + prose
+# body over the tree+blobs proxy); this schema stays the floor those manifests must satisfy.
 
 
 def test_run_manifest_accepts_prose_changes_seen_and_created_action():

--- a/haku/state_template/ui/frontend/src/client.test.ts
+++ b/haku/state_template/ui/frontend/src/client.test.ts
@@ -18,7 +18,7 @@ function stubRepo(tree: unknown, blobs: Record<string, string>) {
   );
 }
 
-describe("fetchRuns (composed over the shared git-store reader)", () => {
+describe("fetchRuns (one .md per run: manifest frontmatter + notes body)", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     resetRepoCache();
@@ -27,29 +27,28 @@ describe("fetchRuns (composed over the shared git-store reader)", () => {
   const RUNS_TREE = {
     sha: "h",
     entries: [
-      { path: "runs/2026-06-29/01RUNAAA.yaml", type: "blob", sha: "a-yaml" },
-      { path: "runs/2026-06-29/01RUNAAA.md", type: "blob", sha: "a-md" },
-      { path: "runs/2026-06-28/01RUNBBB.yaml", type: "blob", sha: "b-yaml" }, // no .md sibling
-      { path: "runs/README.md", type: "blob", sha: "readme" }, // ignored
-      { path: "items/01X.yaml", type: "blob", sha: "item" }, // ignored (not a run)
+      { path: "runs/2026-06-29/01RUNAAA.md", type: "blob", sha: "a" },
+      { path: "runs/2026-06-28/01RUNBBB.md", type: "blob", sha: "b" }, // older
+      { path: "runs/README.md", type: "blob", sha: "readme" }, // no frontmatter → dropped
     ],
   };
   const RUNS_BLOBS: Record<string, string> = {
-    "a-yaml":
-      "run_id: 01RUNAAA\nstarted: '2026-06-29T09:08:00-07:00'\n" +
-      "sources:\n  - {source: gmail, changes_seen: 2}\n  - {source: tana, skipped: 'no egress'}\n",
-    "a-md": "## Run notes\n\nQuiet run.",
-    "b-yaml": "run_id: 01RUNBBB\nstarted: '2026-06-28T08:00:00-07:00'\n", // older; no md
+    a:
+      "---\nrun_id: 01RUNAAA\nstarted: '2026-06-29T09:08:00-07:00'\n" +
+      "sources:\n  - {source: gmail, changes_seen: 2}\n  - {source: tana, skipped: 'no egress'}\n" +
+      "---\n## Run notes\n\nQuiet run.",
+    b: "---\nrun_id: 01RUNBBB\nstarted: '2026-06-28T08:00:00-07:00'\n---\n", // empty body
+    readme: "# Runs\n\nPer-run propagation record. (prose, no frontmatter)",
   };
 
-  it("pairs each run yaml with its sibling md, ignores README/non-runs, sorts newest-first", async () => {
+  it("reads each run's frontmatter + body, drops README, sorts newest-first", async () => {
     stubRepo(RUNS_TREE, RUNS_BLOBS);
     const { runs } = await fetchRuns();
     expect(runs.map((r) => r.run_id)).toEqual(["01RUNAAA", "01RUNBBB"]); // newest `started` first
-    expect(runs[0].notes_md).toMatch(/^## Run notes/);
+    expect(runs[0].notes_md).toMatch(/^## Run notes/); // body → notes
     expect(runs[0].sources.map((s) => s.source)).toEqual(["gmail", "tana"]);
     expect("skipped" in runs[0].sources[1]).toBe(true); // discriminated union preserved
-    expect(runs[1].notes_md).toBe(""); // B has no .md sibling
+    expect(runs[1].notes_md).toBe(""); // B has an empty body
     expect(runs[1].propagation).toEqual([]); // omitted section → default
   });
 });

--- a/haku/state_template/ui/frontend/src/client.ts
+++ b/haku/state_template/ui/frontend/src/client.ts
@@ -1,6 +1,6 @@
 import { parse } from "yaml";
 
-import { invalidateTree, readBlobs, repoFile } from "./repo.ts";
+import { docsUnder, invalidateTree, repoFile } from "./repo.ts";
 import type { FeedbackContext, MetaResponse, RunManifest, RunsResponse } from "./types.ts";
 
 // Same-origin JSON client: the FastAPI backend serves this bundle and the API.
@@ -68,10 +68,11 @@ export async function readResponse(scope: string, field: string): Promise<string
   return typeof parsed.value === "string" ? parsed.value : null;
 }
 
-// Recent per-run propagation manifests, composed over the shared git-store reader (no bespoke
-// /api/runs): pair each `runs/<date>/<ulid>.yaml` with its sibling `.md` prose notes (README.md
-// and dangling `.md` ignored), newest-first by `started`. Missing optional fields default (mirrors
-// the backend RunManifest) so one lean manifest can't crash the table.
+// Recent per-run propagation records. Each run is one `runs/<date>/<ulid>.md`: the manifest as YAML
+// frontmatter, prose notes as the body. `docsUnder` parses both; keep the docs that carry a
+// manifest (a `run_id`) so `runs/README.md` and any dangling note drop out. Newest-first by
+// `started`; missing optional fields default (mirrors the backend RunManifest) so one lean manifest
+// can't crash the table.
 const EMPTY_RUN: Omit<RunManifest, "run_id" | "notes_md"> = {
   date: "",
   started: "",
@@ -82,23 +83,16 @@ const EMPTY_RUN: Omit<RunManifest, "run_id" | "notes_md"> = {
 };
 
 export async function fetchRuns(limit = 20): Promise<RunsResponse> {
-  const blobs = await readBlobs(
-    (e) =>
-      e.path.startsWith("runs/") &&
-      (e.path.endsWith(".yaml") || (e.path.endsWith(".md") && !e.path.endsWith("/README.md")))
-  );
-  // Pair each runs/<date>/<ulid>.yaml manifest with its sibling .md notes (by shared base path).
-  const yamls = new Map<string, string>(); // base → manifest yaml
-  const notes = new Map<string, string>(); // base → prose notes
-  for (const b of blobs) {
-    if (b.path.endsWith(".yaml")) yamls.set(b.path.slice(0, -".yaml".length), b.content);
-    else notes.set(b.path.slice(0, -".md".length), b.content);
-  }
-  const runs = [...yamls]
-    .map(([base, yamlText]): RunManifest => {
-      const m = (parse(yamlText) ?? {}) as Partial<RunManifest>;
-      return { ...EMPTY_RUN, ...m, run_id: m.run_id ?? base, notes_md: notes.get(base) ?? "" };
-    })
+  const runs = (await docsUnder("runs"))
+    .filter((d) => typeof d.data.run_id === "string")
+    .map(
+      (d): RunManifest => ({
+        ...EMPTY_RUN,
+        ...(d.data as Partial<RunManifest>),
+        run_id: d.data.run_id as string,
+        notes_md: d.body,
+      })
+    )
     .sort((a, b) => b.started.localeCompare(a.started));
   return { runs: runs.slice(0, limit) };
 }

--- a/haku/state_template/ui/frontend/src/types.ts
+++ b/haku/state_template/ui/frontend/src/types.ts
@@ -19,7 +19,7 @@ export interface MetaResponse {
 // Improvements are a content collection (memory/improvements/<id>.md) rendered by the
 // <improvement-board/> widget — no wire type; the widget parses frontmatter itself.
 
-// --- Runs surface (runs/<date>/<ulid>.{yaml,md}) ---
+// --- Runs surface (runs/<date>/<ulid>.md) ---
 // Per-run propagation record: each source processed + how each change reached every surface.
 // A source was either scanned (bookmarks + count) or skipped (reason) — a discriminated union
 // (mirrors the backend's ScannedSource | SkippedSource); discriminate on the `skipped` key.


### PR DESCRIPTION
## What

Haku's per-run propagation records used to be **two files per run** — a YAML manifest (`runs/<date>/<ulid>.yaml`) and a sibling `.md` for prose notes. This folds them into a **single `runs/<date>/<ulid>.md`**: the `RunManifest` as YAML frontmatter, the run's reasoning as the markdown body.

This PR updates the ducktape `state_template` (the seed for Haku's live `haku-state` repo); the same change is already live in `haku-state` (deployed, CI green).

## Changes

- **`ui/backend/models.py`** — drop `RunManifest.notes_md`; prose is the markdown *body* now, read by the frontend from the doc body rather than a manifest field. Also reconcile the stale module docstring (it described an `action`/`actions[]` discriminated-union item schema that no longer matches `ItemDoc`).
- **`ui/frontend/src/client.ts`** — `fetchRuns` reads `runs/` through the shared `docsUnder()` reader (one doc per run: frontmatter + body) instead of pairing `.yaml`/`.md` siblings by base path; `runs/README.md` and any frontmatter-less note drop out.
- **`ui/frontend/src/client.test.ts`** — rewritten for the single-`.md` format.
- **`runs/README.md`, `haku/run.md`** — document the single-file format.
- **Stale-reference cleanup** — comments/docs across `test_models.py`, `app.py`, `types.ts`, `procedures/propagation/README.md`, `ui/README.md`, and `README.md` still described the old two-file layout; updated to the single-`.md`-with-frontmatter format.

## Verification

- Template frontend: `tsc` clean, 83 vitest tests pass, prettier + eslint clean.
- `models.py` change validated (identical change is green in `haku-state` CI `validate-state` + backend suite).
- Backend Bazel tests couldn't run in this session (the proxy egress policy blocks `releases.bazel.build`, so `bbr`/`bazelisk` can't fetch the Bazel binary) — CI will run them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LD4L7Z4fZ3yEqTmUMzn8NG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LD4L7Z4fZ3yEqTmUMzn8NG)_