### PR TITLE
cluster/seaweedfs: SSD tier Phase 1 — add hdd+ssd volumeTopology groups

### DIFF
--- a/cluster/k8s/seaweedfs/cluster/seaweed.yaml
+++ b/cluster/k8s/seaweedfs/cluster/seaweed.yaml
@@ -147,8 +147,20 @@ spec:
     hdd:
       # 3 servers on the KS-5 HDD nodes; destination for the migrated bulk.
       # -disk=hdd matches the flat servers' default disk type ("" == hdd,
-      # verified in seaweedfs 4.29 ToDiskType). Same rack as the flat servers
-      # so replication 001 places 2 copies across 2 KS-5 hosts.
+      # verified in seaweedfs 4.29 ToDiskType).
+      #
+      # TODO(rack label is logical, not physical — current state is weird): OVH
+      # actually racks these boxes across THREE racks (verified via the
+      # ovh_dedicated_server data source): 102453=H109A09, 103656+103711=H109B04,
+      # and the ssd nodes 104952+104963=H108B01. This hdd group carries ONE rack
+      # label (matching the flat servers, so volume.move doesn't create transient
+      # same-rack placement mismatches during Phase 2). So `hil-ovh-h109b04` is
+      # accurate for 103656/103711 but WRONG for 102453 (really H109A09). Kept as
+      # a single label deliberately: repl 001 (same-rack, 2 nodes) needs ≥2 nodes
+      # per rack, so a faithful per-rack split would strand the singleton H109A09
+      # (102453, the 3.6 TB disk) with no bulk. Real rack-fault tolerance = split
+      # HDD + repl 010 for bulk ("Path B"), deferred. See
+      # cluster/docs/plans/ovh_storage_tiering.md.
       replicas: 3
       dataCenter: "hil"
       rack: "hil-ovh-h109b04"
@@ -181,7 +193,11 @@ spec:
       # seaweedfs-ovh-ssd StorageClass (diskType=ssd -> -disk=ssd).
       replicas: 2
       dataCenter: "hil"
-      rack: "hil-ovh-ssd"
+      # Real OVH rack — both KS-GAME nodes (104952, 104963) are physically in
+      # H108B01 (verified via the ovh_dedicated_server data source). This is the
+      # one group whose rack label matches physical topology; repl 001 places the
+      # 2 git copies across the 2 nodes in this rack.
+      rack: "hil-ovh-h108b01"
       priorityClassName: stateful-infra
       requests:
         storage: 250Gi

--- a/cluster/k8s/seaweedfs/cluster/seaweed.yaml
+++ b/cluster/k8s/seaweedfs/cluster/seaweed.yaml
@@ -127,6 +127,94 @@ spec:
                 app.kubernetes.io/name: seaweedfs
             topologyKey: kubernetes.io/hostname
 
