### PR TITLE
cluster/oci-cache: record reload-fix options + mark cache verified

### DIFF
--- a/cluster/docs/lessons_learned/2026_07_04_seaweedfs_s3_identity_stale_after_tenant_add.md
+++ b/cluster/docs/lessons_learned/2026_07_04_seaweedfs_s3_identity_stale_after_tenant_add.md
@@ -74,18 +74,33 @@ until one of the durable fixes below lands.
 The operator is already on the latest (v1.0.30 / chart 0.1.33) — there is no newer-version
 fix. The static-`configSecret` model is the constraint.
 
-1. **Reloader `reloadStrategy: annotations`.** The operator preserves pod-template
-   _annotations_ (it kept a `restartedAt` from a manual restart) but strips Reloader's
-   default _env-var_ patch. Switching Reloader's global strategy to `annotations` may make
-   its reloads survive reconciliation. Global setting — validate against all Reloader-managed
-   workloads before adopting.
-2. **Filer-backed dynamic identities.** SeaweedFS hot-reloads identities managed via the
-   filer (`weed shell s3.configure` / the embedded IAM API / credential manager) with no
-   restart. This is the "proper" fix but an architecture change away from the static
-   `configSecret`, with known upstream footguns
+1. **Reloader `reloadStrategy: annotations`** — cheapest; try first. Evidence it should
+   work: when Reloader fired we watched the operator revert its default _env-var_ patch (the
+   fresh RS scaled to 0), yet a `restartedAt` _annotation_ (not in the CR) survived on the
+   same pod template. So the operator overwrites container spec but **merges** pod-template
+   annotations — an annotation-mode patch should survive reconciliation and roll the gateway.
+   One-line change in `cluster/k8s/reloader/reloader.yaml`. Caveats: `reloadStrategy` is a
+   **global** Reloader setting (affects every managed workload — `annotations` is a common,
+   low-risk mode though), and it's unproven here, so validate on the next tenant add.
+2. **Automate the restart** (the guaranteed fallback if A doesn't survive the operator). A
+   small reconciler in `cluster/provisioners/` (matching grocy/inventree/matrix) that hashes
+   `seaweedfs-s3-config` and, on change, runs `kubectl delete pod -l
+app.kubernetes.io/component=s3` — pod deletion is _not_ reverted by the operator. Isolated
+   to seaweedfs; costs a new moving part + up to one poll-interval of lag.
+3. **Filer-backed dynamic identities** (the "proper" fix, biggest lift). SeaweedFS
+   hot-reloads identities stored in the filer (`weed shell s3.configure` / the embedded IAM
+   API / credential manager) with no restart. But: the operator has **no identity CRD** (only
+   `Seaweed` + `Bucket`), so identities would be provisioned _outside_ it — a `provisioners/`
+   Job upserting each tenant into the filer from the SOPS `s3-identity-*` secrets. The
+   **load-bearing unknown** is whether `weed s3` can be pointed at the filer credential store
+   under this operator (the CR wires `configSecret → -config` with no obvious knob; may need
+   `additionalArgs`/a patch). Go **fully** filer-backed, not half — mixing static + dynamic
+   auth has upstream footguns
    ([#8331](https://github.com/seaweedfs/seaweedfs/issues/8331),
    [#6442](https://github.com/seaweedfs/seaweedfs/issues/6442),
-   [#6130](https://github.com/seaweedfs/seaweedfs/issues/6130)).
-3. **Automate the restart.** A small controller/Job that deletes `seaweedfs-s3` pods when
-   `seaweedfs-s3-config` changes — closes the gap without the operator conflict, at the cost
-   of a moving part.
+   [#6130](https://github.com/seaweedfs/seaweedfs/issues/6130)). Only worth it if S3-tenant
+   churn becomes frequent.
+
+**Recommended order:** try (1) — one line, evidence-backed; fall back to (2) — guaranteed —
+if the operator strips annotations too; reach for (3) only if tenant churn makes the manual
+restart a real tax.

--- a/cluster/k8s/oci-cache/README.md
+++ b/cluster/k8s/oci-cache/README.md
@@ -69,14 +69,25 @@ The public, authenticated endpoint and node-level pull-through are deliberately 
    change needed: the Service is on port 80, which haku-ci's `toEntities: cluster` rule
    already permits (the claude/haku sandboxes have unrestricted cluster egress).
 
-## Verify before trusting it
+## Verified working (2026-07-04)
 
-Config points not smoke-tested at authoring time (no live cluster access): the pinned
-Zot image tag (`v2.1.11`), the exact S3 `storageDriver` keys against this Zot version
-(see [zot#3571](https://github.com/project-zot/zot/issues/3571) re 2.1.10 S3 config
-drift), and the `sync` prefix/`stripPrefix` routing. Smoke test:
+Confirmed live end-to-end: image tag `v2.1.11` runs with the `sync` extension, the S3
+`storageDriver` keys are correct, the `prefix`/`destination` routing resolves
+(`docker-hub/library/busybox` → `docker.io/library/busybox`), Docker Hub anonymous pull
+works, and a fresh image **persists to the SeaweedFS bucket** (`successfully synced image`
+in Zot's log; tag reads back). Getting here took three fixes on top of the initial deploy:
+`sync.downloadDir` (crashloop), the `prefix:"**"` + `destination` routing (was mapping
+backwards), and a `seaweedfs-s3` gateway restart so it loaded the `registry-cache` identity
+(see the SeaweedFS S3 identity RCA in `../../docs/lessons_learned/`).
+
+Smoke test (use a **fresh** tag — an image pulled during the pre-fix window can be stuck in
+Zot's metadb as "already synced"; clear with `kubectl -n oci-cache rollout restart
+deploy/zot` + a Valkey flush):
 
 ```bash
 kubectl -n oci-cache run probe --rm -it --image=curlimages/curl --restart=Never -- \
-  curl -sS http://oci-cache/v2/docker-hub/library/alpine/manifests/latest -I
+  curl -sS http://oci-cache/v2/docker-hub/library/busybox/manifests/latest -I
 ```
+
+Known cosmetic quirk: `GET /v2/_catalog` lists empty even for cached repos (clients pull by
+name, not via the catalog, so pulls are unaffected).


### PR DESCRIPTION
Notes for later (per request — **no implementation**), plus a doc correction now that the cache is confirmed working live.

**Reload-fix options** (in the SeaweedFS S3 identity RCA doc) — sharpened into a prioritized list with the evidence/unknowns for each:
1. Reloader `reloadStrategy: annotations` — cheapest, try first (evidence: the operator reverted Reloader's env-var patch but preserved a `restartedAt` *annotation*, so it merges annotations); global setting, validate on next tenant add.
2. Automated pod-restart reconciler in `provisioners/` — guaranteed fallback (pod deletion isn't reverted).
3. Filer-backed dynamic identities — the "proper" fix but biggest lift; operator has no identity CRD, and the load-bearing unknown is whether `weed s3` can use the filer credential store under this operator.

**oci-cache README** — the pull-through is now verified end-to-end on the cluster (routing + Docker Hub anon pull + S3 persistence, confirmed with a fresh busybox pull: `successfully synced image`, tag reads back). Replaced the "unverified at authoring time" caveats with the verified status, a fresh-tag smoke test, and a note on the cosmetic empty-`_catalog` quirk.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015rpAEqZPQNV4gc5fuUCtVE

---
_Generated by [Claude Code](https://claude.ai/code/session_015rpAEqZPQNV4gc5fuUCtVE)_