### PR TITLE
haku: build himalaya with the oauth2 cargo feature + verified mailbox recipe

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -400,7 +400,7 @@
             paths = [
               self.packages.${system}.devtools
               ducktapePkgs.fastmcp
-# nixpkgs ships himalaya WITHOUT the `oauth2` cargo feature, so any
+              # nixpkgs ships himalaya WITHOUT the `oauth2` cargo feature, so any
               # config with backend.auth.type = "oauth2" fails to parse ("missing
               # `oauth2` cargo feature") — OAUTHBEARER against haku-mailbox needs
               # the feature compiled in (verified against the live server).

--- a/flake.nix
+++ b/flake.nix
@@ -400,7 +400,13 @@
             paths = [
               self.packages.${system}.devtools
               ducktapePkgs.fastmcp
-              pkgs.himalaya
+# nixpkgs ships himalaya WITHOUT the `oauth2` cargo feature, so any
+              # config with backend.auth.type = "oauth2" fails to parse ("missing
+              # `oauth2` cargo feature") — OAUTHBEARER against haku-mailbox needs
+              # the feature compiled in (verified against the live server).
+              (pkgs.himalaya.overrideAttrs (o: {
+                cargoBuildFeatures = (o.cargoBuildFeatures or [ ]) ++ [ "oauth2" ];
+              }))
               pkgs.tea
             ];
           };

--- a/haku/base/sources/mailbox.md
+++ b/haku/base/sources/mailbox.md
@@ -16,13 +16,24 @@ like any other untrusted source material.
 
 ## Reading it (himalaya)
 
-`himalaya` is in your devtools closure. It speaks IMAP to the mailserver's
-cluster-internal listener, authenticating with your rotating Authentik mail
-JWT via SASL OAUTHBEARER (minted for the `stalwart-haku` provider — your k8s
-JWT will not work here, different audience). One-time config at
-`~/.config/himalaya/config.toml`:
+`himalaya` is in your devtools closure (the flake builds it with the non-default
+`oauth2` cargo feature — stock nixpkgs lacks it and fails config parse with
+"missing `oauth2` cargo feature"). It speaks IMAP to the mailserver's
+**cluster-internal** listener (`haku-mailbox.haku-mailbox.svc.cluster.local:1143`),
+authenticating with your rotating Authentik mail JWT via SASL OAUTHBEARER (minted
+for the `stalwart-haku` provider — your k8s JWT will not work here, different
+audience). From runtimes outside the cluster (e.g. the web home), that listener is
+unreachable — use the JMAP fallback below, or relay IMAP over
+`kubectl exec -i <pod>` with a stdio↔1143 pump if you specifically need IMAP.
 
-```toml
+**Generate the config per run** (the JWT rotates; embed the current token as a
+`raw` secret — the `cmd` secret form errors "cannot get secret from command:
+empty output" in himalaya 1.1.0's refresh branch; `raw` is verified working):
+
+```bash
+MAIL_TOK=$(kubectl -n haku-sandbox get secret haku-mail-token -o jsonpath='{.data.jwt}' | base64 -d)
+mkdir -p ~/.config/himalaya
+cat > ~/.config/himalaya/config.toml << CFG
 [accounts.haku]
 default = true
 email = "haku@allegedly.works"
@@ -33,15 +44,19 @@ backend.encryption.type = "none"
 backend.login = "haku@allegedly.works"
 backend.auth.type = "oauth2"
 backend.auth.method = "oauthbearer"
+backend.auth.pkce = false
+backend.auth.scope = "openid"
 backend.auth.client-id = "stalwart-haku"
 backend.auth.auth-url = "https://auth.allegedly.works/application/o/authorize/"
 backend.auth.token-url = "https://auth.allegedly.works/application/o/token/"
-backend.auth.access-token.cmd = "kubectl -n haku-sandbox get secret haku-mail-token -o jsonpath={.data.jwt} | base64 -d"
+backend.auth.access-token.raw = "$MAIL_TOK"
+CFG
 ```
 
-(The `auth-url`/`token-url` are required by the config schema but never used —
-the `access-token.cmd` supplies the rotated JWT directly; himalaya never runs
-an OAuth flow itself.)
+(`pkce` and `scope` are required by the 1.1.0 config schema; `auth-url`/`token-url`
+are schema-required but never contacted — the raw access token short-circuits the
+OAuth flow. All of this verified against the live server, IMAP greeting through
+`envelope list`.)
 
 ```bash
 himalaya envelope list -o json          # newest mail, machine-readable

