### PR TITLE
feat: add Groq provider behind LiteLLM + workstation GROQ_API_KEY env

### DIFF
--- a/cluster/k8s/litellm/app/deployment.yaml
+++ b/cluster/k8s/litellm/app/deployment.yaml
@@ -126,6 +126,12 @@ spec:
                 secretKeyRef:
                   name: litellm-anthropic-key
                   key: api-key
+            # Groq key for the groq upstream models (Llama chat + Whisper ASR).
+            - name: GROQ_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: litellm-groq-key
+                  key: GROQ_API_KEY
             - name: LANGFUSE_OTEL_HOST
               value: "http://langfuse-web.langfuse.svc.cluster.local:3000"
             - name: LANGFUSE_PUBLIC_KEY

--- a/cluster/k8s/litellm/app/generate_litellm.py
+++ b/cluster/k8s/litellm/app/generate_litellm.py
@@ -86,12 +86,33 @@ _CHATGPT_MODELS: list[str] = ["gpt-5.4", "gpt-5.5", "gpt-5.3-codex-spark"]
 ANTHROPIC_MODELS: list[str] = ["claude-sonnet-5", "claude-haiku-4-5"]
 
 
+# Groq (fast open-model inference: Llama chat + Whisper ASR). Key from the
+# GROQ_API_KEY env var (litellm-groq-key secret). Free tier.
+GROQ_CHAT_MODELS: list[str] = ["llama-3.3-70b-versatile", "llama-3.1-8b-instant"]
+GROQ_WHISPER_MODELS: list[str] = ["whisper-large-v3", "whisper-large-v3-turbo"]
+
+
 def _anthropic_entries() -> Iterator[dict]:
     for model in ANTHROPIC_MODELS:
         yield {
             "model_name": model,
             "litellm_params": {"model": f"anthropic/{model}", "api_key": "os.environ/ANTHROPIC_API_KEY"},
             "model_info": {"mode": "chat", "supports_function_calling": True},
+        }
+
+
+def _groq_entries() -> Iterator[dict]:
+    for model in GROQ_CHAT_MODELS:
+        yield {
+            "model_name": model,
+            "litellm_params": {"model": f"groq/{model}", "api_key": "os.environ/GROQ_API_KEY"},
+            "model_info": {"mode": "chat", "supports_function_calling": True},
+        }
+    for model in GROQ_WHISPER_MODELS:
+        yield {
+            "model_name": model,
+            "litellm_params": {"model": f"groq/{model}", "api_key": "os.environ/GROQ_API_KEY"},
+            "model_info": {"mode": "audio_transcription"},
         }
 
 
@@ -149,6 +170,7 @@ def generate() -> str:
     model_list.extend(_zai_anthropic_entries())
     model_list.extend(_chatgpt_entries())
     model_list.extend(_anthropic_entries())
+    model_list.extend(_groq_entries())
 
     # Master key and Langfuse credentials are injected as env vars in the
     # Deployment; not repeated here.

--- a/cluster/k8s/litellm/app/proxy-config.yaml
+++ b/cluster/k8s/litellm/app/proxy-config.yaml
@@ -201,6 +201,32 @@ model_list:
     model_info:
       mode: chat
       supports_function_calling: true
+  - model_name: llama-3.3-70b-versatile
+    litellm_params:
+      model: groq/llama-3.3-70b-versatile
+      api_key: os.environ/GROQ_API_KEY
+    model_info:
+      mode: chat
+      supports_function_calling: true
+  - model_name: llama-3.1-8b-instant
+    litellm_params:
+      model: groq/llama-3.1-8b-instant
+      api_key: os.environ/GROQ_API_KEY
+    model_info:
+      mode: chat
+      supports_function_calling: true
+  - model_name: whisper-large-v3
+    litellm_params:
+      model: groq/whisper-large-v3
+      api_key: os.environ/GROQ_API_KEY
+    model_info:
+      mode: audio_transcription
+  - model_name: whisper-large-v3-turbo
+    litellm_params:
+      model: groq/whisper-large-v3-turbo
+      api_key: os.environ/GROQ_API_KEY
+    model_info:
+      mode: audio_transcription
 litellm_settings:
   drop_params: true
   callbacks:

--- a/cluster/k8s/litellm/secrets/groq-api-key.sops.yaml
+++ b/cluster/k8s/litellm/secrets/groq-api-key.sops.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: litellm-groq-key
+    namespace: litellm
+    annotations:
+        description: Groq API key for LiteLLM's groq upstream models (whisper + Llama chat).
+type: Opaque
+stringData:
+    GROQ_API_KEY: ENC[AES256_GCM,data:OJxxVVuQTvqdfEHJSNVjbnucHJFLOE7J+/zWmylpnhN7Gqq4EIVZUrmsxhrSaYmnmAdDiUsfy+8=,iv:kYMR97elkrlyqndHnO8kHDrXd7CT/mFeUF6V12PfK3s=,tag:aeEFhYyrq3emHe0VgVfRKw==,type:str]
+sops:
+    age:
+        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAySVQwMmxmSktCTVNITWs3
+            WFZwd05nZFNjUG82QUpzQ2VpaVRiRzh1c2pNCjFHUUd5S0NEV2R6ODljMnhXMW5P
+            SGx4a2hncnRxWFB2U3VHOEprUVRTMnMKLS0tIHkrT3liUWpMRHhuRjlybG5mTEdo
+            MElPYUtmTXRpdG9oTGpuTFBqY2pCS3cKRqnmnAzmIb16z4VpcvW1c9xuHCFDwJiu
+            pmiZxixNQD4E+BKhQpu0aUCAcqodlSe5QNoLkcrhf/JwxkMpgzi4wg==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1nywlwepsyfxvyhqwkjquzz02nmus65gf6qewfjju4alym8f7se5qnua8na
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrcDlvck5ZZzl6ZExacUZC
+            czhKcjdQNWxzNStWZ2R6QWI0MDlSTkdRbTJZCmlFOFkrTTZZVlBWOS9sTGNOTXN2
+            b3BxVVdxL3FqVml0NytKZGFQK01GaGMKLS0tIGtzSDNpYVI5Y0xYU01WanZGZVIr
+            d2pMRk1ob1VyRUVIS2RsejZxbS9kdzQKYc4lNkOSpwk1MG7AgOfQhAN05niOeS/e
+            G7SwcZnw5SQzIGSkxOhEaUKOpHpCvArw4tJf4Qt4XTNA58p6x2K/EQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-07-04T10:51:17Z"
+    mac: ENC[AES256_GCM,data:DH9MmKf9DnWew/ZuLqWj0xzFMKyzrPeUM2Di3lNgs8p2OUp5RzltFa2LSLMqgunSCMwSOpJxgR1vByTzAb0l+De1t+C64zuwhHBoCVtcs48KCaK/gozhANyKymNOCTO1xWIcVPxl8aaEJsb4hq0ezojBlZJ2de/4Fh1CwoSjlyo=,iv:L63dOkpD7wbiZNXASO6JS4pr6qtxr5TEA10UQ/jI6M4=,tag:+sV0E8w6WFy1L9dfX8lKiQ==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.1

--- a/cluster/k8s/litellm/secrets/kustomization.yaml
+++ b/cluster/k8s/litellm/secrets/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - anthropic-api-key-eso.yaml
   - zai-api-key-eso.yaml
   - litellm-chatgpt-auth-seed.sops.yaml
+  - groq-api-key.sops.yaml

--- a/nix/home/hosts/rugged.nix
+++ b/nix/home/hosts/rugged.nix
@@ -55,6 +55,13 @@ in
     sandbox.filesystem.allowWrite = lib.mkAfter [ bazeliskCache ];
   };
 
+  ducktape.sopsEnv = {
+    GROQ_API_KEY = {
+      sopsFile = ../../../secrets/home/rugged/groq.yaml;
+      key = "groq_api_key";
+    };
+  };
+
   # SSH keys for wyrm and vps, decrypted from SOPS binary at activation time.
   sops.secrets =
     builtins.listToAttrs (

--- a/nix/home/hosts/wyrm2.nix
+++ b/nix/home/hosts/wyrm2.nix
@@ -33,6 +33,10 @@
       sopsFile = ../../../secrets/home/wyrm2/openai.yaml;
       key = "openai_api_key";
     };
