### PR TITLE
seaweedfs filer-db → SSD: promote + repoint (Case B cutover)

### DIFF
--- a/cluster/k8s/seaweedfs/cluster/filer.toml
+++ b/cluster/k8s/seaweedfs/cluster/filer.toml
@@ -21,7 +21,10 @@ createTable = """
     PRIMARY KEY (dirhash, name)
   );
 """
-hostname = "seaweedfs-filer-db-rw.seaweedfs.svc"
+# Repointed to the SSD-tier filer DB (Case B git-latency migration, 2026-07). The
+# seaweedfs-filer-db-app Secret still holds valid creds: the -ssd role password was
+# physically replicated from the old seaweedfs-filer-db before promotion.
+hostname = "seaweedfs-filer-db-ssd-rw.seaweedfs.svc"
 port = 5432
 database = "seaweedfs"
 sslmode = "disable"

--- a/cluster/k8s/seaweedfs/db/postgres-cluster-ssd.yaml
+++ b/cluster/k8s/seaweedfs/db/postgres-cluster-ssd.yaml
@@ -42,8 +42,11 @@ spec:
   monitoring:
     enablePodMonitor: true
 
+  # Promoted to an independent primary at cutover (was a streaming replica of
+  # seaweedfs-filer-db). bootstrap/externalClusters below are inert post-bootstrap;
+  # kept for a minimal diff and removed in the post-cutover cleanup.
   replica:
-    enabled: true
+    enabled: false
     source: seaweedfs-filer-db
 
   bootstrap:


### PR DESCRIPTION
Promotes the seaweedfs-filer-db-ssd streaming replica and repoints the filer's postgres2 host to it. Executed as a coordinated window (filer scale-0 → catch up → promote → repoint → scale up) to avoid split-brain on the metadata SSOT. Creds unchanged (role pw physically replicated). Old cluster kept as rollback.