--- a/haku/base/sources/mailbox.md
+++ b/haku/base/sources/mailbox.md
@@ -17,46 +17,18 @@ like any other untrusted source material.
 ## Reading it (himalaya)
 
 `himalaya` is in your devtools closure (the flake builds it with the non-default
-`oauth2` cargo feature — stock nixpkgs lacks it and fails config parse with
-"missing `oauth2` cargo feature"). It speaks IMAP to the mailserver's
-**cluster-internal** listener (`haku-mailbox.haku-mailbox.svc.cluster.local:1143`),
-authenticating with your rotating Authentik mail JWT via SASL OAUTHBEARER (minted
-for the `stalwart-haku` provider — your k8s JWT will not work here, different
-audience). From runtimes outside the cluster (e.g. the web home), that listener is
-unreachable — use the JMAP fallback below, or relay IMAP over
+`oauth2` cargo feature — stock nixpkgs lacks it and fails config parse). It speaks
+IMAP to the mailserver's **cluster-internal** listener
+(`haku-mailbox.haku-mailbox.svc.cluster.local:1143`) via SASL OAUTHBEARER with your
+rotating Authentik mail JWT. From runtimes outside the cluster (e.g. the web home)
+that listener is unreachable — use the JMAP fallback below, or relay IMAP over
 `kubectl exec -i <pod>` with a stdio↔1143 pump if you specifically need IMAP.
 
