### PR TITLE
cluster/oci-cache: fix zot crashloop — set sync.downloadDir

### DIFF
--- a/cluster/k8s/oci-cache/app/config.json
+++ b/cluster/k8s/oci-cache/app/config.json
@@ -47,6 +47,7 @@
   },
   "extensions": {
     "sync": {
+      "downloadDir": "/var/lib/zot/.sync",
       "registries": [
         {
           "urls": ["https://registry-1.docker.io"],


### PR DESCRIPTION
The `oci-cache` Zot pod (from #2851) is in CrashLoopBackOff. Zot's config validation rejects the sync extension combined with S3 remote storage unless an explicit scratch dir is given:

```
using both sync and remote storage features needs config.Extensions.Sync.DownloadDir to be specified
```

`downloadDir` is where on-demand pulls are staged locally before being committed to S3 (confirms the design note that sync stages locally). Point it at `/var/lib/zot/.sync`, under the existing writable `emptyDir` cache mount — so it stays off the read-only root FS and needs no extra volume.

Found by inspecting the live reconcile: Valkey is healthy (both replicas Running on OVH), the bucket and reflected S3 secret exist; only Zot was crashing, on this one validation error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015rpAEqZPQNV4gc5fuUCtVE

---
_Generated by [Claude Code](https://claude.ai/code/session_015rpAEqZPQNV4gc5fuUCtVE)_