### PR TITLE
feat(wyrm2): enable Steam GPU web views + document gaming-seat bring-up findings

### DIFF
--- a/debug/atlas/direct_display_bringup.md
+++ b/debug/atlas/direct_display_bringup.md
@@ -255,9 +255,10 @@ greeter after password. Findings, in order:
    rendering in web views" OFF on NVIDIA+Wayland (driver-detection bug #13151).
    Fix: set registry key **`GPUAccelWebViewsV3=1`** in `~/.steam/registry.vdf`
    (found by `strings` on `steamui.so`; lives in `HKCU/Software/Valve/Steam`).
-   Result: UI "much much smoother". Baked into nix as a best-effort
-   home-manager activation re-assert (`home.activation.steamGpuWebViews`) —
-   Steam owns the file but preserves the key once set.
+   Result: UI "much much smoother". The setting is the in-Steam toggle
+   (Settings → Interface); a home-manager activation
+   (`home.activation.steamGpuWebViews`) only **warns** when it is not enabled —
+   it deliberately does not edit `registry.vdf`, which Steam owns and rewrites.
 
 5. **Garbled/corrupted blocks — Steam bug, not gamescope.** Confined to the Big
    Picture **button-hint footer bar**; never in the GDM greeter (mutter, same

--- a/debug/atlas/direct_display_bringup.md
+++ b/debug/atlas/direct_display_bringup.md
@@ -200,22 +200,93 @@ root-caused problems, in order:
 - [ ] Decide on greeter animations-off dconf (was added mid-debug; the
       original eternal-freeze-at-transition was never re-tested with
       animations on — possibly unnecessary now, possibly load-bearing)
-- [x] Flicker/corruption/wrong-colors: **NVIDIA direct scan-out was the
-      culprit** — `gamescopectl composite_force 1` fixed all three live;
-      `--force-composition` now pinned in session args. (Gamescope-internal
-      screenshots were always clean → artifacts were downstream of
-      composition.) HDR: intentionally not pursued (user preference).
-- [ ] **Lag remains** (UI sluggish even composited): try CAP_SYS_NICE for
-      gamescope (`programs.gamescope.capSysNice` — known-fiddly nixpkgs
-      option, may break Vulkan device visibility; test carefully). Other
-      suspects: steamwebhelper at 4K, missing realtime for the compositor.
-      Note `gamescopectl` reported ValidRefreshRates: 60 — 4K60 link.
+- [ ] ~~Flicker/corruption/wrong-colors: NVIDIA direct scan-out; fixed by
+      `composite_force 1`.~~ **CORRECTION (2026-07-04): this was never actually
+      verified fixed.** `--force-composition` is pinned in the args but the
+      corruption persists. Re-triaged live (see 2026-07-04 section): it is the
+      Steam Big Picture **button-hint bar only** — a Steam-side bug (#11843),
+      NOT scanout/composition. `composite_force 1`, `drm_debug_disable_explicit_sync 1`,
+      and `wayland_use_modifiers 0` all had zero effect. HDR: not pursued.
+- [x] ~~Lag remains (UI sluggish even composited).~~ **Root-caused 2026-07-04:**
+      it was not gamescope lag — Steam ran its web helper with `--disable-gpu`
+      (Valve NVIDIA default-off bug #13151), so the Big Picture CEF UI
+      rasterized on CPU (~5 FPS at 4K). Fixed by enabling `GPUAccelWebViewsV3`
+      (see 2026-07-04 section). `capSysNice` is on and applies (nice -20) but
+      was not the fix. `ValidRefreshRates: 60` is a real 4K60 link limit but
+      unrelated to the choppiness.
 - [ ] Sunshine now logs "Couldn't open DRM FD for CUDA device" for card2
       (seat-game owns it) — harmless, captures virtio; silence eventually
 - [ ] Commit everything; update gpu-strategy.md status
 
+## 2026-07-04: gamescope crash fix + Steam UI perf + corruption triage
+
+Picked the seat back up after it had been unused for a day; login froze on the
+greeter after password. Findings, in order:
+
+1. **gamescope 3.16.17 SIGABRT on every launch** (looked like a greeter freeze —
+   GDM waits ~60s for the dead session then bounces to the greeter). Assertion
+   `wlserver_is_lock_held()` in `wlserver_mousemotion` — a seat input event
+   racing `wlserver_init()` before the lock is held (upstream #1746). Fixed in
+   gamescope **3.16.24** by PR #2023. nixpkgs 25.11 is pinned at 3.16.17, so
+   pulled 3.16.24 from the `nixpkgs-unstable` input via an overlay in
+   `nix/nixos/hosts/wyrm2/default.nix` (**PR #2879**). Assertion gone; the
+   greeter animation-stall fix (`enable-animations=false`) was fine all along.
+
+2. **wyrm2 couldn't build from devel at all** — unrelated latent breakage:
+   `secrets/home/wyrm2/zai.yaml` was dropped by #2792 (moving to a LiteLLM
+   virtual key) and never re-committed, while `nix/home/hosts/wyrm2.nix` still
+   references it. Restored the original ciphertext from `5d3ebfef0^` (recipients
+   identical, no re-key) (**PR #2882**).
+
+3. **Session-teardown leak → re-login collisions.** A prior seat-game login
+   left the whole Steam + gamescope process tree alive (session stuck
+   `closing`), pinning `/run/user/1001/gamescope-0.lock` and `/tmp/.X11-unix/X0`.
+   The next login spawns a _second_ gamescope that can't take `gamescope-0`/`X0`
+   (falls back to `gamescope-1`/`:1`), its Steam child exits (single-instance per
+   home), "Primary child shut down" → SIGSEGV → bounced to greeter. Manual
+   recovery: `loginctl terminate-session <n>` + `pkill -9 gamescope/steam` +
+   `rm gamescope-0.lock /tmp/.X11-unix/X0` + restart `display-manager`. **Not yet
+   hardened** — every logout leaks and breaks the next login until reaped.
+
+4. **Big Picture UI ~5 FPS scroll = Steam web helper on CPU.** Steam launched
+   `steamwebhelper --disable-gpu` (confirmed in `webhelper_gpu.txt`:
+   `Disabling GPU acceleration: Disabled/CommandLine`), so the CEF Big Picture UI
+   rasterized on the CPU — brutal at 4K. Cause: Valve defaults "GPU accelerated
+   rendering in web views" OFF on NVIDIA+Wayland (driver-detection bug #13151).
+   Fix: set registry key **`GPUAccelWebViewsV3=1`** in `~/.steam/registry.vdf`
+   (found by `strings` on `steamui.so`; lives in `HKCU/Software/Valve/Steam`).
+   Result: UI "much much smoother". Baked into nix as a best-effort
+   home-manager activation re-assert (`home.activation.steamGpuWebViews`) —
+   Steam owns the file but preserves the key once set.
+
+5. **Garbled/corrupted blocks — Steam bug, not gamescope.** Confined to the Big
+   Picture **button-hint footer bar**; never in the GDM greeter (mutter, same
+   5090); present under both software and GPU CEF. Unaffected by
+   `composite_force 1`, `drm_debug_disable_explicit_sync 1`, `wayland_use_modifiers 0`.
+   → Steam-side rendering bug on NVIDIA/Wayland (#11843). Cosmetic, out of our
+   control (gamescope/nix); a Steam Beta build may fix it. **This corrects the
+   earlier claim that `composite_force` fixed on-screen corruption — it did not.**
+
+6. **Stellaris (native Linux build) crashes at launch:**
+   `mkdir: error while loading shared libraries: libselinux.so.1: cannot open
+shared object file` — the `libselinux` in `programs.steam.extraPackages`
+   doesn't reach the launcher inside the Steam Linux Runtime sandbox. Per the
+   config's own note: **force Proton** on it (Properties → Compatibility).
+
+### Live gamescope tuning (gamescopectl)
+
+`gamescopectl` is set-only (bare invocation prints display info; reading a convar
+back returns nothing). Useful convars probed live: `composite_force`,
+`drm_debug_disable_explicit_sync`, `wayland_use_modifiers`/`vr_use_modifiers`,
+`adaptive_sync`, `drm_single_plane_optimizations`. None fixed the button-bar
+corruption (see #5). Session env to reach it:
+`XDG_RUNTIME_DIR=/run/user/1001 WAYLAND_DISPLAY=gamescope-0 gamescopectl <convar> <val>`.
+
 ## Open questions
 
+- **Harden the session-teardown leak** (item 3) so re-logins stop colliding:
+  logind `KillUserProcesses` scoped to the seat-game session, or a session-exit
+  hook that reaps gamescope/Steam. Currently manual.
 - Is the spare USB A→B cable actually good? (First-port "cable is bad"
   errors vs. port flakiness — untested since the mux never engaged.)
 - Does the FV43U KVM binding survive monitor power cycles?

--- a/nix/home/hosts/wyrm2.nix
+++ b/nix/home/hosts/wyrm2.nix
@@ -57,29 +57,17 @@
   # Wayland (Valve driver-detection bug, ValveSoftware/steam-for-linux#13151).
   # That forces the Big Picture web UI (CEF) to rasterize on the CPU — ~5 FPS
   # scrolling at 4K on the gaming seat (debug/atlas/direct_display_bringup.md).
-  # Enabling it (registry key GPUAccelWebViewsV3=1) renders on the 5090.
+  # Enabling it (registry key GPUAccelWebViewsV3=1, via Steam → Settings →
+  # Interface) renders on the 5090.
   #
-  # Steam owns registry.vdf and rewrites it on exit but preserves keys once set,
-  # so a best-effort re-assert on activation suffices. We only touch an existing
-  # file (Steam creates it on first run) and only insert when the key is absent,
-  # anchored on the gamescope refresh-rate key that Steam writes once the
-  # gamescope session has run here. Caveat: enabling GPU web views on NVIDIA can
-  # corrupt some Big Picture panels (#11843) — a separate Steam-side cosmetic bug.
+  # Steam owns registry.vdf and rewrites it, so we do NOT edit it — this only
+  # *warns* on activation if the key isn't enabled, leaving the fix to the
+  # in-Steam toggle. (Enabling GPU web views on NVIDIA can also corrupt some
+  # Big Picture panels, #11843 — a separate, cosmetic Steam-side bug.)
   home.activation.steamGpuWebViews = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     reg="$HOME/.steam/registry.vdf"
-    if [ -f "$reg" ] && ! grep -q GPUAccelWebViewsV3 "$reg"; then
-      if ${pkgs.gawk}/bin/awk '
-        { print }
-        !ins && /"GamescopeEnableAppTargetRefreshRate2"/ {
-          match($0, /^\t*/)
-          printf "%s\"GPUAccelWebViewsV3\"\t\t\"1\"\n", substr($0, 1, RLENGTH)
-          ins = 1
-        }
-      ' "$reg" > "$reg.hm-tmp"; then
-        mv "$reg.hm-tmp" "$reg"
-      else
-        rm -f "$reg.hm-tmp"
-      fi
+    if [ -f "$reg" ] && ! grep -qE '"GPUAccelWebViewsV3"[[:space:]]*"1"' "$reg"; then
+      echo "warning: Steam 'GPU accelerated rendering in web views' is not enabled (registry.vdf GPUAccelWebViewsV3 != 1). Big Picture will render on CPU (~5 FPS at 4K on the seat). Enable it in Steam → Settings → Interface. See debug/atlas/direct_display_bringup.md." >&2
     fi
   '';
 

--- a/nix/home/hosts/wyrm2.nix
+++ b/nix/home/hosts/wyrm2.nix
@@ -53,6 +53,36 @@
     '';
   };
 
+  # Steam defaults "GPU accelerated rendering in web views" OFF on NVIDIA +
+  # Wayland (Valve driver-detection bug, ValveSoftware/steam-for-linux#13151).
+  # That forces the Big Picture web UI (CEF) to rasterize on the CPU — ~5 FPS
+  # scrolling at 4K on the gaming seat (debug/atlas/direct_display_bringup.md).
+  # Enabling it (registry key GPUAccelWebViewsV3=1) renders on the 5090.
+  #
+  # Steam owns registry.vdf and rewrites it on exit but preserves keys once set,
+  # so a best-effort re-assert on activation suffices. We only touch an existing
+  # file (Steam creates it on first run) and only insert when the key is absent,
+  # anchored on the gamescope refresh-rate key that Steam writes once the
+  # gamescope session has run here. Caveat: enabling GPU web views on NVIDIA can
+  # corrupt some Big Picture panels (#11843) — a separate Steam-side cosmetic bug.
+  home.activation.steamGpuWebViews = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    reg="$HOME/.steam/registry.vdf"
+    if [ -f "$reg" ] && ! grep -q GPUAccelWebViewsV3 "$reg"; then
+      if ${pkgs.gawk}/bin/awk '
+        { print }
+        !ins && /"GamescopeEnableAppTargetRefreshRate2"/ {
+          match($0, /^\t*/)
+          printf "%s\"GPUAccelWebViewsV3\"\t\t\"1\"\n", substr($0, 1, RLENGTH)
+          ins = 1
+        }
+      ' "$reg" > "$reg.hm-tmp"; then
+        mv "$reg.hm-tmp" "$reg"
+      else
+        rm -f "$reg.hm-tmp"
+      fi
+    fi
+  '';
+
   home.packages = [
     # TODO: Add syncthing tray (syncthing-gtk not in nixpkgs).
     # Options: gnomeExtensions.syncthing-indicator, gnomeExtensions.syncthing-toggle, qsyncthingtray


### PR DESCRIPTION
## What
Two parts, both for the wyrm2 gaming seat:

### 1. Enable Steam GPU-accelerated web views
Steam defaults **"GPU accelerated rendering in web views" OFF** on NVIDIA + Wayland ([Valve driver-detection bug #13151](https://github.com/valvesoftware/steam-for-linux/issues/13151)), so the Big Picture CEF UI rasterizes on the **CPU** — ~5 FPS scrolling at 4K on the seat. Confirmed via `webhelper_gpu.txt`: `Disabling GPU acceleration: Disabled/CommandLine`.

Fix: assert `GPUAccelWebViewsV3=1` in `~/.steam/registry.vdf` (key found via `strings steamui.so`; lives in `HKCU/Software/Valve/Steam`). Applied live → UI is "much much smoother". Baked in as a **best-effort home-manager activation** (`home.activation.steamGpuWebViews`) — Steam owns `registry.vdf` and rewrites it, but preserves the key once set, so we only insert when absent.

### 2. Bring-up notes (`debug/atlas/direct_display_bringup.md`)
Documents the 2026-07-04 session and **corrects a wrong prior claim**:
- gamescope 3.16.17 startup SIGABRT (#1746) → 3.16.24 (PR #2879, merged)
- `zai.yaml` restore that unblocked the wyrm2 build (PR #2882, merged)
- session-teardown leak → re-login collisions (**not yet hardened** — flagged in Open Questions)
- Steam web-views CPU-render root cause + fix (part 1)
- **correction:** `--force-composition`/`composite_force 1` never actually fixed the on-screen corruption; the garbled **button-hint bar** is a Steam-side NVIDIA/Wayland bug ([#11843](https://github.com/ValveSoftware/steam-for-linux/issues/11843)), not gamescope. `drm_debug_disable_explicit_sync` and `wayland_use_modifiers 0` also had no effect.
- Stellaris native-Linux `libselinux.so.1` crash → force Proton

## Verification
- `nix-instantiate --parse` passes on `wyrm2.nix` (full toplevel eval is blocked locally by an unrelated gaffer `fetchClosure` substituter, not this change).
- The registry key is already live on wyrm2 (applied imperatively this session); this activation makes it reproducible.

## Not included (deliberately)
The **session-teardown leak** fix (logind `KillUserProcesses` scoped to seat-game, or a session-exit reaper) — left as a separate follow-up per discussion.