### PR TITLE
haku-ci: allow egress to oci-cache backend :5000 (fix broken Docker Hub pulls)

### DIFF
--- a/cluster/k8s/agents/haku-egress-proxy/cnp-haku-cloud-api-egress.yaml
+++ b/cluster/k8s/agents/haku-egress-proxy/cnp-haku-cloud-api-egress.yaml
@@ -31,24 +31,16 @@ spec:
     - toFQDNs:
         # Container image registries (base-image + tooling pulls: dind base images,
         # ghcr tools).
-        # TODO(pull-through-cache): these OCI-registry hosts can leave this allowlist
-        #   entirely once an in-cluster pull-through mirror exists again — the mirror
-        #   fetches from origin under ITS own egress and dind points at it via
-        #   `--registry-mirror`, so the runner/proxy no longer needs Docker Hub / ghcr
-        #   here. (This re-homes the `haku-ci-pull-through-cache` TODO deleted with
-        #   haku-ci/networkpolicy.yaml; tracked in cluster/docs/plan.md. registry:2 is
-        #   single-upstream, so Docker Hub and ghcr need one proxy each — or Harbor
-        #   proxy-cache projects, once Harbor is back.)
+        # Docker Hub is gone from this allowlist: haku-ci's dind pulls Docker Hub
+        # through the in-cluster oci-cache Zot mirror (`--registry-mirror`, see
+        # cluster/k8s/oci-cache/), which fetches from origin under its OWN namespace
+        # egress — so the runner no longer needs registry-1.docker.io / auth.docker.io /
+        # the cloudflare+cloudfront blob fronts / index.docker.io here.
+        # ghcr stays until dind can mirror it too (needs containerd hosts.toml /
+        # buildkit — classic dockerd only mirrors Docker Hub). See the oci-cache README
+        # "Phase 2" + cluster/docs/plan.md.
         - matchName: ghcr.io
         - matchName: pkg-containers.githubusercontent.com
-        - matchName: registry-1.docker.io
-        - matchName: auth.docker.io
-        - matchName: production.cloudflare.docker.com
-        # Docker Hub 307-redirects blob/config GETs to BOTH cloudFLARE and
-        # cloudFRONT fronts — both required (the easily-confused pair; missing
-        # cloudfront makes blob pulls dial-timeout with "No such image").
-        - matchName: production.cloudfront.docker.com
-        - matchName: index.docker.io
         - matchName: gmail.googleapis.com
         - matchName: www.googleapis.com
         # Google Tasks API — Haku reads the operator's task list (the Tasks

--- a/cluster/k8s/haku-ci/ccnp-force-proxy-egress.yaml
+++ b/cluster/k8s/haku-ci/ccnp-force-proxy-egress.yaml
@@ -39,7 +39,11 @@ spec:
     # All cluster-internal traffic (bypasses the proxy via NO_PROXY). This is how
     # the runner reaches the in-cluster Forgejo git + OCI registry
     # (forgejo-http.forgejo:3000) it clones source from, pushes images to, and
-    # long-polls for jobs.
+    # long-polls for jobs, plus the oci-cache Zot mirror for dind base-image pulls.
+    # GOTCHA: Cilium's socket-LB translates a ClusterIP:port to backend podIP:targetPort
+    # *before* egress policy is enforced, so the port here must be the backend
+    # targetPort, not the Service port. oci-cache's Service is :80 but its pods listen
+    # on 5000 — hence 5000, not 80, is what unblocks dind→oci-cache.
     - toEntities:
         - cluster
       toPorts:
@@ -49,6 +53,8 @@ spec:
             - port: "443"
               protocol: TCP
             - port: "3000"
+              protocol: TCP
+            - port: "5000"
               protocol: TCP
     # haku-egress-proxy — all external internet traffic must go through here.
     - toEndpoints:

--- a/cluster/k8s/haku-ci/deployment.yaml
+++ b/cluster/k8s/haku-ci/deployment.yaml
@@ -118,6 +118,15 @@ spec:
           args:
             - --host=tcp://0.0.0.0:2375
             - --tls=false
+            # Pull Docker Hub base images through the in-cluster oci-cache Zot mirror
+            # instead of docker.io (+ its CDN fronts) directly — that's why the Docker
+            # Hub FQDNs are gone from the haku-egress-proxy allowlist. The mirror serves
+            # Docker Hub at its root and fetches from origin under oci-cache's own egress.
+            # `.svc.cluster.local` so NO_PROXY routes it direct (not via the proxy);
+            # insecure-registry because oci-cache is plain HTTP on :80. Classic dockerd
+            # only mirrors Docker Hub — ghcr/quay still go direct via the proxy.
+            - --registry-mirror=http://oci-cache.oci-cache.svc.cluster.local
+            - --insecure-registry=oci-cache.oci-cache.svc.cluster.local
           # --tls=false alone isn't enough: the dind entrypoint defaults DOCKER_TLS_CERTDIR
           # to /certs and re-enables TLS on 2375, so the runner's plain-HTTP client hits
           # "HTTP request to an HTTPS server". Emptying it disables TLS so 2375 is plain HTTP

