### PR TITLE
seaweedfs evacuate: robust move confirmation (stderr merge + re-verify)

### DIFF
--- a/cluster/scripts/seaweedfs_evacuate_flat_volume.py
+++ b/cluster/scripts/seaweedfs_evacuate_flat_volume.py
@@ -39,17 +39,29 @@ class Move:
 
 
 def _kubectl(args: list[str], stdin: str | None = None, retries: int = 3) -> str:
-    """Run kubectl, retrying transient apiserver timeouts (etcd contention)."""
+    """Run kubectl with stderr merged into stdout, retrying transient apiserver
+    timeouts (etcd contention). `weed`'s glog status lines (`moved volume N`) go
+    to stderr while progress goes to stdout, so callers need the merged stream.
+    The 600s ceiling covers a full 16 GB volume.move over nebula."""
     for attempt in range(retries):
-        result = subprocess.run(
-            ["kubectl", "-n", NAMESPACE, *args], check=False, input=stdin, capture_output=True, text=True, timeout=180
-        )
+        try:
+            result = subprocess.run(
+                ["kubectl", "-n", NAMESPACE, *args],
+                check=False,
+                input=stdin,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                timeout=600,
+            )
+        except subprocess.TimeoutExpired:
+            raise SystemExit(f"kubectl {' '.join(args)} exceeded 600s; re-run to resume (idempotent)") from None
         if result.returncode == 0:
             return result.stdout
-        if "Timeout" in result.stderr and attempt < retries - 1:
+        if "Timeout" in result.stdout and attempt < retries - 1:
             time.sleep(3 * (attempt + 1))
             continue
-        raise SystemExit(f"kubectl {' '.join(args)} failed: {result.stderr.strip()}")
+        raise SystemExit(f"kubectl {' '.join(args)} failed:\n{result.stdout.strip()[-800:]}")
     raise SystemExit(f"kubectl {' '.join(args)} timed out after {retries} attempts")
 
 
@@ -142,8 +154,13 @@ def apply_move(move: Move, master: str) -> None:
         f" -target {peer_address(move.target)} -volumeId {move.volume_id}"
     )
     out = weed_shell(["lock", command, "unlock"], master)
-    if f"moved volume {move.volume_id}" not in out:
-        raise SystemExit(f"volume.move {move.volume_id} did not confirm:\n{out}")
+    if f"moved volume {move.volume_id}" in out:
+        return
+    # The exec stream can truncate while the move still completes server-side, so
+    # confirm authoritatively: the source no longer holds the volume.
+    if move.source not in volume_locations(master).get(move.volume_id, []):
+        return
+    raise SystemExit(f"volume.move {move.volume_id} did not confirm:\n{out[-800:]}")
 
 
 def under_replicated(master: str) -> int:


### PR DESCRIPTION
Follow-up fix to the Stage 1 Phase 2 evacuation tool (merged in #2834).

## Problem
`weed shell volume.move` prints its `moved volume N` success line to **stderr**, but `_kubectl` returned only stdout. `apply_move` checked stdout for that line and false-failed on the very first move — even though the volume had actually moved (verified: it was already on its new server with 2 copies).

## Fix
- Merge stderr into stdout in `_kubectl` so the confirmation line is visible.
- Add a 600s timeout ceiling (covers a full 16 GB volume.move over nebula) with a clear "re-run to resume" message — the tool is idempotent.
- `apply_move` re-verify fallback: if the confirmation line isn't in the (possibly truncated) exec stream, re-query `volume.list` and treat "source no longer holds the volume" as authoritative success.

## Verification
Ran live end-to-end: evacuated all 24 volumes off `seaweedfs-volume-0` onto the `hdd` topology group, under-replicated stayed **0** throughout, `volume-0` now holds 0 volumes.