### PR TITLE
cluster/oci-cache: fix zot sync prefix routing (was mapping backwards)

### DIFF
--- a/cluster/k8s/oci-cache/app/config.json
+++ b/cluster/k8s/oci-cache/app/config.json
@@ -53,31 +53,31 @@
           "urls": ["https://registry-1.docker.io"],
           "onDemand": true,
           "tlsVerify": true,
-          "content": [{ "prefix": "/docker-hub/**", "destination": "/", "stripPrefix": true }]
+          "content": [{ "prefix": "**", "destination": "/docker-hub" }]
         },
         {
           "urls": ["https://ghcr.io"],
           "onDemand": true,
           "tlsVerify": true,
-          "content": [{ "prefix": "/ghcr/**", "destination": "/", "stripPrefix": true }]
+          "content": [{ "prefix": "**", "destination": "/ghcr" }]
         },
         {
           "urls": ["https://quay.io"],
           "onDemand": true,
           "tlsVerify": true,
-          "content": [{ "prefix": "/quay/**", "destination": "/", "stripPrefix": true }]
+          "content": [{ "prefix": "**", "destination": "/quay" }]
         },
         {
           "urls": ["https://registry.k8s.io"],
           "onDemand": true,
           "tlsVerify": true,
-          "content": [{ "prefix": "/k8s/**", "destination": "/", "stripPrefix": true }]
+          "content": [{ "prefix": "**", "destination": "/k8s" }]
         },
         {
           "urls": ["https://gcr.io"],
           "onDemand": true,
           "tlsVerify": true,
-          "content": [{ "prefix": "/gcr/**", "destination": "/", "stripPrefix": true }]
+          "content": [{ "prefix": "**", "destination": "/gcr" }]
         }
       ]
     }


### PR DESCRIPTION
Ran the functional pull-through test against the live cache (now that #2854/#2856 landed and Zot is serving) — **every prefix 404'd**. Zot's logs showed why: for a request `X` it tried `<upstream>/docker-hub/X` on *every* registry, i.e. it **prepended** the prefix to the upstream repo instead of stripping it. `docker-hub/library/alpine` never mapped to `docker.io/library/alpine`.

**Root cause.** In Zot's `sync` extension, `content.prefix` matches the **upstream** repo path (not the client path — a docs summary I first trusted had this backwards), `destination` is the local root, and `stripPrefix` strips the matched prefix from the *local* path. So the old `{prefix:/docker-hub/**, destination:/, stripPrefix:true}` meant "upstream repos under `docker-hub/`, stored at local root" — meaningless for Docker Hub, and the on-demand reverse-map prepended `docker-hub`.

**Fix.** Mirror each upstream's whole namespace (`prefix:"**"`) under a distinct local destination namespace:

```json
{ "prefix": "**", "destination": "/docker-hub" }   // and /ghcr, /quay, /k8s, /gcr
```

Now `docker-hub/library/alpine` → strip the `docker-hub` destination → fetch `library/alpine` from docker.io; each registry is routed unambiguously by its destination namespace. Confirmed against the upstream `examples/config-sync.json` semantics.

Verified live so far: Zot Running, S3 + Valkey connected, `/v2/` 200, reachable from `haku-sandbox`. Will re-run the pull test once this reconciles to confirm a real image caches through and lands in S3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015rpAEqZPQNV4gc5fuUCtVE

---
_Generated by [Claude Code](https://claude.ai/code/session_015rpAEqZPQNV4gc5fuUCtVE)_