+    GROQ_API_KEY = {
+      sopsFile = ../../../secrets/home/wyrm2/groq.yaml;
+      key = "groq_api_key";
+    };
   };
 
   # Place decrypted z.ai API key where aiquota reads it.

--- a/secrets/home/rugged/groq.yaml
+++ b/secrets/home/rugged/groq.yaml
@@ -1,0 +1,26 @@
+comment_unencrypted: Groq API key (free-tier inference; Llama/Whisper).
+groq_api_key: ENC[AES256_GCM,data:nN9L+4Nqeqf6Lt8InQkUJ+07AX9t2AlYzTHEt6/KqldSbOgQ7dcYZzu2MxL4bu2GL659tqVRvXU=,iv:P3IJttGZqOQU2cLAG+LJNRI6HiQfCuXv8WBj/MfmVWE=,tag:lk7BPy/ZY0SAJoFfhV5ttg==,type:str]
+sops:
+  age:
+    - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZN2l1MU1lR0ZCVnd1d3ZZ
+        QW9rUlFSdGRFajB0Q2MxL0cxRkRSVUo3SGd3CmRQQS9QNTdGaWRGWGxuUUFRSkFZ
+        eFU4bmJlVG5sSnlJNmtVM2c1Q0xxcEUKLS0tIHRIOXpyZC9YeFl2eXZ0MDNucjZZ
+        cEJHUnFwU1BNeUZ3WWZ4aFd6ZmJhNUkKE2bYGsrg36g6SbdRIlzXNyKTxZ2O/TVp
+        jxz/0Df4FQWldeJ1KIrjVdDeIwyWQcg3SR1Qub6ksEmzaE+Fz6RZtg==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1qdgn0k59t7ghg3t4gg02g2ppnzp7uz0ddplup38y84hqslcsgsxq3v9tkz
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVdlVlMTJVQ2xGdTJTZG53
+        clVtSDR1UFQzNTlWM24xWTJTR1BQRlcvUzFZCmdNSGp3MEovWHJ6aW05Vis2S3hY
+        RlVPcGlkL2xFUVZSK1IzSHh0TjV4SU0KLS0tIDRiMHNBaXM1VytuVjdpYnN2ZmlN
+        NzUrYnpSSjdTTjY3QjRDSk9hUXdYVjgK0zswQDWTQBpVaw/wHo9fOOaAzHJbVjh7
+        tB9NepDmSkafgI6zoiamNACX2A29TqfpTv0evczMz4OYN8bZPbcUoA==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-07-04T10:51:17Z"
+  mac: ENC[AES256_GCM,data:kTL1mkZL0CpqWOfJOIy4JrlR0DQqrQNejho3+on5/qkF3dD4CUlPtnksF/k3exouz0YvvuX4xDl+Vv68mwFeKxQbH03Gt4poY58X4UBkjKUUVLJdu33pDSil4KjRoX85LjfxqZYppQYagmHDKrVuBG2U6TchIyyU16c14GtdhgE=,iv:SrzfgV5SkjM2D/zIAJYWJZDcQqYjnJhEMI90uBuQvxE=,tag:TmLsQwohHEza0eFpxINcqQ==,type:str]
+  unencrypted_suffix: _unencrypted
+  version: 3.12.1

