### PR TITLE
seaweedfs: declare filer-db-ssd app user = seaweedfs to end CNPG app-role loop

### DIFF
--- a/cluster/k8s/seaweedfs/cluster/seaweed.yaml
+++ b/cluster/k8s/seaweedfs/cluster/seaweed.yaml
@@ -194,10 +194,10 @@ spec:
     config: ""
     # Postgres credentials override filer.toml [postgres2] keys via viper's
     # env-var binding (WEED_<key>, dot→underscore). seaweedfs-filer-db-ssd-creds is a
-    # committed Secret (../db/seaweedfs-filer-db-ssd-creds.sops.yaml) enforced onto the
-    # -ssd seaweedfs role via managed.roles. The -creds suffix is deliberate: CNPG
-    # auto-generates a bogus <cluster>-app Secret (default user "app") for this
-    # pg_basebackup cluster, so the committed one must not collide with that name.
+    # committed Secret (../db/seaweedfs-filer-db-ssd-creds.sops.yaml) that CNPG syncs onto
+    # the -ssd seaweedfs role (declared as the app user in that cluster's initdb stanza).
+    # The -creds suffix is deliberate: CNPG auto-generates a bogus <cluster>-app Secret
+    # (default user "app") for this cluster, so the committed one must not collide.
     env:
       # Soft heap ceiling ~90% of the memory limit below; see the sizing note
       # at requests/limits. Go's GC (GOGC=100) otherwise ignores the cgroup

--- a/cluster/k8s/seaweedfs/db/flux-kustomization.yaml
+++ b/cluster/k8s/seaweedfs/db/flux-kustomization.yaml
@@ -14,7 +14,7 @@ spec:
   prune: true
   wait: true
   # Required to apply seaweedfs-filer-db-ssd-creds.sops.yaml (the filer DB app creds
-  # enforced onto -ssd via managed.roles); without it Flux applies the ciphertext.
+  # CNPG syncs onto the -ssd seaweedfs role); without it Flux applies the ciphertext.
   decryption:
     provider: sops
     secretRef:

--- a/cluster/k8s/seaweedfs/db/postgres-cluster-ssd.yaml
+++ b/cluster/k8s/seaweedfs/db/postgres-cluster-ssd.yaml
@@ -2,9 +2,9 @@
 # completed 2026-07-05). filer-db metadata is on the critical path of every SeaweedFS/git
 # op; it was moved off the KS-5 HDD tier to the KS-GAME NVMe tier via the CNPG
 # standalone-replica pattern (skills/cnpg_region_switch): a streaming replica of the old
-# seaweedfs-filer-db was bootstrapped here, promoted, and the filer repointed onto it. The
-# source cluster has since been retired; the inert bootstrap/replica/externalClusters
-# stanzas were dropped once the promotion was durable.
+# seaweedfs-filer-db was bootstrapped here (pg_basebackup), promoted, and the filer
+# repointed onto it. The source cluster has since been retired; the inert replica /
+# externalClusters / pg_basebackup stanzas were dropped once the promotion was durable.
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
@@ -34,23 +34,19 @@ spec:
   monitoring:
     enablePodMonitor: true
 
-  # The filer's owner role. This cluster was physically cloned (pg_basebackup) from
-  # seaweedfs-filer-db, whose owner role is "seaweedfs" — not CNPG's default "app" — so we
-  # enforce the role's password from a committed Secret (attributes replicated from the
-  # live role: login-only, no superuser/createdb/createrole/replication/bypassrls,
-  # unlimited connections). The filer authenticates with this same Secret. See
-  # seaweedfs-filer-db-ssd-creds.sops.yaml for why the name avoids CNPG's reserved -app.
-  managed:
-    roles:
-      - name: seaweedfs
-        ensure: present
-        login: true
-        superuser: false
-        createdb: false
-        createrole: false
-        inherit: true
-        replication: false
-        bypassrls: false
-        connectionLimit: -1
-        passwordSecret:
-          name: seaweedfs-filer-db-ssd-creds
+  # Application-user identity for CNPG's ongoing reconcile. NOT a re-initialization: CNPG
+  # runs bootstrap exactly once, at cluster creation on empty PGDATA (this cluster was
+  # actually created via pg_basebackup, see the header) — the running instances are never
+  # re-init'd by this stanza. Its sole purpose is to tell CNPG the application role is
+  # "seaweedfs" (this clone's owner) rather than CNPG's default "app": without it, the
+  # instance-manager loops forever on `role "app" does not exist` because no "app" role was
+  # cloned. CNPG keeps the seaweedfs role's password in sync with this Secret — a no-op,
+  # since the Secret holds the value physically replicated from the source. The filer
+  # authenticates with the same Secret. The -creds name deliberately avoids CNPG's reserved
+  # <cluster>-app; see seaweedfs-filer-db-ssd-creds.sops.yaml.
+  bootstrap:
+    initdb:
+      database: seaweedfs
+      owner: seaweedfs
+      secret:
+        name: seaweedfs-filer-db-ssd-creds

