### PR TITLE
docs: consolidate ovh storage tiering plan to be forward-facing

### DIFF
--- a/cluster/docs/plans/ovh_storage_tiering.md
+++ b/cluster/docs/plans/ovh_storage_tiering.md
@@ -1,31 +1,33 @@
-# Plan: OVH storage tiering (HDD bulk vs SSD hot) + etcd onto NVMe
+# Plan: etcd onto NVMe + data-disk mount rename (OVH storage tiering — Stage 2)
 
-**Status: active — Stage 1 complete, Stage 2 is the active front.** Done (2026-07): tier node
-labels + media-scoped StorageClasses; the SeaweedFS volume layer migrated to `volumeTopology`
-(`hdd` 3× KS-5, `ssd` 2× KS-GAME) with the flat servers retired; operator upgraded to 1.0.30
-and the `spec.volume` stub dropped; and **Forgejo git cut over to `seaweedfs-ovh-ssd`**
-(read-zero-downtime via VolSync). Lessons + reusable procedure extracted:
+**Status: active — Stage 2 is the remaining work.** The tiering foundation is already in
+place: media-scoped StorageClasses (`local-path-ovh-{hdd,ssd}`, keyed to a
+`storage.allegedly.works/tier` node label), the SeaweedFS volume layer on `volumeTopology`
+(`hdd` 3× KS-5, `ssd` 2× KS-GAME; operator 1.0.30), and both **Forgejo git** and the
+**`seaweedfs-filer-db` metadata DB** cut over to the SSD tier. What's left is the one
+destructive piece the rest was sequenced around: moving **etcd onto NVMe** via a rolling
+Talos control-plane reshuffle, and renaming the OVH data-disk mounts off the legacy
+`/var/mnt/seaweedfs-data` path. Then an optional **Stage 3** (3rd NVMe box).
+
+Reference material from the completed foundation work:
 <../lessons_learned/2026_07_04_seaweedfs_volumetopology_and_operator.md>,
 <../lessons_learned/2026_07_04_seaweedfs_stale_mount_cache_after_evacuation.md>,
-<../runbooks/seaweedfs_pvc_storageclass_migration.md>.
+<../runbooks/seaweedfs_pvc_storageclass_migration.md> (reusable PVC storage-class migration).
 
-Also done (2026-07-05, ahead of Stage 2): **`seaweedfs-filer-db` migrated to `local-path-ovh-ssd`**
-via the CNPG clone-and-cutover (`seaweedfs-filer-db-ssd`) — the remaining git-latency win, since
-the filer metadata DB is on the critical path of every SeaweedFS op. Source cluster retired.
+## Small independent cleanups
 
-**Remaining:** **Stage 2** (mount rename + etcd onto NVMe — the rolling destructive part:
-Talos CP reshuffle; the only Case B DB left is the optional `forgejo-db` move), then the
-optional **Stage 3**. Plus one-off cleanups: delete the old `forgejo-git-rwx` PVC + the three
-VolSync objects once satisfied (rollback until then = revert the `claimName` commit); and
-reclaim the retired `seaweedfs-filer-db` HDD PVCs.
+- Delete the old `forgejo-git-rwx` PVC + the three VolSync objects (`ReplicationSource`/
+  `ReplicationDestination` + the intermediate PVC) from the git cutover, once satisfied it
+  won't be rolled back (rollback until then = revert the `claimName` commit).
 
 ## Goal
 
-Split OVH node-local storage into media-scoped StorageClasses so fsync/latency-critical
-data (etcd, Forgejo git) sits on the KS-GAME NVMe, while bulk/append-heavy data (SeaweedFS
-blobs, most small Postgres DBs, logs, caches, VM disks) stays on the KS-5 HDDs. Motivated
-by slow Forgejo (SeaweedFS-over-FUSE on 7200rpm HDD) degrading the Haku dashboard, and by
-etcd HDD I/O contention (<../lessons_learned/2026_06_19_etcd_hdd_io_contention.md>).
+Split OVH node-local storage into media-scoped StorageClasses so fsync/latency-critical data
+(etcd, Forgejo git) sits on the KS-GAME NVMe, while bulk/append-heavy data (SeaweedFS blobs,
+most small Postgres DBs, logs, caches, VM disks) stays on the KS-5 HDDs. Motivated by slow
+Forgejo (SeaweedFS-over-FUSE on 7200rpm HDD) degrading the Haku dashboard, and by etcd HDD
+I/O contention (<../lessons_learned/2026_06_19_etcd_hdd_io_contention.md>). The storage side
+of this is done; **etcd on HDD is the last unaddressed motivator** — hence Stage 2.
 
 ## Verified hardware + current usage (2026-07-03)
 
@@ -54,8 +56,8 @@ Each OVH node has one XFS Talos UserVolume (`seaweedfs-data`) on its data disk, 
   - The combined small-CNPG footprint across both SSD nodes is only a few GiB.
 
 So the SSD is currently occupied by exactly the things this plan moves **off** it (one
-SeaweedFS bulk volume server + two VM root disks). Almost nothing on the NVMe today
-actually needs NVMe.
+SeaweedFS bulk volume server + two VM root disks). Almost nothing on the NVMe today actually
+needs NVMe.
 
 **Reclaimable garbage:** several `Released`/orphaned local-path dirs still consume disk
 (duplicate `seaweedfs-volume-*` dirs, stale CNPG instance ordinals such as
@@ -63,7 +65,7 @@ actually needs NVMe.
 several `study-casino`/`atuin` ordinals). Do a `Released`-PV GC pass before trusting any
 per-node sizing — stale dirs inflate `used`.
 
