### PR TITLE
[codex] provision Forgejo tea credentials for agents

### DIFF
--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -155,6 +155,11 @@ jobs:
               image_name: authentik-jwt-rotation,
               test_target: "//cluster/rotators/authentik_jwt_rotation/...",
             }
+          - {
+              image: "//cluster/rotators/forgejo_token_rotation:image",
+              image_name: forgejo-token-rotation,
+              test_target: "//cluster/rotators/forgejo_token_rotation/...",
+            }
           - { image: "//cluster/rotators/attic_jwt_rotation:image", image_name: attic-jwt-rotation, test_target: "" }
           - {
               image: "//cluster/provisioners/inventree_token_provisioner:image",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -296,6 +296,7 @@ repos:
             cluster/k8s/.*/ccm-values\.yaml|
             # rotate.py rotation list, mounted via configMapGenerator, not a K8s manifest
             cluster/k8s/agents/authentik-jwt-rotation/rotations\.yaml|
+            cluster/k8s/agents/forgejo-token-rotation/tokens\.yaml|
             # rotate.py token list, mounted via configMapGenerator, not a K8s manifest
             cluster/k8s/agents/attic-jwt-rotation/rotators\.yaml|
             # provision.py user→permission policy, mounted via configMapGenerator, not a K8s manifest

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -517,6 +517,18 @@ creation_rules:
           - *rugged-agentydragon
           - *atlas-agentydragon
           - *iguana-agentydragon
+  # Claude web Forgejo tea token (auto-rotated by forgejo-token-rotation).
+  # Same service account as claude-forgejo-credentials, but stored as an API
+  # token so `tea` can use the account directly.
+  - path_regex: secrets/claude-forgejo-tea-token\.yaml$
+    key_groups:
+      - age:
+          - *admin
+          - *claude-web
+          - *wyrm2-agentydragon
+          - *rugged-agentydragon
+          - *atlas-agentydragon
+          - *iguana-agentydragon
   # Private half of the haku age keypair. Encrypted only to agentydragon's
   # user ssh keys (+ admin) so the operator can retrieve it for the Haku routine's
   # env; haku itself is deliberately NOT a reader (it would be circular).
@@ -540,10 +552,33 @@ creation_rules:
           - *rugged-agentydragon
           - *atlas-agentydragon
           - *iguana-agentydragon
+  # Haku Forgejo tea token (auto-rotated by forgejo-token-rotation). Decrypted
+  # by the Haku routine directly and also materialized as a k8s Secret for web
+  # bootstrap + the self-hosted worker.
+  - path_regex: secrets/haku-forgejo-tea-token\.yaml$
+    key_groups:
+      - age:
+          - *admin
+          - *haku
+          - *wyrm2-agentydragon
+          - *rugged-agentydragon
+          - *atlas-agentydragon
+          - *iguana-agentydragon
   # agent-box Codex K8s bearer JWT (auto-rotated by the authentik-jwt-rotation
   # CronJob). Decrypted by the codex user's home-manager on agent-box to render
   # ~/.kube/config; admin + user keys retained for break-glass.
   - path_regex: secrets/agent-box-codex-k8s-jwt\.yaml$
+    key_groups:
+      - age:
+          - *admin
+          - *agent-box-codex-user
+          - *wyrm2-agentydragon
+          - *rugged-agentydragon
+          - *atlas-agentydragon
+          - *iguana-agentydragon
+  # agent-box Codex Forgejo tea token (auto-rotated by forgejo-token-rotation).
+  # Decrypted by the codex user's home-manager to render ~/.config/tea/config.yml.
+  - path_regex: secrets/agent-box-codex-forgejo-tea-token\.yaml$
     key_groups:
       - age:
           - *admin
@@ -560,6 +595,28 @@ creation_rules:
       - age:
           - *admin
           - *agent-box-zai-user
+          - *wyrm2-agentydragon
+          - *rugged-agentydragon
+          - *atlas-agentydragon
+          - *iguana-agentydragon
+  # agent-box zai Forgejo tea token (auto-rotated by forgejo-token-rotation).
+  # Decrypted by the zai user's home-manager to render ~/.config/tea/config.yml.
+  - path_regex: secrets/agent-box-zai-forgejo-tea-token\.yaml$
+    key_groups:
+      - age:
+          - *admin
+          - *agent-box-zai-user
+          - *wyrm2-agentydragon
+          - *rugged-agentydragon
+          - *atlas-agentydragon
+          - *iguana-agentydragon
+  # codex-pod Forgejo tea token (auto-rotated by forgejo-token-rotation). The pod
+  # consumes the cluster/k8s Secret manifest; this bare SOPS file is the rotator's
+  # encrypted stamp/raw-token output and operator break-glass copy.
+  - path_regex: secrets/codex-pod-forgejo-tea-token\.yaml$
+    key_groups:
+      - age:
+          - *admin
           - *wyrm2-agentydragon
           - *rugged-agentydragon
           - *atlas-agentydragon

--- a/cluster/k8s/TODO.md
+++ b/cluster/k8s/TODO.md
@@ -23,6 +23,14 @@ committed. `NO_PROXY` in `inject-mitmproxy.yaml` is unchanged.
 
 - [ ] `agents/openclaw/sandbox-secrets/ibkr-flex-query-credentials.sops.yaml` — consider moving `query-id` out of SOPS (not sensitive)
 
+## Secret layout
+
+- [ ] Restructure the flat agent token files under `secrets/` into clearer
+      ownership folders (for example per-agent or per-rotator). Current
+      rotators write paths like `secrets/*-k8s-jwt.yaml` and
+      `secrets/*-forgejo-tea-token.yaml`; keep `.sops.yaml`, home-manager
+      modules, and rotator configs in sync when moving them.
+
 ## InvenTree secrets if unsuspending
 
 - [ ] Add SOPS secrets for InvenTree admin and database passwords before

--- a/cluster/k8s/agent-box/README.md
+++ b/cluster/k8s/agent-box/README.md
@@ -49,7 +49,12 @@ This relies on the `git.allegedly.works` matchBlock (port 2222 + the
 `agent-box-codex-forgejo` key) that `nix/home/modules/forgejo-ssh.nix` writes to
 `~/.ssh/config`. Forgejo is the working forge for codex (push topic branches, open
 PRs there); the Forgejo repos are not formal pull-mirrors of GitHub, so sync them
-from GitHub manually when needed.
+from GitHub manually when needed. The VM's system toolset includes `tea` for
+Forgejo/Gitea issue, PR, release, and repo API workflows. Home Manager renders
+`~/.config/tea/config.yml` from the rotated SOPS file
+`secrets/agent-box-<user>-forgejo-tea-token.yaml`; smoke test with `tea whoami`.
+Those tokens have the full API privileges of their Forgejo service account, while
+repository access remains governed by the Terraform collaborator grants.
 
 ## First-boot secret ordering (known-ugly, works)
 

--- a/cluster/k8s/agents/claude-sandbox-secrets/claude-forgejo-tea.sops.yaml
+++ b/cluster/k8s/agents/claude-sandbox-secrets/claude-forgejo-tea.sops.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: claude-forgejo-tea
+    namespace: claude-sandbox
+    annotations:
+        description: Forgejo API token + tea config minted by forgejo-token-rotation.
+type: Opaque
+stringData:
+    config.yml: ENC[AES256_GCM,data:PaM43bPZ92891RSxJpeSlwAc8D7EVEL9pSgIVYNat0ZNHp6xlsI/o5c3ClCrP6oH+uVt3WOevxzxC6yXUCswKcxyNy2TIUmSzDDkOaRbdPWUuO137ip5kFhZoZaCOvMg7BUAsdhIBnWKwJBwkuJWho4dfGvmxfxJT2uTyF9PjtQneStZWkzgGx2iU5pTL4HJcA6cOVidGdCmImOZ,iv:KYc6Xbh1IybhJhdwJ++AstuVdXwJNHPsAbdmpR+uBiI=,tag:kTcRH6UNOkq4oWx0onjLIw==,type:str]
+    token: ENC[AES256_GCM,data:ZXKjUwzzzJU2u/rMDDtgVrNjnJyt,iv:bmZyoe4QYWAVwpVW+WTMbyG0ARIC6OOug/GRwQnHe1g=,tag:8jx7xfNO8C7LHRRneDWVYg==,type:str]
+    username: ENC[AES256_GCM,data:CkO51aUd,iv:aIwHGnZuqjBs9AgSKHhyVKZ8iT8HU72Fgsb4FsjgxF0=,tag:Zb6Kk9wqLDhpvlrIPhxhrQ==,type:str]
+    url: ENC[AES256_GCM,data:13eKLFTv8gfZJVtbI5CIQcw0sXVKqoesldSe,iv:qDl1vdvSFbKWeVJkPr3cL2RmZ5+XsR5aDtMGM4mmm/s=,tag:eyujEGVuqMoQUvxdXiFWMw==,type:str]
+    token-name: ENC[AES256_GCM,data:ITDvBWPWiB2qGdrvBlzPWVhP9+ze,iv:l1WDbuqnkqZz5Ggqbcn2V/4p4KAwIVkYv9UcTCaekuQ=,tag:pI61WevcazGohYWNPak0Jw==,type:str]
+    token-last-eight: ENC[AES256_GCM,data:XqYyaCZ/7zQ=,iv:04ri9wHargd0dQB3NbhQnMMswqYut9F77t1xMRcJwFk=,tag:TpPtBimSv0hfWvty8Pk6gw==,type:str]
+sops:
+    age:
+        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQVUJUWXJVRXNKS1VnVnJj
+            SGN1WEhaWGIvRkxaVFlkU0NTR01keUtUNkhrCjNndHBDZXZBRGM1blhzT3lmNFIr
+            dHM1ejFNZUlZRXRVYW1zRjUwTUJGMlEKLS0tIGcrZjNIV2VEendYRU9wS1YxY1Zl
+            YTdxT3BzQzhiVER3ZVptZGFEbUJRNTQKRPmKw3NTRRGKTCdaK4CceQvZrTTs5/KZ
+            QqU+s+1rXmSE2/iRGeJ27wRiFiLQw2+Gd6WObwgZDaj2gki3Eo3CKw==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1nywlwepsyfxvyhqwkjquzz02nmus65gf6qewfjju4alym8f7se5qnua8na
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVSVMrWWpSM29SU1cvM1la
+            TFB0bUN3dEN0V1JHTjMwVHJlYmgvR0g3Z0VFCnNPZlEvai9hUzFybDEwK2tnR1Jw
+            QXorV2VKVEdtT21xUmZSaG5SOWwwaTQKLS0tIGVyNXM5bk5lMXplc2R3bDFqemdV
+            empoM3hYNk15em5aVWtxbXh6UzBPeDgKuMyNENDRlARQi7WiBF0PH+Cc2Syp/ZET
+            FARuIVpm+mafdmh8kZgnukhYr6YCaZLGJ3XLlTfgMP8BdK9MoE1u2Q==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-07-04T23:17:39Z"
+    mac: ENC[AES256_GCM,data:HwtLXRHMUy0nLwrEwfoQBO/bELeinXkyE7eGMUqMGel0LGjS26g6RIIBmYEj6u/WpvxjOsf1YRbdt/6GGb5E1Py8IbZ8XHUNiFzQOe93tIr9YXKQojCWqXVk07VbU70VAT8kKcmoC3Ig9EwVfRshbZIb59hIMv+XGkaaODr8nVk=,iv:z79Cg+FAw/IXUD3qLTn03PT9f11vPJqeCmWuQrWD7IY=,tag:DCAEiTUPuBnwzJDWGXGzCw==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.1

--- a/cluster/k8s/agents/claude-sandbox-secrets/kustomization.yaml
+++ b/cluster/k8s/agents/claude-sandbox-secrets/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - claude-web-age-key.sops.yaml
+  - claude-forgejo-tea.sops.yaml

--- a/cluster/k8s/agents/codex-pod/README.md
+++ b/cluster/k8s/agents/codex-pod/README.md
@@ -78,6 +78,11 @@ this non-root image pod has not) and no boot-time render script:
   key is the only credential (all agent users follow this — see that module's
   header). The `git.allegedly.works` ssh matchBlock is baked by home-manager
   (`home.nix`), not rendered at boot.
+- **Forgejo API / `tea`** — `forgejo-token-rotation` mints a full-account API
+  token for the `codex-pod` Forgejo user and writes a pod-ready Secret
+  (`forgejo-tea`) mounted at `/home/codex/.config/tea/config.yml`. Smoke test with
+  `tea whoami`. The token does not expand repository permissions; it follows the
+  account's existing collaborator grants.
 - **BuildBuddy** — `BUILDBUDDY_API_KEY` is set on the container from the shared
   `buildbuddy-api-key` Secret via `secretKeyRef` (`optional: true`); `bbr` reads
   it. That Secret

--- a/cluster/k8s/agents/codex-pod/deployment.yaml
+++ b/cluster/k8s/agents/codex-pod/deployment.yaml
@@ -94,6 +94,9 @@ spec:
             - name: identity
               mountPath: /run/codex-secret
               readOnly: true
+            - name: forgejo-tea
+              mountPath: /home/codex/.config/tea
+              readOnly: true
           resources:
             requests:
               cpu: "500m"
@@ -110,4 +113,8 @@ spec:
         - name: identity
           secret:
             secretName: codex-bootstrap-identity
+            defaultMode: 0444
+        - name: forgejo-tea
+          secret:
+            secretName: forgejo-tea
             defaultMode: 0444

--- a/cluster/k8s/agents/codex-pod/forgejo-tea.sops.yaml
+++ b/cluster/k8s/agents/codex-pod/forgejo-tea.sops.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: forgejo-tea
+    namespace: codex-pod
+    annotations:
+        description: Forgejo API token + tea config minted by forgejo-token-rotation.
+type: Opaque
+stringData:
+    config.yml: ENC[AES256_GCM,data:o5BtqH2QGQp/zCg7qPleWJVpIOfGB8dH0RAncZ9skHtq4iRicQnQ+GFnlItBGWy74PTc3eyj/IXyNQMfGaLTkHVMkU11h1yLLFsSZRIO3lkdpz1jrjXGjWHhxzhBb7oyjdC0OwZevD+C5VXYsx08HUbRJF876omHBtzDDN5++LyOQ32AdIFu/Fow1kVLyfcmygHbIQI8GYDL46iYqkBG,iv:9pGXei6gksB2+U9oCv+tLQjbJ/Lk7Zp9M+6tMv13MTM=,tag:lwiRH6ughbPyCpls12W1Bg==,type:str]
+    token: ENC[AES256_GCM,data:THeHtF870dLU/XAjHGKSbHnpVcMG,iv:M6dZm3HHiGELrMWy3abhRZaXH1BDSxNOSrvJuEd+jGk=,tag:NZU4SEHmuO12fQZkZvv6nw==,type:str]
+    username: ENC[AES256_GCM,data:WmEUcdPn8sdZ,iv:c+wWoFLrbP3ChzYyg9yoq15IPBJUZKUqZldrb8j1A38=,tag:/nZy/FNnwEUQljfFudkFRg==,type:str]
+    url: ENC[AES256_GCM,data:qBEfjhpo+wehBMNBky3bKKUtjVMSiYiXiTc6,iv:yOk41j2CKAJlUOVQo3A+4y7iMvgSRBv93hAn0qrF+jw=,tag:zqh/D38hj4P//49v+0FImA==,type:str]
+    token-name: ENC[AES256_GCM,data:4cDs0arNUvKG3Vdd1lYnLyAWaLjX,iv:a4+DRheKndWPXzzHZ5ab4KP5ghnefYyJZf4HfJ0/52M=,tag:AWHl3XmUWK8RP+bgXacTmw==,type:str]
+    token-last-eight: ENC[AES256_GCM,data:gVBx47qtQXY=,iv:Quz1Lc4OXnOJqVNq3PGbFWSBS65+pWu/HWPRdn7wCr4=,tag:ixD8xPL3ga86SpZ32OhEXA==,type:str]
+sops:
+    age:
+        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZU3NoZ056ZW11SlJYd3cr
+            ckdvTDR2Q21XK2FpTUxFN2tWSjhKZmZPV0Y0CmtZa2tWOVlnMWM3MzdJbnRjT1E1
+            Q2ZuNnY3MHVPNVFZVHd3cmgyckwyTHMKLS0tIGFYZ2szcC9BYjJGcEtmYVhRb1F5
+            TktqMmZtVUNPM0RtUDRLOGlPSGFyRDQKfPAMY3b+quF91TP97Z2P3KRAPIiXHFRV
+            Vxrr56upYRpBFbvOOeNv48LfMlq86wHxhrClPvcBIAN6u4QvewRxHQ==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1nywlwepsyfxvyhqwkjquzz02nmus65gf6qewfjju4alym8f7se5qnua8na
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLV3hzZ08vN1o0ZnV4Tm9R
+            UU01MW9iQkJzNUI2OFU4eUlsdDFvOHRGOUFJCnhTeTFjN2NvUTYvUnZWa21OTzNN
+            YmpDS2cxZEMxa2hleThOSVpOSDExSFkKLS0tIGtTN0NjcW1SVnFmaEVnNHo3andy
+            YTFkaUlHclg3ME5URTBySFBpYXJEa2cK0S5q4HJqrjY+sxOd7aczGcnaYOryvrPM
+            9Ysp44lTLeuxAjK2dBDTW0HES933wIqDXCCCs5FVfOE26PiaNIip/w==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-07-04T23:17:39Z"
+    mac: ENC[AES256_GCM,data:cWnV/XGGGQl7axkWqNs6TLCJ3s2e3ncuFRoGwX1bt3GRtPxlaVC87MjfVCv9MRwV+TOYuTaihif6EF4eKWHtZTCwhW0DH3LNgmiNGxUvRqMNtAbistqdtJmMXfP14ntnho5eOrx+YRPOfx8O0ob56f7nghHs1gKp+jvQEEQki84=,iv:pLi6TXto6uYwpWlvyeObf1q3fDkWsDzWbjMxrdqjMCA=,tag:t9o8T8pKo2stTVXRhjm5Nw==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.1

--- a/cluster/k8s/agents/codex-pod/kustomization.yaml
+++ b/cluster/k8s/agents/codex-pod/kustomization.yaml
@@ -7,4 +7,5 @@ resources:
   - namespace.yaml
   - pvc.yaml
   - codex-bootstrap-identity.sops.yaml
+  - forgejo-tea.sops.yaml
   - deployment.yaml

--- a/cluster/k8s/agents/forgejo-token-rotation/cronjob.yaml
+++ b/cluster/k8s/agents/forgejo-token-rotation/cronjob.yaml
@@ -1,0 +1,89 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: forgejo-token-rotation
+  namespace: agents-infra
+  annotations:
+    description: >-
+      Mints full-account Forgejo API tokens for agent service accounts, commits
+      SOPS-encrypted raw-token files plus pod-ready tea config Secrets, then
+      prunes older rotator-created tokens after the Git push succeeds.
+spec:
+  schedule: "35 * * * *"
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        spec:
+          # No Kubernetes API access; all source credentials arrive as mounted Secrets.
+          serviceAccountName: ""
+          automountServiceAccountToken: false
+          restartPolicy: OnFailure
+          volumes:
+            - name: rotations-config
+              configMap:
+                name: forgejo-token-rotations-config
+            - name: github-pat
+              secret:
+                secretName: github-secrets-sync-pat
+            - name: haku-forgejo
+              secret:
+                secretName: forgejo-token-mint-haku
+            - name: claude-forgejo
+              secret:
+                secretName: forgejo-token-mint-claude
+            - name: agent-box-codex-forgejo
+              secret:
+                secretName: forgejo-token-mint-agent-box-codex
+            - name: agent-box-zai-forgejo
+              secret:
+                secretName: forgejo-token-mint-agent-box-zai
+            - name: codex-pod-forgejo
+              secret:
+                secretName: forgejo-token-mint-codex-pod
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: rotate
+              # Initial placeholder matching the ImagePolicy filterTags regex
+              # (^devel-\d{14}-[0-9a-f]{7}$). Flux rewrites the field after CI
+              # publishes ghcr.io/agentydragon/forgejo-token-rotation.
+              image: ghcr.io/agentydragon/forgejo-token-rotation:devel-00000000000000-0000000 # {"$imagepolicy": "flux-system:forgejo-token-rotation"}
+              args: ["--config", "/config/tokens.yaml"]
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+              volumeMounts:
+                - name: rotations-config
+                  mountPath: /config
+                  readOnly: true
+                - name: github-pat
+                  mountPath: /var/run/secrets/github-pat
+                  readOnly: true
+                - name: haku-forgejo
+                  mountPath: /var/run/secrets/forgejo/haku
+                  readOnly: true
+                - name: claude-forgejo
+                  mountPath: /var/run/secrets/forgejo/claude
+                  readOnly: true
+                - name: agent-box-codex-forgejo
+                  mountPath: /var/run/secrets/forgejo/agent-box-codex
+                  readOnly: true
+                - name: agent-box-zai-forgejo
+                  mountPath: /var/run/secrets/forgejo/agent-box-zai
+                  readOnly: true
+                - name: codex-pod-forgejo
+                  mountPath: /var/run/secrets/forgejo/codex-pod
+                  readOnly: true
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+                limits:
+                  memory: 256Mi

--- a/cluster/k8s/agents/forgejo-token-rotation/flux-kustomization.yaml
+++ b/cluster/k8s/agents/forgejo-token-rotation/flux-kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: forgejo-token-rotation
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./cluster/k8s/agents/forgejo-token-rotation
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  dependsOn:
+    - name: github-secrets-sync-secrets
+    - name: authentik-jwt-rotation # owns the agents-infra namespace
+    - name: forgejo-claude
+    - name: haku-state
+    - name: forgejo-agentydragon-repos
+  timeout: 2m

--- a/cluster/k8s/agents/forgejo-token-rotation/kustomization.yaml
+++ b/cluster/k8s/agents/forgejo-token-rotation/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cronjob.yaml
+configMapGenerator:
+  - name: forgejo-token-rotations-config
+    namespace: agents-infra
+    files:
+      - tokens.yaml

--- a/cluster/k8s/agents/forgejo-token-rotation/tokens.yaml
+++ b/cluster/k8s/agents/forgejo-token-rotation/tokens.yaml
@@ -1,0 +1,36 @@
+# Forgejo API tokens for agent service accounts. Omitted `repositories` means
+# full-account repository access in Forgejo 15's token API; account-level grants
+# still constrain what each agent can do.
+rotations:
+  - name: haku
+    credentials_dir: /var/run/secrets/forgejo/haku
+    sops_file: secrets/haku-forgejo-tea-token.yaml
+    token_prefix: forgejo-tea-haku
+    tea_secret:
+      path: cluster/k8s/haku/agent-worker/haku-forgejo-tea.sops.yaml
+      name: haku-forgejo-tea
+      namespace: haku-sandbox
+  - name: claude
+    credentials_dir: /var/run/secrets/forgejo/claude
+    sops_file: secrets/claude-forgejo-tea-token.yaml
+    token_prefix: forgejo-tea-claude
+    tea_secret:
+      path: cluster/k8s/agents/claude-sandbox-secrets/claude-forgejo-tea.sops.yaml
+      name: claude-forgejo-tea
+      namespace: claude-sandbox
+  - name: agent-box-codex
+    credentials_dir: /var/run/secrets/forgejo/agent-box-codex
+    sops_file: secrets/agent-box-codex-forgejo-tea-token.yaml
+    token_prefix: forgejo-tea-agent-box-codex
+  - name: agent-box-zai
+    credentials_dir: /var/run/secrets/forgejo/agent-box-zai
+    sops_file: secrets/agent-box-zai-forgejo-tea-token.yaml
+    token_prefix: forgejo-tea-agent-box-zai
+  - name: codex-pod
+    credentials_dir: /var/run/secrets/forgejo/codex-pod
+    sops_file: secrets/codex-pod-forgejo-tea-token.yaml
+    token_prefix: forgejo-tea-codex-pod
+    tea_secret:
+      path: cluster/k8s/agents/codex-pod/forgejo-tea.sops.yaml
+      name: forgejo-tea
+      namespace: codex-pod

--- a/cluster/k8s/flux-image-automation-ghcr/forgejo-token-rotation-image-policy.yaml
+++ b/cluster/k8s/flux-image-automation-ghcr/forgejo-token-rotation-image-policy.yaml
@@ -1,0 +1,14 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: forgejo-token-rotation
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: forgejo-token-rotation
+  filterTags:
+    # Tags pushed by CI: {branch}-YYYYMMDDHHMMSS-{sha7} — alphabetical order == chronological
+    pattern: '^devel-\d{14}-[0-9a-f]{7}$'
+  policy:
+    alphabetical:
+      order: asc

--- a/cluster/k8s/flux-image-automation-ghcr/forgejo-token-rotation-image-repository.yaml
+++ b/cluster/k8s/flux-image-automation-ghcr/forgejo-token-rotation-image-repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: forgejo-token-rotation
+  namespace: flux-system
+spec:
+  image: ghcr.io/agentydragon/forgejo-token-rotation
+  interval: 5m

--- a/cluster/k8s/flux-image-automation-ghcr/kustomization.yaml
+++ b/cluster/k8s/flux-image-automation-ghcr/kustomization.yaml
@@ -51,6 +51,8 @@ resources:
   - matrix-user-provisioner-image-policy.yaml
   - authentik-jwt-rotation-image-repository.yaml
   - authentik-jwt-rotation-image-policy.yaml
+  - forgejo-token-rotation-image-repository.yaml
+  - forgejo-token-rotation-image-policy.yaml
   - attic-jwt-rotation-image-repository.yaml
   - attic-jwt-rotation-image-policy.yaml
   - grocy-mcp-oidc-server-image-repository.yaml

--- a/cluster/k8s/flux-webhook/github-webhook-receiver.yaml
+++ b/cluster/k8s/flux-webhook/github-webhook-receiver.yaml
@@ -45,6 +45,9 @@ spec:
       name: authentik-jwt-rotation
     - apiVersion: image.toolkit.fluxcd.io/v1beta2
       kind: ImageRepository
+      name: forgejo-token-rotation
+    - apiVersion: image.toolkit.fluxcd.io/v1beta2
+      kind: ImageRepository
       name: attic-jwt-rotation
     - apiVersion: image.toolkit.fluxcd.io/v1beta2
       kind: ImageRepository

--- a/cluster/k8s/haku/agent-worker/deployment.yaml
+++ b/cluster/k8s/haku/agent-worker/deployment.yaml
@@ -108,6 +108,9 @@ spec:
               mountPath: /workspace
             - name: home # $HOME (.netrc, .gitconfig, ant config) — see HOME env
               mountPath: /home/haku
+            - name: forgejo-tea # ~/.config/tea/config.yml from forgejo-token-rotation
+              mountPath: /home/haku/.config/tea
+              readOnly: true
             - name: tmp
               mountPath: /tmp
       volumes:
@@ -118,5 +121,9 @@ spec:
         # writable emptyDir there (fsGroup 100 makes it haku-writable).
         - name: home
           emptyDir: {}
+        - name: forgejo-tea
+          secret:
+            secretName: haku-forgejo-tea
+            defaultMode: 0444
         - name: tmp
           emptyDir: {}

--- a/cluster/k8s/haku/agent-worker/haku-forgejo-tea.sops.yaml
+++ b/cluster/k8s/haku/agent-worker/haku-forgejo-tea.sops.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: haku-forgejo-tea
+    namespace: haku-sandbox
+    annotations:
+        description: Forgejo API token + tea config minted by forgejo-token-rotation.
+type: Opaque
+stringData:
+    config.yml: ENC[AES256_GCM,data:qdJ7TrKRXLRHafXMU+1iNIkhwXBZx1kRahJKWP+W8YTxZ2NziOfpA/MLGFRvV5EwCRCOTVxD1AsnLJoODoZf7k2MsL/pn0Ixe6zAUUs8aB1yAgj09Uu6Hkcp3Ykdmdv2DlraklDlwtUNTVMLDU94LM7Aa7NreHaCWRSchO6D8lX3AK9MVhtAOD+yyxNEEh4WYqYqccuxsFHKaQ==,iv:kZKc9bC8MgfEHIEWCBb1UqxOXdZBMn8GR96wauwa9Es=,tag:xFzwcDEdThUslBL5ITPV1g==,type:str]
+    token: ENC[AES256_GCM,data:5sKl+gn/PYO7QYroqCJvY/0VLdI9,iv:+hMnISDPFzv7SYsBy0/z7l7746P6i3fSDqnNCTdhynE=,tag:O+TKUIai/O4bFrjiIFoGzA==,type:str]
+    username: ENC[AES256_GCM,data:F2yGkQ==,iv:3E0MrU9vTavgpwPzf16VRsQvHsQ1UIqRDb/NIwINwMU=,tag:FHN0daObcsNMyEGBAF0wTw==,type:str]
+    url: ENC[AES256_GCM,data:Mhj8nrC+oXtsIu7BY1Y2YLqx6lgpkjFnq/at,iv:mM9ntnreAI5aQaTCgPbNBYSw7W6Il0WtIvRxSInx+XY=,tag:/n3FS3g7utL+uSfqKWOSXQ==,type:str]
+    token-name: ENC[AES256_GCM,data:fJAP7FavQdW7shTTvbMNeq9yLmMF,iv:/UfFeRacTgOryx10iDWLfX11b1p2u810Z1lk/2d9zHI=,tag:7joQNsFCAX4bCIEvT6hoCA==,type:str]
+    token-last-eight: ENC[AES256_GCM,data:fyb5ggxY594=,iv:xqG1zUOZcUaQ4piG2dwtuFser6ZP2FeXato4C420RPs=,tag:lXzhpM3P+i9oKxH9+Pbq5Q==,type:str]
+sops:
+    age:
+        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoZ3NQWWJtRjM4dDdSTzdP
+            QWN4d3RHOFFxbm9zZjNnS0FveTViM1hvUDNzCnpQOWU0TkovN1ZWU1ljSGh3eGxL
+            VUpRTU9hQXBXdFNlUnpsbGVQbEJ5bmsKLS0tIHVtcG1PMFhHdGJydkVWUE1CN2pT
+            ZEpFNDFBaHoyQkFWY3NpbFljVTNIdFEKt2w2P+xIDWBl7XY0sASpmBQpQIbVbAVT
+            kx5nRycmoUlEnZhpRi9Z1/anUfy9uvSKFloJO1bA9rWpcYDS35yDmQ==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1nywlwepsyfxvyhqwkjquzz02nmus65gf6qewfjju4alym8f7se5qnua8na
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmdUJCOHVXb0hEekhFTHZi
+            ck0vYVBvR1RoSk5TTGEvb0RvekNyRDJzRzJ3CllXYWVLOVNReEJpOGFOeDZkSVNR
+            LytkTWZYRmJ0M0lUSXIvZ1Z5LzJ3cTQKLS0tIElSUHlZdStVNURjK291WFYrUVZP
+            a2prTjM0ZEpiUWM2K296eURTZmZCWVkKZaazLzM6L29gAYzD/NnRbCFyyq/D1QAr
+            XzyBXuqJkmrOGSBzMWJW+NIWPofNfYYmY/nGgzncPEp4f6uVz8rMOg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-07-04T23:17:39Z"
+    mac: ENC[AES256_GCM,data:x1VdqDMJVwlVe+xfKMpGRB0UFtBz72jHbTbeqPJL30O6aqshHf5IlRQ684Rp32xhkhEzTO2AaQuB/EOHSpM9Om7yjvYVLEfucUv3g1W+J31ygmtA/0BRtoDGxgxIygUn5iip4kpK2QqNIWRRzA6J9w1tOzPv4TUyDr46qjOo/pw=,iv:V1CIeZxGwsEGf5ujkugV35O9fnuihB7PIu9rKuJDZKo=,tag:hKvjoZajdtYvfzphiJmPEA==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.1

--- a/cluster/k8s/haku/agent-worker/kustomization.yaml
+++ b/cluster/k8s/haku/agent-worker/kustomization.yaml
@@ -4,5 +4,6 @@ resources:
   - serviceaccount.yaml
   - rolebinding.yaml
   - environment-key.sops.yaml
+  - haku-forgejo-tea.sops.yaml
   - deployment.yaml
   - grocy-token-eso.yaml

--- a/cluster/k8s/kustomization.yaml
+++ b/cluster/k8s/kustomization.yaml
@@ -65,6 +65,7 @@ resources:
   - agents/tana-mcp/agent-rbac/flux-kustomization.yaml
   - agents/claude-sandbox-secrets/flux-kustomization.yaml
   - agents/authentik-jwt-rotation/flux-kustomization.yaml
+  - agents/forgejo-token-rotation/flux-kustomization.yaml
   - agents/attic-jwt-rotation/flux-kustomization.yaml
   - agents/claude-sandbox-firecracker/flux-kustomization.yaml
   - agents/claude-zai-key/flux-kustomization.yaml

--- a/cluster/rotators/forgejo_token_rotation/BUILD.bazel
+++ b/cluster/rotators/forgejo_token_rotation/BUILD.bazel
@@ -1,0 +1,66 @@
+load("@aspect_rules_py//py:defs.bzl", "py_image_layer", aspect_py_binary = "py_binary")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("//devinfra/python:defs.bzl", "py_library", "py_test")
+load("//props:oci.bzl", "py_image_entrypoint", "py_image_env")
+
+py_library(
+    name = "rotate",
+    srcs = ["rotate.py"],
+    deps = [
+        "@pypi//httpx",
+        "@pypi//pydantic",
+        "@pypi//pyyaml",
+        "@pypi//typer",
+    ],
+)
+
+py_test(
+    name = "test_rotate",
+    srcs = ["test_rotate.py"],
+    deps = [
+        ":rotate",
+        "@pypi//pytest_bazel",
+    ],
+)
+
+aspect_py_binary(
+    name = "rotate_bin",
+    main = "rotate.py",
+    deps = [":rotate"],
+)
+
+# sops binary layer — placed at /usr/local/bin/sops.
+pkg_tar(
+    name = "sops_layer",
+    srcs = ["@sops_linux_amd64//file:sops"],
+    package_dir = "/usr/local/bin",
+)
+
+py_image_layer(
+    name = "layers",
+    binary = ":rotate_bin",
+    group = "65534",
+    owner = "65534",
+)
+
+oci_image(
+    name = "image",
+    base = "@debian_trixie_slim_linux_amd64",
+    entrypoint = py_image_entrypoint("rotate_bin"),
+    env = py_image_env(binary_name = "rotate_bin"),
+    labels = {"org.opencontainers.image.source": "https://github.com/agentydragon/ducktape"},
+    # Same runtime needs as authentik-jwt-rotation: git + ca-certificates for the
+    # sparse GitHub push, sops for encrypting repo outputs, and the Python app.
+    tars = [
+        "@trixie_authentik_rotation//:flat",
+        ":sops_layer",
+        ":layers",
+    ],
+)
+
+oci_load(
+    name = "load",
+    image = ":image",
+    repo_tags = ["forgejo-token-rotation:latest"],
+)

--- a/cluster/rotators/forgejo_token_rotation/rotate.py
+++ b/cluster/rotators/forgejo_token_rotation/rotate.py
@@ -1,0 +1,447 @@
+"""Rotate Forgejo API tokens into SOPS files and tea config Secrets.
+
+The rotator authenticates to Forgejo with each agent account's username/password,
+mints a scoped API token for the full account (no repository restriction), writes
+the raw token to a SOPS file, and optionally writes a Kubernetes Secret containing
+both the raw token and a ready-to-mount `tea` config.
+
+Token minting is an external side effect, so pruning old rotator-created tokens is
+deliberately deferred until after the new SOPS outputs have been committed and
+pushed. If the commit/push fails, the new token can sit unused until a later run;
+the old token is left intact.
+"""
+
+import logging
+import os
+import subprocess
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Annotated, Any
+from urllib.parse import quote
+
+import httpx
+import typer
+import yaml
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+FULL_ACCOUNT_SCOPES = [
+    "write:activitypub",
+    "write:issue",
+    "write:misc",
+    "write:notification",
+    "write:organization",
+    "write:package",
+    "write:repository",
+    "write:user",
+]
+
+
+class TeaSecretOutput(BaseModel):
+    """Optional k8s Secret manifest carrying a mounted `tea` config."""
+
+    path: Path = Field(description="Repo-relative path for the Secret manifest (under cluster/k8s/, *.sops.yaml)")
+    name: str
+    namespace: str
+    config_key: str = "config.yml"
+    token_key: str = "token"
+    username_key: str = "username"
+    url_key: str = "url"
+    token_name_key: str = "token-name"
+    token_last_eight_key: str = "token-last-eight"
+
+
+class Rotation(BaseModel):
+    name: str = Field(description="Human-readable name for logs and commit messages")
+    credentials_dir: Path = Field(description="Mounted secret dir with username/password and optional url/internal_url")
+    sops_file: Path = Field(description="Repo-relative path to the encrypted raw-token output")
+    token_field: str = Field(default="token", description="YAML field name for the raw token in sops_file")
+    token_prefix: str | None = Field(
+        default=None,
+        description="Prefix for Forgejo token names. Defaults to rotation.name; minted names append UTC timestamp.",
+    )
+    scopes: list[str] = Field(
+        default_factory=lambda: list(FULL_ACCOUNT_SCOPES),
+        description="Forgejo token scopes. Defaults to every non-admin write scope.",
+    )
+    rotate_after_days: int = Field(default=30, description="Mint a fresh token once the current one is this old")
+    keep_previous: int = Field(
+        default=1,
+        description="After committing a new token, keep this many older rotator-created tokens as rollback cushion",
+    )
+    api_url: str = Field(
+        default="http://forgejo-http.forgejo:3000",
+        description="Forgejo base URL used by the rotator API client; credentials_dir/internal_url overrides it",
+    )
+    tea_url: str = Field(
+        default="https://git.allegedly.works",
+        description="Forgejo URL written into tea config; credentials_dir/url overrides it",
+    )
+    login_name: str = Field(default="forgejo", description="tea login name")
+    tea_secret: TeaSecretOutput | None = Field(
+        default=None, description="When set, also write a k8s Secret manifest with config.yml + raw token"
+    )
+
+    @property
+    def token_name_prefix(self) -> str:
+        return self.token_prefix or self.name
+
+
+class Config(BaseModel):
+    rotations: list[Rotation]
+    github_repo: str = "agentydragon/ducktape"
+    sops_config: str = Field(default=".sops.yaml", description="Repo path sops reads to pick the recipient set")
+    git_author_name: str = "forgejo-token-rotation"
+    git_author_email: str = "noreply@allegedly.works"
+
+
+@dataclass(frozen=True)
+class ForgejoCredentials:
+    username: str
+    password: str
+    api_url: str
+    tea_url: str
+
+
+@dataclass(frozen=True)
+class RotatedToken:
+    rotation: Rotation
+    credentials: ForgejoCredentials
+    token_id: int | None
+    token_name: str
+    token_last_eight: str
+
+
+def read_credentials(rotation: Rotation) -> ForgejoCredentials:
+    username = (rotation.credentials_dir / "username").read_text().strip()
+    password = (rotation.credentials_dir / "password").read_text().strip()
+    api_url = (
+        (rotation.credentials_dir / "internal_url").read_text().strip()
+        if (rotation.credentials_dir / "internal_url").exists()
+        else rotation.api_url
+    )
+    tea_url = (
+        (rotation.credentials_dir / "url").read_text().strip()
+        if (rotation.credentials_dir / "url").exists()
+        else rotation.tea_url
+    )
+    return ForgejoCredentials(
+        username=username, password=password, api_url=api_url.rstrip("/"), tea_url=tea_url.rstrip("/")
+    )
+
+
+def api_base(api_url: str) -> str:
+    return f"{api_url.rstrip('/')}/api/v1"
+
+
+def unencrypted_stamps(sops_file: Path) -> dict[str, Any]:
+    """Read plaintext `*_unencrypted` stamps from a SOPS YAML file."""
+    if not sops_file.exists():
+        return {}
+    return yaml.safe_load(sops_file.read_text()) or {}
+
+
+def parse_utc(value: str) -> datetime:
+    return datetime.fromisoformat(value).astimezone(UTC)
+
+
+def token_still_present(stamps: dict[str, Any], tokens: list[dict[str, Any]]) -> bool:
+    token_id = stamps.get("token_id_unencrypted")
+    token_name = stamps.get("token_name_unencrypted")
+    token_last_eight = stamps.get("token_last_eight_unencrypted")
+    if token_id is None and token_name is None:
+        return False
+
+    for token in tokens:
+        id_matches = token_id is not None and str(token.get("id")) == str(token_id)
+        name_matches = token_name is not None and token.get("name") == token_name
+        if not (id_matches or name_matches):
+            continue
+        if token_last_eight is not None and token.get("token_last_eight") != token_last_eight:
+            continue
+        return True
+    return False
+
+
+def should_rotate(
+    rotation: Rotation, stamps: dict[str, Any], tokens: list[dict[str, Any]], now: datetime | None = None
+) -> tuple[bool, str]:
+    """Return whether a rotation is due and the reason."""
+    now = now or datetime.now(UTC)
+    if not stamps:
+        return True, "no existing token stamp"
+    if stamps.get("scopes_unencrypted") != rotation.scopes:
+        return True, "scope set changed"
+    if stamps.get("repository_access_unencrypted") != "all":
+        return True, "repository access stamp missing or changed"
+    if int(stamps.get("rotate_after_days_unencrypted", 0)) != rotation.rotate_after_days:
+        return True, "rotation interval changed"
+    if not token_still_present(stamps, tokens):
+        return True, "stamped token is not present in Forgejo"
+
+    rotated_at = stamps.get("rotated_at_unencrypted")
+    if not rotated_at:
+        return True, "rotated_at stamp missing"
+    next_rotation = parse_utc(rotated_at) + timedelta(days=rotation.rotate_after_days)
+    if now >= next_rotation:
+        return True, f"token age reached {rotation.rotate_after_days}d"
+    return False, f"fresh until {next_rotation:%Y-%m-%dT%H:%M:%SZ}"
+
+
+def list_tokens(client: httpx.Client, creds: ForgejoCredentials) -> list[dict[str, Any]]:
+    tokens: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        resp = client.get(
+            f"{api_base(creds.api_url)}/users/{creds.username}/tokens",
+            auth=(creds.username, creds.password),
+            params={"page": page, "limit": 50},
+        )
+        resp.raise_for_status()
+        batch: list[dict[str, Any]] = resp.json()
+        tokens.extend(batch)
+        if len(batch) < 50:
+            return tokens
+        page += 1
+
+
+def mint_token(
+    client: httpx.Client, rotation: Rotation, creds: ForgejoCredentials, now: datetime | None = None
+) -> dict[str, Any]:
+    now = now or datetime.now(UTC)
+    token_name = f"{rotation.token_name_prefix}-{now:%Y%m%d%H%M%S}{now.microsecond:06d}"
+    # Omit `repositories`: in Forgejo 15's API that means the token is not
+    # limited to selected repositories, i.e. it follows the account's full access.
+    resp = client.post(
+        f"{api_base(creds.api_url)}/users/{creds.username}/tokens",
+        auth=(creds.username, creds.password),
+        json={"name": token_name, "scopes": rotation.scopes},
+    )
+    resp.raise_for_status()
+    data: dict[str, Any] = resp.json()
+    token = data.get("sha1") or data.get("token")
+    if not token:
+        raise RuntimeError(f"{rotation.name}: Forgejo returned no token body field")
+    data["sha1"] = token
+    data["token_last_eight"] = data.get("token_last_eight") or token[-8:]
+    return data
+
+
+def verify_token(client: httpx.Client, creds: ForgejoCredentials, token: str) -> None:
+    resp = client.get(f"{api_base(creds.api_url)}/user", headers={"Authorization": f"token {token}"})
+    resp.raise_for_status()
+    login = resp.json().get("login")
+    if login != creds.username:
+        raise RuntimeError(f"minted token authenticates as {login!r}, expected {creds.username!r}")
+
+
+def tea_config_yaml(rotation: Rotation, creds: ForgejoCredentials, token: str) -> str:
+    return yaml.safe_dump(
+        {
+            "logins": [
+                {
+                    "name": rotation.login_name,
+                    "url": creds.tea_url,
+                    "token": token,
+                    "default": True,
+                    "version_check": False,
+                    "user": creds.username,
+                }
+            ]
+        },
+        sort_keys=False,
+        width=2**31,
+    )
+
+
+def write_raw_token_sops_file(
+    rotation: Rotation, creds: ForgejoCredentials, token_data: dict[str, Any], now: datetime | None = None
+) -> None:
+    now = now or datetime.now(UTC)
+    token = token_data["sha1"]
+    stamps: dict[str, Any] = {
+        "rotated_at_unencrypted": f"{now:%Y-%m-%dT%H:%M:%SZ}",
+        "rotate_after_days_unencrypted": rotation.rotate_after_days,
+        "repository_access_unencrypted": "all",
+        "scopes_unencrypted": rotation.scopes,
+        "token_id_unencrypted": token_data.get("id"),
+        "token_name_unencrypted": token_data["name"],
+        "token_last_eight_unencrypted": token_data.get("token_last_eight") or token[-8:],
+        "username": creds.username,
+        "url": creds.tea_url,
+        rotation.token_field: token,
+    }
+    rotation.sops_file.parent.mkdir(parents=True, exist_ok=True)
+    rotation.sops_file.write_text(yaml.safe_dump(stamps, sort_keys=False, width=2**31))
+    subprocess.run(["sops", "encrypt", "--in-place", str(rotation.sops_file)], check=True)
+
+
+def build_secret_manifest(
+    out: TeaSecretOutput, rotation: Rotation, creds: ForgejoCredentials, token_data: dict[str, Any]
+) -> dict[str, Any]:
+    token = token_data["sha1"]
+    return {
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "metadata": {
+            "name": out.name,
+            "namespace": out.namespace,
+            "annotations": {"description": "Forgejo API token + tea config minted by forgejo-token-rotation."},
+        },
+        "type": "Opaque",
+        "stringData": {
+            out.config_key: tea_config_yaml(rotation, creds, token),
+            out.token_key: token,
+            out.username_key: creds.username,
+            out.url_key: creds.tea_url,
+            out.token_name_key: token_data["name"],
+            out.token_last_eight_key: token_data.get("token_last_eight") or token[-8:],
+        },
+    }
+
+
+def write_tea_secret(rotation: Rotation, creds: ForgejoCredentials, token_data: dict[str, Any]) -> None:
+    if rotation.tea_secret is None:
+        return
+    rotation.tea_secret.path.parent.mkdir(parents=True, exist_ok=True)
+    rotation.tea_secret.path.write_text(
+        yaml.safe_dump(
+            build_secret_manifest(rotation.tea_secret, rotation, creds, token_data), sort_keys=False, width=2**31
+        )
+    )
+    subprocess.run(["sops", "encrypt", "--in-place", str(rotation.tea_secret.path)], check=True)
+
+
+def rotate_one(client: httpx.Client, rotation: Rotation) -> RotatedToken | None:
+    creds = read_credentials(rotation)
+    tokens = list_tokens(client, creds)
+    due, reason = should_rotate(rotation, unencrypted_stamps(rotation.sops_file), tokens)
+    if not due:
+        logger.info("%s: %s; skipping", rotation.name, reason)
+        return None
+
+    now = datetime.now(UTC)
+    logger.info("%s: rotating (%s)", rotation.name, reason)
+    token_data = mint_token(client, rotation, creds, now)
+    verify_token(client, creds, token_data["sha1"])
+    write_raw_token_sops_file(rotation, creds, token_data, now)
+    write_tea_secret(rotation, creds, token_data)
+    return RotatedToken(
+        rotation=rotation,
+        credentials=creds,
+        token_id=token_data.get("id"),
+        token_name=token_data["name"],
+        token_last_eight=token_data.get("token_last_eight") or token_data["sha1"][-8:],
+    )
+
+
+def tokens_to_prune(rotation: Rotation, current: RotatedToken, tokens: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    prefix = f"{rotation.token_name_prefix}-"
+    candidates = [
+        token
+        for token in tokens
+        if str(token.get("name", "")).startswith(prefix)
+        and str(token.get("id")) != str(current.token_id)
+        and token.get("name") != current.token_name
+    ]
+    candidates.sort(key=lambda token: str(token.get("name", "")), reverse=True)
+    return candidates[rotation.keep_previous :]
+
+
+def delete_token(client: httpx.Client, creds: ForgejoCredentials, token: dict[str, Any]) -> None:
+    token_ref = str(token.get("id") or token["name"])
+    resp = client.delete(
+        f"{api_base(creds.api_url)}/users/{creds.username}/tokens/{quote(token_ref, safe='')}",
+        auth=(creds.username, creds.password),
+    )
+    if resp.status_code == 404:
+        logger.info("%s: old token already absent", token_ref)
+        return
+    resp.raise_for_status()
+
+
+def prune_old_tokens(client: httpx.Client, rotated: list[RotatedToken]) -> None:
+    for result in rotated:
+        tokens = list_tokens(client, result.credentials)
+        for token in tokens_to_prune(result.rotation, result, tokens):
+            logger.info("%s: pruning old token %s", result.rotation.name, token.get("name"))
+            delete_token(client, result.credentials, token)
+
+
+def sparse_clone(config: Config, github_pat: str) -> None:
+    """Init + sparse-fetch only .sops.yaml and the configured outputs into cwd."""
+    remote = f"https://x-access-token:{github_pat}@github.com/{config.github_repo}.git"
+    sparse_paths = [config.sops_config, *(str(r.sops_file) for r in config.rotations)]
+    sparse_paths += [str(r.tea_secret.path) for r in config.rotations if r.tea_secret]
+    subprocess.run(["git", "init", "-q"], check=True)
+    subprocess.run(["git", "remote", "add", "origin", remote], check=True)
+    subprocess.run(["git", "config", "core.sparseCheckout", "true"], check=True)
+    Path(".git/info/sparse-checkout").write_text("\n".join(sparse_paths) + "\n")
+    subprocess.run(["git", "fetch", "-q", "--depth=1", "--no-tags", "origin", "devel"], check=True)
+    subprocess.run(["git", "checkout", "-q", "FETCH_HEAD"], check=True)
+
+
+def commit_and_push(config: Config, rotated: list[RotatedToken]) -> bool:
+    subprocess.run(["git", "config", "user.name", config.git_author_name], check=True)
+    subprocess.run(["git", "config", "user.email", config.git_author_email], check=True)
+    for result in rotated:
+        subprocess.run(["git", "add", "--", str(result.rotation.sops_file)], check=True)
+        if result.rotation.tea_secret:
+            subprocess.run(["git", "add", "--", str(result.rotation.tea_secret.path)], check=True)
+    if subprocess.run(["git", "diff", "--cached", "--quiet"], check=False).returncode == 0:
+        logger.info("tokens minted but SOPS outputs are unchanged on disk; nothing to commit")
+        return False
+    message = f"chore: rotate forgejo tea tokens ({datetime.now(UTC):%Y-%m-%d}): "
+    message += ", ".join(result.rotation.name for result in rotated)
+    subprocess.run(["git", "commit", "-q", "-m", message], check=True)
+    subprocess.run(["git", "push", "-q", "origin", "HEAD:devel"], check=True)
+    logger.info("pushed: %s", ", ".join(result.rotation.name for result in rotated))
+    return True
+
+
+def main(
+    config_path: Annotated[Path, typer.Option("--config", exists=True, dir_okay=False, help="tokens.yaml")],
+    github_pat_file: Annotated[Path, typer.Option("--github-pat-file")] = Path("/var/run/secrets/github-pat/token"),
+    ca_bundle: Annotated[Path, typer.Option(help="CA bundle assembled for git + httpx")] = Path("/tmp/ca-bundle.crt"),
+) -> None:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    config = Config.model_validate(yaml.safe_load(config_path.read_text()))
+    github_pat = github_pat_file.read_text().strip()
+
+    ca_bundle.write_text(
+        "".join(p.read_text() for p in sorted(Path("/usr/share/ca-certificates/mozilla").glob("*.crt")))
+    )
+    os.environ["GIT_SSL_CAINFO"] = str(ca_bundle)
+
+    repo_dir = Path("/tmp/repo")
+    repo_dir.mkdir()
+    os.chdir(repo_dir)
+    sparse_clone(config, github_pat)
+
+    rotated: list[RotatedToken] = []
+    failed: list[str] = []
+    with httpx.Client(verify=str(ca_bundle), timeout=30) as client:
+        for rotation in config.rotations:
+            try:
+                result = rotate_one(client, rotation)
+                if result is not None:
+                    rotated.append(result)
+            except Exception:
+                logger.exception("%s: rotation failed; continuing with remaining entries", rotation.name)
+                failed.append(rotation.name)
+
+        if rotated:
+            pushed = commit_and_push(config, rotated)
+            if pushed:
+                prune_old_tokens(client, rotated)
+        else:
+            logger.info("no rotations needed this cycle")
+
+    if failed:
+        raise SystemExit(f"rotations failed: {', '.join(failed)}")
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/cluster/rotators/forgejo_token_rotation/test_rotate.py
+++ b/cluster/rotators/forgejo_token_rotation/test_rotate.py
@@ -1,0 +1,203 @@
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest_bazel
+
+from cluster.rotators.forgejo_token_rotation.rotate import (
+    FULL_ACCOUNT_SCOPES,
+    ForgejoCredentials,
+    RotatedToken,
+    Rotation,
+    TeaSecretOutput,
+    build_secret_manifest,
+    mint_token,
+    should_rotate,
+    tea_config_yaml,
+    tokens_to_prune,
+)
+
+
+class _FakeResponse:
+    def __init__(self, payload, status_code: int = 200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"status {self.status_code}")
+
+    def json(self):
+        return self._payload
+
+
+class _RecordingClient:
+    def __init__(self):
+        self.posts = []
+
+    def post(self, url: str, **kwargs):
+        self.posts.append((url, kwargs))
+        return _FakeResponse(
+            {
+                "id": 12,
+                "name": kwargs["json"]["name"],
+                "sha1": "abcd1234token",
+                "token_last_eight": "34token",
+                "scopes": kwargs["json"]["scopes"],
+                "repositories": None,
+            },
+            status_code=201,
+        )
+
+
+def test_default_scopes_are_full_non_admin_write_set():
+    r = Rotation(name="haku", credentials_dir=Path("/creds"), sops_file=Path("secrets/haku.yaml"))
+    assert r.scopes == FULL_ACCOUNT_SCOPES
+
+
+def test_should_rotate_missing_stamps():
+    r = Rotation(name="haku", credentials_dir=Path("/creds"), sops_file=Path("secrets/haku.yaml"))
+    due, reason = should_rotate(r, {}, [], now=datetime(2026, 7, 1, tzinfo=UTC))
+    assert due
+    assert "no existing" in reason
+
+
+def test_should_skip_fresh_present_token():
+    r = Rotation(name="haku", credentials_dir=Path("/creds"), sops_file=Path("secrets/haku.yaml"))
+    stamps = {
+        "rotated_at_unencrypted": "2026-07-01T00:00:00Z",
+        "rotate_after_days_unencrypted": 30,
+        "repository_access_unencrypted": "all",
+        "scopes_unencrypted": FULL_ACCOUNT_SCOPES,
+        "token_id_unencrypted": 12,
+        "token_name_unencrypted": "forgejo-tea-haku-20260701000000",
+        "token_last_eight_unencrypted": "34token",
+    }
+    tokens = [{"id": 12, "name": "forgejo-tea-haku-20260701000000", "token_last_eight": "34token"}]
+    due, reason = should_rotate(r, stamps, tokens, now=datetime(2026, 7, 2, tzinfo=UTC))
+    assert not due
+    assert "fresh until" in reason
+
+
+def test_should_rotate_when_scopes_change():
+    r = Rotation(name="haku", credentials_dir=Path("/creds"), sops_file=Path("secrets/haku.yaml"))
+    stamps = {
+        "rotated_at_unencrypted": "2026-07-01T00:00:00Z",
+        "rotate_after_days_unencrypted": 30,
+        "repository_access_unencrypted": "all",
+        "scopes_unencrypted": ["write:repository"],
+        "token_id_unencrypted": 12,
+    }
+    due, reason = should_rotate(r, stamps, [{"id": 12}], now=datetime(2026, 7, 2, tzinfo=UTC))
+    assert due
+    assert reason == "scope set changed"
+
+
+def test_should_rotate_when_token_age_reaches_interval():
+    r = Rotation(name="haku", credentials_dir=Path("/creds"), sops_file=Path("secrets/haku.yaml"))
+    stamps = {
+        "rotated_at_unencrypted": "2026-07-01T00:00:00Z",
+        "rotate_after_days_unencrypted": 30,
+        "repository_access_unencrypted": "all",
+        "scopes_unencrypted": FULL_ACCOUNT_SCOPES,
+        "token_id_unencrypted": 12,
+    }
+    due, reason = should_rotate(r, stamps, [{"id": 12}], now=datetime(2026, 7, 31, tzinfo=UTC))
+    assert due
+    assert reason == "token age reached 30d"
+
+
+def test_should_rotate_when_stamped_token_missing_from_forgejo():
+    r = Rotation(name="haku", credentials_dir=Path("/creds"), sops_file=Path("secrets/haku.yaml"))
+    stamps = {
+        "rotated_at_unencrypted": "2026-07-01T00:00:00Z",
+        "rotate_after_days_unencrypted": 30,
+        "repository_access_unencrypted": "all",
+        "scopes_unencrypted": FULL_ACCOUNT_SCOPES,
+        "token_id_unencrypted": 12,
+    }
+    due, reason = should_rotate(r, stamps, [{"id": 13}], now=datetime(2026, 7, 2, tzinfo=UTC))
+    assert due
+    assert reason == "stamped token is not present in Forgejo"
+
+
+def test_tea_config_yaml_matches_upstream_config_shape():
+    r = Rotation(name="haku", credentials_dir=Path("/creds"), sops_file=Path("secrets/haku.yaml"))
+    creds = ForgejoCredentials(
+        username="haku",
+        password="secret",
+        api_url="http://forgejo-http.forgejo:3000",
+        tea_url="https://git.allegedly.works",
+    )
+    rendered = tea_config_yaml(r, creds, "token-value")
+    assert "logins:" in rendered
+    assert "name: forgejo" in rendered
+    assert "url: https://git.allegedly.works" in rendered
+    assert "token: token-value" in rendered
+    assert "default: true" in rendered
+    assert "version_check: false" in rendered
+    assert "user: haku" in rendered
+
+
+def test_secret_manifest_carries_config_and_raw_token():
+    out = TeaSecretOutput(
+        path=Path("cluster/k8s/haku/agent-worker/haku-forgejo-tea.sops.yaml"),
+        name="haku-forgejo-tea",
+        namespace="haku-sandbox",
+    )
+    r = Rotation(name="haku", credentials_dir=Path("/creds"), sops_file=Path("secrets/haku.yaml"), tea_secret=out)
+    creds = ForgejoCredentials("haku", "secret", "http://forgejo-http.forgejo:3000", "https://git.allegedly.works")
+    manifest = build_secret_manifest(
+        out,
+        r,
+        creds,
+        {"id": 12, "name": "forgejo-tea-haku-20260701", "sha1": "token-value", "token_last_eight": "en-value"},
+    )
+    assert manifest["metadata"]["name"] == "haku-forgejo-tea"
+    assert manifest["metadata"]["namespace"] == "haku-sandbox"
+    assert manifest["stringData"]["token"] == "token-value"
+    assert manifest["stringData"]["username"] == "haku"
+    assert "config.yml" in manifest["stringData"]
+
+
+def test_mint_token_omits_repositories_for_full_account_access():
+    r = Rotation(
+        name="haku",
+        token_prefix="forgejo-tea-haku",
+        credentials_dir=Path("/creds"),
+        sops_file=Path("secrets/haku.yaml"),
+    )
+    creds = ForgejoCredentials("haku", "secret", "http://forgejo-http.forgejo:3000", "https://git.allegedly.works")
+    client = _RecordingClient()
+    data = mint_token(client, r, creds, now=datetime(2026, 7, 1, 1, 2, 3, 456789, tzinfo=UTC))
+    assert data["name"] == "forgejo-tea-haku-20260701010203456789"
+    assert client.posts[0][1]["auth"] == ("haku", "secret")
+    assert client.posts[0][1]["json"] == {"name": data["name"], "scopes": FULL_ACCOUNT_SCOPES}
+
+
+def test_tokens_to_prune_keeps_current_and_newest_previous():
+    r = Rotation(
+        name="haku",
+        token_prefix="forgejo-tea-haku",
+        credentials_dir=Path("/creds"),
+        sops_file=Path("secrets/haku.yaml"),
+        keep_previous=1,
+    )
+    creds = ForgejoCredentials("haku", "secret", "http://forgejo-http.forgejo:3000", "https://git.allegedly.works")
+    current = RotatedToken(
+        rotation=r,
+        credentials=creds,
+        token_id=4,
+        token_name="forgejo-tea-haku-20260704000000",
+        token_last_eight="current",
+    )
+    tokens = [
+        {"id": 4, "name": "forgejo-tea-haku-20260704000000"},
+        {"id": 3, "name": "forgejo-tea-haku-20260703000000"},
+        {"id": 2, "name": "forgejo-tea-haku-20260702000000"},
+        {"id": 1, "name": "manual-token"},
+    ]
+    assert tokens_to_prune(r, current, tokens) == [{"id": 2, "name": "forgejo-tea-haku-20260702000000"}]
+
+
+if __name__ == "__main__":
+    pytest_bazel.main()

--- a/devinfra/claude/README.md
+++ b/devinfra/claude/README.md
@@ -219,8 +219,11 @@ at the `home-manager.yaml` sibling.
 `web_setup.sh` installs `.#devtools` by default, or the output named by
 `DUCKTAPE_WEB_SETUP_OUTPUT`. Haku's <../../haku/runtime/claude_web_env/setup.sh> sets
 `DUCKTAPE_WEB_SETUP_OUTPUT=agent-haku` to get `.#agent-haku`, which composes
-`.#devtools` and adds the fastmcp MCP-client CLI (`fastmcp call <url> --auth
-<bearer>`) for talking to in-cluster MCP facades; Claude web uses the lean default.
+`.#devtools` and adds Haku-only CLIs: fastmcp (`fastmcp call <url> --auth
+<bearer>`) for in-cluster MCP facades, himalaya for mailbox access, and tea for
+Gitea/Forgejo workflows. Haku's profile materializes tea config from
+`haku-forgejo-tea`; generic Claude sessions can fetch `claude-forgejo-tea` from
+`claude-sandbox` when they need a `tea` login. Claude web uses the lean default.
 
 Secrets are **not** decrypted by `web_setup.sh`. `SOPS_AGE_KEY` is a user UI env var
 delivered only to the interactive Claude Code process — not to the setup script. All

--- a/devinfra/claude/claude_hook/creds_banner.sh
+++ b/devinfra/claude/claude_hook/creds_banner.sh
@@ -37,5 +37,12 @@ P=$(kubectl get secret -n claude-sandbox claude-forgejo-credentials -o jsonpath=
 git clone "https://$U:$P@git.allegedly.works/<owner>/<repo>.git"
 curl -su "$U:$P" https://git.allegedly.works/api/v1/user/repos   # list repos the account can read
 ```
+`tea` config for the same account is also published as k8s `claude-sandbox/claude-forgejo-tea` by forgejo-token-rotation. To use it in a session that has `tea`, write its config field to tea's config path:
+```
+mkdir -p ~/.config/tea
+kubectl get secret -n claude-sandbox claude-forgejo-tea -o jsonpath='{.data.config\.yml}' | base64 -d > ~/.config/tea/config.yml
+chmod 600 ~/.config/tea/config.yml
+tea whoami
+```
 In-cluster URL: `http://forgejo-http.forgejo:3000`. The account holds read-only collaborations on private data repos: `thrive-scrape/thrive-scrape` (weekly Thrive Market catalog scrapes: per-page raw API responses + `products.json`), `augur-evidence/augur-evidence` (daily FRED/Yahoo/Zillow evidence scrapes), `cpap-data/cpap-data` (nightly CPAP EDF archive), and `budget-ledger/ledger` (generated budget Beancount ledger). History via `git log`.
 EOF

--- a/devinfra/claude/web_setup.sh
+++ b/devinfra/claude/web_setup.sh
@@ -86,13 +86,15 @@ esac
 # Which flake output to `nix profile install`. Default is the lean `.#devtools`
 # (Claude web). Haku sets DUCKTAPE_WEB_SETUP_OUTPUT=agent-haku (in
 # haku/runtime/claude_web_env/setup.sh) to get `.#agent-haku`, which composes `.#devtools`
-# and adds the fastmcp MCP-client CLI. Only honored in `profile` install mode.
+# and adds agent-only CLIs such as fastmcp and tea. Only honored in `profile`
+# install mode.
 WEB_SETUP_OUTPUT="${DUCKTAPE_WEB_SETUP_OUTPUT:-devtools}"
 # Self-heal the Haku web home. DUCKTAPE_WEB_SETUP_OUTPUT=agent-haku is set inside
 # haku/runtime/claude_web_env/setup.sh (the init-script path), but the Setup-hook
 # path (web_setup_hook.sh → this script) and resume-cached sessions run WITHOUT it
 # — so they would reinstall the lean .#devtools and clobber the .#agent-haku
-# (fastmcp) the init script installed, silently breaking Haku's Tana access. The
+# agent tools the init script installed, silently breaking Haku's Tana/Forgejo
+# access. The
 # hooks profile IS visible on both paths (UI env var), so when it's Haku's profile
 # and no explicit output was requested, default to agent-haku. (Explicit
 # DUCKTAPE_WEB_SETUP_OUTPUT always wins.)

--- a/flake.nix
+++ b/flake.nix
@@ -387,13 +387,10 @@
             name = "ducktape-rbetools";
             paths = devToolPackages;
           };
-          # Haku's agent closure: the single shared `.#devtools` plus a turnkey
-          # MCP-client CLI (the fastmcp `call`/`list` commands, with
-          # `--auth <bearer>`), so the background agent can talk to in-cluster
-          # MCP facades (tana-mcp-ro) without a runtime `pip install` or a
-          # hand-rolled JSON-RPC handshake, and himalaya, the mail CLI for
-          # Haku's own mailbox (IMAP + OAUTHBEARER against haku-mailbox;
-          # usage in haku/base/sources/mailbox.md). This is NOT a devtools
+          # Haku's agent closure: the single shared `.#devtools` plus agent
+          # CLIs: fastmcp (`call`/`list --auth <bearer>`) for in-cluster MCP
+          # facades (tana-mcp-ro), himalaya for Haku's own mailbox, and tea for
+          # Gitea/Forgejo issue/PR/release workflows. This is NOT a devtools
           # fork — it composes the one `.#devtools` and adds agent tools on
           # top. Installed by web_setup.sh when
           # DUCKTAPE_WEB_SETUP_OUTPUT=agent-haku (set in
@@ -404,6 +401,7 @@
               self.packages.${system}.devtools
               ducktapePkgs.fastmcp
               pkgs.himalaya
+              pkgs.tea
             ];
           };
           # home-manager CLI, pinned to our flake input (release-25.11). Used by

--- a/haku/base/instructions.md
+++ b/haku/base/instructions.md
@@ -317,6 +317,7 @@ labeled write-capable below):
 | Purpose                           | Secret                      | Key fields                                                                |
 | --------------------------------- | --------------------------- | ------------------------------------------------------------------------- |
 | State repo (write)                | `haku-state-git-write`      | `username`, `password`, `repo_url`                                        |
+| Forgejo API / `tea` (write)       | `haku-forgejo-tea`          | `config.yml` for `~/.config/tea/config.yml`; raw `token` for debugging    |
 | Plaid Postgres (read-only)        | `plaid-mcp-db-readonly`     | `DATABASE_URL` (+ `username`/`password`/…)                                |
 | Google read-only APIs             | `google-access-token`       | `access_token` (Gmail, Calendar, Drive, Tasks, …)                         |
 | Tana (read-only MCP)              | `haku-tana-ro-token`        | `token` (bearer for the `tana-mcp-ro` facade)                             |
@@ -326,6 +327,13 @@ More sources arrive the same way: a new read-only credential shows up as a
 secret in `haku-sandbox` and a row under `cluster/k8s/haku/`. Model calls go
 through in-cluster LiteLLM via env (`ANTHROPIC_BASE_URL`), not a secret you
 manage.
+
+`tea` should already be logged in as the `haku` Forgejo account using
+`~/.config/tea/config.yml`, rendered from `haku-forgejo-tea` by your runtime
+bootstrap. Smoke test with `tea whoami`; if it fails, re-read the Secret and write
+its `config.yml` field to that path, then retry. This token has the full API
+privileges of the `haku` account, but repository access is still limited by
+Forgejo collaborators and ownership.
 
 **You also have a compute sandbox.** Your `haku-sandbox-admin` Role grants full
 CRUD **within `haku-sandbox`** (pods, jobs, configmaps, services, …), so you can

--- a/haku/runtime/agent/trixie_haku_agent.yaml
+++ b/haku/runtime/agent/trixie_haku_agent.yaml
@@ -9,6 +9,11 @@
 # trixie main — if the shell route needs `kubectl`, add it from an upstream static
 # binary (cf. loom/gym's docker CLI), not here.
 #
+# TODO: decide whether this Runtime C image should also carry `tea`. The Nix-built
+# agent surfaces (`.#agent-haku`, agent-box, codex-pod, and haku-worker) include it
+# for Forgejo/Gitea issue/PR/release workflows, but this apt-locked Debian image
+# intentionally diverges until we regenerate and validate the apt lock.
+#
 # Regenerate the lock after any change. NOTE: this needs the apt index over the network,
 # which is 403 in the Claude-web sandbox — run it on CI / a full-network machine:
 #   bazel run @trixie_haku_agent//:lock

--- a/haku/runtime/claude_web_env/README.md
+++ b/haku/runtime/claude_web_env/README.md
@@ -29,33 +29,39 @@ here (on Anthropic infra) and drives the cluster over `kubectl`; the
 
 - `setup.sh` — environment setup script; delegates to `devinfra/claude/web_setup.sh`,
   setting `DUCKTAPE_WEB_SETUP_OUTPUT=agent-haku` so Haku installs `.#agent-haku`
-  (the shared `.#devtools` plus the fastmcp MCP-client CLI, `fastmcp call <url>
---auth <bearer>`) for `tana-mcp-ro`.
+  (the shared `.#devtools` plus fastmcp for MCP facades, himalaya for mailbox
+  access, and tea for Gitea/Forgejo issue/PR/release workflows).
 - `profile.yaml` — the claude-hook profile. Sets the `K8S_*` overrides (→ group
   `haku` / `haku-sandbox`) and runs `bootstrap.sh` as its background command.
 - `bootstrap.sh` — profile background command: materializes `~/.kube/config`
   from the haku JWT, writes `~/.netrc` from the `haku-state-git-write` secret,
-  and clones `haku-state` into `~/haku-state`.
+  writes `~/.config/tea/config.yml` from `haku-forgejo-tea` when the rotator has
+  published it, and clones `haku-state` into `~/haku-state`.
+- `tea` is present in the installed closure and logs in from the
+  forgejo-token-rotation output (`haku-sandbox/haku-forgejo-tea`). Smoke test:
+  `tea whoami`.
 - `run.md` — the web entrypoint: bootstrap recap + concrete paths, then defers
   to the environment-neutral `haku/run.md` for the run procedure.
 
 ## How a session boots
 
 1. `setup.sh` (env creation) → shared web setup installing `.#agent-haku`
-   (`.#devtools` plus the fastmcp MCP-client CLI), claude-hook daemon, certs,
-   git remotes.
+   (`.#devtools` plus fastmcp, himalaya, and tea), claude-hook daemon, certs, git
+   remotes.
 2. `profile.yaml` runs `bootstrap.sh` (each session start): it materializes
    `~/.kube/config` from the SOPS-encrypted haku JWT, then — with cluster access
-   in hand — writes `~/.netrc` and clones `haku-state` into `~/haku-state`.
+   in hand — writes `~/.netrc`, writes tea's config from `haku-forgejo-tea` if
+   present, and clones `haku-state` into `~/haku-state`.
 3. The `Execute haku/runtime/claude_web_env/run.md` prompt runs a scan and pushes state.
 
 Depends on `secrets/haku-k8s-jwt.yaml` existing (minted by the
 `authentik-jwt-rotation` CronJob) — that JWT is what the kubeconfig is built from.
 
-## Gotcha: the Setup hook can clobber `.#agent-haku` (fastmcp/Tana)
+## Gotcha: the Setup hook can clobber `.#agent-haku` tools
 
 `web_setup.sh` runs **twice** per fresh session: once as the init script (via
-`setup.sh`, which sets `DUCKTAPE_WEB_SETUP_OUTPUT=agent-haku` → installs fastmcp)
+`setup.sh`, which sets `DUCKTAPE_WEB_SETUP_OUTPUT=agent-haku` → installs Haku's
+extra tools)
 and once as the **Setup hook** (`web_setup_hook.sh` → `web_setup.sh`), which does
 **not** carry that env var. The Setup-hook run was defaulting to `.#devtools` and
 running `nix profile remove agent-haku`, **wiping fastmcp** and leaving a dangling
@@ -65,7 +71,7 @@ at all.
 
 Fix (in `devinfra/claude/web_setup.sh`): when `DUCKTAPE_WEB_SETUP_OUTPUT` is unset
 but `DUCKTAPE_CLAUDE_HOOKS_PROFILE` points at a Haku profile, it now defaults to
-`agent-haku` — so **both** paths install fastmcp consistently — and it prunes
+`agent-haku` — so **both** paths install the Haku-only tools consistently — and it prunes
 dangling `/usr/local/bin` symlinks before re-bridging. Setting
 `DUCKTAPE_WEB_SETUP_OUTPUT=agent-haku` as a web-UI env var is an equally valid
 explicit override. (Tana also has a `curl` fallback in the base instructions, so a

--- a/haku/runtime/claude_web_env/bootstrap.sh
+++ b/haku/runtime/claude_web_env/bootstrap.sh
@@ -6,7 +6,9 @@
 #      one and only place the kubeconfig is built — no second writer to race.
 #   2. Read the haku-state-git-write secret from haku-sandbox and write a
 #      ~/.netrc so git needs no inline credentials.
-#   3. Clone (or fast-forward) haku-state into ~/haku-state — outside the
+#   3. Read haku-forgejo-tea from haku-sandbox and write tea's config when the
+#      token rotator has published it.
+#   4. Clone (or fast-forward) haku-state into ~/haku-state — outside the
 #      ducktape checkout, so there's no collision. The clone runs into a temp dir
 #      and is atomically swapped into place, so ~/haku-state never exists
 #      half-populated (it's absent until the clone completes). An early echo +
@@ -27,6 +29,15 @@ p=$(kubectl -n "$ns" get secret haku-state-git-write -o jsonpath='{.data.passwor
 umask 077
 printf 'machine git.allegedly.works login %s password %s\n' "$u" "$p" >~/.netrc
 
+if kubectl -n "$ns" get secret haku-forgejo-tea >/dev/null 2>&1; then
+  install -d -m700 "$HOME/.config/tea"
+  kubectl -n "$ns" get secret haku-forgejo-tea -o jsonpath='{.data.config\.yml}' \
+    | base64 -d >"$HOME/.config/tea/config.yml"
+  chmod 600 "$HOME/.config/tea/config.yml"
+else
+  echo "haku warning: haku-forgejo-tea secret is absent; tea is installed but not logged in yet"
+fi
+
 if [ -d "$state_dir/.git" ]; then
   git -C "$state_dir" pull --ff-only || true
 else
@@ -46,4 +57,4 @@ else
 fi
 git -C "$state_dir" config user.name haku
 git -C "$state_dir" config user.email haku@allegedly.works
-echo "haku ready: ~/.kube/config materialized, haku-state at $state_dir, ~/.netrc set"
+echo "haku ready: ~/.kube/config materialized, haku-state at $state_dir, ~/.netrc set, tea config checked"

--- a/haku/runtime/claude_web_env/run.md
+++ b/haku/runtime/claude_web_env/run.md
@@ -16,6 +16,9 @@ environment-neutral `haku/run.md`.
   for `git.allegedly.works`, so you can `git -C ~/haku-state pull/commit/push`
   with no credentials to manage. (If `~/haku-state` is somehow missing, re-run
   `haku/runtime/claude_web_env/bootstrap.sh`.)
+- `tea` is installed and should be logged in as the `haku` Forgejo account via
+  `~/.config/tea/config.yml` from `haku-sandbox/haku-forgejo-tea`. Check with
+  `tea whoami`; if missing, re-run `haku/runtime/claude_web_env/bootstrap.sh`.
 - Discover your other credentials from `haku-sandbox` secrets and your full
   cluster perimeter from the ducktape repo you have checked out — grep
   `oidc-ksbx-groups:haku` under `cluster/k8s` for every binding (write CRUD in

--- a/haku/runtime/claude_web_env/setup.sh
+++ b/haku/runtime/claude_web_env/setup.sh
@@ -14,9 +14,8 @@
 set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 # Install Haku's agent closure (.#agent-haku), which composes the shared
-# `.#devtools` and adds the fastmcp MCP-client CLI — so Haku can talk to
-# in-cluster MCP facades (tana-mcp-ro) turnkey-ly via
-# `fastmcp call <url> --auth <bearer>`, no runtime pip install. Claude web
+# `.#devtools` and adds Haku-only CLIs: fastmcp for in-cluster MCP facades,
+# himalaya for the mailbox, and tea for Gitea/Forgejo workflows. Claude web
 # installs the lean default `.#devtools`.
 export DUCKTAPE_WEB_SETUP_OUTPUT=agent-haku
 exec bash "${repo_root}/devinfra/claude/web_setup.sh"

--- a/haku/runtime/managed_agent/self_hosted/README.md
+++ b/haku/runtime/managed_agent/self_hosted/README.md
@@ -101,7 +101,7 @@ durable memory, so a cold session just re-orients.
 
 A full-NixOS rootfs (`nixos.nix`, declaratively consistent with the fleet)
 carrying `bash`, `git`, `kubectl`, `postgresql` (`psql`), `curl`, `jq`, `cacert`,
-`fastmcp`, and `haku-worker` (the pinned `python3` + `anthropic` 0.111 running
+`fastmcp`, `tea`, and `haku-worker` (the pinned `python3` + `anthropic` 0.111 running
 `worker.py`). We do **not** boot it: booting systemd PID 1 in an unprivileged
 container can't mount the API filesystems, so the pod runs the closure
 **directly** — k8s execs `/sw/bin/haku-worker-run` (a wrapper that puts the tool
@@ -109,6 +109,11 @@ closure on PATH and execs `entrypoint.sh`) as the non-root `haku` uid with all
 caps dropped. Build the uncompressed rootfs tarball with `nix build
 .#haku-worker-image`; CI imports it (`podman import`) and pushes to GHCR, pinned
 by Flux — see <../../../../cluster/docs/container-images.md>.
+
+`tea` is available in the image and logged in via the `haku-forgejo-tea` Secret
+mounted at `/home/haku/.config/tea/config.yml`. The token is minted by
+`forgejo-token-rotation` with the full privileges of the `haku` Forgejo account;
+check it in a worker session with `tea whoami`.
 
 The fixed toolset is `agent_toolset_20260401` (`bash/read/write/edit/glob/grep`);
 Haku reaches Plaid (`psql`), Google (`curl`), and the cluster (`kubectl`,

--- a/haku/runtime/managed_agent/self_hosted/nixos.nix
+++ b/haku/runtime/managed_agent/self_hosted/nixos.nix
@@ -48,6 +48,7 @@ let
     openssl
     cacert
     git
+    tea
     kubectl
     postgresql # psql (Plaid, reached cluster-internally)
     fastmcp # in-cluster MCP facades (tana-mcp-ro, …)

--- a/nix/home/hosts/agent-box/codex.nix
+++ b/nix/home/hosts/agent-box/codex.nix
@@ -10,6 +10,7 @@
       gitEmail = "codex@allegedly.works";
       kubeconfigUser = "agent-box-codex";
       forgejoKeySopsFile = ../../../../ssh_keys/agent-box-codex-forgejo.sops.key;
+      forgejoTeaSopsFile = ../../../../secrets/agent-box-codex-forgejo-tea-token.yaml;
       kubeJwtSopsFile = ../../../../secrets/agent-box-codex-k8s-jwt.yaml;
     })
     ../../codex # OpenAI Codex CLI + config

--- a/nix/home/hosts/agent-box/common.nix
+++ b/nix/home/hosts/agent-box/common.nix
@@ -19,6 +19,7 @@
   gitEmail,
   kubeconfigUser,
   forgejoKeySopsFile,
+  forgejoTeaSopsFile,
   kubeJwtSopsFile,
 }:
 {
@@ -31,6 +32,7 @@
     ../../modules/sops-env.nix # ducktape.sopsEnv
     ../../modules/buildbuddy.nix # BuildBuddy creds -> bazelrc + BUILDBUDDY_API_KEY
     ../../modules/forgejo-ssh.nix # Forgejo bot push key + git.allegedly.works ssh block
+    ../../modules/forgejo-tea.nix # Forgejo API token -> ~/.config/tea/config.yml
     ../../modules/attic.nix # attic ~/.config/attic/config.toml (push/pull client)
     ../../modules/agent-kubeconfig.nix # agent-box-<user> k8s bearer kubeconfig
   ];
@@ -43,6 +45,12 @@
     sopsFile = ../../../../secrets/hosts/agent-box-attic.yaml;
   };
   ducktape.forgejoSsh.sopsFile = forgejoKeySopsFile;
+  # TODO: like the kubeconfig JWT path below, this relies on a home-manager
+  # activation after forgejo-token-rotation commits a refreshed SOPS file.
+  ducktape.forgejoTea = {
+    enable = true;
+    sopsFile = forgejoTeaSopsFile;
+  };
   # TODO: this simple path still requires a home-manager activation after the
   # authentik-jwt-rotation CronJob commits a refreshed JWT. Replace with a local
   # token refresh/apply path if rotation staleness becomes operationally annoying.

--- a/nix/home/hosts/agent-box/zai.nix
+++ b/nix/home/hosts/agent-box/zai.nix
@@ -25,6 +25,7 @@ in
       gitEmail = "zai@allegedly.works";
       kubeconfigUser = "agent-box-zai";
       forgejoKeySopsFile = ../../../../ssh_keys/agent-box-zai-forgejo.sops.key;
+      forgejoTeaSopsFile = ../../../../secrets/agent-box-zai-forgejo-tea-token.yaml;
       kubeJwtSopsFile = ../../../../secrets/agent-box-zai-k8s-jwt.yaml;
     })
   ];

