### PR TITLE
cluster/local-path-provisioner: media-scoped OVH StorageClasses (hdd/ssd)

### DIFF
--- a/cluster/k8s/local-path-provisioner/kustomization.yaml
+++ b/cluster/k8s/local-path-provisioner/kustomization.yaml
@@ -4,4 +4,6 @@ resources:
   - namespace.yaml
   - helmrelease.yaml
   - sc-local-path-ovh.yaml
+  - sc-local-path-ovh-hdd.yaml
+  - sc-local-path-ovh-ssd.yaml
   - sc-local-path-proxmox.yaml

--- a/cluster/k8s/local-path-provisioner/sc-local-path-ovh-hdd.yaml
+++ b/cluster/k8s/local-path-provisioner/sc-local-path-ovh-hdd.yaml
@@ -1,0 +1,21 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-path-ovh-hdd
+provisioner: cluster.local/local-path-provisioner
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+# Media-scoped OVH node-local storage: KS-5 7200rpm HDD data disks. Both keys
+# are ANDed in the same topology term — zone keeps it OVH-scoped (never a
+# non-OVH SSD node such as wyrm2), and `storage.allegedly.works/tier=hdd` is the
+# hardware-keyed node label from cluster/terraform/main/ovh-nodes.tf. Under
+# WaitForFirstConsumer a PVC binds only where an OVH hdd node is schedulable.
+# See cluster/docs/plans/ovh_storage_tiering.md.
+allowedTopologies:
+  - matchLabelExpressions:
+      - key: topology.kubernetes.io/zone
+        values:
+          - hil-ovh
+      - key: storage.allegedly.works/tier
+        values:
+          - hdd

--- a/cluster/k8s/local-path-provisioner/sc-local-path-ovh-ssd.yaml
+++ b/cluster/k8s/local-path-provisioner/sc-local-path-ovh-ssd.yaml
@@ -1,0 +1,21 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-path-ovh-ssd
+provisioner: cluster.local/local-path-provisioner
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+# Media-scoped OVH node-local storage: KS-GAME NVMe data disks. zone (OVH-only)
+# ANDed with the hardware-keyed `storage.allegedly.works/tier=ssd` node label.
+# A PVC on this class binds only where an OVH ssd node is schedulable, else it
+# stays Pending (loud) instead of silently landing on HDD. Reserved for
+# fsync/latency-critical data (Forgejo git, forgejo-db, seaweedfs-filer-db).
+# See cluster/docs/plans/ovh_storage_tiering.md.
+allowedTopologies:
+  - matchLabelExpressions:
+      - key: topology.kubernetes.io/zone
+        values:
+          - hil-ovh
+      - key: storage.allegedly.works/tier
+        values:
+          - ssd

--- a/cluster/k8s/local-path-provisioner/sc-local-path-ovh.yaml
+++ b/cluster/k8s/local-path-provisioner/sc-local-path-ovh.yaml
@@ -5,14 +5,20 @@ metadata:
 provisioner: cluster.local/local-path-provisioner
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
-# TODO(2026-05-28): Decide whether to split OVH local storage into separate
-# HDD-backed KS-5 and SSD/NVMe-backed KS-GAME storage classes. For now,
-# local-path-ovh means "OVH HIL node-local data disk" regardless of media.
-# zone (not region): keep this tied to OVH nodes even if other HIL capacity
-# appears later. The user volume at /var/mnt/seaweedfs-data is declared via
-# Talos UserVolumeConfig in cluster/terraform/main/ovh-nodes.tf.
+# DEPRECATED alias, re-pinned to the same media as local-path-ovh-hdd (KS-5
+# 7200rpm HDD). New OVH PVCs should target local-path-ovh-{hdd,ssd} explicitly;
+# this stays only for the ~40 existing bound PVCs referencing it. Adding the
+# `storage.allegedly.works/tier=hdd` key means a re-provisioned PVC can only land
+# on an OVH hdd node, not silently on a KS-GAME NVMe. `allowedTopologies` is
+# immutable, so applying this needs a one-time
+# `kubectl delete storageclass local-path-ovh` for Flux to recreate it (bound
+# PVCs survive — the SC is only read at provision time).
+# See cluster/docs/plans/ovh_storage_tiering.md.
 allowedTopologies:
   - matchLabelExpressions:
       - key: topology.kubernetes.io/zone
         values:
           - hil-ovh
+      - key: storage.allegedly.works/tier
+        values:
+          - hdd


### PR DESCRIPTION
Stage 0 (Move 2) of the OVH storage tiering plan — the tier node labels are already applied to the live nodes (all five carry `storage.allegedly.works/tier`, KS-5 `hdd` / KS-GAME `ssd`), so it's now safe to land the StorageClasses that consume them.

## What

- **`local-path-ovh-hdd`** — zone `hil-ovh` **and** `tier=hdd` → KS-5 7200rpm HDD data disks.
- **`local-path-ovh-ssd`** — zone `hil-ovh` **and** `tier=ssd` → KS-GAME NVMe. Reserved for fsync/latency-critical data (Forgejo git, `forgejo-db`, `seaweedfs-filer-db`).
- **Re-pin `local-path-ovh`** (deprecated alias) to `= -hdd` — adds the `tier=hdd` key so a re-provisioned existing PVC can't drift onto a KS-GAME NVMe.

Both keys are ANDed in one `matchLabelExpressions` term, so under `WaitForFirstConsumer` a PVC binds only where a node of that media is schedulable — otherwise it stays **Pending (loud)** instead of silently landing on the wrong disk.

## ⚠️ One manual step on merge

`allowedTopologies` is **immutable**, so Flux can't update the existing `local-path-ovh` in place. After merge, run once:

```bash
kubectl delete storageclass local-path-ovh
```

Flux recreates it with the new topology on the next reconcile. **Bound PVCs are unaffected** — the SC is only read at provision time. The two new classes need no such step.

## Nothing moves

No workload reschedules and no PVC rebinds on merge — these classes are only consulted when a *new* PVC provisions. Existing bound PVs keep their node affinity.

## Testing

- `bbr test //cluster/validation/...` → 14/14 pass (`buildbuddy:39d9e464-8a1d-47ed-a8ae-506a97156946`)
- `kubectl kustomize` renders all classes with the expected topologies; kubeconform passes.

Plan: `cluster/docs/plans/ovh_storage_tiering.md`