### PR TITLE
fix(wyrm2): restore secrets/home/wyrm2/zai.yaml dropped in #2792

### DIFF
--- a/secrets/home/wyrm2/zai.yaml
+++ b/secrets/home/wyrm2/zai.yaml
@@ -1,0 +1,30 @@
+comment_unencrypted: |
+  Z.ai GLM Coding Plan API key for wyrm2 — Max tier, 1 quarter sub starting 2026-05-06.
+  Anthropic-compatible endpoint: https://api.z.ai/api/anthropic
+  To use with Claude Code: ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic ANTHROPIC_AUTH_TOKEN=$ZAI_API_KEY claude
+  Key: "sops wyrm2 user"
+zai_api_key: ENC[AES256_GCM,data:SWHsdwLndVInBMOy32anasCt4MpLpuG6y2ZRASOPgrWlwXTnMq72tY2NHsAKAWEB9w==,iv:lFul2MGtnrifaEpJEr+7pzmIBRPmu0cfc4YVPB9ir1I=,tag:AzSzs9cDMQFZ9QBjq8vg2g==,type:str]
+sops:
+  age:
+    - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxc1dTQktTelNoUzRTbU4x
+        ZElNTkpSSXY4YnFWVVBXQ25HaWJTSDFPQlc0CmpjR3lFaWtGRVp3NG1ZNSt0ZXNw
+        NTZFVzMzMTZlVER6RWIycklUTHJlVzgKLS0tIFNKV1dOUmxBN0pITDBQT05pZzJk
+        RVcyeTlnUkFtOHhvTHZFYStOc0s4T3cK+tsQ70f5KyilvakGQFhPlLVyOCvvkRDY
+        pBZ6t0+pcr4FVA5MKjTqq9WT1SBLzr8NTxM1C6VeMwF4QUZ3m6RbOg==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age12c2ef6ayydzvmz6k49pyyhtgu2g00nyynmht8y3laqvxn3wya4wselpc4s
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzaEhhUFhOOWxKMGp5S25U
+        R3RKNXRuMWhNNUExeGloclowQkRGMTN5bldjCmlVbC95SDZjdjNWaENlYklVQUpI
+        UWN3alk3cERYYkNOVlZoUElZWnluRWsKLS0tIHpzVktUQktUTGlXQ0FSSVlXOU82
+        dmcvRmgvWGJLK3VlYUU4enA0ZURxaGcK2z0z/JYuAURLbdxDM+paRP7lg5kwc/FW
+        KWrMbPiNEK7BD0NjCuA/erHOQOZBHQmbmVE3Hn+5VVqZkxP3izSvDg==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-05-06T20:04:51Z"
+  mac: ENC[AES256_GCM,data:llV4xSZ2nfEgVIQaIImX/Nr+hPZ6/LpTET6krB4CGzpG1QSBpHnKqP3yv7vnJ0D6caWqP+nmtrywTdxIVu/VnPIsTLpTFG1Xfr1losb7V46uOxMNEvoamqObDemopCLv0d0DVCoNUeA0+iZv4/i5IUCQnvzF9HJHyBSdDWPuoKE=,iv:o+FWe9TEY/zgHM/rDMSjcjSLrHoQCQVpKPpH0dhikKg=,tag:bmFsK3V5RdGm667eJiJolQ==,type:str]
+  unencrypted_suffix: _unencrypted
+  version: 3.12.1


### PR DESCRIPTION
## Problem
wyrm2 currently **fails to evaluate/build from devel** — unrelated to any recent host change:

```
error: path '.../secrets/home/wyrm2/zai.yaml' does not exist
```

`nix/home/hosts/wyrm2.nix:45` references `secrets/home/wyrm2/zai.yaml`, but the file isn't tracked.

## Root cause
`#2792` deleted **both** `secrets/home/{rugged,wyrm2}/zai.yaml` (and their `.nix` references) while moving to a z.ai-scoped LiteLLM virtual key. The follow-up restoration re-added `secrets/home/rugged/zai.yaml` **and both** `rugged.nix`/`wyrm2.nix` references — but **never re-committed `secrets/home/wyrm2/zai.yaml`**. So wyrm2 was left with a dangling reference.

The aiquota z.ai monitor needs the **real** subscription key here (the LiteLLM virtual key can't substitute — same rationale that made #2792 break rugged).

## Fix
Restore the original ciphertext verbatim from `5d3ebfef0^`. Its age recipients are **identical** to wyrm2's other tracked secrets (`anthropic.yaml` etc.), so no re-keying is needed and it decrypts with wyrm2's host key at runtime. Schema unchanged: single sops `zai_api_key` string, matching `.sops.yaml`'s `secrets/home/wyrm2/*.yaml` creation rule.