### PR TITLE
test: update source match diagnostic expectation

### DIFF
--- a/devinfra/js/debundle/e2e/cross_module_emission_test.rs
+++ b/devinfra/js/debundle/e2e/cross_module_emission_test.rs
@@ -644,7 +644,7 @@ fn fail_fast_dry_run_stops_before_later_duplicate_claim_diagnostics() {
     for required in [
         "diagnostics/ambiguous",
         "export `AmbiguousHelper`",
-        "target_binding `repeatedHelper`",
+        "source_matches[].bindings[`repeatedHelper`]",
         "valid global selector assignment",
     ] {
         assert!(


### PR DESCRIPTION
## Summary
- update the fail-fast cross-module emission test to expect the canonical source_matches[].bindings diagnostic wording

## Validation
- pre-commit run --files devinfra/js/debundle/e2e/cross_module_emission_test.rs
- bbr test //devinfra/js/debundle/e2e:cross_module_emission_test