-## Tier-placement policy (post-switch)
+## Tier-placement policy
 
 SSD is scarce (2 × 419 GiB, and at replication `001` it only survives one KS-GAME node
 down). **Default everything to HDD.** Promote to SSD only fsync/latency-critical data,
@@ -74,70 +76,43 @@ deliberately:
 - **etcd** — the whole reason for the control-plane reshuffle. It is **not a PVC**, so no
   StorageClass can place it: "etcd on SSD" means keeping the control plane on the KS-GAME
   NVMe boxes (Stage 2). This is a hard requirement.
-- **Forgejo git** — the SeaweedFS `ssd` volume group + the `forgejo-git` RWX PVC. This is
-  the change that fixes the Haku dashboard. Definite.
-- **`forgejo-db`** — likely (small; keeps hot Forgejo metadata next to its git).
-- **`seaweedfs-filer-db`** — **done** (2026-07-05, `seaweedfs-filer-db-ssd`). It is the
-  `postgres2` metadata backend on the critical path of _every_ SeaweedFS CSI/S3 op, so moving
-  it off HDD was the last git small-op latency win after git blobs went to SSD.
+- **Forgejo git** (SeaweedFS `ssd` volume group + `forgejo-git` RWX PVC) and
+  **`seaweedfs-filer-db`** — already on SSD.
+- **`forgejo-db`** — optional, still pending (small; keeps hot Forgejo metadata next to its
+  git).
 
 **HDD tier (default — includes "most of the tiny Postgreses"):** all other CNPG DBs
 (`authentik`, `langfuse`, `atuin`, `airlock`, `litellm`, `props`, `paperless`, `plaid`,
 `gatus`, `tofu-state`, `attic`, `grafana`, `alertmanager`, `study-casino`, `haku-*`,
-`wayback`, `gmail-labeling`, `postscanmail`, `manifold`, `tana`, `grocy`), the SeaweedFS
-bulk volume servers, Loki/Mimir/Tempo WAL+cache, Valkey caches, and VM root disks
-(`agent-box`, `gecko`, `codex`).
+`wayback`, `gmail-labeling`, `postscanmail`, `manifold`, `tana`, `grocy`), the SeaweedFS bulk
+volume servers, Loki/Mimir/Tempo WAL+cache, Valkey caches, and VM root disks (`agent-box`,
+`gecko`, `codex`).
 
-## Design: media as a node label + `allowedTopologies`
+## Tier enforcement (built — Stage 2 relies on it)
 
-`storage.allegedly.works/tier` node label, set in <../../terraform/main/ovh-nodes.tf> and
-keyed to the node's actual data-disk hardware (a per-node `storage_tier` field), **not** its
-role — so it stays correct when a KS-GAME node is later re-designated control-plane (Stage 2).
+The `storage.allegedly.works/tier` node label (<../../terraform/main/ovh-nodes.tf>, a
+per-node `storage_tier` field) is keyed to the node's **actual data-disk hardware, not its
+role** — so it stays correct when a KS-GAME node is re-designated control-plane in Stage 2.
+Three StorageClasses (<../../k8s/local-path-provisioner/>) share one provisioner +
+nodePathMap and differ only by `allowedTopologies`, which ANDs
+`topology.kubernetes.io/zone=hil-ovh` (never lands on a non-OVH SSD node like wyrm2) with the
+tier label: `-hdd` → `tier=hdd`, `-ssd` → `tier=ssd`, and `local-path-ovh` → deprecated alias
+re-pinned to `-hdd`. Under `WaitForFirstConsumer` a mis-scheduled `-ssd` PVC stays **Pending
+(loud)** rather than silently landing on HDD.
 
-Three StorageClasses (<../../k8s/local-path-provisioner/>) share the one provisioner +
-nodePathMap; media differs only by `allowedTopologies`. Each ANDs two keys:
-`topology.kubernetes.io/zone=hil-ovh` (keeps the class OVH-scoped, so it never lands on a
-non-OVH SSD node such as wyrm2) **and** `storage.allegedly.works/tier`:
+Two facts that matter for the Stage 2 reshuffle:
 
-- `local-path-ovh-hdd` → zone `hil-ovh` + `tier=hdd` (KS-5)
-- `local-path-ovh-ssd` → zone `hil-ovh` + `tier=ssd` (KS-GAME)
-- `local-path-ovh` → deprecated alias, re-pinned to the same as `-hdd`
+- **No control-plane taint trap.** OVH control planes run `allowSchedulingOnControlPlanes =
+true` and carry no CP taint, so when the KS-GAME nodes are promoted they stay schedulable;
+  neither the SSD volume group nor SSD-pinned CNPG pods need a CP toleration.
+- **Guardrail:** `-disk` tags are unverified, so an alert fires if a SeaweedFS `ssd`
+  volume-server pod is not on a `tier=ssd` node.
 