--- a/nix/home/modules/forgejo-tea.nix
+++ b/nix/home/modules/forgejo-tea.nix
@@ -1,0 +1,52 @@
+# Forgejo API token for the `tea` CLI.
+{
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.ducktape.forgejoTea;
+in
+{
+  options.ducktape.forgejoTea = {
+    enable = lib.mkEnableOption "Forgejo tea CLI config";
+    sopsFile = lib.mkOption {
+      type = lib.types.path;
+      description = "Path to the SOPS-encrypted YAML file containing token, username, and url keys.";
+    };
+    loginName = lib.mkOption {
+      type = lib.types.str;
+      default = "forgejo";
+      description = "tea login name.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    sops.secrets.forgejo_tea_token = {
+      inherit (cfg) sopsFile;
+      key = "token";
+    };
+    sops.secrets.forgejo_tea_username = {
+      inherit (cfg) sopsFile;
+      key = "username";
+    };
+    sops.secrets.forgejo_tea_url = {
+      inherit (cfg) sopsFile;
+      key = "url";
+    };
+
+    sops.templates."tea-config.yml" = {
+      path = "${config.xdg.configHome}/tea/config.yml";
+      content = ''
+        logins:
+          - name: ${cfg.loginName}
+            url: ${config.sops.placeholder.forgejo_tea_url}
+            token: ${config.sops.placeholder.forgejo_tea_token}
+            default: true
+            version_check: false
+            user: ${config.sops.placeholder.forgejo_tea_username}
+      '';
+      mode = "0600";
+    };
+  };
+}

--- a/nix/nixos/hosts/agent-box/default.nix
+++ b/nix/nixos/hosts/agent-box/default.nix
@@ -90,6 +90,7 @@ in
     strace
     lsof
     git
+    tea
     sops
     ssh-to-age
     home-manager

--- a/secrets/agent-box-codex-forgejo-tea-token.yaml
+++ b/secrets/agent-box-codex-forgejo-tea-token.yaml
@@ -1,0 +1,78 @@
+rotated_at_unencrypted: "1970-01-01T00:00:00Z"
+rotate_after_days_unencrypted: 30
+repository_access_unencrypted: all
+scopes_unencrypted:
+  - write:activitypub
+  - write:issue
+  - write:misc
+  - write:notification
+  - write:organization
+  - write:package
+  - write:repository
+  - write:user
+token_id_unencrypted: 0
+token_name_unencrypted: bootstrap-placeholder
+token_last_eight_unencrypted: ceholder
+username: ENC[AES256_GCM,data:mQkv71dwLG7egNDiyAV4,iv:bp+QkP2lFn+gZNIIYtC4XrSyB5d5Q4Z3MqRaTWbrz+Q=,tag:do2hO/RZi1TEMLBEtWgFgw==,type:str]
+url: ENC[AES256_GCM,data:q7b1SxrAKWl0f7myGrM9UKM/dqtrqeZID3tK,iv:/4eaDBPz4ulA7zQ1UE43f/TwMsT8am5py4YokGzJ258=,tag:J7/N08hB6ZnZlUs4+mx4cw==,type:str]
+token: ENC[AES256_GCM,data:FuEZRWm8I33DgKetKOBf7IU5ZLbp,iv:odyQvRPHFChfPvnJCoeyapTs2/IicHUiQfVy9NBpoQ8=,tag:ZPtLE52+EeGlxcrZWa77Sg==,type:str]
+sops:
+  age:
+    - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0bXowWnlNSlQxTWZmL040
+        MGhMWmRrRkdoT2gxazBrQTUzKzJVa1N0YTF3CkJCc3gwZ1BGME9IVkg2bDliVC9l
+        Z0d6OGVMNXRjR0VOdlJKeDVQWGJ2YlEKLS0tIHhFdmFZNVBoVkpHV21VR1hEUXdB
+        UkRvMzgwN2QyY1pWVjVXOE03azVHSDgKbFLIUi1O0xTzfceTMkGtvtm0OE8SWvqq
+        n3qr2EMj2ujPIcSP4ffGbBmT33vpOCiNnNijTycIe0ndSfYbupKCyg==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age16madmg3yjv39dekr6dscqr2slv0haxcw7lw25v8vmly4wl95td4qwev54u
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTb3VDc3JrTXViQnZwa09K
+        Mi8yMS9sTEpMcFE1cEZLcTZyWUxRWmVTSDNBCm5Lc0E3UGRMSFM1RGNKMWhtdVp5
+        VGZ6M05KdkNnWGRUN1A2SXRoRUtySXcKLS0tIHFYcmZSNUdtVFI5d091K2FXRDdy
+        Ynozcm1sbzJUMHIwUXNXQ3o2ZElZWHMKgkZ/TpMdI4OQukBJMVxtNp1WlAPrwUK1
+        wMXHwhTfd/h8oVl2yd9G+aJXNlK92/xqvdygrwCYiE7mJrxkD0bcBQ==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age12c2ef6ayydzvmz6k49pyyhtgu2g00nyynmht8y3laqvxn3wya4wselpc4s
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCTVFsZm1NWmRDWnR4Q1Zo
+        SG5YQTZndGsrbFEzRk1Nc3MwRTFmVmlyN2dZCnVkT1BLNStlcm1YemNncitLajRD
+        RzllR2I5L0tXcFUzVHRhUUV5eXpLS2cKLS0tIDZqemFWdmxwTVdVeFpVdUdQQVE2
+        eWRUUDYzV0gzMStNaEphcjhDKzlTWE0K1lu7+GIU35wNkLwOKcGBTQ+JgkwRJWvv
+        hhukxoccv4RnPACxYnp8E1qVR104SOw2jCXprNnwGwm9FewMd6gV+A==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1qdgn0k59t7ghg3t4gg02g2ppnzp7uz0ddplup38y84hqslcsgsxq3v9tkz
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3cHI4T0grVFlqeTRoMS9i
+        WTA2RTVibFJsVUoycnpJNm1nNEVzVUdWZXl3CitZbjlXUUE1dEtiK1dNSC8vVkFv
+        RzZKaVRaaUIzaitTdU8xSU41T0lDekkKLS0tIGJ0Y0lUZTd1OHlGa2J4VzducUxO
+        cnY0dExNQWpCc2ZtZHJqWnBjbExlTjAKU1BKTtGpvUMLLAKKz5YNc28aQpyvT4dX
+        mIeVwPqpcQLoRY5JlA5wCyfbbqUodam5F2sI1kIhe+5QSoCndc1REA==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age15hfg4r2zfc2zl6zarecpvykxjktw4zu3grlahz4397rstmhqpvtqjgf6yy
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDSGdvODFOcWZNNGFaT1cz
+        NWwrZUhBeGxsYTVTU0hscDFNOWlRdHlXSFY4CnlCNnRZWjExaWY2dnZPd0d6RUZW
+        K2gxUlp6N2VVK2l2RmN6RGVNbzIzek0KLS0tIFA4YmdDbk5MaTdLNHRQU1Y2K2l3
+        ZWoyZy9LdXRTcTByMmd3TzVuL1BBZG8KAOdHIBBiyoRxa66D5ltGUwF+t0CyPE9U
+        Zc/ZbLR2sN2MixLO7IzlaYOtoOmXugJEge2RzoYFs/cSc6uq8ILeew==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1l325yz3v2mev3t896mzvmmkaatjc7z4d9kukvnjuslgwwd8zg9ss9pnsc7
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxZmhGZ1hhQjVZL0dNSzI4
+        bUc4QUkzNFpubjhjRWsvWUFRN3ZNajlKK0RVCmluZ1dlcWhUeDBidGlpV2ExR3Ra
+        UkN4SzZkK3I2Y0duVzlMajRqN2RvUUEKLS0tIGZndlk4RXJHS2hsTndWdGJsWE9j
+        dGk0Rno3TVgrc3JpYmw1TjFhM04yVGMKVtgdmhcx2ugBNRfM5L9bg9fPx/vLeQD1
+        JCO1AczmSIiKOJWIjB1jIXJpMhmYOgnq8bPioSAxJI6YUw54FurTHA==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-07-04T23:17:39Z"
+  mac: ENC[AES256_GCM,data:LcBP/hur6lhxzpxPcTQYSvAQrE05gFBm6gT/Lh/syXxR/aq17KnD5zvYByvQlcc7tm+GnKJE7U0DclJ9rZUtIrkE7AqJLO6vfEVgFG0fxN/CiQNEGJAnghnZrDY1Kq8Z/HJ2/I9/WxOaIs2wpuDy4AWbxr7x276zP2D76aojeIA=,iv:3ljnxUXLlYZM+PvYOWzvDHrxeiYOGttfdC642ABFhzA=,tag:7iGhf4AjOUY8xqPWUsqBuA==,type:str]
+  unencrypted_suffix: _unencrypted
+  version: 3.12.1

--- a/secrets/agent-box-zai-forgejo-tea-token.yaml
+++ b/secrets/agent-box-zai-forgejo-tea-token.yaml
@@ -1,0 +1,78 @@
+rotated_at_unencrypted: "1970-01-01T00:00:00Z"
+rotate_after_days_unencrypted: 30
+repository_access_unencrypted: all
+scopes_unencrypted:
+  - write:activitypub
+  - write:issue
+  - write:misc
+  - write:notification
+  - write:organization
+  - write:package
+  - write:repository
+  - write:user
+token_id_unencrypted: 0
+token_name_unencrypted: bootstrap-placeholder
+token_last_eight_unencrypted: ceholder
+username: ENC[AES256_GCM,data:PUFbvnmXyzeK+OykLA==,iv:gkoWzyG2C8sXXxBZxnpl1dT4p8U/5gF3hXVikNlIEts=,tag:FpWPy617egxpEMTtPEme7w==,type:str]
+url: ENC[AES256_GCM,data:3fiQE0j+R+V989+tgTLf2R9RMo78erCN1KRF,iv:SIrL0O+/RGkMw7pZKf0+oVDsp3t0Ow32cx5E2NKbM0w=,tag:TtLk8sgZlC18FAwmwp5TlQ==,type:str]
+token: ENC[AES256_GCM,data:rl5OV7Jsm0n/2QNTXaCFPYSM+N+u,iv:aXZVkRAX3VrlSqKagsDeu+fvU9b0tpKTUEjOBTBcKcM=,tag:5xhbklH3uE7SdlQJhC4mdA==,type:str]
+sops:
+  age:
+    - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPQy9YYnZ3S0daMk5jMDht
+        VGF2VENpS3hQTStZS2pvZGltdkpDODY4YlNBCmlIcENnZThnWThRVUdESHg5eHlW
+        dm43Mm5XRjZlV2VLeWh6VG1OK1FzSGsKLS0tIHduZCtpWHF6Y2xSaUpXanh1azRG
+        ZVNlSVdrZXF3aFp4MnVCQUpxMmtVS1EK7BS9UmAjbI//MTrxH1o7yps1TX9RWiVa
+        G//qgzWPl81JlZEHsF2jNNVnwGCz+L5z58ZYOcCw3A3MmZAYNBlRjQ==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age14zkdx3rku2yp9zv8ejrlv0yd53yx7rmmtfzxmxhawvc5hp2gxf7sxnv4sv
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRbWRtTFpWUWtocGFVZEV0
+        SVlJb2tOR2krcVhtbmJweDc2YjRDcWM4SXlrCmE1czhjQkZybkhXeXF5SjlzYXBL
+        QlExL21UVHk3S2c0TFZSTkc2Y0dmdHcKLS0tIDVvYjRRLzdaTTd3REtJalFyVEkr
+        TEFZZjRRYnJnOWE4VllleEJjMUpoS2MKR0bwu2ojcc8gEKgJ/F/U6foDCCZtO1CH
+        q41oi1UL3l9nVu/cyBsOA1+oYzUr6hH2kWC5Of/ldojAXjDcgCd7Sw==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age12c2ef6ayydzvmz6k49pyyhtgu2g00nyynmht8y3laqvxn3wya4wselpc4s
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLZG9rTlc1Qjd2N3EyVHNB
+        YTRna3NSbnhzbFlGaHRobjZseWRDVGlWNUJzCjFzMkNvdXJIcmVLMENSOEVVeXVl
+        OGdQbThoSFVqQTZEa21ReDRqMWxJdzQKLS0tIDdSMkFaVjZYRXQwOEQrM1IwdVB3
+        ZTNxRWtaMGc2NHZ0eWRGTXdDaW5yWW8K38SBKSrR9oFXN6hvIKpr8o7jMcSYqHFa
+        cHqTH24GsGBscBeKLJ8J9B0xOqy2hKWTguPCtVzmKKi20VtCunNFOA==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1qdgn0k59t7ghg3t4gg02g2ppnzp7uz0ddplup38y84hqslcsgsxq3v9tkz
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSVU1FSlZkcmhZWWZ3S1RV
+        OHJyaTRlbzA3V3VZQmJDa1hOVWRZd1lMdmg0CmxvWDZDdGlBZ0piclpOS0xEQTR6
+        ZGU1SEVtWlo1b0tQWXg1cXVTYmlFZnMKLS0tIC9PczZsQzJ4d3JWRTdZc3IxaXd6
+        NzVHaTliTTJ0cGZ2bWgzYy95SUFiQW8KFkvDwkuDxNhKxSxGhzl49ECR9OucQPx+
+        7/RStdjp9yzb+leuznmu5bT4CZCM1bDDud62J7clknp930XNdPBPPQ==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age15hfg4r2zfc2zl6zarecpvykxjktw4zu3grlahz4397rstmhqpvtqjgf6yy
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArN3RsRTFkNHJCRDFMUkFs
+        MWFmMCtKYTVtdzVIbGZCRzRSTTlOVVJTZmxjCitRbXVFU0lYWWZWTXBvaENOZkNs
+        VUdDeGZjeEJhWFYxUFVkekRCM2xIK2sKLS0tIGFMSzkvdjdvUEFjZnUxQWsydUJx
+        SkF2SVc4SEtnY0N2bnJ4NS9Pb2hyMjgKUL8daDPQwRi395TwiXxvX15q5RWGzzMX
+        /sEHfc3D0V7EiBsqjKWUCgZ2GiPLB+74Db8j8QdOHxGwwmPnqbGJAw==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1l325yz3v2mev3t896mzvmmkaatjc7z4d9kukvnjuslgwwd8zg9ss9pnsc7
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvMFgrTnYxaGpVNkhqWmxa
+        cGx6aTJjRFF1L2RDbGdyV1M4VW8yWjFWakM0CjNhZkxVazRVbnhNeC92RisxQ0N0
+        Nk1RUVNHUkpFcFZ2cEYvdEdGZjRkdVUKLS0tIGJaL3h5VE9pVG11Mlo5UHFQMVZU
+        dkw3Wlg3QlVsMklMdDRNTElkR2hMUDAKb6qyBybZ4OGfbA/0K+GNQi45d7CfxZ/5
+        /y5QAWcAagPpMVldWdWa0b/YwfmBMZmcvTeNGDn4OrTMGciB5vT9mQ==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-07-04T23:17:39Z"
+  mac: ENC[AES256_GCM,data:K3YeWI3qQtIZ9ZobwNjEEq6Z4mm3rGNAexMjCuY/VYaGMPuOMCERmtNRqslTLLcWvxpd5/53eafjJzcBVdGbwNj0Um+FtI1AcYFxs6rn8yOcDP/ZuvcldIHZfiEor5Dy25BZfGbWiPOII18714jRE7vQapSpjMc5tLGlDMYfLjE=,iv:52u1KzhCAR01K75nAeJSwGIrOv6pAwUH2sGk8vTmhTg=,tag:eG9fRAvraPa9xeBT/8IiiQ==,type:str]
+  unencrypted_suffix: _unencrypted
+  version: 3.12.1

--- a/secrets/claude-forgejo-tea-token.yaml
+++ b/secrets/claude-forgejo-tea-token.yaml
@@ -1,0 +1,78 @@
+rotated_at_unencrypted: "1970-01-01T00:00:00Z"
+rotate_after_days_unencrypted: 30
+repository_access_unencrypted: all
+scopes_unencrypted:
+  - write:activitypub
+  - write:issue
+  - write:misc
+  - write:notification
+  - write:organization
+  - write:package
+  - write:repository
+  - write:user
+token_id_unencrypted: 0
+token_name_unencrypted: bootstrap-placeholder
+token_last_eight_unencrypted: ceholder
+username: ENC[AES256_GCM,data:+AC8PnUs,iv:f1LgBDVq53EkJI4rG2YZBOCvu21Ga8mond+jJ/vbCWA=,tag:mgn9TDiha86roMN4GtJmBw==,type:str]
+url: ENC[AES256_GCM,data:rvYJek78Viak8NQ03l0U2diUvjms7eLuG5Wt,iv:K8O2YwmAhoJNoQlaMO4PUvZonIlqaaGOk4evXtf6KDo=,tag:4lQfIBRz16FCQPmziePcpQ==,type:str]
+token: ENC[AES256_GCM,data:ZK5NDjDas8j+B9CQL1Ir6PvuHgTf,iv:72IY5bH7K7OG6n7Qf8cDiOaYRCnBvE/anPiiZvp+viQ=,tag:XhsquJvX3DhCNUpjUsoB5w==,type:str]
+sops:
+  age:
+    - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEaVBhNytHck82cHZ1R2FV
+        SmtUcnhFS2dqWFFkQ2RqSEtwWWRIV0ZGeEd3CjNBNzhBSUIvUXlkamhEbnNrTmhY
+        bzdtRWFhVFRUeHR1WERISERPNngrdm8KLS0tIGF4OG01cXdISkpCOWJ6NDhFbisr
+        ZlpWVENJK0dXMGFjS2JNYmxIT0pQRU0KtNAoWLzzKnUwSpNGcf8gcgCq/4RrabF0
+        cjuPA5UgOiqpEC3Bzz+ksbw2tRh0HMMUXQ2eoBPsB1EGMfUGD1LXJQ==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age15gxxqn49sp8qhdya6utanzsxgzpfup63yfuht9yza4adpule4auqzsddj2
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRajJidHVFU1YvRFpCM2Nj
+        OFlybWpNQnMvaDRoUHlmT1dLQnpycmFCbWtZCnNBUVN2SFU1U0M4Z1ZMOVI2Vlk5
+        Zm5oVHdOc1FXNUtlVlI1ZElzdzZqamcKLS0tIG1ldXB1akQ4RUxTNEcvZmJMa1lu
+        ai82SWdYaDN4Y1FGTXdwWEo3MHBIQlEK0DLjQA5oIxroTbyCHkNY92N41FPsrPrx
+        o057/1j5LVpI80BU0PTr7uCygkK2qMPefX9JdaiYWR6IiGqzXUQbYA==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age12c2ef6ayydzvmz6k49pyyhtgu2g00nyynmht8y3laqvxn3wya4wselpc4s
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2bTFIMXgzTURnTVc4a3dx
+        bmhjV2tYVGxRaVp3Uk9rU3puRVYzWnlwWndRCktVVlRIZnFGbXpUMkhzd2o2S2Rz
+        cDFuenFORms3ZzhNQzlVMG1jVThONkkKLS0tIG5XMkRjMUNvL2Y3b1dLWDdpSEpG
+        WStYUTFTRmdzUlFBL2pvdFdNS0J1NkUKrPi5nO+BxsKoXNsMkhO5K/WiKiQ8x4TF
+        Fb5LKkHqZhPz7pZ6QXiThrioVmgaed7CvO2v3Ekt3FZ9sgLL3jIVIA==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1qdgn0k59t7ghg3t4gg02g2ppnzp7uz0ddplup38y84hqslcsgsxq3v9tkz
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQdFZ1eVRGbDFvLzNCT1hE
+        MGhJNFlCejJsY1VwdTZVbi8wSG5DeE1FbFNRCmlqU21IcjRqYnFwWlcyZ0laTDdF
+        S2wwMmRFVytnY3lRQm1CZFY1NG1YalkKLS0tIGlmYmVuVFFGZ3poRnU1MUNVcTh3
+        SG82N1B5NnRscGpqYXZQTVhnY3JqS1kKpvHE8XmHoI5UBE5y2FhDNj5I3PU0oMBc
+        0n2+YeRXhIK4GF46GXdV2q6KS0JLYc7ll9d2WtlLvyvHO4lE5pzD3Q==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age15hfg4r2zfc2zl6zarecpvykxjktw4zu3grlahz4397rstmhqpvtqjgf6yy
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIOTgzWWFwKzhFYnUzWTBh
+        cUU4dkdXN0dwVGs3UW01bGVNYUQ5MDZPWENzCkliMVpzYjZtcHZZYmxkeVl4VXFn
+        dEE5T1hRY1ZQUjdXNmlhS2xoNWtUV1UKLS0tIGk5SzVtQzhlNTBjRDh1TWM5aEJk
+        eloveWRFQ1pkNGNScFluNk9UeHB6c3MKZDnelFJDn4TfLl0lLiZyt6jiOnkgRRNV
+        I7TV6QBOtw9yRGIqehqju1aKgaKC/olGz8fEzIspBwKRsIYAh2kNHA==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1l325yz3v2mev3t896mzvmmkaatjc7z4d9kukvnjuslgwwd8zg9ss9pnsc7
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJa1JZaExQcURQWHVNNmdT
+        ZnU5K2daR295VGNlN1NGeFZDM3VabCs4aHhVCjdOQUwrTEluVG5ISllvei9OR1Vv
+        OEZRTmxtVEQ5SkJtbXRtZndreFQ0RTgKLS0tICtjeXVFNzNlcERpUXlzOXRvWERT
+        cmg3a1VpbWxtS1F4dmNXRGJJTElvelkK02ByC5geDpSP2mme/w7Rwe8alzIewyO7
+        INcUwHPcxGr0bYNAxyMbSTt2X3zntJvzH8WJ8LopO1qhbxXbyT+z6g==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-07-04T23:17:39Z"
+  mac: ENC[AES256_GCM,data:YnW5CnXicDVX/k/kBWrJcdD39ioHUjp3Vpy3gUBkj4WzaCsbsdiC00i7evfNdntHsd0bi3v6MJT5djadStasuG2nyHvDCqb/1Rk3C5UBNp/NMI0UnBmqD1IrbSThRdHXL4M4yPvg1t5SwC7NKVmelbj/PEPz0vgqSYkPasSJ5qA=,iv:xAThYaLjoGsw0sL1ZCbnrwJhd2zyzNmwgToPb+Cdw/k=,tag:7mFteZP06IZV2/wxmSOhGw==,type:str]
+  unencrypted_suffix: _unencrypted
+  version: 3.12.1

--- a/secrets/codex-pod-forgejo-tea-token.yaml
+++ b/secrets/codex-pod-forgejo-tea-token.yaml
@@ -1,0 +1,69 @@
+rotated_at_unencrypted: "1970-01-01T00:00:00Z"
+rotate_after_days_unencrypted: 30
+repository_access_unencrypted: all
+scopes_unencrypted:
+  - write:activitypub
+  - write:issue
+  - write:misc
+  - write:notification
+  - write:organization
+  - write:package
+  - write:repository
+  - write:user
+token_id_unencrypted: 0
+token_name_unencrypted: bootstrap-placeholder
+token_last_eight_unencrypted: ceholder
+username: ENC[AES256_GCM,data:wTotZlYUshUY,iv:8Pb0h0oAEReLCvNB6Kdo6R2Ct85IGR6SYZmGVuya9Jk=,tag:LOPu9l5PG1M3EkVoaEVY3A==,type:str]
+url: ENC[AES256_GCM,data:3minL89XAtczJ3h13DrNVwAhm1o1wRDyMfHV,iv:HONtUkYC3nuAoI8fbC9e2x+kTzXJk1QwS5H2BKTsyJc=,tag:secO5OiAQKvIUbPNYmVh8A==,type:str]
+token: ENC[AES256_GCM,data:8qujydAwfDT/BCnQbY1Mv+dAPHCv,iv:7gpw1BTSZHhoZ+6YqSI3g/snkRHLtt4ZFti2tkeqcdA=,tag:pMjnrCVCdYmlsMmWM+ck2g==,type:str]
+sops:
+  age:
+    - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPMUxzQTY3azRXZzhZOHRP
+        dlk4VXVLNWlNcGRabmQvSjQyZnF3VEIza0FVCjJGbmF4TmV4ZkIyVVBGV0NTekM5
+        RVFiV2NJWEswblNIZ1NrOHpNMllPRm8KLS0tIDBsT25rckFXdUZzbUJMcWRTWmo0
+        cmhOOXhTK2R1Y0podlh0bU1pc3pwUVEKsBPA+r0Jmaue33ugLt46obeYrHpazW7q
+        OY0taVrhsduWavN5yqm38JXhjVWAmAEz4ATOED/tFIFDnK0APEOVpg==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age12c2ef6ayydzvmz6k49pyyhtgu2g00nyynmht8y3laqvxn3wya4wselpc4s
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0RnRoamd4K3BVVVpPNUxJ
+        blJPeWtFSzg4Z3Z1cEY3TFQ0UmRReTZCbFNvCkNCYVh4M2liTVpTNlF3dDd6eEVo
+        QXFwRUJoTW5lVmcya1hUekRTSk1PRzAKLS0tIHJDTVZWeUE0bUFMd3ExQjdrNEw5
+        c3VJSnVFMmtLQXhwUXpueS9pbFdoSjAKT4fcKOSIqXsePU5sgwsEfbkucOZMEIbH
+        +If6qZss5vRy3oD28aQNadBvZ8uQnn5qIfj3tf70X7EcFrCFqUx5fQ==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1qdgn0k59t7ghg3t4gg02g2ppnzp7uz0ddplup38y84hqslcsgsxq3v9tkz
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDS1NkQytQclFwV2dnZ0lY
+        cllSeHRZaWxzZ0d2RW9SSm5jaU9odWU1SEI0CjZpYUZlOWpDSElxNEticmllZ1Vz
+        TGx5dDVzKzVYSW5LSy9ONVBJWVZVVDQKLS0tIFFtcVVtNWo0M2pXN3IxclZGcWRk
+        RGY0cW9jdkRoYjk5cjMrbUhQMGlyWlkK2h7U498bvzrSLHyhxTYC3LuchiD4uuHT
+        eWmzouF4AjuqYCfWWMNLVVXFGKVb6Ndvil9Y3ES5LpaFCqFxfQY09w==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age15hfg4r2zfc2zl6zarecpvykxjktw4zu3grlahz4397rstmhqpvtqjgf6yy
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA0cCtnRUZubmtuUEUySlJM
+        OE9ZQ1RCOWkzMVErNHF3Qmx3SW1rK2FPM1JjCnZDMmdyeE9vTkRsNjlyU2tsa0Vv
+        RTExUFIrQ2hkOWl5Qzd5MTZ3eWQxWmcKLS0tIHRSWTFOOU5vZGlMTVZrbXNWanpN
+        bnlNNW1uUFp5dDZhR0VnOUxmV1ZzVmcKd5/dRGqUp4necxuEQf4KTntd0/RtWu4c
+        oQsaZrvsASrQ6riieLhUJmExYIJ3XWCiXLOqaenYXrumm5s8FOWDHw==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1l325yz3v2mev3t896mzvmmkaatjc7z4d9kukvnjuslgwwd8zg9ss9pnsc7
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2U1BVZlhGRm9wSDQ0RVBQ
+        eHJMQi9FRkdudm1Ud3RoWlJuK21KbEdoSkc4CkREUDhEVFZjcUZtWFIzZ0VOOWdI
+        UlJieWJLL1ZmSTFxL2dGd1VoY0NzemcKLS0tIDlwSG5TbWV5Qk1YRTRrYllnd0pq
+        UWFOc0hXVHl0bGVmOStlMjdZY0lNbFkKFO7/FjghX3PVNuPR4uUPCr13N6ZoRbEG
+        o/FP2EmLXKXW24SfGnSdlbLQtb3x57kDu5YMbqMMR87DgrKp4gvSsQ==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-07-04T23:17:39Z"
+  mac: ENC[AES256_GCM,data:o0zSXbmGPGAXX677XVLW4yYUwMSL8HS9SLyO2dI1DD3C09f8d8IKpmvfwwPV95bsLSOxN0zKcZxW2VAphHIrukbub/K4eaS1m583KDZ2hWF2Z+kD8ewILixfDDVSmFpJ4S/X4J1GpTo0xkYtekx173WtI1mviiPopIqieFYueMM=,iv:Puktjv9jePwaMrGRMIxv9h+VbmadPIMDdTk+ZTIaZ6w=,tag:5/0etolC8gOFRtriYTZzyw==,type:str]
+  unencrypted_suffix: _unencrypted
+  version: 3.12.1

--- a/secrets/haku-forgejo-tea-token.yaml
+++ b/secrets/haku-forgejo-tea-token.yaml
@@ -1,0 +1,78 @@
+rotated_at_unencrypted: "1970-01-01T00:00:00Z"
+rotate_after_days_unencrypted: 30
+repository_access_unencrypted: all
+scopes_unencrypted:
+  - write:activitypub
+  - write:issue
+  - write:misc
+  - write:notification
+  - write:organization
+  - write:package
+  - write:repository
+  - write:user
+token_id_unencrypted: 0
+token_name_unencrypted: bootstrap-placeholder
+token_last_eight_unencrypted: ceholder
+username: ENC[AES256_GCM,data:UKAstg==,iv:Pi4hci3qJb5AdOhLyt/HWfV+cQVE7eacFXzHy5BUgOM=,tag:RNaYyKwZifhUq491DY0RIg==,type:str]
+url: ENC[AES256_GCM,data:spb6jS+taGbwtEwP56S65+HkNcgx/HWXjtbS,iv:0mxT7YgIBBM+z8/D5cJThAQ4l6Z1odBGV/mW6Lh8umw=,tag:bacXOaqODl6EzojnaLG+vg==,type:str]
+token: ENC[AES256_GCM,data:jgB8k4bKcUUH0PZTakrM124ReAGi,iv:alQpsVmku07fREe51uOKnEq+/pY+jNT+0xhM7u8b244=,tag:ZURo0KFJe1FkvI6sWN78CA==,type:str]
+sops:
+  age:
+    - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxalQ0VmlIOGJub01qZlRR
+        OEttWCtadUdoR3l4YXlBVVdoR1JGQUhDbmo4CklVRVpKcC9wUHY3d25PL1NrSVBr
+        QzdObDAwVmRvTGcvc1pWSktGWk9WdFEKLS0tIFZmR0dkS0dNWTgwVHU3QjBUL0Ry
+        WVV4TE9uWjNiVG5xMzkwUDNJRUE2c28KqjaYU8jaR5im1339EjN08WbxHsV/aO1x
+        i2iCkMV209LiKFWnJG+BCkmswhcT5xSpPa4G0Mhgk7xs4MqYUuyJ5w==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1756xpy6yg7r8vdducm5cdn4cqt3m5qkcncxumsh8htlfdzpae4cq0c6gqf
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoaXlMNkJUM0tTd1c1Y1g0
+        NitHUlE2dFZ0bzBKcWwyNzJuTGZtZWFTeGdBClNJMnlvMzc2ZDdsQ3h1WFJXd2pt
+        S09OYy9qK3JhY3p4NWxRTUphYzdzdW8KLS0tIGFMQ2FaQXo1MDZBWGV3VmttNjh5
+        cDd0RFlpRCtacWJEenlwSU9NZk0va0UK0jYMDvaPCEzbD5RG5ej3n0S+vykAXzPH
+        2ZQn0sPpkeBti9t2dNcclXUgQ+1i4Qohx2TizsB6QWGVuVvoat/j7g==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age12c2ef6ayydzvmz6k49pyyhtgu2g00nyynmht8y3laqvxn3wya4wselpc4s
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQSEVjM3BxM2ZxRXlvWmNq
+        cGtlajlhTVVFY1N3bHV1czhMekhYWkFGUDBZCjgwOG95TzRuUVBvZGVndWU2bW5Z
+        Vko5Zml3b1pKYWdOUmJYaDFBZElTckEKLS0tIExGNUVQY1VLV2Z5aXo4SGo4TCti
+        ZlNZdjJFYXpOdVA5SitzdXBnR2lwRFEKdeQP7ItR0Z2XlOIvBOGz9GFKah8060Er
+        JfGaekSaEl7Ah36HuVg5CJr+SlLN6AgSUDoAwhGMeDfHrJwofnxm8g==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1qdgn0k59t7ghg3t4gg02g2ppnzp7uz0ddplup38y84hqslcsgsxq3v9tkz
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlcEovbm9iMkg3MmhZQlIr
+        a0RhMSthVUEzUU1TTFc0SnI2c2I3VW5FK1FVCkRpUGRrVjlnTjZHNTlKTTRLb3J5
+        RHFPT3VnT3lmKzY0dVdMOWEvMjFVQjQKLS0tIGFHdHd2WGsrUzVReEVTNkt2UXUy
+        SktXNUVRd01IQWRSTno4dTBoOUtQaUEKnsYYO+8AnjUNeI39s7qli535Q8d/BgK0
+        3rRhY5jyEyjstY3zAXgEMB1o2HkgWCuE7L4NlDWtmE3soRiuYRtcjw==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age15hfg4r2zfc2zl6zarecpvykxjktw4zu3grlahz4397rstmhqpvtqjgf6yy
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsKzhHdHFJNFRHTmhwWDc1
+        dEY1eHRtQi9WWWVTQ1Ava2RyOVVmMkllSjBFCkFhTmxDSUsrWFdhV1pnMldHQ0hM
+        eHRKeFQxM0VmQWJvdjJpQlNKZHdmK0EKLS0tIHJBTkxLQlBMTXByMDRyWnZrRlFJ
+        TFZuQzFwNnZDREEwOXdqazkzMWU5TUEKXEZrt08yzjQiUAhfisZ4/Ud5I3kiA9sr
+        /i6H8xYnVeCWundPcrPTBAYghUwRLzuoznFEKaAH36M/d1lJVncwzA==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1l325yz3v2mev3t896mzvmmkaatjc7z4d9kukvnjuslgwwd8zg9ss9pnsc7
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1Q2lGaUovbEtqbTYxZm94
+        bFVLYU4vK1N1bkJVSGp5dGVKek1xK3FLUlRVClpiYkJqazlJcVVGSnh1RTNaTWh4
+        Ym1WM2ZLQ090a0RhNW1ISHozNFFpelkKLS0tIHc3L21NS1pQaXo2eXpFWll1RXEw
+        c3FUYmVrVWZDZ3BzREZiRURUcVR0SncKI50KzPXvRDqUbCPitUOS4ZgTZJprAqEm
+        3YhletJzXmlWwwoGt94PcnIdJsEdkjw6DHbDX+ZZx2iNUblSo6BYnw==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-07-04T23:17:39Z"
+  mac: ENC[AES256_GCM,data:TM5GNYDfGax+cHHxCvi9DddaOPLV6l2H/NecU3rghEUAYZBjmZAj8umKbY3VJHmkLY1r2UaOYHjd0HTQB8uarLyFmpAq66rgkmk/yZ5CkaxXYnwgsLd6rOVbKr+V1i7wFv+UkTP+sp+xfK/1gb9Sp1jYLKZh4EY89sd/5nVI4Ug=,iv:9DOceK3fWdJ0qdZcr7z6b65DE9fqA6m4jzxUNViTHEc=,tag:ArJWDIxG5Whnte+l/Ln5dQ==,type:str]
+  unencrypted_suffix: _unencrypted
+  version: 3.12.1

--- a/tf/gitops/forgejo-agentydragon-repos/main.tf
+++ b/tf/gitops/forgejo-agentydragon-repos/main.tf
@@ -28,6 +28,23 @@ provider "forgejo" {
   password = data.kubernetes_secret.forgejo_admin.data["password"]
 }
 
+locals {
+  forgejo_token_mint_users = {
+    agent-box-codex = {
+      username = forgejo_user.agent_box_codex.login
+      password = random_password.agent_box_codex.result
+    }
+    agent-box-zai = {
+      username = forgejo_user.agent_box_zai.login
+      password = random_password.agent_box_zai.result
+    }
+    codex-pod = {
+      username = forgejo_user.codex_pod.login
+      password = random_password.codex_pod.result
+    }
+  }
+}
+
 resource "random_password" "agent_box_codex" {
   length  = 48
   special = false
@@ -168,6 +185,24 @@ resource "forgejo_collaborator" "codex_pod_ducktape" {
   repository_id = forgejo_repository.ducktape.id
   user          = forgejo_user.codex_pod.login
   permission    = "read"
+}
+
+# Source credentials for forgejo-token-rotation. The passwords still originate
+# here; the rotator converts them into API tokens and tea configs for consumers.
+resource "kubernetes_secret" "forgejo_token_mint" {
+  for_each = local.forgejo_token_mint_users
+
+  metadata {
+    name      = "forgejo-token-mint-${each.key}"
+    namespace = "agents-infra"
+  }
+
+  data = {
+    username     = each.value.username
+    password     = each.value.password
+    url          = "https://git.allegedly.works"
+    internal_url = var.forgejo_url
+  }
 }
 
 # --- haku read collaboration ---

--- a/tf/gitops/forgejo-claude/main.tf
+++ b/tf/gitops/forgejo-claude/main.tf
@@ -49,3 +49,20 @@ resource "kubernetes_secret" "claude_forgejo_credentials" {
     internal_url = "http://forgejo-http.forgejo:3000"
   }
 }
+
+# Source credential for forgejo-token-rotation. The rotator mints the API token
+# that `tea` consumes, while this Terraform root remains the owner of the
+# account password.
+resource "kubernetes_secret" "claude_forgejo_token_mint" {
+  metadata {
+    name      = "forgejo-token-mint-claude"
+    namespace = "agents-infra"
+  }
+
+  data = {
+    username     = forgejo_user.claude.login
+    password     = random_password.claude.result
+    url          = "https://git.allegedly.works"
+    internal_url = var.forgejo_url
+  }
+}

--- a/tf/gitops/haku-state/main.tf
+++ b/tf/gitops/haku-state/main.tf
@@ -91,6 +91,23 @@ resource "kubernetes_secret" "haku_state_git_write" {
   }
 }
 