--- a/cluster/k8s/seaweedfs/db/seaweedfs-filer-db-ssd-creds.sops.yaml
+++ b/cluster/k8s/seaweedfs/db/seaweedfs-filer-db-ssd-creds.sops.yaml
@@ -1,10 +1,10 @@
 # App credentials for the SeaweedFS filer's connection to seaweedfs-filer-db-ssd.
 # Named -creds, NOT -app: CNPG auto-generates a bogus <cluster>-app Secret (default
-# username "app", no matching role) for this pg_basebackup cluster, so we must not
-# collide with that name. postgres-cluster-ssd.yaml enforces this password onto the
-# real owner role (seaweedfs) via spec.managed.roles; the filer authenticates with it.
-# Password copied from the old seaweedfs-filer-db-app (physically replicated), so the
-# managed.roles apply is a no-op and lets us delete the old cluster.
+# username "app", no matching role) for this pg_basebackup clone, so we must not
+# collide with that name. postgres-cluster-ssd.yaml names "seaweedfs" as the app user
+# (bootstrap.initdb.owner + this Secret), so CNPG keeps that role's password in sync
+# with this value; the filer authenticates with it. Password copied from the source
+# role (physically replicated), so the sync is a no-op.
 apiVersion: v1
 kind: Secret
 metadata:
@@ -12,29 +12,29 @@ metadata:
     namespace: seaweedfs
 type: kubernetes.io/basic-auth
 stringData:
-    username: ENC[AES256_GCM,data:phtZUnB1If5z,iv:+KjXF2wlZVJ1MVkpNCkwTg355Fwq0IJSEVRQ2bS8gOw=,tag:BRQqQSJ2XkBEUTjrdHjghQ==,type:str]
-    password: ENC[AES256_GCM,data:4OU3T3Oyo1GAa69ENoAGcOrDhnUfqOOoe4ZlD6UjZfedZRbegxFgY6AYlv+QD3hEH0kRDoX9tj33wMbKQ4RPxQ==,iv:b6a39pWR9xIc77rr8Y5FFaQmdyHoqY3662jH2PmI36A=,tag:ZFIVKvz9u30I0YGicocThA==,type:str]
+    username: ENC[AES256_GCM,data:ISXZkYYiThDX,iv:V6TjfPmXRZZqfJ2iHs0fczMlhDqKeee2uCwDZAbZbN0=,tag:GpIIdYoACAKNr8Chvwqdng==,type:str]
+    password: ENC[AES256_GCM,data:XUxVTNtHHhPoiHjcl7LhGTyUr3MD4dznA0C6R0Kc1sAvIua3qUysT6xTujLNe/MkI4hqGlvhj3M6LVGGT1AJcA==,iv:Lc2oXzPDm9RN107Wj39MqP/xNGVW0ZSPqDF7YOKO+gM=,tag:Dqt45pzK2/60NJo02jZ4vg==,type:str]
 sops:
     age:
         - recipient: age1u858fg7wyakvv5tj7dh3e04jc4hvj7l8880m4nhh9djtx8g04gxs8xyjh0
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBscjhuOVlGMUhlMTNwTmp1
-            S1dzSHk1ZGRaTjFkbFYvallDUy9zU3ZudkFrCko1dy9LS3pIU2ZieGlFVk9mNk9J
-            dGo5MUx4TDdaL1lLVHdBN3J1Sm9XaTAKLS0tIElNTkF2L3cvb3FaVnhqSHJKckdx
-            Sll0NjhUTUwzWDc5ZnYyQ0dPYmNEa0kKoRfwxM7Wo+ixPJf3N792mB8hppzKgCzV
-            //xTHPIkTXFPHiIfbW/DmTAagky65qMl5L8tGFEuD0gtSCrcyZHluw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBuYVFmUFVsQ0N4V0VtL3dB
+            cm1RTWQyOG8wMk9rWVFwWjRXeERrUVVMeWdFClo1OFJuRERlWDFiTURuaS9sTHhF
+            NktJa1owVm1FbUxZbVJHWmZSK0cza3cKLS0tIDlmTmtNbVBIVGdBTFNoSm9DSFpD
+            d1UyajlxMVpvaFRMZDE5YUM5MzJCam8KHQk6+5ucBNGfvsOMgVd9MIfcocf/MzMC
+            /D3rWOykLCwKLXBnadaW84qRGu5vNfo/qXymrWkXppy7NI8BAkUksg==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1nywlwepsyfxvyhqwkjquzz02nmus65gf6qewfjju4alym8f7se5qnua8na
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4YnZaalo0NDVGcFhnYS9u
-            U0o0NlVqQXdRdVI2VDFVOGtDQ05ZNnJ0dkdZCkdUWHc3Nm8yMG5pU3Jld0ZNL0Jl
-            MUZtSHZBUFdzb3FyWUt5VVNJQy94R0UKLS0tIG5LOU1zUTc2cTQvSWp0bE5oQzd1
-            TE11Mi9naVVId0NmUFRGeXV2N28yTTgKjh/bLEw57VITRF0Knr3tBVTbDsm43bhN
-            rKgSM4NEhmrlYVI8DIfkLh4jUFSwvgDgywaEAgsbeyGR5A6gXh5eBg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFUmxjRjhtcm1MdU55Y21M
+            T2tNcm5vRU5PV0U2amRacGxPR2JJOC9DT2hVCi9XR05XcmRISCt2d3ZsQ2lRV0Mx
+            ZmJ5TGptVGUzbzBhbFdDNlFhWExBRkkKLS0tIEJtNmM0dTJ4UnJOY21RdFpKTjdO
+            TmI4aFB5QXFrZDZXeFlUYnR4d1hWa0kK/HyAxHP+BpUi0p3KPOBNgPqjYfmvCNUh
+            y+hukMdd+A4UCn/DUkaInw8L5UOqFbERqq3m2vLr7q3bHOBeUQShRA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-07-05T00:48:41Z"
-    mac: ENC[AES256_GCM,data:fEc3LCPOWvi7hCZ+L/tGoXu1fia31XiDF13scm9V0fzmCJDlhag+k0gexYAB6AGTo1PLAW9DufAD2vOfkh5/6BaeQkXAyIC3BhRMpRSLl3TeHqoXzQI459wgW4rhP6EhsVKhavEcZ52x+NtZYFAHYaO4pyHXeXaiAmFgkh4bLKs=,iv:8ADQLXMx4meWnT/YCK++MfD8+clt9NgovXBwHcBIMlM=,tag:hypIhORGR9k5TWs3VyW86g==,type:str]
+    lastmodified: "2026-07-05T01:27:22Z"
+    mac: ENC[AES256_GCM,data:SG5MGVpx0CrRB4rLEwNwHehe7HOBkwovPob/DPcYI21Lfw5ercpDgab0zMQFJq/JA2t7I7rniVFO2izR11jCVeVD1xX3gI1Of5bJ6n5NzyKGgD+KF2sxQKXv4isyT9iyIGLLhgWlfBUvgKP65s0WELTInU/28ScP/FZvJg3FrrA=,iv:68y/tHMEQ9ghfNd1pIyBoTM1TTOICWwv19rLopq4460=,tag:lyyBnfQDXyUoKtl8bwKQXA==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.12.1


### PR DESCRIPTION
## What

Silences CNPG's permanent `role "app" does not exist (SQLSTATE 42704)` reconcile-error
loop on `seaweedfs-filer-db-ssd`.

The cluster was created via `pg_basebackup`, so its owner role is **`seaweedfs`** (cloned
from the source), not CNPG's default **`app`**. CNPG's instance-manager kept trying to sync
a nonexistent `app` role's password → a permanent reconcile error. It's cosmetic (all
cluster conditions stay `True`, no alert fires, the filer runs 2/2 healthy), but leaving a
CNPG cluster in a perpetual reconcile-error state is undesirable.

## Fix

Declare `seaweedfs` as the application user via `bootstrap.initdb.{database,owner,secret}`,
and drop the now-redundant `managed.roles`.

**This does not re-initialize the DB.** CNPG runs `bootstrap` exactly once, at cluster
creation on empty PGDATA; the running instances are never re-init'd by a spec change. The
stanza only informs the *ongoing* reconcile that the app role is `seaweedfs`, so `ALTER
ROLE` targets an existing role and CNPG keeps its password in sync with
`seaweedfs-filer-db-ssd-creds` — a no-op, since that Secret holds the physically-replicated
value.

## Safety

- Server-side dry-run accepted (webhook allows adding `initdb` to the running cluster).
- Password unchanged, so no filer reconnect/auth disruption expected.
- Comments in `seaweed.yaml` / `flux-kustomization.yaml` / the creds Secret updated to
  describe the initdb-owner mechanism instead of `managed.roles`.

## After merge

I'll reconcile, confirm the `app`-role errors stop, the filer stays 2/2 with connections as
`seaweedfs`, and git still works. If CNPG's orphaned `seaweedfs-filer-db-ssd-app` Secret
lingers unused, delete it.