### PR TITLE
cluster/oci-cache: co-subject Haku on diagnostics RBAC

### DIFF
--- a/cluster/k8s/oci-cache/agent-rbac/rolebinding-logs-configmaps-reader.yaml
+++ b/cluster/k8s/oci-cache/agent-rbac/rolebinding-logs-configmaps-reader.yaml
@@ -11,3 +11,6 @@ subjects:
   - kind: Group
     name: oidc-ksbx-groups:kubectl-sandbox-users
     apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: oidc-ksbx-groups:haku
+    apiGroup: rbac.authorization.k8s.io

--- a/cluster/k8s/oci-cache/agent-rbac/rolebinding-namespace-diagnostics-reader.yaml
+++ b/cluster/k8s/oci-cache/agent-rbac/rolebinding-namespace-diagnostics-reader.yaml
@@ -11,3 +11,6 @@ subjects:
   - kind: Group
     name: oidc-ksbx-groups:kubectl-sandbox-users
     apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: oidc-ksbx-groups:haku
+    apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Follow-up to #2852. Adds `oidc-ksbx-groups:haku` alongside `kubectl-sandbox-users` on both `oci-cache` diagnostics RoleBindings (`namespace-diagnostics-reader`, `logs-configmaps-reader`), so the Haku background agent can inspect the pull-through cache too.

Still read-only — no secrets, exec, or write. Matches the co-subject pattern used on other infra namespaces (cnpg, monitoring, kube-system, cert-manager, …).

Validated: kustomize build + kubeconform (both bindings now list both groups), pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015rpAEqZPQNV4gc5fuUCtVE

---
_Generated by [Claude Code](https://claude.ai/code/session_015rpAEqZPQNV4gc5fuUCtVE)_