### PR TITLE
seaweedfs filer-db-ssd: own app credentials (decouple from old cluster)

### DIFF
--- a/cluster/k8s/seaweedfs/cluster/seaweed.yaml
+++ b/cluster/k8s/seaweedfs/cluster/seaweed.yaml
@@ -193,8 +193,10 @@ spec:
     # outside of YAML string escaping.
     config: ""
     # Postgres credentials override filer.toml [postgres2] keys via viper's
-    # env-var binding (WEED_<key>, dot→underscore). CNPG auto-generates the
-    # Secret seaweedfs-filer-db-app at cluster bootstrap.
+    # env-var binding (WEED_<key>, dot→underscore). seaweedfs-filer-db-ssd-app is a
+    # committed Secret (../db/seaweedfs-filer-db-ssd-app.sops.yaml) enforced onto the
+    # -ssd seaweedfs role via managed.roles — the -ssd cluster is pg_basebackup'd so
+    # CNPG generates no -app Secret of its own.
     env:
       # Soft heap ceiling ~90% of the memory limit below; see the sizing note
       # at requests/limits. Go's GC (GOGC=100) otherwise ignores the cgroup
@@ -204,12 +206,12 @@ spec:
       - name: WEED_POSTGRES2_USERNAME
         valueFrom:
           secretKeyRef:
-            name: seaweedfs-filer-db-app
+            name: seaweedfs-filer-db-ssd-app
             key: username
       - name: WEED_POSTGRES2_PASSWORD
         valueFrom:
           secretKeyRef:
-            name: seaweedfs-filer-db-app
+            name: seaweedfs-filer-db-ssd-app
             key: password
     metricsPort: 9326
     # QoS / eviction protection as on master. Now 2 replicas → a minAvailable:1

--- a/cluster/k8s/seaweedfs/db/flux-kustomization.yaml
+++ b/cluster/k8s/seaweedfs/db/flux-kustomization.yaml
@@ -13,6 +13,12 @@ spec:
   path: ./cluster/k8s/seaweedfs/db
   prune: true
   wait: true
+  # Required to apply seaweedfs-filer-db-ssd-app.sops.yaml (the filer DB app creds
+  # enforced onto -ssd via managed.roles); without it Flux applies the ciphertext.
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age-cluster-secrets
   dependsOn:
     - name: seaweedfs-namespace
     - name: cnpg

--- a/cluster/k8s/seaweedfs/db/kustomization.yaml
+++ b/cluster/k8s/seaweedfs/db/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - postgres-cluster.yaml
   - postgres-cluster-ssd.yaml
+  - seaweedfs-filer-db-ssd-app.sops.yaml

--- a/cluster/k8s/seaweedfs/db/postgres-cluster-ssd.yaml
+++ b/cluster/k8s/seaweedfs/db/postgres-cluster-ssd.yaml
@@ -42,6 +42,25 @@ spec:
   monitoring:
     enablePodMonitor: true
 
+  # CNPG doesn't auto-generate an -app Secret for pg_basebackup clusters, so enforce
+  # the seaweedfs role's password from a committed Secret (attributes replicated from
+  # the live role: login-only, no superuser/createdb/createrole/replication/bypassrls,
+  # unlimited connections). The filer authenticates with this same Secret.
+  managed:
+    roles:
+      - name: seaweedfs
+        ensure: present
+        login: true
+        superuser: false
+        createdb: false
+        createrole: false
+        inherit: true
+        replication: false
+        bypassrls: false
+        connectionLimit: -1
+        passwordSecret:
+          name: seaweedfs-filer-db-ssd-app
+
   # Promoted to an independent primary at cutover (was a streaming replica of
   # seaweedfs-filer-db). bootstrap/externalClusters below are inert post-bootstrap;
   # kept for a minimal diff and removed in the post-cutover cleanup.

