### PR TITLE
cluster: sibling provisioner test gaps + logging cleanup

### DIFF
--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -164,7 +164,7 @@ jobs:
           - {
               image: "//cluster/provisioners/grocy_user_perms:image",
               image_name: grocy-user-perms-provisioner,
-              test_target: "",
+              test_target: "//cluster/provisioners/grocy_user_perms/...",
             }
           - {
               image: "//cluster/provisioners/matrix_user_provisioner:image",

--- a/cluster/provisioners/inventree_token_provisioner/BUILD.bazel
+++ b/cluster/provisioners/inventree_token_provisioner/BUILD.bazel
@@ -2,7 +2,7 @@
 
 load("@aspect_rules_py//py:defs.bzl", "py_image_layer", aspect_py_binary = "py_binary")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
-load("//devinfra/python:defs.bzl", "py_library")
+load("//devinfra/python:defs.bzl", "py_library", "py_test")
 load("//props:oci.bzl", "py_image_entrypoint", "py_image_env")
 
 py_library(
@@ -11,6 +11,16 @@ py_library(
     deps = [
         "@pypi//inventree",
         "@pypi//kubernetes",
+    ],
+)
+
+py_test(
+    name = "test_provision",
+    srcs = ["test_provision.py"],
+    deps = [
+        ":provision",
+        "@pypi//pytest",
+        "@pypi//pytest_bazel",
     ],
 )
 

--- a/cluster/provisioners/inventree_token_provisioner/test_provision.py
+++ b/cluster/provisioners/inventree_token_provisioner/test_provision.py
@@ -1,0 +1,127 @@
+"""Tests for provision.py's InvenTree token provisioning logic."""
+
+import datetime
+
+import pytest
+import pytest_bazel
+
+from cluster.provisioners.inventree_token_provisioner import provision
+from cluster.provisioners.inventree_token_provisioner.provision import (
+    SANDBOX_USERNAME,
+    TOKEN_NAME,
+    find_token,
+    get_or_create_sandbox_user,
+    needs_renewal,
+    provision_token,
+)
+
+
+class _FakeInvenTreeUser:
+    """InvenTree's model wrapper supports both attribute (u.pk) and dict-style (u["username"]) access."""
+
+    def __init__(self, pk: int, username: str):
+        self.pk = pk
+        self.username = username
+
+    def __getitem__(self, key: str) -> object:
+        return getattr(self, key)
+
+
+class _FakeApi:
+    def __init__(self, get_response: object = None, post_response: dict | None = None):
+        self._get_response = get_response
+        self._post_response = post_response
+        self.deleted: list[str] = []
+        self.posted: list[tuple[str, dict]] = []
+
+    def get(self, path: str, params: dict | None = None) -> object:
+        return self._get_response
+
+    def post(self, path: str, data: dict) -> dict:
+        self.posted.append((path, data))
+        assert self._post_response is not None
+        return self._post_response
+
+    def delete(self, path: str) -> None:
+        self.deleted.append(path)
+
+
+def test_find_token_returns_matching_named_token_for_user():
+    api = _FakeApi(
+        get_response=[
+            {"user": 1, "name": "other-token", "pk": 10},
+            {"user": 2, "name": TOKEN_NAME, "pk": 11},
+            {"user": 2, "name": "unrelated", "pk": 12},
+        ]
+    )
+    assert find_token(api, user_pk=2) == {"user": 2, "name": TOKEN_NAME, "pk": 11}
+
+
+def test_find_token_handles_paginated_dict_response():
+    api = _FakeApi(get_response={"results": [{"user": 2, "name": TOKEN_NAME, "pk": 11}]})
+    assert find_token(api, user_pk=2) == {"user": 2, "name": TOKEN_NAME, "pk": 11}
+
+
+def test_find_token_returns_none_when_absent():
+    api = _FakeApi(get_response=[])
+    assert find_token(api, user_pk=2) is None
+
+
+def test_needs_renewal_true_when_expiry_soon():
+    expiry = (datetime.date.today() + datetime.timedelta(days=10)).isoformat()
+    assert needs_renewal({"expiry": expiry}) is True
+
+
+def test_needs_renewal_false_when_expiry_far_out():
+    expiry = (datetime.date.today() + datetime.timedelta(days=60)).isoformat()
+    assert needs_renewal({"expiry": expiry}) is False
+
+
+def test_needs_renewal_false_when_no_expiry():
+    assert needs_renewal({}) is False
+
+
+def test_provision_token_creates_without_revoking_when_no_existing():
+    api = _FakeApi(post_response={"token": "new-token-value"})
+    token = provision_token(api, user_pk=5, existing=None)
+    assert token == "new-token-value"
+    assert api.deleted == []
+    assert api.posted == [("user/tokens/", {"user": 5, "name": TOKEN_NAME})]
+
+
+def test_provision_token_revokes_existing_before_creating():
+    api = _FakeApi(post_response={"token": "new-token-value"})
+    token = provision_token(api, user_pk=5, existing={"pk": 99})
+    assert token == "new-token-value"
+    assert api.deleted == ["user/tokens/99/"]
+
+
+def test_provision_token_raises_when_response_missing_token_field():
+    api = _FakeApi(post_response={})
+    with pytest.raises(RuntimeError, match="missing 'token' field"):
+        provision_token(api, user_pk=5, existing=None)
+
+
+def test_get_or_create_sandbox_user_returns_existing_pk(monkeypatch: pytest.MonkeyPatch):
+    existing = _FakeInvenTreeUser(pk=7, username=SANDBOX_USERNAME)
+    monkeypatch.setattr(provision.User, "list", lambda api: [existing])
+    assert get_or_create_sandbox_user(api=object()) == 7
+
+
+def test_get_or_create_sandbox_user_creates_when_absent(monkeypatch: pytest.MonkeyPatch):
+    created = _FakeInvenTreeUser(pk=9, username=SANDBOX_USERNAME)
+    create_calls: list[dict] = []
+
+    def fake_create(api: object, data: dict) -> _FakeInvenTreeUser:
+        create_calls.append(data)
+        return created
+
+    monkeypatch.setattr(provision.User, "list", lambda api: [])
+    monkeypatch.setattr(provision.User, "create", fake_create)
+
+    assert get_or_create_sandbox_user(api=object()) == 9
+    assert create_calls == [{"username": SANDBOX_USERNAME}]
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/cluster/provisioners/matrix_user_provisioner/provision_matrix_users.py
+++ b/cluster/provisioners/matrix_user_provisioner/provision_matrix_users.py
@@ -14,11 +14,14 @@ Requires: REGISTRATION_SECRET, ADMIN_PASSWORD, BOT_PASSWORD env vars.
 
 import hashlib
 import hmac
+import logging
 import os
 import urllib.parse
 from typing import Protocol
 
 import httpx
+
+logger = logging.getLogger(__name__)
 
 SYNAPSE_URL = "http://matrix-synapse.matrix.svc.cluster.local:8008"
 ADMIN_USERNAME = "provisioner"
@@ -50,10 +53,10 @@ def register_admin(client: SynapseClient, registration_secret: str, admin_passwo
         json={"nonce": nonce, "username": ADMIN_USERNAME, "password": admin_password, "admin": True, "mac": mac},
     )
     if resp.status_code == 400 and resp.json().get("errcode") == "M_USER_IN_USE":
-        print(f"Phase 1: Admin @{ADMIN_USERNAME}:{SERVER_NAME} already exists, skipping")
+        logger.info("Phase 1: Admin @%s:%s already exists, skipping", ADMIN_USERNAME, SERVER_NAME)
         return
     resp.raise_for_status()
-    print(f"Phase 1: Registered admin @{resp.json()['user_id']}")
+    logger.info("Phase 1: Registered admin @%s", resp.json()["user_id"])
 
 
 def _admin_user_url(encoded_mxid: str) -> str:
@@ -83,7 +86,7 @@ def upsert_bot(client: SynapseClient, admin_password: str, bot_password: str) ->
     )
     login_resp.raise_for_status()
     access_token = login_resp.json()["access_token"]
-    print(f"Phase 2: Logged in as @{ADMIN_USERNAME}:{SERVER_NAME}")
+    logger.info("Phase 2: Logged in as @%s:%s", ADMIN_USERNAME, SERVER_NAME)
 
     bot_mxid = f"@{BOT_USERNAME}:{SERVER_NAME}"
     encoded_mxid = urllib.parse.quote(bot_mxid)
@@ -96,16 +99,17 @@ def upsert_bot(client: SynapseClient, admin_password: str, bot_password: str) ->
         # the value is identical (bcrypt rehash triggers device purge).
         resp = client.put(url, json={"displayname": BOT_DISPLAYNAME, "admin": False}, headers=auth)
         resp.raise_for_status()
-        print(f"Phase 2: Updated {bot_mxid} (displayname: {resp.json().get('displayname', 'n/a')})")
+        logger.info("Phase 2: Updated %s (displayname: %s)", bot_mxid, resp.json().get("displayname", "n/a"))
     else:
         resp = client.put(
             url, json={"password": bot_password, "displayname": BOT_DISPLAYNAME, "admin": False}, headers=auth
         )
         resp.raise_for_status()
-        print(f"Phase 2: Created {bot_mxid} (displayname: {resp.json().get('displayname', 'n/a')})")
+        logger.info("Phase 2: Created %s (displayname: %s)", bot_mxid, resp.json().get("displayname", "n/a"))
 
 
 def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
     registration_secret = os.environ["REGISTRATION_SECRET"]
     admin_password = os.environ["ADMIN_PASSWORD"]
     bot_password = os.environ["BOT_PASSWORD"]
@@ -113,7 +117,7 @@ def main() -> None:
     with httpx.Client(timeout=30) as client:
         register_admin(client, registration_secret, admin_password)
         upsert_bot(client, admin_password, bot_password)
-    print("Done: all Matrix users provisioned")
+    logger.info("Done: all Matrix users provisioned")
 
 
 if __name__ == "__main__":

--- a/cluster/provisioners/matrix_user_provisioner/test_provision_matrix_users.py
+++ b/cluster/provisioners/matrix_user_provisioner/test_provision_matrix_users.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import hmac
+import logging
 
 import httpx
 import pytest
@@ -68,14 +69,15 @@ def test_register_admin_computes_hmac_and_posts_registration():
     }
 
 