-Under `WaitForFirstConsumer`, binding follows the pod: a PVC on the SSD class binds only
-where an OVH SSD node is schedulable; if none is, it stays **Pending (loud)** instead of
-silently landing on HDD. (`local-path` never checks free space, so PVC size is not a
-placement lever, and a SeaweedFS `-disk=ssd` tag is unverified — media must be a hard
-constraint, not a hint.)
+The mount rename (below) is naming/clarity, **not** an enforcement layer: local-path's
+`nodePathMap` is keyed by node, not StorageClass, so a mis-scheduled pod would still provision
+at whatever path that node has.
 
-### Why not "StorageClass + PVC size"
-
-`local-path-ovh` is media-blind: the only thing deciding media is which node the pod
-schedules on (`/var/mnt/seaweedfs-data` is HDD on KS-5 and NVMe on KS-GAME). Making media
-an explicit hard constraint is the whole point.
-
-### Robustness layers
-
-1. **Foundation:** hard `storage.allegedly.works/tier` labels + media-scoped SCs — a
-   consumer of `-ssd` cannot provision on HDD.
-2. The SeaweedFS SSD volume-topology group (Stage 1) also carries a `required`
-   nodeAffinity on `tier=ssd` — belt-and-suspenders so the pod, not just the volume, is
-   media-locked.
-
-The mount rename (below) is **naming/clarity, not** a third enforcement layer:
-local-path's `nodePathMap` is keyed by node, not by StorageClass, so a mis-scheduled pod
-would still provision at whatever path that node has.
-
-**Guardrail:** since `-disk` tags are unverified, alert if a SeaweedFS `ssd`
-volume-server pod is not on a `tier=ssd` node.
-
-**Verified — no control-plane taint trap.** OVH control planes run with
-`allowSchedulingOnControlPlanes = true` (ovh-nodes.tf), and live OVH nodes carry no
-control-plane taint. So when the KS-GAME nodes are promoted (Stage 2) they stay
-schedulable, and neither the SSD volume group nor the SSD-pinned CNPG pods need a
-control-plane toleration. (The CP tolerations already on the flat SeaweedFS blocks are
-harmless no-ops.)
-
-## SeaweedFS re-replication is manual (Stage 1/2 depend on this)
+## SeaweedFS re-replication is manual (Stage 2 depends on this)
 
 SeaweedFS does **not** auto-re-replicate: neither the operator (the `Seaweed` CRD exposes no
 repair/heal field) nor the master self-heals under-replicated volumes. Restoring replica
@@ -153,14 +128,14 @@ printf 'lock\nvolume.fix.replication -apply\nunlock\n' | kubectl -n seaweedfs ex
 `volume.fix.replication -apply` fixes **one** missing replica per volume per run and needs a
 target server with a **free volume slot** (see the slot model below). So an _unplanned_
 volume-server/node loss leaves volumes at 1 copy until a human runs this. Every volume-server
-wipe in Stage 1/2 is therefore gated on **G-swfs** before (a source copy exists) and after
+wipe in Stage 2 is therefore gated on **G-swfs** before (a source copy exists) and after
 (re-replication back to 2 completed via this command).
 
 The **`SeaweedFSReplicaPlacementMismatch`** alert
-(<../../k8s/seaweedfs/monitoring/prometheusrule.yaml>) now surfaces under-replication so it
+(<../../k8s/seaweedfs/monitoring/prometheusrule.yaml>) surfaces under-replication so it
 doesn't lurk — it fires on `sum(SeaweedFS_master_replica_placement_mismatch) > 0`. Keep it
 **alert-only**, not auto-remediation, so node failures surface rather than being masked; if a
-scheduled `-apply` autoheal is ever added it must be **suspended during Stage 1/2** so
+scheduled `-apply` autoheal is ever added it must be **suspended during Stage 2** so
 re-replication stays deliberate and gated at G-swfs checkpoints.
 
 **Slot model** (why re-replication can stall): a volume server's capacity is a **volume-slot
@@ -181,10 +156,10 @@ idle → **only then** delete. Full RCA:
 ## Data-disk mount rename (fixing the backwards `/var/mnt/seaweedfs-data` path)
 
 Today the OVH data disk is a UserVolume named `seaweedfs-data`, and the general
-local-path-provisioner is nested under it at `/var/mnt/seaweedfs-data/local-path` — so
-every OVH local-path PVC (~70: CNPG DBs, Valkey, Loki/Mimir/Tempo, VM disks, and SeaweedFS
-volume servers, which are themselves just `local-path` PVCs) lives inside a mount named
-after one tenant, three levels down. It's a leftover from the SeaweedFS trial.
+local-path-provisioner is nested under it at `/var/mnt/seaweedfs-data/local-path` — so every
+OVH local-path PVC (~70: CNPG DBs, Valkey, Loki/Mimir/Tempo, VM disks, and SeaweedFS volume
+servers, which are themselves just `local-path` PVCs) lives inside a mount named after one
+tenant, three levels down. It's a leftover from the SeaweedFS trial.
 
 **Target:** name the mount for the disk/tier; SeaweedFS becomes one PVC of the class:
 
