### PR TITLE
cluster/docs: document Cilium egress targetPort gotcha

### DIFF
--- a/cluster/docs/cilium_network_policy.md
+++ b/cluster/docs/cilium_network_policy.md
@@ -45,3 +45,35 @@ Live example: <../k8s/agents/manifold-mcp/app/networkpolicy.yaml>.
 
 Origin: manifold-mcp deployment (2026-04-30). Full incident write-up:
 <../../debug/manifold_mcp_cnp_cilium_envoy_identity.md>.
+
+# Egress to a ClusterIP: allow the backend targetPort, not the Service port
+
+A port-restricted egress rule to an in-cluster Service must list the backend
+**`targetPort`**, not the Service `port`. With kube-proxy replacement, Cilium's
+socket-LB rewrites `ClusterIP:port → podIP:targetPort` in the `connect()` hook —
+**before** L4 egress policy is enforced — so the policy only ever sees the
+translated backend port.
+
+## Symptom
+
+The client's TCP connection to the Service times out ("connection refused"/dial
+timeout / `Client.Timeout ... while awaiting connection`), even though the egress
+rule allows the Service's advertised port and DNS resolves fine. A pod with
+unrestricted egress (all ports, or `toEntities: cluster` with no `toPorts`) reaches
+the same Service without trouble — which is the tell that it's a port, not a
+routing/DNS, problem.
+
+## Example
+
+`oci-cache`'s Service is `:80 → targetPort 5000`. Exposing it on `:80` did **not**
+let `haku-ci`'s `toEntities: cluster` rule (ports `80/443/3000`) reach it — the
+policy had to allow **5000**, the pod's container port. See
+<../k8s/haku-ci/ccnp-force-proxy-egress.yaml>.
+
+## Debug
+
+`kubectl exec -n kube-system ds/cilium -- hubble observe --from-namespace <ns>
+--type drop` shows the dropped egress flow with the actual (translated) destination
+port — compare that to the ports your `toPorts` allows.
+
+Origin: oci-cache pull-through mirror wiring (2026-07-04).

--- a/cluster/docs/cilium_network_policy.md
+++ b/cluster/docs/cilium_network_policy.md
@@ -1,11 +1,13 @@
-# CiliumNetworkPolicy patterns for Gateway API backends
+# CiliumNetworkPolicy gotchas
+
+## Gateway API backends must admit `reserved:ingress`
 
 A default-deny `CiliumNetworkPolicy` in front of a pod that is the backend of a
 Gateway API `HTTPRoute` (Cilium gateway implementation) must admit
 `reserved:ingress` — **not** the gateway pod's namespace, **not** `reserved:host`,
 **not** `reserved:remote-node`.
 
-## Why
+### Why
 
 `cilium-envoy` runs `hostNetwork: true` on each node. Its egress to backend pods
 uses the node's `cilium_host` interface IP, and Cilium assigns those interface
@@ -16,7 +18,7 @@ SYN-ACK on the return path, so external requests through
 `Accepted`, `ResolvedRefs=True`, the Service has endpoints, and the pod is
 `Ready`.
 
-## Pattern
+### Pattern
 
 ```yaml
 spec:
@@ -34,7 +36,7 @@ spec:
 
 Live example: <../k8s/agents/manifold-mcp/app/networkpolicy.yaml>.
 
-## Debugging a mis-classified source
+### Debugging a mis-classified source
 
 1. `kubectl exec -n kube-system ds/cilium -- hubble observe --to-namespace <ns>` —
    SYN forwards reaching the pod with no return flow indicate a reverse-path
@@ -46,7 +48,7 @@ Live example: <../k8s/agents/manifold-mcp/app/networkpolicy.yaml>.
 Origin: manifold-mcp deployment (2026-04-30). Full incident write-up:
 <../../debug/manifold_mcp_cnp_cilium_envoy_identity.md>.
 
-# Egress to a ClusterIP: allow the backend targetPort, not the Service port
+## Egress to a ClusterIP: allow the backend targetPort, not the Service port
 
 A port-restricted egress rule to an in-cluster Service must list the backend
 **`targetPort`**, not the Service `port`. With kube-proxy replacement, Cilium's
@@ -54,7 +56,7 @@ socket-LB rewrites `ClusterIP:port → podIP:targetPort` in the `connect()` hook
 **before** L4 egress policy is enforced — so the policy only ever sees the
 translated backend port.
 
-## Symptom
+### Symptom
 
 The client's TCP connection to the Service times out ("connection refused"/dial
 timeout / `Client.Timeout ... while awaiting connection`), even though the egress
@@ -63,14 +65,14 @@ unrestricted egress (all ports, or `toEntities: cluster` with no `toPorts`) reac
 the same Service without trouble — which is the tell that it's a port, not a
 routing/DNS, problem.
 
-## Example
+### Example
 
 `oci-cache`'s Service is `:80 → targetPort 5000`. Exposing it on `:80` did **not**
 let `haku-ci`'s `toEntities: cluster` rule (ports `80/443/3000`) reach it — the
 policy had to allow **5000**, the pod's container port. See
 <../k8s/haku-ci/ccnp-force-proxy-egress.yaml>.
 
-## Debug
+### Debugging
 
 `kubectl exec -n kube-system ds/cilium -- hubble observe --from-namespace <ns>
 --type drop` shows the dropped egress flow with the actual (translated) destination


### PR DESCRIPTION
Prevent-recurrence doc for the gotcha that cost a round-trip (#2867) while wiring haku-ci to the oci-cache mirror.

Cilium's socket-LB rewrites `ClusterIP:port → podIP:targetPort` in the `connect()` hook **before** L4 egress policy is enforced, so a port-restricted egress rule to an in-cluster Service must allow the backend **`targetPort`**, not the Service `port`. `oci-cache`'s Service is `:80 → targetPort 5000`, and haku-ci's `80/443/3000` cluster egress didn't reach it until `5000` was added.

Adds an "Egress to a ClusterIP" section (symptom / example / debug) next to the existing Gateway-backend ingress gotcha in `cluster/docs/cilium_network_policy.md`. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015rpAEqZPQNV4gc5fuUCtVE

---
_Generated by [Claude Code](https://claude.ai/code/session_015rpAEqZPQNV4gc5fuUCtVE)_