-def test_register_admin_skips_when_already_registered(capsys: pytest.CaptureFixture):
+def test_register_admin_skips_when_already_registered(caplog: pytest.LogCaptureFixture):
     client = _FakeClient(
         [_response(200, {"nonce": NONCE}), _response(400, {"errcode": "M_USER_IN_USE", "error": "already taken"})]
     )
 
-    register_admin(client, "shared-secret", "adminpw")  # must not raise
+    with caplog.at_level(logging.INFO):
+        register_admin(client, "shared-secret", "adminpw")  # must not raise
 
-    assert "already exists" in capsys.readouterr().out
+    assert "already exists" in caplog.text
 
 
 def test_register_admin_raises_on_unexpected_error():


### PR DESCRIPTION
## Summary

`/followups` pass after #2847 (the matrix provisioner OCI image migration + test coverage), surfacing the same "small provisioner, no test coverage" pattern in its siblings plus one style gap in the code just touched:

- **`cluster/provisioners/inventree_token_provisioner`**: had zero test coverage (no test file, no `py_test` target at all) — the exact gap `matrix_user_provisioner` had before #2847. Added `test_provision.py` covering `find_token` (list + paginated-dict response shapes), `needs_renewal` (date-threshold logic), `provision_token` (revoke-then-create, and the missing-token-field error), and `get_or_create_sandbox_user` (existing vs. created, via monkeypatching `inventree.user.User.list`/`.create` — the only points where the module touches the `inventree` library's own model classes rather than the injected `api` object). `main()` itself isn't tested, matching the existing convention (`rotate.py`'s tests don't cover its `main()` either — too many real integration pieces: k8s client, `InvenTreeAPI` construction, env vars).
- **`.github/workflows/push-images.yml`**: `grocy_user_perms` already had a real test (`test_provision.py`/`test_provision` in `BUILD.bazel`) but its row still had `test_target: ""`, so the test didn't gate the image push — inconsistent with `authentik_jwt_rotation` and the just-added `matrix_user_provisioner`, which do gate on their own tests. Wired it up the same way.
- **`cluster/provisioners/matrix_user_provisioner/provision_matrix_users.py`**: switched `print()` to `logging` (module-level `logger = logging.getLogger(__name__)`, `logging.basicConfig` in `main()`), matching its httpx sibling `rotate.py` and STYLE.md's logging convention. Updated the one test that asserted on printed output to use `caplog` instead of `capsys`.

## Test plan

- [x] `pytest` — 11/11 (inventree) + 9/9 (matrix) pass, run directly against Python 3.13 + pip-installed deps (`bbr`/`bazelisk` unable to reach BuildBuddy in this session)
- [x] `ruff check`/`ruff format` — clean
- [x] `buildifier` — clean
- [x] Local mypy (trimmed config, real `mypy.ini`'s pydantic plugin unavailable in this session) — only the same "missing py.typed stub" notes already seen for `inventree`/`kubernetes`/`pytest_bazel`, no new errors, none on lines this diff touches
- [x] `pre-commit run` on changed files — all applicable hooks pass

https://claude.ai/code/session_01Ta13s4j8nXANE1mdjCn2r5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ta13s4j8nXANE1mdjCn2r5)_