### PR TITLE
cluster/oci-cache: expose Service on port 80 for haku-ci reachability

### DIFF
--- a/cluster/k8s/oci-cache/README.md
+++ b/cluster/k8s/oci-cache/README.md
@@ -7,27 +7,28 @@ allowlisting every registry CDN.
 
 ## Architecture
 
-| Concern            | Choice                                                                                                                                           |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Registry           | Zot (`ghcr.io/project-zot/zot-linux-amd64`, full image — needs the `sync` extension)                                                             |
-| Durable content    | SeaweedFS S3 `registry-cache` bucket (`seaweedfs/registry-cache-bucket/`) — manifests + blobs                                                    |
-| Dedupe index       | `oci-cache-valkey` `RedisReplication` (Zot `cacheDriver: redis`, `remoteCache`)                                                                  |
-| Local state        | none durable — only ephemeral upload staging on `emptyDir`, so the pod reschedules freely                                                        |
-| Placement          | unpinned (soft-prefers OVH region to sit near SeaweedFS); Valkey on `seaweedfs-ovh` (HDD, networked)                                             |
-| S3 credentials     | `s3-identity-registry-cache` Secret (seaweedfs ns), Reflector-mirrored into `oci-cache`, injected as `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` |
-| Exposure (phase 1) | ClusterIP `oci-cache.oci-cache.svc:5000` only — no public route, no auth                                                                         |
+| Concern            | Choice                                                                                                                                                                                                         |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Registry           | Zot (`ghcr.io/project-zot/zot-linux-amd64`, full image — needs the `sync` extension)                                                                                                                           |
+| Durable content    | SeaweedFS S3 `registry-cache` bucket (`seaweedfs/registry-cache-bucket/`) — manifests + blobs                                                                                                                  |
+| Dedupe index       | `oci-cache-valkey` `RedisReplication` (Zot `cacheDriver: redis`, `remoteCache`)                                                                                                                                |
+| Local state        | none durable — only ephemeral upload staging on `emptyDir`, so the pod reschedules freely                                                                                                                      |
+| Placement          | unpinned (soft-prefers OVH region to sit near SeaweedFS); Valkey on `seaweedfs-ovh` (HDD, networked)                                                                                                           |
+| S3 credentials     | `s3-identity-registry-cache` Secret (seaweedfs ns), Reflector-mirrored into `oci-cache`, injected as `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`                                                               |
+| Exposure (phase 1) | ClusterIP, plain HTTP on `oci-cache.oci-cache.svc:80` (→ container 5000) — no public route, no auth. Port 80 (not 5000) so port-restricted consumers like haku-ci can reach it without a NetworkPolicy change. |
 
-Upstreams are addressed **by path prefix** (Zot `sync` `stripPrefix`):
+Upstreams are addressed **by path prefix** (Zot `sync` `stripPrefix`); the endpoint
+is plain HTTP on port 80, so clients need an `http://` endpoint / insecure-registry config:
 
-| Upstream          | Pull as                                          |
-| ----------------- | ------------------------------------------------ |
-| `docker.io`       | `oci-cache.oci-cache.svc:5000/docker-hub/<repo>` |
-| `ghcr.io`         | `oci-cache.oci-cache.svc:5000/ghcr/<repo>`       |
-| `quay.io`         | `oci-cache.oci-cache.svc:5000/quay/<repo>`       |
-| `registry.k8s.io` | `oci-cache.oci-cache.svc:5000/k8s/<repo>`        |
-| `gcr.io`          | `oci-cache.oci-cache.svc:5000/gcr/<repo>`        |
+| Upstream          | Pull as                                     |
+| ----------------- | ------------------------------------------- |
+| `docker.io`       | `oci-cache.oci-cache.svc/docker-hub/<repo>` |
+| `ghcr.io`         | `oci-cache.oci-cache.svc/ghcr/<repo>`       |
+| `quay.io`         | `oci-cache.oci-cache.svc/quay/<repo>`       |
+| `registry.k8s.io` | `oci-cache.oci-cache.svc/k8s/<repo>`        |
+| `gcr.io`          | `oci-cache.oci-cache.svc/gcr/<repo>`        |
 
-e.g. `docker.io/library/nginx` → `oci-cache.oci-cache.svc:5000/docker-hub/library/nginx`.
+e.g. `docker.io/library/nginx` → `oci-cache.oci-cache.svc/docker-hub/library/nginx`.
 
 ## Eviction
 
@@ -64,8 +65,9 @@ The public, authenticated endpoint and node-level pull-through are deliberately 
 
 4. **Haku dind allowlist** — point Haku CI's dind `--registry-mirror` at this Service and
    drop the registry CDN FQDNs from `cluster/k8s/agents/haku-egress-proxy/`
-   (`cnp-haku-cloud-api-egress.yaml`, the `TODO(pull-through-cache)`). Needs a
-   NetworkPolicy allowing egress from the runner to `oci-cache`.
+   (`cnp-haku-cloud-api-egress.yaml`, the `TODO(pull-through-cache)`). No egress-policy
+   change needed: the Service is on port 80, which haku-ci's `toEntities: cluster` rule
+   already permits (the claude/haku sandboxes have unrestricted cluster egress).
 
 ## Verify before trusting it
 
@@ -76,5 +78,5 @@ drift), and the `sync` prefix/`stripPrefix` routing. Smoke test:
 
 ```bash
 kubectl -n oci-cache run probe --rm -it --image=curlimages/curl --restart=Never -- \
-  curl -sS http://oci-cache:5000/v2/docker-hub/library/alpine/manifests/latest -I
+  curl -sS http://oci-cache/v2/docker-hub/library/alpine/manifests/latest -I
 ```

--- a/cluster/k8s/oci-cache/app/service.yaml
+++ b/cluster/k8s/oci-cache/app/service.yaml
@@ -9,7 +9,10 @@ spec:
   selector:
     app.kubernetes.io/name: zot
   ports:
+    # Exposed on 80 (→ container 5000) so port-restricted in-cluster consumers
+    # like haku-ci — whose egress allows cluster traffic on 80/443/3000 — can
+    # reach the mirror without a NetworkPolicy change. Plain HTTP.
     - name: http
-      port: 5000
+      port: 80
       targetPort: http
       protocol: TCP


### PR DESCRIPTION
Makes `oci-cache` reachable by the port-restricted agent consumers, per the egress request.

**Finding:** the claude-sandbox and haku-sandbox egress policies already have an *unrestricted* `toEntities: cluster` rule, so they can already reach `oci-cache`. The one that couldn't is **haku-ci** (the dind runner) — its `toEntities: cluster` is port-capped to 80/443/3000 (for in-cluster Forgejo), and Zot was on 5000.

**Fix (Option A):** move the `oci-cache` Service to **port 80** (→ container 5000). haku-ci reaches it via its existing `:80` cluster allow — **no NetworkPolicy edit**, and `:80` is the conventional in-cluster registry port. Container/config stay on 5000.

README endpoint references updated (`:5000` → `:80`, plain HTTP), including the phase-2 note (haku-ci no longer needs an egress-policy change).

Follows #2854 (crashloop fix), which merged; the Zot pod should now be reconciling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015rpAEqZPQNV4gc5fuUCtVE

---
_Generated by [Claude Code](https://claude.ai/code/session_015rpAEqZPQNV4gc5fuUCtVE)_