### PR TITLE
forgejo: VolSync migration scaffolding for git → SSD tier (Phase 3, inert)

### DIFF
--- a/cluster/k8s/forgejo/app/kustomization.yaml
+++ b/cluster/k8s/forgejo/app/kustomization.yaml
@@ -5,5 +5,6 @@ resources:
   - httproute.yaml
   - ciliumenvoyconfig.yaml
   - git-storage-pvc.yaml
+  - volsync-git-ssd-migration.yaml
   - poddisruptionbudget.yaml
 # OAuth OIDC credentials provisioned by tf/gitops/sso-providers/ as a k8s Secret.

--- a/cluster/k8s/forgejo/app/volsync-git-ssd-migration.yaml
+++ b/cluster/k8s/forgejo/app/volsync-git-ssd-migration.yaml
@@ -1,0 +1,86 @@
+# One-time migration of Forgejo git repos from seaweedfs-ovh (HDD tier) to
+# seaweedfs-ovh-ssd (KS-GAME NVMe) — Phase 3 of
+# cluster/docs/plans/ovh_storage_tiering.md. Same VolSync rsync-TLS pattern as
+# cluster/k8s/grocy/*/app/volsync-backup.yaml.
+#
+# copyMethod: Direct — no VolumeSnapshotClass is installed for SeaweedFS, so the
+# source mover bind-mounts the live git PVC. The ReplicationSource ships paused:
+#   - pre-seed (Forgejo live): set paused:false — rsyncs the ~1 GiB hdd->ssd with
+#     zero downtime; a torn pack here is corrected by the final sync.
+#   - cutover: scale Forgejo to 0, bump trigger.manual -> a fast delta sync against
+#     a now-quiescent source, then repoint the HelmRelease claimName to
+#     forgejo-git-rwx-ssd. Runbook: the plan's Phase 3.
+#
+# mover UID/GID 1000 matches Forgejo's git user (pod fsGroup=1000) so the copied
+# repos stay readable. Delete these three objects (and the old forgejo-git-rwx
+# PVC) once the cutover is verified.
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: forgejo-git-rwx-ssd
+  namespace: forgejo
+  annotations:
+    description: Forgejo git repos on the SeaweedFS SSD tier (Phase 3 target; replaces forgejo-git-rwx on HDD)
+spec:
+  accessModes: ["ReadWriteMany"]
+  storageClassName: seaweedfs-ovh-ssd
+  resources:
+    requests:
+      storage: 50Gi
+---
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationDestination
+metadata:
+  name: forgejo-git-ssd-migration
+  namespace: forgejo
+spec:
+  rsyncTLS:
+    destinationPVC: forgejo-git-rwx-ssd
+    copyMethod: Direct
+    serviceType: ClusterIP
+    moverSecurityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+      seccompProfile:
+        type: RuntimeDefault
+    moverAffinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: topology.kubernetes.io/zone
+                  operator: In
+                  values: ["hil-ovh"]
+---
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: forgejo-git-ssd-migration
+  namespace: forgejo
+spec:
+  sourcePVC: forgejo-git-rwx
+  # Inert until the migration: unpause to pre-seed, bump trigger.manual to cut over.
+  paused: true
+  trigger:
+    manual: preseed-1
+  rsyncTLS:
+    copyMethod: Direct
+    keySecret: volsync-rsync-tls-forgejo-git-ssd-migration
+    address: volsync-rsync-tls-dst-forgejo-git-ssd-migration.forgejo.svc
+    port: 8000
+    moverSecurityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+      seccompProfile:
+        type: RuntimeDefault
+    moverAffinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: topology.kubernetes.io/zone
+                  operator: In
+                  values: ["hil-ovh"]

--- a/cluster/k8s/seaweedfs-csi/sc-seaweedfs-ovh-ssd.yaml
+++ b/cluster/k8s/seaweedfs-csi/sc-seaweedfs-ovh-ssd.yaml
@@ -12,6 +12,9 @@ metadata:
 provisioner: seaweedfs-csi-driver
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
+# SeaweedFS CSI expansion is a collection-quota bump — enable it (parity with the
+# seaweedfs-ovh class) so a growing PVC (e.g. Forgejo git) can be resized in place.
+allowVolumeExpansion: true
 parameters:
   # CSI v1.4.14 maps `diskType`→`weed mount -disk` and passes `replication`
   # through (verified against pkg/driver/mounter.go).


### PR DESCRIPTION
Phase 3 prep of the OVH storage tiering plan — move Forgejo git repos from `seaweedfs-ovh` (HDD) to `seaweedfs-ovh-ssd` (KS-GAME NVMe) using **VolSync rsync-TLS**, the cluster's established PVC-migration tool (same pattern as `cluster/k8s/grocy/*/app/volsync-backup.yaml`).

**This PR is inert** — no data moves and Forgejo is untouched:
- `forgejo-git-rwx-ssd` PVC (RWX, `seaweedfs-ovh-ssd`, 50 Gi) — the SSD target.
- `ReplicationDestination` — rsync-TLS receiver, `copyMethod: Direct` (no `VolumeSnapshotClass` on SeaweedFS), mover pinned to `hil-ovh`, UID/GID **1000** to match Forgejo's git user (pod `fsGroup=1000`).
- `ReplicationSource` with **`paused: true`** — nothing syncs until we unpause.

## Cutover (separate windowed step, when ready)
1. **Pre-seed (zero downtime):** set `paused: false` → rsyncs ~1 GiB hdd→ssd while Forgejo serves. A torn pack here is corrected by the final sync.
2. **Window (~1–2 min):** `flux suspend hr forgejo` + scale to 0 → bump `trigger.manual` for a fast delta sync against the quiesced source → verify repo count + `git fsck` sample.
3. Repoint `helmrelease.yaml` `claimName` → `forgejo-git-rwx-ssd`, `flux resume` (applies repoint + scales back to 2).
4. Verify clone/push, PVC bound on `seaweedfs-ovh-ssd`, git collection on `seaweedfs-volume-ssd-*`.

**Rollback:** revert the `claimName` commit — the source PVC is untouched by `Direct` reads. Delete the old PVC + these CRs once verified.

Possible gotcha to check at pre-seed: any forgejo-namespace NetworkPolicy blocking the mover↔mover rsync on `:8000` (grocy's same-namespace movers work, so likely fine).