### PR TITLE
cluster docs: reflect completed SeaweedFS volume-tiering migration

### DIFF
--- a/cluster/README.md
+++ b/cluster/README.md
@@ -83,14 +83,17 @@ All storage is region-local — no cross-site synchronous replication. Key
 classes below (curated — SSOT is the `StorageClass` manifests under `k8s/`,
 e.g. `k8s/{local-path-provisioner,openebs-lvm}/`, plus CSI Helm values):
 
-| StorageClass         | Provisioner            | Region    | Notes                                                                                       |
-| -------------------- | ---------------------- | --------- | ------------------------------------------------------------------------------------------- |
-| `local-path-proxmox` | local-path-provisioner | `proxmox` | Proxmox-single CNPG DBs; node-pinned app data on Proxmox nodes                              |
-| `local-path-ovh`     | local-path-provisioner | `hil-ovh` | OVH-HA CNPG DBs; SeaweedFS volume servers; node-pinned app data on OVH nodes                |
-| `seaweedfs-ovh`      | SeaweedFS CSI          | `hil-ovh` | **Default for app data volumes** — not node-pinned, pods reschedule freely; POSIX/S3-backed |
-| `lvm-proxmox-ssd`    | OpenEBS LVM CSI        | `proxmox` | NVMe thin provisioning                                                                      |
-| `lvm-proxmox-hdd`    | OpenEBS LVM CSI        | `proxmox` | HDD thin provisioning                                                                       |
-| `proxmox-csi-retain` | Proxmox CSI            | `proxmox` | Block storage via Proxmox API                                                               |
+| StorageClass         | Provisioner            | Region    | Notes                                                                                                |
+| -------------------- | ---------------------- | --------- | ---------------------------------------------------------------------------------------------------- |
+| `local-path-proxmox` | local-path-provisioner | `proxmox` | Proxmox-single CNPG DBs; node-pinned app data on Proxmox nodes                                       |
+| `local-path-ovh-hdd` | local-path-provisioner | `hil-ovh` | OVH KS-5 HDD tier: SeaweedFS bulk (`hdd`) volume servers, OVH-HA CNPG DBs, node-pinned bulk app data |
+| `local-path-ovh-ssd` | local-path-provisioner | `hil-ovh` | OVH KS-GAME NVMe tier: SeaweedFS hot (`ssd`) volume servers; SSD-pinned DBs                          |
+| `local-path-ovh`     | local-path-provisioner | `hil-ovh` | Deprecated alias, re-pinned to `local-path-ovh-hdd`                                                  |
+| `seaweedfs-ovh`      | SeaweedFS CSI          | `hil-ovh` | **Default for app data volumes** — not node-pinned, pods reschedule freely; POSIX/S3-backed (HDD)    |
+| `seaweedfs-ovh-ssd`  | SeaweedFS CSI          | `hil-ovh` | NVMe-backed SeaweedFS (`diskType: ssd`) — Forgejo git hot tier                                       |
+| `lvm-proxmox-ssd`    | OpenEBS LVM CSI        | `proxmox` | NVMe thin provisioning                                                                               |
+| `lvm-proxmox-hdd`    | OpenEBS LVM CSI        | `proxmox` | HDD thin provisioning                                                                                |
+| `proxmox-csi-retain` | Proxmox CSI            | `proxmox` | Block storage via Proxmox API                                                                        |
 
 Proxmox CSI needs VLAN access to Proxmox API. OpenEBS LVM is constrained to nodes
 with the `openebs-proxmox-ssd` / `openebs-proxmox-hdd` volume groups (currently Proxmox nodes only).

--- a/cluster/docs/plan.md
+++ b/cluster/docs/plan.md
@@ -85,7 +85,8 @@ returns (not independently parked):
       is the one workload that can't roll without a brief SeaweedFS-wide blip); pin the
       tofu-controller runners (blocked on centralizing the ~22 copy-pasted
       `runnerPodTemplate`s) and the cross-repo augur ingest job; then the structural
-      etcd-on-NVMe move. Full RCA + remediation tracking:
+      etcd-on-NVMe move — Stage 2 of <plans/ovh_storage_tiering.md>, whose SeaweedFS
+      volume-tiering foundation landed 2026-07. Full RCA + remediation tracking:
       <lessons_learned/2026_06_19_etcd_hdd_io_contention.md>.
 - [ ] **haku-ci Docker Hub pull-through cache** (replace the external-CDN egress
       allows). The haku-ci runner's rootless dind pulls base images from Docker

--- a/cluster/docs/runbooks/rolling_seaweedfs_volume_pvc.md
+++ b/cluster/docs/runbooks/rolling_seaweedfs_volume_pvc.md
@@ -1,9 +1,15 @@
 # Runbook: rolling a SeaweedFS volume-server PVC
 