--- a/secrets/home/wyrm2/groq.yaml
+++ b/secrets/home/wyrm2/groq.yaml
@@ -1,0 +1,26 @@
+comment_unencrypted: Groq API key (free-tier inference; Llama/Whisper).
+groq_api_key: ENC[AES256_GCM,data:5WD//ojLXGgSGKkc/pyPW3Xmio1VhKruxQTZj73xElCH5dFboVsYqpfWXo+sZB8NPPmLsBpZBtQ=,iv:7WQeX5sgK220mk3olCviHSPmYASOlMOR31CMBTRShPE=,tag:sNMy9n+ML6kWPxxkqysWyw==,type:str]
+sops:
+  age:
+    - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqQzVNMDZuVTNRYzh2dEIz
+        WFpXL3VvdEhSNm5QcnA4Z0Foby8wVGhOQTA4ClZYUGJKNFdaeit0VXFYN3M4NGZJ
+        ZXZjdDd3WllnWUpjMGhnYnlDZWl2ejQKLS0tIG55YjlRRElDYnQ4YTVIT28xeVRj
+        M2dBQjNWcnhRZGFmdkFtWGpOKzZWL2cKgZ2xmG7u7xFaRl6ZFpV9P4o216T7fQgz
+        QIijdzFGYMFmDfqKlKZ8X0jk2fR9MGpw4ewAOQ37w8lqtxJWXkddPA==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age12c2ef6ayydzvmz6k49pyyhtgu2g00nyynmht8y3laqvxn3wya4wselpc4s
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAycFd5ci90UVZnY2dIV2FM
+        azByV25SSWRla2NJWWVDWXdNVDBxRnRGSkU0Ci9TSUs1dHYyRy9yYjM2UFNFZUF5
+        U1VtbktnVlZxbXJnSUdHazErYTlQNzgKLS0tIEQveVg3b0pDb0V0SFFsem5FVWdi
+        LzU2VFhteEZxU3kzVk5ZdG81SG55UkkKMcdkBDEqR73dlg7BC76MiFu7Vwm66cXD
+        Tm8RoBC4yY35Ehe8D1KWObByiOIJEy/8sRCcgANSDVHaSQVfBpfBZg==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-07-04T10:51:17Z"
+  mac: ENC[AES256_GCM,data:o7dLP7gIW+KHERZ4bPCoOaBADQOcSjVAZcZ3ow9d43+OwrqkceifT4Hakw0X8hm4fwk7Q9mg++SHsV3XcNpMH5HUbUufLfZl2EzG01ONt+9U0snLLhvo4o0gVPT8Gw/QM8eMe71dnVKtLEr3YkS9eSTR6MbrZA/8VFhCCsw973I=,iv:ujKGM/fhYwU6264OCDpCPtJYpNFwcitpYYiSCtlrKfg=,tag:kdRIlMPTSDwDxDxEagFjsw==,type:str]
+  unencrypted_suffix: _unencrypted
+  version: 3.12.1


### PR DESCRIPTION
## What
Wires **Groq** (free-tier fast inference: Llama chat + Whisper ASR) as a first-class provider — usable behind LiteLLM **and** as `GROQ_API_KEY` in the workstation shell.

## Changes
**Workstation env** (`GROQ_API_KEY` on rugged + wyrm2):
- `secrets/home/{rugged,wyrm2}/groq.yaml` (sops) + `ducktape.sopsEnv.GROQ_API_KEY` (mirrors the existing `ANTHROPIC`/`OPENAI` pattern).

**LiteLLM**:
- `cluster/k8s/litellm/secrets/groq-api-key.sops.yaml` — litellm-level sops Secret `litellm-groq-key`. **Not** openhands (openhands is suspended; litellm-only keys live at litellm level, like `litellm-chatgpt-auth-seed`).
- `secrets/kustomization.yaml` + `deployment.yaml` `GROQ_API_KEY` secretKeyRef.
- `generate_litellm.py`: Groq models (`llama-3.3-70b-versatile`, `llama-3.1-8b-instant` chat; `whisper-large-v3` + `-turbo` ASR) + `proxy-config.yaml` regenerated.

Two sops copies of the same plaintext key with different age recipients (laptop user key vs cluster-secrets key) — can't be collapsed, since a shell and an in-cluster pod decrypt with different identities.

## Verification
- pre-commit green (ruff, nixfmt, statix, prettier, kubeconform).
- LiteLLM parity test **passed** (BuildBuddy `87824af2`): regenerated `proxy-config.yaml` matches the generator.
- Post-merge: Flux rolls the Secret + Deployment; `home-manager switch` exports `$GROQ_API_KEY`; `/v1/models` lists the groq models.

## Notes
- Gemini deferred (no key yet) — same pattern once a key is provided.
- The ad-hoc repo-root `groq-api-key` plaintext is now redundant — remove in a follow-up after merge.

BAZEL_TEST_INVOCATIONS=buildbuddy:87824af2-1de1-49dd-8567-38eeb6b04774
