### PR TITLE
codex-pod: fix ssh login shell noise (hm-session-vars + prompt)

### DIFF
--- a/x/codex_pod_image/default.nix
+++ b/x/codex_pod_image/default.nix
@@ -57,12 +57,17 @@ let
     ];
   };
 
+  homeConfig = home-manager.lib.homeManagerConfiguration {
+    inherit pkgs;
+    modules = [ ./home.nix ];
+  };
   # home-manager's realized dotfiles tree (~/.ssh/config, ~/.bashrc, direnv, …).
-  homeFiles =
-    (home-manager.lib.homeManagerConfiguration {
-      inherit pkgs;
-      modules = [ ./home.nix ];
-    }).config.home-files;
+  homeFiles = homeConfig.config.home-files;
+  # The generated ~/.bashrc sources ~/.nix-profile/etc/profile.d/hm-session-vars.sh,
+  # which only exists after a real `home-manager switch`. This package holds that
+  # file; symlinking ~/.nix-profile at it (below) makes the source succeed instead
+  # of erroring on every login shell.
+  homeSessionVars = homeConfig.config.home.sessionVariablesPackage;
 in
 pkgs.dockerTools.buildLayeredImage {
   name = "codex-pod";
@@ -84,6 +89,10 @@ pkgs.dockerTools.buildLayeredImage {
     mkdir -p home/codex
     cp -a ${homeFiles}/. home/codex/
     chmod 700 home/codex/.ssh home/codex/.codex
+
+    # ~/.bashrc sources ~/.nix-profile/etc/profile.d/hm-session-vars.sh; point the
+    # profile at the session-vars package so that source succeeds (no activation here).
+    ln -s ${homeSessionVars} home/codex/.nix-profile
 
     # Replace the read-only /nix/store config.toml symlink with a writable real copy:
     # the `codex` shell wrapper (home.nix) appends per-directory trust tables to it so

--- a/x/codex_pod_image/home.nix
+++ b/x/codex_pod_image/home.nix
@@ -49,6 +49,9 @@ in
         fi
         command codex "$@"
       }
+
+      # A real prompt (bash falls back to `-bash-5.3$` with PS1 unset).
+      PS1='\[\e[1;36m\]codex-pod\[\e[0m\]:\[\e[1;34m\]\w\[\e[0m\]\$ '
     '';
   };
   programs.git = {


### PR DESCRIPTION
Cleans up the `ssh codex-pod` login experience:

```
-bash: /home/codex/.nix-profile/etc/profile.d/hm-session-vars.sh: No such file or directory
-bash-5.3$
```

The home-manager-generated `~/.bashrc` sources `~/.nix-profile/etc/profile.d/hm-session-vars.sh`, which only exists after a real `home-manager switch` — this image bakes the dotfiles but never activates, so the source errored and PS1 was unset.

- `default.nix`: symlink `~/.nix-profile` at `config.home.sessionVariablesPackage` (the exact store path `~/.profile` already sources by absolute path), so the `.bashrc` source succeeds.
- `home.nix`: set a `PS1` (`codex-pod:<cwd>$`).

Verified in the built image: `~/.nix-profile` → `…-hm-session-vars.sh`, and `etc/profile.d/hm-session-vars.sh` exists there.