### PR TITLE
web sessions: wire Attic substituter (cache.allegedly.works) into Nix

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -669,6 +669,18 @@ creation_rules:
       - age:
           - *admin
           - *claude-web
+  # Haku home Attic reader token (auto-rotated by the attic-jwt-rotation
+  # CronJob). Decrypted by the Haku routine (web_env.sh writes it into the Nix
+  # netrc); admin + user keys for break-glass.
+  - path_regex: secrets/haku-attic\.yaml$
+    key_groups:
+      - age:
+          - *admin
+          - *haku
+          - *wyrm2-agentydragon
+          - *rugged-agentydragon
+          - *atlas-agentydragon
+          - *iguana-agentydragon
   # Alloy OTLP bearer JWT (auto-rotated by the authentik-jwt-rotation CronJob)
   - path_regex: secrets/alloy-otlp-bearer-token\.yaml$
     key_groups:

--- a/cluster/k8s/agents/attic-jwt-rotation/rotators.yaml
+++ b/cluster/k8s/agents/attic-jwt-rotation/rotators.yaml
@@ -39,6 +39,11 @@ tokens:
     sub: claude-web
     validity: 1 year
     pull: [main, gaffer]
+  - name: haku attic reader
+    sops_file: secrets/haku-attic.yaml
+    sub: haku
+    validity: 1 year
+    pull: [main, gaffer]
   # ducktape CI writer pulls both caches:
   #  - main:r is an extra substituter for the nix-attic-push workflow, so paths
   #    cache.nixos.org can't serve (the unfree CUDA stack: cuda-merged/ollama for

--- a/devinfra/ci/nix_attic_build_and_push.sh
+++ b/devinfra/ci/nix_attic_build_and_push.sh
@@ -86,6 +86,7 @@ for output in \
   .#packages.x86_64-linux.bbr \
   .#packages.x86_64-linux.bbapi \
   .#packages.x86_64-linux.devtools \
+  .#packages.x86_64-linux.agent-haku \
   .#devShells.x86_64-linux.default; do
   nix build --impure \
     "$output" \

--- a/devinfra/claude/README.md
+++ b/devinfra/claude/README.md
@@ -177,9 +177,18 @@ bash ducktape/devinfra/claude/web_setup.sh
 This runs <web_setup.sh> which installs:
 
 1. Nix + devtools (`claude-hook` Rust binary, Python statusline, `bbapi`, `gh`, `sops`, skills)
