### PR TITLE
litellm: pin to hil-ovh (seaweedfs-ovh chatgpt-auth PVC) + SC-scheduling TODO

### DIFF
--- a/cluster/docs/plan.md
+++ b/cluster/docs/plan.md
@@ -82,17 +82,24 @@ returns (not independently parked):
       (its `region=proxmox` preference for ollama co-location pulled a replica onto
       wyrm2 with the `chatgpt-auth` PVC). **Interim (done):** pin the affected consumer
       to `zone=hil-ovh` via `nodeSelector` — but that's **per-consumer duplication**.
-      Less-duplicative + more-capable fixes to evaluate, in rough order:
-  - **Run seaweedfs-csi on wyrm2** (relax the DaemonSet's `hil-ovh` zone affinity,
-    confirm the mount reaches the OVH filer over nebula) — then `seaweedfs-ovh` RWX PVCs
-    work there too, and litellm can go back to preferring proxmox for ollama co-location
-    (drop the interim `nodeSelector`). This is the direction the goal actually wants.
-  - **Give seaweedfs-csi topology** so `allowedTopologies` on the SC steers the scheduler
-    from one place. **Needs upstream/forked driver code** — v1.4.14 implements no topology
-    (no `accessible_topology` in `NodeGetInfo`, no flag, registers `topologyKeys=null`),
-    so it is not configurable; and it formalizes "hil-ovh only", the opposite of the above.
-  - A **Kyverno mutating policy** injecting the `zone=hil-ovh` constraint for any pod that
-    mounts a `seaweedfs-ovh*` PVC — zero driver changes, one place; the pragmatic middle.
+      **Locality caveat:** wyrm2 is in SF, hil-ovh in Oregon, so a `seaweedfs-ovh` mount
+      on wyrm2 does its I/O **cross-DC over nebula**. So "CSI only in hil-ovh" is partly a
+      _feature_ (keeps SeaweedFS I/O in-DC); the actual bug is only the ugly failure mode
+      (stuck Pending) instead of a clean "keep it in-DC" scheduling rule. For most
+      consumers, staying in hil-ovh **is** correct — litellm especially, since its Postgres
+      (`litellm-db`, `local-path-ovh`) is in-DC and hit per request; ollama fallback calls
+      crossing the mesh from hil-ovh is the cheaper trade than a cross-DC DB. Fixes:
+  - **Kyverno mutating policy** injecting `zone=hil-ovh` for any pod mounting a
+    `seaweedfs-ovh*` PVC — zero driver changes, one place, and it encodes the correct
+    default (keep SeaweedFS consumers in-DC). Preferred.
+  - **Give seaweedfs-csi topology** so `allowedTopologies` on the SC does the same from the
+    SC. **Needs upstream/forked driver code** — v1.4.14 implements no topology (no
+    `accessible_topology` in `NodeGetInfo`, no flag, registers `topologyKeys=null`), so it
+    is not configurable.
+  - **Run seaweedfs-csi on wyrm2** — only worth it for **tiny/occasional-I/O** volumes
+    (e.g. the codex/chatgpt `auth.json`, read at startup + rare refresh) where cross-DC
+    latency is negligible AND you specifically want the wyrm2 pod (e.g. ollama
+    co-location). **Not** a blanket enable — heavy or DB-hot workloads must stay in-DC.
 
 - [ ] **etcd lease-PUT latency / control-plane HDD I/O contention.** etcd runs on
       rotational HDDs on the KS-5 control planes (no SSD there; the NVMe is on the

--- a/cluster/docs/plan.md
+++ b/cluster/docs/plan.md
@@ -82,12 +82,17 @@ returns (not independently parked):
       (its `region=proxmox` preference for ollama co-location pulled a replica onto
       wyrm2 with the `chatgpt-auth` PVC). **Interim (done):** pin the affected consumer
       to `zone=hil-ovh` via `nodeSelector` — but that's **per-consumer duplication**.
-      Evaluate a less-duplicative + more-capable fix, roughly in order: 1. **Run seaweedfs-csi on wyrm2** (relax the DaemonSet's `hil-ovh` zone affinity,
-      confirm the mount reaches the OVH filer over nebula) — then `seaweedfs-ovh`
-      RWX PVCs work there too, and litellm can go back to preferring proxmox for
-      ollama co-location (drop the interim `nodeSelector`). 2. **Give seaweedfs-csi topology** so `allowedTopologies` on the SC steers the
-      scheduler from one place instead of a `nodeSelector` on every consumer. 3. Failing both, a **Kyverno mutating policy** injecting the `zone=hil-ovh`
-      constraint for any pod that mounts a `seaweedfs-ovh*` PVC.
+      Less-duplicative + more-capable fixes to evaluate, in rough order:
+  - **Run seaweedfs-csi on wyrm2** (relax the DaemonSet's `hil-ovh` zone affinity,
+    confirm the mount reaches the OVH filer over nebula) — then `seaweedfs-ovh` RWX PVCs
+    work there too, and litellm can go back to preferring proxmox for ollama co-location
+    (drop the interim `nodeSelector`). This is the direction the goal actually wants.
+  - **Give seaweedfs-csi topology** so `allowedTopologies` on the SC steers the scheduler
+    from one place. **Needs upstream/forked driver code** — v1.4.14 implements no topology
+    (no `accessible_topology` in `NodeGetInfo`, no flag, registers `topologyKeys=null`),
+    so it is not configurable; and it formalizes "hil-ovh only", the opposite of the above.
+  - A **Kyverno mutating policy** injecting the `zone=hil-ovh` constraint for any pod that
+    mounts a `seaweedfs-ovh*` PVC — zero driver changes, one place; the pragmatic middle.
 
 - [ ] **etcd lease-PUT latency / control-plane HDD I/O contention.** etcd runs on
       rotational HDDs on the KS-5 control planes (no SSD there; the NVMe is on the

--- a/cluster/docs/plan.md
+++ b/cluster/docs/plan.md
@@ -72,6 +72,23 @@ returns (not independently parked):
 
 ## Next Actions
 
+- [ ] **SeaweedFS CSI node coverage — `seaweedfs-ovh` consumers can't schedule off
+      hil-ovh.** The `seaweedfs-csi-driver-node` DaemonSet is pinned to
+      `topology.kubernetes.io/zone=hil-ovh` and reports **no topology keys**
+      (`CSINode ... topologyKeys=null`), so `allowedTopologies` on the SeaweedFS
+      StorageClasses is a **no-op** — the scheduler can place a pod with a
+      `seaweedfs-ovh` PVC anywhere (e.g. wyrm2), where the CSI is absent and the PVC
+      then fails to attach (stuck `Pending`, `FailedAttachVolume`). Hit by litellm
+      (its `region=proxmox` preference for ollama co-location pulled a replica onto
+      wyrm2 with the `chatgpt-auth` PVC). **Interim (done):** pin the affected consumer
+      to `zone=hil-ovh` via `nodeSelector` — but that's **per-consumer duplication**.
+      Evaluate a less-duplicative + more-capable fix, roughly in order: 1. **Run seaweedfs-csi on wyrm2** (relax the DaemonSet's `hil-ovh` zone affinity,
+      confirm the mount reaches the OVH filer over nebula) — then `seaweedfs-ovh`
+      RWX PVCs work there too, and litellm can go back to preferring proxmox for
+      ollama co-location (drop the interim `nodeSelector`). 2. **Give seaweedfs-csi topology** so `allowedTopologies` on the SC steers the
+      scheduler from one place instead of a `nodeSelector` on every consumer. 3. Failing both, a **Kyverno mutating policy** injecting the `zone=hil-ovh`
+      constraint for any pod that mounts a `seaweedfs-ovh*` PVC.
+
 - [ ] **etcd lease-PUT latency / control-plane HDD I/O contention.** etcd runs on
       rotational HDDs on the KS-5 control planes (no SSD there; the NVMe is on the
       KS-GAME workers). **Recurred 2026-06-28 as a full outage** (two CPs NotReady,

--- a/cluster/k8s/litellm/app/deployment.yaml
+++ b/cluster/k8s/litellm/app/deployment.yaml
@@ -67,20 +67,17 @@ spec:
             - name: chatgpt-auth-seed
               mountPath: /seed
               readOnly: true
-      # Prefer the Proxmox GPU host (co-located with ollama for its fallback
-      # paths), but allow scheduling elsewhere (e.g. OVH) so external-provider
-      # models (z.ai/GLM) keep serving when the home node is offline — ollama
-      # is unreachable during a home outage regardless of where litellm runs.
-      affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              preference:
-                matchExpressions:
-                  - key: topology.kubernetes.io/region
-                    operator: In
-                    values:
-                      - proxmox
+      # Must run on hil-ovh. The chatgpt-auth PVC is seaweedfs-ovh, and the SeaweedFS
+      # CSI node plugin only runs on OVH nodes (zone hil-ovh) and reports no topology
+      # keys — so allowedTopologies can't steer the scheduler and a pod that lands
+      # elsewhere can't mount the PVC and hangs Pending. The old `prefer region=proxmox`
+      # affinity (for ollama GPU co-location) did exactly that, wedging a replica on
+      # wyrm2. Losing co-location is acceptable: ollama calls just cross the mesh, and
+      # external-provider models keep serving when home is offline either way.
+      # TODO(seaweedfs-csi-on-wyrm2): once the CSI runs on wyrm2, restore the proxmox
+      # preference — see cluster/docs/plan.md Next Actions.
+      nodeSelector:
+        topology.kubernetes.io/zone: hil-ovh
       containers:
         - name: litellm
           image: litellm/litellm:1.90.2


### PR DESCRIPTION
litellm's `region=proxmox` preference pulled a replica onto wyrm2, where the seaweedfs-csi driver is absent, so its `chatgpt-auth` (seaweedfs-ovh) PVC couldn't attach → stuck Pending. Pin to `zone=hil-ovh` via nodeSelector. Files a Next Actions TODO to fix the general `seaweedfs-ovh`-can't-schedule-off-hil-ovh gap with less duplication (CSI on wyrm2 / CSI topology / Kyverno mutation).