### PR TITLE
forgejo: repoint git PVC to SSD tier (Phase 3 cutover)

### DIFF
--- a/cluster/k8s/forgejo/app/helmrelease.yaml
+++ b/cluster/k8s/forgejo/app/helmrelease.yaml
@@ -259,7 +259,9 @@ spec:
       # migration cutover. (The old gitea-shared-storage PVC has the chart's
       # helm.sh/resource-policy:keep annotation, so it survives as a rollback.)
       create: false
-      claimName: forgejo-git-rwx
+      # git repos on the SeaweedFS SSD tier (Phase 3, ovh_storage_tiering.md). Migrated
+      # from forgejo-git-rwx (HDD) via VolSync rsync-TLS; read-zero-downtime rolling repoint.
+      claimName: forgejo-git-rwx-ssd
       # The chart refuses replicaCount > 1 unless accessModes[0] is ReadWriteMany
       # (a guard against a single-writer FS under multiple replicas). create:false
       # means the chart won't actually create a PVC from this — our git-storage-pvc.yaml


### PR DESCRIPTION
Rolling repoint of Forgejo's git claimName forgejo-git-rwx (HDD) -> forgejo-git-rwx-ssd (SSD), after the VolSync pre-seed + frozen-write final delta sync. RollingUpdate maxUnavailable=0 keeps reads up. Rollback = revert (old PVC intact).