-2. `github-no-proxy` git remote + `buildbuddy.remote-bazel-remote-name` for bbr
-3. Skills symlinked into `~/.claude/skills/` (preserves Anthropic defaults)
-4. A user-level `~/.bazelrc` with a shared local `--disk_cache` (50 GiB GC cap) at
+2. Attic substituter config: `extra-substituters = https://cache.allegedly.works/main`
+   (+ trusted pubkeys from <../../nix/attic-pubkeys.json> and `fallback = true`) in
+   `/etc/nix/nix.custom.conf`, so tool closures substitute from the private cache
+   instead of building from source — required in-session, where GitHub-release
+   fixed-output fetches (e.g. bazel-diff's deploy jar) 403 through the proxy. The
+   per-principal reader JWT (rotated by `cluster/k8s/agents/attic-jwt-rotation/`) is
+   upserted into `/nix/var/determinate/netrc` by `web_env.sh` at hook-daemon startup,
+   so a fresh rootfs's first install runs anonymous (falls back to source) and every
+   later `nix` invocation substitutes with auth.
+3. `github-no-proxy` git remote + `buildbuddy.remote-bazel-remote-name` for bbr
+4. Skills symlinked into `~/.claude/skills/` (preserves Anthropic defaults)
+5. A user-level `~/.bazelrc` with a shared local `--disk_cache` (50 GiB GC cap) at
    `~/.cache/bazel/disk`, so all Bazel server instances and worktrees in the container
    reuse locally-executed action results across the persistent rootfs. Web sessions
    only — CLI machines configure their own (<../docs/bazel_worktree_cache_sharing.md>).

--- a/devinfra/claude/web_setup.sh
+++ b/devinfra/claude/web_setup.sh
@@ -3,10 +3,12 @@
 #
 # Installs:
 #   1. Nix (Determinate Systems installer, designed for non-interactive/CI use)
-#   2. devtools — Rust claude-hook, statusline, bbapi, gh, skills; from flake via attic binary cache
-#   3. git remote + bbr config for BuildBuddy remote execution
-#   4. skills — symlinked per-skill into ~/.claude/skills/ (preserves Anthropic defaults)
-#   5. user-level ~/.bazelrc with a shared local --disk_cache (web sessions only)
+#   2. Attic substituter config (nix.custom.conf + netrc) for cache.allegedly.works;
+#      the reader JWT is upserted into the netrc by web_env.sh at hook-daemon startup
+#   3. devtools — Rust claude-hook, statusline, bbapi, gh, skills; from flake via attic binary cache
+#   4. git remote + bbr config for BuildBuddy remote execution
+#   5. skills — symlinked per-skill into ~/.claude/skills/ (preserves Anthropic defaults)
+#   6. user-level ~/.bazelrc with a shared local --disk_cache (web sessions only)
 #
 # Also reclaims ~90% of the root ext4's nobody-reserved blocks up front (the
 # container ships with ~84% reserved; we run as root, so it's pure overhead).
@@ -183,6 +185,51 @@ log "--- nix show-config ---"
 nix show-config 2>/dev/null | grep -E "max-jobs|sandbox|build-users" || true
 log "---"
 
+# --- Attic binary cache substituter (cache.allegedly.works) ---
+# Point Nix at the private Attic cache so devtools/agent-haku closures
+# substitute instead of building from source. Not just a speedup: GitHub-release
+# fixed-output fetches inside those closures (e.g. bazel-diff's deploy jar) 403
+# through the session proxy, so in-session rebuilds can be impossible without
+# the cache. Auth: web_env.sh upserts the per-principal reader JWT
+# (auto-rotated in-cluster by attic-jwt-rotation) into the netrc at hook-daemon
+# startup — which is AFTER this script on a fresh rootfs, so the first install
+# may still run anonymous (401 → Nix disables the substituter with a warning
+# and builds from source, same as before this block existed). Every later boot
+# — and any in-session `nix build` once the daemon is up, since Nix re-reads
+# the netrc per download — substitutes with auth. `fallback = true` also
+# covers dangling narinfos from interrupted CI pushes. No attic CLI involved:
+# sessions only pull, and netrc + substituter settings need no tooling this
+# early in init.
+#
+# Determinate layout gotcha: /etc/nix/nix.conf is managed ("will be replaced")
+# and sets `netrc-file = /nix/var/determinate/netrc` AFTER its
+# `!include nix.custom.conf` line — later assignment wins, so a custom
+# netrc-file would be overridden. We therefore write the token into
+# Determinate's own netrc path, and the netrc-file line below is redundant
+# today but takes over if the managed conf ever drops theirs.
+configure_attic_substituter() {
+  mkdir -p /nix/var/determinate
+  [ -f /nix/var/determinate/netrc ] || (umask 077 && : >/nix/var/determinate/netrc)
+  if grep -q 'cache\.allegedly\.works' /etc/nix/nix.custom.conf 2>/dev/null; then
+    log "Attic substituter already configured in /etc/nix/nix.custom.conf."
+    return 0
+  fi
+  # Trusted pubkeys SSOT: nix/attic-pubkeys.json — parsed without jq, which is
+  # not guaranteed to exist before devtools are installed.
+  local pubkeys
+  pubkeys=$(grep -o '"[^"]*"' "${FLAKE#path:}/nix/attic-pubkeys.json" | tr -d '"' | paste -sd' ' -)
+  cat >>/etc/nix/nix.custom.conf <<EOF
+
+# Attic substituter (added by web_setup.sh; reader JWT lands in the netrc via web_env.sh)
+netrc-file = /nix/var/determinate/netrc
+extra-substituters = https://cache.allegedly.works/main
+extra-trusted-public-keys = ${pubkeys}
+fallback = true
+EOF
+  log "Attic substituter configured (nix.custom.conf + netrc; token pending web_env.sh)."
+}
+configure_attic_substituter
+
 log "Installing web session tools..."
 log "  FLAKE=${FLAKE}"
 log "  pwd=$(pwd)"
@@ -205,21 +252,6 @@ ls -la
 # first so `install` re-evaluates `.#devtools` against the current flake.
 #
 # See <devinfra/claude/docs/web-setup-debug.md> ("Pin drift on persistent rootfs").
-# TODO: `attic login` against cache.allegedly.works/{main,gaffer} before this
-# install so devtools (and any gaffer-built closures pulled transitively) hit
-# the private cache instead of building from source. The reader JWT is in
-# secrets/claude-web-attic.yaml, auto-rotated by the in-cluster
-# attic-jwt-rotation CronJob; web_env.sh decrypts SOPS files at hook-daemon
-# startup but isn't running yet at this point in init_script. Sketch:
-#   if [ -f /tmp/_secret_attic_token ]; then
-#     attic login allegedly https://cache.allegedly.works \
-#       "$(cat /tmp/_secret_attic_token)"
-#   fi
-# Plumbing needed: have web_env.sh write the decrypted token to a known
-# path (mode 0600, owned by user) before init_script runs, OR fold the
-# sops decrypt into web_setup.sh directly using SOPS_AGE_KEY. Today the
-# install path falls back to building from source if main isn't reachable
-# anonymously — slow but works.
 log "Install mode: $MODE"
 if [ "$MODE" = "home-manager" ]; then
   # Home Manager installs the same devtools (homeConfigurations.claude-web reuses

--- a/devinfra/secrets/web_env.sh
+++ b/devinfra/secrets/web_env.sh
@@ -7,6 +7,8 @@
 #   claude-web-k8s-jwt.yaml:          admin, all user keys, claude-web
 #   alloy-otlp-bearer-token.yaml:     admin, all user keys, claude-web
 #   public-s3/claude-reader-credentials.sops.yaml: admin, cluster-secrets, claude-web
+#   claude-web-attic.yaml:            admin, claude-web
+#   haku-attic.yaml:                  admin, haku, all user keys
 #
 # Consumed by:
 #   - web_setup.sh: eval'd to populate shell env, then written to
@@ -14,8 +16,9 @@
 #   - hook daemon startup_env_script: eval'd into daemon os.environ,
 #     vars flow into the session env file for hook subprocesses
 #
-# Side effects: none beyond printing export lines. Kubeconfig is written by
-# the SessionStart handler.
+# Side effects: upserts the Attic reader token into /nix/var/determinate/netrc
+# (see the attic block below); otherwise only prints export lines. Kubeconfig
+# is written by the SessionStart handler.
 
 # shellcheck source=_common.sh
 source "$(dirname "${BASH_SOURCE[0]}")/_common.sh"
@@ -48,6 +51,45 @@ try_export AWS_SECRET_ACCESS_KEY "$_s3_reader" '["stringData"]["claudeReaderSecr
 export AWS_ENDPOINT_URL="https://s3.allegedly.works"
 export AWS_DEFAULT_REGION="us-east-1"
 unset _s3_reader
+
+# Attic reader JWT → Nix netrc (a file write, not an env export: Nix reads
+# substitution auth from netrc-file — /etc/nix/nix.conf points it at
+# Determinate's /nix/var/determinate/netrc — not from the session env).
+# web_setup.sh adds cache.allegedly.works/main as an extra substituter; Nix
+# re-reads the netrc per download, so upserting the token here at daemon
+# startup enables authenticated substitution for the current session and for
+# the next boot's tool install. Tokens are per-principal, auto-rotated by the
+# attic-jwt-rotation CronJob: claude-web sessions can decrypt
+# claude-web-attic.yaml, Haku homes haku-attic.yaml — try both, first that
+# decrypts wins (each principal's key opens exactly one, so per-file failures
+# are expected and only the aggregate miss warns).
+_attic_token=""
+for _attic_file in "$REPO_ROOT/secrets/claude-web-attic.yaml" "$REPO_ROOT/secrets/haku-attic.yaml"; do
+  [ -f "$_attic_file" ] || continue
+  if _attic_token=$(sops -d --extract '["attic_token"]' "$_attic_file" 2>/dev/null) && [ -n "$_attic_token" ]; then
+    break
+  fi
+  _attic_token=""
+done
+_netrc="/nix/var/determinate/netrc"
+if [ -z "$_attic_token" ]; then
+  echo "WARNING: secrets: attic: no reader token decryptable (tried claude-web-attic.yaml, haku-attic.yaml) — cache.allegedly.works substitution stays anonymous (401 → source builds)" >&2
+elif mkdir -p "${_netrc%/*}" 2>/dev/null && _netrc_tmp=$(mktemp "${_netrc}.XXXXXX" 2>/dev/null); then
+  {
+    grep -v '^machine cache\.allegedly\.works ' "$_netrc" 2>/dev/null || true
+    printf 'machine cache.allegedly.works password %s\n' "$_attic_token"
+  } >"$_netrc_tmp"
+  if chmod 600 "$_netrc_tmp" && mv "$_netrc_tmp" "$_netrc"; then
+    echo "secrets: attic: OK — reader token in ${_netrc} (cache.allegedly.works substitution)" >&2
+  else
+    rm -f "$_netrc_tmp"
+    echo "WARNING: secrets: attic: failed to move token into ${_netrc} — substitution stays anonymous" >&2
+  fi
+  unset _netrc_tmp
+else
+  echo "WARNING: secrets: attic: cannot write ${_netrc} — cache.allegedly.works substitution stays anonymous" >&2
+fi
+unset _attic_token _attic_file _netrc
 
 # Restore the caller's shell options (do not leak our `set -euo pipefail`; see _common.sh).
 _secrets_restore_shell_opts


### PR DESCRIPTION
Implements the `web_setup.sh` TODO: point managed/web sessions' Nix at the private Attic cache so tool closures substitute instead of building from source.

## Why

- Sessions currently have **no** `cache.allegedly.works` substituter (only the Determinate defaults), and the cache 401s anonymous pulls — so every `nix build`/reinstall runs from source.
- From-source isn't even always possible in-session: GitHub-release fixed-output fetches 403 through the session proxy. Concretely, `nix build .#agent-haku` failed Jul 5 in the Haku home on `bazel-diff_deploy.jar` (same class as the uv/python-build-standalone 403s).
- The token infrastructure already exists: `attic-jwt-rotation` mints `secrets/claude-web-attic.yaml` (`sub=claude-web`, pull `main`+`gaffer`, expires 2027-05-07).

## What

- **`devinfra/claude/web_setup.sh`**: new `configure_attic_substituter` step (replaces the TODO). Appends `netrc-file` + `extra-substituters = https://cache.allegedly.works/main` + trusted pubkeys (read from `nix/attic-pubkeys.json`, the SSOT, parsed without jq — not guaranteed pre-install) + `fallback = true` to `/etc/nix/nix.custom.conf`, and pre-creates the netrc (0600). Idempotent (marker grep).
  - **Determinate gotcha**: the managed `nix.conf` sets `netrc-file = /nix/var/determinate/netrc` *after* its `!include nix.custom.conf`, so a custom `netrc-file` would be overridden — the token therefore goes into Determinate's own netrc path.
  - Deviation from the TODO sketch: no `attic login` — sessions only pull, and netrc + substituter settings need no tooling this early in init.
- **`devinfra/secrets/web_env.sh`**: at hook-daemon startup (the one place `SOPS_AGE_KEY` exists), decrypt the per-principal reader JWT and upsert its `machine cache.allegedly.works password <jwt>` line into the netrc, preserving other entries. Nix re-reads the netrc per download, so the *current* session's `nix` invocations get auth immediately, and the next boot's install substitutes. First boot on a fresh rootfs stays anonymous (401 → Nix disables the substituter with a warning; `fallback = true` also covers dangling narinfos from interrupted CI pushes) — i.e. today's behavior.
- **`rotators.yaml` + `.sops.yaml`**: dedicated `haku attic reader` token (`secrets/haku-attic.yaml`, `sub=haku`) per the per-principal house pattern — the motivating 403 hit a Haku home, whose key can't decrypt the claude-web token. Expected bootstrap window until the hourly CronJob first mints the file (same as the OTEL token's first deploy).
- **`devinfra/ci/nix_attic_build_and_push.sh`**: also push `.#agent-haku`, so Haku homes find their closure — including the `oauth2`-featured himalaya override (#2875), which no public cache serves.

## Verification

- Netrc format + substituter settings mirror the proven `nix-attic-push` CI config (same cache, same auth path).
- `configure_attic_substituter` exercised against scratch paths: correct block written, second run is a no-op; pubkeys parse yields `main:… gaffer:…`.
- `web_env.sh` block exercised under `set -euo pipefail`: no-token path (this Haku home, pre-rotation — realistic first-boot state) warns and continues; token path upserts 0600 netrc preserving foreign lines, no tmp leftovers.
- End-to-end substitution is only verifiable in a claude-web session (this session's key can't decrypt the claude-web token; `haku-attic.yaml` doesn't exist until the rotator runs post-merge). Degradation path = exactly today's from-source behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7Yyrzkp7gx7Q3mr4CPkkC

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7Yyrzkp7gx7Q3mr4CPkkC)_