### PR TITLE
codex-pod: route Codex at LiteLLM instead of ChatGPT sign-in

### DIFF
--- a/cluster/k8s/agents/codex-pod/README.md
+++ b/cluster/k8s/agents/codex-pod/README.md
@@ -83,6 +83,14 @@ this non-root image pod has not) and no boot-time render script:
   it. That Secret
   (`cluster/k8s/agents/shared-secrets/buildbuddy-api-key.sops.yaml`) is reflected
   into `codex-pod` — no per-pod key, just the one shared key.
+- **LiteLLM (Codex model)** — Codex routes to LiteLLM's `chatgpt/` (Codex-account)
+  models instead of an interactive ChatGPT sign-in. The baked `~/.codex/config.toml`
+  defines a `litellm` `model_provider` (`base_url = litellm.allegedly.works/v1`,
+  `wire_api = responses`, `env_key = LITELLM_API_KEY`) and defaults to
+  `gpt-5.5-chatgpt`. `LITELLM_API_KEY` is a dedicated virtual key minted by
+  `tf/gitops/litellm-keys` (alias `codex-pod`, scoped to the oai/chatgpt models with
+  a budget — deleting it is the kill switch), reflected into `codex-pod` and set on
+  the container via `secretKeyRef` (`optional: true`).
 
 ## Follow-ups
 

--- a/cluster/k8s/agents/codex-pod/deployment.yaml
+++ b/cluster/k8s/agents/codex-pod/deployment.yaml
@@ -66,6 +66,17 @@ spec:
                   name: buildbuddy-api-key
                   key: api-key
                   optional: true
+            # LiteLLM virtual key (chatgpt/ oai models) minted by
+            # tf/gitops/litellm-keys and reflected into this namespace. Codex's
+            # baked config.toml points its `litellm` model_provider at this via
+            # env_key=LITELLM_API_KEY, so codex routes to LiteLLM instead of a
+            # ChatGPT sign-in. Optional during the pre-reflection window.
+            - name: LITELLM_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: litellm-key-codex-pod
+                  key: api-key
+                  optional: true
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/tf/gitops/litellm-keys/main.tf
+++ b/tf/gitops/litellm-keys/main.tf
@@ -216,6 +216,42 @@ resource "kubernetes_secret" "dispatcher_classifier" {
 }
 
 # ============================================================================
+# codex-pod — OpenAI/ChatGPT-backend key for the interactive codex agent pod
+# ============================================================================
+# Routes the codex-pod agent's Codex CLI at LiteLLM's chatgpt/ (Codex-account)
+# models instead of an interactive ChatGPT sign-in. Scoped to the same oai lane
+# models as the haku oai lane (gpt-5.4/5.5/codex-spark-chatgpt); deleting this is
+# the kill switch. Reflected into codex-pod, consumed as LITELLM_API_KEY.
+
+resource "litellm_key" "codex_pod" {
+  key_alias       = "codex-pod"
+  models          = local.oai_lane_models
+  max_budget      = 50
+  budget_duration = "30d"
+  metadata = {
+    consumer = "codex-pod"
+  }
+}
+
+resource "kubernetes_secret" "codex_pod" {
+  metadata {
+    name      = "litellm-key-codex-pod"
+    namespace = "litellm"
+    annotations = {
+      description                                                     = "LiteLLM virtual key for the codex-pod agent (chatgpt/ oai models only); reflected into codex-pod as LITELLM_API_KEY"
+      "reflector.v1.k8s.emberstack.com/reflection-allowed"            = "true"
+      "reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces" = "codex-pod"
+      "reflector.v1.k8s.emberstack.com/reflection-auto-enabled"       = "true"
+      "reflector.v1.k8s.emberstack.com/reflection-auto-namespaces"    = "codex-pod"
+    }
+  }
+
+  data = {
+    api-key = litellm_key.codex_pod.key
+  }
+}
+
+# ============================================================================
 # zai-clients — z.ai-scoped key for interactive Claude-Code-on-GLM clients
 # ============================================================================
 # A LiteLLM virtual key for the laptop `z-claude` alias (nix/home/home.nix) and the

--- a/x/codex_pod_image/home.nix
+++ b/x/codex_pod_image/home.nix
@@ -90,7 +90,19 @@ in
   # static home-files and never runs activation — so we bake config.toml directly.
   # Codex reads it from its default CODEX_HOME (~/.codex).
   home.file.".codex/config.toml".source = (pkgs.formats.toml { }).generate "codex-config.toml" {
-    model = "gpt-5.5";
+    # Route Codex at LiteLLM's chatgpt/ (Codex-account) models instead of an
+    # interactive ChatGPT sign-in. `env_key` names the env var carrying the
+    # LiteLLM virtual key (LITELLM_API_KEY, from the reflected litellm-key-codex-pod
+    # secret; see deployment.yaml + tf/gitops/litellm-keys). wire_api=responses:
+    # LiteLLM serves these models over the Responses API (streaming-only).
+    model = "gpt-5.5-chatgpt";
+    model_provider = "litellm";
+    model_providers.litellm = {
+      name = "Cluster LiteLLM";
+      base_url = "https://litellm.allegedly.works/v1";
+      env_key = "LITELLM_API_KEY";
+      wire_api = "responses";
+    };
     model_reasoning_effort = "xhigh";
     approval_policy = "never";
     sandbox_mode = "danger-full-access";


### PR DESCRIPTION
codex in the pod prompted for an interactive **ChatGPT sign-in**. This routes it at **LiteLLM's `chatgpt/` (Codex-account) models** instead.

LiteLLM already serves these via its native `chatgpt/` provider (Codex OAuth backend, Responses API): `gpt-5.4-chatgpt`, `gpt-5.5-chatgpt`, `gpt-5.3-codex-spark-chatgpt` (streaming-only; codex streams by default).

## Changes

- **`tf/gitops/litellm-keys`** — mint a dedicated `codex-pod` virtual key scoped to the oai lane models (same allowlist as the haku oai lane) with a $50/30d budget; reflect it into the `codex-pod` namespace. Deleting the key is the kill switch. Mirrors the existing `haku_lane_oai` pattern exactly.
- **`deployment.yaml`** — set `LITELLM_API_KEY` from the reflected `litellm-key-codex-pod` secret (`secretKeyRef`, `optional`).
- **`home.nix`** — bake a `litellm` `model_provider` (`base_url = litellm.allegedly.works/v1`, `wire_api = responses`, `env_key = LITELLM_API_KEY`) and default `model = gpt-5.5-chatgpt`.

## Rollout note

On merge: the litellm-keys TF mints the key + reflects the secret; the image rebuilds with the new config; Flux rolls the pod (picks up `LITELLM_API_KEY`). If the pod happens to start before the key reflects, one restart picks it up (env is resolved at container start).

Caveat: codex → LiteLLM → ChatGPT backend is a double-hop over the Responses API; will confirm a real codex session works after it deploys.