### PR TITLE
[codex] upgrade Forgejo to 15.0.3

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -46,7 +46,7 @@
 
 - [ ] Unify manual `tofu` runs with Bazel-managed providers. Currently manual `tofu plan/apply` resolves providers independently from the `tf.download(mirror={...})` pins in `MODULE.bazel`. Create a wrapper (script or `bazel run` target) that sets `TF_CLI_CONFIG_FILE` pointing at the Bazel-fetched filesystem mirror (`<output_base>/external/@tf_toolchains/mirror/`), so manual runs use the exact same provider versions as `bazel test`.
 - [ ] Merge `ollama-bearer-token` and `litellm-api-key` into a single TF root/CR — both are simple `random_password` + `k8s secret` patterns for the ollama stack, already in the same `ollama-secrets` kustomization. Reduces CR count and state overhead.
-- [ ] Restore proper Forgejo branch protection for `agentydragon/ducktape:devel` and `agentydragon/gaffer-private:main` once Forgejo or the `svalabs/forgejo` provider can express "protected branch, but allow `agentydragon` force-push". Current Forgejo 15.0.2 / Gitea 1.22 API only has a normal push whitelist, so protected branches still reject `git push --force`.
+- [ ] Restore proper Forgejo branch protection for `agentydragon/ducktape:devel` and `agentydragon/gaffer-private:main` once Forgejo or the `svalabs/forgejo` provider can express "protected branch, but allow `agentydragon` force-push". Forgejo 15.x / Gitea 1.22 API only has a normal push whitelist, so protected branches still reject `git push --force`.
 
 ## Renovate Coverage gaps
 

--- a/cluster/k8s/forgejo/app/helmrelease.yaml
+++ b/cluster/k8s/forgejo/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
   chart:
     spec:
       chart: forgejo
-      version: "17.1.0"
+      version: "17.1.1"
       sourceRef:
         kind: HelmRepository
         name: forgejo


### PR DESCRIPTION
## Summary

- Bump the Forgejo Helm chart from `17.1.0` to `17.1.1`.
- This moves the chart-rendered Forgejo app image from `15.0.2-rootless` to `15.0.3-rootless`.
- Loosen the branch-protection TODO wording from an exact `15.0.2` patch version to `15.x`, so the note does not go stale on patch bumps.

## Upstream Notes

Forgejo Helm `17.1.1` updates the Forgejo Docker tag to `15.0.3` and bumps the chart `common` dependency to `2.40.0`.

Forgejo `15.0.3` includes security fixes for stored XSS in user display names on the Actions page, draft-release API authorization, LFS lock repository checks, OpenID visibility writes, and private PR visibility through linked public issues. It also includes Actions, UI, LFS quota, and commit-status bug fixes.

## Validation

- `helm template forgejo oci://code.forgejo.org/forgejo-helm/forgejo --version 17.1.1 -n forgejo -f /tmp/forgejo-values-17.1.1.yaml`
- `git diff --check`
- `bbr test //cluster/validation:all` passed on latest base `8e3f08595`: https://app.buildbuddy.io/invocation/3aa4a69e-90fa-4e58-93e2-9ea932c8ff2d

## Note

A broader `bbr build //...` was attempted before publishing and failed in unchanged `origin/devel` code: `//devinfra/js/debundle:stage_one` trips `clippy::too_many_arguments` at `devinfra/js/debundle/stage_one/mod.rs:125`. This branch only changes the Forgejo HelmRelease and the stale TODO wording.