### PR TITLE
haku zone-worker: fix Dockerfile useradd UID collision

### DIFF
--- a/haku/dispatch/worker/Dockerfile
+++ b/haku/dispatch/worker/Dockerfile
@@ -17,7 +17,10 @@ RUN npm install -g @anthropic-ai/claude-code@2.1.198 @openai/codex@0.142.5 \
 
 COPY entrypoint.py /opt/haku/entrypoint.py
 
-RUN useradd --create-home --uid 1000 worker \
+# node:*-slim already owns UID 1000 (user `node`); rename it rather than
+# useradd a second UID-1000 user (fails: "UID 1000 is not unique").
+RUN usermod --login worker --home /home/worker --move-home node \
+    && groupmod --new-name worker node \
     && mkdir -p /workspace /output \
     && chown worker:worker /workspace /output
 USER worker


### PR DESCRIPTION
The first (and only) run of `haku-zone-worker-image.yml` (on the #2754 merge) failed at the `useradd --create-home --uid 1000 worker` step: `node:22-bookworm-slim` already ships user `node` at UID 1000, so `useradd` exits with `UID 1000 is not unique`. `ghcr.io/agentydragon/haku-zone-worker` was therefore never published — the Flux `ImageRepository` scan and any Job pulling the image fail with DENIED (package doesn't exist).

Fix: rename the existing `node` user (`usermod --login worker --move-home` + `groupmod`) instead of creating a second UID-1000 user, keeping the `worker`/UID-1000 contract the Job template's `runAsUser` expects.

Merging this touches `haku/dispatch/worker/**`, so the workflow re-fires and publishes the first image. Note: after that first push, the GHCR package will still need a one-time visibility flip to public (cluster pulls without credentials, per `cluster/docs/container-images.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDFQogCNq94uP7rdiYYBZg

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDFQogCNq94uP7rdiYYBZg)_