@@ -197,18 +172,18 @@ after one tenant, three levels down. It's a leftover from the SeaweedFS trial.
 The rename touches **both** (a) the Talos `UserVolumeConfig` name in
 <../../terraform/main/ovh-nodes.tf> (renaming a UserVolume **repartitions/wipes** the disk)
 and (b) the local-path-provisioner `nodePathMap` in
-<../../k8s/local-path-provisioner/helmrelease.yaml> (Flux). If (a) renames a node's mount
-to `/var/mnt/local-path-ovh-hdd` but (b) still points that node at
+<../../k8s/local-path-provisioner/helmrelease.yaml> (Flux). If (a) renames a node's mount to
+`/var/mnt/local-path-ovh-hdd` but (b) still points that node at
 `/var/mnt/seaweedfs-data/local-path`, new PVCs land on the **root filesystem**. The
-`nodePathMap` is a single ConfigMap but has per-node entries, so per-node rollout is
-possible — but the "opt-in node set" idiom (rule 2) covers only the Talos side; each node's
+`nodePathMap` is a single ConfigMap but has per-node entries, so per-node rollout is possible
+— but the "opt-in node set" idiom (rule 2) covers only the Talos side; each node's
 `nodePathMap` entry must be flipped in lockstep with its wipe.
 
 ### Why the wipe is OK
 
 Nearly all data is replicated or rebuildable: CNPG re-clones a wiped instance from its
-replica; SeaweedFS re-replicates (`001`); Loki/Mimir/Tempo local PVCs are WAL/cache backed
-by SeaweedFS S3; Valkey is cache. So a **rolling, one-node-at-a-time wipe** is safe.
+replica; SeaweedFS re-replicates (`001`); Loki/Mimir/Tempo local PVCs are WAL/cache backed by
+SeaweedFS S3; Valkey is cache. So a **rolling, one-node-at-a-time wipe** is safe.
 
 ### Rules
 
@@ -218,8 +193,8 @@ by SeaweedFS S3; Valkey is cache. So a **rolling, one-node-at-a-time wipe** is s
 2. **Do NOT apply via a blanket `bazel run //cluster:bootstrap`** — it hits all OVH nodes
    together. Gate the rename per node with an opt-in node set (same idiom as
    `kimsufi_eno1_peer_route_enabled_nodes` in `ovh-nodes.tf`): an empty set is a no-op; you
-   roll by adding one node at a time. Flip that node's `nodePathMap` entry (surface b) in
-   the same step.
+   roll by adding one node at a time. Flip that node's `nodePathMap` entry (surface b) in the
+   same step.
 3. **Warn before wiping any single-copy disk.** These local-path PVCs are not replicated.
    They are pre-accepted as **disposable**, but the per-node preflight (**G-losable**) must
    **list them and halt for explicit acknowledgment**, and must **halt on any single-copy