+  # SSD tiering — Stage 1 of cluster/docs/plans/ovh_storage_tiering.md.
+  #
+  # volumeTopology REPLACES the flat spec.volume above as the volume-server
+  # source: once this is set, the operator (verified 1.0.19) reconciles ONLY
+  # these groups and stops reconciling the flat `seaweedfs-volume` StatefulSet
+  # — it is NOT additive. Two hard constraints from the rehearsal
+  # (2026-07-04, swfs-migtest):
+  #   1. spec.volume MUST stay above (removing it nil-panics the operator, which
+  #      reads m.Spec.Volume.* for topology defaults). It is now a defaults stub;
+  #      no flat StatefulSet is created while volumeTopology is set.
+  #   2. Each group requires dataCenter + rack.
+  #
+  # Migration (Phase 2, run by hand, G-swfs-gated): the pre-existing flat
+  # `seaweedfs-volume` StatefulSet keeps running (orphaned) and still holds the
+  # ~237 GiB bulk; `volume.move` relocates each volume onto the `hdd` group
+  # (2 copies throughout), then the flat StatefulSet + its PVCs are deleted.
+  volumeTopology:
+    hdd:
+      # 3 servers on the KS-5 HDD nodes; destination for the migrated bulk.
+      # -disk=hdd matches the flat servers' default disk type ("" == hdd,
+      # verified in seaweedfs 4.29 ToDiskType). Same rack as the flat servers
+      # so replication 001 places 2 copies across 2 KS-5 hosts.
+      replicas: 3
+      dataCenter: "hil"
+      rack: "hil-ovh-h109b04"
+      priorityClassName: stateful-infra
+      requests:
+        storage: 1800Gi
+        cpu: 100m
+        memory: 512Mi
+      limits:
+        memory: 1536Mi
+      storageClassName: local-path-ovh-hdd
+      metricsPort: 9325
+      extraArgs: ["-disk=hdd"]
+      nodeSelector:
+        storage.allegedly.works/tier: hdd
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/instance: seaweedfs
+                  seaweedfs/topology: hdd
+              topologyKey: kubernetes.io/hostname
+    ssd:
+      # 2 servers on the KS-GAME NVMe nodes; serves Forgejo git via the
+      # seaweedfs-ovh-ssd StorageClass (diskType=ssd -> -disk=ssd).
+      replicas: 2
+      dataCenter: "hil"
+      rack: "hil-ovh-ssd"
+      priorityClassName: stateful-infra
+      requests:
+        storage: 250Gi
+        cpu: 100m
+        memory: 512Mi
+      limits:
+        memory: 1536Mi
+      storageClassName: local-path-ovh-ssd
+      metricsPort: 9328
+      extraArgs: ["-disk=ssd"]
+      # NVMe#2 is one shared XFS pool (this ssd server + forgejo-db + filer-db);
+      # go read-only before the disk fills so the fragile CNPG DBs keep a reserve.
+      minFreeSpacePercent: 10
+      # Overcommit the volume-slot count: -max=0 auto-derives only ~24 slots on
+      # the 419 GB NVMe and SeaweedFS pre-grabs ~2-6 (mostly-empty) volumes per
+      # collection. Thin volumes make over-committing ~free; disk-full is bounded
+      # by minFreeSpacePercent, not the slot cap.
+      maxVolumeCounts: 50
+      nodeSelector:
+        storage.allegedly.works/tier: ssd
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/instance: seaweedfs
+                  seaweedfs/topology: ssd
+              topologyKey: kubernetes.io/hostname
+
   filer:
     # 2-replica HA. The filer is a stateless metadata gateway to the shared
     # postgres2 store (seaweedfs-filer-db), so both replicas serve identical


### PR DESCRIPTION
**Stage 1, Phase 1** of the OVH storage tiering plan. Adds `spec.volumeTopology` `{hdd, ssd}` to the Seaweed CR, **keeping `spec.volume`** as the required defaults stub (removing it panics the operator — rehearsal finding).

## What happens on merge (watch closely, G-swfs)
- Operator brings up **5 empty** volume servers: `seaweedfs-volume-hdd-{0,1,2}` (KS-5) + `seaweedfs-volume-ssd-{0,1}` (KS-GAME).
- The flat `seaweedfs-volume-{0,1,2}` StatefulSet **keeps running, untouched** (same UID, orphaned) — still holds the ~237 GiB bulk at 2 copies.
- Master will list **8 volume servers**. **No data moves** in this phase.

## Config notes
- `hdd`: `-disk=hdd` (== the flat servers' default `""` disk type, verified in 4.29 source), rack `hil-ovh-h109b04` (same as flat → repl `001` spreads copies across 2 KS-5 hosts), `local-path-ovh-hdd`.
- `ssd`: `-disk=ssd`, `minFreeSpacePercent: 10`, `maxVolumeCounts: 50`, `local-path-ovh-ssd`.
- Anti-affinity scoped to `seaweedfs/topology=<group>` (one per host) so it doesn't conflict with the flat pods; hdd fills the 3 KS-5 nodes, ssd the 2 KS-GAME.

## Reversible
Removing `volumeTopology` reverts to flat-only mode — the flat servers are never touched, so the only cleanup would be deleting the empty orphaned topology StatefulSets. **Phase 2** (the `volume.move` evacuation of the flat servers onto the `hdd` group, then their deletion) is a separate, hand-run, G-swfs-gated step — that's the committing one.

## Post-merge checks I'll run
`cluster.check` lists all 8 servers; the 5 topology pods reach Running; G-swfs green (bulk still 2-copy on the flat 3).

## Testing
- **Server-side dry-run** against the live Seaweed CRD: accepted.
- `bbr test //cluster/validation/...` → 14/14 — `buildbuddy:295eeaaa-329b-4ccf-b95d-bfa89605d32b`
- Behavior rehearsed end-to-end on a throwaway cluster (#2821).