### PR TITLE
cluster: add oci-cache Zot pull-through registry mirror (phase 1)

### DIFF
--- a/cluster/docs/plan.md
+++ b/cluster/docs/plan.md
@@ -98,7 +98,10 @@ returns (not independently parked):
       Hub pull-through cache: transparent via the dind `--registry-mirror` (Harbor's
       proxy-cache can't act as a root mirror, and Harbor is currently down anyway),
       then drop the docker.com CDN allows. Bonus: caching + Docker Hub rate-limit
-      relief.
+      relief. - The in-cluster mirror now exists: `oci-cache` (Zot), phase 1 landed 2026-07 —
+      see <../k8s/oci-cache/README.md>. Remaining work here is pointing the haku-ci
+      dind `--registry-mirror` at its ClusterIP, adding a NetworkPolicy egress allow to
+      `oci-cache`, and dropping the docker.com CDN FQDNs (phase 2, item 4 in that README).
 - [ ] **Investigate whether to re-enable VPA/Goldilocks recommendations.**
       Forgejo's namespace is Goldilocks-enabled and has a generated
       `goldilocks-forgejo` VPA, but the VPA control-plane deployments in
@@ -290,7 +293,10 @@ hil-ovh`) and apply the same `nodePathMap` entry to any matching node.
       and (b) props agent image storage. Candidates: [Zot](https://zotregistry.dev/) (single binary,
       multi-upstream proxy + private images), or separate `registry:2` per upstream + GHCR for props.
       Would drop the Harbor Helm chart, CNPG cluster, 32Gi HDD PVC, ~700Mi RAM, and all
-      Harbor-specific TF modules.
+      Harbor-specific TF modules. - Phase 1 landed 2026-07: `oci-cache` (Zot on SeaweedFS S3 + Valkey dedupe, no PVC,
+      unpinned) covers the pull-through role — see <../k8s/oci-cache/README.md>. Still
+      ClusterIP-only; the authenticated public endpoint + Talos containerd mirrors that
+      would let Harbor's proxy-cache be retired are phase 2 in that README.
 
 - [ ] Verify dmeventd thin pool monitoring after wyrm2 reboot: NixOS config changed
       `pkgs.lvm2` → `pkgs.lvm2_dmeventd` so `lvchange --monitor y` actually registers

--- a/cluster/docs/plan.md
+++ b/cluster/docs/plan.md
@@ -98,10 +98,10 @@ returns (not independently parked):
       Hub pull-through cache: transparent via the dind `--registry-mirror` (Harbor's
       proxy-cache can't act as a root mirror, and Harbor is currently down anyway),
       then drop the docker.com CDN allows. Bonus: caching + Docker Hub rate-limit
-      relief. - The in-cluster mirror now exists: `oci-cache` (Zot), phase 1 landed 2026-07 —
-      see <../k8s/oci-cache/README.md>. Remaining work here is pointing the haku-ci
-      dind `--registry-mirror` at its ClusterIP, adding a NetworkPolicy egress allow to
-      `oci-cache`, and dropping the docker.com CDN FQDNs (phase 2, item 4 in that README).
+      relief. Update 2026-07: the in-cluster mirror now exists — `oci-cache` (Zot),
+      phase 1, see <../k8s/oci-cache/README.md>. Remaining work here is pointing the
+      haku-ci dind `--registry-mirror` at its ClusterIP, adding a NetworkPolicy egress
+      allow to `oci-cache`, and dropping the docker.com CDN FQDNs (phase 2, item 4 there).
 - [ ] **Investigate whether to re-enable VPA/Goldilocks recommendations.**
       Forgejo's namespace is Goldilocks-enabled and has a generated
       `goldilocks-forgejo` VPA, but the VPA control-plane deployments in
@@ -293,10 +293,9 @@ hil-ovh`) and apply the same `nodePathMap` entry to any matching node.
       and (b) props agent image storage. Candidates: [Zot](https://zotregistry.dev/) (single binary,
       multi-upstream proxy + private images), or separate `registry:2` per upstream + GHCR for props.
       Would drop the Harbor Helm chart, CNPG cluster, 32Gi HDD PVC, ~700Mi RAM, and all