@@ -235,39 +210,36 @@ by SeaweedFS S3; Valkey is cache. So a **rolling, one-node-at-a-time wipe** is s
 existing PVCs, and the proven path (the repo's `cnpg_region_switch` skill / RUNBOOK) is a
 **clone-and-cutover**, not an in-place edit. So the two cases are handled very differently.
 
-**Verified inventory (2026-07-03):** all 18 OVH CNPG clusters are on `local-path-ovh`.
-Instance counts: 16 × 2-instance, `study-casino-db` × 3, `wayback-archive-db` × **1**.
-Four clusters have _both_ instances on the two KS-GAME nodes (`airlock`, `atuin`, `forgejo`,
-`langfuse`).
+**Verified inventory (2026-07-03):** all OVH CNPG clusters are on `local-path-ovh`. Instance
+counts: mostly 2-instance, `study-casino-db` × 3, `wayback-archive-db` × **1**. Four clusters
+have _both_ instances on the two KS-GAME nodes (`airlock`, `atuin`, `forgejo`, `langfuse`).
 
-### Case A — HDD-destined (16 of 18): no class change, ride node-eviction
+### Case A — HDD-destined (nearly all): no class change, ride node-eviction
 
 `local-path-ovh` re-pins to `= -hdd`, so these keep their existing PVC/SC name — **no
-migration, no app repoint**. They only need to leave the KS-GAME nodes, which happens for
-free when those nodes drain in Stage 2: CNPG deletes the unschedulable PVC + pod and
-re-clones from the surviving instance via `pg_basebackup`, and the re-pinned SC's
-`tier=hdd` `allowedTopologies` **forces** the new PVC onto a KS-5 node. Gate: **G-cnpg**
-before (≥1 healthy instance elsewhere as the re-clone source) and after (re-cloned instance
-`streaming`, caught up). Strictly one KS-GAME node at a time — the four both-on-KS-GAME
-clusters pass through a single-healthy-instance window, so never drain the second KS-GAME
-node until the first's re-clone is streaming.
+migration, no app repoint**. They only need to leave the KS-GAME nodes, which happens for free
+when those nodes drain in Stage 2: CNPG deletes the unschedulable PVC + pod and re-clones from
+the surviving instance via `pg_basebackup`, and the re-pinned SC's `tier=hdd`
+`allowedTopologies` **forces** the new PVC onto a KS-5 node. Gate: **G-cnpg** before (≥1
+healthy instance elsewhere as the re-clone source) and after (re-cloned instance `streaming`,
+caught up). Strictly one KS-GAME node at a time — the four both-on-KS-GAME clusters pass
+through a single-healthy-instance window, so never drain the second KS-GAME node until the
+first's re-clone is streaming.
 
-### Case B — SSD-destined (`forgejo-db`, `filer-db`): clone-and-cutover
+### Case B — SSD-destined (`forgejo-db` only, remaining): clone-and-cutover
 
 A real class change (`local-path-ovh` → `local-path-ovh-ssd`), so use the
 **`cnpg_region_switch`** procedure: stand up a new Cluster on `local-path-ovh-ssd` as a
 streaming replica (`bootstrap.pg_basebackup` + `replica.enabled`), confirm lag ≈ 0, promote
-(`replica.enabled: false`), **repoint the app**, then delete the old cluster. App repoints:
-`forgejo-db` → Forgejo's DB host; `filer-db` → the filer's `WEED_POSTGRES2_*` host (new
-cluster name = new `-rw` service DNS). Non-destructive to the source until the final delete
-— important for `filer-db`, the SeaweedFS metadata SSOT with no off-cluster backup: verify
-the clone, then delete.
+(`replica.enabled: false`), **repoint the app** (Forgejo's DB host → the new cluster's `-rw`
+service), then delete the old cluster. `seaweedfs-filer-db` already went through this path;
+`forgejo-db` is optional and the only Case B left.
 
 ### Pre-execution prep
 
 - **`wayback-archive-db`: scale 1 → 2 instances first** (make it HA like the others) so it
-  gains a re-clone source and rides Case A during the Stage-2 KS-GAME drain, instead of
-  being destroyed with its only node. Do this before Stage 2.
+  gains a re-clone source and rides Case A during the Stage-2 KS-GAME drain, instead of being
+  destroyed with its only node. Do this before Stage 2.
 - Confirm every 2-instance cluster is `G-cnpg`-green before the roll; `study-casino-db` (3
   instances across 4 to-be-wiped nodes) always keeps ≥1 healthy instance if steps stay
   one-at-a-time.
@@ -278,18 +250,13 @@ See <../cnpg_conventions.md> and <../../skills/cnpg_region_switch/RUNBOOK.md>.
 
 ### Application discipline (every Terraform-applying step)
 
-**Never run a blind `bazel run //cluster:bootstrap`** for this plan — it applies against
-all nodes at once. Each TF-applying step is: `tofu plan` against
-`cluster/terraform/main/` → **read the full diff** → apply only the intended addresses with
-**`tofu apply -target=<addr>`** (the same `-target` mechanism `bootstrap.py` uses) → re-plan
-to confirm the residual diff is empty or only what's expected. One concern at a time.
-
-- **Stage 2** per-node ops are targeted single-node applies, gated additionally by the
-  opt-in node set (rule 2) so the plan surfaces only that node — reviewed before apply.
-
-The Stage-0 label apply already followed this: a targeted
-`talos_machine_configuration_apply.{kimsufi,kimsufi_cp}` plan whose diff was exactly one
-`nodeLabels` line per node (anything else — image/disk/network — is a stop-and-investigate).
+**Never run a blind `bazel run //cluster:bootstrap`** for this plan — it applies against all
+nodes at once. Each TF-applying step is: `tofu plan` against `cluster/terraform/main/` →
+**read the full diff** → apply only the intended addresses with **`tofu apply
+-target=<addr>`** (the same `-target` mechanism `bootstrap.py` uses) → re-plan to confirm the
+residual diff is empty or only what's expected. One concern at a time. Stage 2 per-node ops
+are targeted single-node applies, gated additionally by the opt-in node set (rule 2) so the
+plan surfaces only that node — reviewed before apply.
 
 ### Final state (no new hardware — end of Stage 2)
 
@@ -302,55 +269,51 @@ The Stage-0 label apply already followed this: a targeted
 | `ovh-ns103711` | KS-5    | **worker**                               | —              | `/dev/sdb` → `/var/mnt/local-path-ovh-hdd` | HDD bulk                                                      |
 
 etcd quorum = 2 NVMe + 1 HDD (commits gated by the two-NVMe majority; the HDD member lags
-harmlessly and occasionally leads — accepted). Forgejo git on `seaweedfs-ovh-ssd` (NVMe
-volume servers). Mounts self-describing; bulk on HDD.
+harmlessly and occasionally leads — accepted). Forgejo git on `seaweedfs-ovh-ssd` (NVMe volume
+servers). Mounts self-describing; bulk on HDD.
 
