### PR TITLE
oci-cache: route haku-ci dind Docker Hub pulls through the mirror (Tier 1)

### DIFF
--- a/cluster/k8s/agents/haku-egress-proxy/cnp-haku-cloud-api-egress.yaml
+++ b/cluster/k8s/agents/haku-egress-proxy/cnp-haku-cloud-api-egress.yaml
@@ -31,24 +31,16 @@ spec:
     - toFQDNs:
         # Container image registries (base-image + tooling pulls: dind base images,
         # ghcr tools).
-        # TODO(pull-through-cache): these OCI-registry hosts can leave this allowlist
-        #   entirely once an in-cluster pull-through mirror exists again — the mirror
-        #   fetches from origin under ITS own egress and dind points at it via
-        #   `--registry-mirror`, so the runner/proxy no longer needs Docker Hub / ghcr
-        #   here. (This re-homes the `haku-ci-pull-through-cache` TODO deleted with
-        #   haku-ci/networkpolicy.yaml; tracked in cluster/docs/plan.md. registry:2 is
-        #   single-upstream, so Docker Hub and ghcr need one proxy each — or Harbor
-        #   proxy-cache projects, once Harbor is back.)
+        # Docker Hub is gone from this allowlist: haku-ci's dind pulls Docker Hub
+        # through the in-cluster oci-cache Zot mirror (`--registry-mirror`, see
+        # cluster/k8s/oci-cache/), which fetches from origin under its OWN namespace
+        # egress — so the runner no longer needs registry-1.docker.io / auth.docker.io /
+        # the cloudflare+cloudfront blob fronts / index.docker.io here.
+        # ghcr stays until dind can mirror it too (needs containerd hosts.toml /
+        # buildkit — classic dockerd only mirrors Docker Hub). See the oci-cache README
+        # "Phase 2" + cluster/docs/plan.md.
         - matchName: ghcr.io
         - matchName: pkg-containers.githubusercontent.com
-        - matchName: registry-1.docker.io
-        - matchName: auth.docker.io
-        - matchName: production.cloudflare.docker.com
-        # Docker Hub 307-redirects blob/config GETs to BOTH cloudFLARE and
-        # cloudFRONT fronts — both required (the easily-confused pair; missing
-        # cloudfront makes blob pulls dial-timeout with "No such image").
-        - matchName: production.cloudfront.docker.com
-        - matchName: index.docker.io
         - matchName: gmail.googleapis.com
         - matchName: www.googleapis.com
         # Google Tasks API — Haku reads the operator's task list (the Tasks

--- a/cluster/k8s/haku-ci/deployment.yaml
+++ b/cluster/k8s/haku-ci/deployment.yaml
@@ -118,6 +118,15 @@ spec:
           args:
             - --host=tcp://0.0.0.0:2375
             - --tls=false
+            # Pull Docker Hub base images through the in-cluster oci-cache Zot mirror
+            # instead of docker.io (+ its CDN fronts) directly — that's why the Docker
+            # Hub FQDNs are gone from the haku-egress-proxy allowlist. The mirror serves
+            # Docker Hub at its root and fetches from origin under oci-cache's own egress.
+            # `.svc.cluster.local` so NO_PROXY routes it direct (not via the proxy);
+            # insecure-registry because oci-cache is plain HTTP on :80. Classic dockerd
+            # only mirrors Docker Hub — ghcr/quay still go direct via the proxy.
+            - --registry-mirror=http://oci-cache.oci-cache.svc.cluster.local
+            - --insecure-registry=oci-cache.oci-cache.svc.cluster.local
           # --tls=false alone isn't enough: the dind entrypoint defaults DOCKER_TLS_CERTDIR
           # to /certs and re-enables TLS on 2375, so the runner's plain-HTTP client hits
           # "HTTP request to an HTTPS server". Emptying it disables TLS so 2375 is plain HTTP

--- a/cluster/k8s/oci-cache/README.md
+++ b/cluster/k8s/oci-cache/README.md
@@ -30,6 +30,19 @@ is plain HTTP on port 80, so clients need an `http://` endpoint / insecure-regis
 
 e.g. `docker.io/library/nginx` → `oci-cache.oci-cache.svc/docker-hub/library/nginx`.
 
+Docker Hub is **also** served at the **root** (`oci-cache.oci-cache.svc/library/nginx`),
+so it works with Docker's `--registry-mirror` (which is Hub-only and can't take a path
+prefix). Note the root is a catch-all — it's listed last so the prefixed registries match
+first.
+
+## Consumers
+
+- **haku-ci dind** pulls Docker Hub base images via `--registry-mirror` (see
+  `cluster/k8s/haku-ci/deployment.yaml`); the Docker Hub FQDNs are consequently dropped
+  from the `haku-egress-proxy` allowlist. ghcr/quay aren't mirrored yet — classic dockerd
+  only mirrors Docker Hub; collapsing those needs containerd `hosts.toml` / buildkit
+  (Phase 2).
+
 ## Eviction
 
 Time/count-based, **not** a hard byte cap. A cached tag is kept if pulled within the

--- a/cluster/k8s/oci-cache/app/config.json
+++ b/cluster/k8s/oci-cache/app/config.json
@@ -78,6 +78,12 @@
           "onDemand": true,
           "tlsVerify": true,
           "content": [{ "prefix": "**", "destination": "/gcr" }]
+        },
+        {
+          "urls": ["https://registry-1.docker.io"],
+          "onDemand": true,
+          "tlsVerify": true,
+          "content": [{ "prefix": "**", "destination": "/" }]
         }
       ]
     }


### PR DESCRIPTION
First payoff of the pull-through cache: shrink the `haku-egress-proxy` allowlist by routing haku-ci's dind Docker Hub pulls through `oci-cache`.

**Changes:**
- **haku-ci dind** (`deployment.yaml`): `--registry-mirror=http://oci-cache.oci-cache.svc.cluster.local` + `--insecure-registry=…` (the `.svc.cluster.local` name matches the existing `NO_PROXY` so it goes direct, not via the proxy; insecure because Zot is plain HTTP on :80).
- **oci-cache** (`config.json`): a 6th Zot sync entry — `registry-1.docker.io` at destination `/` (root), **listed last** so the prefixed registries still match first. Docker's `--registry-mirror` is Hub-only and takes no path, so Hub has to be at the mirror root; the existing `/docker-hub` prefix still works.
- **allowlist** (`cnp-haku-cloud-api-egress.yaml`): drop `registry-1.docker.io`, `auth.docker.io`, `production.cloudflare.docker.com`, `production.cloudfront.docker.com`, `index.docker.io`. The mirror fetches from origin under **oci-cache's** namespace egress, so haku-ci no longer needs them.

`ghcr.io` + `pkg-containers.githubusercontent.com` stay — classic dockerd only mirrors Docker Hub; collapsing ghcr/quay needs containerd `hosts.toml`/buildkit (Tier 2, deferred).

**Heads-up — this touches live haku CI.** If the mirror path is wrong, dind base-image pulls break (revert = re-add the FQDNs). I'll verify the oci-cache **root** mapping resolves once this reconciles (independent of dind), and a haku CI run will exercise the dind side. Note the intended availability coupling: with the Hub FQDNs gone, dind hard-depends on oci-cache for Hub pulls (oci-cache is in-cluster and falls back upstream itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015rpAEqZPQNV4gc5fuUCtVE

---
_Generated by [Claude Code](https://claude.ai/code/session_015rpAEqZPQNV4gc5fuUCtVE)_