### PR TITLE
codex-pod: pass secret env (LITELLM/BuildBuddy keys) to ssh sessions

### DIFF
--- a/cluster/k8s/agents/codex-pod/deployment.yaml
+++ b/cluster/k8s/agents/codex-pod/deployment.yaml
@@ -53,6 +53,13 @@ spec:
               install -d -m700 /workspace/.sshd
               [ -f /workspace/.sshd/ssh_host_ed25519_key ] \
                 || ssh-keygen -q -t ed25519 -N "" -f /workspace/.sshd/ssh_host_ed25519_key
+              # sshd strips env; expose the secret env to ssh sessions via
+              # ~/.ssh/environment (sshd_config: PermitUserEnvironment yes). kubectl
+              # exec already inherits the container env, so this is ssh-only.
+              install -m600 /dev/null "$HOME/.ssh/environment"
+              for v in LITELLM_API_KEY BUILDBUDDY_API_KEY; do
+                [ -n "${!v:-}" ] && printf '%s=%s\n' "$v" "${!v}" >>"$HOME/.ssh/environment"
+              done
               # sshd re-execs itself for privsep, so it refuses a PATH-resolved
               # invocation ("sshd requires execution with an absolute path").
               exec /bin/sshd -D -e -f "$HOME/.ssh/sshd_config"

--- a/x/codex_pod_image/home.nix
+++ b/x/codex_pod_image/home.nix
@@ -94,6 +94,11 @@ in
     UsePAM no
     PidFile /tmp/sshd.pid
     Subsystem sftp internal-sftp
+    # sshd sanitizes the environment, so ssh sessions don't inherit the container's
+    # secret env (LITELLM_API_KEY, BUILDBUDDY_API_KEY). The entrypoint writes those
+    # into ~/.ssh/environment at startup; read them here so `codex`/`bbr` work over
+    # ssh (kubectl exec already inherits the container env).
+    PermitUserEnvironment yes
     # sshd sanitizes the environment; pass the tools + trust store that the
     # container Env sets, so ssh sessions match `kubectl exec`.
     SetEnv PATH=/bin SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt GIT_SSL_CAINFO=/etc/ssl/certs/ca-certificates.crt XDG_CACHE_HOME=/workspace/.cache


### PR DESCRIPTION
Found while verifying the trust fix: over `ssh codex-pod`, `codex` failed with **`Missing environment variable: LITELLM_API_KEY`**. sshd sanitizes the environment, so ssh sessions don't inherit the container's secret env (`kubectl exec` does).

Fix: expose the secrets to ssh sessions via `~/.ssh/environment` + `PermitUserEnvironment yes`.

- `home.nix` (sshd_config): `PermitUserEnvironment yes`.
- `deployment.yaml` (entrypoint): write `LITELLM_API_KEY` + `BUILDBUDDY_API_KEY` (whichever are set) to `~/.ssh/environment` at startup.

Verified live in the running pod: a session on a throwaway sshd with `PermitUserEnvironment` + a seeded `~/.ssh/environment` received both keys (`LITELLM=SENTINEL… BB=SENTINEL…`).