### PR TITLE
feat(litellm): add Gemini provider (key + current models)

### DIFF
--- a/cluster/k8s/litellm/app/deployment.yaml
+++ b/cluster/k8s/litellm/app/deployment.yaml
@@ -132,6 +132,12 @@ spec:
                 secretKeyRef:
                   name: litellm-groq-key
                   key: GROQ_API_KEY
+            # Google AI (Gemini) key for the gemini upstream chat models.
+            - name: GEMINI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: litellm-gemini-key
+                  key: GEMINI_API_KEY
             - name: LANGFUSE_OTEL_HOST
               value: "http://langfuse-web.langfuse.svc.cluster.local:3000"
             - name: LANGFUSE_PUBLIC_KEY

--- a/cluster/k8s/litellm/app/generate_litellm.py
+++ b/cluster/k8s/litellm/app/generate_litellm.py
@@ -91,6 +91,19 @@ ANTHROPIC_MODELS: list[str] = ["claude-sonnet-5", "claude-haiku-4-5"]
 GROQ_CHAT_MODELS: list[str] = ["llama-3.3-70b-versatile", "llama-3.1-8b-instant"]
 GROQ_WHISPER_MODELS: list[str] = ["whisper-large-v3", "whisper-large-v3-turbo"]
 
+# Google AI (Gemini). Key from the GEMINI_API_KEY env var (litellm-gemini-key
+# secret). Current chat lineup per generativelanguage.googleapis.com/v1beta/models
+# (2026-07): gemini-3.x previews + gemini-3.5-flash, the stable 2.5 pair, and the
+# -latest aliases that auto-point at the newest generation.
+GEMINI_MODELS: list[str] = [
+    "gemini-3.1-pro-preview",
+    "gemini-3.5-flash",
+    "gemini-2.5-pro",
+    "gemini-2.5-flash",
+    "gemini-pro-latest",
+    "gemini-flash-latest",
+]
+
 
 def _anthropic_entries() -> Iterator[dict]:
     for model in ANTHROPIC_MODELS:
@@ -113,6 +126,15 @@ def _groq_entries() -> Iterator[dict]:
             "model_name": model,
             "litellm_params": {"model": f"groq/{model}", "api_key": "os.environ/GROQ_API_KEY"},
             "model_info": {"mode": "audio_transcription"},
+        }
+
+
+def _gemini_entries() -> Iterator[dict]:
+    for model in GEMINI_MODELS:
+        yield {
+            "model_name": model,
+            "litellm_params": {"model": f"gemini/{model}", "api_key": "os.environ/GEMINI_API_KEY"},
+            "model_info": {"mode": "chat", "supports_function_calling": True},
         }
 
 
@@ -171,6 +193,7 @@ def generate() -> str:
     model_list.extend(_chatgpt_entries())
     model_list.extend(_anthropic_entries())
     model_list.extend(_groq_entries())
+    model_list.extend(_gemini_entries())
 
     # Master key and Langfuse credentials are injected as env vars in the
     # Deployment; not repeated here.

--- a/cluster/k8s/litellm/app/proxy-config.yaml
+++ b/cluster/k8s/litellm/app/proxy-config.yaml
@@ -227,6 +227,48 @@ model_list:
       api_key: os.environ/GROQ_API_KEY
     model_info:
       mode: audio_transcription
+  - model_name: gemini-3.1-pro-preview
+    litellm_params:
+      model: gemini/gemini-3.1-pro-preview
+      api_key: os.environ/GEMINI_API_KEY
+    model_info:
+      mode: chat
+      supports_function_calling: true
+  - model_name: gemini-3.5-flash
+    litellm_params:
+      model: gemini/gemini-3.5-flash
+      api_key: os.environ/GEMINI_API_KEY
+    model_info:
+      mode: chat
+      supports_function_calling: true
+  - model_name: gemini-2.5-pro
+    litellm_params:
+      model: gemini/gemini-2.5-pro
+      api_key: os.environ/GEMINI_API_KEY
+    model_info:
+      mode: chat
+      supports_function_calling: true
+  - model_name: gemini-2.5-flash
+    litellm_params:
+      model: gemini/gemini-2.5-flash
+      api_key: os.environ/GEMINI_API_KEY
+    model_info:
+      mode: chat
+      supports_function_calling: true
+  - model_name: gemini-pro-latest
+    litellm_params:
+      model: gemini/gemini-pro-latest
+      api_key: os.environ/GEMINI_API_KEY
+    model_info:
+      mode: chat
+      supports_function_calling: true
+  - model_name: gemini-flash-latest
+    litellm_params:
+      model: gemini/gemini-flash-latest
+      api_key: os.environ/GEMINI_API_KEY
+    model_info:
+      mode: chat
+      supports_function_calling: true
 litellm_settings:
   drop_params: true
   callbacks:

--- a/cluster/k8s/litellm/secrets/gemini-api-key.sops.yaml
+++ b/cluster/k8s/litellm/secrets/gemini-api-key.sops.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: litellm-gemini-key
+    namespace: litellm
+    annotations:
+        description: Google AI (Gemini) API key for LiteLLM gemini upstream chat models.
+type: Opaque
+stringData:
+    GEMINI_API_KEY: ENC[AES256_GCM,data:nFJIAy+7pBiQQ3asKtFDUJtziMdo6lGbggJtimPHcCcnYJKQAoEE,iv:1vp5A7wt2effBxnzGEsOizLD/IRhWh3nBs127QmsWtE=,tag:IZ0LmlngkTcPGBz5DYC7HQ==,type:str]
+sops:
+    age:
+        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3dll3QVNSRWFhSlF1ZTFz
+            U3JFV1NjbTRyWTFWOWdHd0prUWloL2lxWHpzCll2UUQwUEVGdDZWcUFnY3hwUGlw
+            c3BKUUlEMmVZSWRhRlh4TlU2d1hLL0EKLS0tIHZqOUdLbzhGUytCaVR1VnhGdnU2
+            cVVNYjVwWTBZcVhUb3R1MG1ZRk5JTVUKxlRX65v58b/TxZzmkhCjzx0I1Od2C8XU
+            /bysfDrTq++cszV0j+uUbJmpSnPFM9+JQvUmbG+K9VwdLOelazoCpQ==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1nywlwepsyfxvyhqwkjquzz02nmus65gf6qewfjju4alym8f7se5qnua8na
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWSmJ1a0pCNzU4YnNqcjBl
+            cXFoZEwzanBSS2N2SnQ5cXM5SVlYeDN1L2tNCjZsOWVLRmJ4bHh2dk1WODhoMDU1
+            TnhvekprM3N6a0lnK0JJNkY3dEZNV1kKLS0tIGRXTlRiSTBHWHROZ0pLd2JpeSt5
+            Tno5NDM5MjhxMkdJN3R4bzJDNVdQSXcK7138EvzRvH3bcEjpv0tEJ6aPqtUr00b9
+            t05XduUrdCBVkb7DiCaqv+kznQ3mVGgzeOszFYtKjK9vktmwXXgsHg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-07-04T12:58:11Z"
+    mac: ENC[AES256_GCM,data:PtOuwMtDTpzIioJhOoC55S+hVVNhSXaL5loOigDSayX0Pk4QMmS6H/KzJMKIC2u2KPPXPtKKENsNTEBgR04vJQMiKoL2q1mdFcEWrpX5lYlMqfPEfXx6xr/7hXtFqMc0WHUw6i92eQPUdcdrIBB5Tjv4dEemmYpcvvXBDgMscFY=,iv:Or9+wqSXJzkb9w88okG7BFk+QVWKSQ3Ruv3PwE20PEo=,tag:XDm6BLJPjgX3R6FhOhgkxQ==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.1

--- a/cluster/k8s/litellm/secrets/kustomization.yaml
+++ b/cluster/k8s/litellm/secrets/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - zai-api-key-eso.yaml
   - litellm-chatgpt-auth-seed.sops.yaml
   - groq-api-key.sops.yaml
+  - gemini-api-key.sops.yaml


### PR DESCRIPTION
## What
Wires **Google AI (Gemini)** into LiteLLM behind a litellm-level sops Secret `litellm-gemini-key` (`GEMINI_API_KEY`), mirroring the Groq pattern from #2828.

The key was recovered from the revived **openclaw** `gateway-secrets` (#2837 un-suspended it; #2838 fixed the `harbor`-namespace blocker so it reconciled). Read from the live `openclaw-gemini-api-key` Secret, then re-sops-encrypted to `admin + cluster-secrets` (litellm-level — not borrowed; openclaw is a separate app).

## Models
Current chat lineup per the Gemini API (`generativelanguage.googleapis.com`, 2026-07):
`gemini-3.1-pro-preview`, `gemini-3.5-flash`, `gemini-2.5-pro`, `gemini-2.5-flash`, plus `gemini-{pro,flash}-latest` aliases.

## Changes
- `cluster/k8s/litellm/secrets/gemini-api-key.sops.yaml` (new) + `secrets/kustomization.yaml`.
- `deployment.yaml`: `GEMINI_API_KEY` secretKeyRef.
- `generate_litellm.py`: `GEMINI_MODELS` + `_gemini_entries()` + `proxy-config.yaml` regenerated.

## Verification
- pre-commit green (ruff, prettier, kubeconform).
- LiteLLM parity test **passed** (BuildBuddy `9f8c8735`).
- Post-merge: Flux rolls the Secret + Deployment; `/v1/models` lists the gemini models.

BAZEL_TEST_INVOCATIONS=buildbuddy:9f8c8735-4ed5-4cb0-b314-76a0d5125974