### PR TITLE
[codex] Use annotation reload strategy for Reloader

### DIFF
--- a/cluster/docs/lessons_learned/2026_07_04_seaweedfs_s3_identity_stale_after_tenant_add.md
+++ b/cluster/docs/lessons_learned/2026_07_04_seaweedfs_s3_identity_stale_after_tenant_add.md
@@ -74,14 +74,18 @@ until one of the durable fixes below lands.
 The operator is already on the latest (v1.0.30 / chart 0.1.33) — there is no newer-version
 fix. The static-`configSecret` model is the constraint.
 
-1. **Reloader `reloadStrategy: annotations`** — cheapest; try first. Evidence it should
-   work: when Reloader fired we watched the operator revert its default _env-var_ patch (the
-   fresh RS scaled to 0), yet a `restartedAt` _annotation_ (not in the CR) survived on the
-   same pod template. So the operator overwrites container spec but **merges** pod-template
-   annotations — an annotation-mode patch should survive reconciliation and roll the gateway.
-   One-line change in `cluster/k8s/reloader/reloader.yaml`. Caveats: `reloadStrategy` is a
-   **global** Reloader setting (affects every managed workload — `annotations` is a common,
-   low-risk mode though), and it's unproven here, so validate on the next tenant add.
+1. **Reloader `reloadStrategy: annotations`** — cheapest and now validated. When
+   Reloader fired with its default _env-var_ patch, we watched the operator revert the
+   container-spec drift (fresh RS scaled to 0), yet a `restartedAt` _annotation_ (not in
+   the CR) survived on the same pod template. A 2026-07-04 throwaway Seaweed experiment
+   confirmed the annotation strategy works: changing a disposable `seaweedfs-s3-config`
+   Secret made Reloader add `reloader.stakater.com/last-reloaded-from` to the generated
+   S3 Deployment's pod template, Kubernetes rolled to a new ReplicaSet, and forced
+   Seaweed operator reconciles preserved the annotation and active RS. The one-line
+   durable fix lives in `cluster/k8s/reloader/reloader.yaml`. Caveat: `reloadStrategy`
+   is a **global** Reloader setting (affects every managed workload), but `annotations`
+   is the less invasive patch mode for operator-owned workloads because it avoids
+   mutating container specs.
 2. **Automate the restart** (the guaranteed fallback if A doesn't survive the operator). A
    small reconciler in `cluster/provisioners/` (matching grocy/inventree/matrix) that hashes
    `seaweedfs-s3-config` and, on change, runs `kubectl delete pod -l

--- a/cluster/k8s/reloader/reloader.yaml
+++ b/cluster/k8s/reloader/reloader.yaml
@@ -55,11 +55,16 @@ spec:
       # s3 gateway on stale identities until a manual restart (the 2026-06-08 attic
       # `InvalidAccessKeyId` incident). Opt a workload out with
       # `reloader.stakater.com/auto: "false"`.
-      # CAVEAT: for seaweedfs-s3 this still isn't reliable — Reloader fires but the
-      # SeaweedFS operator reconciles the Deployment back, reverting the env-var patch,
-      # so a manual pod restart is still needed after adding a tenant. Full RCA + fix
-      # options: <../../docs/lessons_learned/2026_07_04_seaweedfs_s3_identity_stale_after_tenant_add.md>.
       autoReloadAll: true
+      # Use pod-template annotations, not Reloader's default env-var patch, to
+      # force rollouts. The default mutates the container spec; operator-owned
+      # workloads can reconcile that drift away. SeaweedFS proved this with
+      # `seaweedfs-s3`: the operator reverted Reloader's env-var patch, leaving
+      # stale S3 identities loaded. Annotation mode changes the pod-template hash
+      # without touching the container spec, and a throwaway Seaweed experiment
+      # confirmed the operator preserves that annotation across reconcile.
+      # Full RCA: <../../docs/lessons_learned/2026_07_04_seaweedfs_s3_identity_stale_after_tenant_add.md>.
+      reloadStrategy: annotations
       deployment:
         resources:
           limits:


### PR DESCRIPTION
## Summary

Switch Stakater Reloader to `reloadStrategy: annotations` and document why this cluster uses that strategy.

The SeaweedFS S3 gateway reads `seaweedfs-s3-config` only at startup. Reloader's default env-var patch does trigger a rollout, but the SeaweedFS operator reconciles the generated Deployment back to its CR-derived container spec, which can undo the ReplicaSet change and leave old S3 pods serving stale identities.

Annotation strategy mutates only the pod-template annotations, which still changes the ReplicaSet hash but avoids container-spec drift. A throwaway SeaweedFS experiment on 2026-07-04 confirmed the operator preserves Reloader's `reloader.stakater.com/last-reloaded-from` annotation across forced reconciles and keeps the new ReplicaSet active.

## Changes

- Add `reloadStrategy: annotations` to `cluster/k8s/reloader/reloader.yaml`.
- Add an inline comment explaining why annotation mode is used instead of the default env-var patch.
- Update the SeaweedFS stale-identity lesson note with the experiment result.

## Validation

- `kubectl kustomize cluster/k8s/reloader`
- `pre-commit run --files cluster/k8s/reloader/reloader.yaml cluster/docs/lessons_learned/2026_07_04_seaweedfs_s3_identity_stale_after_tenant_add.md`