-This procedure is the safe way to delete and recreate the `local-path-ovh`
-PVC of one SeaweedFS volume-server pod — e.g. as part of renaming the OVH
-node it lives on, swapping in new hardware, or recovering from a corrupt
-local disk.
+This procedure is the safe way to delete and recreate the local-path PVC of
+one SeaweedFS volume-server pod — e.g. as part of renaming the OVH node it
+lives on, swapping in new hardware, or recovering from a corrupt local disk.
+
+Since the 2026-07 storage-tiering migration the volume layer runs as two
+`volumeTopology` groups, so the StatefulSet and PVC names depend on the
+node's tier: KS-5 nodes host `seaweedfs-volume-hdd-*`
+(`mount0-seaweedfs-volume-hdd-<ordinal>`, class `local-path-ovh-hdd`); KS-GAME
+nodes host `seaweedfs-volume-ssd-*` (`…-ssd-…`, class `local-path-ovh-ssd`).
+Substitute the right tier below.
 
 **Why this runbook exists**: On 2026-06-02 we did three of these PVC deletes
 back-to-back across pilots 2–4 of the OVH node rename project without
@@ -45,14 +51,15 @@ just runs to completion by removing `-n` and waiting).
 kubectl cordon <node>
 kubectl drain <node> --ignore-daemonsets --delete-emptydir-data
 
-# Identify the StatefulSet ordinal pinned to that node:
+# Identify the tier StatefulSet + ordinal pinned to that node:
 kubectl get pods -n seaweedfs -o wide | grep seaweedfs-volume
-# e.g. seaweedfs-volume-1 lives on ovh-ns103656
+# e.g. seaweedfs-volume-hdd-2 lives on ovh-ns103656 (KS-5 → hdd group)
 
-# Patch the Seaweed CR to scale only that ordinal out:
-# (depends on operator; safest: scale the volume server StatefulSet to 0
-# replicas via the Seaweed CR's volume.count or via direct kubectl scale)
-kubectl scale statefulset -n seaweedfs seaweedfs-volume --replicas=<N-1>
+# Scale that tier's StatefulSet down by one (seaweedfs-volume-hdd or
+# seaweedfs-volume-ssd). The operator reconciles replicas from the Seaweed CR's
+# volumeTopology.<tier>.replicas, so for a lasting change lower it there; a
+# direct kubectl scale is fine for a transient roll (operator will restore it).
+kubectl scale statefulset -n seaweedfs seaweedfs-volume-<tier> --replicas=<N-1>
 ```
 
 (Alternative: just delete the volume-server pod and let the SS recreate it
@@ -81,8 +88,8 @@ re-replication is exactly the failure mode we hit.
 ### 4. Delete the PVC and let it rebind on the renamed/new node
 
 ```bash
-kubectl delete pvc -n seaweedfs mount0-seaweedfs-volume-<ordinal>
-# local-path-ovh is hostname-pinned in the HelmRelease nodePathMap; if
+kubectl delete pvc -n seaweedfs mount0-seaweedfs-volume-<tier>-<ordinal>
+# local-path-ovh-<tier> is hostname-pinned in the HelmRelease nodePathMap; if
 # you're renaming the node, update nodePathMap first so the new PV lands
 # in the right hostPath after rebind.
 ```
@@ -108,13 +115,13 @@ fix should be clean within a few minutes.
 
 ## Caveat: rack labels
 
-As of 2026-06-02 all three OVH volume servers advertise the same rack id
-(`hil-ovh-h109b04`). `001` replication then falls back to "any other
-DataNode" rather than "another rack" — i.e. we have single-node tolerance,
-not rack tolerance. Until rack labels are fixed (see
-`cluster/docs/plan.md` Next Actions), treat **any concurrent loss of two
-volume-server pods or their PVCs as a data-loss event** regardless of what
-the policy nominally says.
+Each topology group's servers share one rack id: the `hdd` group's three
+KS-5 servers advertise `hil-ovh-h109b04`, the `ssd` group's two KS-GAME
+servers advertise `hil-ovh-h108b01`. `001` means "2 copies, 2 DataNodes, 1
+rack" — by design here, so it's **single-node tolerance within a tier, not
+rack tolerance**. Treat **any concurrent loss of two volume-server pods or
+their PVCs in the same tier as a data-loss event** regardless of what the
+policy nominally says.
 
 ## Quick sanity checks
 


### PR DESCRIPTION
The 2026-07 storage-tiering migration split the flat `seaweedfs-volume` StatefulSet into `hdd` + `ssd` `volumeTopology` groups and retired the flat servers. Three docs were left stale — one actively broken:

- **`runbooks/rolling_seaweedfs_volume_pvc.md`** (was broken): drove operators to `kubectl scale statefulset seaweedfs-volume` and `mount0-seaweedfs-volume-N` on `local-path-ovh` — all now gone. Retargeted to the per-tier StatefulSets/PVCs (`seaweedfs-volume-{hdd,ssd}`, `mount0-…-{hdd,ssd}-N`, `local-path-ovh-{hdd,ssd}`) and reframed the rack caveat as single-node-tolerance-within-a-tier (each tier group shares one rack, which is what `001` requires).
- **`README.md`** storage table: SeaweedFS volume servers no longer live on `local-path-ovh` (now a deprecated alias → `-hdd`). Added the live media-scoped classes: `local-path-ovh-{hdd,ssd}` and `seaweedfs-ovh-ssd`.
- **`plan.md`**: linked the etcd-on-NVMe TODO to Stage 2 of `plans/ovh_storage_tiering.md`.

Docs only. Companion to #2842 (plan-doc trim).