--- a/cluster/k8s/seaweedfs/db/seaweedfs-filer-db-ssd-app.sops.yaml
+++ b/cluster/k8s/seaweedfs/db/seaweedfs-filer-db-ssd-app.sops.yaml
@@ -1,0 +1,38 @@
+# App credentials for seaweedfs-filer-db-ssd. CNPG doesn't auto-generate an -app
+# Secret for pg_basebackup-bootstrapped clusters, so this is a committed secret that
+# postgres-cluster-ssd.yaml enforces onto the seaweedfs role via spec.managed.roles.
+# Password copied from the old seaweedfs-filer-db-app (physically replicated to -ssd),
+# so applying it is a no-op — lets us delete the old cluster without a password change.
+apiVersion: v1
+kind: Secret
+metadata:
+    name: seaweedfs-filer-db-ssd-app
+    namespace: seaweedfs
+type: kubernetes.io/basic-auth
+stringData:
+    username: ENC[AES256_GCM,data:hjlgh54Wyf8b,iv:SdpW65Q1HvvgOGO2nlbceEVW6m7Gx8xf39LU3AAr1ME=,tag:EUIXTBM491JCcSBHCQqmHQ==,type:str]
+    password: ENC[AES256_GCM,data:fzNC/9EORav4gqefmYS483A9f6qyWGq9McsupbIk5Wf/WtqKqZErkOmjYl1DPw1gy9Q+NPbOvYzvGp49LRobcw==,iv:byXJdYXt+NYwL+OjEX/F9473F84uDXsygI/ch96Bh/M=,tag:xeSS7Gycv1ZHO7hGrpTecA==,type:str]
+sops:
+    age:
+        - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTOE9QUFdkZmNybzVJUkRI
+            NEg4NWxicmdTeWpRcmJJdHpZbE9zYzNYQ3dVCllyUFRqd3NOUDllazBEN1c0Y3BT
+            bmpFa2MwS2lEQVVHWHJ1aTlROWVmbXcKLS0tIHBnd0JxVkF6dHlSY1FsV2hBVGFD
+            ci9JUFlCWDE2MUM1Y0lhL3RjZkpuUEkKIo9YFN2hCyqn8zR3hCr+tevM9hO+TAdN
+            4zVz8nNAZKi+7m5sjwJn+cLSY3DoCBk/OI5I1i5O58IE/5QZtO8kNA==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1nywlwepsyfxvyhqwkjquzz02nmus65gf6qewfjju4alym8f7se5qnua8na
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpbGpWNHZRMmVvZHNrQm5p
+            NGVSNHhuV09DWXJ5Q2p0TnZkdEVMeEtwZVg0CkhUQTJDdGsrcjJMdkJqdGM0MFpF
+            Z05NV3YvelVISUlHNDRzVVgvVEJpOFUKLS0tIDhoMzJCTlE0TEJiUk1QaDFIOHls
+            VGxSa3RkRzdIUzBxcElrcm5GMDFxZm8KGq7vkUUECy9ZNDZfY+1Qn25vwEU8lD1Z
+            zoq8jamGcNCPaTGXsZJdMFvWopI/QebpqX8hzdEcZi+XnysPm9iijw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-07-05T00:36:45Z"
+    mac: ENC[AES256_GCM,data:8H7VYMGodjYzxI0eFVgx4BjK4eF13gj3pgoi06D5Pv3uEjjLELahugiMbO3SmqkjfEHVu09xMeevW4R72KBiFFlzhlHcq/bl4g5Jw3UQ7MplZW2Ogtr/wGvcikoy9lOl4nokwUbtugzxBzU0KJqsQtbkIFUJXJPGknuRnUAfb6I=,iv:rCWGaEjKFkcPzZj78KlKCS6NBD3TP9F3dznE8G1u84g=,tag:ki2eAlJJLuqqfVD4haG6cg==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.1


### PR DESCRIPTION
Gives seaweedfs-filer-db-ssd its own app credentials so the old seaweedfs-filer-db can be deleted. Committed SOPS Secret (same password, so managed.roles is a no-op), enforced via CNPG managed.roles, filer repointed, and the db Flux Kustomization gets its decryption block. Same-password + HA filer = rolling restart, near-zero downtime.