### PR TITLE
lessons_learned: SeaweedFS stale FUSE mount cache after volume-server evacuation

### DIFF
--- a/cluster/docs/lessons_learned/2026_07_04_seaweedfs_stale_mount_cache_after_evacuation.md
+++ b/cluster/docs/lessons_learned/2026_07_04_seaweedfs_stale_mount_cache_after_evacuation.md
@@ -1,0 +1,98 @@
+# SeaweedFS stale FUSE mount cache after volume-server evacuation (2026-07-04)
+
+## Summary
+
+During OVH storage tiering Stage 1 Phase 2 we evacuated the three flat SeaweedFS
+volume servers (`volume.move` onto the new `hdd` topology group), verified every
+volume was 2-copy on the `hdd` servers, then **deleted the flat `seaweedfs-volume`
+StatefulSet + its PVCs**. Shortly after, git operations against Forgejo started
+failing intermittently:
+
+- `git clone`/`ls-remote` over SSH: ~1 in 5 attempts returned `Forgejo: Failed to
+execute git command`.
+- `git push` (both Forgejo and, reported by the user, `gaffer-private`):
+  `remote: unpack-objects died of signal 7` → `remote unpack failed` → `remote
+rejected (unpacker error)`. **Signal 7 is SIGBUS.**
+
+## Root cause
+
+The Forgejo git repos live on a SeaweedFS RWX PVC served through a `weed mount`
+FUSE client (the `seaweedfs-csi-driver-mount` DaemonSet). That client caches each
+volume's location (a `vidMap`: volume id → volume-server address).
+
+`volume.move` relocated the chunks and the master's location index updated
+correctly (`volume.list` showed every volume on `seaweedfs-volume-hdd-*`). But the
+long-lived FUSE clients — running since **before** the migration — kept serving
+their **cached** locations, still pointing moved chunks at
+`seaweedfs-volume-{0,1,2}`. Once we deleted the flat StatefulSet, those pod/service
+DNS names stopped resolving, so a read of any chunk whose cached location was a flat
+server failed with:
+
+```text
+read http://seaweedfs-volume-1.seaweedfs-volume-peer.seaweedfs:8444/305,... failed:
+  dial tcp: lookup seaweedfs-volume-1... no such host
+fetching chunk ...ducktape.git/objects/pack/pack-219a...idx: ... no such host
+```
+
+git reads pack indexes via `mmap`; an I/O error on a memory-mapped page is delivered
+as **SIGBUS**, which killed `upload-pack`/`unpack-objects`.
+
+**Why it did not self-heal:** the client retried the _same_ dead hosts with
+exponential backoff and never re-resolved from the master. A SeaweedFS client only
+re-looks-up a volume's location gracefully when the old server is **alive** and
+answers "volume not found" (HTTP 404). A **deleted** server (DNS `no such host`)
+never triggers the re-lookup — so the stale cache is permanent until the mount is
+refreshed.
+
+## Blast radius
+
+3 of 5 `seaweedfs-csi-driver-mount` pods held stale caches (707 / 416 / 55 errors).
+Both Forgejo replicas were affected (hence the intermittency — SSH load-balances
+across them). Other `seaweedfs-ovh` consumers on the same mounts (paperless, a
+grocy backup Job, litellm's auth PVC, a codex workspace) were latent risks.
+
+## The mistake (ordering, not the refresh itself)
+
+The evacuation procedure was **move → verify → delete**. The missing step was
+refreshing (or letting self-heal) the FUSE clients **while the emptied servers were
+still alive**. We deleted the servers before any client had re-resolved, and the
+alive-but-empty server — the graceful fallback that turns a stale read into a clean
+re-lookup — no longer existed.
+
+## Correct sequence (retire a volume server with no window)
+
+Server deletion must be the **last, quiescence-gated** step:
+
+1. `volume.move` all data off the server — it is now empty but **stays running**.
+2. Verify 2-copy on the destination group (**G-swfs**).
+3. **Refresh clients while the emptied server is still alive.** Either passively
+   (clients self-heal on the next read: the alive-but-empty server returns 404 →
+   client re-looks-up → reads from the destination group) optionally nudged by a
+   grace period, or deterministically by **rolling the consumer pods**. Because the
+   old server still resolves, there is no window — every read resolves to either the
+   alive-empty old server (→ re-lookup) or the new copy.
+4. Confirm the emptied server sees **no more volume-data requests** in its logs
+   (all clients have re-resolved).
+5. **Only then** delete the StatefulSet + PVCs.
+
+## Recovery (from the already-broken state)
+
+Once the servers are gone there is no zero-window fix — the window already exists.
+Refresh the stale clients:
+
+- **Rolling the consumer pod** refreshes its mount: NodeUnpublish tears down the
+  stale `weed mount` subprocess, NodePublish respawns a fresh one that rebuilds the
+  `vidMap` from the master. Verified: after `kubectl -n forgejo rollout restart
+deploy/forgejo`, stale errors dropped to 0, `ls-remote` went 8/8, and a real
+  push (`unpack-objects`) succeeded. Repeated for paperless + codex-pod; all mount
+  pods reached 0 stale errors.
+- Deleting the `seaweedfs-csi-driver-mount` pods also works but is more disruptive
+  (it breaks every mount on the node). The DaemonSet is `updateStrategy: OnDelete`
+  precisely because restarting a mount is disruptive — prefer rolling consumers.
+
+## Prevention
+
+- Volume-server retirement runbook updated with the "keep the emptied server alive,
+  refresh clients, then delete" sequence: <../runbooks/rolling_seaweedfs_volume_pvc.md>.
+- The OVH tiering plan's Stage 2 (which retires/moves volume servers again) carries
+  the same gotcha: <../plans/ovh_storage_tiering.md>.

--- a/cluster/docs/plans/ovh_storage_tiering.md
+++ b/cluster/docs/plans/ovh_storage_tiering.md
@@ -167,6 +167,21 @@ count** (`-max=0` → disk size ÷ `volumeSizeLimitMB`, 16 GB here), not raw spa
 419 GB NVMe yields only ~24 slots. Re-replication needs a server with a **free slot**, so a
 slot-full server (`volume-0` at 24/24) cannot receive replicas even with disk free.
 
+**GOTCHA — never delete a volume server before its clients re-resolve (bit us 2026-07-04).**
+`weed mount` FUSE clients cache each volume's location and only re-look-up gracefully when the
+old server is **alive** and returns "volume not found"; a **deleted** server (DNS `no such
+host`) leaves the cache permanently stale, so reads I/O-error and git's `mmap` turns that into
+**SIGBUS** (`unpack-objects died of signal 7`). After `volume.move` + deleting the flat
+`seaweedfs-volume` StatefulSet, both Forgejo replicas' mounts kept pointing moved chunks at the
+gone `seaweedfs-volume-{1,2}` and pushes/clones failed intermittently. So server deletion is the
+**last, quiescence-gated** step: (1) move data off (server stays running, empty); (2) verify
+2-copy (**G-swfs**); (3) refresh clients **while the emptied server is still alive** — roll the
+consumer pods (NodeUnpublish→NodePublish respawns the mount with a fresh vidMap) or let them
+self-heal via the alive-empty server's 404→re-lookup; (4) confirm the emptied server logs no
+more volume-data requests; (5) **only then** delete the StatefulSet + PVCs. **Stage 2 retires
+and re-provisions volume-server nodes again — it must follow this order.** Full RCA:
+<../lessons_learned/2026_07_04_seaweedfs_stale_mount_cache_after_evacuation.md>.
+
 ## Data-disk mount rename (fixing the backwards `/var/mnt/seaweedfs-data` path)
 
 Today the OVH data disk is a UserVolume named `seaweedfs-data`, and the general

--- a/cluster/docs/runbooks/rolling_seaweedfs_volume_pvc.md
+++ b/cluster/docs/runbooks/rolling_seaweedfs_volume_pvc.md
@@ -123,6 +123,26 @@ rack tolerance**. Treat **any concurrent loss of two volume-server pods or
 their PVCs in the same tier as a data-loss event** regardless of what the
 policy nominally says.
 
+## Caveat: retiring a volume server (refresh FUSE clients before you delete it)
+
+The steps above **roll** a PVC — the volume-server pod keeps its identity, so its
+hostname keeps resolving. **Deleting a volume server outright** (removing its
+StatefulSet, e.g. retiring the flat servers or reprovisioning a node in Stage 2 of
+the tiering plan) is different and bit us on 2026-07-04: long-lived `weed mount`
+FUSE clients cache each volume's location and only re-resolve gracefully when the
+old server is **alive** and returns "volume not found". A **deleted** server (DNS
+`no such host`) leaves the cache permanently stale → reads I/O-error → git `mmap`
+→ **SIGBUS** (`unpack-objects died of signal 7`).
+
+So make server deletion the **last, quiescence-gated** step: move the data off
+(server stays running, empty) → verify 2-copy → **refresh the FUSE clients while
+the emptied server is still alive** (roll the consumer pods, or let them self-heal
+on the alive-empty server's 404→re-lookup) → confirm the emptied server logs no
+more volume-data requests → _only then_ delete the StatefulSet + PVCs. Recovery if
+you already deleted too early: `kubectl rollout restart` the consumer workloads
+(NodeUnpublish→NodePublish respawns each mount with a fresh vidMap). Full RCA:
+<../lessons_learned/2026_07_04_seaweedfs_stale_mount_cache_after_evacuation.md>.
+
 ## Quick sanity checks
 
 ```bash


### PR DESCRIPTION
## What happened
After Stage 1 Phase 2 of the OVH tiering migration (evacuate flat SeaweedFS volume servers → delete the flat StatefulSet + PVCs), git pushes/clones to Forgejo began failing **intermittently** with `unpack-objects died of signal 7` (SIGBUS) and `Forgejo: Failed to execute git command`. Same symptom hit a `gaffer-private` push.

## Root cause
Long-lived `weed mount` FUSE clients cache each volume's location. `volume.move` relocated the chunks (master index updated correctly), but the clients kept pointing moved chunks at `seaweedfs-volume-{0,1,2}`. Once we **deleted** those servers, their DNS names stopped resolving → chunk reads I/O-errored → git's `mmap` turned that into **SIGBUS**. It never self-healed: a SeaweedFS client only re-resolves gracefully off an **alive** server's 404, not a DNS `no such host`. 3 of 5 mount pods were stale; both Forgejo replicas affected (hence intermittent).

## The fix / prevention
The mistake was **ordering**, not the refresh. Server deletion must be the last, quiescence-gated step: move data (server stays running, empty) → verify 2-copy → **refresh clients while the emptied server is still alive** (roll consumers, or self-heal via the alive-empty server's 404→re-lookup) → confirm the server is idle → *only then* delete.

**Recovery** (from the already-broken state): `kubectl rollout restart` the consumer workloads — NodeUnpublish/NodePublish respawns each mount with a fresh vidMap. Verified: forgejo stale-errors → 0, `ls-remote` 8/8, real push succeeds; repeated for paperless + codex-pod; all mount pods at 0 stale errors.

## Changes
- New `lessons_learned/2026_07_04_seaweedfs_stale_mount_cache_after_evacuation.md` (full RCA).
- Gotcha + correct sequence added to `plans/ovh_storage_tiering.md` (Stage 2 retires servers again — must follow this order).
- Caveat added to `runbooks/rolling_seaweedfs_volume_pvc.md`.

Docs only. Prod already recovered (consumers rolled).