-**The 3rd (HDD) control-plane is `103656`, not the big-disk `102453`.** etcd rides each
-CP's **system disk** (`/dev/sda`), not the big data disk, so an HDD control-plane is
-equivalent whichever KS-5 node holds it — while the largest data disk (`102453`, 3.6 TB)
-is left as a **worker** so it can attract the most local-path/bulk pods without
-control-plane resource/I-O contention. `103656` is chosen because it is the current etcd
-leader, so it doubles as the migration anchor (below) with no opening `move-leader` needed.
-This means the TF **primary/bootstrap control-plane must move `102453` → `103656`**:
-`primary_controlplane_ip` and the `talos_machine_bootstrap`/kubeconfig endpoints
-(`infrastructure.tf`) point at `102453` today, and `102453` sits in its own
-`kimsufi_cp_servers` map — reassign both to `103656` and demote `102453` into the worker
-set. (Bootstrap already ran; guard the endpoint change so it does not retrigger.)
+**The 3rd (HDD) control-plane is `103656`, not the big-disk `102453`.** etcd rides each CP's
+**system disk** (`/dev/sda`), not the big data disk, so an HDD control-plane is equivalent
+whichever KS-5 node holds it — while the largest data disk (`102453`, 3.6 TB) is left as a
+**worker** so it can attract the most local-path/bulk pods without control-plane resource/I-O
+contention. `103656` is chosen because it is the current etcd leader, so it doubles as the
+migration anchor (below) with no opening `move-leader` needed. This means the TF
+primary/bootstrap control-plane must move `102453` → `103656`: `primary_controlplane_ip` and
+the `talos_machine_bootstrap`/kubeconfig endpoints (`infrastructure.tf`) point at `102453`
+today, and `102453` sits in its own `kimsufi_cp_servers` map — reassign both to `103656` and
+demote `102453` into the worker set. (Bootstrap already ran; guard the endpoint change so it
+does not retrigger.)
 