+# Source credential for forgejo-token-rotation. The rotator uses Basic auth only
+# to mint full-account API tokens, then writes the distributed `tea` configs as
+# SOPS outputs in git.
+resource "kubernetes_secret" "haku_forgejo_token_mint" {
+  metadata {
+    name      = "forgejo-token-mint-haku"
+    namespace = "agents-infra"
+  }
+
+  data = {
+    username     = forgejo_user.haku.login
+    password     = random_password.haku.result
+    url          = "https://git.allegedly.works"
+    internal_url = var.forgejo_url
+  }
+}
+
 # dockerconfigjson for the private git.allegedly.works/haku/ui package, in haku-sandbox:
 #   - the imagePullSecret Haku's UI Deployment uses to pull the image its Forgejo CI builds
 #     (kubelet pulls over HTTPS via the public host — node-level, not subject to the pod's

--- a/x/codex_pod_image/default.nix
+++ b/x/codex_pod_image/default.nix
@@ -36,6 +36,7 @@ let
       pkgs.which
       pkgs.psmisc
       pkgs.git
+      pkgs.tea
       pkgs.openssh # ssh client + sshd (inbound `ssh codex-pod` over kubectl exec)
       pkgs.socat # relay for the ssh-over-kubectl-exec ProxyCommand
       pkgs.tini # PID 1 init: reaps zombies from exec/ssh sessions, forwards signals


