### PR TITLE
haku-ci: grant Haku read-only logs+configmaps (agent-rbac) to debug CI

### DIFF
--- a/cluster/k8s/haku-ci/agent-rbac/flux-kustomization.yaml
+++ b/cluster/k8s/haku-ci/agent-rbac/flux-kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: haku-ci-agent-rbac
+  namespace: flux-system
+  annotations:
+    description: Agent RBAC for haku-ci — read-only pod logs + configmaps for Haku (oidc-ksbx-groups:haku) to debug the CI runner. No secrets/exec/write. Depends on the haku-ci namespace + agent RBAC base ClusterRoles.
+spec:
+  interval: 10m
+  path: ./cluster/k8s/haku-ci/agent-rbac
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  dependsOn:
+    - name: haku-ci
+    - name: claude-rbac

--- a/cluster/k8s/haku-ci/agent-rbac/kustomization.yaml
+++ b/cluster/k8s/haku-ci/agent-rbac/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - rolebinding-logs-configmaps-reader.yaml

--- a/cluster/k8s/haku-ci/agent-rbac/rolebinding-logs-configmaps-reader.yaml
+++ b/cluster/k8s/haku-ci/agent-rbac/rolebinding-logs-configmaps-reader.yaml
@@ -1,0 +1,18 @@
+# Read-only pod logs + configmaps in haku-ci for Haku (group oidc-ksbx-groups:haku),
+# so the agent can debug its own CI runner (build failures, dockerd/act_runner output).
+# Read-only: no secrets (the registration + push tokens stay unreadable), no exec, no
+# write — so this does NOT weaken the "Haku has no write/tamper RBAC in haku-ci" model
+# (cluster/k8s/haku-ci/README.md); it only lets Haku see the logs it produces.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: agent-logs-configmaps-reader
+  namespace: haku-ci
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: logs-configmaps-reader
+subjects:
+  - kind: Group
+    name: oidc-ksbx-groups:haku
+    apiGroup: rbac.authorization.k8s.io

--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -55,6 +55,7 @@ resources:
   - docker-ci/flux-kustomization.yaml
   - docker-ci/agent-rbac/flux-kustomization.yaml
   - haku-ci/flux-kustomization.yaml # Forgejo Actions runner for Haku's in-cluster image builds
+  - haku-ci/agent-rbac/flux-kustomization.yaml # read-only logs/configmaps for Haku to debug its CI
 
   # --- agents ---
   - agents/shared-rbac/flux-kustomization.yaml


### PR DESCRIPTION
Lets Haku read its **own** `haku-ci` runner logs, so it can debug CI failures (like the post-rehome egress regression it just hit) instead of being blind — `pods/log` is currently RBAC-denied to `oidc-ksbx:haku-k8s` in `haku-ci`.

## What

New `cluster/k8s/haku-ci/agent-rbac/` — the standard per-service agent-RBAC pattern (mirrors `kube-system/`, `authentik/`):

- `rolebinding-logs-configmaps-reader.yaml` — binds the existing `logs-configmaps-reader` ClusterRole to group `oidc-ksbx-groups:haku`, in the `haku-ci` namespace.
- `kustomization.yaml` + `flux-kustomization.yaml` (`dependsOn: [haku-ci, claude-rbac]`), wired into the root `cluster/k8s/kustomization.yaml`.

## Scope (why it doesn't weaken the model)

`logs-configmaps-reader` grants **only** `pods/log` + `configmaps` with `get/list/watch` — **read-only**:

- **No secrets** — the runner registration token + `REGISTRY_PUSH_TOKEN` stay unreadable.
- **No `exec`/`attach`/`portforward`, no write, no pod mutation.

So the `haku-ci` trust model (`cluster/k8s/haku-ci/README.md`: "Haku has **no RBAC** … can't tamper with the runner pod or its creds") is unchanged — this only surfaces the logs Haku's own builds already produce. Subject is `haku` only (not the broader sandbox group).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0189a1fUCQnvrMwEx5fedtYd)_