### PR TITLE
codex-pod: auto-trust codex launch dir (no trust prompt)

### DIFF
--- a/x/codex_pod_image/home.nix
+++ b/x/codex_pod_image/home.nix
@@ -22,7 +22,22 @@ in
   programs.home-manager.enable = true;
   targets.genericLinux.enable = true;
 
-  programs.bash.enable = true;
+  programs.bash = {
+    enable = true;
+    # Codex has no global "trust all": its directory-trust prompt is gated
+    # per-directory (exact-match `[projects."<path>"]`, no ancestor/global option),
+    # and it can't even persist a "Yes" here because config.toml is a read-only
+    # /nix/store symlink. So wrap `codex` to auto-mark the launch dir (git repo
+    # root, else cwd) trusted via `-c`, and never prompt. This is an isolated YOLO
+    # agent pod (danger-full-access, approval=never) — trusting everything is intended.
+    initExtra = ''
+      codex() {
+        local d
+        d="$(command git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || printf '%s' "$PWD")"
+        command codex -c "projects.\"$d\".trust_level=\"trusted\"" "$@"
+      }
+    '';
+  };
   programs.git = {
     enable = true;
     settings.user = {

--- a/x/codex_pod_image/home.nix
+++ b/x/codex_pod_image/home.nix
@@ -25,11 +25,17 @@ in
   programs.bash = {
     enable = true;
     # Codex has no global "trust all": its directory-trust prompt is gated
-    # per-directory (exact-match `[projects."<path>"]`, no ancestor/global option),
-    # and it can't even persist a "Yes" here because config.toml is a read-only
-    # /nix/store symlink. So wrap `codex` to auto-mark the launch dir (git repo
-    # root, else cwd) trusted via `-c`, and never prompt. This is an isolated YOLO
-    # agent pod (danger-full-access, approval=never) — trusting everything is intended.
+    # per-directory (exact-match `[projects."<path>"]`, no ancestor/global option).
+    #
+    # Deviation from agent-box: agent-box runs the activation-based `programs.codex`
+    # module (../../nix/home/codex/), where `home-manager switch` merges the nix base
+    # into a WRITABLE ~/.codex/config.toml and merge.py's PRESERVE_KEYS keeps the
+    # live `projects` block — so codex persists each "Yes" and you answer once per
+    # repo. This pod bakes config.toml as a read-only /nix/store symlink (no
+    # activation, no merge), so codex can't persist a "Yes" and would re-prompt every
+    # session. Instead, wrap `codex` to auto-mark the launch dir (git repo root, else
+    # cwd) trusted via `-c` — it never prompts at all. Isolated YOLO agent pod
+    # (danger-full-access, approval=never), so trusting everything is intended.
     initExtra = ''
       codex() {
         local d


### PR DESCRIPTION
Interactive `codex` prompted **"Do you trust the contents of this directory?"** every session.

Why it kept asking: codex has **no global "trust all"** — I traced its source (`codex-rs/config/src/loader/mod.rs`, `tui/src/lib.rs`): the trust gate is per-directory **exact-match** `[projects."<path>"]` (no ancestor/global, and `--dangerously-bypass-approvals-and-sandbox` explicitly does *not* skip it), and it cannot persist a "Yes" here because `config.toml` is a read-only `/nix/store` symlink.

So this wraps `codex` in the baked `.bashrc` to auto-mark the launch dir (git repo root, else cwd) trusted via `-c projects."<dir>".trust_level="trusted"` — it never prompts. This is an isolated YOLO agent pod (`danger-full-access`, `approval=never`), so trusting everything is intended.

Verified: `-c` accepts the nested trust override (before the subcommand, as the wrapper passes it) and codex runs. The interactive prompt is gated solely on `active_project.trust_level.is_none()`, which the override sets.

(Separate, still open: the cosmetic `hm-session-vars.sh: No such file` login error + `-bash-5.3$` prompt — small follow-up.)