-**Generate the config per run** (the JWT rotates; embed the current token as a
-`raw` secret — the `cmd` secret form errors "cannot get secret from command:
-empty output" in himalaya 1.1.0's refresh branch; `raw` is verified working):
-
-```bash
-MAIL_TOK=$(kubectl -n haku-sandbox get secret haku-mail-token -o jsonpath='{.data.jwt}' | base64 -d)
-mkdir -p ~/.config/himalaya
-cat > ~/.config/himalaya/config.toml << CFG
-[accounts.haku]
-default = true
-email = "haku@allegedly.works"
-backend.type = "imap"
-backend.host = "haku-mailbox.haku-mailbox.svc.cluster.local"
-backend.port = 1143
-backend.encryption.type = "none"
-backend.login = "haku@allegedly.works"
-backend.auth.type = "oauth2"
-backend.auth.method = "oauthbearer"
-backend.auth.pkce = false
-backend.auth.scope = "openid"
-backend.auth.client-id = "stalwart-haku"
-backend.auth.auth-url = "https://auth.allegedly.works/application/o/authorize/"
-backend.auth.token-url = "https://auth.allegedly.works/application/o/token/"
-backend.auth.access-token.raw = "$MAIL_TOK"
-CFG
-```
-
-(`pkce` and `scope` are required by the 1.1.0 config schema; `auth-url`/`token-url`
-are schema-required but never contacted — the raw access token short-circuits the
-OAuth flow. All of this verified against the live server, IMAP greeting through
-`envelope list`.)
+**The config lands automatically at session start** —
+`haku/runtime/claude_web_env/bootstrap.sh` materializes
+`~/.config/himalaya/config.toml` from the `haku-mail-token` secret and is the
+canonical recipe (schema gotchas documented there); other runtimes replicate that
+block. If the token rotates mid-session, re-run the bootstrap.
 
 ```bash
 himalaya envelope list -o json          # newest mail, machine-readable

--- a/haku/runtime/claude_web_env/bootstrap.sh
+++ b/haku/runtime/claude_web_env/bootstrap.sh
@@ -43,6 +43,12 @@ else
   echo "haku warning: haku-forgejo-tea secret is absent; tea is installed but not logged in yet"
 fi
 
+# Canonical himalaya config recipe (haku/base/sources/mailbox.md points here).
+# Verified against the live server (himalaya 1.1.0 + oauth2 feature): `pkce` and
+# `scope` are required by the config schema; auth-url/token-url are schema-
+# required but never contacted; the token is embedded as a `raw` secret because
+# the `cmd` secret form fails ("cannot get secret from command: empty output"
+# in the refresh branch) — hence re-materializing per session as the JWT rotates.
 if mail_tok=$(kubectl -n "$ns" get secret haku-mail-token -o jsonpath='{.data.jwt}' 2>/dev/null | base64 -d) && [ -n "$mail_tok" ]; then
   install -d -m700 "$HOME/.config/himalaya"
   cat >"$HOME/.config/himalaya/config.toml" <<EOF

--- a/haku/runtime/claude_web_env/bootstrap.sh
+++ b/haku/runtime/claude_web_env/bootstrap.sh
@@ -8,7 +8,12 @@
 #      ~/.netrc so git needs no inline credentials.
 #   3. Read haku-forgejo-tea from haku-sandbox and write tea's config when the
 #      token rotator has published it.
-#   4. Clone (or fast-forward) haku-state into ~/haku-state — outside the
+#   4. Read haku-mail-token and write himalaya's config with the current mail
+#      JWT embedded (the token rotates; each session materializes it fresh).
+#      The IMAP host is cluster-internal — from the web home read mail via
+#      JMAP, or relay IMAP through kubectl exec; the config is still landed
+#      here so every runtime shares one recipe.
+#   5. Clone (or fast-forward) haku-state into ~/haku-state — outside the
 #      ducktape checkout, so there's no collision. The clone runs into a temp dir
 #      and is atomically swapped into place, so ~/haku-state never exists
 #      half-populated (it's absent until the clone completes). An early echo +
@@ -36,6 +41,31 @@ if kubectl -n "$ns" get secret haku-forgejo-tea >/dev/null 2>&1; then
   chmod 600 "$HOME/.config/tea/config.yml"
 else
   echo "haku warning: haku-forgejo-tea secret is absent; tea is installed but not logged in yet"
+fi
+
+if mail_tok=$(kubectl -n "$ns" get secret haku-mail-token -o jsonpath='{.data.jwt}' 2>/dev/null | base64 -d) && [ -n "$mail_tok" ]; then
+  install -d -m700 "$HOME/.config/himalaya"
+  cat >"$HOME/.config/himalaya/config.toml" <<EOF
+[accounts.haku]
+default = true
+email = "haku@allegedly.works"
+backend.type = "imap"
+backend.host = "haku-mailbox.haku-mailbox.svc.cluster.local"
+backend.port = 1143
+backend.encryption.type = "none"
+backend.login = "haku@allegedly.works"
+backend.auth.type = "oauth2"
+backend.auth.method = "oauthbearer"
+backend.auth.pkce = false
+backend.auth.scope = "openid"
+backend.auth.client-id = "stalwart-haku"
+backend.auth.auth-url = "https://auth.allegedly.works/application/o/authorize/"
+backend.auth.token-url = "https://auth.allegedly.works/application/o/token/"
+backend.auth.access-token.raw = "$mail_tok"
+EOF
+  chmod 600 "$HOME/.config/himalaya/config.toml"
+else
+  echo "haku warning: haku-mail-token secret is absent/empty; himalaya not configured"
 fi
 
 if [ -d "$state_dir/.git" ]; then


### PR DESCRIPTION
Answering "does himalaya work?" — it does now, end to end, but only after two fixes this PR propagates:

## 1. nixpkgs' himalaya lacks the `oauth2` cargo feature

Stock `pkgs.himalaya` (`v1.1.0 +imap +smtp +wizard…`, no `+oauth2`) **cannot parse** the documented config — `backend.auth.type = "oauth2"` fails with `missing oauth2 cargo feature`. That's fatal in every runtime, in-cluster included, so #2758's himalaya-as-primary-interface never could have worked. Fix: `overrideAttrs` adding `cargoBuildFeatures = ["oauth2"]` in the `agent-haku` closure.

## 2. The doc's recipe had three untested assumptions

Verified against the **live haku-mailbox** (feature-enabled build; IMAP relayed from the web home over `kubectl exec` since the listener is cluster-internal and port-forward's upgrade path is currently broken):

- The 1.1.0 config schema also **requires `pkce` and `scope`** fields (parse errors without them).
- The **`access-token.cmd` secret form fails** (`cannot get secret from command: empty output`, surfacing in the refresh branch) — while **`access-token.raw` works**. Doc now generates the config per run, embedding the freshly-read JWT (it rotates anyway; the config is runtime-ephemeral).
- Documents explicitly that the IMAP listener is **cluster-internal** — web-home runtimes use the JMAP fallback (verified working) or an exec-based stdio relay.

Proof of life with the fixed build + recipe against production:

```text
| ID | FLAGS | SUBJECT                                     | FROM           | DATE                   |
| 1  |       | Fwd: Delivery Status Notification (Failure) | Michal Pokorny | 2026-07-04 16:44-07:00 |
```

(That's the operator's mailbox-verification test mail, listed over IMAP + SASL OAUTHBEARER. Raw-IMAP `AUTHENTICATE OAUTHBEARER` with the rotated JWT was also confirmed directly: `a1 OK Authentication successful`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7Yyrzkp7gx7Q3mr4CPkkC

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7Yyrzkp7gx7Q3mr4CPkkC)_