-      Harbor-specific TF modules. - Phase 1 landed 2026-07: `oci-cache` (Zot on SeaweedFS S3 + Valkey dedupe, no PVC,
-      unpinned) covers the pull-through role — see <../k8s/oci-cache/README.md>. Still
-      ClusterIP-only; the authenticated public endpoint + Talos containerd mirrors that
-      would let Harbor's proxy-cache be retired are phase 2 in that README.
+      Harbor-specific TF modules. Update 2026-07: phase 1 landed — `oci-cache` (Zot on
+      SeaweedFS S3 + Valkey dedupe, no PVC, unpinned) covers the pull-through role, see
+      <../k8s/oci-cache/README.md>. Still ClusterIP-only; the authenticated public endpoint + Talos containerd mirrors that would let Harbor's proxy-cache be retired are phase 2.
 
 - [ ] Verify dmeventd thin pool monitoring after wyrm2 reboot: NixOS config changed
       `pkgs.lvm2` → `pkgs.lvm2_dmeventd` so `lvchange --monitor y` actually registers

--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -185,6 +185,10 @@ resources:
   - harbor/servicemonitor/flux-kustomization.yaml
   - harbor/oidc-config/flux-kustomization.yaml
 
+  # --- oci-cache (Zot pull-through mirror for docker.io/ghcr.io/quay.io/etc.) ---
+  - oci-cache/namespace/flux-kustomization.yaml
+  - oci-cache/app/flux-kustomization.yaml
+
   # --- firecrawl ---
   - firecrawl/namespace/flux-kustomization.yaml
   - firecrawl/db/flux-kustomization.yaml
@@ -399,6 +403,7 @@ resources:
   - seaweedfs/drivefs-artifacts-bucket/flux-kustomization.yaml
   - seaweedfs/forgejo-bucket/flux-kustomization.yaml
   - seaweedfs/langfuse-bucket/flux-kustomization.yaml
+  - seaweedfs/registry-cache-bucket/flux-kustomization.yaml
   - seaweedfs/loom-gym-bucket/flux-kustomization.yaml
   - seaweedfs/wayback-archive-bucket/flux-kustomization.yaml
   - seaweedfs/public-s3/flux-kustomization.yaml

