### PR TITLE
haku-egress-proxy: stream large bodies + raise memory (fix OOMKill breaking haku-ci builds)

### DIFF
--- a/cluster/k8s/agents/haku-egress-proxy/deployment.yaml
+++ b/cluster/k8s/agents/haku-egress-proxy/deployment.yaml
@@ -55,6 +55,13 @@ spec:
             - "8081"
             - --set
             - confdir=/mitmproxy-data
+            # Stream (don't buffer) response bodies over 1 MB. dind pulls
+            # multi-hundred-MB image layers through here; buffering them OOM-killed
+            # the container (exit 137, connection refused mid-restart → haku-ci
+            # builds failed). We gate at the CONNECT/host level (the allowlist), not
+            # blob content, so streaming loses no enforcement.
+            - --set
+            - stream_large_bodies=1m
             # Passthrough (raw TCP, no TLS interception) for Anthropic's control
             # plane. The haku-worker drives Managed Agents sessions over a
             # long-lived HTTP/2 stream to api.anthropic.com; mitmproxy's
@@ -79,10 +86,13 @@ spec:
           resources:
             requests:
               cpu: 50m
-              memory: 128Mi
+              memory: 256Mi
             limits:
               cpu: 500m
-              memory: 512Mi
+              # Headroom over the 512Mi that OOM-killed under haku-ci build traffic;
+              # with stream_large_bodies the working set stays bounded, this is slack
+              # for concurrent connections + the dynamic cert cache.
+              memory: 1Gi
       volumes:
         - name: mitmproxy-ca
           secret:


### PR DESCRIPTION
Second-order regression from onboarding haku-ci onto the proxy: once the ingress (#2833) let haku-ci reach it, the **proxy itself started `OOMKilled`ing** under build traffic.

## Root cause (confirmed from pod status)

```
lastTerminated: reason=OOMKilled exit=137   (limit: memory 512Mi)
```

mitmproxy **buffers response bodies** by default. `dind` pulling multi-hundred-MB image layers (`catthehacker/ubuntu`, `python:3.13-slim`, …) through the TLS-intercepting proxy blows past 512Mi → OOMKilled → `dind` gets `connection refused` while it restarts → builds fail. haku-sandbox's `pip`/`npx` traffic was far lighter, so this only appeared once haku-ci's image pulls hit it.

## Fix

- `--set stream_large_bodies=1m` — bodies over 1 MB **stream** instead of buffering. We enforce at the CONNECT/host level (the allowlist CNP), not blob content, so this loses no enforcement — it just stops mitmproxy from holding whole image layers in RAM.
- memory limit **512Mi → 1Gi** (request 128→256Mi) for headroom (concurrent connections + the dynamic-cert cache).

## Note

Squid (#2798) streams and caches to disk by design, so it supersedes this band-aid once its ssl-bump chain is verified in-cluster. This unblocks haku-ci CI on the current mitmproxy in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0189a1fUCQnvrMwEx5fedtYd)_