### PR TITLE
fix(wyrm2): bump gamescope to 3.16.24 to fix seat-game startup SIGABRT

### DIFF
--- a/nix/nixos/hosts/wyrm2/default.nix
+++ b/nix/nixos/hosts/wyrm2/default.nix
@@ -6,6 +6,7 @@
   pkgs,
   lib,
   username,
+  inputs,
   ...
 }:
 let
@@ -152,6 +153,24 @@ in
       # start). With animations off the callback runs immediately.
       settings."org/gnome/desktop/interface".enable-animations = false;
     }
+  ];
+
+  # gamescope 3.16.17 (nixpkgs 25.11) SIGABRTs on startup when a seat input
+  # event races wlserver_init's lock — upstream ValveSoftware/gamescope#1746,
+  # fixed in 3.16.24 by PR #2023 ("Lock wlserver while initializing wayland").
+  # Pull the fixed build from unstable until 25.11 catches up. Overriding the
+  # package-set attr covers the gamescopeSession, the capSysNice wrapper, and
+  # Steam in one place. CLEANUP: drop once nixpkgs 25.11 ships gamescope ≥3.16.24.
+  nixpkgs.overlays = [
+    (_: _: {
+      inherit
+        (import inputs.nixpkgs-unstable {
+          inherit (pkgs.stdenv.hostPlatform) system;
+          config.allowUnfree = true;
+        })
+        gamescope
+        ;
+    })
   ];
 
   # Steam — games run on the RTX 5090s (direct display via seat-game, or


### PR DESCRIPTION
## Problem
The seat-game gaming seat on wyrm2 freezes at the greeter right after password entry. Root cause: **gamescope 3.16.17** (nixpkgs 25.11) aborts on startup when a seat input event arrives during `wlserver_init()` before the wlserver lock is held:

```
gamescope: src/wlserver.cpp: wlserver_mousemotion(...): Assertion `wlserver_is_lock_held()' failed.  → SIGABRT
```

This is upstream [ValveSoftware/gamescope#1746](https://github.com/ValveSoftware/gamescope/issues/1746). Two core dumps on wyrm2 (07-03, 07-04) confirm it; DP output, 4K60 mode, and Vulkan GPU selection are all healthy before the abort. Because the session dies, GDM waits ~60s then bounces to the greeter — presenting as a post-password freeze.

## Fix
Fixed upstream in **3.16.24** by [PR #2023](https://github.com/ValveSoftware/gamescope/pull/2023) ("Lock wlserver while initializing wayland"). nixpkgs 25.11 is pinned at 3.16.17; unstable has 3.16.24. Pull the fixed build from the existing `nixpkgs-unstable` flake input via an overlay — overriding the package-set attr covers the gamescopeSession, the `capSysNice` wrapper, and Steam at once.

Verified 3.16.24 contains the fix commit (ancestor of the tag), and:
```
nix eval .#nixosConfigurations.wyrm2.config.programs.gamescope.package.version => 3.16.24
```

CLEANUP tombstone in the config: drop the overlay once nixpkgs 25.11 ships gamescope ≥3.16.24.