### PR TITLE
chore(openclaw): revive gateway-secrets (materialize the provider keys)

### DIFF
--- a/cluster/k8s/agents/openclaw/gateway-namespace/flux-kustomization.yaml
+++ b/cluster/k8s/agents/openclaw/gateway-namespace/flux-kustomization.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openclaw-gateway-namespace
   namespace: flux-system
 spec:
-  suspend: true
+  suspend: false
   interval: 1h
   path: ./cluster/k8s/agents/openclaw/gateway-namespace
   prune: false

--- a/cluster/k8s/agents/openclaw/gateway-secrets/flux-kustomization.yaml
+++ b/cluster/k8s/agents/openclaw/gateway-secrets/flux-kustomization.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openclaw-gateway-secrets
   namespace: flux-system
 spec:
-  suspend: true
+  suspend: false
   interval: 10m
   path: ./cluster/k8s/agents/openclaw/gateway-secrets
   prune: true

--- a/cluster/k8s/agents/openclaw/sandbox/flux-kustomization.yaml
+++ b/cluster/k8s/agents/openclaw/sandbox/flux-kustomization.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openclaw-sandbox
   namespace: flux-system
 spec:
-  suspend: true
+  suspend: false
   interval: 10m
   path: ./cluster/k8s/agents/openclaw/sandbox
   prune: true


### PR DESCRIPTION
## What
Un-suspend `openclaw-gateway-secrets` so its sops-encrypted provider keys — **Gemini, OpenAI, Anthropic, Telegram** — reconcile into the cluster and become `kubectl`-readable (currently dormant: OpenClaw was never deployed, so no live secrets).

Flux gates `openclaw-gateway-secrets` on `openclaw-gateway-namespace` and `openclaw-sandbox` (both suspended → blocked reconciliation), so this un-suspends those two as well. Both are **lightweight** (namespace / RBAC / quota — no workloads/pods). The cluster-wide deps (`external-secrets-config`, `reflector`) are already active.

## Why
Recover the keys — especially **Gemini** — to wire into LiteLLM (see #2828 and the `TODO(gemini-litellm)` there). The only existing copy is the admin+cluster-secrets-encrypted sops in this kustomization, undecryptable from a workstation; reviving it materializes the Secrets in `openclaw-gateway` so they can be read.

## Post-merge
Flux reconciles `gateway-namespace` → `sandbox` → `gateway-secrets`; the four Secrets land in `openclaw-gateway` and are readable via `kubectl get secret -n openclaw-gateway`.

## Verification
- pre-commit green (prettier, kubeconform).
- `kubectl get kustomization -n flux-system` (post-merge): the three should move to `True`.

BAZEL_TEST_INVOCATIONS=none: Flux kustomization suspend flips; no Bazel targets