### PR TITLE
forgejo: unpause git→SSD pre-seed (zero downtime)

### DIFF
--- a/cluster/k8s/forgejo/app/volsync-git-ssd-migration.yaml
+++ b/cluster/k8s/forgejo/app/volsync-git-ssd-migration.yaml
@@ -61,8 +61,9 @@ metadata:
   namespace: forgejo
 spec:
   sourcePVC: forgejo-git-rwx
-  # Inert until the migration: unpause to pre-seed, bump trigger.manual to cut over.
-  paused: true
+  # Pre-seed running (Forgejo live). Cut over by bumping trigger.manual with
+  # Forgejo scaled to 0, then repoint the HelmRelease claimName.
+  paused: false
   trigger:
     manual: preseed-1
   rsyncTLS:


### PR DESCRIPTION
Unpauses the Phase 3 VolSync ReplicationSource to run the pre-seed rsync (hdd→ssd, ~1 GiB) while Forgejo stays live. One-shot (manual trigger); cutover is a later windowed step (scale to 0, bump trigger, repoint claimName).