-**etcd's neighbors on the KS-GAME NVMe#1 (accepted co-location).** On Talos the install
-disk's EPHEMERAL partition (`/var`) is one XFS filesystem, so etcd (`/var/lib/etcd`) shares
-that disk _and_ filesystem with containerd's image + snapshot store (`/var/lib/containerd`),
-disk-backed emptyDirs (`/var/lib/kubelet/...`; memory-medium emptyDirs are tmpfs, so they
-don't count), and pod/system logs (`/var/log`). etcd therefore contends with containerd and
-emptyDir I/O — but this is accepted:
+**etcd's neighbors on the KS-GAME NVMe#1 (accepted co-location).** On Talos the install disk's
+EPHEMERAL partition (`/var`) is one XFS filesystem, so etcd (`/var/lib/etcd`) shares that disk
+_and_ filesystem with containerd's image + snapshot store (`/var/lib/containerd`), disk-backed
+emptyDirs (`/var/lib/kubelet/...`; memory-medium emptyDirs are tmpfs, so they don't count),
+and pod/system logs (`/var/log`). etcd therefore contends with containerd and emptyDir I/O —
+but this is accepted:
 
-- On NVMe the contention is a different order of magnitude from the HDD problem we're
-  fixing (seek-bound p99 124–240 ms → sub-ms NVMe fsync even under concurrent I/O), so the
-  move off HDD already captures ~all the win.
-- A 2-NVMe box cannot fully isolate etcd's device queue — etcd always shares a physical
-  device with something (OS/containerd on NVMe#1, or the SSD blob store + DBs on NVMe#2).
-  Keeping etcd on **NVMe#1 is the better side**: NVMe#2's heaviest tenant is the SeaweedFS
-  ssd volume server (sustained blob writes), so NVMe#1 keeps etcd away from that, leaving
-  only containerd's bursty pulls + emptyDirs as neighbors, which NVMe absorbs.
+- On NVMe the contention is a different order of magnitude from the HDD problem we're fixing
+  (seek-bound p99 124–240 ms → sub-ms NVMe fsync even under concurrent I/O), so the move off
+  HDD already captures ~all the win.
+- A 2-NVMe box cannot fully isolate etcd's device queue — etcd always shares a physical device
+  with something (OS/containerd on NVMe#1, or the SSD blob store + DBs on NVMe#2). Keeping
+  etcd on **NVMe#1 is the better side**: NVMe#2's heaviest tenant is the SeaweedFS ssd volume
+  server (sustained blob writes), so NVMe#1 keeps etcd away from that, leaving only
+  containerd's bursty pulls + emptyDirs as neighbors, which NVMe absorbs.
 - Residual risk: these CPs are schedulable (`allowSchedulingOnControlPlanes=true`), so a
   scratch-/image-heavy pod could land on a KS-GAME CP and pound NVMe#1. Mitigate by steering
   heavy/emptyDir-heavy workloads onto the **HDD workers** — which is already the reason the
-  biggest-disk node (`102453`) is a worker. A dedicated `/var/lib/etcd` UserVolume carved
-  from NVMe#2 (filesystem isolation, not device isolation) is available if a benchmark ever
-  shows fsync contention, but it trades blob-store contention for containerd contention and
-  is not worth it up front.
-
-**Stage 3 (optional, +1 NVMe OVH box):** control plane becomes 3× NVMe → all-NVMe etcd
-(leadership never on HDD) + SSD replication headroom (repl `001` across 3 SSD nodes
-tolerates 1 down). All 3 KS-5 then workers/bulk.
+  biggest-disk node (`102453`) is a worker. A dedicated `/var/lib/etcd` UserVolume carved from
+  NVMe#2 (filesystem isolation, not device isolation) is available if a benchmark ever shows
+  fsync contention, but it trades blob-store contention for containerd contention and is not
+  worth it up front.
 
 ### Health gates (each destructive step is fenced by these)
 
 **G-all** = all of the below green; must hold before starting a stage and after each node op.
 
 - **G-etcd** — `talosctl … etcd status` / `service etcd`: every member `HEALTH OK`, same DB
-  revision/raft index, no alarms, no leader churn; `ControlPlaneLeasePutLatency*` not
-  firing. Change **one** etcd member at a time, only when the rest are green.
+  revision/raft index, no alarms, no leader churn; `ControlPlaneLeasePutLatency*` not firing.
+  Change **one** etcd member at a time, only when the rest are green.
 - **G-nodes** — `kubectl get nodes`: all `Ready` except the one intentionally cordoned.
 - **G-swfs** — from a master pod (commands on stdin — no `-c` flag), a dry-run
   `printf 'volume.fix.replication\n' | weed shell` returns **empty** (nothing
@@ -358,9 +321,9 @@ tolerates 1 down). All 3 KS-5 then workers/bulk.
   volume-server wipe on this **before** (a source copy exists elsewhere) and **after**
   (re-replication back to 2 completed — see "SeaweedFS re-replication is manual" above).
 - **G-cnpg** — for each affected cluster, `kubectl cnpg status <cluster>`: healthy, all
-  instances `streaming`, lag ≈ 0. Gate every node wipe on: every CNPG cluster with an
-  instance on that node has **≥1 healthy instance elsewhere** (re-clone source); after: the
-  re-cloned instance is `streaming` and caught up.
+  instances `streaming`, lag ≈ 0. Gate every node wipe on: every CNPG cluster with an instance
+  on that node has **≥1 healthy instance elsewhere** (re-clone source); after: the re-cloned
+  instance is `streaming` and caught up.
 - **G-flux** — `flux get kustomizations` / `helmreleases` all `Ready`.
 - **G-public** — Gatus green + blackbox: `git.allegedly.works`, `auth.allegedly.works`
   reachable; a test `git clone` succeeds.
@@ -368,16 +331,16 @@ tolerates 1 down). All 3 KS-5 then workers/bulk.
 ### Stage 2 — mount rename + etcd onto NVMe (rolling, node-by-node)
 
 Two rolls interleaved per node: **(E)** move the etcd quorum from
-{`102453`, `103656`, `103711`} to {`103656`, `104952`, `104963`}, and **(R)** wipe+rename
-each data disk to `local-path-ovh-{hdd,ssd}`. Rules: **one etcd membership change at a
-time** with **G-etcd** green between each; **never wipe both KS-GAME at once** (**G-cnpg**);
-the data-disk wipe (R) is independent of etcd (which lives on the install disk).
+{`102453`, `103656`, `103711`} to {`103656`, `104952`, `104963`}, and **(R)** wipe+rename each
+data disk to `local-path-ovh-{hdd,ssd}`. Rules: **one etcd membership change at a time** with
+**G-etcd** green between each; **never wipe both KS-GAME at once** (**G-cnpg**); the data-disk
+wipe (R) is independent of etcd (which lives on the install disk).
 
-Anchor = `103656` (the KS-5 node that stays control-plane throughout and holds the final
-HDD etcd seat). It is the current leader, so no opening `move-leader` is needed — just
-confirm leadership is on `103656` and keep it there; no membership step ever touches the
-leader. Do the TF primary/bootstrap reassignment (`102453` → `103656`, see Final state)
-before promoting any KS-GAME node.
+Anchor = `103656` (the KS-5 node that stays control-plane throughout and holds the final HDD
+etcd seat). It is the current leader, so no opening `move-leader` is needed — just confirm
+leadership is on `103656` and keep it there; no membership step ever touches the leader. Do the
+TF primary/bootstrap reassignment (`102453` → `103656`, see Final state) before promoting any
+KS-GAME node.
 
 **G-losable** (before wiping each node `N`): list the local-path volumes pinned to `N` and
 confirm the only non-replicated ones are the pre-accepted disposable disks (rename rule 3):
@@ -393,48 +356,39 @@ kubectl get pv -o json | jq -r --arg n "$node" '
 ```
 
 Everything CNPG re-clones and every SeaweedFS volume re-replicates; Loki/Mimir/Tempo are
-S3-backed and Valkey is cache. Anything left that is **not** on the disposable list
-**halts the roll**. Otherwise print the disposable disks about to be destroyed and get an
-explicit ack. HDD-destined DBs (Case A above) need no pre-step — draining forces the
-re-clone, and the re-pinned `local-path-ovh` (`tier=hdd`) `allowedTopologies` lands it on a
-KS-5 node. The two SSD-destined DBs (Case B) are migrated separately by clone-and-cutover,
-not by these node drains. Ensure `wayback-archive-db` is already 2-instance before draining
-its KS-GAME node.
+S3-backed and Valkey is cache. Anything left that is **not** on the disposable list **halts the
+roll**. Otherwise print the disposable disks about to be destroyed and get an explicit ack.
+HDD-destined DBs (Case A above) need no pre-step — draining forces the re-clone, and the
+re-pinned `local-path-ovh` (`tier=hdd`) `allowedTopologies` lands it on a KS-5 node. Ensure
+`wayback-archive-db` is already 2-instance before draining its KS-GAME node.
 
 Per-node order — each fenced by **G-all** + **G-losable** before and after:
 
-1. **`ovh-ns104952` → SSD control-plane.** Verify re-clone sources (**G-cnpg**),
-   cordon+drain. Wipe+rename NVMe#2 → `local-path-ovh-ssd` (R). Promote to control-plane →
-   joins etcd (learner → voter). **Post:** **G-etcd** shows 4 healthy members incl.
-   `104952`; **G-swfs**/**G-cnpg** re-replicated.
-2. **`ovh-ns103711` → worker.** One membership change: remove from etcd, reprovision as
-   worker; wipe+rename `/dev/sdb` → `local-path-ovh-hdd` (R). **Post:** **G-etcd** back to 3
-   {`102453`, `103656`, `104952`}.
+1. **`ovh-ns104952` → SSD control-plane.** Verify re-clone sources (**G-cnpg**), cordon+drain.
+   Wipe+rename NVMe#2 → `local-path-ovh-ssd` (R). Promote to control-plane → joins etcd
+   (learner → voter). **Post:** **G-etcd** shows 4 healthy members incl. `104952`;
+   **G-swfs**/**G-cnpg** re-replicated.
+2. **`ovh-ns103711` → worker.** One membership change: remove from etcd, reprovision as worker;
+   wipe+rename `/dev/sdb` → `local-path-ovh-hdd` (R). **Post:** **G-etcd** back to 3 {`102453`,
+   `103656`, `104952`}.
 3. **`ovh-ns104963` → SSD control-plane.** As step 1. **Post:** **G-etcd** 4 members incl.
    `104963`.
 4. **`ovh-ns102453` → worker (big 3.6 TB HDD).** Membership change: remove from etcd,
-   reprovision as worker; drain its `/dev/sdb` local-path PVs, wipe+rename →
-   `local-path-ovh-hdd` (R). **Post:** **G-etcd** = target {`103656`, `104952`, `104963`}.
-5. **`ovh-ns103656` — data disk only.** Stays control-plane (anchor); do **not** touch its
-   etcd / `/dev/sda`. Drain its `/dev/sdb` local-path PVs, wipe+rename → `local-path-ovh-hdd`
-   (R). **Post:** **G-swfs**/**G-cnpg** green.
-6. **Move the last SSD-tier DB (Case B).** `seaweedfs-filer-db` is already done (see status
-   header). Optionally migrate `forgejo-db` to `local-path-ovh-ssd` via the
-   `cnpg_region_switch` clone-and-cutover (new cluster → stream → promote → repoint app →
-   delete old); repoint Forgejo. Leave every other DB on HDD. Re-check Nebula lighthouse
-   placement now that `102453`/`103711` are workers (lighthouse role is per-node, not tied to
-   k8s control-plane role).
+   reprovision as worker; drain its `/dev/sdb` local-path PVs, wipe+rename → `local-path-ovh-hdd`
+   (R). **Post:** **G-etcd** = target {`103656`, `104952`, `104963`}.
+5. **`ovh-ns103656` — data disk only.** Stays control-plane (anchor); do **not** touch its etcd
+   / `/dev/sda`. Drain its `/dev/sdb` local-path PVs, wipe+rename → `local-path-ovh-hdd` (R).
+   **Post:** **G-swfs**/**G-cnpg** green.
+6. **(Optional) migrate `forgejo-db` to SSD (Case B).** Clone-and-cutover via
+   `cnpg_region_switch` (new cluster → stream → promote → repoint Forgejo → delete old). Leave
+   every other DB on HDD. Re-check Nebula lighthouse placement now that `102453`/`103711` are
+   workers (lighthouse role is per-node, not tied to k8s control-plane role).
 
 **Exit:** matches the Final-state table; watch `ControlPlaneLeasePutLatency*` drop as etcd
 fsync moves onto NVMe.
 
 ### Stage 3 — third SSD node (optional, future)
 
-Buy 1 NVMe OVH box; add as control-plane (learner → voter), then remove `103656` (the last
-HDD etcd seat) → all-NVMe 3-member quorum; bump the SeaweedFS `ssd` group to `replicas: 3`. Same
+Buy 1 NVMe OVH box; add as control-plane (learner → voter), then remove `103656` (the last HDD
+etcd seat) → all-NVMe 3-member quorum; bump the SeaweedFS `ssd` group to `replicas: 3`. Same
 one-member-at-a-time **G-etcd** discipline.
-
-## Forgejo git → SSD migration (done)
-
-Completed 2026-07-04, read-zero-downtime via VolSync. The reusable procedure is now a
-runbook: <../runbooks/seaweedfs_pvc_storageclass_migration.md>.


### PR DESCRIPTION
Stage 1 (tiering foundation), the Forgejo git → SSD cutover, and the
`seaweedfs-filer-db` → SSD migration are all shipped. This strips the
completed-work narration down to a brief starting-point summary and retitles the
plan around the remaining scope: **etcd onto NVMe + data-disk mount rename
(Stage 2)**.

Keeps the full Stage 2 execution detail (health gates, per-node roll order,
final-state table, mount-rename change surfaces, CNPG Case A/B, manual SeaweedFS
re-replication) and the reference material it depends on. Drops the settled
design justifications and the trailing "done" sections; Case B now lists only the
optional `forgejo-db` move (filer-db HDD-PVC reclaim removed — already done).

Net −46 lines, forward-facing per the plans convention (no completed-phase
tracking).