--- a/cluster/k8s/oci-cache/README.md
+++ b/cluster/k8s/oci-cache/README.md
@@ -30,6 +30,19 @@ is plain HTTP on port 80, so clients need an `http://` endpoint / insecure-regis
 
 e.g. `docker.io/library/nginx` → `oci-cache.oci-cache.svc/docker-hub/library/nginx`.
 
+Docker Hub is **also** served at the **root** (`oci-cache.oci-cache.svc/library/nginx`),
+so it works with Docker's `--registry-mirror` (which is Hub-only and can't take a path
+prefix). Note the root is a catch-all — it's listed last so the prefixed registries match
+first.
+
+## Consumers
+
+- **haku-ci dind** pulls Docker Hub base images via `--registry-mirror` (see
+  `cluster/k8s/haku-ci/deployment.yaml`); the Docker Hub FQDNs are consequently dropped
+  from the `haku-egress-proxy` allowlist. ghcr/quay aren't mirrored yet — classic dockerd
+  only mirrors Docker Hub; collapsing those needs containerd `hosts.toml` / buildkit
+  (Phase 2).
+
 ## Eviction
 
 Time/count-based, **not** a hard byte cap. A cached tag is kept if pulled within the

--- a/cluster/k8s/oci-cache/README.md
+++ b/cluster/k8s/oci-cache/README.md
@@ -7,15 +7,15 @@ allowlisting every registry CDN.
 
 ## Architecture
 
-| Concern            | Choice                                                                                                                                                                                                         |
-| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Registry           | Zot (`ghcr.io/project-zot/zot-linux-amd64`, full image — needs the `sync` extension)                                                                                                                           |
-| Durable content    | SeaweedFS S3 `registry-cache` bucket (`seaweedfs/registry-cache-bucket/`) — manifests + blobs                                                                                                                  |
-| Dedupe index       | `oci-cache-valkey` `RedisReplication` (Zot `cacheDriver: redis`, `remoteCache`)                                                                                                                                |
-| Local state        | none durable — only ephemeral upload staging on `emptyDir`, so the pod reschedules freely                                                                                                                      |
-| Placement          | unpinned (soft-prefers OVH region to sit near SeaweedFS); Valkey on `seaweedfs-ovh` (HDD, networked)                                                                                                           |
-| S3 credentials     | `s3-identity-registry-cache` Secret (seaweedfs ns), Reflector-mirrored into `oci-cache`, injected as `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`                                                               |
-| Exposure (phase 1) | ClusterIP, plain HTTP on `oci-cache.oci-cache.svc:80` (→ container 5000) — no public route, no auth. Port 80 (not 5000) so port-restricted consumers like haku-ci can reach it without a NetworkPolicy change. |
+| Concern            | Choice                                                                                                                                                                                                                                                                                                 |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Registry           | Zot (`ghcr.io/project-zot/zot-linux-amd64`, full image — needs the `sync` extension)                                                                                                                                                                                                                   |
+| Durable content    | SeaweedFS S3 `registry-cache` bucket (`seaweedfs/registry-cache-bucket/`) — manifests + blobs                                                                                                                                                                                                          |
+| Dedupe index       | `oci-cache-valkey` `RedisReplication` (Zot `cacheDriver: redis`, `remoteCache`)                                                                                                                                                                                                                        |
+| Local state        | none durable — only ephemeral upload staging on `emptyDir`, so the pod reschedules freely                                                                                                                                                                                                              |
+| Placement          | unpinned (soft-prefers OVH region to sit near SeaweedFS); Valkey on `seaweedfs-ovh` (HDD, networked)                                                                                                                                                                                                   |
+| S3 credentials     | `s3-identity-registry-cache` Secret (seaweedfs ns), Reflector-mirrored into `oci-cache`, injected as `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`                                                                                                                                                       |
+| Exposure (phase 1) | ClusterIP, plain HTTP on `oci-cache.oci-cache.svc:80` (→ container 5000) — no public route, no auth. (Port 80 is for conventional addressing; a port-restricted egress policy must still allow the **backend** port 5000 — Cilium enforces egress on the translated targetPort, not the Service port.) |
 
 Upstreams are addressed **by path prefix** (Zot `sync` `stripPrefix`); the endpoint
 is plain HTTP on port 80, so clients need an `http://` endpoint / insecure-registry config:
@@ -76,11 +76,13 @@ The public, authenticated endpoint and node-level pull-through are deliberately 
    `credentialsFile` to Zot's `sync` config keyed by `registry-1.docker.io` with a Docker
    Hub username + PAT. Anonymous pull-through works without it.
 
-4. **Haku dind allowlist** — point Haku CI's dind `--registry-mirror` at this Service and
-   drop the registry CDN FQDNs from `cluster/k8s/agents/haku-egress-proxy/`
-   (`cnp-haku-cloud-api-egress.yaml`, the `TODO(pull-through-cache)`). No egress-policy
-   change needed: the Service is on port 80, which haku-ci's `toEntities: cluster` rule
-   already permits (the claude/haku sandboxes have unrestricted cluster egress).
+4. **Haku dind allowlist — ghcr/quay (Docker Hub done in Tier 1).** Docker Hub already
+   routes through the mirror (see Consumers above); dropping `ghcr.io` +
+   `pkg-containers.githubusercontent.com` from `cnp-haku-cloud-api-egress.yaml` needs dind
+   to mirror ghcr too, which classic dockerd can't — enable Docker's containerd image
+   store + `hosts.toml`, or move to buildkit. Egress note: haku-ci's force-proxy policy
+   had to allow the **backend** port 5000 for the mirror (Cilium enforces on targetPort,
+   not the Service port).
 
 ## Verified working (2026-07-04)
 

--- a/cluster/k8s/oci-cache/app/config.json
+++ b/cluster/k8s/oci-cache/app/config.json
@@ -78,6 +78,12 @@
           "onDemand": true,
           "tlsVerify": true,
           "content": [{ "prefix": "**", "destination": "/gcr" }]
+        },
+        {
+          "urls": ["https://registry-1.docker.io"],
+          "onDemand": true,
+          "tlsVerify": true,
+          "content": [{ "prefix": "**", "destination": "/" }]
         }
       ]
     }

--- a/cluster/k8s/oci-cache/app/service.yaml
+++ b/cluster/k8s/oci-cache/app/service.yaml
@@ -9,9 +9,12 @@ spec:
   selector:
     app.kubernetes.io/name: zot
   ports:
-    # Exposed on 80 (→ container 5000) so port-restricted in-cluster consumers
-    # like haku-ci — whose egress allows cluster traffic on 80/443/3000 — can
-    # reach the mirror without a NetworkPolicy change. Plain HTTP.
+    # Exposed on 80 (→ container 5000) for conventional registry addressing by
+    # unrestricted consumers. NOTE: this does NOT let a port-restricted egress
+    # policy reach the mirror on :80 — Cilium's socket-LB enforces egress on the
+    # backend targetPort (5000), not this Service port. So haku-ci's force-proxy
+    # egress allows 5000 explicitly (see cluster/k8s/haku-ci/ccnp-force-proxy-egress.yaml).
+    # Plain HTTP.
     - name: http
       port: 80
       targetPort: http


### PR DESCRIPTION
**Fix for a live break introduced by #2865 (Tier 1).** After Tier 1 reconciled, haku-ci dind logs show it **times out reaching the mirror** (`http://oci-cache.oci-cache.svc.cluster.local/v2/`) and falls back to `registry-1.docker.io` — which is now blocked — so Docker Hub pulls fail.

**Root cause:** Cilium's socket-LB rewrites `ClusterIP:port → backend podIP:targetPort` **before** egress policy is enforced, so the policy must allow the **backend** port. `oci-cache`'s Service is `:80` but its pods listen on **5000** — so exposing it on `:80` did *not* let haku-ci's `80/443/3000` cluster egress reach it. (haku-sandbox works only because it allows *all* ports — which is why the earlier busybox test passed and this didn't surface until dind ran.)

**Fix:** add `5000` to haku-ci's `toEntities: cluster` egress. Also corrects the now-wrong "port 80 avoids a policy edit" claims in the Service comment + README, and documents the targetPort gotcha.

I verified live before this: the oci-cache **root Docker Hub mapping resolves** (`library/busybox → 200`), the dind pod has the mirror flags, and forgejo (which briefly blocked haku-ci's reconcile) recovered. Once this lands, dind → oci-cache:5000 is unblocked and Hub pulls go through the mirror. I'll confirm from the dind logs after it reconciles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015rpAEqZPQNV4gc5fuUCtVE

---
_Generated by [Claude Code](https://claude.ai/code/session_015rpAEqZPQNV4gc5fuUCtVE)_