### PR DESCRIPTION
## Summary

- Add the `tea` CLI to Haku, haku-worker, agent-box, and codex-pod agent environments.
- Add `forgejo-token-rotation`, a BuildBuddy-built CronJob image that mints full-account Forgejo API tokens for agent service accounts, writes raw SOPS token files, and publishes pod-ready `tea` config Secrets where appropriate.
- Wire consumers: mounted `tea` configs for Haku/codex-pod, Home Manager-rendered `~/.config/tea/config.yml` for agent-box users, and Claude/Haku docs explaining how to fetch or use the config.
- Add bootstrap placeholder SOPS files plus TODOs for the Debian Runtime C divergence and the growing flat `secrets/` layout.

## Notes

The committed token files are intentionally invalid bootstrap placeholders. The first `forgejo-token-rotation` run will replace them with real Forgejo tokens. The rotator deliberately omits the `repositories` field when minting tokens so Forgejo grants the token the full repository access of the service account it drives.

## Validation

- `ruff check cluster/rotators/forgejo_token_rotation`
- `ruff format --check cluster/rotators/forgejo_token_rotation`
- `buildifier -mode=check cluster/rotators/forgejo_token_rotation/BUILD.bazel`
- `nixfmt --check ...`
- Nix evals for `agent-haku`, `codex-pod-image`, `haku-worker-image`, and `nixosConfigurations.agent-box.config.system.build.toplevel`
- `kubectl kustomize` for root `cluster/k8s` plus the touched rotator/consumer directories
- `bbr test //cluster/rotators/forgejo_token_rotation/...`
- `bbr build //cluster/rotators/forgejo_token_rotation:image`
- commit hooks: pre-commit, kubeconform, checkov, tflint, commit-msg hooks