### PR TITLE
haku-egress-proxy: allow haku-ci ingress to the proxy (fix rehome regression breaking ALL haku-ci CI)

### DIFF
--- a/cluster/k8s/agents/haku-egress-proxy/networkpolicy.yaml
+++ b/cluster/k8s/agents/haku-egress-proxy/networkpolicy.yaml
@@ -1,5 +1,8 @@
-# Allow haku-sandbox proxy clients to reach the egress proxy (port 8080) and the
-# Authentik outpost to reach the mitmweb UI (port 8081) for proxy auth.
+# Allow proxy clients (haku-sandbox + haku-ci) to reach the egress proxy (port 8080)
+# and the Authentik outpost to reach the mitmweb UI (port 8081) for proxy auth.
+# haku-ci was rehomed onto this proxy (cluster/k8s/haku-ci) as a client but its ingress
+# was missed — without it the runner/dind get `proxyconnect ... i/o timeout` on every
+# egress and all haku-ci builds fail.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -14,6 +17,9 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: haku-sandbox
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: haku-ci
       ports:
         - port: 8080
           protocol: TCP


### PR DESCRIPTION
**Regression fix — the merged rehome (#2799) broke all haku-ci CI, `main` included.**

## Root cause (confirmed from `dind` logs)

```
Error getting v2 registry: Get "https://registry-1.docker.io/v2/":
  proxyconnect tcp: dial tcp 10.111.75.119:8080: i/o timeout
```

`10.111.75.119:8080` is the `haku-egress-proxy` ClusterIP. #2799 rehomed `haku-ci` onto the proxy as a **client** (force-proxy CCNP + `HTTP(S)_PROXY` env + CA), but never added `haku-ci` to the proxy's **ingress** NetworkPolicy — which allows port 8080 only `from: haku-sandbox`. So every `haku-ci` → proxy connection times out, and `dockerd` can't pull base images / the runner can't fetch actions. Both post-rehome runs failed (`validate` on `main` hung ~11 min then failed; the Bazel branch failed in 16 s); every pre-rehome run passed. haku-sandbox was unaffected (it's in the ingress list — my smoke test through the proxy worked).

## Fix

Add `haku-ci` to the port-8080 ingress `from` list in `allow-authentik-egress-proxy-ingress`. One rule, no other change.

## After merge

Flux reconciles → `haku-ci` can reach the proxy → I'll re-kick the `bazel` run (and `main`'s `validate` self-heals) and continue the Bazel-migration green loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0189a1fUCQnvrMwEx5fedtYd)_