### PR TITLE
cluster/oci-cache: grant agents diagnostics read access

### DIFF
--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -188,6 +188,7 @@ resources:
   # --- oci-cache (Zot pull-through mirror for docker.io/ghcr.io/quay.io/etc.) ---
   - oci-cache/namespace/flux-kustomization.yaml
   - oci-cache/app/flux-kustomization.yaml
+  - oci-cache/agent-rbac/flux-kustomization.yaml
 
   # --- firecrawl ---
   - firecrawl/namespace/flux-kustomization.yaml

--- a/cluster/k8s/oci-cache/agent-rbac/flux-kustomization.yaml
+++ b/cluster/k8s/oci-cache/agent-rbac/flux-kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: oci-cache-agent-rbac
+  namespace: flux-system
+  annotations:
+    description: Agent RBAC for oci-cache namespace. Lightweight — only RoleBindings. Depends on namespace existing + agent RBAC base for ClusterRoles.
+spec:
+  interval: 10m
+  path: ./cluster/k8s/oci-cache/agent-rbac
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  timeout: 2m
+  dependsOn:
+    - name: oci-cache-namespace
+    - name: claude-rbac

--- a/cluster/k8s/oci-cache/agent-rbac/kustomization.yaml
+++ b/cluster/k8s/oci-cache/agent-rbac/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - rolebinding-namespace-diagnostics-reader.yaml
+  - rolebinding-logs-configmaps-reader.yaml

--- a/cluster/k8s/oci-cache/agent-rbac/rolebinding-logs-configmaps-reader.yaml
+++ b/cluster/k8s/oci-cache/agent-rbac/rolebinding-logs-configmaps-reader.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: agent-logs-configmaps-reader
+  namespace: oci-cache
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: logs-configmaps-reader
+subjects:
+  - kind: Group
+    name: oidc-ksbx-groups:kubectl-sandbox-users
+    apiGroup: rbac.authorization.k8s.io

--- a/cluster/k8s/oci-cache/agent-rbac/rolebinding-namespace-diagnostics-reader.yaml
+++ b/cluster/k8s/oci-cache/agent-rbac/rolebinding-namespace-diagnostics-reader.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: agent-namespace-diagnostics-reader
+  namespace: oci-cache
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: namespace-diagnostics-reader
+subjects:
+  - kind: Group
+    name: oidc-ksbx-groups:kubectl-sandbox-users
+    apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Follow-up to #2851. Adds the standard per-service `agent-rbac/` directory for the `oci-cache` namespace so agents can debug the pull-through cache.

Binds two ClusterRoles from the agent RBAC base to the `kubectl-sandbox-users` group, in the `oci-cache` namespace:

- `namespace-diagnostics-reader` — workloads, events, describe
- `logs-configmaps-reader` — pod logs + configmaps (needed to read Zot's logs when diagnosing S3/redis/sync issues)

Read-only; no secrets, exec, or write. Follows the established pattern (`cluster/k8s/**/agent-rbac/`, per <cluster/k8s/agents/agent-rbac-base/README.md>): an independent Flux kustomization depending on the `oci-cache` namespace + the agent RBAC base (`claude-rbac`), zero coupling to the service manifests.

Subjects `kubectl-sandbox-users` only (matches most service dirs); `oidc-ksbx-groups:haku` is not co-subjected — say the word if you want Haku to have it too.

Validated: `kustomize build` + kubeconform on the new dir, root build (+1 flux-kustomization), and both `dependsOn` targets resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015rpAEqZPQNV4gc5fuUCtVE

---
_Generated by [Claude Code](https://claude.ai/code/session_015rpAEqZPQNV4gc5fuUCtVE)_