### PR TITLE
secrets: restore rugged z.ai api key (aiquota needs it locally)

### DIFF
--- a/secrets/home/rugged/zai.yaml
+++ b/secrets/home/rugged/zai.yaml
@@ -1,0 +1,30 @@
+comment_unencrypted: |
+  Z.ai GLM Coding Plan API key for rugged — Max tier, 1 quarter sub starting 2026-05-06.
+  Anthropic-compatible endpoint: https://api.z.ai/api/anthropic
+  To use with Claude Code: ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic ANTHROPIC_AUTH_TOKEN=$ZAI_API_KEY claude
+  Key: "sops rugged user"
+zai_api_key: ENC[AES256_GCM,data:v+Fcjbg39mc/uDeCKL5MRLllg2xmuoJBebmeDKatbnbRxhFIf2DfD14ykVmaNDOeOw==,iv:AlmNEfLqWOtL72zVsVNHvwKuSiX0Dic54M5eZ5lX8r8=,tag:Af4LNSymCFiXbuHeICeH+A==,type:str]
+sops:
+  age:
+    - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFQW53Y1R3bURxSExVRHhr
+        c282c0RoMmxtenVOci9TZGpTRE55N0Q1dUU0CmVlRjUraS9USTgrWkpMLzZsSkt2
+        QzJnQnk4a3k5cUZyQ3FwYVpobGw2dTgKLS0tIC9XUkdmdWFGbERSaCtvMHJxeDUy
+        SXI3NWJ2VzhyLzgzUjdHOTdock44TlUKeOYaKAbkHekT7IVpQ2IVWKEZSetAXwMz
+        XsRUmzRPkFZv4p5Yps1/PK4OnplZXR7OiKF+LdLYZGyy7KQp62he1Q==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1qdgn0k59t7ghg3t4gg02g2ppnzp7uz0ddplup38y84hqslcsgsxq3v9tkz
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVRDFGTXJZdnhxT1MycklY
+        bkRHcW9DdDZJdXRIRmphencwYmhkczFKODNNCmlJdUVKczVIZlVqK0RCcmJHNGNx
+        T3c1Y01lR3RPenRlNmNkczYvanJOekkKLS0tIDNFOVk2ZFk3Rkt0cFA2VXN2Wmw3
+        Nkc3cmJrTm5UQ29uRlJhSHVjZGwxT28Kix5RXi7iWdH4jf3ZRJHEkt3OZCnwPj1F
+        CtaQliA/nDQofMUULEzZUn4Q55wSum4fRdGfSDXVP9wz9mHIdB978w==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-05-12T20:20:13Z"
+  mac: ENC[AES256_GCM,data:pT01bouzY1ZcrGHcHyxY4R98wtGcqIJXULOIv6kOrynvZXpY6EDfacO/kQiwHXYsDMxkj00tAJwiPXY04wugztME8sei5LJbwqUWn0cBxqFHRImIMQLoMUEtK8FHuBEwORZB5htuYXnH8w9+9PpdWp/ptEgjJaEA+kcP9suykKI=,iv:X0dlNaoWkUMAprxMr6AoG8jZla3mw6KHzy5iJEufbcs=,tag:948Zm61Q5kO4QphJu8geaQ==,type:str]
+  unencrypted_suffix: _unencrypted
+  version: 3.12.1


### PR DESCRIPTION
Restores `secrets/home/rugged/zai.yaml`, deleted in #2792.

#2792 unified `z-claude` on a z.ai-scoped LiteLLM virtual key and dropped the per-host `secrets/home/rugged/zai.yaml`. But rugged's **aiquota** reads that file to query z.ai's *native* quota endpoint (`aiquota/providers/zai.py`), which needs the real subscription key locally — the LiteLLM virtual key can't substitute. So the deletion broke `sudo nixos-rebuild switch --flake .#rugged`:

```
error: path '.../secrets/home/rugged/zai.yaml' does not exist
```

Restored the file unchanged (ciphertext from `5d3ebfef0^`, the commit before the deletion; still encrypted to the admin + rugged age keys).

Note: `wyrm2` was unaffected — it still has its own `secrets/home/wyrm2/zai.yaml` wired to aiquota the same way.