### PR TITLE
codex-pod: trust dirs via config file, not -c (fix trust prompt)

### DIFF
--- a/x/codex_pod_image/default.nix
+++ b/x/codex_pod_image/default.nix
@@ -80,11 +80,17 @@ pkgs.dockerTools.buildLayeredImage {
     # Bake the home-manager dotfiles into /home/codex (HOME; the /workspace PVC is
     # mounted elsewhere so it doesn't shadow these). home-manager leaves these dirs
     # 0555; make them writable so the entrypoint can plant id_ed25519 into ~/.ssh
-    # and Codex can write history/sessions/auth into ~/.codex (its baked config.toml
-    # stays a read-only store symlink, which Codex only reads).
+    # and Codex can write history/sessions/auth into ~/.codex.
     mkdir -p home/codex
     cp -a ${homeFiles}/. home/codex/
     chmod 700 home/codex/.ssh home/codex/.codex
+
+    # Replace the read-only /nix/store config.toml symlink with a writable real copy:
+    # the `codex` shell wrapper (home.nix) appends per-directory trust tables to it so
+    # codex never shows its directory-trust prompt.
+    cp --remove-destination "$(readlink -f home/codex/.codex/config.toml)" home/codex/.codex/config.toml
+    chmod 644 home/codex/.codex/config.toml
+
     chown -R 1000:1000 home/codex workspace
 
     cat > etc/passwd <<'PASSWD'

--- a/x/codex_pod_image/home.nix
+++ b/x/codex_pod_image/home.nix
@@ -26,21 +26,28 @@ in
     enable = true;
     # Codex has no global "trust all": its directory-trust prompt is gated
     # per-directory (exact-match `[projects."<path>"]`, no ancestor/global option).
+    # The common dirs (~ and /workspace) are pre-trusted in the baked config.toml
+    # below; this wrapper covers everything else (e.g. cloned repos) by appending
+    # the launch dir (git repo root, else cwd) to config.toml before running codex.
     #
     # Deviation from agent-box: agent-box runs the activation-based `programs.codex`
     # module (../../nix/home/codex/), where `home-manager switch` merges the nix base
-    # into a WRITABLE ~/.codex/config.toml and merge.py's PRESERVE_KEYS keeps the
-    # live `projects` block — so codex persists each "Yes" and you answer once per
-    # repo. This pod bakes config.toml as a read-only /nix/store symlink (no
-    # activation, no merge), so codex can't persist a "Yes" and would re-prompt every
-    # session. Instead, wrap `codex` to auto-mark the launch dir (git repo root, else
-    # cwd) trusted via `-c` — it never prompts at all. Isolated YOLO agent pod
+    # into config.toml and merge.py's PRESERVE_KEYS keeps the live `projects` block —
+    # so codex persists each "Yes" and you answer once per repo. This pod has no
+    # activation; instead the baked config.toml is made writable (default.nix) and we
+    # pre-trust dirs here. `-c projects."<path>".trust_level=...` does NOT work: codex
+    # `-c` keys are naive dotted paths, so the quoted path segment is mis-parsed and
+    # never matches the resolved dir. Writing real TOML tables to the file does work
+    # (verified: it gates project-local config loading). Isolated YOLO agent pod
     # (danger-full-access, approval=never), so trusting everything is intended.
     initExtra = ''
       codex() {
-        local d
+        local cfg="$HOME/.codex/config.toml" d
         d="$(command git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || printf '%s' "$PWD")"
-        command codex -c "projects.\"$d\".trust_level=\"trusted\"" "$@"
+        if [ -w "$cfg" ] && ! grep -qF "[projects.\"$d\"]" "$cfg" 2>/dev/null; then
+          printf '\n[projects."%s"]\ntrust_level = "trusted"\n' "$d" >>"$cfg"
+        fi
+        command codex "$@"
       }
     '';
   };
@@ -138,6 +145,13 @@ in
     shell_environment_policy = {
       "inherit" = "all";
       set.CODEX_AGENT = "1";
+    };
+    # Pre-trust the dirs codex is normally launched from (HOME landing dir + the
+    # /workspace work root) so its directory-trust prompt never fires there. Other
+    # dirs (cloned repos) are appended at launch by the `codex` wrapper above.
+    projects = {
+      "/home/codex".trust_level = "trusted";
+      "/workspace".trust_level = "trusted";
     };
   };
 }


### PR DESCRIPTION
Fixes the trust prompt that #2820 did **not** actually fix.

## Root cause of #2820 failing

#2820's wrapper passed `-c projects."<dir>".trust_level="trusted"`. But codex `-c` keys are **naive dotted paths** (per `codex debug --help`: "dotted path `foo.bar.baz`", only the *value* is TOML-parsed). The quoted path segment `"/home/codex"` is mis-split, so the trust never lands on the resolved directory key — and the prompt kept firing.

## Verified the real mechanism

Writing a proper `[projects."<dir>"]` **TOML table** to `config.toml` flips the trust. Confirmed with a non-TUI oracle: a project-local `.codex/config.toml` override (`model_reasoning_effort`) took effect **only** in the trusted dir (`low`) vs base (`xhigh`) in an untrusted dir — proving the trust flag is read and gates project-local config loading (same gate as the prompt).

## Fix

- `home.nix`: pre-trust `/home/codex` + `/workspace` in the baked config; change the `codex` wrapper to **append** `[projects."<launch dir>"]` (git repo root, else cwd) to `config.toml` before running — covers cloned repos too.
- `default.nix`: bake `config.toml` as a **writable real file** (was a read-only `/nix/store` symlink) so the wrapper can append.

Verified in the built image: `config.toml` is `-rw-r--r--` with `[projects."/home/codex"]` + `[projects."/workspace"]` trusted, and the wrapper appends real TOML.