--- a/cluster/k8s/oci-cache/README.md
+++ b/cluster/k8s/oci-cache/README.md
@@ -1,0 +1,80 @@
+# oci-cache
+
+[Zot](https://zotregistry.dev/) as an **on-demand pull-through cache** for upstream
+OCI registries. Two goals: fewer external image pulls from the cluster, and letting
+in-cluster consumers (agent dind, etc.) reach one internal endpoint instead of
+allowlisting every registry CDN.
+
+## Architecture
+
+| Concern            | Choice                                                                                                                                           |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Registry           | Zot (`ghcr.io/project-zot/zot-linux-amd64`, full image — needs the `sync` extension)                                                             |
+| Durable content    | SeaweedFS S3 `registry-cache` bucket (`seaweedfs/registry-cache-bucket/`) — manifests + blobs                                                    |
+| Dedupe index       | `oci-cache-valkey` `RedisReplication` (Zot `cacheDriver: redis`, `remoteCache`)                                                                  |
+| Local state        | none durable — only ephemeral upload staging on `emptyDir`, so the pod reschedules freely                                                        |
+| Placement          | unpinned (soft-prefers OVH region to sit near SeaweedFS); Valkey on `seaweedfs-ovh` (HDD, networked)                                             |
+| S3 credentials     | `s3-identity-registry-cache` Secret (seaweedfs ns), Reflector-mirrored into `oci-cache`, injected as `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` |
+| Exposure (phase 1) | ClusterIP `oci-cache.oci-cache.svc:5000` only — no public route, no auth                                                                         |
+
+Upstreams are addressed **by path prefix** (Zot `sync` `stripPrefix`):
+
+| Upstream          | Pull as                                          |
+| ----------------- | ------------------------------------------------ |
+| `docker.io`       | `oci-cache.oci-cache.svc:5000/docker-hub/<repo>` |
+| `ghcr.io`         | `oci-cache.oci-cache.svc:5000/ghcr/<repo>`       |
+| `quay.io`         | `oci-cache.oci-cache.svc:5000/quay/<repo>`       |
+| `registry.k8s.io` | `oci-cache.oci-cache.svc:5000/k8s/<repo>`        |
+| `gcr.io`          | `oci-cache.oci-cache.svc:5000/gcr/<repo>`        |
+
+e.g. `docker.io/library/nginx` → `oci-cache.oci-cache.svc:5000/docker-hub/library/nginx`.
+
+## Eviction
+
+Time/count-based, **not** a hard byte cap. A cached tag is kept if pulled within the
+last 30d (`pulledWithin: 720h`) **or** among the 20 most-recently-pulled per repo;
+everything else ages out and `gc` reclaims its blobs from S3. Tune `pulledWithin` /
+`mostRecentlyPulledCount` in `app/config.json` to your storage budget. Never add a
+SeaweedFS bucket-lifecycle rule under Zot — deleting blobs out from under the registry
+corrupts manifests.
+
+## Phase 2 (not yet wired)
+
+The public, authenticated endpoint and node-level pull-through are deliberately deferred
+— nothing here depends on them, and Talos machine-config changes reboot nodes.
+
+1. **Authenticated public endpoint** at `oci-cache.allegedly.works`. The gateway already
+   terminates `*.allegedly.works`, so this is an `HTTPRoute` to the `oci-cache` Service
+   plus Zot htpasswd auth. Generate the credential from the devshell and add it as a SOPS
+   Secret mounted at `/etc/zot/htpasswd`, with `http.auth.htpasswd.path` in `config.json`:
+
+   ```bash
+   htpasswd -nbBC 10 puller "$(openssl rand -base64 30)"   # -> puller:$2y$10$...
+   ```
+
+2. **Talos containerd mirrors** — point node pulls at the endpoint in
+   `cluster/terraform/main/infrastructure.tf` (`machine.registries.mirrors`), with
+   `machine.registries.config.<host>.auth` for the htpasswd cred. **Keep `skipFallback`
+   false** so nodes fall back to the origin registry when the cache is down (avoids a
+   pull-time SPOF and the CNI-bootstrap cycle).
+
+3. **Authenticated Docker Hub upstream** (optional, higher rate limits) — add a
+   `credentialsFile` to Zot's `sync` config keyed by `registry-1.docker.io` with a Docker
+   Hub username + PAT. Anonymous pull-through works without it.
+
+4. **Haku dind allowlist** — point Haku CI's dind `--registry-mirror` at this Service and
+   drop the registry CDN FQDNs from `cluster/k8s/agents/haku-egress-proxy/`
+   (`cnp-haku-cloud-api-egress.yaml`, the `TODO(pull-through-cache)`). Needs a
+   NetworkPolicy allowing egress from the runner to `oci-cache`.
+
+## Verify before trusting it
+
+Config points not smoke-tested at authoring time (no live cluster access): the pinned
+Zot image tag (`v2.1.11`), the exact S3 `storageDriver` keys against this Zot version
+(see [zot#3571](https://github.com/project-zot/zot/issues/3571) re 2.1.10 S3 config
+drift), and the `sync` prefix/`stripPrefix` routing. Smoke test:
+
+```bash
+kubectl -n oci-cache run probe --rm -it --image=curlimages/curl --restart=Never -- \
+  curl -sS http://oci-cache:5000/v2/docker-hub/library/alpine/manifests/latest -I
+```

--- a/cluster/k8s/oci-cache/app/config.json
+++ b/cluster/k8s/oci-cache/app/config.json
@@ -1,0 +1,84 @@
+{
+  "storage": {
+    "rootDirectory": "/var/lib/zot",
+    "dedupe": true,
+    "gc": true,
+    "gcDelay": "1h",
+    "gcInterval": "24h",
+    "remoteCache": true,
+    "storageDriver": {
+      "name": "s3",
+      "rootdirectory": "/zot",
+      "region": "us-east-1",
+      "regionendpoint": "http://seaweedfs-s3.seaweedfs.svc:8333",
+      "bucket": "registry-cache",
+      "secure": false,
+      "skipverify": true,
+      "forcepathstyle": true
+    },
+    "cacheDriver": {
+      "name": "redis",
+      "url": "redis://oci-cache-valkey-master.oci-cache.svc.cluster.local:6379",
+      "keyprefix": "zot"
+    },
+    "retention": {
+      "delay": "24h",
+      "policies": [
+        {
+          "repositories": ["**"],
+          "deleteUntagged": true,
+          "keepTags": [
+            {
+              "patterns": [".*"],
+              "pulledWithin": "720h",
+              "mostRecentlyPulledCount": 20
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "http": {
+    "address": "0.0.0.0",
+    "port": "5000"
+  },
+  "log": {
+    "level": "info"
+  },
+  "extensions": {
+    "sync": {
+      "registries": [
+        {
+          "urls": ["https://registry-1.docker.io"],
+          "onDemand": true,
+          "tlsVerify": true,
+          "content": [{ "prefix": "/docker-hub/**", "destination": "/", "stripPrefix": true }]
+        },
+        {
+          "urls": ["https://ghcr.io"],
+          "onDemand": true,
+          "tlsVerify": true,
+          "content": [{ "prefix": "/ghcr/**", "destination": "/", "stripPrefix": true }]
+        },
+        {
+          "urls": ["https://quay.io"],
+          "onDemand": true,
+          "tlsVerify": true,
+          "content": [{ "prefix": "/quay/**", "destination": "/", "stripPrefix": true }]
+        },
+        {
+          "urls": ["https://registry.k8s.io"],
+          "onDemand": true,
+          "tlsVerify": true,
+          "content": [{ "prefix": "/k8s/**", "destination": "/", "stripPrefix": true }]
+        },
+        {
+          "urls": ["https://gcr.io"],
+          "onDemand": true,
+          "tlsVerify": true,
+          "content": [{ "prefix": "/gcr/**", "destination": "/", "stripPrefix": true }]
+        }
+      ]
+    }
+  }
+}

--- a/cluster/k8s/oci-cache/app/deployment.yaml
+++ b/cluster/k8s/oci-cache/app/deployment.yaml
@@ -1,0 +1,95 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zot
+  namespace: oci-cache
+  labels:
+    app.kubernetes.io/name: zot
+  annotations:
+    description: >-
+      Zot OCI pull-through cache. On-demand mirror for docker.io, ghcr.io,
+      quay.io, registry.k8s.io and gcr.io addressed by path prefix
+      (/docker-hub, /ghcr, /quay, /k8s, /gcr). Durable content in the
+      SeaweedFS registry-cache bucket (S3); dedupe index in the oci-cache-valkey
+      RedisReplication. No PVC — the only local state is ephemeral upload
+      staging on emptyDir, so the pod reschedules freely. ClusterIP-only for
+      now; the authenticated public endpoint + Talos containerd mirrors are a
+      later phase (see README).
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: zot
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: zot
+    spec:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      securityContext:
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: zot
+          image: ghcr.io/project-zot/zot-linux-amd64:v2.1.11
+          imagePullPolicy: IfNotPresent
+          args: ["serve", "/etc/zot/config.json"]
+          ports:
+            - name: http
+              containerPort: 5000
+              protocol: TCP
+          env:
+            # docker/distribution S3 driver reads the AWS default credential
+            # chain when accesskey/secretkey are omitted from config.json.
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: s3-identity-registry-cache
+                  key: accessKey
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: s3-identity-registry-cache
+                  key: secretKey
+          volumeMounts:
+            - name: config
+              mountPath: /etc/zot
+              readOnly: true
+            - name: cache
+              mountPath: /var/lib/zot
+          resources:
+            requests:
+              memory: 128Mi
+              cpu: 50m
+            limits:
+              memory: 512Mi
+              cpu: "1"
+          readinessProbe:
+            httpGet:
+              path: /v2/
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /v2/
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+      volumes:
+        - name: config
+          configMap:
+            name: oci-cache-zot-config
+        - name: cache
+          emptyDir:
+            sizeLimit: 5Gi

--- a/cluster/k8s/oci-cache/app/flux-kustomization.yaml
+++ b/cluster/k8s/oci-cache/app/flux-kustomization.yaml
@@ -1,0 +1,28 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: oci-cache
+  namespace: flux-system
+spec:
+  retryInterval: 1m
+  interval: 10m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./cluster/k8s/oci-cache/app
+  prune: true
+  wait: true
+  healthChecks:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: zot
+      namespace: oci-cache
+  dependsOn:
+    - name: oci-cache-namespace
+    # RedisReplication CRD (Opstree operator)
+    - name: valkey
+    # S3 backend: bucket + the s3-identity-registry-cache Secret that Reflector
+    # mirrors into oci-cache for Zot's AWS_* env.
+    - name: seaweedfs-registry-cache-bucket
+    - name: seaweedfs-secrets

--- a/cluster/k8s/oci-cache/app/kustomization.yaml
+++ b/cluster/k8s/oci-cache/app/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: oci-cache
+resources:
+  - valkey-instance.yaml
+  - deployment.yaml
+  - service.yaml
+configMapGenerator:
+  - name: oci-cache-zot-config
+    files:
+      - config.json
+generatorOptions:
+  # Stable name; the Deployment's reloader annotation restarts Zot on change.
+  disableNameSuffixHash: true

--- a/cluster/k8s/oci-cache/app/service.yaml
+++ b/cluster/k8s/oci-cache/app/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: oci-cache
+  namespace: oci-cache
+  labels:
+    app.kubernetes.io/name: zot
+spec:
+  selector:
+    app.kubernetes.io/name: zot
+  ports:
+    - name: http
+      port: 5000
+      targetPort: http
+      protocol: TCP

--- a/cluster/k8s/oci-cache/app/valkey-instance.yaml
+++ b/cluster/k8s/oci-cache/app/valkey-instance.yaml
@@ -1,0 +1,57 @@
+apiVersion: redis.redis.opstreelabs.in/v1beta2
+kind: RedisReplication
+metadata:
+  name: oci-cache-valkey
+  namespace: oci-cache
+  annotations:
+    description: >-
+      Shared dedupe/metadata cache for the Zot OCI pull-through cache. Zot's
+      cacheDriver points here (remoteCache); the durable content lives in S3, so
+      this holds only the regenerable dedupe index — safe to lose (Zot rebuilds
+      from the bucket). On seaweedfs-ovh (networked, not node-pinned) so it
+      reschedules freely.
+spec:
+  clusterSize: 2
+  kubernetesConfig:
+    image: valkey/valkey:8-alpine
+    imagePullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi
+  redisConfig:
+    maxMemoryPercentOfLimit: 80
+  storage:
+    volumeClaimTemplate:
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: seaweedfs-ovh
+        resources:
+          requests:
+            storage: 2Gi
+  affinity:
+    nodeAffinity:
+      # Soft off control-plane nodes (their etcd is on a rotational HDD;
+      # co-located I/O starves etcd fsync — 2026-06-28 outage), and soft-prefer
+      # the OVH region to sit near the SeaweedFS backend. Not hard-pinned.
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: DoesNotExist
+        - weight: 50
+          preference:
+            matchExpressions:
+              - key: topology.kubernetes.io/region
+                operator: In
+                values: ["hil"]
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app: oci-cache-valkey
+          topologyKey: kubernetes.io/hostname

--- a/cluster/k8s/oci-cache/namespace/flux-kustomization.yaml
+++ b/cluster/k8s/oci-cache/namespace/flux-kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: oci-cache-namespace
+  namespace: flux-system
+spec:
+  interval: 1h
+  path: ./cluster/k8s/oci-cache/namespace
+  prune: false
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 1m

--- a/cluster/k8s/oci-cache/namespace/kustomization.yaml
+++ b/cluster/k8s/oci-cache/namespace/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml

--- a/cluster/k8s/oci-cache/namespace/namespace.yaml
+++ b/cluster/k8s/oci-cache/namespace/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: oci-cache
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"
+    goldilocks.fairwinds.com/vpa-update-mode: "auto"

--- a/cluster/k8s/seaweedfs/registry-cache-bucket/bucket.yaml
+++ b/cluster/k8s/seaweedfs/registry-cache-bucket/bucket.yaml
@@ -1,0 +1,14 @@
+apiVersion: seaweed.seaweedfs.com/v1
+kind: Bucket
+metadata:
+  name: registry-cache
+  namespace: seaweedfs
+spec:
+  name: registry-cache
+  clusterRef:
+    name: seaweedfs
+    namespace: seaweedfs
+  reclaimPolicy: Retain
+  access:
+    - user: registry-cache
+      actions: [Read, Write, List, Tagging]

--- a/cluster/k8s/seaweedfs/registry-cache-bucket/flux-kustomization.yaml
+++ b/cluster/k8s/seaweedfs/registry-cache-bucket/flux-kustomization.yaml
@@ -1,0 +1,25 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: seaweedfs-registry-cache-bucket
+  namespace: flux-system
+spec:
+  interval: 10m
+  retryInterval: 1m
+  path: ./cluster/k8s/seaweedfs/registry-cache-bucket
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  dependsOn:
+    - name: seaweedfs-cluster
+      namespace: flux-system
+    - name: seaweedfs-secrets
+      namespace: flux-system
+  wait: true
+  timeout: 5m
+  healthChecks:
+    - apiVersion: seaweed.seaweedfs.com/v1
+      kind: Bucket
+      name: registry-cache
+      namespace: seaweedfs

--- a/cluster/k8s/seaweedfs/registry-cache-bucket/kustomization.yaml
+++ b/cluster/k8s/seaweedfs/registry-cache-bucket/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - bucket.yaml

--- a/cluster/k8s/seaweedfs/secrets/identities/registry-cache.sops.yaml
+++ b/cluster/k8s/seaweedfs/secrets/identities/registry-cache.sops.yaml
@@ -1,0 +1,100 @@
+# SeaweedFS s3 identity for "registry-cache".
+# Scoped to the registry-cache bucket (Bucket CR in seaweedfs/registry-cache-bucket/).
+# Zot (the OCI pull-through cache, cluster/k8s/oci-cache/) uses this as its S3
+# storage backend: cached manifests + blobs live in the bucket. The Secret is
+# mirrored into the oci-cache namespace via Reflector so the Zot Deployment can
+# inject the creds as AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY env.
+apiVersion: v1
+kind: Secret
+metadata:
+    name: s3-identity-registry-cache
+    namespace: seaweedfs
+    labels:
+        seaweedfs.io/role: s3-identity
+    annotations:
+        reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+        reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: oci-cache
+        reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+        reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: oci-cache
+type: Opaque
+stringData:
+    name: registry-cache
+    actions: Read,Write,List,Tagging
+    accessKey: ENC[AES256_GCM,data:lmZknf+Zpgb69FS7l7hhjVwuA8VVaq1Ij6bxOYYt9uY=,iv:nv33hm6WYfapDFi0GRf9OvOqyZcvr/SLMQ9CNNcYqh0=,tag:wLtFE2W+w9pK1ZraXo6ODw==,type:str]
+    secretKey: ENC[AES256_GCM,data:IZZRCCzEllKxGdxXk0EscQ0rqCSpbXp4srrdyDKhP6gulKwGEcBskA==,iv:Ono6Hl3Tn4xWSDZ/acMBFgSCV331aoD8UOCUUvdwXXM=,tag:7cAmjKU9D6m/0tuGNmSFKw==,type:str]
+sops:
+    age:
+        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2a0szMHo0aFh3R09RdzYr
+            MmdqVk1LTk01SVEvRUpyWjRXRlZqRnp6bHpNCmNNNEhYTmhzSFZsODRScnY3TGVF
+            MFArREtNTjVEVVJYTUFveER5QmUxZlUKLS0tIDc4QlZRYUthemszaStjNUVCUXpz
+            MTAyeFVKbWRPdTUwZzJuSVdxdjcxVjAKHeZJNdy4LZWVSgrsNfm05pB+8uKthhsP
+            zTOlpBNK0m7YQ+mxLZDY2T/CDJXXrmcW80VGwGXIfnHQa4qB/GDFrQ==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1nywlwepsyfxvyhqwkjquzz02nmus65gf6qewfjju4alym8f7se5qnua8na
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2b2xOZExiQlI2Tm5DYXlO
+            ZGoyNTRjbWNsZlFFR2Z5S2RWNkx6MXk5UnhvCmJVZlhPTkRmVWEva0JxNFRrQkR6
+            SGVURm5nb2FEcjhFcWlqTmZnblBkWU0KLS0tIFB4d2RmMytxc29xb09jTExtV25i
+            MjZVZFZtQ1ZxRVZpYlpmejJGdkVFTTQKFLpce+OH/T/EyjBVGmMscSHyOAIlnuqy
+            CS2RVEsF2YIRIMxNHYxoNoCFIc8+BpUek0iBZFmDKk2x/oo61hJ01Q==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-07-04T20:39:41Z"
+    mac: ENC[AES256_GCM,data:JSFmwZYf5XvGadTOjh7bcy1cM2mxuxmdFn/qKOWg3w5V87ot7cbvDjQCr0DfNtAXek4s90OMjCcQQRVd+SVL7WWfssBPlRD9l40/etIPqSwToromxi//rQr+BVRqwRDagrCvoyW3PnC+slWMp4eFSJ7+sURwtUD4KfFn89pCk3Q=,iv:OsSAiEkwfFcRlyCsWMllrwCpgRwcHrVT/myuVN6SvJU=,tag:Fwm/KId1eQY7ytcmaWLhKA==,type:str]
+    encrypted_regex: ^(accessKey|secretKey)$
+    version: 3.12.1
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+    name: s3-identity-registry-cache-json
+    namespace: seaweedfs
+    labels:
+        seaweedfs.io/role: s3-identity-json
+spec:
+    refreshInterval: 1m
+    secretStoreRef:
+        kind: SecretStore
+        name: seaweedfs-identities
+    target:
+        name: s3-identity-registry-cache-json
+        template:
+            type: Opaque
+            data:
+                identity: |
+                    {"name":"{{ .name }}",
+                     "credentials":[{"accessKey":"{{ .accessKey }}","secretKey":"{{ .secretKey }}"}],
+                     "actions":[{{- $first := true -}}
+                       {{- range splitList "," .actions -}}
+                       {{- if not $first }},{{ end -}}"{{ . }}"{{- $first = false -}}
+                       {{- end }}]}
+    dataFrom:
+        - extract:
+            key: s3-identity-registry-cache
+sops:
+    age:
+        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2a0szMHo0aFh3R09RdzYr
+            MmdqVk1LTk01SVEvRUpyWjRXRlZqRnp6bHpNCmNNNEhYTmhzSFZsODRScnY3TGVF
+            MFArREtNTjVEVVJYTUFveER5QmUxZlUKLS0tIDc4QlZRYUthemszaStjNUVCUXpz
+            MTAyeFVKbWRPdTUwZzJuSVdxdjcxVjAKHeZJNdy4LZWVSgrsNfm05pB+8uKthhsP
+            zTOlpBNK0m7YQ+mxLZDY2T/CDJXXrmcW80VGwGXIfnHQa4qB/GDFrQ==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1nywlwepsyfxvyhqwkjquzz02nmus65gf6qewfjju4alym8f7se5qnua8na
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2b2xOZExiQlI2Tm5DYXlO
+            ZGoyNTRjbWNsZlFFR2Z5S2RWNkx6MXk5UnhvCmJVZlhPTkRmVWEva0JxNFRrQkR6
+            SGVURm5nb2FEcjhFcWlqTmZnblBkWU0KLS0tIFB4d2RmMytxc29xb09jTExtV25i
+            MjZVZFZtQ1ZxRVZpYlpmejJGdkVFTTQKFLpce+OH/T/EyjBVGmMscSHyOAIlnuqy
+            CS2RVEsF2YIRIMxNHYxoNoCFIc8+BpUek0iBZFmDKk2x/oo61hJ01Q==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-07-04T20:39:41Z"
+    mac: ENC[AES256_GCM,data:JSFmwZYf5XvGadTOjh7bcy1cM2mxuxmdFn/qKOWg3w5V87ot7cbvDjQCr0DfNtAXek4s90OMjCcQQRVd+SVL7WWfssBPlRD9l40/etIPqSwToromxi//rQr+BVRqwRDagrCvoyW3PnC+slWMp4eFSJ7+sURwtUD4KfFn89pCk3Q=,iv:OsSAiEkwfFcRlyCsWMllrwCpgRwcHrVT/myuVN6SvJU=,tag:Fwm/KId1eQY7ytcmaWLhKA==,type:str]
+    encrypted_regex: ^(accessKey|secretKey)$
+    version: 3.12.1

--- a/cluster/k8s/seaweedfs/secrets/kustomization.yaml
+++ b/cluster/k8s/seaweedfs/secrets/kustomization.yaml
@@ -17,4 +17,5 @@ resources:
   - identities/loki.sops.yaml
   - identities/tempo.sops.yaml
   - identities/mimir.sops.yaml
+  - identities/registry-cache.sops.yaml
   - identities/wayback-archive.sops.yaml


### PR DESCRIPTION
Stands up `oci-cache` — [Zot](https://zotregistry.dev/) as an on-demand pull-through cache for upstream OCI registries. Two motivations: fewer external image pulls from the cluster, and letting in-cluster consumers reach one internal endpoint instead of allowlisting every registry CDN.

This also discharges phase 1 of the `plan.md` "Evaluate lighter registry to replace Harbor" and "haku-ci Docker Hub pull-through cache" TODOs.

## Architecture

| Concern | Choice |
| --- | --- |
| Registry | Zot (`ghcr.io/project-zot/zot-linux-amd64`, full image — needs the `sync` extension) |
| Durable content | SeaweedFS S3 `registry-cache` bucket — manifests + blobs |
| Dedupe index | `oci-cache-valkey` `RedisReplication` (Opstree operator, `seaweedfs-ovh` HDD), Zot `cacheDriver: redis` + `remoteCache` |
| Local state | none durable — only ephemeral upload staging on `emptyDir`, so the pod reschedules freely |
| Placement | unpinned (soft-prefers OVH region to sit near SeaweedFS) |
| S3 creds | `s3-identity-registry-cache` Secret (seaweedfs ns), Reflector-mirrored into `oci-cache`, injected as `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` |
| Exposure | ClusterIP `oci-cache.oci-cache.svc:5000` only — no public route, no auth |

Upstreams (docker.io, ghcr.io, quay.io, registry.k8s.io, gcr.io) are addressed by path prefix (`/docker-hub`, `/ghcr`, `/quay`, `/k8s`, `/gcr`) with `stripPrefix`. Eviction is time/count-based: keep tags pulled within 30d (`pulledWithin: 720h`) or the 20 most-recently-pulled per repo, GC reclaims the rest from S3.

## What's here

- `cluster/k8s/oci-cache/` — namespace, Zot Deployment/Service/config (`config.json` via `configMapGenerator`), and the Valkey `RedisReplication`.
- `cluster/k8s/seaweedfs/registry-cache-bucket/` + `secrets/identities/registry-cache.sops.yaml` — the S3 bucket and its SOPS-encrypted identity.
- Root kustomization wiring + `plan.md` TODO annotations.

## Not in this PR (phase 2, documented in the component README)

Authenticated public endpoint at `oci-cache.allegedly.works` (htpasswd), Talos `registries.mirrors` with fallback for node containerd, optional authenticated Docker Hub upstream, and pointing Haku's dind at the mirror to trim its egress allowlist.

## Validation

Local: `kustomize build` (all dirs + root), kubeconform (cluster pre-commit hook), `config.json` JSON validity, prettier, CRD-layering, and a manual orphan/path/`dependsOn` graph check all pass.

Not runnable in the authoring environment (proxy blocks the bbr git-mirror and a `rules_mypy` fetch; `markdownlint-cli2` absent) — the Bazel validators and full pre-commit will run here in CI.

Runtime Zot behavior is **unverified** (no live cluster at authoring time): the pinned image tag `v2.1.11`, exact S3 `storageDriver` keys for this Zot version, and `sync` prefix routing. It deploys active — smoke-test on first reconcile (see the README's "Verify before trusting it"); a bad config just crashloops in its own namespace with nothing depending on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015rpAEqZPQNV4gc5fuUCtVE

---
_Generated by [Claude Code](https://claude.ai/code/session_015rpAEqZPQNV4gc5fuUCtVE)_