### PR TITLE
seaweedfs-operator: upgrade 1.0.19 → 1.0.30 (chart 0.1.22 → 0.1.33)

### DIFF
--- a/cluster/k8s/seaweedfs/operator/helmrelease.yaml
+++ b/cluster/k8s/seaweedfs/operator/helmrelease.yaml
@@ -14,7 +14,7 @@ spec:
   chart:
     spec:
       chart: seaweedfs-operator
-      version: "0.1.22" # operator v1.0.19, latest stable as of 2026-05-15
+      version: "0.1.33" # operator v1.0.30 (latest stable as of 2026-07-04)
       sourceRef:
         kind: HelmRepository
         name: seaweedfs-operator


### PR DESCRIPTION
Phase 2.5 of the OVH storage tiering plan.

## Why
- **1.0.20** — nil-safe `spec.volume` fallback in the topology startup script → lets us drop the `spec.volume` stub (follow-up PR, gated on this landing healthy).
- **1.0.28** — native volume-server evacuation controller (drain-before-scaledown).

## Compatibility (verified against the chart/CRD at tag `seaweedfs-operator-0.1.33`)
- Values keys we set (`replicaCount`, `webhook.enabled`) unchanged.
- Operator image → `chrislusf/seaweedfs-operator:1.0.30` (image-level `registry: chrislusf`; the `global.imageRegistry` default went `"chrislusf"`→`""` but that only overrides when set).
- Seaweed CRD retains `spec.volume` + `spec.volumeTopology` (+`dataCenter`); several additive new CRDs (S3 IAM, backups, restores) applied via `crds: CreateReplace`.
- **Data plane stays on the CR-pinned `chrislusf/seaweedfs:4.29`** — the upgrade only rolls the operator controller pod, not master/volume/filer.

## Post-merge watch
After Flux reconciles: operator pod on 1.0.30 & Ready; Seaweed CR reconciles without churning the data-plane StatefulSets; G-swfs green (0 under-replicated). If the new operator does re-render any StatefulSet, it rolls with pod identity preserved (no stale-mount risk) — I'll watch and gate on G-swfs.